### PR TITLE
GH-44501: [C#] Use an index lookup for `O(1)` field index access

### DIFF
--- a/csharp/src/Apache.Arrow/Schema.cs
+++ b/csharp/src/Apache.Arrow/Schema.cs
@@ -31,6 +31,7 @@ namespace Apache.Arrow
         private readonly List<Field> _fieldsList;
 
         public ILookup<string, Field> FieldsLookup { get; }
+        private readonly ILookup<string, int> _fieldsIndexLookup;
 
         public IReadOnlyDictionary<string, string> Metadata { get; }
 
@@ -43,17 +44,11 @@ namespace Apache.Arrow
         public Schema(
             IEnumerable<Field> fields,
             IEnumerable<KeyValuePair<string, string>> metadata)
+            : this(
+                fields?.ToList() ?? throw new ArgumentNullException(nameof(fields)),
+                metadata?.ToDictionary(kv => kv.Key, kv => kv.Value),
+                false)
         {
-            if (fields is null)
-            {
-                throw new ArgumentNullException(nameof(fields));
-            }
-
-            _fieldsList = fields.ToList();
-            FieldsLookup = _fieldsList.ToLookup(f => f.Name);
-            _fieldsDictionary = FieldsLookup.ToDictionary(g => g.Key, g => g.First());
-
-            Metadata = metadata?.ToDictionary(kv => kv.Key, kv => kv.Value);
         }
 
         internal Schema(List<Field> fieldsList, IReadOnlyDictionary<string, string> metadata, bool copyCollections)
@@ -66,6 +61,10 @@ namespace Apache.Arrow
             _fieldsDictionary = FieldsLookup.ToDictionary(g => g.Key, g => g.First());
 
             Metadata = metadata;
+
+            _fieldsIndexLookup = _fieldsList
+                .Select((x, idx) => (Name: x.Name, Index: idx))
+                .ToLookup(x => x.Name, x => x.Index, StringComparer.CurrentCulture);
         }
 
         public Field GetFieldByIndex(int i) => _fieldsList[i];
@@ -80,7 +79,10 @@ namespace Apache.Arrow
 
         public int GetFieldIndex(string name, IEqualityComparer<string> comparer = default)
         {
-            comparer ??= StringComparer.CurrentCulture;
+            if (comparer == null || comparer.Equals(StringComparer.CurrentCulture))
+            {
+                return _fieldsIndexLookup[name].First();
+            }
 
             for (int i = 0; i < _fieldsList.Count; i++)
             {
@@ -88,7 +90,7 @@ namespace Apache.Arrow
                     return i;
             }
 
-            return -1;
+            throw new InvalidOperationException();
         }
 
         public Schema RemoveField(int fieldIndex)

--- a/csharp/test/Apache.Arrow.Tests/SchemaTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/SchemaTests.cs
@@ -1,0 +1,68 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Apache.Arrow;
+using Apache.Arrow.Types;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Apache.Arrow.Tests;
+
+public class SchemaTests
+{
+    [Fact]
+    public void ThrowsWhenFieldsAreNull()
+    {
+        Assert.Throws<ArgumentNullException>(() => new Schema(null, null));
+    }
+
+    [Theory]
+    [MemberData(nameof(StringComparers))]
+    public void CanRetrieveFieldIndexByName(StringComparer comparer)
+    {
+        var field0 = new Field("f0", Int32Type.Default, true);
+        var field1 = new Field("f1", Int64Type.Default, true);
+        var schema = new Schema([field0, field1], null);
+
+        Assert.Equal(0, schema.GetFieldIndex("f0", comparer));
+        Assert.Equal(1, schema.GetFieldIndex("f1", comparer));
+        Assert.Throws<InvalidOperationException>(() => schema.GetFieldIndex("nonexistent", comparer));
+    }
+
+    [Theory]
+    [MemberData(nameof(StringComparers))]
+    public void CanRetrieveFieldIndexByNonUniqueName(StringComparer comparer)
+    {
+        var field0 = new Field("f0", Int32Type.Default, true);
+        var field1 = new Field("f1", Int64Type.Default, true);
+
+        // Repeat fields in the list
+        var schema = new Schema([field0, field1, field0, field1], null);
+
+        Assert.Equal(0, schema.GetFieldIndex("f0", comparer));
+        Assert.Equal(1, schema.GetFieldIndex("f1", comparer));
+        Assert.Throws<InvalidOperationException>(() => schema.GetFieldIndex("nonexistent", comparer));
+    }
+
+    public static IEnumerable<object[]> StringComparers() =>
+        new List<object[]>
+        {
+            new object[] {null},
+            new object[] {StringComparer.Ordinal},
+            new object[] {StringComparer.OrdinalIgnoreCase},
+            new object[] {StringComparer.CurrentCulture},
+        };
+}


### PR DESCRIPTION
Fixes #44501

### Rationale for this change

This should speed up the reasonably common operation of looking up a column via name in `Schema` or `RecordBatch`.

I would argue that the fact that this operation was previously O(N) (now O(1)) is unintuitive and could easily lead to accidental performance woes.

Note that I would like to also replace the existing Lookups with signature `string -> Field` but unfortunately those use `StringComparer.Default` instead of `StringComparer.CurrentCulture` (which I'm using to make the changed `public` function backwards compatible). Not sure if this is intentional.

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

This PR simply memoizes the index lookup of the fields. It should not break any existing behaviour.

It also fixes a recent regression about the behaviour of the changed function in the case of using a custom comparator and have no matches in the schema. 

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

All code paths changed are covered by new unit tests. 

### Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
Yes, the lookup function throws an exception when there are no matches fuels rather than returning -1. This was a regression introduces O(days) ago. 

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #44501