### PR TITLE
GH-44657: [CI][Dev] Add write permission to the crossbow comment bot

### DIFF
--- a/.github/workflows/comment_bot.yml
+++ b/.github/workflows/comment_bot.yml
@@ -32,6 +32,8 @@ jobs:
     name: Listen!
     if: startsWith(github.event.comment.body, '@github-actions crossbow')
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Checkout Arrow
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0


### PR DESCRIPTION
### Rationale for this change

It needs to write a comment to the target PR.

### What changes are included in this PR?

Add write permission to only the crossbow comment bot.

### Are these changes tested?

No.

### Are there any user-facing changes?

No.
* GitHub Issue: #44657