### PR TITLE
GH-44668: [Docs] Fix ColumnChunkMetaData offset documentation in pyarrow

### DIFF
--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -467,7 +467,7 @@ cdef class ColumnChunkMetaData(_Weakrefable):
 
     @property
     def dictionary_page_offset(self):
-        """Offset of dictionary page relative to column chunk offset (int)."""
+        """Offset of dictionary page relative to beginning of the file (int)."""
         if self.has_dictionary_page:
             return self.metadata.dictionary_page_offset()
         else:
@@ -475,7 +475,7 @@ cdef class ColumnChunkMetaData(_Weakrefable):
 
     @property
     def data_page_offset(self):
-        """Offset of data page relative to column chunk offset (int)."""
+        """Offset of data page relative to beginning of the file (int)."""
         return self.metadata.data_page_offset()
 
     @property


### PR DESCRIPTION
### Rationale for this change

The pyarrow documentation of ColumnMetaData is contradicting the C++ implementation.

The pyarrow [documentation](https://arrow.apache.org/docs/dev/python/generated/pyarrow.parquet.ColumnChunkMetaData.html#pyarrow.parquet.ColumnChunkMetaData.data_page_offset) says:
The data_page_offset and dictionary_page_offset are relative to the column chunk offset

The C++ [comments in the code](https://github.com/apache/arrow/blob/df24a8225999896eb03db280354fbff42dfea0f5/cpp/src/generated/parquet_types.h#L2896) say:
The offsets are byte offsets from the beginning of the file to first data_page / dictionary_page

### What changes are included in this PR?

Update comments that `data_page_offset` and `dictionary_page_offset` are relative to start of file

### Are these changes tested?

Verified locally that C++ code comments are correct

### Are there any user-facing changes?

Documentation

GitHub Issue: https://github.com/apache/arrow/issues/44668
* GitHub Issue: #44668