### PR TITLE
GH-44671: [CI][Packaging][Python] Enable BulidKit for building wheel on Windows

### DIFF
--- a/dev/tasks/python-wheels/github.windows.yml
+++ b/dev/tasks/python-wheels/github.windows.yml
@@ -33,8 +33,6 @@ jobs:
       # note that we don't run docker build since there wouldn't be a cache hit
       # and rebuilding the dependencies takes a fair amount of time
       REPO: ghcr.io/ursacomputing/arrow
-      # BuildKit isn't really supported on Windows for now
-      DOCKER_BUILDKIT: 0
 
     steps:
       {{ macros.github_checkout_arrow()|indent }}
@@ -45,18 +43,10 @@ jobs:
         shell: cmd
         run: |
           cd arrow
-          @rem We want to use only
-          @rem   archery docker run -e SETUPTOOLS_SCM_PRETEND_VERSION={{ arrow.no_rc_version }} python-wheel-windows-vs2019
-          @rem but it doesn't use pulled caches.
-          @rem It always build an image from scratch.
-          @rem We can remove this workaround once we find a way to use
-          @rem pulled caches when build an image.
-          echo on
-          archery docker pull --no-ignore-pull-failures python-wheel-windows-vs2019
-          if errorlevel 1 (
-            archery docker build --no-pull python-wheel-windows-vs2019 || exit /B 1
-          )
-          archery docker run --no-build -e SETUPTOOLS_SCM_PRETEND_VERSION={{ arrow.no_rc_version }} python-wheel-windows-vs2019
+          docker buildx inspect
+          archery docker run ^
+            -e SETUPTOOLS_SCM_PRETEND_VERSION={{ arrow.no_rc_version }} ^
+            python-wheel-windows-vs2019
 
       - uses: actions/upload-artifact@v4
         with:
@@ -73,10 +63,8 @@ jobs:
       {{ macros.github_upload_gemfury("arrow/python/dist/*.whl")|indent }}
       {{ macros.github_upload_wheel_scientific_python("arrow/python/dist/*.whl")|indent }}
 
-      {% if arrow.is_default_branch() %}
       - name: Push Docker Image
         shell: cmd
         run: |
           cd arrow
           archery docker push python-wheel-windows-vs2019
-      {% endif %}


### PR DESCRIPTION
### Rationale for this change

If we can use BuildKit, we can use build cache. It'll reduce CI time.

### What changes are included in this PR?

Enable BuildKit.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #44671