### PR TITLE
GH-44674: [R] Fix R CMD check failure with dev testthat

### DIFF
--- a/r/tests/testthat/test-Array.R
+++ b/r/tests/testthat/test-Array.R
@@ -1261,7 +1261,7 @@ test_that("concat_arrays works", {
 
   concat_int <- concat_arrays(arrow_array(1:3), arrow_array(4:5))
   expect_true(concat_int$type == int32())
-  expect_true(all(concat_int == arrow_array(1:5)))
+  expect_equal(concat_int,  arrow_array(1:5))
 
   concat_int64 <- concat_arrays(
     arrow_array(1:3),
@@ -1269,7 +1269,7 @@ test_that("concat_arrays works", {
     type = int64()
   )
   expect_true(concat_int64$type == int64())
-  expect_true(all(concat_int == arrow_array(1:5)))
+  expect_equal(concat_int, arrow_array(1:5))
 
   expect_error(
     concat_arrays(
@@ -1283,7 +1283,7 @@ test_that("concat_arrays works", {
 test_that("concat_arrays() coerces its input to Array", {
   concat_ints <- concat_arrays(1L, 2L)
   expect_true(concat_ints$type == int32())
-  expect_true(all(concat_ints == arrow_array(c(1L, 2L))))
+  expect_equal(concat_ints, arrow_array(c(1L, 2L)))
 
   expect_error(
     concat_arrays(1L, "not a number", type = int32()),

--- a/r/tests/testthat/test-extension.R
+++ b/r/tests/testthat/test-extension.R
@@ -35,7 +35,7 @@ test_that("extension types can be created", {
   expect_r6_class(array$type, "ExtensionType")
 
   expect_true(array$type == type)
-  expect_true(all(array$storage() == storage))
+  expect_equal(array$storage(), storage)
 
   expect_identical(array$as_vector(), 1:10)
   expect_identical(chunked_array(array)$as_vector(), 1:10)

--- a/r/tests/testthat/test-parquet.R
+++ b/r/tests/testthat/test-parquet.R
@@ -455,7 +455,7 @@ test_that("deprecated int96 timestamp unit can be specified when reading Parquet
   )
 
   expect_identical(result$some_datetime$type$unit(), TimeUnit$MILLI)
-  expect_equal(result$some_datetime, table$some_datetime)
+  expect_equal(result$some_datetime, table$some_datetime$cast(result$some_datetime$type))
 })
 
 test_that("Can read parquet with nested lists and maps", {

--- a/r/tests/testthat/test-parquet.R
+++ b/r/tests/testthat/test-parquet.R
@@ -455,7 +455,7 @@ test_that("deprecated int96 timestamp unit can be specified when reading Parquet
   )
 
   expect_identical(result$some_datetime$type$unit(), TimeUnit$MILLI)
-  expect_true(result$some_datetime == table$some_datetime)
+  expect_equal(result$some_datetime, table$some_datetime)
 })
 
 test_that("Can read parquet with nested lists and maps", {


### PR DESCRIPTION
### Rationale for this change

Update assertion code in some of the R tests to be compatible with the in-development version of testthat.

### What changes are included in this PR?

Updated assertions in tests.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.

Fixes https://github.com/apache/arrow/issues/44674.
* GitHub Issue: #44674