### PR TITLE
GH-44679: [C++] Make `arrow.flight.Timestamp` nanoseconds precision

### DIFF
--- a/cpp/src/arrow/flight/types.h
+++ b/cpp/src/arrow/flight/types.h
@@ -80,7 +80,8 @@ class FlightServerBase;
 /// > all minutes are 60 seconds long, i.e. leap seconds are "smeared"
 /// > so that no leap second table is needed for interpretation. Range
 /// > is from 0001-01-01T00:00:00Z to 9999-12-31T23:59:59.999999999Z.
-using Timestamp = std::chrono::system_clock::time_point;
+using Timestamp =
+    std::chrono::time_point<std::chrono::system_clock, std::chrono::nanoseconds>;
 
 /// \brief A Flight-specific status code.  Used to encode some
 ///   additional status codes into an Arrow Status.


### PR DESCRIPTION
### What changes are included in this PR?
Make `arrow.flight.Timestamp` nanoseconds precision and OS-independent.

### Are these changes tested?
Existing unit tests are adjusted to the new precision.

### Are there any user-facing changes?
The precision of `Timestamp` is increased, so there is no loss of precision for users expected on any operating system. However, typing and time conversion might break for users accessing `FlightEndpoint.expiration_time` and `PollInfo.expiration_time`.

**This PR includes breaking changes to public APIs.**
* GitHub Issue: #44679