### PR TITLE
GH-44563: [C++] Add missing ARROW_IPC dependency to ARROW_COMPUTE

### DIFF
--- a/cpp/cmake_modules/DefineOptions.cmake
+++ b/cpp/cmake_modules/DefineOptions.cmake
@@ -310,7 +310,11 @@ takes precedence over ccache if a storage backend is configured" ON)
 
   define_option(ARROW_BUILD_UTILITIES "Build Arrow commandline utilities" OFF)
 
-  define_option(ARROW_COMPUTE "Build all Arrow Compute kernels" OFF)
+  define_option(ARROW_COMPUTE
+                "Build all Arrow Compute kernels"
+                OFF
+                DEPENDS
+                ARROW_IPC)
 
   define_option(ARROW_CSV "Build the Arrow CSV Parser Module" OFF)
 


### PR DESCRIPTION
### Rationale for this change

The compute module uses the IPC module features for option serialization.

### What changes are included in this PR?

Enable the IPC module when the compute module is enabled.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #44563