### PR TITLE
GH-44479: [CI][Archery] Add missing Flight integration targets

### DIFF
--- a/dev/archery/archery/integration/runner.py
+++ b/dev/archery/archery/integration/runner.py
@@ -130,10 +130,24 @@ class IntegrationRunner(object):
         Run Arrow Flight integration tests for the matrix of enabled
         implementations.
         """
-        servers = filter(lambda t: t.FLIGHT_SERVER, self.testers)
-        clients = filter(lambda t: (t.FLIGHT_CLIENT and t.CONSUMER),
-                         self.testers + self.other_testers)
-        for server, client in itertools.product(servers, clients):
+
+        def is_server(t):
+            return t.FLIGHT_SERVER
+
+        def is_client(t):
+            return t.FLIGHT_CLIENT and t.CONSUMER
+
+        for server, client in itertools.product(
+                filter(is_server, self.testers),
+                filter(is_client, self.testers)):
+            self._compare_flight_implementations(server, client)
+        for server, client in itertools.product(
+                filter(is_server, self.testers),
+                filter(is_client, self.other_testers)):
+            self._compare_flight_implementations(server, client)
+        for server, client in itertools.product(
+                filter(is_server, self.other_testers),
+                filter(is_client, self.testers)):
             self._compare_flight_implementations(server, client)
         log('\n')
 


### PR DESCRIPTION
### Rationale for this change

Go, Rust -> C++, Java, C# don't exist.

### What changes are included in this PR?

Add Go, Rust -> C++, Java, C# pairs.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.

* GitHub Issue: #44479