### PR TITLE
GH-44614: [Python][C++] Add version suffix to libarrow_python* libraries

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -480,9 +480,8 @@ else()
 endif()
 target_link_libraries(arrow_python PUBLIC Python3::NumPy)
 target_compile_definitions(arrow_python PRIVATE ARROW_PYTHON_EXPORTING)
-set_target_properties(arrow_python
-    PROPERTIES VERSION "${PYARROW_FULL_SO_VERSION}"
-              SOVERSION "${PYARROW_SO_VERSION}")
+set_target_properties(arrow_python PROPERTIES VERSION "${PYARROW_FULL_SO_VERSION}"
+                                              SOVERSION "${PYARROW_SO_VERSION}")
 install(TARGETS arrow_python
         ARCHIVE DESTINATION .
         LIBRARY DESTINATION .
@@ -499,8 +498,8 @@ else()
     target_compile_definitions(arrow_python_parquet_encryption
                                PRIVATE ARROW_PYTHON_PARQUET_ENCRYPTION_EXPORTING)
     set_target_properties(arrow_python_parquet_encryption
-      PROPERTIES VERSION "${PYARROW_FULL_SO_VERSION}"
-               SOVERSION "${PYARROW_SO_VERSION}")
+                          PROPERTIES VERSION "${PYARROW_FULL_SO_VERSION}"
+                                     SOVERSION "${PYARROW_SO_VERSION}")
     install(TARGETS arrow_python_parquet_encryption
             ARCHIVE DESTINATION .
             LIBRARY DESTINATION .
@@ -532,8 +531,8 @@ if(PYARROW_BUILD_FLIGHT)
                                                    ArrowFlight::arrow_flight_shared)
   target_compile_definitions(arrow_python_flight PRIVATE ARROW_PYFLIGHT_EXPORTING)
   set_target_properties(arrow_python_flight
-    PROPERTIES VERSION "${PYARROW_FULL_SO_VERSION}"
-             SOVERSION "${PYARROW_SO_VERSION}")
+                        PROPERTIES VERSION "${PYARROW_FULL_SO_VERSION}"
+                                   SOVERSION "${PYARROW_SO_VERSION}")
   install(TARGETS arrow_python_flight
           ARCHIVE DESTINATION .
           LIBRARY DESTINATION .

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -31,6 +31,16 @@ set(CMAKE_NO_SYSTEM_FROM_IMPORTED ON)
 set(PYARROW_VERSION "19.0.0-SNAPSHOT")
 string(REGEX MATCH "^[0-9]+\\.[0-9]+\\.[0-9]+" PYARROW_BASE_VERSION "${PYARROW_VERSION}")
 
+# Generate SO version and full SO version
+project(pyarrow VERSION "${PYARROW_BASE_VERSION}")
+set(PYARROW_VERSION_MAJOR "${pyarrow_VERSION_MAJOR}")
+set(PYARROW_VERSION_MINOR "${pyarrow_VERSION_MINOR}")
+set(PYARROW_VERSION_PATCH "${pyarrow_VERSION_PATCH}")
+# pyarrow 1.x.y => SO version is "10x", full SO version is "10x.y.0"
+# Example: for 18.0.0 --> PYARROW_SO_VERSION=1800, PYARROW_FULL_SO_VERSION=1800.0.0
+math(EXPR PYARROW_SO_VERSION "${PYARROW_VERSION_MAJOR} * 100 + ${PYARROW_VERSION_MINOR}")
+set(PYARROW_FULL_SO_VERSION "${PYARROW_SO_VERSION}.${PYARROW_VERSION_PATCH}.0")
+
 # Running from a Python sdist tarball
 set(LOCAL_CMAKE_MODULES "${CMAKE_SOURCE_DIR}/cmake_modules")
 if(EXISTS "${LOCAL_CMAKE_MODULES}")
@@ -470,6 +480,9 @@ else()
 endif()
 target_link_libraries(arrow_python PUBLIC Python3::NumPy)
 target_compile_definitions(arrow_python PRIVATE ARROW_PYTHON_EXPORTING)
+set_target_properties(arrow_python
+    PROPERTIES VERSION "${PYARROW_FULL_SO_VERSION}"
+              SOVERSION "${PYARROW_SO_VERSION}")
 install(TARGETS arrow_python
         ARCHIVE DESTINATION .
         LIBRARY DESTINATION .
@@ -485,6 +498,9 @@ else()
                                                                  ${PARQUET_LINK_LIBS})
     target_compile_definitions(arrow_python_parquet_encryption
                                PRIVATE ARROW_PYTHON_PARQUET_ENCRYPTION_EXPORTING)
+    set_target_properties(arrow_python_parquet_encryption
+      PROPERTIES VERSION "${PYARROW_FULL_SO_VERSION}"
+               SOVERSION "${PYARROW_SO_VERSION}")
     install(TARGETS arrow_python_parquet_encryption
             ARCHIVE DESTINATION .
             LIBRARY DESTINATION .
@@ -515,6 +531,9 @@ if(PYARROW_BUILD_FLIGHT)
   target_link_libraries(arrow_python_flight PUBLIC arrow_python
                                                    ArrowFlight::arrow_flight_shared)
   target_compile_definitions(arrow_python_flight PRIVATE ARROW_PYFLIGHT_EXPORTING)
+  set_target_properties(arrow_python_flight
+    PROPERTIES VERSION "${PYARROW_FULL_SO_VERSION}"
+             SOVERSION "${PYARROW_SO_VERSION}")
   install(TARGETS arrow_python_flight
           ARCHIVE DESTINATION .
           LIBRARY DESTINATION .


### PR DESCRIPTION
### Rationale for this change

We are currently not setting library version suffixes for arrow python C++ libraries but we do so for libarrow C++.

### What changes are included in this PR?

Add the same logic that we use for libarrow.

### Are these changes tested?

I've validated manually that the suffixes are generated.

```
tree | grep libarrow_python
│       │   ├── libarrow_python.so -> libarrow_python.so.1900
│       │   ├── libarrow_python.so.1900 -> libarrow_python.so.1900.0.0
│       │   ├── libarrow_python.so.1900.0.0
│   │   ├── libarrow_python.pxd
│   ├── libarrow_python.so -> libarrow_python.so.1900
│   ├── libarrow_python.so.1900 -> libarrow_python.so.1900.0.0
│   ├── libarrow_python.so.1900.0.0
```

### Are there any user-facing changes?

We will generate so libraries with version suffixes.
* GitHub Issue: #44614