### PR TITLE
GH-44706: [Release][Archery][Packaging] Add "so_version" variable

### DIFF
--- a/dev/archery/archery/crossbow/core.py
+++ b/dev/archery/archery/crossbow/core.py
@@ -820,10 +820,18 @@ class Target(Serializable):
         #
         # Example:
         #
-        # '10.0.0.dev235' ->
-        # '10.0.0-SNAPSHOT'
+        #   '10.0.0.dev235' ->
+        #   '10.0.0-SNAPSHOT'
         self.no_rc_snapshot_version = re.sub(
             r'\.(dev\d+)$', '-SNAPSHOT', self.no_rc_version)
+        # SO (shared object) version for C++/C GLib
+        #
+        # Example:
+        #
+        #   '18.1.0' ->
+        #   '1801'
+        major, minor = map(int, self.no_rc_version.split(".")[0:2])
+        self.so_version = f"{major * 100 + minor}"
 
     @classmethod
     def from_repo(cls, repo, head=None, branch=None, remote=None, version=None,
@@ -1191,6 +1199,7 @@ class Job(Serializable):
             'no_rc_snapshot_version': target.no_rc_snapshot_version,
             'r_version': target.r_version,
             'no_rc_r_version': target.no_rc_r_version,
+            'so_version': target.so_version,
         }
         for task_name, task in task_definitions.items():
             task = task.copy()

--- a/dev/release/01-prepare-test.rb
+++ b/dev/release/01-prepare-test.rb
@@ -76,13 +76,6 @@ class PrepareTest < Test::Unit::TestCase
           ],
           path: "dev/tasks/linux-packages/apache-arrow/debian/control.in",
         },
-        {
-          sampled_diff: [
-            "-      - libarrow-acero#{@snapshot_so_version}-dbgsym_{no_rc_version}-1_[a-z0-9]+.d?deb",
-            "+      - libarrow-acero#{@so_version}-dbgsym_{no_rc_version}-1_[a-z0-9]+.d?deb",
-          ],
-          path: "dev/tasks/tasks.yml",
-        },
       ]
     else
       expected_changes = []

--- a/dev/release/post-12-bump-versions-test.rb
+++ b/dev/release/post-12-bump-versions-test.rb
@@ -333,13 +333,6 @@ class PostBumpVersionsTest < Test::Unit::TestCase
           ],
           path: "dev/tasks/linux-packages/apache-arrow/debian/control.in",
         },
-        {
-          sampled_diff: [
-            "-      - libarrow-acero#{@so_version}-dbgsym_{no_rc_version}-1_[a-z0-9]+.d?deb",
-            "+      - libarrow-acero#{@next_so_version}-dbgsym_{no_rc_version}-1_[a-z0-9]+.d?deb",
-          ],
-          path: "dev/tasks/tasks.yml",
-        },
       ]
     else
       expected_changes = []

--- a/dev/release/utils-prepare.sh
+++ b/dev/release/utils-prepare.sh
@@ -231,12 +231,6 @@ update_deb_package_names() {
     git add debian*/control*
     popd
 
-    pushd ${ARROW_DIR}/dev/tasks
-    sed -i.bak -E -e "${deb_lib_suffix_substitute_pattern}" tasks.yml
-    rm -f tasks.yml.bak
-    git add tasks.yml
-    popd
-
     pushd ${ARROW_DIR}/dev/release
     sed -i.bak -E -e "${deb_lib_suffix_substitute_pattern}" rat_exclude_files.txt
     rm -f rat_exclude_files.txt.bak

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -513,59 +513,59 @@ tasks:
       - gir1.2-gandiva-1.0_{no_rc_version}-1_[a-z0-9]+.deb
       - gir1.2-parquet-1.0_{no_rc_version}-1_[a-z0-9]+.deb
       - libarrow-acero-dev_{no_rc_version}-1_[a-z0-9]+.deb
-      - libarrow-acero1900-dbgsym_{no_rc_version}-1_[a-z0-9]+.d?deb
-      - libarrow-acero1900_{no_rc_version}-1_[a-z0-9]+.deb
+      - libarrow-acero{so_version}-dbgsym_{no_rc_version}-1_[a-z0-9]+.d?deb
+      - libarrow-acero{so_version}_{no_rc_version}-1_[a-z0-9]+.deb
       - libarrow-dataset-dev_{no_rc_version}-1_[a-z0-9]+.deb
       - libarrow-dataset-glib-dev_{no_rc_version}-1_[a-z0-9]+.deb
       - libarrow-dataset-glib-doc_{no_rc_version}-1_[a-z0-9]+.deb
-      - libarrow-dataset-glib1900-dbgsym_{no_rc_version}-1_[a-z0-9]+.d?deb
-      - libarrow-dataset-glib1900_{no_rc_version}-1_[a-z0-9]+.deb
-      - libarrow-dataset1900-dbgsym_{no_rc_version}-1_[a-z0-9]+.d?deb
-      - libarrow-dataset1900_{no_rc_version}-1_[a-z0-9]+.deb
+      - libarrow-dataset-glib{so_version}-dbgsym_{no_rc_version}-1_[a-z0-9]+.d?deb
+      - libarrow-dataset-glib{so_version}_{no_rc_version}-1_[a-z0-9]+.deb
+      - libarrow-dataset{so_version}-dbgsym_{no_rc_version}-1_[a-z0-9]+.d?deb
+      - libarrow-dataset{so_version}_{no_rc_version}-1_[a-z0-9]+.deb
       - libarrow-dev_{no_rc_version}-1_[a-z0-9]+.deb
       - libarrow-flight-dev_{no_rc_version}-1_[a-z0-9]+.deb
       - libarrow-flight-glib-dev_{no_rc_version}-1_[a-z0-9]+.deb
       - libarrow-flight-glib-doc_{no_rc_version}-1_[a-z0-9]+.deb
-      - libarrow-flight-glib1900-dbgsym_{no_rc_version}-1_[a-z0-9]+.d?deb
-      - libarrow-flight-glib1900_{no_rc_version}-1_[a-z0-9]+.deb
+      - libarrow-flight-glib{so_version}-dbgsym_{no_rc_version}-1_[a-z0-9]+.d?deb
+      - libarrow-flight-glib{so_version}_{no_rc_version}-1_[a-z0-9]+.deb
       - libarrow-flight-sql-dev_{no_rc_version}-1_[a-z0-9]+.deb
       - libarrow-flight-sql-glib-dev_{no_rc_version}-1_[a-z0-9]+.deb
       - libarrow-flight-sql-glib-doc_{no_rc_version}-1_[a-z0-9]+.deb
-      - libarrow-flight-sql-glib1900-dbgsym_{no_rc_version}-1_[a-z0-9]+.d?deb
-      - libarrow-flight-sql-glib1900_{no_rc_version}-1_[a-z0-9]+.deb
-      - libarrow-flight-sql1900-dbgsym_{no_rc_version}-1_[a-z0-9]+.d?deb
-      - libarrow-flight-sql1900_{no_rc_version}-1_[a-z0-9]+.deb
-      - libarrow-flight1900-dbgsym_{no_rc_version}-1_[a-z0-9]+.d?deb
-      - libarrow-flight1900_{no_rc_version}-1_[a-z0-9]+.deb
+      - libarrow-flight-sql-glib{so_version}-dbgsym_{no_rc_version}-1_[a-z0-9]+.d?deb
+      - libarrow-flight-sql-glib{so_version}_{no_rc_version}-1_[a-z0-9]+.deb
+      - libarrow-flight-sql{so_version}-dbgsym_{no_rc_version}-1_[a-z0-9]+.d?deb
+      - libarrow-flight-sql{so_version}_{no_rc_version}-1_[a-z0-9]+.deb
+      - libarrow-flight{so_version}-dbgsym_{no_rc_version}-1_[a-z0-9]+.d?deb
+      - libarrow-flight{so_version}_{no_rc_version}-1_[a-z0-9]+.deb
       - libarrow-glib-dev_{no_rc_version}-1_[a-z0-9]+.deb
       - libarrow-glib-doc_{no_rc_version}-1_[a-z0-9]+.deb
-      - libarrow-glib1900-dbgsym_{no_rc_version}-1_[a-z0-9]+.d?deb
-      - libarrow-glib1900_{no_rc_version}-1_[a-z0-9]+.deb
-      - libarrow1900-dbgsym_{no_rc_version}-1_[a-z0-9]+.d?deb
-      - libarrow1900_{no_rc_version}-1_[a-z0-9]+.deb
+      - libarrow-glib{so_version}-dbgsym_{no_rc_version}-1_[a-z0-9]+.d?deb
+      - libarrow-glib{so_version}_{no_rc_version}-1_[a-z0-9]+.deb
+      - libarrow{so_version}-dbgsym_{no_rc_version}-1_[a-z0-9]+.d?deb
+      - libarrow{so_version}_{no_rc_version}-1_[a-z0-9]+.deb
       - libgandiva-dev_{no_rc_version}-1_[a-z0-9]+.deb
       - libgandiva-glib-dev_{no_rc_version}-1_[a-z0-9]+.deb
       - libgandiva-glib-doc_{no_rc_version}-1_[a-z0-9]+.deb
-      - libgandiva-glib1900-dbgsym_{no_rc_version}-1_[a-z0-9]+.d?deb
-      - libgandiva-glib1900_{no_rc_version}-1_[a-z0-9]+.deb
-      - libgandiva1900-dbgsym_{no_rc_version}-1_[a-z0-9]+.d?deb
-      - libgandiva1900_{no_rc_version}-1_[a-z0-9]+.deb
+      - libgandiva-glib{so_version}-dbgsym_{no_rc_version}-1_[a-z0-9]+.d?deb
+      - libgandiva-glib{so_version}_{no_rc_version}-1_[a-z0-9]+.deb
+      - libgandiva{so_version}-dbgsym_{no_rc_version}-1_[a-z0-9]+.d?deb
+      - libgandiva{so_version}_{no_rc_version}-1_[a-z0-9]+.deb
       - libparquet-dev_{no_rc_version}-1_[a-z0-9]+.deb
       - libparquet-glib-dev_{no_rc_version}-1_[a-z0-9]+.deb
       - libparquet-glib-doc_{no_rc_version}-1_[a-z0-9]+.deb
-      - libparquet-glib1900-dbgsym_{no_rc_version}-1_[a-z0-9]+.d?deb
-      - libparquet-glib1900_{no_rc_version}-1_[a-z0-9]+.deb
-      - libparquet1900-dbgsym_{no_rc_version}-1_[a-z0-9]+.d?deb
-      - libparquet1900_{no_rc_version}-1_[a-z0-9]+.deb
+      - libparquet-glib{so_version}-dbgsym_{no_rc_version}-1_[a-z0-9]+.d?deb
+      - libparquet-glib{so_version}_{no_rc_version}-1_[a-z0-9]+.deb
+      - libparquet{so_version}-dbgsym_{no_rc_version}-1_[a-z0-9]+.d?deb
+      - libparquet{so_version}_{no_rc_version}-1_[a-z0-9]+.deb
       - parquet-tools_{no_rc_version}-1_[a-z0-9]+.deb
     {% if architecture == "amd64" %}
       - gir1.2-arrow-cuda-1.0_{no_rc_version}-1_[a-z0-9]+.deb
       - libarrow-cuda-dev_{no_rc_version}-1_[a-z0-9]+.deb
       - libarrow-cuda-glib-dev_{no_rc_version}-1_[a-z0-9]+.deb
-      - libarrow-cuda-glib1900-dbgsym_{no_rc_version}-1_[a-z0-9]+.d?deb
-      - libarrow-cuda-glib1900_{no_rc_version}-1_[a-z0-9]+.deb
-      - libarrow-cuda1900-dbgsym_{no_rc_version}-1_[a-z0-9]+.d?deb
-      - libarrow-cuda1900_{no_rc_version}-1_[a-z0-9]+.deb
+      - libarrow-cuda-glib{so_version}-dbgsym_{no_rc_version}-1_[a-z0-9]+.d?deb
+      - libarrow-cuda-glib{so_version}_{no_rc_version}-1_[a-z0-9]+.deb
+      - libarrow-cuda{so_version}-dbgsym_{no_rc_version}-1_[a-z0-9]+.d?deb
+      - libarrow-cuda{so_version}_{no_rc_version}-1_[a-z0-9]+.deb
     {% endif %}
   {% endfor %}
 {% endfor %}


### PR DESCRIPTION
### Rationale for this change

SO versions must be computed from the target version instead of embedding them to `dev/tasks/tasks.yaml`. Because they depend on the specified version as an argument.

### What changes are included in this PR?

Add `so_version` variable that can be used in `dev/tasks/tasks.yml`.

### Are these changes tested?

Yes.

https://github.com/apache/arrow/pull/44699#issuecomment-2472056561 used this.

### Are there any user-facing changes?

No.
* GitHub Issue: #44706