### PR TITLE
MINOR: [Release] Proactively remove java-jni-dist directory in verification script

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -577,6 +577,7 @@ test_package_java() {
         normalized_arch=x86_64
         ;;
     esac
+    rm -fr ${dist_dir}
     mkdir -p ${dist_dir}
     mv ${install_dir}/lib/* ${dist_dir}
     mvn install \


### PR DESCRIPTION
### Rationale for this change

If you set `ARROW_TMPDIR` and run `TEST_DEFAULT=0 TEST_INTEGRATION=1 dev/release/verify-release-candidate.sh` repeatedly, you'll run into an error:

> mv: rename /Users/bryce/src/apache/arrow/arrow-tempdir//java-jni-install/lib/arrow_cdata_jni to /Users/bryce/src/apache/arrow/arrow-tempdir//java-jni-dist/arrow_cdata_jni: Directory not empty

### What changes are included in this PR?

In the `test_package_java` step in the verification script, I added a `rm -fr `to get rid of java-jni-dist dir so the following `mv` command works.

### Are these changes tested?

Yes, locally.

### Are there any user-facing changes?

No.