### PR TITLE
GH-27919: [CI][C++] Add a nightly job to test offline build

### DIFF
--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1105,6 +1105,7 @@ tasks:
       env:
         UBUNTU: 24.04
       image: ubuntu-cpp-bundled-offline
+      timeout: 120
 
   test-ubuntu-24.04-cpp-gcc-13-bundled:
     ci: github

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1098,6 +1098,14 @@ tasks:
         UBUNTU: 20.04
       image: ubuntu-cpp-bundled
 
+  test-ubuntu-24.04-cpp-bundled-offline:
+    ci: github
+    template: docker-tests/github.linux.yml
+    params:
+      env:
+        UBUNTU: 24.04
+      image: ubuntu-cpp-bundled-offline
+
   test-ubuntu-24.04-cpp-gcc-13-bundled:
     ci: github
     template: docker-tests/github.linux.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -150,6 +150,7 @@ x-hierarchy:
     - ubuntu-r
     - ubuntu-r-only-r
   - ubuntu-cpp-bundled
+  - ubuntu-cpp-bundled-offline
   - ubuntu-cpp-minimal
   - ubuntu-cuda-cpp:
     - ubuntu-cuda-python
@@ -480,6 +481,30 @@ services:
     environment:
       <<: [*common, *ccache, *sccache, *cpp]
       ARROW_DEPENDENCY_SOURCE: BUNDLED
+      CMAKE_GENERATOR: "Unix Makefiles"
+    volumes: *ubuntu-volumes
+    command: *cpp-command
+
+  ubuntu-cpp-bundled-offline:
+    # Arrow build with BUNDLED dependencies with downloaded dependencies.
+    image: ${REPO}:${ARCH}-ubuntu-${UBUNTU}-cpp-minimal
+    build:
+      context: .
+      dockerfile: ci/docker/ubuntu-${UBUNTU}-cpp-minimal.dockerfile
+      cache_from:
+        - ${REPO}:${ARCH}-ubuntu-${UBUNTU}-cpp-minimal
+      args:
+        arch: ${ARCH}
+        base: "${ARCH}/ubuntu:${UBUNTU}"
+        llvm: ${LLVM}
+    shm_size: *shm-size
+    ulimits: *ulimits
+    environment:
+      <<: [*common, *ccache, *sccache, *cpp]
+      ARROW_DEPENDENCY_SOURCE: BUNDLED
+      ARROW_OFFLINE: ON
+      # Apache ORC always uses external orc-format.
+      ARROW_ORC: OFF
       CMAKE_GENERATOR: "Unix Makefiles"
     volumes: *ubuntu-volumes
     command: *cpp-command

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -500,7 +500,7 @@ services:
     shm_size: *shm-size
     ulimits: *ulimits
     environment:
-      <<: [*common, *ccache, *sccache, *cpp]
+      <<: [*common, *ccache, *cpp]
       ARROW_DEPENDENCY_SOURCE: BUNDLED
       ARROW_OFFLINE: ON
       # Apache ORC always uses external orc-format.


### PR DESCRIPTION
### Rationale for this change

If we have a nightly CI job to test offline build, we will be able to notice that offline build support is broken. 

### What changes are included in this PR?

* Add the `ARROW_OFFLINE` option that uses `cpp/thirdparty/download_dependencies.sh` and disable DNS resolution
* Add `ubuntu-cpp-bundled-offline` service that enable the `ARROW_OFFLINE` option
* Add `test-ubuntu-24.04-cpp-bundled-offline` nightly job

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #27919