### PR TITLE
GH-44223: [Dev] Use "Gandiva" instead of "C++ - Gandiva" label

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -38,15 +38,15 @@ body:
         - C
         - C#
         - C++
-        - C++ - Gandiva
         - Continuous Integration
         - Developer Tools
         - Documentation
         - FlightRPC
         - Format
         - GLib
-        - Go
         - GPU
+        - Gandiva
+        - Go
         - Integration
         - Java
         - JavaScript

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -41,15 +41,15 @@ body:
         - C
         - C#
         - C++
-        - C++ - Gandiva
         - Continuous Integration
         - Developer Tools
         - Documentation
         - FlightRPC
         - Format
         - GLib
-        - Go
         - GPU
+        - Gandiva
+        - Go
         - Integration
         - Java
         - JavaScript

--- a/.github/ISSUE_TEMPLATE/usage_question.yaml
+++ b/.github/ISSUE_TEMPLATE/usage_question.yaml
@@ -61,15 +61,15 @@ body:
         - C
         - C#
         - C++
-        - C++ - Gandiva
         - Continuous Integration
         - Developer Tools
         - Documentation
         - FlightRPC
         - Format
         - GLib
-        - Go
         - GPU
+        - Gandiva
+        - Go
         - Integration
         - Java
         - JavaScript

--- a/.github/workflows/dev_pr/labeler.yml
+++ b/.github/workflows/dev_pr/labeler.yml
@@ -53,11 +53,12 @@
   - r/R/flight.*
   - python/pyarrow/*flight.*
 
-"Component: C++ - Gandiva":
+"Component: Gandiva":
   - c_glib/gandiva-glib/**/*
   - cpp/src/gandiva/**/*
-  - ruby/red-gandiva/**/*
+  - java/gandiva/**/*
   - python/pyarrow/gandiva.*
+  - ruby/red-gandiva/**/*
 
 "Component: Parquet":
   - c_glib/parquet-glib/**/*


### PR DESCRIPTION
### Rationale for this change

We have Gandiva related codes. So "C++ -" isn't match the current code base.

### What changes are included in this PR?

Remove the "C++ - " part.

### Are these changes tested?

No.

### Are there any user-facing changes?

No.
* GitHub Issue: #44223