### PR TITLE
GH-43080: [CI][Dev] Enable shellcheck

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -173,3 +173,12 @@ repos:
           '--disable',
           'dangling-hyphen,line-too-long',
         ]
+  - repo: https://github.com/koalaman/shellcheck-precommit
+    rev: v0.10.0
+    hooks:
+      - id: shellcheck
+        # TODO: Remove this when we fix all lint failures
+        files: >-
+          (
+          ?^ci/scripts/c_glib_build\.sh$|
+          )

--- a/ci/scripts/c_glib_build.sh
+++ b/ci/scripts/c_glib_build.sh
@@ -23,59 +23,63 @@ source_dir=${1}/c_glib
 build_dir=${2}/c_glib
 build_root=${2}
 
-: ${ARROW_GLIB_WERROR:=false}
-: ${ARROW_GLIB_VAPI:=true}
-: ${BUILD_DOCS_C_GLIB:=OFF}
+: "${ARROW_GLIB_WERROR:=false}"
+: "${ARROW_GLIB_VAPI:=true}"
+: "${BUILD_DOCS_C_GLIB:=OFF}"
 with_doc=$([ "${BUILD_DOCS_C_GLIB}" == "ON" ] && echo "true" || echo "false")
 
 
 if [ -n "${MSYSTEM:-}" ]; then
   # Fix ARROW_HOME when running under MSYS2
-  export ARROW_HOME="$(cygpath --unix "${ARROW_HOME}")"
+  ARROW_HOME="$(cygpath --unix "${ARROW_HOME}")"
+  export ARROW_HOME
 fi
 
-export PATH="${ARROW_HOME}/bin:${PATH}"
+PATH="${ARROW_HOME}/bin:${PATH}"
 
 meson_pkg_config_path="${ARROW_HOME}/lib/pkgconfig"
 
-mkdir -p ${build_dir}
+mkdir -p "${build_dir}"
 
-if [ -n "${VCPKG_ROOT:-}" -a -n "${VCPKG_TRIPLET:-}" ]; then
+if [ -n "${VCPKG_ROOT:-}" ] && [ -n "${VCPKG_TRIPLET:-}" ]; then
   vcpkg_install_root="${build_root}/vcpkg_installed"
-  $VCPKG_ROOT/vcpkg install --x-manifest-root=${source_dir} --x-install-root=${vcpkg_install_root}
-  export PKG_CONFIG="${vcpkg_install_root}/${VCPKG_TRIPLET}/tools/pkgconf/pkgconf.exe"
+  "${VCPKG_ROOT}/vcpkg" install \
+    --x-manifest-root="${source_dir}" \
+    --x-install-root="${vcpkg_install_root}"
+  PKG_CONFIG="${vcpkg_install_root}/${VCPKG_TRIPLET}/tools/pkgconf/pkgconf.exe"
+  export PKG_CONFIG
   meson_pkg_config_path="${vcpkg_install_root}/${VCPKG_TRIPLET}/lib/pkgconfig:${meson_pkg_config_path}"
   # Configure PATH for libraries required by the gobject-introspection generated binary
   cpp_vcpkg_install_root="${build_root}/cpp/vcpkg_installed"
   PATH="${cpp_vcpkg_install_root}/${VCPKG_TRIPLET}/debug/bin:${PATH}"
   PATH="${cpp_vcpkg_install_root}/${VCPKG_TRIPLET}/bin:${PATH}"
-  export PATH="${vcpkg_install_root}/${VCPKG_TRIPLET}/bin:${PATH}"
+  PATH="${vcpkg_install_root}/${VCPKG_TRIPLET}/bin:${PATH}"
 fi
 
-if [ -n "${VCToolsInstallDir:-}" -a -n "${MSYSTEM:-}" ]; then
+if [ -n "${VCToolsInstallDir:-}" ] && [ -n "${MSYSTEM:-}" ]; then
   # Meson finds the gnu link.exe instead of MSVC link.exe when running in MSYS2/git bash,
   # so we need to make sure the MSCV link.exe is first in $PATH
-  export PATH="$(cygpath --unix "${VCToolsInstallDir}")/bin/HostX64/x64:${PATH}"
+  PATH="$(cygpath --unix "${VCToolsInstallDir}")/bin/HostX64/x64:${PATH}"
 fi
 
 # Build with Meson
 meson setup \
       --backend=ninja \
-      --prefix=$ARROW_HOME \
+      --prefix="${ARROW_HOME}" \
       --libdir=lib \
       --pkg-config-path="${meson_pkg_config_path}" \
-      -Ddoc=${with_doc} \
-      -Dvapi=${ARROW_GLIB_VAPI} \
-      -Dwerror=${ARROW_GLIB_WERROR} \
-      ${build_dir} \
-      ${source_dir}
+      -Ddoc="${with_doc}" \
+      -Dvapi="${ARROW_GLIB_VAPI}" \
+      -Dwerror="${ARROW_GLIB_WERROR}" \
+      "${build_dir}" \
+      "${source_dir}"
 
-pushd ${build_dir}
+pushd "${build_dir}"
 ninja
 ninja install
 popd
 
 if [ "${BUILD_DOCS_C_GLIB}" == "ON" ]; then
-  mkdir -p ${build_root}/docs/c_glib
-  cp -a ${ARROW_HOME}/share/doc/*-glib/ ${build_root}/docs/c_glib/
+  mkdir -p "${build_root}/docs/c_glib"
+  cp -a "${ARROW_HOME}"/share/doc/*-glib/ "${build_root}/docs/c_glib/"
 fi


### PR DESCRIPTION
### Rationale for this change

shellcheck is a shell linter. It will find some potential problems in CI.

### What changes are included in this PR?

* Add a shellcheck entry to `.pre-commit-config.yaml`
* Enable shellcheck lint only for `ci/scripts/c_glib_build.sh`

We should enable shellcheck lint for all shell scripts eventually. 

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #43080