### PR TITLE
GH-44726: [CI] Update substrait consumer call to use updated producer and consumer parameters

### DIFF
--- a/ci/scripts/integration_substrait.sh
+++ b/ci/scripts/integration_substrait.sh
@@ -28,4 +28,4 @@ python -c "from substrait_consumer.consumers.acero_consumer import AceroConsumer
 
 echo "Executing pytest"
 cd consumer-testing
-pytest -r s substrait_consumer/tests/functional/extension_functions/test_boolean_functions.py --producer IsthmusProducer --consumer AceroConsumer
+pytest -r s substrait_consumer/tests/functional/extension_functions/test_boolean_functions.py --producer isthmus --consumer AceroConsumer

--- a/ci/scripts/integration_substrait.sh
+++ b/ci/scripts/integration_substrait.sh
@@ -28,4 +28,4 @@ python -c "from substrait_consumer.consumers.acero_consumer import AceroConsumer
 
 echo "Executing pytest"
 cd consumer-testing
-pytest -r s substrait_consumer/tests/functional/extension_functions/test_boolean_functions.py --producer isthmus --consumer AceroConsumer
+pytest -r s substrait_consumer/tests/functional/extension_functions/test_boolean_functions.py --producer isthmus --consumer acero


### PR DESCRIPTION
### Rationale for this change

The nightly job for substrait integration is failing due to a change on the consumer-testing:
- https://github.com/substrait-io/consumer-testing/pull/124

### What changes are included in this PR?

Update to new parameter.

### Are these changes tested?

Via archery

### Are there any user-facing changes?

No
* GitHub Issue: #44726