### PR TITLE
GH-44734: [C++][CI] Fix arrow-c-bridge-test timeout with threading disabled

### DIFF
--- a/cpp/src/arrow/c/bridge_test.cc
+++ b/cpp/src/arrow/c/bridge_test.cc
@@ -5313,6 +5313,8 @@ TEST_F(TestArrayDeviceStreamRoundtrip, ChunkedArrayRoundtripEmpty) {
   });
 }
 
+#ifdef ARROW_ENABLE_THREADING
+
 class TestAsyncDeviceArrayStreamRoundTrip : public BaseArrayStreamTest {
  public:
   static Result<std::shared_ptr<ArrayData>> ToDeviceData(
@@ -5420,5 +5422,7 @@ TEST_F(TestAsyncDeviceArrayStreamRoundTrip, PropagateError) {
 
   internal::GetCpuThreadPool()->WaitForIdle();
 }
+
+#endif
 
 }  // namespace arrow

--- a/cpp/src/arrow/c/bridge_test.cc
+++ b/cpp/src/arrow/c/bridge_test.cc
@@ -5319,7 +5319,7 @@ class TestAsyncDeviceArrayStreamRoundTrip : public BaseArrayStreamTest {
     BaseArrayStreamTest::SetUp();
 #ifdef ARROW_ENABLE_THREADING
     GTEST_SKIP() << "Test requires ARROW_ENABLE_THREADING=OFF";
-#endif    
+#endif
   }
 
   static Result<std::shared_ptr<ArrayData>> ToDeviceData(

--- a/cpp/src/arrow/c/bridge_test.cc
+++ b/cpp/src/arrow/c/bridge_test.cc
@@ -5313,10 +5313,15 @@ TEST_F(TestArrayDeviceStreamRoundtrip, ChunkedArrayRoundtripEmpty) {
   });
 }
 
-#ifdef ARROW_ENABLE_THREADING
-
 class TestAsyncDeviceArrayStreamRoundTrip : public BaseArrayStreamTest {
  public:
+  void SetUp() override {
+    BaseArrayStreamTest::SetUp();
+#ifdef ARROW_ENABLE_THREADING
+    GTEST_SKIP() << "Test requires ARROW_ENABLE_THREADING=OFF";
+#endif    
+  }
+
   static Result<std::shared_ptr<ArrayData>> ToDeviceData(
       const std::shared_ptr<MemoryManager>& mm, const ArrayData& data) {
     arrow::BufferVector buffers;
@@ -5422,7 +5427,5 @@ TEST_F(TestAsyncDeviceArrayStreamRoundTrip, PropagateError) {
 
   internal::GetCpuThreadPool()->WaitForIdle();
 }
-
-#endif
 
 }  // namespace arrow

--- a/cpp/src/arrow/c/bridge_test.cc
+++ b/cpp/src/arrow/c/bridge_test.cc
@@ -5317,8 +5317,8 @@ class TestAsyncDeviceArrayStreamRoundTrip : public BaseArrayStreamTest {
  public:
   void SetUp() override {
     BaseArrayStreamTest::SetUp();
-#ifdef ARROW_ENABLE_THREADING
-    GTEST_SKIP() << "Test requires ARROW_ENABLE_THREADING=OFF";
+#ifndef ARROW_ENABLE_THREADING
+    GTEST_SKIP() << "Test requires ARROW_ENABLE_THREADING=ON";
 #endif
   }
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change
The Async C Device Stream Interface unit tests requiring threading to be enabled, but a couple of our CI runs go with ARROW_ENABLE_THREADING disabled. 

### What changes are included in this PR?
The Async C Device Stream interface tests are guarded with `#ifdef ARROW_ENABLE_THREADING` to prevent CI timeouts.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->


* GitHub Issue: #44734