### PR TITLE
GH-34698: [C++][Python][Acero] Add node that emits explicit ordering after asserting order

### DIFF
--- a/cpp/src/arrow/acero/CMakeLists.txt
+++ b/cpp/src/arrow/acero/CMakeLists.txt
@@ -21,6 +21,7 @@ arrow_install_all_headers("arrow/acero")
 
 set(ARROW_ACERO_SRCS
     accumulation_queue.cc
+    assert_order_node.cc
     scalar_aggregate_node.cc
     groupby_aggregate_node.cc
     aggregate_internal.cc
@@ -160,6 +161,7 @@ endfunction()
 add_arrow_acero_test(plan_test SOURCES plan_test.cc test_nodes_test.cc)
 add_arrow_acero_test(source_node_test SOURCES source_node_test.cc)
 add_arrow_acero_test(fetch_node_test SOURCES fetch_node_test.cc)
+add_arrow_acero_test(assert_order_node_test SOURCES assert_order_node_test.cc)
 add_arrow_acero_test(order_by_node_test SOURCES order_by_node_test.cc)
 add_arrow_acero_test(hash_join_node_test SOURCES hash_join_node_test.cc
                      bloom_filter_test.cc)

--- a/cpp/src/arrow/acero/assert_order_node.cc
+++ b/cpp/src/arrow/acero/assert_order_node.cc
@@ -128,8 +128,7 @@ class AssertOrderNode : public ExecNode,
 
     const auto& assert_options = checked_cast<const AssertOrderNodeOptions&>(options);
 
-    SortOptions sort_options = assert_options.sort_options;
-    Ordering ordering = sort_options.AsOrdering();
+    Ordering ordering = assert_options.ordering;
 
     // check output ordering
     if (ordering.is_implicit() || ordering.is_unordered()) {

--- a/cpp/src/arrow/acero/assert_order_node.cc
+++ b/cpp/src/arrow/acero/assert_order_node.cc
@@ -1,0 +1,403 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <arrow/compute/kernels/vector_sort_internal.h>
+#include <parquet/types.h>
+#include <sstream>
+
+#include "arrow/acero/accumulation_queue.h"
+#include "arrow/acero/exec_plan.h"
+#include "arrow/acero/options.h"
+#include "arrow/acero/query_context.h"
+#include "arrow/acero/util.h"
+#include "arrow/compute/api_vector.h"
+#include "arrow/compute/exec.h"
+#include "arrow/result.h"
+#include "arrow/util/checked_cast.h"
+#include "arrow/util/future.h"
+#include "arrow/util/logging.h"
+#include "arrow/util/tracing_internal.h"
+
+namespace arrow {
+
+using internal::checked_cast;
+
+namespace acero {
+namespace {
+
+// Compare two records in a single column (either from a batch or table)
+struct ColumnComparator {
+  ColumnComparator(const compute::NullPlacement& null_placement,
+                   const compute::SortOrder sort_order)
+      : null_placement(null_placement),
+        sort_order(sort_order),
+        left_is_null_order(null_placement == compute::NullPlacement::AtStart ? -1 : 1),
+        right_is_null_order(null_placement == compute::NullPlacement::AtStart ? 1 : -1) {}
+
+  virtual ~ColumnComparator() = default;
+
+  virtual int Compare(const Array& column, const int64_t& left,
+                      const int64_t& right) const = 0;
+
+  compute::NullPlacement null_placement;
+  compute::SortOrder sort_order;
+  int left_is_null_order;
+  int right_is_null_order;
+};
+
+template <typename Type>
+struct ConcreteColumnComparator final : public ColumnComparator {
+  using ColumnComparator::ColumnComparator;
+
+  using ArrayType = typename TypeTraits<Type>::ArrayType;
+  using GetView = compute::internal::GetViewType<Type>;
+
+  int Compare(const Array& column, const int64_t& left,
+              const int64_t& right) const override {
+    const ArrayType& array = ::arrow::internal::checked_cast<const ArrayType&>(column);
+
+    const auto left_value = GetView::LogicalValue(array.GetView(left));
+    const auto right_value = GetView::LogicalValue(array.GetView(right));
+
+    auto left_is_null = column.IsNull(left);
+    auto right_is_null = column.IsNull(right);
+
+    auto orientation = sort_order == compute::SortOrder::Ascending ? 1 : -1;
+    auto less = -1 * orientation;
+    auto larger = 1 * orientation;
+
+    if (left_is_null && right_is_null) {
+      // both values are null (equal)
+      return 0;
+    } else if (left_is_null) {
+      // left value is null
+      return left_is_null_order;
+    } else if (right_is_null) {
+      // right value is null
+      return right_is_null_order;
+    } else if (left_value < right_value) {
+      return less;
+    } else if (left_value > right_value) {
+      return larger;
+    }
+
+    return 0;
+  }
+};
+
+template <>
+struct ConcreteColumnComparator<NullType> : public ColumnComparator {
+  using ColumnComparator::ColumnComparator;
+
+  int Compare(const Array& column, const int64_t& left,
+              const int64_t& right) const override {
+    return 0;
+  }
+};
+
+class AssertOrderNode : public ExecNode,
+                        public TracedNode,
+                        util::SequencingQueue::Processor {
+ public:
+  AssertOrderNode(ExecPlan* plan, std::vector<ExecNode*> inputs,
+                  std::shared_ptr<Schema> output_schema, const Ordering& ordering)
+      : ExecNode(plan, std::move(inputs), {"input"}, std::move(output_schema)),
+        TracedNode(this),
+        ordering_(ordering),
+        comparators_(MakeComparators(output_schema_, ordering_)),
+        sort_ascs_(MakeSortAscs(ordering.sort_keys())),
+        sequencing_queue_(util::SequencingQueue::Make(this)) {}
+
+  static Result<ExecNode*> Make(ExecPlan* plan, std::vector<ExecNode*> inputs,
+                                const ExecNodeOptions& options) {
+    RETURN_NOT_OK(ValidateExecNodeInputs(plan, inputs, 1, "AssertOrderNode"));
+
+    const auto& assert_options = checked_cast<const AssertOrderNodeOptions&>(options);
+
+    SortOptions sort_options = assert_options.sort_options;
+    Ordering ordering = sort_options.AsOrdering();
+
+    // check output ordering
+    if (ordering.is_implicit() || ordering.is_unordered()) {
+      return Status::Invalid("`ordering` must be explicit");
+    }
+
+    std::shared_ptr<Schema> output_schema = inputs[0]->output_schema();
+
+    // check sort keys exist in schema
+    for (const auto& key : ordering.sort_keys()) {
+      ARROW_ASSIGN_OR_RAISE(auto res, key.target.GetOneOrNone(*output_schema));
+      ARROW_CHECK_NE(res, nullptr);
+    }
+
+    return plan->EmplaceNode<AssertOrderNode>(plan, std::move(inputs),
+                                              std::move(output_schema), ordering);
+  }
+
+  const char* kind_name() const override { return "AssertOrderNode"; }
+
+  const Ordering& ordering() const override { return ordering_; }
+
+  Status Validate() const override {
+    ARROW_RETURN_NOT_OK(ExecNode::Validate());
+    if (inputs_[0]->ordering().is_unordered()) {
+      return Status::Invalid(
+          "Assert order node's input has no meaningful ordering and so asserting some "
+          "order "
+          "will be non-deterministic.  Please establish order in some way (e.g. by using "
+          "a "
+          "source node with implicit ordering)");
+    }
+    return Status::OK();
+  }
+
+  Status StartProducing() override {
+    NoteStartProducing(ToStringExtra());
+    return Status::OK();
+  }
+
+  void PauseProducing(ExecNode* output, int32_t counter) override {
+    inputs_[0]->PauseProducing(this, counter);
+  }
+
+  void ResumeProducing(ExecNode* output, int32_t counter) override {
+    inputs_[0]->ResumeProducing(this, counter);
+  }
+
+  Status StopProducingImpl() override { return Status::OK(); }
+
+  Status InputReceived(ExecNode* input, ExecBatch batch) override {
+    auto scope = TraceInputReceived(batch);
+    DCHECK_EQ(input, inputs_[0]);
+
+    // assert order inside batch
+    ARROW_ASSIGN_OR_RAISE(
+        const auto record_batch,
+        batch.ToRecordBatch(output_schema_, plan_->query_context()->memory_pool()));
+    ARROW_RETURN_NOT_OK(AssertInBatchOrder(*record_batch, ordering_, comparators_));
+
+    // queue batch to assert order between that batch and its predecessor
+    return sequencing_queue_->InsertBatch(std::move(batch));
+  }
+
+  Status InputFinished(ExecNode* input, int total_batches) override {
+    DCHECK_EQ(input, inputs_[0]);
+    EVENT_ON_CURRENT_SPAN("InputFinished", {{"batches.length", total_batches}});
+    return output_->InputFinished(this, total_batches);
+  }
+
+  Result<std::optional<util::SequencingQueue::Task>> Process(ExecBatch batch) override {
+    // check this batch is in order with previous batch, skip entirely for emtpy batches
+    if (batch.length > 0) {
+      // extract sort values of current batch
+      auto current_record_batch =
+          batch.ToRecordBatch(output_schema_, plan_->query_context()->memory_pool())
+              .ValueOrDie();
+
+      // compare against previous sort values
+      if (previous_sort_values_.has_value()) {
+        // check batches are in order
+        ARROW_ASSIGN_OR_RAISE(
+            auto current_sort_values,
+            ExtractSortKeys(*current_record_batch, 0, ordering_.sort_keys()));
+        ARROW_RETURN_NOT_OK(AssertBatchOrder(previous_sort_values_.value(),
+                                             current_sort_values, sort_ascs_));
+      }
+
+      // memorize last row of record batch for next batch
+      ARROW_ASSIGN_OR_RAISE(
+          previous_sort_values_,
+          ExtractSortKeys(*current_record_batch, current_record_batch->num_rows() - 1,
+                          ordering_.sort_keys()));
+    }
+
+    // send current batch
+    std::optional<util::SequencingQueue::Task> task_or_none =
+        [this, batch = std::move(batch)]() mutable {
+          ExecBatch batch_to_send = std::move(batch);
+          return output_->InputReceived(this, std::move(batch_to_send));
+        };
+
+    return task_or_none;
+  }
+
+  void Schedule(util::SequencingQueue::Task task) override {
+    plan_->query_context()->ScheduleTask(std::move(task),
+                                         "AssertOrderNode::ProcessBatch");
+  }
+
+ protected:
+  std::string ToStringExtra(int indent = 0) const override {
+    std::stringstream ss;
+    ss << "ordering=" << ordering_.ToString();
+    return ss.str();
+  }
+
+  static Status AssertInBatchOrder(
+      const RecordBatch& batch, const Ordering& ordering,
+      const std::vector<std::unique_ptr<ColumnComparator>>& comparators) {
+    auto sort_keys = ordering.sort_keys();
+    ARROW_CHECK_EQ(comparators.size(), sort_keys.size());
+
+    // trivial case: batch is empty or only a single row
+    if (batch.num_rows() <= 1) {
+      return Status::OK();
+    }
+
+    // extract the sort columns
+    std::vector<std::shared_ptr<Array>> sort_columns(sort_keys.size());
+    for (size_t i = 0; i < sort_keys.size(); ++i) {
+      auto& key = sort_keys[i];
+      ARROW_ASSIGN_OR_RAISE(sort_columns[i], key.target.GetOneOrNone(batch));
+    }
+
+    // assert order of sort columns
+    for (int64_t row = 1; row < batch.num_rows(); ++row) {
+      for (size_t col = 0; col < sort_keys.size(); ++col) {
+        auto& sort_column = sort_columns[col];
+        auto& comparator = comparators[col];
+
+        auto result = comparator->Compare(*sort_column, row - 1, row);
+        if (result < 0) {
+          // order asserted, no more keys need to be compared, move to next row
+          break;
+        }
+        if (result > 0) {
+          // order mismatch
+          return Status::ExecutionError("Data is not ordered");
+        }
+      }
+    }
+
+    return Status::OK();
+  }
+
+  static Status AssertBatchOrder(
+      const std::vector<std::shared_ptr<Scalar>>& previous_sort_scalars,
+      const std::vector<std::shared_ptr<Scalar>>& sort_scalars,
+      const std::vector<bool>& sort_ascs) {
+    ARROW_CHECK_EQ(previous_sort_scalars.size(), sort_scalars.size());
+    ARROW_CHECK_EQ(sort_scalars.size(), sort_ascs.size());
+    for (size_t i = 0; i < sort_scalars.size(); ++i) {
+      const auto& previous_sort_scalar = previous_sort_scalars[i];
+      const auto& sort_scalar = sort_scalars[i];
+      const auto& sort_asc = sort_ascs[i];
+
+      if (ScalarLess(*previous_sort_scalar, *sort_scalar)) {
+        if (sort_asc) {
+          return Status::OK();
+        }
+        return Status::ExecutionError("Data is not ordered");
+      }
+      if (ScalarLess(*sort_scalar, *previous_sort_scalar)) {
+        if (!sort_asc) {
+          return Status::OK();
+        }
+        return Status::ExecutionError("Data is not ordered");
+      }
+    }
+    return Status::OK();
+  }
+
+  static Result<std::vector<std::shared_ptr<Scalar>>> ExtractSortKeys(
+      const RecordBatch& batch, const int64_t& row,
+      const std::vector<compute::SortKey>& sort_keys) {
+    DCHECK_GE(row, 0);
+    DCHECK_LE(row, batch.num_rows());
+    std::vector<std::shared_ptr<Scalar>> sort_scalars(sort_keys.size());
+    for (size_t i = 0; i < sort_keys.size(); ++i) {
+      auto& key = sort_keys[i];
+      ARROW_ASSIGN_OR_RAISE(const auto array, key.target.GetOneOrNone(batch));
+      ARROW_ASSIGN_OR_RAISE(sort_scalars[i], array->GetScalar(row));
+    }
+    return sort_scalars;
+  }
+
+ private:
+  Ordering ordering_;
+  std::vector<std::unique_ptr<ColumnComparator>> comparators_;
+  std::vector<bool> sort_ascs_;
+  std::optional<std::vector<std::shared_ptr<Scalar>>> previous_sort_values_ =
+      std::nullopt;
+  std::unique_ptr<util::SequencingQueue> sequencing_queue_;
+
+  static std::vector<std::unique_ptr<ColumnComparator>> MakeComparators(
+      const std::shared_ptr<Schema>& schema, const Ordering& ordering) {
+    ARROW_CHECK(schema);
+    std::vector<std::unique_ptr<ColumnComparator>> comparators(
+        ordering.sort_keys().size());
+    for (size_t i = 0; i < ordering.sort_keys().size(); ++i) {
+      auto& sort_key = ordering.sort_keys()[i];
+      auto factory = ColumnComparatorFactory{ordering.null_placement(), sort_key.order};
+      auto field_path = sort_key.target.FindOne(*schema).ValueOrDie();
+      auto field = field_path.Get(*schema).ValueOrDie();
+      comparators[i] = factory.Create(*field->type()).ValueOrDie();
+    }
+    return comparators;
+  }
+
+  static std::vector<bool> MakeSortAscs(const Ordering& ordering) {
+    std::vector<bool> sort_ascs(ordering.sort_keys().size());
+    for (size_t i = 0; i < ordering.sort_keys().size(); ++i) {
+      auto& sort_key = ordering.sort_keys()[i];
+      sort_ascs[i] = sort_key.order == compute::SortOrder::Ascending;
+    }
+    return sort_ascs;
+  }
+
+  struct ColumnComparatorFactory {
+    Result<std::unique_ptr<ColumnComparator>> Create(const DataType& type) {
+      RETURN_NOT_OK(VisitTypeInline(type, this));
+      return std::move(res);
+    }
+
+#define VISIT(TYPE) \
+  Status Visit(const TYPE& type) { return VisitGeneric(type); }
+
+    VISIT_SORTABLE_PHYSICAL_TYPES(VISIT)
+    VISIT(NullType)
+
+#undef VISIT
+
+    Status Visit(const DataType& type) {
+      return Status::TypeError("Unsupported type for asserting order: ", type.ToString());
+    }
+
+    template <typename Type>
+    Status VisitGeneric(const Type& type) {
+      res.reset(new ConcreteColumnComparator<Type>{null_placement, sort_order});
+      return Status::OK();
+    }
+
+    const compute::NullPlacement null_placement;
+    const compute::SortOrder sort_order;
+    std::unique_ptr<ColumnComparator> res = nullptr;
+  };
+};
+
+}  // namespace
+
+namespace internal {
+
+void RegisterAssertOrderNode(ExecFactoryRegistry* registry) {
+  DCHECK_OK(registry->AddFactory(std::string(AssertOrderNodeOptions::kName),
+                                 AssertOrderNode::Make));
+}
+
+}  // namespace internal
+}  // namespace acero
+}  // namespace arrow

--- a/cpp/src/arrow/acero/assert_order_node_test.cc
+++ b/cpp/src/arrow/acero/assert_order_node_test.cc
@@ -1,0 +1,180 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <arrow/testing/builder.h>
+#include <gtest/gtest.h>
+
+#include <gmock/gmock-matchers.h>
+
+#include "arrow/acero/exec_plan.h"
+#include "arrow/acero/options.h"
+#include "arrow/acero/test_nodes.h"
+#include "arrow/compute/ordering.h"
+#include "arrow/table.h"
+#include "arrow/testing/generator.h"
+#include "arrow/testing/gtest_util.h"
+#include "arrow/testing/random.h"
+
+namespace arrow {
+namespace acero {
+
+auto table_schema = schema(FieldVector({field("id", int64())}));
+
+void CheckAssert(const std::shared_ptr<ChunkedArray>& array,
+                 const std::shared_ptr<Schema>& schema, const SortOptions& sort_options,
+                 const Status& expected_status = Status::OK()) {
+  // count empty chunks at the end of the table
+  int empty_pad_chunks = 0;
+  for (auto it = array->chunks().rbegin(); it != array->chunks().rend(); ++it) {
+    if (it->get()->length() == 0) {
+      ++empty_pad_chunks;
+    } else {
+      break;
+    }
+  }
+  // remove empty chunks from array to construct expected array
+  auto expected_chunks =
+      ArrayVector(array->chunks().begin(), array->chunks().end() - empty_pad_chunks);
+  auto expected_array = ChunkedArray::Make(expected_chunks, array->type()).ValueOrDie();
+
+  auto table = Table::Make(schema, {array});
+  auto expected = Table::Make(schema, {expected_array});
+
+  constexpr random::SeedType kSeed = 42;
+  constexpr int kJitterMod = 4;
+  RegisterTestNodes();
+
+  std::shared_ptr<ExecNodeOptions> assert_options =
+      std::make_shared<AssertOrderNodeOptions>(sort_options);
+  Declaration plan =
+      Declaration::Sequence({{"table_source", TableSourceNodeOptions(table)},
+                             {"jitter", JitterNodeOptions(kSeed, kJitterMod)},
+                             {"assert-order", assert_options}});
+
+  for (bool use_threads : {false, true}) {
+    QueryOptions query_options;
+    query_options.use_threads = use_threads;
+
+    if (expected_status.ok()) {
+      // assert actual output table is identical to input table
+      ASSERT_OK_AND_ASSIGN(std::shared_ptr<Table> actual,
+                           DeclarationToTable(plan, query_options));
+      AssertTablesEqual(*expected, *actual);
+    } else {
+      auto result = DeclarationToTable(plan, query_options);
+      ASSERT_NOT_OK(result);
+      const auto& actual_status = result.status();
+      ASSERT_EQ(actual_status.code(), expected_status.code());
+      ASSERT_EQ(actual_status.message(), expected_status.message());
+    }
+  }
+}
+
+void CheckAssert(const std::shared_ptr<ChunkedArray>& array,
+                 const SortOptions& sort_options,
+                 const Status& expected_status = Status::OK()) {
+  CheckAssert(array, table_schema, sort_options, expected_status);
+}
+
+TEST(AssertOrderNode, SingleColumnAsc) {
+  const auto monotonic_ids =
+      ChunkedArrayFromJSON(int64(), {"[1, 2, 3]", "[4, 5, 6]", "[7, 8, 9]"});
+  const auto repeating_ids =
+      ChunkedArrayFromJSON(int64(), {"[1, 2, 2]", "[3, 3, 3]", "[7, 7, 9]"});
+  const auto identical_ids =
+      ChunkedArrayFromJSON(int64(), {"[3, 3, 3]", "[3, 3, 3]", "[3, 3, 3]"});
+  const auto some_negative_ids =
+      ChunkedArrayFromJSON(int64(), {"[-5, -4, -3]", "[-2, 0, 2]", "[3, 5, 6]"});
+  const auto all_negative_ids =
+      ChunkedArrayFromJSON(int64(), {"[-9, -8, -7]", "[-7, -6, -6]", "[-6, -5, -1]"});
+
+  const auto all_empty_batches = ChunkedArrayFromJSON(int64(), {"[]", "[]", "[]"});
+  const auto many_empty_batches = ChunkedArrayFromJSON(
+      int64(),
+      {"[]", "[]", "[1, 2, 3]", "[]", "[]", "[4, 5, 6]", "[]", "[7, 8, 9]", "[]", "[]"});
+
+  const auto unordered_batch =
+      ChunkedArrayFromJSON(int64(), {"[1, 2, 3]", "[4, 6, 5]", "[7, 8, 9]"});
+  const auto unordered_batches =
+      ChunkedArrayFromJSON(int64(), {"[1, 2, 3]", "[7, 8, 9]", "[4, 5, 6]"});
+
+  // TODO: add tests with NULL and NaN values
+
+  auto asc_sort_options =
+      SortOptions({compute::SortKey{"id", compute::SortOrder::Ascending}});
+
+  CheckAssert(monotonic_ids, asc_sort_options);
+  CheckAssert(repeating_ids, asc_sort_options);
+  CheckAssert(identical_ids, asc_sort_options);
+  CheckAssert(some_negative_ids, asc_sort_options);
+  CheckAssert(all_negative_ids, asc_sort_options);
+
+  CheckAssert(all_empty_batches, asc_sort_options);
+  CheckAssert(many_empty_batches, asc_sort_options);
+
+  CheckAssert(unordered_batch, asc_sort_options,
+              Status::ExecutionError("Data is not ordered"));
+  CheckAssert(unordered_batches, asc_sort_options,
+              Status::ExecutionError("Data is not ordered"));
+}
+
+TEST(AssertOrderNode, SingleColumnDesc) {
+  const auto monotonic_ids =
+      ChunkedArrayFromJSON(int64(), {"[9, 8, 7]", "[6, 5, 4]", "[3, 2, 1]"});
+  const auto repeating_ids =
+      ChunkedArrayFromJSON(int64(), {"[9, 7, 7]", "[5, 5, 5]", "[3, 3, 1]"});
+  const auto identical_ids =
+      ChunkedArrayFromJSON(int64(), {"[3, 3, 3]", "[3, 3, 3]", "[3, 3, 3]"});
+  const auto some_negative_ids =
+      ChunkedArrayFromJSON(int64(), {"[5, 4, 3]", "[2, 0, -2]", "[-3, -5, -6]"});
+  const auto all_negative_ids =
+      ChunkedArrayFromJSON(int64(), {"[-1, -2, -3]", "[-4, -5, -6]", "[-7, -8, -9]"});
+
+  const auto all_empty_batches = ChunkedArrayFromJSON(int64(), {"[]", "[]", "[]"});
+  const auto many_empty_batches = ChunkedArrayFromJSON(
+      int64(),
+      {"[]", "[]", "[9, 8, 7]", "[]", "[]", "[6, 5, 4]", "[]", "[3, 2, 1]", "[]", "[]"});
+
+  const auto unordered_batch =
+      ChunkedArrayFromJSON(int64(), {"[9, 8, 7]", "[6, 4, 5]", "[3, 2, 1]"});
+  const auto unordered_batches =
+      ChunkedArrayFromJSON(int64(), {"[9, 8, 7]", "[3, 2, 1]", "[6, 5, 4]"});
+
+  // TODO: add tests with NULL and NaN values
+
+  auto desc_sort_options =
+      SortOptions({compute::SortKey{"id", compute::SortOrder::Descending}});
+
+  CheckAssert(monotonic_ids, desc_sort_options);
+  CheckAssert(repeating_ids, desc_sort_options);
+  CheckAssert(identical_ids, desc_sort_options);
+  CheckAssert(some_negative_ids, desc_sort_options);
+  CheckAssert(all_negative_ids, desc_sort_options);
+
+  CheckAssert(all_empty_batches, desc_sort_options);
+  CheckAssert(many_empty_batches, desc_sort_options);
+
+  CheckAssert(unordered_batch, desc_sort_options,
+              Status::ExecutionError("Data is not ordered"));
+  CheckAssert(unordered_batches, desc_sort_options,
+              Status::ExecutionError("Data is not ordered"));
+}
+
+// TODO: add tests with multiple columns
+
+}  // namespace acero
+}  // namespace arrow

--- a/cpp/src/arrow/acero/assert_order_node_test.cc
+++ b/cpp/src/arrow/acero/assert_order_node_test.cc
@@ -78,8 +78,9 @@ void CheckAssert(const std::shared_ptr<ChunkedArray>& array,
       auto result = DeclarationToTable(plan, query_options);
       ASSERT_NOT_OK(result);
       const auto& actual_status = result.status();
-      ASSERT_EQ(actual_status.code(), expected_status.code());
-      ASSERT_EQ(actual_status.message(), expected_status.message());
+      EXPECT_EQ(actual_status.code(), expected_status.code());
+      EXPECT_THAT(actual_status.message(),
+                  testing::StartsWith(expected_status.message()));
     }
   }
 }

--- a/cpp/src/arrow/acero/assert_order_node_test.cc
+++ b/cpp/src/arrow/acero/assert_order_node_test.cc
@@ -85,8 +85,7 @@ void CheckAssert(const std::shared_ptr<ChunkedArray>& array,
   }
 }
 
-void CheckAssert(const std::shared_ptr<ChunkedArray>& array,
-                 const Ordering& ordering,
+void CheckAssert(const std::shared_ptr<ChunkedArray>& array, const Ordering& ordering,
                  const Status& expected_status = Status::OK()) {
   CheckAssert(array, table_schema, ordering, expected_status);
 }
@@ -116,7 +115,8 @@ TEST(AssertOrderNode, SingleColumnAsc) {
   // TODO: add tests with NULL and NaN values
 
   auto asc_sort_options =
-      Ordering({{compute::SortKey{"id", compute::SortOrder::Ascending}}}, compute::NullPlacement::AtStart);
+      Ordering({{compute::SortKey{"id", compute::SortOrder::Ascending}}},
+               compute::NullPlacement::AtStart);
 
   CheckAssert(monotonic_ids, asc_sort_options);
   CheckAssert(repeating_ids, asc_sort_options);
@@ -134,31 +134,32 @@ TEST(AssertOrderNode, SingleColumnAsc) {
 }
 
 TEST(AssertOrderNode, SingleColumnDesc) {
-    const auto monotonic_ids =
-        ChunkedArrayFromJSON(int64(), {"[9, 8, 7]", "[6, 5, 4]", "[3, 2, 1]"});
-    const auto repeating_ids =
-        ChunkedArrayFromJSON(int64(), {"[9, 7, 7]", "[5, 5, 5]", "[3, 3, 1]"});
-    const auto identical_ids =
-        ChunkedArrayFromJSON(int64(), {"[3, 3, 3]", "[3, 3, 3]", "[3, 3, 3]"});
-    const auto some_negative_ids =
-        ChunkedArrayFromJSON(int64(), {"[5, 4, 3]", "[2, 0, -2]", "[-3, -5, -6]"});
-    const auto all_negative_ids =
-        ChunkedArrayFromJSON(int64(), {"[-1, -2, -3]", "[-4, -5, -6]", "[-7, -8, -9]"});
+  const auto monotonic_ids =
+      ChunkedArrayFromJSON(int64(), {"[9, 8, 7]", "[6, 5, 4]", "[3, 2, 1]"});
+  const auto repeating_ids =
+      ChunkedArrayFromJSON(int64(), {"[9, 7, 7]", "[5, 5, 5]", "[3, 3, 1]"});
+  const auto identical_ids =
+      ChunkedArrayFromJSON(int64(), {"[3, 3, 3]", "[3, 3, 3]", "[3, 3, 3]"});
+  const auto some_negative_ids =
+      ChunkedArrayFromJSON(int64(), {"[5, 4, 3]", "[2, 0, -2]", "[-3, -5, -6]"});
+  const auto all_negative_ids =
+      ChunkedArrayFromJSON(int64(), {"[-1, -2, -3]", "[-4, -5, -6]", "[-7, -8, -9]"});
 
-    const auto all_empty_batches = ChunkedArrayFromJSON(int64(), {"[]", "[]", "[]"});
-    const auto many_empty_batches = ChunkedArrayFromJSON(
-        int64(),
-        {"[]", "[]", "[9, 8, 7]", "[]", "[]", "[6, 5, 4]", "[]", "[3, 2, 1]", "[]", "[]"});
+  const auto all_empty_batches = ChunkedArrayFromJSON(int64(), {"[]", "[]", "[]"});
+  const auto many_empty_batches = ChunkedArrayFromJSON(
+      int64(),
+      {"[]", "[]", "[9, 8, 7]", "[]", "[]", "[6, 5, 4]", "[]", "[3, 2, 1]", "[]", "[]"});
 
-    const auto unordered_batch =
-        ChunkedArrayFromJSON(int64(), {"[9, 8, 7]", "[6, 4, 5]", "[3, 2, 1]"});
-    const auto unordered_batches =
-        ChunkedArrayFromJSON(int64(), {"[9, 8, 7]", "[3, 2, 1]", "[6, 5, 4]"});
+  const auto unordered_batch =
+      ChunkedArrayFromJSON(int64(), {"[9, 8, 7]", "[6, 4, 5]", "[3, 2, 1]"});
+  const auto unordered_batches =
+      ChunkedArrayFromJSON(int64(), {"[9, 8, 7]", "[3, 2, 1]", "[6, 5, 4]"});
 
-    // TODO: add tests with NULL and NaN values
+  // TODO: add tests with NULL and NaN values
 
-    auto desc_sort_options =
-        Ordering({{compute::SortKey{"id", compute::SortOrder::Descending}}}, compute::NullPlacement::AtStart);
+  auto desc_sort_options =
+      Ordering({{compute::SortKey{"id", compute::SortOrder::Descending}}},
+               compute::NullPlacement::AtStart);
 
   CheckAssert(monotonic_ids, desc_sort_options);
   CheckAssert(repeating_ids, desc_sort_options);

--- a/cpp/src/arrow/acero/exec_plan.cc
+++ b/cpp/src/arrow/acero/exec_plan.cc
@@ -1105,6 +1105,7 @@ namespace internal {
 
 void RegisterSourceNode(ExecFactoryRegistry*);
 void RegisterFetchNode(ExecFactoryRegistry*);
+void RegisterAssertOrderNode(ExecFactoryRegistry*);
 void RegisterFilterNode(ExecFactoryRegistry*);
 void RegisterOrderByNode(ExecFactoryRegistry*);
 void RegisterPivotLongerNode(ExecFactoryRegistry*);
@@ -1124,6 +1125,7 @@ ExecFactoryRegistry* default_exec_factory_registry() {
     DefaultRegistry() {
       internal::RegisterSourceNode(this);
       internal::RegisterFetchNode(this);
+      internal::RegisterAssertOrderNode(this);
       internal::RegisterFilterNode(this);
       internal::RegisterOrderByNode(this);
       internal::RegisterPivotLongerNode(this);

--- a/cpp/src/arrow/acero/exec_plan.h
+++ b/cpp/src/arrow/acero/exec_plan.h
@@ -186,9 +186,11 @@ class ARROW_ACERO_EXPORT ExecNode {
   /// input batch that was mapped.
   ///
   /// Other nodes may introduce order.  For example, an order-by node will emit
-  /// a brand new ordering independent of the input ordering.
+  /// a brand new ordering independent of the input ordering.  An assert-order node
+  /// checks rows are in a given order and turns the implicit input ordering into an
+  /// explicit ordering.  Any out-of-order row will fail the assertion.
   ///
-  /// Finally, as described above, such as a hash-join or aggregation may may
+  /// Finally, as described above, such as a hash-join or aggregation may
   /// destroy ordering (although these nodes could also choose to establish a
   /// new ordering based on the hash keys).
   ///

--- a/cpp/src/arrow/acero/exec_plan.h
+++ b/cpp/src/arrow/acero/exec_plan.h
@@ -190,7 +190,7 @@ class ARROW_ACERO_EXPORT ExecNode {
   /// checks rows are in a given order and turns the implicit input ordering into an
   /// explicit ordering.  Any out-of-order row will fail the assertion.
   ///
-  /// Finally, as described above, such as a hash-join or aggregation may
+  /// Finally, as described above, nodes such as a hash-join or aggregation may
   /// destroy ordering (although these nodes could also choose to establish a
   /// new ordering based on the hash keys).
   ///

--- a/cpp/src/arrow/acero/options.h
+++ b/cpp/src/arrow/acero/options.h
@@ -239,6 +239,22 @@ class ARROW_ACERO_EXPORT RecordBatchSourceNodeOptions
   using SchemaSourceNodeOptions::SchemaSourceNodeOptions;
 };
 
+/// \brief a node which asserts rows are in expected order
+///
+/// The order of rows with batches is asserted in parallel while
+/// consecutive batches are check for expected order sequentially.
+/// The output batches are again processed further in parallel.
+class ARROW_ACERO_EXPORT AssertOrderNodeOptions : public ExecNodeOptions {
+ public:
+  static constexpr std::string_view kName = "assert-order";
+  /// \brief create an instance from sort options
+  explicit AssertOrderNodeOptions(SortOptions sort_options)
+      : sort_options(std::move(sort_options)) {}
+
+  /// \brief options describing which columns and direction to sort
+  SortOptions sort_options;
+};
+
 /// \brief a node which excludes some rows from batches passed through it
 ///
 /// filter_expression will be evaluated against each batch which is pushed to

--- a/cpp/src/arrow/acero/options.h
+++ b/cpp/src/arrow/acero/options.h
@@ -21,6 +21,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "arrow/acero/type_fwd.h"
@@ -246,13 +247,13 @@ class ARROW_ACERO_EXPORT RecordBatchSourceNodeOptions
 /// The output batches are again processed further in parallel.
 class ARROW_ACERO_EXPORT AssertOrderNodeOptions : public ExecNodeOptions {
  public:
-  static constexpr std::string_view kName = "assert-order";
-  /// \brief create an instance from sort options
-  explicit AssertOrderNodeOptions(SortOptions sort_options)
-      : sort_options(std::move(sort_options)) {}
+  static constexpr std::string_view kName = "assert_order";
+  /// \brief create an instance from ordering
+  explicit AssertOrderNodeOptions(Ordering ordering)
+      : ordering(std::move(ordering)) {}
 
-  /// \brief options describing which columns and direction to sort
-  SortOptions sort_options;
+  /// \brief expected null placement and sort columns and directions
+  Ordering ordering;
 };
 
 /// \brief a node which excludes some rows from batches passed through it

--- a/cpp/src/arrow/acero/options.h
+++ b/cpp/src/arrow/acero/options.h
@@ -249,8 +249,7 @@ class ARROW_ACERO_EXPORT AssertOrderNodeOptions : public ExecNodeOptions {
  public:
   static constexpr std::string_view kName = "assert_order";
   /// \brief create an instance from ordering
-  explicit AssertOrderNodeOptions(Ordering ordering)
-      : ordering(std::move(ordering)) {}
+  explicit AssertOrderNodeOptions(Ordering ordering) : ordering(std::move(ordering)) {}
 
   /// \brief expected null placement and sort columns and directions
   Ordering ordering;

--- a/cpp/src/arrow/compare.cc
+++ b/cpp/src/arrow/compare.cc
@@ -904,9 +904,9 @@ class ScalarEqualsVisitor {
   typename std::enable_if<(is_primitive_ctype<typename T::TypeClass>::value ||
                            is_temporal_type<typename T::TypeClass>::value),
                           Status>::type
-  Visit(const T& left_) {
+  Visit(const T& left) {
     const auto& right = checked_cast<const T&>(right_);
-    result_ = right.value == left_.value;
+    result_ = left.value == right.value;
     return Status::OK();
   }
 
@@ -1055,6 +1055,239 @@ class ScalarEqualsVisitor {
   bool result_;
 };
 
+template <typename T, typename Flags>
+struct FloatingLess {
+  explicit FloatingLess(const EqualOptions& options)
+      : epsilon(static_cast<T>(options.atol())) {}
+
+  bool operator()(T x, T y) const {
+    if (x == y) {
+      return !Flags::signed_zeros_equal && std::signbit(x) && !std::signbit(y);
+    }
+    // TODO: consider null (nan) placement
+    if (Flags::nans_equal && std::isnan(x) && std::isnan(y)) {
+      return false;
+    }
+    if (Flags::approximate) {
+      return x + epsilon < y;
+    }
+    return x < y;
+  }
+
+  const T epsilon;
+};
+
+// For half-float equality.
+template <typename Flags>
+struct FloatingLess<uint16_t, Flags> {
+  explicit FloatingLess(const EqualOptions& options)
+      : epsilon(static_cast<float>(options.atol())) {}
+
+  bool operator()(uint16_t x, uint16_t y) const {
+    Float16 f_x = Float16::FromBits(x);
+    Float16 f_y = Float16::FromBits(y);
+    if (x == y) {
+      return Flags::signed_zeros_equal || (f_x.signbit() == f_y.signbit());
+    }
+    // TODO: consider null (nan) placement
+    if (Flags::nans_equal && f_x.is_nan() && f_y.is_nan()) {
+      return true;
+    }
+    if (Flags::approximate && (fabs(f_x.ToFloat() - f_y.ToFloat()) <= epsilon)) {
+      return true;
+    }
+    return false;
+  }
+
+  const float epsilon;
+};
+
+template <typename T, typename Visitor>
+struct FloatingLessDispatcher {
+  const EqualOptions& options;
+  bool floating_approximate;
+  Visitor&& visit;
+
+  template <bool Approximate, bool NansEqual>
+  void DispatchL3() {
+    if (options.signed_zeros_equal()) {
+      visit(FloatingEquality<T, FloatingEqualityFlags<Approximate, NansEqual, true>>{
+          options});
+    } else {
+      visit(FloatingEquality<T, FloatingEqualityFlags<Approximate, NansEqual, false>>{
+          options});
+    }
+  }
+
+  template <bool Approximate>
+  void DispatchL2() {
+    if (options.nans_equal()) {
+      DispatchL3<Approximate, true>();
+    } else {
+      DispatchL3<Approximate, false>();
+    }
+  }
+
+  void Dispatch() {
+    if (floating_approximate) {
+      DispatchL2<true>();
+    } else {
+      DispatchL2<false>();
+    }
+  }
+};
+
+// Call `visit(equality_func)` where `equality_func` has the signature `bool(T, T)`
+// and returns true if the two values compare equal.
+template <typename T, typename Visitor>
+void VisitFloatingLess(const EqualOptions& options, bool floating_approximate,
+                       Visitor&& visit) {
+  FloatingEqualityDispatcher<T, Visitor>{options, floating_approximate,
+                                         std::forward<Visitor>(visit)}
+      .Dispatch();
+}
+
+class ScalarLessVisitor {
+ public:
+  // PRE-CONDITIONS:
+  // - the types are equal
+  // - the scalars are non-null
+  explicit ScalarLessVisitor(const Scalar& right, const EqualOptions& opts,
+                             bool floating_approximate)
+      : right_(right),
+        options_(opts),
+        floating_approximate_(floating_approximate),
+        result_(false) {}
+
+  Status Visit(const NullScalar& left) {
+    result_ = false;
+    return Status::OK();
+  }
+
+  Status Visit(const BooleanScalar& left) {
+    const auto& right = checked_cast<const BooleanScalar&>(right_);
+    result_ = !left.value && right.value;
+    return Status::OK();
+  }
+
+  Status Visit(const MonthDayNanoIntervalScalar& left) {
+    return Status::Invalid("Comparing month day nano interval scalars not supported");
+  }
+
+  template <typename T>
+  typename std::enable_if<(is_primitive_ctype<typename T::TypeClass>::value ||
+                           is_temporal_type<typename T::TypeClass>::value),
+                          Status>::type
+  Visit(const T& left) {
+    const auto& right = checked_cast<const T&>(right_);
+    result_ = left.value < right.value;
+    return Status::OK();
+  }
+
+  Status Visit(const FloatScalar& left) { return CompareFloating(left); }
+
+  Status Visit(const DoubleScalar& left) { return CompareFloating(left); }
+
+  Status Visit(const HalfFloatScalar& left) { return CompareFloating(left); }
+
+  template <typename T>
+  enable_if_t<std::is_base_of<BaseBinaryScalar, T>::value, Status> Visit(const T& left) {
+    return Status::Invalid("Comparing BinaryScalar not supported");
+  }
+
+  Status Visit(const Decimal32Scalar& left) {
+    const auto& right = checked_cast<const Decimal32Scalar&>(right_);
+    result_ = left.value < right.value;
+    return Status::OK();
+  }
+
+  Status Visit(const Decimal64Scalar& left) {
+    const auto& right = checked_cast<const Decimal64Scalar&>(right_);
+    result_ = left.value < right.value;
+    return Status::OK();
+  }
+
+  Status Visit(const Decimal128Scalar& left) {
+    const auto& right = checked_cast<const Decimal128Scalar&>(right_);
+    result_ = left.value < right.value;
+    return Status::OK();
+  }
+
+  Status Visit(const Decimal256Scalar& left) {
+    const auto& right = checked_cast<const Decimal256Scalar&>(right_);
+    result_ = left.value < right.value;
+    return Status::OK();
+  }
+
+  Status Visit(const ListScalar& left) {
+    return Status::Invalid("Comparing list scalars not supported");
+  }
+
+  Status Visit(const LargeListScalar& left) {
+    return Status::Invalid("Comparing list scalars not supported");
+  }
+
+  Status Visit(const ListViewScalar& left) {
+    return Status::Invalid("Comparing list scalars not supported");
+  }
+
+  Status Visit(const LargeListViewScalar& left) {
+    return Status::Invalid("Comparing BinaryScalar not supported");
+  }
+
+  Status Visit(const MapScalar& left) {
+    return Status::Invalid("Comparing map scalars not supported");
+  }
+
+  Status Visit(const FixedSizeListScalar& left) {
+    return Status::Invalid("Comparing list scalars not supported");
+  }
+
+  Status Visit(const StructScalar& left) {
+    return Status::Invalid("Comparing struct scalars not supported");
+  }
+
+  Status Visit(const DenseUnionScalar& left) {
+    return Status::Invalid("Comparing union scalars not supported");
+  }
+
+  Status Visit(const SparseUnionScalar& left) {
+    return Status::Invalid("Comparing union scalars not supported");
+  }
+
+  Status Visit(const DictionaryScalar& left) {
+    return Status::Invalid("Comparing dictionary scalars not supported");
+  }
+
+  Status Visit(const RunEndEncodedScalar& left) {
+    return Status::Invalid("Comparing run end scalars not supported");
+  }
+
+  Status Visit(const ExtensionScalar& left) {
+    return Status::Invalid("Comparing extension scalars not supported");
+  }
+
+  bool result() const { return result_; }
+
+ protected:
+  template <typename ScalarType>
+  Status CompareFloating(const ScalarType& left) {
+    using CType = decltype(left.value);
+    const auto& right = checked_cast<const ScalarType&>(right_);
+
+    auto visitor = [&](auto&& compare_func) {
+      result_ = compare_func(left.value, right.value);
+    };
+    VisitFloatingEquality<CType>(options_, floating_approximate_, std::move(visitor));
+    return Status::OK();
+  }
+
+  const Scalar& right_;
+  const EqualOptions options_;
+  const bool floating_approximate_;
+  bool result_;
+};
+
 Status PrintDiff(const Array& left, const Array& right, std::ostream* os);
 
 Status PrintDiff(const Array& left, const Array& right, int64_t left_offset,
@@ -1147,6 +1380,31 @@ bool ScalarEquals(const Scalar& left, const Scalar& right, const EqualOptions& o
   return visitor.result();
 }
 
+bool ScalarLess(const Scalar& left, const Scalar& right, const EqualOptions& options,
+                bool floating_approximate) {
+  if (&left == &right && IdentityImpliesEquality(*left.type, options)) {
+    return false;
+  }
+  if (!left.type->Equals(right.type)) {
+    return false;
+  }
+  if (!left.is_valid && !right.is_valid) {
+    return false;
+  }
+  if (!left.is_valid) {
+    // TODO: consider null placement
+    return true;
+  }
+  if (!right.is_valid) {
+    // TODO: consider null placement
+    return false;
+  }
+  ScalarLessVisitor visitor(right, options, floating_approximate);
+  auto error = VisitScalarInline(left, &visitor);
+  DCHECK_OK(error);
+  return visitor.result();
+}
+
 }  // namespace
 
 bool ArrayRangeEquals(const Array& left, const Array& right, int64_t left_start_idx,
@@ -1184,6 +1442,17 @@ bool ScalarApproxEquals(const Scalar& left, const Scalar& right,
                         const EqualOptions& options) {
   const bool floating_approximate = true;
   return ScalarEquals(left, right, options, floating_approximate);
+}
+
+bool ScalarLess(const Scalar& left, const Scalar& right, const EqualOptions& options) {
+  const bool floating_approximate = false;
+  return ScalarLess(left, right, options, floating_approximate);
+}
+
+bool ScalarApproxLess(const Scalar& left, const Scalar& right,
+                      const EqualOptions& options) {
+  const bool floating_approximate = true;
+  return ScalarLess(left, right, options, floating_approximate);
 }
 
 namespace {

--- a/cpp/src/arrow/compare.cc
+++ b/cpp/src/arrow/compare.cc
@@ -904,9 +904,9 @@ class ScalarEqualsVisitor {
   typename std::enable_if<(is_primitive_ctype<typename T::TypeClass>::value ||
                            is_temporal_type<typename T::TypeClass>::value),
                           Status>::type
-  Visit(const T& left) {
+  Visit(const T& left_) {
     const auto& right = checked_cast<const T&>(right_);
-    result_ = left.value == right.value;
+    result_ = right.value == left_.value;
     return Status::OK();
   }
 

--- a/cpp/src/arrow/compare.h
+++ b/cpp/src/arrow/compare.h
@@ -142,4 +142,19 @@ ARROW_EXPORT bool ScalarApproxEquals(
     const Scalar& left, const Scalar& right,
     const EqualOptions& options = EqualOptions::Defaults());
 
+/// Returns true if left scalar is less than right scalar
+/// \param[in] left a Scalar
+/// \param[in] right a Scalar
+/// \param[in] options comparison options
+ARROW_EXPORT bool ScalarLess(const Scalar& left, const Scalar& right,
+                             const EqualOptions& options = EqualOptions::Defaults());
+
+/// Returns true if left scalar is less approximately than right scalar
+/// \param[in] left a Scalar
+/// \param[in] right a Scalar
+/// \param[in] options comparison options
+ARROW_EXPORT bool ScalarApproxLess(
+    const Scalar& left, const Scalar& right,
+    const EqualOptions& options = EqualOptions::Defaults());
+
 }  // namespace arrow

--- a/cpp/src/arrow/compute/ordering.h
+++ b/cpp/src/arrow/compute/ordering.h
@@ -62,7 +62,9 @@ class ARROW_EXPORT Ordering : public util::EqualityComparable<Ordering> {
  public:
   Ordering(std::vector<SortKey> sort_keys,
            NullPlacement null_placement = NullPlacement::AtStart)
-      : sort_keys_(std::move(sort_keys)), null_placement_(null_placement), is_implicit_(false) {}
+      : sort_keys_(std::move(sort_keys)),
+        null_placement_(null_placement),
+        is_implicit_(false) {}
   /// true if data ordered by other is also ordered by this
   ///
   /// For example, if data is ordered by [a, b, c] then it is also ordered

--- a/cpp/src/arrow/compute/ordering.h
+++ b/cpp/src/arrow/compute/ordering.h
@@ -62,7 +62,7 @@ class ARROW_EXPORT Ordering : public util::EqualityComparable<Ordering> {
  public:
   Ordering(std::vector<SortKey> sort_keys,
            NullPlacement null_placement = NullPlacement::AtStart)
-      : sort_keys_(std::move(sort_keys)), null_placement_(null_placement) {}
+      : sort_keys_(std::move(sort_keys)), null_placement_(null_placement), is_implicit_(false) {}
   /// true if data ordered by other is also ordered by this
   ///
   /// For example, if data is ordered by [a, b, c] then it is also ordered
@@ -88,7 +88,9 @@ class ARROW_EXPORT Ordering : public util::EqualityComparable<Ordering> {
   std::string ToString() const;
 
   bool is_implicit() const { return is_implicit_; }
-  bool is_unordered() const { return !is_implicit_ && sort_keys_.empty(); }
+  bool is_explicit() const { return !is_implicit_ && !sort_keys_.empty(); }
+  bool is_ordered() const { return is_implicit() || is_explicit(); }
+  bool is_unordered() const { return !is_ordered(); }
 
   const std::vector<SortKey>& sort_keys() const { return sort_keys_; }
   NullPlacement null_placement() const { return null_placement_; }
@@ -113,7 +115,7 @@ class ARROW_EXPORT Ordering : public util::EqualityComparable<Ordering> {
   std::vector<SortKey> sort_keys_;
   /// Whether nulls and NaNs are placed at the start or at the end
   NullPlacement null_placement_;
-  bool is_implicit_ = false;
+  bool is_implicit_;
 };
 
 }  // namespace compute

--- a/cpp/src/arrow/compute/ordering.h
+++ b/cpp/src/arrow/compute/ordering.h
@@ -60,6 +60,7 @@ class ARROW_EXPORT SortKey : public util::EqualityComparable<SortKey> {
 
 class ARROW_EXPORT Ordering : public util::EqualityComparable<Ordering> {
  public:
+  Ordering() : null_placement_(NullPlacement::AtStart), is_implicit_(false) {}
   Ordering(std::vector<SortKey> sort_keys,
            NullPlacement null_placement = NullPlacement::AtStart)
       : sort_keys_(std::move(sort_keys)),

--- a/cpp/src/arrow/dataset/scanner.cc
+++ b/cpp/src/arrow/dataset/scanner.cc
@@ -1078,7 +1078,8 @@ Result<acero::ExecNode*> MakeScanNode(acero::ExecPlan* plan,
 
   // the source can at most establish implicit ordering,
   // the assert_order node will establish explicit ordering
-  auto source_ordering = ordering.is_ordered() ? Ordering::Implicit() : Ordering::Unordered();
+  auto source_ordering =
+      ordering.is_ordered() ? Ordering::Implicit() : Ordering::Unordered();
 
   auto fields = scan_options->dataset_schema->fields();
   if (scan_options->add_augmented_fields) {
@@ -1087,16 +1088,16 @@ Result<acero::ExecNode*> MakeScanNode(acero::ExecPlan* plan,
     }
   }
 
-  auto out = acero::MakeExecNode(
-      "source", plan, {},
-      acero::SourceNodeOptions{schema(std::move(fields)), std::move(gen), source_ordering});
+  auto out =
+      acero::MakeExecNode("source", plan, {},
+                          acero::SourceNodeOptions{schema(std::move(fields)),
+                                                   std::move(gen), source_ordering});
 
   // assert and establish explicit ordering
   if (ordering.is_explicit()) {
     ARROW_ASSIGN_OR_RAISE(auto source, out);
-    out = acero::MakeExecNode(
-        "assert_order", plan, {source},
-        acero::AssertOrderNodeOptions{ordering});
+    out = acero::MakeExecNode("assert_order", plan, {source},
+                              acero::AssertOrderNodeOptions{ordering});
   }
 
   return out;

--- a/cpp/src/arrow/dataset/scanner.cc
+++ b/cpp/src/arrow/dataset/scanner.cc
@@ -936,6 +936,11 @@ Status ScannerBuilder::Filter(const compute::Expression& filter) {
   return Status::OK();
 }
 
+Status ScannerBuilder::Ordering(const compute::Ordering& ordering) {
+  ordering_ = ordering;
+  return Status::OK();
+}
+
 Status ScannerBuilder::UseThreads(bool use_threads) {
   scan_options_->use_threads = use_threads;
   return Status::OK();
@@ -1010,7 +1015,7 @@ Result<acero::ExecNode*> MakeScanNode(acero::ExecPlan* plan,
   auto scan_options = scan_node_options.scan_options;
   auto dataset = scan_node_options.dataset;
   bool require_sequenced_output = scan_node_options.require_sequenced_output;
-  bool implicit_ordering = scan_node_options.implicit_ordering;
+  Ordering ordering = scan_node_options.ordering;
 
   RETURN_NOT_OK(NormalizeScanOptions(scan_options, dataset->schema()));
 
@@ -1071,7 +1076,9 @@ Result<acero::ExecNode*> MakeScanNode(acero::ExecPlan* plan,
         return batch;
       });
 
-  auto ordering = implicit_ordering ? Ordering::Implicit() : Ordering::Unordered();
+  // the source can at most establish implicit ordering,
+  // the assert_order node will establish explicit ordering
+  auto source_ordering = ordering.is_ordered() ? Ordering::Implicit() : Ordering::Unordered();
 
   auto fields = scan_options->dataset_schema->fields();
   if (scan_options->add_augmented_fields) {
@@ -1080,9 +1087,19 @@ Result<acero::ExecNode*> MakeScanNode(acero::ExecPlan* plan,
     }
   }
 
-  return acero::MakeExecNode(
+  auto out = acero::MakeExecNode(
       "source", plan, {},
-      acero::SourceNodeOptions{schema(std::move(fields)), std::move(gen), ordering});
+      acero::SourceNodeOptions{schema(std::move(fields)), std::move(gen), source_ordering});
+
+  // assert and establish explicit ordering
+  if (ordering.is_explicit()) {
+    ARROW_ASSIGN_OR_RAISE(auto source, out);
+    out = acero::MakeExecNode(
+        "assert_order", plan, {source},
+        acero::AssertOrderNodeOptions{ordering});
+  }
+
+  return out;
 }
 
 Result<acero::ExecNode*> MakeAugmentedProjectNode(acero::ExecPlan* plan,

--- a/cpp/src/arrow/dataset/scanner.h
+++ b/cpp/src/arrow/dataset/scanner.h
@@ -522,7 +522,7 @@ class ARROW_DS_EXPORT ScannerBuilder {
   ///
   /// An explicit ordering the scanned data provide. Scan fails on first un-ordered row.
   /// Reading un-ordered data partially might succeed if un-ordered rows are not read.
-  /// Setting an ordering does not actually order the data but asserts that data in the
+  /// Setting an ordering does not actually sort the data but asserts that data in the
   /// dataset is ordered as stated during scan.
   Status Ordering(const compute::Ordering& ordering);
 
@@ -595,8 +595,14 @@ class ARROW_DS_EXPORT ScannerBuilder {
 /// Batches are yielded sequentially, like single-threaded,
 /// when require_sequenced_output=true.
 ///
+/// The scanned data are expected to support the given ordering if it is explicit.
+/// Scan fails on first un-ordered row. Reading un-ordered data partially might
+/// succeed if un-ordered rows are not read. Setting an ordering does not actually
+/// sort the data but asserts that data in the dataset is ordered as stated during
+/// scan.
+///
 /// Yielded batches will be augmented with fragment/batch indices when
-/// implicit_ordering=true to enable stable ordering for simple ExecPlans.
+/// given ordering is implicit to enable stable ordering for simple ExecPlans.
 class ARROW_DS_EXPORT ScanNodeOptions : public acero::ExecNodeOptions {
  public:
   explicit ScanNodeOptions(std::shared_ptr<Dataset> dataset,

--- a/cpp/src/arrow/dataset/scanner.h
+++ b/cpp/src/arrow/dataset/scanner.h
@@ -518,6 +518,14 @@ class ARROW_DS_EXPORT ScannerBuilder {
   ///         Schema.
   Status Filter(const compute::Expression& filter);
 
+  /// \brief Set the ordering of the scanned rows.
+  ///
+  /// An explicit ordering the scanned data provide. Scan fails on first un-ordered row.
+  /// Reading un-ordered data partially might succeed if un-ordered rows are not read.
+  /// Setting an ordering does not actually order the data but asserts that data in the
+  /// dataset is ordered as stated during scan.
+  Status Ordering(const compute::Ordering& ordering);
+
   /// \brief Indicate if the Scanner should make use of the available
   ///        ThreadPool found in ScanOptions;
   Status UseThreads(bool use_threads = true);
@@ -577,6 +585,7 @@ class ARROW_DS_EXPORT ScannerBuilder {
  private:
   std::shared_ptr<Dataset> dataset_;
   std::shared_ptr<ScanOptions> scan_options_ = std::make_shared<ScanOptions>();
+  compute::Ordering ordering_ = Ordering::Unordered();
 };
 
 /// \brief Construct a source ExecNode which yields batches from a dataset scan.
@@ -593,16 +602,24 @@ class ARROW_DS_EXPORT ScanNodeOptions : public acero::ExecNodeOptions {
   explicit ScanNodeOptions(std::shared_ptr<Dataset> dataset,
                            std::shared_ptr<ScanOptions> scan_options,
                            bool require_sequenced_output = false,
-                           bool implicit_ordering = false)
+                           Ordering ordering = Ordering::Unordered())
       : dataset(std::move(dataset)),
         scan_options(std::move(scan_options)),
         require_sequenced_output(require_sequenced_output),
-        implicit_ordering(implicit_ordering) {}
+        ordering(std::move(ordering)) {}
+
+    explicit ScanNodeOptions(std::shared_ptr<Dataset> dataset,
+                             std::shared_ptr<ScanOptions> scan_options,
+                             Ordering ordering = Ordering::Unordered())
+      : ScanNodeOptions(std::move(dataset),
+                        std::move(scan_options),
+                        false,
+                        std::move(ordering)) { }
 
   std::shared_ptr<Dataset> dataset;
   std::shared_ptr<ScanOptions> scan_options;
   bool require_sequenced_output;
-  bool implicit_ordering;
+  Ordering ordering;
 };
 
 /// @}

--- a/cpp/src/arrow/dataset/scanner.h
+++ b/cpp/src/arrow/dataset/scanner.h
@@ -607,20 +607,21 @@ class ARROW_DS_EXPORT ScanNodeOptions : public acero::ExecNodeOptions {
  public:
   explicit ScanNodeOptions(std::shared_ptr<Dataset> dataset,
                            std::shared_ptr<ScanOptions> scan_options,
+                           bool require_sequenced_output,
+                           bool implicit_ordering)
+      : dataset(std::move(dataset)),
+        scan_options(std::move(scan_options)),
+        require_sequenced_output(require_sequenced_output),
+        ordering(implicit_ordering ? Ordering::Implicit() : Ordering::Unordered()) {}
+
+  explicit ScanNodeOptions(std::shared_ptr<Dataset> dataset,
+                           std::shared_ptr<ScanOptions> scan_options,
                            bool require_sequenced_output = false,
                            Ordering ordering = Ordering::Unordered())
       : dataset(std::move(dataset)),
         scan_options(std::move(scan_options)),
         require_sequenced_output(require_sequenced_output),
         ordering(std::move(ordering)) {}
-
-    explicit ScanNodeOptions(std::shared_ptr<Dataset> dataset,
-                             std::shared_ptr<ScanOptions> scan_options,
-                             Ordering ordering = Ordering::Unordered())
-      : ScanNodeOptions(std::move(dataset),
-                        std::move(scan_options),
-                        false,
-                        std::move(ordering)) { }
 
   std::shared_ptr<Dataset> dataset;
   std::shared_ptr<ScanOptions> scan_options;

--- a/cpp/src/arrow/dataset/scanner.h
+++ b/cpp/src/arrow/dataset/scanner.h
@@ -607,8 +607,7 @@ class ARROW_DS_EXPORT ScanNodeOptions : public acero::ExecNodeOptions {
  public:
   explicit ScanNodeOptions(std::shared_ptr<Dataset> dataset,
                            std::shared_ptr<ScanOptions> scan_options,
-                           bool require_sequenced_output,
-                           bool implicit_ordering)
+                           bool require_sequenced_output, bool implicit_ordering)
       : dataset(std::move(dataset)),
         scan_options(std::move(scan_options)),
         require_sequenced_output(require_sequenced_output),

--- a/cpp/src/arrow/dataset/scanner.h
+++ b/cpp/src/arrow/dataset/scanner.h
@@ -607,14 +607,6 @@ class ARROW_DS_EXPORT ScanNodeOptions : public acero::ExecNodeOptions {
  public:
   explicit ScanNodeOptions(std::shared_ptr<Dataset> dataset,
                            std::shared_ptr<ScanOptions> scan_options,
-                           bool require_sequenced_output, bool implicit_ordering)
-      : dataset(std::move(dataset)),
-        scan_options(std::move(scan_options)),
-        require_sequenced_output(require_sequenced_output),
-        ordering(implicit_ordering ? Ordering::Implicit() : Ordering::Unordered()) {}
-
-  explicit ScanNodeOptions(std::shared_ptr<Dataset> dataset,
-                           std::shared_ptr<ScanOptions> scan_options,
                            bool require_sequenced_output = false,
                            Ordering ordering = Ordering::Unordered())
       : dataset(std::move(dataset)),

--- a/cpp/src/arrow/dataset/scanner_test.cc
+++ b/cpp/src/arrow/dataset/scanner_test.cc
@@ -3143,7 +3143,7 @@ TEST(ScanNode, AssertOrder) {
   // test existing orderings pass
   for (const Ordering& ordering : {asc, desc, asc_desc, asc_desc_rand, desc_asc, desc_asc_rand}) {
     declarations = acero::Declaration::Sequence(
-        {acero::Declaration({"scan", dataset::ScanNodeOptions{dataset, scan_options, ordering}})});
+        {acero::Declaration({"scan", dataset::ScanNodeOptions{dataset, scan_options, false, ordering}})});
     ASSERT_OK_AND_ASSIGN(auto actual, acero::DeclarationToTable(declarations));
     // Scan node always emits augmented fields so we drop those
     ASSERT_OK_AND_ASSIGN(auto actualMinusAugmented, actual->SelectColumns({0, 1, 2}));

--- a/cpp/src/arrow/dataset/scanner_test.cc
+++ b/cpp/src/arrow/dataset/scanner_test.cc
@@ -1087,8 +1087,8 @@ class TestScanner : public DatasetFixtureMixinWithParam<TestScannerParams> {
         next = it.Next();
       }
       // expect iteration to stop on failure status
-      ASSERT_NOT_OK(next);
-      ASSERT_EQ(next.status().message(), "Data is not ordered");
+      EXPECT_EQ(next.status().code(), StatusCode::ExecutionError);
+      EXPECT_THAT(next.status().message(), testing::StartsWith("Data is not ordered"));
     }
   }
 };

--- a/cpp/src/arrow/dataset/scanner_test.cc
+++ b/cpp/src/arrow/dataset/scanner_test.cc
@@ -879,7 +879,8 @@ TEST(TestNewScanner, MissingColumn) {
 
 void WriteIpcData(const std::string& path,
                   const std::shared_ptr<fs::FileSystem> file_system,
-                  const std::shared_ptr<Table> input) {
+                  const std::shared_ptr<Table> input,
+                  const ipc::IpcWriteOptions& options = ipc::IpcWriteOptions::Defaults()) {
   EXPECT_OK_AND_ASSIGN(auto out_stream, file_system->OpenOutputStream(path));
   ASSERT_OK_AND_ASSIGN(
       auto file_writer,
@@ -2974,6 +2975,124 @@ TEST(ScanNode, OnlyLoadProjectedFields) {
       [null, 4, null]
   ])"});
   AssertTablesEqual(*expected, *actualMinusAugmented, /*same_chunk_layout=*/false);
+}
+
+Ordering CreateOrdering(const std::pair<std::string, compute::SortOrder>& sort_key) {
+  auto keys = std::vector<compute::SortKey>();
+  keys.emplace_back(FieldRef(sort_key.first), sort_key.second);
+  return {keys};
+}
+
+Ordering CreateOrdering(const std::vector<std::pair<std::string, compute::SortOrder>>& sort_keys) {
+  auto keys = std::vector<compute::SortKey>();
+  for (const auto& sort_key : sort_keys) {
+    keys.emplace_back(FieldRef(sort_key.first), sort_key.second);
+  }
+  return {keys};
+}
+
+void AssertPlanHasAssertOrderNode(acero::Declaration declarations, bool expect_assert_node) {
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<ExecPlan> exec_plan,
+                        ExecPlan::Make(acero::QueryOptions(), ExecContext()));
+  ASSERT_OK(declarations.AddToPlan(exec_plan.get()));
+  if (expect_assert_node) {
+    // we expect the scan node expanded into two nodes
+    ASSERT_EQ(exec_plan->nodes().size(), 2);
+    ASSERT_STREQ(exec_plan->nodes().at(0)->kind_name(), "SourceNode");
+    ASSERT_STREQ(exec_plan->nodes().at(1)->kind_name(), "AssertOrderNode");
+  } else {
+    // we expect only the scan node
+    ASSERT_EQ(exec_plan->nodes().size(), 1);
+    ASSERT_STREQ(exec_plan->nodes().at(0)->kind_name(), "SourceNode");
+  }
+}
+
+TEST(ScanNode, AssertOrder) {
+  compute::ExecContext exec_context;
+  arrow::dataset::internal::Initialize();
+  ASSERT_OK_AND_ASSIGN(auto plan, acero::ExecPlan::Make());
+
+  auto dummy_schema = schema(
+      {field("id", int32()), field("rev", int32()), field("value", int32())});
+
+  // creating a synthetic dataset using generators
+  static constexpr int kRowsPerBatch = 4;
+  static constexpr int kNumBatches = 32;
+
+  std::shared_ptr<Table> table = gen::Gen({
+    {"id", gen::Step(/*start=*/-kRowsPerBatch*kNumBatches/2, /*step=*/1)},
+    {"rev", gen::Step(/*start=*/kRowsPerBatch*kNumBatches/2, /*step=*/-1)},
+    {"value", gen::Random(int32())}
+  })->FailOnError()
+    ->Table(kRowsPerBatch, kNumBatches);
+
+  auto format = std::make_shared<arrow::dataset::IpcFileFormat>();
+  auto filesystem = std::make_shared<fs::LocalFileSystem>();
+  const std::string file_name = "plan_scan_order_disk_test.arrow";
+
+  ASSERT_OK_AND_ASSIGN(auto tempdir,
+                       arrow::internal::TemporaryDir::Make("plan-test-tempdir-"));
+  ASSERT_OK_AND_ASSIGN(auto file_path, tempdir->path().Join(file_name));
+  std::string file_path_str = file_path.ToString();
+
+  // GH-26818: writing data with threads might change order of batches
+  auto ipc_write_options = ipc::IpcWriteOptions::Defaults();
+  ipc_write_options.use_threads = false;
+  WriteIpcData(file_path_str, filesystem, table, ipc_write_options);
+
+  std::vector<fs::FileInfo> files;
+  const std::vector<std::string> f_paths = {file_path_str};
+
+  for (const auto& f_path : f_paths) {
+    ASSERT_OK_AND_ASSIGN(auto f_file, filesystem->GetFileInfo(f_path));
+    files.push_back(std::move(f_file));
+  }
+
+  ASSERT_OK_AND_ASSIGN(auto ds_factory, dataset::FileSystemDatasetFactory::Make(
+                                            filesystem, std::move(files), format, {}));
+  ASSERT_OK_AND_ASSIGN(auto dataset, ds_factory->Finish(dummy_schema));
+
+  auto scan_options = std::make_shared<dataset::ScanOptions>();
+  auto declarations = acero::Declaration::Sequence(
+      {acero::Declaration({"scan", dataset::ScanNodeOptions{dataset, scan_options}})});
+  AssertPlanHasAssertOrderNode(declarations, false);
+
+  using SortKey = std::pair<std::string, compute::SortOrder>;
+  auto asc_key = SortKey({"id", compute::SortOrder::Ascending});
+  auto desc_key = SortKey({"rev", compute::SortOrder::Descending});
+  auto unordered_key = SortKey({"value", compute::SortOrder::Ascending});
+  auto not_asc_key = SortKey({"rev", compute::SortOrder::Ascending});
+  auto not_desc_key = SortKey({"id", compute::SortOrder::Descending});
+
+  compute::Ordering asc = CreateOrdering(asc_key);
+  compute::Ordering desc = CreateOrdering(desc_key);
+  compute::Ordering asc_desc = CreateOrdering({asc_key, desc_key});
+  compute::Ordering asc_desc_rand = CreateOrdering({asc_key, desc_key, unordered_key});
+  compute::Ordering desc_asc = CreateOrdering({desc_key, asc_key});
+  compute::Ordering desc_asc_rand = CreateOrdering({desc_key, asc_key, unordered_key});
+
+  compute::Ordering not_asc = CreateOrdering(not_asc_key);
+  compute::Ordering not_desc = CreateOrdering(not_desc_key);
+  compute::Ordering unordered = CreateOrdering(unordered_key);
+
+  // test existing orderings pass
+  for (const Ordering& ordering : {asc, desc, asc_desc, asc_desc_rand, desc_asc, desc_asc_rand}) {
+    declarations = acero::Declaration::Sequence(
+        {acero::Declaration({"scan", dataset::ScanNodeOptions{dataset, scan_options, ordering}})});
+    ASSERT_OK_AND_ASSIGN(auto actual, acero::DeclarationToTable(declarations));
+    // Scan node always emits augmented fields so we drop those
+    ASSERT_OK_AND_ASSIGN(auto actualMinusAugmented, actual->SelectColumns({0, 1, 2}));
+    AssertTablesEqual(*table, *actualMinusAugmented, /*same_chunk_layout=*/false);
+    AssertPlanHasAssertOrderNode(declarations, true);
+  }
+
+  // test non-existing orderings fail
+  for (const Ordering& non_ordering : {not_asc, not_asc, unordered}) {
+    declarations = acero::Declaration::Sequence(
+        {acero::Declaration({"scan", dataset::ScanNodeOptions{dataset, scan_options, false, non_ordering}})});
+    ASSERT_NOT_OK(acero::DeclarationToTable(declarations));
+    AssertPlanHasAssertOrderNode(declarations, true);
+  }
 }
 
 }  // namespace dataset

--- a/python/pyarrow/_compute.pxd
+++ b/python/pyarrow/_compute.pxd
@@ -70,3 +70,14 @@ cdef vector[CSortKey] unwrap_sort_keys(sort_keys, allow_str=*) except *
 cdef CSortOrder unwrap_sort_order(order) except *
 
 cdef CNullPlacement unwrap_null_placement(null_placement) except *
+
+cdef class Ordering(_Weakrefable):
+    cdef:
+        COrdering wrapped
+
+    cdef void init(self, const COrdering& sp)
+
+    @staticmethod
+    cdef wrap(const COrdering& sp)
+
+    cdef inline COrdering unwrap(self)

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -1999,6 +1999,31 @@ class PartitionNthOptions(_PartitionNthOptions):
         self._set_options(pivot, null_placement)
 
 
+cdef class Ordering(_Weakrefable):
+    def __init__(self):
+        _forbid_instantiation(self.__class__)
+
+    cdef void init(self, const COrdering& sp):
+        self.wrapped = sp
+
+    @staticmethod
+    cdef wrap(const COrdering& sp):
+        cdef Ordering self = Ordering.__new__(Ordering)
+        self.init(sp)
+        return self
+
+    cdef inline COrdering unwrap(self):
+        return self.wrapped
+
+    @staticmethod
+    def implicit():
+        return Ordering.wrap(COrdering.Implicit())
+
+    @staticmethod
+    def unordered():
+        return Ordering.wrap(COrdering.Unordered())
+
+
 cdef class _CumulativeOptions(FunctionOptions):
     def _set_options(self, start, skip_nulls):
         if start is None:

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -2000,8 +2000,11 @@ class PartitionNthOptions(_PartitionNthOptions):
 
 
 cdef class Ordering(_Weakrefable):
-    def __init__(self):
-        _forbid_instantiation(self.__class__)
+    def __init__(self, sort_keys, *, null_placement="at_end"):
+        c_sort_keys = unwrap_sort_keys(sort_keys, allow_str=False)
+        c_null_placement = unwrap_null_placement(null_placement)
+        ordering = COrdering(c_sort_keys, c_null_placement)
+        self.init(ordering)
 
     cdef void init(self, const COrdering& sp):
         self.wrapped = sp

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -872,6 +872,35 @@ cdef class Dataset(_Weakrefable):
         )
         return res
 
+    def assert_sort(self, sorting, *, null_placement="at_end"):
+        """
+        Assert the Dataset is sorted by one or multiple columns.
+
+        Parameters
+        ----------
+        sorting : str or list[tuple(name, order)]
+            Name of the column to use to sort (ascending), or
+            a list of multiple sorting conditions where
+            each entry is a tuple with column name
+            and sorting order ("ascending" or "descending")
+        null_placement : str, default "at_end"
+            Where nulls in input should be sorted, only applying to
+            columns/fields mentioned in `sort_keys`.
+            Accepted values are "at_start", "at_end".
+
+        Returns
+        -------
+        InMemoryDataset
+            A new dataset where sorted order is guaranteed or an exception is raised.
+        """
+        if isinstance(sorting, str):
+            sorting = [(sorting, "ascending")]
+
+        res = _pac()._assert_sorted(
+            self, output_type=InMemoryDataset, sort_keys=sorting, null_placement=null_placement
+        )
+        return res
+
     def join(self, right_dataset, keys, right_keys=None, join_type="left outer",
              left_suffix=None, right_suffix=None, coalesce_keys=True,
              use_threads=True):

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -30,7 +30,7 @@ from pyarrow.lib cimport *
 from pyarrow.lib import ArrowTypeError, frombytes, tobytes, _pac
 from pyarrow.includes.libarrow_dataset cimport *
 from pyarrow._acero cimport ExecNodeOptions
-from pyarrow._compute cimport Expression, _bind
+from pyarrow._compute cimport Expression, Ordering, _bind
 from pyarrow._compute import _forbid_instantiation
 from pyarrow._fs cimport FileSystem, FileSelector, FileInfo
 from pyarrow._csv cimport (
@@ -4153,15 +4153,15 @@ cdef class _ScanNodeOptions(ExecNodeOptions):
         cdef:
             shared_ptr[CScanOptions] c_scan_options
             bint require_sequenced_output=False
-            bint implicit_ordering=False
+            Ordering ordering
 
         c_scan_options = Scanner._make_scan_options(dataset, scan_options)
 
         require_sequenced_output=scan_options.get("require_sequenced_output", False)
-        implicit_ordering=scan_options.get("implicit_ordering", False)
+        ordering=scan_options.get("ordering", Ordering.unordered())
 
         self.wrapped.reset(
-            new CScanNodeOptions(dataset.unwrap(), c_scan_options, require_sequenced_output, implicit_ordering)
+            new CScanNodeOptions(dataset.unwrap(), c_scan_options, require_sequenced_output, ordering.unwrap())
         )
 
 
@@ -4179,9 +4179,6 @@ class ScanNodeOptions(_ScanNodeOptions):
     expression or projection to the scan node that you also supply
     to the filter or project node.
 
-    Yielded batches will be augmented with fragment/batch indices when
-    implicit_ordering=True to enable stable ordering for simple ExecPlans.
-
     Parameters
     ----------
     dataset : pyarrow.dataset.Dataset
@@ -4190,8 +4187,14 @@ class ScanNodeOptions(_ScanNodeOptions):
         Scan options. See `Scanner.from_dataset` for possible arguments.
     require_sequenced_output : bool, default False
         Batches are yielded sequentially, like single-threaded
-    implicit_ordering : bool, default False
-        Preserve implicit ordering of data.
+    ordering : Ordering, default Ordering.unordered()
+        With an implicit ordering given, yielded batches will be augmented
+        with fragment/batch indices when to enable stable ordering.
+        With an explicit ordering given, scanned data are expected exhibit
+        this order. Scan fails on first un-ordered row. Reading un-ordered
+        data partially might succeed if un-ordered rows are not read.
+        Setting an ordering does not actually sort the data but asserts
+        that data in the dataset is ordered as stated during scan.
     """
 
     def __init__(self, Dataset dataset, **kwargs):

--- a/python/pyarrow/acero.py
+++ b/python/pyarrow/acero.py
@@ -23,7 +23,7 @@
 # cython: language_level = 3
 
 from pyarrow.lib import Table, RecordBatch
-from pyarrow.compute import Expression, field
+from pyarrow.compute import Expression, Ordering, field
 
 try:
     from pyarrow._acero import (  # noqa
@@ -56,10 +56,9 @@ except ImportError:
     ds = DatasetModuleStub
 
 
-def _dataset_to_decl(dataset, use_threads=True, implicit_ordering=False):
+def _dataset_to_decl(dataset, use_threads=True, ordering=Ordering.unordered()):
     decl = Declaration("scan", ScanNodeOptions(
-        dataset, use_threads=use_threads,
-        implicit_ordering=implicit_ordering))
+        dataset, use_threads=use_threads, ordering=ordering))
 
     # Get rid of special dataset columns
     # "__fragment_index", "__batch_index", "__last_in_fragment", "__filename"
@@ -316,7 +315,7 @@ def _perform_join_asof(left_operand, left_on, left_by,
         left_source = _dataset_to_decl(
             left_operand,
             use_threads=use_threads,
-            implicit_ordering=True)
+            ordering=Ordering.implicit())
     else:
         left_source = Declaration(
             "table_source", TableSourceNodeOptions(left_operand),
@@ -324,7 +323,7 @@ def _perform_join_asof(left_operand, left_on, left_by,
     if isinstance(right_operand, ds.Dataset):
         right_source = _dataset_to_decl(
             right_operand, use_threads=use_threads,
-            implicit_ordering=True)
+            ordering=Ordering.implicit())
     else:
         right_source = Declaration(
             "table_source", TableSourceNodeOptions(right_operand)

--- a/python/pyarrow/acero.py
+++ b/python/pyarrow/acero.py
@@ -400,6 +400,20 @@ def _sort_source(table_or_dataset, sort_keys, output_type=Table, **kwargs):
         raise TypeError("Unsupported output type")
 
 
+def _assert_sorted(dataset, sort_keys, *, null_placement="at_end", output_type=Table):
+
+    ordering = Ordering(sort_keys, null_placement=null_placement)
+    decl = _dataset_to_decl(dataset, use_threads=True, ordering=ordering)
+    result_table = decl.to_table(use_threads=True)
+
+    if output_type == Table:
+        return result_table
+    elif output_type == ds.InMemoryDataset:
+        return ds.InMemoryDataset(result_table)
+    else:
+        raise TypeError("Unsupported output type")
+
+
 def _group_by(table, aggregates, keys, use_threads=True):
 
     decl = Declaration.from_sequence([

--- a/python/pyarrow/compute.py
+++ b/python/pyarrow/compute.py
@@ -50,6 +50,7 @@ from pyarrow._compute import (  # noqa
     MatchSubstringOptions,
     ModeOptions,
     NullOptions,
+    Ordering,
     PadOptions,
     PairwiseOptions,
     PartitionNthOptions,

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -2739,6 +2739,14 @@ cdef extern from "arrow/compute/api.h" namespace "arrow::compute" nogil:
 
     cdef cppclass COrdering" arrow::compute::Ordering":
         COrdering(vector[CSortKey] sort_keys, CNullPlacement null_placement)
+        COrdering(c_bool is_implicit)
+        COrdering()
+
+        @staticmethod
+        COrdering Implicit();
+
+        @staticmethod
+        COrdering Unordered();
 
     cdef cppclass CSortOptions \
             "arrow::compute::SortOptions"(CFunctionOptions):

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -2743,10 +2743,10 @@ cdef extern from "arrow/compute/api.h" namespace "arrow::compute" nogil:
         COrdering()
 
         @staticmethod
-        COrdering Implicit();
+        COrdering Implicit()
 
         @staticmethod
-        COrdering Unordered();
+        COrdering Unordered()
 
     cdef cppclass CSortOptions \
             "arrow::compute::SortOptions"(CFunctionOptions):

--- a/python/pyarrow/includes/libarrow_dataset.pxd
+++ b/python/pyarrow/includes/libarrow_dataset.pxd
@@ -52,7 +52,7 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
         CExpression filter
 
     cdef cppclass CScanNodeOptions "arrow::dataset::ScanNodeOptions"(CExecNodeOptions):
-        CScanNodeOptions(shared_ptr[CDataset] dataset, shared_ptr[CScanOptions] scan_options, bint require_sequenced_output, bint implicit_ordering)
+        CScanNodeOptions(shared_ptr[CDataset] dataset, shared_ptr[CScanOptions] scan_options, bint require_sequenced_output, COrdering ordering)
 
         shared_ptr[CScanOptions] scan_options
 


### PR DESCRIPTION
### Rationale for this change

An acero node that turns an implicit ordering into an explicit ordering (rows sorted by some columns) is useful to re-use order that already exists in the data.

### What changes are included in this PR?

This PR adds the `AssertOrderNode` that implements this logic. The `Scanner` employs that node to turn the implicit ordering of the `ScanNode` into an explicit order as defined by user code via `ScanBuilder.Ordering`.

### Are these changes tested?
There are unit tests for the `AssertOrderNode` as well as for the `ScanNode` and `ScanBuilder`.

### Are there any user-facing changes?
The following options has been added to C++:
- the `ordering` option added to `ScanOptions`
- the `Ordering` option added to `ScannerBuilder`
- the `AssertNodeOptions` class

The following method is added to Python `Dataset`:
- method `assert_sorted` asserts given order

* GitHub Issue: #34698