### PR TITLE
GH-42971: [C++] Parquet stream writer: Allow writing BYTE_ARRAY with converted type NONE

### DIFF
--- a/cpp/src/parquet/stream_writer.cc
+++ b/cpp/src/parquet/stream_writer.cc
@@ -129,20 +129,26 @@ StreamWriter& StreamWriter::operator<<(FixedStringView v) {
 }
 
 StreamWriter& StreamWriter::operator<<(const char* v) {
-  return WriteVariableLength(v, std::strlen(v));
+  return WriteVariableLength(v, std::strlen(v), ConvertedType::UTF8);
 }
 
 StreamWriter& StreamWriter::operator<<(const std::string& v) {
-  return WriteVariableLength(v.data(), v.size());
+  return WriteVariableLength(v.data(), v.size(), ConvertedType::UTF8);
 }
 
 StreamWriter& StreamWriter::operator<<(::std::string_view v) {
-  return WriteVariableLength(v.data(), v.size());
+  return WriteVariableLength(v.data(), v.size(), ConvertedType::UTF8);
+}
+
+StreamWriter& StreamWriter::operator<<(RawDataView v) {
+  return WriteVariableLength(reinterpret_cast<const char*>(v.data()), v.size(),
+                             ConvertedType::NONE);
 }
 
 StreamWriter& StreamWriter::WriteVariableLength(const char* data_ptr,
-                                                std::size_t data_len) {
-  CheckColumn(Type::BYTE_ARRAY, ConvertedType::UTF8);
+                                                std::size_t data_len,
+                                                ConvertedType::type type) {
+  CheckColumn(Type::BYTE_ARRAY, type);
 
   auto writer = static_cast<ByteArrayWriter*>(row_group_writer_->column(column_index_++));
 

--- a/cpp/src/parquet/stream_writer.h
+++ b/cpp/src/parquet/stream_writer.h
@@ -26,6 +26,8 @@
 #include <string_view>
 #include <vector>
 
+#include "arrow/util/span.h"
+
 #include "parquet/column_writer.h"
 #include "parquet/file_writer.h"
 
@@ -151,6 +153,12 @@ class PARQUET_EXPORT StreamWriter {
   StreamWriter& operator<<(const std::string& v);
   StreamWriter& operator<<(::std::string_view v);
 
+  /// \brief Helper class to write variable length raw data.
+  using RawDataView = ::arrow::util::span<const uint8_t>;
+
+  /// \brief Output operators for variable length raw data.
+  StreamWriter& operator<<(RawDataView v);
+
   /// \brief Output operator for optional fields.
   template <typename T>
   StreamWriter& operator<<(const optional<T>& v) {
@@ -190,7 +198,8 @@ class PARQUET_EXPORT StreamWriter {
     return *this;
   }
 
-  StreamWriter& WriteVariableLength(const char* data_ptr, std::size_t data_len);
+  StreamWriter& WriteVariableLength(const char* data_ptr, std::size_t data_len,
+                                    ConvertedType::type converted_type);
 
   StreamWriter& WriteFixedLength(const char* data_ptr, std::size_t data_len);
 


### PR DESCRIPTION
### Rationale for this change

We are trying to store binary data (in our case, dump of captured CAN messages) in a parquet file. The data has a variable length (from 0 to 8 bytes) and is not an UTF-8 string (or a text string at all). For this, physical type BYTE_ARRAY and logical type NONE seems appropriate.

Unfortunately, the Parquet stream writer will not let us do that. We can do either fixed length and converted type NONE, or variable length and converted type UTF-8. This change relaxes the type check on byte arrays to allow use of the NONE converted type.

### What changes are included in this PR?

Allow the Parquet stream writer to store data in a BYTE_ARRAY with NONE logical type. The changes are based to similar changes made earlier to the stream reader.

The reader part has already been fixed in 4d825497cb04c9e1c288000a7a8f75786cc487ff and this uses a similar implementation, but with a stricter set of "exceptions" (only BYTE_ARRAY with NONE type are allowed).

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Only a new feature.

* GitHub Issue: #42971