### PR TITLE
MINOR: [Java] Bump `orc-core` to 1.9.5

### DIFF
--- a/java/adapter/orc/pom.xml
+++ b/java/adapter/orc/pom.xml
@@ -61,7 +61,7 @@ under the License.
     <dependency>
       <groupId>org.apache.orc</groupId>
       <artifactId>orc-core</artifactId>
-      <version>1.9.4</version>
+      <version>1.9.5</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/java/dataset/pom.xml
+++ b/java/dataset/pom.xml
@@ -130,7 +130,7 @@ under the License.
     <dependency>
       <groupId>org.apache.orc</groupId>
       <artifactId>orc-core</artifactId>
-      <version>1.9.4</version>
+      <version>1.9.5</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>


### PR DESCRIPTION
### Rationale for this change

This PR aims to upgrade `orc-core` to 1.9.5.

### What changes are included in this PR?

To use the latest bug-fixed version in testing.
- https://orc.apache.org/news/2024/11/14/ORC-1.9.5/

### Are these changes tested?

Pass the CIs.

### Are there any user-facing changes?

No, this is a test dependency.