### PR TITLE
GH-44749: [CI][Dev] Apply ShellCheck lint to ci/scripts/c_glib_test.sh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -181,4 +181,5 @@ repos:
         files: >-
           (
           ?^ci/scripts/c_glib_build\.sh$|
+          ?^ci/scripts/c_glib_test\.sh$|
           )

--- a/ci/scripts/c_glib_test.sh
+++ b/ci/scripts/c_glib_test.sh
@@ -22,7 +22,7 @@ set -ex
 source_dir=${1}/c_glib
 build_dir=${2}/c_glib
 
-: ${ARROW_GLIB_VAPI:=true}
+: "${ARROW_GLIB_VAPI:=true}"
 
 export DYLD_LIBRARY_PATH=${ARROW_HOME}/lib:${DYLD_LIBRARY_PATH}
 export LD_LIBRARY_PATH=${ARROW_HOME}/lib:${LD_LIBRARY_PATH}
@@ -34,7 +34,7 @@ if [ -z "${ARROW_DEBUG_MEMORY_POOL}" ]; then
   export ARROW_DEBUG_MEMORY_POOL=trap
 fi
 
-pushd ${source_dir}
+pushd "${source_dir}"
 
 ruby test/run-test.rb
 
@@ -51,7 +51,7 @@ fi
 
 popd
 
-pushd ${build_dir}
+pushd "${build_dir}"
 example/build
 example/extension-type
 if [ "${ARROW_GLIB_VAPI}" = "true" ]; then


### PR DESCRIPTION
### Rationale for this change

```console
$ pre-commit run --show-diff-on-failure --color=always --all-files shellcheck
ShellCheck v0.10.0.......................................................Failed
- hook id: shellcheck
- exit code: 1

In ci/scripts/c_glib_test.sh line 25:
: ${ARROW_GLIB_VAPI:=true}
  ^----------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.

In ci/scripts/c_glib_test.sh line 37:
pushd ${source_dir}
      ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
pushd "${source_dir}"

In ci/scripts/c_glib_test.sh line 54:
pushd ${build_dir}
      ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
pushd "${build_dir}"

For more information:
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
  https://www.shellcheck.net/wiki/SC2223 -- This default assignment may cause...
```

### What changes are included in this PR?

* Add missing quotes.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #44749