### PR TITLE
GH-44754: [C++] Use lowercased `windows.h` to enable cross-platform builds

### DIFF
--- a/cpp/src/arrow/util/io_util.cc
+++ b/cpp/src/arrow/util/io_util.cc
@@ -118,7 +118,7 @@
 #endif
 
 #ifdef _WIN32
-#  include <Windows.h>
+#  include <windows.h>
 #else
 #  include <dlfcn.h>
 #endif


### PR DESCRIPTION
### Rationale for this change

`<Windows.h>` doesn't work cross-compiling to Windows with case-sensitive file system.

### What changes are included in this PR?

Use lowercase.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #44754