### PR TITLE
GH-44742: [Ruby] Fix a bug that empty struct list value can't be built

### DIFF
--- a/ruby/red-arrow/lib/arrow/list-array-builder.rb
+++ b/ruby/red-arrow/lib/arrow/list-array-builder.rb
@@ -54,6 +54,7 @@ module Arrow
         when nil
           append_null
         when ::Array
+          return if value.empty?
           append_value_raw
           @value_builder ||= value_builder
           @value_builder.append(*value)

--- a/ruby/red-arrow/test/test-list-array-builder.rb
+++ b/ruby/red-arrow/test/test-list-array-builder.rb
@@ -33,6 +33,15 @@ class ListArrayBuilderTest < Test::Unit::TestCase
       array = @builder.finish
       assert_equal([true, false, true], array[0].to_a)
     end
+
+    test("Struct[]") do
+      item_type = Arrow::StructDataType.new([{name: "visible", type: :boolean}])
+      data_type = Arrow::ListDataType.new(name: "struct", data_type: item_type)
+      builder = Arrow::ListArrayBuilder.new(data_type)
+      builder.append_value([])
+      array = builder.finish
+      assert_equal([], array[0].to_a)
+    end
   end
 
   sub_test_case("#append_values") do


### PR DESCRIPTION
### Rationale for this change

This codes add a list value but no struct value isn't added:  

```ruby

require "arrow"

schema = Arrow::Schema.new(
  [
   Arrow::Field.new("structs", Arrow::ListDataType.new(
     Arrow::StructDataType.new([
       Arrow::Field.new("foo", :int64),
       Arrow::Field.new("bar", :int64)
     ])
   ))
 ]
)

Arrow::RecordBatchBuilder.build(schema, [{structs: []}])
```

### What changes are included in this PR?

Don't add a list value.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #44742