### PR TITLE
GH-44710: [Docs][C++] Add `arrow::ArrayStatistics` to API doc

### DIFF
--- a/cpp/src/arrow/array/statistics.h
+++ b/cpp/src/arrow/array/statistics.h
@@ -27,6 +27,7 @@
 
 namespace arrow {
 
+/// \class ArrayStatistics
 /// \brief Statistics for an Array
 ///
 /// Apache Arrow format doesn't have statistics but data source such

--- a/docs/source/cpp/api/array.rst
+++ b/docs/source/cpp/api/array.rst
@@ -22,6 +22,10 @@ Arrays
 Base classes
 ============
 
+.. doxygenclass:: arrow::ArrayStatistics
+   :project: arrow_cpp
+   :members:
+
 .. doxygenclass:: arrow::ArrayData
    :project: arrow_cpp
    :members:


### PR DESCRIPTION
### Rationale for this change

https://arrow.apache.org/docs/cpp/api/array.html should have `arrow::ArrayStatistics`. 

### What changes are included in this PR?

Add missing `\class` and `doxygenclass`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #44710