### PR TITLE
GH-44765: [Python][Parquet] ParquetDataset should expose partition_base_dir

### DIFF
--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -1275,7 +1275,8 @@ Examples
 
     def __init__(self, path_or_paths, filesystem=None, schema=None, *, filters=None,
                  read_dictionary=None, memory_map=False, buffer_size=None,
-                 partitioning="hive", ignore_prefixes=None, pre_buffer=True,
+                 partitioning="hive", partition_base_dir=None,
+                 ignore_prefixes=None, pre_buffer=True,
                  coerce_int96_timestamp_unit=None,
                  decryption_properties=None, thrift_string_size_limit=None,
                  thrift_container_size_limit=None,
@@ -1371,6 +1372,7 @@ Examples
         self._dataset = ds.dataset(path_or_paths, filesystem=filesystem,
                                    schema=schema, format=parquet_format,
                                    partitioning=partitioning,
+                                   partition_base_dir=partition_base_dir,
                                    ignore_prefixes=ignore_prefixes)
 
     def equals(self, other):

--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -1171,11 +1171,11 @@ default "hive"
     you need to specify the field names or a full schema. See the
     ``pyarrow.dataset.partitioning()`` function for more details.
 partition_base_dir : str, optional
-        For the purposes of applying the partitioning, paths will be
-        stripped of the partition_base_dir. Files not matching the
-        partition_base_dir prefix will be skipped for partitioning discovery.
-        The ignored files will still be part of the Dataset, but will not
-        have partition information."""
+    For the purposes of applying the partitioning, paths will be
+    stripped of the partition_base_dir. Files not matching the
+    partition_base_dir prefix will be skipped for partitioning discovery.
+    The ignored files will still be part of the Dataset, but will not
+    have partition information."""
 
 
 _parquet_dataset_example = """\

--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -1169,7 +1169,13 @@ default "hive"
     assumes directory names with key=value pairs like "/year=2009/month=11".
     In addition, a scheme like "/2009/11" is also supported, in which case
     you need to specify the field names or a full schema. See the
-    ``pyarrow.dataset.partitioning()`` function for more details."""
+    ``pyarrow.dataset.partitioning()`` function for more details.
+partition_base_dir : str, optional
+        For the purposes of applying the partitioning, paths will be
+        stripped of the partition_base_dir. Files not matching the
+        partition_base_dir prefix will be skipped for partitioning discovery.
+        The ignored files will still be part of the Dataset, but will not
+        have partition information."""
 
 
 _parquet_dataset_example = """\


### PR DESCRIPTION
### Rationale for this change

Currently ParquetDataset object can receive partition as a parameter, but it's not possible to set a partition_base_dir. We need to expose this in the constructor parameters and pass it in the ds.dataset call.

### What changes are included in this PR?

- We add a partition_base_dir parameter to the constructor
-  pass it down to ds.dataset

### Are these changes tested?

no test introduced - functionality should be covered by the tests of ds.dataset

### Are there any user-facing changes?

the interface for the class constructor changed, but no breaking changes. documentation updated accordingly.

* GitHub Issue: #44765