### PR TITLE
GH-44767: [C++] Fix Float16.To{Little,Big}Endian on big endian machines

### DIFF
--- a/cpp/src/arrow/util/float16.h
+++ b/cpp/src/arrow/util/float16.h
@@ -111,11 +111,7 @@ class ARROW_EXPORT Float16 {
   }
   /// \brief Return the value's bytes in little-endian byte order
   constexpr std::array<uint8_t, 2> ToLittleEndian() const {
-#if ARROW_LITTLE_ENDIAN
     return {uint8_t(bits_ & 0xff), uint8_t(bits_ >> 8)};
-#else
-    return {uint8_t(bits_ >> 8), uint8_t(bits_ & 0xff)};
-#endif
   }
 
   /// \brief Copy the value's bytes in big-endian byte order
@@ -125,11 +121,7 @@ class ARROW_EXPORT Float16 {
   }
   /// \brief Return the value's bytes in big-endian byte order
   constexpr std::array<uint8_t, 2> ToBigEndian() const {
-#if ARROW_LITTLE_ENDIAN
     return {uint8_t(bits_ >> 8), uint8_t(bits_ & 0xff)};
-#else
-    return {uint8_t(bits_ & 0xff), uint8_t(bits_ >> 8)};
-#endif
   }
 
   constexpr Float16 operator-() const { return FromBits(bits_ ^ 0x8000); }


### PR DESCRIPTION
### Rationale for this change

See issue.

### What changes are included in this PR?

For `ToLittleEndian`/`ToBigEndian`, the result should always be in the specified endianness, not depend on host order.

In the test, instead of casting the `uint8_t` data into a `uint16_t` (with unspecified endianness handling), compare the bytes directly in their expected orders.

### Are these changes tested?

Tested on little-endian, still building for big-endian.

### Are there any user-facing changes?

Fixes #44767
* GitHub Issue: #44767