### PR TITLE
GH-44770: [Java] Update minor protobuf version to avoid CVE-2024-7254

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -98,7 +98,7 @@ under the License.
     <dep.guava-bom.version>33.3.1-jre</dep.guava-bom.version>
     <dep.netty-bom.version>4.1.114.Final</dep.netty-bom.version>
     <dep.grpc-bom.version>1.65.0</dep.grpc-bom.version>
-    <dep.protobuf-bom.version>3.25.4</dep.protobuf-bom.version>
+    <dep.protobuf-bom.version>3.25.5</dep.protobuf-bom.version>
     <dep.jackson-bom.version>2.18.1</dep.jackson-bom.version>
     <dep.hadoop.version>3.4.1</dep.hadoop.version>
     <dep.fbs.version>24.3.25</dep.fbs.version>


### PR DESCRIPTION
### Rationale for this change

There seems to be a CVE affecting our current dependency:
https://github.com/advisories/GHSA-735f-pc8j-v9w8

### What changes are included in this PR?

Update to latest minor which solves the issue.

### Are these changes tested?

Via CI

### Are there any user-facing changes?

No
* GitHub Issue: #44770