### PR TITLE
GH-44788: [C++] Fix a couple of maybe-uninitialized warnings

### DIFF
--- a/cpp/src/arrow/compute/expression.cc
+++ b/cpp/src/arrow/compute/expression.cc
@@ -1263,7 +1263,7 @@ struct Inequality {
     if (!lhs.field_ref()) return std::nullopt;
     if (*lhs.field_ref() != guarantee.target) return std::nullopt;
 
-    FilterOptions::NullSelectionBehavior null_selection;
+    FilterOptions::NullSelectionBehavior null_selection {};
     switch (options->null_matching_behavior) {
       case SetLookupOptions::MATCH:
         null_selection =

--- a/cpp/src/arrow/compute/expression.cc
+++ b/cpp/src/arrow/compute/expression.cc
@@ -1263,7 +1263,7 @@ struct Inequality {
     if (!lhs.field_ref()) return std::nullopt;
     if (*lhs.field_ref() != guarantee.target) return std::nullopt;
 
-    FilterOptions::NullSelectionBehavior null_selection {};
+    FilterOptions::NullSelectionBehavior null_selection{};
     switch (options->null_matching_behavior) {
       case SetLookupOptions::MATCH:
         null_selection =

--- a/cpp/src/arrow/util/iterator.h
+++ b/cpp/src/arrow/util/iterator.h
@@ -292,18 +292,17 @@ class TransformIterator {
         finished_ = true;
         return next_res.status();
       }
-      auto next = *next_res;
-      if (next.ReadyForNext()) {
+      if (next_res->ReadyForNext()) {
         if (IsIterationEnd(*last_value_)) {
           finished_ = true;
         }
         last_value_.reset();
       }
-      if (next.Finished()) {
+      if (next_res->Finished()) {
         finished_ = true;
       }
-      if (next.HasValue()) {
-        return next.Value();
+      if (next_res->HasValue()) {
+        return next_res->Value();
       }
     }
     if (finished_) {

--- a/cpp/src/arrow/util/iterator.h
+++ b/cpp/src/arrow/util/iterator.h
@@ -292,17 +292,18 @@ class TransformIterator {
         finished_ = true;
         return next_res.status();
       }
-      if (next_res->ReadyForNext()) {
+      auto next = std::move(*next_res);
+      if (next.ReadyForNext()) {
         if (IsIterationEnd(*last_value_)) {
           finished_ = true;
         }
         last_value_.reset();
       }
-      if (next_res->Finished()) {
+      if (next.Finished()) {
         finished_ = true;
       }
-      if (next_res->HasValue()) {
-        return next_res->Value();
+      if (next.HasValue()) {
+        return next.Value();
       }
     }
     if (finished_) {


### PR DESCRIPTION
### Rationale for this change

I was getting some `-Wmaybe-uninitialized` warnings locally when building, see original issue for log.

### What changes are included in this PR?

A couple of minor changes to avoid the warnings, initializing a variable and removing an unnecessary one.

### Are these changes tested?

Code will be tested via CI and I can confirm I can compile without warnings now:

```
$ cmake --build arrow/cpp/build --target install -- -j 8
[411/412] Install the project...
-- Install configuration: "RELEASE"
```

### Are there any user-facing changes?

No
* GitHub Issue: #44788