### PR TITLE
GH-44728: [Python] Trigger manual Garbage collection before checking allocated bytes for dlpack tests

### DIFF
--- a/python/pyarrow/tests/test_dlpack.py
+++ b/python/pyarrow/tests/test_dlpack.py
@@ -17,6 +17,7 @@
 
 import ctypes
 from functools import wraps
+import gc
 import pytest
 
 try:
@@ -50,6 +51,7 @@ def check_dlpack_export(arr, expected_arr):
 def check_bytes_allocated(f):
     @wraps(f)
     def wrapper(*args, **kwargs):
+        gc.collect()
         allocated_bytes = pa.total_allocated_bytes()
         try:
             return f(*args, **kwargs)
@@ -68,7 +70,7 @@ def check_bytes_allocated(f):
         (pa.uint64(), "uint64"),
         (pa.int8(), "int8"),
         (pa.int16(), "int16"),
-        # (pa.int32(), "int32"),
+        (pa.int32(), "int32"),
         (pa.int64(), "int64"),
         (pa.float16(), "float16"),
         (pa.float32(), "float32"),

--- a/python/pyarrow/tests/test_dlpack.py
+++ b/python/pyarrow/tests/test_dlpack.py
@@ -68,7 +68,7 @@ def check_bytes_allocated(f):
         (pa.uint64(), "uint64"),
         (pa.int8(), "int8"),
         (pa.int16(), "int16"),
-        (pa.int32(), "int32"),
+        # (pa.int32(), "int32"),
         (pa.int64(), "int64"),
         (pa.float16(), "float16"),
         (pa.float32(), "float32"),


### PR DESCRIPTION
### Rationale for this change

test_dlpack started failing for several jobs on CI due to our tests deallocating memory:
```
        allocated_bytes = pa.total_allocated_bytes()
        try:
            return f(*args, **kwargs)
        finally:
>           assert pa.total_allocated_bytes() == allocated_bytes
E           assert 3728 == 7440
```

### What changes are included in this PR?

Trigger a `gc.collect` before checking initial allocated bytes.

### Are these changes tested?

Yes via CI

### Are there any user-facing changes?

No

* GitHub Issue: #44728