### PR TITLE
GH-44802: [C++][CI] Migrate to `arrow::Result` based `parquet::arrow::OpenFile() API` in example tutorials

### DIFF
--- a/cpp/examples/tutorial_examples/file_access_example.cc
+++ b/cpp/examples/tutorial_examples/file_access_example.cc
@@ -180,7 +180,8 @@ arrow::Status RunMain() {
   // (Doc section: Parquet OpenFile)
   // Note that Parquet's OpenFile() takes the reader by reference, rather than returning
   // a reader.
-  PARQUET_ASSIGN_OR_THROW(reader, parquet::arrow::OpenFile(infile, arrow::default_memory_pool()));
+  PARQUET_ASSIGN_OR_THROW(reader,
+                          parquet::arrow::OpenFile(infile, arrow::default_memory_pool()));
   // (Doc section: Parquet OpenFile)
 
   // (Doc section: Parquet Read)

--- a/cpp/examples/tutorial_examples/file_access_example.cc
+++ b/cpp/examples/tutorial_examples/file_access_example.cc
@@ -180,9 +180,7 @@ arrow::Status RunMain() {
   // (Doc section: Parquet OpenFile)
   // Note that Parquet's OpenFile() takes the reader by reference, rather than returning
   // a reader.
-  auto result = parquet::arrow::OpenFile(infile, arrow::default_memory_pool());
-  PARQUET_THROW_NOT_OK(result.status());
-  reader = std::move(result.ValueOrDie());
+  PARQUET_ASSIGN_OR_THROW(reader, parquet::arrow::OpenFile(infile, arrow::default_memory_pool()));
   // (Doc section: Parquet OpenFile)
 
   // (Doc section: Parquet Read)

--- a/cpp/examples/tutorial_examples/file_access_example.cc
+++ b/cpp/examples/tutorial_examples/file_access_example.cc
@@ -180,8 +180,9 @@ arrow::Status RunMain() {
   // (Doc section: Parquet OpenFile)
   // Note that Parquet's OpenFile() takes the reader by reference, rather than returning
   // a reader.
-  PARQUET_THROW_NOT_OK(
-      parquet::arrow::OpenFile(infile, arrow::default_memory_pool(), &reader));
+  auto result = parquet::arrow::OpenFile(infile, arrow::default_memory_pool());
+  PARQUET_THROW_NOT_OK(result.status());
+  reader = std::move(result.ValueOrDie());
   // (Doc section: Parquet OpenFile)
 
   // (Doc section: Parquet Read)


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change
This PR address this [issue](https://github.com/apache/arrow/issues/44802) and updates the `example-cpp-tutorial` in Crossbow to resolve build failures caused by deprecated APIs, as seen in [this CI job](https://github.com/ursacomputing/crossbow/actions/runs/11944262092/job/33294899404). The change migrates the examples to non-deprecated APIs to ensure compatibility with the latest Arrow C++ version.

Updating these APIs is necessary to:

Fix build failures and prevent future issues.
Align with the current Arrow C++ API.
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

This PR updates the example-cpp-tutorial to replace deprecated Arrow C++ APIs with the latest supported APIs, resolving build failures in the Crossbow night build.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
By running: 
```
$ cd arrow/cpp/examples/tutorial_examples
$ docker compose run --rm tutorial
```

output:
```==
== Running example project
==

Day:   [
    1,
    12,
    17,
    23,
    28
  ]
Month:   [
    1,
    3,
    5,
    7,
    1
  ]
Year:   [
    1990,
    2000,
    1995,
    2000,
    1995
  ]
Day: int8
Month: int8
Year: int16
----
Day:
  [
    [
      1,
      12,
      17,
      23,
      28
    ],
    [
      6,
      12,
      3,
      30,
      22
    ]
  ]
Month:
  [
    [
      1,
      3,
      5,
      7,
      1
    ],
    [
      5,
      4,
      11,
      3,
      2
    ]
  ]
Year:
  [
    [
      1990,
      2000,
      1995,
      2000,
      1995
    ],
    [
      1980,
      2001,
      1915,
      2020,
      1996
    ]
  ]
Datum kind: Scalar(12891) content type: int64
12891
Datum kind: ChunkedArray([
  [
    75376,
    647,
    2287,
    5671,
    5092
  ]
]) content type: int32
[
  [
    75376,
    647,
    2287,
    5671,
    5092
  ]
]
Datum kind: Scalar(2) content type: int64
2
Found fragment: parquet_dataset/data1.parquet
Partition expression: true
Found fragment: parquet_dataset/data2.parquet
Partition expression: true
a: int64
b: int64
c: int64
----
a:
  [
    [
      0,
      1,
      2,
      3,
      4
    ],
    [
      5,
      6,
      7,
      8,
      9
    ]
  ]
b:
  [
    [
      9,
      8,
      7,
      6,
      5
    ],
    [
      4,
      3,
      2,
      1,
      0
    ]
  ]
c:
  [
    [
      1,
      2,
      1,
      2,
      1
    ],
    [
      2,
      1,
      2,
      1,
      2
    ]
  ]

```

### Are there any user-facing changes?

Yes, the tutorial has been updated to use non-deprecated APIs, which may affect the example code provided to users.



<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #44802