### PR TITLE
GH-44820: [CI] Uninstall pkg-config entirely on macOS jobs

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -255,6 +255,7 @@ jobs:
           # in GitHub Actions runner now. We can remove this once
           # pkg-config formula is removed from GitHub Actions runner.
           brew uninstall pkg-config || :
+          brew uninstall pkg-config@0.29.2 || :
           brew bundle --file=cpp/Brewfile
       - name: Install MinIO
         run: |

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -193,6 +193,7 @@ jobs:
           # in GitHub Actions runner now. We can remove this once
           # pkg-config formula is removed from GitHub Actions runner.
           brew uninstall pkg-config || :
+          brew uninstall pkg-config@0.29.2 || :
           brew bundle --file=cpp/Brewfile
           python -m pip install \
             -r python/requirements-build.txt \

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -155,6 +155,11 @@ jobs:
       - name: Install Homebrew Dependencies
         shell: bash
         run: |
+          # pkg-config formula is deprecated but it's still installed
+          # in GitHub Actions runner now. We can remove this once
+          # pkg-config formula is removed from GitHub Actions runner.
+          brew uninstall pkg-config || :
+          brew uninstall pkg-config@0.29.2 || :
           brew bundle --file=cpp/Brewfile
           brew bundle --file=c_glib/Brewfile
           # For Meson.


### PR DESCRIPTION
### Rationale for this change

`pkg-config@0.29.2` prevents installing `pkgconf`:

```text
Installing pkgconf
==> Downloading https://ghcr.io/v2/homebrew/core/pkgconf/manifests/2.3.0_1
==> Fetching pkgconf
==> Downloading https://ghcr.io/v2/homebrew/core/pkgconf/blobs/sha256:5f83615f295e78e593c767d84f3eddf61bfb0b849a1e6a5ea343506b30b2c620
==> Pouring pkgconf--2.3.0_1.arm64_sonoma.bottle.tar.gz
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /opt/homebrew
Could not symlink bin/pkg-config
Target /opt/homebrew/bin/pkg-config
is a symlink belonging to pkg-config@0.29.2. You can unlink it:
  brew unlink pkg-config@0.29.2

To force the link and overwrite all conflicting files:
  brew link --overwrite pkgconf

To list all files that would be deleted:
  brew link --overwrite pkgconf --dry-run

Possible conflicting files are:
/opt/homebrew/bin/pkg-config -> /opt/homebrew/Cellar/pkg-config@0.29.2/0.29.2_3/bin/pkg-config
/opt/homebrew/share/aclocal/pkg.m4 -> /opt/homebrew/Cellar/pkg-config@0.29.2/0.29.2_3/share/aclocal/pkg.m4
/opt/homebrew/share/man/man1/pkg-config.1 -> /opt/homebrew/Cellar/pkg-config@0.29.2/0.29.2_3/share/man/man1/pkg-config.1
```

### What changes are included in this PR?

Remove not only `pkg-config` but also `pkg-config@0.29.2`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #44820