### PR TITLE
MINOR: [Dev][Release] Stop post-04-website.sh script if archery isn't available

### DIFF
--- a/dev/release/post-04-website.sh
+++ b/dev/release/post-04-website.sh
@@ -29,6 +29,12 @@ if [ "$#" -ne 2 ]; then
   exit 1
 fi
 
+# Verify archery is available and stop if not
+if [ -z "$(which archery)" ]; then
+  echo "This script requires archery. Please install it and try again."
+  exit 1
+fi
+
 previous_version=$1
 version=$2
 

--- a/dev/release/post-04-website.sh
+++ b/dev/release/post-04-website.sh
@@ -30,7 +30,7 @@ if [ "$#" -ne 2 ]; then
 fi
 
 # Verify archery is available and stop if not
-if [ -z "$(which archery)" ]; then
+if archery --help > /dev/null 2>&1; then
   echo "This script requires archery. Please install it and try again."
   exit 1
 fi

--- a/dev/release/post-04-website.sh
+++ b/dev/release/post-04-website.sh
@@ -30,7 +30,7 @@ if [ "$#" -ne 2 ]; then
 fi
 
 # Verify archery is available and stop if not
-if archery --help > /dev/null 2>&1; then
+if ! archery --help > /dev/null 2>&1; then
   echo "This script requires archery. Please install it and try again."
   exit 1
 fi


### PR DESCRIPTION
### Rationale for this change

The release script at `dev/release/post-04-website.sh` doesn't quite work right if archery isn't available. The PR gets made but the changelog isn't included. See when this happened during the 18.0.0 release: https://github.com/apache/arrow-site/pull/551#discussion_r1822264990. 

### What changes are included in this PR?

Before the script does anything meaningful, it checks for archery and stops if it's not available.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.