### PR TITLE
GH-44844: [CI] Uninstall pkg-config entirely on verification and java-jars macOS jobs

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -765,11 +765,6 @@ import pyarrow.parquet
 
 test_glib() {
   show_header "Build and test C GLib libraries"
-  if [ "$(uname)" = "Darwin" ] && [ "$(uname -m)" = "arm64" ] && [ -n "$(command -v brew)" ]; then
-    # On macOS arm64 if brew is present, this is required for Meson.
-    # See also: https://github.com/mesonbuild/meson/issues/7701
-    export PKG_CONFIG=$(brew --prefix pkgconf)/bin/pkgconf
-  fi
 
   # Build and test C GLib
   maybe_setup_conda glib gobject-introspection meson ninja ruby

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -765,6 +765,11 @@ import pyarrow.parquet
 
 test_glib() {
   show_header "Build and test C GLib libraries"
+  if [ "$(uname)" == "Darwin" && "$(uname -m)" == "arm64" &&  $(command -v brew) != "" ]; then
+    # On macOS arm64 if brew is present, this is required for Meson.
+    # See also: https://github.com/mesonbuild/meson/issues/7701
+    export PKG_CONFIG=$(brew --prefix pkgconf)/bin/pkgconf
+  fi
 
   # Build and test C GLib
   maybe_setup_conda glib gobject-introspection meson ninja ruby

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -765,7 +765,7 @@ import pyarrow.parquet
 
 test_glib() {
   show_header "Build and test C GLib libraries"
-  if [ "$(uname)" == "Darwin" && "$(uname -m)" == "arm64" &&  $(command -v brew) != "" ]; then
+  if [ "$(uname)" = "Darwin" ] && [ "$(uname -m)" = "arm64" ] && [ -n "$(command -v brew)" ]; then
     # On macOS arm64 if brew is present, this is required for Meson.
     # See also: https://github.com/mesonbuild/meson/issues/7701
     export PKG_CONFIG=$(brew --prefix pkgconf)/bin/pkgconf

--- a/dev/tasks/java-jars/github.yml
+++ b/dev/tasks/java-jars/github.yml
@@ -129,7 +129,7 @@ jobs:
           done
           brew install --overwrite python
 
-          if [ "${ARCH}" = "arm64" ]; then
+          if [ "${ARCH}" == "arm64" ]; then
             # pkg-config formula is deprecated but it's still installed
             # in GitHub Actions runner now. We can remove this once
             # pkg-config formula is removed from GitHub Actions runner.

--- a/dev/tasks/java-jars/github.yml
+++ b/dev/tasks/java-jars/github.yml
@@ -129,6 +129,12 @@ jobs:
           done
           brew install --overwrite python
 
+          # pkg-config formula is deprecated but it's still installed
+          # in GitHub Actions runner now. We can remove this once
+          # pkg-config formula is removed from GitHub Actions runner.
+          brew uninstall pkg-config || :
+          brew uninstall pkg-config@0.29.2 || :
+
           brew bundle --file=arrow/cpp/Brewfile
           # We want to link aws-sdk-cpp statically but Homebrew's
           # aws-sdk-cpp provides only shared library. If we have

--- a/dev/tasks/java-jars/github.yml
+++ b/dev/tasks/java-jars/github.yml
@@ -129,7 +129,7 @@ jobs:
           done
           brew install --overwrite python
 
-          if [ "$(uname -m)" == "arm64" ]; then
+          if [ "$(uname -m)" = "arm64" ]; then
             # pkg-config formula is deprecated but it's still installed
             # in GitHub Actions runner now. We can remove this once
             # pkg-config formula is removed from GitHub Actions runner.

--- a/dev/tasks/java-jars/github.yml
+++ b/dev/tasks/java-jars/github.yml
@@ -129,11 +129,13 @@ jobs:
           done
           brew install --overwrite python
 
+          {% if '${{ matrix.platform.runs_on }}' == 'macos-14' %}
           # pkg-config formula is deprecated but it's still installed
           # in GitHub Actions runner now. We can remove this once
           # pkg-config formula is removed from GitHub Actions runner.
           brew uninstall pkg-config || :
           brew uninstall pkg-config@0.29.2 || :
+          {% endif %}
 
           brew bundle --file=arrow/cpp/Brewfile
           # We want to link aws-sdk-cpp statically but Homebrew's

--- a/dev/tasks/java-jars/github.yml
+++ b/dev/tasks/java-jars/github.yml
@@ -129,13 +129,13 @@ jobs:
           done
           brew install --overwrite python
 
-          {% if '${{ matrix.platform.runs_on }}' == 'macos-14' %}
-          # pkg-config formula is deprecated but it's still installed
-          # in GitHub Actions runner now. We can remove this once
-          # pkg-config formula is removed from GitHub Actions runner.
-          brew uninstall pkg-config || :
-          brew uninstall pkg-config@0.29.2 || :
-          {% endif %}
+          if [ "${ARCH}" = "arm64" ]; then
+            # pkg-config formula is deprecated but it's still installed
+            # in GitHub Actions runner now. We can remove this once
+            # pkg-config formula is removed from GitHub Actions runner.
+            brew uninstall pkg-config || :
+            brew uninstall pkg-config@0.29.2 || :
+          fi
 
           brew bundle --file=arrow/cpp/Brewfile
           # We want to link aws-sdk-cpp statically but Homebrew's

--- a/dev/tasks/java-jars/github.yml
+++ b/dev/tasks/java-jars/github.yml
@@ -129,7 +129,7 @@ jobs:
           done
           brew install --overwrite python
 
-          if [ "${ARCH}" == "arm64" ]; then
+          if [ "$(uname -m)" == "arm64" ]; then
             # pkg-config formula is deprecated but it's still installed
             # in GitHub Actions runner now. We can remove this once
             # pkg-config formula is removed from GitHub Actions runner.

--- a/dev/tasks/verify-rc/github.macos.yml
+++ b/dev/tasks/verify-rc/github.macos.yml
@@ -42,6 +42,12 @@ jobs:
       - name: Install System Dependencies
         shell: bash
         run: |
+          # pkg-config formula is deprecated but it's still installed
+          # in GitHub Actions runner now. We can remove this once
+          # pkg-config formula is removed from GitHub Actions runner.
+          brew uninstall pkg-config || :
+          brew uninstall pkg-config@0.29.2 || :
+
           brew bundle --file=arrow/cpp/Brewfile
           brew bundle --file=arrow/c_glib/Brewfile
       {% endif %}

--- a/dev/tasks/verify-rc/github.macos.yml
+++ b/dev/tasks/verify-rc/github.macos.yml
@@ -42,11 +42,13 @@ jobs:
       - name: Install System Dependencies
         shell: bash
         run: |
+          {% if github_runner in ("macos-14", "macos-latest") %}
           # pkg-config formula is deprecated but it's still installed
           # in GitHub Actions runner now. We can remove this once
           # pkg-config formula is removed from GitHub Actions runner.
           brew uninstall pkg-config || :
           brew uninstall pkg-config@0.29.2 || :
+          {% endif %}
 
           brew bundle --file=arrow/cpp/Brewfile
           brew bundle --file=arrow/c_glib/Brewfile

--- a/dev/tasks/verify-rc/github.macos.yml
+++ b/dev/tasks/verify-rc/github.macos.yml
@@ -52,6 +52,13 @@ jobs:
 
           brew bundle --file=arrow/cpp/Brewfile
           brew bundle --file=arrow/c_glib/Brewfile
+
+          # For Meson.
+          # See also: https://github.com/mesonbuild/meson/issues/7701
+          pkgconf="$(brew --prefix pkgconf)/bin/pkgconf"
+          if [ -x "${pkgconf}" ]; then
+            echo "PKG_CONFIG=${pkgconf}" >> $GITHUB_ENV
+          fi
       {% endif %}
 
       - uses: actions/setup-java@v2


### PR DESCRIPTION
### Rationale for this change

Jobs are failing on nightlies.

### What changes are included in this PR?

Remove pkg-config entirely as we've done on other CI jobs.

### Are these changes tested?

Yes via archery

### Are there any user-facing changes?

No
* GitHub Issue: #44844