### PR TITLE
GH-44846: [CI][C++] Revert change for maybe uninitialized variable to fix thread sanitizer failure

### DIFF
--- a/cpp/src/arrow/util/iterator.h
+++ b/cpp/src/arrow/util/iterator.h
@@ -292,7 +292,7 @@ class TransformIterator {
         finished_ = true;
         return next_res.status();
       }
-      auto next = std::move(*next_res);
+      auto next = *next_res;
       if (next.ReadyForNext()) {
         if (IsIterationEnd(*last_value_)) {
           finished_ = true;


### PR DESCRIPTION
### Rationale for this change

The thread sanitizer build was failing since the original was merged: https://github.com/apache/arrow/commit/2e1ddf5069731d2b908b18d851b2389973cc988c

### What changes are included in this PR?

Revert change

### Are these changes tested?

Via CI

### Are there any user-facing changes?

No

* GitHub Issue: #44846