### PR TITLE
GH-44846: [C++] Fix thread-unsafe access in ConcurrentQueue::UnsyncFront

### DIFF
--- a/cpp/src/arrow/acero/asof_join_node.cc
+++ b/cpp/src/arrow/acero/asof_join_node.cc
@@ -567,7 +567,7 @@ class InputState : public util::SerialSequencingQueue::Processor {
 
   // Gets latest batch (precondition: must not be empty)
   const std::shared_ptr<arrow::RecordBatch>& GetLatestBatch() const {
-    return queue_.UnsyncFront();
+    return queue_.Front();
   }
 
 #define LATEST_VAL_CASE(id, val)                     \
@@ -634,15 +634,14 @@ class InputState : public util::SerialSequencingQueue::Processor {
       }
       latest_time_ = next_time;
       // If we have an active batch
-      if (++latest_ref_row_ >= (row_index_t)queue_.UnsyncFront()->num_rows()) {
+      if (++latest_ref_row_ >= (row_index_t)queue_.Front()->num_rows()) {
         // hit the end of the batch, need to get the next batch if possible.
         ++batches_processed_;
         latest_ref_row_ = 0;
         have_active_batch &= !queue_.TryPop();
         if (have_active_batch) {
-          DCHECK_GT(queue_.UnsyncFront()->num_rows(), 0);  // empty batches disallowed
-          memo_.UpdateTime(GetTime(queue_.UnsyncFront().get(), time_type_id_,
-                                   time_col_index_,
+          DCHECK_GT(queue_.Front()->num_rows(), 0);  // empty batches disallowed
+          memo_.UpdateTime(GetTime(queue_.Front().get(), time_type_id_, time_col_index_,
                                    0));  // time changed
         }
       }

--- a/cpp/src/arrow/acero/sorted_merge_node.cc
+++ b/cpp/src/arrow/acero/sorted_merge_node.cc
@@ -145,7 +145,7 @@ class InputState {
 
   // Gets latest batch (precondition: must not be empty)
   const std::shared_ptr<arrow::RecordBatch>& GetLatestBatch() const {
-    return queue_.UnsyncFront();
+    return queue_.Front();
   }
 
 #define LATEST_VAL_CASE(id, val)                                   \
@@ -178,7 +178,7 @@ class InputState {
     row_index_t start = latest_ref_row_;
     row_index_t end = latest_ref_row_;
     time_unit_t startTime = GetLatestTime();
-    std::shared_ptr<arrow::RecordBatch> batch = queue_.UnsyncFront();
+    std::shared_ptr<arrow::RecordBatch> batch = queue_.Front();
     auto rows_in_batch = (row_index_t)batch->num_rows();
 
     while (GetLatestTime() == startTime) {
@@ -190,7 +190,7 @@ class InputState {
         latest_ref_row_ = 0;
         active &= !queue_.TryPop();
         if (active) {
-          DCHECK_GT(queue_.UnsyncFront()->num_rows(),
+          DCHECK_GT(queue_.Front()->num_rows(),
                     0);  // empty batches disallowed, sanity check
         }
         break;


### PR DESCRIPTION
### Rationale for this change

The `UnsyncFront` method claims that it can access a `std::deque`'s front element without synchronizing with another thread that would call `std::deque::push_back`, but `std::deque::front` can actually be implemented in terms of `std::deque::begin` while `std::deque::push_back` is specified to invalidate iterators.

In the end, `UnsyncFront` is concretely thread-unsafe even though it might ideally be thread-safe. This shows up as occasional Thread Sanitizer failures.

### What changes are included in this PR?

Replace `UnsyncFront` with a thread-safe `Front` method.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.

* GitHub Issue: #44846