### PR TITLE
GH-44667: [Archery] Only suppress Docker progress logs if `--quiet` is enabled

### DIFF
--- a/.github/workflows/archery.yml
+++ b/.github/workflows/archery.yml
@@ -78,7 +78,7 @@ jobs:
         working-directory: dev/archery
         run: pytest -v archery
       - name: Archery Docker Validation
-        run: archery docker check-config
+        run: archery --quiet docker check-config
       - name: Crossbow Check Config
         working-directory: dev/tasks
         run: archery crossbow check-config

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -169,7 +169,7 @@ jobs:
           # GH-40558: reduce ASLR to avoid ASAN/LSAN crashes
           sudo sysctl -w vm.mmap_rnd_bits=28
           source ci/scripts/util_enable_core_dumps.sh
-          archery docker run ${{ matrix.image }}
+          archery --quiet docker run ${{ matrix.image }}
       - name: Docker Push
         if: >-
           success() &&
@@ -180,7 +180,7 @@ jobs:
           ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}
           ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
         continue-on-error: true
-        run: archery docker push ${{ matrix.image }}
+        run: archery --quiet docker push ${{ matrix.image }}
 
   build-example:
     name: C++ Minimal Build Example

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -74,7 +74,7 @@ jobs:
           UBUNTU: 22.04
         run: |
           source ci/scripts/util_enable_core_dumps.sh
-          archery docker run -e GITHUB_ACTIONS=true ubuntu-lint
+          archery --quiet docker run -e GITHUB_ACTIONS=true ubuntu-lint
       - name: Docker Push
         if: >-
           success() &&
@@ -85,7 +85,7 @@ jobs:
           ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}
           ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
         continue-on-error: true
-        run: archery docker push ubuntu-lint
+        run: archery --quiet docker push ubuntu-lint
 
   release:
     name: Source Release and Merge Script on ${{ matrix.runs-on }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -62,7 +62,7 @@ jobs:
           ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}
           ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
           JDK: 17
-        run: archery docker run debian-docs
+        run: archery --quiet docker run debian-docs
       - name: Docker Push
         if: >-
           success() &&
@@ -73,4 +73,4 @@ jobs:
           ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}
           ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
         continue-on-error: true
-        run: archery docker push debian-docs
+        run: archery --quiet docker push debian-docs

--- a/.github/workflows/docs_light.yml
+++ b/.github/workflows/docs_light.yml
@@ -68,4 +68,4 @@ jobs:
         env:
           ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}
           ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
-        run: archery docker run conda-python-docs
+        run: archery --quiet docker run conda-python-docs

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -112,7 +112,7 @@ jobs:
           ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
           source ci/scripts/util_enable_core_dumps.sh
-          archery docker run \
+          archery --quiet docker run \
             -e ARCHERY_DEFAULT_BRANCH=${{ github.event.repository.default_branch }} \
             -e ARCHERY_INTEGRATION_WITH_GO=1 \
             -e ARCHERY_INTEGRATION_WITH_NANOARROW=1 \
@@ -128,4 +128,4 @@ jobs:
           ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}
           ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
         continue-on-error: true
-        run: archery docker push conda-integration
+        run: archery --quiet docker push conda-integration

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -94,7 +94,7 @@ jobs:
           ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
           DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
         run: |
-          archery docker run \
+          archery --quiet docker run \
             -e CI=true \
             -e "DEVELOCITY_ACCESS_KEY=$DEVELOCITY_ACCESS_KEY" \
             ${{ matrix.image }}
@@ -108,7 +108,7 @@ jobs:
           ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}
           ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
         continue-on-error: true
-        run: archery docker push ${{ matrix.image }}
+        run: archery --quiet docker push ${{ matrix.image }}
 
   macos:
     name: AMD64 macOS 13 Java JDK ${{ matrix.jdk }}

--- a/.github/workflows/java_jni.yml
+++ b/.github/workflows/java_jni.yml
@@ -88,7 +88,7 @@ jobs:
           ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
           source ci/scripts/util_enable_core_dumps.sh
-          archery docker run java-jni-manylinux-2014
+          archery --quiet docker run java-jni-manylinux-2014
       - name: Docker Push
         if: >-
           success() &&
@@ -99,7 +99,7 @@ jobs:
           ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}
           ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
         continue-on-error: true
-        run: archery docker push java-jni-manylinux-2014
+        run: archery --quiet docker push java-jni-manylinux-2014
 
   docker_integration_python:
     name: AMD64 Conda Java C Data Interface Integration
@@ -130,7 +130,7 @@ jobs:
           ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
           DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
         run: |
-          archery docker run \
+          archery --quiet docker run \
             -e CI=true \
             -e "DEVELOCITY_ACCESS_KEY=$DEVELOCITY_ACCESS_KEY" \
             conda-python-java-integration
@@ -144,4 +144,4 @@ jobs:
           ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}
           ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
         continue-on-error: true
-        run: archery docker push conda-python-java-integration
+        run: archery --quiet docker push conda-python-java-integration

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -72,7 +72,7 @@ jobs:
           ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
           source ci/scripts/util_enable_core_dumps.sh
-          archery docker run debian-js
+          archery --quiet docker run debian-js
       - name: Docker Push
         if: >-
           success() &&
@@ -83,7 +83,7 @@ jobs:
           ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}
           ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
         continue-on-error: true
-        run: archery docker push debian-js
+        run: archery --quiet docker push debian-js
 
   macos:
     name: AMD64 macOS 13 NodeJS ${{ matrix.node }}

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -125,7 +125,7 @@ jobs:
           ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
           source ci/scripts/util_enable_core_dumps.sh
-          archery docker run ${{ matrix.image }}
+          archery --quiet docker run ${{ matrix.image }}
       - name: Docker Push
         if: >-
           success() &&
@@ -136,7 +136,7 @@ jobs:
           ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}
           ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
         continue-on-error: true
-        run: archery docker push ${{ matrix.image }}
+        run: archery --quiet docker push ${{ matrix.image }}
 
   macos:
     name: ${{ matrix.architecture }} macOS ${{ matrix.macos-version }} Python 3

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -168,7 +168,7 @@ jobs:
           source ci/scripts/util_enable_core_dumps.sh
           # Setting a non-default and non-probable Marquesas French Polynesia time
           # it has both with a .45 offset and very very few people who live there.
-          archery docker run -e TZ=MART -e ARROW_R_FORCE_TESTS=${{ matrix.force-tests }} ubuntu-r
+          archery --quiet docker run -e TZ=MART -e ARROW_R_FORCE_TESTS=${{ matrix.force-tests }} ubuntu-r
       - name: Dump install logs
         run: cat r/check/arrow.Rcheck/00install.out
         if: always()
@@ -191,7 +191,7 @@ jobs:
           ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}
           ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
         continue-on-error: true
-        run: archery docker push ubuntu-r
+        run: archery --quiet docker push ubuntu-r
 
   bundled:
     name: "${{ matrix.config.org }}/${{ matrix.config.image }}:${{ matrix.config.tag }}"
@@ -228,7 +228,7 @@ jobs:
           # Don't set a TZ here to test that case. These builds will have the following warning in them:
           #   System has not been booted with systemd as init system (PID 1). Can't operate.
           #   Failed to connect to bus: Host is down
-          archery docker run -e TZ="" r
+          archery --quiet docker run -e TZ="" r
       - name: Dump install logs
         run: cat r/check/arrow.Rcheck/00install.out
         if: always()
@@ -251,7 +251,7 @@ jobs:
           ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}
           ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
         continue-on-error: true
-        run: archery docker push r
+        run: archery --quiet docker push r
 
   windows-cpp:
     name: AMD64 Windows C++ RTools ${{ matrix.config.rtools }} ${{ matrix.config.arch }}

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -101,7 +101,7 @@ jobs:
           ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
           source ci/scripts/util_enable_core_dumps.sh
-          archery docker run \
+          archery --quiet docker run \
             -e ARROW_FLIGHT=ON \
             -e ARROW_FLIGHT_SQL=ON \
             -e ARROW_GCS=ON \
@@ -119,7 +119,7 @@ jobs:
           ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
         continue-on-error: true
         shell: bash
-        run: archery docker push ubuntu-ruby
+        run: archery --quiet docker push ubuntu-ruby
 
   macos:
     name: ARM64 macOS 14 GLib & Ruby

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -75,7 +75,7 @@ jobs:
           ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
           source ci/scripts/util_enable_core_dumps.sh
-          archery docker run ubuntu-swift
+          archery --quiet docker run ubuntu-swift
       - name: Docker Push
         if: >-
           success() &&
@@ -86,4 +86,4 @@ jobs:
           ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}
           ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
         continue-on-error: true
-        run: archery docker push ubuntu-swift
+        run: archery --quiet docker push ubuntu-swift

--- a/dev/tasks/docker-tests/github.cuda.yml
+++ b/dev/tasks/docker-tests/github.cuda.yml
@@ -39,7 +39,7 @@ jobs:
         {{ macros.github_set_sccache_envvars()|indent(8) }}
         run: |
           source arrow/ci/scripts/util_enable_core_dumps.sh
-          archery docker run \
+          archery --quiet docker run \
             -e SETUPTOOLS_SCM_PRETEND_VERSION="{{ arrow.no_rc_version }}" \
             {{ flags|default("") }} \
             {{ image }} \
@@ -48,5 +48,5 @@ jobs:
       {{ macros.github_login_dockerhub()|indent }}
       - name: Push Docker Image
         shell: bash
-        run: archery docker push {{ image }}
+        run: archery --quiet docker push {{ image }}
     {% endif %}

--- a/dev/tasks/docker-tests/github.linux.yml
+++ b/dev/tasks/docker-tests/github.linux.yml
@@ -39,7 +39,7 @@ jobs:
           # GH-40558: reduce ASLR to avoid TSAN crashing
           sudo sysctl -w vm.mmap_rnd_bits=28
           source arrow/ci/scripts/util_enable_core_dumps.sh
-          archery docker run \
+          archery --quiet docker run \
             -e SETUPTOOLS_SCM_PRETEND_VERSION="{{ arrow.no_rc_version }}" \
             {{ flags|default("") }} \
             {{ image }} \
@@ -74,5 +74,5 @@ jobs:
       - name: Push Docker Image
         if: {{ push|default("true") }}
         shell: bash
-        run: archery docker push {{ image }}
+        run: archery --quiet docker push {{ image }}
     {% endif %}

--- a/dev/tasks/docs/github.linux.yml
+++ b/dev/tasks/docs/github.linux.yml
@@ -35,7 +35,7 @@ jobs:
           ARROW_JAVA_SKIP_GIT_PLUGIN: true
         run: |
           mkdir -p build
-          archery docker run \
+          archery --quiet docker run \
             -e SETUPTOOLS_SCM_PRETEND_VERSION="{{ arrow.no_rc_version }}" \
             -v $PWD/build/:/build/ \
             {{ flags|default("") }} \

--- a/dev/tasks/java-jars/github.yml
+++ b/dev/tasks/java-jars/github.yml
@@ -62,7 +62,7 @@ jobs:
           else
             export VCPKG_BINARY_SOURCES="clear;nuget,GitHub,readwrite"
           fi
-          archery docker run \
+          archery --quiet docker run \
             -e ARROW_JAVA_BUILD=OFF \
             -e ARROW_JAVA_TEST=OFF \
             java-jni-manylinux-2014
@@ -77,7 +77,7 @@ jobs:
       {{ macros.github_login_dockerhub()|indent }}
       - name: Push Docker image
         shell: bash
-        run: archery docker push java-jni-manylinux-2014
+        run: archery --quiet docker push java-jni-manylinux-2014
     {% endif %}
 
   build-cpp-macos:

--- a/dev/tasks/nuget-packages/github.linux.yml
+++ b/dev/tasks/nuget-packages/github.linux.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Build package
         run: |
           pushd arrow
-          archery docker run {{ run }}
+          archery --quiet docker run {{ run }}
           popd
 
       {% set patterns = ["arrow/csharp/artifacts/**/*.nupkg",

--- a/dev/tasks/python-sdist/github.yml
+++ b/dev/tasks/python-sdist/github.yml
@@ -29,15 +29,15 @@ jobs:
 
       - name: Build sdist
         run: |
-          archery docker run python-sdist
+          archery --quiet docker run python-sdist
           {% if arrow.is_default_branch() %}
-          archery docker push python-sdist || :
+          archery --quiet docker push python-sdist || :
           {% endif %}
         env:
           PYARROW_VERSION: {{ arrow.no_rc_version }}
 
       - name: Test sdist
-        run: archery docker run ubuntu-python-sdist-test
+        run: archery --quiet docker run ubuntu-python-sdist-test
         env:
           UBUNTU: 22.04
           PYARROW_VERSION: {{ arrow.no_rc_version }}

--- a/dev/tasks/python-wheels/github.linux.yml
+++ b/dev/tasks/python-wheels/github.linux.yml
@@ -61,7 +61,7 @@ jobs:
           else
             export VCPKG_BINARY_SOURCES="clear;nuget,GitHub,readwrite"
           fi
-          archery docker run \
+          archery --quiet docker run \
             -e SETUPTOOLS_SCM_PRETEND_VERSION={{ arrow.no_rc_version }} \
             python-wheel-manylinux-{{ manylinux_version }}
 
@@ -77,8 +77,8 @@ jobs:
         shell: bash
         run: |
           source arrow/ci/scripts/util_enable_core_dumps.sh
-          archery docker run python-wheel-manylinux-test-imports
-          archery docker run python-wheel-manylinux-test-unittests
+          archery --quiet docker run python-wheel-manylinux-test-imports
+          archery --quiet docker run python-wheel-manylinux-test-unittests
 
       # Free-threaded wheels need to be tested using a different Docker Compose service
       - name: Test free-threaded wheel
@@ -87,8 +87,8 @@ jobs:
         shell: bash
         run: |
           source arrow/ci/scripts/util_enable_core_dumps.sh
-          archery docker run python-free-threaded-wheel-manylinux-test-imports
-          archery docker run python-free-threaded-wheel-manylinux-test-unittests
+          archery --quiet docker run python-free-threaded-wheel-manylinux-test-imports
+          archery --quiet docker run python-free-threaded-wheel-manylinux-test-unittests
 
       - name: Test wheel on AlmaLinux 8
         shell: bash
@@ -97,7 +97,7 @@ jobs:
         env:
           ALMALINUX: "8"
         run: |
-          archery docker run \
+          archery --quiet docker run \
             -e ARROW_GANDIVA=OFF \
             -e TEST_DEFAULT=0 \
             -e TEST_PYARROW_VERSION={{ arrow.no_rc_version }} \
@@ -113,7 +113,7 @@ jobs:
         env:
           UBUNTU: "20.04"
         run: |
-          archery docker run \
+          archery --quiet docker run \
             -e TEST_DEFAULT=0 \
             -e TEST_PYARROW_VERSION={{ arrow.no_rc_version }} \
             -e TEST_PYTHON_VERSIONS={{ python_version }} \
@@ -128,7 +128,7 @@ jobs:
         env:
           UBUNTU: "22.04"
         run: |
-          archery docker run \
+          archery --quiet docker run \
             -e TEST_DEFAULT=0 \
             -e TEST_PYARROW_VERSION={{ arrow.no_rc_version }} \
             -e TEST_PYTHON_VERSIONS={{ python_version }} \
@@ -144,6 +144,6 @@ jobs:
       - name: Push Docker Image
         shell: bash
         run: |
-          archery docker push python-wheel-manylinux-{{ manylinux_version }}
-          archery docker push python-wheel-manylinux-test-unittests
+          archery --quiet docker push python-wheel-manylinux-{{ manylinux_version }}
+          archery --quiet docker push python-wheel-manylinux-test-unittests
       {% endif %}

--- a/dev/tasks/python-wheels/github.windows.yml
+++ b/dev/tasks/python-wheels/github.windows.yml
@@ -48,17 +48,17 @@ jobs:
         run: |
           cd arrow
           @rem We want to use only
-          @rem   archery docker run -e SETUPTOOLS_SCM_PRETEND_VERSION={{ arrow.no_rc_version }} python-wheel-windows-vs2019
+          @rem   archery --quiet docker run -e SETUPTOOLS_SCM_PRETEND_VERSION={{ arrow.no_rc_version }} python-wheel-windows-vs2019
           @rem but it doesn't use pulled caches.
           @rem It always build an image from scratch.
           @rem We can remove this workaround once we find a way to use
           @rem pulled caches when build an image.
           echo on
-          archery docker pull --no-ignore-pull-failures python-wheel-windows-vs2019
+          archery --quiet docker pull --no-ignore-pull-failures python-wheel-windows-vs2019
           if errorlevel 1 (
-            archery docker build --no-pull python-wheel-windows-vs2019 || exit /B 1
+            archery --quiet docker build --no-pull python-wheel-windows-vs2019 || exit /B 1
           )
-          archery docker run --no-build -e SETUPTOOLS_SCM_PRETEND_VERSION={{ arrow.no_rc_version }} python-wheel-windows-vs2019
+          archery --quiet docker run --no-build -e SETUPTOOLS_SCM_PRETEND_VERSION={{ arrow.no_rc_version }} python-wheel-windows-vs2019
 
       - uses: actions/upload-artifact@v4
         with:
@@ -69,7 +69,7 @@ jobs:
         shell: cmd
         run: |
           cd arrow
-          archery docker run python-wheel-windows-test
+          archery --quiet docker run python-wheel-windows-test
 
       {{ macros.github_upload_releases("arrow/python/dist/*.whl")|indent }}
       {{ macros.github_upload_gemfury("arrow/python/dist/*.whl")|indent }}
@@ -80,5 +80,5 @@ jobs:
         shell: cmd
         run: |
           cd arrow
-          archery docker push python-wheel-windows-vs2019
+          archery --quiet docker push python-wheel-windows-vs2019
       {% endif %}

--- a/dev/tasks/r/github.linux.cran.yml
+++ b/dev/tasks/r/github.linux.cran.yml
@@ -46,7 +46,7 @@ jobs:
         env:
         {{ macros.github_set_sccache_envvars()|indent(8)}}
         # setting ARROW_SOURCE_HOME='' here ensures that we use the cpp source copied into tools/
-        run: archery docker run -e ARROW_SOURCE_HOME='' r
+        run: archery --quiet docker run -e ARROW_SOURCE_HOME='' r
       - name: Dump install logs
         run: cat arrow/r/check/arrow.Rcheck/00install.out
         if: always()

--- a/dev/tasks/r/github.linux.versions.yml
+++ b/dev/tasks/r/github.linux.versions.yml
@@ -46,7 +46,7 @@ jobs:
         shell: bash
         env:
         {{ macros.github_set_sccache_envvars()|indent(8)}}
-        run: archery docker run r
+        run: archery --quiet docker run r
       - name: Dump install logs
         run: cat arrow/r/check/arrow.Rcheck/00install.out
         if: always()

--- a/dev/tasks/r/github.packages.yml
+++ b/dev/tasks/r/github.packages.yml
@@ -141,7 +141,7 @@ jobs:
         {{ macros.github_set_sccache_envvars()|indent(8) }}
         run: |
           source arrow/ci/scripts/util_enable_core_dumps.sh
-          archery docker run \
+          archery --quiet docker run \
             -e EXTRA_CMAKE_FLAGS="{{ '${{ matrix.extra-cmake-flags }}' }}" \
             {{ '${{ matrix.os }}' }}-cpp-static
       - name: Bundle libarrow

--- a/dev/tasks/verify-rc/github.linux.amd64.docker.yml
+++ b/dev/tasks/verify-rc/github.linux.amd64.docker.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Execute Docker Build
         shell: bash
         run: |
-          archery docker run \
+          archery --quiet docker run \
             -e VERIFY_VERSION="{{ release|default("") }}" \
             {% if distro == 'almalinux' and target|upper == 'PYTHON' %}
             -e ARROW_GANDIVA=OFF \
@@ -59,5 +59,5 @@ jobs:
       {{ macros.github_login_dockerhub()|indent }}
       - name: Push Docker Image
         shell: bash
-        run: archery docker push {{ distro }}-verify-rc
+        run: archery --quiet docker push {{ distro }}-verify-rc
     {% endif %}


### PR DESCRIPTION
### Rationale for this change

https://github.com/apache/arrow/pull/44669 went overboard by always suppressing Docker progress output. This may be desirable on CI, to avoid flooding the logs, but is annoying when running `archery docker` locally.

### What changes are included in this PR?

Only suppress Docker progress output if `--quiet` is passed to `archery docker`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes, this restores the previous behavior unless `--quiet` is passed.

* GitHub Issue: #44667