### PR TITLE
GH-44705: [MATLAB][PACKAGING] Update the crossbow MATLAB workflow to use `macOS 13` instead of `macOS 12`

### DIFF
--- a/dev/tasks/matlab/github.yml
+++ b/dev/tasks/matlab/github.yml
@@ -64,7 +64,7 @@ jobs:
     strategy:
       matrix:
         platform:
-            - { architecture: "AMD64", macos-version: "12", architecture-suffix: "x64"}
+            - { architecture: "AMD64", macos-version: "13", architecture-suffix: "x64"}
             - { architecture: "ARM64", macos-version: "14", architecture-suffix: "arm64"}
     steps:
       {{ macros.github_checkout_arrow()|indent }}


### PR DESCRIPTION
### Rationale for this change

GitHub actions has started the deprecation process for `macOS 12`, which will be completed by December 3rd, 2024 according to [this issue](https://github.com/actions/runner-images/issues/10721). The MATLAB CI workflow has already been updated to use `macOS 13` instead of `macOS 12` (thanks @kou for making this change!), but the crossbow MATLAB workflow still uses `macOS 12`. We need to update this workflow to use `macOS 13`.

### What changes are included in this PR?

1. Updated the MATLAB Crossbow GitHub workflow to use `macOS 13` instead of `macOS 12`. 

### Are these changes tested?

1. Yes. Ran a crossbow job: https://github.com/ursacomputing/crossbow/actions/runs/12033796012/job/33548796169.

### Are there any user-facing changes?

No. 

* GitHub Issue: #44705