### PR TITLE
GH-44585: [JS][Release] Skip bin dir in npm-release.sh

### DIFF
--- a/js/npm-release.sh
+++ b/js/npm-release.sh
@@ -24,6 +24,7 @@ yarn gulp
 
 read -p "Please enter your npm 2FA one-time password (or leave empty if you don't have 2FA enabled): " NPM_OTP </dev/tty
 
-# publish the JS target modules to npm
-find targets -type f -name package.json -execdir sh -c \
+# collect targets by finding package.json files
+# skips any in a bin dir, see GH-44585
+find targets -type f -name package.json ! -path "*/bin/*" -execdir sh -c \
   "npm publish \$(dirname \$(realpath {})) ${NPM_OTP:+ --otp=$NPM_OTP}" \;


### PR DESCRIPTION
### Rationale for this change

When publishing packages to npm, we want to skip any package.json files inside ./bin directories because those aren't meant to be published.

### What changes are included in this PR?

Updated `find` command which excludes `bin` directories.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #44585