### PR TITLE
MINOR: [C++] Add missing header for ORC adapter

### DIFF
--- a/cpp/src/arrow/adapters/orc/util.cc
+++ b/cpp/src/arrow/adapters/orc/util.cc
@@ -18,6 +18,7 @@
 #include "arrow/adapters/orc/util.h"
 
 #include <cmath>
+#include <sstream>
 #include <string>
 #include <string_view>
 #include <vector>


### PR DESCRIPTION
### Rationale for this change

Very minor. This source file cannot be compiled on its own manually, due to missing stringstream headers. This fixes that. Otherwise we get `implicit instantiation of undefined template` errors.

Context is we build Apache Arrow in a separate build system, Buck. As such, we do not (and cannot) 100% mirror the CMake build. In the past we've also had to patch header issues like: 529e08c. Thus, this change is for posterity to avoid having to custom patches on every new release.

### What changes are included in this PR?

Adds <sstream> which is used here: 
 https://github.com/apache/arrow/blob/main/cpp/src/arrow/adapters/orc/util.cc#L1226

### Are these changes tested?

N/A

### Are there any user-facing changes?

No