### PR TITLE
GH-44711: [Docs][Python] Add missing canonical extension types to PyArrow arrays and datatypes docs

### DIFF
--- a/docs/source/python/api/arrays.rst
+++ b/docs/source/python/api/arrays.rst
@@ -73,6 +73,7 @@ may expose data type-specific methods or properties.
    DurationArray
    MonthDayNanoIntervalArray
    Decimal128Array
+   Decimal256Array
    DictionaryArray
    ListArray
    FixedSizeListArray
@@ -89,7 +90,6 @@ may expose data type-specific methods or properties.
    JsonArray
    UuidArray
    Bool8Array
-   Decimal256Array
 
 .. _api.scalar:
 

--- a/docs/source/python/api/arrays.rst
+++ b/docs/source/python/api/arrays.rst
@@ -91,7 +91,6 @@ may expose data type-specific methods or properties.
    Bool8Array
    Decimal256Array
 
-
 .. _api.scalar:
 
 Scalars

--- a/docs/source/python/api/arrays.rst
+++ b/docs/source/python/api/arrays.rst
@@ -86,6 +86,11 @@ may expose data type-specific methods or properties.
    ExtensionArray
    FixedShapeTensorArray
    OpaqueArray
+   JsonArray
+   UuidArray
+   Bool8Array
+   Decimal256Array
+
 
 .. _api.scalar:
 

--- a/docs/source/python/api/arrays.rst
+++ b/docs/source/python/api/arrays.rst
@@ -116,6 +116,7 @@ classes may expose data type-specific methods or properties.
    Int16Scalar
    Int32Scalar
    Int64Scalar
+   NullScalar
    UInt8Scalar
    UInt16Scalar
    UInt32Scalar
@@ -138,9 +139,11 @@ classes may expose data type-specific methods or properties.
    DurationScalar
    MonthDayNanoIntervalScalar
    Decimal128Scalar
+   Decimal256Scalar
    DictionaryScalar
    RunEndEncodedScalar
    ListScalar
+   FixedSizeListScalar
    LargeListScalar
    ListViewScalar
    LargeListViewScalar
@@ -150,3 +153,6 @@ classes may expose data type-specific methods or properties.
    ExtensionScalar
    FixedShapeTensorScalar
    OpaqueScalar
+   JsonScalar
+   UuidScalar
+   Bool8Scalar

--- a/docs/source/python/api/datatypes.rst
+++ b/docs/source/python/api/datatypes.rst
@@ -72,6 +72,12 @@ These should be used to create Arrow data types and schemas.
    field
    schema
    from_numpy_dtype
+   bool8
+   uuid
+   json_
+   union
+   dense_union
+   sparse_union
 
 Utility Functions
 -----------------
@@ -109,6 +115,12 @@ functions above.
    Field
    Schema
    RunEndEncodedType
+   ListViewType
+   LargeListViewType
+   FixedSizeListType
+   SparseUnionType
+   DenseUnionType
+   DurationType
 
 Specific classes and functions for extension types.
 
@@ -117,6 +129,7 @@ Specific classes and functions for extension types.
 
    ExtensionType
    PyExtensionType
+   UnknownExtensionType
    register_extension_type
    unregister_extension_type
 
@@ -128,6 +141,9 @@ implemented by PyArrow.
 
    FixedShapeTensorType
    OpaqueType
+   JsonType
+   UuidType
+   Bool8Type
 
 .. _api.types.checking:
 .. currentmodule:: pyarrow.types

--- a/docs/source/python/api/datatypes.rst
+++ b/docs/source/python/api/datatypes.rst
@@ -68,16 +68,16 @@ These should be used to create Arrow data types and schemas.
    dictionary
    run_end_encoded
    fixed_shape_tensor
-   opaque
-   field
-   schema
-   from_numpy_dtype
-   bool8
-   uuid
-   json_
    union
    dense_union
    sparse_union
+   opaque
+   bool8
+   uuid
+   json_
+   field
+   schema
+   from_numpy_dtype
 
 Utility Functions
 -----------------
@@ -102,31 +102,32 @@ functions above.
    DataType
    DictionaryType
    ListType
+   ListViewType
+   FixedSizeListType
    LargeListType
+   LargeListViewType
    MapType
    StructType
    UnionType
+   DenseUnionType
+   SparseUnionType
    TimestampType
    Time32Type
    Time64Type
+   DurationType
    FixedSizeBinaryType
    Decimal128Type
    Decimal256Type
    Field
    Schema
    RunEndEncodedType
-   ListViewType
-   LargeListViewType
-   FixedSizeListType
-   SparseUnionType
-   DenseUnionType
-   DurationType
 
 Specific classes and functions for extension types.
 
 .. autosummary::
    :toctree: ../generated/
 
+   BaseExtensionType
    ExtensionType
    PyExtensionType
    UnknownExtensionType


### PR DESCRIPTION
Some of the canonical extension types which are implemented in PyArrow missing from the PyArrow arrays and datatypes docs pages have been added like JSON, UUID, Decimal256 and Bool8.
* GitHub Issue: #44711