### PR TITLE
GH-15233: [C++] Fix CopyFiles when destination is a FileSystem with background_writes

### DIFF
--- a/cpp/src/arrow/filesystem/filesystem.cc
+++ b/cpp/src/arrow/filesystem/filesystem.cc
@@ -630,9 +630,12 @@ Status CopyFiles(const std::vector<FileLocator>& sources,
                            destinations.size(), " paths.");
   }
 
-  auto copy_one_file = [&](int i) {
-    if (sources[i].filesystem->Equals(destinations[i].filesystem)) {
-      return sources[i].filesystem->CopyFile(sources[i].path, destinations[i].path);
+  auto copy_one_file = [&](size_t i,
+                           const FileLocator& source_file_locator) -> Result<Future<>> {
+    if (source_file_locator.filesystem->Equals(destinations[i].filesystem)) {
+      RETURN_NOT_OK(source_file_locator.filesystem->CopyFile(source_file_locator.path,
+                                                             destinations[i].path));
+      return Future<>::MakeFinished();
     }
 
     ARROW_ASSIGN_OR_RAISE(auto source,
@@ -642,12 +645,26 @@ Status CopyFiles(const std::vector<FileLocator>& sources,
     ARROW_ASSIGN_OR_RAISE(auto destination, destinations[i].filesystem->OpenOutputStream(
                                                 destinations[i].path, metadata));
     RETURN_NOT_OK(internal::CopyStream(source, destination, chunk_size, io_context));
-    return destination->Close();
+    // Using the blocking Close() here can cause reduced performance and deadlocks because
+    // FileSystem implementations that implement background_writes need to queue and wait
+    // for other IO thread(s). There is a risk that most or all the threads in the IO
+    // thread pool are blocking on a call Close(), leaving no IO threads left to actually
+    // fulfil the background writes.
+    return destination->CloseAsync();
   };
 
-  return ::arrow::internal::OptionalParallelFor(
-      use_threads, static_cast<int>(sources.size()), std::move(copy_one_file),
-      io_context.executor());
+  auto future = ::arrow::internal::OptionalParallelForAsync(
+      use_threads, sources, std::move(copy_one_file), io_context.executor());
+
+  // Wait for all the copy_one_file instances to complete.
+  ARROW_ASSIGN_OR_RAISE(auto copy_close_async_future, future.result());
+
+  // Wait for all the futures returned by copy_one_file to complete. When the destination
+  // filesystem uses background_writes this is when most of the upload happens.
+  for (const auto& result : copy_close_async_future) {
+    result.Wait();
+  }
+  return Status::OK();
 }
 
 Status CopyFiles(const std::shared_ptr<FileSystem>& source_fs,

--- a/cpp/src/arrow/filesystem/test_util.cc
+++ b/cpp/src/arrow/filesystem/test_util.cc
@@ -578,6 +578,62 @@ void GenericFileSystemTest::TestCopyFile(FileSystem* fs) {
   AssertAllFiles(fs, {"AB/abc", "EF/ghi", "def"});
 }
 
+void GenericFileSystemTest::TestCopyFiles(FileSystem* fs) {
+  auto originalThreads = io::GetIOThreadPoolCapacity();
+  // Needs to be smaller than the number of files we test with to catch GH-15233
+  ASSERT_OK(io::SetIOThreadPoolCapacity(2));
+  // Ensure the thread pool capacity is set back to the original value after the test
+  auto resetThreadPool = [originalThreads](void*) {
+    ASSERT_OK(io::SetIOThreadPoolCapacity(originalThreads));
+  };
+  std::unique_ptr<void, decltype(resetThreadPool)> resetThreadPoolGuard(nullptr,
+                                                                        resetThreadPool);
+
+  auto mock_fs = std::make_shared<arrow::fs::internal::MockFileSystem>(
+      std::chrono::system_clock::now());
+  std::shared_ptr<FileSystem> shared_ptr_fs(fs, [](FileSystem*) {});
+
+  std::vector<std::string> dirs0{"0", "0/AB", "0/AB/CD"};
+  std::map<std::string, std::string> files0{
+      {"0/123", "123 data"}, {"0/AB/abc", "abc data"}, {"0/AB/CD/def", "def data"}};
+
+  std::vector<std::string> dirs0and1{"0", "0/AB", "0/AB/CD", "1", "1/AB", "1/AB/CD"};
+  std::map<std::string, std::string> files0and1{
+      {"0/123", "123 data"}, {"0/AB/abc", "abc data"}, {"0/AB/CD/def", "def data"},
+      {"1/123", "123 data"}, {"1/AB/abc", "abc data"}, {"1/AB/CD/def", "def data"}};
+
+  ASSERT_OK(mock_fs->CreateDir("0/AB/CD"));
+  for (const auto& kv : files0) {
+    CreateFile(mock_fs.get(), kv.first, kv.second);
+  }
+
+  auto selector0 = arrow::fs::FileSelector{};
+  selector0.base_dir = "0";
+  selector0.recursive = true;
+
+  ASSERT_OK(CopyFiles(mock_fs, selector0, shared_ptr_fs, "0"));
+  AssertAllDirs(fs, dirs0);
+  for (const auto& kv : files0) {
+    AssertFileContents(fs, kv.first, kv.second);
+  }
+
+  ASSERT_OK(CopyFiles(shared_ptr_fs, selector0, shared_ptr_fs, "1"));
+  AssertAllDirs(fs, dirs0and1);
+  for (const auto& kv : files0and1) {
+    AssertFileContents(fs, kv.first, kv.second);
+  }
+
+  auto selector1 = arrow::fs::FileSelector{};
+  selector1.base_dir = "1";
+  selector1.recursive = true;
+
+  ASSERT_OK(CopyFiles(shared_ptr_fs, selector1, mock_fs, "1"));
+  AssertAllDirs(mock_fs.get(), dirs0and1);
+  for (const auto& kv : files0and1) {
+    AssertFileContents(mock_fs.get(), kv.first, kv.second);
+  }
+}
+
 void GenericFileSystemTest::TestGetFileInfo(FileSystem* fs) {
   ASSERT_OK(fs->CreateDir("AB/CD/EF"));
   CreateFile(fs, "AB/CD/ghi", "some data");
@@ -1212,6 +1268,7 @@ GENERIC_FS_TEST_DEFINE(TestDeleteFiles)
 GENERIC_FS_TEST_DEFINE(TestMoveFile)
 GENERIC_FS_TEST_DEFINE(TestMoveDir)
 GENERIC_FS_TEST_DEFINE(TestCopyFile)
+GENERIC_FS_TEST_DEFINE(TestCopyFiles)
 GENERIC_FS_TEST_DEFINE(TestGetFileInfo)
 GENERIC_FS_TEST_DEFINE(TestGetFileInfoVector)
 GENERIC_FS_TEST_DEFINE(TestGetFileInfoSelector)

--- a/cpp/src/arrow/filesystem/test_util.cc
+++ b/cpp/src/arrow/filesystem/test_util.cc
@@ -593,7 +593,7 @@ void GenericFileSystemTest::TestCopyFiles(FileSystem* fs) {
   auto reset_thread_pool = [io_thread_pool, original_threads](void*) {
     ASSERT_OK(io_thread_pool->SetCapacity(original_threads));
   };
-  std::unique_ptr<void, decltype(reset_thread_pool)> resetThreadPoolGuard(
+  std::unique_ptr<void, decltype(reset_thread_pool)> reset_thread_pool_guard(
       nullptr, reset_thread_pool);
 
   auto mock_fs = std::make_shared<arrow::fs::internal::MockFileSystem>(

--- a/cpp/src/arrow/filesystem/test_util.cc
+++ b/cpp/src/arrow/filesystem/test_util.cc
@@ -579,6 +579,11 @@ void GenericFileSystemTest::TestCopyFile(FileSystem* fs) {
 }
 
 void GenericFileSystemTest::TestCopyFiles(FileSystem* fs) {
+#if defined(ADDRESS_SANITIZER) || defined(ARROW_VALGRIND)
+  if (have_false_positive_memory_leak_with_async_close()) {
+    GTEST_SKIP() << "Filesystem have false positive memory leak with generator";
+  }
+#endif
   auto originalThreads = io::GetIOThreadPoolCapacity();
   // Needs to be smaller than the number of files we test with to catch GH-15233
   ASSERT_OK(io::SetIOThreadPoolCapacity(2));

--- a/cpp/src/arrow/filesystem/test_util.h
+++ b/cpp/src/arrow/filesystem/test_util.h
@@ -140,6 +140,7 @@ class ARROW_TESTING_EXPORT GenericFileSystemTest {
   void TestMoveFile();
   void TestMoveDir();
   void TestCopyFile();
+  void TestCopyFiles();
   void TestGetFileInfo();
   void TestGetFileInfoVector();
   void TestGetFileInfoSelector();
@@ -201,6 +202,7 @@ class ARROW_TESTING_EXPORT GenericFileSystemTest {
   void TestMoveFile(FileSystem* fs);
   void TestMoveDir(FileSystem* fs);
   void TestCopyFile(FileSystem* fs);
+  void TestCopyFiles(FileSystem* fs);
   void TestGetFileInfo(FileSystem* fs);
   void TestGetFileInfoVector(FileSystem* fs);
   void TestGetFileInfoSelector(FileSystem* fs);
@@ -233,6 +235,7 @@ class ARROW_TESTING_EXPORT GenericFileSystemTest {
   GENERIC_FS_TEST_FUNCTION(TEST_MACRO, TEST_CLASS, MoveFile)                         \
   GENERIC_FS_TEST_FUNCTION(TEST_MACRO, TEST_CLASS, MoveDir)                          \
   GENERIC_FS_TEST_FUNCTION(TEST_MACRO, TEST_CLASS, CopyFile)                         \
+  GENERIC_FS_TEST_FUNCTION(TEST_MACRO, TEST_CLASS, CopyFiles)                        \
   GENERIC_FS_TEST_FUNCTION(TEST_MACRO, TEST_CLASS, GetFileInfo)                      \
   GENERIC_FS_TEST_FUNCTION(TEST_MACRO, TEST_CLASS, GetFileInfoVector)                \
   GENERIC_FS_TEST_FUNCTION(TEST_MACRO, TEST_CLASS, GetFileInfoSelector)              \

--- a/cpp/src/arrow/filesystem/test_util.h
+++ b/cpp/src/arrow/filesystem/test_util.h
@@ -190,6 +190,8 @@ class ARROW_TESTING_EXPORT GenericFileSystemTest {
   virtual bool have_file_metadata() const { return false; }
   // - Whether the filesystem has a false positive memory leak with generator
   virtual bool have_false_positive_memory_leak_with_generator() const { return false; }
+  // - Whether the filesystem has a false positive memory leak in async close
+  virtual bool have_false_positive_memory_leak_with_async_close() const { return false; }
 
   void TestEmpty(FileSystem* fs);
   void TestNormalizePath(FileSystem* fs);

--- a/cpp/src/arrow/io/interfaces.cc
+++ b/cpp/src/arrow/io/interfaces.cc
@@ -68,8 +68,8 @@ Status SetIOThreadPoolCapacity(int threads) {
 FileInterface::~FileInterface() = default;
 
 Future<> FileInterface::CloseAsync() {
-  return DeferNotOk(
-      default_io_context().executor()->Submit([this]() { return Close(); }));
+  return DeferNotOk(default_io_context().executor()->Submit(
+      [self = shared_from_this()]() { return self->Close(); }));
 }
 
 Status FileInterface::Abort() { return Close(); }

--- a/cpp/src/arrow/util/parallel.h
+++ b/cpp/src/arrow/util/parallel.h
@@ -48,12 +48,13 @@ Status ParallelFor(int num_tasks, FUNCTION&& func,
 
 template <class FUNCTION, typename T,
           typename R = typename internal::call_traits::return_type<FUNCTION>::ValueType>
-Future<std::vector<R>> ParallelForAsync(
-    std::vector<T> inputs, FUNCTION&& func,
-    Executor* executor = internal::GetCpuThreadPool()) {
+Future<std::vector<R>> ParallelForAsync(std::vector<T> inputs, FUNCTION&& func,
+                                        Executor* executor = internal::GetCpuThreadPool(),
+                                        TaskHints hints = TaskHints{}) {
   std::vector<Future<R>> futures(inputs.size());
   for (size_t i = 0; i < inputs.size(); ++i) {
-    ARROW_ASSIGN_OR_RAISE(futures[i], executor->Submit(func, i, std::move(inputs[i])));
+    ARROW_ASSIGN_OR_RAISE(futures[i],
+                          executor->Submit(hints, func, i, std::move(inputs[i])));
   }
   return All(std::move(futures))
       .Then([](const std::vector<Result<R>>& results) -> Result<std::vector<R>> {
@@ -86,9 +87,10 @@ template <class FUNCTION, typename T,
           typename R = typename internal::call_traits::return_type<FUNCTION>::ValueType>
 Future<std::vector<R>> OptionalParallelForAsync(
     bool use_threads, std::vector<T> inputs, FUNCTION&& func,
-    Executor* executor = internal::GetCpuThreadPool()) {
+    Executor* executor = internal::GetCpuThreadPool(), TaskHints hints = TaskHints{}) {
   if (use_threads) {
-    return ParallelForAsync(std::move(inputs), std::forward<FUNCTION>(func), executor);
+    return ParallelForAsync(std::move(inputs), std::forward<FUNCTION>(func), executor,
+                            hints);
   } else {
     std::vector<R> result(inputs.size());
     for (size_t i = 0; i < inputs.size(); ++i) {

--- a/cpp/src/arrow/util/thread_pool.cc
+++ b/cpp/src/arrow/util/thread_pool.cc
@@ -61,9 +61,8 @@ struct QueuedTask {
   // urgently.
   bool operator<(const QueuedTask& other) const {
     if (priority == other.priority) {
-      // Maintain spawn order for tasks with the same priority. TODO: Decide if this is
-      // really needed. Currently several test cases in arrow-acero-hash-aggregate-test
-      // depend on it.
+      // Maintain execution order for tasks with the same priority. Its preferable to keep
+      // the execution order of tasks deterministic.
       return spawn_index > other.spawn_index;
     }
     return priority > other.priority;

--- a/cpp/src/arrow/util/thread_pool.cc
+++ b/cpp/src/arrow/util/thread_pool.cc
@@ -61,6 +61,9 @@ struct QueuedTask {
   // urgently.
   bool operator<(const QueuedTask& other) const {
     if (hints.priority == other.hints.priority) {
+      // Maintain spawn order for tasks with the same priority. TODO: Decide if this is
+      // really needed. Currently several test cases in arrow-acero-hash-aggregate-test
+      // depend on it.
       return spawn_index > other.spawn_index;
     }
     return hints.priority > other.hints.priority;

--- a/cpp/src/arrow/util/thread_pool.cc
+++ b/cpp/src/arrow/util/thread_pool.cc
@@ -73,7 +73,7 @@ struct QueuedTask {
 
 struct SerialExecutor::State {
   std::priority_queue<QueuedTask> task_queue;
-  uint64_t spawned_tasks_count = 0;
+  uint64_t spawned_tasks_count_ = 0;
   std::mutex mutex;
   std::condition_variable wait_for_tasks;
   std::thread::id current_thread;
@@ -173,7 +173,7 @@ Status SerialExecutor::SpawnReal(TaskHints hints, FnOnce<void()> task,
     }
     state->task_queue.push(QueuedTask{std::move(task), std::move(stop_token),
                                       std::move(stop_callback), hints.priority,
-                                      state_->spawned_tasks_count++});
+                                      state_->spawned_tasks_count_++});
   }
   state->wait_for_tasks.notify_one();
   return Status::OK();
@@ -210,7 +210,7 @@ Status SerialExecutor::SpawnReal(TaskHints hints, FnOnce<void()> task,
 
   state_->task_queue.push(QueuedTask{std::move(task), std::move(stop_token),
                                      std::move(stop_callback), hints.priority,
-                                     state_->spawned_tasks_count++});
+                                     state_->spawned_tasks_count_++});
 
   return Status::OK();
 }
@@ -407,7 +407,7 @@ struct ThreadPool::State {
   // Trashcan for finished threads
   std::vector<std::thread> finished_workers_;
   std::priority_queue<QueuedTask> pending_tasks_;
-  uint64_t spawned_tasks_count = 0;
+  uint64_t spawned_tasks_count_ = 0;
 
   // Desired number of threads
   int desired_capacity_ = 0;
@@ -678,7 +678,7 @@ Status ThreadPool::SpawnReal(TaskHints hints, FnOnce<void()> task, StopToken sto
     state_->pending_tasks_.push(
         QueuedTask{{std::move(task), std::move(stop_token), std::move(stop_callback)},
                    hints.priority,
-                   state_->spawned_tasks_count++});
+                   state_->spawned_tasks_count_++});
   }
   state_->cv_.notify_one();
   return Status::OK();

--- a/cpp/src/arrow/util/thread_pool.cc
+++ b/cpp/src/arrow/util/thread_pool.cc
@@ -55,7 +55,7 @@ struct Task {
 struct QueuedTask {
   Task task;
   TaskHints hints;
-  u_int64_t spawn_index;
+  uint64_t spawn_index;
 
   // Implement comparison so that std::priority_queue will pop the low priorities more
   // urgently.

--- a/cpp/src/arrow/util/thread_pool_test.cc
+++ b/cpp/src/arrow/util/thread_pool_test.cc
@@ -580,7 +580,7 @@ TEST_F(TestThreadPool, Spawn) {
 
 TEST_F(TestThreadPool, TasksRunInPriorityOrder) {
   auto pool = this->MakeThreadPool(1);
-  constexpr int kNumTasks = 10;  
+  constexpr int kNumTasks = 10;
   auto recorded_times = std::vector<std::chrono::steady_clock::time_point>(kNumTasks);
   auto futures = std::vector<Future<int>>(kNumTasks);
   auto sleep_task = []() { SleepABit(); };
@@ -609,7 +609,7 @@ TEST_F(TestThreadPool, TasksRunInPriorityOrder) {
 
 TEST_F(TestThreadPool, TasksOfEqualPriorityRunInSpawnOrder) {
   auto pool = this->MakeThreadPool(1);
-  constexpr int kNumTasks = 10; 
+  constexpr int kNumTasks = 10;
   auto recorded_times = std::vector<std::chrono::steady_clock::time_point>(kNumTasks);
   auto futures = std::vector<Future<int>>(kNumTasks);
 

--- a/cpp/src/arrow/util/thread_pool_test.cc
+++ b/cpp/src/arrow/util/thread_pool_test.cc
@@ -601,7 +601,7 @@ TEST_F(TestThreadPool, TasksRunInPriorityOrder) {
 
   ASSERT_OK(pool->Shutdown());
 
-  for (size_t i = 1; i < recorded_times.size(); ++i) {
+  for (size_t i = 1; i < kNumTasks; ++i) {
     ASSERT_GE(recorded_times[i - 1], recorded_times[i]);
     ASSERT_LT(futures[i - 1].result().ValueOrDie(), futures[i].result().ValueOrDie());
   }
@@ -623,7 +623,7 @@ TEST_F(TestThreadPool, TasksOfEqualPriorityRunInSpawnOrder) {
 
   ASSERT_OK(pool->Shutdown());
 
-  for (size_t i = 1; i < recorded_times.size(); ++i) {
+  for (size_t i = 1; i < kNumTasks; ++i) {
     ASSERT_LE(recorded_times[i - 1], recorded_times[i]);
     ASSERT_LT(futures[i - 1].result().ValueOrDie(), futures[i].result().ValueOrDie());
   }


### PR DESCRIPTION
### Rationale for this change
Currently it deadlocks when trying to upload more files than we have IO threads. 

### What changes are included in this PR?
1. Use CloseAsync() inside copy_one_file so that it returns futures, instead of blocking while it waits for other tasks to complete. This avoids the deadlock.
1. Fix a segfault in FileInterface::CloseAsync() by using shared_from_this() to so that it doesn't get destructed prematurely. shared_from_this() is already used in the CloseAsync() implementation on several filesystems. After change 1 this is important when downloading to the local filesystem using CopyFiles.
1. Spawn `copy_one_file` less urgently than default, so that `background_writes` are done with higher priority. Otherwise `copy_one_file` will keep buffering more data in memory without giving the `background_writes` any chance to upload the data and drop it from memory. Therefore, without this large copies would cause OOMs.
   1. The current Arrow thread pool implementation makes provision for spawning with a set priority but the priority numbers are just ignored.
   1. I made a small change to use a `std::priority_queue` to implement the priority.
   1. There is a property of the current implementation that tasks will be scheduled in the order of calls to Spawn. There are also a few test cases in `arrow-acero-hash-aggregate-test` that fail if this property is not maintained. I'm not sure what is the correct option but for now I have ensured that tasks of the same priority are run in the order they are spawned.
   1. I think this has got to be the most contentious part of the change, with the broadest possible impact if I introduce a bug. I would appreciate some input on whether this seems like a reasonable change and I'm very happy to move it to a separate PR and/or discuss further. 

### Are these changes tested?
Added some extra automated tests. I also ran some large scale tests copying between Azure and local with a directory of about 50,000 files of varying sizes totalling 160GiB.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?
1. `CopyFiles` should now work reliably
2. `ThreadPool` now runs tasks in priority order

* GitHub Issue: #15233