### PR TITLE
GH-44915: [C++] Add WithinUlp testing functions

### DIFF
--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -674,6 +674,7 @@ set(ARROW_TESTING_SRCS
     testing/fixed_width_test_util.cc
     testing/generator.cc
     testing/gtest_util.cc
+    testing/math.cc
     testing/process.cc
     testing/random.cc
     testing/util.cc)

--- a/cpp/src/arrow/testing/gtest_util_test.cc
+++ b/cpp/src/arrow/testing/gtest_util_test.cc
@@ -176,8 +176,14 @@ TEST_F(TestTensorFromJSON, FromJSON) {
 
 template <typename Float>
 void CheckWithinUlpSingle(Float x, Float y, int n_ulp) {
-  ARROW_SCOPED_TRACE("x = ", x, ", y = ", x, ", n_ulp = ", n_ulp);
+  ARROW_SCOPED_TRACE("x = ", x, ", y = ", y, ", n_ulp = ", n_ulp);
   ASSERT_TRUE(WithinUlp(x, y, n_ulp));
+}
+
+template <typename Float>
+void CheckNotWithinUlpSingle(Float x, Float y, int n_ulp) {
+  ARROW_SCOPED_TRACE("x = ", x, ", y = ", y, ", n_ulp = ", n_ulp);
+  ASSERT_FALSE(WithinUlp(x, y, n_ulp));
 }
 
 template <typename Float>
@@ -186,6 +192,8 @@ void CheckWithinUlp(Float x, Float y, int n_ulp) {
   CheckWithinUlpSingle(y, x, n_ulp);
   CheckWithinUlpSingle(x, y, n_ulp + 1);
   CheckWithinUlpSingle(y, x, n_ulp + 1);
+  CheckWithinUlpSingle(-x, -y, n_ulp);
+  CheckWithinUlpSingle(-y, -x, n_ulp);
 
   for (int exp : {1, -1, 10, -10}) {
     Float x_scaled = std::ldexp(x, exp);
@@ -197,19 +205,20 @@ void CheckWithinUlp(Float x, Float y, int n_ulp) {
 
 template <typename Float>
 void CheckNotWithinUlp(Float x, Float y, int n_ulp) {
-  ARROW_SCOPED_TRACE("x = ", x, ", y = ", x, ", n_ulp = ", n_ulp);
-  ASSERT_FALSE(WithinUlp(x, y, n_ulp));
-  ASSERT_FALSE(WithinUlp(y, x, n_ulp));
+  CheckNotWithinUlpSingle(x, y, n_ulp);
+  CheckNotWithinUlpSingle(y, x, n_ulp);
   if (n_ulp > 1) {
-    ASSERT_FALSE(WithinUlp(x, y, n_ulp - 1));
-    ASSERT_FALSE(WithinUlp(y, x, n_ulp - 1));
+    CheckNotWithinUlpSingle(x, y, n_ulp - 1);
+    CheckNotWithinUlpSingle(y, x, n_ulp - 1);
   }
+  CheckNotWithinUlpSingle(-x, -y, n_ulp);
+  CheckNotWithinUlpSingle(-y, -x, n_ulp);
 
   for (int exp : {1, -1, 10, -10}) {
     Float x_scaled = std::ldexp(x, exp);
     Float y_scaled = std::ldexp(y, exp);
-    ASSERT_FALSE(WithinUlp(x_scaled, y_scaled, n_ulp));
-    ASSERT_FALSE(WithinUlp(y_scaled, x_scaled, n_ulp));
+    CheckNotWithinUlpSingle(x_scaled, y_scaled, n_ulp);
+    CheckNotWithinUlpSingle(y_scaled, x_scaled, n_ulp);
   }
 }
 
@@ -218,6 +227,7 @@ TEST(TestWithinUlp, Double) {
     CheckWithinUlp(f, f, 1);
     CheckWithinUlp(f, f, 42);
   }
+  CheckWithinUlp(-0.0, 0.0, 1);
   CheckWithinUlp(1.0, 1.0000000000000002, 1);
   CheckWithinUlp(1.0, 1.0000000000000007, 3);
   CheckNotWithinUlp(1.0, 1.0000000000000007, 2);
@@ -233,6 +243,23 @@ TEST(TestWithinUlp, Double) {
   CheckNotWithinUlp(0.0, 1e-20, 10);
 }
 
-// TODO float tests
+TEST(TestWithinUlp, Float) {
+  for (float f : {0.0f, 1e-8f, 1.0f, 123.456f}) {
+    CheckWithinUlp(f, f, 1);
+    CheckWithinUlp(f, f, 42);
+  }
+  CheckWithinUlp(-0.0f, 0.0f, 1);
+  CheckWithinUlp(1.0f, 1.0000001f, 1);
+  CheckWithinUlp(1.0f, 1.0000013f, 11);
+  CheckNotWithinUlp(1.0f, 1.0000013f, 10);
+
+  CheckWithinUlp(123.456f, 123.456085f, 11);
+  CheckNotWithinUlp(123.456f, 123.456085f, 10);
+
+  CheckNotWithinUlp(HUGE_VALF, -HUGE_VALF, 10);
+  CheckNotWithinUlp(12.34f, -HUGE_VALF, 10);
+  CheckNotWithinUlp(12.34f, std::nanf(""), 10);
+  CheckNotWithinUlp(12.34f, -12.34f, 10);
+}
 
 }  // namespace arrow

--- a/cpp/src/arrow/testing/gtest_util_test.cc
+++ b/cpp/src/arrow/testing/gtest_util_test.cc
@@ -233,6 +233,10 @@ TEST(TestWithinUlp, Double) {
   CheckWithinUlp(1.0, 1.0000000000000007, 3);
   CheckNotWithinUlp(1.0, 1.0000000000000007, 2);
   CheckNotWithinUlp(1.0, 1.0000000000000007, 1);
+  // left and right have a different exponent but are still very close
+  CheckWithinUlp(1.0, 0.9999999999999999, 1);
+  CheckWithinUlp(1.0, 0.9999999999999988, 11);
+  CheckNotWithinUlp(1.0, 0.9999999999999988, 10);
 
   CheckWithinUlp(123.4567, 123.45670000000015, 11);
   CheckNotWithinUlp(123.4567, 123.45670000000015, 10);
@@ -253,6 +257,10 @@ TEST(TestWithinUlp, Float) {
   CheckWithinUlp(1.0f, 1.0000001f, 1);
   CheckWithinUlp(1.0f, 1.0000013f, 11);
   CheckNotWithinUlp(1.0f, 1.0000013f, 10);
+  // left and right have a different exponent but are still very close
+  CheckWithinUlp(1.0f, 0.99999994f, 1);
+  CheckWithinUlp(1.0f, 0.99999934f, 11);
+  CheckNotWithinUlp(1.0f, 0.99999934f, 10);
 
   CheckWithinUlp(123.456f, 123.456085f, 11);
   CheckNotWithinUlp(123.456f, 123.456085f, 10);

--- a/cpp/src/arrow/testing/gtest_util_test.cc
+++ b/cpp/src/arrow/testing/gtest_util_test.cc
@@ -208,12 +208,14 @@ template <typename Float>
 void CheckNotWithinUlp(Float x, Float y, int n_ulp) {
   CheckNotWithinUlpSingle(x, y, n_ulp);
   CheckNotWithinUlpSingle(y, x, n_ulp);
+  CheckNotWithinUlpSingle(-x, -y, n_ulp);
+  CheckNotWithinUlpSingle(-y, -x, n_ulp);
   if (n_ulp > 1) {
     CheckNotWithinUlpSingle(x, y, n_ulp - 1);
     CheckNotWithinUlpSingle(y, x, n_ulp - 1);
+    CheckNotWithinUlpSingle(-x, -y, n_ulp - 1);
+    CheckNotWithinUlpSingle(-y, -x, n_ulp - 1);
   }
-  CheckNotWithinUlpSingle(-x, -y, n_ulp);
-  CheckNotWithinUlpSingle(-y, -x, n_ulp);
 
   for (int exp : {1, -1, 10, -10}) {
     Float x_scaled = std::ldexp(x, exp);

--- a/cpp/src/arrow/testing/gtest_util_test.cc
+++ b/cpp/src/arrow/testing/gtest_util_test.cc
@@ -233,4 +233,6 @@ TEST(TestWithinUlp, Double) {
   CheckNotWithinUlp(0.0, 1e-20, 10);
 }
 
+// TODO float tests
+
 }  // namespace arrow

--- a/cpp/src/arrow/testing/gtest_util_test.cc
+++ b/cpp/src/arrow/testing/gtest_util_test.cc
@@ -17,6 +17,7 @@
 
 #include <cmath>
 
+#include <gtest/gtest-spi.h>
 #include <gtest/gtest.h>
 
 #include "arrow/array.h"
@@ -260,6 +261,14 @@ TEST(TestWithinUlp, Float) {
   CheckNotWithinUlp(12.34f, -HUGE_VALF, 10);
   CheckNotWithinUlp(12.34f, std::nanf(""), 10);
   CheckNotWithinUlp(12.34f, -12.34f, 10);
+}
+
+TEST(AssertTestWithinUlp, Basics) {
+  AssertWithinUlp(123.4567, 123.45670000000015, 11);
+  AssertWithinUlp(123.456f, 123.456085f, 11);
+  EXPECT_FATAL_FAILURE(AssertWithinUlp(123.4567, 123.45670000000015, 10),
+                       "not within 10 ulps");
+  EXPECT_FATAL_FAILURE(AssertWithinUlp(123.456f, 123.456085f, 10), "not within 10 ulps");
 }
 
 }  // namespace arrow

--- a/cpp/src/arrow/testing/math.cc
+++ b/cpp/src/arrow/testing/math.cc
@@ -20,7 +20,10 @@
 #include <cmath>
 #include <limits>
 
+#include <gtest/gtest.h>
+
 #include "arrow/util/logging.h"
+#include "arrow/util/string_builder.h"
 
 namespace arrow {
 namespace {
@@ -64,6 +67,15 @@ bool WithinUlpGeneric(Float left, Float right, int n_ulp) {
   return WithinUlpOneWay(left, right, n_ulp) || WithinUlpOneWay(right, left, n_ulp);
 }
 
+template <typename Float>
+void AssertWithinUlpGeneric(Float left, Float right, int n_ulp) {
+  if (!WithinUlpGeneric(left, right, n_ulp)) {
+    FAIL() << left << " and " << right << " are not within " << n_ulp << " ulps";
+    //     FAIL << StringBuilder(left, " and ", right, " are not within ", n_ulp, "
+    //     ulps");
+  }
+}
+
 }  // namespace
 
 bool WithinUlp(float left, float right, int n_ulp) {
@@ -72,6 +84,14 @@ bool WithinUlp(float left, float right, int n_ulp) {
 
 bool WithinUlp(double left, double right, int n_ulp) {
   return WithinUlpGeneric(left, right, n_ulp);
+}
+
+void AssertWithinUlp(float left, float right, int n_ulps) {
+  AssertWithinUlpGeneric(left, right, n_ulps);
+}
+
+void AssertWithinUlp(double left, double right, int n_ulps) {
+  AssertWithinUlpGeneric(left, right, n_ulps);
 }
 
 }  // namespace arrow

--- a/cpp/src/arrow/testing/math.cc
+++ b/cpp/src/arrow/testing/math.cc
@@ -27,6 +27,9 @@
 namespace arrow {
 namespace {
 
+// `kOneUlp` is equal to 1.0 - (1.0 - nextafter(1.0, -inf)).
+// That is, it is the delta between 1.0 and the FP value immediately before 1.0.
+// We're using this value because `frexp` returns a mantissa between 0.5 and 1.0.
 template <typename Float>
 constexpr Float kOneUlp;
 template <>

--- a/cpp/src/arrow/testing/math.cc
+++ b/cpp/src/arrow/testing/math.cc
@@ -27,8 +27,8 @@
 namespace arrow {
 namespace {
 
-// `kOneUlp` is equal to 1.0 - (1.0 - nextafter(1.0, -inf)).
-// That is, it is the delta between 1.0 and the FP value immediately before 1.0.
+// `kOneUlp` is equal to 1.0 - nextafter(1.0, -inf).
+// That is, it is the delta between 1.0 and the FP value immediately before it.
 // We're using this value because `frexp` returns a mantissa between 0.5 and 1.0.
 template <typename Float>
 constexpr Float kOneUlp;

--- a/cpp/src/arrow/testing/math.cc
+++ b/cpp/src/arrow/testing/math.cc
@@ -23,7 +23,6 @@
 #include <gtest/gtest.h>
 
 #include "arrow/util/logging.h"
-#include "arrow/util/string_builder.h"
 
 namespace arrow {
 namespace {
@@ -71,8 +70,6 @@ template <typename Float>
 void AssertWithinUlpGeneric(Float left, Float right, int n_ulp) {
   if (!WithinUlpGeneric(left, right, n_ulp)) {
     FAIL() << left << " and " << right << " are not within " << n_ulp << " ulps";
-    //     FAIL << StringBuilder(left, " and ", right, " are not within ", n_ulp, "
-    //     ulps");
   }
 }
 

--- a/cpp/src/arrow/testing/math.cc
+++ b/cpp/src/arrow/testing/math.cc
@@ -63,7 +63,8 @@ bool WithinUlpGeneric(Float left, Float right, int n_ulp) {
   if (!std::isfinite(left) || !std::isfinite(right)) {
     return left == right;
   }
-  return WithinUlpOneWay(left, right, n_ulp) || WithinUlpOneWay(right, left, n_ulp);
+  return (std::abs(left) <= std::abs(right)) ? WithinUlpOneWay(left, right, n_ulp)
+                                             : WithinUlpOneWay(right, left, n_ulp);
 }
 
 template <typename Float>

--- a/cpp/src/arrow/testing/math.cc
+++ b/cpp/src/arrow/testing/math.cc
@@ -30,7 +30,7 @@ constexpr Float kOneUlp;
 template <>
 constexpr float kOneUlp<float> = 5.9604645e-08f;
 template <>
-constexpr float kOneUlp<double> = 1.1102230246251565e-16;
+constexpr double kOneUlp<double> = 1.1102230246251565e-16;
 
 template <typename Float>
 bool WithinUlpOneWay(Float left, Float right, int n_ulp) {

--- a/cpp/src/arrow/testing/math.cc
+++ b/cpp/src/arrow/testing/math.cc
@@ -1,0 +1,77 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/testing/math.h"
+
+#include <cmath>
+#include <limits>
+
+#include "arrow/util/logging.h"
+
+namespace arrow {
+namespace {
+
+template <typename Float>
+constexpr Float kOneUlp;
+template <>
+constexpr float kOneUlp<float> = 5.9604645e-08f;
+template <>
+constexpr float kOneUlp<double> = 1.1102230246251565e-16;
+
+template <typename Float>
+bool WithinUlpOneWay(Float left, Float right, int n_ulp) {
+  // Ideally these would be compile-time (constexpr) checks
+  DCHECK_LT(Float(1.0) - kOneUlp<Float>, Float(1.0));
+  DCHECK_EQ(std::nextafter(Float(1.0) - kOneUlp<Float>, Float(1.0)), Float(1.0));
+
+  DCHECK_GE(n_ulp, 1);
+
+  if (left == 0) {
+    return left == right;
+  }
+  if (left < 0) {
+    left = -left;
+    right = -right;
+  }
+
+  int left_exp;
+  Float left_mant = std::frexp(left, &left_exp);
+  Float delta = static_cast<Float>(n_ulp) * kOneUlp<Float>;
+  Float lower_bound = std::ldexp(left_mant - delta, left_exp);
+  Float upper_bound = std::ldexp(left_mant + delta, left_exp);
+  return right >= lower_bound && right <= upper_bound;
+}
+
+template <typename Float>
+bool WithinUlpGeneric(Float left, Float right, int n_ulp) {
+  if (!std::isfinite(left) || !std::isfinite(right)) {
+    return left == right;
+  }
+  return WithinUlpOneWay(left, right, n_ulp) || WithinUlpOneWay(right, left, n_ulp);
+}
+
+}  // namespace
+
+bool WithinUlp(float left, float right, int n_ulp) {
+  return WithinUlpGeneric(left, right, n_ulp);
+}
+
+bool WithinUlp(double left, double right, int n_ulp) {
+  return WithinUlpGeneric(left, right, n_ulp);
+}
+
+}  // namespace arrow

--- a/cpp/src/arrow/testing/math.h
+++ b/cpp/src/arrow/testing/math.h
@@ -23,8 +23,12 @@ namespace arrow {
 
 ARROW_TESTING_EXPORT
 bool WithinUlp(float left, float right, int n_ulp);
-
 ARROW_TESTING_EXPORT
 bool WithinUlp(double left, double right, int n_ulp);
+
+ARROW_TESTING_EXPORT
+void AssertWithinUlp(float left, float right, int n_ulps);
+ARROW_TESTING_EXPORT
+void AssertWithinUlp(double left, double right, int n_ulps);
 
 }  // namespace arrow

--- a/cpp/src/arrow/testing/math.h
+++ b/cpp/src/arrow/testing/math.h
@@ -1,0 +1,30 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "arrow/testing/visibility.h"
+
+namespace arrow {
+
+ARROW_TESTING_EXPORT
+bool WithinUlp(float left, float right, int n_ulp);
+
+ARROW_TESTING_EXPORT
+bool WithinUlp(double left, double right, int n_ulp);
+
+}  // namespace arrow

--- a/cpp/src/arrow/util/string_builder.h
+++ b/cpp/src/arrow/util/string_builder.h
@@ -20,6 +20,7 @@
 #include <memory>
 #include <ostream>
 #include <string>
+#include <type_traits>
 #include <utility>
 
 #include "arrow/util/visibility.h"
@@ -46,7 +47,12 @@ class ARROW_EXPORT StringStreamWrapper {
 
 template <typename Head>
 void StringBuilderRecursive(std::ostream& stream, Head&& head) {
-  stream << head;
+  if constexpr (std::is_floating_point_v<std::decay_t<Head>>) {
+    // Avoid losing precision when printing floating point numbers
+    stream << std::to_string(head);
+  } else {
+    stream << head;
+  }
 }
 
 template <typename Head, typename... Tail>


### PR DESCRIPTION
### Rationale for this change

When testing math-related functions, we might want to check that some results are very close to an expected value, but not necessarily exactly equal.

### What changes are included in this PR?

Add functions that test whether two floating-point values are within N ulps.

("ulp" stands for "unit in the last place": https://en.wikipedia.org/wiki/Unit_in_the_last_place)

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Potentially more useful error messages.

* GitHub Issue: #44915