### PR TITLE
GH-44911: [C#] Choose port numbers dynamically for ArrowStreamWriterTests

### DIFF
--- a/csharp/test/Apache.Arrow.Tests/ArrowStreamWriterTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/ArrowStreamWriterTests.cs
@@ -57,14 +57,15 @@ namespace Apache.Arrow.Tests
         }
 
         [Theory]
-        [InlineData(true, 32153)]
-        [InlineData(false, 32154)]
-        public void CanWriteToNetworkStream(bool createDictionaryArray, int port)
+        [InlineData(true)]
+        [InlineData(false)]
+        public void CanWriteToNetworkStream(bool createDictionaryArray)
         {
             RecordBatch originalBatch = TestData.CreateSampleRecordBatch(length: 100, createDictionaryArray: createDictionaryArray);
 
-            TcpListener listener = new TcpListener(IPAddress.Loopback, port);
+            TcpListener listener = new TcpListener(IPAddress.Loopback, 0);
             listener.Start();
+            int port = ((IPEndPoint)listener.LocalEndpoint).Port;
 
             using (TcpClient sender = new TcpClient())
             {
@@ -92,14 +93,15 @@ namespace Apache.Arrow.Tests
         }
 
         [Theory]
-        [InlineData(true, 32155)]
-        [InlineData(false, 32156)]
-        public async Task CanWriteToNetworkStreamAsync(bool createDictionaryArray, int port)
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task CanWriteToNetworkStreamAsync(bool createDictionaryArray)
         {
             RecordBatch originalBatch = TestData.CreateSampleRecordBatch(length: 100, createDictionaryArray: createDictionaryArray);
 
-            TcpListener listener = new TcpListener(IPAddress.Loopback, port);
+            TcpListener listener = new TcpListener(IPAddress.Loopback, 0);
             listener.Start();
+            int port = ((IPEndPoint)listener.LocalEndpoint).Port;
 
             using (TcpClient sender = new TcpClient())
             {


### PR DESCRIPTION
### What changes are included in this PR?

`ArrowStreamWriterTests.CanWriteToNetworkStream` and `ArrowStreamWriterTests.CanWriteToNetworkStreamAsync` pick ports dynamically instead of hardcoding a static port.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.

Resolves #44911.
* GitHub Issue: #44911