### PR TITLE
GH-44934: [Dev] Remove JIRA remnants

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -45,8 +45,8 @@ issues][3] for the Apache Arrow project. Comment on the issue and/or contact
 [dev@arrow.apache.org](https://lists.apache.org/list.html?dev@arrow.apache.org)
 with your questions and ideas.
 
-If you’d like to report a bug but don’t have time to fix it, you can still post
-it on JIRA, or email the mailing list
+If you’d like to report a bug but don’t have time to fix it, you can still create
+a GitHub issue, or email the mailing list
 [dev@arrow.apache.org](https://lists.apache.org/list.html?dev@arrow.apache.org)
 
 To contribute a patch:
@@ -57,8 +57,8 @@ harder to merge in a large change with a lot of disjoint features.
 GitHub](https://github.com/apache/arrow/issues).
 3. Submit the patch as a GitHub pull request against the main branch. For a
 tutorial, see the GitHub guides on [forking a repo](https://help.github.com/en/articles/fork-a-repo)
-and [sending a pull request](https://help.github.com/en/articles/creating-a-pull-request-from-a-fork). So that your pull request syncs with the JIRA issue, prefix your pull request
-name with the JIRA issue id (ex: [ARROW-767: [C++] Filesystem abstraction](https://github.com/apache/arrow/pull/4225))
+and [sending a pull request](https://help.github.com/en/articles/creating-a-pull-request-from-a-fork). Prefix your pull request
+name with the GitHub issue id (ex: [ARROW-767: [C++] Filesystem abstraction](https://github.com/apache/arrow/pull/4225))
 4. Make sure that your code passes the unit tests. You can find instructions
 how to run the unit tests for each Arrow component in its respective README
 file.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -58,7 +58,7 @@ GitHub](https://github.com/apache/arrow/issues).
 3. Submit the patch as a GitHub pull request against the main branch. For a
 tutorial, see the GitHub guides on [forking a repo](https://help.github.com/en/articles/fork-a-repo)
 and [sending a pull request](https://help.github.com/en/articles/creating-a-pull-request-from-a-fork). Prefix your pull request
-name with the GitHub issue id (ex: [ARROW-767: [C++] Filesystem abstraction](https://github.com/apache/arrow/pull/4225))
+name with the GitHub issue id (ex: [GH-767: [C++] Filesystem abstraction](https://github.com/apache/arrow/pull/4225))
 4. Make sure that your code passes the unit tests. You can find instructions
 how to run the unit tests for each Arrow component in its respective README
 file.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,10 +19,6 @@ or
 
     MINOR: [${COMPONENT}] ${SUMMARY}
 
-In the case of PARQUET issues on JIRA the title also supports:
-
-    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}
-
 -->
 
 ### Rationale for this change

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -124,7 +124,7 @@ jobs:
         shell: bash
         run: |
           gem install test-unit
-          pip install "cython>=0.29.31" setuptools pytest jira setuptools-scm
+          pip install "cython>=0.29.31" setuptools pytest requests setuptools-scm
       - name: Run Release Test
         env:
           ARROW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dev_pr.yml
+++ b/.github/workflows/dev_pr.yml
@@ -49,7 +49,7 @@ jobs:
           ref: main
           persist-credentials: false
 
-      - name: Comment JIRA link
+      - name: Add Issue link
         if: |
           (github.event.action == 'opened' ||
            github.event.action == 'edited')

--- a/.github/workflows/dev_pr/helpers.js
+++ b/.github/workflows/dev_pr/helpers.js
@@ -48,27 +48,6 @@ function detectIssue(title) {
 }
 
 /**
- * Retrieves information about a JIRA issue.
- * @param {String} jiraID 
- * @returns {Object} the information about a JIRA issue.
- */
-async function getJiraInfo(jiraID) {
-    const jiraURL = `https://issues.apache.org/jira/rest/api/2/issue/${jiraID}`;
-
-    return new Promise((resolve) => {
-        https.get(jiraURL, res => {
-            let data = '';
-
-            res.on('data', chunk => { data += chunk }) 
-
-            res.on('end', () => {
-               resolve(JSON.parse(data));
-            })
-        })
-    });
-}
-
-/**
  * Retrieves information about a GitHub issue.
  * @param {String} issueID
  * @returns {Object} the information about a GitHub issue.

--- a/.github/workflows/dev_pr/helpers.js
+++ b/.github/workflows/dev_pr/helpers.js
@@ -24,10 +24,8 @@ const https = require('https');
  * @returns {Issue} or null if no issue detected.
  *
  * @typedef {Object} Issue
- * @property {string} kind - The kind of issue: minor, jira or github
- * @property {string} id   - The id of the issue:
- *                            PARQUET-XXXX for jira
- *                            The numeric issue id for github
+ * @property {string} kind - The kind of issue: minor or github
+ * @property {string} id   - The numeric issue id of the issue
  */
 function detectIssue(title) {
     if (!title) {
@@ -35,10 +33,6 @@ function detectIssue(title) {
     }
     if (title.startsWith("MINOR: ")) {
         return {"kind": "minor"};
-    }
-    const matched_jira = /^(WIP:?\s*)?((PARQUET)-\d+)/.exec(title);
-    if (matched_jira) {
-        return {"kind": "jira", "id": matched_jira[2]};
     }
     const matched_gh = /^(WIP:?\s*)?GH-(\d+)/.exec(title);
     if (matched_gh) {

--- a/.github/workflows/dev_pr/link.js
+++ b/.github/workflows/dev_pr/link.js
@@ -48,30 +48,6 @@ async function haveComment(github, context, pullRequestNumber, message) {
 }
 
 /**
- * Adds a comment on the Pull Request linking the JIRA issue.
- *
- * @param {Object} github
- * @param {Object} context
- * @param {String} pullRequestNumber
- * @param {String} jiraID
- */
-async function commentJIRAURL(github, context, pullRequestNumber, jiraID) {
-  const issueInfo = await helpers.getJiraInfo(jiraID);
-  const jiraURL = `https://issues.apache.org/jira/browse/${jiraID}`;
-  if (await haveComment(github, context, pullRequestNumber, jiraURL)) {
-    return;
-  }
-  if (issueInfo){
-    await github.rest.issues.createComment({
-      owner: context.repo.owner,
-      repo: context.repo.repo,
-      issue_number: pullRequestNumber,
-      body: jiraURL
-    });
-  }
-}
-
-/**
  * Adds a comment on the Pull Request linking the GitHub issue.
  *
  * @param {Object} github
@@ -102,10 +78,6 @@ module.exports = async ({github, context}) => {
   const title = context.payload.pull_request.title;
   const issue = helpers.detectIssue(title);
   if (issue){
-    if (issue.kind == "jira") {
-      await commentJIRAURL(github, context, pullRequestNumber, issue.id);
-    } else if (issue.kind == "github") {
-      await commentGitHubURL(github, context, pullRequestNumber, issue.id);
-    }
+    await commentGitHubURL(github, context, pullRequestNumber, issue.id);
   }
 };

--- a/.github/workflows/dev_pr/title_check.md
+++ b/.github/workflows/dev_pr/title_check.md
@@ -31,10 +31,6 @@ or
 
     MINOR: [${COMPONENT}] ${SUMMARY}
 
-In the case of PARQUET issues on JIRA the title also supports:
-
-    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}
-
 See also:
 
   * [Other pull requests](https://github.com/apache/arrow/pulls/)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,8 +29,7 @@ To be assigned to an issue, add a comment "take" to that issue.
 
 Before you create a new bug entry, we recommend you first search among existing
 Arrow issues in
-[Jira](https://issues.apache.org/jira/issues/?jql=project%20%3D%20ARROW%20AND%20status%20%3D%20Open)
-or [GitHub](https://github.com/apache/arrow/issues).
+[GitHub](https://github.com/apache/arrow/issues).
 
 We conventionally prefix the issue title with the component
 name in brackets, such as "[C++][Python] Ensure no validity bitmap in

--- a/dev/README.md
+++ b/dev/README.md
@@ -51,8 +51,7 @@ you'll have to install Python dependencies yourself and then run
 The merge script requires tokens for access control. There are two options
 for configuring your tokens: environment variables or a configuration file.
 
-> Note: Arrow only requires a GitHub token. Parquet can use GitHub or
-JIRA tokens.
+> Note: Arrow and Parquet only requires a GitHub token.
 
 #### Pass tokens via Environment Variables
 
@@ -60,12 +59,6 @@ The merge script uses the GitHub REST API. You must set a
 `ARROW_GITHUB_API_TOKEN` environment variable to use a
 [Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token).
 You need to add `workflow` scope to the Personal Access Token.
-
-You can specify the
-[Personal Access Token](https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html)
-of your JIRA account in the
-`APACHE_JIRA_TOKEN` environment variable.
-If the variable is not set, the script will ask you for it.
 
 #### Pass tokens via configuration file
 

--- a/dev/merge.conf.sample
+++ b/dev/merge.conf.sample
@@ -18,10 +18,6 @@
 # Configuration for the merge_arrow_pr.py tool
 # Install a copy of this file at ~/.config/arrow/merge.conf
 
-[jira]
-# issues.apache.org Jira personal access token
-token=abc123
-
 [github]
 # GitHub's personal access token. "workflow" scope is needed.
 api_token=ghp_ABC

--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -380,7 +380,6 @@ class PullRequest(object):
     GITHUB_PR_TITLE_PATTERN = re.compile(r'^GH-([0-9]+)\b.*$')
 
     def __init__(self, cmd, github_api, git_remote, number):
-        breakpoint()
         self.cmd = cmd
         self._github_api = github_api
         self.git_remote = git_remote

--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -30,7 +30,6 @@
 # variables.
 #
 # Configuration environment variables:
-#   - APACHE_JIRA_TOKEN: your Apache JIRA Personal Access Token
 #   - ARROW_GITHUB_API_TOKEN: a GitHub API token to use for API requests
 #   - ARROW_GITHUB_ORG: the GitHub organisation ('apache' by default)
 #   - DEBUG: use for testing to avoid pushing to apache (0 by default)
@@ -43,15 +42,6 @@ import subprocess
 import sys
 import requests
 import getpass
-
-try:
-    import jira.client
-    import jira.exceptions
-except ImportError:
-    print("Could not find jira library. "
-          "Run 'pip install jira' to install.")
-    print("Exiting without trying to close the associated JIRA.")
-    sys.exit(1)
 
 # Remote name which points to the GitHub site
 ORG_NAME = (
@@ -66,9 +56,6 @@ DEBUG = bool(int(os.environ.get("DEBUG", 0)))
 
 if DEBUG:
     print("**************** DEBUGGING ****************")
-
-
-JIRA_API_BASE = "https://issues.apache.org/jira"
 
 
 def get_json(url, headers=None):
@@ -133,92 +120,6 @@ def fix_version_from_branch(versions):
 MIGRATION_COMMENT_REGEX = re.compile(
     r"This issue has been migrated to \[issue #(?P<issue_id>(\d+))"
 )
-
-
-class JiraIssue(object):
-
-    def __init__(self, jira_con, jira_id, project, cmd):
-        self.jira_con = jira_con
-        self.jira_id = jira_id
-        self.project = project
-        self.cmd = cmd
-
-        try:
-            self.issue = jira_con.issue(jira_id)
-        except Exception as e:
-            self.cmd.fail("ASF JIRA could not find %s\n%s" % (jira_id, e))
-
-    @property
-    def current_fix_versions(self):
-        return self.issue.fields.fixVersions
-
-    @property
-    def current_versions(self):
-        # Only suggest versions starting with a number, like 0.x but not JS-0.x
-        all_versions = self.jira_con.project_versions(self.project)
-        unreleased_versions = [x for x in all_versions
-                               if not x.raw['released']]
-
-        mainline_versions = self._filter_mainline_versions(unreleased_versions)
-        return mainline_versions
-
-    def _filter_mainline_versions(self, versions):
-        if self.project == 'PARQUET':
-            mainline_regex = re.compile(r'cpp-\d.*')
-        else:
-            mainline_regex = re.compile(r'\d.*')
-
-        return [x for x in versions if mainline_regex.match(x.name)]
-
-    def resolve(self, fix_version, comment, *args):
-        fields = self.issue.fields
-        cur_status = fields.status.name
-
-        if cur_status == "Resolved" or cur_status == "Closed":
-            self.cmd.fail("JIRA issue %s already has status '%s'"
-                          % (self.jira_id, cur_status))
-
-        resolve = [x for x in self.jira_con.transitions(self.jira_id)
-                   if x['name'] == "Resolve Issue"][0]
-
-        # ARROW-6915: do not overwrite existing fix versions corresponding to
-        # point releases
-        fix_versions = [v.raw for v in self.jira_con.project_versions(
-            self.project) if v.name == fix_version]
-        fix_version_names = set(x['name'] for x in fix_versions)
-        for version in self.current_fix_versions:
-            major, minor, patch = version.name.split('.')
-            if patch != '0' and version.name not in fix_version_names:
-                fix_versions.append(version.raw)
-
-        if DEBUG:
-            print("JIRA issue %s untouched -> %s" %
-                  (self.jira_id, [v["name"] for v in fix_versions]))
-        else:
-            self.jira_con.transition_issue(self.jira_id, resolve["id"],
-                                           comment=comment,
-                                           fixVersions=fix_versions)
-            print("Successfully resolved %s!" % (self.jira_id))
-
-        self.issue = self.jira_con.issue(self.jira_id)
-        self.show()
-
-    def show(self):
-        fields = self.issue.fields
-        print(format_issue_output("jira", self.jira_id, fields.status.name,
-                                  fields.summary, fields.assignee,
-                                  fields.components))
-
-    def github_issue_id(self):
-        try:
-            last_jira_comment = self.issue.fields.comment.comments[-1].body
-        except Exception:
-            # If no comment found or other issues ignore
-            return None
-        matches = MIGRATION_COMMENT_REGEX.search(last_jira_comment)
-        if matches:
-            values = matches.groupdict()
-            return "GH-" + values['issue_id']
 
 
 class GitHubIssue(object):
@@ -328,12 +229,13 @@ def format_issue_output(issue_type, issue_id, status,
     else:
         components = ', '.join((getattr(x, "name", x) for x in components))
 
-    if issue_type == "jira":
-        url = '/'.join((JIRA_API_BASE, 'browse', issue_id))
-    else:
-        url = (
-            f'https://github.com/{ORG_NAME}/{PROJECT_NAME}/issues/{issue_id}'
-        )
+    url_id = issue_id
+    if "GH" in issue_id:
+        url_id = issue_id.replace("GH-", "")
+
+    url = (
+        f'https://github.com/{ORG_NAME}/{PROJECT_NAME}/issues/{url_id}'
+    )
 
     return """=== {} {} ===
 Summary\t\t{}
@@ -476,19 +378,12 @@ class CommandInput(object):
 
 class PullRequest(object):
     GITHUB_PR_TITLE_PATTERN = re.compile(r'^GH-([0-9]+)\b.*$')
-    # We can merge PARQUET patches from JIRA or GH prefixed issues
-    JIRA_SUPPORTED_PROJECTS = ['PARQUET']
-    JIRA_PR_TITLE_REGEXEN = [
-        (project, re.compile(r'^(' + project + r'-[0-9]+)\b.*$'))
-        for project in JIRA_SUPPORTED_PROJECTS
-    ]
-    JIRA_UNSUPPORTED_ARROW = re.compile(r'^(ARROW-[0-9]+)\b.*$')
 
-    def __init__(self, cmd, github_api, git_remote, jira_con, number):
+    def __init__(self, cmd, github_api, git_remote, number):
+        breakpoint()
         self.cmd = cmd
         self._github_api = github_api
         self.git_remote = git_remote
-        self.con = jira_con
         self.number = number
         self._pr_data = github_api.get_pr_data(number)
         try:
@@ -536,28 +431,8 @@ class PullRequest(object):
             github_id = m.group(1)
             return GitHubIssue(self._github_api, github_id, self.cmd)
 
-        m = self.JIRA_UNSUPPORTED_ARROW.search(self.title)
-        if m:
-            old_jira_id = m.group(1)
-            jira_issue = JiraIssue(self.con, old_jira_id, 'ARROW', self.cmd)
-            self.cmd.fail("PR titles with ARROW- prefixed tickets on JIRA "
-                          "are unsupported, update the PR title from "
-                          f"{old_jira_id}. Possible GitHub id could be: "
-                          f"{jira_issue.github_issue_id()}")
-
-        for project, regex in self.JIRA_PR_TITLE_REGEXEN:
-            m = regex.search(self.title)
-            if m:
-                jira_id = m.group(1)
-                return JiraIssue(self.con, jira_id, project, self.cmd)
-
-        options = ' or '.join(
-            '{0}-XXX'.format(project)
-            for project in self.JIRA_SUPPORTED_PROJECTS + ["GH"]
-        )
-        self.cmd.fail("PR title should be prefixed by a GitHub ID or a "
-                      "Jira ID, like: {0}, but found {1}".format(
-                          options, self.title))
+        self.cmd.fail("PR title should be prefixed by a GitHub ID, like: "
+                      "GH-XXX, but found {0}".format(self.title))
 
     def merge(self):
         """
@@ -706,31 +581,6 @@ def load_configuration():
     return config
 
 
-def get_credentials(cmd):
-    token = None
-
-    config = load_configuration()
-    if "jira" in config.sections():
-        token = config["jira"].get("token")
-
-    # Fallback to environment variables
-    if not token:
-        token = os.environ.get("APACHE_JIRA_TOKEN")
-
-    # Fallback to user tty prompt
-    if not token:
-        token = cmd.prompt("Env APACHE_JIRA_TOKEN not set, "
-                           "please enter your Jira API token "
-                           "(Jira personal access token):")
-
-    return token
-
-
-def connect_jira(cmd):
-    return jira.client.JIRA(options={'server': JIRA_API_BASE},
-                            token_auth=get_credentials(cmd))
-
-
 def get_pr_num():
     if len(sys.argv) == 2:
         return sys.argv[1]
@@ -752,9 +602,7 @@ def cli():
     os.chdir(ARROW_HOME)
 
     github_api = GitHubAPI(PROJECT_NAME, cmd)
-
-    jira_con = connect_jira(cmd)
-    pr = PullRequest(cmd, github_api, ORG_NAME, jira_con, pr_num)
+    pr = PullRequest(cmd, github_api, ORG_NAME, pr_num)
 
     if pr.is_merged:
         print("Pull request %s has already been merged" % pr_num)

--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -233,9 +233,7 @@ def format_issue_output(issue_type, issue_id, status,
     if "GH" in issue_id:
         url_id = issue_id.replace("GH-", "")
 
-    url = (
-        f'https://github.com/{ORG_NAME}/{PROJECT_NAME}/issues/{url_id}'
-    )
+    url = f'https://github.com/{ORG_NAME}/{PROJECT_NAME}/issues/{url_id}'
 
     return """=== {} {} ===
 Summary\t\t{}

--- a/dev/requirements_merge_arrow_pr.txt
+++ b/dev/requirements_merge_arrow_pr.txt
@@ -1,2 +1,1 @@
-jira
 requests

--- a/r/vignettes/install.Rmd
+++ b/r/vignettes/install.Rmd
@@ -433,7 +433,7 @@ compatible with the current version of the R package.
 Please check the "Known installation issues" below to see if any apply, and if
 none apply, set the environment variable `ARROW_R_DEV=TRUE` for more verbose
 output and try installing again. Then,
-please [report an issue](https://issues.apache.org/jira/projects/ARROW/issues)
+please [report an issue](https://github.com/apache/arrow/issues/new/choose)
 and include the full installation output.
 
 ### Using system libraries
@@ -465,7 +465,7 @@ update the libarrow system packages.
 
 If the R package finds and downloads a prebuilt binary of libarrow,
 but then the arrow package can't be loaded, perhaps with "undefined symbols" errors,
-please [report an issue](https://issues.apache.org/jira/projects/ARROW/issues).
+please [report an issue](https://github.com/apache/arrow/issues/new/choose).
 This is likely a compiler mismatch and may be resolvable by setting some
 environment variables to instruct R to compile the packages to match libarrow.
 
@@ -475,7 +475,7 @@ instead of downloading the prebuilt binary.
 That should guarantee that the compiler settings match.
 
 If a prebuilt libarrow binary wasn't found for your operating system but you think it should have been,
-please [report an issue](https://issues.apache.org/jira/projects/ARROW/issues) and share the console output.
+please [report an issue](https://github.com/apache/arrow/issues/new/choose) and share the console output.
 You may also set the environment variable `ARROW_R_DEV=TRUE` for additional
 debug messages.
 
@@ -485,7 +485,7 @@ If building libarrow from source fails, check the error message.
 (If you don't see an error message, only the `----- NOTE -----`,
 set the environment variable `ARROW_R_DEV=TRUE` to increase verbosity and retry installation.)
 The install script should work everywhere, so if libarrow fails to compile,
-please [report an issue](https://issues.apache.org/jira/projects/ARROW/issues)
+please [report an issue](https://github.com/apache/arrow/issues/new/choose)
 so that we can improve the script.
 
 ## Contributing


### PR DESCRIPTION
### Rationale for this change

We are not using JIRA anymore in the project

### What changes are included in this PR?

Remove JIRA from:
- documentation
- pr and issue templates
- comment bot
- merge script

### Are these changes tested?

Via CI

### Are there any user-facing changes?

No
* GitHub Issue: #44934