### PR TITLE
GH-44976: [C++] Enable mimalloc by default, disable jemalloc by default and more

### DIFF
--- a/cpp/CMakePresets.json
+++ b/cpp/CMakePresets.json
@@ -78,6 +78,7 @@
       "name": "features-minimal",
       "hidden": true,
       "cacheVariables": {
+        "ARROW_MIMALLOC": "OFF",
         "ARROW_WITH_RE2": "OFF",
         "ARROW_WITH_UTF8PROC": "OFF"
       }
@@ -91,7 +92,8 @@
         "ARROW_CSV": "ON",
         "ARROW_DATASET": "ON",
         "ARROW_FILESYSTEM": "ON",
-        "ARROW_JSON": "ON"
+        "ARROW_JSON": "ON",
+        "ARROW_MIMALLOC": "ON"
       }
     },
     {

--- a/cpp/cmake_modules/DefineOptions.cmake
+++ b/cpp/cmake_modules/DefineOptions.cmake
@@ -362,29 +362,11 @@ takes precedence over ccache if a storage backend is configured" ON)
 
   define_option(ARROW_IPC "Build the Arrow IPC extensions" ON)
 
-  set(ARROW_JEMALLOC_DESCRIPTION "Build the Arrow jemalloc-based allocator")
-  if(WIN32
-     OR CMAKE_SYSTEM_NAME STREQUAL "FreeBSD"
-     OR CMAKE_SYSTEM_PROCESSOR MATCHES "aarch|ARM|arm"
-     OR NOT ARROW_ENABLE_THREADING)
-    # jemalloc is not supported on Windows.
-    #
-    # jemalloc is the default malloc implementation on FreeBSD and can't
-    # be built with --disable-libdl on FreeBSD. Because lazy-lock feature
-    # is required on FreeBSD. Lazy-lock feature requires libdl.
-    #
-    # jemalloc may have a problem on ARM.
-    # See also: https://github.com/apache/arrow/issues/44342
-    #
-    # jemalloc requires thread.
-    define_option(ARROW_JEMALLOC ${ARROW_JEMALLOC_DESCRIPTION} OFF)
-  else()
-    define_option(ARROW_JEMALLOC ${ARROW_JEMALLOC_DESCRIPTION} ON)
-  endif()
+  define_option(ARROW_JEMALLOC "Build the Arrow jemalloc-based allocator" OFF)
 
   define_option(ARROW_JSON "Build Arrow with JSON support (requires RapidJSON)" OFF)
 
-  define_option(ARROW_MIMALLOC "Build the Arrow mimalloc-based allocator" OFF)
+  define_option(ARROW_MIMALLOC "Build the Arrow mimalloc-based allocator" ON)
 
   define_option(ARROW_PARQUET
                 "Build the Parquet libraries"

--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -727,9 +727,6 @@ set(ARROW_COMPUTE_SRCS
     compute/function.cc
     compute/function_internal.cc
     compute/kernel.cc
-    compute/key_hash_internal.cc
-    compute/key_map_internal.cc
-    compute/light_array_internal.cc
     compute/ordering.cc
     compute/registry.cc
     compute/kernels/chunked_internal.cc
@@ -748,20 +745,7 @@ set(ARROW_COMPUTE_SRCS
     compute/kernels/vector_selection.cc
     compute/kernels/vector_selection_filter_internal.cc
     compute/kernels/vector_selection_internal.cc
-    compute/kernels/vector_selection_take_internal.cc
-    compute/row/encode_internal.cc
-    compute/row/compare_internal.cc
-    compute/row/grouper.cc
-    compute/row/row_encoder_internal.cc
-    compute/row/row_internal.cc
-    compute/util.cc
-    compute/util_internal.cc)
-
-append_runtime_avx2_src(ARROW_COMPUTE_SRCS compute/key_hash_internal_avx2.cc)
-append_runtime_avx2_bmi2_src(ARROW_COMPUTE_SRCS compute/key_map_internal_avx2.cc)
-append_runtime_avx2_src(ARROW_COMPUTE_SRCS compute/row/compare_internal_avx2.cc)
-append_runtime_avx2_src(ARROW_COMPUTE_SRCS compute/row/encode_internal_avx2.cc)
-append_runtime_avx2_bmi2_src(ARROW_COMPUTE_SRCS compute/util_avx2.cc)
+    compute/kernels/vector_selection_take_internal.cc)
 
 if(ARROW_COMPUTE)
   # Include the remaining kernels
@@ -794,10 +778,25 @@ if(ARROW_COMPUTE)
        compute/kernels/vector_replace.cc
        compute/kernels/vector_run_end_encode.cc
        compute/kernels/vector_select_k.cc
-       compute/kernels/vector_sort.cc)
+       compute/kernels/vector_sort.cc
+       compute/key_hash_internal.cc
+       compute/key_map_internal.cc
+       compute/light_array_internal.cc
+       compute/row/encode_internal.cc
+       compute/row/compare_internal.cc
+       compute/row/grouper.cc
+       compute/row/row_encoder_internal.cc
+       compute/row/row_internal.cc
+       compute/util.cc
+       compute/util_internal.cc)
 
   append_runtime_avx2_src(ARROW_COMPUTE_SRCS compute/kernels/aggregate_basic_avx2.cc)
   append_runtime_avx512_src(ARROW_COMPUTE_SRCS compute/kernels/aggregate_basic_avx512.cc)
+  append_runtime_avx2_src(ARROW_COMPUTE_SRCS compute/key_hash_internal_avx2.cc)
+  append_runtime_avx2_bmi2_src(ARROW_COMPUTE_SRCS compute/key_map_internal_avx2.cc)
+  append_runtime_avx2_src(ARROW_COMPUTE_SRCS compute/row/compare_internal_avx2.cc)
+  append_runtime_avx2_src(ARROW_COMPUTE_SRCS compute/row/encode_internal_avx2.cc)
+  append_runtime_avx2_bmi2_src(ARROW_COMPUTE_SRCS compute/util_avx2.cc)
 endif()
 
 arrow_add_object_library(ARROW_COMPUTE ${ARROW_COMPUTE_SRCS})

--- a/cpp/src/arrow/compute/CMakeLists.txt
+++ b/cpp/src/arrow/compute/CMakeLists.txt
@@ -87,16 +87,18 @@ add_arrow_test(internals_test
                function_test.cc
                exec_test.cc
                kernel_test.cc
-               light_array_test.cc
-               registry_test.cc
-               key_hash_test.cc
-               row/compare_test.cc
-               row/grouper_test.cc
-               row/row_encoder_internal_test.cc
-               row/row_test.cc
-               util_internal_test.cc)
+               registry_test.cc)
 
 add_arrow_compute_test(expression_test SOURCES expression_test.cc)
+add_arrow_compute_test(row_test
+                       SOURCES
+                       key_hash_test.cc
+                       light_array_test.cc
+                       row/compare_test.cc
+                       row/grouper_test.cc
+                       row/row_encoder_internal_test.cc
+                       row/row_test.cc
+                       util_internal_test.cc)
 
 add_arrow_benchmark(function_benchmark PREFIX "arrow-compute")
 


### PR DESCRIPTION
### What changes are included in this PR?

1) Disable jemalloc by default
2) Enable mimalloc by default
3) Some files in `arrow/compute` are only required when ARROW_COMPUTE is enabled, so we needn't compile them by default

### Are these changes tested?

Yes, by existing CI tests.

### Are there any user-facing changes?

Yes, but nothing compatibility-breaking.
* GitHub Issue: #44976