### PR TITLE
MINOR: [R] Fix headers

### DIFF
--- a/r/NEWS.md
+++ b/r/NEWS.md
@@ -21,8 +21,6 @@
 
 # arrow 18.1.0
 
-# arrow 18.0.0
-
 ## Minor improvements and fixes
 
 * Fix bindings to allow filtering a factor column in a Dataset using `%in%` (#43446)


### PR DESCRIPTION
### Rationale for this change

The headers in NEWS.md didn't reflect the versions we actually released. We didn't release an 18.0.0 version of the package and waited for Arrow C++ 18.1.0 to do the first R package release in the 18.x.x series.

### What changes are included in this PR?

Update to NEWS.md.

### Are these changes tested?

No.

### Are there any user-facing changes?

No.