### PR TITLE
[WIP] Add a gcc 15 CI job

### DIFF
--- a/ci/docker/ubuntu-24.04-cpp.dockerfile
+++ b/ci/docker/ubuntu-24.04-cpp.dockerfile
@@ -135,14 +135,20 @@ RUN if [ "${gcc_version}" = "" ]; then \
           g++ \
           gcc; \
     else \
-      if [ "${gcc_version}" -gt "14" ]; then \
+      if [ "${gcc_version}" == "snapshot" ]; then \
           apt-get update -y -q && \
           apt-get install -y -q --no-install-recommends software-properties-common && \
-          add-apt-repository ppa:ubuntu-toolchain-r/ppa; \
-      fi; \
-      apt-get update -y -q && \
-      if [ "${gcc_version}" == "snapshot" ]; then \
+          add-apt-repository ppa:ubuntu-toolchain-r/ppa && \
+          apt-get update -y -q && \
           apt-get install -y -q --no-install-recommends \
+          gcc-${gcc_version} ; \
+      elif [ "${gcc_version}" -gt "14" ]; then \
+          apt-get update -y -q && \
+          apt-get install -y -q --no-install-recommends software-properties-common && \
+          add-apt-repository ppa:ubuntu-toolchain-r/ppa && \
+          apt-get update -y -q && \
+          apt-get install -y -q --no-install-recommends \
+          g++-${gcc_version} \
           gcc-${gcc_version} ; \
       else \
           apt-get install -y -q --no-install-recommends \

--- a/ci/docker/ubuntu-24.04-cpp.dockerfile
+++ b/ci/docker/ubuntu-24.04-cpp.dockerfile
@@ -138,17 +138,17 @@ RUN if [ "${gcc_version}" = "" ]; then \
       if [ "${gcc_version}" -gt "14" ]; then \
           apt-get update -y -q && \
           apt-get install -y -q --no-install-recommends software-properties-common && \
-          add-apt-repository ppa:ubuntu-toolchain-r/volatile; \
+          add-apt-repository ppa:ubuntu-toolchain-r/ppa; \
       fi; \
       apt-get update -y -q && \
       if [ "${gcc_version}" == "snapshot" ]; then \
           apt-get install -y -q --no-install-recommends \
-          gcc-${gcc_version} && \
+          gcc-${gcc_version} ; \
       else \
           apt-get install -y -q --no-install-recommends \
           g++-${gcc_version} \
-          gcc-${gcc_version} && \
-      fi; \
+          gcc-${gcc_version} ; \
+      fi & \
       update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${gcc_version} 100 && \
       update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${gcc_version} 100 && \
       update-alternatives --install \

--- a/ci/docker/ubuntu-24.04-cpp.dockerfile
+++ b/ci/docker/ubuntu-24.04-cpp.dockerfile
@@ -143,11 +143,11 @@ RUN if [ "${gcc_version}" = "" ]; then \
       apt-get update -y -q && \
       if [ "${gcc_version}" -eq "snapshot" ]; then \
           apt-get install -y -q --no-install-recommends \
-          gcc-${gcc_version} \
+          gcc-${gcc_version} && \
       else \
           apt-get install -y -q --no-install-recommends \
           g++-${gcc_version} \
-          gcc-${gcc_version} \
+          gcc-${gcc_version} && \
       fi; \
       update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${gcc_version} 100 && \
       update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${gcc_version} 100 && \

--- a/ci/docker/ubuntu-24.04-cpp.dockerfile
+++ b/ci/docker/ubuntu-24.04-cpp.dockerfile
@@ -143,7 +143,6 @@ RUN if [ "${gcc_version}" = "" ]; then \
       apt-get update -y -q && \
       if [ "${gcc_version}" -gt "14" ]; then \
           apt-get install -y -q --no-install-recommends \
-          g++-snapshot \
           gcc-snapshot; \
       else \ 
           apt-get install -y -q --no-install-recommends \

--- a/ci/docker/ubuntu-24.04-cpp.dockerfile
+++ b/ci/docker/ubuntu-24.04-cpp.dockerfile
@@ -141,14 +141,9 @@ RUN if [ "${gcc_version}" = "" ]; then \
           add-apt-repository ppa:ubuntu-toolchain-r/volatile; \
       fi; \
       apt-get update -y -q && \
-      if [ "${gcc_version}" -gt "14" ]; then \
-          apt-get install -y -q --no-install-recommends \
-          gcc-snapshot; \
-      else \ 
-          apt-get install -y -q --no-install-recommends \
+      apt-get install -y -q --no-install-recommends \
           g++-${gcc_version} \
-          gcc-${gcc_version}; \
-      fi; \
+          gcc-${gcc_version} && \
       update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${gcc_version} 100 && \
       update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${gcc_version} 100 && \
       update-alternatives --install \

--- a/ci/docker/ubuntu-24.04-cpp.dockerfile
+++ b/ci/docker/ubuntu-24.04-cpp.dockerfile
@@ -141,9 +141,15 @@ RUN if [ "${gcc_version}" = "" ]; then \
           add-apt-repository ppa:ubuntu-toolchain-r/volatile; \
       fi; \
       apt-get update -y -q && \
-      apt-get install -y -q --no-install-recommends \
+      if [ "${gcc_version}" -gt "14" ]; then \
+          apt-get install -y -q --no-install-recommends \
+          g++-snapshot \
+          gcc-snapshot; \
+      else \ 
+          apt-get install -y -q --no-install-recommends \
           g++-${gcc_version} \
-          gcc-${gcc_version} && \
+          gcc-${gcc_version}; \
+      fi; \
       update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${gcc_version} 100 && \
       update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${gcc_version} 100 && \
       update-alternatives --install \

--- a/ci/docker/ubuntu-24.04-cpp.dockerfile
+++ b/ci/docker/ubuntu-24.04-cpp.dockerfile
@@ -141,7 +141,7 @@ RUN if [ "${gcc_version}" = "" ]; then \
           add-apt-repository ppa:ubuntu-toolchain-r/volatile; \
       fi; \
       apt-get update -y -q && \
-      if [ "${gcc_version}" -eq "snapshot" ]; then \
+      if [ "${gcc_version}" == "snapshot" ]; then \
           apt-get install -y -q --no-install-recommends \
           gcc-${gcc_version} && \
       else \

--- a/ci/docker/ubuntu-24.04-cpp.dockerfile
+++ b/ci/docker/ubuntu-24.04-cpp.dockerfile
@@ -141,9 +141,14 @@ RUN if [ "${gcc_version}" = "" ]; then \
           add-apt-repository ppa:ubuntu-toolchain-r/volatile; \
       fi; \
       apt-get update -y -q && \
-      apt-get install -y -q --no-install-recommends \
+      if [ "${gcc_version}" -eq "snapshot" ]; then \
+          apt-get install -y -q --no-install-recommends \
+          gcc-${gcc_version} \
+      else \
+          apt-get install -y -q --no-install-recommends \
           g++-${gcc_version} \
-          gcc-${gcc_version} && \
+          gcc-${gcc_version} \
+      fi; \
       update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${gcc_version} 100 && \
       update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${gcc_version} 100 && \
       update-alternatives --install \

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -962,6 +962,18 @@ tasks:
       flags: -e CC=gcc-14 -e CXX=g++-14 -e RapidJSON_SOURCE=BUNDLED
       image: ubuntu-cpp
 
+  test-ubuntu-24.04-cpp-gcc-15:
+    ci: github
+    template: docker-tests/github.linux.yml
+    params:
+      env:
+        CLANG_TOOLS: 15
+        GCC_VERSION: 15
+        LLVM: 15
+        UBUNTU: 24.04
+      flags: -e CC=gcc-15 -e CXX=g++-15 -e RapidJSON_SOURCE=BUNDLED
+      image: ubuntu-cpp
+
   test-skyhook-integration:
     ci: github
     template: docker-tests/github.linux.yml

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -968,10 +968,10 @@ tasks:
     params:
       env:
         CLANG_TOOLS: 15
-        GCC_VERSION: 15
+        GCC_VERSION: snapshot
         LLVM: 15
         UBUNTU: 24.04
-      flags: -e CC=gcc-15 -e CXX=g++-15 -e RapidJSON_SOURCE=BUNDLED
+      flags: -e CC=gcc-snapshot -e CXX=g++-snapshot -e RapidJSON_SOURCE=BUNDLED
       image: ubuntu-cpp
 
   test-skyhook-integration:


### PR DESCRIPTION
I'll make an issue if this works, but checking to see if I can replicate [an error I see on CRAN](https://www.stats.ox.ac.uk/pub/bdr/gcc15/arrow.out).

```
...
[ 86%] [32mBuilding CXX object lib/cpp/CMakeFiles/thrift.dir/src/thrift/transport/TSSLServerSocket.cpp.o[0m
make[7]: Leaving directory '/tmp/RtmpBlv7cn/file362bcd655fc78c/thrift_ep-prefix/src/thrift_ep-build'
make[6]: Leaving directory '/tmp/RtmpBlv7cn/file362bcd655fc78c/thrift_ep-prefix/src/thrift_ep-build'
make[5]: Leaving directory '/tmp/RtmpBlv7cn/file362bcd655fc78c/thrift_ep-prefix/src/thrift_ep-build'

-- stderr output is:
...skipping to end...
terator[m[K' is deprecated [[01;35m[K-Wdeprecated-declarations[m[K]
   54 |     : public std::[01;35m[Kiterator[m[K<std::forward_iterator_tag, std::pair<int, const char*> > {
      |                   [01;35m[K^~~~~~~~[m[K
In file included from [01m[K/usr/local/gcc15/include/c++/15.0.0/bits/stl_construct.h:61[m[K,
                 from [01m[K/usr/local/gcc15/include/c++/15.0.0/bits/stl_tempbuf.h:61[m[K,
                 from [01m[K/usr/local/gcc15/include/c++/15.0.0/memory:68[m[K,
                 from [01m[K/tmp/RtmpBlv7cn/file362bcd655fc78c/thrift_ep-prefix/src/thrift_ep/lib/cpp/src/thrift/transport/TSSLSocket.cpp:24[m[K:
[01m[K/usr/local/gcc15/include/c++/15.0.0/bits/stl_iterator_base_types.h:129:34:[m[K [01;36m[Knote: [m[Kdeclared here
  129 |     struct _GLIBCXX17_DEPRECATED [01;36m[Kiterator[m[K
      |                                  [01;36m[K^~~~~~~~[m[K
[01m[K/tmp/RtmpBlv7cn/file362bcd655fc78c/thrift_ep-prefix/src/thrift_ep/lib/cpp/src/thrift/transport/TSSLSocket.cpp:[m[K In constructor '[01m[Kapache::thrift::transport::SSLContext::[01;32m[KSSLContext[m[K(const apache::thrift::transport::SSLProtocol&)[m[K':
[01m[K/tmp/RtmpBlv7cn/file362bcd655fc78c/thrift_ep-prefix/src/thrift_ep/lib/cpp/src/thrift/transport/TSSLSocket.cpp:185:36:[m[K [01;35m[Kwarning: [m[K'[01m[Kconst SSL_METHOD*[01;32m[K TLSv1_method[m[K()[m[K' is deprecated: Since OpenSSL 1.1.0 [[01;35m[K-Wdeprecated-declarations[m[K]
  185 |     ctx_ = SSL_CTX_new([01;35m[KTLSv1_method()[m[K);
      |                        [01;35m[K~~~~~~~~~~~~^~[m[K
In file included from [01m[K/tmp/RtmpBlv7cn/file362bcd655fc78c/thrift_ep-prefix/src/thrift_ep/lib/cpp/src/thrift/transport/TSSLSocket.cpp:53[m[K:
[01m[K/usr/include/openssl/ssl.h:2020:50:[m[K [01;36m[Knote: [m[Kdeclared here
 2020 | OSSL_DEPRECATEDIN_1_1_0 __owur const SSL_METHOD *[01;36m[KTLSv1_method[m[K(void); /* TLSv1.0 */
      |                                                  [01;36m[K^~~~~~~~~~~~[m[K
[01m[K/tmp/RtmpBlv7cn/file362bcd655fc78c/thrift_ep-prefix/src/thrift_ep/lib/cpp/src/thrift/transport/TSSLSocket.cpp:187:38:[m[K [01;35m[Kwarning: [m[K'[01m[Kconst SSL_METHOD*[01;32m[K TLSv1_1_method[m[K()[m[K' is deprecated: Since OpenSSL 1.1.0 [[01;35m[K-Wdeprecated-declarations[m[K]
  187 |     ctx_ = SSL_CTX_new([01;35m[KTLSv1_1_method()[m[K);
      |                        [01;35m[K~~~~~~~~~~~~~~^~[m[K
[01m[K/usr/include/openssl/ssl.h:2028:50:[m[K [01;36m[Knote: [m[Kdeclared here
 2028 | OSSL_DEPRECATEDIN_1_1_0 __owur const SSL_METHOD *[01;36m[KTLSv1_1_method[m[K(void); /* TLSv1.1 */
      |                                                  [01;36m[K^~~~~~~~~~~~~~[m[K
[01m[K/tmp/RtmpBlv7cn/file362bcd655fc78c/thrift_ep-prefix/src/thrift_ep/lib/cpp/src/thrift/transport/TSSLSocket.cpp:189:38:[m[K [01;35m[Kwarning: [m[K'[01m[Kconst SSL_METHOD*[01;32m[K TLSv1_2_method[m[K()[m[K' is deprecated: Since OpenSSL 1.1.0 [[01;35m[K-Wdeprecated-declarations[m[K]
  189 |     ctx_ = SSL_CTX_new([01;35m[KTLSv1_2_method()[m[K);
      |                        [01;35m[K~~~~~~~~~~~~~~^~[m[K
[01m[K/usr/include/openssl/ssl.h:2036:50:[m[K [01;36m[Knote: [m[Kdeclared here
 2036 | OSSL_DEPRECATEDIN_1_1_0 __owur const SSL_METHOD *[01;36m[KTLSv1_2_method[m[K(void); /* TLSv1.2 */
      |                                                  [01;36m[K^~~~~~~~~~~~~~[m[K
[01m[K/tmp/RtmpBlv7cn/file362bcd655fc78c/thrift_ep-prefix/src/thrift_ep/lib/cpp/src/thrift/transport/TSSLSocket.cpp:[m[K In member function '[01m[Kvirtual void apache::thrift::transport::TSSLSocket::[01;32m[Kauthorize[m[K()[m[K':
[01m[K/tmp/RtmpBlv7cn/file362bcd655fc78c/thrift_ep-prefix/src/thrift_ep/lib/cpp/src/thrift/transport/TSSLSocket.cpp:758:43:[m[K [01;35m[Kwarning: [m[K'[01m[Kunsigned char*[01;32m[K ASN1_STRING_data[m[K(ASN1_STRING*)[m[K' is deprecated: Since OpenSSL 1.1.0 [[01;35m[K-Wdeprecated-declarations[m[K]
  758 |       char* data = (char*)[01;35m[KASN1_STRING_data(name->d.ia5)[m[K;
      |                           [01;35m[K~~~~~~~~~~~~~~~~^~~~~~~~~~~~~[m[K
In file included from [01m[K/usr/include/openssl/objects.h:21[m[K,
                 from [01m[K/usr/include/openssl/evp.h:43[m[K,
                 from [01m[K/usr/include/openssl/rand.h:23[m[K,
                 from [01m[K/tmp/RtmpBlv7cn/file362bcd655fc78c/thrift_ep-prefix/src/thrift_ep/lib/cpp/src/thrift/transport/TSSLSocket.cpp:52[m[K:
[01m[K/usr/include/openssl/asn1.h:680:40:[m[K [01;36m[Knote: [m[Kdeclared here
  680 | OSSL_DEPRECATEDIN_1_1_0 unsigned char *[01;36m[KASN1_STRING_data[m[K(ASN1_STRING *x);
      |                                        [01;36m[K^~~~~~~~~~~~~~~~[m[K
[01m[K/tmp/RtmpBlv7cn/file362bcd655fc78c/thrift_ep-prefix/src/thrift_ep/lib/cpp/src/thrift/transport/TSSLSocket.cpp:[m[K At global scope:
[01m[K/tmp/RtmpBlv7cn/file362bcd655fc78c/thrift_ep-prefix/src/thrift_ep/lib/cpp/src/thrift/transport/TSSLSocket.cpp:111:13:[m[K [01;35m[Kwarning: [m[K'[01m[Kvoid apache::thrift::transport::[01;32m[Kdyn_destroy[m[K(CRYPTO_dynlock_value*, const char*, int)[m[K' defined but not used [[01;35m[K-Wunused-function[m[K]
  111 | static void [01;35m[Kdyn_destroy[m[K(struct CRYPTO_dynlock_value* lock, const char*, int) {
      |             [01;35m[K^~~~~~~~~~~[m[K
[01m[K/tmp/RtmpBlv7cn/file362bcd655fc78c/thrift_ep-prefix/src/thrift_ep/lib/cpp/src/thrift/transport/TSSLSocket.cpp:101:13:[m[K [01;35m[Kwarning: [m[K'[01m[Kvoid apache::thrift::transport::[01;32m[Kdyn_lock[m[K(int, CRYPTO_dynlock_value*, const char*, int)[m[K' defined but not used [[01;35m[K-Wunused-function[m[K]
  101 | static void [01;35m[Kdyn_lock[m[K(int mode, struct CRYPTO_dynlock_value* lock, const char*, int) {
      |             [01;35m[K^~~~~~~~[m[K
[01m[K/tmp/RtmpBlv7cn/file362bcd655fc78c/thrift_ep-prefix/src/thrift_ep/lib/cpp/src/thrift/transport/TSSLSocket.cpp:97:30:[m[K [01;35m[Kwarning: [m[K'[01m[KCRYPTO_dynlock_value* apache::thrift::transport::[01;32m[Kdyn_create[m[K(const char*, int)[m[K' defined but not used [[01;35m[K-Wunused-function[m[K]
   97 | static CRYPTO_dynlock_value* [01;35m[Kdyn_create[m[K(const char*, int) {
      |                              [01;35m[K^~~~~~~~~~[m[K
[01m[K/tmp/RtmpBlv7cn/file362bcd655fc78c/thrift_ep-prefix/src/thrift_ep/lib/cpp/src/thrift/transport/TSSLSocket.cpp:76:13:[m[K [01;35m[Kwarning: [m[K'[01m[Kvoid apache::thrift::transport::[01;32m[KcallbackLocking[m[K(int, int, const char*, int)[m[K' defined but not used [[01;35m[K-Wunused-function[m[K]
   76 | static void [01;35m[KcallbackLocking[m[K(int mode, int n, const char*, int) {
      |             [01;35m[K^~~~~~~~~~~~~~~[m[K
In file included from [01m[K/tmp/RtmpBlv7cn/file362bcd655fc78c/thrift_ep-prefix/src/thrift_ep/lib/cpp/src/thrift/transport/TServerSocket.h:25[m[K,
                 from [01m[K/tmp/RtmpBlv7cn/file362bcd655fc78c/thrift_ep-prefix/src/thrift_ep/lib/cpp/src/thrift/transport/TSSLServerSocket.h:23[m[K,
                 from [01m[K/tmp/RtmpBlv7cn/file362bcd655fc78c/thrift_ep-prefix/src/thrift_ep/lib/cpp/src/thrift/transport/TSSLServerSocket.cpp:21[m[K:
[01m[K/tmp/RtmpBlv7cn/file362bcd655fc78c/thrift_ep-prefix/src/thrift_ep/lib/cpp/src/thrift/concurrency/Mutex.h:47:26:[m[K [01;31m[Kerror: [m[K'[01m[Kint64_t[m[K' has not been declared
   47 |   virtual bool timedlock([01;31m[Kint64_t[m[K milliseconds) const;
      |                          [01;31m[K^~~~~~~[m[K
[01m[K/tmp/RtmpBlv7cn/file362bcd655fc78c/thrift_ep-prefix/src/thrift_ep/lib/cpp/src/thrift/concurrency/Mutex.h:60:29:[m[K [01;31m[Kerror: [m[K'[01m[Kint64_t[m[K' has not been declared
   60 |   Guard(const Mutex& value, [01;31m[Kint64_t[m[K timeout = 0) : mutex_(&value) {
      |                             [01;31m[K^~~~~~~[m[K
In file included from [01m[K/tmp/RtmpBlv7cn/file362bcd655fc78c/thrift_ep-prefix/src/thrift_ep/lib/cpp/src/thrift/transport/TTransport.h:23[m[K,
                 from [01m[K/tmp/RtmpBlv7cn/file362bcd655fc78c/thrift_ep-prefix/src/thrift_ep/lib/cpp/src/thrift/transport/TServerTransport.h:23[m[K,
                 from [01m[K/tmp/RtmpBlv7cn/file362bcd655fc78c/thrift_ep-prefix/src/thrift_ep/lib/cpp/src/thrift/transport/TServerSocket.h:27[m[K:
[01m[K/tmp/RtmpBlv7cn/file362bcd655fc78c/thrift_ep-prefix/src/thrift_ep/lib/cpp/src/thrift/Thrift.h:54:19:[m[K [01;35m[Kwarning: [m[K'[01m[Ktemplate<class _Category, class _Tp, class _Distance, class _Pointer, class _Reference> struct std::iterator[m[K' is deprecated [[01;35m[K-Wdeprecated-declarations[m[K]
   54 |     : public std::[01;35m[Kiterator[m[K<std::forward_iterator_tag, std::pair<int, const char*> > {
      |                   [01;35m[K^~~~~~~~[m[K
In file included from [01m[K/usr/local/gcc15/include/c++/15.0.0/bits/stl_algobase.h:65[m[K,
                 from [01m[K/usr/local/gcc15/include/c++/15.0.0/bits/hashtable_policy.h:36[m[K,
                 from [01m[K/usr/local/gcc15/include/c++/15.0.0/bits/hashtable.h:37[m[K,
                 from [01m[K/usr/local/gcc15/include/c++/15.0.0/bits/unordered_map.h:33[m[K,
                 from [01m[K/usr/local/gcc15/include/c++/15.0.0/unordered_map:43[m[K,
                 from [01m[K/usr/local/gcc15/include/c++/15.0.0/functional:65[m[K,
                 from [01m[K/tmp/RtmpBlv7cn/file362bcd655fc78c/thrift_ep-prefix/src/thrift_ep/lib/cpp/src/thrift/transport/TServerSocket.h:23[m[K:
[01m[K/usr/local/gcc15/include/c++/15.0.0/bits/stl_iterator_base_types.h:129:34:[m[K [01;36m[Knote: [m[Kdeclared here
  129 |     struct _GLIBCXX17_DEPRECATED [01;36m[Kiterator[m[K
      |                                  [01;36m[K^~~~~~~~[m[K
make[7]: *** [lib/cpp/CMakeFiles/thrift.dir/build.make:580: lib/cpp/CMakeFiles/thrift.dir/src/thrift/transport/TSSLServerSocket.cpp.o] Error 1
make[6]: *** [CMakeFiles/Makefile2:152: lib/cpp/CMakeFiles/thrift.dir/all] Error 2
make[5]: *** [Makefile:156: all] Error 2

[31mCMake Error at /tmp/RtmpBlv7cn/file362bcd655fc78c/thrift_ep-prefix/src/thrift_ep-stamp/thrift_ep-build-RELEASE.cmake:47 (message):
  Stopping after outputting logs.

[0m
make[4]: *** [CMakeFiles/thrift_ep.dir/build.make:86: thrift_ep-prefix/src/thrift_ep-stamp/thrift_ep-build] Error 1
make[4]: Leaving directory '/tmp/RtmpBlv7cn/file362bcd655fc78c'
make[3]: *** [CMakeFiles/Makefile2:878: CMakeFiles/thrift_ep.dir/all] Error 2
make[3]: *** Waiting for unfinished jobs....
-- re2_ep build command succeeded.  See also /tmp/RtmpBlv7cn/file362bcd655fc78c/re2_ep-prefix/src/re2_ep-stamp/re2_ep-build-*.log
[ 11%] [34m[1mPerforming install step for 're2_ep'[0m
-- re2_ep install command succeeded.  See also /tmp/RtmpBlv7cn/file362bcd655fc78c/re2_ep-prefix/src/re2_ep-stamp/re2_ep-install-*.log
[ 11%] [34m[1mCompleted 're2_ep'[0m
make[4]: Leaving directory '/tmp/RtmpBlv7cn/file362bcd655fc78c'
[ 11%] Built target re2_ep
make[3]: Leaving directory '/tmp/RtmpBlv7cn/file362bcd655fc78c'
gmake[2]: *** [Makefile:146: all] Error 2
gmake[2]: Leaving directory '/tmp/RtmpBlv7cn/file362bcd655fc78c'
**** Complete build log may still be present at /tmp/RtmpBlv7cn/file362bcd68e7503e.log 
*** Failed to find Arrow C++ libraries.
...
```