### PR TITLE
GH-44968: [CI][Dev] Remove nonexistent `getJiraInfo` reference

### DIFF
--- a/.github/workflows/dev_pr/helpers.js
+++ b/.github/workflows/dev_pr/helpers.js
@@ -20,7 +20,7 @@ const https = require('https');
 /**
  * Given the title of a PullRequest return the Issue
  *
- * @param {String} title 
+ * @param {String} title
  * @returns {Issue} or null if no issue detected.
  *
  * @typedef {Object} Issue
@@ -62,6 +62,5 @@ function detectIssue(title) {
 
 module.exports = {
     detectIssue,
-    getJiraInfo,
     getGitHubInfo
 };


### PR DESCRIPTION
### Rationale for this change

It's removed by #44936.

### What changes are included in this PR?

Remove `getJiraInfo` from `exports`.

### Are these changes tested?

No. But this will resolve the reported error.

### Are there any user-facing changes?

No.