### PR TITLE
GH-44980: [CI] Remove retrieval of Arrow version from Java on Spark integration and update test structure for PySpark

### DIFF
--- a/ci/scripts/integration_spark.sh
+++ b/ci/scripts/integration_spark.sh
@@ -42,10 +42,11 @@ pushd ${spark_dir}
   build/mvn -B -DskipTests package
 
   # Run pyarrow related Python tests only
-  # TODO: Investigate why `"pyspark.sql.tests.arrow.test_arrow_grouped_map"` is failing
+  # TODO: Investigate why `"pyspark.sql.tests.arrow.test_arrow_grouped_map"` and
+  # `"pyspark.sql.tests.arrow.test_arrow_cogrouped_map"` are failing.
+  # They seem to require pandas too.
   spark_python_tests=(
     "pyspark.sql.tests.arrow.test_arrow"
-    "pyspark.sql.tests.arrow.test_arrow_cogrouped_map"
     "pyspark.sql.tests.arrow.test_arrow_map"
     "pyspark.sql.tests.arrow.test_arrow_python_udf")
 

--- a/ci/scripts/integration_spark.sh
+++ b/ci/scripts/integration_spark.sh
@@ -43,7 +43,11 @@ pushd ${spark_dir}
 
   # Run pyarrow related Python tests only
   spark_python_tests=(
-    "pyspark.sql.tests.test_arrow")
+    "pyspark.sql.tests.arrow.test_arrow"
+    "pyspark.sql.tests.arrow.test_arrow_cogrouped_map"
+    "pyspark.sql.tests.arrow.test_arrow_grouped_map"
+    "pyspark.sql.tests.arrow.test_arrow_map"
+    "pyspark.sql.tests.arrow.test_arrow_python_udf")
 
   case "${SPARK_VERSION}" in
     v1.*|v2.*|v3.0.*|v3.1.*|v3.2.*|v3.3.*)

--- a/ci/scripts/integration_spark.sh
+++ b/ci/scripts/integration_spark.sh
@@ -42,9 +42,8 @@ pushd ${spark_dir}
   build/mvn -B -DskipTests package
 
   # Run pyarrow related Python tests only
-  # TODO: Investigate why `"pyspark.sql.tests.arrow.test_arrow_grouped_map"` and
-  # `"pyspark.sql.tests.arrow.test_arrow_cogrouped_map"` are failing.
-  # They seem to require pandas too.
+  # "pyspark.sql.tests.arrow.test_arrow_grouped_map" and
+  # "pyspark.sql.tests.arrow.test_arrow_cogrouped_map" currently fail.
   spark_python_tests=(
     "pyspark.sql.tests.arrow.test_arrow"
     "pyspark.sql.tests.arrow.test_arrow_map"

--- a/ci/scripts/integration_spark.sh
+++ b/ci/scripts/integration_spark.sh
@@ -32,11 +32,6 @@ if [ "${SPARK_VERSION:1:2}" == "2." ]; then
   export ARROW_PRE_0_15_IPC_FORMAT=1
 fi
 
-# Get Arrow Java version
-pushd ${source_dir}/java
-  arrow_version=`mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version | sed -n -e '/^\[.*\]/ !{ /^[0-9]/ { p; q } }'`
-popd
-
 export MAVEN_OPTS="-Xss256m -Xmx2g -XX:ReservedCodeCacheSize=1g -Dorg.slf4j.simpleLogger.defaultLogLevel=warn"
 export MAVEN_OPTS="${MAVEN_OPTS} -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
 

--- a/ci/scripts/integration_spark.sh
+++ b/ci/scripts/integration_spark.sh
@@ -42,10 +42,10 @@ pushd ${spark_dir}
   build/mvn -B -DskipTests package
 
   # Run pyarrow related Python tests only
+  # TODO: Investigate why `"pyspark.sql.tests.arrow.test_arrow_grouped_map"` is failing
   spark_python_tests=(
     "pyspark.sql.tests.arrow.test_arrow"
     "pyspark.sql.tests.arrow.test_arrow_cogrouped_map"
-    "pyspark.sql.tests.arrow.test_arrow_grouped_map"
     "pyspark.sql.tests.arrow.test_arrow_map"
     "pyspark.sql.tests.arrow.test_arrow_python_udf")
 

--- a/ci/scripts/integration_spark.sh
+++ b/ci/scripts/integration_spark.sh
@@ -44,6 +44,7 @@ pushd ${spark_dir}
   # Run pyarrow related Python tests only
   # "pyspark.sql.tests.arrow.test_arrow_grouped_map" and
   # "pyspark.sql.tests.arrow.test_arrow_cogrouped_map" currently fail.
+  # See: https://github.com/apache/arrow/issues/44986
   spark_python_tests=(
     "pyspark.sql.tests.arrow.test_arrow"
     "pyspark.sql.tests.arrow.test_arrow_map"


### PR DESCRIPTION
### Rationale for this change

The job is currently failing.

### What changes are included in this PR?

Remove unnecessary check on Java code and refactor pyspark test modules to follow new test structure: https://github.com/apache/spark/pull/49104

### Are these changes tested?

Via archery

### Are there any user-facing changes?

No
* GitHub Issue: #44980