### PR TITLE
GH-43057: [C++] Thread-safe AesEncryptor / AesDecryptor

### DIFF
--- a/cpp/examples/parquet/low_level_api/encryption_reader_writer_all_crypto_options.cc
+++ b/cpp/examples/parquet/low_level_api/encryption_reader_writer_all_crypto_options.cc
@@ -429,7 +429,7 @@ void InteropTestReadEncryptedParquetFiles(std::string root_path) {
 
         // Add the current decryption configuration to ReaderProperties.
         reader_properties.file_decryption_properties(
-            vector_of_decryption_configurations[example_id]->DeepClone());
+            vector_of_decryption_configurations[example_id]);
 
         // Create a ParquetReader instance
         std::unique_ptr<parquet::ParquetFileReader> parquet_reader =

--- a/cpp/src/arrow/dataset/file_parquet.cc
+++ b/cpp/src/arrow/dataset/file_parquet.cc
@@ -76,17 +76,17 @@ parquet::ReaderProperties MakeReaderProperties(
   }
   properties.set_buffer_size(parquet_scan_options->reader_properties->buffer_size());
 
+  auto file_decryption_prop =
+      parquet_scan_options->reader_properties->file_decryption_properties();
+
 #ifdef PARQUET_REQUIRE_ENCRYPTION
   auto parquet_decrypt_config = parquet_scan_options->parquet_decryption_config;
 
   if (parquet_decrypt_config != nullptr) {
-    auto file_decryption_prop =
+    file_decryption_prop =
         parquet_decrypt_config->crypto_factory->GetFileDecryptionProperties(
             *parquet_decrypt_config->kms_connection_config,
             *parquet_decrypt_config->decryption_config, path, filesystem);
-
-    parquet_scan_options->reader_properties->file_decryption_properties(
-        std::move(file_decryption_prop));
   }
 #else
   if (parquet_scan_options->parquet_decryption_config != nullptr) {
@@ -94,8 +94,7 @@ parquet::ReaderProperties MakeReaderProperties(
   }
 #endif
 
-  properties.file_decryption_properties(
-      parquet_scan_options->reader_properties->file_decryption_properties());
+  properties.file_decryption_properties(file_decryption_prop);
 
   properties.set_thrift_string_size_limit(
       parquet_scan_options->reader_properties->thrift_string_size_limit());
@@ -527,9 +526,11 @@ Future<std::shared_ptr<parquet::arrow::FileReader>> ParquetFileFormat::GetReader
   auto self = checked_pointer_cast<const ParquetFileFormat>(shared_from_this());
 
   return source.OpenAsync().Then(
-      [=](const std::shared_ptr<io::RandomAccessFile>& input) mutable {
-        return parquet::ParquetFileReader::OpenAsync(input, std::move(properties),
-                                                     metadata)
+      [self = self, properties = std::move(properties), source = source,
+       options = options, metadata = metadata,
+       parquet_scan_options = parquet_scan_options](
+          const std::shared_ptr<io::RandomAccessFile>& input) mutable {
+        return parquet::ParquetFileReader::OpenAsync(input, properties, metadata)
             .Then(
                 [=](const std::unique_ptr<parquet::ParquetFileReader>& reader) mutable
                 -> Result<std::shared_ptr<parquet::arrow::FileReader>> {
@@ -544,7 +545,7 @@ Future<std::shared_ptr<parquet::arrow::FileReader>> ParquetFileFormat::GetReader
                       // here we know there are no other waiters on the reader.
                       std::move(const_cast<std::unique_ptr<parquet::ParquetFileReader>&>(
                           reader)),
-                      std::move(arrow_properties), &arrow_reader));
+                      arrow_properties, &arrow_reader));
 
                   // R build with openSUSE155 requires an explicit shared_ptr construction
                   return std::shared_ptr<parquet::arrow::FileReader>(

--- a/cpp/src/arrow/dataset/file_parquet_encryption_test.cc
+++ b/cpp/src/arrow/dataset/file_parquet_encryption_test.cc
@@ -138,8 +138,6 @@ class DatasetEncryptionTestBase : public testing::TestWithParam<EncryptionTestPa
     // Write dataset.
     auto dataset = std::make_shared<InMemoryDataset>(table_);
     EXPECT_OK_AND_ASSIGN(auto scanner_builder, dataset->NewScan());
-    // ideally, we would have UseThreads(concurrently) here, but that is not working
-    // unless GH-26818 (https://github.com/apache/arrow/issues/26818) is fixed
     ARROW_EXPECT_OK(scanner_builder->UseThreads(GetParam().concurrently));
     EXPECT_OK_AND_ASSIGN(auto scanner, scanner_builder->Finish());
 

--- a/cpp/src/arrow/dataset/file_parquet_encryption_test.cc
+++ b/cpp/src/arrow/dataset/file_parquet_encryption_test.cc
@@ -54,7 +54,7 @@ namespace arrow {
 namespace dataset {
 
 struct EncryptionTestParam {
-  bool uniform_encryption;   // false is using per-column keys
+  bool uniform_encryption;  // false is using per-column keys
   bool concurrently;
 };
 
@@ -325,15 +325,12 @@ TEST_P(DatasetEncryptionTest, ReadSingleFile) {
   ASSERT_EQ(checked_pointer_cast<Int64Array>(table->column(2)->chunk(0))->GetView(0), 1);
 }
 
-INSTANTIATE_TEST_SUITE_P(
-    DatasetEncryptionTest, DatasetEncryptionTest,
-    ::testing::Values(
-      EncryptionTestParam{false, false},
-      EncryptionTestParam{true, false}));
-INSTANTIATE_TEST_SUITE_P(
-    DatasetEncryptionTestThreaded, DatasetEncryptionTest,
-    ::testing::Values(EncryptionTestParam{false, true},
-                      EncryptionTestParam{true, true}));
+INSTANTIATE_TEST_SUITE_P(DatasetEncryptionTest, DatasetEncryptionTest,
+                         ::testing::Values(EncryptionTestParam{false, false},
+                                           EncryptionTestParam{true, false}));
+INSTANTIATE_TEST_SUITE_P(DatasetEncryptionTestThreaded, DatasetEncryptionTest,
+                         ::testing::Values(EncryptionTestParam{false, true},
+                                           EncryptionTestParam{true, true}));
 
 // GH-39444: This test covers the case where parquet dataset scanner crashes when
 // processing encrypted datasets over 2^15 rows in multi-threaded mode.
@@ -366,14 +363,12 @@ TEST_P(LargeRowCountEncryptionTest, ReadEncryptLargeRowCount) {
   ASSERT_NO_FATAL_FAILURE(TestScanDataset());
 }
 
-INSTANTIATE_TEST_SUITE_P(
-    LargeRowCountEncryptionTest, LargeRowCountEncryptionTest,
-    ::testing::Values(EncryptionTestParam{false, false},
-                      EncryptionTestParam{true, false}));
-INSTANTIATE_TEST_SUITE_P(
-    LargeRowCountEncryptionTestThreaded, LargeRowCountEncryptionTest,
-    ::testing::Values(EncryptionTestParam{false, true},
-                      EncryptionTestParam{true, true}));
+INSTANTIATE_TEST_SUITE_P(LargeRowCountEncryptionTest, LargeRowCountEncryptionTest,
+                         ::testing::Values(EncryptionTestParam{false, false},
+                                           EncryptionTestParam{true, false}));
+INSTANTIATE_TEST_SUITE_P(LargeRowCountEncryptionTestThreaded, LargeRowCountEncryptionTest,
+                         ::testing::Values(EncryptionTestParam{false, true},
+                                           EncryptionTestParam{true, true}));
 
 }  // namespace dataset
 }  // namespace arrow

--- a/cpp/src/arrow/dataset/file_parquet_encryption_test.cc
+++ b/cpp/src/arrow/dataset/file_parquet_encryption_test.cc
@@ -20,6 +20,7 @@
 #include "gtest/gtest.h"
 
 #include "arrow/array.h"
+#include "arrow/compute/api_vector.h"
 #include "arrow/dataset/dataset.h"
 #include "arrow/dataset/file_base.h"
 #include "arrow/dataset/file_parquet.h"
@@ -29,6 +30,7 @@
 #include "arrow/io/api.h"
 #include "arrow/status.h"
 #include "arrow/table.h"
+#include "arrow/testing/future_util.h"
 #include "arrow/testing/gtest_util.h"
 #include "arrow/testing/random.h"
 #include "arrow/type.h"
@@ -58,9 +60,26 @@ struct EncryptionTestParam {
   bool concurrently;
 };
 
+std::string PrintParam(const testing::TestParamInfo<EncryptionTestParam>& info) {
+  std::string out;
+  out += info.param.uniform_encryption ? "UniformEncryption" : "ColumnKeys";
+  out += info.param.concurrently ? "Threaded" : "Serial";
+  return out;
+}
+
+const auto kAllParamValues =
+    ::testing::Values(EncryptionTestParam{false, false}, EncryptionTestParam{true, false},
+                      EncryptionTestParam{false, true}, EncryptionTestParam{true, true});
+
 // Base class to test writing and reading encrypted dataset.
 class DatasetEncryptionTestBase : public testing::TestWithParam<EncryptionTestParam> {
  public:
+#ifdef ARROW_VALGRIND
+  static constexpr int kConcurrentIterations = 4;
+#else
+  static constexpr int kConcurrentIterations = 20;
+#endif
+
   // This function creates a mock file system using the current time point, creates a
   // directory with the given base directory path, and writes a dataset to it using
   // provided Parquet file write options. The function also checks if the written files
@@ -80,6 +99,8 @@ class DatasetEncryptionTestBase : public testing::TestWithParam<EncryptionTestPa
 
     // Init dataset and partitioning.
     ASSERT_NO_FATAL_FAILURE(PrepareTableAndPartitioning());
+    ASSERT_OK_AND_ASSIGN(expected_table_, table_->CombineChunks());
+    ASSERT_OK_AND_ASSIGN(expected_table_, SortTable(expected_table_));
 
     // Prepare encryption properties.
     std::unordered_map<std::string, std::string> key_map;
@@ -119,31 +140,29 @@ class DatasetEncryptionTestBase : public testing::TestWithParam<EncryptionTestPa
     EXPECT_OK_AND_ASSIGN(auto scanner_builder, dataset->NewScan());
     // ideally, we would have UseThreads(concurrently) here, but that is not working
     // unless GH-26818 (https://github.com/apache/arrow/issues/26818) is fixed
-    ARROW_EXPECT_OK(scanner_builder->UseThreads(false));
+    ARROW_EXPECT_OK(scanner_builder->UseThreads(GetParam().concurrently));
     EXPECT_OK_AND_ASSIGN(auto scanner, scanner_builder->Finish());
 
     if (GetParam().concurrently) {
-      // have a notable number of threads to exhibit multi-threading issues
+      // Have a notable number of threads to exhibit multi-threading issues
       ASSERT_OK_AND_ASSIGN(auto pool, arrow::internal::ThreadPool::Make(16));
-      std::vector<Future<>> threads;
+      std::vector<Future<>> futures;
 
-      // write dataset above multiple times concurrently to see that is thread-safe.
-      for (size_t i = 1; i <= 100; ++i) {
+      // Write dataset above multiple times concurrently to see that is thread-safe.
+      for (int i = 1; i <= kConcurrentIterations; ++i) {
         FileSystemDatasetWriteOptions write_options;
         write_options.file_write_options = parquet_file_write_options;
         write_options.filesystem = file_system_;
         write_options.base_dir = "thread-" + std::to_string(i);
         write_options.partitioning = partitioning_;
         write_options.basename_template = "part{i}.parquet";
-        threads.push_back(
+        futures.push_back(
             DeferNotOk(pool->Submit(FileSystemDataset::Write, write_options, scanner)));
       }
-      pool->WaitForIdle();
 
-      // assert all jobs succeeded
-      for (auto& thread : threads) {
-        thread.Wait();
-        ASSERT_TRUE(thread.state() == FutureState::SUCCESS);
+      // Assert all jobs succeeded
+      for (auto& future : futures) {
+        ASSERT_FINISHES_OK(future);
       }
     } else {
       FileSystemDatasetWriteOptions write_options;
@@ -158,7 +177,7 @@ class DatasetEncryptionTestBase : public testing::TestWithParam<EncryptionTestPa
 
   virtual void PrepareTableAndPartitioning() = 0;
 
-  Result<std::shared_ptr<Dataset>> CreateDataset(
+  Result<std::shared_ptr<Dataset>> OpenDataset(
       std::string_view base_dir, const std::shared_ptr<ParquetFileFormat>& file_format) {
     // Get FileInfo objects for all files under the base directory
     fs::FileSelector selector;
@@ -193,66 +212,75 @@ class DatasetEncryptionTestBase : public testing::TestWithParam<EncryptionTestPa
     auto file_format = std::make_shared<ParquetFileFormat>();
     file_format->default_fragment_scan_options = std::move(parquet_scan_options);
 
-    ASSERT_OK_AND_ASSIGN(auto expected_table, table_->CombineChunks());
-
     if (GetParam().concurrently) {
       // Create the dataset
-      ASSERT_OK_AND_ASSIGN(auto dataset, CreateDataset("thread-1", file_format));
+      ASSERT_OK_AND_ASSIGN(auto dataset, OpenDataset("thread-1", file_format));
 
-      // have a notable number of threads to exhibit multi-threading issues
+      // Have a notable number of threads to exhibit multi-threading issues
       ASSERT_OK_AND_ASSIGN(auto pool, arrow::internal::ThreadPool::Make(16));
-      std::vector<Future<std::shared_ptr<Table>>> threads;
+      std::vector<Future<std::shared_ptr<Table>>> futures;
 
       // Read dataset above multiple times concurrently to see that is thread-safe.
-      for (size_t i = 0; i < 100; ++i) {
-        threads.push_back(
-            DeferNotOk(pool->Submit(DatasetEncryptionTestBase::read, dataset)));
-      }
-      pool->WaitForIdle();
-
-      // assert correctness of jobs
-      for (auto& thread : threads) {
-        ASSERT_OK_AND_ASSIGN(auto read_table, thread.result());
-        AssertTablesEqual(*read_table, *expected_table);
+      for (int i = 0; i < kConcurrentIterations; ++i) {
+        futures.push_back(DeferNotOk(pool->Submit(ReadDataset, dataset)));
       }
 
-      // finally check datasets written by all other threads are as expected
-      for (size_t i = 2; i <= 100; ++i) {
+      // Assert correctness of jobs
+      for (auto& future : futures) {
+        ASSERT_OK_AND_ASSIGN(auto read_table, future.result());
+        CheckDatasetResults(read_table);
+      }
+
+      // Finally check datasets written by all other threads are as expected
+      for (int i = 2; i <= kConcurrentIterations; ++i) {
         ASSERT_OK_AND_ASSIGN(dataset,
-                             CreateDataset("thread-" + std::to_string(i), file_format));
-        ASSERT_OK_AND_ASSIGN(auto read_table, DatasetEncryptionTestBase::read(dataset));
-        AssertTablesEqual(*read_table, *expected_table);
+                             OpenDataset("thread-" + std::to_string(i), file_format));
+        ASSERT_OK_AND_ASSIGN(auto read_table, ReadDataset(dataset));
+        CheckDatasetResults(read_table);
       }
     } else {
       // Create the dataset
-      ASSERT_OK_AND_ASSIGN(auto dataset, CreateDataset(kBaseDir, file_format));
+      ASSERT_OK_AND_ASSIGN(auto dataset, OpenDataset(kBaseDir, file_format));
 
       // Reuse the dataset above to scan it twice to make sure decryption works correctly.
-      for (size_t i = 0; i < 2; ++i) {
-        ASSERT_OK_AND_ASSIGN(auto read_table, read(dataset));
-        AssertTablesEqual(*read_table, *expected_table);
+      for (int i = 0; i < 2; ++i) {
+        ASSERT_OK_AND_ASSIGN(auto read_table, ReadDataset(dataset));
+        CheckDatasetResults(read_table);
       }
     }
   }
 
-  static Result<std::shared_ptr<Table>> read(const std::shared_ptr<Dataset>& dataset) {
+  static Result<std::shared_ptr<Table>> ReadDataset(
+      const std::shared_ptr<Dataset>& dataset) {
     // Read dataset into table
     ARROW_ASSIGN_OR_RAISE(auto scanner_builder, dataset->NewScan());
     ARROW_ASSIGN_OR_RAISE(auto scanner, scanner_builder->Finish());
     ARROW_EXPECT_OK(scanner_builder->UseThreads(GetParam().concurrently));
-    ARROW_ASSIGN_OR_RAISE(auto read_table, scanner->ToTable());
+    return scanner->ToTable();
+  }
 
-    // Verify the data was read correctly
-    ARROW_ASSIGN_OR_RAISE(auto combined_table, read_table->CombineChunks());
-    // Validate the table
-    RETURN_NOT_OK(combined_table->ValidateFull());
-    return combined_table;
+  void CheckDatasetResults(const std::shared_ptr<Table>& table) {
+    ASSERT_OK(table->ValidateFull());
+    // Make results comparable despite ordering and chunking differences
+    ASSERT_OK_AND_ASSIGN(auto combined_table, table->CombineChunks());
+    ASSERT_OK_AND_ASSIGN(auto sorted_table, SortTable(combined_table));
+    AssertTablesEqual(*sorted_table, *expected_table_);
+  }
+
+  // Sort table for comparability of dataset read results, which may be unordered.
+  // This relies on column "a" having statistically unique values.
+  Result<std::shared_ptr<Table>> SortTable(const std::shared_ptr<Table>& table) {
+    compute::SortOptions options({compute::SortKey("a")});
+    ARROW_ASSIGN_OR_RAISE(auto indices, compute::SortIndices(table, options));
+    ARROW_ASSIGN_OR_RAISE(auto sorted, compute::Take(table, indices));
+    EXPECT_EQ(sorted.kind(), Datum::TABLE);
+    return sorted.table();
   }
 
  protected:
   std::string base_dir_ = GetParam().concurrently ? "thread-1" : std::string(kBaseDir);
   std::shared_ptr<fs::FileSystem> file_system_;
-  std::shared_ptr<Table> table_;
+  std::shared_ptr<Table> table_, expected_table_;
   std::shared_ptr<Partitioning> partitioning_;
   std::shared_ptr<parquet::encryption::CryptoFactory> crypto_factory_;
   std::shared_ptr<parquet::encryption::KmsConnectionConfig> kms_connection_config_;
@@ -325,12 +353,8 @@ TEST_P(DatasetEncryptionTest, ReadSingleFile) {
   ASSERT_EQ(checked_pointer_cast<Int64Array>(table->column(2)->chunk(0))->GetView(0), 1);
 }
 
-INSTANTIATE_TEST_SUITE_P(DatasetEncryptionTest, DatasetEncryptionTest,
-                         ::testing::Values(EncryptionTestParam{false, false},
-                                           EncryptionTestParam{true, false}));
-INSTANTIATE_TEST_SUITE_P(DatasetEncryptionTestThreaded, DatasetEncryptionTest,
-                         ::testing::Values(EncryptionTestParam{false, true},
-                                           EncryptionTestParam{true, true}));
+INSTANTIATE_TEST_SUITE_P(DatasetEncryptionTest, DatasetEncryptionTest, kAllParamValues,
+                         PrintParam);
 
 // GH-39444: This test covers the case where parquet dataset scanner crashes when
 // processing encrypted datasets over 2^15 rows in multi-threaded mode.
@@ -341,7 +365,7 @@ class LargeRowCountEncryptionTest : public DatasetEncryptionTestBase {
     // Specifically chosen to be greater than batch size for triggering prefetch.
     constexpr int kRowCount = 32769;
     // Number of batches
-    constexpr int kBatchCount = 10;
+    constexpr int kBatchCount = 5;
 
     // Create multiple random floating-point arrays with large number of rows.
     arrow::random::RandomArrayGenerator rand_gen(0);
@@ -364,11 +388,7 @@ TEST_P(LargeRowCountEncryptionTest, ReadEncryptLargeRowCount) {
 }
 
 INSTANTIATE_TEST_SUITE_P(LargeRowCountEncryptionTest, LargeRowCountEncryptionTest,
-                         ::testing::Values(EncryptionTestParam{false, false},
-                                           EncryptionTestParam{true, false}));
-INSTANTIATE_TEST_SUITE_P(LargeRowCountEncryptionTestThreaded, LargeRowCountEncryptionTest,
-                         ::testing::Values(EncryptionTestParam{false, true},
-                                           EncryptionTestParam{true, true}));
+                         kAllParamValues, PrintParam);
 
 }  // namespace dataset
 }  // namespace arrow

--- a/cpp/src/arrow/dataset/file_parquet_encryption_test.cc
+++ b/cpp/src/arrow/dataset/file_parquet_encryption_test.cc
@@ -60,7 +60,8 @@ enum EncryptionParam {
 };
 
 // Base class to test writing and reading encrypted dataset.
-class DatasetEncryptionTestBase : public testing::TestWithParam<std::tuple<EncryptionParam, bool>> {
+class DatasetEncryptionTestBase
+    : public testing::TestWithParam<std::tuple<EncryptionParam, bool>> {
  public:
   // This function creates a mock file system using the current time point, creates a
   // directory with the given base directory path, and writes a dataset to it using
@@ -142,8 +143,7 @@ class DatasetEncryptionTestBase : public testing::TestWithParam<std::tuple<Encry
         write_options.partitioning = partitioning_;
         write_options.basename_template = "part{i}.parquet";
         threads.push_back(
-            DeferNotOk(pool->Submit(FileSystemDataset::Write, write_options, scanner))
-        );
+            DeferNotOk(pool->Submit(FileSystemDataset::Write, write_options, scanner)));
       }
       pool->WaitForIdle();
 
@@ -165,7 +165,8 @@ class DatasetEncryptionTestBase : public testing::TestWithParam<std::tuple<Encry
 
   virtual void PrepareTableAndPartitioning() = 0;
 
-  Result<std::shared_ptr<Dataset>> CreateDataset(std::string_view base_dir, const std::shared_ptr<ParquetFileFormat> &file_format) {
+  Result<std::shared_ptr<Dataset>> CreateDataset(
+      std::string_view base_dir, const std::shared_ptr<ParquetFileFormat>& file_format) {
     // Get FileInfo objects for all files under the base directory
     fs::FileSelector selector;
     selector.base_dir = base_dir;
@@ -175,7 +176,8 @@ class DatasetEncryptionTestBase : public testing::TestWithParam<std::tuple<Encry
     factory_options.partitioning = partitioning_;
     factory_options.partition_base_dir = base_dir;
     ARROW_ASSIGN_OR_RAISE(auto dataset_factory,
-      FileSystemDatasetFactory::Make(file_system_, selector, file_format, factory_options));
+                          FileSystemDatasetFactory::Make(file_system_, selector,
+                                                         file_format, factory_options));
 
     // Create the dataset
     return dataset_factory->Finish();
@@ -224,7 +226,8 @@ class DatasetEncryptionTestBase : public testing::TestWithParam<std::tuple<Encry
 
       // finally check datasets written by all other threads are as expected
       for (size_t i = 2; i <= 100; ++i) {
-        ASSERT_OK_AND_ASSIGN(dataset, CreateDataset("thread-" + std::to_string(i), file_format));
+        ASSERT_OK_AND_ASSIGN(dataset,
+                             CreateDataset("thread-" + std::to_string(i), file_format));
         ASSERT_OK_AND_ASSIGN(auto read_table, DatasetEncryptionTestBase::read(dataset));
         AssertTablesEqual(*read_table, *expected_table);
       }
@@ -300,7 +303,8 @@ TEST_P(DatasetEncryptionTest, WriteReadDatasetWithEncryption) {
 // Read a single parquet file with and without decryption properties.
 TEST_P(DatasetEncryptionTest, ReadSingleFile) {
   // Open the Parquet file.
-  ASSERT_OK_AND_ASSIGN(auto input, file_system_->OpenInputFile(base_dir_ + "/part=a/part0.parquet"));
+  ASSERT_OK_AND_ASSIGN(auto input,
+                       file_system_->OpenInputFile(base_dir_ + "/part=a/part0.parquet"));
 
   // Try to read metadata without providing decryption properties
   // when the footer is encrypted.
@@ -329,10 +333,14 @@ TEST_P(DatasetEncryptionTest, ReadSingleFile) {
   ASSERT_EQ(checked_pointer_cast<Int64Array>(table->column(2)->chunk(0))->GetView(0), 1);
 }
 
-INSTANTIATE_TEST_SUITE_P(DatasetEncryptionTest, DatasetEncryptionTest,
-                         ::testing::Values(std::tuple<EncryptionParam, bool>(COLUMN_KEY, false), std::tuple<EncryptionParam, bool>(UNIFORM, false)));
-INSTANTIATE_TEST_SUITE_P(DatasetEncryptionTestThreaded, DatasetEncryptionTest,
-                         ::testing::Values(std::tuple<EncryptionParam, bool>(COLUMN_KEY, true), std::tuple<EncryptionParam, bool>(UNIFORM, true)));
+INSTANTIATE_TEST_SUITE_P(
+    DatasetEncryptionTest, DatasetEncryptionTest,
+    ::testing::Values(std::tuple<EncryptionParam, bool>(COLUMN_KEY, false),
+                      std::tuple<EncryptionParam, bool>(UNIFORM, false)));
+INSTANTIATE_TEST_SUITE_P(
+    DatasetEncryptionTestThreaded, DatasetEncryptionTest,
+    ::testing::Values(std::tuple<EncryptionParam, bool>(COLUMN_KEY, true),
+                      std::tuple<EncryptionParam, bool>(UNIFORM, true)));
 
 // GH-39444: This test covers the case where parquet dataset scanner crashes when
 // processing encrypted datasets over 2^15 rows in multi-threaded mode.
@@ -365,10 +373,14 @@ TEST_P(LargeRowCountEncryptionTest, ReadEncryptLargeRowCount) {
   ASSERT_NO_FATAL_FAILURE(TestScanDataset());
 }
 
-INSTANTIATE_TEST_SUITE_P(LargeRowCountEncryptionTest, LargeRowCountEncryptionTest,
-                         ::testing::Values(std::tuple<EncryptionParam, bool>(COLUMN_KEY, false), std::tuple<EncryptionParam, bool>(UNIFORM, false)));
-INSTANTIATE_TEST_SUITE_P(LargeRowCountEncryptionTestThreaded, LargeRowCountEncryptionTest,
-                         ::testing::Values(std::tuple<EncryptionParam, bool>(COLUMN_KEY, true), std::tuple<EncryptionParam, bool>(UNIFORM, true)));
+INSTANTIATE_TEST_SUITE_P(
+    LargeRowCountEncryptionTest, LargeRowCountEncryptionTest,
+    ::testing::Values(std::tuple<EncryptionParam, bool>(COLUMN_KEY, false),
+                      std::tuple<EncryptionParam, bool>(UNIFORM, false)));
+INSTANTIATE_TEST_SUITE_P(
+    LargeRowCountEncryptionTestThreaded, LargeRowCountEncryptionTest,
+    ::testing::Values(std::tuple<EncryptionParam, bool>(COLUMN_KEY, true),
+                      std::tuple<EncryptionParam, bool>(UNIFORM, true)));
 
 }  // namespace dataset
 }  // namespace arrow

--- a/cpp/src/arrow/dataset/file_parquet_encryption_test.cc
+++ b/cpp/src/arrow/dataset/file_parquet_encryption_test.cc
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <future>
 #include <string_view>
 
 #include "gtest/gtest.h"
@@ -119,7 +120,7 @@ class DatasetEncryptionTestBase : public ::testing::Test {
 
   virtual void PrepareTableAndPartitioning() = 0;
 
-  void TestScanDataset() {
+  void TestScanDataset(bool concurrently = false) {
     // Create decryption properties.
     auto decryption_config =
         std::make_shared<parquet::encryption::DecryptionConfiguration>();
@@ -151,19 +152,38 @@ class DatasetEncryptionTestBase : public ::testing::Test {
     // Create the dataset
     ASSERT_OK_AND_ASSIGN(auto dataset, dataset_factory->Finish());
 
+    std::vector<std::future<Result<std::shared_ptr<Table>>>> threads;
+
+    // Read dataset above multiple times concurrently to see that is thread-safe.
     // Reuse the dataset above to scan it twice to make sure decryption works correctly.
-    for (size_t i = 0; i < 2; ++i) {
+    const size_t attempts = concurrently ? 1000 : 2;
+    for (size_t i = 0; i < attempts; ++i) {
+      if (concurrently) {
+          threads.push_back(std::async(DatasetEncryptionTestBase::read, dataset));
+      } else {
+          ASSERT_OK_AND_ASSIGN(auto read_table, read(dataset));
+          AssertTablesEqual(*read_table, *table_);
+      }
+    }
+    if (concurrently) {
+        for (auto &thread : threads) {
+          ASSERT_OK_AND_ASSIGN(auto read_table, thread.get());
+          AssertTablesEqual(*read_table, *table_);
+        }
+    }
+  }
+
+  static Result<std::shared_ptr<Table>> read(const std::shared_ptr<Dataset> &dataset) {
       // Read dataset into table
-      ASSERT_OK_AND_ASSIGN(auto scanner_builder, dataset->NewScan());
-      ASSERT_OK_AND_ASSIGN(auto scanner, scanner_builder->Finish());
-      ASSERT_OK_AND_ASSIGN(auto read_table, scanner->ToTable());
+      ARROW_ASSIGN_OR_RAISE(auto scanner_builder, dataset->NewScan());
+      ARROW_ASSIGN_OR_RAISE(auto scanner, scanner_builder->Finish());
+      ARROW_ASSIGN_OR_RAISE(auto read_table, scanner->ToTable());
 
       // Verify the data was read correctly
-      ASSERT_OK_AND_ASSIGN(auto combined_table, read_table->CombineChunks());
+      ARROW_ASSIGN_OR_RAISE(auto combined_table, read_table->CombineChunks());
       // Validate the table
-      ASSERT_OK(combined_table->ValidateFull());
-      AssertTablesEqual(*combined_table, *table_);
-    }
+      RETURN_NOT_OK(combined_table->ValidateFull());
+      return combined_table;
   }
 
  protected:
@@ -206,6 +226,10 @@ class DatasetEncryptionTest : public DatasetEncryptionTestBase {
 // scanned.
 TEST_F(DatasetEncryptionTest, WriteReadDatasetWithEncryption) {
   ASSERT_NO_FATAL_FAILURE(TestScanDataset());
+}
+
+TEST_F(DatasetEncryptionTest, WriteReadDatasetWithEncryptionThreaded) {
+    ASSERT_NO_FATAL_FAILURE(TestScanDataset(true));
 }
 
 // Read a single parquet file with and without decryption properties.

--- a/cpp/src/arrow/dataset/file_parquet_encryption_test.cc
+++ b/cpp/src/arrow/dataset/file_parquet_encryption_test.cc
@@ -54,13 +54,13 @@ namespace arrow {
 namespace dataset {
 
 // Tests come in these variations
-enum CompressionParam {
+enum EncryptionParam {
   COLUMN_KEY,
   UNIFORM,
 };
 
 // Base class to test writing and reading encrypted dataset.
-class DatasetEncryptionTestBase : public testing::TestWithParam<CompressionParam> {
+class DatasetEncryptionTestBase : public testing::TestWithParam<EncryptionParam> {
  public:
   // This function creates a mock file system using the current time point, creates a
   // directory with the given base directory path, and writes a dataset to it using
@@ -104,7 +104,7 @@ class DatasetEncryptionTestBase : public testing::TestWithParam<CompressionParam
     } else if (GetParam() == UNIFORM) {
       encryption_config->uniform_encryption = true;
     } else {
-      FAIL() << "Unsupported compression type " << GetParam();
+      FAIL() << "Unsupported encryption type " << GetParam();
     }
 
     auto parquet_encryption_config = std::make_shared<ParquetEncryptionConfig>();

--- a/cpp/src/arrow/dataset/file_parquet_encryption_test.cc
+++ b/cpp/src/arrow/dataset/file_parquet_encryption_test.cc
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <arrow/acero/exec_plan.h>
-#include <arrow/testing/generator.h>
 #include <future>
 #include <string_view>
 
@@ -116,7 +114,6 @@ class DatasetEncryptionTestBase : public ::testing::Test {
     // Write dataset.
     auto dataset = std::make_shared<InMemoryDataset>(table_);
     EXPECT_OK_AND_ASSIGN(auto scanner_builder, dataset->NewScan());
-    ASSERT_OK(scanner_builder->UseThreads());
     EXPECT_OK_AND_ASSIGN(auto scanner, scanner_builder->Finish());
 
     FileSystemDatasetWriteOptions write_options;
@@ -171,10 +168,8 @@ class DatasetEncryptionTestBase : public ::testing::Test {
       if (concurrently) {
         threads.push_back(std::async(DatasetEncryptionTestBase::read, dataset));
       } else {
-        ASSERT_OK_NO_THROW(arrow::internal::SetEnvVar("OMP_NUM_THREADS", "64"));
         ASSERT_OK_AND_ASSIGN(auto read_table, read(dataset));
         AssertTablesEqual(*read_table, *table_);
-        ASSERT_OK_NO_THROW(arrow::internal::DelEnvVar("OMP_NUM_THREADS"));
       }
     }
     if (concurrently) {
@@ -188,15 +183,14 @@ class DatasetEncryptionTestBase : public ::testing::Test {
   static Result<std::shared_ptr<Table>> read(const std::shared_ptr<Dataset>& dataset) {
     // Read dataset into table
     ARROW_ASSIGN_OR_RAISE(auto scanner_builder, dataset->NewScan());
-    RETURN_NOT_OK(scanner_builder->UseThreads(true));
     ARROW_ASSIGN_OR_RAISE(auto scanner, scanner_builder->Finish());
     ARROW_ASSIGN_OR_RAISE(auto read_table, scanner->ToTable());
 
     // Verify the data was read correctly
-    // ARROW_ASSIGN_OR_RAISE(auto combined_table, read_table->CombineChunks());
+    ARROW_ASSIGN_OR_RAISE(auto combined_table, read_table->CombineChunks());
     // Validate the table
-    // RETURN_NOT_OK(combined_table->ValidateFull());
-    return read_table;
+    RETURN_NOT_OK(combined_table->ValidateFull());
+    return combined_table;
   }
 
  protected:
@@ -313,35 +307,6 @@ class LargeRowEncryptionTest : public DatasetEncryptionTestBase {
 
 // Test for writing and reading encrypted dataset with large row count.
 TEST_F(LargeRowEncryptionTest, ReadEncryptLargeRows) {
-  ASSERT_NO_FATAL_FAILURE(TestScanDataset());
-}
-
-class LargeTableEncryptionTest : public DatasetEncryptionTestBase {
- public:
-  void PrepareTableAndPartitioning() override {
-    auto generator = gen::Gen({{"a", gen::Step()}})->FailOnError();
-    std::vector<::arrow::compute::ExecBatch> ebatches =
-        generator->ExecBatches(/*rows_per_batch=*/64 * 1024, /*num_batches=*/1024);
-    acero::Declaration source = acero::Declaration(
-        "exec_batch_source", ::arrow::acero::ExecBatchSourceNodeOptions(
-                                 generator->Schema(), std::move(ebatches)));
-    acero::QueryOptions opts;
-    ASSERT_OK_AND_ASSIGN(std::vector<std::shared_ptr<RecordBatch>> batches,
-                         DeclarationToBatches(source, opts));
-
-    std::shared_ptr<Schema> expected_schema = schema({field("a", uint32())});
-
-    ASSERT_OK_AND_ASSIGN(acero::BatchesWithCommonSchema batches_with_schema,
-                         DeclarationToExecBatches(source, opts));
-
-    AssertSchemaEqual(*expected_schema, *batches_with_schema.schema);
-
-    ASSERT_OK_AND_ASSIGN(table_, acero::DeclarationToTable(source, opts));
-    partitioning_ = std::make_shared<dataset::DirectoryPartitioning>(arrow::schema({}));
-  }
-};
-
-TEST_F(LargeTableEncryptionTest, ReadEncryptLargeTabl) {
   ASSERT_NO_FATAL_FAILURE(TestScanDataset());
 }
 

--- a/cpp/src/arrow/dataset/file_parquet_encryption_test.cc
+++ b/cpp/src/arrow/dataset/file_parquet_encryption_test.cc
@@ -37,6 +37,7 @@
 #include "arrow/util/thread_pool.h"
 #include "parquet/arrow/reader.h"
 #include "parquet/encryption/crypto_factory.h"
+#include "parquet/encryption/encryption_internal.h"
 #include "parquet/encryption/kms_client.h"
 #include "parquet/encryption/test_in_memory_kms.h"
 

--- a/cpp/src/arrow/dataset/file_parquet_encryption_test.cc
+++ b/cpp/src/arrow/dataset/file_parquet_encryption_test.cc
@@ -56,13 +56,13 @@ namespace dataset {
 struct EncryptionTestParam {
   bool uniform_encryption;  // false is using per-column keys
   bool concurrently;
-  bool crypto_factory;
+  bool use_crypto_factory;
 };
 
 std::ostream& operator<<(std::ostream& os, const EncryptionTestParam& param) {
   os << (param.uniform_encryption ? "UniformEncryption" : "ColumnKeys") << " ";
   os << (param.concurrently ? "Threaded" : "Serial") << " ";
-  os << (param.crypto_factory ? "CryptoFactory" : "PropertyKeys");
+  os << (param.use_crypto_factory ? "CryptoFactory" : "PropertyKeys");
   return os;
 }
 
@@ -112,7 +112,7 @@ class DatasetEncryptionTestBase : public testing::TestWithParam<EncryptionTestPa
     auto parquet_file_write_options =
         checked_pointer_cast<ParquetFileWriteOptions>(file_format->DefaultWriteOptions());
 
-    if (GetParam().crypto_factory) {
+    if (GetParam().use_crypto_factory) {
       // Configure encryption keys via crypto factory.
       crypto_factory_ = std::make_shared<parquet::encryption::CryptoFactory>();
       auto kms_client_factory =
@@ -214,7 +214,7 @@ class DatasetEncryptionTestBase : public testing::TestWithParam<EncryptionTestPa
     // Set scan options.
     auto parquet_scan_options = std::make_shared<ParquetFragmentScanOptions>();
 
-    if (GetParam().crypto_factory) {
+    if (GetParam().use_crypto_factory) {
       // Configure decryption keys via crypto factory.
       auto decryption_config =
           std::make_shared<parquet::encryption::DecryptionConfiguration>();
@@ -360,7 +360,7 @@ TEST_P(DatasetEncryptionTest, ReadSingleFile) {
   auto decryption_config =
       std::make_shared<parquet::encryption::DecryptionConfiguration>();
   std::shared_ptr<parquet::FileDecryptionProperties> file_decryption_properties;
-  if (GetParam().crypto_factory) {
+  if (GetParam().use_crypto_factory) {
     // Configure decryption keys via file decryption properties with crypto factory key
     // retriever.
     file_decryption_properties = crypto_factory_->GetFileDecryptionProperties(

--- a/cpp/src/arrow/dataset/file_parquet_encryption_test.cc
+++ b/cpp/src/arrow/dataset/file_parquet_encryption_test.cc
@@ -59,12 +59,11 @@ struct EncryptionTestParam {
   bool crypto_factory;
 };
 
-std::string PrintParam(const testing::TestParamInfo<EncryptionTestParam>& info) {
-  std::string out;
-  out += info.param.uniform_encryption ? "UniformEncryption" : "ColumnKeys";
-  out += info.param.concurrently ? "Threaded" : "Serial";
-  out += info.param.crypto_factory ? "CryptoFactory" : "PropertyKeys";
-  return out;
+std::ostream& operator<<(std::ostream& os, const EncryptionTestParam& param) {
+  os << (param.uniform_encryption ? "UniformEncryption" : "ColumnKeys") << " ";
+  os << (param.concurrently ? "Threaded" : "Serial") << " ";
+  os << (param.crypto_factory ? "CryptoFactory" : "PropertyKeys");
+  return os;
 }
 
 const auto kAllParamValues = ::testing::Values(
@@ -391,8 +390,7 @@ TEST_P(DatasetEncryptionTest, ReadSingleFile) {
   ASSERT_EQ(checked_pointer_cast<Int64Array>(table->column(2)->chunk(0))->GetView(0), 1);
 }
 
-INSTANTIATE_TEST_SUITE_P(DatasetEncryptionTest, DatasetEncryptionTest, kAllParamValues,
-                         PrintParam);
+INSTANTIATE_TEST_SUITE_P(DatasetEncryptionTest, DatasetEncryptionTest, kAllParamValues);
 
 // GH-39444: This test covers the case where parquet dataset scanner crashes when
 // processing encrypted datasets over 2^15 rows in multi-threaded mode.
@@ -426,7 +424,7 @@ TEST_P(LargeRowCountEncryptionTest, ReadEncryptLargeRowCount) {
 }
 
 INSTANTIATE_TEST_SUITE_P(LargeRowCountEncryptionTest, LargeRowCountEncryptionTest,
-                         kAllParamValues, PrintParam);
+                         kAllParamValues);
 
 }  // namespace dataset
 }  // namespace arrow

--- a/cpp/src/arrow/dataset/scanner.cc
+++ b/cpp/src/arrow/dataset/scanner.cc
@@ -707,7 +707,7 @@ Future<std::shared_ptr<Table>> AsyncScanner::ToTableAsync(Executor* cpu_executor
   auto scan_options = scan_options_;
   ARROW_ASSIGN_OR_RAISE(
       auto positioned_batch_gen,
-      ScanBatchesUnorderedAsync(cpu_executor, /*sequence_fragments=*/false,
+      ScanBatchesUnorderedAsync(cpu_executor, /*sequence_fragments=*/true,
                                 /*use_legacy_batching=*/true));
   /// Wraps the state in a shared_ptr to ensure that failing ScanTasks don't
   /// invalidate concurrently running tasks when Finish() early returns

--- a/cpp/src/arrow/dataset/scanner.cc
+++ b/cpp/src/arrow/dataset/scanner.cc
@@ -707,7 +707,7 @@ Future<std::shared_ptr<Table>> AsyncScanner::ToTableAsync(Executor* cpu_executor
   auto scan_options = scan_options_;
   ARROW_ASSIGN_OR_RAISE(
       auto positioned_batch_gen,
-      ScanBatchesUnorderedAsync(cpu_executor, /*sequence_fragments=*/true,
+      ScanBatchesUnorderedAsync(cpu_executor, /*sequence_fragments=*/false,
                                 /*use_legacy_batching=*/true));
   /// Wraps the state in a shared_ptr to ensure that failing ScanTasks don't
   /// invalidate concurrently running tasks when Finish() early returns

--- a/cpp/src/parquet/column_reader.cc
+++ b/cpp/src/parquet/column_reader.cc
@@ -308,9 +308,7 @@ class SerializedPageReader : public PageReader {
 
   // The CryptoContext used by this PageReader.
   CryptoContext crypto_ctx_;
-  // This PageReader has its own copy of crypto_ctx_->meta_decryptor and
-  // crypto_ctx_->data_decryptor in order to be thread-safe. Do not mutate (update) the
-  // instances of crypto_ctx_.
+  // This PageReader has its own Decryptor instances in order to be thread-safe.
   std::shared_ptr<Decryptor> meta_decryptor_;
   std::shared_ptr<Decryptor> data_decryptor_;
 

--- a/cpp/src/parquet/column_reader.cc
+++ b/cpp/src/parquet/column_reader.cc
@@ -338,16 +338,16 @@ class SerializedPageReader : public PageReader {
 
 void SerializedPageReader::InitDecryption() {
   // Prepare the AAD for quick update later.
-  if (crypto_ctx_.data_decryptor != nullptr) {
-    ARROW_DCHECK(!crypto_ctx_.data_decryptor->file_aad().empty());
-    data_decryptor_ = std::make_shared<Decryptor>(*crypto_ctx_.data_decryptor);
+  if (crypto_ctx_.data_decryptor) {
+    data_decryptor_ = crypto_ctx_.data_decryptor();
+    ARROW_DCHECK(!data_decryptor_->file_aad().empty());
     data_page_aad_ = encryption::CreateModuleAad(
         data_decryptor_->file_aad(), encryption::kDataPage, crypto_ctx_.row_group_ordinal,
         crypto_ctx_.column_ordinal, kNonPageOrdinal);
   }
-  if (crypto_ctx_.meta_decryptor != nullptr) {
-    ARROW_DCHECK(!crypto_ctx_.meta_decryptor->file_aad().empty());
-    meta_decryptor_ = std::make_shared<Decryptor>(*crypto_ctx_.meta_decryptor);
+  if (crypto_ctx_.meta_decryptor) {
+    meta_decryptor_ = crypto_ctx_.meta_decryptor();
+    ARROW_DCHECK(!meta_decryptor_->file_aad().empty());
     data_page_header_aad_ = encryption::CreateModuleAad(
         meta_decryptor_->file_aad(), encryption::kDataPageHeader,
         crypto_ctx_.row_group_ordinal, crypto_ctx_.column_ordinal, kNonPageOrdinal);

--- a/cpp/src/parquet/column_reader.cc
+++ b/cpp/src/parquet/column_reader.cc
@@ -306,8 +306,15 @@ class SerializedPageReader : public PageReader {
   // Please refer to the encryption specification for more details:
   // https://github.com/apache/parquet-format/blob/encryption/Encryption.md#44-additional-authenticated-data
 
-  // The ordinal fields in the context below are used for AAD suffix calculation.
+  // The CryptoContext used by this PageReader.
   CryptoContext crypto_ctx_;
+  // This PageReader has its own copy of crypto_ctx_->meta_decryptor and
+  // crypto_ctx_->data_decryptor in order to be thread-safe. Do not mutate (update) the
+  // instances of crypto_ctx_.
+  std::shared_ptr<Decryptor> meta_decryptor_;
+  std::shared_ptr<Decryptor> data_decryptor_;
+
+  // The ordinal fields in the context below are used for AAD suffix calculation.
   int32_t page_ordinal_;  // page ordinal does not count the dictionary page
 
   // Maximum allowed page size
@@ -333,14 +340,16 @@ void SerializedPageReader::InitDecryption() {
   // Prepare the AAD for quick update later.
   if (crypto_ctx_.data_decryptor != nullptr) {
     ARROW_DCHECK(!crypto_ctx_.data_decryptor->file_aad().empty());
+    data_decryptor_ = std::make_shared<Decryptor>(*crypto_ctx_.data_decryptor);
     data_page_aad_ = encryption::CreateModuleAad(
-        crypto_ctx_.data_decryptor->file_aad(), encryption::kDataPage,
-        crypto_ctx_.row_group_ordinal, crypto_ctx_.column_ordinal, kNonPageOrdinal);
+        data_decryptor_->file_aad(), encryption::kDataPage, crypto_ctx_.row_group_ordinal,
+        crypto_ctx_.column_ordinal, kNonPageOrdinal);
   }
   if (crypto_ctx_.meta_decryptor != nullptr) {
     ARROW_DCHECK(!crypto_ctx_.meta_decryptor->file_aad().empty());
+    meta_decryptor_ = std::make_shared<Decryptor>(*crypto_ctx_.meta_decryptor);
     data_page_header_aad_ = encryption::CreateModuleAad(
-        crypto_ctx_.meta_decryptor->file_aad(), encryption::kDataPageHeader,
+        meta_decryptor_->file_aad(), encryption::kDataPageHeader,
         crypto_ctx_.row_group_ordinal, crypto_ctx_.column_ordinal, kNonPageOrdinal);
   }
 }
@@ -425,15 +434,15 @@ std::shared_ptr<Page> SerializedPageReader::NextPage() {
       // This gets used, then set by DeserializeThriftMsg
       header_size = static_cast<uint32_t>(view.size());
       try {
-        if (crypto_ctx_.meta_decryptor != nullptr) {
-          UpdateDecryption(crypto_ctx_.meta_decryptor, encryption::kDictionaryPageHeader,
+        if (meta_decryptor_ != nullptr) {
+          UpdateDecryption(meta_decryptor_, encryption::kDictionaryPageHeader,
                            &data_page_header_aad_);
         }
         // Reset current page header to avoid unclearing the __isset flag.
         current_page_header_ = format::PageHeader();
         deserializer.DeserializeMessage(reinterpret_cast<const uint8_t*>(view.data()),
                                         &header_size, &current_page_header_,
-                                        crypto_ctx_.meta_decryptor.get());
+                                        meta_decryptor_.get());
         break;
       } catch (std::exception& e) {
         // Failed to deserialize. Double the allowed page header size and try again
@@ -461,9 +470,8 @@ std::shared_ptr<Page> SerializedPageReader::NextPage() {
       continue;
     }
 
-    if (crypto_ctx_.data_decryptor != nullptr) {
-      UpdateDecryption(crypto_ctx_.data_decryptor, encryption::kDictionaryPage,
-                       &data_page_aad_);
+    if (data_decryptor_ != nullptr) {
+      UpdateDecryption(data_decryptor_, encryption::kDictionaryPage, &data_page_aad_);
     }
 
     // Read the compressed data page.
@@ -491,13 +499,13 @@ std::shared_ptr<Page> SerializedPageReader::NextPage() {
     }
 
     // Decrypt it if we need to
-    if (crypto_ctx_.data_decryptor != nullptr) {
-      PARQUET_THROW_NOT_OK(decryption_buffer_->Resize(
-          crypto_ctx_.data_decryptor->PlaintextLength(compressed_len),
-          /*shrink_to_fit=*/false));
-      compressed_len = crypto_ctx_.data_decryptor->Decrypt(
-          page_buffer->span_as<uint8_t>(),
-          decryption_buffer_->mutable_span_as<uint8_t>());
+    if (data_decryptor_ != nullptr) {
+      PARQUET_THROW_NOT_OK(
+          decryption_buffer_->Resize(data_decryptor_->PlaintextLength(compressed_len),
+                                     /*shrink_to_fit=*/false));
+      compressed_len =
+          data_decryptor_->Decrypt(page_buffer->span_as<uint8_t>(),
+                                   decryption_buffer_->mutable_span_as<uint8_t>());
 
       page_buffer = decryption_buffer_;
     }

--- a/cpp/src/parquet/column_reader.h
+++ b/cpp/src/parquet/column_reader.h
@@ -103,7 +103,8 @@ class PARQUET_EXPORT LevelDecoder {
 
 struct CryptoContext {
   CryptoContext(bool start_with_dictionary_page, int16_t rg_ordinal, int16_t col_ordinal,
-                std::shared_ptr<Decryptor> meta, std::shared_ptr<Decryptor> data)
+                std::function<std::shared_ptr<Decryptor>()> meta,
+                std::function<std::shared_ptr<Decryptor>()> data)
       : start_decrypt_with_dictionary_page(start_with_dictionary_page),
         row_group_ordinal(rg_ordinal),
         column_ordinal(col_ordinal),
@@ -114,8 +115,8 @@ struct CryptoContext {
   bool start_decrypt_with_dictionary_page = false;
   int16_t row_group_ordinal = -1;
   int16_t column_ordinal = -1;
-  std::shared_ptr<Decryptor> meta_decryptor;
-  std::shared_ptr<Decryptor> data_decryptor;
+  std::function<std::shared_ptr<Decryptor>()> meta_decryptor;
+  std::function<std::shared_ptr<Decryptor>()> data_decryptor;
 };
 
 // Abstract page iterator interface. This way, we can feed column pages to the

--- a/cpp/src/parquet/column_reader.h
+++ b/cpp/src/parquet/column_reader.h
@@ -102,21 +102,11 @@ class PARQUET_EXPORT LevelDecoder {
 };
 
 struct CryptoContext {
-  CryptoContext(bool start_with_dictionary_page, int16_t rg_ordinal, int16_t col_ordinal,
-                std::function<std::shared_ptr<Decryptor>()> meta,
-                std::function<std::shared_ptr<Decryptor>()> data)
-      : start_decrypt_with_dictionary_page(start_with_dictionary_page),
-        row_group_ordinal(rg_ordinal),
-        column_ordinal(col_ordinal),
-        meta_decryptor(std::move(meta)),
-        data_decryptor(std::move(data)) {}
-  CryptoContext() {}
-
   bool start_decrypt_with_dictionary_page = false;
   int16_t row_group_ordinal = -1;
   int16_t column_ordinal = -1;
-  std::function<std::shared_ptr<Decryptor>()> meta_decryptor;
-  std::function<std::shared_ptr<Decryptor>()> data_decryptor;
+  std::function<std::unique_ptr<Decryptor>()> meta_decryptor_factory;
+  std::function<std::unique_ptr<Decryptor>()> data_decryptor_factory;
 };
 
 // Abstract page iterator interface. This way, we can feed column pages to the

--- a/cpp/src/parquet/encryption/encryption.h
+++ b/cpp/src/parquet/encryption/encryption.h
@@ -150,6 +150,8 @@ class PARQUET_EXPORT ColumnEncryptionProperties {
   ColumnEncryptionProperties(const ColumnEncryptionProperties& other) = default;
   ColumnEncryptionProperties(ColumnEncryptionProperties&& other) = default;
 
+  ~ColumnEncryptionProperties() { key_.clear(); }
+
  private:
   const std::string column_path_;
   bool encrypted_;
@@ -186,6 +188,8 @@ class PARQUET_EXPORT ColumnDecryptionProperties {
   ColumnDecryptionProperties() = default;
   ColumnDecryptionProperties(const ColumnDecryptionProperties& other) = default;
   ColumnDecryptionProperties(ColumnDecryptionProperties&& other) = default;
+
+  ~ColumnDecryptionProperties() { key_.clear(); }
 
   std::string column_path() const { return column_path_; }
   std::string key() const { return key_; }
@@ -300,6 +304,8 @@ class PARQUET_EXPORT FileDecryptionProperties {
     bool plaintext_files_allowed_;
   };
 
+  ~FileDecryptionProperties() { footer_key_.clear(); }
+
   std::string column_key(const std::string& column_path) const;
 
   std::string footer_key() const { return footer_key_; }
@@ -403,6 +409,9 @@ class PARQUET_EXPORT FileEncryptionProperties {
     bool store_aad_prefix_in_file_;
     ColumnPathToEncryptionPropertiesMap encrypted_columns_;
   };
+
+  ~FileEncryptionProperties() { footer_key_.clear(); }
+
   bool encrypted_footer() const { return encrypted_footer_; }
 
   EncryptionAlgorithm algorithm() const { return algorithm_; }

--- a/cpp/src/parquet/encryption/encryption_internal.cc
+++ b/cpp/src/parquet/encryption/encryption_internal.cc
@@ -79,8 +79,15 @@ class AesEncryptionContext {
   virtual ~AesEncryptionContext() = default;
 
  protected:
-  static inline std::function<void(EVP_CIPHER_CTX*)> ctx_deleter_ =
-      [](EVP_CIPHER_CTX* ctx) { EVP_CIPHER_CTX_free(ctx); };
+  static void DeleteCipherContext(EVP_CIPHER_CTX* ctx) {
+    EVP_CIPHER_CTX_free(ctx);
+  }
+  
+  using CipherContext = std::unique_ptr<EVP_CIPHER_CTX, decltype(DeleteCipherContext)>;
+  
+  static CipherContext WrapCipherContext(EVP_CIPHER_CTX* ctx) {
+    return CipherContext(ctx, DeleteCipherContext);
+  }
 
   int32_t aes_mode_;
   int32_t key_length_;

--- a/cpp/src/parquet/encryption/encryption_internal.cc
+++ b/cpp/src/parquet/encryption/encryption_internal.cc
@@ -81,14 +81,14 @@ class AesEncryptionContext {
  protected:
   virtual void InitCipherContext(EVP_CIPHER_CTX* ctx) = 0;
 
-  std::function<void(EVP_CIPHER_CTX*)> ctxDeleter = [](EVP_CIPHER_CTX* ctx) {
+  static inline std::function<void(EVP_CIPHER_CTX*)> ctx_deleter_ = [](EVP_CIPHER_CTX* ctx) {
     EVP_CIPHER_CTX_free(ctx);
   };
 
   /// Create a new cipher context that auto-frees
-  std::unique_ptr<EVP_CIPHER_CTX, decltype(ctxDeleter)> NewCipherContext() {
-    auto ctx = std::unique_ptr<EVP_CIPHER_CTX, decltype(ctxDeleter)>(EVP_CIPHER_CTX_new(),
-                                                                     ctxDeleter);
+  std::unique_ptr<EVP_CIPHER_CTX, decltype(ctx_deleter_)> NewCipherContext() {
+    auto ctx = std::unique_ptr<EVP_CIPHER_CTX, decltype(ctx_deleter_)>(EVP_CIPHER_CTX_new(),
+                                                                     ctx_deleter_);
     if (!ctx) throw ParquetException("Couldn't init cipher context");
     InitCipherContext(ctx.get());
     return ctx;

--- a/cpp/src/parquet/encryption/encryption_internal.cc
+++ b/cpp/src/parquet/encryption/encryption_internal.cc
@@ -518,19 +518,14 @@ AesDecryptor::AesDecryptor(ParquetCipher::type alg_id, int32_t key_len, bool met
           new AesDecryptorImpl(alg_id, key_len, metadata, contains_length))} {}
 
 std::shared_ptr<AesDecryptor> AesDecryptor::Make(
-    ParquetCipher::type alg_id, int32_t key_len, bool metadata,
-    std::vector<std::weak_ptr<AesDecryptor>>* all_decryptors) {
+    ParquetCipher::type alg_id, int32_t key_len, bool metadata) {
   if (ParquetCipher::AES_GCM_V1 != alg_id && ParquetCipher::AES_GCM_CTR_V1 != alg_id) {
     std::stringstream ss;
     ss << "Crypto algorithm " << alg_id << " is not supported";
     throw ParquetException(ss.str());
   }
 
-  auto decryptor = std::make_shared<AesDecryptor>(alg_id, key_len, metadata);
-  if (all_decryptors != nullptr) {
-    all_decryptors->push_back(decryptor);
-  }
-  return decryptor;
+  return std::make_shared<AesDecryptor>(alg_id, key_len, metadata);
 }
 
 int32_t AesDecryptor::PlaintextLength(int32_t ciphertext_len) const {

--- a/cpp/src/parquet/encryption/encryption_internal.cc
+++ b/cpp/src/parquet/encryption/encryption_internal.cc
@@ -74,7 +74,7 @@ class AesEncryptionContext {
     }
 
     key_length_ = key_len;
-  };
+  }
 
   virtual ~AesEncryptionContext() = default;
 

--- a/cpp/src/parquet/encryption/encryption_internal.cc
+++ b/cpp/src/parquet/encryption/encryption_internal.cc
@@ -79,9 +79,8 @@ class AesEncryptionContext {
   virtual ~AesEncryptionContext() = default;
 
  protected:
-  static inline std::function<void(EVP_CIPHER_CTX*)> ctx_deleter_ = [](EVP_CIPHER_CTX* ctx) {
-    EVP_CIPHER_CTX_free(ctx);
-  };
+  static inline std::function<void(EVP_CIPHER_CTX*)> ctx_deleter_ =
+      [](EVP_CIPHER_CTX* ctx) { EVP_CIPHER_CTX_free(ctx); };
 
   int32_t aes_mode_;
   int32_t key_length_;
@@ -120,7 +119,8 @@ class AesEncryptor::AesEncryptorImpl : public AesEncryptionContext {
   }
 
  private:
-  [[nodiscard]] std::unique_ptr<EVP_CIPHER_CTX, decltype(ctx_deleter_)> NewCipherContext() const;
+  [[nodiscard]] std::unique_ptr<EVP_CIPHER_CTX, decltype(ctx_deleter_)> NewCipherContext()
+      const;
 
   int32_t GcmEncrypt(span<const uint8_t> plaintext, span<const uint8_t> key,
                      span<const uint8_t> nonce, span<const uint8_t> aad,
@@ -133,11 +133,12 @@ class AesEncryptor::AesEncryptorImpl : public AesEncryptionContext {
 AesEncryptor::AesEncryptorImpl::AesEncryptorImpl(ParquetCipher::type alg_id,
                                                  int32_t key_len, bool metadata,
                                                  bool write_length)
-    : AesEncryptionContext(alg_id, key_len, metadata, write_length) { }
+    : AesEncryptionContext(alg_id, key_len, metadata, write_length) {}
 
-std::unique_ptr<EVP_CIPHER_CTX, decltype(AesEncryptionContext::ctx_deleter_)> AesEncryptor::AesEncryptorImpl::NewCipherContext() const {
+std::unique_ptr<EVP_CIPHER_CTX, decltype(AesEncryptionContext::ctx_deleter_)>
+AesEncryptor::AesEncryptorImpl::NewCipherContext() const {
   auto ctx = std::unique_ptr<EVP_CIPHER_CTX, decltype(ctx_deleter_)>(EVP_CIPHER_CTX_new(),
-                                                                   ctx_deleter_);
+                                                                     ctx_deleter_);
   if (!ctx) throw ParquetException("Couldn't init cipher context");
   if (kGcmMode == aes_mode_) {
     // Init AES-GCM with specified key length
@@ -417,7 +418,8 @@ class AesDecryptor::AesDecryptorImpl : AesEncryptionContext {
   }
 
  private:
-  [[nodiscard]] std::unique_ptr<EVP_CIPHER_CTX, decltype(ctx_deleter_)> NewCipherContext() const;
+  [[nodiscard]] std::unique_ptr<EVP_CIPHER_CTX, decltype(ctx_deleter_)> NewCipherContext()
+      const;
 
   /// Get the actual ciphertext length, inclusive of the length buffer length,
   /// and validate that the provided buffer size is large enough.
@@ -440,11 +442,12 @@ AesDecryptor::~AesDecryptor() {}
 AesDecryptor::AesDecryptorImpl::AesDecryptorImpl(ParquetCipher::type alg_id,
                                                  int32_t key_len, bool metadata,
                                                  bool contains_length)
-    : AesEncryptionContext(alg_id, key_len, metadata, contains_length) { }
+    : AesEncryptionContext(alg_id, key_len, metadata, contains_length) {}
 
-std::unique_ptr<EVP_CIPHER_CTX, decltype(AesEncryptionContext::ctx_deleter_)> AesDecryptor::AesDecryptorImpl::NewCipherContext() const {
+std::unique_ptr<EVP_CIPHER_CTX, decltype(AesEncryptionContext::ctx_deleter_)>
+AesDecryptor::AesDecryptorImpl::NewCipherContext() const {
   auto ctx = std::unique_ptr<EVP_CIPHER_CTX, decltype(ctx_deleter_)>(EVP_CIPHER_CTX_new(),
-                                                                   ctx_deleter_);
+                                                                     ctx_deleter_);
   if (!ctx) throw ParquetException("Couldn't init cipher context");
   if (kGcmMode == aes_mode_) {
     // Init AES-GCM with specified key length
@@ -490,8 +493,8 @@ AesDecryptor::AesDecryptor(ParquetCipher::type alg_id, int32_t key_len, bool met
     : impl_{std::unique_ptr<AesDecryptorImpl>(
           new AesDecryptorImpl(alg_id, key_len, metadata, contains_length))} {}
 
-std::shared_ptr<AesDecryptor> AesDecryptor::Make(
-    ParquetCipher::type alg_id, int32_t key_len, bool metadata) {
+std::shared_ptr<AesDecryptor> AesDecryptor::Make(ParquetCipher::type alg_id,
+                                                 int32_t key_len, bool metadata) {
   if (ParquetCipher::AES_GCM_V1 != alg_id && ParquetCipher::AES_GCM_CTR_V1 != alg_id) {
     std::stringstream ss;
     ss << "Crypto algorithm " << alg_id << " is not supported";

--- a/cpp/src/parquet/encryption/encryption_internal.cc
+++ b/cpp/src/parquet/encryption/encryption_internal.cc
@@ -79,9 +79,7 @@ class AesCryptoContext {
   virtual ~AesCryptoContext() = default;
 
  protected:
-  static void DeleteCipherContext(EVP_CIPHER_CTX* ctx) {
-    EVP_CIPHER_CTX_free(ctx);
-  }
+  static void DeleteCipherContext(EVP_CIPHER_CTX* ctx) { EVP_CIPHER_CTX_free(ctx); }
 
   using CipherContext = std::unique_ptr<EVP_CIPHER_CTX, decltype(&DeleteCipherContext)>;
 
@@ -141,8 +139,7 @@ AesEncryptor::AesEncryptorImpl::AesEncryptorImpl(ParquetCipher::type alg_id,
                                                  bool write_length)
     : AesCryptoContext(alg_id, key_len, metadata, write_length) {}
 
-AesCryptoContext::CipherContext
-AesEncryptor::AesEncryptorImpl::NewCipherContext() const {
+AesCryptoContext::CipherContext AesEncryptor::AesEncryptorImpl::NewCipherContext() const {
   auto ctx = AesCryptoContext::NewCipherContext();
   if (!ctx) throw ParquetException("Couldn't init cipher context");
   if (kGcmMode == aes_mode_) {
@@ -423,8 +420,7 @@ class AesDecryptor::AesDecryptorImpl : AesCryptoContext {
   }
 
  private:
-  [[nodiscard]] CipherContext NewCipherContext()
-      const;
+  [[nodiscard]] CipherContext NewCipherContext() const;
 
   /// Get the actual ciphertext length, inclusive of the length buffer length,
   /// and validate that the provided buffer size is large enough.
@@ -449,8 +445,7 @@ AesDecryptor::AesDecryptorImpl::AesDecryptorImpl(ParquetCipher::type alg_id,
                                                  bool contains_length)
     : AesCryptoContext(alg_id, key_len, metadata, contains_length) {}
 
-AesCryptoContext::CipherContext
-AesDecryptor::AesDecryptorImpl::NewCipherContext() const {
+AesCryptoContext::CipherContext AesDecryptor::AesDecryptorImpl::NewCipherContext() const {
   auto ctx = AesCryptoContext::NewCipherContext();
   if (!ctx) throw ParquetException("Couldn't init cipher context");
   if (kGcmMode == aes_mode_) {

--- a/cpp/src/parquet/encryption/encryption_internal.h
+++ b/cpp/src/parquet/encryption/encryption_internal.h
@@ -44,6 +44,8 @@ constexpr int8_t kOffsetIndex = 7;
 constexpr int8_t kBloomFilterHeader = 8;
 constexpr int8_t kBloomFilterBitset = 9;
 
+class AesEncryptionContext;
+
 /// Performs AES encryption operations with GCM or CTR ciphers.
 class PARQUET_EXPORT AesEncryptor {
  public:
@@ -76,8 +78,6 @@ class PARQUET_EXPORT AesEncryptor {
                               ::arrow::util::span<const uint8_t> aad,
                               ::arrow::util::span<const uint8_t> nonce,
                               ::arrow::util::span<uint8_t> encrypted_footer);
-
-  void WipeOut();
 
  private:
   // PIMPL Idiom

--- a/cpp/src/parquet/encryption/encryption_internal.h
+++ b/cpp/src/parquet/encryption/encryption_internal.h
@@ -106,7 +106,6 @@ class PARQUET_EXPORT AesDecryptor {
       std::vector<std::weak_ptr<AesDecryptor>>* all_decryptors);
 
   ~AesDecryptor();
-  void WipeOut();
 
   /// The size of the plaintext, for this cipher and the specified ciphertext length.
   [[nodiscard]] int32_t PlaintextLength(int32_t ciphertext_len) const;

--- a/cpp/src/parquet/encryption/encryption_internal.h
+++ b/cpp/src/parquet/encryption/encryption_internal.h
@@ -98,12 +98,10 @@ class PARQUET_EXPORT AesDecryptor {
   /// \param alg_id the encryption algorithm to use
   /// \param key_len key length. Possible values: 16, 24, 32 bytes.
   /// \param metadata if true then this is a metadata decryptor
-  /// \param all_decryptors A weak reference to all decryptors that need to be wiped
   /// out when decryption is finished
   /// \return shared pointer to a new AesDecryptor
   static std::shared_ptr<AesDecryptor> Make(
-      ParquetCipher::type alg_id, int32_t key_len, bool metadata,
-      std::vector<std::weak_ptr<AesDecryptor>>* all_decryptors);
+      ParquetCipher::type alg_id, int32_t key_len, bool metadata);
 
   ~AesDecryptor();
 

--- a/cpp/src/parquet/encryption/encryption_internal.h
+++ b/cpp/src/parquet/encryption/encryption_internal.h
@@ -53,10 +53,7 @@ class PARQUET_EXPORT AesEncryptor {
                         bool write_length = true);
 
   static std::unique_ptr<AesEncryptor> Make(ParquetCipher::type alg_id, int32_t key_len,
-                                            bool metadata);
-
-  static std::unique_ptr<AesEncryptor> Make(ParquetCipher::type alg_id, int32_t key_len,
-                                            bool metadata, bool write_length);
+                                            bool metadata, bool write_length = true);
 
   ~AesEncryptor();
 
@@ -86,19 +83,16 @@ class PARQUET_EXPORT AesEncryptor {
 /// Performs AES decryption operations with GCM or CTR ciphers.
 class PARQUET_EXPORT AesDecryptor {
  public:
-  /// Can serve one key length only. Possible values: 16, 24, 32 bytes.
-  /// If contains_length is true, expect ciphertext length prepended to the ciphertext
-  explicit AesDecryptor(ParquetCipher::type alg_id, int32_t key_len, bool metadata,
-                        bool contains_length = true);
-
-  /// \brief Factory function to create an AesDecryptor
+  /// \brief Construct an AesDecryptor
   ///
   /// \param alg_id the encryption algorithm to use
   /// \param key_len key length. Possible values: 16, 24, 32 bytes.
   /// \param metadata if true then this is a metadata decryptor
-  /// out when decryption is finished
-  /// \return shared pointer to a new AesDecryptor
-  static std::shared_ptr<AesDecryptor> Make(ParquetCipher::type alg_id, int32_t key_len,
+  /// \param contains_length if true, expect ciphertext length prepended to the ciphertext
+  explicit AesDecryptor(ParquetCipher::type alg_id, int32_t key_len, bool metadata,
+                        bool contains_length = true);
+
+  static std::unique_ptr<AesDecryptor> Make(ParquetCipher::type alg_id, int32_t key_len,
                                             bool metadata);
 
   ~AesDecryptor();

--- a/cpp/src/parquet/encryption/encryption_internal.h
+++ b/cpp/src/parquet/encryption/encryption_internal.h
@@ -44,8 +44,6 @@ constexpr int8_t kOffsetIndex = 7;
 constexpr int8_t kBloomFilterHeader = 8;
 constexpr int8_t kBloomFilterBitset = 9;
 
-class AesEncryptionContext;
-
 /// Performs AES encryption operations with GCM or CTR ciphers.
 class PARQUET_EXPORT AesEncryptor {
  public:

--- a/cpp/src/parquet/encryption/encryption_internal.h
+++ b/cpp/src/parquet/encryption/encryption_internal.h
@@ -98,8 +98,8 @@ class PARQUET_EXPORT AesDecryptor {
   /// \param metadata if true then this is a metadata decryptor
   /// out when decryption is finished
   /// \return shared pointer to a new AesDecryptor
-  static std::shared_ptr<AesDecryptor> Make(
-      ParquetCipher::type alg_id, int32_t key_len, bool metadata);
+  static std::shared_ptr<AesDecryptor> Make(ParquetCipher::type alg_id, int32_t key_len,
+                                            bool metadata);
 
   ~AesDecryptor();
 

--- a/cpp/src/parquet/encryption/encryption_internal_nossl.cc
+++ b/cpp/src/parquet/encryption/encryption_internal_nossl.cc
@@ -38,8 +38,6 @@ int32_t AesEncryptor::SignedFooterEncrypt(::arrow::util::span<const uint8_t> foo
   return -1;
 }
 
-void AesEncryptor::WipeOut() { ThrowOpenSSLRequiredException(); }
-
 int32_t AesEncryptor::CiphertextLength(int64_t plaintext_len) const {
   ThrowOpenSSLRequiredException();
   return -1;
@@ -67,8 +65,6 @@ int32_t AesDecryptor::Decrypt(::arrow::util::span<const uint8_t> ciphertext,
   ThrowOpenSSLRequiredException();
   return -1;
 }
-
-void AesDecryptor::WipeOut() { ThrowOpenSSLRequiredException(); }
 
 AesDecryptor::~AesDecryptor() {}
 

--- a/cpp/src/parquet/encryption/encryption_internal_nossl.cc
+++ b/cpp/src/parquet/encryption/encryption_internal_nossl.cc
@@ -86,9 +86,8 @@ AesDecryptor::AesDecryptor(ParquetCipher::type alg_id, int32_t key_len, bool met
   ThrowOpenSSLRequiredException();
 }
 
-std::shared_ptr<AesDecryptor> AesDecryptor::Make(
-    ParquetCipher::type alg_id, int32_t key_len, bool metadata,
-    std::vector<std::weak_ptr<AesDecryptor>>* all_decryptors) {
+std::shared_ptr<AesDecryptor> AesDecryptor::Make(ParquetCipher::type alg_id,
+                                                 int32_t key_len, bool metadata) {
   ThrowOpenSSLRequiredException();
   return NULLPTR;
 }

--- a/cpp/src/parquet/encryption/encryption_internal_nossl.cc
+++ b/cpp/src/parquet/encryption/encryption_internal_nossl.cc
@@ -69,12 +69,6 @@ int32_t AesDecryptor::Decrypt(::arrow::util::span<const uint8_t> ciphertext,
 AesDecryptor::~AesDecryptor() {}
 
 std::unique_ptr<AesEncryptor> AesEncryptor::Make(ParquetCipher::type alg_id,
-                                                 int32_t key_len, bool metadata) {
-  ThrowOpenSSLRequiredException();
-  return NULLPTR;
-}
-
-std::unique_ptr<AesEncryptor> AesEncryptor::Make(ParquetCipher::type alg_id,
                                                  int32_t key_len, bool metadata,
                                                  bool write_length) {
   ThrowOpenSSLRequiredException();
@@ -86,7 +80,7 @@ AesDecryptor::AesDecryptor(ParquetCipher::type alg_id, int32_t key_len, bool met
   ThrowOpenSSLRequiredException();
 }
 
-std::shared_ptr<AesDecryptor> AesDecryptor::Make(ParquetCipher::type alg_id,
+std::unique_ptr<AesDecryptor> AesDecryptor::Make(ParquetCipher::type alg_id,
                                                  int32_t key_len, bool metadata) {
   ThrowOpenSSLRequiredException();
   return NULLPTR;

--- a/cpp/src/parquet/encryption/internal_file_decryptor.cc
+++ b/cpp/src/parquet/encryption/internal_file_decryptor.cc
@@ -64,12 +64,16 @@ InternalFileDecryptor::InternalFileDecryptor(FileDecryptionProperties* propertie
   properties_->set_utilized();
 }
 
+InternalFileDecryptor::~InternalFileDecryptor() { WipeOutDecryptionKeys(); }
+
 void InternalFileDecryptor::WipeOutDecryptionKeys() {
+  std::unique_lock lock(mutex_);
   properties_->WipeOutDecryptionKeys();
   footer_key_.clear();
 }
 
 std::string InternalFileDecryptor::GetFooterKey() {
+  std::unique_lock lock(mutex_);
   if (!footer_key_.empty()) {
     return footer_key_;
   }

--- a/cpp/src/parquet/encryption/internal_file_decryptor.cc
+++ b/cpp/src/parquet/encryption/internal_file_decryptor.cc
@@ -141,10 +141,10 @@ std::shared_ptr<Decryptor> InternalFileDecryptor::GetFooterDecryptor(
   std::shared_ptr<encryption::AesDecryptor> aes_metadata_decryptor;
   std::shared_ptr<encryption::AesDecryptor> aes_data_decryptor;
 
-  aes_metadata_decryptor = encryption::AesDecryptor::Make(
-      algorithm_, key_len, /*metadata=*/true);
-  aes_data_decryptor = encryption::AesDecryptor::Make(
-      algorithm_, key_len, /*metadata=*/false);
+  aes_metadata_decryptor =
+      encryption::AesDecryptor::Make(algorithm_, key_len, /*metadata=*/true);
+  aes_data_decryptor =
+      encryption::AesDecryptor::Make(algorithm_, key_len, /*metadata=*/false);
 
   footer_metadata_decryptor_ = std::make_shared<Decryptor>(
       std::move(aes_metadata_decryptor), footer_key, file_aad_, aad, pool_);
@@ -189,8 +189,7 @@ std::shared_ptr<Decryptor> InternalFileDecryptor::GetColumnDecryptor(
   }
 
   auto key_len = static_cast<int32_t>(column_key.size());
-  auto aes_decryptor =
-      encryption::AesDecryptor::Make(algorithm_, key_len, metadata);
+  auto aes_decryptor = encryption::AesDecryptor::Make(algorithm_, key_len, metadata);
   return std::make_shared<Decryptor>(std::move(aes_decryptor), column_key, file_aad_, aad,
                                      pool_);
 }

--- a/cpp/src/parquet/encryption/internal_file_decryptor.cc
+++ b/cpp/src/parquet/encryption/internal_file_decryptor.cc
@@ -64,16 +64,6 @@ InternalFileDecryptor::InternalFileDecryptor(FileDecryptionProperties* propertie
   properties_->set_utilized();
 }
 
-void InternalFileDecryptor::WipeOutDecryptionKeys() {
-  std::lock_guard<std::mutex> lock(mutex_);
-  properties_->WipeOutDecryptionKeys();
-  for (auto const& i : all_decryptors_) {
-    if (auto aes_decryptor = i.lock()) {
-      aes_decryptor->WipeOut();
-    }
-  }
-}
-
 std::string InternalFileDecryptor::GetFooterKey() {
   std::string footer_key = properties_->footer_key();
   // ignore footer key metadata if footer key is explicitly set via API

--- a/cpp/src/parquet/encryption/internal_file_decryptor.cc
+++ b/cpp/src/parquet/encryption/internal_file_decryptor.cc
@@ -194,18 +194,22 @@ std::shared_ptr<Decryptor> GetColumnDecryptor(
 
 }  // namespace
 
-std::shared_ptr<Decryptor> GetColumnMetaDecryptor(
+std::function<std::shared_ptr<Decryptor>()> GetColumnMetaDecryptor(
     const ColumnCryptoMetaData* crypto_metadata, InternalFileDecryptor* file_decryptor) {
-  return GetColumnDecryptor(crypto_metadata, file_decryptor,
-                            &InternalFileDecryptor::GetColumnMetaDecryptor,
-                            /*metadata=*/true);
+  return [&]() -> std::shared_ptr<Decryptor> {
+    return GetColumnDecryptor(crypto_metadata, file_decryptor,
+               &InternalFileDecryptor::GetColumnMetaDecryptor,
+               /*metadata=*/true);
+  };
 }
 
-std::shared_ptr<Decryptor> GetColumnDataDecryptor(
+std::function<std::shared_ptr<Decryptor>()> GetColumnDataDecryptor(
     const ColumnCryptoMetaData* crypto_metadata, InternalFileDecryptor* file_decryptor) {
-  return GetColumnDecryptor(crypto_metadata, file_decryptor,
-                            &InternalFileDecryptor::GetColumnDataDecryptor,
-                            /*metadata=*/false);
+  return [&]() -> std::shared_ptr<Decryptor> {
+    return GetColumnDecryptor(crypto_metadata, file_decryptor,
+                              &InternalFileDecryptor::GetColumnDataDecryptor,
+                              /*metadata=*/false);
+  };
 }
 
 void UpdateDecryptor(const std::shared_ptr<Decryptor>& decryptor,

--- a/cpp/src/parquet/encryption/internal_file_decryptor.cc
+++ b/cpp/src/parquet/encryption/internal_file_decryptor.cc
@@ -137,13 +137,10 @@ std::shared_ptr<Decryptor> InternalFileDecryptor::GetFooterDecryptor(
   std::shared_ptr<encryption::AesDecryptor> aes_metadata_decryptor;
   std::shared_ptr<encryption::AesDecryptor> aes_data_decryptor;
 
-  {
-    std::lock_guard<std::mutex> lock(mutex_);
-    aes_metadata_decryptor = encryption::AesDecryptor::Make(
-        algorithm_, key_len, /*metadata=*/true, &all_decryptors_);
-    aes_data_decryptor = encryption::AesDecryptor::Make(
-        algorithm_, key_len, /*metadata=*/false, &all_decryptors_);
-  }
+  aes_metadata_decryptor = encryption::AesDecryptor::Make(
+      algorithm_, key_len, /*metadata=*/true);
+  aes_data_decryptor = encryption::AesDecryptor::Make(
+      algorithm_, key_len, /*metadata=*/false);
 
   footer_metadata_decryptor_ = std::make_shared<Decryptor>(
       std::move(aes_metadata_decryptor), footer_key, file_aad_, aad, pool_);
@@ -188,9 +185,8 @@ std::shared_ptr<Decryptor> InternalFileDecryptor::GetColumnDecryptor(
   }
 
   auto key_len = static_cast<int32_t>(column_key.size());
-  std::lock_guard<std::mutex> lock(mutex_);
   auto aes_decryptor =
-      encryption::AesDecryptor::Make(algorithm_, key_len, metadata, &all_decryptors_);
+      encryption::AesDecryptor::Make(algorithm_, key_len, metadata);
   return std::make_shared<Decryptor>(std::move(aes_decryptor), column_key, file_aad_, aad,
                                      pool_);
 }

--- a/cpp/src/parquet/encryption/internal_file_decryptor.cc
+++ b/cpp/src/parquet/encryption/internal_file_decryptor.cc
@@ -64,6 +64,10 @@ InternalFileDecryptor::InternalFileDecryptor(FileDecryptionProperties* propertie
   properties_->set_utilized();
 }
 
+void InternalFileDecryptor::WipeOutDecryptionKeys() {
+  properties_->WipeOutDecryptionKeys();
+}
+
 std::string InternalFileDecryptor::GetFooterKey() {
   std::string footer_key = properties_->footer_key();
   // ignore footer key metadata if footer key is explicitly set via API

--- a/cpp/src/parquet/encryption/internal_file_decryptor.h
+++ b/cpp/src/parquet/encryption/internal_file_decryptor.h
@@ -63,12 +63,11 @@ class PARQUET_EXPORT Decryptor {
 
 class InternalFileDecryptor {
  public:
-  explicit InternalFileDecryptor(FileDecryptionProperties* properties,
+  explicit InternalFileDecryptor(std::shared_ptr<FileDecryptionProperties> properties,
                                  const std::string& file_aad,
                                  ParquetCipher::type algorithm,
                                  const std::string& footer_key_metadata,
                                  ::arrow::MemoryPool* pool);
-  ~InternalFileDecryptor();
 
   const std::string& file_aad() const { return file_aad_; }
 
@@ -78,9 +77,9 @@ class InternalFileDecryptor {
 
   const std::string& footer_key_metadata() const { return footer_key_metadata_; }
 
-  const FileDecryptionProperties* properties() const { return properties_; }
-
-  void WipeOutDecryptionKeys();
+  const std::shared_ptr<FileDecryptionProperties>& properties() const {
+    return properties_;
+  }
 
   ::arrow::MemoryPool* pool() const { return pool_; }
 
@@ -119,7 +118,7 @@ class InternalFileDecryptor {
       const std::string& aad = "");
 
  private:
-  FileDecryptionProperties* properties_;
+  std::shared_ptr<FileDecryptionProperties> properties_;
   // Concatenation of aad_prefix (if exists) and aad_file_unique
   std::string file_aad_;
   ParquetCipher::type algorithm_;

--- a/cpp/src/parquet/encryption/internal_file_decryptor.h
+++ b/cpp/src/parquet/encryption/internal_file_decryptor.h
@@ -94,10 +94,9 @@ class InternalFileDecryptor {
   // Concatenation of aad_prefix (if exists) and aad_file_unique
   std::string file_aad_;
 
-  std::shared_ptr<Decryptor> footer_metadata_decryptor_;
-  std::shared_ptr<Decryptor> footer_data_decryptor_;
   ParquetCipher::type algorithm_;
   std::string footer_key_metadata_;
+  std::string footer_key_;
   ::arrow::MemoryPool* pool_;
 
   std::shared_ptr<Decryptor> GetFooterDecryptor(const std::string& aad, bool metadata);

--- a/cpp/src/parquet/encryption/internal_file_decryptor.h
+++ b/cpp/src/parquet/encryption/internal_file_decryptor.h
@@ -19,7 +19,6 @@
 
 #include <map>
 #include <memory>
-#include <mutex>
 #include <string>
 #include <vector>
 
@@ -75,6 +74,8 @@ class InternalFileDecryptor {
   std::string& footer_key_metadata() { return footer_key_metadata_; }
 
   FileDecryptionProperties* properties() { return properties_; }
+
+  void WipeOutDecryptionKeys();
 
   ::arrow::MemoryPool* pool() { return pool_; }
 

--- a/cpp/src/parquet/encryption/internal_file_decryptor.h
+++ b/cpp/src/parquet/encryption/internal_file_decryptor.h
@@ -107,11 +107,11 @@ class InternalFileDecryptor {
 };
 
 /// Utility to get column meta decryptor of an encrypted column.
-std::shared_ptr<Decryptor> GetColumnMetaDecryptor(
+std::function<std::shared_ptr<Decryptor>()> GetColumnMetaDecryptor(
     const ColumnCryptoMetaData* crypto_metadata, InternalFileDecryptor* file_decryptor);
 
 /// Utility to get column data decryptor of an encrypted column.
-std::shared_ptr<Decryptor> GetColumnDataDecryptor(
+std::function<std::shared_ptr<Decryptor>()> GetColumnDataDecryptor(
     const ColumnCryptoMetaData* crypto_metadata, InternalFileDecryptor* file_decryptor);
 
 void UpdateDecryptor(const std::shared_ptr<Decryptor>& decryptor,

--- a/cpp/src/parquet/encryption/internal_file_decryptor.h
+++ b/cpp/src/parquet/encryption/internal_file_decryptor.h
@@ -17,8 +17,8 @@
 
 #pragma once
 
-#include <map>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -64,20 +64,21 @@ class InternalFileDecryptor {
                                  ParquetCipher::type algorithm,
                                  const std::string& footer_key_metadata,
                                  ::arrow::MemoryPool* pool);
+  ~InternalFileDecryptor();
 
-  std::string& file_aad() { return file_aad_; }
+  const std::string& file_aad() const { return file_aad_; }
 
   std::string GetFooterKey();
 
-  ParquetCipher::type algorithm() { return algorithm_; }
+  ParquetCipher::type algorithm() const { return algorithm_; }
 
-  std::string& footer_key_metadata() { return footer_key_metadata_; }
+  const std::string& footer_key_metadata() const { return footer_key_metadata_; }
 
-  FileDecryptionProperties* properties() { return properties_; }
+  const FileDecryptionProperties* properties() const { return properties_; }
 
   void WipeOutDecryptionKeys();
 
-  ::arrow::MemoryPool* pool() { return pool_; }
+  ::arrow::MemoryPool* pool() const { return pool_; }
 
   std::shared_ptr<Decryptor> GetFooterDecryptor();
 
@@ -105,11 +106,13 @@ class InternalFileDecryptor {
   FileDecryptionProperties* properties_;
   // Concatenation of aad_prefix (if exists) and aad_file_unique
   std::string file_aad_;
-
   ParquetCipher::type algorithm_;
   std::string footer_key_metadata_;
-  std::string footer_key_;
   ::arrow::MemoryPool* pool_;
+
+  // Protects footer_key_ updates
+  std::mutex mutex_;
+  std::string footer_key_;
 
   std::string GetColumnKey(const std::string& column_path,
                            const std::string& column_key_metadata);

--- a/cpp/src/parquet/encryption/internal_file_decryptor.h
+++ b/cpp/src/parquet/encryption/internal_file_decryptor.h
@@ -97,12 +97,6 @@ class InternalFileDecryptor {
   std::shared_ptr<Decryptor> footer_data_decryptor_;
   ParquetCipher::type algorithm_;
   std::string footer_key_metadata_;
-  // Mutex to guard access to all_decryptors_
-  mutable std::mutex mutex_;
-  // A weak reference to all decryptors that need to be wiped out when decryption is
-  // finished, guarded by mutex_ for thread safety
-  std::vector<std::weak_ptr<encryption::AesDecryptor>> all_decryptors_;
-
   ::arrow::MemoryPool* pool_;
 
   std::shared_ptr<Decryptor> GetFooterDecryptor(const std::string& aad, bool metadata);

--- a/cpp/src/parquet/encryption/internal_file_decryptor.h
+++ b/cpp/src/parquet/encryption/internal_file_decryptor.h
@@ -76,8 +76,6 @@ class InternalFileDecryptor {
 
   FileDecryptionProperties* properties() { return properties_; }
 
-  void WipeOutDecryptionKeys();
-
   ::arrow::MemoryPool* pool() { return pool_; }
 
   std::shared_ptr<Decryptor> GetFooterDecryptor();

--- a/cpp/src/parquet/encryption/internal_file_encryptor.cc
+++ b/cpp/src/parquet/encryption/internal_file_encryptor.cc
@@ -43,16 +43,7 @@ int32_t Encryptor::Encrypt(::arrow::util::span<const uint8_t> plaintext,
 // InternalFileEncryptor
 InternalFileEncryptor::InternalFileEncryptor(FileEncryptionProperties* properties,
                                              ::arrow::MemoryPool* pool)
-    : properties_(properties), pool_(pool) {
-  if (properties_->is_utilized()) {
-    throw ParquetException("Re-using encryption properties for another file");
-  }
-  properties_->set_utilized();
-}
-
-void InternalFileEncryptor::WipeOutEncryptionKeys() {
-  properties_->WipeOutEncryptionKeys();
-}
+    : properties_(properties), pool_(pool) {}
 
 std::shared_ptr<Encryptor> InternalFileEncryptor::GetFooterEncryptor() {
   if (footer_encryptor_ != nullptr) {

--- a/cpp/src/parquet/encryption/internal_file_encryptor.cc
+++ b/cpp/src/parquet/encryption/internal_file_encryptor.cc
@@ -50,6 +50,10 @@ InternalFileEncryptor::InternalFileEncryptor(FileEncryptionProperties* propertie
   properties_->set_utilized();
 }
 
+void InternalFileEncryptor::WipeOutEncryptionKeys() {
+  properties_->WipeOutEncryptionKeys();
+}
+
 std::shared_ptr<Encryptor> InternalFileEncryptor::GetFooterEncryptor() {
   if (footer_encryptor_ != nullptr) {
     return footer_encryptor_;

--- a/cpp/src/parquet/encryption/internal_file_encryptor.cc
+++ b/cpp/src/parquet/encryption/internal_file_encryptor.cc
@@ -50,21 +50,6 @@ InternalFileEncryptor::InternalFileEncryptor(FileEncryptionProperties* propertie
   properties_->set_utilized();
 }
 
-void InternalFileEncryptor::WipeOutEncryptionKeys() {
-  properties_->WipeOutEncryptionKeys();
-
-  for (auto const& i : meta_encryptor_) {
-    if (i != nullptr) {
-      i->WipeOut();
-    }
-  }
-  for (auto const& i : data_encryptor_) {
-    if (i != nullptr) {
-      i->WipeOut();
-    }
-  }
-}
-
 std::shared_ptr<Encryptor> InternalFileEncryptor::GetFooterEncryptor() {
   if (footer_encryptor_ != nullptr) {
     return footer_encryptor_;

--- a/cpp/src/parquet/encryption/internal_file_encryptor.h
+++ b/cpp/src/parquet/encryption/internal_file_encryptor.h
@@ -77,7 +77,6 @@ class InternalFileEncryptor {
   std::shared_ptr<Encryptor> GetFooterSigningEncryptor();
   std::shared_ptr<Encryptor> GetColumnMetaEncryptor(const std::string& column_path);
   std::shared_ptr<Encryptor> GetColumnDataEncryptor(const std::string& column_path);
-  void WipeOutEncryptionKeys();
 
  private:
   FileEncryptionProperties* properties_;

--- a/cpp/src/parquet/encryption/internal_file_encryptor.h
+++ b/cpp/src/parquet/encryption/internal_file_encryptor.h
@@ -77,6 +77,7 @@ class InternalFileEncryptor {
   std::shared_ptr<Encryptor> GetFooterSigningEncryptor();
   std::shared_ptr<Encryptor> GetColumnMetaEncryptor(const std::string& column_path);
   std::shared_ptr<Encryptor> GetColumnDataEncryptor(const std::string& column_path);
+  void WipeOutEncryptionKeys();
 
  private:
   FileEncryptionProperties* properties_;

--- a/cpp/src/parquet/encryption/key_management_test.cc
+++ b/cpp/src/parquet/encryption/key_management_test.cc
@@ -57,12 +57,17 @@ class TestEncryptionKeyManagement : public ::testing::Test {
 #ifndef ARROW_WITH_SNAPPY
     GTEST_SKIP() << "Test requires Snappy compression";
 #endif
+    ARROW_LOG(INFO) << "SetUp 1";
     key_list_ = BuildKeyMap(kColumnMasterKeyIds, kColumnMasterKeys, kFooterMasterKeyId,
                             kFooterMasterKey);
+    ARROW_LOG(INFO) << "SetUp 2";
     new_key_list_ = BuildKeyMap(kColumnMasterKeyIds, kNewColumnMasterKeys,
                                 kFooterMasterKeyId, kNewFooterMasterKey);
+    ARROW_LOG(INFO) << "SetUp 3";
     column_key_mapping_ = BuildColumnKeyMapping();
+    ARROW_LOG(INFO) << "SetUp 4";
     temp_dir_ = temp_data_dir().ValueOrDie();
+    ARROW_LOG(INFO) << "SetUp 5";
   }
 
   void SetupCryptoFactory(bool wrap_locally) {
@@ -255,15 +260,19 @@ class TestEncryptionKeyManagementMultiThread : public TestEncryptionKeyManagemen
 };
 
 TEST_F(TestEncryptionKeyManagement, WrapLocally) {
+  ARROW_LOG(INFO) << "WrapLocally 1";
   this->SetupCryptoFactory(true);
 
   for (const bool internal_key_material : {false, true}) {
     for (const bool double_wrapping : {false, true}) {
       for (int encryption_no = 0; encryption_no < 4; encryption_no++) {
+        ARROW_LOG(INFO) << "WrapLocally 2";
         this->WriteEncryptedParquetFile(double_wrapping, internal_key_material,
                                         encryption_no);
+        ARROW_LOG(INFO) << "WrapLocally 3";
         this->ReadEncryptedParquetFile(double_wrapping, internal_key_material,
                                        encryption_no);
+        ARROW_LOG(INFO) << "WrapLocally 4";
       }
     }
   }

--- a/cpp/src/parquet/encryption/key_management_test.cc
+++ b/cpp/src/parquet/encryption/key_management_test.cc
@@ -414,7 +414,7 @@ TEST_F(TestEncryptionKeyManagement, ReadParquetMRExternalKeyMaterialFile) {
       kms_connection_config_, decryption_config, file_path, file_system);
 
   parquet::ReaderProperties reader_properties = parquet::default_reader_properties();
-  reader_properties.file_decryption_properties(file_decryption_properties->DeepClone());
+  reader_properties.file_decryption_properties(file_decryption_properties);
 
   std::shared_ptr<::arrow::io::RandomAccessFile> source;
   PARQUET_ASSIGN_OR_THROW(source, ::arrow::io::ReadableFile::Open(

--- a/cpp/src/parquet/encryption/key_management_test.cc
+++ b/cpp/src/parquet/encryption/key_management_test.cc
@@ -57,17 +57,12 @@ class TestEncryptionKeyManagement : public ::testing::Test {
 #ifndef ARROW_WITH_SNAPPY
     GTEST_SKIP() << "Test requires Snappy compression";
 #endif
-    ARROW_LOG(INFO) << "SetUp 1";
     key_list_ = BuildKeyMap(kColumnMasterKeyIds, kColumnMasterKeys, kFooterMasterKeyId,
                             kFooterMasterKey);
-    ARROW_LOG(INFO) << "SetUp 2";
     new_key_list_ = BuildKeyMap(kColumnMasterKeyIds, kNewColumnMasterKeys,
                                 kFooterMasterKeyId, kNewFooterMasterKey);
-    ARROW_LOG(INFO) << "SetUp 3";
     column_key_mapping_ = BuildColumnKeyMapping();
-    ARROW_LOG(INFO) << "SetUp 4";
     temp_dir_ = temp_data_dir().ValueOrDie();
-    ARROW_LOG(INFO) << "SetUp 5";
   }
 
   void SetupCryptoFactory(bool wrap_locally) {
@@ -260,19 +255,15 @@ class TestEncryptionKeyManagementMultiThread : public TestEncryptionKeyManagemen
 };
 
 TEST_F(TestEncryptionKeyManagement, WrapLocally) {
-  ARROW_LOG(INFO) << "WrapLocally 1";
   this->SetupCryptoFactory(true);
 
   for (const bool internal_key_material : {false, true}) {
     for (const bool double_wrapping : {false, true}) {
       for (int encryption_no = 0; encryption_no < 4; encryption_no++) {
-        ARROW_LOG(INFO) << "WrapLocally 2";
         this->WriteEncryptedParquetFile(double_wrapping, internal_key_material,
                                         encryption_no);
-        ARROW_LOG(INFO) << "WrapLocally 3";
         this->ReadEncryptedParquetFile(double_wrapping, internal_key_material,
                                        encryption_no);
-        ARROW_LOG(INFO) << "WrapLocally 4";
       }
     }
   }

--- a/cpp/src/parquet/encryption/read_configurations_test.cc
+++ b/cpp/src/parquet/encryption/read_configurations_test.cc
@@ -176,7 +176,7 @@ class TestDecryptionConfiguration
     std::shared_ptr<FileDecryptionProperties> file_decryption_properties;
     if (vector_of_decryption_configurations_[decryption_config_num]) {
       file_decryption_properties =
-          vector_of_decryption_configurations_[decryption_config_num]->DeepClone();
+          vector_of_decryption_configurations_[decryption_config_num];
     }
 
     decrypt_func(std::move(file), std::move(file_decryption_properties));
@@ -185,7 +185,7 @@ class TestDecryptionConfiguration
   std::shared_ptr<FileDecryptionProperties> GetDecryptionProperties(
       int decryption_config_num) {
     const auto props = vector_of_decryption_configurations_[decryption_config_num];
-    return props ? props->DeepClone() : nullptr;
+    return props;
   }
 
   void DecryptFile(const std::string& file, int decryption_config_num) {

--- a/cpp/src/parquet/encryption/read_configurations_test.cc
+++ b/cpp/src/parquet/encryption/read_configurations_test.cc
@@ -23,7 +23,6 @@
 #include "arrow/io/file.h"
 #include "arrow/testing/gtest_compat.h"
 #include "arrow/util/config.h"
-#include "arrow/util/logging.h"
 
 #include "parquet/column_reader.h"
 #include "parquet/column_writer.h"
@@ -243,14 +242,11 @@ class TestDecryptionConfiguration
 // once the file is read and the second exists in parquet-testing/data folder.
 // The name of the files are passed as parameters to the unit-test.
 TEST_P(TestDecryptionConfiguration, TestDecryption) {
-  ARROW_LOG(INFO) << "TestDecryption 1";
   int encryption_config_num = std::get<0>(GetParam());
   const char* param_file_name = std::get<1>(GetParam());
   // Decrypt parquet file that was generated in write_configurations_test.cc test.
-  ARROW_LOG(INFO) << "TestDecryption 2";
   std::string tmp_file_name = "tmp_" + std::string(param_file_name);
   std::string file_name = temp_dir->path().ToString() + tmp_file_name;
-  ARROW_LOG(INFO) << "TestDecryption 3";
   if (!fexists(file_name)) {
     std::stringstream ss;
     ss << "File " << file_name << " is missing from temporary dir.";
@@ -260,10 +256,8 @@ TEST_P(TestDecryptionConfiguration, TestDecryption) {
   // Iterate over the decryption configurations and use each one to read the encrypted
   // parquet file.
   for (unsigned index = 0; index < vector_of_decryption_configurations_.size(); ++index) {
-    ARROW_LOG(INFO) << "TestDecryption 4";
     unsigned decryption_config_num = index + 1;
     CheckResults(file_name, decryption_config_num, encryption_config_num);
-    ARROW_LOG(INFO) << "TestDecryption 5";
   }
   // Delete temporary test file.
   ASSERT_EQ(std::remove(file_name.c_str()), 0);
@@ -280,10 +274,8 @@ TEST_P(TestDecryptionConfiguration, TestDecryption) {
   // Iterate over the decryption configurations and use each one to read the encrypted
   // parquet file.
   for (unsigned index = 0; index < vector_of_decryption_configurations_.size(); ++index) {
-    ARROW_LOG(INFO) << "TestDecryption 6";
     unsigned decryption_config_num = index + 1;
     CheckResults(file_name, decryption_config_num, encryption_config_num);
-    ARROW_LOG(INFO) << "TestDecryption 7";
   }
 }
 

--- a/cpp/src/parquet/encryption/test_encryption_util.cc
+++ b/cpp/src/parquet/encryption/test_encryption_util.cc
@@ -351,7 +351,7 @@ void FileDecryptor::DecryptFile(
   std::string exception_msg;
   parquet::ReaderProperties reader_properties = parquet::default_reader_properties();
   if (file_decryption_properties) {
-    reader_properties.file_decryption_properties(file_decryption_properties->DeepClone());
+    reader_properties.file_decryption_properties(file_decryption_properties);
   }
 
   std::shared_ptr<::arrow::io::RandomAccessFile> source;
@@ -364,7 +364,7 @@ void FileDecryptor::DecryptFile(
   ARROW_LOG(INFO) << ".. DecryptFile 3";
 
   if (file_decryption_properties) {
-    reader_properties.file_decryption_properties(file_decryption_properties->DeepClone());
+    reader_properties.file_decryption_properties(file_decryption_properties);
   }
   auto fut = parquet::ParquetFileReader::OpenAsync(source, reader_properties);
   ASSERT_FINISHES_OK(fut);
@@ -528,7 +528,7 @@ void FileDecryptor::DecryptPageIndex(
   std::string exception_msg;
   parquet::ReaderProperties reader_properties = parquet::default_reader_properties();
   if (file_decryption_properties) {
-    reader_properties.file_decryption_properties(file_decryption_properties->DeepClone());
+    reader_properties.file_decryption_properties(file_decryption_properties);
   }
 
   std::shared_ptr<::arrow::io::RandomAccessFile> source;

--- a/cpp/src/parquet/encryption/test_encryption_util.cc
+++ b/cpp/src/parquet/encryption/test_encryption_util.cc
@@ -24,6 +24,7 @@
 
 #include "arrow/io/file.h"
 #include "arrow/testing/future_util.h"
+#include "arrow/util/logging.h"
 #include "arrow/util/unreachable.h"
 
 #include "parquet/encryption/test_encryption_util.h"
@@ -346,6 +347,7 @@ void ReadAndVerifyColumn(RowGroupReader* rg_reader, RowGroupMetadata* rg_md,
 void FileDecryptor::DecryptFile(
     const std::string& file,
     const std::shared_ptr<FileDecryptionProperties>& file_decryption_properties) {
+  ARROW_LOG(INFO) << ".. DecryptFile 1";
   std::string exception_msg;
   parquet::ReaderProperties reader_properties = parquet::default_reader_properties();
   if (file_decryption_properties) {
@@ -357,18 +359,23 @@ void FileDecryptor::DecryptFile(
       source, ::arrow::io::ReadableFile::Open(file, reader_properties.memory_pool()));
 
   auto file_reader = parquet::ParquetFileReader::Open(source, reader_properties);
+  ARROW_LOG(INFO) << ".. DecryptFile 2";
   CheckFile(file_reader.get(), file_decryption_properties);
+  ARROW_LOG(INFO) << ".. DecryptFile 3";
 
   if (file_decryption_properties) {
     reader_properties.file_decryption_properties(file_decryption_properties->DeepClone());
   }
   auto fut = parquet::ParquetFileReader::OpenAsync(source, reader_properties);
   ASSERT_FINISHES_OK(fut);
+  ARROW_LOG(INFO) << ".. DecryptFile 4";
   ASSERT_OK_AND_ASSIGN(file_reader, fut.MoveResult());
   CheckFile(file_reader.get(), file_decryption_properties);
+  ARROW_LOG(INFO) << ".. DecryptFile 5";
 
   file_reader->Close();
   PARQUET_THROW_NOT_OK(source->Close());
+  ARROW_LOG(INFO) << ".. DecryptFile 6";
 }
 
 void FileDecryptor::CheckFile(
@@ -517,6 +524,7 @@ void FileDecryptor::CheckFile(
 void FileDecryptor::DecryptPageIndex(
     const std::string& file,
     const std::shared_ptr<FileDecryptionProperties>& file_decryption_properties) {
+  ARROW_LOG(INFO) << ".. DecryptPageIndex 1";
   std::string exception_msg;
   parquet::ReaderProperties reader_properties = parquet::default_reader_properties();
   if (file_decryption_properties) {
@@ -528,10 +536,13 @@ void FileDecryptor::DecryptPageIndex(
       source, ::arrow::io::ReadableFile::Open(file, reader_properties.memory_pool()));
 
   auto file_reader = parquet::ParquetFileReader::Open(source, reader_properties);
+  ARROW_LOG(INFO) << ".. DecryptPageIndex 2";
   CheckPageIndex(file_reader.get(), file_decryption_properties);
+  ARROW_LOG(INFO) << ".. DecryptPageIndex 3";
 
   ASSERT_NO_FATAL_FAILURE(file_reader->Close());
   PARQUET_THROW_NOT_OK(source->Close());
+  ARROW_LOG(INFO) << ".. DecryptPageIndex 4";
 }
 
 template <typename DType, typename c_type = typename DType::c_type>

--- a/cpp/src/parquet/encryption/test_encryption_util.cc
+++ b/cpp/src/parquet/encryption/test_encryption_util.cc
@@ -24,7 +24,6 @@
 
 #include "arrow/io/file.h"
 #include "arrow/testing/future_util.h"
-#include "arrow/util/logging.h"
 #include "arrow/util/unreachable.h"
 
 #include "parquet/encryption/test_encryption_util.h"
@@ -347,7 +346,6 @@ void ReadAndVerifyColumn(RowGroupReader* rg_reader, RowGroupMetadata* rg_md,
 void FileDecryptor::DecryptFile(
     const std::string& file,
     const std::shared_ptr<FileDecryptionProperties>& file_decryption_properties) {
-  ARROW_LOG(INFO) << ".. DecryptFile 1";
   std::string exception_msg;
   parquet::ReaderProperties reader_properties = parquet::default_reader_properties();
   if (file_decryption_properties) {
@@ -359,23 +357,18 @@ void FileDecryptor::DecryptFile(
       source, ::arrow::io::ReadableFile::Open(file, reader_properties.memory_pool()));
 
   auto file_reader = parquet::ParquetFileReader::Open(source, reader_properties);
-  ARROW_LOG(INFO) << ".. DecryptFile 2";
   CheckFile(file_reader.get(), file_decryption_properties);
-  ARROW_LOG(INFO) << ".. DecryptFile 3";
 
   if (file_decryption_properties) {
     reader_properties.file_decryption_properties(file_decryption_properties);
   }
   auto fut = parquet::ParquetFileReader::OpenAsync(source, reader_properties);
   ASSERT_FINISHES_OK(fut);
-  ARROW_LOG(INFO) << ".. DecryptFile 4";
   ASSERT_OK_AND_ASSIGN(file_reader, fut.MoveResult());
   CheckFile(file_reader.get(), file_decryption_properties);
-  ARROW_LOG(INFO) << ".. DecryptFile 5";
 
   file_reader->Close();
   PARQUET_THROW_NOT_OK(source->Close());
-  ARROW_LOG(INFO) << ".. DecryptFile 6";
 }
 
 void FileDecryptor::CheckFile(
@@ -524,7 +517,6 @@ void FileDecryptor::CheckFile(
 void FileDecryptor::DecryptPageIndex(
     const std::string& file,
     const std::shared_ptr<FileDecryptionProperties>& file_decryption_properties) {
-  ARROW_LOG(INFO) << ".. DecryptPageIndex 1";
   std::string exception_msg;
   parquet::ReaderProperties reader_properties = parquet::default_reader_properties();
   if (file_decryption_properties) {
@@ -536,13 +528,10 @@ void FileDecryptor::DecryptPageIndex(
       source, ::arrow::io::ReadableFile::Open(file, reader_properties.memory_pool()));
 
   auto file_reader = parquet::ParquetFileReader::Open(source, reader_properties);
-  ARROW_LOG(INFO) << ".. DecryptPageIndex 2";
   CheckPageIndex(file_reader.get(), file_decryption_properties);
-  ARROW_LOG(INFO) << ".. DecryptPageIndex 3";
 
   ASSERT_NO_FATAL_FAILURE(file_reader->Close());
   PARQUET_THROW_NOT_OK(source->Close());
-  ARROW_LOG(INFO) << ".. DecryptPageIndex 4";
 }
 
 template <typename DType, typename c_type = typename DType::c_type>

--- a/cpp/src/parquet/file_reader.cc
+++ b/cpp/src/parquet/file_reader.cc
@@ -579,7 +579,8 @@ class SerializedFile : public ParquetFileReader::Contents {
       int64_t metadata_start = read_size.first;
       metadata_len = read_size.second;
       return source_->ReadAsync(metadata_start, metadata_len)
-          .Then([this, metadata_len, is_encrypted_footer, file_decryptor](
+          .Then([this, metadata_len, is_encrypted_footer,
+                 file_decryptor = std::move(file_decryptor)](
                     const std::shared_ptr<::arrow::Buffer>& metadata_buffer) {
             // Continue and read the file footer
             return ParseMetaDataFinal(metadata_buffer, metadata_len, is_encrypted_footer,

--- a/cpp/src/parquet/file_reader.cc
+++ b/cpp/src/parquet/file_reader.cc
@@ -314,11 +314,7 @@ class SerializedFile : public ParquetFileReader::Contents {
     }
   }
 
-  void Close() override {
-    if (file_metadata_ && file_metadata_->file_decryptor()) {
-      file_metadata_->file_decryptor()->WipeOutDecryptionKeys();
-    }
-  }
+  void Close() override {}
 
   std::shared_ptr<RowGroupReader> GetRowGroup(int i) override {
     std::shared_ptr<Buffer> prebuffered_column_chunks_bitmap;

--- a/cpp/src/parquet/file_reader.cc
+++ b/cpp/src/parquet/file_reader.cc
@@ -259,9 +259,9 @@ class SerializedRowGroup : public RowGroupReader::Contents {
     }
 
     // The column is encrypted
-    std::shared_ptr<Decryptor> meta_decryptor = GetColumnMetaDecryptor(
+    std::function<std::shared_ptr<Decryptor>()> meta_decryptor = GetColumnMetaDecryptor(
         crypto_metadata.get(), file_metadata_->file_decryptor().get());
-    std::shared_ptr<Decryptor> data_decryptor = GetColumnDataDecryptor(
+    std::function<std::shared_ptr<Decryptor>()> data_decryptor = GetColumnDataDecryptor(
         crypto_metadata.get(), file_metadata_->file_decryptor().get());
     ARROW_DCHECK_NE(meta_decryptor, nullptr);
     ARROW_DCHECK_NE(data_decryptor, nullptr);

--- a/cpp/src/parquet/file_reader.cc
+++ b/cpp/src/parquet/file_reader.cc
@@ -273,10 +273,10 @@ class SerializedRowGroup : public RowGroupReader::Contents {
       throw ParquetException("Encrypted files cannot contain more than 32767 columns");
     }
 
-    CryptoContext ctx(col->has_dictionary_page(),
+    CryptoContext ctx{col->has_dictionary_page(),
                       static_cast<int16_t>(row_group_ordinal_), static_cast<int16_t>(i),
                       std::move(meta_decryptor_factory),
-                      std::move(data_decryptor_factory));
+                      std::move(data_decryptor_factory)};
     return PageReader::Open(stream, col->num_values(), col->compression(), properties_,
                             always_compressed, &ctx);
   }

--- a/cpp/src/parquet/file_reader.cc
+++ b/cpp/src/parquet/file_reader.cc
@@ -637,7 +637,7 @@ class SerializedFile : public ParquetFileReader::Contents {
 
   std::string HandleAadPrefix(
       const std::shared_ptr<FileDecryptionProperties>& file_decryption_properties,
-      EncryptionAlgorithm& algo);
+      const EncryptionAlgorithm& algo);
 
   void ParseMetaDataOfEncryptedFileWithPlaintextFooter(
       const std::shared_ptr<FileDecryptionProperties>& file_decryption_properties,
@@ -733,7 +733,7 @@ void SerializedFile::ParseMetaDataOfEncryptedFileWithPlaintextFooter(
 
 std::string SerializedFile::HandleAadPrefix(
     const std::shared_ptr<FileDecryptionProperties>& file_decryption_properties,
-    EncryptionAlgorithm& algo) {
+    const EncryptionAlgorithm& algo) {
   std::string aad_prefix_in_properties = file_decryption_properties->aad_prefix();
   std::string aad_prefix = aad_prefix_in_properties;
   bool file_has_aad_prefix = algo.aad.aad_prefix.empty() ? false : true;

--- a/cpp/src/parquet/file_writer.cc
+++ b/cpp/src/parquet/file_writer.cc
@@ -448,9 +448,6 @@ class FileSerializer : public ParquetFileWriter::Contents {
       WriteEncryptedFileMetadata(*file_metadata_, sink_.get(), footer_signing_encryptor,
                                  false);
     }
-    if (file_encryptor_) {
-      file_encryptor_->WipeOutEncryptionKeys();
-    }
   }
 
   void WritePageIndex() {

--- a/cpp/src/parquet/metadata.cc
+++ b/cpp/src/parquet/metadata.cc
@@ -749,8 +749,6 @@ class FileMetaData::FileMetaDataImpl {
     int32_t encrypted_len = aes_encryptor->SignedFooterEncrypt(
         serialized_data_span, str2span(key), str2span(aad), nonce,
         encrypted_buffer->mutable_span_as<uint8_t>());
-    // Delete AES encryptor object. It was created only to verify the footer signature.
-    aes_encryptor->WipeOut();
     return 0 ==
            memcmp(encrypted_buffer->data() + encrypted_len - encryption::kGcmTagLength,
                   tag, encryption::kGcmTagLength);

--- a/cpp/src/parquet/page_index.cc
+++ b/cpp/src/parquet/page_index.cc
@@ -256,8 +256,9 @@ class RowGroupPageIndexReaderImpl : public RowGroupPageIndexReader {
     auto descr = row_group_metadata_->schema()->Column(i);
 
     // Get decryptor of column index if encrypted.
-    std::shared_ptr<Decryptor> decryptor = parquet::GetColumnMetaDecryptor(
+    auto decryptor_func = parquet::GetColumnMetaDecryptor(
         col_chunk->crypto_metadata().get(), file_decryptor_);
+    auto decryptor = decryptor_func();
     if (decryptor != nullptr) {
       UpdateDecryptor(decryptor, row_group_ordinal_, /*column_ordinal=*/i,
                       encryption::kColumnIndex);
@@ -295,8 +296,9 @@ class RowGroupPageIndexReaderImpl : public RowGroupPageIndexReader {
     uint32_t length = static_cast<uint32_t>(offset_index_location->length);
 
     // Get decryptor of offset index if encrypted.
-    std::shared_ptr<Decryptor> decryptor =
+    auto decryptor_func =
         GetColumnMetaDecryptor(col_chunk->crypto_metadata().get(), file_decryptor_);
+    auto decryptor = decryptor_func();
     if (decryptor != nullptr) {
       UpdateDecryptor(decryptor, row_group_ordinal_, /*column_ordinal=*/i,
                       encryption::kOffsetIndex);

--- a/cpp/src/parquet/page_index.cc
+++ b/cpp/src/parquet/page_index.cc
@@ -256,9 +256,9 @@ class RowGroupPageIndexReaderImpl : public RowGroupPageIndexReader {
     auto descr = row_group_metadata_->schema()->Column(i);
 
     // Get decryptor of column index if encrypted.
-    auto decryptor_func = parquet::GetColumnMetaDecryptor(
-        col_chunk->crypto_metadata().get(), file_decryptor_);
-    auto decryptor = decryptor_func();
+    std::shared_ptr<Decryptor> decryptor =
+        InternalFileDecryptor::GetColumnMetaDecryptorFactory(
+            file_decryptor_, col_chunk->crypto_metadata().get())();
     if (decryptor != nullptr) {
       UpdateDecryptor(decryptor, row_group_ordinal_, /*column_ordinal=*/i,
                       encryption::kColumnIndex);
@@ -296,9 +296,9 @@ class RowGroupPageIndexReaderImpl : public RowGroupPageIndexReader {
     uint32_t length = static_cast<uint32_t>(offset_index_location->length);
 
     // Get decryptor of offset index if encrypted.
-    auto decryptor_func =
-        GetColumnMetaDecryptor(col_chunk->crypto_metadata().get(), file_decryptor_);
-    auto decryptor = decryptor_func();
+    std::shared_ptr<Decryptor> decryptor =
+        InternalFileDecryptor::GetColumnMetaDecryptorFactory(
+            file_decryptor_, col_chunk->crypto_metadata().get())();
     if (decryptor != nullptr) {
       UpdateDecryptor(decryptor, row_group_ordinal_, /*column_ordinal=*/i,
                       encryption::kOffsetIndex);

--- a/cpp/src/parquet/page_index.cc
+++ b/cpp/src/parquet/page_index.cc
@@ -256,11 +256,11 @@ class RowGroupPageIndexReaderImpl : public RowGroupPageIndexReader {
     auto descr = row_group_metadata_->schema()->Column(i);
 
     // Get decryptor of column index if encrypted.
-    std::shared_ptr<Decryptor> decryptor =
+    std::unique_ptr<Decryptor> decryptor =
         InternalFileDecryptor::GetColumnMetaDecryptorFactory(
             file_decryptor_, col_chunk->crypto_metadata().get())();
     if (decryptor != nullptr) {
-      UpdateDecryptor(decryptor, row_group_ordinal_, /*column_ordinal=*/i,
+      UpdateDecryptor(decryptor.get(), row_group_ordinal_, /*column_ordinal=*/i,
                       encryption::kColumnIndex);
     }
 
@@ -296,11 +296,11 @@ class RowGroupPageIndexReaderImpl : public RowGroupPageIndexReader {
     uint32_t length = static_cast<uint32_t>(offset_index_location->length);
 
     // Get decryptor of offset index if encrypted.
-    std::shared_ptr<Decryptor> decryptor =
+    std::unique_ptr<Decryptor> decryptor =
         InternalFileDecryptor::GetColumnMetaDecryptorFactory(
             file_decryptor_, col_chunk->crypto_metadata().get())();
     if (decryptor != nullptr) {
-      UpdateDecryptor(decryptor, row_group_ordinal_, /*column_ordinal=*/i,
+      UpdateDecryptor(decryptor.get(), row_group_ordinal_, /*column_ordinal=*/i,
                       encryption::kOffsetIndex);
     }
 


### PR DESCRIPTION
### Rationale for this change

OpenSSL encryption / decryption is wrapped by AesEncryptor / AesDencryptor, which is used by multiple threads of a single scanner or by multiple concurrent scanners when scanning a dataset. Some thread may call `WipeOut` while other threads still use the instance.

### What changes are included in this PR?

- Remove the `WipeOut` methods and related datastructures entirely.
- Each call into `CtrEncrypt` / `CtrDecrypt` and `GcmEncrypt` / `GcmDecrypt` uses its own `EVP_CIPHER_CTX` instance, making this thread-safe.

After fixing this `"AesDecryptor was wiped out"` issue, two other segmentation faults surfaced: GH-44988. This has also been addressed here as it can only be exposed after fixing the wipe-out issue.

Fixes GH-43057.
Fixes GH-44852.
Fixes GH-44988.

### Are these changes tested?
A unit test that scans a dataset concurrently reproduced the initial issue in 30% of the test runs.

### Are there any user-facing changes?
No.
* GitHub Issue: #43057