### PR TITLE
GH-44843: [CI][Doc] Remove building Java documentation from this repository

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1806,7 +1806,6 @@ services:
       ARROW_SUBSTRAIT: "ON"
       BUILD_DOCS_C_GLIB: "ON"
       BUILD_DOCS_CPP: "ON"
-      BUILD_DOCS_JAVA: "ON"
       BUILD_DOCS_JS: "ON"
       BUILD_DOCS_PYTHON: "ON"
       BUILD_DOCS_R: "ON"
@@ -1819,8 +1818,7 @@ services:
         /arrow/ci/scripts/python_build.sh /arrow /build &&
         /arrow/ci/scripts/c_glib_build.sh /arrow /build &&
         /arrow/ci/scripts/r_build.sh /arrow /build &&
-        /arrow/ci/scripts/js_build.sh /arrow /build &&
-        /arrow/ci/scripts/java_build.sh /arrow /build"
+        /arrow/ci/scripts/js_build.sh /arrow /build"
 
   ################################# Tools #####################################
 


### PR DESCRIPTION
### Rationale for this change

Our current documentation jobs are failing to build.

### What changes are included in this PR?

Do not build Java documentation. This will be build on the arrow-java repository:
- https://github.com/apache/arrow-java/issues/455

### Are these changes tested?

Yes on CI

### Are there any user-facing changes?

It shouldn't. We won't be producing the documentation here but it should be generated on the `arrow-java` repository.
* GitHub Issue: #44843