### PR TITLE
GH-45003: [Python][Docs] Update docstrings for metadata methods on Field and Schema classes

### DIFF
--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -2549,7 +2549,11 @@ cdef class Field(_Weakrefable):
     @property
     def metadata(self):
         """
-        The field metadata.
+        The field metadata (if any is set).
+
+        Returns
+        -------
+        metadata : dict or None
 
         Examples
         --------
@@ -2982,11 +2986,11 @@ cdef class Schema(_Weakrefable):
     @property
     def metadata(self):
         """
-        The schema's metadata.
+        The schema's metadata (if any is set).
 
         Returns
         -------
-        metadata: dict
+        metadata: dict or None
 
         Examples
         --------


### PR DESCRIPTION
### Rationale for this change

The docstrings here are not completely accurate. See https://github.com/apache/arrow/issues/45003.

I looked at whether it would make more sense or be more natural for methods like these to return an empty `dict` instead of None and I think None feels better from an API design and usage perspective.

### What changes are included in this PR?

Updated docstrings to reflect actual behavior.

### Are these changes tested?

While the changes don't need testing, I did check to see if we have unit tests for the behavior that's been documented here. We do.

### Are there any user-facing changes?

Accurate docs.
* GitHub Issue: #45003