### PR TITLE
GH-41002: [CI][Python] Remove pytest-cython pin

### DIFF
--- a/ci/conda_env_sphinx.txt
+++ b/ci/conda_env_sphinx.txt
@@ -23,6 +23,7 @@ linkify-it-py
 myst-parser
 numpydoc
 pydata-sphinx-theme=0.14
+pytest-cython
 sphinx-autobuild
 sphinx-design
 sphinx-copybutton
@@ -30,9 +31,4 @@ sphinx-lint
 sphinxcontrib-jquery
 sphinxcontrib-mermaid
 sphinx==6.2
-# Requirement for doctest-cython
-# Needs upper pin of 0.3.0, see:
-# https://github.com/lgpage/pytest-cython/issues/67
-# With 0.3.* bug fix release, the pin can be removed
-pytest-cython==0.2.2
 pandas


### PR DESCRIPTION
### Rationale for this change

pytest-cython has been released with the relevant bugfix.

### Are these changes tested?

Yes, by existing CI builds.

### Are there any user-facing changes?

No.

* GitHub Issue: #41002