### PR TITLE
MINOR: [Python] improve error log to return a list of duplicated columns

### DIFF
--- a/python/pyarrow/pandas_compat.py
+++ b/python/pyarrow/pandas_compat.py
@@ -368,8 +368,9 @@ def _get_columns_to_convert(df, schema, preserve_index, columns):
     columns = _resolve_columns_of_interest(df, schema, columns)
 
     if not df.columns.is_unique:
+        duplicated_columns_list = df.columns[df.columns.duplicated()].tolist()
         raise ValueError(
-            'Duplicate column names found: {}'.format(list(df.columns))
+            f'Duplicate column names found: {duplicated_columns_list}'
         )
 
     if schema is not None:


### PR DESCRIPTION
Improve error log to display the list of duplicated columns instead of the full columns list.


### Rationale for this change

Getting the full list of columns of the dataframe is not usefull, knowing which columns is duplicated is.
I tought that having all duplicated columns of the dataframe is better than having only the set of duplicated column names (`df.columns[df.columns.duplicated()].unique().tolist()` )

### Are these changes tested?
No, very minor changes. Checked that f-strings are compatible with Python 3.9 (oldest compatible Python version in the pyproject.toml .

### Are there any user-facing changes?
No