### PR TITLE
GH-44308: [C++][FS][Azure] Implement SAS token authentication

### DIFF
--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -150,7 +150,7 @@ Status AzureOptions::ExtractFromUriQuery(const Uri& uri) {
     } else {
       // Assume these are part of a SAS token. Its not ideal to make such an assumption
       // but given that a SAS token is a complex set of URI parameters, that could be
-      // tricky to enumerate I think its the best option.
+      // tricky to exhaustively list I think its the best option.
       credential_kind = CredentialKind::kSasToken;
     }
   }

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -441,7 +441,7 @@ Result<std::string> AzureOptions::GenerateSASToken(
   if (credential_kind_ == CredentialKind::kStorageSharedKey) {
     return builder->GenerateSasToken(*storage_shared_key_credential_);
   } else {
-    // GH-39344: This part isn't tested. This may not work.
+    // GH-39344: This part isn't tested.
     try {
       auto delegation_key_response = client->GetUserDelegationKey(builder->ExpiresOn);
       return builder->GenerateSasToken(delegation_key_response.Value, account_name);
@@ -3193,7 +3193,7 @@ class AzureFileSystem::Impl {
       sas_token = "";
     } else {
       Storage::Sas::BlobSasBuilder builder;
-      std::chrono::seconds available_period(60);
+      std::chrono::seconds available_period(600);
       builder.ExpiresOn = std::chrono::system_clock::now() + available_period;
       builder.BlobContainerName = src.container;
       builder.BlobName = src.path;

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -385,7 +385,7 @@ Result<std::unique_ptr<Blobs::BlobServiceClient>> AzureOptions::MakeBlobServiceC
                                                         storage_shared_key_credential_);
     case CredentialKind::kSasToken:
       return std::make_unique<Blobs::BlobServiceClient>(AccountBlobUrl(account_name) +
-                                                        "?" + sas_token_);
+                                                        sas_token_);
   }
   return Status::Invalid("AzureOptions doesn't contain a valid auth configuration");
 }
@@ -420,7 +420,7 @@ AzureOptions::MakeDataLakeServiceClient() const {
           AccountDfsUrl(account_name), storage_shared_key_credential_);
     case CredentialKind::kSasToken:
       return std::make_unique<DataLake::DataLakeServiceClient>(
-          AccountBlobUrl(account_name) + "?" + sas_token_);
+          AccountBlobUrl(account_name) + sas_token_);
   }
   return Status::Invalid("AzureOptions doesn't contain a valid auth configuration");
 }

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -3214,7 +3214,7 @@ class AzureFileSystem::Impl {
     try {
       // We use StartCopyFromUri instead of CopyFromUri because it supports blobs larger
       // than 256 MiB and it doesn't require generating a SAS token to authenticate
-      // reading the source blob.
+      // reading a source blob in the same storage account.
       auto copy_operation = dest_blob_client.StartCopyFromUri(src_url);
       copy_operation.PollUntilDone(std::chrono::milliseconds(1000));
     } catch (const Storage::StorageException& exception) {

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -430,7 +430,7 @@ Result<std::string> AzureOptions::GenerateSASToken(
   using SasProtocol = Storage::Sas::SasProtocol;
   builder->Protocol =
       blob_storage_scheme == "http" ? SasProtocol::HttpsAndHttp : SasProtocol::HttpsOnly;
-  if (storage_shared_key_credential_) {
+  if (credential_kind_ == CredentialKind::kStorageSharedKey) {
     return builder->GenerateSasToken(*storage_shared_key_credential_);
   } else {
     // GH-39344: This part isn't tested. This may not work.

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -444,6 +444,13 @@ Result<std::string> AzureOptions::GenerateSASToken(
   }
 }
 
+std::optional<std::string> AzureOptions::GetSASToken() const {
+  if (credential_kind_ == CredentialKind::kSasToken) {
+    return sas_token_;
+  }
+  return {};
+}
+
 namespace {
 
 // An AzureFileSystem represents an Azure storage account. An AzureLocation describes a
@@ -3179,7 +3186,9 @@ class AzureFileSystem::Impl {
       return Status::OK();
     }
     std::string sas_token;
-    {
+    if (auto token = options_.GetSASToken()) {
+      sas_token = token.value();
+    } else {
       Storage::Sas::BlobSasBuilder builder;
       std::chrono::seconds available_period(60);
       builder.ExpiresOn = std::chrono::system_clock::now() + available_period;

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -112,7 +112,7 @@ Status AzureOptions::ExtractFromUriQuery(const Uri& uri) {
   // https://learn.microsoft.com/en-us/rest/api/storageservices/create-service-sas#construct-a-service-sas
   // (excluding parameters for table storage only)
   // https://learn.microsoft.com/en-us/rest/api/storageservices/create-user-delegation-sas#construct-a-user-delegation-sas
-  constexpr std::array<const char*, 27> sas_token_query_parameters = {
+  static const std::set<std::string> sas_token_query_parameters = {
       "sv",    "ss",    "sr",  "st",  "se",   "sp",   "si",   "sip",   "spr",
       "skoid", "sktid", "srt", "skt", "ske",  "skv",  "sks",  "saoid", "suoid",
       "scid",  "sdd",   "ses", "sig", "rscc", "rscd", "rsce", "rscl",  "rsct",
@@ -159,9 +159,8 @@ Status AzureOptions::ExtractFromUriQuery(const Uri& uri) {
     } else if (kv.first == "background_writes") {
       ARROW_ASSIGN_OR_RAISE(background_writes,
                             ::arrow::internal::ParseBoolean(kv.second));
-    } else if (std::find(sas_token_query_parameters.begin(),
-                         sas_token_query_parameters.end(),
-                         kv.first) != sas_token_query_parameters.end()) {
+    } else if (sas_token_query_parameters.find(kv.first) !=
+               sas_token_query_parameters.end()) {
       credential_kind = CredentialKind::kSASToken;
     } else {
       return Status::Invalid(

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -3184,6 +3184,8 @@ class AzureFileSystem::Impl {
       // than 256 MiB and it doesn't require generating a SAS token to authenticate
       // reading a source blob in the same storage account.
       auto copy_operation = dest_blob_client.StartCopyFromUri(src_url);
+      // For large blobs, the copy operation may be slow so we need to poll until it
+      // completes. We use a polling interval of 1 second.
       copy_operation.PollUntilDone(std::chrono::milliseconds(1000));
     } catch (const Storage::StorageException& exception) {
       // StartCopyFromUri failed or a GetProperties call inside PollUntilDone failed.

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -187,7 +187,7 @@ Status AzureOptions::ExtractFromUriQuery(const Uri& uri) {
         // because some parts are URI escaped and some parts are not. Instead we just
         // pass through the entire query string and Azure ignores the extra query
         // parameters.
-        RETURN_NOT_OK(ConfigureSasCredential("?" + uri.query_string()));
+        RETURN_NOT_OK(ConfigureSASCredential("?" + uri.query_string()));
         break;
       default:
         // Default credential
@@ -321,7 +321,7 @@ Status AzureOptions::ConfigureAccountKeyCredential(const std::string& account_ke
   return Status::OK();
 }
 
-Status AzureOptions::ConfigureSasCredential(const std::string& sas_token) {
+Status AzureOptions::ConfigureSASCredential(const std::string& sas_token) {
   credential_kind_ = CredentialKind::kSASToken;
   if (account_name.empty()) {
     return Status::Invalid("AzureOptions doesn't contain a valid account name");

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -444,13 +444,6 @@ Result<std::string> AzureOptions::GenerateSASToken(
   }
 }
 
-std::optional<std::string> AzureOptions::GetSASToken() const {
-  if (credential_kind_ == CredentialKind::kSasToken) {
-    return sas_token_;
-  }
-  return {};
-}
-
 namespace {
 
 // An AzureFileSystem represents an Azure storage account. An AzureLocation describes a
@@ -3186,8 +3179,10 @@ class AzureFileSystem::Impl {
       return Status::OK();
     }
     std::string sas_token;
-    if (auto token = options_.GetSASToken()) {
-      sas_token = token.value();
+    if (options_.UsesSasCredential()) {
+      // When authenticated with SAS token GetUrl() automatically provides an
+      // authenticated URL with the SAS token appended.
+      sas_token = "";
     } else {
       Storage::Sas::BlobSasBuilder builder;
       std::chrono::seconds available_period(60);

--- a/cpp/src/arrow/filesystem/azurefs.h
+++ b/cpp/src/arrow/filesystem/azurefs.h
@@ -214,6 +214,8 @@ struct ARROW_EXPORT AzureOptions {
   Result<std::string> GenerateSASToken(
       Azure::Storage::Sas::BlobSasBuilder* builder,
       Azure::Storage::Blobs::BlobServiceClient* client) const;
+
+  std::optional<std::string> GetSASToken() const;
 };
 
 /// \brief FileSystem implementation backed by Azure Blob Storage (ABS) [1] and

--- a/cpp/src/arrow/filesystem/azurefs.h
+++ b/cpp/src/arrow/filesystem/azurefs.h
@@ -37,10 +37,6 @@ namespace Azure::Storage::Blobs {
 class BlobServiceClient;
 }
 
-namespace Azure::Storage::Sas {
-struct BlobSasBuilder;
-}
-
 namespace Azure::Storage::Files::DataLake {
 class DataLakeFileSystemClient;
 class DataLakeServiceClient;
@@ -184,7 +180,7 @@ struct ARROW_EXPORT AzureOptions {
   ///   too. AzureOptions::ConfigureClientSecretCredential() is called.
   /// * A SAS token is made up of several query parameters. Appending a SAS
   ///   token to the URI configures SAS token auth by calling
-  ///   AzureOptions::ConfigureSasCredential().
+  ///   AzureOptions::ConfigureSASCredential().
   ///
   /// [1]:
   /// https://learn.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-introduction-abfs-uri
@@ -194,7 +190,7 @@ struct ARROW_EXPORT AzureOptions {
   Status ConfigureDefaultCredential();
   Status ConfigureAnonymousCredential();
   Status ConfigureAccountKeyCredential(const std::string& account_key);
-  Status ConfigureSasCredential(const std::string& sas_token);
+  Status ConfigureSASCredential(const std::string& sas_token);
   Status ConfigureClientSecretCredential(const std::string& tenant_id,
                                          const std::string& client_id,
                                          const std::string& client_secret);

--- a/cpp/src/arrow/filesystem/azurefs.h
+++ b/cpp/src/arrow/filesystem/azurefs.h
@@ -120,7 +120,7 @@ struct ARROW_EXPORT AzureOptions {
     kDefault,
     kAnonymous,
     kStorageSharedKey,
-    kSasToken,
+    kSASToken,
     kClientSecret,
     kManagedIdentity,
     kCLI,
@@ -217,8 +217,6 @@ struct ARROW_EXPORT AzureOptions {
   Result<std::string> GenerateSASToken(
       Azure::Storage::Sas::BlobSasBuilder* builder,
       Azure::Storage::Blobs::BlobServiceClient* client) const;
-
-  bool UsesSasCredential() const { return credential_kind_ == CredentialKind::kSasToken; }
 };
 
 /// \brief FileSystem implementation backed by Azure Blob Storage (ABS) [1] and

--- a/cpp/src/arrow/filesystem/azurefs.h
+++ b/cpp/src/arrow/filesystem/azurefs.h
@@ -215,7 +215,7 @@ struct ARROW_EXPORT AzureOptions {
       Azure::Storage::Sas::BlobSasBuilder* builder,
       Azure::Storage::Blobs::BlobServiceClient* client) const;
 
-  std::optional<std::string> GetSASToken() const;
+  bool UsesSasCredential() const { return credential_kind_ == CredentialKind::kSasToken; }
 };
 
 /// \brief FileSystem implementation backed by Azure Blob Storage (ABS) [1] and

--- a/cpp/src/arrow/filesystem/azurefs.h
+++ b/cpp/src/arrow/filesystem/azurefs.h
@@ -182,9 +182,9 @@ struct ARROW_EXPORT AzureOptions {
   ///   AzureOptions::ConfigureClientSecretCredential() is called.
   /// * client_secret: You must specify "tenant_id" and "client_id"
   ///   too. AzureOptions::ConfigureClientSecretCredential() is called.
-  /// * A SAS token is made up of several query parameters. Appending a SAS 
-  ///   token to the URI configures SAS token auth by calling 
-  ///   AzureOptions::ConfigureSasCredential(). 
+  /// * A SAS token is made up of several query parameters. Appending a SAS
+  ///   token to the URI configures SAS token auth by calling
+  ///   AzureOptions::ConfigureSasCredential().
   ///
   /// [1]:
   /// https://learn.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-introduction-abfs-uri

--- a/cpp/src/arrow/filesystem/azurefs.h
+++ b/cpp/src/arrow/filesystem/azurefs.h
@@ -120,6 +120,7 @@ struct ARROW_EXPORT AzureOptions {
     kDefault,
     kAnonymous,
     kStorageSharedKey,
+    kSasToken,
     kClientSecret,
     kManagedIdentity,
     kCLI,
@@ -129,6 +130,7 @@ struct ARROW_EXPORT AzureOptions {
 
   std::shared_ptr<Azure::Storage::StorageSharedKeyCredential>
       storage_shared_key_credential_;
+  std::string sas_token_;
   mutable std::shared_ptr<Azure::Core::Credentials::TokenCredential> token_credential_;
 
  public:
@@ -189,6 +191,7 @@ struct ARROW_EXPORT AzureOptions {
   Status ConfigureDefaultCredential();
   Status ConfigureAnonymousCredential();
   Status ConfigureAccountKeyCredential(const std::string& account_key);
+  Status ConfigureSasCredential(const std::string& sas_token);
   Status ConfigureClientSecretCredential(const std::string& tenant_id,
                                          const std::string& client_id,
                                          const std::string& client_secret);

--- a/cpp/src/arrow/filesystem/azurefs.h
+++ b/cpp/src/arrow/filesystem/azurefs.h
@@ -182,6 +182,9 @@ struct ARROW_EXPORT AzureOptions {
   ///   AzureOptions::ConfigureClientSecretCredential() is called.
   /// * client_secret: You must specify "tenant_id" and "client_id"
   ///   too. AzureOptions::ConfigureClientSecretCredential() is called.
+  /// * A SAS token is made up of several query parameters. Appending a SAS 
+  ///   token to the URI configures SAS token auth by calling 
+  ///   AzureOptions::ConfigureSasCredential(). 
   ///
   /// [1]:
   /// https://learn.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-introduction-abfs-uri

--- a/cpp/src/arrow/filesystem/azurefs.h
+++ b/cpp/src/arrow/filesystem/azurefs.h
@@ -213,10 +213,6 @@ struct ARROW_EXPORT AzureOptions {
 
   Result<std::unique_ptr<Azure::Storage::Files::DataLake::DataLakeServiceClient>>
   MakeDataLakeServiceClient() const;
-
-  Result<std::string> GenerateSASToken(
-      Azure::Storage::Sas::BlobSasBuilder* builder,
-      Azure::Storage::Blobs::BlobServiceClient* client) const;
 };
 
 /// \brief FileSystem implementation backed by Azure Blob Storage (ABS) [1] and

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -744,6 +744,13 @@ class TestAzureOptions : public ::testing::Test {
     ASSERT_EQ(options.dfs_storage_authority, ".dfs.local");
   }
 
+  void TestFromUriInvalidQueryParameter() {
+    ASSERT_RAISES(Invalid, AzureOptions::FromUri(
+                               "abfs://file_system@account.dfs.core.windows.net/dir/file?"
+                               "unknown=invalid",
+                               nullptr));
+  }
+
   void TestMakeBlobServiceClientInvalidAccountName() {
     AzureOptions options;
     ASSERT_RAISES_WITH_MESSAGE(
@@ -809,6 +816,9 @@ TEST_F(TestAzureOptions, FromUriBlobStorageAuthority) {
   TestFromUriBlobStorageAuthority();
 }
 TEST_F(TestAzureOptions, FromUriDfsStorageAuthority) { TestFromUriDfsStorageAuthority(); }
+TEST_F(TestAzureOptions, FromUriInvalidQueryParameter) {
+  TestFromUriInvalidQueryParameter();
+}
 TEST_F(TestAzureOptions, MakeBlobServiceClientInvalidAccountName) {
   TestMakeBlobServiceClientInvalidAccountName();
 }

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -1667,7 +1667,7 @@ class TestAzureFileSystem : public ::testing::Test {
                                  env->account_name(), env->account_key())));
     // AzureOptions::FromUri will not cut off extra query parameters that it consumes, so
     // make sure these don't cause problems.
-    ARROW_EXPECT_OK(options.ConfigureSasCredential(
+    ARROW_EXPECT_OK(options.ConfigureSASCredential(
         "?blob_storage_authority=dummy_value0&" + sas_token.substr(1) +
         "&credential_kind=dummy-value1"));
     EXPECT_OK_AND_ASSIGN(auto fs, AzureFileSystem::Make(options));

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -1658,7 +1658,11 @@ class TestAzureFileSystem : public ::testing::Test {
     ASSERT_OK_AND_ASSIGN(auto env, GetAzureEnv());
     ASSERT_OK_AND_ASSIGN(auto options, MakeOptions(env));
     ASSERT_OK_AND_ASSIGN(auto sas_token, GetContainerSasToken(data.container_name));
-    ARROW_EXPECT_OK(options.ConfigureSasCredential(sas_token));
+    // AzureOptions::FromUri will not cut off extra query parameters that it consumes, so
+    // make sure these don't cause problems.
+    ARROW_EXPECT_OK(options.ConfigureSasCredential(
+        "?blob_storage_authority=dummy_value0&" + sas_token.substr(1) +
+        "&credential_kind=dummy-value1"));
     EXPECT_OK_AND_ASSIGN(auto fs, AzureFileSystem::Make(options));
 
     AssertFileInfo(fs.get(), data.ObjectPath(), FileType::File);

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -1667,8 +1667,8 @@ class TestAzureFileSystem : public ::testing::Test {
 
     AssertFileInfo(fs.get(), data.ObjectPath(), FileType::File);
 
-    // Test copying because it follows a different code path to other authentications
-    // because it usually requires generating a SAS token at runtime.
+    // Test copying because the most obvious implementation requires generating a SAS
+    // token at runtime which doesn't work when the original auth is SAS token.
     ASSERT_OK(fs->CopyFile(data.ObjectPath(), data.ObjectPath() + "_copy"));
     AssertFileInfo(fs.get(), data.ObjectPath() + "_copy", FileType::File);
   }

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -1629,19 +1629,20 @@ class TestAzureFileSystem : public ::testing::Test {
   }
 
   void TestSasCredential() {
-    ASSERT_OK_AND_ASSIGN(auto env, AzuriteEnv::GetInstance());
-    ASSERT_OK_AND_ASSIGN(auto options, MakeOptions(env));
-    // constexpr auto container_name = "sas-container";
     auto data = SetUpPreexistingData();
-    // const std::string path = data.ContainerPath("test-write-object");
 
+    ASSERT_OK_AND_ASSIGN(auto env, GetAzureEnv());
+    ASSERT_OK_AND_ASSIGN(auto options, MakeOptions(env));
     ASSERT_OK_AND_ASSIGN(auto sas_token, GetContainerSasToken(data.container_name));
     ARROW_EXPECT_OK(options.ConfigureSasCredential(sas_token));
     EXPECT_OK_AND_ASSIGN(auto fs, AzureFileSystem::Make(options));
 
     AssertFileInfo(fs.get(), data.ObjectPath(), FileType::File);
-    // ASSERT_OK_AND_ASSIGN(auto stream, fs->OpenOutputStream(path));
-    // ASSERT_OK(stream->Write(payload));
+
+    // Test copying because it has the extra complexity that it requires generating
+    // a sas token internally.
+    ASSERT_OK(fs->CopyFile(data.ObjectPath(), data.ObjectPath() + "_copy"));
+    AssertFileInfo(fs.get(), data.ObjectPath() + "_copy", FileType::File);
   }
 
  private:

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -698,7 +698,7 @@ class TestAzureOptions : public ::testing::Test {
         auto options,
         AzureOptions::FromUri(
             "abfs://file_system@account.dfs.core.windows.net/" + sas_token, nullptr));
-    ASSERT_EQ(options.credential_kind_, AzureOptions::CredentialKind::kSasToken);
+    ASSERT_EQ(options.credential_kind_, AzureOptions::CredentialKind::kSASToken);
     ASSERT_EQ(options.sas_token_, sas_token);
   }
 
@@ -712,7 +712,7 @@ class TestAzureOptions : public ::testing::Test {
         AzureOptions::FromUri(
             "abfs://account@127.0.0.1:10000/container/dir/blob" + uri_query_string,
             nullptr));
-    ASSERT_EQ(options.credential_kind_, AzureOptions::CredentialKind::kSasToken);
+    ASSERT_EQ(options.credential_kind_, AzureOptions::CredentialKind::kSASToken);
     ASSERT_EQ(options.sas_token_, uri_query_string);
     ASSERT_EQ(options.blob_storage_authority, "127.0.0.1:10000");
     ASSERT_EQ(options.dfs_storage_authority, "127.0.0.1:10000");

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -2694,6 +2694,17 @@ TEST_F(TestAzuriteFileSystem, CopyFileSuccessDestinationNonexistent) {
   EXPECT_EQ(PreexistingData::kLoremIpsum, buffer->ToString());
 }
 
+TEST_F(TestAzuriteFileSystem, CopyFileSuccessDestinationDifferentContainer) {
+  auto data = SetUpPreexistingData();
+  auto data2 = SetUpPreexistingData();
+  const auto destination_path = data2.ContainerPath("copy-destionation");
+  ASSERT_OK(fs()->CopyFile(data.ObjectPath(), destination_path));
+  ASSERT_OK_AND_ASSIGN(auto info, fs()->GetFileInfo(destination_path));
+  ASSERT_OK_AND_ASSIGN(auto stream, fs()->OpenInputStream(info));
+  ASSERT_OK_AND_ASSIGN(auto buffer, stream->Read(1024));
+  EXPECT_EQ(PreexistingData::kLoremIpsum, buffer->ToString());
+}
+
 TEST_F(TestAzuriteFileSystem, CopyFileSuccessDestinationSame) {
   auto data = SetUpPreexistingData();
   ASSERT_OK(fs()->CopyFile(data.ObjectPath(), data.ObjectPath()));

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -690,7 +690,7 @@ class TestAzureOptions : public ::testing::Test {
     ASSERT_EQ(options.credential_kind_, AzureOptions::CredentialKind::kEnvironment);
   }
 
-  void TestFromUriCredentialSasToken() {
+  void TestFromUriCredentialSASToken() {
     const std::string sas_token =
         "?se=2024-12-12T18:57:47Z&sig=pAs7qEBdI6sjUhqX1nrhNAKsTY%2B1SqLxPK%"
         "2BbAxLiopw%3D&sp=racwdxylti&spr=https,http&sr=c&sv=2024-08-04";
@@ -702,7 +702,7 @@ class TestAzureOptions : public ::testing::Test {
     ASSERT_EQ(options.sas_token_, sas_token);
   }
 
-  void TestFromUriCredentialSasTokenWithOtherParameters() {
+  void TestFromUriCredentialSASTokenWithOtherParameters() {
     const std::string uri_query_string =
         "?enable_tls=false&se=2024-12-12T18:57:47Z&sig=pAs7qEBdI6sjUhqX1nrhNAKsTY%"
         "2B1SqLxPK%"
@@ -807,9 +807,9 @@ TEST_F(TestAzureOptions, FromUriCredentialWorkloadIdentity) {
 TEST_F(TestAzureOptions, FromUriCredentialEnvironment) {
   TestFromUriCredentialEnvironment();
 }
-TEST_F(TestAzureOptions, FromUriCredentialSasToken) { TestFromUriCredentialSasToken(); }
-TEST_F(TestAzureOptions, FromUriCredentialSasTokenWithOtherParameters) {
-  TestFromUriCredentialSasTokenWithOtherParameters();
+TEST_F(TestAzureOptions, FromUriCredentialSASToken) { TestFromUriCredentialSASToken(); }
+TEST_F(TestAzureOptions, FromUriCredentialSASTokenWithOtherParameters) {
+  TestFromUriCredentialSASTokenWithOtherParameters();
 }
 TEST_F(TestAzureOptions, FromUriCredentialInvalid) { TestFromUriCredentialInvalid(); }
 TEST_F(TestAzureOptions, FromUriBlobStorageAuthority) {
@@ -946,7 +946,7 @@ class TestAzureFileSystem : public ::testing::Test {
         .Value;
   }
 
-  Result<std::string> GetContainerSasToken(
+  Result<std::string> GetContainerSASToken(
       const std::string& container_name,
       Azure::Storage::StorageSharedKeyCredential storage_shared_key_credential) {
     std::string sas_token;
@@ -1665,14 +1665,14 @@ class TestAzureFileSystem : public ::testing::Test {
     AssertObjectContents(fs.get(), path, payload);
   }
 
-  void TestSasCredential() {
+  void TestSASCredential() {
     auto data = SetUpPreexistingData();
 
     ASSERT_OK_AND_ASSIGN(auto env, GetAzureEnv());
     ASSERT_OK_AND_ASSIGN(auto options, MakeOptions(env));
     ASSERT_OK_AND_ASSIGN(
         auto sas_token,
-        GetContainerSasToken(data.container_name,
+        GetContainerSASToken(data.container_name,
                              Azure::Storage::StorageSharedKeyCredential(
                                  env->account_name(), env->account_key())));
     // AzureOptions::FromUri will not cut off extra query parameters that it consumes, so
@@ -2401,8 +2401,8 @@ TYPED_TEST(TestAzureFileSystemOnAllScenarios, CreateContainerFromPath) {
 
 TYPED_TEST(TestAzureFileSystemOnAllScenarios, MovePath) { this->TestMovePath(); }
 
-TYPED_TEST(TestAzureFileSystemOnAllScenarios, SasCredential) {
-  this->TestSasCredential();
+TYPED_TEST(TestAzureFileSystemOnAllScenarios, SASCredential) {
+  this->TestSASCredential();
 }
 
 // Tests using Azurite (the local Azure emulator)

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -1639,8 +1639,8 @@ class TestAzureFileSystem : public ::testing::Test {
 
     AssertFileInfo(fs.get(), data.ObjectPath(), FileType::File);
 
-    // Test copying because it has the extra complexity that it requires generating
-    // a sas token internally.
+    // Test copying because it follows a different code path to other authentications 
+    // because it usually requires generating a SAS token at runtime.
     ASSERT_OK(fs->CopyFile(data.ObjectPath(), data.ObjectPath() + "_copy"));
     AssertFileInfo(fs.get(), data.ObjectPath() + "_copy", FileType::File);
   }

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -520,6 +520,14 @@ TEST(AzureFileSystem, InitializeWithWorkloadIdentityCredential) {
   EXPECT_OK_AND_ASSIGN(auto fs, AzureFileSystem::Make(options));
 }
 
+TEST(AzureFileSystem, InitializeWithSasCredential) {
+  AzureOptions options;
+  options.account_name = "dummy-account-name";
+  // This SAS token is not secret - its taken from an example in the Azure docs. 
+  ARROW_EXPECT_OK(options.ConfigureSasCredential("sv=2015-02-21&st=2015-07-01T08%3a49Z&se=2015-07-02T08%3a49Z&sr=c&sp=w&si=YWJjZGVmZw%3d%3d&sig=Rcp6gQRfV7WDlURdVTqCa%2bqEArnfJxDgE%2bKH3TCChIs%3d"));
+  EXPECT_OK_AND_ASSIGN(auto fs, AzureFileSystem::Make(options));
+}
+
 TEST(AzureFileSystem, InitializeWithEnvironmentCredential) {
   AzureOptions options;
   options.account_name = "dummy-account-name";

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -967,8 +967,6 @@ class TestAzureFileSystem : public ::testing::Test {
     } else {
       auto container_client = CreateContainer(data.container_name);
       CreateBlob(container_client, data.kObjectName, PreexistingData::kLoremIpsum);
-      // CreateBlob(container_client, data.kObjectName, data.RandomChars((1 << 30),
-      // rng_));
     }
     return data;
   }


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change
SAS token auth is sometimes useful and it the last one we haven't implemented. 

### What changes are included in this PR?
- Implement `ConfigureSasCredential`
- Update `AzureOptions::FromUri` so that simply appending a SAS token to a blob storage URI works. e.g. `AzureOptions::FromUri("abfs://file_system@account.dfs.core.windows.net/?se=2024-12-12T18:57:47Z&sig=pAs7qEBdI6sjUhqX1nrhNAKsTY%2B1SqLxPK%2BbAxLiopw%3D&sp=racwdxylti&spr=https,http&sr=c&sv=2024-08-04")`
  - SAS tokens are made up of a bunch of URI query parameters that I'm not sure we can exhaustively list.
  - Therefore we now assume that any unrecognised URI query parameters are assumed to be part of a SAS token, instead of returning an error status. 
- Update `CopyFile` to use StartCopyFromUri instead of CopyFromUri
  - This avoids the need to generate SAS tokens. 
  - Supports blobs bigger than 256MiB
  - This makes https://github.com/apache/arrow/issues/41315 redundant
 
### Are these changes tested?
Yes
- Added new tests for authenticating with SAS and doing some operations including `CopyFile`
- Added new tests for `AzureOptions::FromUri` with a SAS token. 

I also made sure to run the tests which connect to real blob storage. 
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?
- SAS token in now supported
- Unrecognised URI query parameters are ignored by `AzureOptions::FromUri` instead of failing fast. IMO this is a regression but still the best option to support SAS token. 
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #44308