### PR TITLE
MINOR: [Format] Schema.fbs typo -- s/two number/two numbers/

### DIFF
--- a/format/Schema.fbs
+++ b/format/Schema.fbs
@@ -421,7 +421,7 @@ table Interval {
 // An absolute length of time unrelated to any calendar artifacts.
 //
 // For the purposes of Arrow Implementations, adding this value to a Timestamp
-// ("t1") naively (i.e. simply summing the two number) is acceptable even
+// ("t1") naively (i.e. simply summing the two numbers) is acceptable even
 // though in some cases the resulting Timestamp (t2) would not account for
 // leap-seconds during the elapsed time between "t1" and "t2".  Similarly,
 // representing the difference between two Unix timestamp is acceptable, but


### PR DESCRIPTION
### Rationale for this change

To improve a comment.

### What changes are included in this PR?

Correction of a grammatical typo in a comment: s/two number/two numbers/.

### Are these changes tested?

N/A

### Are there any user-facing changes?

No