### PR TITLE
MINOR: [Format] Schema.fbs grammar -- replace i.e. with e.g.

### DIFF
--- a/format/Schema.fbs
+++ b/format/Schema.fbs
@@ -510,7 +510,7 @@ table DictionaryEncoding {
 /// nested type.
 
 table Field {
-  /// Name is not required, in i.e. a List
+  /// Name is not required (e.g., in a List)
   name: string;
 
   /// Whether or not this field can contain nulls. Should be true in general.


### PR DESCRIPTION
### Rationale for this change

To improve a comment.

### What changes are included in this PR?

Correction of grammar in a comment: use e.g. in a parenthetical instead of i.e. 

For context: https://www.grammarly.com/blog/acronyms-abbreviations/i-e-vs-e-g/ .

### Are these changes tested?

N/A

### Are there any user-facing changes?

No