### PR TITLE
GH-45027: [C++] Include path in the documentation is wrong

### DIFF
--- a/cpp/examples/arrow/parquet_read_write.cc
+++ b/cpp/examples/arrow/parquet_read_write.cc
@@ -26,7 +26,7 @@
 
 arrow::Status ReadFullFile(std::string path_to_file) {
   // #include "arrow/io/api.h"
-  // #include "arrow/parquet/arrow/reader.h"
+  // #include "parquet/arrow/reader.h"
 
   arrow::MemoryPool* pool = arrow::default_memory_pool();
   std::shared_ptr<arrow::io::RandomAccessFile> input;
@@ -44,7 +44,7 @@ arrow::Status ReadFullFile(std::string path_to_file) {
 
 arrow::Status ReadInBatches(std::string path_to_file) {
   // #include "arrow/io/api.h"
-  // #include "arrow/parquet/arrow/reader.h"
+  // #include "parquet/arrow/reader.h"
 
   arrow::MemoryPool* pool = arrow::default_memory_pool();
 


### PR DESCRIPTION
In the comments the includes of `(arrow/)parquet/arrow/reader.h` were broken. Removing the prefix `arrow` makes this include in line with the includes used at the top of the file.
* GitHub Issue: #45027