### PR TITLE
GH-45047: [CI][Python][Packaging] Test 3.12 wheels on Ubuntu 24.04

### DIFF
--- a/ci/docker/ubuntu-24.04-verify-rc.dockerfile
+++ b/ci/docker/ubuntu-24.04-verify-rc.dockerfile
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+ARG arch=amd64
+FROM ${arch}/ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+COPY dev/release/setup-ubuntu.sh /
+RUN /setup-ubuntu.sh && \
+    rm /setup-ubuntu.sh && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists*

--- a/dev/release/setup-ubuntu.sh
+++ b/dev/release/setup-ubuntu.sh
@@ -22,27 +22,20 @@
 
 set -exu
 
-codename=$(. /etc/os-release && echo ${UBUNTU_CODENAME})
+version=$(. /etc/os-release && echo ${VERSION_ID})
 
-case ${codename} in
-  *)
-    nlohmann_json=3
-    python=3
-    apt-get update -y -q
-    apt-get install -y -q --no-install-recommends \
-      llvm-dev
-    ;;
-esac
+apt-get update -y -q
 
-case ${codename} in
-  focal)
-    ;;
-  *)
-    apt-get update -y -q
-    apt-get install -y -q --no-install-recommends \
-      libxsimd-dev
-    ;;
-esac
+if [ ${version} \> "20.04" ]; then
+  apt-get install -y -q --no-install-recommends \
+    libxsimd-dev
+fi
+
+if [ ${version} \> "22.04" ]; then
+  # Some tests rely on legacy timezone aliases such as "US/Pacific"
+  apt-get install -y -q --no-install-recommends \
+    tzdata-legacy
+fi
 
 apt-get install -y -q --no-install-recommends \
   build-essential \
@@ -58,10 +51,10 @@ apt-get install -y -q --no-install-recommends \
   libsqlite3-dev \
   libssl-dev \
   ninja-build \
-  nlohmann-json${nlohmann_json}-dev \
+  nlohmann-json3-dev \
   pkg-config \
-  python${python}-dev \
-  python${python}-venv \
+  python3-dev \
+  python3-venv \
   python3-pip \
   ruby-dev \
   tzdata \

--- a/dev/tasks/python-wheels/github.linux.yml
+++ b/dev/tasks/python-wheels/github.linux.yml
@@ -134,6 +134,21 @@ jobs:
             -e TEST_WHEELS=1 \
             ubuntu-verify-rc
 
+      - name: Test wheel on Ubuntu 24.04
+        shell: bash
+        if: |
+          '{{ python_version }}' == '3.12'
+        env:
+          UBUNTU: "24.04"
+        run: |
+          archery docker run \
+            -e TEST_DEFAULT=0 \
+            -e TEST_PYARROW_VERSION={{ arrow.no_rc_version }} \
+            -e TEST_PYTHON_VERSIONS={{ python_version }} \
+            -e TEST_WHEEL_PLATFORM_TAGS={{ wheel_platform_tag }} \
+            -e TEST_WHEELS=1 \
+            ubuntu-verify-rc
+
       {{ macros.github_upload_releases("arrow/python/repaired_wheels/*.whl")|indent }}
       {{ macros.github_upload_gemfury("arrow/python/repaired_wheels/*.whl")|indent }}
       {{ macros.github_upload_wheel_scientific_python("arrow/python/repaired_wheels/*.whl")|indent }}


### PR DESCRIPTION
### Rationale for this change

We already test some Python wheels on Ubuntu 20.04 or 22.04, depending on the system Python version. Also do so with Ubuntu 24.04.

### Are these changes tested?

Yes, by definition.

### Are there any user-facing changes?

No.
* GitHub Issue: #45047