### PR TITLE
GH-45050: [CI][Dev] Apply ShellCheck lint to c_glib/test/run-test.sh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -182,4 +182,5 @@ repos:
           (
           ?^ci/scripts/c_glib_build\.sh$|
           ?^ci/scripts/c_glib_test\.sh$|
+          ?^c_glib/test/run-test\.sh$|
           )

--- a/c_glib/test/run-test.sh
+++ b/c_glib/test/run-test.sh
@@ -17,7 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-test_dir="$(cd "$(dirname "$0")" || exit; pwd)"
+test_dir="$(cd "$(dirname "$0")" && pwd)"
 build_dir="$(cd .; pwd)"
 
 modules=(

--- a/c_glib/test/run-test.sh
+++ b/c_glib/test/run-test.sh
@@ -17,7 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-test_dir="$(cd $(dirname $0); pwd)"
+test_dir="$(cd "$(dirname "$0")" || exit; pwd)"
 build_dir="$(cd .; pwd)"
 
 modules=(
@@ -47,7 +47,7 @@ if [ "${BUILD}" != "no" ]; then
 fi
 
 for module in "${modules[@]}"; do
-  MODULE_TYPELIB_DIR_VAR_NAME="$(echo ${module} | tr a-z- A-Z_)_TYPELIB_DIR"
+  MODULE_TYPELIB_DIR_VAR_NAME="$(echo "${module}" | tr a-z- A-Z_)_TYPELIB_DIR"
   module_typelib_dir=$(eval "echo \${${MODULE_TYPELIB_DIR_VAR_NAME}}")
   if [ -z "${module_typelib_dir}" ]; then
     module_typelib_dir="${build_dir}/${module}"
@@ -74,4 +74,4 @@ case "${DEBUGGER}" in
     DEBUGGER_ARGS+=(--)
     ;;
 esac
-${DEBUGGER} "${DEBUGGER_ARGS[@]}" "${RUBY}" ${test_dir}/run-test.rb "$@"
+${DEBUGGER} "${DEBUGGER_ARGS[@]}" "${RUBY}" "${test_dir}"/run-test.rb "$@"


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

```bash
❯ pre-commit run --show-diff-on-failure --color=always --all-files shellcheck
ShellCheck v0.10.0.......................................................Failed

- hook id: shellcheck
- exit code: 1

In c_glib/test/run-test.sh line 20:
test_dir="$(cd $(dirname $0); pwd)"
            ^--------------^ SC2164 (warning): Use 'cd ... || exit' or 'cd ... || return' in case cd fails.
               ^-----------^ SC2046 (warning): Quote this to prevent word splitting.
                         ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
test_dir="$(cd $(dirname "$0") || exit; pwd)"

In c_glib/test/run-test.sh line 50:
  MODULE_TYPELIB_DIR_VAR_NAME="$(echo ${module} | tr a-z- A-Z_)_TYPELIB_DIR"
                                      ^-------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
  MODULE_TYPELIB_DIR_VAR_NAME="$(echo "${module}" | tr a-z- A-Z_)_TYPELIB_DIR"

In c_glib/test/run-test.sh line 77:
${DEBUGGER} "${DEBUGGER_ARGS[@]}" "${RUBY}" ${test_dir}/run-test.rb "$@"
                                            ^---------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
${DEBUGGER} "${DEBUGGER_ARGS[@]}" "${RUBY}" "${test_dir}"/run-test.rb "$@"

For more information:
  <https://www.shellcheck.net/wiki/SC2046> -- Quote this to prevent word splitt...
  <https://www.shellcheck.net/wiki/SC2164> -- Use 'cd ... || exit' or 'cd ... |...
  <https://www.shellcheck.net/wiki/SC2086> -- Double quote to prevent globbing ...

```

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?
- add missing double quotes(SC2046,SC2086)
- Use cd ... || exit in case cd fails.(SC2164)

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?
yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?
no
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #45050