### PR TITLE
GH-45059: [C++][CI] Fix test-build-cpp-fuzz failures

### DIFF
--- a/dev/tasks/fuzz-tests/github.oss-fuzz.yml
+++ b/dev/tasks/fuzz-tests/github.oss-fuzz.yml
@@ -33,6 +33,12 @@ jobs:
         run: |
           git clone --depth=50 https://github.com/google/oss-fuzz.git
 
+      - uses: actions/setup-python@v5
+        # Use a Python version that's compatible with the pinned requirements
+        # for dependencies below.
+        with:
+          python-version: '3.11'
+
       - name: Install dependencies
         working-directory: oss-fuzz
         run: |


### PR DESCRIPTION
### Rationale for this change

The CI requirements file in the OSS-Fuzz repo pins an old PyYAML version that fails installing on Python 3.12:
https://github.com/google/oss-fuzz/blob/4161b2267f39e32f32e122501b7b82f9bc28caea/infra/ci/requirements.txt

### What changes are included in this PR?

Use a Python version compatible with the requirements.

### Are these changes tested?

Yes, by definition.

### Are there any user-facing changes?

No.
* GitHub Issue: #45059