### PR TITLE
MINOR: [C++] Fix clang-format of arrow/util/tracing_internal.h

### DIFF
--- a/cpp/src/arrow/util/tracing_internal.h
+++ b/cpp/src/arrow/util/tracing_internal.h
@@ -135,12 +135,11 @@ opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span>& RewrapSpan(
 opentelemetry::trace::StartSpanOptions SpanOptionsWithParent(
     const util::tracing::Span& parent_span);
 
-#  define START_SPAN(target_span, ...)                           \
-    auto opentelemetry_scope##__LINE__ =                         \
-        ::arrow::internal::tracing::GetTracer()->WithActiveSpan( \
-            ::arrow::internal::tracing::RewrapSpan(              \
-                target_span.details.get(),                       \
-                ::arrow::internal::tracing::GetTracer()->StartSpan(__VA_ARGS__)))
+#  define START_SPAN(target_span, ...)                                           \
+    auto opentelemetry_scope##__LINE__ = ::arrow::internal::tracing::GetTracer() \
+        -> WithActiveSpan(::arrow::internal::tracing::RewrapSpan(                \
+            target_span.details.get(),                                           \
+            ::arrow::internal::tracing::GetTracer()->StartSpan(__VA_ARGS__)))
 
 #  define START_SCOPED_SPAN(target_span, ...)                    \
     ::arrow::internal::tracing::Scope(                           \


### PR DESCRIPTION
### Rationale for this change

It seems that arrow/util/tracing_internal.h has escaped the linter check.

### What changes are included in this PR?

Apply clang-format to arrow/util/tracing_internal.h.

### Are these changes tested?

Pass CI.

### Are there any user-facing changes?

No.