### PR TITLE
GH-45069: [R][CI] Fix r-binary-packages crossbow job

### DIFF
--- a/dev/tasks/r/github.packages.yml
+++ b/dev/tasks/r/github.packages.yml
@@ -447,7 +447,7 @@ jobs:
       - name: Install R
         uses: r-lib/actions/setup-r@v2
         with:
-          install-r: false
+          install-r: true
       - name: Rename artifacts
         shell: Rscript {0}
         run: |

--- a/dev/tasks/r/github.packages.yml
+++ b/dev/tasks/r/github.packages.yml
@@ -40,7 +40,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r@v2
         with:
-          install-r: false
+          install-r: true
 
       - name: Build R source package
         shell: bash


### PR DESCRIPTION
### Rationale for this change

GitHub phased out R from their Ubuntu images in their 24.04 image and this job started failing because of it. We now need to install R ourselves if a job needs it and uses ubuntu-latest (>=24.04).

### What changes are included in this PR?

Change in GHA workflow config to always install R.

### Are these changes tested?

They're testing here with crossbow.

### Are there any user-facing changes?

No.

* GitHub Issue: #45069