### PR TITLE
GH-45073: [C++][Parquet] Fix generation of repetition levels for encryption test data

### DIFF
--- a/cpp/src/parquet/encryption/test_encryption_util.cc
+++ b/cpp/src/parquet/encryption/test_encryption_util.cc
@@ -116,9 +116,9 @@ ColumnData<Int64Type> GenerateSampleData<Int64Type>(int rows) {
     int64_t value = i * 1000 * 1000;
     value *= 1000 * 1000;
     int16_t definition_level = 1;
-    int16_t repetition_level = 0;
+    int16_t repetition_level = 1;
     if ((i % 2) == 0) {
-      repetition_level = 1;  // start of a new record
+      repetition_level = 0;  // start of a new record
     }
     int64_col.values.push_back(value);
     int64_col.definition_levels.push_back(definition_level);


### PR DESCRIPTION
### Rationale for this change

This makes the test data readable by other Parquet implementations that validate the repetition levels.

### What changes are included in this PR?

* Corrects the generation of encryption test files so that the int64 list columns correctly start lists with repetition level 0.
* Updates the parquet-testing submodule to use the corrected files.

### Are these changes tested?

Yes, covered by existing tests.

### Are there any user-facing changes?

No
* GitHub Issue: #45073