### PR TITLE
GH-45361: [CI][C++] Curate `ci/vcpkg/vcpkg.json`

### DIFF
--- a/.env
+++ b/.env
@@ -92,11 +92,11 @@ TZ=UTC
 VCPKG="943c5ef1c8f6b5e6ced092b242c8299caae2ff01"    # 2024.04.26 Release
 
 # This must be updated when we update
-# ci/docker/python-*-windows-*.dockerfile.
+# ci/docker/python-*-windows-*.dockerfile or the vcpkg config.
 # This is a workaround for our CI problem that "archery docker build" doesn't
 # use pulled built images in dev/tasks/python-wheels/github.windows.yml.
-PYTHON_WHEEL_WINDOWS_IMAGE_REVISION=2025-01-08
-PYTHON_WHEEL_WINDOWS_TEST_IMAGE_REVISION=2025-01-08
+PYTHON_WHEEL_WINDOWS_IMAGE_REVISION=2025-01-27
+PYTHON_WHEEL_WINDOWS_TEST_IMAGE_REVISION=2025-01-27
 
 # Use conanio/${CONAN_BASE}:{CONAN_VERSION} for "docker compose run --rm conan".
 # See https://github.com/conan-io/conan-docker-tools#readme and

--- a/ci/vcpkg/vcpkg.json
+++ b/ci/vcpkg/vcpkg.json
@@ -5,13 +5,8 @@
   "homepage": "https://arrow.apache.org",
   "supports": "x64 | (arm64 & !windows)",
   "dependencies": [
-    "boost-filesystem",
     {
       "name": "boost-multiprecision",
-      "platform": "windows"
-    },
-    {
-      "name": "boost-system",
       "platform": "windows"
     },
     "brotli",
@@ -42,6 +37,8 @@
       "description": "Development dependencies",
       "dependencies": [
         "benchmark",
+        "boost-crc",
+        "boost-filesystem",
         "boost-process",
         "gtest"
       ]


### PR DESCRIPTION
### Rationale for this change

Our CI config for vcpkg declares superfluous Boost dependencies.

### Are these changes tested?

Yes, by existing CI tests.

### Are there any user-facing changes?

No.
* GitHub Issue: #45361