### PR TITLE
GH-45045: [C++][Parquet] Add a benchmark for size_statistics_level

### DIFF
--- a/cpp/src/parquet/CMakeLists.txt
+++ b/cpp/src/parquet/CMakeLists.txt
@@ -437,3 +437,4 @@ add_parquet_benchmark(metadata_benchmark)
 add_parquet_benchmark(page_index_benchmark SOURCES page_index_benchmark.cc
                       benchmark_util.cc)
 add_parquet_benchmark(arrow/reader_writer_benchmark PREFIX "parquet-arrow")
+add_parquet_benchmark(arrow/size_stats_benchmark PREFIX "parquet-arrow")

--- a/cpp/src/parquet/arrow/size_stats_benchmark.cc
+++ b/cpp/src/parquet/arrow/size_stats_benchmark.cc
@@ -45,12 +45,12 @@ int64_t GetTotalBytes(const std::shared_ptr<::arrow::ArrayData>& data) {
     return 0;
   }
   int64_t total_bytes =
-      std::accumulate(data->buffers.cbegin(), data->buffers.cend(), 0L,
+      std::accumulate(data->buffers.cbegin(), data->buffers.cend(), int64_t{0},
                       [](int64_t acc, const auto& buffer) {
-                        return acc + (buffer != nullptr ? buffer->size() : 0L);
+                        return acc + (buffer != nullptr ? buffer->size() : int64_t{0});
                       });
   total_bytes += std::accumulate(
-      data->child_data.cbegin(), data->child_data.cend(), 0L,
+      data->child_data.cbegin(), data->child_data.cend(), int64_t{0},
       [](int64_t acc, const auto& child) { return acc + GetTotalBytes(child); });
   total_bytes += GetTotalBytes(data->dictionary);
   return total_bytes;

--- a/cpp/src/parquet/arrow/size_stats_benchmark.cc
+++ b/cpp/src/parquet/arrow/size_stats_benchmark.cc
@@ -83,6 +83,8 @@ void WriteColumn(::benchmark::State& state, const std::shared_ptr<::arrow::Table
   auto properties = WriterProperties::Builder()
                         .enable_statistics()
                         ->enable_write_page_index()
+                        ->disable_dictionary()
+                        ->encoding(Encoding::PLAIN)
                         ->set_size_statistics_level(stats_level)
                         ->build();
 

--- a/cpp/src/parquet/arrow/size_stats_benchmark.cc
+++ b/cpp/src/parquet/arrow/size_stats_benchmark.cc
@@ -37,7 +37,8 @@ namespace parquet::benchmark {
 
 // This should result in multiple pages for most primitive types
 constexpr int64_t kBenchmarkSize = 1024 * 1024;
-constexpr double kNullProbability = 0.5;
+// Use a skewed null probability to reduce levels encoding overhead
+constexpr double kNullProbability = 0.95;
 
 int64_t GetTotalBytes(const std::shared_ptr<::arrow::ArrayData>& data) {
   if (data == nullptr) {
@@ -80,6 +81,8 @@ int64_t GetTotalPageIndexSize(const std::shared_ptr<::parquet::FileMetaData>& me
 
 void WriteColumn(::benchmark::State& state, const std::shared_ptr<::arrow::Table>& table,
                  SizeStatisticsLevel stats_level) {
+  // Use the fastest possible encoding and compression settings, to better exhibit
+  // the size statistics overhead.
   auto properties = WriterProperties::Builder()
                         .enable_statistics()
                         ->enable_write_page_index()

--- a/cpp/src/parquet/arrow/size_stats_benchmark.cc
+++ b/cpp/src/parquet/arrow/size_stats_benchmark.cc
@@ -1,0 +1,127 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "benchmark/benchmark.h"
+
+#include <cstdint>
+
+#include "parquet/arrow/writer.h"
+#include "parquet/platform.h"
+#include "parquet/properties.h"
+
+#include "arrow/array.h"
+#include "arrow/io/memory.h"
+#include "arrow/table.h"
+#include "arrow/testing/gtest_util.h"
+#include "arrow/testing/random.h"
+
+namespace parquet::benchmark {
+
+// This should result in multiple pages for most primitive types
+constexpr int64_t kBenchmarkSize = 10 * 1024 * 1024;
+constexpr int64_t kRowGroupSize = DEFAULT_MAX_ROW_GROUP_LENGTH;
+constexpr double kNullProbability = 0.5;
+
+int64_t GetTotalBytes(const std::shared_ptr<::arrow::ArrayData>& data) {
+  if (data == nullptr) {
+    return 0;
+  }
+  int64_t total_bytes =
+      std::accumulate(data->buffers.cbegin(), data->buffers.cend(), 0,
+                      [](int64_t acc, const auto& buffer) {
+                        return acc + (buffer != nullptr ? buffer->size() : 0);
+                      });
+  total_bytes += std::accumulate(
+      data->child_data.cbegin(), data->child_data.cend(), 0,
+      [](int64_t acc, const auto& child) { return acc + GetTotalBytes(child); });
+  total_bytes += GetTotalBytes(data->dictionary);
+  return total_bytes;
+}
+
+void WriteColumn(::benchmark::State& state,
+                 const std::shared_ptr<::arrow::DataType>& type,
+                 SizeStatisticsLevel stats_level) {
+  ::arrow::random::RandomArrayGenerator generator(/*seed=*/42);
+  std::shared_ptr<::arrow::Array> arr =
+      generator.ArrayOf(type, kBenchmarkSize, kNullProbability);
+  auto table = ::arrow::Table::Make(
+      ::arrow::schema({::arrow::field("column", type, kNullProbability > 0)}), {arr});
+
+  for (auto _ : state) {
+    state.PauseTiming();
+    auto output = std::static_pointer_cast<::arrow::io::OutputStream>(
+        parquet::CreateOutputStream());
+    auto properties = WriterProperties::Builder()
+                          .enable_statistics()
+                          ->enable_write_page_index()
+                          ->set_size_statistics_level(stats_level)
+                          ->build();
+    state.ResumeTiming();
+    ARROW_EXPECT_OK(::parquet::arrow::WriteTable(*table, ::arrow::default_memory_pool(),
+                                                 output, kRowGroupSize, properties));
+    state.counters["output_size"] = output->Tell().ValueOrDie();
+  }
+
+  int64_t bytes_processed = 0;
+  for (const auto& column : table->columns()) {
+    for (const auto& chunk : column->chunks()) {
+      bytes_processed += GetTotalBytes(chunk->data());
+    }
+  }
+  state.SetItemsProcessed(state.iterations() * kBenchmarkSize);
+  state.SetBytesProcessed(state.iterations() * bytes_processed);
+}
+
+template <SizeStatisticsLevel level, typename ArrowType>
+void BM_WritePrimitiveColumn(::benchmark::State& state) {
+  WriteColumn(state, std::make_shared<ArrowType>(), level);
+}
+
+template <SizeStatisticsLevel level, typename ArrowType>
+void BM_WriteListColumn(::benchmark::State& state) {
+  WriteColumn(state, ::arrow::list(std::make_shared<ArrowType>()), level);
+}
+
+BENCHMARK_TEMPLATE(BM_WritePrimitiveColumn, SizeStatisticsLevel::None,
+                   ::arrow::Int64Type);
+BENCHMARK_TEMPLATE(BM_WritePrimitiveColumn, SizeStatisticsLevel::ColumnChunk,
+                   ::arrow::Int64Type);
+BENCHMARK_TEMPLATE(BM_WritePrimitiveColumn, SizeStatisticsLevel::PageAndColumnChunk,
+                   ::arrow::Int64Type);
+
+BENCHMARK_TEMPLATE(BM_WritePrimitiveColumn, SizeStatisticsLevel::None,
+                   ::arrow::StringType);
+BENCHMARK_TEMPLATE(BM_WritePrimitiveColumn, SizeStatisticsLevel::ColumnChunk,
+                   ::arrow::StringType);
+BENCHMARK_TEMPLATE(BM_WritePrimitiveColumn, SizeStatisticsLevel::PageAndColumnChunk,
+                   ::arrow::StringType);
+
+BENCHMARK_TEMPLATE(BM_WriteListColumn, SizeStatisticsLevel::None, ::arrow::Int64Type);
+BENCHMARK_TEMPLATE(BM_WriteListColumn, SizeStatisticsLevel::ColumnChunk,
+                   ::arrow::Int64Type);
+BENCHMARK_TEMPLATE(BM_WriteListColumn, SizeStatisticsLevel::PageAndColumnChunk,
+                   ::arrow::Int64Type);
+
+BENCHMARK_TEMPLATE(BM_WriteListColumn, SizeStatisticsLevel::None, ::arrow::StringType);
+BENCHMARK_TEMPLATE(BM_WriteListColumn, SizeStatisticsLevel::ColumnChunk,
+                   ::arrow::StringType);
+BENCHMARK_TEMPLATE(BM_WriteListColumn, SizeStatisticsLevel::PageAndColumnChunk,
+                   ::arrow::StringType);
+
+}  // namespace parquet::benchmark
+
+BENCHMARK_MAIN();

--- a/cpp/src/parquet/arrow/size_stats_benchmark.cc
+++ b/cpp/src/parquet/arrow/size_stats_benchmark.cc
@@ -74,7 +74,7 @@ void WriteColumn(::benchmark::State& state,
     state.ResumeTiming();
     ARROW_EXPECT_OK(::parquet::arrow::WriteTable(*table, ::arrow::default_memory_pool(),
                                                  output, kRowGroupSize, properties));
-    state.counters["output_size"] = output->Tell().ValueOrDie();
+    state.counters["output_size"] = static_cast<double>(output->Tell().ValueOrDie());
   }
 
   int64_t bytes_processed = 0;

--- a/cpp/src/parquet/arrow/size_stats_benchmark.cc
+++ b/cpp/src/parquet/arrow/size_stats_benchmark.cc
@@ -18,6 +18,7 @@
 #include "benchmark/benchmark.h"
 
 #include <cstdint>
+#include <numeric>
 
 #include "parquet/arrow/writer.h"
 #include "parquet/platform.h"

--- a/cpp/src/parquet/arrow/size_stats_benchmark.cc
+++ b/cpp/src/parquet/arrow/size_stats_benchmark.cc
@@ -42,12 +42,12 @@ int64_t GetTotalBytes(const std::shared_ptr<::arrow::ArrayData>& data) {
     return 0;
   }
   int64_t total_bytes =
-      std::accumulate(data->buffers.cbegin(), data->buffers.cend(), 0,
+      std::accumulate(data->buffers.cbegin(), data->buffers.cend(), 0L,
                       [](int64_t acc, const auto& buffer) {
-                        return acc + (buffer != nullptr ? buffer->size() : 0);
+                        return acc + (buffer != nullptr ? buffer->size() : 0L);
                       });
   total_bytes += std::accumulate(
-      data->child_data.cbegin(), data->child_data.cend(), 0,
+      data->child_data.cbegin(), data->child_data.cend(), 0L,
       [](int64_t acc, const auto& child) { return acc + GetTotalBytes(child); });
   total_bytes += GetTotalBytes(data->dictionary);
   return total_bytes;


### PR DESCRIPTION
### Rationale for this change

Add a benchmark to know the performance of writing different size stats levels.

### What changes are included in this PR?

Add a size_stats_benchmark for parquet.

### Are these changes tested?

No

### Are there any user-facing changes?

No
* GitHub Issue: #45045