### PR TITLE
GH-44900: [Python] Support explicit `fsspec+{protocol}` and `hf://` filesystem URIs

### DIFF
--- a/docs/source/python/filesystems.rst
+++ b/docs/source/python/filesystems.rst
@@ -408,7 +408,7 @@ Example reading parquet file from GitHub directly::
 
    pq.read_table("fsspec+github://apache:arrow-testing@/data/parquet/alltypes-java.parquet")
 
-Hugging Face's sceheme explicitly allowed as a shortcut without needing to prefix
+Hugging Face URIs are explicitly allowed as a shortcut without needing to prefix
 with ``fsspec+``. This is useful for reading datasets hosted on Hugging Face::
 
    pq.read_table("hf://datasets/stanfordnlp/imdb/plain_text/train-00000-of-00001.parquet")

--- a/docs/source/python/filesystems.rst
+++ b/docs/source/python/filesystems.rst
@@ -414,8 +414,6 @@ with ``fsspec+``. This is useful for reading datasets hosted on Hugging Face::
    pq.read_table("hf://datasets/stanfordnlp/imdb/plain_text/train-00000-of-00001.parquet")
 
 
-
-
 Using Arrow filesystems with fsspec
 -----------------------------------
 

--- a/docs/source/python/filesystems.rst
+++ b/docs/source/python/filesystems.rst
@@ -388,6 +388,34 @@ Then all the functionalities of :class:`FileSystem` are accessible::
    ds.dataset("data/", filesystem=pa_fs)
 
 
+Using fsspec-compatible filesystem URIs
+---------------------------------------
+
+PyArrow can automatically instantiate fsspec filesystems by prefixing the URI
+scheme with ``fsspec+``. This allows you to use the fsspec-compatible
+filesystems directly with PyArrow's IO functions without needing to manually
+create a filesystem object. Example writing and reading a Parquet file
+using an in-memory filesystem provided by `fsspec`_::
+
+   import pyarrow as pa
+   import pyarrow.parquet as pq
+
+   table = pa.table({'a': [1, 2, 3]})
+   pq.write_table(table, "fsspec+memory://path/to/my_table.parquet")
+   pq.read_table("fsspec+memory://path/to/my_table.parquet")
+
+Example reading parquet file from GitHub directly::
+
+   pq.read_table("fsspec+github://apache:arrow-testing@/data/parquet/alltypes-java.parquet")
+
+Hugging Face's sceheme explicitly allowed as a shortcut without needing to prefix
+with ``fsspec+``. This is useful for reading datasets hosted on Hugging Face::
+
+   pq.read_table("hf://datasets/stanfordnlp/imdb/plain_text/train-00000-of-00001.parquet")
+
+
+
+
 Using Arrow filesystems with fsspec
 -----------------------------------
 

--- a/python/pyarrow/_fs.pyx
+++ b/python/pyarrow/_fs.pyx
@@ -430,7 +430,7 @@ cdef class FileSystem(_Weakrefable):
             import fsspec
         except ImportError:
             raise ImportError(
-                "`fsspec` is required to handle fsspec+<protocol> filesystems."
+                "`fsspec` is required to handle `fsspec+<filesystem>://` and `hf://` URIs."
             )
         from .fs import FSSpecHandler
 

--- a/python/pyarrow/_fs.pyx
+++ b/python/pyarrow/_fs.pyx
@@ -503,11 +503,6 @@ cdef class FileSystem(_Weakrefable):
         >>> fs.FileSystem.from_uri("fsspec+memory:///path/to/file")
         (<pyarrow._fs.PyFileSystem object at ...>, '/path/to/file')
 
-        Or from a Hugging Face dataset URI:
-
-        >>> fs.FileSystem.from_uri("hf://datasets/stanfordnlp/imdb/plain_text/train-00000-of-00001.parquet")
-        (<pyarrow._fs.PyFileSystem object at ...>, 'datasets/stanfordnlp/imdb/plain_text/train-00000-of-00001.parquet')
-
         Create a subtree FileSystem by treating the path as a prefix:
 
         >>> uri = f'file://{local_path}'

--- a/python/pyarrow/fs.py
+++ b/python/pyarrow/fs.py
@@ -82,16 +82,16 @@ def __getattr__(name):
     )
 
 
-def _filesystem_from_str(path, treat_path_as_prefix=True):
+def _filesystem_from_str(uri, treat_path_as_prefix=True):
     # instantiate the file system from an uri, if the uri has a path
     # component then it will be treated as a path prefix
     try:
-        filesystem, path = FileSystem.from_uri(path)
+        filesystem, path = FileSystem.from_uri(uri)
     except ValueError as e:
-        if path.startswith("fsspec+") or path.startswith("hf://"):
+        if uri.startswith("fsspec+") or uri.startswith("hf://"):
             # if the path starts with fsspec+ or hf://, then it is a valid
             # fsspec URI, so try to parse it using fsspec
-            filesystem, path = _fsspec_filesystem_from_str(path)
+            filesystem, path = _fsspec_filesystem_from_str(uri)
         else:
             raise e
 
@@ -105,7 +105,7 @@ def _filesystem_from_str(path, treat_path_as_prefix=True):
                     "The path component of the filesystem URI must point to a "
                     f"directory but it has a type: `{prefix_info.type.name}`. The path "
                     f"component is `{prefix_info.path}` and the given filesystem URI "
-                    f"is `{path}`"
+                    f"is `{uri}`"
                 )
             filesystem = SubTreeFileSystem(prefix, filesystem)
         return filesystem

--- a/python/pyarrow/fs.py
+++ b/python/pyarrow/fs.py
@@ -176,12 +176,18 @@ def _resolve_filesystem_and_path(path, filesystem=None, *, memory_map=False):
         try:
             filesystem, path = FileSystem.from_uri(path)
         except ValueError as e:
-            # neither an URI nor a locally existing path, so assume that
-            # local path was given and propagate a nicer file not found error
-            # instead of a more confusing scheme parsing error
-            if "empty scheme" not in str(e) \
-                    and "Cannot parse URI" not in str(e):
-                raise
+            try:
+                import fsspec
+            except ImportError:
+                # neither an URI nor a locally existing path, so assume that
+                # local path was given and propagate a nicer file not found error
+                # instead of a more confusing scheme parsing error
+                if "empty scheme" not in str(e) \
+                        and "Cannot parse URI" not in str(e):
+                    raise e
+            else:
+                fs, path = fsspec.url_to_fs(path)
+                filesystem = _ensure_filesystem(fs)
     else:
         path = filesystem.normalize_path(path)
 

--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -44,8 +44,8 @@ from pyarrow._parquet import (ParquetReader, Statistics,  # noqa
                               FileEncryptionProperties,
                               FileDecryptionProperties,
                               SortingColumn)
-from pyarrow.fs import (LocalFileSystem, FileSystem, FileType,
-                        _resolve_filesystem_and_path, _ensure_filesystem)
+from pyarrow.fs import (LocalFileSystem, FileType, _resolve_filesystem_and_path,
+                        _ensure_filesystem)
 from pyarrow.util import guid, _is_path_like, _stringify_path, _deprecate_api
 
 
@@ -1392,14 +1392,9 @@ Examples
         self._base_dir = None
         if not isinstance(path_or_paths, list):
             if _is_path_like(path_or_paths):
-                path_or_paths = _stringify_path(path_or_paths)
-                if filesystem is None:
-                    # path might be a URI describing the FileSystem as well
-                    try:
-                        filesystem, path_or_paths = FileSystem.from_uri(
-                            path_or_paths)
-                    except ValueError:
-                        filesystem = LocalFileSystem(use_mmap=memory_map)
+                filesystem, path_or_paths = _resolve_filesystem_and_path(
+                    path_or_paths, filesystem, memory_map=memory_map
+                )
                 finfo = filesystem.get_file_info(path_or_paths)
                 if finfo.type == FileType.Directory:
                     self._base_dir = path_or_paths

--- a/python/pyarrow/tests/parquet/test_parquet_file.py
+++ b/python/pyarrow/tests/parquet/test_parquet_file.py
@@ -374,3 +374,7 @@ def test_parquet_file_fsspec_fallback():
     pq.write_table(table, "memory://example.parquet")
     table2 = pq.read_table("memory://example.parquet")
     assert table.equals(table2)
+
+    msg = "Unrecognized filesystem type in URI"
+    with pytest.raises(pa.ArrowInvalid, match=msg):
+        pq.read_table("non-existing://example.parquet")

--- a/python/pyarrow/tests/parquet/test_parquet_file.py
+++ b/python/pyarrow/tests/parquet/test_parquet_file.py
@@ -418,7 +418,15 @@ def test_parquet_file_hugginface_support():
 
 
 def test_fsspec_uri_raises_if_fsspec_is_not_available():
-    with mock.patch.dict(sys.modules, {'fsspec': None}):
-        msg = re.escape("`fsspec` is required to handle fsspec+<protocol> filesystems.")
-        with pytest.raises(ImportError, match=msg):
-            pq.read_table("fsspec+memory://example.parquet")
+    # sadly cannot patch sys.modules because cython will still be able to import fsspec
+    try:
+        import fsspec  # noqa: F401
+    except ImportError:
+        pass
+    else:
+        pytest.skip("fsspec is available, skipping test")
+
+    msg = re.escape(
+        "`fsspec` is required to handle `fsspec+<filesystem>://` and `hf://` URIs.")
+    with pytest.raises(ImportError, match=msg):
+        pq.read_table("fsspec+memory://example.parquet")

--- a/python/pyarrow/tests/parquet/test_parquet_file.py
+++ b/python/pyarrow/tests/parquet/test_parquet_file.py
@@ -365,3 +365,12 @@ def test_read_undefined_logical_type(parquet_test_datadir):
         b"unknown string 2",
         b"unknown string 3"
     ]
+
+
+def test_parquet_file_fsspec_fallback():
+    pytest.importorskip("fsspec")
+
+    table = pa.table({"a": range(10)})
+    pq.write_table(table, "memory://example.parquet")
+    table2 = pq.read_table("memory://example.parquet")
+    assert table.equals(table2)

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -2156,11 +2156,12 @@ def test_fsspec_filesystem_from_uri():
 
     # check that if fsspec+ is specified than we don't coerce to the native
     # arrow local filesystem
-    uri = "file:///tmp/my.file"
+    path = "/tmp/my.file"
+    uri = f"file://{path}"
     fs, path = FileSystem.from_uri(f"fsspec+{uri}")
     expected_fs = PyFileSystem(FSSpecHandler(LocalFileSystem()))
     assert fs == expected_fs
-    assert path == str(pathlib.Path.from_uri(uri))
+    assert path == str(pathlib.Path(path))
 
 
 def test_huggingface_filesystem_from_uri():

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -2156,10 +2156,11 @@ def test_fsspec_filesystem_from_uri():
 
     # check that if fsspec+ is specified than we don't coerce to the native
     # arrow local filesystem
-    fs, path = FileSystem.from_uri("fsspec+local:///tmp/my.file")
+    uri = "file:///tmp/my.file"
+    fs, path = FileSystem.from_uri(f"fsspec+{uri}")
     expected_fs = PyFileSystem(FSSpecHandler(LocalFileSystem()))
     assert fs == expected_fs
-    assert path == "/tmp/my.file"
+    assert path == str(pathlib.Path.from_uri(uri))
 
 
 def test_huggingface_filesystem_from_uri():
@@ -2178,7 +2179,7 @@ def test_huggingface_filesystem_from_uri():
 
 
 def test_from_uri_treat_path_as_prefix(tempdir):
-    uri = f"local://{tempdir}"
+    uri = pathlib.Path(tempdir).as_uri()
 
     fs, path = FileSystem.from_uri(uri)
     assert isinstance(fs, LocalFileSystem)

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -2175,16 +2175,3 @@ def test_huggingface_filesystem_from_uri():
     expected_fs = PyFileSystem(FSSpecHandler(HfFileSystem()))
     assert fs == expected_fs
     assert path == "datasets/stanfordnlp/imdb/plain_text/train-00000-of-00001.parquet"
-
-
-def test_from_uri_treat_path_as_prefix(tempdir):
-    uri = pathlib.Path(tempdir).as_uri()
-
-    fs, local_path = FileSystem.from_uri(uri)
-    assert isinstance(fs, LocalFileSystem)
-    assert pathlib.Path(local_path) == pathlib.Path(tempdir)
-
-    fs = FileSystem.from_uri(uri, treat_path_as_prefix=True)
-    assert isinstance(fs, SubTreeFileSystem)
-    assert fs.base_fs == LocalFileSystem()
-    assert pathlib.Path(fs.base_path) == pathlib.Path(tempdir)

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -2156,12 +2156,10 @@ def test_fsspec_filesystem_from_uri():
 
     # check that if fsspec+ is specified than we don't coerce to the native
     # arrow local filesystem
-    path = "/tmp/my.file"
-    uri = f"file://{path}"
-    fs, path = FileSystem.from_uri(f"fsspec+{uri}")
+    uri = "file:///tmp/my.file"
+    fs, _ = FileSystem.from_uri(f"fsspec+{uri}")
     expected_fs = PyFileSystem(FSSpecHandler(LocalFileSystem()))
     assert fs == expected_fs
-    assert path == str(pathlib.Path(path))
 
 
 def test_huggingface_filesystem_from_uri():
@@ -2182,11 +2180,11 @@ def test_huggingface_filesystem_from_uri():
 def test_from_uri_treat_path_as_prefix(tempdir):
     uri = pathlib.Path(tempdir).as_uri()
 
-    fs, path = FileSystem.from_uri(uri)
+    fs, local_path = FileSystem.from_uri(uri)
     assert isinstance(fs, LocalFileSystem)
-    assert path == str(tempdir)
+    assert pathlib.Path(local_path) == pathlib.Path(tempdir)
 
     fs = FileSystem.from_uri(uri, treat_path_as_prefix=True)
     assert isinstance(fs, SubTreeFileSystem)
     assert fs.base_fs == LocalFileSystem()
-    assert fs.base_path == f"{tempdir}/"
+    assert pathlib.Path(fs.base_path) == pathlib.Path(tempdir)


### PR DESCRIPTION
### Rationale for this change

Make filesystem operations more convenient to users by supporting:
- `fsspec` filesystems explicitly by passing `fsspec+` prefix to the filsystem scheme
- explicitly support `hf://` scheme by loading the huggingface fsspec filesystem adapter

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

`_resolve_filesystem_and_path()` is now able to recognize `fsspec+{protocol}` and `hf://` scheme in which case it attempts to load the specific fsspec filesystem implementation. Made some additional refactoring to consolidate the filesystem from string logic.

### Are these changes tested?

Yes. `fsspec+{protocol}` uris are tested using the `fsspec.MemoryFilesystem` whereas the `hf://` scheme is tested by mocking out the `huggingface_hub.HfFileSystem` class. I also tested the huggingface integration using a live huggingface repository. 

### Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

Various user facing functions now support more filesystem implementations:

```py
pyarrow.fs.copy_files()
ParquetFile()
ParquetDataset()
dt.dataset()

pq.read_metadata()
pq.write_metadata()
pq.read_table()
pq.read_schema()

orc.read_table()
```

This includes both the path containing additional schemes and the `filesystem=` argument.

* GitHub Issue: #44900