### PR TITLE
GH-44948: [Dev][Archery] Remove JIRA remnants from Archery

### DIFF
--- a/dev/archery/archery/release/tests/test_release.py
+++ b/dev/archery/archery/release/tests/test_release.py
@@ -21,7 +21,6 @@ from archery.release.core import (
     Release, MajorRelease, MinorRelease, PatchRelease,
     IssueTracker, Version, Issue, CommitTitle, Commit
 )
-from archery.testing import DotDict
 
 
 # subset of issues per revision
@@ -140,22 +139,6 @@ def test_issue(fake_issue_tracker):
     assert i.summary == "another title"
     assert i.project == "PARQUET"
     assert i.number == 1111
-
-    fake_jira_issue = DotDict({
-        'key': 'ARROW-2222',
-        'fields': {
-            'issuetype': {
-                'name': 'Feature'
-            },
-            'summary': 'Issue title'
-        }
-    })
-    i = Issue.from_jira(fake_jira_issue)
-    assert i.key == "ARROW-2222"
-    assert i.type == "Feature"
-    assert i.summary == "Issue title"
-    assert i.project == "ARROW"
-    assert i.number == 2222
 
 
 def test_commit_title():

--- a/dev/archery/archery/templates/release_changelog.md.j2
+++ b/dev/archery/archery/templates/release_changelog.md.j2
@@ -23,11 +23,7 @@
 ## {{ category }}
 
 {% for issue, commit in issue_commit_pairs -%}
-{% if issue.project in ('ARROW', 'PARQUET') -%}
-* [{{ issue.key }}](https://issues.apache.org/jira/browse/{{ issue.key }}) - {{ commit.title.to_string(with_issue=False) if commit else issue.summary | md }}
-{% else -%}
 * [GH-{{ issue.key }}](https://github.com/apache/arrow/issues/{{ issue.key }}) - {{ commit.title.to_string(with_issue=False) if commit else issue.summary | md }}
-{% endif -%}
 {% endfor %}
 
 {% endfor %}

--- a/dev/archery/archery/testing.py
+++ b/dev/archery/archery/testing.py
@@ -21,19 +21,6 @@ from unittest import mock
 import re
 
 
-class DotDict(dict):
-
-    def __getattr__(self, key):
-        try:
-            item = self[key]
-        except KeyError:
-            raise AttributeError(key)
-        if isinstance(item, dict):
-            return DotDict(item)
-        else:
-            return item
-
-
 class PartialEnv(dict):
 
     def __eq__(self, other):

--- a/dev/archery/setup.py
+++ b/dev/archery/setup.py
@@ -39,9 +39,9 @@ extras = {
     'lint': ['numpydoc==1.1.0', 'autopep8', 'flake8==6.1.0', 'cython-lint',
              'cmake_format==0.6.13', 'sphinx-lint==0.9.1'],
     'numpydoc': ['numpydoc==1.1.0'],
-    'release': ['pygithub', jinja_req, 'jira', 'semver', 'gitpython'],
+    'release': ['pygithub', jinja_req, 'semver', 'gitpython'],
 }
-extras['bot'] = extras['crossbow'] + ['pygithub', 'jira']
+extras['bot'] = extras['crossbow'] + ['pygithub']
 extras['all'] = list(set(functools.reduce(operator.add, extras.values())))
 
 setup(


### PR DESCRIPTION
### Rationale for this change

We are not using JIRA as issue tracker anymore, we should remove it from archery.

### What changes are included in this PR?

Remove Jira dependency from archery and related code mainly for release curate for release changelog generation.

### Are these changes tested?

Yes, archery tests are still successful and I've validated that I can generate:
`archery release curate 18.0.0` and `archery release curate 19.0.0` successfully.
I haven't tested cherry-picking but there doesn't seem to be code involved and we have been able to cherry-pick during the last releases.

### Are there any user-facing changes?
No
* GitHub Issue: #44948