### PR TITLE
GH-45092: [C++][Parquet] Add GetReadRanges function to FileReader

### DIFF
--- a/cpp/src/parquet/file_reader.cc
+++ b/cpp/src/parquet/file_reader.cc
@@ -404,11 +404,11 @@ class SerializedFile : public ParquetFileReader::Contents {
   ::arrow::Result<std::vector<::arrow::io::ReadRange>> GetReadRanges(
       const std::vector<int>& row_groups, const std::vector<int>& column_indices,
       int64_t hole_size_limit, int64_t range_size_limit) {
-    std::vector<::arrow::io::ReadRange> ranges;    
-    for (int row : row_groups) {
+    std::vector<::arrow::io::ReadRange> ranges;
+    for (int row_group : row_groups) {
       for (int col : column_indices) {
         ranges.push_back(
-            ComputeColumnChunkRange(file_metadata_.get(), source_size_, row, col));
+            ComputeColumnChunkRange(file_metadata_.get(), source_size_, row_group, col));
       }
     }
 

--- a/cpp/src/parquet/file_reader.cc
+++ b/cpp/src/parquet/file_reader.cc
@@ -29,6 +29,7 @@
 #include "arrow/io/caching.h"
 #include "arrow/io/file.h"
 #include "arrow/io/memory.h"
+#include "arrow/io/util_internal.h"
 #include "arrow/util/bit_util.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/future.h"
@@ -398,6 +399,21 @@ class SerializedFile : public ParquetFileReader::Contents {
       }
     }
     PARQUET_THROW_NOT_OK(cached_source_->Cache(ranges));
+  }
+
+  ::arrow::Result<std::vector<::arrow::io::ReadRange>> GetReadRanges(
+      const std::vector<int>& row_groups, const std::vector<int>& column_indices,
+      int64_t hole_size_limit, int64_t range_size_limit) {
+    std::vector<::arrow::io::ReadRange> ranges;    
+    for (int row : row_groups) {
+      for (int col : column_indices) {
+        ranges.push_back(
+            ComputeColumnChunkRange(file_metadata_.get(), source_size_, row, col));
+      }
+    }
+
+    return ::arrow::io::internal::CoalesceReadRanges(std::move(ranges), hole_size_limit,
+                                                     range_size_limit);
   }
 
   ::arrow::Future<> WhenBuffered(const std::vector<int>& row_groups,

--- a/cpp/src/parquet/file_reader.h
+++ b/cpp/src/parquet/file_reader.h
@@ -201,6 +201,32 @@ class PARQUET_EXPORT ParquetFileReader {
                  const ::arrow::io::IOContext& ctx,
                  const ::arrow::io::CacheOptions& options);
 
+  // Retrieve the list of byte ranges that would need to be read to retrieve
+  // the data for the specified row groups and column indices.
+  //
+  // A reader can optionally call this if they wish to handle their own
+  // caching and management of file reads (or offload them to other readers).
+  // Unlike PreBuffer, this method will not perform any actual caching or 
+  // reads, instead just using the file metadata to determine the byte ranges
+  // that would need to be read if you were to consume the entirety of the column
+  // chunks for the provided columns in the specified row groups.
+  //
+  // If row_groups or column_indices are empty, then the result of this will be empty.
+  // 
+  // hole_size_limit represents the maximum distance, in bytes, between two
+  // consecutive ranges; beyond this value, ranges will not be combined. The default
+  // value is 1MB.
+  //
+  // range_size_limit is the maximum size in bytes of a combined range; if combining
+  // two consecutive ranges would produce a range larger than this, they are not combined.
+  // The default values is 64MB. This *must* be larger than hole_size_limit.
+  //
+  // This will not take into account page indexes or any other predicate push down
+  // benefits that may be available.
+  ::arrow::Result<std::vector<::arrow::io::ReadRange>> GetReadRanges(
+      const std::vector<int>& row_groups, const std::vector<int>& column_indices,
+      int64_t hole_size_limit = 1024 * 1024, int64_t range_size_limit = 64 * 1024 * 1024);
+
   /// Wait for the specified row groups and column indices to be pre-buffered.
   ///
   /// After the returned Future completes, reading the specified row

--- a/cpp/src/parquet/file_reader.h
+++ b/cpp/src/parquet/file_reader.h
@@ -218,8 +218,8 @@ class PARQUET_EXPORT ParquetFileReader {
   /// value is 1MB.
   ///
   /// range_size_limit is the maximum size in bytes of a combined range; if combining
-  /// two consecutive ranges would produce a range larger than this, they are not combined.
-  /// The default values is 64MB. This *must* be larger than hole_size_limit.
+  /// two consecutive ranges would produce a range larger than this, they are not
+  /// combined. The default values is 64MB. This *must* be larger than hole_size_limit.
   ///
   /// This will not take into account page indexes or any other predicate push down
   /// benefits that may be available.

--- a/cpp/src/parquet/file_reader.h
+++ b/cpp/src/parquet/file_reader.h
@@ -201,28 +201,28 @@ class PARQUET_EXPORT ParquetFileReader {
                  const ::arrow::io::IOContext& ctx,
                  const ::arrow::io::CacheOptions& options);
 
-  // Retrieve the list of byte ranges that would need to be read to retrieve
-  // the data for the specified row groups and column indices.
-  //
-  // A reader can optionally call this if they wish to handle their own
-  // caching and management of file reads (or offload them to other readers).
-  // Unlike PreBuffer, this method will not perform any actual caching or
-  // reads, instead just using the file metadata to determine the byte ranges
-  // that would need to be read if you were to consume the entirety of the column
-  // chunks for the provided columns in the specified row groups.
-  //
-  // If row_groups or column_indices are empty, then the result of this will be empty.
-  //
-  // hole_size_limit represents the maximum distance, in bytes, between two
-  // consecutive ranges; beyond this value, ranges will not be combined. The default
-  // value is 1MB.
-  //
-  // range_size_limit is the maximum size in bytes of a combined range; if combining
-  // two consecutive ranges would produce a range larger than this, they are not combined.
-  // The default values is 64MB. This *must* be larger than hole_size_limit.
-  //
-  // This will not take into account page indexes or any other predicate push down
-  // benefits that may be available.
+  /// Retrieve the list of byte ranges that would need to be read to retrieve
+  /// the data for the specified row groups and column indices.
+  ///
+  /// A reader can optionally call this if they wish to handle their own
+  /// caching and management of file reads (or offload them to other readers).
+  /// Unlike PreBuffer, this method will not perform any actual caching or
+  /// reads, instead just using the file metadata to determine the byte ranges
+  /// that would need to be read if you were to consume the entirety of the column
+  /// chunks for the provided columns in the specified row groups.
+  ///
+  /// If row_groups or column_indices are empty, then the result of this will be empty.
+  ///
+  /// hole_size_limit represents the maximum distance, in bytes, between two
+  /// consecutive ranges; beyond this value, ranges will not be combined. The default
+  /// value is 1MB.
+  ///
+  /// range_size_limit is the maximum size in bytes of a combined range; if combining
+  /// two consecutive ranges would produce a range larger than this, they are not combined.
+  /// The default values is 64MB. This *must* be larger than hole_size_limit.
+  ///
+  /// This will not take into account page indexes or any other predicate push down
+  /// benefits that may be available.
   ::arrow::Result<std::vector<::arrow::io::ReadRange>> GetReadRanges(
       const std::vector<int>& row_groups, const std::vector<int>& column_indices,
       int64_t hole_size_limit = 1024 * 1024, int64_t range_size_limit = 64 * 1024 * 1024);

--- a/cpp/src/parquet/file_reader.h
+++ b/cpp/src/parquet/file_reader.h
@@ -206,13 +206,13 @@ class PARQUET_EXPORT ParquetFileReader {
   //
   // A reader can optionally call this if they wish to handle their own
   // caching and management of file reads (or offload them to other readers).
-  // Unlike PreBuffer, this method will not perform any actual caching or 
+  // Unlike PreBuffer, this method will not perform any actual caching or
   // reads, instead just using the file metadata to determine the byte ranges
   // that would need to be read if you were to consume the entirety of the column
   // chunks for the provided columns in the specified row groups.
   //
   // If row_groups or column_indices are empty, then the result of this will be empty.
-  // 
+  //
   // hole_size_limit represents the maximum distance, in bytes, between two
   // consecutive ranges; beyond this value, ranges will not be combined. The default
   // value is 1MB.


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change
For some consumers, it is convenient to expose a way to retrieve the necessary byte ranges of a parquet file to read specific column chunks from row groups without having to go through a full `ReadRangeCache`. Ultimately, it's a fairly simple function since we already have all the infrastructure implemented to compute these ranges.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?
A single function added to `parquet::FileReader` named `GetReadRanges` which computes and retrieves the coalesced read ranges for specified row groups and column indices.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

* GitHub Issue: #45092