### PR TITLE
GH-45099: [C++] Avoid static const variable in the status.h

### DIFF
--- a/cpp/src/arrow/status.cc
+++ b/cpp/src/arrow/status.cc
@@ -141,6 +141,11 @@ std::string Status::ToStringWithoutContextLines() const {
   return message;
 }
 
+const std::string& Status::message() const {
+  static const std::string no_message = "";
+  return ok() ? no_message : state_->msg;
+}
+
 void Status::Abort() const { Abort(std::string()); }
 
 void Status::Abort(const std::string& message) const {

--- a/cpp/src/arrow/status.cc
+++ b/cpp/src/arrow/status.cc
@@ -146,6 +146,11 @@ const std::string& Status::message() const {
   return ok() ? no_message : state_->msg;
 }
 
+const std::shared_ptr<StatusDetail>& Status::detail() const {
+  static std::shared_ptr<StatusDetail> no_detail = NULLPTR;
+  return state_ ? state_->detail : no_detail;
+}
+
 void Status::Abort() const { Abort(std::string()); }
 
 void Status::Abort(const std::string& message) const {

--- a/cpp/src/arrow/status.h
+++ b/cpp/src/arrow/status.h
@@ -335,10 +335,7 @@ class ARROW_EXPORT [[nodiscard]] Status : public util::EqualityComparable<Status
   const std::string& message() const;
 
   /// \brief Return the status detail attached to this message.
-  const std::shared_ptr<StatusDetail>& detail() const {
-    static std::shared_ptr<StatusDetail> no_detail = NULLPTR;
-    return state_ ? state_->detail : no_detail;
-  }
+  const std::shared_ptr<StatusDetail>& detail() const;
 
   /// \brief Return a new Status copying the existing status, but
   /// updating with the existing detail.

--- a/cpp/src/arrow/status.h
+++ b/cpp/src/arrow/status.h
@@ -332,10 +332,7 @@ class ARROW_EXPORT [[nodiscard]] Status : public util::EqualityComparable<Status
   constexpr StatusCode code() const { return ok() ? StatusCode::OK : state_->code; }
 
   /// \brief Return the specific error message attached to this status.
-  const std::string& message() const {
-    static const std::string no_message = "";
-    return ok() ? no_message : state_->msg;
-  }
+  const std::string& message() const;
 
   /// \brief Return the status detail attached to this message.
   const std::shared_ptr<StatusDetail>& detail() const {


### PR DESCRIPTION
### Rationale for this change

The `Status::message` function below has defined a static const string in the header file which may cause troubles in different translation units.

```
  const std::string& message() const {
    static const std::string no_message = "";
    return ok() ? no_message : state_->msg;
  }
```

### What changes are included in this PR?

Move the definition of `Status::message` function into the source file.

### Are these changes tested?

Pass CIs.

### Are there any user-facing changes?

No.
* GitHub Issue: #45099