### PR TITLE
MINOR: [Docs] Small grammar fix in Intro.rst

### DIFF
--- a/docs/source/format/Intro.rst
+++ b/docs/source/format/Intro.rst
@@ -71,7 +71,7 @@ In a columnar format, the data is organized column-by-column instead.
 This organization makes analytical operations like filtering, grouping,
 aggregations and others, more efficient thanks to memory locality.
 When processing the data, the memory locations accessed by the CPU tend
-be near one another. By keeping the data contiguous in memory, it also
+to be near one another. By keeping the data contiguous in memory, it also
 enables vectorization of the computations. Most modern CPUs have
 `SIMD instructions`_ (a single instruction that operates on multiple values at
 once) enabling parallel processing and execution of operations on vector data


### PR DESCRIPTION
Small grammar fix in the intro docs (missing `the`).

### Rationale for this change

Improving docs.

### What changes are included in this PR?

Small grammar fix in `docs/source/format/Intro.rst`

### Are these changes tested?

No, as these are only docs changes.

### Are there any user-facing changes?

No.