### PR TITLE
MINOR: [Docs] Add "Field" as a term to "Overview of Arrow Terminology"

### DIFF
--- a/docs/source/format/Intro.rst
+++ b/docs/source/format/Intro.rst
@@ -437,8 +437,11 @@ of the same length.
 
 **Schema**
 An ordered collection of fields that communicates all the data types of an object
-like a RecordBatch or Table. Schemas can contain optional key/value metadata. A Field includes a field name,
-a data type, a nullability flag and optional key-value metadata for a specific column in a RecordBatch.
+like a RecordBatch or Table. Schemas can contain optional key/value metadata.
+
+**Field**
+A Field includes a field name, a data type, a nullability flag and
+optional key-value metadata for a specific column in a RecordBatch.
 
 **Table**
 A discontiguous, two-dimensional chunk of data consisting of an ordered collection of Chunked

--- a/docs/source/format/Intro.rst
+++ b/docs/source/format/Intro.rst
@@ -437,10 +437,8 @@ of the same length.
 
 **Schema**
 An ordered collection of fields that communicates all the data types of an object
-like a RecordBatch or Table. Schemas can contain optional key/value metadata.
-
-A Field includes a field name, a data type, a nullability flag and optional key-value metadata
-for a specific column in a RecordBatch.
+like a RecordBatch or Table. Schemas can contain optional key/value metadata. A Field includes a field name,
+a data type, a nullability flag and optional key-value metadata for a specific column in a RecordBatch.
 
 **Table**
 A discontiguous, two-dimensional chunk of data consisting of an ordered collection of Chunked


### PR DESCRIPTION
### Rationale for this change

In the intro docs ("Overview of Arrow Terminology" section) the sentence `[...]A Field includes a field name, a data type, a nullability flag and optional key-value metadata for a specific column in a RecordBatch.[...]` is positioned in a non-consistent way compared to others. This felt a bit confusing in the beginning as I thought, that either the term, which should be described is missing or that the sentence should belong to `Schema`.

<img width="736" alt="image" src="https://github.com/user-attachments/assets/afac4db0-10a8-46e7-a384-80faffad2334" />

(Here you can see that the sentence from above is positioned in a way implying that it also describes an Arrow term on its own)

As `field` also appears in the images at the end of the section I suggest that it should also be treated as a separate term, therefore adding the sub-heading (Initially I thought it should be moved closer to **Schema**, but it feels more consistent to treat it as a separate term).

### What changes are included in this PR?

Added a **Field** sub-heading to "Overview of Arrow Terminology"

### Are these changes tested?

No, as this is only a docs change.

### Are there any user-facing changes?

No, as this is only a docs change.
