### PR TITLE
MINOR: [Docs] Update version number in example `pom.xml` for JDBC driver

### DIFF
--- a/docs/source/java/flight_sql_jdbc_driver.rst
+++ b/docs/source/java/flight_sql_jdbc_driver.rst
@@ -48,7 +48,7 @@ To add a dependency via Maven, use a ``pom.xml`` like the following:
      <artifactId>demo</artifactId>
      <version>1.0-SNAPSHOT</version>
      <properties>
-       <arrow.version>10.0.0</arrow.version>
+       <arrow.version>18.1.0</arrow.version>
      </properties>
      <dependencies>
        <dependency>


### PR DESCRIPTION
The docs still use version `10.0.0` for the JDBC driver example `pom.xml`.

This PR updates the version number to `18.1.0`.