### PR TITLE
MINOR: [C++][Parquet] Remove unused SerializedPageReader::current_page_

### DIFF
--- a/cpp/src/parquet/column_reader.cc
+++ b/cpp/src/parquet/column_reader.cc
@@ -291,7 +291,6 @@ class SerializedPageReader : public PageReader {
   std::shared_ptr<ArrowInputStream> stream_;
 
   format::PageHeader current_page_header_;
-  std::shared_ptr<Page> current_page_;
 
   // Compression codec to use.
   std::unique_ptr<::arrow::util::Codec> decompressor_;


### PR DESCRIPTION
### Rationale for this change

std::shared_ptr<Page> current_page_ has been defined but not used in the SerializedPageReader.

### What changes are included in this PR?

Simply remove it.

### Are these changes tested?

Pass CI.

### Are there any user-facing changes?

No