### PR TITLE
GH-45118: [Packaging] Use armored keyring for APT repository

### DIFF
--- a/dev/release/verify-apt.sh
+++ b/dev/release/verify-apt.sh
@@ -124,8 +124,13 @@ if [ "${TYPE}" = "local" ]; then
   if [ -f "${keys}" ]; then
     gpg \
       --no-default-keyring \
-      --keyring /usr/share/keyrings/apache-arrow-apt-source.gpg \
+      --keyring /tmp/apache-arrow-apt-source.kbx \
       --import "${keys}"
+    gpg \
+      --no-default-keyring \
+      --keyring /tmp/apache-arrow-apt-source.kbx \
+      --armor \
+      --export > /usr/share/keyrings/apache-arrow-apt-source.asc
   fi
 else
   case "${TYPE}" in

--- a/dev/tasks/linux-packages/apache-arrow-apt-source/debian/rules
+++ b/dev/tasks/linux-packages/apache-arrow-apt-source/debian/rules
@@ -11,9 +11,14 @@ export DH_OPTIONS
 
 override_dh_auto_build:
 	gpg \
-	  --no-default-keyring \
+	  --import KEYS \
 	  --keyring ./apache-arrow-apt-source.gpg \
-	  --import KEYS
+	  --no-default-keyring
+	gpg \
+	  --armor \
+	  --export \
+	  --keyring ./apache-arrow-apt-source.gpg \
+	  --no-default-keyring > ./apache-arrow-apt-source.asc
 
 	( \
 	  distribution=$$(lsb_release --id --short | tr 'A-Z' 'a-z'); \
@@ -22,12 +27,12 @@ override_dh_auto_build:
 	  echo "URIs: https://apache.jfrog.io/artifactory/arrow/$${distribution}/"; \
 	  echo "Suites: $${code_name}"; \
 	  echo "Components: main"; \
-	  echo "Signed-By: /usr/share/keyrings/apache-arrow-apt-source.gpg"; \
+	  echo "Signed-By: /usr/share/keyrings/apache-arrow-apt-source.asc"; \
 	) > apache-arrow.sources
 
 override_dh_install:
 	install -d debian/tmp/usr/share/keyrings/
-	install -m 0644 apache-arrow-apt-source.gpg \
+	install -m 0644 apache-arrow-apt-source.asc \
 	  debian/tmp/usr/share/keyrings/
 
 	install -d debian/tmp/etc/apt/sources.list.d/

--- a/dev/tasks/linux-packages/apache-arrow-apt-source/debian/rules
+++ b/dev/tasks/linux-packages/apache-arrow-apt-source/debian/rules
@@ -11,14 +11,14 @@ export DH_OPTIONS
 
 override_dh_auto_build:
 	gpg \
-	  --import KEYS \
+	  --no-default-keyring \
 	  --keyring ./apache-arrow-apt-source.gpg \
-	  --no-default-keyring
+	  --import KEYS
 	gpg \
-	  --armor \
-	  --export \
+	  --no-default-keyring \
 	  --keyring ./apache-arrow-apt-source.gpg \
-	  --no-default-keyring > ./apache-arrow-apt-source.asc
+	  --armor \
+	  --export > apache-arrow-apt-source.asc
 
 	( \
 	  distribution=$$(lsb_release --id --short | tr 'A-Z' 'a-z'); \

--- a/dev/tasks/linux-packages/apache-arrow-apt-source/debian/rules
+++ b/dev/tasks/linux-packages/apache-arrow-apt-source/debian/rules
@@ -12,11 +12,11 @@ export DH_OPTIONS
 override_dh_auto_build:
 	gpg \
 	  --no-default-keyring \
-	  --keyring ./apache-arrow-apt-source.gpg \
+	  --keyring ./apache-arrow-apt-source.kbx \
 	  --import KEYS
 	gpg \
 	  --no-default-keyring \
-	  --keyring ./apache-arrow-apt-source.gpg \
+	  --keyring ./apache-arrow-apt-source.kbx \
 	  --armor \
 	  --export > apache-arrow-apt-source.asc
 


### PR DESCRIPTION
### Rationale for this change

We're using the keybox format for keyring because we have multiple GPG keys. It seems that we should use the armored format for keyring.

libapt-pkg 2.9.16 or later shipped by Debian trixie rejects the keybox format files. So we should use the armored format.

### What changes are included in this PR?

Use `.asc` not `.gpg` for keyring.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #45118