### PR TITLE
GH-45119: [Ruby] Use #size for Arrow::Column#size backend

### DIFF
--- a/ruby/red-arrow/lib/arrow/column.rb
+++ b/ruby/red-arrow/lib/arrow/column.rb
@@ -58,11 +58,11 @@ module Arrow
       @data.reverse_each(&block)
     end
 
-    def n_rows
-      @data.n_rows
+    def size
+      @data.size
     end
-    alias_method :size, :n_rows
-    alias_method :length, :n_rows
+    alias_method :length, :size
+    alias_method :n_rows, :size
 
     def n_nulls
       @data.n_nulls

--- a/ruby/red-arrow/test/test-column.rb
+++ b/ruby/red-arrow/test/test-column.rb
@@ -49,6 +49,14 @@ class ColumnTest < Test::Unit::TestCase
     assert_equal([false, nil, true], @column.reverse_each.to_a)
   end
 
+  test("#size") do
+    assert_equal(3, @column.size)
+  end
+
+  test("#length") do
+    assert_equal(3, @column.length)
+  end
+
   test("#n_rows") do
     assert_equal(3, @column.n_rows)
   end

--- a/ruby/red-arrow/test/test-record-batch.rb
+++ b/ruby/red-arrow/test/test-record-batch.rb
@@ -178,5 +178,11 @@ class RecordBatchTest < Test::Unit::TestCase
                      @record_batch[[:c, "a", -1, 3..4]])
       end
     end
+
+    sub_test_case("#column") do
+      test("#size") do
+        assert_equal(@counts.size, @record_batch[:count].size)
+      end
+    end
   end
 end


### PR DESCRIPTION
### Rationale for this change

`#n_rows` is available only on `Arrow::ChunkedArray`. It's not available on `Arrow::Array`.

### What changes are included in this PR?

It's available on both of `Arrow::Array` and `Arrow::ChunkedArray`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #45119