### PR TITLE
GH-45142: [C++] Ensure using `cpp/cmake_modules/*.cmake`

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -92,7 +92,7 @@ endif()
 string(TOLOWER ${CMAKE_BUILD_TYPE} LOWERCASE_BUILD_TYPE)
 string(TOUPPER ${CMAKE_BUILD_TYPE} UPPERCASE_BUILD_TYPE)
 
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules")
+list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules")
 
 # this must be included before the project() command, because of the way
 # vcpkg (ab)uses CMAKE_TOOLCHAIN_FILE to inject its logic into CMake


### PR DESCRIPTION
### Rationale for this change

If we use `list(APPEND)` not `list(PREPEND)` for `cpp/cmake_modules/`, `*.cmake` that doesn't exist in `cpp/cmake_modules/` may be used.

See also: https://github.com/apache/iceberg-cpp/pull/6/files#r1900075993

### What changes are included in this PR?

Use `list(PREPEND)`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #45142