### PR TITLE
GH-45144: [C++] use std::atomic<std::shared_ptr> instead of std::atomic_load()/std::atomic_store()

### DIFF
--- a/cpp/src/arrow/array/array_nested.cc
+++ b/cpp/src/arrow/array/array_nested.cc
@@ -1077,7 +1077,7 @@ const ArrayVector& StructArray::fields() const {
 }
 
 const std::shared_ptr<Array>& StructArray::field(int i) const {
-  std::shared_ptr<Array> result = std::atomic_load(&boxed_fields_[i]);
+  std::shared_ptr<Array> result = std::atomic(&boxed_fields_[i]);
   if (!result) {
     std::shared_ptr<ArrayData> field_data;
     if (data_->offset != 0 || data_->child_data[i]->length != data_->length) {
@@ -1086,7 +1086,7 @@ const std::shared_ptr<Array>& StructArray::field(int i) const {
       field_data = data_->child_data[i];
     }
     result = MakeArray(field_data);
-    std::atomic_store(&boxed_fields_[i], std::move(result));
+    std::atomic(&boxed_fields_[i], std::move(result));
     return boxed_fields_[i];
   }
   return boxed_fields_[i];
@@ -1357,7 +1357,7 @@ std::shared_ptr<Array> UnionArray::field(int i) const {
       static_cast<decltype(boxed_fields_)::size_type>(i) >= boxed_fields_.size()) {
     return nullptr;
   }
-  std::shared_ptr<Array> result = std::atomic_load(&boxed_fields_[i]);
+  std::shared_ptr<Array> result = std::atomic(&boxed_fields_[i]);
   if (!result) {
     std::shared_ptr<ArrayData> child_data = data_->child_data[i]->Copy();
     if (mode() == UnionMode::SPARSE) {
@@ -1369,7 +1369,7 @@ std::shared_ptr<Array> UnionArray::field(int i) const {
       }
     }
     result = MakeArray(child_data);
-    std::atomic_store(&boxed_fields_[i], result);
+    std::atomic(&boxed_fields_[i], result);
   }
   return result;
 }

--- a/cpp/src/arrow/filesystem/s3fs.cc
+++ b/cpp/src/arrow/filesystem/s3fs.cc
@@ -1220,7 +1220,7 @@ class RegionResolver {
   }
 
   static Result<std::shared_ptr<RegionResolver>> DefaultInstance() {
-    auto resolver = std::atomic_load(&instance_);
+    auto resolver = std::atomic(&instance_);
     if (resolver) {
       return resolver;
     }
@@ -1239,7 +1239,7 @@ class RegionResolver {
   }
 
   static void ResetDefaultInstance() {
-    std::atomic_store(&instance_, std::shared_ptr<RegionResolver>());
+    std::atomic(&instance_, std::shared_ptr<RegionResolver>());
   }
 
   Result<std::string> ResolveRegion(const std::string& bucket) {

--- a/cpp/src/arrow/record_batch.cc
+++ b/cpp/src/arrow/record_batch.cc
@@ -100,10 +100,10 @@ class SimpleRecordBatch : public RecordBatch {
   }
 
   std::shared_ptr<Array> column(int i) const override {
-    std::shared_ptr<Array> result = std::atomic_load(&boxed_columns_[i]);
+    std::shared_ptr<Array> result = std::atomic(&boxed_columns_[i]);
     if (!result) {
       result = MakeArray(columns_[i]);
-      std::atomic_store(&boxed_columns_[i], result);
+      std::atomic(&boxed_columns_[i], result);
     }
     return result;
   }


### PR DESCRIPTION
### Rationale for this change

Replace deprecated calls to quite warnings (turned into errors) on GCC15

### What changes are included in this PR?

~`s/atomic_(load|store)/atomic/g`~ not actually this simple.

### Are these changes tested?

Yes

### Are there any user-facing changes?

There should be none.
* GitHub Issue: #45144