### PR TITLE
MINOR: [Docs][Python] Mention explicit None partitioning options for pyarrow.parquet.read_table

### DIFF
--- a/python/pyarrow/dataset.py
+++ b/python/pyarrow/dataset.py
@@ -542,7 +542,7 @@ def parquet_dataset(metadata_path, schema=None, filesystem=None, format=None,
     format : ParquetFileFormat
         An instance of a ParquetFileFormat if special options needs to be
         passed.
-    partitioning : Partitioning, PartitioningFactory, str, list of str
+    partitioning : Partitioning, PartitioningFactory, str, list of str, optional
         The partitioning scheme specified with the ``partitioning()``
         function. A flavor string can be used as shortcut, and with a list of
         field names a DirectoryPartitioning will be inferred.
@@ -638,7 +638,7 @@ RecordBatch or Table, iterable of RecordBatch, RecordBatchReader, or URI
         examples below.
         Note that the URIs on Windows must follow 'file:///C:...' or
         'file:/C:...' patterns.
-    partitioning : Partitioning, PartitioningFactory, str, list of str
+    partitioning : Partitioning, PartitioningFactory, str, list of str, optional
         The partitioning scheme specified with the ``partitioning()``
         function. A flavor string can be used as shortcut, and with a list of
         field names a DirectoryPartitioning will be inferred.

--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -1163,13 +1163,14 @@ memory_map : bool, default False
 buffer_size : int, default 0
     If positive, perform read buffering when deserializing individual
     column chunks. Otherwise IO calls are unbuffered.
-partitioning : pyarrow.dataset.Partitioning or str or list of str, \
+partitioning : pyarrow.dataset.Partitioning or str or list of str or None, \
 default "hive"
     The partitioning scheme for a partitioned dataset. The default of "hive"
     assumes directory names with key=value pairs like "/year=2009/month=11".
     In addition, a scheme like "/2009/11" is also supported, in which case
-    you need to specify the field names or a full schema. See the
-    ``pyarrow.dataset.partitioning()`` function for more details."""
+    you need to specify the field names or a full schema. If no partitioning
+    is used, pass ``None``.
+    See the ``pyarrow.dataset.partitioning()`` function for more details."""
 
 
 _parquet_dataset_example = """\


### PR DESCRIPTION
pyarrow.parquet.read_parquet does support using `None` as the partioning argument (and is required when not using partitioning).

This adjusts the documentation accordingly.