### PR TITLE
GH-45164: [CI][Integration] Remove "java_" prefix from Java build scripts

### DIFF
--- a/ci/scripts/integration_arrow_build.sh
+++ b/ci/scripts/integration_arrow_build.sh
@@ -59,7 +59,7 @@ if [ "${ARCHERY_INTEGRATION_WITH_JAVA}" -gt "0" ]; then
     export ARROW_JAVA_CDATA="ON"
     export JAVA_JNI_CMAKE_ARGS="-DARROW_JAVA_JNI_ENABLE_DEFAULT=OFF -DARROW_JAVA_JNI_ENABLE_C=ON"
 
-    ${arrow_dir}/java/ci/scripts/java_jni_build.sh "${arrow_dir}/java" "${ARROW_HOME}" "${build_dir}/java/" /tmp/dist/java
+    ${arrow_dir}/java/ci/scripts/jni_build.sh "${arrow_dir}/java" "${ARROW_HOME}" "${build_dir}/java/" /tmp/dist/java
     ${arrow_dir}/java/ci/scripts/java_build.sh "${arrow_dir}/java" "${build_dir}/java" /tmp/dist/java
 fi
 github_actions_group_end


### PR DESCRIPTION
### Rationale for this change

apache/arrow-java removed `java_` prefix from scripts by https://github.com/apache/arrow-java/pull/449 .

### What changes are included in this PR?

Follow the script name change.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #45164