### PR TITLE
GH-45169: [Python] Adapt to modified pytest ignore collect hook api

### DIFF
--- a/python/pyarrow/conftest.py
+++ b/python/pyarrow/conftest.py
@@ -217,10 +217,10 @@ except ImportError:
 
 
 # Doctest should ignore files for the modules that are not built
-def pytest_ignore_collect(path, config):
+def pytest_ignore_collect(collection_path, config):
     if config.option.doctestmodules:
         # don't try to run doctests on the /tests directory
-        if "/pyarrow/tests/" in str(path):
+        if "/pyarrow/tests/" in str(collection_path):
             return True
 
         doctest_groups = [
@@ -233,22 +233,22 @@ def pytest_ignore_collect(path, config):
 
         # handle cuda, flight, etc
         for group in doctest_groups:
-            if 'pyarrow/{}'.format(group) in str(path):
+            if 'pyarrow/{}'.format(group) in str(collection_path):
                 if not defaults[group]:
                     return True
 
-        if 'pyarrow/parquet/encryption' in str(path):
+        if 'pyarrow/parquet/encryption' in str(collection_path):
             if not defaults['parquet_encryption']:
                 return True
 
-        if 'pyarrow/cuda' in str(path):
+        if 'pyarrow/cuda' in str(collection_path):
             try:
                 import pyarrow.cuda  # noqa
                 return False
             except ImportError:
                 return True
 
-        if 'pyarrow/fs' in str(path):
+        if 'pyarrow/fs' in str(collection_path):
             try:
                 from pyarrow.fs import S3FileSystem  # noqa
                 return False
@@ -256,9 +256,9 @@ def pytest_ignore_collect(path, config):
                 return True
 
     if getattr(config.option, "doctest_cython", False):
-        if "/pyarrow/tests/" in str(path):
+        if "/pyarrow/tests/" in str(collection_path):
             return True
-        if "/pyarrow/_parquet_encryption" in str(path):
+        if "/pyarrow/_parquet_encryption" in str(collection_path):
             return True
 
     return False


### PR DESCRIPTION
### Rationale for this change

Prevent pytest from logging a warning during the unit tests and adapt to the future removal of the path argument in the `pytest_ignore_collect` hook.

### What changes are included in this PR?

This changes the deprecated `path` argument in  the pytest `pytest_ignore_collect` hook to `collection_path` which it should be as of pytest 7.0: https://docs.pytest.org/en/latest/deprecations.html#py-path-local-arguments-for-hooks-replaced-with-pathlib-path

### Are these changes tested?

The existing tests keep on running without a deprecation warning being logged for this. 

### Are there any user-facing changes?
 No

* GitHub Issue: #45169