### PR TITLE
GH-45183: [C++][Release] Add llvm-dev back to setup-ubuntu.sh

### DIFF
--- a/dev/release/setup-ubuntu.sh
+++ b/dev/release/setup-ubuntu.sh
@@ -42,7 +42,6 @@ apt-get install -y -q --no-install-recommends \
   bundler \
   clang \
   cmake \
-  llvm-dev \
   curl \
   git \
   gnupg \
@@ -51,6 +50,7 @@ apt-get install -y -q --no-install-recommends \
   libglib2.0-dev \
   libsqlite3-dev \
   libssl-dev \
+  llvm-dev \
   ninja-build \
   nlohmann-json3-dev \
   pkg-config \

--- a/dev/release/setup-ubuntu.sh
+++ b/dev/release/setup-ubuntu.sh
@@ -42,6 +42,7 @@ apt-get install -y -q --no-install-recommends \
   bundler \
   clang \
   cmake \
+  llvm-dev \
   curl \
   git \
   gnupg \


### PR DESCRIPTION
### Rationale for this change

Fixes verification nightly jobs. See https://github.com/apache/arrow/issues/45183.

### What changes are included in this PR?

Updates dev/release/setup-ubuntu.sh to re-add llvm-dev as an installed package.

### Are these changes tested?

Yes, locally (via `archery docker run....`)

### Are there any user-facing changes?

No.

Closes #45183 
* GitHub Issue: #45183