### PR TITLE
GH-45129: [Python][C++] Fix usage of deprecated C++ functionality on pyarrow

### DIFF
--- a/python/pyarrow/_parquet.pxd
+++ b/python/pyarrow/_parquet.pxd
@@ -484,11 +484,9 @@ cdef extern from "parquet/arrow/reader.h" namespace "parquet::arrow" nogil:
                               const vector[int]& column_indices,
                               shared_ptr[CTable]* out)
 
-        CStatus GetRecordBatchReader(const vector[int]& row_group_indices,
-                                     const vector[int]& column_indices,
-                                     unique_ptr[CRecordBatchReader]* out)
-        CStatus GetRecordBatchReader(const vector[int]& row_group_indices,
-                                     unique_ptr[CRecordBatchReader]* out)
+        CResult[unique_ptr[CRecordBatchReader]] GetRecordBatchReader(const vector[int]& row_group_indices,
+                                                                     const vector[int]& column_indices)
+        CResult[unique_ptr[CRecordBatchReader]] GetRecordBatchReader(const vector[int]& row_group_indices)
 
         CStatus ReadTable(shared_ptr[CTable]* out)
         CStatus ReadTable(const vector[int]& column_indices,

--- a/python/pyarrow/_parquet.pxd
+++ b/python/pyarrow/_parquet.pxd
@@ -484,9 +484,9 @@ cdef extern from "parquet/arrow/reader.h" namespace "parquet::arrow" nogil:
                               const vector[int]& column_indices,
                               shared_ptr[CTable]* out)
 
-        CResult[unique_ptr[CRecordBatchReader]] GetRecordBatchReader(const vector[int]& row_group_indices,
+        CResult[shared_ptr[CRecordBatchReader]] GetRecordBatchReader(const vector[int]& row_group_indices,
                                                                      const vector[int]& column_indices)
-        CResult[unique_ptr[CRecordBatchReader]] GetRecordBatchReader(const vector[int]& row_group_indices)
+        CResult[shared_ptr[CRecordBatchReader]] GetRecordBatchReader(const vector[int]& row_group_indices)
 
         CStatus ReadTable(shared_ptr[CTable]* out)
         CStatus ReadTable(const vector[int]& column_indices,

--- a/python/pyarrow/_parquet.pxd
+++ b/python/pyarrow/_parquet.pxd
@@ -484,9 +484,9 @@ cdef extern from "parquet/arrow/reader.h" namespace "parquet::arrow" nogil:
                               const vector[int]& column_indices,
                               shared_ptr[CTable]* out)
 
-        CResult[shared_ptr[CRecordBatchReader]] GetRecordBatchReader(const vector[int]& row_group_indices,
+        CResult[unique_ptr[CRecordBatchReader]] GetRecordBatchReader(const vector[int]& row_group_indices,
                                                                      const vector[int]& column_indices)
-        CResult[shared_ptr[CRecordBatchReader]] GetRecordBatchReader(const vector[int]& row_group_indices)
+        CResult[unique_ptr[CRecordBatchReader]] GetRecordBatchReader(const vector[int]& row_group_indices)
 
         CStatus ReadTable(shared_ptr[CTable]* out)
         CStatus ReadTable(const vector[int]& column_indices,

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -1616,16 +1616,16 @@ cdef class ParquetReader(_Weakrefable):
             for index in column_indices:
                 c_column_indices.push_back(index)
             with nogil:
-                check_status(
+                recordbatchreader = GetResultValue(
                     self.reader.get().GetRecordBatchReader(
-                        c_row_groups, c_column_indices, &recordbatchreader
+                        c_row_groups, c_column_indices
                     )
                 )
         else:
             with nogil:
-                check_status(
+                recordbatchreader = GetResultValue(
                     self.reader.get().GetRecordBatchReader(
-                        c_row_groups, &recordbatchreader
+                        c_row_groups
                     )
                 )
 

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -1602,7 +1602,7 @@ cdef class ParquetReader(_Weakrefable):
             vector[int] c_row_groups
             vector[int] c_column_indices
             shared_ptr[CRecordBatch] record_batch
-            SharedPtrNoGIL[CRecordBatchReader] recordbatchreader
+            UniquePtrNoGIL[CRecordBatchReader] recordbatchreader
 
         self.set_batch_size(batch_size)
 

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -1602,7 +1602,7 @@ cdef class ParquetReader(_Weakrefable):
             vector[int] c_row_groups
             vector[int] c_column_indices
             shared_ptr[CRecordBatch] record_batch
-            shared_ptr[CRecordBatchReader] recordbatchreader
+            SharedPtrNoGIL[CRecordBatchReader] recordbatchreader
 
         self.set_batch_size(batch_size)
 

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -1602,7 +1602,7 @@ cdef class ParquetReader(_Weakrefable):
             vector[int] c_row_groups
             vector[int] c_column_indices
             shared_ptr[CRecordBatch] record_batch
-            UniquePtrNoGIL[CRecordBatchReader] recordbatchreader
+            shared_ptr[CRecordBatchReader] recordbatchreader
 
         self.set_batch_size(batch_size)
 

--- a/python/pyarrow/src/arrow/python/python_test.cc
+++ b/python/pyarrow/src/arrow/python/python_test.cc
@@ -663,7 +663,7 @@ Status TestDecimal128OverflowFails() {
   ASSERT_EQ(38, metadata.precision());
   ASSERT_EQ(1, metadata.scale());
 
-  auto type = ::arrow::decimal(38, 38);
+  auto type = ::arrow::smallest_decimal(38, 38);
   const auto& decimal_type = checked_cast<const DecimalType&>(*type);
   ASSERT_RAISES(Invalid,
                 internal::DecimalFromPythonDecimal(python_decimal, decimal_type, &value));
@@ -689,7 +689,7 @@ Status TestDecimal256OverflowFails() {
   ASSERT_EQ(76, metadata.precision());
   ASSERT_EQ(1, metadata.scale());
 
-  auto type = ::arrow::decimal(76, 76);
+  auto type = ::arrow::smallest_decimal(76, 76);
   const auto& decimal_type = checked_cast<const DecimalType&>(*type);
   ASSERT_RAISES(Invalid,
                 internal::DecimalFromPythonDecimal(python_decimal, decimal_type, &value));


### PR DESCRIPTION
### Rationale for this change

We are using two C++ deprecated APIs:
- we are using decimal instead of smallest_decimal
- we are using Arrow:Status on GetRecordBatchReader instead of Arrow::Result

### What changes are included in this PR?

Update code to use non deprecated functions.

### Are these changes tested?

Yes via CI with existing tests.

### Are there any user-facing changes?

No
* GitHub Issue: #45129