### PR TITLE
GH-46308: [C++] Drop aws-cpp-sdk-config

### DIFF
--- a/cpp/cmake_modules/FindAWSSDKAlt.cmake
+++ b/cpp/cmake_modules/FindAWSSDKAlt.cmake
@@ -33,12 +33,7 @@ if(DEFINED ENV{CONDA_PREFIX})
   endif()
   set(BUILD_SHARED_LIBS ON)
 endif()
-find_package(AWSSDK ${find_package_args}
-             COMPONENTS config
-                        s3
-                        transfer
-                        identity-management
-                        sts)
+find_package(AWSSDK ${find_package_args} COMPONENTS s3 transfer identity-management sts)
 # Restore previous value of BUILD_SHARED_LIBS
 if(DEFINED ENV{CONDA_PREFIX})
   if(BUILD_SHARED_LIBS_WAS_SET)


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Arch Linux has started [splitting the aws-sdk-cpp into several packages](https://gitlab.archlinux.org/archlinux/packaging/packages/aws-sdk-cpp/-/merge_requests/1) and leaving out unused components avoids unnecessary packaging work.

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

The `config` component of the AWS SDK is not used when building arrow and thus can be dropped: https://github.com/apache/arrow/blob/e12bc56c158d97b72b18a4120e05feb2b0a79aff/cpp/src/arrow/CMakeLists.txt#L97-L102

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

No.

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #46308