### PR TITLE
GH-45198: [CI][Integration] Follow build script name change in apache/arrow-java

### DIFF
--- a/ci/scripts/integration_arrow_build.sh
+++ b/ci/scripts/integration_arrow_build.sh
@@ -60,7 +60,7 @@ if [ "${ARCHERY_INTEGRATION_WITH_JAVA}" -gt "0" ]; then
     export JAVA_JNI_CMAKE_ARGS="-DARROW_JAVA_JNI_ENABLE_DEFAULT=OFF -DARROW_JAVA_JNI_ENABLE_C=ON"
 
     ${arrow_dir}/java/ci/scripts/jni_build.sh "${arrow_dir}/java" "${ARROW_HOME}" "${build_dir}/java/" /tmp/dist/java
-    ${arrow_dir}/java/ci/scripts/java_build.sh "${arrow_dir}/java" "${build_dir}/java" /tmp/dist/java
+    ${arrow_dir}/java/ci/scripts/build.sh "${arrow_dir}/java" "${build_dir}/java" /tmp/dist/java
 fi
 github_actions_group_end
 


### PR DESCRIPTION
### Rationale for this change

For apache/arrow-java#493.

### What changes are included in this PR?

Remove `java_` prefix.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #45198