### PR TITLE
GH-45204: [Integration][Archery] Remove skips for nanoarrow IPC compression ZSTD/uncompressible golden files

### DIFF
--- a/ci/docker/conda-integration.dockerfile
+++ b/ci/docker/conda-integration.dockerfile
@@ -38,7 +38,8 @@ RUN mamba install -q -y \
         maven=${maven} \
         nodejs=${node} \
         yarn=${yarn} \
-        openjdk=${jdk} && \
+        openjdk=${jdk} \
+        zstd && \
     mamba clean --all --force-pkgs-dirs
 
 # Install Rust with only the needed components

--- a/ci/scripts/nanoarrow_build.sh
+++ b/ci/scripts/nanoarrow_build.sh
@@ -48,7 +48,7 @@ pushd ${build_dir}
 
 cmake ${source_dir} \
   -DNANOARROW_IPC=ON \
-  -DNANOARROW_IPC_WITH_ZSTD \
+  -DNANOARROW_IPC_WITH_ZSTD=ON \
   -DNANOARROW_BUILD_INTEGRATION_TESTS=ON
 cmake --build .
 

--- a/ci/scripts/nanoarrow_build.sh
+++ b/ci/scripts/nanoarrow_build.sh
@@ -46,7 +46,10 @@ set -x
 mkdir -p ${build_dir}
 pushd ${build_dir}
 
-cmake ${source_dir} -DNANOARROW_IPC=ON -DNANOARROW_BUILD_INTEGRATION_TESTS=ON
+cmake ${source_dir} \
+  -DNANOARROW_IPC=ON \
+  -DNANOARROW_IPC_WITH_ZSTD \
+  -DNANOARROW_BUILD_INTEGRATION_TESTS=ON
 cmake --build .
 
 popd

--- a/dev/archery/archery/integration/runner.py
+++ b/dev/archery/archery/integration/runner.py
@@ -200,7 +200,7 @@ class IntegrationRunner(object):
                 skip_testers.add("Rust")
             if prefix == '2.0.0-compression':
                 skip_testers.add("JS")
-            if prefix == '2.0.0-compression' and name == 'lz4':
+            if prefix == '2.0.0-compression' and 'lz4' in name:
                 # https://github.com/apache/arrow-nanoarrow/issues/621
                 skip_testers.add("nanoarrow")
 

--- a/dev/archery/archery/integration/runner.py
+++ b/dev/archery/archery/integration/runner.py
@@ -200,6 +200,7 @@ class IntegrationRunner(object):
                 skip_testers.add("Rust")
             if prefix == '2.0.0-compression':
                 skip_testers.add("JS")
+            if prefix == '2.0.0-compression' and name == 'lz4':
                 # https://github.com/apache/arrow-nanoarrow/issues/621
                 skip_testers.add("nanoarrow")
 


### PR DESCRIPTION
### Rationale for this change

After apache/arrow-nanoarrow#693 , ZSTD compression is now supported in the nanoarrow IPC reader. The list of skips lives in archery, though, and I'd like those checks to run (here and on our own CI!).

### What changes are included in this PR?

The line skipping compression checks for nanoarrow IPC were modified to only skip lz4 (which is not yet implemented).

### Are these changes tested?

Yes, this code runs as part of the integration CI job. The skipped tester is not run in the Arrow repo, though (because of the "target implementations", which correctly doesn't include nanoarrow here); however, the changes are tested in https://github.com/apache/arrow-nanoarrow/pull/704 .

(That PR will need to merge before this one because this PR updates the nanoarrow build script in a way will cause the integration job to fail before that PR is merged)

### Are there any user-facing changes?

No!
* GitHub Issue: #45204