### PR TITLE
GH-45206: [C++][CMake] Add sanitizer presets

### DIFF
--- a/cpp/CMakePresets.json
+++ b/cpp/CMakePresets.json
@@ -557,8 +557,7 @@
     {
       "name": "ninja-debug-asan",
       "inherits": [
-        "base-debug",
-        "features-main",
+        "ninja-debug",
         "sanitizer-asan"
       ],
       "displayName": "Debug ASAN build with tests and more optional components",
@@ -567,8 +566,7 @@
     {
       "name": "ninja-debug-tsan",
       "inherits": [
-        "base-debug",
-        "features-main",
+        "ninja-debug",
         "sanitizer-tsan"
       ],
       "displayName": "Debug TSAN build with tests and more optional components",
@@ -577,8 +575,7 @@
     {
       "name": "ninja-debug-ubsan",
       "inherits": [
-        "base-debug",
-        "features-main",
+        "ninja-debug",
         "sanitizer-ubsan"
       ],
       "displayName": "Debug UBSAN build with tests and more optional components",

--- a/cpp/CMakePresets.json
+++ b/cpp/CMakePresets.json
@@ -233,6 +233,33 @@
       }
     },
     {
+      "name": "sanitizer-asan",
+      "hidden": true,
+      "cacheVariables": {
+        "ARROW_USE_ASAN": "ON",
+        "ARROW_JEMALLOC": "OFF",
+        "ARROW_MIMALLOC": "OFF"
+      }
+    },
+    {
+      "name": "sanitizer-tsan",
+      "hidden": true,
+      "cacheVariables": {
+        "ARROW_USE_TSAN": "ON",
+        "ARROW_JEMALLOC": "OFF",
+        "ARROW_MIMALLOC": "OFF"
+      }
+    },
+    {
+      "name": "sanitizer-ubsan",
+      "hidden": true,
+      "cacheVariables": {
+        "ARROW_USE_UBSAN": "ON",
+        "ARROW_JEMALLOC": "OFF",
+        "ARROW_MIMALLOC": "OFF"
+      }
+    },
+    {
       "name": "ninja-debug-minimal",
       "inherits": [
         "base-debug",
@@ -528,15 +555,47 @@
       "cacheVariables": {}
     },
     {
+      "name": "ninja-debug-asan",
+      "inherits": [
+        "base-debug",
+        "features-main",
+        "sanitizer-asan"
+      ],
+      "displayName": "Debug ASAN build with tests and more optional components",
+      "cacheVariables": {}
+    },
+    {
+      "name": "ninja-debug-tsan",
+      "inherits": [
+        "base-debug",
+        "features-main",
+        "sanitizer-tsan"
+      ],
+      "displayName": "Debug TSAN build with tests and more optional components",
+      "cacheVariables": {}
+    },
+    {
+      "name": "ninja-debug-ubsan",
+      "inherits": [
+        "base-debug",
+        "features-main",
+        "sanitizer-ubsan"
+      ],
+      "displayName": "Debug UBSAN build with tests and more optional components",
+      "cacheVariables": {}
+    },
+    {
       "name": "fuzzing",
-      "inherits": "base",
+      "inherits": [
+        "base",
+        "sanitizer-asan",
+        "sanitizer-ubsan"
+      ],
       "displayName": "Debug build with IPC and Parquet fuzzing targets",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
         "CMAKE_C_COMPILER": "clang",
         "CMAKE_CXX_COMPILER": "clang++",
-        "ARROW_USE_ASAN": "ON",
-        "ARROW_USE_UBSAN": "ON",
         "ARROW_IPC": "ON",
         "ARROW_PARQUET": "ON",
         "ARROW_FUZZING": "ON"


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

See #45206

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

Add base presets for ASAN/TSAN/UBSAN. And cross product such base presets by `ninja-debug` which is, IMO, the config just enough necessary and likely to need sanitizers' aid. 

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

No need.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

None.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #45206