### PR TITLE
GH-45209: [C++][CMake] Fix the issue that allocator not disabled for sanitizer cmake presets

### DIFF
--- a/cpp/CMakePresets.json
+++ b/cpp/CMakePresets.json
@@ -172,6 +172,7 @@
     {
       "name": "features-maximal",
       "inherits": [
+        "features-main",
         "features-python-maximal"
       ],
       "hidden": true,

--- a/cpp/CMakePresets.json
+++ b/cpp/CMakePresets.json
@@ -7,38 +7,6 @@
   },
   "configurePresets": [
     {
-      "name": "_allocators-none",
-      "hidden": true,
-      "cacheVariables": {
-        "ARROW_JEMALLOC": "OFF",
-        "ARROW_MIMALLOC": "OFF"
-      }
-    },
-    {
-      "name": "_allocators-jemalloc",
-      "hidden": true,
-      "cacheVariables": {
-        "ARROW_JEMALLOC": "ON",
-        "ARROW_MIMALLOC": "OFF"
-      }
-    },
-    {
-      "name": "_allocators-mimalloc",
-      "hidden": true,
-      "cacheVariables": {
-        "ARROW_JEMALLOC": "OFF",
-        "ARROW_MIMALLOC": "ON"
-      }
-    },
-    {
-      "name": "_allocators-all",
-      "hidden": true,
-      "cacheVariables": {
-        "ARROW_JEMALLOC": "ON",
-        "ARROW_MIMALLOC": "ON"
-      }
-    },
-    {
       "name": "base",
       "hidden": true,
       "generator": "Ninja",
@@ -80,11 +48,9 @@
     },
     {
       "name": "features-minimal",
-      "inherits": [
-        "_allocators-none"
-      ],
       "hidden": true,
       "cacheVariables": {
+        "ARROW_MIMALLOC": "OFF",
         "ARROW_WITH_RE2": "OFF",
         "ARROW_WITH_UTF8PROC": "OFF"
       }
@@ -92,7 +58,6 @@
     {
       "name": "features-basic",
       "inherits": [
-        "_allocators-mimalloc",
         "features-minimal"
       ],
       "hidden": true,
@@ -101,7 +66,8 @@
         "ARROW_CSV": "ON",
         "ARROW_DATASET": "ON",
         "ARROW_FILESYSTEM": "ON",
-        "ARROW_JSON": "ON"
+        "ARROW_JSON": "ON",
+        "ARROW_MIMALLOC": "ON"
       }
     },
     {
@@ -206,7 +172,6 @@
     {
       "name": "features-maximal",
       "inherits": [
-        "_allocators-all",
         "features-python-maximal"
       ],
       "hidden": true,
@@ -221,9 +186,6 @@
     },
     {
       "name": "features-emscripten",
-      "inherits": [
-        "_allocators-none"
-      ],
       "hidden": true,
       "cacheVariables": {
         "ARROW_ACERO": "ON",
@@ -236,7 +198,9 @@
         "ARROW_ENABLE_THREADING": "OFF",
         "ARROW_FLIGHT": "OFF",
         "ARROW_IPC": "ON",
+        "ARROW_JEMALLOC": "OFF",
         "ARROW_JSON": "ON",
+        "ARROW_MIMALLOC": "OFF",
         "ARROW_ORC": "ON",
         "ARROW_RUNTIME_SIMD_LEVEL": "NONE",
         "ARROW_S3": "OFF",
@@ -258,39 +222,36 @@
     },
     {
       "name": "sanitizer-asan",
-      "inherits": [
-        "_allocators-none"
-      ],
       "hidden": true,
       "cacheVariables": {
+        "ARROW_JEMALLOC": "OFF",
+        "ARROW_MIMALLOC": "OFF",
         "ARROW_USE_ASAN": "ON"
       }
     },
     {
       "name": "sanitizer-tsan",
-      "inherits": [
-        "_allocators-none"
-      ],
       "hidden": true,
       "cacheVariables": {
+        "ARROW_JEMALLOC": "OFF",
+        "ARROW_MIMALLOC": "OFF",
         "ARROW_USE_TSAN": "ON"
       }
     },
     {
       "name": "sanitizer-ubsan",
-      "inherits": [
-        "_allocators-none"
-      ],
       "hidden": true,
       "cacheVariables": {
+        "ARROW_JEMALLOC": "OFF",
+        "ARROW_MIMALLOC": "OFF",
         "ARROW_USE_UBSAN": "ON"
       }
     },
     {
       "name": "ninja-debug-minimal",
       "inherits": [
-        "base-debug",
-        "features-minimal"
+        "features-minimal",
+        "base-debug"
       ],
       "displayName": "Debug build without anything enabled",
       "cacheVariables": {
@@ -301,8 +262,8 @@
     {
       "name": "ninja-debug-basic",
       "inherits": [
-        "base-debug",
-        "features-basic"
+        "features-basic",
+        "base-debug"
       ],
       "displayName": "Debug build with tests and reduced dependencies",
       "cacheVariables": {}
@@ -310,8 +271,8 @@
     {
       "name": "ninja-debug",
       "inherits": [
-        "base-debug",
-        "features-main"
+        "features-main",
+        "base-debug"
       ],
       "displayName": "Debug build with tests and more optional components",
       "cacheVariables": {}
@@ -319,8 +280,8 @@
     {
       "name": "ninja-debug-cuda",
       "inherits": [
-        "base-debug",
-        "features-cuda"
+        "features-cuda",
+        "base-debug"
       ],
       "displayName": "Debug build with tests and CUDA integration",
       "cacheVariables": {}
@@ -328,8 +289,8 @@
     {
       "name": "ninja-debug-filesystems",
       "inherits": [
-        "base-debug",
-        "features-filesystems"
+        "features-filesystems",
+        "base-debug"
       ],
       "displayName": "Debug build with tests and filesystems",
       "cacheVariables": {}
@@ -337,8 +298,8 @@
     {
       "name": "ninja-debug-flight",
       "inherits": [
-        "base-debug",
-        "features-flight"
+        "features-flight",
+        "base-debug"
       ],
       "displayName": "Debug build with tests and Flight",
       "cacheVariables": {}
@@ -346,8 +307,8 @@
     {
       "name": "ninja-debug-flight-sql",
       "inherits": [
-        "base-debug",
-        "features-flight-sql"
+        "features-flight-sql",
+        "base-debug"
       ],
       "displayName": "Debug build with tests and Flight SQL",
       "cacheVariables": {}
@@ -355,8 +316,8 @@
     {
       "name": "ninja-debug-gandiva",
       "inherits": [
-        "base-debug",
-        "features-gandiva"
+        "features-gandiva",
+        "base-debug"
       ],
       "displayName": "Debug build with tests and Gandiva",
       "cacheVariables": {}
@@ -364,8 +325,8 @@
     {
       "name": "ninja-debug-python-minimal",
       "inherits": [
-        "base-debug",
-        "features-python-minimal"
+        "features-python-minimal",
+        "base-debug"
       ],
       "displayName": "Debug build for PyArrow with minimal features",
       "cacheVariables": {}
@@ -373,8 +334,8 @@
     {
       "name": "ninja-debug-python",
       "inherits": [
-        "base-debug",
-        "features-python"
+        "features-python",
+        "base-debug"
       ],
       "displayName": "Debug build for PyArrow with common features (for backward compatibility)",
       "cacheVariables": {}
@@ -382,8 +343,8 @@
     {
       "name": "ninja-debug-python-maximal",
       "inherits": [
-        "base-debug",
-        "features-python-maximal"
+        "features-python-maximal",
+        "base-debug"
       ],
       "displayName": "Debug build for PyArrow with everything enabled",
       "cacheVariables": {}
@@ -391,8 +352,8 @@
     {
       "name": "ninja-debug-maximal",
       "inherits": [
-        "base-debug",
-        "features-maximal"
+        "features-maximal",
+        "base-debug"
       ],
       "displayName": "Debug build with everything enabled (except benchmarks)",
       "cacheVariables": {}
@@ -400,8 +361,8 @@
     {
       "name": "ninja-debug-emscripten",
       "inherits": [
-        "base-debug",
-        "features-emscripten"
+        "features-emscripten",
+        "base-debug"
       ],
       "displayName": "Debug build which builds an Emscripten library",
       "cacheVariables": {}
@@ -445,9 +406,8 @@
     {
       "name": "ninja-debug-asan",
       "inherits": [
-        "_allocators-none",
-        "ninja-debug",
-        "sanitizer-asan"
+        "sanitizer-asan",
+        "ninja-debug"
       ],
       "displayName": "Debug build for ASAN with tests and more optional components",
       "cacheVariables": {}
@@ -455,9 +415,8 @@
     {
       "name": "ninja-debug-tsan",
       "inherits": [
-        "_allocators-none",
-        "ninja-debug",
-        "sanitizer-tsan"
+        "sanitizer-tsan",
+        "ninja-debug"
       ],
       "displayName": "Debug build for TSAN with tests and more optional components",
       "cacheVariables": {}
@@ -465,9 +424,8 @@
     {
       "name": "ninja-debug-ubsan",
       "inherits": [
-        "_allocators-none",
-        "ninja-debug",
-        "sanitizer-ubsan"
+        "sanitizer-ubsan",
+        "ninja-debug"
       ],
       "displayName": "Debug build for UBSAN with tests and more optional components",
       "cacheVariables": {}
@@ -492,8 +450,8 @@
     {
       "name": "ninja-release-minimal",
       "inherits": [
-        "base-release",
-        "features-minimal"
+        "features-minimal",
+        "base-release"
       ],
       "displayName": "Release build without anything enabled",
       "cacheVariables": {}
@@ -501,8 +459,8 @@
     {
       "name": "ninja-release-basic",
       "inherits": [
-        "base-release",
-        "features-basic"
+        "features-basic",
+        "base-release"
       ],
       "displayName": "Release build with reduced dependencies",
       "cacheVariables": {}
@@ -510,8 +468,8 @@
     {
       "name": "ninja-release",
       "inherits": [
-        "base-release",
-        "features-main"
+        "features-main",
+        "base-release"
       ],
       "displayName": "Release build with more optional components",
       "cacheVariables": {}
@@ -519,8 +477,8 @@
     {
       "name": "ninja-release-cuda",
       "inherits": [
-        "base-release",
-        "features-cuda"
+        "features-cuda",
+        "base-release"
       ],
       "displayName": "Release build with CUDA integration",
       "cacheVariables": {}
@@ -528,8 +486,8 @@
     {
       "name": "ninja-release-flight",
       "inherits": [
-        "base-release",
-        "features-flight"
+        "features-flight",
+        "base-release"
       ],
       "displayName": "Release build with Flight",
       "cacheVariables": {}
@@ -537,8 +495,8 @@
     {
       "name": "ninja-release-flight-sql",
       "inherits": [
-        "base-release",
-        "features-flight-sql"
+        "features-flight-sql",
+        "base-release"
       ],
       "displayName": "Release build with Flight SQL",
       "cacheVariables": {}
@@ -546,8 +504,8 @@
     {
       "name": "ninja-release-gandiva",
       "inherits": [
-        "base-release",
-        "features-gandiva"
+        "features-gandiva",
+        "base-release"
       ],
       "displayName": "Release build with Gandiva",
       "cacheVariables": {}
@@ -555,8 +513,8 @@
     {
       "name": "ninja-release-python-minimal",
       "inherits": [
-        "base-release",
-        "features-python-minimal"
+        "features-python-minimal",
+        "base-release"
       ],
       "displayName": "Release build for PyArrow with minimal features",
       "cacheVariables": {}
@@ -564,8 +522,8 @@
     {
       "name": "ninja-release-python",
       "inherits": [
-        "base-release",
-        "features-python"
+        "features-python",
+        "base-release"
       ],
       "displayName": "Release build for PyArrow with common features (for backward compatibility)",
       "cacheVariables": {}
@@ -573,8 +531,8 @@
     {
       "name": "ninja-release-python-maximal",
       "inherits": [
-        "base-release",
-        "features-python-maximal"
+        "features-python-maximal",
+        "base-release"
       ],
       "displayName": "Release build for PyArrow with everything enabled",
       "cacheVariables": {}
@@ -582,8 +540,8 @@
     {
       "name": "ninja-release-maximal",
       "inherits": [
-        "base-release",
-        "features-maximal"
+        "features-maximal",
+        "base-release"
       ],
       "displayName": "Release build with everything enabled (except benchmarks)",
       "cacheVariables": {}
@@ -600,8 +558,8 @@
     {
       "name": "ninja-benchmarks-basic",
       "inherits": [
-        "base-benchmarks",
-        "features-basic"
+        "features-basic",
+        "base-benchmarks"
       ],
       "displayName": "Benchmarking build with reduced dependencies",
       "cacheVariables": {}
@@ -609,8 +567,8 @@
     {
       "name": "ninja-benchmarks",
       "inherits": [
-        "base-benchmarks",
-        "features-main"
+        "features-main",
+        "base-benchmarks"
       ],
       "displayName": "Benchmarking build with more optional components",
       "cacheVariables": {}
@@ -618,8 +576,8 @@
     {
       "name": "ninja-benchmarks-maximal",
       "inherits": [
-        "base-benchmarks",
-        "features-maximal"
+        "features-maximal",
+        "base-benchmarks"
       ],
       "displayName": "Benchmarking build with everything enabled",
       "cacheVariables": {}

--- a/cpp/CMakePresets.json
+++ b/cpp/CMakePresets.json
@@ -7,7 +7,7 @@
   },
   "configurePresets": [
     {
-      "name": "_allocator-none",
+      "name": "_allocators-none",
       "hidden": true,
       "cacheVariables": {
         "ARROW_JEMALLOC": "OFF",
@@ -15,7 +15,7 @@
       }
     },
     {
-      "name": "_allocator-jemalloc",
+      "name": "_allocators-jemalloc",
       "hidden": true,
       "cacheVariables": {
         "ARROW_JEMALLOC": "ON",
@@ -23,10 +23,18 @@
       }
     },
     {
-      "name": "_allocator-mimalloc",
+      "name": "_allocators-mimalloc",
       "hidden": true,
       "cacheVariables": {
         "ARROW_JEMALLOC": "OFF",
+        "ARROW_MIMALLOC": "ON"
+      }
+    },
+    {
+      "name": "_allocators-all",
+      "hidden": true,
+      "cacheVariables": {
+        "ARROW_JEMALLOC": "ON",
         "ARROW_MIMALLOC": "ON"
       }
     },
@@ -73,7 +81,7 @@
     {
       "name": "features-minimal",
       "inherits": [
-        "_allocator-none"
+        "_allocators-none"
       ],
       "hidden": true,
       "cacheVariables": {
@@ -84,7 +92,7 @@
     {
       "name": "features-basic",
       "inherits": [
-        "_allocator-mimalloc",
+        "_allocators-mimalloc",
         "features-minimal"
       ],
       "hidden": true,
@@ -198,6 +206,7 @@
     {
       "name": "features-maximal",
       "inherits": [
+        "_allocators-all",
         "features-python-maximal"
       ],
       "hidden": true,
@@ -213,7 +222,7 @@
     {
       "name": "features-emscripten",
       "inherits": [
-        "_allocator-none"
+        "_allocators-none"
       ],
       "hidden": true,
       "cacheVariables": {
@@ -250,7 +259,7 @@
     {
       "name": "sanitizer-asan",
       "inherits": [
-        "_allocator-none"
+        "_allocators-none"
       ],
       "hidden": true,
       "cacheVariables": {
@@ -260,7 +269,7 @@
     {
       "name": "sanitizer-tsan",
       "inherits": [
-        "_allocator-none"
+        "_allocators-none"
       ],
       "hidden": true,
       "cacheVariables": {
@@ -270,7 +279,7 @@
     {
       "name": "sanitizer-ubsan",
       "inherits": [
-        "_allocator-none"
+        "_allocators-none"
       ],
       "hidden": true,
       "cacheVariables": {
@@ -436,7 +445,7 @@
     {
       "name": "ninja-debug-asan",
       "inherits": [
-        "_allocator-none",
+        "_allocators-none",
         "ninja-debug",
         "sanitizer-asan"
       ],
@@ -446,7 +455,7 @@
     {
       "name": "ninja-debug-tsan",
       "inherits": [
-        "_allocator-none",
+        "_allocators-none",
         "ninja-debug",
         "sanitizer-tsan"
       ],
@@ -456,7 +465,7 @@
     {
       "name": "ninja-debug-ubsan",
       "inherits": [
-        "_allocator-none",
+        "_allocators-none",
         "ninja-debug",
         "sanitizer-ubsan"
       ],

--- a/cpp/CMakePresets.json
+++ b/cpp/CMakePresets.json
@@ -7,6 +7,30 @@
   },
   "configurePresets": [
     {
+      "name": "_allocator-none",
+      "hidden": true,
+      "cacheVariables": {
+        "ARROW_JEMALLOC": "OFF",
+        "ARROW_MIMALLOC": "OFF"
+      }
+    },
+    {
+      "name": "_allocator-jemalloc",
+      "hidden": true,
+      "cacheVariables": {
+        "ARROW_JEMALLOC": "ON",
+        "ARROW_MIMALLOC": "OFF"
+      }
+    },
+    {
+      "name": "_allocator-mimalloc",
+      "hidden": true,
+      "cacheVariables": {
+        "ARROW_JEMALLOC": "OFF",
+        "ARROW_MIMALLOC": "ON"
+      }
+    },
+    {
       "name": "base",
       "hidden": true,
       "generator": "Ninja",
@@ -47,34 +71,6 @@
       }
     },
     {
-      "name": "features-emscripten",
-      "hidden": true,
-      "cacheVariables": {
-        "ARROW_ACERO": "ON",
-        "ARROW_BUILD_SHARED": "OFF",
-        "ARROW_BUILD_STATIC": "ON",
-        "ARROW_CSV": "ON",
-        "ARROW_CUDA": "OFF",
-        "ARROW_DEPENDENCY_SOURCE": "BUNDLED",
-        "ARROW_DEPENDENCY_USE_SHARED": "OFF",
-        "ARROW_ENABLE_THREADING": "OFF",
-        "ARROW_FLIGHT": "OFF",
-        "ARROW_IPC": "ON",
-        "ARROW_JEMALLOC": "OFF",
-        "ARROW_JSON": "ON",
-        "ARROW_MIMALLOC": "OFF",
-        "ARROW_ORC": "ON",
-        "ARROW_RUNTIME_SIMD_LEVEL": "NONE",
-        "ARROW_S3": "OFF",
-        "ARROW_SIMD_LEVEL": "NONE",
-        "ARROW_SUBSTRAIT": "ON",
-        "ARROW_WITH_BROTLI": "ON",
-        "ARROW_WITH_OPENTELEMETRY": "OFF",
-        "ARROW_WITH_SNAPPY": "ON",
-        "CMAKE_C_BYTE_ORDER": "LITTLE_ENDIAN"
-      }
-    },
-    {
       "name": "features-minimal",
       "hidden": true,
       "cacheVariables": {
@@ -103,7 +99,6 @@
       "cacheVariables": {
         "ARROW_SUBSTRAIT": "ON",
         "ARROW_ACERO": "ON",
-        "ARROW_MIMALLOC": "ON",
         "ARROW_PARQUET": "ON",
         "ARROW_WITH_BROTLI": "ON",
         "ARROW_WITH_BZ2": "ON",
@@ -174,15 +169,11 @@
     {
       "name": "features-python",
       "inherits": [
-        "features-main"
+        "features-main",
+        "features-python-minimal"
       ],
       "hidden": true,
       "cacheVariables": {
-        "ARROW_COMPUTE": "ON",
-        "ARROW_CSV": "ON",
-        "ARROW_DATASET": "ON",
-        "ARROW_FILESYSTEM": "ON",
-        "ARROW_JSON": "ON",
         "ARROW_ORC": "ON"
       }
     },
@@ -193,35 +184,54 @@
         "features-filesystems",
         "features-flight-sql",
         "features-gandiva",
-        "features-main",
-        "features-python-minimal"
+        "features-python"
       ],
       "hidden": true,
       "cacheVariables": {
-        "ARROW_ORC": "ON",
         "PARQUET_REQUIRE_ENCRYPTION": "ON"
       }
     },
     {
       "name": "features-maximal",
       "inherits": [
-        "features-main",
-        "features-cuda",
-        "features-filesystems",
-        "features-flight-sql",
-        "features-gandiva",
         "features-python-maximal"
       ],
       "hidden": true,
       "cacheVariables": {
         "ARROW_BUILD_EXAMPLES": "ON",
         "ARROW_BUILD_UTILITIES": "ON",
-        "ARROW_ORC": "ON",
         "ARROW_SKYHOOK": "ON",
         "ARROW_TENSORFLOW": "ON",
         "PARQUET_BUILD_EXAMPLES": "ON",
-        "PARQUET_BUILD_EXECUTABLES": "ON",
-        "PARQUET_REQUIRE_ENCRYPTION": "ON"
+        "PARQUET_BUILD_EXECUTABLES": "ON"
+      }
+    },
+    {
+      "name": "features-emscripten",
+      "hidden": true,
+      "cacheVariables": {
+        "ARROW_ACERO": "ON",
+        "ARROW_BUILD_SHARED": "OFF",
+        "ARROW_BUILD_STATIC": "ON",
+        "ARROW_CSV": "ON",
+        "ARROW_CUDA": "OFF",
+        "ARROW_DEPENDENCY_SOURCE": "BUNDLED",
+        "ARROW_DEPENDENCY_USE_SHARED": "OFF",
+        "ARROW_ENABLE_THREADING": "OFF",
+        "ARROW_FLIGHT": "OFF",
+        "ARROW_IPC": "ON",
+        "ARROW_JEMALLOC": "OFF",
+        "ARROW_JSON": "ON",
+        "ARROW_MIMALLOC": "OFF",
+        "ARROW_ORC": "ON",
+        "ARROW_RUNTIME_SIMD_LEVEL": "NONE",
+        "ARROW_S3": "OFF",
+        "ARROW_SIMD_LEVEL": "NONE",
+        "ARROW_SUBSTRAIT": "ON",
+        "ARROW_WITH_BROTLI": "ON",
+        "ARROW_WITH_OPENTELEMETRY": "OFF",
+        "ARROW_WITH_SNAPPY": "ON",
+        "CMAKE_C_BYTE_ORDER": "LITTLE_ENDIAN"
       }
     },
     {
@@ -371,44 +381,96 @@
       "cacheVariables": {}
     },
     {
-      "name": "ninja-debug-valgrind-basic",
+      "name": "ninja-debug-emscripten",
       "inherits": [
         "base-debug",
-        "features-basic",
-        "features-valgrind"
+        "features-emscripten"
       ],
-      "displayName": "Debug build for Valgrind with reduced dependencies",
-      "cacheVariables": {}
-    },
-    {
-      "name": "ninja-debug-valgrind",
-      "inherits": [
-        "base-debug",
-        "features-main",
-        "features-valgrind"
-      ],
-      "displayName": "Debug build for Valgrind with more optional components",
+      "displayName": "Debug build which builds an Emscripten library",
       "cacheVariables": {}
     },
     {
       "name": "ninja-debug-valgrind-minimal",
       "inherits": [
-        "base-debug",
-        "features-minimal",
-        "features-valgrind"
+        "features-valgrind",
+        "ninja-debug-minimal"
       ],
       "displayName": "Debug build for Valgrind without anything enabled",
       "cacheVariables": {}
     },
     {
+      "name": "ninja-debug-valgrind-basic",
+      "inherits": [
+        "features-valgrind",
+        "ninja-debug-basic"
+      ],
+      "displayName": "Debug build for Valgrind with tests and reduced dependencies",
+      "cacheVariables": {}
+    },
+    {
+      "name": "ninja-debug-valgrind",
+      "inherits": [
+        "features-valgrind",
+        "ninja-debug"
+      ],
+      "displayName": "Debug build for Valgrind with tests and more optional components",
+      "cacheVariables": {}
+    },
+    {
       "name": "ninja-debug-valgrind-maximal",
       "inherits": [
-        "base-debug",
-        "features-maximal",
-        "features-valgrind"
+        "features-valgrind",
+        "ninja-debug-maximal"
       ],
-      "displayName": "Debug build for Valgrind with everything enabled",
+      "displayName": "Debug build for Valgrind with tests and everything enabled",
       "cacheVariables": {}
+    },
+    {
+      "name": "ninja-debug-asan",
+      "inherits": [
+        "_allocator-none",
+        "ninja-debug",
+        "sanitizer-asan"
+      ],
+      "displayName": "Debug build for ASAN with tests and more optional components",
+      "cacheVariables": {}
+    },
+    {
+      "name": "ninja-debug-tsan",
+      "inherits": [
+        "_allocator-none",
+        "ninja-debug",
+        "sanitizer-tsan"
+      ],
+      "displayName": "Debug build for TSAN with tests and more optional components",
+      "cacheVariables": {}
+    },
+    {
+      "name": "ninja-debug-ubsan",
+      "inherits": [
+        "_allocator-none",
+        "ninja-debug",
+        "sanitizer-ubsan"
+      ],
+      "displayName": "Debug build for UBSAN with tests and more optional components",
+      "cacheVariables": {}
+    },
+    {
+      "name": "fuzzing",
+      "inherits": [
+        "base",
+        "sanitizer-asan",
+        "sanitizer-ubsan"
+      ],
+      "displayName": "Debug build with IPC and Parquet fuzzing targets",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_C_COMPILER": "clang",
+        "CMAKE_CXX_COMPILER": "clang++",
+        "ARROW_IPC": "ON",
+        "ARROW_PARQUET": "ON",
+        "ARROW_FUZZING": "ON"
+      }
     },
     {
       "name": "ninja-release-minimal",
@@ -444,24 +506,6 @@
         "features-cuda"
       ],
       "displayName": "Release build with CUDA integration",
-      "cacheVariables": {}
-    },
-    {
-      "name": "ninja-debug-emscripten",
-      "inherits": [
-        "features-emscripten",
-        "base-debug"
-      ],
-      "displayName": "Debug build which builds an Emscripten library",
-      "cacheVariables": {}
-    },
-    {
-      "name": "ninja-release-emscripten",
-      "inherits": [
-        "features-emscripten",
-        "base-release"
-      ],
-      "displayName": "Release build which builds an Emscripten library",
       "cacheVariables": {}
     },
     {
@@ -528,6 +572,15 @@
       "cacheVariables": {}
     },
     {
+      "name": "ninja-release-emscripten",
+      "inherits": [
+        "features-emscripten",
+        "base-release"
+      ],
+      "displayName": "Release build which builds an Emscripten library",
+      "cacheVariables": {}
+    },
+    {
       "name": "ninja-benchmarks-basic",
       "inherits": [
         "base-benchmarks",
@@ -553,50 +606,6 @@
       ],
       "displayName": "Benchmarking build with everything enabled",
       "cacheVariables": {}
-    },
-    {
-      "name": "ninja-debug-asan",
-      "inherits": [
-        "sanitizer-asan",
-        "ninja-debug"
-      ],
-      "displayName": "Debug ASAN build with tests and more optional components",
-      "cacheVariables": {}
-    },
-    {
-      "name": "ninja-debug-tsan",
-      "inherits": [
-        "sanitizer-tsan",
-        "ninja-debug"
-      ],
-      "displayName": "Debug TSAN build with tests and more optional components",
-      "cacheVariables": {}
-    },
-    {
-      "name": "ninja-debug-ubsan",
-      "inherits": [
-        "sanitizer-ubsan",
-        "ninja-debug"
-      ],
-      "displayName": "Debug UBSAN build with tests and more optional components",
-      "cacheVariables": {}
-    },
-    {
-      "name": "fuzzing",
-      "inherits": [
-        "sanitizer-asan",
-        "sanitizer-ubsan",
-        "base"
-      ],
-      "displayName": "Debug build with IPC and Parquet fuzzing targets",
-      "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Debug",
-        "CMAKE_C_COMPILER": "clang",
-        "CMAKE_CXX_COMPILER": "clang++",
-        "ARROW_IPC": "ON",
-        "ARROW_PARQUET": "ON",
-        "ARROW_FUZZING": "ON"
-      }
     }
   ]
 }

--- a/cpp/CMakePresets.json
+++ b/cpp/CMakePresets.json
@@ -434,9 +434,9 @@
     {
       "name": "fuzzing",
       "inherits": [
-        "base",
         "sanitizer-asan",
-        "sanitizer-ubsan"
+        "sanitizer-ubsan",
+        "base"
       ],
       "displayName": "Debug build with IPC and Parquet fuzzing targets",
       "cacheVariables": {

--- a/cpp/CMakePresets.json
+++ b/cpp/CMakePresets.json
@@ -72,24 +72,28 @@
     },
     {
       "name": "features-minimal",
+      "inherits": [
+        "_allocator-none"
+      ],
       "hidden": true,
       "cacheVariables": {
-        "ARROW_MIMALLOC": "OFF",
         "ARROW_WITH_RE2": "OFF",
         "ARROW_WITH_UTF8PROC": "OFF"
       }
     },
     {
       "name": "features-basic",
-      "inherits": "features-minimal",
+      "inherits": [
+        "_allocator-mimalloc",
+        "features-minimal"
+      ],
       "hidden": true,
       "cacheVariables": {
         "ARROW_COMPUTE": "ON",
         "ARROW_CSV": "ON",
         "ARROW_DATASET": "ON",
         "ARROW_FILESYSTEM": "ON",
-        "ARROW_JSON": "ON",
-        "ARROW_MIMALLOC": "ON"
+        "ARROW_JSON": "ON"
       }
     },
     {
@@ -208,6 +212,9 @@
     },
     {
       "name": "features-emscripten",
+      "inherits": [
+        "_allocator-none"
+      ],
       "hidden": true,
       "cacheVariables": {
         "ARROW_ACERO": "ON",
@@ -220,9 +227,7 @@
         "ARROW_ENABLE_THREADING": "OFF",
         "ARROW_FLIGHT": "OFF",
         "ARROW_IPC": "ON",
-        "ARROW_JEMALLOC": "OFF",
         "ARROW_JSON": "ON",
-        "ARROW_MIMALLOC": "OFF",
         "ARROW_ORC": "ON",
         "ARROW_RUNTIME_SIMD_LEVEL": "NONE",
         "ARROW_S3": "OFF",
@@ -244,29 +249,32 @@
     },
     {
       "name": "sanitizer-asan",
+      "inherits": [
+        "_allocator-none"
+      ],
       "hidden": true,
       "cacheVariables": {
-        "ARROW_USE_ASAN": "ON",
-        "ARROW_JEMALLOC": "OFF",
-        "ARROW_MIMALLOC": "OFF"
+        "ARROW_USE_ASAN": "ON"
       }
     },
     {
       "name": "sanitizer-tsan",
+      "inherits": [
+        "_allocator-none"
+      ],
       "hidden": true,
       "cacheVariables": {
-        "ARROW_USE_TSAN": "ON",
-        "ARROW_JEMALLOC": "OFF",
-        "ARROW_MIMALLOC": "OFF"
+        "ARROW_USE_TSAN": "ON"
       }
     },
     {
       "name": "sanitizer-ubsan",
+      "inherits": [
+        "_allocator-none"
+      ],
       "hidden": true,
       "cacheVariables": {
-        "ARROW_USE_UBSAN": "ON",
-        "ARROW_JEMALLOC": "OFF",
-        "ARROW_MIMALLOC": "OFF"
+        "ARROW_USE_UBSAN": "ON"
       }
     },
     {

--- a/cpp/CMakePresets.json
+++ b/cpp/CMakePresets.json
@@ -557,8 +557,8 @@
     {
       "name": "ninja-debug-asan",
       "inherits": [
-        "ninja-debug",
-        "sanitizer-asan"
+        "sanitizer-asan",
+        "ninja-debug"
       ],
       "displayName": "Debug ASAN build with tests and more optional components",
       "cacheVariables": {}
@@ -566,8 +566,8 @@
     {
       "name": "ninja-debug-tsan",
       "inherits": [
-        "ninja-debug",
-        "sanitizer-tsan"
+        "sanitizer-tsan",
+        "ninja-debug"
       ],
       "displayName": "Debug TSAN build with tests and more optional components",
       "cacheVariables": {}
@@ -575,8 +575,8 @@
     {
       "name": "ninja-debug-ubsan",
       "inherits": [
-        "ninja-debug",
-        "sanitizer-ubsan"
+        "sanitizer-ubsan",
+        "ninja-debug"
       ],
       "displayName": "Debug UBSAN build with tests and more optional components",
       "cacheVariables": {}
@@ -584,9 +584,9 @@
     {
       "name": "fuzzing",
       "inherits": [
-        "base",
         "sanitizer-asan",
-        "sanitizer-ubsan"
+        "sanitizer-ubsan",
+        "base"
       ],
       "displayName": "Debug build with IPC and Parquet fuzzing targets",
       "cacheVariables": {


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

I gave the reason in #45209

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

Adjust the inheritance list order and make a lot of simplification/regrouping/reordering for existing presets the way I see fit.

Also introduce a soft rule to order inheritance list: `sanitizer` comes before `features` comes before `base`. Though we can't really mandate such a rule (thus it's "soft") or make it clear in comments (our current cmake dosn't support comment in json), we hope people will notice this pattern and follow it when editing this file.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

Manually tested.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

None.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #45209