### PR TITLE
GH-45212: [C++][Parquet] Fix uninitialized size_statistics_level property

### DIFF
--- a/cpp/src/parquet/properties.h
+++ b/cpp/src/parquet/properties.h
@@ -271,6 +271,7 @@ class PARQUET_EXPORT WriterProperties {
           created_by_(properties.created_by()),
           store_decimal_as_integer_(properties.store_decimal_as_integer()),
           page_checksum_enabled_(properties.page_checksum_enabled()),
+          size_statistics_level_(properties.size_statistics_level()),
           sorting_columns_(properties.sorting_columns()),
           default_column_properties_(properties.default_column_properties()) {}
 


### PR DESCRIPTION
### Rationale for this change

The PR to introduce SizeStatistics has spanned several months, during which time WriterProperties::Builder(const WriterProperties& properties) was added.

### What changes are included in this PR?

This PR fixes WriterProperties::Builder(const WriterProperties& properties) function to initialize size_statistics_level_.

### Are these changes tested?

Pass CIs.

### Are there any user-facing changes?

No.
* GitHub Issue: #45212