### PR TITLE
GH-45216: [C++][Compute] Refactor Rank implementation

### DIFF
--- a/cpp/src/arrow/compute/kernels/vector_sort.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort.cc
@@ -121,7 +121,7 @@ class ChunkedArraySorter : public TypeVisitor {
                              CompressedChunkLocation* nulls_middle,
                              CompressedChunkLocation* nulls_end,
                              CompressedChunkLocation* temp_indices, int64_t null_count) {
-        if (has_null_like_values<typename ArrayType::TypeClass>::value) {
+        if (has_null_like_values<typename ArrayType::TypeClass>()) {
           PartitionNullsOnly<StablePartitioner>(nulls_begin, nulls_end, arrays,
                                                 null_count, null_placement_);
         }
@@ -781,7 +781,7 @@ class TableSorter {
                   CompressedChunkLocation* nulls_middle,
                   CompressedChunkLocation* nulls_end,
                   CompressedChunkLocation* temp_indices, int64_t null_count) {
-    if constexpr (has_null_like_values<ArrowType>::value) {
+    if constexpr (has_null_like_values<ArrowType>()) {
       // Merge rows with a null or a null-like in the first sort key
       auto& comparator = comparator_;
       const auto& first_sort_key = sort_keys_[0];

--- a/cpp/src/arrow/type_traits.h
+++ b/cpp/src/arrow/type_traits.h
@@ -1069,6 +1069,13 @@ constexpr bool is_floating(Type::type type_id) {
   return false;
 }
 
+/// \brief Check for a physical floating point type
+///
+/// This predicate matches floating-point types, except half-float.
+constexpr bool is_physical_floating(Type::type type_id) {
+  return is_floating(type_id) && type_id != Type::HALF_FLOAT;
+}
+
 /// \brief Check for a numeric type
 ///
 /// This predicate doesn't match decimals (see `is_decimal`).


### PR DESCRIPTION
### Rationale for this change

The Rank implementation currently mixes ties/duplicates detection and rank computation in a single function `CreateRankings`. This makes it poorly reusable for other Rank-like functions such as the Percentile Rank function proposed in GH-45190.

### What changes are included in this PR?

Split duplicates detection into a dedicated function that sets a marker bit in the sort-indices array (it is private to the Rank implementation, so it is safe to mutate it).

The rank computation itself (`CreateRankings`) becomes simpler and, moreover, it does not need to read the input values: it becomes therefore type-agnostic.

This yields a code size reduction (around 45kB saved on the author's machine):
* before:
```console
$ size /build/build-release/relwithdebinfo/libarrow.so
   text	   data	    bss	    dec	    hex	filename
26072218	 353832	2567985	28994035	1ba69f3	/build/build-release/relwithdebinfo/libarrow.so
```
* after:
```console
$ size /build/build-release/relwithdebinfo/libarrow.so
   text	   data	    bss	    dec	    hex	filename
26028198	 353832	2567985	28950015	1b9bdff	/build/build-release/relwithdebinfo/libarrow.so
```

Rank benchmark results are mostly neutral, though there are slight improvements on some benchmarks, and slight regressions especially on all-nulls input.

### Are these changes tested?

Yes, by existing tests.

### Are there any user-facing changes?

No.
* GitHub Issue: #45216