### PR TITLE
GH-45230: [Docs] Add LinkedIn social link and fix top nav scaling problems

### DIFF
--- a/docs/source/_static/theme_overrides.css
+++ b/docs/source/_static/theme_overrides.css
@@ -25,11 +25,25 @@
   --pst-font-weight-heading: 600;
 }
 
-/* Change header hight to make the logo a bit larger */
+/* Change header height to make the logo a bit larger */
 /* only on wider screens */
 @media only screen and (min-width: 1170px){
   :root {
     --pst-header-height: 6rem;
+  }
+}
+
+/* Adjust layout on narrower screens */
+@media only screen and (max-width: 1170px){
+  /* Condense link text in nav to preserve layout */
+  .navbar-header-items__center .nav-item {
+    font-stretch: ultra-condensed;
+  }
+  /* Reduce horizontal space between icons in nav and sidebar */
+  div.sidebar-header-items__end,
+  div.navbar-header-items__end,
+  ul.navbar-icon-links {
+    column-gap: 0.75rem;
   }
 }
 

--- a/docs/source/_static/theme_overrides.css
+++ b/docs/source/_static/theme_overrides.css
@@ -109,3 +109,9 @@ dl.cpp.enumerator {
 p.breathe-sectiondef-title {
   margin-top: 1rem;
 }
+
+/* Keep social icons arranged horizontally in sidebar */
+
+.sidebar-header-items__end {
+  flex-wrap: wrap;
+}

--- a/docs/source/_static/theme_overrides.css
+++ b/docs/source/_static/theme_overrides.css
@@ -28,7 +28,7 @@
 /* Change header height to make the logo a bit larger */
 /* only on wider screens */
 
-@media only screen and (min-width: 1180px){
+@media only screen and (min-width: 1200px){
   :root {
     --pst-header-height: 6rem;
   }
@@ -36,15 +36,24 @@
 
 /* Adjust layout of nav to fit narrower screens */
 
-@media only screen and (max-width: 1179px){
+@media only screen and (max-width: 1199px){
+
   /* Condense link text in nav to preserve layout */
   .navbar-header-items__center .nav-item:not(.dropdown-item) {
     font-stretch: condensed;
   }
+
   /* Shrink search button */
   .search-button__default-text,
   .search-button__kbd-shortcut {
     display:none !important;
+  }
+
+  /* Reduce horizontal space between icons in nav and sidebar */
+  div.sidebar-header-items__end,
+  div.navbar-header-items__end,
+  ul.navbar-icon-links {
+    column-gap: 0.75rem !important;
   }
 }
 
@@ -98,12 +107,4 @@ dl.cpp.enumerator {
 
 p.breathe-sectiondef-title {
   margin-top: 1rem;
-}
-
-/* Reduce horizontal space between icons in nav and sidebar */
-
-div.sidebar-header-items__end,
-div.navbar-header-items__end,
-ul.navbar-icon-links {
-  column-gap: 0.75rem !important;
 }

--- a/docs/source/_static/theme_overrides.css
+++ b/docs/source/_static/theme_overrides.css
@@ -27,23 +27,24 @@
 
 /* Change header height to make the logo a bit larger */
 /* only on wider screens */
-@media only screen and (min-width: 1170px){
+
+@media only screen and (min-width: 1180px){
   :root {
     --pst-header-height: 6rem;
   }
 }
 
-/* Adjust layout on narrower screens */
-@media only screen and (max-width: 1170px){
+/* Adjust layout of nav to fit narrower screens */
+
+@media only screen and (max-width: 1179px){
   /* Condense link text in nav to preserve layout */
-  .navbar-header-items__center .nav-item {
-    font-stretch: ultra-condensed;
+  .navbar-header-items__center .nav-item:not(.dropdown-item) {
+    font-stretch: condensed;
   }
-  /* Reduce horizontal space between icons in nav and sidebar */
-  div.sidebar-header-items__end,
-  div.navbar-header-items__end,
-  ul.navbar-icon-links {
-    column-gap: 0.75rem;
+  /* Shrink search button */
+  .search-button__default-text,
+  .search-button__kbd-shortcut {
+    display:none !important;
   }
 }
 
@@ -97,4 +98,12 @@ dl.cpp.enumerator {
 
 p.breathe-sectiondef-title {
   margin-top: 1rem;
+}
+
+/* Reduce horizontal space between icons in nav and sidebar */
+
+div.sidebar-header-items__end,
+div.navbar-header-items__end,
+ul.navbar-icon-links {
+  column-gap: 0.75rem !important;
 }

--- a/docs/source/_static/theme_overrides.css
+++ b/docs/source/_static/theme_overrides.css
@@ -28,7 +28,7 @@
 /* Change header height to make the logo a bit larger */
 /* only on wider screens */
 
-@media only screen and (min-width: 1200px){
+@media only screen and (min-width: 1200px) {
   :root {
     --pst-header-height: 6rem;
   }
@@ -36,7 +36,7 @@
 
 /* Adjust layout of nav to fit narrower screens */
 
-@media only screen and (max-width: 1199px){
+@media only screen and (max-width: 1199px) {
 
   /* Condense link text in nav to preserve layout */
   .navbar-header-items__center a.nav-link:not(.dropdown-item),

--- a/docs/source/_static/theme_overrides.css
+++ b/docs/source/_static/theme_overrides.css
@@ -41,7 +41,7 @@
   /* Condense link text in nav to preserve layout */
   .navbar-header-items__center a.nav-link:not(.dropdown-item),
   .navbar-header-items__center button.nav-item {
-    font-stretch: condensed;
+    letter-spacing: -0.02em;
   }
 
   /* Shrink search button */

--- a/docs/source/_static/theme_overrides.css
+++ b/docs/source/_static/theme_overrides.css
@@ -39,7 +39,8 @@
 @media only screen and (max-width: 1199px){
 
   /* Condense link text in nav to preserve layout */
-  .navbar-header-items__center .nav-item:not(.dropdown-item) {
+  .navbar-header-items__center a.nav-link:not(.dropdown-item),
+  .navbar-header-items__center button.nav-item {
     font-stretch: condensed;
   }
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -342,6 +342,7 @@ html_theme_options = {
     },
     "header_links_before_dropdown": 2,
     "header_dropdown_text": "Implementations",
+    "navbar_align": "left",
     "navbar_end": ["version-switcher", "theme-switcher", "navbar-icon-links"],
     "icon_links": [
         {

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -350,6 +350,11 @@ html_theme_options = {
             "icon": "fa-brands fa-square-github",
         },
         {
+            "name": "LinkedIn",
+            "url": "https://www.linkedin.com/company/apache-arrow/",
+            "icon": "fa-brands fa-linkedin",
+        },
+        {
             "name": "X",
             "url": "https://twitter.com/ApacheArrow",
             "icon": "fa-brands fa-square-x-twitter",


### PR DESCRIPTION
This adds a LinkedIn icon social link to the main docs pages. This follows the [creation of a Linkedin page for the project](https://lists.apache.org/thread/p77fzly89vp4yb14fdcqtp3o5qp3y7lw) in mid-2024, the active use of that page since then, and the [addition of a LinkedIn follow button to the website homepage](https://github.com/apache/arrow-site/pull/570) earlier this month.

This also fixes the layout of the top nav, which previously looked bad at widths between 960px and 1200px.

* GitHub Issue: #45230