### PR TITLE
GH-41002: [Python] Remove pins for pytest-cython and conda-docs pytest

### DIFF
--- a/ci/conda_env_sphinx.txt
+++ b/ci/conda_env_sphinx.txt
@@ -30,9 +30,5 @@ sphinx-lint
 sphinxcontrib-jquery
 sphinxcontrib-mermaid
 sphinx==6.2
-# Requirement for doctest-cython
-# Needs upper pin of 0.3.0, see:
-# https://github.com/lgpage/pytest-cython/issues/67
-# With 0.3.* bug fix release, the pin can be removed
-pytest-cython==0.2.2
+pytest-cython
 pandas

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1429,15 +1429,10 @@ services:
       BUILD_DOCS_PYTHON: "ON"
       PYTEST_ARGS: "--doctest-modules --doctest-cython"
     volumes: *conda-volumes
-    # pytest is installed with an upper pin of 8.0.0 because
-    # newer version breaks cython doctesting, see:
-    # https://github.com/lgpage/pytest-cython/issues/58
-    # Remove pip install pytest~=7 when upstream issue is resolved
     command:
       ["/arrow/ci/scripts/cpp_build.sh /arrow /build &&
         /arrow/ci/scripts/python_build.sh /arrow /build &&
         pip install -e /arrow/dev/archery[numpydoc] &&
-        pip install pytest~=7.4 &&
         archery numpydoc --allow-rule GL10,PR01,PR03,PR04,PR05,PR10,RT03,YD01 &&
         /arrow/ci/scripts/python_test.sh /arrow"]
 


### PR DESCRIPTION
### Rationale for this change

pytest-cython 0.3.1 was releases with the fix required for our tests to pass.

### What changes are included in this PR?

Remove unnecessary dependency pinned versions.

### Are these changes tested?

Via existing CI

### Are there any user-facing changes?

No
* GitHub Issue: #45239
* GitHub Issue: #41002