### PR TITLE
MINOR: [Dev] Remove current committer from collaborators list

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -23,7 +23,6 @@ github:
     - benibus
     - jbonofre
     - js8544
-    - laurentgo
     - vibhatha
     - ZhangHuiGui
 


### PR DESCRIPTION
### Rationale for this change

Laurent Goujon became a committer on November. No requirement to be specified as collaborator anymore. Announcement here: https://lists.apache.org/thread/jj7z0hvjbr6y2m4xjwv78s9ptvbhsc78

### What changes are included in this PR?

Remove laurentgo from list of collaborators as is a committer now.

### Are these changes tested?

No

### Are there any user-facing changes?
No