### PR TITLE
GH-45190: [C++][Compute] Add rank_quantile function

### DIFF
--- a/cpp/src/arrow/compute/api_vector.cc
+++ b/cpp/src/arrow/compute/api_vector.cc
@@ -48,6 +48,7 @@ using compute::DictionaryEncodeOptions;
 using compute::FilterOptions;
 using compute::NullPlacement;
 using compute::RankOptions;
+using compute::RankPercentileOptions;
 
 template <>
 struct EnumTraits<FilterOptions::NullSelectionBehavior>
@@ -151,6 +152,10 @@ static auto kRankOptionsType = GetFunctionOptionsType<RankOptions>(
     DataMember("sort_keys", &RankOptions::sort_keys),
     DataMember("null_placement", &RankOptions::null_placement),
     DataMember("tiebreaker", &RankOptions::tiebreaker));
+static auto kRankPercentileOptionsType = GetFunctionOptionsType<RankPercentileOptions>(
+    DataMember("sort_keys", &RankPercentileOptions::sort_keys),
+    DataMember("null_placement", &RankPercentileOptions::null_placement),
+    DataMember("factor", &RankPercentileOptions::factor));
 static auto kPairwiseOptionsType = GetFunctionOptionsType<PairwiseOptions>(
     DataMember("periods", &PairwiseOptions::periods));
 static auto kListFlattenOptionsType = GetFunctionOptionsType<ListFlattenOptions>(
@@ -227,6 +232,14 @@ RankOptions::RankOptions(std::vector<SortKey> sort_keys, NullPlacement null_plac
       null_placement(null_placement),
       tiebreaker(tiebreaker) {}
 constexpr char RankOptions::kTypeName[];
+
+RankPercentileOptions::RankPercentileOptions(std::vector<SortKey> sort_keys,
+                                             NullPlacement null_placement, double factor)
+    : FunctionOptions(internal::kRankPercentileOptionsType),
+      sort_keys(std::move(sort_keys)),
+      null_placement(null_placement),
+      factor(factor) {}
+constexpr char RankPercentileOptions::kTypeName[];
 
 PairwiseOptions::PairwiseOptions(int64_t periods)
     : FunctionOptions(internal::kPairwiseOptionsType), periods(periods) {}

--- a/cpp/src/arrow/compute/api_vector.cc
+++ b/cpp/src/arrow/compute/api_vector.cc
@@ -48,7 +48,7 @@ using compute::DictionaryEncodeOptions;
 using compute::FilterOptions;
 using compute::NullPlacement;
 using compute::RankOptions;
-using compute::RankPercentileOptions;
+using compute::RankQuantileOptions;
 
 template <>
 struct EnumTraits<FilterOptions::NullSelectionBehavior>
@@ -152,10 +152,10 @@ static auto kRankOptionsType = GetFunctionOptionsType<RankOptions>(
     DataMember("sort_keys", &RankOptions::sort_keys),
     DataMember("null_placement", &RankOptions::null_placement),
     DataMember("tiebreaker", &RankOptions::tiebreaker));
-static auto kRankPercentileOptionsType = GetFunctionOptionsType<RankPercentileOptions>(
-    DataMember("sort_keys", &RankPercentileOptions::sort_keys),
-    DataMember("null_placement", &RankPercentileOptions::null_placement),
-    DataMember("factor", &RankPercentileOptions::factor));
+static auto kRankQuantileOptionsType = GetFunctionOptionsType<RankQuantileOptions>(
+    DataMember("sort_keys", &RankQuantileOptions::sort_keys),
+    DataMember("null_placement", &RankQuantileOptions::null_placement),
+    DataMember("factor", &RankQuantileOptions::factor));
 static auto kPairwiseOptionsType = GetFunctionOptionsType<PairwiseOptions>(
     DataMember("periods", &PairwiseOptions::periods));
 static auto kListFlattenOptionsType = GetFunctionOptionsType<ListFlattenOptions>(
@@ -233,13 +233,13 @@ RankOptions::RankOptions(std::vector<SortKey> sort_keys, NullPlacement null_plac
       tiebreaker(tiebreaker) {}
 constexpr char RankOptions::kTypeName[];
 
-RankPercentileOptions::RankPercentileOptions(std::vector<SortKey> sort_keys,
-                                             NullPlacement null_placement, double factor)
-    : FunctionOptions(internal::kRankPercentileOptionsType),
+RankQuantileOptions::RankQuantileOptions(std::vector<SortKey> sort_keys,
+                                         NullPlacement null_placement, double factor)
+    : FunctionOptions(internal::kRankQuantileOptionsType),
       sort_keys(std::move(sort_keys)),
       null_placement(null_placement),
       factor(factor) {}
-constexpr char RankPercentileOptions::kTypeName[];
+constexpr char RankQuantileOptions::kTypeName[];
 
 PairwiseOptions::PairwiseOptions(int64_t periods)
     : FunctionOptions(internal::kPairwiseOptionsType), periods(periods) {}

--- a/cpp/src/arrow/compute/api_vector.cc
+++ b/cpp/src/arrow/compute/api_vector.cc
@@ -154,8 +154,7 @@ static auto kRankOptionsType = GetFunctionOptionsType<RankOptions>(
     DataMember("tiebreaker", &RankOptions::tiebreaker));
 static auto kRankQuantileOptionsType = GetFunctionOptionsType<RankQuantileOptions>(
     DataMember("sort_keys", &RankQuantileOptions::sort_keys),
-    DataMember("null_placement", &RankQuantileOptions::null_placement),
-    DataMember("factor", &RankQuantileOptions::factor));
+    DataMember("null_placement", &RankQuantileOptions::null_placement));
 static auto kPairwiseOptionsType = GetFunctionOptionsType<PairwiseOptions>(
     DataMember("periods", &PairwiseOptions::periods));
 static auto kListFlattenOptionsType = GetFunctionOptionsType<ListFlattenOptions>(
@@ -234,11 +233,10 @@ RankOptions::RankOptions(std::vector<SortKey> sort_keys, NullPlacement null_plac
 constexpr char RankOptions::kTypeName[];
 
 RankQuantileOptions::RankQuantileOptions(std::vector<SortKey> sort_keys,
-                                         NullPlacement null_placement, double factor)
+                                         NullPlacement null_placement)
     : FunctionOptions(internal::kRankQuantileOptionsType),
       sort_keys(std::move(sort_keys)),
-      null_placement(null_placement),
-      factor(factor) {}
+      null_placement(null_placement) {}
 constexpr char RankQuantileOptions::kTypeName[];
 
 PairwiseOptions::PairwiseOptions(int64_t periods)

--- a/cpp/src/arrow/compute/api_vector.h
+++ b/cpp/src/arrow/compute/api_vector.h
@@ -195,6 +195,30 @@ class ARROW_EXPORT RankOptions : public FunctionOptions {
   Tiebreaker tiebreaker;
 };
 
+/// \brief Percentile rank options
+class ARROW_EXPORT RankPercentileOptions : public FunctionOptions {
+ public:
+  explicit RankPercentileOptions(std::vector<SortKey> sort_keys = {},
+                                 NullPlacement null_placement = NullPlacement::AtEnd,
+                                 double factor = 1.0);
+  /// Convenience constructor for array inputs
+  explicit RankPercentileOptions(SortOrder order,
+                                 NullPlacement null_placement = NullPlacement::AtEnd,
+                                 double factor = 1.0)
+      : RankPercentileOptions({SortKey("", order)}, null_placement, factor) {}
+
+  static constexpr char const kTypeName[] = "RankPercentileOptions";
+  static RankPercentileOptions Defaults() { return RankPercentileOptions(); }
+
+  /// Column key(s) to order by and how to order by these sort keys.
+  std::vector<SortKey> sort_keys;
+  /// Whether nulls and NaNs are placed at the start or at the end
+  NullPlacement null_placement;
+  /// Factor to apply to the output.
+  /// Use 1.0 for results in (0, 1), 100.0 for percentages, etc.
+  double factor;
+};
+
 /// \brief Partitioning options for NthToIndices
 class ARROW_EXPORT PartitionNthOptions : public FunctionOptions {
  public:

--- a/cpp/src/arrow/compute/api_vector.h
+++ b/cpp/src/arrow/compute/api_vector.h
@@ -199,13 +199,11 @@ class ARROW_EXPORT RankOptions : public FunctionOptions {
 class ARROW_EXPORT RankQuantileOptions : public FunctionOptions {
  public:
   explicit RankQuantileOptions(std::vector<SortKey> sort_keys = {},
-                               NullPlacement null_placement = NullPlacement::AtEnd,
-                               double factor = 1.0);
+                               NullPlacement null_placement = NullPlacement::AtEnd);
   /// Convenience constructor for array inputs
   explicit RankQuantileOptions(SortOrder order,
-                               NullPlacement null_placement = NullPlacement::AtEnd,
-                               double factor = 1.0)
-      : RankQuantileOptions({SortKey("", order)}, null_placement, factor) {}
+                               NullPlacement null_placement = NullPlacement::AtEnd)
+      : RankQuantileOptions({SortKey("", order)}, null_placement) {}
 
   static constexpr char const kTypeName[] = "RankQuantileOptions";
   static RankQuantileOptions Defaults() { return RankQuantileOptions(); }
@@ -214,9 +212,6 @@ class ARROW_EXPORT RankQuantileOptions : public FunctionOptions {
   std::vector<SortKey> sort_keys;
   /// Whether nulls and NaNs are placed at the start or at the end
   NullPlacement null_placement;
-  /// Factor to apply to the output.
-  /// Use 1.0 for results in (0, 1), 100.0 for percentages, etc.
-  double factor;
 };
 
 /// \brief Partitioning options for NthToIndices

--- a/cpp/src/arrow/compute/api_vector.h
+++ b/cpp/src/arrow/compute/api_vector.h
@@ -195,20 +195,20 @@ class ARROW_EXPORT RankOptions : public FunctionOptions {
   Tiebreaker tiebreaker;
 };
 
-/// \brief Percentile rank options
-class ARROW_EXPORT RankPercentileOptions : public FunctionOptions {
+/// \brief Quantile rank options
+class ARROW_EXPORT RankQuantileOptions : public FunctionOptions {
  public:
-  explicit RankPercentileOptions(std::vector<SortKey> sort_keys = {},
-                                 NullPlacement null_placement = NullPlacement::AtEnd,
-                                 double factor = 1.0);
+  explicit RankQuantileOptions(std::vector<SortKey> sort_keys = {},
+                               NullPlacement null_placement = NullPlacement::AtEnd,
+                               double factor = 1.0);
   /// Convenience constructor for array inputs
-  explicit RankPercentileOptions(SortOrder order,
-                                 NullPlacement null_placement = NullPlacement::AtEnd,
-                                 double factor = 1.0)
-      : RankPercentileOptions({SortKey("", order)}, null_placement, factor) {}
+  explicit RankQuantileOptions(SortOrder order,
+                               NullPlacement null_placement = NullPlacement::AtEnd,
+                               double factor = 1.0)
+      : RankQuantileOptions({SortKey("", order)}, null_placement, factor) {}
 
-  static constexpr char const kTypeName[] = "RankPercentileOptions";
-  static RankPercentileOptions Defaults() { return RankPercentileOptions(); }
+  static constexpr char const kTypeName[] = "RankQuantileOptions";
+  static RankQuantileOptions Defaults() { return RankQuantileOptions(); }
 
   /// Column key(s) to order by and how to order by these sort keys.
   std::vector<SortKey> sort_keys;

--- a/cpp/src/arrow/compute/kernels/vector_rank.cc
+++ b/cpp/src/arrow/compute/kernels/vector_rank.cc
@@ -15,9 +15,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <functional>
+#include <memory>
+
 #include "arrow/compute/function.h"
 #include "arrow/compute/kernels/vector_sort_internal.h"
 #include "arrow/compute/registry.h"
+#include "arrow/util/logging.h"
 
 namespace arrow::compute::internal {
 
@@ -31,10 +35,6 @@ namespace {
 // A bit that is set in the sort indices when the value at the current sort index
 // is the same as the value at the previous sort index.
 constexpr uint64_t kDuplicateMask = 1ULL << 63;
-
-constexpr bool NeedsDuplicates(RankOptions::Tiebreaker tiebreaker) {
-  return tiebreaker != RankOptions::First;
-}
 
 template <typename ValueSelector>
 void MarkDuplicates(const NullPartitionResult& sorted, ValueSelector&& value_selector) {
@@ -63,72 +63,137 @@ void MarkDuplicates(const NullPartitionResult& sorted, ValueSelector&& value_sel
   }
 }
 
-Result<Datum> CreateRankings(ExecContext* ctx, const NullPartitionResult& sorted,
-                             const NullPlacement null_placement,
-                             const RankOptions::Tiebreaker tiebreaker) {
-  auto length = sorted.overall_end() - sorted.overall_begin();
-  ARROW_ASSIGN_OR_RAISE(auto rankings,
-                        MakeMutableUInt64Array(length, ctx->memory_pool()));
-  auto out_begin = rankings->GetMutableValues<uint64_t>(1);
-  uint64_t rank;
+struct RankingsEmitter {
+  virtual ~RankingsEmitter() = default;
+  virtual bool NeedsDuplicates() = 0;
+  virtual Result<Datum> CreateRankings(ExecContext* ctx,
+                                       const NullPartitionResult& sorted) = 0;
+};
 
-  auto is_duplicate = [](uint64_t index) { return (index & kDuplicateMask) != 0; };
-  auto original_index = [](uint64_t index) { return index & ~kDuplicateMask; };
+// A helper class that emits rankings for the "rank_percentile" function
+struct PercentileRankingsEmitter : public RankingsEmitter {
+  explicit PercentileRankingsEmitter(double factor) : factor_(factor) {}
 
-  switch (tiebreaker) {
-    case RankOptions::Dense: {
-      rank = 0;
-      for (auto it = sorted.overall_begin(); it < sorted.overall_end(); ++it) {
-        if (!is_duplicate(*it)) {
-          ++rank;
-        }
-        out_begin[original_index(*it)] = rank;
+  bool NeedsDuplicates() override { return true; }
+
+  Result<Datum> CreateRankings(ExecContext* ctx,
+                               const NullPartitionResult& sorted) override {
+    const int64_t length = sorted.overall_end() - sorted.overall_begin();
+    ARROW_ASSIGN_OR_RAISE(auto rankings,
+                          MakeMutableFloat64Array(length, ctx->memory_pool()));
+    auto out_begin = rankings->GetMutableValues<double>(1);
+
+    auto is_duplicate = [](uint64_t index) { return (index & kDuplicateMask) != 0; };
+    auto original_index = [](uint64_t index) { return index & ~kDuplicateMask; };
+
+    // The count of values strictly less than the value being considered
+    int64_t cum_freq = 0;
+    auto it = sorted.overall_begin();
+
+    while (it < sorted.overall_end()) {
+      // Look for a run of duplicate values
+      DCHECK(!is_duplicate(*it));
+      auto run_end = it;
+      while (++run_end < sorted.overall_end() && is_duplicate(*run_end)) {
       }
-      break;
-    }
-
-    case RankOptions::First: {
-      rank = 0;
-      for (auto it = sorted.overall_begin(); it < sorted.overall_end(); it++) {
-        // No duplicate marks expected for RankOptions::First
-        DCHECK(!is_duplicate(*it));
-        out_begin[*it] = ++rank;
+      // The run length, i.e. the frequency of the current value
+      int64_t freq = run_end - it;
+      double percentile = (cum_freq + 0.5 * freq) * factor_ / static_cast<double>(length);
+      // Output percentile rank values
+      for (; it < run_end; ++it) {
+        out_begin[original_index(*it)] = percentile;
       }
-      break;
+      cum_freq += freq;
     }
-
-    case RankOptions::Min: {
-      rank = 0;
-      for (auto it = sorted.overall_begin(); it < sorted.overall_end(); ++it) {
-        if (!is_duplicate(*it)) {
-          rank = (it - sorted.overall_begin()) + 1;
-        }
-        out_begin[original_index(*it)] = rank;
-      }
-      break;
-    }
-
-    case RankOptions::Max: {
-      rank = length;
-      for (auto it = sorted.overall_end() - 1; it >= sorted.overall_begin(); --it) {
-        out_begin[original_index(*it)] = rank;
-        // If the current index isn't marked as duplicate, then it's the last
-        // tie in a row (since we iterate in reverse order), so update rank
-        // for the next row of ties.
-        if (!is_duplicate(*it)) {
-          rank = it - sorted.overall_begin();
-        }
-      }
-      break;
-    }
+    DCHECK_EQ(cum_freq, length);
+    return Datum(rankings);
   }
 
-  return Datum(rankings);
-}
+ private:
+  const double factor_;
+};
+
+// A helper class that emits rankings for the "rank" function
+struct OrdinalRankingsEmitter : public RankingsEmitter {
+  explicit OrdinalRankingsEmitter(RankOptions::Tiebreaker tiebreaker)
+      : tiebreaker_(tiebreaker) {}
+
+  bool NeedsDuplicates() override { return tiebreaker_ != RankOptions::First; }
+
+  Result<Datum> CreateRankings(ExecContext* ctx,
+                               const NullPartitionResult& sorted) override {
+    const int64_t length = sorted.overall_end() - sorted.overall_begin();
+    ARROW_ASSIGN_OR_RAISE(auto rankings,
+                          MakeMutableUInt64Array(length, ctx->memory_pool()));
+    auto out_begin = rankings->GetMutableValues<uint64_t>(1);
+    uint64_t rank;
+
+    auto is_duplicate = [](uint64_t index) { return (index & kDuplicateMask) != 0; };
+    auto original_index = [](uint64_t index) { return index & ~kDuplicateMask; };
+
+    switch (tiebreaker_) {
+      case RankOptions::Dense: {
+        rank = 0;
+        for (auto it = sorted.overall_begin(); it < sorted.overall_end(); ++it) {
+          if (!is_duplicate(*it)) {
+            ++rank;
+          }
+          out_begin[original_index(*it)] = rank;
+        }
+        break;
+      }
+
+      case RankOptions::First: {
+        rank = 0;
+        for (auto it = sorted.overall_begin(); it < sorted.overall_end(); it++) {
+          // No duplicate marks expected for RankOptions::First
+          DCHECK(!is_duplicate(*it));
+          out_begin[*it] = ++rank;
+        }
+        break;
+      }
+
+      case RankOptions::Min: {
+        rank = 0;
+        for (auto it = sorted.overall_begin(); it < sorted.overall_end(); ++it) {
+          if (!is_duplicate(*it)) {
+            rank = (it - sorted.overall_begin()) + 1;
+          }
+          out_begin[original_index(*it)] = rank;
+        }
+        break;
+      }
+
+      case RankOptions::Max: {
+        rank = length;
+        for (auto it = sorted.overall_end() - 1; it >= sorted.overall_begin(); --it) {
+          out_begin[original_index(*it)] = rank;
+          // If the current index isn't marked as duplicate, then it's the last
+          // tie in a row (since we iterate in reverse order), so update rank
+          // for the next row of ties.
+          if (!is_duplicate(*it)) {
+            rank = it - sorted.overall_begin();
+          }
+        }
+        break;
+      }
+    }
+
+    return Datum(rankings);
+  }
+
+ private:
+  const RankOptions::Tiebreaker tiebreaker_;
+};
 
 const RankOptions* GetDefaultRankOptions() {
   static const auto kDefaultRankOptions = RankOptions::Defaults();
   return &kDefaultRankOptions;
+}
+
+const RankPercentileOptions* GetDefaultPercentileRankOptions() {
+  static const auto kDefaultPercentileRankOptions = RankPercentileOptions::Defaults();
+  return &kDefaultPercentileRankOptions;
 }
 
 template <typename InputType, typename RankerType>
@@ -136,8 +201,7 @@ class RankerMixin : public TypeVisitor {
  public:
   RankerMixin(ExecContext* ctx, uint64_t* indices_begin, uint64_t* indices_end,
               const InputType& input, const SortOrder order,
-              const NullPlacement null_placement,
-              const RankOptions::Tiebreaker tiebreaker, Datum* output)
+              const NullPlacement null_placement, RankingsEmitter* emitter)
       : TypeVisitor(),
         ctx_(ctx),
         indices_begin_(indices_begin),
@@ -145,15 +209,17 @@ class RankerMixin : public TypeVisitor {
         input_(input),
         order_(order),
         null_placement_(null_placement),
-        tiebreaker_(tiebreaker),
         physical_type_(GetPhysicalType(input.type())),
-        output_(output) {}
+        emitter_(emitter) {}
 
-  Status Run() { return physical_type_->Accept(this); }
+  Result<Datum> Run() {
+    RETURN_NOT_OK(physical_type_->Accept(this));
+    return emitter_->CreateRankings(ctx_, sorted_);
+  }
 
-#define VISIT(TYPE)                                                       \
-  Status Visit(const TYPE& type) {                                        \
-    return static_cast<RankerType*>(this)->template RankInternal<TYPE>(); \
+#define VISIT(TYPE)                                                                \
+  Status Visit(const TYPE& type) {                                                 \
+    return static_cast<RankerType*>(this)->template SortAndMarkDuplicates<TYPE>(); \
   }
 
   VISIT_SORTABLE_PHYSICAL_TYPES(VISIT)
@@ -167,9 +233,9 @@ class RankerMixin : public TypeVisitor {
   const InputType& input_;
   const SortOrder order_;
   const NullPlacement null_placement_;
-  const RankOptions::Tiebreaker tiebreaker_;
   const std::shared_ptr<DataType> physical_type_;
-  Datum* output_;
+  RankingsEmitter* emitter_;
+  NullPartitionResult sorted_{};
 };
 
 template <typename T>
@@ -181,26 +247,23 @@ class Ranker<Array> : public RankerMixin<Array, Ranker<Array>> {
   using RankerMixin::RankerMixin;
 
   template <typename InType>
-  Status RankInternal() {
+  Status SortAndMarkDuplicates() {
     using GetView = GetViewType<InType>;
     using ArrayType = typename TypeTraits<InType>::ArrayType;
 
     ARROW_ASSIGN_OR_RAISE(auto array_sorter, GetArraySorter(*physical_type_));
 
     ArrayType array(input_.data());
-    ARROW_ASSIGN_OR_RAISE(NullPartitionResult sorted,
+    ARROW_ASSIGN_OR_RAISE(sorted_,
                           array_sorter(indices_begin_, indices_end_, array, 0,
                                        ArraySortOptions(order_, null_placement_), ctx_));
 
-    if (NeedsDuplicates(tiebreaker_)) {
+    if (emitter_->NeedsDuplicates()) {
       auto value_selector = [&array](int64_t index) {
         return GetView::LogicalValue(array.GetView(index));
       };
-      MarkDuplicates(sorted, value_selector);
+      MarkDuplicates(sorted_, value_selector);
     }
-    ARROW_ASSIGN_OR_RAISE(*output_,
-                          CreateRankings(ctx_, sorted, null_placement_, tiebreaker_));
-
     return Status::OK();
   }
 };
@@ -214,26 +277,21 @@ class Ranker<ChunkedArray> : public RankerMixin<ChunkedArray, Ranker<ChunkedArra
         physical_chunks_(GetPhysicalChunks(input_, physical_type_)) {}
 
   template <typename InType>
-  Status RankInternal() {
+  Status SortAndMarkDuplicates() {
     if (physical_chunks_.empty()) {
       return Status::OK();
     }
-
     ARROW_ASSIGN_OR_RAISE(
-        NullPartitionResult sorted,
-        SortChunkedArray(ctx_, indices_begin_, indices_end_, physical_type_,
-                         physical_chunks_, order_, null_placement_));
-
-    if (NeedsDuplicates(tiebreaker_)) {
+        sorted_, SortChunkedArray(ctx_, indices_begin_, indices_end_, physical_type_,
+                                  physical_chunks_, order_, null_placement_));
+    if (emitter_->NeedsDuplicates()) {
       const auto arrays = GetArrayPointers(physical_chunks_);
       auto value_selector = [resolver =
                                  ChunkedArrayResolver(span(arrays))](int64_t index) {
         return resolver.Resolve(index).Value<InType>();
       };
-      MarkDuplicates(sorted, value_selector);
+      MarkDuplicates(sorted_, value_selector);
     }
-    ARROW_ASSIGN_OR_RAISE(*output_,
-                          CreateRankings(ctx_, sorted, null_placement_, tiebreaker_));
     return Status::OK();
   }
 
@@ -242,7 +300,7 @@ class Ranker<ChunkedArray> : public RankerMixin<ChunkedArray, Ranker<ChunkedArra
 };
 
 const FunctionDoc rank_doc(
-    "Compute numerical ranks of an array (1-based)",
+    "Compute ordinal ranks of an array (1-based)",
     ("This function computes a rank of the input array.\n"
      "By default, null values are considered greater than any other value and\n"
      "are therefore sorted at the end of the input. For floating-point types,\n"
@@ -253,21 +311,32 @@ const FunctionDoc rank_doc(
      "The handling of nulls, NaNs and tiebreakers can be changed in RankOptions."),
     {"input"}, "RankOptions");
 
-class RankMetaFunction : public MetaFunction {
+const FunctionDoc rank_percentile_doc(
+    "Compute percentile ranks of an array",
+    ("This function computes a percentile rank of the input array.\n"
+     "By default, null values are considered greater than any other value and\n"
+     "are therefore sorted at the end of the input. For floating-point types,\n"
+     "NaNs are considered greater than any other non-null value, but smaller\n"
+     "than null values.\n"
+     "Results are computed as in https://en.wikipedia.org/wiki/Percentile_rank\n"
+     "\n"
+     "The handling of nulls and NaNs, and the constant factor can be changed\n"
+     "in RankPercentileOptions."),
+    {"input"}, "RankPercentileOptions");
+
+class RankMetaFunctionBase : public MetaFunction {
  public:
-  RankMetaFunction()
-      : MetaFunction("rank", Arity::Unary(), rank_doc, GetDefaultRankOptions()) {}
+  using MetaFunction::MetaFunction;
 
   Result<Datum> ExecuteImpl(const std::vector<Datum>& args,
                             const FunctionOptions* options,
                             ExecContext* ctx) const override {
-    const auto& rank_options = checked_cast<const RankOptions&>(*options);
     switch (args[0].kind()) {
       case Datum::ARRAY: {
-        return Rank(*args[0].make_array(), rank_options, ctx);
+        return Rank(*args[0].make_array(), *options, ctx);
       } break;
       case Datum::CHUNKED_ARRAY: {
-        return Rank(*args[0].chunked_array(), rank_options, ctx);
+        return Rank(*args[0].chunked_array(), *options, ctx);
       } break;
       default:
         break;
@@ -278,14 +347,19 @@ class RankMetaFunction : public MetaFunction {
         args[0].ToString());
   }
 
- private:
+ protected:
+  struct UnpackedOptions {
+    SortOrder order{SortOrder::Ascending};
+    NullPlacement null_placement;
+    std::unique_ptr<RankingsEmitter> emitter;
+  };
+
+  virtual UnpackedOptions UnpackOptions(const FunctionOptions&) const = 0;
+
   template <typename T>
-  static Result<Datum> Rank(const T& input, const RankOptions& options,
-                            ExecContext* ctx) {
-    SortOrder order = SortOrder::Ascending;
-    if (!options.sort_keys.empty()) {
-      order = options.sort_keys[0].order;
-    }
+  Result<Datum> Rank(const T& input, const FunctionOptions& function_options,
+                     ExecContext* ctx) const {
+    auto options = UnpackOptions(function_options);
 
     int64_t length = input.length();
     ARROW_ASSIGN_OR_RAISE(auto indices,
@@ -294,11 +368,45 @@ class RankMetaFunction : public MetaFunction {
     auto* indices_end = indices_begin + length;
     std::iota(indices_begin, indices_end, 0);
 
-    Datum output;
-    Ranker<T> ranker(ctx, indices_begin, indices_end, input, order,
-                     options.null_placement, options.tiebreaker, &output);
-    ARROW_RETURN_NOT_OK(ranker.Run());
-    return output;
+    Ranker<T> ranker(ctx, indices_begin, indices_end, input, options.order,
+                     options.null_placement, options.emitter.get());
+    return ranker.Run();
+  }
+};
+
+class RankMetaFunction : public RankMetaFunctionBase {
+ public:
+  RankMetaFunction()
+      : RankMetaFunctionBase("rank", Arity::Unary(), rank_doc, GetDefaultRankOptions()) {}
+
+ protected:
+  UnpackedOptions UnpackOptions(const FunctionOptions& function_options) const override {
+    const auto& options = checked_cast<const RankOptions&>(function_options);
+    UnpackedOptions unpacked{
+        SortOrder::Ascending, options.null_placement,
+        std::make_unique<OrdinalRankingsEmitter>(options.tiebreaker)};
+    if (!options.sort_keys.empty()) {
+      unpacked.order = options.sort_keys[0].order;
+    }
+    return unpacked;
+  }
+};
+
+class RankPercentileMetaFunction : public RankMetaFunctionBase {
+ public:
+  RankPercentileMetaFunction()
+      : RankMetaFunctionBase("rank_percentile", Arity::Unary(), rank_percentile_doc,
+                             GetDefaultPercentileRankOptions()) {}
+
+ protected:
+  UnpackedOptions UnpackOptions(const FunctionOptions& function_options) const override {
+    const auto& options = checked_cast<const RankPercentileOptions&>(function_options);
+    UnpackedOptions unpacked{SortOrder::Ascending, options.null_placement,
+                             std::make_unique<PercentileRankingsEmitter>(options.factor)};
+    if (!options.sort_keys.empty()) {
+      unpacked.order = options.sort_keys[0].order;
+    }
+    return unpacked;
   }
 };
 
@@ -306,6 +414,7 @@ class RankMetaFunction : public MetaFunction {
 
 void RegisterVectorRank(FunctionRegistry* registry) {
   DCHECK_OK(registry->AddFunction(std::make_shared<RankMetaFunction>()));
+  DCHECK_OK(registry->AddFunction(std::make_shared<RankPercentileMetaFunction>()));
 }
 
 }  // namespace arrow::compute::internal

--- a/cpp/src/arrow/compute/kernels/vector_sort_internal.h
+++ b/cpp/src/arrow/compute/kernels/vector_sort_internal.h
@@ -806,4 +806,11 @@ inline Result<std::shared_ptr<ArrayData>> MakeMutableUInt64Array(
   return ArrayData::Make(uint64(), length, {nullptr, std::move(data)}, /*null_count=*/0);
 }
 
+inline Result<std::shared_ptr<ArrayData>> MakeMutableFloat64Array(
+    int64_t length, MemoryPool* memory_pool) {
+  auto buffer_size = length * sizeof(double);
+  ARROW_ASSIGN_OR_RAISE(auto data, AllocateBuffer(buffer_size, memory_pool));
+  return ArrayData::Make(float64(), length, {nullptr, std::move(data)}, /*null_count=*/0);
+}
+
 }  // namespace arrow::compute::internal

--- a/cpp/src/arrow/compute/kernels/vector_sort_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort_test.cc
@@ -2522,22 +2522,22 @@ class TestRankQuantile : public BaseTestRank {
   // Expecting an input ordered like [1, 2, 1, 2, 1]
   void AssertRankQuantile_12121() {
     for (auto null_placement : AllNullPlacements()) {
-      AssertRankQuantile(SortOrder::Ascending, null_placement, 100.0,
+      AssertRankQuantile(SortOrder::Ascending, null_placement, /*factor=*/100.0,
                          "[30.0, 80.0, 30.0, 80.0, 30.0]");
-      AssertRankQuantile(SortOrder::Descending, null_placement, 100.0,
+      AssertRankQuantile(SortOrder::Descending, null_placement, /*factor=*/100.0,
                          "[70.0, 20.0, 70.0, 20.0, 70.0]");
     }
   }
 
   // Expecting an input ordered like [null, 1, null, 2, null]
   void AssertRankQuantile_N1N2N() {
-    AssertRankQuantile(SortOrder::Ascending, NullPlacement::AtStart, 1.0,
+    AssertRankQuantile(SortOrder::Ascending, NullPlacement::AtStart, /*factor=*/1.0,
                        "[0.3, 0.7, 0.3, 0.9, 0.3]");
-    AssertRankQuantile(SortOrder::Ascending, NullPlacement::AtEnd, 1.0,
+    AssertRankQuantile(SortOrder::Ascending, NullPlacement::AtEnd, /*factor=*/1.0,
                        "[0.7, 0.1, 0.7, 0.3, 0.7]");
-    AssertRankQuantile(SortOrder::Descending, NullPlacement::AtStart, 1.0,
+    AssertRankQuantile(SortOrder::Descending, NullPlacement::AtStart, /*factor=*/1.0,
                        "[0.3, 0.9, 0.3, 0.7, 0.3]");
-    AssertRankQuantile(SortOrder::Descending, NullPlacement::AtEnd, 1.0,
+    AssertRankQuantile(SortOrder::Descending, NullPlacement::AtEnd, /*factor=*/1.0,
                        "[0.7, 0.3, 0.7, 0.1, 0.7]");
   }
 
@@ -2548,13 +2548,13 @@ class TestRankQuantile : public BaseTestRank {
     // Reproduce the example from https://en.wikipedia.org/wiki/Percentile_rank
     SetInput(ArrayFromJSON(type, "[7, 5, 5, 4, 4, 3, 3, 3, 2, 1]"));
     for (auto null_placement : AllNullPlacements()) {
-      AssertRankQuantile(SortOrder::Ascending, null_placement, 10.0,
+      AssertRankQuantile(SortOrder::Ascending, null_placement, /*factor=*/10.0,
                          "[9.5, 8.0, 8.0, 6.0, 6.0, 3.5, 3.5, 3.5, 1.5, 0.5]");
-      AssertRankQuantile(SortOrder::Ascending, null_placement, 100.0,
+      AssertRankQuantile(SortOrder::Ascending, null_placement, /*factor=*/100.0,
                          "[95, 80, 80, 60, 60, 35, 35, 35, 15, 5]");
-      AssertRankQuantile(SortOrder::Descending, null_placement, 10.0,
+      AssertRankQuantile(SortOrder::Descending, null_placement, /*factor=*/10.0,
                          "[0.5, 2.0, 2.0, 4.0, 4.0, 6.5, 6.5, 6.5, 8.5, 9.5]");
-      AssertRankQuantile(SortOrder::Descending, null_placement, 100.0,
+      AssertRankQuantile(SortOrder::Descending, null_placement, /*factor=*/100.0,
                          "[5, 20, 20, 40, 40, 65, 65, 65, 85, 95]");
     }
 

--- a/cpp/src/arrow/compute/kernels/vector_sort_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort_test.cc
@@ -2545,7 +2545,7 @@ class TestRankQuantile : public BaseTestRank {
     ARROW_SCOPED_TRACE("type = ", type->ToString());
     AssertRankQuantileEmpty(type);
 
-    // Reproduce the example from https://en.wikipedia.org/wiki/Quantile_rank
+    // Reproduce the example from https://en.wikipedia.org/wiki/Percentile_rank
     SetInput(ArrayFromJSON(type, "[7, 5, 5, 4, 4, 3, 3, 3, 2, 1]"));
     for (auto null_placement : AllNullPlacements()) {
       AssertRankQuantile(SortOrder::Ascending, null_placement, 10.0,

--- a/cpp/src/arrow/compute/kernels/vector_sort_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort_test.cc
@@ -2205,7 +2205,7 @@ TEST_F(TestNestedSortIndices, SortRecordBatch) { TestSort(GetRecordBatch()); }
 TEST_F(TestNestedSortIndices, SortTable) { TestSort(GetTable()); }
 
 // ----------------------------------------------------------------------
-// Tests for Rank and Percentile Rank
+// Tests for Rank and Quantile Rank
 
 class BaseTestRank : public ::testing::Test {
  protected:
@@ -2469,151 +2469,150 @@ TEST_F(TestRank, EmptyChunks) {
   }
 }
 
-class TestRankPercentile : public BaseTestRank {
+class TestRankQuantile : public BaseTestRank {
  public:
-  void AssertRankPercentile(const DatumVector& datums, SortOrder order,
-                            NullPlacement null_placement, double factor,
-                            const std::shared_ptr<Array>& expected) {
+  void AssertRankQuantile(const DatumVector& datums, SortOrder order,
+                          NullPlacement null_placement, double factor,
+                          const std::shared_ptr<Array>& expected) {
     const std::vector<SortKey> sort_keys{SortKey("foo", order)};
-    RankPercentileOptions options(sort_keys, null_placement, factor);
+    RankQuantileOptions options(sort_keys, null_placement, factor);
     ARROW_SCOPED_TRACE("options = ", options.ToString());
     for (const auto& datum : datums) {
-      ASSERT_OK_AND_ASSIGN(auto actual,
-                           CallFunction("rank_percentile", {datum}, &options));
+      ASSERT_OK_AND_ASSIGN(auto actual, CallFunction("rank_quantile", {datum}, &options));
       ValidateOutput(actual);
       AssertDatumsEqual(expected, actual, /*verbose=*/true);
     }
   }
 
-  void AssertRankPercentile(const DatumVector& datums, SortOrder order,
-                            NullPlacement null_placement, double factor,
-                            const std::string& expected) {
-    AssertRankPercentile(datums, order, null_placement, factor,
-                         ArrayFromJSON(float64(), expected));
+  void AssertRankQuantile(const DatumVector& datums, SortOrder order,
+                          NullPlacement null_placement, double factor,
+                          const std::string& expected) {
+    AssertRankQuantile(datums, order, null_placement, factor,
+                       ArrayFromJSON(float64(), expected));
   }
 
-  void AssertRankPercentile(SortOrder order, NullPlacement null_placement, double factor,
-                            const std::shared_ptr<Array>& expected) {
-    AssertRankPercentile(datums_, order, null_placement, factor, expected);
+  void AssertRankQuantile(SortOrder order, NullPlacement null_placement, double factor,
+                          const std::shared_ptr<Array>& expected) {
+    AssertRankQuantile(datums_, order, null_placement, factor, expected);
   }
 
-  void AssertRankPercentile(SortOrder order, NullPlacement null_placement, double factor,
-                            const std::string& expected) {
-    AssertRankPercentile(datums_, order, null_placement, factor,
-                         ArrayFromJSON(float64(), expected));
+  void AssertRankQuantile(SortOrder order, NullPlacement null_placement, double factor,
+                          const std::string& expected) {
+    AssertRankQuantile(datums_, order, null_placement, factor,
+                       ArrayFromJSON(float64(), expected));
   }
 
-  void AssertRankPercentileEmpty(std::shared_ptr<DataType> type) {
+  void AssertRankQuantileEmpty(std::shared_ptr<DataType> type) {
     for (auto null_placement : AllNullPlacements()) {
       for (auto order : AllOrders()) {
-        AssertRankPercentile({ArrayFromJSON(type, "[]")}, order, null_placement,
-                             /*factor=*/1.0, "[]");
-        AssertRankPercentile({ArrayFromJSON(type, "[null]")}, order, null_placement,
-                             /*factor=*/1.0, "[0.5]");
-        AssertRankPercentile({ArrayFromJSON(type, "[null]")}, order, null_placement,
-                             /*factor=*/10.0, "[5]");
-        AssertRankPercentile({ArrayFromJSON(type, "[null, null, null]")}, order,
-                             null_placement, /*factor=*/1.0, "[0.5, 0.5, 0.5]");
-        AssertRankPercentile({ArrayFromJSON(type, "[null, null, null]")}, order,
-                             null_placement, /*factor=*/100.0, "[50, 50, 50]");
+        AssertRankQuantile({ArrayFromJSON(type, "[]")}, order, null_placement,
+                           /*factor=*/1.0, "[]");
+        AssertRankQuantile({ArrayFromJSON(type, "[null]")}, order, null_placement,
+                           /*factor=*/1.0, "[0.5]");
+        AssertRankQuantile({ArrayFromJSON(type, "[null]")}, order, null_placement,
+                           /*factor=*/10.0, "[5]");
+        AssertRankQuantile({ArrayFromJSON(type, "[null, null, null]")}, order,
+                           null_placement, /*factor=*/1.0, "[0.5, 0.5, 0.5]");
+        AssertRankQuantile({ArrayFromJSON(type, "[null, null, null]")}, order,
+                           null_placement, /*factor=*/100.0, "[50, 50, 50]");
       }
     }
   }
 
   // Expecting an input ordered like [1, 2, 1, 2, 1]
-  void AssertRankPercentile_12121() {
+  void AssertRankQuantile_12121() {
     for (auto null_placement : AllNullPlacements()) {
-      AssertRankPercentile(SortOrder::Ascending, null_placement, 100.0,
-                           "[30.0, 80.0, 30.0, 80.0, 30.0]");
-      AssertRankPercentile(SortOrder::Descending, null_placement, 100.0,
-                           "[70.0, 20.0, 70.0, 20.0, 70.0]");
+      AssertRankQuantile(SortOrder::Ascending, null_placement, 100.0,
+                         "[30.0, 80.0, 30.0, 80.0, 30.0]");
+      AssertRankQuantile(SortOrder::Descending, null_placement, 100.0,
+                         "[70.0, 20.0, 70.0, 20.0, 70.0]");
     }
   }
 
   // Expecting an input ordered like [null, 1, null, 2, null]
-  void AssertRankPercentile_N1N2N() {
-    AssertRankPercentile(SortOrder::Ascending, NullPlacement::AtStart, 1.0,
-                         "[0.3, 0.7, 0.3, 0.9, 0.3]");
-    AssertRankPercentile(SortOrder::Ascending, NullPlacement::AtEnd, 1.0,
-                         "[0.7, 0.1, 0.7, 0.3, 0.7]");
-    AssertRankPercentile(SortOrder::Descending, NullPlacement::AtStart, 1.0,
-                         "[0.3, 0.9, 0.3, 0.7, 0.3]");
-    AssertRankPercentile(SortOrder::Descending, NullPlacement::AtEnd, 1.0,
-                         "[0.7, 0.3, 0.7, 0.1, 0.7]");
+  void AssertRankQuantile_N1N2N() {
+    AssertRankQuantile(SortOrder::Ascending, NullPlacement::AtStart, 1.0,
+                       "[0.3, 0.7, 0.3, 0.9, 0.3]");
+    AssertRankQuantile(SortOrder::Ascending, NullPlacement::AtEnd, 1.0,
+                       "[0.7, 0.1, 0.7, 0.3, 0.7]");
+    AssertRankQuantile(SortOrder::Descending, NullPlacement::AtStart, 1.0,
+                       "[0.3, 0.9, 0.3, 0.7, 0.3]");
+    AssertRankQuantile(SortOrder::Descending, NullPlacement::AtEnd, 1.0,
+                       "[0.7, 0.3, 0.7, 0.1, 0.7]");
   }
 
-  void AssertRankPercentileNumeric(std::shared_ptr<DataType> type) {
+  void AssertRankQuantileNumeric(std::shared_ptr<DataType> type) {
     ARROW_SCOPED_TRACE("type = ", type->ToString());
-    AssertRankPercentileEmpty(type);
+    AssertRankQuantileEmpty(type);
 
-    // Reproduce the example from https://en.wikipedia.org/wiki/Percentile_rank
+    // Reproduce the example from https://en.wikipedia.org/wiki/Quantile_rank
     SetInput(ArrayFromJSON(type, "[7, 5, 5, 4, 4, 3, 3, 3, 2, 1]"));
     for (auto null_placement : AllNullPlacements()) {
-      AssertRankPercentile(SortOrder::Ascending, null_placement, 10.0,
-                           "[9.5, 8.0, 8.0, 6.0, 6.0, 3.5, 3.5, 3.5, 1.5, 0.5]");
-      AssertRankPercentile(SortOrder::Ascending, null_placement, 100.0,
-                           "[95, 80, 80, 60, 60, 35, 35, 35, 15, 5]");
-      AssertRankPercentile(SortOrder::Descending, null_placement, 10.0,
-                           "[0.5, 2.0, 2.0, 4.0, 4.0, 6.5, 6.5, 6.5, 8.5, 9.5]");
-      AssertRankPercentile(SortOrder::Descending, null_placement, 100.0,
-                           "[5, 20, 20, 40, 40, 65, 65, 65, 85, 95]");
+      AssertRankQuantile(SortOrder::Ascending, null_placement, 10.0,
+                         "[9.5, 8.0, 8.0, 6.0, 6.0, 3.5, 3.5, 3.5, 1.5, 0.5]");
+      AssertRankQuantile(SortOrder::Ascending, null_placement, 100.0,
+                         "[95, 80, 80, 60, 60, 35, 35, 35, 15, 5]");
+      AssertRankQuantile(SortOrder::Descending, null_placement, 10.0,
+                         "[0.5, 2.0, 2.0, 4.0, 4.0, 6.5, 6.5, 6.5, 8.5, 9.5]");
+      AssertRankQuantile(SortOrder::Descending, null_placement, 100.0,
+                         "[5, 20, 20, 40, 40, 65, 65, 65, 85, 95]");
     }
 
     // With nulls
     SetInput(ArrayFromJSON(type, "[null, 1, null, 2, null]"));
-    AssertRankPercentile_N1N2N();
+    AssertRankQuantile_N1N2N();
   }
 
-  void AssertRankPercentileBinaryLike(std::shared_ptr<DataType> type) {
+  void AssertRankQuantileBinaryLike(std::shared_ptr<DataType> type) {
     ARROW_SCOPED_TRACE("type = ", type->ToString());
-    AssertRankPercentileEmpty(type);
+    AssertRankQuantileEmpty(type);
 
     SetInput(ArrayFromJSON(type, R"(["", "ab", "", "ab", ""])"));
-    AssertRankPercentile_12121();
+    AssertRankQuantile_12121();
     // With nulls
     SetInput(ArrayFromJSON(type, R"([null, "", null, "ab", null])"));
-    AssertRankPercentile_N1N2N();
+    AssertRankQuantile_N1N2N();
   }
 };
 
-TEST_F(TestRankPercentile, Real) {
+TEST_F(TestRankQuantile, Real) {
   for (auto type : ::arrow::FloatingPointTypes()) {
-    AssertRankPercentileNumeric(type);
+    AssertRankQuantileNumeric(type);
   }
 }
 
-TEST_F(TestRankPercentile, Integral) {
+TEST_F(TestRankQuantile, Integral) {
   for (auto type : ::arrow::IntTypes()) {
-    AssertRankPercentileNumeric(type);
+    AssertRankQuantileNumeric(type);
   }
 }
 
-TEST_F(TestRankPercentile, Boolean) {
+TEST_F(TestRankQuantile, Boolean) {
   auto type = boolean();
-  AssertRankPercentileEmpty(type);
+  AssertRankQuantileEmpty(type);
 
   SetInput(ArrayFromJSON(type, "[false, true, false, true, false]"));
-  AssertRankPercentile_12121();
+  AssertRankQuantile_12121();
   // With nulls
   SetInput(ArrayFromJSON(type, "[null, false, null, true, null]"));
-  AssertRankPercentile_N1N2N();
+  AssertRankQuantile_N1N2N();
 }
 
-TEST_F(TestRankPercentile, BinaryLike) {
+TEST_F(TestRankQuantile, BinaryLike) {
   for (auto type : BaseBinaryTypes()) {
-    AssertRankPercentileBinaryLike(type);
+    AssertRankQuantileBinaryLike(type);
   }
 }
 
-TEST_F(TestRankPercentile, FixedSizeBinary) {
+TEST_F(TestRankQuantile, FixedSizeBinary) {
   auto type = fixed_size_binary(3);
-  AssertRankPercentileEmpty(type);
+  AssertRankQuantileEmpty(type);
 
   SetInput(ArrayFromJSON(type, R"(["abc", "def", "abc", "def", "abc"])"));
-  AssertRankPercentile_12121();
+  AssertRankQuantile_12121();
   // With nulls
   SetInput(ArrayFromJSON(type, R"([null, "abc", null, "def", null])"));
-  AssertRankPercentile_N1N2N();
+  AssertRankQuantile_N1N2N();
 }
 
 }  // namespace compute

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -1796,21 +1796,21 @@ in the respective option classes.
    Binary- and String-like inputs are ordered lexicographically as bytestrings,
    even for String types.
 
-+-----------------------+------------+---------------------------------------------------------+-------------------+---------------------------------+----------------+
-| Function name         | Arity      | Input types                                             | Output type       | Options class                   | Notes          |
-+=======================+============+=========================================================+===================+=================================+================+
-| array_sort_indices    | Unary      | Boolean, Numeric, Temporal, Binary- and String-like     | UInt64            | :struct:`ArraySortOptions`      | \(1) \(2)      |
-+-----------------------+------------+---------------------------------------------------------+-------------------+---------------------------------+----------------+
-| partition_nth_indices | Unary      | Boolean, Numeric, Temporal, Binary- and String-like     | UInt64            | :struct:`PartitionNthOptions`   | \(3)           |
-+-----------------------+------------+---------------------------------------------------------+-------------------+---------------------------------+----------------+
-| rank                  | Unary      | Boolean, Numeric, Temporal, Binary- and String-like     | UInt64            | :struct:`RankOptions`           | \(4)           |
-+-----------------------+------------+---------------------------------------------------------+-------------------+---------------------------------+----------------+
-| rank_percentile       | Unary      | Boolean, Numeric, Temporal, Binary- and String-like     | Float64           | :struct:`RankPercentileOptions` | \(5)           |
-+-----------------------+------------+---------------------------------------------------------+-------------------+---------------------------------+----------------+
-| select_k_unstable     | Unary      | Boolean, Numeric, Temporal, Binary- and String-like     | UInt64            | :struct:`SelectKOptions`        | \(6) \(7)      |
-+-----------------------+------------+---------------------------------------------------------+-------------------+---------------------------------+----------------+
-| sort_indices          | Unary      | Boolean, Numeric, Temporal, Binary- and String-like     | UInt64            | :struct:`SortOptions`           | \(1) \(6)      |
-+-----------------------+------------+---------------------------------------------------------+-------------------+---------------------------------+----------------+
++-----------------------+------------+---------------------------------------------------------+-------------------+-------------------------------+----------------+
+| Function name         | Arity      | Input types                                             | Output type       | Options class                 | Notes          |
++=======================+============+=========================================================+===================+===============================+================+
+| array_sort_indices    | Unary      | Boolean, Numeric, Temporal, Binary- and String-like     | UInt64            | :struct:`ArraySortOptions`    | \(1) \(2)      |
++-----------------------+------------+---------------------------------------------------------+-------------------+-------------------------------+----------------+
+| partition_nth_indices | Unary      | Boolean, Numeric, Temporal, Binary- and String-like     | UInt64            | :struct:`PartitionNthOptions` | \(3)           |
++-----------------------+------------+---------------------------------------------------------+-------------------+-------------------------------+----------------+
+| rank                  | Unary      | Boolean, Numeric, Temporal, Binary- and String-like     | UInt64            | :struct:`RankOptions`         | \(4)           |
++-----------------------+------------+---------------------------------------------------------+-------------------+-------------------------------+----------------+
+| rank_quantile         | Unary      | Boolean, Numeric, Temporal, Binary- and String-like     | Float64           | :struct:`RankQuantileOptions` | \(5)           |
++-----------------------+------------+---------------------------------------------------------+-------------------+-------------------------------+----------------+
+| select_k_unstable     | Unary      | Boolean, Numeric, Temporal, Binary- and String-like     | UInt64            | :struct:`SelectKOptions`      | \(6) \(7)      |
++-----------------------+------------+---------------------------------------------------------+-------------------+-------------------------------+----------------+
+| sort_indices          | Unary      | Boolean, Numeric, Temporal, Binary- and String-like     | UInt64            | :struct:`SortOptions`         | \(1) \(6)      |
++-----------------------+------------+---------------------------------------------------------+-------------------+-------------------------------+----------------+
 
 
 * \(1) The output is an array of indices into the input, that define a
@@ -1828,7 +1828,7 @@ in the respective option classes.
 * \(4) The output is a one-based numerical array of ranks.
 
 * \(5) The output is an array of quantiles between 0 and a constant *factor*.
-  The *factor* can be configured in :class:`RankPercentileOptions`
+  The *factor* can be configured in :class:`RankQuantileOptions`
   (use 100.0 for a percentile rank).
 
 * \(6) The input can be an array, chunked array, record batch or

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -1796,19 +1796,21 @@ in the respective option classes.
    Binary- and String-like inputs are ordered lexicographically as bytestrings,
    even for String types.
 
-+-----------------------+------------+---------------------------------------------------------+-------------------+--------------------------------+----------------+
-| Function name         | Arity      | Input types                                             | Output type       | Options class                  | Notes          |
-+=======================+============+=========================================================+===================+================================+================+
-| array_sort_indices    | Unary      | Boolean, Numeric, Temporal, Binary- and String-like     | UInt64            | :struct:`ArraySortOptions`     | \(1) \(2)      |
-+-----------------------+------------+---------------------------------------------------------+-------------------+--------------------------------+----------------+
-| partition_nth_indices | Unary      | Boolean, Numeric, Temporal, Binary- and String-like     | UInt64            | :struct:`PartitionNthOptions`  | \(3)           |
-+-----------------------+------------+---------------------------------------------------------+-------------------+--------------------------------+----------------+
-| rank                  | Unary      | Boolean, Numeric, Temporal, Binary- and String-like     | UInt64            | :struct:`RankOptions`          | \(4)           |
-+-----------------------+------------+---------------------------------------------------------+-------------------+--------------------------------+----------------+
-| select_k_unstable     | Unary      | Boolean, Numeric, Temporal, Binary- and String-like     | UInt64            | :struct:`SelectKOptions`       | \(5) \(6)      |
-+-----------------------+------------+---------------------------------------------------------+-------------------+--------------------------------+----------------+
-| sort_indices          | Unary      | Boolean, Numeric, Temporal, Binary- and String-like     | UInt64            | :struct:`SortOptions`          | \(1) \(5)      |
-+-----------------------+------------+---------------------------------------------------------+-------------------+--------------------------------+----------------+
++-----------------------+------------+---------------------------------------------------------+-------------------+---------------------------------+----------------+
+| Function name         | Arity      | Input types                                             | Output type       | Options class                   | Notes          |
++=======================+============+=========================================================+===================+=================================+================+
+| array_sort_indices    | Unary      | Boolean, Numeric, Temporal, Binary- and String-like     | UInt64            | :struct:`ArraySortOptions`      | \(1) \(2)      |
++-----------------------+------------+---------------------------------------------------------+-------------------+---------------------------------+----------------+
+| partition_nth_indices | Unary      | Boolean, Numeric, Temporal, Binary- and String-like     | UInt64            | :struct:`PartitionNthOptions`   | \(3)           |
++-----------------------+------------+---------------------------------------------------------+-------------------+---------------------------------+----------------+
+| rank                  | Unary      | Boolean, Numeric, Temporal, Binary- and String-like     | UInt64            | :struct:`RankOptions`           | \(4)           |
++-----------------------+------------+---------------------------------------------------------+-------------------+---------------------------------+----------------+
+| rank_percentile       | Unary      | Boolean, Numeric, Temporal, Binary- and String-like     | Float64           | :struct:`RankPercentileOptions` | \(5)           |
++-----------------------+------------+---------------------------------------------------------+-------------------+---------------------------------+----------------+
+| select_k_unstable     | Unary      | Boolean, Numeric, Temporal, Binary- and String-like     | UInt64            | :struct:`SelectKOptions`        | \(6) \(7)      |
++-----------------------+------------+---------------------------------------------------------+-------------------+---------------------------------+----------------+
+| sort_indices          | Unary      | Boolean, Numeric, Temporal, Binary- and String-like     | UInt64            | :struct:`SortOptions`           | \(1) \(6)      |
++-----------------------+------------+---------------------------------------------------------+-------------------+---------------------------------+----------------+
 
 
 * \(1) The output is an array of indices into the input, that define a
@@ -1823,13 +1825,17 @@ in the respective option classes.
   :func:`std::nth_element`).  *N* is given in
   :member:`PartitionNthOptions::pivot`.
 
-* \(4) The output is a one-based numerical array of ranks
+* \(4) The output is a one-based numerical array of ranks.
 
-* \(5) The input can be an array, chunked array, record batch or
+* \(5) The output is an array of quantiles between 0 and a constant *factor*.
+  The *factor* can be configured in :class:`RankPercentileOptions`
+  (use 100.0 for a percentile rank).
+
+* \(6) The input can be an array, chunked array, record batch or
   table. If the input is a record batch or table, one or more sort
   keys must be specified.
 
-* \(6) The output is an array of indices into the input, that define a
+* \(7) The output is an array of indices into the input, that define a
   non-stable sort of the input.
 
 .. _cpp-compute-vector-structural-transforms:

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -1827,9 +1827,7 @@ in the respective option classes.
 
 * \(4) The output is a one-based numerical array of ranks.
 
-* \(5) The output is an array of quantiles between 0 and a constant *factor*.
-  The *factor* can be configured in :class:`RankQuantileOptions`
-  (use 100.0 for a percentile rank).
+* \(5) The output is an array of quantiles strictly between 0 and 1.
 
 * \(6) The input can be an array, chunked array, record batch or
   table. If the input is a record batch or table, one or more sort


### PR DESCRIPTION
### Rationale for this change

Add a "rank_quantile" function following the Wikipedia definition:
https://en.wikipedia.org/wiki/Percentile_rank

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes, an additional compute function.

* GitHub Issue: #45190