### PR TITLE
GH-44924: [R] Remove usage of cpp11's HAS_UNWIND_PROTECT

### DIFF
--- a/r/src/safe-call-into-r-impl.cpp
+++ b/r/src/safe-call-into-r-impl.cpp
@@ -46,11 +46,7 @@ bool SetEnableSignalStopSource(bool enabled) {
 
 // [[arrow::export]]
 bool CanRunWithCapturedR() {
-#if defined(HAS_UNWIND_PROTECT)
   return MainRThread::GetInstance().Executor() == nullptr;
-#else
-  return false;
-#endif
 }
 
 // [[arrow::export]]

--- a/r/src/safe-call-into-r.h
+++ b/r/src/safe-call-into-r.h
@@ -29,12 +29,8 @@
 #include <functional>
 #include <thread>
 
-// Unwind protection was added in R 3.5 and some calls here use it
-// and crash R in older versions (ARROW-16201). Implementation provided
-// in safe-call-into-r-impl.cpp so that we can skip some tests
-// when this feature is not provided. This also checks that there
-// is not already an event loop registered (via MainRThread::Executor()),
-// because only one of these can exist at any given time.
+// This checks that there is not already an event loop registered (via
+// MainRThread::Executor()), because only one of these can exist at any given time.
 bool CanRunWithCapturedR();
 
 // The MainRThread class keeps track of the thread on which it is safe


### PR DESCRIPTION

### Rationale for this change

The macro is no longer required on R >= 4.0 which is our minimum version.

### What changes are included in this PR?

Remove use of HAS_UNWIND_PROTECT

### Are these changes tested?

ci
### Are there any user-facing changes?

no
* GitHub Issue: #44924