### PR TITLE
MINOR: [Docs] Correct ListView example doc in Columnar.rst

### DIFF
--- a/docs/source/format/Columnar.rst
+++ b/docs/source/format/Columnar.rst
@@ -693,7 +693,7 @@ having logical values::
 
 It may have the following representation: ::
 
-    * Length: 4, Null count: 1
+    * Length: 5, Null count: 1
     * Validity bitmap buffer:
 
       | Byte 0 (validity bitmap) | Bytes 1-63            |


### PR DESCRIPTION
### Rationale for this change
The pr aims to correct an error in doc `Columnar.rst`

### What changes are included in this PR?
Obviously, the value of `Length` below is incorrect, it should be `5`.
<img width="775" alt="image" src="https://github.com/user-attachments/assets/9e53d415-0a6e-4d2b-9822-9eb20456898a" />


### Are these changes tested?
No, only for docs.

### Are there any user-facing changes?
Reduce misunderstandings among end users.