### PR TITLE
MINOR: [Docs][FOLLOWUP] Correct ListView example doc in Columnar.rst

### DIFF
--- a/docs/source/format/Columnar.rst
+++ b/docs/source/format/Columnar.rst
@@ -790,7 +790,7 @@ type.
 **Example Layout: ``Struct<VarBinary, Int32>``**
 
 The layout for ``[{'joe', 1}, {null, 2}, null, {'mark', 4}]``, having
-child arrays ``['joe', null, 'alice', 'mark']`` and ``[1, 2, null, 4]``
+child arrays ``['joe', null, null, 'mark']`` and ``[1, 2, null, 4]``
 would be: ::
 
     * Length: 4, Null count: 1
@@ -802,24 +802,24 @@ would be: ::
 
     * Children arrays:
       * field-0 array (`VarBinary`):
-        * Length: 4, Null count: 1
+        * Length: 4, Null count: 2
         * Validity bitmap buffer:
 
           | Byte 0 (validity bitmap) | Bytes 1-63            |
           |--------------------------|-----------------------|
-          | 00001101                 | 0 (padding)           |
+          | 00001001                 | 0 (padding)           |
 
         * Offsets buffer:
 
           | Bytes 0-19     | Bytes 20-63           |
           |----------------|-----------------------|
-          | 0, 3, 3, 8, 12 | unspecified (padding) |
+          | 0, 3, 3, 3, 7  | unspecified (padding) |
 
          * Value buffer:
 
           | Bytes 0-11     | Bytes 12-63           |
           |----------------|-----------------------|
-          | joealicemark   | unspecified (padding) |
+          | joemark        | unspecified (padding) |
 
       * field-1 array (int32 array):
         * Length: 4, Null count: 1


### PR DESCRIPTION
### Rationale for this change
The pr aims to correct an error in doc `Columnar.rst`
It is following up https://github.com/apache/arrow/pull/45265.

### What changes are included in this PR?
Obviously, the following description does not match the example above.
<img width="762" alt="image" src="https://github.com/user-attachments/assets/1988e1ca-f98f-4247-9078-569dc4dd025c" />


### Are these changes tested?
No, only for docs.

### Are there any user-facing changes?
Reduce misunderstandings among end users.