### PR TITLE
GH-45270: [C++][CI] Disable mimalloc on Valgrind builds

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -332,6 +332,7 @@ services:
       ARROW_FLIGHT_SQL: "OFF"
       ARROW_GANDIVA: "OFF"
       ARROW_JEMALLOC: "OFF"
+      ARROW_MIMALLOC: "OFF"
       ARROW_RUNTIME_SIMD_LEVEL: "AVX2"  # AVX512 not supported by Valgrind (ARROW-9851)
       ARROW_TEST_MEMCHECK: "ON"
       ARROW_USE_LD_GOLD: "ON"


### PR DESCRIPTION
### Rationale for this change

Valgrind is not aware of third-party allocators such as mimalloc and jemalloc. This can lead to spurious errors or, on the contrary, it could hide some actual issues.

### What changes are included in this PR?

Disable mimalloc in the Valgrind build (jemalloc is already disabled).

### Are these changes tested?

Yes, by existing CI.

### Are there any user-facing changes?

No.

* GitHub Issue: #45270