### PR TITLE
GH-45307: [CI] Use GitHub hosted arm runner

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -69,26 +69,6 @@ env:
   DOCKER_VOLUME_PREFIX: ".docker/"
 
 jobs:
-  docker-targets:
-    name: Docker targets
-    runs-on: ubuntu-latest
-    outputs:
-      targets: ${{ steps.detect-targets.outputs.targets }}
-    steps:
-      - name: Detect targets
-        id: detect-targets
-        run: |
-          JSON
-          if [ "$GITHUB_REPOSITORY_OWNER" = "apache" ]; then
-            echo "," >> "$GITHUB_OUTPUT"
-            cat <<JSON >> "$GITHUB_OUTPUT"
-          {
-          }
-          JSON
-          fi
-          echo "]" >> "$GITHUB_OUTPUT"
-          echo "JSON" >> "$GITHUB_OUTPUT"
-
   docker:
     name: ${{ matrix.title }}
     runs-on: ${{ matrix.runs-on }}

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -96,7 +96,7 @@ jobs:
           - arch: arm64v8
             clang-tools: 10
             image: ubuntu-cpp
-            llvm: 10,
+            llvm: 10
             runs-on: ubuntu-24.04-arm
             title: ARM64 Ubuntu 20.04 C++
             ubuntu: 20.04

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -78,40 +78,11 @@ jobs:
       - name: Detect targets
         id: detect-targets
         run: |
-          echo "targets<<JSON" >> "$GITHUB_OUTPUT"
-          echo "[" >> "$GITHUB_OUTPUT"
-          cat <<JSON >> "$GITHUB_OUTPUT"
-          {
-            "arch": "amd64",
-            "clang-tools": "14",
-            "image": "conda-cpp",
-            "llvm": "14",
-            "runs-on": "ubuntu-latest",
-            "simd-level": "AVX2",
-            "title": "AMD64 Conda C++ AVX2",
-            "ubuntu": "22.04"
-          },
-          {
-            "arch": "amd64",
-            "clang-tools": "14",
-            "image": "ubuntu-cpp-sanitizer",
-            "llvm": "14",
-            "runs-on": "ubuntu-latest",
-            "title": "AMD64 Ubuntu 22.04 C++ ASAN UBSAN",
-            "ubuntu": "22.04"
-          }
           JSON
           if [ "$GITHUB_REPOSITORY_OWNER" = "apache" ]; then
             echo "," >> "$GITHUB_OUTPUT"
             cat <<JSON >> "$GITHUB_OUTPUT"
           {
-            "arch": "arm64v8",
-            "clang-tools": "10",
-            "image": "ubuntu-cpp",
-            "llvm": "10",
-            "runs-on": ["self-hosted", "arm", "linux"],
-            "title": "ARM64 Ubuntu 20.04 C++",
-            "ubuntu": "20.04"
           }
           JSON
           fi
@@ -120,14 +91,35 @@ jobs:
 
   docker:
     name: ${{ matrix.title }}
-    needs: docker-targets
     runs-on: ${{ matrix.runs-on }}
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     timeout-minutes: 75
     strategy:
       fail-fast: false
       matrix:
-        include: ${{ fromJson(needs.docker-targets.outputs.targets) }}
+        include:
+          - arch: amd64
+            clang-tools: 14
+            image: conda-cpp
+            llvm: 14
+            runs-on: ubuntu-latest
+            simd-level: AVX2
+            title: AMD64 Conda C++ AVX2
+            ubuntu: 22.04
+          - arch: amd64
+            clang-tools: 14
+            image: ubuntu-cpp-sanitizer
+            llvm: 14
+            runs-on: ubuntu-latest
+            title: AMD64 Ubuntu 22.04 C++ ASAN UBSAN
+            ubuntu: 22.04
+          - arch: arm64v8
+            clang-tools: 10
+            image: ubuntu-cpp
+            llvm: 10,
+            runs-on: ubuntu-24.04-arm
+            title: ARM64 Ubuntu 20.04 C++
+            ubuntu: 20.04
     env:
       ARCH: ${{ matrix.arch }}
       ARROW_SIMD_LEVEL: ${{ matrix.simd-level }}

--- a/dev/tasks/linux-packages/github.linux.yml
+++ b/dev/tasks/linux-packages/github.linux.yml
@@ -23,9 +23,9 @@ jobs:
   package:
     name: Package
     {% if architecture == "amd64" %}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     {% else %}
-    runs-on: ["self-hosted", "Linux", "arm64"]
+    runs-on: ubuntu-24.04-arm
     {% endif %}
     env:
       ARCHITECTURE: {{ architecture }}

--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -145,23 +145,11 @@ env:
 
 {%- macro github_upload_gemfury(pattern) -%}
   {%- if arrow.is_default_branch() -%}
-  - name: Set up Ruby by apt
-    if: runner.os == 'Linux' && runner.arch != 'X64'
-    run: |
-      sudo apt update
-      sudo apt install -y ruby-full
-  - name: Set up Ruby by GitHub Actions
-    if: runner.arch == 'X64' && runner.os != 'macOS'
+  - name: Set up Ruby
     uses: ruby/setup-ruby@v1
     with:
       ruby-version: "ruby"
-  - name: Install gemfury client on ARM self-hosted
-    if: runner.arch != 'X64'
-    run: |
-      gem install --user-install gemfury
-      ruby -r rubygems -e 'puts("#{Gem.user_dir}/bin")' >> $GITHUB_PATH
   - name: Install gemfury client
-    if: runner.arch == 'X64'
     run: |
       gem install gemfury
   - name: Upload package to Gemfury

--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -57,20 +57,11 @@ env:
 {% endmacro %}
 
 {%- macro github_install_archery() -%}
-  - name: Set up Python by actions/setup-python
-    if: |
-      !(runner.os == 'Linux' && runner.arch != 'X64')
+  - name: Set up Python
     uses: actions/setup-python@v4
     with:
       cache: 'pip'
       python-version: 3.12
-  - name: Set up Python by apt
-    if: runner.os == 'Linux' && runner.arch != 'X64'
-    run: |
-      sudo apt update
-      sudo apt-get install -y python3-pip
-      pip install -U pip
-      echo "$HOME/.local/bin" >>"$GITHUB_PATH"
   - name: Install Archery
     shell: bash
     run: pip install -e arrow/dev/archery[all]
@@ -85,21 +76,10 @@ env:
 {% endmacro %}
 
 {%- macro github_upload_releases(pattern) -%}
-  - name: Set up Python by actions/setup-python
-    if: |
-      !(runner.os == 'Linux' && runner.arch != 'X64')
+  - name: Set up Python
     uses: actions/setup-python@v4
     with:
       python-version: 3.12
-  - name: Set up Python by apt
-    if: runner.os == 'Linux' && runner.arch != 'X64'
-    run: |
-      sudo apt update
-      sudo apt install -y \
-        libgit2-dev \
-        libpython3-dev \
-        python3-pip
-      sudo python3 -m pip install --upgrade pip
   - name: Checkout Crossbow
     uses: actions/checkout@v4
     with:

--- a/dev/tasks/python-wheels/github.linux.yml
+++ b/dev/tasks/python-wheels/github.linux.yml
@@ -28,7 +28,7 @@ jobs:
     {% if arch == "amd64" %}
     runs-on: ubuntu-latest
     {% else %}
-    runs-on: ["self-hosted", "Linux", "arm64"]
+    runs-on: ubuntu-24.04-arm
     {% endif %}
     env:
       # archery uses these environment variables


### PR DESCRIPTION
### Rationale for this change

GitHub hosted arm runner is available:
https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/

### What changes are included in this PR?

Use `ubuntu-24.04-arm` instead of self-hosted runner.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #45307