### PR TITLE
GH-45316: [Release][C#] Use GitHub Releases for artifacts

### DIFF
--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -133,3 +133,88 @@ jobs:
       - name: Test
         shell: bash
         run: ci/scripts/csharp_test.sh $(pwd)
+
+  package:
+    name: Package
+    # Branch or RC tag
+    if: github.ref_type != 'tag' || contains(github.ref_name, 'rc')
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout for utilities
+        if: github.ref_type == 'tag'
+        uses: actions/checkout@v4
+        with:
+          path: arrow
+      - name: Download source archive
+        if: github.ref_type == 'tag'
+        run: |
+          arrow/dev/release/utils-watch-gh-workflow.sh \
+            ${GITHUB_REF_NAME} \
+            release_candidate.yml
+          gh release download ${GITHUB_REF_NAME} \
+            --pattern "*.tar.gz" \
+            --repo ${GITHUB_REPOSITORY}
+          tar -xf *.tar.gz --strip-components=1
+          mv csharp/dummy.git .git
+        env:
+          GH_TOKEN: ${{ github.token }}
+      - name: Checkout
+        if: github.ref_type != 'tag'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Prepare version
+        if: github.ref_type != 'tag'
+        run: |
+          # apache-arrow-20.0.0.dev-9-g758867f907 ->
+          #              20.0.0.dev-9-g758867f907 ->
+          #              20.0.0.dev-9             ->
+          #              20.0.0-dev-9
+          semver="$(git describe --tags | \
+                     sed -E \
+                         -e 's/^apache-arrow-//' \
+                         -e 's/-[^-]*$//' \
+                         -e 's/^([0-9]*\.[0-9]*\.[0-9])\./\1-/')"
+          sed -i'' -E -e \
+            "s/^    <Version>.+<\/Version>/    <Version>${semver}<\/Version>/" \
+            csharp/Directory.Build.props
+      - name: Setup Python
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+        with:
+          python-version: 3
+      - name: Setup Archery
+        run: |
+          python3 -m pip install -e 'dev/archery[docker]'
+      - name: Build
+        run: |
+          archery docker run ubuntu-csharp
+      - name: Prepare artifacts
+        run: |
+          shopt -s globstar
+          cp csharp/artifacts/**/*.{,s}nupkg ./
+          for artifact in *.{,s}nupkg; do
+            dev/release/utils-generate-checksum.sh "${artifact}"
+          done
+      - name: Upload
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: nuget
+          path: |
+            *.nupkg
+            *.sha256
+            *.sha512
+            *.snupkg
+      - name: Publish
+        if: github.ref_type == 'tag'
+        run: |
+          gh release upload ${GITHUB_REF_NAME} \
+            --repo ${GITHUB_REPOSITORY} \
+            *.nupkg \
+            *.sha256 \
+            *.sha512 \
+            *.snupkg
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,13 +32,13 @@ env:
 
 jobs:
   publish:
-    name: Publish 
+    name: Publish
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Get Tag Name of Latest Release Candidate
         run: |
-          rc_tag=$(gh release list --repo apache/arrow | \
+          rc_tag=$(gh release list --repo ${GITHUB_REPOSITORY} | \
                     cut -f3 | \
                     grep -F "${GITHUB_REF_NAME}-rc" | \
                     head -n1)
@@ -52,23 +52,25 @@ jobs:
           echo "VERSION_WITH_RC=${version_with_rc}" >> ${GITHUB_ENV}
           echo "VERSION=${version}" >> ${GITHUB_ENV}
           echo "RC_NUM=${rc_num}" >> ${GITHUB_ENV}
-      - name: Download Release Candidate Artifacts 
+      - name: Download Release Candidate Artifacts
         run: |
           mkdir release_candidate_artifacts
-          gh release download ${RELEASE_CANDIDATE_TAG_NAME} --repo apache/arrow --dir release_candidate_artifacts
+          gh release download ${RELEASE_CANDIDATE_TAG_NAME} \
+            --dir release_candidate_artifacts \
+            --repo ${GITHUB_REPOSITORY}
       - name: Create Release Title
         run: |
           title="Apache Arrow ${VERSION}"
           echo "RELEASE_TITLE=${title}" >> ${GITHUB_ENV}
       # Set the release notes to "TODO" temporarily. After the release notes page
-      # (https://arrow.apache.org/release/{VERSION}.html) is published, use 
-      # gh release edit to update the release notes to refer to the newly 
+      # (https://arrow.apache.org/release/{VERSION}.html) is published, use
+      # gh release edit to update the release notes to refer to the newly
       # pushed web page. See dev/post/post-05-update-gh-release-notes.sh
       - name: Create GitHub Release
         run: |
           gh release create ${GITHUB_REF_NAME} \
-            --repo apache/arrow \
-            --verify-tag \
-            --title "${RELEASE_TITLE}" \
             --notes "TODO" \
+            --repo ${GITHUB_REPOSITORY} \
+            --title "${RELEASE_TITLE}" \
+            --verify-tag \
             release_candidate_artifacts/*

--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -32,10 +32,10 @@ env:
 
 jobs:
   publish:
-    name: Publish 
+    name: Publish
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    steps: 
+    steps:
       - name: Checkout Arrow
         uses: actions/checkout@v4
         with:
@@ -58,8 +58,9 @@ jobs:
           echo "RELEASE_CANDIDATE_NOTES=${release_notes}" >> ${GITHUB_ENV}
       - name: Create Release tarball
         run: |
-          cd dev/release/ && ./utils-create-release-tarball.sh ${VERSION} ${RC_NUM}
+          dev/release/utils-create-release-tarball.sh ${VERSION} ${RC_NUM}
           echo "RELEASE_TARBALL=apache-arrow-${VERSION}.tar.gz" >> ${GITHUB_ENV}
+          dev/release/utils-generate-checksum.sh "apache-arrow-${VERSION}.tar.gz"
       - name: Create GitHub Release
         run: |
           gh release create ${GITHUB_REF_NAME} \
@@ -67,4 +68,4 @@ jobs:
             --prerelease \
             --title "${RELEASE_CANDIDATE_TITLE}" \
             --notes "Release Notes: ${RELEASE_CANDIDATE_NOTES}" \
-            dev/release/${RELEASE_TARBALL}
+            ${RELEASE_TARBALL}*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -183,4 +183,5 @@ repos:
           ?^ci/scripts/c_glib_build\.sh$|
           ?^ci/scripts/c_glib_test\.sh$|
           ?^c_glib/test/run-test\.sh$|
+          ?^dev/release/utils-generate-checksum\.sh$|
           )

--- a/dev/release/02-source-test.rb
+++ b/dev/release/02-source-test.rb
@@ -143,13 +143,13 @@ This release candidate is based on commit:
 #{@current_commit} [2]
 
 The source release rc0 is hosted at [3].
-The binary artifacts are hosted at [4][5][6][7][8][9][10].
-The changelog is located at [11].
+The binary artifacts are hosted at [4][5][6][7][8][9].
+The changelog is located at [10].
 
 Please download, verify checksums and signatures, run the unit tests,
-and vote on the release. See [12] for how to validate a release candidate.
+and vote on the release. See [11] for how to validate a release candidate.
 
-See also a verification result on GitHub pull request [13].
+See also a verification result on GitHub pull request [12].
 
 The vote will be open for at least 72 hours.
 
@@ -164,12 +164,11 @@ The vote will be open for at least 72 hours.
 [5]: https://apache.jfrog.io/artifactory/arrow/amazon-linux-rc/
 [6]: https://apache.jfrog.io/artifactory/arrow/centos-rc/
 [7]: https://apache.jfrog.io/artifactory/arrow/debian-rc/
-[8]: https://apache.jfrog.io/artifactory/arrow/nuget-rc/#{@release_version}-rc0
-[9]: https://apache.jfrog.io/artifactory/arrow/python-rc/#{@release_version}-rc0
-[10]: https://apache.jfrog.io/artifactory/arrow/ubuntu-rc/
-[11]: https://github.com/apache/arrow/blob/#{@current_commit}/CHANGELOG.md
-[12]: https://arrow.apache.org/docs/developers/release_verification.html
-[13]: #{verify_pr_url || "null"}
+[8]: https://apache.jfrog.io/artifactory/arrow/python-rc/#{@release_version}-rc0
+[9]: https://apache.jfrog.io/artifactory/arrow/ubuntu-rc/
+[10]: https://github.com/apache/arrow/blob/#{@current_commit}/CHANGELOG.md
+[11]: https://arrow.apache.org/docs/developers/release_verification.html
+[12]: #{verify_pr_url || "null"}
     VOTE
   end
 end

--- a/dev/release/02-source.sh
+++ b/dev/release/02-source.sh
@@ -46,6 +46,7 @@ rc_url="https://dist.apache.org/repos/dist/dev/arrow/${tag}"
 echo "Preparing source for tag ${tag}"
 
 : ${release_hash:=$(cd "${SOURCE_TOP_DIR}" && git rev-list --max-count=1 ${tag})}
+: ${GITHUB_REPOSITORY:=apache/arrow}
 
 if [ ${SOURCE_UPLOAD} -gt 0 ]; then
   if [ -z "$release_hash" ]; then
@@ -62,35 +63,40 @@ if [ ${SOURCE_DOWNLOAD} -gt 0 ]; then
   # Wait for the release candidate workflow to finish before attempting
   # to download the tarball from the GitHub Release.
   . $SOURCE_DIR/utils-watch-gh-workflow.sh ${tag} "release_candidate.yml"
-  rm -f ${tarball}
-  gh release download \
-    ${tag} \
-    --repo apache/arrow \
-    --dir . \
-    --pattern "${tarball}"
+  . $SOURCE_DIR/utils-watch-gh-workflow.sh ${tag} "csharp.yml"
+  rm -rf artifacts
+  gh release download ${tag} \
+    --dir artifacts \
+    --repo "${GITHUB_REPOSITORY}"
 fi
 
 if [ ${SOURCE_RAT} -gt 0 ]; then
-  "${SOURCE_DIR}/run-rat.sh" ${tarball}
+  "${SOURCE_DIR}/run-rat.sh" artifacts/${tarball}
 fi
-
-if type shasum >/dev/null 2>&1; then
-  sha256_generate="shasum -a 256"
-  sha512_generate="shasum -a 512"
-else
-  sha256_generate="sha256sum"
-  sha512_generate="sha512sum"
-fi
-
 
 if [ ${SOURCE_UPLOAD} -gt 0 ]; then
-  # sign the archive
-  gpg --armor --output ${tarball}.asc --detach-sig ${tarball}
-  ${sha256_generate} $tarball > ${tarball}.sha256
-  ${sha512_generate} $tarball > ${tarball}.sha512
+  rm -rf signed-artifacts
+  mkdir -p signed-artifacts
+
+  # sign the artifacts
+  for artifact in artifacts/*; do
+    case "${artifact}" in
+      *.sha256|*.sha512)
+        continue
+        ;;
+    esac
+    gpg \
+      --armor \
+      --detach-sig \
+      --output signed-artifacts/$(basename ${artifact}).asc \
+      ${artifact}
+  done
 
   # Upload signed tarballs to GitHub Release
-  gh release upload --repo apache/arrow ${tag} ${tarball}.sha256 ${tarball}.sha512
+  gh release upload ${tag} \
+     --repo "${GITHUB_REPOSITORY}" \
+     --verify-tag \
+     signed-artifacts/*
 
   # check out the arrow RC folder
   svn co --depth=empty https://dist.apache.org/repos/dist/dev/arrow tmp
@@ -99,13 +105,16 @@ if [ ${SOURCE_UPLOAD} -gt 0 ]; then
   mkdir -p tmp/${tag}
 
   # copy the rc tarball into the tmp dir
-  cp ${tarball}* tmp/${tag}
+  cp artifacts/${tarball}* tmp/${tag}
+  cp signed-artifacts/${tarball}.asc tmp/${tag}
 
   # commit to svn
   svn add tmp/${tag}
   svn ci -m "Apache Arrow ${version} RC${rc}" tmp/${tag}
 
   # clean up
+  rm -rf artifacts
+  rm -rf signed-artifacts
   rm -rf tmp
 
   echo "Success! The release candidate is available here:"
@@ -124,7 +133,7 @@ if [ ${SOURCE_PR} -gt 0 ]; then
     --head-branch=${rc_branch} \
     --pr-body="PR to verify Release Candidate" \
     --pr-title="WIP: [Release] Verify ${rc_branch}" \
-    --remote=https://github.com/apache/arrow \
+    --remote=https://github.com/${GITHUB_REPOSITORY} \
     --rc=${rc} \
     --verify-source \
     --version=${version}
@@ -143,7 +152,7 @@ if [ ${SOURCE_VOTE} -gt 0 ]; then
   curl_options+=(--get)
   curl_options+=(--data "state=open")
   curl_options+=(--data "head=apache:${rc_branch}")
-  curl_options+=(https://api.github.com/repos/apache/arrow/pulls)
+  curl_options+=(https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls)
   verify_pr_url=$(curl "${curl_options[@]}" | jq -r ".[0].html_url")
   echo "The following draft email has been created to send to the"
   echo "dev@arrow.apache.org mailing list"
@@ -163,13 +172,13 @@ This release candidate is based on commit:
 ${release_hash} [2]
 
 The source release rc${rc} is hosted at [3].
-The binary artifacts are hosted at [4][5][6][7][8][9][10].
-The changelog is located at [11].
+The binary artifacts are hosted at [4][5][6][7][8][9].
+The changelog is located at [10].
 
 Please download, verify checksums and signatures, run the unit tests,
-and vote on the release. See [12] for how to validate a release candidate.
+and vote on the release. See [11] for how to validate a release candidate.
 
-See also a verification result on GitHub pull request [13].
+See also a verification result on GitHub pull request [12].
 
 The vote will be open for at least 72 hours.
 
@@ -184,12 +193,11 @@ The vote will be open for at least 72 hours.
 [5]: https://apache.jfrog.io/artifactory/arrow/amazon-linux-rc/
 [6]: https://apache.jfrog.io/artifactory/arrow/centos-rc/
 [7]: https://apache.jfrog.io/artifactory/arrow/debian-rc/
-[8]: https://apache.jfrog.io/artifactory/arrow/nuget-rc/${version}-rc${rc}
-[9]: https://apache.jfrog.io/artifactory/arrow/python-rc/${version}-rc${rc}
-[10]: https://apache.jfrog.io/artifactory/arrow/ubuntu-rc/
-[11]: https://github.com/apache/arrow/blob/${release_hash}/CHANGELOG.md
-[12]: https://arrow.apache.org/docs/developers/release_verification.html
-[13]: ${verify_pr_url}
+[8]: https://apache.jfrog.io/artifactory/arrow/python-rc/${version}-rc${rc}
+[9]: https://apache.jfrog.io/artifactory/arrow/ubuntu-rc/
+[10]: https://github.com/apache/arrow/blob/${release_hash}/CHANGELOG.md
+[11]: https://arrow.apache.org/docs/developers/release_verification.html
+[12]: ${verify_pr_url}
 MAIL
   echo "---------------------------------------------------------"
 fi

--- a/dev/release/05-binary-upload.sh
+++ b/dev/release/05-binary-upload.sh
@@ -72,7 +72,6 @@ fi
 : ${UPLOAD_CENTOS:=${UPLOAD_DEFAULT}}
 : ${UPLOAD_DEBIAN:=${UPLOAD_DEFAULT}}
 : ${UPLOAD_DOCS:=${UPLOAD_DEFAULT}}
-: ${UPLOAD_NUGET:=${UPLOAD_DEFAULT}}
 : ${UPLOAD_PYTHON:=${UPLOAD_DEFAULT}}
 : ${UPLOAD_R:=${UPLOAD_DEFAULT}}
 : ${UPLOAD_UBUNTU:=${UPLOAD_DEFAULT}}
@@ -98,9 +97,6 @@ if [ ${UPLOAD_DEBIAN} -gt 0 ]; then
 fi
 if [ ${UPLOAD_DOCS} -gt 0 ]; then
   rake_tasks+=(docs:rc)
-fi
-if [ ${UPLOAD_NUGET} -gt 0 ]; then
-  rake_tasks+=(nuget:rc)
 fi
 if [ ${UPLOAD_PYTHON} -gt 0 ]; then
   rake_tasks+=(python:rc)

--- a/dev/release/binary-task.rb
+++ b/dev/release/binary-task.rb
@@ -803,7 +803,6 @@ class BinaryTask
     define_apt_tasks
     define_yum_tasks
     define_docs_tasks
-    define_nuget_tasks
     define_python_tasks
     define_r_tasks
     define_summary_tasks
@@ -1899,14 +1898,6 @@ APT::FTPArchive::Release::Description "#{apt_repository_description}";
                               "test-debian-12-docs/**/*")
   end
 
-  def define_nuget_tasks
-    define_generic_data_tasks("NuGet",
-                              :nuget,
-                              "#{rc_dir}/nuget/#{full_version}",
-                              "#{release_dir}/nuget/#{full_version}",
-                              "nuget/**/*")
-  end
-
   def define_python_tasks
     define_generic_data_tasks("Python",
                               :python,
@@ -1989,7 +1980,6 @@ Success! The release candidate binaries are available here:
   https://apache.jfrog.io/artifactory/arrow/centos#{suffix}-rc/
   https://apache.jfrog.io/artifactory/arrow/debian#{suffix}-rc/
   https://apache.jfrog.io/artifactory/arrow/docs#{suffix}-rc/
-  https://apache.jfrog.io/artifactory/arrow/nuget#{suffix}-rc/#{full_version}
   https://apache.jfrog.io/artifactory/arrow/python#{suffix}-rc/#{full_version}
   https://apache.jfrog.io/artifactory/arrow/r#{suffix}-rc/#{full_version}
   https://apache.jfrog.io/artifactory/arrow/ubuntu#{suffix}-rc/
@@ -2007,7 +1997,6 @@ Success! The release binaries are available here:
   https://apache.jfrog.io/artifactory/arrow/centos#{suffix}/
   https://apache.jfrog.io/artifactory/arrow/debian#{suffix}/
   https://apache.jfrog.io/artifactory/arrow/docs#{suffix}/
-  https://apache.jfrog.io/artifactory/arrow/nuget#{suffix}/#{version}
   https://apache.jfrog.io/artifactory/arrow/python#{suffix}/#{version}
   https://apache.jfrog.io/artifactory/arrow/r#{suffix}/#{version}
   https://apache.jfrog.io/artifactory/arrow/ubuntu#{suffix}/

--- a/dev/release/download_rc_binaries.py
+++ b/dev/release/download_rc_binaries.py
@@ -280,7 +280,7 @@ def download_rc_binaries(version, rc_number, re_match=None, dest=None,
         if package_type == 'jars':
             downloader = Maven()
             prefix = ''
-        elif package_type == 'github':
+        elif package_type == 'github' or package_type == 'nuget':
             downloader = GitHub(repository, tag)
             prefix = ''
             filter = None

--- a/dev/release/post-08-csharp.sh
+++ b/dev/release/post-08-csharp.sh
@@ -30,6 +30,8 @@ fi
 
 version=$1
 
+: "${GITHUB_REPOSITORY:=apache/arrow}"
+
 if [ -z "${NUGET_API_KEY}" ]; then
   echo "NUGET_API_KEY is empty"
   exit 1
@@ -41,7 +43,7 @@ base_names+=(Apache.Arrow.Flight.${version})
 base_names+=(Apache.Arrow.Flight.AspNetCore.${version})
 base_names+=(Apache.Arrow.Flight.Sql.${version})
 base_names+=(Apache.Arrow.Compression.${version})
-for base_name in ${base_names[@]}; do
+for base_name in "${base_names[@]}"; do
   for extension in nupkg snupkg; do
     path=${base_name}.${extension}
     rm -f ${path}
@@ -49,7 +51,7 @@ for base_name in ${base_names[@]}; do
       --fail \
       --location \
       --remote-name \
-      https://apache.jfrog.io/artifactory/arrow/nuget/${version}/${path}
+      "https://github.com/${GITHUB_REPOSITORY}/releases/download/apache-arrow-${version}/${path}"
   done
   dotnet nuget push \
     ${base_name}.nupkg \

--- a/dev/release/utils-create-release-tarball.sh
+++ b/dev/release/utils-create-release-tarball.sh
@@ -54,9 +54,9 @@ dummy_git=${root_folder}/csharp/dummy.git
 mkdir ${dummy_git}
 pushd ${dummy_git}
 echo ${release_hash} > HEAD
-echo '[remote "origin"] url = https://github.com/apache/arrow.git' >> config
+echo "[remote \"origin\"] url = https://github.com/${GITHUB_REPOSITORY:-apache/arrow}.git" >> config
 mkdir objects refs
-popd 
+popd
 
 # Create new tarball from modified source directory
 tar czf ${tarball} ${root_folder}

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -60,7 +60,6 @@ groups:
     - conan-*
     - debian-*
     - matlab
-    - nuget
     - python-sdist
     - r-binary-packages
     - ubuntu-*
@@ -153,7 +152,6 @@ groups:
     - conan-*
     - conda-*
     - homebrew-cpp
-    - nuget
     - test-*
     - example-*
     - wheel-*
@@ -184,7 +182,6 @@ groups:
     - ~conda-osx-arm64-cpu-py3
     - conan-*
     - homebrew-cpp
-    - nuget
     - wheel-*
     - python-sdist
     - r-binary-packages
@@ -688,25 +685,6 @@ tasks:
     template: matlab/github.yml
     artifacts:
       - matlab-arrow-{no_rc_no_dev_version}.mltbx
-
-  ############################## NuGet packages ###############################
-
-  nuget:
-    ci: github
-    template: nuget-packages/github.linux.yml
-    params:
-      run: ubuntu-csharp
-    artifacts:
-      - Apache.Arrow.Compression.{no_rc_version}.nupkg
-      - Apache.Arrow.Compression.{no_rc_version}.snupkg
-      - Apache.Arrow.Flight.AspNetCore.{no_rc_version}.nupkg
-      - Apache.Arrow.Flight.AspNetCore.{no_rc_version}.snupkg
-      - Apache.Arrow.Flight.Sql.{no_rc_version}.nupkg
-      - Apache.Arrow.Flight.Sql.{no_rc_version}.snupkg
-      - Apache.Arrow.Flight.{no_rc_version}.nupkg
-      - Apache.Arrow.Flight.{no_rc_version}.snupkg
-      - Apache.Arrow.{no_rc_version}.nupkg
-      - Apache.Arrow.{no_rc_version}.snupkg
 
   ######################## R packages & binaries ##############################
   r-binary-packages:


### PR DESCRIPTION
### Rationale for this change

We don't need to use Artifactory for NuGet packages because it's not published to Artifactory.

### What changes are included in this PR?

* Use GitHub Releases for easy to maintain
* Use `.github/workflows/csharp.yml` instead of nightly job for easy to maintain

### Are these changes tested?

Almost yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #45316