### PR TITLE
GH-45305: [CI] Bump Minio version and unpin boto3

### DIFF
--- a/ci/appveyor-cpp-setup.bat
+++ b/ci/appveyor-cpp-setup.bat
@@ -85,7 +85,7 @@ set CXX=cl.exe
 @rem Download Minio somewhere on PATH, for unit tests
 @rem
 if "%ARROW_S3%" == "ON" (
-  appveyor DownloadFile https://dl.min.io/server/minio/release/windows-amd64/archive/minio.RELEASE.2024-09-13T20-26-02Z -FileName C:\Windows\Minio.exe || exit /B
+  appveyor DownloadFile https://dl.min.io/server/minio/release/windows-amd64/archive/minio.RELEASE.2025-01-20T14-49-07Z -FileName C:\Windows\Minio.exe || exit /B
 )
 
 @rem

--- a/ci/conda_env_python.txt
+++ b/ci/conda_env_python.txt
@@ -18,8 +18,7 @@
 # Don't add pandas here, because it is not a mandatory test dependency
 
 # Not a direct dependency of s3fs, but needed for our s3fs fixture
-# (temporary upper bound because of GH-45305)
-boto3<1.36
+boto3
 cffi
 cython>=3
 cloudpickle

--- a/ci/scripts/install_minio.sh
+++ b/ci/scripts/install_minio.sh
@@ -63,7 +63,7 @@ if [ "${version}" != "latest" ]; then
 fi
 
 # Use specific versions for minio server and client to avoid CI failures on new releases.
-minio_version="minio.RELEASE.2024-09-13T20-26-02Z"
+minio_version="minio.RELEASE.2025-01-20T14-49-07Z"
 mc_version="mc.RELEASE.2024-09-16T17-43-14Z"
 
 download()


### PR DESCRIPTION
### What changes are included in this PR?

Use latest Minio server release, which includes a fix for https://github.com/minio/minio/issues/20845

This allows us to remove the boto3 version constraint.

### Are these changes tested?

Yes, by existing CI tests.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #45305