### PR TITLE
GH-45278: [Python][Packaging] Updated delvewheel install command and updated flags used with delvewheel repair

### DIFF
--- a/ci/scripts/python_wheel_validate_contents.py
+++ b/ci/scripts/python_wheel_validate_contents.py
@@ -29,7 +29,7 @@ def validate_wheel(path):
     f = zipfile.ZipFile(wheels[0])
     outliers = [
         info.filename for info in f.filelist if not re.match(
-            r'(pyarrow/|pyarrow-[-.\w\d]+\.dist-info/)', info.filename
+            r'(pyarrow/|pyarrow-[-.\w\d]+\.dist-info/|pyarrow\.libs/)', info.filename
         )
     ]
     assert not outliers, f"Unexpected contents in wheel: {sorted(outliers)}"

--- a/ci/scripts/python_wheel_windows_build.bat
+++ b/ci/scripts/python_wheel_windows_build.bat
@@ -144,16 +144,13 @@ cp C:\Windows\System32\msvcp140.dll pyarrow\
 @REM Since we bundled the Arrow C++ libraries ourselves, we only need to
 @REM mangle msvcp140.dll so as to avoid ABI issues when msvcp140.dll is
 @REM required by multiple Python libraries in the same process.
-@REM
-@REM For now this requires a custom version of delvewheel:
-@REM https://github.com/adang1345/delvewheel/pull/59
-%PYTHON_CMD% -m pip install https://github.com/pitrou/delvewheel/archive/refs/heads/fixes-for-arrow.zip || exit /B 1
+%PYTHON_CMD% -m pip install delvewheel || exit /B 1
 
 for /f %%i in ('dir dist\pyarrow-*.whl /B') do (set WHEEL_NAME=%cd%\dist\%%i) || exit /B 1
 echo "Wheel name: %WHEEL_NAME%"
 
 %PYTHON_CMD% -m delvewheel repair -vv ^
-    --mangle-only=msvcp140.dll --no-patch ^
+    --ignore-existing --with-mangle=msvcp140.dll ^
     -w repaired_wheels %WHEEL_NAME% || exit /B 1
 
 popd

--- a/ci/scripts/python_wheel_windows_build.bat
+++ b/ci/scripts/python_wheel_windows_build.bat
@@ -27,11 +27,6 @@ py -0p
 call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat"
 @echo on
 
-@REM Install a more recent msvcp140.dll in C:\Windows\System32
-choco install -r -y --no-progress vcredist140
-choco upgrade -r -y --no-progress vcredist140
-dir C:\Windows\System32\msvcp140.dll
-
 echo "=== (%PYTHON%) Clear output directories and leftovers ==="
 del /s /q C:\arrow-build
 del /s /q C:\arrow-dist

--- a/ci/scripts/python_wheel_windows_build.bat
+++ b/ci/scripts/python_wheel_windows_build.bat
@@ -150,7 +150,7 @@ for /f %%i in ('dir dist\pyarrow-*.whl /B') do (set WHEEL_NAME=%cd%\dist\%%i) ||
 echo "Wheel name: %WHEEL_NAME%"
 
 %PYTHON_CMD% -m delvewheel repair -vv ^
-    --ignore-existing --with-mangle=msvcp140.dll ^
+    --ignore-existing --with-mangle ^
     -w repaired_wheels %WHEEL_NAME% || exit /B 1
 
 popd

--- a/ci/scripts/python_wheel_windows_build.bat
+++ b/ci/scripts/python_wheel_windows_build.bat
@@ -133,9 +133,6 @@ set CMAKE_PREFIX_PATH=C:\arrow-dist
 
 pushd C:\arrow\python
 
-@REM Bundle the C++ runtime
-cp C:\Windows\System32\msvcp140.dll pyarrow\
-
 @REM Build wheel
 %PYTHON_CMD% setup.py bdist_wheel || exit /B 1
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

It is already explained in the issue.

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

This PR installs delvewheel by using its latest version instead of using a github branch. The new flag `--with-mangle` introduced in the latest version of delvewheel is used with `delvewheel repair` command. Removed comments that referred to the use of the github branch for delvewheel installation.

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

No, these changes are not tested because to run Windows containers I will need [Windows 11 Pro or Enterprise](https://docs.docker.com/desktop/setup/install/windows-install/#:~:text=To%20run%20Windows%20containers%2C%20you%20need%20Windows%2010%20or%20Windows%2011%20Professional%20or%20Enterprise%20edition.%20Windows%20Home%20or%20Education%20editions%20only%20allow%20you%20to%20run%20Linux%20containers.). I do not have a machine that satisfies this requirement. 

<!-- ### Are there any user-facing changes? -->

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #45278