### PR TITLE
GH-37630: [C++][Python][Dataset] Allow disabling fragment metadata caching

### DIFF
--- a/cpp/src/arrow/acero/options.h
+++ b/cpp/src/arrow/acero/options.h
@@ -29,10 +29,8 @@
 #include "arrow/compute/api_vector.h"
 #include "arrow/compute/exec.h"
 #include "arrow/compute/expression.h"
-#include "arrow/record_batch.h"
 #include "arrow/result.h"
-#include "arrow/util/async_generator.h"
-#include "arrow/util/async_util.h"
+#include "arrow/util/future.h"
 
 namespace arrow {
 
@@ -55,7 +53,7 @@ namespace acero {
 /// \brief This must not be used in release-mode
 struct DebugOptions;
 
-using AsyncExecBatchGenerator = AsyncGenerator<std::optional<ExecBatch>>;
+using AsyncExecBatchGenerator = std::function<Future<std::optional<ExecBatch>>()>;
 
 /// \addtogroup acero-nodes
 /// @{

--- a/cpp/src/arrow/acero/source_node_test.cc
+++ b/cpp/src/arrow/acero/source_node_test.cc
@@ -21,6 +21,7 @@
 #include "arrow/acero/map_node.h"
 #include "arrow/acero/options.h"
 #include "arrow/acero/test_nodes.h"
+#include "arrow/record_batch.h"
 
 namespace arrow {
 namespace acero {

--- a/cpp/src/arrow/dataset/dataset.cc
+++ b/cpp/src/arrow/dataset/dataset.cc
@@ -21,6 +21,7 @@
 #include "arrow/acero/util.h"
 #include "arrow/dataset/dataset.h"
 #include "arrow/dataset/dataset_internal.h"
+#include "arrow/dataset/projector.h"
 #include "arrow/dataset/scanner.h"
 #include "arrow/table.h"
 #include "arrow/util/async_generator.h"
@@ -41,7 +42,7 @@ const compute::Expression Fragment::kNoPartitionInformation = compute::literal(t
 Fragment::Fragment(compute::Expression partition_expression,
                    std::shared_ptr<Schema> physical_schema)
     : partition_expression_(std::move(partition_expression)),
-      physical_schema_(std::move(physical_schema)) {}
+      given_physical_schema_(std::move(physical_schema)) {}
 
 Future<std::shared_ptr<InspectedFragment>> Fragment::InspectFragment(
     const FragmentScanOptions* format_options, compute::ExecContext* exec_context) {
@@ -75,8 +76,13 @@ Future<std::optional<int64_t>> Fragment::CountRows(compute::Expression,
   return Future<std::optional<int64_t>>::MakeFinished(std::nullopt);
 }
 
+Status Fragment::ClearCachedMetadata() {
+  physical_schema_.reset();
+  return Status::OK();
+}
+
 Result<std::shared_ptr<Schema>> InMemoryFragment::ReadPhysicalSchemaImpl() {
-  return physical_schema_;
+  return given_physical_schema_;
 }
 
 InMemoryFragment::InMemoryFragment(std::shared_ptr<Schema> schema,
@@ -84,7 +90,8 @@ InMemoryFragment::InMemoryFragment(std::shared_ptr<Schema> schema,
                                    compute::Expression partition_expression)
     : Fragment(std::move(partition_expression), std::move(schema)),
       record_batches_(std::move(record_batches)) {
-  DCHECK_NE(physical_schema_, nullptr);
+  DCHECK_NE(given_physical_schema_, nullptr);
+  physical_schema_ = given_physical_schema_;
 }
 
 InMemoryFragment::InMemoryFragment(RecordBatchVector record_batches,

--- a/cpp/src/arrow/dataset/dataset.cc
+++ b/cpp/src/arrow/dataset/dataset.cc
@@ -77,6 +77,7 @@ Future<std::optional<int64_t>> Fragment::CountRows(compute::Expression,
 }
 
 Status Fragment::ClearCachedMetadata() {
+  auto lock = physical_schema_mutex_.Lock();
   physical_schema_.reset();
   return Status::OK();
 }

--- a/cpp/src/arrow/dataset/dataset.h
+++ b/cpp/src/arrow/dataset/dataset.h
@@ -190,6 +190,13 @@ class ARROW_DS_EXPORT Fragment : public std::enable_shared_from_this<Fragment> {
   virtual Future<std::optional<int64_t>> CountRows(
       compute::Expression predicate, const std::shared_ptr<ScanOptions>& options);
 
+  /// \brief Clear any metadata that may have been cached by this object.
+  ///
+  /// A fragment may typically cache metadata to speed up repeated accesses.
+  /// In use cases when memory use is more critical than CPU time, calling
+  /// this function can help reclaim memory.
+  virtual Status ClearCachedMetadata();
+
   virtual std::string type_name() const = 0;
   virtual std::string ToString() const { return type_name(); }
 
@@ -210,7 +217,10 @@ class ARROW_DS_EXPORT Fragment : public std::enable_shared_from_this<Fragment> {
 
   util::Mutex physical_schema_mutex_;
   compute::Expression partition_expression_ = compute::literal(true);
+  // The physical schema that is inferred from the Fragment
   std::shared_ptr<Schema> physical_schema_;
+  // The physical schema that was passed to the Fragment constructor
+  std::shared_ptr<Schema> given_physical_schema_;
 };
 
 /// \brief Per-scan options for fragment(s) in a dataset.

--- a/cpp/src/arrow/dataset/dataset_test.cc
+++ b/cpp/src/arrow/dataset/dataset_test.cc
@@ -22,6 +22,7 @@
 #include "arrow/dataset/dataset_internal.h"
 #include "arrow/dataset/discovery.h"
 #include "arrow/dataset/partition.h"
+#include "arrow/dataset/projector.h"
 #include "arrow/dataset/test_util_internal.h"
 #include "arrow/filesystem/mockfs.h"
 #include "arrow/stl.h"

--- a/cpp/src/arrow/dataset/discovery.cc
+++ b/cpp/src/arrow/dataset/discovery.cc
@@ -29,6 +29,7 @@
 #include "arrow/dataset/partition.h"
 #include "arrow/dataset/type_fwd.h"
 #include "arrow/filesystem/path_util.h"
+#include "arrow/record_batch.h"
 #include "arrow/util/logging.h"
 #include "arrow/util/string.h"
 

--- a/cpp/src/arrow/dataset/file_base.cc
+++ b/cpp/src/arrow/dataset/file_base.cc
@@ -33,6 +33,7 @@
 #include "arrow/dataset/dataset_internal.h"
 #include "arrow/dataset/dataset_writer.h"
 #include "arrow/dataset/forest_internal.h"
+#include "arrow/dataset/projector.h"
 #include "arrow/dataset/scanner.h"
 #include "arrow/dataset/subtree_internal.h"
 #include "arrow/filesystem/filesystem.h"

--- a/cpp/src/arrow/dataset/file_parquet.cc
+++ b/cpp/src/arrow/dataset/file_parquet.cc
@@ -802,15 +802,12 @@ Status ParquetFileFragment::EnsureCompleteMetadata(parquet::arrow::FileReader* r
     return EnsureCompleteMetadata(reader.get());
   }
 
-  // TODO temp variable is useless
-  std::shared_ptr<Schema> schema;
-  RETURN_NOT_OK(reader->GetSchema(&schema));
-  if (given_physical_schema_ && !given_physical_schema_->Equals(*schema)) {
+  RETURN_NOT_OK(reader->GetSchema(&physical_schema_));
+  if (given_physical_schema_ && !given_physical_schema_->Equals(*physical_schema_)) {
     return Status::Invalid("Fragment initialized with physical schema ",
                            *given_physical_schema_, " but ", source_.path(),
-                           " has schema ", *schema);
+                           " has schema ", *physical_schema_);
   }
-  physical_schema_ = std::move(schema);
 
   if (!row_groups_) {
     row_groups_ = Iota(reader->num_row_groups());

--- a/cpp/src/arrow/dataset/file_parquet.h
+++ b/cpp/src/arrow/dataset/file_parquet.h
@@ -165,10 +165,15 @@ class ARROW_DS_EXPORT ParquetFileFragment : public FileFragment {
   }
 
   /// \brief Return the FileMetaData associated with this fragment.
+  ///
+  /// This may return nullptr if the fragment wasn't scanned yet, or if
+  /// `ScanOptions::cache_metadata` was disabled.
   std::shared_ptr<parquet::FileMetaData> metadata();
 
   /// \brief Ensure this fragment's FileMetaData is in memory.
   Status EnsureCompleteMetadata(parquet::arrow::FileReader* reader = NULLPTR);
+
+  Status ClearCachedMetadata() override;
 
   /// \brief Return fragment which selects a filtered subset of this fragment's RowGroups.
   Result<std::shared_ptr<Fragment>> Subset(compute::Expression predicate);

--- a/cpp/src/arrow/dataset/scanner_test.cc
+++ b/cpp/src/arrow/dataset/scanner_test.cc
@@ -929,6 +929,7 @@ class ClearCachedMetadataFragment : public InMemoryFragment {
   using InMemoryFragment::InMemoryFragment;
 
   Status ClearCachedMetadata() override {
+    RETURN_NOT_OK(InMemoryFragment::ClearCachedMetadata());
     metadata_clear_count_.fetch_add(1);
     return Status::OK();
   }

--- a/cpp/src/arrow/dataset/scanner_test.cc
+++ b/cpp/src/arrow/dataset/scanner_test.cc
@@ -17,6 +17,7 @@
 
 #include "arrow/dataset/scanner.h"
 
+#include <atomic>
 #include <memory>
 #include <mutex>
 #include <utility>
@@ -269,8 +270,8 @@ struct MockFragment : public Fragment {
   std::string type_name() const override { return "mock"; }
 
   Result<std::shared_ptr<Schema>> ReadPhysicalSchemaImpl() override {
-    return physical_schema_;
-  };
+    return given_physical_schema_;
+  }
 
   // ### Unit Test API ###
 
@@ -922,6 +923,22 @@ std::ostream& operator<<(std::ostream& out, const TestScannerParams& params) {
   return out;
 }
 
+// An InMemoryFragment subclass that tracks the calls to ClearCachedMetadata()
+class ClearCachedMetadataFragment : public InMemoryFragment {
+ public:
+  using InMemoryFragment::InMemoryFragment;
+
+  Status ClearCachedMetadata() override {
+    metadata_clear_count_.fetch_add(1);
+    return Status::OK();
+  }
+
+  int metadata_clear_count() const { return metadata_clear_count_.load(); }
+
+ protected:
+  std::atomic<int> metadata_clear_count_{0};
+};
+
 class TestScanner : public DatasetFixtureMixinWithParam<TestScannerParams> {
  protected:
   std::shared_ptr<Scanner> MakeScanner(std::shared_ptr<Dataset> dataset) {
@@ -977,6 +994,39 @@ class TestScanner : public DatasetFixtureMixinWithParam<TestScannerParams> {
     auto expected = ConstantArrayGenerator::Repeat(total_batches, batch);
 
     AssertScanBatchesUnorderedEquals(expected.get(), scanner.get(), 1);
+  }
+
+  void TestCacheMetadata(std::function<Status(Scanner*)> consume_scanner) {
+    // Test that ClearCachedMetadata() is called if ScanOptions::cache_metadata is false.
+    SetSchema({field("i32", int32())});
+    auto batch = ConstantArrayGenerator::Zeroes(GetParam().items_per_batch, schema_);
+    RecordBatchVector batches{batch, batch};
+    auto frag1 = std::make_shared<ClearCachedMetadataFragment>(batches);
+    auto frag2 = std::make_shared<ClearCachedMetadataFragment>(batches);
+    auto check_metadata_clear_counts = [&](const std::vector<int>& expected) {
+      auto actual =
+          std::vector<int>{frag1->metadata_clear_count(), frag2->metadata_clear_count()};
+      ASSERT_EQ(expected, actual);
+    };
+    {
+      ScannerBuilder builder(
+          std::make_shared<FragmentDataset>(schema_, FragmentVector{frag1, frag2}),
+          options_);
+      ASSERT_OK(builder.UseThreads(GetParam().use_threads));
+      ASSERT_OK_AND_ASSIGN(auto scanner, builder.Finish());
+      ASSERT_OK(consume_scanner(scanner.get()));
+      check_metadata_clear_counts({0, 0});
+    }
+    options_->cache_metadata = false;
+    {
+      ScannerBuilder builder(
+          std::make_shared<FragmentDataset>(schema_, FragmentVector{frag1, frag2}),
+          options_);
+      ASSERT_OK(builder.UseThreads(GetParam().use_threads));
+      ASSERT_OK_AND_ASSIGN(auto scanner, builder.Finish());
+      ASSERT_OK(consume_scanner(scanner.get()));
+      check_metadata_clear_counts({1, 1});
+    }
   }
 };
 
@@ -1329,6 +1379,22 @@ TEST_P(TestScanner, EmptyFragment) {
   AssertTablesEqual(*expected, *actual, /*same_chunk_layout=*/false);
 }
 
+TEST_P(TestScanner, CacheMetadataScanBatches) {
+  auto consume_scanner = [](Scanner* scanner) -> Status {
+    ARROW_ASSIGN_OR_RAISE(auto batches_it, scanner->ScanBatches());
+    return batches_it.ToVector().status();
+  };
+  TestCacheMetadata(consume_scanner);
+}
+
+TEST_P(TestScanner, CacheMetadataScanBatchesUnordered) {
+  auto consume_scanner = [](Scanner* scanner) -> Status {
+    ARROW_ASSIGN_OR_RAISE(auto batches_it, scanner->ScanBatchesUnordered());
+    return batches_it.ToVector().status();
+  };
+  TestCacheMetadata(consume_scanner);
+}
+
 class CountRowsOnlyFragment : public InMemoryFragment {
  public:
   using InMemoryFragment::InMemoryFragment;
@@ -1644,7 +1710,7 @@ class ControlledFragment : public Fragment {
         tracking_generator_(record_batch_generator_) {}
 
   Result<std::shared_ptr<Schema>> ReadPhysicalSchemaImpl() override {
-    return physical_schema_;
+    return given_physical_schema_;
   }
   std::string type_name() const override { return "scanner_test.cc::ControlledFragment"; }
 
@@ -1657,7 +1723,7 @@ class ControlledFragment : public Fragment {
 
   void Finish() { ARROW_UNUSED(record_batch_generator_.producer().Close()); }
   void DeliverBatch(uint32_t num_rows) {
-    auto batch = ConstantArrayGenerator::Zeroes(num_rows, physical_schema_);
+    auto batch = ConstantArrayGenerator::Zeroes(num_rows, given_physical_schema_);
     record_batch_generator_.producer().Push(std::move(batch));
   }
 

--- a/cpp/src/arrow/engine/substrait/util.cc
+++ b/cpp/src/arrow/engine/substrait/util.cc
@@ -31,6 +31,7 @@
 #include "arrow/engine/substrait/relation.h"
 #include "arrow/engine/substrait/serde.h"
 #include "arrow/engine/substrait/type_fwd.h"
+#include "arrow/record_batch.h"
 #include "arrow/status.h"
 #include "arrow/type_fwd.h"
 #include "arrow/util/async_generator.h"

--- a/cpp/src/arrow/io/test_common.cc
+++ b/cpp/src/arrow/io/test_common.cc
@@ -158,6 +158,8 @@ class TrackedRandomAccessFileImpl : public TrackedRandomAccessFile {
     return read_ranges_;
   }
 
+  void ResetStats() override { read_ranges_.clear(); }
+
  private:
   io::RandomAccessFile* delegate_;
   std::vector<io::ReadRange> read_ranges_;

--- a/cpp/src/arrow/io/test_common.h
+++ b/cpp/src/arrow/io/test_common.h
@@ -60,6 +60,8 @@ class ARROW_TESTING_EXPORT TrackedRandomAccessFile : public io::RandomAccessFile
   virtual int64_t num_reads() const = 0;
   virtual int64_t bytes_read() const = 0;
   virtual const std::vector<io::ReadRange>& get_read_ranges() const = 0;
+  virtual void ResetStats() = 0;
+
   static std::unique_ptr<TrackedRandomAccessFile> Make(io::RandomAccessFile* target);
 };
 

--- a/cpp/src/arrow/util/async_generator.h
+++ b/cpp/src/arrow/util/async_generator.h
@@ -1489,19 +1489,6 @@ AsyncGenerator<T> MakeConcatenatedGenerator(AsyncGenerator<AsyncGenerator<T>> so
   return MergedGenerator<T>(std::move(source), 1);
 }
 
-template <typename T>
-struct Enumerated {
-  T value;
-  int index;
-  bool last;
-};
-
-template <typename T>
-struct IterationTraits<Enumerated<T>> {
-  static Enumerated<T> End() { return Enumerated<T>{IterationEnd<T>(), -1, false}; }
-  static bool IsEnd(const Enumerated<T>& val) { return val.index < 0; }
-};
-
 /// \see MakeEnumeratedGenerator
 template <typename T>
 class EnumeratingGenerator {

--- a/cpp/src/arrow/util/async_generator_fwd.h
+++ b/cpp/src/arrow/util/async_generator_fwd.h
@@ -20,6 +20,7 @@
 #include <functional>
 
 #include "arrow/type_fwd.h"
+#include "arrow/util/type_fwd.h"
 
 namespace arrow {
 
@@ -46,9 +47,6 @@ class PushGenerator;
 
 template <typename T>
 class MergedGenerator;
-
-template <typename T>
-struct Enumerated;
 
 template <typename T>
 class EnumeratingGenerator;

--- a/cpp/src/arrow/util/iterator.h
+++ b/cpp/src/arrow/util/iterator.h
@@ -31,6 +31,7 @@
 #include "arrow/util/compare.h"
 #include "arrow/util/functional.h"
 #include "arrow/util/macros.h"
+#include "arrow/util/type_fwd.h"
 #include "arrow/util/visibility.h"
 
 namespace arrow {
@@ -80,6 +81,12 @@ struct IterationTraits<std::optional<T>> {
   // TODO(bkietz) The range-for loop over Iterator<optional<T>> yields
   // Result<optional<T>> which is unnecessary (since only the unyielded end optional
   // is nullopt. Add IterationTraits::GetRangeElement() to handle this case
+};
+
+template <typename T>
+struct IterationTraits<Enumerated<T>> {
+  static Enumerated<T> End() { return Enumerated<T>{IterationEnd<T>(), -1, false}; }
+  static bool IsEnd(const Enumerated<T>& val) { return val.index < 0; }
 };
 
 /// \brief A generic Iterator that can return errors

--- a/cpp/src/arrow/util/type_fwd.h
+++ b/cpp/src/arrow/util/type_fwd.h
@@ -67,4 +67,16 @@ class Codec;
 class Uri;
 }  // namespace util
 
+template <typename T>
+struct Enumerated {
+  T value;
+  int index;
+  bool last;
+
+  friend inline bool operator==(const Enumerated<T>& left, const Enumerated<T>& right) {
+    return left.index == right.index && left.last == right.last &&
+           left.value == right.value;
+  }
+};
+
 }  // namespace arrow

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -300,6 +300,7 @@ cdef class Dataset(_Weakrefable):
                 int fragment_readahead=_DEFAULT_FRAGMENT_READAHEAD,
                 FragmentScanOptions fragment_scan_options=None,
                 bint use_threads=True,
+                bint cache_metadata=True,
                 MemoryPool memory_pool=None):
         """
         Build a scan operation against the dataset.
@@ -354,6 +355,9 @@ cdef class Dataset(_Weakrefable):
         use_threads : bool, default True
             If enabled, then maximum parallelism will be used determined by
             the number of available CPU cores.
+        cache_metadata : bool, default True
+            If enabled, metadata may be cached when scanning to speed up
+            repeated scans.
         memory_pool : MemoryPool, default None
             For memory allocations, if required. If not specified, uses the
             default pool.
@@ -417,6 +421,7 @@ cdef class Dataset(_Weakrefable):
             fragment_readahead=fragment_readahead,
             fragment_scan_options=fragment_scan_options,
             use_threads=use_threads,
+            cache_metadata=cache_metadata,
             memory_pool=memory_pool
         )
 
@@ -428,6 +433,7 @@ cdef class Dataset(_Weakrefable):
                    int fragment_readahead=_DEFAULT_FRAGMENT_READAHEAD,
                    FragmentScanOptions fragment_scan_options=None,
                    bint use_threads=True,
+                   bint cache_metadata=True,
                    MemoryPool memory_pool=None):
         """
         Read the dataset as materialized record batches.
@@ -476,6 +482,9 @@ cdef class Dataset(_Weakrefable):
         use_threads : bool, default True
             If enabled, then maximum parallelism will be used determined by
             the number of available CPU cores.
+        cache_metadata : bool, default True
+            If enabled, metadata may be cached when scanning to speed up
+            repeated scans.
         memory_pool : MemoryPool, default None
             For memory allocations, if required. If not specified, uses the
             default pool.
@@ -492,6 +501,7 @@ cdef class Dataset(_Weakrefable):
             fragment_readahead=fragment_readahead,
             fragment_scan_options=fragment_scan_options,
             use_threads=use_threads,
+            cache_metadata=cache_metadata,
             memory_pool=memory_pool
         ).to_batches()
 
@@ -503,6 +513,7 @@ cdef class Dataset(_Weakrefable):
                  int fragment_readahead=_DEFAULT_FRAGMENT_READAHEAD,
                  FragmentScanOptions fragment_scan_options=None,
                  bint use_threads=True,
+                 bint cache_metadata=True,
                  MemoryPool memory_pool=None):
         """
         Read the dataset to an Arrow table.
@@ -554,6 +565,9 @@ cdef class Dataset(_Weakrefable):
         use_threads : bool, default True
             If enabled, then maximum parallelism will be used determined by
             the number of available CPU cores.
+        cache_metadata : bool, default True
+            If enabled, metadata may be cached when scanning to speed up
+            repeated scans.
         memory_pool : MemoryPool, default None
             For memory allocations, if required. If not specified, uses the
             default pool.
@@ -570,6 +584,7 @@ cdef class Dataset(_Weakrefable):
             fragment_readahead=fragment_readahead,
             fragment_scan_options=fragment_scan_options,
             use_threads=use_threads,
+            cache_metadata=cache_metadata,
             memory_pool=memory_pool
         ).to_table()
 
@@ -582,6 +597,7 @@ cdef class Dataset(_Weakrefable):
              int fragment_readahead=_DEFAULT_FRAGMENT_READAHEAD,
              FragmentScanOptions fragment_scan_options=None,
              bint use_threads=True,
+             bint cache_metadata=True,
              MemoryPool memory_pool=None):
         """
         Select rows of data by index.
@@ -632,6 +648,9 @@ cdef class Dataset(_Weakrefable):
         use_threads : bool, default True
             If enabled, then maximum parallelism will be used determined by
             the number of available CPU cores.
+        cache_metadata : bool, default True
+            If enabled, metadata may be cached when scanning to speed up
+            repeated scans.
         memory_pool : MemoryPool, default None
             For memory allocations, if required. If not specified, uses the
             default pool.
@@ -648,6 +667,7 @@ cdef class Dataset(_Weakrefable):
             fragment_readahead=fragment_readahead,
             fragment_scan_options=fragment_scan_options,
             use_threads=use_threads,
+            cache_metadata=cache_metadata,
             memory_pool=memory_pool
         ).take(indices)
 
@@ -660,6 +680,7 @@ cdef class Dataset(_Weakrefable):
              int fragment_readahead=_DEFAULT_FRAGMENT_READAHEAD,
              FragmentScanOptions fragment_scan_options=None,
              bint use_threads=True,
+             bint cache_metadata=True,
              MemoryPool memory_pool=None):
         """
         Load the first N rows of the dataset.
@@ -710,6 +731,9 @@ cdef class Dataset(_Weakrefable):
         use_threads : bool, default True
             If enabled, then maximum parallelism will be used determined by
             the number of available CPU cores.
+        cache_metadata : bool, default True
+            If enabled, metadata may be cached when scanning to speed up
+            repeated scans.
         memory_pool : MemoryPool, default None
             For memory allocations, if required. If not specified, uses the
             default pool.
@@ -726,6 +750,7 @@ cdef class Dataset(_Weakrefable):
             fragment_readahead=fragment_readahead,
             fragment_scan_options=fragment_scan_options,
             use_threads=use_threads,
+            cache_metadata=cache_metadata,
             memory_pool=memory_pool
         ).head(num_rows)
 
@@ -736,6 +761,7 @@ cdef class Dataset(_Weakrefable):
                    int fragment_readahead=_DEFAULT_FRAGMENT_READAHEAD,
                    FragmentScanOptions fragment_scan_options=None,
                    bint use_threads=True,
+                   bint cache_metadata=True,
                    MemoryPool memory_pool=None):
         """
         Count rows matching the scanner filter.
@@ -765,6 +791,9 @@ cdef class Dataset(_Weakrefable):
         use_threads : bool, default True
             If enabled, then maximum parallelism will be used determined by
             the number of available CPU cores.
+        cache_metadata : bool, default True
+            If enabled, metadata may be cached when scanning to speed up
+            repeated scans.
         memory_pool : MemoryPool, default None
             For memory allocations, if required. If not specified, uses the
             default pool.
@@ -780,6 +809,7 @@ cdef class Dataset(_Weakrefable):
             fragment_readahead=fragment_readahead,
             fragment_scan_options=fragment_scan_options,
             use_threads=use_threads,
+            cache_metadata=cache_metadata,
             memory_pool=memory_pool
         ).count_rows()
 
@@ -1458,6 +1488,7 @@ cdef class Fragment(_Weakrefable):
                 int fragment_readahead=_DEFAULT_FRAGMENT_READAHEAD,
                 FragmentScanOptions fragment_scan_options=None,
                 bint use_threads=True,
+                bint cache_metadata=True,
                 MemoryPool memory_pool=None):
         """
         Build a scan operation against the fragment.
@@ -1514,6 +1545,9 @@ cdef class Fragment(_Weakrefable):
         use_threads : bool, default True
             If enabled, then maximum parallelism will be used determined by
             the number of available CPU cores.
+        cache_metadata : bool, default True
+            If enabled, metadata may be cached when scanning to speed up
+            repeated scans.
         memory_pool : MemoryPool, default None
             For memory allocations, if required. If not specified, uses the
             default pool.
@@ -1532,6 +1566,7 @@ cdef class Fragment(_Weakrefable):
             fragment_readahead=fragment_readahead,
             fragment_scan_options=fragment_scan_options,
             use_threads=use_threads,
+            cache_metadata=cache_metadata,
             memory_pool=memory_pool
         )
 
@@ -1544,6 +1579,7 @@ cdef class Fragment(_Weakrefable):
                    int fragment_readahead=_DEFAULT_FRAGMENT_READAHEAD,
                    FragmentScanOptions fragment_scan_options=None,
                    bint use_threads=True,
+                   bint cache_metadata=True,
                    MemoryPool memory_pool=None):
         """
         Read the fragment as materialized record batches.
@@ -1594,6 +1630,9 @@ cdef class Fragment(_Weakrefable):
         use_threads : bool, default True
             If enabled, then maximum parallelism will be used determined by
             the number of available CPU cores.
+        cache_metadata : bool, default True
+            If enabled, metadata may be cached when scanning to speed up
+            repeated scans.
         memory_pool : MemoryPool, default None
             For memory allocations, if required. If not specified, uses the
             default pool.
@@ -1612,6 +1651,7 @@ cdef class Fragment(_Weakrefable):
             fragment_readahead=fragment_readahead,
             fragment_scan_options=fragment_scan_options,
             use_threads=use_threads,
+            cache_metadata=cache_metadata,
             memory_pool=memory_pool
         ).to_batches()
 
@@ -1624,6 +1664,7 @@ cdef class Fragment(_Weakrefable):
                  int fragment_readahead=_DEFAULT_FRAGMENT_READAHEAD,
                  FragmentScanOptions fragment_scan_options=None,
                  bint use_threads=True,
+                 bint cache_metadata=True,
                  MemoryPool memory_pool=None):
         """
         Convert this Fragment into a Table.
@@ -1677,6 +1718,9 @@ cdef class Fragment(_Weakrefable):
         use_threads : bool, default True
             If enabled, then maximum parallelism will be used determined by
             the number of available CPU cores.
+        cache_metadata : bool, default True
+            If enabled, metadata may be cached when scanning to speed up
+            repeated scans.
         memory_pool : MemoryPool, default None
             For memory allocations, if required. If not specified, uses the
             default pool.
@@ -1694,6 +1738,7 @@ cdef class Fragment(_Weakrefable):
             fragment_readahead=fragment_readahead,
             fragment_scan_options=fragment_scan_options,
             use_threads=use_threads,
+            cache_metadata=cache_metadata,
             memory_pool=memory_pool
         ).to_table()
 
@@ -1706,6 +1751,7 @@ cdef class Fragment(_Weakrefable):
              int fragment_readahead=_DEFAULT_FRAGMENT_READAHEAD,
              FragmentScanOptions fragment_scan_options=None,
              bint use_threads=True,
+             bint cache_metadata=True,
              MemoryPool memory_pool=None):
         """
         Select rows of data by index.
@@ -1756,6 +1802,9 @@ cdef class Fragment(_Weakrefable):
         use_threads : bool, default True
             If enabled, then maximum parallelism will be used determined by
             the number of available CPU cores.
+        cache_metadata : bool, default True
+            If enabled, metadata may be cached when scanning to speed up
+            repeated scans.
         memory_pool : MemoryPool, default None
             For memory allocations, if required. If not specified, uses the
             default pool.
@@ -1772,6 +1821,7 @@ cdef class Fragment(_Weakrefable):
             fragment_readahead=fragment_readahead,
             fragment_scan_options=fragment_scan_options,
             use_threads=use_threads,
+            cache_metadata=cache_metadata,
             memory_pool=memory_pool
         ).take(indices)
 
@@ -1784,6 +1834,7 @@ cdef class Fragment(_Weakrefable):
              int fragment_readahead=_DEFAULT_FRAGMENT_READAHEAD,
              FragmentScanOptions fragment_scan_options=None,
              bint use_threads=True,
+             bint cache_metadata=True,
              MemoryPool memory_pool=None):
         """
         Load the first N rows of the fragment.
@@ -1834,6 +1885,9 @@ cdef class Fragment(_Weakrefable):
         use_threads : bool, default True
             If enabled, then maximum parallelism will be used determined by
             the number of available CPU cores.
+        cache_metadata : bool, default True
+            If enabled, metadata may be cached when scanning to speed up
+            repeated scans.
         memory_pool : MemoryPool, default None
             For memory allocations, if required. If not specified, uses the
             default pool.
@@ -1850,6 +1904,7 @@ cdef class Fragment(_Weakrefable):
             fragment_readahead=fragment_readahead,
             fragment_scan_options=fragment_scan_options,
             use_threads=use_threads,
+            cache_metadata=cache_metadata,
             memory_pool=memory_pool
         ).head(num_rows)
 
@@ -1860,6 +1915,7 @@ cdef class Fragment(_Weakrefable):
                    int fragment_readahead=_DEFAULT_FRAGMENT_READAHEAD,
                    FragmentScanOptions fragment_scan_options=None,
                    bint use_threads=True,
+                   bint cache_metadata=True,
                    MemoryPool memory_pool=None):
         """
         Count rows matching the scanner filter.
@@ -1889,6 +1945,9 @@ cdef class Fragment(_Weakrefable):
         use_threads : bool, default True
             If enabled, then maximum parallelism will be used determined by
             the number of available CPU cores.
+        cache_metadata : bool, default True
+            If enabled, metadata may be cached when scanning to speed up
+            repeated scans.
         memory_pool : MemoryPool, default None
             For memory allocations, if required. If not specified, uses the
             default pool.
@@ -1904,6 +1963,7 @@ cdef class Fragment(_Weakrefable):
             fragment_readahead=fragment_readahead,
             fragment_scan_options=fragment_scan_options,
             use_threads=use_threads,
+            cache_metadata=cache_metadata,
             memory_pool=memory_pool
         ).count_rows()
 
@@ -2519,7 +2579,7 @@ cdef class Partitioning(_Weakrefable):
 
     def format(self, expr):
         """
-        Convert a filter expression into a tuple of (directory, filename) using 
+        Convert a filter expression into a tuple of (directory, filename) using
         the current partitioning scheme
 
         Parameters
@@ -3446,7 +3506,8 @@ cdef void _populate_builder(const shared_ptr[CScannerBuilder]& ptr,
                             int batch_size=_DEFAULT_BATCH_SIZE,
                             int batch_readahead=_DEFAULT_BATCH_READAHEAD,
                             int fragment_readahead=_DEFAULT_FRAGMENT_READAHEAD,
-                            bint use_threads=True, MemoryPool memory_pool=None,
+                            bint use_threads=True, bint cache_metadata=True,
+                            MemoryPool memory_pool=None,
                             FragmentScanOptions fragment_scan_options=None)\
         except *:
     cdef:
@@ -3486,6 +3547,7 @@ cdef void _populate_builder(const shared_ptr[CScannerBuilder]& ptr,
     check_status(builder.BatchReadahead(batch_readahead))
     check_status(builder.FragmentReadahead(fragment_readahead))
     check_status(builder.UseThreads(use_threads))
+    check_status(builder.CacheMetadata(cache_metadata))
     check_status(builder.Pool(maybe_unbox_memory_pool(memory_pool)))
     if fragment_scan_options:
         check_status(
@@ -3534,6 +3596,7 @@ cdef class Scanner(_Weakrefable):
             fragment_readahead=py_scanoptions.get(
                 "fragment_readahead", _DEFAULT_FRAGMENT_READAHEAD),
             use_threads=py_scanoptions.get("use_threads", True),
+            cache_metadata=py_scanoptions.get("cache_metadata", True),
             memory_pool=py_scanoptions.get("memory_pool"),
             fragment_scan_options=py_scanoptions.get("fragment_scan_options"))
 
@@ -3547,7 +3610,8 @@ cdef class Scanner(_Weakrefable):
                      int batch_readahead=_DEFAULT_BATCH_READAHEAD,
                      int fragment_readahead=_DEFAULT_FRAGMENT_READAHEAD,
                      FragmentScanOptions fragment_scan_options=None,
-                     bint use_threads=True, MemoryPool memory_pool=None):
+                     bint use_threads=True, bint cache_metadata=True,
+                     MemoryPool memory_pool=None):
         """
         Create Scanner from Dataset,
 
@@ -3597,6 +3661,9 @@ cdef class Scanner(_Weakrefable):
         use_threads : bool, default True
             If enabled, then maximum parallelism will be used determined by
             the number of available CPU cores.
+        cache_metadata : bool, default True
+            If enabled, metadata may be cached when scanning to speed up
+            repeated scans.
         memory_pool : MemoryPool, default None
             For memory allocations, if required. If not specified, uses the
             default pool.
@@ -3611,7 +3678,8 @@ cdef class Scanner(_Weakrefable):
             dict(columns=columns, filter=filter, batch_size=batch_size,
                  batch_readahead=batch_readahead,
                  fragment_readahead=fragment_readahead, use_threads=use_threads,
-                 memory_pool=memory_pool, fragment_scan_options=fragment_scan_options)
+                 cache_metadata=cache_metadata, memory_pool=memory_pool,
+                 fragment_scan_options=fragment_scan_options)
         )
         builder = make_shared[CScannerBuilder](dataset.unwrap(), options)
         scanner = GetResultValue(builder.get().Finish())
@@ -3624,7 +3692,8 @@ cdef class Scanner(_Weakrefable):
                       int batch_readahead=_DEFAULT_BATCH_READAHEAD,
                       int fragment_readahead=_DEFAULT_FRAGMENT_READAHEAD,
                       FragmentScanOptions fragment_scan_options=None,
-                      bint use_threads=True, MemoryPool memory_pool=None):
+                      bint use_threads=True, bint cache_metadata=True,
+                      MemoryPool memory_pool=None):
         """
         Create Scanner from Fragment,
 
@@ -3676,6 +3745,9 @@ cdef class Scanner(_Weakrefable):
         use_threads : bool, default True
             If enabled, then maximum parallelism will be used determined by
             the number of available CPU cores.
+        cache_metadata : bool, default True
+            If enabled, metadata may be cached when scanning to speed up
+            repeated scans.
         memory_pool : MemoryPool, default None
             For memory allocations, if required. If not specified, uses the
             default pool.
@@ -3692,7 +3764,7 @@ cdef class Scanner(_Weakrefable):
         _populate_builder(builder, columns=columns, filter=filter,
                           batch_size=batch_size, batch_readahead=batch_readahead,
                           fragment_readahead=fragment_readahead,
-                          use_threads=use_threads,
+                          use_threads=use_threads, cache_metadata=cache_metadata,
                           memory_pool=memory_pool,
                           fragment_scan_options=fragment_scan_options)
 
@@ -3705,7 +3777,8 @@ cdef class Scanner(_Weakrefable):
                      int batch_readahead=_DEFAULT_BATCH_READAHEAD,
                      int fragment_readahead=_DEFAULT_FRAGMENT_READAHEAD,
                      FragmentScanOptions fragment_scan_options=None,
-                     bint use_threads=True, MemoryPool memory_pool=None):
+                     bint use_threads=True, bint cache_metadata=True,
+                     MemoryPool memory_pool=None):
         """
         Create a Scanner from an iterator of batches.
 
@@ -3765,6 +3838,9 @@ cdef class Scanner(_Weakrefable):
         use_threads : bool, default True
             If enabled, then maximum parallelism will be used determined by
             the number of available CPU cores.
+        cache_metadata : bool, default True
+            If enabled, metadata may be cached when scanning to speed up
+            repeated scans.
         memory_pool : MemoryPool, default None
             For memory allocations, if required. If not specified, uses the
             default pool.
@@ -3797,7 +3873,7 @@ cdef class Scanner(_Weakrefable):
         _populate_builder(builder, columns=columns, filter=filter,
                           batch_size=batch_size, batch_readahead=batch_readahead,
                           fragment_readahead=fragment_readahead, use_threads=use_threads,
-                          memory_pool=memory_pool,
+                          cache_metadata=cache_metadata, memory_pool=memory_pool,
                           fragment_scan_options=fragment_scan_options)
         scanner = GetResultValue(builder.get().Finish())
         return Scanner.wrap(scanner)
@@ -4111,7 +4187,7 @@ class ScanNodeOptions(_ScanNodeOptions):
     dataset : pyarrow.dataset.Dataset
         The table which acts as the data source.
     **kwargs : dict, optional
-        Scan options. See `Scanner.from_dataset` for possible arguments.        
+        Scan options. See `Scanner.from_dataset` for possible arguments.
     require_sequenced_output : bool, default False
         Batches are yielded sequentially, like single-threaded
     implicit_ordering : bool, default False

--- a/python/pyarrow/includes/libarrow_dataset.pxd
+++ b/python/pyarrow/includes/libarrow_dataset.pxd
@@ -48,6 +48,7 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
         shared_ptr[CSchema] dataset_schema
         shared_ptr[CSchema] projected_schema
         c_bool use_threads
+        c_bool cache_metadata
         CExpression filter
 
     cdef cppclass CScanNodeOptions "arrow::dataset::ScanNodeOptions"(CExecNodeOptions):
@@ -115,6 +116,7 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
         CStatus Project(vector[CExpression]& exprs, vector[c_string]& columns)
         CStatus Filter(CExpression filter)
         CStatus UseThreads(c_bool use_threads)
+        CStatus CacheMetadata(c_bool cache_metadata)
         CStatus Pool(CMemoryPool* pool)
         CStatus BatchSize(int64_t batch_size)
         CStatus BatchReadahead(int32_t batch_readahead)


### PR DESCRIPTION
### Rationale for this change

Parquet file fragments currently cache their (Parquet) metadata for later accesses when scanning has finished.
This can produce surprisingly high memory consumption in cases where:
1. the dataset is only scanned once, rather than repeatedly (this is very common)
2. there is a high metadata-to-data ratio; this can happen when the schemas on disk are very wide, with few rows per file and/or a low number of columns selected for reading

### What changes are included in this PR?

Add an option to disable metadata caching on Parquet file fragments.

### Are these changes tested?

Yes, by new unit tests. Also, reading a wide dataset locally has been confirmed to consume much less memory when the new option is toggled.

### Are there any user-facing changes?

No.

* GitHub Issue: #37630