### PR TITLE
GH-45300: [R] Remove data.table from class attribute in metadata

### DIFF
--- a/r/R/metadata.R
+++ b/r/R/metadata.R
@@ -228,6 +228,10 @@ apply_arrow_r_metadata <- function(x, r_metadata) {
           attr(x, ".group_vars") <- NULL
           attr(x, ".group_by_drop") <- NULL
         }
+        # GH-45300: Prevent warning about "Invalid .internal.selfref..."
+        if (inherits(x, "data.table") && requireNamespace("data.table", quietly = TRUE)) {
+          data.table::setDT(x)
+        }
       }
     },
     error = function(e) {

--- a/r/tests/testthat/test-metadata.R
+++ b/r/tests/testthat/test-metadata.R
@@ -486,3 +486,22 @@ test_that("data.frame class attribute is not saved", {
   df_arrow <- arrow_table(df)
   expect_identical(df_arrow$r_metadata, list(attributes = list(foo = "bar"), columns = list(x = NULL)))
 })
+
+test_that("data.tables don't warn when read back in from parquet", {
+  # See GH-45300
+  skip_if_not_installed("data.table")
+
+  tf <- tempfile()
+  on.exit(unlink(tf))
+
+  dt_in <- data.table::data.table(x = 1:3)
+  arrow::write_parquet(dt_in, tf)
+  dt_out <- read_parquet(tf)
+
+  expect_no_warning({
+    dt_out <- dt_out[, z := 4:6]
+  })
+  # testthat will skip this entire test if we don't have another assertion
+  # so we need this here
+  expect_equal(ncol(dt_out), 2)
+})


### PR DESCRIPTION
### Rationale for this change

Fixes https://github.com/apache/arrow/issues/45300.

### What changes are included in this PR?

Updated check in `arrow_attributes` in metadata.R.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Users may be depending on data.tables round-tripping so this may be considered a very minor breaking change.
* GitHub Issue: #45300