### PR TITLE
GH-45347: [Packaging][Linux] Use cpp/CMakeLists.txt instead of java/pom.xml to detect version

### DIFF
--- a/dev/tasks/linux-packages/helper.rb
+++ b/dev/tasks/linux-packages/helper.rb
@@ -49,9 +49,9 @@ module Helper
       version_env = ENV["ARROW_VERSION"]
       return version_env if version_env
 
-      pom_xml_path = File.join(arrow_source_dir, "java", "pom.xml")
-      pom_xml_content = File.read(pom_xml_path)
-      version = pom_xml_content[/^  <version>(.+?)<\/version>/, 1]
+      cmakelists_txt_path = File.join(arrow_source_dir, "cpp", "CMakeLists.txt")
+      cmakelists_txt_content = File.read(cmakelists_txt_path)
+      version = cmakelists_txt_content[/^set\(ARROW_VERSION "(.+?)"/, 1]
       formatted_release_time = release_time.strftime("%Y%m%d")
       version.gsub(/-SNAPSHOT\z/) {"-dev#{formatted_release_time}"}
     end


### PR DESCRIPTION
### Rationale for this change

java/pom.xml was moved to apache/arrow-java from apache/arrow.

### What changes are included in this PR?

Detect version from cpp/CMakeLists.txt.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #45347