### PR TITLE
GH-44759: [GLib] Add garrow_record_batch_validate()

### DIFF
--- a/c_glib/arrow-glib/record-batch.cpp
+++ b/c_glib/arrow-glib/record-batch.cpp
@@ -191,12 +191,7 @@ garrow_record_batch_new(GArrowSchema *schema,
   }
 
   auto arrow_record_batch = arrow::RecordBatch::Make(arrow_schema, n_rows, arrow_columns);
-  auto status = arrow_record_batch->Validate();
-  if (garrow_error_check(error, status, tag)) {
-    return garrow_record_batch_new_raw(&arrow_record_batch);
-  } else {
-    return NULL;
-  }
+  return garrow_record_batch_new_raw(&arrow_record_batch);
 }
 
 /**
@@ -701,4 +696,20 @@ garrow_record_batch_iterator_get_raw(GArrowRecordBatchIterator *iterator)
 {
   auto priv = GARROW_RECORD_BATCH_ITERATOR_GET_PRIVATE(iterator);
   return &priv->iterator;
+}
+
+/**
+ * garrow_record_batch_validate
+ * @record_batch: A #GArrowRecordBatch
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: %TRUE on success, %FALSE on error.
+ *
+ * Since: 20.0.0
+ */
+gboolean
+garrow_record_batch_validate(GArrowRecordBatch *record_batch, GError **error)
+{
+  const auto arrow_record_batch = garrow_record_batch_get_raw(record_batch);
+  return garrow::check(error, arrow_record_batch->Validate(), "[record-batch][validate]");
 }

--- a/c_glib/arrow-glib/record-batch.h
+++ b/c_glib/arrow-glib/record-batch.h
@@ -109,6 +109,10 @@ garrow_record_batch_serialize(GArrowRecordBatch *record_batch,
                               GArrowWriteOptions *options,
                               GError **error);
 
+GARROW_AVAILABLE_IN_20_0
+gboolean
+garrow_record_batch_validate(GArrowRecordBatch *record_batch, GError **error);
+
 #define GARROW_TYPE_RECORD_BATCH_ITERATOR (garrow_record_batch_iterator_get_type())
 GARROW_AVAILABLE_IN_0_17
 G_DECLARE_DERIVABLE_TYPE(GArrowRecordBatchIterator,

--- a/c_glib/test/test-record-batch.rb
+++ b/c_glib/test/test-record-batch.rb
@@ -189,5 +189,37 @@ valid:   [
       assert_equal(@record_batch,
                    input_stream.read_record_batch(@record_batch.schema))
     end
+
+    sub_test_case("#validate") do
+      def setup
+        @id_field = Arrow::Field.new("id",Arrow::UInt8DataType.new)
+        @name_field = Arrow::Field.new("name",Arrow::StringDataType.new)
+        @schema = Arrow::Schema.new([@id_field,@name_field])
+
+        @id_value = build_uint_array([1])
+        @name_value = build_string_array(["abc"])
+        @values = [@id_value,@name_value]
+      end
+
+      def test_valid
+        nrows = @id_value.length
+        record_batch = Arrow::RecordBatch.new(@schema,nrows,@values)
+
+        assert do
+          record_batch.validate
+        end
+      end
+
+      def test_invalid
+        message = "[record-batch][validate]: Invalid: " +
+          "Number of rows in column 0 did not match batch: 1 vs 2"
+        nrows = @id_value.length + 1 # incorrect num
+
+        record_batch = Arrow::RecordBatch.new(@schema,nrows,@values)
+        assert_raise(Arrow::Error::Invalid.new(message)) do
+          record_batch.validate
+        end
+      end
+    end
   end
 end

--- a/c_glib/test/test-record-batch.rb
+++ b/c_glib/test/test-record-batch.rb
@@ -192,18 +192,18 @@ valid:   [
 
     sub_test_case("#validate") do
       def setup
-        @id_field = Arrow::Field.new("id",Arrow::UInt8DataType.new)
-        @name_field = Arrow::Field.new("name",Arrow::StringDataType.new)
-        @schema = Arrow::Schema.new([@id_field,@name_field])
+        @id_field = Arrow::Field.new("id", Arrow::UInt8DataType.new)
+        @name_field = Arrow::Field.new("name", Arrow::StringDataType.new)
+        @schema = Arrow::Schema.new([@id_field, @name_field])
 
         @id_value = build_uint_array([1])
         @name_value = build_string_array(["abc"])
-        @values = [@id_value,@name_value]
+        @values = [@id_value, @name_value]
       end
 
       def test_valid
-        nrows = @id_value.length
-        record_batch = Arrow::RecordBatch.new(@schema,nrows,@values)
+        n_rows = @id_value.length
+        record_batch = Arrow::RecordBatch.new(@schema, n_rows, @values)
 
         assert do
           record_batch.validate
@@ -213,9 +213,9 @@ valid:   [
       def test_invalid
         message = "[record-batch][validate]: Invalid: " +
           "Number of rows in column 0 did not match batch: 1 vs 2"
-        nrows = @id_value.length + 1 # incorrect num
+        n_rows = @id_value.length + 1 # incorrect number of rows
 
-        record_batch = Arrow::RecordBatch.new(@schema,nrows,@values)
+        record_batch = Arrow::RecordBatch.new(@schema, n_rows, @values)
         assert_raise(Arrow::Error::Invalid.new(message)) do
           record_batch.validate
         end


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

[RecordBatch::Validate](https://arrow.apache.org/docs/cpp/api/table.html#_CPPv4NK5arrow11RecordBatch8ValidateEv) available in the C++ API.
But, GLib doesn't support that method yet.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

This PR adds a validation method in the record-batch class.
Before this change, the `Validate()` method was used in the `garrow_record_batch_new` implicitly.
This PR removes it and adds it as a separate method. Users need to call `garrow_record_batch_validate()` explicitly by themselves. This is a backward incompatible change.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

Yes.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

Yes.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
**This PR includes breaking changes to public APIs.**

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #44759