### PR TITLE
GH-45354: [GLib] Fix garrow_record_batch_validate() definied location

### DIFF
--- a/c_glib/arrow-glib/record-batch.cpp
+++ b/c_glib/arrow-glib/record-batch.cpp
@@ -500,6 +500,22 @@ garrow_record_batch_serialize(GArrowRecordBatch *record_batch,
   }
 }
 
+/**
+ * garrow_record_batch_validate
+ * @record_batch: A #GArrowRecordBatch
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: %TRUE on success, %FALSE on error.
+ *
+ * Since: 20.0.0
+ */
+gboolean
+garrow_record_batch_validate(GArrowRecordBatch *record_batch, GError **error)
+{
+  const auto arrow_record_batch = garrow_record_batch_get_raw(record_batch);
+  return garrow::check(error, arrow_record_batch->Validate(), "[record-batch][validate]");
+}
+
 typedef struct GArrowRecordBatchIteratorPrivate_
 {
   arrow::RecordBatchIterator iterator;
@@ -696,20 +712,4 @@ garrow_record_batch_iterator_get_raw(GArrowRecordBatchIterator *iterator)
 {
   auto priv = GARROW_RECORD_BATCH_ITERATOR_GET_PRIVATE(iterator);
   return &priv->iterator;
-}
-
-/**
- * garrow_record_batch_validate
- * @record_batch: A #GArrowRecordBatch
- * @error: (nullable): Return location for a #GError or %NULL.
- *
- * Returns: %TRUE on success, %FALSE on error.
- *
- * Since: 20.0.0
- */
-gboolean
-garrow_record_batch_validate(GArrowRecordBatch *record_batch, GError **error)
-{
-  const auto arrow_record_batch = garrow_record_batch_get_raw(record_batch);
-  return garrow::check(error, arrow_record_batch->Validate(), "[record-batch][validate]");
 }


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

#45353 implemented `garrow_record_batch_validate()` method. But it was the incorrect location.
We need to move the code location to use it as a C API.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

Move the `garrow_record_batch_validate()` location between `G_BEGIN_DECLS` and `G_END_DECLS`.
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

Yes.
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

Yes.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #45354