### PR TITLE
GH-45358: [C++][Python] Add MemoryPool method to print statistics

### DIFF
--- a/cpp/src/arrow/memory_pool.cc
+++ b/cpp/src/arrow/memory_pool.cc
@@ -266,6 +266,10 @@ class DebugAllocator {
     }
   }
 
+  static void PrintStats() {
+    WrappedAllocator::PrintStats();
+  }
+
  private:
   static Result<int64_t> RawSize(int64_t size) {
     if (ARROW_PREDICT_FALSE(internal::AddWithOverflow(size, kOverhead, &size))) {
@@ -380,6 +384,12 @@ class SystemAllocator {
     ARROW_UNUSED(malloc_trim(0));
 #endif
   }
+
+  static void PrintStats() {
+#ifdef __GLIBC__
+    malloc_stats();
+#endif
+  }
 };
 
 #ifdef ARROW_MIMALLOC
@@ -429,6 +439,10 @@ class MimallocAllocator {
     } else {
       mi_free(ptr);
     }
+  }
+
+  static void PrintStats() {
+    mi_stats_print_out(nullptr, nullptr);
   }
 };
 
@@ -511,6 +525,8 @@ class BaseMemoryPoolImpl : public MemoryPool {
   }
 
   void ReleaseUnused() override { Allocator::ReleaseUnused(); }
+
+  void PrintStats() override { Allocator::PrintStats(); }
 
   int64_t bytes_allocated() const override { return stats_.bytes_allocated(); }
 
@@ -724,6 +740,14 @@ void LoggingMemoryPool::Free(uint8_t* buffer, int64_t size, int64_t alignment) {
   std::cout << "Free: size = " << size << ", alignment = " << alignment << std::endl;
 }
 
+void LoggingMemoryPool::ReleaseUnused() {
+  pool_->ReleaseUnused();
+}
+
+void LoggingMemoryPool::PrintStats() {
+  pool_->PrintStats();
+}
+
 int64_t LoggingMemoryPool::bytes_allocated() const {
   int64_t nb_bytes = pool_->bytes_allocated();
   std::cout << "bytes_allocated: " << nb_bytes << std::endl;
@@ -775,6 +799,16 @@ class ProxyMemoryPool::ProxyMemoryPoolImpl {
     stats_.DidFreeBytes(size);
   }
 
+  void ReleaseUnused() {
+    pool_->ReleaseUnused();
+  }
+
+  void PrintStats() {
+    // XXX these are the allocation stats for the underlying allocator, not
+    // the subset allocated through the ProxyMemoryPool
+    pool_->PrintStats();
+  }
+
   int64_t bytes_allocated() const { return stats_.bytes_allocated(); }
 
   int64_t max_memory() const { return stats_.max_memory(); }
@@ -807,6 +841,14 @@ Status ProxyMemoryPool::Reallocate(int64_t old_size, int64_t new_size, int64_t a
 
 void ProxyMemoryPool::Free(uint8_t* buffer, int64_t size, int64_t alignment) {
   return impl_->Free(buffer, size, alignment);
+}
+
+void ProxyMemoryPool::ReleaseUnused() {
+  impl_->ReleaseUnused();
+}
+
+void ProxyMemoryPool::PrintStats() {
+  impl_->PrintStats();
 }
 
 int64_t ProxyMemoryPool::bytes_allocated() const { return impl_->bytes_allocated(); }

--- a/cpp/src/arrow/memory_pool.cc
+++ b/cpp/src/arrow/memory_pool.cc
@@ -266,9 +266,7 @@ class DebugAllocator {
     }
   }
 
-  static void PrintStats() {
-    WrappedAllocator::PrintStats();
-  }
+  static void PrintStats() { WrappedAllocator::PrintStats(); }
 
  private:
   static Result<int64_t> RawSize(int64_t size) {
@@ -441,9 +439,7 @@ class MimallocAllocator {
     }
   }
 
-  static void PrintStats() {
-    mi_stats_print_out(nullptr, nullptr);
-  }
+  static void PrintStats() { mi_stats_print_out(nullptr, nullptr); }
 };
 
 #endif  // defined(ARROW_MIMALLOC)
@@ -740,13 +736,9 @@ void LoggingMemoryPool::Free(uint8_t* buffer, int64_t size, int64_t alignment) {
   std::cout << "Free: size = " << size << ", alignment = " << alignment << std::endl;
 }
 
-void LoggingMemoryPool::ReleaseUnused() {
-  pool_->ReleaseUnused();
-}
+void LoggingMemoryPool::ReleaseUnused() { pool_->ReleaseUnused(); }
 
-void LoggingMemoryPool::PrintStats() {
-  pool_->PrintStats();
-}
+void LoggingMemoryPool::PrintStats() { pool_->PrintStats(); }
 
 int64_t LoggingMemoryPool::bytes_allocated() const {
   int64_t nb_bytes = pool_->bytes_allocated();
@@ -799,9 +791,7 @@ class ProxyMemoryPool::ProxyMemoryPoolImpl {
     stats_.DidFreeBytes(size);
   }
 
-  void ReleaseUnused() {
-    pool_->ReleaseUnused();
-  }
+  void ReleaseUnused() { pool_->ReleaseUnused(); }
 
   void PrintStats() {
     // XXX these are the allocation stats for the underlying allocator, not
@@ -843,13 +833,9 @@ void ProxyMemoryPool::Free(uint8_t* buffer, int64_t size, int64_t alignment) {
   return impl_->Free(buffer, size, alignment);
 }
 
-void ProxyMemoryPool::ReleaseUnused() {
-  impl_->ReleaseUnused();
-}
+void ProxyMemoryPool::ReleaseUnused() { impl_->ReleaseUnused(); }
 
-void ProxyMemoryPool::PrintStats() {
-  impl_->PrintStats();
-}
+void ProxyMemoryPool::PrintStats() { impl_->PrintStats(); }
 
 int64_t ProxyMemoryPool::bytes_allocated() const { return impl_->bytes_allocated(); }
 

--- a/cpp/src/arrow/memory_pool.h
+++ b/cpp/src/arrow/memory_pool.h
@@ -151,6 +151,12 @@ class ARROW_EXPORT MemoryPool {
   /// unable to fulfill the request due to fragmentation.
   virtual void ReleaseUnused() {}
 
+  /// Print statistics
+  ///
+  /// Print allocation statistics on stderr. The output format is
+  /// implementation-specific. Not all memory pools implement this method.
+  virtual void PrintStats() {}
+
   /// The number of bytes that were allocated and not yet free'd through
   /// this allocator.
   virtual int64_t bytes_allocated() const = 0;
@@ -187,6 +193,8 @@ class ARROW_EXPORT LoggingMemoryPool : public MemoryPool {
   Status Reallocate(int64_t old_size, int64_t new_size, int64_t alignment,
                     uint8_t** ptr) override;
   void Free(uint8_t* buffer, int64_t size, int64_t alignment) override;
+  void ReleaseUnused() override;
+  void PrintStats() override;
 
   int64_t bytes_allocated() const override;
 
@@ -219,6 +227,8 @@ class ARROW_EXPORT ProxyMemoryPool : public MemoryPool {
   Status Reallocate(int64_t old_size, int64_t new_size, int64_t alignment,
                     uint8_t** ptr) override;
   void Free(uint8_t* buffer, int64_t size, int64_t alignment) override;
+  void ReleaseUnused() override;
+  void PrintStats() override;
 
   int64_t bytes_allocated() const override;
 

--- a/cpp/src/arrow/memory_pool_internal.h
+++ b/cpp/src/arrow/memory_pool_internal.h
@@ -44,6 +44,7 @@ class JemallocAllocator {
                                   uint8_t** ptr);
   static void DeallocateAligned(uint8_t* ptr, int64_t size, int64_t alignment);
   static void ReleaseUnused();
+  static void PrintStats();
 };
 
 #endif  // defined(ARROW_JEMALLOC)

--- a/cpp/src/arrow/memory_pool_jemalloc.cc
+++ b/cpp/src/arrow/memory_pool_jemalloc.cc
@@ -131,6 +131,10 @@ void JemallocAllocator::ReleaseUnused() {
   mallctl("arena." ARROW_STRINGIFY(MALLCTL_ARENAS_ALL) ".purge", NULL, NULL, NULL, 0);
 }
 
+void JemallocAllocator::PrintStats() {
+  malloc_stats_print(nullptr, nullptr, /*opts=*/"");
+}
+
 }  // namespace internal
 
 }  // namespace memory_pool

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -323,8 +323,11 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
     cdef cppclass CMemoryPool" arrow::MemoryPool":
         int64_t bytes_allocated()
         int64_t max_memory()
+        int64_t total_bytes_allocated()
+        int64_t num_allocations()
         c_string backend_name()
         void ReleaseUnused()
+        void PrintStats()
 
     cdef cppclass CLoggingMemoryPool" arrow::LoggingMemoryPool"(CMemoryPool):
         CLoggingMemoryPool(CMemoryPool*)

--- a/python/pyarrow/memory.pxi
+++ b/python/pyarrow/memory.pxi
@@ -58,6 +58,13 @@ cdef class MemoryPool(_Weakrefable):
         """
         return self.pool.bytes_allocated()
 
+    def total_bytes_allocated(self):
+        """
+        Return the total number of bytes that have been allocated from this
+        memory pool.
+        """
+        return self.pool.total_bytes_allocated()
+
     def max_memory(self):
         """
         Return the peak memory allocation in this memory pool.
@@ -68,6 +75,23 @@ cdef class MemoryPool(_Weakrefable):
         """
         ret = self.pool.max_memory()
         return ret if ret >= 0 else None
+
+    def num_allocations(self):
+        """
+        Return the number of allocations or reallocations that were made
+        using this memory pool.
+        """
+        return self.pool.num_allocations()
+
+    def print_stats(self):
+        """
+        Print statistics about this memory pool.
+
+        The output format is implementation-specific. Not all memory pools
+        implement this method.
+        """
+        with nogil:
+            self.pool.PrintStats()
 
     @property
     def backend_name(self):
@@ -82,6 +106,7 @@ cdef class MemoryPool(_Weakrefable):
                 f"backend_name={self.backend_name} "
                 f"bytes_allocated={self.bytes_allocated()} "
                 f"max_memory={self.max_memory()}>")
+
 
 cdef CMemoryPool* maybe_unbox_memory_pool(MemoryPool memory_pool):
     if memory_pool is None:


### PR DESCRIPTION
### Rationale for this change

Add a MemoryPool method to print allocator-specific statistics to stderr, to help diagnose perceived memory consumption issues.

Also add missing Python bindings for `MemoryPool::total_bytes_allocated` and `MemoryPool::num_allocations`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.

* GitHub Issue: #45358