### PR TITLE
GH-45356: [CI][R] Update MACOSX_DEPLOYMENT_TARGET to 11.6

### DIFF
--- a/dev/tasks/r/github.packages.yml
+++ b/dev/tasks/r/github.packages.yml
@@ -81,7 +81,7 @@ jobs:
         shell: bash
         env:
         {{ macros.github_set_sccache_envvars()|indent(8) }}
-          MACOSX_DEPLOYMENT_TARGET: "10.13"
+          MACOSX_DEPLOYMENT_TARGET: "11.6"
           ARROW_S3: ON
           ARROW_GCS: ON
           ARROW_DEPENDENCY_SOURCE: BUNDLED
@@ -231,7 +231,7 @@ jobs:
         shell: sudo -E Rscript {0}
         run: |
           # get the mac-recipes version of openssl from CRAN
-          source("https://mac.R-project.org/bin/install.R") 
+          source("https://mac.R-project.org/bin/install.R")
           install.libs("openssl")
 
           # override our cmakes default setting of the brew --prefix as root dir to avoid version conflicts.


### PR DESCRIPTION
### Rationale for this change

CRAN uses 11.6 as the minimal macOS version now:
https://cran.r-project.org/web/checks/check_flavors.html

### What changes are included in this PR?

Update to 11.6 from 10.13.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #45356