### PR TITLE
MINOR: [Python] Use libcpp.optional provided by Cython.

### DIFF
--- a/python/pyarrow/includes/common.pxd
+++ b/python/pyarrow/includes/common.pxd
@@ -21,6 +21,7 @@ from libc.stdint cimport *
 from libcpp cimport bool as c_bool, nullptr
 from libcpp.functional cimport function
 from libcpp.memory cimport shared_ptr, unique_ptr, make_shared
+from libcpp.optional cimport optional, nullopt
 from libcpp.string cimport string as c_string
 from libcpp.utility cimport pair
 from libcpp.vector cimport vector
@@ -34,25 +35,6 @@ cimport cpython
 
 cdef extern from * namespace "std" nogil:
     cdef shared_ptr[T] static_pointer_cast[T, U](shared_ptr[U])
-
-
-cdef extern from "<optional>" namespace "std" nogil:
-    cdef cppclass optional[T]:
-        ctypedef T value_type
-        optional()
-        optional(nullopt_t)
-        optional(optional&) except +
-        optional(T&) except +
-        c_bool has_value()
-        T& value()
-        T& value_or[U](U& default_value)
-        void swap(optional&)
-        void reset()
-        T& emplace(...)
-        T& operator*()
-        # T* operator->() # Not Supported
-        optional& operator=(optional&)
-        optional& operator=[U](U&)
 
 
 # vendored from the cymove project https://github.com/ozars/cymove

--- a/python/pyarrow/lib.pxd
+++ b/python/pyarrow/lib.pxd
@@ -21,44 +21,11 @@ from cpython cimport PyObject
 from libcpp cimport nullptr, bool as c_bool
 from libcpp.cast cimport dynamic_cast
 from libcpp.memory cimport dynamic_pointer_cast
+from libcpp.optional cimport optional
 from pyarrow.includes.common cimport *
 from pyarrow.includes.libarrow cimport *
 from pyarrow.includes.libarrow_python cimport *
 
-# Will be available in Cython 3, not backported
-# ref: https://github.com/cython/cython/issues/3293#issuecomment-1223058101
-cdef extern from "<optional>" namespace "std" nogil:
-    cdef cppclass nullopt_t:
-        nullopt_t()
-
-    cdef nullopt_t nullopt
-
-    cdef cppclass optional[T]:
-        ctypedef T value_type
-        optional()
-        optional(nullopt_t)
-        optional(optional&) except +
-        optional(T&) except +
-        c_bool has_value()
-        T& value()
-        T& value_or[U](U& default_value)
-        void swap(optional&)
-        void reset()
-        T& emplace(...)
-        T& operator*()
-        # T* operator->() # Not Supported
-        optional& operator=(optional&)
-        optional& operator=[U](U&)
-        c_bool operator bool()
-        c_bool operator!()
-        c_bool operator==[U](optional&, U&)
-        c_bool operator!=[U](optional&, U&)
-        c_bool operator<[U](optional&, U&)
-        c_bool operator>[U](optional&, U&)
-        c_bool operator<=[U](optional&, U&)
-        c_bool operator>=[U](optional&, U&)
-
-    optional[T] make_optional[T](...) except +
 
 cdef extern from "Python.h":
     int PySlice_Check(object)


### PR DESCRIPTION
### Rationale for this change

Now that arrow depends on Cython 3+, there's no need to include a custom definition of std::optional.

### What changes are included in this PR?

### Are these changes tested?

Should be covered by existing tests.

### Are there any user-facing changes?

No.