### PR TITLE
GH-45362: [C++] Fix identity cast for time and list scalar

### DIFF
--- a/cpp/src/arrow/scalar.cc
+++ b/cpp/src/arrow/scalar.cc
@@ -1177,14 +1177,16 @@ enable_if_duration<To, Result<std::shared_ptr<Scalar>>> CastImpl(
 }
 
 // time to time
-template <typename To, typename From>
+template <typename To, typename From,
+          typename T = typename TypeTraits<To>::ScalarType::TypeClass>
 enable_if_time<To, Result<std::shared_ptr<Scalar>>> CastImpl(
     const TimeScalar<From>& from, std::shared_ptr<DataType> to_type) {
   using ToScalar = typename TypeTraits<To>::ScalarType;
   ARROW_ASSIGN_OR_RAISE(
       auto value, util::ConvertTimestampValue(AsTimestampType<From>(from.type),
                                               AsTimestampType<To>(to_type), from.value));
-  return std::make_shared<ToScalar>(value, std::move(to_type));
+  return std::make_shared<ToScalar>(static_cast<typename To::c_type>(value),
+                                    std::move(to_type));
 }
 
 constexpr int64_t kMillisecondsInDay = 86400000;

--- a/cpp/src/arrow/scalar.cc
+++ b/cpp/src/arrow/scalar.cc
@@ -1290,10 +1290,11 @@ CastImpl(const StructScalar& from, std::shared_ptr<DataType> to_type) {
 }
 
 // casts between variable-length and fixed-length list types
-template <typename To, typename From>
+template <typename To, typename FromScalar,
+          typename From = typename FromScalar::TypeClass>
 std::enable_if_t<is_list_type<To>::value && is_list_type<From>::value,
                  Result<std::shared_ptr<Scalar>>>
-CastImpl(const From& from, std::shared_ptr<DataType> to_type) {
+CastImpl(const FromScalar& from, std::shared_ptr<DataType> to_type) {
   if constexpr (sizeof(typename To::offset_type) < sizeof(int64_t)) {
     if (from.value->length() > std::numeric_limits<typename To::offset_type>::max()) {
       return Status::Invalid(from.type->ToString(), " too large to cast to ",

--- a/cpp/src/arrow/scalar.cc
+++ b/cpp/src/arrow/scalar.cc
@@ -1177,7 +1177,7 @@ enable_if_duration<To, Result<std::shared_ptr<Scalar>>> CastImpl(
 }
 
 // time to time
-template <typename To, typename From, typename T = typename To::TypeClass>
+template <typename To, typename From>
 enable_if_time<To, Result<std::shared_ptr<Scalar>>> CastImpl(
     const TimeScalar<From>& from, std::shared_ptr<DataType> to_type) {
   using ToScalar = typename TypeTraits<To>::ScalarType;

--- a/cpp/src/arrow/scalar_test.cc
+++ b/cpp/src/arrow/scalar_test.cc
@@ -157,7 +157,7 @@ TEST(TestBooleanScalar, Cast) {
   }
 }
 
-TEST(TestScalar, IndentityCast) {
+TEST(TestScalar, IdentityCast) {
   random::RandomArrayGenerator gen(/*seed=*/42);
   auto test_identity_cast_for_type =
       [&gen](const std::shared_ptr<arrow::DataType>& data_type) {
@@ -179,11 +179,16 @@ TEST(TestScalar, IndentityCast) {
   }
   for (auto& type : {
            arrow::fixed_size_list(arrow::int32(), 20), arrow::list(arrow::int32()),
+           arrow::large_list(arrow::int32()),
+           // TODO(GH-45430): CastTo for ListView is not implemented yet.
+           // arrow::list_view(arrow::int32()), arrow::large_list_view(arrow::int32())
+           // TODO(GH-45431): CastTo for ComplexType is not implemented yet.
            // arrow::map(arrow::binary(), arrow::int32()),
            // struct_({field("float", arrow::float32())}),
        }) {
     test_identity_cast_for_type(type);
   }
+  // TODO(GH-45429): CastTo for Decimal is not implemented yet.
   /*
   for (auto& type: {
     arrow::decimal32(2, 2),

--- a/cpp/src/arrow/scalar_test.cc
+++ b/cpp/src/arrow/scalar_test.cc
@@ -866,6 +866,9 @@ TEST(TestTimeScalars, Basics) {
     ASSERT_TRUE(first->Equals(*MakeScalar(ty, 5).ValueOrDie()));
     ASSERT_TRUE(last->Equals(*MakeScalar(ty, 42).ValueOrDie()));
     ASSERT_FALSE(last->Equals(*MakeScalar("string")));
+
+    ASSERT_OK_AND_ASSIGN(auto casted, first->CastTo(ty));
+    ASSERT_TRUE(casted->Equals(*first));
   }
 }
 


### PR DESCRIPTION
### Rationale for this change

The PR https://github.com/apache/arrow/pull/40237 introduced code:

```
// time to time
template <typename To, typename From, typename T = typename To::TypeClass>
```

However, the `Time64Type::TypeClass` doesn't exist, so SFINAE always failed.

### Are these changes tested?

Yes

### Are there any user-facing changes?

No.

* GitHub Issue: #45362