### PR TITLE
GH-45371: [C++] Fix data race in `SimpleRecordBatch::columns`

### DIFF
--- a/cpp/src/arrow/record_batch.cc
+++ b/cpp/src/arrow/record_batch.cc
@@ -104,6 +104,9 @@ class SimpleRecordBatch : public RecordBatch {
     std::shared_ptr<Array> result = std::atomic_load(&boxed_columns_[i]);
     if (!result) {
       auto new_array = MakeArray(columns_[i]);
+      // Be careful not to overwrite existing entry if another thread has been calling
+      // `column(i)` at the same time, since the `boxed_columns_` contents are exposed
+      // by `columns()` (see GH-45371).
       if (std::atomic_compare_exchange_strong(&boxed_columns_[i], &result, new_array)) {
         return new_array;
       }

--- a/cpp/src/arrow/record_batch_test.cc
+++ b/cpp/src/arrow/record_batch_test.cc
@@ -20,7 +20,6 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -406,15 +405,10 @@ TEST_F(TestRecordBatch, ColumnsThreadSafety) {
   std::shared_ptr<ArrayData> array_data = gen.ArrayOf(utf8(), length)->data();
   auto schema = ::arrow::schema({field("f1", utf8())});
   auto record_batch = RecordBatch::Make(schema, length, {array_data});
-  std::atomic_bool start_flag{false};
-  std::thread t([record_batch, &start_flag]() {
-    start_flag.store(true);
+  std::thread t([record_batch]() {
     auto columns = record_batch->columns();
     ASSERT_EQ(columns.size(), 1);
   });
-  // Wait for thread startup
-  while (!start_flag.load()) {
-  };
   auto columns = record_batch->columns();
   ASSERT_EQ(columns.size(), 1);
   t.join();


### PR DESCRIPTION
### Rationale for this change

GH-45371

### What changes are included in this PR?

Use `std::atomic_compare_exchange` to initialize `boxed_columns_[i]` so they are correctly written only once. This means that a reference to `boxed_columns_` is safe to read after each element has been initialized.

### Are these changes tested?

Yes, there is a test case `TestRecordBatch.ColumnsThreadSafety` which passes under TSAN.

### Are there any user-facing changes?

No

**This PR contains a "Critical Fix".**

Without this fix, concurrent calls to `SimpleRecordBatch::columns` could lead to an invalid memory access and crash.
* GitHub Issue: #45371