### PR TITLE
GH-45378: [CI][R] Increase timeout of test-ubuntu-r-sanitizer job

### DIFF
--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1315,6 +1315,7 @@ tasks:
       env:
         R_PRUNE_DEPS: TRUE
       image: ubuntu-r-sanitizer
+      timeout: 90
 
   test-r-clang-sanitizer:
     ci: github

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1315,7 +1315,7 @@ tasks:
       env:
         R_PRUNE_DEPS: TRUE
       image: ubuntu-r-sanitizer
-      timeout: 90
+      timeout: 120
 
   test-r-clang-sanitizer:
     ci: github


### PR DESCRIPTION
### Rationale for this change

The job is currently timing out.

### What changes are included in this PR?

Increase timeout

### Are these changes tested?

Via archery

### Are there any user-facing changes?

No
* GitHub Issue: #45378