### PR TITLE
GH-45296: [Python] Only enable the string dtype on pandas export for pandas>=2.3

### DIFF
--- a/python/pyarrow/pandas-shim.pxi
+++ b/python/pyarrow/pandas-shim.pxi
@@ -38,7 +38,7 @@ cdef class _PandasAPIShim(object):
         object _array_like_types, _is_extension_array_dtype, _lock
         bint has_sparse
         bint _pd024
-        bint _is_v1, _is_ge_v21, _is_ge_v3, _is_ge_v3_strict
+        bint _is_v1, _is_ge_v21, _is_ge_v23, _is_ge_v3, _is_ge_v3_strict
 
     def __init__(self):
         self._lock = Lock()
@@ -79,6 +79,7 @@ cdef class _PandasAPIShim(object):
 
         self._is_v1 = self._loose_version < Version('2.0.0')
         self._is_ge_v21 = self._loose_version >= Version('2.1.0')
+        self._is_ge_v23 = self._loose_version >= Version('2.3.0')
         self._is_ge_v3 = self._loose_version >= Version('3.0.0.dev0')
         self._is_ge_v3_strict = self._loose_version >= Version('3.0.0')
 
@@ -171,6 +172,10 @@ cdef class _PandasAPIShim(object):
         self._check_import()
         return self._is_ge_v21
 
+    def is_ge_v23(self):
+        self._check_import()
+        return self._is_ge_v23
+
     def is_ge_v3(self):
         self._check_import()
         return self._is_ge_v3
@@ -183,7 +188,7 @@ cdef class _PandasAPIShim(object):
         if self.is_ge_v3_strict():
             return True
         try:
-            if self.pd.options.future.infer_string:
+            if self.is_ge_v23() and self.pd.options.future.infer_string:
                 return True
         except:
             pass


### PR DESCRIPTION
### Rationale for this change

The option already exists in pandas 2.2, but for that version our code does not work, so restricting it to pandas >= 2.3

* GitHub Issue: #45296