### PR TITLE
GH-45388: [CI][MATLAB] Can we use Ubuntu 22.04 or 24.04 for Ubuntu CI

### DIFF
--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -46,7 +46,7 @@ permissions:
 jobs:
 
   ubuntu:
-    name: AMD64 Ubuntu 20.04 MATLAB
+    name: AMD64 Ubuntu 22.04 MATLAB
     # Explicitly pin the Ubuntu version to 20.04 for the time being because:
     #
     #     1. The version of GLIBCXX shipped with Ubuntu 22.04 is not binary compatible
@@ -63,7 +63,7 @@ jobs:
     #        Using Ubuntu 20.04 eases development workflows for these community members.
     #
     # In the future, we can investigate adding support for building against more Linux (e.g. `ubuntu-22.04`) and MATLAB versions (e.g. R2023b).
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     steps:
       - name: Check out repository
@@ -155,7 +155,7 @@ jobs:
     runs-on: windows-2022
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     steps:
-      - name: Check out repository        
+      - name: Check out repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0

--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -47,22 +47,6 @@ jobs:
 
   ubuntu:
     name: AMD64 Ubuntu 22.04 MATLAB
-    # Explicitly pin the Ubuntu version to 20.04 for the time being because:
-    #
-    #     1. The version of GLIBCXX shipped with Ubuntu 22.04 is not binary compatible
-    #        with the GLIBCXX bundled with MATLAB R2023a. This is a relatively common
-    #        issue.
-    #
-    #        For example, see:
-    #
-    #        https://www.mathworks.com/matlabcentral/answers/1907290-how-to-manually-select-the-libstdc-library-to-use-to-resolve-a-version-glibcxx_-not-found
-    #
-    #     2. The version of GLIBCXX shipped with Ubuntu 22.04 is not binary compatible with
-    #        the version of GLIBCXX shipped with Debian 11. Several of the Arrow community
-    #        members who work on the MATLAB bindings use Debian 11 locally for qualification.
-    #        Using Ubuntu 20.04 eases development workflows for these community members.
-    #
-    # In the future, we can investigate adding support for building against more Linux (e.g. `ubuntu-22.04`) and MATLAB versions (e.g. R2023b).
     runs-on: ubuntu-22.04
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     steps:

--- a/dev/tasks/matlab/github.yml
+++ b/dev/tasks/matlab/github.yml
@@ -22,8 +22,8 @@
 jobs:
 
   ubuntu:
-    name: AMD64 Ubuntu 20.04 MATLAB
-    runs-on: ubuntu-20.04
+    name: AMD64 Ubuntu 22.04 MATLAB
+    runs-on: ubuntu-22.04
     steps:
       {{ macros.github_checkout_arrow()|indent }}
       - name: Install ninja-build
@@ -37,13 +37,13 @@ jobs:
         {{ macros.github_set_sccache_envvars()|indent(8) }}
         run: arrow/ci/scripts/matlab_build.sh $(pwd)/arrow
       - name: Change shared library dependency name
-        # MATLAB's programmatic packaging interface does not properly 
+        # MATLAB's programmatic packaging interface does not properly
         # include symbolic link files in the package MLTBX - this is a
-        # bug. As a temporary workaround, change the expected name of the 
+        # bug. As a temporary workaround, change the expected name of the
         # Arrow C++ library which libarrowproxy.so depends on. For example,
         # change libarrow.so.1500 to libarrow.so.1500.0.0.
         run: |
-          pushd arrow/matlab/install/arrow_matlab/+libmexclass/+proxy/ 
+          pushd arrow/matlab/install/arrow_matlab/+libmexclass/+proxy/
           SYMLINK_ARROW_LIB="$(find . -name 'libarrow.so.*' -type l | xargs basename)"
           REGULAR_ARROW_LIB="$(echo libarrow.so.*.*)"
           echo "SYMLINK_ARROW_LIB = ${SYMLINK_ARROW_LIB}"
@@ -139,7 +139,7 @@ jobs:
           tar -xzvf matlab-arrow-macos-x64.tar.gz
           tar -xzvf matlab-arrow-macos-arm64.tar.gz
           tar -xzvf matlab-arrow-windows.tar.gz
-      - name: Copy LICENSE.txt and NOTICE.txt for packaging 
+      - name: Copy LICENSE.txt and NOTICE.txt for packaging
         run: |
           cp arrow/LICENSE.txt arrow/matlab/install/arrow_matlab/LICENSE.txt
           cp arrow/NOTICE.txt arrow/matlab/install/arrow_matlab/NOTICE.txt


### PR DESCRIPTION
### Rationale for this change

Ubuntu 20.04 will reach EOL by 2025-04, so we must upgrade the MATLAB workflow's GitHub runner from Ubuntu 20.04 to Ubuntu 22.04 or Ubuntu 24.04.

### What changes are included in this PR?

1. Updated the Ubuntu MATLAB GitHub workflow to use Ubuntu 22.04 as the GitHub runner.
2. Updated the Ubuntu MATLAB crossbow task to use Ubuntu 22.04 as the GitHub runner.

### Are these changes tested?

1. All GitHub checks passed.
2. Manually triggered the MATLAB crossbow task and installed the MATLAB-Arrow Interface Toolbox on Debian-12. 

### Are there any user-facing changes?

N/A

* GitHub Issue: #45388