### PR TITLE
GH-46419: [C++] Remove duplicate declaration and sync arg names on acero test_util_internal functions

### DIFF
--- a/cpp/src/arrow/acero/test_util_internal.h
+++ b/cpp/src/arrow/acero/test_util_internal.h
@@ -114,22 +114,13 @@ Result<std::vector<std::shared_ptr<ArrayVector>>> ToArrayVectors(
     const BatchesWithSchema& batches_with_schema);
 
 Result<std::vector<std::shared_ptr<ExecBatch>>> ToExecBatches(
-    const BatchesWithSchema& batches);
+    const BatchesWithSchema& batches_with_schema);
 
 Result<std::vector<std::shared_ptr<RecordBatch>>> ToRecordBatches(
-    const BatchesWithSchema& batches);
+    const BatchesWithSchema& batches_with_schema);
 
 Result<std::shared_ptr<RecordBatchReader>> ToRecordBatchReader(
     const BatchesWithSchema& batches_with_schema);
-
-Result<std::vector<std::shared_ptr<ArrayVector>>> ToArrayVectors(
-    const BatchesWithSchema& batches_with_schema);
-
-Result<std::vector<std::shared_ptr<ExecBatch>>> ToExecBatches(
-    const BatchesWithSchema& batches);
-
-Result<std::vector<std::shared_ptr<RecordBatch>>> ToRecordBatches(
-    const BatchesWithSchema& batches);
 
 Result<std::shared_ptr<Table>> SortTableOnAllFields(const std::shared_ptr<Table>& tab);
 


### PR DESCRIPTION

### Rationale for this change

While reviewing code I came across minor inconsistencies. 

### What changes are included in this PR?
Remove duplicate declarations and rename arguments for match source

### Are these changes tested?

No functional changes. No new tests needed.

### Are there any user-facing changes?
No.
* GitHub Issue: #46419