### PR TITLE
GH-45402: [CI][Dev][Ruby] Reformat codes before apply lint

### DIFF
--- a/c_glib/test/dataset/test-file-system-dataset.rb
+++ b/c_glib/test/dataset/test-file-system-dataset.rb
@@ -91,15 +91,15 @@ class TestDatasetFileSystemDataset < Test::Unit::TestCase
     dataset = @factory.finish
 
     expected_table = build_table(count: [
-                               build_int32_array([1, 10]),
-                               build_int32_array([2]),
-                               build_int32_array([3]),
-                             ],
-                             label: [
-                               build_string_array(["a", "a"]),
-                               build_string_array(["b"]),
-                               build_string_array(["c"]),
-                             ])
+                                   build_int32_array([1, 10]),
+                                   build_int32_array([2]),
+                                   build_int32_array([3]),
+                                 ],
+                                 label: [
+                                   build_string_array(["a", "a"]),
+                                   build_string_array(["b"]),
+                                   build_string_array(["c"]),
+                                 ])
 
     return dataset, expected_table
   end

--- a/c_glib/test/test-array.rb
+++ b/c_glib/test/test-array.rb
@@ -118,9 +118,9 @@ class TestArray < Test::Unit::TestCase
 
   sub_test_case("#view") do
     def test_valid
+      int32_array = build_int32_array([0, 1069547520, -1071644672, nil])
       assert_equal(build_float_array([0.0, 1.5, -2.5, nil]),
-                   build_int32_array([0, 1069547520, -1071644672, nil])
-                     .view(Arrow::FloatDataType.new))
+                   int32_array.view(Arrow::FloatDataType.new))
     end
 
     def test_invalid

--- a/c_glib/test/test-array.rb
+++ b/c_glib/test/test-array.rb
@@ -119,7 +119,8 @@ class TestArray < Test::Unit::TestCase
   sub_test_case("#view") do
     def test_valid
       assert_equal(build_float_array([0.0, 1.5, -2.5, nil]),
-                   build_int32_array([0, 1069547520, -1071644672, nil]).view(Arrow::FloatDataType.new))
+                   build_int32_array([0, 1069547520, -1071644672, nil])
+                     .view(Arrow::FloatDataType.new))
     end
 
     def test_invalid

--- a/c_glib/test/test-chunked-array-datum.rb
+++ b/c_glib/test/test-chunked-array-datum.rb
@@ -49,7 +49,10 @@ class TestChunkedArrayDatum < Test::Unit::TestCase
   end
 
   def test_to_string
-    assert_equal("ChunkedArray([\n" + "  [\n" + "    true,\n" + "    false\n" + "  ]\n" + "])", @datum.to_s)
+    assert_equal("ChunkedArray([\n" +
+                 "  [\n" + "    true,\n" +
+                 "    false\n" + "  ]\n" + "])",
+                 @datum.to_s)
   end
 
   def test_value

--- a/c_glib/test/test-chunked-array-datum.rb
+++ b/c_glib/test/test-chunked-array-datum.rb
@@ -49,10 +49,14 @@ class TestChunkedArrayDatum < Test::Unit::TestCase
   end
 
   def test_to_string
-    assert_equal("ChunkedArray([\n" +
-                 "  [\n" + "    true,\n" +
-                 "    false\n" + "  ]\n" + "])",
-                 @datum.to_s)
+    assert_equal(<<-CHUNKED_ARRAY.chomp, @datum.to_s)
+ChunkedArray([
+  [
+    true,
+    false
+  ]
+])
+    CHUNKED_ARRAY
   end
 
   def test_value

--- a/c_glib/test/test-chunked-array-datum.rb
+++ b/c_glib/test/test-chunked-array-datum.rb
@@ -49,14 +49,14 @@ class TestChunkedArrayDatum < Test::Unit::TestCase
   end
 
   def test_to_string
-    assert_equal(<<-CHUNKED_ARRAY.chomp, @datum.to_s)
+    assert_equal(<<-DATUM.chomp, @datum.to_s)
 ChunkedArray([
   [
     true,
     false
   ]
 ])
-    CHUNKED_ARRAY
+    DATUM
   end
 
   def test_value

--- a/c_glib/test/test-large-list-array.rb
+++ b/c_glib/test/test-large-list-array.rb
@@ -88,10 +88,10 @@ class TestLargeListArray < Test::Unit::TestCase
 
   def test_value_offsets
     array = build_large_list_array(Arrow::Int8DataType.new,
-                             [
-                               [-29, 29],
-                               [-1, 0, 1],
-                             ])
+                                   [
+                                     [-29, 29],
+                                     [-1, 0, 1],
+                                   ])
     assert_equal([0, 2, 5],
                  array.value_offsets)
   end

--- a/c_glib/test/test-record-batch-datum.rb
+++ b/c_glib/test/test-record-batch-datum.rb
@@ -49,7 +49,10 @@ class TestRecordBatchDatum < Test::Unit::TestCase
   end
 
   def test_to_string
-    assert_equal("RecordBatch(visible:   [\n" + "    true,\n" + "    false\n" + "  ]\n" + ")", @datum.to_s)
+    assert_equal("RecordBatch(visible:   [\n" +
+                 "    true,\n" + "    false\n" +
+                 "  ]\n" + ")",
+                 @datum.to_s)
   end
 
   def test_value

--- a/c_glib/test/test-record-batch-datum.rb
+++ b/c_glib/test/test-record-batch-datum.rb
@@ -49,10 +49,13 @@ class TestRecordBatchDatum < Test::Unit::TestCase
   end
 
   def test_to_string
-    assert_equal("RecordBatch(visible:   [\n" +
-                 "    true,\n" + "    false\n" +
-                 "  ]\n" + ")",
-                 @datum.to_s)
+    assert_equal(<<-RECORD_BATCH.chomp, @datum.to_s)
+RecordBatch(visible:   [
+    true,
+    false
+  ]
+)
+    RECORD_BATCH
   end
 
   def test_value

--- a/c_glib/test/test-record-batch-datum.rb
+++ b/c_glib/test/test-record-batch-datum.rb
@@ -49,13 +49,13 @@ class TestRecordBatchDatum < Test::Unit::TestCase
   end
 
   def test_to_string
-    assert_equal(<<-RECORD_BATCH.chomp, @datum.to_s)
+    assert_equal(<<-DATUM.chomp, @datum.to_s)
 RecordBatch(visible:   [
     true,
     false
   ]
 )
-    RECORD_BATCH
+    DATUM
   end
 
   def test_value

--- a/c_glib/test/test-record-batch.rb
+++ b/c_glib/test/test-record-batch.rb
@@ -243,7 +243,8 @@ valid:   [
       end
 
       def test_valid
-        record_batch = Arrow::RecordBatch.new(@schema, @n_rows, [@uint8_value, @valid_name_value])
+        record_batch = Arrow::RecordBatch.new(@schema, @n_rows,
+                                              [@uint8_value, @valid_name_value])
 
         assert do
           record_batch.validate_full
@@ -253,7 +254,10 @@ valid:   [
       def test_invalid
         message = "[record-batch][validate-full]: Invalid: " +
           "In column 1: Invalid: Invalid UTF8 sequence at string index 0"
-        record_batch = Arrow::RecordBatch.new(@schema, @n_rows, [@uint8_value, @invalid_name_value])
+        record_batch = Arrow::RecordBatch.new(@schema, @n_rows,
+                                              [@uint8_value,
+                                               @invalid_name_value]
+                                             )
 
         assert_raise(Arrow::Error::Invalid.new(message)) do
           record_batch.validate_full

--- a/c_glib/test/test-record-batch.rb
+++ b/c_glib/test/test-record-batch.rb
@@ -254,10 +254,8 @@ valid:   [
       def test_invalid
         message = "[record-batch][validate-full]: Invalid: " +
           "In column 1: Invalid: Invalid UTF8 sequence at string index 0"
-        record_batch = Arrow::RecordBatch.new(@schema, @n_rows,
-                                              [@uint8_value,
-                                               @invalid_name_value]
-                                             )
+        columns = [@uint8_value, @invalid_name_value]
+        record_batch = Arrow::RecordBatch.new(@schema, @n_rows, columns)
 
         assert_raise(Arrow::Error::Invalid.new(message)) do
           record_batch.validate_full

--- a/c_glib/test/test-record-batch.rb
+++ b/c_glib/test/test-record-batch.rb
@@ -243,8 +243,8 @@ valid:   [
       end
 
       def test_valid
-        record_batch = Arrow::RecordBatch.new(@schema, @n_rows,
-                                              [@uint8_value, @valid_name_value])
+        columns = [@uint8_value, @valid_name_value]
+        record_batch = Arrow::RecordBatch.new(@schema, @n_rows, columns)
 
         assert do
           record_batch.validate_full

--- a/c_glib/test/test-struct-field-options.rb
+++ b/c_glib/test/test-struct-field-options.rb
@@ -42,7 +42,8 @@ class TestStructFieldOptions < Test::Unit::TestCase
   end
 
   def test_set_invalid
-    message = "[struct-field-options][set-field-ref]: Invalid: Dot path '[foo]' contained an unterminated index"
+    message = "[struct-field-options][set-field-ref]: " +
+              "Invalid: Dot path '[foo]' contained an unterminated index"
     assert_raise(Arrow::Error::Invalid.new(message)) do
       @options.field_ref = "[foo]"
     end

--- a/c_glib/test/test-uint-array-builder.rb
+++ b/c_glib/test/test-uint-array-builder.rb
@@ -32,9 +32,9 @@ class TestUIntArrayBuilder < Test::Unit::TestCase
     values = [0, border_value]
     assert_equal(build_uint_array([*values, nil]),
                  Arrow::UInt16Array.new(3,
-                                       Arrow::Buffer.new(values.pack("S*")),
-                                       Arrow::Buffer.new([0b011].pack("C*")),
-                                       -1))
+                                        Arrow::Buffer.new(values.pack("S*")),
+                                        Arrow::Buffer.new([0b011].pack("C*")),
+                                        -1))
   end
 
   def test_uint32
@@ -42,9 +42,9 @@ class TestUIntArrayBuilder < Test::Unit::TestCase
     values = [0, border_value]
     assert_equal(build_uint_array([*values, nil]),
                  Arrow::UInt32Array.new(3,
-                                       Arrow::Buffer.new(values.pack("L*")),
-                                       Arrow::Buffer.new([0b011].pack("C*")),
-                                       -1))
+                                        Arrow::Buffer.new(values.pack("L*")),
+                                        Arrow::Buffer.new([0b011].pack("C*")),
+                                        -1))
   end
 
   def test_uint64

--- a/dev/release/01-prepare-test.rb
+++ b/dev/release/01-prepare-test.rb
@@ -264,7 +264,8 @@ class PrepareTest < Test::Unit::TestCase
               "-<p><a href=\"../r/\">#{@previous_r_version} (release)</a></p>",
               "+<body><p><a href=\"../dev/r/\">#{@release_version}.9000 (dev)</a></p>",
               "+<p><a href=\"../r/\">#{@release_version} (release)</a></p>",
-              "+<p><a href=\"../#{@previous_compatible_version}/r/\">#{@previous_r_version}</a></p>",
+              "+<p><a href=\"../#{@previous_compatible_version}/r/\">" +
+              "#{@previous_r_version}</a></p>",
             ]
           ],
         },

--- a/dev/release/post-12-bump-versions-test.rb
+++ b/dev/release/post-12-bump-versions-test.rb
@@ -302,7 +302,8 @@ class PostBumpVersionsTest < Test::Unit::TestCase
                 "-<p><a href=\"../r/\">#{@previous_r_version} (release)</a></p>",
                 "+<body><p><a href=\"../dev/r/\">#{@release_version}.9000 (dev)</a></p>",
                 "+<p><a href=\"../r/\">#{@release_version} (release)</a></p>",
-                "+<p><a href=\"../#{@previous_compatible_version}/r/\">#{@previous_r_version}</a></p>",
+                "+<p><a href=\"../#{@previous_compatible_version}/r/\">" +
+                "#{@previous_r_version}</a></p>",
               ],
             ],
           },

--- a/dev/tasks/homebrew-formulae/apache-arrow.rb
+++ b/dev/tasks/homebrew-formulae/apache-arrow.rb
@@ -110,8 +110,7 @@ class ApacheArrow < Formula
         return 0;
       }
     EOS
-    system ENV.cxx, "test.cpp", "-std=c++17", "-I#{include}", "-L#{lib}",
-           "-larrow", "-o", "test"
+    system ENV.cxx, "test.cpp", "-std=c++17", "-I#{include}", "-L#{lib}", "-larrow", "-o", "test"
     system "./test"
   end
 end

--- a/dev/tasks/homebrew-formulae/apache-arrow.rb
+++ b/dev/tasks/homebrew-formulae/apache-arrow.rb
@@ -110,7 +110,8 @@ class ApacheArrow < Formula
         return 0;
       }
     EOS
-    system ENV.cxx, "test.cpp", "-std=c++17", "-I#{include}", "-L#{lib}", "-larrow", "-o", "test"
+    system ENV.cxx, "test.cpp", "-std=c++17", "-I#{include}", "-L#{lib}",
+           "-larrow", "-o", "test"
     system "./test"
   end
 end

--- a/ruby/red-arrow/test/each-raw-record/test-map-array.rb
+++ b/ruby/red-arrow/test/each-raw-record/test-map-array.rb
@@ -269,11 +269,10 @@ module EachRawRecordMapArrayTests
 
   def test_time64_nano
     unit = Arrow::TimeUnit::NANO
+    # 00:10:00.123456789
+    value = Arrow::Time.new(unit, (60 * 10) * 1_000_000_000 + 123_456_789)
     records = [
-      # 00:10:00.123456789
-      [{"key1" => Arrow::Time.new(unit,
-                                  (60 * 10) * 1_000_000_000 + 123_456_789),
-        "key2" => nil}],
+      [{"key1" => value, "key2" => nil}],
       [nil],
     ]
     target = build({

--- a/ruby/red-arrow/test/each-raw-record/test-map-array.rb
+++ b/ruby/red-arrow/test/each-raw-record/test-map-array.rb
@@ -271,7 +271,9 @@ module EachRawRecordMapArrayTests
     unit = Arrow::TimeUnit::NANO
     records = [
       # 00:10:00.123456789
-      [{"key1" => Arrow::Time.new(unit, (60 * 10) * 1_000_000_000 + 123_456_789), "key2" => nil}],
+      [{"key1" => Arrow::Time.new(unit,
+                                  (60 * 10) * 1_000_000_000 + 123_456_789),
+        "key2" => nil}],
       [nil],
     ]
     target = build({

--- a/ruby/red-arrow/test/raw-records/test-map-array.rb
+++ b/ruby/red-arrow/test/raw-records/test-map-array.rb
@@ -271,7 +271,8 @@ module RawRecordsMapArrayTests
     unit = Arrow::TimeUnit::NANO
     records = [
       # 00:10:00.123456789
-      [{"key1" => Arrow::Time.new(unit, (60 * 10) * 1_000_000_000 + 123_456_789), "key2" => nil}],
+      [{"key1" => Arrow::Time.new(unit, (60 * 10) * 1_000_000_000 + 123_456_789),
+        "key2" => nil}],
       [nil],
     ]
     target = build({

--- a/ruby/red-arrow/test/raw-records/test-map-array.rb
+++ b/ruby/red-arrow/test/raw-records/test-map-array.rb
@@ -269,10 +269,10 @@ module RawRecordsMapArrayTests
 
   def test_time64_nano
     unit = Arrow::TimeUnit::NANO
+    # 00:10:00.123456789
+    value = Arrow::Time.new(unit, (60 * 10) * 1_000_000_000 + 123_456_789)
     records = [
-      # 00:10:00.123456789
-      [{"key1" => Arrow::Time.new(unit, (60 * 10) * 1_000_000_000 + 123_456_789),
-        "key2" => nil}],
+      [{"key1" => value, "key2" => nil}],
       [nil],
     ]
     target = build({

--- a/ruby/red-arrow/test/test-table.rb
+++ b/ruby/red-arrow/test/test-table.rb
@@ -1521,10 +1521,10 @@ visible: false
                                       ["key2_right", [100, 20]],
                                       ["string", ["1-100", "2-20"]],
                                     ]),
-                    table1.join(table2,
-                                ["key1", "key2"],
-                                left_suffix: "_left",
-                                right_suffix: "_right"))
+                   table1.join(table2,
+                               ["key1", "key2"],
+                               left_suffix: "_left",
+                               right_suffix: "_right"))
     end
   end
 end

--- a/ruby/red-arrow/test/values/test-map-array.rb
+++ b/ruby/red-arrow/test/values/test-map-array.rb
@@ -263,7 +263,8 @@ module ValuesMapArrayTests
     unit = Arrow::TimeUnit::NANO
     values = [
       # 00:10:00.123456789
-      {"key1" => Arrow::Time.new(unit, (60 * 10) * 1_000_000_000 + 123_456_789), "key2" => nil},
+      {"key1" => Arrow::Time.new(unit, (60 * 10) * 1_000_000_000 + 123_456_789),
+       "key2" => nil},
       nil,
     ]
     target = build({

--- a/ruby/red-arrow/test/values/test-map-array.rb
+++ b/ruby/red-arrow/test/values/test-map-array.rb
@@ -262,7 +262,7 @@ module ValuesMapArrayTests
   def test_time64_nano
     unit = Arrow::TimeUnit::NANO
     # 00:10:00.123456789
-    key1_value = Arrow::Time.new(unit, (60 * 10) * 1_000_000_000 + 123_456_789)
+    value = Arrow::Time.new(unit, (60 * 10) * 1_000_000_000 + 123_456_789)
     values = [
       {"key1" => value, "key2" => nil},
       nil,

--- a/ruby/red-arrow/test/values/test-map-array.rb
+++ b/ruby/red-arrow/test/values/test-map-array.rb
@@ -261,10 +261,10 @@ module ValuesMapArrayTests
 
   def test_time64_nano
     unit = Arrow::TimeUnit::NANO
+    # 00:10:00.123456789
+    key1_value = Arrow::Time.new(unit, (60 * 10) * 1_000_000_000 + 123_456_789)
     values = [
-      # 00:10:00.123456789
-      {"key1" => Arrow::Time.new(unit, (60 * 10) * 1_000_000_000 + 123_456_789),
-       "key2" => nil},
+      {"key1" => key1_value, "key2" => nil},
       nil,
     ]
     target = build({

--- a/ruby/red-arrow/test/values/test-map-array.rb
+++ b/ruby/red-arrow/test/values/test-map-array.rb
@@ -264,7 +264,7 @@ module ValuesMapArrayTests
     # 00:10:00.123456789
     key1_value = Arrow::Time.new(unit, (60 * 10) * 1_000_000_000 + 123_456_789)
     values = [
-      {"key1" => key1_value, "key2" => nil},
+      {"key1" => value, "key2" => nil},
       nil,
     ]
     target = build({


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

#45398 will apply Ruby lint. Before this change, some code needs to be reformatted to avoid format errors.

```bash
Ruby Format..............................................................Failed
- hook id: rubocop
- exit code: 1
- files were modified by this hook

Inspecting 79 files
..............................C................................................

Offenses:

c_glib/test/test-record-batch-datum.rb:52:101: C: [Corrected] Layout/LineLength: Line is too long. [107/100]
    assert_equal("RecordBatch(visible:   [\n" + "    true,\n" + "    false\n" + "  ]\n" + ")", @datum.to_s)
                                                                                                    ^^^^^^^
c_glib/test/test-record-batch-datum.rb:53:1: C: [Corrected] Layout/ArgumentAlignment: Align the arguments of a method call if they span more than one line.
@datum.to_s)
^^^^^^^^^^^

79 files inspected, 2 offenses detected, 2 offenses corrected
Inspecting 79 files
..................C................................C.....................C.....

Offenses:

dev/release/01-prepare-test.rb:267:101: C: Layout/LineLength: Line is too long. [101/100]
              "+<p><a href=\"../#{@previous_compatible_version}/r/\">#{@previous_r_version}</a></p>",
                                                                                                    ^
c_glib/test/test-struct-field-options.rb:45:101: C: Layout/LineLength: Line is too long. [112/100]
    message = "[struct-field-options][set-field-ref]: Invalid: Dot path '[foo]' contained an unterminated index"
                                                                                                    ^^^^^^^^^^^^
ruby/red-arrow/test/test-table.rb:1524:21: C: [Corrected] Layout/ArgumentAlignment: Align the arguments of a method call if they span more than one line.
                    table1.join(table2, ...
                    ^^^^^^^^^^^^^^^^^^^

79 files inspected, 3 offenses detected, 1 offense corrected
Inspecting 79 files
......................C........................................................

Offenses:

c_glib/test/test-chunked-array-datum.rb:52:101: C: [Corrected] Layout/LineLength: Line is too long. [108/100]
    assert_equal("ChunkedArray([\n" + "  [\n" + "    true,\n" + "    false\n" + "  ]\n" + "])", @datum.to_s)
                                                                                                    ^^^^^^^^
c_glib/test/test-chunked-array-datum.rb:53:1: C: [Corrected] Layout/ArgumentAlignment: Align the arguments of a method call if they span more than one line.
@datum.to_s)
^^^^^^^^^^^

79 files inspected, 2 offenses detected, 2 offenses corrected
Inspecting 79 files
..............C............................C....C..............................

Offenses:

c_glib/test/dataset/test-file-system-dataset.rb:98:30: C: [Corrected] Layout/ArgumentAlignment: Align the arguments of a method call if they span more than one line.
                             label: [ ...
                             ^^^^^^^^
dev/release/post-12-bump-versions-test.rb:305:101: C: Layout/LineLength: Line is too long. [103/100]
                "+<p><a href=\"../#{@previous_compatible_version}/r/\">#{@previous_r_version}</a></p>",
                                                                                                    ^^^
c_glib/test/test-array.rb:122:101: C: [Corrected] Layout/LineLength: Line is too long. [103/100]
                   build_int32_array([0, 1069547520, -1071644672, nil]).view(Arrow::FloatDataType.new))
                                                                                                    ^^^

79 files inspected, 3 offenses detected, 2 offenses corrected
Inspecting 79 files
...............................................................................

79 files inspected, no offenses detected
Inspecting 79 files
........................................................................C......

Offenses:

c_glib/test/test-large-list-array.rb:91:30: C: [Corrected] Layout/ArgumentAlignment: Align the arguments of a method call if they span more than one line.
                             [ ...
                             ^

79 files inspected, 1 offense detected, 1 offense corrected
Inspecting 79 files
...............................................................................

79 files inspected, no offenses detected
Inspecting 79 files
...............................C...............................................

Offenses:

c_glib/test/test-uint-array-builder.rb:35:40: C: [Corrected] Layout/ArgumentAlignment: Align the arguments of a method call if they span more than one line.
                                       Arrow::Buffer.new(values.pack("S*")),
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
c_glib/test/test-uint-array-builder.rb:36:40: C: [Corrected] Layout/ArgumentAlignment: Align the arguments of a method call if they span more than one line.
                                       Arrow::Buffer.new([0b011].pack("C*")),
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
c_glib/test/test-uint-array-builder.rb:37:40: C: [Corrected] Layout/ArgumentAlignment: Align the arguments of a method call if they span more than one line.
                                       -1))
                                       ^^
c_glib/test/test-uint-array-builder.rb:45:40: C: [Corrected] Layout/ArgumentAlignment: Align the arguments of a method call if they span more than one line.
                                       Arrow::Buffer.new(values.pack("L*")),
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
c_glib/test/test-uint-array-builder.rb:46:40: C: [Corrected] Layout/ArgumentAlignment: Align the arguments of a method call if they span more than one line.
                                       Arrow::Buffer.new([0b011].pack("C*")),
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
c_glib/test/test-uint-array-builder.rb:47:40: C: [Corrected] Layout/ArgumentAlignment: Align the arguments of a method call if they span more than one line.
                                       -1))
                                       ^^

79 files inspected, 6 offenses detected, 6 offenses corrected

pre-commit hook(s) made changes.
If you are seeing this message in CI, reproduce locally with: `pre-commit run --all-files`.
To run `pre-commit` as part of git workflow, use `pre-commit install`.
All changes made by hooks:
diff --git a/c_glib/test/dataset/test-file-system-dataset.rb b/c_glib/test/dataset/test-file-system-dataset.rb
index 96deedf6b..0cd2a61ea 100644
--- a/c_glib/test/dataset/test-file-system-dataset.rb
+++ b/c_glib/test/dataset/test-file-system-dataset.rb
@@ -95,11 +95,11 @@ class TestDatasetFileSystemDataset < Test::Unit::TestCase
                                build_int32_array([2]),
                                build_int32_array([3]),
                              ],
-                             label: [
-                               build_string_array(["a", "a"]),
-                               build_string_array(["b"]),
-                               build_string_array(["c"]),
-                             ])
+                                 label: [
+                                   build_string_array(["a", "a"]),
+                                   build_string_array(["b"]),
+                                   build_string_array(["c"]),
+                                 ])

     return dataset, expected_table
   end
diff --git a/c_glib/test/test-array.rb b/c_glib/test/test-array.rb
index aa129a474..681544920 100644
--- a/c_glib/test/test-array.rb
+++ b/c_glib/test/test-array.rb
@@ -119,7 +119,8 @@ class TestArray < Test::Unit::TestCase
   sub_test_case("#view") do
     def test_valid
       assert_equal(build_float_array([0.0, 1.5, -2.5, nil]),
-                   build_int32_array([0, 1069547520, -1071644672, nil]).view(Arrow::FloatDataType.new))
+                   build_int32_array([0, 1069547520, -1071644672,
+nil]).view(Arrow::FloatDataType.new))
     end

     def test_invalid
diff --git a/c_glib/test/test-chunked-array-datum.rb b/c_glib/test/test-chunked-array-datum.rb
index b82f3eed8..17a2cbd1a 100644
--- a/c_glib/test/test-chunked-array-datum.rb
+++ b/c_glib/test/test-chunked-array-datum.rb
@@ -49,7 +49,8 @@ class TestChunkedArrayDatum < Test::Unit::TestCase
   end

   def test_to_string
-    assert_equal("ChunkedArray([\n" + "  [\n" + "    true,\n" + "    false\n" + "  ]\n" + "])", @datum.to_s)
+    assert_equal("ChunkedArray([\n" + "  [\n" + "    true,\n" + "    false\n" + "  ]\n" + "])",
+                 @datum.to_s)
   end

   def test_value
diff --git a/c_glib/test/test-large-list-array.rb b/c_glib/test/test-large-list-array.rb
index 2f7efab5a..fa9c92ec8 100644
--- a/c_glib/test/test-large-list-array.rb
+++ b/c_glib/test/test-large-list-array.rb
@@ -88,10 +88,10 @@ class TestLargeListArray < Test::Unit::TestCase

   def test_value_offsets
     array = build_large_list_array(Arrow::Int8DataType.new,
-                             [
-                               [-29, 29],
-                               [-1, 0, 1],
-                             ])
+                                   [
+                                     [-29, 29],
+                                     [-1, 0, 1],
+                                   ])
     assert_equal([0, 2, 5],
                  array.value_offsets)
   end
diff --git a/c_glib/test/test-record-batch-datum.rb b/c_glib/test/test-record-batch-datum.rb
index ec572e0f1..e2d9c0258 100644
--- a/c_glib/test/test-record-batch-datum.rb
+++ b/c_glib/test/test-record-batch-datum.rb
@@ -49,7 +49,8 @@ class TestRecordBatchDatum < Test::Unit::TestCase
   end

   def test_to_string
-    assert_equal("RecordBatch(visible:   [\n" + "    true,\n" + "    false\n" + "  ]\n" + ")", @datum.to_s)
+    assert_equal("RecordBatch(visible:   [\n" + "    true,\n" + "    false\n" + "  ]\n" + ")",
+                 @datum.to_s)
   end

   def test_value
diff --git a/c_glib/test/test-uint-array-builder.rb b/c_glib/test/test-uint-array-builder.rb
index 89621189b..3aa3a1c48 100644
--- a/c_glib/test/test-uint-array-builder.rb
+++ b/c_glib/test/test-uint-array-builder.rb
@@ -32,9 +32,9 @@ class TestUIntArrayBuilder < Test::Unit::TestCase
     values = [0, border_value]
     assert_equal(build_uint_array([*values, nil]),
                  Arrow::UInt16Array.new(3,
-                                       Arrow::Buffer.new(values.pack("S*")),
-                                       Arrow::Buffer.new([0b011].pack("C*")),
-                                       -1))
+                                        Arrow::Buffer.new(values.pack("S*")),
+                                        Arrow::Buffer.new([0b011].pack("C*")),
+                                        -1))
   end

   def test_uint32
@@ -42,9 +42,9 @@ class TestUIntArrayBuilder < Test::Unit::TestCase
     values = [0, border_value]
     assert_equal(build_uint_array([*values, nil]),
                  Arrow::UInt32Array.new(3,
-                                       Arrow::Buffer.new(values.pack("L*")),
-                                       Arrow::Buffer.new([0b011].pack("C*")),
-                                       -1))
+                                        Arrow::Buffer.new(values.pack("L*")),
+                                        Arrow::Buffer.new([0b011].pack("C*")),
+                                        -1))
   end

   def test_uint64
diff --git a/ruby/red-arrow/test/test-table.rb b/ruby/red-arrow/test/test-table.rb
index a69e92615..2117e60df 100644
--- a/ruby/red-arrow/test/test-table.rb
+++ b/ruby/red-arrow/test/test-table.rb
@@ -1521,10 +1521,10 @@ visible: false
                                       ["key2_right", [100, 20]],
                                       ["string", ["1-100", "2-20"]],
                                     ]),
-                    table1.join(table2,
-                                ["key1", "key2"],
-                                left_suffix: "_left",
-                                right_suffix: "_right"))
+                   table1.join(table2,
+                               ["key1", "key2"],
+                               left_suffix: "_left",
+                               right_suffix: "_right"))
     end
   end
 end
```
<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

Reformat Ruby codes.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

Yes.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

No.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #45402