### PR TITLE
GH-43244: [C++][Parquet] Supports write BinaryView/StringView to Parquet file

### DIFF
--- a/cpp/src/parquet/arrow/arrow_schema_test.cc
+++ b/cpp/src/parquet/arrow/arrow_schema_test.cc
@@ -68,6 +68,8 @@ const auto TIMESTAMP_US = ::arrow::timestamp(TimeUnit::MICRO);
 const auto TIMESTAMP_NS = ::arrow::timestamp(TimeUnit::NANO);
 const auto BINARY = ::arrow::binary();
 const auto DECIMAL_8_4 = std::make_shared<::arrow::Decimal128Type>(8, 4);
+const auto BINARY_VIEW = ::arrow::binary_view();
+const auto UTF8_VIEW = ::arrow::utf8_view();
 
 class TestConvertParquetSchema : public ::testing::Test {
  public:
@@ -1014,6 +1016,14 @@ TEST_F(TestConvertArrowSchema, ParquetFlatPrimitives) {
       "binary", Repetition::OPTIONAL, ParquetType::BYTE_ARRAY, ConvertedType::NONE));
   arrow_fields.push_back(::arrow::field("binary", BINARY));
 
+  parquet_fields.push_back(PrimitiveNode::Make(
+      "string_view", Repetition::OPTIONAL, ParquetType::BYTE_ARRAY, ConvertedType::UTF8));
+  arrow_fields.push_back(::arrow::field("string_view", UTF8_VIEW));
+
+  parquet_fields.push_back(PrimitiveNode::Make(
+      "binary_view", Repetition::OPTIONAL, ParquetType::BYTE_ARRAY, ConvertedType::NONE));
+  arrow_fields.push_back(::arrow::field("binary_view", BINARY_VIEW));
+
   ASSERT_OK(ConvertSchema(arrow_fields));
 
   ASSERT_NO_FATAL_FAILURE(CheckFlatSchema(parquet_fields));
@@ -1031,6 +1041,8 @@ TEST_F(TestConvertArrowSchema, ArrowFields) {
   std::vector<FieldConstructionArguments> cases = {
       {"boolean", ::arrow::boolean(), LogicalType::None(), ParquetType::BOOLEAN, -1},
       {"binary", ::arrow::binary(), LogicalType::None(), ParquetType::BYTE_ARRAY, -1},
+      {"binary_view", ::arrow::binary_view(), LogicalType::None(),
+       ParquetType::BYTE_ARRAY, -1},
       {"large_binary", ::arrow::large_binary(), LogicalType::None(),
        ParquetType::BYTE_ARRAY, -1},
       {"fixed_size_binary", ::arrow::fixed_size_binary(64), LogicalType::None(),
@@ -1046,6 +1058,8 @@ TEST_F(TestConvertArrowSchema, ArrowFields) {
       {"float32", ::arrow::float32(), LogicalType::None(), ParquetType::FLOAT, -1},
       {"float64", ::arrow::float64(), LogicalType::None(), ParquetType::DOUBLE, -1},
       {"utf8", ::arrow::utf8(), LogicalType::String(), ParquetType::BYTE_ARRAY, -1},
+      {"utf8_view", ::arrow::utf8_view(), LogicalType::String(), ParquetType::BYTE_ARRAY,
+       -1},
       {"large_utf8", ::arrow::large_utf8(), LogicalType::String(),
        ParquetType::BYTE_ARRAY, -1},
       {"decimal(1, 0)", ::arrow::decimal128(1, 0), LogicalType::Decimal(1, 0),
@@ -1174,6 +1188,16 @@ TEST_F(TestConvertArrowSchema, ParquetFlatPrimitivesAsDictionaries) {
       "binary", Repetition::OPTIONAL, ParquetType::BYTE_ARRAY, ConvertedType::NONE));
   arrow_fields.push_back(
       ::arrow::field("binary", ::arrow::dictionary(::arrow::int8(), ::arrow::binary())));
+
+  parquet_fields.push_back(PrimitiveNode::Make(
+      "string_view", Repetition::OPTIONAL, ParquetType::BYTE_ARRAY, ConvertedType::UTF8));
+  arrow_fields.push_back(::arrow::field(
+      "string_view", ::arrow::dictionary(::arrow::int8(), ::arrow::utf8_view())));
+
+  parquet_fields.push_back(PrimitiveNode::Make(
+      "binary_view", Repetition::OPTIONAL, ParquetType::BYTE_ARRAY, ConvertedType::NONE));
+  arrow_fields.push_back(::arrow::field(
+      "binary_view", ::arrow::dictionary(::arrow::int8(), ::arrow::binary_view())));
 
   ASSERT_OK(ConvertSchema(arrow_fields));
 

--- a/cpp/src/parquet/arrow/schema.cc
+++ b/cpp/src/parquet/arrow/schema.cc
@@ -342,11 +342,13 @@ Status FieldToNode(const std::string& name, const std::shared_ptr<Field>& field,
       break;
     case ArrowTypeId::LARGE_STRING:
     case ArrowTypeId::STRING:
+    case ArrowTypeId::STRING_VIEW:
       type = ParquetType::BYTE_ARRAY;
       logical_type = LogicalType::String();
       break;
     case ArrowTypeId::LARGE_BINARY:
     case ArrowTypeId::BINARY:
+    case ArrowTypeId::BINARY_VIEW:
       type = ParquetType::BYTE_ARRAY;
       break;
     case ArrowTypeId::FIXED_SIZE_BINARY: {

--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -2274,7 +2274,8 @@ template <>
 Status TypedColumnWriterImpl<ByteArrayType>::WriteArrowDense(
     const int16_t* def_levels, const int16_t* rep_levels, int64_t num_levels,
     const ::arrow::Array& array, ArrowWriteContext* ctx, bool maybe_parent_nulls) {
-  if (!::arrow::is_base_binary_like(array.type()->id())) {
+  if (!::arrow::is_base_binary_like(array.type()->id()) &&
+      !::arrow::is_binary_view_like(array.type()->id())) {
     ARROW_UNSUPPORTED();
   }
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

In the case of PARQUET issues on JIRA the title also supports:

    PARQUET-${JIRA_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

`BinaryView`/`StringView` are two new types added in Arrow, this PR aims to add support for writing these types into Parquet files.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

Supports write `BinaryView`/`StringView` to Parquet file

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

I have reimplemented all relevant tests originally designed for `Binary` and `String` types  in `cpp/src/parquet/arrow/arrow_schema_test.cc` and `cpp/src/parquet/encoding_test.cc`, adapting them for `BinaryView` and `StringView`, not sure if there is anything more to do.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

I suppose no?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #43244