### PR TITLE
GH-44761: [GLib] Add garrow_table_validate()

### DIFF
--- a/c_glib/arrow-glib/table.cpp
+++ b/c_glib/arrow-glib/table.cpp
@@ -741,6 +741,8 @@ garrow_table_combine_chunks(GArrowTable *table, GError **error)
  * @table: A #GArrowTable
  * @error: (nullable): Return location for a #GError or %NULL.
  *
+ * Validate the given table. This is a cheap validation.
+ *
  * Returns: %TRUE on success, %FALSE on error.
  *
  * Since: 20.0.0

--- a/c_glib/arrow-glib/table.cpp
+++ b/c_glib/arrow-glib/table.cpp
@@ -339,20 +339,10 @@ garrow_table_new_values(GArrowSchema *schema, GList *values, GError **error)
 
   if (!arrow_chunked_arrays.empty()) {
     auto arrow_table = arrow::Table::Make(arrow_schema, std::move(arrow_chunked_arrays));
-    auto status = arrow_table->Validate();
-    if (garrow_error_check(error, status, context)) {
-      return garrow_table_new_raw(&arrow_table);
-    } else {
-      return NULL;
-    }
+    return garrow_table_new_raw(&arrow_table);
   } else if (!arrow_arrays.empty()) {
     auto arrow_table = arrow::Table::Make(arrow_schema, std::move(arrow_arrays));
-    auto status = arrow_table->Validate();
-    if (garrow_error_check(error, status, context)) {
-      return garrow_table_new_raw(&arrow_table);
-    } else {
-      return NULL;
-    }
+    return garrow_table_new_raw(&arrow_table);
   } else {
     auto maybe_table =
       arrow::Table::FromRecordBatches(arrow_schema, std::move(arrow_record_batches));
@@ -390,12 +380,7 @@ garrow_table_new_chunked_arrays(GArrowSchema *schema,
   }
 
   auto arrow_table = arrow::Table::Make(arrow_schema, arrow_chunked_arrays);
-  auto status = arrow_table->Validate();
-  if (garrow_error_check(error, status, "[table][new][chunked-arrays]")) {
-    return garrow_table_new_raw(&arrow_table);
-  } else {
-    return NULL;
-  }
+  return garrow_table_new_raw(&arrow_table);
 }
 
 /**
@@ -422,12 +407,7 @@ garrow_table_new_arrays(GArrowSchema *schema,
   }
 
   auto arrow_table = arrow::Table::Make(arrow_schema, arrow_arrays);
-  auto status = arrow_table->Validate();
-  if (garrow_error_check(error, status, "[table][new][arrays]")) {
-    return garrow_table_new_raw(&arrow_table);
-  } else {
-    return NULL;
-  }
+  return garrow_table_new_raw(&arrow_table);
 }
 
 /**
@@ -754,6 +734,22 @@ garrow_table_combine_chunks(GArrowTable *table, GError **error)
   } else {
     return NULL;
   }
+}
+
+/**
+ * garrow_table_validate
+ * @table: A #GArrowTable
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: %TRUE on success, %FALSE on error.
+ *
+ * Since: 20.0.0
+ */
+gboolean
+garrow_table_validate(GArrowTable *table, GError **error)
+{
+  const auto arrow_table = garrow_table_get_raw(table);
+  return garrow::check(error, arrow_table->Validate(), "[table][validate]");
 }
 
 typedef struct GArrowFeatherWritePropertiesPrivate_

--- a/c_glib/arrow-glib/table.h
+++ b/c_glib/arrow-glib/table.h
@@ -142,6 +142,10 @@ GARROW_AVAILABLE_IN_0_16
 GArrowTable *
 garrow_table_combine_chunks(GArrowTable *table, GError **error);
 
+GARROW_AVAILABLE_IN_20_0
+gboolean
+garrow_table_validate(GArrowTable *table, GError **error);
+
 #define GARROW_TYPE_FEATHER_WRITE_PROPERTIES (garrow_feather_write_properties_get_type())
 GARROW_AVAILABLE_IN_0_17
 G_DECLARE_DERIVABLE_TYPE(GArrowFeatherWriteProperties,

--- a/c_glib/test/test-table.rb
+++ b/c_glib/test/test-table.rb
@@ -243,6 +243,38 @@ valid:
                    all_values)
     end
 
+    sub_test_case("#validate") do
+      def setup
+        @id_field = Arrow::Field.new("id", Arrow::UInt8DataType.new)
+        @name_field = Arrow::Field.new("name", Arrow::StringDataType.new)
+        @schema = Arrow::Schema.new([@id_field, @name_field])
+
+        @id_value = build_uint_array([1])
+        @name_value = build_string_array(["abc"])
+        @values = [@id_value, @name_value]
+      end
+
+      def test_valid
+        table = Arrow::Table.new(@schema, @values)
+
+        assert do
+          table.validate
+        end
+      end
+
+      def test_invalid
+        message = "[table][validate]: Invalid: " +
+          "Column 1 named name expected length 1 but got length 2"
+
+        invalid_values = [@id_value, build_string_array(["abc","def"])]
+        table = Arrow::Table.new(@schema, invalid_values)
+        assert_raise(Arrow::Error::Invalid.new(message)) do
+          table.validate
+        end
+      end
+
+    end
+
     sub_test_case("#write_as_feather") do
       def setup
         super

--- a/c_glib/test/test-table.rb
+++ b/c_glib/test/test-table.rb
@@ -255,7 +255,7 @@ valid:
       end
 
       def test_valid
-        table = Arrow::Table.new(@schema, @values)
+        table = Arrow::Table.new(@schema, @arrays)
 
         assert do
           table.validate

--- a/c_glib/test/test-table.rb
+++ b/c_glib/test/test-table.rb
@@ -272,7 +272,6 @@ valid:
           table.validate
         end
       end
-
     end
 
     sub_test_case("#write_as_feather") do

--- a/c_glib/test/test-table.rb
+++ b/c_glib/test/test-table.rb
@@ -266,7 +266,7 @@ valid:
         message = "[table][validate]: Invalid: " +
           "Column 1 named name expected length 1 but got length 2"
 
-        invalid_values = [@id_value, build_string_array(["abc", "def"])]
+        invalid_values = [@id_array, build_string_array(["abc", "def"])]
         table = Arrow::Table.new(@schema, invalid_values)
         assert_raise(Arrow::Error::Invalid.new(message)) do
           table.validate

--- a/c_glib/test/test-table.rb
+++ b/c_glib/test/test-table.rb
@@ -266,7 +266,7 @@ valid:
         message = "[table][validate]: Invalid: " +
           "Column 1 named name expected length 1 but got length 2"
 
-        invalid_values = [@id_value, build_string_array(["abc","def"])]
+        invalid_values = [@id_value, build_string_array(["abc", "def"])]
         table = Arrow::Table.new(@schema, invalid_values)
         assert_raise(Arrow::Error::Invalid.new(message)) do
           table.validate

--- a/c_glib/test/test-table.rb
+++ b/c_glib/test/test-table.rb
@@ -251,7 +251,7 @@ valid:
 
         @id_array = build_uint_array([1])
         @name_array = build_string_array(["abc"])
-        @values = [@id_value, @name_value]
+        @arrays = [@id_value, @name_value]
       end
 
       def test_valid

--- a/c_glib/test/test-table.rb
+++ b/c_glib/test/test-table.rb
@@ -251,7 +251,7 @@ valid:
 
         @id_array = build_uint_array([1])
         @name_array = build_string_array(["abc"])
-        @arrays = [@id_value, @name_value]
+        @arrays = [@id_array, @name_array]
       end
 
       def test_valid

--- a/c_glib/test/test-table.rb
+++ b/c_glib/test/test-table.rb
@@ -249,8 +249,8 @@ valid:
         @name_field = Arrow::Field.new("name", Arrow::StringDataType.new)
         @schema = Arrow::Schema.new([@id_field, @name_field])
 
-        @id_value = build_uint_array([1])
-        @name_value = build_string_array(["abc"])
+        @id_array = build_uint_array([1])
+        @name_array = build_string_array(["abc"])
         @values = [@id_value, @name_value]
       end
 


### PR DESCRIPTION
### Rationale for this change

[Table::Validate](https://arrow.apache.org/docs/cpp/api/table.html#_CPPv4NK5arrow5Table8ValidateEv) is available in the C++ API.
But, GLib doesn't support that method yet.

### What changes are included in this PR?

This PR adds a validation method in the table class.
Before this change, the `Validate()` method was used in 
`garrow_table_new_values()`, `garrow_table_new_arrays()`,
and `garrow_table_new_chunked_arrays()` functions implicitly.
This PR removes them and adds it as a separate method.
Users need to call `garrow_table_validate()` explicitly by themselves.
This is a backward incompatible change.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.

**This PR includes breaking changes to public APIs.**

* GitHub Issue: #44761
