### PR TITLE
GH-45412: [JS] Drop support for Node.js 18

### DIFF
--- a/.env
+++ b/.env
@@ -64,7 +64,7 @@ KARTOTHEK=latest
 # LLVM 12 and GCC 11 reports -Wmismatched-new-delete.
 LLVM=14
 MAVEN=3.8.7
-NODE=18
+NODE=20
 NUMBA=latest
 NUMPY=latest
 PANDAS=latest

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -51,7 +51,7 @@ env:
 jobs:
 
   docker:
-    name: AMD64 Debian 12 NodeJS 18
+    name: AMD64 Debian 12 NodeJS 20
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     timeout-minutes: 60
@@ -93,7 +93,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [18]
+        node: [20]
     steps:
       - name: Checkout Arrow
         uses: actions/checkout@v4
@@ -124,7 +124,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [18]
+        node: [20]
     steps:
       - name: Checkout Arrow
         uses: actions/checkout@v4

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -21,7 +21,7 @@
 # Requirements
 # - Ruby >= 2.3
 # - gcc >= 4.8
-# - Node.js >= 18
+# - Node.js >= 20
 # - Go >= 1.22
 # - Docker
 #
@@ -305,16 +305,12 @@ install_nodejs() {
   fi
 
   node_major_version=$(node --version 2>&1 | grep -o '^v[0-9]*' | sed -e 's/^v//g' || :)
-  node_minor_version=$(node --version 2>&1 | grep -o '^v[0-9]*\.[0-9]*' | sed -e 's/^v[0-9]*\.//g' || :)
-  if [[ -n "${node_major_version}" && -n "${node_minor_version}" &&
-      ("${node_major_version}" -eq 16 ||
-        ("${node_major_version}" -eq 18 && "${node_minor_version}" -ge 14) ||
-        "${node_major_version}" -ge 20) ]]; then
-    show_info "Found NodeJS installation with version v${node_major_version}.${node_minor_version}.x"
+  if [[ -n "${node_major_version}" && "${node_major_version}" -ge 20 ]]; then
+    show_info "Found NodeJS installation with version v${node_major_version}.x.x"
   else
     export NVM_DIR="$(pwd)/.nvm"
     mkdir -p $NVM_DIR
-    curl -sL https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | \
+    curl -sL https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | \
       PROFILE=/dev/null bash
     [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
 
@@ -764,7 +760,7 @@ test_js() {
   show_header "Build and test JavaScript libraries"
 
   maybe_setup_nodejs
-  maybe_setup_conda nodejs=18
+  maybe_setup_conda nodejs=20
 
   if ! command -v yarn &> /dev/null; then
     npm install yarn

--- a/js/package.json
+++ b/js/package.json
@@ -118,7 +118,7 @@
     "xml2js": "0.6.2"
   },
   "engines": {
-    "node": ">=12.0"
+    "node": ">=20.0"
   },
   "version": "20.0.0-SNAPSHOT"
 }


### PR DESCRIPTION
### Rationale for this change

It'll reach EOL on 2025-04-30.

### What changes are included in this PR?

Require Node.js 20 or later.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: apache/arrow-js#46
* GitHub Issue: #46