### PR TITLE
GH-45398: [CI][Dev][Ruby] Add Ruby lint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -141,6 +141,18 @@ repos:
           (
           ?^r/src/arrowExports\.cpp$|
           )
+  - repo: https://github.com/rubocop/rubocop
+    rev: "v1.71.0"
+    hooks:
+      - id: rubocop
+        name: Ruby Format
+        alias: ruby-format
+        args: [--autocorrect]
+        exclude: >-
+          (
+          ?^dev/tasks/homebrew-formulae/.*\.rb$|
+          )
+        files: .*\.rb$
   - repo: https://github.com/cheshirekow/cmake-format-precommit
     rev: v0.6.13
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -147,7 +147,8 @@ repos:
       - id: rubocop
         name: Ruby Format
         alias: ruby-format
-        args: [--autocorrect]
+        args:
+          - "--autocorrect"
         exclude: >-
           (
           ?^dev/tasks/homebrew-formulae/.*\.rb$|

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -153,7 +153,6 @@ repos:
           (
           ?^dev/tasks/homebrew-formulae/.*\.rb$|
           )
-        files: .*\.rb$
   - repo: https://github.com/cheshirekow/cmake-format-precommit
     rev: v0.6.13
     hooks:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 # Ruby lint begins minimal.
 # All of checkings changed to disable by default.
 AllCops:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,16 @@
+# Ruby lint begins minimal.
+# All of checkings changed to disable by default.
+AllCops:
+  DisabledByDefault: true
+
+Lint:
+  Enabled: false
+
+# The recommendation width are 80 characters.
+# Due to some codes over the limitation(80 characters),
+# apply the relax value.
+Layout/LineLength:
+  Max: 100
+
+Layout/ArgumentAlignment:
+  Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,9 +23,6 @@ AllCops:
 Lint:
   Enabled: false
 
-# The recommendation width are 80 characters.
-# Due to some codes over the limitation(80 characters),
-# apply the relax value.
 Layout/LineLength:
   Max: 100
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

Multiple users are developing Ruby codes. Adding Ruby Lint helps keep the same style.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

Add Ruby Lint. (Rubocop)

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

Yes.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

No.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #45398