### PR TITLE
GH-45652: [C++][Acero] Unify ConcurrentQueue and BackpressureConcurrentQueue API

### DIFF
--- a/cpp/src/arrow/acero/asof_join_node.cc
+++ b/cpp/src/arrow/acero/asof_join_node.cc
@@ -1103,7 +1103,7 @@ class AsofJoinNode : public ExecNode {
 
   void ProcessThread() {
     for (;;) {
-      if (!process_.Pop()) {
+      if (!process_.WaitAndPop()) {
         EndFromProcessThread();
         return;
       }

--- a/cpp/src/arrow/acero/concurrent_queue_internal.h
+++ b/cpp/src/arrow/acero/concurrent_queue_internal.h
@@ -144,14 +144,14 @@ class BackpressureConcurrentQueue : public ConcurrentQueue<T> {
   T Pop() {
     std::unique_lock<std::mutex> lock(ConcurrentQueue<T>::GetMutex());
     DoHandle do_handle(*this);
-    return ConcurrentQueue<T>::PopUnlocked(lock);
+    return ConcurrentQueue<T>::PopUnlocked();
   }
 
   T WaitAndPop() {
     std::unique_lock<std::mutex> lock(ConcurrentQueue<T>::GetMutex());
     ConcurrentQueue<T>::WaitUntilNonEmpty(lock);
     DoHandle do_handle(*this);
-    return ConcurrentQueue<T>::PopUnlocked(lock);
+    return ConcurrentQueue<T>::PopUnlocked();
   }
 
   void Push(const T& item) {

--- a/cpp/src/arrow/acero/concurrent_queue_internal.h
+++ b/cpp/src/arrow/acero/concurrent_queue_internal.h
@@ -31,12 +31,6 @@ namespace arrow::acero {
 template <class T>
 class ConcurrentQueue {
  public:
-  // Pops the last item from the queue. Must be called on a non-empty queue
-  T Pop() {
-    std::unique_lock<std::mutex> lock(mutex_);
-    return PopUnlocked();
-  }
-
   // Pops the last item from the queue but waits if the queue is empty until new items are
   // pushed.
   T WaitAndPop() {
@@ -139,13 +133,6 @@ class BackpressureConcurrentQueue : public ConcurrentQueue<T> {
  public:
   explicit BackpressureConcurrentQueue(BackpressureHandler handler)
       : handler_(std::move(handler)) {}
-
-  // Pops the last item from the queue. Must be called on a non-empty queue
-  T Pop() {
-    std::unique_lock<std::mutex> lock(ConcurrentQueue<T>::GetMutex());
-    DoHandle do_handle(*this);
-    return ConcurrentQueue<T>::PopUnlocked();
-  }
 
   // Pops the last item from the queue but waits if the queue is empty until new items are
   // pushed.

--- a/cpp/src/arrow/acero/concurrent_queue_internal.h
+++ b/cpp/src/arrow/acero/concurrent_queue_internal.h
@@ -21,7 +21,6 @@
 #include <mutex>
 #include <queue>
 #include "arrow/acero/backpressure_handler.h"
-#include "arrow/util/visibility.h"
 
 namespace arrow::acero {
 

--- a/cpp/src/arrow/acero/concurrent_queue_internal.h
+++ b/cpp/src/arrow/acero/concurrent_queue_internal.h
@@ -34,7 +34,6 @@ class ConcurrentQueue {
  public:
   // Pops the last item from the queue. Must be called on a non-empty queue
   //
-
   T Pop() {
     std::unique_lock<std::mutex> lock(mutex_);
     return PopUnlocked();

--- a/cpp/src/arrow/acero/concurrent_queue_internal.h
+++ b/cpp/src/arrow/acero/concurrent_queue_internal.h
@@ -77,7 +77,7 @@ class ConcurrentQueue {
 
   size_t SizeUnlocked() const { return queue_.size(); }
 
-  T PopUnlocked(std::unique_lock<std::mutex> &lock) {
+  T PopUnlocked(std::unique_lock<std::mutex>& lock) {
     cond_.wait(lock, [&] { return !queue_.empty(); });
     auto item = queue_.front();
     queue_.pop();

--- a/cpp/src/arrow/acero/sorted_merge_node.cc
+++ b/cpp/src/arrow/acero/sorted_merge_node.cc
@@ -586,7 +586,7 @@ class SortedMergeNode : public ExecNode {
   void EmitBatches() {
     while (true) {
       // Implementation note: If the queue is empty, we will block here
-      if (process_queue.Pop() == kPoisonPill) {
+      if (process_queue.WaitAndPop() == kPoisonPill) {
         EndFromProcessThread();
       }
       // Either we're out of data or something went wrong

--- a/cpp/src/arrow/acero/util_test.cc
+++ b/cpp/src/arrow/acero/util_test.cc
@@ -246,55 +246,55 @@ class BackpressureTestExecNode : public ExecNode {
 
 class TestBackpressureControl : public BackpressureControl {
  public:
-  explicit TestBackpressureControl(BackpressureTestExecNode* testNode)
-      : testNode(testNode) {}
-  virtual void Pause() { testNode->PauseProducing(nullptr, 0); }
-  virtual void Resume() { testNode->ResumeProducing(nullptr, 0); }
-  BackpressureTestExecNode* testNode;
+  explicit TestBackpressureControl(BackpressureTestExecNode* test_node)
+      : test_node(test_node) {}
+  virtual void Pause() { test_node->PauseProducing(nullptr, 0); }
+  virtual void Resume() { test_node->ResumeProducing(nullptr, 0); }
+  BackpressureTestExecNode* test_node;
 };
 
 TEST(BackpressureConcurrentQueue, BasicTest) {
-  BackpressureTestExecNode dummyNode;
-  auto ctrl = std::make_unique<TestBackpressureControl>(&dummyNode);
+  BackpressureTestExecNode dummy_node;
+  auto ctrl = std::make_unique<TestBackpressureControl>(&dummy_node);
   ASSERT_OK_AND_ASSIGN(auto handler,
-                       BackpressureHandler::Make(&dummyNode, 2, 4, std::move(ctrl)));
+                       BackpressureHandler::Make(&dummy_node, 2, 4, std::move(ctrl)));
   BackpressureConcurrentQueue<int> queue(std::move(handler));
 
   ConcurrentQueueBasicTest(queue);
-  ASSERT_FALSE(dummyNode.paused);
-  ASSERT_FALSE(dummyNode.stopped);
+  ASSERT_FALSE(dummy_node.paused);
+  ASSERT_FALSE(dummy_node.stopped);
 }
 
 TEST(BackpressureConcurrentQueue, BackpressureTest) {
-  BackpressureTestExecNode dummyNode;
-  auto ctrl = std::make_unique<TestBackpressureControl>(&dummyNode);
+  BackpressureTestExecNode dummy_node;
+  auto ctrl = std::make_unique<TestBackpressureControl>(&dummy_node);
   ASSERT_OK_AND_ASSIGN(auto handler,
-                       BackpressureHandler::Make(&dummyNode, 2, 4, std::move(ctrl)));
+                       BackpressureHandler::Make(&dummy_node, 2, 4, std::move(ctrl)));
   BackpressureConcurrentQueue<int> queue(std::move(handler));
 
   queue.Push(6);
   queue.Push(7);
   queue.Push(8);
-  ASSERT_FALSE(dummyNode.paused);
-  ASSERT_FALSE(dummyNode.stopped);
+  ASSERT_FALSE(dummy_node.paused);
+  ASSERT_FALSE(dummy_node.stopped);
   queue.Push(9);
-  ASSERT_TRUE(dummyNode.paused);
-  ASSERT_FALSE(dummyNode.stopped);
+  ASSERT_TRUE(dummy_node.paused);
+  ASSERT_FALSE(dummy_node.stopped);
   ASSERT_EQ(queue.Pop(), 6);
-  ASSERT_TRUE(dummyNode.paused);
-  ASSERT_FALSE(dummyNode.stopped);
+  ASSERT_TRUE(dummy_node.paused);
+  ASSERT_FALSE(dummy_node.stopped);
   ASSERT_EQ(queue.Pop(), 7);
-  ASSERT_FALSE(dummyNode.paused);
-  ASSERT_FALSE(dummyNode.stopped);
+  ASSERT_FALSE(dummy_node.paused);
+  ASSERT_FALSE(dummy_node.stopped);
   queue.Push(10);
-  ASSERT_FALSE(dummyNode.paused);
-  ASSERT_FALSE(dummyNode.stopped);
+  ASSERT_FALSE(dummy_node.paused);
+  ASSERT_FALSE(dummy_node.stopped);
   queue.Push(11);
-  ASSERT_TRUE(dummyNode.paused);
-  ASSERT_FALSE(dummyNode.stopped);
+  ASSERT_TRUE(dummy_node.paused);
+  ASSERT_FALSE(dummy_node.stopped);
   ASSERT_OK(queue.ForceShutdown());
-  ASSERT_FALSE(dummyNode.paused);
-  ASSERT_TRUE(dummyNode.stopped);
+  ASSERT_FALSE(dummy_node.paused);
+  ASSERT_TRUE(dummy_node.stopped);
 }
 
 }  // namespace acero

--- a/cpp/src/arrow/acero/util_test.cc
+++ b/cpp/src/arrow/acero/util_test.cc
@@ -187,6 +187,9 @@ TEST(FieldMap, ExtensionTypeHashJoin) {
 
 template <typename Queue>
 void ConcurrentQueueBasicTest(Queue& queue) {
+#ifndef ARROW_ENABLE_THREADING
+  GTEST_SKIP() << "Test requires threading enabled";
+#endif
   ASSERT_TRUE(queue.Empty());
   queue.Push(1);
   ASSERT_FALSE(queue.Empty());

--- a/cpp/src/arrow/acero/util_test.cc
+++ b/cpp/src/arrow/acero/util_test.cc
@@ -246,7 +246,8 @@ class BackpressureTestExecNode : public ExecNode {
 
 class TestBackpressureControl : public BackpressureControl {
  public:
-  TestBackpressureControl(BackpressureTestExecNode* testNode) : testNode(testNode) {}
+  explicit TestBackpressureControl(BackpressureTestExecNode* testNode)
+      : testNode(testNode) {}
   virtual void Pause() { testNode->PauseProducing(nullptr, 0); }
   virtual void Resume() { testNode->ResumeProducing(nullptr, 0); }
   BackpressureTestExecNode* testNode;

--- a/cpp/src/arrow/acero/util_test.cc
+++ b/cpp/src/arrow/acero/util_test.cc
@@ -15,12 +15,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <future>
+#include "arrow/acero/concurrent_queue_internal.h"
 #include "arrow/acero/hash_join_node.h"
 #include "arrow/acero/schema_util.h"
 #include "arrow/testing/extension_type.h"
 #include "arrow/testing/gtest_util.h"
 #include "arrow/testing/matchers.h"
-
 using testing::Eq;
 
 namespace arrow {
@@ -182,6 +183,117 @@ TEST(FieldMap, ExtensionTypeHashJoin) {
   auto i =
       schema_mgr.proj_maps[0].map(HashJoinProjection::INPUT, HashJoinProjection::OUTPUT);
   EXPECT_EQ(i.get(0), 0);
+}
+
+template <typename Queue>
+void ConcurrentQueueBasicTest(Queue& queue) {
+  ASSERT_TRUE(queue.Empty());
+  queue.Push(1);
+  ASSERT_FALSE(queue.Empty());
+  ASSERT_EQ(queue.Pop(), 1);
+  ASSERT_TRUE(queue.Empty());
+
+  auto fut_pop = std::async(std::launch::async, [&]() { return queue.WaitAndPop(); });
+  ASSERT_EQ(fut_pop.wait_for(std::chrono::milliseconds(10)), std::future_status::timeout);
+  queue.Push(2);
+  queue.Push(3);
+  queue.Push(4);
+  ASSERT_EQ(fut_pop.wait_for(std::chrono::milliseconds(10)), std::future_status::ready);
+  ASSERT_EQ(fut_pop.get(), 2);
+  fut_pop = std::async(std::launch::async, [&]() { return queue.WaitAndPop(); });
+  ASSERT_EQ(fut_pop.wait_for(std::chrono::milliseconds(10)), std::future_status::ready);
+  ASSERT_EQ(fut_pop.get(), 3);
+  ASSERT_FALSE(queue.Empty());
+  ASSERT_EQ(queue.TryPop(), std::make_optional(4));
+  ASSERT_EQ(queue.TryPop(), std::nullopt);
+  queue.Push(5);
+  ASSERT_FALSE(queue.Empty());
+  ASSERT_EQ(queue.Front(), 5);
+  ASSERT_FALSE(queue.Empty());
+  queue.Clear();
+  ASSERT_TRUE(queue.Empty());
+}
+
+TEST(ConcurrentQueue, BasicTest) {
+  ConcurrentQueue<int> queue;
+  ConcurrentQueueBasicTest(queue);
+}
+
+class BackpressureTestExecNode : public ExecNode {
+ public:
+  BackpressureTestExecNode() : ExecNode(nullptr, {}, {}, nullptr) {}
+  const char* kind_name() const { return "BackpressureTestNode"; }
+  Status InputReceived(ExecNode* input, ExecBatch batch) override {
+    return Status::NotImplemented("Test only node");
+  }
+  Status InputFinished(ExecNode* input, int total_batches) override {
+    return Status::NotImplemented("Test only node");
+  }
+  Status StartProducing() override { return Status::NotImplemented("Test only node"); }
+
+ protected:
+  Status StopProducingImpl() override {
+    stopped = true;
+    return Status::OK();
+  }
+
+ public:
+  void PauseProducing(ExecNode* output, int32_t counter) override { paused = true; }
+  void ResumeProducing(ExecNode* output, int32_t counter) override { paused = false; }
+  bool paused{false};
+  bool stopped{false};
+};
+
+class TestBackpressureControl : public BackpressureControl {
+ public:
+  TestBackpressureControl(BackpressureTestExecNode* testNode) : testNode(testNode) {}
+  virtual void Pause() { testNode->PauseProducing(nullptr, 0); }
+  virtual void Resume() { testNode->ResumeProducing(nullptr, 0); }
+  BackpressureTestExecNode* testNode;
+};
+
+TEST(BackpressureConcurrentQueue, BasicTest) {
+  BackpressureTestExecNode dummyNode;
+  auto ctrl = std::make_unique<TestBackpressureControl>(&dummyNode);
+  ASSERT_OK_AND_ASSIGN(auto handler,
+                       BackpressureHandler::Make(&dummyNode, 2, 4, std::move(ctrl)));
+  BackpressureConcurrentQueue<int> queue(std::move(handler));
+
+  ConcurrentQueueBasicTest(queue);
+  ASSERT_FALSE(dummyNode.paused);
+  ASSERT_FALSE(dummyNode.stopped);
+}
+
+TEST(BackpressureConcurrentQueue, BackpressureTest) {
+  BackpressureTestExecNode dummyNode;
+  auto ctrl = std::make_unique<TestBackpressureControl>(&dummyNode);
+  ASSERT_OK_AND_ASSIGN(auto handler,
+                       BackpressureHandler::Make(&dummyNode, 2, 4, std::move(ctrl)));
+  BackpressureConcurrentQueue<int> queue(std::move(handler));
+
+  queue.Push(6);
+  queue.Push(7);
+  queue.Push(8);
+  ASSERT_FALSE(dummyNode.paused);
+  ASSERT_FALSE(dummyNode.stopped);
+  queue.Push(9);
+  ASSERT_TRUE(dummyNode.paused);
+  ASSERT_FALSE(dummyNode.stopped);
+  ASSERT_EQ(queue.Pop(), 6);
+  ASSERT_TRUE(dummyNode.paused);
+  ASSERT_FALSE(dummyNode.stopped);
+  ASSERT_EQ(queue.Pop(), 7);
+  ASSERT_FALSE(dummyNode.paused);
+  ASSERT_FALSE(dummyNode.stopped);
+  queue.Push(10);
+  ASSERT_FALSE(dummyNode.paused);
+  ASSERT_FALSE(dummyNode.stopped);
+  queue.Push(11);
+  ASSERT_TRUE(dummyNode.paused);
+  ASSERT_FALSE(dummyNode.stopped);
+  ASSERT_OK(queue.ForceShutdown());
+  ASSERT_FALSE(dummyNode.paused);
+  ASSERT_TRUE(dummyNode.stopped);
 }
 
 }  // namespace acero

--- a/cpp/src/arrow/acero/util_test.cc
+++ b/cpp/src/arrow/acero/util_test.cc
@@ -193,7 +193,7 @@ void ConcurrentQueueBasicTest(Queue& queue) {
   ASSERT_TRUE(queue.Empty());
   queue.Push(1);
   ASSERT_FALSE(queue.Empty());
-  ASSERT_EQ(queue.Pop(), 1);
+  ASSERT_EQ(queue.TryPop(), std::make_optional(1));
   ASSERT_TRUE(queue.Empty());
 
   auto fut_pop = std::async(std::launch::async, [&]() { return queue.WaitAndPop(); });
@@ -225,7 +225,7 @@ TEST(ConcurrentQueue, BasicTest) {
 class BackpressureTestExecNode : public ExecNode {
  public:
   BackpressureTestExecNode() : ExecNode(nullptr, {}, {}, nullptr) {}
-  const char* kind_name() const { return "BackpressureTestNode"; }
+  const char* kind_name() const override { return "BackpressureTestNode"; }
   Status InputReceived(ExecNode* input, ExecBatch batch) override {
     return Status::NotImplemented("Test only node");
   }
@@ -283,10 +283,10 @@ TEST(BackpressureConcurrentQueue, BackpressureTest) {
   queue.Push(9);
   ASSERT_TRUE(dummy_node.paused);
   ASSERT_FALSE(dummy_node.stopped);
-  ASSERT_EQ(queue.Pop(), 6);
+  ASSERT_EQ(queue.TryPop(), std::make_optional(6));
   ASSERT_TRUE(dummy_node.paused);
   ASSERT_FALSE(dummy_node.stopped);
-  ASSERT_EQ(queue.Pop(), 7);
+  ASSERT_EQ(queue.TryPop(), std::make_optional(7));
   ASSERT_FALSE(dummy_node.paused);
   ASSERT_FALSE(dummy_node.stopped);
   queue.Push(10);


### PR DESCRIPTION
### Rationale for this change
BackpressureConcurrentQueue::Pop() does not check for empty. This can lead to UB.

### Are there any user-facing changes?
No
* GitHub Issue: #45652