### PR TITLE
GH-45295: [Python][CI] Make download_tzdata_on_windows more robust and use tzdata package for tzinfo database on Windows for ORC

### DIFF
--- a/ci/scripts/python_wheel_windows_test.bat
+++ b/ci/scripts/python_wheel_windows_test.bat
@@ -58,11 +58,14 @@ py -0p
 @REM Validate wheel contents
 %PYTHON_CMD% C:\arrow\ci\scripts\python_wheel_validate_contents.py --path C:\arrow\python\repaired_wheels || exit /B 1
 
-@rem Download IANA Timezone Database for ORC C++
-curl https://cygwin.osuosl.org/noarch/release/tzdata/tzdata-2024a-1.tar.xz --output tzdata.tar.xz || exit /B
-mkdir %USERPROFILE%\Downloads\test\tzdata
-arc unarchive tzdata.tar.xz %USERPROFILE%\Downloads\test\tzdata || exit /B
-set TZDIR=%USERPROFILE%\Downloads\test\tzdata\usr\share\zoneinfo
+@rem Install tzdata python package and set TZDIR to tzdata database defined inside
+%PYTHON_CMD% -m pip install tzdata || exit /B 1
+@echo off
+setlocal EnableDelayedExpansion
+set PYTHON_PROGRAM=!PYTHON_CMD! -c "import os; from importlib import resources; print(os.path.join(resources.files('tzdata'), 'zoneinfo'));"
+for /f "delims=" %%i in ('!PYTHON_PROGRAM!') do set "TZDIR=%%i"
+setlocal DisabledDelayedExpansion
+@echo on
 dir %TZDIR%
 
 @REM Execute unittest

--- a/ci/scripts/python_wheel_windows_test.bat
+++ b/ci/scripts/python_wheel_windows_test.bat
@@ -58,14 +58,5 @@ py -0p
 @REM Validate wheel contents
 %PYTHON_CMD% C:\arrow\ci\scripts\python_wheel_validate_contents.py --path C:\arrow\python\repaired_wheels || exit /B 1
 
-@rem Set TZDIR to tzdata database defined inside tzdata package
-@echo off
-setlocal EnableDelayedExpansion
-set PYTHON_PROGRAM=!PYTHON_CMD! -c "import os; from importlib import resources; print(os.path.join(resources.files('tzdata'), 'zoneinfo'));"
-for /f "delims=" %%i in ('!PYTHON_PROGRAM!') do set "TZDIR=%%i"
-setlocal DisabledDelayedExpansion
-@echo on
-dir %TZDIR%
-
 @REM Execute unittest
 %PYTHON_CMD% -m pytest -r s --pyargs pyarrow || exit /B 1

--- a/ci/scripts/python_wheel_windows_test.bat
+++ b/ci/scripts/python_wheel_windows_test.bat
@@ -58,8 +58,7 @@ py -0p
 @REM Validate wheel contents
 %PYTHON_CMD% C:\arrow\ci\scripts\python_wheel_validate_contents.py --path C:\arrow\python\repaired_wheels || exit /B 1
 
-@rem Install tzdata python package and set TZDIR to tzdata database defined inside
-%PYTHON_CMD% -m pip install tzdata || exit /B 1
+@rem Set TZDIR to tzdata database defined inside tzdata package
 @echo off
 setlocal EnableDelayedExpansion
 set PYTHON_PROGRAM=!PYTHON_CMD! -c "import os; from importlib import resources; print(os.path.join(resources.files('tzdata'), 'zoneinfo'));"

--- a/python/pyarrow/tests/conftest.py
+++ b/python/pyarrow/tests/conftest.py
@@ -60,7 +60,10 @@ if sys.platform == 'win32':
         try:
             os.environ['TZDIR'] = os.path.join(resources.files('tzdata'), 'zoneinfo')
         except ModuleNotFoundError:
-            print('Package "tzdata" not found. Not setting TZDATA environment variable.')
+            print(
+                'Package "tzdata" not found. Not setting TZDATA environment variable.'
+            )
+
 
 def pytest_addoption(parser):
     # Create options to selectively enable test groups

--- a/python/pyarrow/tests/conftest.py
+++ b/python/pyarrow/tests/conftest.py
@@ -54,8 +54,13 @@ if sys.platform == 'win32':
     if tzdata_set_path:
         set_timezone_db_path(tzdata_set_path)
 
-    # GH-45295: For ORC, try to populate TZDIR env var from tzdata package
-    # resource path
+
+# GH-45295: For ORC, try to populate TZDIR env var from tzdata package resource
+# path.
+#
+# Note this is a different kind of database than what we allow to be set by
+# `PYARROW_TZDATA_PATH` and passed to set_timezone_db_path.
+if sys.platform == 'win32':
     if os.environ.get('TZDIR', None) is None:
         from importlib import resources
         try:

--- a/python/pyarrow/tests/conftest.py
+++ b/python/pyarrow/tests/conftest.py
@@ -54,6 +54,13 @@ if sys.platform == 'win32':
     if tzdata_set_path:
         set_timezone_db_path(tzdata_set_path)
 
+    # GH-45295: Try to populate TZDIR env var from tzdata package resource path
+    if os.environ.get('TZDIR', None) is None:
+        from importlib import resources
+        try:
+            os.environ['TZDIR'] = os.path.join(resources.files('tzdata'), 'zoneinfo')
+        except ModuleNotFoundError:
+            print('Package "tzdata" not found. Not setting TZDATA environment variable.')
 
 def pytest_addoption(parser):
     # Create options to selectively enable test groups

--- a/python/pyarrow/tests/conftest.py
+++ b/python/pyarrow/tests/conftest.py
@@ -61,7 +61,7 @@ if sys.platform == 'win32':
             os.environ['TZDIR'] = os.path.join(resources.files('tzdata'), 'zoneinfo')
         except ModuleNotFoundError:
             print(
-                'Package "tzdata" not found. Not setting TZDATA environment variable.'
+                'Package "tzdata" not found. Not setting TZDIR environment variable.'
             )
 
 

--- a/python/pyarrow/tests/conftest.py
+++ b/python/pyarrow/tests/conftest.py
@@ -54,7 +54,8 @@ if sys.platform == 'win32':
     if tzdata_set_path:
         set_timezone_db_path(tzdata_set_path)
 
-    # GH-45295: Try to populate TZDIR env var from tzdata package resource path
+    # GH-45295: For ORC, try to populate TZDIR env var from tzdata package
+    # resource path
     if os.environ.get('TZDIR', None) is None:
         from importlib import resources
         try:

--- a/python/pyarrow/util.py
+++ b/python/pyarrow/util.py
@@ -237,7 +237,7 @@ def _download_urllib(url, out_path):
             f.write(response.read())
 
 
-def download_requests(url, out_path):
+def _download_requests(url, out_path):
     import requests
     with requests.get(url) as response:
         with open(out_path, 'wb') as f:
@@ -264,11 +264,11 @@ def download_tzdata_on_windows():
     # Try to download the files with requests and then fall back to urllib. This
     # works around possible issues in certain older environment (GH-45295)
     try:
-        download_requests(tzdata_url, tzdata_compressed_path)
-        download_requests(windows_zones_url, windows_zones_path)
+        _download_requests(tzdata_url, tzdata_compressed_path)
+        _download_requests(windows_zones_url, windows_zones_path)
     except ImportError:
-        download_urllib(tzdata_url, tzdata_compressed_path)
-        download_urllib(windows_zones_url, windows_zones_path)
+        _download_urllib(tzdata_url, tzdata_compressed_path)
+        _download_urllib(windows_zones_url, windows_zones_path)
 
     assert os.path.exists(tzdata_compressed_path)
     assert os.path.exists(windows_zones_path)

--- a/python/pyarrow/util.py
+++ b/python/pyarrow/util.py
@@ -230,7 +230,7 @@ def _break_traceback_cycle_from_frame(frame):
     refs = frame = this_frame = None
 
 
-def download_urllib(url, out_path):
+def _download_urllib(url, out_path):
     from urllib.request import urlopen
     with urlopen(url) as response:
         with open(out_path, 'wb') as f:

--- a/python/pyarrow/util.py
+++ b/python/pyarrow/util.py
@@ -245,7 +245,7 @@ def download_tzdata_on_windows():
     os.makedirs(tzdata_path, exist_ok=True)
 
     import requests
-    with requests.get('https://data.iana.org/time-zones/tzdata-latest.tar.gz') as response:
+    with requests.get('https://data.iana.org/time-zones/tzdata-latest.tar.gz') as response:  # noqa
         with open(tzdata_compressed, 'wb') as f:
             f.write(response.content)
 

--- a/python/pyarrow/util.py
+++ b/python/pyarrow/util.py
@@ -244,10 +244,10 @@ def download_tzdata_on_windows():
     tzdata_compressed = os.path.join(tzdata_path, "tzdata.tar.gz")
     os.makedirs(tzdata_path, exist_ok=True)
 
-    from urllib.request import urlopen
-    with urlopen('https://data.iana.org/time-zones/tzdata-latest.tar.gz') as response:
+    import requests
+    with requests.get('https://data.iana.org/time-zones/tzdata-latest.tar.gz') as response:
         with open(tzdata_compressed, 'wb') as f:
-            f.write(response.read())
+            f.write(response.content)
 
     assert os.path.exists(tzdata_compressed)
 

--- a/python/pyarrow/util.py
+++ b/python/pyarrow/util.py
@@ -230,6 +230,18 @@ def _break_traceback_cycle_from_frame(frame):
     refs = frame = this_frame = None
 
 
+def download_urllib(url, out_path):
+    from urllib.request import urlopen
+    with urlopen(url) as response:
+        with open(out_path, 'wb') as f:
+            f.write(response.read())
+
+def download_requests(url, out_path):
+    import requests
+    with requests.get(url) as response:
+        with open(out_path, 'wb') as f:
+            f.write(response.content)
+
 def download_tzdata_on_windows():
     r"""
     Download and extract latest IANA timezone database into the
@@ -240,19 +252,23 @@ def download_tzdata_on_windows():
 
     import tarfile
 
+    tzdata_url = "https://data.iana.org/time-zones/tzdata-latest.tar.gz"
     tzdata_path = os.path.expandvars(r"%USERPROFILE%\Downloads\tzdata")
-    tzdata_compressed = os.path.join(tzdata_path, "tzdata.tar.gz")
+    tzdata_compressed_path = os.path.join(tzdata_path, "tzdata.tar.gz")
+    windows_zones_url = "https://raw.githubusercontent.com/unicode-org/cldr/master/common/supplemental/windowsZones.xml"  # noqa
+    windows_zones_path = os.path.join(tzdata_path, "windowsZones.xml")
     os.makedirs(tzdata_path, exist_ok=True)
 
-    import requests
-    with requests.get('https://data.iana.org/time-zones/tzdata-latest.tar.gz') as response:  # noqa
-        with open(tzdata_compressed, 'wb') as f:
-            f.write(response.content)
+    # Try to download the files with requests and then fall back to urllib. This
+    # works around possiblssues in certain older environment (GH-45295)
+    try:
+        download_requests(tzdata_url, tzdata_compressed_path)
+        download_requests(windows_zones_url, windows_zones_path)
+    except ImportError:
+        download_urllib(tzdata_url, tzdata_compressed_path)
+        download_urllib(windows_zones_url, windows_zones_path)
 
-    assert os.path.exists(tzdata_compressed)
+    assert os.path.exists(tzdata_compressed_path)
+    assert os.path.exists(windows_zones_path)
 
-    tarfile.open(tzdata_compressed).extractall(tzdata_path)
-
-    with requests.get('https://raw.githubusercontent.com/unicode-org/cldr/master/common/supplemental/windowsZones.xml') as response_zones:   # noqa
-        with open(os.path.join(tzdata_path, "windowsZones.xml"), 'wb') as f:
-            f.write(response_zones.content)
+    tarfile.open(tzdata_compressed_path).extractall(tzdata_path)

--- a/python/pyarrow/util.py
+++ b/python/pyarrow/util.py
@@ -253,6 +253,6 @@ def download_tzdata_on_windows():
 
     tarfile.open(tzdata_compressed).extractall(tzdata_path)
 
-    with urlopen('https://raw.githubusercontent.com/unicode-org/cldr/master/common/supplemental/windowsZones.xml') as response_zones:   # noqa
+    with requests.get('https://raw.githubusercontent.com/unicode-org/cldr/master/common/supplemental/windowsZones.xml') as response_zones:   # noqa
         with open(os.path.join(tzdata_path, "windowsZones.xml"), 'wb') as f:
-            f.write(response_zones.read())
+            f.write(response_zones.content)

--- a/python/pyarrow/util.py
+++ b/python/pyarrow/util.py
@@ -260,7 +260,7 @@ def download_tzdata_on_windows():
     os.makedirs(tzdata_path, exist_ok=True)
 
     # Try to download the files with requests and then fall back to urllib. This
-    # works around possiblssues in certain older environment (GH-45295)
+    # works around possible issues in certain older environment (GH-45295)
     try:
         download_requests(tzdata_url, tzdata_compressed_path)
         download_requests(windows_zones_url, windows_zones_path)

--- a/python/pyarrow/util.py
+++ b/python/pyarrow/util.py
@@ -236,11 +236,13 @@ def download_urllib(url, out_path):
         with open(out_path, 'wb') as f:
             f.write(response.read())
 
+
 def download_requests(url, out_path):
     import requests
     with requests.get(url) as response:
         with open(out_path, 'wb') as f:
             f.write(response.content)
+
 
 def download_tzdata_on_windows():
     r"""

--- a/python/requirements-wheel-test.txt
+++ b/python/requirements-wheel-test.txt
@@ -4,6 +4,7 @@ hypothesis
 pytest
 pytz
 pyuwsgi; sys.platform != 'win32' and python_version < '3.13'
+requests; sys_platform == 'win32'
 tzdata; sys_platform == 'win32'
 
 # We generally test with the oldest numpy version that supports a given Python


### PR DESCRIPTION
### Rationale for this change

We have two Windows issues and this PR is addressing both:

1. PyArrow's `download_tzdata_on_windows` can fail due to TLS issues in certain CI environments.
2. The Python wheel test infrastructure needs a tzinfo database for ORC and the automation fetching that started failing because the URL was made invalid upstream.

These two issues are being solved in one PR simply because they appeared together during the 19.0.1 release process but they're separate.

### What changes are included in this PR?

1. Makes `download_tzdata_on_windows` more robust to TLS errors by attempting to use `requests` if it's available and falling back to urllib otherwise.
2. Switches our Windows wheel test infrastructure to grab a tzinfo database from the tzdata package on PyPi instead of from a mirror URL. This should be much more stable for us over time.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #45295