### PR TITLE
GH-45427: [Python] Fix version comparison in pandas compat for pandas 2.3 dev version

### DIFF
--- a/python/pyarrow/pandas-shim.pxi
+++ b/python/pyarrow/pandas-shim.pxi
@@ -79,7 +79,7 @@ cdef class _PandasAPIShim(object):
 
         self._is_v1 = self._loose_version < Version('2.0.0')
         self._is_ge_v21 = self._loose_version >= Version('2.1.0')
-        self._is_ge_v23 = self._loose_version >= Version('2.3.0')
+        self._is_ge_v23 = self._loose_version >= Version('2.3.0.dev0')
         self._is_ge_v3 = self._loose_version >= Version('3.0.0.dev0')
         self._is_ge_v3_strict = self._loose_version >= Version('3.0.0')
 


### PR DESCRIPTION
### Rationale for this change

Small follow-up on https://github.com/apache/arrow/pull/45383 to ensure this version comparison also does the right thing for the currently not-yet-released dev version of 2.3.0

* GitHub Issue: #45427