### PR TITLE
Draft: Deserialize MapScalar as Python dict's

### DIFF
--- a/python/pyarrow/scalar.pxi
+++ b/python/pyarrow/scalar.pxi
@@ -885,12 +885,15 @@ cdef class MapScalar(ListScalar):
         Return this value as a Python dict.
         """
         if self.is_valid:
-            try:
-                return {k: self[k].as_py() for k in self.keys()}
-            except KeyError:
-                raise ValueError(
-                    "Converting to Python dictionary is not supported when "
-                    "duplicate field names are present")
+            result_dict = {}
+            for item in self:
+                key, value = item
+                if key in result_dict:
+                    raise ValueError(
+                        "Converting to Python dictionary is not supported when duplicate field names are present"
+                    )
+                result_dict[key] = value
+            return result_dict
         else:
             return None
 

--- a/python/pyarrow/scalar.pxi
+++ b/python/pyarrow/scalar.pxi
@@ -882,10 +882,17 @@ cdef class MapScalar(ListScalar):
 
     def as_py(self):
         """
-        Return this value as a Python list.
+        Return this value as a Python dict.
         """
-        cdef CStructScalar* sp = <CStructScalar*> self.wrapped.get()
-        return list(self) if sp.is_valid else None
+        if self.is_valid:
+            try:
+                return {k: self[k].as_py() for k in self.keys()}
+            except KeyError:
+                raise ValueError(
+                    "Converting to Python dictionary is not supported when "
+                    "duplicate field names are present")
+        else:
+            return None
 
 
 cdef class DictionaryScalar(Scalar):

--- a/python/pyarrow/tests/test_convert_builtin.py
+++ b/python/pyarrow/tests/test_convert_builtin.py
@@ -2055,7 +2055,7 @@ def test_map_from_dicts():
             [{'key': b'd', 'value': 4}, {'key': b'e', 'value': 5},
              {'key': b'f', 'value': None}],
             [{'key': b'g', 'value': 7}]]
-    expected = [[(d['key'], d['value']) for d in entry] for entry in data]
+    expected = [[{'key': d['key'], 'value': d['value']} for d in entry] for entry in data]
 
     arr = pa.array(expected, type=pa.map_(pa.binary(), pa.int32()))
 
@@ -2088,7 +2088,7 @@ def test_map_from_tuples():
 
     arr = pa.array(expected, type=pa.map_(pa.binary(), pa.int32()))
 
-    assert arr.to_pylist() == expected
+    assert arr.to_pylist() == [{b'a': 1, b'b':2}, {b'c': 3}, {b'd': 4, b'e': 5, b'f': None}, {b'g': 7}]
 
     # With omitted values
     expected[1] = None

--- a/python/pyarrow/tests/test_scalars.py
+++ b/python/pyarrow/tests/test_scalars.py
@@ -69,7 +69,7 @@ import pyarrow.compute as pc
     (pa.MonthDayNano([1, -1, -10100]), None,
      pa.MonthDayNanoIntervalScalar),
     ({'a': 1, 'b': [1, 2]}, None, pa.StructScalar),
-    ([('a', 1), ('b', 2)], pa.map_(pa.string(), pa.int8()), pa.MapScalar),
+    ({'a': 1, 'b': 2}, pa.map_(pa.string(), pa.int8()), pa.MapScalar),
 ])
 def test_basics(value, ty, klass, pickle_module):
     s = pa.scalar(value, type=ty)
@@ -757,7 +757,7 @@ def test_map(pickle_module):
     assert len(s) == 2
     assert isinstance(s, pa.MapScalar)
     assert isinstance(s.values, pa.Array)
-    assert repr(s) == "<pyarrow.MapScalar: [('a', 1), ('b', 2)]>"
+    assert repr(s) == "<pyarrow.MapScalar: {'a': 1, 'b': 2}>"
     assert s.values.to_pylist() == [
         {'key': 'a', 'value': 1},
         {'key': 'b', 'value': 2}


### PR DESCRIPTION
### Rationale for this change

As mentioned in [this](https://github.com/apache/arrow/issues/39010) issue, `MapStruct`s are not really deserialized to Python as proper maps/dicts, but as `(key, value)` tuples. This in turn leads to the problem that one can no longer store Python dicts and read them again exactly as they were before they were serialized to parquet files.

### What changes are included in this PR?

`MapStruct`'s will always be deserialized as Python `dict`'s. This will break whenever there are duplicate keys.

### Are these changes tested?

No, not yet.

### Are there any user-facing changes?

Yes, `MapStruct`s will behave totally different now in Python.

This is a Draft PR, for properly supporting this, the `to_pylist` method should receive a `maps_as_pydicts` parameter and this has to be handed all the way through to the `MapScalar` types.