### PR TITLE
GH-37891: [C++] Pass shared_ptr<DataType> by value in SliceBuffer-related constructors

### DIFF
--- a/cpp/src/arrow/buffer.cc
+++ b/cpp/src/arrow/buffer.cc
@@ -75,14 +75,14 @@ Result<std::shared_ptr<Buffer>> SliceBufferSafe(std::shared_ptr<Buffer> buffer,
   return SliceBuffer(std::move(buffer), offset, length);
 }
 
-Result<std::shared_ptr<Buffer>> SliceMutableBufferSafe(
-    std::shared_ptr<Buffer> buffer, int64_t offset) {
+Result<std::shared_ptr<Buffer>> SliceMutableBufferSafe(std::shared_ptr<Buffer> buffer,
+                                                       int64_t offset) {
   RETURN_NOT_OK(CheckBufferSlice(*buffer, offset));
   return SliceMutableBuffer(std::move(buffer), offset);
 }
 
-Result<std::shared_ptr<Buffer>> SliceMutableBufferSafe(
-    std::shared_ptr<Buffer> buffer, int64_t offset, int64_t length) {
+Result<std::shared_ptr<Buffer>> SliceMutableBufferSafe(std::shared_ptr<Buffer> buffer,
+                                                       int64_t offset, int64_t length) {
   RETURN_NOT_OK(CheckBufferSlice(*buffer, offset, length));
   return SliceMutableBuffer(std::move(buffer), offset, length);
 }

--- a/cpp/src/arrow/buffer.cc
+++ b/cpp/src/arrow/buffer.cc
@@ -63,28 +63,28 @@ Status CheckBufferSlice(const Buffer& buffer, int64_t offset) {
 
 }  // namespace
 
-Result<std::shared_ptr<Buffer>> SliceBufferSafe(const std::shared_ptr<Buffer>& buffer,
+Result<std::shared_ptr<Buffer>> SliceBufferSafe(std::shared_ptr<Buffer> buffer,
                                                 int64_t offset) {
   RETURN_NOT_OK(CheckBufferSlice(*buffer, offset));
-  return SliceBuffer(buffer, offset);
+  return SliceBuffer(std::move(buffer), offset);
 }
 
-Result<std::shared_ptr<Buffer>> SliceBufferSafe(const std::shared_ptr<Buffer>& buffer,
+Result<std::shared_ptr<Buffer>> SliceBufferSafe(std::shared_ptr<Buffer> buffer,
                                                 int64_t offset, int64_t length) {
   RETURN_NOT_OK(CheckBufferSlice(*buffer, offset, length));
-  return SliceBuffer(buffer, offset, length);
+  return SliceBuffer(std::move(buffer), offset, length);
 }
 
 Result<std::shared_ptr<Buffer>> SliceMutableBufferSafe(
-    const std::shared_ptr<Buffer>& buffer, int64_t offset) {
+    std::shared_ptr<Buffer> buffer, int64_t offset) {
   RETURN_NOT_OK(CheckBufferSlice(*buffer, offset));
-  return SliceMutableBuffer(buffer, offset);
+  return SliceMutableBuffer(std::move(buffer), offset);
 }
 
 Result<std::shared_ptr<Buffer>> SliceMutableBufferSafe(
-    const std::shared_ptr<Buffer>& buffer, int64_t offset, int64_t length) {
+    std::shared_ptr<Buffer> buffer, int64_t offset, int64_t length) {
   RETURN_NOT_OK(CheckBufferSlice(*buffer, offset, length));
-  return SliceMutableBuffer(buffer, offset, length);
+  return SliceMutableBuffer(std::move(buffer), offset, length);
 }
 
 std::string Buffer::ToHexString() {
@@ -167,9 +167,9 @@ std::shared_ptr<Buffer> Buffer::FromString(std::string data) {
   return std::make_shared<StlStringBuffer>(std::move(data));
 }
 
-std::shared_ptr<Buffer> SliceMutableBuffer(const std::shared_ptr<Buffer>& buffer,
+std::shared_ptr<Buffer> SliceMutableBuffer(std::shared_ptr<Buffer> buffer,
                                            const int64_t offset, const int64_t length) {
-  return std::make_shared<MutableBuffer>(buffer, offset, length);
+  return std::make_shared<MutableBuffer>(std::move(buffer), offset, length);
 }
 
 MutableBuffer::MutableBuffer(const std::shared_ptr<Buffer>& parent, const int64_t offset,

--- a/cpp/src/arrow/buffer.h
+++ b/cpp/src/arrow/buffer.h
@@ -437,8 +437,8 @@ std::shared_ptr<Buffer> SliceMutableBuffer(std::shared_ptr<Buffer> buffer,
 ///
 /// If the parent buffer is not mutable, behavior is undefined (it may abort
 /// in debug builds).
-static inline std::shared_ptr<Buffer> SliceMutableBuffer(
-    std::shared_ptr<Buffer> buffer, const int64_t offset) {
+static inline std::shared_ptr<Buffer> SliceMutableBuffer(std::shared_ptr<Buffer> buffer,
+                                                         const int64_t offset) {
   int64_t length = buffer->size() - offset;
   return SliceMutableBuffer(std::move(buffer), offset, length);
 }
@@ -447,15 +447,15 @@ static inline std::shared_ptr<Buffer> SliceMutableBuffer(
 ///
 /// An Invalid Status is returned if the requested slice falls out of bounds.
 ARROW_EXPORT
-Result<std::shared_ptr<Buffer>> SliceMutableBufferSafe(
-    std::shared_ptr<Buffer> buffer, int64_t offset);
+Result<std::shared_ptr<Buffer>> SliceMutableBufferSafe(std::shared_ptr<Buffer> buffer,
+                                                       int64_t offset);
 /// \brief Input-checking version of SliceMutableBuffer
 ///
 /// An Invalid Status is returned if the requested slice falls out of bounds.
 /// Note that unlike SliceBuffer, `length` isn't clamped to the available buffer size.
 ARROW_EXPORT
-Result<std::shared_ptr<Buffer>> SliceMutableBufferSafe(
-    std::shared_ptr<Buffer> buffer, int64_t offset, int64_t length);
+Result<std::shared_ptr<Buffer>> SliceMutableBufferSafe(std::shared_ptr<Buffer> buffer,
+                                                       int64_t offset, int64_t length);
 
 /// @}
 

--- a/cpp/src/arrow/buffer.h
+++ b/cpp/src/arrow/buffer.h
@@ -396,33 +396,33 @@ class ARROW_EXPORT Buffer {
 /// \brief Construct a view on a buffer at the given offset and length.
 ///
 /// This function cannot fail and does not check for errors (except in debug builds)
-static inline std::shared_ptr<Buffer> SliceBuffer(const std::shared_ptr<Buffer>& buffer,
+static inline std::shared_ptr<Buffer> SliceBuffer(std::shared_ptr<Buffer> buffer,
                                                   const int64_t offset,
                                                   const int64_t length) {
-  return std::make_shared<Buffer>(buffer, offset, length);
+  return std::make_shared<Buffer>(std::move(buffer), offset, length);
 }
 
 /// \brief Construct a view on a buffer at the given offset, up to the buffer's end.
 ///
 /// This function cannot fail and does not check for errors (except in debug builds)
-static inline std::shared_ptr<Buffer> SliceBuffer(const std::shared_ptr<Buffer>& buffer,
+static inline std::shared_ptr<Buffer> SliceBuffer(std::shared_ptr<Buffer> buffer,
                                                   const int64_t offset) {
   int64_t length = buffer->size() - offset;
-  return SliceBuffer(buffer, offset, length);
+  return SliceBuffer(std::move(buffer), offset, length);
 }
 
 /// \brief Input-checking version of SliceBuffer
 ///
 /// An Invalid Status is returned if the requested slice falls out of bounds.
 ARROW_EXPORT
-Result<std::shared_ptr<Buffer>> SliceBufferSafe(const std::shared_ptr<Buffer>& buffer,
+Result<std::shared_ptr<Buffer>> SliceBufferSafe(std::shared_ptr<Buffer> buffer,
                                                 int64_t offset);
 /// \brief Input-checking version of SliceBuffer
 ///
 /// An Invalid Status is returned if the requested slice falls out of bounds.
 /// Note that unlike SliceBuffer, `length` isn't clamped to the available buffer size.
 ARROW_EXPORT
-Result<std::shared_ptr<Buffer>> SliceBufferSafe(const std::shared_ptr<Buffer>& buffer,
+Result<std::shared_ptr<Buffer>> SliceBufferSafe(std::shared_ptr<Buffer> buffer,
                                                 int64_t offset, int64_t length);
 
 /// \brief Like SliceBuffer, but construct a mutable buffer slice.
@@ -430,7 +430,7 @@ Result<std::shared_ptr<Buffer>> SliceBufferSafe(const std::shared_ptr<Buffer>& b
 /// If the parent buffer is not mutable, behavior is undefined (it may abort
 /// in debug builds).
 ARROW_EXPORT
-std::shared_ptr<Buffer> SliceMutableBuffer(const std::shared_ptr<Buffer>& buffer,
+std::shared_ptr<Buffer> SliceMutableBuffer(std::shared_ptr<Buffer> buffer,
                                            const int64_t offset, const int64_t length);
 
 /// \brief Like SliceBuffer, but construct a mutable buffer slice.
@@ -438,9 +438,9 @@ std::shared_ptr<Buffer> SliceMutableBuffer(const std::shared_ptr<Buffer>& buffer
 /// If the parent buffer is not mutable, behavior is undefined (it may abort
 /// in debug builds).
 static inline std::shared_ptr<Buffer> SliceMutableBuffer(
-    const std::shared_ptr<Buffer>& buffer, const int64_t offset) {
+    std::shared_ptr<Buffer> buffer, const int64_t offset) {
   int64_t length = buffer->size() - offset;
-  return SliceMutableBuffer(buffer, offset, length);
+  return SliceMutableBuffer(std::move(buffer), offset, length);
 }
 
 /// \brief Input-checking version of SliceMutableBuffer
@@ -448,14 +448,14 @@ static inline std::shared_ptr<Buffer> SliceMutableBuffer(
 /// An Invalid Status is returned if the requested slice falls out of bounds.
 ARROW_EXPORT
 Result<std::shared_ptr<Buffer>> SliceMutableBufferSafe(
-    const std::shared_ptr<Buffer>& buffer, int64_t offset);
+    std::shared_ptr<Buffer> buffer, int64_t offset);
 /// \brief Input-checking version of SliceMutableBuffer
 ///
 /// An Invalid Status is returned if the requested slice falls out of bounds.
 /// Note that unlike SliceBuffer, `length` isn't clamped to the available buffer size.
 ARROW_EXPORT
 Result<std::shared_ptr<Buffer>> SliceMutableBufferSafe(
-    const std::shared_ptr<Buffer>& buffer, int64_t offset, int64_t length);
+    std::shared_ptr<Buffer> buffer, int64_t offset, int64_t length);
 
 /// @}
 


### PR DESCRIPTION
### Rationale for this change

These changes facilitate the process of moving newly constructed shared_ptr without the need of adding a refcount and still support cases where a reference of a shared_ptr is passed from caller.

### What changes are included in this PR?

- Change `SliceBuffer`-related constructor to take `shared_ptr` by value instead of `const &`.
- Change `SliceBufferSafe`-related constructor to take `shared_ptr` by value instead of `const &`.
- Change `SliceMutableBufferSafe` -related constructors to take `shared_ptr` by value instead of `const &`.

### Are these changes tested?

Yes, by existing tests.

### Are there any user-facing changes?

No, the API changes should not break any compatibility.
* GitHub Issue: #37891