### PR TITLE
GH-45322: [Docs][Python] Added hyperbolic trig functions to PyArrow API reference

### DIFF
--- a/docs/source/python/api/compute.rst
+++ b/docs/source/python/api/compute.rst
@@ -169,6 +169,18 @@ variants which detect domain errors where appropriate.
    sin_checked
    tan
    tan_checked
+   sinh
+   sinh_checked
+   cosh
+   cosh_checked
+   tanh
+   tanh_checked
+   asinh
+   asinh_checked
+   acosh
+   acosh_checked
+   atanh
+   atanh_checked
 
 Comparisons
 -----------


### PR DESCRIPTION
### Description
Added hyperbolic trigonometric functions (sinh, cosh, tanh, etc.) to the PyArrow API reference documentation.

### Motivation
Currently, these functions were missing from the documentation. This PR improves clarity and completeness.

### Changes
- Updated `docs/source/compute.rst` to include hyperbolic trig functions.

### Testing
- Verified that the documentation builds correctly without errors.

### Issue
Fixes GH-45322



* GitHub Issue: #45322