### PR TITLE
GH-45389: [CI][R] Use Ubuntu 22.04 for test-r-versions

### DIFF
--- a/dev/tasks/r/github.linux.versions.yml
+++ b/dev/tasks/r/github.linux.versions.yml
@@ -21,7 +21,7 @@
 
 jobs:
   r-versions:
-    name: "rstudio/r-base:{{ MATRIX }}-focal"
+    name: "rstudio/r-base:{{ MATRIX }}-jammy"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/dev/tasks/r/github.linux.versions.yml
+++ b/dev/tasks/r/github.linux.versions.yml
@@ -36,7 +36,7 @@ jobs:
     env:
       R_ORG: "rstudio"
       R_IMAGE: "r-base"
-      R_TAG: "{{ MATRIX }}-focal"
+      R_TAG: "{{ MATRIX }}-jammy"
       ARROW_R_DEV: "TRUE"
     steps:
       {{ macros.github_checkout_arrow()|indent }}


### PR DESCRIPTION
### Rationale for this change

Ubuntu 20.04 will reach EOL on 2025-05.

### What changes are included in this PR?

Use Ubuntu 22.04 instead of 20.04.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #45389