### PR TITLE
GH-45436: [Docs][Packaging][Linux] Update how to build .deb/.rpm

### DIFF
--- a/dev/tasks/linux-packages/README.md
+++ b/dev/tasks/linux-packages/README.md
@@ -25,16 +25,87 @@
   * Docker
   * Tools to build tar.gz for Apache Arrow C++ and GLib
 
-## How to build .deb packages
+## How to build .deb packages for all supported platforms
 
-```console
-% rake version:update
-% rake apt
+```bash
+cd dev/tasks/linux-packages/apache-arrow
+rake version:update
+rake apt:build
 ```
 
-## How to build .rpm packages
+## How to build .deb packages only for specified supported platforms
+
+The following command line shows all supported platforms:
+
+```bash
+for x in dev/tasks/linux-packages/apache-arrow/apt/{debian,ubuntu}*; do basename $x; done
+```
+
+You can specify target platforms by `APT_TARGETS`:
+
+```bash
+cd dev/tasks/linux-packages/apache-arrow
+rake version:update
+rake apt:build APT_TARGETS=debian-bookworm,ubuntu-noble
+```
+
+## How to debug .deb packages build
+
+You can use `apt:build:console` task to debug .deb packages build:
+
+```bash
+cd dev/tasks/linux-packages/apache-arrow
+rake version:update
+rake apt:build:console APT_TARGETS=debian-bookworm
+```
+
+It will show a Bash prompt. You can start .deb build by `/host/build.sh`:
 
 ```console
-% rake version:update
-% rake yum
+host$ rake apt:build:console APT_TARGETS=debian-bookworm
+container$ /host/build.sh
 ```
+
+You can keep the Bash session even when the .deb build failed. You can
+debug in the Bash session.
+
+## How to build .rpm packages for all supported platforms
+
+```bash
+cd dev/tasks/linux-packages/apache-arrow
+rake yum:build
+```
+
+## How to build .rpm packages only for specified supported platforms
+
+The following command line shows all supported platforms:
+
+```bash
+for x in dev/tasks/linux-packages/apache-arrow/yum/{alma,amazon,centos}*; do basename $x; done
+```
+
+You can specify target platforms by `YUM_TARGETS`:
+
+```bash
+cd dev/tasks/linux-packages/apache-arrow
+rake yum:build YUM_TARGETS=almalinux-9,amazon-linux-2023
+```
+
+## How to debug .rpm packages build
+
+You can use `yum:build:console` task to debug .rpm packages build:
+
+```bash
+cd dev/tasks/linux-packages/apache-arrow
+rake yum:build:console YUM_TARGETS=almalinux-9
+```
+
+It will show a Bash prompt. You can start .rpm build by `/host/build.sh`:
+
+```console
+host$ rake yum:build:console YUM_TARGETS=almalinux-9
+container$ /host/build.sh
+```
+
+You can keep the Bash session even when the .rpm build failed. You can
+debug in the Bash session.

--- a/dev/tasks/linux-packages/README.md
+++ b/dev/tasks/linux-packages/README.md
@@ -33,15 +33,16 @@ rake version:update
 rake apt:build
 ```
 
-## How to build .deb packages only for specified supported platforms
+## How to build only specific .deb packages for supported platforms
 
-The following command line shows all supported platforms:
+The following command line shows all supported platforms, bear in mind to
+execute this command from your root `arrow` clone folder:
 
 ```bash
 for x in dev/tasks/linux-packages/apache-arrow/apt/{debian,ubuntu}*; do basename $x; done
 ```
 
-You can specify target platforms by `APT_TARGETS`:
+You can specify target platforms by setting `APT_TARGETS`:
 
 ```bash
 cd dev/tasks/linux-packages/apache-arrow
@@ -76,7 +77,7 @@ cd dev/tasks/linux-packages/apache-arrow
 rake yum:build
 ```
 
-## How to build .rpm packages only for specified supported platforms
+## How to build only specific .rpm packages for supported platforms
 
 The following command line shows all supported platforms:
 
@@ -84,7 +85,7 @@ The following command line shows all supported platforms:
 for x in dev/tasks/linux-packages/apache-arrow/yum/{alma,amazon,centos}*; do basename $x; done
 ```
 
-You can specify target platforms by `YUM_TARGETS`:
+You can specify target platforms by setting `YUM_TARGETS`:
 
 ```bash
 cd dev/tasks/linux-packages/apache-arrow

--- a/dev/tasks/linux-packages/README.md
+++ b/dev/tasks/linux-packages/README.md
@@ -35,8 +35,8 @@ rake apt:build
 
 ## How to build only specific .deb packages for supported platforms
 
-The following command line shows all supported platforms, bear in mind to
-execute this command from your root `arrow` clone folder:
+The following command line shows all supported platforms, bear in mind
+to execute this command from your root `arrow` clone folder:
 
 ```bash
 for x in dev/tasks/linux-packages/apache-arrow/apt/{debian,ubuntu}*; do basename $x; done
@@ -79,7 +79,8 @@ rake yum:build
 
 ## How to build only specific .rpm packages for supported platforms
 
-The following command line shows all supported platforms:
+The following command line shows all supported platforms, bear in mind
+to execute this command from your root `arrow` clone folder:
 
 ```bash
 for x in dev/tasks/linux-packages/apache-arrow/yum/{alma,amazon,centos}*; do basename $x; done


### PR DESCRIPTION
### Rationale for this change

If we can build .deb/.rpm, we can debug .deb/.rpm build easily.

### What changes are included in this PR?

Update `dev/tasks/linux-packages/README.md`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #45436