### PR TITLE
MINOR: [CI][JAVA] Adding arrow-java submodule to the project

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "testing"]
 	path = testing
 	url = https://github.com/apache/arrow-testing
+[submodule "java"]
+	path = java
+	url = https://github.com/apache/arrow-java.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "cpp/submodules/parquet-testing"]
 	path = cpp/submodules/parquet-testing
 	url = https://github.com/apache/parquet-testing.git
-[submodule "testing"]
-	path = testing
-	url = https://github.com/apache/arrow-testing
 [submodule "java"]
 	path = java
 	url = https://github.com/apache/arrow-java.git
+[submodule "testing"]
+	path = testing
+	url = https://github.com/apache/arrow-testing.git


### PR DESCRIPTION
### What’s done:
- The current [documentation](https://arrow.apache.org/docs/dev/developers/java/building.html#building) recommends running `git submodule update --init --recursive` before building the Java modules (`cd arrow/java`). However, the Java modules are not yet included as submodules, which can be confusing for new contributors. This should be addressed either by updating the documentation or modifying the code. I prefer the code-based solution, as it introduces little to no overhead for development.
- Fixing a misprint which silently caused `testing` submodule not being dowloaded.
