### PR TITLE
GH-45486: [GLib] Add `GArrowArrayStatistics`

### DIFF
--- a/c_glib/arrow-glib/basic-array.h
+++ b/c_glib/arrow-glib/basic-array.h
@@ -42,6 +42,22 @@ GARROW_AVAILABLE_IN_5_0
 gboolean
 garrow_equal_options_is_approx(GArrowEqualOptions *options);
 
+#define GARROW_TYPE_ARRAY_STATISTICS (garrow_array_statistics_get_type())
+GARROW_AVAILABLE_IN_20_0
+G_DECLARE_DERIVABLE_TYPE(
+  GArrowArrayStatistics, garrow_array_statistics, GARROW, ARRAY_STATISTICS, GObject)
+struct _GArrowArrayStatisticsClass
+{
+  GObjectClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_20_0
+gboolean
+garrow_array_statistics_has_null_count(GArrowArrayStatistics *statistics);
+GARROW_AVAILABLE_IN_20_0
+gint64
+garrow_array_statistics_get_null_count(GArrowArrayStatistics *statistics);
+
 GARROW_AVAILABLE_IN_6_0
 GArrowArray *
 garrow_array_import(gpointer c_abi_array, GArrowDataType *data_type, GError **error);
@@ -133,6 +149,10 @@ garrow_array_validate(GArrowArray *array, GError **error);
 GARROW_AVAILABLE_IN_20_0
 gboolean
 garrow_array_validate_full(GArrowArray *array, GError **error);
+
+GARROW_AVAILABLE_IN_20_0
+GArrowArrayStatistics *
+garrow_array_get_statistics(GArrowArray *array);
 
 #define GARROW_TYPE_NULL_ARRAY (garrow_null_array_get_type())
 GARROW_AVAILABLE_IN_ALL

--- a/c_glib/arrow-glib/basic-array.hpp
+++ b/c_glib/arrow-glib/basic-array.hpp
@@ -28,6 +28,10 @@ arrow::EqualOptions *
 garrow_equal_options_get_raw(GArrowEqualOptions *equal_options);
 
 GARROW_EXTERN
+GArrowArrayStatistics *
+garrow_array_statistics_new_raw(arrow::ArrayStatistics *arrow_statistics);
+
+GARROW_EXTERN
 GArrowArray *
 garrow_array_new_raw(std::shared_ptr<arrow::Array> *arrow_array);
 

--- a/c_glib/test/test-array-statistics.rb
+++ b/c_glib/test/test-array-statistics.rb
@@ -1,0 +1,51 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestArrayStatistics < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def setup
+    omit("Parquet is required") unless defined?(::Parquet)
+
+    Tempfile.create(["data", ".parquet"]) do |file|
+      @file = file
+      array = build_int64_array([nil, -(2 ** 32), 2 ** 32])
+      @table = build_table("int64" => array)
+      writer = Parquet::ArrowFileWriter.new(@table.schema, @file.path)
+      chunk_size = 1024
+      writer.write_table(@table, chunk_size)
+      writer.close
+      reader = Parquet::ArrowFileReader.new(@file.path)
+      begin
+        @statistics = reader.read_table.get_column_data(0).get_chunk(0).statistics
+        yield
+      ensure
+        reader.unref
+      end
+    end
+  end
+
+  test("#has_null_count?") do
+    assert do
+      @statistics.has_null_count?
+    end
+  end
+
+  test("#null_count") do
+    assert_equal(1, @statistics.null_count)
+  end
+end


### PR DESCRIPTION
### Rationale for this change

GLib should be able to use `arrow::ArrayStatistics`.

### What changes are included in this PR?

Add `GArrowArrayStatistics` with minimal features.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #45486