### PR TITLE
GH-45491: [GLib] Require Meson 0.61.2 or later

### DIFF
--- a/c_glib/meson.build
+++ b/c_glib/meson.build
@@ -34,9 +34,10 @@ project(
     #   * 22.04: 0.61.2
     #   * 24.04: 1.3.2
     meson_version: '>=0.61.2',
+    version: '20.0.0-SNAPSHOT'
 )
 
-version = '20.0.0-SNAPSHOT'
+version = meson.project_version()
 if version.endswith('-SNAPSHOT')
     version_numbers = version.split('-')[0].split('.')
     version_tag = version.split('-')[1]

--- a/c_glib/meson.build
+++ b/c_glib/meson.build
@@ -34,7 +34,7 @@ project(
     #   * 22.04: 0.61.2
     #   * 24.04: 1.3.2
     meson_version: '>=0.61.2',
-    version: '20.0.0-SNAPSHOT'
+    version: '20.0.0-SNAPSHOT',
 )
 
 version = meson.project_version()

--- a/c_glib/meson.build
+++ b/c_glib/meson.build
@@ -31,9 +31,9 @@ project(
     # Ubuntu:
     #   https://packages.ubuntu.com/search?keywords=meson
     #
-    #   * 20.04: 0.53.2
     #   * 22.04: 0.61.2
-    meson_version: '>=0.53.2',
+    #   * 24.04: 1.3.2
+    meson_version: '>=0.61.2',
 )
 
 version = '20.0.0-SNAPSHOT'
@@ -53,13 +53,8 @@ so_version = version_major * 100 + version_minor
 so_version_patch = version_micro
 library_version = '@0@.@1@.@2@'.format(so_version, so_version_patch, 0)
 
-if meson.version().version_compare('>=0.56.0')
-    project_build_root = meson.project_build_root()
-    project_source_root = meson.project_source_root()
-else
-    project_build_root = meson.build_root()
-    project_source_root = meson.source_root()
-endif
+project_build_root = meson.project_build_root()
+project_source_root = meson.project_source_root()
 
 prefix = get_option('prefix')
 include_dir = join_paths(prefix, get_option('includedir'))
@@ -75,7 +70,7 @@ pkgconfig_variables = []
 base_include_directories = [include_directories('.')]
 
 generate_gi_common_args = {'install': true, 'nsversion': api_version}
-if get_option('werror') and meson.version().version_compare('>=0.55.0')
+if get_option('werror')
     generate_gi_common_args += {'fatal_warnings': true}
 endif
 have_gi = dependency('gobject-introspection-1.0', required: false).found()

--- a/dev/release/01-prepare-test.rb
+++ b/dev/release/01-prepare-test.rb
@@ -136,8 +136,8 @@ class PrepareTest < Test::Unit::TestCase
       {
         path: "c_glib/meson.build",
         hunks: [
-          ["-    version: '#{@snapshot_version}'",
-           "+    version: '#{@release_version}'"],
+          ["-    version: '#{@snapshot_version}',",
+           "+    version: '#{@release_version}',"],
         ],
       },
       {

--- a/dev/release/01-prepare-test.rb
+++ b/dev/release/01-prepare-test.rb
@@ -136,8 +136,8 @@ class PrepareTest < Test::Unit::TestCase
       {
         path: "c_glib/meson.build",
         hunks: [
-          ["-version = '#{@snapshot_version}'",
-           "+version = '#{@release_version}'"],
+          ["-    version: '#{@snapshot_version}'",
+           "+    version: '#{@release_version}'"],
         ],
       },
       {

--- a/dev/release/post-12-bump-versions-test.rb
+++ b/dev/release/post-12-bump-versions-test.rb
@@ -166,8 +166,8 @@ class PostBumpVersionsTest < Test::Unit::TestCase
         {
           path: "c_glib/meson.build",
           hunks: [
-            ["-version = '#{@snapshot_version}'",
-             "+version = '#{@next_snapshot_version}'"],
+            ["     version: '#{@snapshot_version}'",
+             "+    version: '#{@next_snapshot_version}'"],
           ],
         },
         {

--- a/dev/release/post-12-bump-versions-test.rb
+++ b/dev/release/post-12-bump-versions-test.rb
@@ -166,8 +166,8 @@ class PostBumpVersionsTest < Test::Unit::TestCase
         {
           path: "c_glib/meson.build",
           hunks: [
-            ["     version: '#{@snapshot_version}'",
-             "+    version: '#{@next_snapshot_version}'"],
+            ["      version: '#{@snapshot_version}'",
+             "+     version: '#{@next_snapshot_version}'"],
           ],
         },
         {

--- a/dev/release/post-12-bump-versions-test.rb
+++ b/dev/release/post-12-bump-versions-test.rb
@@ -166,8 +166,8 @@ class PostBumpVersionsTest < Test::Unit::TestCase
         {
           path: "c_glib/meson.build",
           hunks: [
-            ["      version: '#{@snapshot_version}',",
-             "+     version: '#{@next_snapshot_version}',"],
+            ["-    version: '#{@snapshot_version}',",
+             "+    version: '#{@next_snapshot_version}',"],
           ],
         },
         {

--- a/dev/release/post-12-bump-versions-test.rb
+++ b/dev/release/post-12-bump-versions-test.rb
@@ -166,8 +166,8 @@ class PostBumpVersionsTest < Test::Unit::TestCase
         {
           path: "c_glib/meson.build",
           hunks: [
-            ["      version: '#{@snapshot_version}'",
-             "+     version: '#{@next_snapshot_version}'"],
+            ["      version: '#{@snapshot_version}',",
+             "+     version: '#{@next_snapshot_version}',"],
           ],
         },
         {

--- a/dev/release/utils-prepare.sh
+++ b/dev/release/utils-prepare.sh
@@ -38,7 +38,7 @@ update_versions() {
 
   pushd "${ARROW_DIR}/c_glib"
   sed -i.bak -E -e \
-    "s/^version = '.+'/version = '${version}'/" \
+    "s/^    version: '.+'/    version: '${version}'/" \
     meson.build
   rm -f meson.build.bak
   git add meson.build


### PR DESCRIPTION
### Rationale for this change

Ubuntu 20.04 that provides Meson 0.53.2 will reach EOL on 2025-05.

Ubuntu 22.04 provides Meson 0.61.2. So we can require Meson 0.61.2 or later.

### What changes are included in this PR?

* Require Meson 0.61.2 or later
* Remove codes for old Meson

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #45491