### PR TITLE
GH-45499: [CI] Bump actions/cache version on GHA

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -113,7 +113,7 @@ jobs:
           fetch-depth: 0
           submodules: recursive
       - name: Cache Docker Volumes
-        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
+        uses: actions/cache@v4
         with:
           path: .docker
           key: ${{ matrix.image }}-${{ hashFiles('cpp/**') }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           ci/scripts/util_free_space.sh
       - name: Cache Docker Volumes
-        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
+        uses: actions/cache@v4
         with:
           path: .docker
           key: debian-docs-${{ hashFiles('cpp/**') }}

--- a/.github/workflows/docs_light.yml
+++ b/.github/workflows/docs_light.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Cache Docker Volumes
-        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
+        uses: actions/cache@v4
         with:
           path: .docker
           key: conda-docs-${{ hashFiles('cpp/**') }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -100,7 +100,7 @@ jobs:
         run: |
           ci/scripts/util_free_space.sh
       - name: Cache Docker Volumes
-        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
+        uses: actions/cache@v4
         with:
           path: .docker
           key: conda-${{ hashFiles('cpp/**') }}

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -108,7 +108,7 @@ jobs:
           fetch-depth: 0
           submodules: recursive
       - name: Cache Docker Volumes
-        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
+        uses: actions/cache@v4
         with:
           path: .docker
           key: ${{ matrix.cache }}-${{ hashFiles('cpp/**') }}

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -145,7 +145,7 @@ jobs:
         run: |
           ci/scripts/util_free_space.sh
       - name: Cache Docker Volumes
-        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
+        uses: actions/cache@v4
         with:
           path: .docker
           # As this key is identical on both matrix builds only one will be able to successfully cache,

--- a/.github/workflows/r_nightly.yml
+++ b/.github/workflows/r_nightly.yml
@@ -86,7 +86,7 @@ jobs:
             exit 1
           fi
       - name: Cache Repo
-        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
+        uses: actions/cache@v4
         with:
           path: repo
           key: r-nightly-${{ github.run_id }}

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -84,7 +84,7 @@ jobs:
           fetch-depth: 0
           submodules: recursive
       - name: Cache Docker Volumes
-        uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
+        uses: actions/cache@v4
         with:
           path: .docker
           key: ubuntu-${{ matrix.ubuntu }}-ruby-${{ hashFiles('cpp/**') }}


### PR DESCRIPTION
### Rationale for this change

Older versions of the `actions/cache` GitHub action are being deprecated as explained in https://github.com/actions/cache/discussions/1510.
Because of this, some CI jobs have started to fail: https://github.com/apache/arrow/actions/runs/13265539807/job/37034895918

### Are these changes tested?

Yes, by construction.

### Are there any user-facing changes?

No.
* GitHub Issue: #45499