### PR TITLE
GH-45505: [CI][R] Use Ubuntu 22.04 instead of 20.04 as much as possible for nightly jobs

### DIFF
--- a/dev/tasks/r/github.linux.arrow.version.back.compat.yml
+++ b/dev/tasks/r/github.linux.arrow.version.back.compat.yml
@@ -89,11 +89,19 @@ jobs:
         - { old_arrow_version: '1.0.1', r: '4.0' }
     env:
       ARROW_R_DEV: "TRUE"
-      RSPM: "https://packagemanager.rstudio.com/cran/__linux__/jammy/latest"
       OLD_ARROW_VERSION: {{ '${{ matrix.config.old_arrow_version }}' }}
     steps:
       {{ macros.github_checkout_arrow()|indent }}
 
+      - name: Prepare RSPM
+        run: |
+          old_arrow_version_major=$(echo ${OLD_ARROW_VERSION} | cut -d. -f1)
+          # Binary arrow packages for Ubuntu 22.04 are available only
+          # for 6.0.0 or later.
+          if [ ${old_arrow_version_major} -ge 6 ]; then
+            rspm="https://packagemanager.rstudio.com/cran/__linux__/jammy/latest"
+            echo "RSPM=${rspm}" >> $GITHUB_ENV
+          fi
       - uses: r-lib/actions/setup-r@v2
         with:
           r-version: {{ '${{ matrix.config.r }}' }}

--- a/dev/tasks/r/github.linux.arrow.version.back.compat.yml
+++ b/dev/tasks/r/github.linux.arrow.version.back.compat.yml
@@ -74,10 +74,11 @@ jobs:
     # earlier can't be built on Ubuntu 22.04. We will drop 3.0.0 or
     # earlier when Ubuntu 20.04 is unavailable on GitHub Actions.
     runs-on: >-
-      ${{ (startsWith(matrix.config.old_arrow_version, '3.') ||
-           startsWith(matrix.config.old_arrow_version, '2.') ||
-           startsWith(matrix.config.old_arrow_version, '1.')) && 'ubuntu-20.04' ||
-                                                                 'ubuntu-22.04' }}
+      {{ '${{ (startsWith(matrix.config.old_arrow_version, '3.') ||
+               startsWith(matrix.config.old_arrow_version, '2.') ||
+               startsWith(matrix.config.old_arrow_version, '1.')) &&
+                 'ubuntu-20.04' ||
+                 'ubuntu-22.04' }}' }}
     strategy:
       fail-fast: false
       matrix:

--- a/dev/tasks/r/github.linux.arrow.version.back.compat.yml
+++ b/dev/tasks/r/github.linux.arrow.version.back.compat.yml
@@ -74,11 +74,11 @@ jobs:
     # earlier can't be built on Ubuntu 22.04. We will drop 3.0.0 or
     # earlier when Ubuntu 20.04 is unavailable on GitHub Actions.
     runs-on: >-
-      {{ '${{ (startsWith(matrix.config.old_arrow_version, '3.') ||
+      {{ "${{ (startsWith(matrix.config.old_arrow_version, '3.') ||
                startsWith(matrix.config.old_arrow_version, '2.') ||
                startsWith(matrix.config.old_arrow_version, '1.')) &&
                  'ubuntu-20.04' ||
-                 'ubuntu-22.04' }}' }}
+                 'ubuntu-22.04' }}" }}
     strategy:
       fail-fast: false
       matrix:

--- a/dev/tasks/r/github.linux.arrow.version.back.compat.yml
+++ b/dev/tasks/r/github.linux.arrow.version.back.compat.yml
@@ -22,12 +22,12 @@
 jobs:
   write-files:
     name: "Write files"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
     env:
       ARROW_R_DEV: "TRUE"
-      RSPM: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"
+      RSPM: "https://packagemanager.rstudio.com/cran/__linux__/jammy/latest"
     steps:
       {{ macros.github_checkout_arrow()|indent }}
 
@@ -66,7 +66,7 @@ jobs:
   read-files:
     name: "Read files with Arrow {{ '${{ matrix.config.old_arrow_version }}' }}"
     needs: [write-files]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
@@ -89,7 +89,7 @@ jobs:
         - { old_arrow_version: '1.0.1', r: '4.0' }
     env:
       ARROW_R_DEV: "TRUE"
-      RSPM: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"
+      RSPM: "https://packagemanager.rstudio.com/cran/__linux__/jammy/latest"
       OLD_ARROW_VERSION: {{ '${{ matrix.config.old_arrow_version }}' }}
     steps:
       {{ macros.github_checkout_arrow()|indent }}

--- a/dev/tasks/r/github.linux.arrow.version.back.compat.yml
+++ b/dev/tasks/r/github.linux.arrow.version.back.compat.yml
@@ -66,7 +66,18 @@ jobs:
   read-files:
     name: "Read files with Arrow {{ '${{ matrix.config.old_arrow_version }}' }}"
     needs: [write-files]
-    runs-on: ubuntu-22.04
+    # condition && true-case || false-case
+    # ==
+    # condition ? true-case : false-case
+    #
+    # We use Ubuntu 20.04 for 3.0.0 or earlier because 3.0.0 or
+    # earlier can't be built on Ubuntu 22.04. We will drop 3.0.0 or
+    # earlier when Ubuntu 20.04 is unavailable on GitHub Actions.
+    runs-on: >-
+      ${{ (startsWith(matrix.config.old_arrow_version, '3.') ||
+           startsWith(matrix.config.old_arrow_version, '2.') ||
+           startsWith(matrix.config.old_arrow_version, '1.')) && 'ubuntu-20.04' ||
+                                                                 'ubuntu-22.04' }}
     strategy:
       fail-fast: false
       matrix:
@@ -96,10 +107,15 @@ jobs:
       - name: Prepare RSPM
         run: |
           old_arrow_version_major=$(echo ${OLD_ARROW_VERSION} | cut -d. -f1)
-          # Binary arrow packages for Ubuntu 22.04 are available only
-          # for 6.0.0 or later.
           if [ ${old_arrow_version_major} -ge 6 ]; then
+            # Binary arrow packages for Ubuntu 22.04 are available only
+            # for 6.0.0 or later.
             rspm="https://packagemanager.rstudio.com/cran/__linux__/jammy/latest"
+            echo "RSPM=${rspm}" >> $GITHUB_ENV
+          elif [ ${old_arrow_version_major} -le 3 ]; then
+            # We use Ubuntu 20.04 for 3.0.0 or earlier because 3.0.0 or earlier
+            # can't be built on Ubuntu 22.04.
+            rspm="https://packagemanager.rstudio.com/cran/__linux__/focal/latest"
             echo "RSPM=${rspm}" >> $GITHUB_ENV
           fi
       - uses: r-lib/actions/setup-r@v2

--- a/dev/tasks/r/github.linux.offline.build.yml
+++ b/dev/tasks/r/github.linux.offline.build.yml
@@ -22,12 +22,12 @@
 jobs:
   grab-dependencies:
     name: "Download thirdparty dependencies"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
     env:
       ARROW_R_DEV: "TRUE"
-      RSPM: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"
+      RSPM: "https://packagemanager.rstudio.com/cran/__linux__/jammy/latest"
     steps:
       {{ macros.github_checkout_arrow()|indent }}
 
@@ -49,12 +49,12 @@ jobs:
   install-offline:
     name: "Install offline"
     needs: [grab-dependencies]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
     env:
       ARROW_R_DEV: TRUE
-      RSPM: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"
+      RSPM: "https://packagemanager.rstudio.com/cran/__linux__/jammy/latest"
     steps:
       {{ macros.github_checkout_arrow()|indent }}
 

--- a/dev/tasks/r/github.linux.rchk.yml
+++ b/dev/tasks/r/github.linux.rchk.yml
@@ -22,12 +22,12 @@
 jobs:
   as-cran:
     name: "rchk"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
     env:
       ARROW_R_DEV: "FALSE"
-      RSPM: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"
+      RSPM: "https://packagemanager.rstudio.com/cran/__linux__/jammy/latest"
     steps:
       {{ macros.github_checkout_arrow()|indent }}
 

--- a/dev/tasks/r/github.macos-linux.local.yml
+++ b/dev/tasks/r/github.macos-linux.local.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macOS-latest, ubuntu-20.04]
+        os: [macOS-latest, ubuntu-22.04]
 
     steps:
       {{ macros.github_checkout_arrow()|indent }}

--- a/dev/tasks/r/github.packages.yml
+++ b/dev/tasks/r/github.packages.yml
@@ -313,8 +313,8 @@ jobs:
           # fedora-clang-devel cannot use binaries bc of libc++ (uncomment to see the error)
           # - {image: "rhub/fedora-clang-devel", libarrow_binary: "TRUE"}
           - {image: "rhub/ubuntu-release"} # currently ubuntu-22.04
-          - {image: "rocker/r-ver:4.0.0"} # ubuntu-20.04
-          - {image: "rstudio/r-base:4.1-focal"}
+          - {image: "rstudio/r-base:4.0-jammy"}
+          - {image: "rstudio/r-base:4.1-jammy"}
           - {image: "rstudio/r-base:4.2-jammy"}
           - {image: "rstudio/r-base:4.3-noble"}
     steps:


### PR DESCRIPTION
### Rationale for this change

Ubuntu 20.04 will reach EOL on 2025-05.

### What changes are included in this PR?

* Use Ubuntu 22.04 instead of Ubuntu 20.04 for Apache Arrow C++ 4.0.0 or later.
* Keep using Ubuntu 20.04 for Apache Arrow C++ 3.0.0 or earlier because we can't build Apache Arrow C++ 3.0.0 or earlier on Ubuntu 22.04. We can use pre-built binaries forApache Arrow C++ 3.0.0 or earlier on Ubuntu 20.04.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #45505