### PR TITLE
GH-45508: [CI][R] Remove Ubuntu version from sanitizer jobs

### DIFF
--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -90,7 +90,7 @@ groups:
     - example-*python*
 
   r:
-    - test*-r-*
+    - test-r-*
     - r-binary-packages
     - r-recheck-most
 
@@ -1291,7 +1291,7 @@ tasks:
       r_tag: latest
       flags: "-e LIBARROW_MINIMAL=TRUE"
 
-  test-ubuntu-r-sanitizer:
+  test-r-linux-sanitizer:
     ci: github
     template: docker-tests/github.linux.yml
     params:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1582,11 +1582,11 @@ services:
       /bin/bash -c "/arrow/ci/scripts/r_test.sh /arrow"
 
   ubuntu-r-sanitizer:
-    # Only 20.04 and amd64 supported
+    # Only 22.04 and amd64 supported
     # Usage:
     #   docker compose build ubuntu-r-sanitizer
     #   docker compose run ubuntu-r-sanitizer
-    image: ${REPO}:amd64-ubuntu-20.04-r-sanitizer
+    image: ${REPO}:amd64-ubuntu-22.04-r-sanitizer
     cap_add:
       # LeakSanitizer and gdb requires ptrace(2)
       - SYS_PTRACE
@@ -1594,7 +1594,7 @@ services:
       context: .
       dockerfile: ci/docker/linux-r.dockerfile
       cache_from:
-        - ${REPO}:amd64-ubuntu-20.04-r-sanitizer
+        - ${REPO}:amd64-ubuntu-22.04-r-sanitizer
       args:
         base: wch1/r-debug:latest
         cmake: ${CMAKE}
@@ -1638,16 +1638,16 @@ services:
         /arrow/ci/scripts/r_sanitize.sh /arrow"
 
   ubuntu-r-valgrind:
-    # Only 20.04 and amd64 supported
+    # Only 22.04 and amd64 supported
     # Usage:
     #   docker compose build ubuntu-r-valgrind
     #   docker compose run ubuntu-r-valgrind
-    image: ${REPO}:amd64-ubuntu-20.04-r-valgrind
+    image: ${REPO}:amd64-ubuntu-22.04-r-valgrind
     build:
       context: .
       dockerfile: ci/docker/linux-r.dockerfile
       cache_from:
-        - ${REPO}:amd64-ubuntu-20.04-r-valgrind
+        - ${REPO}:amd64-ubuntu-22.04-r-valgrind
       args:
         base: wch1/r-debug:latest
         cmake: ${CMAKE}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1586,7 +1586,7 @@ services:
     # Usage:
     #   docker compose build ubuntu-r-sanitizer
     #   docker compose run ubuntu-r-sanitizer
-    image: ${REPO}:amd64-ubuntu-22.04-r-sanitizer
+    image: ${REPO}:amd64-ubuntu-r-sanitizer
     cap_add:
       # LeakSanitizer and gdb requires ptrace(2)
       - SYS_PTRACE

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1582,7 +1582,7 @@ services:
       /bin/bash -c "/arrow/ci/scripts/r_test.sh /arrow"
 
   ubuntu-r-sanitizer:
-    # Only 22.04 and amd64 supported
+    # Only amd64 supported
     # Usage:
     #   docker compose build ubuntu-r-sanitizer
     #   docker compose run ubuntu-r-sanitizer
@@ -1594,7 +1594,7 @@ services:
       context: .
       dockerfile: ci/docker/linux-r.dockerfile
       cache_from:
-        - ${REPO}:amd64-ubuntu-22.04-r-sanitizer
+        - ${REPO}:amd64-ubuntu-r-sanitizer
       args:
         base: wch1/r-debug:latest
         cmake: ${CMAKE}
@@ -1638,16 +1638,16 @@ services:
         /arrow/ci/scripts/r_sanitize.sh /arrow"
 
   ubuntu-r-valgrind:
-    # Only 22.04 and amd64 supported
+    # Only amd64 supported
     # Usage:
     #   docker compose build ubuntu-r-valgrind
     #   docker compose run ubuntu-r-valgrind
-    image: ${REPO}:amd64-ubuntu-22.04-r-valgrind
+    image: ${REPO}:amd64-ubuntu-r-valgrind
     build:
       context: .
       dockerfile: ci/docker/linux-r.dockerfile
       cache_from:
-        - ${REPO}:amd64-ubuntu-22.04-r-valgrind
+        - ${REPO}:amd64-ubuntu-r-valgrind
       args:
         base: wch1/r-debug:latest
         cmake: ${CMAKE}


### PR DESCRIPTION
### Rationale for this change

`ubuntu-r-sanitizer` and `ubuntu-r-valgrind` use `wch1/r-debug` as their base image.

So we can't control Ubuntu versions for them.

### What changes are included in this PR?

Remove Ubuntu version from their configurations.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #45508