### PR TITLE
GH-45506: [C++][Acero] More overflow-safe Swiss table

### DIFF
--- a/cpp/src/arrow/acero/swiss_join.cc
+++ b/cpp/src/arrow/acero/swiss_join.cc
@@ -645,6 +645,8 @@ void SwissTableMerge::MergePartition(SwissTable* target, const SwissTable* sourc
       SwissTable::num_groupid_bits_from_log_blocks(source->log_blocks());
   int source_block_bytes =
       SwissTable::num_block_bytes_from_num_groupid_bits(source_group_id_bits);
+  uint32_t source_group_id_mask =
+      SwissTable::group_id_mask_from_num_groupid_bits(source_group_id_bits);
   ARROW_DCHECK(source_block_bytes % sizeof(uint64_t) == 0);
 
   // Compute index of the last block in target that corresponds to the given
@@ -670,8 +672,8 @@ void SwissTableMerge::MergePartition(SwissTable* target, const SwissTable* sourc
     for (int local_slot_id = 0; local_slot_id < num_full_slots; ++local_slot_id) {
       // Read group id and hash for this slot.
       //
-      uint32_t group_id =
-          source->extract_group_id(block_bytes, local_slot_id, source_group_id_bits);
+      uint32_t group_id = SwissTable::extract_group_id(
+          block_bytes, local_slot_id, source_group_id_bits, source_group_id_mask);
       uint32_t global_slot_id = SwissTable::global_slot_id(block_id, local_slot_id);
       uint32_t hash = source->hashes()[global_slot_id];
       // Insert partition id into the highest bits of hash, shifting the

--- a/cpp/src/arrow/acero/swiss_join_internal.h
+++ b/cpp/src/arrow/acero/swiss_join_internal.h
@@ -380,8 +380,8 @@ class SwissTableMerge {
   // Max block id value greater or equal to the number of blocks guarantees that
   // the search will not be stopped.
   //
-  static inline bool InsertNewGroup(SwissTable* target, uint64_t group_id, uint32_t hash,
-                                    int64_t max_block_id);
+  static inline bool InsertNewGroup(SwissTable* target, uint32_t group_id, uint32_t hash,
+                                    uint32_t max_block_id);
 };
 
 struct SwissTableWithKeys {

--- a/cpp/src/arrow/compute/key_map_internal.cc
+++ b/cpp/src/arrow/compute/key_map_internal.cc
@@ -94,27 +94,32 @@ inline void SwissTable::search_block(uint64_t block, int stamp, int start_slot,
   *out_slot = static_cast<int>(CountLeadingZeros(matches | block_high_bits) >> 3);
 }
 
-template <typename T, bool use_selection>
+template <bool use_selection>
 void SwissTable::extract_group_ids_imp(const int num_keys, const uint16_t* selection,
                                        const uint32_t* hashes, const uint8_t* local_slots,
-                                       uint32_t* out_group_ids, int element_offset,
-                                       int element_multiplier) const {
-  const T* elements = reinterpret_cast<const T*>(blocks_->data()) + element_offset;
+                                       uint32_t* out_group_ids) const {
   if (log_blocks_ == 0) {
-    ARROW_DCHECK(sizeof(T) == sizeof(uint8_t));
     for (int i = 0; i < num_keys; ++i) {
       uint32_t id = use_selection ? selection[i] : i;
-      uint32_t group_id = blocks()[8 + local_slots[id]];
+      uint32_t group_id =
+          block_data(/*block_id=*/0,
+                     /*num_block_bytes=*/0)[bytes_status_in_block_ + local_slots[id]];
       out_group_ids[id] = group_id;
     }
   } else {
+    int num_groupid_bits = num_groupid_bits_from_log_blocks(log_blocks_);
+    int num_groupid_bytes = num_groupid_bits / 8;
+    uint32_t group_id_mask = group_id_mask_from_num_groupid_bits(num_groupid_bits);
+    int num_block_bytes = num_block_bytes_from_num_groupid_bits(num_groupid_bits);
+
     for (int i = 0; i < num_keys; ++i) {
       uint32_t id = use_selection ? selection[i] : i;
       uint32_t hash = hashes[id];
-      int64_t pos =
-          (hash >> (bits_hash_ - log_blocks_)) * element_multiplier + local_slots[id];
-      uint32_t group_id = static_cast<uint32_t>(elements[pos]);
-      ARROW_DCHECK(group_id < num_inserted_ || num_inserted_ == 0);
+      uint32_t block_id = block_id_from_hash(hash, log_blocks_);
+      uint32_t group_id = *reinterpret_cast<const uint32_t*>(
+          block_data(block_id, num_block_bytes) + local_slots[id] * num_groupid_bytes +
+          bytes_status_in_block_);
+      group_id &= group_id_mask;
       out_group_ids[id] = group_id;
     }
   }
@@ -123,59 +128,22 @@ void SwissTable::extract_group_ids_imp(const int num_keys, const uint16_t* selec
 void SwissTable::extract_group_ids(const int num_keys, const uint16_t* optional_selection,
                                    const uint32_t* hashes, const uint8_t* local_slots,
                                    uint32_t* out_group_ids) const {
-  // Group id values for all 8 slots in the block are bit-packed and follow the status
-  // bytes. We assume here that the number of bits is rounded up to 8, 16, 32 or 64. In
-  // that case we can extract group id using aligned 64-bit word access.
-  int num_group_id_bits = num_groupid_bits_from_log_blocks(log_blocks_);
-  ARROW_DCHECK(num_group_id_bits == 8 || num_group_id_bits == 16 ||
-               num_group_id_bits == 32);
-
   int num_processed = 0;
-
   // Optimistically use simplified lookup involving only a start block to find
   // a single group id candidate for every input.
 #if defined(ARROW_HAVE_RUNTIME_AVX2) && defined(ARROW_HAVE_RUNTIME_BMI2)
-  int num_group_id_bytes = num_group_id_bits / 8;
   if ((hardware_flags_ & CpuInfo::AVX2) && CpuInfo::GetInstance()->HasEfficientBmi2() &&
       !optional_selection) {
-    num_processed = extract_group_ids_avx2(num_keys, hashes, local_slots, out_group_ids,
-                                           sizeof(uint64_t), 8 + 8 * num_group_id_bytes,
-                                           num_group_id_bytes);
+    num_processed = extract_group_ids_avx2(num_keys, hashes, local_slots, out_group_ids);
   }
 #endif
-  switch (num_group_id_bits) {
-    case 8:
-      if (optional_selection) {
-        extract_group_ids_imp<uint8_t, true>(num_keys, optional_selection, hashes,
-                                             local_slots, out_group_ids, 8, 16);
-      } else {
-        extract_group_ids_imp<uint8_t, false>(
-            num_keys - num_processed, nullptr, hashes + num_processed,
-            local_slots + num_processed, out_group_ids + num_processed, 8, 16);
-      }
-      break;
-    case 16:
-      if (optional_selection) {
-        extract_group_ids_imp<uint16_t, true>(num_keys, optional_selection, hashes,
-                                              local_slots, out_group_ids, 4, 12);
-      } else {
-        extract_group_ids_imp<uint16_t, false>(
-            num_keys - num_processed, nullptr, hashes + num_processed,
-            local_slots + num_processed, out_group_ids + num_processed, 4, 12);
-      }
-      break;
-    case 32:
-      if (optional_selection) {
-        extract_group_ids_imp<uint32_t, true>(num_keys, optional_selection, hashes,
-                                              local_slots, out_group_ids, 2, 10);
-      } else {
-        extract_group_ids_imp<uint32_t, false>(
-            num_keys - num_processed, nullptr, hashes + num_processed,
-            local_slots + num_processed, out_group_ids + num_processed, 2, 10);
-      }
-      break;
-    default:
-      ARROW_DCHECK(false);
+  if (optional_selection) {
+    extract_group_ids_imp<true>(num_keys, optional_selection, hashes, local_slots,
+                                out_group_ids);
+  } else {
+    extract_group_ids_imp<false>(num_keys - num_processed, nullptr,
+                                 hashes + num_processed, local_slots + num_processed,
+                                 out_group_ids + num_processed);
   }
 }
 
@@ -195,9 +163,9 @@ void SwissTable::init_slot_ids(const int num_keys, const uint16_t* selection,
     for (int i = 0; i < num_keys; ++i) {
       uint16_t id = selection[i];
       uint32_t hash = hashes[id];
-      uint32_t iblock = (hash >> (bits_hash_ - log_blocks_));
+      uint32_t iblock = block_id_from_hash(hash, log_blocks_);
       uint32_t match = ::arrow::bit_util::GetBit(match_bitvector, id) ? 1 : 0;
-      uint32_t slot_id = iblock * 8 + local_slots[id] + match;
+      uint32_t slot_id = global_slot_id(iblock, local_slots[id] + match);
       out_slot_ids[id] = slot_id;
     }
   }
@@ -207,11 +175,11 @@ void SwissTable::init_slot_ids_for_new_keys(uint32_t num_ids, const uint16_t* id
                                             const uint32_t* hashes,
                                             uint32_t* slot_ids) const {
   int num_groupid_bits = num_groupid_bits_from_log_blocks(log_blocks_);
-  uint32_t num_block_bytes = num_groupid_bits + 8;
+  int num_block_bytes = num_block_bytes_from_num_groupid_bits(num_groupid_bits);
   if (log_blocks_ == 0) {
     uint64_t block = *reinterpret_cast<const uint64_t*>(blocks_->mutable_data());
-    uint32_t empty_slot =
-        static_cast<uint32_t>(8 - ARROW_POPCOUNT64(block & kHighBitOfEachByte));
+    uint32_t empty_slot = static_cast<uint32_t>(
+        kSlotsPerBlock - ARROW_POPCOUNT64(block & kHighBitOfEachByte));
     for (uint32_t i = 0; i < num_ids; ++i) {
       int id = ids[i];
       slot_ids[id] = empty_slot;
@@ -220,19 +188,18 @@ void SwissTable::init_slot_ids_for_new_keys(uint32_t num_ids, const uint16_t* id
     for (uint32_t i = 0; i < num_ids; ++i) {
       int id = ids[i];
       uint32_t hash = hashes[id];
-      uint32_t iblock = hash >> (bits_hash_ - log_blocks_);
+      uint32_t iblock = block_id_from_hash(hash, log_blocks_);
       uint64_t block;
       for (;;) {
-        block = *reinterpret_cast<const uint64_t*>(blocks_->mutable_data() +
-                                                   num_block_bytes * iblock);
+        block = *reinterpret_cast<const uint64_t*>(block_data(iblock, num_block_bytes));
         block &= kHighBitOfEachByte;
         if (block) {
           break;
         }
         iblock = (iblock + 1) & ((1 << log_blocks_) - 1);
       }
-      uint32_t empty_slot = static_cast<int>(8 - ARROW_POPCOUNT64(block));
-      slot_ids[id] = iblock * 8 + empty_slot;
+      uint32_t empty_slot = static_cast<int>(kSlotsPerBlock - ARROW_POPCOUNT64(block));
+      slot_ids[id] = global_slot_id(iblock, empty_slot);
     }
   }
 }
@@ -249,6 +216,7 @@ void SwissTable::early_filter_imp(const int num_keys, const uint32_t* hashes,
   // Based on the size of the table, prepare bit number constants.
   uint32_t stamp_mask = (1 << bits_stamp_) - 1;
   int num_groupid_bits = num_groupid_bits_from_log_blocks(log_blocks_);
+  int num_block_bytes = num_block_bytes_from_num_groupid_bits(num_groupid_bits);
 
   for (int i = 0; i < num_keys; ++i) {
     // Extract from hash: block index and stamp
@@ -258,9 +226,7 @@ void SwissTable::early_filter_imp(const int num_keys, const uint32_t* hashes,
     uint32_t stamp = iblock & stamp_mask;
     iblock >>= bits_shift_for_block_;
 
-    uint32_t num_block_bytes = num_groupid_bits + 8;
-    const uint8_t* blockbase =
-        blocks_->data() + static_cast<uint64_t>(iblock) * num_block_bytes;
+    const uint8_t* blockbase = block_data(iblock, num_block_bytes);
     ARROW_DCHECK(num_block_bytes % sizeof(uint64_t) == 0);
     uint64_t block = *reinterpret_cast<const uint64_t*>(blockbase);
 
@@ -297,8 +263,8 @@ uint64_t SwissTable::num_groups_for_resize() const {
   }
 }
 
-uint64_t SwissTable::wrap_global_slot_id(uint64_t global_slot_id) const {
-  uint64_t global_slot_id_mask = (1 << (log_blocks_ + 3)) - 1;
+uint32_t SwissTable::wrap_global_slot_id(uint32_t global_slot_id) const {
+  uint32_t global_slot_id_mask = static_cast<uint32_t>((1ULL << (log_blocks_ + 3)) - 1);
   return global_slot_id & global_slot_id_mask;
 }
 
@@ -396,23 +362,22 @@ void SwissTable::run_comparisons(const int num_keys,
 bool SwissTable::find_next_stamp_match(const uint32_t hash, const uint32_t in_slot_id,
                                        uint32_t* out_slot_id,
                                        uint32_t* out_group_id) const {
-  const uint64_t num_groupid_bits = num_groupid_bits_from_log_blocks(log_blocks_);
+  const int num_groupid_bits = num_groupid_bits_from_log_blocks(log_blocks_);
+  const int num_block_bytes = num_block_bytes_from_num_groupid_bits(num_groupid_bits);
   constexpr uint64_t stamp_mask = 0x7f;
   const int stamp =
       static_cast<int>((hash >> bits_shift_for_block_and_stamp_) & stamp_mask);
-  uint64_t start_slot_id = wrap_global_slot_id(in_slot_id);
+  uint32_t start_slot_id = wrap_global_slot_id(in_slot_id);
   int match_found;
   int local_slot;
-  uint8_t* blockbase;
+  const uint8_t* blockbase;
   for (;;) {
-    const uint64_t num_block_bytes = (8 + num_groupid_bits);
-    blockbase = blocks_->mutable_data() + num_block_bytes * (start_slot_id >> 3);
-    uint64_t block = *reinterpret_cast<uint64_t*>(blockbase);
+    blockbase = block_data(start_slot_id >> 3, num_block_bytes);
+    uint64_t block = *reinterpret_cast<const uint64_t*>(blockbase);
 
-    search_block<true>(block, stamp, (start_slot_id & 7), &local_slot, &match_found);
+    search_block<true>(block, stamp, start_slot_id & 7, &local_slot, &match_found);
 
-    start_slot_id =
-        wrap_global_slot_id((start_slot_id & ~7ULL) + local_slot + match_found);
+    start_slot_id = wrap_global_slot_id((start_slot_id & ~7U) + local_slot + match_found);
 
     // Match found can be 1 in two cases:
     // - match was found
@@ -423,10 +388,8 @@ bool SwissTable::find_next_stamp_match(const uint32_t hash, const uint32_t in_sl
     }
   }
 
-  const uint64_t groupid_mask = (1ULL << num_groupid_bits) - 1;
-  *out_group_id =
-      static_cast<uint32_t>(extract_group_id(blockbase, local_slot, groupid_mask));
-  *out_slot_id = static_cast<uint32_t>(start_slot_id);
+  *out_group_id = extract_group_id(blockbase, local_slot, num_groupid_bits);
+  *out_slot_id = start_slot_id;
 
   return match_found;
 }
@@ -531,7 +494,7 @@ Status SwissTable::map_new_keys_helper(
   //
   ARROW_DCHECK(*inout_num_selected <= static_cast<uint32_t>(1 << log_minibatch_));
 
-  size_t num_bytes_for_bits = (*inout_num_selected + 7) / 8 + sizeof(uint64_t);
+  size_t num_bytes_for_bits = (*inout_num_selected + 7) / 8 + bytes_status_in_block_;
   auto match_bitvector_buf = util::TempVectorHolder<uint8_t>(
       temp_stack, static_cast<uint32_t>(num_bytes_for_bits));
   uint8_t* match_bitvector = match_bitvector_buf.mutable_data();
@@ -645,7 +608,8 @@ Status SwissTable::map_new_keys(uint32_t num_ids, uint16_t* ids, const uint32_t*
       for (uint32_t i = 0; i < num_ids; ++i) {
         // First slot in the new starting block
         const int16_t id = ids[i];
-        slot_ids[id] = (hashes[id] >> (bits_hash_ - log_blocks_)) * 8;
+        uint32_t block_id = block_id_from_hash(hashes[id], log_blocks_);
+        slot_ids[id] = global_slot_id(block_id, 0);
       }
     }
   } while (num_ids > 0);
@@ -662,10 +626,11 @@ Status SwissTable::grow_double() {
   int bits_shift_for_block_and_stamp_after =
       ComputeBitsShiftForBlockAndStamp(log_blocks_after);
   int bits_shift_for_block_after = ComputeBitsShiftForBlock(log_blocks_after);
-  uint64_t block_size_before = (8 + num_group_id_bits_before);
-  uint64_t block_size_after = (8 + num_group_id_bits_after);
-  uint64_t block_size_total_after = (block_size_after << log_blocks_after) + padding_;
-  uint64_t hashes_size_total_after =
+  int block_size_before = num_block_bytes_from_num_groupid_bits(num_group_id_bits_before);
+  int block_size_after = num_block_bytes_from_num_groupid_bits(num_group_id_bits_after);
+  int64_t block_size_total_after =
+      num_bytes_total_blocks(block_size_after, log_blocks_after);
+  int64_t hashes_size_total_after =
       (bits_hash_ / 8 * (1 << (log_blocks_after + 3))) + padding_;
   constexpr uint32_t stamp_mask = (1 << bits_stamp_) - 1;
 
@@ -682,42 +647,42 @@ Status SwissTable::grow_double() {
   // (block other than selected by hash bits corresponding to the entry).
   for (int i = 0; i < (1 << log_blocks_); ++i) {
     // How many full slots in this block
-    uint8_t* block_base = blocks_->mutable_data() + i * block_size_before;
+    const uint8_t* block_base = block_data(i, block_size_before);
     uint8_t* double_block_base_new =
-        blocks_new->mutable_data() + 2 * i * block_size_after;
+        mutable_block_data(blocks_new->mutable_data(), 2 * i, block_size_after);
     uint64_t block = *reinterpret_cast<const uint64_t*>(block_base);
 
-    auto full_slots =
-        static_cast<int>(CountLeadingZeros(block & kHighBitOfEachByte) >> 3);
-    int full_slots_new[2];
+    uint32_t full_slots = CountLeadingZeros(block & kHighBitOfEachByte) >> 3;
+    uint32_t full_slots_new[2];
     full_slots_new[0] = full_slots_new[1] = 0;
     util::SafeStore(double_block_base_new, kHighBitOfEachByte);
     util::SafeStore(double_block_base_new + block_size_after, kHighBitOfEachByte);
 
-    for (int j = 0; j < full_slots; ++j) {
-      uint64_t slot_id = i * 8 + j;
+    for (uint32_t j = 0; j < full_slots; ++j) {
+      uint64_t slot_id = global_slot_id(i, j);
       uint32_t hash = hashes()[slot_id];
-      uint64_t block_id_new = hash >> (bits_hash_ - log_blocks_after);
+      uint32_t block_id_new = block_id_from_hash(hash, log_blocks_after);
       bool is_overflow_entry = ((block_id_new >> 1) != static_cast<uint64_t>(i));
       if (is_overflow_entry) {
         continue;
       }
 
-      int ihalf = block_id_new & 1;
+      uint32_t ihalf = block_id_new & 1;
       uint8_t stamp_new = (hash >> bits_shift_for_block_and_stamp_after) & stamp_mask;
       uint64_t group_id_bit_offs = j * num_group_id_bits_before;
       uint64_t group_id =
-          (util::SafeLoadAs<uint64_t>(block_base + 8 + (group_id_bit_offs >> 3)) >>
+          (util::SafeLoadAs<uint64_t>(block_base + bytes_status_in_block_ +
+                                      (group_id_bit_offs >> 3)) >>
            (group_id_bit_offs & 7)) &
           group_id_mask_before;
 
-      uint64_t slot_id_new = i * 16 + ihalf * 8 + full_slots_new[ihalf];
+      uint64_t slot_id_new = global_slot_id(i * 2 + ihalf, full_slots_new[ihalf]);
       hashes_new[slot_id_new] = hash;
       uint8_t* block_base_new = double_block_base_new + ihalf * block_size_after;
       block_base_new[7 - full_slots_new[ihalf]] = stamp_new;
-      int group_id_bit_offs_new = full_slots_new[ihalf] * num_group_id_bits_after;
-      uint64_t* ptr =
-          reinterpret_cast<uint64_t*>(block_base_new + 8 + (group_id_bit_offs_new >> 3));
+      int64_t group_id_bit_offs_new = full_slots_new[ihalf] * num_group_id_bits_after;
+      uint64_t* ptr = reinterpret_cast<uint64_t*>(
+          block_base_new + bytes_status_in_block_ + (group_id_bit_offs_new >> 3));
       util::SafeStore(ptr,
                       util::SafeLoad(ptr) | (group_id << (group_id_bit_offs_new & 7)));
       full_slots_new[ihalf]++;
@@ -728,14 +693,14 @@ Status SwissTable::grow_double() {
   // Reinsert entries that were in an overflow block.
   for (int i = 0; i < (1 << log_blocks_); ++i) {
     // How many full slots in this block
-    uint8_t* block_base = blocks_->mutable_data() + i * block_size_before;
+    const uint8_t* block_base = block_data(i, block_size_before);
     uint64_t block = util::SafeLoadAs<uint64_t>(block_base);
-    int full_slots = static_cast<int>(CountLeadingZeros(block & kHighBitOfEachByte) >> 3);
+    uint32_t full_slots = CountLeadingZeros(block & kHighBitOfEachByte) >> 3;
 
-    for (int j = 0; j < full_slots; ++j) {
-      uint64_t slot_id = i * 8 + j;
+    for (uint32_t j = 0; j < full_slots; ++j) {
+      uint64_t slot_id = global_slot_id(i, j);
       uint32_t hash = hashes()[slot_id];
-      uint64_t block_id_new = hash >> (bits_hash_ - log_blocks_after);
+      uint32_t block_id_new = block_id_from_hash(hash, log_blocks_after);
       bool is_overflow_entry = ((block_id_new >> 1) != static_cast<uint64_t>(i));
       if (!is_overflow_entry) {
         continue;
@@ -743,17 +708,18 @@ Status SwissTable::grow_double() {
 
       uint64_t group_id_bit_offs = j * num_group_id_bits_before;
       uint64_t group_id =
-          (util::SafeLoadAs<uint64_t>(block_base + 8 + (group_id_bit_offs >> 3)) >>
+          (util::SafeLoadAs<uint64_t>(block_base + bytes_status_in_block_ +
+                                      (group_id_bit_offs >> 3)) >>
            (group_id_bit_offs & 7)) &
           group_id_mask_before;
       uint8_t stamp_new = (hash >> bits_shift_for_block_and_stamp_after) & stamp_mask;
 
       uint8_t* block_base_new =
-          blocks_new->mutable_data() + block_id_new * block_size_after;
+          mutable_block_data(blocks_new->mutable_data(), block_id_new, block_size_after);
       uint64_t block_new = util::SafeLoadAs<uint64_t>(block_base_new);
       int full_slots_new =
           static_cast<int>(CountLeadingZeros(block_new & kHighBitOfEachByte) >> 3);
-      while (full_slots_new == 8) {
+      while (full_slots_new == kSlotsPerBlock) {
         block_id_new = (block_id_new + 1) & ((1 << log_blocks_after) - 1);
         block_base_new = blocks_new->mutable_data() + block_id_new * block_size_after;
         block_new = util::SafeLoadAs<uint64_t>(block_base_new);
@@ -763,9 +729,9 @@ Status SwissTable::grow_double() {
 
       hashes_new[block_id_new * 8 + full_slots_new] = hash;
       block_base_new[7 - full_slots_new] = stamp_new;
-      int group_id_bit_offs_new = full_slots_new * num_group_id_bits_after;
-      uint64_t* ptr =
-          reinterpret_cast<uint64_t*>(block_base_new + 8 + (group_id_bit_offs_new >> 3));
+      int64_t group_id_bit_offs_new = full_slots_new * num_group_id_bits_after;
+      uint64_t* ptr = reinterpret_cast<uint64_t*>(
+          block_base_new + bytes_status_in_block_ + (group_id_bit_offs_new >> 3));
       util::SafeStore(ptr,
                       util::SafeLoad(ptr) | (group_id << (group_id_bit_offs_new & 7)));
     }
@@ -792,17 +758,17 @@ Status SwissTable::init(int64_t hardware_flags, MemoryPool* pool, int log_blocks
   int num_groupid_bits = num_groupid_bits_from_log_blocks(log_blocks_);
   num_inserted_ = 0;
 
-  const uint64_t block_bytes = 8 + num_groupid_bits;
-  const uint64_t slot_bytes = (block_bytes << log_blocks_) + padding_;
+  const int block_bytes = num_block_bytes_from_num_groupid_bits(num_groupid_bits);
+  const int64_t slot_bytes = num_bytes_total_blocks(block_bytes, log_blocks_);
   ARROW_ASSIGN_OR_RAISE(blocks_, AllocateBuffer(slot_bytes, pool_));
 
   // Make sure group ids are initially set to zero for all slots.
   memset(blocks_->mutable_data(), 0, slot_bytes);
 
   // Initialize all status bytes to represent an empty slot.
-  uint8_t* blocks_ptr = blocks_->mutable_data();
-  for (uint64_t i = 0; i < (static_cast<uint64_t>(1) << log_blocks_); ++i) {
-    util::SafeStore(blocks_ptr + i * block_bytes, kHighBitOfEachByte);
+  for (int i = 0; i < 1 << log_blocks_; ++i) {
+    auto block = mutable_block_data(i, block_bytes);
+    util::SafeStore(block, kHighBitOfEachByte);
   }
 
   if (no_hash_array) {

--- a/cpp/src/arrow/compute/key_map_internal.h
+++ b/cpp/src/arrow/compute/key_map_internal.h
@@ -85,8 +85,6 @@ class ARROW_EXPORT SwissTable {
     return reinterpret_cast<uint32_t*>(hashes_->mutable_data());
   }
 
-  inline void insert_into_empty_slot(uint32_t slot_id, uint32_t hash, uint32_t group_id);
-
   /// \brief Extract group id for a given slot in a given block.
   ///
   static uint32_t extract_group_id(const uint8_t* block_ptr, int local_slot,
@@ -96,6 +94,8 @@ class ARROW_EXPORT SwissTable {
         block_ptr + bytes_status_in_block_ + local_slot * num_group_id_bits / 8);
     return group_id & group_id_mask;
   }
+
+  inline void insert_into_empty_slot(uint32_t slot_id, uint32_t hash, uint32_t group_id);
 
   static uint32_t block_id_from_hash(uint32_t hash, int log_blocks) {
     return hash >> (bits_hash_ - log_blocks);

--- a/cpp/src/arrow/compute/key_map_internal.h
+++ b/cpp/src/arrow/compute/key_map_internal.h
@@ -102,7 +102,7 @@ class ARROW_EXPORT SwissTable {
   }
 
   static uint32_t global_slot_id(uint32_t block_id, uint32_t local_slot_id) {
-    return block_id * static_cast<uint32_t>(kSlotsPerBlock) + local_slot_id;
+    return block_id * kSlotsPerBlock + local_slot_id;
   }
 
   static int num_groupid_bits_from_log_blocks(int log_blocks) {

--- a/cpp/src/arrow/compute/key_map_internal.h
+++ b/cpp/src/arrow/compute/key_map_internal.h
@@ -81,18 +81,29 @@ class ARROW_EXPORT SwissTable {
 
   void num_inserted(uint32_t i) { num_inserted_ = i; }
 
-  uint8_t* blocks() const { return blocks_->mutable_data(); }
-
   uint32_t* hashes() const {
     return reinterpret_cast<uint32_t*>(hashes_->mutable_data());
   }
 
+  inline void insert_into_empty_slot(uint32_t slot_id, uint32_t hash, uint32_t group_id);
+
   /// \brief Extract group id for a given slot in a given block.
   ///
-  inline uint64_t extract_group_id(const uint8_t* block_ptr, int slot,
-                                   uint64_t group_id_mask) const;
+  static uint32_t extract_group_id(const uint8_t* block_ptr, int local_slot,
+                                   int64_t num_group_id_bits) {
+    uint32_t group_id_mask = group_id_mask_from_num_groupid_bits(num_group_id_bits);
+    uint32_t group_id = *reinterpret_cast<const uint32_t*>(
+        block_ptr + bytes_status_in_block_ + local_slot * num_group_id_bits / 8);
+    return group_id & group_id_mask;
+  }
 
-  inline void insert_into_empty_slot(uint32_t slot_id, uint32_t hash, uint32_t group_id);
+  static uint32_t block_id_from_hash(uint32_t hash, int log_blocks) {
+    return hash >> (bits_hash_ - log_blocks);
+  }
+
+  static uint32_t global_slot_id(uint32_t block_id, uint32_t local_slot_id) {
+    return block_id * static_cast<uint32_t>(kSlotsPerBlock) + local_slot_id;
+  }
 
   static int num_groupid_bits_from_log_blocks(int log_blocks) {
     int required_bits = log_blocks + 3;
@@ -102,10 +113,38 @@ class ARROW_EXPORT SwissTable {
                                  : 64;
   }
 
+  static int num_block_bytes_from_num_groupid_bits(int num_groupid_bits) {
+    return num_groupid_bits + bytes_status_in_block_;
+  }
+
+  static int64_t num_bytes_total_blocks(int num_block_bytes, int log_blocks) {
+    return (static_cast<int64_t>(num_block_bytes) << log_blocks) + padding_;
+  }
+
+  const uint8_t* block_data(uint32_t block_id, int num_block_bytes) const {
+    return block_data(blocks_->data(), block_id, num_block_bytes);
+  }
+
+  uint8_t* mutable_block_data(uint32_t block_id, int num_block_bytes) {
+    return mutable_block_data(blocks_->mutable_data(), block_id, num_block_bytes);
+  }
+
+  static constexpr int kSlotsPerBlock = 8;
+
   // Use 32-bit hash for now
   static constexpr int bits_hash_ = 32;
 
  private:
+  static const uint8_t* block_data(const uint8_t* blocks, uint32_t block_id,
+                                   int num_block_bytes) {
+    return blocks + static_cast<int64_t>(block_id) * num_block_bytes;
+  }
+
+  static uint8_t* mutable_block_data(uint8_t* blocks, uint32_t block_id,
+                                     int num_block_bytes) {
+    return blocks + static_cast<int64_t>(block_id) * num_block_bytes;
+  }
+
   // Lookup helpers
 
   /// \brief Scan bytes in block in reverse and stop as soon
@@ -139,18 +178,17 @@ class ARROW_EXPORT SwissTable {
                          const uint32_t* hashes, const uint8_t* local_slots,
                          uint32_t* out_group_ids) const;
 
-  template <typename T, bool use_selection>
+  template <bool use_selection>
   void extract_group_ids_imp(const int num_keys, const uint16_t* selection,
                              const uint32_t* hashes, const uint8_t* local_slots,
-                             uint32_t* out_group_ids, int elements_offset,
-                             int element_multiplier) const;
+                             uint32_t* out_group_ids) const;
 
   inline uint64_t next_slot_to_visit(uint64_t block_index, int slot,
                                      int match_found) const;
 
   inline uint64_t num_groups_for_resize() const;
 
-  inline uint64_t wrap_global_slot_id(uint64_t global_slot_id) const;
+  inline uint32_t wrap_global_slot_id(uint32_t global_slot_id) const;
 
   void init_slot_ids(const int num_keys, const uint16_t* selection,
                      const uint32_t* hashes, const uint8_t* local_slots,
@@ -173,8 +211,7 @@ class ARROW_EXPORT SwissTable {
                                 uint8_t* out_match_bitvector,
                                 uint8_t* out_local_slots) const;
   int extract_group_ids_avx2(const int num_keys, const uint32_t* hashes,
-                             const uint8_t* local_slots, uint32_t* out_group_ids,
-                             int byte_offset, int byte_multiplier, int byte_size) const;
+                             const uint8_t* local_slots, uint32_t* out_group_ids) const;
 #endif
 
   void run_comparisons(const int num_keys, const uint16_t* optional_selection_ids,
@@ -220,6 +257,12 @@ class ARROW_EXPORT SwissTable {
     return bits_stamp_;
   }
 
+  static uint32_t group_id_mask_from_num_groupid_bits(int64_t num_groupid_bits) {
+    return static_cast<uint32_t>((1ULL << num_groupid_bits) - 1);
+  }
+
+  static constexpr int bytes_status_in_block_ = 8;
+
   // Number of hash bits stored in slots in a block.
   // The highest bits of hash determine block id.
   // The next set of highest bits is a "stamp" stored in a slot in a block.
@@ -263,39 +306,22 @@ class ARROW_EXPORT SwissTable {
   MemoryPool* pool_;
 };
 
-uint64_t SwissTable::extract_group_id(const uint8_t* block_ptr, int slot,
-                                      uint64_t group_id_mask) const {
-  // Group id values for all 8 slots in the block are bit-packed and follow the status
-  // bytes. We assume here that the number of bits is rounded up to 8, 16, 32 or 64. In
-  // that case we can extract group id using aligned 64-bit word access.
-  int num_group_id_bits = static_cast<int>(ARROW_POPCOUNT64(group_id_mask));
-  assert(num_group_id_bits == 8 || num_group_id_bits == 16 || num_group_id_bits == 32 ||
-         num_group_id_bits == 64);
-
-  int bit_offset = slot * num_group_id_bits;
-  const uint64_t* group_id_bytes =
-      reinterpret_cast<const uint64_t*>(block_ptr) + 1 + (bit_offset >> 6);
-  uint64_t group_id = (*group_id_bytes >> (bit_offset & 63)) & group_id_mask;
-
-  return group_id;
-}
-
 void SwissTable::insert_into_empty_slot(uint32_t slot_id, uint32_t hash,
                                         uint32_t group_id) {
-  const uint64_t num_groupid_bits = num_groupid_bits_from_log_blocks(log_blocks_);
+  const int num_groupid_bits = num_groupid_bits_from_log_blocks(log_blocks_);
 
   // We assume here that the number of bits is rounded up to 8, 16, 32 or 64.
   // In that case we can insert group id value using aligned 64-bit word access.
   assert(num_groupid_bits == 8 || num_groupid_bits == 16 || num_groupid_bits == 32 ||
          num_groupid_bits == 64);
 
-  const uint64_t num_block_bytes = (8 + num_groupid_bits);
+  const int num_block_bytes = num_block_bytes_from_num_groupid_bits(num_groupid_bits);
   constexpr uint64_t stamp_mask = 0x7f;
 
   int start_slot = (slot_id & 7);
   int stamp = static_cast<int>((hash >> bits_shift_for_block_and_stamp_) & stamp_mask);
-  uint64_t block_id = slot_id >> 3;
-  uint8_t* blockbase = blocks_->mutable_data() + num_block_bytes * block_id;
+  uint32_t block_id = slot_id >> 3;
+  uint8_t* blockbase = mutable_block_data(block_id, num_block_bytes);
 
   blockbase[7 - start_slot] = static_cast<uint8_t>(stamp);
   int groupid_bit_offset = static_cast<int>(start_slot * num_groupid_bits);

--- a/cpp/src/arrow/compute/key_map_internal_avx2.cc
+++ b/cpp/src/arrow/compute/key_map_internal_avx2.cc
@@ -35,6 +35,7 @@ int SwissTable::early_filter_imp_avx2_x8(const int num_hashes, const uint32_t* h
   constexpr int unroll = 8;
 
   const int num_group_id_bits = num_groupid_bits_from_log_blocks(log_blocks_);
+  const int num_block_bytes = num_block_bytes_from_num_groupid_bits(num_group_id_bits);
   const __m256i* vhash_ptr = reinterpret_cast<const __m256i*>(hashes);
   const __m256i vstamp_mask = _mm256_set1_epi32((1 << bits_stamp_) - 1);
 
@@ -53,7 +54,7 @@ int SwissTable::early_filter_imp_avx2_x8(const int num_hashes, const uint32_t* h
     // in order to process 64-bit blocks
     //
     __m256i vblock_offset =
-        _mm256_mullo_epi32(vblock_id, _mm256_set1_epi32(num_group_id_bits + 8));
+        _mm256_mullo_epi32(vblock_id, _mm256_set1_epi32(num_block_bytes));
     __m256i voffset_A = _mm256_and_si256(vblock_offset, _mm256_set1_epi64x(0xffffffff));
     __m256i vstamp_A = _mm256_and_si256(vstamp, _mm256_set1_epi64x(0xffffffff));
     __m256i voffset_B = _mm256_srli_epi64(vblock_offset, 32);
@@ -230,9 +231,10 @@ int SwissTable::early_filter_imp_avx2_x32(const int num_hashes, const uint32_t* 
   // Assemble the sequence of block bytes.
   uint64_t block_bytes[16];
   const int num_groupid_bits = num_groupid_bits_from_log_blocks(log_blocks_);
+  const int num_block_bytes = num_block_bytes_from_num_groupid_bits(num_groupid_bits);
   for (int i = 0; i < (1 << log_blocks_); ++i) {
     uint64_t in_blockbytes =
-        *reinterpret_cast<const uint64_t*>(blocks_->data() + (8 + num_groupid_bits) * i);
+        *reinterpret_cast<const uint64_t*>(block_data(i, num_block_bytes));
     block_bytes[i] = in_blockbytes;
   }
 
@@ -365,14 +367,9 @@ int SwissTable::early_filter_imp_avx2_x32(const int num_hashes, const uint32_t* 
 
 int SwissTable::extract_group_ids_avx2(const int num_keys, const uint32_t* hashes,
                                        const uint8_t* local_slots,
-                                       uint32_t* out_group_ids, int byte_offset,
-                                       int byte_multiplier, int byte_size) const {
-  ARROW_DCHECK(byte_size == 1 || byte_size == 2 || byte_size == 4);
-  uint32_t mask = byte_size == 1 ? 0xFF : byte_size == 2 ? 0xFFFF : 0xFFFFFFFF;
-  auto elements = reinterpret_cast<const int*>(blocks_->data() + byte_offset);
+                                       uint32_t* out_group_ids) const {
   constexpr int unroll = 8;
   if (log_blocks_ == 0) {
-    ARROW_DCHECK(byte_size == 1 && byte_offset == 8 && byte_multiplier == 16);
     __m256i block_group_ids =
         _mm256_set1_epi64x(reinterpret_cast<const uint64_t*>(blocks_->data())[1]);
     for (int i = 0; i < num_keys / unroll; ++i) {
@@ -385,33 +382,52 @@ int SwissTable::extract_group_ids_avx2(const int num_keys, const uint32_t* hashe
       _mm256_storeu_si256(reinterpret_cast<__m256i*>(out_group_ids) + i, group_id);
     }
   } else {
+    int num_groupid_bits = num_groupid_bits_from_log_blocks(log_blocks_);
+    int num_groupid_bytes = num_groupid_bits / 8;
+    uint32_t mask = num_groupid_bytes == 1   ? 0xFF
+                    : num_groupid_bytes == 2 ? 0xFFFF
+                                             : 0xFFFFFFFF;
+    int num_block_bytes = num_block_bytes_from_num_groupid_bits(num_groupid_bits);
+    const int* slots_base =
+        reinterpret_cast<const int*>(blocks_->data() + bytes_status_in_block_);
+
     for (int i = 0; i < num_keys / unroll; ++i) {
       __m256i hash = _mm256_loadu_si256(reinterpret_cast<const __m256i*>(hashes) + i);
-      // Extend hash and local_slot to 64-bit to compute 64-bit group id offsets to
-      // gather from. This is to prevent index overflow issues in GH-44513.
-      // NB: Use zero-extend conversion for unsigned hash.
-      __m256i hash_lo = _mm256_cvtepu32_epi64(_mm256_castsi256_si128(hash));
-      __m256i hash_hi = _mm256_cvtepu32_epi64(_mm256_extracti128_si256(hash, 1));
+      __m256i block_id =
+          _mm256_srlv_epi32(hash, _mm256_set1_epi32(bits_hash_ - log_blocks_));
+
       __m256i local_slot =
           _mm256_set1_epi64x(reinterpret_cast<const uint64_t*>(local_slots)[i]);
+
+      // Extend block_id and local_slot to 64-bit to compute 64-bit group id offsets to
+      // gather from. This is to prevent index overflow issues in GH-44513.
       __m256i local_slot_lo = _mm256_shuffle_epi8(
           local_slot, _mm256_setr_epi32(0x80808000, 0x80808080, 0x80808001, 0x80808080,
                                         0x80808002, 0x80808080, 0x80808003, 0x80808080));
       __m256i local_slot_hi = _mm256_shuffle_epi8(
           local_slot, _mm256_setr_epi32(0x80808004, 0x80808080, 0x80808005, 0x80808080,
                                         0x80808006, 0x80808080, 0x80808007, 0x80808080));
-      local_slot_lo = _mm256_mul_epu32(local_slot_lo, _mm256_set1_epi32(byte_size));
-      local_slot_hi = _mm256_mul_epu32(local_slot_hi, _mm256_set1_epi32(byte_size));
-      __m256i pos_lo = _mm256_srli_epi64(hash_lo, bits_hash_ - log_blocks_);
-      __m256i pos_hi = _mm256_srli_epi64(hash_hi, bits_hash_ - log_blocks_);
-      pos_lo = _mm256_mul_epu32(pos_lo, _mm256_set1_epi32(byte_multiplier));
-      pos_hi = _mm256_mul_epu32(pos_hi, _mm256_set1_epi32(byte_multiplier));
-      pos_lo = _mm256_add_epi64(pos_lo, local_slot_lo);
-      pos_hi = _mm256_add_epi64(pos_hi, local_slot_hi);
-      __m128i group_id_lo = _mm256_i64gather_epi32(elements, pos_lo, 1);
-      __m128i group_id_hi = _mm256_i64gather_epi32(elements, pos_hi, 1);
+      local_slot_lo =
+          _mm256_mul_epu32(local_slot_lo, _mm256_set1_epi32(num_groupid_bytes));
+      local_slot_hi =
+          _mm256_mul_epu32(local_slot_hi, _mm256_set1_epi32(num_groupid_bytes));
+
+      // NB: Use zero-extend conversion for unsigned block_id.
+      __m256i slot_offset_lo = _mm256_cvtepu32_epi64(_mm256_castsi256_si128(block_id));
+      __m256i slot_offset_hi =
+          _mm256_cvtepu32_epi64(_mm256_extracti128_si256(block_id, 1));
+      slot_offset_lo =
+          _mm256_mul_epi32(slot_offset_lo, _mm256_set1_epi64x(num_block_bytes));
+      slot_offset_hi =
+          _mm256_mul_epi32(slot_offset_hi, _mm256_set1_epi64x(num_block_bytes));
+      slot_offset_lo = _mm256_add_epi64(slot_offset_lo, local_slot_lo);
+      slot_offset_hi = _mm256_add_epi64(slot_offset_hi, local_slot_hi);
+
+      __m128i group_id_lo = _mm256_i64gather_epi32(slots_base, slot_offset_lo, 1);
+      __m128i group_id_hi = _mm256_i64gather_epi32(slots_base, slot_offset_hi, 1);
       __m256i group_id = _mm256_set_m128i(group_id_hi, group_id_lo);
       group_id = _mm256_and_si256(group_id, _mm256_set1_epi32(mask));
+
       _mm256_storeu_si256(reinterpret_cast<__m256i*>(out_group_ids) + i, group_id);
     }
   }


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

See #45506.

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

### What changes are included in this PR?

1. Abstract current overflow-prone block data access into functions that do proper type promotion to avoid overflow. Also remove the old block base address accessor.
2. Unify the data types used for various concepts as they naturally are (i.e., w/o explicit promotion): `uint32_t` for `block_id`, `int` for `num_xxx_bits/bytes`, `uint32_t` for `group_id`, `int` for `local_slot_id` and `uint32_t` for `global_slot_id`.
3. Abstract several constants and utility functions for readability and maintainability.

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?

Existing tests should suffice.

It is really hard (gosh I did try) to create a concrete test case that fails w/o this change and passes w/ this change.

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
5. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?

None.

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #45506