### PR TITLE
GH-45517: [GLib] garrow_data_type_new_raw() returns GARROW_TYPE_STRING_VIEW_DATA_TYPE

### DIFF
--- a/c_glib/arrow-glib/basic-data-type.cpp
+++ b/c_glib/arrow-glib/basic-data-type.cpp
@@ -2402,6 +2402,9 @@ garrow_data_type_new_raw(std::shared_ptr<arrow::DataType> *arrow_data_type)
   case arrow::Type::type::RUN_END_ENCODED:
     type = GARROW_TYPE_RUN_END_ENCODED_DATA_TYPE;
     break;
+  case arrow::Type::type::STRING_VIEW:
+    type = GARROW_TYPE_STRING_VIEW_DATA_TYPE;
+    break;
   default:
     type = GARROW_TYPE_DATA_TYPE;
     break;

--- a/c_glib/test/test-string-view-data-type.rb
+++ b/c_glib/test/test-string-view-data-type.rb
@@ -30,4 +30,11 @@ class TestStringViewDataType < Test::Unit::TestCase
     data_type = Arrow::StringViewDataType.new
     assert_equal("string_view", data_type.to_s)
   end
+
+  def test_export
+    data_type = Arrow::StringViewDataType.new
+    c_abi_schema = data_type.export
+    assert_equal(data_type,
+                 Arrow::DataType.import(c_abi_schema))
+  end
 end


### PR DESCRIPTION
### Rationale for this change

The #44686 introduced `GArrowStringViewDataType`.
It was missed the one work. It is necessary that `garrow_data_type_new_raw()` returns `GARROW_TYPE_STRING_VIEW_DATA_TYPE`.

### What changes are included in this PR?

 `garrow_data_type_new_raw()` returns `GARROW_TYPE_STRING_VIEW_DATA_TYPE`
if the input data type is `arrow::Type::type::STRING_VIEW`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #45517