### PR TITLE
GH-45528: [GLib] garrow_data_type_new_raw() returns GARROW_TYPE_BINARY_VIEW_DATA_TYPE

### DIFF
--- a/c_glib/arrow-glib/basic-data-type.cpp
+++ b/c_glib/arrow-glib/basic-data-type.cpp
@@ -2405,6 +2405,9 @@ garrow_data_type_new_raw(std::shared_ptr<arrow::DataType> *arrow_data_type)
   case arrow::Type::type::STRING_VIEW:
     type = GARROW_TYPE_STRING_VIEW_DATA_TYPE;
     break;
+  case arrow::Type::type::BINARY_VIEW:
+    type = GARROW_TYPE_BINARY_VIEW_DATA_TYPE;
+    break;
   default:
     type = GARROW_TYPE_DATA_TYPE;
     break;

--- a/c_glib/test/test-binary-view-data-type.rb
+++ b/c_glib/test/test-binary-view-data-type.rb
@@ -30,4 +30,11 @@ class TestBinaryViewDataType < Test::Unit::TestCase
     data_type = Arrow::BinaryViewDataType.new
     assert_equal("binary_view", data_type.to_s)
   end
+
+  def test_export
+    data_type = Arrow::BinaryViewDataType.new
+    c_abi_schema = data_type.export
+    assert_equal(data_type,
+                 Arrow::DataType.import(c_abi_schema))
+  end
 end


### PR DESCRIPTION
### Rationale for this change

The #44656 introduced `GArrowStringViewDataType`.
It was missed the one work. It is necessary that `garrow_data_type_new_raw()` return `GARROW_TYPE_BINARY_VIEW_DATA_TYPE`.


### What changes are included in this PR?

`garrow_data_type_new_raw()` returns `GARROW_TYPE_BINARY_VIEW_DATA_TYPE`
if the input data type is `arrow::Type::type::BINARY_VIEW`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #45528