### PR TITLE
GH-45532: [C++] `RunEndEncodedBuilder` should clear dimensions after a `Finish()` call

### DIFF
--- a/cpp/src/arrow/array/array_run_end_test.cc
+++ b/cpp/src/arrow/array/array_run_end_test.cc
@@ -362,6 +362,18 @@ TEST_P(TestRunEndEncodedArray, Builder) {
       ASSERT_ARRAYS_EQUAL(*expected_values, *ree_array->values());
       ASSERT_EQ(array->length(), 516);
       ASSERT_EQ(array->offset(), 0);
+      continue;
+    }
+    // Ensure builder->Finish() properly resets the builder state and is idempotent
+    if (step == 14) {
+      ASSERT_EQ(builder->length(), 516);
+      ASSERT_OK(builder->Finish());
+      ASSERT_EQ(builder->length(), 0);
+      ASSERT_EQ(*builder->type(), *run_end_encoded(run_end_type, utf8()));
+
+      ASSERT_OK(builder->Finish());
+      ASSERT_OK(builder->Finish());
+      ASSERT_EQ(builder->length(), 0);
       break;
     }
   }

--- a/cpp/src/arrow/array/builder_run_end.cc
+++ b/cpp/src/arrow/array/builder_run_end.cc
@@ -290,7 +290,7 @@ Status RunEndEncodedBuilder::FinishInternal(std::shared_ptr<ArrayData>* out) {
                         RunEndEncodedArray::Make(length_, run_ends_array, values_array));
   *out = std::move(ree_array->data());
 
-  UpdateDimensions(0, 0);
+  Reset();
 
   return Status::OK();
 }

--- a/cpp/src/arrow/array/builder_run_end.cc
+++ b/cpp/src/arrow/array/builder_run_end.cc
@@ -289,6 +289,9 @@ Status RunEndEncodedBuilder::FinishInternal(std::shared_ptr<ArrayData>* out) {
   ARROW_ASSIGN_OR_RAISE(auto ree_array,
                         RunEndEncodedArray::Make(length_, run_ends_array, values_array));
   *out = std::move(ree_array->data());
+
+  UpdateDimensions(0, 0);
+
   return Status::OK();
 }
 


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
This resolves the issue reported in https://github.com/apache/arrow/issues/45532. Specifically, this updates the `RunEndEncodedBuilder` dimensions after a `Finish()` call and therefore makes the function idempotent.

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
This updates the `RunEndEncodedBuilder`'s dimensions after a `Finish()` call and adds a test which ensures the function properly resets the builder state and is idempotent.

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
Yes

### Are there any user-facing changes?

<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->
Yes; this is a bug fix to a user-facing API.
<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #45532