### PR TITLE
GH-45534: [C++] Test: `RunEndEncodeTableColumns` should update REE columns' schema types

### DIFF
--- a/cpp/src/arrow/testing/gtest_util.cc
+++ b/cpp/src/arrow/testing/gtest_util.cc
@@ -478,17 +478,24 @@ Result<std::shared_ptr<Table>> RunEndEncodeTableColumns(
   const int num_columns = table.num_columns();
   std::vector<std::shared_ptr<ChunkedArray>> encoded_columns;
   encoded_columns.reserve(num_columns);
+  std::vector<std::shared_ptr<Field>> encoded_fields;
+  encoded_fields.reserve(num_columns);
   for (int i = 0; i < num_columns; i++) {
+    auto field = table.schema()->field(i);
     if (std::find(column_indices.begin(), column_indices.end(), i) !=
         column_indices.end()) {
       ARROW_ASSIGN_OR_RAISE(auto run_end_encoded, compute::RunEndEncode(table.column(i)));
       DCHECK_EQ(run_end_encoded.kind(), Datum::CHUNKED_ARRAY);
       encoded_columns.push_back(run_end_encoded.chunked_array());
+      auto encoded_type = arrow::run_end_encoded(arrow::int32(), field->type());
+      encoded_fields.push_back(field->WithType(encoded_type));
     } else {
       encoded_columns.push_back(table.column(i));
+      encoded_fields.push_back(field);
     }
   }
-  return Table::Make(table.schema(), std::move(encoded_columns));
+  auto updated_schema = arrow::schema(encoded_fields);
+  return Table::Make(updated_schema, std::move(encoded_columns));
 }
 
 Result<std::optional<std::string>> PrintArrayDiff(const ChunkedArray& expected,

--- a/cpp/src/arrow/testing/gtest_util.cc
+++ b/cpp/src/arrow/testing/gtest_util.cc
@@ -481,7 +481,7 @@ Result<std::shared_ptr<Table>> RunEndEncodeTableColumns(
   std::vector<std::shared_ptr<Field>> encoded_fields;
   encoded_fields.reserve(num_columns);
   for (int i = 0; i < num_columns; i++) {
-    auto field = table.schema()->field(i);
+    const auto& field = table.schema()->field(i);
     if (std::find(column_indices.begin(), column_indices.end(), i) !=
         column_indices.end()) {
       ARROW_ASSIGN_OR_RAISE(auto run_end_encoded, compute::RunEndEncode(table.column(i)));
@@ -494,8 +494,8 @@ Result<std::shared_ptr<Table>> RunEndEncodeTableColumns(
       encoded_fields.push_back(field);
     }
   }
-  auto updated_schema = arrow::schema(encoded_fields);
-  return Table::Make(updated_schema, std::move(encoded_columns));
+  auto updated_schema = arrow::schema(std::move(encoded_fields));
+  return Table::Make(std::move(updated_schema), std::move(encoded_columns));
 }
 
 Result<std::optional<std::string>> PrintArrayDiff(const ChunkedArray& expected,

--- a/cpp/src/arrow/testing/gtest_util_test.cc
+++ b/cpp/src/arrow/testing/gtest_util_test.cc
@@ -24,6 +24,7 @@
 #include "arrow/array/builder_decimal.h"
 #include "arrow/datum.h"
 #include "arrow/record_batch.h"
+#include "arrow/table.h"
 #include "arrow/tensor.h"
 #include "arrow/testing/gtest_util.h"
 #include "arrow/testing/math.h"
@@ -281,4 +282,17 @@ TEST(AssertTestWithinUlp, Basics) {
   EXPECT_FATAL_FAILURE(AssertWithinUlp(123.456f, 123.456085f, 10), "not within 10 ulps");
 }
 
+TEST(RunEndEncodeGtestUtilTest, SchemaTypeIsModified) {
+  std::shared_ptr<Table> table =
+      arrow::TableFromJSON(arrow::schema({arrow::field("col", arrow::utf8())}), {R"([
+      {"col": "a"},
+      {"col": "b"},
+      {"col": "c"},
+      {"col": "d"}
+    ])"});
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<Table> ree_table,
+                       RunEndEncodeTableColumns(*table, {0}));
+  ASSERT_TRUE(ree_table->schema()->field(0)->type()->Equals(
+      arrow::run_end_encoded(arrow::int32(), arrow::utf8())));
+}
 }  // namespace arrow


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->
This change makes the returned schema more correct pending discussion in https://github.com/apache/arrow/issues/45534.

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->
For every column which is run-end-encoded in `RunEndEncodeTableColumns`, the corresponding schema field will be changed to also be run-end-encoded.

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->
Yes

### Are there any user-facing changes?

no, this fixes a bug in a gtest util which is user-facing.
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #45534