### PR TITLE
GH-45537: [CI][C++] Add missing includes (iwyu) to file_skyhook.cc

### DIFF
--- a/cpp/src/skyhook/client/file_skyhook.cc
+++ b/cpp/src/skyhook/client/file_skyhook.cc
@@ -23,6 +23,8 @@
 #include "arrow/dataset/file_base.h"
 #include "arrow/dataset/file_ipc.h"
 #include "arrow/dataset/file_parquet.h"
+#include "arrow/record_batch.h"
+#include "arrow/util/async_generator.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/compression.h"
 


### PR DESCRIPTION
### Rationale for this change

The job is failing because it was using some includes from a different header file `cpp/src/arrow/acero/options.h`. The file removed some of those includes and now they were missing.

### What changes are included in this PR?

Add missing includes

### Are these changes tested?

Yes, via archery

### Are there any user-facing changes?

No
* GitHub Issue: #45537