### PR TITLE
GH-45541: [Doc][C++] Render ASCII art as-is

### DIFF
--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -800,12 +800,15 @@ class ARROW_EXPORT BinaryViewType : public DataType {
   /// This union supports two states:
   ///
   /// - Entirely inlined string data
+  /// \code{.unparsed}
   ///                |----|--------------|
   ///                 ^    ^
   ///                 |    |
   ///              size    in-line string data, zero padded
+  /// \endcode
   ///
   /// - Reference into a buffer
+  /// \code{.unparsed}
   ///                |----|----|----|----|
   ///                 ^    ^    ^    ^
   ///                 |    |    |    |
@@ -813,6 +816,7 @@ class ARROW_EXPORT BinaryViewType : public DataType {
   ///                  prefix   |           |
   ///                        buffer index   |
   ///                                  offset in buffer
+  /// \endcode
   ///
   /// Adapted from TU Munich's UmbraDB [1], Velox, DuckDB.
   ///


### PR DESCRIPTION
### Rationale for this change

[union c_type](https://arrow.apache.org/docs/cpp/api/datatype.html#_CPPv4N5arrow14BinaryViewType6c_typeE) in the BinaryViewType class describes data layout using ASCII art. It rendered a non-readable layout.

```
- Entirely inlined string data |-&#8212;|———–&#8212;| ^ ^ | | size in-line string data, zero padded

- Reference into a buffer |-&#8212;|-&#8212;|-&#8212;|-&#8212;| ^ ^ ^ ^ | | | | size | | `—&#8212;. prefix | | buffer index | offset in buffer
```

It would be better render ascii as is.

```
 - Entirely inlined string data

  |----|--------------|
   ^    ^
   |    |
size    in-line string data, zero padded

- Reference into a buffer

  |----|----|----|----|
   ^    ^    ^    ^
   |    |    |    |
size    |    |    `------.
    prefix   |           |
          buffer index   |
                    offset in buffer
```


### What changes are included in this PR?

Render the ASCII part as-is.

### Are these changes tested?

No.

### Are there any user-facing changes?

No.
* GitHub Issue: #45541