### PR TITLE
GH-45536: [Dev][R] Update code to match new linters on lintr=3.2.0

### DIFF
--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -361,6 +361,7 @@ jobs:
           working-directory: 'r'
           extra-packages: |
             any::rcmdcheck
+            any::cyclocomp
       # TODO(ARROW-17149): figure out why the GCS tests are hanging on Windows
       # - name: Install Google Cloud Storage Testbench
       #   shell: bash

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -405,9 +405,7 @@ jobs:
           )
           # we use pak for package installation since it is faster, safer and more convenient
           pak::local_install()
-          # Pin the lintr version to avoid breaking changes with newer 3.2.0 version
-          # See: https://github.com/apache/arrow/pull/45524
-          pak::pak("lintr@3.1.2")
+          pak::pak("lintr")
           lintr::expect_lint_free()
       - name: Dump install logs
         shell: cmd

--- a/dev/release/rat_exclude_files.txt
+++ b/dev/release/rat_exclude_files.txt
@@ -130,6 +130,7 @@ csharp/test/Apache.Arrow.Tests/app.config
 *.svg
 *.devhelp2
 *.scss
+r/.lintr
 r/R/arrowExports.R
 r/src/arrowExports.cpp
 r/DESCRIPTION

--- a/r/.lintr
+++ b/r/.lintr
@@ -18,6 +18,7 @@ linters: linters_with_defaults(
   indentation_linter = NULL,
   line_length_linter = line_length_linter(120),
   object_name_linter = NULL,
+  return_linter = NULL,
   # Even with a liberal definition of name styles, some of our names cause issues due to `.`s for s3 classes or NA in the name
   # TODO: figure out if we con contribute to lintr to make these work
   # object_name_linter = object_name_linter(styles = c("snake_case", "camelCase", "CamelCase", "symbols", "dotted.case", "UPPERCASE", "SNAKE_CASE")),

--- a/r/.lintr
+++ b/r/.lintr
@@ -1,19 +1,3 @@
-license:  '#  Licensed to the Apache Software Foundation (ASF) under one
-  #  or more contributor license agreements.  See the NOTICE file
-  #  distributed with this work for additional information
-  #  regarding copyright ownership.  The ASF licenses this file
-  #  to you under the Apache License, Version 2.0 (the
-  #  "License"); you may not use this file except in compliance
-  #  with the License.  You may obtain a copy of the License at
-  #
-  #   http://www.apache.org/licenses/LICENSE-2.0
-  #
-  #  Unless required by applicable law or agreed to in writing,
-  #  software distributed under the License is distributed on an
-  #  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  #  KIND, either express or implied.  See the License for the
-  #  specific language governing permissions and limitations
-  #  under the License.'
 linters: linters_with_defaults(
   indentation_linter = NULL,
   line_length_linter = line_length_linter(120),

--- a/r/tests/testthat/test-dplyr-collapse.R
+++ b/r/tests/testthat/test-dplyr-collapse.R
@@ -142,21 +142,6 @@ test_that("Properties of collapsed query", {
     summarize(total = sum(int, na.rm = TRUE)) %>%
     mutate(extra = total * 5)
 
-  # print(tbl %>%
-  #   filter(dbl > 2) %>%
-  #   select(chr, int, lgl) %>%
-  #   mutate(twice = int * 2L) %>%
-  #   group_by(lgl) %>%
-  #   summarize(total = sum(int, na.rm = TRUE)) %>%
-  #   mutate(extra = total * 5))
-
-  #   # A tibble: 3 × 3
-  #   lgl   total extra
-  #   <lgl> <int> <dbl>
-  # 1 FALSE     8    40
-  # 2 TRUE      8    40
-  # 3 NA       25   125
-
   # Avoid evaluating just for nrow
   expect_identical(dim(q), c(NA_integer_, 3L))
 

--- a/r/tests/testthat/test-dplyr-collapse.R
+++ b/r/tests/testthat/test-dplyr-collapse.R
@@ -142,6 +142,12 @@ test_that("Properties of collapsed query", {
     summarize(total = sum(int, na.rm = TRUE)) %>%
     mutate(extra = total * 5)
 
+  #  # A tibble: 2 × 3
+  #   lgl   total extra
+  #   <lgl> <int> <dbl>
+  # 1 TRUE      5    25
+  # 2 NA       36   180
+
   # Avoid evaluating just for nrow
   expect_identical(dim(q), c(NA_integer_, 3L))
 


### PR DESCRIPTION
### Rationale for this change

CI jobs failing with lintr >= 3.2.0

### What changes are included in this PR?

Remove some comments and update some lintr config to ensure compatibility with lintr package version 3.2.0

### Are these changes tested?

Nope

### Are there any user-facing changes?

Nope
* GitHub Issue: #45536