### PR TITLE
GH-45269: [C++][Compute] Add "pivot_wider" and "hash_pivot_wider" functions

### DIFF
--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -753,10 +753,12 @@ if(ARROW_COMPUTE)
        ARROW_COMPUTE_SRCS
        compute/kernels/aggregate_basic.cc
        compute/kernels/aggregate_mode.cc
+       compute/kernels/aggregate_pivot.cc
        compute/kernels/aggregate_quantile.cc
        compute/kernels/aggregate_tdigest.cc
        compute/kernels/aggregate_var_std.cc
        compute/kernels/hash_aggregate.cc
+       compute/kernels/pivot_internal.cc
        compute/kernels/scalar_arithmetic.cc
        compute/kernels/scalar_boolean.cc
        compute/kernels/scalar_compare.cc

--- a/cpp/src/arrow/acero/groupby_aggregate_node.cc
+++ b/cpp/src/arrow/acero/groupby_aggregate_node.cc
@@ -282,6 +282,11 @@ Status GroupByNode::Merge() {
       DCHECK(state0->agg_states[span_i]);
       batch_ctx.SetState(state0->agg_states[span_i].get());
 
+      // XXX this resizes each KernelState (state0->agg_states[span_i]) multiple times.
+      // An alternative would be a two-pass algorithm:
+      // 1. Compute all transpositions (one per local state) and the final number of
+      // groups.
+      // 2. Process all agg kernels, resizing each KernelState only once.
       RETURN_NOT_OK(
           agg_kernels_[span_i]->resize(&batch_ctx, state0->grouper->num_groups()));
       RETURN_NOT_OK(agg_kernels_[span_i]->merge(

--- a/cpp/src/arrow/acero/scalar_aggregate_node.cc
+++ b/cpp/src/arrow/acero/scalar_aggregate_node.cc
@@ -294,14 +294,6 @@ Status ScalarAggregateNode::OutputResult(bool is_last) {
   // First, insert segment keys
   PlaceFields(batch, /*base=*/0, segmenter_values_);
 
-  // Move away the states and recreate them eagerly, to make sure that any error
-  // below does not leave us with empty states.
-  auto states = std::move(states_);
-  states_.resize(kernels_.size());
-  if (!is_last) {
-    RETURN_NOT_OK(ResetKernelStates());
-  }
-
   // Followed by aggregate values
   std::size_t base = segment_field_ids_.size();
   for (size_t i = 0; i < kernels_.size(); ++i) {
@@ -313,7 +305,7 @@ Status ScalarAggregateNode::OutputResult(bool is_last) {
                         {"function.kind", std::string(kind_name()) + "::Finalize"}});
     KernelContext ctx{plan()->query_context()->exec_context()};
     ARROW_ASSIGN_OR_RAISE(auto merged, ScalarAggregateKernel::MergeAll(
-                                           kernels_[i], &ctx, std::move(states[i])));
+                                           kernels_[i], &ctx, std::move(states_[i])));
     RETURN_NOT_OK(kernels_[i]->finalize(&ctx, &batch.values[base + i]));
   }
 
@@ -321,6 +313,8 @@ Status ScalarAggregateNode::OutputResult(bool is_last) {
   total_output_batches_++;
   if (is_last) {
     ARROW_RETURN_NOT_OK(output_->InputFinished(this, total_output_batches_));
+  } else {
+    ARROW_RETURN_NOT_OK(ResetKernelStates());
   }
   return Status::OK();
 }

--- a/cpp/src/arrow/compute/api_aggregate.cc
+++ b/cpp/src/arrow/compute/api_aggregate.cc
@@ -24,8 +24,8 @@
 #include "arrow/util/logging.h"
 
 namespace arrow {
-
 namespace internal {
+
 template <>
 struct EnumTraits<compute::CountOptions::CountMode>
     : BasicEnumTraits<compute::CountOptions::CountMode, compute::CountOptions::ONLY_VALID,
@@ -67,6 +67,24 @@ struct EnumTraits<compute::QuantileOptions::Interpolation>
     return "<INVALID>";
   }
 };
+
+template <>
+struct EnumTraits<compute::PivotWiderOptions::UnexpectedKeyBehavior>
+    : BasicEnumTraits<compute::PivotWiderOptions::UnexpectedKeyBehavior,
+                      compute::PivotWiderOptions::kIgnore,
+                      compute::PivotWiderOptions::kRaise> {
+  static std::string name() { return "PivotWiderOptions::UnexpectedKeyBehavior"; }
+  static std::string value_name(compute::PivotWiderOptions::UnexpectedKeyBehavior value) {
+    switch (value) {
+      case compute::PivotWiderOptions::kIgnore:
+        return "kIgnore";
+      case compute::PivotWiderOptions::kRaise:
+        return "kRaise";
+    }
+    return "<INVALID>";
+  }
+};
+
 }  // namespace internal
 
 namespace compute {
@@ -101,6 +119,9 @@ static auto kTDigestOptionsType = GetFunctionOptionsType<TDigestOptions>(
     DataMember("buffer_size", &TDigestOptions::buffer_size),
     DataMember("skip_nulls", &TDigestOptions::skip_nulls),
     DataMember("min_count", &TDigestOptions::min_count));
+static auto kPivotOptionsType = GetFunctionOptionsType<PivotWiderOptions>(
+    DataMember("key_names", &PivotWiderOptions::key_names),
+    DataMember("unexpected_key_behavior", &PivotWiderOptions::unexpected_key_behavior));
 static auto kIndexOptionsType =
     GetFunctionOptionsType<IndexOptions>(DataMember("value", &IndexOptions::value));
 }  // namespace
@@ -164,6 +185,13 @@ TDigestOptions::TDigestOptions(std::vector<double> q, uint32_t delta,
       min_count{min_count} {}
 constexpr char TDigestOptions::kTypeName[];
 
+PivotWiderOptions::PivotWiderOptions(std::vector<std::string> key_names,
+                                     UnexpectedKeyBehavior unexpected_key_behavior)
+    : FunctionOptions(internal::kPivotOptionsType),
+      key_names(std::move(key_names)),
+      unexpected_key_behavior(unexpected_key_behavior) {}
+PivotWiderOptions::PivotWiderOptions() : FunctionOptions(internal::kPivotOptionsType) {}
+
 IndexOptions::IndexOptions(std::shared_ptr<Scalar> value)
     : FunctionOptions(internal::kIndexOptionsType), value{std::move(value)} {}
 IndexOptions::IndexOptions() : IndexOptions(std::make_shared<NullScalar>()) {}
@@ -177,6 +205,7 @@ void RegisterAggregateOptions(FunctionRegistry* registry) {
   DCHECK_OK(registry->AddFunctionOptionsType(kVarianceOptionsType));
   DCHECK_OK(registry->AddFunctionOptionsType(kQuantileOptionsType));
   DCHECK_OK(registry->AddFunctionOptionsType(kTDigestOptionsType));
+  DCHECK_OK(registry->AddFunctionOptionsType(kPivotOptionsType));
   DCHECK_OK(registry->AddFunctionOptionsType(kIndexOptionsType));
 }
 }  // namespace internal

--- a/cpp/src/arrow/compute/api_aggregate.h
+++ b/cpp/src/arrow/compute/api_aggregate.h
@@ -236,11 +236,11 @@ class ARROW_EXPORT TDigestOptions : public FunctionOptions {
 /// ```
 class ARROW_EXPORT PivotWiderOptions : public FunctionOptions {
  public:
-  // Configure the behavior of pivot keys not in `key_names`
+  /// Configure the behavior of pivot keys not in `key_names`
   enum UnexpectedKeyBehavior {
-    // Unexpected pivot keys are ignored silently
+    /// Unexpected pivot keys are ignored silently
     kIgnore,
-    // Unexpected pivot keys return a KeyError
+    /// Unexpected pivot keys return a KeyError
     kRaise
   };
 
@@ -251,9 +251,9 @@ class ARROW_EXPORT PivotWiderOptions : public FunctionOptions {
   static constexpr char const kTypeName[] = "PivotWiderOptions";
   static PivotWiderOptions Defaults() { return PivotWiderOptions{}; }
 
-  // The values expected in the pivot key column
+  /// The values expected in the pivot key column
   std::vector<std::string> key_names;
-  // The behavior when pivot keys not in `key_names` are encountered
+  /// The behavior when pivot keys not in `key_names` are encountered
   UnexpectedKeyBehavior unexpected_key_behavior = kIgnore;
 };
 

--- a/cpp/src/arrow/compute/api_aggregate.h
+++ b/cpp/src/arrow/compute/api_aggregate.h
@@ -175,6 +175,88 @@ class ARROW_EXPORT TDigestOptions : public FunctionOptions {
   uint32_t min_count;
 };
 
+/// \brief Control Pivot kernel behavior
+///
+/// These options apply to the "pivot_wider" and "hash_pivot_wider" functions.
+///
+/// Constraints:
+/// - The corresponding `Aggregate::target` must have two FieldRef elements;
+///   the first one points to the pivot key column, the second points to the
+///   pivoted data column.
+/// - The pivot key column must be string-like; its values will be matched
+///   against `key_names` in order to dispatch the pivoted data into the
+///   output.
+///
+/// "pivot_wider" example
+/// ---------------------
+///
+/// Assuming the following two input columns with types utf8 and int16 (respectively):
+/// ```
+/// width   |  11
+/// height  |  13
+/// ```
+/// and the options `PivotWiderOptions(.key_names = {"height", "width"})`
+///
+/// then the output will be a scalar with the type
+/// `struct{"height": int16, "width": int16}`
+/// and the value `{"height": 13, "width": 11}`.
+///
+/// "hash_pivot_wider" example
+/// --------------------------
+///
+/// Assuming the following input with schema
+/// `{"group": int32, "key": utf8, "value": int16}`:
+/// ```
+///  group |  key     |  value
+/// -----------------------------
+///   1    |  height  |    11
+///   1    |  width   |    12
+///   2    |  width   |    13
+///   3    |  height  |    14
+///   3    |  depth   |    15
+/// ```
+/// and the following settings:
+/// - a hash grouping key "group"
+/// - Aggregate(
+///     .function = "hash_pivot_wider",
+///     .options = PivotWiderOptions(.key_names = {"height", "width"}),
+///     .target = {"key", "value"},
+///     .name = {"properties"})
+///
+/// then the output will have the schema
+/// `{"group": int32, "properties": struct{"height": int16, "width": int16}}`
+/// and the following value:
+/// ```
+///  group |     properties
+///        |  height  |   width
+/// -----------------------------
+///   1    |   11     |    12
+///   2    |   null   |    13
+///   3    |   14     |    null
+/// ```
+class ARROW_EXPORT PivotWiderOptions : public FunctionOptions {
+ public:
+  // Configure the behavior of pivot keys not in `key_names`
+  enum UnexpectedKeyBehavior {
+    // Unexpected pivot keys are ignored silently
+    kIgnore,
+    // Unexpected pivot keys return a KeyError
+    kRaise
+  };
+
+  explicit PivotWiderOptions(std::vector<std::string> key_names,
+                             UnexpectedKeyBehavior unexpected_key_behavior = kIgnore);
+  // Default constructor for serialization
+  PivotWiderOptions();
+  static constexpr char const kTypeName[] = "PivotWiderOptions";
+  static PivotWiderOptions Defaults() { return PivotWiderOptions{}; }
+
+  // The values expected in the pivot key column
+  std::vector<std::string> key_names;
+  // The behavior when pivot keys not in `key_names` are encountered
+  UnexpectedKeyBehavior unexpected_key_behavior = kIgnore;
+};
+
 /// \brief Control Index kernel behavior
 class ARROW_EXPORT IndexOptions : public FunctionOptions {
  public:

--- a/cpp/src/arrow/compute/kernels/aggregate_pivot.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_pivot.cc
@@ -162,8 +162,10 @@ const FunctionDoc pivot_doc{
      "All output struct fields have the same type as `pivot_values`.\n"
      "Each pivot key decides in which output field the corresponding pivot value\n"
      "is emitted. If a pivot key doesn't appear, null is emitted.\n"
-     "If a pivot key appears twice, KeyError is raised.\n"
-     "Behavior of unexpected pivot keys is controlled by PivotWiderOptions."),
+     "If more than one non-null value is encountered for a given pivot key,\n"
+     "Invalid is raised.\n"
+     "Behavior of unexpected pivot keys is controlled by `unexpected_key_behavior`\n"
+     "in PivotWiderOptions."),
     {"pivot_keys", "pivot_values"},
     "PivotWiderOptions"};
 

--- a/cpp/src/arrow/compute/kernels/aggregate_pivot.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_pivot.cc
@@ -1,0 +1,159 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/compute/api_aggregate.h"
+#include "arrow/compute/kernels/aggregate_internal.h"
+#include "arrow/compute/kernels/common_internal.h"
+#include "arrow/compute/kernels/pivot_internal.h"
+#include "arrow/scalar.h"
+#include "arrow/util/bit_run_reader.h"
+#include "arrow/util/logging.h"
+
+namespace arrow::compute::internal {
+namespace {
+
+using arrow::internal::VisitSetBitRunsVoid;
+using arrow::util::span;
+
+struct PivotImpl : public ScalarAggregator {
+  Status Init(const PivotWiderOptions& options, const std::vector<TypeHolder>& in_types) {
+    options_ = &options;
+    key_type_ = in_types[0].GetSharedPtr();
+    auto value_type = in_types[1].GetSharedPtr();
+    FieldVector fields;
+    fields.reserve(options_->key_names.size());
+    values_.reserve(options_->key_names.size());
+    for (const auto& key_name : options_->key_names) {
+      fields.push_back(field(key_name, value_type));
+      values_.push_back(MakeNullScalar(value_type));
+    }
+    out_type_ = struct_(std::move(fields));
+    ARROW_ASSIGN_OR_RAISE(key_mapper_, PivotWiderKeyMapper::Make(*key_type_, options_));
+    return Status::OK();
+  }
+
+  Status Consume(KernelContext*, const ExecSpan& batch) override {
+    DCHECK_EQ(batch.num_values(), 2);
+    if (!batch[1].is_array()) {
+      return Status::NotImplemented("Consuming scalar pivot value");
+    }
+    auto values = batch[1].array.ToArray();
+    if (batch[0].is_array()) {
+      ARROW_ASSIGN_OR_RAISE(span<const PivotWiderKeyIndex> keys,
+                            key_mapper_->MapKeys(batch[0].array));
+      for (int64_t i = 0; i < batch.length; ++i) {
+        PivotWiderKeyIndex key = keys[i];
+        if (key != kNullPivotKey && !values->IsNull(i)) {
+          if (ARROW_PREDICT_FALSE(values_[key]->is_valid)) {
+            return DuplicateValue();
+          }
+          ARROW_ASSIGN_OR_RAISE(values_[key], values->GetScalar(i));
+          DCHECK(values_[key]->is_valid);
+        }
+      }
+    } else {
+      ARROW_ASSIGN_OR_RAISE(PivotWiderKeyIndex key,
+                            key_mapper_->MapKey(*batch[0].scalar));
+      if (key != kNullPivotKey) {
+        for (int64_t i = 0; i < batch.length; ++i) {
+          if (!values->IsNull(i)) {
+            if (ARROW_PREDICT_FALSE(values_[key]->is_valid)) {
+              return DuplicateValue();
+            }
+            ARROW_ASSIGN_OR_RAISE(values_[key], values->GetScalar(i));
+            DCHECK(values_[key]->is_valid);
+          }
+        }
+      }
+    }
+    return Status::OK();
+  }
+
+  Status MergeFrom(KernelContext*, KernelState&& src) override {
+    const auto& other_state = checked_cast<const PivotImpl&>(src);
+    for (int64_t key = 0; key < static_cast<int64_t>(values_.size()); ++key) {
+      if (other_state.values_[key]->is_valid) {
+        if (ARROW_PREDICT_FALSE(values_[key]->is_valid)) {
+          return DuplicateValue();
+        }
+        values_[key] = other_state.values_[key];
+      }
+    }
+    return Status::OK();
+  }
+
+  Status Finalize(KernelContext* ctx, Datum* out) override {
+    *out = std::make_shared<StructScalar>(std::move(values_), out_type_);
+    return Status::OK();
+  }
+
+  Status DuplicateValue() {
+    return Status::Invalid(
+        "Encountered more than one non-null value for the same pivot key");
+  }
+
+  std::shared_ptr<DataType> out_type() const { return out_type_; }
+
+  std::shared_ptr<DataType> key_type_;
+  std::shared_ptr<DataType> out_type_;
+  const PivotWiderOptions* options_;
+  std::unique_ptr<PivotWiderKeyMapper> key_mapper_;
+  ScalarVector values_;
+};
+
+Result<std::unique_ptr<KernelState>> PivotInit(KernelContext* ctx,
+                                               const KernelInitArgs& args) {
+  const auto& options = checked_cast<const PivotWiderOptions&>(*args.options);
+  DCHECK_EQ(args.inputs.size(), 2);
+  DCHECK(is_base_binary_like(args.inputs[0].id()));
+  auto state = std::make_unique<PivotImpl>();
+  RETURN_NOT_OK(state->Init(options, args.inputs));
+  return state;
+}
+
+Result<TypeHolder> ResolveOutputType(KernelContext* ctx, const std::vector<TypeHolder>&) {
+  return checked_cast<PivotImpl*>(ctx->state())->out_type();
+}
+
+const FunctionDoc pivot_doc{
+    "Pivot values according to a pivot key column",
+    ("Output is a struct with as many fields as `PivotWiderOptions.key_names`.\n"
+     "All output struct fields have the same type as `pivot_values`.\n"
+     "Each pivot key decides in which output field the corresponding pivot value\n"
+     "is emitted. If a pivot key doesn't appear, null is emitted.\n"
+     "If a pivot key appears twice, KeyError is raised.\n"
+     "Behavior of unexpected pivot keys is controlled by PivotWiderOptions."),
+    {"pivot_keys", "pivot_values"},
+    "PivotWiderOptions"};
+
+}  // namespace
+
+void RegisterScalarAggregatePivot(FunctionRegistry* registry) {
+  static auto default_pivot_options = PivotWiderOptions::Defaults();
+
+  auto func = std::make_shared<ScalarAggregateFunction>(
+      "pivot_wider", Arity::Binary(), pivot_doc, &default_pivot_options);
+
+  for (auto key_type : BaseBinaryTypes()) {
+    auto sig = KernelSignature::Make({key_type->id(), InputType::Any()},
+                                     OutputType(ResolveOutputType));
+    AddAggKernel(std::move(sig), PivotInit, func.get());
+  }
+  DCHECK_OK(registry->AddFunction(std::move(func)));
+}
+
+}  // namespace arrow::compute::internal

--- a/cpp/src/arrow/compute/kernels/aggregate_test.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_test.cc
@@ -4307,5 +4307,200 @@ TEST(TestTDigestKernel, ApproximateMedian) {
   }
 }
 
+//
+// Pivot
+//
+
+class TestPivotKernel : public ::testing::Test {
+ public:
+  void AssertPivot(const Datum& keys, const Datum& values, const Scalar& expected,
+                   const PivotWiderOptions& options) {
+    SCOPED_TRACE(options.ToString());
+    ASSERT_OK_AND_ASSIGN(Datum out,
+                         CallFunction("pivot_wider", {keys, values}, &options));
+    ValidateOutput(out);
+    ASSERT_TRUE(out.is_scalar());
+    AssertScalarsEqual(expected, *out.scalar(), /*verbose=*/true);
+  }
+};
+
+TEST_F(TestPivotKernel, Basics) {
+  auto key_type = utf8();
+  auto value_type = float32();
+
+  auto keys = ArrayFromJSON(key_type, R"(["width", "height"])");
+  auto values = ArrayFromJSON(value_type, "[10.5, 11.5]");
+  auto expected = ScalarFromJSON(
+      struct_({field("height", value_type), field("width", value_type)}), "[11.5, 10.5]");
+  AssertPivot(keys, values, *expected,
+              PivotWiderOptions(/*key_names=*/{"height", "width"}));
+}
+
+TEST_F(TestPivotKernel, AllKeyTypes) {
+  for (auto key_type : BaseBinaryTypes()) {
+    auto value_type = float32();
+
+    auto keys = ArrayFromJSON(key_type, R"(["width", "height"])");
+    auto values = ArrayFromJSON(value_type, "[10.5, 11.5]");
+    auto expected =
+        ScalarFromJSON(struct_({field("height", value_type), field("width", value_type)}),
+                       "[11.5, 10.5]");
+    AssertPivot(keys, values, *expected,
+                PivotWiderOptions(/*key_names=*/{"height", "width"}));
+  }
+}
+
+TEST_F(TestPivotKernel, Numbers) {
+  auto key_type = utf8();
+  for (auto value_type : NumericTypes()) {
+    auto keys = ArrayFromJSON(key_type, R"(["width", "height"])");
+    auto values = ArrayFromJSON(value_type, "[10, 11]");
+    auto expected = ScalarFromJSON(
+        struct_({field("height", value_type), field("width", value_type)}), "[11, 10]");
+    AssertPivot(keys, values, *expected,
+                PivotWiderOptions(/*key_names=*/{"height", "width"}));
+  }
+}
+
+TEST_F(TestPivotKernel, Binary) {
+  auto key_type = utf8();
+  for (auto value_type : BaseBinaryTypes()) {
+    auto keys = ArrayFromJSON(key_type, R"(["abc", "def"])");
+    auto values = ArrayFromJSON(value_type, R"(["foo", "bar"])");
+    auto expected =
+        ScalarFromJSON(struct_({field("abc", value_type), field("def", value_type)}),
+                       R"(["foo", "bar"])");
+    AssertPivot(keys, values, *expected, PivotWiderOptions(/*key_names=*/{"abc", "def"}));
+  }
+}
+
+TEST_F(TestPivotKernel, NullType) {
+  auto key_type = utf8();
+  auto value_type = null();
+
+  auto keys = ArrayFromJSON(key_type, R"(["abc", "def"])");
+  auto values = ArrayFromJSON(value_type, "[null, null]");
+  auto expected = ScalarFromJSON(
+      struct_({field("abc", value_type), field("def", value_type)}), R"([null, null])");
+  AssertPivot(keys, values, *expected, PivotWiderOptions(/*key_names=*/{"abc", "def"}));
+}
+
+TEST_F(TestPivotKernel, NullValues) {
+  auto key_type = utf8();
+  auto value_type = float32();
+
+  auto keys = ArrayFromJSON(key_type, R"(["width", "height", "height", "width"])");
+  auto values = ArrayFromJSON(value_type, "[null, 10.5, null, 11.5]");
+  auto expected = ScalarFromJSON(
+      struct_({field("height", value_type), field("width", value_type)}), "[10.5, 11.5]");
+  AssertPivot(keys, values, *expected,
+              PivotWiderOptions(/*key_names=*/{"height", "width"}));
+}
+
+TEST_F(TestPivotKernel, ChunkedInput) {
+  auto key_type = utf8();
+  auto value_type = float32();
+
+  auto keys = ChunkedArrayFromJSON(key_type,
+                                   {R"(["width"])", R"(["height", "height", "width"])"});
+  auto values = ChunkedArrayFromJSON(value_type, {"[null, 10.5]", "[null, 11.5]"});
+  auto expected = ScalarFromJSON(
+      struct_({field("height", value_type), field("width", value_type)}), "[10.5, 11.5]");
+  AssertPivot(keys, values, *expected,
+              PivotWiderOptions(/*key_names=*/{"height", "width"}));
+}
+
+TEST_F(TestPivotKernel, EmptyInput) {
+  auto key_type = utf8();
+  auto value_type = float32();
+  auto options = PivotWiderOptions(/*key_names=*/{"height", "width"});
+  auto expected_type = struct_({field("height", value_type), field("width", value_type)});
+  auto expected = ScalarFromJSON(expected_type, "[null, null]");
+
+  AssertPivot(ArrayFromJSON(key_type, "[]"), ArrayFromJSON(value_type, "[]"), *expected,
+              options);
+  AssertPivot(ChunkedArrayFromJSON(key_type, {}), ChunkedArrayFromJSON(value_type, {}),
+              *expected, options);
+}
+
+TEST_F(TestPivotKernel, MissingKey) {
+  auto key_type = utf8();
+  auto value_type = float32();
+
+  auto keys = ArrayFromJSON(key_type, R"(["width", "height"])");
+  auto values = ArrayFromJSON(value_type, "[10.5, 11.5]");
+  auto options = PivotWiderOptions(/*key_names=*/{"height", "width", "depth"});
+  auto expected =
+      ScalarFromJSON(struct_({field("height", value_type), field("width", value_type),
+                              field("depth", value_type)}),
+                     "[11.5, 10.5, null]");
+  AssertPivot(keys, values, *expected, options);
+}
+
+TEST_F(TestPivotKernel, UnexpectedKey) {
+  auto key_type = utf8();
+  auto value_type = float32();
+
+  auto keys = ArrayFromJSON(key_type, R"(["width", "height", "depth"])");
+  auto values = ArrayFromJSON(value_type, "[10.5, 11.5, 12.5]");
+  auto options = PivotWiderOptions(/*key_names=*/{"height", "width"});
+  auto expected = ScalarFromJSON(
+      struct_({field("height", value_type), field("width", value_type)}), "[11.5, 10.5]");
+  AssertPivot(keys, values, *expected, options);
+
+  options.unexpected_key_behavior = PivotWiderOptions::kRaise;
+  EXPECT_RAISES_WITH_MESSAGE_THAT(KeyError,
+                                  ::testing::HasSubstr("Unexpected pivot key: depth"),
+                                  CallFunction("pivot_wider", {keys, values}, &options));
+}
+
+TEST_F(TestPivotKernel, NullKey) {
+  auto key_type = utf8();
+  auto value_type = float32();
+
+  auto keys = ArrayFromJSON(key_type, R"(["width", null])");
+  auto values = ArrayFromJSON(value_type, "[10.5, 11.5]");
+  auto options = PivotWiderOptions(/*key_names=*/{"height", "width"});
+  EXPECT_RAISES_WITH_MESSAGE_THAT(KeyError,
+                                  ::testing::HasSubstr("pivot key name cannot be null"),
+                                  CallFunction("pivot_wider", {keys, values}, &options));
+}
+
+TEST_F(TestPivotKernel, DuplicateKeyNames) {
+  auto key_type = utf8();
+  auto value_type = float32();
+
+  auto keys = ArrayFromJSON(key_type, "[]");
+  auto values = ArrayFromJSON(value_type, "[]");
+  auto options = PivotWiderOptions(/*key_names=*/{"height", "height", "width"});
+  EXPECT_RAISES_WITH_MESSAGE_THAT(
+      KeyError, ::testing::HasSubstr("Duplicate key name 'height' in PivotWiderOptions"),
+      CallFunction("pivot_wider", {keys, values}, &options));
+}
+
+TEST_F(TestPivotKernel, DuplicateValues) {
+  auto key_type = utf8();
+  auto value_type = float32();
+  auto options = PivotWiderOptions(/*key_names=*/{"height", "width"});
+
+  {
+    // Duplicate values in the same chunk
+    auto keys = ArrayFromJSON(key_type, R"(["width", "height", "height"])");
+    auto values = ArrayFromJSON(value_type, "[10.5, 11.5, 12.5]");
+    EXPECT_RAISES_WITH_MESSAGE_THAT(
+        Invalid, ::testing::HasSubstr("Encountered more than one non-null value"),
+        CallFunction("pivot_wider", {keys, values}, &options));
+  }
+  {
+    // Duplicate values in different chunks
+    auto keys =
+        ChunkedArrayFromJSON(key_type, {R"(["width", "height"])", R"(["height"])"});
+    auto values = ChunkedArrayFromJSON(value_type, {"[10.5, 11.5]", "[12.5]"});
+    EXPECT_RAISES_WITH_MESSAGE_THAT(
+        Invalid, ::testing::HasSubstr("Encountered more than one non-null value"),
+        CallFunction("pivot_wider", {keys, values}, &options));
+  }
+}
+
 }  // namespace compute
 }  // namespace arrow

--- a/cpp/src/arrow/compute/kernels/hash_aggregate.cc
+++ b/cpp/src/arrow/compute/kernels/hash_aggregate.cc
@@ -3860,8 +3860,10 @@ const FunctionDoc hash_pivot_doc{
      "All output struct fields have the same type as `pivot_values`.\n"
      "Each pivot key decides in which output field the corresponding pivot value\n"
      "is emitted. If a pivot key doesn't appear in a given group, null is emitted.\n"
-     "If a pivot key appears twice in a given group, KeyError is raised.\n"
-     "Behavior of unexpected pivot keys is controlled by PivotWiderOptions."),
+     "If more than one non-null value is encountered in the same group for a\n"
+     "given pivot key, Invalid is raised.\n"
+     "Behavior of unexpected pivot keys is controlled by `unexpected_key_behavior`\n"
+     "in PivotWiderOptions."),
     {"pivot_keys", "pivot_values", "group_id_array"},
     "PivotWiderOptions"};
 

--- a/cpp/src/arrow/compute/kernels/hash_aggregate.cc
+++ b/cpp/src/arrow/compute/kernels/hash_aggregate.cc
@@ -26,6 +26,7 @@
 
 #include "arrow/array/builder_nested.h"
 #include "arrow/array/builder_primitive.h"
+#include "arrow/array/concatenate.h"
 #include "arrow/buffer_builder.h"
 #include "arrow/compute/api_aggregate.h"
 #include "arrow/compute/api_vector.h"
@@ -33,6 +34,7 @@
 #include "arrow/compute/kernels/aggregate_internal.h"
 #include "arrow/compute/kernels/aggregate_var_std_internal.h"
 #include "arrow/compute/kernels/common_internal.h"
+#include "arrow/compute/kernels/pivot_internal.h"
 #include "arrow/compute/kernels/util_internal.h"
 #include "arrow/compute/row/grouper.h"
 #include "arrow/compute/row/row_encoder_internal.h"
@@ -40,6 +42,7 @@
 #include "arrow/stl_allocator.h"
 #include "arrow/type_traits.h"
 #include "arrow/util/bit_run_reader.h"
+#include "arrow/util/bit_util.h"
 #include "arrow/util/bitmap_ops.h"
 #include "arrow/util/bitmap_writer.h"
 #include "arrow/util/checked_cast.h"
@@ -47,6 +50,7 @@
 #include "arrow/util/int128_internal.h"
 #include "arrow/util/int_util_overflow.h"
 #include "arrow/util/ree_util.h"
+#include "arrow/util/span.h"
 #include "arrow/util/task_group.h"
 #include "arrow/util/tdigest.h"
 #include "arrow/util/thread_pool.h"
@@ -56,6 +60,7 @@ namespace arrow {
 
 using internal::checked_cast;
 using internal::FirstTimeBitmapWriter;
+using util::span;
 
 namespace compute {
 namespace internal {
@@ -3319,9 +3324,401 @@ struct GroupedListFactory {
   HashAggregateKernel kernel;
   InputType argument_type;
 };
-}  // namespace
 
-namespace {
+// ----------------------------------------------------------------------
+// Pivot implementation
+
+struct GroupedPivotAccumulator {
+  Status Init(ExecContext* ctx, std::shared_ptr<DataType> value_type,
+              const PivotWiderOptions* options) {
+    ctx_ = ctx;
+    value_type_ = std::move(value_type);
+    num_keys_ = static_cast<int>(options->key_names.size());
+    num_groups_ = 0;
+    columns_.resize(num_keys_);
+    scratch_buffer_ = BufferBuilder(ctx_->memory_pool());
+    return Status::OK();
+  }
+
+  Status Consume(span<const uint32_t> groups, span<const PivotWiderKeyIndex> keys,
+                 const ArraySpan& values) {
+    // To dispatch the values into the right (group, key) coordinates,
+    // we first compute a vector of take indices for each output column.
+    //
+    // For each index #i, we set take_indices[keys[#i]][groups[#i]] = #i.
+    // Unpopulated take_indices entries are null.
+    //
+    // For example, assuming we get:
+    //   groups  |  keys
+    // ===================
+    //    1      |   0
+    //    3      |   1
+    //    1      |   1
+    //    0      |   1
+    //
+    // We are going to compute:
+    // - take_indices[key = 0] = [null, 0, null, null]
+    // - take_indices[key = 1] = [3, 2, null, 2]
+    //
+    // Then each output column is computed by taking the values with the
+    // respective take_indices for the column's keys.
+    //
+
+    DCHECK_EQ(groups.size(), keys.size());
+    DCHECK_EQ(groups.size(), static_cast<size_t>(values.length));
+
+    std::shared_ptr<DataType> take_index_type;
+    std::vector<std::shared_ptr<Buffer>> take_indices(num_keys_);
+    std::vector<std::shared_ptr<Buffer>> take_bitmaps(num_keys_);
+
+    // A generic lambda that computes the take indices with the desired integer width
+    auto compute_take_indices = [&](auto typed_index) {
+      ARROW_UNUSED(typed_index);
+      using TakeIndex = std::decay_t<decltype(typed_index)>;
+      take_index_type = CTypeTraits<TakeIndex>::type_singleton();
+
+      const int64_t take_indices_size =
+          bit_util::RoundUpToMultipleOf64(num_groups_ * sizeof(TakeIndex));
+      const int64_t take_bitmap_size =
+          bit_util::RoundUpToMultipleOf64(bit_util::BytesForBits(num_groups_));
+      const int64_t total_scratch_size =
+          num_keys_ * (take_indices_size + take_bitmap_size);
+      RETURN_NOT_OK(scratch_buffer_.Resize(total_scratch_size, /*shrink_to_fit=*/false));
+
+      // Slice the scratch space into individual buffers for each output column's
+      // take_indices array.
+      std::vector<TakeIndex*> take_indices_data(num_keys_);
+      std::vector<uint8_t*> take_bitmap_data(num_keys_);
+      int64_t offset = 0;
+      for (int i = 0; i < num_keys_; ++i) {
+        take_indices[i] = std::make_shared<MutableBuffer>(
+            scratch_buffer_.mutable_data() + offset, take_indices_size);
+        take_indices_data[i] = take_indices[i]->mutable_data_as<TakeIndex>();
+        offset += take_indices_size;
+        take_bitmaps[i] = std::make_shared<MutableBuffer>(
+            scratch_buffer_.mutable_data() + offset, take_bitmap_size);
+        take_bitmap_data[i] = take_bitmaps[i]->mutable_data();
+        memset(take_bitmap_data[i], 0, take_bitmap_size);
+        offset += take_bitmap_size;
+      }
+      DCHECK_LE(offset, scratch_buffer_.capacity());
+
+      // Populate the take_indices for each output column
+      for (int64_t i = 0; i < values.length; ++i) {
+        const PivotWiderKeyIndex key = keys[i];
+        const uint32_t group = groups[i];
+        if (key != kNullPivotKey && !values.IsNull(i)) {
+          DCHECK_LT(static_cast<int>(key), num_keys_);
+          if (bit_util::GetBit(take_bitmap_data[key], group)) {
+            return DuplicateValue();
+          }
+          // For row #group in column #key, we are going to take the value at index #i
+          bit_util::SetBit(take_bitmap_data[key], group);
+          take_indices_data[key][group] = static_cast<TakeIndex>(i);
+        }
+      }
+      return Status::OK();
+    };
+
+    // Call compute_take_indices with the optimal integer width
+    if (values.length <= static_cast<int64_t>(std::numeric_limits<uint8_t>::max())) {
+      RETURN_NOT_OK(compute_take_indices(uint8_t{}));
+    } else if (values.length <=
+               static_cast<int64_t>(std::numeric_limits<uint16_t>::max())) {
+      RETURN_NOT_OK(compute_take_indices(uint16_t{}));
+    } else if (values.length <=
+               static_cast<int64_t>(std::numeric_limits<uint32_t>::max())) {
+      RETURN_NOT_OK(compute_take_indices(uint32_t{}));
+    } else {
+      RETURN_NOT_OK(compute_take_indices(uint64_t{}));
+    }
+
+    // Use take_indices to compute the output columns for this batch
+    auto values_data = values.ToArrayData();
+    ArrayVector new_columns(num_keys_);
+    for (int i = 0; i < num_keys_; ++i) {
+      auto indices_data =
+          ArrayData::Make(take_index_type, num_groups_,
+                          {std::move(take_bitmaps[i]), std::move(take_indices[i])});
+      // If indices_data is all nulls, we can just ignore this column.
+      if (indices_data->GetNullCount() != indices_data->length) {
+        ARROW_ASSIGN_OR_RAISE(Datum grouped_column, Take(values_data, indices_data,
+                                                         TakeOptions::Defaults(), ctx_));
+        new_columns[i] = grouped_column.make_array();
+      }
+    }
+    // Merge them with the previous columns
+    return MergeColumns(std::move(new_columns));
+  }
+
+  Status Consume(span<const uint32_t> groups, const PivotWiderKeyIndex key,
+                 const ArraySpan& values) {
+    if (key == kNullPivotKey) {
+      // Nothing to update
+      return Status::OK();
+    }
+    DCHECK_LT(static_cast<int>(key), num_keys_);
+    DCHECK_EQ(groups.size(), static_cast<size_t>(values.length));
+
+    // The algorithm is simpler than in the array-taking version of Consume()
+    // below, since only the column #key needs to be updated.
+    std::shared_ptr<DataType> take_index_type;
+    std::shared_ptr<Buffer> take_indices;
+    std::shared_ptr<Buffer> take_bitmap;
+
+    // A generic lambda that computes the take indices with the desired integer width
+    auto compute_take_indices = [&](auto typed_index) {
+      ARROW_UNUSED(typed_index);
+      using TakeIndex = std::decay_t<decltype(typed_index)>;
+      take_index_type = CTypeTraits<TakeIndex>::type_singleton();
+
+      const int64_t take_indices_size =
+          bit_util::RoundUpToMultipleOf64(num_groups_ * sizeof(TakeIndex));
+      const int64_t take_bitmap_size =
+          bit_util::RoundUpToMultipleOf64(bit_util::BytesForBits(num_groups_));
+      const int64_t total_scratch_size = take_indices_size + take_bitmap_size;
+      RETURN_NOT_OK(scratch_buffer_.Resize(total_scratch_size, /*shrink_to_fit=*/false));
+
+      take_indices = std::make_shared<MutableBuffer>(scratch_buffer_.mutable_data(),
+                                                     take_indices_size);
+      take_bitmap = std::make_shared<MutableBuffer>(
+          scratch_buffer_.mutable_data() + take_indices_size, take_bitmap_size);
+      auto take_indices_data = take_indices->mutable_data_as<TakeIndex>();
+      auto take_bitmap_data = take_bitmap->mutable_data();
+      memset(take_bitmap_data, 0, take_bitmap_size);
+
+      for (int64_t i = 0; i < values.length; ++i) {
+        const uint32_t group = groups[i];
+        if (!values.IsNull(i)) {
+          if (bit_util::GetBit(take_bitmap_data, group)) {
+            return DuplicateValue();
+          }
+          bit_util::SetBit(take_bitmap_data, group);
+          take_indices_data[group] = static_cast<TakeIndex>(i);
+        }
+      }
+      return Status::OK();
+    };
+
+    // Call compute_take_indices with the optimal integer width
+    if (values.length <= static_cast<int64_t>(std::numeric_limits<uint8_t>::max())) {
+      RETURN_NOT_OK(compute_take_indices(uint8_t{}));
+    } else if (values.length <=
+               static_cast<int64_t>(std::numeric_limits<uint16_t>::max())) {
+      RETURN_NOT_OK(compute_take_indices(uint16_t{}));
+    } else if (values.length <=
+               static_cast<int64_t>(std::numeric_limits<uint32_t>::max())) {
+      RETURN_NOT_OK(compute_take_indices(uint32_t{}));
+    } else {
+      RETURN_NOT_OK(compute_take_indices(uint64_t{}));
+    }
+
+    // Use take_indices to update column #key
+    auto values_data = values.ToArrayData();
+    auto indices_data = ArrayData::Make(
+        take_index_type, num_groups_, {std::move(take_bitmap), std::move(take_indices)});
+    ARROW_ASSIGN_OR_RAISE(Datum grouped_column,
+                          Take(values_data, indices_data, TakeOptions::Defaults(), ctx_));
+    return MergeColumn(&columns_[key], grouped_column.make_array());
+  }
+
+  Status Resize(int64_t new_num_groups) {
+    if (new_num_groups > std::numeric_limits<int32_t>::max()) {
+      return Status::NotImplemented("Pivot with more 2**31 groups");
+    }
+    return ResizeColumns(new_num_groups);
+  }
+
+  Status Merge(GroupedPivotAccumulator&& other, const ArrayData& group_id_mapping) {
+    // To merge `other` into `*this`, we simply merge their respective columns.
+    // However, we must first transpose `other`'s rows using `group_id_mapping`.
+    // This is a logical "scatter" operation.
+    //
+    // Since `scatter(indices)` is implemented as `take(inverse_permutation(indices))`,
+    // we can save time by computing `inverse_permutation(indices)` once for all
+    // columns.
+
+    // Scatter/InversePermutation only accept signed indices. We checked
+    // in Resize() above that we were inside the limites for int32.
+    auto scatter_indices = group_id_mapping.Copy();
+    scatter_indices->type = int32();
+    std::shared_ptr<DataType> take_indices_type;
+    if (num_groups_ - 1 <= std::numeric_limits<int8_t>::max()) {
+      take_indices_type = int8();
+    } else if (num_groups_ - 1 <= std::numeric_limits<int16_t>::max()) {
+      take_indices_type = int16();
+    } else {
+      DCHECK_GE(num_groups_ - 1, std::numeric_limits<int32_t>::max());
+      take_indices_type = int32();
+    }
+    InversePermutationOptions options(/*max_index=*/num_groups_ - 1, take_indices_type);
+    ARROW_ASSIGN_OR_RAISE(auto take_indices,
+                          InversePermutation(scatter_indices, options, ctx_));
+    auto scatter_column =
+        [&](const std::shared_ptr<Array>& column) -> Result<std::shared_ptr<Array>> {
+      ARROW_ASSIGN_OR_RAISE(auto scattered,
+                            CallFunction("take", {column, take_indices}, &options, ctx_));
+      return scattered.make_array();
+    };
+    return MergeColumns(std::move(other.columns_), std::move(scatter_column));
+  }
+
+  Result<ArrayVector> Finalize() {
+    // Ensure that columns are allocated even if num_groups_ == 0
+    RETURN_NOT_OK(ResizeColumns(num_groups_));
+    return std::move(columns_);
+  }
+
+ protected:
+  Status ResizeColumns(int64_t new_num_groups) {
+    if (new_num_groups == num_groups_ && num_groups_ != 0) {
+      return Status::OK();
+    }
+    ARROW_ASSIGN_OR_RAISE(
+        auto array_suffix,
+        MakeArrayOfNull(value_type_, new_num_groups - num_groups_, ctx_->memory_pool()));
+    for (auto& column : columns_) {
+      if (num_groups_ != 0) {
+        DCHECK_NE(column, nullptr);
+        ARROW_ASSIGN_OR_RAISE(
+            column, Concatenate({std::move(column), array_suffix}, ctx_->memory_pool()));
+      } else {
+        column = array_suffix;
+      }
+      DCHECK_EQ(column->length(), new_num_groups);
+    }
+    num_groups_ = new_num_groups;
+    return Status::OK();
+  }
+
+  using ColumnTransform =
+      std::function<Result<std::shared_ptr<Array>>(const std::shared_ptr<Array>&)>;
+
+  Status MergeColumns(ArrayVector&& other_columns,
+                      const ColumnTransform& transform = {}) {
+    DCHECK_EQ(columns_.size(), other_columns.size());
+    for (int i = 0; i < num_keys_; ++i) {
+      if (other_columns[i]) {
+        RETURN_NOT_OK(MergeColumn(&columns_[i], std::move(other_columns[i]), transform));
+      }
+    }
+    return Status::OK();
+  }
+
+  Status MergeColumn(std::shared_ptr<Array>* column, std::shared_ptr<Array> other_column,
+                     const ColumnTransform& transform = {}) {
+    if (other_column->null_count() == other_column->length()) {
+      // Avoid paying for the transform step below, since merging will be a no-op anyway.
+      return Status::OK();
+    }
+    if (transform) {
+      ARROW_ASSIGN_OR_RAISE(other_column, transform(other_column));
+    }
+    DCHECK_EQ(num_groups_, other_column->length());
+    if (!*column) {
+      *column = other_column;
+      return Status::OK();
+    }
+    if ((*column)->null_count() == (*column)->length()) {
+      *column = other_column;
+      return Status::OK();
+    }
+    int64_t expected_non_nulls = (num_groups_ - (*column)->null_count()) +
+                                 (num_groups_ - other_column->null_count());
+    ARROW_ASSIGN_OR_RAISE(auto coalesced,
+                          CallFunction("coalesce", {*column, other_column}, ctx_));
+    // Check that all non-null values in other_column and column were kept in the result.
+    if (expected_non_nulls != num_groups_ - coalesced.null_count()) {
+      DCHECK_GT(expected_non_nulls, num_groups_ - coalesced.null_count());
+      return DuplicateValue();
+    }
+    *column = coalesced.make_array();
+    return Status::OK();
+  }
+
+  Status DuplicateValue() {
+    return Status::Invalid(
+        "Encountered more than one non-null value for the same grouped pivot key");
+  }
+
+  ExecContext* ctx_;
+  std::shared_ptr<DataType> value_type_;
+  int num_keys_;
+  int64_t num_groups_;
+  ArrayVector columns_;
+  // A persistent scratch buffer to store the take indices in Consume
+  BufferBuilder scratch_buffer_;
+};
+
+struct GroupedPivotImpl : public GroupedAggregator {
+  Status Init(ExecContext* ctx, const KernelInitArgs& args) override {
+    DCHECK_EQ(args.inputs.size(), 3);
+    key_type_ = args.inputs[0].GetSharedPtr();
+    options_ = checked_cast<const PivotWiderOptions*>(args.options);
+    DCHECK_NE(options_, nullptr);
+    auto value_type = args.inputs[1].GetSharedPtr();
+    FieldVector fields;
+    fields.reserve(options_->key_names.size());
+    for (const auto& key_name : options_->key_names) {
+      fields.push_back(field(key_name, value_type));
+    }
+    out_type_ = struct_(std::move(fields));
+    out_struct_type_ = checked_cast<const StructType*>(out_type_.get());
+    ARROW_ASSIGN_OR_RAISE(key_mapper_, PivotWiderKeyMapper::Make(*key_type_, options_));
+    RETURN_NOT_OK(accumulator_.Init(ctx, value_type, options_));
+    return Status::OK();
+  }
+
+  Status Resize(int64_t new_num_groups) override {
+    num_groups_ = new_num_groups;
+    return accumulator_.Resize(new_num_groups);
+  }
+
+  Status Merge(GroupedAggregator&& raw_other,
+               const ArrayData& group_id_mapping) override {
+    auto other = checked_cast<GroupedPivotImpl*>(&raw_other);
+    return accumulator_.Merge(std::move(other->accumulator_), group_id_mapping);
+  }
+
+  Status Consume(const ExecSpan& batch) override {
+    DCHECK_EQ(batch.values.size(), 3);
+    auto groups = batch[2].array.GetSpan<const uint32_t>(1, batch.length);
+    if (!batch[1].is_array()) {
+      return Status::NotImplemented("Consuming scalar pivot value");
+    }
+    if (batch[0].is_array()) {
+      ARROW_ASSIGN_OR_RAISE(span<const PivotWiderKeyIndex> keys,
+                            key_mapper_->MapKeys(batch[0].array));
+      return accumulator_.Consume(groups, keys, batch[1].array);
+    } else {
+      ARROW_ASSIGN_OR_RAISE(PivotWiderKeyIndex key,
+                            key_mapper_->MapKey(*batch[0].scalar));
+      return accumulator_.Consume(groups, key, batch[1].array);
+    }
+  }
+
+  Result<Datum> Finalize() override {
+    ARROW_ASSIGN_OR_RAISE(auto columns, accumulator_.Finalize());
+    DCHECK_EQ(columns.size(), static_cast<size_t>(out_struct_type_->num_fields()));
+    return std::make_shared<StructArray>(out_type_, num_groups_, std::move(columns),
+                                         /*null_bitmap=*/nullptr,
+                                         /*null_count=*/0);
+  }
+
+  std::shared_ptr<DataType> out_type() const override { return out_type_; }
+
+  std::shared_ptr<DataType> key_type_;
+  std::shared_ptr<DataType> out_type_;
+  const StructType* out_struct_type_;
+  const PivotWiderOptions* options_;
+  std::unique_ptr<PivotWiderKeyMapper> key_mapper_;
+  GroupedPivotAccumulator accumulator_;
+  int64_t num_groups_ = 0;
+};
+
+// ----------------------------------------------------------------------
+// Docstrings
+
 const FunctionDoc hash_count_doc{
     "Count the number of null / non-null values in each group",
     ("By default, only non-null values are counted.\n"
@@ -3456,6 +3853,18 @@ const FunctionDoc hash_one_doc{"Get one value from each group",
 const FunctionDoc hash_list_doc{"List all values in each group",
                                 ("Null values are also returned."),
                                 {"array", "group_id_array"}};
+
+const FunctionDoc hash_pivot_doc{
+    "Pivot values according to a pivot key column",
+    ("Output is a struct array with as many fields as `PivotWiderOptions.key_names`.\n"
+     "All output struct fields have the same type as `pivot_values`.\n"
+     "Each pivot key decides in which output field the corresponding pivot value\n"
+     "is emitted. If a pivot key doesn't appear in a given group, null is emitted.\n"
+     "If a pivot key appears twice in a given group, KeyError is raised.\n"
+     "Behavior of unexpected pivot keys is controlled by PivotWiderOptions."),
+    {"pivot_keys", "pivot_values", "group_id_array"},
+    "PivotWiderOptions"};
+
 }  // namespace
 
 void RegisterHashAggregateBasic(FunctionRegistry* registry) {
@@ -3703,6 +4112,20 @@ void RegisterHashAggregateBasic(FunctionRegistry* registry) {
     DCHECK_OK(AddHashAggKernels({null(), boolean(), decimal128(1, 1), decimal256(1, 1),
                                  month_interval(), fixed_size_binary(1)},
                                 GroupedListFactory::Make, func.get()));
+    DCHECK_OK(registry->AddFunction(std::move(func)));
+  }
+
+  {
+    auto func = std::make_shared<HashAggregateFunction>("hash_pivot_wider",
+                                                        Arity::Ternary(), hash_pivot_doc);
+    for (auto key_type : BaseBinaryTypes()) {
+      // Anything that scatter() (i.e. take()) accepts can be passed as values
+      auto sig = KernelSignature::Make(
+          {key_type->id(), InputType::Any(), InputType(Type::UINT32)},
+          OutputType(ResolveGroupOutputType));
+      DCHECK_OK(func->AddKernel(
+          MakeKernel(std::move(sig), HashAggregateInit<GroupedPivotImpl>)));
+    }
     DCHECK_OK(registry->AddFunction(std::move(func)));
   }
 }

--- a/cpp/src/arrow/compute/kernels/hash_aggregate.cc
+++ b/cpp/src/arrow/compute/kernels/hash_aggregate.cc
@@ -3358,7 +3358,7 @@ struct GroupedPivotAccumulator {
     //
     // We are going to compute:
     // - take_indices[key = 0] = [null, 0, null, null]
-    // - take_indices[key = 1] = [3, 2, null, 2]
+    // - take_indices[key = 1] = [3, 2, null, 1]
     //
     // Then each output column is computed by taking the values with the
     // respective take_indices for the column's keys.
@@ -3406,9 +3406,9 @@ struct GroupedPivotAccumulator {
       // Populate the take_indices for each output column
       for (int64_t i = 0; i < values.length; ++i) {
         const PivotWiderKeyIndex key = keys[i];
-        const uint32_t group = groups[i];
         if (key != kNullPivotKey && !values.IsNull(i)) {
           DCHECK_LT(static_cast<int>(key), num_keys_);
+          const uint32_t group = groups[i];
           if (bit_util::GetBit(take_bitmap_data[key], group)) {
             return DuplicateValue();
           }

--- a/cpp/src/arrow/compute/kernels/pivot_internal.cc
+++ b/cpp/src/arrow/compute/kernels/pivot_internal.cc
@@ -56,6 +56,7 @@ struct BasePivotKeyMapper : public PivotWiderKeyMapper {
     if (unexpected_key_behavior_ == PivotWiderOptions::kIgnore) {
       return kNullPivotKey;
     }
+    DCHECK_EQ(unexpected_key_behavior_, PivotWiderOptions::kRaise);
     return Status::KeyError("Unexpected pivot key: ", key_name);
   }
 

--- a/cpp/src/arrow/compute/kernels/pivot_internal.cc
+++ b/cpp/src/arrow/compute/kernels/pivot_internal.cc
@@ -1,0 +1,127 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/compute/kernels/pivot_internal.h"
+
+#include <cstdint>
+
+#include "arrow/compute/exec.h"
+#include "arrow/compute/kernels/codegen_internal.h"
+#include "arrow/scalar.h"
+#include "arrow/type_traits.h"
+#include "arrow/util/checked_cast.h"
+#include "arrow/visit_type_inline.h"
+
+namespace arrow::compute::internal {
+
+using ::arrow::util::span;
+
+struct BasePivotKeyMapper : public PivotWiderKeyMapper {
+  Status Init(const PivotWiderOptions* options) override {
+    if (options->key_names.size() > static_cast<size_t>(kMaxPivotKey) + 1) {
+      return Status::NotImplemented("Pivoting to more than ",
+                                    static_cast<size_t>(kMaxPivotKey) + 1,
+                                    " columns: got ", options->key_names.size());
+    }
+    key_name_map_.reserve(options->key_names.size());
+    PivotWiderKeyIndex index = 0;
+    for (const auto& key_name : options->key_names) {
+      bool inserted =
+          key_name_map_.try_emplace(std::string_view(key_name), index++).second;
+      if (!inserted) {
+        return Status::KeyError("Duplicate key name '", key_name,
+                                "' in PivotWiderOptions");
+      }
+    }
+    unexpected_key_behavior_ = options->unexpected_key_behavior;
+    return Status::OK();
+  }
+
+ protected:
+  Result<PivotWiderKeyIndex> KeyNotFound(std::string_view key_name) {
+    if (unexpected_key_behavior_ == PivotWiderOptions::kIgnore) {
+      return kNullPivotKey;
+    }
+    return Status::KeyError("Unexpected pivot key: ", key_name);
+  }
+
+  Result<PivotWiderKeyIndex> LookupKey(std::string_view key_name) {
+    const auto it = this->key_name_map_.find(key_name);
+    if (ARROW_PREDICT_FALSE(it == this->key_name_map_.end())) {
+      return KeyNotFound(key_name);
+    } else {
+      return it->second;
+    }
+  }
+
+  Status NullKeyName() { return Status::KeyError("pivot key name cannot be null"); }
+
+  static constexpr int kBatchLength = 512;
+  // The strings backing the string_views should be kept alive by PivotWiderOptions.
+  std::unordered_map<std::string_view, PivotWiderKeyIndex> key_name_map_;
+  PivotWiderOptions::UnexpectedKeyBehavior unexpected_key_behavior_;
+  TypedBufferBuilder<PivotWiderKeyIndex> key_indices_buffer_;
+};
+
+template <typename KeyType>
+struct TypedPivotKeyMapper : public BasePivotKeyMapper {
+  Result<span<const PivotWiderKeyIndex>> MapKeys(const ArraySpan& array) override {
+    // XXX Should use a faster hashing facility than unordered_map, for example
+    // Grouper or SwissTable.
+    RETURN_NOT_OK(this->key_indices_buffer_.Reserve(array.length));
+    PivotWiderKeyIndex* key_indices = this->key_indices_buffer_.mutable_data();
+    int64_t i = 0;
+    RETURN_NOT_OK(VisitArrayValuesInline<KeyType>(
+        array,
+        [&](std::string_view key_name) {
+          ARROW_ASSIGN_OR_RAISE(key_indices[i], LookupKey(key_name));
+          ++i;
+          return Status::OK();
+        },
+        [&]() { return NullKeyName(); }));
+    return span(key_indices, array.length);
+  }
+
+  Result<PivotWiderKeyIndex> MapKey(const Scalar& scalar) override {
+    if (!scalar.is_valid) {
+      return NullKeyName();
+    }
+    const auto& binary_scalar = checked_cast<const BaseBinaryScalar&>(scalar);
+    return LookupKey(binary_scalar.view());
+  }
+};
+
+Result<std::unique_ptr<PivotWiderKeyMapper>> PivotWiderKeyMapper::Make(
+    const DataType& key_type, const PivotWiderOptions* options) {
+  std::unique_ptr<PivotWiderKeyMapper> instance;
+
+  auto visit_key_type =
+      [&](auto&& key_type) -> Result<std::unique_ptr<PivotWiderKeyMapper>> {
+    using T = std::decay_t<decltype(key_type)>;
+    // Only binary-like keys are supported for now
+    if constexpr (is_base_binary_type<T>::value) {
+      instance = std::make_unique<TypedPivotKeyMapper<T>>();
+      RETURN_NOT_OK(instance->Init(options));
+      return std::move(instance);
+    }
+    return Status::NotImplemented("Pivot key type: ", key_type);
+  };
+
+  return VisitType(key_type, visit_key_type);
+}
+
+}  // namespace arrow::compute::internal

--- a/cpp/src/arrow/compute/kernels/pivot_internal.cc
+++ b/cpp/src/arrow/compute/kernels/pivot_internal.cc
@@ -70,7 +70,6 @@ struct BasePivotKeyMapper : public PivotWiderKeyMapper {
 
   Status NullKeyName() { return Status::KeyError("pivot key name cannot be null"); }
 
-  static constexpr int kBatchLength = 512;
   // The strings backing the string_views should be kept alive by PivotWiderOptions.
   std::unordered_map<std::string_view, PivotWiderKeyIndex> key_name_map_;
   PivotWiderOptions::UnexpectedKeyBehavior unexpected_key_behavior_;

--- a/cpp/src/arrow/compute/kernels/pivot_internal.h
+++ b/cpp/src/arrow/compute/kernels/pivot_internal.h
@@ -1,0 +1,51 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <limits>
+#include <memory>
+
+#include "arrow/compute/api_aggregate.h"
+#include "arrow/compute/type_fwd.h"
+#include "arrow/result.h"
+#include "arrow/status.h"
+#include "arrow/type_fwd.h"
+#include "arrow/util/span.h"
+
+namespace arrow::compute::internal {
+
+using PivotWiderKeyIndex = uint8_t;
+
+constexpr PivotWiderKeyIndex kNullPivotKey =
+    std::numeric_limits<PivotWiderKeyIndex>::max();
+constexpr PivotWiderKeyIndex kMaxPivotKey = kNullPivotKey - 1;
+
+struct PivotWiderKeyMapper {
+  virtual ~PivotWiderKeyMapper() = default;
+
+  virtual Status Init(const PivotWiderOptions* options) = 0;
+  virtual Result<::arrow::util::span<const PivotWiderKeyIndex>> MapKeys(
+      const ArraySpan&) = 0;
+  virtual Result<PivotWiderKeyIndex> MapKey(const Scalar&) = 0;
+
+  static Result<std::unique_ptr<PivotWiderKeyMapper>> Make(
+      const DataType& key_type, const PivotWiderOptions* options);
+};
+
+}  // namespace arrow::compute::internal

--- a/cpp/src/arrow/compute/registry.cc
+++ b/cpp/src/arrow/compute/registry.cc
@@ -327,6 +327,7 @@ static std::unique_ptr<FunctionRegistry> CreateBuiltInRegistry() {
   RegisterHashAggregateBasic(registry.get());
   RegisterScalarAggregateBasic(registry.get());
   RegisterScalarAggregateMode(registry.get());
+  RegisterScalarAggregatePivot(registry.get());
   RegisterScalarAggregateQuantile(registry.get());
   RegisterScalarAggregateTDigest(registry.get());
   RegisterScalarAggregateVariance(registry.get());

--- a/cpp/src/arrow/compute/registry_internal.h
+++ b/cpp/src/arrow/compute/registry_internal.h
@@ -63,6 +63,7 @@ void RegisterVectorOptions(FunctionRegistry* registry);
 void RegisterHashAggregateBasic(FunctionRegistry* registry);
 void RegisterScalarAggregateBasic(FunctionRegistry* registry);
 void RegisterScalarAggregateMode(FunctionRegistry* registry);
+void RegisterScalarAggregatePivot(FunctionRegistry* registry);
 void RegisterScalarAggregateQuantile(FunctionRegistry* registry);
 void RegisterScalarAggregateTDigest(FunctionRegistry* registry);
 void RegisterScalarAggregateVariance(FunctionRegistry* registry);

--- a/cpp/src/arrow/compute/type_fwd.h
+++ b/cpp/src/arrow/compute/type_fwd.h
@@ -40,6 +40,7 @@ class CastOptions;
 
 struct ExecBatch;
 class ExecContext;
+struct ExecValue;
 class KernelContext;
 
 struct Kernel;

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -214,35 +214,37 @@ the input to a single output value.
 +--------------------+---------+------------------+------------------------+----------------------------------+-------+
 | count_distinct     | Unary   | Non-nested types | Scalar Int64           | :struct:`CountOptions`           | \(2)  |
 +--------------------+---------+------------------+------------------------+----------------------------------+-------+
-| first              | Unary   | Numeric, Binary  | Scalar Input type      | :struct:`ScalarAggregateOptions` | \(11) |
+| first              | Unary   | Numeric, Binary  | Scalar Input type      | :struct:`ScalarAggregateOptions` | \(3) |
 +--------------------+---------+------------------+------------------------+----------------------------------+-------+
-| first_last         | Unary   | Numeric, Binary  | Scalar Struct          | :struct:`ScalarAggregateOptions` | \(11) |
+| first_last         | Unary   | Numeric, Binary  | Scalar Struct          | :struct:`ScalarAggregateOptions` | \(3) |
 +--------------------+---------+------------------+------------------------+----------------------------------+-------+
-| index              | Unary   | Any              | Scalar Int64           | :struct:`IndexOptions`           | \(3)  |
+| index              | Unary   | Any              | Scalar Int64           | :struct:`IndexOptions`           | \(4)  |
 +--------------------+---------+------------------+------------------------+----------------------------------+-------+
-| last               | Unary   | Numeric, Binary  | Scalar Input type      | :struct:`ScalarAggregateOptions` | \(11) |
+| last               | Unary   | Numeric, Binary  | Scalar Input type      | :struct:`ScalarAggregateOptions` | \(3) |
 +--------------------+---------+------------------+------------------------+----------------------------------+-------+
 | max                | Unary   | Non-nested types | Scalar Input type      | :struct:`ScalarAggregateOptions` |       |
 +--------------------+---------+------------------+------------------------+----------------------------------+-------+
-| mean               | Unary   | Numeric          | Scalar Decimal/Float64 | :struct:`ScalarAggregateOptions` | \(4)  |
+| mean               | Unary   | Numeric          | Scalar Decimal/Float64 | :struct:`ScalarAggregateOptions` | \(5)  |
 +--------------------+---------+------------------+------------------------+----------------------------------+-------+
 | min                | Unary   | Non-nested types | Scalar Input type      | :struct:`ScalarAggregateOptions` |       |
 +--------------------+---------+------------------+------------------------+----------------------------------+-------+
-| min_max            | Unary   | Non-nested types | Scalar Struct          | :struct:`ScalarAggregateOptions` | \(5)  |
+| min_max            | Unary   | Non-nested types | Scalar Struct          | :struct:`ScalarAggregateOptions` | \(6)  |
 +--------------------+---------+------------------+------------------------+----------------------------------+-------+
-| mode               | Unary   | Numeric          | Struct                 | :struct:`ModeOptions`            | \(6)  |
+| mode               | Unary   | Numeric          | Struct                 | :struct:`ModeOptions`            | \(7)  |
 +--------------------+---------+------------------+------------------------+----------------------------------+-------+
-| product            | Unary   | Numeric          | Scalar Numeric         | :struct:`ScalarAggregateOptions` | \(7)  |
+| pivot_wider        | Binary  | Binary, Any      | Scalar Struct          | :struct:`PivotWiderOptions`      | \(8)  |
 +--------------------+---------+------------------+------------------------+----------------------------------+-------+
-| quantile           | Unary   | Numeric          | Scalar Numeric         | :struct:`QuantileOptions`        | \(8)  |
+| product            | Unary   | Numeric          | Scalar Numeric         | :struct:`ScalarAggregateOptions` | \(9)  |
 +--------------------+---------+------------------+------------------------+----------------------------------+-------+
-| stddev             | Unary   | Numeric          | Scalar Float64         | :struct:`VarianceOptions`        | \(9)  |
+| quantile           | Unary   | Numeric          | Scalar Numeric         | :struct:`QuantileOptions`        | \(10) |
 +--------------------+---------+------------------+------------------------+----------------------------------+-------+
-| sum                | Unary   | Numeric          | Scalar Numeric         | :struct:`ScalarAggregateOptions` | \(7)  |
+| stddev             | Unary   | Numeric          | Scalar Float64         | :struct:`VarianceOptions`        | \(11) |
 +--------------------+---------+------------------+------------------------+----------------------------------+-------+
-| tdigest            | Unary   | Numeric          | Float64                | :struct:`TDigestOptions`         | \(10) |
+| sum                | Unary   | Numeric          | Scalar Numeric         | :struct:`ScalarAggregateOptions` | \(9)  |
 +--------------------+---------+------------------+------------------------+----------------------------------+-------+
-| variance           | Unary   | Numeric          | Scalar Float64         | :struct:`VarianceOptions`        | \(9)  |
+| tdigest            | Unary   | Numeric          | Float64                | :struct:`TDigestOptions`         | \(12) |
++--------------------+---------+------------------+------------------------+----------------------------------+-------+
+| variance           | Unary   | Numeric          | Scalar Float64         | :struct:`VarianceOptions`        | \(11) |
 +--------------------+---------+------------------+------------------------+----------------------------------+-------+
 
 * \(1) If null values are taken into account, by setting the
@@ -252,36 +254,40 @@ the input to a single output value.
 * \(2) CountMode controls whether only non-null values are counted (the
   default), only null values are counted, or all values are counted.
 
-* \(3) Returns -1 if the value is not found. The index of a null value
+* \(3) Result is based on the ordering of input data.
+
+* \(4) Returns -1 if the value is not found. The index of a null value
   is always -1, regardless of whether there are nulls in the input.
 
-* \(4) For decimal inputs, the resulting decimal will have the same
+* \(5) For decimal inputs, the resulting decimal will have the same
   precision and scale. The result is rounded away from zero.
 
-* \(5) Output is a ``{"min": input type, "max": input type}`` Struct.
+* \(6) Output is a ``{"min": input type, "max": input type}`` Struct.
 
   Of the interval types, only the month interval is supported, as the day-time
   and month-day-nano types are not sortable.
 
-* \(6) Output is an array of ``{"mode": input type, "count": Int64}`` Struct.
+* \(7) Output is an array of ``{"mode": input type, "count": Int64}`` Struct.
   It contains the *N* most common elements in the input, in descending
   order, where *N* is given in :member:`ModeOptions::n`.
   If two values have the same count, the smallest one comes first.
   Note that the output can have less than *N* elements if the input has
   less than *N* distinct values.
 
-* \(7) Output is Int64, UInt64, Float64, or Decimal128/256, depending on the
+* \(8) The first input contains the pivot key, while the second input contains
+  the values to be pivoted. The output is a Struct with one field for each key
+  in :member:`PivotOptions::key_names`.
+
+* \(9) Output is Int64, UInt64, Float64, or Decimal128/256, depending on the
   input type.
 
-* \(8) Output is Float64 or input type, depending on QuantileOptions.
+* \(10) Output is Float64 or input type, depending on QuantileOptions.
 
-* \(9) Decimal arguments are cast to Float64 first.
+* \(11) Decimal arguments are cast to Float64 first.
 
-* \(10) tdigest/t-digest computes approximate quantiles, and so only needs a
+* \(12) tdigest/t-digest computes approximate quantiles, and so only needs a
   fixed amount of memory. See the `reference implementation
   <https://github.com/tdunning/t-digest>`_ for details.
-
-* \(11) Result is based on the ordering of input data
 
   Decimal arguments are cast to Float64 first.
 
@@ -350,11 +356,11 @@ equivalents above and reflects how they are implemented internally.
 +-------------------------+---------+------------------------------------+------------------------+----------------------------------+-----------+
 | hash_distinct           | Unary   | Any                                | List of input type     | :struct:`CountOptions`           | \(2) \(3) |
 +-------------------------+---------+------------------------------------+------------------------+----------------------------------+-----------+
-| hash_first              | Unary   | Numeric, Binary                    | Input type             | :struct:`ScalarAggregateOptions` | \(10)     |
+| hash_first              | Unary   | Numeric, Binary                    | Input type             | :struct:`ScalarAggregateOptions` | \(11)     |
 +-------------------------+---------+------------------------------------+------------------------+----------------------------------+-----------+
-| hash_first_last         | Unary   | Numeric, Binary                    | Struct                 | :struct:`ScalarAggregateOptions` | \(10)     |
+| hash_first_last         | Unary   | Numeric, Binary                    | Struct                 | :struct:`ScalarAggregateOptions` | \(11)     |
 +-------------------------+---------+------------------------------------+------------------------+----------------------------------+-----------+
-| hash_last               | Unary   | Numeric, Binary                    | Input type             | :struct:`ScalarAggregateOptions` | \(10)     |
+| hash_last               | Unary   | Numeric, Binary                    | Input type             | :struct:`ScalarAggregateOptions` | \(11)     |
 +-------------------------+---------+------------------------------------+------------------------+----------------------------------+-----------+
 | hash_list               | Unary   | Any                                | List of input type     |                                  | \(3)      |
 +-------------------------+---------+------------------------------------+------------------------+----------------------------------+-----------+
@@ -368,15 +374,17 @@ equivalents above and reflects how they are implemented internally.
 +-------------------------+---------+------------------------------------+------------------------+----------------------------------+-----------+
 | hash_one                | Unary   | Any                                | Input type             |                                  | \(6)      |
 +-------------------------+---------+------------------------------------+------------------------+----------------------------------+-----------+
-| hash_product            | Unary   | Numeric                            | Numeric                | :struct:`ScalarAggregateOptions` | \(7)      |
+| hash_pivot_wider        | Binary  | Binary, Any                        | Struct                 | :struct:`PivotWiderOptions`      | \(7)      |
 +-------------------------+---------+------------------------------------+------------------------+----------------------------------+-----------+
-| hash_stddev             | Unary   | Numeric                            | Float64                | :struct:`VarianceOptions`        | \(8)      |
+| hash_product            | Unary   | Numeric                            | Numeric                | :struct:`ScalarAggregateOptions` | \(8)      |
 +-------------------------+---------+------------------------------------+------------------------+----------------------------------+-----------+
-| hash_sum                | Unary   | Numeric                            | Numeric                | :struct:`ScalarAggregateOptions` | \(7)      |
+| hash_stddev             | Unary   | Numeric                            | Float64                | :struct:`VarianceOptions`        | \(9)      |
 +-------------------------+---------+------------------------------------+------------------------+----------------------------------+-----------+
-| hash_tdigest            | Unary   | Numeric                            | FixedSizeList[Float64] | :struct:`TDigestOptions`         | \(9)      |
+| hash_sum                | Unary   | Numeric                            | Numeric                | :struct:`ScalarAggregateOptions` | \(8)      |
 +-------------------------+---------+------------------------------------+------------------------+----------------------------------+-----------+
-| hash_variance           | Unary   | Numeric                            | Float64                | :struct:`VarianceOptions`        | \(8)      |
+| hash_tdigest            | Unary   | Numeric                            | FixedSizeList[Float64] | :struct:`TDigestOptions`         | \(10)     |
++-------------------------+---------+------------------------------------+------------------------+----------------------------------+-----------+
+| hash_variance           | Unary   | Numeric                            | Float64                | :struct:`VarianceOptions`        | \(9)      |
 +-------------------------+---------+------------------------------------+------------------------+----------------------------------+-----------+
 
 * \(1) If null values are taken into account, by setting the
@@ -405,18 +413,21 @@ equivalents above and reflects how they are implemented internally.
   one non-null value for a certain group, that value is returned, and only if
   all the values are ``null`` for the group will the function return ``null``.
 
-* \(7) Output is Int64, UInt64, Float64, or Decimal128/256, depending on the
+* \(7) The first input contains the pivot key, while the second input contains
+  the values to be pivoted. The output is a Struct with one field for each key
+  in :member:`PivotOptions::key_names`.
+
+* \(8) Output is Int64, UInt64, Float64, or Decimal128/256, depending on the
   input type.
 
-* \(8) Decimal arguments are cast to Float64 first.
+* \(9) Decimal arguments are cast to Float64 first.
 
-* \(9) T-digest computes approximate quantiles, and so only needs a
+* \(10) T-digest computes approximate quantiles, and so only needs a
   fixed amount of memory. See the `reference implementation
   <https://github.com/tdunning/t-digest>`_ for details.
 
-* \(10) Result is based on ordering of the input data.
+* \(11) Result is based on ordering of the input data.
 
-  Decimal arguments are cast to Float64 first.
 
 Element-wise ("scalar") functions
 ---------------------------------

--- a/docs/source/python/api/compute.rst
+++ b/docs/source/python/api/compute.rst
@@ -38,6 +38,7 @@ Aggregations
    min
    min_max
    mode
+   pivot_wider
    product
    quantile
    stddev
@@ -557,6 +558,7 @@ Compute Options
    PadOptions
    PairwiseOptions
    PartitionNthOptions
+   PivotWiderOptions
    QuantileOptions
    ReplaceSliceOptions
    ReplaceSubstringOptions

--- a/python/pyarrow/compute.py
+++ b/python/pyarrow/compute.py
@@ -53,6 +53,7 @@ from pyarrow._compute import (  # noqa
     PadOptions,
     PairwiseOptions,
     PartitionNthOptions,
+    PivotWiderOptions,
     QuantileOptions,
     RandomOptions,
     RankOptions,

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -2823,6 +2823,16 @@ cdef extern from "arrow/compute/api.h" namespace "arrow::compute" nogil:
         vector[CSortKey] sort_keys
         CNullPlacement null_placement
 
+    cdef enum PivotWiderUnexpectedKeyBehavior \
+            "arrow::compute::PivotWiderOptions::UnexpectedKeyBehavior":
+        PivotWiderUnexpectedKeyBehavior_Ignore "arrow::compute::PivotWiderOptions::kIgnore"
+        PivotWiderUnexpectedKeyBehavior_Raise "arrow::compute::PivotWiderOptions::kRaise"
+
+    cdef cppclass CPivotWiderOptions \
+            "arrow::compute::PivotWiderOptions"(CFunctionOptions):
+        CPivotWiderOptions(vector[c_string] key_names,
+                           PivotWiderUnexpectedKeyBehavior)
+
     cdef enum DatumType" arrow::Datum::type":
         DatumType_NONE" arrow::Datum::NONE"
         DatumType_SCALAR" arrow::Datum::SCALAR"


### PR DESCRIPTION
### Rationale for this change

Add "pivot wider" functionality such as [in Pandas](https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.pivot.html), through two dedicated functions:
1. a "pivot_wider" scalar aggregate function returning a Struct scalar
2. a "hash_pivot_wider" grouped aggregate function returning a Struct array

Both functions take two arguments (the column of pivot keys and the column of pivot values) and require passing a `PivotWiderOptions` structure with the expected pivot keys, so as to determine the output Struct type.

### Are these changes tested?

Yes, by dedicated unit tests.

### Are there any user-facing changes?

No, just new APIs.
* GitHub Issue: #45269