### PR TITLE
GH-45564: [C++][Acero] Add size validation for names and expressions vectors in ProjectNode

### DIFF
--- a/cpp/src/arrow/acero/plan_test.cc
+++ b/cpp/src/arrow/acero/plan_test.cc
@@ -1264,20 +1264,17 @@ TEST(ExecPlanExecution, SourceFilterProjectGroupedSumFilter) {
 }
 
 TEST(ExecPlanExecution, TestNamesSizeMismatch) {
+  auto input = MakeGroupableBatches();
 
-    auto input = MakeGroupableBatches();
+  Declaration plan = Declaration::Sequence(
+      {{"source", SourceNodeOptions{input.schema, input.gen(true, /*slow=*/false)}},
+       {"project", ProjectNodeOptions{{field_ref("str"),
+                                       call("multiply", {field_ref("i32"), literal(2)})},
+                                      {"a"}}}});  // expected 2 names but only 1 provided
 
-    Declaration plan = Declaration::Sequence(
-        {{"source", SourceNodeOptions{input.schema, input.gen(true, /*slow=*/false)}},
-         {"project",
-          ProjectNodeOptions{
-              {field_ref("str"), call("multiply", {field_ref("i32"), literal(2)})},
-              {"a"}}}}); // expected 2 names but only 1 provided
-
-    EXPECT_RAISES_WITH_MESSAGE_THAT(
-        Invalid, ::testing::HasSubstr("Check failed: (names.size()) == (exprs.size())"),
-        DeclarationToTable(std::move(plan)));
-  
+  EXPECT_RAISES_WITH_MESSAGE_THAT(
+      Invalid, ::testing::HasSubstr("Check failed: (names.size()) == (exprs.size())"),
+      DeclarationToTable(std::move(plan)));
 }
 
 TEST(ExecPlanExecution, SourceFilterProjectGroupedSumOrderBy) {

--- a/cpp/src/arrow/acero/plan_test.cc
+++ b/cpp/src/arrow/acero/plan_test.cc
@@ -1263,6 +1263,23 @@ TEST(ExecPlanExecution, SourceFilterProjectGroupedSumFilter) {
   }
 }
 
+TEST(ExecPlanExecution, TestNamesSizeMismatch) {
+
+    auto input = MakeGroupableBatches();
+
+    Declaration plan = Declaration::Sequence(
+        {{"source", SourceNodeOptions{input.schema, input.gen(true, /*slow=*/false)}},
+         {"project",
+          ProjectNodeOptions{
+              {field_ref("str"), call("multiply", {field_ref("i32"), literal(2)})},
+              {"a"}}}}); // expected 2 names but only 1 provided
+
+    EXPECT_RAISES_WITH_MESSAGE_THAT(
+        Invalid, ::testing::HasSubstr("Check failed: (names.size()) == (exprs.size())"),
+        DeclarationToTable(std::move(plan)));
+  
+}
+
 TEST(ExecPlanExecution, SourceFilterProjectGroupedSumOrderBy) {
   for (bool parallel : {false, true}) {
     SCOPED_TRACE(parallel ? "parallel/merged" : "serial");

--- a/cpp/src/arrow/acero/plan_test.cc
+++ b/cpp/src/arrow/acero/plan_test.cc
@@ -1263,17 +1263,20 @@ TEST(ExecPlanExecution, SourceFilterProjectGroupedSumFilter) {
   }
 }
 
-TEST(ExecPlanExecution, TestNamesSizeMismatch) {
+TEST(ExecPlanExecution, ProjectNamesSizeMismatch) {
   auto input = MakeGroupableBatches();
 
   Declaration plan = Declaration::Sequence(
       {{"source", SourceNodeOptions{input.schema, input.gen(true, /*slow=*/false)}},
-       {"project", ProjectNodeOptions{{field_ref("str"),
-                                       call("multiply", {field_ref("i32"), literal(2)})},
-                                      {"a"}}}});  // expected 2 names but only 1 provided
+       {"project", ProjectNodeOptions{
+                       /*expressions=*/{field_ref("str"),
+                                        call("multiply", {field_ref("i32"), literal(2)})},
+                       /*names=*/{"a"}}}});  // expected 2 names but only 1 provided
 
   EXPECT_RAISES_WITH_MESSAGE_THAT(
-      Invalid, ::testing::HasSubstr("Check failed: (names.size()) == (exprs.size())"),
+      Invalid,
+      ::testing::HasSubstr(
+          "Project node's size of names 1 doesn't match size of expressions 2"),
       DeclarationToTable(std::move(plan)));
 }
 

--- a/cpp/src/arrow/acero/project_node.cc
+++ b/cpp/src/arrow/acero/project_node.cc
@@ -59,8 +59,10 @@ class ProjectNode : public MapNode {
       for (size_t i = 0; i < exprs.size(); ++i) {
         names[i] = exprs[i].ToString();
       }
+    } else {
+      ARROW_RETURN_IF(names.size() != exprs.size(),
+                      Status::Invalid("Check failed: (names.size()) == (exprs.size())"));
     }
-
     FieldVector fields(exprs.size());
     int i = 0;
     for (auto& expr : exprs) {

--- a/cpp/src/arrow/acero/project_node.cc
+++ b/cpp/src/arrow/acero/project_node.cc
@@ -60,8 +60,11 @@ class ProjectNode : public MapNode {
         names[i] = exprs[i].ToString();
       }
     } else {
-      ARROW_RETURN_IF(names.size() != exprs.size(),
-                      Status::Invalid("Check failed: (names.size()) == (exprs.size())"));
+      ARROW_RETURN_IF(
+          names.size() != exprs.size(),
+          Status::Invalid("Project node's size of names " + std::to_string(names.size()) +
+                          " doesn't match size of expressions " +
+                          std::to_string(exprs.size())));
     }
     FieldVector fields(exprs.size());
     int i = 0;


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

-->



### What changes are included in this PR?
Added a check to validate that the sizes of the names and expressions vectors match in the ProjectNode class
<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

### Are these changes tested?
Yes
<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

### Are there any user-facing changes?
No
<!--
If there are user-facing changes then we may require documentation to be updated before approving the PR.
-->

<!--
If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
-->
<!-- **This PR includes breaking changes to public APIs.** -->

<!--
Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
-->
<!-- **This PR contains a "Critical Fix".** -->
* GitHub Issue: #45564