### PR TITLE
GH-45572: [C++][Compute] Add rank_normal function

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -2257,5 +2257,36 @@ SOFTWARE.
 java/vector/src/main/java/org/apache/arrow/vector/util/IntObjectHashMap.java
 java/vector/src/main/java/org/apache/arrow/vector/util/IntObjectMap.java
 
-These file are derived from code from Netty, which is made available under the
+These files are derived from code from Netty, which is made available under the
 Apache License 2.0.
+
+--------------------------------------------------------------------------------
+cpp/src/arrow/util/math_internal.cc (some portions)
+
+Some portions of this file are derived from
+
+https://github.com/ankane/dist-rust/
+
+which is made available under the MIT license
+
+The MIT License (MIT)
+
+Copyright (c) 2021-2023 Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -529,6 +529,7 @@ set(ARROW_UTIL_SRCS
     util/logger.cc
     util/logging.cc
     util/key_value_metadata.cc
+    util/math_internal.cc
     util/memory.cc
     util/mutex.cc
     util/ree_util.cc

--- a/cpp/src/arrow/util/CMakeLists.txt
+++ b/cpp/src/arrow/util/CMakeLists.txt
@@ -66,6 +66,7 @@ add_arrow_test(utility-test
                list_util_test.cc
                logger_test.cc
                logging_test.cc
+               math_test.cc
                queue_test.cc
                range_test.cc
                ree_util_test.cc

--- a/cpp/src/arrow/util/math_internal.cc
+++ b/cpp/src/arrow/util/math_internal.cc
@@ -1,0 +1,130 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/util/math_internal.h"
+
+#include <cmath>
+
+#include "arrow/util/logging.h"
+
+namespace arrow::internal {
+
+double NormalPPF(double p) {
+  DCHECK(p >= 0.0 && p <= 1.0);
+  if (p == 0.0) {
+    return -HUGE_VAL;
+  }
+  if (p == 1.0) {
+    return HUGE_VAL;
+  }
+
+  // Algorithm from https://doi.org/10.2307/2347330
+  // Wichura, M. J. (1988).
+  // Algorithm AS 241: The Percentage Points of the Normal Distribution.
+  // Journal of the Royal Statistical Society. Series C (Applied Statistics),
+  // 37(3), 477-484.
+  //
+  // Copied from the Rust implementation at https://github.com/ankane/dist-rust/
+  double q = p - 0.5;
+  if (std::abs(q) < 0.425) {
+    double r = 0.180625 - q * q;
+    return q *
+           (((((((2.5090809287301226727e3 * r + 3.3430575583588128105e4) * r +
+                 6.7265770927008700853e4) *
+                    r +
+                4.5921953931549871457e4) *
+                   r +
+               1.3731693765509461125e4) *
+                  r +
+              1.9715909503065514427e3) *
+                 r +
+             1.3314166789178437745e2) *
+                r +
+            3.3871328727963666080e0) /
+           (((((((5.2264952788528545610e3 * r + 2.8729085735721942674e4) * r +
+                 3.9307895800092710610e4) *
+                    r +
+                2.1213794301586595867e4) *
+                   r +
+               5.3941960214247511077e3) *
+                  r +
+              6.8718700749205790830e2) *
+                 r +
+             4.2313330701600911252e1) *
+                r +
+            1.0);
+  } else {
+    double r = q < 0.0 ? p : 1.0 - p;
+    r = std::sqrt(-std::log(r));
+    if (r < 5.0) {
+      r -= 1.6;
+      r = (((((((7.74545014278341407640e-4 * r + 2.27238449892691845833e-2) * r +
+                2.41780725177450611770e-1) *
+                   r +
+               1.27045825245236838258e0) *
+                  r +
+              3.64784832476320460504e0) *
+                 r +
+             5.76949722146069140550e0) *
+                r +
+            4.63033784615654529590e0) *
+               r +
+           1.42343711074968357734e0) /
+          (((((((1.05075007164441684324e-9 * r + 5.47593808499534494600e-4) * r +
+                1.51986665636164571966e-2) *
+                   r +
+               1.48103976427480074590e-1) *
+                  r +
+              6.89767334985100004550e-1) *
+                 r +
+             1.67638483018380384940e0) *
+                r +
+            2.05319162663775882187e0) *
+               r +
+           1.0);
+    } else {
+      r -= 5.0;
+      r = (((((((2.01033439929228813265e-7 * r + 2.71155556874348757815e-5) * r +
+                1.24266094738807843860e-3) *
+                   r +
+               2.65321895265761230930e-2) *
+                  r +
+              2.96560571828504891230e-1) *
+                 r +
+             1.78482653991729133580e0) *
+                r +
+            5.46378491116411436990e0) *
+               r +
+           6.65790464350110377720e0) /
+          (((((((2.04426310338993978564e-15 * r + 1.42151175831644588870e-7) * r +
+                1.84631831751005468180e-5) *
+                   r +
+               7.86869131145613259100e-4) *
+                  r +
+              1.48753612908506148525e-2) *
+                 r +
+             1.36929880922735805310e-1) *
+                r +
+            5.99832206555887937690e-1) *
+               r +
+           1.0);
+    }
+    return std::copysign(r, q);
+  }
+}
+
+}  // namespace arrow::internal

--- a/cpp/src/arrow/util/math_internal.h
+++ b/cpp/src/arrow/util/math_internal.h
@@ -1,0 +1,36 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include "arrow/util/macros.h"
+#include "arrow/util/visibility.h"
+
+namespace arrow::internal {
+
+/// \brief Percent-point / quantile function (PPF) of the normal distribution.
+///
+/// Given p in [0, 1], return the corresponding quantile value in the normal
+/// distribution. This is the reciprocal of the cumulative distribution function.
+///
+/// If p is not in [0, 1], behavior is undefined.
+///
+/// This function is sometimes also called the probit function.
+ARROW_EXPORT
+double NormalPPF(double p);
+
+}  // namespace arrow::internal

--- a/cpp/src/arrow/util/math_test.cc
+++ b/cpp/src/arrow/util/math_test.cc
@@ -1,0 +1,82 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <cmath>
+
+#include <gtest/gtest.h>
+
+#include "arrow/testing/gtest_util.h"
+#include "arrow/util/math_internal.h"
+
+namespace arrow::internal {
+
+TEST(NormalPPF, Basics) {
+  struct PPFTestCase {
+    double input;
+    double expected;
+  };
+  // Test vectors obtained using Scipy's norm.ppf
+  std::vector<PPFTestCase> cases = {
+      {0.0, -HUGE_VAL},
+      {0.001, -3.090232306167813},
+      {0.01, -2.3263478740408408},
+      {0.02, -2.053748910631823},
+      {0.03, -1.880793608151251},
+      {0.04, -1.75068607125217},
+      {0.05, -1.6448536269514729},
+      {0.06, -1.5547735945968535},
+      {0.07, -1.4757910281791706},
+      {0.08, -1.4050715603096329},
+      {0.09, -1.3407550336902165},
+      {0.1, -1.2815515655446004},
+      {0.2, -0.8416212335729142},
+      {0.3, -0.5244005127080409},
+      {0.4, -0.2533471031357997},
+      {0.5, 0.0},
+      {0.6, 0.2533471031357997},
+      {0.7, 0.5244005127080407},
+      {0.8, 0.8416212335729143},
+      {0.9, 1.2815515655446004},
+      {0.91, 1.3407550336902165},
+      {0.92, 1.4050715603096329},
+      {0.93, 1.475791028179171},
+      {0.94, 1.5547735945968535},
+      {0.95, 1.6448536269514722},
+      {0.96, 1.7506860712521692},
+      {0.97, 1.8807936081512509},
+      {0.98, 2.0537489106318225},
+      {0.99, 2.3263478740408408},
+      {0.999, 3.090232306167813},
+      {1.0, HUGE_VAL},
+  };
+  for (auto test_case : cases) {
+    ARROW_SCOPED_TRACE("p = ", test_case.input);
+    EXPECT_DOUBLE_EQ(NormalPPF(test_case.input), test_case.expected);
+  }
+  // Test vectors from https://doi.org/10.2307/2347330
+  cases = {
+      {0.25, -0.6744897501960817},
+      {0.001, -3.090232306167814},
+      {1e-20, -9.262340089798408},
+  };
+  for (auto test_case : cases) {
+    ARROW_SCOPED_TRACE("p = ", test_case.input);
+    EXPECT_DOUBLE_EQ(NormalPPF(test_case.input), test_case.expected);
+  }
+}
+
+}  // namespace arrow::internal

--- a/docs/source/cpp/compute.rst
+++ b/docs/source/cpp/compute.rst
@@ -1805,6 +1805,8 @@ in the respective option classes.
 +-----------------------+------------+---------------------------------------------------------+-------------------+-------------------------------+----------------+
 | rank                  | Unary      | Boolean, Numeric, Temporal, Binary- and String-like     | UInt64            | :struct:`RankOptions`         | \(4)           |
 +-----------------------+------------+---------------------------------------------------------+-------------------+-------------------------------+----------------+
+| rank_normal           | Unary      | Boolean, Numeric, Temporal, Binary- and String-like     | Float64           | :struct:`RankQuantileOptions` | \(5)           |
++-----------------------+------------+---------------------------------------------------------+-------------------+-------------------------------+----------------+
 | rank_quantile         | Unary      | Boolean, Numeric, Temporal, Binary- and String-like     | Float64           | :struct:`RankQuantileOptions` | \(5)           |
 +-----------------------+------------+---------------------------------------------------------+-------------------+-------------------------------+----------------+
 | select_k_unstable     | Unary      | Boolean, Numeric, Temporal, Binary- and String-like     | UInt64            | :struct:`SelectKOptions`      | \(6) \(7)      |
@@ -1827,7 +1829,10 @@ in the respective option classes.
 
 * \(4) The output is a one-based numerical array of ranks.
 
-* \(5) The output is an array of quantiles strictly between 0 and 1.
+* \(5) The output of ``rank_quantile`` is an array of quantiles strictly between
+  0 and 1. The ouput of ``rank_normal`` is an array of finite real values
+  corresponding to points in the normal distribution that reflect the input's
+  quantile ranks.
 
 * \(6) The input can be an array, chunked array, record batch or
   table. If the input is a record batch or table, one or more sort

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -3392,6 +3392,30 @@ def test_rank_quantile_options():
         pc.rank_quantile(arr, sort_keys="XXX")
 
 
+def test_rank_normal_options():
+    arr = pa.array([None, 1, None, 2, None])
+
+    expected = pytest.approx(
+        [0.5244005127080407, -1.2815515655446004, 0.5244005127080407,
+         -0.5244005127080409, 0.5244005127080407])
+    result = pc.rank_normal(arr)
+    assert result.to_pylist() == expected
+    result = pc.rank_normal(arr, null_placement="at_end", sort_keys="ascending")
+    assert result.to_pylist() == expected
+    result = pc.rank_normal(arr, options=pc.RankQuantileOptions())
+    assert result.to_pylist() == expected
+
+    expected = pytest.approx(
+        [-0.5244005127080409, 1.2815515655446004, -0.5244005127080409,
+         0.5244005127080407, -0.5244005127080409])
+    result = pc.rank_normal(arr, null_placement="at_start", sort_keys="descending")
+    assert result.to_pylist() == expected
+    result = pc.rank_normal(arr,
+                            options=pc.RankQuantileOptions(null_placement="at_start",
+                                                           sort_keys="descending"))
+    assert result.to_pylist() == expected
+
+
 def create_sample_expressions():
     # We need a schema for substrait conversion
     schema = pa.schema([pa.field("i64", pa.int64()), pa.field(


### PR DESCRIPTION
### Rationale for this change

Computing ranks as values of the "probit" function (https://en.wikipedia.org/wiki/Probit), rather than quantiles between 0 and 1, can be useful for machine learning and other tasks.

### What changes are included in this PR?

Add a "rank_normal" function that computes array ranks as points on the normal distribution.

It is similar to calling the "rank_quantile" function and then applying the normal percent-point function ("probit").

### Are these changes tested?

Yes, by dedicated unit tests.

### Are there any user-facing changes?

No, except a new compute function.
* GitHub Issue: #45572