### PR TITLE
GH-45578: [C++] Use max not min in MakeStatisticsArrayMaxApproximate test

### DIFF
--- a/cpp/src/arrow/record_batch_test.cc
+++ b/cpp/src/arrow/record_batch_test.cc
@@ -1398,7 +1398,7 @@ TEST_F(TestRecordBatch, MakeStatisticsArrayMaxApproximate) {
   auto no_statistics_array = ArrayFromJSON(boolean(), "[true, false, true]");
   auto float64_array_data = ArrayFromJSON(float64(), "[1.0, null, -1.0]")->data()->Copy();
   float64_array_data->statistics = std::make_shared<ArrayStatistics>();
-  float64_array_data->statistics->min = -1.0;
+  float64_array_data->statistics->max = 1.0;
   auto float64_array = MakeArray(std::move(float64_array_data));
   auto batch = RecordBatch::Make(schema, float64_array->length(),
                                  {no_statistics_array, float64_array});
@@ -1412,13 +1412,13 @@ TEST_F(TestRecordBatch, MakeStatisticsArrayMaxApproximate) {
                                ARROW_STATISTICS_KEY_ROW_COUNT_EXACT,
                            },
                            {
-                               ARROW_STATISTICS_KEY_MIN_VALUE_APPROXIMATE,
+                               ARROW_STATISTICS_KEY_MAX_VALUE_APPROXIMATE,
                            }},
                           {{
                                ArrayStatistics::ValueType{int64_t{3}},
                            },
                            {
-                               ArrayStatistics::ValueType{-1.0},
+                               ArrayStatistics::ValueType{1.0},
                            }}));
   AssertArraysEqual(*expected_statistics_array, *statistics_array, true);
 }


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

The test was written for min instead of max.

### What changes are included in this PR?

Use max not min for MaxApproximate test case.

### Are these changes tested?

Yes, by dedicated unit tests.

### Are there any user-facing changes?
No
* GitHub Issue: #45578