### PR TITLE
GH-45576: [Python] Support building C++ library automatically

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -127,6 +127,8 @@ class build_ext(_build_ext):
     description = "Build the C-extensions for arrow"
     user_options = ([('cmake-generator=', None, 'CMake generator'),
                      ('extra-cmake-args=', None, 'extra arguments for CMake'),
+                     ('extra-cpp-cmake-args=', None,
+                      'extra arguments for arrow-cpp CMake'),
                      ('build-type=', None,
                       'build type (debug or release), default release'),
                      ('boost-namespace=', None,
@@ -169,6 +171,7 @@ class build_ext(_build_ext):
         if not self.cmake_generator and sys.platform == 'win32':
             self.cmake_generator = 'Visual Studio 15 2017 Win64'
         self.extra_cmake_args = os.environ.get('PYARROW_CMAKE_OPTIONS', '')
+        self.extra_cpp_cmake_args = os.environ.get('ARROW_CMAKE_OPTIONS', '')
         self.build_type = os.environ.get('PYARROW_BUILD_TYPE',
                                          'release').lower()
 
@@ -322,6 +325,8 @@ class build_ext(_build_ext):
                     f'-DCMAKE_INSTALL_PREFIX={cpp_install}',
                 ]
 
+                extra_cpp_cmake_args = shlex.split(self.extra_cpp_cmake_args)
+
                 append_cmake_component(self.with_cuda, 'ARROW_CUDA')
                 append_cmake_component(self.with_substrait, 'ARROW_SUBSTRAIT')
                 append_cmake_component(self.with_flight, 'ARROW_FLIGHT')
@@ -341,11 +346,11 @@ class build_ext(_build_ext):
                     # Generate the build files
                     if is_emscripten:
                         print("-- Running emcmake cmake for Arrow on Emscripten")
-                        self.spawn(['emcmake', 'cmake'] + extra_cmake_args +
+                        self.spawn(['emcmake', 'cmake'] + extra_cpp_cmake_args +
                                    cmake_options + [cpp_source])
                     else:
                         print("-- Running cmake for Arrow")
-                        self.spawn(['cmake'] + extra_cmake_args + cmake_options + [cpp_source])
+                        self.spawn(['cmake'] + extra_cpp_cmake_args + cmake_options + [cpp_source])
 
                     print("-- Finished cmake for Arrow")
 


### PR DESCRIPTION
### What changes are included in this PR?

Add a `PYARROW_BUILD_ARROW_CPP` environment variable and a corresponding `--build-arrow-cpp` option that enables automatically building the Arrow C++ libraries as part of `setup.py` invocation and using them to build PyArrow afterwards.  This is a prototype / proof-of-concept.

### Are these changes tested?

This change introduces an additional build path. I've tested it locally.

### Are there any user-facing changes?

It introduces a new option, primarily aimed at downstream packagers — though I suppose some users building from source may also want to use it. If the approach is sound, updating https://arrow.apache.org/docs/developers/python.html#build-and-test may make sense.
* GitHub Issue: #45576