### PR TITLE
GH-45582: [Python] Preserve decimal32/64/256 metadata in Schema.metadata

### DIFF
--- a/python/pyarrow/pandas_compat.py
+++ b/python/pyarrow/pandas_compat.py
@@ -84,7 +84,7 @@ def get_logical_type(arrow_type):
             return 'list[{}]'.format(get_logical_type(arrow_type.value_type))
         elif isinstance(arrow_type, pa.lib.TimestampType):
             return 'datetimetz' if arrow_type.tz is not None else 'datetime'
-        elif isinstance(arrow_type, pa.lib.Decimal128Type):
+        elif pa.types.is_decimal(arrow_type):
             return 'decimal'
         return 'object'
 

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -598,6 +598,20 @@ class TestConvertMetadata:
         assert data_column['numpy_type'] == 'object'
         assert data_column['metadata'] == {'precision': 26, 'scale': 11}
 
+    @pytest.mark.parametrize('typ', [
+        pa.decimal32,
+        pa.decimal64,
+        pa.decimal128,
+        pa.decimal256,
+    ])
+    def test_decimal_other_bitwidts(self, typ):
+        df = pd.DataFrame({'a': [decimal.Decimal('3.14')]})
+        schema = pa.schema([pa.field('a', type=typ(4, 2))])
+        table = pa.Table.from_pandas(df, schema=schema)
+        col_meta = table.schema.pandas_metadata['columns'][0]
+        assert col_meta['pandas_type'] == 'decimal'
+        assert col_meta['metadata'] == {'precision': 4, 'scale': 2}
+
     def test_table_column_subset_metadata(self):
         # ARROW-1883
         # non-default index


### PR DESCRIPTION
### Rationale for this change

Before, these types would be interpreted as `"object"` type and therefore the `precision` and `scale` attributes of these types would not be preserved in the `"metadata"`

### What changes are included in this PR?

Uses `pa.types.is_decimal` is instead of `isinstance`ing just the `Decimal128Type` to determine a `"decimal"` pandas type

### Are these changes tested?

Yes

### Are there any user-facing changes?

Yes, but should not break compatibility.

* GitHub Issue: #45582