### PR TITLE
GH-45587: [C++][Docs] Fix the statistics schema link in `arrow::RecordBatch::MakeStatisticsArray()`'s docstring

### DIFF
--- a/cpp/src/arrow/record_batch.h
+++ b/cpp/src/arrow/record_batch.h
@@ -286,7 +286,7 @@ class ARROW_EXPORT RecordBatch {
   ///
   /// The created array follows the C data interface statistics
   /// specification. See
-  /// https://arrow.apache.org/docs/format/CDataInterfaceStatistics.html
+  /// https://arrow.apache.org/docs/format/StatisticsSchema.html
   /// for details.
   ///
   /// \param[in] pool the memory pool to allocate memory from


### PR DESCRIPTION
### Rationale for this change

`arrow::RecordBatch::MakeStatisticsArray()`'s docstring uses https://arrow.apache.org/docs/format/CDataInterfaceStatistics.html not https://arrow.apache.org/docs/format/StatisticsSchema.html for statistics schema URL.

Because https://github.com/apache/arrow/pull/44252 assumed that we use https://github.com/apache/arrow/pull/43553 but we use https://github.com/apache/arrow/pull/45058 finally.

### What changes are included in this PR?

Fix URL.

### Are these changes tested?
It does not need since just a correction in document

### Are there any user-facing changes?
No, Just a correction in document
* GitHub Issue: #45587