### PR TITLE
GH-43135: [R] Change the binary type mapping to `blob::blob`

### DIFF
--- a/r/R/metadata.R
+++ b/r/R/metadata.R
@@ -245,14 +245,14 @@ remove_attributes <- function(x) {
     removed_attributes <- c("row.names", "names")
   } else if (inherits(x, "factor")) {
     removed_attributes <- c("class", "levels")
-  } else if (inherits(x, c("integer64", "Date", "arrow_binary", "arrow_large_binary"))) {
-    removed_attributes <- c("class")
   } else if (inherits(x, "arrow_fixed_size_binary")) {
     removed_attributes <- c("class", "byte_width")
   } else if (inherits(x, "POSIXct")) {
     removed_attributes <- c("class", "tzone")
   } else if (inherits(x, "hms") || inherits(x, "difftime")) {
     removed_attributes <- c("class", "units")
+  } else if (inherits(x, c("integer64", "Date", "blob", "arrow_binary", "arrow_large_binary"))) {
+    removed_attributes <- c("class")
   }
   removed_attributes
 }

--- a/r/src/arrow_types.h
+++ b/r/src/arrow_types.h
@@ -151,8 +151,8 @@ static inline bool can_convert_native(SEXP x) {
     return Rf_inherits(x, "factor") || Rf_inherits(x, "Date") ||
            Rf_inherits(x, "integer64") || Rf_inherits(x, "POSIXct") ||
            Rf_inherits(x, "hms") || Rf_inherits(x, "difftime") ||
-           Rf_inherits(x, "data.frame") || Rf_inherits(x, "arrow_binary") ||
-           Rf_inherits(x, "arrow_large_binary") ||
+           Rf_inherits(x, "data.frame") || Rf_inherits(x, "blob") ||
+           Rf_inherits(x, "arrow_binary") || Rf_inherits(x, "arrow_large_binary") ||
            Rf_inherits(x, "arrow_fixed_size_binary") ||
            Rf_inherits(x, "vctrs_unspecified") || Rf_inherits(x, "AsIs");
   }

--- a/r/src/r_to_arrow.cpp
+++ b/r/src/r_to_arrow.cpp
@@ -123,7 +123,7 @@ RVectorType GetVectorType(SEXP x) {
         return POSIXLT;
       }
 
-      if (Rf_inherits(x, "arrow_binary")) {
+      if (Rf_inherits(x, "arrow_binary") || Rf_inherits(x, "blob")) {
         return BINARY;
       }
 

--- a/r/src/symbols.cpp
+++ b/r/src/symbols.cpp
@@ -59,12 +59,12 @@ SEXP data::classes_vctrs_list_of =
 SEXP data::classes_tbl_df =
     precious(cpp11::writable::strings({"tbl_df", "tbl", "data.frame"}));
 
-SEXP data::classes_arrow_binary =
-    precious(cpp11::writable::strings({"arrow_binary", "vctrs_vctr", "list"}));
-SEXP data::classes_arrow_large_binary =
-    precious(cpp11::writable::strings({"arrow_large_binary", "vctrs_vctr", "list"}));
-SEXP data::classes_arrow_fixed_size_binary =
-    precious(cpp11::writable::strings({"arrow_fixed_size_binary", "vctrs_vctr", "list"}));
+SEXP data::classes_arrow_binary = precious(cpp11::writable::strings(
+    {"arrow_binary", "blob", "vctrs_list_of", "vctrs_vctr", "list"}));
+SEXP data::classes_arrow_large_binary = precious(cpp11::writable::strings(
+    {"arrow_large_binary", "blob", "vctrs_list_of", "vctrs_vctr", "list"}));
+SEXP data::classes_arrow_fixed_size_binary = precious(cpp11::writable::strings(
+    {"arrow_fixed_size_binary", "blob", "vctrs_list_of", "vctrs_vctr", "list"}));
 SEXP data::classes_factor = precious(cpp11::writable::strings({"factor"}));
 SEXP data::classes_ordered = precious(cpp11::writable::strings({"ordered", "factor"}));
 

--- a/r/src/type_infer.cpp
+++ b/r/src/type_infer.cpp
@@ -150,12 +150,12 @@ std::shared_ptr<arrow::DataType> InferArrowTypeFromVector<VECSXP>(SEXP x) {
       return arrow::fixed_size_binary(INTEGER(byte_width)[0]);
     }
 
-    if (Rf_inherits(x, "arrow_binary")) {
-      return arrow::binary();
-    }
-
     if (Rf_inherits(x, "arrow_large_binary")) {
       return arrow::large_binary();
+    }
+
+    if (Rf_inherits(x, "arrow_binary") || Rf_inherits(x, "blob")) {
+      return arrow::binary();
     }
 
     // Check attr(x, "ptype") for an appropriate R prototype

--- a/r/tests/testthat/test-Array.R
+++ b/r/tests/testthat/test-Array.R
@@ -800,7 +800,7 @@ test_that("arrow_array() handles vector -> fixed size list arrays", {
 })
 
 test_that("Handling string data with embedded nuls", {
-  raws <- structure(
+  raws <- blob::as_blob(
     list(
       as.raw(c(0x70, 0x65, 0x72, 0x73, 0x6f, 0x6e)),
       as.raw(c(0x77, 0x6f, 0x6d, 0x61, 0x6e)),
@@ -808,8 +808,7 @@ test_that("Handling string data with embedded nuls", {
       as.raw(c(0x66, 0x00, 0x00, 0x61, 0x00, 0x6e)), # multiple nuls
       as.raw(c(0x63, 0x61, 0x6d, 0x65, 0x72, 0x61)),
       as.raw(c(0x74, 0x76))
-    ),
-    class = c("arrow_binary", "vctrs_vctr", "list")
+    )
   )
   expect_error(
     rawToChar(raws[[3]]),

--- a/r/tests/testthat/test-RecordBatch.R
+++ b/r/tests/testthat/test-RecordBatch.R
@@ -606,15 +606,13 @@ test_that("RecordBatch supports cbind", {
 })
 
 test_that("Handling string data with embedded nuls", {
-  raws <- Array$create(structure(list(
+  raws <- Array$create(blob::as_blob(list(
     as.raw(c(0x70, 0x65, 0x72, 0x73, 0x6f, 0x6e)),
     as.raw(c(0x77, 0x6f, 0x6d, 0x61, 0x6e)),
     as.raw(c(0x6d, 0x61, 0x00, 0x6e)), # <-- there's your nul, 0x00
     as.raw(c(0x63, 0x61, 0x6d, 0x65, 0x72, 0x61)),
     as.raw(c(0x74, 0x76))
-  ),
-  class = c("arrow_binary", "vctrs_vctr", "list")
-  ))
+  )))
   batch_with_nul <- record_batch(a = 1:5, b = raws)
   batch_with_nul$b <- batch_with_nul$b$cast(utf8())
 

--- a/r/tests/testthat/test-chunked-array.R
+++ b/r/tests/testthat/test-chunked-array.R
@@ -463,16 +463,14 @@ test_that("Converting a chunked array unifies factors (ARROW-8374)", {
 })
 
 test_that("Handling string data with embedded nuls", {
-  raws <- structure(list(
+  raws <- blob::as_blob(list(
     as.raw(c(0x70, 0x65, 0x72, 0x73, 0x6f, 0x6e)),
     as.raw(c(0x77, 0x6f, 0x6d, 0x61, 0x6e)),
     as.raw(c(0x6d, 0x61, 0x00, 0x6e)), # <-- there's your nul, 0x00
     as.raw(c(0x66, 0x00, 0x00, 0x61, 0x00, 0x6e)), # multiple nuls
     as.raw(c(0x63, 0x61, 0x6d, 0x65, 0x72, 0x61)),
     as.raw(c(0x74, 0x76))
-  ),
-  class = c("arrow_binary", "vctrs_vctr", "list")
-  )
+  ))
   chunked_array_with_nul <- ChunkedArray$create(raws)$cast(utf8())
 
   v <- expect_error(as.vector(chunked_array_with_nul), NA)


### PR DESCRIPTION
### Rationale for this change

Many packages, including `nanoarrow`, use the `blob` class provided by the `blob` package to represent a vector of binary data.
However, this package did not use `blob`.
Therefore, when this package convert Arrow Binary type to R, it was difficult for other packages to interpret it as a Binary type.

### What changes are included in this PR?

The current special processing for the `arrow_binary` class should also be performed for the `blob` class.
Also, `arrow_binary`, `arrow_large_binary`, and `arrow_fixed_size_binary` will be changed to subclasses of the `blob` class.

### Are these changes tested?

Rewrote some existing tests to use `blob` instead of `arrow_binary`.

### Are there any user-facing changes?

Yes.

But the traditional classes have been changed to subclasses of `blob`, so little impact is expected.
* GitHub Issue: #43135