### PR TITLE
GH-45589: [C++] Enable singular test in Meson configuration

### DIFF
--- a/ci/scripts/cpp_build.sh
+++ b/ci/scripts/cpp_build.sh
@@ -110,10 +110,18 @@ if [ "${ARROW_OFFLINE}" = "ON" ]; then
 fi
 
 if [ "${ARROW_USE_MESON:-OFF}" = "ON" ]; then
+  function meson_boolean() {
+    if [ "${1}" = "ON" ]; then
+      echo "true"
+    else
+      echo "false"
+    fi
+  }
+
   meson setup \
     --prefix=${MESON_PREFIX:-${ARROW_HOME}} \
     --buildtype=${ARROW_BUILD_TYPE:-debug} \
-    -Dtests=true \
+    -Dtests=$(meson_boolean ${ARROW_BUILD_TESTS:-OFF}) \
     . \
     ${source_dir}
 elif [ "${ARROW_EMSCRIPTEN:-OFF}" = "ON" ]; then

--- a/ci/scripts/cpp_build.sh
+++ b/ci/scripts/cpp_build.sh
@@ -113,6 +113,7 @@ if [ "${ARROW_USE_MESON:-OFF}" = "ON" ]; then
   meson setup \
     --prefix=${MESON_PREFIX:-${ARROW_HOME}} \
     --buildtype=${ARROW_BUILD_TYPE:-debug} \
+    -Dtests=true \
     . \
     ${source_dir}
 elif [ "${ARROW_EMSCRIPTEN:-OFF}" = "ON" ]; then

--- a/cpp/.gitignore
+++ b/cpp/.gitignore
@@ -46,6 +46,6 @@ cmake-build-*/
 
 # meson subprojects - wrap files need to be kept to let meson download
 # dependencies as needed, but dependencies themselves should not be versioned
-subprojects/*
-!subprojects/packagefiles
-!subprojects/*.wrap
+/subprojects/*
+!/subprojects/packagefiles
+!/subprojects/*.wrap

--- a/cpp/meson.build
+++ b/cpp/meson.build
@@ -56,4 +56,10 @@ if git_description == ''
     git_description = run_command('git', 'describe', '--tags', check: false).stdout().strip()
 endif
 
+needs_integration = false
+needs_tests = get_option('tests')
+needs_ipc = get_option('ipc') or needs_tests
+needs_testing = get_option('testing') or needs_tests
+needs_json = get_option('json') or needs_testing
+
 subdir('src/arrow')

--- a/cpp/meson.options
+++ b/cpp/meson.options
@@ -16,6 +16,20 @@
 # under the License.
 
 option(
+    'ipc',
+    type: 'boolean',
+    description: 'Build the Arrow IPC extensions',
+    value: false,
+)
+
+option(
+    'json',
+    type: 'boolean',
+    description: 'Build Arrow with JSON support',
+    value: false,    
+)
+
+option(
     'git_id',
     type: 'string',
 )
@@ -29,4 +43,18 @@ option(
     'package_kind',
     type: 'string',
     description: 'Arbitrary string that identifies the kind of package (for informational purposes)',
+)
+
+option(
+    'testing',
+    type: 'boolean',
+    description: 'Build the Arrow testing libraries',
+    value: false,    
+)
+
+option(
+    'tests',
+    type: 'boolean',
+    description: 'Build the Arrow googletest unit tests',
+    value: false,    
 )

--- a/cpp/meson.options
+++ b/cpp/meson.options
@@ -26,7 +26,7 @@ option(
     'json',
     type: 'boolean',
     description: 'Build Arrow with JSON support',
-    value: false,    
+    value: false,
 )
 
 option(
@@ -49,12 +49,12 @@ option(
     'testing',
     type: 'boolean',
     description: 'Build the Arrow testing libraries',
-    value: false,    
+    value: false,
 )
 
 option(
     'tests',
     type: 'boolean',
     description: 'Build the Arrow googletest unit tests',
-    value: false,    
+    value: false,
 )

--- a/cpp/src/arrow/meson.build
+++ b/cpp/src/arrow/meson.build
@@ -270,11 +270,8 @@ if needs_ipc
         'ipc/writer.cc',
     ]
 
-    # ideally we could use the meson wrapdb for flatbuffers
-    # but Arrow statically asserts that version 23.5 is required
-    # while the wrapdb does not have that minor version
-    arrow_ipc_deps = []
-    arrow_ipc_includes = ['../../../thirdparty/flatbuffers/include']
+    flatbuffers_dep = dependency('flatbuffers')
+    arrow_ipc_deps = [flatbuffers_dep]
 
     if needs_json
         arrow_ipc_srcs += 'ipc/json_simple.cc'
@@ -284,7 +281,7 @@ if needs_ipc
     arrow_components += {
         'arrow_ipc': {
             'sources': arrow_ipc_srcs,
-            'include_dirs': arrow_ipc_includes,
+            'include_dirs': [],
             'dependencies': arrow_ipc_deps,
         },
     }

--- a/cpp/src/arrow/meson.build
+++ b/cpp/src/arrow/meson.build
@@ -227,6 +227,90 @@ arrow_components = {
     },
 }
 
+arrow_testing_srcs = [
+    'io/test_common.cc',
+    'ipc/test_common.cc',
+    'testing/fixed_width_test_util.cc',
+    'testing/generator.cc',
+    'testing/gtest_util.cc',
+    'testing/math.cc',
+    'testing/process.cc',
+    'testing/random.cc',
+    'testing/util.cc',
+]
+
+if needs_integration or needs_tests
+    arrow_components += {
+        'arrow_integration': {
+            'sources': [
+                'integration/c_data_integration_internal.cc',
+                'integration/json_integration.cc',
+                'integration/json_internal.cc',
+            ],
+            'include_dirs': [],
+            'dependencies': [],
+        },
+    }
+endif
+
+if needs_json
+    rapidjson_dep = dependency('rapidjson', include_type: 'system')
+else
+    rapidjson_dep = disabler()
+endif
+
+if needs_ipc
+    arrow_ipc_srcs = [
+        'ipc/dictionary.cc',
+        'ipc/feather.cc',
+        'ipc/message.cc',
+        'ipc/metadata_internal.cc',
+        'ipc/options.cc',
+        'ipc/reader.cc',
+        'ipc/writer.cc',
+    ]
+
+    # ideally we could use the meson wrapdb for flatbuffers
+    # but Arrow statically asserts that version 23.5 is required
+    # while the wrapdb does not have that minor version
+    arrow_ipc_deps = []
+    arrow_ipc_includes = ['../../../thirdparty/flatbuffers/include']
+
+    if needs_json
+        arrow_ipc_srcs += 'ipc/json_simple.cc'
+        arrow_ipc_deps += rapidjson_dep
+    endif
+
+    arrow_components += {
+        'arrow_ipc': {
+            'sources': arrow_ipc_srcs,
+            'include_dirs': arrow_ipc_includes,
+            'dependencies': arrow_ipc_deps,
+        },
+    }
+endif
+
+if needs_json
+    arrow_components += {
+        'arrow_json': {
+            'sources': [
+                'extension/fixed_shape_tensor.cc',
+                'extension/opaque.cc',
+                'json/options.cc',
+                'json/chunked_builder.cc',
+                'json/chunker.cc',
+                'json/converter.cc',
+                'json/object_parser.cc',
+                'json/object_writer.cc',
+                'json/parser.cc',
+                'json/reader.cc',
+            ],
+            'include_dirs': [],
+            'dependencies': [rapidjson_dep],
+        },
+    }
+endif
+
 arrow_srcs = []
 include_dir = include_directories('..')
 arrow_includes = [include_dir]
@@ -288,6 +372,49 @@ install_headers(
     ],
     install_dir: 'arrow',
 )
+
+if needs_tests
+    filesystem_dep = dependency('boost', modules: ['filesystem'])
+    gtest_main_dep = dependency('gtest_main')
+    gmock_dep = dependency('gmock')
+else
+    filesystem_dep = disabler()
+    gtest_main_dep = disabler()
+    gmock_dep = disabler()
+endif
+
+arrow_test_lib = static_library(
+    'arrow_testing',
+    sources: arrow_testing_srcs,
+    include_directories: [include_dir],
+    link_with: [arrow_lib],
+    dependencies: [filesystem_dep, gtest_main_dep],
+)
+
+arrow_test_dep = declare_dependency(
+    link_with: [arrow_lib, arrow_test_lib],
+    include_directories: [include_dir],
+    dependencies: [filesystem_dep, gmock_dep, gtest_main_dep],
+)
+
+array_array_test = executable(
+    'arrow_array_test',
+    sources: [
+        'array/array_test.cc',
+        'array/array_binary_test.cc',
+        'array/array_dict_test.cc',
+        'array/array_list_test.cc',
+        'array/array_list_view_test.cc',
+        'array/array_run_end_test.cc',
+        'array/array_struct_test.cc',
+        'array/array_union_test.cc',
+        'array/array_view_test.cc',
+        'array/statistics_test.cc',
+    ],
+    dependencies: [arrow_test_dep],
+)
+
+test('arrow_array_test', array_array_test)
 
 version = meson.project_version()
 

--- a/cpp/src/arrow/meson.build
+++ b/cpp/src/arrow/meson.build
@@ -371,7 +371,21 @@ install_headers(
 )
 
 if needs_tests
-    filesystem_dep = dependency('boost', modules: ['filesystem'])
+    filesystem_dep = dependency(
+        'boost',
+        modules: ['filesystem'],
+        required: false,
+    )
+    if not filesystem_dep.found()
+        cmake = import('cmake')
+        boost_opt = cmake.subproject_options()
+        boost_opt.add_cmake_defines(
+            {'BOOST_INCLUDE_LIBRARIES': 'filesystem;system'},
+        )
+        boost_proj = cmake.subproject('boost', options: boost_opt)
+        filesystem_dep = boost_proj.dependency('boost_filesystem')
+    endif
+
     gtest_main_dep = dependency('gtest_main')
     gmock_dep = dependency('gmock')
 else

--- a/cpp/subprojects/boost.wrap
+++ b/cpp/subprojects/boost.wrap
@@ -20,7 +20,7 @@ source_url = https://github.com/boostorg/boost/releases/download/boost-1.87.0/bo
 source_filename = boost-1.87.0-cmake.tar.gz
 source_hash = 78fbf579e3caf0f47517d3fb4d9301852c3154bfecdc5eeebd9b2b0292366f5b
 directory = boost-1.87.0
-method=cmake
+method = cmake
 
 [provide]
 boost_filesystem = boost_filesystem_dep

--- a/cpp/subprojects/boost.wrap
+++ b/cpp/subprojects/boost.wrap
@@ -1,0 +1,27 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[wrap-file]
+source_url = https://github.com/boostorg/boost/releases/download/boost-1.87.0/boost-1.87.0-cmake.tar.gz
+source_filename = boost-1.87.0-cmake.tar.gz
+source_hash = 78fbf579e3caf0f47517d3fb4d9301852c3154bfecdc5eeebd9b2b0292366f5b
+directory = boost-1.87.0
+method=cmake
+
+[provide]
+boost_filesystem = boost_filesystem_dep
+boost_system = boost_system_dep

--- a/cpp/subprojects/flatbuffers.wrap
+++ b/cpp/subprojects/flatbuffers.wrap
@@ -1,0 +1,31 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[wrap-file]
+directory = flatbuffers-24.3.6
+source_url = https://github.com/google/flatbuffers/archive/v24.3.6.tar.gz
+source_filename = flatbuffers-24.3.6.tar.gz
+source_hash = 5d8bfbf5b1b4c47f516e7673677f0e8db0efd32f262f7a14c3fd5ff67e2bd8fc
+patch_filename = flatbuffers_24.3.6-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/flatbuffers_24.3.6-1/get_patch
+patch_hash = bc0e1035a67ae74b1f862491fe2b0fd49b2889d989508143fff0a45508421bd7
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/flatbuffers_24.3.6-1/flatbuffers-24.3.6.tar.gz
+wrapdb_version = 24.3.6-1
+
+[provide]
+flatbuffers = flatbuffers_dep
+program_names = flatc, flathash

--- a/cpp/subprojects/gtest.wrap
+++ b/cpp/subprojects/gtest.wrap
@@ -15,37 +15,19 @@
 # specific language governing permissions and limitations
 # under the License.
 
-thirdparty/*.tar*
-CMakeFiles/
-CMakeCache.txt
-CMakeUserPresets.json
-CTestTestfile.cmake
-Makefile
-cmake_install.cmake
-build/
-*-build/
-Testing/
-build-support/boost_*
-vcpkg_installed/
+[wrap-file]
+directory = googletest-1.15.2
+source_url = https://github.com/google/googletest/archive/refs/tags/v1.15.2.tar.gz
+source_filename = gtest-1.15.2.tar.gz
+source_hash = 7b42b4d6ed48810c5362c265a17faebe90dc2373c885e5216439d37927f02926
+patch_filename = gtest_1.15.2-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/gtest_1.15.2-1/get_patch
+patch_hash = b41cba05fc61d47b2ba5bf95732eb86ce2b67303f291b68a9587b7563c318141
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/gtest_1.15.2-1/gtest-1.15.2.tar.gz
+wrapdb_version = 1.15.2-1
 
-# Build directories created by Clion
-cmake-build-*/
-
-#########################################
-# Editor temporary/working/backup files #
-.#*
-*\#*\#
-[#]*#
-*~
-*$
-*.bak
-*flymake*
-*.kdev4
-*.log
-*.swp
-
-# meson subprojects - wrap files need to be kept to let meson download
-# dependencies as needed, but dependencies themselves should not be versioned
-subprojects/*
-!subprojects/packagefiles
-!subprojects/*.wrap
+[provide]
+gtest = gtest_dep
+gtest_main = gtest_main_dep
+gmock = gmock_dep
+gmock_main = gmock_main_dep

--- a/cpp/subprojects/rapidjson.wrap
+++ b/cpp/subprojects/rapidjson.wrap
@@ -15,37 +15,16 @@
 # specific language governing permissions and limitations
 # under the License.
 
-thirdparty/*.tar*
-CMakeFiles/
-CMakeCache.txt
-CMakeUserPresets.json
-CTestTestfile.cmake
-Makefile
-cmake_install.cmake
-build/
-*-build/
-Testing/
-build-support/boost_*
-vcpkg_installed/
+[wrap-file]
+directory = rapidjson-1.1.0
+source_url = https://github.com/Tencent/rapidjson/archive/v1.1.0.tar.gz
+source_filename = rapidjson-1.1.0.tar.gz
+source_hash = bf7ced29704a1e696fbccf2a2b4ea068e7774fa37f6d7dd4039d0787f8bed98e
+patch_filename = rapidjson_1.1.0-2_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/rapidjson_1.1.0-2/get_patch
+patch_hash = c1480d0ecef09dbaa4b4d85d86090205386fb2c7e87f4f158b20dbbda14c9afc
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/rapidjson_1.1.0-2/rapidjson-1.1.0.tar.gz
+wrapdb_version = 1.1.0-2
 
-# Build directories created by Clion
-cmake-build-*/
-
-#########################################
-# Editor temporary/working/backup files #
-.#*
-*\#*\#
-[#]*#
-*~
-*$
-*.bak
-*flymake*
-*.kdev4
-*.log
-*.swp
-
-# meson subprojects - wrap files need to be kept to let meson download
-# dependencies as needed, but dependencies themselves should not be versioned
-subprojects/*
-!subprojects/packagefiles
-!subprojects/*.wrap
+[provide]
+rapidjson = rapidjson_dep


### PR DESCRIPTION
<!--
Thanks for opening a pull request!
If this is your first pull request you can find detailed information on how 
to contribute here:
  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)


If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose

Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.

Then could you also rename the pull request title in the following format?

    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}

or

    MINOR: [${COMPONENT}] ${SUMMARY}

-->

### Rationale for this change

<!--
 Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
 Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
-->

Adding this singular test helps us make incremental progress on Meson as a build system generator

### What changes are included in this PR?

<!--
There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
-->

A single array-test for libarrow is being added

### Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->

Yes - see CI

### Are there any user-facing changes?

No - this is only for developers
* GitHub Issue: #45589