### PR TITLE
GH-45485: [Dev] Simplify pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,61 +1,20 @@
-
-<!--
 Thanks for opening a pull request!
-If this is your first pull request you can find detailed information on how 
-to contribute here:
+
+If this is your first pull request you can find detailed information on how to contribute here:
+
   * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
   * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)
 
-
-If this is not a [minor PR](https://github.com/apache/arrow/blob/main/CONTRIBUTING.md#Minor-Fixes). Could you open an issue for this pull request on GitHub? https://github.com/apache/arrow/issues/new/choose
-
-Opening GitHub issues ahead of time contributes to the [Openness](http://theapacheway.com/open/#:~:text=Openness%20allows%20new%20users%20the,must%20happen%20in%20the%20open.) of the Apache Arrow project.
-
-Then could you also rename the pull request title in the following format?
-
-    GH-${GITHUB_ISSUE_ID}: [${COMPONENT}] ${SUMMARY}
-
-or
-
-    MINOR: [${COMPONENT}] ${SUMMARY}
-
--->
+Please remove this line and the above text before creating your pull request.
 
 ### Rationale for this change
 
-<!--
- Why are you proposing this change? If this is already explained clearly in the issue then this section is not needed.
- Explaining clearly why changes are proposed helps reviewers understand your changes and offer better suggestions for fixes.  
--->
-
 ### What changes are included in this PR?
-
-<!--
-There is no need to duplicate the description in the issue here but it is sometimes worth providing a summary of the individual changes in this PR.
--->
 
 ### Are these changes tested?
 
-<!--
-We typically require tests for all PRs in order to:
-1. Prevent the code from being accidentally broken by subsequent changes
-2. Serve as another way to document the expected behavior of the code
-
-If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
--->
-
 ### Are there any user-facing changes?
 
-<!--
-If there are user-facing changes then we may require documentation to be updated before approving the PR.
--->
+**This PR includes breaking changes to public APIs.** (If there are any breaking changes to public APIs, please explain which changes are breaking. If not, you can remove this.)
 
-<!--
-If there are any breaking changes to public APIs, please uncomment the line below and explain which changes are breaking.
--->
-<!-- **This PR includes breaking changes to public APIs.** -->
-
-<!--
-Please uncomment the line below (and provide explanation) if the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld). We use this to highlight fixes to issues that may affect users without their knowledge. For this reason, fixing bugs that cause errors don't count, since those are usually obvious.
--->
-<!-- **This PR contains a "Critical Fix".** -->
+**This PR contains a "Critical Fix".** (If the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld), please provide explanation. If not, you can remove this.)


### PR DESCRIPTION
### Rationale for this change

It seems that the current comment based pull request template isn't read carefully.

### What changes are included in this PR?

* Remove explanations as comments
* Keep a basic introduction in the top as a normal text not a comment
* Use normal texts not comments for breaking changes and critical fix

### Are these changes tested?

No.

### Are there any user-facing changes?

No. This is only for developers.
* GitHub Issue: #45485