### PR TITLE
MINOR: [R] Bump the timeout for library download

### DIFF
--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -84,10 +84,10 @@ try_download <- function(from_url, to_file, hush = quietly) {
     return(FALSE)
   }
   # We download some fairly large files, so ensure the timeout is set appropriately.
-  # This assumes a static library size of 100 MB (generous) and a download speed
-  # of .3 MB/s (slow). This is to anticipate slower user connections or load on
-  # artifactory servers.
-  opts <- options(timeout = max(300, getOption("timeout")))
+  # This assumes a static library size of 100 MB (our current biggest is 78 MB) and
+  # a download speed of 0.2 MB/s (slow). This is to anticipate slower user connections
+  # or load on artifactory servers.
+  opts <- options(timeout = max(600, getOption("timeout")))
   on.exit(options(opts))
 
   status <- try(


### PR DESCRIPTION
### Rationale for this change

Increase the timeout, see if that's the issue on CRAN.

### What changes are included in this PR?

Timeout, increased

### Are these changes tested?

No

### Are there any user-facing changes?

Slightly slower downloads are possible.