### PR TITLE
MINOR: [R] Make update-checksums.R work on macOS out of the box

### DIFF
--- a/r/tools/update-checksums.R
+++ b/r/tools/update-checksums.R
@@ -28,6 +28,13 @@ args <- commandArgs(TRUE)
 VERSION <- args[1]
 tools_root <- ""
 
+# Use gsed on macOS and sed otherwise
+if (identical(unname(Sys.info()["sysname"]), "Darwin")) {
+  SED_BIN <- "gsed"
+} else {
+  SED_BIN <- "sed"
+}
+
 if (length(args) != 1) {
   stop("Usage: Rscript tools/update-checksums.R <version>")
 }
@@ -62,7 +69,7 @@ for (path in binary_paths) {
   if (grepl("windows", path)) {
     cat(paste0("Converting ", path, " to windows style line endings\n"))
     # UNIX style line endings cause errors with mysys2 sha512sum
-    sed_status <- system2("sed", args = c("-i", "s/\\\\r//", file))
+    sed_status <- system2(SED_BIN, args = c("-i", "s/\\\\r//", file))
     if (sed_status != 0) {
       stop("Failed to remove \\r from windows checksum file. Exit code: ", sed_status)
     }


### PR DESCRIPTION
### Rationale for this change

For R release managers on macOS, the update-checksums.R script we use doesn't run because the sed command we use in that script only works on GNU sed and not BSD sed.

### What changes are included in this PR?

- Makes update-checksum-R work on macOS by assuming the user has gsed available from Homebrew and using that always

### Are these changes tested?

Yes

### Are there any user-facing changes?

No.
