### PR TITLE
GH-45620: [CI][C++] Use Visual Studio 2022 not 2019

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -278,7 +278,7 @@ jobs:
         include:
           - os: windows-2022
             simd-level: AVX2
-            title: AMD64 Windows 2022 C++17 AVX2
+            title: AMD64 Windows 2022 AVX2
     env:
       ARROW_BOOST_USE_SHARED: OFF
       ARROW_BUILD_BENCHMARKS: ON

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -274,11 +274,11 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - windows-2019
+          - windows-2022
         include:
-          - os: windows-2019
+          - os: windows-2022
             simd-level: AVX2
-            title: AMD64 Windows 2019 C++17 AVX2
+            title: AMD64 Windows 2022 C++17 AVX2
     env:
       ARROW_BOOST_USE_SHARED: OFF
       ARROW_BUILD_BENCHMARKS: ON
@@ -352,7 +352,7 @@ jobs:
       - name: Build
         shell: cmd
         run: |
-          call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
           bash -c "ci/scripts/cpp_build.sh $(pwd) $(pwd)/build"
       - name: Test
         shell: bash


### PR DESCRIPTION
### Rationale for this change

It seems that Visual Studio 2019 is in maintenance mode: https://learn.microsoft.com/en-us/visualstudio/releases/2019/servicing-vs2019

### What changes are included in this PR?

Use Visual Studio 2022 on `windows-2022` image.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #45620