### PR TITLE
GH-45649: [GLib] Add GArrowBinaryViewArray

### DIFF
--- a/c_glib/arrow-glib/basic-array.cpp
+++ b/c_glib/arrow-glib/basic-array.cpp
@@ -127,6 +127,11 @@ G_BEGIN_DECLS
  * string data. If you don't have Arrow format data, you need to
  * use #GArrowLargeStringArrayBuilder to create a new array.
  *
+ * #GArrayBinaryViewArray is a class for variable-size binary view array
+ * It can store zero or more binary view data. If you don't have Arrow
+ * format data, you need to use #GArrowBinaryViewArrayBuilder to create
+ * a new array.
+ *
  * #GArrowFixedSizeBinaryArray is a class for fixed size binary array.
  * It can store zero or more fixed size binary data. If you don't have
  * Arrow format data, you need to use
@@ -2530,6 +2535,58 @@ garrow_large_string_array_get_string(GArrowLargeStringArray *array, gint64 i)
                                                                      i);
 }
 
+G_DEFINE_TYPE(GArrowBinaryViewArray, garrow_binary_view_array, GARROW_TYPE_ARRAY)
+static void
+garrow_binary_view_array_init(GArrowBinaryViewArray *object)
+{
+}
+
+static void
+garrow_binary_view_array_class_init(GArrowBinaryViewArrayClass *klass)
+{
+}
+
+/**
+ * garrow_binary_view_array_new:
+ * @length: The number of elements.
+ * @views: The view buffer.
+ * @data_buffers: (element-type GArrowBuffer): The data buffers.
+ * @null_bitmap: (nullable): The bitmap that shows null elements. The
+ *   N-th element is null when the N-th bit is 0, not null otherwise.
+ *   If the array has no null elements, the bitmap must be %NULL and
+ *   @n_nulls is 0.
+ * @n_nulls: The number of null elements. If -1 is specified, the
+ *   number of nulls are computed from @null_bitmap.
+ * @offset: The position of the first element.
+ *
+ * Returns: A newly created #GArrowBinaryViewArray.
+ *
+ * Since: 20.0.0
+ */
+GArrowBinaryViewArray *
+garrow_binary_view_array_new(gint64 length,
+                             GArrowBuffer *views,
+                             GList *data_buffers,
+                             GArrowBuffer *null_bitmap,
+                             gint64 n_nulls,
+                             gint64 offset)
+{
+  std::vector<std::shared_ptr<arrow::Buffer>> arrow_data_buffers;
+  for (GList *node = data_buffers; node; node = g_list_next(node)) {
+    arrow_data_buffers.push_back(garrow_buffer_get_raw(GARROW_BUFFER(node->data)));
+  }
+  auto binary_view_array =
+    std::make_shared<arrow::BinaryViewArray>(arrow::binary_view(),
+                                             length,
+                                             garrow_buffer_get_raw(views),
+                                             std::move(arrow_data_buffers),
+                                             garrow_buffer_get_raw(null_bitmap),
+                                             n_nulls,
+                                             offset);
+  return GARROW_BINARY_VIEW_ARRAY(
+    g_object_new(GARROW_TYPE_BINARY_VIEW_ARRAY, "array", &binary_view_array, nullptr));
+}
+
 G_DEFINE_TYPE(GArrowDate32Array, garrow_date32_array, GARROW_TYPE_NUMERIC_ARRAY)
 
 static void
@@ -3749,6 +3806,9 @@ garrow_array_new_raw_valist(std::shared_ptr<arrow::Array> *arrow_array,
     break;
   case arrow::Type::type::RUN_END_ENCODED:
     type = GARROW_TYPE_RUN_END_ENCODED_ARRAY;
+    break;
+  case arrow::Type::type::BINARY_VIEW:
+    type = GARROW_TYPE_BINARY_VIEW_ARRAY;
     break;
   default:
     type = GARROW_TYPE_ARRAY;

--- a/c_glib/arrow-glib/basic-array.cpp
+++ b/c_glib/arrow-glib/basic-array.cpp
@@ -2587,6 +2587,21 @@ garrow_binary_view_array_new(gint64 length,
     g_object_new(GARROW_TYPE_BINARY_VIEW_ARRAY, "array", &binary_view_array, nullptr));
 }
 
+/**
+ * garrow_binary_view_array_get_value:
+ * @array: A #GArrowBinaryViewArray.
+ * @i: The index of the target value.
+ *
+ * Returns: (transfer full): The @i-th value.
+ */
+GBytes *
+garrow_binary_view_array_get_value(GArrowBinaryViewArray *array, gint64 i)
+{
+  auto arrow_array = garrow_array_get_raw(GARROW_ARRAY(array));
+  auto view = static_cast<arrow::BinaryViewArray *>(arrow_array.get())->GetView(i);
+  return g_bytes_new_static(view.data(), view.length());
+}
+
 G_DEFINE_TYPE(GArrowDate32Array, garrow_date32_array, GARROW_TYPE_NUMERIC_ARRAY)
 
 static void

--- a/c_glib/arrow-glib/basic-array.cpp
+++ b/c_glib/arrow-glib/basic-array.cpp
@@ -127,7 +127,7 @@ G_BEGIN_DECLS
  * string data. If you don't have Arrow format data, you need to
  * use #GArrowLargeStringArrayBuilder to create a new array.
  *
- * #GArrayBinaryViewArray is a class for variable-size binary view array
+ * #GArrayBinaryViewArray is a class for variable-size binary view array.
  * It can store zero or more binary view data. If you don't have Arrow
  * format data, you need to use #GArrowBinaryViewArrayBuilder to create
  * a new array.

--- a/c_glib/arrow-glib/basic-array.h
+++ b/c_glib/arrow-glib/basic-array.h
@@ -620,6 +620,10 @@ garrow_binary_view_array_new(gint64 length,
                              gint64 n_nulls,
                              gint64 offset);
 
+GARROW_AVAILABLE_IN_20_0
+GBytes *
+garrow_binary_view_array_get_value(GArrowBinaryViewArray *array, gint64 i);
+
 #define GARROW_TYPE_DATE32_ARRAY (garrow_date32_array_get_type())
 GARROW_AVAILABLE_IN_ALL
 G_DECLARE_DERIVABLE_TYPE(

--- a/c_glib/arrow-glib/basic-array.h
+++ b/c_glib/arrow-glib/basic-array.h
@@ -602,6 +602,24 @@ GARROW_AVAILABLE_IN_0_16
 gchar *
 garrow_large_string_array_get_string(GArrowLargeStringArray *array, gint64 i);
 
+#define GARROW_TYPE_BINARY_VIEW_ARRAY (garrow_binary_view_array_get_type())
+GARROW_AVAILABLE_IN_20_0
+G_DECLARE_DERIVABLE_TYPE(
+  GArrowBinaryViewArray, garrow_binary_view_array, GARROW, BINARY_VIEW_ARRAY, GArrowArray)
+struct _GArrowBinaryViewArrayClass
+{
+  GArrowArrayClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_20_0
+GArrowBinaryViewArray *
+garrow_binary_view_array_new(gint64 length,
+                             GArrowBuffer *views,
+                             GList *data_buffers,
+                             GArrowBuffer *null_bitmap,
+                             gint64 n_nulls,
+                             gint64 offset);
+
 #define GARROW_TYPE_DATE32_ARRAY (garrow_date32_array_get_type())
 GARROW_AVAILABLE_IN_ALL
 G_DECLARE_DERIVABLE_TYPE(

--- a/c_glib/test/test-binary-view-array.rb
+++ b/c_glib/test/test-binary-view-array.rb
@@ -31,5 +31,6 @@ class TestBinaryViewArray < Test::Unit::TestCase
     assert do
       str_view.validate_full
     end
+    assert_equal(buffer_string, str_view.get_value(0).to_s)
   end
 end

--- a/c_glib/test/test-binary-view-array.rb
+++ b/c_glib/test/test-binary-view-array.rb
@@ -19,15 +19,14 @@ class TestBinaryViewArray < Test::Unit::TestCase
   def test_new
     view_bytes = 16
     buffer_string = "test"
-    view_data = [ buffer_string.size ].pack("l")
-    view_data += buffer_string
-    view_data += "\x00" * (view_bytes - buffer_string.size)
+    view_data = [buffer_string.size].pack("l")
+    view_data += buffer_string.ljust(12, "\x00")
 
     view = Arrow::Buffer.new(view_data)
     data_buffer = Arrow::Buffer.new(buffer_string)
     bitmap = Arrow::Buffer.new([0b1].pack("C*"))
 
-    str_view = Arrow::BinaryViewArray.new(1,view,[data_buffer],bitmap,0, 0)
+    binary_view = Arrow::BinaryViewArray.new(1, view, [data_buffer], bitmap, 0, 0)
     assert do
       str_view.validate_full
     end

--- a/c_glib/test/test-binary-view-array.rb
+++ b/c_glib/test/test-binary-view-array.rb
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestBinaryViewArray < Test::Unit::TestCase
+  def test_new
+    view_bytes = 16
+    buffer_string = "test"
+    view_data = [ buffer_string.size ].pack("l")
+    view_data += buffer_string
+    view_data += "\x00" * (view_bytes - buffer_string.size)
+
+    view = Arrow::Buffer.new(view_data)
+    data_buffer = Arrow::Buffer.new(buffer_string)
+    bitmap = Arrow::Buffer.new([0b1].pack("C*"))
+
+    str_view = Arrow::BinaryViewArray.new(1,view,[data_buffer],bitmap,0, 0)
+    assert do
+      str_view.validate_full
+    end
+  end
+end

--- a/c_glib/test/test-binary-view-array.rb
+++ b/c_glib/test/test-binary-view-array.rb
@@ -17,19 +17,24 @@
 
 class TestBinaryViewArray < Test::Unit::TestCase
   def test_new
-    view_bytes = 16
-    buffer_string = "test"
-    view_data = [buffer_string.size].pack("l")
-    view_data += buffer_string.ljust(12, "\x00")
+    short_binary_data = "test"
+    short_view_buffer_space = 12
+    short_view_buffer = [short_binary_data.size].pack("l")
+    short_view_buffer += short_binary_data.ljust(short_view_buffer_space, "\x00")
 
-    view = Arrow::Buffer.new(view_data)
-    data_buffer = Arrow::Buffer.new(buffer_string)
+    arrow_view_buffer = Arrow::Buffer.new(short_view_buffer)
+    arrow_data_buffer = Arrow::Buffer.new(short_binary_data)
     bitmap = Arrow::Buffer.new([0b1].pack("C*"))
 
-    binary_view = Arrow::BinaryViewArray.new(1, view, [data_buffer], bitmap, 0, 0)
+    binary_view_array = Arrow::BinaryViewArray.new(1,
+                                                   arrow_view_buffer,
+                                                   [arrow_data_buffer],
+                                                   bitmap,
+                                                   0,
+                                                   0)
     assert do
-      str_view.validate_full
+      binary_view_array.validate_full
     end
-    assert_equal(buffer_string, str_view.get_value(0).to_s)
+    assert_equal(short_binary_data, binary_view_array.get_value(0).to_s)
   end
 end


### PR DESCRIPTION
### Rationale for this change

[arrow::BinaryViewArray](https://arrow.apache.org/docs/cpp/api/array.html#_CPPv4N5arrow15BinaryViewArrayE) is available in the C++ API.
But, GLib doesn't support that method yet.


### What changes are included in this PR?

Add `GArrowBinaryViewArray` for wrapping `arrow::BinaryViewArray` class

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #45649