### PR TITLE
GH-45659: [GLib][Ruby] Fix Ruby lint violation(add space after comma)

### DIFF
--- a/c_glib/test/test-record-batch.rb
+++ b/c_glib/test/test-record-batch.rb
@@ -234,7 +234,7 @@ valid:   [
 
         # U+3042 HIRAGANA LETTER A, U+3044 HIRAGANA LETTER I
         data = "\u3042\u3044".b[0..-2]
-        value_offsets = Arrow::Buffer.new([0,data.size].pack("l*"))
+        value_offsets = Arrow::Buffer.new([0, data.size].pack("l*"))
         @invalid_name_value = Arrow::StringArray.new(1,
                                                      value_offsets,
                                                      Arrow::Buffer.new(data),

--- a/c_glib/test/test-take.rb
+++ b/c_glib/test/test-take.rb
@@ -23,7 +23,7 @@ class TestTake < Test::Unit::TestCase
     def test_no_null
       indices = build_int16_array([1, 0, 2])
       assert_equal(build_int16_array([0, 1, 2]),
-                   build_int16_array([1, 0 ,2]).take(indices))
+                   build_int16_array([1, 0, 2]).take(indices))
     end
 
     def test_null

--- a/ruby/red-arrow/test/test-array.rb
+++ b/ruby/red-arrow/test/test-array.rb
@@ -142,7 +142,7 @@ class ArrayTest < Test::Unit::TestCase
 
   sub_test_case("#take") do
     def setup
-      values = [1, 0 ,2]
+      values = [1, 0, 2]
       @array = Arrow::Int16Array.new(values)
     end
 
@@ -205,14 +205,14 @@ class ArrayTest < Test::Unit::TestCase
 
   sub_test_case("#concatenate") do
     test("Arrow::Array: same") do
-      assert_equal(Arrow::Int32Array.new([1, 2, nil, 4 ,5, 6]),
+      assert_equal(Arrow::Int32Array.new([1, 2, nil, 4, 5, 6]),
                    Arrow::Int32Array.new([1, 2, nil]).
                      concatenate(Arrow::Int32Array.new([4, 5]),
                                  Arrow::Int32Array.new([6])))
     end
 
     test("Arrow::Array: castable") do
-      assert_equal(Arrow::Int32Array.new([1, 2, nil, 4 ,5, 6]),
+      assert_equal(Arrow::Int32Array.new([1, 2, nil, 4, 5, 6]),
                    Arrow::Int32Array.new([1, 2, nil]).
                      concatenate(Arrow::Int8Array.new([4, 5]),
                                  Arrow::UInt32Array.new([6])))
@@ -226,7 +226,7 @@ class ArrayTest < Test::Unit::TestCase
     end
 
     test("Array") do
-      assert_equal(Arrow::Int32Array.new([1, 2, nil, 4 ,nil, 6]),
+      assert_equal(Arrow::Int32Array.new([1, 2, nil, 4, nil, 6]),
                    Arrow::Int32Array.new([1, 2, nil]).
                      concatenate([4, nil],
                                  [6]))
@@ -243,13 +243,13 @@ class ArrayTest < Test::Unit::TestCase
 
   sub_test_case("#+") do
     test("Arrow::Array: same") do
-      assert_equal(Arrow::Int32Array.new([1, 2, nil, 4 ,5, 6]),
+      assert_equal(Arrow::Int32Array.new([1, 2, nil, 4, 5, 6]),
                    Arrow::Int32Array.new([1, 2, nil]) +
                    Arrow::Int32Array.new([4, 5, 6]))
     end
 
     test("Arrow::Array: castable") do
-      assert_equal(Arrow::Int32Array.new([1, 2, nil, 4 ,5, 6]),
+      assert_equal(Arrow::Int32Array.new([1, 2, nil, 4, 5, 6]),
                    Arrow::Int32Array.new([1, 2, nil]) +
                    Arrow::Int8Array.new([4, 5, 6]))
     end
@@ -262,7 +262,7 @@ class ArrayTest < Test::Unit::TestCase
     end
 
     test("Array") do
-      assert_equal(Arrow::Int32Array.new([1, 2, nil, 4 ,nil, 6]),
+      assert_equal(Arrow::Int32Array.new([1, 2, nil, 4, nil, 6]),
                    Arrow::Int32Array.new([1, 2, nil]) +
                    [4, nil, 6])
     end


### PR DESCRIPTION
### Rationale for this change

Preparing to add Ruby lint rule. require space after comma.
ex) `[1,2,3]` -> `[1, 2, 3]`


### What changes are included in this PR?

Add space after comma.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.

* GitHub Issue: #45659