### PR TITLE
GH-45661: [GLib][Ruby][Dev] Add Ruby lint rule (add space after comma)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,3 +28,6 @@ Layout/LineLength:
 
 Layout/ArgumentAlignment:
   Enabled: true
+
+Layout/SpaceAfterComma:
+  Enabled: true


### PR DESCRIPTION
### Rationale for this change

Automatic style checking for Ruby language.
It is necessary to have extra space after a comma like `[1, 2]` instead of `[1,2]`.

### What changes are included in this PR?

Enable automatic lint checking (add space after comma)

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #45661