### PR TITLE
GH-45665: [Docs] Add kapa AI bot to the docs 

### DIFF
--- a/docs/source/_templates/kapa-ai-bot.html
+++ b/docs/source/_templates/kapa-ai-bot.html
@@ -5,13 +5,12 @@
         data-website-id="9db461d5-ac77-4b3f-a5c5-75efa78339d2"
         data-project-name="Apache Arrow"
         data-project-color="#000000"
-        data-project-logo="https://arrow.apache.org/docs/_static/arrow.png"
+        data-project-logo="https://arrow.apache.org/img/arrow-logo_chevrons_white-txt_black-bg.png"
         data-modal-disclaimer="This is a custom LLM with access to all [Arrow documentation](https://arrow.apache.org/docs/)."
         data-consent-required="true" 
         data-consent-screen-disclaimer="By clicking &quot;I agree, let's chat&quot;, you consent to the use of the AI assistant in accordance with kapa.ai's [Privacy Policy](https://www.kapa.ai/content/privacy-policy). This service uses reCAPTCHA, which requires your consent to Google's [Privacy Policy](https://policies.google.com/privacy) and [Terms of Service](https://policies.google.com/terms). By proceeding, you explicitly agree to both kapa.ai's and Google's privacy policies."
     ></script>
-    <button>
-        <span>Ask&nbsp;AI!</span>
-    </button>
+   
 </div>
+
 

--- a/docs/source/_templates/kapa-ai-bot.html
+++ b/docs/source/_templates/kapa-ai-bot.html
@@ -1,11 +1,17 @@
 <div class="kapa-ai-bot">
     <script
-    async
-    src="https://widget.kapa.ai/kapa-widget.bundle.js"
-    data-website-id="9db461d5-ac77-4b3f-a5c5-75efa78339d2"
-    data-project-name="Apache Arrow"
-    data-project-color="#000000"
-    data-project-logo="https://arrow.apache.org/docs/_static/arrow.png"
+        async
+        src="https://widget.kapa.ai/kapa-widget.bundle.js"
+        data-website-id="9db461d5-ac77-4b3f-a5c5-75efa78339d2"
+        data-project-name="Apache Arrow"
+        data-project-color="#000000"
+        data-project-logo="https://arrow.apache.org/docs/_static/arrow.png"
+        data-modal-disclaimer="This is a custom LLM with access to all [Arrow documentation](https://arrow.apache.org/docs/)."
+        data-consent-required="true" 
+        data-consent-screen-disclaimer="By clicking &quot;I agree, let's chat&quot;, you consent to the use of the AI assistant in accordance with kapa.ai's [Privacy Policy](https://www.kapa.ai/content/privacy-policy). This service uses reCAPTCHA, which requires your consent to Google's [Privacy Policy](https://policies.google.com/privacy) and [Terms of Service](https://policies.google.com/terms). By proceeding, you explicitly agree to both kapa.ai's and Google's privacy policies."
     ></script>
+    <button>
+        <span>Ask&nbsp;AI!</span>
+    </button>
 </div>
 

--- a/docs/source/_templates/kapa-ai-bot.html
+++ b/docs/source/_templates/kapa-ai-bot.html
@@ -1,0 +1,11 @@
+<div class="kapa-ai-bot">
+    <script
+    async
+    src="https://widget.kapa.ai/kapa-widget.bundle.js"
+    data-website-id="9db461d5-ac77-4b3f-a5c5-75efa78339d2"
+    data-project-name="Apache Arrow"
+    data-project-color="#000000"
+    data-project-logo="https://arrow.apache.org/docs/_static/arrow.png"
+    ></script>
+</div>
+

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -344,7 +344,7 @@ html_theme_options = {
     "header_links_before_dropdown": 2,
     "header_dropdown_text": "Implementations",
     "navbar_align": "left",
-    "navbar_end": ["version-switcher", "theme-switcher", "navbar-icon-links"],
+    "navbar_end": ["kapa-ai-bot.html", "version-switcher", "theme-switcher", "navbar-icon-links"],
     "icon_links": [
         {
             "name": "GitHub",

--- a/r/_pkgdown.yml
+++ b/r/_pkgdown.yml
@@ -43,6 +43,20 @@ template:
         })();
       </script>
       <!-- End Matomo Code -->
+      <!-- Kapa AI -->
+      <script
+          async
+          src="https://widget.kapa.ai/kapa-widget.bundle.js"
+          data-website-id="9db461d5-ac77-4b3f-a5c5-75efa78339d2"
+          data-project-name="Apache Arrow"
+          data-project-color="#000000"
+          data-project-logo="https://arrow.apache.org/img/arrow-logo_chevrons_white-txt_black-bg.png"
+          data-modal-example-questions=""
+          data-modal-disclaimer="This is a custom LLM with access to all of [Arrow documentation](https://arrow.apache.org/docs/).  If you want an R-specific answer, please mention this in your question."
+          data-consent-required="true" 
+          data-consent-screen-disclaimer="By clicking &quot;I agree, let's chat&quot;, you consent to the use of the AI assistant in accordance with kapa.ai's [Privacy Policy](https://www.kapa.ai/content/privacy-policy). This service uses reCAPTCHA, which requires your consent to Google's [Privacy Policy](https://policies.google.com/privacy) and [Terms of Service](https://policies.google.com/terms). By proceeding, you explicitly agree to both kapa.ai's and Google's privacy policies."
+      ></script>
+      <!-- End Kapa AI -->
   opengraph:
     image:
       src: https://arrow.apache.org/img/arrow-logo_horizontal_black-txt_white-bg.png

--- a/r/_pkgdown.yml
+++ b/r/_pkgdown.yml
@@ -51,7 +51,6 @@ template:
           data-project-name="Apache Arrow"
           data-project-color="#000000"
           data-project-logo="https://arrow.apache.org/img/arrow-logo_chevrons_white-txt_black-bg.png"
-          data-modal-example-questions=""
           data-modal-disclaimer="This is a custom LLM with access to all of [Arrow documentation](https://arrow.apache.org/docs/).  If you want an R-specific answer, please mention this in your question."
           data-consent-required="true" 
           data-consent-screen-disclaimer="By clicking &quot;I agree, let's chat&quot;, you consent to the use of the AI assistant in accordance with kapa.ai's [Privacy Policy](https://www.kapa.ai/content/privacy-policy). This service uses reCAPTCHA, which requires your consent to Google's [Privacy Policy](https://policies.google.com/privacy) and [Terms of Service](https://policies.google.com/terms). By proceeding, you explicitly agree to both kapa.ai's and Google's privacy policies."


### PR DESCRIPTION
### Rationale for this change

Add kapa AI bot to the docs to make it easier to find answers to questions

### What changes are included in this PR?

Config for enabling bot

### Are these changes tested?

Manually, yep

### Are there any user-facing changes?

Yep, adds widget to header in docs pages

* GitHub Issue: #45665
