### PR TITLE
GH-45670: [Release][Archery] Crossbow bot accepts `--prefix`

### DIFF
--- a/dev/archery/archery/bot.py
+++ b/dev/archery/archery/bot.py
@@ -376,8 +376,10 @@ def _clone_arrow_and_crossbow(dest, crossbow_repo, arrow_repo_url, pr_number):
               help='Set target version explicitly.')
 @click.option('--wait', default=60,
               help='Wait the specified seconds before generating a report.')
+@click.option('--prefix', default='actions',
+              help='Prefix for job IDs.')
 @click.pass_obj
-def submit(obj, tasks, groups, params, arrow_version, wait):
+def submit(obj, tasks, groups, params, arrow_version, wait, prefix):
     """
     Submit crossbow testing tasks.
 
@@ -411,7 +413,7 @@ def submit(obj, tasks, groups, params, arrow_version, wait):
                               groups=groups, params=params)
 
         # add the job to the crossbow queue and push to the remote repository
-        queue.put(job, prefix="actions", increment_job_id=False)
+        queue.put(job, prefix=prefix, increment_job_id=False)
         queue.push()
 
         # render the response comment's content


### PR DESCRIPTION
### Rationale for this change

I want to find binary verification jobs in a release PR easily for GH-45548.
Example jobs: https://github.com/apache/arrow/pull/45502#issuecomment-2655272971

If we use specific prefix for the jobs, we can find them easily.

### What changes are included in this PR?

Make `prefix` customizable by an option.

### Are these changes tested?

No.

### Are there any user-facing changes?

No.
* GitHub Issue: #45670