### PR TITLE
GH-45669: [C++] Export `arrow::io::ReadRange`

### DIFF
--- a/cpp/src/arrow/io/interfaces.h
+++ b/cpp/src/arrow/io/interfaces.h
@@ -33,7 +33,7 @@
 namespace arrow {
 namespace io {
 
-struct ReadRange {
+struct ARROW_EXPORT ReadRange {
   int64_t offset;
   int64_t length;
 


### PR DESCRIPTION
### Rationale for this change

`parquet::ParquetFileReader::GetReadRanges()` uses it. So we need to export it explicitly on Windows.

### What changes are included in this PR?

Add missing `ARROW_EXPORT` to `arrow::io::ReadRange`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #45669