### PR TITLE
GH-45694: [C++] Bump vendored flatbuffers to 24.3.6

### DIFF
--- a/cpp/src/arrow/ipc/message.cc
+++ b/cpp/src/arrow/ipc/message.cc
@@ -62,7 +62,7 @@ class Message::MessageImpl {
       return Status::Invalid("Old metadata version not supported");
     }
 
-    if (message_->version() > flatbuf::MetadataVersion::MAX) {
+    if (message_->version() > flatbuf::MetadataVersion::MetadataVersion_MAX) {
       return Status::Invalid("Unsupported future MetadataVersion: ",
                              static_cast<int16_t>(message_->version()));
     }
@@ -79,15 +79,15 @@ class Message::MessageImpl {
 
   MessageType type() const {
     switch (message_->header_type()) {
-      case flatbuf::MessageHeader::Schema:
+      case flatbuf::MessageHeader::MessageHeader_Schema:
         return MessageType::SCHEMA;
-      case flatbuf::MessageHeader::DictionaryBatch:
+      case flatbuf::MessageHeader::MessageHeader_DictionaryBatch:
         return MessageType::DICTIONARY_BATCH;
-      case flatbuf::MessageHeader::RecordBatch:
+      case flatbuf::MessageHeader::MessageHeader_RecordBatch:
         return MessageType::RECORD_BATCH;
-      case flatbuf::MessageHeader::Tensor:
+      case flatbuf::MessageHeader::MessageHeader_Tensor:
         return MessageType::TENSOR;
-      case flatbuf::MessageHeader::SparseTensor:
+      case flatbuf::MessageHeader::MessageHeader_SparseTensor:
         return MessageType::SPARSE_TENSOR;
       default:
         return MessageType::NONE;

--- a/cpp/src/arrow/ipc/metadata_internal.cc
+++ b/cpp/src/arrow/ipc/metadata_internal.cc
@@ -67,19 +67,19 @@ using FBString = flatbuffers::Offset<flatbuffers::String>;
 
 MetadataVersion GetMetadataVersion(flatbuf::MetadataVersion version) {
   switch (version) {
-    case flatbuf::MetadataVersion::V1:
+    case flatbuf::MetadataVersion::MetadataVersion_V1:
       // Arrow 0.1
       return MetadataVersion::V1;
-    case flatbuf::MetadataVersion::V2:
+    case flatbuf::MetadataVersion::MetadataVersion_V2:
       // Arrow 0.2
       return MetadataVersion::V2;
-    case flatbuf::MetadataVersion::V3:
+    case flatbuf::MetadataVersion::MetadataVersion_V3:
       // Arrow 0.3 to 0.7.1
       return MetadataVersion::V3;
-    case flatbuf::MetadataVersion::V4:
+    case flatbuf::MetadataVersion::MetadataVersion_V4:
       // Arrow 0.8 to 0.17
       return MetadataVersion::V4;
-    case flatbuf::MetadataVersion::V5:
+    case flatbuf::MetadataVersion::MetadataVersion_V5:
       // Arrow >= 1.0
       return MetadataVersion::V5;
     // Add cases as other versions become available
@@ -91,18 +91,18 @@ MetadataVersion GetMetadataVersion(flatbuf::MetadataVersion version) {
 flatbuf::MetadataVersion MetadataVersionToFlatbuffer(MetadataVersion version) {
   switch (version) {
     case MetadataVersion::V1:
-      return flatbuf::MetadataVersion::V1;
+      return flatbuf::MetadataVersion::MetadataVersion_V1;
     case MetadataVersion::V2:
-      return flatbuf::MetadataVersion::V2;
+      return flatbuf::MetadataVersion::MetadataVersion_V2;
     case MetadataVersion::V3:
-      return flatbuf::MetadataVersion::V3;
+      return flatbuf::MetadataVersion::MetadataVersion_V3;
     case MetadataVersion::V4:
-      return flatbuf::MetadataVersion::V4;
+      return flatbuf::MetadataVersion::MetadataVersion_V4;
     case MetadataVersion::V5:
-      return flatbuf::MetadataVersion::V5;
+      return flatbuf::MetadataVersion::MetadataVersion_V5;
     // Add cases as other versions become available
     default:
-      return flatbuf::MetadataVersion::V5;
+      return flatbuf::MetadataVersion::MetadataVersion_V5;
   }
 }
 
@@ -145,9 +145,9 @@ Status IntFromFlatbuffer(const flatbuf::Int* int_data, std::shared_ptr<DataType>
 
 Status FloatFromFlatbuffer(const flatbuf::FloatingPoint* float_data,
                            std::shared_ptr<DataType>* out) {
-  if (float_data->precision() == flatbuf::Precision::HALF) {
+  if (float_data->precision() == flatbuf::Precision::Precision_HALF) {
     *out = float16();
-  } else if (float_data->precision() == flatbuf::Precision::SINGLE) {
+  } else if (float_data->precision() == flatbuf::Precision::Precision_SINGLE) {
     *out = float32();
   } else {
     *out = float64();
@@ -170,8 +170,8 @@ Status UnionFromFlatbuffer(const flatbuf::Union* union_data,
                            const std::vector<std::shared_ptr<Field>>& children,
                            std::shared_ptr<DataType>* out) {
   UnionMode::type mode =
-      (union_data->mode() == flatbuf::UnionMode::Sparse ? UnionMode::SPARSE
-                                                        : UnionMode::DENSE);
+      (union_data->mode() == flatbuf::UnionMode::UnionMode_Sparse ? UnionMode::SPARSE
+                                                                  : UnionMode::DENSE);
 
   std::vector<int8_t> type_codes;
 
@@ -199,7 +199,7 @@ Status UnionFromFlatbuffer(const flatbuf::Union* union_data,
 }
 
 #define INT_TO_FB_CASE(BIT_WIDTH, IS_SIGNED)            \
-  *out_type = flatbuf::Type::Int;                       \
+  *out_type = flatbuf::Type::Type_Int;                  \
   *offset = IntToFlatbuffer(fbb, BIT_WIDTH, IS_SIGNED); \
   break;
 
@@ -208,28 +208,28 @@ Status UnionFromFlatbuffer(const flatbuf::Union* union_data,
 flatbuf::TimeUnit ToFlatbufferUnit(TimeUnit::type unit) {
   switch (unit) {
     case TimeUnit::SECOND:
-      return flatbuf::TimeUnit::SECOND;
+      return flatbuf::TimeUnit::TimeUnit_SECOND;
     case TimeUnit::MILLI:
-      return flatbuf::TimeUnit::MILLISECOND;
+      return flatbuf::TimeUnit::TimeUnit_MILLISECOND;
     case TimeUnit::MICRO:
-      return flatbuf::TimeUnit::MICROSECOND;
+      return flatbuf::TimeUnit::TimeUnit_MICROSECOND;
     case TimeUnit::NANO:
-      return flatbuf::TimeUnit::NANOSECOND;
+      return flatbuf::TimeUnit::TimeUnit_NANOSECOND;
     default:
       break;
   }
-  return flatbuf::TimeUnit::MIN;
+  return flatbuf::TimeUnit::TimeUnit_MIN;
 }
 
 TimeUnit::type FromFlatbufferUnit(flatbuf::TimeUnit unit) {
   switch (unit) {
-    case flatbuf::TimeUnit::SECOND:
+    case flatbuf::TimeUnit::TimeUnit_SECOND:
       return TimeUnit::SECOND;
-    case flatbuf::TimeUnit::MILLISECOND:
+    case flatbuf::TimeUnit::TimeUnit_MILLISECOND:
       return TimeUnit::MILLI;
-    case flatbuf::TimeUnit::MICROSECOND:
+    case flatbuf::TimeUnit::TimeUnit_MICROSECOND:
       return TimeUnit::MICRO;
-    case flatbuf::TimeUnit::NANOSECOND:
+    case flatbuf::TimeUnit::TimeUnit_NANOSECOND:
       return TimeUnit::NANO;
     default:
       break;
@@ -241,42 +241,42 @@ TimeUnit::type FromFlatbufferUnit(flatbuf::TimeUnit unit) {
 Status ConcreteTypeFromFlatbuffer(flatbuf::Type type, const void* type_data,
                                   FieldVector children, std::shared_ptr<DataType>* out) {
   switch (type) {
-    case flatbuf::Type::NONE:
+    case flatbuf::Type::Type_NONE:
       return Status::Invalid("Type metadata cannot be none");
-    case flatbuf::Type::Null:
+    case flatbuf::Type::Type_Null:
       *out = null();
       return Status::OK();
-    case flatbuf::Type::Int:
+    case flatbuf::Type::Type_Int:
       return IntFromFlatbuffer(static_cast<const flatbuf::Int*>(type_data), out);
-    case flatbuf::Type::FloatingPoint:
+    case flatbuf::Type::Type_FloatingPoint:
       return FloatFromFlatbuffer(static_cast<const flatbuf::FloatingPoint*>(type_data),
                                  out);
-    case flatbuf::Type::Binary:
+    case flatbuf::Type::Type_Binary:
       *out = binary();
       return Status::OK();
-    case flatbuf::Type::LargeBinary:
+    case flatbuf::Type::Type_LargeBinary:
       *out = large_binary();
       return Status::OK();
-    case flatbuf::Type::BinaryView:
+    case flatbuf::Type::Type_BinaryView:
       *out = binary_view();
       return Status::OK();
-    case flatbuf::Type::FixedSizeBinary: {
+    case flatbuf::Type::Type_FixedSizeBinary: {
       auto fw_binary = static_cast<const flatbuf::FixedSizeBinary*>(type_data);
       return FixedSizeBinaryType::Make(fw_binary->byteWidth()).Value(out);
     }
-    case flatbuf::Type::Utf8:
+    case flatbuf::Type::Type_Utf8:
       *out = utf8();
       return Status::OK();
-    case flatbuf::Type::LargeUtf8:
+    case flatbuf::Type::Type_LargeUtf8:
       *out = large_utf8();
       return Status::OK();
-    case flatbuf::Type::Utf8View:
+    case flatbuf::Type::Type_Utf8View:
       *out = utf8_view();
       return Status::OK();
-    case flatbuf::Type::Bool:
+    case flatbuf::Type::Type_Bool:
       *out = boolean();
       return Status::OK();
-    case flatbuf::Type::Decimal: {
+    case flatbuf::Type::Type_Decimal: {
       auto dec_type = static_cast<const flatbuf::Decimal*>(type_data);
       switch (dec_type->bitWidth()) {
         case 32:
@@ -292,16 +292,16 @@ Status ConcreteTypeFromFlatbuffer(flatbuf::Type type, const void* type_data,
       }
       return Status::Invalid("Library only supports 32/64/128/256-bit decimal values");
     }
-    case flatbuf::Type::Date: {
+    case flatbuf::Type::Type_Date: {
       auto date_type = static_cast<const flatbuf::Date*>(type_data);
-      if (date_type->unit() == flatbuf::DateUnit::DAY) {
+      if (date_type->unit() == flatbuf::DateUnit::DateUnit_DAY) {
         *out = date32();
       } else {
         *out = date64();
       }
       return Status::OK();
     }
-    case flatbuf::Type::Time: {
+    case flatbuf::Type::Type_Time: {
       auto time_type = static_cast<const flatbuf::Time*>(type_data);
       TimeUnit::type unit = FromFlatbufferUnit(time_type->unit());
       int32_t bit_width = time_type->bitWidth();
@@ -322,31 +322,31 @@ Status ConcreteTypeFromFlatbuffer(flatbuf::Type type, const void* type_data,
       }
       return Status::OK();
     }
-    case flatbuf::Type::Timestamp: {
+    case flatbuf::Type::Type_Timestamp: {
       auto ts_type = static_cast<const flatbuf::Timestamp*>(type_data);
       TimeUnit::type unit = FromFlatbufferUnit(ts_type->unit());
       *out = timestamp(unit, StringFromFlatbuffers(ts_type->timezone()));
       return Status::OK();
     }
-    case flatbuf::Type::Duration: {
+    case flatbuf::Type::Type_Duration: {
       auto duration = static_cast<const flatbuf::Duration*>(type_data);
       TimeUnit::type unit = FromFlatbufferUnit(duration->unit());
       *out = arrow::duration(unit);
       return Status::OK();
     }
 
-    case flatbuf::Type::Interval: {
+    case flatbuf::Type::Type_Interval: {
       auto i_type = static_cast<const flatbuf::Interval*>(type_data);
       switch (i_type->unit()) {
-        case flatbuf::IntervalUnit::YEAR_MONTH: {
+        case flatbuf::IntervalUnit::IntervalUnit_YEAR_MONTH: {
           *out = month_interval();
           return Status::OK();
         }
-        case flatbuf::IntervalUnit::DAY_TIME: {
+        case flatbuf::IntervalUnit::IntervalUnit_DAY_TIME: {
           *out = day_time_interval();
           return Status::OK();
         }
-        case flatbuf::IntervalUnit::MONTH_DAY_NANO: {
+        case flatbuf::IntervalUnit::IntervalUnit_MONTH_DAY_NANO: {
           *out = month_day_nano_interval();
           return Status::OK();
         }
@@ -354,31 +354,31 @@ Status ConcreteTypeFromFlatbuffer(flatbuf::Type type, const void* type_data,
       return Status::NotImplemented("Unrecognized interval type.");
     }
 
-    case flatbuf::Type::List:
+    case flatbuf::Type::Type_List:
       if (children.size() != 1) {
         return Status::Invalid("List must have exactly 1 child field");
       }
       *out = std::make_shared<ListType>(children[0]);
       return Status::OK();
-    case flatbuf::Type::LargeList:
+    case flatbuf::Type::Type_LargeList:
       if (children.size() != 1) {
         return Status::Invalid("LargeList must have exactly 1 child field");
       }
       *out = std::make_shared<LargeListType>(children[0]);
       return Status::OK();
-    case flatbuf::Type::ListView:
+    case flatbuf::Type::Type_ListView:
       if (children.size() != 1) {
         return Status::Invalid("ListView must have exactly 1 child field");
       }
       *out = std::make_shared<ListViewType>(children[0]);
       return Status::OK();
-    case flatbuf::Type::LargeListView:
+    case flatbuf::Type::Type_LargeListView:
       if (children.size() != 1) {
         return Status::Invalid("LargeListView must have exactly 1 child field");
       }
       *out = std::make_shared<LargeListViewType>(children[0]);
       return Status::OK();
-    case flatbuf::Type::Map:
+    case flatbuf::Type::Type_Map:
       if (children.size() != 1) {
         return Status::Invalid("Map must have exactly 1 child field");
       }
@@ -395,7 +395,7 @@ Status ConcreteTypeFromFlatbuffer(flatbuf::Type type, const void* type_data,
                                          map->keysSorted());
       }
       return Status::OK();
-    case flatbuf::Type::FixedSizeList:
+    case flatbuf::Type::Type_FixedSizeList:
       if (children.size() != 1) {
         return Status::Invalid("FixedSizeList must have exactly 1 child field");
       } else {
@@ -403,13 +403,13 @@ Status ConcreteTypeFromFlatbuffer(flatbuf::Type type, const void* type_data,
         *out = std::make_shared<FixedSizeListType>(children[0], fs_list->listSize());
       }
       return Status::OK();
-    case flatbuf::Type::Struct_:
+    case flatbuf::Type::Type_Struct_:
       *out = std::make_shared<StructType>(children);
       return Status::OK();
-    case flatbuf::Type::Union:
+    case flatbuf::Type::Type_Union:
       return UnionFromFlatbuffer(static_cast<const flatbuf::Union*>(type_data), children,
                                  out);
-    case flatbuf::Type::RunEndEncoded:
+    case flatbuf::Type::Type_RunEndEncoded:
       if (children.size() != 2) {
         return Status::Invalid("RunEndEncoded must have exactly 2 child fields");
       }
@@ -447,19 +447,19 @@ Status TensorTypeToFlatbuffer(FBB& fbb, const DataType& type, flatbuf::Type* out
     case Type::INT64:
       INT_TO_FB_CASE(64, true);
     case Type::HALF_FLOAT:
-      *out_type = flatbuf::Type::FloatingPoint;
-      *offset = FloatToFlatbuffer(fbb, flatbuf::Precision::HALF);
+      *out_type = flatbuf::Type::Type_FloatingPoint;
+      *offset = FloatToFlatbuffer(fbb, flatbuf::Precision::Precision_HALF);
       break;
     case Type::FLOAT:
-      *out_type = flatbuf::Type::FloatingPoint;
-      *offset = FloatToFlatbuffer(fbb, flatbuf::Precision::SINGLE);
+      *out_type = flatbuf::Type::Type_FloatingPoint;
+      *offset = FloatToFlatbuffer(fbb, flatbuf::Precision::Precision_SINGLE);
       break;
     case Type::DOUBLE:
-      *out_type = flatbuf::Type::FloatingPoint;
-      *offset = FloatToFlatbuffer(fbb, flatbuf::Precision::DOUBLE);
+      *out_type = flatbuf::Type::Type_FloatingPoint;
+      *offset = FloatToFlatbuffer(fbb, flatbuf::Precision::Precision_DOUBLE);
       break;
     default:
-      *out_type = flatbuf::Type::NONE;  // Make clang-tidy happy
+      *out_type = flatbuf::Type::Type_NONE;  // Make clang-tidy happy
       return Status::NotImplemented("Unable to convert type: ", type.ToString());
   }
   return Status::OK();
@@ -504,20 +504,20 @@ class FieldToFlatbufferVisitor {
   Status VisitType(const DataType& type) { return VisitTypeInline(type, this); }
 
   Status Visit(const NullType& type) {
-    fb_type_ = flatbuf::Type::Null;
+    fb_type_ = flatbuf::Type::Type_Null;
     type_offset_ = flatbuf::CreateNull(fbb_).Union();
     return Status::OK();
   }
 
   Status Visit(const BooleanType& type) {
-    fb_type_ = flatbuf::Type::Bool;
+    fb_type_ = flatbuf::Type::Type_Bool;
     type_offset_ = flatbuf::CreateBool(fbb_).Union();
     return Status::OK();
   }
 
   template <int BitWidth, bool IsSigned, typename T>
   Status Visit(const T& type) {
-    fb_type_ = flatbuf::Type::Int;
+    fb_type_ = flatbuf::Type::Type_Int;
     type_offset_ = IntToFlatbuffer(fbb_, BitWidth, IsSigned);
     return Status::OK();
   }
@@ -529,81 +529,82 @@ class FieldToFlatbufferVisitor {
   }
 
   Status Visit(const HalfFloatType& type) {
-    fb_type_ = flatbuf::Type::FloatingPoint;
-    type_offset_ = FloatToFlatbuffer(fbb_, flatbuf::Precision::HALF);
+    fb_type_ = flatbuf::Type::Type_FloatingPoint;
+    type_offset_ = FloatToFlatbuffer(fbb_, flatbuf::Precision::Precision_HALF);
     return Status::OK();
   }
 
   Status Visit(const FloatType& type) {
-    fb_type_ = flatbuf::Type::FloatingPoint;
-    type_offset_ = FloatToFlatbuffer(fbb_, flatbuf::Precision::SINGLE);
+    fb_type_ = flatbuf::Type::Type_FloatingPoint;
+    type_offset_ = FloatToFlatbuffer(fbb_, flatbuf::Precision::Precision_SINGLE);
     return Status::OK();
   }
 
   Status Visit(const DoubleType& type) {
-    fb_type_ = flatbuf::Type::FloatingPoint;
-    type_offset_ = FloatToFlatbuffer(fbb_, flatbuf::Precision::DOUBLE);
+    fb_type_ = flatbuf::Type::Type_FloatingPoint;
+    type_offset_ = FloatToFlatbuffer(fbb_, flatbuf::Precision::Precision_DOUBLE);
     return Status::OK();
   }
 
   Status Visit(const FixedSizeBinaryType& type) {
     const auto& fw_type = checked_cast<const FixedSizeBinaryType&>(type);
-    fb_type_ = flatbuf::Type::FixedSizeBinary;
+    fb_type_ = flatbuf::Type::Type_FixedSizeBinary;
     type_offset_ = flatbuf::CreateFixedSizeBinary(fbb_, fw_type.byte_width()).Union();
     return Status::OK();
   }
 
   Status Visit(const BinaryType& type) {
-    fb_type_ = flatbuf::Type::Binary;
+    fb_type_ = flatbuf::Type::Type_Binary;
     type_offset_ = flatbuf::CreateBinary(fbb_).Union();
     return Status::OK();
   }
 
   Status Visit(const BinaryViewType& type) {
-    fb_type_ = flatbuf::Type::BinaryView;
+    fb_type_ = flatbuf::Type::Type_BinaryView;
     type_offset_ = flatbuf::CreateBinaryView(fbb_).Union();
     return Status::OK();
   }
 
   Status Visit(const StringViewType& type) {
-    fb_type_ = flatbuf::Type::Utf8View;
+    fb_type_ = flatbuf::Type::Type_Utf8View;
     type_offset_ = flatbuf::CreateUtf8View(fbb_).Union();
     return Status::OK();
   }
 
   Status Visit(const LargeBinaryType& type) {
-    fb_type_ = flatbuf::Type::LargeBinary;
+    fb_type_ = flatbuf::Type::Type_LargeBinary;
     type_offset_ = flatbuf::CreateLargeBinary(fbb_).Union();
     return Status::OK();
   }
 
   Status Visit(const StringType& type) {
-    fb_type_ = flatbuf::Type::Utf8;
+    fb_type_ = flatbuf::Type::Type_Utf8;
     type_offset_ = flatbuf::CreateUtf8(fbb_).Union();
     return Status::OK();
   }
 
   Status Visit(const LargeStringType& type) {
-    fb_type_ = flatbuf::Type::LargeUtf8;
+    fb_type_ = flatbuf::Type::Type_LargeUtf8;
     type_offset_ = flatbuf::CreateLargeUtf8(fbb_).Union();
     return Status::OK();
   }
 
   Status Visit(const Date32Type& type) {
-    fb_type_ = flatbuf::Type::Date;
-    type_offset_ = flatbuf::CreateDate(fbb_, flatbuf::DateUnit::DAY).Union();
+    fb_type_ = flatbuf::Type::Type_Date;
+    type_offset_ = flatbuf::CreateDate(fbb_, flatbuf::DateUnit::DateUnit_DAY).Union();
     return Status::OK();
   }
 
   Status Visit(const Date64Type& type) {
-    fb_type_ = flatbuf::Type::Date;
-    type_offset_ = flatbuf::CreateDate(fbb_, flatbuf::DateUnit::MILLISECOND).Union();
+    fb_type_ = flatbuf::Type::Type_Date;
+    type_offset_ =
+        flatbuf::CreateDate(fbb_, flatbuf::DateUnit::DateUnit_MILLISECOND).Union();
     return Status::OK();
   }
 
   Status Visit(const Time32Type& type) {
     const auto& time_type = checked_cast<const Time32Type&>(type);
-    fb_type_ = flatbuf::Type::Time;
+    fb_type_ = flatbuf::Type::Type_Time;
     type_offset_ =
         flatbuf::CreateTime(fbb_, ToFlatbufferUnit(time_type.unit()), 32).Union();
     return Status::OK();
@@ -611,7 +612,7 @@ class FieldToFlatbufferVisitor {
 
   Status Visit(const Time64Type& type) {
     const auto& time_type = checked_cast<const Time64Type&>(type);
-    fb_type_ = flatbuf::Type::Time;
+    fb_type_ = flatbuf::Type::Type_Time;
     type_offset_ =
         flatbuf::CreateTime(fbb_, ToFlatbufferUnit(time_type.unit()), 64).Union();
     return Status::OK();
@@ -619,7 +620,7 @@ class FieldToFlatbufferVisitor {
 
   Status Visit(const TimestampType& type) {
     const auto& ts_type = checked_cast<const TimestampType&>(type);
-    fb_type_ = flatbuf::Type::Timestamp;
+    fb_type_ = flatbuf::Type::Type_Timestamp;
     flatbuf::TimeUnit fb_unit = ToFlatbufferUnit(ts_type.unit());
     FBString fb_timezone = 0;
     if (ts_type.timezone().size() > 0) {
@@ -630,35 +631,39 @@ class FieldToFlatbufferVisitor {
   }
 
   Status Visit(const DurationType& type) {
-    fb_type_ = flatbuf::Type::Duration;
+    fb_type_ = flatbuf::Type::Type_Duration;
     flatbuf::TimeUnit fb_unit = ToFlatbufferUnit(type.unit());
     type_offset_ = flatbuf::CreateDuration(fbb_, fb_unit).Union();
     return Status::OK();
   }
 
   Status Visit(const DayTimeIntervalType& type) {
-    fb_type_ = flatbuf::Type::Interval;
-    type_offset_ = flatbuf::CreateInterval(fbb_, flatbuf::IntervalUnit::DAY_TIME).Union();
+    fb_type_ = flatbuf::Type::Type_Interval;
+    type_offset_ =
+        flatbuf::CreateInterval(fbb_, flatbuf::IntervalUnit::IntervalUnit_DAY_TIME)
+            .Union();
     return Status::OK();
   }
 
   Status Visit(const MonthDayNanoIntervalType& type) {
-    fb_type_ = flatbuf::Type::Interval;
+    fb_type_ = flatbuf::Type::Type_Interval;
     type_offset_ =
-        flatbuf::CreateInterval(fbb_, flatbuf::IntervalUnit::MONTH_DAY_NANO).Union();
+        flatbuf::CreateInterval(fbb_, flatbuf::IntervalUnit::IntervalUnit_MONTH_DAY_NANO)
+            .Union();
     return Status::OK();
   }
 
   Status Visit(const MonthIntervalType& type) {
-    fb_type_ = flatbuf::Type::Interval;
+    fb_type_ = flatbuf::Type::Type_Interval;
     type_offset_ =
-        flatbuf::CreateInterval(fbb_, flatbuf::IntervalUnit::YEAR_MONTH).Union();
+        flatbuf::CreateInterval(fbb_, flatbuf::IntervalUnit::IntervalUnit_YEAR_MONTH)
+            .Union();
     return Status::OK();
   }
 
   Status Visit(const Decimal32Type& type) {
     const auto& dec_type = checked_cast<const Decimal32Type&>(type);
-    fb_type_ = flatbuf::Type::Decimal;
+    fb_type_ = flatbuf::Type::Type_Decimal;
     type_offset_ = flatbuf::CreateDecimal(fbb_, dec_type.precision(), dec_type.scale(),
                                           /*bitWidth=*/32)
                        .Union();
@@ -667,7 +672,7 @@ class FieldToFlatbufferVisitor {
 
   Status Visit(const Decimal64Type& type) {
     const auto& dec_type = checked_cast<const Decimal64Type&>(type);
-    fb_type_ = flatbuf::Type::Decimal;
+    fb_type_ = flatbuf::Type::Type_Decimal;
     type_offset_ = flatbuf::CreateDecimal(fbb_, dec_type.precision(), dec_type.scale(),
                                           /*bitWidth=*/64)
                        .Union();
@@ -676,7 +681,7 @@ class FieldToFlatbufferVisitor {
 
   Status Visit(const Decimal128Type& type) {
     const auto& dec_type = checked_cast<const Decimal128Type&>(type);
-    fb_type_ = flatbuf::Type::Decimal;
+    fb_type_ = flatbuf::Type::Type_Decimal;
     type_offset_ = flatbuf::CreateDecimal(fbb_, dec_type.precision(), dec_type.scale(),
                                           /*bitWidth=*/128)
                        .Union();
@@ -685,7 +690,7 @@ class FieldToFlatbufferVisitor {
 
   Status Visit(const Decimal256Type& type) {
     const auto& dec_type = checked_cast<const Decimal256Type&>(type);
-    fb_type_ = flatbuf::Type::Decimal;
+    fb_type_ = flatbuf::Type::Type_Decimal;
     type_offset_ = flatbuf::CreateDecimal(fbb_, dec_type.precision(), dec_type.scale(),
                                           /*bitWith=*/256)
                        .Union();
@@ -693,63 +698,63 @@ class FieldToFlatbufferVisitor {
   }
 
   Status Visit(const ListType& type) {
-    fb_type_ = flatbuf::Type::List;
+    fb_type_ = flatbuf::Type::Type_List;
     RETURN_NOT_OK(VisitChildFields(type));
     type_offset_ = flatbuf::CreateList(fbb_).Union();
     return Status::OK();
   }
 
   Status Visit(const LargeListType& type) {
-    fb_type_ = flatbuf::Type::LargeList;
+    fb_type_ = flatbuf::Type::Type_LargeList;
     RETURN_NOT_OK(VisitChildFields(type));
     type_offset_ = flatbuf::CreateLargeList(fbb_).Union();
     return Status::OK();
   }
 
   Status Visit(const ListViewType& type) {
-    fb_type_ = flatbuf::Type::ListView;
+    fb_type_ = flatbuf::Type::Type_ListView;
     RETURN_NOT_OK(VisitChildFields(type));
     type_offset_ = flatbuf::CreateListView(fbb_).Union();
     return Status::OK();
   }
 
   Status Visit(const LargeListViewType& type) {
-    fb_type_ = flatbuf::Type::LargeListView;
+    fb_type_ = flatbuf::Type::Type_LargeListView;
     RETURN_NOT_OK(VisitChildFields(type));
     type_offset_ = flatbuf::CreateListView(fbb_).Union();
     return Status::OK();
   }
 
   Status Visit(const MapType& type) {
-    fb_type_ = flatbuf::Type::Map;
+    fb_type_ = flatbuf::Type::Type_Map;
     RETURN_NOT_OK(VisitChildFields(type));
     type_offset_ = flatbuf::CreateMap(fbb_, type.keys_sorted()).Union();
     return Status::OK();
   }
 
   Status Visit(const FixedSizeListType& type) {
-    fb_type_ = flatbuf::Type::FixedSizeList;
+    fb_type_ = flatbuf::Type::Type_FixedSizeList;
     RETURN_NOT_OK(VisitChildFields(type));
     type_offset_ = flatbuf::CreateFixedSizeList(fbb_, type.list_size()).Union();
     return Status::OK();
   }
 
   Status Visit(const StructType& type) {
-    fb_type_ = flatbuf::Type::Struct_;
+    fb_type_ = flatbuf::Type::Type_Struct_;
     RETURN_NOT_OK(VisitChildFields(type));
     type_offset_ = flatbuf::CreateStruct_(fbb_).Union();
     return Status::OK();
   }
 
   Status Visit(const UnionType& type) {
-    fb_type_ = flatbuf::Type::Union;
+    fb_type_ = flatbuf::Type::Type_Union;
     RETURN_NOT_OK(VisitChildFields(type));
 
     const auto& union_type = checked_cast<const UnionType&>(type);
 
     flatbuf::UnionMode mode = union_type.mode() == UnionMode::SPARSE
-                                  ? flatbuf::UnionMode::Sparse
-                                  : flatbuf::UnionMode::Dense;
+                                  ? flatbuf::UnionMode::UnionMode_Sparse
+                                  : flatbuf::UnionMode::UnionMode_Dense;
 
     std::vector<int32_t> type_ids;
     type_ids.reserve(union_type.type_codes().size());
@@ -771,7 +776,7 @@ class FieldToFlatbufferVisitor {
   }
 
   Status Visit(const RunEndEncodedType& type) {
-    fb_type_ = flatbuf::Type::RunEndEncoded;
+    fb_type_ = flatbuf::Type::Type_RunEndEncoded;
     RETURN_NOT_OK(VisitChildFields(type));
     type_offset_ = flatbuf::CreateRunEndEncoded(fbb_).Union();
     return Status::OK();
@@ -936,7 +941,8 @@ flatbuf::Endianness endianness() {
     char c[4];
   } bint = {0x01020304};
 
-  return bint.c[0] == 1 ? flatbuf::Endianness::Big : flatbuf::Endianness::Little;
+  return bint.c[0] == 1 ? flatbuf::Endianness::Endianness_Big
+                        : flatbuf::Endianness::Endianness_Little;
 }
 
 flatbuffers::Offset<KVVector> SerializeCustomMetadata(
@@ -1020,15 +1026,15 @@ static Status GetBodyCompression(FBB& fbb, const IpcWriteOptions& options,
   if (options.codec != nullptr) {
     flatbuf::CompressionType codec;
     if (options.codec->compression_type() == Compression::LZ4_FRAME) {
-      codec = flatbuf::CompressionType::LZ4_FRAME;
+      codec = flatbuf::CompressionType::CompressionType_LZ4_FRAME;
     } else if (options.codec->compression_type() == Compression::ZSTD) {
-      codec = flatbuf::CompressionType::ZSTD;
+      codec = flatbuf::CompressionType::CompressionType_ZSTD;
     } else {
       return Status::Invalid("Unsupported IPC compression codec: ",
                              options.codec->name());
     }
-    *out = flatbuf::CreateBodyCompression(fbb, codec,
-                                          flatbuf::BodyCompressionMethod::BUFFER);
+    *out = flatbuf::CreateBodyCompression(
+        fbb, codec, flatbuf::BodyCompressionMethod::BodyCompressionMethod_BUFFER);
   }
   return Status::OK();
 }
@@ -1061,7 +1067,8 @@ Status MakeSparseTensorIndexCOO(FBB& fbb, const SparseCOOIndex& sparse_index,
                                 const std::vector<BufferMetadata>& buffers,
                                 flatbuf::SparseTensorIndex* fb_sparse_index_type,
                                 Offset* fb_sparse_index, size_t* num_buffers) {
-  *fb_sparse_index_type = flatbuf::SparseTensorIndex::SparseTensorIndexCOO;
+  *fb_sparse_index_type =
+      flatbuf::SparseTensorIndex::SparseTensorIndex_SparseTensorIndexCOO;
 
   // We assume that the value type of indices tensor is an integer.
   const auto& index_value_type =
@@ -1088,12 +1095,14 @@ struct SparseMatrixCompressedAxis {};
 
 template <>
 struct SparseMatrixCompressedAxis<SparseCSRIndex> {
-  constexpr static const auto value = flatbuf::SparseMatrixCompressedAxis::Row;
+  constexpr static const auto value =
+      flatbuf::SparseMatrixCompressedAxis::SparseMatrixCompressedAxis_Row;
 };
 
 template <>
 struct SparseMatrixCompressedAxis<SparseCSCIndex> {
-  constexpr static const auto value = flatbuf::SparseMatrixCompressedAxis::Column;
+  constexpr static const auto value =
+      flatbuf::SparseMatrixCompressedAxis::SparseMatrixCompressedAxis_Column;
 };
 
 template <typename SparseIndexType>
@@ -1101,7 +1110,8 @@ Status MakeSparseMatrixIndexCSX(FBB& fbb, const SparseIndexType& sparse_index,
                                 const std::vector<BufferMetadata>& buffers,
                                 flatbuf::SparseTensorIndex* fb_sparse_index_type,
                                 Offset* fb_sparse_index, size_t* num_buffers) {
-  *fb_sparse_index_type = flatbuf::SparseTensorIndex::SparseMatrixIndexCSX;
+  *fb_sparse_index_type =
+      flatbuf::SparseTensorIndex::SparseTensorIndex_SparseMatrixIndexCSX;
 
   // We assume that the value type of indptr tensor is an integer.
   const auto& indptr_value_type =
@@ -1134,7 +1144,8 @@ Status MakeSparseTensorIndexCSF(FBB& fbb, const SparseCSFIndex& sparse_index,
                                 const std::vector<BufferMetadata>& buffers,
                                 flatbuf::SparseTensorIndex* fb_sparse_index_type,
                                 Offset* fb_sparse_index, size_t* num_buffers) {
-  *fb_sparse_index_type = flatbuf::SparseTensorIndex::SparseTensorIndexCSF;
+  *fb_sparse_index_type =
+      flatbuf::SparseTensorIndex::SparseTensorIndex_SparseTensorIndexCSF;
   const int ndim = static_cast<int>(sparse_index.axis_order().size());
 
   // We assume that the value type of indptr tensor is an integer.
@@ -1218,7 +1229,8 @@ Status MakeSparseTensorIndex(FBB& fbb, const SparseIndex& sparse_index,
       break;
 
     default:
-      *fb_sparse_index_type = flatbuf::SparseTensorIndex::NONE;  // Silence warnings
+      *fb_sparse_index_type =
+          flatbuf::SparseTensorIndex::SparseTensorIndex_NONE;  // Silence warnings
       std::stringstream ss;
       ss << "Unsupported sparse tensor format:: " << sparse_index.ToString() << std::endl;
       return Status::NotImplemented(ss.str());
@@ -1290,7 +1302,8 @@ Status WriteSchemaMessage(const Schema& schema, const DictionaryFieldMapper& map
   FBB fbb;
   flatbuffers::Offset<flatbuf::Schema> fb_schema;
   RETURN_NOT_OK(SchemaToFlatbuffer(fbb, schema, mapper, &fb_schema));
-  return WriteFBMessage(fbb, flatbuf::MessageHeader::Schema, fb_schema.Union(),
+  return WriteFBMessage(fbb, flatbuf::MessageHeader::MessageHeader_Schema,
+                        fb_schema.Union(),
                         /*body_length=*/0, options.metadata_version,
                         /*custom_metadata=*/nullptr, options.memory_pool)
       .Value(out);
@@ -1306,9 +1319,9 @@ Status WriteRecordBatchMessage(
   RecordBatchOffset record_batch;
   RETURN_NOT_OK(MakeRecordBatch(fbb, length, body_length, nodes, buffers,
                                 variadic_buffer_counts, options, &record_batch));
-  return WriteFBMessage(fbb, flatbuf::MessageHeader::RecordBatch, record_batch.Union(),
-                        body_length, options.metadata_version, custom_metadata,
-                        options.memory_pool)
+  return WriteFBMessage(fbb, flatbuf::MessageHeader::MessageHeader_RecordBatch,
+                        record_batch.Union(), body_length, options.metadata_version,
+                        custom_metadata, options.memory_pool)
       .Value(out);
 }
 
@@ -1341,8 +1354,8 @@ Result<std::shared_ptr<Buffer>> WriteTensorMessage(const Tensor& tensor,
   TensorOffset fb_tensor =
       flatbuf::CreateTensor(fbb, fb_type_type, fb_type, fb_shape, fb_strides, &buffer);
 
-  return WriteFBMessage(fbb, flatbuf::MessageHeader::Tensor, fb_tensor.Union(),
-                        body_length, options.metadata_version,
+  return WriteFBMessage(fbb, flatbuf::MessageHeader::MessageHeader_Tensor,
+                        fb_tensor.Union(), body_length, options.metadata_version,
                         /*custom_metadata=*/nullptr, options.memory_pool);
 }
 
@@ -1353,7 +1366,7 @@ Result<std::shared_ptr<Buffer>> WriteSparseTensorMessage(
   SparseTensorOffset fb_sparse_tensor;
   RETURN_NOT_OK(
       MakeSparseTensor(fbb, sparse_tensor, body_length, buffers, &fb_sparse_tensor));
-  return WriteFBMessage(fbb, flatbuf::MessageHeader::SparseTensor,
+  return WriteFBMessage(fbb, flatbuf::MessageHeader::MessageHeader_SparseTensor,
                         fb_sparse_tensor.Union(), body_length, options.metadata_version,
                         /*custom_metadata=*/nullptr, options.memory_pool);
 }
@@ -1370,9 +1383,9 @@ Status WriteDictionaryMessage(
                                 variadic_buffer_counts, options, &record_batch));
   auto dictionary_batch =
       flatbuf::CreateDictionaryBatch(fbb, id, record_batch, is_delta).Union();
-  return WriteFBMessage(fbb, flatbuf::MessageHeader::DictionaryBatch, dictionary_batch,
-                        body_length, options.metadata_version, custom_metadata,
-                        options.memory_pool)
+  return WriteFBMessage(fbb, flatbuf::MessageHeader::MessageHeader_DictionaryBatch,
+                        dictionary_batch, body_length, options.metadata_version,
+                        custom_metadata, options.memory_pool)
       .Value(out);
 }
 
@@ -1449,7 +1462,7 @@ Status GetSchema(const void* opaque_schema, DictionaryMemo* dictionary_memo,
   std::shared_ptr<KeyValueMetadata> metadata;
   RETURN_NOT_OK(internal::GetKeyValueMetadata(schema->custom_metadata(), &metadata));
   // set endianness using the value in flatbuf schema
-  auto endianness = schema->endianness() == flatbuf::Endianness::Little
+  auto endianness = schema->endianness() == flatbuf::Endianness::Endianness_Little
                         ? Endianness::Little
                         : Endianness::Big;
   *out = ::arrow::schema(std::move(fields), endianness, metadata);
@@ -1554,18 +1567,18 @@ Status GetSparseTensorMetadata(const Buffer& metadata, std::shared_ptr<DataType>
 
   if (sparse_tensor_format_id) {
     switch (sparse_tensor->sparseIndex_type()) {
-      case flatbuf::SparseTensorIndex::SparseTensorIndexCOO:
+      case flatbuf::SparseTensorIndex::SparseTensorIndex_SparseTensorIndexCOO:
         *sparse_tensor_format_id = SparseTensorFormat::COO;
         break;
 
-      case flatbuf::SparseTensorIndex::SparseMatrixIndexCSX: {
+      case flatbuf::SparseTensorIndex::SparseTensorIndex_SparseMatrixIndexCSX: {
         auto cs = sparse_tensor->sparseIndex_as_SparseMatrixIndexCSX();
         switch (cs->compressedAxis()) {
-          case flatbuf::SparseMatrixCompressedAxis::Row:
+          case flatbuf::SparseMatrixCompressedAxis::SparseMatrixCompressedAxis_Row:
             *sparse_tensor_format_id = SparseTensorFormat::CSR;
             break;
 
-          case flatbuf::SparseMatrixCompressedAxis::Column:
+          case flatbuf::SparseMatrixCompressedAxis::SparseMatrixCompressedAxis_Column:
             *sparse_tensor_format_id = SparseTensorFormat::CSC;
             break;
 
@@ -1574,7 +1587,7 @@ Status GetSparseTensorMetadata(const Buffer& metadata, std::shared_ptr<DataType>
         }
       } break;
 
-      case flatbuf::SparseTensorIndex::SparseTensorIndexCSF:
+      case flatbuf::SparseTensorIndex::SparseTensorIndex_SparseTensorIndexCSF:
         *sparse_tensor_format_id = SparseTensorFormat::CSF;
         break;
 

--- a/cpp/src/arrow/ipc/metadata_internal.h
+++ b/cpp/src/arrow/ipc/metadata_internal.h
@@ -60,13 +60,13 @@ using KVVector = flatbuffers::Vector<KeyValueOffset>;
 constexpr int32_t kIpcContinuationToken = -1;
 
 static constexpr flatbuf::MetadataVersion kCurrentMetadataVersion =
-    flatbuf::MetadataVersion::V5;
+    flatbuf::MetadataVersion::MetadataVersion_V5;
 
 static constexpr flatbuf::MetadataVersion kLatestMetadataVersion =
-    flatbuf::MetadataVersion::V5;
+    flatbuf::MetadataVersion::MetadataVersion_V5;
 
 static constexpr flatbuf::MetadataVersion kMinMetadataVersion =
-    flatbuf::MetadataVersion::V4;
+    flatbuf::MetadataVersion::MetadataVersion_V4;
 
 // These functions are used in unit tests
 ARROW_EXPORT

--- a/cpp/src/arrow/ipc/read_write_test.cc
+++ b/cpp/src/arrow/ipc/read_write_test.cc
@@ -119,7 +119,8 @@ TEST_P(TestMessage, SerializeTo) {
   const int64_t body_length = 64;
 
   flatbuffers::FlatBufferBuilder fbb;
-  fbb.Finish(flatbuf::CreateMessage(fbb, fb_version_, flatbuf::MessageHeader::RecordBatch,
+  fbb.Finish(flatbuf::CreateMessage(fbb, fb_version_,
+                                    flatbuf::MessageHeader::MessageHeader_RecordBatch,
                                     0 /* header */, body_length));
 
   std::shared_ptr<Buffer> metadata;
@@ -521,7 +522,8 @@ class IpcTestFixture : public io::MemoryMapFixture, public ExtensionTypesMixin {
 
 TEST(MetadataVersion, ForwardsCompatCheck) {
   // Verify UBSAN is ok with casting out of range metadata version.
-  EXPECT_LT(flatbuf::MetadataVersion::MAX, static_cast<flatbuf::MetadataVersion>(72));
+  EXPECT_LT(flatbuf::MetadataVersion::MetadataVersion_MAX,
+            static_cast<flatbuf::MetadataVersion>(72));
 }
 
 class TestWriteRecordBatch : public ::testing::Test, public IpcTestFixture {
@@ -589,20 +591,20 @@ TEST(TestReadMessage, CorruptedSmallInput) {
 }
 
 TEST(TestMetadata, GetMetadataVersion) {
-  ASSERT_EQ(MetadataVersion::V1,
-            ipc::internal::GetMetadataVersion(flatbuf::MetadataVersion::V1));
-  ASSERT_EQ(MetadataVersion::V2,
-            ipc::internal::GetMetadataVersion(flatbuf::MetadataVersion::V2));
-  ASSERT_EQ(MetadataVersion::V3,
-            ipc::internal::GetMetadataVersion(flatbuf::MetadataVersion::V3));
-  ASSERT_EQ(MetadataVersion::V4,
-            ipc::internal::GetMetadataVersion(flatbuf::MetadataVersion::V4));
-  ASSERT_EQ(MetadataVersion::V5,
-            ipc::internal::GetMetadataVersion(flatbuf::MetadataVersion::V5));
-  ASSERT_EQ(MetadataVersion::V1,
-            ipc::internal::GetMetadataVersion(flatbuf::MetadataVersion::MIN));
-  ASSERT_EQ(MetadataVersion::V5,
-            ipc::internal::GetMetadataVersion(flatbuf::MetadataVersion::MAX));
+  ASSERT_EQ(MetadataVersion::V1, ipc::internal::GetMetadataVersion(
+                                     flatbuf::MetadataVersion::MetadataVersion_V1));
+  ASSERT_EQ(MetadataVersion::V2, ipc::internal::GetMetadataVersion(
+                                     flatbuf::MetadataVersion::MetadataVersion_V2));
+  ASSERT_EQ(MetadataVersion::V3, ipc::internal::GetMetadataVersion(
+                                     flatbuf::MetadataVersion::MetadataVersion_V3));
+  ASSERT_EQ(MetadataVersion::V4, ipc::internal::GetMetadataVersion(
+                                     flatbuf::MetadataVersion::MetadataVersion_V4));
+  ASSERT_EQ(MetadataVersion::V5, ipc::internal::GetMetadataVersion(
+                                     flatbuf::MetadataVersion::MetadataVersion_V5));
+  ASSERT_EQ(MetadataVersion::V1, ipc::internal::GetMetadataVersion(
+                                     flatbuf::MetadataVersion::MetadataVersion_MIN));
+  ASSERT_EQ(MetadataVersion::V5, ipc::internal::GetMetadataVersion(
+                                     flatbuf::MetadataVersion::MetadataVersion_MAX));
 }
 
 TEST_P(TestIpcRoundTrip, SliceRoundTrip) {

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -659,14 +659,15 @@ Status GetCompression(const flatbuf::RecordBatch* batch, Compression::type* out)
   *out = Compression::UNCOMPRESSED;
   const flatbuf::BodyCompression* compression = batch->compression();
   if (compression != nullptr) {
-    if (compression->method() != flatbuf::BodyCompressionMethod::BUFFER) {
+    if (compression->method() !=
+        flatbuf::BodyCompressionMethod::BodyCompressionMethod_BUFFER) {
       // Forward compatibility
       return Status::Invalid("This library only supports BUFFER compression method");
     }
 
-    if (compression->codec() == flatbuf::CompressionType::LZ4_FRAME) {
+    if (compression->codec() == flatbuf::CompressionType::CompressionType_LZ4_FRAME) {
       *out = Compression::LZ4_FRAME;
-    } else if (compression->codec() == flatbuf::CompressionType::ZSTD) {
+    } else if (compression->codec() == flatbuf::CompressionType::CompressionType_ZSTD) {
       *out = Compression::ZSTD;
     } else {
       return Status::Invalid("Unsupported codec in RecordBatch::compression metadata");
@@ -717,7 +718,7 @@ Result<RecordBatchWithMetadata> ReadRecordBatchInternal(
   Compression::type compression;
   RETURN_NOT_OK(GetCompression(batch, &compression));
   if (context.compression == Compression::UNCOMPRESSED &&
-      message->version() == flatbuf::MetadataVersion::V4) {
+      message->version() == flatbuf::MetadataVersion::MetadataVersion_V4) {
     // Possibly obtain codec information from experimental serialization format
     // in 0.17.x
     RETURN_NOT_OK(GetCompressionExperimental(message, &compression));
@@ -820,7 +821,7 @@ Status ReadDictionary(const Buffer& metadata, const IpcReadContext& context,
   Compression::type compression;
   RETURN_NOT_OK(GetCompression(batch_meta, &compression));
   if (compression == Compression::UNCOMPRESSED &&
-      message->version() == flatbuf::MetadataVersion::V4) {
+      message->version() == flatbuf::MetadataVersion::MetadataVersion_V4) {
     // Possibly obtain codec information from experimental serialization format
     // in 0.17.x
     RETURN_NOT_OK(GetCompressionExperimental(message, &compression));
@@ -1626,7 +1627,7 @@ class RecordBatchFileReaderImpl : public RecordBatchFileReader {
     Compression::type compression;
     RETURN_NOT_OK(GetCompression(batch, &compression));
     if (context.compression == Compression::UNCOMPRESSED &&
-        message->version() == flatbuf::MetadataVersion::V4) {
+        message->version() == flatbuf::MetadataVersion::MetadataVersion_V4) {
       // Possibly obtain codec information from experimental serialization format
       // in 0.17.x
       RETURN_NOT_OK(GetCompressionExperimental(message, &compression));
@@ -2258,7 +2259,7 @@ Result<std::shared_ptr<SparseIndex>> ReadSparseCSXIndex(
   }
 
   switch (sparse_index->compressedAxis()) {
-    case flatbuf::SparseMatrixCompressedAxis::Row: {
+    case flatbuf::SparseMatrixCompressedAxis::SparseMatrixCompressedAxis_Row: {
       std::vector<int64_t> indptr_shape({shape[0] + 1});
       const int64_t indptr_minimum_bytes = indptr_shape[0] * indptr_byte_width;
       if (indptr_minimum_bytes > indptr_buffer->length()) {
@@ -2268,7 +2269,7 @@ Result<std::shared_ptr<SparseIndex>> ReadSparseCSXIndex(
           std::make_shared<Tensor>(indptr_type, indptr_data, indptr_shape),
           std::make_shared<Tensor>(indices_type, indices_data, indices_shape));
     }
-    case flatbuf::SparseMatrixCompressedAxis::Column: {
+    case flatbuf::SparseMatrixCompressedAxis::SparseMatrixCompressedAxis_Column: {
       std::vector<int64_t> indptr_shape({shape[1] + 1});
       const int64_t indptr_minimum_bytes = indptr_shape[0] * indptr_byte_width;
       if (indptr_minimum_bytes > indptr_buffer->length()) {

--- a/cpp/src/generated/File_generated.h
+++ b/cpp/src/generated/File_generated.h
@@ -8,9 +8,9 @@
 
 // Ensure the included flatbuffers.h is the same version as when this file was
 // generated, otherwise it may not be compatible.
-static_assert(FLATBUFFERS_VERSION_MAJOR == 23 &&
-              FLATBUFFERS_VERSION_MINOR == 5 &&
-              FLATBUFFERS_VERSION_REVISION == 26,
+static_assert(FLATBUFFERS_VERSION_MAJOR == 24 &&
+              FLATBUFFERS_VERSION_MINOR == 3 &&
+              FLATBUFFERS_VERSION_REVISION == 6,
              "Non-compatible flatbuffers version included");
 
 #include "Schema_generated.h"
@@ -139,7 +139,7 @@ struct FooterBuilder {
 
 inline ::flatbuffers::Offset<Footer> CreateFooter(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    org::apache::arrow::flatbuf::MetadataVersion version = org::apache::arrow::flatbuf::MetadataVersion::V1,
+    org::apache::arrow::flatbuf::MetadataVersion version = org::apache::arrow::flatbuf::MetadataVersion_V1,
     ::flatbuffers::Offset<org::apache::arrow::flatbuf::Schema> schema = 0,
     ::flatbuffers::Offset<::flatbuffers::Vector<const org::apache::arrow::flatbuf::Block *>> dictionaries = 0,
     ::flatbuffers::Offset<::flatbuffers::Vector<const org::apache::arrow::flatbuf::Block *>> recordBatches = 0,
@@ -155,7 +155,7 @@ inline ::flatbuffers::Offset<Footer> CreateFooter(
 
 inline ::flatbuffers::Offset<Footer> CreateFooterDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    org::apache::arrow::flatbuf::MetadataVersion version = org::apache::arrow::flatbuf::MetadataVersion::V1,
+    org::apache::arrow::flatbuf::MetadataVersion version = org::apache::arrow::flatbuf::MetadataVersion_V1,
     ::flatbuffers::Offset<org::apache::arrow::flatbuf::Schema> schema = 0,
     const std::vector<org::apache::arrow::flatbuf::Block> *dictionaries = nullptr,
     const std::vector<org::apache::arrow::flatbuf::Block> *recordBatches = nullptr,

--- a/cpp/src/generated/Message_generated.h
+++ b/cpp/src/generated/Message_generated.h
@@ -8,9 +8,9 @@
 
 // Ensure the included flatbuffers.h is the same version as when this file was
 // generated, otherwise it may not be compatible.
-static_assert(FLATBUFFERS_VERSION_MAJOR == 23 &&
-              FLATBUFFERS_VERSION_MINOR == 5 &&
-              FLATBUFFERS_VERSION_REVISION == 26,
+static_assert(FLATBUFFERS_VERSION_MAJOR == 24 &&
+              FLATBUFFERS_VERSION_MINOR == 3 &&
+              FLATBUFFERS_VERSION_REVISION == 6,
              "Non-compatible flatbuffers version included");
 
 #include "Schema_generated.h"
@@ -36,17 +36,17 @@ struct DictionaryBatchBuilder;
 struct Message;
 struct MessageBuilder;
 
-enum class CompressionType : int8_t {
-  LZ4_FRAME = 0,
-  ZSTD = 1,
-  MIN = LZ4_FRAME,
-  MAX = ZSTD
+enum CompressionType : int8_t {
+  CompressionType_LZ4_FRAME = 0,
+  CompressionType_ZSTD = 1,
+  CompressionType_MIN = CompressionType_LZ4_FRAME,
+  CompressionType_MAX = CompressionType_ZSTD
 };
 
 inline const CompressionType (&EnumValuesCompressionType())[2] {
   static const CompressionType values[] = {
-    CompressionType::LZ4_FRAME,
-    CompressionType::ZSTD
+    CompressionType_LZ4_FRAME,
+    CompressionType_ZSTD
   };
   return values;
 }
@@ -61,7 +61,7 @@ inline const char * const *EnumNamesCompressionType() {
 }
 
 inline const char *EnumNameCompressionType(CompressionType e) {
-  if (::flatbuffers::IsOutRange(e, CompressionType::LZ4_FRAME, CompressionType::ZSTD)) return "";
+  if (::flatbuffers::IsOutRange(e, CompressionType_LZ4_FRAME, CompressionType_ZSTD)) return "";
   const size_t index = static_cast<size_t>(e);
   return EnumNamesCompressionType()[index];
 }
@@ -69,7 +69,7 @@ inline const char *EnumNameCompressionType(CompressionType e) {
 /// Provided for forward compatibility in case we need to support different
 /// strategies for compressing the IPC message body (like whole-body
 /// compression rather than buffer-level) in the future
-enum class BodyCompressionMethod : int8_t {
+enum BodyCompressionMethod : int8_t {
   /// Each constituent buffer is first compressed with the indicated
   /// compressor, and then written with the uncompressed length in the first 8
   /// bytes as a 64-bit little-endian signed integer followed by the compressed
@@ -77,14 +77,14 @@ enum class BodyCompressionMethod : int8_t {
   /// uncompressed length may be set to -1 to indicate that the data that
   /// follows is not compressed, which can be useful for cases where
   /// compression does not yield appreciable savings.
-  BUFFER = 0,
-  MIN = BUFFER,
-  MAX = BUFFER
+  BodyCompressionMethod_BUFFER = 0,
+  BodyCompressionMethod_MIN = BodyCompressionMethod_BUFFER,
+  BodyCompressionMethod_MAX = BodyCompressionMethod_BUFFER
 };
 
 inline const BodyCompressionMethod (&EnumValuesBodyCompressionMethod())[1] {
   static const BodyCompressionMethod values[] = {
-    BodyCompressionMethod::BUFFER
+    BodyCompressionMethod_BUFFER
   };
   return values;
 }
@@ -98,7 +98,7 @@ inline const char * const *EnumNamesBodyCompressionMethod() {
 }
 
 inline const char *EnumNameBodyCompressionMethod(BodyCompressionMethod e) {
-  if (::flatbuffers::IsOutRange(e, BodyCompressionMethod::BUFFER, BodyCompressionMethod::BUFFER)) return "";
+  if (::flatbuffers::IsOutRange(e, BodyCompressionMethod_BUFFER, BodyCompressionMethod_BUFFER)) return "";
   const size_t index = static_cast<size_t>(e);
   return EnumNamesBodyCompressionMethod()[index];
 }
@@ -111,25 +111,25 @@ inline const char *EnumNameBodyCompressionMethod(BodyCompressionMethod e) {
 /// Arrow implementations do not need to implement all of the message types,
 /// which may include experimental metadata types. For maximum compatibility,
 /// it is best to send data using RecordBatch
-enum class MessageHeader : uint8_t {
-  NONE = 0,
-  Schema = 1,
-  DictionaryBatch = 2,
-  RecordBatch = 3,
-  Tensor = 4,
-  SparseTensor = 5,
-  MIN = NONE,
-  MAX = SparseTensor
+enum MessageHeader : uint8_t {
+  MessageHeader_NONE = 0,
+  MessageHeader_Schema = 1,
+  MessageHeader_DictionaryBatch = 2,
+  MessageHeader_RecordBatch = 3,
+  MessageHeader_Tensor = 4,
+  MessageHeader_SparseTensor = 5,
+  MessageHeader_MIN = MessageHeader_NONE,
+  MessageHeader_MAX = MessageHeader_SparseTensor
 };
 
 inline const MessageHeader (&EnumValuesMessageHeader())[6] {
   static const MessageHeader values[] = {
-    MessageHeader::NONE,
-    MessageHeader::Schema,
-    MessageHeader::DictionaryBatch,
-    MessageHeader::RecordBatch,
-    MessageHeader::Tensor,
-    MessageHeader::SparseTensor
+    MessageHeader_NONE,
+    MessageHeader_Schema,
+    MessageHeader_DictionaryBatch,
+    MessageHeader_RecordBatch,
+    MessageHeader_Tensor,
+    MessageHeader_SparseTensor
   };
   return values;
 }
@@ -148,37 +148,37 @@ inline const char * const *EnumNamesMessageHeader() {
 }
 
 inline const char *EnumNameMessageHeader(MessageHeader e) {
-  if (::flatbuffers::IsOutRange(e, MessageHeader::NONE, MessageHeader::SparseTensor)) return "";
+  if (::flatbuffers::IsOutRange(e, MessageHeader_NONE, MessageHeader_SparseTensor)) return "";
   const size_t index = static_cast<size_t>(e);
   return EnumNamesMessageHeader()[index];
 }
 
 template<typename T> struct MessageHeaderTraits {
-  static const MessageHeader enum_value = MessageHeader::NONE;
+  static const MessageHeader enum_value = MessageHeader_NONE;
 };
 
 template<> struct MessageHeaderTraits<org::apache::arrow::flatbuf::Schema> {
-  static const MessageHeader enum_value = MessageHeader::Schema;
+  static const MessageHeader enum_value = MessageHeader_Schema;
 };
 
 template<> struct MessageHeaderTraits<org::apache::arrow::flatbuf::DictionaryBatch> {
-  static const MessageHeader enum_value = MessageHeader::DictionaryBatch;
+  static const MessageHeader enum_value = MessageHeader_DictionaryBatch;
 };
 
 template<> struct MessageHeaderTraits<org::apache::arrow::flatbuf::RecordBatch> {
-  static const MessageHeader enum_value = MessageHeader::RecordBatch;
+  static const MessageHeader enum_value = MessageHeader_RecordBatch;
 };
 
 template<> struct MessageHeaderTraits<org::apache::arrow::flatbuf::Tensor> {
-  static const MessageHeader enum_value = MessageHeader::Tensor;
+  static const MessageHeader enum_value = MessageHeader_Tensor;
 };
 
 template<> struct MessageHeaderTraits<org::apache::arrow::flatbuf::SparseTensor> {
-  static const MessageHeader enum_value = MessageHeader::SparseTensor;
+  static const MessageHeader enum_value = MessageHeader_SparseTensor;
 };
 
 bool VerifyMessageHeader(::flatbuffers::Verifier &verifier, const void *obj, MessageHeader type);
-bool VerifyMessageHeaderVector(::flatbuffers::Verifier &verifier, const ::flatbuffers::Vector<::flatbuffers::Offset<void>> *values, const ::flatbuffers::Vector<MessageHeader> *types);
+bool VerifyMessageHeaderVector(::flatbuffers::Verifier &verifier, const ::flatbuffers::Vector<::flatbuffers::Offset<void>> *values, const ::flatbuffers::Vector<uint8_t> *types);
 
 /// ----------------------------------------------------------------------
 /// Data structures for describing a table row batch (a collection of
@@ -266,8 +266,8 @@ struct BodyCompressionBuilder {
 
 inline ::flatbuffers::Offset<BodyCompression> CreateBodyCompression(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    org::apache::arrow::flatbuf::CompressionType codec = org::apache::arrow::flatbuf::CompressionType::LZ4_FRAME,
-    org::apache::arrow::flatbuf::BodyCompressionMethod method = org::apache::arrow::flatbuf::BodyCompressionMethod::BUFFER) {
+    org::apache::arrow::flatbuf::CompressionType codec = org::apache::arrow::flatbuf::CompressionType_LZ4_FRAME,
+    org::apache::arrow::flatbuf::BodyCompressionMethod method = org::apache::arrow::flatbuf::BodyCompressionMethod_BUFFER) {
   BodyCompressionBuilder builder_(_fbb);
   builder_.add_method(method);
   builder_.add_codec(codec);
@@ -496,19 +496,19 @@ struct Message FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   }
   template<typename T> const T *header_as() const;
   const org::apache::arrow::flatbuf::Schema *header_as_Schema() const {
-    return header_type() == org::apache::arrow::flatbuf::MessageHeader::Schema ? static_cast<const org::apache::arrow::flatbuf::Schema *>(header()) : nullptr;
+    return header_type() == org::apache::arrow::flatbuf::MessageHeader_Schema ? static_cast<const org::apache::arrow::flatbuf::Schema *>(header()) : nullptr;
   }
   const org::apache::arrow::flatbuf::DictionaryBatch *header_as_DictionaryBatch() const {
-    return header_type() == org::apache::arrow::flatbuf::MessageHeader::DictionaryBatch ? static_cast<const org::apache::arrow::flatbuf::DictionaryBatch *>(header()) : nullptr;
+    return header_type() == org::apache::arrow::flatbuf::MessageHeader_DictionaryBatch ? static_cast<const org::apache::arrow::flatbuf::DictionaryBatch *>(header()) : nullptr;
   }
   const org::apache::arrow::flatbuf::RecordBatch *header_as_RecordBatch() const {
-    return header_type() == org::apache::arrow::flatbuf::MessageHeader::RecordBatch ? static_cast<const org::apache::arrow::flatbuf::RecordBatch *>(header()) : nullptr;
+    return header_type() == org::apache::arrow::flatbuf::MessageHeader_RecordBatch ? static_cast<const org::apache::arrow::flatbuf::RecordBatch *>(header()) : nullptr;
   }
   const org::apache::arrow::flatbuf::Tensor *header_as_Tensor() const {
-    return header_type() == org::apache::arrow::flatbuf::MessageHeader::Tensor ? static_cast<const org::apache::arrow::flatbuf::Tensor *>(header()) : nullptr;
+    return header_type() == org::apache::arrow::flatbuf::MessageHeader_Tensor ? static_cast<const org::apache::arrow::flatbuf::Tensor *>(header()) : nullptr;
   }
   const org::apache::arrow::flatbuf::SparseTensor *header_as_SparseTensor() const {
-    return header_type() == org::apache::arrow::flatbuf::MessageHeader::SparseTensor ? static_cast<const org::apache::arrow::flatbuf::SparseTensor *>(header()) : nullptr;
+    return header_type() == org::apache::arrow::flatbuf::MessageHeader_SparseTensor ? static_cast<const org::apache::arrow::flatbuf::SparseTensor *>(header()) : nullptr;
   }
   int64_t bodyLength() const {
     return GetField<int64_t>(VT_BODYLENGTH, 0);
@@ -582,8 +582,8 @@ struct MessageBuilder {
 
 inline ::flatbuffers::Offset<Message> CreateMessage(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    org::apache::arrow::flatbuf::MetadataVersion version = org::apache::arrow::flatbuf::MetadataVersion::V1,
-    org::apache::arrow::flatbuf::MessageHeader header_type = org::apache::arrow::flatbuf::MessageHeader::NONE,
+    org::apache::arrow::flatbuf::MetadataVersion version = org::apache::arrow::flatbuf::MetadataVersion_V1,
+    org::apache::arrow::flatbuf::MessageHeader header_type = org::apache::arrow::flatbuf::MessageHeader_NONE,
     ::flatbuffers::Offset<void> header = 0,
     int64_t bodyLength = 0,
     ::flatbuffers::Offset<::flatbuffers::Vector<::flatbuffers::Offset<org::apache::arrow::flatbuf::KeyValue>>> custom_metadata = 0) {
@@ -598,8 +598,8 @@ inline ::flatbuffers::Offset<Message> CreateMessage(
 
 inline ::flatbuffers::Offset<Message> CreateMessageDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    org::apache::arrow::flatbuf::MetadataVersion version = org::apache::arrow::flatbuf::MetadataVersion::V1,
-    org::apache::arrow::flatbuf::MessageHeader header_type = org::apache::arrow::flatbuf::MessageHeader::NONE,
+    org::apache::arrow::flatbuf::MetadataVersion version = org::apache::arrow::flatbuf::MetadataVersion_V1,
+    org::apache::arrow::flatbuf::MessageHeader header_type = org::apache::arrow::flatbuf::MessageHeader_NONE,
     ::flatbuffers::Offset<void> header = 0,
     int64_t bodyLength = 0,
     const std::vector<::flatbuffers::Offset<org::apache::arrow::flatbuf::KeyValue>> *custom_metadata = nullptr) {
@@ -615,26 +615,26 @@ inline ::flatbuffers::Offset<Message> CreateMessageDirect(
 
 inline bool VerifyMessageHeader(::flatbuffers::Verifier &verifier, const void *obj, MessageHeader type) {
   switch (type) {
-    case MessageHeader::NONE: {
+    case MessageHeader_NONE: {
       return true;
     }
-    case MessageHeader::Schema: {
+    case MessageHeader_Schema: {
       auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::Schema *>(obj);
       return verifier.VerifyTable(ptr);
     }
-    case MessageHeader::DictionaryBatch: {
+    case MessageHeader_DictionaryBatch: {
       auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::DictionaryBatch *>(obj);
       return verifier.VerifyTable(ptr);
     }
-    case MessageHeader::RecordBatch: {
+    case MessageHeader_RecordBatch: {
       auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::RecordBatch *>(obj);
       return verifier.VerifyTable(ptr);
     }
-    case MessageHeader::Tensor: {
+    case MessageHeader_Tensor: {
       auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::Tensor *>(obj);
       return verifier.VerifyTable(ptr);
     }
-    case MessageHeader::SparseTensor: {
+    case MessageHeader_SparseTensor: {
       auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::SparseTensor *>(obj);
       return verifier.VerifyTable(ptr);
     }
@@ -642,7 +642,7 @@ inline bool VerifyMessageHeader(::flatbuffers::Verifier &verifier, const void *o
   }
 }
 
-inline bool VerifyMessageHeaderVector(::flatbuffers::Verifier &verifier, const ::flatbuffers::Vector<::flatbuffers::Offset<void>> *values, const ::flatbuffers::Vector<MessageHeader> *types) {
+inline bool VerifyMessageHeaderVector(::flatbuffers::Verifier &verifier, const ::flatbuffers::Vector<::flatbuffers::Offset<void>> *values, const ::flatbuffers::Vector<uint8_t> *types) {
   if (!values || !types) return !values && !types;
   if (values->size() != types->size()) return false;
   for (::flatbuffers::uoffset_t i = 0; i < values->size(); ++i) {

--- a/cpp/src/generated/Schema_generated.h
+++ b/cpp/src/generated/Schema_generated.h
@@ -8,9 +8,9 @@
 
 // Ensure the included flatbuffers.h is the same version as when this file was
 // generated, otherwise it may not be compatible.
-static_assert(FLATBUFFERS_VERSION_MAJOR == 23 &&
-              FLATBUFFERS_VERSION_MINOR == 5 &&
-              FLATBUFFERS_VERSION_REVISION == 26,
+static_assert(FLATBUFFERS_VERSION_MAJOR == 24 &&
+              FLATBUFFERS_VERSION_MINOR == 3 &&
+              FLATBUFFERS_VERSION_REVISION == 6,
              "Non-compatible flatbuffers version included");
 
 namespace org {
@@ -110,34 +110,34 @@ struct Buffer;
 struct Schema;
 struct SchemaBuilder;
 
-enum class MetadataVersion : int16_t {
+enum MetadataVersion : int16_t {
   /// 0.1.0 (October 2016).
-  V1 = 0,
+  MetadataVersion_V1 = 0,
   /// 0.2.0 (February 2017). Non-backwards compatible with V1.
-  V2 = 1,
+  MetadataVersion_V2 = 1,
   /// 0.3.0 -> 0.7.1 (May - December 2017). Non-backwards compatible with V2.
-  V3 = 2,
+  MetadataVersion_V3 = 2,
   /// >= 0.8.0 (December 2017). Non-backwards compatible with V3.
-  V4 = 3,
-  /// >= 1.0.0 (July 2020. Backwards compatible with V4 (V5 readers can read V4
+  MetadataVersion_V4 = 3,
+  /// >= 1.0.0 (July 2020). Backwards compatible with V4 (V5 readers can read V4
   /// metadata and IPC messages). Implementations are recommended to provide a
   /// V4 compatibility mode with V5 format changes disabled.
   ///
   /// Incompatible changes between V4 and V5:
   /// - Union buffer layout has changed. In V5, Unions don't have a validity
   ///   bitmap buffer.
-  V5 = 4,
-  MIN = V1,
-  MAX = V5
+  MetadataVersion_V5 = 4,
+  MetadataVersion_MIN = MetadataVersion_V1,
+  MetadataVersion_MAX = MetadataVersion_V5
 };
 
 inline const MetadataVersion (&EnumValuesMetadataVersion())[5] {
   static const MetadataVersion values[] = {
-    MetadataVersion::V1,
-    MetadataVersion::V2,
-    MetadataVersion::V3,
-    MetadataVersion::V4,
-    MetadataVersion::V5
+    MetadataVersion_V1,
+    MetadataVersion_V2,
+    MetadataVersion_V3,
+    MetadataVersion_V4,
+    MetadataVersion_V5
   };
   return values;
 }
@@ -155,7 +155,7 @@ inline const char * const *EnumNamesMetadataVersion() {
 }
 
 inline const char *EnumNameMetadataVersion(MetadataVersion e) {
-  if (::flatbuffers::IsOutRange(e, MetadataVersion::V1, MetadataVersion::V5)) return "";
+  if (::flatbuffers::IsOutRange(e, MetadataVersion_V1, MetadataVersion_V5)) return "";
   const size_t index = static_cast<size_t>(e);
   return EnumNamesMetadataVersion()[index];
 }
@@ -170,32 +170,32 @@ inline const char *EnumNameMetadataVersion(MetadataVersion e) {
 ///      forward compatibility guarantees).
 ///  2.  A means of negotiating between a client and server
 ///      what features a stream is allowed to use. The enums
-///      values here are intented to represent higher level
-///      features, additional details maybe negotiated
+///      values here are intended to represent higher level
+///      features, additional details may be negotiated
 ///      with key-value pairs specific to the protocol.
 ///
 /// Enums added to this list should be assigned power-of-two values
 /// to facilitate exchanging and comparing bitmaps for supported
 /// features.
-enum class Feature : int64_t {
+enum Feature : int64_t {
   /// Needed to make flatbuffers happy.
-  UNUSED = 0,
+  Feature_UNUSED = 0,
   /// The stream makes use of multiple full dictionaries with the
   /// same ID and assumes clients implement dictionary replacement
   /// correctly.
-  DICTIONARY_REPLACEMENT = 1LL,
+  Feature_DICTIONARY_REPLACEMENT = 1LL,
   /// The stream makes use of compressed bodies as described
   /// in Message.fbs.
-  COMPRESSED_BODY = 2LL,
-  MIN = UNUSED,
-  MAX = COMPRESSED_BODY
+  Feature_COMPRESSED_BODY = 2LL,
+  Feature_MIN = Feature_UNUSED,
+  Feature_MAX = Feature_COMPRESSED_BODY
 };
 
 inline const Feature (&EnumValuesFeature())[3] {
   static const Feature values[] = {
-    Feature::UNUSED,
-    Feature::DICTIONARY_REPLACEMENT,
-    Feature::COMPRESSED_BODY
+    Feature_UNUSED,
+    Feature_DICTIONARY_REPLACEMENT,
+    Feature_COMPRESSED_BODY
   };
   return values;
 }
@@ -211,22 +211,22 @@ inline const char * const *EnumNamesFeature() {
 }
 
 inline const char *EnumNameFeature(Feature e) {
-  if (::flatbuffers::IsOutRange(e, Feature::UNUSED, Feature::COMPRESSED_BODY)) return "";
+  if (::flatbuffers::IsOutRange(e, Feature_UNUSED, Feature_COMPRESSED_BODY)) return "";
   const size_t index = static_cast<size_t>(e);
   return EnumNamesFeature()[index];
 }
 
-enum class UnionMode : int16_t {
-  Sparse = 0,
-  Dense = 1,
-  MIN = Sparse,
-  MAX = Dense
+enum UnionMode : int16_t {
+  UnionMode_Sparse = 0,
+  UnionMode_Dense = 1,
+  UnionMode_MIN = UnionMode_Sparse,
+  UnionMode_MAX = UnionMode_Dense
 };
 
 inline const UnionMode (&EnumValuesUnionMode())[2] {
   static const UnionMode values[] = {
-    UnionMode::Sparse,
-    UnionMode::Dense
+    UnionMode_Sparse,
+    UnionMode_Dense
   };
   return values;
 }
@@ -241,24 +241,24 @@ inline const char * const *EnumNamesUnionMode() {
 }
 
 inline const char *EnumNameUnionMode(UnionMode e) {
-  if (::flatbuffers::IsOutRange(e, UnionMode::Sparse, UnionMode::Dense)) return "";
+  if (::flatbuffers::IsOutRange(e, UnionMode_Sparse, UnionMode_Dense)) return "";
   const size_t index = static_cast<size_t>(e);
   return EnumNamesUnionMode()[index];
 }
 
-enum class Precision : int16_t {
-  HALF = 0,
-  SINGLE = 1,
-  DOUBLE = 2,
-  MIN = HALF,
-  MAX = DOUBLE
+enum Precision : int16_t {
+  Precision_HALF = 0,
+  Precision_SINGLE = 1,
+  Precision_DOUBLE = 2,
+  Precision_MIN = Precision_HALF,
+  Precision_MAX = Precision_DOUBLE
 };
 
 inline const Precision (&EnumValuesPrecision())[3] {
   static const Precision values[] = {
-    Precision::HALF,
-    Precision::SINGLE,
-    Precision::DOUBLE
+    Precision_HALF,
+    Precision_SINGLE,
+    Precision_DOUBLE
   };
   return values;
 }
@@ -274,22 +274,22 @@ inline const char * const *EnumNamesPrecision() {
 }
 
 inline const char *EnumNamePrecision(Precision e) {
-  if (::flatbuffers::IsOutRange(e, Precision::HALF, Precision::DOUBLE)) return "";
+  if (::flatbuffers::IsOutRange(e, Precision_HALF, Precision_DOUBLE)) return "";
   const size_t index = static_cast<size_t>(e);
   return EnumNamesPrecision()[index];
 }
 
-enum class DateUnit : int16_t {
-  DAY = 0,
-  MILLISECOND = 1,
-  MIN = DAY,
-  MAX = MILLISECOND
+enum DateUnit : int16_t {
+  DateUnit_DAY = 0,
+  DateUnit_MILLISECOND = 1,
+  DateUnit_MIN = DateUnit_DAY,
+  DateUnit_MAX = DateUnit_MILLISECOND
 };
 
 inline const DateUnit (&EnumValuesDateUnit())[2] {
   static const DateUnit values[] = {
-    DateUnit::DAY,
-    DateUnit::MILLISECOND
+    DateUnit_DAY,
+    DateUnit_MILLISECOND
   };
   return values;
 }
@@ -304,26 +304,26 @@ inline const char * const *EnumNamesDateUnit() {
 }
 
 inline const char *EnumNameDateUnit(DateUnit e) {
-  if (::flatbuffers::IsOutRange(e, DateUnit::DAY, DateUnit::MILLISECOND)) return "";
+  if (::flatbuffers::IsOutRange(e, DateUnit_DAY, DateUnit_MILLISECOND)) return "";
   const size_t index = static_cast<size_t>(e);
   return EnumNamesDateUnit()[index];
 }
 
-enum class TimeUnit : int16_t {
-  SECOND = 0,
-  MILLISECOND = 1,
-  MICROSECOND = 2,
-  NANOSECOND = 3,
-  MIN = SECOND,
-  MAX = NANOSECOND
+enum TimeUnit : int16_t {
+  TimeUnit_SECOND = 0,
+  TimeUnit_MILLISECOND = 1,
+  TimeUnit_MICROSECOND = 2,
+  TimeUnit_NANOSECOND = 3,
+  TimeUnit_MIN = TimeUnit_SECOND,
+  TimeUnit_MAX = TimeUnit_NANOSECOND
 };
 
 inline const TimeUnit (&EnumValuesTimeUnit())[4] {
   static const TimeUnit values[] = {
-    TimeUnit::SECOND,
-    TimeUnit::MILLISECOND,
-    TimeUnit::MICROSECOND,
-    TimeUnit::NANOSECOND
+    TimeUnit_SECOND,
+    TimeUnit_MILLISECOND,
+    TimeUnit_MICROSECOND,
+    TimeUnit_NANOSECOND
   };
   return values;
 }
@@ -340,24 +340,24 @@ inline const char * const *EnumNamesTimeUnit() {
 }
 
 inline const char *EnumNameTimeUnit(TimeUnit e) {
-  if (::flatbuffers::IsOutRange(e, TimeUnit::SECOND, TimeUnit::NANOSECOND)) return "";
+  if (::flatbuffers::IsOutRange(e, TimeUnit_SECOND, TimeUnit_NANOSECOND)) return "";
   const size_t index = static_cast<size_t>(e);
   return EnumNamesTimeUnit()[index];
 }
 
-enum class IntervalUnit : int16_t {
-  YEAR_MONTH = 0,
-  DAY_TIME = 1,
-  MONTH_DAY_NANO = 2,
-  MIN = YEAR_MONTH,
-  MAX = MONTH_DAY_NANO
+enum IntervalUnit : int16_t {
+  IntervalUnit_YEAR_MONTH = 0,
+  IntervalUnit_DAY_TIME = 1,
+  IntervalUnit_MONTH_DAY_NANO = 2,
+  IntervalUnit_MIN = IntervalUnit_YEAR_MONTH,
+  IntervalUnit_MAX = IntervalUnit_MONTH_DAY_NANO
 };
 
 inline const IntervalUnit (&EnumValuesIntervalUnit())[3] {
   static const IntervalUnit values[] = {
-    IntervalUnit::YEAR_MONTH,
-    IntervalUnit::DAY_TIME,
-    IntervalUnit::MONTH_DAY_NANO
+    IntervalUnit_YEAR_MONTH,
+    IntervalUnit_DAY_TIME,
+    IntervalUnit_MONTH_DAY_NANO
   };
   return values;
 }
@@ -373,7 +373,7 @@ inline const char * const *EnumNamesIntervalUnit() {
 }
 
 inline const char *EnumNameIntervalUnit(IntervalUnit e) {
-  if (::flatbuffers::IsOutRange(e, IntervalUnit::YEAR_MONTH, IntervalUnit::MONTH_DAY_NANO)) return "";
+  if (::flatbuffers::IsOutRange(e, IntervalUnit_YEAR_MONTH, IntervalUnit_MONTH_DAY_NANO)) return "";
   const size_t index = static_cast<size_t>(e);
   return EnumNamesIntervalUnit()[index];
 }
@@ -381,67 +381,67 @@ inline const char *EnumNameIntervalUnit(IntervalUnit e) {
 /// ----------------------------------------------------------------------
 /// Top-level Type value, enabling extensible type-specific metadata. We can
 /// add new logical types to Type without breaking backwards compatibility
-enum class Type : uint8_t {
-  NONE = 0,
-  Null = 1,
-  Int = 2,
-  FloatingPoint = 3,
-  Binary = 4,
-  Utf8 = 5,
-  Bool = 6,
-  Decimal = 7,
-  Date = 8,
-  Time = 9,
-  Timestamp = 10,
-  Interval = 11,
-  List = 12,
-  Struct_ = 13,
-  Union = 14,
-  FixedSizeBinary = 15,
-  FixedSizeList = 16,
-  Map = 17,
-  Duration = 18,
-  LargeBinary = 19,
-  LargeUtf8 = 20,
-  LargeList = 21,
-  RunEndEncoded = 22,
-  BinaryView = 23,
-  Utf8View = 24,
-  ListView = 25,
-  LargeListView = 26,
-  MIN = NONE,
-  MAX = LargeListView
+enum Type : uint8_t {
+  Type_NONE = 0,
+  Type_Null = 1,
+  Type_Int = 2,
+  Type_FloatingPoint = 3,
+  Type_Binary = 4,
+  Type_Utf8 = 5,
+  Type_Bool = 6,
+  Type_Decimal = 7,
+  Type_Date = 8,
+  Type_Time = 9,
+  Type_Timestamp = 10,
+  Type_Interval = 11,
+  Type_List = 12,
+  Type_Struct_ = 13,
+  Type_Union = 14,
+  Type_FixedSizeBinary = 15,
+  Type_FixedSizeList = 16,
+  Type_Map = 17,
+  Type_Duration = 18,
+  Type_LargeBinary = 19,
+  Type_LargeUtf8 = 20,
+  Type_LargeList = 21,
+  Type_RunEndEncoded = 22,
+  Type_BinaryView = 23,
+  Type_Utf8View = 24,
+  Type_ListView = 25,
+  Type_LargeListView = 26,
+  Type_MIN = Type_NONE,
+  Type_MAX = Type_LargeListView
 };
 
 inline const Type (&EnumValuesType())[27] {
   static const Type values[] = {
-    Type::NONE,
-    Type::Null,
-    Type::Int,
-    Type::FloatingPoint,
-    Type::Binary,
-    Type::Utf8,
-    Type::Bool,
-    Type::Decimal,
-    Type::Date,
-    Type::Time,
-    Type::Timestamp,
-    Type::Interval,
-    Type::List,
-    Type::Struct_,
-    Type::Union,
-    Type::FixedSizeBinary,
-    Type::FixedSizeList,
-    Type::Map,
-    Type::Duration,
-    Type::LargeBinary,
-    Type::LargeUtf8,
-    Type::LargeList,
-    Type::RunEndEncoded,
-    Type::BinaryView,
-    Type::Utf8View,
-    Type::ListView,
-    Type::LargeListView
+    Type_NONE,
+    Type_Null,
+    Type_Int,
+    Type_FloatingPoint,
+    Type_Binary,
+    Type_Utf8,
+    Type_Bool,
+    Type_Decimal,
+    Type_Date,
+    Type_Time,
+    Type_Timestamp,
+    Type_Interval,
+    Type_List,
+    Type_Struct_,
+    Type_Union,
+    Type_FixedSizeBinary,
+    Type_FixedSizeList,
+    Type_Map,
+    Type_Duration,
+    Type_LargeBinary,
+    Type_LargeUtf8,
+    Type_LargeList,
+    Type_RunEndEncoded,
+    Type_BinaryView,
+    Type_Utf8View,
+    Type_ListView,
+    Type_LargeListView
   };
   return values;
 }
@@ -481,136 +481,136 @@ inline const char * const *EnumNamesType() {
 }
 
 inline const char *EnumNameType(Type e) {
-  if (::flatbuffers::IsOutRange(e, Type::NONE, Type::LargeListView)) return "";
+  if (::flatbuffers::IsOutRange(e, Type_NONE, Type_LargeListView)) return "";
   const size_t index = static_cast<size_t>(e);
   return EnumNamesType()[index];
 }
 
 template<typename T> struct TypeTraits {
-  static const Type enum_value = Type::NONE;
+  static const Type enum_value = Type_NONE;
 };
 
 template<> struct TypeTraits<org::apache::arrow::flatbuf::Null> {
-  static const Type enum_value = Type::Null;
+  static const Type enum_value = Type_Null;
 };
 
 template<> struct TypeTraits<org::apache::arrow::flatbuf::Int> {
-  static const Type enum_value = Type::Int;
+  static const Type enum_value = Type_Int;
 };
 
 template<> struct TypeTraits<org::apache::arrow::flatbuf::FloatingPoint> {
-  static const Type enum_value = Type::FloatingPoint;
+  static const Type enum_value = Type_FloatingPoint;
 };
 
 template<> struct TypeTraits<org::apache::arrow::flatbuf::Binary> {
-  static const Type enum_value = Type::Binary;
+  static const Type enum_value = Type_Binary;
 };
 
 template<> struct TypeTraits<org::apache::arrow::flatbuf::Utf8> {
-  static const Type enum_value = Type::Utf8;
+  static const Type enum_value = Type_Utf8;
 };
 
 template<> struct TypeTraits<org::apache::arrow::flatbuf::Bool> {
-  static const Type enum_value = Type::Bool;
+  static const Type enum_value = Type_Bool;
 };
 
 template<> struct TypeTraits<org::apache::arrow::flatbuf::Decimal> {
-  static const Type enum_value = Type::Decimal;
+  static const Type enum_value = Type_Decimal;
 };
 
 template<> struct TypeTraits<org::apache::arrow::flatbuf::Date> {
-  static const Type enum_value = Type::Date;
+  static const Type enum_value = Type_Date;
 };
 
 template<> struct TypeTraits<org::apache::arrow::flatbuf::Time> {
-  static const Type enum_value = Type::Time;
+  static const Type enum_value = Type_Time;
 };
 
 template<> struct TypeTraits<org::apache::arrow::flatbuf::Timestamp> {
-  static const Type enum_value = Type::Timestamp;
+  static const Type enum_value = Type_Timestamp;
 };
 
 template<> struct TypeTraits<org::apache::arrow::flatbuf::Interval> {
-  static const Type enum_value = Type::Interval;
+  static const Type enum_value = Type_Interval;
 };
 
 template<> struct TypeTraits<org::apache::arrow::flatbuf::List> {
-  static const Type enum_value = Type::List;
+  static const Type enum_value = Type_List;
 };
 
 template<> struct TypeTraits<org::apache::arrow::flatbuf::Struct_> {
-  static const Type enum_value = Type::Struct_;
+  static const Type enum_value = Type_Struct_;
 };
 
 template<> struct TypeTraits<org::apache::arrow::flatbuf::Union> {
-  static const Type enum_value = Type::Union;
+  static const Type enum_value = Type_Union;
 };
 
 template<> struct TypeTraits<org::apache::arrow::flatbuf::FixedSizeBinary> {
-  static const Type enum_value = Type::FixedSizeBinary;
+  static const Type enum_value = Type_FixedSizeBinary;
 };
 
 template<> struct TypeTraits<org::apache::arrow::flatbuf::FixedSizeList> {
-  static const Type enum_value = Type::FixedSizeList;
+  static const Type enum_value = Type_FixedSizeList;
 };
 
 template<> struct TypeTraits<org::apache::arrow::flatbuf::Map> {
-  static const Type enum_value = Type::Map;
+  static const Type enum_value = Type_Map;
 };
 
 template<> struct TypeTraits<org::apache::arrow::flatbuf::Duration> {
-  static const Type enum_value = Type::Duration;
+  static const Type enum_value = Type_Duration;
 };
 
 template<> struct TypeTraits<org::apache::arrow::flatbuf::LargeBinary> {
-  static const Type enum_value = Type::LargeBinary;
+  static const Type enum_value = Type_LargeBinary;
 };
 
 template<> struct TypeTraits<org::apache::arrow::flatbuf::LargeUtf8> {
-  static const Type enum_value = Type::LargeUtf8;
+  static const Type enum_value = Type_LargeUtf8;
 };
 
 template<> struct TypeTraits<org::apache::arrow::flatbuf::LargeList> {
-  static const Type enum_value = Type::LargeList;
+  static const Type enum_value = Type_LargeList;
 };
 
 template<> struct TypeTraits<org::apache::arrow::flatbuf::RunEndEncoded> {
-  static const Type enum_value = Type::RunEndEncoded;
+  static const Type enum_value = Type_RunEndEncoded;
 };
 
 template<> struct TypeTraits<org::apache::arrow::flatbuf::BinaryView> {
-  static const Type enum_value = Type::BinaryView;
+  static const Type enum_value = Type_BinaryView;
 };
 
 template<> struct TypeTraits<org::apache::arrow::flatbuf::Utf8View> {
-  static const Type enum_value = Type::Utf8View;
+  static const Type enum_value = Type_Utf8View;
 };
 
 template<> struct TypeTraits<org::apache::arrow::flatbuf::ListView> {
-  static const Type enum_value = Type::ListView;
+  static const Type enum_value = Type_ListView;
 };
 
 template<> struct TypeTraits<org::apache::arrow::flatbuf::LargeListView> {
-  static const Type enum_value = Type::LargeListView;
+  static const Type enum_value = Type_LargeListView;
 };
 
 bool VerifyType(::flatbuffers::Verifier &verifier, const void *obj, Type type);
-bool VerifyTypeVector(::flatbuffers::Verifier &verifier, const ::flatbuffers::Vector<::flatbuffers::Offset<void>> *values, const ::flatbuffers::Vector<Type> *types);
+bool VerifyTypeVector(::flatbuffers::Verifier &verifier, const ::flatbuffers::Vector<::flatbuffers::Offset<void>> *values, const ::flatbuffers::Vector<uint8_t> *types);
 
 /// ----------------------------------------------------------------------
 /// Dictionary encoding metadata
 /// Maintained for forwards compatibility, in the future
 /// Dictionaries might be explicit maps between integers and values
 /// allowing for non-contiguous index values
-enum class DictionaryKind : int16_t {
-  DenseArray = 0,
-  MIN = DenseArray,
-  MAX = DenseArray
+enum DictionaryKind : int16_t {
+  DictionaryKind_DenseArray = 0,
+  DictionaryKind_MIN = DictionaryKind_DenseArray,
+  DictionaryKind_MAX = DictionaryKind_DenseArray
 };
 
 inline const DictionaryKind (&EnumValuesDictionaryKind())[1] {
   static const DictionaryKind values[] = {
-    DictionaryKind::DenseArray
+    DictionaryKind_DenseArray
   };
   return values;
 }
@@ -624,24 +624,24 @@ inline const char * const *EnumNamesDictionaryKind() {
 }
 
 inline const char *EnumNameDictionaryKind(DictionaryKind e) {
-  if (::flatbuffers::IsOutRange(e, DictionaryKind::DenseArray, DictionaryKind::DenseArray)) return "";
+  if (::flatbuffers::IsOutRange(e, DictionaryKind_DenseArray, DictionaryKind_DenseArray)) return "";
   const size_t index = static_cast<size_t>(e);
   return EnumNamesDictionaryKind()[index];
 }
 
 /// ----------------------------------------------------------------------
 /// Endianness of the platform producing the data
-enum class Endianness : int16_t {
-  Little = 0,
-  Big = 1,
-  MIN = Little,
-  MAX = Big
+enum Endianness : int16_t {
+  Endianness_Little = 0,
+  Endianness_Big = 1,
+  Endianness_MIN = Endianness_Little,
+  Endianness_MAX = Endianness_Big
 };
 
 inline const Endianness (&EnumValuesEndianness())[2] {
   static const Endianness values[] = {
-    Endianness::Little,
-    Endianness::Big
+    Endianness_Little,
+    Endianness_Big
   };
   return values;
 }
@@ -656,7 +656,7 @@ inline const char * const *EnumNamesEndianness() {
 }
 
 inline const char *EnumNameEndianness(Endianness e) {
-  if (::flatbuffers::IsOutRange(e, Endianness::Little, Endianness::Big)) return "";
+  if (::flatbuffers::IsOutRange(e, Endianness_Little, Endianness_Big)) return "";
   const size_t index = static_cast<size_t>(e);
   return EnumNamesEndianness()[index];
 }
@@ -1035,7 +1035,7 @@ struct UnionBuilder {
 
 inline ::flatbuffers::Offset<Union> CreateUnion(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    org::apache::arrow::flatbuf::UnionMode mode = org::apache::arrow::flatbuf::UnionMode::Sparse,
+    org::apache::arrow::flatbuf::UnionMode mode = org::apache::arrow::flatbuf::UnionMode_Sparse,
     ::flatbuffers::Offset<::flatbuffers::Vector<int32_t>> typeIds = 0) {
   UnionBuilder builder_(_fbb);
   builder_.add_typeIds(typeIds);
@@ -1045,7 +1045,7 @@ inline ::flatbuffers::Offset<Union> CreateUnion(
 
 inline ::flatbuffers::Offset<Union> CreateUnionDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    org::apache::arrow::flatbuf::UnionMode mode = org::apache::arrow::flatbuf::UnionMode::Sparse,
+    org::apache::arrow::flatbuf::UnionMode mode = org::apache::arrow::flatbuf::UnionMode_Sparse,
     const std::vector<int32_t> *typeIds = nullptr) {
   auto typeIds__ = typeIds ? _fbb.CreateVector<int32_t>(*typeIds) : 0;
   return org::apache::arrow::flatbuf::CreateUnion(
@@ -1140,7 +1140,7 @@ struct FloatingPointBuilder {
 
 inline ::flatbuffers::Offset<FloatingPoint> CreateFloatingPoint(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    org::apache::arrow::flatbuf::Precision precision = org::apache::arrow::flatbuf::Precision::HALF) {
+    org::apache::arrow::flatbuf::Precision precision = org::apache::arrow::flatbuf::Precision_HALF) {
   FloatingPointBuilder builder_(_fbb);
   builder_.add_precision(precision);
   return builder_.Finish();
@@ -1446,9 +1446,9 @@ inline ::flatbuffers::Offset<RunEndEncoded> CreateRunEndEncoded(
 }
 
 /// Exact decimal value represented as an integer value in two's
-/// complement. Currently only 128-bit (16-byte) and 256-bit (32-byte) integers
-/// are used. The representation uses the endianness indicated
-/// in the Schema.
+/// complement. Currently 32-bit (4-byte), 64-bit (8-byte), 
+/// 128-bit (16-byte) and 256-bit (32-byte) integers are used.
+/// The representation uses the endianness indicated in the Schema.
 struct Decimal FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   typedef DecimalBuilder Builder;
   enum FlatBuffersVTableOffset FLATBUFFERS_VTABLE_UNDERLYING_TYPE {
@@ -1464,7 +1464,7 @@ struct Decimal FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   int32_t scale() const {
     return GetField<int32_t>(VT_SCALE, 0);
   }
-  /// Number of bits per value. The only accepted widths are 128 and 256.
+  /// Number of bits per value. The accepted widths are 32, 64, 128 and 256.
   /// We use bitWidth for consistency with Int::bitWidth.
   int32_t bitWidth() const {
     return GetField<int32_t>(VT_BITWIDTH, 128);
@@ -1555,7 +1555,7 @@ struct DateBuilder {
 
 inline ::flatbuffers::Offset<Date> CreateDate(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    org::apache::arrow::flatbuf::DateUnit unit = org::apache::arrow::flatbuf::DateUnit::MILLISECOND) {
+    org::apache::arrow::flatbuf::DateUnit unit = org::apache::arrow::flatbuf::DateUnit_MILLISECOND) {
   DateBuilder builder_(_fbb);
   builder_.add_unit(unit);
   return builder_.Finish();
@@ -1618,7 +1618,7 @@ struct TimeBuilder {
 
 inline ::flatbuffers::Offset<Time> CreateTime(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    org::apache::arrow::flatbuf::TimeUnit unit = org::apache::arrow::flatbuf::TimeUnit::MILLISECOND,
+    org::apache::arrow::flatbuf::TimeUnit unit = org::apache::arrow::flatbuf::TimeUnit_MILLISECOND,
     int32_t bitWidth = 32) {
   TimeBuilder builder_(_fbb);
   builder_.add_bitWidth(bitWidth);
@@ -1785,7 +1785,7 @@ struct TimestampBuilder {
 
 inline ::flatbuffers::Offset<Timestamp> CreateTimestamp(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    org::apache::arrow::flatbuf::TimeUnit unit = org::apache::arrow::flatbuf::TimeUnit::SECOND,
+    org::apache::arrow::flatbuf::TimeUnit unit = org::apache::arrow::flatbuf::TimeUnit_SECOND,
     ::flatbuffers::Offset<::flatbuffers::String> timezone = 0) {
   TimestampBuilder builder_(_fbb);
   builder_.add_timezone(timezone);
@@ -1795,7 +1795,7 @@ inline ::flatbuffers::Offset<Timestamp> CreateTimestamp(
 
 inline ::flatbuffers::Offset<Timestamp> CreateTimestampDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    org::apache::arrow::flatbuf::TimeUnit unit = org::apache::arrow::flatbuf::TimeUnit::SECOND,
+    org::apache::arrow::flatbuf::TimeUnit unit = org::apache::arrow::flatbuf::TimeUnit_SECOND,
     const char *timezone = nullptr) {
   auto timezone__ = timezone ? _fbb.CreateString(timezone) : 0;
   return org::apache::arrow::flatbuf::CreateTimestamp(
@@ -1839,7 +1839,7 @@ struct IntervalBuilder {
 
 inline ::flatbuffers::Offset<Interval> CreateInterval(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    org::apache::arrow::flatbuf::IntervalUnit unit = org::apache::arrow::flatbuf::IntervalUnit::YEAR_MONTH) {
+    org::apache::arrow::flatbuf::IntervalUnit unit = org::apache::arrow::flatbuf::IntervalUnit_YEAR_MONTH) {
   IntervalBuilder builder_(_fbb);
   builder_.add_unit(unit);
   return builder_.Finish();
@@ -1880,7 +1880,7 @@ struct DurationBuilder {
 
 inline ::flatbuffers::Offset<Duration> CreateDuration(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    org::apache::arrow::flatbuf::TimeUnit unit = org::apache::arrow::flatbuf::TimeUnit::MILLISECOND) {
+    org::apache::arrow::flatbuf::TimeUnit unit = org::apache::arrow::flatbuf::TimeUnit_MILLISECOND) {
   DurationBuilder builder_(_fbb);
   builder_.add_unit(unit);
   return builder_.Finish();
@@ -2029,7 +2029,7 @@ inline ::flatbuffers::Offset<DictionaryEncoding> CreateDictionaryEncoding(
     int64_t id = 0,
     ::flatbuffers::Offset<org::apache::arrow::flatbuf::Int> indexType = 0,
     bool isOrdered = false,
-    org::apache::arrow::flatbuf::DictionaryKind dictionaryKind = org::apache::arrow::flatbuf::DictionaryKind::DenseArray) {
+    org::apache::arrow::flatbuf::DictionaryKind dictionaryKind = org::apache::arrow::flatbuf::DictionaryKind_DenseArray) {
   DictionaryEncodingBuilder builder_(_fbb);
   builder_.add_id(id);
   builder_.add_indexType(indexType);
@@ -2052,7 +2052,7 @@ struct Field FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
     VT_CHILDREN = 14,
     VT_CUSTOM_METADATA = 16
   };
-  /// Name is not required, in i.e. a List
+  /// Name is not required (e.g., in a List)
   const ::flatbuffers::String *name() const {
     return GetPointer<const ::flatbuffers::String *>(VT_NAME);
   }
@@ -2069,82 +2069,82 @@ struct Field FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   }
   template<typename T> const T *type_as() const;
   const org::apache::arrow::flatbuf::Null *type_as_Null() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::Null ? static_cast<const org::apache::arrow::flatbuf::Null *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_Null ? static_cast<const org::apache::arrow::flatbuf::Null *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::Int *type_as_Int() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::Int ? static_cast<const org::apache::arrow::flatbuf::Int *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_Int ? static_cast<const org::apache::arrow::flatbuf::Int *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::FloatingPoint *type_as_FloatingPoint() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::FloatingPoint ? static_cast<const org::apache::arrow::flatbuf::FloatingPoint *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_FloatingPoint ? static_cast<const org::apache::arrow::flatbuf::FloatingPoint *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::Binary *type_as_Binary() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::Binary ? static_cast<const org::apache::arrow::flatbuf::Binary *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_Binary ? static_cast<const org::apache::arrow::flatbuf::Binary *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::Utf8 *type_as_Utf8() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::Utf8 ? static_cast<const org::apache::arrow::flatbuf::Utf8 *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_Utf8 ? static_cast<const org::apache::arrow::flatbuf::Utf8 *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::Bool *type_as_Bool() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::Bool ? static_cast<const org::apache::arrow::flatbuf::Bool *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_Bool ? static_cast<const org::apache::arrow::flatbuf::Bool *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::Decimal *type_as_Decimal() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::Decimal ? static_cast<const org::apache::arrow::flatbuf::Decimal *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_Decimal ? static_cast<const org::apache::arrow::flatbuf::Decimal *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::Date *type_as_Date() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::Date ? static_cast<const org::apache::arrow::flatbuf::Date *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_Date ? static_cast<const org::apache::arrow::flatbuf::Date *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::Time *type_as_Time() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::Time ? static_cast<const org::apache::arrow::flatbuf::Time *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_Time ? static_cast<const org::apache::arrow::flatbuf::Time *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::Timestamp *type_as_Timestamp() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::Timestamp ? static_cast<const org::apache::arrow::flatbuf::Timestamp *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_Timestamp ? static_cast<const org::apache::arrow::flatbuf::Timestamp *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::Interval *type_as_Interval() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::Interval ? static_cast<const org::apache::arrow::flatbuf::Interval *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_Interval ? static_cast<const org::apache::arrow::flatbuf::Interval *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::List *type_as_List() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::List ? static_cast<const org::apache::arrow::flatbuf::List *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_List ? static_cast<const org::apache::arrow::flatbuf::List *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::Struct_ *type_as_Struct_() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::Struct_ ? static_cast<const org::apache::arrow::flatbuf::Struct_ *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_Struct_ ? static_cast<const org::apache::arrow::flatbuf::Struct_ *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::Union *type_as_Union() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::Union ? static_cast<const org::apache::arrow::flatbuf::Union *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_Union ? static_cast<const org::apache::arrow::flatbuf::Union *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::FixedSizeBinary *type_as_FixedSizeBinary() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::FixedSizeBinary ? static_cast<const org::apache::arrow::flatbuf::FixedSizeBinary *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_FixedSizeBinary ? static_cast<const org::apache::arrow::flatbuf::FixedSizeBinary *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::FixedSizeList *type_as_FixedSizeList() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::FixedSizeList ? static_cast<const org::apache::arrow::flatbuf::FixedSizeList *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_FixedSizeList ? static_cast<const org::apache::arrow::flatbuf::FixedSizeList *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::Map *type_as_Map() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::Map ? static_cast<const org::apache::arrow::flatbuf::Map *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_Map ? static_cast<const org::apache::arrow::flatbuf::Map *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::Duration *type_as_Duration() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::Duration ? static_cast<const org::apache::arrow::flatbuf::Duration *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_Duration ? static_cast<const org::apache::arrow::flatbuf::Duration *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::LargeBinary *type_as_LargeBinary() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::LargeBinary ? static_cast<const org::apache::arrow::flatbuf::LargeBinary *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_LargeBinary ? static_cast<const org::apache::arrow::flatbuf::LargeBinary *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::LargeUtf8 *type_as_LargeUtf8() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::LargeUtf8 ? static_cast<const org::apache::arrow::flatbuf::LargeUtf8 *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_LargeUtf8 ? static_cast<const org::apache::arrow::flatbuf::LargeUtf8 *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::LargeList *type_as_LargeList() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::LargeList ? static_cast<const org::apache::arrow::flatbuf::LargeList *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_LargeList ? static_cast<const org::apache::arrow::flatbuf::LargeList *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::RunEndEncoded *type_as_RunEndEncoded() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::RunEndEncoded ? static_cast<const org::apache::arrow::flatbuf::RunEndEncoded *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_RunEndEncoded ? static_cast<const org::apache::arrow::flatbuf::RunEndEncoded *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::BinaryView *type_as_BinaryView() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::BinaryView ? static_cast<const org::apache::arrow::flatbuf::BinaryView *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_BinaryView ? static_cast<const org::apache::arrow::flatbuf::BinaryView *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::Utf8View *type_as_Utf8View() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::Utf8View ? static_cast<const org::apache::arrow::flatbuf::Utf8View *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_Utf8View ? static_cast<const org::apache::arrow::flatbuf::Utf8View *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::ListView *type_as_ListView() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::ListView ? static_cast<const org::apache::arrow::flatbuf::ListView *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_ListView ? static_cast<const org::apache::arrow::flatbuf::ListView *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::LargeListView *type_as_LargeListView() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::LargeListView ? static_cast<const org::apache::arrow::flatbuf::LargeListView *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_LargeListView ? static_cast<const org::apache::arrow::flatbuf::LargeListView *>(type()) : nullptr;
   }
   /// Present only if the field is dictionary encoded.
   const org::apache::arrow::flatbuf::DictionaryEncoding *dictionary() const {
@@ -2323,7 +2323,7 @@ inline ::flatbuffers::Offset<Field> CreateField(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     ::flatbuffers::Offset<::flatbuffers::String> name = 0,
     bool nullable = false,
-    org::apache::arrow::flatbuf::Type type_type = org::apache::arrow::flatbuf::Type::NONE,
+    org::apache::arrow::flatbuf::Type type_type = org::apache::arrow::flatbuf::Type_NONE,
     ::flatbuffers::Offset<void> type = 0,
     ::flatbuffers::Offset<org::apache::arrow::flatbuf::DictionaryEncoding> dictionary = 0,
     ::flatbuffers::Offset<::flatbuffers::Vector<::flatbuffers::Offset<org::apache::arrow::flatbuf::Field>>> children = 0,
@@ -2343,7 +2343,7 @@ inline ::flatbuffers::Offset<Field> CreateFieldDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     const char *name = nullptr,
     bool nullable = false,
-    org::apache::arrow::flatbuf::Type type_type = org::apache::arrow::flatbuf::Type::NONE,
+    org::apache::arrow::flatbuf::Type type_type = org::apache::arrow::flatbuf::Type_NONE,
     ::flatbuffers::Offset<void> type = 0,
     ::flatbuffers::Offset<org::apache::arrow::flatbuf::DictionaryEncoding> dictionary = 0,
     const std::vector<::flatbuffers::Offset<org::apache::arrow::flatbuf::Field>> *children = nullptr,
@@ -2385,8 +2385,8 @@ struct Schema FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
     return GetPointer<const ::flatbuffers::Vector<::flatbuffers::Offset<org::apache::arrow::flatbuf::KeyValue>> *>(VT_CUSTOM_METADATA);
   }
   /// Features used in the stream/file.
-  const ::flatbuffers::Vector<org::apache::arrow::flatbuf::Feature> *features() const {
-    return GetPointer<const ::flatbuffers::Vector<org::apache::arrow::flatbuf::Feature> *>(VT_FEATURES);
+  const ::flatbuffers::Vector<int64_t> *features() const {
+    return GetPointer<const ::flatbuffers::Vector<int64_t> *>(VT_FEATURES);
   }
   bool Verify(::flatbuffers::Verifier &verifier) const {
     return VerifyTableStart(verifier) &&
@@ -2416,7 +2416,7 @@ struct SchemaBuilder {
   void add_custom_metadata(::flatbuffers::Offset<::flatbuffers::Vector<::flatbuffers::Offset<org::apache::arrow::flatbuf::KeyValue>>> custom_metadata) {
     fbb_.AddOffset(Schema::VT_CUSTOM_METADATA, custom_metadata);
   }
-  void add_features(::flatbuffers::Offset<::flatbuffers::Vector<org::apache::arrow::flatbuf::Feature>> features) {
+  void add_features(::flatbuffers::Offset<::flatbuffers::Vector<int64_t>> features) {
     fbb_.AddOffset(Schema::VT_FEATURES, features);
   }
   explicit SchemaBuilder(::flatbuffers::FlatBufferBuilder &_fbb)
@@ -2432,10 +2432,10 @@ struct SchemaBuilder {
 
 inline ::flatbuffers::Offset<Schema> CreateSchema(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    org::apache::arrow::flatbuf::Endianness endianness = org::apache::arrow::flatbuf::Endianness::Little,
+    org::apache::arrow::flatbuf::Endianness endianness = org::apache::arrow::flatbuf::Endianness_Little,
     ::flatbuffers::Offset<::flatbuffers::Vector<::flatbuffers::Offset<org::apache::arrow::flatbuf::Field>>> fields = 0,
     ::flatbuffers::Offset<::flatbuffers::Vector<::flatbuffers::Offset<org::apache::arrow::flatbuf::KeyValue>>> custom_metadata = 0,
-    ::flatbuffers::Offset<::flatbuffers::Vector<org::apache::arrow::flatbuf::Feature>> features = 0) {
+    ::flatbuffers::Offset<::flatbuffers::Vector<int64_t>> features = 0) {
   SchemaBuilder builder_(_fbb);
   builder_.add_features(features);
   builder_.add_custom_metadata(custom_metadata);
@@ -2446,13 +2446,13 @@ inline ::flatbuffers::Offset<Schema> CreateSchema(
 
 inline ::flatbuffers::Offset<Schema> CreateSchemaDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    org::apache::arrow::flatbuf::Endianness endianness = org::apache::arrow::flatbuf::Endianness::Little,
+    org::apache::arrow::flatbuf::Endianness endianness = org::apache::arrow::flatbuf::Endianness_Little,
     const std::vector<::flatbuffers::Offset<org::apache::arrow::flatbuf::Field>> *fields = nullptr,
     const std::vector<::flatbuffers::Offset<org::apache::arrow::flatbuf::KeyValue>> *custom_metadata = nullptr,
-    const std::vector<org::apache::arrow::flatbuf::Feature> *features = nullptr) {
+    const std::vector<int64_t> *features = nullptr) {
   auto fields__ = fields ? _fbb.CreateVector<::flatbuffers::Offset<org::apache::arrow::flatbuf::Field>>(*fields) : 0;
   auto custom_metadata__ = custom_metadata ? _fbb.CreateVector<::flatbuffers::Offset<org::apache::arrow::flatbuf::KeyValue>>(*custom_metadata) : 0;
-  auto features__ = features ? _fbb.CreateVector<org::apache::arrow::flatbuf::Feature>(*features) : 0;
+  auto features__ = features ? _fbb.CreateVector<int64_t>(*features) : 0;
   return org::apache::arrow::flatbuf::CreateSchema(
       _fbb,
       endianness,
@@ -2463,110 +2463,110 @@ inline ::flatbuffers::Offset<Schema> CreateSchemaDirect(
 
 inline bool VerifyType(::flatbuffers::Verifier &verifier, const void *obj, Type type) {
   switch (type) {
-    case Type::NONE: {
+    case Type_NONE: {
       return true;
     }
-    case Type::Null: {
+    case Type_Null: {
       auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::Null *>(obj);
       return verifier.VerifyTable(ptr);
     }
-    case Type::Int: {
+    case Type_Int: {
       auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::Int *>(obj);
       return verifier.VerifyTable(ptr);
     }
-    case Type::FloatingPoint: {
+    case Type_FloatingPoint: {
       auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::FloatingPoint *>(obj);
       return verifier.VerifyTable(ptr);
     }
-    case Type::Binary: {
+    case Type_Binary: {
       auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::Binary *>(obj);
       return verifier.VerifyTable(ptr);
     }
-    case Type::Utf8: {
+    case Type_Utf8: {
       auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::Utf8 *>(obj);
       return verifier.VerifyTable(ptr);
     }
-    case Type::Bool: {
+    case Type_Bool: {
       auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::Bool *>(obj);
       return verifier.VerifyTable(ptr);
     }
-    case Type::Decimal: {
+    case Type_Decimal: {
       auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::Decimal *>(obj);
       return verifier.VerifyTable(ptr);
     }
-    case Type::Date: {
+    case Type_Date: {
       auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::Date *>(obj);
       return verifier.VerifyTable(ptr);
     }
-    case Type::Time: {
+    case Type_Time: {
       auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::Time *>(obj);
       return verifier.VerifyTable(ptr);
     }
-    case Type::Timestamp: {
+    case Type_Timestamp: {
       auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::Timestamp *>(obj);
       return verifier.VerifyTable(ptr);
     }
-    case Type::Interval: {
+    case Type_Interval: {
       auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::Interval *>(obj);
       return verifier.VerifyTable(ptr);
     }
-    case Type::List: {
+    case Type_List: {
       auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::List *>(obj);
       return verifier.VerifyTable(ptr);
     }
-    case Type::Struct_: {
+    case Type_Struct_: {
       auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::Struct_ *>(obj);
       return verifier.VerifyTable(ptr);
     }
-    case Type::Union: {
+    case Type_Union: {
       auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::Union *>(obj);
       return verifier.VerifyTable(ptr);
     }
-    case Type::FixedSizeBinary: {
+    case Type_FixedSizeBinary: {
       auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::FixedSizeBinary *>(obj);
       return verifier.VerifyTable(ptr);
     }
-    case Type::FixedSizeList: {
+    case Type_FixedSizeList: {
       auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::FixedSizeList *>(obj);
       return verifier.VerifyTable(ptr);
     }
-    case Type::Map: {
+    case Type_Map: {
       auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::Map *>(obj);
       return verifier.VerifyTable(ptr);
     }
-    case Type::Duration: {
+    case Type_Duration: {
       auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::Duration *>(obj);
       return verifier.VerifyTable(ptr);
     }
-    case Type::LargeBinary: {
+    case Type_LargeBinary: {
       auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::LargeBinary *>(obj);
       return verifier.VerifyTable(ptr);
     }
-    case Type::LargeUtf8: {
+    case Type_LargeUtf8: {
       auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::LargeUtf8 *>(obj);
       return verifier.VerifyTable(ptr);
     }
-    case Type::LargeList: {
+    case Type_LargeList: {
       auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::LargeList *>(obj);
       return verifier.VerifyTable(ptr);
     }
-    case Type::RunEndEncoded: {
+    case Type_RunEndEncoded: {
       auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::RunEndEncoded *>(obj);
       return verifier.VerifyTable(ptr);
     }
-    case Type::BinaryView: {
+    case Type_BinaryView: {
       auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::BinaryView *>(obj);
       return verifier.VerifyTable(ptr);
     }
-    case Type::Utf8View: {
+    case Type_Utf8View: {
       auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::Utf8View *>(obj);
       return verifier.VerifyTable(ptr);
     }
-    case Type::ListView: {
+    case Type_ListView: {
       auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::ListView *>(obj);
       return verifier.VerifyTable(ptr);
     }
-    case Type::LargeListView: {
+    case Type_LargeListView: {
       auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::LargeListView *>(obj);
       return verifier.VerifyTable(ptr);
     }
@@ -2574,7 +2574,7 @@ inline bool VerifyType(::flatbuffers::Verifier &verifier, const void *obj, Type 
   }
 }
 
-inline bool VerifyTypeVector(::flatbuffers::Verifier &verifier, const ::flatbuffers::Vector<::flatbuffers::Offset<void>> *values, const ::flatbuffers::Vector<Type> *types) {
+inline bool VerifyTypeVector(::flatbuffers::Verifier &verifier, const ::flatbuffers::Vector<::flatbuffers::Offset<void>> *values, const ::flatbuffers::Vector<uint8_t> *types) {
   if (!values || !types) return !values && !types;
   if (values->size() != types->size()) return false;
   for (::flatbuffers::uoffset_t i = 0; i < values->size(); ++i) {

--- a/cpp/src/generated/SparseTensor_generated.h
+++ b/cpp/src/generated/SparseTensor_generated.h
@@ -8,9 +8,9 @@
 
 // Ensure the included flatbuffers.h is the same version as when this file was
 // generated, otherwise it may not be compatible.
-static_assert(FLATBUFFERS_VERSION_MAJOR == 23 &&
-              FLATBUFFERS_VERSION_MINOR == 5 &&
-              FLATBUFFERS_VERSION_REVISION == 26,
+static_assert(FLATBUFFERS_VERSION_MAJOR == 24 &&
+              FLATBUFFERS_VERSION_MINOR == 3 &&
+              FLATBUFFERS_VERSION_REVISION == 6,
              "Non-compatible flatbuffers version included");
 
 #include "Tensor_generated.h"
@@ -32,17 +32,17 @@ struct SparseTensorIndexCSFBuilder;
 struct SparseTensor;
 struct SparseTensorBuilder;
 
-enum class SparseMatrixCompressedAxis : int16_t {
-  Row = 0,
-  Column = 1,
-  MIN = Row,
-  MAX = Column
+enum SparseMatrixCompressedAxis : int16_t {
+  SparseMatrixCompressedAxis_Row = 0,
+  SparseMatrixCompressedAxis_Column = 1,
+  SparseMatrixCompressedAxis_MIN = SparseMatrixCompressedAxis_Row,
+  SparseMatrixCompressedAxis_MAX = SparseMatrixCompressedAxis_Column
 };
 
 inline const SparseMatrixCompressedAxis (&EnumValuesSparseMatrixCompressedAxis())[2] {
   static const SparseMatrixCompressedAxis values[] = {
-    SparseMatrixCompressedAxis::Row,
-    SparseMatrixCompressedAxis::Column
+    SparseMatrixCompressedAxis_Row,
+    SparseMatrixCompressedAxis_Column
   };
   return values;
 }
@@ -57,26 +57,26 @@ inline const char * const *EnumNamesSparseMatrixCompressedAxis() {
 }
 
 inline const char *EnumNameSparseMatrixCompressedAxis(SparseMatrixCompressedAxis e) {
-  if (::flatbuffers::IsOutRange(e, SparseMatrixCompressedAxis::Row, SparseMatrixCompressedAxis::Column)) return "";
+  if (::flatbuffers::IsOutRange(e, SparseMatrixCompressedAxis_Row, SparseMatrixCompressedAxis_Column)) return "";
   const size_t index = static_cast<size_t>(e);
   return EnumNamesSparseMatrixCompressedAxis()[index];
 }
 
-enum class SparseTensorIndex : uint8_t {
-  NONE = 0,
-  SparseTensorIndexCOO = 1,
-  SparseMatrixIndexCSX = 2,
-  SparseTensorIndexCSF = 3,
-  MIN = NONE,
-  MAX = SparseTensorIndexCSF
+enum SparseTensorIndex : uint8_t {
+  SparseTensorIndex_NONE = 0,
+  SparseTensorIndex_SparseTensorIndexCOO = 1,
+  SparseTensorIndex_SparseMatrixIndexCSX = 2,
+  SparseTensorIndex_SparseTensorIndexCSF = 3,
+  SparseTensorIndex_MIN = SparseTensorIndex_NONE,
+  SparseTensorIndex_MAX = SparseTensorIndex_SparseTensorIndexCSF
 };
 
 inline const SparseTensorIndex (&EnumValuesSparseTensorIndex())[4] {
   static const SparseTensorIndex values[] = {
-    SparseTensorIndex::NONE,
-    SparseTensorIndex::SparseTensorIndexCOO,
-    SparseTensorIndex::SparseMatrixIndexCSX,
-    SparseTensorIndex::SparseTensorIndexCSF
+    SparseTensorIndex_NONE,
+    SparseTensorIndex_SparseTensorIndexCOO,
+    SparseTensorIndex_SparseMatrixIndexCSX,
+    SparseTensorIndex_SparseTensorIndexCSF
   };
   return values;
 }
@@ -93,29 +93,29 @@ inline const char * const *EnumNamesSparseTensorIndex() {
 }
 
 inline const char *EnumNameSparseTensorIndex(SparseTensorIndex e) {
-  if (::flatbuffers::IsOutRange(e, SparseTensorIndex::NONE, SparseTensorIndex::SparseTensorIndexCSF)) return "";
+  if (::flatbuffers::IsOutRange(e, SparseTensorIndex_NONE, SparseTensorIndex_SparseTensorIndexCSF)) return "";
   const size_t index = static_cast<size_t>(e);
   return EnumNamesSparseTensorIndex()[index];
 }
 
 template<typename T> struct SparseTensorIndexTraits {
-  static const SparseTensorIndex enum_value = SparseTensorIndex::NONE;
+  static const SparseTensorIndex enum_value = SparseTensorIndex_NONE;
 };
 
 template<> struct SparseTensorIndexTraits<org::apache::arrow::flatbuf::SparseTensorIndexCOO> {
-  static const SparseTensorIndex enum_value = SparseTensorIndex::SparseTensorIndexCOO;
+  static const SparseTensorIndex enum_value = SparseTensorIndex_SparseTensorIndexCOO;
 };
 
 template<> struct SparseTensorIndexTraits<org::apache::arrow::flatbuf::SparseMatrixIndexCSX> {
-  static const SparseTensorIndex enum_value = SparseTensorIndex::SparseMatrixIndexCSX;
+  static const SparseTensorIndex enum_value = SparseTensorIndex_SparseMatrixIndexCSX;
 };
 
 template<> struct SparseTensorIndexTraits<org::apache::arrow::flatbuf::SparseTensorIndexCSF> {
-  static const SparseTensorIndex enum_value = SparseTensorIndex::SparseTensorIndexCSF;
+  static const SparseTensorIndex enum_value = SparseTensorIndex_SparseTensorIndexCSF;
 };
 
 bool VerifySparseTensorIndex(::flatbuffers::Verifier &verifier, const void *obj, SparseTensorIndex type);
-bool VerifySparseTensorIndexVector(::flatbuffers::Verifier &verifier, const ::flatbuffers::Vector<::flatbuffers::Offset<void>> *values, const ::flatbuffers::Vector<SparseTensorIndex> *types);
+bool VerifySparseTensorIndexVector(::flatbuffers::Verifier &verifier, const ::flatbuffers::Vector<::flatbuffers::Offset<void>> *values, const ::flatbuffers::Vector<uint8_t> *types);
 
 /// ----------------------------------------------------------------------
 /// EXPERIMENTAL: Data structures for sparse tensors
@@ -357,7 +357,7 @@ struct SparseMatrixIndexCSXBuilder {
 
 inline ::flatbuffers::Offset<SparseMatrixIndexCSX> CreateSparseMatrixIndexCSX(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    org::apache::arrow::flatbuf::SparseMatrixCompressedAxis compressedAxis = org::apache::arrow::flatbuf::SparseMatrixCompressedAxis::Row,
+    org::apache::arrow::flatbuf::SparseMatrixCompressedAxis compressedAxis = org::apache::arrow::flatbuf::SparseMatrixCompressedAxis_Row,
     ::flatbuffers::Offset<org::apache::arrow::flatbuf::Int> indptrType = 0,
     const org::apache::arrow::flatbuf::Buffer *indptrBuffer = nullptr,
     ::flatbuffers::Offset<org::apache::arrow::flatbuf::Int> indicesType = 0,
@@ -567,82 +567,82 @@ struct SparseTensor FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   }
   template<typename T> const T *type_as() const;
   const org::apache::arrow::flatbuf::Null *type_as_Null() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::Null ? static_cast<const org::apache::arrow::flatbuf::Null *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_Null ? static_cast<const org::apache::arrow::flatbuf::Null *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::Int *type_as_Int() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::Int ? static_cast<const org::apache::arrow::flatbuf::Int *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_Int ? static_cast<const org::apache::arrow::flatbuf::Int *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::FloatingPoint *type_as_FloatingPoint() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::FloatingPoint ? static_cast<const org::apache::arrow::flatbuf::FloatingPoint *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_FloatingPoint ? static_cast<const org::apache::arrow::flatbuf::FloatingPoint *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::Binary *type_as_Binary() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::Binary ? static_cast<const org::apache::arrow::flatbuf::Binary *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_Binary ? static_cast<const org::apache::arrow::flatbuf::Binary *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::Utf8 *type_as_Utf8() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::Utf8 ? static_cast<const org::apache::arrow::flatbuf::Utf8 *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_Utf8 ? static_cast<const org::apache::arrow::flatbuf::Utf8 *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::Bool *type_as_Bool() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::Bool ? static_cast<const org::apache::arrow::flatbuf::Bool *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_Bool ? static_cast<const org::apache::arrow::flatbuf::Bool *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::Decimal *type_as_Decimal() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::Decimal ? static_cast<const org::apache::arrow::flatbuf::Decimal *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_Decimal ? static_cast<const org::apache::arrow::flatbuf::Decimal *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::Date *type_as_Date() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::Date ? static_cast<const org::apache::arrow::flatbuf::Date *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_Date ? static_cast<const org::apache::arrow::flatbuf::Date *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::Time *type_as_Time() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::Time ? static_cast<const org::apache::arrow::flatbuf::Time *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_Time ? static_cast<const org::apache::arrow::flatbuf::Time *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::Timestamp *type_as_Timestamp() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::Timestamp ? static_cast<const org::apache::arrow::flatbuf::Timestamp *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_Timestamp ? static_cast<const org::apache::arrow::flatbuf::Timestamp *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::Interval *type_as_Interval() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::Interval ? static_cast<const org::apache::arrow::flatbuf::Interval *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_Interval ? static_cast<const org::apache::arrow::flatbuf::Interval *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::List *type_as_List() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::List ? static_cast<const org::apache::arrow::flatbuf::List *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_List ? static_cast<const org::apache::arrow::flatbuf::List *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::Struct_ *type_as_Struct_() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::Struct_ ? static_cast<const org::apache::arrow::flatbuf::Struct_ *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_Struct_ ? static_cast<const org::apache::arrow::flatbuf::Struct_ *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::Union *type_as_Union() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::Union ? static_cast<const org::apache::arrow::flatbuf::Union *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_Union ? static_cast<const org::apache::arrow::flatbuf::Union *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::FixedSizeBinary *type_as_FixedSizeBinary() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::FixedSizeBinary ? static_cast<const org::apache::arrow::flatbuf::FixedSizeBinary *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_FixedSizeBinary ? static_cast<const org::apache::arrow::flatbuf::FixedSizeBinary *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::FixedSizeList *type_as_FixedSizeList() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::FixedSizeList ? static_cast<const org::apache::arrow::flatbuf::FixedSizeList *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_FixedSizeList ? static_cast<const org::apache::arrow::flatbuf::FixedSizeList *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::Map *type_as_Map() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::Map ? static_cast<const org::apache::arrow::flatbuf::Map *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_Map ? static_cast<const org::apache::arrow::flatbuf::Map *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::Duration *type_as_Duration() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::Duration ? static_cast<const org::apache::arrow::flatbuf::Duration *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_Duration ? static_cast<const org::apache::arrow::flatbuf::Duration *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::LargeBinary *type_as_LargeBinary() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::LargeBinary ? static_cast<const org::apache::arrow::flatbuf::LargeBinary *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_LargeBinary ? static_cast<const org::apache::arrow::flatbuf::LargeBinary *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::LargeUtf8 *type_as_LargeUtf8() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::LargeUtf8 ? static_cast<const org::apache::arrow::flatbuf::LargeUtf8 *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_LargeUtf8 ? static_cast<const org::apache::arrow::flatbuf::LargeUtf8 *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::LargeList *type_as_LargeList() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::LargeList ? static_cast<const org::apache::arrow::flatbuf::LargeList *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_LargeList ? static_cast<const org::apache::arrow::flatbuf::LargeList *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::RunEndEncoded *type_as_RunEndEncoded() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::RunEndEncoded ? static_cast<const org::apache::arrow::flatbuf::RunEndEncoded *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_RunEndEncoded ? static_cast<const org::apache::arrow::flatbuf::RunEndEncoded *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::BinaryView *type_as_BinaryView() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::BinaryView ? static_cast<const org::apache::arrow::flatbuf::BinaryView *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_BinaryView ? static_cast<const org::apache::arrow::flatbuf::BinaryView *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::Utf8View *type_as_Utf8View() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::Utf8View ? static_cast<const org::apache::arrow::flatbuf::Utf8View *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_Utf8View ? static_cast<const org::apache::arrow::flatbuf::Utf8View *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::ListView *type_as_ListView() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::ListView ? static_cast<const org::apache::arrow::flatbuf::ListView *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_ListView ? static_cast<const org::apache::arrow::flatbuf::ListView *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::LargeListView *type_as_LargeListView() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::LargeListView ? static_cast<const org::apache::arrow::flatbuf::LargeListView *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_LargeListView ? static_cast<const org::apache::arrow::flatbuf::LargeListView *>(type()) : nullptr;
   }
   /// The dimensions of the tensor, optionally named.
   const ::flatbuffers::Vector<::flatbuffers::Offset<org::apache::arrow::flatbuf::TensorDim>> *shape() const {
@@ -661,13 +661,13 @@ struct SparseTensor FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   }
   template<typename T> const T *sparseIndex_as() const;
   const org::apache::arrow::flatbuf::SparseTensorIndexCOO *sparseIndex_as_SparseTensorIndexCOO() const {
-    return sparseIndex_type() == org::apache::arrow::flatbuf::SparseTensorIndex::SparseTensorIndexCOO ? static_cast<const org::apache::arrow::flatbuf::SparseTensorIndexCOO *>(sparseIndex()) : nullptr;
+    return sparseIndex_type() == org::apache::arrow::flatbuf::SparseTensorIndex_SparseTensorIndexCOO ? static_cast<const org::apache::arrow::flatbuf::SparseTensorIndexCOO *>(sparseIndex()) : nullptr;
   }
   const org::apache::arrow::flatbuf::SparseMatrixIndexCSX *sparseIndex_as_SparseMatrixIndexCSX() const {
-    return sparseIndex_type() == org::apache::arrow::flatbuf::SparseTensorIndex::SparseMatrixIndexCSX ? static_cast<const org::apache::arrow::flatbuf::SparseMatrixIndexCSX *>(sparseIndex()) : nullptr;
+    return sparseIndex_type() == org::apache::arrow::flatbuf::SparseTensorIndex_SparseMatrixIndexCSX ? static_cast<const org::apache::arrow::flatbuf::SparseMatrixIndexCSX *>(sparseIndex()) : nullptr;
   }
   const org::apache::arrow::flatbuf::SparseTensorIndexCSF *sparseIndex_as_SparseTensorIndexCSF() const {
-    return sparseIndex_type() == org::apache::arrow::flatbuf::SparseTensorIndex::SparseTensorIndexCSF ? static_cast<const org::apache::arrow::flatbuf::SparseTensorIndexCSF *>(sparseIndex()) : nullptr;
+    return sparseIndex_type() == org::apache::arrow::flatbuf::SparseTensorIndex_SparseTensorIndexCSF ? static_cast<const org::apache::arrow::flatbuf::SparseTensorIndexCSF *>(sparseIndex()) : nullptr;
   }
   /// The location and size of the tensor's data
   const org::apache::arrow::flatbuf::Buffer *data() const {
@@ -848,11 +848,11 @@ struct SparseTensorBuilder {
 
 inline ::flatbuffers::Offset<SparseTensor> CreateSparseTensor(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    org::apache::arrow::flatbuf::Type type_type = org::apache::arrow::flatbuf::Type::NONE,
+    org::apache::arrow::flatbuf::Type type_type = org::apache::arrow::flatbuf::Type_NONE,
     ::flatbuffers::Offset<void> type = 0,
     ::flatbuffers::Offset<::flatbuffers::Vector<::flatbuffers::Offset<org::apache::arrow::flatbuf::TensorDim>>> shape = 0,
     int64_t non_zero_length = 0,
-    org::apache::arrow::flatbuf::SparseTensorIndex sparseIndex_type = org::apache::arrow::flatbuf::SparseTensorIndex::NONE,
+    org::apache::arrow::flatbuf::SparseTensorIndex sparseIndex_type = org::apache::arrow::flatbuf::SparseTensorIndex_NONE,
     ::flatbuffers::Offset<void> sparseIndex = 0,
     const org::apache::arrow::flatbuf::Buffer *data = nullptr) {
   SparseTensorBuilder builder_(_fbb);
@@ -868,11 +868,11 @@ inline ::flatbuffers::Offset<SparseTensor> CreateSparseTensor(
 
 inline ::flatbuffers::Offset<SparseTensor> CreateSparseTensorDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    org::apache::arrow::flatbuf::Type type_type = org::apache::arrow::flatbuf::Type::NONE,
+    org::apache::arrow::flatbuf::Type type_type = org::apache::arrow::flatbuf::Type_NONE,
     ::flatbuffers::Offset<void> type = 0,
     const std::vector<::flatbuffers::Offset<org::apache::arrow::flatbuf::TensorDim>> *shape = nullptr,
     int64_t non_zero_length = 0,
-    org::apache::arrow::flatbuf::SparseTensorIndex sparseIndex_type = org::apache::arrow::flatbuf::SparseTensorIndex::NONE,
+    org::apache::arrow::flatbuf::SparseTensorIndex sparseIndex_type = org::apache::arrow::flatbuf::SparseTensorIndex_NONE,
     ::flatbuffers::Offset<void> sparseIndex = 0,
     const org::apache::arrow::flatbuf::Buffer *data = nullptr) {
   auto shape__ = shape ? _fbb.CreateVector<::flatbuffers::Offset<org::apache::arrow::flatbuf::TensorDim>>(*shape) : 0;
@@ -889,18 +889,18 @@ inline ::flatbuffers::Offset<SparseTensor> CreateSparseTensorDirect(
 
 inline bool VerifySparseTensorIndex(::flatbuffers::Verifier &verifier, const void *obj, SparseTensorIndex type) {
   switch (type) {
-    case SparseTensorIndex::NONE: {
+    case SparseTensorIndex_NONE: {
       return true;
     }
-    case SparseTensorIndex::SparseTensorIndexCOO: {
+    case SparseTensorIndex_SparseTensorIndexCOO: {
       auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::SparseTensorIndexCOO *>(obj);
       return verifier.VerifyTable(ptr);
     }
-    case SparseTensorIndex::SparseMatrixIndexCSX: {
+    case SparseTensorIndex_SparseMatrixIndexCSX: {
       auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::SparseMatrixIndexCSX *>(obj);
       return verifier.VerifyTable(ptr);
     }
-    case SparseTensorIndex::SparseTensorIndexCSF: {
+    case SparseTensorIndex_SparseTensorIndexCSF: {
       auto ptr = reinterpret_cast<const org::apache::arrow::flatbuf::SparseTensorIndexCSF *>(obj);
       return verifier.VerifyTable(ptr);
     }
@@ -908,7 +908,7 @@ inline bool VerifySparseTensorIndex(::flatbuffers::Verifier &verifier, const voi
   }
 }
 
-inline bool VerifySparseTensorIndexVector(::flatbuffers::Verifier &verifier, const ::flatbuffers::Vector<::flatbuffers::Offset<void>> *values, const ::flatbuffers::Vector<SparseTensorIndex> *types) {
+inline bool VerifySparseTensorIndexVector(::flatbuffers::Verifier &verifier, const ::flatbuffers::Vector<::flatbuffers::Offset<void>> *values, const ::flatbuffers::Vector<uint8_t> *types) {
   if (!values || !types) return !values && !types;
   if (values->size() != types->size()) return false;
   for (::flatbuffers::uoffset_t i = 0; i < values->size(); ++i) {

--- a/cpp/src/generated/Tensor_generated.h
+++ b/cpp/src/generated/Tensor_generated.h
@@ -8,9 +8,9 @@
 
 // Ensure the included flatbuffers.h is the same version as when this file was
 // generated, otherwise it may not be compatible.
-static_assert(FLATBUFFERS_VERSION_MAJOR == 23 &&
-              FLATBUFFERS_VERSION_MINOR == 5 &&
-              FLATBUFFERS_VERSION_REVISION == 26,
+static_assert(FLATBUFFERS_VERSION_MAJOR == 24 &&
+              FLATBUFFERS_VERSION_MINOR == 3 &&
+              FLATBUFFERS_VERSION_REVISION == 6,
              "Non-compatible flatbuffers version included");
 
 #include "Schema_generated.h"
@@ -113,82 +113,82 @@ struct Tensor FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   }
   template<typename T> const T *type_as() const;
   const org::apache::arrow::flatbuf::Null *type_as_Null() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::Null ? static_cast<const org::apache::arrow::flatbuf::Null *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_Null ? static_cast<const org::apache::arrow::flatbuf::Null *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::Int *type_as_Int() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::Int ? static_cast<const org::apache::arrow::flatbuf::Int *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_Int ? static_cast<const org::apache::arrow::flatbuf::Int *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::FloatingPoint *type_as_FloatingPoint() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::FloatingPoint ? static_cast<const org::apache::arrow::flatbuf::FloatingPoint *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_FloatingPoint ? static_cast<const org::apache::arrow::flatbuf::FloatingPoint *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::Binary *type_as_Binary() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::Binary ? static_cast<const org::apache::arrow::flatbuf::Binary *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_Binary ? static_cast<const org::apache::arrow::flatbuf::Binary *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::Utf8 *type_as_Utf8() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::Utf8 ? static_cast<const org::apache::arrow::flatbuf::Utf8 *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_Utf8 ? static_cast<const org::apache::arrow::flatbuf::Utf8 *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::Bool *type_as_Bool() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::Bool ? static_cast<const org::apache::arrow::flatbuf::Bool *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_Bool ? static_cast<const org::apache::arrow::flatbuf::Bool *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::Decimal *type_as_Decimal() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::Decimal ? static_cast<const org::apache::arrow::flatbuf::Decimal *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_Decimal ? static_cast<const org::apache::arrow::flatbuf::Decimal *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::Date *type_as_Date() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::Date ? static_cast<const org::apache::arrow::flatbuf::Date *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_Date ? static_cast<const org::apache::arrow::flatbuf::Date *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::Time *type_as_Time() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::Time ? static_cast<const org::apache::arrow::flatbuf::Time *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_Time ? static_cast<const org::apache::arrow::flatbuf::Time *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::Timestamp *type_as_Timestamp() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::Timestamp ? static_cast<const org::apache::arrow::flatbuf::Timestamp *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_Timestamp ? static_cast<const org::apache::arrow::flatbuf::Timestamp *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::Interval *type_as_Interval() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::Interval ? static_cast<const org::apache::arrow::flatbuf::Interval *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_Interval ? static_cast<const org::apache::arrow::flatbuf::Interval *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::List *type_as_List() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::List ? static_cast<const org::apache::arrow::flatbuf::List *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_List ? static_cast<const org::apache::arrow::flatbuf::List *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::Struct_ *type_as_Struct_() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::Struct_ ? static_cast<const org::apache::arrow::flatbuf::Struct_ *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_Struct_ ? static_cast<const org::apache::arrow::flatbuf::Struct_ *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::Union *type_as_Union() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::Union ? static_cast<const org::apache::arrow::flatbuf::Union *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_Union ? static_cast<const org::apache::arrow::flatbuf::Union *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::FixedSizeBinary *type_as_FixedSizeBinary() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::FixedSizeBinary ? static_cast<const org::apache::arrow::flatbuf::FixedSizeBinary *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_FixedSizeBinary ? static_cast<const org::apache::arrow::flatbuf::FixedSizeBinary *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::FixedSizeList *type_as_FixedSizeList() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::FixedSizeList ? static_cast<const org::apache::arrow::flatbuf::FixedSizeList *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_FixedSizeList ? static_cast<const org::apache::arrow::flatbuf::FixedSizeList *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::Map *type_as_Map() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::Map ? static_cast<const org::apache::arrow::flatbuf::Map *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_Map ? static_cast<const org::apache::arrow::flatbuf::Map *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::Duration *type_as_Duration() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::Duration ? static_cast<const org::apache::arrow::flatbuf::Duration *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_Duration ? static_cast<const org::apache::arrow::flatbuf::Duration *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::LargeBinary *type_as_LargeBinary() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::LargeBinary ? static_cast<const org::apache::arrow::flatbuf::LargeBinary *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_LargeBinary ? static_cast<const org::apache::arrow::flatbuf::LargeBinary *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::LargeUtf8 *type_as_LargeUtf8() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::LargeUtf8 ? static_cast<const org::apache::arrow::flatbuf::LargeUtf8 *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_LargeUtf8 ? static_cast<const org::apache::arrow::flatbuf::LargeUtf8 *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::LargeList *type_as_LargeList() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::LargeList ? static_cast<const org::apache::arrow::flatbuf::LargeList *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_LargeList ? static_cast<const org::apache::arrow::flatbuf::LargeList *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::RunEndEncoded *type_as_RunEndEncoded() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::RunEndEncoded ? static_cast<const org::apache::arrow::flatbuf::RunEndEncoded *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_RunEndEncoded ? static_cast<const org::apache::arrow::flatbuf::RunEndEncoded *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::BinaryView *type_as_BinaryView() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::BinaryView ? static_cast<const org::apache::arrow::flatbuf::BinaryView *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_BinaryView ? static_cast<const org::apache::arrow::flatbuf::BinaryView *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::Utf8View *type_as_Utf8View() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::Utf8View ? static_cast<const org::apache::arrow::flatbuf::Utf8View *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_Utf8View ? static_cast<const org::apache::arrow::flatbuf::Utf8View *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::ListView *type_as_ListView() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::ListView ? static_cast<const org::apache::arrow::flatbuf::ListView *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_ListView ? static_cast<const org::apache::arrow::flatbuf::ListView *>(type()) : nullptr;
   }
   const org::apache::arrow::flatbuf::LargeListView *type_as_LargeListView() const {
-    return type_type() == org::apache::arrow::flatbuf::Type::LargeListView ? static_cast<const org::apache::arrow::flatbuf::LargeListView *>(type()) : nullptr;
+    return type_type() == org::apache::arrow::flatbuf::Type_LargeListView ? static_cast<const org::apache::arrow::flatbuf::LargeListView *>(type()) : nullptr;
   }
   /// The dimensions of the tensor, optionally named
   const ::flatbuffers::Vector<::flatbuffers::Offset<org::apache::arrow::flatbuf::TensorDim>> *shape() const {
@@ -357,7 +357,7 @@ struct TensorBuilder {
 
 inline ::flatbuffers::Offset<Tensor> CreateTensor(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    org::apache::arrow::flatbuf::Type type_type = org::apache::arrow::flatbuf::Type::NONE,
+    org::apache::arrow::flatbuf::Type type_type = org::apache::arrow::flatbuf::Type_NONE,
     ::flatbuffers::Offset<void> type = 0,
     ::flatbuffers::Offset<::flatbuffers::Vector<::flatbuffers::Offset<org::apache::arrow::flatbuf::TensorDim>>> shape = 0,
     ::flatbuffers::Offset<::flatbuffers::Vector<int64_t>> strides = 0,
@@ -373,7 +373,7 @@ inline ::flatbuffers::Offset<Tensor> CreateTensor(
 
 inline ::flatbuffers::Offset<Tensor> CreateTensorDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    org::apache::arrow::flatbuf::Type type_type = org::apache::arrow::flatbuf::Type::NONE,
+    org::apache::arrow::flatbuf::Type type_type = org::apache::arrow::flatbuf::Type_NONE,
     ::flatbuffers::Offset<void> type = 0,
     const std::vector<::flatbuffers::Offset<org::apache::arrow::flatbuf::TensorDim>> *shape = nullptr,
     const std::vector<int64_t> *strides = nullptr,

--- a/cpp/src/generated/feather_generated.h
+++ b/cpp/src/generated/feather_generated.h
@@ -8,9 +8,9 @@
 
 // Ensure the included flatbuffers.h is the same version as when this file was
 // generated, otherwise it may not be compatible.
-static_assert(FLATBUFFERS_VERSION_MAJOR == 23 &&
-              FLATBUFFERS_VERSION_MINOR == 5 &&
-              FLATBUFFERS_VERSION_REVISION == 26,
+static_assert(FLATBUFFERS_VERSION_MAJOR == 24 &&
+              FLATBUFFERS_VERSION_MINOR == 3 &&
+              FLATBUFFERS_VERSION_REVISION == 6,
              "Non-compatible flatbuffers version included");
 
 namespace arrow {
@@ -45,51 +45,51 @@ struct CTableBuilder;
 /// R. It enabled the developers to sidestep some of the open design questions
 /// in Arrow from early 2016 and instead create something simple and useful for
 /// the intended use cases.
-enum class Type : int8_t {
-  BOOL = 0,
-  INT8 = 1,
-  INT16 = 2,
-  INT32 = 3,
-  INT64 = 4,
-  UINT8 = 5,
-  UINT16 = 6,
-  UINT32 = 7,
-  UINT64 = 8,
-  FLOAT = 9,
-  DOUBLE = 10,
-  UTF8 = 11,
-  BINARY = 12,
-  CATEGORY = 13,
-  TIMESTAMP = 14,
-  DATE = 15,
-  TIME = 16,
-  LARGE_UTF8 = 17,
-  LARGE_BINARY = 18,
-  MIN = BOOL,
-  MAX = LARGE_BINARY
+enum Type : int8_t {
+  Type_BOOL = 0,
+  Type_INT8 = 1,
+  Type_INT16 = 2,
+  Type_INT32 = 3,
+  Type_INT64 = 4,
+  Type_UINT8 = 5,
+  Type_UINT16 = 6,
+  Type_UINT32 = 7,
+  Type_UINT64 = 8,
+  Type_FLOAT = 9,
+  Type_DOUBLE = 10,
+  Type_UTF8 = 11,
+  Type_BINARY = 12,
+  Type_CATEGORY = 13,
+  Type_TIMESTAMP = 14,
+  Type_DATE = 15,
+  Type_TIME = 16,
+  Type_LARGE_UTF8 = 17,
+  Type_LARGE_BINARY = 18,
+  Type_MIN = Type_BOOL,
+  Type_MAX = Type_LARGE_BINARY
 };
 
 inline const Type (&EnumValuesType())[19] {
   static const Type values[] = {
-    Type::BOOL,
-    Type::INT8,
-    Type::INT16,
-    Type::INT32,
-    Type::INT64,
-    Type::UINT8,
-    Type::UINT16,
-    Type::UINT32,
-    Type::UINT64,
-    Type::FLOAT,
-    Type::DOUBLE,
-    Type::UTF8,
-    Type::BINARY,
-    Type::CATEGORY,
-    Type::TIMESTAMP,
-    Type::DATE,
-    Type::TIME,
-    Type::LARGE_UTF8,
-    Type::LARGE_BINARY
+    Type_BOOL,
+    Type_INT8,
+    Type_INT16,
+    Type_INT32,
+    Type_INT64,
+    Type_UINT8,
+    Type_UINT16,
+    Type_UINT32,
+    Type_UINT64,
+    Type_FLOAT,
+    Type_DOUBLE,
+    Type_UTF8,
+    Type_BINARY,
+    Type_CATEGORY,
+    Type_TIMESTAMP,
+    Type_DATE,
+    Type_TIME,
+    Type_LARGE_UTF8,
+    Type_LARGE_BINARY
   };
   return values;
 }
@@ -121,28 +121,28 @@ inline const char * const *EnumNamesType() {
 }
 
 inline const char *EnumNameType(Type e) {
-  if (::flatbuffers::IsOutRange(e, Type::BOOL, Type::LARGE_BINARY)) return "";
+  if (::flatbuffers::IsOutRange(e, Type_BOOL, Type_LARGE_BINARY)) return "";
   const size_t index = static_cast<size_t>(e);
   return EnumNamesType()[index];
 }
 
-enum class Encoding : int8_t {
-  PLAIN = 0,
+enum Encoding : int8_t {
+  Encoding_PLAIN = 0,
   /// Data is stored dictionary-encoded
   /// dictionary size: <INT32 Dictionary size>
   /// dictionary data: <TYPE primitive array>
   /// dictionary index: <INT32 primitive array>
   ///
   /// TODO: do we care about storing the index values in a smaller typeclass
-  DICTIONARY = 1,
-  MIN = PLAIN,
-  MAX = DICTIONARY
+  Encoding_DICTIONARY = 1,
+  Encoding_MIN = Encoding_PLAIN,
+  Encoding_MAX = Encoding_DICTIONARY
 };
 
 inline const Encoding (&EnumValuesEncoding())[2] {
   static const Encoding values[] = {
-    Encoding::PLAIN,
-    Encoding::DICTIONARY
+    Encoding_PLAIN,
+    Encoding_DICTIONARY
   };
   return values;
 }
@@ -157,26 +157,26 @@ inline const char * const *EnumNamesEncoding() {
 }
 
 inline const char *EnumNameEncoding(Encoding e) {
-  if (::flatbuffers::IsOutRange(e, Encoding::PLAIN, Encoding::DICTIONARY)) return "";
+  if (::flatbuffers::IsOutRange(e, Encoding_PLAIN, Encoding_DICTIONARY)) return "";
   const size_t index = static_cast<size_t>(e);
   return EnumNamesEncoding()[index];
 }
 
-enum class TimeUnit : int8_t {
-  SECOND = 0,
-  MILLISECOND = 1,
-  MICROSECOND = 2,
-  NANOSECOND = 3,
-  MIN = SECOND,
-  MAX = NANOSECOND
+enum TimeUnit : int8_t {
+  TimeUnit_SECOND = 0,
+  TimeUnit_MILLISECOND = 1,
+  TimeUnit_MICROSECOND = 2,
+  TimeUnit_NANOSECOND = 3,
+  TimeUnit_MIN = TimeUnit_SECOND,
+  TimeUnit_MAX = TimeUnit_NANOSECOND
 };
 
 inline const TimeUnit (&EnumValuesTimeUnit())[4] {
   static const TimeUnit values[] = {
-    TimeUnit::SECOND,
-    TimeUnit::MILLISECOND,
-    TimeUnit::MICROSECOND,
-    TimeUnit::NANOSECOND
+    TimeUnit_SECOND,
+    TimeUnit_MILLISECOND,
+    TimeUnit_MICROSECOND,
+    TimeUnit_NANOSECOND
   };
   return values;
 }
@@ -193,28 +193,28 @@ inline const char * const *EnumNamesTimeUnit() {
 }
 
 inline const char *EnumNameTimeUnit(TimeUnit e) {
-  if (::flatbuffers::IsOutRange(e, TimeUnit::SECOND, TimeUnit::NANOSECOND)) return "";
+  if (::flatbuffers::IsOutRange(e, TimeUnit_SECOND, TimeUnit_NANOSECOND)) return "";
   const size_t index = static_cast<size_t>(e);
   return EnumNamesTimeUnit()[index];
 }
 
-enum class TypeMetadata : uint8_t {
-  NONE = 0,
-  CategoryMetadata = 1,
-  TimestampMetadata = 2,
-  DateMetadata = 3,
-  TimeMetadata = 4,
-  MIN = NONE,
-  MAX = TimeMetadata
+enum TypeMetadata : uint8_t {
+  TypeMetadata_NONE = 0,
+  TypeMetadata_CategoryMetadata = 1,
+  TypeMetadata_TimestampMetadata = 2,
+  TypeMetadata_DateMetadata = 3,
+  TypeMetadata_TimeMetadata = 4,
+  TypeMetadata_MIN = TypeMetadata_NONE,
+  TypeMetadata_MAX = TypeMetadata_TimeMetadata
 };
 
 inline const TypeMetadata (&EnumValuesTypeMetadata())[5] {
   static const TypeMetadata values[] = {
-    TypeMetadata::NONE,
-    TypeMetadata::CategoryMetadata,
-    TypeMetadata::TimestampMetadata,
-    TypeMetadata::DateMetadata,
-    TypeMetadata::TimeMetadata
+    TypeMetadata_NONE,
+    TypeMetadata_CategoryMetadata,
+    TypeMetadata_TimestampMetadata,
+    TypeMetadata_DateMetadata,
+    TypeMetadata_TimeMetadata
   };
   return values;
 }
@@ -232,33 +232,33 @@ inline const char * const *EnumNamesTypeMetadata() {
 }
 
 inline const char *EnumNameTypeMetadata(TypeMetadata e) {
-  if (::flatbuffers::IsOutRange(e, TypeMetadata::NONE, TypeMetadata::TimeMetadata)) return "";
+  if (::flatbuffers::IsOutRange(e, TypeMetadata_NONE, TypeMetadata_TimeMetadata)) return "";
   const size_t index = static_cast<size_t>(e);
   return EnumNamesTypeMetadata()[index];
 }
 
 template<typename T> struct TypeMetadataTraits {
-  static const TypeMetadata enum_value = TypeMetadata::NONE;
+  static const TypeMetadata enum_value = TypeMetadata_NONE;
 };
 
 template<> struct TypeMetadataTraits<arrow::ipc::feather::fbs::CategoryMetadata> {
-  static const TypeMetadata enum_value = TypeMetadata::CategoryMetadata;
+  static const TypeMetadata enum_value = TypeMetadata_CategoryMetadata;
 };
 
 template<> struct TypeMetadataTraits<arrow::ipc::feather::fbs::TimestampMetadata> {
-  static const TypeMetadata enum_value = TypeMetadata::TimestampMetadata;
+  static const TypeMetadata enum_value = TypeMetadata_TimestampMetadata;
 };
 
 template<> struct TypeMetadataTraits<arrow::ipc::feather::fbs::DateMetadata> {
-  static const TypeMetadata enum_value = TypeMetadata::DateMetadata;
+  static const TypeMetadata enum_value = TypeMetadata_DateMetadata;
 };
 
 template<> struct TypeMetadataTraits<arrow::ipc::feather::fbs::TimeMetadata> {
-  static const TypeMetadata enum_value = TypeMetadata::TimeMetadata;
+  static const TypeMetadata enum_value = TypeMetadata_TimeMetadata;
 };
 
 bool VerifyTypeMetadata(::flatbuffers::Verifier &verifier, const void *obj, TypeMetadata type);
-bool VerifyTypeMetadataVector(::flatbuffers::Verifier &verifier, const ::flatbuffers::Vector<::flatbuffers::Offset<void>> *values, const ::flatbuffers::Vector<TypeMetadata> *types);
+bool VerifyTypeMetadataVector(::flatbuffers::Verifier &verifier, const ::flatbuffers::Vector<::flatbuffers::Offset<void>> *values, const ::flatbuffers::Vector<uint8_t> *types);
 
 struct PrimitiveArray FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   typedef PrimitiveArrayBuilder Builder;
@@ -340,8 +340,8 @@ struct PrimitiveArrayBuilder {
 
 inline ::flatbuffers::Offset<PrimitiveArray> CreatePrimitiveArray(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    arrow::ipc::feather::fbs::Type type = arrow::ipc::feather::fbs::Type::BOOL,
-    arrow::ipc::feather::fbs::Encoding encoding = arrow::ipc::feather::fbs::Encoding::PLAIN,
+    arrow::ipc::feather::fbs::Type type = arrow::ipc::feather::fbs::Type_BOOL,
+    arrow::ipc::feather::fbs::Encoding encoding = arrow::ipc::feather::fbs::Encoding_PLAIN,
     int64_t offset = 0,
     int64_t length = 0,
     int64_t null_count = 0,
@@ -456,7 +456,7 @@ struct TimestampMetadataBuilder {
 
 inline ::flatbuffers::Offset<TimestampMetadata> CreateTimestampMetadata(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    arrow::ipc::feather::fbs::TimeUnit unit = arrow::ipc::feather::fbs::TimeUnit::SECOND,
+    arrow::ipc::feather::fbs::TimeUnit unit = arrow::ipc::feather::fbs::TimeUnit_SECOND,
     ::flatbuffers::Offset<::flatbuffers::String> timezone = 0) {
   TimestampMetadataBuilder builder_(_fbb);
   builder_.add_timezone(timezone);
@@ -466,7 +466,7 @@ inline ::flatbuffers::Offset<TimestampMetadata> CreateTimestampMetadata(
 
 inline ::flatbuffers::Offset<TimestampMetadata> CreateTimestampMetadataDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    arrow::ipc::feather::fbs::TimeUnit unit = arrow::ipc::feather::fbs::TimeUnit::SECOND,
+    arrow::ipc::feather::fbs::TimeUnit unit = arrow::ipc::feather::fbs::TimeUnit_SECOND,
     const char *timezone = nullptr) {
   auto timezone__ = timezone ? _fbb.CreateString(timezone) : 0;
   return arrow::ipc::feather::fbs::CreateTimestampMetadata(
@@ -539,7 +539,7 @@ struct TimeMetadataBuilder {
 
 inline ::flatbuffers::Offset<TimeMetadata> CreateTimeMetadata(
     ::flatbuffers::FlatBufferBuilder &_fbb,
-    arrow::ipc::feather::fbs::TimeUnit unit = arrow::ipc::feather::fbs::TimeUnit::SECOND) {
+    arrow::ipc::feather::fbs::TimeUnit unit = arrow::ipc::feather::fbs::TimeUnit_SECOND) {
   TimeMetadataBuilder builder_(_fbb);
   builder_.add_unit(unit);
   return builder_.Finish();
@@ -568,16 +568,16 @@ struct Column FLATBUFFERS_FINAL_CLASS : private ::flatbuffers::Table {
   }
   template<typename T> const T *metadata_as() const;
   const arrow::ipc::feather::fbs::CategoryMetadata *metadata_as_CategoryMetadata() const {
-    return metadata_type() == arrow::ipc::feather::fbs::TypeMetadata::CategoryMetadata ? static_cast<const arrow::ipc::feather::fbs::CategoryMetadata *>(metadata()) : nullptr;
+    return metadata_type() == arrow::ipc::feather::fbs::TypeMetadata_CategoryMetadata ? static_cast<const arrow::ipc::feather::fbs::CategoryMetadata *>(metadata()) : nullptr;
   }
   const arrow::ipc::feather::fbs::TimestampMetadata *metadata_as_TimestampMetadata() const {
-    return metadata_type() == arrow::ipc::feather::fbs::TypeMetadata::TimestampMetadata ? static_cast<const arrow::ipc::feather::fbs::TimestampMetadata *>(metadata()) : nullptr;
+    return metadata_type() == arrow::ipc::feather::fbs::TypeMetadata_TimestampMetadata ? static_cast<const arrow::ipc::feather::fbs::TimestampMetadata *>(metadata()) : nullptr;
   }
   const arrow::ipc::feather::fbs::DateMetadata *metadata_as_DateMetadata() const {
-    return metadata_type() == arrow::ipc::feather::fbs::TypeMetadata::DateMetadata ? static_cast<const arrow::ipc::feather::fbs::DateMetadata *>(metadata()) : nullptr;
+    return metadata_type() == arrow::ipc::feather::fbs::TypeMetadata_DateMetadata ? static_cast<const arrow::ipc::feather::fbs::DateMetadata *>(metadata()) : nullptr;
   }
   const arrow::ipc::feather::fbs::TimeMetadata *metadata_as_TimeMetadata() const {
-    return metadata_type() == arrow::ipc::feather::fbs::TypeMetadata::TimeMetadata ? static_cast<const arrow::ipc::feather::fbs::TimeMetadata *>(metadata()) : nullptr;
+    return metadata_type() == arrow::ipc::feather::fbs::TypeMetadata_TimeMetadata ? static_cast<const arrow::ipc::feather::fbs::TimeMetadata *>(metadata()) : nullptr;
   }
   /// This should (probably) be JSON
   const ::flatbuffers::String *user_metadata() const {
@@ -648,7 +648,7 @@ inline ::flatbuffers::Offset<Column> CreateColumn(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     ::flatbuffers::Offset<::flatbuffers::String> name = 0,
     ::flatbuffers::Offset<arrow::ipc::feather::fbs::PrimitiveArray> values = 0,
-    arrow::ipc::feather::fbs::TypeMetadata metadata_type = arrow::ipc::feather::fbs::TypeMetadata::NONE,
+    arrow::ipc::feather::fbs::TypeMetadata metadata_type = arrow::ipc::feather::fbs::TypeMetadata_NONE,
     ::flatbuffers::Offset<void> metadata = 0,
     ::flatbuffers::Offset<::flatbuffers::String> user_metadata = 0) {
   ColumnBuilder builder_(_fbb);
@@ -664,7 +664,7 @@ inline ::flatbuffers::Offset<Column> CreateColumnDirect(
     ::flatbuffers::FlatBufferBuilder &_fbb,
     const char *name = nullptr,
     ::flatbuffers::Offset<arrow::ipc::feather::fbs::PrimitiveArray> values = 0,
-    arrow::ipc::feather::fbs::TypeMetadata metadata_type = arrow::ipc::feather::fbs::TypeMetadata::NONE,
+    arrow::ipc::feather::fbs::TypeMetadata metadata_type = arrow::ipc::feather::fbs::TypeMetadata_NONE,
     ::flatbuffers::Offset<void> metadata = 0,
     const char *user_metadata = nullptr) {
   auto name__ = name ? _fbb.CreateString(name) : 0;
@@ -790,22 +790,22 @@ inline ::flatbuffers::Offset<CTable> CreateCTableDirect(
 
 inline bool VerifyTypeMetadata(::flatbuffers::Verifier &verifier, const void *obj, TypeMetadata type) {
   switch (type) {
-    case TypeMetadata::NONE: {
+    case TypeMetadata_NONE: {
       return true;
     }
-    case TypeMetadata::CategoryMetadata: {
+    case TypeMetadata_CategoryMetadata: {
       auto ptr = reinterpret_cast<const arrow::ipc::feather::fbs::CategoryMetadata *>(obj);
       return verifier.VerifyTable(ptr);
     }
-    case TypeMetadata::TimestampMetadata: {
+    case TypeMetadata_TimestampMetadata: {
       auto ptr = reinterpret_cast<const arrow::ipc::feather::fbs::TimestampMetadata *>(obj);
       return verifier.VerifyTable(ptr);
     }
-    case TypeMetadata::DateMetadata: {
+    case TypeMetadata_DateMetadata: {
       auto ptr = reinterpret_cast<const arrow::ipc::feather::fbs::DateMetadata *>(obj);
       return verifier.VerifyTable(ptr);
     }
-    case TypeMetadata::TimeMetadata: {
+    case TypeMetadata_TimeMetadata: {
       auto ptr = reinterpret_cast<const arrow::ipc::feather::fbs::TimeMetadata *>(obj);
       return verifier.VerifyTable(ptr);
     }
@@ -813,7 +813,7 @@ inline bool VerifyTypeMetadata(::flatbuffers::Verifier &verifier, const void *ob
   }
 }
 
-inline bool VerifyTypeMetadataVector(::flatbuffers::Verifier &verifier, const ::flatbuffers::Vector<::flatbuffers::Offset<void>> *values, const ::flatbuffers::Vector<TypeMetadata> *types) {
+inline bool VerifyTypeMetadataVector(::flatbuffers::Verifier &verifier, const ::flatbuffers::Vector<::flatbuffers::Offset<void>> *values, const ::flatbuffers::Vector<uint8_t> *types) {
   if (!values || !types) return !values && !types;
   if (values->size() != types->size()) return false;
   for (::flatbuffers::uoffset_t i = 0; i < values->size(); ++i) {

--- a/cpp/src/skyhook/protocol/ScanRequest_generated.h
+++ b/cpp/src/skyhook/protocol/ScanRequest_generated.h
@@ -8,9 +8,9 @@
 
 // Ensure the included flatbuffers.h is the same version as when this file was
 // generated, otherwise it may not be compatible.
-static_assert(FLATBUFFERS_VERSION_MAJOR == 23 &&
-              FLATBUFFERS_VERSION_MINOR == 5 &&
-              FLATBUFFERS_VERSION_REVISION == 26,
+static_assert(FLATBUFFERS_VERSION_MAJOR == 24 &&
+              FLATBUFFERS_VERSION_MINOR == 3 &&
+              FLATBUFFERS_VERSION_REVISION == 6,
              "Non-compatible flatbuffers version included");
 
 namespace org {

--- a/cpp/thirdparty/flatbuffers/README.md
+++ b/cpp/thirdparty/flatbuffers/README.md
@@ -18,7 +18,7 @@
 -->
 
 This directory contains a vendored version of Flatbuffers
-(v23.5.26), with a patch for ARROW-17280.
+(v24.3.6), with a patch for ARROW-17280.
 
 ```diff
 diff --git a/cpp/thirdparty/flatbuffers/include/flatbuffers/allocator.h b/cpp/thirdparty/flatbuffers/include/flatbuffers/allocator.h

--- a/cpp/thirdparty/flatbuffers/include/flatbuffers/base.h
+++ b/cpp/thirdparty/flatbuffers/include/flatbuffers/base.h
@@ -145,9 +145,9 @@ namespace flatbuffers = arrow_vendored_private::flatbuffers;
   #endif
 #endif // !defined(FLATBUFFERS_LITTLEENDIAN)
 
-#define FLATBUFFERS_VERSION_MAJOR 23
-#define FLATBUFFERS_VERSION_MINOR 5
-#define FLATBUFFERS_VERSION_REVISION 26
+#define FLATBUFFERS_VERSION_MAJOR 24
+#define FLATBUFFERS_VERSION_MINOR 3
+#define FLATBUFFERS_VERSION_REVISION 6
 #define FLATBUFFERS_STRING_EXPAND(X) #X
 #define FLATBUFFERS_STRING(X) FLATBUFFERS_STRING_EXPAND(X)
 
@@ -164,7 +164,7 @@ namespace flatbuffers {
   #define FLATBUFFERS_FINAL_CLASS final
   #define FLATBUFFERS_OVERRIDE override
   #define FLATBUFFERS_EXPLICIT_CPP11 explicit
-  #define FLATBUFFERS_VTABLE_UNDERLYING_TYPE : flatbuffers::voffset_t
+  #define FLATBUFFERS_VTABLE_UNDERLYING_TYPE : ::flatbuffers::voffset_t
 #else
   #define FLATBUFFERS_FINAL_CLASS
   #define FLATBUFFERS_OVERRIDE
@@ -298,10 +298,14 @@ namespace flatbuffers {
   #define FLATBUFFERS_SUPPRESS_UBSAN(type)
 #endif
 
-// This is constexpr function used for checking compile-time constants.
-// Avoid `#pragma warning(disable: 4127) // C4127: expression is constant`.
-template<typename T> FLATBUFFERS_CONSTEXPR inline bool IsConstTrue(T t) {
-  return !!t;
+namespace arrow_vendored_private {
+namespace flatbuffers {
+  // This is constexpr function used for checking compile-time constants.
+  // Avoid `#pragma warning(disable: 4127) // C4127: expression is constant`.
+  template<typename T> FLATBUFFERS_CONSTEXPR inline bool IsConstTrue(T t) {
+    return !!t;
+  }
+}
 }
 
 // Enable C++ attribute [[]] if std:c++17 or higher.
@@ -371,7 +375,6 @@ inline bool VerifyAlignmentRequirements(size_t align, size_t min_align = 1) {
 }
 
 #if defined(_MSC_VER)
-  #pragma warning(disable: 4351) // C4351: new behavior: elements of array ... will be default initialized
   #pragma warning(push)
   #pragma warning(disable: 4127) // C4127: conditional expression is constant
 #endif

--- a/cpp/thirdparty/flatbuffers/include/flatbuffers/flatbuffer_builder.h
+++ b/cpp/thirdparty/flatbuffers/include/flatbuffers/flatbuffer_builder.h
@@ -52,8 +52,9 @@ inline voffset_t FieldIndexToOffset(voffset_t field_id) {
   // Should correspond to what EndTable() below builds up.
   const voffset_t fixed_fields =
       2 * sizeof(voffset_t);  // Vtable size and Object Size.
-  return fixed_fields + field_id * sizeof(voffset_t);
-}
+  size_t offset = fixed_fields + field_id * sizeof(voffset_t);
+  FLATBUFFERS_ASSERT(offset < std::numeric_limits<voffset_t>::max());
+  return static_cast<voffset_t>(offset);}
 
 template<typename T, typename Alloc = std::allocator<T>>
 const T *data(const std::vector<T, Alloc> &v) {
@@ -227,21 +228,13 @@ template<bool Is64Aware = false> class FlatBufferBuilderImpl {
   /// @return Returns a `uint8_t` pointer to the unfinished buffer.
   uint8_t *GetCurrentBufferPointer() const { return buf_.data(); }
 
-  /// @brief Get the released pointer to the serialized buffer.
-  /// @warning Do NOT attempt to use this FlatBufferBuilder afterwards!
-  /// @return A `FlatBuffer` that owns the buffer and its allocator and
-  /// behaves similar to a `unique_ptr` with a deleter.
-  FLATBUFFERS_ATTRIBUTE([[deprecated("use Release() instead")]])
-  DetachedBuffer ReleaseBufferPointer() {
-    Finished();
-    return buf_.release();
-  }
-
   /// @brief Get the released DetachedBuffer.
   /// @return A `DetachedBuffer` that owns the buffer and its allocator.
   DetachedBuffer Release() {
     Finished();
-    return buf_.release();
+    DetachedBuffer buffer = buf_.release();
+    Clear();
+    return buffer;
   }
 
   /// @brief Get the released pointer to the serialized buffer.
@@ -252,10 +245,12 @@ template<bool Is64Aware = false> class FlatBufferBuilderImpl {
   /// @return A raw pointer to the start of the memory block containing
   /// the serialized `FlatBuffer`.
   /// @remark If the allocator is owned, it gets deleted when the destructor is
-  /// called..
+  /// called.
   uint8_t *ReleaseRaw(size_t &size, size_t &offset) {
     Finished();
-    return buf_.release_raw(size, offset);
+    uint8_t* raw = buf_.release_raw(size, offset);
+    Clear();
+    return raw;
   }
 
   /// @brief get the minimum alignment this buffer needs to be accessed
@@ -573,7 +568,7 @@ template<bool Is64Aware = false> class FlatBufferBuilderImpl {
     return CreateString<OffsetT>(str.c_str(), str.length());
   }
 
-  // clang-format off
+// clang-format off
   #ifdef FLATBUFFERS_HAS_STRING_VIEW
   /// @brief Store a string in the buffer, which can contain any binary data.
   /// @param[in] str A const string_view to copy in to the buffer.
@@ -595,14 +590,14 @@ template<bool Is64Aware = false> class FlatBufferBuilderImpl {
 
   /// @brief Store a string in the buffer, which can contain any binary data.
   /// @param[in] str A const reference to a std::string like type with support
-  /// of T::c_str() and T::length() to store in the buffer.
+  /// of T::data() and T::length() to store in the buffer.
   /// @return Returns the offset in the buffer where the string starts.
   template<template<typename> class OffsetT = Offset,
            // No need to explicitly declare the T type, let the compiler deduce
            // it.
            int &...ExplicitArgumentBarrier, typename T>
   OffsetT<String> CreateString(const T &str) {
-    return CreateString<OffsetT>(str.c_str(), str.length());
+    return CreateString<OffsetT>(str.data(), str.length());
   }
 
   /// @brief Store a string in the buffer, which can contain any binary data.
@@ -705,10 +700,25 @@ template<bool Is64Aware = false> class FlatBufferBuilderImpl {
   // normally dictate.
   // This is useful when storing a nested_flatbuffer in a vector of bytes,
   // or when storing SIMD floats, etc.
-  void ForceVectorAlignment(size_t len, size_t elemsize, size_t alignment) {
+  void ForceVectorAlignment(const size_t len, const size_t elemsize,
+                            const size_t alignment) {
     if (len == 0) return;
     FLATBUFFERS_ASSERT(VerifyAlignmentRequirements(alignment));
     PreAlign(len * elemsize, alignment);
+  }
+
+  template<bool is_64 = Is64Aware>
+  typename std::enable_if<is_64, void>::type ForceVectorAlignment64(
+      const size_t len, const size_t elemsize, const size_t alignment) {
+    // If you hit this assertion, you are trying to force alignment on a
+    // vector with offset64 after serializing a 32-bit offset.
+    FLATBUFFERS_ASSERT(GetSize() == length_of_64_bit_region_);
+
+    // Call through.
+    ForceVectorAlignment(len, elemsize, alignment);
+
+    // Update the 64 bit region.
+    length_of_64_bit_region_ = GetSize();
   }
 
   // Similar to ForceVectorAlignment but for String fields.
@@ -740,7 +750,7 @@ template<bool Is64Aware = false> class FlatBufferBuilderImpl {
     AssertScalarT<T>();
     StartVector<T, OffsetT, LenT>(len);
     if (len > 0) {
-      // clang-format off
+// clang-format off
       #if FLATBUFFERS_LITTLEENDIAN
         PushBytes(reinterpret_cast<const uint8_t *>(v), len * sizeof(T));
       #else
@@ -871,7 +881,9 @@ template<bool Is64Aware = false> class FlatBufferBuilderImpl {
   /// where the vector is stored.
   template<class It>
   Offset<Vector<Offset<String>>> CreateVectorOfStrings(It begin, It end) {
-    auto size = std::distance(begin, end);
+    auto distance = std::distance(begin, end);
+    FLATBUFFERS_ASSERT(distance >= 0);
+    auto size = static_cast<size_t>(distance);
     auto scratch_buffer_usage = size * sizeof(Offset<String>);
     // If there is not enough space to store the offsets, there definitely won't
     // be enough space to store all the strings. So ensuring space for the
@@ -881,7 +893,7 @@ template<bool Is64Aware = false> class FlatBufferBuilderImpl {
       buf_.scratch_push_small(CreateString(*it));
     }
     StartVector<Offset<String>>(size);
-    for (auto i = 1; i <= size; i++) {
+    for (size_t i = 1; i <= size; i++) {
       // Note we re-evaluate the buf location each iteration to account for any
       // underlying buffer resizing that may occur.
       PushElement(*reinterpret_cast<Offset<String> *>(
@@ -905,8 +917,7 @@ template<bool Is64Aware = false> class FlatBufferBuilderImpl {
     typedef typename VectorT<T>::size_type LenT;
     typedef typename OffsetT<VectorT<const T *>>::offset_type offset_type;
 
-    StartVector<OffsetT, LenT>(len * sizeof(T) / AlignOf<T>(), sizeof(T),
-                               AlignOf<T>());
+    StartVector<OffsetT, LenT>(len, sizeof(T), AlignOf<T>());
     if (len > 0) {
       PushBytes(reinterpret_cast<const uint8_t *>(v), sizeof(T) * len);
     }
@@ -1251,6 +1262,9 @@ template<bool Is64Aware = false> class FlatBufferBuilderImpl {
   FlatBufferBuilderImpl &operator=(const FlatBufferBuilderImpl &);
 
   void Finish(uoffset_t root, const char *file_identifier, bool size_prefix) {
+    // A buffer can only be finished once. To reuse a builder use `clear()`.
+    FLATBUFFERS_ASSERT(!finished);
+
     NotNested();
     buf_.clear_scratch();
 
@@ -1376,8 +1390,7 @@ template<bool Is64Aware = false> class FlatBufferBuilderImpl {
   // Must be completed with EndVectorOfStructs().
   template<typename T, template<typename> class OffsetT = Offset>
   T *StartVectorOfStructs(size_t vector_size) {
-    StartVector<OffsetT>(vector_size * sizeof(T) / AlignOf<T>(), sizeof(T),
-                         AlignOf<T>());
+    StartVector<OffsetT>(vector_size, sizeof(T), AlignOf<T>());
     return reinterpret_cast<T *>(buf_.make_space(vector_size * sizeof(T)));
   }
 
@@ -1463,7 +1476,7 @@ T *GetMutableTemporaryPointer(FlatBufferBuilder &fbb, Offset<T> offset) {
 }
 
 template<typename T>
-const T *GetTemporaryPointer(FlatBufferBuilder &fbb, Offset<T> offset) {
+const T *GetTemporaryPointer(const FlatBufferBuilder &fbb, Offset<T> offset) {
   return GetMutableTemporaryPointer<T>(fbb, offset);
 }
 

--- a/cpp/thirdparty/flatbuffers/include/flatbuffers/flatbuffers.h
+++ b/cpp/thirdparty/flatbuffers/include/flatbuffers/flatbuffers.h
@@ -255,31 +255,31 @@ inline const char *flatbuffers_version_string() {
 
 // clang-format off
 #define FLATBUFFERS_DEFINE_BITMASK_OPERATORS(E, T)\
-    inline E operator | (E lhs, E rhs){\
+    inline FLATBUFFERS_CONSTEXPR_CPP11 E operator | (E lhs, E rhs){\
         return E(T(lhs) | T(rhs));\
     }\
-    inline E operator & (E lhs, E rhs){\
+    inline FLATBUFFERS_CONSTEXPR_CPP11 E operator & (E lhs, E rhs){\
         return E(T(lhs) & T(rhs));\
     }\
-    inline E operator ^ (E lhs, E rhs){\
+    inline FLATBUFFERS_CONSTEXPR_CPP11 E operator ^ (E lhs, E rhs){\
         return E(T(lhs) ^ T(rhs));\
     }\
-    inline E operator ~ (E lhs){\
+    inline FLATBUFFERS_CONSTEXPR_CPP11 E operator ~ (E lhs){\
         return E(~T(lhs));\
     }\
-    inline E operator |= (E &lhs, E rhs){\
+    inline FLATBUFFERS_CONSTEXPR_CPP11 E operator |= (E &lhs, E rhs){\
         lhs = lhs | rhs;\
         return lhs;\
     }\
-    inline E operator &= (E &lhs, E rhs){\
+    inline FLATBUFFERS_CONSTEXPR_CPP11 E operator &= (E &lhs, E rhs){\
         lhs = lhs & rhs;\
         return lhs;\
     }\
-    inline E operator ^= (E &lhs, E rhs){\
+    inline FLATBUFFERS_CONSTEXPR_CPP11 E operator ^= (E &lhs, E rhs){\
         lhs = lhs ^ rhs;\
         return lhs;\
     }\
-    inline bool operator !(E rhs) \
+    inline FLATBUFFERS_CONSTEXPR_CPP11 bool operator !(E rhs) \
     {\
         return !bool(T(rhs)); \
     }

--- a/cpp/thirdparty/flatbuffers/include/flatbuffers/stl_emulation.h
+++ b/cpp/thirdparty/flatbuffers/include/flatbuffers/stl_emulation.h
@@ -51,7 +51,8 @@ namespace flatbuffers = arrow_vendored_private::flatbuffers;
   // Testing __cpp_lib_span requires including either <version> or <span>,
   // both of which were added in C++20.
   // See: https://en.cppreference.com/w/cpp/utility/feature_test
-  #if defined(__cplusplus) && __cplusplus >= 202002L
+  #if defined(__cplusplus) && __cplusplus >= 202002L \
+      || (defined(_MSVC_LANG) && _MSVC_LANG >= 202002L)
     #define FLATBUFFERS_USE_STD_SPAN 1
   #endif
 #endif // FLATBUFFERS_USE_STD_SPAN

--- a/cpp/thirdparty/flatbuffers/include/flatbuffers/string.h
+++ b/cpp/thirdparty/flatbuffers/include/flatbuffers/string.h
@@ -38,6 +38,11 @@ struct String : public Vector<char> {
   flatbuffers::string_view string_view() const {
     return flatbuffers::string_view(c_str(), size());
   }
+
+  /* implicit */
+  operator flatbuffers::string_view() const {
+    return flatbuffers::string_view(c_str(), size());
+  }
   #endif // FLATBUFFERS_HAS_STRING_VIEW
   // clang-format on
 


### PR DESCRIPTION
### Rationale for this change

This bumps the vendored copy of flatbuffers to a version that also exists in the Meson wrapdb, which will subsequently make using the Meson build system easier

### What changes are included in this PR?

I have re-vendored flatbuffers keeping the namespacing modifications for arrow inplace. I have also regenerated the appropriate header files using flatc version 24.3.6

### Are these changes tested?

In CI

### Are there any user-facing changes?

I do not believe so


* GitHub Issue: #45694