### PR TITLE
GH-45693: [C++][Gandiva] Fix aes_encrypt/decrypt algorithm selection

### DIFF
--- a/cpp/src/gandiva/encrypt_utils.cc
+++ b/cpp/src/gandiva/encrypt_utils.cc
@@ -20,6 +20,21 @@
 
 #include <stdexcept>
 
+namespace {
+const EVP_CIPHER* get_cipher_algo(int32_t key_length) {
+  switch (key_length) {
+    case 16:
+      return EVP_aes_128_ecb();
+    case 24:
+      return EVP_aes_192_ecb();
+    case 32:
+      return EVP_aes_256_ecb();
+    default:
+      throw std::runtime_error("unsupported key length: " + std::to_string(key_length));
+  }
+}
+}   // namespace
+
 namespace gandiva {
 GANDIVA_EXPORT
 int32_t aes_encrypt(const char* plaintext, int32_t plaintext_len, const char* key,

--- a/cpp/src/gandiva/encrypt_utils.cc
+++ b/cpp/src/gandiva/encrypt_utils.cc
@@ -16,8 +16,8 @@
 // under the License.
 
 #include "gandiva/encrypt_utils.h"
-#include <sstream>
 
+#include <sstream>
 #include <stdexcept>
 
 namespace {

--- a/cpp/src/gandiva/encrypt_utils.cc
+++ b/cpp/src/gandiva/encrypt_utils.cc
@@ -22,7 +22,7 @@
 
 namespace gandiva {
 GANDIVA_EXPORT
-int32_t aes_encrypt(const char* plaintext, int32_t plaintext_len, const char* key, 
+int32_t aes_encrypt(const char* plaintext, int32_t plaintext_len, const char* key,
                     int32_t key_len, unsigned char* cipher) {
   int32_t cipher_len = 0;
   int32_t len = 0;
@@ -57,7 +57,7 @@ int32_t aes_encrypt(const char* plaintext, int32_t plaintext_len, const char* ke
 }
 
 GANDIVA_EXPORT
-int32_t aes_decrypt(const char* ciphertext, int32_t ciphertext_len, const char* key, 
+int32_t aes_decrypt(const char* ciphertext, int32_t ciphertext_len, const char* key,
                     int32_t key_len, unsigned char* plaintext) {
   int32_t plaintext_len = 0;
   int32_t len = 0;
@@ -91,7 +91,7 @@ int32_t aes_decrypt(const char* ciphertext, int32_t ciphertext_len, const char* 
   return plaintext_len;
 }
 
-const EVP_CIPHER* get_cipher_algo(int32_t key_length){
+const EVP_CIPHER* get_cipher_algo(int32_t key_length) {
   switch (key_length) {
     case 16:
       return EVP_aes_128_ecb();

--- a/cpp/src/gandiva/encrypt_utils.cc
+++ b/cpp/src/gandiva/encrypt_utils.cc
@@ -33,7 +33,7 @@ const EVP_CIPHER* get_cipher_algo(int32_t key_length) {
       throw std::runtime_error("unsupported key length: " + std::to_string(key_length));
   }
 }
-}   // namespace
+}  // namespace
 
 namespace gandiva {
 GANDIVA_EXPORT

--- a/cpp/src/gandiva/encrypt_utils.cc
+++ b/cpp/src/gandiva/encrypt_utils.cc
@@ -16,7 +16,7 @@
 // under the License.
 
 #include "gandiva/encrypt_utils.h"
-#include <string.h>
+#include <sstream>
 
 #include <stdexcept>
 
@@ -29,8 +29,11 @@ const EVP_CIPHER* get_cipher_algo(int32_t key_length) {
       return EVP_aes_192_ecb();
     case 32:
       return EVP_aes_256_ecb();
-    default:
-      throw std::runtime_error("unsupported key length: " + std::to_string(key_length));
+    default: {
+      std::ostringstream oss;
+      oss << "unsupported key length: " << key_length;
+      throw std::runtime_error(oss.str());
+    }
   }
 }
 }  // namespace

--- a/cpp/src/gandiva/encrypt_utils.h
+++ b/cpp/src/gandiva/encrypt_utils.h
@@ -28,13 +28,15 @@ namespace gandiva {
  **/
 GANDIVA_EXPORT
 int32_t aes_encrypt(const char* plaintext, int32_t plaintext_len, const char* key,
-                    unsigned char* cipher);
+                    int32_t key_len, unsigned char* cipher);
 
 /**
  * Decrypt data using aes algorithm
  **/
 GANDIVA_EXPORT
 int32_t aes_decrypt(const char* ciphertext, int32_t ciphertext_len, const char* key,
-                    unsigned char* plaintext);
+                    int32_t key_len, unsigned char* plaintext);
+
+const EVP_CIPHER* get_cipher_algo(int32_t key_length);
 
 }  // namespace gandiva

--- a/cpp/src/gandiva/encrypt_utils.h
+++ b/cpp/src/gandiva/encrypt_utils.h
@@ -37,6 +37,4 @@ GANDIVA_EXPORT
 int32_t aes_decrypt(const char* ciphertext, int32_t ciphertext_len, const char* key,
                     int32_t key_len, unsigned char* plaintext);
 
-const EVP_CIPHER* get_cipher_algo(int32_t key_length);
-
 }  // namespace gandiva

--- a/cpp/src/gandiva/encrypt_utils_test.cc
+++ b/cpp/src/gandiva/encrypt_utils_test.cc
@@ -20,36 +20,38 @@
 #include <gtest/gtest.h>
 
 TEST(TestShaEncryptUtils, TestAesEncryptDecrypt) {
-  // 8 bytes key
-  auto* key = "1234abcd";
+  // 16 bytes key
+  auto* key = "12345678abcdefgh";
   auto* to_encrypt = "some test string";
 
+  auto key_len = static_cast<int32_t>(strlen(reinterpret_cast<const char*>(key)));
   auto to_encrypt_len =
       static_cast<int32_t>(strlen(reinterpret_cast<const char*>(to_encrypt)));
   unsigned char cipher_1[64];
 
-  int32_t cipher_1_len = gandiva::aes_encrypt(to_encrypt, to_encrypt_len, key, cipher_1);
+  int32_t cipher_1_len = gandiva::aes_encrypt(to_encrypt, to_encrypt_len, key, key_len, cipher_1);
 
   unsigned char decrypted_1[64];
   int32_t decrypted_1_len = gandiva::aes_decrypt(reinterpret_cast<const char*>(cipher_1),
-                                                 cipher_1_len, key, decrypted_1);
+                                                 cipher_1_len, key, key_len, decrypted_1);
 
   EXPECT_EQ(std::string(reinterpret_cast<const char*>(to_encrypt), to_encrypt_len),
             std::string(reinterpret_cast<const char*>(decrypted_1), decrypted_1_len));
 
-  // 16 bytes key
-  key = "12345678abcdefgh";
+  // 24 bytes key
+  key = "12345678abcdefgh12345678";
   to_encrypt = "some\ntest\nstring";
 
+  key_len = static_cast<int32_t>(strlen(reinterpret_cast<const char*>(key)));
   to_encrypt_len =
       static_cast<int32_t>(strlen(reinterpret_cast<const char*>(to_encrypt)));
   unsigned char cipher_2[64];
 
-  int32_t cipher_2_len = gandiva::aes_encrypt(to_encrypt, to_encrypt_len, key, cipher_2);
+  int32_t cipher_2_len = gandiva::aes_encrypt(to_encrypt, to_encrypt_len, key, key_len, cipher_2);
 
   unsigned char decrypted_2[64];
   int32_t decrypted_2_len = gandiva::aes_decrypt(reinterpret_cast<const char*>(cipher_2),
-                                                 cipher_2_len, key, decrypted_2);
+                                                 cipher_2_len, key, key_len, decrypted_2);
 
   EXPECT_EQ(std::string(reinterpret_cast<const char*>(to_encrypt), to_encrypt_len),
             std::string(reinterpret_cast<const char*>(decrypted_2), decrypted_2_len));
@@ -58,97 +60,51 @@ TEST(TestShaEncryptUtils, TestAesEncryptDecrypt) {
   key = "12345678abcdefgh12345678abcdefgh";
   to_encrypt = "New\ntest\nstring";
 
+  key_len = static_cast<int32_t>(strlen(reinterpret_cast<const char*>(key)));
   to_encrypt_len =
       static_cast<int32_t>(strlen(reinterpret_cast<const char*>(to_encrypt)));
   unsigned char cipher_3[64];
 
-  int32_t cipher_3_len = gandiva::aes_encrypt(to_encrypt, to_encrypt_len, key, cipher_3);
+  int32_t cipher_3_len = gandiva::aes_encrypt(to_encrypt, to_encrypt_len, key, key_len, cipher_3);
 
   unsigned char decrypted_3[64];
   int32_t decrypted_3_len = gandiva::aes_decrypt(reinterpret_cast<const char*>(cipher_3),
-                                                 cipher_3_len, key, decrypted_3);
+                                                 cipher_3_len, key, key_len, decrypted_3);
 
   EXPECT_EQ(std::string(reinterpret_cast<const char*>(to_encrypt), to_encrypt_len),
             std::string(reinterpret_cast<const char*>(decrypted_3), decrypted_3_len));
 
-  // 64 bytes key
+  // check exception
+  char cipher[64] = "JBB7oJAQuqhDCx01fvBRi8PcljW1+nbnOSMk+R0Sz7E==";
+  int32_t cipher_len = static_cast<int32_t>(strlen(reinterpret_cast<const char*>(cipher)));
+  unsigned char plain_text[64];
+
   key = "12345678abcdefgh12345678abcdefgh12345678abcdefgh12345678abcdefgh";
   to_encrypt = "New\ntest\nstring";
 
+  key_len = static_cast<int32_t>(strlen(reinterpret_cast<const char*>(key)));
   to_encrypt_len =
       static_cast<int32_t>(strlen(reinterpret_cast<const char*>(to_encrypt)));
   unsigned char cipher_4[64];
+  ASSERT_THROW({
+        gandiva::aes_encrypt(to_encrypt, to_encrypt_len, key, key_len, cipher_4);
+    }, std::runtime_error);
 
-  int32_t cipher_4_len = gandiva::aes_encrypt(to_encrypt, to_encrypt_len, key, cipher_4);
+  ASSERT_THROW({
+        gandiva::aes_decrypt(cipher, cipher_len, key, key_len, plain_text);
+    }, std::runtime_error);
 
-  unsigned char decrypted_4[64];
-  int32_t decrypted_4_len = gandiva::aes_decrypt(reinterpret_cast<const char*>(cipher_4),
-                                                 cipher_4_len, key, decrypted_4);
+  key = "12345678";
+  to_encrypt = "New\ntest\nstring";
 
-  EXPECT_EQ(std::string(reinterpret_cast<const char*>(to_encrypt), to_encrypt_len),
-            std::string(reinterpret_cast<const char*>(decrypted_4), decrypted_4_len));
-
-  // 128 bytes key
-  key =
-      "12345678abcdefgh12345678abcdefgh12345678abcdefgh12345678abcdefgh12345678abcdefgh12"
-      "345678abcdefgh12345678abcdefgh12345678abcdefgh";
-  to_encrypt = "A much more longer string then the previous one, but without newline";
-
+  key_len = static_cast<int32_t>(strlen(reinterpret_cast<const char*>(key)));
   to_encrypt_len =
       static_cast<int32_t>(strlen(reinterpret_cast<const char*>(to_encrypt)));
-  unsigned char cipher_5[128];
-
-  int32_t cipher_5_len = gandiva::aes_encrypt(to_encrypt, to_encrypt_len, key, cipher_5);
-
-  unsigned char decrypted_5[128];
-  int32_t decrypted_5_len = gandiva::aes_decrypt(reinterpret_cast<const char*>(cipher_5),
-                                                 cipher_5_len, key, decrypted_5);
-
-  EXPECT_EQ(std::string(reinterpret_cast<const char*>(to_encrypt), to_encrypt_len),
-            std::string(reinterpret_cast<const char*>(decrypted_5), decrypted_5_len));
-
-  // 192 bytes key
-  key =
-      "12345678abcdefgh12345678abcdefgh12345678abcdefgh12345678abcdefgh12345678abcdefgh12"
-      "345678abcdefgh12345678abcdefgh12345678abcdefgh12345678abcdefgh12345678abcdefgh1234"
-      "5678abcdefgh12345678abcdefgh";
-  to_encrypt =
-      "A much more longer string then the previous one, but with \nnewline, pretty cool, "
-      "right?";
-
-  to_encrypt_len =
-      static_cast<int32_t>(strlen(reinterpret_cast<const char*>(to_encrypt)));
-  unsigned char cipher_6[256];
-
-  int32_t cipher_6_len = gandiva::aes_encrypt(to_encrypt, to_encrypt_len, key, cipher_6);
-
-  unsigned char decrypted_6[256];
-  int32_t decrypted_6_len = gandiva::aes_decrypt(reinterpret_cast<const char*>(cipher_6),
-                                                 cipher_6_len, key, decrypted_6);
-
-  EXPECT_EQ(std::string(reinterpret_cast<const char*>(to_encrypt), to_encrypt_len),
-            std::string(reinterpret_cast<const char*>(decrypted_6), decrypted_6_len));
-
-  // 256 bytes key
-  key =
-      "12345678abcdefgh12345678abcdefgh12345678abcdefgh12345678abcdefgh12345678abcdefgh12"
-      "345678abcdefgh12345678abcdefgh12345678abcdefgh12345678abcdefgh12345678abcdefgh1234"
-      "5678abcdefgh12345678abcdefgh12345678abcdefgh12345678abcdefgh12345678abcdefgh123456"
-      "78abcdefgh";
-  to_encrypt =
-      "A much more longer string then the previous one, but with \nnewline, pretty cool, "
-      "right?";
-
-  to_encrypt_len =
-      static_cast<int32_t>(strlen(reinterpret_cast<const char*>(to_encrypt)));
-  unsigned char cipher_7[256];
-
-  int32_t cipher_7_len = gandiva::aes_encrypt(to_encrypt, to_encrypt_len, key, cipher_7);
-
-  unsigned char decrypted_7[256];
-  int32_t decrypted_7_len = gandiva::aes_decrypt(reinterpret_cast<const char*>(cipher_7),
-                                                 cipher_7_len, key, decrypted_7);
-
-  EXPECT_EQ(std::string(reinterpret_cast<const char*>(to_encrypt), to_encrypt_len),
-            std::string(reinterpret_cast<const char*>(decrypted_7), decrypted_7_len));
+  unsigned char cipher_5[64];
+  ASSERT_THROW({
+        gandiva::aes_encrypt(to_encrypt, to_encrypt_len, key, key_len, cipher_5);
+    }, std::runtime_error);
+  ASSERT_THROW({
+        gandiva::aes_decrypt(cipher, cipher_len, key, key_len, plain_text);
+    }, std::runtime_error);  
 }

--- a/cpp/src/gandiva/encrypt_utils_test.cc
+++ b/cpp/src/gandiva/encrypt_utils_test.cc
@@ -29,7 +29,8 @@ TEST(TestShaEncryptUtils, TestAesEncryptDecrypt) {
       static_cast<int32_t>(strlen(reinterpret_cast<const char*>(to_encrypt)));
   unsigned char cipher_1[64];
 
-  int32_t cipher_1_len = gandiva::aes_encrypt(to_encrypt, to_encrypt_len, key, key_len, cipher_1);
+  int32_t cipher_1_len =
+      gandiva::aes_encrypt(to_encrypt, to_encrypt_len, key, key_len, cipher_1);
 
   unsigned char decrypted_1[64];
   int32_t decrypted_1_len = gandiva::aes_decrypt(reinterpret_cast<const char*>(cipher_1),
@@ -47,7 +48,8 @@ TEST(TestShaEncryptUtils, TestAesEncryptDecrypt) {
       static_cast<int32_t>(strlen(reinterpret_cast<const char*>(to_encrypt)));
   unsigned char cipher_2[64];
 
-  int32_t cipher_2_len = gandiva::aes_encrypt(to_encrypt, to_encrypt_len, key, key_len, cipher_2);
+  int32_t cipher_2_len =
+      gandiva::aes_encrypt(to_encrypt, to_encrypt_len, key, key_len, cipher_2);
 
   unsigned char decrypted_2[64];
   int32_t decrypted_2_len = gandiva::aes_decrypt(reinterpret_cast<const char*>(cipher_2),
@@ -65,7 +67,8 @@ TEST(TestShaEncryptUtils, TestAesEncryptDecrypt) {
       static_cast<int32_t>(strlen(reinterpret_cast<const char*>(to_encrypt)));
   unsigned char cipher_3[64];
 
-  int32_t cipher_3_len = gandiva::aes_encrypt(to_encrypt, to_encrypt_len, key, key_len, cipher_3);
+  int32_t cipher_3_len =
+      gandiva::aes_encrypt(to_encrypt, to_encrypt_len, key, key_len, cipher_3);
 
   unsigned char decrypted_3[64];
   int32_t decrypted_3_len = gandiva::aes_decrypt(reinterpret_cast<const char*>(cipher_3),
@@ -76,7 +79,8 @@ TEST(TestShaEncryptUtils, TestAesEncryptDecrypt) {
 
   // check exception
   char cipher[64] = "JBB7oJAQuqhDCx01fvBRi8PcljW1+nbnOSMk+R0Sz7E==";
-  int32_t cipher_len = static_cast<int32_t>(strlen(reinterpret_cast<const char*>(cipher)));
+  int32_t cipher_len =
+      static_cast<int32_t>(strlen(reinterpret_cast<const char*>(cipher)));
   unsigned char plain_text[64];
 
   key = "12345678abcdefgh12345678abcdefgh12345678abcdefgh12345678abcdefgh";
@@ -86,13 +90,12 @@ TEST(TestShaEncryptUtils, TestAesEncryptDecrypt) {
   to_encrypt_len =
       static_cast<int32_t>(strlen(reinterpret_cast<const char*>(to_encrypt)));
   unsigned char cipher_4[64];
-  ASSERT_THROW({
-        gandiva::aes_encrypt(to_encrypt, to_encrypt_len, key, key_len, cipher_4);
-    }, std::runtime_error);
+  ASSERT_THROW(
+      { gandiva::aes_encrypt(to_encrypt, to_encrypt_len, key, key_len, cipher_4); },
+      std::runtime_error);
 
-  ASSERT_THROW({
-        gandiva::aes_decrypt(cipher, cipher_len, key, key_len, plain_text);
-    }, std::runtime_error);
+  ASSERT_THROW({ gandiva::aes_decrypt(cipher, cipher_len, key, key_len, plain_text); },
+               std::runtime_error);
 
   key = "12345678";
   to_encrypt = "New\ntest\nstring";
@@ -101,10 +104,9 @@ TEST(TestShaEncryptUtils, TestAesEncryptDecrypt) {
   to_encrypt_len =
       static_cast<int32_t>(strlen(reinterpret_cast<const char*>(to_encrypt)));
   unsigned char cipher_5[64];
-  ASSERT_THROW({
-        gandiva::aes_encrypt(to_encrypt, to_encrypt_len, key, key_len, cipher_5);
-    }, std::runtime_error);
-  ASSERT_THROW({
-        gandiva::aes_decrypt(cipher, cipher_len, key, key_len, plain_text);
-    }, std::runtime_error);  
+  ASSERT_THROW(
+      { gandiva::aes_encrypt(to_encrypt, to_encrypt_len, key, key_len, cipher_5); },
+      std::runtime_error);
+  ASSERT_THROW({ gandiva::aes_decrypt(cipher, cipher_len, key, key_len, plain_text); },
+               std::runtime_error);
 }

--- a/cpp/src/gandiva/gdv_function_stubs.cc
+++ b/cpp/src/gandiva/gdv_function_stubs.cc
@@ -332,6 +332,7 @@ const char* gdv_fn_aes_encrypt(int64_t context, const char* data, int32_t data_l
     std::string err_msg =
         "Could not allocate memory for returning aes encrypt cypher text";
     gdv_fn_context_set_error_msg(context, err_msg.data());
+     *out_len = 0;
     return nullptr;
   }
 
@@ -340,6 +341,7 @@ const char* gdv_fn_aes_encrypt(int64_t context, const char* data, int32_t data_l
                                     reinterpret_cast<unsigned char*>(ret));
   } catch (const std::runtime_error& e) {
     gdv_fn_context_set_error_msg(context, e.what());
+     *out_len = 0;
     return nullptr;
   }
 
@@ -372,6 +374,7 @@ const char* gdv_fn_aes_decrypt(int64_t context, const char* data, int32_t data_l
     std::string err_msg =
         "Could not allocate memory for returning aes encrypt cypher text";
     gdv_fn_context_set_error_msg(context, err_msg.data());
+     *out_len = 0;
     return nullptr;
   }
 
@@ -380,6 +383,7 @@ const char* gdv_fn_aes_decrypt(int64_t context, const char* data, int32_t data_l
                                     reinterpret_cast<unsigned char*>(ret));
   } catch (const std::runtime_error& e) {
     gdv_fn_context_set_error_msg(context, e.what());
+     *out_len = 0;
     return nullptr;
   }
   ret[*out_len] = '\0';

--- a/cpp/src/gandiva/gdv_function_stubs.cc
+++ b/cpp/src/gandiva/gdv_function_stubs.cc
@@ -320,7 +320,9 @@ const char* gdv_fn_aes_encrypt(int64_t context, const char* data, int32_t data_l
   if (key_data_len == 16 || key_data_len == 24 || key_data_len == 32) {
     kAesBlockSize = static_cast<int64_t>(key_data_len);
   } else {
-    gdv_fn_context_set_error_msg(context, (std::string("invalid key length: ") + std::to_string(key_data_len)).c_str());
+    gdv_fn_context_set_error_msg(
+        context,
+        (std::string("invalid key length: ") + std::to_string(key_data_len)).c_str());
     *out_len = 0;
     return nullptr;
   }
@@ -362,7 +364,9 @@ const char* gdv_fn_aes_decrypt(int64_t context, const char* data, int32_t data_l
   if (key_data_len == 16 || key_data_len == 24 || key_data_len == 32) {
     kAesBlockSize = static_cast<int64_t>(key_data_len);
   } else {
-    gdv_fn_context_set_error_msg(context, (std::string("invalid key length: ") + std::to_string(key_data_len)).c_str());
+    gdv_fn_context_set_error_msg(
+        context,
+        (std::string("invalid key length: ") + std::to_string(key_data_len)).c_str());
     *out_len = 0;
     return nullptr;
   }

--- a/cpp/src/gandiva/gdv_function_stubs.cc
+++ b/cpp/src/gandiva/gdv_function_stubs.cc
@@ -323,7 +323,7 @@ const char* gdv_fn_aes_encrypt(int64_t context, const char* data, int32_t data_l
   } else {
     std::ostringstream oss;
     oss << "invalid key length: " << key_data_len;
-    gdv_fn_context_set_error_msg( context, oss.str().c_str());
+    gdv_fn_context_set_error_msg(context, oss.str().c_str());
     *out_len = 0;
     return nullptr;
   }
@@ -367,7 +367,7 @@ const char* gdv_fn_aes_decrypt(int64_t context, const char* data, int32_t data_l
   } else {
     std::ostringstream oss;
     oss << "invalid key length: " << key_data_len;
-    gdv_fn_context_set_error_msg( context, oss.str().c_str());
+    gdv_fn_context_set_error_msg(context, oss.str().c_str());
     *out_len = 0;
     return nullptr;
   }

--- a/cpp/src/gandiva/gdv_function_stubs.cc
+++ b/cpp/src/gandiva/gdv_function_stubs.cc
@@ -320,7 +320,7 @@ const char* gdv_fn_aes_encrypt(int64_t context, const char* data, int32_t data_l
   if (key_data_len == 16 || key_data_len == 24 || key_data_len == 32) {
     kAesBlockSize = static_cast<int64_t>(key_data_len);
   } else {
-    gdv_fn_context_set_error_msg(context, "invalid key length");
+    gdv_fn_context_set_error_msg(context, "invalid key length: " + std::to_string(key_data_len));
     *out_len = 0;
     return nullptr;
   }
@@ -362,7 +362,7 @@ const char* gdv_fn_aes_decrypt(int64_t context, const char* data, int32_t data_l
   if (key_data_len == 16 || key_data_len == 24 || key_data_len == 32) {
     kAesBlockSize = static_cast<int64_t>(key_data_len);
   } else {
-    gdv_fn_context_set_error_msg(context, "invalid key length");
+    gdv_fn_context_set_error_msg(context, "invalid key length: " + std::to_string(key_data_len));
     *out_len = 0;
     return nullptr;
   }

--- a/cpp/src/gandiva/gdv_function_stubs.cc
+++ b/cpp/src/gandiva/gdv_function_stubs.cc
@@ -323,9 +323,7 @@ const char* gdv_fn_aes_encrypt(int64_t context, const char* data, int32_t data_l
   } else {
     std::ostringstream oss;
     oss << "invalid key length: " << key_data_len;
-    gdv_fn_context_set_error_msg(
-        context,
-        oss.str().c_str());
+    gdv_fn_context_set_error_msg( context, oss.str().c_str());
     *out_len = 0;
     return nullptr;
   }
@@ -369,9 +367,7 @@ const char* gdv_fn_aes_decrypt(int64_t context, const char* data, int32_t data_l
   } else {
     std::ostringstream oss;
     oss << "invalid key length: " << key_data_len;
-    gdv_fn_context_set_error_msg(
-        context,
-        oss.str().c_str());
+    gdv_fn_context_set_error_msg( context, oss.str().c_str());
     *out_len = 0;
     return nullptr;
   }

--- a/cpp/src/gandiva/gdv_function_stubs.cc
+++ b/cpp/src/gandiva/gdv_function_stubs.cc
@@ -320,7 +320,7 @@ const char* gdv_fn_aes_encrypt(int64_t context, const char* data, int32_t data_l
   if (key_data_len == 16 || key_data_len == 24 || key_data_len == 32) {
     kAesBlockSize = static_cast<int64_t>(key_data_len);
   } else {
-    gdv_fn_context_set_error_msg(context, "invalid key length: " + std::to_string(key_data_len));
+    gdv_fn_context_set_error_msg(context, (std::string("invalid key length: ") + std::to_string(key_data_len)).c_str());
     *out_len = 0;
     return nullptr;
   }
@@ -362,7 +362,7 @@ const char* gdv_fn_aes_decrypt(int64_t context, const char* data, int32_t data_l
   if (key_data_len == 16 || key_data_len == 24 || key_data_len == 32) {
     kAesBlockSize = static_cast<int64_t>(key_data_len);
   } else {
-    gdv_fn_context_set_error_msg(context, "invalid key length: " + std::to_string(key_data_len));
+    gdv_fn_context_set_error_msg(context, (std::string("invalid key length: ") + std::to_string(key_data_len)).c_str());
     *out_len = 0;
     return nullptr;
   }

--- a/cpp/src/gandiva/gdv_function_stubs.cc
+++ b/cpp/src/gandiva/gdv_function_stubs.cc
@@ -20,6 +20,7 @@
 #include <utf8proc.h>
 
 #include <boost/crc.hpp>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -320,9 +321,11 @@ const char* gdv_fn_aes_encrypt(int64_t context, const char* data, int32_t data_l
   if (key_data_len == 16 || key_data_len == 24 || key_data_len == 32) {
     kAesBlockSize = static_cast<int64_t>(key_data_len);
   } else {
+    std::ostringstream oss;
+    oss << "invalid key length: " << key_data_len;
     gdv_fn_context_set_error_msg(
         context,
-        (std::string("invalid key length: ") + std::to_string(key_data_len)).c_str());
+        oss.str().c_str());
     *out_len = 0;
     return nullptr;
   }
@@ -364,9 +367,11 @@ const char* gdv_fn_aes_decrypt(int64_t context, const char* data, int32_t data_l
   if (key_data_len == 16 || key_data_len == 24 || key_data_len == 32) {
     kAesBlockSize = static_cast<int64_t>(key_data_len);
   } else {
+    std::ostringstream oss;
+    oss << "invalid key length: " << key_data_len;
     gdv_fn_context_set_error_msg(
         context,
-        (std::string("invalid key length: ") + std::to_string(key_data_len)).c_str());
+        oss.str().c_str());
     *out_len = 0;
     return nullptr;
   }

--- a/cpp/src/gandiva/gdv_function_stubs.cc
+++ b/cpp/src/gandiva/gdv_function_stubs.cc
@@ -324,7 +324,7 @@ const char* gdv_fn_aes_encrypt(int64_t context, const char* data, int32_t data_l
     *out_len = 0;
     return nullptr;
   }
-   
+
   *out_len =
       static_cast<int32_t>(arrow::bit_util::RoundUpToPowerOf2(data_len, kAesBlockSize));
   char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, *out_len));
@@ -332,7 +332,7 @@ const char* gdv_fn_aes_encrypt(int64_t context, const char* data, int32_t data_l
     std::string err_msg =
         "Could not allocate memory for returning aes encrypt cypher text";
     gdv_fn_context_set_error_msg(context, err_msg.data());
-     *out_len = 0;
+    *out_len = 0;
     return nullptr;
   }
 
@@ -341,7 +341,7 @@ const char* gdv_fn_aes_encrypt(int64_t context, const char* data, int32_t data_l
                                     reinterpret_cast<unsigned char*>(ret));
   } catch (const std::runtime_error& e) {
     gdv_fn_context_set_error_msg(context, e.what());
-     *out_len = 0;
+    *out_len = 0;
     return nullptr;
   }
 
@@ -374,7 +374,7 @@ const char* gdv_fn_aes_decrypt(int64_t context, const char* data, int32_t data_l
     std::string err_msg =
         "Could not allocate memory for returning aes encrypt cypher text";
     gdv_fn_context_set_error_msg(context, err_msg.data());
-     *out_len = 0;
+    *out_len = 0;
     return nullptr;
   }
 
@@ -383,7 +383,7 @@ const char* gdv_fn_aes_decrypt(int64_t context, const char* data, int32_t data_l
                                     reinterpret_cast<unsigned char*>(ret));
   } catch (const std::runtime_error& e) {
     gdv_fn_context_set_error_msg(context, e.what());
-     *out_len = 0;
+    *out_len = 0;
     return nullptr;
   }
   ret[*out_len] = '\0';

--- a/cpp/src/gandiva/gdv_function_stubs_test.cc
+++ b/cpp/src/gandiva/gdv_function_stubs_test.cc
@@ -1345,4 +1345,74 @@ TEST(TestGdvFnStubs, TestMask) {
   EXPECT_EQ(std::string(result, out_len), expected);
 }
 
+TEST(TestGdvFnStubs, TestAesEncryptDecrypt16) {
+  gandiva::ExecutionContext ctx;
+  std::string key16 = "12345678abcdefgh";
+  auto key16_len = static_cast<int32_t>(key16.length());
+  int32_t cipher_len = 0;
+  int32_t decrypted_len = 0;
+  std::string data = "test string";
+  auto data_len = static_cast<int32_t>(data.length());
+  int64_t ctx_ptr = reinterpret_cast<int64_t>(&ctx);
+
+  const char* cipher = gdv_fn_aes_encrypt(ctx_ptr, data.c_str(), data_len, key16.c_str(), key16_len, &cipher_len);
+  const char* decrypted_value = gdv_fn_aes_decrypt(ctx_ptr, cipher, cipher_len, key16.c_str(), key16_len, &decrypted_len);
+
+  EXPECT_EQ(data, std::string(reinterpret_cast<const char*>(decrypted_value), decrypted_len));
+}
+
+TEST(TestGdvFnStubs, TestAesEncryptDecrypt24) {
+  gandiva::ExecutionContext ctx;
+  std::string key24 = "12345678abcdefgh12345678";
+  auto key24_len = static_cast<int32_t>(key24.length());
+  int32_t cipher_len = 0;
+  int32_t decrypted_len = 0;
+  std::string data = "test string";
+  auto data_len = static_cast<int32_t>(data.length());
+  int64_t ctx_ptr = reinterpret_cast<int64_t>(&ctx);
+
+  const char* cipher = gdv_fn_aes_encrypt(ctx_ptr, data.c_str(), data_len, key24.c_str(), key24_len, &cipher_len);
+
+  const char* decrypted_value = gdv_fn_aes_decrypt(ctx_ptr, cipher, cipher_len, key24.c_str(), key24_len, &decrypted_len);
+
+  EXPECT_EQ(data, std::string(reinterpret_cast<const char*>(decrypted_value), decrypted_len));
+}
+
+TEST(TestGdvFnStubs, TestAesEncryptDecrypt32) {
+  gandiva::ExecutionContext ctx;
+  std::string key32 = "12345678abcdefgh12345678abcdefgh";
+  auto key32_len = static_cast<int32_t>(key32.length());
+  int32_t cipher_len = 0;
+  int32_t decrypted_len = 0;
+  std::string data = "test string";
+  auto data_len = static_cast<int32_t>(data.length());
+  int64_t ctx_ptr = reinterpret_cast<int64_t>(&ctx);
+
+  const char* cipher = gdv_fn_aes_encrypt(ctx_ptr, data.c_str(), data_len, key32.c_str(), key32_len, &cipher_len);
+
+  const char* decrypted_value = gdv_fn_aes_decrypt(ctx_ptr, cipher, cipher_len, key32.c_str(), key32_len, &decrypted_len);
+
+  EXPECT_EQ(data, std::string(reinterpret_cast<const char*>(decrypted_value), decrypted_len));
+}
+
+TEST(TestGdvFnStubs, TestAesEncryptDecryptValidation) {
+  gandiva::ExecutionContext ctx;
+  std::string key33 = "12345678abcdefgh12345678abcdefghb";
+  auto key33_len = static_cast<int32_t>(key33.length());
+  int32_t decrypted_len = 0;
+  std::string data = "test string";
+  auto data_len = static_cast<int32_t>(data.length());
+  int64_t ctx_ptr = reinterpret_cast<int64_t>(&ctx);
+  std::string cipher = "12345678abcdefgh12345678abcdefghb";
+  auto cipher_len = static_cast<int32_t>(cipher.length());
+
+  gdv_fn_aes_encrypt(ctx_ptr, data.c_str(), data_len, key33.c_str(), key33_len, &cipher_len);
+  EXPECT_THAT(ctx.get_error(),
+              ::testing::HasSubstr("invalid key length"));
+  ctx.Reset();
+
+  gdv_fn_aes_decrypt(ctx_ptr, cipher.c_str(), cipher_len, key33.c_str(), key33_len, &decrypted_len);  EXPECT_THAT(ctx.get_error(),
+              ::testing::HasSubstr("invalid key length"));
+  ctx.Reset();
+}
 }  // namespace gandiva

--- a/cpp/src/gandiva/gdv_function_stubs_test.cc
+++ b/cpp/src/gandiva/gdv_function_stubs_test.cc
@@ -1355,10 +1355,13 @@ TEST(TestGdvFnStubs, TestAesEncryptDecrypt16) {
   auto data_len = static_cast<int32_t>(data.length());
   int64_t ctx_ptr = reinterpret_cast<int64_t>(&ctx);
 
-  const char* cipher = gdv_fn_aes_encrypt(ctx_ptr, data.c_str(), data_len, key16.c_str(), key16_len, &cipher_len);
-  const char* decrypted_value = gdv_fn_aes_decrypt(ctx_ptr, cipher, cipher_len, key16.c_str(), key16_len, &decrypted_len);
+  const char* cipher = gdv_fn_aes_encrypt(ctx_ptr, data.c_str(), data_len, key16.c_str(),
+                                          key16_len, &cipher_len);
+  const char* decrypted_value = gdv_fn_aes_decrypt(
+      ctx_ptr, cipher, cipher_len, key16.c_str(), key16_len, &decrypted_len);
 
-  EXPECT_EQ(data, std::string(reinterpret_cast<const char*>(decrypted_value), decrypted_len));
+  EXPECT_EQ(data,
+            std::string(reinterpret_cast<const char*>(decrypted_value), decrypted_len));
 }
 
 TEST(TestGdvFnStubs, TestAesEncryptDecrypt24) {
@@ -1371,11 +1374,14 @@ TEST(TestGdvFnStubs, TestAesEncryptDecrypt24) {
   auto data_len = static_cast<int32_t>(data.length());
   int64_t ctx_ptr = reinterpret_cast<int64_t>(&ctx);
 
-  const char* cipher = gdv_fn_aes_encrypt(ctx_ptr, data.c_str(), data_len, key24.c_str(), key24_len, &cipher_len);
+  const char* cipher = gdv_fn_aes_encrypt(ctx_ptr, data.c_str(), data_len, key24.c_str(),
+                                          key24_len, &cipher_len);
 
-  const char* decrypted_value = gdv_fn_aes_decrypt(ctx_ptr, cipher, cipher_len, key24.c_str(), key24_len, &decrypted_len);
+  const char* decrypted_value = gdv_fn_aes_decrypt(
+      ctx_ptr, cipher, cipher_len, key24.c_str(), key24_len, &decrypted_len);
 
-  EXPECT_EQ(data, std::string(reinterpret_cast<const char*>(decrypted_value), decrypted_len));
+  EXPECT_EQ(data,
+            std::string(reinterpret_cast<const char*>(decrypted_value), decrypted_len));
 }
 
 TEST(TestGdvFnStubs, TestAesEncryptDecrypt32) {
@@ -1388,11 +1394,14 @@ TEST(TestGdvFnStubs, TestAesEncryptDecrypt32) {
   auto data_len = static_cast<int32_t>(data.length());
   int64_t ctx_ptr = reinterpret_cast<int64_t>(&ctx);
 
-  const char* cipher = gdv_fn_aes_encrypt(ctx_ptr, data.c_str(), data_len, key32.c_str(), key32_len, &cipher_len);
+  const char* cipher = gdv_fn_aes_encrypt(ctx_ptr, data.c_str(), data_len, key32.c_str(),
+                                          key32_len, &cipher_len);
 
-  const char* decrypted_value = gdv_fn_aes_decrypt(ctx_ptr, cipher, cipher_len, key32.c_str(), key32_len, &decrypted_len);
+  const char* decrypted_value = gdv_fn_aes_decrypt(
+      ctx_ptr, cipher, cipher_len, key32.c_str(), key32_len, &decrypted_len);
 
-  EXPECT_EQ(data, std::string(reinterpret_cast<const char*>(decrypted_value), decrypted_len));
+  EXPECT_EQ(data,
+            std::string(reinterpret_cast<const char*>(decrypted_value), decrypted_len));
 }
 
 TEST(TestGdvFnStubs, TestAesEncryptDecryptValidation) {
@@ -1406,13 +1415,14 @@ TEST(TestGdvFnStubs, TestAesEncryptDecryptValidation) {
   std::string cipher = "12345678abcdefgh12345678abcdefghb";
   auto cipher_len = static_cast<int32_t>(cipher.length());
 
-  gdv_fn_aes_encrypt(ctx_ptr, data.c_str(), data_len, key33.c_str(), key33_len, &cipher_len);
-  EXPECT_THAT(ctx.get_error(),
-              ::testing::HasSubstr("invalid key length"));
+  gdv_fn_aes_encrypt(ctx_ptr, data.c_str(), data_len, key33.c_str(), key33_len,
+                     &cipher_len);
+  EXPECT_THAT(ctx.get_error(), ::testing::HasSubstr("invalid key length"));
   ctx.Reset();
 
-  gdv_fn_aes_decrypt(ctx_ptr, cipher.c_str(), cipher_len, key33.c_str(), key33_len, &decrypted_len);  EXPECT_THAT(ctx.get_error(),
-              ::testing::HasSubstr("invalid key length"));
+  gdv_fn_aes_decrypt(ctx_ptr, cipher.c_str(), cipher_len, key33.c_str(), key33_len,
+                     &decrypted_len);
+  EXPECT_THAT(ctx.get_error(), ::testing::HasSubstr("invalid key length"));
   ctx.Reset();
 }
 }  // namespace gandiva

--- a/cpp/src/gandiva/tests/projector_test.cc
+++ b/cpp/src/gandiva/tests/projector_test.cc
@@ -2817,27 +2817,19 @@ TEST_F(TestProjector, TestAesEncryptDecrypt) {
   std::shared_ptr<Projector> projector_en;
   ASSERT_OK(Projector::Make(schema, {encrypt_expr}, TestConfiguration(), &projector_en));
 
-  int num_records = 4;
+  int num_records = 3;
 
+  const char* key_16_bytes = "12345678abcdefgh";
+  const char* key_24_bytes = "12345678abcdefgh12345678";
   const char* key_32_bytes = "12345678abcdefgh12345678abcdefgh";
-  const char* key_64_bytes =
-      "12345678abcdefgh12345678abcdefgh12345678abcdefgh12345678abcdefgh";
-  const char* key_128_bytes =
-      "12345678abcdefgh12345678abcdefgh12345678abcdefgh12345678abcdefgh12345678abcdefgh12"
-      "345678abcdefgh12345678abcdefgh12345678abcdefgh";
-  const char* key_256_bytes =
-      "12345678abcdefgh12345678abcdefgh12345678abcdefgh12345678abcdefgh12345678abcdefgh12"
-      "345678abcdefgh12345678abcdefgh12345678abcdefgh12345678abcdefgh12345678abcdefgh1234"
-      "5678abcdefgh12345678abcdefgh12345678abcdefgh12345678abcdefgh12345678abcdefgh123456"
-      "78abcdefgh";
 
-  auto array_data = MakeArrowArrayUtf8({"abc", "some words", "to be encrypted", "hyah\n"},
-                                       {true, true, true, true});
+  auto array_data = MakeArrowArrayUtf8({"abc", "some words", "to be encrypted"},
+                                       {true, true, true});
   auto array_key =
-      MakeArrowArrayUtf8({key_32_bytes, key_64_bytes, key_128_bytes, key_256_bytes},
-                         {true, true, true, true});
+      MakeArrowArrayUtf8({key_16_bytes, key_24_bytes, key_32_bytes},
+                         {true, true, true});
 
-  auto array_holder_en = MakeArrowArrayUtf8({"", "", "", ""}, {true, true, true, true});
+  auto array_holder_en = MakeArrowArrayUtf8({"", "", ""}, {true, true, true});
 
   auto in_batch = arrow::RecordBatch::Make(schema, num_records, {array_data, array_key});
 

--- a/cpp/src/gandiva/tests/projector_test.cc
+++ b/cpp/src/gandiva/tests/projector_test.cc
@@ -2823,11 +2823,10 @@ TEST_F(TestProjector, TestAesEncryptDecrypt) {
   const char* key_24_bytes = "12345678abcdefgh12345678";
   const char* key_32_bytes = "12345678abcdefgh12345678abcdefgh";
 
-  auto array_data = MakeArrowArrayUtf8({"abc", "some words", "to be encrypted"},
-                                       {true, true, true});
+  auto array_data =
+      MakeArrowArrayUtf8({"abc", "some words", "to be encrypted"}, {true, true, true});
   auto array_key =
-      MakeArrowArrayUtf8({key_16_bytes, key_24_bytes, key_32_bytes},
-                         {true, true, true});
+      MakeArrowArrayUtf8({key_16_bytes, key_24_bytes, key_32_bytes}, {true, true, true});
 
   auto array_holder_en = MakeArrowArrayUtf8({"", "", ""}, {true, true, true});
 


### PR DESCRIPTION
### Rationale for this change
AES encrypt was only using a 128 bit algorithm which allowed limited cipher length and provided no warning when the cipher provided was longer than that which is supported.

### What changes are included in this PR?
Update the C++ Gandiva functions to support 128, 192, 256 bits and corresponding cipher lengths. Throw an error if its incompatible.

### Are these changes tested?
Yes, unit test and tested at Dremio.

### Are there any user-facing changes?
Decryption may not work if the previously used encryption method used a truncated cipher.

**This PR includes breaking changes to public APIs.**
Decryption of previously encrypted values may not work. Previously supported cipher keys may not be supported. They must now be 128, 192, or 256 bits (16, 24 or 32 characters).

* GitHub Issue: #45693