### PR TITLE
GH-45696: [C++][Gandiva] Accept LLVM 20.1

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -160,6 +160,7 @@ set(ARROW_DOC_DIR "share/doc/${PROJECT_NAME}")
 set(BUILD_SUPPORT_DIR "${CMAKE_SOURCE_DIR}/build-support")
 
 set(ARROW_LLVM_VERSIONS
+    "20.1"
     "19.1"
     "18.1"
     "17.0"

--- a/cpp/src/gandiva/engine.cc
+++ b/cpp/src/gandiva/engine.cc
@@ -321,6 +321,14 @@ Status Engine::LoadFunctionIRs() {
   return Status::OK();
 }
 
+llvm::Constant* Engine::CreateGlobalStringPtr(const std::string& string) {
+  auto gloval_variable = ir_builder()->CreateGlobalString(string);
+  auto zero = llvm::ConstantInt::get(llvm::Type::getInt32Ty(*context()), 0);
+  llvm::Constant* indices[] = {zero, zero};
+  return llvm::ConstantExpr::getInBoundsGetElementPtr(gloval_variable->getValueType(),
+                                                      gloval_variable, indices);
+}
+
 /// factory method to construct the engine.
 Result<std::unique_ptr<Engine>> Engine::Make(
     const std::shared_ptr<Configuration>& conf, bool cached,

--- a/cpp/src/gandiva/engine.h
+++ b/cpp/src/gandiva/engine.h
@@ -90,6 +90,9 @@ class GANDIVA_EXPORT Engine {
   /// Load the function IRs that can be accessed in the module.
   Status LoadFunctionIRs();
 
+  // Create a global string as a pointer with "i8*" type.
+  llvm::Constant* CreateGlobalStringPtr(const std::string& string);
+
  private:
   Engine(const std::shared_ptr<Configuration>& conf,
          std::unique_ptr<llvm::orc::LLJIT> lljit,

--- a/cpp/src/gandiva/function_ir_builder.h
+++ b/cpp/src/gandiva/function_ir_builder.h
@@ -39,6 +39,9 @@ class FunctionIRBuilder {
   llvm::Module* module() { return engine_->module(); }
   llvm::LLVMContext* context() { return engine_->context(); }
   llvm::IRBuilder<>* ir_builder() { return engine_->ir_builder(); }
+  llvm::Constant* CreateGlobalStringPtr(const std::string& string) {
+    return engine_->CreateGlobalStringPtr(string);
+  }
 
   /// Build an if-else block.
   llvm::Value* BuildIfElse(llvm::Value* condition, llvm::Type* return_type,

--- a/cpp/src/gandiva/llvm_generator.cc
+++ b/cpp/src/gandiva/llvm_generator.cc
@@ -723,7 +723,7 @@ void LLVMGenerator::Visitor::Visit(const LiteralDex& dex) {
     case arrow::Type::BINARY: {
       const std::string& str = std::get<std::string>(dex.holder());
 
-      value = ir_builder()->CreateGlobalStringPtr(str.c_str());
+      value = CreateGlobalStringPtr(str);
       len = types->i32_constant(static_cast<int32_t>(str.length()));
       break;
     }

--- a/cpp/src/gandiva/llvm_generator.h
+++ b/cpp/src/gandiva/llvm_generator.h
@@ -96,6 +96,9 @@ class GANDIVA_EXPORT LLVMGenerator {
 
   llvm::LLVMContext* context() { return engine_->context(); }
   llvm::IRBuilder<>* ir_builder() { return engine_->ir_builder(); }
+  llvm::Constant* CreateGlobalStringPtr(const std::string& string) {
+    return engine_->CreateGlobalStringPtr(string);
+  }
 
   /// Visitor to generate the code for a decomposed expression.
   class Visitor : public DexVisitor {
@@ -137,6 +140,9 @@ class GANDIVA_EXPORT LLVMGenerator {
 
     llvm::IRBuilder<>* ir_builder() { return generator_->ir_builder(); }
     llvm::Module* module() { return generator_->module(); }
+    llvm::Constant* CreateGlobalStringPtr(const std::string& string) {
+      return generator_->CreateGlobalStringPtr(string);
+    }
 
     // Generate the code to build the combined validity (bitwise and) from the
     // vector of validities.

--- a/cpp/src/gandiva/llvm_types.h
+++ b/cpp/src/gandiva/llvm_types.h
@@ -55,7 +55,9 @@ class GANDIVA_EXPORT LLVMTypes {
 
   llvm::Type* double_type() { return llvm::Type::getDoubleTy(context_); }
 
-  llvm::PointerType* ptr_type(llvm::Type* type) { return type->getPointerTo(); }
+  llvm::PointerType* ptr_type(llvm::Type* type) {
+    return llvm::PointerType::get(type, 0);
+  }
 
   llvm::PointerType* i8_ptr_type() { return ptr_type(i8_type()); }
 


### PR DESCRIPTION
### Rationale for this change

LLVM 20.1 was released.

### What changes are included in this PR?

* Accept LLVM 20.1
* Don't use deprecated API

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #45696