### PR TITLE
GH-45700: [C++][Compute] Added nullptr check in Equals method to handle null impl_ pointers

### DIFF
--- a/cpp/src/arrow/compute/expression.cc
+++ b/cpp/src/arrow/compute/expression.cc
@@ -220,6 +220,7 @@ void PrintTo(const Expression& expr, std::ostream* os) {
 
 bool Expression::Equals(const Expression& other) const {
   if (Identical(*this, other)) return true;
+  if (impl_ == nullptr || other.impl_ == nullptr) return false;
 
   if (impl_->index() != other.impl_->index()) {
     return false;

--- a/cpp/src/arrow/compute/expression.cc
+++ b/cpp/src/arrow/compute/expression.cc
@@ -220,6 +220,7 @@ void PrintTo(const Expression& expr, std::ostream* os) {
 
 bool Expression::Equals(const Expression& other) const {
   if (Identical(*this, other)) return true;
+
   if (impl_ == nullptr || other.impl_ == nullptr) return false;
 
   if (impl_->index() != other.impl_->index()) {

--- a/cpp/src/arrow/compute/expression_test.cc
+++ b/cpp/src/arrow/compute/expression_test.cc
@@ -1916,6 +1916,12 @@ TEST(Expression, SerializationRoundTrips) {
                          equal(field_ref("beta"), literal(3.25f))}));
 }
 
+TEST(Expression, ExpressionEquals) {
+  Expression expr1;
+  Expression expr2(literal(1));
+
+  EXPECT_FALSE(expr1.Equals(expr2));
+}
 TEST(Projection, AugmentWithNull) {
   // NB: input contains *no columns* except i32
   auto input = ArrayFromJSON(struct_({kBoringSchema->GetFieldByName("i32")}),

--- a/cpp/src/arrow/compute/expression_test.cc
+++ b/cpp/src/arrow/compute/expression_test.cc
@@ -338,6 +338,13 @@ TEST(Expression, Equality) {
               literal(std::numeric_limits<double>::signaling_NaN()));
   }
 
+  Expression expr1;
+  Expression expr2(literal(1));
+  EXPECT_NE(literal("a"), expr1);
+
+  EXPECT_FALSE(expr1.Equals(expr2));
+  EXPECT_FALSE(expr2.Equals(expr1));
+
   EXPECT_EQ(field_ref("a"), field_ref("a"));
   EXPECT_NE(field_ref("a"), field_ref("b"));
   EXPECT_NE(field_ref("a"), literal(2));
@@ -1916,12 +1923,6 @@ TEST(Expression, SerializationRoundTrips) {
                          equal(field_ref("beta"), literal(3.25f))}));
 }
 
-TEST(Expression, ExpressionEquals) {
-  Expression expr1;
-  Expression expr2(literal(1));
-
-  EXPECT_FALSE(expr1.Equals(expr2));
-}
 TEST(Projection, AugmentWithNull) {
   // NB: input contains *no columns* except i32
   auto input = ArrayFromJSON(struct_({kBoringSchema->GetFieldByName("i32")}),

--- a/cpp/src/arrow/compute/expression_test.cc
+++ b/cpp/src/arrow/compute/expression_test.cc
@@ -341,6 +341,7 @@ TEST(Expression, Equality) {
   Expression expr1;
   Expression expr2(literal(1));
   EXPECT_NE(literal("a"), expr1);
+  EXPECT_NE(expr1, literal("a"));
 
   EXPECT_FALSE(expr1.Equals(expr2));
   EXPECT_FALSE(expr2.Equals(expr1));

--- a/cpp/src/arrow/compute/expression_test.cc
+++ b/cpp/src/arrow/compute/expression_test.cc
@@ -338,6 +338,7 @@ TEST(Expression, Equality) {
               literal(std::numeric_limits<double>::signaling_NaN()));
   }
 
+  // Equality when underlying `impl_` is null.
   Expression expr1;
   Expression expr2(literal(1));
   EXPECT_NE(literal("a"), expr1);


### PR DESCRIPTION

### Rationale for this change

### What changes are included in this PR?
This PR adds a check to ensure that the Expression is not nullptr
### Are these changes tested?
Yes.
### Are there any user-facing changes?
No

* GitHub Issue: #45700