### PR TITLE
GH-45705: [Python] Add support for SAS token in AzureFileSystem

### DIFF
--- a/python/pyarrow/_azurefs.pyx
+++ b/python/pyarrow/_azurefs.pyx
@@ -48,7 +48,8 @@ cdef class AzureFileSystem(FileSystem):
         storage account.
     account_key : str, default None
         Account key of the storage account. If sas_token and account_key are None the 
-        default credential will be used. 
+        default credential will be used. The parameters account_key and sas_token are
+        mutually exclusive.
     blob_storage_authority : str, default None
         hostname[:port] of the Blob Service. Defaults to `.blob.core.windows.net`. Useful
         for connecting to a local emulator, like Azurite.
@@ -63,7 +64,8 @@ cdef class AzureFileSystem(FileSystem):
         emulator, like Azurite.
     sas_token : str, default None
         SAS token for the storage account, used as an alternative to account_key. If sas_token
-        and account_key are None the default credential will be used. 
+        and account_key are None the default credential will be used. The parameters 
+        account_key and sas_token are mutually exclusive.
 
     Examples
     --------

--- a/python/pyarrow/_azurefs.pyx
+++ b/python/pyarrow/_azurefs.pyx
@@ -62,7 +62,7 @@ cdef class AzureFileSystem(FileSystem):
         Either `http` or `https`. Defaults to `https`. Useful for connecting to a local 
         emulator, like Azurite.
     sas_token : str, default None
-        Sas token for the storage account, used as an alternative to account_key. If sas_token
+        SAS token for the storage account, used as an alternative to account_key. If sas_token
         and account_key are None the default credential will be used. 
 
     Examples

--- a/python/pyarrow/_azurefs.pyx
+++ b/python/pyarrow/_azurefs.pyx
@@ -102,6 +102,9 @@ cdef class AzureFileSystem(FileSystem):
         if dfs_storage_scheme:
             options.dfs_storage_scheme = tobytes(dfs_storage_scheme)
 
+        if account_key and sas_token:
+            raise ValueError("Cannot specify both account_key and sas_token.")
+
         if account_key:
             options.ConfigureAccountKeyCredential(tobytes(account_key))
             self.account_key = tobytes(account_key)

--- a/python/pyarrow/_azurefs.pyx
+++ b/python/pyarrow/_azurefs.pyx
@@ -47,7 +47,8 @@ cdef class AzureFileSystem(FileSystem):
         Azure Blob Storage account name. This is the globally unique identifier for the 
         storage account.
     account_key : str, default None
-        Account key of the storage account. Pass None to use default credential. 
+        Account key of the storage account. If sas_token and account_key are None the 
+        default credential will be used. 
     blob_storage_authority : str, default None
         hostname[:port] of the Blob Service. Defaults to `.blob.core.windows.net`. Useful
         for connecting to a local emulator, like Azurite.
@@ -61,7 +62,8 @@ cdef class AzureFileSystem(FileSystem):
         Either `http` or `https`. Defaults to `https`. Useful for connecting to a local 
         emulator, like Azurite.
     sas_token : str, default None
-        Sas token for the storage account, used as an alternative to account_key.
+        Sas token for the storage account, used as an alternative to account_key. If sas_token
+        and account_key are None the default credential will be used. 
 
     Examples
     --------
@@ -133,5 +135,6 @@ cdef class AzureFileSystem(FileSystem):
                 blob_storage_authority=frombytes(opts.blob_storage_authority),
                 dfs_storage_authority=frombytes(opts.dfs_storage_authority),
                 blob_storage_scheme=frombytes(opts.blob_storage_scheme),
-                dfs_storage_scheme=frombytes(opts.dfs_storage_scheme)
+                dfs_storage_scheme=frombytes(opts.dfs_storage_scheme),
+                sas_token=frombytes(self.sas_token)
             ),))

--- a/python/pyarrow/_azurefs.pyx
+++ b/python/pyarrow/_azurefs.pyx
@@ -60,6 +60,8 @@ cdef class AzureFileSystem(FileSystem):
     dfs_storage_scheme : str, default None
         Either `http` or `https`. Defaults to `https`. Useful for connecting to a local 
         emulator, like Azurite.
+    sas_token : str, default None
+        Sas token for the storage account, used as an alternative to account_key.
 
     Examples
     --------
@@ -79,10 +81,11 @@ cdef class AzureFileSystem(FileSystem):
     cdef:
         CAzureFileSystem* azurefs
         c_string account_key
+        c_string sas_token
 
     def __init__(self, account_name, *, account_key=None, blob_storage_authority=None,
                  dfs_storage_authority=None, blob_storage_scheme=None,
-                 dfs_storage_scheme=None):
+                 dfs_storage_scheme=None, sas_token=None):
         cdef:
             CAzureOptions options
             shared_ptr[CAzureFileSystem] wrapped
@@ -100,6 +103,9 @@ cdef class AzureFileSystem(FileSystem):
         if account_key:
             options.ConfigureAccountKeyCredential(tobytes(account_key))
             self.account_key = tobytes(account_key)
+        elif sas_token:
+            options.ConfigureSASCredential(tobytes(sas_token))
+            self.sas_token = tobytes(sas_token)
         else:
             options.ConfigureDefaultCredential()
 

--- a/python/pyarrow/includes/libarrow_fs.pxd
+++ b/python/pyarrow/includes/libarrow_fs.pxd
@@ -252,6 +252,7 @@ cdef extern from "arrow/filesystem/api.h" namespace "arrow::fs" nogil:
         c_bool Equals(const CAzureOptions& other)
         CStatus ConfigureDefaultCredential()
         CStatus ConfigureAccountKeyCredential(c_string account_key)
+        CStatus ConfigureSASCredential(c_string sas_token)
 
     cdef cppclass CAzureFileSystem "arrow::fs::AzureFileSystem":
         @staticmethod

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -1463,6 +1463,12 @@ def test_azurefs_options(pickle_module):
     assert pickle_module.loads(pickle_module.dumps(fs3)) == fs3
     assert fs3 != fs2
 
+    fs4 = AzureFileSystem(account_name='fake-account-name',
+                          sas_token='fakesastoken')
+    assert isinstance(fs4, AzureFileSystem)
+    assert pickle_module.loads(pickle_module.dumps(fs4)) == fs4
+    assert fs4 != fs3
+
     with pytest.raises(TypeError):
         AzureFileSystem()
 

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -1468,6 +1468,10 @@ def test_azurefs_options(pickle_module):
     assert isinstance(fs4, AzureFileSystem)
     assert pickle_module.loads(pickle_module.dumps(fs4)) == fs4
     assert fs4 != fs3
+    
+    with pytest.raises(ValueError):
+        AzureFileSystem(account_name='fake-account-name', account_key='fakeaccount',
+                        sas_token = 'fakesastoken')
 
     with pytest.raises(TypeError):
         AzureFileSystem()

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -1468,10 +1468,10 @@ def test_azurefs_options(pickle_module):
     assert isinstance(fs4, AzureFileSystem)
     assert pickle_module.loads(pickle_module.dumps(fs4)) == fs4
     assert fs4 != fs3
-    
+
     with pytest.raises(ValueError):
         AzureFileSystem(account_name='fake-account-name', account_key='fakeaccount',
-                        sas_token = 'fakesastoken')
+                        sas_token='fakesastoken')
 
     with pytest.raises(TypeError):
         AzureFileSystem()


### PR DESCRIPTION
### Rationale for this change

Python bindings could use the ability to use SAS tokens just like C++

### What changes are included in this PR?

AzureFileSystem now includes a sas_token parameter

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Additional parameter to AzureFileSystem

* GitHub Issue: #45705