### PR TITLE
GH-45710: [GLib] Add GArrowStringViewArray

### DIFF
--- a/c_glib/arrow-glib/basic-array.cpp
+++ b/c_glib/arrow-glib/basic-array.cpp
@@ -132,6 +132,11 @@ G_BEGIN_DECLS
  * format data, you need to use #GArrowBinaryViewArrayBuilder to create
  * a new array.
  *
+ * #GArrayStringViewArray is a class for variable-size string view array.
+ * It can store zero or more string view data. If you don't have Arrow
+ * format data, you need to use #GArrowStringViewArrayBuilder to create
+ * a new array.
+ *
  * #GArrowFixedSizeBinaryArray is a class for fixed size binary array.
  * It can store zero or more fixed size binary data. If you don't have
  * Arrow format data, you need to use
@@ -2599,6 +2604,75 @@ garrow_binary_view_array_get_value(GArrowBinaryViewArray *array, gint64 i)
 {
   auto arrow_array = garrow_array_get_raw(GARROW_ARRAY(array));
   auto view = static_cast<arrow::BinaryViewArray *>(arrow_array.get())->GetView(i);
+  return g_bytes_new_static(view.data(), view.length());
+}
+
+G_DEFINE_TYPE(GArrowStringViewArray,
+              garrow_string_view_array,
+              GARROW_TYPE_BINARY_VIEW_ARRAY)
+static void
+garrow_string_view_array_init(GArrowStringViewArray *object)
+{
+}
+
+static void
+garrow_string_view_array_class_init(GArrowStringViewArrayClass *klass)
+{
+}
+
+/**
+ * garrow_string_view_array_new:
+ * @length: The number of elements.
+ * @views: The view buffer.
+ * @data_buffers: (element-type GArrowBuffer): The data buffers.
+ * @null_bitmap: (nullable): The bitmap that shows null elements. The
+ *   N-th element is null when the N-th bit is 0, not null otherwise.
+ *   If the array has no null elements, the bitmap must be %NULL and
+ *   @n_nulls is 0.
+ * @n_nulls: The number of null elements. If -1 is specified, the
+ *   number of nulls are computed from @null_bitmap.
+ * @offset: The position of the first element.
+ *
+ * Returns: A newly created #GArrowStringViewArray.
+ *
+ * Since: 20.0.0
+ */
+GArrowStringViewArray *
+garrow_string_view_array_new(gint64 length,
+                             GArrowBuffer *views,
+                             GList *data_buffers,
+                             GArrowBuffer *null_bitmap,
+                             gint64 n_nulls,
+                             gint64 offset)
+{
+  std::vector<std::shared_ptr<arrow::Buffer>> arrow_data_buffers;
+  for (GList *node = data_buffers; node; node = g_list_next(node)) {
+    arrow_data_buffers.push_back(garrow_buffer_get_raw(GARROW_BUFFER(node->data)));
+  }
+  auto string_view_array =
+    std::make_shared<arrow::StringViewArray>(arrow::utf8_view(),
+                                             length,
+                                             garrow_buffer_get_raw(views),
+                                             std::move(arrow_data_buffers),
+                                             garrow_buffer_get_raw(null_bitmap),
+                                             n_nulls,
+                                             offset);
+  return GARROW_STRING_VIEW_ARRAY(
+    g_object_new(GARROW_TYPE_STRING_VIEW_ARRAY, "array", &string_view_array, nullptr));
+}
+
+/**
+ * garrow_string_view_array_get_value:
+ * @array: A #GArrowStringViewArray.
+ * @i: The index of the target value.
+ *
+ * Returns: (transfer full): The @i-th value.
+ */
+GBytes *
+garrow_string_view_array_get_value(GArrowStringViewArray *array, gint64 i)
+{
+  auto arrow_array = garrow_array_get_raw(GARROW_ARRAY(array));
+  auto view = static_cast<arrow::StringViewArray *>(arrow_array.get())->GetView(i);
   return g_bytes_new_static(view.data(), view.length());
 }
 

--- a/c_glib/arrow-glib/basic-array.cpp
+++ b/c_glib/arrow-glib/basic-array.cpp
@@ -2649,7 +2649,7 @@ garrow_string_view_array_new(gint64 length,
   for (GList *node = data_buffers; node; node = g_list_next(node)) {
     arrow_data_buffers.push_back(garrow_buffer_get_raw(GARROW_BUFFER(node->data)));
   }
-  auto string_view_array =
+  auto arrow_string_view_array =
     std::make_shared<arrow::StringViewArray>(arrow::utf8_view(),
                                              length,
                                              garrow_buffer_get_raw(views),

--- a/c_glib/arrow-glib/basic-array.cpp
+++ b/c_glib/arrow-glib/basic-array.cpp
@@ -2657,8 +2657,10 @@ garrow_string_view_array_new(gint64 length,
                                              garrow_buffer_get_raw(null_bitmap),
                                              n_nulls,
                                              offset);
-  return GARROW_STRING_VIEW_ARRAY(
-    g_object_new(GARROW_TYPE_STRING_VIEW_ARRAY, "array", &string_view_array, nullptr));
+  return GARROW_STRING_VIEW_ARRAY(g_object_new(GARROW_TYPE_STRING_VIEW_ARRAY,
+                                               "array",
+                                               &arrow_string_view_array,
+                                               nullptr));
 }
 
 /**

--- a/c_glib/arrow-glib/basic-array.h
+++ b/c_glib/arrow-glib/basic-array.h
@@ -624,6 +624,31 @@ GARROW_AVAILABLE_IN_20_0
 GBytes *
 garrow_binary_view_array_get_value(GArrowBinaryViewArray *array, gint64 i);
 
+#define GARROW_TYPE_STRING_VIEW_ARRAY (garrow_string_view_array_get_type())
+GARROW_AVAILABLE_IN_20_0
+G_DECLARE_DERIVABLE_TYPE(GArrowStringViewArray,
+                         garrow_string_view_array,
+                         GARROW,
+                         STRING_VIEW_ARRAY,
+                         GArrowBinaryViewArray)
+struct _GArrowStringViewArrayClass
+{
+  GArrowBinaryViewArrayClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_20_0
+GArrowStringViewArray *
+garrow_string_view_array_new(gint64 length,
+                             GArrowBuffer *views,
+                             GList *data_buffers,
+                             GArrowBuffer *null_bitmap,
+                             gint64 n_nulls,
+                             gint64 offset);
+
+GARROW_AVAILABLE_IN_20_0
+GBytes *
+garrow_string_view_array_get_value(GArrowStringViewArray *array, gint64 i);
+
 #define GARROW_TYPE_DATE32_ARRAY (garrow_date32_array_get_type())
 GARROW_AVAILABLE_IN_ALL
 G_DECLARE_DERIVABLE_TYPE(

--- a/c_glib/test/test-string-view-array.rb
+++ b/c_glib/test/test-string-view-array.rb
@@ -1,0 +1,40 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestStringViewArray < Test::Unit::TestCase
+  def test_new
+    short_string_data = "test"
+    short_view_buffer_space = 12
+    short_view_buffer = [short_string_data.size].pack("l")
+    short_view_buffer += short_string_data.ljust(short_view_buffer_space, "\x00")
+
+    arrow_view_buffer = Arrow::Buffer.new(short_view_buffer)
+    arrow_data_buffer = Arrow::Buffer.new(short_string_data)
+    bitmap = Arrow::Buffer.new([0b1].pack("C*"))
+
+    string_view_array = Arrow::StringViewArray.new(1,
+                                                   arrow_view_buffer,
+                                                   [arrow_data_buffer],
+                                                   bitmap,
+                                                   0,
+                                                   0)
+    assert do
+      string_view_array.validate_full
+    end
+    assert_equal(short_string_data, string_view_array.get_value(0).to_s)
+  end
+end


### PR DESCRIPTION
### Rationale for this change

[arrow::StringViewArray](https://arrow.apache.org/docs/cpp/api/array.html#_CPPv4N5arrow15StringViewArrayE) is available in the C++ API.
But, GLib doesn't support that method yet.

### What changes are included in this PR?

Add `GArrowBinaryViewArray` to wrap the `arrow::BinaryViewArray` class.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #45710