### PR TITLE
WIP: [R] [CI] try a different image for our lto check

### DIFF
--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1251,7 +1251,7 @@ tasks:
     template: r/azure.linux.yml
     params:
       r_org: rhub
-      r_image: gcc13
+      r_image: gcc14
       r_tag: latest
       flags: '-e INSTALL_ARGS=--use-LTO'
 


### PR DESCRIPTION
Something is up with the installation (or possibly the base image from r-hub) where the stats package is not findable / linkable (see below). So trying a slightly newer (gcc) image which should work the same as the prior one, to see if it avoids whatever malignancy is in the gcc13 one. 

```

#21 0.343 package ‘stats’ in options("defaultPackages") was not found 
#21 0.346 > options(warn=2); install.packages('remotes'); remotes::install_cran(c('glue', 'rcmdcheck', 'sys')); remotes::install_deps(INSTALL_opts = '')
#21 0.349 Installing package into ‘/root/R/x86_64-pc-linux-gnu-library/4.5’
#21 0.349 (as ‘lib’ is unspecified)
#21 1.042 trying URL 'https://cloud.r-project.org/src/contrib/remotes_2.5.0.tar.gz'
#21 1.401 Content type 'application/x-gzip' length 164496 bytes (160 KB)
#21 1.401 ==================================================
#21 1.403 downloaded 160 KB
#21 1.403 
#21 1.599 During startup - Warning message:
#21 1.599 package ‘stats’ in options("defaultPackages") was not found 
#21 1.744 * installing *source* package ‘remotes’ ...
#21 1.744 ** this is package ‘remotes’ version ‘2.5.0’
#21 1.750 ** package ‘remotes’ successfully unpacked and MD5 sums checked
#21 1.751 ** using staged installation
#21 1.772 ** R
#21 1.793 ** inst
#21 1.794 ** byte-compile and prepare package for lazy loading
#21 2.064 ERROR: lazy loading failed for package ‘remotes’
#21 2.065 During startup - Warning message:
#21 2.065 package ‘stats’ in options("defaultPackages") was not found 
#21 2.065 Error in dyn.load(file, DLLpath = DLLpath, ...) : 
#21 2.065   unable to load shared object '/opt/R/devel-gcc13/lib/R/library/stats/libs/stats.so':
#21 2.065   /opt/R/devel-gcc13/lib/R/lib/libRlapack.so: undefined symbol: dgemmtr_
#21 2.065 Calls: <Anonymous> ... asNamespace -> loadNamespace -> library.dynam -> dyn.load
#21 2.065 Execution halted
#21 2.066 * removing ‘/root/R/x86_64-pc-linux-gnu-library/4.5/remotes’
#21 2.079 Error in install.packages("remotes") : 
#21 2.079   (converted from warning) installation of package ‘remotes’ had non-zero exit status
#21 2.079 Execution halted
```
https://dev.azure.com/ursacomputing/crossbow/_build/results?buildId=68656&view=logs&j=0da5d1d9-276d-5173-c4c4-9d4d4ed14fdb&t=d9b15392-e4ce-5e4c-0c8c-b69645229181
