### PR TITLE
GH-45724: [Docs] Fix docs image name from ubuntu-docs to debian-docs

### DIFF
--- a/docs/source/developers/documentation.rst
+++ b/docs/source/developers/documentation.rst
@@ -115,7 +115,7 @@ Docker container.
 
 .. code-block:: shell
 
-  archery docker run -v "${PWD}/docs:/build/docs" ubuntu-docs
+  archery docker run -v "${PWD}/docs:/build/docs" debian-docs
 
 The final output is located under the ``${PWD}/docs`` directory.
 


### PR DESCRIPTION
### Rationale for this change

The document for build Docker image still use `ubuntu-docs` currently, which was changed in #41455 . This PR updates the documentation to replace `ubuntu-docs` with `debian-docs`.

### What changes are included in this PR?

Change docker image name from `ubuntu-docs` to `debian-docs`

### Are these changes tested?

yes.

### Are there any user-facing changes?

no.
* GitHub Issue: #45724