### PR TITLE
GH-45656: [C#] Fix failing MacOS builds

### DIFF
--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -65,9 +65,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Install Source Link
-        shell: bash
-        run: dotnet tool install --global sourcelink
       - name: Build
         shell: bash
         run: ci/scripts/csharp_build.sh $(pwd)
@@ -93,8 +90,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Install Source Link
-        run: dotnet tool install --global sourcelink
       - name: Build
         shell: bash
         run: ci/scripts/csharp_build.sh $(pwd)
@@ -124,9 +119,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Install Source Link
-        shell: bash
-        run: dotnet tool install --global sourcelink
       - name: Build
         shell: bash
         run: ci/scripts/csharp_build.sh $(pwd)

--- a/ci/scripts/csharp_test.sh
+++ b/ci/scripts/csharp_test.sh
@@ -34,7 +34,4 @@ export PYTHONNET_PYDLL=$(${PYTHON} -m find_libpython)
 
 pushd ${source_dir}
 dotnet test
-for pdb in artifacts/Apache.Arrow/*/*/Apache.Arrow.pdb; do
-  sourcelink test ${pdb}
-done
 popd

--- a/csharp/examples/Examples.sln
+++ b/csharp/examples/Examples.sln
@@ -1,11 +1,19 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27703.2042
+# Visual Studio Version 17
+VisualStudioVersion = 17.12.35707.178 d17.12
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FluentBuilderExample", "FluentBuilderExample\FluentBuilderExample.csproj", "{ECE22119-D91D-44F7-9575-85B98F946289}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Apache.Arrow", "..\src\Apache.Arrow\Apache.Arrow.csproj", "{1FE1DE95-FF6E-4895-82E7-909713C53524}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FlightAspServerExample", "FlightAspServerExample\FlightAspServerExample.csproj", "{16FF9B95-1E65-4285-9A78-463A71823D3C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FlightClientExample", "FlightClientExample\FlightClientExample.csproj", "{8D19CF7A-3DAB-41D0-94B1-20892C4EACB8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Apache.Arrow.Flight", "..\src\Apache.Arrow.Flight\Apache.Arrow.Flight.csproj", "{9D5029EC-CFF6-4A0C-A03D-CC534A54C6BB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Apache.Arrow.Flight.AspNetCore", "..\src\Apache.Arrow.Flight.AspNetCore\Apache.Arrow.Flight.AspNetCore.csproj", "{6F2FA3F3-1B33-4742-99C2-B728CBD27861}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -21,6 +29,22 @@ Global
 		{1FE1DE95-FF6E-4895-82E7-909713C53524}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1FE1DE95-FF6E-4895-82E7-909713C53524}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1FE1DE95-FF6E-4895-82E7-909713C53524}.Release|Any CPU.Build.0 = Release|Any CPU
+		{16FF9B95-1E65-4285-9A78-463A71823D3C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{16FF9B95-1E65-4285-9A78-463A71823D3C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{16FF9B95-1E65-4285-9A78-463A71823D3C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{16FF9B95-1E65-4285-9A78-463A71823D3C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8D19CF7A-3DAB-41D0-94B1-20892C4EACB8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8D19CF7A-3DAB-41D0-94B1-20892C4EACB8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8D19CF7A-3DAB-41D0-94B1-20892C4EACB8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8D19CF7A-3DAB-41D0-94B1-20892C4EACB8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9D5029EC-CFF6-4A0C-A03D-CC534A54C6BB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9D5029EC-CFF6-4A0C-A03D-CC534A54C6BB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9D5029EC-CFF6-4A0C-A03D-CC534A54C6BB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9D5029EC-CFF6-4A0C-A03D-CC534A54C6BB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6F2FA3F3-1B33-4742-99C2-B728CBD27861}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6F2FA3F3-1B33-4742-99C2-B728CBD27861}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6F2FA3F3-1B33-4742-99C2-B728CBD27861}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6F2FA3F3-1B33-4742-99C2-B728CBD27861}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -364,16 +364,6 @@ install_csharp() {
     show_info "Installed C# at $(which csharp) (.NET $(dotnet --version))"
   fi
 
-  # Ensure to have sourcelink installed
-  if ! dotnet tool list | grep sourcelink > /dev/null 2>&1; then
-    dotnet new tool-manifest
-    dotnet tool install --local sourcelink
-    PATH=${csharp_bin}:${PATH}
-    if ! dotnet tool run sourcelink --help > /dev/null 2>&1; then
-      export DOTNET_ROOT=${csharp_bin}
-    fi
-  fi
-
   CSHARP_ALREADY_INSTALLED=1
 }
 
@@ -747,13 +737,6 @@ test_csharp() {
     mv dummy.git ../.git
     dotnet pack -c Release
     mv ../.git dummy.git
-  fi
-
-  if [ "${SOURCE_KIND}" = "local" ]; then
-    echo "Skipping sourcelink verification on local build"
-  else
-    dotnet tool run sourcelink test artifacts/Apache.Arrow/Release/netstandard2.0/Apache.Arrow.pdb
-    dotnet tool run sourcelink test artifacts/Apache.Arrow/Release/net6.0/Apache.Arrow.pdb
   fi
 
   popd


### PR DESCRIPTION
### Rationale for this change

Fix MacOS builds by removing command-line sourcelink tool. This appears to be deprecated and the certificate is expired.

### Are there any user-facing changes?

No.
* GitHub Issue: #45656