### PR TITLE
GH-45708: [Release] Re-run binary verification jobs after we upload binaries

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -195,6 +195,7 @@ repos:
           ?^ci/scripts/c_glib_build\.sh$|
           ?^ci/scripts/c_glib_test\.sh$|
           ?^c_glib/test/run-test\.sh$|
+          ?^dev/release/07-binary-verify\.sh$|
           ?^dev/release/utils-generate-checksum\.sh$|
           )
   - repo: https://github.com/trim21/pre-commit-mirror-meson

--- a/dev/release/07-binary-verify.sh
+++ b/dev/release/07-binary-verify.sh
@@ -29,14 +29,17 @@ fi
 version=$1
 rc=$2
 
-rc_branch="release-${version}-rc${rc}"
+rc_tag="apache-arrow-${version}-rc${rc}"
+repository="${REPOSITORY:-apache/arrow}"
 
-archery crossbow \
-  verify-release-candidate \
-  --head-branch=${rc_branch} \
-  --pr-title="WIP: [Release] Verify ${rc_branch}" \
-  --rc=${rc} \
-  --remote=https://github.com/apache/arrow \
-  --verify-binaries \
-  --verify-wheels \
-  --version=${version}
+run_id=$(gh run list \
+            --branch "${rc_tag}" \
+            --jq '.[].databaseId' \
+            --json databaseId \
+            --limit 1 \
+            --repo "${repository}" \
+            --workflow "verify_rc.yml")
+gh run rerun \
+   "${run_id}" \
+   --failed \
+   --repo "${repository}"


### PR DESCRIPTION
### Rationale for this change

We don't need to run new crossbow jobs. We need to re-run GitHub Actions workflow for apache-arrow-X.Y.Z-rcN tag instead.

### What changes are included in this PR?

Re-run GitHub Actions workflow for apache-arrow-X.Y.Z-rcN tag.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #45708