### PR TITLE
GH-45548: [Release][Dev][Packaging] Omit APT/Yum repositories check on local in the RC verification script

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -191,7 +191,7 @@ check_verification_result_on_github() {
   conclusion="$(jq -r '.conclusion' latest_verify_rc.json)"
   if [ "${conclusion}" != "success" ]; then
     html_url="$(jq -r '.html_url' latest_verify_rc.json)"
-    echo "Verification on GitHub wasn't succeeded: ${conclusion}: ${html_url}"
+    echo "Verification on GitHub wasn't successful: ${conclusion}: ${html_url}"
     exit 1
   fi
   popd

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -181,95 +181,123 @@ test_binary() {
   verify_dir_artifact_signatures ${download_dir}
 }
 
+check_verification_result_on_github() {
+  pushd ${ARROW_TMPDIR}
+  curl \
+    --get \
+    --data "branch=apache-arrow-${VERSION}-rc${RC_NUMBER}" \
+    "https://api.github.com/repos/apache/arrow/actions/workflows/verify_rc.yml/runs" | \
+    jq '.workflow_runs[0]' > latest_verify_rc.json
+  conclusion="$(jq -r '.conclusion' latest_verify_rc.json)"
+  if [ "${conclusion}" != "success" ]; then
+    html_url="$(jq -r '.html_url' latest_verify_rc.json)"
+    echo "Verification on GitHub wasn't succeeded: ${conclusion}: ${html_url}"
+    exit 1
+  fi
+  popd
+}
+
 test_apt() {
   show_header "Testing APT packages"
 
-  if [ "$(arch)" = "x86_64" ]; then
-    for target in "debian:bookworm" \
-                  "debian:trixie" \
-                  "ubuntu:jammy" \
-                  "ubuntu:noble"; do \
-      if ! docker run \
-             --platform=linux/x86_64 \
-             --rm \
-             --security-opt="seccomp=unconfined" \
-             --volume "${ARROW_DIR}":/arrow:delegated \
-             "${target}" \
-             /arrow/dev/release/verify-apt.sh \
-             "${VERSION}" \
-             "rc"; then
-        echo "Failed to verify the APT repository for ${target} on x86_64"
-        exit 1
-      fi
-    done
+  if [ "${GITHUB_ACTIONS}" != "true" ]; then
+    check_verification_result_on_github
+    return 0
   fi
 
-  if [ "$(arch)" = "aarch64" -o -e /usr/bin/qemu-aarch64-static ]; then
-    for target in "arm64v8/debian:bookworm" \
-                  "arm64v8/debian:trixie" \
-                  "arm64v8/ubuntu:jammy" \
-                  "arm64v8/ubuntu:noble"; do \
-      if ! docker run \
-             --platform=linux/arm64 \
-             --rm \
-             --security-opt="seccomp=unconfined" \
-             --volume "${ARROW_DIR}":/arrow:delegated \
-             "${target}" \
-             /arrow/dev/release/verify-apt.sh \
-             "${VERSION}" \
-             "rc"; then
-        echo "Failed to verify the APT repository for ${target} on arm64"
-        exit 1
-      fi
-    done
-  fi
+  case "$(arch)" in
+    "x86_64")
+      for target in "debian:bookworm" \
+                    "debian:trixie" \
+                    "ubuntu:jammy" \
+                    "ubuntu:noble"; do \
+        if ! docker run \
+               --platform=linux/x86_64 \
+               --rm \
+               --security-opt="seccomp=unconfined" \
+               --volume "${ARROW_DIR}":/arrow:delegated \
+               "${target}" \
+               /arrow/dev/release/verify-apt.sh \
+               "${VERSION}" \
+               "rc"; then
+          echo "Failed to verify the APT repository for ${target} on x86_64"
+          exit 1
+        fi
+      done
+      ;;
+    "aarch64")
+      for target in "arm64v8/debian:bookworm" \
+                    "arm64v8/debian:trixie" \
+                    "arm64v8/ubuntu:jammy" \
+                    "arm64v8/ubuntu:noble"; do \
+        if ! docker run \
+               --platform=linux/arm64 \
+               --rm \
+               --security-opt="seccomp=unconfined" \
+               --volume "${ARROW_DIR}":/arrow:delegated \
+               "${target}" \
+               /arrow/dev/release/verify-apt.sh \
+               "${VERSION}" \
+               "rc"; then
+          echo "Failed to verify the APT repository for ${target} on arm64"
+          exit 1
+        fi
+      done
+      ;;
+  esac
 }
 
 test_yum() {
   show_header "Testing Yum packages"
 
-  if [ "$(arch)" = "x86_64" ]; then
-    for target in "almalinux:9" \
-                  "almalinux:8" \
-                  "amazonlinux:2023" \
-                  "quay.io/centos/centos:stream9" \
-                  "quay.io/centos/centos:stream8" \
-                  "centos:7"; do
-      if ! docker run \
-             --platform linux/x86_64 \
-             --rm \
-             --security-opt="seccomp=unconfined" \
-             --volume "${ARROW_DIR}":/arrow:delegated \
-             "${target}" \
-             /arrow/dev/release/verify-yum.sh \
-             "${VERSION}" \
-             "rc"; then
-        echo "Failed to verify the Yum repository for ${target} on x86_64"
-        exit 1
-      fi
-    done
+  if [ "${GITHUB_ACTIONS}" != "true" ]; then
+    check_verification_result_on_github
+    return 0
   fi
 
-  if [ "$(arch)" = "aarch64" -o -e /usr/bin/qemu-aarch64-static ]; then
-    for target in "arm64v8/almalinux:9" \
-                  "arm64v8/almalinux:8" \
-                  "arm64v8/amazonlinux:2023" \
-                  "quay.io/centos/centos:stream9" \
-                  "quay.io/centos/centos:stream8"; do
-      if ! docker run \
-             --platform linux/arm64 \
-             --rm \
-             --security-opt="seccomp=unconfined" \
-             --volume "${ARROW_DIR}":/arrow:delegated \
-             "${target}" \
-             /arrow/dev/release/verify-yum.sh \
-             "${VERSION}" \
-             "rc"; then
-        echo "Failed to verify the Yum repository for ${target} on arm64"
-        exit 1
-      fi
-    done
-  fi
+  case "$(arch)" in
+    "x86_64")
+      for target in "almalinux:9" \
+                    "almalinux:8" \
+                    "amazonlinux:2023" \
+                    "quay.io/centos/centos:stream9" \
+                    "quay.io/centos/centos:stream8" \
+                    "centos:7"; do
+        if ! docker run \
+               --platform linux/x86_64 \
+               --rm \
+               --security-opt="seccomp=unconfined" \
+               --volume "${ARROW_DIR}":/arrow:delegated \
+               "${target}" \
+               /arrow/dev/release/verify-yum.sh \
+               "${VERSION}" \
+               "rc"; then
+          echo "Failed to verify the Yum repository for ${target} on x86_64"
+          exit 1
+        fi
+      done
+      ;;
+    "aarch64")
+      for target in "arm64v8/almalinux:9" \
+                    "arm64v8/almalinux:8" \
+                    "arm64v8/amazonlinux:2023" \
+                    "quay.io/centos/centos:stream9" \
+                    "quay.io/centos/centos:stream8"; do
+        if ! docker run \
+               --platform linux/arm64 \
+               --rm \
+               --security-opt="seccomp=unconfined" \
+               --volume "${ARROW_DIR}":/arrow:delegated \
+               "${target}" \
+               /arrow/dev/release/verify-yum.sh \
+               "${VERSION}" \
+               "rc"; then
+          echo "Failed to verify the Yum repository for ${target} on arm64"
+          exit 1
+        fi
+      done
+      ;;
+  esac
 }
 
 setup_tempdir() {


### PR DESCRIPTION
### Rationale for this change

They use Docker. So results of them must be same on both of local and GitHub Actions.

### What changes are included in this PR?

Check the result on GitHub Actions on local.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #45548