### PR TITLE
GH-45739: [C++][Python] Fix crash when calling hash_pivot_wider without options

### DIFF
--- a/cpp/src/arrow/compute/kernels/hash_aggregate_pivot.cc
+++ b/cpp/src/arrow/compute/kernels/hash_aggregate_pivot.cc
@@ -452,9 +452,11 @@ const FunctionDoc hash_pivot_doc{
 }  // namespace
 
 void RegisterHashAggregatePivot(FunctionRegistry* registry) {
+  static const auto default_pivot_options = PivotWiderOptions::Defaults();
+
   {
-    auto func = std::make_shared<HashAggregateFunction>("hash_pivot_wider",
-                                                        Arity::Ternary(), hash_pivot_doc);
+    auto func = std::make_shared<HashAggregateFunction>(
+        "hash_pivot_wider", Arity::Ternary(), hash_pivot_doc, &default_pivot_options);
     for (auto key_type : BaseBinaryTypes()) {
       // Anything that scatter() (i.e. take()) accepts can be passed as values
       auto sig = KernelSignature::Make(


### PR DESCRIPTION
### Rationale for this change

Calling `hash_pivot_wider` without options is not very useful (it defaults to `key_names=[]`) but at least it shouldn't crash.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Just a bugfix.
* GitHub Issue: #45739