### PR TITLE
[Python] Configure pre-commit hook to run `ruff` on `archery` and other developer tools

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,12 +42,24 @@ repos:
           ?^ci/docker/python-.*-wheel-windows-test-vs2022.*\.dockerfile$|
           )
         types: []
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.10
+    hooks:
+      # Run the linter.
+      - id: ruff
+        args: [--fix]
+        files: >-
+          ^dev/archery/
+      # Run the formatter.
+      - id: ruff-format
+        files: >-
+          ^dev/
   - repo: https://github.com/pycqa/flake8
     rev: 6.1.0
     hooks:
       - id: flake8
         name: Python Format
-        files: ^(python|dev|c_glib|integration)/
+        files: ^(python|c_glib|integration)/
         types:
           - file
           - python

--- a/dev/archery/archery/benchmark/codec.py
+++ b/dev/archery/archery/benchmark/codec.py
@@ -63,13 +63,12 @@ class BenchmarkSuiteCodec:
     def encode(bs):
         return {
             "name": bs.name,
-            "benchmarks": [BenchmarkCodec.encode(b) for b in bs.benchmarks]
+            "benchmarks": [BenchmarkCodec.encode(b) for b in bs.benchmarks],
         }
 
     @staticmethod
     def decode(dct, **kwargs):
-        benchmarks = [BenchmarkCodec.decode(b)
-                      for b in dct.pop("benchmarks", [])]
+        benchmarks = [BenchmarkCodec.decode(b) for b in dct.pop("benchmarks", [])]
         return BenchmarkSuite(benchmarks=benchmarks, **dct, **kwargs)
 
 
@@ -80,8 +79,7 @@ class BenchmarkRunnerCodec:
 
     @staticmethod
     def decode(dct, **kwargs):
-        suites = [BenchmarkSuiteCodec.decode(s)
-                  for s in dct.pop("suites", [])]
+        suites = [BenchmarkSuiteCodec.decode(s) for s in dct.pop("suites", [])]
         return StaticBenchmarkRunner(suites=suites, **dct, **kwargs)
 
 

--- a/dev/archery/archery/benchmark/codec.py
+++ b/dev/archery/archery/benchmark/codec.py
@@ -14,13 +14,13 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
+from __future__ import annotations
 
 import json
 
+from ..benchmark.compare import BenchmarkComparator
 from ..benchmark.core import Benchmark, BenchmarkSuite
 from ..benchmark.runner import BenchmarkRunner, StaticBenchmarkRunner
-from ..benchmark.compare import BenchmarkComparator
 
 
 class JsonEncoder(json.JSONEncoder):

--- a/dev/archery/archery/benchmark/compare.py
+++ b/dev/archery/archery/benchmark/compare.py
@@ -18,35 +18,37 @@
 
 # Define a global regression threshold as 5%. This is purely subjective and
 # flawed. This does not track cumulative regression.
+from __future__ import annotations
+
 DEFAULT_THRESHOLD = 0.05
 
 
 def items_per_seconds_fmt(value):
     if value < 1000:
-        return "{} items/sec".format(value)
+        return f"{value} items/sec"
     if value < 1000**2:
-        return "{:.3f}K items/sec".format(value / 1000)
+        return f"{value / 1000:.3f}K items/sec"
     if value < 1000**3:
-        return "{:.3f}M items/sec".format(value / 1000**2)
+        return f"{value / 1000**2:.3f}M items/sec"
     else:
-        return "{:.3f}G items/sec".format(value / 1000**3)
+        return f"{value / 1000**3:.3f}G items/sec"
 
 
 def bytes_per_seconds_fmt(value):
     if value < 1024:
-        return "{} bytes/sec".format(value)
+        return f"{value} bytes/sec"
     if value < 1024**2:
-        return "{:.3f} KiB/sec".format(value / 1024)
+        return f"{value / 1024:.3f} KiB/sec"
     if value < 1024**3:
-        return "{:.3f} MiB/sec".format(value / 1024**2)
+        return f"{value / 1024**2:.3f} MiB/sec"
     if value < 1024**4:
-        return "{:.3f} GiB/sec".format(value / 1024**3)
+        return f"{value / 1024**3:.3f} GiB/sec"
     else:
-        return "{:.3f} TiB/sec".format(value / 1024**4)
+        return f"{value / 1024**4:.3f} TiB/sec"
 
 
 def change_fmt(value):
-    return "{:.3%}".format(value)
+    return f"{value:.3%}"
 
 
 def formatter_for_unit(unit):

--- a/dev/archery/archery/benchmark/compare.py
+++ b/dev/archery/archery/benchmark/compare.py
@@ -61,14 +61,15 @@ def formatter_for_unit(unit):
 
 
 class BenchmarkComparator:
-    """ Compares two benchmarks.
+    """Compares two benchmarks.
 
     Encodes the logic of comparing two benchmarks and taking a decision on
     if it induce a regression.
     """
 
-    def __init__(self, contender, baseline, threshold=DEFAULT_THRESHOLD,
-                 suite_name=None):
+    def __init__(
+        self, contender, baseline, threshold=DEFAULT_THRESHOLD, suite_name=None
+    ):
         self.contender = contender
         self.baseline = baseline
         self.threshold = threshold
@@ -100,14 +101,14 @@ class BenchmarkComparator:
 
     @property
     def confidence(self):
-        """ Indicate if a comparison of benchmarks should be trusted. """
+        """Indicate if a comparison of benchmarks should be trusted."""
         return True
 
     @property
     def regression(self):
         change = self.change
         adjusted_change = change if self.less_is_better else -change
-        return (self.confidence and adjusted_change > self.threshold)
+        return self.confidence and adjusted_change > self.threshold
 
     @property
     def formatted(self):
@@ -120,7 +121,7 @@ class BenchmarkComparator:
             "contender": fmt(self.contender.value),
             "unit": self.unit,
             "less_is_better": self.less_is_better,
-            "counters": str(self.baseline.counters)
+            "counters": str(self.baseline.counters),
         }
 
     def compare(self, comparator=None):
@@ -132,7 +133,7 @@ class BenchmarkComparator:
             "contender": self.contender.value,
             "unit": self.unit,
             "less_is_better": self.less_is_better,
-            "counters": self.baseline.counters
+            "counters": self.baseline.counters,
         }
 
     def __call__(self, **kwargs):
@@ -143,12 +144,12 @@ def pairwise_compare(contender, baseline):
     dict_contender = {e.name: e for e in contender}
     dict_baseline = {e.name: e for e in baseline}
 
-    for name in (dict_contender.keys() & dict_baseline.keys()):
+    for name in dict_contender.keys() & dict_baseline.keys():
         yield name, (dict_contender[name], dict_baseline[name])
 
 
 class RunnerComparator:
-    """ Compares suites/benchmarks from runners.
+    """Compares suites/benchmarks from runners.
 
     It is up to the caller that ensure that runners are compatible (both from
     the same language implementation).
@@ -166,10 +167,12 @@ class RunnerComparator:
         suites = pairwise_compare(contender, baseline)
 
         for suite_name, (suite_cont, suite_base) in suites:
-            benchmarks = pairwise_compare(
-                suite_cont.benchmarks, suite_base.benchmarks)
+            benchmarks = pairwise_compare(suite_cont.benchmarks, suite_base.benchmarks)
 
             for _, (bench_cont, bench_base) in benchmarks:
-                yield BenchmarkComparator(bench_cont, bench_base,
-                                          threshold=self.threshold,
-                                          suite_name=suite_name)
+                yield BenchmarkComparator(
+                    bench_cont,
+                    bench_base,
+                    threshold=self.threshold,
+                    suite_name=suite_name,
+                )

--- a/dev/archery/archery/benchmark/core.py
+++ b/dev/archery/archery/benchmark/core.py
@@ -28,8 +28,9 @@ def median(values):
 
 
 class Benchmark:
-    def __init__(self, name, unit, less_is_better, values, time_unit,
-                 times, counters=None):
+    def __init__(
+        self, name, unit, less_is_better, values, time_unit, times, counters=None
+    ):
         self.name = name
         self.unit = unit
         self.less_is_better = less_is_better

--- a/dev/archery/archery/benchmark/core.py
+++ b/dev/archery/archery/benchmark/core.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
 
 def median(values):
@@ -43,7 +44,7 @@ class Benchmark:
         return self.median
 
     def __repr__(self):
-        return "Benchmark[name={},value={}]".format(self.name, self.value)
+        return f"Benchmark[name={self.name},value={self.value}]"
 
 
 class BenchmarkSuite:
@@ -52,6 +53,4 @@ class BenchmarkSuite:
         self.benchmarks = benchmarks
 
     def __repr__(self):
-        return "BenchmarkSuite[name={}, benchmarks={}]".format(
-            self.name, self.benchmarks
-        )
+        return f"BenchmarkSuite[name={self.name}, benchmarks={self.benchmarks}]"

--- a/dev/archery/archery/benchmark/google.py
+++ b/dev/archery/archery/benchmark/google.py
@@ -14,14 +14,15 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
-from itertools import filterfalse, groupby, tee
 import json
 import subprocess
+from itertools import filterfalse, groupby, tee
 from tempfile import NamedTemporaryFile
 
-from .core import Benchmark
 from ..utils.command import Command
+from .core import Benchmark
 
 
 def partition(pred, iterable):
@@ -45,7 +46,7 @@ class GoogleBenchmarkCommand(Command):
     def list_benchmarks(self):
         argv = ["--benchmark_list_tests"]
         if self.benchmark_filter:
-            argv.append("--benchmark_filter={}".format(self.benchmark_filter))
+            argv.append(f"--benchmark_filter={self.benchmark_filter}")
         result = self.run(*argv, stdout=subprocess.PIPE,
                           stderr=subprocess.PIPE)
         return str.splitlines(result.stdout.decode("utf-8"))
@@ -166,7 +167,7 @@ class GoogleBenchmark(Benchmark):
                          counters)
 
     def __repr__(self):
-        return "GoogleBenchmark[name={},runs={}]".format(self.names, self.runs)
+        return f"GoogleBenchmark[name={self.names},runs={self.runs}]"
 
     @classmethod
     def from_json(cls, payload):

--- a/dev/archery/archery/benchmark/google.py
+++ b/dev/archery/archery/benchmark/google.py
@@ -32,7 +32,7 @@ def partition(pred, iterable):
 
 
 class GoogleBenchmarkCommand(Command):
-    """ Run a google benchmark binary.
+    """Run a google benchmark binary.
 
     This assumes the binary supports the standard command line options,
     notably `--benchmark_filter`, `--benchmark_format`, etc...
@@ -47,15 +47,16 @@ class GoogleBenchmarkCommand(Command):
         argv = ["--benchmark_list_tests"]
         if self.benchmark_filter:
             argv.append(f"--benchmark_filter={self.benchmark_filter}")
-        result = self.run(*argv, stdout=subprocess.PIPE,
-                          stderr=subprocess.PIPE)
+        result = self.run(*argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         return str.splitlines(result.stdout.decode("utf-8"))
 
     def results(self, repetitions=1, repetition_min_time=None):
         with NamedTemporaryFile() as out:
-            argv = [f"--benchmark_repetitions={repetitions}",
-                    f"--benchmark_out={out.name}",
-                    "--benchmark_out_format=json"]
+            argv = [
+                f"--benchmark_repetitions={repetitions}",
+                f"--benchmark_out={out.name}",
+                "--benchmark_out_format=json",
+            ]
 
             if repetition_min_time is not None:
                 argv.append(f"--benchmark_min_time={repetition_min_time:.6f}s")
@@ -70,7 +71,7 @@ class GoogleBenchmarkCommand(Command):
 
 
 class GoogleBenchmarkObservation:
-    """ Represents one run of a single (google c++) benchmark.
+    """Represents one run of a single (google c++) benchmark.
 
     Aggregates are reported by Google Benchmark executables alongside
     other observations whenever repetitions are specified (with
@@ -88,9 +89,18 @@ class GoogleBenchmarkObservation:
     RegressionSumKernel/32768/0_stddev          0 us          0 us  288.046MB/s
     """
 
-    def __init__(self, name, real_time, cpu_time, time_unit, run_type,
-                 size=None, bytes_per_second=None, items_per_second=None,
-                 **counters):
+    def __init__(
+        self,
+        name,
+        real_time,
+        cpu_time,
+        time_unit,
+        run_type,
+        size=None,
+        bytes_per_second=None,
+        items_per_second=None,
+        **counters,
+    ):
         self._name = name
         self.real_time = real_time
         self.cpu_time = cpu_time
@@ -103,12 +113,12 @@ class GoogleBenchmarkObservation:
 
     @property
     def is_aggregate(self):
-        """ Indicate if the observation is a run or an aggregate. """
+        """Indicate if the observation is a run or an aggregate."""
         return self.run_type == "aggregate"
 
     @property
     def is_realtime(self):
-        """ Indicate if the preferred value is realtime instead of cputime. """
+        """Indicate if the preferred value is realtime instead of cputime."""
         return self.name.find("/real_time") != -1
 
     @property
@@ -122,7 +132,7 @@ class GoogleBenchmarkObservation:
 
     @property
     def value(self):
-        """ Return the benchmark value."""
+        """Return the benchmark value."""
         return self.bytes_per_second or self.items_per_second or self.time
 
     @property
@@ -139,10 +149,10 @@ class GoogleBenchmarkObservation:
 
 
 class GoogleBenchmark(Benchmark):
-    """ A set of GoogleBenchmarkObservations. """
+    """A set of GoogleBenchmarkObservations."""
 
     def __init__(self, name, runs):
-        """ Initialize a GoogleBenchmark.
+        """Initialize a GoogleBenchmark.
 
         Parameters
         ----------
@@ -163,8 +173,7 @@ class GoogleBenchmark(Benchmark):
         times = [b.real_time for b in self.runs]
         # Slight kludge to extract the UserCounters for each benchmark
         counters = self.runs[0].counters
-        super().__init__(name, unit, less_is_better, values, time_unit, times,
-                         counters)
+        super().__init__(name, unit, less_is_better, values, time_unit, times, counters)
 
     def __repr__(self):
         return f"GoogleBenchmark[name={self.names},runs={self.runs}]"

--- a/dev/archery/archery/benchmark/google.py
+++ b/dev/archery/archery/benchmark/google.py
@@ -173,6 +173,6 @@ class GoogleBenchmark(Benchmark):
         def group_key(x):
             return x.name
 
-        benchmarks = map(lambda x: GoogleBenchmarkObservation(**x), payload)
+        benchmarks = (GoogleBenchmarkObservation(**x) for x in payload)
         groups = groupby(sorted(benchmarks, key=group_key), group_key)
         return [cls(k, list(bs)) for k, bs in groups]

--- a/dev/archery/archery/benchmark/jmh.py
+++ b/dev/archery/archery/benchmark/jmh.py
@@ -33,7 +33,7 @@ def partition(pred, iterable):
 
 
 class JavaMicrobenchmarkHarnessCommand(Command):
-    """ Run a Java Micro Benchmark Harness
+    """Run a Java Micro Benchmark Harness
 
     This assumes the binary supports the standard command line options,
     notably `-Dbenchmark_filter`
@@ -60,8 +60,7 @@ class JavaMicrobenchmarkHarnessCommand(Command):
         argv = []
         if self.benchmark_filter:
             argv.append(f"-Dbenchmark.filter={self.benchmark_filter}")
-        result = self.build.list(
-            *argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        result = self.build.list(*argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
         lists = []
         benchmarks = False
@@ -78,24 +77,30 @@ class JavaMicrobenchmarkHarnessCommand(Command):
 
     def results(self, repetitions):
         with NamedTemporaryFile(suffix=".json") as out:
-            argv = [f"-Dbenchmark.runs={repetitions}",
-                    f"-Dbenchmark.resultfile={out.name}",
-                    "-Dbenchmark.resultformat=json"]
+            argv = [
+                f"-Dbenchmark.runs={repetitions}",
+                f"-Dbenchmark.resultfile={out.name}",
+                "-Dbenchmark.resultformat=json",
+            ]
             if self.benchmark_filter:
-                argv.append(
-                    f"-Dbenchmark.filter={self.benchmark_filter}"
-                )
+                argv.append(f"-Dbenchmark.filter={self.benchmark_filter}")
 
             self.build.benchmark(*argv, check=True)
             return json.load(out)
 
 
 class JavaMicrobenchmarkHarnessObservation:
-    """ Represents one run of a single Java Microbenchmark Harness
-    """
+    """Represents one run of a single Java Microbenchmark Harness"""
 
-    def __init__(self, benchmark, primaryMetric,
-                 forks, warmupIterations, measurementIterations, **counters):
+    def __init__(
+        self,
+        benchmark,
+        primaryMetric,
+        forks,
+        warmupIterations,
+        measurementIterations,
+        **counters,
+    ):
         self.name = benchmark
         self.primaryMetric = primaryMetric
         self.score = primaryMetric["score"]
@@ -110,7 +115,7 @@ class JavaMicrobenchmarkHarnessObservation:
             "warmupTime": counters["warmupTime"],
             "measurements": measurementIterations,
             "measurementTime": counters["measurementTime"],
-            "jvmArgs": counters["jvmArgs"]
+            "jvmArgs": counters["jvmArgs"],
         }
         self.reciprocal_value = bool(self.score_unit.endswith("/op"))
         if self.score_unit.startswith("ops/"):
@@ -124,7 +129,7 @@ class JavaMicrobenchmarkHarnessObservation:
 
     @property
     def value(self):
-        """ Return the benchmark value."""
+        """Return the benchmark value."""
         val = 1 / self.score if self.reciprocal_value else self.score
         return val * self.normalizeFactor
 
@@ -156,10 +161,10 @@ class JavaMicrobenchmarkHarnessObservation:
 
 
 class JavaMicrobenchmarkHarness(Benchmark):
-    """ A set of JavaMicrobenchmarkHarnessObservations. """
+    """A set of JavaMicrobenchmarkHarnessObservations."""
 
     def __init__(self, name, runs):
-        """ Initialize a JavaMicrobenchmarkHarness.
+        """Initialize a JavaMicrobenchmarkHarness.
 
         Parameters
         ----------
@@ -181,8 +186,7 @@ class JavaMicrobenchmarkHarness(Benchmark):
         times = []
         # Slight kludge to extract the UserCounters for each benchmark
         counters = self.runs[0].counters
-        super().__init__(name, unit, less_is_better, values, time_unit, times,
-                         counters)
+        super().__init__(name, unit, less_is_better, values, time_unit, times, counters)
 
     def __repr__(self):
         return f"JavaMicrobenchmark[name={self.name},runs={self.runs}]"

--- a/dev/archery/archery/benchmark/jmh.py
+++ b/dev/archery/archery/benchmark/jmh.py
@@ -111,11 +111,10 @@ class JavaMicrobenchmarkHarnessObservation:
             "measurementTime": counters["measurementTime"],
             "jvmArgs": counters["jvmArgs"]
         }
-        self.reciprocal_value = True if self.score_unit.endswith(
-            "/op") else False
+        self.reciprocal_value = bool(self.score_unit.endswith("/op"))
         if self.score_unit.startswith("ops/"):
             idx = self.score_unit.find("/")
-            self.normalizePerSec(self.score_unit[idx+1:])
+            self.normalizePerSec(self.score_unit[(idx + 1) :])
         elif self.score_unit.endswith("/op"):
             idx = self.score_unit.find("/")
             self.normalizePerSec(self.score_unit[:idx])
@@ -195,7 +194,6 @@ class JavaMicrobenchmarkHarness(Benchmark):
         def group_key(x):
             return x.name
 
-        benchmarks = map(
-            lambda x: JavaMicrobenchmarkHarnessObservation(**x), payload)
+        benchmarks = (JavaMicrobenchmarkHarnessObservation(**x) for x in payload)
         groups = groupby(sorted(benchmarks, key=group_key), group_key)
         return [cls(k, list(bs)) for k, bs in groups]

--- a/dev/archery/archery/benchmark/jmh.py
+++ b/dev/archery/archery/benchmark/jmh.py
@@ -14,15 +14,16 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
-from itertools import filterfalse, groupby, tee
 import json
 import subprocess
+from itertools import filterfalse, groupby, tee
 from tempfile import NamedTemporaryFile
 
-from .core import Benchmark
 from ..utils.command import Command
 from ..utils.maven import Maven
+from .core import Benchmark
 
 
 def partition(pred, iterable):
@@ -58,7 +59,7 @@ class JavaMicrobenchmarkHarnessCommand(Command):
     def list_benchmarks(self):
         argv = []
         if self.benchmark_filter:
-            argv.append("-Dbenchmark.filter={}".format(self.benchmark_filter))
+            argv.append(f"-Dbenchmark.filter={self.benchmark_filter}")
         result = self.build.list(
             *argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
@@ -77,12 +78,12 @@ class JavaMicrobenchmarkHarnessCommand(Command):
 
     def results(self, repetitions):
         with NamedTemporaryFile(suffix=".json") as out:
-            argv = ["-Dbenchmark.runs={}".format(repetitions),
-                    "-Dbenchmark.resultfile={}".format(out.name),
+            argv = [f"-Dbenchmark.runs={repetitions}",
+                    f"-Dbenchmark.resultfile={out.name}",
                     "-Dbenchmark.resultformat=json"]
             if self.benchmark_filter:
                 argv.append(
-                    "-Dbenchmark.filter={}".format(self.benchmark_filter)
+                    f"-Dbenchmark.filter={self.benchmark_filter}"
                 )
 
             self.build.benchmark(*argv, check=True)
@@ -145,9 +146,7 @@ class JavaMicrobenchmarkHarnessObservation:
 
     @property
     def unit(self):
-        if self.score_unit.startswith("ops/"):
-            return "items_per_second"
-        elif self.score_unit.endswith("/op"):
+        if self.score_unit.startswith("ops/") or self.score_unit.endswith("/op"):
             return "items_per_second"
         else:
             return "?"
@@ -186,8 +185,7 @@ class JavaMicrobenchmarkHarness(Benchmark):
                          counters)
 
     def __repr__(self):
-        return "JavaMicrobenchmark[name={},runs={}]".format(
-            self.name, self.runs)
+        return f"JavaMicrobenchmark[name={self.name},runs={self.runs}]"
 
     @classmethod
     def from_json(cls, payload):

--- a/dev/archery/archery/benchmark/runner.py
+++ b/dev/archery/archery/benchmark/runner.py
@@ -43,8 +43,13 @@ DEFAULT_REPETITIONS = 1
 
 
 class BenchmarkRunner:
-    def __init__(self, suite_filter=None, benchmark_filter=None,
-                 repetitions=DEFAULT_REPETITIONS, repetition_min_time=None):
+    def __init__(
+        self,
+        suite_filter=None,
+        benchmark_filter=None,
+        repetitions=DEFAULT_REPETITIONS,
+        repetition_min_time=None,
+    ):
         self.suite_filter = suite_filter
         self.benchmark_filter = benchmark_filter
         self.repetitions = repetitions
@@ -56,12 +61,11 @@ class BenchmarkRunner:
 
     @staticmethod
     def from_rev_or_path(src, root, rev_or_path, cmake_conf, **kwargs):
-        raise NotImplementedError(
-            "BenchmarkRunner must implement from_rev_or_path")
+        raise NotImplementedError("BenchmarkRunner must implement from_rev_or_path")
 
 
 class StaticBenchmarkRunner(BenchmarkRunner):
-    """ Run suites from a (static) set of suites. """
+    """Run suites from a (static) set of suites."""
 
     def __init__(self, suites, **kwargs):
         self._suites = suites
@@ -94,6 +98,7 @@ class StaticBenchmarkRunner(BenchmarkRunner):
     def from_json(path_or_str, **kwargs):
         # .codec imported here to break recursive imports
         from .codec import BenchmarkRunnerCodec
+
         if os.path.isfile(path_or_str):
             with open(path_or_str) as f:
                 loaded = json.load(f)
@@ -106,19 +111,21 @@ class StaticBenchmarkRunner(BenchmarkRunner):
 
 
 class CppBenchmarkRunner(BenchmarkRunner):
-    """ Run suites from a CMakeBuild. """
+    """Run suites from a CMakeBuild."""
 
     def __init__(self, build, benchmark_extras, **kwargs):
-        """ Initialize a CppBenchmarkRunner. """
+        """Initialize a CppBenchmarkRunner."""
         self.build = build
         self.benchmark_extras = benchmark_extras
         super().__init__(**kwargs)
 
     @staticmethod
     def default_configuration(**kwargs):
-        """ Returns the default benchmark configuration. """
+        """Returns the default benchmark configuration."""
         return CppConfiguration(
-            build_type="release", with_tests=False, with_benchmarks=True,
+            build_type="release",
+            with_tests=False,
+            with_benchmarks=True,
             with_compute=True,
             with_csv=True,
             with_dataset=True,
@@ -133,11 +140,12 @@ class CppBenchmarkRunner(BenchmarkRunner):
             with_snappy=True,
             with_zlib=True,
             with_zstd=True,
-            **kwargs)
+            **kwargs,
+        )
 
     @property
     def suites_binaries(self):
-        """ Returns a list of benchmark binaries for this build. """
+        """Returns a list of benchmark binaries for this build."""
         # Ensure build is up-to-date to run benchmarks
         self.build()
         # Not the best method, but works for now
@@ -145,9 +153,10 @@ class CppBenchmarkRunner(BenchmarkRunner):
         return {os.path.basename(b): b for b in glob.glob(glob_expr)}
 
     def suite(self, name, suite_bin):
-        """ Returns the resulting benchmarks for a given suite. """
-        suite_cmd = GoogleBenchmarkCommand(suite_bin, self.benchmark_filter,
-                                           self.benchmark_extras)
+        """Returns the resulting benchmarks for a given suite."""
+        suite_cmd = GoogleBenchmarkCommand(
+            suite_bin, self.benchmark_filter, self.benchmark_extras
+        )
 
         # Ensure there will be data
         benchmark_names = suite_cmd.list_benchmarks()
@@ -155,8 +164,8 @@ class CppBenchmarkRunner(BenchmarkRunner):
             return None
 
         results = suite_cmd.results(
-            repetitions=self.repetitions,
-            repetition_min_time=self.repetition_min_time)
+            repetitions=self.repetitions, repetition_min_time=self.repetition_min_time
+        )
         benchmarks = GoogleBenchmark.from_json(results.get("benchmarks"))
         return BenchmarkSuite(name, benchmarks)
 
@@ -169,7 +178,7 @@ class CppBenchmarkRunner(BenchmarkRunner):
 
     @property
     def suites(self):
-        """ Returns all suite for a runner. """
+        """Returns all suite for a runner."""
         suite_matcher = regex_filter(self.suite_filter)
 
         suite_found = False
@@ -184,8 +193,7 @@ class CppBenchmarkRunner(BenchmarkRunner):
 
             # Filter may exclude all benchmarks
             if not suite:
-                logger.debug(f"Suite {suite_name} executed but no results"
-                             )
+                logger.debug(f"Suite {suite_name} executed but no results")
                 continue
 
             suite_found = True
@@ -196,7 +204,7 @@ class CppBenchmarkRunner(BenchmarkRunner):
 
     @staticmethod
     def from_rev_or_path(src, root, rev_or_path, cmake_conf, **kwargs):
-        """ Returns a BenchmarkRunner from a path or a git revision.
+        """Returns a BenchmarkRunner from a path or a git revision.
 
         First, it checks if `rev_or_path` is a valid path (or string) of a json
         object that can deserialize to a BenchmarkRunner. If so, it initialize
@@ -212,7 +220,7 @@ class CppBenchmarkRunner(BenchmarkRunner):
         """
         build = None
         if StaticBenchmarkRunner.is_json_result(rev_or_path):
-            kwargs.pop('benchmark_extras', None)
+            kwargs.pop("benchmark_extras", None)
             return StaticBenchmarkRunner.from_json(rev_or_path, **kwargs)
         elif CMakeBuild.is_build_dir(rev_or_path):
             build = CMakeBuild.from_path(rev_or_path)
@@ -234,26 +242,25 @@ class CppBenchmarkRunner(BenchmarkRunner):
 
 
 class JavaBenchmarkRunner(BenchmarkRunner):
-    """ Run suites for Java. """
+    """Run suites for Java."""
 
     # default repetitions is 5 for Java microbenchmark harness
     def __init__(self, build, **kwargs):
-        """ Initialize a JavaBenchmarkRunner. """
+        """Initialize a JavaBenchmarkRunner."""
         self.build = build
         super().__init__(**kwargs)
 
     @staticmethod
     def default_configuration(**kwargs):
-        """ Returns the default benchmark configuration. """
+        """Returns the default benchmark configuration."""
         return JavaConfiguration(**kwargs)
 
     def suite(self, name):
-        """ Returns the resulting benchmarks for a given suite. """
+        """Returns the resulting benchmarks for a given suite."""
         # update .m2 directory, which installs target jars
         self.build.build()
 
-        suite_cmd = JavaMicrobenchmarkHarnessCommand(
-            self.build, self.benchmark_filter)
+        suite_cmd = JavaMicrobenchmarkHarnessCommand(self.build, self.benchmark_filter)
 
         # Ensure there will be data
         benchmark_names = suite_cmd.list_benchmarks()
@@ -267,7 +274,7 @@ class JavaBenchmarkRunner(BenchmarkRunner):
 
     @property
     def list_benchmarks(self):
-        """ Returns all suite names """
+        """Returns all suite names"""
         # Ensure build is up-to-date to run benchmarks
         self.build.build()
 
@@ -278,21 +285,20 @@ class JavaBenchmarkRunner(BenchmarkRunner):
 
     @property
     def suites(self):
-        """ Returns all suite for a runner. """
+        """Returns all suite for a runner."""
         suite_name = "JavaBenchmark"
         suite = self.suite(suite_name)
 
         # Filter may exclude all benchmarks
         if not suite:
-            logger.debug(f"Suite {suite_name} executed but no results"
-                         )
+            logger.debug(f"Suite {suite_name} executed but no results")
             return
 
         yield suite
 
     @staticmethod
     def from_rev_or_path(src, root, rev_or_path, maven_conf, **kwargs):
-        """ Returns a BenchmarkRunner from a path or a git revision.
+        """Returns a BenchmarkRunner from a path or a git revision.
 
         First, it checks if `rev_or_path` is a valid path (or string) of a json
         object that can deserialize to a BenchmarkRunner. If so, it initialize

--- a/dev/archery/archery/benchmark/runner.py
+++ b/dev/archery/archery/benchmark/runner.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
 import contextlib
 import glob
@@ -21,14 +22,14 @@ import json
 import os
 import re
 
-from .core import BenchmarkSuite
-from .google import GoogleBenchmarkCommand, GoogleBenchmark
-from .jmh import JavaMicrobenchmarkHarnessCommand, JavaMicrobenchmarkHarness
 from ..lang.cpp import CppCMakeDefinition, CppConfiguration
-from ..lang.java import JavaMavenDefinition, JavaConfiguration
+from ..lang.java import JavaConfiguration, JavaMavenDefinition
 from ..utils.cmake import CMakeBuild
-from ..utils.maven import MavenBuild
 from ..utils.logger import logger
+from ..utils.maven import MavenBuild
+from .core import BenchmarkSuite
+from .google import GoogleBenchmark, GoogleBenchmarkCommand
+from .jmh import JavaMicrobenchmarkHarness, JavaMicrobenchmarkHarnessCommand
 
 
 def regex_filter(re_expr):
@@ -70,7 +71,7 @@ class StaticBenchmarkRunner(BenchmarkRunner):
     def list_benchmarks(self):
         for suite in self._suites:
             for benchmark in suite.benchmarks:
-                yield "{}.{}".format(suite.name, benchmark.name)
+                yield f"{suite.name}.{benchmark.name}"
 
     @property
     def suites(self):
@@ -101,7 +102,7 @@ class StaticBenchmarkRunner(BenchmarkRunner):
         return BenchmarkRunnerCodec.decode(loaded, **kwargs)
 
     def __repr__(self):
-        return "BenchmarkRunner[suites={}]".format(list(self.suites))
+        return f"BenchmarkRunner[suites={list(self.suites)}]"
 
 
 class CppBenchmarkRunner(BenchmarkRunner):
@@ -164,7 +165,7 @@ class CppBenchmarkRunner(BenchmarkRunner):
         for suite_name, suite_bin in self.suites_binaries.items():
             suite_cmd = GoogleBenchmarkCommand(suite_bin)
             for benchmark_name in suite_cmd.list_benchmarks():
-                yield "{}.{}".format(suite_name, benchmark_name)
+                yield f"{suite_name}.{benchmark_name}"
 
     @property
     def suites(self):
@@ -175,7 +176,7 @@ class CppBenchmarkRunner(BenchmarkRunner):
         suite_and_binaries = self.suites_binaries
         for suite_name in suite_and_binaries:
             if not suite_matcher(suite_name):
-                logger.debug("Ignoring suite {}".format(suite_name))
+                logger.debug(f"Ignoring suite {suite_name}")
                 continue
 
             suite_bin = suite_and_binaries[suite_name]
@@ -183,8 +184,8 @@ class CppBenchmarkRunner(BenchmarkRunner):
 
             # Filter may exclude all benchmarks
             if not suite:
-                logger.debug("Suite {} executed but no results"
-                             .format(suite_name))
+                logger.debug(f"Suite {suite_name} executed but no results"
+                             )
                 continue
 
             suite_found = True
@@ -273,7 +274,7 @@ class JavaBenchmarkRunner(BenchmarkRunner):
         suite_cmd = JavaMicrobenchmarkHarnessCommand(self.build)
         benchmark_names = suite_cmd.list_benchmarks()
         for benchmark_name in benchmark_names:
-            yield "{}".format(benchmark_name)
+            yield f"{benchmark_name}"
 
     @property
     def suites(self):
@@ -283,8 +284,8 @@ class JavaBenchmarkRunner(BenchmarkRunner):
 
         # Filter may exclude all benchmarks
         if not suite:
-            logger.debug("Suite {} executed but no results"
-                         .format(suite_name))
+            logger.debug(f"Suite {suite_name} executed but no results"
+                         )
             return
 
         yield suite

--- a/dev/archery/archery/benchmark/runner.py
+++ b/dev/archery/archery/benchmark/runner.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+import contextlib
 import glob
 import json
 import os
@@ -83,10 +84,8 @@ class StaticBenchmarkRunner(BenchmarkRunner):
     @classmethod
     def is_json_result(cls, path_or_str):
         builder = None
-        try:
+        with contextlib.suppress(BaseException):
             builder = cls.from_json(path_or_str)
-        except BaseException:
-            pass
 
         return builder is not None
 

--- a/dev/archery/archery/cli.py
+++ b/dev/archery/archery/cli.py
@@ -67,7 +67,8 @@ def archery(ctx, debug, pdb, quiet):
     ctx.obj['debug'] = debug
 
     if pdb:
-        import pdb
+        import pdb  # noqa: T100
+
         sys.excepthook = lambda t, v, e: pdb.pm()
 
 

--- a/dev/archery/archery/cli.py
+++ b/dev/archery/archery/cli.py
@@ -46,16 +46,32 @@ BOOL = ArrowBool()
 
 
 @click.group(context_settings={"help_option_names": ["-h", "--help"]})
-@click.option("--debug", type=BOOL, is_flag=True, default=False,
-              envvar='ARCHERY_DEBUG',
-              help="Increase logging with debugging output.")
-@click.option("--pdb", type=BOOL, is_flag=True, default=False,
-              help="Invoke pdb on uncaught exception.")
-@click.option("-q", "--quiet", type=BOOL, is_flag=True, default=False,
-              help="Silence executed commands.")
+@click.option(
+    "--debug",
+    type=BOOL,
+    is_flag=True,
+    default=False,
+    envvar="ARCHERY_DEBUG",
+    help="Increase logging with debugging output.",
+)
+@click.option(
+    "--pdb",
+    type=BOOL,
+    is_flag=True,
+    default=False,
+    help="Invoke pdb on uncaught exception.",
+)
+@click.option(
+    "-q",
+    "--quiet",
+    type=BOOL,
+    is_flag=True,
+    default=False,
+    help="Silence executed commands.",
+)
 @click.pass_context
 def archery(ctx, debug, pdb, quiet):
-    """ Apache Arrow developer utilities.
+    """Apache Arrow developer utilities.
 
     See sub-commands help with `archery <cmd> --help`.
 
@@ -67,7 +83,7 @@ def archery(ctx, debug, pdb, quiet):
     if debug:
         logger.setLevel(logging.DEBUG)
 
-    ctx.obj['debug'] = debug
+    ctx.obj["debug"] = debug
 
     if pdb:
         import pdb  # noqa: T100
@@ -77,14 +93,13 @@ def archery(ctx, debug, pdb, quiet):
 
 build_dir_type = click.Path(dir_okay=True, file_okay=False, resolve_path=True)
 # Supported build types
-build_type = click.Choice(["debug", "relwithdebinfo", "release"],
-                          case_sensitive=False)
+build_type = click.Choice(["debug", "relwithdebinfo", "release"], case_sensitive=False)
 # Supported warn levels
-warn_level_type = click.Choice(["everything", "checkin", "production"],
-                               case_sensitive=False)
+warn_level_type = click.Choice(
+    ["everything", "checkin", "production"], case_sensitive=False
+)
 
-simd_level = click.Choice(["NONE", "SSE4_2", "AVX2", "AVX512"],
-                          case_sensitive=True)
+simd_level = click.Choice(["NONE", "SSE4_2", "AVX2", "AVX512"], case_sensitive=True)
 
 
 def cpp_toolchain_options(cmd):
@@ -92,17 +107,22 @@ def cpp_toolchain_options(cmd):
         click.option("--cc", metavar="<compiler>", help="C compiler."),
         click.option("--cxx", metavar="<compiler>", help="C++ compiler."),
         click.option("--cxx-flags", help="C++ compiler flags."),
-        click.option("--cpp-package-prefix",
-                     help=("Value to pass for ARROW_PACKAGE_PREFIX and "
-                           "use ARROW_DEPENDENCY_SOURCE=SYSTEM"))
+        click.option(
+            "--cpp-package-prefix",
+            help=(
+                "Value to pass for ARROW_PACKAGE_PREFIX and "
+                "use ARROW_DEPENDENCY_SOURCE=SYSTEM"
+            ),
+        ),
     ]
     return _apply_options(cmd, options)
 
 
 def java_toolchain_options(cmd):
     options = [
-        click.option("--java-home", metavar="<java_home>",
-                     help="Path to Java Developers Kit."),
+        click.option(
+            "--java-home", metavar="<java_home>", help="Path to Java Developers Kit."
+        ),
         click.option("--java-options", help="java compiler options."),
     ]
     return _apply_options(cmd, options)
@@ -115,109 +135,189 @@ def _apply_options(cmd, options):
 
 
 @archery.command(short_help="Initialize an Arrow C++ build")
-@click.option("--src", metavar="<arrow_src>", default=None,
-              callback=validate_arrow_sources,
-              help="Specify Arrow source directory")
+@click.option(
+    "--src",
+    metavar="<arrow_src>",
+    default=None,
+    callback=validate_arrow_sources,
+    help="Specify Arrow source directory",
+)
 # toolchain
 @cpp_toolchain_options
-@click.option("--build-type", default=None, type=build_type,
-              help="CMake's CMAKE_BUILD_TYPE")
-@click.option("--build-static", default=True, type=BOOL,
-              help="Build static libraries")
-@click.option("--build-shared", default=True, type=BOOL,
-              help="Build shared libraries")
-@click.option("--build-unity", default=True, type=BOOL,
-              help="Use CMAKE_UNITY_BUILD")
-@click.option("--warn-level", default="production", type=warn_level_type,
-              help="Controls compiler warnings -W(no-)error.")
-@click.option("--use-gold-linker", default=True, type=BOOL,
-              help="Toggles ARROW_USE_LD_GOLD option.")
-@click.option("--simd-level", default="DEFAULT", type=simd_level,
-              help="Toggles ARROW_SIMD_LEVEL option.")
+@click.option(
+    "--build-type", default=None, type=build_type, help="CMake's CMAKE_BUILD_TYPE"
+)
+@click.option("--build-static", default=True, type=BOOL, help="Build static libraries")
+@click.option("--build-shared", default=True, type=BOOL, help="Build shared libraries")
+@click.option("--build-unity", default=True, type=BOOL, help="Use CMAKE_UNITY_BUILD")
+@click.option(
+    "--warn-level",
+    default="production",
+    type=warn_level_type,
+    help="Controls compiler warnings -W(no-)error.",
+)
+@click.option(
+    "--use-gold-linker",
+    default=True,
+    type=BOOL,
+    help="Toggles ARROW_USE_LD_GOLD option.",
+)
+@click.option(
+    "--simd-level",
+    default="DEFAULT",
+    type=simd_level,
+    help="Toggles ARROW_SIMD_LEVEL option.",
+)
 # Tests and benchmarks
-@click.option("--with-tests", default=True, type=BOOL,
-              help="Build with tests.")
-@click.option("--with-benchmarks", default=None, type=BOOL,
-              help="Build with benchmarks.")
-@click.option("--with-examples", default=None, type=BOOL,
-              help="Build with examples.")
-@click.option("--with-integration", default=None, type=BOOL,
-              help="Build with integration test executables.")
+@click.option("--with-tests", default=True, type=BOOL, help="Build with tests.")
+@click.option(
+    "--with-benchmarks", default=None, type=BOOL, help="Build with benchmarks."
+)
+@click.option("--with-examples", default=None, type=BOOL, help="Build with examples.")
+@click.option(
+    "--with-integration",
+    default=None,
+    type=BOOL,
+    help="Build with integration test executables.",
+)
 # Static checks
-@click.option("--use-asan", default=None, type=BOOL,
-              help="Toggle ARROW_USE_ASAN sanitizer.")
-@click.option("--use-tsan", default=None, type=BOOL,
-              help="Toggle ARROW_USE_TSAN sanitizer.")
-@click.option("--use-ubsan", default=None, type=BOOL,
-              help="Toggle ARROW_USE_UBSAN sanitizer.")
-@click.option("--with-fuzzing", default=None, type=BOOL,
-              help="Toggle ARROW_FUZZING.")
+@click.option(
+    "--use-asan", default=None, type=BOOL, help="Toggle ARROW_USE_ASAN sanitizer."
+)
+@click.option(
+    "--use-tsan", default=None, type=BOOL, help="Toggle ARROW_USE_TSAN sanitizer."
+)
+@click.option(
+    "--use-ubsan", default=None, type=BOOL, help="Toggle ARROW_USE_UBSAN sanitizer."
+)
+@click.option("--with-fuzzing", default=None, type=BOOL, help="Toggle ARROW_FUZZING.")
 # Components
-@click.option("--with-compute", default=None, type=BOOL,
-              help="Build the Arrow compute module.")
-@click.option("--with-csv", default=None, type=BOOL,
-              help="Build the Arrow CSV parser module.")
-@click.option("--with-cuda", default=None, type=BOOL,
-              help="Build the Arrow CUDA extensions.")
-@click.option("--with-dataset", default=None, type=BOOL,
-              help="Build the Arrow dataset module.")
-@click.option("--with-filesystem", default=None, type=BOOL,
-              help="Build the Arrow filesystem layer.")
-@click.option("--with-flight", default=None, type=BOOL,
-              help="Build with Flight rpc support.")
-@click.option("--with-gandiva", default=None, type=BOOL,
-              help="Build with Gandiva expression compiler support.")
-@click.option("--with-gcs", default=None, type=BOOL,
-              help="Build Arrow with Google Cloud Storage (GCS) support.")
-@click.option("--with-hdfs", default=None, type=BOOL,
-              help="Build the Arrow HDFS bridge.")
-@click.option("--with-hiveserver2", default=None, type=BOOL,
-              help="Build the HiveServer2 client and arrow adapter.")
-@click.option("--with-ipc", default=None, type=BOOL,
-              help="Build the Arrow IPC extensions.")
-@click.option("--with-json", default=None, type=BOOL,
-              help="Build the Arrow JSON parser module.")
-@click.option("--with-mimalloc", default=None, type=BOOL,
-              help="Build the Arrow mimalloc based allocator.")
-@click.option("--with-parquet", default=None, type=BOOL,
-              help="Build with Parquet file support.")
-@click.option("--with-python", default=None, type=BOOL,
-              help="Build the Arrow CPython extensions.")
-@click.option("--with-r", default=None, type=BOOL,
-              help="Build the Arrow R extensions. This is not a CMake option, "
-              "it will toggle required options")
-@click.option("--with-s3", default=None, type=BOOL,
-              help="Build Arrow with S3 support.")
+@click.option(
+    "--with-compute", default=None, type=BOOL, help="Build the Arrow compute module."
+)
+@click.option(
+    "--with-csv", default=None, type=BOOL, help="Build the Arrow CSV parser module."
+)
+@click.option(
+    "--with-cuda", default=None, type=BOOL, help="Build the Arrow CUDA extensions."
+)
+@click.option(
+    "--with-dataset", default=None, type=BOOL, help="Build the Arrow dataset module."
+)
+@click.option(
+    "--with-filesystem",
+    default=None,
+    type=BOOL,
+    help="Build the Arrow filesystem layer.",
+)
+@click.option(
+    "--with-flight", default=None, type=BOOL, help="Build with Flight rpc support."
+)
+@click.option(
+    "--with-gandiva",
+    default=None,
+    type=BOOL,
+    help="Build with Gandiva expression compiler support.",
+)
+@click.option(
+    "--with-gcs",
+    default=None,
+    type=BOOL,
+    help="Build Arrow with Google Cloud Storage (GCS) support.",
+)
+@click.option(
+    "--with-hdfs", default=None, type=BOOL, help="Build the Arrow HDFS bridge."
+)
+@click.option(
+    "--with-hiveserver2",
+    default=None,
+    type=BOOL,
+    help="Build the HiveServer2 client and arrow adapter.",
+)
+@click.option(
+    "--with-ipc", default=None, type=BOOL, help="Build the Arrow IPC extensions."
+)
+@click.option(
+    "--with-json", default=None, type=BOOL, help="Build the Arrow JSON parser module."
+)
+@click.option(
+    "--with-mimalloc",
+    default=None,
+    type=BOOL,
+    help="Build the Arrow mimalloc based allocator.",
+)
+@click.option(
+    "--with-parquet", default=None, type=BOOL, help="Build with Parquet file support."
+)
+@click.option(
+    "--with-python", default=None, type=BOOL, help="Build the Arrow CPython extensions."
+)
+@click.option(
+    "--with-r",
+    default=None,
+    type=BOOL,
+    help="Build the Arrow R extensions. This is not a CMake option, "
+    "it will toggle required options",
+)
+@click.option("--with-s3", default=None, type=BOOL, help="Build Arrow with S3 support.")
 # Compressions
-@click.option("--with-brotli", default=None, type=BOOL,
-              help="Build Arrow with brotli compression.")
-@click.option("--with-bz2", default=None, type=BOOL,
-              help="Build Arrow with bz2 compression.")
-@click.option("--with-lz4", default=None, type=BOOL,
-              help="Build Arrow with lz4 compression.")
-@click.option("--with-snappy", default=None, type=BOOL,
-              help="Build Arrow with snappy compression.")
-@click.option("--with-zlib", default=None, type=BOOL,
-              help="Build Arrow with zlib compression.")
-@click.option("--with-zstd", default=None, type=BOOL,
-              help="Build Arrow with zstd compression.")
+@click.option(
+    "--with-brotli",
+    default=None,
+    type=BOOL,
+    help="Build Arrow with brotli compression.",
+)
+@click.option(
+    "--with-bz2", default=None, type=BOOL, help="Build Arrow with bz2 compression."
+)
+@click.option(
+    "--with-lz4", default=None, type=BOOL, help="Build Arrow with lz4 compression."
+)
+@click.option(
+    "--with-snappy",
+    default=None,
+    type=BOOL,
+    help="Build Arrow with snappy compression.",
+)
+@click.option(
+    "--with-zlib", default=None, type=BOOL, help="Build Arrow with zlib compression."
+)
+@click.option(
+    "--with-zstd", default=None, type=BOOL, help="Build Arrow with zstd compression."
+)
 # CMake extra feature
-@click.option("--cmake-extras", type=str, multiple=True,
-              help="Extra flags/options to pass to cmake invocation. "
-              "Can be stacked")
-@click.option("--install-prefix", type=str,
-              help="Destination directory where files are installed. Expand to"
-              "CMAKE_INSTALL_PREFIX. Defaults to to $CONDA_PREFIX if the"
-              "variable exists.")
+@click.option(
+    "--cmake-extras",
+    type=str,
+    multiple=True,
+    help="Extra flags/options to pass to cmake invocation. Can be stacked",
+)
+@click.option(
+    "--install-prefix",
+    type=str,
+    help="Destination directory where files are installed. Expand to"
+    "CMAKE_INSTALL_PREFIX. Defaults to to $CONDA_PREFIX if the"
+    "variable exists.",
+)
 # misc
-@click.option("-f", "--force", type=BOOL, is_flag=True, default=False,
-              help="Delete existing build directory if found.")
-@click.option("--targets", type=str, multiple=True,
-              help="Generator targets to run. Can be stacked.")
+@click.option(
+    "-f",
+    "--force",
+    type=BOOL,
+    is_flag=True,
+    default=False,
+    help="Delete existing build directory if found.",
+)
+@click.option(
+    "--targets",
+    type=str,
+    multiple=True,
+    help="Generator targets to run. Can be stacked.",
+)
 @click.argument("build_dir", type=build_dir_type)
 @click.pass_context
 def build(ctx, src, build_dir, force, targets, **kwargs):
-    """ Initialize a C++ build directory.
+    """Initialize a C++ build directory.
 
     The build command creates a directory initialized with Arrow's cpp source
     cmake and configuration. It can also optionally invoke the generator to
@@ -249,57 +349,69 @@ def build(ctx, src, build_dir, force, targets, **kwargs):
         build.run(target)
 
 
-LintCheck = namedtuple('LintCheck', ('option_name', 'help'))
+LintCheck = namedtuple("LintCheck", ("option_name", "help"))
 
 lint_checks = [
-    LintCheck('clang-format', "Format C++ files with clang-format."),
-    LintCheck('clang-tidy', "Lint C++ files with clang-tidy."),
-    LintCheck('cpplint', "Lint C++ files with cpplint."),
-    LintCheck('iwyu', "Lint changed C++ files with Include-What-You-Use."),
-    LintCheck('python',
-              "Format and lint Python files with autopep8 and flake8."),
-    LintCheck('numpydoc', "Lint Python files with numpydoc."),
-    LintCheck('cmake-format', "Format CMake files with cmake-format.py."),
-    LintCheck('rat',
-              "Check all sources files for license texts via Apache RAT."),
-    LintCheck('r', "Lint R files."),
-    LintCheck('docker', "Lint Dockerfiles with hadolint."),
-    LintCheck('docs', "Lint docs with sphinx-lint."),
+    LintCheck("clang-format", "Format C++ files with clang-format."),
+    LintCheck("clang-tidy", "Lint C++ files with clang-tidy."),
+    LintCheck("cpplint", "Lint C++ files with cpplint."),
+    LintCheck("iwyu", "Lint changed C++ files with Include-What-You-Use."),
+    LintCheck("python", "Format and lint Python files with autopep8 and flake8."),
+    LintCheck("numpydoc", "Lint Python files with numpydoc."),
+    LintCheck("cmake-format", "Format CMake files with cmake-format.py."),
+    LintCheck("rat", "Check all sources files for license texts via Apache RAT."),
+    LintCheck("r", "Lint R files."),
+    LintCheck("docker", "Lint Dockerfiles with hadolint."),
+    LintCheck("docs", "Lint docs with sphinx-lint."),
 ]
 
 
 def decorate_lint_command(cmd):
-    """Decorate the lint() command function to add individual per-check options.
-    """
+    """Decorate the lint() command function to add individual per-check options."""
     for check in lint_checks:
-        option = click.option(f"--{check.option_name}/--no-{check.option_name}",
-                              default=None, help=check.help)
+        option = click.option(
+            f"--{check.option_name}/--no-{check.option_name}",
+            default=None,
+            help=check.help,
+        )
         cmd = option(cmd)
     return cmd
 
 
 @archery.command(short_help="Check Arrow source tree for errors")
-@click.option("--src", metavar="<arrow_src>", default=None,
-              callback=validate_arrow_sources,
-              help="Specify Arrow source directory")
-@click.option("--fix", is_flag=True, type=BOOL, default=False,
-              help="Toggle fixing the lint errors if the linter supports it.")
-@click.option("--iwyu_all", is_flag=True, type=BOOL, default=False,
-              help="Run IWYU on all C++ files if enabled")
-@click.option("-a", "--all", is_flag=True, default=False,
-              help="Enable all checks.")
+@click.option(
+    "--src",
+    metavar="<arrow_src>",
+    default=None,
+    callback=validate_arrow_sources,
+    help="Specify Arrow source directory",
+)
+@click.option(
+    "--fix",
+    is_flag=True,
+    type=BOOL,
+    default=False,
+    help="Toggle fixing the lint errors if the linter supports it.",
+)
+@click.option(
+    "--iwyu_all",
+    is_flag=True,
+    type=BOOL,
+    default=False,
+    help="Run IWYU on all C++ files if enabled",
+)
+@click.option("-a", "--all", is_flag=True, default=False, help="Enable all checks.")
 @click.argument("path", required=False)
 @decorate_lint_command
 @click.pass_context
 def lint(ctx, src, fix, iwyu_all, path, **checks):
-    if checks.pop('all'):
+    if checks.pop("all"):
         # "--all" is given => enable all non-selected checks
         for k, v in checks.items():
             if v is None:
                 checks[k] = True
     if not any(checks.values()):
-        raise click.UsageError(
-            "Need to enable at least one lint check (try --help)")
+        raise click.UsageError("Need to enable at least one lint check (try --help)")
     try:
         linter(src, fix, iwyu_all=iwyu_all, path=path, **checks)
     except LintValidationException:
@@ -309,19 +421,31 @@ def lint(ctx, src, fix, iwyu_all, path, **checks):
 def _flatten_numpydoc_rules(rules):
     flattened = []
     for rule in rules:
-        flattened.extend(filter(None, rule.split(',')))
+        flattened.extend(filter(None, rule.split(",")))
     return flattened
 
 
 @archery.command(short_help="Lint python docstring with NumpyDoc")
-@click.argument('symbols', nargs=-1)
-@click.option("--src", metavar="<arrow_src>", default=None,
-              callback=validate_arrow_sources,
-              help="Specify Arrow source directory")
-@click.option("--allow-rule", "-a", multiple=True,
-              help="Allow only these rules (can be comma-separated)")
-@click.option("--disallow-rule", "-d", multiple=True,
-              help="Disallow these rules (can be comma-separated)")
+@click.argument("symbols", nargs=-1)
+@click.option(
+    "--src",
+    metavar="<arrow_src>",
+    default=None,
+    callback=validate_arrow_sources,
+    help="Specify Arrow source directory",
+)
+@click.option(
+    "--allow-rule",
+    "-a",
+    multiple=True,
+    help="Allow only these rules (can be comma-separated)",
+)
+@click.option(
+    "--disallow-rule",
+    "-d",
+    multiple=True,
+    help="Disallow these rules (can be comma-separated)",
+)
 def numpydoc(src, symbols, allow_rule, disallow_rule):
     """Pass list of modules or symbols as arguments to restrict the validation.
 
@@ -333,11 +457,13 @@ def numpydoc(src, symbols, allow_rule, disallow_rule):
     archery numpydoc pyarrow.csv pyarrow.json pyarrow.parquet
     archery numpydoc pyarrow.array
     """
-    disallow_rule = disallow_rule or {'GL01', 'SA01', 'EX01', 'ES01'}
+    disallow_rule = disallow_rule or {"GL01", "SA01", "EX01", "ES01"}
     try:
         results = python_numpydoc(
-            symbols, allow_rules=_flatten_numpydoc_rules(allow_rule),
-            disallow_rules=_flatten_numpydoc_rules(disallow_rule))
+            symbols,
+            allow_rules=_flatten_numpydoc_rules(allow_rule),
+            disallow_rules=_flatten_numpydoc_rules(disallow_rule),
+        )
         for result in results:
             result.ok()
     except LintValidationException:
@@ -347,7 +473,7 @@ def numpydoc(src, symbols, allow_rule, disallow_rule):
 @archery.group()
 @click.pass_context
 def benchmark(ctx):
-    """ Arrow benchmarking.
+    """Arrow benchmarking.
 
     Use the diff sub-command to benchmark revisions, and/or build directories.
     """
@@ -360,30 +486,66 @@ def benchmark_common_options(cmd):
         return value
 
     options = [
-        click.option("--src", metavar="<arrow_src>", show_default=True,
-                     default=None, callback=validate_arrow_sources,
-                     help="Specify Arrow source directory"),
-        click.option("--preserve", type=BOOL, default=False, show_default=True,
-                     is_flag=True,
-                     help="Preserve workspace for investigation."),
-        click.option("--output", metavar="<output>",
-                     type=click.File("w", encoding="utf8"), default=None,
-                     help="Capture output result into file."),
-        click.option("--language", metavar="<lang>", type=str, default="cpp",
-                     show_default=True, callback=check_language,
-                     help="Specify target language for the benchmark"),
-        click.option("--build-extras", type=str, multiple=True,
-                     help="Extra flags/options to pass to mvn build. "
-                     "Can be stacked. For language=java"),
-        click.option("--benchmark-extras", type=str, multiple=True,
-                     help="Extra flags/options to pass to mvn benchmark. "
-                     "Can be stacked. For language=java"),
-        click.option("--cmake-extras", type=str, multiple=True,
-                     help="Extra flags/options to pass to cmake invocation. "
-                     "Can be stacked. For language=cpp"),
-        click.option("--cpp-benchmark-extras", type=str, multiple=True,
-                     help="Extra flags/options to pass to C++ benchmark executables. "
-                     "Can be stacked. For language=cpp"),
+        click.option(
+            "--src",
+            metavar="<arrow_src>",
+            show_default=True,
+            default=None,
+            callback=validate_arrow_sources,
+            help="Specify Arrow source directory",
+        ),
+        click.option(
+            "--preserve",
+            type=BOOL,
+            default=False,
+            show_default=True,
+            is_flag=True,
+            help="Preserve workspace for investigation.",
+        ),
+        click.option(
+            "--output",
+            metavar="<output>",
+            type=click.File("w", encoding="utf8"),
+            default=None,
+            help="Capture output result into file.",
+        ),
+        click.option(
+            "--language",
+            metavar="<lang>",
+            type=str,
+            default="cpp",
+            show_default=True,
+            callback=check_language,
+            help="Specify target language for the benchmark",
+        ),
+        click.option(
+            "--build-extras",
+            type=str,
+            multiple=True,
+            help="Extra flags/options to pass to mvn build. "
+            "Can be stacked. For language=java",
+        ),
+        click.option(
+            "--benchmark-extras",
+            type=str,
+            multiple=True,
+            help="Extra flags/options to pass to mvn benchmark. "
+            "Can be stacked. For language=java",
+        ),
+        click.option(
+            "--cmake-extras",
+            type=str,
+            multiple=True,
+            help="Extra flags/options to pass to cmake invocation. "
+            "Can be stacked. For language=cpp",
+        ),
+        click.option(
+            "--cpp-benchmark-extras",
+            type=str,
+            multiple=True,
+            help="Extra flags/options to pass to C++ benchmark executables. "
+            "Can be stacked. For language=cpp",
+        ),
     ]
 
     cmd = java_toolchain_options(cmd)
@@ -393,71 +555,126 @@ def benchmark_common_options(cmd):
 
 def benchmark_filter_options(cmd):
     options = [
-        click.option("--suite-filter", metavar="<regex>", show_default=True,
-                     type=str, default=None,
-                     help="Regex filtering benchmark suites."),
-        click.option("--benchmark-filter", metavar="<regex>",
-                     show_default=True, type=str, default=None,
-                     help="Regex filtering benchmarks.")
+        click.option(
+            "--suite-filter",
+            metavar="<regex>",
+            show_default=True,
+            type=str,
+            default=None,
+            help="Regex filtering benchmark suites.",
+        ),
+        click.option(
+            "--benchmark-filter",
+            metavar="<regex>",
+            show_default=True,
+            type=str,
+            default=None,
+            help="Regex filtering benchmarks.",
+        ),
     ]
     return _apply_options(cmd, options)
 
 
 @benchmark.command(name="list", short_help="List benchmark suite")
-@click.argument("rev_or_path", metavar="[<rev_or_path>]",
-                default="WORKSPACE", required=False)
+@click.argument(
+    "rev_or_path", metavar="[<rev_or_path>]", default="WORKSPACE", required=False
+)
 @benchmark_common_options
 @click.pass_context
-def benchmark_list(ctx, rev_or_path, src, preserve, output, cmake_extras,
-                   java_home, java_options, build_extras, benchmark_extras,
-                   cpp_benchmark_extras, language, **kwargs):
-    """ List benchmark suite.
-    """
+def benchmark_list(
+    ctx,
+    rev_or_path,
+    src,
+    preserve,
+    output,
+    cmake_extras,
+    java_home,
+    java_options,
+    build_extras,
+    benchmark_extras,
+    cpp_benchmark_extras,
+    language,
+    **kwargs,
+):
+    """List benchmark suite."""
     with tmpdir(preserve=preserve) as root:
         logger.debug(f"Running benchmark {rev_or_path}")
 
         if language == "cpp":
             conf = CppBenchmarkRunner.default_configuration(
-                cmake_extras=cmake_extras, **kwargs)
+                cmake_extras=cmake_extras, **kwargs
+            )
 
             runner_base = CppBenchmarkRunner.from_rev_or_path(
-                src, root, rev_or_path, conf,
-                benchmark_extras=cpp_benchmark_extras)
+                src, root, rev_or_path, conf, benchmark_extras=cpp_benchmark_extras
+            )
 
         elif language == "java":
-            for key in ('cpp_package_prefix', 'cxx_flags', 'cxx', 'cc'):
+            for key in ("cpp_package_prefix", "cxx_flags", "cxx", "cc"):
                 del kwargs[key]
             conf = JavaBenchmarkRunner.default_configuration(
-                java_home=java_home, java_options=java_options,
-                build_extras=build_extras, benchmark_extras=benchmark_extras,
-                **kwargs)
+                java_home=java_home,
+                java_options=java_options,
+                build_extras=build_extras,
+                benchmark_extras=benchmark_extras,
+                **kwargs,
+            )
 
             runner_base = JavaBenchmarkRunner.from_rev_or_path(
-                src, root, rev_or_path, conf)
+                src, root, rev_or_path, conf
+            )
 
         for b in runner_base.list_benchmarks:
             click.echo(b, file=output or sys.stdout)
 
 
 @benchmark.command(name="run", short_help="Run benchmark suite")
-@click.argument("rev_or_path", metavar="[<rev_or_path>]",
-                default="WORKSPACE", required=False)
+@click.argument(
+    "rev_or_path", metavar="[<rev_or_path>]", default="WORKSPACE", required=False
+)
 @benchmark_common_options
 @benchmark_filter_options
-@click.option("--repetitions", type=int, default=-1,
-              help=("Number of repetitions of each benchmark. Increasing "
-                    "may improve result precision. "
-                    "[default: 1 for cpp, 5 for java]"))
-@click.option("--repetition-min-time", type=float, default=None,
-              help=("Minimum duration of each repetition in seconds. "
-                    "Currently only supported for language=cpp. "
-                    "[default: use runner-specific defaults]"))
+@click.option(
+    "--repetitions",
+    type=int,
+    default=-1,
+    help=(
+        "Number of repetitions of each benchmark. Increasing "
+        "may improve result precision. "
+        "[default: 1 for cpp, 5 for java]"
+    ),
+)
+@click.option(
+    "--repetition-min-time",
+    type=float,
+    default=None,
+    help=(
+        "Minimum duration of each repetition in seconds. "
+        "Currently only supported for language=cpp. "
+        "[default: use runner-specific defaults]"
+    ),
+)
 @click.pass_context
-def benchmark_run(ctx, rev_or_path, src, preserve, output, cmake_extras,
-                  java_home, java_options, build_extras, benchmark_extras,
-                  language, suite_filter, benchmark_filter, repetitions,
-                  repetition_min_time, cpp_benchmark_extras, **kwargs):
-    """ Run benchmark suite.
+def benchmark_run(
+    ctx,
+    rev_or_path,
+    src,
+    preserve,
+    output,
+    cmake_extras,
+    java_home,
+    java_options,
+    build_extras,
+    benchmark_extras,
+    language,
+    suite_filter,
+    benchmark_filter,
+    repetitions,
+    repetition_min_time,
+    cpp_benchmark_extras,
+    **kwargs,
+):
+    """Run benchmark suite.
 
     This command will run the benchmark suite for a single build. This is
     used to capture (and/or publish) the results.
@@ -498,28 +715,42 @@ def benchmark_run(ctx, rev_or_path, src, preserve, output, cmake_extras,
 
         if language == "cpp":
             conf = CppBenchmarkRunner.default_configuration(
-                cmake_extras=cmake_extras, **kwargs)
+                cmake_extras=cmake_extras, **kwargs
+            )
 
             repetitions = repetitions if repetitions != -1 else 1
             runner_base = CppBenchmarkRunner.from_rev_or_path(
-                src, root, rev_or_path, conf,
-                repetitions=repetitions, repetition_min_time=repetition_min_time,
-                suite_filter=suite_filter, benchmark_filter=benchmark_filter,
-                benchmark_extras=cpp_benchmark_extras)
+                src,
+                root,
+                rev_or_path,
+                conf,
+                repetitions=repetitions,
+                repetition_min_time=repetition_min_time,
+                suite_filter=suite_filter,
+                benchmark_filter=benchmark_filter,
+                benchmark_extras=cpp_benchmark_extras,
+            )
 
         elif language == "java":
-            for key in ('cpp_package_prefix', 'cxx_flags', 'cxx', 'cc'):
+            for key in ("cpp_package_prefix", "cxx_flags", "cxx", "cc"):
                 del kwargs[key]
             conf = JavaBenchmarkRunner.default_configuration(
-                java_home=java_home, java_options=java_options,
-                build_extras=build_extras, benchmark_extras=benchmark_extras,
-                **kwargs)
+                java_home=java_home,
+                java_options=java_options,
+                build_extras=build_extras,
+                benchmark_extras=benchmark_extras,
+                **kwargs,
+            )
 
             repetitions = repetitions if repetitions != -1 else 5
             runner_base = JavaBenchmarkRunner.from_rev_or_path(
-                src, root, rev_or_path, conf,
+                src,
+                root,
+                rev_or_path,
+                conf,
                 repetitions=repetitions,
-                benchmark_filter=benchmark_filter)
+                benchmark_filter=benchmark_filter,
+            )
 
         # XXX for some reason, the benchmark runner only does its work
         # when asked to JSON-serialize the results, so produce a JSON
@@ -532,25 +763,59 @@ def benchmark_run(ctx, rev_or_path, src, preserve, output, cmake_extras,
 @benchmark.command(name="diff", short_help="Compare benchmark suites")
 @benchmark_common_options
 @benchmark_filter_options
-@click.option("--threshold", type=float, default=DEFAULT_THRESHOLD,
-              show_default=True,
-              help="Regression failure threshold in percentage.")
-@click.option("--repetitions", type=int, default=1, show_default=True,
-              help=("Number of repetitions of each benchmark. Increasing "
-                    "may improve result precision. "
-                    "[default: 1 for cpp, 5 for java"))
-@click.option("--no-counters", type=BOOL, default=False, is_flag=True,
-              help="Hide counters field in diff report.")
-@click.argument("contender", metavar="[<contender>",
-                default=ArrowSources.WORKSPACE, required=False)
-@click.argument("baseline", metavar="[<baseline>]]", default="origin/HEAD",
-                required=False)
+@click.option(
+    "--threshold",
+    type=float,
+    default=DEFAULT_THRESHOLD,
+    show_default=True,
+    help="Regression failure threshold in percentage.",
+)
+@click.option(
+    "--repetitions",
+    type=int,
+    default=1,
+    show_default=True,
+    help=(
+        "Number of repetitions of each benchmark. Increasing "
+        "may improve result precision. "
+        "[default: 1 for cpp, 5 for java"
+    ),
+)
+@click.option(
+    "--no-counters",
+    type=BOOL,
+    default=False,
+    is_flag=True,
+    help="Hide counters field in diff report.",
+)
+@click.argument(
+    "contender", metavar="[<contender>", default=ArrowSources.WORKSPACE, required=False
+)
+@click.argument(
+    "baseline", metavar="[<baseline>]]", default="origin/HEAD", required=False
+)
 @click.pass_context
-def benchmark_diff(ctx, src, preserve, output, language, cmake_extras,
-                   suite_filter, benchmark_filter, repetitions, no_counters,
-                   java_home, java_options, build_extras, benchmark_extras,
-                   cpp_benchmark_extras, threshold, contender, baseline,
-                   **kwargs):
+def benchmark_diff(
+    ctx,
+    src,
+    preserve,
+    output,
+    language,
+    cmake_extras,
+    suite_filter,
+    benchmark_filter,
+    repetitions,
+    no_counters,
+    java_home,
+    java_options,
+    build_extras,
+    benchmark_extras,
+    cpp_benchmark_extras,
+    threshold,
+    contender,
+    baseline,
+    **kwargs,
+):
     """Compare (diff) benchmark runs.
 
     This command acts like git-diff but for benchmark results.
@@ -624,52 +889,72 @@ def benchmark_diff(ctx, src, preserve, output, language, cmake_extras,
     archery --quiet benchmark diff WORKSPACE run.json > result.json
     """
     with tmpdir(preserve=preserve) as root:
-        logger.debug(f"Comparing {contender} (contender) with {baseline} (baseline)"
-                     )
+        logger.debug(f"Comparing {contender} (contender) with {baseline} (baseline)")
 
         if language == "cpp":
             conf = CppBenchmarkRunner.default_configuration(
-                cmake_extras=cmake_extras, **kwargs)
+                cmake_extras=cmake_extras, **kwargs
+            )
 
             repetitions = repetitions if repetitions != -1 else 1
             runner_cont = CppBenchmarkRunner.from_rev_or_path(
-                src, root, contender, conf,
+                src,
+                root,
+                contender,
+                conf,
                 repetitions=repetitions,
                 suite_filter=suite_filter,
                 benchmark_filter=benchmark_filter,
-                benchmark_extras=cpp_benchmark_extras)
+                benchmark_extras=cpp_benchmark_extras,
+            )
             runner_base = CppBenchmarkRunner.from_rev_or_path(
-                src, root, baseline, conf,
+                src,
+                root,
+                baseline,
+                conf,
                 repetitions=repetitions,
                 suite_filter=suite_filter,
                 benchmark_filter=benchmark_filter,
-                benchmark_extras=cpp_benchmark_extras)
+                benchmark_extras=cpp_benchmark_extras,
+            )
 
         elif language == "java":
-            for key in ('cpp_package_prefix', 'cxx_flags', 'cxx', 'cc'):
+            for key in ("cpp_package_prefix", "cxx_flags", "cxx", "cc"):
                 del kwargs[key]
             conf = JavaBenchmarkRunner.default_configuration(
-                java_home=java_home, java_options=java_options,
-                build_extras=build_extras, benchmark_extras=benchmark_extras,
-                **kwargs)
+                java_home=java_home,
+                java_options=java_options,
+                build_extras=build_extras,
+                benchmark_extras=benchmark_extras,
+                **kwargs,
+            )
 
             repetitions = repetitions if repetitions != -1 else 5
             runner_cont = JavaBenchmarkRunner.from_rev_or_path(
-                src, root, contender, conf,
+                src,
+                root,
+                contender,
+                conf,
                 repetitions=repetitions,
-                benchmark_filter=benchmark_filter)
+                benchmark_filter=benchmark_filter,
+            )
             runner_base = JavaBenchmarkRunner.from_rev_or_path(
-                src, root, baseline, conf,
+                src,
+                root,
+                baseline,
+                conf,
                 repetitions=repetitions,
-                benchmark_filter=benchmark_filter)
+                benchmark_filter=benchmark_filter,
+            )
 
         runner_comp = RunnerComparator(runner_cont, runner_base, threshold)
 
         # TODO(kszucs): test that the output is properly formatted jsonlines
         comparisons_json = _get_comparisons_as_json(runner_comp.comparisons)
         ren_counters = language == "java"
-        formatted = _format_comparisons_with_pandas(comparisons_json,
-                                                    no_counters, ren_counters)
+        formatted = _format_comparisons_with_pandas(
+            comparisons_json, no_counters, ren_counters
+        )
         print(formatted, file=output or sys.stdout)
 
 
@@ -682,37 +967,41 @@ def _get_comparisons_as_json(comparisons):
     return buf.getvalue()
 
 
-def _format_comparisons_with_pandas(comparisons_json, no_counters,
-                                    ren_counters):
+def _format_comparisons_with_pandas(comparisons_json, no_counters, ren_counters):
     pd = _import_pandas()
     df = pd.read_json(StringIO(comparisons_json), lines=True)
     # parse change % so we can sort by it
-    df['change %'] = df.pop('change').str[:-1].map(float)
-    first_regression = len(df) - df['regression'].sum()
+    df["change %"] = df.pop("change").str[:-1].map(float)
+    first_regression = len(df) - df["regression"].sum()
 
-    fields = ['benchmark', 'baseline', 'contender', 'change %']
+    fields = ["benchmark", "baseline", "contender", "change %"]
     if not no_counters:
-        fields += ['counters']
+        fields += ["counters"]
 
     df = df[fields]
     if ren_counters:
-        df = df.rename(columns={'counters': 'configurations'})
-    df = df.sort_values(by='change %', ascending=False)
+        df = df.rename(columns={"counters": "configurations"})
+    df = df.sort_values(by="change %", ascending=False)
 
     def labelled(title, df):
         if len(df) == 0:
-            return ''
-        title += f': ({len(df)})'
+            return ""
+        title += f": ({len(df)})"
         df_str = df.to_string(index=False)
-        bar = '-' * df_str.index('\n')
-        return '\n'.join([bar, title, bar, df_str])
+        bar = "-" * df_str.index("\n")
+        return "\n".join([bar, title, bar, df_str])
 
-    return '\n\n'.join([labelled('Non-regressions', df[:first_regression]),
-                        labelled('Regressions', df[first_regression:])])
+    return "\n\n".join(
+        [
+            labelled("Non-regressions", df[:first_regression]),
+            labelled("Regressions", df[first_regression:]),
+        ]
+    )
 
 
 # ----------------------------------------------------------------------
 # Integration testing
+
 
 def _set_default(opt, default):
     if opt is None:
@@ -721,55 +1010,110 @@ def _set_default(opt, default):
 
 
 @archery.command(short_help="Execute protocol and Flight integration tests")
-@click.option('--with-all', is_flag=True, default=False,
-              help=('Include all known implementations by default '
-                    'in integration tests'))
-@click.option('--random-seed', type=int, default=12345,
-              help="Seed for PRNG when generating test data")
-@click.option('--with-cpp', type=bool, default=False,
-              help='Include C++ in integration tests')
-@click.option('--with-csharp', type=bool, default=False,
-              help='Include C# in integration tests')
-@click.option('--with-java', type=bool, default=False,
-              help='Include Java in integration tests',
-              envvar="ARCHERY_INTEGRATION_WITH_JAVA")
-@click.option('--with-js', type=bool, default=False,
-              help='Include JavaScript in integration tests')
-@click.option('--with-go', type=bool, default=False,
-              help='Include Go in integration tests',
-              envvar="ARCHERY_INTEGRATION_WITH_GO")
-@click.option('--with-nanoarrow', type=bool, default=False,
-              help='Include nanoarrow in integration tests',
-              envvar="ARCHERY_INTEGRATION_WITH_NANOARROW")
-@click.option('--with-rust', type=bool, default=False,
-              help='Include Rust in integration tests',
-              envvar="ARCHERY_INTEGRATION_WITH_RUST")
-@click.option('--target-implementations', default='',
-              help=('Target implementations in this integration tests'),
-              envvar="ARCHERY_INTEGRATION_TARGET_IMPLEMENTATIONS")
-@click.option('--write_generated_json', default="",
-              help='Generate test JSON to indicated path')
-@click.option('--run-ipc', is_flag=True, default=False,
-              help='Run IPC integration tests')
-@click.option('--run-flight', is_flag=True, default=False,
-              help='Run Flight integration tests')
-@click.option('--run-c-data', is_flag=True, default=False,
-              help='Run C Data Interface integration tests')
-@click.option('--debug', is_flag=True, default=False,
-              help='Run executables in debug mode as relevant')
-@click.option('--serial', is_flag=True, default=False,
-              help='Run tests serially, rather than in parallel')
-@click.option('--tempdir', default=None,
-              help=('Directory to use for writing '
-                    'integration test temporary files'))
-@click.option('stop_on_error', '-x', '--stop-on-error',
-              is_flag=True, default=False,
-              help='Stop on first error')
-@click.option('--gold-dirs', multiple=True,
-              help="gold integration test file paths")
-@click.option('-k', '--match',
-              help=("Substring for test names to include in run, "
-                    "e.g. -k primitive"))
+@click.option(
+    "--with-all",
+    is_flag=True,
+    default=False,
+    help=("Include all known implementations by default in integration tests"),
+)
+@click.option(
+    "--random-seed",
+    type=int,
+    default=12345,
+    help="Seed for PRNG when generating test data",
+)
+@click.option(
+    "--with-cpp", type=bool, default=False, help="Include C++ in integration tests"
+)
+@click.option(
+    "--with-csharp", type=bool, default=False, help="Include C# in integration tests"
+)
+@click.option(
+    "--with-java",
+    type=bool,
+    default=False,
+    help="Include Java in integration tests",
+    envvar="ARCHERY_INTEGRATION_WITH_JAVA",
+)
+@click.option(
+    "--with-js",
+    type=bool,
+    default=False,
+    help="Include JavaScript in integration tests",
+)
+@click.option(
+    "--with-go",
+    type=bool,
+    default=False,
+    help="Include Go in integration tests",
+    envvar="ARCHERY_INTEGRATION_WITH_GO",
+)
+@click.option(
+    "--with-nanoarrow",
+    type=bool,
+    default=False,
+    help="Include nanoarrow in integration tests",
+    envvar="ARCHERY_INTEGRATION_WITH_NANOARROW",
+)
+@click.option(
+    "--with-rust",
+    type=bool,
+    default=False,
+    help="Include Rust in integration tests",
+    envvar="ARCHERY_INTEGRATION_WITH_RUST",
+)
+@click.option(
+    "--target-implementations",
+    default="",
+    help=("Target implementations in this integration tests"),
+    envvar="ARCHERY_INTEGRATION_TARGET_IMPLEMENTATIONS",
+)
+@click.option(
+    "--write_generated_json", default="", help="Generate test JSON to indicated path"
+)
+@click.option(
+    "--run-ipc", is_flag=True, default=False, help="Run IPC integration tests"
+)
+@click.option(
+    "--run-flight", is_flag=True, default=False, help="Run Flight integration tests"
+)
+@click.option(
+    "--run-c-data",
+    is_flag=True,
+    default=False,
+    help="Run C Data Interface integration tests",
+)
+@click.option(
+    "--debug",
+    is_flag=True,
+    default=False,
+    help="Run executables in debug mode as relevant",
+)
+@click.option(
+    "--serial",
+    is_flag=True,
+    default=False,
+    help="Run tests serially, rather than in parallel",
+)
+@click.option(
+    "--tempdir",
+    default=None,
+    help=("Directory to use for writing integration test temporary files"),
+)
+@click.option(
+    "stop_on_error",
+    "-x",
+    "--stop-on-error",
+    is_flag=True,
+    default=False,
+    help="Stop on first error",
+)
+@click.option("--gold-dirs", multiple=True, help="gold integration test file paths")
+@click.option(
+    "-k",
+    "--match",
+    help=("Substring for test names to include in run, e.g. -k primitive"),
+)
 def integration(with_all=False, random_seed=12345, **args):
     """If you don't specify the "--target-implementations" option nor
     the "ARCHERY_INTEGRATION_TARGET_IMPLEMENTATIONS" environment
@@ -838,21 +1182,21 @@ def integration(with_all=False, random_seed=12345, **args):
     # Make runs involving data generation deterministic
     np.random.seed(random_seed)
 
-    gen_path = args['write_generated_json']
+    gen_path = args["write_generated_json"]
 
-    implementations = ['cpp', 'csharp', 'java', 'js', 'go', 'nanoarrow', 'rust']
-    formats = ['ipc', 'flight', 'c_data']
+    implementations = ["cpp", "csharp", "java", "js", "go", "nanoarrow", "rust"]
+    formats = ["ipc", "flight", "c_data"]
 
     enabled_implementations = 0
     for lang in implementations:
-        param = f'with_{lang}'
+        param = f"with_{lang}"
         if with_all:
             args[param] = with_all
         enabled_implementations += args[param]
 
     enabled_formats = 0
     for fmt in formats:
-        param = f'run_{fmt}'
+        param = f"run_{fmt}"
         enabled_formats += args[param]
 
     if gen_path:
@@ -864,52 +1208,69 @@ def integration(with_all=False, random_seed=12345, **args):
         if enabled_formats == 0:
             raise click.UsageError(
                 "Need to enable at least one format to test "
-                "(IPC, Flight, C Data Interface); try --help")
+                "(IPC, Flight, C Data Interface); try --help"
+            )
         if enabled_implementations == 0:
             raise click.UsageError(
-                "Need to enable at least one implementation to test; try --help")
+                "Need to enable at least one implementation to test; try --help"
+            )
         run_all_tests(**args)
 
 
 @archery.command()
-@click.option('--arrow-token', envvar='ARROW_GITHUB_TOKEN',
-              help='OAuth token for responding comment in the arrow repo')
-@click.option('--committers-file', '-c', type=click.File('r', encoding='utf8'))
-@click.option('--event-name', '-n', required=True)
-@click.option('--event-payload', '-p', type=click.File('r', encoding='utf8'),
-              default='-', required=True)
+@click.option(
+    "--arrow-token",
+    envvar="ARROW_GITHUB_TOKEN",
+    help="OAuth token for responding comment in the arrow repo",
+)
+@click.option("--committers-file", "-c", type=click.File("r", encoding="utf8"))
+@click.option("--event-name", "-n", required=True)
+@click.option(
+    "--event-payload",
+    "-p",
+    type=click.File("r", encoding="utf8"),
+    default="-",
+    required=True,
+)
 def trigger_bot(arrow_token, committers_file, event_name, event_payload):
     from ruamel.yaml import YAML
 
     from .bot import CommentBot, PullRequestWorkflowBot, actions
 
     event_payload = json.loads(event_payload.read())
-    if 'comment' in event_name:
-        bot = CommentBot(name='github-actions', handler=actions, token=arrow_token)
+    if "comment" in event_name:
+        bot = CommentBot(name="github-actions", handler=actions, token=arrow_token)
         bot.handle(event_name, event_payload)
     else:
         committers = None
         if committers_file:
-            committers = [committer['alias']
-                          for committer in YAML().load(committers_file)]
-        bot = PullRequestWorkflowBot(event_name, event_payload, token=arrow_token,
-                                     committers=committers)
+            committers = [
+                committer["alias"] for committer in YAML().load(committers_file)
+            ]
+        bot = PullRequestWorkflowBot(
+            event_name, event_payload, token=arrow_token, committers=committers
+        )
         bot.handle()
 
 
 @archery.group("linking")
 @click.pass_obj
 def linking(obj):
-    """Quick and dirty utilities for checking library linkage.
-    """
+    """Quick and dirty utilities for checking library linkage."""
 
 
 @linking.command("check-dependencies")
 @click.argument("paths", nargs=-1)
-@click.option("--allow", "-a", "allowed", multiple=True,
-              help="Name of the allowed libraries")
-@click.option("--disallow", "-d", "disallowed", multiple=True,
-              help="Name of the disallowed libraries")
+@click.option(
+    "--allow", "-a", "allowed", multiple=True, help="Name of the allowed libraries"
+)
+@click.option(
+    "--disallow",
+    "-d",
+    "disallowed",
+    multiple=True,
+    help="Name of the disallowed libraries",
+)
 @click.pass_obj
 def linking_check_dependencies(obj, allowed, disallowed, paths):
     from .linking import DependencyError, check_dynamic_library_dependencies
@@ -917,18 +1278,20 @@ def linking_check_dependencies(obj, allowed, disallowed, paths):
     allowed, disallowed = set(allowed), set(disallowed)
     try:
         for path in map(pathlib.Path, paths):
-            check_dynamic_library_dependencies(path, allowed=allowed,
-                                               disallowed=disallowed)
+            check_dynamic_library_dependencies(
+                path, allowed=allowed, disallowed=disallowed
+            )
     except DependencyError as e:
         raise click.ClickException(str(e))
 
 
-add_optional_command("docker", module=".docker.cli", function="docker",
-                     parent=archery)
-add_optional_command("release", module=".release.cli", function="release",
-                     parent=archery)
-add_optional_command("crossbow", module=".crossbow.cli", function="crossbow",
-                     parent=archery)
+add_optional_command("docker", module=".docker.cli", function="docker", parent=archery)
+add_optional_command(
+    "release", module=".release.cli", function="release", parent=archery
+)
+add_optional_command(
+    "crossbow", module=".crossbow.cli", function="crossbow", parent=archery
+)
 
 
 if __name__ == "__main__":

--- a/dev/archery/archery/compat.py
+++ b/dev/archery/archery/compat.py
@@ -21,7 +21,7 @@ import sys
 
 
 def _is_path_like(path):
-    return isinstance(path, str) or hasattr(path, '__fspath__')
+    return isinstance(path, str) or hasattr(path, "__fspath__")
 
 
 def _ensure_path(path):
@@ -32,8 +32,7 @@ def _ensure_path(path):
 
 
 def _stringify_path(path):
-    """Convert *path* to a string or unicode path if possible.
-    """
+    """Convert *path* to a string or unicode path if possible."""
     if isinstance(path, str):
         return path
 
@@ -48,14 +47,14 @@ def _stringify_path(path):
 
 def _import_pandas():
     # ARROW-13425: avoid importing PyArrow from Pandas
-    sys.modules['pyarrow'] = None
+    sys.modules["pyarrow"] = None
     import pandas as pd
+
     return pd
 
 
 def _get_module(obj, *, default=None):
-    """Try to find the name of the module *obj* is defined on.
-    """
+    """Try to find the name of the module *obj* is defined on."""
     try:
         return obj.__module__
     except AttributeError:

--- a/dev/archery/archery/compat.py
+++ b/dev/archery/archery/compat.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
 import pathlib
 import sys
@@ -31,8 +32,7 @@ def _ensure_path(path):
 
 
 def _stringify_path(path):
-    """
-    Convert *path* to a string or unicode path if possible.
+    """Convert *path* to a string or unicode path if possible.
     """
     if isinstance(path, str):
         return path
@@ -54,8 +54,7 @@ def _import_pandas():
 
 
 def _get_module(obj, *, default=None):
-    """
-    Try to find the name of the module *obj* is defined on.
+    """Try to find the name of the module *obj* is defined on.
     """
     try:
         return obj.__module__

--- a/dev/archery/archery/crossbow/__init__.py
+++ b/dev/archery/archery/crossbow/__init__.py
@@ -15,5 +15,16 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from .core import Config, Repo, Queue, Target, Job  # noqa
-from .reports import CommentReport, ConsoleReport, EmailReport  # noqa
+from .core import Config, Job, Queue, Repo, Target
+from .reports import CommentReport, ConsoleReport, EmailReport
+
+__all__ = [
+    "CommentReport",
+    "Config",
+    "ConsoleReport",
+    "EmailReport",
+    "Job",
+    "Queue",
+    "Repo",
+    "Target",
+]

--- a/dev/archery/archery/crossbow/__init__.py
+++ b/dev/archery/archery/crossbow/__init__.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
 from .core import Config, Job, Queue, Repo, Target
 from .reports import CommentReport, ConsoleReport, EmailReport

--- a/dev/archery/archery/crossbow/cli.py
+++ b/dev/archery/archery/crossbow/cli.py
@@ -14,19 +14,25 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
+import sys
+import time
 from datetime import date
 from pathlib import Path
-import time
-import sys
 
 import click
 
-from .core import Config, Repo, Queue, Target, Job, CrossbowError
-from .reports import (ChatReport, Report, ReportUtils, ConsoleReport,
-                      EmailReport, CommentReport)
 from ..utils.source import ArrowSources
-
+from .core import Config, CrossbowError, Job, Queue, Repo, Target
+from .reports import (
+    ChatReport,
+    CommentReport,
+    ConsoleReport,
+    EmailReport,
+    Report,
+    ReportUtils,
+)
 
 _default_arrow_path = ArrowSources.find().path
 _default_queue_path = _default_arrow_path.parent / "crossbow"
@@ -54,8 +60,7 @@ _default_config_path = _default_arrow_path / "dev" / "tasks" / "tasks.yml"
 @click.pass_context
 def crossbow(ctx, github_token, arrow_path, queue_path, queue_remote,
              output_file):
-    """
-    Schedule packaging tasks or nightly builds on CI services.
+    """Schedule packaging tasks or nightly builds on CI services.
     """
     ctx.ensure_object(dict)
     ctx.obj['output'] = output_file
@@ -150,11 +155,11 @@ def submit(obj, tasks, groups, params, job_prefix, config_path, arrow_version,
     queue.put(job, prefix=job_prefix)
 
     if no_push:
-        click.echo('Branches and commits created but not pushed: `{}`'
-                   .format(job.branch))
+        click.echo(f'Branches and commits created but not pushed: `{job.branch}`'
+                   )
     else:
         queue.push()
-        click.echo('Pushed job identifier is: `{}`'.format(job.branch))
+        click.echo(f'Pushed job identifier is: `{job.branch}`')
 
 
 @crossbow.command()
@@ -235,16 +240,15 @@ def verify_release_candidate(obj, base_branch, create_pr,
 @click.pass_obj
 def render(obj, task, config_path, arrow_version, arrow_remote, arrow_branch,
            arrow_sha, params):
-    """
-    Utility command to check the rendered CI templates.
+    """Utility command to check the rendered CI templates.
     """
     from .core import _flatten
 
     def highlight(code):
         try:
             from pygments import highlight
-            from pygments.lexers import YamlLexer
             from pygments.formatters import TerminalFormatter
+            from pygments.lexers import YamlLexer
             return highlight(code, YamlLexer(), TerminalFormatter())
         except ImportError:
             return code
@@ -259,7 +263,7 @@ def render(obj, task, config_path, arrow_version, arrow_remote, arrow_branch,
     job = Job.from_config(config=config, target=target, tasks=[task],
                           params=params)
 
-    for task_name, rendered_files in job.render_tasks().items():
+    for _task_name, rendered_files in job.render_tasks().items():
         for path, content in _flatten(rendered_files).items():
             click.echo('#' * 80)
             click.echo('### {:^72} ###'.format("/".join(path)))
@@ -373,8 +377,7 @@ def latest_prefix(obj, prefix, fetch):
 def report(obj, job_name, sender_name, sender_email, recipient_email,
            smtp_user, smtp_password, smtp_server, smtp_port, poll,
            poll_max_minutes, poll_interval_minutes, send, fetch):
-    """
-    Send an e-mail report showing success/failure of tasks in a Crossbow run
+    """Send an e-mail report showing success/failure of tasks in a Crossbow run
     """
     output = obj['output']
     queue = obj['queue']
@@ -423,8 +426,7 @@ def report(obj, job_name, sender_name, sender_email, recipient_email,
 @click.pass_obj
 def report_chat(obj, job_name, send, webhook, extra_message_success,
                 extra_message_failure, fetch):
-    """
-    Send a chat report to a webhook showing success/failure
+    """Send a chat report to a webhook showing success/failure
     of tasks in a Crossbow run.
     """
     output = obj['output']
@@ -450,8 +452,7 @@ def report_chat(obj, job_name, send, webhook, extra_message_success,
               help='Fetch references (branches and tags) from the remote')
 @click.pass_obj
 def report_csv(obj, job_name, save, fetch):
-    """
-    Generates a CSV report with the different tasks information
+    """Generates a CSV report with the different tasks information
     from a Crossbow run.
     """
     output = obj['output']
@@ -531,8 +532,8 @@ def download_artifacts(obj, job_name, target_dir, dry_run, fetch,
                     else:
                         break
 
-    click.echo('Downloading {}\'s artifacts.'.format(job_name))
-    click.echo('Destination directory is {}'.format(target_dir))
+    click.echo(f'Downloading {job_name}\'s artifacts.')
+    click.echo(f'Destination directory is {target_dir}')
     click.echo()
 
     report = ConsoleReport(job, task_filters=task_filters)
@@ -565,8 +566,7 @@ def upload_artifacts(obj, tag, sha, patterns, method):
               help='Maximum limit of branches to delete for a single run')
 @click.pass_obj
 def delete_old_branches(obj, dry_run, days, maximum):
-    """
-    Deletes branches on queue repository (crossbow) that are older than number
+    """Deletes branches on queue repository (crossbow) that are older than number
     of days.
     With a maximum number of branches to be deleted. This is required to avoid
     triggering GitHub protection limits.
@@ -623,8 +623,7 @@ def delete_old_branches(obj, dry_run, days, maximum):
 def notify_token_expiration(obj, days, sender_name, sender_email,
                             recipient_email, smtp_user, smtp_password,
                             smtp_server, smtp_port, send):
-    """
-    Check if token is close to expiration and send email notifying.
+    """Check if token is close to expiration and send email notifying.
     """
     output = obj['output']
     queue = obj['queue']

--- a/dev/archery/archery/crossbow/cli.py
+++ b/dev/archery/archery/crossbow/cli.py
@@ -40,84 +40,155 @@ _default_config_path = _default_arrow_path / "dev" / "tasks" / "tasks.yml"
 
 
 @click.group()
-@click.option('--github-token', '-t', default=None,
-              envvar="CROSSBOW_GITHUB_TOKEN",
-              help='OAuth token for GitHub authentication')
-@click.option('--arrow-path', '-a',
-              type=click.Path(), default=_default_arrow_path,
-              help='Arrow\'s repository path. Defaults to the repository of '
-                   'this script')
-@click.option('--queue-path', '-q',
-              envvar="CROSSBOW_QUEUE_PATH",
-              type=click.Path(), default=_default_queue_path,
-              help='The repository path used for scheduling the tasks. '
-                   'Defaults to crossbow directory placed next to arrow')
-@click.option('--queue-remote', '-qr', default=None,
-              help='Force to use this remote URL for the Queue repository')
-@click.option('--output-file', metavar='<output>',
-              type=click.File('w', encoding='utf8'), default='-',
-              help='Capture output result into file.')
+@click.option(
+    "--github-token",
+    "-t",
+    default=None,
+    envvar="CROSSBOW_GITHUB_TOKEN",
+    help="OAuth token for GitHub authentication",
+)
+@click.option(
+    "--arrow-path",
+    "-a",
+    type=click.Path(),
+    default=_default_arrow_path,
+    help="Arrow's repository path. Defaults to the repository of this script",
+)
+@click.option(
+    "--queue-path",
+    "-q",
+    envvar="CROSSBOW_QUEUE_PATH",
+    type=click.Path(),
+    default=_default_queue_path,
+    help="The repository path used for scheduling the tasks. "
+    "Defaults to crossbow directory placed next to arrow",
+)
+@click.option(
+    "--queue-remote",
+    "-qr",
+    default=None,
+    help="Force to use this remote URL for the Queue repository",
+)
+@click.option(
+    "--output-file",
+    metavar="<output>",
+    type=click.File("w", encoding="utf8"),
+    default="-",
+    help="Capture output result into file.",
+)
 @click.pass_context
-def crossbow(ctx, github_token, arrow_path, queue_path, queue_remote,
-             output_file):
-    """Schedule packaging tasks or nightly builds on CI services.
-    """
+def crossbow(ctx, github_token, arrow_path, queue_path, queue_remote, output_file):
+    """Schedule packaging tasks or nightly builds on CI services."""
     ctx.ensure_object(dict)
-    ctx.obj['output'] = output_file
-    ctx.obj['arrow'] = Repo(arrow_path)
-    ctx.obj['queue'] = Queue(queue_path, remote_url=queue_remote,
-                             github_token=github_token, require_https=True)
+    ctx.obj["output"] = output_file
+    ctx.obj["arrow"] = Repo(arrow_path)
+    ctx.obj["queue"] = Queue(
+        queue_path,
+        remote_url=queue_remote,
+        github_token=github_token,
+        require_https=True,
+    )
 
 
 @crossbow.command()
-@click.option('--config-path', '-c',
-              type=click.Path(exists=True), default=_default_config_path,
-              help='Task configuration yml. Defaults to tasks.yml')
+@click.option(
+    "--config-path",
+    "-c",
+    type=click.Path(exists=True),
+    default=_default_config_path,
+    help="Task configuration yml. Defaults to tasks.yml",
+)
 @click.pass_obj
 def check_config(obj, config_path):
     # load available tasks configuration and groups from yaml
     config = Config.load_yaml(config_path)
     config.validate()
 
-    output = obj['output']
+    output = obj["output"]
     config.show(output)
 
 
 @crossbow.command()
-@click.argument('tasks', nargs=-1, required=False)
-@click.option('--group', '-g', 'groups', multiple=True,
-              help='Submit task groups as defined in task.yml')
-@click.option('--param', '-p', 'params', multiple=True,
-              help='Additional task parameters for rendering the CI templates')
-@click.option('--job-prefix', default='build',
-              help='Arbitrary prefix for branch names, e.g. nightly')
-@click.option('--config-path', '-c',
-              type=click.Path(exists=True), default=_default_config_path,
-              help='Task configuration yml. Defaults to tasks.yml')
-@click.option('--arrow-version', '-v', default=None,
-              help='Set target version explicitly.')
-@click.option('--arrow-remote', '-r', default=None,
-              help='Set GitHub remote explicitly, which is going to be cloned '
-                   'on the CI services. Note, that no validation happens '
-                   'locally. Examples: https://github.com/apache/arrow or '
-                   'https://github.com/kszucs/arrow.')
-@click.option('--arrow-branch', '-b', default=None,
-              help='Give the branch name explicitly, e.g. ARROW-1949.')
-@click.option('--arrow-sha', '-t', default=None,
-              help='Set commit SHA or Tag name explicitly, e.g. f67a515, '
-                   'apache-arrow-0.11.1.')
-@click.option('--fetch/--no-fetch', default=True,
-              help='Fetch references (branches and tags) from the remote')
-@click.option('--dry-run/--commit', default=False,
-              help='Just display the rendered CI configurations without '
-                   'committing them')
-@click.option('--no-push/--push', default=False,
-              help='Don\'t push the changes')
+@click.argument("tasks", nargs=-1, required=False)
+@click.option(
+    "--group",
+    "-g",
+    "groups",
+    multiple=True,
+    help="Submit task groups as defined in task.yml",
+)
+@click.option(
+    "--param",
+    "-p",
+    "params",
+    multiple=True,
+    help="Additional task parameters for rendering the CI templates",
+)
+@click.option(
+    "--job-prefix",
+    default="build",
+    help="Arbitrary prefix for branch names, e.g. nightly",
+)
+@click.option(
+    "--config-path",
+    "-c",
+    type=click.Path(exists=True),
+    default=_default_config_path,
+    help="Task configuration yml. Defaults to tasks.yml",
+)
+@click.option(
+    "--arrow-version", "-v", default=None, help="Set target version explicitly."
+)
+@click.option(
+    "--arrow-remote",
+    "-r",
+    default=None,
+    help="Set GitHub remote explicitly, which is going to be cloned "
+    "on the CI services. Note, that no validation happens "
+    "locally. Examples: https://github.com/apache/arrow or "
+    "https://github.com/kszucs/arrow.",
+)
+@click.option(
+    "--arrow-branch",
+    "-b",
+    default=None,
+    help="Give the branch name explicitly, e.g. ARROW-1949.",
+)
+@click.option(
+    "--arrow-sha",
+    "-t",
+    default=None,
+    help="Set commit SHA or Tag name explicitly, e.g. f67a515, apache-arrow-0.11.1.",
+)
+@click.option(
+    "--fetch/--no-fetch",
+    default=True,
+    help="Fetch references (branches and tags) from the remote",
+)
+@click.option(
+    "--dry-run/--commit",
+    default=False,
+    help="Just display the rendered CI configurations without committing them",
+)
+@click.option("--no-push/--push", default=False, help="Don't push the changes")
 @click.pass_obj
-def submit(obj, tasks, groups, params, job_prefix, config_path, arrow_version,
-           arrow_remote, arrow_branch, arrow_sha, fetch, dry_run, no_push):
-    output = obj['output']
-    queue, arrow = obj['queue'], obj['arrow']
+def submit(
+    obj,
+    tasks,
+    groups,
+    params,
+    job_prefix,
+    config_path,
+    arrow_version,
+    arrow_remote,
+    arrow_branch,
+    arrow_sha,
+    fetch,
+    dry_run,
+    no_push,
+):
+    output = obj["output"]
+    queue, arrow = obj["queue"], obj["arrow"]
 
     # load available tasks configuration and groups from yaml
     config = Config.load_yaml(config_path)
@@ -133,16 +204,22 @@ def submit(obj, tasks, groups, params, job_prefix, config_path, arrow_version,
     # in case of the release procedure), because the templates still
     # contain some business logic (dependency installation, deployments)
     # which will be reduced to a single command in the future.
-    target = Target.from_repo(arrow, remote=arrow_remote, branch=arrow_branch,
-                              head=arrow_sha, version=arrow_version)
+    target = Target.from_repo(
+        arrow,
+        remote=arrow_remote,
+        branch=arrow_branch,
+        head=arrow_sha,
+        version=arrow_version,
+    )
 
     # parse additional job parameters
     params = dict([p.split("=") for p in params])
 
     # instantiate the job object
     try:
-        job = Job.from_config(config=config, target=target, tasks=tasks,
-                              groups=groups, params=params)
+        job = Job.from_config(
+            config=config, target=target, tasks=tasks, groups=groups, params=params
+        )
     except CrossbowError as e:
         raise click.ClickException(str(e))
 
@@ -155,93 +232,141 @@ def submit(obj, tasks, groups, params, job_prefix, config_path, arrow_version,
     queue.put(job, prefix=job_prefix)
 
     if no_push:
-        click.echo(f'Branches and commits created but not pushed: `{job.branch}`'
-                   )
+        click.echo(f"Branches and commits created but not pushed: `{job.branch}`")
     else:
         queue.push()
-        click.echo(f'Pushed job identifier is: `{job.branch}`')
+        click.echo(f"Pushed job identifier is: `{job.branch}`")
 
 
 @crossbow.command()
-@click.option('--base-branch', default=None,
-              help='Set base branch for the PR.')
-@click.option('--create-pr', is_flag=True, default=False,
-              help='Create GitHub Pull Request')
-@click.option('--head-branch', default=None,
-              help='Give the branch name explicitly, e.g. release-9.0.0-rc0')
-@click.option('--pr-body', default=None,
-              help='Set body for the PR.')
-@click.option('--pr-title', default=None,
-              help='Set title for the PR.')
-@click.option('--remote', default=None,
-              help='Set GitHub remote explicitly, which is going to be used '
-                   'for the PR. Note, that no validation happens '
-                   'locally. Examples: https://github.com/apache/arrow or '
-                   'https://github.com/raulcd/arrow.')
-@click.option('--rc', default=None,
-              help='Release Candidate number.')
-@click.option('--version', default=None,
-              help='Release version.')
-@click.option('--verify-binaries', is_flag=True, default=False,
-              help='Trigger the verify binaries jobs')
-@click.option('--verify-source', is_flag=True, default=False,
-              help='Trigger the verify source jobs')
-@click.option('--verify-wheels', is_flag=True, default=False,
-              help='Trigger the verify wheels jobs')
+@click.option("--base-branch", default=None, help="Set base branch for the PR.")
+@click.option(
+    "--create-pr", is_flag=True, default=False, help="Create GitHub Pull Request"
+)
+@click.option(
+    "--head-branch",
+    default=None,
+    help="Give the branch name explicitly, e.g. release-9.0.0-rc0",
+)
+@click.option("--pr-body", default=None, help="Set body for the PR.")
+@click.option("--pr-title", default=None, help="Set title for the PR.")
+@click.option(
+    "--remote",
+    default=None,
+    help="Set GitHub remote explicitly, which is going to be used "
+    "for the PR. Note, that no validation happens "
+    "locally. Examples: https://github.com/apache/arrow or "
+    "https://github.com/raulcd/arrow.",
+)
+@click.option("--rc", default=None, help="Release Candidate number.")
+@click.option("--version", default=None, help="Release version.")
+@click.option(
+    "--verify-binaries",
+    is_flag=True,
+    default=False,
+    help="Trigger the verify binaries jobs",
+)
+@click.option(
+    "--verify-source",
+    is_flag=True,
+    default=False,
+    help="Trigger the verify source jobs",
+)
+@click.option(
+    "--verify-wheels",
+    is_flag=True,
+    default=False,
+    help="Trigger the verify wheels jobs",
+)
 @click.pass_obj
-def verify_release_candidate(obj, base_branch, create_pr,
-                             head_branch, pr_body, pr_title, remote,
-                             rc, version, verify_binaries, verify_source,
-                             verify_wheels):
+def verify_release_candidate(
+    obj,
+    base_branch,
+    create_pr,
+    head_branch,
+    pr_body,
+    pr_title,
+    remote,
+    rc,
+    version,
+    verify_binaries,
+    verify_source,
+    verify_wheels,
+):
     # The verify-release-candidate command will create a PR (or find one)
     # and add the verify-rc* comment to trigger the verify tasks
 
     # Redefine Arrow repo to use the correct arrow remote.
-    arrow = Repo(path=obj['arrow'].path, remote_url=remote)
+    arrow = Repo(path=obj["arrow"].path, remote_url=remote)
 
-    response = arrow.github_pr(title=pr_title, head=head_branch,
-                               base=base_branch, body=pr_body,
-                               github_token=obj['queue'].github_token,
-                               create=create_pr)
+    response = arrow.github_pr(
+        title=pr_title,
+        head=head_branch,
+        base=base_branch,
+        body=pr_body,
+        github_token=obj["queue"].github_token,
+        create=create_pr,
+    )
 
     # If we want to trigger any verification job we add a comment to the PR.
     verify_flags = [verify_source, verify_binaries, verify_wheels]
     if any(verify_flags):
         command = "@github-actions crossbow submit"
-        verify_groups = ["verify-rc-source",
-                         "verify-rc-binaries", "verify-rc-wheels"]
+        verify_groups = ["verify-rc-source", "verify-rc-binaries", "verify-rc-wheels"]
         job_groups = ""
         for flag, group in zip(verify_flags, verify_groups):
             if flag:
                 job_groups += f" --group {group}"
         response.create_comment(
-            f"{command} {job_groups} --param release={version} --param rc={rc}")
+            f"{command} {job_groups} --param release={version} --param rc={rc}"
+        )
 
 
 @crossbow.command()
-@click.argument('task', required=True)
-@click.option('--config-path', '-c',
-              type=click.Path(exists=True), default=_default_config_path,
-              help='Task configuration yml. Defaults to tasks.yml')
-@click.option('--arrow-version', '-v', default=None,
-              help='Set target version explicitly.')
-@click.option('--arrow-remote', '-r', default=None,
-              help='Set GitHub remote explicitly, which is going to be cloned '
-                   'on the CI services. Note, that no validation happens '
-                   'locally. Examples: https://github.com/apache/arrow or '
-                   'https://github.com/kszucs/arrow.')
-@click.option('--arrow-branch', '-b', default=None,
-              help='Give the branch name explicitly, e.g. ARROW-1949.')
-@click.option('--arrow-sha', '-t', default=None,
-              help='Set commit SHA or Tag name explicitly, e.g. f67a515, '
-                   'apache-arrow-0.11.1.')
-@click.option('--param', '-p', 'params', multiple=True,
-              help='Additional task parameters for rendering the CI templates')
+@click.argument("task", required=True)
+@click.option(
+    "--config-path",
+    "-c",
+    type=click.Path(exists=True),
+    default=_default_config_path,
+    help="Task configuration yml. Defaults to tasks.yml",
+)
+@click.option(
+    "--arrow-version", "-v", default=None, help="Set target version explicitly."
+)
+@click.option(
+    "--arrow-remote",
+    "-r",
+    default=None,
+    help="Set GitHub remote explicitly, which is going to be cloned "
+    "on the CI services. Note, that no validation happens "
+    "locally. Examples: https://github.com/apache/arrow or "
+    "https://github.com/kszucs/arrow.",
+)
+@click.option(
+    "--arrow-branch",
+    "-b",
+    default=None,
+    help="Give the branch name explicitly, e.g. ARROW-1949.",
+)
+@click.option(
+    "--arrow-sha",
+    "-t",
+    default=None,
+    help="Set commit SHA or Tag name explicitly, e.g. f67a515, apache-arrow-0.11.1.",
+)
+@click.option(
+    "--param",
+    "-p",
+    "params",
+    multiple=True,
+    help="Additional task parameters for rendering the CI templates",
+)
 @click.pass_obj
-def render(obj, task, config_path, arrow_version, arrow_remote, arrow_branch,
-           arrow_sha, params):
-    """Utility command to check the rendered CI templates.
-    """
+def render(
+    obj, task, config_path, arrow_version, arrow_remote, arrow_branch, arrow_sha, params
+):
+    """Utility command to check the rendered CI templates."""
     from .core import _flatten
 
     def highlight(code):
@@ -249,41 +374,56 @@ def render(obj, task, config_path, arrow_version, arrow_remote, arrow_branch,
             from pygments import highlight
             from pygments.formatters import TerminalFormatter
             from pygments.lexers import YamlLexer
+
             return highlight(code, YamlLexer(), TerminalFormatter())
         except ImportError:
             return code
 
-    arrow = obj['arrow']
+    arrow = obj["arrow"]
 
-    target = Target.from_repo(arrow, remote=arrow_remote, branch=arrow_branch,
-                              head=arrow_sha, version=arrow_version)
+    target = Target.from_repo(
+        arrow,
+        remote=arrow_remote,
+        branch=arrow_branch,
+        head=arrow_sha,
+        version=arrow_version,
+    )
     config = Config.load_yaml(config_path)
     params = dict([p.split("=") for p in params])
     params["queue_remote_url"] = "https://github.com/org/crossbow"
-    job = Job.from_config(config=config, target=target, tasks=[task],
-                          params=params)
+    job = Job.from_config(config=config, target=target, tasks=[task], params=params)
 
     for _task_name, rendered_files in job.render_tasks().items():
         for path, content in _flatten(rendered_files).items():
-            click.echo('#' * 80)
-            click.echo('### {:^72} ###'.format("/".join(path)))
-            click.echo('#' * 80)
+            click.echo("#" * 80)
+            click.echo("### {:^72} ###".format("/".join(path)))
+            click.echo("#" * 80)
             click.echo(highlight(content))
 
 
 @crossbow.command()
-@click.argument('job-name', required=True)
-@click.option('--fetch/--no-fetch', default=True,
-              help='Fetch references (branches and tags) from the remote')
-@click.option('--task-filter', '-f', 'task_filters', multiple=True,
-              help='Glob pattern for filtering relevant tasks')
-@click.option('--validate/--no-validate', default=False,
-              help='Return non-zero exit code '
-                   'if there is any non-success task')
+@click.argument("job-name", required=True)
+@click.option(
+    "--fetch/--no-fetch",
+    default=True,
+    help="Fetch references (branches and tags) from the remote",
+)
+@click.option(
+    "--task-filter",
+    "-f",
+    "task_filters",
+    multiple=True,
+    help="Glob pattern for filtering relevant tasks",
+)
+@click.option(
+    "--validate/--no-validate",
+    default=False,
+    help="Return non-zero exit code if there is any non-success task",
+)
 @click.pass_obj
 def status(obj, job_name, fetch, task_filters, validate):
-    output = obj['output']
-    queue = obj['queue']
+    output = obj["output"]
+    queue = obj["queue"]
     if fetch:
         queue.fetch()
     job = queue.get(job_name)
@@ -292,7 +432,7 @@ def status(obj, job_name, fetch, task_filters, validate):
 
     def asset_callback(task_name, task, asset):
         nonlocal success
-        if task.status().combined_state in {'error', 'failure'}:
+        if task.status().combined_state in {"error", "failure"}:
             success = False
         if asset is None:
             success = False
@@ -304,43 +444,58 @@ def status(obj, job_name, fetch, task_filters, validate):
 
 
 @crossbow.command()
-@click.option('--arrow-remote', '-r', default=None,
-              help='Set GitHub remote explicitly, which is going to be cloned '
-                   'on the CI services. Note, that no validation happens '
-                   'locally. Examples: "https://github.com/apache/arrow" or '
-                   '"raulcd/arrow".')
-@click.option('--crossbow', '-c', default='ursacomputing/crossbow',
-              help='Crossbow repository on github to use')
-@click.option('--fetch/--no-fetch', default=True,
-              help='Fetch references (branches and tags) from the remote')
-@click.option('--job-name', required=True)
-@click.option('--pr-title', required=True,
-              help='Track the job submitted on PR with given title')
+@click.option(
+    "--arrow-remote",
+    "-r",
+    default=None,
+    help="Set GitHub remote explicitly, which is going to be cloned "
+    "on the CI services. Note, that no validation happens "
+    'locally. Examples: "https://github.com/apache/arrow" or '
+    '"raulcd/arrow".',
+)
+@click.option(
+    "--crossbow",
+    "-c",
+    default="ursacomputing/crossbow",
+    help="Crossbow repository on github to use",
+)
+@click.option(
+    "--fetch/--no-fetch",
+    default=True,
+    help="Fetch references (branches and tags) from the remote",
+)
+@click.option("--job-name", required=True)
+@click.option(
+    "--pr-title", required=True, help="Track the job submitted on PR with given title"
+)
 @click.pass_obj
 def report_pr(obj, arrow_remote, crossbow, fetch, job_name, pr_title):
-    arrow = obj['arrow']
-    queue = obj['queue']
+    arrow = obj["arrow"]
+    queue = obj["queue"]
     if fetch:
         queue.fetch()
     job = queue.get(job_name)
 
     report = CommentReport(job, crossbow_repo=crossbow)
     target_arrow = Repo(path=arrow.path, remote_url=arrow_remote)
-    pull_request = target_arrow.github_pr(title=pr_title,
-                                          github_token=queue.github_token,
-                                          create=False)
+    pull_request = target_arrow.github_pr(
+        title=pr_title, github_token=queue.github_token, create=False
+    )
     # render the response comment's content on the PR
     pull_request.create_comment(report.show())
-    click.echo(f'Job is tracked on PR {pull_request.html_url}')
+    click.echo(f"Job is tracked on PR {pull_request.html_url}")
 
 
 @crossbow.command()
-@click.argument('prefix', required=True)
-@click.option('--fetch/--no-fetch', default=True,
-              help='Fetch references (branches and tags) from the remote')
+@click.argument("prefix", required=True)
+@click.option(
+    "--fetch/--no-fetch",
+    default=True,
+    help="Fetch references (branches and tags) from the remote",
+)
 @click.pass_obj
 def latest_prefix(obj, prefix, fetch):
-    queue = obj['queue']
+    queue = obj["queue"]
     if fetch:
         queue.fetch()
     latest = queue.latest_for_prefix(prefix)
@@ -348,39 +503,64 @@ def latest_prefix(obj, prefix, fetch):
 
 
 @crossbow.command()
-@click.argument('job-name', required=True)
-@click.option('--sender-name', '-n',
-              help='Name to use for report e-mail.')
-@click.option('--sender-email', '-e',
-              help='E-mail to use for report e-mail.')
-@click.option('--recipient-email', '-r',
-              help='Where to send the e-mail report')
-@click.option('--smtp-user', '-u',
-              help='E-mail address to use for SMTP login')
-@click.option('--smtp-password', '-P',
-              help='SMTP password to use for report e-mail.')
-@click.option('--smtp-server', '-s', default='smtp.gmail.com',
-              help='SMTP server to use for report e-mail.')
-@click.option('--smtp-port', '-p', default=465,
-              help='SMTP port to use for report e-mail.')
-@click.option('--poll/--no-poll', default=False,
-              help='Wait for completion if there are tasks pending')
-@click.option('--poll-max-minutes', default=180,
-              help='Maximum amount of time waiting for job completion')
-@click.option('--poll-interval-minutes', default=10,
-              help='Number of minutes to wait to check job status again')
-@click.option('--send/--dry-run', default=False,
-              help='Just display the report, don\'t send it')
-@click.option('--fetch/--no-fetch', default=True,
-              help='Fetch references (branches and tags) from the remote')
+@click.argument("job-name", required=True)
+@click.option("--sender-name", "-n", help="Name to use for report e-mail.")
+@click.option("--sender-email", "-e", help="E-mail to use for report e-mail.")
+@click.option("--recipient-email", "-r", help="Where to send the e-mail report")
+@click.option("--smtp-user", "-u", help="E-mail address to use for SMTP login")
+@click.option("--smtp-password", "-P", help="SMTP password to use for report e-mail.")
+@click.option(
+    "--smtp-server",
+    "-s",
+    default="smtp.gmail.com",
+    help="SMTP server to use for report e-mail.",
+)
+@click.option(
+    "--smtp-port", "-p", default=465, help="SMTP port to use for report e-mail."
+)
+@click.option(
+    "--poll/--no-poll",
+    default=False,
+    help="Wait for completion if there are tasks pending",
+)
+@click.option(
+    "--poll-max-minutes",
+    default=180,
+    help="Maximum amount of time waiting for job completion",
+)
+@click.option(
+    "--poll-interval-minutes",
+    default=10,
+    help="Number of minutes to wait to check job status again",
+)
+@click.option(
+    "--send/--dry-run", default=False, help="Just display the report, don't send it"
+)
+@click.option(
+    "--fetch/--no-fetch",
+    default=True,
+    help="Fetch references (branches and tags) from the remote",
+)
 @click.pass_obj
-def report(obj, job_name, sender_name, sender_email, recipient_email,
-           smtp_user, smtp_password, smtp_server, smtp_port, poll,
-           poll_max_minutes, poll_interval_minutes, send, fetch):
-    """Send an e-mail report showing success/failure of tasks in a Crossbow run
-    """
-    output = obj['output']
-    queue = obj['queue']
+def report(
+    obj,
+    job_name,
+    sender_name,
+    sender_email,
+    recipient_email,
+    smtp_user,
+    smtp_password,
+    smtp_server,
+    smtp_port,
+    poll,
+    poll_max_minutes,
+    poll_interval_minutes,
+    send,
+    fetch,
+):
+    """Send an e-mail report showing success/failure of tasks in a Crossbow run"""
+    output = obj["output"]
+    queue = obj["queue"]
     if fetch:
         queue.fetch()
 
@@ -389,13 +569,13 @@ def report(obj, job_name, sender_name, sender_email, recipient_email,
         report=Report(job),
         sender_name=sender_name,
         sender_email=sender_email,
-        recipient_email=recipient_email
+        recipient_email=recipient_email,
     )
 
     if poll:
         job.wait_until_finished(
             poll_max_minutes=poll_max_minutes,
-            poll_interval_minutes=poll_interval_minutes
+            poll_interval_minutes=poll_interval_minutes,
         )
 
     if send:
@@ -405,39 +585,55 @@ def report(obj, job_name, sender_name, sender_email, recipient_email,
             smtp_server=smtp_server,
             smtp_port=smtp_port,
             recipient_email=recipient_email,
-            message=email_report.render("nightly_report")
+            message=email_report.render("nightly_report"),
         )
     else:
         output.write(email_report.render("nightly_report"))
 
 
 @crossbow.command()
-@click.argument('job-name', required=True)
-@click.option('--send/--dry-run', default=False,
-              help='Just display the report, don\'t send it')
-@click.option('--webhook', '-w',
-              help='Zulip/Slack Webhook address to send the report to')
-@click.option('--extra-message-success', '-s', default=None,
-              help='Extra message, will be appended if no failures.')
-@click.option('--extra-message-failure', '-f', default=None,
-              help='Extra message, will be appended if there are failures.')
-@click.option('--fetch/--no-fetch', default=True,
-              help='Fetch references (branches and tags) from the remote')
+@click.argument("job-name", required=True)
+@click.option(
+    "--send/--dry-run", default=False, help="Just display the report, don't send it"
+)
+@click.option(
+    "--webhook", "-w", help="Zulip/Slack Webhook address to send the report to"
+)
+@click.option(
+    "--extra-message-success",
+    "-s",
+    default=None,
+    help="Extra message, will be appended if no failures.",
+)
+@click.option(
+    "--extra-message-failure",
+    "-f",
+    default=None,
+    help="Extra message, will be appended if there are failures.",
+)
+@click.option(
+    "--fetch/--no-fetch",
+    default=True,
+    help="Fetch references (branches and tags) from the remote",
+)
 @click.pass_obj
-def report_chat(obj, job_name, send, webhook, extra_message_success,
-                extra_message_failure, fetch):
+def report_chat(
+    obj, job_name, send, webhook, extra_message_success, extra_message_failure, fetch
+):
     """Send a chat report to a webhook showing success/failure
     of tasks in a Crossbow run.
     """
-    output = obj['output']
-    queue = obj['queue']
+    output = obj["output"]
+    queue = obj["queue"]
     if fetch:
         queue.fetch()
 
     job = queue.get(job_name)
-    report_chat = ChatReport(report=Report(job),
-                             extra_message_success=extra_message_success,
-                             extra_message_failure=extra_message_failure)
+    report_chat = ChatReport(
+        report=Report(job),
+        extra_message_success=extra_message_success,
+        extra_message_failure=extra_message_failure,
+    )
     if send:
         ReportUtils.send_message(webhook, report_chat.render("text"))
     else:
@@ -445,18 +641,22 @@ def report_chat(obj, job_name, send, webhook, extra_message_success,
 
 
 @crossbow.command()
-@click.argument('job-name', required=True)
-@click.option('--save/--dry-run', default=False,
-              help='Just display the report, don\'t save it')
-@click.option('--fetch/--no-fetch', default=True,
-              help='Fetch references (branches and tags) from the remote')
+@click.argument("job-name", required=True)
+@click.option(
+    "--save/--dry-run", default=False, help="Just display the report, don't save it"
+)
+@click.option(
+    "--fetch/--no-fetch",
+    default=True,
+    help="Fetch references (branches and tags) from the remote",
+)
 @click.pass_obj
 def report_csv(obj, job_name, save, fetch):
     """Generates a CSV report with the different tasks information
     from a Crossbow run.
     """
-    output = obj['output']
-    queue = obj['queue']
+    output = obj["output"]
+    queue = obj["queue"]
     if fetch:
         queue.fetch()
 
@@ -469,27 +669,45 @@ def report_csv(obj, job_name, save, fetch):
 
 
 @crossbow.command()
-@click.argument('job-name', required=True)
-@click.option('-t', '--target-dir',
-              default=_default_arrow_path / 'packages',
-              type=click.Path(file_okay=False, dir_okay=True),
-              help='Directory to download the build artifacts')
-@click.option('--dry-run/--execute', default=False,
-              help='Just display process, don\'t download anything')
-@click.option('--fetch/--no-fetch', default=True,
-              help='Fetch references (branches and tags) from the remote')
-@click.option('--task-filter', '-f', 'task_filters', multiple=True,
-              help='Glob pattern for filtering relevant tasks')
-@click.option('--validate-patterns/--skip-pattern-validation', default=True,
-              help='Whether to validate artifact name patterns or not')
+@click.argument("job-name", required=True)
+@click.option(
+    "-t",
+    "--target-dir",
+    default=_default_arrow_path / "packages",
+    type=click.Path(file_okay=False, dir_okay=True),
+    help="Directory to download the build artifacts",
+)
+@click.option(
+    "--dry-run/--execute",
+    default=False,
+    help="Just display process, don't download anything",
+)
+@click.option(
+    "--fetch/--no-fetch",
+    default=True,
+    help="Fetch references (branches and tags) from the remote",
+)
+@click.option(
+    "--task-filter",
+    "-f",
+    "task_filters",
+    multiple=True,
+    help="Glob pattern for filtering relevant tasks",
+)
+@click.option(
+    "--validate-patterns/--skip-pattern-validation",
+    default=True,
+    help="Whether to validate artifact name patterns or not",
+)
 @click.pass_obj
-def download_artifacts(obj, job_name, target_dir, dry_run, fetch,
-                       validate_patterns, task_filters):
+def download_artifacts(
+    obj, job_name, target_dir, dry_run, fetch, validate_patterns, task_filters
+):
     """Download build artifacts from GitHub releases"""
-    output = obj['output']
+    output = obj["output"]
 
     # fetch the queue repository
-    queue = obj['queue']
+    queue = obj["queue"]
     if fetch:
         queue.fetch()
 
@@ -515,6 +733,7 @@ def download_artifacts(obj, job_name, target_dir, dry_run, fetch,
 
             if need_download():
                 import github3
+
                 max_n_retries = 5
                 n_retries = 0
                 while True:
@@ -525,45 +744,50 @@ def download_artifacts(obj, job_name, target_dir, dry_run, fetch,
                         if n_retries == max_n_retries:
                             raise
                         wait_seconds = 60
-                        click.echo(f'Failed to download {path}')
-                        click.echo(f'Retry #{n_retries} after {wait_seconds}s')
+                        click.echo(f"Failed to download {path}")
+                        click.echo(f"Retry #{n_retries} after {wait_seconds}s")
                         click.echo(error)
                         time.sleep(wait_seconds)
                     else:
                         break
 
-    click.echo(f'Downloading {job_name}\'s artifacts.')
-    click.echo(f'Destination directory is {target_dir}')
+    click.echo(f"Downloading {job_name}'s artifacts.")
+    click.echo(f"Destination directory is {target_dir}")
     click.echo()
 
     report = ConsoleReport(job, task_filters=task_filters)
     report.show(
-        output,
-        asset_callback=asset_callback,
-        validate_patterns=validate_patterns
+        output, asset_callback=asset_callback, validate_patterns=validate_patterns
     )
 
 
 @crossbow.command()
-@click.argument('patterns', nargs=-1, required=True)
-@click.option('--sha', required=True, help='Target committish')
-@click.option('--tag', required=True, help='Target tag')
-@click.option('--method', default='curl', help='Use cURL to upload')
+@click.argument("patterns", nargs=-1, required=True)
+@click.option("--sha", required=True, help="Target committish")
+@click.option("--tag", required=True, help="Target tag")
+@click.option("--method", default="curl", help="Use cURL to upload")
 @click.pass_obj
 def upload_artifacts(obj, tag, sha, patterns, method):
-    queue = obj['queue']
+    queue = obj["queue"]
     queue.github_overwrite_release_assets(
         tag_name=tag, target_commitish=sha, method=method, patterns=patterns
     )
 
 
 @crossbow.command()
-@click.option('--dry-run/--execute', default=False,
-              help='Just display process, don\'t download anything')
-@click.option('--days', default=90,
-              help='Branches older than this amount of days will be deleted')
-@click.option('--maximum', default=1000,
-              help='Maximum limit of branches to delete for a single run')
+@click.option(
+    "--dry-run/--execute",
+    default=False,
+    help="Just display process, don't download anything",
+)
+@click.option(
+    "--days", default=90, help="Branches older than this amount of days will be deleted"
+)
+@click.option(
+    "--maximum",
+    default=1000,
+    help="Maximum limit of branches to delete for a single run",
+)
 @click.pass_obj
 def delete_old_branches(obj, dry_run, days, maximum):
     """Deletes branches on queue repository (crossbow) that are older than number
@@ -571,13 +795,14 @@ def delete_old_branches(obj, dry_run, days, maximum):
     With a maximum number of branches to be deleted. This is required to avoid
     triggering GitHub protection limits.
     """
-    queue = obj['queue']
+    queue = obj["queue"]
     ts = time.time() - days * 24 * 3600
     refs = []
     for ref in queue.repo.listall_reference_objects():
         commit = ref.peel()
         if commit.commit_time < ts and not ref.name.startswith(
-                "refs/remotes/origin/pr/"):
+            "refs/remotes/origin/pr/"
+        ):
             # Check if reference is a remote reference to point
             # to the remote head.
             ref_name = ref.name
@@ -590,7 +815,7 @@ def delete_old_branches(obj, dry_run, days, maximum):
         to_delete = min(total_length, maximum)
         print(f"Total number of references to be deleted: {to_delete}")
         for index in range(0, to_delete, step):
-            yield iterable[index:min(index + step, to_delete)]
+            yield iterable[index : min(index + step, to_delete)]
 
     for batch in batch_gen(refs, 50):
         if not dry_run:
@@ -600,33 +825,45 @@ def delete_old_branches(obj, dry_run, days, maximum):
 
 
 @crossbow.command()
-@click.option('--days', default=30,
-              help='Notification will be sent if expiration date is '
-                   'closer than the number of days.')
-@click.option('--sender-name', '-n',
-              help='Name to use for report e-mail.')
-@click.option('--sender-email', '-e',
-              help='E-mail to use for report e-mail.')
-@click.option('--recipient-email', '-r',
-              help='Where to send the e-mail report')
-@click.option('--smtp-user', '-u',
-              help='E-mail address to use for SMTP login')
-@click.option('--smtp-password', '-P',
-              help='SMTP password to use for report e-mail.')
-@click.option('--smtp-server', '-s', default='smtp.gmail.com',
-              help='SMTP server to use for report e-mail.')
-@click.option('--smtp-port', '-p', default=465,
-              help='SMTP port to use for report e-mail.')
-@click.option('--send/--dry-run', default=False,
-              help='Just display the report, don\'t send it')
+@click.option(
+    "--days",
+    default=30,
+    help="Notification will be sent if expiration date is "
+    "closer than the number of days.",
+)
+@click.option("--sender-name", "-n", help="Name to use for report e-mail.")
+@click.option("--sender-email", "-e", help="E-mail to use for report e-mail.")
+@click.option("--recipient-email", "-r", help="Where to send the e-mail report")
+@click.option("--smtp-user", "-u", help="E-mail address to use for SMTP login")
+@click.option("--smtp-password", "-P", help="SMTP password to use for report e-mail.")
+@click.option(
+    "--smtp-server",
+    "-s",
+    default="smtp.gmail.com",
+    help="SMTP server to use for report e-mail.",
+)
+@click.option(
+    "--smtp-port", "-p", default=465, help="SMTP port to use for report e-mail."
+)
+@click.option(
+    "--send/--dry-run", default=False, help="Just display the report, don't send it"
+)
 @click.pass_obj
-def notify_token_expiration(obj, days, sender_name, sender_email,
-                            recipient_email, smtp_user, smtp_password,
-                            smtp_server, smtp_port, send):
-    """Check if token is close to expiration and send email notifying.
-    """
-    output = obj['output']
-    queue = obj['queue']
+def notify_token_expiration(
+    obj,
+    days,
+    sender_name,
+    sender_email,
+    recipient_email,
+    smtp_user,
+    smtp_password,
+    smtp_server,
+    smtp_port,
+    send,
+):
+    """Check if token is close to expiration and send email notifying."""
+    output = obj["output"]
+    queue = obj["queue"]
 
     token_expiration_date = queue.token_expiration_date()
     days_left = 0
@@ -645,10 +882,11 @@ def notify_token_expiration(obj, days, sender_name, sender_email,
 
     email_report = EmailReport(
         report=TokenExpirationReport(
-            token_expiration_date or "ALREADY_EXPIRED", days_left),
+            token_expiration_date or "ALREADY_EXPIRED", days_left
+        ),
         sender_name=sender_name,
         sender_email=sender_email,
-        recipient_email=recipient_email
+        recipient_email=recipient_email,
     )
 
     message = email_report.render("token_expiration").strip()
@@ -659,7 +897,7 @@ def notify_token_expiration(obj, days, sender_name, sender_email,
             smtp_server=smtp_server,
             smtp_port=smtp_port,
             recipient_email=recipient_email,
-            message=message
+            message=message,
         )
     else:
         output.write(message)

--- a/dev/archery/archery/crossbow/cli.py
+++ b/dev/archery/archery/crossbow/cli.py
@@ -210,8 +210,7 @@ def verify_release_candidate(obj, base_branch, create_pr,
             if flag:
                 job_groups += f" --group {group}"
         response.create_comment(
-            f"{command} {job_groups} --param " +
-            f"release={version} --param rc={rc}")
+            f"{command} {job_groups} --param release={version} --param rc={rc}")
 
 
 @crossbow.command()
@@ -511,9 +510,7 @@ def download_artifacts(obj, job_name, target_dir, dry_run, fetch,
                     return False
                 if not path.exists():
                     return True
-                if path.stat().st_size != asset.size:
-                    return True
-                return False
+                return path.stat().st_size != asset.size
 
             if need_download():
                 import github3
@@ -637,8 +634,9 @@ def notify_token_expiration(obj, days, sender_name, sender_email,
     if token_expiration_date:
         days_left = (token_expiration_date - date.today()).days
         if days_left > days:
-            output.write("Notification not sent. " +
-                         f"Token will expire in {days_left} days.")
+            output.write(
+                f"Notification not sent. Token will expire in {days_left} days."
+            )
             return
 
     class TokenExpirationReport:

--- a/dev/archery/archery/crossbow/reports.py
+++ b/dev/archery/archery/crossbow/reports.py
@@ -120,7 +120,7 @@ class Report:
                 task.ci,
                 # We want this to be serialized as a dict instead
                 # of an orderedict.
-                {k: v for k, v in task.params.items()},
+                dict(task.params.items()),
                 task.template,
                 # Arrow repository commit
                 self.job.target.head

--- a/dev/archery/archery/crossbow/reports.py
+++ b/dev/archery/archery/crossbow/reports.py
@@ -14,12 +14,13 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
 import collections
 import csv
-import operator
 import fnmatch
 import functools
+import operator
 import time
 
 import click
@@ -62,10 +63,10 @@ class Report:
         return url[:-4] if url.endswith('.git') else url
 
     def url(self, query):
-        return '{}/branches/all?query={}'.format(self.repo_url, query)
+        return f'{self.repo_url}/branches/all?query={query}'
 
     def branch_url(self, branch):
-        return '{}/tree/{}'.format(self.repo_url, branch)
+        return f'{self.repo_url}/tree/{branch}'
 
     def task_url(self, task):
         build_links = task.status().build_links
@@ -105,8 +106,7 @@ class Report:
 
     @property
     def rows(self):
-        """
-        Produces a generator that allow us to iterate over
+        """Produces a generator that allow us to iterate over
         the job tasks as a list of rows.
         Row headers are defined at Report.ROW_HEADERS.
         """
@@ -155,7 +155,7 @@ class ConsoleReport(Report):
         line = self.HEADER.format(
             state=state.upper(),
             branch=branch,
-            content='uploaded {} / {}'.format(n_uploaded, n_expected)
+            content=f'uploaded {n_uploaded} / {n_expected}'
         )
         return click.style(line, fg=self.COLORS[state.lower()])
 
@@ -166,7 +166,7 @@ class ConsoleReport(Report):
             content='Artifacts'
         )
         delimiter = '-' * len(header)
-        return '{}\n{}'.format(header, delimiter)
+        return f'{header}\n{delimiter}'
 
     def artifact(self, state, pattern, asset):
         if asset is None:
@@ -324,9 +324,9 @@ class CommentReport(Report):
         url = 'https://github.com/{repo}/branches/all?query={branch}'
         sha = self.job.target.head
 
-        msg = 'Revision: {}\n\n'.format(sha)
+        msg = f'Revision: {sha}\n\n'
         msg += 'Submitted crossbow builds: [{repo} @ {branch}]'
-        msg += '({})\n'.format(url)
+        msg += f'({url})\n'
         msg += '\n|Task|Status|\n|----|------|'
 
         tasks = sorted(self.job.tasks.items(), key=operator.itemgetter(0))
@@ -342,8 +342,8 @@ class CommentReport(Report):
                     url=self.task_url(task)
                 )
             except KeyError:
-                badge = 'unsupported CI service `{}`'.format(task.ci)
+                badge = f'unsupported CI service `{task.ci}`'
 
-            msg += '\n|{}|{}|'.format(key, badge)
+            msg += f'\n|{key}|{badge}|'
 
         return msg.format(repo=self.crossbow_repo, branch=self.job.branch)

--- a/dev/archery/archery/crossbow/tests/test_core.py
+++ b/dev/archery/archery/crossbow/tests/test_core.py
@@ -30,8 +30,9 @@ def test_config():
 
 
 def test_task_select(request):
-    conf = Config.load_yaml(pathlib.Path(
-        request.node.fspath).parent / "fixtures" / "tasks.yaml")
+    conf = Config.load_yaml(
+        pathlib.Path(request.node.fspath).parent / "fixtures" / "tasks.yaml"
+    )
     conf.validate()
 
     test_out = conf.select(tasks=["test-a-test-two"])
@@ -39,8 +40,9 @@ def test_task_select(request):
 
 
 def test_group_select(request):
-    conf = Config.load_yaml(pathlib.Path(
-        request.node.fspath).parent / "fixtures" / "tasks.yaml")
+    conf = Config.load_yaml(
+        pathlib.Path(request.node.fspath).parent / "fixtures" / "tasks.yaml"
+    )
     conf.validate()
 
     test_out = conf.select(groups=["test"])
@@ -48,8 +50,9 @@ def test_group_select(request):
 
 
 def test_group_select_blocklist(request):
-    conf = Config.load_yaml(pathlib.Path(
-        request.node.fspath).parent / "fixtures" / "tasks.yaml")
+    conf = Config.load_yaml(
+        pathlib.Path(request.node.fspath).parent / "fixtures" / "tasks.yaml"
+    )
     conf.validate()
 
     # we respect the nightly blocklist
@@ -58,19 +61,22 @@ def test_group_select_blocklist(request):
 
     # but if a task is not blocked in both groups, it shows up at least once
     test_nightly_out = conf.select(groups=["nightly", "test"])
-    assert test_nightly_out.keys() >= {
-        "test-a-test-two", "test-a-test", "nightly-fine"}
+    assert test_nightly_out.keys() >= {"test-a-test-two", "test-a-test", "nightly-fine"}
 
     # but can then over-ride by requesting the task
     test_nightly_out = conf.select(
-        tasks=["nightly-not-fine", "nightly-fine"], groups=["nightly", "test"])
+        tasks=["nightly-not-fine", "nightly-fine"], groups=["nightly", "test"]
+    )
     assert test_nightly_out.keys() >= {
-        "test-a-test-two", "test-a-test", "nightly-fine", "nightly-not-fine"}
+        "test-a-test-two",
+        "test-a-test",
+        "nightly-fine",
+        "nightly-not-fine",
+    }
 
     # and we can glob with the blocklist too!
     test_nightly_no_test_out = conf.select(groups=["nightly-no-test"])
-    assert test_nightly_no_test_out.keys(
-    ) >= {"nightly-fine", "nightly-not-fine"}
+    assert test_nightly_no_test_out.keys() >= {"nightly-fine", "nightly-not-fine"}
 
 
 def test_latest_for_prefix(request):
@@ -82,8 +88,7 @@ def test_latest_for_prefix(request):
         ]
         with mock.patch("archery.crossbow.core.Queue.get") as mocked_get:
             queue.latest_for_prefix("nightly-packaging-2022-04-10")
-            mocked_get.assert_called_once_with(
-                "nightly-packaging-2022-04-10-0")
+            mocked_get.assert_called_once_with("nightly-packaging-2022-04-10-0")
 
     with mock.patch("archery.crossbow.core.Repo.repo") as mocked_repo:
         mocked_repo.branches = [
@@ -92,5 +97,4 @@ def test_latest_for_prefix(request):
         ]
         with mock.patch("archery.crossbow.core.Queue.get") as mocked_get:
             queue.latest_for_prefix("nightly-packaging")
-            mocked_get.assert_called_once_with(
-                "nightly-packaging-2022-04-11-0")
+            mocked_get.assert_called_once_with("nightly-packaging-2022-04-11-0")

--- a/dev/archery/archery/crossbow/tests/test_core.py
+++ b/dev/archery/archery/crossbow/tests/test_core.py
@@ -14,12 +14,13 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
-from archery.utils.source import ArrowSources
-from archery.crossbow import Config, Queue
+from __future__ import annotations
 
 import pathlib
 from unittest import mock
+
+from archery.crossbow import Config, Queue
+from archery.utils.source import ArrowSources
 
 
 def test_config():

--- a/dev/archery/archery/crossbow/tests/test_crossbow_cli.py
+++ b/dev/archery/archery/crossbow/tests/test_crossbow_cli.py
@@ -28,17 +28,17 @@ def test_crossbow_submit(tmp_path):
     runner = CliRunner()
 
     def invoke(*args):
-        return runner.invoke(crossbow, ['--queue-path', str(tmp_path), *args])
+        return runner.invoke(crossbow, ["--queue-path", str(tmp_path), *args])
 
     # initialize an empty crossbow repository
     git.run_cmd("init", str(tmp_path))
-    git.run_cmd("-C", str(tmp_path), "remote", "add", "origin",
-                "https://github.com/dummy/repo")
-    git.run_cmd("-C", str(tmp_path), "commit", "-m", "initial",
-                "--allow-empty")
+    git.run_cmd(
+        "-C", str(tmp_path), "remote", "add", "origin", "https://github.com/dummy/repo"
+    )
+    git.run_cmd("-C", str(tmp_path), "commit", "-m", "initial", "--allow-empty")
 
-    result = invoke('check-config')
+    result = invoke("check-config")
     assert result.exit_code == 0
 
-    result = invoke('submit', '--no-fetch', '--no-push', '-g', 'wheel')
+    result = invoke("submit", "--no-fetch", "--no-push", "-g", "wheel")
     assert result.exit_code == 0

--- a/dev/archery/archery/crossbow/tests/test_crossbow_cli.py
+++ b/dev/archery/archery/crossbow/tests/test_crossbow_cli.py
@@ -14,9 +14,10 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
-from click.testing import CliRunner
 import pytest
+from click.testing import CliRunner
 
 from archery.crossbow.cli import crossbow
 from archery.utils.git import git

--- a/dev/archery/archery/crossbow/tests/test_reports.py
+++ b/dev/archery/archery/crossbow/tests/test_reports.py
@@ -14,12 +14,12 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
 import textwrap
 
 from archery.crossbow.core import yaml
-from archery.crossbow.reports import (ChatReport, CommentReport, EmailReport,
-                                      Report)
+from archery.crossbow.reports import ChatReport, CommentReport, EmailReport, Report
 
 
 def test_crossbow_comment_formatter(load_fixture):

--- a/dev/archery/archery/crossbow/tests/test_reports.py
+++ b/dev/archery/archery/crossbow/tests/test_reports.py
@@ -23,82 +23,91 @@ from archery.crossbow.reports import ChatReport, CommentReport, EmailReport, Rep
 
 
 def test_crossbow_comment_formatter(load_fixture):
-    msg = load_fixture('crossbow-success-message.md')
-    job = load_fixture('crossbow-job.yaml', decoder=yaml.load)
+    msg = load_fixture("crossbow-success-message.md")
+    job = load_fixture("crossbow-job.yaml", decoder=yaml.load)
 
-    report = CommentReport(job, crossbow_repo='ursa-labs/crossbow')
+    report = CommentReport(job, crossbow_repo="ursa-labs/crossbow")
     expected = msg.format(
-        repo='ursa-labs/crossbow',
-        branch='ursabot-1',
-        revision='f766a1d615dd1b7ee706d05102e579195951a61c',
-        status='has been succeeded.'
+        repo="ursa-labs/crossbow",
+        branch="ursabot-1",
+        revision="f766a1d615dd1b7ee706d05102e579195951a61c",
+        status="has been succeeded.",
     )
     assert report.show() == textwrap.dedent(expected).strip()
 
 
 def test_crossbow_chat_report(load_fixture):
-    expected_msg = load_fixture('chat-report.txt')
-    job = load_fixture('crossbow-job.yaml', decoder=yaml.load)
+    expected_msg = load_fixture("chat-report.txt")
+    job = load_fixture("crossbow-job.yaml", decoder=yaml.load)
     report = Report(job)
     assert report.tasks_by_state is not None
-    report_chat = ChatReport(report=report, extra_message_success=None,
-                             extra_message_failure=None)
+    report_chat = ChatReport(
+        report=report, extra_message_success=None, extra_message_failure=None
+    )
 
     assert report_chat.render("text") == textwrap.dedent(expected_msg)
 
 
 def test_crossbow_chat_report_extra_message_failure(load_fixture):
-    expected_msg = load_fixture('chat-report-extra-message-failure.txt')
-    job = load_fixture('crossbow-job.yaml', decoder=yaml.load)
+    expected_msg = load_fixture("chat-report-extra-message-failure.txt")
+    job = load_fixture("crossbow-job.yaml", decoder=yaml.load)
     report = Report(job)
     assert report.tasks_by_state is not None
-    report_chat = ChatReport(report=report,
-                             extra_message_success="Should not be present",
-                             extra_message_failure="Failure present")
+    report_chat = ChatReport(
+        report=report,
+        extra_message_success="Should not be present",
+        extra_message_failure="Failure present",
+    )
 
     assert report_chat.render("text") == textwrap.dedent(expected_msg)
 
 
 def test_crossbow_chat_report_extra_message_success(load_fixture):
-    expected_msg = load_fixture('chat-report-extra-message-success.txt')
-    job = load_fixture('crossbow-job-no-failure.yaml', decoder=yaml.load)
+    expected_msg = load_fixture("chat-report-extra-message-success.txt")
+    job = load_fixture("crossbow-job-no-failure.yaml", decoder=yaml.load)
     report = Report(job)
     assert report.tasks_by_state is not None
-    report_chat = ChatReport(report=report,
-                             extra_message_success="Success present",
-                             extra_message_failure="Should not be present")
+    report_chat = ChatReport(
+        report=report,
+        extra_message_success="Success present",
+        extra_message_failure="Should not be present",
+    )
 
     assert report_chat.render("text") == textwrap.dedent(expected_msg)
 
 
 def test_crossbow_email_report(load_fixture):
-    expected_msg = load_fixture('email-report.txt')
-    job = load_fixture('crossbow-job.yaml', decoder=yaml.load)
+    expected_msg = load_fixture("email-report.txt")
+    job = load_fixture("crossbow-job.yaml", decoder=yaml.load)
     report = Report(job)
     assert report.tasks_by_state is not None
-    email_report = EmailReport(report=report, sender_name="Sender Reporter",
-                               sender_email="sender@arrow.com",
-                               recipient_email="recipient@arrow.com")
-
-    assert (
-        email_report.render("nightly_report") == textwrap.dedent(expected_msg)
+    email_report = EmailReport(
+        report=report,
+        sender_name="Sender Reporter",
+        sender_email="sender@arrow.com",
+        recipient_email="recipient@arrow.com",
     )
+
+    assert email_report.render("nightly_report") == textwrap.dedent(expected_msg)
 
 
 def test_crossbow_export_report(load_fixture):
-    job = load_fixture('crossbow-job.yaml', decoder=yaml.load)
+    job = load_fixture("crossbow-job.yaml", decoder=yaml.load)
     report = Report(job)
     assert len(list(report.rows)) == 4
     expected_first_row = [
-        'docker-cpp-cmake32',
-        'success',
-        ['https://github.com/apache/crossbow/runs/1'],
-        'https://github.com/apache/crossbow/tree/'
-        'ursabot-1-circle-docker-cpp-cmake32',
-        'circle',
-        {'commands': ['docker compose build cpp-cmake32',
-                      'docker compose run cpp-cmake32']},
-        'docker-tests/circle.linux.yml',
-        'f766a1d615dd1b7ee706d05102e579195951a61c'
+        "docker-cpp-cmake32",
+        "success",
+        ["https://github.com/apache/crossbow/runs/1"],
+        "https://github.com/apache/crossbow/tree/ursabot-1-circle-docker-cpp-cmake32",
+        "circle",
+        {
+            "commands": [
+                "docker compose build cpp-cmake32",
+                "docker compose run cpp-cmake32",
+            ]
+        },
+        "docker-tests/circle.linux.yml",
+        "f766a1d615dd1b7ee706d05102e579195951a61c",
     ]
     assert next(report.rows) == expected_first_row

--- a/dev/archery/archery/docker/__init__.py
+++ b/dev/archery/archery/docker/__init__.py
@@ -15,4 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from .core import DockerCompose, UndefinedImage  # noqa
+from .core import DockerCompose, UndefinedImage
+
+__all__ = ["DockerCompose", "UndefinedImage"]

--- a/dev/archery/archery/docker/__init__.py
+++ b/dev/archery/archery/docker/__init__.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
 from .core import DockerCompose, UndefinedImage
 

--- a/dev/archery/archery/docker/cli.py
+++ b/dev/archery/archery/docker/cli.py
@@ -32,46 +32,70 @@ def _mock_compose_calls(compose):
 
     def _mock(compose, command_tuple):
         def _execute(self, *args, **kwargs):
-            params = [f'{k}={v}'
-                      for k, v in self.config.params.items()]
-            command = ' '.join(params + command_tuple + args)
+            params = [f"{k}={v}" for k, v in self.config.params.items()]
+            command = " ".join(params + command_tuple + args)
             click.echo(command)
             return CompletedProcess([], 0)
+
         return MethodType(_execute, compose)
 
-    compose._execute_docker = _mock(compose, command_tuple=('docker',))
-    compose._execute_compose = _mock(compose, command_tuple=('docker', 'compose'))
+    compose._execute_docker = _mock(compose, command_tuple=("docker",))
+    compose._execute_compose = _mock(compose, command_tuple=("docker", "compose"))
 
 
 @click.group()
-@click.option("--src", metavar="<arrow_src>", default=None,
-              callback=validate_arrow_sources,
-              help="Specify Arrow source directory.")
-@click.option('--dry-run/--execute', default=False,
-              help="Display the docker commands instead of executing them.")
-@click.option('--using-legacy-docker-compose', default=False, is_flag=True,
-              envvar='ARCHERY_USE_LEGACY_DOCKER_COMPOSE',
-              help="Use legacy docker-compose utility instead of the built-in "
-                   "`docker compose` subcommand. This may be necessary if the "
-                   "Docker client is too old for some options.")
-@click.option('--using-docker-cli', default=False, is_flag=True,
-              envvar='ARCHERY_USE_DOCKER_CLI',
-              help="Use docker CLI directly for building instead of calling "
-                   "`docker compose`. This may help to reuse cached layers.")
-@click.option('--using-docker-buildx', default=False, is_flag=True,
-              envvar='ARCHERY_USE_DOCKER_BUILDX',
-              help="Use buildx with docker CLI directly for building instead "
-                   "of calling `docker compose` or the plain docker build "
-                   "command. This option makes the build cache reusable "
-                   "across hosts.")
+@click.option(
+    "--src",
+    metavar="<arrow_src>",
+    default=None,
+    callback=validate_arrow_sources,
+    help="Specify Arrow source directory.",
+)
+@click.option(
+    "--dry-run/--execute",
+    default=False,
+    help="Display the docker commands instead of executing them.",
+)
+@click.option(
+    "--using-legacy-docker-compose",
+    default=False,
+    is_flag=True,
+    envvar="ARCHERY_USE_LEGACY_DOCKER_COMPOSE",
+    help="Use legacy docker-compose utility instead of the built-in "
+    "`docker compose` subcommand. This may be necessary if the "
+    "Docker client is too old for some options.",
+)
+@click.option(
+    "--using-docker-cli",
+    default=False,
+    is_flag=True,
+    envvar="ARCHERY_USE_DOCKER_CLI",
+    help="Use docker CLI directly for building instead of calling "
+    "`docker compose`. This may help to reuse cached layers.",
+)
+@click.option(
+    "--using-docker-buildx",
+    default=False,
+    is_flag=True,
+    envvar="ARCHERY_USE_DOCKER_BUILDX",
+    help="Use buildx with docker CLI directly for building instead "
+    "of calling `docker compose` or the plain docker build "
+    "command. This option makes the build cache reusable "
+    "across hosts.",
+)
 @click.pass_context
-def docker(ctx, src, dry_run, using_legacy_docker_compose, using_docker_cli,
-           using_docker_buildx):
-    """Interact with Docker Compose based builds.
-    """
+def docker(
+    ctx,
+    src,
+    dry_run,
+    using_legacy_docker_compose,
+    using_docker_cli,
+    using_docker_buildx,
+):
+    """Interact with Docker Compose based builds."""
     ctx.ensure_object(dict)
 
-    config_path = src.path / 'docker-compose.yml'
+    config_path = src.path / "docker-compose.yml"
     if not config_path.exists():
         raise click.ClickException(
             f"Docker compose configuration cannot be found in directory {src}, "
@@ -81,116 +105,160 @@ def docker(ctx, src, dry_run, using_legacy_docker_compose, using_docker_cli,
     # take the Docker Compose parameters like PYTHON, PANDAS, UBUNTU from the
     # environment variables to keep the usage similar to docker compose
     using_docker_cli |= using_docker_buildx
-    compose_bin = ("docker-compose" if using_legacy_docker_compose
-                   else "docker compose")
+    compose_bin = "docker-compose" if using_legacy_docker_compose else "docker compose"
     with group("Docker: Prepare"):
-        compose = DockerCompose(config_path, params=os.environ,
-                                using_docker=using_docker_cli,
-                                using_buildx=using_docker_buildx,
-                                debug=ctx.obj.get('debug', False),
-                                compose_bin=compose_bin)
+        compose = DockerCompose(
+            config_path,
+            params=os.environ,
+            using_docker=using_docker_cli,
+            using_buildx=using_docker_buildx,
+            debug=ctx.obj.get("debug", False),
+            compose_bin=compose_bin,
+        )
     if dry_run:
         _mock_compose_calls(compose)
-    ctx.obj['compose'] = compose
+    ctx.obj["compose"] = compose
 
 
 @docker.command("check-config")
 @click.pass_obj
 def check_config(obj):
-    """Validate Docker Compose configuration.
-    """
+    """Validate Docker Compose configuration."""
     # executes the body of the docker function above which does the validation
     # during the configuration loading
 
 
-@docker.command('pull')
-@click.argument('image')
-@click.option('--pull-leaf/--no-leaf', default=True,
-              help="Whether to pull leaf images too.")
-@click.option('--ignore-pull-failures/--no-ignore-pull-failures', default=True,
-              help="Whether to ignore pull failures.")
+@docker.command("pull")
+@click.argument("image")
+@click.option(
+    "--pull-leaf/--no-leaf", default=True, help="Whether to pull leaf images too."
+)
+@click.option(
+    "--ignore-pull-failures/--no-ignore-pull-failures",
+    default=True,
+    help="Whether to ignore pull failures.",
+)
 @click.pass_obj
 def docker_pull(obj, image, *, pull_leaf, ignore_pull_failures):
-    """Execute docker compose pull.
-    """
-    compose = obj['compose']
+    """Execute docker compose pull."""
+    compose = obj["compose"]
 
     try:
-        compose.pull(image, pull_leaf=pull_leaf,
-                     ignore_pull_failures=ignore_pull_failures)
+        compose.pull(
+            image, pull_leaf=pull_leaf, ignore_pull_failures=ignore_pull_failures
+        )
     except UndefinedImage as e:
         raise click.ClickException(
-            "There is no service/image defined in docker-compose.yml with "
-            f"name: {e!s}"
+            f"There is no service/image defined in docker-compose.yml with name: {e!s}"
         )
     except RuntimeError as e:
         raise click.ClickException(str(e))
 
 
-@docker.command('build')
-@click.argument('image')
-@click.option('--force-pull/--no-pull', default=True,
-              help="Whether to force pull the image and its ancestor images")
-@click.option('--use-cache/--no-cache', default=True,
-              help="Whether to use cache when building the image and its "
-                   "ancestor images")
-@click.option('--use-leaf-cache/--no-leaf-cache', default=True,
-              help="Whether to use cache when building only the (leaf) image "
-                   "passed as the argument. To disable caching for both the "
-                   "image and its ancestors use --no-cache option.")
+@docker.command("build")
+@click.argument("image")
+@click.option(
+    "--force-pull/--no-pull",
+    default=True,
+    help="Whether to force pull the image and its ancestor images",
+)
+@click.option(
+    "--use-cache/--no-cache",
+    default=True,
+    help="Whether to use cache when building the image and its ancestor images",
+)
+@click.option(
+    "--use-leaf-cache/--no-leaf-cache",
+    default=True,
+    help="Whether to use cache when building only the (leaf) image "
+    "passed as the argument. To disable caching for both the "
+    "image and its ancestors use --no-cache option.",
+)
 @click.pass_obj
 def docker_build(obj, image, *, force_pull, use_cache, use_leaf_cache):
-    """Execute Docker Compose builds.
-    """
-    compose = obj['compose']
+    """Execute Docker Compose builds."""
+    compose = obj["compose"]
 
     try:
         if force_pull:
             compose.pull(image, pull_leaf=use_leaf_cache)
-        compose.build(image, use_cache=use_cache,
-                      use_leaf_cache=use_leaf_cache,
-                      pull_parents=force_pull)
+        compose.build(
+            image,
+            use_cache=use_cache,
+            use_leaf_cache=use_leaf_cache,
+            pull_parents=force_pull,
+        )
     except UndefinedImage as e:
         raise click.ClickException(
-            "There is no service/image defined in docker-compose.yml with "
-            f"name: {e!s}"
+            f"There is no service/image defined in docker-compose.yml with name: {e!s}"
         )
     except RuntimeError as e:
         raise click.ClickException(str(e))
 
 
-@docker.command('run')
-@click.argument('image')
-@click.argument('command', required=False, default=None)
-@click.option('--env', '-e', multiple=True,
-              help="Set environment variable within the container")
-@click.option('--user', '-u', default=None,
-              help="Username or UID to run the container with")
-@click.option('--force-pull/--no-pull', default=True,
-              help="Whether to force pull the image and its ancestor images")
-@click.option('--force-build/--no-build', default=True,
-              help="Whether to force build the image and its ancestor images")
-@click.option('--build-only', default=False, is_flag=True,
-              help="Pull and/or build the image, but do not run it")
-@click.option('--use-cache/--no-cache', default=True,
-              help="Whether to use cache when building the image and its "
-                   "ancestor images")
-@click.option('--use-leaf-cache/--no-leaf-cache', default=True,
-              help="Whether to use cache when building only the (leaf) image "
-                   "passed as the argument. To disable caching for both the "
-                   "image and its ancestors use --no-cache option.")
-@click.option('--resource-limit', default=None,
-              help="A CPU/memory limit preset to mimic CI environments like "
-                   "GitHub Actions. Mandates --using-docker-cli. Note that "
-                   "exporting ARCHERY_DOCKER_BIN=\"sudo docker\" is likely "
-                   "required, unless Docker is configured with cgroups v2 "
-                   "(else Docker will silently ignore the limits).")
-@click.option('--volume', '-v', multiple=True,
-              help="Set volume within the container")
+@docker.command("run")
+@click.argument("image")
+@click.argument("command", required=False, default=None)
+@click.option(
+    "--env", "-e", multiple=True, help="Set environment variable within the container"
+)
+@click.option(
+    "--user", "-u", default=None, help="Username or UID to run the container with"
+)
+@click.option(
+    "--force-pull/--no-pull",
+    default=True,
+    help="Whether to force pull the image and its ancestor images",
+)
+@click.option(
+    "--force-build/--no-build",
+    default=True,
+    help="Whether to force build the image and its ancestor images",
+)
+@click.option(
+    "--build-only",
+    default=False,
+    is_flag=True,
+    help="Pull and/or build the image, but do not run it",
+)
+@click.option(
+    "--use-cache/--no-cache",
+    default=True,
+    help="Whether to use cache when building the image and its ancestor images",
+)
+@click.option(
+    "--use-leaf-cache/--no-leaf-cache",
+    default=True,
+    help="Whether to use cache when building only the (leaf) image "
+    "passed as the argument. To disable caching for both the "
+    "image and its ancestors use --no-cache option.",
+)
+@click.option(
+    "--resource-limit",
+    default=None,
+    help="A CPU/memory limit preset to mimic CI environments like "
+    "GitHub Actions. Mandates --using-docker-cli. Note that "
+    'exporting ARCHERY_DOCKER_BIN="sudo docker" is likely '
+    "required, unless Docker is configured with cgroups v2 "
+    "(else Docker will silently ignore the limits).",
+)
+@click.option("--volume", "-v", multiple=True, help="Set volume within the container")
 @click.pass_obj
-def docker_run(obj, image, command, *, env, user, force_pull, force_build,
-               build_only, use_cache, use_leaf_cache, resource_limit,
-               volume):
+def docker_run(
+    obj,
+    image,
+    command,
+    *,
+    env,
+    user,
+    force_pull,
+    force_build,
+    build_only,
+    use_cache,
+    use_leaf_cache,
+    resource_limit,
+    volume,
+):
     """Execute Docker Compose builds.
 
     To see the available builds run `archery docker images`.
@@ -221,17 +289,16 @@ def docker_run(obj, image, command, *, env, user, force_pull, force_build,
     # starting an interactive bash session for debugging
     archery docker run ubuntu-cpp bash
     """
-    compose = obj['compose']
+    compose = obj["compose"]
 
-    env = dict(kv.split('=', 1) for kv in env)
+    env = dict(kv.split("=", 1) for kv in env)
     try:
         if force_pull:
             with group("Docker: Pull"):
                 compose.pull(image, pull_leaf=use_leaf_cache)
         if force_build:
             with group("Docker: Build"):
-                compose.build(image, use_cache=use_cache,
-                              use_leaf_cache=use_leaf_cache)
+                compose.build(image, use_cache=use_cache, use_leaf_cache=use_leaf_cache)
         if build_only:
             return
         compose.run(
@@ -240,46 +307,58 @@ def docker_run(obj, image, command, *, env, user, force_pull, force_build,
             env=env,
             user=user,
             resource_limit=resource_limit,
-            volumes=volume
+            volumes=volume,
         )
     except UndefinedImage as e:
         raise click.ClickException(
-            "There is no service/image defined in docker-compose.yml with "
-            f"name: {e!s}"
+            f"There is no service/image defined in docker-compose.yml with name: {e!s}"
         )
     except RuntimeError as e:
         raise click.ClickException(str(e))
 
 
-@docker.command('push')
-@click.argument('image')
-@click.option('--user', '-u', required=False, envvar='ARCHERY_DOCKER_USER',
-              help='Docker repository username')
-@click.option('--password', '-p', required=False,
-              envvar='ARCHERY_DOCKER_PASSWORD',
-              help='Docker repository password')
+@docker.command("push")
+@click.argument("image")
+@click.option(
+    "--user",
+    "-u",
+    required=False,
+    envvar="ARCHERY_DOCKER_USER",
+    help="Docker repository username",
+)
+@click.option(
+    "--password",
+    "-p",
+    required=False,
+    envvar="ARCHERY_DOCKER_PASSWORD",
+    help="Docker repository password",
+)
 @click.pass_obj
 def docker_compose_push(obj, image, user, password):
     """Push the generated Docker Compose image."""
-    compose = obj['compose']
+    compose = obj["compose"]
     compose.push(image, user=user, password=password)
 
 
-@docker.command('images')
+@docker.command("images")
 @click.pass_obj
 def docker_compose_images(obj):
     """List the available Docker Compose images."""
-    compose = obj['compose']
-    click.echo('Available images:')
+    compose = obj["compose"]
+    click.echo("Available images:")
     for image in compose.images():
-        click.echo(f' - {image}')
+        click.echo(f" - {image}")
 
 
-@docker.command('info')
-@click.argument('service_name')
-@click.option('--show', '-s', required=False,
-              help="Show only specific docker compose key. Examples of keys:"
-                   " command, environment, build, dockerfile")
+@docker.command("info")
+@click.argument("service_name")
+@click.option(
+    "--show",
+    "-s",
+    required=False,
+    help="Show only specific docker compose key. Examples of keys:"
+    " command, environment, build, dockerfile",
+)
 @click.pass_obj
 def docker_compose_info(obj, service_name, show):
     """Show Docker Compose definition info for service_name.
@@ -287,13 +366,13 @@ def docker_compose_info(obj, service_name, show):
     SERVICE_NAME is the name of the docker service defined in
     docker-compose.yml. Look at `archery docker images` output for names.
     """
-    compose = obj['compose']
+    compose = obj["compose"]
     try:
         service = compose.config.raw_config["services"][service_name]
     except KeyError:
-        click.echo(f'Service name {service_name} could not be found', err=True)
+        click.echo(f"Service name {service_name} could not be found", err=True)
         sys.exit(1)
     else:
-        click.echo(f'Service {service_name} Docker Compose config:')
+        click.echo(f"Service {service_name} Docker Compose config:")
         output = "\n".join(compose.info(service, show))
         click.echo(output)

--- a/dev/archery/archery/docker/cli.py
+++ b/dev/archery/archery/docker/cli.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
 import os
 import sys
@@ -26,8 +27,8 @@ from .core import DockerCompose, UndefinedImage
 
 
 def _mock_compose_calls(compose):
-    from types import MethodType
     from subprocess import CompletedProcess
+    from types import MethodType
 
     def _mock(compose, command_tuple):
         def _execute(self, *args, **kwargs):
@@ -66,16 +67,15 @@ def _mock_compose_calls(compose):
 @click.pass_context
 def docker(ctx, src, dry_run, using_legacy_docker_compose, using_docker_cli,
            using_docker_buildx):
-    """
-    Interact with Docker Compose based builds.
+    """Interact with Docker Compose based builds.
     """
     ctx.ensure_object(dict)
 
     config_path = src.path / 'docker-compose.yml'
     if not config_path.exists():
         raise click.ClickException(
-            "Docker compose configuration cannot be found in directory {}, "
-            "try to pass the arrow source directory explicitly.".format(src)
+            f"Docker compose configuration cannot be found in directory {src}, "
+            "try to pass the arrow source directory explicitly."
         )
 
     # take the Docker Compose parameters like PYTHON, PANDAS, UBUNTU from the
@@ -97,8 +97,7 @@ def docker(ctx, src, dry_run, using_legacy_docker_compose, using_docker_cli,
 @docker.command("check-config")
 @click.pass_obj
 def check_config(obj):
-    """
-    Validate Docker Compose configuration.
+    """Validate Docker Compose configuration.
     """
     # executes the body of the docker function above which does the validation
     # during the configuration loading
@@ -112,8 +111,7 @@ def check_config(obj):
               help="Whether to ignore pull failures.")
 @click.pass_obj
 def docker_pull(obj, image, *, pull_leaf, ignore_pull_failures):
-    """
-    Execute docker compose pull.
+    """Execute docker compose pull.
     """
     compose = obj['compose']
 
@@ -123,7 +121,7 @@ def docker_pull(obj, image, *, pull_leaf, ignore_pull_failures):
     except UndefinedImage as e:
         raise click.ClickException(
             "There is no service/image defined in docker-compose.yml with "
-            "name: {}".format(str(e))
+            f"name: {e!s}"
         )
     except RuntimeError as e:
         raise click.ClickException(str(e))
@@ -142,8 +140,7 @@ def docker_pull(obj, image, *, pull_leaf, ignore_pull_failures):
                    "image and its ancestors use --no-cache option.")
 @click.pass_obj
 def docker_build(obj, image, *, force_pull, use_cache, use_leaf_cache):
-    """
-    Execute Docker Compose builds.
+    """Execute Docker Compose builds.
     """
     compose = obj['compose']
 
@@ -156,7 +153,7 @@ def docker_build(obj, image, *, force_pull, use_cache, use_leaf_cache):
     except UndefinedImage as e:
         raise click.ClickException(
             "There is no service/image defined in docker-compose.yml with "
-            "name: {}".format(str(e))
+            f"name: {e!s}"
         )
     except RuntimeError as e:
         raise click.ClickException(str(e))
@@ -194,13 +191,11 @@ def docker_build(obj, image, *, force_pull, use_cache, use_leaf_cache):
 def docker_run(obj, image, command, *, env, user, force_pull, force_build,
                build_only, use_cache, use_leaf_cache, resource_limit,
                volume):
-    """
-    Execute Docker Compose builds.
+    """Execute Docker Compose builds.
 
     To see the available builds run `archery docker images`.
 
     Examples:
-
     # execute a single build
     archery docker run conda-python
 
@@ -250,7 +245,7 @@ def docker_run(obj, image, command, *, env, user, force_pull, force_build,
     except UndefinedImage as e:
         raise click.ClickException(
             "There is no service/image defined in docker-compose.yml with "
-            "name: {}".format(str(e))
+            f"name: {e!s}"
         )
     except RuntimeError as e:
         raise click.ClickException(str(e))

--- a/dev/archery/archery/docker/core.py
+++ b/dev/archery/archery/docker/core.py
@@ -469,7 +469,6 @@ class DockerCompose(Command):
             else:
                 if key == filters or filters is None:
                     output.append(
-                        f'{prefix} {key}: ' +
-                        f'{value if value is not None else "<inherited>"}'
+                        f'{prefix} {key}: {value if value is not None else "<inherited>"}'
                     )
         return output

--- a/dev/archery/archery/docker/core.py
+++ b/dev/archery/archery/docker/core.py
@@ -45,13 +45,8 @@ def flatten(node, parents=None):
         raise TypeError(node)
 
 
-_arch_short_mapping = {
-    'arm64v8': 'arm64',
-}
-_arch_alias_mapping = {
-    'amd64': 'x86_64',
-    'arm64v8': 'aarch64',
-}
+_arch_short_mapping = {"arm64v8": "arm64"}
+_arch_alias_mapping = {"amd64": "x86_64", "arm64v8": "aarch64"}
 
 
 class UndefinedImage(Exception):
@@ -59,10 +54,16 @@ class UndefinedImage(Exception):
 
 
 class ComposeConfig:
-
-    def __init__(self, config_path, dotenv_path, compose_bin,
-                 using_docker=False, using_buildx=False,
-                 params=None, debug=False):
+    def __init__(
+        self,
+        config_path,
+        dotenv_path,
+        compose_bin,
+        using_docker=False,
+        using_buildx=False,
+        params=None,
+        debug=False,
+    ):
         self.using_docker = using_docker
         self.using_buildx = using_buildx
         self.debug = debug
@@ -70,17 +71,16 @@ class ComposeConfig:
         if dotenv_path:
             dotenv_path = _ensure_path(dotenv_path)
         else:
-            dotenv_path = config_path.parent / '.env'
+            dotenv_path = config_path.parent / ".env"
         if self.debug:
             # Log docker version
-            Docker().run('version')
+            Docker().run("version")
 
         self._read_env(dotenv_path, params)
         self._read_config(config_path, compose_bin)
 
     def _read_env(self, dotenv_path, params):
-        """Read .env and merge it with explicitly passed parameters.
-        """
+        """Read .env and merge it with explicitly passed parameters."""
         self.dotenv = dotenv_values(str(dotenv_path))
         if params is None:
             self.params = {}
@@ -95,61 +95,60 @@ class ComposeConfig:
         self.env.update(self.params)
 
         # translate docker's architecture notation to a more widely used one
-        arch = self.env.get('ARCH', 'amd64')
-        self.env['ARCH_ALIAS'] = _arch_alias_mapping.get(arch, arch)
-        self.env['ARCH_SHORT'] = _arch_short_mapping.get(arch, arch)
+        arch = self.env.get("ARCH", "amd64")
+        self.env["ARCH_ALIAS"] = _arch_alias_mapping.get(arch, arch)
+        self.env["ARCH_SHORT"] = _arch_short_mapping.get(arch, arch)
 
     def _read_config(self, config_path, compose_bin):
-        """Validate and read the docker-compose.yml
-        """
+        """Validate and read the docker-compose.yml"""
         yaml = YAML()
         with config_path.open() as fp:
             self.raw_config = yaml.load(fp)
 
-        services = self.raw_config['services'].keys()
-        self.hierarchy = dict(flatten(self.raw_config.get('x-hierarchy', {})))
-        self.limit_presets = self.raw_config.get('x-limit-presets', {})
-        self.with_gpus = self.raw_config.get('x-with-gpus', [])
+        services = self.raw_config["services"].keys()
+        self.hierarchy = dict(flatten(self.raw_config.get("x-hierarchy", {})))
+        self.limit_presets = self.raw_config.get("x-limit-presets", {})
+        self.with_gpus = self.raw_config.get("x-with-gpus", [])
         nodes = self.hierarchy.keys()
         errors = []
 
         for name in self.with_gpus:
             if name not in services:
                 errors.append(
-                    f'Service `{name}` defined in `x-with-gpus` bot not in '
-                    '`services`'
+                    f"Service `{name}` defined in `x-with-gpus` bot not in `services`"
                 )
         for name in nodes - services:
             errors.append(
-                f'Service `{name}` is defined in `x-hierarchy` bot not in '
-                '`services`'
+                f"Service `{name}` is defined in `x-hierarchy` bot not in `services`"
             )
         for name in services - nodes:
             errors.append(
-                f'Service `{name}` is defined in `services` but not in '
-                '`x-hierarchy`'
+                f"Service `{name}` is defined in `services` but not in `x-hierarchy`"
             )
 
         # trigger Docker Compose's own validation
         if self.using_docker:
             compose = Docker()
-            args = ['compose']
+            args = ["compose"]
         else:
             compose = Command(compose_bin)
             args = []
-        args += [f'--file={config_path}', 'config']
-        result = compose.run(*args, env=self.env, check=False,
-                             stderr=subprocess.PIPE, stdout=subprocess.PIPE)
+        args += [f"--file={config_path}", "config"]
+        result = compose.run(
+            *args,
+            env=self.env,
+            check=False,
+            stderr=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+        )
 
         if result.returncode != 0:
             # strip the intro line of docker compose errors
             errors += result.stderr.decode().splitlines()
 
         if errors:
-            msg = '\n'.join([f' - {msg}' for msg in errors])
-            raise ValueError(
-                f'Found errors with docker-compose:\n{msg}'
-            )
+            msg = "\n".join([f" - {msg}" for msg in errors])
+            raise ValueError(f"Found errors with docker-compose:\n{msg}")
 
         rendered_config = StringIO(result.stdout.decode())
         self.path = config_path
@@ -157,36 +156,47 @@ class ComposeConfig:
 
     def get(self, service_name):
         try:
-            service = self.config['services'][service_name]
+            service = self.config["services"][service_name]
         except KeyError:
             raise UndefinedImage(service_name)
-        service['name'] = service_name
-        service['need_gpu'] = service_name in self.with_gpus
-        service['ancestors'] = self.hierarchy[service_name]
+        service["name"] = service_name
+        service["need_gpu"] = service_name in self.with_gpus
+        service["ancestors"] = self.hierarchy[service_name]
         return service
 
     def __getitem__(self, service_name):
         return self.get(service_name)
 
     def verbosity_args(self):
-        return ['--quiet'] if running_in_ci() else []
+        return ["--quiet"] if running_in_ci() else []
 
 
 class Docker(Command):
-
     def __init__(self, docker_bin=None):
         self.bin = default_bin(docker_bin, "docker")
 
 
 class DockerCompose(Command):
-
-    def __init__(self, config_path, dotenv_path=None, compose_bin=None,
-                 using_docker=False, using_buildx=False, params=None,
-                 debug=False):
-        compose_bin = default_bin(compose_bin, 'docker compose')
-        self.config = ComposeConfig(config_path, dotenv_path, compose_bin,
-                                    params=params, using_docker=using_docker,
-                                    using_buildx=using_buildx, debug=debug)
+    def __init__(
+        self,
+        config_path,
+        dotenv_path=None,
+        compose_bin=None,
+        using_docker=False,
+        using_buildx=False,
+        params=None,
+        debug=False,
+    ):
+        compose_bin = default_bin(compose_bin, "docker compose")
+        self.config = ComposeConfig(
+            config_path,
+            dotenv_path,
+            compose_bin,
+            params=params,
+            using_docker=using_docker,
+            using_buildx=using_buildx,
+            debug=debug,
+        )
         self.bin = compose_bin
         self.pull_memory = set()
 
@@ -196,14 +206,15 @@ class DockerCompose(Command):
     def _execute_compose(self, *args, **kwargs):
         # execute as a docker compose command
         try:
-            result = super().run(f'--file={self.config.path}', *args,
-                                 env=self.config.env, **kwargs)
+            result = super().run(
+                f"--file={self.config.path}", *args, env=self.config.env, **kwargs
+            )
             result.check_returncode()
         except subprocess.CalledProcessError as e:
+
             def formatdict(d, template):
-                return '\n'.join(
-                    template.format(k, v) for k, v in sorted(d.items())
-                )
+                return "\n".join(template.format(k, v) for k, v in sorted(d.items()))
+
             msg = (
                 "`{cmd}` exited with a non-zero exit code {code}, see the "
                 "process log above.\n\nThe {bin} command was "
@@ -212,13 +223,11 @@ class DockerCompose(Command):
             )
             raise RuntimeError(
                 msg.format(
-                    cmd=' '.join(e.cmd),
+                    cmd=" ".join(e.cmd),
                     code=e.returncode,
                     bin=self.bin,
-                    dotenv=formatdict(self.config.dotenv, template='  {}: {}'),
-                    params=formatdict(
-                        self.config.params, template='  export {}={}'
-                    )
+                    dotenv=formatdict(self.config.dotenv, template="  {}: {}"),
+                    params=formatdict(self.config.params, template="  export {}={}"),
                 )
             )
 
@@ -230,19 +239,19 @@ class DockerCompose(Command):
         except subprocess.CalledProcessError as e:
             raise RuntimeError(
                 "{} exited with non-zero exit code {}".format(
-                    ' '.join(e.cmd), e.returncode
+                    " ".join(e.cmd), e.returncode
                 )
             )
 
     def pull(self, service_name, pull_leaf=True, ignore_pull_failures=True):
         def _pull(service):
-            args = ['pull'] + self.config.verbosity_args()
-            if service['image'] in self.pull_memory:
+            args = ["pull"] + self.config.verbosity_args()
+            if service["image"] in self.pull_memory:
                 return
 
             if self.config.using_docker:
                 try:
-                    self._execute_docker(*args, service['image'])
+                    self._execute_docker(*args, service["image"])
                 except Exception as e:
                     if ignore_pull_failures:
                         # better --ignore-pull-failures handling
@@ -251,163 +260,177 @@ class DockerCompose(Command):
                         raise
             else:
                 if ignore_pull_failures:
-                    args.append('--ignore-pull-failures')
-                self._execute_compose(*args, service['name'])
+                    args.append("--ignore-pull-failures")
+                self._execute_compose(*args, service["name"])
 
-            self.pull_memory.add(service['image'])
+            self.pull_memory.add(service["image"])
 
         service = self.config.get(service_name)
-        for ancestor in service['ancestors']:
+        for ancestor in service["ancestors"]:
             _pull(self.config.get(ancestor))
         if pull_leaf:
             _pull(service)
 
-    def build(self, service_name, use_cache=True, use_leaf_cache=True,
-              pull_parents=True):
+    def build(
+        self, service_name, use_cache=True, use_leaf_cache=True, pull_parents=True
+    ):
         def _build(service, use_cache):
-            if 'build' not in service:
+            if "build" not in service:
                 # nothing to do
                 return
 
             args = []
-            cache_from = list(service.get('build', {}).get('cache_from', []))
+            cache_from = list(service.get("build", {}).get("cache_from", []))
             if pull_parents:
                 for image in cache_from:
                     if image not in self.pull_memory:
                         try:
-                            self._execute_docker('pull', image)
+                            self._execute_docker("pull", image)
                         except Exception as e:
                             print(e)
                         finally:
                             self.pull_memory.add(image)
 
             if not use_cache:
-                args.append('--no-cache')
+                args.append("--no-cache")
 
             # turn on inline build cache, this is a docker buildx feature
             # used to bundle the image build cache to the pushed image manifest
             # so the build cache can be reused across hosts, documented at
             # https://github.com/docker/buildx#--cache-tonametypetypekeyvalue
-            if self.config.env.get('BUILDKIT_INLINE_CACHE') == '1':
-                args.extend(['--build-arg', 'BUILDKIT_INLINE_CACHE=1'])
+            if self.config.env.get("BUILDKIT_INLINE_CACHE") == "1":
+                args.extend(["--build-arg", "BUILDKIT_INLINE_CACHE=1"])
 
             if self.config.using_buildx:
-                for k, v in service['build'].get('args', {}).items():
-                    args.extend(['--build-arg', f'{k}={v}'])
+                for k, v in service["build"].get("args", {}).items():
+                    args.extend(["--build-arg", f"{k}={v}"])
 
                 if use_cache:
-                    cache_ref = '{}-cache'.format(service['image'])
-                    cache_from = f'type=registry,ref={cache_ref}'
-                    cache_to = (
-                        f'type=registry,ref={cache_ref},mode=max'
-                    )
-                    args.extend([
-                        '--cache-from', cache_from,
-                        '--cache-to', cache_to,
-                    ])
+                    cache_ref = "{}-cache".format(service["image"])
+                    cache_from = f"type=registry,ref={cache_ref}"
+                    cache_to = f"type=registry,ref={cache_ref},mode=max"
+                    args.extend(["--cache-from", cache_from, "--cache-to", cache_to])
 
-                args.extend([
-                    '--output', 'type=docker',
-                    '-f', arrow_path(service['build']['dockerfile']),
-                    '-t', service['image'],
-                    service['build'].get('context', '.')
-                ])
+                args.extend(
+                    [
+                        "--output",
+                        "type=docker",
+                        "-f",
+                        arrow_path(service["build"]["dockerfile"]),
+                        "-t",
+                        service["image"],
+                        service["build"].get("context", "."),
+                    ]
+                )
                 self._execute_docker("buildx", "build", *args)
             elif self.config.using_docker:
                 # better for caching
                 if self.config.debug and os.name != "nt":
                     args.append("--progress=plain")
-                for k, v in service['build'].get('args', {}).items():
-                    args.extend(['--build-arg', f'{k}={v}'])
+                for k, v in service["build"].get("args", {}).items():
+                    args.extend(["--build-arg", f"{k}={v}"])
                 for img in cache_from:
                     args.append(f'--cache-from="{img}"')
-                args.extend([
-                    '-f', arrow_path(service['build']['dockerfile']),
-                    '-t', service['image'],
-                    service['build'].get('context', '.')
-                ])
+                args.extend(
+                    [
+                        "-f",
+                        arrow_path(service["build"]["dockerfile"]),
+                        "-t",
+                        service["image"],
+                        service["build"].get("context", "."),
+                    ]
+                )
                 self._execute_docker("build", *args)
             else:
                 if self.config.debug and os.name != "nt":
                     args.append("--progress=plain")
-                self._execute_compose("build", *args, service['name'])
+                self._execute_compose("build", *args, service["name"])
 
         service = self.config.get(service_name)
         # build ancestor services
-        for ancestor in service['ancestors']:
+        for ancestor in service["ancestors"]:
             _build(self.config.get(ancestor), use_cache=use_cache)
         # build the leaf/target service
         _build(service, use_cache=use_cache and use_leaf_cache)
 
-    def run(self, service_name, command=None, *, env=None, volumes=None,
-            user=None, resource_limit=None):
+    def run(
+        self,
+        service_name,
+        command=None,
+        *,
+        env=None,
+        volumes=None,
+        user=None,
+        resource_limit=None,
+    ):
         service = self.config.get(service_name)
 
         args = []
 
-        use_docker = self.config.using_docker or service['need_gpu'] or resource_limit
+        use_docker = self.config.using_docker or service["need_gpu"] or resource_limit
         if use_docker:
             # use gpus, requires docker>=19.03
-            if service['need_gpu']:
-                args.extend(['--gpus', 'all'])
+            if service["need_gpu"]:
+                args.extend(["--gpus", "all"])
 
-            if service.get('shm_size'):
-                args.extend(['--shm-size', service['shm_size']])
+            if service.get("shm_size"):
+                args.extend(["--shm-size", service["shm_size"]])
 
             # append env variables from the compose conf
-            for k, v in service.get('environment', {}).items():
+            for k, v in service.get("environment", {}).items():
                 if v is not None:
-                    args.extend(['-e', f'{k}={v}'])
+                    args.extend(["-e", f"{k}={v}"])
 
             # append volumes from the compose conf
-            for v in service.get('volumes', []):
+            for v in service.get("volumes", []):
                 if not isinstance(v, str):
                     # if not the compact string volume definition
-                    v = "{}:{}".format(v['source'], v['target'])
-                args.extend(['-v', v])
+                    v = "{}:{}".format(v["source"], v["target"])
+                args.extend(["-v", v])
 
             # append capabilities from the compose conf
-            for c in service.get('cap_add', []):
-                args.extend([f'--cap-add={c}'])
+            for c in service.get("cap_add", []):
+                args.extend([f"--cap-add={c}"])
 
             # infer whether an interactive shell is desired or not
-            if command in ['cmd.exe', 'bash', 'sh', 'powershell']:
-                args.append('-it')
+            if command in ["cmd.exe", "bash", "sh", "powershell"]:
+                args.append("-it")
 
             if resource_limit:
                 limits = self.config.limit_presets.get(resource_limit)
                 if not limits:
                     raise ValueError(
-                        f"Unknown resource limit preset '{resource_limit}'")
-                cpuset = limits.get('cpuset_cpus', [])
+                        f"Unknown resource limit preset '{resource_limit}'"
+                    )
+                cpuset = limits.get("cpuset_cpus", [])
                 if cpuset:
-                    args.append(f'--cpuset-cpus={",".join(map(str, cpuset))}')
-                memory = limits.get('memory')
+                    args.append(f"--cpuset-cpus={','.join(map(str, cpuset))}")
+                memory = limits.get("memory")
                 if memory:
-                    args.append(f'--memory={memory}')
-                    args.append(f'--memory-swap={memory}')
+                    args.append(f"--memory={memory}")
+                    args.append(f"--memory-swap={memory}")
 
         if user is not None:
-            args.extend(['-u', user])
+            args.extend(["-u", user])
 
         if env is not None:
             for k, v in env.items():
-                args.extend(['-e', f'{k}={v}'])
+                args.extend(["-e", f"{k}={v}"])
 
         if volumes is not None:
             for volume in volumes:
-                args.extend(['--volume', volume])
+                args.extend(["--volume", volume])
 
         if use_docker:
             # get the actual docker image name instead of the compose service
             # name which we refer as image in general
-            args.append(service['image'])
+            args.append(service["image"])
 
             # add command from compose if it wasn't overridden
             if command is not None:
                 args.append(command)
             else:
-                cmd = service.get('command', '')
+                cmd = service.get("command", "")
                 if cmd:
                     # service command might be already defined as a list
                     # in docker-compose.yml.
@@ -420,53 +443,52 @@ class DockerCompose(Command):
                     args.extend(shlex.split(cmd))
 
             # execute as a plain docker cli command
-            self._execute_docker('run', '--rm', *args)
+            self._execute_docker("run", "--rm", *args)
         else:
             # execute as a docker compose command
             args.append(service_name)
             if command is not None:
                 args.append(command)
-            self._execute_compose('run', '--rm', *args)
+            self._execute_compose("run", "--rm", *args)
 
     def push(self, service_name, user=None, password=None):
         def _push(service):
-            args = ['push'] + self.config.verbosity_args()
+            args = ["push"] + self.config.verbosity_args()
             if self.config.using_docker:
-                return self._execute_docker(*args, service['image'])
+                return self._execute_docker(*args, service["image"])
             else:
-                return self._execute_compose(*args, service['name'])
+                return self._execute_compose(*args, service["name"])
 
         if user is not None:
             try:
                 # TODO(kszucs): have an option for a prompt
-                self._execute_docker('login', '-u', user, '-p', password)
+                self._execute_docker("login", "-u", user, "-p", password)
             except subprocess.CalledProcessError:
                 # hide credentials
-                msg = (f'Failed to push `{service_name}`, check the passed credentials'
-                       )
+                msg = f"Failed to push `{service_name}`, check the passed credentials"
                 raise RuntimeError(msg) from None
 
         service = self.config.get(service_name)
-        for ancestor in service['ancestors']:
+        for ancestor in service["ancestors"]:
             _push(self.config.get(ancestor))
         _push(service)
 
     def images(self):
         return sorted(self.config.hierarchy.keys())
 
-    def info(self, key_name, filters=None, prefix=' '):
+    def info(self, key_name, filters=None, prefix=" "):
         output = []
         for key, value in key_name.items():
-            if hasattr(value, 'items'):
+            if hasattr(value, "items"):
                 temp_filters = filters
                 if key == filters or filters is None:
-                    output.append(f'{prefix} {key}')
+                    output.append(f"{prefix} {key}")
                     # Keep showing this specific key
                     # as parent matched filter
                     temp_filters = None
                 output.extend(self.info(value, temp_filters, prefix + "  "))
             elif key == filters or filters is None:
                 output.append(
-                    f'{prefix} {key}: {value if value is not None else "<inherited>"}'
+                    f"{prefix} {key}: {value if value is not None else '<inherited>'}"
                 )
         return output

--- a/dev/archery/archery/docker/tests/test_docker.py
+++ b/dev/archery/archery/docker/tests/test_docker.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
 import collections
 import os
@@ -24,8 +25,7 @@ from unittest import mock
 import pytest
 
 from archery.docker import DockerCompose
-from archery.testing import assert_subprocess_calls, override_env, PartialEnv
-
+from archery.testing import PartialEnv, assert_subprocess_calls, override_env
 
 missing_service_compose_yml = """
 version: '3.5'
@@ -199,7 +199,7 @@ def create_config(directory, yml_content, env_content=None):
     if env_content is not None:
         with env_path.open('w') as fp:
             for k, v in env_content.items():
-                fp.write("{}={}\n".format(k, v))
+                fp.write(f"{k}={v}\n")
 
     return config_path
 

--- a/dev/archery/archery/docker/tests/test_docker.py
+++ b/dev/archery/archery/docker/tests/test_docker.py
@@ -182,22 +182,22 @@ services:
 """
 
 arrow_compose_env = {
-    'UBUNTU': '20.04',  # overridden below
-    'PYTHON': '3.8',
-    'PANDAS': 'latest',
-    'DASK': 'latest',  # overridden below
+    "UBUNTU": "20.04",  # overridden below
+    "PYTHON": "3.8",
+    "PANDAS": "latest",
+    "DASK": "latest",  # overridden below
 }
 
 
 def create_config(directory, yml_content, env_content=None):
-    env_path = directory / '.env'
-    config_path = directory / 'docker-compose.yml'
+    env_path = directory / ".env"
+    config_path = directory / "docker-compose.yml"
 
-    with config_path.open('w') as fp:
+    with config_path.open("w") as fp:
         fp.write(yml_content)
 
     if env_content is not None:
-        with env_path.open('w') as fp:
+        with env_path.open("w") as fp:
             for k, v in env_content.items():
                 fp.write(f"{k}={v}\n")
 
@@ -241,7 +241,7 @@ def test_config_validation(tmpdir):
 
 
 def assert_docker_calls(compose, expected_args):
-    base_command = ['docker']
+    base_command = ["docker"]
     expected_commands = []
     for args in expected_args:
         if isinstance(args, str):
@@ -251,7 +251,7 @@ def assert_docker_calls(compose, expected_args):
 
 
 def assert_compose_calls(compose, expected_args, env=mock.ANY):
-    base_command = ['docker', 'compose', f'--file={compose.config.path}']
+    base_command = ["docker", "compose", f"--file={compose.config.path}"]
     expected_commands = []
     for args in expected_args:
         if isinstance(args, str):
@@ -265,33 +265,23 @@ def test_arrow_example_validation_passes(arrow_compose_path):
 
 
 def test_compose_default_params_and_env(arrow_compose_path):
-    compose = DockerCompose(arrow_compose_path, params=dict(
-        UBUNTU='18.04',
-        DASK='upstream_devel'
-    ))
+    compose = DockerCompose(
+        arrow_compose_path, params=dict(UBUNTU="18.04", DASK="upstream_devel")
+    )
     assert compose.config.dotenv == arrow_compose_env
-    assert compose.config.params == {
-        'UBUNTU': '18.04',
-        'DASK': 'upstream_devel',
-    }
+    assert compose.config.params == {"UBUNTU": "18.04", "DASK": "upstream_devel"}
 
 
 def test_forwarding_env_variables(arrow_compose_path):
-    expected_calls = [
-        "pull --ignore-pull-failures conda-cpp",
-        "build conda-cpp",
-    ]
-    expected_env = PartialEnv(
-        MY_CUSTOM_VAR_A='a',
-        MY_CUSTOM_VAR_B='b'
-    )
-    with override_env({'MY_CUSTOM_VAR_A': 'a', 'MY_CUSTOM_VAR_B': 'b'}):
+    expected_calls = ["pull --ignore-pull-failures conda-cpp", "build conda-cpp"]
+    expected_env = PartialEnv(MY_CUSTOM_VAR_A="a", MY_CUSTOM_VAR_B="b")
+    with override_env({"MY_CUSTOM_VAR_A": "a", "MY_CUSTOM_VAR_B": "b"}):
         compose = DockerCompose(arrow_compose_path)
         with assert_compose_calls(compose, expected_calls, env=expected_env):
-            assert os.environ['MY_CUSTOM_VAR_A'] == 'a'
-            assert os.environ['MY_CUSTOM_VAR_B'] == 'b'
-            compose.pull('conda-cpp')
-            compose.build('conda-cpp')
+            assert os.environ["MY_CUSTOM_VAR_A"] == "a"
+            assert os.environ["MY_CUSTOM_VAR_B"] == "b"
+            compose.pull("conda-cpp")
+            compose.build("conda-cpp")
 
 
 def test_compose_pull(arrow_compose_path, monkeypatch):
@@ -300,16 +290,16 @@ def test_compose_pull(arrow_compose_path, monkeypatch):
     expected_calls = ["pull --ignore-pull-failures conda-cpp"]
     with assert_compose_calls(compose, expected_calls):
         compose.clear_pull_memory()
-        compose.pull('conda-cpp')
+        compose.pull("conda-cpp")
 
     expected_calls = [
         "pull --ignore-pull-failures conda-cpp",
         "pull --ignore-pull-failures conda-python",
-        "pull --ignore-pull-failures conda-python-pandas"
+        "pull --ignore-pull-failures conda-python-pandas",
     ]
     with assert_compose_calls(compose, expected_calls):
         compose.clear_pull_memory()
-        compose.pull('conda-python-pandas')
+        compose.pull("conda-python-pandas")
 
     expected_calls = [
         "pull --ignore-pull-failures conda-cpp",
@@ -317,7 +307,7 @@ def test_compose_pull(arrow_compose_path, monkeypatch):
     ]
     with assert_compose_calls(compose, expected_calls):
         compose.clear_pull_memory()
-        compose.pull('conda-python-pandas', pull_leaf=False)
+        compose.pull("conda-python-pandas", pull_leaf=False)
 
     with monkeypatch.context() as m:
         # `--quiet` is passed to `docker` on CI
@@ -325,7 +315,7 @@ def test_compose_pull(arrow_compose_path, monkeypatch):
         expected_calls = ["pull --quiet --ignore-pull-failures conda-cpp"]
         with assert_compose_calls(compose, expected_calls):
             compose.clear_pull_memory()
-            compose.pull('conda-cpp')
+            compose.pull("conda-cpp")
 
 
 def test_compose_pull_params(arrow_compose_path):
@@ -333,11 +323,11 @@ def test_compose_pull_params(arrow_compose_path):
         "pull --ignore-pull-failures conda-cpp",
         "pull --ignore-pull-failures conda-python",
     ]
-    compose = DockerCompose(arrow_compose_path, params=dict(UBUNTU='18.04'))
-    expected_env = PartialEnv(PYTHON='3.8', PANDAS='latest')
+    compose = DockerCompose(arrow_compose_path, params=dict(UBUNTU="18.04"))
+    expected_env = PartialEnv(PYTHON="3.8", PANDAS="latest")
     with assert_compose_calls(compose, expected_calls, env=expected_env):
         compose.clear_pull_memory()
-        compose.pull('conda-python-pandas', pull_leaf=False)
+        compose.pull("conda-python-pandas", pull_leaf=False)
 
 
 def test_compose_build(arrow_compose_path):
@@ -345,21 +335,19 @@ def test_compose_build(arrow_compose_path):
 
     expected_calls = ["build conda-cpp"]
     with assert_compose_calls(compose, expected_calls):
-        compose.build('conda-cpp')
+        compose.build("conda-cpp")
 
-    expected_calls = [
-        "build --no-cache conda-cpp"
-    ]
+    expected_calls = ["build --no-cache conda-cpp"]
     with assert_compose_calls(compose, expected_calls):
-        compose.build('conda-cpp', use_cache=False)
+        compose.build("conda-cpp", use_cache=False)
 
     expected_calls = [
         "build conda-cpp",
         "build conda-python",
-        "build conda-python-pandas"
+        "build conda-python-pandas",
     ]
     with assert_compose_calls(compose, expected_calls):
-        compose.build('conda-python-pandas')
+        compose.build("conda-python-pandas")
 
     expected_calls = [
         "build --no-cache conda-cpp",
@@ -367,7 +355,7 @@ def test_compose_build(arrow_compose_path):
         "build --no-cache conda-python-pandas",
     ]
     with assert_compose_calls(compose, expected_calls):
-        compose.build('conda-python-pandas', use_cache=False)
+        compose.build("conda-python-pandas", use_cache=False)
 
     expected_calls = [
         "build conda-cpp",
@@ -375,8 +363,7 @@ def test_compose_build(arrow_compose_path):
         "build --no-cache conda-python-pandas",
     ]
     with assert_compose_calls(compose, expected_calls):
-        compose.build('conda-python-pandas', use_cache=True,
-                      use_leaf_cache=False)
+        compose.build("conda-python-pandas", use_cache=True, use_leaf_cache=False)
 
 
 @mock.patch.dict(os.environ, {"BUILDKIT_INLINE_CACHE": "1"})
@@ -385,126 +372,119 @@ def test_compose_buildkit_inline_cache(arrow_compose_path):
 
     expected_calls = ["build --build-arg BUILDKIT_INLINE_CACHE=1 conda-cpp"]
     with assert_compose_calls(compose, expected_calls):
-        compose.build('conda-cpp')
+        compose.build("conda-cpp")
 
 
 def test_compose_build_params(arrow_compose_path):
     expected_calls = ["build ubuntu-cpp"]
 
-    compose = DockerCompose(arrow_compose_path, params=dict(UBUNTU='18.04'))
+    compose = DockerCompose(arrow_compose_path, params=dict(UBUNTU="18.04"))
     expected_env = PartialEnv(UBUNTU="18.04")
     with assert_compose_calls(compose, expected_calls, env=expected_env):
-        compose.build('ubuntu-cpp')
+        compose.build("ubuntu-cpp")
 
-    compose = DockerCompose(arrow_compose_path, params=dict(UBUNTU='16.04'))
+    compose = DockerCompose(arrow_compose_path, params=dict(UBUNTU="16.04"))
     expected_env = PartialEnv(UBUNTU="16.04")
     with assert_compose_calls(compose, expected_calls, env=expected_env):
-        compose.build('ubuntu-cpp')
+        compose.build("ubuntu-cpp")
 
     expected_calls = [
         "build --no-cache conda-cpp",
         "build --no-cache conda-python",
         "build --no-cache conda-python-pandas",
     ]
-    compose = DockerCompose(arrow_compose_path, params=dict(UBUNTU='18.04'))
-    expected_env = PartialEnv(PYTHON='3.8', PANDAS='latest')
+    compose = DockerCompose(arrow_compose_path, params=dict(UBUNTU="18.04"))
+    expected_env = PartialEnv(PYTHON="3.8", PANDAS="latest")
     with assert_compose_calls(compose, expected_calls, env=expected_env):
-        compose.build('conda-python-pandas', use_cache=False)
+        compose.build("conda-python-pandas", use_cache=False)
 
 
 def test_compose_run(arrow_compose_path):
     expected_calls = [format_run("conda-cpp")]
     compose = DockerCompose(arrow_compose_path)
     with assert_compose_calls(compose, expected_calls):
-        compose.run('conda-cpp')
+        compose.run("conda-cpp")
 
-    expected_calls = [
-        format_run("conda-python")
-    ]
-    expected_env = PartialEnv(PYTHON='3.8')
+    expected_calls = [format_run("conda-python")]
+    expected_env = PartialEnv(PYTHON="3.8")
     with assert_compose_calls(compose, expected_calls, env=expected_env):
-        compose.run('conda-python')
+        compose.run("conda-python")
 
-    compose = DockerCompose(arrow_compose_path, params=dict(PYTHON='3.9'))
-    expected_env = PartialEnv(PYTHON='3.9')
+    compose = DockerCompose(arrow_compose_path, params=dict(PYTHON="3.9"))
+    expected_env = PartialEnv(PYTHON="3.9")
     with assert_compose_calls(compose, expected_calls, env=expected_env):
-        compose.run('conda-python')
+        compose.run("conda-python")
 
-    compose = DockerCompose(arrow_compose_path, params=dict(PYTHON='3.9'))
+    compose = DockerCompose(arrow_compose_path, params=dict(PYTHON="3.9"))
     for command in ["bash", "echo 1"]:
-        expected_calls = [
-            format_run(["conda-python", command]),
-        ]
-        expected_env = PartialEnv(PYTHON='3.9')
+        expected_calls = [format_run(["conda-python", command])]
+        expected_env = PartialEnv(PYTHON="3.9")
         with assert_compose_calls(compose, expected_calls, env=expected_env):
-            compose.run('conda-python', command)
+            compose.run("conda-python", command)
 
     expected_calls = [
-        (
-            format_run("-e CONTAINER_ENV_VAR_A=a -e CONTAINER_ENV_VAR_B=b "
-                       "conda-python")
-        )
+        (format_run("-e CONTAINER_ENV_VAR_A=a -e CONTAINER_ENV_VAR_B=b conda-python"))
     ]
     compose = DockerCompose(arrow_compose_path)
-    expected_env = PartialEnv(PYTHON='3.8')
+    expected_env = PartialEnv(PYTHON="3.8")
     with assert_compose_calls(compose, expected_calls, env=expected_env):
-        env = collections.OrderedDict([
-            ("CONTAINER_ENV_VAR_A", "a"),
-            ("CONTAINER_ENV_VAR_B", "b")
-        ])
-        compose.run('conda-python', env=env)
+        env = collections.OrderedDict(
+            [("CONTAINER_ENV_VAR_A", "a"), ("CONTAINER_ENV_VAR_B", "b")]
+        )
+        compose.run("conda-python", env=env)
 
     expected_calls = [
         (
-            format_run("--volume /host/build:/build --volume "
-                       "/host/ccache:/ccache:delegated conda-python")
+            format_run(
+                "--volume /host/build:/build --volume "
+                "/host/ccache:/ccache:delegated conda-python"
+            )
         )
     ]
     compose = DockerCompose(arrow_compose_path)
     with assert_compose_calls(compose, expected_calls):
         volumes = ("/host/build:/build", "/host/ccache:/ccache:delegated")
-        compose.run('conda-python', volumes=volumes)
+        compose.run("conda-python", volumes=volumes)
 
 
 def test_compose_run_with_resource_limits(arrow_compose_path):
     expected_calls = [
-        format_run([
-            "--cpuset-cpus=0,1",
-            "--memory=7g",
-            "--memory-swap=7g",
-            "org/conda-cpp"
-        ]),
+        format_run(
+            ["--cpuset-cpus=0,1", "--memory=7g", "--memory-swap=7g", "org/conda-cpp"]
+        )
     ]
     compose = DockerCompose(arrow_compose_path)
     with assert_docker_calls(compose, expected_calls):
-        compose.run('conda-cpp', resource_limit="github")
+        compose.run("conda-cpp", resource_limit="github")
 
 
 def test_compose_push(arrow_compose_path):
-    compose = DockerCompose(arrow_compose_path, params=dict(PYTHON='3.9'))
+    compose = DockerCompose(arrow_compose_path, params=dict(PYTHON="3.9"))
     expected_env = PartialEnv(PYTHON="3.9")
     expected_calls = [
         mock.call(["docker", "login", "-u", "user", "-p", "pass"], check=True)
     ]
     for image in ["conda-cpp", "conda-python", "conda-python-pandas"]:
         expected_calls.append(
-            mock.call(["docker", "compose", f"--file={compose.config.path}",
-                       "push", image], check=True, env=expected_env)
+            mock.call(
+                ["docker", "compose", f"--file={compose.config.path}", "push", image],
+                check=True,
+                env=expected_env,
+            )
         )
     with assert_subprocess_calls(expected_calls):
         compose.push("conda-python-pandas", user="user", password="pass")  # noqa: S106
 
 
 def test_compose_error(arrow_compose_path):
-    compose = DockerCompose(arrow_compose_path, params=dict(
-        PYTHON='3.8',
-        PANDAS='upstream_devel'
-    ))
+    compose = DockerCompose(
+        arrow_compose_path, params=dict(PYTHON="3.8", PANDAS="upstream_devel")
+    )
 
     error = subprocess.CalledProcessError(99, [])
-    with mock.patch('subprocess.run', side_effect=error):
+    with mock.patch("subprocess.run", side_effect=error):
         with pytest.raises(RuntimeError) as exc:
-            compose.run('conda-cpp')
+            compose.run("conda-cpp")
 
     exception_message = str(exc.value)
     assert "exited with a non-zero exit code 99" in exception_message
@@ -517,30 +497,38 @@ def test_image_with_gpu(arrow_compose_path):
 
     expected_calls = [
         [
-            "run", "--rm", "--gpus", "all",
-            "-e", "CUDA_ENV=1",
-            "-e", "OTHER_ENV=2",
-            "-v", "/host:/container",
+            "run",
+            "--rm",
+            "--gpus",
+            "all",
+            "-e",
+            "CUDA_ENV=1",
+            "-e",
+            "OTHER_ENV=2",
+            "-v",
+            "/host:/container",
             "org/ubuntu-cuda",
-            "/bin/bash", "-c", "echo 1 > /tmp/dummy && cat /tmp/dummy",
+            "/bin/bash",
+            "-c",
+            "echo 1 > /tmp/dummy && cat /tmp/dummy",
         ]
     ]
     with assert_docker_calls(compose, expected_calls):
-        compose.run('ubuntu-cuda')
+        compose.run("ubuntu-cuda")
 
 
 def test_listing_images(arrow_compose_path):
     compose = DockerCompose(arrow_compose_path)
     assert sorted(compose.images()) == [
-        'conda-cpp',
-        'conda-python',
-        'conda-python-dask',
-        'conda-python-pandas',
-        'ubuntu-c-glib',
-        'ubuntu-cpp',
-        'ubuntu-cpp-cmake32',
-        'ubuntu-cuda',
-        'ubuntu-ruby',
+        "conda-cpp",
+        "conda-python",
+        "conda-python-dask",
+        "conda-python-pandas",
+        "ubuntu-c-glib",
+        "ubuntu-cpp",
+        "ubuntu-cpp-cmake32",
+        "ubuntu-cuda",
+        "ubuntu-ruby",
     ]
 
 
@@ -551,7 +539,7 @@ def test_service_info(arrow_compose_path):
         "  image: org/conda-cpp",
         "  build",
         "    context: .",
-        "    dockerfile: ci/docker/conda-cpp.dockerfile"
+        "    dockerfile: ci/docker/conda-cpp.dockerfile",
     ]
 
 
@@ -576,5 +564,5 @@ def test_service_info_inherited_env(arrow_compose_path):
         "  environment",
         "    AWS_ACCESS_KEY_ID: <inherited>",
         "    AWS_SECRET_ACCESS_KEY: <inherited>",
-        "    SCCACHE_BUCKET: <inherited>"
+        "    SCCACHE_BUCKET: <inherited>",
     ]

--- a/dev/archery/archery/docker/tests/test_docker.py
+++ b/dev/archery/archery/docker/tests/test_docker.py
@@ -297,9 +297,7 @@ def test_forwarding_env_variables(arrow_compose_path):
 def test_compose_pull(arrow_compose_path, monkeypatch):
     compose = DockerCompose(arrow_compose_path)
 
-    expected_calls = [
-        "pull --ignore-pull-failures conda-cpp",
-    ]
+    expected_calls = ["pull --ignore-pull-failures conda-cpp"]
     with assert_compose_calls(compose, expected_calls):
         compose.clear_pull_memory()
         compose.pull('conda-cpp')
@@ -324,9 +322,7 @@ def test_compose_pull(arrow_compose_path, monkeypatch):
     with monkeypatch.context() as m:
         # `--quiet` is passed to `docker` on CI
         m.setenv("GITHUB_ACTIONS", "true")
-        expected_calls = [
-            "pull --quiet --ignore-pull-failures conda-cpp",
-        ]
+        expected_calls = ["pull --quiet --ignore-pull-failures conda-cpp"]
         with assert_compose_calls(compose, expected_calls):
             compose.clear_pull_memory()
             compose.pull('conda-cpp')
@@ -347,9 +343,7 @@ def test_compose_pull_params(arrow_compose_path):
 def test_compose_build(arrow_compose_path):
     compose = DockerCompose(arrow_compose_path)
 
-    expected_calls = [
-        "build conda-cpp",
-    ]
+    expected_calls = ["build conda-cpp"]
     with assert_compose_calls(compose, expected_calls):
         compose.build('conda-cpp')
 
@@ -389,17 +383,13 @@ def test_compose_build(arrow_compose_path):
 def test_compose_buildkit_inline_cache(arrow_compose_path):
     compose = DockerCompose(arrow_compose_path)
 
-    expected_calls = [
-        "build --build-arg BUILDKIT_INLINE_CACHE=1 conda-cpp",
-    ]
+    expected_calls = ["build --build-arg BUILDKIT_INLINE_CACHE=1 conda-cpp"]
     with assert_compose_calls(compose, expected_calls):
         compose.build('conda-cpp')
 
 
 def test_compose_build_params(arrow_compose_path):
-    expected_calls = [
-        "build ubuntu-cpp",
-    ]
+    expected_calls = ["build ubuntu-cpp"]
 
     compose = DockerCompose(arrow_compose_path, params=dict(UBUNTU='18.04'))
     expected_env = PartialEnv(UBUNTU="18.04")
@@ -423,9 +413,7 @@ def test_compose_build_params(arrow_compose_path):
 
 
 def test_compose_run(arrow_compose_path):
-    expected_calls = [
-        format_run("conda-cpp"),
-    ]
+    expected_calls = [format_run("conda-cpp")]
     compose = DockerCompose(arrow_compose_path)
     with assert_compose_calls(compose, expected_calls):
         compose.run('conda-cpp')
@@ -496,7 +484,7 @@ def test_compose_push(arrow_compose_path):
     compose = DockerCompose(arrow_compose_path, params=dict(PYTHON='3.9'))
     expected_env = PartialEnv(PYTHON="3.9")
     expected_calls = [
-        mock.call(["docker", "login", "-u", "user", "-p", "pass"], check=True),
+        mock.call(["docker", "login", "-u", "user", "-p", "pass"], check=True)
     ]
     for image in ["conda-cpp", "conda-python", "conda-python-pandas"]:
         expected_calls.append(
@@ -504,7 +492,7 @@ def test_compose_push(arrow_compose_path):
                        "push", image], check=True, env=expected_env)
         )
     with assert_subprocess_calls(expected_calls):
-        compose.push('conda-python-pandas', user='user', password='pass')
+        compose.push("conda-python-pandas", user="user", password="pass")  # noqa: S106
 
 
 def test_compose_error(arrow_compose_path):

--- a/dev/archery/archery/docker/tests/test_docker_cli.py
+++ b/dev/archery/archery/docker/tests/test_docker_cli.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
 from unittest.mock import patch
 

--- a/dev/archery/archery/docker/tests/test_docker_cli.py
+++ b/dev/archery/archery/docker/tests/test_docker_cli.py
@@ -33,14 +33,8 @@ def test_docker_run_with_custom_command(run, build, pull):
     result = CliRunner().invoke(docker, args)
 
     assert result.exit_code == 0
-    pull.assert_called_once_with(
-        "ubuntu-cpp", pull_leaf=True,
-    )
-    build.assert_called_once_with(
-        "ubuntu-cpp",
-        use_cache=True,
-        use_leaf_cache=True,
-    )
+    pull.assert_called_once_with("ubuntu-cpp", pull_leaf=True)
+    build.assert_called_once_with("ubuntu-cpp", use_cache=True, use_leaf_cache=True)
     run.assert_called_once_with(
         "ubuntu-cpp", command="bash", env={}, resource_limit=None, user=None, volumes=()
     )
@@ -67,14 +61,8 @@ def test_docker_run_options(run, build, pull):
     ]
     result = CliRunner().invoke(docker, args)
     assert result.exit_code == 0
-    pull.assert_called_once_with(
-        "ubuntu-cpp", pull_leaf=True,
-    )
-    build.assert_called_once_with(
-        "ubuntu-cpp",
-        use_cache=True,
-        use_leaf_cache=True,
-    )
+    pull.assert_called_once_with("ubuntu-cpp", pull_leaf=True)
+    build.assert_called_once_with("ubuntu-cpp", use_cache=True, use_leaf_cache=True)
     run.assert_called_once_with(
         "ubuntu-cpp",
         command=None,
@@ -133,14 +121,8 @@ def test_docker_run_only_pulling_and_building(build, pull):
     args = ["run", "ubuntu-cpp", "--build-only"]
     result = CliRunner().invoke(docker, args)
     assert result.exit_code == 0
-    pull.assert_called_once_with(
-        "ubuntu-cpp", pull_leaf=True,
-    )
-    build.assert_called_once_with(
-        "ubuntu-cpp",
-        use_cache=True,
-        use_leaf_cache=True,
-    )
+    pull.assert_called_once_with("ubuntu-cpp", pull_leaf=True)
+    build.assert_called_once_with("ubuntu-cpp", use_cache=True, use_leaf_cache=True)
 
 
 @patch.object(DockerCompose, "build")

--- a/dev/archery/archery/docker/tests/test_docker_cli.py
+++ b/dev/archery/archery/docker/tests/test_docker_cli.py
@@ -41,12 +41,7 @@ def test_docker_run_with_custom_command(run, build, pull):
         use_leaf_cache=True,
     )
     run.assert_called_once_with(
-        "ubuntu-cpp",
-        command="bash",
-        env={},
-        resource_limit=None,
-        user=None,
-        volumes=(),
+        "ubuntu-cpp", command="bash", env={}, resource_limit=None, user=None, volumes=()
     )
 
 
@@ -85,10 +80,7 @@ def test_docker_run_options(run, build, pull):
         env={"ARROW_GANDIVA": "OFF", "ARROW_FLIGHT": "ON"},
         resource_limit=None,
         user="root",
-        volumes=(
-            "./build:/build",
-            "./ccache:/ccache:delegated",
-        ),
+        volumes=("./build:/build", "./ccache:/ccache:delegated"),
     )
 
 
@@ -120,10 +112,7 @@ def test_docker_limit_options(run):
         env={"ARROW_GANDIVA": "OFF", "ARROW_FLIGHT": "ON"},
         resource_limit="github",
         user="root",
-        volumes=(
-            "./build:/build",
-            "./ccache:/ccache:delegated",
-        ),
+        volumes=("./build:/build", "./ccache:/ccache:delegated"),
     )
 
 
@@ -133,12 +122,7 @@ def test_docker_run_without_pulling_or_building(run):
     result = CliRunner().invoke(docker, args)
     assert result.exit_code == 0
     run.assert_called_once_with(
-        "ubuntu-cpp",
-        command=None,
-        env={},
-        resource_limit=None,
-        user=None,
-        volumes=(),
+        "ubuntu-cpp", command=None, env={}, resource_limit=None, user=None, volumes=()
     )
 
 
@@ -173,16 +157,7 @@ def test_docker_run_without_build_cache(run, build):
     ]
     result = CliRunner().invoke(docker, args)
     assert result.exit_code == 0
-    build.assert_called_once_with(
-        "ubuntu-cpp",
-        use_cache=False,
-        use_leaf_cache=False,
-    )
+    build.assert_called_once_with("ubuntu-cpp", use_cache=False, use_leaf_cache=False)
     run.assert_called_once_with(
-        "ubuntu-cpp",
-        command=None,
-        env={},
-        resource_limit=None,
-        user="me",
-        volumes=(),
+        "ubuntu-cpp", command=None, env={}, resource_limit=None, user="me", volumes=()
     )

--- a/dev/archery/archery/integration/cdata.py
+++ b/dev/archery/archery/integration/cdata.py
@@ -20,8 +20,10 @@ from contextlib import contextmanager
 import functools
 import os
 import sys
+from typing import TYPE_CHECKING
 
-from .tester import CDataExporter, CDataImporter
+if TYPE_CHECKING:
+    from .tester import CDataExporter, CDataImporter
 
 
 if sys.platform == "darwin":

--- a/dev/archery/archery/integration/cdata.py
+++ b/dev/archery/archery/integration/cdata.py
@@ -85,8 +85,7 @@ _c_data_decls = """
 
 @functools.lru_cache
 def ffi() -> cffi.FFI:
-    """Return a FFI object supporting C Data Interface types.
-    """
+    """Return a FFI object supporting C Data Interface types."""
     ffi = cffi.FFI()
     ffi.cdef(_c_data_decls)
     return ffi
@@ -111,8 +110,7 @@ def check_memory_released(exporter: CDataExporter, importer: CDataImporter):
     However, if either the exporter or importer doesn't support deterministic
     memory release, no memory check is performed.
     """
-    do_check = (exporter.supports_releasing_memory and
-                importer.supports_releasing_memory)
+    do_check = exporter.supports_releasing_memory and importer.supports_releasing_memory
     if do_check:
         before = exporter.record_allocation_state()
     yield
@@ -125,4 +123,5 @@ def check_memory_released(exporter: CDataExporter, importer: CDataImporter):
         if after != before:
             raise RuntimeError(
                 f"Memory was not released correctly after roundtrip: "
-                f"before = {before}, after = {after} (should have been equal)")
+                f"before = {before}, after = {after} (should have been equal)"
+            )

--- a/dev/archery/archery/integration/cdata.py
+++ b/dev/archery/archery/integration/cdata.py
@@ -14,13 +14,15 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
-import cffi
-from contextlib import contextmanager
 import functools
 import os
 import sys
+from contextlib import contextmanager
 from typing import TYPE_CHECKING
+
+import cffi
 
 if TYPE_CHECKING:
     from .tester import CDataExporter, CDataImporter
@@ -83,8 +85,7 @@ _c_data_decls = """
 
 @functools.lru_cache
 def ffi() -> cffi.FFI:
-    """
-    Return a FFI object supporting C Data Interface types.
+    """Return a FFI object supporting C Data Interface types.
     """
     ffi = cffi.FFI()
     ffi.cdef(_c_data_decls)
@@ -93,7 +94,7 @@ def ffi() -> cffi.FFI:
 
 def _release_memory_steps(exporter: CDataExporter, importer: CDataImporter):
     yield
-    for i in range(max(exporter.required_gc_runs, importer.required_gc_runs)):
+    for _i in range(max(exporter.required_gc_runs, importer.required_gc_runs)):
         importer.run_gc()
         yield
         exporter.run_gc()
@@ -102,8 +103,7 @@ def _release_memory_steps(exporter: CDataExporter, importer: CDataImporter):
 
 @contextmanager
 def check_memory_released(exporter: CDataExporter, importer: CDataImporter):
-    """
-    A context manager for memory release checks.
+    """A context manager for memory release checks.
 
     The context manager arranges cooperation between the exporter and importer
     to try and release memory at the end of the enclosed block.

--- a/dev/archery/archery/integration/datagen.py
+++ b/dev/archery/archery/integration/datagen.py
@@ -116,8 +116,8 @@ class PrimitiveColumn(Column):
 
     def _get_buffers(self):
         return [
-            ('VALIDITY', [int(v) for v in self.is_valid]),
-            ('DATA', list([self._encode_value(x) for x in self.values]))
+            ("VALIDITY", [int(v) for v in self.is_valid]),
+            ("DATA", [self._encode_value(x) for x in self.values]),
         ]
 
 
@@ -404,7 +404,6 @@ class DayTimeIntervalField(PrimitiveField):
         return object
 
     def _get_type(self):
-
         return OrderedDict([
             ('name', 'interval'),
             ('unit', 'DAY_TIME'),
@@ -433,7 +432,6 @@ class MonthDayNanoIntervalField(PrimitiveField):
         return object
 
     def _get_type(self):
-
         return OrderedDict([
             ('name', 'interval'),
             ('unit', 'MONTH_DAY_NANO'),

--- a/dev/archery/archery/integration/datagen.py
+++ b/dev/archery/archery/integration/datagen.py
@@ -14,25 +14,33 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
-from collections import namedtuple, OrderedDict
 import binascii
 import json
 import os
 import random
 import tempfile
+from collections import OrderedDict, namedtuple
 
 import numpy as np
 
-from .util import frombytes, tobytes, random_bytes, random_utf8
-from .util import SKIP_C_SCHEMA, SKIP_C_ARRAY, SKIP_FLIGHT
+from .util import (
+    SKIP_C_ARRAY,
+    SKIP_C_SCHEMA,
+    SKIP_FLIGHT,
+    frombytes,
+    random_bytes,
+    random_utf8,
+    tobytes,
+)
 
 
 def metadata_key_values(pairs):
     return [{'key': k, 'value': v} for k, v in pairs]
 
 
-class Field(object):
+class Field:
 
     def __init__(self, name, *, nullable=True, metadata=None):
         self.name = name
@@ -67,7 +75,7 @@ class Field(object):
             return np.ones(size, dtype=np.int8)
 
 
-class Column(object):
+class Column:
 
     def __init__(self, name, count):
         self.name = name
@@ -577,7 +585,7 @@ class FixedSizeBinaryField(PrimitiveField):
         is_valid = self._make_is_valid(size)
         values = []
 
-        for i in range(size):
+        for _i in range(size):
             values.append(random_bytes(self.byte_width))
 
         if name is None:
@@ -683,7 +691,7 @@ class StringViewField(StringField):
         return OrderedDict([('name', 'utf8view')])
 
 
-class Schema(object):
+class Schema:
 
     def __init__(self, fields, metadata=None):
         self.fields = fields
@@ -837,7 +845,7 @@ class FixedSizeBinaryColumn(PrimitiveColumn):
 
     def _get_buffers(self):
         data = []
-        for i, v in enumerate(self.values):
+        for _i, v in enumerate(self.values):
             data.append(self._encode_value(v))
 
         return [
@@ -1227,7 +1235,7 @@ class DenseUnionField(_BaseUnionField):
                                 field_values)
 
 
-class Dictionary(object):
+class Dictionary:
 
     def __init__(self, id_, field, size, name=None, ordered=False):
         self.id_ = id_
@@ -1372,7 +1380,7 @@ class DenseUnionColumn(Column):
         return [field.get_json() for field in self.field_values]
 
 
-class RecordBatch(object):
+class RecordBatch:
 
     def __init__(self, count, columns):
         self.count = count
@@ -1385,7 +1393,7 @@ class RecordBatch(object):
         ])
 
 
-class File(object):
+class File:
 
     def __init__(self, name, schema, batches, dictionaries=None,
                  skip_testers=None, path=None, quirks=None):
@@ -1590,7 +1598,7 @@ def generate_null_trivial_case(batch_sizes):
 
 def generate_decimal32_case():
     fields = [
-        DecimalField(name='f{}'.format(i), precision=precision, scale=2,
+        DecimalField(name=f'f{i}', precision=precision, scale=2,
                      bit_width=32)
         for i, precision in enumerate(range(3, 10))
     ]
@@ -1601,7 +1609,7 @@ def generate_decimal32_case():
 
 def generate_decimal64_case():
     fields = [
-        DecimalField(name='f{}'.format(i), precision=precision, scale=2,
+        DecimalField(name=f'f{i}', precision=precision, scale=2,
                      bit_width=64)
         for i, precision in enumerate(range(3, 19))
     ]
@@ -1612,7 +1620,7 @@ def generate_decimal64_case():
 
 def generate_decimal128_case():
     fields = [
-        DecimalField(name='f{}'.format(i), precision=precision, scale=2,
+        DecimalField(name=f'f{i}', precision=precision, scale=2,
                      bit_width=128)
         for i, precision in enumerate(range(3, 39))
     ]
@@ -1626,7 +1634,7 @@ def generate_decimal128_case():
 
 def generate_decimal256_case():
     fields = [
-        DecimalField(name='f{}'.format(i), precision=precision, scale=5,
+        DecimalField(name=f'f{i}', precision=precision, scale=5,
                      bit_width=256)
         for i, precision in enumerate(range(37, 70))
     ]

--- a/dev/archery/archery/integration/datagen.py
+++ b/dev/archery/archery/integration/datagen.py
@@ -37,11 +37,10 @@ from .util import (
 
 
 def metadata_key_values(pairs):
-    return [{'key': k, 'value': v} for k, v in pairs]
+    return [{"key": k, "value": v} for k, v in pairs]
 
 
 class Field:
-
     def __init__(self, name, *, nullable=True, metadata=None):
         self.name = name
         self.nullable = nullable
@@ -49,18 +48,18 @@ class Field:
 
     def get_json(self):
         entries = [
-            ('name', self.name),
-            ('type', self._get_type()),
-            ('nullable', self.nullable),
-            ('children', self._get_children()),
+            ("name", self.name),
+            ("type", self._get_type()),
+            ("nullable", self.nullable),
+            ("children", self._get_children()),
         ]
 
         dct = self._get_dictionary()
         if dct:
-            entries.append(('dictionary', dct))
+            entries.append(("dictionary", dct))
 
         if self.metadata is not None and len(self.metadata) > 0:
-            entries.append(('metadata', metadata_key_values(self.metadata)))
+            entries.append(("metadata", metadata_key_values(self.metadata)))
 
         return OrderedDict(entries)
 
@@ -69,14 +68,12 @@ class Field:
 
     def _make_is_valid(self, size, null_probability=0.4):
         if self.nullable:
-            return (np.random.random_sample(size) > null_probability
-                    ).astype(np.int8)
+            return (np.random.random_sample(size) > null_probability).astype(np.int8)
         else:
             return np.ones(size, dtype=np.int8)
 
 
 class Column:
-
     def __init__(self, name, count):
         self.name = name
         self.count = count
@@ -91,29 +88,24 @@ class Column:
         return []
 
     def get_json(self):
-        entries = [
-            ('name', self.name),
-            ('count', self.count)
-        ]
+        entries = [("name", self.name), ("count", self.count)]
 
         buffers = self._get_buffers()
         entries.extend(buffers)
 
         children = self._get_children()
         if len(children) > 0:
-            entries.append(('children', children))
+            entries.append(("children", children))
 
         return OrderedDict(entries)
 
 
 class PrimitiveField(Field):
-
     def _get_children(self):
         return []
 
 
 class PrimitiveColumn(Column):
-
     def __init__(self, name, count, is_valid, values):
         super().__init__(name, count)
         self.is_valid = is_valid
@@ -135,30 +127,33 @@ class NullColumn(Column):
 
 
 class NullField(PrimitiveField):
-
     def __init__(self, name, metadata=None):
-        super().__init__(name, nullable=True,
-                         metadata=metadata)
+        super().__init__(name, nullable=True, metadata=metadata)
 
     def _get_type(self):
-        return OrderedDict([('name', 'null')])
+        return OrderedDict([("name", "null")])
 
     def generate_column(self, size, name=None):
         return NullColumn(name or self.name, size)
 
 
-TEST_INT_MAX = 2 ** 31 - 1
+TEST_INT_MAX = 2**31 - 1
 TEST_INT_MIN = ~TEST_INT_MAX
 
 
 class IntegerField(PrimitiveField):
-
-    def __init__(self, name, is_signed, bit_width, *, nullable=True,
-                 metadata=None,
-                 min_value=TEST_INT_MIN,
-                 max_value=TEST_INT_MAX):
-        super().__init__(name, nullable=nullable,
-                         metadata=metadata)
+    def __init__(
+        self,
+        name,
+        is_signed,
+        bit_width,
+        *,
+        nullable=True,
+        metadata=None,
+        min_value=TEST_INT_MIN,
+        max_value=TEST_INT_MAX,
+    ):
+        super().__init__(name, nullable=nullable, metadata=metadata)
         self.is_signed = is_signed
         self.bit_width = bit_width
         self.min_value = min_value
@@ -166,10 +161,10 @@ class IntegerField(PrimitiveField):
 
     def _get_generated_data_bounds(self):
         if self.is_signed:
-            signed_iinfo = np.iinfo('int' + str(self.bit_width))
+            signed_iinfo = np.iinfo("int" + str(self.bit_width))
             min_value, max_value = signed_iinfo.min, signed_iinfo.max
         else:
-            unsigned_iinfo = np.iinfo('uint' + str(self.bit_width))
+            unsigned_iinfo = np.iinfo("uint" + str(self.bit_width))
             min_value, max_value = 0, unsigned_iinfo.max
 
         lower_bound = max(min_value, self.min_value)
@@ -177,19 +172,21 @@ class IntegerField(PrimitiveField):
         return lower_bound, upper_bound
 
     def _get_type(self):
-        return OrderedDict([
-            ('name', 'int'),
-            ('isSigned', self.is_signed),
-            ('bitWidth', self.bit_width)
-        ])
+        return OrderedDict(
+            [
+                ("name", "int"),
+                ("isSigned", self.is_signed),
+                ("bitWidth", self.bit_width),
+            ]
+        )
 
     def generate_column(self, size, name=None):
         lower_bound, upper_bound = self._get_generated_data_bounds()
-        return self.generate_range(size, lower_bound, upper_bound,
-                                   name=name, include_extremes=True)
+        return self.generate_range(
+            size, lower_bound, upper_bound, name=name, include_extremes=True
+        )
 
-    def generate_range(self, size, lower, upper, name=None,
-                       include_extremes=False):
+    def generate_range(self, size, lower, upper, name=None, include_extremes=False):
         values = np.random.randint(lower, upper, size=size, dtype=np.int64)
         if include_extremes and size >= 2:
             values[:2] = [lower, upper]
@@ -207,11 +204,16 @@ class IntegerField(PrimitiveField):
 class RunEndsField(IntegerField):
     # bit_width should only be one of 16/32/64
     def __init__(self, name, bit_width, *, metadata=None):
-        super().__init__(name, is_signed=True, bit_width=bit_width,
-                         nullable=False, metadata=metadata, min_value=1)
+        super().__init__(
+            name,
+            is_signed=True,
+            bit_width=bit_width,
+            nullable=False,
+            metadata=metadata,
+            min_value=1,
+        )
 
-    def generate_range(self, size, lower, upper, name=None,
-                       include_extremes=False):
+    def generate_range(self, size, lower, upper, name=None, include_extremes=False):
         rng = np.random.default_rng()
         # generate values that are strictly increasing with a min-value of
         # 1, but don't go higher than the max signed value for the given
@@ -232,35 +234,36 @@ class RunEndsField(IntegerField):
 
 
 class DateField(IntegerField):
-
     DAY = 0
     MILLISECOND = 1
 
     # 1/1/1 to 12/31/9999
-    _ranges = {
-        DAY: [-719162, 2932896],
-        MILLISECOND: [-62135596800000, 253402214400000]
-    }
+    _ranges = {DAY: [-719162, 2932896], MILLISECOND: [-62135596800000, 253402214400000]}
 
     def __init__(self, name, unit, *, nullable=True, metadata=None):
         bit_width = 32 if unit == self.DAY else 64
 
         min_value, max_value = self._ranges[unit]
         super().__init__(
-            name, True, bit_width,
-            nullable=nullable, metadata=metadata,
-            min_value=min_value, max_value=max_value
+            name,
+            True,
+            bit_width,
+            nullable=nullable,
+            metadata=metadata,
+            min_value=min_value,
+            max_value=max_value,
         )
         self.unit = unit
 
     def _get_type(self):
-        return OrderedDict([
-            ('name', 'date'),
-            ('unit', 'DAY' if self.unit == self.DAY else 'MILLISECOND')
-        ])
+        return OrderedDict(
+            [
+                ("name", "date"),
+                ("unit", "DAY" if self.unit == self.DAY else "MILLISECOND"),
+            ]
+        )
 
-    def generate_range(self, size, lower, upper, name=None,
-                       include_extremes=False):
+    def generate_range(self, size, lower, upper, name=None, include_extremes=False):
         if self.unit == self.DAY:
             return super().generate_range(size, lower, upper, name)
 
@@ -268,8 +271,10 @@ class DateField(IntegerField):
         lower = -1 * (abs(lower) // full_day_millis)
         upper //= full_day_millis
 
-        values = [val * full_day_millis for val in np.random.randint(
-            lower, upper, size=size, dtype=np.int64)]
+        values = [
+            val * full_day_millis
+            for val in np.random.randint(lower, upper, size=size, dtype=np.int64)
+        ]
         lower *= full_day_millis
         upper *= full_day_millis
 
@@ -285,143 +290,142 @@ class DateField(IntegerField):
 
 
 TIMEUNIT_NAMES = {
-    's': 'SECOND',
-    'ms': 'MILLISECOND',
-    'us': 'MICROSECOND',
-    'ns': 'NANOSECOND'
+    "s": "SECOND",
+    "ms": "MILLISECOND",
+    "us": "MICROSECOND",
+    "ns": "NANOSECOND",
 }
 
 
 class TimeField(IntegerField):
-
-    BIT_WIDTHS = {
-        's': 32,
-        'ms': 32,
-        'us': 64,
-        'ns': 64
-    }
+    BIT_WIDTHS = {"s": 32, "ms": 32, "us": 64, "ns": 64}
 
     _ranges = {
-        's': [0, 86400],
-        'ms': [0, 86400000],
-        'us': [0, 86400000000],
-        'ns': [0, 86400000000000]
+        "s": [0, 86400],
+        "ms": [0, 86400000],
+        "us": [0, 86400000000],
+        "ns": [0, 86400000000000],
     }
 
-    def __init__(self, name, unit='s', *, nullable=True,
-                 metadata=None):
+    def __init__(self, name, unit="s", *, nullable=True, metadata=None):
         min_val, max_val = self._ranges[unit]
-        super().__init__(name, True, self.BIT_WIDTHS[unit],
-                         nullable=nullable, metadata=metadata,
-                         min_value=min_val, max_value=max_val)
+        super().__init__(
+            name,
+            True,
+            self.BIT_WIDTHS[unit],
+            nullable=nullable,
+            metadata=metadata,
+            min_value=min_val,
+            max_value=max_val,
+        )
         self.unit = unit
 
     def _get_type(self):
-        return OrderedDict([
-            ('name', 'time'),
-            ('unit', TIMEUNIT_NAMES[self.unit]),
-            ('bitWidth', self.bit_width)
-        ])
+        return OrderedDict(
+            [
+                ("name", "time"),
+                ("unit", TIMEUNIT_NAMES[self.unit]),
+                ("bitWidth", self.bit_width),
+            ]
+        )
 
     def generate_column(self, size, name=None):
         lower_bound, upper_bound = self._get_generated_data_bounds()
-        return self.generate_range(size, lower_bound, upper_bound,
-                                   name=name)
+        return self.generate_range(size, lower_bound, upper_bound, name=name)
 
 
 class TimestampField(IntegerField):
-
     # 1/1/1 to 12/31/9999
     _ranges = {
-        's': [-62135596800, 253402214400],
-        'ms': [-62135596800000, 253402214400000],
-        'us': [-62135596800000000, 253402214400000000],
-
+        "s": [-62135596800, 253402214400],
+        "ms": [-62135596800000, 253402214400000],
+        "us": [-62135596800000000, 253402214400000000],
         # Physical range for int64, ~584 years and change
-        'ns': [np.iinfo('int64').min, np.iinfo('int64').max]
+        "ns": [np.iinfo("int64").min, np.iinfo("int64").max],
     }
 
-    def __init__(self, name, unit='s', tz=None, *, nullable=True,
-                 metadata=None):
+    def __init__(self, name, unit="s", tz=None, *, nullable=True, metadata=None):
         min_val, max_val = self._ranges[unit]
-        super().__init__(name, True, 64,
-                         nullable=nullable,
-                         metadata=metadata,
-                         min_value=min_val,
-                         max_value=max_val)
+        super().__init__(
+            name,
+            True,
+            64,
+            nullable=nullable,
+            metadata=metadata,
+            min_value=min_val,
+            max_value=max_val,
+        )
         self.unit = unit
         self.tz = tz
 
     def _get_type(self):
-        fields = [
-            ('name', 'timestamp'),
-            ('unit', TIMEUNIT_NAMES[self.unit])
-        ]
+        fields = [("name", "timestamp"), ("unit", TIMEUNIT_NAMES[self.unit])]
 
         if self.tz is not None:
-            fields.append(('timezone', self.tz))
+            fields.append(("timezone", self.tz))
 
         return OrderedDict(fields)
 
 
 class DurationIntervalField(IntegerField):
-
-    def __init__(self, name, unit='s', *, nullable=True,
-                 metadata=None):
-        min_val, max_val = np.iinfo('int64').min, np.iinfo('int64').max,
+    def __init__(self, name, unit="s", *, nullable=True, metadata=None):
+        min_val, max_val = np.iinfo("int64").min, np.iinfo("int64").max
         super().__init__(
-            name, True, 64,
-            nullable=nullable, metadata=metadata,
-            min_value=min_val, max_value=max_val)
+            name,
+            True,
+            64,
+            nullable=nullable,
+            metadata=metadata,
+            min_value=min_val,
+            max_value=max_val,
+        )
         self.unit = unit
 
     def _get_type(self):
-        fields = [
-            ('name', 'duration'),
-            ('unit', TIMEUNIT_NAMES[self.unit])
-        ]
+        fields = [("name", "duration"), ("unit", TIMEUNIT_NAMES[self.unit])]
 
         return OrderedDict(fields)
 
 
 class YearMonthIntervalField(IntegerField):
     def __init__(self, name, *, nullable=True, metadata=None):
-        min_val, max_val = [-10000*12, 10000*12]  # +/- 10000 years.
+        min_val, max_val = [-10000 * 12, 10000 * 12]  # +/- 10000 years.
         super().__init__(
-            name, True, 32,
-            nullable=nullable, metadata=metadata,
-            min_value=min_val, max_value=max_val)
+            name,
+            True,
+            32,
+            nullable=nullable,
+            metadata=metadata,
+            min_value=min_val,
+            max_value=max_val,
+        )
 
     def _get_type(self):
-        fields = [
-            ('name', 'interval'),
-            ('unit', 'YEAR_MONTH'),
-        ]
+        fields = [("name", "interval"), ("unit", "YEAR_MONTH")]
 
         return OrderedDict(fields)
 
 
 class DayTimeIntervalField(PrimitiveField):
     def __init__(self, name, *, nullable=True, metadata=None):
-        super().__init__(name,
-                         nullable=True,
-                         metadata=metadata)
+        super().__init__(name, nullable=True, metadata=metadata)
 
     @property
     def numpy_type(self):
         return object
 
     def _get_type(self):
-        return OrderedDict([
-            ('name', 'interval'),
-            ('unit', 'DAY_TIME'),
-        ])
+        return OrderedDict([("name", "interval"), ("unit", "DAY_TIME")])
 
     def generate_column(self, size, name=None):
-        min_day_value, max_day_value = -10000*366, 10000*366
-        values = [{'days': random.randint(min_day_value, max_day_value),
-                   'milliseconds': random.randint(-86400000, +86400000)}
-                  for _ in range(size)]
+        min_day_value, max_day_value = -10000 * 366, 10000 * 366
+        values = [
+            {
+                "days": random.randint(min_day_value, max_day_value),
+                "milliseconds": random.randint(-86400000, +86400000),
+            }
+            for _ in range(size)
+        ]
 
         is_valid = self._make_is_valid(size)
         if name is None:
@@ -431,29 +435,28 @@ class DayTimeIntervalField(PrimitiveField):
 
 class MonthDayNanoIntervalField(PrimitiveField):
     def __init__(self, name, *, nullable=True, metadata=None):
-        super().__init__(name,
-                         nullable=True,
-                         metadata=metadata)
+        super().__init__(name, nullable=True, metadata=metadata)
 
     @property
     def numpy_type(self):
         return object
 
     def _get_type(self):
-        return OrderedDict([
-            ('name', 'interval'),
-            ('unit', 'MONTH_DAY_NANO'),
-        ])
+        return OrderedDict([("name", "interval"), ("unit", "MONTH_DAY_NANO")])
 
     def generate_column(self, size, name=None):
-        I32 = 'int32'
+        I32 = "int32"
         min_int_value, max_int_value = np.iinfo(I32).min, np.iinfo(I32).max
-        I64 = 'int64'
-        min_nano_val, max_nano_val = np.iinfo(I64).min, np.iinfo(I64).max,
-        values = [{'months': random.randint(min_int_value, max_int_value),
-                   'days': random.randint(min_int_value, max_int_value),
-                   'nanoseconds': random.randint(min_nano_val, max_nano_val)}
-                  for _ in range(size)]
+        I64 = "int64"
+        min_nano_val, max_nano_val = np.iinfo(I64).min, np.iinfo(I64).max
+        values = [
+            {
+                "months": random.randint(min_int_value, max_int_value),
+                "days": random.randint(min_int_value, max_int_value),
+                "nanoseconds": random.randint(min_nano_val, max_nano_val),
+            }
+            for _ in range(size)
+        ]
 
         is_valid = self._make_is_valid(size)
         if name is None:
@@ -462,29 +465,18 @@ class MonthDayNanoIntervalField(PrimitiveField):
 
 
 class FloatingPointField(PrimitiveField):
-
-    def __init__(self, name, bit_width, *, nullable=True,
-                 metadata=None):
-        super().__init__(name,
-                         nullable=nullable,
-                         metadata=metadata)
+    def __init__(self, name, bit_width, *, nullable=True, metadata=None):
+        super().__init__(name, nullable=nullable, metadata=metadata)
 
         self.bit_width = bit_width
-        self.precision = {
-            16: 'HALF',
-            32: 'SINGLE',
-            64: 'DOUBLE'
-        }[self.bit_width]
+        self.precision = {16: "HALF", 32: "SINGLE", 64: "DOUBLE"}[self.bit_width]
 
     @property
     def numpy_type(self):
-        return 'float' + str(self.bit_width)
+        return "float" + str(self.bit_width)
 
     def _get_type(self):
-        return OrderedDict([
-            ('name', 'floatingpoint'),
-            ('precision', self.precision)
-        ])
+        return OrderedDict([("name", "floatingpoint"), ("precision", self.precision)])
 
     def generate_column(self, size, name=None):
         values = np.random.randn(size) * 1000
@@ -498,15 +490,15 @@ class FloatingPointField(PrimitiveField):
 
 def decimal_range_from_precision(precision):
     assert 1 <= precision <= 76
-    max_value = (10 ** precision) - 1
+    max_value = (10**precision) - 1
     return -max_value, max_value
 
 
 class DecimalField(PrimitiveField):
-    def __init__(self, name, precision, scale, bit_width, *,
-                 nullable=True, metadata=None):
-        super().__init__(name, nullable=True,
-                         metadata=metadata)
+    def __init__(
+        self, name, precision, scale, bit_width, *, nullable=True, metadata=None
+    ):
+        super().__init__(name, nullable=True, metadata=metadata)
         self.precision = precision
         self.scale = scale
         self.bit_width = bit_width
@@ -516,12 +508,14 @@ class DecimalField(PrimitiveField):
         return object
 
     def _get_type(self):
-        return OrderedDict([
-            ('name', 'decimal'),
-            ('precision', self.precision),
-            ('scale', self.scale),
-            ('bitWidth', self.bit_width),
-        ])
+        return OrderedDict(
+            [
+                ("name", "decimal"),
+                ("precision", self.precision),
+                ("scale", self.scale),
+                ("bitWidth", self.bit_width),
+            ]
+        )
 
     def generate_column(self, size, name=None):
         min_value, max_value = decimal_range_from_precision(self.precision)
@@ -534,7 +528,6 @@ class DecimalField(PrimitiveField):
 
 
 class DecimalColumn(PrimitiveColumn):
-
     def __init__(self, name, count, is_valid, values, bit_width):
         super().__init__(name, count, is_valid, values)
         self.bit_width = bit_width
@@ -547,11 +540,11 @@ class BooleanField(PrimitiveField):
     bit_width = 1
 
     def _get_type(self):
-        return OrderedDict([('name', 'bool')])
+        return OrderedDict([("name", "bool")])
 
     @property
     def numpy_type(self):
-        return 'bool'
+        return "bool"
 
     def generate_column(self, size, name=None):
         values = list(map(bool, np.random.randint(0, 2, size=size)))
@@ -562,11 +555,8 @@ class BooleanField(PrimitiveField):
 
 
 class FixedSizeBinaryField(PrimitiveField):
-
-    def __init__(self, name, byte_width, *, nullable=True,
-                 metadata=None):
-        super().__init__(name, nullable=nullable,
-                         metadata=metadata)
+    def __init__(self, name, byte_width, *, nullable=True, metadata=None):
+        super().__init__(name, nullable=nullable, metadata=metadata)
         self.byte_width = byte_width
 
     @property
@@ -578,8 +568,9 @@ class FixedSizeBinaryField(PrimitiveField):
         return FixedSizeBinaryColumn
 
     def _get_type(self):
-        return OrderedDict([('name', 'fixedsizebinary'),
-                            ('byteWidth', self.byte_width)])
+        return OrderedDict(
+            [("name", "fixedsizebinary"), ("byteWidth", self.byte_width)]
+        )
 
     def generate_column(self, size, name=None):
         is_valid = self._make_is_valid(size)
@@ -594,7 +585,6 @@ class FixedSizeBinaryField(PrimitiveField):
 
 
 class BinaryField(PrimitiveField):
-
     @property
     def numpy_type(self):
         return object
@@ -604,7 +594,7 @@ class BinaryField(PrimitiveField):
         return BinaryColumn
 
     def _get_type(self):
-        return OrderedDict([('name', 'binary')])
+        return OrderedDict([("name", "binary")])
 
     def _random_sizes(self, size):
         return np.random.exponential(scale=4, size=size).astype(np.int32)
@@ -627,13 +617,12 @@ class BinaryField(PrimitiveField):
 
 
 class StringField(BinaryField):
-
     @property
     def column_class(self):
         return StringColumn
 
     def _get_type(self):
-        return OrderedDict([('name', 'utf8')])
+        return OrderedDict([("name", "utf8")])
 
     def generate_column(self, size, name=None):
         K = 7
@@ -652,70 +641,61 @@ class StringField(BinaryField):
 
 
 class LargeBinaryField(BinaryField):
-
     @property
     def column_class(self):
         return LargeBinaryColumn
 
     def _get_type(self):
-        return OrderedDict([('name', 'largebinary')])
+        return OrderedDict([("name", "largebinary")])
 
 
 class LargeStringField(StringField):
-
     @property
     def column_class(self):
         return LargeStringColumn
 
     def _get_type(self):
-        return OrderedDict([('name', 'largeutf8')])
+        return OrderedDict([("name", "largeutf8")])
 
 
 class BinaryViewField(BinaryField):
-
     @property
     def column_class(self):
         return BinaryViewColumn
 
     def _get_type(self):
-        return OrderedDict([('name', 'binaryview')])
+        return OrderedDict([("name", "binaryview")])
 
 
 class StringViewField(StringField):
-
     @property
     def column_class(self):
         return StringViewColumn
 
     def _get_type(self):
-        return OrderedDict([('name', 'utf8view')])
+        return OrderedDict([("name", "utf8view")])
 
 
 class Schema:
-
     def __init__(self, fields, metadata=None):
         self.fields = fields
         self.metadata = metadata
 
     def get_json(self):
-        entries = [
-            ('fields', [field.get_json() for field in self.fields])
-        ]
+        entries = [("fields", [field.get_json() for field in self.fields])]
 
         if self.metadata is not None and len(self.metadata) > 0:
-            entries.append(('metadata', metadata_key_values(self.metadata)))
+            entries.append(("metadata", metadata_key_values(self.metadata)))
 
         return OrderedDict(entries)
 
 
 class _NarrowOffsetsMixin:
-
     def _encode_offsets(self, offsets):
         return list(map(int, offsets))
 
 
 class _LargeOffsetsMixin:
-
     def _encode_offsets(self, offsets):
         # 64-bit offsets have to be represented as strings to roundtrip
         # through JSON.
@@ -723,7 +703,6 @@ class _LargeOffsetsMixin:
 
 
 class _BaseBinaryColumn(PrimitiveColumn):
-
     def _encode_value(self, x):
         return frombytes(binascii.hexlify(x).upper())
 
@@ -742,14 +721,13 @@ class _BaseBinaryColumn(PrimitiveColumn):
             data.append(self._encode_value(v))
 
         return [
-            ('VALIDITY', [int(x) for x in self.is_valid]),
-            ('OFFSET', self._encode_offsets(offsets)),
-            ('DATA', data)
+            ("VALIDITY", [int(x) for x in self.is_valid]),
+            ("OFFSET", self._encode_offsets(offsets)),
+            ("DATA", data),
         ]
 
 
 class _BaseStringColumn(_BaseBinaryColumn):
-
     def _encode_value(self, x):
         return frombytes(x)
 
@@ -771,7 +749,6 @@ class LargeStringColumn(_BaseStringColumn, _LargeOffsetsMixin):
 
 
 class BinaryViewColumn(PrimitiveColumn):
-
     def _encode_value(self, x):
         return frombytes(binascii.hexlify(x).upper())
 
@@ -785,15 +762,14 @@ class BinaryViewColumn(PrimitiveColumn):
 
         for i, v in enumerate(self.values):
             if not self.is_valid[i]:
-                v = b''
+                v = b""
             assert isinstance(v, bytes)
 
             if len(v) <= INLINE_SIZE:
                 # Append an inline view, skip data buffer management.
-                views.append(OrderedDict([
-                    ('SIZE', len(v)),
-                    ('INLINED', self._encode_value(v)),
-                ]))
+                views.append(
+                    OrderedDict([("SIZE", len(v)), ("INLINED", self._encode_value(v))])
+                )
                 continue
 
             if len(data_buffers) == 0:
@@ -815,31 +791,33 @@ class BinaryViewColumn(PrimitiveColumn):
             # even if the whole string view is
             prefix = frombytes(binascii.hexlify(v[:4]).upper())
 
-            views.append(OrderedDict([
-                ('SIZE', len(v)),
-                ('PREFIX_HEX', prefix),
-                ('BUFFER_INDEX', len(data_buffers) - 1),
-                ('OFFSET', offset),
-            ]))
+            views.append(
+                OrderedDict(
+                    [
+                        ("SIZE", len(v)),
+                        ("PREFIX_HEX", prefix),
+                        ("BUFFER_INDEX", len(data_buffers) - 1),
+                        ("OFFSET", offset),
+                    ]
+                )
+            )
 
         return [
-            ('VALIDITY', [int(x) for x in self.is_valid]),
-            ('VIEWS', views),
-            ('VARIADIC_DATA_BUFFERS', [
-                frombytes(binascii.hexlify(b).upper())
-                for b in data_buffers
-            ]),
+            ("VALIDITY", [int(x) for x in self.is_valid]),
+            ("VIEWS", views),
+            (
+                "VARIADIC_DATA_BUFFERS",
+                [frombytes(binascii.hexlify(b).upper()) for b in data_buffers],
+            ),
         ]
 
 
 class StringViewColumn(BinaryViewColumn):
-
     def _encode_value(self, x):
         return frombytes(x)
 
 
 class FixedSizeBinaryColumn(PrimitiveColumn):
-
     def _encode_value(self, x):
         return frombytes(binascii.hexlify(x).upper())
 
@@ -848,18 +826,12 @@ class FixedSizeBinaryColumn(PrimitiveColumn):
         for _i, v in enumerate(self.values):
             data.append(self._encode_value(v))
 
-        return [
-            ('VALIDITY', [int(x) for x in self.is_valid]),
-            ('DATA', data)
-        ]
+        return [("VALIDITY", [int(x) for x in self.is_valid]), ("DATA", data)]
 
 
 class ListField(Field):
-
-    def __init__(self, name, value_field, *, nullable=True,
-                 metadata=None):
-        super().__init__(name, nullable=nullable,
-                         metadata=metadata)
+    def __init__(self, name, value_field, *, nullable=True, metadata=None):
+        super().__init__(name, nullable=nullable, metadata=metadata)
         self.value_field = value_field
 
     @property
@@ -867,9 +839,7 @@ class ListField(Field):
         return ListColumn
 
     def _get_type(self):
-        return OrderedDict([
-            ('name', 'list')
-        ])
+        return OrderedDict([("name", "list")])
 
     def _get_children(self):
         return [self.value_field.get_json()]
@@ -896,19 +866,15 @@ class ListField(Field):
 
 
 class LargeListField(ListField):
-
     @property
     def column_class(self):
         return LargeListColumn
 
     def _get_type(self):
-        return OrderedDict([
-            ('name', 'largelist')
-        ])
+        return OrderedDict([("name", "largelist")])
 
 
 class _BaseListColumn(Column):
-
     def __init__(self, name, count, is_valid, offsets, values):
         super().__init__(name, count)
         self.is_valid = is_valid
@@ -917,8 +883,8 @@ class _BaseListColumn(Column):
 
     def _get_buffers(self):
         return [
-            ('VALIDITY', [int(v) for v in self.is_valid]),
-            ('OFFSET', self._encode_offsets(self.offsets))
+            ("VALIDITY", [int(v) for v in self.is_valid]),
+            ("OFFSET", self._encode_offsets(self.offsets)),
         ]
 
     def _get_children(self):
@@ -934,11 +900,8 @@ class LargeListColumn(_BaseListColumn, _LargeOffsetsMixin):
 
 
 class ListViewField(Field):
-
-    def __init__(self, name, value_field, *, nullable=True,
-                 metadata=None):
-        super().__init__(name, nullable=nullable,
-                         metadata=metadata)
+    def __init__(self, name, value_field, *, nullable=True, metadata=None):
+        super().__init__(name, nullable=nullable, metadata=metadata)
         self.value_field = value_field
 
     @property
@@ -946,9 +909,7 @@ class ListViewField(Field):
         return ListViewColumn
 
     def _get_type(self):
-        return OrderedDict([
-            ('name', 'listview')
-        ])
+        return OrderedDict([("name", "listview")])
 
     def _get_children(self):
         return [self.value_field.get_json()]
@@ -971,19 +932,15 @@ class ListViewField(Field):
 
 
 class LargeListViewField(ListViewField):
-
     @property
     def column_class(self):
         return LargeListViewColumn
 
     def _get_type(self):
-        return OrderedDict([
-            ('name', 'largelistview')
-        ])
+        return OrderedDict([("name", "largelistview")])
 
 
 class _BaseListViewColumn(Column):
-
     def __init__(self, name, count, is_valid, offsets, sizes, values):
         super().__init__(name, count)
         self.is_valid = is_valid
@@ -993,9 +950,9 @@ class _BaseListViewColumn(Column):
 
     def _get_buffers(self):
         return [
-            ('VALIDITY', [int(v) for v in self.is_valid]),
-            ('OFFSET', self._encode_offsets(self.offsets)),
-            ('SIZE', self._encode_offsets(self.sizes)),
+            ("VALIDITY", [int(v) for v in self.is_valid]),
+            ("OFFSET", self._encode_offsets(self.offsets)),
+            ("SIZE", self._encode_offsets(self.sizes)),
         ]
 
     def _get_children(self):
@@ -1011,24 +968,29 @@ class LargeListViewColumn(_BaseListViewColumn, _LargeOffsetsMixin):
 
 
 class MapField(Field):
-
-    def __init__(self, name, key_field, item_field, *, nullable=True,
-                 metadata=None, keys_sorted=False, entries_name='entries'):
-        super().__init__(name, nullable=nullable,
-                         metadata=metadata)
+    def __init__(
+        self,
+        name,
+        key_field,
+        item_field,
+        *,
+        nullable=True,
+        metadata=None,
+        keys_sorted=False,
+        entries_name="entries",
+    ):
+        super().__init__(name, nullable=nullable, metadata=metadata)
 
         assert not key_field.nullable
         self.key_field = key_field
         self.item_field = item_field
-        self.pair_field = StructField(entries_name, [key_field, item_field],
-                                      nullable=False)
+        self.pair_field = StructField(
+            entries_name, [key_field, item_field], nullable=False
+        )
         self.keys_sorted = keys_sorted
 
     def _get_type(self):
-        return OrderedDict([
-            ('name', 'map'),
-            ('keysSorted', self.keys_sorted)
-        ])
+        return OrderedDict([("name", "map"), ("keysSorted", self.keys_sorted)])
 
     def _get_children(self):
         return [self.pair_field.get_json()]
@@ -1055,7 +1017,6 @@ class MapField(Field):
 
 
 class MapColumn(Column):
-
     def __init__(self, name, count, is_valid, offsets, pairs):
         super().__init__(name, count)
         self.is_valid = is_valid
@@ -1064,8 +1025,8 @@ class MapColumn(Column):
 
     def _get_buffers(self):
         return [
-            ('VALIDITY', [int(v) for v in self.is_valid]),
-            ('OFFSET', list(self.offsets))
+            ("VALIDITY", [int(v) for v in self.is_valid]),
+            ("OFFSET", list(self.offsets)),
         ]
 
     def _get_children(self):
@@ -1073,19 +1034,13 @@ class MapColumn(Column):
 
 
 class FixedSizeListField(Field):
-
-    def __init__(self, name, value_field, list_size, *, nullable=True,
-                 metadata=None):
-        super().__init__(name, nullable=nullable,
-                         metadata=metadata)
+    def __init__(self, name, value_field, list_size, *, nullable=True, metadata=None):
+        super().__init__(name, nullable=nullable, metadata=metadata)
         self.value_field = value_field
         self.list_size = list_size
 
     def _get_type(self):
-        return OrderedDict([
-            ('name', 'fixedsizelist'),
-            ('listSize', self.list_size)
-        ])
+        return OrderedDict([("name", "fixedsizelist"), ("listSize", self.list_size)])
 
     def _get_children(self):
         return [self.value_field.get_json()]
@@ -1100,33 +1055,25 @@ class FixedSizeListField(Field):
 
 
 class FixedSizeListColumn(Column):
-
     def __init__(self, name, count, is_valid, values):
         super().__init__(name, count)
         self.is_valid = is_valid
         self.values = values
 
     def _get_buffers(self):
-        return [
-            ('VALIDITY', [int(v) for v in self.is_valid])
-        ]
+        return [("VALIDITY", [int(v) for v in self.is_valid])]
 
     def _get_children(self):
         return [self.values.get_json()]
 
 
 class StructField(Field):
-
-    def __init__(self, name, fields, *, nullable=True,
-                 metadata=None):
-        super().__init__(name, nullable=nullable,
-                         metadata=metadata)
+    def __init__(self, name, fields, *, nullable=True, metadata=None):
+        super().__init__(name, nullable=nullable, metadata=metadata)
         self.fields = fields
 
     def _get_type(self):
-        return OrderedDict([
-            ('name', 'struct')
-        ])
+        return OrderedDict([("name", "struct")])
 
     def _get_children(self):
         return [field.get_json() for field in self.fields]
@@ -1141,23 +1088,18 @@ class StructField(Field):
 
 
 class RunEndEncodedField(Field):
-
-    def __init__(self, name, run_ends_bitwidth, values_field, *, nullable=True,
-                 metadata=None):
+    def __init__(
+        self, name, run_ends_bitwidth, values_field, *, nullable=True, metadata=None
+    ):
         super().__init__(name, nullable=nullable, metadata=metadata)
-        self.run_ends_field = RunEndsField('run_ends', run_ends_bitwidth)
+        self.run_ends_field = RunEndsField("run_ends", run_ends_bitwidth)
         self.values_field = values_field
 
     def _get_type(self):
-        return OrderedDict([
-            ('name', 'runendencoded')
-        ])
+        return OrderedDict([("name", "runendencoded")])
 
     def _get_children(self):
-        return [
-            self.run_ends_field.get_json(),
-            self.values_field.get_json()
-        ]
+        return [self.run_ends_field.get_json(), self.values_field.get_json()]
 
     def generate_column(self, size, name=None):
         values = self.values_field.generate_column(size)
@@ -1168,9 +1110,7 @@ class RunEndEncodedField(Field):
 
 
 class _BaseUnionField(Field):
-
-    def __init__(self, name, fields, type_ids=None, *, nullable=True,
-                 metadata=None):
+    def __init__(self, name, fields, type_ids=None, *, nullable=True, metadata=None):
         super().__init__(name, nullable=nullable, metadata=metadata)
         if type_ids is None:
             type_ids = list(range(fields))
@@ -1181,11 +1121,9 @@ class _BaseUnionField(Field):
         assert all(x >= 0 for x in self.type_ids)
 
     def _get_type(self):
-        return OrderedDict([
-            ('name', 'union'),
-            ('mode', self.mode),
-            ('typeIds', self.type_ids),
-        ])
+        return OrderedDict(
+            [("name", "union"), ("mode", self.mode), ("typeIds", self.type_ids)]
+        )
 
     def _get_children(self):
         return [field.get_json() for field in self.fields]
@@ -1195,7 +1133,7 @@ class _BaseUnionField(Field):
 
 
 class SparseUnionField(_BaseUnionField):
-    mode = 'SPARSE'
+    mode = "SPARSE"
 
     def generate_column(self, size, name=None):
         array_type_ids = self._make_type_ids(size)
@@ -1207,7 +1145,7 @@ class SparseUnionField(_BaseUnionField):
 
 
 class DenseUnionField(_BaseUnionField):
-    mode = 'DENSE'
+    mode = "DENSE"
 
     def generate_column(self, size, name=None):
         # Reverse mapping {logical type id => physical child id}
@@ -1227,16 +1165,15 @@ class DenseUnionField(_BaseUnionField):
 
         field_values = [
             field.generate_column(child_size)
-            for field, child_size in zip(self.fields, child_sizes)]
+            for field, child_size in zip(self.fields, child_sizes)
+        ]
 
         if name is None:
             name = self.name
-        return DenseUnionColumn(name, size, array_type_ids, offsets,
-                                field_values)
+        return DenseUnionColumn(name, size, array_type_ids, offsets, field_values)
 
 
 class Dictionary:
-
     def __init__(self, id_, field, size, name=None, ordered=False):
         self.id_ = id_
         self.field = field
@@ -1248,19 +1185,13 @@ class Dictionary:
 
     def get_json(self):
         dummy_batch = RecordBatch(len(self.values), [self.values])
-        return OrderedDict([
-            ('id', self.id_),
-            ('data', dummy_batch.get_json())
-        ])
+        return OrderedDict([("id", self.id_), ("data", dummy_batch.get_json())])
 
 
 class DictionaryField(Field):
-
-    def __init__(self, name, index_field, dictionary, *, nullable=True,
-                 metadata=None):
-        super().__init__(name, nullable=nullable,
-                         metadata=metadata)
-        assert index_field.name == ''
+    def __init__(self, name, index_field, dictionary, *, nullable=True, metadata=None):
+        super().__init__(name, nullable=nullable, metadata=metadata)
+        assert index_field.name == ""
         assert isinstance(index_field, IntegerField)
         assert isinstance(dictionary, Dictionary)
 
@@ -1274,29 +1205,30 @@ class DictionaryField(Field):
         return self.dictionary.field._get_children()
 
     def _get_dictionary(self):
-        return OrderedDict([
-            ('id', self.dictionary.id_),
-            ('indexType', self.index_field._get_type()),
-            ('isOrdered', self.dictionary.ordered)
-        ])
+        return OrderedDict(
+            [
+                ("id", self.dictionary.id_),
+                ("indexType", self.index_field._get_type()),
+                ("isOrdered", self.dictionary.ordered),
+            ]
+        )
 
     def generate_column(self, size, name=None):
         if name is None:
             name = self.name
-        return self.index_field.generate_range(size, 0, len(self.dictionary),
-                                               name=name)
+        return self.index_field.generate_range(size, 0, len(self.dictionary), name=name)
 
 
 ExtensionType = namedtuple(
-    'ExtensionType', ['extension_name', 'serialized', 'storage_field'])
+    "ExtensionType", ["extension_name", "serialized", "storage_field"]
+)
 
 
 class ExtensionField(Field):
-
     def __init__(self, name, extension_type, *, nullable=True, metadata=None):
         metadata = (metadata or []) + [
-            ('ARROW:extension:name', extension_type.extension_name),
-            ('ARROW:extension:metadata', extension_type.serialized),
+            ("ARROW:extension:name", extension_type.extension_name),
+            ("ARROW:extension:metadata", extension_type.serialized),
         ]
         super().__init__(name, nullable=nullable, metadata=metadata)
         self.extension_type = extension_type
@@ -1317,23 +1249,19 @@ class ExtensionField(Field):
 
 
 class StructColumn(Column):
-
     def __init__(self, name, count, is_valid, field_values):
         super().__init__(name, count)
         self.is_valid = is_valid
         self.field_values = field_values
 
     def _get_buffers(self):
-        return [
-            ('VALIDITY', [int(v) for v in self.is_valid])
-        ]
+        return [("VALIDITY", [int(v) for v in self.is_valid])]
 
     def _get_children(self):
         return [field.get_json() for field in self.field_values]
 
 
 class RunEndEncodedColumn(Column):
-
     def __init__(self, name, count, run_ends_field, values_field):
         super().__init__(name, count)
         self.run_ends = run_ends_field
@@ -1347,23 +1275,19 @@ class RunEndEncodedColumn(Column):
 
 
 class SparseUnionColumn(Column):
-
     def __init__(self, name, count, type_ids, field_values):
         super().__init__(name, count)
         self.type_ids = type_ids
         self.field_values = field_values
 
     def _get_buffers(self):
-        return [
-            ('TYPE_ID', [int(v) for v in self.type_ids])
-        ]
+        return [("TYPE_ID", [int(v) for v in self.type_ids])]
 
     def _get_children(self):
         return [field.get_json() for field in self.field_values]
 
 
 class DenseUnionColumn(Column):
-
     def __init__(self, name, count, type_ids, offsets, field_values):
         super().__init__(name, count)
         self.type_ids = type_ids
@@ -1372,8 +1296,8 @@ class DenseUnionColumn(Column):
 
     def _get_buffers(self):
         return [
-            ('TYPE_ID', [int(v) for v in self.type_ids]),
-            ('OFFSET', [int(v) for v in self.offsets]),
+            ("TYPE_ID", [int(v) for v in self.type_ids]),
+            ("OFFSET", [int(v) for v in self.offsets]),
         ]
 
     def _get_children(self):
@@ -1381,22 +1305,30 @@ class DenseUnionColumn(Column):
 
 
 class RecordBatch:
-
     def __init__(self, count, columns):
         self.count = count
         self.columns = columns
 
     def get_json(self):
-        return OrderedDict([
-            ('count', self.count),
-            ('columns', [col.get_json() for col in self.columns])
-        ])
+        return OrderedDict(
+            [
+                ("count", self.count),
+                ("columns", [col.get_json() for col in self.columns]),
+            ]
+        )
 
 
 class File:
-
-    def __init__(self, name, schema, batches, dictionaries=None,
-                 skip_testers=None, path=None, quirks=None):
+    def __init__(
+        self,
+        name,
+        schema,
+        batches,
+        dictionaries=None,
+        skip_testers=None,
+        path=None,
+        quirks=None,
+    ):
         self.name = name
         self.schema = schema
         self.dictionaries = dictionaries or []
@@ -1413,88 +1345,82 @@ class File:
             self.quirks.update(quirks)
 
     def get_json(self):
-        entries = [
-            ('schema', self.schema.get_json())
-        ]
+        entries = [("schema", self.schema.get_json())]
 
         if len(self.dictionaries) > 0:
-            entries.append(('dictionaries',
-                            [dictionary.get_json()
-                             for dictionary in self.dictionaries]))
+            entries.append(
+                (
+                    "dictionaries",
+                    [dictionary.get_json() for dictionary in self.dictionaries],
+                )
+            )
 
-        entries.append(('batches', [batch.get_json()
-                                    for batch in self.batches]))
+        entries.append(("batches", [batch.get_json() for batch in self.batches]))
         return OrderedDict(entries)
 
     def write(self, path):
-        with open(path, 'wb') as f:
-            f.write(json.dumps(self.get_json(), indent=2).encode('utf-8'))
+        with open(path, "wb") as f:
+            f.write(json.dumps(self.get_json(), indent=2).encode("utf-8"))
         self.path = path
 
     def skip_tester(self, tester):
-        """Skip this test for the given tester (such as 'C#').
-        """
+        """Skip this test for the given tester (such as 'C#')."""
         self.skipped_testers.add(tester)
         return self
 
-    def skip_format(self, format, tester='all'):
-        """Skip this test for the given format, and optionally tester.
-        """
+    def skip_format(self, format, tester="all"):
+        """Skip this test for the given format, and optionally tester."""
         self.skipped_formats.setdefault(format, set()).add(tester)
         return self
 
     def add_skips_from(self, other_file):
-        """Add skips from another File object.
-        """
+        """Add skips from another File object."""
         self.skipped_testers.update(other_file.skipped_testers)
         for format, testers in other_file.skipped_formats.items():
             self.skipped_formats.setdefault(format, set()).update(testers)
 
     def should_skip(self, tester, format):
-        """Whether this (tester, format) combination should be skipped.
-        """
+        """Whether this (tester, format) combination should be skipped."""
         if tester in self.skipped_testers:
             return True
         testers = self.skipped_formats.get(format, ())
-        return 'all' in testers or tester in testers
+        return "all" in testers or tester in testers
 
     @property
     def num_batches(self):
-        """The number of record batches in this file.
-        """
+        """The number of record batches in this file."""
         return len(self.batches)
 
 
 def get_field(name, type_, **kwargs):
-    if type_ == 'binary':
+    if type_ == "binary":
         return BinaryField(name, **kwargs)
-    elif type_ == 'utf8':
+    elif type_ == "utf8":
         return StringField(name, **kwargs)
-    elif type_ == 'largebinary':
+    elif type_ == "largebinary":
         return LargeBinaryField(name, **kwargs)
-    elif type_ == 'largeutf8':
+    elif type_ == "largeutf8":
         return LargeStringField(name, **kwargs)
-    elif type_.startswith('fixedsizebinary_'):
-        byte_width = int(type_.split('_')[1])
+    elif type_.startswith("fixedsizebinary_"):
+        byte_width = int(type_.split("_")[1])
         return FixedSizeBinaryField(name, byte_width=byte_width, **kwargs)
 
     dtype = np.dtype(type_)
 
-    if dtype.kind in ('i', 'u'):
-        signed = dtype.kind == 'i'
+    if dtype.kind in ("i", "u"):
+        signed = dtype.kind == "i"
         bit_width = dtype.itemsize * 8
         return IntegerField(name, signed, bit_width, **kwargs)
-    elif dtype.kind == 'f':
+    elif dtype.kind == "f":
         bit_width = dtype.itemsize * 8
         return FloatingPointField(name, bit_width, **kwargs)
-    elif dtype.kind == 'b':
+    elif dtype.kind == "b":
         return BooleanField(name, **kwargs)
     else:
         raise TypeError(dtype)
 
 
-def _generate_file(name, fields, batch_sizes, *,
-                   dictionaries=None, metadata=None):
+def _generate_file(name, fields, batch_sizes, *, dictionaries=None, metadata=None):
     schema = Schema(fields, metadata=metadata)
     batches = []
     for size in batch_sizes:
@@ -1512,47 +1438,64 @@ def generate_custom_metadata_case():
     def meta(items):
         # Generate a simple block of metadata where each value is '{}'.
         # Keys are delimited by whitespace in `items`.
-        return [(k, '{}') for k in items.split()]
+        return [(k, "{}") for k in items.split()]
 
     fields = [
-        get_field('sort_of_pandas', 'int8', metadata=meta('pandas')),
-
-        get_field('lots_of_meta', 'int8', metadata=meta('a b c d .. w x y z')),
-
+        get_field("sort_of_pandas", "int8", metadata=meta("pandas")),
+        get_field("lots_of_meta", "int8", metadata=meta("a b c d .. w x y z")),
         get_field(
-            'unregistered_extension', 'int8',
+            "unregistered_extension",
+            "int8",
             metadata=[
-                ('ARROW:extension:name', '!nonexistent'),
-                ('ARROW:extension:metadata', ''),
-                ('ARROW:integration:allow_unregistered_extension', 'true'),
-            ]),
-
-        ListField('list_with_odd_values',
-                  get_field('item', 'int32', metadata=meta('odd_values'))),
+                ("ARROW:extension:name", "!nonexistent"),
+                ("ARROW:extension:metadata", ""),
+                ("ARROW:integration:allow_unregistered_extension", "true"),
+            ],
+        ),
+        ListField(
+            "list_with_odd_values",
+            get_field("item", "int32", metadata=meta("odd_values")),
+        ),
     ]
 
     batch_sizes = [1]
-    return _generate_file('custom_metadata', fields, batch_sizes,
-                          metadata=meta('schema_custom_0 schema_custom_1'))
+    return _generate_file(
+        "custom_metadata",
+        fields,
+        batch_sizes,
+        metadata=meta("schema_custom_0 schema_custom_1"),
+    )
 
 
 def generate_duplicate_fieldnames_case():
     fields = [
-        get_field('ints', 'int8'),
-        get_field('ints', 'int32'),
-
-        StructField('struct', [get_field('', 'int32'), get_field('', 'utf8')]),
+        get_field("ints", "int8"),
+        get_field("ints", "int32"),
+        StructField("struct", [get_field("", "int32"), get_field("", "utf8")]),
     ]
 
     batch_sizes = [1]
-    return _generate_file('duplicate_fieldnames', fields, batch_sizes)
+    return _generate_file("duplicate_fieldnames", fields, batch_sizes)
 
 
-def generate_primitive_case(batch_sizes, name='primitive'):
-    types = ['bool', 'int8', 'int16', 'int32', 'int64',
-             'uint8', 'uint16', 'uint32', 'uint64',
-             'float32', 'float64', 'binary', 'utf8',
-             'fixedsizebinary_19', 'fixedsizebinary_120']
+def generate_primitive_case(batch_sizes, name="primitive"):
+    types = [
+        "bool",
+        "int8",
+        "int16",
+        "int32",
+        "int64",
+        "uint8",
+        "uint16",
+        "uint32",
+        "uint64",
+        "float32",
+        "float64",
+        "binary",
+        "utf8",
+        "fixedsizebinary_19",
+        "fixedsizebinary_120",
+    ]
 
     fields = []
 
@@ -1564,7 +1507,7 @@ def generate_primitive_case(batch_sizes, name='primitive'):
 
 
 def generate_primitive_large_offsets_case(batch_sizes):
-    types = ['largebinary', 'largeutf8']
+    types = ["largebinary", "largeutf8"]
 
     fields = []
 
@@ -1572,56 +1515,51 @@ def generate_primitive_large_offsets_case(batch_sizes):
         fields.append(get_field(type_ + "_nullable", type_, nullable=True))
         fields.append(get_field(type_ + "_nonnullable", type_, nullable=False))
 
-    return _generate_file('primitive_large_offsets', fields, batch_sizes)
+    return _generate_file("primitive_large_offsets", fields, batch_sizes)
 
 
 def generate_null_case(batch_sizes):
     # Interleave null with non-null types to ensure the appropriate number of
     # buffers (0) is read and written
     fields = [
-        NullField(name='f0'),
-        get_field('f1', 'int32'),
-        NullField(name='f2'),
-        get_field('f3', 'float64'),
-        NullField(name='f4')
+        NullField(name="f0"),
+        get_field("f1", "int32"),
+        NullField(name="f2"),
+        get_field("f3", "float64"),
+        NullField(name="f4"),
     ]
-    return _generate_file('null', fields, batch_sizes)
+    return _generate_file("null", fields, batch_sizes)
 
 
 def generate_null_trivial_case(batch_sizes):
     # Generate a case with no buffers
-    fields = [
-        NullField(name='f0'),
-    ]
-    return _generate_file('null_trivial', fields, batch_sizes)
+    fields = [NullField(name="f0")]
+    return _generate_file("null_trivial", fields, batch_sizes)
 
 
 def generate_decimal32_case():
     fields = [
-        DecimalField(name=f'f{i}', precision=precision, scale=2,
-                     bit_width=32)
+        DecimalField(name=f"f{i}", precision=precision, scale=2, bit_width=32)
         for i, precision in enumerate(range(3, 10))
     ]
 
     batch_sizes = [7, 10]
-    return _generate_file('decimal32', fields, batch_sizes)
+    return _generate_file("decimal32", fields, batch_sizes)
 
 
 def generate_decimal64_case():
     fields = [
-        DecimalField(name=f'f{i}', precision=precision, scale=2,
-                     bit_width=64)
+        DecimalField(name=f"f{i}", precision=precision, scale=2, bit_width=64)
         for i, precision in enumerate(range(3, 19))
     ]
 
     batch_sizes = [7, 10]
-    return _generate_file('decimal64', fields, batch_sizes)
+    return _generate_file("decimal64", fields, batch_sizes)
 
 
 def generate_decimal128_case():
     fields = [
-        DecimalField(name=f'f{i}', precision=precision, scale=2,
-                     bit_width=128)
+        DecimalField(name=f"f{i}", precision=precision, scale=2, bit_width=128)
         for i, precision in enumerate(range(3, 39))
     ]
 
@@ -1629,37 +1567,36 @@ def generate_decimal128_case():
     # 'decimal' is the original name for the test, and it must match
     # provide "gold" files that test backwards compatibility, so they
     # can be appropriately skipped.
-    return _generate_file('decimal', fields, batch_sizes)
+    return _generate_file("decimal", fields, batch_sizes)
 
 
 def generate_decimal256_case():
     fields = [
-        DecimalField(name=f'f{i}', precision=precision, scale=5,
-                     bit_width=256)
+        DecimalField(name=f"f{i}", precision=precision, scale=5, bit_width=256)
         for i, precision in enumerate(range(37, 70))
     ]
 
     batch_sizes = [7, 10]
-    return _generate_file('decimal256', fields, batch_sizes)
+    return _generate_file("decimal256", fields, batch_sizes)
 
 
 def generate_datetime_case():
     fields = [
-        DateField('f0', DateField.DAY),
-        DateField('f1', DateField.MILLISECOND),
-        TimeField('f2', 's'),
-        TimeField('f3', 'ms'),
-        TimeField('f4', 'us'),
-        TimeField('f5', 'ns'),
-        TimestampField('f6', 's'),
-        TimestampField('f7', 'ms'),
-        TimestampField('f8', 'us'),
-        TimestampField('f9', 'ns'),
-        TimestampField('f10', 'ms', tz=None),
-        TimestampField('f11', 's', tz='UTC'),
-        TimestampField('f12', 'ms', tz='US/Eastern'),
-        TimestampField('f13', 'us', tz='Europe/Paris'),
-        TimestampField('f14', 'ns', tz='US/Pacific'),
+        DateField("f0", DateField.DAY),
+        DateField("f1", DateField.MILLISECOND),
+        TimeField("f2", "s"),
+        TimeField("f3", "ms"),
+        TimeField("f4", "us"),
+        TimeField("f5", "ns"),
+        TimestampField("f6", "s"),
+        TimestampField("f7", "ms"),
+        TimestampField("f8", "us"),
+        TimestampField("f9", "ns"),
+        TimestampField("f10", "ms", tz=None),
+        TimestampField("f11", "s", tz="UTC"),
+        TimestampField("f12", "ms", tz="US/Eastern"),
+        TimestampField("f13", "us", tz="Europe/Paris"),
+        TimestampField("f14", "ns", tz="US/Pacific"),
     ]
 
     batch_sizes = [7, 10]
@@ -1668,10 +1605,10 @@ def generate_datetime_case():
 
 def generate_duration_case():
     fields = [
-        DurationIntervalField('f1', 's'),
-        DurationIntervalField('f2', 'ms'),
-        DurationIntervalField('f3', 'us'),
-        DurationIntervalField('f4', 'ns'),
+        DurationIntervalField("f1", "s"),
+        DurationIntervalField("f2", "ms"),
+        DurationIntervalField("f3", "us"),
+        DurationIntervalField("f4", "ns"),
     ]
 
     batch_sizes = [7, 10]
@@ -1679,19 +1616,14 @@ def generate_duration_case():
 
 
 def generate_interval_case():
-    fields = [
-        YearMonthIntervalField('f5'),
-        DayTimeIntervalField('f6'),
-    ]
+    fields = [YearMonthIntervalField("f5"), DayTimeIntervalField("f6")]
 
     batch_sizes = [7, 10]
     return _generate_file("interval", fields, batch_sizes)
 
 
 def generate_month_day_nano_interval_case():
-    fields = [
-        MonthDayNanoIntervalField('f1'),
-    ]
+    fields = [MonthDayNanoIntervalField("f1")]
 
     batch_sizes = [7, 10]
     return _generate_file("interval_mdn", fields, batch_sizes)
@@ -1699,8 +1631,11 @@ def generate_month_day_nano_interval_case():
 
 def generate_map_case():
     fields = [
-        MapField('map_nullable', get_field('key', 'utf8', nullable=False),
-                 get_field('value', 'int32')),
+        MapField(
+            "map_nullable",
+            get_field("key", "utf8", nullable=False),
+            get_field("value", "int32"),
+        )
     ]
 
     batch_sizes = [7, 10]
@@ -1709,10 +1644,12 @@ def generate_map_case():
 
 def generate_non_canonical_map_case():
     fields = [
-        MapField('map_other_names',
-                 get_field('some_key', 'utf8', nullable=False),
-                 get_field('some_value', 'int32'),
-                 entries_name='some_entries'),
+        MapField(
+            "map_other_names",
+            get_field("some_key", "utf8", nullable=False),
+            get_field("some_value", "int32"),
+            entries_name="some_entries",
+        )
     ]
 
     batch_sizes = [7]
@@ -1721,11 +1658,11 @@ def generate_non_canonical_map_case():
 
 def generate_nested_case():
     fields = [
-        ListField('list_nullable', get_field('item', 'int32')),
-        FixedSizeListField('fixedsizelist_nullable',
-                           get_field('item', 'int32'), 4),
-        StructField('struct_nullable', [get_field('f1', 'int32'),
-                                        get_field('f2', 'utf8')]),
+        ListField("list_nullable", get_field("item", "int32")),
+        FixedSizeListField("fixedsizelist_nullable", get_field("item", "int32"), 4),
+        StructField(
+            "struct_nullable", [get_field("f1", "int32"), get_field("f2", "utf8")]
+        ),
         # Fails on Go (ARROW-8452)
         # ListField('list_nonnullable', get_field('item', 'int32'),
         #           nullable=False),
@@ -1737,12 +1674,13 @@ def generate_nested_case():
 
 def generate_recursive_nested_case():
     fields = [
-        ListField('lists_list',
-                  ListField('inner_list', get_field('item', 'int16'))),
-        ListField('structs_list',
-                  StructField('inner_struct',
-                              [get_field('f1', 'int32'),
-                               get_field('f2', 'utf8')])),
+        ListField("lists_list", ListField("inner_list", get_field("item", "int16"))),
+        ListField(
+            "structs_list",
+            StructField(
+                "inner_struct", [get_field("f1", "int32"), get_field("f2", "utf8")]
+            ),
+        ),
     ]
 
     batch_sizes = [7, 10]
@@ -1751,27 +1689,24 @@ def generate_recursive_nested_case():
 
 def generate_run_end_encoded_case():
     fields = [
-        RunEndEncodedField('ree16', 16, get_field('values', 'int32')),
-        RunEndEncodedField('ree32', 32, get_field('values', 'utf8')),
-        RunEndEncodedField('ree64', 64, get_field('values', 'float32')),
+        RunEndEncodedField("ree16", 16, get_field("values", "int32")),
+        RunEndEncodedField("ree32", 32, get_field("values", "utf8")),
+        RunEndEncodedField("ree64", 64, get_field("values", "float32")),
     ]
     batch_sizes = [0, 7, 10]
     return _generate_file("run_end_encoded", fields, batch_sizes)
 
 
 def generate_binary_view_case():
-    fields = [
-        BinaryViewField('bv'),
-        StringViewField('sv'),
-    ]
+    fields = [BinaryViewField("bv"), StringViewField("sv")]
     batch_sizes = [0, 7, 256]
     return _generate_file("binary_view", fields, batch_sizes)
 
 
 def generate_list_view_case():
     fields = [
-        ListViewField('lv', get_field('item', 'float32')),
-        LargeListViewField('llv', get_field('item', 'float32')),
+        ListViewField("lv", get_field("item", "float32")),
+        LargeListViewField("llv", get_field("item", "float32")),
     ]
     batch_sizes = [0, 7, 256]
     return _generate_file("list_view", fields, batch_sizes)
@@ -1779,11 +1714,13 @@ def generate_list_view_case():
 
 def generate_nested_large_offsets_case():
     fields = [
-        LargeListField('large_list_nullable', get_field('item', 'int32')),
-        LargeListField('large_list_nonnullable',
-                       get_field('item', 'int32'), nullable=False),
-        LargeListField('large_list_nested',
-                       ListField('inner_list', get_field('item', 'int16'))),
+        LargeListField("large_list_nullable", get_field("item", "int32")),
+        LargeListField(
+            "large_list_nonnullable", get_field("item", "int32"), nullable=False
+        ),
+        LargeListField(
+            "large_list_nested", ListField("inner_list", get_field("item", "int16"))
+        ),
     ]
 
     batch_sizes = [0, 13]
@@ -1792,19 +1729,32 @@ def generate_nested_large_offsets_case():
 
 def generate_unions_case():
     fields = [
-        SparseUnionField('sparse_1', [get_field('f1', 'int32'),
-                                      get_field('f2', 'utf8')],
-                         type_ids=[5, 7]),
-        DenseUnionField('dense_1', [get_field('f1', 'int16'),
-                                    get_field('f2', 'binary')],
-                        type_ids=[10, 20]),
-        SparseUnionField('sparse_2', [get_field('f1', 'float32', nullable=False),
-                                      get_field('f2', 'bool')],
-                         type_ids=[5, 7], nullable=False),
-        DenseUnionField('dense_2', [get_field('f1', 'uint8', nullable=False),
-                                    get_field('f2', 'uint16'),
-                                    NullField('f3')],
-                        type_ids=[42, 43, 44], nullable=False),
+        SparseUnionField(
+            "sparse_1",
+            [get_field("f1", "int32"), get_field("f2", "utf8")],
+            type_ids=[5, 7],
+        ),
+        DenseUnionField(
+            "dense_1",
+            [get_field("f1", "int16"), get_field("f2", "binary")],
+            type_ids=[10, 20],
+        ),
+        SparseUnionField(
+            "sparse_2",
+            [get_field("f1", "float32", nullable=False), get_field("f2", "bool")],
+            type_ids=[5, 7],
+            nullable=False,
+        ),
+        DenseUnionField(
+            "dense_2",
+            [
+                get_field("f1", "uint8", nullable=False),
+                get_field("f2", "uint16"),
+                NullField("f3"),
+            ],
+            type_ids=[42, 43, 44],
+            nullable=False,
+        ),
     ]
 
     batch_sizes = [0, 11]
@@ -1812,200 +1762,175 @@ def generate_unions_case():
 
 
 def generate_dictionary_case():
-    dict0 = Dictionary(0, StringField('dictionary1'), size=10, name='DICT0')
-    dict1 = Dictionary(1, StringField('dictionary1'), size=5, name='DICT1')
-    dict2 = Dictionary(2, get_field('dictionary2', 'int64'),
-                       size=50, name='DICT2')
+    dict0 = Dictionary(0, StringField("dictionary1"), size=10, name="DICT0")
+    dict1 = Dictionary(1, StringField("dictionary1"), size=5, name="DICT1")
+    dict2 = Dictionary(2, get_field("dictionary2", "int64"), size=50, name="DICT2")
 
     fields = [
-        DictionaryField('dict0', get_field('', 'int8'), dict0),
-        DictionaryField('dict1', get_field('', 'int32'), dict1),
-        DictionaryField('dict2', get_field('', 'int16'), dict2)
+        DictionaryField("dict0", get_field("", "int8"), dict0),
+        DictionaryField("dict1", get_field("", "int32"), dict1),
+        DictionaryField("dict2", get_field("", "int16"), dict2),
     ]
     batch_sizes = [7, 10]
-    return _generate_file("dictionary", fields, batch_sizes,
-                          dictionaries=[dict0, dict1, dict2])
+    return _generate_file(
+        "dictionary", fields, batch_sizes, dictionaries=[dict0, dict1, dict2]
+    )
 
 
 def generate_dictionary_unsigned_case():
-    dict0 = Dictionary(0, StringField('dictionary0'), size=5, name='DICT0')
-    dict1 = Dictionary(1, StringField('dictionary1'), size=5, name='DICT1')
-    dict2 = Dictionary(2, StringField('dictionary2'), size=5, name='DICT2')
+    dict0 = Dictionary(0, StringField("dictionary0"), size=5, name="DICT0")
+    dict1 = Dictionary(1, StringField("dictionary1"), size=5, name="DICT1")
+    dict2 = Dictionary(2, StringField("dictionary2"), size=5, name="DICT2")
 
     # TODO: JavaScript does not support uint64 dictionary indices, so disabled
     # for now
     # dict3 = Dictionary(3, StringField('dictionary3'), size=5, name='DICT3')
     fields = [
-        DictionaryField('f0', get_field('', 'uint8'), dict0),
-        DictionaryField('f1', get_field('', 'uint16'), dict1),
-        DictionaryField('f2', get_field('', 'uint32'), dict2),
+        DictionaryField("f0", get_field("", "uint8"), dict0),
+        DictionaryField("f1", get_field("", "uint16"), dict1),
+        DictionaryField("f2", get_field("", "uint32"), dict2),
         # DictionaryField('f3', get_field('', 'uint64'), dict3)
     ]
     batch_sizes = [7, 10]
-    return _generate_file("dictionary_unsigned", fields, batch_sizes,
-                          dictionaries=[dict0, dict1, dict2])
+    return _generate_file(
+        "dictionary_unsigned", fields, batch_sizes, dictionaries=[dict0, dict1, dict2]
+    )
 
 
 def generate_nested_dictionary_case():
-    dict0 = Dictionary(0, StringField('str'), size=10, name='DICT0')
+    dict0 = Dictionary(0, StringField("str"), size=10, name="DICT0")
 
     list_of_dict = ListField(
-        'list',
-        DictionaryField('str_dict', get_field('', 'int8'), dict0))
-    dict1 = Dictionary(1, list_of_dict, size=30, name='DICT1')
+        "list", DictionaryField("str_dict", get_field("", "int8"), dict0)
+    )
+    dict1 = Dictionary(1, list_of_dict, size=30, name="DICT1")
 
-    struct_of_dict = StructField('struct', [
-        DictionaryField('str_dict_a', get_field('', 'int8'), dict0),
-        DictionaryField('str_dict_b', get_field('', 'int8'), dict0)
-    ])
-    dict2 = Dictionary(2, struct_of_dict, size=30, name='DICT2')
+    struct_of_dict = StructField(
+        "struct",
+        [
+            DictionaryField("str_dict_a", get_field("", "int8"), dict0),
+            DictionaryField("str_dict_b", get_field("", "int8"), dict0),
+        ],
+    )
+    dict2 = Dictionary(2, struct_of_dict, size=30, name="DICT2")
 
     fields = [
-        DictionaryField('list_dict', get_field('', 'int8'), dict1),
-        DictionaryField('struct_dict', get_field('', 'int8'), dict2)
+        DictionaryField("list_dict", get_field("", "int8"), dict1),
+        DictionaryField("struct_dict", get_field("", "int8"), dict2),
     ]
 
     batch_sizes = [10, 13]
-    return _generate_file("nested_dictionary", fields, batch_sizes,
-                          dictionaries=[dict0, dict1, dict2])
+    return _generate_file(
+        "nested_dictionary", fields, batch_sizes, dictionaries=[dict0, dict1, dict2]
+    )
 
 
 def generate_extension_case():
-    dict0 = Dictionary(0, StringField('dictionary0'), size=5, name='DICT0')
+    dict0 = Dictionary(0, StringField("dictionary0"), size=5, name="DICT0")
 
-    uuid_type = ExtensionType('arrow.uuid', '',
-                              FixedSizeBinaryField('', 16))
+    uuid_type = ExtensionType("arrow.uuid", "", FixedSizeBinaryField("", 16))
     dict_ext_type = ExtensionType(
-        'dict-extension', 'dict-extension-serialized',
-        DictionaryField('str_dict', get_field('', 'int8'), dict0))
+        "dict-extension",
+        "dict-extension-serialized",
+        DictionaryField("str_dict", get_field("", "int8"), dict0),
+    )
 
     fields = [
-        ExtensionField('uuids', uuid_type),
-        ExtensionField('dict_exts', dict_ext_type),
+        ExtensionField("uuids", uuid_type),
+        ExtensionField("dict_exts", dict_ext_type),
     ]
 
     batch_sizes = [0, 13]
-    return _generate_file("extension", fields, batch_sizes,
-                          dictionaries=[dict0])
+    return _generate_file("extension", fields, batch_sizes, dictionaries=[dict0])
 
 
 def get_generated_json_files(tempdir=None):
-    tempdir = tempdir or tempfile.mkdtemp(prefix='arrow-integration-')
+    tempdir = tempdir or tempfile.mkdtemp(prefix="arrow-integration-")
 
     def _temp_path():
         return
 
     file_objs = [
-        generate_primitive_case([], name='primitive_no_batches'),
-        generate_primitive_case([17, 20], name='primitive'),
-        generate_primitive_case([0, 0, 0], name='primitive_zerolength'),
-
+        generate_primitive_case([], name="primitive_no_batches"),
+        generate_primitive_case([17, 20], name="primitive"),
+        generate_primitive_case([0, 0, 0], name="primitive_zerolength"),
         generate_primitive_large_offsets_case([17, 20]),
-
         generate_null_case([10, 0]),
-
         generate_null_trivial_case([0, 0]),
-
         generate_decimal128_case(),
-
-        generate_decimal256_case()
-        .skip_tester('JS'),
-
+        generate_decimal256_case().skip_tester("JS"),
         generate_decimal32_case()
-        .skip_tester('Java')
-        .skip_tester('JS')
-        .skip_tester('nanoarrow')
-        .skip_tester('Rust')
-        .skip_tester('Go'),
-
+        .skip_tester("Java")
+        .skip_tester("JS")
+        .skip_tester("nanoarrow")
+        .skip_tester("Rust")
+        .skip_tester("Go"),
         generate_decimal64_case()
-        .skip_tester('Java')
-        .skip_tester('JS')
-        .skip_tester('nanoarrow')
-        .skip_tester('Rust')
-        .skip_tester('Go'),
-
+        .skip_tester("Java")
+        .skip_tester("JS")
+        .skip_tester("nanoarrow")
+        .skip_tester("Rust")
+        .skip_tester("Go"),
         generate_datetime_case(),
-
         generate_duration_case(),
-
         generate_interval_case(),
-
         generate_month_day_nano_interval_case(),
-
         generate_map_case(),
-
         generate_non_canonical_map_case()
-        .skip_tester('Java')  # TODO(ARROW-8715)
+        .skip_tester("Java")  # TODO(ARROW-8715)
         # Canonical map names are restored on import, so the schemas are unequal
-        .skip_format(SKIP_C_SCHEMA, 'C++'),
-
+        .skip_format(SKIP_C_SCHEMA, "C++"),
         generate_nested_case(),
-
         generate_recursive_nested_case(),
-
-        generate_nested_large_offsets_case()
-        .skip_tester('JS'),
-
+        generate_nested_large_offsets_case().skip_tester("JS"),
         generate_unions_case(),
-
         generate_custom_metadata_case(),
-
-        generate_duplicate_fieldnames_case()
-        .skip_tester('JS'),
-
+        generate_duplicate_fieldnames_case().skip_tester("JS"),
         generate_dictionary_case()
         # TODO(https://github.com/apache/arrow-nanoarrow/issues/622)
-        .skip_tester('nanoarrow')
+        .skip_tester("nanoarrow")
         # TODO(https://github.com/apache/arrow/issues/38045)
-        .skip_format(SKIP_FLIGHT, 'C#'),
-
+        .skip_format(SKIP_FLIGHT, "C#"),
         generate_dictionary_unsigned_case()
-        .skip_tester('nanoarrow')
-        .skip_tester('Java')  # TODO(ARROW-9377)
+        .skip_tester("nanoarrow")
+        .skip_tester("Java")  # TODO(ARROW-9377)
         # TODO(https://github.com/apache/arrow/issues/38045)
-        .skip_format(SKIP_FLIGHT, 'C#'),
-
+        .skip_format(SKIP_FLIGHT, "C#"),
         generate_nested_dictionary_case()
         # TODO(https://github.com/apache/arrow-nanoarrow/issues/622)
-        .skip_tester('nanoarrow')
-        .skip_tester('Java')  # TODO(ARROW-7779)
+        .skip_tester("nanoarrow")
+        .skip_tester("Java")  # TODO(ARROW-7779)
         # TODO(https://github.com/apache/arrow/issues/38045)
-        .skip_format(SKIP_FLIGHT, 'C#'),
-
+        .skip_format(SKIP_FLIGHT, "C#"),
         generate_run_end_encoded_case()
-        .skip_tester('C#')
-        .skip_tester('JS')
+        .skip_tester("C#")
+        .skip_tester("JS")
         # TODO(https://github.com/apache/arrow-nanoarrow/issues/618)
-        .skip_tester('nanoarrow')
-        .skip_tester('Rust'),
-
+        .skip_tester("nanoarrow")
+        .skip_tester("Rust"),
         generate_binary_view_case()
-        .skip_tester('JS')
+        .skip_tester("JS")
         # TODO(https://github.com/apache/arrow-nanoarrow/issues/618)
-        .skip_tester('nanoarrow')
-        .skip_tester('Rust'),
-
+        .skip_tester("nanoarrow")
+        .skip_tester("Rust"),
         generate_list_view_case()
-        .skip_tester('C#')     # Doesn't support large list views
-        .skip_tester('JS')
+        .skip_tester("C#")  # Doesn't support large list views
+        .skip_tester("JS")
         # TODO(https://github.com/apache/arrow-nanoarrow/issues/618)
-        .skip_tester('nanoarrow')
-        .skip_tester('Rust'),
-
+        .skip_tester("nanoarrow")
+        .skip_tester("Rust"),
         generate_extension_case()
-        .skip_tester('nanoarrow')
+        .skip_tester("nanoarrow")
         # TODO: ensure the extension is registered in the C++ entrypoint
-        .skip_format(SKIP_C_SCHEMA, 'C++')
-        .skip_format(SKIP_C_ARRAY, 'C++')
+        .skip_format(SKIP_C_SCHEMA, "C++")
+        .skip_format(SKIP_C_ARRAY, "C++")
         # TODO(https://github.com/apache/arrow/issues/38045)
-        .skip_format(SKIP_FLIGHT, 'C#'),
+        .skip_format(SKIP_FLIGHT, "C#"),
     ]
 
     generated_paths = []
     for file_obj in file_objs:
-        out_path = os.path.join(tempdir, 'generated_' +
-                                file_obj.name + '.json')
+        out_path = os.path.join(tempdir, "generated_" + file_obj.name + ".json")
         file_obj.write(out_path)
         generated_paths.append(file_obj)
 

--- a/dev/archery/archery/integration/runner.py
+++ b/dev/archery/archery/integration/runner.py
@@ -56,12 +56,20 @@ class Outcome:
 
 
 class IntegrationRunner:
-
-    def __init__(self, json_files,
-                 flight_scenarios: List[Scenario],
-                 testers: List[Tester], other_testers: List[Tester],
-                 tempdir=None, debug=False, stop_on_error=True, gold_dirs=None,
-                 serial=False, match=None, **unused_kwargs):
+    def __init__(
+        self,
+        json_files,
+        flight_scenarios: List[Scenario],
+        testers: List[Tester],
+        other_testers: List[Tester],
+        tempdir=None,
+        debug=False,
+        stop_on_error=True,
+        gold_dirs=None,
+        serial=False,
+        match=None,
+        **unused_kwargs,
+    ):
         self.json_files = json_files
         self.flight_scenarios = flight_scenarios
         self.testers = testers
@@ -76,54 +84,60 @@ class IntegrationRunner:
         self.match = match
 
         if self.match is not None:
-            print(f"-- Only running tests with {self.match} in their name"
-                  )
-            self.json_files = [json_file for json_file in self.json_files
-                               if self.match in json_file.name]
+            print(f"-- Only running tests with {self.match} in their name")
+            self.json_files = [
+                json_file
+                for json_file in self.json_files
+                if self.match in json_file.name
+            ]
 
     def run_ipc(self):
         """Run Arrow IPC integration tests for the matrix of enabled
         implementations.
         """
         for producer, consumer in itertools.product(
-                filter(lambda t: t.PRODUCER, self.testers),
-                filter(lambda t: t.CONSUMER, self.testers)):
+            filter(lambda t: t.PRODUCER, self.testers),
+            filter(lambda t: t.CONSUMER, self.testers),
+        ):
             self._compare_ipc_implementations(
-                producer, consumer, self._produce_consume,
-                self.json_files)
+                producer, consumer, self._produce_consume, self.json_files
+            )
 
         for producer, consumer in itertools.product(
-                filter(lambda t: t.PRODUCER, self.testers),
-                filter(lambda t: t.CONSUMER, self.other_testers)):
+            filter(lambda t: t.PRODUCER, self.testers),
+            filter(lambda t: t.CONSUMER, self.other_testers),
+        ):
             self._compare_ipc_implementations(
-                producer, consumer, self._produce_consume,
-                self.json_files)
+                producer, consumer, self._produce_consume, self.json_files
+            )
 
         for producer, consumer in itertools.product(
-                filter(lambda t: t.PRODUCER, self.other_testers),
-                filter(lambda t: t.CONSUMER, self.testers)):
+            filter(lambda t: t.PRODUCER, self.other_testers),
+            filter(lambda t: t.CONSUMER, self.testers),
+        ):
             self._compare_ipc_implementations(
-                producer, consumer, self._produce_consume,
-                self.json_files)
+                producer, consumer, self._produce_consume, self.json_files
+            )
 
         if self.gold_dirs:
             for gold_dir, consumer in itertools.product(
-                    self.gold_dirs,
-                    filter(lambda t: t.CONSUMER, self.testers)):
+                self.gold_dirs, filter(lambda t: t.CONSUMER, self.testers)
+            ):
                 with group(f"Integration: Test: IPC: Gold: {consumer.name}"):
-                    log('\n')
-                    log('******************************************************')
-                    log(f'Tests against golden files in {gold_dir}')
-                    log('******************************************************')
+                    log("\n")
+                    log("******************************************************")
+                    log(f"Tests against golden files in {gold_dir}")
+                    log("******************************************************")
 
                     def run_gold(
                         _, consumer, test_case: datagen.File, gold_dir=gold_dir
                     ):
                         return self._run_gold(gold_dir, consumer, test_case)
+
                     self._compare_ipc_implementations(
-                        consumer, consumer, run_gold,
-                        self._gold_tests(gold_dir))
-        log('\n')
+                        consumer, consumer, run_gold, self._gold_tests(gold_dir)
+                    )
+        log("\n")
 
     def run_flight(self):
         """Run Arrow Flight integration tests for the matrix of enabled
@@ -137,43 +151,46 @@ class IntegrationRunner:
             return t.FLIGHT_CLIENT and t.CONSUMER
 
         for server, client in itertools.product(
-                filter(is_server, self.testers),
-                filter(is_client, self.testers)):
+            filter(is_server, self.testers), filter(is_client, self.testers)
+        ):
             self._compare_flight_implementations(server, client)
         for server, client in itertools.product(
-                filter(is_server, self.testers),
-                filter(is_client, self.other_testers)):
+            filter(is_server, self.testers), filter(is_client, self.other_testers)
+        ):
             self._compare_flight_implementations(server, client)
         for server, client in itertools.product(
-                filter(is_server, self.other_testers),
-                filter(is_client, self.testers)):
+            filter(is_server, self.other_testers), filter(is_client, self.testers)
+        ):
             self._compare_flight_implementations(server, client)
-        log('\n')
+        log("\n")
 
     def run_c_data(self):
         """Run Arrow C Data interface integration tests for the matrix of
         enabled implementations.
         """
         for producer, consumer in itertools.product(
-                filter(lambda t: t.C_DATA_SCHEMA_EXPORTER, self.testers),
-                filter(lambda t: t.C_DATA_SCHEMA_IMPORTER, self.testers)):
+            filter(lambda t: t.C_DATA_SCHEMA_EXPORTER, self.testers),
+            filter(lambda t: t.C_DATA_SCHEMA_IMPORTER, self.testers),
+        ):
             self._compare_c_data_implementations(producer, consumer)
         for producer, consumer in itertools.product(
-                filter(lambda t: t.C_DATA_SCHEMA_EXPORTER, self.testers),
-                filter(lambda t: t.C_DATA_SCHEMA_IMPORTER, self.other_testers)):
+            filter(lambda t: t.C_DATA_SCHEMA_EXPORTER, self.testers),
+            filter(lambda t: t.C_DATA_SCHEMA_IMPORTER, self.other_testers),
+        ):
             self._compare_c_data_implementations(producer, consumer)
         for producer, consumer in itertools.product(
-                filter(lambda t: t.C_DATA_SCHEMA_EXPORTER, self.other_testers),
-                filter(lambda t: t.C_DATA_SCHEMA_IMPORTER, self.testers)):
+            filter(lambda t: t.C_DATA_SCHEMA_EXPORTER, self.other_testers),
+            filter(lambda t: t.C_DATA_SCHEMA_IMPORTER, self.testers),
+        ):
             self._compare_c_data_implementations(producer, consumer)
-        log('\n')
+        log("\n")
 
     def _gold_tests(self, gold_dir):
         prefix = os.path.basename(os.path.normpath(gold_dir))
         SUFFIX = ".json.gz"
         golds = [jf for jf in os.listdir(gold_dir) if jf.endswith(SUFFIX)]
         for json_path in golds:
-            name = json_path[json_path.index('_')+1: -len(SUFFIX)]
+            name = json_path[json_path.index("_") + 1 : -len(SUFFIX)]
             base_name = prefix + "_" + name + ".gold.json"
             out_path = os.path.join(self.temp_dir, base_name)
             with gzip.open(os.path.join(gold_dir, json_path)) as i:
@@ -182,13 +199,12 @@ class IntegrationRunner:
 
             # Find the generated file with the same name as this gold file
             try:
-                equiv_json_file = next(f for f in self.json_files
-                                       if f.name == name)
+                equiv_json_file = next(f for f in self.json_files if f.name == name)
             except StopIteration:
                 equiv_json_file = None
 
             skip_testers = set()
-            if name == 'union' and prefix == '0.17.1':
+            if name == "union" and prefix == "0.17.1":
                 skip_testers.add("Java")
                 skip_testers.add("JS")
             if prefix in ("1.0.0-bigendian", "1.0.0-littleendian"):
@@ -196,44 +212,51 @@ class IntegrationRunner:
                 skip_testers.add("Java")
                 skip_testers.add("JS")
                 skip_testers.add("Rust")
-            if prefix == '2.0.0-compression':
+            if prefix == "2.0.0-compression":
                 skip_testers.add("JS")
-            if prefix == '2.0.0-compression' and 'lz4' in name:
+            if prefix == "2.0.0-compression" and "lz4" in name:
                 # https://github.com/apache/arrow-nanoarrow/issues/621
                 skip_testers.add("nanoarrow")
 
             # See https://github.com/apache/arrow/pull/9822 for how to
             # disable specific compression type tests.
 
-            if prefix == '4.0.0-shareddict':
+            if prefix == "4.0.0-shareddict":
                 skip_testers.add("C#")
                 # https://github.com/apache/arrow-nanoarrow/issues/622
                 skip_testers.add("nanoarrow")
 
             quirks = set()
-            if prefix in {'0.14.1', '0.17.1',
-                          '1.0.0-bigendian', '1.0.0-littleendian'}:
+            if prefix in {"0.14.1", "0.17.1", "1.0.0-bigendian", "1.0.0-littleendian"}:
                 # ARROW-13558: older versions generated decimal values that
                 # were out of range for the given precision.
                 quirks.add("no_decimal_validate")
                 quirks.add("no_date64_validate")
                 quirks.add("no_times_validate")
 
-            json_file = datagen.File(name, schema=None, batches=None,
-                                     path=out_path,
-                                     skip_testers=skip_testers,
-                                     quirks=quirks)
+            json_file = datagen.File(
+                name,
+                schema=None,
+                batches=None,
+                path=out_path,
+                skip_testers=skip_testers,
+                quirks=quirks,
+            )
             if equiv_json_file is not None:
                 json_file.add_skips_from(equiv_json_file)
             yield json_file
 
-    def _run_test_cases(self,
-                        case_runner: Callable[[datagen.File], Outcome],
-                        test_cases: List[datagen.File],
-                        *, serial: Optional[bool] = None) -> None:
+    def _run_test_cases(
+        self,
+        case_runner: Callable[[datagen.File], Outcome],
+        test_cases: List[datagen.File],
+        *,
+        serial: Optional[bool] = None,
+    ) -> None:
         """Populate self.failures with the outcomes of the
         ``case_runner`` ran against ``test_cases``
         """
+
         def case_wrapper(test_case):
             if serial:
                 return case_runner(test_case)
@@ -270,18 +293,17 @@ class IntegrationRunner:
         producer: Tester,
         consumer: Tester,
         run_binaries: Callable[[Tester, Tester, datagen.File], None],
-        test_cases: List[datagen.File]
+        test_cases: List[datagen.File],
     ):
-        """Compare Arrow IPC for two implementations (one producer, one consumer).
-        """
+        """Compare Arrow IPC for two implementations (one producer, one consumer)."""
         with group(f"Integration: Test: IPC: {producer.name} -> {consumer.name}"):
-            log('##########################################################')
-            log(f'IPC: {producer.name} producing, {consumer.name} consuming'
-                )
-            log('##########################################################')
+            log("##########################################################")
+            log(f"IPC: {producer.name} producing, {consumer.name} consuming")
+            log("##########################################################")
 
-            case_runner = partial(self._run_ipc_test_case,
-                                  producer, consumer, run_binaries)
+            case_runner = partial(
+                self._run_ipc_test_case, producer, consumer, run_binaries
+            )
             self._run_test_cases(case_runner, test_cases)
 
     def _run_ipc_test_case(
@@ -291,22 +313,25 @@ class IntegrationRunner:
         run_binaries: Callable[[Tester, Tester, datagen.File], None],
         test_case: datagen.File,
     ) -> Outcome:
-        """Run one IPC test case.
-        """
+        """Run one IPC test case."""
         outcome = Outcome()
 
         json_path = test_case.path
-        log('=' * 70)
-        log(f'Testing file {json_path}')
+        log("=" * 70)
+        log(f"Testing file {json_path}")
 
         if test_case.should_skip(producer.name, SKIP_IPC):
-            log(f'-- Skipping test because producer {producer.name} does '
-                f'not support IPC')
+            log(
+                f"-- Skipping test because producer {producer.name} does "
+                f"not support IPC"
+            )
             outcome.skipped = True
 
         elif test_case.should_skip(consumer.name, SKIP_IPC):
-            log(f'-- Skipping test because consumer {consumer.name} does '
-                f'not support IPC')
+            log(
+                f"-- Skipping test because consumer {consumer.name} does "
+                f"not support IPC"
+            )
             outcome.skipped = True
 
         else:
@@ -314,18 +339,15 @@ class IntegrationRunner:
                 run_binaries(producer, consumer, test_case)
             except Exception:
                 traceback.print_exc(file=printer.stdout)
-                outcome.failure = Failure(test_case, producer, consumer,
-                                          sys.exc_info())
+                outcome.failure = Failure(test_case, producer, consumer, sys.exc_info())
 
-        log('=' * 70)
+        log("=" * 70)
 
         return outcome
 
-    def _produce_consume(self,
-                         producer: Tester,
-                         consumer: Tester,
-                         test_case: datagen.File
-                         ) -> None:
+    def _produce_consume(
+        self, producer: Tester, consumer: Tester, test_case: datagen.File
+    ) -> None:
         """Given a producer and a consumer, run different combination of
         tests for the ``test_case``
         * read and write are consistent
@@ -336,29 +358,31 @@ class IntegrationRunner:
         file_id = guid()[:8]
         name = os.path.splitext(os.path.basename(json_path))[0]
 
-        producer_file_path = os.path.join(self.temp_dir, file_id + '_' +
-                                          name + '.json_as_file')
-        producer_stream_path = os.path.join(self.temp_dir, file_id + '_' +
-                                            name + '.producer_file_as_stream')
-        consumer_file_path = os.path.join(self.temp_dir, file_id + '_' +
-                                          name + '.consumer_stream_as_file')
+        producer_file_path = os.path.join(
+            self.temp_dir, file_id + "_" + name + ".json_as_file"
+        )
+        producer_stream_path = os.path.join(
+            self.temp_dir, file_id + "_" + name + ".producer_file_as_stream"
+        )
+        consumer_file_path = os.path.join(
+            self.temp_dir, file_id + "_" + name + ".consumer_stream_as_file"
+        )
 
-        log('-- Creating binary inputs')
+        log("-- Creating binary inputs")
         producer.json_to_file(json_path, producer_file_path)
 
         # Validate the file
-        log('-- Validating file')
+        log("-- Validating file")
         consumer.validate(json_path, producer_file_path)
 
-        log('-- Validating stream')
+        log("-- Validating stream")
         producer.file_to_stream(producer_file_path, producer_stream_path)
         consumer.stream_to_file(producer_stream_path, consumer_file_path)
         consumer.validate(json_path, consumer_file_path)
 
-    def _run_gold(self,
-                  gold_dir: str,
-                  consumer: Tester,
-                  test_case: datagen.File) -> None:
+    def _run_gold(
+        self, gold_dir: str, consumer: Tester, test_case: datagen.File
+    ) -> None:
         """Given a directory with:
         * an ``.arrow_file``
         * a ``.stream``
@@ -372,69 +396,66 @@ class IntegrationRunner:
         json_path = test_case.path
 
         # Validate the file
-        log('-- Validating file')
+        log("-- Validating file")
         producer_file_path = os.path.join(
-            gold_dir, "generated_" + test_case.name + ".arrow_file")
-        consumer.validate(json_path, producer_file_path,
-                          quirks=test_case.quirks)
+            gold_dir, "generated_" + test_case.name + ".arrow_file"
+        )
+        consumer.validate(json_path, producer_file_path, quirks=test_case.quirks)
 
-        log('-- Validating stream')
+        log("-- Validating stream")
         consumer_stream_path = os.path.join(
-            gold_dir, "generated_" + test_case.name + ".stream")
+            gold_dir, "generated_" + test_case.name + ".stream"
+        )
         file_id = guid()[:8]
         name = os.path.splitext(os.path.basename(json_path))[0]
 
-        consumer_file_path = os.path.join(self.temp_dir, file_id + '_' +
-                                          name + '.consumer_stream_as_file')
+        consumer_file_path = os.path.join(
+            self.temp_dir, file_id + "_" + name + ".consumer_stream_as_file"
+        )
 
         consumer.stream_to_file(consumer_stream_path, consumer_file_path)
-        consumer.validate(json_path, consumer_file_path,
-                          quirks=test_case.quirks)
+        consumer.validate(json_path, consumer_file_path, quirks=test_case.quirks)
 
-    def _compare_flight_implementations(
-        self,
-        producer: Tester,
-        consumer: Tester
-    ):
+    def _compare_flight_implementations(self, producer: Tester, consumer: Tester):
         with group(f"Integration: Test: Flight: {producer.name} -> {consumer.name}"):
-            log('##########################################################')
-            log(f'Flight: {producer.name} serving, {consumer.name} requesting'
-                )
-            log('##########################################################')
+            log("##########################################################")
+            log(f"Flight: {producer.name} serving, {consumer.name} requesting")
+            log("##########################################################")
 
             case_runner = partial(self._run_flight_test_case, producer, consumer)
-            self._run_test_cases(
-                case_runner, self.json_files + self.flight_scenarios)
+            self._run_test_cases(case_runner, self.json_files + self.flight_scenarios)
 
-    def _run_flight_test_case(self,
-                              producer: Tester,
-                              consumer: Tester,
-                              test_case: datagen.File) -> Outcome:
-        """Run one Flight test case.
-        """
+    def _run_flight_test_case(
+        self, producer: Tester, consumer: Tester, test_case: datagen.File
+    ) -> Outcome:
+        """Run one Flight test case."""
         outcome = Outcome()
 
-        log('=' * 70)
-        log(f'Testing file {test_case.name}')
+        log("=" * 70)
+        log(f"Testing file {test_case.name}")
 
         if test_case.should_skip(producer.name, SKIP_FLIGHT):
-            log(f'-- Skipping test because producer {producer.name} does '
-                f'not support Flight')
+            log(
+                f"-- Skipping test because producer {producer.name} does "
+                f"not support Flight"
+            )
             outcome.skipped = True
 
         elif test_case.should_skip(consumer.name, SKIP_FLIGHT):
-            log(f'-- Skipping test because consumer {consumer.name} does '
-                f'not support Flight')
+            log(
+                f"-- Skipping test because consumer {consumer.name} does "
+                f"not support Flight"
+            )
             outcome.skipped = True
 
         else:
             try:
                 if isinstance(test_case, Scenario):
                     server = producer.flight_server(test_case.name)
-                    client_args = {'scenario_name': test_case.name}
+                    client_args = {"scenario_name": test_case.name}
                 else:
                     server = producer.flight_server()
-                    client_args = {'json_path': test_case.path}
+                    client_args = {"json_path": test_case.path}
 
                 with server as port:
                     # Have the client upload the file, then download and
@@ -442,51 +463,61 @@ class IntegrationRunner:
                     consumer.flight_request(port, **client_args)
             except Exception:
                 traceback.print_exc(file=printer.stdout)
-                outcome.failure = Failure(test_case, producer, consumer,
-                                          sys.exc_info())
+                outcome.failure = Failure(test_case, producer, consumer, sys.exc_info())
 
-        log('=' * 70)
+        log("=" * 70)
 
         return outcome
 
-    def _compare_c_data_implementations(
-        self,
-        producer: Tester,
-        consumer: Tester
-    ):
-        with group("Integration: Test: C Data Interface: "
-                   f"{producer.name} -> {consumer.name}"):
-            log('##########################################################')
-            log(f'C Data Interface: '
-                f'{producer.name} exporting, {consumer.name} importing')
-            log('##########################################################')
+    def _compare_c_data_implementations(self, producer: Tester, consumer: Tester):
+        with group(
+            f"Integration: Test: C Data Interface: {producer.name} -> {consumer.name}"
+        ):
+            log("##########################################################")
+            log(
+                f"C Data Interface: "
+                f"{producer.name} exporting, {consumer.name} importing"
+            )
+            log("##########################################################")
 
             # Serial execution is required for proper memory accounting
             serial = True
 
             with producer.make_c_data_exporter() as exporter:
                 with consumer.make_c_data_importer() as importer:
-                    case_runner = partial(self._run_c_schema_test_case,
-                                          producer, consumer,
-                                          exporter, importer)
+                    case_runner = partial(
+                        self._run_c_schema_test_case,
+                        producer,
+                        consumer,
+                        exporter,
+                        importer,
+                    )
                     self._run_test_cases(case_runner, self.json_files, serial=serial)
 
-                    if producer.C_DATA_ARRAY_EXPORTER and \
-                       consumer.C_DATA_ARRAY_IMPORTER:
-                        case_runner = partial(self._run_c_array_test_cases,
-                                              producer, consumer,
-                                              exporter, importer)
-                        self._run_test_cases(case_runner,
-                                             self.json_files,
-                                             serial=serial)
+                    if (
+                        producer.C_DATA_ARRAY_EXPORTER
+                        and consumer.C_DATA_ARRAY_IMPORTER
+                    ):
+                        case_runner = partial(
+                            self._run_c_array_test_cases,
+                            producer,
+                            consumer,
+                            exporter,
+                            importer,
+                        )
+                        self._run_test_cases(
+                            case_runner, self.json_files, serial=serial
+                        )
 
-    def _run_c_schema_test_case(self,
-                                producer: Tester, consumer: Tester,
-                                exporter: CDataExporter,
-                                importer: CDataImporter,
-                                test_case: datagen.File) -> Outcome:
-        """Run one C ArrowSchema test case.
-        """
+    def _run_c_schema_test_case(
+        self,
+        producer: Tester,
+        consumer: Tester,
+        exporter: CDataExporter,
+        importer: CDataImporter,
+        test_case: datagen.File,
+    ) -> Outcome:
+        """Run one C ArrowSchema test case."""
         outcome = Outcome()
 
         def do_run():
@@ -497,17 +528,21 @@ class IntegrationRunner:
                 exporter.export_schema_from_json(json_path, c_schema_ptr)
                 importer.import_schema_and_compare_to_json(json_path, c_schema_ptr)
 
-        log('=' * 70)
-        log(f'Testing C ArrowSchema from file {test_case.name!r}')
+        log("=" * 70)
+        log(f"Testing C ArrowSchema from file {test_case.name!r}")
 
         if test_case.should_skip(producer.name, SKIP_C_SCHEMA):
-            log(f'-- Skipping test because producer {producer.name} does '
-                f'not support C ArrowSchema')
+            log(
+                f"-- Skipping test because producer {producer.name} does "
+                f"not support C ArrowSchema"
+            )
             outcome.skipped = True
 
         elif test_case.should_skip(consumer.name, SKIP_C_SCHEMA):
-            log(f'-- Skipping test because consumer {consumer.name} does '
-                f'not support C ArrowSchema')
+            log(
+                f"-- Skipping test because consumer {consumer.name} does "
+                f"not support C ArrowSchema"
+            )
             outcome.skipped = True
 
         else:
@@ -515,20 +550,21 @@ class IntegrationRunner:
                 do_run()
             except Exception:
                 traceback.print_exc(file=printer.stdout)
-                outcome.failure = Failure(test_case, producer, consumer,
-                                          sys.exc_info())
+                outcome.failure = Failure(test_case, producer, consumer, sys.exc_info())
 
-        log('=' * 70)
+        log("=" * 70)
 
         return outcome
 
-    def _run_c_array_test_cases(self,
-                                producer: Tester, consumer: Tester,
-                                exporter: CDataExporter,
-                                importer: CDataImporter,
-                                test_case: datagen.File) -> Outcome:
-        """Run one set C ArrowArray test cases.
-        """
+    def _run_c_array_test_cases(
+        self,
+        producer: Tester,
+        consumer: Tester,
+        exporter: CDataExporter,
+        importer: CDataImporter,
+        test_case: datagen.File,
+    ) -> Outcome:
+        """Run one set C ArrowArray test cases."""
         outcome = Outcome()
 
         def do_run():
@@ -536,27 +572,28 @@ class IntegrationRunner:
             ffi = cdata.ffi()
             c_array_ptr = ffi.new("struct ArrowArray*")
             for num_batch in range(test_case.num_batches):
-                log(f'... with record batch #{num_batch}')
+                log(f"... with record batch #{num_batch}")
                 with cdata.check_memory_released(exporter, importer):
-                    exporter.export_batch_from_json(json_path,
-                                                    num_batch,
-                                                    c_array_ptr)
-                    importer.import_batch_and_compare_to_json(json_path,
-                                                              num_batch,
-                                                              c_array_ptr)
+                    exporter.export_batch_from_json(json_path, num_batch, c_array_ptr)
+                    importer.import_batch_and_compare_to_json(
+                        json_path, num_batch, c_array_ptr
+                    )
 
-        log('=' * 70)
-        log(f'Testing C ArrowArray '
-            f'from file {test_case.name!r}')
+        log("=" * 70)
+        log(f"Testing C ArrowArray from file {test_case.name!r}")
 
         if test_case.should_skip(producer.name, SKIP_C_ARRAY):
-            log(f'-- Skipping test because producer {producer.name} does '
-                f'not support C ArrowArray')
+            log(
+                f"-- Skipping test because producer {producer.name} does "
+                f"not support C ArrowArray"
+            )
             outcome.skipped = True
 
         elif test_case.should_skip(consumer.name, SKIP_C_ARRAY):
-            log(f'-- Skipping test because consumer {consumer.name} does '
-                f'not support C ArrowArray')
+            log(
+                f"-- Skipping test because consumer {consumer.name} does "
+                f"not support C ArrowArray"
+            )
             outcome.skipped = True
 
         else:
@@ -564,32 +601,40 @@ class IntegrationRunner:
                 do_run()
             except Exception:
                 traceback.print_exc(file=printer.stdout)
-                outcome.failure = Failure(test_case, producer, consumer,
-                                          sys.exc_info())
+                outcome.failure = Failure(test_case, producer, consumer, sys.exc_info())
 
-        log('=' * 70)
+        log("=" * 70)
 
         return outcome
 
 
 def get_static_json_files():
-    glob_pattern = os.path.join(ARROW_ROOT_DEFAULT,
-                                'integration', 'data', '*.json')
+    glob_pattern = os.path.join(ARROW_ROOT_DEFAULT, "integration", "data", "*.json")
     return [
-        datagen.File(name=os.path.basename(p), path=p,
-                     schema=None, batches=None)
+        datagen.File(name=os.path.basename(p), path=p, schema=None, batches=None)
         for p in glob.glob(glob_pattern)
     ]
 
 
-def run_all_tests(with_cpp=True, with_java=True, with_js=True,
-                  with_csharp=True, with_go=True, with_rust=False,
-                  with_nanoarrow=False, run_ipc=False, run_flight=False,
-                  run_c_data=False, tempdir=None, target_implementations="",
-                  **kwargs):
-    tempdir = tempdir or tempfile.mkdtemp(prefix='arrow-integration-')
-    target_implementations = \
+def run_all_tests(
+    with_cpp=True,
+    with_java=True,
+    with_js=True,
+    with_csharp=True,
+    with_go=True,
+    with_rust=False,
+    with_nanoarrow=False,
+    run_ipc=False,
+    run_flight=False,
+    run_c_data=False,
+    tempdir=None,
+    target_implementations="",
+    **kwargs,
+):
+    tempdir = tempdir or tempfile.mkdtemp(prefix="arrow-integration-")
+    target_implementations = (
         target_implementations.split(",") if target_implementations else []
+    )
 
     testers: List[Tester] = []
     other_testers: List[Tester] = []
@@ -602,30 +647,37 @@ def run_all_tests(with_cpp=True, with_java=True, with_js=True,
 
     if with_cpp:
         from .tester_cpp import CppTester
+
         append_tester("cpp", CppTester(**kwargs))
 
     if with_java:
         from .tester_java import JavaTester
+
         append_tester("java", JavaTester(**kwargs))
 
     if with_js:
         from .tester_js import JSTester
+
         append_tester("js", JSTester(**kwargs))
 
     if with_csharp:
         from .tester_csharp import CSharpTester
+
         append_tester("csharp", CSharpTester(**kwargs))
 
     if with_go:
         from .tester_go import GoTester
+
         append_tester("go", GoTester(**kwargs))
 
     if with_nanoarrow:
         from .tester_nanoarrow import NanoarrowTester
+
         append_tester("nanoarrow", NanoarrowTester(**kwargs))
 
     if with_rust:
         from .tester_rust import RustTester
+
         append_tester("rust", RustTester(**kwargs))
 
     static_json_files = get_static_json_files()
@@ -651,33 +703,42 @@ def run_all_tests(with_cpp=True, with_java=True, with_js=True,
         ),
         Scenario(
             "expiration_time:do_get",
-            description=("Ensure FlightEndpoint.expiration_time with "
-                         "DoGet is working as expected."),
+            description=(
+                "Ensure FlightEndpoint.expiration_time with "
+                "DoGet is working as expected."
+            ),
             skip_testers={"JS", "C#", "Rust"},
         ),
         Scenario(
             "expiration_time:list_actions",
-            description=("Ensure FlightEndpoint.expiration_time related "
-                         "pre-defined actions is working with ListActions "
-                         "as expected."),
+            description=(
+                "Ensure FlightEndpoint.expiration_time related "
+                "pre-defined actions is working with ListActions "
+                "as expected."
+            ),
             skip_testers={"JS", "C#", "Rust"},
         ),
         Scenario(
             "expiration_time:cancel_flight_info",
-            description=("Ensure FlightEndpoint.expiration_time and "
-                         "CancelFlightInfo are working as expected."),
+            description=(
+                "Ensure FlightEndpoint.expiration_time and "
+                "CancelFlightInfo are working as expected."
+            ),
             skip_testers={"JS", "C#", "Rust"},
         ),
         Scenario(
             "expiration_time:renew_flight_endpoint",
-            description=("Ensure FlightEndpoint.expiration_time and "
-                         "RenewFlightEndpoint are working as expected."),
+            description=(
+                "Ensure FlightEndpoint.expiration_time and "
+                "RenewFlightEndpoint are working as expected."
+            ),
             skip_testers={"JS", "C#", "Rust"},
         ),
         Scenario(
             "do_exchange:echo",
-            description=("Test the do_exchange method by "
-                         "echoing data back to the client."),
+            description=(
+                "Test the do_exchange method by echoing data back to the client."
+            ),
             skip_testers={"Go", "JS", "Rust"},
         ),
         Scenario(
@@ -688,37 +749,38 @@ def run_all_tests(with_cpp=True, with_java=True, with_js=True,
         Scenario(
             "session_options",
             description="Ensure Flight SQL Sessions work as expected.",
-            skip_testers={"JS", "C#", "Rust"}
+            skip_testers={"JS", "C#", "Rust"},
         ),
         Scenario(
             "poll_flight_info",
             description="Ensure PollFlightInfo is supported.",
-            skip_testers={"JS", "C#", "Rust"}
+            skip_testers={"JS", "C#", "Rust"},
         ),
         Scenario(
             "app_metadata_flight_info_endpoint",
             description="Ensure support FlightInfo and Endpoint app_metadata",
-            skip_testers={"JS", "C#", "Rust"}
+            skip_testers={"JS", "C#", "Rust"},
         ),
         Scenario(
             "flight_sql",
             description="Ensure Flight SQL protocol is working as expected.",
-            skip_testers={"Rust", "C#"}
+            skip_testers={"Rust", "C#"},
         ),
         Scenario(
             "flight_sql:extension",
             description="Ensure Flight SQL extensions work as expected.",
-            skip_testers={"Rust", "C#"}
+            skip_testers={"Rust", "C#"},
         ),
         Scenario(
             "flight_sql:ingestion",
             description="Ensure Flight SQL ingestion works as expected.",
-            skip_testers={"JS", "C#", "Rust"}
+            skip_testers={"JS", "C#", "Rust"},
         ),
     ]
 
-    runner = IntegrationRunner(json_files, flight_scenarios, testers,
-                               other_testers, **kwargs)
+    runner = IntegrationRunner(
+        json_files, flight_scenarios, testers, other_testers, **kwargs
+    )
     if run_ipc:
         runner.run_ipc()
     if run_flight:
@@ -733,11 +795,16 @@ def run_all_tests(with_cpp=True, with_java=True, with_js=True,
             for test_case, producer, consumer, exc_info in runner.failures:
                 fail_count += 1
                 log("FAILED TEST:", end=" ")
-                log(test_case.name, producer.name, "producing, ",
-                    consumer.name, "consuming")
+                log(
+                    test_case.name,
+                    producer.name,
+                    "producing, ",
+                    consumer.name,
+                    "consuming",
+                )
                 if exc_info:
                     exc_type, exc_value, exc_tb = exc_info
-                    log(f'{exc_type}: {exc_value}')
+                    log(f"{exc_type}: {exc_value}")
                 log()
 
         log(f"{fail_count} failures, {len(runner.skips)} skips")
@@ -746,33 +813,27 @@ def run_all_tests(with_cpp=True, with_java=True, with_js=True,
 
 
 def write_js_test_json(directory):
-    datagen.generate_primitive_case([], name='primitive_no_batches').write(
-        os.path.join(directory, 'primitive-no-batches.json')
+    datagen.generate_primitive_case([], name="primitive_no_batches").write(
+        os.path.join(directory, "primitive-no-batches.json")
     )
-    datagen.generate_primitive_case([17, 20], name='primitive').write(
-        os.path.join(directory, 'primitive.json')
+    datagen.generate_primitive_case([17, 20], name="primitive").write(
+        os.path.join(directory, "primitive.json")
     )
-    datagen.generate_primitive_case([0, 0, 0], name='primitive_zerolength').write(
-        os.path.join(directory, 'primitive-empty.json')
+    datagen.generate_primitive_case([0, 0, 0], name="primitive_zerolength").write(
+        os.path.join(directory, "primitive-empty.json")
     )
     # datagen.generate_primitive_large_offsets_case([17, 20]).write(
     #     os.path.join(directory, 'primitive-large-offsets.json')
     # )
-    datagen.generate_null_case([10, 0]).write(
-        os.path.join(directory, 'null.json')
-    )
+    datagen.generate_null_case([10, 0]).write(os.path.join(directory, "null.json"))
     datagen.generate_null_trivial_case([0, 0]).write(
-        os.path.join(directory, 'null-trivial.json')
+        os.path.join(directory, "null-trivial.json")
     )
-    datagen.generate_decimal128_case().write(
-        os.path.join(directory, 'decimal128.json')
-    )
+    datagen.generate_decimal128_case().write(os.path.join(directory, "decimal128.json"))
     # datagen.generate_decimal256_case().write(
     #     os.path.join(directory, 'decimal256.json')
     # )
-    datagen.generate_datetime_case().write(
-        os.path.join(directory, 'datetime.json')
-    )
+    datagen.generate_datetime_case().write(os.path.join(directory, "datetime.json"))
     # datagen.generate_duration_case().write(
     #     os.path.join(directory, 'duration.json')
     # )
@@ -782,42 +843,32 @@ def write_js_test_json(directory):
     # datagen.generate_month_day_nano_interval_case().write(
     #     os.path.join(directory, 'month_day_nano_interval.json')
     # )
-    datagen.generate_map_case().write(
-        os.path.join(directory, 'map.json')
-    )
+    datagen.generate_map_case().write(os.path.join(directory, "map.json"))
     datagen.generate_non_canonical_map_case().write(
-        os.path.join(directory, 'non_canonical_map.json')
+        os.path.join(directory, "non_canonical_map.json")
     )
-    datagen.generate_nested_case().write(
-        os.path.join(directory, 'nested.json')
-    )
+    datagen.generate_nested_case().write(os.path.join(directory, "nested.json"))
     datagen.generate_recursive_nested_case().write(
-        os.path.join(directory, 'recursive-nested.json')
+        os.path.join(directory, "recursive-nested.json")
     )
     # datagen.generate_nested_large_offsets_case().write(
     #     os.path.join(directory, 'nested-large-offsets.json')
     # )
-    datagen.generate_unions_case().write(
-        os.path.join(directory, 'unions.json')
-    )
+    datagen.generate_unions_case().write(os.path.join(directory, "unions.json"))
     datagen.generate_custom_metadata_case().write(
-        os.path.join(directory, 'custom-metadata.json')
+        os.path.join(directory, "custom-metadata.json")
     )
     # datagen.generate_duplicate_fieldnames_case().write(
     #     os.path.join(directory, 'duplicate-fieldnames.json')
     # )
-    datagen.generate_dictionary_case().write(
-        os.path.join(directory, 'dictionary.json')
-    )
+    datagen.generate_dictionary_case().write(os.path.join(directory, "dictionary.json"))
     datagen.generate_dictionary_unsigned_case().write(
-        os.path.join(directory, 'dictionary-unsigned.json')
+        os.path.join(directory, "dictionary-unsigned.json")
     )
     datagen.generate_nested_dictionary_case().write(
-        os.path.join(directory, 'dictionary-nested.json')
+        os.path.join(directory, "dictionary-nested.json")
     )
     # datagen.generate_run_end_encoded_case().write(
     #     os.path.join(directory, 'run_end_encoded.json')
     # )
-    datagen.generate_extension_case().write(
-        os.path.join(directory, 'extension.json')
-    )
+    datagen.generate_extension_case().write(os.path.join(directory, "extension.json"))

--- a/dev/archery/archery/integration/scenario.py
+++ b/dev/archery/archery/integration/scenario.py
@@ -14,11 +14,11 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
 
 class Scenario:
-    """
-    An integration test scenario for Arrow Flight.
+    """An integration test scenario for Arrow Flight.
 
     Does not correspond to a particular IPC JSON file.
     """

--- a/dev/archery/archery/integration/tester.py
+++ b/dev/archery/archery/integration/tester.py
@@ -31,10 +31,8 @@ _Predicate = typing.Callable[[], bool]
 
 
 class CDataExporter(ABC):
-
     @abstractmethod
-    def export_schema_from_json(self, json_path: os.PathLike,
-                                c_schema_ptr: object):
+    def export_schema_from_json(self, json_path: os.PathLike, c_schema_ptr: object):
         """Read a JSON integration file and export its schema.
 
         Parameters
@@ -46,9 +44,9 @@ class CDataExporter(ABC):
         """
 
     @abstractmethod
-    def export_batch_from_json(self, json_path: os.PathLike,
-                               num_batch: int,
-                               c_array_ptr: object):
+    def export_batch_from_json(
+        self, json_path: os.PathLike, num_batch: int, c_array_ptr: object
+    ):
         """Read a JSON integration file and export one of its batches.
 
         Parameters
@@ -101,8 +99,7 @@ class CDataExporter(ABC):
         return 1
 
     def close(self):
-        """Final cleanup after usage.
-        """
+        """Final cleanup after usage."""
 
     def __enter__(self):
         return self
@@ -112,10 +109,10 @@ class CDataExporter(ABC):
 
 
 class CDataImporter(ABC):
-
     @abstractmethod
-    def import_schema_and_compare_to_json(self, json_path: os.PathLike,
-                                          c_schema_ptr: object):
+    def import_schema_and_compare_to_json(
+        self, json_path: os.PathLike, c_schema_ptr: object
+    ):
         """Import schema and compare it to the schema of a JSON integration file.
 
         An error is raised if importing fails or the schemas differ.
@@ -129,9 +126,9 @@ class CDataImporter(ABC):
         """
 
     @abstractmethod
-    def import_batch_and_compare_to_json(self, json_path: os.PathLike,
-                                         num_batch: int,
-                                         c_array_ptr: object):
+    def import_batch_and_compare_to_json(
+        self, json_path: os.PathLike, num_batch: int, c_array_ptr: object
+    ):
         """Import record batch and compare it to one of the batches
         from a JSON integration file.
 
@@ -175,8 +172,7 @@ class CDataImporter(ABC):
         return 1
 
     def close(self):
-        """Final cleanup after usage.
-        """
+        """Final cleanup after usage."""
 
     def __enter__(self):
         return self
@@ -189,8 +185,7 @@ class CDataImporter(ABC):
 
 
 class Tester:
-    """The interface to declare a tester to run integration tests against.
-    """
+    """The interface to declare a tester to run integration tests against."""
 
     # whether the language supports producing / writing IPC
     PRODUCER = False
@@ -215,7 +210,7 @@ class Tester:
         self.debug = debug
 
     def run_shell_command(self, cmd, **kwargs):
-        cmd = ' '.join(cmd)
+        cmd = " ".join(cmd)
         if self.debug:
             log(cmd)
         kwargs.update(shell=True)  # noqa: S604
@@ -234,8 +229,7 @@ class Tester:
         raise NotImplementedError
 
     def file_to_stream(self, file_path, stream_path):
-        """Run the conversion of an Arrow IPC file to an Arrow IPC stream
-        """
+        """Run the conversion of an Arrow IPC file to an Arrow IPC stream"""
         raise NotImplementedError
 
     def validate(self, json_path, arrow_path, quirks=None):

--- a/dev/archery/archery/integration/tester.py
+++ b/dev/archery/archery/integration/tester.py
@@ -16,10 +16,11 @@
 # under the License.
 
 # Base class for language-specific integration test harnesses
+from __future__ import annotations
 
-from abc import ABC, abstractmethod
 import subprocess
 import typing
+from abc import ABC, abstractmethod
 
 from .util import log
 
@@ -34,8 +35,7 @@ class CDataExporter(ABC):
     @abstractmethod
     def export_schema_from_json(self, json_path: os.PathLike,
                                 c_schema_ptr: object):
-        """
-        Read a JSON integration file and export its schema.
+        """Read a JSON integration file and export its schema.
 
         Parameters
         ----------
@@ -49,8 +49,7 @@ class CDataExporter(ABC):
     def export_batch_from_json(self, json_path: os.PathLike,
                                num_batch: int,
                                c_array_ptr: object):
-        """
-        Read a JSON integration file and export one of its batches.
+        """Read a JSON integration file and export one of its batches.
 
         Parameters
         ----------
@@ -65,8 +64,7 @@ class CDataExporter(ABC):
     @property
     @abstractmethod
     def supports_releasing_memory(self) -> bool:
-        """
-        Whether the implementation is able to release memory deterministically.
+        """Whether the implementation is able to release memory deterministically.
 
         Here, "release memory" means that, after the `release` callback of
         a C Data Interface export is called, `run_gc` is able to trigger
@@ -77,8 +75,7 @@ class CDataExporter(ABC):
         """
 
     def record_allocation_state(self) -> object:
-        """
-        Return the current memory allocation state.
+        """Return the current memory allocation state.
 
         Returns
         -------
@@ -89,8 +86,7 @@ class CDataExporter(ABC):
         raise NotImplementedError
 
     def run_gc(self):
-        """
-        Run the GC if necessary.
+        """Run the GC if necessary.
 
         This should ensure that any temporary objects and data created by
         previous exporter calls are collected.
@@ -98,16 +94,14 @@ class CDataExporter(ABC):
 
     @property
     def required_gc_runs(self):
-        """
-        The maximum number of calls to `run_gc` that need to be issued to
+        """The maximum number of calls to `run_gc` that need to be issued to
         ensure proper deallocation. Some implementations may require this
         to be greater than one.
         """
         return 1
 
     def close(self):
-        """
-        Final cleanup after usage.
+        """Final cleanup after usage.
         """
 
     def __enter__(self):
@@ -122,8 +116,7 @@ class CDataImporter(ABC):
     @abstractmethod
     def import_schema_and_compare_to_json(self, json_path: os.PathLike,
                                           c_schema_ptr: object):
-        """
-        Import schema and compare it to the schema of a JSON integration file.
+        """Import schema and compare it to the schema of a JSON integration file.
 
         An error is raised if importing fails or the schemas differ.
 
@@ -139,8 +132,7 @@ class CDataImporter(ABC):
     def import_batch_and_compare_to_json(self, json_path: os.PathLike,
                                          num_batch: int,
                                          c_array_ptr: object):
-        """
-        Import record batch and compare it to one of the batches
+        """Import record batch and compare it to one of the batches
         from a JSON integration file.
 
         The schema used for importing the record batch is the one from
@@ -161,8 +153,7 @@ class CDataImporter(ABC):
     @property
     @abstractmethod
     def supports_releasing_memory(self) -> bool:
-        """
-        Whether the implementation is able to release memory deterministically.
+        """Whether the implementation is able to release memory deterministically.
 
         Here, "release memory" means `run_gc()` is able to trigger the
         `release` callback of a C Data Interface export (which would then
@@ -170,24 +161,21 @@ class CDataImporter(ABC):
         """
 
     def run_gc(self):
-        """
-        Run the GC if necessary.
+        """Run the GC if necessary.
 
         This should ensure that any imported data has its release callback called.
         """
 
     @property
     def required_gc_runs(self):
-        """
-        The maximum number of calls to `run_gc` that need to be issued to
+        """The maximum number of calls to `run_gc` that need to be issued to
         ensure release callbacks are triggered. Some implementations may
         require this to be greater than one.
         """
         return 1
 
     def close(self):
-        """
-        Final cleanup after usage.
+        """Final cleanup after usage.
         """
 
     def __enter__(self):
@@ -195,15 +183,15 @@ class CDataImporter(ABC):
 
     def __exit__(self, *exc):
         # Make sure any exported data is released.
-        for i in range(self.required_gc_runs):
+        for _i in range(self.required_gc_runs):
             self.run_gc()
         self.close()
 
 
 class Tester:
+    """The interface to declare a tester to run integration tests against.
     """
-    The interface to declare a tester to run integration tests against.
-    """
+
     # whether the language supports producing / writing IPC
     PRODUCER = False
     # whether the language supports consuming / reading IPC
@@ -234,28 +222,24 @@ class Tester:
         subprocess.check_call(cmd, **kwargs)
 
     def json_to_file(self, json_path, arrow_path):
-        """
-        Run the conversion of an Arrow JSON integration file
+        """Run the conversion of an Arrow JSON integration file
         to an Arrow IPC file
         """
         raise NotImplementedError
 
     def stream_to_file(self, stream_path, file_path):
-        """
-        Run the conversion of an Arrow IPC stream to an
+        """Run the conversion of an Arrow IPC stream to an
         Arrow IPC file
         """
         raise NotImplementedError
 
     def file_to_stream(self, file_path, stream_path):
-        """
-        Run the conversion of an Arrow IPC file to an Arrow IPC stream
+        """Run the conversion of an Arrow IPC file to an Arrow IPC stream
         """
         raise NotImplementedError
 
     def validate(self, json_path, arrow_path, quirks=None):
-        """
-        Validate that the Arrow IPC file is equal to the corresponding
+        """Validate that the Arrow IPC file is equal to the corresponding
         Arrow JSON integration file
         """
         raise NotImplementedError

--- a/dev/archery/archery/integration/tester.py
+++ b/dev/archery/archery/integration/tester.py
@@ -18,12 +18,13 @@
 # Base class for language-specific integration test harnesses
 
 from abc import ABC, abstractmethod
-import os
 import subprocess
 import typing
 
 from .util import log
 
+if typing.TYPE_CHECKING:
+    import os
 
 _Predicate = typing.Callable[[], bool]
 
@@ -229,7 +230,7 @@ class Tester:
         cmd = ' '.join(cmd)
         if self.debug:
             log(cmd)
-        kwargs.update(shell=True)
+        kwargs.update(shell=True)  # noqa: S604
         subprocess.check_call(cmd, **kwargs)
 
     def json_to_file(self, json_path, arrow_path):

--- a/dev/archery/archery/integration/tester_cpp.py
+++ b/dev/archery/archery/integration/tester_cpp.py
@@ -14,17 +14,17 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
 import contextlib
 import functools
 import os
 import subprocess
 
-from . import cdata
-from .tester import Tester, CDataExporter, CDataImporter
-from .util import run_cmd, log
 from ..utils.source import ARROW_ROOT_DEFAULT
-
+from . import cdata
+from .tester import CDataExporter, CDataImporter, Tester
+from .util import log, run_cmd
 
 _EXE_PATH = os.environ.get(
     "ARROW_CPP_EXE_PATH", os.path.join(ARROW_ROOT_DEFAULT, "cpp/build/debug")
@@ -116,9 +116,7 @@ class CppTester(Tester):
                 out, err = server.communicate()
                 raise RuntimeError(
                     "Flight-C++ server did not start properly, "
-                    "stdout:\n{}\n\nstderr:\n{}\n".format(
-                        output + out.decode(), err.decode()
-                    )
+                    f"stdout:\n{output + out.decode()}\n\nstderr:\n{err.decode()}\n"
                 )
             port = int(output.split(":")[1])
             yield port
@@ -179,8 +177,7 @@ class _CDataBase:
         self.dll = _load_ffi(self.ffi)
 
     def _check_c_error(self, c_error):
-        """
-        Check a `const char*` error return from an integration entrypoint.
+        """Check a `const char*` error return from an integration entrypoint.
 
         A null means success, a non-empty string is an error message.
         The string is statically allocated on the C++ side.

--- a/dev/archery/archery/integration/tester_cpp.py
+++ b/dev/archery/archery/integration/tester_cpp.py
@@ -108,11 +108,7 @@ class CppTester(Tester):
             cmd = cmd + ["-scenario", scenario_name]
         if self.debug:
             log(" ".join(cmd))
-        server = subprocess.Popen(
-            cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
+        server = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         try:
             output = server.stdout.readline().decode()
             if not output.startswith("Server listening on localhost:"):
@@ -170,7 +166,7 @@ def _load_ffi(ffi, lib_path=_ARROW_DLL):
     os.environ['ARROW_DEBUG_MEMORY_POOL'] = 'trap'
     ffi.cdef(_cpp_c_data_entrypoints)
     dll = ffi.dlopen(lib_path)
-    dll.ArrowCpp_CDataIntegration_ExportSchemaFromJson
+    dll.ArrowCpp_CDataIntegration_ExportSchemaFromJson  # noqa: B018
     return dll
 
 

--- a/dev/archery/archery/integration/tester_csharp.py
+++ b/dev/archery/archery/integration/tester_csharp.py
@@ -14,16 +14,16 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
-from contextlib import contextmanager
 import os
 import subprocess
+from contextlib import contextmanager
 
-from . import cdata
-from .tester import Tester, CDataExporter, CDataImporter
-from .util import run_cmd, log
 from ..utils.source import ARROW_ROOT_DEFAULT
-
+from . import cdata
+from .tester import CDataExporter, CDataImporter, Tester
+from .util import log, run_cmd
 
 _ARTIFACTS_PATH = os.path.join(ARROW_ROOT_DEFAULT, "csharp/artifacts")
 _BUILD_SUBDIR = "Debug/net8.0"
@@ -64,8 +64,7 @@ def _load_clr():
 
 @contextmanager
 def _disposing(disposable):
-    """
-    Ensure the IDisposable object is disposed of when the enclosed block exits.
+    """Ensure the IDisposable object is disposed of when the enclosed block exits.
     """
     try:
         yield disposable
@@ -234,9 +233,7 @@ class CSharpTester(Tester):
                 out, err = server.communicate()
                 raise RuntimeError(
                     '.NET Flight server did not start properly, '
-                    'stdout: \n{}\n\nstderr:\n{}\n'.format(
-                        output + out.decode(), err.decode()
-                    )
+                    f'stdout: \n{output + out.decode()}\n\nstderr:\n{err.decode()}\n'
                 )
             port = int(output.split(':')[-1])
             yield port

--- a/dev/archery/archery/integration/tester_csharp.py
+++ b/dev/archery/archery/integration/tester_csharp.py
@@ -28,17 +28,19 @@ from .util import log, run_cmd
 _ARTIFACTS_PATH = os.path.join(ARROW_ROOT_DEFAULT, "csharp/artifacts")
 _BUILD_SUBDIR = "Debug/net8.0"
 
-_EXE_PATH = os.path.join(_ARTIFACTS_PATH,
-                         "Apache.Arrow.IntegrationTest",
-                         _BUILD_SUBDIR,
-                         "Apache.Arrow.IntegrationTest",
-                         )
+_EXE_PATH = os.path.join(
+    _ARTIFACTS_PATH,
+    "Apache.Arrow.IntegrationTest",
+    _BUILD_SUBDIR,
+    "Apache.Arrow.IntegrationTest",
+)
 
-_FLIGHT_EXE_PATH = os.path.join(_ARTIFACTS_PATH,
-                                "Apache.Arrow.Flight.IntegrationTest",
-                                _BUILD_SUBDIR,
-                                "Apache.Arrow.Flight.IntegrationTest",
-                                )
+_FLIGHT_EXE_PATH = os.path.join(
+    _ARTIFACTS_PATH,
+    "Apache.Arrow.Flight.IntegrationTest",
+    _BUILD_SUBDIR,
+    "Apache.Arrow.Flight.IntegrationTest",
+)
 
 _clr_loaded = False
 
@@ -47,25 +49,29 @@ def _load_clr():
     global _clr_loaded
     if not _clr_loaded:
         _clr_loaded = True
-        os.environ['DOTNET_GCHeapHardLimit'] = '0xC800000'  # 200 MiB
+        os.environ["DOTNET_GCHeapHardLimit"] = "0xC800000"  # 200 MiB
         import pythonnet
+
         pythonnet.load("coreclr")
         import clr
+
         clr.AddReference(
             f"{_ARTIFACTS_PATH}/Apache.Arrow.IntegrationTest/"
-            f"{_BUILD_SUBDIR}/Apache.Arrow.IntegrationTest.dll")
+            f"{_BUILD_SUBDIR}/Apache.Arrow.IntegrationTest.dll"
+        )
         clr.AddReference(
             f"{_ARTIFACTS_PATH}/Apache.Arrow.Tests/"
-            f"{_BUILD_SUBDIR}/Apache.Arrow.Tests.dll")
+            f"{_BUILD_SUBDIR}/Apache.Arrow.Tests.dll"
+        )
 
         from Apache.Arrow.IntegrationTest import CDataInterface
+
         CDataInterface.Initialize()
 
 
 @contextmanager
 def _disposing(disposable):
-    """Ensure the IDisposable object is disposed of when the enclosed block exits.
-    """
+    """Ensure the IDisposable object is disposed of when the enclosed block exits."""
     try:
         yield disposable
     finally:
@@ -73,7 +79,6 @@ def _disposing(disposable):
 
 
 class _CDataBase:
-
     def __init__(self, debug, args):
         self.debug = debug
         self.args = args
@@ -81,7 +86,7 @@ class _CDataBase:
         _load_clr()
 
     def _pointer_to_int(self, c_ptr):
-        return int(self.ffi.cast('uintptr_t', c_ptr))
+        return int(self.ffi.cast("uintptr_t", c_ptr))
 
     def _read_batch_from_json(self, json_path, num_batch):
         from Apache.Arrow.IntegrationTest import CDataInterface
@@ -90,25 +95,25 @@ class _CDataBase:
 
     def _run_gc(self):
         from Apache.Arrow.IntegrationTest import CDataInterface
+
         CDataInterface.RunGC()
 
 
 class CSharpCDataExporter(CDataExporter, _CDataBase):
-
     def export_schema_from_json(self, json_path, c_schema_ptr):
         from Apache.Arrow.IntegrationTest import CDataInterface
 
         jf = CDataInterface.ParseJsonFile(json_path)
-        CDataInterface.ExportSchema(jf.Schema.ToArrow(),
-                                    self._pointer_to_int(c_schema_ptr))
+        CDataInterface.ExportSchema(
+            jf.Schema.ToArrow(), self._pointer_to_int(c_schema_ptr)
+        )
 
     def export_batch_from_json(self, json_path, num_batch, c_array_ptr):
         from Apache.Arrow.IntegrationTest import CDataInterface
 
         _, batch = self._read_batch_from_json(json_path, num_batch)
         with _disposing(batch):
-            CDataInterface.ExportRecordBatch(batch,
-                                             self._pointer_to_int(c_array_ptr))
+            CDataInterface.ExportRecordBatch(batch, self._pointer_to_int(c_array_ptr))
 
     @property
     def supports_releasing_memory(self):
@@ -120,28 +125,29 @@ class CSharpCDataExporter(CDataExporter, _CDataBase):
 
 
 class CSharpCDataImporter(CDataImporter, _CDataBase):
-
     def import_schema_and_compare_to_json(self, json_path, c_schema_ptr):
         from Apache.Arrow.IntegrationTest import CDataInterface
         from Apache.Arrow.Tests import SchemaComparer
 
         jf = CDataInterface.ParseJsonFile(json_path)
         imported_schema = CDataInterface.ImportSchema(
-            self._pointer_to_int(c_schema_ptr))
+            self._pointer_to_int(c_schema_ptr)
+        )
         SchemaComparer.Compare(jf.Schema.ToArrow(), imported_schema)
 
-    def import_batch_and_compare_to_json(self, json_path, num_batch,
-                                         c_array_ptr):
+    def import_batch_and_compare_to_json(self, json_path, num_batch, c_array_ptr):
         from Apache.Arrow.IntegrationTest import CDataInterface
         from Apache.Arrow.Tests import ArrowReaderVerifier
 
         schema, batch = self._read_batch_from_json(json_path, num_batch)
         with _disposing(batch):
             imported_batch = CDataInterface.ImportRecordBatch(
-                self._pointer_to_int(c_array_ptr), schema)
+                self._pointer_to_int(c_array_ptr), schema
+            )
             with _disposing(imported_batch):
-                ArrowReaderVerifier.CompareBatches(batch, imported_batch,
-                                                   strictCompare=False)
+                ArrowReaderVerifier.CompareBatches(
+                    batch, imported_batch, strictCompare=False
+                )
 
     @property
     def supports_releasing_memory(self):
@@ -161,40 +167,40 @@ class CSharpTester(Tester):
     C_DATA_ARRAY_EXPORTER = True
     C_DATA_ARRAY_IMPORTER = True
 
-    name = 'C#'
+    name = "C#"
 
-    def _run(self, json_path=None, arrow_path=None, command='validate'):
+    def _run(self, json_path=None, arrow_path=None, command="validate"):
         cmd = [_EXE_PATH]
 
-        cmd.extend(['--mode', command])
+        cmd.extend(["--mode", command])
 
         if json_path is not None:
-            cmd.extend(['-j', json_path])
+            cmd.extend(["-j", json_path])
 
         if arrow_path is not None:
-            cmd.extend(['-a', arrow_path])
+            cmd.extend(["-a", arrow_path])
 
         if self.debug:
-            log(' '.join(cmd))
+            log(" ".join(cmd))
 
         run_cmd(cmd)
 
     def validate(self, json_path, arrow_path, quirks=None):
-        return self._run(json_path, arrow_path, 'validate')
+        return self._run(json_path, arrow_path, "validate")
 
     def json_to_file(self, json_path, arrow_path):
-        return self._run(json_path, arrow_path, 'json-to-arrow')
+        return self._run(json_path, arrow_path, "json-to-arrow")
 
     def stream_to_file(self, stream_path, file_path):
         cmd = [_EXE_PATH]
-        cmd.extend(['--mode', 'stream-to-file', '-a', file_path])
-        cmd.extend(['<', stream_path])
+        cmd.extend(["--mode", "stream-to-file", "-a", file_path])
+        cmd.extend(["<", stream_path])
         self.run_shell_command(cmd)
 
     def file_to_stream(self, file_path, stream_path):
         cmd = [_EXE_PATH]
-        cmd.extend(['--mode', 'file-to-stream'])
-        cmd.extend(['-a', file_path, '>', stream_path])
+        cmd.extend(["--mode", "file-to-stream"])
+        cmd.extend(["-a", file_path, ">", stream_path])
         self.run_shell_command(cmd)
 
     def make_c_data_exporter(self):
@@ -204,27 +210,26 @@ class CSharpTester(Tester):
         return CSharpCDataImporter(self.debug, self.args)
 
     def flight_request(self, port, json_path=None, scenario_name=None):
-        cmd = [_FLIGHT_EXE_PATH, 'client', '--port', f'{port}']
+        cmd = [_FLIGHT_EXE_PATH, "client", "--port", f"{port}"]
         if json_path:
-            cmd.extend(['--path', json_path])
+            cmd.extend(["--path", json_path])
         elif scenario_name:
-            cmd.extend(['--scenario', scenario_name])
+            cmd.extend(["--scenario", scenario_name])
         else:
             raise TypeError("Must provide one of json_path or scenario_name")
 
         if self.debug:
-            log(' '.join(cmd))
+            log(" ".join(cmd))
         run_cmd(cmd)
 
     @contextmanager
     def flight_server(self, scenario_name=None):
-        cmd = [_FLIGHT_EXE_PATH, 'server']
+        cmd = [_FLIGHT_EXE_PATH, "server"]
         if scenario_name:
-            cmd.extend(['--scenario', scenario_name])
+            cmd.extend(["--scenario", scenario_name])
         if self.debug:
-            log(' '.join(cmd))
-        server = subprocess.Popen(
-            cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            log(" ".join(cmd))
+        server = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
         try:
             output = server.stdout.readline().decode()
@@ -232,10 +237,10 @@ class CSharpTester(Tester):
                 server.kill()
                 out, err = server.communicate()
                 raise RuntimeError(
-                    '.NET Flight server did not start properly, '
-                    f'stdout: \n{output + out.decode()}\n\nstderr:\n{err.decode()}\n'
+                    ".NET Flight server did not start properly, "
+                    f"stdout: \n{output + out.decode()}\n\nstderr:\n{err.decode()}\n"
                 )
-            port = int(output.split(':')[-1])
+            port = int(output.split(":")[-1])
             yield port
         finally:
             server.kill()

--- a/dev/archery/archery/integration/tester_go.py
+++ b/dev/archery/archery/integration/tester_go.py
@@ -14,17 +14,17 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
 import contextlib
 import functools
 import os
 import subprocess
 
-from . import cdata
-from .tester import Tester, CDataExporter, CDataImporter
-from .util import run_cmd, log
 from ..utils.source import ARROW_ROOT_DEFAULT
-
+from . import cdata
+from .tester import CDataExporter, CDataImporter, Tester
+from .util import log, run_cmd
 
 # FIXME(sbinet): revisit for Go modules
 _HOME = os.getenv("HOME", "~")
@@ -107,9 +107,7 @@ class GoTester(Tester):
                 out, err = server.communicate()
                 raise RuntimeError(
                     'Flight-Go server did not start properly, '
-                    'stdout: \n{}\n\nstderr:\n{}\n'.format(
-                        output + out.decode(), err.decode()
-                    )
+                    f'stdout: \n{output + out.decode()}\n\nstderr:\n{err.decode()}\n'
                 )
             port = int(output.split(':')[1])
             yield port
@@ -179,8 +177,7 @@ class _CDataBase:
         return self.ffi.cast('uintptr_t', c_ptr)
 
     def _check_go_error(self, go_error):
-        """
-        Check a `const char*` error return from an integration entrypoint.
+        """Check a `const char*` error return from an integration entrypoint.
 
         A null means success, a non-empty string is an error message.
         The string is dynamically allocated on the Go side.

--- a/dev/archery/archery/integration/tester_java.py
+++ b/dev/archery/archery/integration/tester_java.py
@@ -14,18 +14,18 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
 import contextlib
 import functools
 import os
-from pathlib import Path
 import subprocess
+from pathlib import Path
 
-from . import cdata
-from .tester import Tester, CDataExporter, CDataImporter
-from .util import run_cmd, log
 from ..utils.source import ARROW_ROOT_DEFAULT
-
+from . import cdata
+from .tester import CDataExporter, CDataImporter, Tester
+from .util import log, run_cmd
 
 ARROW_BUILD_ROOT = os.environ.get(
     'ARROW_BUILD_ROOT',
@@ -340,9 +340,7 @@ class JavaTester(Tester):
                 out, err = server.communicate()
                 raise RuntimeError(
                     'Flight-Java server did not start properly, '
-                    'stdout:\n{}\n\nstderr:\n{}\n'.format(
-                        output + out.decode(), err.decode()
-                    )
+                    f'stdout:\n{output + out.decode()}\n\nstderr:\n{err.decode()}\n'
                 )
             port = int(output.split(':')[1])
             yield port

--- a/dev/archery/archery/integration/tester_java.py
+++ b/dev/archery/archery/integration/tester_java.py
@@ -35,9 +35,10 @@ ARROW_BUILD_ROOT = os.environ.get(
 
 def load_version_from_pom():
     import xml.etree.ElementTree as ET
-    tree = ET.parse(os.path.join(ARROW_ROOT_DEFAULT, 'java', 'pom.xml'))
-    tag_pattern = '{http://maven.apache.org/POM/4.0.0}version'
-    version_tag = list(tree.getroot().findall(tag_pattern))[0]
+
+    tree = ET.parse(os.path.join(ARROW_ROOT_DEFAULT, "java", "pom.xml"))
+    tag_pattern = "{http://maven.apache.org/POM/4.0.0}version"
+    version_tag = next(iter(tree.getroot().findall(tag_pattern)))
     return version_tag.text
 
 
@@ -211,8 +212,7 @@ class JavaCDataImporter(CDataImporter, _CDataBase):
                     # We need to pass a dict provider primed with dictionary ids
                     # matching those in the schema, hence an empty
                     # CDataDictionaryProvider would not work here.
-                    dict_provider = (self.java_arrow.vector.dictionary
-                                     .DictionaryProvider.MapDictionaryProvider())
+                    dict_provider = self.java_arrow.vector.dictionary.DictionaryProvider.MapDictionaryProvider()  # noqa: E501
                     dict_provider.copyStructureFrom(json_reader, self.java_allocator)
                     with dict_provider:
                         self.java_arrow.c.Data.importIntoVectorSchemaRoot(

--- a/dev/archery/archery/integration/tester_java.py
+++ b/dev/archery/archery/integration/tester_java.py
@@ -28,8 +28,7 @@ from .tester import CDataExporter, CDataImporter, Tester
 from .util import log, run_cmd
 
 ARROW_BUILD_ROOT = os.environ.get(
-    'ARROW_BUILD_ROOT',
-    Path(__file__).resolve().parents[4]
+    "ARROW_BUILD_ROOT", Path(__file__).resolve().parents[4]
 )
 
 
@@ -59,51 +58,48 @@ _ARROW_TOOLS_JAR = os.environ.get(
     os.path.join(
         ARROW_BUILD_ROOT,
         "java/tools/target",
-        f"arrow-tools-{_arrow_version}-jar-with-dependencies.jar"
-    )
+        f"arrow-tools-{_arrow_version}-jar-with-dependencies.jar",
+    ),
 )
 _ARROW_C_DATA_JAR = os.environ.get(
     "ARROW_C_DATA_JAVA_INTEGRATION_JAR",
     os.path.join(
-        ARROW_BUILD_ROOT,
-        "java/c/target",
-        f"arrow-c-data-{_arrow_version}.jar"
-    )
+        ARROW_BUILD_ROOT, "java/c/target", f"arrow-c-data-{_arrow_version}.jar"
+    ),
 )
 _ARROW_FLIGHT_JAR = os.environ.get(
     "ARROW_FLIGHT_JAVA_INTEGRATION_JAR",
     os.path.join(
         ARROW_BUILD_ROOT,
         "java/flight/flight-integration-tests/target",
-        f"flight-integration-tests-{_arrow_version}-jar-with-dependencies.jar"
-    )
+        f"flight-integration-tests-{_arrow_version}-jar-with-dependencies.jar",
+    ),
 )
-_ARROW_FLIGHT_SERVER = (
-    "org.apache.arrow.flight.integration.tests.IntegrationTestServer"
-)
-_ARROW_FLIGHT_CLIENT = (
-    "org.apache.arrow.flight.integration.tests.IntegrationTestClient"
-)
+_ARROW_FLIGHT_SERVER = "org.apache.arrow.flight.integration.tests.IntegrationTestServer"
+_ARROW_FLIGHT_CLIENT = "org.apache.arrow.flight.integration.tests.IntegrationTestClient"
 
 
 @functools.lru_cache
 def setup_jpype():
     import jpype
+
     jar_path = f"{_ARROW_TOOLS_JAR}:{_ARROW_C_DATA_JAR}"
     # XXX Didn't manage to tone down the logging level here (DEBUG -> INFO)
-    jpype.startJVM(jpype.getDefaultJVMPath(),
-                   "-Djava.class.path=" + jar_path,
-                   # This flag is too heavy for IPC and Flight tests
-                   "-Darrow.memory.debug.allocator=true",
-                   # Reduce internal use of signals by the JVM
-                   "-Xrs",
-                   *_JAVA_OPTS)
+    jpype.startJVM(
+        jpype.getDefaultJVMPath(),
+        "-Djava.class.path=" + jar_path,
+        # This flag is too heavy for IPC and Flight tests
+        "-Darrow.memory.debug.allocator=true",
+        # Reduce internal use of signals by the JVM
+        "-Xrs",
+        *_JAVA_OPTS,
+    )
 
 
 class _CDataBase:
-
     def __init__(self, debug, args):
         import jpype
+
         self.debug = debug
         self.args = args
         self.ffi = cdata.ffi()
@@ -114,15 +110,13 @@ class _CDataBase:
         self.java_allocator = self._make_java_allocator()
 
     def _pointer_to_int(self, c_ptr):
-        return int(self.ffi.cast('uintptr_t', c_ptr))
+        return int(self.ffi.cast("uintptr_t", c_ptr))
 
     def _wrap_c_schema_ptr(self, c_schema_ptr):
-        return self.java_arrow.c.ArrowSchema.wrap(
-            self._pointer_to_int(c_schema_ptr))
+        return self.java_arrow.c.ArrowSchema.wrap(self._pointer_to_int(c_schema_ptr))
 
     def _wrap_c_array_ptr(self, c_array_ptr):
-        return self.java_arrow.c.ArrowArray.wrap(
-            self._pointer_to_int(c_array_ptr))
+        return self.java_arrow.c.ArrowArray.wrap(self._pointer_to_int(c_array_ptr))
 
     def _make_java_allocator(self):
         # Return a new allocator
@@ -131,37 +125,39 @@ class _CDataBase:
     def _assert_schemas_equal(self, expected, actual):
         # XXX This is fragile for dictionaries, as Schema.equals compares
         # dictionary ids.
-        self.java_arrow.vector.util.Validator.compareSchemas(
-            expected, actual)
+        self.java_arrow.vector.util.Validator.compareSchemas(expected, actual)
 
     def _assert_batches_equal(self, expected, actual):
-        self.java_arrow.vector.util.Validator.compareVectorSchemaRoot(
-            expected, actual)
+        self.java_arrow.vector.util.Validator.compareVectorSchemaRoot(expected, actual)
 
     def _assert_dict_providers_equal(self, expected, actual):
         self.java_arrow.vector.util.Validator.compareDictionaryProviders(
-            expected, actual)
+            expected, actual
+        )
 
     # Note: no need to call the Java GC anywhere thanks to AutoCloseable
 
 
 class JavaCDataExporter(CDataExporter, _CDataBase):
-
     def export_schema_from_json(self, json_path, c_schema_ptr):
         json_file = self.java_io.File(json_path)
         with self.java_arrow.vector.ipc.JsonFileReader(
-                json_file, self.java_allocator) as json_reader:
+            json_file, self.java_allocator
+        ) as json_reader:
             schema = json_reader.start()
             dict_provider = json_reader
             self.java_arrow.c.Data.exportSchema(
-                self.java_allocator, schema, dict_provider,
-                self._wrap_c_schema_ptr(c_schema_ptr)
+                self.java_allocator,
+                schema,
+                dict_provider,
+                self._wrap_c_schema_ptr(c_schema_ptr),
             )
 
     def export_batch_from_json(self, json_path, num_batch, c_array_ptr):
         json_file = self.java_io.File(json_path)
         with self.java_arrow.vector.ipc.JsonFileReader(
-                json_file, self.java_allocator) as json_reader:
+            json_file, self.java_allocator
+        ) as json_reader:
             json_reader.start()
             if num_batch > 0:
                 actually_skipped = json_reader.skip(num_batch)
@@ -169,8 +165,11 @@ class JavaCDataExporter(CDataExporter, _CDataBase):
             with json_reader.read() as batch:
                 dict_provider = json_reader
                 self.java_arrow.c.Data.exportVectorSchemaRoot(
-                    self.java_allocator, batch, dict_provider,
-                    self._wrap_c_array_ptr(c_array_ptr))
+                    self.java_allocator,
+                    batch,
+                    dict_provider,
+                    self._wrap_c_array_ptr(c_array_ptr),
+                )
 
     @property
     def supports_releasing_memory(self):
@@ -184,31 +183,33 @@ class JavaCDataExporter(CDataExporter, _CDataBase):
 
 
 class JavaCDataImporter(CDataImporter, _CDataBase):
-
     def import_schema_and_compare_to_json(self, json_path, c_schema_ptr):
         json_file = self.java_io.File(json_path)
         with self.java_arrow.vector.ipc.JsonFileReader(
-                json_file, self.java_allocator) as json_reader:
+            json_file, self.java_allocator
+        ) as json_reader:
             json_schema = json_reader.start()
             with self.java_arrow.c.CDataDictionaryProvider() as dict_provider:
                 imported_schema = self.java_arrow.c.Data.importSchema(
                     self.java_allocator,
                     self._wrap_c_schema_ptr(c_schema_ptr),
-                    dict_provider)
+                    dict_provider,
+                )
                 self._assert_schemas_equal(json_schema, imported_schema)
 
-    def import_batch_and_compare_to_json(self, json_path, num_batch,
-                                         c_array_ptr):
+    def import_batch_and_compare_to_json(self, json_path, num_batch, c_array_ptr):
         json_file = self.java_io.File(json_path)
         with self.java_arrow.vector.ipc.JsonFileReader(
-                json_file, self.java_allocator) as json_reader:
+            json_file, self.java_allocator
+        ) as json_reader:
             schema = json_reader.start()
             if num_batch > 0:
                 actually_skipped = json_reader.skip(num_batch)
                 assert actually_skipped == num_batch
             with json_reader.read() as batch:
                 with self.java_arrow.vector.VectorSchemaRoot.create(
-                        schema, self.java_allocator) as imported_batch:
+                    schema, self.java_allocator
+                ) as imported_batch:
                     # We need to pass a dict provider primed with dictionary ids
                     # matching those in the schema, hence an empty
                     # CDataDictionaryProvider would not work here.
@@ -218,7 +219,9 @@ class JavaCDataImporter(CDataImporter, _CDataBase):
                         self.java_arrow.c.Data.importIntoVectorSchemaRoot(
                             self.java_allocator,
                             self._wrap_c_array_ptr(c_array_ptr),
-                            imported_batch, dict_provider)
+                            imported_batch,
+                            dict_provider,
+                        )
                         self._assert_batches_equal(batch, imported_batch)
                         self._assert_dict_providers_equal(json_reader, dict_provider)
 
@@ -240,109 +243,111 @@ class JavaTester(Tester):
     C_DATA_ARRAY_EXPORTER = True
     C_DATA_ARRAY_IMPORTER = True
 
-    name = 'Java'
+    name = "Java"
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._java_opts = _JAVA_OPTS[:]
-        self._java_opts.append(
-            '--add-reads=org.apache.arrow.flight.core=ALL-UNNAMED')
+        self._java_opts.append("--add-reads=org.apache.arrow.flight.core=ALL-UNNAMED")
 
-    def _run(self, arrow_path=None, json_path=None, command='VALIDATE'):
+    def _run(self, arrow_path=None, json_path=None, command="VALIDATE"):
         cmd = (
-            ['java'] +
-            self._java_opts +
-            ['-cp', _ARROW_TOOLS_JAR, 'org.apache.arrow.tools.Integration']
+            ["java"]
+            + self._java_opts
+            + ["-cp", _ARROW_TOOLS_JAR, "org.apache.arrow.tools.Integration"]
         )
 
         if arrow_path is not None:
-            cmd.extend(['-a', arrow_path])
+            cmd.extend(["-a", arrow_path])
 
         if json_path is not None:
-            cmd.extend(['-j', json_path])
+            cmd.extend(["-j", json_path])
 
-        cmd.extend(['-c', command])
+        cmd.extend(["-c", command])
 
         if self.debug:
-            log(' '.join(cmd))
+            log(" ".join(cmd))
 
         run_cmd(cmd)
 
     def validate(self, json_path, arrow_path, quirks=None):
-        return self._run(arrow_path, json_path, 'VALIDATE')
+        return self._run(arrow_path, json_path, "VALIDATE")
 
     def json_to_file(self, json_path, arrow_path):
-        return self._run(arrow_path, json_path, 'JSON_TO_ARROW')
+        return self._run(arrow_path, json_path, "JSON_TO_ARROW")
 
     def stream_to_file(self, stream_path, file_path):
         cmd = (
-            ['java'] + self._java_opts + [
-                '-cp',
+            ["java"]
+            + self._java_opts
+            + [
+                "-cp",
                 _ARROW_TOOLS_JAR,
-                'org.apache.arrow.tools.StreamToFile',
+                "org.apache.arrow.tools.StreamToFile",
                 stream_path,
                 file_path,
             ]
         )
         if self.debug:
-            log(' '.join(cmd))
+            log(" ".join(cmd))
         run_cmd(cmd)
 
     def file_to_stream(self, file_path, stream_path):
         cmd = (
-            ['java'] + self._java_opts + [
-                '-cp',
+            ["java"]
+            + self._java_opts
+            + [
+                "-cp",
                 _ARROW_TOOLS_JAR,
-                'org.apache.arrow.tools.FileToStream',
+                "org.apache.arrow.tools.FileToStream",
                 file_path,
                 stream_path,
             ]
         )
         if self.debug:
-            log(' '.join(cmd))
+            log(" ".join(cmd))
         run_cmd(cmd)
 
     def flight_request(self, port, json_path=None, scenario_name=None):
         cmd = (
-            ['java'] + self._java_opts + [
-                '-cp', _ARROW_FLIGHT_JAR, _ARROW_FLIGHT_CLIENT, '-port', str(
-                    port)
-            ])
+            ["java"]
+            + self._java_opts
+            + ["-cp", _ARROW_FLIGHT_JAR, _ARROW_FLIGHT_CLIENT, "-port", str(port)]
+        )
 
         if json_path:
-            cmd.extend(('-j', json_path))
+            cmd.extend(("-j", json_path))
         elif scenario_name:
-            cmd.extend(('-scenario', scenario_name))
+            cmd.extend(("-scenario", scenario_name))
         else:
-            raise TypeError('Must provide one of json_path or scenario_name')
+            raise TypeError("Must provide one of json_path or scenario_name")
 
         if self.debug:
-            log(' '.join(cmd))
+            log(" ".join(cmd))
         run_cmd(cmd)
 
     @contextlib.contextmanager
     def flight_server(self, scenario_name=None):
         cmd = (
-            ['java'] +
-            self._java_opts +
-            ['-cp', _ARROW_FLIGHT_JAR, _ARROW_FLIGHT_SERVER, '-port', '0']
+            ["java"]
+            + self._java_opts
+            + ["-cp", _ARROW_FLIGHT_JAR, _ARROW_FLIGHT_SERVER, "-port", "0"]
         )
         if scenario_name:
-            cmd.extend(('-scenario', scenario_name))
+            cmd.extend(("-scenario", scenario_name))
         if self.debug:
-            log(' '.join(cmd))
-        server = subprocess.Popen(
-            cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            log(" ".join(cmd))
+        server = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         try:
             output = server.stdout.readline().decode()
-            if not output.startswith('Server listening on localhost:'):
+            if not output.startswith("Server listening on localhost:"):
                 server.kill()
                 out, err = server.communicate()
                 raise RuntimeError(
-                    'Flight-Java server did not start properly, '
-                    f'stdout:\n{output + out.decode()}\n\nstderr:\n{err.decode()}\n'
+                    "Flight-Java server did not start properly, "
+                    f"stdout:\n{output + out.decode()}\n\nstderr:\n{err.decode()}\n"
                 )
-            port = int(output.split(':')[1])
+            port = int(output.split(":")[1])
             yield port
         finally:
             server.kill()

--- a/dev/archery/archery/integration/tester_js.py
+++ b/dev/archery/archery/integration/tester_js.py
@@ -23,57 +23,49 @@ from .tester import Tester
 from .util import log, run_cmd
 
 ARROW_BUILD_ROOT = os.environ.get(
-    'ARROW_BUILD_ROOT',
-    Path(__file__).resolve().parents[4]
+    "ARROW_BUILD_ROOT", Path(__file__).resolve().parents[4]
 )
-ARROW_JS_ROOT = os.path.join(ARROW_BUILD_ROOT, 'js')
-_EXE_PATH = os.path.join(ARROW_JS_ROOT, 'bin')
-_VALIDATE = os.path.join(_EXE_PATH, 'integration.ts')
-_JSON_TO_ARROW = os.path.join(_EXE_PATH, 'json-to-arrow.ts')
-_STREAM_TO_FILE = os.path.join(_EXE_PATH, 'stream-to-file.ts')
-_FILE_TO_STREAM = os.path.join(_EXE_PATH, 'file-to-stream.ts')
+ARROW_JS_ROOT = os.path.join(ARROW_BUILD_ROOT, "js")
+_EXE_PATH = os.path.join(ARROW_JS_ROOT, "bin")
+_VALIDATE = os.path.join(_EXE_PATH, "integration.ts")
+_JSON_TO_ARROW = os.path.join(_EXE_PATH, "json-to-arrow.ts")
+_STREAM_TO_FILE = os.path.join(_EXE_PATH, "stream-to-file.ts")
+_FILE_TO_STREAM = os.path.join(_EXE_PATH, "file-to-stream.ts")
 
 
 class JSTester(Tester):
     PRODUCER = True
     CONSUMER = True
 
-    name = 'JS'
+    name = "JS"
 
-    def _run(self, exe_cmd, arrow_path=None, json_path=None,
-             command='VALIDATE'):
+    def _run(self, exe_cmd, arrow_path=None, json_path=None, command="VALIDATE"):
         cmd = [exe_cmd]
 
         if arrow_path is not None:
-            cmd.extend(['-a', arrow_path])
+            cmd.extend(["-a", arrow_path])
 
         if json_path is not None:
-            cmd.extend(['-j', json_path])
+            cmd.extend(["-j", json_path])
 
-        cmd.extend(['--mode', command])
+        cmd.extend(["--mode", command])
 
         if self.debug:
-            log(' '.join(cmd))
+            log(" ".join(cmd))
 
         run_cmd(cmd, cwd=ARROW_JS_ROOT)
 
     def validate(self, json_path, arrow_path, quirks=None):
-        return self._run(_VALIDATE, arrow_path, json_path, 'VALIDATE')
+        return self._run(_VALIDATE, arrow_path, json_path, "VALIDATE")
 
     def json_to_file(self, json_path, arrow_path):
-        cmd = [_JSON_TO_ARROW,
-               '-a', arrow_path,
-               '-j', json_path]
+        cmd = [_JSON_TO_ARROW, "-a", arrow_path, "-j", json_path]
         self.run_shell_command(cmd, cwd=ARROW_JS_ROOT)
 
     def stream_to_file(self, stream_path, file_path):
-        cmd = [_STREAM_TO_FILE,
-               '<', stream_path,
-               '>', file_path]
+        cmd = [_STREAM_TO_FILE, "<", stream_path, ">", file_path]
         self.run_shell_command(cmd, cwd=ARROW_JS_ROOT)
 
     def file_to_stream(self, file_path, stream_path):
-        cmd = [_FILE_TO_STREAM,
-               '<', file_path,
-               '>', stream_path]
+        cmd = [_FILE_TO_STREAM, "<", file_path, ">", stream_path]
         self.run_shell_command(cmd, cwd=ARROW_JS_ROOT)

--- a/dev/archery/archery/integration/tester_js.py
+++ b/dev/archery/archery/integration/tester_js.py
@@ -14,13 +14,13 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
 import os
 from pathlib import Path
 
 from .tester import Tester
-from .util import run_cmd, log
-
+from .util import log, run_cmd
 
 ARROW_BUILD_ROOT = os.environ.get(
     'ARROW_BUILD_ROOT',

--- a/dev/archery/archery/integration/tester_nanoarrow.py
+++ b/dev/archery/archery/integration/tester_nanoarrow.py
@@ -14,15 +14,15 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
 import functools
 import os
 
-from . import cdata
-from .tester import Tester, CDataExporter, CDataImporter
-from .util import run_cmd, log
 from ..utils.source import ARROW_ROOT_DEFAULT
-
+from . import cdata
+from .tester import CDataExporter, CDataImporter, Tester
+from .util import log, run_cmd
 
 _NANOARROW_PATH = os.environ.get(
     "ARROW_NANOARROW_PATH", os.path.join(ARROW_ROOT_DEFAULT, "nanoarrow/cdata")
@@ -122,8 +122,7 @@ class _CDataBase:
         self.dll = _load_ffi(self.ffi)
 
     def _check_nanoarrow_error(self, na_error):
-        """
-        Check a `const char*` error return from an integration entrypoint.
+        """Check a `const char*` error return from an integration entrypoint.
 
         A null means success, a non-empty string is an error message.
         The string is statically allocated on the nanoarrow side and does not

--- a/dev/archery/archery/integration/tester_nanoarrow.py
+++ b/dev/archery/archery/integration/tester_nanoarrow.py
@@ -32,9 +32,7 @@ _INTEGRATION_DLL = os.path.join(
     _NANOARROW_PATH, "libnanoarrow_c_data_integration" + cdata.dll_suffix
 )
 
-_INTEGRATION_EXE = os.path.join(
-    _NANOARROW_PATH, "nanoarrow_ipc_integration"
-)
+_INTEGRATION_EXE = os.path.join(_NANOARROW_PATH, "nanoarrow_ipc_integration")
 
 
 class NanoarrowTester(Tester):
@@ -51,37 +49,34 @@ class NanoarrowTester(Tester):
 
     def _run(self, arrow_path, json_path, command, quirks):
         env = {
-            'ARROW_PATH': arrow_path,
-            'JSON_PATH': json_path,
-            'COMMAND': command,
-            **{
-                f'QUIRK_{q}': "1"
-                for q in quirks or ()
-            },
+            "ARROW_PATH": arrow_path,
+            "JSON_PATH": json_path,
+            "COMMAND": command,
+            **{f"QUIRK_{q}": "1" for q in quirks or ()},
         }
 
         if self.debug:
-            log(f'{_INTEGRATION_EXE} {env}')
+            log(f"{_INTEGRATION_EXE} {env}")
 
         run_cmd([_INTEGRATION_EXE], env=env)
 
     def validate(self, json_path, arrow_path, quirks=None):
-        return self._run(arrow_path, json_path, 'VALIDATE', quirks)
+        return self._run(arrow_path, json_path, "VALIDATE", quirks)
 
     def json_to_file(self, json_path, arrow_path):
-        return self._run(arrow_path, json_path, 'JSON_TO_ARROW', quirks=None)
+        return self._run(arrow_path, json_path, "JSON_TO_ARROW", quirks=None)
 
     def stream_to_file(self, stream_path, file_path):
-        self.run_shell_command([_INTEGRATION_EXE, '<', stream_path], env={
-            'COMMAND': 'STREAM_TO_FILE',
-            'ARROW_PATH': file_path,
-        })
+        self.run_shell_command(
+            [_INTEGRATION_EXE, "<", stream_path],
+            env={"COMMAND": "STREAM_TO_FILE", "ARROW_PATH": file_path},
+        )
 
     def file_to_stream(self, file_path, stream_path):
-        self.run_shell_command([_INTEGRATION_EXE, '>', stream_path], env={
-            'COMMAND': 'FILE_TO_STREAM',
-            'ARROW_PATH': file_path,
-        })
+        self.run_shell_command(
+            [_INTEGRATION_EXE, ">", stream_path],
+            env={"COMMAND": "FILE_TO_STREAM", "ARROW_PATH": file_path},
+        )
 
     def make_c_data_exporter(self):
         return NanoarrowCDataExporter(self.debug, self.args)

--- a/dev/archery/archery/integration/tester_nanoarrow.py
+++ b/dev/archery/archery/integration/tester_nanoarrow.py
@@ -25,8 +25,7 @@ from ..utils.source import ARROW_ROOT_DEFAULT
 
 
 _NANOARROW_PATH = os.environ.get(
-    "ARROW_NANOARROW_PATH",
-    os.path.join(ARROW_ROOT_DEFAULT, "nanoarrow/cdata"),
+    "ARROW_NANOARROW_PATH", os.path.join(ARROW_ROOT_DEFAULT, "nanoarrow/cdata")
 )
 
 _INTEGRATION_DLL = os.path.join(

--- a/dev/archery/archery/integration/tester_rust.py
+++ b/dev/archery/archery/integration/tester_rust.py
@@ -14,17 +14,17 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
 import contextlib
 import functools
 import os
 import subprocess
 
-from . import cdata
-from .tester import Tester, CDataExporter, CDataImporter
-from .util import run_cmd, log
 from ..utils.source import ARROW_ROOT_DEFAULT
-
+from . import cdata
+from .tester import CDataExporter, CDataImporter, Tester
+from .util import log, run_cmd
 
 _EXE_PATH = os.environ.get(
     "ARROW_RUST_EXE_PATH", os.path.join(ARROW_ROOT_DEFAULT, "rust/target/debug")
@@ -106,9 +106,7 @@ class RustTester(Tester):
                 out, err = server.communicate()
                 raise RuntimeError(
                     'Flight-Rust server did not start properly, '
-                    'stdout:\n{}\n\nstderr:\n{}\n'.format(
-                        output + out.decode(), err.decode()
-                    )
+                    f'stdout:\n{output + out.decode()}\n\nstderr:\n{err.decode()}\n'
                 )
             port = int(output.split(':')[1])
             yield port
@@ -170,8 +168,7 @@ class _CDataBase:
         return self.ffi.cast('uintptr_t', c_ptr)
 
     def _check_rust_error(self, rs_error):
-        """
-        Check a `const char*` error return from an integration entrypoint.
+        """Check a `const char*` error return from an integration entrypoint.
 
         A null means success, a non-empty string is an error message.
         The string is dynamically allocated on the Rust side.

--- a/dev/archery/archery/integration/tester_rust.py
+++ b/dev/archery/archery/integration/tester_rust.py
@@ -33,16 +33,16 @@ _INTEGRATION_EXE = os.path.join(_EXE_PATH, "arrow-json-integration-test")
 _STREAM_TO_FILE = os.path.join(_EXE_PATH, "arrow-stream-to-file")
 _FILE_TO_STREAM = os.path.join(_EXE_PATH, "arrow-file-to-stream")
 
-_FLIGHT_SERVER_CMD = [os.path.join(
-    _EXE_PATH, "flight-test-integration-server")]
+_FLIGHT_SERVER_CMD = [os.path.join(_EXE_PATH, "flight-test-integration-server")]
 _FLIGHT_CLIENT_CMD = [
     os.path.join(_EXE_PATH, "flight-test-integration-client"),
     "--host",
     "localhost",
 ]
 
-_INTEGRATION_DLL = os.path.join(_EXE_PATH,
-                                "libarrow_integration_testing" + cdata.dll_suffix)
+_INTEGRATION_DLL = os.path.join(
+    _EXE_PATH, "libarrow_integration_testing" + cdata.dll_suffix
+)
 
 
 class RustTester(Tester):
@@ -55,76 +55,72 @@ class RustTester(Tester):
     C_DATA_SCHEMA_IMPORTER = True
     C_DATA_ARRAY_IMPORTER = True
 
-    name = 'Rust'
+    name = "Rust"
 
-    def _run(self, arrow_path=None, json_path=None, command='VALIDATE'):
-        cmd = [_INTEGRATION_EXE, '--integration']
+    def _run(self, arrow_path=None, json_path=None, command="VALIDATE"):
+        cmd = [_INTEGRATION_EXE, "--integration"]
 
         if arrow_path is not None:
-            cmd.append('--arrow=' + arrow_path)
+            cmd.append("--arrow=" + arrow_path)
 
         if json_path is not None:
-            cmd.append('--json=' + json_path)
+            cmd.append("--json=" + json_path)
 
-        cmd.append('--mode=' + command)
+        cmd.append("--mode=" + command)
 
         if self.debug:
-            log(' '.join(cmd))
+            log(" ".join(cmd))
 
         run_cmd(cmd)
 
     def validate(self, json_path, arrow_path, quirks=None):
-        return self._run(arrow_path, json_path, 'VALIDATE')
+        return self._run(arrow_path, json_path, "VALIDATE")
 
     def json_to_file(self, json_path, arrow_path):
-        return self._run(arrow_path, json_path, 'JSON_TO_ARROW')
+        return self._run(arrow_path, json_path, "JSON_TO_ARROW")
 
     def stream_to_file(self, stream_path, file_path):
-        cmd = [_STREAM_TO_FILE, '<', stream_path, '>', file_path]
+        cmd = [_STREAM_TO_FILE, "<", stream_path, ">", file_path]
         self.run_shell_command(cmd)
 
     def file_to_stream(self, file_path, stream_path):
-        cmd = [_FILE_TO_STREAM, file_path, '>', stream_path]
+        cmd = [_FILE_TO_STREAM, file_path, ">", stream_path]
         self.run_shell_command(cmd)
 
     @contextlib.contextmanager
     def flight_server(self, scenario_name=None):
-        cmd = _FLIGHT_SERVER_CMD + ['--port=0']
+        cmd = _FLIGHT_SERVER_CMD + ["--port=0"]
         if scenario_name:
-            cmd = cmd + ['--scenario', scenario_name]
+            cmd = cmd + ["--scenario", scenario_name]
         if self.debug:
-            log(' '.join(cmd))
-        server = subprocess.Popen(
-            cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
+            log(" ".join(cmd))
+        server = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         try:
             output = server.stdout.readline().decode()
-            if not output.startswith('Server listening on localhost:'):
+            if not output.startswith("Server listening on localhost:"):
                 server.kill()
                 out, err = server.communicate()
                 raise RuntimeError(
-                    'Flight-Rust server did not start properly, '
-                    f'stdout:\n{output + out.decode()}\n\nstderr:\n{err.decode()}\n'
+                    "Flight-Rust server did not start properly, "
+                    f"stdout:\n{output + out.decode()}\n\nstderr:\n{err.decode()}\n"
                 )
-            port = int(output.split(':')[1])
+            port = int(output.split(":")[1])
             yield port
         finally:
             server.kill()
             server.wait(5)
 
     def flight_request(self, port, json_path=None, scenario_name=None):
-        cmd = _FLIGHT_CLIENT_CMD + [f'--port={port}']
+        cmd = _FLIGHT_CLIENT_CMD + [f"--port={port}"]
         if json_path:
-            cmd.extend(('--path', json_path))
+            cmd.extend(("--path", json_path))
         elif scenario_name:
-            cmd.extend(('--scenario', scenario_name))
+            cmd.extend(("--scenario", scenario_name))
         else:
-            raise TypeError('Must provide one of json_path or scenario_name')
+            raise TypeError("Must provide one of json_path or scenario_name")
 
         if self.debug:
-            log(' '.join(cmd))
+            log(" ".join(cmd))
         run_cmd(cmd)
 
     def make_c_data_exporter(self):
@@ -157,7 +153,6 @@ def _load_ffi(ffi, lib_path=_INTEGRATION_DLL):
 
 
 class _CDataBase:
-
     def __init__(self, debug, args):
         self.debug = debug
         self.args = args
@@ -165,7 +160,7 @@ class _CDataBase:
         self.dll = _load_ffi(self.ffi)
 
     def _pointer_to_int(self, c_ptr):
-        return self.ffi.cast('uintptr_t', c_ptr)
+        return self.ffi.cast("uintptr_t", c_ptr)
 
     def _check_rust_error(self, rs_error):
         """Check a `const char*` error return from an integration entrypoint.
@@ -176,25 +171,23 @@ class _CDataBase:
         assert self.ffi.typeof(rs_error) is self.ffi.typeof("const char*")
         if rs_error != self.ffi.NULL:
             try:
-                error = self.ffi.string(rs_error).decode(
-                    'utf8', errors='replace')
-                raise RuntimeError(
-                    f"Rust C Data Integration call failed: {error}")
+                error = self.ffi.string(rs_error).decode("utf8", errors="replace")
+                raise RuntimeError(f"Rust C Data Integration call failed: {error}")
             finally:
                 self.dll.arrow_rs_free_error(rs_error)
 
 
 class RustCDataExporter(CDataExporter, _CDataBase):
-
     def export_schema_from_json(self, json_path, c_schema_ptr):
         rs_error = self.dll.arrow_rs_cdata_integration_export_schema_from_json(
-            str(json_path).encode(), self._pointer_to_int(c_schema_ptr))
+            str(json_path).encode(), self._pointer_to_int(c_schema_ptr)
+        )
         self._check_rust_error(rs_error)
 
     def export_batch_from_json(self, json_path, num_batch, c_array_ptr):
         rs_error = self.dll.arrow_rs_cdata_integration_export_batch_from_json(
-            str(json_path).encode(), num_batch,
-            self._pointer_to_int(c_array_ptr))
+            str(json_path).encode(), num_batch, self._pointer_to_int(c_array_ptr)
+        )
         self._check_rust_error(rs_error)
 
     @property
@@ -207,18 +200,18 @@ class RustCDataExporter(CDataExporter, _CDataBase):
 
 
 class RustCDataImporter(CDataImporter, _CDataBase):
-
     def import_schema_and_compare_to_json(self, json_path, c_schema_ptr):
-        rs_error = \
+        rs_error = (
             self.dll.arrow_rs_cdata_integration_import_schema_and_compare_to_json(
-                str(json_path).encode(), self._pointer_to_int(c_schema_ptr))
+                str(json_path).encode(), self._pointer_to_int(c_schema_ptr)
+            )
+        )
         self._check_rust_error(rs_error)
 
-    def import_batch_and_compare_to_json(self, json_path, num_batch,
-                                         c_array_ptr):
-        rs_error = \
-            self.dll.arrow_rs_cdata_integration_import_batch_and_compare_to_json(
-                str(json_path).encode(), num_batch, self._pointer_to_int(c_array_ptr))
+    def import_batch_and_compare_to_json(self, json_path, num_batch, c_array_ptr):
+        rs_error = self.dll.arrow_rs_cdata_integration_import_batch_and_compare_to_json(
+            str(json_path).encode(), num_batch, self._pointer_to_int(c_array_ptr)
+        )
         self._check_rust_error(rs_error)
 
     @property

--- a/dev/archery/archery/integration/util.py
+++ b/dev/archery/archery/integration/util.py
@@ -33,10 +33,10 @@ def guid():
 
 
 # SKIP categories
-SKIP_C_ARRAY = 'c_array'
-SKIP_C_SCHEMA = 'c_schema'
-SKIP_FLIGHT = 'flight'
-SKIP_IPC = 'ipc'
+SKIP_C_ARRAY = "c_array"
+SKIP_C_SCHEMA = "c_schema"
+SKIP_FLIGHT = "flight"
+SKIP_IPC = "ipc"
 
 
 class _Printer:
@@ -56,8 +56,7 @@ class _Printer:
             return self._tls.stdout
 
     def print(self, *args, **kwargs):
-        """A variant of print() that writes to a thread-local stream.
-        """
+        """A variant of print() that writes to a thread-local stream."""
         print(*args, file=self._get_stdout(), **kwargs)
 
     @property
@@ -94,37 +93,34 @@ _RAND_CHARS = np.array(list("abcdefghijklmnop123456Ârrôwµ£°€矢"), dtype=
 
 
 def random_utf8(nchars):
-    """Generate one random UTF8 string.
-    """
-    return ''.join(np.random.choice(_RAND_CHARS, nchars))
+    """Generate one random UTF8 string."""
+    return "".join(np.random.choice(_RAND_CHARS, nchars))
 
 
 def random_bytes(nbytes):
-    """Generate one random binary string.
-    """
+    """Generate one random binary string."""
     # NOTE getrandbits(0) fails
     if nbytes > 0:
-        return random.getrandbits(nbytes * 8).to_bytes(nbytes,
-                                                       byteorder='little')
+        return random.getrandbits(nbytes * 8).to_bytes(nbytes, byteorder="little")
     else:
         return b""
 
 
 def tobytes(o):
     if isinstance(o, str):
-        return o.encode('utf8')
+        return o.encode("utf8")
     return o
 
 
 def frombytes(o):
     if isinstance(o, bytes):
-        return o.decode('utf8')
+        return o.decode("utf8")
     return o
 
 
 def run_cmd(cmd, **kwargs):
     if isinstance(cmd, str):
-        cmd = cmd.split(' ')
+        cmd = cmd.split(" ")
 
     try:
         kwargs.update(stderr=subprocess.STDOUT)
@@ -132,11 +128,11 @@ def run_cmd(cmd, **kwargs):
     except subprocess.CalledProcessError as e:
         # this avoids hiding the stdout / stderr of failed processes
         sio = io.StringIO()
-        print('Command failed:', " ".join(cmd), file=sio)
-        print('With output:', file=sio)
-        print('--------------', file=sio)
+        print("Command failed:", " ".join(cmd), file=sio)
+        print("With output:", file=sio)
+        print("--------------", file=sio)
         print(frombytes(e.output), file=sio)
-        print('--------------', file=sio)
+        print("--------------", file=sio)
         raise RuntimeError(sio.getvalue())
 
     return frombytes(output)
@@ -152,7 +148,7 @@ def find_unused_port(family=socket.AF_INET, socktype=socket.SOCK_STREAM):
     then closed and deleted, and the ephemeral port is returned.
     """
     with socket.socket(family, socktype) as tempsock:
-        tempsock.bind(('', 0))
+        tempsock.bind(("", 0))
         port = tempsock.getsockname()[1]
     del tempsock
     return port

--- a/dev/archery/archery/integration/util.py
+++ b/dev/archery/archery/integration/util.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
 import contextlib
 import io
@@ -39,8 +40,7 @@ SKIP_IPC = 'ipc'
 
 
 class _Printer:
-    """
-    A print()-providing object that can override the stream output on
+    """A print()-providing object that can override the stream output on
     a per-thread basis.
     """
 
@@ -56,23 +56,20 @@ class _Printer:
             return self._tls.stdout
 
     def print(self, *args, **kwargs):
-        """
-        A variant of print() that writes to a thread-local stream.
+        """A variant of print() that writes to a thread-local stream.
         """
         print(*args, file=self._get_stdout(), **kwargs)
 
     @property
     def stdout(self):
-        """
-        A thread-local stdout wrapper that may be temporarily buffered
+        """A thread-local stdout wrapper that may be temporarily buffered
         using `cork()`.
         """
         return self._get_stdout()
 
     @contextlib.contextmanager
     def cork(self):
-        """
-        Temporarily buffer this thread's stream and write out its contents
+        """Temporarily buffer this thread's stream and write out its contents
         at the end of the context manager.  Useful to avoid interleaved
         output when multiple threads output progress information.
         """
@@ -97,15 +94,13 @@ _RAND_CHARS = np.array(list("abcdefghijklmnop123456Ârrôwµ£°€矢"), dtype=
 
 
 def random_utf8(nchars):
-    """
-    Generate one random UTF8 string.
+    """Generate one random UTF8 string.
     """
     return ''.join(np.random.choice(_RAND_CHARS, nchars))
 
 
 def random_bytes(nbytes):
-    """
-    Generate one random binary string.
+    """Generate one random binary string.
     """
     # NOTE getrandbits(0) fails
     if nbytes > 0:

--- a/dev/archery/archery/lang/cpp.py
+++ b/dev/archery/archery/lang/cpp.py
@@ -37,36 +37,62 @@ LLVM_VERSION = 7
 
 
 class CppConfiguration:
-    def __init__(self,
-
-                 # toolchain
-                 cc=None, cxx=None, cxx_flags=None,
-                 build_type=None, warn_level=None,
-                 cpp_package_prefix=None, install_prefix=None, use_conda=None,
-                 build_static=True, build_shared=True, build_unity=True,
-                 # tests & examples
-                 with_tests=None, with_benchmarks=None, with_examples=None,
-                 with_integration=None,
-                 # static checks
-                 use_asan=None, use_tsan=None, use_ubsan=None,
-                 with_fuzzing=None,
-                 # Components
-                 with_compute=None, with_csv=None, with_cuda=None,
-                 with_dataset=None, with_filesystem=None, with_flight=None,
-                 with_gandiva=None, with_gcs=None, with_hdfs=None,
-                 with_hiveserver2=None,
-                 with_ipc=True, with_json=None,
-                 with_mimalloc=None, with_jemalloc=None,
-                 with_parquet=None, with_python=True,
-                 with_r=None, with_s3=None,
-                 # Compressions
-                 with_brotli=None, with_bz2=None, with_lz4=None,
-                 with_snappy=None, with_zlib=None, with_zstd=None,
-                 # extras
-                 with_lint_only=False,
-                 use_gold_linker=True,
-                 simd_level="DEFAULT",
-                 cmake_extras=None):
+    def __init__(
+        self,
+        # toolchain
+        cc=None,
+        cxx=None,
+        cxx_flags=None,
+        build_type=None,
+        warn_level=None,
+        cpp_package_prefix=None,
+        install_prefix=None,
+        use_conda=None,
+        build_static=True,
+        build_shared=True,
+        build_unity=True,
+        # tests & examples
+        with_tests=None,
+        with_benchmarks=None,
+        with_examples=None,
+        with_integration=None,
+        # static checks
+        use_asan=None,
+        use_tsan=None,
+        use_ubsan=None,
+        with_fuzzing=None,
+        # Components
+        with_compute=None,
+        with_csv=None,
+        with_cuda=None,
+        with_dataset=None,
+        with_filesystem=None,
+        with_flight=None,
+        with_gandiva=None,
+        with_gcs=None,
+        with_hdfs=None,
+        with_hiveserver2=None,
+        with_ipc=True,
+        with_json=None,
+        with_mimalloc=None,
+        with_jemalloc=None,
+        with_parquet=None,
+        with_python=True,
+        with_r=None,
+        with_s3=None,
+        # Compressions
+        with_brotli=None,
+        with_bz2=None,
+        with_lz4=None,
+        with_snappy=None,
+        with_zlib=None,
+        with_zstd=None,
+        # extras
+        with_lint_only=False,
+        use_gold_linker=True,
+        simd_level="DEFAULT",
+        cmake_extras=None,
+    ):
         self._cc = cc
         self._cxx = cxx
         self.cxx_flags = cxx_flags
@@ -187,8 +213,7 @@ class CppConfiguration:
         yield ("CMAKE_BUILD_TYPE", self.build_type)
 
         if not self.with_lint_only:
-            yield ("BUILD_WARNING_LEVEL",
-                   or_else(self.warn_level, "production"))
+            yield ("BUILD_WARNING_LEVEL", or_else(self.warn_level, "production"))
 
         # if not ctx.quiet:
         #   yield ("ARROW_VERBOSE_THIRDPARTY_BUILD", "ON")
@@ -252,7 +277,7 @@ class CppConfiguration:
 
         # Detect custom conda toolchain
         if self.use_conda:
-            for d, v in [('CMAKE_AR', 'AR'), ('CMAKE_RANLIB', 'RANLIB')]:
+            for d, v in [("CMAKE_AR", "AR"), ("CMAKE_RANLIB", "RANLIB")]:
                 v = os.environ.get(v)
                 if v:
                     yield (d, v)
@@ -297,6 +322,10 @@ class CppConfiguration:
 class CppCMakeDefinition(CMakeDefinition):
     def __init__(self, source, conf, **kwargs):
         self.configuration = conf
-        super().__init__(source, **kwargs,
-                         definitions=conf.definitions, env=conf.environment,
-                         build_type=conf.build_type)
+        super().__init__(
+            source,
+            **kwargs,
+            definitions=conf.definitions,
+            env=conf.environment,
+            build_type=conf.build_type,
+        )

--- a/dev/archery/archery/lang/cpp.py
+++ b/dev/archery/archery/lang/cpp.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
 import os
 
@@ -164,7 +165,7 @@ class CppConfiguration:
             return self._cc
 
         if self.with_fuzzing:
-            return "clang-{}".format(LLVM_VERSION)
+            return f"clang-{LLVM_VERSION}"
 
         return None
 
@@ -174,7 +175,7 @@ class CppConfiguration:
             return self._cxx
 
         if self.with_fuzzing:
-            return "clang++-{}".format(LLVM_VERSION)
+            return f"clang++-{LLVM_VERSION}"
 
         return None
 
@@ -277,7 +278,7 @@ class CppConfiguration:
     @property
     def definitions(self):
         extras = list(self.cmake_extras) if self.cmake_extras else []
-        definitions = ["-D{}={}".format(d[0], d[1]) for d in self._gen_defs()]
+        definitions = [f"-D{d[0]}={d[1]}" for d in self._gen_defs()]
         return definitions + extras
 
     @property

--- a/dev/archery/archery/lang/java.py
+++ b/dev/archery/archery/lang/java.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
 import os
 

--- a/dev/archery/archery/lang/java.py
+++ b/dev/archery/archery/lang/java.py
@@ -35,7 +35,7 @@ class Jar(CommandStackMixin, Java):
 
 class JavaConfiguration:
     REQUIRED_JAVA_OPTIONS = [
-        "--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED",
+        "--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED"
     ]
 
     def __init__(self,

--- a/dev/archery/archery/lang/java.py
+++ b/dev/archery/archery/lang/java.py
@@ -39,11 +39,15 @@ class JavaConfiguration:
         "--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED"
     ]
 
-    def __init__(self,
-                 # toolchain
-                 java_home=None, java_options=None,
-                 # build & benchmark
-                 build_extras=None, benchmark_extras=None):
+    def __init__(
+        self,
+        # toolchain
+        java_home=None,
+        java_options=None,
+        # build & benchmark
+        build_extras=None,
+        benchmark_extras=None,
+    ):
         self.java_home = java_home
         self.java_options = java_options
 
@@ -55,8 +59,7 @@ class JavaConfiguration:
                     self.java_options += " " + option
 
         self.build_extras = list(build_extras) if build_extras else []
-        self.benchmark_extras = list(
-            benchmark_extras) if benchmark_extras else []
+        self.benchmark_extras = list(benchmark_extras) if benchmark_extras else []
 
     @property
     def build_definitions(self):
@@ -82,7 +85,10 @@ class JavaConfiguration:
 class JavaMavenDefinition(MavenDefinition):
     def __init__(self, source, conf, **kwargs):
         self.configuration = conf
-        super().__init__(source, **kwargs,
-                         build_definitions=conf.build_definitions,
-                         benchmark_definitions=conf.benchmark_definitions,
-                         env=conf.environment)
+        super().__init__(
+            source,
+            **kwargs,
+            build_definitions=conf.build_definitions,
+            benchmark_definitions=conf.benchmark_definitions,
+            env=conf.environment,
+        )

--- a/dev/archery/archery/lang/python.py
+++ b/dev/archery/archery/lang/python.py
@@ -14,11 +14,12 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
-from contextlib import contextmanager
-from enum import EnumMeta
 import inspect
 import tokenize
+from contextlib import contextmanager
+from enum import EnumMeta
 
 try:
     from numpydoc.validate import Docstring, validate
@@ -28,8 +29,8 @@ else:
     have_numpydoc = True
 
 from ..compat import _get_module
-from ..utils.logger import logger
 from ..utils.command import Command, capture_stdout, default_bin
+from ..utils.logger import logger
 
 
 class PythonCommand(Command):
@@ -91,8 +92,7 @@ def _convert_typehint(tokens):
 
 
 def inspect_signature(obj):
-    """
-    Custom signature inspection primarily for cython generated callables.
+    """Custom signature inspection primarily for cython generated callables.
 
     Cython puts the signatures to the first line of the docstrings, which we
     can reuse to parse the python signature from, but some gymnastics are
@@ -176,8 +176,7 @@ class NumpyDoc:
 
     @contextmanager
     def _apply_patches(self):
-        """
-        Patch Docstring class to bypass loading already loaded python objects.
+        """Patch Docstring class to bypass loading already loaded python objects.
         """
         orig_load_obj = Docstring._load_obj
         orig_signature = inspect.signature
@@ -252,7 +251,7 @@ class NumpyDoc:
                 try:
                     obj = Docstring._load_obj(symbol)
                 except (ImportError, AttributeError):
-                    print('{} is not available for import'.format(symbol))
+                    print(f'{symbol} is not available for import')
                 else:
                     self.traverse(callback, obj, from_package=from_package)
 

--- a/dev/archery/archery/lang/python.py
+++ b/dev/archery/archery/lang/python.py
@@ -58,7 +58,7 @@ class Autopep8(Command):
 
 
 def _tokenize_signature(s):
-    lines = s.encode('ascii').splitlines()
+    lines = s.encode("ascii").splitlines()
     generator = iter(lines).__next__
     return tokenize.tokenize(generator)
 
@@ -69,7 +69,7 @@ def _convert_typehint(tokens):
     for token in tokens:
         # omit the tokens before the opening bracket
         if not opening_bracket_reached:
-            if token.string == '(':
+            if token.string == "(":
                 opening_bracket_reached = True
             else:
                 continue
@@ -86,7 +86,7 @@ def _convert_typehint(tokens):
                 # are not supported by _signature_fromstr
                 yield (names[1].type, names[1].string)
             elif len(names) > 2:
-                raise ValueError('More than two NAME tokens follow each other')
+                raise ValueError("More than two NAME tokens follow each other")
             names = []
             yield (token.type, token.string)
 
@@ -121,10 +121,10 @@ class NumpyDoc:
     def __init__(self, symbols=None):
         if not have_numpydoc:
             raise RuntimeError(
-                'Numpydoc is not available, install with command: '
-                'pip install numpydoc==1.1.0'
+                "Numpydoc is not available, install with command: "
+                "pip install numpydoc==1.1.0"
             )
-        self.symbols = set(symbols or {'pyarrow'})
+        self.symbols = set(symbols or {"pyarrow"})
 
     def traverse(self, fn, obj, from_package):
         """Apply a function on publicly exposed API components.
@@ -154,7 +154,7 @@ class NumpyDoc:
             fn(obj)
 
             for name in dir(obj):
-                if name.startswith('_'):
+                if name.startswith("_"):
                     continue
 
                 member = getattr(obj, name)
@@ -166,18 +166,17 @@ class NumpyDoc:
                 # and no user-defined docstring following it.
                 # The generated docstring would lack description of method
                 # parameters and therefore fail Numpydoc validation.
-                if hasattr(member, '__objclass__'):
-                    doc = getattr(member, '__doc__', None)
+                if hasattr(member, "__objclass__"):
+                    doc = getattr(member, "__doc__", None)
                     # The Cython-generated docstring would be a one-liner,
                     # such as "ReadOptions.equals(self, ReadOptions other)".
-                    if (doc and '\n' not in doc and f'.{name}(' in doc):
+                    if doc and "\n" not in doc and f".{name}(" in doc:
                         continue
                 todo.append(member)
 
     @contextmanager
     def _apply_patches(self):
-        """Patch Docstring class to bypass loading already loaded python objects.
-        """
+        """Patch Docstring class to bypass loading already loaded python objects."""
         orig_load_obj = Docstring._load_obj
         orig_signature = inspect.signature
 
@@ -233,7 +232,7 @@ class NumpyDoc:
                 return
 
             errors = []
-            for errcode, errmsg in result.get('errors', []):
+            for errcode, errmsg in result.get("errors", []):
                 if allow_rules and errcode not in allow_rules:
                     continue
                 if disallow_rules and errcode in disallow_rules:
@@ -243,7 +242,7 @@ class NumpyDoc:
                 errors.append((errcode, errmsg))
 
             if len(errors):
-                result['errors'] = errors
+                result["errors"] = errors
                 results.append((obj, result))
 
         with self._apply_patches():
@@ -251,7 +250,7 @@ class NumpyDoc:
                 try:
                     obj = Docstring._load_obj(symbol)
                 except (ImportError, AttributeError):
-                    print(f'{symbol} is not available for import')
+                    print(f"{symbol} is not available for import")
                 else:
                     self.traverse(callback, obj, from_package=from_package)
 

--- a/dev/archery/archery/lang/python.py
+++ b/dev/archery/archery/lang/python.py
@@ -216,8 +216,13 @@ class NumpyDoc:
             Docstring._load_obj = orig_load_obj
             inspect.signature = orig_signature
 
-    def validate(self, from_package='', allow_rules=None,
-                 disallow_rules=None):
+    def _should_ignore_error(self, obj, errcode):
+        for obj_type, errcode_list in self.IGNORE_VALIDATION_ERRORS_FOR_TYPE.items():
+            if isinstance(obj, obj_type) and errcode in errcode_list:
+                return True
+        return False
+
+    def validate(self, from_package="", allow_rules=None, disallow_rules=None):
         results = []
 
         def callback(obj):
@@ -234,9 +239,7 @@ class NumpyDoc:
                     continue
                 if disallow_rules and errcode in disallow_rules:
                     continue
-                if any(isinstance(obj, obj_type) and errcode in errcode_list
-                       for obj_type, errcode_list
-                       in NumpyDoc.IGNORE_VALIDATION_ERRORS_FOR_TYPE.items()):
+                if self._should_ignore_error(obj, errcode):
                     continue
                 errors.append((errcode, errmsg))
 

--- a/dev/archery/archery/linking.py
+++ b/dev/archery/archery/linking.py
@@ -14,12 +14,12 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
 import platform
 import subprocess
 
 from .utils.command import Command
-
 
 _ldd = Command("ldd")
 _otool = Command("otool")
@@ -35,8 +35,7 @@ class DynamicLibrary:
         self.path = path
 
     def list_dependencies(self):
-        """
-        List the full name of the library dependencies.
+        """List the full name of the library dependencies.
         """
         system = platform.system()
         if system == "Linux":
@@ -51,8 +50,7 @@ class DynamicLibrary:
             raise ValueError(f"{platform} is not supported")
 
     def list_dependency_names(self):
-        """
-        List the truncated names of the dynamic library dependencies.
+        """List the truncated names of the dynamic library dependencies.
         """
         names = []
         for dependency in self.list_dependencies():

--- a/dev/archery/archery/linking.py
+++ b/dev/archery/archery/linking.py
@@ -30,13 +30,11 @@ class DependencyError(Exception):
 
 
 class DynamicLibrary:
-
     def __init__(self, path):
         self.path = path
 
     def list_dependencies(self):
-        """List the full name of the library dependencies.
-        """
+        """List the full name of the library dependencies."""
         system = platform.system()
         if system == "Linux":
             result = _ldd.run(self.path, stdout=subprocess.PIPE)
@@ -50,8 +48,7 @@ class DynamicLibrary:
             raise ValueError(f"{platform} is not supported")
 
     def list_dependency_names(self):
-        """List the truncated names of the dynamic library dependencies.
-        """
+        """List the truncated names of the dynamic library dependencies."""
         names = []
         for dependency in self.list_dependencies():
             *_, library = dependency.rsplit("/", 1)

--- a/dev/archery/archery/release/__init__.py
+++ b/dev/archery/archery/release/__init__.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
 from .core import MajorRelease, MinorRelease, PatchRelease, Release
 

--- a/dev/archery/archery/release/__init__.py
+++ b/dev/archery/archery/release/__init__.py
@@ -15,4 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from .core import Release, MajorRelease, MinorRelease, PatchRelease  # noqa
+from .core import MajorRelease, MinorRelease, PatchRelease, Release
+
+__all__ = ["MajorRelease", "MinorRelease", "PatchRelease", "Release"]

--- a/dev/archery/archery/release/cli.py
+++ b/dev/archery/archery/release/cli.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
 import pathlib
 
@@ -33,7 +34,6 @@ from .core import IssueTracker, Release
 @click.pass_obj
 def release(obj, src, github_token):
     """Release related commands."""
-
     obj['issue_tracker'] = IssueTracker(github_token=github_token)
     obj['repo'] = src.path
 
@@ -55,7 +55,6 @@ def release_curate(obj, version, minimal):
 @release.group('changelog')
 def release_changelog():
     """Release changelog."""
-    pass
 
 
 @release_changelog.command('add')
@@ -108,7 +107,7 @@ def release_changelog_regenerate(obj):
             continue
         release = Release(version, repo=repo,
                           issue_tracker=issue_tracker)
-        click.echo('Querying changelog for version: {}'.format(version))
+        click.echo(f'Querying changelog for version: {version}')
         changelogs.append(release.changelog())
 
     click.echo('Rendering new CHANGELOG.md file...')
@@ -127,8 +126,7 @@ def release_changelog_regenerate(obj):
                    "patches.")
 @click.pass_obj
 def release_cherry_pick(obj, version, dry_run, recreate):
-    """
-    Cherry pick commits.
+    """Cherry pick commits.
     """
     issue_tracker = obj['issue_tracker']
     release = Release(version,
@@ -139,4 +137,4 @@ def release_cherry_pick(obj, version, dry_run, recreate):
     else:
         click.echo(f'git checkout -b {release.branch} {release.base_branch}')
         for commit in release.commits_to_pick():
-            click.echo('git cherry-pick {}'.format(commit.hexsha))
+            click.echo(f'git cherry-pick {commit.hexsha}')

--- a/dev/archery/archery/release/cli.py
+++ b/dev/archery/archery/release/cli.py
@@ -24,117 +24,127 @@ from ..utils.cli import validate_arrow_sources
 from .core import IssueTracker, Release
 
 
-@click.group('release')
-@click.option("--src", metavar="<arrow_src>", default=None,
-              callback=validate_arrow_sources,
-              help="Specify Arrow source directory.")
-@click.option('--github-token', '-t', default=None,
-              envvar="CROSSBOW_GITHUB_TOKEN",
-              help='OAuth token for GitHub authentication')
+@click.group("release")
+@click.option(
+    "--src",
+    metavar="<arrow_src>",
+    default=None,
+    callback=validate_arrow_sources,
+    help="Specify Arrow source directory.",
+)
+@click.option(
+    "--github-token",
+    "-t",
+    default=None,
+    envvar="CROSSBOW_GITHUB_TOKEN",
+    help="OAuth token for GitHub authentication",
+)
 @click.pass_obj
 def release(obj, src, github_token):
     """Release related commands."""
-    obj['issue_tracker'] = IssueTracker(github_token=github_token)
-    obj['repo'] = src.path
+    obj["issue_tracker"] = IssueTracker(github_token=github_token)
+    obj["repo"] = src.path
 
 
-@release.command('curate', help="Lists release related issues.")
-@click.argument('version')
-@click.option('--minimal/--full', '-m/-f',
-              help="Only show actionable issues.", default=False)
+@release.command("curate", help="Lists release related issues.")
+@click.argument("version")
+@click.option(
+    "--minimal/--full", "-m/-f", help="Only show actionable issues.", default=False
+)
 @click.pass_obj
 def release_curate(obj, version, minimal):
     """Release curation."""
-    release = Release(version, repo=obj['repo'],
-                      issue_tracker=obj['issue_tracker'])
+    release = Release(version, repo=obj["repo"], issue_tracker=obj["issue_tracker"])
     curation = release.curate(minimal)
 
-    click.echo(curation.render('console'))
+    click.echo(curation.render("console"))
 
 
-@release.group('changelog')
+@release.group("changelog")
 def release_changelog():
     """Release changelog."""
 
 
-@release_changelog.command('add')
-@click.argument('version')
+@release_changelog.command("add")
+@click.argument("version")
 @click.pass_obj
 def release_changelog_add(obj, version):
     """Prepend the changelog with the current release"""
-    repo, issue_tracker = obj['repo'], obj['issue_tracker']
+    repo, issue_tracker = obj["repo"], obj["issue_tracker"]
 
     # just handle the current version
     release = Release(version, repo=repo, issue_tracker=issue_tracker)
     if release.is_released:
-        raise ValueError('This version has been already released!')
+        raise ValueError("This version has been already released!")
 
     changelog = release.changelog()
-    changelog_path = pathlib.Path(repo) / 'CHANGELOG.md'
+    changelog_path = pathlib.Path(repo) / "CHANGELOG.md"
 
     current_content = changelog_path.read_text()
-    new_content = changelog.render('markdown') + current_content
+    new_content = changelog.render("markdown") + current_content
 
     changelog_path.write_text(new_content)
     click.echo("CHANGELOG.md is updated!")
 
 
-@release_changelog.command('generate')
-@click.argument('version')
-@click.argument('output', type=click.File('w', encoding='utf8'), default='-')
+@release_changelog.command("generate")
+@click.argument("version")
+@click.argument("output", type=click.File("w", encoding="utf8"), default="-")
 @click.pass_obj
 def release_changelog_generate(obj, version, output):
     """Generate the changelog of a specific release."""
-    repo, issue_tracker = obj['repo'], obj['issue_tracker']
+    repo, issue_tracker = obj["repo"], obj["issue_tracker"]
 
     # just handle the current version
     release = Release(version, repo=repo, issue_tracker=issue_tracker)
 
     changelog = release.changelog()
-    output.write(changelog.render('markdown'))
+    output.write(changelog.render("markdown"))
 
 
-@release_changelog.command('regenerate')
+@release_changelog.command("regenerate")
 @click.pass_obj
 def release_changelog_regenerate(obj):
     """Regenerate the whole CHANGELOG.md file"""
-    issue_tracker, repo = obj['issue_tracker'], obj['repo']
+    issue_tracker, repo = obj["issue_tracker"], obj["repo"]
     changelogs = []
     issue_tracker = IssueTracker(issue_tracker=issue_tracker)
 
     for version in issue_tracker.project_versions():
         if not version.released:
             continue
-        release = Release(version, repo=repo,
-                          issue_tracker=issue_tracker)
-        click.echo(f'Querying changelog for version: {version}')
+        release = Release(version, repo=repo, issue_tracker=issue_tracker)
+        click.echo(f"Querying changelog for version: {version}")
         changelogs.append(release.changelog())
 
-    click.echo('Rendering new CHANGELOG.md file...')
-    changelog_path = pathlib.Path(repo) / 'CHANGELOG.md'
-    with changelog_path.open('w') as fp:
+    click.echo("Rendering new CHANGELOG.md file...")
+    changelog_path = pathlib.Path(repo) / "CHANGELOG.md"
+    with changelog_path.open("w") as fp:
         for cl in changelogs:
-            fp.write(cl.render('markdown'))
+            fp.write(cl.render("markdown"))
 
 
-@release.command('cherry-pick')
-@click.argument('version')
-@click.option('--dry-run/--execute', default=True,
-              help="Display the git commands instead of executing them.")
-@click.option('--recreate/--continue', default=True,
-              help="Recreate the maintenance branch or only apply unapplied "
-                   "patches.")
+@release.command("cherry-pick")
+@click.argument("version")
+@click.option(
+    "--dry-run/--execute",
+    default=True,
+    help="Display the git commands instead of executing them.",
+)
+@click.option(
+    "--recreate/--continue",
+    default=True,
+    help="Recreate the maintenance branch or only apply unapplied patches.",
+)
 @click.pass_obj
 def release_cherry_pick(obj, version, dry_run, recreate):
-    """Cherry pick commits.
-    """
-    issue_tracker = obj['issue_tracker']
-    release = Release(version,
-                      repo=obj['repo'], issue_tracker=issue_tracker)
+    """Cherry pick commits."""
+    issue_tracker = obj["issue_tracker"]
+    release = Release(version, repo=obj["repo"], issue_tracker=issue_tracker)
 
     if not dry_run:
         release.cherry_pick_commits(recreate_branch=recreate)
     else:
-        click.echo(f'git checkout -b {release.branch} {release.base_branch}')
+        click.echo(f"git checkout -b {release.branch} {release.base_branch}")
         for commit in release.commits_to_pick():
-            click.echo(f'git cherry-pick {commit.hexsha}')
+            click.echo(f"git cherry-pick {commit.hexsha}")

--- a/dev/archery/archery/release/core.py
+++ b/dev/archery/archery/release/core.py
@@ -182,9 +182,7 @@ class CommitTitle:
     def parse(cls, headline):
         matches = _TITLE_REGEX.match(headline)
         if matches is None:
-            warnings.warn(
-                "Unable to parse commit message `{}`".format(headline)
-            )
+            warnings.warn(f"Unable to parse commit message `{headline}`", stacklevel=2)
             return CommitTitle(headline)
 
         values = matches.groupdict()
@@ -363,13 +361,15 @@ class Release:
             try:
                 upper = self.repo.tags[self.tag]
             except IndexError:
-                warnings.warn(f"Release tag `{self.tag}` doesn't exist.")
+                warnings.warn(f"Release tag `{self.tag}` doesn't exist.", stacklevel=2)
                 return []
         else:
             try:
                 upper = self.repo.branches[self.branch]
             except IndexError:
-                warnings.warn(f"Release branch `{self.branch}` doesn't exist.")
+                warnings.warn(
+                    f"Release branch `{self.branch}` doesn't exist.", stacklevel=2
+                )
                 return []
 
         commit_range = f"{lower}..{upper}"
@@ -404,12 +404,15 @@ class Release:
             except (KeyError, IndexError):
                 # Use a hard-coded default value to set default_branch_name
                 default_branch_name = "main"
-                warnings.warn('Unable to determine default branch name: '
-                              'ARCHERY_DEFAULT_BRANCH environment variable is '
-                              'not set. Git repository does not contain a '
-                              '\'refs/remotes/origin/HEAD\'reference. Setting '
-                              'the default branch name to ' +
-                              default_branch_name, RuntimeWarning)
+                warnings.warn(
+                    "Unable to determine default branch name: "
+                    "ARCHERY_DEFAULT_BRANCH environment variable is "
+                    "not set. Git repository does not contain a "
+                    "'refs/remotes/origin/HEAD'reference. Setting "
+                    "the default branch name to " + default_branch_name,
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
 
         return default_branch_name
 
@@ -430,8 +433,7 @@ class Release:
                     outside.append(
                         (self.issue_tracker.issue(int(c.issue_id)), c))
             else:
-                warnings.warn(
-                    f'Issue {c.issue} does not pertain to GH')
+                warnings.warn(f"Issue {c.issue} does not pertain to GH", stacklevel=2)
                 outside.append((c.issue, c))
 
         # remaining tickets

--- a/dev/archery/archery/release/core.py
+++ b/dev/archery/archery/release/core.py
@@ -14,22 +14,23 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
-from abc import abstractmethod
-from collections import defaultdict
 import functools
 import os
 import pathlib
 import re
 import warnings
+from abc import abstractmethod
+from collections import defaultdict
 
 from git import Repo
 from github import Github
 from semver import VersionInfo as SemVer
 
-from ..utils.source import ArrowSources
 from ..utils.logger import logger
-from .reports import ReleaseCuration, ReleaseChangelog
+from ..utils.source import ArrowSources
+from .reports import ReleaseChangelog, ReleaseCuration
 
 
 def cached_property(fn):
@@ -38,7 +39,7 @@ def cached_property(fn):
 
 class Version(SemVer):
 
-    __slots__ = ('released', 'release_date')
+    __slots__ = ('release_date', 'released')
 
     def __init__(self, released=False, release_date=None, **kwargs):
         super().__init__(**kwargs)
@@ -201,10 +202,10 @@ class CommitTitle:
     def to_string(self, with_issue=True, with_components=True):
         out = ""
         if with_issue and self.issue:
-            out += "{}: ".format(self.issue)
+            out += f"{self.issue}: "
         if with_components and self.components:
             for component in self.components:
-                out += "[{}]".format(component)
+                out += f"[{component}]"
             out += " "
         out += self.summary
         return out
@@ -229,7 +230,7 @@ class Commit:
 
     @property
     def url(self):
-        return 'https://github.com/apache/arrow/commit/{}'.format(self.hexsha)
+        return f'https://github.com/apache/arrow/commit/{self.hexsha}'
 
     @property
     def title(self):
@@ -297,16 +298,14 @@ class Release:
     @property
     @abstractmethod
     def branch(self):
-        """
-        Target branch that serves as the base for the release.
+        """Target branch that serves as the base for the release.
         """
         ...
 
     @property
     @abstractmethod
     def siblings(self):
-        """
-        Releases to consider when calculating previous and next releases.
+        """Releases to consider when calculating previous and next releases.
         """
         ...
 
@@ -348,8 +347,7 @@ class Release:
 
     @cached_property
     def commits(self):
-        """
-        All commits applied between two versions.
+        """All commits applied between two versions.
         """
         if self.previous is None:
             # first release
@@ -556,8 +554,7 @@ class MajorRelease(Release):
 
     @cached_property
     def siblings(self):
-        """
-        Filter only the major releases.
+        """Filter only the major releases.
         """
         # handle minor releases before 1.0 as major releases
         return [v for v in self.issue_tracker.project_versions()
@@ -576,8 +573,7 @@ class MinorRelease(Release):
 
     @cached_property
     def siblings(self):
-        """
-        Filter the major and minor releases.
+        """Filter the major and minor releases.
         """
         return [v for v in self.issue_tracker.project_versions()
                 if v.patch == 0]
@@ -595,7 +591,6 @@ class PatchRelease(Release):
 
     @cached_property
     def siblings(self):
-        """
-        No filtering, consider all releases.
+        """No filtering, consider all releases.
         """
         return self.issue_tracker.project_versions()

--- a/dev/archery/archery/release/reports.py
+++ b/dev/archery/archery/release/reports.py
@@ -20,27 +20,22 @@ from ..utils.report import JinjaReport
 
 
 class ReleaseCuration(JinjaReport):
-    templates = {
-        'console': 'release_curation.txt.j2'
-    }
+    templates = {"console": "release_curation.txt.j2"}
     fields = [
-        'release',
-        'within',
-        'outside',
-        'noissue',
-        'parquet',
-        'nopatch',
-        'minimal',
-        'minor'
+        "release",
+        "within",
+        "outside",
+        "noissue",
+        "parquet",
+        "nopatch",
+        "minimal",
+        "minor",
     ]
 
 
 class ReleaseChangelog(JinjaReport):
     templates = {
-        'markdown': 'release_changelog.md.j2',
-        'html': 'release_changelog.html.j2'
+        "markdown": "release_changelog.md.j2",
+        "html": "release_changelog.html.j2",
     }
-    fields = [
-        'release',
-        'categories'
-    ]
+    fields = ["release", "categories"]

--- a/dev/archery/archery/release/reports.py
+++ b/dev/archery/archery/release/reports.py
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
+from __future__ import annotations
 
 from ..utils.report import JinjaReport
 

--- a/dev/archery/archery/release/tests/test_release.py
+++ b/dev/archery/archery/release/tests/test_release.py
@@ -37,7 +37,7 @@ _issues = {
         Issue("GH-9767", type="New Feature", summary="[Crossbow] Title"),
         Issue("GH-1231", type="Bug", summary="[Java] Title"),
         Issue("GH-1244", type="Bug", summary="[C++] Title"),
-        Issue("GH-1301", type="Bug", summary="[Python][Archery] Title")
+        Issue("GH-1301", type="Bug", summary="[Python][Archery] Title"),
     ],
     "2.0.0": [
         Issue("ARROW-9784", type="Bug", summary="[Java] Title"),
@@ -46,7 +46,7 @@ _issues = {
         Issue("ARROW-9694", type="Bug", summary="[Release] Title"),
         Issue("ARROW-5643", type="Bug", summary="[Go] Title"),
         Issue("GH-1243", type="Bug", summary="[Python] Title"),
-        Issue("GH-1300", type="Bug", summary="[CI][Archery] Title")
+        Issue("GH-1300", type="Bug", summary="[CI][Archery] Title"),
     ],
     "1.0.1": [
         Issue("ARROW-9684", type="Bug", summary="[C++] Title"),
@@ -55,7 +55,7 @@ _issues = {
         Issue("ARROW-9644", type="Bug", summary="[C++][Dataset] Title"),
         Issue("ARROW-9643", type="Bug", summary="[C++] Title"),
         Issue("ARROW-9609", type="Bug", summary="[C++] Title"),
-        Issue("ARROW-9606", type="Bug", summary="[C++][Dataset] Title")
+        Issue("ARROW-9606", type="Bug", summary="[C++][Dataset] Title"),
     ],
     "1.0.0": [
         Issue("ARROW-300", type="New Feature", summary="[Format] Title"),
@@ -65,7 +65,7 @@ _issues = {
         Issue("ARROW-8472", type="Bug", summary="[Go][Integration] Title"),
         Issue("ARROW-8471", type="Bug", summary="[C++][Integration] Title"),
         Issue("ARROW-8974", type="Improvement", summary="[C++] Title"),
-        Issue("ARROW-8973", type="New Feature", summary="[Java] Title")
+        Issue("ARROW-8973", type="New Feature", summary="[Java] Title"),
     ],
     "0.17.1": [
         Issue("ARROW-8684", type="Bug", summary="[Python] Title"),
@@ -79,13 +79,12 @@ _issues = {
         Issue("ARROW-2447", type="Improvement", summary="[C++] Title"),
         Issue("ARROW-2255", type="Bug", summary="[Integration] Title"),
         Issue("ARROW-1907", type="Bug", summary="[C++/Python] Title"),
-        Issue("ARROW-1636", type="New Feature", summary="[Format] Title")
-    ]
+        Issue("ARROW-1636", type="New Feature", summary="[Format] Title"),
+    ],
 }
 
 
 class FakeIssueTracker(IssueTracker):
-
     def __init__(self):
         pass
 
@@ -133,14 +132,14 @@ def test_version(fake_issue_tracker):
 
 
 def test_issue(fake_issue_tracker):
-    i = Issue("ARROW-1234", type='Bug', summary="title")
+    i = Issue("ARROW-1234", type="Bug", summary="title")
     assert i.key == "ARROW-1234"
     assert i.type == "Bug"
     assert i.summary == "title"
     assert i.project == "ARROW"
     assert i.number == 1234
 
-    i = Issue("PARQUET-1111", type='Improvement', summary="another title")
+    i = Issue("PARQUET-1111", type="Improvement", summary="another title")
     assert i.key == "PARQUET-1111"
     assert i.type == "Improvement"
     assert i.summary == "another title"
@@ -149,9 +148,7 @@ def test_issue(fake_issue_tracker):
 
 
 def test_commit_title():
-    t = CommitTitle.parse(
-        "ARROW-9598: [C++][Parquet] Fix writing nullable structs"
-    )
+    t = CommitTitle.parse("ARROW-9598: [C++][Parquet] Fix writing nullable structs")
     assert t.project == "ARROW"
     assert t.issue == "ARROW-9598"
     assert t.components == ["C++", "Parquet"]
@@ -168,8 +165,7 @@ def test_commit_title():
     assert t.minor is False
 
     t = CommitTitle.parse(
-        "ARROW-9600: [Rust][Arrow] pin older version of proc-macro2 during "
-        "build"
+        "ARROW-9600: [Rust][Arrow] pin older version of proc-macro2 during build"
     )
     assert t.project == "ARROW"
     assert t.issue == "ARROW-9600"
@@ -201,8 +197,8 @@ def test_commit_title():
     t = CommitTitle.parse(
         "PARQUET-1882: [C++] Buffered Reads should allow for 0 length"
     )
-    assert t.project == 'PARQUET'
-    assert t.issue == 'PARQUET-1882'
+    assert t.project == "PARQUET"
+    assert t.issue == "PARQUET-1882"
     assert t.components == ["C++"]
     assert t.summary == "Buffered Reads should allow for 0 length"
     assert t.minor is False
@@ -212,8 +208,8 @@ def test_commit_title():
         "\nsomething else\n"
         "\nwhich should be truncated"
     )
-    assert t.project == 'ARROW'
-    assert t.issue == 'ARROW-9340'
+    assert t.project == "ARROW"
+    assert t.issue == "ARROW-9340"
     assert t.components == ["R"]
     assert t.summary == "Use CRAN version of decor package "
     assert t.minor is False
@@ -223,27 +219,27 @@ def test_release_basics(fake_issue_tracker):
     r = Release("1.0.0", repo=None, issue_tracker=fake_issue_tracker)
     assert isinstance(r, MajorRelease)
     assert r.is_released is True
-    assert r.branch == 'maint-1.0.0'
-    assert r.tag == 'apache-arrow-1.0.0'
+    assert r.branch == "maint-1.0.0"
+    assert r.tag == "apache-arrow-1.0.0"
 
     r = Release("1.1.0", repo=None, issue_tracker=fake_issue_tracker)
     assert isinstance(r, MinorRelease)
     assert r.is_released is False
-    assert r.branch == 'maint-1.x.x'
-    assert r.tag == 'apache-arrow-1.1.0'
+    assert r.branch == "maint-1.x.x"
+    assert r.tag == "apache-arrow-1.1.0"
 
     # minor releases before 1.0 are treated as major releases
     r = Release("0.17.0", repo=None, issue_tracker=fake_issue_tracker)
     assert isinstance(r, MajorRelease)
     assert r.is_released is True
-    assert r.branch == 'maint-0.17.0'
-    assert r.tag == 'apache-arrow-0.17.0'
+    assert r.branch == "maint-0.17.0"
+    assert r.tag == "apache-arrow-0.17.0"
 
     r = Release("0.17.1", repo=None, issue_tracker=fake_issue_tracker)
     assert isinstance(r, PatchRelease)
     assert r.is_released is True
-    assert r.branch == 'maint-0.17.x'
-    assert r.tag == 'apache-arrow-0.17.1'
+    assert r.branch == "maint-0.17.x"
+    assert r.tag == "apache-arrow-0.17.1"
 
 
 def test_previous_and_next_release(fake_issue_tracker):
@@ -334,12 +330,10 @@ def test_release_issues(fake_issue_tracker):
     }
 
 
-@pytest.mark.parametrize(('version', 'ncommits'), [
-    ("1.0.0", 771),
-    ("0.17.1", 27),
-    ("0.17.0", 569),
-    ("0.15.1", 41)
-])
+@pytest.mark.parametrize(
+    ("version", "ncommits"),
+    [("1.0.0", 771), ("0.17.1", 27), ("0.17.0", 569), ("0.15.1", 41)],
+)
 def test_release_commits(fake_issue_tracker, version, ncommits):
     r = Release(version, repo=None, issue_tracker=fake_issue_tracker)
     assert len(r.commits) == ncommits
@@ -352,13 +346,11 @@ def test_release_commits(fake_issue_tracker, version, ncommits):
 def test_maintenance_patch_selection(fake_issue_tracker):
     r = Release("0.17.1", repo=None, issue_tracker=fake_issue_tracker)
 
-    shas_to_pick = [
-        c.hexsha for c in r.commits_to_pick(exclude_already_applied=False)
-    ]
+    shas_to_pick = [c.hexsha for c in r.commits_to_pick(exclude_already_applied=False)]
     expected = [
-        '8939b4bd446ee406d5225c79d563a27d30fd7d6d',
-        'bcef6c95a324417e85e0140f9745d342cd8784b3',
-        '6002ec388840de5622e39af85abdc57a2cccc9b2',
-        '9123dadfd123bca7af4eaa9455f5b0d1ca8b929d',
+        "8939b4bd446ee406d5225c79d563a27d30fd7d6d",
+        "bcef6c95a324417e85e0140f9745d342cd8784b3",
+        "6002ec388840de5622e39af85abdc57a2cccc9b2",
+        "9123dadfd123bca7af4eaa9455f5b0d1ca8b929d",
     ]
     assert shas_to_pick == expected

--- a/dev/archery/archery/release/tests/test_release.py
+++ b/dev/archery/archery/release/tests/test_release.py
@@ -14,14 +14,21 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
 import pytest
 
 from archery.release.core import (
-    Release, MajorRelease, MinorRelease, PatchRelease,
-    IssueTracker, Version, Issue, CommitTitle, Commit
+    Commit,
+    CommitTitle,
+    Issue,
+    IssueTracker,
+    MajorRelease,
+    MinorRelease,
+    PatchRelease,
+    Release,
+    Version,
 )
-
 
 # subset of issues per revision
 _issues = {

--- a/dev/archery/archery/release/tests/test_release.py
+++ b/dev/archery/archery/release/tests/test_release.py
@@ -284,7 +284,7 @@ def test_previous_and_next_release(fake_issue_tracker):
 def test_release_issues(fake_issue_tracker):
     # major release issues
     r = Release("1.0.0", repo=None, issue_tracker=fake_issue_tracker)
-    assert r.issues.keys() == set([
+    assert r.issues.keys() == {
         "ARROW-300",
         "ARROW-4427",
         "ARROW-5035",
@@ -292,39 +292,39 @@ def test_release_issues(fake_issue_tracker):
         "ARROW-8472",
         "ARROW-8471",
         "ARROW-8974",
-        "ARROW-8973"
-    ])
+        "ARROW-8973",
+    }
     # minor release issues
     r = Release("0.17.0", repo=None, issue_tracker=fake_issue_tracker)
-    assert r.issues.keys() == set([
+    assert r.issues.keys() == {
         "ARROW-2882",
         "ARROW-2587",
         "ARROW-2447",
         "ARROW-2255",
         "ARROW-1907",
         "ARROW-1636",
-    ])
+    }
     # patch release issues
     r = Release("1.0.1", repo=None, issue_tracker=fake_issue_tracker)
-    assert r.issues.keys() == set([
+    assert r.issues.keys() == {
         "ARROW-9684",
         "ARROW-9667",
         "ARROW-9659",
         "ARROW-9644",
         "ARROW-9643",
         "ARROW-9609",
-        "ARROW-9606"
-    ])
+        "ARROW-9606",
+    }
     r = Release("2.0.0", repo=None, issue_tracker=fake_issue_tracker)
-    assert r.issues.keys() == set([
+    assert r.issues.keys() == {
         "ARROW-9784",
         "ARROW-9767",
         "GH-1230",
         "ARROW-9694",
         "ARROW-5643",
         "GH-1243",
-        "GH-1300"
-    ])
+        "GH-1300",
+    }
 
 
 @pytest.mark.parametrize(('version', 'ncommits'), [

--- a/dev/archery/archery/testing.py
+++ b/dev/archery/archery/testing.py
@@ -23,7 +23,6 @@ from unittest import mock
 
 
 class PartialEnv(dict):
-
     def __eq__(self, other):
         return self.items() <= other.items()
 
@@ -44,7 +43,6 @@ def _ensure_mock_call_object(obj, **kwargs):
 
 
 class SuccessfulSubprocessResult:
-
     def check_returncode(self):
         return
 
@@ -52,10 +50,9 @@ class SuccessfulSubprocessResult:
 @contextmanager
 def assert_subprocess_calls(expected_commands_or_calls, **kwargs):
     calls = [
-        _ensure_mock_call_object(obj, **kwargs)
-        for obj in expected_commands_or_calls
+        _ensure_mock_call_object(obj, **kwargs) for obj in expected_commands_or_calls
     ]
-    with mock.patch('subprocess.run', autospec=True) as run:
+    with mock.patch("subprocess.run", autospec=True) as run:
         run.return_value = SuccessfulSubprocessResult()
         yield run
         run.assert_has_calls(calls)

--- a/dev/archery/archery/testing.py
+++ b/dev/archery/archery/testing.py
@@ -14,11 +14,12 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
-from contextlib import contextmanager
 import os
-from unittest import mock
 import re
+from contextlib import contextmanager
+from unittest import mock
 
 
 class PartialEnv(dict):

--- a/dev/archery/archery/tests/test_benchmarks.py
+++ b/dev/archery/archery/tests/test_benchmarks.py
@@ -59,15 +59,11 @@ def test_static_runner_from_json_not_a_regression():
                         "name": "FloatParsing<DoubleType>",
                         "unit": "items_per_second",
                         "less_is_better": False,
-                        "values": [
-                            109941112.87296811
-                        ],
+                        "values": [109941112.87296811],
                         "time_unit": "ns",
-                        "times": [
-                            9095.800104330105
-                        ]
-                    },
-                ]
+                        "times": [9095.800104330105],
+                    }
+                ],
             }
         ]
     }
@@ -94,7 +90,7 @@ def test_static_runner_from_json_multiple_values_not_a_regression():
                             94873831.3818328,
                             95593675.20810866,
                             95797325.6543961,
-                            96134728.05794072
+                            96134728.05794072,
                         ],
                         "time_unit": "ns",
                         "times": [
@@ -102,7 +98,7 @@ def test_static_runner_from_json_multiple_values_not_a_regression():
                             10575.162068480413,
                             10599.271208720838,
                             10679.028059166194,
-                            10827.995119861762
+                            10827.995119861762,
                         ],
                         "counters": {
                             "family_index": 0,
@@ -111,10 +107,10 @@ def test_static_runner_from_json_multiple_values_not_a_regression():
                             "repetitions": 5,
                             "repetition_index": 0,
                             "threads": 1,
-                            "iterations": 10656
-                        }
+                            "iterations": 10656,
+                        },
                     }
-                ]
+                ],
             }
         ]
     }
@@ -135,15 +131,11 @@ def test_static_runner_from_json_regression():
                         "name": "FloatParsing<DoubleType>",
                         "unit": "items_per_second",
                         "less_is_better": False,
-                        "values": [
-                            109941112.87296811
-                        ],
+                        "values": [109941112.87296811],
                         "time_unit": "ns",
-                        "times": [
-                            9095.800104330105
-                        ]
-                    },
-                ]
+                        "times": [9095.800104330105],
+                    }
+                ],
             }
         ]
     }
@@ -151,7 +143,7 @@ def test_static_runner_from_json_regression():
     contender = StaticBenchmarkRunner.from_json(json.dumps(archery_result))
 
     # introduce artificial regression
-    archery_result['suites'][0]['benchmarks'][0]['values'][0] *= 2
+    archery_result["suites"][0]["benchmarks"][0]["values"][0] *= 2
     baseline = StaticBenchmarkRunner.from_json(json.dumps(archery_result))
 
     [comparison] = RunnerComparator(contender, baseline).comparisons
@@ -174,7 +166,7 @@ def test_static_runner_from_json_multiple_values_regression():
                             94873831.3818328,
                             95593675.20810866,
                             95797325.6543961,
-                            96134728.05794072
+                            96134728.05794072,
                         ],
                         "time_unit": "ns",
                         "times": [
@@ -182,7 +174,7 @@ def test_static_runner_from_json_multiple_values_regression():
                             10575.162068480413,
                             10599.271208720838,
                             10679.028059166194,
-                            10827.995119861762
+                            10827.995119861762,
                         ],
                         "counters": {
                             "family_index": 0,
@@ -191,10 +183,10 @@ def test_static_runner_from_json_multiple_values_regression():
                             "repetitions": 5,
                             "repetition_index": 0,
                             "threads": 1,
-                            "iterations": 10656
-                        }
+                            "iterations": 10656,
+                        },
                     }
-                ]
+                ],
             }
         ]
     }
@@ -202,7 +194,7 @@ def test_static_runner_from_json_multiple_values_regression():
     contender = StaticBenchmarkRunner.from_json(json.dumps(archery_result))
 
     # introduce artificial regression
-    values = archery_result['suites'][0]['benchmarks'][0]['values']
+    values = archery_result["suites"][0]["benchmarks"][0]["values"]
     values[:] = [v * 2 for v in values]
     baseline = StaticBenchmarkRunner.from_json(json.dumps(archery_result))
 
@@ -248,12 +240,14 @@ def test_items_per_second():
         "time_unit": "ns",
     }
     archery_result = {
-        "counters": {"iterations": 5964,
-                     "null_percent": 0.0,
-                     "repetition_index": 0,
-                     "repetitions": 0,
-                     "run_name": name,
-                     "threads": 1},
+        "counters": {
+            "iterations": 5964,
+            "null_percent": 0.0,
+            "repetition_index": 0,
+            "repetitions": 0,
+            "run_name": name,
+            "threads": 1,
+        },
         "name": name,
         "unit": "items_per_second",
         "less_is_better": False,
@@ -282,11 +276,13 @@ def test_bytes_per_second():
         "time_unit": "ns",
     }
     archery_result = {
-        "counters": {"iterations": 47,
-                     "repetition_index": 1,
-                     "repetitions": 0,
-                     "run_name": name,
-                     "threads": 1},
+        "counters": {
+            "iterations": 47,
+            "repetition_index": 1,
+            "repetitions": 0,
+            "run_name": name,
+            "threads": 1,
+        },
         "name": name,
         "unit": "bytes_per_second",
         "less_is_better": False,
@@ -319,12 +315,14 @@ def test_both_items_and_bytes_per_second():
     }
     # Note that bytes_per_second trumps items_per_second
     archery_result = {
-        "counters": {"iterations": 5964,
-                     "null_percent": 0.0,
-                     "repetition_index": 0,
-                     "repetitions": 0,
-                     "run_name": name,
-                     "threads": 1},
+        "counters": {
+            "iterations": 5964,
+            "null_percent": 0.0,
+            "repetition_index": 0,
+            "repetitions": 0,
+            "run_name": name,
+            "threads": 1,
+        },
         "name": name,
         "unit": "bytes_per_second",
         "less_is_better": False,
@@ -352,11 +350,13 @@ def test_neither_items_nor_bytes_per_second():
         "time_unit": "ns",
     }
     archery_result = {
-        "counters": {"iterations": 352765,
-                     "repetition_index": 0,
-                     "repetitions": 0,
-                     "run_name": name,
-                     "threads": 1},
+        "counters": {
+            "iterations": 352765,
+            "repetition_index": 0,
+            "repetitions": 0,
+            "run_name": name,
+            "threads": 1,
+        },
         "name": name,
         "unit": "ns",
         "less_is_better": True,
@@ -384,11 +384,13 @@ def test_prefer_real_time():
         "time_unit": "ns",
     }
     archery_result = {
-        "counters": {"iterations": 352765,
-                     "repetition_index": 0,
-                     "repetitions": 0,
-                     "run_name": name,
-                     "threads": 1},
+        "counters": {
+            "iterations": 352765,
+            "repetition_index": 0,
+            "repetitions": 0,
+            "run_name": name,
+            "threads": 1,
+        },
         "name": name,
         "unit": "ns",
         "less_is_better": True,
@@ -415,11 +417,13 @@ def test_prefer_cpu_time():
         "time_unit": "ns",
     }
     archery_result = {
-        "counters": {"iterations": 352765,
-                     "repetition_index": 0,
-                     "repetitions": 0,
-                     "run_name": name,
-                     "threads": 1},
+        "counters": {
+            "iterations": 352765,
+            "repetition_index": 0,
+            "repetitions": 0,
+            "run_name": name,
+            "threads": 1,
+        },
         "name": name,
         "unit": "ns",
         "less_is_better": True,
@@ -458,11 +462,13 @@ def test_omits_aggregates():
         "time_unit": "ns",
     }
     archery_result = {
-        "counters": {"iterations": 352765,
-                     "repetition_index": 0,
-                     "repetitions": 0,
-                     "run_name": name,
-                     "threads": 1},
+        "counters": {
+            "iterations": 352765,
+            "repetition_index": 0,
+            "repetitions": 0,
+            "run_name": name,
+            "threads": 1,
+        },
         "name": name,
         "unit": "ns",
         "less_is_better": True,
@@ -483,68 +489,68 @@ def test_multiple_observations():
     name = "FloatParsing<DoubleType>"
     google_results = [
         {
-            'cpu_time': 10627.38199641615,
-            'family_index': 0,
-            'items_per_second': 94096551.75067839,
-            'iterations': 9487,
-            'name': 'FloatParsing<DoubleType>',
-            'per_family_instance_index': 0,
-            'real_time': 10628.84905663701,
-            'repetition_index': 0,
-            'repetitions': 3,
-            'run_name': 'FloatParsing<DoubleType>',
-            'run_type': 'iteration',
-            'threads': 1,
-            'time_unit': 'ns'
+            "cpu_time": 10627.38199641615,
+            "family_index": 0,
+            "items_per_second": 94096551.75067839,
+            "iterations": 9487,
+            "name": "FloatParsing<DoubleType>",
+            "per_family_instance_index": 0,
+            "real_time": 10628.84905663701,
+            "repetition_index": 0,
+            "repetitions": 3,
+            "run_name": "FloatParsing<DoubleType>",
+            "run_type": "iteration",
+            "threads": 1,
+            "time_unit": "ns",
         },
         {
-            'cpu_time': 10633.318014124594,
-            'family_index': 0,
-            'items_per_second': 94044022.63448404,
-            'iterations': 9487,
-            'name': 'FloatParsing<DoubleType>',
-            'per_family_instance_index': 0,
-            'real_time': 10634.858754122948,
-            'repetition_index': 1,
-            'repetitions': 3,
-            'run_name': 'FloatParsing<DoubleType>',
-            'run_type': 'iteration',
-            'threads': 1,
-            'time_unit': 'ns'
+            "cpu_time": 10633.318014124594,
+            "family_index": 0,
+            "items_per_second": 94044022.63448404,
+            "iterations": 9487,
+            "name": "FloatParsing<DoubleType>",
+            "per_family_instance_index": 0,
+            "real_time": 10634.858754122948,
+            "repetition_index": 1,
+            "repetitions": 3,
+            "run_name": "FloatParsing<DoubleType>",
+            "run_type": "iteration",
+            "threads": 1,
+            "time_unit": "ns",
         },
         {
-            'cpu_time': 10664.315484347,
-            'family_index': 0,
-            'items_per_second': 93770669.24434038,
-            'iterations': 9487,
-            'name': 'FloatParsing<DoubleType>',
-            'per_family_instance_index': 0,
-            'real_time': 10665.584589337563,
-            'repetition_index': 2,
-            'repetitions': 3,
-            'run_name': 'FloatParsing<DoubleType>',
-            'run_type': 'iteration',
-            'threads': 1,
-            'time_unit': 'ns'
-        }
+            "cpu_time": 10664.315484347,
+            "family_index": 0,
+            "items_per_second": 93770669.24434038,
+            "iterations": 9487,
+            "name": "FloatParsing<DoubleType>",
+            "per_family_instance_index": 0,
+            "real_time": 10665.584589337563,
+            "repetition_index": 2,
+            "repetitions": 3,
+            "run_name": "FloatParsing<DoubleType>",
+            "run_type": "iteration",
+            "threads": 1,
+            "time_unit": "ns",
+        },
     ]
 
     archery_result = {
-        'counters': {
-            'family_index': 0,
-            'iterations': 9487,
-            'per_family_instance_index': 0,
-            'repetition_index': 2,
-            'repetitions': 3,
-            'run_name': 'FloatParsing<DoubleType>',
-            'threads': 1
+        "counters": {
+            "family_index": 0,
+            "iterations": 9487,
+            "per_family_instance_index": 0,
+            "repetition_index": 2,
+            "repetitions": 3,
+            "run_name": "FloatParsing<DoubleType>",
+            "threads": 1,
         },
-        'less_is_better': False,
-        'name': 'FloatParsing<DoubleType>',
-        'time_unit': 'ns',
-        'times': [10628.84905663701, 10634.858754122948, 10665.584589337563],
-        'unit': 'items_per_second',
-        'values': [93770669.24434038, 94044022.63448404, 94096551.75067839]
+        "less_is_better": False,
+        "name": "FloatParsing<DoubleType>",
+        "time_unit": "ns",
+        "times": [10628.84905663701, 10634.858754122948, 10665.584589337563],
+        "unit": "items_per_second",
+        "values": [93770669.24434038, 94044022.63448404, 94096551.75067839],
     }
 
     observations = [GoogleBenchmarkObservation(**g) for g in google_results]

--- a/dev/archery/archery/tests/test_benchmarks.py
+++ b/dev/archery/archery/tests/test_benchmarks.py
@@ -14,17 +14,14 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
 import json
 
 from archery.benchmark.codec import JsonEncoder
+from archery.benchmark.compare import BenchmarkComparator, RunnerComparator
 from archery.benchmark.core import Benchmark, median
-from archery.benchmark.compare import (
-    BenchmarkComparator, RunnerComparator
-)
-from archery.benchmark.google import (
-    GoogleBenchmark, GoogleBenchmarkObservation
-)
+from archery.benchmark.google import GoogleBenchmark, GoogleBenchmarkObservation
 from archery.benchmark.runner import StaticBenchmarkRunner
 
 
@@ -221,7 +218,7 @@ def test_benchmark_median():
     assert median([1, 1, 1, 1]) == 1
     try:
         median([])
-        assert False
+        raise AssertionError()
     except ValueError:
         pass
 

--- a/dev/archery/archery/tests/test_bot.py
+++ b/dev/archery/archery/tests/test_bot.py
@@ -42,16 +42,19 @@ def responses():
 
 @pytest.fixture(autouse=True)
 def set_env_vars():
-    with mock.patch.dict(os.environ, {
-        "GITHUB_SERVER_URL": "https://github.com",
-        "GITHUB_REPOSITORY": "apache/arrow",
-        "GITHUB_RUN_ID": "1463784188"
-    }):
+    with mock.patch.dict(
+        os.environ,
+        {
+            "GITHUB_SERVER_URL": "https://github.com",
+            "GITHUB_REPOSITORY": "apache/arrow",
+            "GITHUB_RUN_ID": "1463784188",
+        },
+    ):
         yield
 
 
 def github_url(path):
-    return 'https://api.github.com:443/{}'.format(path.strip('/'))
+    return "https://api.github.com:443/{}".format(path.strip("/"))
 
 
 @group()
@@ -66,40 +69,43 @@ def extra(obj):
 
 
 @custom_handler.command()
-@click.option('--force', '-f', is_flag=True)
+@click.option("--force", "-f", is_flag=True)
 def build(force):
     return force
 
 
 @custom_handler.command()
-@click.option('--name', required=True)
+@click.option("--name", required=True)
 def benchmark(name):
     return name
 
 
 def test_click_based_commands():
-    assert custom_handler('build') is False
-    assert custom_handler('build -f') is True
+    assert custom_handler("build") is False
+    assert custom_handler("build -f") is True
 
-    assert custom_handler('benchmark --name strings') == 'strings'
+    assert custom_handler("benchmark --name strings") == "strings"
     with pytest.raises(CommandError):
-        assert custom_handler('benchmark')
+        assert custom_handler("benchmark")
 
-    assert custom_handler('extra', extra='data') == {'extra': 'data'}
+    assert custom_handler("extra", extra="data") == {"extra": "data"}
 
 
-@pytest.mark.parametrize('fixture_name', [
-    # the bot is not mentioned, nothing to do
-    'event-issue-comment-not-mentioning-ursabot.json',
-    # don't respond to itself, it prevents recursive comment storms!
-    'event-issue-comment-by-ursabot.json',
-])
+@pytest.mark.parametrize(
+    "fixture_name",
+    [
+        # the bot is not mentioned, nothing to do
+        "event-issue-comment-not-mentioning-ursabot.json",
+        # don't respond to itself, it prevents recursive comment storms!
+        "event-issue-comment-by-ursabot.json",
+    ],
+)
 def test_noop_events(load_fixture, fixture_name):
     payload = load_fixture(fixture_name)
 
     handler = Mock()
-    bot = CommentBot(name='ursabot', handler=handler)
-    bot.handle('issue_comment', payload)
+    bot = CommentBot(name="ursabot", handler=handler)
+    bot.handle("issue_comment", payload)
 
     handler.assert_not_called()
 
@@ -107,276 +113,273 @@ def test_noop_events(load_fixture, fixture_name):
 def test_unauthorized_user_comment(load_fixture, responses):
     responses.add(
         responses.GET,
-        github_url('/repositories/169101701/issues/26'),
-        json=load_fixture('issue-26.json'),
-        status=200
+        github_url("/repositories/169101701/issues/26"),
+        json=load_fixture("issue-26.json"),
+        status=200,
     )
     responses.add(
         responses.GET,
-        github_url('/repos/ursa-labs/ursabot/pulls/26'),
-        json=load_fixture('pull-request-26.json'),
-        status=200
+        github_url("/repos/ursa-labs/ursabot/pulls/26"),
+        json=load_fixture("pull-request-26.json"),
+        status=200,
     )
     responses.add(
         responses.GET,
-        github_url('/repos/ursa-labs/ursabot/issues/comments/480243815'),
-        json=load_fixture('pull-request-26.json'),
-        status=200
+        github_url("/repos/ursa-labs/ursabot/issues/comments/480243815"),
+        json=load_fixture("pull-request-26.json"),
+        status=200,
     )
     responses.add(
         responses.POST,
-        github_url('/repos/ursa-labs/ursabot/issues/26/comments'),
-        json={}
+        github_url("/repos/ursa-labs/ursabot/issues/26/comments"),
+        json={},
     )
     responses.add(
         responses.POST,
-        github_url(
-            '/repos/ursa-labs/ursabot/pulls/26/reactions'),
-        json=()
+        github_url("/repos/ursa-labs/ursabot/pulls/26/reactions"),
+        json=(),
     )
 
     def handler(command, **kwargs):
         pass
 
-    payload = load_fixture('event-issue-comment-by-non-authorized-user.json')
-    payload["comment"]["body"] = '@ursabot crossbow submit -g nightly'
-    bot = CommentBot(name='ursabot', handler=handler)
-    bot.handle('issue_comment', payload)
+    payload = load_fixture("event-issue-comment-by-non-authorized-user.json")
+    payload["comment"]["body"] = "@ursabot crossbow submit -g nightly"
+    bot = CommentBot(name="ursabot", handler=handler)
+    bot.handle("issue_comment", payload)
 
     print([c.request.body for c in responses.calls])
     post = responses.calls[-2]
     reaction = responses.calls[-1]
-    comment = ("```\nOnly contributors can submit requests to this bot. "
-               "Please ask someone from the community for help with getting "
-               "the first commit in.\n"
-               "The Archery job run can be found at: "
-               "https://github.com/apache/arrow/actions/runs/1463784188\n"
-               "```")
-    assert json.loads(post.request.body) == {
-        "body": f'{comment}'}
-    assert json.loads(reaction.request.body) == {'content': '-1'}
+    comment = (
+        "```\nOnly contributors can submit requests to this bot. "
+        "Please ask someone from the community for help with getting "
+        "the first commit in.\n"
+        "The Archery job run can be found at: "
+        "https://github.com/apache/arrow/actions/runs/1463784188\n"
+        "```"
+    )
+    assert json.loads(post.request.body) == {"body": f"{comment}"}
+    assert json.loads(reaction.request.body) == {"content": "-1"}
 
 
 def test_issue_comment_without_pull_request(load_fixture, responses):
     responses.add(
         responses.GET,
-        github_url('/repositories/169101701/issues/19'),
-        json=load_fixture('issue-19.json'),
-        status=200
+        github_url("/repositories/169101701/issues/19"),
+        json=load_fixture("issue-19.json"),
+        status=200,
     )
     responses.add(
         responses.GET,
-        github_url('repos/ursa-labs/ursabot/pulls/19'),
+        github_url("repos/ursa-labs/ursabot/pulls/19"),
         json={},
-        status=404
+        status=404,
     )
     responses.add(
         responses.POST,
-        github_url('/repos/ursa-labs/ursabot/issues/19/comments'),
-        json={}
+        github_url("/repos/ursa-labs/ursabot/issues/19/comments"),
+        json={},
     )
 
     def handler(command, **kwargs):
         pass
 
-    payload = load_fixture('event-issue-comment-without-pull-request.json')
-    bot = CommentBot(name='ursabot', handler=handler)
-    bot.handle('issue_comment', payload)
+    payload = load_fixture("event-issue-comment-without-pull-request.json")
+    bot = CommentBot(name="ursabot", handler=handler)
+    bot.handle("issue_comment", payload)
 
     post = responses.calls[2]
     assert json.loads(post.request.body) == {
-        'body': "The comment bot only listens to pull request comments!"
+        "body": "The comment bot only listens to pull request comments!"
     }
 
 
 def test_respond_with_usage(load_fixture, responses):
     responses.add(
         responses.GET,
-        github_url('/repositories/169101701/issues/26'),
-        json=load_fixture('issue-26.json'),
-        status=200
+        github_url("/repositories/169101701/issues/26"),
+        json=load_fixture("issue-26.json"),
+        status=200,
     )
     responses.add(
         responses.GET,
-        github_url('/repos/ursa-labs/ursabot/pulls/26'),
-        json=load_fixture('pull-request-26.json'),
-        status=200
+        github_url("/repos/ursa-labs/ursabot/pulls/26"),
+        json=load_fixture("pull-request-26.json"),
+        status=200,
     )
     responses.add(
         responses.GET,
-        github_url('/repos/ursa-labs/ursabot/issues/comments/480243811'),
-        json=load_fixture('issue-comment-480243811.json')
+        github_url("/repos/ursa-labs/ursabot/issues/comments/480243811"),
+        json=load_fixture("issue-comment-480243811.json"),
     )
     responses.add(
         responses.POST,
-        github_url('/repos/ursa-labs/ursabot/issues/26/comments'),
-        json={}
+        github_url("/repos/ursa-labs/ursabot/issues/26/comments"),
+        json={},
     )
     responses.add(
         responses.POST,
-        github_url(
-            '/repos/ursa-labs/ursabot/issues/comments/479081273/reactions'),
-        json=()
+        github_url("/repos/ursa-labs/ursabot/issues/comments/479081273/reactions"),
+        json=(),
     )
 
     def handler(command, **kwargs):
-        raise CommandError('test-usage')
+        raise CommandError("test-usage")
 
-    payload = load_fixture('event-issue-comment-with-empty-command.json')
-    bot = CommentBot(name='ursabot', handler=handler)
-    bot.handle('issue_comment', payload)
+    payload = load_fixture("event-issue-comment-with-empty-command.json")
+    bot = CommentBot(name="ursabot", handler=handler)
+    bot.handle("issue_comment", payload)
 
     post = responses.calls[3]
-    assert json.loads(post.request.body) == \
-        {'body':
-         ("```\ntest-usage\n"
-          "The Archery job run can be found at: "
-          "https://github.com/apache/arrow/actions/runs/1463784188\n"
-          "```")
-         }
+    assert json.loads(post.request.body) == {
+        "body": (
+            "```\ntest-usage\n"
+            "The Archery job run can be found at: "
+            "https://github.com/apache/arrow/actions/runs/1463784188\n"
+            "```"
+        )
+    }
 
 
-@pytest.mark.parametrize(('command', 'reaction'), [
-    ('@ursabot build', '+1'),
-    ('@ursabot build\nwith a comment', '+1'),
-])
-def test_issue_comment_with_commands(load_fixture, responses, command,
-                                     reaction):
+@pytest.mark.parametrize(
+    ("command", "reaction"),
+    [("@ursabot build", "+1"), ("@ursabot build\nwith a comment", "+1")],
+)
+def test_issue_comment_with_commands(load_fixture, responses, command, reaction):
     responses.add(
         responses.GET,
-        github_url('/repositories/169101701/issues/26'),
-        json=load_fixture('issue-26.json'),
-        status=200
+        github_url("/repositories/169101701/issues/26"),
+        json=load_fixture("issue-26.json"),
+        status=200,
     )
     responses.add(
         responses.GET,
-        github_url('/repos/ursa-labs/ursabot/pulls/26'),
-        json=load_fixture('pull-request-26.json'),
-        status=200
+        github_url("/repos/ursa-labs/ursabot/pulls/26"),
+        json=load_fixture("pull-request-26.json"),
+        status=200,
     )
     responses.add(
         responses.GET,
-        github_url('/repos/ursa-labs/ursabot/issues/comments/480248726'),
-        json=load_fixture('issue-comment-480248726.json')
+        github_url("/repos/ursa-labs/ursabot/issues/comments/480248726"),
+        json=load_fixture("issue-comment-480248726.json"),
     )
     responses.add(
         responses.POST,
-        github_url(
-            '/repos/ursa-labs/ursabot/issues/comments/480248726/reactions'
-        ),
-        json={}
+        github_url("/repos/ursa-labs/ursabot/issues/comments/480248726/reactions"),
+        json={},
     )
 
     def handler(command, **kwargs):
-        if command == 'build':
+        if command == "build":
             return True
         else:
-            raise ValueError('Only `build` command is supported.')
+            raise ValueError("Only `build` command is supported.")
 
-    payload = load_fixture('event-issue-comment-build-command.json')
+    payload = load_fixture("event-issue-comment-build-command.json")
     payload["comment"]["body"] = command
 
-    bot = CommentBot(name='ursabot', handler=handler)
-    bot.handle('issue_comment', payload)
+    bot = CommentBot(name="ursabot", handler=handler)
+    bot.handle("issue_comment", payload)
 
     post = responses.calls[3]
-    assert json.loads(post.request.body) == {'content': reaction}
+    assert json.loads(post.request.body) == {"content": reaction}
 
 
-@pytest.mark.parametrize(('command', 'reaction'), [
-    ('@ursabot listen', '-1'),
-])
-def test_issue_comment_invalid_commands(load_fixture, responses, command,
-                                        reaction):
+@pytest.mark.parametrize(("command", "reaction"), [("@ursabot listen", "-1")])
+def test_issue_comment_invalid_commands(load_fixture, responses, command, reaction):
     responses.add(
         responses.GET,
-        github_url('/repositories/169101701/issues/26'),
-        json=load_fixture('issue-26.json'),
-        status=200
+        github_url("/repositories/169101701/issues/26"),
+        json=load_fixture("issue-26.json"),
+        status=200,
     )
     responses.add(
         responses.GET,
-        github_url('/repos/ursa-labs/ursabot/pulls/26'),
-        json=load_fixture('pull-request-26.json'),
-        status=200
+        github_url("/repos/ursa-labs/ursabot/pulls/26"),
+        json=load_fixture("pull-request-26.json"),
+        status=200,
     )
     responses.add(
         responses.GET,
-        github_url('/repos/ursa-labs/ursabot/issues/comments/480248726'),
-        json=load_fixture('issue-comment-480248726.json')
+        github_url("/repos/ursa-labs/ursabot/issues/comments/480248726"),
+        json=load_fixture("issue-comment-480248726.json"),
     )
     responses.add(
         responses.POST,
-        github_url(
-            '/repos/ursa-labs/ursabot/issues/comments/480248726/reactions'
-        ),
-        json={}
+        github_url("/repos/ursa-labs/ursabot/issues/comments/480248726/reactions"),
+        json={},
     )
     responses.add(
         responses.POST,
-        github_url('/repos/ursa-labs/ursabot/issues/26/comments'),
-        json={}
+        github_url("/repos/ursa-labs/ursabot/issues/26/comments"),
+        json={},
     )
 
     def handler(command, **kwargs):
-        if command == 'build':
+        if command == "build":
             return True
         else:
-            raise ValueError('Only `build` command is supported.')
+            raise ValueError("Only `build` command is supported.")
 
-    payload = load_fixture('event-issue-comment-build-command.json')
+    payload = load_fixture("event-issue-comment-build-command.json")
     payload["comment"]["body"] = command
 
-    bot = CommentBot(name='ursabot', handler=handler)
-    bot.handle('issue_comment', payload)
+    bot = CommentBot(name="ursabot", handler=handler)
+    bot.handle("issue_comment", payload)
 
     # Setting reaction is always the last call
     post = responses.calls[-1]
-    assert json.loads(post.request.body) == {'content': reaction}
+    assert json.loads(post.request.body) == {"content": reaction}
 
 
 def test_issue_comment_with_commands_bot_not_first(load_fixture, responses):
     # when the @-mention is not first, this is a no-op
     handler = Mock()
 
-    payload = load_fixture('event-issue-comment-build-command.json')
-    payload["comment"]["body"] = 'with a comment\n@ursabot build'
+    payload = load_fixture("event-issue-comment-build-command.json")
+    payload["comment"]["body"] = "with a comment\n@ursabot build"
 
-    bot = CommentBot(name='ursabot', handler=handler)
-    bot.handle('issue_comment', payload)
+    bot = CommentBot(name="ursabot", handler=handler)
+    bot.handle("issue_comment", payload)
 
     handler.assert_not_called()
 
 
-@pytest.mark.parametrize(('fixture_name', 'expected_label'), [
-    ('event-pull-request-target-opened-committer.json',
-     PullRequestState.committer_review.value),
-    ('event-pull-request-target-opened-non-committer.json',
-     PullRequestState.review.value),
-])
+@pytest.mark.parametrize(
+    ("fixture_name", "expected_label"),
+    [
+        (
+            "event-pull-request-target-opened-committer.json",
+            PullRequestState.committer_review.value,
+        ),
+        (
+            "event-pull-request-target-opened-non-committer.json",
+            PullRequestState.review.value,
+        ),
+    ],
+)
 def test_open_pull_request(load_fixture, responses, fixture_name, expected_label):
     responses.add(
         responses.GET,
-        github_url('/repositories/169101701/pulls/26'),
-        json=load_fixture('pull-request-26.json'),
-        status=200
+        github_url("/repositories/169101701/pulls/26"),
+        json=load_fixture("pull-request-26.json"),
+        status=200,
     )
     responses.add(
         responses.GET,
-        github_url('/repos/ursa-labs/ursabot/issues/26/labels'),
+        github_url("/repos/ursa-labs/ursabot/issues/26/labels"),
         json=[],
-        status=200
+        status=200,
     )
     responses.add(
         responses.POST,
-        github_url(
-            '/repos/ursa-labs/ursabot/issues/26/labels'
-        ),
-        status=201
+        github_url("/repos/ursa-labs/ursabot/issues/26/labels"),
+        status=201,
     )
     payload = load_fixture(fixture_name)
 
-    bot = PullRequestWorkflowBot('pull_request_target', payload)
+    bot = PullRequestWorkflowBot("pull_request_target", payload)
     bot.handle()
 
     # Setting awaiting committer review or awaiting review label
@@ -384,36 +387,39 @@ def test_open_pull_request(load_fixture, responses, fixture_name, expected_label
     assert json.loads(post.request.body) == [expected_label]
 
 
-@pytest.mark.parametrize(('fixture_name', 'expected_label'), [
-    ('event-pull-request-target-opened-non-committer.json',
-     PullRequestState.committer_review.value),
-])
-def test_open_pull_request_with_committer_list(load_fixture, responses, fixture_name,
-                                               expected_label):
+@pytest.mark.parametrize(
+    ("fixture_name", "expected_label"),
+    [
+        (
+            "event-pull-request-target-opened-non-committer.json",
+            PullRequestState.committer_review.value,
+        )
+    ],
+)
+def test_open_pull_request_with_committer_list(
+    load_fixture, responses, fixture_name, expected_label
+):
     responses.add(
         responses.GET,
-        github_url('/repositories/169101701/pulls/26'),
-        json=load_fixture('pull-request-26.json'),
-        status=200
+        github_url("/repositories/169101701/pulls/26"),
+        json=load_fixture("pull-request-26.json"),
+        status=200,
     )
     responses.add(
         responses.GET,
-        github_url('/repos/ursa-labs/ursabot/issues/26/labels'),
+        github_url("/repos/ursa-labs/ursabot/issues/26/labels"),
         json=[],
-        status=200
+        status=200,
     )
     responses.add(
         responses.POST,
-        github_url(
-            '/repos/ursa-labs/ursabot/issues/26/labels'
-        ),
-        status=201
+        github_url("/repos/ursa-labs/ursabot/issues/26/labels"),
+        status=201,
     )
     payload = load_fixture(fixture_name)
 
     # Even though the author_association is not committer the list overrides.
-    bot = PullRequestWorkflowBot(
-        'pull_request_target', payload, committers=['kszucs'])
+    bot = PullRequestWorkflowBot("pull_request_target", payload, committers=["kszucs"])
     bot.handle()
 
     # Setting awaiting committer review or awaiting review label
@@ -421,252 +427,265 @@ def test_open_pull_request_with_committer_list(load_fixture, responses, fixture_
     assert json.loads(post.request.body) == [expected_label]
 
 
-@pytest.mark.parametrize(('fixture_name', 'expected_label'), [
-    ('event-pull-request-target-opened-committer.json',
-     PullRequestState.committer_review.value),
-])
+@pytest.mark.parametrize(
+    ("fixture_name", "expected_label"),
+    [
+        (
+            "event-pull-request-target-opened-committer.json",
+            PullRequestState.committer_review.value,
+        )
+    ],
+)
 def test_open_pull_request_with_existing_label(
-        load_fixture, responses, fixture_name, expected_label):
+    load_fixture, responses, fixture_name, expected_label
+):
     responses.add(
         responses.GET,
-        github_url('/repositories/169101701/pulls/26'),
-        json=load_fixture('pull-request-26-awaiting-review.json'),
-        status=200
+        github_url("/repositories/169101701/pulls/26"),
+        json=load_fixture("pull-request-26-awaiting-review.json"),
+        status=200,
     )
     responses.add(
         responses.GET,
-        github_url('/repos/ursa-labs/ursabot/issues/26/labels'),
-        json=load_fixture('label-awaiting-review.json'),
-        status=200
+        github_url("/repos/ursa-labs/ursabot/issues/26/labels"),
+        json=load_fixture("label-awaiting-review.json"),
+        status=200,
     )
     responses.add(
         responses.DELETE,
-        github_url('/repos/ursa-labs/ursabot/issues/26/labels/awaiting%20review'),
-        status=200
+        github_url("/repos/ursa-labs/ursabot/issues/26/labels/awaiting%20review"),
+        status=200,
     )
     responses.add(
         responses.POST,
-        github_url(
-            '/repos/ursa-labs/ursabot/issues/26/labels'
-        ),
-        status=201
+        github_url("/repos/ursa-labs/ursabot/issues/26/labels"),
+        status=201,
     )
     payload = load_fixture(fixture_name)
-    payload['pull_request']['labels'] = ['awaiting review']
+    payload["pull_request"]["labels"] = ["awaiting review"]
 
-    bot = PullRequestWorkflowBot('pull_request_target', payload)
+    bot = PullRequestWorkflowBot("pull_request_target", payload)
     bot.handle()
 
     post = responses.calls[-1]
     assert json.loads(post.request.body) == [expected_label]
 
 
-@pytest.mark.parametrize(('fixture_name', 'review_state', 'expected_label'), [
-    ('event-pr-review-committer.json', 'commented', PullRequestState.changes.value),
-    ('event-pr-review-committer.json', 'changes_requested',
-     PullRequestState.changes.value),
-    ('event-pr-review-committer.json', 'approved', PullRequestState.merge.value),
-    ('event-pr-review-non-committer.json', 'commented',
-     PullRequestState.committer_review.value),
-    ('event-pr-review-non-committer.json', 'changes_requested',
-     PullRequestState.committer_review.value),
-    ('event-pr-review-non-committer.json', 'approved',
-     PullRequestState.committer_review.value),
-])
+@pytest.mark.parametrize(
+    ("fixture_name", "review_state", "expected_label"),
+    [
+        ("event-pr-review-committer.json", "commented", PullRequestState.changes.value),
+        (
+            "event-pr-review-committer.json",
+            "changes_requested",
+            PullRequestState.changes.value,
+        ),
+        ("event-pr-review-committer.json", "approved", PullRequestState.merge.value),
+        (
+            "event-pr-review-non-committer.json",
+            "commented",
+            PullRequestState.committer_review.value,
+        ),
+        (
+            "event-pr-review-non-committer.json",
+            "changes_requested",
+            PullRequestState.committer_review.value,
+        ),
+        (
+            "event-pr-review-non-committer.json",
+            "approved",
+            PullRequestState.committer_review.value,
+        ),
+    ],
+)
 def test_pull_request_review_awaiting_review(
-        load_fixture, responses, fixture_name, review_state, expected_label):
+    load_fixture, responses, fixture_name, review_state, expected_label
+):
     responses.add(
         responses.GET,
-        github_url('/repositories/169101701/pulls/26'),
-        json=load_fixture('pull-request-26-awaiting-review.json'),
-        status=200
+        github_url("/repositories/169101701/pulls/26"),
+        json=load_fixture("pull-request-26-awaiting-review.json"),
+        status=200,
     )
     responses.add(
         responses.GET,
-        github_url('/repos/ursa-labs/ursabot/issues/26/labels'),
-        json=load_fixture('label-awaiting-review.json'),
-        status=200
+        github_url("/repos/ursa-labs/ursabot/issues/26/labels"),
+        json=load_fixture("label-awaiting-review.json"),
+        status=200,
     )
     responses.add(
         responses.DELETE,
-        github_url('/repos/ursa-labs/ursabot/issues/26/labels/awaiting%20review'),
-        status=200
+        github_url("/repos/ursa-labs/ursabot/issues/26/labels/awaiting%20review"),
+        status=200,
     )
     responses.add(
         responses.POST,
-        github_url(
-            '/repos/ursa-labs/ursabot/issues/26/labels'
-        ),
-        status=201
+        github_url("/repos/ursa-labs/ursabot/issues/26/labels"),
+        status=201,
     )
     payload = load_fixture(fixture_name)
-    payload['pull_request']['labels'] = ['awaiting review']
-    payload['review']['state'] = review_state
+    payload["pull_request"]["labels"] = ["awaiting review"]
+    payload["review"]["state"] = review_state
 
-    bot = PullRequestWorkflowBot('pull_request_review', payload)
+    bot = PullRequestWorkflowBot("pull_request_review", payload)
     bot.handle()
 
     post = responses.calls[-1]
     assert json.loads(post.request.body) == [expected_label]
 
 
-@pytest.mark.parametrize(('review_state', 'expected_label'), [
-    ('commented', PullRequestState.changes.value),
-    ('changes_requested', PullRequestState.changes.value),
-    ('approved', PullRequestState.merge.value),
-])
+@pytest.mark.parametrize(
+    ("review_state", "expected_label"),
+    [
+        ("commented", PullRequestState.changes.value),
+        ("changes_requested", PullRequestState.changes.value),
+        ("approved", PullRequestState.merge.value),
+    ],
+)
 def test_pull_request_committer_review_awaiting_change_review(
-        load_fixture, responses, review_state, expected_label):
+    load_fixture, responses, review_state, expected_label
+):
     responses.add(
         responses.GET,
-        github_url('/repositories/169101701/pulls/26'),
-        json=load_fixture('pull-request-26-awaiting-review.json'),
-        status=200
+        github_url("/repositories/169101701/pulls/26"),
+        json=load_fixture("pull-request-26-awaiting-review.json"),
+        status=200,
     )
     responses.add(
         responses.GET,
-        github_url('/repos/ursa-labs/ursabot/issues/26/labels'),
-        json=load_fixture('label-awaiting-change-review.json'),
-        status=200
+        github_url("/repos/ursa-labs/ursabot/issues/26/labels"),
+        json=load_fixture("label-awaiting-change-review.json"),
+        status=200,
     )
     responses.add(
         responses.DELETE,
         github_url(
-            '/repos/ursa-labs/ursabot/issues/26/labels/awaiting%20change%20review'
+            "/repos/ursa-labs/ursabot/issues/26/labels/awaiting%20change%20review"
         ),
-        status=200
+        status=200,
     )
     responses.add(
         responses.POST,
-        github_url(
-            '/repos/ursa-labs/ursabot/issues/26/labels'
-        ),
-        status=201
+        github_url("/repos/ursa-labs/ursabot/issues/26/labels"),
+        status=201,
     )
-    payload = load_fixture('event-pr-review-committer.json')
-    payload['pull_request']['labels'] = ['awaiting change review']
-    payload['review']['state'] = review_state
+    payload = load_fixture("event-pr-review-committer.json")
+    payload["pull_request"]["labels"] = ["awaiting change review"]
+    payload["review"]["state"] = review_state
 
-    bot = PullRequestWorkflowBot('pull_request_review', payload)
+    bot = PullRequestWorkflowBot("pull_request_review", payload)
     bot.handle()
 
     post = responses.calls[-1]
     assert json.loads(post.request.body) == [expected_label]
 
 
-@pytest.mark.parametrize('review_state', [
-    'commented', 'changes_requested', 'approved'])
+@pytest.mark.parametrize("review_state", ["commented", "changes_requested", "approved"])
 def test_pull_request_non_committer_review_awaiting_change_review(
-        load_fixture, responses, review_state):
+    load_fixture, responses, review_state
+):
     responses.add(
         responses.GET,
-        github_url('/repositories/169101701/pulls/26'),
-        json=load_fixture('pull-request-26-awaiting-review.json'),
-        status=200
+        github_url("/repositories/169101701/pulls/26"),
+        json=load_fixture("pull-request-26-awaiting-review.json"),
+        status=200,
     )
     responses.add(
         responses.GET,
-        github_url('/repos/ursa-labs/ursabot/issues/26/labels'),
-        json=load_fixture('label-awaiting-change-review.json'),
-        status=200
+        github_url("/repos/ursa-labs/ursabot/issues/26/labels"),
+        json=load_fixture("label-awaiting-change-review.json"),
+        status=200,
     )
-    payload = load_fixture('event-pr-review-non-committer.json')
-    payload['pull_request']['labels'] = ['awaiting change review']
-    payload['review']['state'] = review_state
+    payload = load_fixture("event-pr-review-non-committer.json")
+    payload["pull_request"]["labels"] = ["awaiting change review"]
+    payload["review"]["state"] = review_state
 
-    bot = PullRequestWorkflowBot('pull_request_review', payload)
+    bot = PullRequestWorkflowBot("pull_request_review", payload)
     bot.handle()
 
     # No requests to delete post new labels on non-committer reviews
     assert len(responses.calls) == 2
 
 
-def test_pull_request_synchronize_event_on_awaiting_changes(
-        load_fixture, responses):
-    payload = load_fixture('event-pull-request-target-synchronize.json')
+def test_pull_request_synchronize_event_on_awaiting_changes(load_fixture, responses):
+    payload = load_fixture("event-pull-request-target-synchronize.json")
 
     responses.add(
         responses.GET,
-        github_url('/repositories/169101701/pulls/26'),
-        json=load_fixture('pull-request-26-awaiting-review.json'),
-        status=200
+        github_url("/repositories/169101701/pulls/26"),
+        json=load_fixture("pull-request-26-awaiting-review.json"),
+        status=200,
     )
     responses.add(
         responses.GET,
-        github_url('/repos/ursa-labs/ursabot/issues/26/labels'),
-        json=load_fixture('label-awaiting-changes.json'),
-        status=200
+        github_url("/repos/ursa-labs/ursabot/issues/26/labels"),
+        json=load_fixture("label-awaiting-changes.json"),
+        status=200,
     )
     responses.add(
         responses.DELETE,
-        github_url(
-            '/repos/ursa-labs/ursabot/issues/26/labels/awaiting%20changes'
-        ),
-        status=200
+        github_url("/repos/ursa-labs/ursabot/issues/26/labels/awaiting%20changes"),
+        status=200,
     )
     responses.add(
         responses.POST,
-        github_url(
-            '/repos/ursa-labs/ursabot/issues/26/labels'
-        ),
-        status=201
+        github_url("/repos/ursa-labs/ursabot/issues/26/labels"),
+        status=201,
     )
 
-    bot = PullRequestWorkflowBot('pull_request_target', payload)
+    bot = PullRequestWorkflowBot("pull_request_target", payload)
     bot.handle()
     # after push event label changes.
     post = responses.calls[-1]
     assert json.loads(post.request.body) == ["awaiting change review"]
 
 
-def test_pull_request_synchronize_event_on_awaiting_review(
-        load_fixture, responses):
-    payload = load_fixture('event-pull-request-target-synchronize.json')
+def test_pull_request_synchronize_event_on_awaiting_review(load_fixture, responses):
+    payload = load_fixture("event-pull-request-target-synchronize.json")
 
     responses.add(
         responses.GET,
-        github_url('/repositories/169101701/pulls/26'),
-        json=load_fixture('pull-request-26-awaiting-review.json'),
-        status=200
+        github_url("/repositories/169101701/pulls/26"),
+        json=load_fixture("pull-request-26-awaiting-review.json"),
+        status=200,
     )
     responses.add(
         responses.GET,
-        github_url('/repos/ursa-labs/ursabot/issues/26/labels'),
-        json=load_fixture('label-awaiting-review.json'),
-        status=200
+        github_url("/repos/ursa-labs/ursabot/issues/26/labels"),
+        json=load_fixture("label-awaiting-review.json"),
+        status=200,
     )
 
-    bot = PullRequestWorkflowBot('pull_request_target', payload)
+    bot = PullRequestWorkflowBot("pull_request_target", payload)
     bot.handle()
     # No requests to delete or post new labels on push awaiting review
     assert len(responses.calls) == 2
 
 
 def test_pull_request_synchronize_event_on_existing_pr_without_state(
-        load_fixture, responses):
-    payload = load_fixture('event-pull-request-target-synchronize.json')
+    load_fixture, responses
+):
+    payload = load_fixture("event-pull-request-target-synchronize.json")
 
     responses.add(
         responses.GET,
-        github_url('/repositories/169101701/pulls/26'),
-        json=load_fixture('pull-request-26.json'),
-        status=200
+        github_url("/repositories/169101701/pulls/26"),
+        json=load_fixture("pull-request-26.json"),
+        status=200,
     )
     responses.add(
         responses.GET,
-        github_url('/repos/ursa-labs/ursabot/issues/26/labels'),
+        github_url("/repos/ursa-labs/ursabot/issues/26/labels"),
         json=[],
-        status=200
+        status=200,
     )
     responses.add(
         responses.POST,
-        github_url(
-            '/repos/ursa-labs/ursabot/issues/26/labels'
-        ),
-        status=201
+        github_url("/repos/ursa-labs/ursabot/issues/26/labels"),
+        status=201,
     )
 
-    bot = PullRequestWorkflowBot('pull_request_target', payload)
+    bot = PullRequestWorkflowBot("pull_request_target", payload)
     bot.handle()
     # after push event label get set to default
     post = responses.calls[-1]

--- a/dev/archery/archery/tests/test_bot.py
+++ b/dev/archery/archery/tests/test_bot.py
@@ -530,8 +530,9 @@ def test_pull_request_committer_review_awaiting_change_review(
     )
     responses.add(
         responses.DELETE,
-        github_url('/repos/ursa-labs/ursabot/issues/26/' +
-                   'labels/awaiting%20change%20review'),
+        github_url(
+            '/repos/ursa-labs/ursabot/issues/26/labels/awaiting%20change%20review'
+        ),
         status=200
     )
     responses.add(
@@ -597,8 +598,9 @@ def test_pull_request_synchronize_event_on_awaiting_changes(
     )
     responses.add(
         responses.DELETE,
-        github_url('/repos/ursa-labs/ursabot/issues/26/' +
-                   'labels/awaiting%20changes'),
+        github_url(
+            '/repos/ursa-labs/ursabot/issues/26/labels/awaiting%20changes'
+        ),
         status=200
     )
     responses.add(

--- a/dev/archery/archery/tests/test_bot.py
+++ b/dev/archery/archery/tests/test_bot.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
 import json
 import os
@@ -25,11 +26,11 @@ import pytest
 import responses as rsps
 
 from archery.bot import (
-    CommentBot,
     CommandError,
+    CommentBot,
     PullRequestState,
     PullRequestWorkflowBot,
-    group
+    group,
 )
 
 

--- a/dev/archery/archery/tests/test_cli.py
+++ b/dev/archery/archery/tests/test_cli.py
@@ -29,12 +29,14 @@ def test_linking_check_dependencies(fn):
     args = [
         "linking",
         "check-dependencies",
-        "-a", "libarrow",
-        "-d", "libcurl",
-        "somelib.so"
+        "-a",
+        "libarrow",
+        "-d",
+        "libcurl",
+        "somelib.so",
     ]
     result = CliRunner().invoke(archery, args)
     assert result.exit_code == 0
     fn.assert_called_once_with(
-        Path('somelib.so'), allowed={'libarrow'}, disallowed={'libcurl'}
+        Path("somelib.so"), allowed={"libarrow"}, disallowed={"libcurl"}
     )

--- a/dev/archery/archery/tests/test_cli.py
+++ b/dev/archery/archery/tests/test_cli.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
 from pathlib import Path
 from unittest.mock import patch

--- a/dev/archery/archery/tests/test_testing.py
+++ b/dev/archery/archery/tests/test_testing.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
 import subprocess
 

--- a/dev/archery/archery/tests/test_testing.py
+++ b/dev/archery/archery/tests/test_testing.py
@@ -24,40 +24,27 @@ from archery.testing import PartialEnv, assert_subprocess_calls
 
 
 def test_partial_env():
-    assert PartialEnv(a=1, b=2) == {'a': 1, 'b': 2, 'c': 3}
-    assert PartialEnv(a=1) == {'a': 1, 'b': 2, 'c': 3}
-    assert PartialEnv(a=1, b=2) == {'a': 1, 'b': 2}
-    assert PartialEnv(a=1, b=2) != {'b': 2, 'c': 3}
-    assert PartialEnv(a=1, b=2) != {'a': 1, 'c': 3}
+    assert PartialEnv(a=1, b=2) == {"a": 1, "b": 2, "c": 3}
+    assert PartialEnv(a=1) == {"a": 1, "b": 2, "c": 3}
+    assert PartialEnv(a=1, b=2) == {"a": 1, "b": 2}
+    assert PartialEnv(a=1, b=2) != {"b": 2, "c": 3}
+    assert PartialEnv(a=1, b=2) != {"a": 1, "c": 3}
 
 
 def test_assert_subprocess_calls():
-    expected_calls = [
-        "echo Hello",
-        ["echo", "World"]
-    ]
+    expected_calls = ["echo Hello", ["echo", "World"]]
     with assert_subprocess_calls(expected_calls):
-        subprocess.run(['echo', 'Hello'])
-        subprocess.run(['echo', 'World'])
+        subprocess.run(["echo", "Hello"])
+        subprocess.run(["echo", "World"])
 
-    expected_env = PartialEnv(
-        CUSTOM_ENV_A='a',
-        CUSTOM_ENV_C='c'
-    )
+    expected_env = PartialEnv(CUSTOM_ENV_A="a", CUSTOM_ENV_C="c")
     with assert_subprocess_calls(expected_calls, env=expected_env):
-        env = {
-            'CUSTOM_ENV_A': 'a',
-            'CUSTOM_ENV_B': 'b',
-            'CUSTOM_ENV_C': 'c'
-        }
-        subprocess.run(['echo', 'Hello'], env=env)
-        subprocess.run(['echo', 'World'], env=env)
+        env = {"CUSTOM_ENV_A": "a", "CUSTOM_ENV_B": "b", "CUSTOM_ENV_C": "c"}
+        subprocess.run(["echo", "Hello"], env=env)
+        subprocess.run(["echo", "World"], env=env)
 
     with pytest.raises(AssertionError):
         with assert_subprocess_calls(expected_calls, env=expected_env):
-            env = {
-                'CUSTOM_ENV_B': 'b',
-                'CUSTOM_ENV_C': 'c'
-            }
-            subprocess.run(['echo', 'Hello'], env=env)
-            subprocess.run(['echo', 'World'], env=env)
+            env = {"CUSTOM_ENV_B": "b", "CUSTOM_ENV_C": "c"}
+            subprocess.run(["echo", "Hello"], env=env)
+            subprocess.run(["echo", "World"], env=env)

--- a/dev/archery/archery/utils/cache.py
+++ b/dev/archery/archery/utils/cache.py
@@ -14,9 +14,10 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
-from pathlib import Path
 import os
+from pathlib import Path
 from urllib.request import urlopen
 
 from .logger import logger
@@ -49,8 +50,7 @@ class Cache:
             path.unlink()
 
     def get_or_insert(self, key, create):
-        """
-        Get or Insert a key from the cache. If the key is not found, the
+        """Get or Insert a key from the cache. If the key is not found, the
         `create` closure will be evaluated.
 
         The `create` closure takes a single parameter, the path where the
@@ -64,13 +64,12 @@ class Cache:
         return path
 
     def get_or_insert_from_url(self, key, url):
-        """
-        Get or Insert a key from the cache. If the key is not found, the file
+        """Get or Insert a key from the cache. If the key is not found, the file
         is downloaded from `url`.
         """
         def download(path):
             """ Tiny wrapper that download a file and save as key. """
-            logger.debug("Downloading {} as {}".format(url, path))
+            logger.debug(f"Downloading {url} as {path}")
             conn = urlopen(url)
             # Ensure the download is completed before writing to disks.
             content = conn.read()

--- a/dev/archery/archery/utils/cache.py
+++ b/dev/archery/archery/utils/cache.py
@@ -26,7 +26,7 @@ ARCHERY_CACHE_DIR = Path.home() / ".cache" / "archery"
 
 
 class Cache:
-    """ Cache stores downloaded objects, notably apache-rat.jar. """
+    """Cache stores downloaded objects, notably apache-rat.jar."""
 
     def __init__(self, path=ARCHERY_CACHE_DIR):
         self.root = path
@@ -35,16 +35,16 @@ class Cache:
             os.makedirs(path)
 
     def key_path(self, key):
-        """ Return the full path of a key. """
-        return self.root/key
+        """Return the full path of a key."""
+        return self.root / key
 
     def get(self, key):
-        """ Return the full path of a key if cached, None otherwise. """
+        """Return the full path of a key if cached, None otherwise."""
         path = self.key_path(key)
         return path if path.exists() else None
 
     def delete(self, key):
-        """ Remove a key (and the file) from the cache. """
+        """Remove a key (and the file) from the cache."""
         path = self.get(key)
         if path:
             path.unlink()
@@ -67,8 +67,9 @@ class Cache:
         """Get or Insert a key from the cache. If the key is not found, the file
         is downloaded from `url`.
         """
+
         def download(path):
-            """ Tiny wrapper that download a file and save as key. """
+            """Tiny wrapper that download a file and save as key."""
             logger.debug(f"Downloading {url} as {path}")
             conn = urlopen(url)
             # Ensure the download is completed before writing to disks.

--- a/dev/archery/archery/utils/cli.py
+++ b/dev/archery/archery/utils/cli.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
 import importlib
 
@@ -23,11 +24,11 @@ from .source import ArrowSources, InvalidArrowSource
 
 
 class ArrowBool(click.types.BoolParamType):
-    """
-    ArrowBool supports the 'ON' and 'OFF' values on top of the values
+    """ArrowBool supports the 'ON' and 'OFF' values on top of the values
     supported by BoolParamType. This is convenient to port script which exports
     CMake options variables.
     """
+
     name = "boolean"
 
     def convert(self, value, param, ctx):
@@ -42,8 +43,7 @@ class ArrowBool(click.types.BoolParamType):
 
 
 def validate_arrow_sources(ctx, param, src):
-    """
-    Ensure a directory contains Arrow cpp sources.
+    """Ensure a directory contains Arrow cpp sources.
     """
     try:
         return ArrowSources.find(src)

--- a/dev/archery/archery/utils/cli.py
+++ b/dev/archery/archery/utils/cli.py
@@ -43,8 +43,7 @@ class ArrowBool(click.types.BoolParamType):
 
 
 def validate_arrow_sources(ctx, param, src):
-    """Ensure a directory contains Arrow cpp sources.
-    """
+    """Ensure a directory contains Arrow cpp sources."""
     try:
         return ArrowSources.find(src)
     except InvalidArrowSource as e:
@@ -60,10 +59,7 @@ def add_optional_command(name, module, function, parent):
 
         @parent.command(
             name,
-            context_settings={
-                "allow_extra_args": True,
-                "ignore_unknown_options": True,
-            }
+            context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
         )
         def command():
             raise click.ClickException(

--- a/dev/archery/archery/utils/cmake.py
+++ b/dev/archery/archery/utils/cmake.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
 import os
 import re
@@ -97,11 +98,11 @@ class CMakeDefinition:
             # Extra safety to ensure we're deleting a build folder.
             if not CMakeBuild.is_build_dir(build_dir):
                 raise FileExistsError(
-                    "{} is not a cmake build".format(build_dir)
+                    f"{build_dir} is not a cmake build"
                 )
             if not force:
                 raise FileExistsError(
-                    "{} exists use force=True".format(build_dir)
+                    f"{build_dir} exists use force=True"
                 )
             rmtree(build_dir)
 
@@ -113,7 +114,7 @@ class CMakeDefinition:
                           **kwargs)
 
     def __repr__(self):
-        return "CMakeDefinition[source={}]".format(self.source)
+        return f"CMakeDefinition[source={self.source}]"
 
 
 CMAKE_BUILD_TYPE_RE = re.compile("CMAKE_BUILD_TYPE:STRING=([a-zA-Z]+)")
@@ -191,13 +192,13 @@ class CMakeBuild(CMake):
         be lost. Only build_type is recovered.
         """
         if not CMakeBuild.is_build_dir(path):
-            raise ValueError("Not a valid CMakeBuild path: {}".format(path))
+            raise ValueError(f"Not a valid CMakeBuild path: {path}")
 
         build_type = None
         # Infer build_type by looking at CMakeCache.txt and looking for a magic
         # definition
         cmake_cache_path = os.path.join(path, "CMakeCache.txt")
-        with open(cmake_cache_path, "r") as cmake_cache:
+        with open(cmake_cache_path) as cmake_cache:
             candidates = CMAKE_BUILD_TYPE_RE.findall(cmake_cache.read())
             build_type = candidates[0].lower() if candidates else "release"
 
@@ -205,8 +206,6 @@ class CMakeBuild(CMake):
 
     def __repr__(self):
         return ("CMakeBuild["
-                "build = {},"
-                "build_type = {},"
-                "definition = {}]".format(self.build_dir,
-                                          self.build_type,
-                                          self.definition))
+                f"build = {self.build_dir},"
+                f"build_type = {self.build_type},"
+                f"definition = {self.definition}]")

--- a/dev/archery/archery/utils/cmake.py
+++ b/dev/archery/archery/utils/cmake.py
@@ -29,7 +29,7 @@ class CMake(Command):
 
     @staticmethod
     def default_generator():
-        """ Infer default generator.
+        """Infer default generator.
 
         Gives precedence to ninja if there exists an executable named `ninja`
         in the search path.
@@ -42,7 +42,7 @@ cmake = CMake()
 
 
 class CMakeDefinition:
-    """ CMakeDefinition captures the cmake invocation arguments.
+    """CMakeDefinition captures the cmake invocation arguments.
 
     It allows creating build directories with the same definition, e.g.
     ```
@@ -56,9 +56,10 @@ class CMakeDefinition:
     ```
     """
 
-    def __init__(self, source, build_type="release", generator=None,
-                 definitions=None, env=None):
-        """ Initialize a CMakeDefinition
+    def __init__(
+        self, source, build_type="release", generator=None, definitions=None, env=None
+    ):
+        """Initialize a CMakeDefinition
 
         Parameters
         ----------
@@ -84,7 +85,7 @@ class CMakeDefinition:
         return arguments
 
     def build(self, build_dir, force=False, cmd_kwargs=None, **kwargs):
-        """ Invoke cmake into a build directory.
+        """Invoke cmake into a build directory.
 
         Parameters
         ----------
@@ -97,21 +98,16 @@ class CMakeDefinition:
         if os.path.exists(build_dir):
             # Extra safety to ensure we're deleting a build folder.
             if not CMakeBuild.is_build_dir(build_dir):
-                raise FileExistsError(
-                    f"{build_dir} is not a cmake build"
-                )
+                raise FileExistsError(f"{build_dir} is not a cmake build")
             if not force:
-                raise FileExistsError(
-                    f"{build_dir} exists use force=True"
-                )
+                raise FileExistsError(f"{build_dir} exists use force=True")
             rmtree(build_dir)
 
         os.mkdir(build_dir)
 
         cmd_kwargs = cmd_kwargs if cmd_kwargs else {}
         cmake(*self.arguments, cwd=build_dir, env=self.env, **cmd_kwargs)
-        return CMakeBuild(build_dir, self.build_type, definition=self,
-                          **kwargs)
+        return CMakeBuild(build_dir, self.build_type, definition=self, **kwargs)
 
     def __repr__(self):
         return f"CMakeDefinition[source={self.source}]"
@@ -121,14 +117,14 @@ CMAKE_BUILD_TYPE_RE = re.compile("CMAKE_BUILD_TYPE:STRING=([a-zA-Z]+)")
 
 
 class CMakeBuild(CMake):
-    """ CMakeBuild represents a build directory initialized by cmake.
+    """CMakeBuild represents a build directory initialized by cmake.
 
     The build instance can be used to build/test/install. It alleviates the
     user to know which generator is used.
     """
 
     def __init__(self, build_dir, build_type, definition=None):
-        """ Initialize a CMakeBuild.
+        """Initialize a CMakeBuild.
 
         The caller must ensure that cmake was invoked in the build directory.
 
@@ -155,8 +151,7 @@ class CMakeBuild(CMake):
         if verbose:
             extra.append("-v" if self.bin.endswith("ninja") else "VERBOSE=1")
         # Commands must be ran under the build directory
-        return super().run(*cmake_args, *extra,
-                           *argv, **kwargs, cwd=self.build_dir)
+        return super().run(*cmake_args, *extra, *argv, **kwargs, cwd=self.build_dir)
 
     def all(self):
         return self.run("all")
@@ -172,7 +167,7 @@ class CMakeBuild(CMake):
 
     @staticmethod
     def is_build_dir(path):
-        """ Indicate if a path is CMake build directory.
+        """Indicate if a path is CMake build directory.
 
         This method only checks for the existence of paths and does not do any
         validation whatsoever.
@@ -183,7 +178,7 @@ class CMakeBuild(CMake):
 
     @staticmethod
     def from_path(path):
-        """ Instantiate a CMakeBuild from a path.
+        """Instantiate a CMakeBuild from a path.
 
         This is used to recover from an existing physical directory (created
         with or without CMakeBuild).
@@ -205,7 +200,9 @@ class CMakeBuild(CMake):
         return CMakeBuild(path, build_type)
 
     def __repr__(self):
-        return ("CMakeBuild["
-                f"build = {self.build_dir},"
-                f"build_type = {self.build_type},"
-                f"definition = {self.definition}]")
+        return (
+            "CMakeBuild["
+            f"build = {self.build_dir},"
+            f"build_type = {self.build_type},"
+            f"definition = {self.definition}]"
+        )

--- a/dev/archery/archery/utils/cmake.py
+++ b/dev/archery/archery/utils/cmake.py
@@ -52,6 +52,7 @@ class CMakeDefinition:
 
     build1.all()
     build2.all()
+    ```
     """
 
     def __init__(self, source, build_type="release", generator=None,
@@ -77,12 +78,8 @@ class CMakeDefinition:
 
     @property
     def arguments(self):
-        """" Return the arguments to cmake invocation. """
-        arguments = [
-            "-G{}".format(self.generator),
-        ] + self.definitions + [
-            self.source
-        ]
+        """Return the arguments to cmake invocation."""
+        arguments = [f"-G{self.generator}"] + self.definitions + [self.source]
         return arguments
 
     def build(self, build_dir, force=False, cmd_kwargs=None, **kwargs):

--- a/dev/archery/archery/utils/command.py
+++ b/dev/archery/archery/utils/command.py
@@ -14,18 +14,19 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
 import os
 import shlex
 import shutil
 import subprocess
 
-from .logger import logger, ctx
+from .logger import ctx, logger
 
 
 def default_bin(name, default):
     assert default
-    env_name = "ARCHERY_{0}_BIN".format(default.upper())
+    env_name = f"ARCHERY_{default.upper()}_BIN"
     return name if name else os.environ.get(env_name, default)
 
 
@@ -50,8 +51,7 @@ class capture_stdout:
 
 
 class Command:
-    """
-    A runnable command.
+    """A runnable command.
 
     Class inheriting from the Command class must provide the bin
     property/attribute.
@@ -74,13 +74,12 @@ class Command:
         if "check" not in kwargs:
             kwargs["check"] = True
 
-        logger.debug("Executing `{}`".format(invocation))
+        logger.debug(f"Executing `{invocation}`")
         return subprocess.run(invocation, **kwargs)
 
     @property
     def available(self):
-        """
-        Indicate if the command binary is found in PATH.
+        """Indicate if the command binary is found in PATH.
         """
         binary = shlex.split(self.bin)[0]
         return shutil.which(binary) is not None

--- a/dev/archery/archery/utils/command.py
+++ b/dev/archery/archery/utils/command.py
@@ -92,7 +92,7 @@ class Command:
 class CommandStackMixin:
     def run(self, *argv, **kwargs):
         stacked_args = self.argv + argv
-        return super(CommandStackMixin, self).run(*stacked_args, **kwargs)
+        return super().run(*stacked_args, **kwargs)
 
 
 class Bash(Command):

--- a/dev/archery/archery/utils/command.py
+++ b/dev/archery/archery/utils/command.py
@@ -41,12 +41,13 @@ class capture_stdout:
             return x.strip() if self.strip else x
 
         def list_it(x):
-            return x.decode('utf-8').splitlines() if self.listify else x
+            return x.decode("utf-8").splitlines() if self.listify else x
 
         def wrapper(*argv, **kwargs):
             # Ensure stdout is captured
             kwargs["stdout"] = subprocess.PIPE
             return list_it(strip_it(f(*argv, **kwargs).stdout))
+
         return wrapper
 
 
@@ -79,8 +80,7 @@ class Command:
 
     @property
     def available(self):
-        """Indicate if the command binary is found in PATH.
-        """
+        """Indicate if the command binary is found in PATH."""
         binary = shlex.split(self.bin)[0]
         return shutil.which(binary) is not None
 

--- a/dev/archery/archery/utils/git.py
+++ b/dev/archery/archery/utils/git.py
@@ -28,6 +28,7 @@ def git_cmd(fn):
 
     def wrapper(self, *argv, **kwargs):
         return fn(self, sub_cmd, *argv, **kwargs)
+
     return wrapper
 
 
@@ -36,7 +37,7 @@ class Git(Command):
         self.bin = default_bin(git_bin, "git")
 
     def run_cmd(self, cmd, *argv, git_dir=None, **kwargs):
-        """ Inject flags before sub-command in argv. """
+        """Inject flags before sub-command in argv."""
         opts = []
         if git_dir is not None:
             opts.extend(["-C", _stringify_path(git_dir)])
@@ -85,7 +86,7 @@ class Git(Command):
 
     @capture_stdout(strip=True)
     def head(self, **kwargs):
-        """ Return commit pointed by HEAD. """
+        """Return commit pointed by HEAD."""
         return self.rev_parse("HEAD", **kwargs)
 
     @capture_stdout(strip=True)
@@ -93,9 +94,9 @@ class Git(Command):
         return self.rev_parse("--abbrev-ref", "HEAD", **kwargs)
 
     def repository_root(self, git_dir=None, **kwargs):
-        """ Locates the repository's root path from a subdirectory. """
+        """Locates the repository's root path from a subdirectory."""
         stdout = self.rev_parse("--show-toplevel", git_dir=git_dir, **kwargs)
-        return stdout.decode('utf-8')
+        return stdout.decode("utf-8")
 
 
 git = Git()

--- a/dev/archery/archery/utils/git.py
+++ b/dev/archery/archery/utils/git.py
@@ -14,9 +14,10 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
-from .command import Command, capture_stdout, default_bin
 from ..compat import _stringify_path
+from .command import Command, capture_stdout, default_bin
 
 
 # Decorator prepending argv with the git sub-command found with the method

--- a/dev/archery/archery/utils/lint.py
+++ b/dev/archery/archery/utils/lint.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
 import fnmatch
 import gzip
@@ -22,16 +23,15 @@ from pathlib import Path
 
 import click
 
-from .command import Bash, Command, default_bin
 from ..compat import _get_module
+from ..lang.cpp import CppCMakeDefinition, CppConfiguration
+from ..lang.python import Autopep8, CythonLint, Flake8, NumpyDoc, PythonCommand
 from .cmake import CMake
+from .command import Bash, Command, default_bin
 from .git import git
 from .logger import logger
-from ..lang.cpp import CppCMakeDefinition, CppConfiguration
-from ..lang.python import Autopep8, Flake8, CythonLint, NumpyDoc, PythonCommand
 from .rat import Rat, exclusion_from_globs
 from .tmpdir import tmpdir
-
 
 _archery_install_msg = (
     "Please install archery using: `pip install -e dev/archery[lint]`. "
@@ -139,8 +139,7 @@ class CMakeFormat(Command):
 
 
 def cmake_linter(src, fix=False):
-    """
-    Run cmake-format on all CMakeFiles.txt
+    """Run cmake-format on all CMakeFiles.txt
     """
     logger.info("Running cmake-format linters")
 
@@ -173,7 +172,8 @@ def cmake_linter(src, fix=False):
 
 def python_linter(src, fix=False):
     """Run Python linters on python/pyarrow, python/examples, setup.py
-    and dev/. """
+    and dev/.
+    """
     setup_py = os.path.join(src.python, "setup.py")
     setup_cfg = os.path.join(src.python, "setup.cfg")
 
@@ -355,7 +355,7 @@ def python_numpydoc(symbols=None, allow_rules=None, disallow_rules=None):
             qualname_with_signature = '.'.join([module, cython_signature])
             click.echo(
                 click.style(
-                    '-> {}'.format(qualname_with_signature),
+                    f'-> {qualname_with_signature}',
                     fg='yellow'
                 )
             )
@@ -364,9 +364,7 @@ def python_numpydoc(symbols=None, allow_rules=None, disallow_rules=None):
             number_of_violations += 1
             click.echo('{}: {}'.format(*error))
 
-    msg = 'Total number of docstring violations: {}'.format(
-        number_of_violations
-    )
+    msg = f'Total number of docstring violations: {number_of_violations}'
     click.echo()
     click.echo(click.style(msg, fg='red'))
 
@@ -392,7 +390,7 @@ def rat_linter(src, root):
 
     violations = list(report.validate(exclusion=exclusion))
     for violation in violations:
-        print("apache-rat license violation: {}".format(violation))
+        print(f"apache-rat license violation: {violation}")
 
     yield LintResult(len(violations) == 0)
 

--- a/dev/archery/archery/utils/lint.py
+++ b/dev/archery/archery/utils/lint.py
@@ -413,8 +413,7 @@ def is_docker_image(path):
     dirname = os.path.dirname(path)
     filename = os.path.basename(path)
 
-    excluded = dirname.startswith(
-        "dev") or dirname.startswith("python/manylinux")
+    excluded = dirname.startswith(("dev", "python/manylinux"))
 
     return filename.startswith("Dockerfile") and not excluded
 

--- a/dev/archery/archery/utils/lint.py
+++ b/dev/archery/archery/utils/lint.py
@@ -55,10 +55,17 @@ class LintResult:
         return LintResult(command_result.returncode == 0)
 
 
-def cpp_linter(src, build_dir, clang_format=True, cpplint=True,
-               clang_tidy=False, iwyu=False, iwyu_all=False,
-               fix=False):
-    """ Run clang-format, cpplint and clang-tidy on cpp/ codebase. """
+def cpp_linter(
+    src,
+    build_dir,
+    clang_format=True,
+    cpplint=True,
+    clang_tidy=False,
+    iwyu=False,
+    iwyu_all=False,
+    fix=False,
+):
+    """Run clang-format, cpplint and clang-tidy on cpp/ codebase."""
     logger.info("Running C++ linters")
 
     cmake = CMake()
@@ -97,7 +104,6 @@ def cpp_linter(src, build_dir, clang_format=True, cpplint=True,
 
 
 class CMakeFormat(Command):
-
     def __init__(self, paths, cmake_format_bin=None):
         self.check_version()
         self.bin = default_bin(cmake_format_bin, "cmake-format")
@@ -121,14 +127,11 @@ class CMakeFormat(Command):
             # cmake_format is part of the cmakelang package
             import cmakelang
         except ImportError:
-            raise ImportError(
-
-            )
+            raise ImportError()
         # pin a specific version of cmake_format, must be updated in setup.py
         if cmakelang.__version__ != "0.6.13":
             raise LintValidationException(
-                f"Wrong version of cmake_format is detected. "
-                f"{_archery_install_msg}"
+                f"Wrong version of cmake_format is detected. {_archery_install_msg}"
             )
 
     def check(self):
@@ -139,31 +142,30 @@ class CMakeFormat(Command):
 
 
 def cmake_linter(src, fix=False):
-    """Run cmake-format on all CMakeFiles.txt
-    """
+    """Run cmake-format on all CMakeFiles.txt"""
     logger.info("Running cmake-format linters")
 
     cmake_format = CMakeFormat.from_patterns(
         src.path,
         include_patterns=[
-            'ci/**/*.cmake',
-            'cpp/CMakeLists.txt',
-            'cpp/src/**/*.cmake',
-            'cpp/src/**/*.cmake.in',
-            'cpp/src/**/CMakeLists.txt',
-            'cpp/examples/**/CMakeLists.txt',
-            'cpp/cmake_modules/*.cmake',
-            'go/**/CMakeLists.txt',
-            'java/**/CMakeLists.txt',
-            'matlab/**/CMakeLists.txt',
-            'python/**/CMakeLists.txt',
+            "ci/**/*.cmake",
+            "cpp/CMakeLists.txt",
+            "cpp/src/**/*.cmake",
+            "cpp/src/**/*.cmake.in",
+            "cpp/src/**/CMakeLists.txt",
+            "cpp/examples/**/CMakeLists.txt",
+            "cpp/cmake_modules/*.cmake",
+            "go/**/CMakeLists.txt",
+            "java/**/CMakeLists.txt",
+            "matlab/**/CMakeLists.txt",
+            "python/**/CMakeLists.txt",
         ],
         exclude_patterns=[
-            'cpp/cmake_modules/FindNumPy.cmake',
-            'cpp/cmake_modules/FindPythonLibsNew.cmake',
-            'cpp/cmake_modules/UseCython.cmake',
-            'cpp/src/arrow/util/*.h.cmake',
-        ]
+            "cpp/cmake_modules/FindNumPy.cmake",
+            "cpp/cmake_modules/FindPythonLibsNew.cmake",
+            "cpp/cmake_modules/UseCython.cmake",
+            "cpp/src/arrow/util/*.h.cmake",
+        ],
     )
     method = cmake_format.fix if fix else cmake_format.check
 
@@ -183,37 +185,40 @@ def python_linter(src, fix=False):
     if not autopep8.available:
         logger.error(
             "Python formatter requested but autopep8 binary not found. "
-            f"{_archery_install_msg}")
+            f"{_archery_install_msg}"
+        )
         return
 
     # Gather files for autopep8
-    patterns = ["python/benchmarks/**/*.py",
-                "python/examples/**/*.py",
-                "python/pyarrow/**/*.py",
-                "python/pyarrow/**/*.pyx",
-                "python/pyarrow/**/*.pxd",
-                "python/pyarrow/**/*.pxi",
-                "dev/*.py",
-                "dev/archery/**/*.py",
-                "dev/release/**/*.py"]
+    patterns = [
+        "python/benchmarks/**/*.py",
+        "python/examples/**/*.py",
+        "python/pyarrow/**/*.py",
+        "python/pyarrow/**/*.pyx",
+        "python/pyarrow/**/*.pxd",
+        "python/pyarrow/**/*.pxi",
+        "dev/*.py",
+        "dev/archery/**/*.py",
+        "dev/release/**/*.py",
+    ]
     files = [setup_py]
     for pattern in patterns:
         files += list(map(str, Path(src.path).glob(pattern)))
 
-    args = ['--global-config', setup_cfg, '--ignore-local-config']
+    args = ["--global-config", setup_cfg, "--ignore-local-config"]
     if fix:
-        args += ['-j0', '--in-place']
+        args += ["-j0", "--in-place"]
         args += sorted(files)
         yield LintResult.from_cmd(autopep8(*args))
     else:
         # XXX `-j0` doesn't work well with `--exit-code`, so instead
         # we capture the diff and check whether it's empty
         # (https://github.com/hhatto/autopep8/issues/543)
-        args += ['-j0', '--diff']
+        args += ["-j0", "--diff"]
         args += sorted(files)
         diff = autopep8.run_captured(*args)
         if diff:
-            print(diff.decode('utf8'))
+            print(diff.decode("utf8"))
             yield LintResult(success=False)
         else:
             yield LintResult(success=True)
@@ -225,16 +230,24 @@ def python_linter(src, fix=False):
     if not flake8.available:
         logger.error(
             "Python linter requested but flake8 binary not found. "
-            f"{_archery_install_msg}")
+            f"{_archery_install_msg}"
+        )
         return
 
-    flake8_exclude = ['.venv*', 'vendored']
+    flake8_exclude = [".venv*", "vendored"]
 
     yield LintResult.from_cmd(
-        flake8("--extend-exclude=" + ','.join(flake8_exclude),
-               "--config=" + os.path.join(src.python, "setup.cfg"),
-               setup_py, src.pyarrow, os.path.join(src.python, "benchmarks"),
-               os.path.join(src.python, "examples"), src.dev, check=False))
+        flake8(
+            "--extend-exclude=" + ",".join(flake8_exclude),
+            "--config=" + os.path.join(src.python, "setup.cfg"),
+            setup_py,
+            src.pyarrow,
+            os.path.join(src.python, "benchmarks"),
+            os.path.join(src.python, "examples"),
+            src.dev,
+            check=False,
+        )
+    )
 
     logger.info("Running Cython linter (cython-lint)")
 
@@ -242,21 +255,23 @@ def python_linter(src, fix=False):
     if not cython_lint.available:
         logger.error(
             "Cython linter requested but cython-lint binary not found. "
-            f"{_archery_install_msg}")
+            f"{_archery_install_msg}"
+        )
         return
 
     # Gather files for cython-lint
-    patterns = ["python/pyarrow/**/*.pyx",
-                "python/pyarrow/**/*.pxd",
-                "python/pyarrow/**/*.pxi",
-                "python/examples/**/*.pyx",
-                "python/examples/**/*.pxd",
-                "python/examples/**/*.pxi",
-                ]
+    patterns = [
+        "python/pyarrow/**/*.pyx",
+        "python/pyarrow/**/*.pxd",
+        "python/pyarrow/**/*.pxi",
+        "python/examples/**/*.pyx",
+        "python/examples/**/*.pxd",
+        "python/examples/**/*.pxi",
+    ]
     files = []
     for pattern in patterns:
         files += list(map(str, Path(src.path).glob(pattern)))
-    args = ['--no-pycodestyle']
+    args = ["--no-pycodestyle"]
     args += sorted(files)
     yield LintResult.from_cmd(cython_lint(*args))
 
@@ -272,14 +287,19 @@ def python_cpp_linter(src, clang_format=True, fix=False):
 
         if "CLANG_TOOLS_PATH" in os.environ:
             clang_format_binary = os.path.join(
-                os.environ["CLANG_TOOLS_PATH"], "clang-format")
+                os.environ["CLANG_TOOLS_PATH"], "clang-format"
+            )
         else:
             clang_format_binary = "clang-format-14"
 
-        run_clang_format = os.path.join(src.cpp, "build-support",
-                                        "run_clang_format.py")
-        args = [run_clang_format, "--source_dir", cpp_src,
-                "--clang_format_binary", clang_format_binary]
+        run_clang_format = os.path.join(src.cpp, "build-support", "run_clang_format.py")
+        args = [
+            run_clang_format,
+            "--source_dir",
+            cpp_src,
+            "--clang_format_binary",
+            clang_format_binary,
+        ]
         if fix:
             args += ["--fix"]
 
@@ -294,19 +314,19 @@ def python_numpydoc(symbols=None, allow_rules=None, disallow_rules=None):
     logger.info("Running Python docstring linters")
     # by default try to run on all pyarrow package
     symbols = symbols or {
-        'pyarrow',
-        'pyarrow.compute',
-        'pyarrow.csv',
-        'pyarrow.dataset',
-        'pyarrow.feather',
+        "pyarrow",
+        "pyarrow.compute",
+        "pyarrow.csv",
+        "pyarrow.dataset",
+        "pyarrow.feather",
         # 'pyarrow.flight',
-        'pyarrow.fs',
-        'pyarrow.gandiva',
-        'pyarrow.ipc',
-        'pyarrow.json',
-        'pyarrow.orc',
-        'pyarrow.parquet',
-        'pyarrow.types',
+        "pyarrow.fs",
+        "pyarrow.gandiva",
+        "pyarrow.ipc",
+        "pyarrow.json",
+        "pyarrow.orc",
+        "pyarrow.parquet",
+        "pyarrow.types",
     }
     try:
         numpydoc = NumpyDoc(symbols)
@@ -317,9 +337,9 @@ def python_numpydoc(symbols=None, allow_rules=None, disallow_rules=None):
 
     results = numpydoc.validate(
         # limit the validation scope to the pyarrow package
-        from_package='pyarrow',
+        from_package="pyarrow",
         allow_rules=allow_rules,
-        disallow_rules=disallow_rules
+        disallow_rules=disallow_rules,
     )
 
     if len(results) == 0:
@@ -328,45 +348,40 @@ def python_numpydoc(symbols=None, allow_rules=None, disallow_rules=None):
 
     number_of_violations = 0
     for obj, result in results:
-        errors = result['errors']
+        errors = result["errors"]
 
         # inspect doesn't play nice with cython generated source code,
         # to use a hacky way to represent a proper __qualname__
-        doc = getattr(obj, '__doc__', '')
-        name = getattr(obj, '__name__', '')
-        qualname = getattr(obj, '__qualname__', '')
-        module = _get_module(obj, default='')
-        instance = getattr(obj, '__self__', '')
+        doc = getattr(obj, "__doc__", "")
+        name = getattr(obj, "__name__", "")
+        qualname = getattr(obj, "__qualname__", "")
+        module = _get_module(obj, default="")
+        instance = getattr(obj, "__self__", "")
         if instance:
             klass = instance.__class__.__name__
         else:
-            klass = ''
+            klass = ""
 
         try:
             cython_signature = doc.splitlines()[0]
         except Exception:
-            cython_signature = ''
+            cython_signature = ""
 
-        desc = '.'.join(filter(None, [module, klass, qualname or name]))
+        desc = ".".join(filter(None, [module, klass, qualname or name]))
 
         click.echo()
-        click.echo(click.style(desc, bold=True, fg='yellow'))
+        click.echo(click.style(desc, bold=True, fg="yellow"))
         if cython_signature:
-            qualname_with_signature = '.'.join([module, cython_signature])
-            click.echo(
-                click.style(
-                    f'-> {qualname_with_signature}',
-                    fg='yellow'
-                )
-            )
+            qualname_with_signature = ".".join([module, cython_signature])
+            click.echo(click.style(f"-> {qualname_with_signature}", fg="yellow"))
 
         for error in errors:
             number_of_violations += 1
-            click.echo('{}: {}'.format(*error))
+            click.echo("{}: {}".format(*error))
 
-    msg = f'Total number of docstring violations: {number_of_violations}'
+    msg = f"Total number of docstring violations: {number_of_violations}"
     click.echo()
-    click.echo(click.style(msg, fg='red'))
+    click.echo(click.style(msg, fg="red"))
 
     yield LintResult(success=False)
 
@@ -376,11 +391,14 @@ def rat_linter(src, root):
     logger.info("Running apache-rat linter")
 
     if src.git_dirty:
-        logger.warn("Due to the usage of git-archive, uncommitted files will"
-                    " not be checked for rat violations. ")
+        logger.warn(
+            "Due to the usage of git-archive, uncommitted files will"
+            " not be checked for rat violations. "
+        )
 
     exclusion = exclusion_from_globs(
-        os.path.join(src.dev, "release", "rat_exclude_files.txt"))
+        os.path.join(src.dev, "release", "rat_exclude_files.txt")
+    )
 
     # Creates a git-archive of ArrowSources, apache-rat expects a gzip
     # compressed tar archive.
@@ -423,14 +441,12 @@ def docker_linter(src):
     hadolint = Hadolint()
 
     if not hadolint.available:
-        logger.error(
-            "hadolint linter requested but hadolint binary not found.")
+        logger.error("hadolint linter requested but hadolint binary not found.")
         return
 
     for path in git.ls_files(git_dir=src.path):
         if is_docker_image(path):
-            yield LintResult.from_cmd(hadolint.run(path, check=False,
-                                                   cwd=src.path))
+            yield LintResult.from_cmd(hadolint.run(path, check=False, cwd=src.path))
 
 
 class SphinxLint(Command):
@@ -468,7 +484,7 @@ def docs_linter(src, path=None):
         src,
         path=path,
         disable="all",
-        enable="trailing-whitespace,missing-final-newline"
+        enable="trailing-whitespace,missing-final-newline",
     )
 
     if not sphinx_lint.available:
@@ -478,10 +494,24 @@ def docs_linter(src, path=None):
     yield LintResult.from_cmd(sphinx_lint.lint())
 
 
-def linter(src, fix=False, path=None, *, clang_format=False, cpplint=False,
-           clang_tidy=False, iwyu=False, iwyu_all=False,
-           python=False, numpydoc=False, cmake_format=False, rat=False,
-           r=False, docker=False, docs=False):
+def linter(
+    src,
+    fix=False,
+    path=None,
+    *,
+    clang_format=False,
+    cpplint=False,
+    clang_tidy=False,
+    iwyu=False,
+    iwyu_all=False,
+    python=False,
+    numpydoc=False,
+    cmake_format=False,
+    rat=False,
+    r=False,
+    docker=False,
+    docs=False,
+):
     """Run all linters."""
     with tmpdir(prefix="arrow-lint-") as root:
         build_dir = os.path.join(root, "cpp-build")
@@ -492,21 +522,24 @@ def linter(src, fix=False, path=None, *, clang_format=False, cpplint=False,
         results = []
 
         if clang_format or cpplint or clang_tidy or iwyu:
-            results.extend(cpp_linter(src, build_dir,
-                                      clang_format=clang_format,
-                                      cpplint=cpplint,
-                                      clang_tidy=clang_tidy,
-                                      iwyu=iwyu,
-                                      iwyu_all=iwyu_all,
-                                      fix=fix))
+            results.extend(
+                cpp_linter(
+                    src,
+                    build_dir,
+                    clang_format=clang_format,
+                    cpplint=cpplint,
+                    clang_tidy=clang_tidy,
+                    iwyu=iwyu,
+                    iwyu_all=iwyu_all,
+                    fix=fix,
+                )
+            )
 
         if python:
             results.extend(python_linter(src, fix=fix))
 
         if python and clang_format:
-            results.extend(python_cpp_linter(src,
-                                             clang_format=clang_format,
-                                             fix=fix))
+            results.extend(python_cpp_linter(src, clang_format=clang_format, fix=fix))
 
         if numpydoc:
             results.extend(python_numpydoc())

--- a/dev/archery/archery/utils/logger.py
+++ b/dev/archery/archery/utils/logger.py
@@ -57,8 +57,10 @@ def group(name, output=None):
     This does nothing in non GitHub Actions environment for now.
     """
     if output is None:
+
         def output(message):
             print(message, flush=True)
+
     if in_github_actions():
         output(f"::group::{name}")
     try:

--- a/dev/archery/archery/utils/logger.py
+++ b/dev/archery/archery/utils/logger.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
 import contextlib
 import logging
@@ -51,8 +52,7 @@ def running_in_ci():
 
 @contextlib.contextmanager
 def group(name, output=None):
-    """
-    Group outputs in the given with block.
+    """Group outputs in the given with block.
 
     This does nothing in non GitHub Actions environment for now.
     """

--- a/dev/archery/archery/utils/maven.py
+++ b/dev/archery/archery/utils/maven.py
@@ -30,7 +30,7 @@ maven = Maven()
 
 
 class MavenDefinition:
-    """ MavenDefinition captures the maven invocation arguments.
+    """MavenDefinition captures the maven invocation arguments.
 
     It allows creating build directories with the same definition, e.g.
     ```
@@ -44,9 +44,10 @@ class MavenDefinition:
     ```
     """
 
-    def __init__(self, source, build_definitions=None,
-                 benchmark_definitions=None, env=None):
-        """ Initialize a MavenDefinition
+    def __init__(
+        self, source, build_definitions=None, benchmark_definitions=None, env=None
+    ):
+        """Initialize a MavenDefinition
 
         Parameters
         ----------
@@ -58,23 +59,28 @@ class MavenDefinition:
         """
         self.source = os.path.abspath(source)
         self.build_definitions = build_definitions if build_definitions else []
-        self.benchmark_definitions =\
+        self.benchmark_definitions = (
             benchmark_definitions if benchmark_definitions else []
+        )
         self.env = env
 
     @property
     def build_arguments(self):
-        """" Return the arguments to maven invocation for build. """
+        """ " Return the arguments to maven invocation for build."""
         arguments = self.build_definitions + [
-            "-B", "-DskipTests", "-Drat.skip=true",
+            "-B",
+            "-DskipTests",
+            "-Drat.skip=true",
             "-Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer."
             "Slf4jMavenTransferListener=warn",
-            "-T", "2C", "install"
+            "-T",
+            "2C",
+            "install",
         ]
         return arguments
 
     def build(self, build_dir, force=False, cmd_kwargs=None, **kwargs):
-        """ Invoke maven into a build directory.
+        """Invoke maven into a build directory.
 
         Parameters
         ----------
@@ -94,20 +100,19 @@ class MavenDefinition:
 
     @property
     def list_arguments(self):
-        """" Return the arguments to maven invocation for list """
-        arguments = [
-            "-Dskip.perf.benchmarks=false", "-Dbenchmark.list=-lp", "install"
-        ]
+        """ " Return the arguments to maven invocation for list"""
+        arguments = ["-Dskip.perf.benchmarks=false", "-Dbenchmark.list=-lp", "install"]
         return arguments
 
     @property
     def benchmark_arguments(self):
-        """" Return the arguments to maven invocation for benchmark """
+        """ " Return the arguments to maven invocation for benchmark"""
         arguments = self.benchmark_definitions + [
-            "-Dskip.perf.benchmarks=false", "-Dbenchmark.fork=1",
-            "-Dbenchmark.jvmargs=\"-Darrow.enable_null_check_for_get=false "
-            "-Darrow.enable_unsafe_memory_access=true\"",
-            "install"
+            "-Dskip.perf.benchmarks=false",
+            "-Dbenchmark.fork=1",
+            '-Dbenchmark.jvmargs="-Darrow.enable_null_check_for_get=false '
+            '-Darrow.enable_unsafe_memory_access=true"',
+            "install",
         ]
         return arguments
 
@@ -116,14 +121,14 @@ class MavenDefinition:
 
 
 class MavenBuild(Maven):
-    """ MavenBuild represents a build directory initialized by maven.
+    """MavenBuild represents a build directory initialized by maven.
 
     The build instance can be used to build/test/install. It alleviates the
     user to know which generator is used.
     """
 
     def __init__(self, build_dir, definition=None):
-        """ Initialize a MavenBuild.
+        """Initialize a MavenBuild.
 
         The caller must ensure that maven was invoked in the build directory.
 
@@ -155,24 +160,42 @@ class MavenBuild(Maven):
     def build(self, *argv, verbose=False, **kwargs):
         definition_args = self.definition.build_arguments
         cwd = self.binaries_dir
-        return self.run(*argv, *definition_args, verbose=verbose, cwd=cwd,
-                        env=self.definition.env, **kwargs)
+        return self.run(
+            *argv,
+            *definition_args,
+            verbose=verbose,
+            cwd=cwd,
+            env=self.definition.env,
+            **kwargs,
+        )
 
     def list(self, *argv, verbose=False, **kwargs):
         definition_args = self.definition.list_arguments
         cwd = self.binaries_dir + "/performance"
-        return self.run(*argv, *definition_args, verbose=verbose, cwd=cwd,
-                        env=self.definition.env, **kwargs)
+        return self.run(
+            *argv,
+            *definition_args,
+            verbose=verbose,
+            cwd=cwd,
+            env=self.definition.env,
+            **kwargs,
+        )
 
     def benchmark(self, *argv, verbose=False, **kwargs):
         definition_args = self.definition.benchmark_arguments
         cwd = self.binaries_dir + "/performance"
-        return self.run(*argv, *definition_args, verbose=verbose, cwd=cwd,
-                        env=self.definition.env, **kwargs)
+        return self.run(
+            *argv,
+            *definition_args,
+            verbose=verbose,
+            cwd=cwd,
+            env=self.definition.env,
+            **kwargs,
+        )
 
     @staticmethod
     def is_build_dir(path):
-        """ Indicate if a path is Maven top directory.
+        """Indicate if a path is Maven top directory.
 
         This method only checks for the existence of paths and does not do any
         validation whatsoever.
@@ -183,7 +206,7 @@ class MavenBuild(Maven):
 
     @staticmethod
     def from_path(path):
-        """ Instantiate a Maven from a path.
+        """Instantiate a Maven from a path.
 
         This is used to recover from an existing physical directory (created
         with or without Maven).
@@ -197,6 +220,4 @@ class MavenBuild(Maven):
         return MavenBuild(path, definition=None)
 
     def __repr__(self):
-        return ("MavenBuild["
-                f"build = {self.build_dir},"
-                f"definition = {self.definition}]")
+        return f"MavenBuild[build = {self.build_dir},definition = {self.definition}]"

--- a/dev/archery/archery/utils/maven.py
+++ b/dev/archery/archery/utils/maven.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
 import os
 
@@ -111,7 +112,7 @@ class MavenDefinition:
         return arguments
 
     def __repr__(self):
-        return "MavenDefinition[source={}]".format(self.source)
+        return f"MavenDefinition[source={self.source}]"
 
 
 class MavenBuild(Maven):
@@ -191,12 +192,11 @@ class MavenBuild(Maven):
         be lost.
         """
         if not MavenBuild.is_build_dir(path):
-            raise ValueError("Not a valid MavenBuild path: {}".format(path))
+            raise ValueError(f"Not a valid MavenBuild path: {path}")
 
         return MavenBuild(path, definition=None)
 
     def __repr__(self):
         return ("MavenBuild["
-                "build = {},"
-                "definition = {}]".format(self.build_dir,
-                                          self.definition))
+                f"build = {self.build_dir},"
+                f"definition = {self.definition}]")

--- a/dev/archery/archery/utils/maven.py
+++ b/dev/archery/archery/utils/maven.py
@@ -40,6 +40,7 @@ class MavenDefinition:
 
     build1.install()
     build2.install()
+    ```
     """
 
     def __init__(self, source, build_definitions=None,
@@ -81,12 +82,9 @@ class MavenDefinition:
         force : bool
                 not used now
         """
-        if os.path.exists(build_dir):
+        if os.path.exists(build_dir) and not MavenBuild.is_build_dir(build_dir):
             # Extra safety to ensure we're deleting a build folder.
-            if not MavenBuild.is_build_dir(build_dir):
-                raise FileExistsError(
-                    "{} is not a maven build".format(build_dir)
-                )
+            raise FileExistsError(f"{build_dir} is not a maven build")
 
         cmd_kwargs = cmd_kwargs if cmd_kwargs else {}
         assert MavenBuild.is_build_dir(build_dir)

--- a/dev/archery/archery/utils/rat.py
+++ b/dev/archery/archery/utils/rat.py
@@ -58,12 +58,12 @@ class RatReport:
         return f"RatReport({self.xml})"
 
     def validate(self, exclusion=None):
-        for r in self.tree.findall('resource'):
-            approvals = r.findall('license-approval')
-            if not approvals or approvals[0].attrib['name'] == 'true':
+        for r in self.tree.findall("resource"):
+            approvals = r.findall("license-approval")
+            if not approvals or approvals[0].attrib["name"] == "true":
                 continue
 
-            clean_name = re.sub('^[^/]+/', '', r.attrib['name'])
+            clean_name = re.sub("^[^/]+/", "", r.attrib["name"])
 
             if exclusion and exclusion(clean_name):
                 continue

--- a/dev/archery/archery/utils/rat.py
+++ b/dev/archery/archery/utils/rat.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
 import fnmatch
 import re
@@ -24,7 +25,7 @@ from .cache import Cache
 from .command import capture_stdout
 
 RAT_VERSION = 0.13
-RAT_JAR_FILENAME = "apache-rat-{}.jar".format(RAT_VERSION)
+RAT_JAR_FILENAME = f"apache-rat-{RAT_VERSION}.jar"
 RAT_URL_ = "https://repo1.maven.org/maven2/org/apache/rat/apache-rat"
 RAT_URL = "/".join([RAT_URL_, str(RAT_VERSION), RAT_JAR_FILENAME])
 
@@ -43,7 +44,7 @@ class Rat(Jar):
 
 
 def exclusion_from_globs(exclusions_path):
-    with open(exclusions_path, 'r') as exclusions_fd:
+    with open(exclusions_path) as exclusions_fd:
         exclusions = [e.strip() for e in exclusions_fd]
         return lambda path: any(fnmatch.fnmatch(path, e) for e in exclusions)
 
@@ -54,7 +55,7 @@ class RatReport:
         self.tree = ElementTree.fromstring(xml)
 
     def __repr__(self):
-        return "RatReport({})".format(self.xml)
+        return f"RatReport({self.xml})"
 
     def validate(self, exclusion=None):
         for r in self.tree.findall('resource'):

--- a/dev/archery/archery/utils/rat.py
+++ b/dev/archery/archery/utils/rat.py
@@ -45,7 +45,7 @@ class Rat(Jar):
 def exclusion_from_globs(exclusions_path):
     with open(exclusions_path, 'r') as exclusions_fd:
         exclusions = [e.strip() for e in exclusions_fd]
-        return lambda path: any([fnmatch.fnmatch(path, e) for e in exclusions])
+        return lambda path: any(fnmatch.fnmatch(path, e) for e in exclusions)
 
 
 class RatReport:

--- a/dev/archery/archery/utils/report.py
+++ b/dev/archery/archery/utils/report.py
@@ -23,17 +23,16 @@ import jinja2
 
 
 def markdown_escape(s):
-    for char in ('*', '#', '_', '~', '`', '>'):
-        s = s.replace(char, '\\' + char)
+    for char in ("*", "#", "_", "~", "`", ">"):
+        s = s.replace(char, "\\" + char)
     return s
 
 
 class Report(metaclass=ABCMeta):
-
     def __init__(self, **kwargs):
         for field in self.fields:
             if field not in kwargs:
-                raise ValueError(f'Missing keyword argument {field}')
+                raise ValueError(f"Missing keyword argument {field}")
         self._data = kwargs
 
     def __getattr__(self, key):
@@ -50,13 +49,12 @@ class Report(metaclass=ABCMeta):
 
 
 class JinjaReport(Report):
-
     def __init__(self, **kwargs):
         self.env = jinja2.Environment(
-            loader=jinja2.PackageLoader('archery', 'templates')
+            loader=jinja2.PackageLoader("archery", "templates")
         )
-        self.env.filters['md'] = markdown_escape
-        self.env.globals['today'] = datetime.date.today
+        self.env.filters["md"] = markdown_escape
+        self.env.globals["today"] = datetime.date.today
         super().__init__(**kwargs)
 
     def render(self, template_name):

--- a/dev/archery/archery/utils/report.py
+++ b/dev/archery/archery/utils/report.py
@@ -14,9 +14,10 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
-from abc import ABCMeta, abstractmethod
 import datetime
+from abc import ABCMeta, abstractmethod
 
 import jinja2
 
@@ -32,7 +33,7 @@ class Report(metaclass=ABCMeta):
     def __init__(self, **kwargs):
         for field in self.fields:
             if field not in kwargs:
-                raise ValueError('Missing keyword argument {}'.format(field))
+                raise ValueError(f'Missing keyword argument {field}')
         self._data = kwargs
 
     def __getattr__(self, key):

--- a/dev/archery/archery/utils/source.py
+++ b/dev/archery/archery/utils/source.py
@@ -24,15 +24,11 @@ from pathlib import Path
 from .command import Command
 from .git import git
 
-ARROW_ROOT_DEFAULT = os.environ.get(
-    'ARROW_ROOT',
-    Path(__file__).resolve().parents[4]
-)
+ARROW_ROOT_DEFAULT = os.environ.get("ARROW_ROOT", Path(__file__).resolve().parents[4])
 
 
 def arrow_path(path):
-    """Return full path to a file given its path inside the Arrow repo.
-    """
+    """Return full path to a file given its path inside the Arrow repo."""
     return os.path.join(ARROW_ROOT_DEFAULT, path)
 
 
@@ -41,7 +37,7 @@ class InvalidArrowSource(Exception):
 
 
 class ArrowSources:
-    """ ArrowSources is a companion class representing a directory containing
+    """ArrowSources is a companion class representing a directory containing
     Apache Arrow's sources.
     """
 
@@ -51,7 +47,7 @@ class ArrowSources:
     WORKSPACE = "WORKSPACE"
 
     def __init__(self, path):
-        """ Initialize an ArrowSources
+        """Initialize an ArrowSources
 
         The caller must ensure that path is valid arrow source directory (can
         be checked with ArrowSources.valid)
@@ -62,65 +58,62 @@ class ArrowSources:
         """
         path = Path(path)
         # validate by checking a specific path in the arrow source tree
-        if not (path / 'cpp' / 'CMakeLists.txt').exists():
-            raise InvalidArrowSource(
-                f"No Arrow C++ sources found in {path}."
-            )
+        if not (path / "cpp" / "CMakeLists.txt").exists():
+            raise InvalidArrowSource(f"No Arrow C++ sources found in {path}.")
         self.path = path
 
     @property
     def archery(self):
-        """ Returns the archery directory of an Arrow sources. """
+        """Returns the archery directory of an Arrow sources."""
         return self.dev / "archery"
 
     @property
     def cpp(self):
-        """ Returns the cpp directory of an Arrow sources. """
+        """Returns the cpp directory of an Arrow sources."""
         return self.path / "cpp"
 
     @property
     def dev(self):
-        """ Returns the dev directory of an Arrow sources. """
+        """Returns the dev directory of an Arrow sources."""
         return self.path / "dev"
 
     @property
     def java(self):
-        """ Returns the java directory of an Arrow sources. """
+        """Returns the java directory of an Arrow sources."""
         return self.path / "java"
 
     @property
     def python(self):
-        """ Returns the python directory of an Arrow sources. """
+        """Returns the python directory of an Arrow sources."""
         return self.path / "python"
 
     @property
     def pyarrow(self):
-        """ Returns the python/pyarrow directory of an Arrow sources. """
+        """Returns the python/pyarrow directory of an Arrow sources."""
         return self.python / "pyarrow"
 
     @property
     def r(self):
-        """ Returns the r directory of an Arrow sources. """
+        """Returns the r directory of an Arrow sources."""
         return self.path / "r"
 
     @property
     def git_backed(self):
-        """ Indicate if the sources are backed by git. """
+        """Indicate if the sources are backed by git."""
         return (self.path / ".git").exists()
 
     @property
     def git_dirty(self):
-        """ Indicate if the sources is a dirty git directory. """
+        """Indicate if the sources is a dirty git directory."""
         return self.git_backed and git.dirty(git_dir=self.path)
 
     def archive(self, path, dereference=False, compressor=None, revision=None):
-        """ Saves a git archive at path. """
+        """Saves a git archive at path."""
         if not self.git_backed:
             raise ValueError(f"{self} is not backed by git")
 
         rev = revision if revision else "HEAD"
-        archive = git.archive("--prefix=apache-arrow.tmp/", rev,
-                              git_dir=self.path)
+        archive = git.archive("--prefix=apache-arrow.tmp/", rev, git_dir=self.path)
         with tempfile.TemporaryDirectory() as tmp:
             tmp = Path(tmp)
             tar_path = tmp / "apache-arrow.tar"
@@ -128,8 +121,9 @@ class ArrowSources:
                 tar.write(archive)
             Command("tar").run("xf", tar_path, "-C", tmp)
             # Must use the same logic in dev/release/02-source.sh
-            Command("cp").run("-R", "-L", tmp /
-                              "apache-arrow.tmp", tmp / "apache-arrow")
+            Command("cp").run(
+                "-R", "-L", tmp / "apache-arrow.tmp", tmp / "apache-arrow"
+            )
             Command("tar").run("cf", tar_path, "-C", tmp, "apache-arrow")
             with open(tar_path, "rb") as tar:
                 archive = tar.read()
@@ -141,7 +135,7 @@ class ArrowSources:
             archive_fd.write(archive)
 
     def at_revision(self, revision, clone_dir):
-        """ Return a copy of the current sources for a specified git revision.
+        """Return a copy of the current sources for a specified git revision.
 
         This method may return the current object if no checkout is required.
         The caller is responsible to remove the cloned repository directory.
@@ -183,7 +177,7 @@ class ArrowSources:
 
     @staticmethod
     def find(path=None):
-        """ Infer Arrow sources directory from various method.
+        """Infer Arrow sources directory from various method.
 
         The following guesses are done in order until a valid match is found:
 

--- a/dev/archery/archery/utils/source.py
+++ b/dev/archery/archery/utils/source.py
@@ -14,15 +14,15 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
 import os
-from pathlib import Path
 import subprocess
 import tempfile
+from pathlib import Path
 
 from .command import Command
 from .git import git
-
 
 ARROW_ROOT_DEFAULT = os.environ.get(
     'ARROW_ROOT',
@@ -31,8 +31,7 @@ ARROW_ROOT_DEFAULT = os.environ.get(
 
 
 def arrow_path(path):
-    """
-    Return full path to a file given its path inside the Arrow repo.
+    """Return full path to a file given its path inside the Arrow repo.
     """
     return os.path.join(ARROW_ROOT_DEFAULT, path)
 
@@ -45,6 +44,7 @@ class ArrowSources:
     """ ArrowSources is a companion class representing a directory containing
     Apache Arrow's sources.
     """
+
     # Note that WORKSPACE is a reserved git revision name by this module to
     # reference the current git workspace. In other words, this indicates to
     # ArrowSources.at_revision that no cloning/checkout is required.
@@ -64,7 +64,7 @@ class ArrowSources:
         # validate by checking a specific path in the arrow source tree
         if not (path / 'cpp' / 'CMakeLists.txt').exists():
             raise InvalidArrowSource(
-                "No Arrow C++ sources found in {}.".format(path)
+                f"No Arrow C++ sources found in {path}."
             )
         self.path = path
 
@@ -116,7 +116,7 @@ class ArrowSources:
     def archive(self, path, dereference=False, compressor=None, revision=None):
         """ Saves a git archive at path. """
         if not self.git_backed:
-            raise ValueError("{} is not backed by git".format(self))
+            raise ValueError(f"{self} is not backed by git")
 
         rev = revision if revision else "HEAD"
         archive = git.archive("--prefix=apache-arrow.tmp/", rev,
@@ -160,7 +160,7 @@ class ArrowSources:
                     Path to checkout the local clone.
         """
         if not self.git_backed:
-            raise ValueError("{} is not backed by git".format(self))
+            raise ValueError(f"{self} is not backed by git")
 
         if revision == ArrowSources.WORKSPACE:
             return self, False
@@ -199,7 +199,6 @@ class ArrowSources:
            repository. If so, returns the relative path to the source
            directory.
         """
-
         # Explicit via environment
         env = os.environ.get("ARROW_SRC")
 
@@ -226,10 +225,10 @@ class ArrowSources:
             except InvalidArrowSource:
                 pass
 
-        searched_paths = "\n".join([" - {}".format(p) for p in paths])
+        searched_paths = "\n".join([f" - {p}" for p in paths])
         raise InvalidArrowSource(
             "Unable to locate Arrow's source directory. "
-            "Searched paths are:\n{}".format(searched_paths)
+            f"Searched paths are:\n{searched_paths}"
         )
 
     def __repr__(self):

--- a/dev/archery/archery/utils/tmpdir.py
+++ b/dev/archery/archery/utils/tmpdir.py
@@ -14,9 +14,10 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
 from contextlib import contextmanager
-from tempfile import mkdtemp, TemporaryDirectory
+from tempfile import TemporaryDirectory, mkdtemp
 
 
 @contextmanager

--- a/dev/archery/conftest.py
+++ b/dev/archery/conftest.py
@@ -59,7 +59,8 @@ def load_fixture(request):
                 return json.load(fp)
             elif path.suffix == '.yaml':
                 import yaml
-                return yaml.load(fp)
+
+                return yaml.safe_load(fp)
             else:
                 return fp.read()
 

--- a/dev/archery/conftest.py
+++ b/dev/archery/conftest.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
 import pathlib
 

--- a/dev/archery/conftest.py
+++ b/dev/archery/conftest.py
@@ -26,7 +26,7 @@ def pytest_addoption(parser):
         "--enable-integration",
         action="store_true",
         default=False,
-        help="run slow tests"
+        help="run slow tests",
     )
 
 
@@ -36,7 +36,7 @@ def pytest_configure(config):
         (
             "integration: mark test as integration tests involving more "
             "extensive setup (only used for crossbow at the moment)"
-        )
+        ),
     )
 
 
@@ -54,11 +54,12 @@ def load_fixture(request):
     current_test_directory = pathlib.Path(request.node.fspath).parent
 
     def decoder(path):
-        with path.open('r') as fp:
-            if path.suffix == '.json':
+        with path.open("r") as fp:
+            if path.suffix == ".json":
                 import json
+
                 return json.load(fp)
-            elif path.suffix == '.yaml':
+            elif path.suffix == ".yaml":
                 import yaml
 
                 return yaml.safe_load(fp)
@@ -66,7 +67,7 @@ def load_fixture(request):
                 return fp.read()
 
     def loader(name, decoder=decoder):
-        path = current_test_directory / 'fixtures' / name
+        path = current_test_directory / "fixtures" / name
         return decoder(path)
 
     return loader

--- a/dev/archery/setup.py
+++ b/dev/archery/setup.py
@@ -27,40 +27,51 @@ if sys.version_info < (3, 9):  # noqa: UP036
     sys.exit("Python < 3.9 is not supported")
 
 # For pathlib.Path compatibility
-jinja_req = 'jinja2>=2.11'
+jinja_req = "jinja2>=2.11"
 
 extras = {
-    'benchmark': ['pandas'],
-    'crossbow': ['github3.py', jinja_req, 'pygit2>=1.14.0', 'requests',
-                 'ruamel.yaml', 'setuptools_scm>=8.0.0'],
-    'crossbow-upload': ['github3.py', jinja_req, 'ruamel.yaml',
-                        'setuptools_scm'],
-    'docker': ['ruamel.yaml', 'python-dotenv'],
-    'integration': ['cffi', 'numpy'],
-    'integration-java': ['jpype1'],
-    'lint': ['numpydoc==1.1.0', 'autopep8', 'flake8==6.1.0', 'cython-lint',
-             'cmake_format==0.6.13', 'sphinx-lint==0.9.1'],
-    'numpydoc': ['numpydoc==1.1.0'],
-    'release': ['pygithub', jinja_req, 'semver', 'gitpython'],
+    "benchmark": ["pandas"],
+    "crossbow": [
+        "github3.py",
+        jinja_req,
+        "pygit2>=1.14.0",
+        "requests",
+        "ruamel.yaml",
+        "setuptools_scm>=8.0.0",
+    ],
+    "crossbow-upload": ["github3.py", jinja_req, "ruamel.yaml", "setuptools_scm"],
+    "docker": ["ruamel.yaml", "python-dotenv"],
+    "integration": ["cffi", "numpy"],
+    "integration-java": ["jpype1"],
+    "lint": [
+        "numpydoc==1.1.0",
+        "autopep8",
+        "flake8==6.1.0",
+        "cython-lint",
+        "cmake_format==0.6.13",
+        "sphinx-lint==0.9.1",
+    ],
+    "numpydoc": ["numpydoc==1.1.0"],
+    "release": ["pygithub", jinja_req, "semver", "gitpython"],
 }
-extras['bot'] = extras['crossbow'] + ['pygithub']
-extras['all'] = list(set(functools.reduce(operator.add, extras.values())))
+extras["bot"] = extras["crossbow"] + ["pygithub"]
+extras["all"] = list(set(functools.reduce(operator.add, extras.values())))
 
 setup(
-    name='archery',
+    name="archery",
     version="0.1.0",
-    description='Apache Arrow Developers Tools',
-    url='http://github.com/apache/arrow',
-    maintainer='Arrow Developers',
-    maintainer_email='dev@arrow.apache.org',
+    description="Apache Arrow Developers Tools",
+    url="http://github.com/apache/arrow",
+    maintainer="Arrow Developers",
+    maintainer_email="dev@arrow.apache.org",
     packages=find_packages(),
     include_package_data=True,
-    python_requires='>=3.9',
-    install_requires=['click>=7'],
-    tests_require=['pytest', 'responses'],
+    python_requires=">=3.9",
+    install_requires=["click>=7"],
+    tests_require=["pytest", "responses"],
     extras_require=extras,
-    entry_points='''
+    entry_points="""
         [console_scripts]
         archery=archery.cli:archery
-    '''
+    """,
 )

--- a/dev/archery/setup.py
+++ b/dev/archery/setup.py
@@ -15,11 +15,13 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
 import functools
 import operator
 import sys
-from setuptools import setup, find_packages
+
+from setuptools import find_packages, setup
 
 if sys.version_info < (3, 9):  # noqa: UP036
     sys.exit("Python < 3.9 is not supported")

--- a/dev/archery/setup.py
+++ b/dev/archery/setup.py
@@ -21,8 +21,8 @@ import operator
 import sys
 from setuptools import setup, find_packages
 
-if sys.version_info < (3, 9):
-    sys.exit('Python < 3.9 is not supported')
+if sys.version_info < (3, 9):  # noqa: UP036
+    sys.exit("Python < 3.9 is not supported")
 
 # For pathlib.Path compatibility
 jinja_req = 'jinja2>=2.11'

--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -47,11 +47,11 @@ import requests
 
 # Remote name which points to the GitHub site
 ORG_NAME = (
-    os.environ.get("ARROW_GITHUB_ORG") or
-    os.environ.get("PR_REMOTE_NAME") or  # backward compatibility
-    "apache"
+    os.environ.get("ARROW_GITHUB_ORG")
+    or os.environ.get("PR_REMOTE_NAME")  # backward compatibility
+    or "apache"
 )
-PROJECT_NAME = os.environ.get('ARROW_PROJECT_NAME') or "arrow"
+PROJECT_NAME = os.environ.get("ARROW_PROJECT_NAME") or "arrow"
 
 # For testing to avoid accidentally pushing to apache
 DEBUG = bool(int(os.environ.get("DEBUG", 0)))
@@ -69,7 +69,7 @@ def get_json(url, headers=None):
     # https://docs.github.com/en/rest/guides/using-pagination-in-the-rest-api#using-link-headers
     next_responses = None
     if "link" in response.headers:
-        links = response.headers['link'].split(', ')
+        links = response.headers["link"].split(", ")
         for link in links:
             if 'rel="next"' in link:
                 # Format: '<url>; rel="next"'
@@ -80,37 +80,37 @@ def get_json(url, headers=None):
         if isinstance(responses, list):
             responses.extend(next_responses)
         else:
-            raise ValueError('GitHub response was paginated and is not a list')
+            raise ValueError("GitHub response was paginated and is not a list")
     return responses
 
 
 def run_cmd(cmd):
     if isinstance(cmd, str):
-        cmd = cmd.split(' ')
+        cmd = cmd.split(" ")
 
     try:
         output = subprocess.check_output(cmd)
     except subprocess.CalledProcessError as e:
         # this avoids hiding the stdout / stderr of failed processes
-        print(f'Command failed: {cmd}')
-        print('With output:')
-        print('--------------')
+        print(f"Command failed: {cmd}")
+        print("With output:")
+        print("--------------")
         print(e.output)
-        print('--------------')
+        print("--------------")
         raise e
 
     if isinstance(output, bytes):
-        output = output.decode('utf-8')
+        output = output.decode("utf-8")
     return output
 
 
-_REGEX_CI_DIRECTIVE = re.compile(r'\[[^\]]*\]')
+_REGEX_CI_DIRECTIVE = re.compile(r"\[[^\]]*\]")
 
 
 def strip_ci_directives(commit_message):
     # Remove things like '[force ci]', '[skip appveyor]' from the assembled
     # commit message
-    return _REGEX_CI_DIRECTIVE.sub('', commit_message)
+    return _REGEX_CI_DIRECTIVE.sub("", commit_message)
 
 
 def fix_version_from_branch(versions):
@@ -138,8 +138,9 @@ class GitHubIssue:
     def get_label(self, prefix):
         prefix = f"{prefix}:"
         return [
-            lbl["name"][len(prefix):].strip()
-            for lbl in self.issue["labels"] if lbl["name"].startswith(prefix)
+            lbl["name"][len(prefix) :].strip()
+            for lbl in self.issue["labels"]
+            if lbl["name"].startswith(prefix)
         ]
 
     @property
@@ -187,46 +188,52 @@ class GitHubIssue:
 
     def show(self):
         issue = self.issue
-        print(format_issue_output("github", self.github_id, issue["state"],
-                                  issue["title"], ', '.join(self.assignees),
-                                  self.components))
+        print(
+            format_issue_output(
+                "github",
+                self.github_id,
+                issue["state"],
+                issue["title"],
+                ", ".join(self.assignees),
+                self.components,
+            )
+        )
 
 
-def get_candidate_fix_version(mainline_versions,
-                              maintenance_branches=()):
-
+def get_candidate_fix_version(mainline_versions, maintenance_branches=()):
     all_versions = [getattr(v, "name", v) for v in mainline_versions]
 
     def version_tuple(x):
         # Parquet versions are something like cpp-1.2.0
         numeric_version = getattr(x, "name", x).split("-", 1)[-1]
         return tuple(int(_) for _ in numeric_version.split("."))
+
     all_versions = sorted(all_versions, key=version_tuple, reverse=True)
 
     # Only suggest versions starting with a number, like 0.x but not JS-0.x
     mainline_versions = all_versions
-    major_versions = [v for v in mainline_versions if v.endswith('.0.0')]
+    major_versions = [v for v in mainline_versions if v.endswith(".0.0")]
 
     if len(mainline_versions) > len(major_versions):
         # If there is a future major release, suggest that
         mainline_versions = major_versions
 
-    mainline_versions = [v for v in mainline_versions
-                         if f"maint-{v}" not in maintenance_branches]
+    mainline_versions = [
+        v for v in mainline_versions if f"maint-{v}" not in maintenance_branches
+    ]
     default_fix_versions = fix_version_from_branch(mainline_versions)
 
     return default_fix_versions
 
 
-def format_issue_output(issue_type, issue_id, status,
-                        summary, assignee, components):
+def format_issue_output(issue_type, issue_id, status, summary, assignee, components):
     if not assignee:
         assignee = "NOT ASSIGNED!!!"
     else:
         assignee = getattr(assignee, "displayName", assignee)
 
     if len(components) == 0:
-        components = 'NO COMPONENTS!!!'
+        components = "NO COMPONENTS!!!"
     else:
         components = ", ".join(getattr(x, "name", x) for x in components)
 
@@ -234,7 +241,7 @@ def format_issue_output(issue_type, issue_id, status,
     if "GH" in issue_id:
         url_id = issue_id.replace("GH-", "")
 
-    url = f'https://github.com/{ORG_NAME}/{PROJECT_NAME}/issues/{url_id}'
+    url = f"https://github.com/{ORG_NAME}/{PROJECT_NAME}/issues/{url_id}"
 
     return f"""=== {issue_type.upper()} {issue_id} ===
 Summary\t\t{summary}
@@ -246,104 +253,98 @@ URL\t\t{url}"""
 
 class GitHubAPI:
     def __init__(self, project_name, cmd):
-        self.github_api = (
-            f"https://api.github.com/repos/{ORG_NAME}/{project_name}"
-        )
+        self.github_api = f"https://api.github.com/repos/{ORG_NAME}/{project_name}"
 
         token = None
         config = load_configuration()
         if "github" in config.sections():
             token = config["github"]["api_token"]
         if not token:
-            token = os.environ.get('ARROW_GITHUB_API_TOKEN')
+            token = os.environ.get("ARROW_GITHUB_API_TOKEN")
         if not token:
-            token = cmd.prompt('Env ARROW_GITHUB_API_TOKEN not set, '
-                               'please enter your GitHub API token '
-                               '(GitHub personal access token):')
+            token = cmd.prompt(
+                "Env ARROW_GITHUB_API_TOKEN not set, "
+                "please enter your GitHub API token "
+                "(GitHub personal access token):"
+            )
         headers = {
-            'Accept': 'application/vnd.github.v3+json',
-            'Authorization': f'token {token}',
+            "Accept": "application/vnd.github.v3+json",
+            "Authorization": f"token {token}",
         }
         self.headers = headers
 
     def get_milestones(self):
-        return get_json(f"{self.github_api}/milestones",
-                        headers=self.headers)
+        return get_json(f"{self.github_api}/milestones", headers=self.headers)
 
     def get_milestone_number(self, version):
-        return next((
-            m["number"] for m in self.get_milestones() if m["title"] == version
-        ), None)
+        return next(
+            (m["number"] for m in self.get_milestones() if m["title"] == version), None
+        )
 
     def get_issue_data(self, number):
-        return get_json(f"{self.github_api}/issues/{number}",
-                        headers=self.headers)
+        return get_json(f"{self.github_api}/issues/{number}", headers=self.headers)
 
     def get_pr_data(self, number):
-        return get_json(f"{self.github_api}/pulls/{number}",
-                        headers=self.headers)
+        return get_json(f"{self.github_api}/pulls/{number}", headers=self.headers)
 
     def get_pr_commits(self, number):
-        return get_json(f"{self.github_api}/pulls/{number}/commits",
-                        headers=self.headers)
+        return get_json(
+            f"{self.github_api}/pulls/{number}/commits", headers=self.headers
+        )
 
     def get_branches(self):
-        return get_json(f"{self.github_api}/branches",
-                        headers=self.headers)
+        return get_json(f"{self.github_api}/branches", headers=self.headers)
 
     def close_issue(self, number, comment):
-        issue_url = f'{self.github_api}/issues/{number}'
-        comment_url = f'{self.github_api}/issues/{number}/comments'
+        issue_url = f"{self.github_api}/issues/{number}"
+        comment_url = f"{self.github_api}/issues/{number}/comments"
 
-        r = requests.post(comment_url, json={
-                          "body": comment}, headers=self.headers)
+        r = requests.post(comment_url, json={"body": comment}, headers=self.headers)
         if not r.ok:
             raise ValueError(
-                f"Failed request: {comment_url}:{r.status_code} -> {r.json()}")
+                f"Failed request: {comment_url}:{r.status_code} -> {r.json()}"
+            )
 
-        r = requests.patch(
-            issue_url, json={"state": "closed"}, headers=self.headers)
+        r = requests.patch(issue_url, json={"state": "closed"}, headers=self.headers)
         if not r.ok:
             raise ValueError(
-                f"Failed request: {issue_url}:{r.status_code} -> {r.json()}")
+                f"Failed request: {issue_url}:{r.status_code} -> {r.json()}"
+            )
 
     def assign_milestone(self, number, version):
-        url = f'{self.github_api}/issues/{number}'
+        url = f"{self.github_api}/issues/{number}"
         milestone_number = self.get_milestone_number(version)
         if not milestone_number:
             raise ValueError(f"Invalid version {version}, milestone not found")
-        payload = {
-            'milestone': milestone_number
-        }
+        payload = {"milestone": milestone_number}
         r = requests.patch(url, headers=self.headers, json=payload)
         if not r.ok:
-            raise ValueError(
-                f"Failed request: {url}:{r.status_code} -> {r.json()}")
+            raise ValueError(f"Failed request: {url}:{r.status_code} -> {r.json()}")
         return r.json()
 
     def merge_pr(self, number, commit_title, commit_message):
-        url = f'{self.github_api}/pulls/{number}/merge'
+        url = f"{self.github_api}/pulls/{number}/merge"
         payload = {
-            'commit_title': commit_title,
-            'commit_message': commit_message,
-            'merge_method': 'squash',
+            "commit_title": commit_title,
+            "commit_message": commit_message,
+            "merge_method": "squash",
         }
         response = requests.put(url, headers=self.headers, json=payload)
         result = response.json()
-        if response.status_code == 200 and 'merged' in result:
+        if response.status_code == 200 and "merged" in result:
             self.clear_pr_state_labels(number)
         else:
-            result['merged'] = False
-            result['message'] += f': {url}'
+            result["merged"] = False
+            result["message"] += f": {url}"
         return result
 
     def clear_pr_state_labels(self, number):
-        url = f'{self.github_api}/issues/{number}/labels'
+        url = f"{self.github_api}/issues/{number}/labels"
         response = requests.get(url, headers=self.headers)
         labels = response.json()
         for label in labels:
             # All PR workflow state labels starts with "awaiting"
-            if label['name'].startswith('awaiting'):
+            if label["name"].startswith("awaiting"):
                 label_url = f"{url}/{label['name']}"
                 requests.delete(label_url, headers=self.headers)
 
@@ -417,8 +418,11 @@ class PullRequest:
 
     @property
     def maintenance_branches(self):
-        return [x["name"] for x in self._github_api.get_branches()
-                if x["name"].startswith("maint-")]
+        return [
+            x["name"]
+            for x in self._github_api.get_branches()
+            if x["name"].startswith("maint-")
+        ]
 
     def _get_issue(self):
         if self.title.startswith("MINOR:"):
@@ -429,46 +433,50 @@ class PullRequest:
             github_id = m.group(1)
             return GitHubIssue(self._github_api, github_id, self.cmd)
 
-        self.cmd.fail("PR title should be prefixed by a GitHub ID, like: "
-                      f"GH-XXX, but found {self.title}")
+        self.cmd.fail(
+            "PR title should be prefixed by a GitHub ID, like: "
+            f"GH-XXX, but found {self.title}"
+        )
 
     def merge(self):
         """Merge the requested PR and return the merge hash"""
         commits = self._github_api.get_pr_commits(self.number)
 
         def format_commit_author(commit):
-            author = commit['commit']['author']
-            name = author['name']
-            email = author['email']
-            return f'{name} <{email}>'
+            author = commit["commit"]["author"]
+            name = author["name"]
+            email = author["email"]
+            return f"{name} <{email}>"
+
         commit_authors = [format_commit_author(commit) for commit in commits]
-        co_authored_by_re = re.compile(
-            r'^Co-authored-by:\s*(.*)', re.MULTILINE)
+        co_authored_by_re = re.compile(r"^Co-authored-by:\s*(.*)", re.MULTILINE)
 
         def extract_co_authors(commit):
-            message = commit['commit']['message']
+            message = commit["commit"]["message"]
             return co_authored_by_re.findall(message)
+
         commit_co_authors = []
         for commit in commits:
             commit_co_authors.extend(extract_co_authors(commit))
 
         all_commit_authors = commit_authors + commit_co_authors
-        distinct_authors = sorted(set(all_commit_authors),
-                                  key=lambda x: commit_authors.count(x),
-                                  reverse=True)
+        distinct_authors = sorted(
+            set(all_commit_authors), key=lambda x: commit_authors.count(x), reverse=True
+        )
 
         for i, author in enumerate(distinct_authors):
             print(f"Author {i + 1}: {author}")
 
         if len(distinct_authors) > 1:
             primary_author, distinct_other_authors = get_primary_author(
-                self.cmd, distinct_authors)
+                self.cmd, distinct_authors
+            )
         else:
             # If there is only one author, do not prompt for a lead author
             primary_author = distinct_authors.pop()
             distinct_other_authors = []
 
-        commit_title = f'{self.title} (#{self.number})'
+        commit_title = f"{self.title} (#{self.number})"
         commit_message_chunks = []
         if self.body is not None:
             # Remove comments (i.e. <-- comment -->) from the PR description.
@@ -480,12 +488,14 @@ class PullRequest:
         committer_name = run_cmd("git config --get user.name").strip()
         committer_email = run_cmd("git config --get user.email").strip()
 
-        authors = ("Authored-by:" if len(distinct_other_authors) == 0
-                   else "Lead-authored-by:")
+        authors = (
+            "Authored-by:" if len(distinct_other_authors) == 0 else "Lead-authored-by:"
+        )
         authors += f" {primary_author}"
         if len(distinct_authors) > 0:
-            authors += "\n" + "\n".join([f"Co-authored-by: {a}"
-                                         for a in distinct_other_authors])
+            authors += "\n" + "\n".join(
+                [f"Co-authored-by: {a}" for a in distinct_other_authors]
+            )
         authors += "\n" + f"Signed-off-by: {committer_name} <{committer_email}>"
         commit_message_chunks.append(authors)
 
@@ -506,25 +516,26 @@ class PullRequest:
         if DEBUG:
             merge_hash = None
         else:
-            result = self._github_api.merge_pr(self.number,
-                                               commit_title,
-                                               commit_message)
-            if not result['merged']:
-                message = result['message']
-                self.cmd.fail(f'Failed to merge pull request: {message}')
-            merge_hash = result['sha']
+            result = self._github_api.merge_pr(
+                self.number, commit_title, commit_message
+            )
+            if not result["merged"]:
+                message = result["message"]
+                self.cmd.fail(f"Failed to merge pull request: {message}")
+            merge_hash = result["sha"]
 
         print(f"Pull request #{self.number} merged!")
         print(f"Merge hash: {merge_hash}")
 
 
 def get_primary_author(cmd, distinct_authors):
-    author_pat = re.compile(r'(.*) <(.*)>')
+    author_pat = re.compile(r"(.*) <(.*)>")
 
     while True:
         primary_author = cmd.prompt(
             "Enter primary author in the format of "
-            f"\"name <email>\" [{distinct_authors[0]}]: ")
+            f'"name <email>" [{distinct_authors[0]}]: '
+        )
 
         if primary_author == "":
             return distinct_authors[0], distinct_authors[1:]
@@ -535,24 +546,22 @@ def get_primary_author(cmd, distinct_authors):
 
     # When primary author is specified manually, de-dup it from
     # author list and put it at the head of author list.
-    distinct_other_authors = [x for x in distinct_authors
-                              if x != primary_author]
+    distinct_other_authors = [x for x in distinct_authors if x != primary_author]
     return primary_author, distinct_other_authors
 
 
 def prompt_for_fix_version(cmd, issue, maintenance_branches=()):
     default_fix_version = get_candidate_fix_version(
         mainline_versions=issue.current_versions,
-        maintenance_branches=maintenance_branches
+        maintenance_branches=maintenance_branches,
     )
 
     current_fix_versions = issue.current_fix_versions
-    if (current_fix_versions and
-            current_fix_versions != default_fix_version):
+    if current_fix_versions and current_fix_versions != default_fix_version:
         print("\n=== The assigned milestone is not the default ===")
         print(f"Assigned milestone: {current_fix_versions}")
         print(f"Current milestone: {default_fix_version}")
-        if issue.issue["milestone"].get("state") == 'closed':
+        if issue.issue["milestone"].get("state") == "closed":
             print("The assigned milestone state is closed. Contact the ")
             print("Release Manager if it has to be added to a closed Release")
         print("Please ensure to assign the correct milestone.")
@@ -617,16 +626,14 @@ def cli():
         return
 
     cmd.continue_maybe("Would you like to update the associated issue?")
-    issue_comment = (
-        "Issue resolved by pull request {}\n{}".format(pr_num,
-           f"https://github.com/{ORG_NAME}/{PROJECT_NAME}/pull/{pr_num}")
+    issue_comment = "Issue resolved by pull request {}\n{}".format(
+        pr_num, f"https://github.com/{ORG_NAME}/{PROJECT_NAME}/pull/{pr_num}"
     )
-    fix_version = prompt_for_fix_version(cmd, pr.issue,
-                                         pr.maintenance_branches)
+    fix_version = prompt_for_fix_version(cmd, pr.issue, pr.maintenance_branches)
     pr.issue.resolve(fix_version, issue_comment, pr.body)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     try:
         cli()
     except Exception:

--- a/dev/release/check-rat-report.py
+++ b/dev/release/check-rat-report.py
@@ -35,26 +35,29 @@ with open(exclude_globs_filename) as f:
 
 tree = ET.parse(xml_filename)
 root = tree.getroot()
-resources = root.findall('resource')
+resources = root.findall("resource")
 
 all_ok = True
 for r in resources:
-    approvals = r.findall('license-approval')
-    if not approvals or approvals[0].attrib['name'] == 'true':
+    approvals = r.findall("license-approval")
+    if not approvals or approvals[0].attrib["name"] == "true":
         continue
-    clean_name = re.sub('^[^/]+/', '', r.attrib['name'])
+    clean_name = re.sub("^[^/]+/", "", r.attrib["name"])
     excluded = False
     for g in globs:
         if fnmatch.fnmatch(clean_name, g):
             excluded = True
             break
     if not excluded:
-        sys.stdout.write("NOT APPROVED: {} ({}): {}\n".format(
-            clean_name, r.attrib['name'], approvals[0].attrib['name']))
+        sys.stdout.write(
+            "NOT APPROVED: {} ({}): {}\n".format(
+                clean_name, r.attrib["name"], approvals[0].attrib["name"]
+            )
+        )
         all_ok = False
 
 if not all_ok:
     sys.exit(1)
 
-print('OK')
+print("OK")
 sys.exit(0)

--- a/dev/release/check-rat-report.py
+++ b/dev/release/check-rat-report.py
@@ -16,6 +16,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
 import fnmatch
 import re
@@ -23,8 +24,7 @@ import sys
 import xml.etree.ElementTree as ET
 
 if len(sys.argv) != 3:
-    sys.stderr.write("Usage: %s exclude_globs.lst rat_report.xml\n" %
-                     sys.argv[0])
+    sys.stderr.write(f"Usage: {sys.argv[0]} exclude_globs.lst rat_report.xml\n")
     sys.exit(1)
 
 exclude_globs_filename = sys.argv[1]
@@ -49,7 +49,7 @@ for r in resources:
             excluded = True
             break
     if not excluded:
-        sys.stdout.write("NOT APPROVED: %s (%s): %s\n" % (
+        sys.stdout.write("NOT APPROVED: {} ({}): {}\n".format(
             clean_name, r.attrib['name'], approvals[0].attrib['name']))
         all_ok = False
 

--- a/dev/release/check-rat-report.py
+++ b/dev/release/check-rat-report.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-##############################################################################
+#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -16,7 +16,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-##############################################################################
+
 import fnmatch
 import re
 import sys
@@ -30,7 +30,8 @@ if len(sys.argv) != 3:
 exclude_globs_filename = sys.argv[1]
 xml_filename = sys.argv[2]
 
-globs = [line.strip() for line in open(exclude_globs_filename, "r")]
+with open(exclude_globs_filename) as f:
+    globs = [line.strip() for line in f]
 
 tree = ET.parse(xml_filename)
 root = tree.getroot()

--- a/dev/release/download_rc_binaries.py
+++ b/dev/release/download_rc_binaries.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 
 """Download release binaries."""
+from __future__ import annotations
 
 import argparse
 import concurrent.futures as cf
@@ -28,7 +29,6 @@ import re
 import subprocess
 import time
 import urllib.request
-
 
 DEFAULT_PARALLEL_DOWNLOADS = 8
 
@@ -64,8 +64,7 @@ class Downloader:
 
     def download_files(self, files, dest=None, num_parallel=None,
                        re_match=None):
-        """
-        Download files from Bintray in parallel. If file already exists, will
+        """Download files from Bintray in parallel. If file already exists, will
         overwrite if the checksum does not match what Bintray says it should be
 
         Parameters
@@ -105,7 +104,7 @@ class Downloader:
 
         dest_path = os.path.join(dest_dir, filename)
 
-        print("Downloading {} to {}".format(path, dest_path))
+        print(f"Downloading {path} to {dest_path}")
 
         url = f'{self.URL_ROOT}/{path}'
         self._download_url(url, dest_path)
@@ -254,7 +253,7 @@ ARROW_PACKAGE_TYPES = \
 def download_rc_binaries(version, rc_number, re_match=None, dest=None,
                          num_parallel=None, target_package_type=None,
                          repository=None, tag=None):
-    version_string = '{}-rc{}'.format(version, rc_number)
+    version_string = f'{version}-rc{rc_number}'
     version_pattern = re.compile(r'\d+\.\d+\.\d+')
     if target_package_type:
         package_types = [target_package_type]

--- a/dev/release/download_rc_binaries.py
+++ b/dev/release/download_rc_binaries.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 
 """Download release binaries."""
+
 from __future__ import annotations
 
 import argparse
@@ -34,36 +35,33 @@ DEFAULT_PARALLEL_DOWNLOADS = 8
 
 
 class Downloader:
-
     def get_file_list(self, prefix, filter=None):
         def traverse(directory, files, directories):
-            url = f'{self.URL_ROOT}/{directory}'
+            url = f"{self.URL_ROOT}/{directory}"
             response = urllib.request.urlopen(url).read().decode()
             paths = re.findall('<a href="(.+?)"', response)
             for path in paths:
-                path = re.sub(f'^{re.escape(url)}',
-                              '',
-                              path)
-                if path == '../':
+                path = re.sub(f"^{re.escape(url)}", "", path)
+                if path == "../":
                     continue
-                resolved_path = f'{directory}{path}'
+                resolved_path = f"{directory}{path}"
                 if filter and not filter(path):
                     continue
-                if path.endswith('/'):
+                if path.endswith("/"):
                     directories.append(resolved_path)
                 else:
                     files.append(resolved_path)
+
         files = []
-        if prefix != '' and not prefix.endswith('/'):
-            prefix += '/'
+        if prefix != "" and not prefix.endswith("/"):
+            prefix += "/"
         directories = [prefix]
         while len(directories) > 0:
             directory = directories.pop()
             traverse(directory, files, directories)
         return files
 
-    def download_files(self, files, dest=None, num_parallel=None,
-                       re_match=None):
+    def download_files(self, files, dest=None, num_parallel=None, re_match=None):
         """Download files from Bintray in parallel. If file already exists, will
         overwrite if the checksum does not match what Bintray says it should be
 
@@ -91,9 +89,7 @@ class Downloader:
                 self._download_file(dest, path)
         else:
             parallel_map_terminate_early(
-                functools.partial(self._download_file, dest),
-                files,
-                num_parallel
+                functools.partial(self._download_file, dest), files, num_parallel
             )
 
     def _download_file(self, dest, path):
@@ -106,7 +102,7 @@ class Downloader:
 
         print(f"Downloading {path} to {dest_path}")
 
-        url = f'{self.URL_ROOT}/{path}'
+        url = f"{self.URL_ROOT}/{path}"
         self._download_url(url, dest_path)
 
     def _download_url(self, url, dest_path, *, extra_args=None):
@@ -128,8 +124,7 @@ class Downloader:
                 delay = attempt * 3
                 print(f"Waiting {delay} seconds before retrying {url}")
                 time.sleep(delay)
-            proc = subprocess.Popen(cmd, stdout=subprocess.PIPE,
-                                    stderr=subprocess.PIPE)
+            proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             stdout, stderr = proc.communicate()
             if proc.returncode != 0:
                 with contextlib.suppress(OSError):
@@ -140,8 +135,7 @@ class Downloader:
                     break
             else:
                 return
-        raise Exception(f"Downloading {url} failed\n"
-                        f"stdout: {stdout}\nstderr: {stderr}")
+        raise Exception(f"Downloading {url} failed\nstdout: {stdout}\nstderr: {stderr}")
 
     def _curl_version(self):
         cmd = ["curl", "--version"]
@@ -173,8 +167,9 @@ class GitHub(Downloader):
         self._token = os.environ.get("GH_TOKEN")
 
     def get_file_list(self, prefix, filter=None):
-        url = (f"https://api.github.com/repos/{self._repository}/"
-               f"releases/tags/{self._tag}")
+        url = (
+            f"https://api.github.com/repos/{self._repository}/releases/tags/{self._tag}"
+        )
         print("Fetching release from", url)
         headers = {"Accept": "application/vnd.github+json"}
         if self._token:
@@ -216,11 +211,7 @@ class GitHub(Downloader):
         if self._curl_version() >= (7, 71, 0):
             # Also retry 403s
             extra_args.append("--retry-all-errors")
-        self._download_url(
-            url,
-            dest_path,
-            extra_args=extra_args
-        )
+        self._download_url(url, dest_path, extra_args=extra_args)
 
 
 def parallel_map_terminate_early(f, iterable, num_parallel):
@@ -238,77 +229,105 @@ def parallel_map_terminate_early(f, iterable, num_parallel):
 
 
 ARROW_REPOSITORY_PACKAGE_TYPES = [
-    'almalinux',
-    'amazon-linux',
-    'centos',
-    'debian',
-    'ubuntu',
+    "almalinux",
+    "amazon-linux",
+    "centos",
+    "debian",
+    "ubuntu",
 ]
-ARROW_STANDALONE_PACKAGE_TYPES = ['nuget', 'python']
-ARROW_PACKAGE_TYPES = \
-    ARROW_REPOSITORY_PACKAGE_TYPES + \
-    ARROW_STANDALONE_PACKAGE_TYPES
+ARROW_STANDALONE_PACKAGE_TYPES = ["nuget", "python"]
+ARROW_PACKAGE_TYPES = ARROW_REPOSITORY_PACKAGE_TYPES + ARROW_STANDALONE_PACKAGE_TYPES
 
 
-def download_rc_binaries(version, rc_number, re_match=None, dest=None,
-                         num_parallel=None, target_package_type=None,
-                         repository=None, tag=None):
-    version_string = f'{version}-rc{rc_number}'
-    version_pattern = re.compile(r'\d+\.\d+\.\d+')
+def download_rc_binaries(
+    version,
+    rc_number,
+    re_match=None,
+    dest=None,
+    num_parallel=None,
+    target_package_type=None,
+    repository=None,
+    tag=None,
+):
+    version_string = f"{version}-rc{rc_number}"
+    version_pattern = re.compile(r"\d+\.\d+\.\d+")
     if target_package_type:
         package_types = [target_package_type]
     else:
         package_types = ARROW_PACKAGE_TYPES
     for package_type in package_types:
+
         def is_target(path):
             match = version_pattern.search(path)
             if not match:
                 return True
             return match[0] == version
+
         filter = is_target
 
-        if package_type == 'jars':
+        if package_type == "jars":
             downloader = Maven()
             prefix = ""
         elif package_type in ("github", "nuget"):
             downloader = GitHub(repository, tag)
-            prefix = ''
+            prefix = ""
             filter = None
         elif package_type in ARROW_REPOSITORY_PACKAGE_TYPES:
             downloader = Artifactory()
-            prefix = f'{package_type}-rc'
+            prefix = f"{package_type}-rc"
         else:
             downloader = Artifactory()
-            prefix = f'{package_type}-rc/{version_string}'
+            prefix = f"{package_type}-rc/{version_string}"
             filter = None
         files = downloader.get_file_list(prefix, filter=filter)
-        downloader.download_files(files, re_match=re_match, dest=dest,
-                                  num_parallel=num_parallel)
+        downloader.download_files(
+            files, re_match=re_match, dest=dest, num_parallel=num_parallel
+        )
 
 
-if __name__ == '__main__':
-    parser = argparse.ArgumentParser(
-        description='Download release candidate binaries'
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Download release candidate binaries")
+    parser.add_argument("version", type=str, help="The version number")
+    parser.add_argument(
+        "rc_number", type=int, help="The release candidate number, e.g. 0, 1, etc"
     )
-    parser.add_argument('version', type=str, help='The version number')
-    parser.add_argument('rc_number', type=int,
-                        help='The release candidate number, e.g. 0, 1, etc')
-    parser.add_argument('-e', '--regexp', type=str, default=None,
-                        help=('Regular expression to match on file names '
-                              'to only download certain files'))
-    parser.add_argument('--dest', type=str, default=os.getcwd(),
-                        help='The output folder for the downloaded files')
-    parser.add_argument('--num_parallel', type=int,
-                        default=DEFAULT_PARALLEL_DOWNLOADS,
-                        help='The number of concurrent downloads to do')
-    parser.add_argument('--package_type', type=str, default=None,
-                        help='The package type to be downloaded')
-    parser.add_argument('--repository', type=str,
-                        help=('The repository to pull from '
-                              '(required if --package_type=github)'))
-    parser.add_argument('--tag', type=str,
-                        help=('The release tag to download '
-                              '(required if --package_type=github)'))
+    parser.add_argument(
+        "-e",
+        "--regexp",
+        type=str,
+        default=None,
+        help=(
+            "Regular expression to match on file names to only download certain files"
+        ),
+    )
+    parser.add_argument(
+        "--dest",
+        type=str,
+        default=os.getcwd(),
+        help="The output folder for the downloaded files",
+    )
+    parser.add_argument(
+        "--num_parallel",
+        type=int,
+        default=DEFAULT_PARALLEL_DOWNLOADS,
+        help="The number of concurrent downloads to do",
+    )
+    parser.add_argument(
+        "--package_type",
+        type=str,
+        default=None,
+        help="The package type to be downloaded",
+    )
+    parser.add_argument(
+        "--repository",
+        type=str,
+        help=("The repository to pull from (required if --package_type=github)"),
+    )
+    parser.add_argument(
+        "--tag",
+        type=str,
+        help=("The release tag to download (required if --package_type=github)"),
+    )
     args = parser.parse_args()
 
     download_rc_binaries(

--- a/dev/release/utils-update-docs-versions.py
+++ b/dev/release/utils-update-docs-versions.py
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+from __future__ import annotations
 
 import json
 import sys

--- a/dev/release/utils-update-docs-versions.py
+++ b/dev/release/utils-update-docs-versions.py
@@ -59,19 +59,25 @@ if release_type != "patch":
     if stable_compatible_version != previous_compatible_version:
         # Create new versions
         new_versions = [
-            {"name": f"{dev_compatible_version} (dev)",
-             "version": "dev/",
-             "url": "https://arrow.apache.org/docs/dev/"},
-            {"name": f"{stable_compatible_version} (stable)",
-             "version": "",
-             "url": "https://arrow.apache.org/docs/",
-             "preferred": True},
-            {"name": previous_compatible_version,
-             "version": f"{previous_compatible_version}/",
-             "url": f"https://arrow.apache.org/docs/{previous_compatible_version}/"},
+            {
+                "name": f"{dev_compatible_version} (dev)",
+                "version": "dev/",
+                "url": "https://arrow.apache.org/docs/dev/",
+            },
+            {
+                "name": f"{stable_compatible_version} (stable)",
+                "version": "",
+                "url": "https://arrow.apache.org/docs/",
+                "preferred": True,
+            },
+            {
+                "name": previous_compatible_version,
+                "version": f"{previous_compatible_version}/",
+                "url": f"https://arrow.apache.org/docs/{previous_compatible_version}/",
+            },
             *old_versions[2:],
         ]
-        with open(main_versions_path, 'w') as json_file:
+        with open(main_versions_path, "w") as json_file:
             json.dump(new_versions, json_file, indent=4)
             json_file.write("\n")
 
@@ -104,7 +110,7 @@ else:
         {"name": f"{release_r_version} (release)", "version": ""},
         *old_r_versions[2:],
     ]
-with open(r_versions_path, 'w') as json_file:
+with open(r_versions_path, "w") as json_file:
     json.dump(new_r_versions, json_file, indent=4)
     json_file.write("\n")
 
@@ -113,8 +119,8 @@ with open(r_versions_path) as json_file:
     data = json.load(json_file)
 
 # Write HTML to file
-with open(r_html_path, 'w') as html_file:
-    html_file.write('<!DOCTYPE html>\n<html>\n<body>')
+with open(r_html_path, "w") as html_file:
+    html_file.write("<!DOCTYPE html>\n<html>\n<body>")
     for i in data:
         html_file.write(f'<p><a href="../{i["version"]}r/">{i["name"]}</a></p>\n')
-    html_file.write('</body>\n</html>\n')
+    html_file.write("</body>\n</html>\n")

--- a/dev/ruff.toml
+++ b/dev/ruff.toml
@@ -1,0 +1,159 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+line-length = 88
+indent-width = 4
+
+# Assume Python 3.9
+target-version = "py39"
+
+[format]
+# Like Black, use double quotes for strings.
+quote-style = "double"
+
+# Like Black, indent with spaces, rather than tabs.
+indent-style = "space"
+
+# Like Black, respect magic trailing commas.
+skip-magic-trailing-comma = true
+
+# Like Black, automatically detect the appropriate line ending.
+line-ending = "auto"
+
+# Enable auto-formatting of code examples in docstrings. Markdown,
+# reStructuredText code/literal blocks and doctests are all supported.
+#
+# This is currently disabled by default, but it is planned for this
+# to be opt-out in the future.
+docstring-code-format = true
+
+# Set the line length limit used when formatting code snippets in
+# docstrings.
+#
+# This only has an effect when the `docstring-code-format` setting is
+# enabled.
+docstring-code-line-length = 88
+
+[lint]
+select = [
+  "B",   # flake8-bugbear
+  "BLE", # flake8-blind-except
+  "C4",  # comprehensions
+  "D",   # pydocstyle
+  "E",   # pycodestyle
+  "EXE", # flake8-executable
+  "F",   # pyflakes
+  "FA",  # flake8-future-annotations
+  "FLY", # flynt (format string conversion)
+  "G",   # flake8-logging-format
+  "I",   # isort
+  "ICN", # flake8-import-conventions
+  "INP", # flake8-no-pep420 (implicit namespace packages)
+  "ISC", # flake8-implicit-str-concat
+  "PGH", # pygrep-hooks
+  "PIE", # flake8-pie
+  "PL",  # pylint
+  "RET", # flake8-return
+  "RUF", # ruff-specific rules
+  "S",   # flake8-bandit
+  "SIM", # flake8-simplify
+  "T10", # flake8-debugger
+  "T20", # flake8-print
+  "TCH", # flake8-type-checking
+  "TID", # flake8-tidy-imports
+  "UP",  # pyupgrade
+  "W",   # pycodestyle
+  "YTT", # flake8-2020
+]
+ignore = [
+  "B003",    # Assigning to `os.environ` doesn't clear the environment
+  "B017",    # `pytest.raises(Exception)` should be considered evil
+  "B019",    # Use of `functools.lru_cache` or `functools.cache` on methods can lead to memory leaks
+  "B027",    # `CDataExporter.run_gc` is an empty method in an abstract base class, but has no abstract decorator
+  "B904",    # raise from e or raise from None in exception handlers
+  "BLE001",  # Do not catch blind exception: `Exception`
+  "C408",    # Unnecessary `dict()` call (rewrite as a literal)
+  "D100",    # public module
+  "D101",    # public class
+  "D102",    # public method
+  "D103",    # public function
+  "D104",    # public package
+  "D105",    # magic methods
+  "D106",    # nested class
+  "D107",    # init
+  "D200",    # One-line docstring should fit on one line
+  "D203",    # blank line before class docstring
+  "D205",    # 1 blank line required between summary line and description
+  "D210",    # No whitespaces allowed surrounding docstring text
+  "D213",    # Multi-line docstring summary should start at the second line
+  "D301",    # Use `r"""` if any backslashes in a docstring
+  "D400",    # First line should end with a period
+  "D401",    # Imperative mood
+  "D402",    # First line should not be the function's signature
+  "D413",    # Blank line required after last section
+  "D415",    # First line should end with a period, question mark, or exclamation point
+  "D417",    # Missing argument descriptions in the docstring
+  "FLY002",  # Consider `f"{}.{}"` instead of string join"
+  "G004",    # Logging statement uses f-string
+  "ICN001",  # `xml.etree.ElementTree` should be imported as `ET`
+  "INP001",  # implicit-namespace-package
+  "ISC001",  # single line implicit string concat, handled by ruff format
+  "PLR0911", # too many return statements
+  "PLR0912", # too many branches
+  "PLR0913", # too many arguments
+  "PLR0915", # too many statements
+  "PLR2004", # forces everything to be a constant
+  "PLW0603", # Using the global statement to update `variable` is discouraged
+  "PLW1510", # `subprocess.run` without explicit `check` argument
+  "PLW2901", # overwriting loop variable
+  "RET503",  # Missing explicit `return` at the end of function able to return non-`None` value
+  "RET504",  # unnecessary-assign, these are useful for debugging
+  "RET505",  # superfluous-else-return, stylistic choice
+  "RET506",  # superfluous-else-raise, stylistic choice
+  "RET507",  # superfluous-else-continue, stylistic choice
+  "RET508",  # superfluous-else-break, stylistic choice
+  "RUF005",  # splat instead of concat
+  "RUF012",  # Mutable class attributes should be annotated with `typing.ClassVar`
+  "S101",    # ignore "Use of `assert` detected"
+  "S113",    # Probable use of `requests` call without timeout
+  "S310",    # Audit URL open for permitted schemes. Allowing use of `file:` or custom schemes is often unexpected.
+  "S311",    # Standard pseudo-random generators are not suitable for cryptographic purposes
+  "S314",    # Using `xml` to parse untrusted data is known to be vulnerable to XML attacks; use `defusedxml` equivalents
+  "S603",    # `subprocess` call: check for execution of untrusted input
+  "S607",    # Starting a process with a partial executable path
+  "S701",    # By default, jinja2 sets `autoescape` to `False`. Consider using `autoescape=True` or the `select_autoescape` function to mitigate XSS vulnerabilities.
+  "SIM108",  # convert everything to ternary operator
+  "SIM112",  # Use capitalized environment variable `DOTNET_GCHEAPHARDLIMIT` instead of `DOTNET_GCHeapHardLimit`
+  "SIM117",  # Use a single `with` statement with multiple contexts instead of nested `with` statements
+  "T201",    # `print` found
+  "T203",    # `pprint` found
+  "TID252",  # Prefer absolute imports over relative imports from parent modules
+  "UP006",   # Use `list` instead of `List` for type annotation
+  "UP007",   # Optional[str] -> str | None
+  "UP035",   # `typing.List` is deprecated, use `list` instead
+]
+# none of these codes will be automatically fixed by ruff
+unfixable = [
+  "T201",   # print statements
+  "F401",   # unused imports
+  "RUF100", # unused noqa comments
+  "F841",   # unused variables
+]
+
+[lint.isort]
+required-imports = ["from __future__ import annotations"]
+split-on-trailing-comma = false

--- a/dev/test_merge_arrow_pr.py
+++ b/dev/test_merge_arrow_pr.py
@@ -24,37 +24,40 @@ import pytest
 
 import merge_arrow_pr
 
-FakeIssue = namedtuple('issue', ['fields'])
+FakeIssue = namedtuple("issue", ["fields"])
 FakeFields = namedtuple(
-    'fields', ['assignees', 'labels', 'milestone', 'state', 'title'])
-FakeAssignee = namedtuple('assignees', ['login'])
-FakeLabel = namedtuple('label', ['name'])
-FakeMilestone = namedtuple('milestone', ['title', 'state'])
+    "fields", ["assignees", "labels", "milestone", "state", "title"]
+)
+FakeAssignee = namedtuple("assignees", ["login"])
+FakeLabel = namedtuple("label", ["name"])
+FakeMilestone = namedtuple("milestone", ["title", "state"])
 
 RAW_VERSION_JSON = [
-    {'title': 'JS-0.4.0', 'state': 'open'},
-    {'title': '1.0.0', 'state': 'open'},
-    {'title': '2.0.0', 'state': 'open'},
-    {'title': '0.9.0', 'state': 'open'},
-    {'title': '0.10.0', 'state': 'open'},
-    {'title': '0.8.0', 'state': 'closed'},
-    {'title': '0.7.0', 'state': 'closed'}
+    {"title": "JS-0.4.0", "state": "open"},
+    {"title": "1.0.0", "state": "open"},
+    {"title": "2.0.0", "state": "open"},
+    {"title": "0.9.0", "state": "open"},
+    {"title": "0.10.0", "state": "open"},
+    {"title": "0.8.0", "state": "closed"},
+    {"title": "0.7.0", "state": "closed"},
 ]
 
-SOURCE_VERSIONS = [FakeMilestone(raw['title'], raw['state'])
-                   for raw in RAW_VERSION_JSON]
-fake_issue_id = 'GH-1234'
-fields = FakeFields([FakeAssignee('groundhog')._asdict()],
-                    [FakeLabel('Component: C++')._asdict(),
-                     FakeLabel('Component: Format')._asdict()],
-                    FakeMilestone('', 'open')._asdict(),
-                    'open', '[C++][Format] The issue Title')
+SOURCE_VERSIONS = [
+    FakeMilestone(raw["title"], raw["state"]) for raw in RAW_VERSION_JSON
+]
+fake_issue_id = "GH-1234"
+fields = FakeFields(
+    [FakeAssignee("groundhog")._asdict()],
+    [FakeLabel("Component: C++")._asdict(), FakeLabel("Component: Format")._asdict()],
+    FakeMilestone("", "open")._asdict(),
+    "open",
+    "[C++][Format] The issue Title",
+)
 FAKE_ISSUE_1 = FakeIssue(fields)
 
 
 class FakeGitHub:
-
-    def __init__(self, issues=None, project_versions=None, state='open'):
+    def __init__(self, issues=None, project_versions=None, state="open"):
         self._issues = issues
         self._project_versions = project_versions
         self._state = state
@@ -66,13 +69,11 @@ class FakeGitHub:
 
     @property
     def current_versions(self):
-        return [
-            v.title for v in self._project_versions if v.state != 'closed'
-        ]
+        return [v.title for v in self._project_versions if v.state != "closed"]
 
     @property
     def current_fix_versions(self):
-        return 'JS-0.4.0'
+        return "JS-0.4.0"
 
     @property
     def state(self):
@@ -86,12 +87,13 @@ class FakeGitHub:
 
     def assign_milestone(self, issue_id, milestone):
         self._transitions.append(
-            {'action': 'assign_milestone', 'issue_id': issue_id,
-             'milestone': milestone})
+            {"action": "assign_milestone", "issue_id": issue_id, "milestone": milestone}
+        )
 
     def close_issue(self, issue_id, comment):
         self._transitions.append(
-            {'action': 'close_issue', 'issue_id': issue_id, 'comment': comment})
+            {"action": "close_issue", "issue_id": issue_id, "comment": comment}
+        )
 
     @property
     def captured_transitions(self):
@@ -99,7 +101,6 @@ class FakeGitHub:
 
 
 class FakeCLI:
-
     def __init__(self, responses=()):
         self.responses = responses
         self.position = 0
@@ -114,49 +115,45 @@ class FakeCLI:
 
 
 def test_gh_fix_versions():
-    gh = FakeGitHub(issues={fake_issue_id: FAKE_ISSUE_1},
-                    project_versions=SOURCE_VERSIONS)
+    gh = FakeGitHub(
+        issues={fake_issue_id: FAKE_ISSUE_1}, project_versions=SOURCE_VERSIONS
+    )
 
     issue = merge_arrow_pr.GitHubIssue(gh, fake_issue_id, FakeCLI())
-    fix_version = merge_arrow_pr.get_candidate_fix_version(
-        issue.current_versions
-    )
-    assert fix_version == '1.0.0'
+    fix_version = merge_arrow_pr.get_candidate_fix_version(issue.current_versions)
+    assert fix_version == "1.0.0"
 
 
 def test_gh_fix_versions_filters_maintenance():
     maintenance_branches = ["maint-1.0.0"]
-    gh = FakeGitHub(issues={fake_issue_id: FAKE_ISSUE_1},
-                    project_versions=SOURCE_VERSIONS)
+    gh = FakeGitHub(
+        issues={fake_issue_id: FAKE_ISSUE_1}, project_versions=SOURCE_VERSIONS
+    )
 
     issue = merge_arrow_pr.GitHubIssue(gh, fake_issue_id, FakeCLI())
     fix_version = merge_arrow_pr.get_candidate_fix_version(
-        issue.current_versions,
-        maintenance_branches=maintenance_branches
+        issue.current_versions, maintenance_branches=maintenance_branches
     )
-    assert fix_version == '2.0.0'
+    assert fix_version == "2.0.0"
 
 
 def test_gh_only_suggest_major_release():
     versions_json = [
-        {'name': '0.9.1', 'state': "open"},
-        {'name': '0.10.0', 'state': "open"},
-        {'name': '1.0.0', 'state': "open"},
+        {"name": "0.9.1", "state": "open"},
+        {"name": "0.10.0", "state": "open"},
+        {"name": "1.0.0", "state": "open"},
     ]
 
-    versions = [FakeMilestone(raw['name'], raw['state']) for raw in versions_json]
+    versions = [FakeMilestone(raw["name"], raw["state"]) for raw in versions_json]
 
     gh = FakeGitHub(issues={fake_issue_id: FAKE_ISSUE_1}, project_versions=versions)
     issue = merge_arrow_pr.GitHubIssue(gh, fake_issue_id, FakeCLI())
-    fix_version = merge_arrow_pr.get_candidate_fix_version(
-        issue.current_versions
-    )
-    assert fix_version == '1.0.0'
+    fix_version = merge_arrow_pr.get_candidate_fix_version(issue.current_versions)
+    assert fix_version == "1.0.0"
 
 
 def test_gh_invalid_issue():
     class Mock:
-
         def issue(self, gh_id):
             raise Exception("not found")
 
@@ -165,124 +162,142 @@ def test_gh_invalid_issue():
 
 
 def test_gh_resolve():
-    gh = FakeGitHub(issues={fake_issue_id: FAKE_ISSUE_1},
-                    project_versions=SOURCE_VERSIONS)
+    gh = FakeGitHub(
+        issues={fake_issue_id: FAKE_ISSUE_1}, project_versions=SOURCE_VERSIONS
+    )
 
-    my_comment = 'my comment'
+    my_comment = "my comment"
     fix_version = "0.10.0"
 
     issue = merge_arrow_pr.GitHubIssue(gh, fake_issue_id, FakeCLI())
     issue.resolve(fix_version, my_comment, pr_body="")
 
     assert len(gh.captured_transitions) == 2
-    assert gh.captured_transitions[0]['action'] == 'assign_milestone'
-    assert gh.captured_transitions[1]['action'] == 'close_issue'
-    assert gh.captured_transitions[1]['comment'] == my_comment
-    assert gh.captured_transitions[0]['milestone'] == fix_version
+    assert gh.captured_transitions[0]["action"] == "assign_milestone"
+    assert gh.captured_transitions[1]["action"] == "close_issue"
+    assert gh.captured_transitions[1]["comment"] == my_comment
+    assert gh.captured_transitions[0]["milestone"] == fix_version
 
 
 def test_gh_resolve_non_mainline():
-    gh = FakeGitHub(issues={fake_issue_id: FAKE_ISSUE_1},
-                    project_versions=SOURCE_VERSIONS)
+    gh = FakeGitHub(
+        issues={fake_issue_id: FAKE_ISSUE_1}, project_versions=SOURCE_VERSIONS
+    )
 
-    my_comment = 'my comment'
+    my_comment = "my comment"
     fix_version = "JS-0.4.0"
 
     issue = merge_arrow_pr.GitHubIssue(gh, fake_issue_id, FakeCLI())
     issue.resolve(fix_version, my_comment, "")
 
     assert len(gh.captured_transitions) == 2
-    assert gh.captured_transitions[1]['comment'] == my_comment
-    assert gh.captured_transitions[0]['milestone'] == fix_version
+    assert gh.captured_transitions[1]["comment"] == my_comment
+    assert gh.captured_transitions[0]["milestone"] == fix_version
 
 
 def test_gh_resolve_released_fix_version():
     # ARROW-5083
-    gh = FakeGitHub(issues={fake_issue_id: FAKE_ISSUE_1},
-                    project_versions=SOURCE_VERSIONS)
+    gh = FakeGitHub(
+        issues={fake_issue_id: FAKE_ISSUE_1}, project_versions=SOURCE_VERSIONS
+    )
 
-    cmd = FakeCLI(responses=['1.0.0'])
+    cmd = FakeCLI(responses=["1.0.0"])
     fix_versions_json = merge_arrow_pr.prompt_for_fix_version(cmd, gh)
     assert fix_versions_json == "1.0.0"
 
 
 def test_multiple_authors_bad_input():
-    a0 = 'Jimbob Crawfish <jimbob.crawfish@gmail.com>'
-    a1 = 'Jarvis McCratchett <jarvis.mccratchett@hotmail.com>'
-    a2 = 'Hank Miller <hank.miller@protonmail.com>'
+    a0 = "Jimbob Crawfish <jimbob.crawfish@gmail.com>"
+    a1 = "Jarvis McCratchett <jarvis.mccratchett@hotmail.com>"
+    a2 = "Hank Miller <hank.miller@protonmail.com>"
     distinct_authors = [a0, a1]
 
-    cmd = FakeCLI(responses=[''])
-    primary_author, distinct_other_authors = \
-        merge_arrow_pr.get_primary_author(cmd, distinct_authors)
+    cmd = FakeCLI(responses=[""])
+    primary_author, distinct_other_authors = merge_arrow_pr.get_primary_author(
+        cmd, distinct_authors
+    )
     assert primary_author == a0
     assert distinct_other_authors == [a1]
 
-    cmd = FakeCLI(responses=['oops', a1])
-    primary_author, distinct_other_authors = \
-        merge_arrow_pr.get_primary_author(cmd, distinct_authors)
+    cmd = FakeCLI(responses=["oops", a1])
+    primary_author, distinct_other_authors = merge_arrow_pr.get_primary_author(
+        cmd, distinct_authors
+    )
     assert primary_author == a1
     assert distinct_other_authors == [a0]
 
     cmd = FakeCLI(responses=[a2])
-    primary_author, distinct_other_authors = \
-        merge_arrow_pr.get_primary_author(cmd, distinct_authors)
+    primary_author, distinct_other_authors = merge_arrow_pr.get_primary_author(
+        cmd, distinct_authors
+    )
     assert primary_author == a2
     assert distinct_other_authors == [a0, a1]
 
 
 def test_gh_already_resolved():
-    fields = FakeFields([FakeAssignee('groundhog')._asdict()],
-                        [FakeLabel('Component: Java')._asdict()],
-                        FakeMilestone('', 'open')._asdict(),
-                        'closed', '[Java] The issue Title')
+    fields = FakeFields(
+        [FakeAssignee("groundhog")._asdict()],
+        [FakeLabel("Component: Java")._asdict()],
+        FakeMilestone("", "open")._asdict(),
+        "closed",
+        "[Java] The issue Title",
+    )
     issue = FakeIssue(fields)
 
-    gh = FakeGitHub(issues={fake_issue_id: issue},
-                    project_versions=SOURCE_VERSIONS)
+    gh = FakeGitHub(issues={fake_issue_id: issue}, project_versions=SOURCE_VERSIONS)
 
     fix_versions = [SOURCE_VERSIONS[0]._asdict()]
     issue = merge_arrow_pr.GitHubIssue(gh, fake_issue_id, FakeCLI())
 
-    with pytest.raises(Exception,
-                       match="GitHub issue GH-1234 already has status 'closed'"):
+    with pytest.raises(
+        Exception, match="GitHub issue GH-1234 already has status 'closed'"
+    ):
         issue.resolve(fix_versions, "", "")
 
 
 def test_gh_output_no_components():
     # ARROW-5472
-    status = 'Interesting work'
+    status = "Interesting work"
     output = merge_arrow_pr.format_issue_output(
-        'github', 'GH-1234', 'Resolved', status,
-        'username', []
+        "github", "GH-1234", "Resolved", status, "username", []
     )
 
-    assert output == """=== GITHUB GH-1234 ===
+    assert (
+        output
+        == """=== GITHUB GH-1234 ===
 Summary\t\tInteresting work
 Assignee\tusername
 Components\tNO COMPONENTS!!!
 Status\t\tResolved
 URL\t\thttps://github.com/apache/arrow/issues/1234"""
-
-    output = merge_arrow_pr.format_issue_output(
-        'github', 'GH-1234', 'Resolved', status, 'username',
-        [FakeLabel('C++'), FakeLabel('Python')]
     )
 
-    assert output == """=== GITHUB GH-1234 ===
+    output = merge_arrow_pr.format_issue_output(
+        "github",
+        "GH-1234",
+        "Resolved",
+        status,
+        "username",
+        [FakeLabel("C++"), FakeLabel("Python")],
+    )
+
+    assert (
+        output
+        == """=== GITHUB GH-1234 ===
 Summary\t\tInteresting work
 Assignee\tusername
 Components\tC++, Python
 Status\t\tResolved
 URL\t\thttps://github.com/apache/arrow/issues/1234"""
+    )
 
 
 def test_sorting_versions():
     versions_json = [
-        {'title': '11.0.0', 'state': 'open'},
-        {'title': '9.0.0', 'state': 'open'},
-        {'title': '10.0.0', 'state': 'open'},
+        {"title": "11.0.0", "state": "open"},
+        {"title": "9.0.0", "state": "open"},
+        {"title": "10.0.0", "state": "open"},
     ]
-    versions = [FakeMilestone(raw['title'], raw['state']) for raw in versions_json]
+    versions = [FakeMilestone(raw["title"], raw["state"]) for raw in versions_json]
     fix_version = merge_arrow_pr.get_candidate_fix_version([x.title for x in versions])
     assert fix_version == "9.0.0"

--- a/dev/test_merge_arrow_pr.py
+++ b/dev/test_merge_arrow_pr.py
@@ -16,13 +16,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from __future__ import annotations
 
 from collections import namedtuple
 
 import pytest
 
 import merge_arrow_pr
-
 
 FakeIssue = namedtuple('issue', ['fields'])
 FakeFields = namedtuple(
@@ -67,7 +67,7 @@ class FakeGitHub:
     @property
     def current_versions(self):
         return [
-            v.title for v in self._project_versions if not v.state == 'closed'
+            v.title for v in self._project_versions if v.state != 'closed'
         ]
 
     @property

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1958,7 +1958,8 @@ cdef class Array(_PandasConvertible):
                     inner_array = pyarrow_unwrap_array(casted_array)
                 except ArrowInvalid as e:
                     raise ValueError(
-                        f"Could not cast {self.type} to requested type {target_type}: {e}"
+                        f"Could not cast {self.type} to requested "
+                        f"type {target_type}: {e}"
                     )
             else:
                 inner_array = self.sp_array
@@ -2103,7 +2104,8 @@ cdef class Array(_PandasConvertible):
                     inner_array = pyarrow_unwrap_array(casted_array)
                 except ArrowInvalid as e:
                     raise ValueError(
-                        f"Could not cast {self.type} to requested type {target_type}: {e}"
+                        f"Could not cast {self.type} to requested "
+                        f"type {target_type}: {e}"
                     )
             else:
                 inner_array = self.sp_array

--- a/python/pyarrow/lib.pyx
+++ b/python/pyarrow/lib.pyx
@@ -177,7 +177,8 @@ def _ensure_cuda_loaded():
     if __cuda_loaded is not True:
         raise ImportError(
             "Trying to import data on a CUDA device, but PyArrow is not built with "
-            f"CUDA support.\n(importing 'pyarrow.cuda' resulted in \"{__cuda_loaded}\")."
+            "CUDA support.\n"
+            f"(importing 'pyarrow.cuda' resulted in \"{__cuda_loaded}\")."
         )
 
 

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -1409,7 +1409,8 @@ cdef class ChunkedArray(_PandasConvertible):
                     chunked = self.cast(target_type, safe=True)
                 except ArrowInvalid as e:
                     raise ValueError(
-                        f"Could not cast {self.type} to requested type {target_type}: {e}"
+                        f"Could not cast {self.type} to requested "
+                        f"type {target_type}: {e}"
                     )
             else:
                 chunked = self
@@ -3818,7 +3819,8 @@ cdef class RecordBatch(_Tabular):
                     inner_batch = pyarrow_unwrap_batch(casted_batch)
                 except ArrowInvalid as e:
                     raise ValueError(
-                        f"Could not cast {self.schema} to requested schema {target_schema}: {e}"
+                        f"Could not cast {self.schema} to requested "
+                        f"schema {target_schema}: {e}"
                     )
             else:
                 inner_batch = self.sp_batch
@@ -3997,7 +3999,8 @@ cdef class RecordBatch(_Tabular):
                     inner_batch = pyarrow_unwrap_batch(casted_batch)
                 except ArrowInvalid as e:
                     raise ValueError(
-                        f"Could not cast {self.schema} to requested schema {target_schema}: {e}"
+                        f"Could not cast {self.schema} to requested "
+                        f"schema {target_schema}: {e}"
                     )
             else:
                 inner_batch = self.sp_batch

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -25,6 +25,7 @@ import sys
 import tempfile
 import textwrap
 import threading
+
 import time
 from shutil import copytree
 from urllib.parse import quote
@@ -1546,10 +1547,15 @@ def test_parquet_fragment_statistics(tempdir):
 
     fragment = list(dataset.get_fragments())[0]
 
-    import datetime
-    def dt_s(x): return datetime.datetime(1970, 1, 1, 0, 0, x)
-    def dt_ms(x): return datetime.datetime(1970, 1, 1, 0, 0, 0, x*1000)
-    def dt_us(x): return datetime.datetime(1970, 1, 1, 0, 0, 0, x)
+    def dt_s(x):
+        return datetime.datetime(1970, 1, 1, 0, 0, x)
+
+    def dt_ms(x):
+        return datetime.datetime(1970, 1, 1, 0, 0, 0, x*1000)
+
+    def dt_us(x):
+        return datetime.datetime(1970, 1, 1, 0, 0, 0, x)
+
     date = datetime.date
     time = datetime.time
 

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -4054,9 +4054,11 @@ def test_nested_with_timestamp_tz():
         if unit in ['s', 'ms']:
             # This is used for verifying timezone conversion to micros are not
             # important
-            def truncate(x): return x.replace(microsecond=0)
+            def truncate(x):
+                return x.replace(microsecond=0)
         else:
-            def truncate(x): return x
+            def truncate(x):
+                return x
         arr = pa.array([ts], type=pa.timestamp(unit))
         arr2 = pa.array([ts], type=pa.timestamp(unit, tz='America/New_York'))
 

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -148,7 +148,8 @@ cdef void* _as_c_pointer(v, allow_null=False) except *:
         else:
             capsule_name_str = capsule_name.decode()
             raise ValueError(
-                f"Can't convert PyCapsule with name '{capsule_name_str}' to pointer address"
+                f"Can't convert PyCapsule with name '{capsule_name_str}' "
+                "to pointer address"
             )
     else:
         raise TypeError(f"Expected a pointer value, got {type(v)!r}")

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -34,8 +34,11 @@ filterwarnings =
 faulthandler_timeout = 300
 
 [pep8]
-ignore = E211,E225,E226,E227,E402,W503,W504
+ignore = E203,E211,E225,E226,E227,E402,W503,W504
 max_line_length = 88
 
 [flake8]
+ignore = E203,E211,E225,E226,E227,E402,W503,W504
 max-line-length = 88
+
+


### PR DESCRIPTION
I am aware that this is a somewhat controversial topic, but black/ruff are becoming standard nowadays and can can save us a significant amount of manual work. While cython isn’t supported by either of these tools, we have plenty of pure Python code where we could benefit from modern automatic formatting. I understand that we have different style preferences, but maintaining consistency without an auto formatter is simply too time consuming. 

Here I configured `ruff` to be used on the developer tools under the `dev/` directory. I applied formatting and configured a list rules to exclude when running `ruff check dev/`. Some of these rules would make sense to enable, but I wanted to keep manual edits low for now, we can enable those incrementally in follow-ups.

