### PR TITLE
MINOR: [R] Remove whitespace after operator""

### DIFF
--- a/r/src/filesystem.cpp
+++ b/r/src/filesystem.cpp
@@ -438,7 +438,7 @@ std::shared_ptr<fs::GcsFileSystem> fs___GcsFileSystem__Make(bool anonymous,
 
 // [[gcs::export]]
 cpp11::list fs___GcsFileSystem__options(const std::shared_ptr<fs::GcsFileSystem>& fs) {
-  using cpp11::literals::operator"" _nm;
+  using cpp11::literals::operator""_nm;
 
   cpp11::writable::list out;
 


### PR DESCRIPTION
### Rationale for this change

The space after "" is deprecated since it creates ambiguity with reserved _-initial names per:

https://en.cppreference.com/w/cpp/language/user_literal

### What changes are included in this PR?

Whitespace change:

```diff
-operator"" _nm
+operator""_nm
```

### Are these changes tested?

No

### Are there any user-facing changes?

No