### PR TITLE
GH-45733: [C++][Python] Add biased/unbiased toggle to skew and kurtosis functions

### DIFF
--- a/cpp/src/arrow/acero/hash_aggregate_test.cc
+++ b/cpp/src/arrow/acero/hash_aggregate_test.cc
@@ -1504,11 +1504,12 @@ TEST_P(GroupBy, VarianceOptionsAndSkewOptions) {
       /*ddof=*/0, /*skip_nulls=*/false, /*min_count=*/3);
 
   auto skew_keep_nulls = std::make_shared<SkewOptions>(/*skip_nulls=*/false,
+                                                       /*bias=*/true,
                                                        /*min_count=*/0);
   auto skew_min_count =
-      std::make_shared<SkewOptions>(/*skip_nulls=*/true, /*min_count=*/3);
+      std::make_shared<SkewOptions>(/*skip_nulls=*/true, /*bias=*/true, /*min_count=*/3);
   auto skew_keep_nulls_min_count = std::make_shared<SkewOptions>(
-      /*skip_nulls=*/false, /*min_count=*/3);
+      /*skip_nulls=*/false, /*bias=*/true, /*min_count=*/3);
 
   for (std::string value_column : {"argument", "argument1"}) {
     for (bool use_threads : {false}) {

--- a/cpp/src/arrow/acero/hash_aggregate_test.cc
+++ b/cpp/src/arrow/acero/hash_aggregate_test.cc
@@ -1504,15 +1504,15 @@ TEST_P(GroupBy, VarianceOptionsAndSkewOptions) {
       /*ddof=*/0, /*skip_nulls=*/false, /*min_count=*/3);
 
   auto skew_keep_nulls = std::make_shared<SkewOptions>(/*skip_nulls=*/false,
-                                                       /*bias=*/true,
+                                                       /*biased=*/true,
                                                        /*min_count=*/0);
-  auto skew_min_count =
-      std::make_shared<SkewOptions>(/*skip_nulls=*/true, /*bias=*/true, /*min_count=*/3);
+  auto skew_min_count = std::make_shared<SkewOptions>(/*skip_nulls=*/true,
+                                                      /*biased=*/true, /*min_count=*/3);
   auto skew_keep_nulls_min_count = std::make_shared<SkewOptions>(
-      /*skip_nulls=*/false, /*bias=*/true, /*min_count=*/3);
+      /*skip_nulls=*/false, /*biased=*/true, /*min_count=*/3);
 
   auto skew_unbiased = std::make_shared<SkewOptions>(
-      /*skip_nulls=*/false, /*bias=*/false, /*min_count=*/0);
+      /*skip_nulls=*/false, /*biased=*/false, /*min_count=*/0);
 
   for (std::string value_column : {"argument", "argument1"}) {
     for (bool use_threads : {false}) {

--- a/cpp/src/arrow/acero/hash_aggregate_test.cc
+++ b/cpp/src/arrow/acero/hash_aggregate_test.cc
@@ -1579,7 +1579,7 @@ TEST_P(GroupBy, VarianceOptionsAndSkewOptions) {
                                R"([
          [1, null,      0.707106,  null,     null,    null,      -1.5,      null,      null    ],
          [2, 0.213833,  0.213833,  0.213833, 0.37037, -1.720164, -1.720164, -1.720164, -3.90123],
-         [3, 0.0,       null,      null,     -NaN,    -2.0,       null,     null,      -NaN    ],
+         [3, 0.0,       null,      null,     NaN,     -2.0,       null,     null,      NaN     ],
          [4, null,      0.707106,  null,     null,    null,      -1.5,      null,      null    ]
          ])");
       ValidateOutput(actual);

--- a/cpp/src/arrow/acero/hash_aggregate_test.cc
+++ b/cpp/src/arrow/acero/hash_aggregate_test.cc
@@ -1579,7 +1579,7 @@ TEST_P(GroupBy, VarianceOptionsAndSkewOptions) {
                                R"([
          [1, null,      0.707106,  null,     null,    null,      -1.5,      null,      null    ],
          [2, 0.213833,  0.213833,  0.213833, 0.37037, -1.720164, -1.720164, -1.720164, -3.90123],
-         [3, 0.0,       null,      null,     NaN,     -2.0,       null,     null,      NaN     ],
+         [3, 0.0,       null,      null,     null,    -2.0,       null,     null,      null    ],
          [4, null,      0.707106,  null,     null,    null,      -1.5,      null,      null    ]
          ])");
       ValidateOutput(actual);

--- a/cpp/src/arrow/compute/api_aggregate.cc
+++ b/cpp/src/arrow/compute/api_aggregate.cc
@@ -111,6 +111,7 @@ static auto kVarianceOptionsType = GetFunctionOptionsType<VarianceOptions>(
     DataMember("min_count", &VarianceOptions::min_count));
 static auto kSkewOptionsType = GetFunctionOptionsType<SkewOptions>(
     DataMember("skip_nulls", &SkewOptions::skip_nulls),
+    DataMember("bias", &SkewOptions::bias),
     DataMember("min_count", &SkewOptions::min_count));
 static auto kQuantileOptionsType = GetFunctionOptionsType<QuantileOptions>(
     DataMember("q", &QuantileOptions::q),
@@ -154,9 +155,10 @@ VarianceOptions::VarianceOptions(int ddof, bool skip_nulls, uint32_t min_count)
       min_count(min_count) {}
 constexpr char VarianceOptions::kTypeName[];
 
-SkewOptions::SkewOptions(bool skip_nulls, uint32_t min_count)
+SkewOptions::SkewOptions(bool skip_nulls, bool bias, uint32_t min_count)
     : FunctionOptions(internal::kSkewOptionsType),
       skip_nulls(skip_nulls),
+      bias(bias),
       min_count(min_count) {}
 
 QuantileOptions::QuantileOptions(double q, enum Interpolation interpolation,

--- a/cpp/src/arrow/compute/api_aggregate.cc
+++ b/cpp/src/arrow/compute/api_aggregate.cc
@@ -111,7 +111,7 @@ static auto kVarianceOptionsType = GetFunctionOptionsType<VarianceOptions>(
     DataMember("min_count", &VarianceOptions::min_count));
 static auto kSkewOptionsType = GetFunctionOptionsType<SkewOptions>(
     DataMember("skip_nulls", &SkewOptions::skip_nulls),
-    DataMember("bias", &SkewOptions::bias),
+    DataMember("biased", &SkewOptions::biased),
     DataMember("min_count", &SkewOptions::min_count));
 static auto kQuantileOptionsType = GetFunctionOptionsType<QuantileOptions>(
     DataMember("q", &QuantileOptions::q),
@@ -155,10 +155,10 @@ VarianceOptions::VarianceOptions(int ddof, bool skip_nulls, uint32_t min_count)
       min_count(min_count) {}
 constexpr char VarianceOptions::kTypeName[];
 
-SkewOptions::SkewOptions(bool skip_nulls, bool bias, uint32_t min_count)
+SkewOptions::SkewOptions(bool skip_nulls, bool biased, uint32_t min_count)
     : FunctionOptions(internal::kSkewOptionsType),
       skip_nulls(skip_nulls),
-      bias(bias),
+      biased(biased),
       min_count(min_count) {}
 
 QuantileOptions::QuantileOptions(double q, enum Interpolation interpolation,

--- a/cpp/src/arrow/compute/api_aggregate.h
+++ b/cpp/src/arrow/compute/api_aggregate.h
@@ -124,6 +124,9 @@ class ARROW_EXPORT SkewOptions : public FunctionOptions {
   /// If true (the default), null values are ignored. Otherwise, if any value is null,
   /// emit null.
   bool skip_nulls;
+  /// If true (the default), the calculated value is biased. If false, the calculated
+  /// value includes a correction factor to reduce bias, making it more accurate for
+  /// small sample sizes.
   bool bias;
   /// If less than this many non-null values are observed, emit null.
   uint32_t min_count;

--- a/cpp/src/arrow/compute/api_aggregate.h
+++ b/cpp/src/arrow/compute/api_aggregate.h
@@ -117,7 +117,8 @@ class ARROW_EXPORT VarianceOptions : public FunctionOptions {
 /// \brief Control Skew and Kurtosis kernel behavior
 class ARROW_EXPORT SkewOptions : public FunctionOptions {
  public:
-  explicit SkewOptions(bool skip_nulls = true, bool bias = true, uint32_t min_count = 0);
+  explicit SkewOptions(bool skip_nulls = true, bool biased = true,
+                       uint32_t min_count = 0);
   static constexpr char const kTypeName[] = "SkewOptions";
   static SkewOptions Defaults() { return SkewOptions{}; }
 
@@ -127,7 +128,7 @@ class ARROW_EXPORT SkewOptions : public FunctionOptions {
   /// If true (the default), the calculated value is biased. If false, the calculated
   /// value includes a correction factor to reduce bias, making it more accurate for
   /// small sample sizes.
-  bool bias;
+  bool biased;
   /// If less than this many non-null values are observed, emit null.
   uint32_t min_count;
 };

--- a/cpp/src/arrow/compute/api_aggregate.h
+++ b/cpp/src/arrow/compute/api_aggregate.h
@@ -117,13 +117,14 @@ class ARROW_EXPORT VarianceOptions : public FunctionOptions {
 /// \brief Control Skew and Kurtosis kernel behavior
 class ARROW_EXPORT SkewOptions : public FunctionOptions {
  public:
-  explicit SkewOptions(bool skip_nulls = true, uint32_t min_count = 0);
+  explicit SkewOptions(bool skip_nulls = true, bool bias = true, uint32_t min_count = 0);
   static constexpr char const kTypeName[] = "SkewOptions";
   static SkewOptions Defaults() { return SkewOptions{}; }
 
   /// If true (the default), null values are ignored. Otherwise, if any value is null,
   /// emit null.
   bool skip_nulls;
+  bool bias;
   /// If less than this many non-null values are observed, emit null.
   uint32_t min_count;
 };

--- a/cpp/src/arrow/compute/kernels/aggregate_test.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_test.cc
@@ -3694,7 +3694,7 @@ TEST_F(TestSkewKurtosis, Options) {
     AssertSkewKurtosisAre(type, "[0, 1, null, 2]", options, 0.0, -1.5);
     AssertSkewKurtosisAre(type, {"[0, 1]", "[]", "[null, 2]"}, options, 0.0, -1.5);
     options.biased = false;
-    AssertSkewKurtosisAre(type, {"[0, 1]", "[]", "[null, 2]"}, options, 0.0, NAN);
+    AssertSkewKurtosisInvalid(type, "[0, 1]", options);
     AssertSkewKurtosisAre(type, {"[1, 2, 3]", "[40, null]"}, options, 1.9889477403978211,
                           3.9631931024230695);
     options.biased = true;

--- a/cpp/src/arrow/compute/kernels/aggregate_test.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_test.cc
@@ -3693,11 +3693,11 @@ TEST_F(TestSkewKurtosis, Options) {
     AssertSkewKurtosisInvalid(type, {"[]", "[]", "[]"}, options);
     AssertSkewKurtosisAre(type, "[0, 1, null, 2]", options, 0.0, -1.5);
     AssertSkewKurtosisAre(type, {"[0, 1]", "[]", "[null, 2]"}, options, 0.0, -1.5);
-    options.bias = false;
+    options.biased = false;
     AssertSkewKurtosisAre(type, {"[0, 1]", "[]", "[null, 2]"}, options, 0.0, NAN);
     AssertSkewKurtosisAre(type, {"[1, 2, 3]", "[40, null]"}, options, 1.9889477403978211,
                           3.9631931024230695);
-    options.bias = true;
+    options.biased = true;
     options.min_count = 3;
     AssertSkewKurtosisAre(type, "[0, 1, null, 2]", options, 0.0, -1.5);
     AssertSkewKurtosisAre(type, {"[0, 1]", "[]", "[null, 2]"}, options, 0.0, -1.5);

--- a/cpp/src/arrow/compute/kernels/aggregate_test.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_test.cc
@@ -3694,7 +3694,7 @@ TEST_F(TestSkewKurtosis, Options) {
     AssertSkewKurtosisAre(type, "[0, 1, null, 2]", options, 0.0, -1.5);
     AssertSkewKurtosisAre(type, {"[0, 1]", "[]", "[null, 2]"}, options, 0.0, -1.5);
     options.bias = false;
-    AssertSkewKurtosisAre(type, {"[0, 1]", "[]", "[null, 2]"}, options, 0.0, -NAN);
+    AssertSkewKurtosisAre(type, {"[0, 1]", "[]", "[null, 2]"}, options, 0.0, NAN);
     AssertSkewKurtosisAre(type, {"[1, 2, 3]", "[40, null]"}, options, 1.9889477403978211,
                           3.9631931024230695);
     options.bias = true;

--- a/cpp/src/arrow/compute/kernels/aggregate_test.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_test.cc
@@ -3693,6 +3693,11 @@ TEST_F(TestSkewKurtosis, Options) {
     AssertSkewKurtosisInvalid(type, {"[]", "[]", "[]"}, options);
     AssertSkewKurtosisAre(type, "[0, 1, null, 2]", options, 0.0, -1.5);
     AssertSkewKurtosisAre(type, {"[0, 1]", "[]", "[null, 2]"}, options, 0.0, -1.5);
+    options.bias = false;
+    AssertSkewKurtosisAre(type, {"[0, 1]", "[]", "[null, 2]"}, options, 0.0, -NAN);
+    AssertSkewKurtosisAre(type, {"[1, 2, 3]", "[40, null]"}, options, 1.9889477403978211,
+                          3.9631931024230695);
+    options.bias = true;
     options.min_count = 3;
     AssertSkewKurtosisAre(type, "[0, 1, null, 2]", options, 0.0, -1.5);
     AssertSkewKurtosisAre(type, {"[0, 1]", "[]", "[null, 2]"}, options, 0.0, -1.5);

--- a/cpp/src/arrow/compute/kernels/aggregate_var_std.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_var_std.cc
@@ -198,7 +198,9 @@ struct StatisticImpl : public ScalarAggregator {
 
   Status Finalize(KernelContext*, Datum* out) override {
     if (state.count() <= ddof || state.count() < min_count ||
-        (!state.all_valid && !skip_nulls)) {
+        (!state.all_valid && !skip_nulls) ||
+        (stat_type == StatisticType::Skew && !biased && state.count() < 3) ||
+        (stat_type == StatisticType::Kurtosis && !biased && state.count() < 4)) {
       out->value = std::make_shared<DoubleScalar>();
     } else {
       switch (stat_type) {

--- a/cpp/src/arrow/compute/kernels/aggregate_var_std.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_var_std.cc
@@ -176,6 +176,7 @@ struct StatisticImpl : public ScalarAggregator {
       : out_type(out_type),
         stat_type(stat_type),
         skip_nulls(options.skip_nulls),
+        bias(options.bias),
         min_count(options.min_count),
         ddof(0),
         state(moments_level_for_statistic(stat_type), decimal_scale, skip_nulls) {}
@@ -208,7 +209,7 @@ struct StatisticImpl : public ScalarAggregator {
           out->value = std::make_shared<DoubleScalar>(state.moments.Variance(ddof));
           break;
         case StatisticType::Skew:
-          out->value = std::make_shared<DoubleScalar>(state.moments.Skew());
+          out->value = std::make_shared<DoubleScalar>(state.moments.Skew(bias));
           break;
         case StatisticType::Kurtosis:
           out->value = std::make_shared<DoubleScalar>(state.moments.Kurtosis());
@@ -224,6 +225,7 @@ struct StatisticImpl : public ScalarAggregator {
   std::shared_ptr<DataType> out_type;
   StatisticType stat_type;
   bool skip_nulls;
+  bool bias;
   uint32_t min_count;
   int ddof = 0;
   MomentsState<ArrowType> state;

--- a/cpp/src/arrow/compute/kernels/aggregate_var_std.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_var_std.cc
@@ -212,7 +212,7 @@ struct StatisticImpl : public ScalarAggregator {
           out->value = std::make_shared<DoubleScalar>(state.moments.Skew(bias));
           break;
         case StatisticType::Kurtosis:
-          out->value = std::make_shared<DoubleScalar>(state.moments.Kurtosis());
+          out->value = std::make_shared<DoubleScalar>(state.moments.Kurtosis(bias));
           break;
         default:
           return Status::NotImplemented("Unsupported statistic type ",

--- a/cpp/src/arrow/compute/kernels/aggregate_var_std.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_var_std.cc
@@ -176,7 +176,7 @@ struct StatisticImpl : public ScalarAggregator {
       : out_type(out_type),
         stat_type(stat_type),
         skip_nulls(options.skip_nulls),
-        bias(options.bias),
+        biased(options.biased),
         min_count(options.min_count),
         ddof(0),
         state(moments_level_for_statistic(stat_type), decimal_scale, skip_nulls) {}
@@ -209,10 +209,10 @@ struct StatisticImpl : public ScalarAggregator {
           out->value = std::make_shared<DoubleScalar>(state.moments.Variance(ddof));
           break;
         case StatisticType::Skew:
-          out->value = std::make_shared<DoubleScalar>(state.moments.Skew(bias));
+          out->value = std::make_shared<DoubleScalar>(state.moments.Skew(biased));
           break;
         case StatisticType::Kurtosis:
-          out->value = std::make_shared<DoubleScalar>(state.moments.Kurtosis(bias));
+          out->value = std::make_shared<DoubleScalar>(state.moments.Kurtosis(biased));
           break;
         default:
           return Status::NotImplemented("Unsupported statistic type ",
@@ -225,7 +225,7 @@ struct StatisticImpl : public ScalarAggregator {
   std::shared_ptr<DataType> out_type;
   StatisticType stat_type;
   bool skip_nulls;
-  bool bias;
+  bool biased;
   uint32_t min_count;
   int ddof = 0;
   MomentsState<ArrowType> state;

--- a/cpp/src/arrow/compute/kernels/aggregate_var_std_internal.h
+++ b/cpp/src/arrow/compute/kernels/aggregate_var_std_internal.h
@@ -86,8 +86,7 @@ struct Moments {
 
   double Skew(bool biased = true) const {
     double result;
-    // This may return NaN for m2 == 0 and m3 == 0, which is expected
-    // or if unbiased and not enough samples (count < 2).
+    // This may return NaN for m2 == 0 and m3 == 0, which is expected.
     if (biased) {
       result = sqrt(count) * m3 / sqrt(m2 * m2 * m2);
     } else {
@@ -100,8 +99,7 @@ struct Moments {
 
   double Kurtosis(bool biased = true) const {
     double result;
-    // This may return NaN for m2 == 0 and m4 == 0, which is expected
-    // or if unbiased and not enough samples (count < 3).
+    // This may return NaN for m2 == 0 and m4 == 0, which is expected.
     if (biased) {
       result = count * m4 / (m2 * m2) - 3;
     } else {

--- a/cpp/src/arrow/compute/kernels/aggregate_var_std_internal.h
+++ b/cpp/src/arrow/compute/kernels/aggregate_var_std_internal.h
@@ -84,11 +84,11 @@ struct Moments {
 
   double Stddev(int ddof) const { return sqrt(Variance(ddof)); }
 
-  double Skew(bool bias = true) const {
+  double Skew(bool biased = true) const {
     double result;
     // This may return NaN for m2 == 0 and m3 == 0, which is expected
     // or if unbiased and not enough samples (count < 2).
-    if (bias) {
+    if (biased) {
       result = sqrt(count) * m3 / sqrt(m2 * m2 * m2);
     } else {
       auto m2_avg = m2 / count;
@@ -98,11 +98,11 @@ struct Moments {
     return result;
   }
 
-  double Kurtosis(bool bias = true) const {
+  double Kurtosis(bool biased = true) const {
     double result;
     // This may return NaN for m2 == 0 and m4 == 0, which is expected
     // or if unbiased and not enough samples (count < 3).
-    if (bias) {
+    if (biased) {
       result = count * m4 / (m2 * m2) - 3;
     } else {
       auto m2_avg = m2 / count;

--- a/cpp/src/arrow/compute/kernels/aggregate_var_std_internal.h
+++ b/cpp/src/arrow/compute/kernels/aggregate_var_std_internal.h
@@ -103,8 +103,8 @@ struct Moments {
       result = count * m4 / (m2 * m2) - 3;
     } else {
       result = 1.0 / (count - 2) / (count - 3) *
-               ((pow(count, 2) - 1.0) * (m4 / count) / pow((m2 / count), 2.0) -
-                3 * pow((count - 1), 2.0));
+               ((pow(count, 2) - 1.0) * (m4 / count) / pow((m2 / count), 2) -
+                3 * pow((count - 1), 2));
     }
     return result;
   }

--- a/cpp/src/arrow/compute/kernels/aggregate_var_std_internal.h
+++ b/cpp/src/arrow/compute/kernels/aggregate_var_std_internal.h
@@ -96,9 +96,17 @@ struct Moments {
     return result;
   }
 
-  double Kurtosis() const {
+  double Kurtosis(bool bias = true) const {
+    double result;
     // This may return NaN for m2 == 0 and m4 == 0, which is expected
-    return count * m4 / (m2 * m2) - 3;
+    if (bias) {
+      result = count * m4 / (m2 * m2) - 3;
+    } else {
+      result = 1.0 / (count - 2) / (count - 3) *
+               ((pow(count, 2) - 1.0) * (m4 / count) / pow((m2 / count), 2.0) -
+                3 * pow((count - 1), 2.0));
+    }
+    return result;
   }
 
   void MergeFrom(int level, const Moments& other) { *this = Merge(level, *this, other); }

--- a/cpp/src/arrow/compute/kernels/aggregate_var_std_internal.h
+++ b/cpp/src/arrow/compute/kernels/aggregate_var_std_internal.h
@@ -84,9 +84,16 @@ struct Moments {
 
   double Stddev(int ddof) const { return sqrt(Variance(ddof)); }
 
-  double Skew() const {
+  double Skew(bool bias = true) const {
+    double result;
     // This may return NaN for m2 == 0 and m3 == 0, which is expected
-    return sqrt(count) * m3 / sqrt(m2 * m2 * m2);
+    if (bias) {
+      result = sqrt(count) * m3 / sqrt(m2 * m2 * m2);
+    } else {
+      result =
+          sqrt(count * (count - 1)) / (count - 2) * (m3 / count) / pow((m2 / count), 1.5);
+    }
+    return result;
   }
 
   double Kurtosis() const {

--- a/cpp/src/arrow/compute/kernels/aggregate_var_std_internal.h
+++ b/cpp/src/arrow/compute/kernels/aggregate_var_std_internal.h
@@ -91,8 +91,9 @@ struct Moments {
     if (bias) {
       result = sqrt(count) * m3 / sqrt(m2 * m2 * m2);
     } else {
-      result =
-          sqrt(count * (count - 1)) / (count - 2) * (m3 / count) / pow((m2 / count), 1.5);
+      auto m2_avg = m2 / count;
+      result = sqrt(count * (count - 1)) / (count - 2) * (m3 / count) /
+               sqrt(m2_avg * m2_avg * m2_avg);
     }
     return result;
   }
@@ -104,9 +105,10 @@ struct Moments {
     if (bias) {
       result = count * m4 / (m2 * m2) - 3;
     } else {
-      result = 1.0 / (count - 2) / (count - 3) *
-               ((pow(count, 2) - 1.0) * (m4 / count) / pow((m2 / count), 2) -
-                3 * pow((count - 1), 2));
+      auto m2_avg = m2 / count;
+      result = 1.0 / ((count - 2) * (count - 3)) *
+               (((count * count) - 1.0) * (m4 / count) / (m2_avg * m2_avg) -
+                3 * ((count - 1) * (count - 1)));
     }
     return result;
   }

--- a/cpp/src/arrow/compute/kernels/aggregate_var_std_internal.h
+++ b/cpp/src/arrow/compute/kernels/aggregate_var_std_internal.h
@@ -87,6 +87,7 @@ struct Moments {
   double Skew(bool bias = true) const {
     double result;
     // This may return NaN for m2 == 0 and m3 == 0, which is expected
+    // or if unbiased and not enough samples (count < 2).
     if (bias) {
       result = sqrt(count) * m3 / sqrt(m2 * m2 * m2);
     } else {
@@ -99,6 +100,7 @@ struct Moments {
   double Kurtosis(bool bias = true) const {
     double result;
     // This may return NaN for m2 == 0 and m4 == 0, which is expected
+    // or if unbiased and not enough samples (count < 3).
     if (bias) {
       result = count * m4 / (m2 * m2) - 3;
     } else {

--- a/cpp/src/arrow/compute/kernels/hash_aggregate_numeric.cc
+++ b/cpp/src/arrow/compute/kernels/hash_aggregate_numeric.cc
@@ -452,37 +452,37 @@ struct GroupedStatisticImpl : public GroupedAggregator {
   Status InitInternal(ExecContext* ctx, const KernelInitArgs& args,
                       StatisticType stat_type, const VarianceOptions& options) {
     return InitInternal(ctx, args, stat_type, options.ddof, options.skip_nulls,
-                        /*bias=*/false, options.min_count);
+                        /*biased=*/false, options.min_count);
   }
 
   // Init helper for hash_skew and hash_kurtosis
   Status InitInternal(ExecContext* ctx, const KernelInitArgs& args,
                       StatisticType stat_type, const SkewOptions& options) {
     return InitInternal(ctx, args, stat_type, /*ddof=*/0, options.skip_nulls,
-                        options.bias, options.min_count);
+                        options.biased, options.min_count);
   }
 
   Status InitInternal(ExecContext* ctx, const KernelInitArgs& args,
-                      StatisticType stat_type, int ddof, bool skip_nulls, bool bias,
+                      StatisticType stat_type, int ddof, bool skip_nulls, bool biased,
                       uint32_t min_count) {
     if constexpr (is_decimal_type<Type>::value) {
       int32_t decimal_scale =
           checked_cast<const DecimalType&>(*args.inputs[0].type).scale();
-      return InitInternal(ctx, stat_type, decimal_scale, ddof, skip_nulls, bias,
+      return InitInternal(ctx, stat_type, decimal_scale, ddof, skip_nulls, biased,
                           min_count);
     } else {
-      return InitInternal(ctx, stat_type, /*decimal_scale=*/0, ddof, skip_nulls, bias,
+      return InitInternal(ctx, stat_type, /*decimal_scale=*/0, ddof, skip_nulls, biased,
                           min_count);
     }
   }
 
   Status InitInternal(ExecContext* ctx, StatisticType stat_type, int32_t decimal_scale,
-                      int ddof, bool skip_nulls, bool bias, uint32_t min_count) {
+                      int ddof, bool skip_nulls, bool biased, uint32_t min_count) {
     stat_type_ = stat_type;
     moments_level_ = moments_level_for_statistic(stat_type_);
     decimal_scale_ = decimal_scale;
     skip_nulls_ = skip_nulls;
-    bias_ = bias;
+    biased_ = biased;
     min_count_ = min_count;
     ddof_ = ddof;
     ctx_ = ctx;
@@ -541,7 +541,7 @@ struct GroupedStatisticImpl : public GroupedAggregator {
   Status ConsumeGeneric(const ExecSpan& batch) {
     GroupedStatisticImpl<Type> state;
     RETURN_NOT_OK(state.InitInternal(ctx_, stat_type_, decimal_scale_, ddof_, skip_nulls_,
-                                     bias_, min_count_));
+                                     biased_, min_count_));
     RETURN_NOT_OK(state.Resize(num_groups_));
     int64_t* counts = state.counts_.mutable_data();
     double* means = state.means_.mutable_data();
@@ -614,7 +614,7 @@ struct GroupedStatisticImpl : public GroupedAggregator {
       var_std.resize(num_groups_);
       GroupedStatisticImpl<Type> state;
       RETURN_NOT_OK(state.InitInternal(ctx_, stat_type_, decimal_scale_, ddof_,
-                                       skip_nulls_, bias_, min_count_));
+                                       skip_nulls_, biased_, min_count_));
       RETURN_NOT_OK(state.Resize(num_groups_));
       int64_t* other_counts = state.counts_.mutable_data();
       double* other_means = state.means_.mutable_data();
@@ -751,10 +751,10 @@ struct GroupedStatisticImpl : public GroupedAggregator {
             results[i] = moments.Stddev(ddof_);
             break;
           case StatisticType::Skew:
-            results[i] = moments.Skew(bias_);
+            results[i] = moments.Skew(biased_);
             break;
           case StatisticType::Kurtosis:
-            results[i] = moments.Kurtosis(bias_);
+            results[i] = moments.Kurtosis(biased_);
             break;
           default:
             return Status::NotImplemented("Statistic type ",
@@ -811,7 +811,7 @@ struct GroupedStatisticImpl : public GroupedAggregator {
   int moments_level_;
   int32_t decimal_scale_;
   bool skip_nulls_;
-  bool bias_;
+  bool biased_;
   uint32_t min_count_;
   int ddof_;
   int64_t num_groups_ = 0;

--- a/cpp/src/arrow/compute/kernels/hash_aggregate_numeric.cc
+++ b/cpp/src/arrow/compute/kernels/hash_aggregate_numeric.cc
@@ -741,7 +741,9 @@ struct GroupedStatisticImpl : public GroupedAggregator {
     const double* m3s = m3s_data();
     const double* m4s = m4s_data();
     for (int64_t i = 0; i < num_groups_; ++i) {
-      if (counts[i] > ddof_ && counts[i] >= min_count_) {
+      if (counts[i] > ddof_ && counts[i] >= min_count_ &&
+          (stat_type_ != StatisticType::Skew || biased_ || counts[i] > 2) &&
+          (stat_type_ != StatisticType::Kurtosis || biased_ || counts[i] > 3)) {
         const auto moments = Moments(counts[i], means[i], m2s[i], m3s[i], m4s[i]);
         switch (stat_type_) {
           case StatisticType::Var:

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -1909,8 +1909,8 @@ class VarianceOptions(_VarianceOptions):
 
 
 cdef class _SkewOptions(FunctionOptions):
-    def _set_options(self, skip_nulls, bias, min_count):
-        self.wrapped.reset(new CSkewOptions(skip_nulls, bias, min_count))
+    def _set_options(self, skip_nulls, biased, min_count):
+        self.wrapped.reset(new CSkewOptions(skip_nulls, biased, min_count))
 
 
 class SkewOptions(_SkewOptions):
@@ -1920,14 +1920,14 @@ class SkewOptions(_SkewOptions):
     Parameters
     ----------
     {_skip_nulls_doc()}
-    bias : bool, default True
+    biased : bool, default True
         Whether the calculated value is biased.
         If False, the value computed includes a corrections factor to reduce bias.
     {_min_count_doc(default=0)}
     """
 
-    def __init__(self, *, skip_nulls=True, bias=True, min_count=0):
-        self._set_options(skip_nulls, bias, min_count)
+    def __init__(self, *, skip_nulls=True, biased=True, min_count=0):
+        self._set_options(skip_nulls, biased, min_count)
 
 
 cdef class _SplitOptions(FunctionOptions):

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -1920,6 +1920,9 @@ class SkewOptions(_SkewOptions):
     Parameters
     ----------
     {_skip_nulls_doc()}
+    bias : bool, default True
+        Whether the calculated value is biased.
+        If False, the value computed includes a corrections factor to reduce bias.
     {_min_count_doc(default=0)}
     """
 

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -1922,7 +1922,7 @@ class SkewOptions(_SkewOptions):
     {_skip_nulls_doc()}
     biased : bool, default True
         Whether the calculated value is biased.
-        If False, the value computed includes a corrections factor to reduce bias.
+        If False, the value computed includes a correction factor to reduce bias.
     {_min_count_doc(default=0)}
     """
 

--- a/python/pyarrow/_compute.pyx
+++ b/python/pyarrow/_compute.pyx
@@ -1909,8 +1909,8 @@ class VarianceOptions(_VarianceOptions):
 
 
 cdef class _SkewOptions(FunctionOptions):
-    def _set_options(self, skip_nulls, min_count):
-        self.wrapped.reset(new CSkewOptions(skip_nulls, min_count))
+    def _set_options(self, skip_nulls, bias, min_count):
+        self.wrapped.reset(new CSkewOptions(skip_nulls, bias, min_count))
 
 
 class SkewOptions(_SkewOptions):
@@ -1923,8 +1923,8 @@ class SkewOptions(_SkewOptions):
     {_min_count_doc(default=0)}
     """
 
-    def __init__(self, *, skip_nulls=True, min_count=0):
-        self._set_options(skip_nulls, min_count)
+    def __init__(self, *, skip_nulls=True, bias=True, min_count=0):
+        self._set_options(skip_nulls, bias, min_count)
 
 
 cdef class _SplitOptions(FunctionOptions):

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -2628,8 +2628,9 @@ cdef extern from "arrow/compute/api.h" namespace "arrow::compute" nogil:
 
     cdef cppclass CSkewOptions \
             "arrow::compute::SkewOptions"(CFunctionOptions):
-        CSkewOptions(c_bool skip_nulls, uint32_t min_count)
+        CSkewOptions(c_bool skip_nulls, c_bool bias, uint32_t min_count)
         c_bool skip_nulls
+        c_bool bias
         uint32_t min_count
 
     cdef cppclass CScalarAggregateOptions \

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -2628,9 +2628,9 @@ cdef extern from "arrow/compute/api.h" namespace "arrow::compute" nogil:
 
     cdef cppclass CSkewOptions \
             "arrow::compute::SkewOptions"(CFunctionOptions):
-        CSkewOptions(c_bool skip_nulls, c_bool bias, uint32_t min_count)
+        CSkewOptions(c_bool skip_nulls, c_bool biased, uint32_t min_count)
         c_bool skip_nulls
-        c_bool bias
+        c_bool biased
         uint32_t min_count
 
     cdef cppclass CScalarAggregateOptions \

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -3841,7 +3841,8 @@ def test_pivot_wider():
 
 
 @pytest.mark.pandas
-def test_biased_skew_and_kurtosis():
+def test_unbiased_skew_and_kurtosis():
+    # Validate computing unbiased skew and kurtosis matches pandas
     input = [1.0, 2.0, 3.0, 40.0, None]
     arrow_skew = pc.skew(input, skip_nulls=True, bias=False)
     pandas_skew = pd.Series(np.array(input)).skew(skipna=True)

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -3838,3 +3838,10 @@ def test_pivot_wider():
     with pytest.raises(ValueError, match="Encountered more than one non-null value"):
         result = pc.pivot_wider(["height", "width", "height"], [10, None, 11],
                                 key_names=key_names)
+
+
+@pytest.mark.pandas
+def test_biased_skew():
+    arrow_skew = pc.skew([1.0, 2.0, 3.0, 40.0, None], skip_nulls=True, bias=False)
+    pandas_skew = pd.Series(np.array([1.0, 2.0, 3.0, 40.0, np.nan])).skew(skipna=True)
+    assert arrow_skew == pa.scalar(pandas_skew)

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -3844,9 +3844,9 @@ def test_pivot_wider():
 @pytest.mark.parametrize("input", ([1.0, 2.0, 3.0, 40.0, None], [1, 40]))
 def test_unbiased_skew_and_kurtosis(input):
     # Validate computing unbiased skew and kurtosis matches pandas
-    arrow_skew = pc.skew(input, skip_nulls=True, bias=False)
+    arrow_skew = pc.skew(input, skip_nulls=True, biased=False)
     pandas_skew = pd.Series(np.array(input)).skew(skipna=True)
-    arrow_kurtosis = pc.kurtosis(input, skip_nulls=True, bias=False)
+    arrow_kurtosis = pc.kurtosis(input, skip_nulls=True, biased=False)
     pandas_kurtosis = pd.Series(np.array(input)).kurtosis(skipna=True)
 
     if len(input) > 2:

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -457,6 +457,21 @@ def test_kurtosis():
     assert pc.kurtosis(data, min_count=4).as_py() is None
 
 
+@pytest.mark.parametrize("input, expected", (
+    (
+        [1.0, 2.0, 3.0, 40.0, None],
+        {'skew': 1.988947740397821, 'kurtosis': 3.9631931024230695}
+    ),
+    ([1, 2, 40], {'skew': 1.7281098503730385, 'kurtosis': None}),
+    ([1, 40], {'skew': None, 'kurtosis': None}),
+))
+def test_unbiased_skew_and_kurtosis(input, expected):
+    arrow_skew = pc.skew(input, skip_nulls=True, biased=False)
+    arrow_kurtosis = pc.kurtosis(input, skip_nulls=True, biased=False)
+    assert arrow_skew == pa.scalar(expected['skew'], type=pa.float64())
+    assert arrow_kurtosis == pa.scalar(expected['kurtosis'], type=pa.float64())
+
+
 def test_count_substring():
     for (ty, offset) in [(pa.string(), pa.int32()),
                          (pa.large_string(), pa.int64())]:
@@ -3838,18 +3853,3 @@ def test_pivot_wider():
     with pytest.raises(ValueError, match="Encountered more than one non-null value"):
         result = pc.pivot_wider(["height", "width", "height"], [10, None, 11],
                                 key_names=key_names)
-
-
-@pytest.mark.parametrize("input, expected", (
-    (
-        [1.0, 2.0, 3.0, 40.0, None],
-        {'skew': 1.988947740397821, 'kurtosis': 3.9631931024230695}
-    ),
-    ([1, 2, 40], {'skew': 1.7281098503730385, 'kurtosis': None}),
-    ([1, 40], {'skew': None, 'kurtosis': None}),
-))
-def test_unbiased_skew_and_kurtosis(input, expected):
-    arrow_skew = pc.skew(input, skip_nulls=True, biased=False)
-    arrow_kurtosis = pc.kurtosis(input, skip_nulls=True, biased=False)
-    assert arrow_skew == pa.scalar(expected['skew'], type=pa.float64())
-    assert arrow_kurtosis == pa.scalar(expected['kurtosis'], type=pa.float64())

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -3841,7 +3841,11 @@ def test_pivot_wider():
 
 
 @pytest.mark.pandas
-def test_biased_skew():
-    arrow_skew = pc.skew([1.0, 2.0, 3.0, 40.0, None], skip_nulls=True, bias=False)
-    pandas_skew = pd.Series(np.array([1.0, 2.0, 3.0, 40.0, np.nan])).skew(skipna=True)
+def test_biased_skew_and_kurtosis():
+    input = [1.0, 2.0, 3.0, 40.0, None]
+    arrow_skew = pc.skew(input, skip_nulls=True, bias=False)
+    pandas_skew = pd.Series(np.array(input)).skew(skipna=True)
     assert arrow_skew == pa.scalar(pandas_skew)
+    arrow_kurtosis = pc.kurtosis(input, skip_nulls=True, bias=False)
+    pandas_kurtosis = pd.Series(np.array(input)).kurtosis(skipna=True)
+    assert arrow_kurtosis == pa.scalar(pandas_kurtosis)


### PR DESCRIPTION
### Rationale for this change

Allow unbiased computations of skew and kurtosis. Toggle variable to compute biased/unbiased.

### What changes are included in this PR?

Add `biased` option to compute biased/unbiased versions when computing Skew and kurtosis.

### Are these changes tested?

Yes, tests added.

### Are there any user-facing changes?

There is a new `biased` option on `SkewOptions`

* GitHub Issue: #45733