### PR TITLE
GH-45720: [Docs] Kapa.ai widget not loading on the dev docs

### DIFF
--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -6,7 +6,11 @@
 
 
   <!-- Content Security Policy for kapa.ai -->
-  <meta http-equiv="Content-Security-Policy" content="script-src 'self' https://widget.kapa.ai">
+  <meta http-equiv="Content-Security-Policy" content="
+  script-src 'self' widget.kapa.ai www.google.com;
+  connect-src 'self' proxy.kapa.ai kapa-widget-proxy-la7dkmplpq-uc.a.run.app metrics.kapa.ai;
+  frame-src 'self' www.google.com;
+  ">
 
   <!-- Matomo -->
   <script>

--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -4,6 +4,10 @@
 {% block extrahead %}
   {{ super() }}
 
+
+  <!-- Content Security Policy for kapa.ai -->
+  <meta http-equiv="Content-Security-Policy" content="script-src 'self' https://widget.kapa.ai">
+
   <!-- Matomo -->
   <script>
     var _paq = window._paq = window._paq || [];

--- a/r/_pkgdown.yml
+++ b/r/_pkgdown.yml
@@ -44,7 +44,11 @@ template:
       </script>
       <!-- End Matomo Code -->
       <!-- Kapa AI -->
-      <meta http-equiv="Content-Security-Policy" content="script-src 'self' https://widget.kapa.ai">
+      <meta http-equiv="Content-Security-Policy" content="
+      script-src 'self' widget.kapa.ai www.google.com;
+      connect-src 'self' proxy.kapa.ai kapa-widget-proxy-la7dkmplpq-uc.a.run.app metrics.kapa.ai;
+      frame-src 'self' www.google.com;
+      ">
       <script
           async
           src="https://widget.kapa.ai/kapa-widget.bundle.js"

--- a/r/_pkgdown.yml
+++ b/r/_pkgdown.yml
@@ -44,6 +44,7 @@ template:
       </script>
       <!-- End Matomo Code -->
       <!-- Kapa AI -->
+      <meta http-equiv="Content-Security-Policy" content="script-src 'self' https://widget.kapa.ai">
       <script
           async
           src="https://widget.kapa.ai/kapa-widget.bundle.js"


### PR DESCRIPTION
### Rationale for this change

Add the kapa.ai domain to the content security policy so that the AI bot we are trying out can load.  Following the approach shown on https://github.com/apache/dubbo-website/pull/2925 but being more restrictive on URLs.

### What changes are included in this PR?

Updates to sphinx and pkgdown docs to fix this

### Are these changes tested?

Nope - this wasn't an issue on the docs built in crossbow when I tested it on the PR, so I was thinking I just check it's working on the dev docs once they're built

### Are there any user-facing changes?

Nope
* GitHub Issue: #45720