### PR TITLE
GH-45530: [Python][Packaging] Add pyarrow.libs dir to get_library_dirs

### DIFF
--- a/python/pyarrow/__init__.py
+++ b/python/pyarrow/__init__.py
@@ -423,8 +423,8 @@ def get_library_dirs():
 
         # GH-45530: Add pyarrow.libs dir containing delvewheel-mangled
         # msvcp140.dll
-        pyarrow_libs_dir = _os.path.join(
-            python_base_install, "Lib", "site-packages", "pyarrow.libs"
+        pyarrow_libs_dir = _os.path.abspath(
+            _os.path.join(_os.path.dirname(__file__), _os.pardir, "pyarrow.libs")
         )
 
         if _os.path.exists(pyarrow_libs_dir):

--- a/python/pyarrow/__init__.py
+++ b/python/pyarrow/__init__.py
@@ -425,7 +425,6 @@ def get_library_dirs():
         pyarrow_libs_dir = _os.path.abspath(
             _os.path.join(_os.path.dirname(__file__), _os.pardir, "pyarrow.libs")
         )
-
         if _os.path.exists(pyarrow_libs_dir):
             append_library_dir(pyarrow_libs_dir)
 

--- a/python/pyarrow/__init__.py
+++ b/python/pyarrow/__init__.py
@@ -411,7 +411,7 @@ def get_library_dirs():
                         "value {!r}".format(library_dir))
                 append_library_dir(library_dir[2:])
 
-    if _sys.platform == "win32":
+    if _sys.platform == 'win32':
         # TODO(wesm): Is this necessary, or does setuptools within a conda
         # installation add Library\lib to the linker path for MSVC?
         python_base_install = _os.path.dirname(_sys.executable)

--- a/python/pyarrow/__init__.py
+++ b/python/pyarrow/__init__.py
@@ -411,11 +411,10 @@ def get_library_dirs():
                         "value {!r}".format(library_dir))
                 append_library_dir(library_dir[2:])
 
-    if _sys.platform == 'win32':
-        python_base_install = _os.path.dirname(_sys.executable)
-
+    if _sys.platform == "win32":
         # TODO(wesm): Is this necessary, or does setuptools within a conda
         # installation add Library\lib to the linker path for MSVC?
+        python_base_install = _os.path.dirname(_sys.executable)
         library_dir = _os.path.join(python_base_install, 'Library', 'lib')
 
         if _os.path.exists(_os.path.join(library_dir, 'arrow.lib')):

--- a/python/pyarrow/__init__.py
+++ b/python/pyarrow/__init__.py
@@ -412,13 +412,23 @@ def get_library_dirs():
                 append_library_dir(library_dir[2:])
 
     if _sys.platform == 'win32':
+        python_base_install = _os.path.dirname(_sys.executable)
+
         # TODO(wesm): Is this necessary, or does setuptools within a conda
         # installation add Library\lib to the linker path for MSVC?
-        python_base_install = _os.path.dirname(_sys.executable)
         library_dir = _os.path.join(python_base_install, 'Library', 'lib')
 
         if _os.path.exists(_os.path.join(library_dir, 'arrow.lib')):
             append_library_dir(library_dir)
+
+        # GH-45530: Add pyarrow.libs dir containing delvewheel-mangled
+        # msvcp140.dll
+        pyarrow_libs_dir = _os.path.join(
+            python_base_install, "Lib", "site-packages", "pyarrow.libs"
+        )
+
+        if _os.path.exists(pyarrow_libs_dir):
+            append_library_dir(pyarrow_libs_dir)
 
     # ARROW-4074: Allow for ARROW_HOME to be set to some other directory
     if _os.environ.get('ARROW_HOME'):


### PR DESCRIPTION
### Rationale for this change

To run `test_cython` on Windows, we need a copy of msvcp140.dll in the library search path.

### What changes are included in this PR?

- Updated `pa.get_library_dirs()` behavior to add the `pyarrow.libs` folder to the library search path

### Are these changes tested?

Not yet.

### Are there any user-facing changes?

Only a bugfix.

Closes #45530
* GitHub Issue: #45530