### PR TITLE
GH-45767: [C++] Fix Meson compilation issue with non-system Boost

### DIFF
--- a/cpp/src/arrow/meson.build
+++ b/cpp/src/arrow/meson.build
@@ -441,19 +441,53 @@ install_headers(
 )
 
 if needs_testing
+    boost_dep = dependency('boost', include_type: 'system', required: false)
+
+    asio_dep = dependency(
+        'boost',
+        include_type: 'system',
+        modules: ['asio'],
+        required: false,
+    )
+
     filesystem_dep = dependency(
         'boost',
+        include_type: 'system',
         modules: ['filesystem'],
         required: false,
     )
-    if not filesystem_dep.found()
+
+    process_dep = dependency(
+        'boost',
+        include_type: 'system',
+        modules: ['process'],
+        required: false,
+    )
+
+    if not (boost_dep.found()
+and asio_dep.found()
+and filesystem_dep.found()
+and process_dep.found()
+)
         cmake = import('cmake')
         boost_opt = cmake.subproject_options()
         boost_opt.add_cmake_defines(
-            {'BOOST_INCLUDE_LIBRARIES': 'filesystem;system'},
+            {'BOOST_INCLUDE_LIBRARIES': 'asio;filesystem;process'},
         )
         boost_proj = cmake.subproject('boost', options: boost_opt)
-        filesystem_dep = boost_proj.dependency('boost_filesystem')
+        boost_dep = boost_proj.dependency(
+            'boost_headers',
+            include_type: 'system',
+        )
+        asio_dep = boost_proj.dependency('boost_asio', include_type: 'system')
+        filesystem_dep = boost_proj.dependency(
+            'boost_filesystem',
+            include_type: 'system',
+        )
+        process_dep = boost_proj.dependency(
+            'boost_process',
+            include_type: 'system',
+        )
     endif
 
     gtest_dep = dependency('gtest')
@@ -461,17 +495,28 @@ if needs_testing
     gtest_dep = dependency('gtest')
     gmock_dep = dependency('gmock')
 else
+    asio_dep = disabler()
+    boost_dep = disabler()
     filesystem_dep = disabler()
     gtest_dep = disabler()
     gtest_main_dep = disabler()
     gtest_dep = disabler()
     gmock_dep = disabler()
+    process_dep = disabler()
 endif
 
 arrow_test_lib = static_library(
     'arrow_testing',
     sources: arrow_testing_srcs,
-    dependencies: [arrow_dep, filesystem_dep, gmock_dep, gtest_main_dep],
+    dependencies: [
+        arrow_dep,
+        asio_dep,
+        boost_dep,
+        filesystem_dep,
+        gmock_dep,
+        gtest_main_dep,
+        process_dep,
+    ],
 )
 
 if needs_tests

--- a/cpp/subprojects/boost.wrap
+++ b/cpp/subprojects/boost.wrap
@@ -21,7 +21,3 @@ source_filename = boost-1.87.0-cmake.tar.gz
 source_hash = 78fbf579e3caf0f47517d3fb4d9301852c3154bfecdc5eeebd9b2b0292366f5b
 directory = boost-1.87.0
 method = cmake
-
-[provide]
-boost_filesystem = boost_filesystem_dep
-boost_system = boost_system_dep


### PR DESCRIPTION
### Rationale for this change

The recently added support for Meson compilation fails during the compilation step when using a non-system provided version of Boost

### What changes are included in this PR?

This PR makes it so that the wrapdb version of Boost will compile the project correctly

### Are these changes tested?

Yes

### Are there any user-facing changes?

No

* GitHub Issue: #45767