### PR TITLE
GH-45769:[C#][flight] add FlightInfo ByteString serialization

### DIFF
--- a/csharp/src/Apache.Arrow.Flight/Extensions/FlightInfoExtensions.cs
+++ b/csharp/src/Apache.Arrow.Flight/Extensions/FlightInfoExtensions.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Google.Protobuf;
+
+
+namespace Apache.Arrow.Flight.Extensions
+{
+    public static class FlightInfoExtensions
+    {
+        public static ByteString ToByteString(this FlightInfo flightInfo)
+        { 
+            return flightInfo.ToProtocol().ToByteString();
+        }
+    }
+}


### PR DESCRIPTION
### What changes are included in this PR?

ToByteString extension method for FlightInfo https://github.com/apache/arrow/issues/45769

### Are these changes tested?

YES

### Are there any user-facing changes?

NO


* GitHub Issue: #45769