### PR TITLE
GH-45779: [C++] Add testing directory to Meson configuration

### DIFF
--- a/cpp/meson.build
+++ b/cpp/meson.build
@@ -56,6 +56,7 @@ if git_description == ''
     git_description = run_command('git', 'describe', '--tags', check: false).stdout().strip()
 endif
 
+needs_filesystem = false
 needs_integration = false
 needs_tests = get_option('tests')
 needs_ipc = get_option('ipc') or needs_tests

--- a/cpp/src/arrow/meson.build
+++ b/cpp/src/arrow/meson.build
@@ -438,4 +438,6 @@ pkg.generate(
     },
 )
 
+subdir('testing')
+
 subdir('util')

--- a/cpp/src/arrow/testing/meson.build
+++ b/cpp/src/arrow/testing/meson.build
@@ -1,0 +1,63 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+install_headers(
+    [
+        'async_test_util.h',
+        'builder.h',
+        'executor_util.h',
+        'extension_type.h',
+        'fixed_width_test_util.h',
+        'future_util.h',
+        'generator.h',
+        'gtest_compat.h',
+        'gtest_util.h',
+        'matchers.h',
+        'math.h',
+        'pch.h',
+        'process.h',
+        'random.h',
+        'uniform_real.h',
+        'util.h',
+        'visibility.h',
+    ],
+)
+
+if needs_tests
+    testing_tests = {
+        'arrow-generator-test': {'sources': ['generator_test.cc']},
+        'arrow-gtest-util-test': {'sources': ['gtest_util_test.cc']},
+        'arrow-random-test': {'sources': ['random_test.cc']},
+    }
+
+    foreach key, val : testing_tests
+        exc = executable(
+            key,
+            sources: val['sources'],
+            dependencies: [arrow_test_dep, val.get('dependencies', [])],
+        )
+        test(key, exc)
+    endforeach
+
+    if needs_filesystem
+        library(
+            'arrow-filesystem-example',
+            sources: ['examplefs.cc'],
+            dependencies: [arrow_dep, gtest_main_dep],
+        )
+    endif
+endif


### PR DESCRIPTION
### Rationale for this change

This adds the testing directory to the Meson configuration

### What changes are included in this PR?

Adds a meson.build configuration in the testing directory

### Are these changes tested?

Yes

### Are there any user-facing changes?

No

* GitHub Issue: #45779