### PR TITLE
GH-45782: [GLib] Check only the first line for validation error

### DIFF
--- a/c_glib/test/test-array.rb
+++ b/c_glib/test/test-array.rb
@@ -198,9 +198,11 @@ class TestArray < Test::Unit::TestCase
     def test_invalid
       message = "[array][validate]: Invalid: Array length is negative"
       array = Arrow::Int8Array.new(-1, Arrow::Buffer.new(""), Arrow::Buffer.new(""), -1)
-      assert_raise(Arrow::Error::Invalid.new(message)) do
+      error = assert_raise(Arrow::Error::Invalid) do
         array.validate
       end
+      assert_equal(message,
+                   error.message.lines.first.chomp)
     end
   end
 
@@ -224,9 +226,11 @@ class TestArray < Test::Unit::TestCase
                                      Arrow::Buffer.new([0b01].pack("C*")),
                                      -1)
 
-      assert_raise(Arrow::Error::Invalid.new(message)) do
+      error = assert_raise(Arrow::Error::Invalid) do
         array.validate_full
       end
+      assert_equal(message,
+                   error.message.lines.first.chomp)
     end
   end
 end

--- a/c_glib/test/test-record-batch.rb
+++ b/c_glib/test/test-record-batch.rb
@@ -216,9 +216,11 @@ valid:   [
         n_rows = @id_value.length + 1 # incorrect number of rows
 
         record_batch = Arrow::RecordBatch.new(@schema, n_rows, @values)
-        assert_raise(Arrow::Error::Invalid.new(message)) do
+        error = assert_raise(Arrow::Error::Invalid) do
           record_batch.validate
         end
+        assert_equal(message,
+                     error.message.lines.first.chomp)
       end
     end
 
@@ -257,9 +259,11 @@ valid:   [
         columns = [@uint8_value, @invalid_name_value]
         record_batch = Arrow::RecordBatch.new(@schema, @n_rows, columns)
 
-        assert_raise(Arrow::Error::Invalid.new(message)) do
+        error = assert_raise(Arrow::Error::Invalid) do
           record_batch.validate_full
         end
+        assert_equal(message,
+                     error.message.lines.first.chomp)
       end
     end
   end

--- a/c_glib/test/test-table.rb
+++ b/c_glib/test/test-table.rb
@@ -268,9 +268,11 @@ valid:
 
         invalid_values = [@id_array, build_string_array(["abc", "def"])]
         table = Arrow::Table.new(@schema, invalid_values)
-        assert_raise(Arrow::Error::Invalid.new(message)) do
+        error = assert_raise(Arrow::Error::Invalid) do
           table.validate
         end
+        assert_equal(message,
+                     error.message.lines.first.chomp)
       end
     end
 
@@ -308,9 +310,11 @@ valid:
         columns = [@id_values, @invalid_name_values]
         table = Arrow::Table.new(@schema, columns)
 
-        assert_raise(Arrow::Error::Invalid.new(message)) do
+        error = assert_raise(Arrow::Error::Invalid) do
           table.validate_full
         end
+        assert_equal(message,
+                     error.message.lines.first.chomp)
       end
     end
 


### PR DESCRIPTION
### Rationale for this change

Validation error message may include error context when we build Apache Arrow C++ with `ARROW_EXTRA_ERROR_CONTEXT=ON`.

### What changes are included in this PR?

We can check only the first line to make tests more stable for build options.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #45782