### PR TITLE
GH-45787: [Integration][CI] Remove pin for Rust 1.77 on conda integration tests

### DIFF
--- a/ci/docker/conda-integration.dockerfile
+++ b/ci/docker/conda-integration.dockerfile
@@ -44,10 +44,7 @@ RUN mamba install -q -y \
 
 # Install Rust with only the needed components
 # (rustfmt is needed for tonic-build to compile the protobuf definitions)
-# GH-41637: Version pinned at 1.77 because the glibc for conda-cpp is currently too old
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- --profile=minimal -y && \
-    $HOME/.cargo/bin/rustup override set 1.77 && \
-    $HOME/.cargo/bin/rustup toolchain install 1.77 && \
     $HOME/.cargo/bin/rustup component add rustfmt
 
 ENV GOROOT=/opt/go \


### PR DESCRIPTION
### Rationale for this change

Our integration jobs are failing due to an old version of rustc being used.

### What changes are included in this PR?

Remove current pin for rust to 1.77

### Are these changes tested?

The currently failing CI job is now successful

### Are there any user-facing changes?

This image might be used on other repositories (nanoarrow, arrow-rust, arrow-go, arrow-java, ...). It might also affect those?

* GitHub Issue: #45787