### PR TITLE
GH-45792: [C++] Add benchmarks to Meson configuration

### DIFF
--- a/cpp/meson.build
+++ b/cpp/meson.build
@@ -56,11 +56,12 @@ if git_description == ''
     git_description = run_command('git', 'describe', '--tags', check: false).stdout().strip()
 endif
 
+needs_benchmarks = get_option('benchmarks')
 needs_filesystem = false
 needs_integration = false
 needs_tests = get_option('tests')
-needs_ipc = get_option('ipc') or needs_tests
-needs_testing = get_option('testing') or needs_tests
+needs_ipc = get_option('ipc') or needs_tests or needs_benchmarks
+needs_testing = get_option('testing') or needs_tests or needs_benchmarks
 needs_json = get_option('json') or needs_testing
 
 subdir('src/arrow')

--- a/cpp/meson.options
+++ b/cpp/meson.options
@@ -16,6 +16,13 @@
 # under the License.
 
 option(
+    'benchmarks',
+    type: 'boolean',
+    description: 'Build the Arrow micro benchmarks',
+    value: false,
+)
+
+option(
     'ipc',
     type: 'boolean',
     description: 'Build the Arrow IPC extensions',

--- a/cpp/src/arrow/meson.build
+++ b/cpp/src/arrow/meson.build
@@ -355,7 +355,7 @@ install_headers(
     install_dir: 'arrow',
 )
 
-if needs_tests
+if needs_testing
     filesystem_dep = dependency(
         'boost',
         modules: ['filesystem'],
@@ -440,13 +440,44 @@ if needs_ipc
     }
 endif
 
-foreach key, val : arrow_tests
-    exc = executable(
-        key,
-        sources: val['sources'],
-        dependencies: [arrow_test_dep, val.get('dependencies', [])],
+if needs_tests
+    foreach key, val : arrow_tests
+        exc = executable(
+            key,
+            sources: val['sources'],
+            dependencies: [arrow_test_dep, val.get('dependencies', [])],
+        )
+        test(key, exc)
+    endforeach
+endif
+
+if needs_benchmarks
+    benchmark_dep = dependency(
+        'benchmark',
+        default_options: {'tests': 'disabled'},
     )
-    test(key, exc)
+else
+    benchmark_dep = disabler()
+endif
+
+arrow_benchmarks = [
+    'builder_benchmark',
+    'chunk_resolver_benchmark',
+    'compare_benchmark',
+    'memory_pool_benchmark',
+    'type_benchmark',
+    'tensor_benchmark',
+]
+
+foreach benchmark : arrow_benchmarks
+    benchmark_name = 'arrow-@0@'.format(benchmark.replace('_', '-'))
+    exc = executable(
+        benchmark_name,
+        sources: '@0@.cc'.format(benchmark),
+        dependencies: [arrow_test_dep, benchmark_dep],
+    )
+
+    benchmark(benchmark_name, exc)
 endforeach
 
 version = meson.project_version()

--- a/cpp/subprojects/google-benchmark.wrap
+++ b/cpp/subprojects/google-benchmark.wrap
@@ -1,0 +1,31 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[wrap-file]
+directory = benchmark-1.8.4
+source_url = https://github.com/google/benchmark/archive/refs/tags/v1.8.4.tar.gz
+source_filename = benchmark-1.8.4.tar.gz
+source_hash = 3e7059b6b11fb1bbe28e33e02519398ca94c1818874ebed18e504dc6f709be45
+patch_filename = google-benchmark_1.8.4-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/google-benchmark_1.8.4-1/get_patch
+patch_hash = 77cdae534fe12b6783c1267de3673d3462b229054519034710d581b419e73cca
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/google-benchmark_1.8.4-1/benchmark-1.8.4.tar.gz
+wrapdb_version = 1.8.4-1
+
+[provide]
+benchmark = google_benchmark_dep
+benchmark-main = google_benchmark_main_dep


### PR DESCRIPTION
### Rationale for this change

This makes it possible to add benchmarks to the Meson configuration

### What changes are included in this PR?

Benchmarks from the top level configuration are added

### Are these changes tested?

Locally yes. To do so, simply:

```sh
meson setup builddir -Dbenchmarks=true
meson test -C builddir --benchmark 
```

### Are there any user-facing changes?
No
* GitHub Issue: #45792