### PR TITLE
GH-45796: [C++] Add integration directory to Meson configuration

### DIFF
--- a/cpp/meson.build
+++ b/cpp/meson.build
@@ -60,10 +60,10 @@ needs_benchmarks = get_option('benchmarks')
 needs_csv = get_option('csv')
 needs_hdfs = get_option('hdfs')
 needs_filesystem = false or needs_hdfs
-needs_integration = false
+needs_integration = get_option('integration')
 needs_tests = get_option('tests')
 needs_ipc = get_option('ipc') or needs_tests or needs_benchmarks
-needs_testing = get_option('testing') or needs_tests or needs_benchmarks
+needs_testing = get_option('testing') or needs_tests or needs_benchmarks or needs_integration
 needs_json = get_option('json') or needs_testing
 
 subdir('src/arrow')

--- a/cpp/meson.options
+++ b/cpp/meson.options
@@ -37,10 +37,17 @@ option(
 )
 
 option(
+    'integration',
+    type: 'boolean',
+    description: 'Build the Arrow integration test executables',
+    value: false,
+)
+
+option(
     'ipc',
     type: 'boolean',
     description: 'Build the Arrow IPC extensions',
-    value: false,
+    value: true,
 )
 
 option(

--- a/cpp/meson.options
+++ b/cpp/meson.options
@@ -47,7 +47,7 @@ option(
     'ipc',
     type: 'boolean',
     description: 'Build the Arrow IPC extensions',
-    value: true,
+    value: false,
 )
 
 option(

--- a/cpp/src/arrow/integration/meson.build
+++ b/cpp/src/arrow/integration/meson.build
@@ -1,0 +1,29 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+install_headers(['json_integration.h'])
+
+exc = executable(
+    'arrow-json-integration-test',
+    sources: ['json_integration_test.cc'],
+    dependencies: [arrow_dep, rapidjson_dep, gflags_dep, gtest_dep],
+    link_with: [arrow_test_lib],
+)
+
+if needs_tests
+    test('arrow-json-integration-test', exc)
+endif

--- a/cpp/src/arrow/meson.build
+++ b/cpp/src/arrow/meson.build
@@ -392,11 +392,13 @@ if needs_testing
 
     gtest_dep = dependency('gtest')
     gtest_main_dep = dependency('gtest_main')
+    gtest_dep = dependency('gtest')
     gmock_dep = dependency('gmock')
 else
     filesystem_dep = disabler()
     gtest_dep = disabler()
     gtest_main_dep = disabler()
+    gtest_dep = disabler()
     gmock_dep = disabler()
 endif
 
@@ -542,6 +544,11 @@ subdir('testing')
 subdir('c')
 subdir('io')
 subdir('util')
+
+gflags_dep = dependency('gflags', include_type: 'system')
+if needs_integration or needs_tests
+    subdir('integration')
+endif
 
 if needs_csv
     subdir('csv')

--- a/cpp/src/arrow/meson.build
+++ b/cpp/src/arrow/meson.build
@@ -257,7 +257,7 @@ if needs_csv
     arrow_testing_srcs += ['csv/test_common.cc']
 endif
 
-if needs_json
+if needs_json or needs_integration
     rapidjson_dep = dependency('rapidjson', include_type: 'system')
 else
     rapidjson_dep = disabler()

--- a/cpp/subprojects/gflags.wrap
+++ b/cpp/subprojects/gflags.wrap
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[wrap-file]
+source_url = https://github.com/gflags/gflags/archive/refs/tags/v2.2.2.tar.gz
+source_filename = gflags-2.2.2.tar.gz
+source_hash = 34af2f15cf7367513b352bdcd2493ab14ce43692d2dcd9dfc499492966c64dcf
+directory = gflags-2.2.2
+method = cmake
+
+[provide]
+gflags = gflags_static_dep


### PR DESCRIPTION
### Rationale for this change

This continues to add features to the Meson build configuration

### What changes are included in this PR?

The integration directory has been added

### Are these changes tested?

Yes

### Are there any user-facing changes?

No
* GitHub Issue: #45796