### PR TITLE
GH-45787: [Integration][CI] Fix Rust integration build, workaround dep

### DIFF
--- a/ci/scripts/rust_build.sh
+++ b/ci/scripts/rust_build.sh
@@ -54,6 +54,11 @@ rustup show
 
 pushd ${source_dir}
 
+# Workaround for https://github.com/apache/arrow/issues/45787
+# half 2.5.0 requires rust 1.81.0 or newer, so use the
+# 2.4.0 which is compatible with version of rust in builder
+cargo update -p half --precise 2.4.0
+
 # build only the integration testing binaries
 cargo build -p arrow-integration-testing --target-dir ${build_dir}
 


### PR DESCRIPTION
### Rationale for this change

Our integration jobs are failing due to an old version of rustc being used with a new rust dependency

NOTE this is an alternate workaround to this PR proposed by @raulcd 
- https://github.com/apache/arrow/pull/45790

I think the approach of updating the version of rustc in the integration image is the right long term solution, but I think this PR would be enough to get the tests running successfully again

### What changes are included in this PR?

Pin the dependency that causes compilation to fail to the previous version

### Are these changes tested?

The currently failing CI job is now successful

### Are there any user-facing changes?

This image might be used on other repositories (nanoarrow, arrow-rust, arrow-go, arrow-java, ...). It might also affect those?

* GitHub Issue: #45787
* Related backstory in arrow-rs: https://github.com/apache/arrow-rs/issues/7289