### PR TITLE
GH-45807: [C++] compatibility patches for protobuf 30

### DIFF
--- a/cpp/src/arrow/engine/substrait/expression_internal.cc
+++ b/cpp/src/arrow/engine/substrait/expression_internal.cc
@@ -142,7 +142,7 @@ std::string EnumToString(int value, const google::protobuf::EnumDescriptor* desc
   if (value_desc == nullptr) {
     return "unknown";
   }
-  return value_desc->name();
+  return std::string(value_desc->name());
 }
 
 Result<compute::Expression> FromProto(const substrait::Expression::ReferenceSegment* ref,

--- a/cpp/src/arrow/engine/substrait/serde.cc
+++ b/cpp/src/arrow/engine/substrait/serde.cc
@@ -62,8 +62,8 @@ Status ParseFromBufferImpl(const Buffer& buf, const std::string& full_name,
 template <typename Message>
 Result<Message> ParseFromBuffer(const Buffer& buf) {
   Message message;
-  ARROW_RETURN_NOT_OK(
-      ParseFromBufferImpl(buf, Message::descriptor()->full_name(), &message));
+  ARROW_RETURN_NOT_OK(ParseFromBufferImpl(
+      buf, std::string(Message::descriptor()->full_name()), &message));
   return message;
 }
 

--- a/cpp/src/arrow/engine/substrait/util_internal.cc
+++ b/cpp/src/arrow/engine/substrait/util_internal.cc
@@ -30,7 +30,7 @@ std::string EnumToString(int value, const google::protobuf::EnumDescriptor& desc
   if (value_desc == nullptr) {
     return "unknown";
   }
-  return value_desc->name();
+  return std::string(value_desc->name());
 }
 
 std::unique_ptr<substrait::Version> CreateVersion() {


### PR DESCRIPTION
### Rationale for this change

The current version of arrow is not compatible with protobuf 30.0 and beyond, which we are currently rolling out in Arch Linux:
https://archlinux.org/todo/protobuf-300/

### What changes are included in this PR?

In order to migrate to the new APIs based on `std::string_view` we just use a few casts to `std::string`.

### Are these changes tested?

Compile tested only, but there are no problems expected.

* GitHub Issue: #45807