### PR TITLE
GH-45813: [Docs] Enable discussions

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -18,6 +18,10 @@
 github:
   description: "Apache Arrow is the universal columnar format and multi-language toolbox for fast data interchange and in-memory analytics"
   homepage: https://arrow.apache.org/
+  labels:
+    - arrow
+    - parquet
+
   collaborators:
     - anjakefala
     - hiroyuki-sato

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -22,6 +22,11 @@ github:
     - arrow
     - parquet
 
+  features:
+    issues: true
+    projects: true
+    discussions: true
+
   collaborators:
     - anjakefala
     - hiroyuki-sato
@@ -35,4 +40,5 @@ notifications:
   issues_status: issues@arrow.apache.org
   issues:       github@arrow.apache.org
   pullrequests: github@arrow.apache.org
+  discussions: users@arrow.apache.org
   jira_options: link label worklog

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -27,6 +27,10 @@ github:
     projects: true
     discussions: true
 
+  protected_branches:
+    # protect main against force push
+    main: {}
+
   collaborators:
     - anjakefala
     - hiroyuki-sato

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -44,5 +44,5 @@ notifications:
   issues_status: issues@arrow.apache.org
   issues:       github@arrow.apache.org
   pullrequests: github@arrow.apache.org
-  discussions: users@arrow.apache.org
+  discussions: user@arrow.apache.org
   jira_options: link label worklog


### PR DESCRIPTION
### Rationale for this change
See: https://lists.apache.org/thread/wxtcq0xtfcr2rrdlowo93qqvpvhb10pl

### What changes are included in this PR?
- turn on discussions
- turn on existing features
  - this is required as the recently updated backend of .asf.yaml will now turn features of that have previously been turned on manually and are not part of the current config
- protect main against force pushes 
  - this is imo a basic security feature. any additional rules would need to work with our current release process that currently requires direct pushes to main

### Are these changes tested?
The asf yaml parser will send an email if the config is broken, this only works when the change is made from within the repo and not a fork.

### Are there any user-facing changes?
Yes, discussions are now available.
* GitHub Issue: #45813