### PR TITLE
GH-45816: [C++] Make `VisitType()` fallback branch unreachable

### DIFF
--- a/cpp/src/arrow/visit_type_inline.h
+++ b/cpp/src/arrow/visit_type_inline.h
@@ -20,6 +20,7 @@
 #include "arrow/extension_type.h"
 #include "arrow/type.h"
 #include "arrow/util/macros.h"
+#include "arrow/util/unreachable.h"
 #include "arrow/visitor_generate.h"
 
 namespace arrow {
@@ -83,9 +84,8 @@ inline auto VisitType(const DataType& type, VISITOR&& visitor, ARGS&&... args)
   switch (type.id()) {
     ARROW_GENERATE_FOR_ALL_TYPES(TYPE_VISIT_INLINE);
     default:
-      break;
+      Unreachable("Type not implemented");
   }
-  return std::forward<VISITOR>(visitor)(type, std::forward<ARGS>(args)...);
 }
 
 #undef TYPE_VISIT_INLINE


### PR DESCRIPTION
### Rationale for this change

Enable using the more convenient `constexpr` type checking functions from `type_traits` with `VisitType` dispatchers, like:

```cpp
  auto handle_type = [&](auto&& type) {
    using Type = std::decay_t<decltype(type)>;
    if constexpr (::arrow::is_boolean(Type::type_id)) {
      ...
    }
    else if constexpr (::arrow::is_primitive(Type::type_id)) {
        ...
    }
    /* else etc. */
  };
  return VisitType(*values.type(), handle_type);
```

### What changes are included in this PR?

Remove the fallback call with `const DataType&` rather make the default branch unreachable at compile time.

### Are these changes tested?

Yes, `VisitType` is being used at multiple places in the codebase.

### Are there any user-facing changes?

Yes, this is a breaking change. The visitor passed to `VisitType` doesn't need to have an implementation for the base `DataType`.
* GitHub Issue: #45816