### PR TITLE
GH-45653: [Python] Scalar subclasses should implement Python protocols

### DIFF
--- a/docs/source/python/compute.rst
+++ b/docs/source/python/compute.rst
@@ -63,8 +63,8 @@ Below are a few simple examples::
    >>> pc.multiply(x, y)
    <pyarrow.DoubleScalar: 72.54>
 
-If you are using a compute function which returns more than one value, results 
-will be returned as a StructScalar.  You can extract the individual values by 
+If you are using a compute function which returns more than one value, results
+will be returned as a StructScalar.  You can extract the individual values by
 calling the :meth:`pyarrow.StructScalar.values` method::
 
    >>> import pyarrow as pa

--- a/docs/source/python/compute.rst
+++ b/docs/source/python/compute.rst
@@ -64,7 +64,7 @@ Below are a few simple examples::
    <pyarrow.DoubleScalar: 72.54>
 
 If you are using a compute function which returns more than one value, results
-will be returned as a StructScalar.  You can extract the individual values by
+will be returned as a ``StructScalar``.  You can extract the individual values by
 calling the :meth:`pyarrow.StructScalar.values` method::
 
    >>> import pyarrow as pa

--- a/docs/source/python/compute.rst
+++ b/docs/source/python/compute.rst
@@ -63,6 +63,21 @@ Below are a few simple examples::
    >>> pc.multiply(x, y)
    <pyarrow.DoubleScalar: 72.54>
 
+If you are using a compute function which returns more than one value, results 
+will be returned as a StructScalar.  You can extract the individual values by 
+calling the :meth:`pyarrow.StructScalar.values` method::
+
+   >>> import pyarrow as pa
+   >>> import pyarrow.compute as pc
+   >>> a = pa.array([1, 1, 2, 3])
+   >>> pc.min_max(a)
+   <pyarrow.StructScalar: [('min', 1), ('max', 3)]>
+   >>> a, b = pc.min_max(a).values()
+   >>> a
+   <pyarrow.Int64Scalar: 1>
+   >>> b
+   <pyarrow.Int64Scalar: 3>
+
 These functions can do more than just element-by-element operations.
 Here is an example of sorting a table::
 

--- a/python/pyarrow/scalar.pxi
+++ b/python/pyarrow/scalar.pxi
@@ -219,6 +219,8 @@ cdef class BooleanScalar(Scalar):
         cdef CBooleanScalar* sp = <CBooleanScalar*> self.wrapped.get()
         return sp.value if sp.is_valid else None
 
+    def __bool__(self):
+        return (self.as_py())
 
 cdef class UInt8Scalar(Scalar):
     """

--- a/python/pyarrow/scalar.pxi
+++ b/python/pyarrow/scalar.pxi
@@ -238,6 +238,13 @@ cdef class UInt8Scalar(Scalar):
         cdef CUInt8Scalar* sp = <CUInt8Scalar*> self.wrapped.get()
         return sp.value if sp.is_valid else None
 
+    def __int__(self):
+        """
+        Return this value as a Python int.
+        """
+
+        val = self.as_py()
+        return(val)
 
 cdef class Int8Scalar(Scalar):
     """
@@ -256,6 +263,14 @@ cdef class Int8Scalar(Scalar):
         """
         cdef CInt8Scalar* sp = <CInt8Scalar*> self.wrapped.get()
         return sp.value if sp.is_valid else None
+
+    def __int__(self):
+        """
+        Return this value as a Python int.
+        """
+
+        val = self.as_py()
+        return(val)
 
 
 cdef class UInt16Scalar(Scalar):
@@ -276,6 +291,14 @@ cdef class UInt16Scalar(Scalar):
         cdef CUInt16Scalar* sp = <CUInt16Scalar*> self.wrapped.get()
         return sp.value if sp.is_valid else None
 
+    def __int__(self):
+        """
+        Return this value as a Python int.
+        """
+
+        val = self.as_py()
+        return(val)
+
 
 cdef class Int16Scalar(Scalar):
     """
@@ -294,6 +317,14 @@ cdef class Int16Scalar(Scalar):
         """
         cdef CInt16Scalar* sp = <CInt16Scalar*> self.wrapped.get()
         return sp.value if sp.is_valid else None
+
+    def __int__(self):
+        """
+        Return this value as a Python int.
+        """
+
+        val = self.as_py()
+        return(val)
 
 
 cdef class UInt32Scalar(Scalar):
@@ -314,6 +345,14 @@ cdef class UInt32Scalar(Scalar):
         cdef CUInt32Scalar* sp = <CUInt32Scalar*> self.wrapped.get()
         return sp.value if sp.is_valid else None
 
+    def __int__(self):
+        """
+        Return this value as a Python int.
+        """
+
+        val = self.as_py()
+        return(val)
+
 
 cdef class Int32Scalar(Scalar):
     """
@@ -332,6 +371,14 @@ cdef class Int32Scalar(Scalar):
         """
         cdef CInt32Scalar* sp = <CInt32Scalar*> self.wrapped.get()
         return sp.value if sp.is_valid else None
+
+    def __int__(self):
+        """
+        Return this value as a Python int.
+        """
+
+        val = self.as_py()
+        return(val)
 
 
 cdef class UInt64Scalar(Scalar):
@@ -352,6 +399,14 @@ cdef class UInt64Scalar(Scalar):
         cdef CUInt64Scalar* sp = <CUInt64Scalar*> self.wrapped.get()
         return sp.value if sp.is_valid else None
 
+    def __int__(self):
+        """
+        Return this value as a Python int.
+        """
+
+        val = self.as_py()
+        return(val)
+
 
 cdef class Int64Scalar(Scalar):
     """
@@ -370,6 +425,14 @@ cdef class Int64Scalar(Scalar):
         """
         cdef CInt64Scalar* sp = <CInt64Scalar*> self.wrapped.get()
         return sp.value if sp.is_valid else None
+
+    def __int__(self):
+        """
+        Return this value as a Python int.
+        """
+
+        val = self.as_py()
+        return(val)
 
 
 cdef class HalfFloatScalar(Scalar):

--- a/python/pyarrow/scalar.pxi
+++ b/python/pyarrow/scalar.pxi
@@ -881,7 +881,7 @@ cdef class BinaryScalar(Scalar):
     def __bytes__(self):
         return (self.as_py())
 
-    def __buffer__(self):
+    def __getbuffer__(self):
         return(self.as_buffer().__getbuffer__())
 
 

--- a/python/pyarrow/scalar.pxi
+++ b/python/pyarrow/scalar.pxi
@@ -18,6 +18,7 @@
 import collections
 import warnings
 from uuid import UUID
+from collections.abc import Sequence, Mapping
 
 
 cdef class Scalar(_Weakrefable):
@@ -927,7 +928,7 @@ cdef class StringViewScalar(StringScalar):
     pass
 
 
-cdef class ListScalar(Scalar, collections.abc.Sequence):
+cdef class ListScalar(Scalar, Sequence):
     """
     Concrete class for list-like scalars.
     """
@@ -996,7 +997,7 @@ cdef class LargeListViewScalar(ListScalar):
     pass
 
 
-cdef class StructScalar(Scalar, collections.abc.Mapping):
+cdef class StructScalar(Scalar, Mapping):
     """
     Concrete class for struct scalars.
     """
@@ -1095,7 +1096,7 @@ cdef class StructScalar(Scalar, collections.abc.Mapping):
         return str(self._as_py_tuple())
 
 
-cdef class MapScalar(ListScalar, collections.abc.Mapping):
+cdef class MapScalar(ListScalar, Mapping):
     """
     Concrete class for map scalars.
     """

--- a/python/pyarrow/scalar.pxi
+++ b/python/pyarrow/scalar.pxi
@@ -264,7 +264,7 @@ cdef class Int8Scalar(Scalar):
         return sp.value if sp.is_valid else None
 
     def __int__(self):
-        return (self.as_py())
+        return self.as_py()
 
 
 cdef class UInt16Scalar(Scalar):
@@ -286,7 +286,7 @@ cdef class UInt16Scalar(Scalar):
         return sp.value if sp.is_valid else None
 
     def __int__(self):
-        return (self.as_py())
+        return self.as_py()
 
 
 cdef class Int16Scalar(Scalar):
@@ -308,7 +308,7 @@ cdef class Int16Scalar(Scalar):
         return sp.value if sp.is_valid else None
 
     def __int__(self):
-        return (self.as_py())
+        return self.as_py()
 
 
 cdef class UInt32Scalar(Scalar):
@@ -330,7 +330,7 @@ cdef class UInt32Scalar(Scalar):
         return sp.value if sp.is_valid else None
 
     def __int__(self):
-        return (self.as_py())
+        return self.as_py()
 
 
 cdef class Int32Scalar(Scalar):
@@ -352,7 +352,7 @@ cdef class Int32Scalar(Scalar):
         return sp.value if sp.is_valid else None
 
     def __int__(self):
-        return (self.as_py())
+        return self.as_py()
 
 
 cdef class UInt64Scalar(Scalar):
@@ -374,7 +374,7 @@ cdef class UInt64Scalar(Scalar):
         return sp.value if sp.is_valid else None
 
     def __int__(self):
-        return (self.as_py())
+        return self.as_py()
 
 
 cdef class Int64Scalar(Scalar):
@@ -396,7 +396,7 @@ cdef class Int64Scalar(Scalar):
         return sp.value if sp.is_valid else None
 
     def __int__(self):
-        return (self.as_py())
+        return self.as_py()
 
 
 cdef class HalfFloatScalar(Scalar):
@@ -418,7 +418,7 @@ cdef class HalfFloatScalar(Scalar):
         return PyFloat_FromHalf(sp.value) if sp.is_valid else None
 
     def __float__(self):
-        return (self.as_py())
+        return self.as_py()
 
 
 cdef class FloatScalar(Scalar):
@@ -440,7 +440,7 @@ cdef class FloatScalar(Scalar):
         return sp.value if sp.is_valid else None
 
     def __float__(self):
-        return (self.as_py())
+        return self.as_py()
 
 
 cdef class DoubleScalar(Scalar):
@@ -462,7 +462,7 @@ cdef class DoubleScalar(Scalar):
         return sp.value if sp.is_valid else None
 
     def __float__(self):
-        return (self.as_py())
+        return self.as_py()
 
 
 cdef class Decimal32Scalar(Scalar):
@@ -880,7 +880,7 @@ cdef class BinaryScalar(Scalar):
         return None if buffer is None else buffer.to_pybytes()
 
     def __bytes__(self):
-        return (self.as_py())
+        return self.as_py()
 
     def __getbuffer__(self, cp.Py_buffer* buffer, int flags):
         buf = self.as_buffer()

--- a/python/pyarrow/scalar.pxi
+++ b/python/pyarrow/scalar.pxi
@@ -414,6 +414,9 @@ cdef class HalfFloatScalar(Scalar):
         cdef CHalfFloatScalar* sp = <CHalfFloatScalar*> self.wrapped.get()
         return PyFloat_FromHalf(sp.value) if sp.is_valid else None
 
+    def __float__(self):
+        return (self.as_py())
+
 
 cdef class FloatScalar(Scalar):
     """
@@ -433,6 +436,9 @@ cdef class FloatScalar(Scalar):
         cdef CFloatScalar* sp = <CFloatScalar*> self.wrapped.get()
         return sp.value if sp.is_valid else None
 
+    def __float__(self):
+        return (self.as_py())
+
 
 cdef class DoubleScalar(Scalar):
     """
@@ -451,6 +457,9 @@ cdef class DoubleScalar(Scalar):
         """
         cdef CDoubleScalar* sp = <CDoubleScalar*> self.wrapped.get()
         return sp.value if sp.is_valid else None
+
+    def __float__(self):
+        return (self.as_py())
 
 
 cdef class Decimal32Scalar(Scalar):

--- a/python/pyarrow/scalar.pxi
+++ b/python/pyarrow/scalar.pxi
@@ -882,31 +882,10 @@ cdef class BinaryScalar(Scalar):
         return (self.as_py())
 
     def __getbuffer__(self, cp.Py_buffer* buffer, int flags):
-        cdef Buffer buf = self.as_buffer()
-
+        buf = self.as_buffer()
         if buf is None:
-            raise TypeError('Buffer view requested on empty scalar')
-
-        if buf.buffer.get().is_mutable():
-            buffer.readonly = 0
-        else:
-            if flags & cp.PyBUF_WRITABLE:
-                raise BufferError("Writable buffer requested but Arrow "
-                                  "buffer was not mutable")
-            buffer.readonly = 1
-        buffer.buf = <char *>buf.buffer.get().data()
-        buffer.len = buf.size
-        if buffer.buf == NULL:
-            assert buffer.len == 0
-            buffer.buf = cp.PyBytes_AS_STRING(b"")
-        buffer.format = 'b'
-        buffer.internal = NULL
-        buffer.itemsize = 1
-        buffer.ndim = 1
-        buffer.obj = buf
-        buffer.shape = buf.shape
-        buffer.strides = buf.strides
-        buffer.suboffsets = NULL
+            raise ValueError("Cannot export buffer from null Arrow Scalar")
+        cp.PyObject_GetBuffer(buf, buffer, flags)
 
 
 cdef class LargeBinaryScalar(BinaryScalar):

--- a/python/pyarrow/scalar.pxi
+++ b/python/pyarrow/scalar.pxi
@@ -875,6 +875,9 @@ cdef class BinaryScalar(Scalar):
         """
         buffer = self.as_buffer()
         return None if buffer is None else buffer.to_pybytes()
+    
+    def __bytes__(self):
+        return (self.as_py())
 
 
 cdef class LargeBinaryScalar(BinaryScalar):

--- a/python/pyarrow/scalar.pxi
+++ b/python/pyarrow/scalar.pxi
@@ -875,7 +875,7 @@ cdef class BinaryScalar(Scalar):
         """
         buffer = self.as_buffer()
         return None if buffer is None else buffer.to_pybytes()
-    
+
     def __bytes__(self):
         return (self.as_py())
 

--- a/python/pyarrow/scalar.pxi
+++ b/python/pyarrow/scalar.pxi
@@ -1115,9 +1115,12 @@ cdef class MapScalar(ListScalar, Mapping):
 
         if isinstance(i, (bytes, str)):
             try:
-                i = list(self.keys()).index(i)
+                key_index = list(self.keys()).index(i)
             except ValueError:
                 raise KeyError(i)
+
+            dct = arr[_normalize_index(key_index, len(arr))]
+            return dct[item_field]
 
         dct = arr[_normalize_index(i, len(arr))]
         return (dct[key_field], dct[item_field])

--- a/python/pyarrow/scalar.pxi
+++ b/python/pyarrow/scalar.pxi
@@ -883,7 +883,7 @@ cdef class BinaryScalar(Scalar):
 
     def __getbuffer__(self, cp.Py_buffer* buffer, int flags):
         cdef Buffer buf = self.as_buffer()
-        buf.__getbuffer__(buffer, flags)
+        PyObject_GetBuffer(<object>buf, buffer, flags)
 
 
 cdef class LargeBinaryScalar(BinaryScalar):

--- a/python/pyarrow/scalar.pxi
+++ b/python/pyarrow/scalar.pxi
@@ -220,7 +220,7 @@ cdef class BooleanScalar(Scalar):
         return sp.value if sp.is_valid else None
 
     def __bool__(self):
-        return (self.as_py())
+        return self.as_py()
 
 cdef class UInt8Scalar(Scalar):
     """

--- a/python/pyarrow/scalar.pxi
+++ b/python/pyarrow/scalar.pxi
@@ -420,6 +420,9 @@ cdef class HalfFloatScalar(Scalar):
     def __float__(self):
         return self.as_py()
 
+    def __int__(self):
+        return int(float(self))
+
 
 cdef class FloatScalar(Scalar):
     """
@@ -442,6 +445,9 @@ cdef class FloatScalar(Scalar):
     def __float__(self):
         return self.as_py()
 
+    def __int__(self):
+        return int(float(self))
+
 
 cdef class DoubleScalar(Scalar):
     """
@@ -463,6 +469,9 @@ cdef class DoubleScalar(Scalar):
 
     def __float__(self):
         return self.as_py()
+
+    def __int__(self):
+        return int(float(self))
 
 
 cdef class Decimal32Scalar(Scalar):

--- a/python/pyarrow/scalar.pxi
+++ b/python/pyarrow/scalar.pxi
@@ -882,7 +882,8 @@ cdef class BinaryScalar(Scalar):
         return (self.as_py())
 
     def __getbuffer__(self, cp.Py_buffer* buffer, int flags):
-        return(self.as_buffer().__getbuffer__(buffer, flags))
+        cdef Buffer buf = self.as_buffer()
+        buf.__getbuffer__(buffer, flags)
 
 
 cdef class LargeBinaryScalar(BinaryScalar):

--- a/python/pyarrow/scalar.pxi
+++ b/python/pyarrow/scalar.pxi
@@ -242,7 +242,7 @@ cdef class UInt8Scalar(Scalar):
         return sp.value if sp.is_valid else None
 
     def __int__(self):
-        return (self.as_py())
+        return self.as_py()
 
 
 cdef class Int8Scalar(Scalar):

--- a/python/pyarrow/scalar.pxi
+++ b/python/pyarrow/scalar.pxi
@@ -421,7 +421,7 @@ cdef class HalfFloatScalar(Scalar):
         return self.as_py()
 
     def __int__(self):
-        return int(float(self))
+        return int(self.as_py())
 
 
 cdef class FloatScalar(Scalar):

--- a/python/pyarrow/scalar.pxi
+++ b/python/pyarrow/scalar.pxi
@@ -881,8 +881,8 @@ cdef class BinaryScalar(Scalar):
     def __bytes__(self):
         return (self.as_py())
 
-    def __getbuffer__(self):
-        return(self.as_buffer().__getbuffer__())
+    def __getbuffer__(self, cp.Py_buffer* buffer, int flags):
+        return(self.as_buffer().__getbuffer__(buffer, flags))
 
 
 cdef class LargeBinaryScalar(BinaryScalar):

--- a/python/pyarrow/scalar.pxi
+++ b/python/pyarrow/scalar.pxi
@@ -1112,14 +1112,11 @@ cdef class MapScalar(ListScalar):
         key_field = self.type.key_field.name
         item_field = self.type.item_field.name
 
-        if isinstance(i, int):
-            dct = arr[_normalize_index(i, len(arr))]
-            return (dct[key_field], dct[item_field])
-        else:
-            for dct in arr:
-                if dct[key_field].as_py() == i:
-                    return dct[item_field]
-            raise KeyError(i)
+        if isinstance(i, (str, bytes)):
+            i = self.keys().index(i)
+
+        dct = arr[_normalize_index(i, len(arr))]
+        return (dct[key_field], dct[item_field])
 
     def __iter__(self):
         """

--- a/python/pyarrow/scalar.pxi
+++ b/python/pyarrow/scalar.pxi
@@ -927,7 +927,7 @@ cdef class StringViewScalar(StringScalar):
     pass
 
 
-cdef class ListScalar(Scalar):
+cdef class ListScalar(Scalar, collections.abc.Sequence):
     """
     Concrete class for list-like scalars.
     """
@@ -1095,7 +1095,7 @@ cdef class StructScalar(Scalar, collections.abc.Mapping):
         return str(self._as_py_tuple())
 
 
-cdef class MapScalar(ListScalar):
+cdef class MapScalar(ListScalar, collections.abc.Mapping):
     """
     Concrete class for map scalars.
     """

--- a/python/pyarrow/scalar.pxi
+++ b/python/pyarrow/scalar.pxi
@@ -907,7 +907,6 @@ cdef class BinaryScalar(Scalar):
         buffer.suboffsets = NULL
 
 
-
 cdef class LargeBinaryScalar(BinaryScalar):
     pass
 

--- a/python/pyarrow/scalar.pxi
+++ b/python/pyarrow/scalar.pxi
@@ -1113,8 +1113,10 @@ cdef class MapScalar(ListScalar, Mapping):
         key_field = self.type.key_field.name
         item_field = self.type.item_field.name
 
-        if isinstance(i, (str, bytes)):
-            i = self.keys().index(i)
+        try:
+            i = list(self.keys()).index(i)
+        except ValueError:
+            raise KeyError(i)
 
         dct = arr[_normalize_index(i, len(arr))]
         return (dct[key_field], dct[item_field])

--- a/python/pyarrow/scalar.pxi
+++ b/python/pyarrow/scalar.pxi
@@ -882,7 +882,7 @@ cdef class BinaryScalar(Scalar):
         return (self.as_py())
 
     def __buffer__(self):
-        return(memoryview(self.as_buffer()))
+        return(self.as_buffer().__getbuffer__())
 
 
 cdef class LargeBinaryScalar(BinaryScalar):

--- a/python/pyarrow/scalar.pxi
+++ b/python/pyarrow/scalar.pxi
@@ -239,7 +239,6 @@ cdef class UInt8Scalar(Scalar):
         return sp.value if sp.is_valid else None
 
     def __int__(self):
-
         return (self.as_py())
 
 
@@ -262,7 +261,6 @@ cdef class Int8Scalar(Scalar):
         return sp.value if sp.is_valid else None
 
     def __int__(self):
-
         return (self.as_py())
 
 
@@ -285,7 +283,6 @@ cdef class UInt16Scalar(Scalar):
         return sp.value if sp.is_valid else None
 
     def __int__(self):
-
         return (self.as_py())
 
 
@@ -308,7 +305,6 @@ cdef class Int16Scalar(Scalar):
         return sp.value if sp.is_valid else None
 
     def __int__(self):
-
         return (self.as_py())
 
 
@@ -331,7 +327,6 @@ cdef class UInt32Scalar(Scalar):
         return sp.value if sp.is_valid else None
 
     def __int__(self):
-
         return (self.as_py())
 
 
@@ -354,7 +349,6 @@ cdef class Int32Scalar(Scalar):
         return sp.value if sp.is_valid else None
 
     def __int__(self):
-
         return (self.as_py())
 
 
@@ -377,7 +371,6 @@ cdef class UInt64Scalar(Scalar):
         return sp.value if sp.is_valid else None
 
     def __int__(self):
-
         return (self.as_py())
 
 
@@ -400,7 +393,6 @@ cdef class Int64Scalar(Scalar):
         return sp.value if sp.is_valid else None
 
     def __int__(self):
-
         return (self.as_py())
 
 

--- a/python/pyarrow/scalar.pxi
+++ b/python/pyarrow/scalar.pxi
@@ -221,7 +221,7 @@ cdef class BooleanScalar(Scalar):
         return sp.value if sp.is_valid else None
 
     def __bool__(self):
-        return self.as_py()
+        return self.as_py() or False
 
 cdef class UInt8Scalar(Scalar):
     """

--- a/python/pyarrow/scalar.pxi
+++ b/python/pyarrow/scalar.pxi
@@ -881,6 +881,9 @@ cdef class BinaryScalar(Scalar):
     def __bytes__(self):
         return (self.as_py())
 
+    def __buffer__(self):
+        return(memoryview(self.as_buffer()))
+
 
 cdef class LargeBinaryScalar(BinaryScalar):
     pass

--- a/python/pyarrow/scalar.pxi
+++ b/python/pyarrow/scalar.pxi
@@ -241,7 +241,7 @@ cdef class UInt8Scalar(Scalar):
         cdef CUInt8Scalar* sp = <CUInt8Scalar*> self.wrapped.get()
         return sp.value if sp.is_valid else None
 
-    def __int__(self):
+    def __index__(self):
         return self.as_py()
 
 
@@ -263,7 +263,7 @@ cdef class Int8Scalar(Scalar):
         cdef CInt8Scalar* sp = <CInt8Scalar*> self.wrapped.get()
         return sp.value if sp.is_valid else None
 
-    def __int__(self):
+    def __index__(self):
         return self.as_py()
 
 
@@ -285,7 +285,7 @@ cdef class UInt16Scalar(Scalar):
         cdef CUInt16Scalar* sp = <CUInt16Scalar*> self.wrapped.get()
         return sp.value if sp.is_valid else None
 
-    def __int__(self):
+    def __index__(self):
         return self.as_py()
 
 
@@ -307,7 +307,7 @@ cdef class Int16Scalar(Scalar):
         cdef CInt16Scalar* sp = <CInt16Scalar*> self.wrapped.get()
         return sp.value if sp.is_valid else None
 
-    def __int__(self):
+    def __index__(self):
         return self.as_py()
 
 
@@ -329,7 +329,7 @@ cdef class UInt32Scalar(Scalar):
         cdef CUInt32Scalar* sp = <CUInt32Scalar*> self.wrapped.get()
         return sp.value if sp.is_valid else None
 
-    def __int__(self):
+    def __index__(self):
         return self.as_py()
 
 
@@ -351,7 +351,7 @@ cdef class Int32Scalar(Scalar):
         cdef CInt32Scalar* sp = <CInt32Scalar*> self.wrapped.get()
         return sp.value if sp.is_valid else None
 
-    def __int__(self):
+    def __index__(self):
         return self.as_py()
 
 
@@ -373,7 +373,7 @@ cdef class UInt64Scalar(Scalar):
         cdef CUInt64Scalar* sp = <CUInt64Scalar*> self.wrapped.get()
         return sp.value if sp.is_valid else None
 
-    def __int__(self):
+    def __index__(self):
         return self.as_py()
 
 
@@ -395,7 +395,7 @@ cdef class Int64Scalar(Scalar):
         cdef CInt64Scalar* sp = <CInt64Scalar*> self.wrapped.get()
         return sp.value if sp.is_valid else None
 
-    def __int__(self):
+    def __index__(self):
         return self.as_py()
 
 

--- a/python/pyarrow/scalar.pxi
+++ b/python/pyarrow/scalar.pxi
@@ -894,7 +894,6 @@ cdef class BinaryScalar(Scalar):
         buffer.buf = <char *>buf.buffer.get().data()
         buffer.len = buf.size
         if buffer.buf == NULL:
-            # ARROW-16048: Ensure we don't export a NULL address.
             assert buffer.len == 0
             buffer.buf = cp.PyBytes_AS_STRING(b"")
         buffer.format = 'b'

--- a/python/pyarrow/scalar.pxi
+++ b/python/pyarrow/scalar.pxi
@@ -1113,10 +1113,11 @@ cdef class MapScalar(ListScalar, Mapping):
         key_field = self.type.key_field.name
         item_field = self.type.item_field.name
 
-        try:
-            i = list(self.keys()).index(i)
-        except ValueError:
-            raise KeyError(i)
+        if isinstance(i, (bytes, str)):
+            try:
+                i = list(self.keys()).index(i)
+            except ValueError:
+                raise KeyError(i)
 
         dct = arr[_normalize_index(i, len(arr))]
         return (dct[key_field], dct[item_field])

--- a/python/pyarrow/scalar.pxi
+++ b/python/pyarrow/scalar.pxi
@@ -240,7 +240,7 @@ cdef class UInt8Scalar(Scalar):
 
     def __int__(self):
 
-        return(self.as_py())
+        return (self.as_py())
 
 
 cdef class Int8Scalar(Scalar):
@@ -263,7 +263,7 @@ cdef class Int8Scalar(Scalar):
 
     def __int__(self):
 
-        return(self.as_py())
+        return (self.as_py())
 
 
 cdef class UInt16Scalar(Scalar):
@@ -286,7 +286,7 @@ cdef class UInt16Scalar(Scalar):
 
     def __int__(self):
 
-        return(self.as_py())
+        return (self.as_py())
 
 
 cdef class Int16Scalar(Scalar):
@@ -309,7 +309,7 @@ cdef class Int16Scalar(Scalar):
 
     def __int__(self):
 
-        return(self.as_py())
+        return (self.as_py())
 
 
 cdef class UInt32Scalar(Scalar):
@@ -332,7 +332,7 @@ cdef class UInt32Scalar(Scalar):
 
     def __int__(self):
 
-        return(self.as_py())
+        return (self.as_py())
 
 
 cdef class Int32Scalar(Scalar):
@@ -355,7 +355,7 @@ cdef class Int32Scalar(Scalar):
 
     def __int__(self):
 
-        return(self.as_py())
+        return (self.as_py())
 
 
 cdef class UInt64Scalar(Scalar):
@@ -378,7 +378,7 @@ cdef class UInt64Scalar(Scalar):
 
     def __int__(self):
 
-        return(self.as_py())
+        return (self.as_py())
 
 
 cdef class Int64Scalar(Scalar):
@@ -401,7 +401,7 @@ cdef class Int64Scalar(Scalar):
 
     def __int__(self):
 
-        return(self.as_py())
+        return (self.as_py())
 
 
 cdef class HalfFloatScalar(Scalar):

--- a/python/pyarrow/scalar.pxi
+++ b/python/pyarrow/scalar.pxi
@@ -243,8 +243,8 @@ cdef class UInt8Scalar(Scalar):
         Return this value as a Python int.
         """
 
-        val = self.as_py()
-        return(val)
+        return(self.as_py())
+
 
 cdef class Int8Scalar(Scalar):
     """
@@ -269,8 +269,7 @@ cdef class Int8Scalar(Scalar):
         Return this value as a Python int.
         """
 
-        val = self.as_py()
-        return(val)
+        return(self.as_py())
 
 
 cdef class UInt16Scalar(Scalar):
@@ -296,8 +295,7 @@ cdef class UInt16Scalar(Scalar):
         Return this value as a Python int.
         """
 
-        val = self.as_py()
-        return(val)
+        return(self.as_py())
 
 
 cdef class Int16Scalar(Scalar):
@@ -323,8 +321,7 @@ cdef class Int16Scalar(Scalar):
         Return this value as a Python int.
         """
 
-        val = self.as_py()
-        return(val)
+        return(self.as_py())
 
 
 cdef class UInt32Scalar(Scalar):
@@ -350,8 +347,7 @@ cdef class UInt32Scalar(Scalar):
         Return this value as a Python int.
         """
 
-        val = self.as_py()
-        return(val)
+        return(self.as_py())
 
 
 cdef class Int32Scalar(Scalar):
@@ -377,8 +373,7 @@ cdef class Int32Scalar(Scalar):
         Return this value as a Python int.
         """
 
-        val = self.as_py()
-        return(val)
+        return(self.as_py())
 
 
 cdef class UInt64Scalar(Scalar):
@@ -404,8 +399,7 @@ cdef class UInt64Scalar(Scalar):
         Return this value as a Python int.
         """
 
-        val = self.as_py()
-        return(val)
+        return(self.as_py())
 
 
 cdef class Int64Scalar(Scalar):
@@ -431,8 +425,7 @@ cdef class Int64Scalar(Scalar):
         Return this value as a Python int.
         """
 
-        val = self.as_py()
-        return(val)
+        return(self.as_py())
 
 
 cdef class HalfFloatScalar(Scalar):

--- a/python/pyarrow/scalar.pxi
+++ b/python/pyarrow/scalar.pxi
@@ -239,9 +239,6 @@ cdef class UInt8Scalar(Scalar):
         return sp.value if sp.is_valid else None
 
     def __int__(self):
-        """
-        Return this value as a Python int.
-        """
 
         return(self.as_py())
 
@@ -265,9 +262,6 @@ cdef class Int8Scalar(Scalar):
         return sp.value if sp.is_valid else None
 
     def __int__(self):
-        """
-        Return this value as a Python int.
-        """
 
         return(self.as_py())
 
@@ -291,9 +285,6 @@ cdef class UInt16Scalar(Scalar):
         return sp.value if sp.is_valid else None
 
     def __int__(self):
-        """
-        Return this value as a Python int.
-        """
 
         return(self.as_py())
 
@@ -317,9 +308,6 @@ cdef class Int16Scalar(Scalar):
         return sp.value if sp.is_valid else None
 
     def __int__(self):
-        """
-        Return this value as a Python int.
-        """
 
         return(self.as_py())
 
@@ -343,9 +331,6 @@ cdef class UInt32Scalar(Scalar):
         return sp.value if sp.is_valid else None
 
     def __int__(self):
-        """
-        Return this value as a Python int.
-        """
 
         return(self.as_py())
 
@@ -369,9 +354,6 @@ cdef class Int32Scalar(Scalar):
         return sp.value if sp.is_valid else None
 
     def __int__(self):
-        """
-        Return this value as a Python int.
-        """
 
         return(self.as_py())
 
@@ -395,9 +377,6 @@ cdef class UInt64Scalar(Scalar):
         return sp.value if sp.is_valid else None
 
     def __int__(self):
-        """
-        Return this value as a Python int.
-        """
 
         return(self.as_py())
 
@@ -421,9 +400,6 @@ cdef class Int64Scalar(Scalar):
         return sp.value if sp.is_valid else None
 
     def __int__(self):
-        """
-        Return this value as a Python int.
-        """
 
         return(self.as_py())
 

--- a/python/pyarrow/scalar.pxi
+++ b/python/pyarrow/scalar.pxi
@@ -1120,13 +1120,26 @@ cdef class MapScalar(ListScalar):
 
     def __getitem__(self, i):
         """
-        Return the value at the given index.
+        Return the value at the given index or key.
         """
+
         arr = self.values
         if arr is None:
-            raise IndexError(i)
-        dct = arr[_normalize_index(i, len(arr))]
-        return (dct[self.type.key_field.name], dct[self.type.item_field.name])
+            raise IndexError(i) if isinstance(i, int) else KeyError(i)
+
+        key_field = self.type.key_field.name
+        item_field = self.type.item_field.name
+
+        if isinstance(i, int):
+            if arr is None:
+                raise IndexError(i)
+            dct = arr[_normalize_index(i, len(arr))]
+            return (dct[key_field], dct[item_field])
+        else:
+            for dct in arr:
+                if dct[key_field].as_py() == i:
+                    return dct[item_field]
+            raise KeyError(i)
 
     def __iter__(self):
         """

--- a/python/pyarrow/tests/test_scalars.py
+++ b/python/pyarrow/tests/test_scalars.py
@@ -258,7 +258,7 @@ def test_numerics():
     assert repr(s) == "<pyarrow.HalfFloatScalar: 0.5>"
     assert str(s) == "0.5"
     assert s.as_py() == 0.5
-    assert float(s) == 1.5
+    assert float(s) == 0.5
     assert int(s) == 0
 
 

--- a/python/pyarrow/tests/test_scalars.py
+++ b/python/pyarrow/tests/test_scalars.py
@@ -253,7 +253,7 @@ def test_numerics():
     assert int(s) == 1
 
     # float16
-    s = pa.scalar(np.float16(0.5), type='float16')
+    s = pa.scalar(0.5, type='float16')
     assert isinstance(s, pa.HalfFloatScalar)
     assert repr(s) == "<pyarrow.HalfFloatScalar: 0.5>"
     assert str(s) == "0.5"

--- a/python/pyarrow/tests/test_scalars.py
+++ b/python/pyarrow/tests/test_scalars.py
@@ -591,7 +591,7 @@ def test_binary(value, ty, scalar_typ):
     assert s != b'xxxxx'
 
     buf = s.as_buffer()
-    
+
     if value is None:
         with pytest.raises(ValueError):
             memoryview(s)
@@ -607,7 +607,8 @@ def test_binary(value, ty, scalar_typ):
         assert memview.ndim == 1
         assert memview.shape == (len(value),)
         assert memview.strides == (1,)
-   
+
+
 def test_fixed_size_binary():
     s = pa.scalar(b'foof', type=pa.binary(4))
     assert isinstance(s, pa.FixedSizeBinaryScalar)
@@ -830,12 +831,12 @@ def test_map(pickle_module):
     )
     assert s[-1] == s[1]
     assert s[-2] == s[0]
-    assert s['b'] == pa.scalar(2, type=pa.int8())
+    assert s['b'] == (pa.scalar('b', type=pa.string()), pa.scalar(2, type=pa.int8()))
     with pytest.raises(IndexError):
         s[-3]
     with pytest.raises(IndexError):
         s[2]
-    with pytest.raises(KeyError):
+    with pytest.raises(ValueError):
         s['fake_key']
 
     restored = pickle_module.loads(pickle_module.dumps(s))

--- a/python/pyarrow/tests/test_scalars.py
+++ b/python/pyarrow/tests/test_scalars.py
@@ -19,6 +19,7 @@ import datetime
 import decimal
 import pytest
 import weakref
+from collections.abc import Sequence, Mapping
 
 try:
     import numpy as np
@@ -27,36 +28,6 @@ except ImportError:
 
 import pyarrow as pa
 import pyarrow.compute as pc
-
-
-def is_python_sequence_like(obj):
-    if not hasattr(obj, "__getitem__") or not hasattr(obj, "__len__"):
-        return False
-    try:
-        length = len(obj)
-        if length > 0:
-            _ = obj[0]
-    except (TypeError, IndexError, AttributeError):
-        return False
-    return True
-
-
-def is_python_mapping_like(obj):
-    if not is_python_sequence_like(obj):
-        return False
-    if not hasattr(obj, "__iter__") or not hasattr(obj, "keys"):
-        return False
-    try:
-        keys = obj.keys()
-        if not hasattr(keys, "__iter__"):
-            return False
-        _ = len(obj)
-        for key in keys:
-            _ = obj[key]
-            break
-    except (TypeError, KeyError, AttributeError):
-        return False
-    return True
 
 
 @pytest.mark.parametrize(['value', 'ty', 'klass'], [
@@ -643,6 +614,7 @@ def test_list(ty, klass):
         s[-3]
     with pytest.raises(IndexError):
         s[2]
+    assert isinstance(s, Sequence)
 
 
 @pytest.mark.numpy
@@ -738,7 +710,7 @@ def test_struct():
     assert isinstance(s['y'], pa.FloatScalar)
     assert s['x'].as_py() == 2
     assert s['y'].as_py() == 3.5
-    assert is_python_sequence_like(s)
+    assert isinstance(s, Mapping)
 
     with pytest.raises(KeyError):
         s['nonexistent']
@@ -756,7 +728,7 @@ def test_struct():
     assert s['y'].is_valid is False
     assert s['x'].as_py() is None
     assert s['y'].as_py() is None
-    assert is_python_sequence_like(s)
+    assert isinstance(s, Mapping)
 
 
 def test_struct_duplicate_fields():
@@ -844,7 +816,7 @@ def test_map(pickle_module):
 
     assert s.as_py(maps_as_pydicts="strict") == {'a': 1, 'b': 2}
 
-    assert is_python_mapping_like(s)
+    assert isinstance(s, Mapping)
 
 
 def test_map_duplicate_fields():

--- a/python/pyarrow/tests/test_scalars.py
+++ b/python/pyarrow/tests/test_scalars.py
@@ -255,7 +255,7 @@ def test_numerics():
         assert repr(s) == f"<pyarrow.HalfFloatScalar: {np.float16(0.5)!r}>"
         assert str(s) == "0.5"
         assert s.as_py() == 0.5
-        assert int(s) == np.float16(0)
+        assert int(s) == 0
 
 
 def test_decimal128():

--- a/python/pyarrow/tests/test_scalars.py
+++ b/python/pyarrow/tests/test_scalars.py
@@ -809,7 +809,7 @@ def test_map(pickle_module):
         s[-3]
     with pytest.raises(IndexError):
         s[2]
-    with pytest.raises(ValueError):
+    with pytest.raises(KeyError):
         s['fake_key']
 
     restored = pickle_module.loads(pickle_module.dumps(s))

--- a/python/pyarrow/tests/test_scalars.py
+++ b/python/pyarrow/tests/test_scalars.py
@@ -244,13 +244,18 @@ def test_numerics():
     assert str(s) == "1.5"
     assert s.as_py() == 1.5
     assert float(s) == 1.5
+    assert int(s) == 1
 
-    # float16
-    s = pa.scalar(0.5, type='float16')
-    assert isinstance(s, pa.HalfFloatScalar)
-    assert repr(s) == "<pyarrow.HalfFloatScalar: 0.5>"
-    assert str(s) == "0.5"
-    assert s.as_py() == 0.5
+    if np is not None:
+        # float16
+        s = pa.scalar(np.float16(0.5), type='float16')
+        assert isinstance(s, pa.HalfFloatScalar)
+        # on numpy2 repr(np.float16(0.5)) == "np.float16(0.5)"
+        # on numpy1 repr(np.float16(0.5)) == "0.5"
+        assert repr(s) == f"<pyarrow.HalfFloatScalar: {np.float16(0.5)!r}>"
+        assert str(s) == "0.5"
+        assert s.as_py() == 0.5
+        assert int(s) == 0
 
 
 def test_decimal128():

--- a/python/pyarrow/tests/test_scalars.py
+++ b/python/pyarrow/tests/test_scalars.py
@@ -792,10 +792,13 @@ def test_map(pickle_module):
     )
     assert s[-1] == s[1]
     assert s[-2] == s[0]
+    assert s['b'] == pa.scalar(2, type=pa.int8())
     with pytest.raises(IndexError):
         s[-3]
     with pytest.raises(IndexError):
         s[2]
+    with pytest.raises(KeyError):
+        s['fake_key']
 
     restored = pickle_module.loads(pickle_module.dumps(s))
     assert restored.equals(s)

--- a/python/pyarrow/tests/test_scalars.py
+++ b/python/pyarrow/tests/test_scalars.py
@@ -255,7 +255,7 @@ def test_numerics():
         assert repr(s) == f"<pyarrow.HalfFloatScalar: {np.float16(0.5)!r}>"
         assert str(s) == "0.5"
         assert s.as_py() == 0.5
-        assert int(s) == 0
+        assert int(s) == np.float16(0)
 
 
 def test_decimal128():

--- a/python/pyarrow/tests/test_scalars.py
+++ b/python/pyarrow/tests/test_scalars.py
@@ -575,7 +575,7 @@ def test_string(value, ty, scalar_typ):
     assert buf.to_pybytes() == value.encode()
 
 
-@pytest.mark.parametrize('value', [b'foo', b'bar', None])
+@pytest.mark.parametrize('value', [b'foo', b'bar', b'', None])
 @pytest.mark.parametrize(('ty', 'scalar_typ'), [
     (pa.binary(), pa.BinaryScalar),
     (pa.large_binary(), pa.LargeBinaryScalar),
@@ -605,9 +605,9 @@ def test_binary(value, ty, scalar_typ):
         assert memview.format == 'b'
         assert memview.itemsize == 1
         assert memview.ndim == 1
-        assert memview.shape == (3,)
-        assert memview.strides == (1,)  
-
+        assert memview.shape == (len(value),)
+        assert memview.strides == (1,)
+   
 def test_fixed_size_binary():
     s = pa.scalar(b'foof', type=pa.binary(4))
     assert isinstance(s, pa.FixedSizeBinaryScalar)

--- a/python/pyarrow/tests/test_scalars.py
+++ b/python/pyarrow/tests/test_scalars.py
@@ -681,7 +681,7 @@ def test_struct():
 
     v = {'x': 2, 'y': 3.5}
     s = pa.scalar(v, type=ty)
-    assert list(s) == list(s.keys()) == ['x', 'y']
+        
     assert list(s.values()) == [
         pa.scalar(2, type=pa.int16()),
         pa.scalar(3.5, type=pa.float32())
@@ -706,10 +706,6 @@ def test_struct():
 
     with pytest.raises(KeyError):
         s['nonexistent']
-
-    a, b = s
-    assert a == 2
-    assert b == 3.5
 
     s = pa.scalar(None, type=ty)
     assert list(s) == list(s.keys()) == ['x', 'y']

--- a/python/pyarrow/tests/test_scalars.py
+++ b/python/pyarrow/tests/test_scalars.py
@@ -566,8 +566,13 @@ def test_binary(value, ty, scalar_typ):
     assert buf.to_pybytes() == value
 
     memview = memoryview(s)
-    assert isinstance(memview, memoryview)
     assert memview.tobytes() == value
+
+    assert memview.format == 'b'
+    assert memview.itemsize == 1
+    assert memview.ndim == 1
+    assert memview.shape == (3,)
+    assert memview.strides == (1,)
 
 
 def test_fixed_size_binary():

--- a/python/pyarrow/tests/test_scalars.py
+++ b/python/pyarrow/tests/test_scalars.py
@@ -714,6 +714,8 @@ def test_struct():
     assert 'y' in s
     assert isinstance(s['x'], pa.Int16Scalar)
     assert isinstance(s['y'], pa.FloatScalar)
+    assert isinstance(s[0], pa.Int16Scalar)
+    assert isinstance(s[1], pa.FloatScalar)
     assert s['x'].is_valid is False
     assert s['y'].is_valid is False
     assert s['x'].as_py() is None

--- a/python/pyarrow/tests/test_scalars.py
+++ b/python/pyarrow/tests/test_scalars.py
@@ -564,6 +564,7 @@ def test_binary(value, ty, scalar_typ):
     buf = s.as_buffer()
 
     if value is None:
+        assert buf is None
         with pytest.raises(ValueError):
             memoryview(s)
     else:

--- a/python/pyarrow/tests/test_scalars.py
+++ b/python/pyarrow/tests/test_scalars.py
@@ -239,6 +239,7 @@ def test_numerics():
     assert repr(s) == "<pyarrow.DoubleScalar: 1.5>"
     assert str(s) == "1.5"
     assert s.as_py() == 1.5
+    assert float(s) == 1.5
 
     # float16
     s = pa.scalar(0.5, type='float16')

--- a/python/pyarrow/tests/test_scalars.py
+++ b/python/pyarrow/tests/test_scalars.py
@@ -681,7 +681,8 @@ def test_struct():
 
     v = {'x': 2, 'y': 3.5}
     s = pa.scalar(v, type=ty)
-        
+    assert list(s) == list(s.keys()) == ['x', 'y']
+
     assert list(s.values()) == [
         pa.scalar(2, type=pa.int16()),
         pa.scalar(3.5, type=pa.float32())

--- a/python/pyarrow/tests/test_scalars.py
+++ b/python/pyarrow/tests/test_scalars.py
@@ -220,6 +220,9 @@ def test_bool():
     assert true.as_py() is True
     assert false.as_py() is False
 
+    assert bool(true) is True
+    assert bool(false) is False
+
 
 def test_numerics():
     # int64

--- a/python/pyarrow/tests/test_scalars.py
+++ b/python/pyarrow/tests/test_scalars.py
@@ -565,6 +565,10 @@ def test_binary(value, ty, scalar_typ):
     assert isinstance(buf, pa.Buffer)
     assert buf.to_pybytes() == value
 
+    memview = memoryview(s)
+    assert isinstance(memview, memoryview)
+    assert memview.tobytes() == value
+
 
 def test_fixed_size_binary():
     s = pa.scalar(b'foof', type=pa.binary(4))

--- a/python/pyarrow/tests/test_scalars.py
+++ b/python/pyarrow/tests/test_scalars.py
@@ -707,6 +707,10 @@ def test_struct():
     with pytest.raises(KeyError):
         s['nonexistent']
 
+    a, b = s
+    assert a == 2
+    assert b == 3.5
+
     s = pa.scalar(None, type=ty)
     assert list(s) == list(s.keys()) == ['x', 'y']
     assert s.as_py() is None

--- a/python/pyarrow/tests/test_scalars.py
+++ b/python/pyarrow/tests/test_scalars.py
@@ -804,7 +804,7 @@ def test_map(pickle_module):
     )
     assert s[-1] == s[1]
     assert s[-2] == s[0]
-    assert s['b'] == (pa.scalar('b', type=pa.string()), pa.scalar(2, type=pa.int8()))
+    assert s['b'] == pa.scalar(2, type=pa.int8())
     with pytest.raises(IndexError):
         s[-3]
     with pytest.raises(IndexError):

--- a/python/pyarrow/tests/test_scalars.py
+++ b/python/pyarrow/tests/test_scalars.py
@@ -209,20 +209,26 @@ def test_timestamp_scalar():
 def test_bool():
     false = pa.scalar(False)
     true = pa.scalar(True)
+    null = pa.scalar(None, type=pa.bool_())
 
     assert isinstance(false, pa.BooleanScalar)
     assert isinstance(true, pa.BooleanScalar)
+    assert isinstance(null, pa.BooleanScalar)
 
     assert repr(true) == "<pyarrow.BooleanScalar: True>"
     assert str(true) == "True"
     assert repr(false) == "<pyarrow.BooleanScalar: False>"
     assert str(false) == "False"
+    assert repr(null) == "<pyarrow.BooleanScalar: None>"
+    assert str(null) == "None"
 
     assert true.as_py() is True
     assert false.as_py() is False
+    assert null.as_py() is None
 
     assert bool(true) is True
     assert bool(false) is False
+    assert bool(null) is False
 
 
 def test_numerics():

--- a/python/pyarrow/tests/test_scalars.py
+++ b/python/pyarrow/tests/test_scalars.py
@@ -555,6 +555,7 @@ def test_binary(value, ty, scalar_typ):
     assert str(s) == str(value)
     assert repr(value) in repr(s)
     assert s.as_py() == value
+    assert bytes(s) == value
     assert s != b'xxxxx'
 
     buf = s.as_buffer()
@@ -566,6 +567,7 @@ def test_fixed_size_binary():
     s = pa.scalar(b'foof', type=pa.binary(4))
     assert isinstance(s, pa.FixedSizeBinaryScalar)
     assert s.as_py() == b'foof'
+    assert bytes(s) == b'foof'
 
     with pytest.raises(pa.ArrowInvalid):
         pa.scalar(b'foof5', type=pa.binary(4))

--- a/python/pyarrow/tests/test_scalars.py
+++ b/python/pyarrow/tests/test_scalars.py
@@ -258,6 +258,7 @@ def test_numerics():
     assert repr(s) == "<pyarrow.HalfFloatScalar: 0.5>"
     assert str(s) == "0.5"
     assert s.as_py() == 0.5
+    assert float(s) == 1.5
     assert int(s) == 0
 
 

--- a/python/pyarrow/tests/test_scalars.py
+++ b/python/pyarrow/tests/test_scalars.py
@@ -252,16 +252,13 @@ def test_numerics():
     assert float(s) == 1.5
     assert int(s) == 1
 
-    if np is not None:
-        # float16
-        s = pa.scalar(np.float16(0.5), type='float16')
-        assert isinstance(s, pa.HalfFloatScalar)
-        # on numpy2 repr(np.float16(0.5)) == "np.float16(0.5)"
-        # on numpy1 repr(np.float16(0.5)) == "0.5"
-        assert repr(s) == f"<pyarrow.HalfFloatScalar: {np.float16(0.5)!r}>"
-        assert str(s) == "0.5"
-        assert s.as_py() == 0.5
-        assert int(s) == 0
+    # float16
+    s = pa.scalar(np.float16(0.5), type='float16')
+    assert isinstance(s, pa.HalfFloatScalar)
+    assert repr(s) == "<pyarrow.HalfFloatScalar: 0.5>"
+    assert str(s) == "0.5"
+    assert s.as_py() == 0.5
+    assert int(s) == 0
 
 
 def test_decimal128():

--- a/python/pyarrow/tests/test_scalars.py
+++ b/python/pyarrow/tests/test_scalars.py
@@ -228,6 +228,7 @@ def test_numerics():
     assert repr(s) == "<pyarrow.Int64Scalar: 1>"
     assert str(s) == "1"
     assert s.as_py() == 1
+    assert int(s) == 1
 
     with pytest.raises(OverflowError):
         pa.scalar(-1, type='uint8')


### PR DESCRIPTION
### Rationale for this change

Implement dunder methods on Scalar objects

### What changes are included in this PR?

* integer scalars implement `__int__`
* floating-point scalars implement `__float__`
* binary scalars implement [`__bytes__`](https://docs.python.org/3.13/reference/datamodel.html#object.__bytes__)
* binary scalars  implement the [buffer protocol](https://docs.python.org/3.13/reference/datamodel.html#object.__buffer__)
* we explicitly test that Struct scalars implement Sequences
* Map scalar implement mapping


### Are these changes tested?

Yes

### Are there any user-facing changes?

Yes

* GitHub Issue: #45653