### PR TITLE
GH-45825: [C++] Add c directory to Meson configuration

### DIFF
--- a/cpp/src/arrow/c/meson.build
+++ b/cpp/src/arrow/c/meson.build
@@ -1,0 +1,39 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+exc = executable(
+    'arrow-c-bridge-test',
+    sources: ['bridge_test.cc'],
+    dependencies: [arrow_test_dep],
+)
+test('arrow-c-bridge-test', exc)
+
+exc = executable(
+    'arrow-dlpack-test',
+    sources: ['dlpack_test.cc'],
+    dependencies: [arrow_test_dep],
+)
+test('arrow-dlpack-test', exc)
+
+exc = executable(
+    'arrow-bridge-benchmark',
+    sources: ['bridge_benchmark.cc'],
+    dependencies: [arrow_test_dep, benchmark_dep],
+)
+benchmark('arrow-bridge-benchmark', exc)
+
+install_headers(['abi.h', 'bridge.h', 'dlpack_abi.h', 'dlpack.h', 'helpers.h'])

--- a/cpp/src/arrow/meson.build
+++ b/cpp/src/arrow/meson.build
@@ -511,4 +511,5 @@ pkg.generate(
 
 subdir('testing')
 
+subdir('c')
 subdir('util')


### PR DESCRIPTION
### Rationale for this change

This continues adding features to the Arrow C++ Meson configurations

### What changes are included in this PR?

Added the c directory to the Meson configuration

### Are these changes tested?

Yes

### Are there any user-facing changes?

No

* GitHub Issue: #45825