### PR TITLE
GH-45827: [C++] Add io directory to Meson configuration

### DIFF
--- a/cpp/meson.build
+++ b/cpp/meson.build
@@ -58,7 +58,8 @@ endif
 
 needs_benchmarks = get_option('benchmarks')
 needs_csv = get_option('csv')
-needs_filesystem = false
+needs_hdfs = get_option('hdfs')
+needs_filesystem = false or needs_hdfs
 needs_integration = false
 needs_tests = get_option('tests')
 needs_ipc = get_option('ipc') or needs_tests or needs_benchmarks

--- a/cpp/meson.options
+++ b/cpp/meson.options
@@ -30,6 +30,13 @@ option(
 )
 
 option(
+    'hdfs',
+    type: 'boolean',
+    description: 'Build the Arrow HDFS bridge',
+    value: false,
+)
+
+option(
     'ipc',
     type: 'boolean',
     description: 'Build the Arrow IPC extensions',

--- a/cpp/src/arrow/io/meson.build
+++ b/cpp/src/arrow/io/meson.build
@@ -1,0 +1,75 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+io_tests = ['buffered_test', 'compressed_test', 'file_test', 'memory_test']
+
+foreach io_test : io_tests
+    test_name = 'arrow-io-@0@'.format(io_test.replace('_', '-'))
+    exc = executable(
+        test_name,
+        sources: '@0@.cc'.format(io_test),
+        dependencies: [arrow_test_dep],
+        implicit_include_directories: false,
+    )
+    test(test_name, exc)
+endforeach
+
+if needs_hdfs
+    hdfs_incdir = '../../../thirdparty/hadoop/include'
+    exc = executable(
+        'arrow-io-hdfs-test',
+        sources: 'hdfs_test.cc',
+        dependencies: [arrow_test_dep, filesystem_dep],
+        implicit_include_directories: false,
+        include_directories: [hdfs_incdir],
+    )
+    test('arrow-io-hdfs-test', exc)
+endif
+
+io_benchmarks = ['file_benchmark', 'compressed_benchmark']
+
+foreach io_benchmark : io_benchmarks
+    benchmark_name = 'arrow-io-@0@'.format(io_benchmark.replace('_', '-'))
+    exc = executable(
+        benchmark_name,
+        sources: '@0@.cc'.format(io_benchmark),
+        dependencies: [arrow_test_dep, benchmark_dep],
+        implicit_include_directories: false,
+    )
+    benchmark(benchmark_name, exc)
+endforeach
+
+# TODO: Add memory benchmark with SIMD. See GH-45823
+
+install_headers(
+    [
+        'api.h',
+        'buffered.h',
+        'caching.h',
+        'compressed.h',
+        'concurrency.h',
+        'file.h',
+        'hdfs.h',
+        'interfaces.h',
+        'memory.h',
+        'mman.h',
+        'slow.h',
+        'stdio.h',
+        'transform.h',
+        'type_fwd.h',
+    ],
+)

--- a/cpp/src/arrow/io/meson.build
+++ b/cpp/src/arrow/io/meson.build
@@ -72,4 +72,5 @@ install_headers(
         'transform.h',
         'type_fwd.h',
     ],
+    subdir: 'arrow/io',
 )

--- a/cpp/src/arrow/meson.build
+++ b/cpp/src/arrow/meson.build
@@ -263,30 +263,6 @@ else
     rapidjson_dep = disabler()
 endif
 
-if needs_filesystem
-    arrow_fs_srcs = [
-        'filesystem/filesystem.cc',
-        'filesystem/localfs.cc',
-        'filesystem/mockfs.cc',
-        'filesystem/path_util.cc',
-        'filesystem/util_internal.cc',
-    ]
-    arrow_fs_incdir = []
-
-    if needs_hdfs
-        arrow_fs_srcs += 'filesystem/hdfs.cc'
-        hdfs_incdir = '../../thirdparty/hadoop/include'
-        arrow_fs_incdir += hdfs_incdir
-    endif
-
-    arrow_components += {
-        'arrow_filesystem': {
-            'sources': arrow_fs_srcs,
-            'include_dirs': arrow_fs_incdir,
-        },
-    }
-endif
-
 if needs_ipc
     arrow_ipc_srcs = [
         'ipc/dictionary.cc',

--- a/cpp/src/arrow/meson.build
+++ b/cpp/src/arrow/meson.build
@@ -395,7 +395,7 @@ install_headers(
         'visit_scalar_inline.h',
         'visit_type_inline.h',
     ],
-    install_dir: 'arrow',
+    subdir: 'arrow',
 )
 
 if needs_testing

--- a/cpp/src/arrow/meson.build
+++ b/cpp/src/arrow/meson.build
@@ -263,6 +263,30 @@ else
     rapidjson_dep = disabler()
 endif
 
+if needs_filesystem
+    arrow_fs_srcs = [
+        'filesystem/filesystem.cc',
+        'filesystem/localfs.cc',
+        'filesystem/mockfs.cc',
+        'filesystem/path_util.cc',
+        'filesystem/util_internal.cc',
+    ]
+    arrow_fs_incdir = []
+
+    if needs_hdfs
+        arrow_fs_srcs += 'filesystem/hdfs.cc'
+        hdfs_incdir = '../../thirdparty/hadoop/include'
+        arrow_fs_incdir += hdfs_incdir
+    endif
+
+    arrow_components += {
+        'arrow_filesystem': {
+            'sources': arrow_fs_srcs,
+            'include_dirs': arrow_fs_incdir,
+        },
+    }
+endif
+
 if needs_ipc
     arrow_ipc_srcs = [
         'ipc/dictionary.cc',
@@ -531,6 +555,7 @@ pkg.generate(
 subdir('testing')
 
 subdir('c')
+subdir('io')
 subdir('util')
 
 if needs_csv

--- a/cpp/src/arrow/testing/meson.build
+++ b/cpp/src/arrow/testing/meson.build
@@ -35,6 +35,7 @@ install_headers(
         'util.h',
         'visibility.h',
     ],
+    subdir: 'arrow/testing',
 )
 
 if needs_tests


### PR DESCRIPTION
### Rationale for this change

This continues building out the Meson C++ configuration

### What changes are included in this PR?

This adds the io directory to the Meson configuration

### Are these changes tested?

Yes

### Are there any user-facing changes?

No

* GitHub Issue: #45827