### PR TITLE
GH-45831: [C++] Add CSV directory to Meson configuration

### DIFF
--- a/cpp/meson.build
+++ b/cpp/meson.build
@@ -57,6 +57,7 @@ if git_description == ''
 endif
 
 needs_benchmarks = get_option('benchmarks')
+needs_csv = get_option('csv')
 needs_filesystem = false
 needs_integration = false
 needs_tests = get_option('tests')

--- a/cpp/meson.options
+++ b/cpp/meson.options
@@ -23,6 +23,13 @@ option(
 )
 
 option(
+    'csv',
+    type: 'boolean',
+    description: 'Build the Arrow CSV Parser Module',
+    value: false,
+)
+
+option(
     'ipc',
     type: 'boolean',
     description: 'Build the Arrow IPC extensions',

--- a/cpp/src/arrow/csv/meson.build
+++ b/cpp/src/arrow/csv/meson.build
@@ -1,0 +1,71 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+csv_test_sources = [
+    'chunker_test.cc',
+    'column_builder_test.cc',
+    'column_decoder_test.cc',
+    'converter_test.cc',
+    'parser_test.cc',
+    'reader_test.cc',
+    'writer_test.cc',
+]
+
+exc = executable(
+    'arrow-csv-test',
+    sources: csv_test_sources,
+    dependencies: [arrow_test_dep],
+)
+test('arrow-csv-test', exc)
+
+csv_benchmarks = ['converter_benchmark', 'parser_benchmark', 'writer_benchmark']
+
+foreach csv_benchmark : csv_benchmarks
+    benchmark_name = 'arrow-csv-@0@'.format(csv_benchmark.replace('_', '-'))
+    exc = executable(
+        benchmark_name,
+        sources: '@0@.cc'.format(csv_benchmark),
+        dependencies: [arrow_test_dep, benchmark_dep],
+    )
+    benchmark(benchmark_name, exc)
+endforeach
+
+install_headers(
+    [
+        'api.h',
+        'chunker.h',
+        'column_builder.h',
+        'column_decoder.h',
+        'converter.h',
+        'invalid_row.h',
+        'options.h',
+        'parser.h',
+        'reader.h',
+        'test_common.h',
+        'type_fwd.h',
+        'writer.h',
+    ],
+    subdir: 'arrow/csv',
+)
+
+
+pkg.generate(
+    filebase: 'arrow-csv',
+    name: 'Apache Arrow CSV',
+    description: 'CSV reader module for Apache Arrow',
+    requires: 'arrow',
+)

--- a/cpp/src/arrow/meson.build
+++ b/cpp/src/arrow/meson.build
@@ -238,6 +238,25 @@ if needs_integration or needs_tests
     }
 endif
 
+if needs_csv
+    arrow_components += {
+        'arrow_csv': {
+            'sources': [
+                'csv/converter.cc',
+                'csv/chunker.cc',
+                'csv/column_builder.cc',
+                'csv/column_decoder.cc',
+                'csv/options.cc',
+                'csv/parser.cc',
+                'csv/reader.cc',
+                'csv/writer.cc',
+            ],
+        },
+    }
+
+    arrow_testing_srcs += ['csv/test_common.cc']
+endif
+
 if needs_json
     rapidjson_dep = dependency('rapidjson', include_type: 'system')
 else
@@ -512,3 +531,7 @@ pkg.generate(
 subdir('testing')
 
 subdir('util')
+
+if needs_csv
+    subdir('csv')
+endif


### PR DESCRIPTION
### Rationale for this change

This continues improving the Arrow C++ Meson build system

### What changes are included in this PR?

This adds the csv directory to the Meson configuration

### Are these changes tested?

Yes

### Are there any user-facing changes?

No
* GitHub Issue: #45831