### PR TITLE
GH-45833: [C++] Add JSON directory to Meson configuration

### DIFF
--- a/cpp/src/arrow/json/meson.build
+++ b/cpp/src/arrow/json/meson.build
@@ -1,0 +1,61 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+exc = executable(
+    'arrow-json-test',
+    sources: [
+        'chunked_builder_test.cc',
+        'chunker_test.cc',
+        'converter_test.cc',
+        'parser_test.cc',
+        'reader_test.cc',
+    ],
+    dependencies: [arrow_test_dep, rapidjson_dep],
+)
+test('arrow-json-test', exc)
+
+exc = executable(
+    'arrow-json-parser-benchmark',
+    sources: ['parser_benchmark.cc'],
+    dependencies: [arrow_benchmark_dep, rapidjson_dep],
+)
+benchmark('arrow-json-parser-benchmark', exc)
+
+install_headers(
+    [
+        'api.h',
+        'chunked_builder.h',
+        'chunker.h',
+        'converter.h',
+        'object_parser.h',
+        'object_writer.h',
+        'options.h',
+        'parser.h',
+        'rapidjson_defs.h',
+        'reader.h',
+        'test_common.h',
+        'type_fwd.h',
+    ],
+    subdir: 'arrow/json',
+)
+
+pkg.generate(
+    filebase: 'arrow-json',
+    name: 'Apache Arrow JSON',
+    description: 'JSON reader module for Apache Arrow',
+    requires: ['arrow'],
+)

--- a/cpp/src/arrow/meson.build
+++ b/cpp/src/arrow/meson.build
@@ -624,3 +624,7 @@ endif
 if needs_filesystem
     subdir('filesystem')
 endif
+
+if needs_json
+    subdir('json')
+endif


### PR DESCRIPTION
### Rationale for this change

This continues building out the feature set of the C++ Meson build system

### What changes are included in this PR?

This adds the JSON directory to the Meson build configuration

### Are these changes tested?

Yes

### Are there any user-facing changes?

No
* GitHub Issue: #45833