### PR TITLE
GH-45820: [C++] Add optional out_offset for Buffer-returning CopyBitmap function

### DIFF
--- a/cpp/src/arrow/util/bit_util_test.cc
+++ b/cpp/src/arrow/util/bit_util_test.cc
@@ -1589,18 +1589,22 @@ TEST(BitUtilTests, TestCopyBitmap) {
 
   std::vector<int64_t> lengths = {kBufferSize * 8 - 4, kBufferSize * 8};
   std::vector<int64_t> offsets = {0, 12, 16, 32, 37, 63, 64, 128};
-  for (bool maintan_offset : {true, false}) {
-    for (int64_t num_bits : lengths) {
-      for (int64_t offset : offsets) {
+  for (int64_t num_bits : lengths) {
+    for (int64_t offset : offsets) {
+      std::vector<int64_t> dest_offsets = {0, offset - 1, offset + 1};
+      for (int64_t dest_offset : dest_offsets) {
+        if (dest_offset < 0) {
+          continue;
+        }
         const int64_t copy_length = num_bits - offset;
 
         std::shared_ptr<Buffer> copy;
         ASSERT_OK_AND_ASSIGN(copy, CopyBitmap(default_memory_pool(), src, offset,
-                                              copy_length, maintan_offset ? offset : 0));
+                                              copy_length, dest_offset));
 
         for (int64_t i = 0; i < copy_length; ++i) {
           ASSERT_EQ(bit_util::GetBit(src, i + offset),
-                    bit_util::GetBit(copy->data(), i + (maintan_offset ? offset : 0)));
+                    bit_util::GetBit(copy->data(), i + dest_offset));
         }
       }
     }

--- a/cpp/src/arrow/util/bit_util_test.cc
+++ b/cpp/src/arrow/util/bit_util_test.cc
@@ -1589,16 +1589,19 @@ TEST(BitUtilTests, TestCopyBitmap) {
 
   std::vector<int64_t> lengths = {kBufferSize * 8 - 4, kBufferSize * 8};
   std::vector<int64_t> offsets = {0, 12, 16, 32, 37, 63, 64, 128};
-  for (int64_t num_bits : lengths) {
-    for (int64_t offset : offsets) {
-      const int64_t copy_length = num_bits - offset;
+  for (bool maintan_offset : {true, false}) {
+    for (int64_t num_bits : lengths) {
+      for (int64_t offset : offsets) {
+        const int64_t copy_length = num_bits - offset;
 
-      std::shared_ptr<Buffer> copy;
-      ASSERT_OK_AND_ASSIGN(copy,
-                           CopyBitmap(default_memory_pool(), src, offset, copy_length));
+        std::shared_ptr<Buffer> copy;
+        ASSERT_OK_AND_ASSIGN(copy, CopyBitmap(default_memory_pool(), src, offset,
+                                              copy_length, maintan_offset ? offset : 0));
 
-      for (int64_t i = 0; i < copy_length; ++i) {
-        ASSERT_EQ(bit_util::GetBit(src, i + offset), bit_util::GetBit(copy->data(), i));
+        for (int64_t i = 0; i < copy_length; ++i) {
+          ASSERT_EQ(bit_util::GetBit(src, i + offset),
+                    bit_util::GetBit(copy->data(), i + (maintan_offset ? offset : 0)));
+        }
       }
     }
   }

--- a/cpp/src/arrow/util/bitmap_ops.cc
+++ b/cpp/src/arrow/util/bitmap_ops.cc
@@ -257,7 +257,8 @@ Result<std::shared_ptr<Buffer>> CopyBitmap(MemoryPool* pool, const uint8_t* data
 
 Result<std::shared_ptr<Buffer>> InvertBitmap(MemoryPool* pool, const uint8_t* data,
                                              int64_t offset, int64_t length) {
-  return TransferBitmap<TransferMode::Invert>(pool, data, offset, length, 0);
+  return TransferBitmap<TransferMode::Invert>(pool, data, offset, length,
+                                              /*out_offset=*/0);
 }
 
 Result<std::shared_ptr<Buffer>> ReverseBitmap(MemoryPool* pool, const uint8_t* data,

--- a/cpp/src/arrow/util/bitmap_ops.cc
+++ b/cpp/src/arrow/util/bitmap_ops.cc
@@ -225,9 +225,9 @@ Result<std::shared_ptr<Buffer>> TransferBitmap(MemoryPool* pool, const uint8_t* 
 
   // As we have freshly allocated this bitmap, we should take care of zeroing the
   // remaining bits.
-  int64_t num_bytes = bit_util::BytesForBits(length);
-  int64_t bits_to_zero = num_bytes * 8 - length;
-  for (int64_t i = length; i < length + bits_to_zero; ++i) {
+  int64_t num_bytes = bit_util::BytesForBits(phys_bits);
+  int64_t bits_to_zero = num_bytes * 8 - phys_bits;
+  for (int64_t i = phys_bits; i < phys_bits + bits_to_zero; ++i) {
     // Both branches may copy extra bits - unsetting to match specification.
     bit_util::ClearBit(dest, i);
   }

--- a/cpp/src/arrow/util/bitmap_ops.cc
+++ b/cpp/src/arrow/util/bitmap_ops.cc
@@ -223,14 +223,6 @@ Result<std::shared_ptr<Buffer>> TransferBitmap(MemoryPool* pool, const uint8_t* 
 
   TransferBitmap<mode>(data, offset, length, out_offset, dest);
 
-  // As we have freshly allocated this bitmap, we should take care of zeroing the
-  // remaining bits.
-  int64_t num_bytes = bit_util::BytesForBits(phys_bits);
-  int64_t bits_to_zero = num_bytes * 8 - phys_bits;
-  for (int64_t i = phys_bits; i < phys_bits + bits_to_zero; ++i) {
-    // Both branches may copy extra bits - unsetting to match specification.
-    bit_util::ClearBit(dest, i);
-  }
   return buffer;
 }
 

--- a/cpp/src/arrow/util/bitmap_ops.h
+++ b/cpp/src/arrow/util/bitmap_ops.h
@@ -40,6 +40,7 @@ namespace internal {
 /// \param[in] offset bit offset into the source data
 /// \param[in] length number of bits to copy
 /// \param[in] out_offset bit offset into the output buffer
+///
 /// \return Status message
 ARROW_EXPORT
 Result<std::shared_ptr<Buffer>> CopyBitmap(MemoryPool* pool, const uint8_t* bitmap,

--- a/cpp/src/arrow/util/bitmap_ops.h
+++ b/cpp/src/arrow/util/bitmap_ops.h
@@ -39,7 +39,6 @@ namespace internal {
 /// \param[in] bitmap source data
 /// \param[in] offset bit offset into the source data
 /// \param[in] length number of bits to copy
-/// \param[in] length number of bits to copy
 /// \param[in] out_offset bit offset into the output buffer
 /// \return Status message
 ARROW_EXPORT

--- a/cpp/src/arrow/util/bitmap_ops.h
+++ b/cpp/src/arrow/util/bitmap_ops.h
@@ -39,11 +39,13 @@ namespace internal {
 /// \param[in] bitmap source data
 /// \param[in] offset bit offset into the source data
 /// \param[in] length number of bits to copy
-///
+/// \param[in] length number of bits to copy
+/// \param[in] out_offset bit offset into the output buffer
 /// \return Status message
 ARROW_EXPORT
 Result<std::shared_ptr<Buffer>> CopyBitmap(MemoryPool* pool, const uint8_t* bitmap,
-                                           int64_t offset, int64_t length);
+                                           int64_t offset, int64_t length,
+                                           int64_t out_offset = 0);
 
 /// Copy a bit range of an existing bitmap into an existing bitmap
 ///


### PR DESCRIPTION
### Rationale for this change

The `CopyBitmap` variant that returns a `std::shared_ptr<Buffer>` doesn't allow passing a destination bit offset for the output.

Accepting such an argument would allow using that function to replace the null bitmap of an existing array, without changing its offset.

### What changes are included in this PR?

Adding the option `out_offset` argument.

### Are these changes tested?

Yes, the existing `TestCopyBitmap` has been adapted to use `dest_offset` or not.

### Are there any user-facing changes?

No, but we allow a new optional argument (`out_offset`) to `CopyBitmap`

* GitHub Issue: #45820