### PR TITLE
GH-45853: [C++][Dev] Fix Meson compilation issues in Docker builds

### DIFF
--- a/ci/scripts/cpp_build.sh
+++ b/ci/scripts/cpp_build.sh
@@ -118,11 +118,26 @@ if [ "${ARROW_USE_MESON:-OFF}" = "ON" ]; then
     fi
   }
 
-  ORIGINAL_CXX=${CXX}
-  if [ "${ARROW_USE_CCACHE}" = "ON" ]; then
-      export CXX="ccache ${CXX}"
-  else
-      export CXX="sccache ${CXX}"
+  ORIGINAL_CC="${CC}"
+  if [ -n "${CC}" ]; then
+    if [ "${ARROW_USE_CCACHE}" = "ON" ]; then
+      CC="ccache ${CC}"
+    else
+      if command -v sccache; then
+        CC="sccache ${CC}"
+      fi
+    fi
+  fi
+
+  ORIGINAL_CXX="${CXX}"
+  if [ -n "${CXX}" ]; then
+    if [ "${ARROW_USE_CCACHE}" = "ON" ]; then
+      CXX="ccache ${CXX}"
+    else
+      if command -v sccache; then
+        CXX="sccache ${CXX}"
+      fi
+    fi
   fi
   meson setup \
     --prefix=${MESON_PREFIX:-${ARROW_HOME}} \
@@ -133,7 +148,8 @@ if [ "${ARROW_USE_MESON:-OFF}" = "ON" ]; then
     . \
     ${source_dir}
 
-  export CXX=${ORIGINAL_CXX}
+  CC="${ORIGINAL_CC}"
+  CXX="${ORIGINAL_CXX}"
 elif [ "${ARROW_EMSCRIPTEN:-OFF}" = "ON" ]; then
   if [ "${UBUNTU}" = "20.04" ]; then
     echo "arrow emscripten build is not supported on Ubuntu 20.04, run with UBUNTU=22.04"

--- a/ci/scripts/cpp_build.sh
+++ b/ci/scripts/cpp_build.sh
@@ -118,6 +118,12 @@ if [ "${ARROW_USE_MESON:-OFF}" = "ON" ]; then
     fi
   }
 
+  ORIGINAL_CXX=${CXX}
+  if [ "${ARROW_USE_CCACHE}" = "ON" ]; then
+      export CXX="ccache ${CXX}"
+  else
+      export CXX="sccache ${CXX}"
+  fi
   meson setup \
     --prefix=${MESON_PREFIX:-${ARROW_HOME}} \
     --buildtype=${ARROW_BUILD_TYPE:-debug} \
@@ -126,6 +132,8 @@ if [ "${ARROW_USE_MESON:-OFF}" = "ON" ]; then
     -Ds3=disabled \
     . \
     ${source_dir}
+
+  export CXX=${ORIGINAL_CXX}
 elif [ "${ARROW_EMSCRIPTEN:-OFF}" = "ON" ]; then
   if [ "${UBUNTU}" = "20.04" ]; then
     echo "arrow emscripten build is not supported on Ubuntu 20.04, run with UBUNTU=22.04"

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -657,7 +657,7 @@ tasks:
     ci: github
     template: docker-tests/github.linux.yml
     params:
-      # ARROW_USE_CACHE=OFF is for using sccache
+      # ARROW_USE_CCACHE=OFF is for using sccache
       flags: >-
         -e ARROW_USE_CCACHE=OFF
         -e ARROW_USE_MESON=ON

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -657,7 +657,10 @@ tasks:
     ci: github
     template: docker-tests/github.linux.yml
     params:
-      flags: -e ARROW_USE_MESON=ON
+      # ARROW_USE_CACHE=OFF is for using sccache
+      flags: >-
+        -e ARROW_USE_CCACHE=OFF
+        -e ARROW_USE_MESON=ON
       image: conda-cpp
 
   test-conda-cpp-valgrind:


### PR DESCRIPTION
### Rationale for this change

The Meson configure runs very slowly in Docker builds

### What changes are included in this PR?

This makes it so that ccache or sccache can be used

### Are these changes tested?

Yes

### Are there any user-facing changes?

No

* GitHub Issue: #45853