### PR TITLE
GH-45819: [C++] Add OptionalBitmapAnd utility function

### DIFF
--- a/cpp/src/arrow/util/bit_util_test.cc
+++ b/cpp/src/arrow/util/bit_util_test.cc
@@ -64,6 +64,7 @@ using internal::BitsetStack;
 using internal::CopyBitmap;
 using internal::CountSetBits;
 using internal::InvertBitmap;
+using internal::OptionalBitmapAnd;
 using internal::ReverseBitmap;
 using util::SafeCopy;
 
@@ -1272,6 +1273,24 @@ struct BitmapOperation {
   virtual ~BitmapOperation() = default;
 };
 
+struct OptionalBitmapAndOp : public BitmapOperation {
+  Result<std::shared_ptr<Buffer>> Call(MemoryPool* pool, const uint8_t* left,
+                                       int64_t left_offset, const uint8_t* right,
+                                       int64_t right_offset, int64_t length,
+                                       int64_t out_offset) const override {
+    return OptionalBitmapAnd(pool, left, left_offset, right, right_offset, length,
+                             out_offset);
+  }
+
+  Status Call(const uint8_t* left, int64_t left_offset, const uint8_t* right,
+              int64_t right_offset, int64_t length, int64_t out_offset,
+              uint8_t* out_buffer) const override {
+    OptionalBitmapAnd(left, left_offset, right, right_offset, length, out_offset,
+                      out_buffer);
+    return Status::OK();
+  }
+};
+
 struct BitmapAndOp : public BitmapOperation {
   Result<std::shared_ptr<Buffer>> Call(MemoryPool* pool, const uint8_t* left,
                                        int64_t left_offset, const uint8_t* right,
@@ -1342,23 +1361,34 @@ class BitmapOp : public ::testing::Test {
                    const std::vector<int>& right_bits,
                    const std::vector<int>& result_bits) {
     std::shared_ptr<Buffer> left, right, out;
-    int64_t length;
+    int64_t length{0};
+    uint8_t *left_buffer, *right_buffer;
 
     for (int64_t left_offset : {0, 1, 3, 5, 7, 8, 13, 21, 38, 75, 120, 65536}) {
-      BitmapFromVector(left_bits, left_offset, &left, &length);
+      if (left_bits.size() > 0) {
+        BitmapFromVector(left_bits, left_offset, &left, &length);
+        left_buffer = left->mutable_data();
+      } else {
+        left_buffer = nullptr;
+      }
       for (int64_t right_offset : {left_offset, left_offset + 8, left_offset + 40}) {
-        BitmapFromVector(right_bits, right_offset, &right, &length);
+        if (right_bits.size() > 0) {
+          BitmapFromVector(right_bits, right_offset, &right, &length);
+          right_buffer = right->mutable_data();
+        } else {
+          right_buffer = nullptr;
+        }
         for (int64_t out_offset : {left_offset, left_offset + 16, left_offset + 24}) {
           ASSERT_OK_AND_ASSIGN(
-              out, op.Call(default_memory_pool(), left->mutable_data(), left_offset,
-                           right->mutable_data(), right_offset, length, out_offset));
+              out, op.Call(default_memory_pool(), left_buffer, left_offset, right_buffer,
+                           right_offset, length, out_offset));
           auto reader = internal::BitmapReader(out->mutable_data(), out_offset, length);
           ASSERT_READER_VALUES(reader, result_bits);
 
           // Clear out buffer and try non-allocating version
           std::memset(out->mutable_data(), 0, out->size());
-          ASSERT_OK(op.Call(left->mutable_data(), left_offset, right->mutable_data(),
-                            right_offset, length, out_offset, out->mutable_data()));
+          ASSERT_OK(op.Call(left_buffer, left_offset, right_buffer, right_offset, length,
+                            out_offset, out->mutable_data()));
           reader = internal::BitmapReader(out->mutable_data(), out_offset, length);
           ASSERT_READER_VALUES(reader, result_bits);
         }
@@ -1370,26 +1400,36 @@ class BitmapOp : public ::testing::Test {
                      const std::vector<int>& right_bits,
                      const std::vector<int>& result_bits) {
     std::shared_ptr<Buffer> left, right, out;
-    int64_t length;
+    int64_t length{0};
+    uint8_t *left_buffer, *right_buffer;
     auto offset_values = {0, 1, 3, 5, 7, 8, 13, 21, 38, 75, 120, 65536};
 
     for (int64_t left_offset : offset_values) {
-      BitmapFromVector(left_bits, left_offset, &left, &length);
+      if (left_bits.size() > 0) {
+        BitmapFromVector(left_bits, left_offset, &left, &length);
+        left_buffer = left->mutable_data();
+      } else {
+        left_buffer = nullptr;
+      }
 
       for (int64_t right_offset : offset_values) {
-        BitmapFromVector(right_bits, right_offset, &right, &length);
-
+        if (right_bits.size() > 0) {
+          BitmapFromVector(right_bits, right_offset, &right, &length);
+          right_buffer = right->mutable_data();
+        } else {
+          right_buffer = nullptr;
+        }
         for (int64_t out_offset : offset_values) {
           ASSERT_OK_AND_ASSIGN(
-              out, op.Call(default_memory_pool(), left->mutable_data(), left_offset,
-                           right->mutable_data(), right_offset, length, out_offset));
+              out, op.Call(default_memory_pool(), left_buffer, left_offset, right_buffer,
+                           right_offset, length, out_offset));
           auto reader = internal::BitmapReader(out->mutable_data(), out_offset, length);
           ASSERT_READER_VALUES(reader, result_bits);
 
           // Clear out buffer and try non-allocating version
           std::memset(out->mutable_data(), 0, out->size());
-          ASSERT_OK(op.Call(left->mutable_data(), left_offset, right->mutable_data(),
-                            right_offset, length, out_offset, out->mutable_data()));
+          ASSERT_OK(op.Call(left_buffer, left_offset, right_buffer, right_offset, length,
+                            out_offset, out->mutable_data()));
           reader = internal::BitmapReader(out->mutable_data(), out_offset, length);
           ASSERT_READER_VALUES(reader, result_bits);
         }
@@ -1397,6 +1437,24 @@ class BitmapOp : public ::testing::Test {
     }
   }
 };
+
+TEST_F(BitmapOp, OptionalAnd) {
+  OptionalBitmapAndOp op;
+  std::vector<int> left = {0, 1, 1, 1, 0, 0, 0, 1, 0, 1, 0, 1, 0, 1};
+  std::vector<int> right = {0, 0, 1, 0, 1, 1, 0, 0, 1, 1, 1, 0, 1, 0};
+  std::vector<int> result = {0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0};
+
+  TestAligned(op, left, right, result);
+  TestUnaligned(op, left, right, result);
+
+  result = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  TestAligned(op, {}, right, result);
+  TestUnaligned(op, {}, right, result);
+  TestAligned(op, left, {}, result);
+  TestUnaligned(op, left, {}, result);
+  TestAligned(op, {}, {}, {});
+  TestUnaligned(op, {}, {}, {});
+}
 
 TEST_F(BitmapOp, And) {
   BitmapAndOp op;

--- a/cpp/src/arrow/util/bit_util_test.cc
+++ b/cpp/src/arrow/util/bit_util_test.cc
@@ -1370,25 +1370,25 @@ class BitmapOp : public ::testing::Test {
                    const std::vector<int>& result_bits) {
     std::shared_ptr<Buffer> left, right, out;
     int64_t length{0};
-    uint8_t *left_buffer, *right_buffer;
+    uint8_t *left_data, *right_data;
 
     for (int64_t left_offset : {0, 1, 3, 5, 7, 8, 13, 21, 38, 75, 120, 65536}) {
       if (left_bits.size() > 0) {
         BitmapFromVector(left_bits, left_offset, &left, &length);
-        left_buffer = left->mutable_data();
+        left_data = left->mutable_data();
       } else {
-        left_buffer = nullptr;
+        left_data = nullptr;
       }
       for (int64_t right_offset : {left_offset, left_offset + 8, left_offset + 40}) {
         if (right_bits.size() > 0) {
           BitmapFromVector(right_bits, right_offset, &right, &length);
-          right_buffer = right->mutable_data();
+          right_data = right->mutable_data();
         } else {
-          right_buffer = nullptr;
+          right_data = nullptr;
         }
         for (int64_t out_offset : {left_offset, left_offset + 16, left_offset + 24}) {
           ASSERT_OK_AND_ASSIGN(
-              out, op.Call(default_memory_pool(), left_buffer, left_offset, right_buffer,
+              out, op.Call(default_memory_pool(), left_data, left_offset, right_data,
                            right_offset, length, out_offset));
           if (out == nullptr) {
             ASSERT_EQ(std::vector<int>{}, result_bits);
@@ -1398,7 +1398,7 @@ class BitmapOp : public ::testing::Test {
 
             // Clear out buffer and try non-allocating version
             std::memset(out->mutable_data(), 0, out->size());
-            auto status = op.Call(left_buffer, left_offset, right_buffer, right_offset,
+            auto status = op.Call(left_data, left_offset, right_data, right_offset,
                                   length, out_offset, out->mutable_data());
             if (status.IsNotImplemented()) {
               ASSERT_EQ(
@@ -1421,27 +1421,27 @@ class BitmapOp : public ::testing::Test {
                      const std::vector<int>& result_bits) {
     std::shared_ptr<Buffer> left, right, out;
     int64_t length{0};
-    uint8_t *left_buffer, *right_buffer;
+    uint8_t *left_data, *right_data;
     auto offset_values = {0, 1, 3, 5, 7, 8, 13, 21, 38, 75, 120, 65536};
 
     for (int64_t left_offset : offset_values) {
       if (left_bits.size() > 0) {
         BitmapFromVector(left_bits, left_offset, &left, &length);
-        left_buffer = left->mutable_data();
+        left_data = left->mutable_data();
       } else {
-        left_buffer = nullptr;
+        left_data = nullptr;
       }
 
       for (int64_t right_offset : offset_values) {
         if (right_bits.size() > 0) {
           BitmapFromVector(right_bits, right_offset, &right, &length);
-          right_buffer = right->mutable_data();
+          right_data = right->mutable_data();
         } else {
-          right_buffer = nullptr;
+          right_data = nullptr;
         }
         for (int64_t out_offset : offset_values) {
           ASSERT_OK_AND_ASSIGN(
-              out, op.Call(default_memory_pool(), left_buffer, left_offset, right_buffer,
+              out, op.Call(default_memory_pool(), left_data, left_offset, right_data,
                            right_offset, length, out_offset));
           if (out == nullptr) {
             ASSERT_EQ(std::vector<int>{}, result_bits);
@@ -1451,7 +1451,7 @@ class BitmapOp : public ::testing::Test {
 
             // Clear out buffer and try non-allocating version
             std::memset(out->mutable_data(), 0, out->size());
-            auto status = op.Call(left_buffer, left_offset, right_buffer, right_offset,
+            auto status = op.Call(left_data, left_offset, right_data, right_offset,
                                   length, out_offset, out->mutable_data());
             if (status.IsNotImplemented()) {
               ASSERT_EQ(

--- a/cpp/src/arrow/util/bit_util_test.cc
+++ b/cpp/src/arrow/util/bit_util_test.cc
@@ -1382,15 +1382,19 @@ class BitmapOp : public ::testing::Test {
           ASSERT_OK_AND_ASSIGN(
               out, op.Call(default_memory_pool(), left_buffer, left_offset, right_buffer,
                            right_offset, length, out_offset));
-          auto reader = internal::BitmapReader(out->mutable_data(), out_offset, length);
-          ASSERT_READER_VALUES(reader, result_bits);
-
-          // Clear out buffer and try non-allocating version
-          std::memset(out->mutable_data(), 0, out->size());
-          ASSERT_OK(op.Call(left_buffer, left_offset, right_buffer, right_offset, length,
-                            out_offset, out->mutable_data()));
-          reader = internal::BitmapReader(out->mutable_data(), out_offset, length);
-          ASSERT_READER_VALUES(reader, result_bits);
+          if (out == nullptr) {
+            ASSERT_EQ(std::vector<int>{}, result_bits);
+            // TODO(raulcd) This has to test the case of non-allocating buffer
+          } else {
+            auto reader = internal::BitmapReader(out->mutable_data(), out_offset, length);
+            ASSERT_READER_VALUES(reader, result_bits);
+            // Clear out buffer and try non-allocating version
+            std::memset(out->mutable_data(), 0, out->size());
+            ASSERT_OK(op.Call(left_buffer, left_offset, right_buffer, right_offset,
+                              length, out_offset, out->mutable_data()));
+            reader = internal::BitmapReader(out->mutable_data(), out_offset, length);
+            ASSERT_READER_VALUES(reader, result_bits);
+          }
         }
       }
     }
@@ -1423,15 +1427,20 @@ class BitmapOp : public ::testing::Test {
           ASSERT_OK_AND_ASSIGN(
               out, op.Call(default_memory_pool(), left_buffer, left_offset, right_buffer,
                            right_offset, length, out_offset));
-          auto reader = internal::BitmapReader(out->mutable_data(), out_offset, length);
-          ASSERT_READER_VALUES(reader, result_bits);
+          if (out == nullptr) {
+            ASSERT_EQ(std::vector<int>{}, result_bits);
+            // TODO: This has to test the case of non-allocating buffer
+          } else {
+            auto reader = internal::BitmapReader(out->mutable_data(), out_offset, length);
+            ASSERT_READER_VALUES(reader, result_bits);
 
-          // Clear out buffer and try non-allocating version
-          std::memset(out->mutable_data(), 0, out->size());
-          ASSERT_OK(op.Call(left_buffer, left_offset, right_buffer, right_offset, length,
-                            out_offset, out->mutable_data()));
-          reader = internal::BitmapReader(out->mutable_data(), out_offset, length);
-          ASSERT_READER_VALUES(reader, result_bits);
+            // Clear out buffer and try non-allocating version
+            std::memset(out->mutable_data(), 0, out->size());
+            ASSERT_OK(op.Call(left_buffer, left_offset, right_buffer, right_offset,
+                              length, out_offset, out->mutable_data()));
+            reader = internal::BitmapReader(out->mutable_data(), out_offset, length);
+            ASSERT_READER_VALUES(reader, result_bits);
+          }
         }
       }
     }
@@ -1448,10 +1457,10 @@ TEST_F(BitmapOp, OptionalAnd) {
   TestUnaligned(op, left, right, result);
 
   result = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-  TestAligned(op, {}, right, result);
-  TestUnaligned(op, {}, right, result);
-  TestAligned(op, left, {}, result);
-  TestUnaligned(op, left, {}, result);
+  TestAligned(op, {}, right, right);
+  TestUnaligned(op, {}, right, right);
+  TestAligned(op, left, {}, left);
+  TestUnaligned(op, left, {}, left);
   TestAligned(op, {}, {}, {});
   TestUnaligned(op, {}, {}, {});
 }

--- a/cpp/src/arrow/util/bitmap_ops.cc
+++ b/cpp/src/arrow/util/bitmap_ops.cc
@@ -394,6 +394,32 @@ Result<std::shared_ptr<Buffer>> BitmapOp(MemoryPool* pool, const uint8_t* left,
 
 }  // namespace
 
+Result<std::shared_ptr<Buffer>> OptionalBitmapAnd(MemoryPool* pool, const uint8_t* left,
+                                                  int64_t left_offset,
+                                                  const uint8_t* right,
+                                                  int64_t right_offset, int64_t length,
+                                                  int64_t out_offset) {
+  if (left == nullptr || right == nullptr) {
+    const int64_t phys_bits = length + out_offset;
+    ARROW_ASSIGN_OR_RAISE(auto out_buffer, AllocateEmptyBitmap(phys_bits, pool));
+    return out_buffer;
+  } else {
+    return BitmapOp<std::bit_and>(pool, left, left_offset, right, right_offset, length,
+                                  out_offset);
+  }
+}
+
+void OptionalBitmapAnd(const uint8_t* left, int64_t left_offset, const uint8_t* right,
+                       int64_t right_offset, int64_t length, int64_t out_offset,
+                       uint8_t* out) {
+  if (left == nullptr || right == nullptr) {
+    bit_util::ClearBitmap(out, out_offset, length);
+  } else {
+    BitmapOp<std::bit_and>(left, left_offset, right, right_offset, length, out_offset,
+                           out);
+  }
+}
+
 Result<std::shared_ptr<Buffer>> BitmapAnd(MemoryPool* pool, const uint8_t* left,
                                           int64_t left_offset, const uint8_t* right,
                                           int64_t right_offset, int64_t length,

--- a/cpp/src/arrow/util/bitmap_ops.cc
+++ b/cpp/src/arrow/util/bitmap_ops.cc
@@ -399,10 +399,12 @@ Result<std::shared_ptr<Buffer>> OptionalBitmapAnd(MemoryPool* pool, const uint8_
                                                   const uint8_t* right,
                                                   int64_t right_offset, int64_t length,
                                                   int64_t out_offset) {
-  if (left == nullptr || right == nullptr) {
-    const int64_t phys_bits = length + out_offset;
-    ARROW_ASSIGN_OR_RAISE(auto out_buffer, AllocateEmptyBitmap(phys_bits, pool));
-    return out_buffer;
+  if (left == nullptr && right == nullptr) {
+    return nullptr;
+  } else if (left == nullptr) {
+    return CopyBitmap(pool, right, right_offset, length, out_offset);
+  } else if (right == nullptr) {
+    return CopyBitmap(pool, left, left_offset, length, out_offset);
   } else {
     return BitmapOp<std::bit_and>(pool, left, left_offset, right, right_offset, length,
                                   out_offset);
@@ -412,8 +414,15 @@ Result<std::shared_ptr<Buffer>> OptionalBitmapAnd(MemoryPool* pool, const uint8_
 void OptionalBitmapAnd(const uint8_t* left, int64_t left_offset, const uint8_t* right,
                        int64_t right_offset, int64_t length, int64_t out_offset,
                        uint8_t* out) {
-  if (left == nullptr || right == nullptr) {
-    bit_util::ClearBitmap(out, out_offset, length);
+  if (left == nullptr && right == nullptr) {
+    return;
+  } else if (left == nullptr) {
+    // TODO(raulcd) this is obviously wrong. Investigate how to copy right to out.
+    BitmapOp<std::bit_and>(right, right_offset, right, right_offset, length, out_offset,
+                           out);
+  } else if (right == nullptr) {
+    // TODO(raulcd) this is obviously wrong. Investigate how to copy left to out.
+    BitmapOp<std::bit_and>(left, left_offset, left, left_offset, length, out_offset, out);
   } else {
     BitmapOp<std::bit_and>(left, left_offset, right, right_offset, length, out_offset,
                            out);

--- a/cpp/src/arrow/util/bitmap_ops.h
+++ b/cpp/src/arrow/util/bitmap_ops.h
@@ -150,6 +150,31 @@ bool OptionalBitmapEquals(const std::shared_ptr<Buffer>& left, int64_t left_offs
 /// \brief Do a "bitmap and" on right and left buffers starting at
 /// their respective bit-offsets for the given bit-length and put
 /// the results in out_buffer starting at the given bit-offset.
+/// Both right and left buffers are optional. If any of the buffers is
+/// null a bitmap of zeros is returned.
+///
+/// out_buffer will be allocated and initialized to zeros using pool before
+/// the operation.
+ARROW_EXPORT
+Result<std::shared_ptr<Buffer>> OptionalBitmapAnd(MemoryPool* pool, const uint8_t* left,
+                                                  int64_t left_offset,
+                                                  const uint8_t* right,
+                                                  int64_t right_offset, int64_t length,
+                                                  int64_t out_offset);
+
+/// \brief Do a "bitmap and" on right and left buffers starting at
+/// their respective bit-offsets for the given bit-length and put
+/// the results in out starting at the given bit-offset.
+/// Both right and left buffers are optional. If any of the buffers is
+/// null a bitmap of zeros is returned.
+ARROW_EXPORT
+void OptionalBitmapAnd(const uint8_t* left, int64_t left_offset, const uint8_t* right,
+                       int64_t right_offset, int64_t length, int64_t out_offset,
+                       uint8_t* out);
+
+/// \brief Do a "bitmap and" on right and left buffers starting at
+/// their respective bit-offsets for the given bit-length and put
+/// the results in out_buffer starting at the given bit-offset.
 ///
 /// out_buffer will be allocated and initialized to zeros using pool before
 /// the operation.

--- a/cpp/src/arrow/util/bitmap_ops.h
+++ b/cpp/src/arrow/util/bitmap_ops.h
@@ -150,10 +150,10 @@ bool OptionalBitmapEquals(const std::shared_ptr<Buffer>& left, int64_t left_offs
 /// \brief Do a "bitmap and" on right and left buffers starting at
 /// their respective bit-offsets for the given bit-length and put
 /// the results in out_buffer starting at the given bit-offset.
-/// Both right and left buffers are optional. If any of the buffers is
-/// null a bitmap of zeros is returned.
+/// Both right and left buffers are optional. If one of the buffers is
+/// null the non-null bitmap is returned. If both are null a nullptr is returned.
 ///
-/// out_buffer will be allocated and initialized to zeros using pool before
+/// if necessary out_buffer will be allocated and initialized to zeros using pool before
 /// the operation.
 ARROW_EXPORT
 Result<std::shared_ptr<Buffer>> OptionalBitmapAnd(MemoryPool* pool, const uint8_t* left,

--- a/cpp/src/arrow/util/bitmap_ops.h
+++ b/cpp/src/arrow/util/bitmap_ops.h
@@ -148,26 +148,19 @@ bool OptionalBitmapEquals(const std::shared_ptr<Buffer>& left, int64_t left_offs
                           int64_t length);
 
 /// \brief Do a "bitmap and" on right and left buffers starting at
-/// their respective bit-offsets for the given bit-length and put
-/// the results in out_buffer starting at the given bit-offset.
+/// their respective bit-offsets for the given bit-length and return
+/// the result buffer starting at the given bit-offset.
 /// Both right and left buffers are optional. If one of the buffers is
-/// null the non-null bitmap is returned. If both are null a nullptr is returned.
+/// null the non-null bitmap is returned if out_offset and input_offset are
+/// compatible. If non-compatible a copy of the bitmap is performed.
+// If both right and left are null a nullptr is returned.
 ARROW_EXPORT
-Result<std::shared_ptr<Buffer>> OptionalBitmapAnd(MemoryPool* pool, const uint8_t* left,
+Result<std::shared_ptr<Buffer>> OptionalBitmapAnd(MemoryPool* pool,
+                                                  const std::shared_ptr<Buffer>& left,
                                                   int64_t left_offset,
-                                                  const uint8_t* right,
+                                                  const std::shared_ptr<Buffer>& right,
                                                   int64_t right_offset, int64_t length,
                                                   int64_t out_offset);
-
-/// \brief Do a "bitmap and" on right and left buffers starting at
-/// their respective bit-offsets for the given bit-length and put
-/// the results in out starting at the given bit-offset.
-/// Both right and left buffers are optional. If one of the buffers is
-/// null the non-null bitmap is copied. If both are null out is not modified.
-ARROW_EXPORT
-void OptionalBitmapAnd(const uint8_t* left, int64_t left_offset, const uint8_t* right,
-                       int64_t right_offset, int64_t length, int64_t out_offset,
-                       uint8_t* out);
 
 /// \brief Do a "bitmap and" on right and left buffers starting at
 /// their respective bit-offsets for the given bit-length and put

--- a/cpp/src/arrow/util/bitmap_ops.h
+++ b/cpp/src/arrow/util/bitmap_ops.h
@@ -152,9 +152,6 @@ bool OptionalBitmapEquals(const std::shared_ptr<Buffer>& left, int64_t left_offs
 /// the results in out_buffer starting at the given bit-offset.
 /// Both right and left buffers are optional. If one of the buffers is
 /// null the non-null bitmap is returned. If both are null a nullptr is returned.
-///
-/// if necessary out_buffer will be allocated and initialized to zeros using pool before
-/// the operation.
 ARROW_EXPORT
 Result<std::shared_ptr<Buffer>> OptionalBitmapAnd(MemoryPool* pool, const uint8_t* left,
                                                   int64_t left_offset,
@@ -165,8 +162,8 @@ Result<std::shared_ptr<Buffer>> OptionalBitmapAnd(MemoryPool* pool, const uint8_
 /// \brief Do a "bitmap and" on right and left buffers starting at
 /// their respective bit-offsets for the given bit-length and put
 /// the results in out starting at the given bit-offset.
-/// Both right and left buffers are optional. If any of the buffers is
-/// null a bitmap of zeros is returned.
+/// Both right and left buffers are optional. If one of the buffers is
+/// null the non-null bitmap is copied. If both are null out is not modified.
 ARROW_EXPORT
 void OptionalBitmapAnd(const uint8_t* left, int64_t left_offset, const uint8_t* right,
                        int64_t right_offset, int64_t length, int64_t out_offset,


### PR DESCRIPTION
### Rationale for this change

Bitmaps are optional, having the possibility an utility function that allows us to do a `BitmapAnd` operation that takes into account the possibility of a bitmap being null can be handy as we don't have to cater for the specific case.

### What changes are included in this PR?

Add a new `OptionalBitmapAnd` function.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No, just a new utility function.

* GitHub Issue: #45819