### PR TITLE
GH-45850: Fix r-devel note about symbols in .a libs

### DIFF
--- a/r/src/Makevars.in
+++ b/r/src/Makevars.in
@@ -27,3 +27,8 @@ PKG_CPPFLAGS=@cflags@
 # PKG_CXXFLAGS=$(CXX_VISIBILITY)
 CXX_STD=CXX17
 PKG_LIBS=@libs@
+
+all: $(SHLIB) purify
+
+purify: $(SHLIB)
+	rm -rf ../libarrow || true


### PR DESCRIPTION
### Rationale for this change

[CRAN](https://github.com/wch/r-source/commit/fb5500bb6f392020e9b622c6e52607018d94daac)

Fixes #45850

### What changes are included in this PR?

Attempt to delete static libraries we build or download during the R package build.

### Are these changes tested?

CI should pass once again

### Are there any user-facing changes?

No

* GitHub Issue: #45850