### PR TITLE
GH-45868: [C++][CI] Fix test for ambiguous initialization on C++ 20

### DIFF
--- a/cpp/src/arrow/compute/kernels/aggregate_test.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_test.cc
@@ -3695,8 +3695,8 @@ TEST_F(TestSkewKurtosis, Options) {
     AssertSkewKurtosisAre(type, {"[0, 1]", "[]", "[null, 2]"}, options, 0.0, -1.5);
     options.biased = false;
     AssertSkewKurtosisInvalid(type, "[0, 1]", options);
-    AssertSkewKurtosisAre(type, {"[1, 2, 3]", "[40, null]"}, options, 1.9889477403978211,
-                          3.9631931024230695);
+    AssertSkewKurtosisAre(type, {"[1, 2, 3]", "[40]", "[null]"}, options,
+                          1.9889477403978211, 3.9631931024230695);
     options.biased = true;
     options.min_count = 3;
     AssertSkewKurtosisAre(type, "[0, 1, null, 2]", options, 0.0, -1.5);


### PR DESCRIPTION
### Rationale for this change

Fails to compile on C++ 20

### What changes are included in this PR?

Pass more than 2 strings so compiler correctly assumes `std::vector<std::string>` not `std::string_view`

### Are these changes tested?

Via the archery job that failed

### Are there any user-facing changes?

No
* GitHub Issue: #45868