### PR TITLE
Limit setuptools version

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -27,7 +27,7 @@ requires = [
     # configuring setuptools_scm in pyproject.toml requires
     # versions released after 2022
     "setuptools_scm[toml]>=8",
-    "setuptools>=64",
+    "setuptools>=64,<77",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
### Rationale for this change
Temporary Fix for #45867

### What changes are included in this PR?
Limit version of setuptools to the one that works

### Are these changes tested?
No

### Are there any user-facing changes?
No

**This PR contains a "Critical Fix".** (If the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld), please provide explanation. If not, you can remove this.)
