### PR TITLE
GH-45718: [R][CI] Fix compilation error on opensuse155

### DIFF
--- a/cpp/src/arrow/compute/kernels/aggregate_pivot.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_pivot.cc
@@ -149,6 +149,9 @@ Result<std::unique_ptr<KernelState>> PivotInit(KernelContext* ctx,
   DCHECK(is_base_binary_like(args.inputs[0].id()));
   auto state = std::make_unique<PivotImpl>();
   RETURN_NOT_OK(state->Init(options, args.inputs));
+  // GH-45718: This can be simplified once we drop the R openSUSE155 crossbow
+  // job
+  // R build with openSUSE155 requires an explicit shared_ptr construction
   return std::unique_ptr<KernelState>(std::move(state));
 }
 

--- a/cpp/src/arrow/compute/kernels/aggregate_pivot.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_pivot.cc
@@ -149,7 +149,7 @@ Result<std::unique_ptr<KernelState>> PivotInit(KernelContext* ctx,
   DCHECK(is_base_binary_like(args.inputs[0].id()));
   auto state = std::make_unique<PivotImpl>();
   RETURN_NOT_OK(state->Init(options, args.inputs));
-  return state;
+  return std::unique_ptr<KernelState>(std::move(state));
 }
 
 Result<TypeHolder> ResolveOutputType(KernelContext* ctx, const std::vector<TypeHolder>&) {


### PR DESCRIPTION
### Rationale for this change

Closes https://github.com/apache/arrow/issues/45718.

### What changes are included in this PR?

- Similar fix as in https://github.com/apache/arrow/blob/0fbf9823542233c5f32c26534c34cc97ce3f0be2/cpp/src/arrow/buffer.cc#L44.

### Are these changes tested?

Compiles locally using newer toolchain, will test on CI.

### Are there any user-facing changes?

No.
* GitHub Issue: #45718