### PR TITLE
GH-40754: [Python] Expose tls_ca_file_path to S3FileSystem

### DIFF
--- a/python/pyarrow/includes/libarrow_fs.pxd
+++ b/python/pyarrow/includes/libarrow_fs.pxd
@@ -160,6 +160,7 @@ cdef extern from "arrow/filesystem/api.h" namespace "arrow::fs" nogil:
         c_bool allow_bucket_deletion
         c_bool check_directory_existence_before_creation
         c_bool force_virtual_addressing
+        c_string tls_ca_file_path
         shared_ptr[const CKeyValueMetadata] default_metadata
         c_string role_arn
         c_string session_name

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -1257,6 +1257,12 @@ def test_s3_options(pickle_module):
     assert isinstance(fs, S3FileSystem)
     assert pickle_module.loads(pickle_module.dumps(fs)) == fs
 
+    fs = S3FileSystem(tls_ca_file_path="ca.pem")
+    assert isinstance(fs, S3FileSystem)
+    assert pickle_module.loads(pickle_module.dumps(fs)) == fs
+    assert fs != S3FileSystem(tls_ca_file_path="other_ca.pem")
+    assert fs != S3FileSystem()
+
     with pytest.raises(ValueError):
         S3FileSystem(access_key='access')
     with pytest.raises(ValueError):


### PR DESCRIPTION
### Rationale for this change

Currently, when using the pyarrow.fs.S3FileSystem, it is not immediately obvious how provide an alternative TLS certificate authority when working with (for example) a self-hosted minio using a self-signed certificate. It is possible to do this via environment variables, as per #40754; however, the user may not be able to easily specify these depending on their python execution environment.

### What changes are included in this PR?

Adds an additional parameter to S3FileSystem to specify the file path to a custom certificate.

### Are these changes tested?

Yes. A unit-test for S3FileSystem pickling is included; and I have manually verified that I can access files from a self-hosted minio with TLS enabled.

### Are there any user-facing changes?

An additional parameter `tls_ca_file_path` is available on the S3FileSystem constructor.

* GitHub Issue: #40754