### PR TITLE
GH-45862: [JS] Fix FixedSizeListBuilder behavior for null slots

### DIFF
--- a/js/src/builder/fixedsizelist.ts
+++ b/js/src/builder/fixedsizelist.ts
@@ -25,14 +25,14 @@ export class FixedSizeListBuilder<T extends DataType = any, TNull = any> extends
         const [child] = this.children;
         const start = index * this.stride;
         for (let i = -1, n = this.stride; ++i < n;) {
-            // Use either the actual value or a null (if the slot is null)
-            const finalVal = value ? value[i] : null;
-            child.set(start + i, finalVal);
+            child.set(start + i, value[i]);
         }
     }
     public setValid(index: number, valid: boolean) {
-        this.length = this._nulls.set(index, +valid).length;
-        return true;
+        if (!super.setValid(index, valid)) {
+            this.children[0].setValid((index + 1) * this.stride - 1, false);
+        }
+        return valid;
     }
     public addChild(child: Builder<T>, name = '0') {
         if (this.numChildren > 0) {

--- a/js/src/builder/fixedsizelist.ts
+++ b/js/src/builder/fixedsizelist.ts
@@ -24,9 +24,15 @@ export class FixedSizeListBuilder<T extends DataType = any, TNull = any> extends
     public setValue(index: number, value: T['TValue']) {
         const [child] = this.children;
         const start = index * this.stride;
-        for (let i = -1, n = value.length; ++i < n;) {
-            child.set(start + i, value[i]);
+        for (let i = -1, n = this.stride; ++i < n;) {
+            // Use either the actual value or a null (if the slot is null)
+            const finalVal = value ? value[i] : null;
+            child.set(start + i, finalVal);
         }
+    }
+    public setValid(index: number, valid: boolean) {
+        this.length = this._nulls.set(index, +valid).length;
+        return true;
     }
     public addChild(child: Builder<T>, name = '0') {
         if (this.numChildren > 0) {


### PR DESCRIPTION
### Rationale for this change

`vectorFromArray` could produce an incorrect result when used on a `FixedSizeList<T>` with one or more null slots in trailing positions.

### What changes are included in this PR?

Fixed behavior of the FixedSizeListBuilder.

### Are these changes tested?

Yes. This PR includes specific test cases to cover this bug fix.

### Are there any user-facing changes?

No.
* GitHub Issue: #45862