### PR TITLE
GH-45879: [CI][Release][Ruby] Omit Flight related tests on x86_64 macOS

### DIFF
--- a/c_glib/test/flight-sql/test-client.rb
+++ b/c_glib/test/flight-sql/test-client.rb
@@ -23,6 +23,7 @@ class TestFlightSQLClient < Test::Unit::TestCase
     @server = nil
     omit("Arrow Flight SQL is required") unless defined?(ArrowFlightSQL)
     omit("Unstable on Windows") if Gem.win_platform?
+    omit("Unstable on x86_64 macOS") if /x86_64-darwin/.match?(RUBY_PLATFORM)
     @server = Helper::FlightSQLServer.new
     host = "127.0.0.1"
     location = ArrowFlight::Location.new("grpc://#{host}:0")

--- a/c_glib/test/flight/test-client.rb
+++ b/c_glib/test/flight/test-client.rb
@@ -22,6 +22,7 @@ class TestFlightClient < Test::Unit::TestCase
     @server = nil
     omit("Arrow Flight is required") unless defined?(ArrowFlight)
     omit("Unstable on Windows") if Gem.win_platform?
+    omit("Unstable on x86_64 macOS") if /x86_64-darwin/.match?(RUBY_PLATFORM)
     require_gi_bindings(3, 4, 7)
     @server = Helper::FlightServer.new
     host = "127.0.0.1"

--- a/c_glib/test/flight/test-stream-reader.rb
+++ b/c_glib/test/flight/test-stream-reader.rb
@@ -22,6 +22,7 @@ class TestFlightStreamReader < Test::Unit::TestCase
     @server = nil
     omit("Arrow Flight is required") unless defined?(ArrowFlight)
     omit("Unstable on Windows") if Gem.win_platform?
+    omit("Unstable on x86_64 macOS") if /x86_64-darwin/.match?(RUBY_PLATFORM)
     require_gi_bindings(3, 4, 5)
     @server = Helper::FlightServer.new
     host = "127.0.0.1"

--- a/ruby/red-arrow-flight-sql/test/test-client.rb
+++ b/ruby/red-arrow-flight-sql/test/test-client.rb
@@ -19,6 +19,7 @@ class TestClient < Test::Unit::TestCase
   def setup
     @server = nil
     omit("Unstable on Windows") if Gem.win_platform?
+    omit("Unstable on x86_64 macOS") if /x86_64-darwin/.match?(RUBY_PLATFORM)
     @server = Helper::Server.new
     @server.listen("grpc://127.0.0.1:0")
     @location = "grpc://127.0.0.1:#{@server.port}"

--- a/ruby/red-arrow-flight/test/test-client.rb
+++ b/ruby/red-arrow-flight/test/test-client.rb
@@ -19,6 +19,7 @@ class TestClient < Test::Unit::TestCase
   def setup
     @server = nil
     omit("Unstable on Windows") if Gem.win_platform?
+    omit("Unstable on x86_64 macOS") if /x86_64-darwin/.match?(RUBY_PLATFORM)
     @server = Helper::Server.new
     @server.listen("grpc://127.0.0.1:0")
     @location = "grpc://127.0.0.1:#{@server.port}"


### PR DESCRIPTION
### Rationale for this change

Flight related tests cause a crash on x86_64 macOS. It uses thread. So it may be related.

### What changes are included in this PR?

Omit Flight related tests on x86_64 macOS. Because they are not so important. x86_64 macOS is deprecated.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #45879