### PR TITLE
GH-45735: [C++] Broken tests for extract_regex compute funcion

### DIFF
--- a/cpp/src/arrow/compute/kernels/scalar_string_ascii.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_ascii.cc
@@ -2209,14 +2209,13 @@ struct BaseExtractRegexData {
   std::vector<std::string> group_names;
 
  protected:
-  explicit BaseExtractRegexData(const std::string& pattern, bool is_utf8 = true)
+  explicit BaseExtractRegexData(const std::string& pattern, bool is_utf8)
       : regex(new RE2(pattern, MakeRE2Options(is_utf8))) {}
 };
 
 // TODO cache this once per ExtractRegexOptions
 struct ExtractRegexData : public BaseExtractRegexData {
-  static Result<ExtractRegexData> Make(const ExtractRegexOptions& options,
-                                       bool is_utf8 = true) {
+  static Result<ExtractRegexData> Make(const ExtractRegexOptions& options, bool is_utf8) {
     ExtractRegexData data(options.pattern, is_utf8);
     ARROW_RETURN_NOT_OK(data.Init());
     return data;
@@ -2233,7 +2232,7 @@ struct ExtractRegexData : public BaseExtractRegexData {
   }
 
  private:
-  explicit ExtractRegexData(const std::string& pattern, bool is_utf8 = true)
+  explicit ExtractRegexData(const std::string& pattern, bool is_utf8)
       : BaseExtractRegexData(pattern, is_utf8) {}
 };
 
@@ -2359,8 +2358,7 @@ void AddAsciiStringExtractRegex(FunctionRegistry* registry) {
 }
 
 struct ExtractRegexSpanData : public BaseExtractRegexData {
-  static Result<ExtractRegexSpanData> Make(const std::string& pattern,
-                                           bool is_utf8 = true) {
+  static Result<ExtractRegexSpanData> Make(const std::string& pattern, bool is_utf8) {
     auto data = ExtractRegexSpanData(pattern, is_utf8);
     ARROW_RETURN_NOT_OK(data.Init());
     return data;

--- a/cpp/src/arrow/compute/kernels/scalar_string_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_test.cc
@@ -330,8 +330,8 @@ TYPED_TEST(TestBinaryKernels, NonUtf8Regex) {
                              field("digit", fixed_size_list(offset_type, 2))});
     this->CheckUnary("extract_regex_span",
                      this->MakeArray({"foo\xfc\x31\x34 bar", "\x02\xfc\x32"}), out_type,
-                     R"([{"letter": [3, 1], "digit": [4,2]},
-                                             {"letter": [1, 1], "digit": [2, 1]}])",
+                     R"([{"letter": [3, 1], "digit": [4, 2]},
+                         {"letter": [1, 1], "digit": [2, 1]}])",
                      &options);
   }
 }
@@ -400,8 +400,8 @@ TYPED_TEST(TestBinaryKernels, NonUtf8WithNullRegex) {
     this->CheckUnary("extract_regex_span",
                      this->template MakeArray<std::string>(
                          {{"foo\x00\x31\x34 bar", 10}, {"\x02\x00\x32", 3}}),
-                     out_type, R"([{"null": [3, 1], "digit": [4,2]},
-                                             {"null": [1, 1], "digit": [2, 1]}])",
+                     out_type, R"([{"null": [3, 1], "digit": [4, 2]},
+                                   {"null": [1, 1], "digit": [2, 1]}])",
                      &options);
   }
   {

--- a/cpp/src/arrow/compute/kernels/scalar_string_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_test.cc
@@ -314,15 +314,25 @@ TYPED_TEST(TestBinaryKernels, NonUtf8Regex) {
                      this->MakeArray({"\xfc\x40", "this \xfc\x40 that \xfc\x40"}),
                      this->MakeArray({"bazz", "this bazz that \xfc\x40"}), &options);
   }
-  // TODO the following test is broken (GH-45735)
   {
-    ExtractRegexOptions options("(?P<letter>[\\xfc])(?P<digit>\\d)");
-    auto null_bitmap = std::make_shared<Buffer>("0");
+    ExtractRegexOptions options("(?P<letter>[\xfc])(?P<digit>\\d+)");
     auto output = StructArray::Make(
-        {this->MakeArray({"\xfc", "1"}), this->MakeArray({"\xfc", "2"})},
-        {field("letter", this->type()), field("digit", this->type())}, null_bitmap);
-    this->CheckUnary("extract_regex", this->MakeArray({"foo\xfc 1bar", "\x02\xfc\x40"}),
+        {this->MakeArray({"\xfc", "\xfc"}), this->MakeArray({"14", "2"})},
+        {field("letter", this->type()), field("digit", this->type())});
+    this->CheckUnary("extract_regex",
+                     this->MakeArray({"foo\xfc\x31\x34 bar", "\x02\xfc\x32"}),
                      std::static_pointer_cast<Array>(*output), &options);
+  }
+  {
+    ExtractRegexSpanOptions options("(?P<letter>[\xfc])(?P<digit>\\d+)");
+    auto offset_type = is_binary_like(this->type()->id()) ? int32() : int64();
+    auto out_type = struct_({field("letter", fixed_size_list(offset_type, 2)),
+                             field("digit", fixed_size_list(offset_type, 2))});
+    this->CheckUnary("extract_regex_span",
+                     this->MakeArray({"foo\xfc\x31\x34 bar", "\x02\xfc\x32"}), out_type,
+                     R"([{"letter": [3, 1], "digit": [4,2]},
+                                             {"letter": [1, 1], "digit": [2, 1]}])",
+                     &options);
   }
 }
 
@@ -371,18 +381,28 @@ TYPED_TEST(TestBinaryKernels, NonUtf8WithNullRegex) {
                      this->template MakeArray<std::string>({{"\x00\x40", 2}}),
                      this->type(), R"(["bazz"])", &options);
   }
-  // TODO the following test is broken (GH-45735)
   {
-    ExtractRegexOptions options("(?P<null>[\\x00])(?P<digit>\\d)");
-    auto null_bitmap = std::make_shared<Buffer>("0");
+    ExtractRegexOptions options(std::string("(?P<null>[\x00])(?P<digit>\\d+)", 27));
     auto output = StructArray::Make(
-        {this->template MakeArray<std::string>({{"\x00", 1}, {"1", 1}}),
-         this->template MakeArray<std::string>({{"\x00", 1}, {"2", 1}})},
-        {field("null", this->type()), field("digit", this->type())}, null_bitmap);
-    this->CheckUnary(
-        "extract_regex",
-        this->template MakeArray<std::string>({{"foo\x00 1bar", 9}, {"\x02\x00\x40", 3}}),
-        std::static_pointer_cast<Array>(*output), &options);
+        {this->template MakeArray<std::string>({{"\x00", 1}, {"\x00", 1}}),
+         this->template MakeArray<std::string>({"14", "2"})},
+        {field("null", this->type()), field("digit", this->type())});
+    this->CheckUnary("extract_regex",
+                     this->template MakeArray<std::string>(
+                         {{"foo\x00\x31\x34 bar", 10}, {"\x02\x00\x32", 3}}),
+                     std::static_pointer_cast<Array>(*output), &options);
+  }
+  {
+    ExtractRegexSpanOptions options(std::string("(?P<null>[\x00])(?P<digit>\\d+)", 27));
+    auto offset_type = is_binary_like(this->type()->id()) ? int32() : int64();
+    auto out_type = struct_({field("null", fixed_size_list(offset_type, 2)),
+                             field("digit", fixed_size_list(offset_type, 2))});
+    this->CheckUnary("extract_regex_span",
+                     this->template MakeArray<std::string>(
+                         {{"foo\x00\x31\x34 bar", 10}, {"\x02\x00\x32", 3}}),
+                     out_type, R"([{"null": [3, 1], "digit": [4,2]},
+                                             {"null": [1, 1], "digit": [2, 1]}])",
+                     &options);
   }
   {
     ReplaceSliceOptions options(1, 2, std::string("\x00\x40", 2));

--- a/cpp/src/arrow/compute/kernels/scalar_string_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_test.cc
@@ -316,12 +316,14 @@ TYPED_TEST(TestBinaryKernels, NonUtf8Regex) {
   }
   {
     ExtractRegexOptions options("(?P<letter>[\xfc])(?P<digit>\\d+)");
-    auto output = StructArray::Make(
-        {this->MakeArray({"\xfc", "\xfc"}), this->MakeArray({"14", "2"})},
-        {field("letter", this->type()), field("digit", this->type())});
+    ASSERT_OK_AND_ASSIGN(
+        auto output,
+        StructArray::Make(
+            {this->MakeArray({"\xfc", "\xfc"}), this->MakeArray({"14", "2"})},
+            {field("letter", this->type()), field("digit", this->type())}));
     this->CheckUnary("extract_regex",
-                     this->MakeArray({"foo\xfc\x31\x34 bar", "\x02\xfc\x32"}),
-                     std::static_pointer_cast<Array>(*output), &options);
+                     this->MakeArray({"foo\xfc\x31\x34 bar", "\x02\xfc\x32"}), output,
+                     &options);
   }
   {
     ExtractRegexSpanOptions options("(?P<letter>[\xfc])(?P<digit>\\d+)");
@@ -383,14 +385,16 @@ TYPED_TEST(TestBinaryKernels, NonUtf8WithNullRegex) {
   }
   {
     ExtractRegexOptions options(std::string("(?P<null>[\x00])(?P<digit>\\d+)", 27));
-    auto output = StructArray::Make(
-        {this->template MakeArray<std::string>({{"\x00", 1}, {"\x00", 1}}),
-         this->template MakeArray<std::string>({"14", "2"})},
-        {field("null", this->type()), field("digit", this->type())});
+    ASSERT_OK_AND_ASSIGN(
+        auto output,
+        StructArray::Make(
+            {this->template MakeArray<std::string>({{"\x00", 1}, {"\x00", 1}}),
+             this->template MakeArray<std::string>({"14", "2"})},
+            {field("null", this->type()), field("digit", this->type())}));
     this->CheckUnary("extract_regex",
                      this->template MakeArray<std::string>(
                          {{"foo\x00\x31\x34 bar", 10}, {"\x02\x00\x32", 3}}),
-                     std::static_pointer_cast<Array>(*output), &options);
+                     output, &options);
   }
   {
     ExtractRegexSpanOptions options(std::string("(?P<null>[\x00])(?P<digit>\\d+)", 27));


### PR DESCRIPTION
### Rationale for this change

I fix two broken tests of extract_regex and add the similar tests to extract_regex_span.

### What changes are included in this PR?

1. Modify the ResolveOutput Method for extract_regex and extract_regex_span compute functions to be able to accept non-utf8 regex.

2. Fix broken tests for extract_regex.

3. Add similar tests for extract_regex_span.

### Are these changes tested?

I run the relevant unit tests.

### Are there any user-facing changes?

No.
* GitHub Issue: #45735