### PR TITLE
GH-40760: [Release] Use repository.apache.org

### DIFF
--- a/dev/release/.env.example
+++ b/dev/release/.env.example
@@ -30,3 +30,15 @@
 #
 # You must set this.
 #ARTIFACTORY_API_KEY=secret
+
+# The Apache Sofotware Foundation ID to upload artifacts to
+# repository.apache.org.
+#
+# You must set this.
+#ASF_USER=kou
+
+# The Apache Sofotware Foundation password to upload artifacts to
+# repository.apache.org.
+#
+# You must set this.
+#ASF_PASSWORD=secret

--- a/dev/release/05-binary-upload.sh
+++ b/dev/release/05-binary-upload.sh
@@ -123,6 +123,8 @@ docker_run \
     APT_TARGETS=$(IFS=,; echo "${apt_targets[*]}") \
     ARTIFACTORY_API_KEY="${ARTIFACTORY_API_KEY}" \
     ARTIFACTS_DIR="${tmp_dir}/artifacts" \
+    ASF_PASSWORD="${ASF_PASSWORD}" \
+    ASF_USER="${ASF_USER}" \
     DEB_PACKAGE_NAME=${DEB_PACKAGE_NAME:-} \
     DRY_RUN=${DRY_RUN:-no} \
     GPG_KEY_ID="${GPG_KEY_ID}" \

--- a/dev/release/05-binary-upload.sh
+++ b/dev/release/05-binary-upload.sh
@@ -80,19 +80,19 @@ rake_tasks=()
 apt_targets=()
 yum_targets=()
 if [ ${UPLOAD_ALMALINUX} -gt 0 ]; then
-  rake_tasks+=(yum:rc)
+  rake_tasks+=(yum:rc:artifactory yum:rc)
   yum_targets+=(almalinux)
 fi
 if [ ${UPLOAD_AMAZON_LINUX} -gt 0 ]; then
-  rake_tasks+=(yum:rc)
+  rake_tasks+=(yum:rc:artifactory yum:rc)
   yum_targets+=(amazon-linux)
 fi
 if [ ${UPLOAD_CENTOS} -gt 0 ]; then
-  rake_tasks+=(yum:rc)
+  rake_tasks+=(yum:rc:artifactory yum:rc)
   yum_targets+=(centos)
 fi
 if [ ${UPLOAD_DEBIAN} -gt 0 ]; then
-  rake_tasks+=(apt:rc)
+  rake_tasks+=(apt:rc:artifactory apt:rc)
   apt_targets+=(debian)
 fi
 if [ ${UPLOAD_DOCS} -gt 0 ]; then
@@ -105,7 +105,7 @@ if [ ${UPLOAD_R} -gt 0 ]; then
   rake_tasks+=(r:rc)
 fi
 if [ ${UPLOAD_UBUNTU} -gt 0 ]; then
-  rake_tasks+=(apt:rc)
+  rake_tasks+=(apt:rc:artifactory apt:rc)
   apt_targets+=(ubuntu)
 fi
 rake_tasks+=(summary:rc)

--- a/dev/release/copy-binary.rb
+++ b/dev/release/copy-binary.rb
@@ -58,7 +58,6 @@ repository_id = maven.create_staging_repository
           BinaryTask::ThreadPool.new(:maven_repository) do |source, destination|
           maven_pool.pull do |maven|
             maven.upload(source.path, destination)
-            pp [:done, destination]
           end
           progress_reporter.advance
           source.close!

--- a/dev/release/copy-binary.rb
+++ b/dev/release/copy-binary.rb
@@ -1,0 +1,96 @@
+#!/usr/bin/env ruby
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# This is a one shot https://apache.jfrog.io/ ->
+# https://repository.apache.org/ migration tool. The migration is
+# already done. So we can remove this anytime.
+
+require "json"
+require "rake"
+
+require_relative "binary-task"
+
+maven_args = [nil, nil, ENV["ASF_USER"], ENV["ASF_PASSWORD"]]
+maven = BinaryTask::MavenRepositoryClient.new(*maven_args)
+repository_id = maven.create_staging_repository
+
+[
+  "almalinux",
+  "amazon-linux",
+  "centos",
+  "debian",
+  "ubuntu",
+].each do |prefix|
+  BinaryTask::ArtifactoryClientPool.open(prefix, nil) do |artifactory_pool|
+    maven_args = [prefix, repository_id, ENV["ASF_USER"], ENV["ASF_PASSWORD"]]
+    BinaryTask::MavenRepositoryClientPool.open(*maven_args) do |maven_pool|
+      cache_file = "#{prefix}.list"
+      if File.exist?(cache_file)
+        files = File.readlines(cache_file, chomp: true)
+      else
+        files = artifactory_pool.pull do |artifactory|
+          artifactory.files
+        end
+        File.write(cache_file, files.join("\n"))
+      end
+
+      progress_reporter =
+        BinaryTask::ProgressReporter.new("Copying: #{prefix}", files.size)
+      parallel = false
+      if parallel
+        upload_thread_pool =
+          BinaryTask::ThreadPool.new(:maven_repository) do |source, destination|
+          maven_pool.pull do |maven|
+            maven.upload(source.path, destination)
+            pp [:done, destination]
+          end
+          progress_reporter.advance
+          source.close!
+        end
+        download_thread_pool = BinaryTask::ThreadPool.new(:artifactory) do |source|
+          destination = Tempfile.new("copy-binary")
+          File.utime(0, 0, destination.path)
+          artifactory_pool.pull do |artifactory|
+            artifactory.download(source, destination.path)
+          end
+          upload_thread_pool << [destination, source]
+        end
+        files.each do |file|
+          download_thread_pool << file
+        end
+        download_thread_pool.join
+        upload_thread_pool.join
+      else
+        files.each do |file|
+          local_file = Tempfile.new("copy-binary")
+          File.utime(0, 0, local_file.path)
+          artifactory_pool.pull do |artifactory|
+            artifactory.download(file, local_file.path)
+          end
+          maven_pool.pull do |maven|
+            maven.upload(local_file.path, file)
+          end
+          progress_reporter.advance
+          local_file.close!
+        end
+      end
+      progress_reporter.finish
+    end
+  end
+end

--- a/dev/release/download_rc_binaries.py
+++ b/dev/release/download_rc_binaries.py
@@ -152,10 +152,6 @@ class Downloader:
         return (int(match.group(1)), int(match.group(2)), int(match.group(3)))
 
 
-class Artifactory(Downloader):
-    URL_ROOT = "https://apache.jfrog.io/artifactory/arrow"
-
-
 class Maven(Downloader):
     URL_ROOT = "https://repository.apache.org" + \
         "/content/repositories/staging/org/apache/arrow"
@@ -277,19 +273,16 @@ def download_rc_binaries(version, rc_number, re_match=None, dest=None,
             return match[0] == version
         filter = is_target
 
-        if package_type == 'jars':
-            downloader = Maven()
-            prefix = ''
-        elif package_type == 'github' or package_type == 'nuget':
+        if package_type == 'github' or package_type == 'nuget':
             downloader = GitHub(repository, tag)
             prefix = ''
             filter = None
         elif package_type in ARROW_REPOSITORY_PACKAGE_TYPES:
-            downloader = Artifactory()
-            prefix = f'{package_type}-rc'
+            downloader = Maven()
+            prefix = package_type
         else:
-            downloader = Artifactory()
-            prefix = f'{package_type}-rc/{version_string}'
+            downloader = Maven()
+            prefix = f'{package_type}/{version_string}'
             filter = None
         files = downloader.get_file_list(prefix, filter=filter)
         downloader.download_files(files, re_match=re_match, dest=dest,

--- a/dev/release/post-03-binary.sh
+++ b/dev/release/post-03-binary.sh
@@ -58,19 +58,19 @@ rake_tasks=()
 apt_targets=()
 yum_targets=()
 if [ ${DEPLOY_ALMALINUX} -gt 0 ]; then
-  rake_tasks+=(yum:release)
+  rake_tasks+=(yum:artifactory:release)
   yum_targets+=(almalinux)
 fi
 if [ ${DEPLOY_AMAZON_LINUX} -gt 0 ]; then
-  rake_tasks+=(yum:release)
+  rake_tasks+=(yum:artifactory:release)
   yum_targets+=(amazon-linux)
 fi
 if [ ${DEPLOY_CENTOS} -gt 0 ]; then
-  rake_tasks+=(yum:release)
+  rake_tasks+=(yum:artifactory:release)
   yum_targets+=(centos)
 fi
 if [ ${DEPLOY_DEBIAN} -gt 0 ]; then
-  rake_tasks+=(apt:release)
+  rake_tasks+=(apt:artifactory:release)
   apt_targets+=(debian)
 fi
 if [ ${DEPLOY_DOCS} -gt 0 ]; then
@@ -83,7 +83,7 @@ if [ ${DEPLOY_R} -gt 0 ]; then
   rake_tasks+=(r:release)
 fi
 if [ ${DEPLOY_UBUNTU} -gt 0 ]; then
-  rake_tasks+=(apt:release)
+  rake_tasks+=(apt:artifactory:release)
   apt_targets+=(ubuntu)
 fi
 rake_tasks+=(summary:release)

--- a/dev/release/verify-apt.sh
+++ b/dev/release/verify-apt.sh
@@ -21,14 +21,10 @@ set -exu
 
 if [ $# -lt 2 ]; then
   echo "Usage: $0 VERSION rc"
-  echo "       $0 VERSION staging-rc"
   echo "       $0 VERSION release"
-  echo "       $0 VERSION staging-release"
   echo "       $0 VERSION local"
   echo " e.g.: $0 0.13.0 rc                # Verify 0.13.0 RC"
-  echo " e.g.: $0 0.13.0 staging-rc        # Verify 0.13.0 RC on staging"
   echo " e.g.: $0 0.13.0 release           # Verify 0.13.0"
-  echo " e.g.: $0 0.13.0 staging-release   # Verify 0.13.0 on staging"
   echo " e.g.: $0 0.13.0-dev20210203 local # Verify 0.13.0-dev20210203 on local"
   exit 1
 fi
@@ -70,13 +66,12 @@ ${APT_INSTALL} \
 
 code_name="$(lsb_release --codename --short)"
 distribution="$(lsb_release --id --short | tr 'A-Z' 'a-z')"
-artifactory_base_url="https://apache.jfrog.io/artifactory/arrow/${distribution}"
-case "${TYPE}" in
-  rc|staging-rc|staging-release)
-    suffix=${TYPE%-release}
-    artifactory_base_url+="-${suffix}"
-    ;;
-esac
+production_repository_base_url="https://repo1.maven.org/maven2/org/apache/arrow/${distribution}"
+staging_repository_base_url="https://repository.apache.org/content/repositories/staging/org/apache/arrow/${distribution}"
+repository_base_url="${production_repository_base_url}"
+if [ "${TYPE}" = "rc" ]; then
+  repository_base_url="${staging_repository_base_url}"
+fi
 
 workaround_missing_packages=()
 case "${distribution}-${code_name}" in
@@ -111,7 +106,7 @@ else
   apt_source_base_name="apache-arrow-apt-source-latest-${code_name}.deb"
   curl \
     --output "${apt_source_base_name}" \
-    "${artifactory_base_url}/${apt_source_base_name}"
+    "${repository_base_url}/${apt_source_base_name}"
   ${APT_INSTALL} "./${apt_source_base_name}"
 fi
 
@@ -134,11 +129,10 @@ if [ "${TYPE}" = "local" ]; then
   fi
 else
   case "${TYPE}" in
-    rc|staging-rc|staging-release)
-      suffix=${TYPE%-release}
+    rc)
       sed \
         -i"" \
-        -e "s,^URIs: \\(.*\\)/,URIs: \\1-${suffix}/,g" \
+        -e "s,^URIs: ${production_repository_base_url},URIs: ${staging_repository_base_url},g" \
         /etc/apt/sources.list.d/apache-arrow.sources
       ;;
   esac
@@ -186,7 +180,7 @@ popd
 
 
 ${APT_INSTALL} ruby-dev rubygems-integration
-gem install gobject-introspection
+MAKEFLAGS="-j$(nproc)" gem install gobject-introspection
 ruby -r gi -e "p GI.load('Arrow')"
 echo "::endgroup::"
 

--- a/dev/tasks/linux-packages/apache-arrow-apt-source/debian/rules
+++ b/dev/tasks/linux-packages/apache-arrow-apt-source/debian/rules
@@ -24,7 +24,7 @@ override_dh_auto_build:
 	  distribution=$$(lsb_release --id --short | tr 'A-Z' 'a-z'); \
 	  code_name=$$(lsb_release --codename --short); \
 	  echo "Types: deb deb-src"; \
-	  echo "URIs: https://apache.jfrog.io/artifactory/arrow/$${distribution}/"; \
+	  echo "URIs: https://repo1.maven.org/maven2/org/apache/arrow/$${distribution}/"; \
 	  echo "Suites: $${code_name}"; \
 	  echo "Components: main"; \
 	  echo "Signed-By: /usr/share/keyrings/apache-arrow-apt-source.asc"; \

--- a/dev/tasks/linux-packages/apache-arrow-release/yum/Apache-Arrow.repo
+++ b/dev/tasks/linux-packages/apache-arrow-release/yum/Apache-Arrow.repo
@@ -17,42 +17,42 @@
 
 [apache-arrow-almalinux]
 name=Apache Arrow for AlmaLinux $releasever - $basearch
-baseurl=https://apache.jfrog.io/artifactory/arrow/almalinux/$releasever/$basearch/
+baseurl=https://repo1.maven.org/maven2/org/apache/arrow/almalinux/$releasever/$basearch/
 gpgcheck=1
 enabled=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-Apache-Arrow
 
 [apache-arrow-amazon-linux-2023]
 name=Apache Arrow for Amazon Linux 2023 - $basearch
-baseurl=https://apache.jfrog.io/artifactory/arrow/amazon-linux/2023/$basearch/
+baseurl=https://repo1.maven.org/maven2/org/apache/arrow/amazon-linux/2023/$basearch/
 gpgcheck=1
 enabled=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-Apache-Arrow
 
 [apache-arrow-centos-stream]
 name=Apache Arrow for CentOS Stream $releasever - $basearch
-baseurl=https://apache.jfrog.io/artifactory/arrow/centos/$stream/$basearch/
+baseurl=https://repo1.maven.org/maven2/org/apache/arrow/centos/$stream/$basearch/
 gpgcheck=1
 enabled=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-Apache-Arrow
 
 [apache-arrow-centos]
 name=Apache Arrow for CentOS $releasever - $basearch
-baseurl=https://apache.jfrog.io/artifactory/arrow/centos/$releasever/$basearch/
+baseurl=https://repo1.maven.org/maven2/org/apache/arrow/centos/$releasever/$basearch/
 gpgcheck=1
 enabled=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-Apache-Arrow
 
 [apache-arrow-rhel]
 name=Apache Arrow for RHEL $releasever - $basearch
-baseurl=https://apache.jfrog.io/artifactory/arrow/almalinux/$releasever/$basearch/
+baseurl=https://repo1.maven.org/maven2/org/apache/arrow/almalinux/$releasever/$basearch/
 gpgcheck=1
 enabled=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-Apache-Arrow
 
 [apache-arrow-rhel7]
 name=Apache Arrow for RHEL 7 - $basearch
-baseurl=https://apache.jfrog.io/artifactory/arrow/centos/7/$basearch/
+baseurl=https://repo1.maven.org/maven2/org/apache/arrow/centos/7/$basearch/
 gpgcheck=1
 enabled=0
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-Apache-Arrow


### PR DESCRIPTION
### Rationale for this change

We're using apache.jfrog.io for binary artifacts mainly for APT/Yum repositories. But apache.jfrog.io isn't stable as we expected. For example, it was down annually. See also: #40744

FYI: Based on https://issues.apache.org/jira/browse/INFRA-26324 , it will not be down this year.

### What changes are included in this PR?

Use repository.apache.org instead of apache.jfrog.io.

Existing binary artifacts are already copied to repository.apache.org from apache.jfrog.io. For example: https://repo1.maven.org/maven2/org/apache/arrow/debian/

Migration plan:

1. We use repo1.maven.org (it's a CDN of repository.apache.org) in apache-arrow-apt-source (for APT repositories) and apache-arrow-release (for Yum repositories)
2. We keep uploading only apache-arrow-apt-source (for APT repositories) and apache-arrow-release (for Yum repositories) to apache.jfrog.io
   * Existing users can migrate to repository.apache.org automatically by this
3. We'll stop uploading apache-arrow-apt-source (for APT repositories) and apache-arrow-release (for Yum repositories) to apache.jfrog.io after we use reproducible builds based auto signing
   * We'll not change signing key after this

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #40760