### PR TITLE
GH-45865: [C++] Create dedicated benchmark dependency in Meson

### DIFF
--- a/cpp/src/arrow/c/meson.build
+++ b/cpp/src/arrow/c/meson.build
@@ -32,7 +32,7 @@ test('arrow-dlpack-test', exc)
 exc = executable(
     'arrow-bridge-benchmark',
     sources: ['bridge_benchmark.cc'],
-    dependencies: [arrow_test_dep, benchmark_dep],
+    dependencies: [arrow_benchmark_dep],
 )
 benchmark('arrow-bridge-benchmark', exc)
 

--- a/cpp/src/arrow/csv/meson.build
+++ b/cpp/src/arrow/csv/meson.build
@@ -39,7 +39,7 @@ foreach csv_benchmark : csv_benchmarks
     exc = executable(
         benchmark_name,
         sources: '@0@.cc'.format(csv_benchmark),
-        dependencies: [arrow_test_dep, benchmark_dep],
+        dependencies: [arrow_benchmark_dep],
     )
     benchmark(benchmark_name, exc)
 endforeach

--- a/cpp/src/arrow/io/meson.build
+++ b/cpp/src/arrow/io/meson.build
@@ -47,7 +47,7 @@ foreach io_benchmark : io_benchmarks
     exc = executable(
         benchmark_name,
         sources: '@0@.cc'.format(io_benchmark),
-        dependencies: [arrow_test_dep, benchmark_dep],
+        dependencies: [arrow_benchmark_dep],
         implicit_include_directories: false,
     )
     benchmark(benchmark_name, exc)

--- a/cpp/src/arrow/meson.build
+++ b/cpp/src/arrow/meson.build
@@ -390,10 +390,12 @@ if needs_testing
         filesystem_dep = boost_proj.dependency('boost_filesystem')
     endif
 
+    gtest_dep = dependency('gtest')
     gtest_main_dep = dependency('gtest_main')
     gmock_dep = dependency('gmock')
 else
     filesystem_dep = disabler()
+    gtest_dep = disabler()
     gtest_main_dep = disabler()
     gmock_dep = disabler()
 endif
@@ -473,14 +475,14 @@ foreach key, val : arrow_tests
 endforeach
 
 if needs_benchmarks
-    benchmark_dep = dependency(
-        'benchmark',
+    benchmark_main_dep = dependency(
+        'benchmark-main',
         default_options: {'tests': 'disabled'},
     )
 
     arrow_benchmark_dep = declare_dependency(
         link_with: [arrow_test_lib],
-        dependencies: [arrow_dep, gtest_main_dep, benchmark_dep],
+        dependencies: [arrow_dep, benchmark_main_dep, gtest_dep],
     )
 else
     arrow_benchmark_dep = disabler()

--- a/cpp/src/arrow/meson.build
+++ b/cpp/src/arrow/meson.build
@@ -404,10 +404,14 @@ arrow_test_lib = static_library(
     dependencies: [arrow_dep, filesystem_dep, gtest_main_dep],
 )
 
-arrow_test_dep = declare_dependency(
-    link_with: [arrow_test_lib],
-    dependencies: [arrow_dep, filesystem_dep, gmock_dep, gtest_main_dep],
-)
+if needs_tests
+    arrow_test_dep = declare_dependency(
+        link_with: [arrow_test_lib],
+        dependencies: [arrow_dep, filesystem_dep, gmock_dep, gtest_main_dep],
+    )
+else
+    arrow_test_dep = disabler()
+endif
 
 arrow_tests = {
     'arrow-array-test': {
@@ -459,24 +463,27 @@ if needs_ipc
     }
 endif
 
-if needs_tests
-    foreach key, val : arrow_tests
-        exc = executable(
-            key,
-            sources: val['sources'],
-            dependencies: [arrow_test_dep, val.get('dependencies', [])],
-        )
-        test(key, exc)
-    endforeach
-endif
+foreach key, val : arrow_tests
+    exc = executable(
+        key,
+        sources: val['sources'],
+        dependencies: [arrow_test_dep, val.get('dependencies', [])],
+    )
+    test(key, exc)
+endforeach
 
 if needs_benchmarks
     benchmark_dep = dependency(
         'benchmark',
         default_options: {'tests': 'disabled'},
     )
+
+    arrow_benchmark_dep = declare_dependency(
+        link_with: [arrow_test_lib],
+        dependencies: [arrow_dep, gtest_main_dep, benchmark_dep],
+    )
 else
-    benchmark_dep = disabler()
+    arrow_benchmark_dep = disabler()
 endif
 
 arrow_benchmarks = [
@@ -493,7 +500,7 @@ foreach benchmark : arrow_benchmarks
     exc = executable(
         benchmark_name,
         sources: '@0@.cc'.format(benchmark),
-        dependencies: [arrow_test_dep, benchmark_dep],
+        dependencies: [arrow_benchmark_dep],
     )
 
     benchmark(benchmark_name, exc)

--- a/cpp/src/arrow/testing/meson.build
+++ b/cpp/src/arrow/testing/meson.build
@@ -54,9 +54,9 @@ foreach key, val : testing_tests
 endforeach
 
 if needs_tests and needs_filesystem
-    library(
+    shared_module(
         'arrow-filesystem-example',
         sources: ['examplefs.cc'],
-        dependencies: [arrow_dep, gtest_main_dep],
+        dependencies: [arrow_dep, gtest_dep],
     )
 endif

--- a/cpp/src/arrow/testing/meson.build
+++ b/cpp/src/arrow/testing/meson.build
@@ -38,27 +38,25 @@ install_headers(
     subdir: 'arrow/testing',
 )
 
-if needs_tests
-    testing_tests = {
-        'arrow-generator-test': {'sources': ['generator_test.cc']},
-        'arrow-gtest-util-test': {'sources': ['gtest_util_test.cc']},
-        'arrow-random-test': {'sources': ['random_test.cc']},
-    }
+testing_tests = {
+    'arrow-generator-test': {'sources': ['generator_test.cc']},
+    'arrow-gtest-util-test': {'sources': ['gtest_util_test.cc']},
+    'arrow-random-test': {'sources': ['random_test.cc']},
+}
 
-    foreach key, val : testing_tests
-        exc = executable(
-            key,
-            sources: val['sources'],
-            dependencies: [arrow_test_dep, val.get('dependencies', [])],
-        )
-        test(key, exc)
-    endforeach
+foreach key, val : testing_tests
+    exc = executable(
+        key,
+        sources: val['sources'],
+        dependencies: [arrow_test_dep, val.get('dependencies', [])],
+    )
+    test(key, exc)
+endforeach
 
-    if needs_filesystem
-        library(
-            'arrow-filesystem-example',
-            sources: ['examplefs.cc'],
-            dependencies: [arrow_dep, gtest_main_dep],
-        )
-    endif
+if needs_tests and needs_filesystem
+    library(
+        'arrow-filesystem-example',
+        sources: ['examplefs.cc'],
+        dependencies: [arrow_dep, gtest_main_dep],
+    )
 endif


### PR DESCRIPTION
### Rationale for this change

This helps simplify the Meson configuration by conditionally creating an "Arrow Benchmark Dependency," which may be a disabler when benchmarks are not desired

### What changes are included in this PR?

This is a refactor of the meson.build configuration files

### Are these changes tested?

Yes

### Are there any user-facing changes?

No

* GitHub Issue: #45865