### PR TITLE
GH-45917: [C++][Acero] Add flush taskgroup to enable parallelization

### DIFF
--- a/cpp/src/arrow/acero/swiss_join.cc
+++ b/cpp/src/arrow/acero/swiss_join.cc
@@ -2242,8 +2242,8 @@ void JoinProbeProcessor::Init(QueryContext* ctx, int num_key_columns, JoinType j
   cmp_ = cmp;
   output_batch_fn_ = output_batch_fn;
 
-  is_parallel_ =
-      ctx_->exec_context()->use_threads() && ctx_->executor()->GetCapacity() > 1;
+  is_parallel_ = ctx_->exec_context()->use_threads() &&
+                 (ctx_->executor() && ctx_->executor()->GetCapacity() > 1);
 
   if (is_parallel_) {
     task_group_finished_ = false;

--- a/cpp/src/arrow/acero/swiss_join_internal.h
+++ b/cpp/src/arrow/acero/swiss_join_internal.h
@@ -1007,21 +1007,15 @@ class JoinProbeProcessor {
  public:
   using OutputBatchFn = std::function<Status(int64_t, ExecBatch)>;
 
-  void Init(QueryContext* ctx, int num_key_columns, JoinType join_type,
-            SwissTableForJoin* hash_table, JoinResidualFilter* residual_filter,
+  void Init(int num_key_columns, JoinType join_type, SwissTableForJoin* hash_table,
+            JoinResidualFilter* residual_filter,
             std::vector<JoinResultMaterialize*> materialize,
             const std::vector<JoinKeyCmp>* cmp, OutputBatchFn output_batch_fn);
   Status OnNextBatch(int64_t thread_id, const ExecBatch& keypayload_batch,
                      arrow::util::TempVectorStack* temp_stack,
                      std::vector<KeyColumnArray>* temp_column_arrays);
 
-  // Must be called by a single-thread having exclusive access to the instance
-  // of this class. The caller is responsible for ensuring that.
-  //
-  Status OnFinished();
-
  private:
-  QueryContext* ctx_;
   int num_key_columns_;
   JoinType join_type_;
 
@@ -1032,12 +1026,6 @@ class JoinProbeProcessor {
   std::vector<JoinResultMaterialize*> materialize_;
   const std::vector<JoinKeyCmp>* cmp_;
   OutputBatchFn output_batch_fn_;
-
-  bool is_parallel_;
-  bool task_group_finished_;
-  int flush_task_group_id_;
-  std::condition_variable cv_;
-  std::mutex mutex_;
 };
 
 }  // namespace acero

--- a/cpp/src/arrow/acero/swiss_join_internal.h
+++ b/cpp/src/arrow/acero/swiss_join_internal.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-#include <condition_variable>
 #include <cstdint>
 #include "arrow/acero/options.h"
 #include "arrow/acero/partition_util.h"

--- a/cpp/src/arrow/acero/swiss_join_internal.h
+++ b/cpp/src/arrow/acero/swiss_join_internal.h
@@ -1033,8 +1033,9 @@ class JoinProbeProcessor {
   const std::vector<JoinKeyCmp>* cmp_;
   OutputBatchFn output_batch_fn_;
 
+  bool is_parallel_;
+  bool task_group_finished_;
   int flush_task_group_id_;
-  bool finished_{false};
   std::condition_variable cv_;
   std::mutex mutex_;
 };

--- a/cpp/src/arrow/acero/swiss_join_internal.h
+++ b/cpp/src/arrow/acero/swiss_join_internal.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <condition_variable>
 #include <cstdint>
 #include "arrow/acero/options.h"
 #include "arrow/acero/partition_util.h"
@@ -1031,6 +1032,11 @@ class JoinProbeProcessor {
   std::vector<JoinResultMaterialize*> materialize_;
   const std::vector<JoinKeyCmp>* cmp_;
   OutputBatchFn output_batch_fn_;
+
+  int flush_task_group_id_;
+  bool finished_{false};
+  std::condition_variable cv_;
+  std::mutex mutex_;
 };
 
 }  // namespace acero

--- a/cpp/src/arrow/acero/swiss_join_internal.h
+++ b/cpp/src/arrow/acero/swiss_join_internal.h
@@ -1006,8 +1006,8 @@ class JoinProbeProcessor {
  public:
   using OutputBatchFn = std::function<Status(int64_t, ExecBatch)>;
 
-  void Init(int num_key_columns, JoinType join_type, SwissTableForJoin* hash_table,
-            JoinResidualFilter* residual_filter,
+  void Init(QueryContext* ctx, int num_key_columns, JoinType join_type,
+            SwissTableForJoin* hash_table, JoinResidualFilter* residual_filter,
             std::vector<JoinResultMaterialize*> materialize,
             const std::vector<JoinKeyCmp>* cmp, OutputBatchFn output_batch_fn);
   Status OnNextBatch(int64_t thread_id, const ExecBatch& keypayload_batch,
@@ -1020,6 +1020,7 @@ class JoinProbeProcessor {
   Status OnFinished();
 
  private:
+  QueryContext* ctx_;
   int num_key_columns_;
   JoinType join_type_;
 


### PR DESCRIPTION
### Rationale for this change

Closes https://github.com/apache/arrow/issues/45917

### What changes are included in this PR?

Execute JoinResultMaterialize.Flush() in task group to enhance parallelism in downstream processing, improving the performance of hash join.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

None.

* GitHub Issue: #45917