### PR TITLE
GH-45905: [C++][Acero] Enlarge the timeout in ConcurrentQueue test to reduce sporadical failures

### DIFF
--- a/cpp/src/arrow/acero/util_test.cc
+++ b/cpp/src/arrow/acero/util_test.cc
@@ -201,10 +201,14 @@ void ConcurrentQueueBasicTest(Queue& queue) {
   queue.Push(2);
   queue.Push(3);
   queue.Push(4);
-  fut_pop.wait();
+  // A long enough timeout to prevent test from hanging forever once the code is broken.
+  // Though theoretically the readiness of the future is not guaranteed, in practice it
+  // is.
+  ASSERT_EQ(fut_pop.wait_for(std::chrono::seconds(5)), std::future_status::ready);
   ASSERT_EQ(fut_pop.get(), 2);
   fut_pop = std::async(std::launch::async, [&]() { return queue.WaitAndPop(); });
-  fut_pop.wait();
+  // Ditto.
+  ASSERT_EQ(fut_pop.wait_for(std::chrono::seconds(5)), std::future_status::ready);
   ASSERT_EQ(fut_pop.get(), 3);
   ASSERT_FALSE(queue.Empty());
   ASSERT_EQ(queue.TryPop(), std::make_optional(4));

--- a/cpp/src/arrow/acero/util_test.cc
+++ b/cpp/src/arrow/acero/util_test.cc
@@ -201,10 +201,10 @@ void ConcurrentQueueBasicTest(Queue& queue) {
   queue.Push(2);
   queue.Push(3);
   queue.Push(4);
-  ASSERT_EQ(fut_pop.wait_for(std::chrono::milliseconds(10)), std::future_status::ready);
+  fut_pop.wait();
   ASSERT_EQ(fut_pop.get(), 2);
   fut_pop = std::async(std::launch::async, [&]() { return queue.WaitAndPop(); });
-  ASSERT_EQ(fut_pop.wait_for(std::chrono::milliseconds(10)), std::future_status::ready);
+  fut_pop.wait();
   ASSERT_EQ(fut_pop.get(), 3);
   ASSERT_FALSE(queue.Empty());
   ASSERT_EQ(queue.TryPop(), std::make_optional(4));

--- a/cpp/src/arrow/acero/util_test.cc
+++ b/cpp/src/arrow/acero/util_test.cc
@@ -201,9 +201,9 @@ void ConcurrentQueueBasicTest(Queue& queue) {
   queue.Push(2);
   queue.Push(3);
   queue.Push(4);
-  // A long enough timeout to prevent test from hanging forever once the code is broken.
-  // Though theoretically the readiness of the future is not guaranteed, in practice it
-  // is.
+  // Note we should use wait() which guarantees the future is ready, but this will make
+  // the test hang forever if the code is broken. Thus we in turn use wait_for() with a
+  // large enough timeout which should be enough in practice.
   ASSERT_EQ(fut_pop.wait_for(std::chrono::seconds(5)), std::future_status::ready);
   ASSERT_EQ(fut_pop.get(), 2);
   fut_pop = std::async(std::launch::async, [&]() { return queue.WaitAndPop(); });


### PR DESCRIPTION
### Rationale for this change

The original test doesn't establish proper synchronization between `queue.WaitAndPop()` in one thread and the `fut_pop.get()` in the other. I.e., if the `std::async` thread (doing `queue.WaitAndPop()`) is scheduled by the os later than the timeout set for the `fut_pop.wait_for()` in the main thread, the timeout is returned and the assertion fires.

### What changes are included in this PR?

Enlarge the timeout from `10ms` to `5s` to reduce the chance of timing related failures.

Note in theory we should use `wait` (block forever until fulfilled) to prevent the timing issue, but in practice `5s` should be enough and it prevents the CI from hanging forever if any bug is introduced.

### Are these changes tested?

The fix is to the test.

### Are there any user-facing changes?

None.

* GitHub Issue: #45905