### PR TITLE
GH-45924: [CI] Update chrome_version for emscripten job to latest stable (v134)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -931,7 +931,7 @@ services:
         clang_tools: ${CLANG_TOOLS}
         llvm: ${LLVM}
         pyodide_version: "0.26.0"
-        chrome_version: "122"
+        chrome_version: "134"
         selenium_version: "4.15.2"
         required_python_min: "(3,12)"
         python: ${PYTHON}


### PR DESCRIPTION
### Rationale for this change

The `122` version fails to be installed from stable releases on chrome due to a new stable version released.

### What changes are included in this PR?

Update version of latest stable chrome driver to `134`.

### Are these changes tested?

Via archery job.

### Are there any user-facing changes?

No

* GitHub Issue: #45924