### PR TITLE
GH-45926: [Python] Use pytest.approx for float values on unbiased skew and kurtosis tests

### DIFF
--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -461,16 +461,17 @@ def test_kurtosis():
 @pytest.mark.parametrize("input, expected", (
     (
         [1.0, 2.0, 3.0, 40.0, None],
-        {'skew': 1.988947740397821, 'kurtosis': 3.9631931024230695}
+        {'skew': pytest.approx(1.988947740397821),
+         'kurtosis': pytest.approx(3.9631931024230695)}
     ),
-    ([1, 2, 40], {'skew': 1.7281098503730385, 'kurtosis': None}),
+    ([1, 2, 40], {'skew': pytest.approx(1.7281098503730385), 'kurtosis': None}),
     ([1, 40], {'skew': None, 'kurtosis': None}),
 ))
 def test_unbiased_skew_and_kurtosis(input, expected):
     arrow_skew = pc.skew(input, skip_nulls=True, biased=False)
     arrow_kurtosis = pc.kurtosis(input, skip_nulls=True, biased=False)
-    assert arrow_skew == pa.scalar(expected['skew'], type=pa.float64())
-    assert arrow_kurtosis == pa.scalar(expected['kurtosis'], type=pa.float64())
+    assert arrow_skew.as_py() == expected['skew']
+    assert arrow_kurtosis.as_py() == expected['kurtosis']
 
 
 def test_count_substring():


### PR DESCRIPTION
### Rationale for this change

The test fails on test-debian-12-python-3-i386 due to accuracy

### What changes are included in this PR?

Use pytest.approx instead of hardcoded float value

### Are these changes tested?

Yes via CI

### Are there any user-facing changes?

No

* GitHub Issue: #45926