### PR TITLE
GH-37891: [C++] Followup SliceBuffer shared_ptr move usage

### DIFF
--- a/cpp/src/arrow/compute/row/grouper.cc
+++ b/cpp/src/arrow/compute/row/grouper.cc
@@ -812,14 +812,14 @@ struct GrouperFastImpl : public Grouper {
     ARROW_ASSIGN_OR_RAISE(
         std::shared_ptr<Buffer> buf,
         AllocateBitmap(length + kBitmapPaddingForSIMD, ctx_->memory_pool()));
-    return SliceMutableBuffer(buf, 0, bit_util::BytesForBits(length));
+    return SliceMutableBuffer(std::move(buf), 0, bit_util::BytesForBits(length));
   }
 
   Result<std::shared_ptr<Buffer>> AllocatePaddedBuffer(int64_t size) {
     ARROW_ASSIGN_OR_RAISE(
         std::shared_ptr<Buffer> buf,
         AllocateBuffer(size + kBitmapPaddingForSIMD, ctx_->memory_pool()));
-    return SliceMutableBuffer(buf, 0, size);
+    return SliceMutableBuffer(std::move(buf), 0, size);
   }
 
   Result<ExecBatch> GetUniques() override {

--- a/cpp/src/arrow/csv/reader.cc
+++ b/cpp/src/arrow/csv/reader.cc
@@ -126,12 +126,12 @@ class CSVBufferIterator {
     }
 
     trailing_cr_ = (buf->data()[buf->size() - 1] == '\r');
-    buf = SliceBuffer(buf, offset);
+    buf = SliceBuffer(std::move(buf), offset);
     if (buf->size() == 0) {
       // EOF
       return TransformFinish();
     } else {
-      return TransformYield(buf);
+      return TransformYield(std::move(buf));
     }
   }
 

--- a/cpp/src/arrow/io/transform.cc
+++ b/cpp/src/arrow/io/transform.cc
@@ -125,12 +125,12 @@ Result<int64_t> TransformInputStream::Read(int64_t nbytes, void* out) {
   }
   {
     // Last buffer: splice into `out` and `pending_`
-    const auto buf = std::move(avail.back());
+    auto buf = std::move(avail.back());
     const int64_t to_copy = std::min(buf->size(), nbytes);
     memcpy(out_data, buf->data(), static_cast<size_t>(to_copy));
     copied_bytes += to_copy;
     if (buf->size() > to_copy) {
-      impl_->pending_ = SliceBuffer(buf, to_copy);
+      impl_->pending_ = SliceBuffer(std::move(buf), to_copy);
     } else {
       impl_->pending_.reset();
     }

--- a/cpp/src/arrow/ipc/writer.cc
+++ b/cpp/src/arrow/ipc/writer.cc
@@ -444,7 +444,7 @@ class RecordBatchSerializer {
       const int64_t buffer_length =
           std::min(bit_util::RoundUpToMultipleOf8(array.length() * type_width),
                    data->size() - byte_offset);
-      data = SliceBuffer(data, byte_offset, buffer_length);
+      data = SliceBuffer(std::move(data), byte_offset, buffer_length);
     }
     out_->body_buffers.emplace_back(std::move(data));
     return Status::OK();
@@ -473,7 +473,7 @@ class RecordBatchSerializer {
       const int64_t start_offset = array.value_offset(0);
       const int64_t slice_length =
           std::min(PaddedLength(total_data_bytes), data->size() - start_offset);
-      data = SliceBuffer(data, start_offset, slice_length);
+      data = SliceBuffer(std::move(data), start_offset, slice_length);
     }
 
     out_->body_buffers.emplace_back(std::move(value_offsets));

--- a/cpp/src/arrow/util/delimiting.cc
+++ b/cpp/src/arrow/util/delimiting.cc
@@ -160,10 +160,10 @@ Status Chunker::ProcessFinal(std::shared_ptr<Buffer> partial,
   if (first_pos == BoundaryFinder::kNoDelimiterFound) {
     // No delimiter in block => it's entirely a completion of partial
     *completion = block;
-    *rest = SliceBuffer(block, 0, 0);
+    *rest = SliceBuffer(std::move(block), 0, 0);
   } else {
     *completion = SliceBuffer(block, 0, first_pos);
-    *rest = SliceBuffer(block, first_pos);
+    *rest = SliceBuffer(std::move(block), first_pos);
   }
   return Status::OK();
 }
@@ -182,9 +182,9 @@ Status Chunker::ProcessSkip(std::shared_ptr<Buffer> partial,
   if (ARROW_PREDICT_FALSE(final && *count > num_found && block->size() != pos)) {
     // Skip the last row in the final block which does not have a delimiter
     ++num_found;
-    *rest = SliceBuffer(block, 0, 0);
+    *rest = SliceBuffer(std::move(block), 0, 0);
   } else {
-    *rest = SliceBuffer(block, pos);
+    *rest = SliceBuffer(std::move(block), pos);
   }
   *count -= num_found;
   return Status::OK();

--- a/cpp/src/parquet/encoder.cc
+++ b/cpp/src/parquet/encoder.cc
@@ -1193,7 +1193,7 @@ std::shared_ptr<Buffer> DeltaBitPackEncoder<DType>::FlushValues() {
   PARQUET_THROW_NOT_OK(sink_.Advance(kMaxPageHeaderWriterSize));
 
   // Excess bytes at the beginning are sliced off and ignored.
-  return SliceBuffer(buffer, offset_bytes);
+  return SliceBuffer(std::move(buffer), offset_bytes);
 }
 
 template <>


### PR DESCRIPTION
### Rationale for this change

https://github.com/apache/arrow/pull/45466/ Has basic implement the `SliceBuffer` api. This pr is a followup

### What changes are included in this PR?

Change the `SliceBuffer` buffer usage

### Are these changes tested?

Covered by existing

### Are there any user-facing changes?

no

* GitHub Issue: #37891