### PR TITLE
GH-45939: [C++][Benchmarking] Fix compilation failures

### DIFF
--- a/cpp/src/arrow/acero/aggregate_benchmark.cc
+++ b/cpp/src/arrow/acero/aggregate_benchmark.cc
@@ -17,6 +17,10 @@
 
 #include "benchmark/benchmark.h"
 
+#include <cassert>
+#include <cmath>
+#include <iostream>
+#include <random>
 #include <vector>
 
 #include "arrow/acero/exec_plan.h"
@@ -45,11 +49,6 @@ using compute::TDigestOptions;
 using compute::VarianceOptions;
 
 namespace acero {
-
-#include <cassert>
-#include <cmath>
-#include <iostream>
-#include <random>
 
 using arrow::internal::ToChars;
 using arrow::util::TotalBufferSize;
@@ -908,8 +907,7 @@ static void BenchmarkSegmentedAggregate(
   BenchmarkAggregate(state, std::move(aggregates), arguments, keys, segment_keys);
 }
 
-template <typename... Args>
-static void CountScalarSegmentedByInts(benchmark::State& state, Args&&...) {
+static void CountScalarSegmentedByInts(benchmark::State& state) {
   constexpr int64_t num_rows = 32 * 1024;
 
   // A trivial column to count from.
@@ -922,8 +920,7 @@ BENCHMARK(CountScalarSegmentedByInts)
     ->ArgNames({"SegmentKeys", "Segments"})
     ->ArgsProduct({{0, 1, 2}, benchmark::CreateRange(1, 256, 8)});
 
-template <typename... Args>
-static void CountGroupByIntsSegmentedByInts(benchmark::State& state, Args&&...) {
+static void CountGroupByIntsSegmentedByInts(benchmark::State& state) {
   constexpr int64_t num_rows = 32 * 1024;
 
   // A trivial column to count from.

--- a/cpp/src/arrow/c/bridge_benchmark.cc
+++ b/cpp/src/arrow/c/bridge_benchmark.cc
@@ -28,7 +28,7 @@
 #include "arrow/type.h"
 #include "arrow/util/key_value_metadata.h"
 
-namespace arrow {
+namespace arrow::benchmarks {
 
 std::shared_ptr<Schema> ExampleSchema() {
   auto f0 = field("f0", utf8());
@@ -60,7 +60,7 @@ static void ExportType(benchmark::State& state) {  // NOLINT non-const reference
   auto type = utf8();
 
   for (auto _ : state) {
-    ABORT_NOT_OK(ExportType(*type, &c_export));
+    ABORT_NOT_OK(::arrow::ExportType(*type, &c_export));
     ArrowSchemaRelease(&c_export);
   }
   state.SetItemsProcessed(state.iterations());
@@ -71,7 +71,7 @@ static void ExportSchema(benchmark::State& state) {  // NOLINT non-const referen
   auto schema = ExampleSchema();
 
   for (auto _ : state) {
-    ABORT_NOT_OK(ExportSchema(*schema, &c_export));
+    ABORT_NOT_OK(::arrow::ExportSchema(*schema, &c_export));
     ArrowSchemaRelease(&c_export);
   }
   state.SetItemsProcessed(state.iterations());
@@ -82,7 +82,7 @@ static void ExportArray(benchmark::State& state) {  // NOLINT non-const referenc
   auto array = ArrayFromJSON(utf8(), R"(["foo", "bar", null])");
 
   for (auto _ : state) {
-    ABORT_NOT_OK(ExportArray(*array, &c_export));
+    ABORT_NOT_OK(::arrow::ExportArray(*array, &c_export));
     ArrowArrayRelease(&c_export);
   }
   state.SetItemsProcessed(state.iterations());
@@ -93,7 +93,7 @@ static void ExportRecordBatch(benchmark::State& state) {  // NOLINT non-const re
   auto batch = ExampleRecordBatch();
 
   for (auto _ : state) {
-    ABORT_NOT_OK(ExportRecordBatch(*batch, &c_export));
+    ABORT_NOT_OK(::arrow::ExportRecordBatch(*batch, &c_export));
     ArrowArrayRelease(&c_export);
   }
   state.SetItemsProcessed(state.iterations());
@@ -104,7 +104,7 @@ static void ExportImportType(benchmark::State& state) {  // NOLINT non-const ref
   auto type = utf8();
 
   for (auto _ : state) {
-    ABORT_NOT_OK(ExportType(*type, &c_export));
+    ABORT_NOT_OK(::arrow::ExportType(*type, &c_export));
     ImportType(&c_export).ValueOrDie();
   }
   state.SetItemsProcessed(state.iterations());
@@ -115,7 +115,7 @@ static void ExportImportSchema(benchmark::State& state) {  // NOLINT non-const r
   auto schema = ExampleSchema();
 
   for (auto _ : state) {
-    ABORT_NOT_OK(ExportSchema(*schema, &c_export));
+    ABORT_NOT_OK(::arrow::ExportSchema(*schema, &c_export));
     ImportSchema(&c_export).ValueOrDie();
   }
   state.SetItemsProcessed(state.iterations());
@@ -127,7 +127,7 @@ static void ExportImportArray(benchmark::State& state) {  // NOLINT non-const re
   auto type = array->type();
 
   for (auto _ : state) {
-    ABORT_NOT_OK(ExportArray(*array, &c_export));
+    ABORT_NOT_OK(::arrow::ExportArray(*array, &c_export));
     ImportArray(&c_export, type).ValueOrDie();
   }
   state.SetItemsProcessed(state.iterations());
@@ -140,7 +140,7 @@ static void ExportImportRecordBatch(
   auto schema = batch->schema();
 
   for (auto _ : state) {
-    ABORT_NOT_OK(ExportRecordBatch(*batch, &c_export));
+    ABORT_NOT_OK(::arrow::ExportRecordBatch(*batch, &c_export));
     ImportRecordBatch(&c_export, schema).ValueOrDie();
   }
   state.SetItemsProcessed(state.iterations());
@@ -156,4 +156,4 @@ BENCHMARK(ExportImportSchema);
 BENCHMARK(ExportImportArray);
 BENCHMARK(ExportImportRecordBatch);
 
-}  // namespace arrow
+}  // namespace arrow::benchmarks

--- a/cpp/src/arrow/compute/kernels/scalar_list_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_list_benchmark.cc
@@ -45,38 +45,38 @@ static void BenchmarkListSlice(benchmark::State& state, const ListSliceOptions& 
   }
 }
 
-template <typename InListType = ListType>
-static void ListSliceInt64List(benchmark::State& state) {
+template <typename InListType>
+static void BenchmarkListSliceInt64List(benchmark::State& state) {
   ListSliceOptions opts;
   opts.start = kSliceStart;
   BenchmarkListSlice(state, opts, std::make_shared<InListType>(int64()));
 }
 
-template <typename InListType = ListType>
-static void ListSliceStringList(benchmark::State& state) {
+template <typename InListType>
+static void BenchmarkListSliceStringList(benchmark::State& state) {
   ListSliceOptions opts;
   opts.start = kSliceStart;
   BenchmarkListSlice(state, opts, std::make_shared<InListType>(utf8()));
 }
 
-template <typename InListType = ListType>
-static void ListSliceInt64ListWithStop(benchmark::State& state) {
+template <typename InListType>
+static void BenchmarkListSliceInt64ListWithStop(benchmark::State& state) {
   ListSliceOptions opts;
   opts.start = kSliceStart;
   opts.stop = kSliceStop;
   BenchmarkListSlice(state, opts, std::make_shared<InListType>(int64()));
 }
 
-template <typename InListType = ListType>
-static void ListSliceStringListWithStop(benchmark::State& state) {
+template <typename InListType>
+static void BenchmarkListSliceStringListWithStop(benchmark::State& state) {
   ListSliceOptions opts;
   opts.start = kSliceStart;
   opts.stop = kSliceStop;
   BenchmarkListSlice(state, opts, std::make_shared<InListType>(utf8()));
 }
 
-template <typename InListType = ListType>
-static void ListSliceInt64ListWithStepAndStop(benchmark::State& state) {
+template <typename InListType>
+static void BenchmarkListSliceInt64ListWithStepAndStop(benchmark::State& state) {
   ListSliceOptions opts;
   opts.start = kSliceStart;
   opts.step = 2;
@@ -84,8 +84,8 @@ static void ListSliceInt64ListWithStepAndStop(benchmark::State& state) {
   BenchmarkListSlice(state, opts, std::make_shared<InListType>(int64()));
 }
 
-template <typename InListType = ListType>
-static void ListSliceStringListWithStepAndStop(benchmark::State& state) {
+template <typename InListType>
+static void BenchmarkListSliceStringListWithStepAndStop(benchmark::State& state) {
   ListSliceOptions opts;
   opts.start = kSliceStart;
   opts.step = 2;
@@ -93,29 +93,25 @@ static void ListSliceStringListWithStepAndStop(benchmark::State& state) {
   BenchmarkListSlice(state, opts, std::make_shared<InListType>(utf8()));
 }
 
-static void ListSliceInt64ListView(benchmark::State& state) {
-  ListSliceInt64List<ListViewType>(state);
-}
+const auto ListSliceInt64List = BenchmarkListSliceInt64List<ListType>;
+const auto ListSliceStringList = BenchmarkListSliceStringList<ListType>;
+const auto ListSliceInt64ListWithStop = BenchmarkListSliceInt64ListWithStop<ListType>;
+const auto ListSliceStringListWithStop = BenchmarkListSliceStringListWithStop<ListType>;
+const auto ListSliceInt64ListWithStepAndStop =
+    BenchmarkListSliceInt64ListWithStepAndStop<ListType>;
+const auto ListSliceStringListWithStepAndStop =
+    BenchmarkListSliceStringListWithStepAndStop<ListType>;
 
-static void ListSliceStringListView(benchmark::State& state) {
-  ListSliceStringList<ListViewType>(state);
-}
-
-static void ListSliceInt64ListViewWithStop(benchmark::State& state) {
-  ListSliceInt64ListWithStop<ListViewType>(state);
-}
-
-static void ListSliceStringListViewWithStop(benchmark::State& state) {
-  ListSliceStringListWithStop<ListViewType>(state);
-}
-
-static void ListSliceInt64ListViewWithStepAndStop(benchmark::State& state) {
-  ListSliceInt64ListWithStepAndStop<ListViewType>(state);
-}
-
-static void ListSliceStringListViewWithStepAndStop(benchmark::State& state) {
-  ListSliceStringListWithStepAndStop<ListViewType>(state);
-}
+const auto ListSliceInt64ListView = BenchmarkListSliceInt64List<ListViewType>;
+const auto ListSliceStringListView = BenchmarkListSliceStringList<ListViewType>;
+const auto ListSliceInt64ListViewWithStop =
+    BenchmarkListSliceInt64ListWithStop<ListViewType>;
+const auto ListSliceStringListViewWithStop =
+    BenchmarkListSliceStringListWithStop<ListViewType>;
+const auto ListSliceInt64ListViewWithStepAndStop =
+    BenchmarkListSliceInt64ListWithStepAndStop<ListViewType>;
+const auto ListSliceStringListViewWithStepAndStop =
+    BenchmarkListSliceStringListWithStepAndStop<ListViewType>;
 
 static void ListSliceInt64ListToFSL(benchmark::State& state) {
   ListSliceOptions opts;

--- a/cpp/src/arrow/util/bit_util_benchmark.cc
+++ b/cpp/src/arrow/util/bit_util_benchmark.cc
@@ -42,8 +42,7 @@
 #include "arrow/util/bitmap_visit.h"
 #include "arrow/util/bitmap_writer.h"
 
-namespace arrow {
-namespace bit_util {
+namespace arrow::bit_util::benchmarks {
 
 constexpr int64_t kBufferSize = 1024 * 8;
 
@@ -435,7 +434,7 @@ static void SetBitsTo(benchmark::State& state) {
   std::shared_ptr<Buffer> buffer = CreateRandomBuffer(nbytes);
 
   for (auto _ : state) {
-    bit_util::SetBitsTo(buffer->mutable_data(), /*offset=*/0, nbytes * 8, true);
+    ::arrow::bit_util::SetBitsTo(buffer->mutable_data(), /*offset=*/0, nbytes * 8, true);
   }
   state.SetBytesProcessed(state.iterations() * nbytes);
 }
@@ -551,5 +550,4 @@ BENCHMARK(BenchmarkBitmapVisitBitsetAnd)->Ranges(AND_BENCHMARK_RANGES);
 BENCHMARK(BenchmarkBitmapVisitUInt8And)->Ranges(AND_BENCHMARK_RANGES);
 BENCHMARK(BenchmarkBitmapVisitUInt64And)->Ranges(AND_BENCHMARK_RANGES);
 
-}  // namespace bit_util
-}  // namespace arrow
+}  // namespace arrow::bit_util::benchmarks

--- a/cpp/src/parquet/arrow/reader_writer_benchmark.cc
+++ b/cpp/src/parquet/arrow/reader_writer_benchmark.cc
@@ -64,7 +64,7 @@ using arrow::FileReader;
 using arrow::WriteTable;
 using schema::PrimitiveNode;
 
-namespace benchmark {
+namespace benchmarks {
 
 // This should result in multiple pages for most primitive types
 constexpr int64_t BENCHMARK_SIZE = 10 * 1024 * 1024;
@@ -738,6 +738,5 @@ static void BM_ReadMultipleRowGroupsGenerator(::benchmark::State& state) {
 
 BENCHMARK(BM_ReadMultipleRowGroupsGenerator);
 
-}  // namespace benchmark
-
+}  // namespace benchmarks
 }  // namespace parquet

--- a/cpp/src/parquet/arrow/size_stats_benchmark.cc
+++ b/cpp/src/parquet/arrow/size_stats_benchmark.cc
@@ -33,7 +33,7 @@
 #include "arrow/testing/gtest_util.h"
 #include "arrow/testing/random.h"
 
-namespace parquet::benchmark {
+namespace parquet::benchmarks {
 
 // This should result in multiple pages for most primitive types
 constexpr int64_t kBenchmarkSize = 1024 * 1024;
@@ -176,4 +176,4 @@ BENCHMARK_TEMPLATE(BM_WriteListColumn, SizeStatisticsLevel::ColumnChunk,
 BENCHMARK_TEMPLATE(BM_WriteListColumn, SizeStatisticsLevel::PageAndColumnChunk,
                    ::arrow::StringType, /*enable_page_index=*/true);
 
-}  // namespace parquet::benchmark
+}  // namespace parquet::benchmarks

--- a/cpp/src/parquet/benchmark_util.cc
+++ b/cpp/src/parquet/benchmark_util.cc
@@ -19,7 +19,7 @@
 
 #include <random>
 
-namespace parquet::benchmark {
+namespace parquet::benchmarks {
 
 namespace {
 
@@ -123,4 +123,4 @@ void GenerateBenchmarkData(uint32_t size, uint32_t seed, ByteArray* data,
   }
 }
 
-}  // namespace parquet::benchmark
+}  // namespace parquet::benchmarks

--- a/cpp/src/parquet/benchmark_util.h
+++ b/cpp/src/parquet/benchmark_util.h
@@ -23,7 +23,7 @@
 
 #include "parquet/types.h"
 
-namespace parquet::benchmark {
+namespace parquet::benchmarks {
 
 template <typename T>
 void GenerateBenchmarkData(uint32_t size, uint32_t seed, T* data,
@@ -44,4 +44,4 @@ _GENERATE_BENCHMARK_DATA_DECL(Int96)
 
 #undef _GENERATE_BENCHMARK_DATA_DECL
 
-}  // namespace parquet::benchmark
+}  // namespace parquet::benchmarks

--- a/cpp/src/parquet/bloom_filter_benchmark.cc
+++ b/cpp/src/parquet/bloom_filter_benchmark.cc
@@ -24,7 +24,7 @@
 
 #include <random>
 
-namespace parquet::benchmark {
+namespace parquet::benchmarks {
 
 constexpr static uint32_t kNumBloomFilterInserts = 16 * 1024;
 // The sample string length for FLBA and ByteArray benchmarks
@@ -181,4 +181,4 @@ BENCHMARK(BM_BatchInsertHash);
 BENCHMARK(BM_FindExistingHash);
 BENCHMARK(BM_FindNonExistingHash);
 
-}  // namespace parquet::benchmark
+}  // namespace parquet::benchmarks

--- a/cpp/src/parquet/column_io_benchmark.cc
+++ b/cpp/src/parquet/column_io_benchmark.cc
@@ -33,7 +33,7 @@ namespace parquet {
 
 using schema::PrimitiveNode;
 
-namespace benchmark {
+namespace benchmarks {
 
 std::shared_ptr<Int64Writer> BuildWriter(int64_t output_size,
                                          const std::shared_ptr<ArrowOutputStream>& dst,
@@ -334,6 +334,5 @@ static void BM_RleDecoding(::benchmark::State& state) {
 
 BENCHMARK(BM_RleDecoding)->RangePair(1024, 65536, 1, 16);
 
-}  // namespace benchmark
-
+}  // namespace benchmarks
 }  // namespace parquet

--- a/cpp/src/parquet/column_reader_benchmark.cc
+++ b/cpp/src/parquet/column_reader_benchmark.cc
@@ -31,7 +31,7 @@ using parquet::internal::RecordReader;
 using parquet::test::MakePages;
 using schema::NodePtr;
 
-namespace benchmark {
+namespace benchmarks {
 
 class BenchmarkHelper {
  public:
@@ -368,5 +368,5 @@ static void ReadLevelsArguments(::benchmark::internal::Benchmark* b) {
 BENCHMARK(ReadLevels_Rle)->Apply(ReadLevelsArguments);
 BENCHMARK(ReadLevels_BitPack)->Apply(ReadLevelsArguments);
 
-}  // namespace benchmark
+}  // namespace benchmarks
 }  // namespace parquet

--- a/cpp/src/parquet/page_index_benchmark.cc
+++ b/cpp/src/parquet/page_index_benchmark.cc
@@ -27,7 +27,7 @@
 #include "parquet/test_util.h"
 #include "parquet/thrift_internal.h"
 
-namespace parquet::benchmark {
+namespace parquet::benchmarks {
 
 void PageIndexSetArgs(::benchmark::internal::Benchmark* bench) {
   bench->ArgNames({"num_pages"});
@@ -104,4 +104,4 @@ BENCHMARK_TEMPLATE(BM_ReadColumnIndex, DoubleType)->Apply(PageIndexSetArgs);
 BENCHMARK_TEMPLATE(BM_ReadColumnIndex, FLBAType)->Apply(PageIndexSetArgs);
 BENCHMARK_TEMPLATE(BM_ReadColumnIndex, ByteArrayType)->Apply(PageIndexSetArgs);
 
-}  // namespace parquet::benchmark
+}  // namespace parquet::benchmarks


### PR DESCRIPTION
### Rationale for this change

Benchmarks fail compiling with Google Benchmark 1.9.2. The errors seem triggered by this change upstream: https://github.com/google/benchmark/pull/1948

### What changes are included in this PR?

* Move some benchmark functions to a dedicated namespace so that there is no ambiguity with other functions
* Reduce reliance on templating in benchmark functions to avoid resolution ambiguities
* Other required fixes

Note that we don't rename the benchmark functions, to avoid breaking continuous benchmarking history.

### Are these changes tested?

By continuous benchmarking.

### Are there any user-facing changes?

No.
* GitHub Issue: #45939