### PR TITLE
GH-45949: [R] Fix CRAN warnings for 19.0.1 about compiled code

### DIFF
--- a/r/src/altrep.cpp
+++ b/r/src/altrep.cpp
@@ -222,8 +222,10 @@ struct AltrepVectorPrimitive : public AltrepVectorBase<AltrepVectorPrimitive<sex
       // copy the data from the array, through Get_region
       if constexpr (std::is_same_v<c_type, double>) {
         Get_region(alt, 0, size, REAL(copy));
-      } else {
+      } else if constexpr (std::is_same_v<c_type, int>) {
         Get_region(alt, 0, size, INTEGER(copy));
+      } else {
+        static_assert(false, "ALTREP not implemented for c_type");
       }
 
       // store as data2, this is now considered materialized
@@ -287,8 +289,10 @@ struct AltrepVectorPrimitive : public AltrepVectorBase<AltrepVectorPrimitive<sex
     if (IsMaterialized(alt)) {
       if constexpr (std::is_same_v<c_type, double>) {
         return reinterpret_cast<c_type*>(REAL(Representation(alt)))[i];
-      } else {
+      } else if constexpr (std::is_same_v<c_type, int>) {
         return reinterpret_cast<c_type*>(INTEGER(Representation(alt)))[i];
+      } else {
+        static_assert(false, "ALTREP not implemented for c_type");
       }
     }
 
@@ -1285,23 +1289,16 @@ sexp test_arrow_altrep_copy_by_dataptr(sexp x) {
 
   if (TYPEOF(x) == INTSXP) {
     cpp11::writable::integers out(Rf_xlength(x));
-    int* ptr = reinterpret_cast<int*>(INTEGER(x));
+    int* ptr = INTEGER(x);
     for (R_xlen_t i = 0; i < n; i++) {
       out[i] = ptr[i];
     }
     return out;
   } else if (TYPEOF(x) == REALSXP) {
     cpp11::writable::doubles out(Rf_xlength(x));
-    double* ptr = reinterpret_cast<double*>(REAL(x));
+    double* ptr = REAL(x);
     for (R_xlen_t i = 0; i < n; i++) {
       out[i] = ptr[i];
-    }
-    return out;
-  } else if (TYPEOF(x) == STRSXP) {
-    cpp11::writable::strings out(Rf_xlength(x));
-    for (R_xlen_t i = 0; i < n; i++) {
-      SEXP str_elt = reinterpret_cast<SEXP>(STRING_ELT(x, i));
-      out[i] = str_elt;
     }
     return out;
   } else {

--- a/r/src/altrep.cpp
+++ b/r/src/altrep.cpp
@@ -531,7 +531,7 @@ struct AltrepFactor : public AltrepVectorBase<AltrepFactor> {
       SEXP copy = PROTECT(Rf_allocVector(INTSXP, size));
 
       // copy the data from the array, through Get_region
-      Get_region(alt, 0, size, reinterpret_cast<int*>(DATAPTR(copy)));
+      Get_region(alt, 0, size, reinterpret_cast<int*>(INTEGER(copy)));
 
       // store as data2, this is now considered materialized
       SetRepresentation(alt, copy);
@@ -892,7 +892,7 @@ struct AltrepVectorString : public AltrepVectorBase<AltrepVectorString<Type>> {
     return s;
   }
 
-  static void* Dataptr(SEXP alt, Rboolean writeable) { return DATAPTR(Materialize(alt)); }
+  static void* Dataptr(SEXP alt, Rboolean writeable) { return STRING_PTR(Materialize(alt)); }
 
   static SEXP Materialize(SEXP alt) {
     if (Base::IsMaterialized(alt)) {
@@ -931,7 +931,7 @@ struct AltrepVectorString : public AltrepVectorBase<AltrepVectorString<Type>> {
   }
 
   static const void* Dataptr_or_null(SEXP alt) {
-    if (Base::IsMaterialized(alt)) return DATAPTR(Representation(alt));
+    if (Base::IsMaterialized(alt)) return STRING_PTR(Representation(alt));
 
     // otherwise give up
     return nullptr;
@@ -1267,21 +1267,21 @@ sexp test_arrow_altrep_copy_by_dataptr(sexp x) {
 
   if (TYPEOF(x) == INTSXP) {
     cpp11::writable::integers out(Rf_xlength(x));
-    int* ptr = reinterpret_cast<int*>(DATAPTR(x));
+    int* ptr = reinterpret_cast<int*>(INTEGER(x));
     for (R_xlen_t i = 0; i < n; i++) {
       out[i] = ptr[i];
     }
     return out;
   } else if (TYPEOF(x) == REALSXP) {
     cpp11::writable::doubles out(Rf_xlength(x));
-    double* ptr = reinterpret_cast<double*>(DATAPTR(x));
+    double* ptr = reinterpret_cast<double*>(REAL(x));
     for (R_xlen_t i = 0; i < n; i++) {
       out[i] = ptr[i];
     }
     return out;
   } else if (TYPEOF(x) == STRSXP) {
     cpp11::writable::strings out(Rf_xlength(x));
-    SEXP* ptr = reinterpret_cast<SEXP*>(DATAPTR(x));
+    SEXP* ptr = reinterpret_cast<SEXP*>(STRING_PTR(x));
     for (R_xlen_t i = 0; i < n; i++) {
       out[i] = ptr[i];
     }

--- a/r/src/altrep.cpp
+++ b/r/src/altrep.cpp
@@ -905,19 +905,16 @@ struct AltrepVectorString : public AltrepVectorBase<AltrepVectorString<Type>> {
   }
 
   static void* Dataptr(SEXP alt, Rboolean writeable) {
-      SEXP materialized = Materialize(alt);
-      // if (!isString(materialized)) {
-      //     error("Expected a character vector");
-      // }
+    SEXP materialized = Materialize(alt);
 
-      R_xlen_t len = XLENGTH(materialized);
-      void** str_array = (void**) R_alloc(len, sizeof(void*)); // Allocate array (R's memory allocator)
+    R_xlen_t len = XLENGTH(materialized);
+    void** str_array =
+        (void**)R_alloc(len, sizeof(void*));  // Allocate array (R's memory allocator)
+    for (R_xlen_t i = 0; i < len; i++) {
+      str_array[i] = (void*) STRING_ELT(materialized, i);
+    }
 
-      for (R_xlen_t i = 0; i < len; i++) {
-          str_array[i] = (void*) STRING_ELT(materialized, i);
-      }
-
-      return str_array; // Pointer to array of SEXP elements
+    return str_array;  // Pointer to array of SEXP elements
   }
 
   static SEXP Materialize(SEXP alt) {

--- a/r/src/altrep.cpp
+++ b/r/src/altrep.cpp
@@ -955,17 +955,7 @@ struct AltrepVectorString : public AltrepVectorBase<AltrepVectorString<Type>> {
 
   static const void* Dataptr_or_null(SEXP alt) {
     if (Base::IsMaterialized(alt)) {
-      SEXP materialized = Materialize(alt);
-
-      R_xlen_t len = XLENGTH(materialized);
-      void** str_array =
-          (void**)R_alloc(len, sizeof(void*));  // Allocate array (R's memory allocator)
-
-      for (R_xlen_t i = 0; i < len; i++) {
-        str_array[i] = (void*)STRING_ELT(materialized, i);
-      }
-
-      return str_array;  // Pointer to array of SEXP elements
+      return DATAPTR_RO(alt);
     }
 
     // otherwise give up

--- a/r/src/altrep.cpp
+++ b/r/src/altrep.cpp
@@ -225,7 +225,8 @@ struct AltrepVectorPrimitive : public AltrepVectorBase<AltrepVectorPrimitive<sex
       } else if constexpr (std::is_same_v<c_type, int>) {
         Get_region(alt, 0, size, INTEGER(copy));
       } else {
-        static_assert(false, "ALTREP not implemented for c_type");
+        static_assert(std::is_same_v<c_type, double> || std::is_same_v<c_type, int>,
+                      "ALTREP not implemented for this c_type");
       }
 
       // store as data2, this is now considered materialized
@@ -280,7 +281,8 @@ struct AltrepVectorPrimitive : public AltrepVectorBase<AltrepVectorPrimitive<sex
     } else if constexpr (std::is_same_v<c_type, int>) {
       return INTEGER(Materialize(alt));
     } else {
-      static_assert(false, "ALTREP not implemented for c_type");
+      static_assert(std::is_same_v<c_type, double> || std::is_same_v<c_type, int>,
+                    "ALTREP not implemented for this c_type");
     }
   }
 
@@ -292,7 +294,8 @@ struct AltrepVectorPrimitive : public AltrepVectorBase<AltrepVectorPrimitive<sex
       } else if constexpr (std::is_same_v<c_type, int>) {
         return reinterpret_cast<c_type*>(INTEGER(Representation(alt)))[i];
       } else {
-        static_assert(false, "ALTREP not implemented for c_type");
+        static_assert(std::is_same_v<c_type, double> || std::is_same_v<c_type, int>,
+                      "ALTREP not implemented for this c_type");
       }
     }
 

--- a/r/src/altrep.cpp
+++ b/r/src/altrep.cpp
@@ -275,8 +275,10 @@ struct AltrepVectorPrimitive : public AltrepVectorBase<AltrepVectorPrimitive<sex
     // Otherwise we have to materialize and hand the pointer to data2
     if constexpr (std::is_same_v<c_type, double>) {
       return REAL(Materialize(alt));
-    } else {
+    } else if constexpr (std::is_same_v<c_type, int>) {
       return INTEGER(Materialize(alt));
+    } else {
+      static_assert(false, "ALTREP not implemented for c_type");
     }
   }
 

--- a/r/src/altrep.cpp
+++ b/r/src/altrep.cpp
@@ -959,10 +959,10 @@ struct AltrepVectorString : public AltrepVectorBase<AltrepVectorString<Type>> {
 
       R_xlen_t len = XLENGTH(materialized);
       void** str_array =
-          (void**) R_alloc(len, sizeof(void*)); // Allocate array (R's memory allocator)
+          (void**)R_alloc(len, sizeof(void*));  // Allocate array (R's memory allocator)
 
       for (R_xlen_t i = 0; i < len; i++) {
-          str_array[i] = (void*)STRING_ELT(materialized, i);
+        str_array[i] = (void*)STRING_ELT(materialized, i);
       }
 
       return str_array;  // Pointer to array of SEXP elements

--- a/r/src/altrep.cpp
+++ b/r/src/altrep.cpp
@@ -892,7 +892,9 @@ struct AltrepVectorString : public AltrepVectorBase<AltrepVectorString<Type>> {
     return s;
   }
 
-  static void* Dataptr(SEXP alt, Rboolean writeable) { return STRING_PTR(Materialize(alt)); }
+  static void* Dataptr(SEXP alt, Rboolean writeable) { 
+    return STRING_PTR(Materialize(alt)); 
+  }
 
   static SEXP Materialize(SEXP alt) {
     if (Base::IsMaterialized(alt)) {

--- a/r/src/altrep.cpp
+++ b/r/src/altrep.cpp
@@ -290,9 +290,9 @@ struct AltrepVectorPrimitive : public AltrepVectorBase<AltrepVectorPrimitive<sex
   static c_type Elt(SEXP alt, R_xlen_t i) {
     if (IsMaterialized(alt)) {
       if constexpr (std::is_same_v<c_type, double>) {
-        return reinterpret_cast<c_type*>(REAL(Representation(alt)))[i];
+        return REAL(Representation(alt))[i];
       } else if constexpr (std::is_same_v<c_type, int>) {
-        return reinterpret_cast<c_type*>(INTEGER(Representation(alt)))[i];
+        return INTEGER(Representation(alt))[i];
       } else {
         static_assert(std::is_same_v<c_type, double> || std::is_same_v<c_type, int>,
                       "ALTREP not implemented for this c_type");
@@ -552,7 +552,7 @@ struct AltrepFactor : public AltrepVectorBase<AltrepFactor> {
       SEXP copy = PROTECT(Rf_allocVector(INTSXP, size));
 
       // copy the data from the array, through Get_region
-      Get_region(alt, 0, size, reinterpret_cast<int*>(INTEGER(copy)));
+      Get_region(alt, 0, size, INTEGER(copy));
 
       // store as data2, this is now considered materialized
       SetRepresentation(alt, copy);

--- a/r/src/altrep.cpp
+++ b/r/src/altrep.cpp
@@ -1307,13 +1307,10 @@ sexp test_arrow_altrep_copy_by_dataptr(sexp x) {
     return out;
   } else if (TYPEOF(x) == STRSXP) {
     cpp11::writable::strings out(Rf_xlength(x));
-    R_xlen_t len = Rf_xlength(x);
-
-    for (R_xlen_t i = 0; i < len; i++) {
+    for (R_xlen_t i = 0; i < n; i++) {
       SEXP str_elt = reinterpret_cast<SEXP>(STRING_ELT(x, i));
       out[i] = str_elt;
     }
-
     return out;
   } else {
     return R_NilValue;

--- a/r/src/altrep.cpp
+++ b/r/src/altrep.cpp
@@ -905,16 +905,17 @@ struct AltrepVectorString : public AltrepVectorBase<AltrepVectorString<Type>> {
   }
 
   static void* Dataptr(SEXP alt, Rboolean writeable) {
+    // DATAPTR(Materialize(alt)) is disallowed by CRAN, so we need to createt the array of
+    // string and place the SEXPs in it ourselves with STRING_ELT()
     SEXP materialized = Materialize(alt);
 
     R_xlen_t len = XLENGTH(materialized);
-    void** str_array =
-        (void**)R_alloc(len, sizeof(void*));  // Allocate array (R's memory allocator)
+    void** str_array = (void**)R_alloc(len, sizeof(void*));
     for (R_xlen_t i = 0; i < len; i++) {
       str_array[i] = (void*)STRING_ELT(materialized, i);
     }
 
-    return str_array;  // Pointer to array of SEXP elements
+    return str_array;
   }
 
   static SEXP Materialize(SEXP alt) {

--- a/r/src/altrep.cpp
+++ b/r/src/altrep.cpp
@@ -892,8 +892,8 @@ struct AltrepVectorString : public AltrepVectorBase<AltrepVectorString<Type>> {
     return s;
   }
 
-  static void* Dataptr(SEXP alt, Rboolean writeable) { 
-    return STRING_PTR(Materialize(alt)); 
+  static void* Dataptr(SEXP alt, Rboolean writeable) {
+    return STRING_PTR(Materialize(alt));
   }
 
   static SEXP Materialize(SEXP alt) {

--- a/r/src/altrep.cpp
+++ b/r/src/altrep.cpp
@@ -911,7 +911,7 @@ struct AltrepVectorString : public AltrepVectorBase<AltrepVectorString<Type>> {
     void** str_array =
         (void**)R_alloc(len, sizeof(void*));  // Allocate array (R's memory allocator)
     for (R_xlen_t i = 0; i < len; i++) {
-      str_array[i] = (void*) STRING_ELT(materialized, i);
+      str_array[i] = (void*)STRING_ELT(materialized, i);
     }
 
     return str_array;  // Pointer to array of SEXP elements
@@ -958,13 +958,14 @@ struct AltrepVectorString : public AltrepVectorBase<AltrepVectorString<Type>> {
       SEXP materialized = Materialize(alt);
 
       R_xlen_t len = XLENGTH(materialized);
-      void** str_array = (void**) R_alloc(len, sizeof(void*)); // Allocate array (R's memory allocator)
+      void** str_array =
+          (void**) R_alloc(len, sizeof(void*)); // Allocate array (R's memory allocator)
 
       for (R_xlen_t i = 0; i < len; i++) {
-          str_array[i] = (void*) STRING_ELT(materialized, i);
+          str_array[i] = (void*)STRING_ELT(materialized, i);
       }
 
-      return str_array; // Pointer to array of SEXP elements
+      return str_array;  // Pointer to array of SEXP elements
     }
 
     // otherwise give up

--- a/r/src/altrep.cpp
+++ b/r/src/altrep.cpp
@@ -221,9 +221,9 @@ struct AltrepVectorPrimitive : public AltrepVectorBase<AltrepVectorPrimitive<sex
 
       // copy the data from the array, through Get_region
       if constexpr (std::is_same_v<c_type, double>) {
-        Get_region(alt, 0, size, reinterpret_cast<double*>(REAL(copy)));
+        Get_region(alt, 0, size, REAL(copy));
       } else {
-        Get_region(alt, 0, size, reinterpret_cast<int*>(INTEGER(copy)));
+        Get_region(alt, 0, size, INTEGER(copy));
       }
 
       // store as data2, this is now considered materialized
@@ -907,17 +907,7 @@ struct AltrepVectorString : public AltrepVectorBase<AltrepVectorString<Type>> {
   }
 
   static void* Dataptr(SEXP alt, Rboolean writeable) {
-    // DATAPTR(Materialize(alt)) is disallowed by CRAN, so we need to createt the array of
-    // string and place the SEXPs in it ourselves with STRING_ELT()
-    SEXP materialized = Materialize(alt);
-
-    R_xlen_t len = XLENGTH(materialized);
-    void** str_array = (void**)R_alloc(len, sizeof(void*));
-    for (R_xlen_t i = 0; i < len; i++) {
-      str_array[i] = (void*)STRING_ELT(materialized, i);
-    }
-
-    return str_array;
+    return const_cast<void*>(DATAPTR_RO(Materialize(alt)));
   }
 
   static SEXP Materialize(SEXP alt) {

--- a/r/src/arrow_types.h
+++ b/r/src/arrow_types.h
@@ -173,7 +173,7 @@ template <typename RVector>
 class RBuffer : public MutableBuffer {
  public:
   explicit RBuffer(RVector vec)
-      : MutableBuffer(reinterpret_cast<uint8_t*>(DATAPTR(vec)),
+      : MutableBuffer(reinterpret_cast<uint8_t*>(getDataPointer(vec)),
                       vec.size() * sizeof(typename RVector::value_type),
                       arrow::CPUDevice::memory_manager(gc_memory_pool())),
         vec_(vec) {}
@@ -181,6 +181,22 @@ class RBuffer : public MutableBuffer {
  private:
   // vec_ holds the memory
   RVector vec_;
+
+  static void* getDataPointer(RVector& vec) {    
+    if (TYPEOF(vec) == LGLSXP) {
+      return LOGICAL(vec);
+    } else if (TYPEOF(vec) == INTSXP) {
+      return INTEGER(vec);
+    } else if (TYPEOF(vec) == REALSXP) {
+      return REAL(vec);
+    } else if (TYPEOF(vec) == CPLXSXP) {
+      return COMPLEX(vec);
+    } else if (TYPEOF(vec) == STRSXP) {
+      return STRING_PTR(vec);
+    } else if (TYPEOF(vec) == RAWSXP) {
+      return RAW(vec);
+    }
+  }
 };
 
 std::shared_ptr<arrow::DataType> InferArrowTypeFromFactor(SEXP);

--- a/r/src/arrow_types.h
+++ b/r/src/arrow_types.h
@@ -195,6 +195,8 @@ class RBuffer : public MutableBuffer {
       return STRING_PTR(vec);
     } else if (TYPEOF(vec) == RAWSXP) {
       return RAW(vec);
+    } else {
+      return RAW(vec);
     }
   }
 };

--- a/r/src/arrow_types.h
+++ b/r/src/arrow_types.h
@@ -192,9 +192,8 @@ class RBuffer : public MutableBuffer {
     } else if (TYPEOF(vec) == CPLXSXP) {
       return COMPLEX(vec);
     } else if (TYPEOF(vec) == STRSXP) {
-      // Technically this returns the address to the first element of the string vector
-      // which is similar to what we would get with DATAPTR() before it was removed
-      return STRING_ELT(vec, 0);
+      // We don't want to expose the string data here, so we error
+      cpp11::stop("Operation not supported for string vectors.");
     } else {
       // raw
       return RAW(vec);

--- a/r/src/arrow_types.h
+++ b/r/src/arrow_types.h
@@ -192,10 +192,9 @@ class RBuffer : public MutableBuffer {
     } else if (TYPEOF(vec) == CPLXSXP) {
       return COMPLEX(vec);
     } else if (TYPEOF(vec) == STRSXP) {
-      return STRING_PTR(vec);
-    } else if (TYPEOF(vec) == RAWSXP) {
-      return RAW(vec);
+      return STRING_ELT(vec, 0);
     } else {
+      // raw
       return RAW(vec);
     }
   }

--- a/r/src/arrow_types.h
+++ b/r/src/arrow_types.h
@@ -192,15 +192,9 @@ class RBuffer : public MutableBuffer {
     } else if (TYPEOF(vec) == CPLXSXP) {
       return COMPLEX(vec);
     } else if (TYPEOF(vec) == STRSXP) {
-      cpp11::writable::strings out(Rf_xlength(vec));
-      R_xlen_t len = Rf_xlength(vec);
-
-      for (R_xlen_t i = 0; i < len; i++) {
-        SEXP str_elt = reinterpret_cast<SEXP>(STRING_ELT(vec, i));
-        out[i] = str_elt;
-      }
-
-      return out;
+      // Technically this returns the address to the first element of the string vector
+      // which is similar to what we would get with DATAPTR() before it was removed
+      return STRING_ELT(vec, 0);
     } else {
       // raw
       return RAW(vec);

--- a/r/src/arrow_types.h
+++ b/r/src/arrow_types.h
@@ -192,7 +192,15 @@ class RBuffer : public MutableBuffer {
     } else if (TYPEOF(vec) == CPLXSXP) {
       return COMPLEX(vec);
     } else if (TYPEOF(vec) == STRSXP) {
-      return STRING_ELT(vec, 0);
+      cpp11::writable::strings out(Rf_xlength(vec));
+      R_xlen_t len = Rf_xlength(vec);
+
+      for (R_xlen_t i = 0; i < len; i++) {
+        SEXP str_elt = reinterpret_cast<SEXP>(STRING_ELT(vec, i));
+        out[i] = str_elt;
+      }
+
+      return out;
     } else {
       // raw
       return RAW(vec);

--- a/r/src/arrow_types.h
+++ b/r/src/arrow_types.h
@@ -182,7 +182,7 @@ class RBuffer : public MutableBuffer {
   // vec_ holds the memory
   RVector vec_;
 
-  static void* getDataPointer(RVector& vec) {    
+  static void* getDataPointer(RVector& vec) {
     if (TYPEOF(vec) == LGLSXP) {
       return LOGICAL(vec);
     } else if (TYPEOF(vec) == INTSXP) {

--- a/r/src/r_to_arrow.cpp
+++ b/r/src/r_to_arrow.cpp
@@ -1214,11 +1214,11 @@ bool can_reuse_memory(SEXP x, const std::shared_ptr<arrow::DataType>& type) {
   //       because MakeSimpleArray below will force materialization
   switch (type->id()) {
     case Type::INT32:
-      return TYPEOF(x) == INTSXP && !OBJECT(x);
+      return TYPEOF(x) == INTSXP && !Rf_isObject(x);
     case Type::DOUBLE:
-      return TYPEOF(x) == REALSXP && !OBJECT(x);
+      return TYPEOF(x) == REALSXP && !Rf_isObject(x);
     case Type::INT8:
-      return TYPEOF(x) == RAWSXP && !OBJECT(x);
+      return TYPEOF(x) == RAWSXP && !Rf_isObject(x);
     case Type::INT64:
       return TYPEOF(x) == REALSXP && Rf_inherits(x, "integer64");
     default:
@@ -1412,17 +1412,17 @@ bool vector_from_r_memory(SEXP x, const std::shared_ptr<DataType>& type,
 
   switch (type->id()) {
     case Type::INT32:
-      return TYPEOF(x) == INTSXP && !OBJECT(x) &&
+      return TYPEOF(x) == INTSXP && !Rf_isObject(x) &&
              vector_from_r_memory_impl<cpp11::integers, Int32Type>(x, type, columns, j,
                                                                    tasks);
 
     case Type::DOUBLE:
-      return TYPEOF(x) == REALSXP && !OBJECT(x) &&
+      return TYPEOF(x) == REALSXP && !Rf_isObject(x) &&
              vector_from_r_memory_impl<cpp11::doubles, DoubleType>(x, type, columns, j,
                                                                    tasks);
 
     case Type::UINT8:
-      return TYPEOF(x) == RAWSXP && !OBJECT(x) &&
+      return TYPEOF(x) == RAWSXP && !Rf_isObject(x) &&
              vector_from_r_memory_impl<cpp11::raws, UInt8Type>(x, type, columns, j,
                                                                tasks);
 

--- a/r/tests/testthat/test-altrep.R
+++ b/r/tests/testthat/test-altrep.R
@@ -170,7 +170,7 @@ test_that("element access methods for int32 ALTREP with nulls", {
   expect_identical(test_arrow_altrep_copy_by_region(altrep, 123), original)
   expect_false(test_arrow_altrep_is_materialized(altrep))
 
-  # because there are no nulls, DATAPTR() does not materialize
+  # because there are nulls, DATAPTR() does materialize
   expect_identical(test_arrow_altrep_copy_by_dataptr(altrep), original)
   expect_true(test_arrow_altrep_is_materialized(altrep))
 
@@ -193,7 +193,7 @@ test_that("element access methods for double ALTREP with nulls", {
   expect_identical(test_arrow_altrep_copy_by_region(altrep, 123), original)
   expect_false(test_arrow_altrep_is_materialized(altrep))
 
-  # because there are no nulls, DATAPTR() does not materialize
+  # because there are nulls, DATAPTR() does materialize
   expect_identical(test_arrow_altrep_copy_by_dataptr(altrep), original)
   expect_true(test_arrow_altrep_is_materialized(altrep))
 
@@ -244,11 +244,12 @@ test_that("element access methods for character ALTREP", {
   expect_identical(test_arrow_altrep_copy_by_element(altrep), original)
   expect_false(test_arrow_altrep_is_materialized(altrep))
 
-  # DATAPTR() should always materialize for strings
+  # DATAPTR() does not materialize
   expect_identical(test_arrow_altrep_copy_by_dataptr(altrep), original)
-  expect_true(test_arrow_altrep_is_materialized(altrep))
+  expect_false(test_arrow_altrep_is_materialized(altrep))
 
   # test element access after materialization
+  test_arrow_altrep_force_materialize(altrep)
   expect_true(test_arrow_altrep_is_materialized(altrep))
   expect_identical(test_arrow_altrep_copy_by_element(altrep), original)
   expect_identical(test_arrow_altrep_copy_by_dataptr(altrep), original)
@@ -265,11 +266,12 @@ test_that("element access methods for character ALTREP from large_utf8()", {
   expect_identical(test_arrow_altrep_copy_by_element(altrep), original)
   expect_false(test_arrow_altrep_is_materialized(altrep))
 
-  # DATAPTR() should always materialize for strings
+  # DATAPTR() sdoes not materialize
   expect_identical(test_arrow_altrep_copy_by_dataptr(altrep), original)
-  expect_true(test_arrow_altrep_is_materialized(altrep))
+  expect_false(test_arrow_altrep_is_materialized(altrep))
 
   # test element access after materialization
+  test_arrow_altrep_force_materialize(altrep)
   expect_true(test_arrow_altrep_is_materialized(altrep))
   expect_identical(test_arrow_altrep_copy_by_element(altrep), original)
   expect_identical(test_arrow_altrep_copy_by_dataptr(altrep), original)

--- a/r/tests/testthat/test-altrep.R
+++ b/r/tests/testthat/test-altrep.R
@@ -244,15 +244,13 @@ test_that("element access methods for character ALTREP", {
   expect_identical(test_arrow_altrep_copy_by_element(altrep), original)
   expect_false(test_arrow_altrep_is_materialized(altrep))
 
-  # DATAPTR() does not materialize
-  expect_identical(test_arrow_altrep_copy_by_dataptr(altrep), original)
-  expect_false(test_arrow_altrep_is_materialized(altrep))
+  # match() calls DATAPTR() internally which materializes the vector
+  match(altrep, c("1", "40", "999"))
+  expect_true(test_arrow_altrep_is_materialized(altrep))
 
   # test element access after materialization
-  test_arrow_altrep_force_materialize(altrep)
   expect_true(test_arrow_altrep_is_materialized(altrep))
   expect_identical(test_arrow_altrep_copy_by_element(altrep), original)
-  expect_identical(test_arrow_altrep_copy_by_dataptr(altrep), original)
 })
 
 test_that("element access methods for character ALTREP from large_utf8()", {
@@ -266,15 +264,13 @@ test_that("element access methods for character ALTREP from large_utf8()", {
   expect_identical(test_arrow_altrep_copy_by_element(altrep), original)
   expect_false(test_arrow_altrep_is_materialized(altrep))
 
-  # DATAPTR() sdoes not materialize
-  expect_identical(test_arrow_altrep_copy_by_dataptr(altrep), original)
-  expect_false(test_arrow_altrep_is_materialized(altrep))
+  # match() calls DATAPTR() internally which materializes the vector
+  match(altrep, c("1", "40", "999"))
+  expect_true(test_arrow_altrep_is_materialized(altrep))
 
   # test element access after materialization
-  test_arrow_altrep_force_materialize(altrep)
   expect_true(test_arrow_altrep_is_materialized(altrep))
   expect_identical(test_arrow_altrep_copy_by_element(altrep), original)
-  expect_identical(test_arrow_altrep_copy_by_dataptr(altrep), original)
 })
 
 test_that("empty vectors are not altrep", {


### PR DESCRIPTION
This gets rid of `OBJECT`, `DATAPTR` has been replaced with `INTEGER()`, `REAL()`, etc. though strings are more complicated. I will fully admit that this C++ is stretching my comfort zone, so might include obviously wrong things!

CI is currently failing, but I'm not totally sure yet if that means the code changes here are wrong or if maybe these allow us to have slightly different assumptions about materialization (see https://github.com/apache/arrow/pull/45951#discussion_r2019675135)

I've also requested reviews broadly for folks I know have been around this code before, I appreciate any effort that y'all can spare 🙏 

* GitHub Issue: #45949