### PR TITLE
GH-45959: [C++][CMake] Fix Protobuf dependency in Arrow::arrow_static

### DIFF
--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -126,9 +126,7 @@ if(ARROW_WITH_RE2)
   endif()
 endif()
 
-# This should be done after if(ARROW_ORC) and if(ARROW_WITH_OPENTELEMETRY)
-# because they depend on Protobuf.
-if(ARROW_WITH_PROTOBUF)
+if(ARROW_PROTOBUF_ARROW_CMAKE_PACKAGE_NAME STREQUAL "Arrow")
   if(Protobuf_SOURCE STREQUAL "SYSTEM")
     list(APPEND ARROW_STATIC_INSTALL_INTERFACE_LIBS ${ARROW_PROTOBUF_LIBPROTOBUF})
   endif()

--- a/cpp/src/arrow/flight/CMakeLists.txt
+++ b/cpp/src/arrow/flight/CMakeLists.txt
@@ -33,6 +33,13 @@ if(APPLE AND ARROW_USE_OPENSSL)
   list(APPEND ARROW_FLIGHT_LINK_LIBS ${ARROW_OPENSSL_LIBS})
 endif()
 
+set(ARROW_FLIGHT_STATIC_INSTALL_INTERFACE_LIBS Arrow::arrow_static)
+if(ARROW_PROTOBUF_ARROW_CMAKE_PACKAGE_NAME STREQUAL "ArrowFlight")
+  if(Protobuf_SOURCE STREQUAL "SYSTEM")
+    list(APPEND ARROW_FLIGHT_STATIC_INSTALL_INTERFACE_LIBS ${ARROW_PROTOBUF_LIBPROTOBUF})
+  endif()
+endif()
+
 set(ARROW_FLIGHT_TEST_LINKAGE "${ARROW_TEST_LINKAGE}")
 if(Protobuf_USE_STATIC_LIBS)
   message(STATUS "Linking Arrow Flight tests statically due to static Protobuf")
@@ -204,7 +211,7 @@ add_arrow_lib(arrow_flight
               ${ARROW_FLIGHT_LINK_LIBS}
               arrow_static
               STATIC_INSTALL_INTERFACE_LIBS
-              Arrow::arrow_static)
+              ${ARROW_FLIGHT_STATIC_INSTALL_INTERFACE_LIBS})
 
 if(ARROW_BUILD_STATIC AND WIN32)
   target_compile_definitions(arrow_flight_static PUBLIC ARROW_FLIGHT_STATIC)


### PR DESCRIPTION
### Rationale for this change

If Protobuf is used only for Flight, Arrow::arrow_static must not depend on Protobuf. Instead, ArrowFlight::arrow_flight_static must depend on Protobuf.

### What changes are included in this PR?

Use `ARROW_PROTOBUF_ARROW_CMAKE_PACKAGE_NAME` instead of `ARROW_WITH_PROTOBUF` to detect which CMake target must depend on Protobuf.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #45959