### PR TITLE
GH-45961: [Release][Docs] Upload generated docs to GitHub Releases not apache.jfrog.io

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -198,6 +198,7 @@ repos:
           ?^dev/release/05-binary-upload\.sh$|
           ?^dev/release/07-binary-verify\.sh$|
           ?^dev/release/post-03-binary\.sh$|
+          ?^dev/release/post-10-docs\.sh$|
           ?^dev/release/post-11-python\.sh$|
           ?^dev/release/utils-generate-checksum\.sh$|
           )
@@ -214,6 +215,7 @@ repos:
           (
           ?^dev/release/05-binary-upload\.sh$|
           ?^dev/release/post-03-binary\.sh$|
+          ?^dev/release/post-10-docs\.sh$|
           ?^dev/release/post-11-python\.sh$|
           )
   - repo: https://github.com/trim21/pre-commit-mirror-meson

--- a/dev/release/05-binary-upload.sh
+++ b/dev/release/05-binary-upload.sh
@@ -82,11 +82,15 @@ tmp_dir=binary/tmp
 rm -rf "${tmp_dir}"
 mkdir -p "${tmp_dir}"
 
-if [ "${UPLOAD_PYTHON}" -gt 0 ]; then
-  dist_dir="${tmp_dir}/dist"
+upload_to_github_release() {
+  local id="$1"
+  shift
+  local dist_dir="${tmp_dir}/${id}"
   mkdir -p "${dist_dir}"
-  for target in "${ARROW_ARTIFACTS_DIR}"/python-sdist/* \
-    "${ARROW_ARTIFACTS_DIR}"/wheel-*/*; do
+  while [ $# -gt 0 ]; do
+    local target="$1"
+    shift
+    local base_name
     base_name="$(basename "${target}")"
     cp -a "${target}" "${dist_dir}/${base_name}"
     gpg \
@@ -103,6 +107,14 @@ if [ "${UPLOAD_PYTHON}" -gt 0 ]; then
     --repo apache/arrow \
     "apache-arrow-${version}-rc${rc}" \
     "${dist_dir}"/*
+}
+
+if [ "${UPLOAD_DOCS}" -gt 0 ]; then
+  upload_to_github_release docs "${ARROW_ARTIFACTS_DIR}"/*-docs/*
+fi
+if [ "${UPLOAD_PYTHON}" -gt 0 ]; then
+  upload_to_github_release python \
+    "${ARROW_ARTIFACTS_DIR}"/{python-sdist,wheel-*}/*
 fi
 
 rake_tasks=()

--- a/dev/release/binary-task.rb
+++ b/dev/release/binary-task.rb
@@ -1123,7 +1123,6 @@ class BinaryTask
   def define
     define_apt_tasks
     define_yum_tasks
-    define_docs_tasks
     define_r_tasks
     define_summary_tasks
   end
@@ -2516,14 +2515,6 @@ APT::FTPArchive::Release::Description "#{apt_repository_description}";
                                 target_files_glob)
     define_generic_data_rc_tasks(label, id, rc_dir, target_files_glob)
     define_generic_data_release_tasks(label, id, release_dir)
-  end
-
-  def define_docs_tasks
-    define_generic_data_tasks("Docs",
-                              :docs,
-                              "#{rc_dir}/docs/#{full_version}",
-                              "#{release_dir}/docs/#{full_version}",
-                              "test-debian-12-docs/**/*")
   end
 
   def define_r_rc_tasks(label, id, rc_dir)

--- a/dev/release/post-03-binary.sh
+++ b/dev/release/post-03-binary.sh
@@ -50,7 +50,6 @@ fi
 : "${DEPLOY_AMAZON_LINUX:=${DEPLOY_DEFAULT}}"
 : "${DEPLOY_CENTOS:=${DEPLOY_DEFAULT}}"
 : "${DEPLOY_DEBIAN:=${DEPLOY_DEFAULT}}"
-: "${DEPLOY_DOCS:=${DEPLOY_DEFAULT}}"
 : "${DEPLOY_R:=${DEPLOY_DEFAULT}}"
 : "${DEPLOY_UBUNTU:=${DEPLOY_DEFAULT}}"
 
@@ -72,9 +71,6 @@ fi
 if [ "${DEPLOY_DEBIAN}" -gt 0 ]; then
   rake_tasks+=(apt:artifactory:release)
   apt_targets+=(debian)
-fi
-if [ "${DEPLOY_DOCS}" -gt 0 ]; then
-  rake_tasks+=(docs:release)
 fi
 if [ "${DEPLOY_R}" -gt 0 ]; then
   rake_tasks+=(r:release)

--- a/dev/release/post-10-docs.sh
+++ b/dev/release/post-10-docs.sh
@@ -22,9 +22,9 @@ set -u
 
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ARROW_DIR="${SOURCE_DIR}/../.."
-: ${ARROW_SITE_DIR:="${ARROW_DIR}/../arrow-site"}
+: "${ARROW_SITE_DIR:=${ARROW_DIR}/../arrow-site}"
 
-if [ "$#" -ne 2  ]; then
+if [ "$#" -ne 2 ]; then
   echo "Usage: $0 <version> <previous_version>"
   exit 1
 fi
@@ -35,35 +35,35 @@ release_tag="apache-arrow-${version}"
 branch_name=release-docs-${version}
 
 case "${version}" in
-  *.0.0)
-    is_major_release=yes
-    ;;
-  *)
-    is_major_release=no
-    ;;
+*.0.0)
+  is_major_release=yes
+  ;;
+*)
+  is_major_release=no
+  ;;
 esac
 
 pushd "${ARROW_SITE_DIR}"
 source "${SOURCE_DIR}/git-vars.sh"
-git fetch --all --prune --tags --force -j$(nproc)
+git fetch --all --prune --tags --force
 git checkout .
-git checkout ${DEFAULT_BRANCH}
+git checkout "${DEFAULT_BRANCH}"
 git clean -d -f -x
 git branch -D asf-site || :
 git checkout -b asf-site origin/asf-site
 git rebase apache/asf-site
-git branch -D ${branch_name} || :
-git checkout -b ${branch_name}
+git branch -D "${branch_name}" || :
+git checkout -b "${branch_name}"
 # list and remove previous versioned docs
 versioned_paths=()
 for versioned_path in docs/*.*/; do
-  versioned_paths+=(${versioned_path})
-  rm -rf ${versioned_path}
+  versioned_paths+=("${versioned_path}")
+  rm -rf "${versioned_path}"
 done
 # add to list and remove dev docs
 versioned_paths+=("docs/dev/")
 rm -rf docs/dev/
-if [ "$is_major_release" = "yes" ] ; then
+if [ "$is_major_release" = "yes" ]; then
   cp -r docs/ docs_temp/
 fi
 # delete current stable docs and restore all previous versioned docs
@@ -77,55 +77,55 @@ curl \
   --fail \
   --location \
   --remote-name \
-  https://apache.jfrog.io/artifactory/arrow/docs/${version}/docs.tar.gz
+  "https://github.com/apache/arrow/releases/download/${release_tag}/docs.tar.gz"
 tar xvf docs.tar.gz
 # Update DOCUMENTATION_OPTIONS.show_version_warning_banner
 find docs \
   -type f \
   -exec \
-    sed -i.bak \
-      -e "s/DOCUMENTATION_OPTIONS.show_version_warning_banner = true/DOCUMENTATION_OPTIONS.show_version_warning_banner = false/g" \
-      {} \;
+  sed -i.bak \
+  -e "s/DOCUMENTATION_OPTIONS.show_version_warning_banner = true/DOCUMENTATION_OPTIONS.show_version_warning_banner = false/g" \
+  {} \;
 find ./ -name '*.bak' -delete
 popd
 mv docs_new/docs/* docs/
 rm -rf docs_new
 
-if [ "$is_major_release" = "yes" ] ; then
+if [ "$is_major_release" = "yes" ]; then
   previous_series=${previous_version%.*}
-  mv docs_temp docs/${previous_series}
+  mv docs_temp "docs/${previous_series}"
 fi
 git add docs
 git commit -m "[Website] Update documentations for ${version}"
 
 # Update DOCUMENTATION_OPTIONS.theme_switcher_version_match and
 # DOCUMENTATION_OPTIONS.show_version_warning_banner
-if [ "$is_major_release" = "yes" ] ; then
-  pushd docs/${previous_series}
+if [ "$is_major_release" = "yes" ]; then
+  pushd "docs/${previous_series}"
   find ./ \
     -type f \
     -exec \
-      sed -i.bak \
-        -e "s/DOCUMENTATION_OPTIONS.theme_switcher_version_match = '';/DOCUMENTATION_OPTIONS.theme_switcher_version_match = '${previous_series}';/g" \
-        -e "s/DOCUMENTATION_OPTIONS.show_version_warning_banner = false/DOCUMENTATION_OPTIONS.show_version_warning_banner = true/g" \
-        {} \;
+    sed -i.bak \
+    -e "s/DOCUMENTATION_OPTIONS.theme_switcher_version_match = '';/DOCUMENTATION_OPTIONS.theme_switcher_version_match = '${previous_series}';/g" \
+    -e "s/DOCUMENTATION_OPTIONS.show_version_warning_banner = false/DOCUMENTATION_OPTIONS.show_version_warning_banner = true/g" \
+    {} \;
   find ./ -name '*.bak' -delete
   popd
-  git add docs/${previous_series}
+  git add "docs/${previous_series}"
   git commit -m "[Website] Update warning banner for ${previous_series}"
   git clean -d -f -x
   popd
 fi
 
-: ${PUSH:=1}
+: "${PUSH:=1}"
 
-if [ ${PUSH} -gt 0 ]; then
+if [ "${PUSH}" -gt 0 ]; then
   pushd "${ARROW_SITE_DIR}"
-  git push -u origin ${branch_name}
-  github_url=$(git remote get-url origin | \
-                 sed \
-                   -e 's,^git@github.com:,https://github.com/,' \
-                   -e 's,\.git$,,')
+  git push -u origin "${branch_name}"
+  github_url=$(git remote get-url origin |
+    sed \
+      -e 's,^git@github.com:,https://github.com/,' \
+      -e 's,\.git$,,')
   popd
 
   echo "Success!"


### PR DESCRIPTION
### Rationale for this change

We want to stop using apache.jfrog.io. See also: #40760

### What changes are included in this PR?

Upload generated docs to GitHub Release instead of apache.jfrog.io.

Our generated docs are only for publishing. We publish them to
https://arrow.apache.org/docs/ . So we don't need any migration path
for users.

### Are these changes tested?

No. I want to try this in the next release.

### Are there any user-facing changes?

No.
* GitHub Issue: #45961