### PR TITLE
MINOR: [Docs][MATLAB] update README failing example code snippets

### DIFF
--- a/matlab/doc/matlab_interface_for_apache_arrow_design.md
+++ b/matlab/doc/matlab_interface_for_apache_arrow_design.md
@@ -109,19 +109,7 @@ ans =
 
 To serialize MATLAB data to a file on disk (e.g. Feather, Parquet), a MATLAB developer could start by constructing an `arrow.Table` using one of several different approaches. 
 
-They could individually compose the table from a set of `arrow.Array` objects (one for each table variable). 
-
-###### Example Code: 
-``` matlab
->> Var1 = arrow.array(["foo"; "bar"; "baz"]); 
-
->> Var2 = arrow.array([today; today + 1; today + 2]); 
-
->> Var3 = arrow.array([10; 20; 30]); 
-
->> AT = arrow.Table(Var1, Var2, Var3); 
-```
-Alternatively, they could directly convert from an existing MATLAB `table` to an `arrow.Table` using a function like `arrow.matlab2arrow` to convert between an existing MATLAB `table` and an `arrow.Table`. 
+They could directly convert from an existing MATLAB `table` to an `arrow.Table` using a function like `arrow.table` to convert between an existing MATLAB `table` and an `arrow.Table`. 
 
 ###### Example Code: 
 ``` matlab
@@ -133,23 +121,26 @@ Alternatively, they could directly convert from an existing MATLAB `table` to an
 
 >> T = table(Weight, Radius, Density); % Create a MATLAB table 
 
->> AT = arrow.matlab2arrow(T); % Create an arrow.Table 
+>> AT = arrow.table(T); % Create an arrow.Table 
 ```
-To serialize the `arrow.Table`, `AT`, to a file (e.g. Feather) on disk, the user could then instantiate an `arrow.FeatherTableWriter`. 
+To serialize the `arrow.Table`, `AT`, to a file (e.g. Feather) on disk, the user could then instantiate an `arrow.internal.io.feather.Writer`. 
 
 ###### Example Code: 
 ``` matlab
->> featherTableWriter = arrow.FeatherTableWriter(); 
+>> recordBatchWrite = arrow.recordBatch(AT);
 
->> featherTableWriter.write(AT, "data.feather"); 
+>> filename = fullfile(pwd, "temp.feather");
+>> writer = arrow.internal.io.feather.Writer(filename);
+>> writer.write(recordBatchWrite);
 ```
-The Feather file could then be read and operated on by an external process like Rust or Go. To read it back into MATLAB after modification by another process, the user could instantiate an `arrow.FeatherTableReader`. 
+The Feather file could then be read and operated on by an external process like Rust or Go. To read it back into MATLAB after modification by another process, the user could instantiate an `arrow.internal.io.feather.Reader`. 
 
 ###### Example Code: 
 ``` matlab
->> featherTableReader = arrow.FeatherTableReader("data.feather"); 
+>> reader = arrow.internal.io.feather.Reader(filename);
+>> recordBatchRead = reader.read();
 
->> AT = featherTableReader.read(); 
+>> AT = table(recordBatchRead);
 ```
 #### Advanced MATLAB User Workflow for Implementing Support for Writing to Feather Files 
 

--- a/matlab/doc/matlab_interface_for_apache_arrow_design.md
+++ b/matlab/doc/matlab_interface_for_apache_arrow_design.md
@@ -109,7 +109,7 @@ ans =
 
 To serialize MATLAB data to a file on disk (e.g. Feather, Parquet), a MATLAB developer could start by constructing an `arrow.Table` using one of several different approaches. 
 
-They could directly convert from an existing MATLAB `table` to an `arrow.Table` using a function like `arrow.table`.
+They could directly convert from an existing MATLAB `table` to an `arrow.tabular.Table` using a function like `arrow.table`.
 
 ###### Example Code: 
 ``` matlab

--- a/matlab/doc/matlab_interface_for_apache_arrow_design.md
+++ b/matlab/doc/matlab_interface_for_apache_arrow_design.md
@@ -179,7 +179,7 @@ To share a MATLAB `arrow.Array` with PyArrow efficiently, a user could use the `
 
 Memory addresses for the `ArrowArray` and `ArrowSchema` structs are returned by the call to `export`. These addresses can be passed to Python directly, without having to make any copies of the underlying Arrow data structures that they refer to. A user can then wrap the underlying data pointed to by the `ArrowArray` struct (which is already in the [Arrow Columnar Format]), as well as extract the necessary metadata from the `ArrowSchema` struct, to create a `pyarrow.Array` by using the static method `pyarrow.Array._import_from_c`. 
 
-Multiple lines of Python are required to import the Arrow array from MATLAB. Therefore, the function [`pyrunfile`]((https://www.mathworks.com/help/matlab/ref/pyrunfile.html)) can be used when can run Python scripts defined in an external file.
+Multiple lines of Python are required to import the Arrow array from MATLAB. Therefore, the function [`pyrunfile`]((https://www.mathworks.com/help/matlab/ref/pyrunfile.html)) can be used which can run Python scripts defined in an external file.
 
 ###### Example Code: 
 

--- a/matlab/doc/matlab_interface_for_apache_arrow_design.md
+++ b/matlab/doc/matlab_interface_for_apache_arrow_design.md
@@ -109,7 +109,7 @@ ans =
 
 To serialize MATLAB data to a file on disk (e.g. Feather, Parquet), a MATLAB developer could start by constructing an `arrow.Table` using one of several different approaches. 
 
-They could directly convert from an existing MATLAB `table` to an `arrow.Table` using a function like `arrow.table` to convert between an existing MATLAB `table` and an `arrow.Table`. 
+They could directly convert from an existing MATLAB `table` to an `arrow.Table` using a function like `arrow.table`.
 
 ###### Example Code: 
 ``` matlab

--- a/matlab/doc/matlab_interface_for_apache_arrow_design.md
+++ b/matlab/doc/matlab_interface_for_apache_arrow_design.md
@@ -123,24 +123,34 @@ They could directly convert from an existing MATLAB `table` to an `arrow.Table` 
 
 >> AT = arrow.table(T); % Create an arrow.Table 
 ```
-To serialize the `arrow.Table`, `AT`, to a file (e.g. Feather) on disk, the user could then instantiate an `arrow.internal.io.feather.Writer`. 
+
+To serialize the `arrow.Table`, `AT`, to a file (e.g. Feather) on disk, the user could then instantiate an `arrow.io.ipc.RecordBatchFileWriter`. 
 
 ###### Example Code: 
 ``` matlab
->> recordBatchWrite = arrow.recordBatch(AT);
+% create a RecordBatch out of the table from the previous example
+>> recordBatch = arrow.recordBatch(AT);
+>> filename = fullfile(pwd, "data.arrow");
 
->> filename = fullfile(pwd, "temp.feather");
->> writer = arrow.internal.io.feather.Writer(filename);
->> writer.write(recordBatchWrite);
+% write the RecordBatch schema and the RecordBatch itself
+>> writer = arrow.io.ipc.RecordBatchFileWriter(filename, recordBatch.Schema);
+>> writer.writeRecordBatch(recordBatch);
+
+% close the writer to enable reading 
+>> writer.close();
 ```
-The Feather file could then be read and operated on by an external process like Rust or Go. To read it back into MATLAB after modification by another process, the user could instantiate an `arrow.internal.io.feather.Reader`. 
+The Feather file could then be read and operated on by an external process like Rust or Go. To read it back into MATLAB after modification by another process, the user could instantiate an `arrow.io.ipc.RecordBatchFileReader`. 
 
 ###### Example Code: 
 ``` matlab
->> reader = arrow.internal.io.feather.Reader(filename);
->> recordBatchRead = reader.read();
+% open record batch file reader
+>> reader = arrow.io.ipc.RecordBatchFileReader(filename);
 
->> AT = table(recordBatchRead);
+% read in the first RecordBatch
+>> newBatch = reader.read(1);
+
+% create a table that matches AT before it was written to data.arrow from the RecordBatch
+>> AT = table(newBatch);
 ```
 #### Advanced MATLAB User Workflow for Implementing Support for Writing to Feather Files 
 


### PR DESCRIPTION
### Rationale for this change

MATLAB currently has multiple "example code" sections in the readme `matlab/doc/matlab_interface_for_apache_arrow_design.md` that have either been deprecated or were retrieved from other languages where MATLAB does not have the same endpoints. Example code that works out of the box not only helps with early developers get started using arrow, but also helps experienced developers ensure their development setup is in proper condition.

The broken endpoints described include:

#### Use Case 2
1. `arrow.Table(Var1, Var2, Var3)`
	a. With the current implementation of arrow.Table, it cannot take multiple `arrow.array`s and create a table from that. All examples inside of `matlab/test/arrow/tabular/tTable.m` create a table by first creating a MATLAB table.
3. `arrow.FeatherTableWriter`
4. `arrow.FeatherTableReader`
5. `arrow.matlab2arrow`

#### Use Case 3
1. `importFromCDataInterface`
2. `ExportToCDataInterface`
3. `arrow.ipcwrite`
4. Python lines using `_import_from_c` or `_export_from_c`
	a. While these are functions inside of Python, MATLAB [has syntax that does not allow for underscores to begin variable or function names](https://www.mathworks.com/help/matlab/matlab_prog/variable-names.html). Therefore, running these in MATLAB using the Python in MATLAB module will result in errors.

### What changes are included in this PR?

I changed the use case README example code in use case 2 and use case 3 to use code that can be copy-and-pasted into MATLAB and work out of the box, rather than the current endpoints.

### Are these changes tested?

Yes. These changes have been tested by running each example piece of code inside of MATLAB inside of the changes and verifying that they work out of the box.

### Are there any user-facing changes?

No.