### PR TITLE
GH-45975: [Ruby] Add support for rubygems-requirements-system

### DIFF
--- a/ruby/red-arrow/README.md
+++ b/ruby/red-arrow/README.md
@@ -33,12 +33,20 @@ gobject-introspection gem is a Ruby bindings of GObject Introspection. Red Arrow
 
 ## Install
 
-Install Apache Arrow GLib before install Red Arrow. See [Apache Arrow install document](https://arrow.apache.org/install/) for details.
+You need to install Apache Arrow GLib to install Red Arrow. You can automate it by enabling [rubygems-requirements-system](https://github.com/ruby-gnome/rubygems-requirements-system/). If you want to install Apache Arrow GLib manually, see [Apache Arrow install document](https://arrow.apache.org/install/) for details.
 
-Install Red Arrow after you install Apache Arrow GLib:
+If you want to install Red Arrow by Bundler, you can add the followings to your `Gemfile`:
+
+```ruby
+plugin "rubygems-requirements-system"
+
+gem "red-arrow"
+```
+
+If you want to install Red Arrow by RubyGems, you can use the following command line:
 
 ```console
-% gem install red-arrow
+$ gem install rubygems-requirements-system red-arrow
 ```
 
 ## Usage

--- a/ruby/red-arrow/ext/arrow/extconf.rb
+++ b/ruby/red-arrow/ext/arrow/extconf.rb
@@ -38,32 +38,28 @@ checking_for(checking_message("Homebrew")) do
   end
 end
 
-unless required_pkg_config_package([
-                                     "arrow",
-                                     Arrow::Version::MAJOR,
-                                   ],
-                                   conda: "libarrow",
-                                   debian: "libarrow-dev",
-                                   fedora: "libarrow-devel",
-                                   homebrew: "apache-arrow",
-                                   msys2: "arrow",
-                                   redhat: "arrow-devel")
-  exit(false)
+unless PKGConfig.have_package("arrow", Arrow::Version::MAJOR)
+  raise <<-MESSAGE
+Apache Arrow C++ >= #{Arrow::Version::MAJOR} isn't found.
+You can install it automatically by enabling rubygems-requirements-system.
+See https://github.com/ruby-gnome/rubygems-requirements-system/ how to enable it.
+  MESSAGE
 end
 
-unless required_pkg_config_package([
-                                     "arrow-glib",
-                                     Arrow::Version::MAJOR,
-                                     Arrow::Version::MINOR,
-                                     Arrow::Version::MICRO,
-                                   ],
-                                   conda: "arrow-c-glib",
-                                   debian: "libarrow-glib-dev",
-                                   fedora: "libarrow-glib-devel",
-                                   homebrew: "apache-arrow-glib",
-                                   msys2: "arrow",
-                                   redhat: "arrow-glib-devel")
-  exit(false)
+unless PKGConfig.have_package("arrow-glib",
+                              Arrow::Version::MAJOR,
+                              Arrow::Version::MINOR,
+                              Arrow::Version::MICRO)
+  verison = [
+    Arrow::Version::MAJOR,
+    Arrow::Version::MINOR,
+    Arrow::Version::MICRO,
+  ].join(".")
+  raise <<-MESSAGE
+Apache Arrow GLib >= #{version} isn't found.
+You can install it automatically by enabling rubygems-requirements-system.
+See https://github.com/ruby-gnome/rubygems-requirements-system/ how to enable it.
+  MESSAGE
 end
 
 # Old re2.pc (e.g. re2.pc on Ubuntu 20.04) may add -std=c++11. It

--- a/ruby/red-arrow/red-arrow.gemspec
+++ b/ruby/red-arrow/red-arrow.gemspec
@@ -49,6 +49,8 @@ Gem::Specification.new do |spec|
   spec.files += Dir.glob("doc/text/*")
   spec.extensions = ["ext/arrow/extconf.rb"] unless is_jruby
 
+  required_arrow_glib_version = version_components[0, 3].join(".")
+
   spec.add_runtime_dependency("bigdecimal", ">= 3.1.0")
   spec.add_runtime_dependency("csv")
   if is_jruby
@@ -58,11 +60,60 @@ Gem::Specification.new do |spec|
   else
     spec.add_runtime_dependency("extpp", ">= 0.1.1")
     spec.add_runtime_dependency("gio2", ">= 4.2.3")
-    spec.add_runtime_dependency("native-package-installer")
     spec.add_runtime_dependency("pkg-config")
+
+    repository_url_prefix = "https://repo1.maven.org/maven2/org/apache/arrow"
+    [
+      # Try without additional repository
+      ["amazon_linux", "arrow-glib-devel"],
+      # Retry with additional repository
+      [
+        "amazon_linux",
+        "#{repository_url_prefix}/amazon-linux/%{version}/" +
+        "apache-arrow-release-latest.rpm",
+      ],
+      ["amazon_linux", "arrow-glib-devel"],
+
+      # Try without additional repository
+      ["centos", "arrow-glib-devel"],
+      # Retry with additional repository
+      [
+        "centos",
+        "#{repository_url_prefix}/centos/%{major_version}-stream/" +
+        "apache-arrow-release-latest.rpm",
+      ],
+      ["centos", "arrow-glib-devel"],
+
+      ["conda", "arrow-c-glib"],
+
+      # Try without additional repository
+      ["debian", "libarrow-glib-dev"],
+      # Retry with additional repository
+      [
+        "debian",
+        "#{repository_url_prefix}/%{distribution}/" +
+        "apache-arrow-apt-source-latest-%{code_name}.deb",
+      ],
+      ["debian", "libarrow-glib-dev"],
+
+      ["fedora", "libarrow-glib-devel"],
+
+      # Try without additional repository
+      ["rhel", "arrow-glib-devel"],
+      # Retry with additional repository
+      [
+        "rhel",
+        "#{repository_url_prefix}/almalinux/%{major_version}/" +
+        "apache-arrow-release-latest.rpm",
+      ],
+      ["rhel", "arrow-glib-devel"],
+    ].each do |platform, package|
+      spec.requirements <<
+        "system: arrow-glib>=#{required_arrow_glib_version}: " +
+        "#{platform}: #{package}"
+    end
   end
 
-  required_msys2_package_version = version_components[0, 3].join(".")
   spec.metadata["msys2_mingw_dependencies"] =
-    "arrow>=#{required_msys2_package_version}"
+    "arrow>=#{required_arrow_glib_version}"
 end


### PR DESCRIPTION
### Rationale for this change

Currently, we use native-package-installer to install Apache Arrow C++ and GLib automatically. But it lacks a feature that enabling third party APT/Yum repositories. Our packages are distributed from our APT/Yum repositories. So native-package-installer can't install our packages automatically without enabling our APT/Yum repositories manually.

We can solve this by using rubygems-requirements-system instead of native-package-installer. native-package-installer has the feature.

### What changes are included in this PR?

Use rubygems-requirements-system instead of native-package-installer.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #45975