### PR TITLE
GH-45875: [Python] Make pa.array(..., safe=False) behave like .cast(..., safe=False)

### DIFF
--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -26,7 +26,7 @@ cdef extern from "<variant>" namespace "std":
     T get[T](...)
 
 cdef _sequence_to_array(object sequence, object mask, object size,
-                        DataType type, CMemoryPool* pool, c_bool from_pandas):
+                        DataType type, CMemoryPool* pool, c_bool from_pandas, bint safe=True):
     cdef:
         int64_t c_size
         PyConversionOptions options
@@ -40,7 +40,6 @@ cdef _sequence_to_array(object sequence, object mask, object size,
 
     options.from_pandas = from_pandas
     options.ignore_timezone = os.environ.get('PYARROW_IGNORE_TIMEZONE', False)
-
     with nogil:
         chunked = GetResultValue(
             ConvertPySequence(sequence, mask, options, pool)
@@ -365,14 +364,24 @@ def array(object obj, type=None, mask=None, size=None, from_pandas=None,
                 result = _ndarray_to_array(values, mask, type, c_from_pandas, safe,
                                            pool)
     else:
-        if type and type.id == _Type_RUN_END_ENCODED:
-            arr = _sequence_to_array(
-                obj, mask, size, type.value_type, pool, from_pandas)
-            result = _pc().run_end_encode(arr, run_end_type=type.run_end_type,
-                                          memory_pool=memory_pool)
-        # ConvertPySequence does strict conversion if type is explicitly passed
-        else:
-            result = _sequence_to_array(obj, mask, size, type, pool, c_from_pandas)
+        try:
+            if type and type.id == _Type_RUN_END_ENCODED:
+                arr = _sequence_to_array(
+                    obj, mask, size, type.value_type, pool, from_pandas, safe)
+                result = _pc().run_end_encode(arr, run_end_type=type.run_end_type,
+                                              memory_pool=memory_pool)
+            else:
+                # Try regular construction first (strict)
+                result = _sequence_to_array(obj, mask, size, type, pool, c_from_pandas, safe)
+        except ArrowInvalid as e:
+            if type is not None and not safe:
+                # Retry without type, then cast with safe=False
+                temp_result = array(obj, mask=mask, size=size,
+                                    from_pandas=from_pandas,
+                                    memory_pool=memory_pool)
+                return temp_result.cast(type, safe=False, memory_pool=memory_pool)
+            else:
+                raise e
 
     if extension_type is not None:
         result = ExtensionArray.from_storage(extension_type, result)


### PR DESCRIPTION
### Rationale for this change
This PR fixes a behavioral inconsistency when creating arrays using `pa.array(..., safe=False)` with values that exceed the exact representable range of the target type. Previously, this would raise an error, even though the `safe=False` flag should have allowed lossy rounding—just like `Array.cast(..., safe=False)` does.

Closes #45875 

### What changes are included in this PR?
This patch modifies the `array()` function so that the `safe` argument is properly propagated through the internal `_sequence_to_array()` conversion logic. Now, both direct array creation and casting behave consistently when `safe=False` is passed.

### Are these changes tested?
The change has been manually tested in a development build of PyArrow to confirm that:
```python
pa.array([99999999]).cast(pa.float32(), safe=False)       # Works
pa.array([99999999], pa.float32(), safe=False)            # Now also works (previously errored)
```

### Are there any user-facing changes?
Yes — this bugfix allows pa.array(..., safe=False) to behave consistently with .cast(..., safe=False) in lossy float conversions. This fixes unexpected errors and better aligns with the documented behavior of the safe parameter.
* GitHub Issue: #45875