### PR TITLE
MINOR: [C++][Docs] Fix doxygen issue in ree_util.h

### DIFF
--- a/cpp/src/arrow/util/ree_util.h
+++ b/cpp/src/arrow/util/ree_util.h
@@ -392,15 +392,17 @@ class RunEndEncodedArraySpan {
   /// \warning Avoid calling end() in a loop, as it will recompute the physical
   /// length of the array on each call (O(log N) cost per call).
   ///
-  /// \par You can write your loops like this instead:
+  /// You can write your loops like this instead:
+  ///
   /// \code
   /// for (auto it = array.begin(), end = array.end(); it != end; ++it) {
   ///   // ...
   /// }
   /// \endcode
   ///
-  /// \par Or this version that does not look like idiomatic C++, but removes
+  /// Or this version that does not look like idiomatic C++, but removes
   /// the need for calling end() completely:
+  ///
   /// \code
   /// for (auto it = array.begin(); !it.is_end(array); ++it) {
   ///   // ...


### PR DESCRIPTION
### Rationale for this change

clang 19.1.0 or higher now warns (or errors under `-Wdocumentation`) about improper use of the `\par` directive and we have one such instance in our docs in https://github.com/apache/arrow/blob/main/cpp/src/arrow/util/ree_util.h#L395.

See https://godbolt.org/z/61Wh5bEs9.

### What changes are included in this PR?

Fixed docstring so it reads and renders as the original author likely intended.

### Are these changes tested?

Yes. The code in question isn't currently included in any or our rendered documentation so we can't do a preview here in the PR but I have tested this locally.

### Are there any user-facing changes?

No.
