### PR TITLE
GH-46011: [C++] Hide DCHECK family from public headers

### DIFF
--- a/cpp/examples/arrow/rapidjson_row_converter.cc
+++ b/cpp/examples/arrow/rapidjson_row_converter.cc
@@ -516,7 +516,7 @@ arrow::Result<std::shared_ptr<arrow::RecordBatch>> ConvertToRecordBatch(
   ARROW_ASSIGN_OR_RAISE(batch, batch_builder->Flush());
 
   // Use RecordBatch::ValidateFull() to make sure arrays were correctly constructed.
-  DCHECK_OK(batch->ValidateFull());
+  ARROW_RETURN_NOT_OK(batch->ValidateFull());
   return batch;
 }  // ConvertToRecordBatch
 

--- a/cpp/examples/parquet/low_level_api/encryption_reader_writer.cc
+++ b/cpp/examples/parquet/low_level_api/encryption_reader_writer.cc
@@ -189,7 +189,7 @@ int main(int argc, char** argv) {
     file_writer->Close();
 
     // Write the bytes to file
-    DCHECK(out_file->Close().ok());
+    ARROW_DCHECK(out_file->Close().ok());
   } catch (const std::exception& e) {
     std::cerr << "Parquet write error: " << e.what() << std::endl;
     return -1;

--- a/cpp/examples/parquet/low_level_api/encryption_reader_writer_all_crypto_options.cc
+++ b/cpp/examples/parquet/low_level_api/encryption_reader_writer_all_crypto_options.cc
@@ -342,7 +342,7 @@ void InteropTestWriteEncryptedParquetFiles(std::string root_path) {
       file_writer->Close();
 
       // Write the bytes to file
-      DCHECK(out_file->Close().ok());
+      ARROW_DCHECK(out_file->Close().ok());
     } catch (const std::exception& e) {
       std::cerr << "Parquet write error: " << e.what() << std::endl;
       return;

--- a/cpp/examples/parquet/low_level_api/reader_writer.cc
+++ b/cpp/examples/parquet/low_level_api/reader_writer.cc
@@ -166,7 +166,7 @@ int main(int argc, char** argv) {
     file_writer->Close();
 
     // Write the bytes to file
-    DCHECK(out_file->Close().ok());
+    ARROW_DCHECK(out_file->Close().ok());
   } catch (const std::exception& e) {
     std::cerr << "Parquet write error: " << e.what() << std::endl;
     return -1;

--- a/cpp/examples/parquet/low_level_api/reader_writer2.cc
+++ b/cpp/examples/parquet/low_level_api/reader_writer2.cc
@@ -187,7 +187,7 @@ int main(int argc, char** argv) {
     file_writer->Close();
 
     // Write the bytes to file
-    DCHECK(out_file->Close().ok());
+    ARROW_DCHECK(out_file->Close().ok());
   } catch (const std::exception& e) {
     std::cerr << "Parquet write error: " << e.what() << std::endl;
     return -1;

--- a/cpp/src/arrow/acero/accumulation_queue.cc
+++ b/cpp/src/arrow/acero/accumulation_queue.cc
@@ -23,7 +23,7 @@
 #include <vector>
 
 #include "arrow/compute/exec.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 namespace acero {

--- a/cpp/src/arrow/acero/aggregate_benchmark.cc
+++ b/cpp/src/arrow/acero/aggregate_benchmark.cc
@@ -35,6 +35,7 @@
 #include "arrow/util/bit_util.h"
 #include "arrow/util/bitmap_reader.h"
 #include "arrow/util/byte_size.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/string.h"
 
 namespace arrow {

--- a/cpp/src/arrow/acero/aggregate_internal.cc
+++ b/cpp/src/arrow/acero/aggregate_internal.cc
@@ -31,7 +31,7 @@
 #include "arrow/datum.h"
 #include "arrow/result.h"
 #include "arrow/util/checked_cast.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 

--- a/cpp/src/arrow/acero/asof_join_node.cc
+++ b/cpp/src/arrow/acero/asof_join_node.cc
@@ -56,6 +56,7 @@
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/config.h"
 #include "arrow/util/future.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/string.h"
 
 namespace arrow {

--- a/cpp/src/arrow/acero/asof_join_node_test.cc
+++ b/cpp/src/arrow/acero/asof_join_node_test.cc
@@ -48,6 +48,7 @@
 #include "arrow/testing/matchers.h"
 #include "arrow/testing/random.h"
 #include "arrow/util/checked_cast.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/thread_pool.h"
 
 #define TRACED_TEST(t_class, t_name, t_body)  \

--- a/cpp/src/arrow/acero/exec_plan.cc
+++ b/cpp/src/arrow/acero/exec_plan.cc
@@ -38,7 +38,7 @@
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/io_util.h"
 #include "arrow/util/key_value_metadata.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/string.h"
 #include "arrow/util/tracing_internal.h"
 #include "arrow/util/vector.h"

--- a/cpp/src/arrow/acero/fetch_node.cc
+++ b/cpp/src/arrow/acero/fetch_node.cc
@@ -30,7 +30,7 @@
 #include "arrow/result.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/future.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/tracing_internal.h"
 
 namespace arrow {

--- a/cpp/src/arrow/acero/filter_node.cc
+++ b/cpp/src/arrow/acero/filter_node.cc
@@ -26,7 +26,7 @@
 #include "arrow/result.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/future.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/tracing_internal.h"
 
 namespace arrow {

--- a/cpp/src/arrow/acero/groupby_aggregate_node.cc
+++ b/cpp/src/arrow/acero/groupby_aggregate_node.cc
@@ -34,7 +34,7 @@
 #include "arrow/datum.h"
 #include "arrow/result.h"
 #include "arrow/util/checked_cast.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/thread_pool.h"
 #include "arrow/util/tracing_internal.h"
 

--- a/cpp/src/arrow/acero/hash_join.cc
+++ b/cpp/src/arrow/acero/hash_join.cc
@@ -29,6 +29,7 @@
 #include "arrow/acero/task_util.h"
 #include "arrow/compute/row/encode_internal.h"
 #include "arrow/compute/row/row_encoder_internal.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/tracing_internal.h"
 
 namespace arrow {

--- a/cpp/src/arrow/acero/hash_join_benchmark.cc
+++ b/cpp/src/arrow/acero/hash_join_benchmark.cc
@@ -26,6 +26,7 @@
 #include "arrow/api.h"
 #include "arrow/compute/row/row_encoder_internal.h"
 #include "arrow/testing/random.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/thread_pool.h"
 
 #include <cstdint>

--- a/cpp/src/arrow/acero/hash_join_dict.cc
+++ b/cpp/src/arrow/acero/hash_join_dict.cc
@@ -26,6 +26,7 @@
 #include "arrow/buffer.h"
 #include "arrow/util/bit_util.h"
 #include "arrow/util/checked_cast.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 

--- a/cpp/src/arrow/acero/hash_join_node.cc
+++ b/cpp/src/arrow/acero/hash_join_node.cc
@@ -30,6 +30,7 @@
 #include "arrow/compute/key_hash_internal.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/future.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/thread_pool.h"
 #include "arrow/util/tracing_internal.h"
 

--- a/cpp/src/arrow/acero/map_node.cc
+++ b/cpp/src/arrow/acero/map_node.cc
@@ -27,7 +27,7 @@
 #include "arrow/compute/expression.h"
 #include "arrow/result.h"
 #include "arrow/status.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/tracing_internal.h"
 
 namespace arrow {

--- a/cpp/src/arrow/acero/order_by_node.cc
+++ b/cpp/src/arrow/acero/order_by_node.cc
@@ -29,6 +29,7 @@
 #include "arrow/result.h"
 #include "arrow/table.h"
 #include "arrow/util/checked_cast.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/tracing_internal.h"
 
 namespace arrow {

--- a/cpp/src/arrow/acero/pivot_longer_node.cc
+++ b/cpp/src/arrow/acero/pivot_longer_node.cc
@@ -28,6 +28,7 @@
 #include "arrow/status.h"
 #include "arrow/type.h"
 #include "arrow/util/checked_cast.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/tracing_internal.h"
 

--- a/cpp/src/arrow/acero/project_node.cc
+++ b/cpp/src/arrow/acero/project_node.cc
@@ -29,7 +29,7 @@
 #include "arrow/result.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/future.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/tracing_internal.h"
 
 namespace arrow {

--- a/cpp/src/arrow/acero/scalar_aggregate_node.cc
+++ b/cpp/src/arrow/acero/scalar_aggregate_node.cc
@@ -31,7 +31,7 @@
 #include "arrow/datum.h"
 #include "arrow/result.h"
 #include "arrow/util/checked_cast.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/thread_pool.h"
 #include "arrow/util/tracing_internal.h"
 

--- a/cpp/src/arrow/acero/sink_node.cc
+++ b/cpp/src/arrow/acero/sink_node.cc
@@ -38,7 +38,7 @@
 #include "arrow/util/async_util.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/future.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/thread_pool.h"
 #include "arrow/util/tracing_internal.h"
 #include "arrow/util/unreachable.h"

--- a/cpp/src/arrow/acero/sorted_merge_node.cc
+++ b/cpp/src/arrow/acero/sorted_merge_node.cc
@@ -33,7 +33,7 @@
 #include "arrow/array/builder_base.h"
 #include "arrow/result.h"
 #include "arrow/type_fwd.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 namespace {
 template <typename Callable>

--- a/cpp/src/arrow/acero/source_node.cc
+++ b/cpp/src/arrow/acero/source_node.cc
@@ -36,7 +36,7 @@
 #include "arrow/util/async_util.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/future.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/thread_pool.h"
 #include "arrow/util/tracing_internal.h"
 #include "arrow/util/unreachable.h"

--- a/cpp/src/arrow/acero/swiss_join.cc
+++ b/cpp/src/arrow/acero/swiss_join.cc
@@ -30,6 +30,7 @@
 #include "arrow/compute/row/row_encoder_internal.h"
 #include "arrow/util/bit_util.h"
 #include "arrow/util/bitmap_ops.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/tracing_internal.h"
 
 namespace arrow {

--- a/cpp/src/arrow/acero/swiss_join_avx2.cc
+++ b/cpp/src/arrow/acero/swiss_join_avx2.cc
@@ -18,6 +18,7 @@
 #include "arrow/acero/swiss_join_internal.h"
 #include "arrow/compute/row/row_util_avx2_internal.h"
 #include "arrow/util/bit_util.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/simd.h"
 
 namespace arrow {

--- a/cpp/src/arrow/acero/task_util.cc
+++ b/cpp/src/arrow/acero/task_util.cc
@@ -21,7 +21,7 @@
 #include <mutex>
 
 #include "arrow/util/config.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 namespace acero {

--- a/cpp/src/arrow/acero/test_nodes.cc
+++ b/cpp/src/arrow/acero/test_nodes.cc
@@ -31,6 +31,7 @@
 #include "arrow/testing/random.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/iterator.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/tracing_internal.h"
 
 namespace arrow {

--- a/cpp/src/arrow/acero/time_series_util.cc
+++ b/cpp/src/arrow/acero/time_series_util.cc
@@ -18,7 +18,7 @@
 #include "arrow/array/data.h"
 
 #include "arrow/acero/time_series_util.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow::acero {
 

--- a/cpp/src/arrow/acero/union_node.cc
+++ b/cpp/src/arrow/acero/union_node.cc
@@ -24,7 +24,7 @@
 #include "arrow/util/bitmap_ops.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/future.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/string.h"
 #include "arrow/util/thread_pool.h"
 #include "arrow/util/tracing_internal.h"

--- a/cpp/src/arrow/acero/unmaterialized_table_internal.h
+++ b/cpp/src/arrow/acero/unmaterialized_table_internal.h
@@ -76,7 +76,7 @@ class UnmaterializedCompositeTable {
     if (Empty()) {
       return std::nullopt;
     }
-    DCHECK_LE(Size(), (uint64_t)std::numeric_limits<int64_t>::max());
+    ARROW_DCHECK_LE(Size(), (uint64_t)std::numeric_limits<int64_t>::max());
     std::vector<std::shared_ptr<arrow::Array>> arrays(schema->num_fields());
 
 #define MATERIALIZE_CASE(id)                                                          \
@@ -248,8 +248,9 @@ class UnmaterializedSliceBuilder {
     }
     if (slice.num_components) {
       size_t last_index = slice.num_components - 1;
-      DCHECK_EQ(slice.components[last_index].end - slice.components[last_index].start,
-                end - start)
+      ARROW_DCHECK_EQ(
+          slice.components[last_index].end - slice.components[last_index].start,
+          end - start)
           << "Slices should be the same length. ";
     }
     slice.components[slice.num_components++] = CompositeEntry{rb.get(), start, end};

--- a/cpp/src/arrow/acero/util.cc
+++ b/cpp/src/arrow/acero/util.cc
@@ -21,6 +21,7 @@
 #include "arrow/table.h"
 #include "arrow/util/bit_util.h"
 #include "arrow/util/bitmap_ops.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/tracing_internal.h"
 #include "arrow/util/ubsan.h"
 

--- a/cpp/src/arrow/array/array_dict.cc
+++ b/cpp/src/arrow/array/array_dict.cc
@@ -40,7 +40,7 @@
 #include "arrow/util/bitmap_ops.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/int_util.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/visit_type_inline.h"
 
 namespace arrow {

--- a/cpp/src/arrow/array/array_nested.cc
+++ b/cpp/src/arrow/array/array_nested.cc
@@ -41,7 +41,7 @@
 #include "arrow/util/bitmap_ops.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/list_util.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/unreachable.h"
 
 namespace arrow {

--- a/cpp/src/arrow/array/array_primitive.cc
+++ b/cpp/src/arrow/array/array_primitive.cc
@@ -24,7 +24,7 @@
 #include "arrow/type.h"
 #include "arrow/util/bit_block_counter.h"
 #include "arrow/util/bitmap_ops.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 

--- a/cpp/src/arrow/array/array_run_end.cc
+++ b/cpp/src/arrow/array/array_run_end.cc
@@ -18,7 +18,7 @@
 #include "arrow/array/array_run_end.h"
 #include "arrow/array/builder_primitive.h"
 #include "arrow/array/util.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/ree_util.h"
 
 namespace arrow {

--- a/cpp/src/arrow/array/array_view_test.cc
+++ b/cpp/src/arrow/array/array_view_test.cc
@@ -30,7 +30,7 @@
 #include "arrow/testing/gtest_util.h"
 #include "arrow/type.h"
 #include "arrow/util/endian.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 

--- a/cpp/src/arrow/array/builder_adaptive.cc
+++ b/cpp/src/arrow/array/builder_adaptive.cc
@@ -27,7 +27,7 @@
 #include "arrow/status.h"
 #include "arrow/type.h"
 #include "arrow/util/int_util.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 

--- a/cpp/src/arrow/array/builder_base.cc
+++ b/cpp/src/arrow/array/builder_base.cc
@@ -29,7 +29,7 @@
 #include "arrow/builder.h"
 #include "arrow/scalar.h"
 #include "arrow/status.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/visit_type_inline.h"
 
 namespace arrow {

--- a/cpp/src/arrow/array/builder_binary.cc
+++ b/cpp/src/arrow/array/builder_binary.cc
@@ -34,7 +34,7 @@
 #include "arrow/util/bit_util.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/decimal.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/visit_data_inline.h"
 
 namespace arrow {

--- a/cpp/src/arrow/array/builder_dict.cc
+++ b/cpp/src/arrow/array/builder_dict.cc
@@ -26,7 +26,7 @@
 #include "arrow/type_traits.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/hashing.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/visit_type_inline.h"
 
 namespace arrow {

--- a/cpp/src/arrow/array/builder_nested.cc
+++ b/cpp/src/arrow/array/builder_nested.cc
@@ -26,7 +26,7 @@
 #include "arrow/status.h"
 #include "arrow/type.h"
 #include "arrow/util/checked_cast.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 

--- a/cpp/src/arrow/array/builder_primitive.cc
+++ b/cpp/src/arrow/array/builder_primitive.cc
@@ -31,7 +31,7 @@
 #include "arrow/type_traits.h"
 #include "arrow/util/bit_util.h"
 #include "arrow/util/int_util.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 

--- a/cpp/src/arrow/array/builder_run_end.cc
+++ b/cpp/src/arrow/array/builder_run_end.cc
@@ -26,7 +26,7 @@
 #include "arrow/scalar.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/int_util_overflow.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/ree_util.h"
 
 namespace arrow {

--- a/cpp/src/arrow/array/builder_union.cc
+++ b/cpp/src/arrow/array/builder_union.cc
@@ -22,7 +22,7 @@
 
 #include "arrow/buffer.h"
 #include "arrow/util/checked_cast.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 

--- a/cpp/src/arrow/array/concatenate.cc
+++ b/cpp/src/arrow/array/concatenate.cc
@@ -43,7 +43,7 @@
 #include "arrow/util/int_util.h"
 #include "arrow/util/int_util_overflow.h"
 #include "arrow/util/list_util.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/ree_util.h"
 #include "arrow/util/slice_util_internal.h"
 #include "arrow/visit_data_inline.h"

--- a/cpp/src/arrow/array/data.cc
+++ b/cpp/src/arrow/array/data.cc
@@ -35,7 +35,7 @@
 #include "arrow/util/binary_view_util.h"
 #include "arrow/util/bitmap_ops.h"
 #include "arrow/util/dict_util.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/range.h"
 #include "arrow/util/ree_util.h"

--- a/cpp/src/arrow/array/dict_internal.h
+++ b/cpp/src/arrow/array/dict_internal.h
@@ -161,7 +161,7 @@ struct DictionaryTraits<T, enable_if_binary_view_like<T>> {
   static Result<std::shared_ptr<ArrayData>> GetDictionaryArrayData(
       MemoryPool* pool, const std::shared_ptr<DataType>& type,
       const MemoTableType& memo_table, int64_t start_offset) {
-    DCHECK(type->id() == Type::STRING_VIEW || type->id() == Type::BINARY_VIEW);
+    ARROW_DCHECK(type->id() == Type::STRING_VIEW || type->id() == Type::BINARY_VIEW);
 
     BinaryViewBuilder builder(pool);
     RETURN_NOT_OK(builder.Resize(memo_table.size() - start_offset));

--- a/cpp/src/arrow/array/diff.cc
+++ b/cpp/src/arrow/array/diff.cc
@@ -43,7 +43,7 @@
 #include "arrow/type_traits.h"
 #include "arrow/util/bit_util.h"
 #include "arrow/util/checked_cast.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/range.h"
 #include "arrow/util/ree_util.h"
 #include "arrow/util/string.h"

--- a/cpp/src/arrow/array/util.cc
+++ b/cpp/src/arrow/array/util.cc
@@ -42,7 +42,7 @@
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/decimal.h"
 #include "arrow/util/endian.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/sort.h"
 #include "arrow/util/span.h"
 #include "arrow/visit_data_inline.h"

--- a/cpp/src/arrow/array/validate.cc
+++ b/cpp/src/arrow/array/validate.cc
@@ -28,7 +28,7 @@
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/decimal.h"
 #include "arrow/util/int_util_overflow.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/ree_util.h"
 #include "arrow/util/sort.h"
 #include "arrow/util/string.h"

--- a/cpp/src/arrow/buffer.cc
+++ b/cpp/src/arrow/buffer.cc
@@ -25,7 +25,7 @@
 #include "arrow/result.h"
 #include "arrow/status.h"
 #include "arrow/util/bit_util.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/slice_util_internal.h"
 #include "arrow/util/string.h"
 

--- a/cpp/src/arrow/builder.cc
+++ b/cpp/src/arrow/builder.cc
@@ -26,6 +26,7 @@
 #include "arrow/type.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/hashing.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/visit_type_inline.h"
 
 namespace arrow {

--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -45,7 +45,7 @@
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/future.h"
 #include "arrow/util/key_value_metadata.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/range.h"
 #include "arrow/util/small_vector.h"

--- a/cpp/src/arrow/c/bridge_test.cc
+++ b/cpp/src/arrow/c/bridge_test.cc
@@ -43,7 +43,7 @@
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/endian.h"
 #include "arrow/util/key_value_metadata.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/range.h"
 #include "arrow/util/thread_pool.h"

--- a/cpp/src/arrow/chunked_array.cc
+++ b/cpp/src/arrow/chunked_array.cc
@@ -33,7 +33,7 @@
 #include "arrow/type.h"
 #include "arrow/type_traits.h"
 #include "arrow/util/checked_cast.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 

--- a/cpp/src/arrow/compare.cc
+++ b/cpp/src/arrow/compare.cc
@@ -46,7 +46,7 @@
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/float16.h"
 #include "arrow/util/key_value_metadata.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/memory.h"
 #include "arrow/util/ree_util.h"

--- a/cpp/src/arrow/compute/api_aggregate.cc
+++ b/cpp/src/arrow/compute/api_aggregate.cc
@@ -21,7 +21,7 @@
 #include "arrow/compute/function_internal.h"
 #include "arrow/compute/registry.h"
 #include "arrow/util/checked_cast.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 namespace internal {

--- a/cpp/src/arrow/compute/api_scalar.cc
+++ b/cpp/src/arrow/compute/api_scalar.cc
@@ -29,7 +29,7 @@
 #include "arrow/status.h"
 #include "arrow/type.h"
 #include "arrow/util/checked_cast.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 

--- a/cpp/src/arrow/compute/api_vector.cc
+++ b/cpp/src/arrow/compute/api_vector.cc
@@ -34,7 +34,7 @@
 #include "arrow/record_batch.h"
 #include "arrow/result.h"
 #include "arrow/util/checked_cast.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/reflection_internal.h"
 
 namespace arrow {

--- a/cpp/src/arrow/compute/cast.cc
+++ b/cpp/src/arrow/compute/cast.cc
@@ -31,7 +31,7 @@
 #include "arrow/compute/kernel.h"
 #include "arrow/compute/kernels/codegen_internal.h"
 #include "arrow/compute/registry.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/reflection_internal.h"
 
 namespace arrow {

--- a/cpp/src/arrow/compute/exec.cc
+++ b/cpp/src/arrow/compute/exec.cc
@@ -47,7 +47,7 @@
 #include "arrow/util/bitmap_ops.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/cpu_info.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/thread_pool.h"
 #include "arrow/util/vector.h"
 

--- a/cpp/src/arrow/compute/exec_test.cc
+++ b/cpp/src/arrow/compute/exec_test.cc
@@ -44,7 +44,7 @@
 #include "arrow/util/bitmap_ops.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/cpu_info.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 

--- a/cpp/src/arrow/compute/expression.cc
+++ b/cpp/src/arrow/compute/expression.cc
@@ -38,7 +38,7 @@
 #endif
 #include "arrow/util/hash_util.h"
 #include "arrow/util/key_value_metadata.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/string.h"
 #include "arrow/util/value_parsing.h"
 #include "arrow/util/vector.h"

--- a/cpp/src/arrow/compute/expression_internal.h
+++ b/cpp/src/arrow/compute/expression_internal.h
@@ -40,14 +40,14 @@ struct KnownFieldValues {
 
 inline const Expression::Call* CallNotNull(const Expression& expr) {
   auto call = expr.call();
-  DCHECK_NE(call, nullptr);
+  ARROW_DCHECK_NE(call, nullptr);
   return call;
 }
 
 inline std::vector<TypeHolder> GetTypes(const std::vector<Expression>& exprs) {
   std::vector<TypeHolder> types(exprs.size());
   for (size_t i = 0; i < exprs.size(); ++i) {
-    DCHECK(exprs[i].IsBound());
+    ARROW_DCHECK(exprs[i].IsBound());
     types[i] = exprs[i].type();
   }
   return types;
@@ -164,7 +164,7 @@ struct Comparison {
       case GREATER_EQUAL:
         return LESS_EQUAL;
     }
-    DCHECK(false);
+    ARROW_DCHECK(false);
     return NA;
   }
 
@@ -191,7 +191,7 @@ struct Comparison {
   static std::string GetOp(type op) {
     switch (op) {
       case NA:
-        DCHECK(false) << "unreachable";
+        ARROW_DCHECK(false) << "unreachable";
         break;
       case EQUAL:
         return "==";
@@ -206,7 +206,7 @@ struct Comparison {
       case GREATER_EQUAL:
         return ">=";
     }
-    DCHECK(false);
+    ARROW_DCHECK(false);
     return "";
   }
 };
@@ -270,7 +270,7 @@ struct FlattenedAssociativeChain {
       // NB: no increment so we hit sub_call's first argument next iteration
     }
 
-    DCHECK(std::all_of(exprs.begin(), exprs.end(), [](const Expression& expr) {
+    ARROW_DCHECK(std::all_of(exprs.begin(), exprs.end(), [](const Expression& expr) {
       return CallNotNull(expr)->options == nullptr;
     }));
   }

--- a/cpp/src/arrow/compute/function.cc
+++ b/cpp/src/arrow/compute/function.cc
@@ -32,7 +32,7 @@
 #include "arrow/datum.h"
 #include "arrow/device_allocation_type_set.h"
 #include "arrow/util/cpu_info.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/tracing_internal.h"
 
 namespace arrow {

--- a/cpp/src/arrow/compute/kernel.cc
+++ b/cpp/src/arrow/compute/kernel.cc
@@ -30,7 +30,7 @@
 #include "arrow/util/bit_util.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/hash_util.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/macros.h"
 
 namespace arrow {

--- a/cpp/src/arrow/compute/kernels/aggregate_internal.h
+++ b/cpp/src/arrow/compute/kernels/aggregate_internal.h
@@ -25,7 +25,7 @@
 #include "arrow/type_traits.h"
 #include "arrow/util/bit_run_reader.h"
 #include "arrow/util/int128_internal.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow::compute::internal {
 

--- a/cpp/src/arrow/compute/kernels/aggregate_pivot.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_pivot.cc
@@ -21,7 +21,7 @@
 #include "arrow/compute/kernels/pivot_internal.h"
 #include "arrow/scalar.h"
 #include "arrow/util/bit_run_reader.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/visit_data_inline.h"
 
 namespace arrow::compute::internal {

--- a/cpp/src/arrow/compute/kernels/aggregate_quantile.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_quantile.cc
@@ -23,6 +23,7 @@
 #include "arrow/compute/kernels/common_internal.h"
 #include "arrow/compute/kernels/util_internal.h"
 #include "arrow/stl_allocator.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 namespace compute {

--- a/cpp/src/arrow/compute/kernels/base_arithmetic_internal.h
+++ b/cpp/src/arrow/compute/kernels/base_arithmetic_internal.h
@@ -505,8 +505,8 @@ struct NegateChecked {
   static enable_if_unsigned_integer_value<Arg, T> Call(KernelContext* ctx, Arg arg,
                                                        Status* st) {
     static_assert(std::is_same<T, Arg>::value, "");
-    DCHECK(false) << "This is included only for the purposes of instantiability from the "
-                     "arithmetic kernel generator";
+    ARROW_DCHECK(false) << "This is included only for the purposes of instantiability "
+                           "from the arithmetic kernel generator";
     return 0;
   }
 

--- a/cpp/src/arrow/compute/kernels/chunked_internal.cc
+++ b/cpp/src/arrow/compute/kernels/chunked_internal.cc
@@ -20,7 +20,7 @@
 #include <algorithm>
 
 #include "arrow/record_batch.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow::compute::internal {
 

--- a/cpp/src/arrow/compute/kernels/codegen_internal.cc
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.cc
@@ -25,6 +25,7 @@
 
 #include "arrow/compute/api_vector.h"
 #include "arrow/type_fwd.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 namespace compute {

--- a/cpp/src/arrow/compute/kernels/codegen_internal.h
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.h
@@ -376,7 +376,7 @@ struct UnboxScalar<Type, enable_if_has_c_type<Type>> {
   static T Unbox(const Scalar& val) {
     std::string_view view =
         checked_cast<const ::arrow::internal::PrimitiveScalarBase&>(val).view();
-    DCHECK_EQ(view.size(), sizeof(T));
+    ARROW_DCHECK_EQ(view.size(), sizeof(T));
     return *reinterpret_cast<const T*>(view.data());
   }
 };
@@ -532,7 +532,7 @@ static Status SimpleBinary(KernelContext* ctx, const ExecSpan& batch, ExecResult
     if (batch[1].is_array()) {
       return Operator::Call(ctx, *batch[0].scalar, batch[1].array, out);
     } else {
-      DCHECK(false);
+      ARROW_DCHECK(false);
       return Status::Invalid("Should be unreachable");
     }
   }
@@ -602,7 +602,7 @@ struct ScalarUnary {
   using Arg0Value = typename GetViewType<Arg0Type>::T;
 
   static Status Exec(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
-    DCHECK(batch[0].is_array());
+    ARROW_DCHECK(batch[0].is_array());
     const ArraySpan& arg0 = batch[0].array;
     Status st = Status::OK();
     ArrayIterator<Arg0Type> arg0_it(arg0);
@@ -705,7 +705,7 @@ struct ScalarUnaryNotNullStateful {
   };
 
   Status Exec(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
-    DCHECK(batch[0].is_array());
+    ARROW_DCHECK(batch[0].is_array());
     return ArrayExec<OutType>::Exec(*this, ctx, batch[0].array, out);
   }
 };
@@ -800,7 +800,7 @@ struct ScalarBinary {
       if (batch[1].is_array()) {
         return ScalarArray(ctx, *batch[0].scalar, batch[1].array, out);
       } else {
-        DCHECK(false);
+        ARROW_DCHECK(false);
         return Status::Invalid("Should be unreachable");
       }
     }
@@ -885,7 +885,7 @@ struct ScalarBinaryNotNullStateful {
       if (batch[1].is_array()) {
         return ScalarArray(ctx, *batch[0].scalar, batch[1].array, out);
       } else {
-        DCHECK(false);
+        ARROW_DCHECK(false);
         return Status::Invalid("Should be unreachable");
       }
     }
@@ -1013,7 +1013,7 @@ auto GenerateNumeric(detail::GetTypeId get_id) {
     case Type::DOUBLE:
       return Generator<Type0, DoubleType, Args...>::Exec;
     default:
-      DCHECK(false);
+      ARROW_DCHECK(false);
       return FailFunctor<KernelType>::Exec;
   }
 }
@@ -1029,7 +1029,7 @@ ArrayKernelExec GenerateFloatingPoint(detail::GetTypeId get_id) {
     case Type::DOUBLE:
       return Generator<Type0, DoubleType, Args...>::Exec;
     default:
-      DCHECK(false);
+      ARROW_DCHECK(false);
       return nullptr;
   }
 }
@@ -1058,7 +1058,7 @@ KernelType GenerateInteger(detail::GetTypeId get_id) {
     case Type::UINT64:
       return Generator<Type0, UInt64Type, Args...>::Exec;
     default:
-      DCHECK(false);
+      ARROW_DCHECK(false);
       return nullptr;
   }
 }
@@ -1089,7 +1089,7 @@ ArrayKernelExec GeneratePhysicalInteger(detail::GetTypeId get_id) {
     case Type::UINT64:
       return Generator<Type0, UInt64Type, Args...>::Exec;
     default:
-      DCHECK(false);
+      ARROW_DCHECK(false);
       return nullptr;
   }
 }
@@ -1121,7 +1121,7 @@ KernelType ArithmeticExecFromOp(detail::GetTypeId get_id) {
     case Type::DOUBLE:
       return KernelGenerator<DoubleType, DoubleType, Op, Args...>::Exec;
     default:
-      DCHECK(false);
+      ARROW_DCHECK(false);
       return FailFunctor<KernelType>::Exec;
   }
 }
@@ -1157,7 +1157,7 @@ ReturnType GeneratePhysicalNumericGeneric(detail::GetTypeId get_id) {
     case Type::DOUBLE:
       return Generator<DoubleType, Args...>::Exec;
     default:
-      DCHECK(false);
+      ARROW_DCHECK(false);
       return nullptr;
   }
 }
@@ -1179,7 +1179,7 @@ ArrayKernelExec GenerateDecimalToDecimal(detail::GetTypeId get_id) {
     case Type::DECIMAL256:
       return Generator<Decimal256Type, Args...>::Exec;
     default:
-      DCHECK(false);
+      ARROW_DCHECK(false);
       return nullptr;
   }
 }
@@ -1199,7 +1199,7 @@ ArrayKernelExec GenerateSignedInteger(detail::GetTypeId get_id) {
     case Type::INT64:
       return Generator<Type0, Int64Type, Args...>::Exec;
     default:
-      DCHECK(false);
+      ARROW_DCHECK(false);
       return nullptr;
   }
 }
@@ -1244,7 +1244,7 @@ KernelType GenerateTypeAgnosticPrimitive(detail::GetTypeId get_id) {
     case Type::INTERVAL_MONTH_DAY_NANO:
       return Generator<MonthDayNanoIntervalType, Args...>::Exec;
     default:
-      DCHECK(false);
+      ARROW_DCHECK(false);
       return FailFunctor<KernelType>::Exec;
   }
 }
@@ -1261,7 +1261,7 @@ KernelType GenerateTypeAgnosticVarBinaryBase(detail::GetTypeId get_id) {
     case Type::LARGE_STRING:
       return Generator<LargeBinaryType, Args...>::Exec;
     default:
-      DCHECK(false);
+      ARROW_DCHECK(false);
       return FailFunctor<KernelType>::Exec;
   }
 }
@@ -1279,7 +1279,7 @@ ArrayKernelExec GenerateVarBinaryToVarBinary(detail::GetTypeId get_id) {
     case Type::LARGE_STRING:
       return Generator<LargeStringType, Args...>::Exec;
     default:
-      DCHECK(false);
+      ARROW_DCHECK(false);
       return nullptr;
   }
 }
@@ -1300,7 +1300,7 @@ ArrayKernelExec GenerateVarBinaryBase(detail::GetTypeId get_id) {
     case Type::LARGE_STRING:
       return Generator<Type0, LargeBinaryType, Args...>::Exec;
     default:
-      DCHECK(false);
+      ARROW_DCHECK(false);
       return nullptr;
   }
 }
@@ -1318,7 +1318,7 @@ ArrayKernelExec GenerateVarBinary(detail::GetTypeId get_id) {
     case Type::LARGE_STRING:
       return Generator<Type0, LargeStringType, Args...>::Exec;
     default:
-      DCHECK(false);
+      ARROW_DCHECK(false);
       return nullptr;
   }
 }
@@ -1334,7 +1334,7 @@ ArrayKernelExec GenerateVarBinaryViewBase(detail::GetTypeId get_id) {
     case Type::STRING_VIEW:
       return Generator<Type0, BinaryViewType, Args...>::Exec;
     default:
-      DCHECK(false);
+      ARROW_DCHECK(false);
       return nullptr;
   }
 }
@@ -1358,7 +1358,7 @@ ArrayKernelExec GenerateTemporal(detail::GetTypeId get_id) {
     case Type::TIMESTAMP:
       return Generator<Type0, TimestampType, Args...>::Exec;
     default:
-      DCHECK(false);
+      ARROW_DCHECK(false);
       return nullptr;
   }
 }
@@ -1379,7 +1379,7 @@ auto GenerateDecimal(detail::GetTypeId get_id) {
     case Type::DECIMAL256:
       return Generator<Type0, Decimal256Type, Args...>::Exec;
     default:
-      DCHECK(false);
+      ARROW_DCHECK(false);
       return KernelType(nullptr);
   }
 }

--- a/cpp/src/arrow/compute/kernels/copy_data_internal.h
+++ b/cpp/src/arrow/compute/kernels/copy_data_internal.h
@@ -59,7 +59,7 @@ struct CopyDataUtils<FixedSizeBinaryType> {
       std::memset(begin, 0x00, width * length);
     } else {
       const std::string_view buffer = scalar.view();
-      DCHECK_GE(buffer.size(), static_cast<size_t>(width));
+      ARROW_DCHECK_GE(buffer.size(), static_cast<size_t>(width));
       for (int i = 0; i < length; i++) {
         std::memcpy(begin, buffer.data(), width);
         begin += width;

--- a/cpp/src/arrow/compute/kernels/hash_aggregate_pivot.cc
+++ b/cpp/src/arrow/compute/kernels/hash_aggregate_pivot.cc
@@ -31,6 +31,7 @@
 #include "arrow/compute/row/grouper.h"
 #include "arrow/util/bit_block_counter.h"
 #include "arrow/util/checked_cast.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/span.h"
 #include "arrow/visit_type_inline.h"
 

--- a/cpp/src/arrow/compute/kernels/pivot_internal.cc
+++ b/cpp/src/arrow/compute/kernels/pivot_internal.cc
@@ -31,7 +31,7 @@
 #include "arrow/type_traits.h"
 #include "arrow/util/bit_run_reader.h"
 #include "arrow/util/checked_cast.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/unreachable.h"
 #include "arrow/visit_type_inline.h"
 

--- a/cpp/src/arrow/compute/kernels/ree_util_internal.cc
+++ b/cpp/src/arrow/compute/kernels/ree_util_internal.cc
@@ -25,7 +25,7 @@
 #include "arrow/result.h"
 #include "arrow/type.h"
 #include "arrow/type_traits.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 namespace compute {

--- a/cpp/src/arrow/compute/kernels/ree_util_internal.h
+++ b/cpp/src/arrow/compute/kernels/ree_util_internal.h
@@ -97,9 +97,9 @@ class ReadWriteValue<ArrowType, in_has_validity_buffer, out_has_validity_buffer,
 
   /// \brief Ensure padding is zeroed in validity bitmap.
   void ZeroValidityPadding(int64_t length) const {
-    DCHECK(output_values_);
+    ARROW_DCHECK(output_values_);
     if constexpr (out_has_validity_buffer) {
-      DCHECK(output_validity_);
+      ARROW_DCHECK(output_validity_);
       const int64_t validity_buffer_size = bit_util::BytesForBits(length);
       output_validity_[validity_buffer_size - 1] = 0;
     }
@@ -185,9 +185,9 @@ class ReadWriteValue<ArrowType, in_has_validity_buffer, out_has_validity_buffer,
 
   /// \brief Ensure padding is zeroed in validity bitmap.
   void ZeroValidityPadding(int64_t length) const {
-    DCHECK(output_values_);
+    ARROW_DCHECK(output_values_);
     if constexpr (out_has_validity_buffer) {
-      DCHECK(output_validity_);
+      ARROW_DCHECK(output_validity_);
       const int64_t validity_buffer_size = bit_util::BytesForBits(length);
       output_validity_[validity_buffer_size - 1] = 0;
     }
@@ -280,9 +280,9 @@ class ReadWriteValue<ArrowType, in_has_validity_buffer, out_has_validity_buffer,
 
   /// \brief Ensure padding is zeroed in validity bitmap.
   void ZeroValidityPadding(int64_t length) const {
-    DCHECK(output_values_);
+    ARROW_DCHECK(output_values_);
     if constexpr (out_has_validity_buffer) {
-      DCHECK(output_validity_);
+      ARROW_DCHECK(output_validity_);
       const int64_t validity_buffer_size = bit_util::BytesForBits(length);
       output_validity_[validity_buffer_size - 1] = 0;
     }

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
@@ -34,6 +34,7 @@
 #include "arrow/type_traits.h"
 #include "arrow/util/decimal.h"
 #include "arrow/util/int_util_overflow.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/macros.h"
 #include "arrow/visit_scalar_inline.h"
 

--- a/cpp/src/arrow/compute/kernels/scalar_boolean.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_boolean.cc
@@ -21,6 +21,7 @@
 #include "arrow/util/bit_util.h"
 #include "arrow/util/bitmap.h"
 #include "arrow/util/bitmap_ops.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 

--- a/cpp/src/arrow/compute/kernels/scalar_cast_boolean.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_boolean.cc
@@ -20,6 +20,7 @@
 #include "arrow/array/builder_primitive.h"
 #include "arrow/compute/kernels/common_internal.h"
 #include "arrow/compute/kernels/scalar_cast_internal.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/value_parsing.h"
 
 namespace arrow {

--- a/cpp/src/arrow/compute/kernels/scalar_cast_dictionary.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_dictionary.cc
@@ -25,6 +25,7 @@
 #include "arrow/compute/kernels/scalar_cast_internal.h"
 #include "arrow/compute/kernels/util_internal.h"
 #include "arrow/util/int_util.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 using internal::CopyBitmap;

--- a/cpp/src/arrow/compute/kernels/scalar_cast_extension.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_extension.cc
@@ -19,6 +19,7 @@
 #include "arrow/compute/kernels/common_internal.h"
 #include "arrow/compute/kernels/scalar_cast_internal.h"
 #include "arrow/scalar.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 namespace compute {

--- a/cpp/src/arrow/compute/kernels/scalar_cast_internal.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_internal.cc
@@ -22,6 +22,7 @@
 #include "arrow/type_traits.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/float16.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 

--- a/cpp/src/arrow/compute/kernels/scalar_cast_internal.h
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_internal.h
@@ -61,8 +61,8 @@ Status CastFromNull(KernelContext* ctx, const ExecSpan& batch, ExecResult* out);
 // types are parameter free (have a type_singleton).
 template <typename InType, typename OutType>
 void AddSimpleCast(InputType in_ty, OutputType out_ty, CastFunction* func) {
-  DCHECK_OK(func->AddKernel(InType::type_id, {in_ty}, out_ty,
-                            CastFunctor<OutType, InType>::Exec));
+  ARROW_DCHECK_OK(func->AddKernel(InType::type_id, {in_ty}, out_ty,
+                                  CastFunctor<OutType, InType>::Exec));
 }
 
 Status ZeroCopyCastExec(KernelContext* ctx, const ExecSpan& batch, ExecResult* out);

--- a/cpp/src/arrow/compute/kernels/scalar_cast_nested.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_nested.cc
@@ -30,6 +30,7 @@
 #include "arrow/compute/kernels/scalar_cast_internal.h"
 #include "arrow/util/bitmap_ops.h"
 #include "arrow/util/int_util.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 

--- a/cpp/src/arrow/compute/kernels/scalar_cast_numeric.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_numeric.cc
@@ -25,6 +25,7 @@
 #include "arrow/util/bit_block_counter.h"
 #include "arrow/util/float16.h"
 #include "arrow/util/int_util.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/value_parsing.h"
 
 namespace arrow {

--- a/cpp/src/arrow/compute/kernels/scalar_cast_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_string.cc
@@ -30,7 +30,7 @@
 #include "arrow/type_traits.h"
 #include "arrow/util/formatting.h"
 #include "arrow/util/int_util.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/utf8_internal.h"
 #include "arrow/visit_data_inline.h"
 

--- a/cpp/src/arrow/compute/kernels/scalar_cast_temporal.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_temporal.cc
@@ -24,6 +24,7 @@
 #include "arrow/compute/kernels/scalar_cast_internal.h"
 #include "arrow/compute/kernels/temporal_internal.h"
 #include "arrow/util/bitmap_reader.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/time.h"
 #include "arrow/util/value_parsing.h"
 

--- a/cpp/src/arrow/compute/kernels/scalar_compare.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_compare.cc
@@ -25,6 +25,7 @@
 #include "arrow/type.h"
 #include "arrow/util/bit_util.h"
 #include "arrow/util/bitmap_ops.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 

--- a/cpp/src/arrow/compute/kernels/scalar_compare_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_compare_test.cc
@@ -35,6 +35,7 @@
 #include "arrow/type_traits.h"
 #include "arrow/util/bitmap_reader.h"
 #include "arrow/util/checked_cast.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 

--- a/cpp/src/arrow/compute/kernels/scalar_if_else.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else.cc
@@ -30,6 +30,7 @@
 #include "arrow/util/bitmap.h"
 #include "arrow/util/bitmap_ops.h"
 #include "arrow/util/bitmap_reader.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 

--- a/cpp/src/arrow/compute/kernels/scalar_nested.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_nested.cc
@@ -27,6 +27,7 @@
 #include "arrow/util/bit_block_counter.h"
 #include "arrow/util/bit_util.h"
 #include "arrow/util/bitmap_generate.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/string.h"
 #include "arrow/util/unreachable.h"
 

--- a/cpp/src/arrow/compute/kernels/scalar_random.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_random.cc
@@ -23,6 +23,7 @@
 #include "arrow/compute/kernel.h"
 #include "arrow/compute/kernels/common_internal.h"
 #include "arrow/compute/registry.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/pcg_random.h"
 
 namespace arrow {

--- a/cpp/src/arrow/compute/kernels/scalar_round.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_round.cc
@@ -34,6 +34,7 @@
 #include "arrow/type_traits.h"
 #include "arrow/util/decimal.h"
 #include "arrow/util/int_util_overflow.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/macros.h"
 #include "arrow/visit_scalar_inline.h"
 #include "arrow/visit_type_inline.h"

--- a/cpp/src/arrow/compute/kernels/scalar_set_lookup.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_set_lookup.cc
@@ -24,6 +24,7 @@
 #include "arrow/util/bit_util.h"
 #include "arrow/util/bitmap_writer.h"
 #include "arrow/util/hashing.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/visit_data_inline.h"
 
 namespace arrow {

--- a/cpp/src/arrow/compute/kernels/scalar_string_ascii.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_ascii.cc
@@ -26,6 +26,7 @@
 #include "arrow/compute/kernels/scalar_string_internal.h"
 #include "arrow/result.h"
 #include "arrow/util/config.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/string.h"
 #include "arrow/util/value_parsing.h"

--- a/cpp/src/arrow/compute/kernels/scalar_string_internal.h
+++ b/cpp/src/arrow/compute/kernels/scalar_string_internal.h
@@ -106,7 +106,7 @@ struct StringTransformExecBase {
       }
       output_string_offsets[i + 1] = output_ncodeunits;
     }
-    DCHECK_LE(output_ncodeunits, max_output_ncodeunits);
+    ARROW_DCHECK_LE(output_ncodeunits, max_output_ncodeunits);
 
     // Trim the codepoint buffer, since we may have allocated too much
     return values_buffer->Resize(output_ncodeunits, /*shrink_to_fit=*/true);
@@ -154,9 +154,9 @@ void MakeUnaryStringBatchKernel(
     auto exec = GenerateVarBinaryToVarBinary<ExecFunctor>(ty);
     ScalarKernel kernel{{ty}, ty, std::move(exec)};
     kernel.mem_allocation = mem_allocation;
-    DCHECK_OK(func->AddKernel(std::move(kernel)));
+    ARROW_DCHECK_OK(func->AddKernel(std::move(kernel)));
   }
-  DCHECK_OK(registry->AddFunction(std::move(func)));
+  ARROW_DCHECK_OK(registry->AddFunction(std::move(func)));
 }
 
 template <template <typename> class ExecFunctor>
@@ -168,15 +168,15 @@ void MakeUnaryStringBatchKernelWithState(
     using t32 = ExecFunctor<StringType>;
     ScalarKernel kernel{{utf8()}, utf8(), t32::Exec, t32::State::Init};
     kernel.mem_allocation = mem_allocation;
-    DCHECK_OK(func->AddKernel(std::move(kernel)));
+    ARROW_DCHECK_OK(func->AddKernel(std::move(kernel)));
   }
   {
     using t64 = ExecFunctor<LargeStringType>;
     ScalarKernel kernel{{large_utf8()}, large_utf8(), t64::Exec, t64::State::Init};
     kernel.mem_allocation = mem_allocation;
-    DCHECK_OK(func->AddKernel(std::move(kernel)));
+    ARROW_DCHECK_OK(func->AddKernel(std::move(kernel)));
   }
-  DCHECK_OK(registry->AddFunction(std::move(func)));
+  ARROW_DCHECK_OK(registry->AddFunction(std::move(func)));
 }
 
 // ----------------------------------------------------------------------
@@ -238,9 +238,9 @@ void AddUnaryStringPredicate(std::string name, FunctionRegistry* registry,
   auto func = std::make_shared<ScalarFunction>(name, Arity::Unary(), std::move(doc));
   for (const auto& ty : StringTypes()) {
     auto exec = GenerateVarBinaryToVarBinary<StringPredicateFunctor, Predicate>(ty);
-    DCHECK_OK(func->AddKernel({ty}, boolean(), std::move(exec)));
+    ARROW_DCHECK_OK(func->AddKernel({ty}, boolean(), std::move(exec)));
   }
-  DCHECK_OK(registry->AddFunction(std::move(func)));
+  ARROW_DCHECK_OK(registry->AddFunction(std::move(func)));
 }
 
 // ----------------------------------------------------------------------
@@ -333,7 +333,7 @@ struct StringSplitExec {
     ArrayData* output_list = out->array_data().get();
     // List offsets were preallocated
     auto* list_offsets = output_list->GetMutableValues<list_offset_type>(1);
-    DCHECK_NE(list_offsets, nullptr);
+    ARROW_DCHECK_NE(list_offsets, nullptr);
     // Initial value
     *list_offsets++ = 0;
     for (int64_t i = 0; i < input.length(); ++i) {

--- a/cpp/src/arrow/compute/kernels/scalar_string_utf8.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_utf8.cc
@@ -21,6 +21,7 @@
 
 #include "arrow/compute/kernels/scalar_string_internal.h"
 #include "arrow/util/config.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/utf8_internal.h"
 
 #ifdef ARROW_WITH_UTF8PROC

--- a/cpp/src/arrow/compute/kernels/scalar_temporal_binary.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_temporal_binary.cc
@@ -24,6 +24,7 @@
 #include "arrow/compute/kernels/common_internal.h"
 #include "arrow/compute/kernels/temporal_internal.h"
 #include "arrow/util/checked_cast.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/time.h"
 #include "arrow/vendored/datetime.h"
 

--- a/cpp/src/arrow/compute/kernels/scalar_temporal_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_temporal_test.cc
@@ -30,7 +30,7 @@
 #include "arrow/type_traits.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/formatting.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 

--- a/cpp/src/arrow/compute/kernels/scalar_temporal_unary.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_temporal_unary.cc
@@ -24,6 +24,7 @@
 #include "arrow/compute/kernels/common_internal.h"
 #include "arrow/compute/kernels/temporal_internal.h"
 #include "arrow/util/checked_cast.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/time.h"
 #include "arrow/util/value_parsing.h"
 #include "arrow/vendored/datetime.h"

--- a/cpp/src/arrow/compute/kernels/scalar_validity.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_validity.cc
@@ -22,6 +22,7 @@
 
 #include "arrow/util/bit_util.h"
 #include "arrow/util/bitmap_ops.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 

--- a/cpp/src/arrow/compute/kernels/util_internal.cc
+++ b/cpp/src/arrow/compute/kernels/util_internal.cc
@@ -23,6 +23,7 @@
 #include "arrow/compute/function.h"
 #include "arrow/type.h"
 #include "arrow/util/checked_cast.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 

--- a/cpp/src/arrow/compute/kernels/util_internal.h
+++ b/cpp/src/arrow/compute/kernels/util_internal.h
@@ -147,7 +147,7 @@ ArrayKernelExec GenerateArithmeticFloatingPoint(detail::GetTypeId get_id) {
     case Type::DOUBLE:
       return KernelGenerator<DoubleType, DoubleType, Op>::Exec;
     default:
-      DCHECK(false);
+      ARROW_DCHECK(false);
       return nullptr;
   }
 }

--- a/cpp/src/arrow/compute/kernels/vector_array_sort.cc
+++ b/cpp/src/arrow/compute/kernels/vector_array_sort.cc
@@ -33,6 +33,7 @@
 #include "arrow/util/bitmap.h"
 #include "arrow/util/bitmap_ops.h"
 #include "arrow/util/checked_cast.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/visit_type_inline.h"
 
 namespace arrow {

--- a/cpp/src/arrow/compute/kernels/vector_cumulative_ops.cc
+++ b/cpp/src/arrow/compute/kernels/vector_cumulative_ops.cc
@@ -27,6 +27,7 @@
 #include "arrow/result.h"
 #include "arrow/type_traits.h"
 #include "arrow/util/bit_util.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/visit_type_inline.h"
 
 namespace arrow::compute::internal {

--- a/cpp/src/arrow/compute/kernels/vector_hash.cc
+++ b/cpp/src/arrow/compute/kernels/vector_hash.cc
@@ -33,6 +33,7 @@
 #include "arrow/result.h"
 #include "arrow/util/hashing.h"
 #include "arrow/util/int_util.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/unreachable.h"
 
 namespace arrow {

--- a/cpp/src/arrow/compute/kernels/vector_nested.cc
+++ b/cpp/src/arrow/compute/kernels/vector_nested.cc
@@ -24,6 +24,7 @@
 #include "arrow/util/bit_run_reader.h"
 #include "arrow/util/bit_util.h"
 #include "arrow/util/list_util.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/visit_type_inline.h"
 
 namespace arrow {

--- a/cpp/src/arrow/compute/kernels/vector_pairwise.cc
+++ b/cpp/src/arrow/compute/kernels/vector_pairwise.cc
@@ -35,7 +35,7 @@
 #include "arrow/type_traits.h"
 #include "arrow/util/bit_util.h"
 #include "arrow/util/checked_cast.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow::compute::internal {
 namespace {

--- a/cpp/src/arrow/compute/kernels/vector_rank.cc
+++ b/cpp/src/arrow/compute/kernels/vector_rank.cc
@@ -21,6 +21,7 @@
 #include "arrow/compute/function.h"
 #include "arrow/compute/kernels/vector_sort_internal.h"
 #include "arrow/compute/registry.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/math_internal.h"
 
 namespace arrow::compute::internal {

--- a/cpp/src/arrow/compute/kernels/vector_replace.cc
+++ b/cpp/src/arrow/compute/kernels/vector_replace.cc
@@ -20,6 +20,7 @@
 #include "arrow/compute/kernels/copy_data_internal.h"
 #include "arrow/compute/kernels/util_internal.h"
 #include "arrow/util/bitmap_ops.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 namespace compute {

--- a/cpp/src/arrow/compute/kernels/vector_run_end_encode.cc
+++ b/cpp/src/arrow/compute/kernels/vector_run_end_encode.cc
@@ -23,6 +23,7 @@
 #include "arrow/compute/kernels/ree_util_internal.h"
 #include "arrow/type_traits.h"
 #include "arrow/util/checked_cast.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/ree_util.h"
 
 namespace arrow {

--- a/cpp/src/arrow/compute/kernels/vector_run_end_encode_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_run_end_encode_test.cc
@@ -24,7 +24,7 @@
 #include "arrow/datum.h"
 #include "arrow/testing/gtest_util.h"
 #include "arrow/type_fwd.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/ree_util.h"
 
 namespace arrow {

--- a/cpp/src/arrow/compute/kernels/vector_select_k.cc
+++ b/cpp/src/arrow/compute/kernels/vector_select_k.cc
@@ -20,6 +20,7 @@
 #include "arrow/compute/function.h"
 #include "arrow/compute/kernels/vector_sort_internal.h"
 #include "arrow/compute/registry.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 

--- a/cpp/src/arrow/compute/kernels/vector_selection.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection.cc
@@ -45,6 +45,7 @@
 #include "arrow/util/bitmap_ops.h"
 #include "arrow/util/bitmap_reader.h"
 #include "arrow/util/int_util.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 

--- a/cpp/src/arrow/compute/kernels/vector_selection_filter_internal.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_filter_internal.cc
@@ -42,6 +42,7 @@
 #include "arrow/util/bit_util.h"
 #include "arrow/util/bitmap_ops.h"
 #include "arrow/util/fixed_width_internal.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 

--- a/cpp/src/arrow/compute/kernels/vector_selection_internal.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_internal.cc
@@ -39,7 +39,7 @@
 #include "arrow/util/bit_util.h"
 #include "arrow/util/fixed_width_internal.h"
 #include "arrow/util/int_util.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/ree_util.h"
 
 namespace arrow {

--- a/cpp/src/arrow/compute/kernels/vector_selection_take_internal.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection_take_internal.cc
@@ -42,6 +42,7 @@
 #include "arrow/util/bit_util.h"
 #include "arrow/util/fixed_width_internal.h"
 #include "arrow/util/int_util.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/ree_util.h"
 
 namespace arrow {

--- a/cpp/src/arrow/compute/kernels/vector_sort.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort.cc
@@ -20,6 +20,7 @@
 #include "arrow/compute/function.h"
 #include "arrow/compute/kernels/vector_sort_internal.h"
 #include "arrow/compute/registry.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 

--- a/cpp/src/arrow/compute/kernels/vector_sort_internal.h
+++ b/cpp/src/arrow/compute/kernels/vector_sort_internal.h
@@ -142,16 +142,16 @@ struct GenericNullPartitionResult {
   static GenericNullPartitionResult NullsAtEnd(IndexType* indices_begin,
                                                IndexType* indices_end,
                                                IndexType* midpoint) {
-    DCHECK_GE(midpoint, indices_begin);
-    DCHECK_LE(midpoint, indices_end);
+    ARROW_DCHECK_GE(midpoint, indices_begin);
+    ARROW_DCHECK_LE(midpoint, indices_end);
     return {indices_begin, midpoint, midpoint, indices_end};
   }
 
   static GenericNullPartitionResult NullsAtStart(IndexType* indices_begin,
                                                  IndexType* indices_end,
                                                  IndexType* midpoint) {
-    DCHECK_GE(midpoint, indices_begin);
-    DCHECK_LE(midpoint, indices_end);
+    ARROW_DCHECK_GE(midpoint, indices_begin);
+    ARROW_DCHECK_LE(midpoint, indices_end);
     return {midpoint, indices_end, indices_begin, midpoint};
   }
 
@@ -379,9 +379,9 @@ struct GenericMergeImpl {
                                             int64_t null_count) const {
     // Input layout:
     // [left nulls .... left non-nulls .... right nulls .... right non-nulls]
-    DCHECK_EQ(left.nulls_end, left.non_nulls_begin);
-    DCHECK_EQ(left.non_nulls_end, right.nulls_begin);
-    DCHECK_EQ(right.nulls_end, right.non_nulls_begin);
+    ARROW_DCHECK_EQ(left.nulls_end, left.non_nulls_begin);
+    ARROW_DCHECK_EQ(left.non_nulls_end, right.nulls_begin);
+    ARROW_DCHECK_EQ(right.nulls_end, right.non_nulls_begin);
 
     // Mutate the input, stably, to obtain the following layout:
     // [left nulls .... right nulls .... left non-nulls .... right non-nulls]
@@ -400,8 +400,8 @@ struct GenericMergeImpl {
     }
 
     // Merge the non-null values into temp area
-    DCHECK_EQ(right.non_nulls_begin - p.non_nulls_begin, left.non_null_count());
-    DCHECK_EQ(p.non_nulls_end - right.non_nulls_begin, right.non_null_count());
+    ARROW_DCHECK_EQ(right.non_nulls_begin - p.non_nulls_begin, left.non_null_count());
+    ARROW_DCHECK_EQ(p.non_nulls_end - right.non_nulls_begin, right.non_null_count());
     if (p.non_null_count()) {
       merge_non_nulls_(p.non_nulls_begin, right.non_nulls_begin, p.non_nulls_end,
                        temp_indices_);
@@ -414,9 +414,9 @@ struct GenericMergeImpl {
                                           int64_t null_count) const {
     // Input layout:
     // [left non-nulls .... left nulls .... right non-nulls .... right nulls]
-    DCHECK_EQ(left.non_nulls_end, left.nulls_begin);
-    DCHECK_EQ(left.nulls_end, right.non_nulls_begin);
-    DCHECK_EQ(right.non_nulls_end, right.nulls_begin);
+    ARROW_DCHECK_EQ(left.non_nulls_end, left.nulls_begin);
+    ARROW_DCHECK_EQ(left.nulls_end, right.non_nulls_begin);
+    ARROW_DCHECK_EQ(right.non_nulls_end, right.nulls_begin);
 
     // Mutate the input, stably, to obtain the following layout:
     // [left non-nulls .... right non-nulls .... left nulls .... right nulls]
@@ -435,8 +435,8 @@ struct GenericMergeImpl {
     }
 
     // Merge the non-null values into temp area
-    DCHECK_EQ(left.non_nulls_end - p.non_nulls_begin, left.non_null_count());
-    DCHECK_EQ(p.non_nulls_end - left.non_nulls_end, right.non_null_count());
+    ARROW_DCHECK_EQ(left.non_nulls_end - p.non_nulls_begin, left.non_null_count());
+    ARROW_DCHECK_EQ(p.non_nulls_end - left.non_nulls_end, right.non_null_count());
     if (p.non_null_count()) {
       merge_non_nulls_(p.non_nulls_begin, left.non_nulls_end, p.non_nulls_end,
                        temp_indices_);

--- a/cpp/src/arrow/compute/kernels/vector_sort_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort_test.cc
@@ -36,7 +36,7 @@
 #include "arrow/testing/random.h"
 #include "arrow/testing/util.h"
 #include "arrow/type_traits.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 

--- a/cpp/src/arrow/compute/kernels/vector_statistics.cc
+++ b/cpp/src/arrow/compute/kernels/vector_statistics.cc
@@ -32,7 +32,7 @@
 #include "arrow/status.h"
 #include "arrow/util/bit_run_reader.h"
 #include "arrow/util/checked_cast.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow::compute::internal {
 

--- a/cpp/src/arrow/compute/kernels/vector_swizzle.cc
+++ b/cpp/src/arrow/compute/kernels/vector_swizzle.cc
@@ -20,7 +20,7 @@
 #include "arrow/compute/kernels/codegen_internal.h"
 #include "arrow/compute/registry.h"
 #include "arrow/util/checked_cast.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow::compute::internal {
 

--- a/cpp/src/arrow/compute/key_map_internal.cc
+++ b/cpp/src/arrow/compute/key_map_internal.cc
@@ -22,7 +22,7 @@
 
 #include "arrow/util/bit_util.h"
 #include "arrow/util/bitmap_ops.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/ubsan.h"
 
 namespace arrow {

--- a/cpp/src/arrow/compute/light_array_internal.h
+++ b/cpp/src/arrow/compute/light_array_internal.h
@@ -135,32 +135,32 @@ class ARROW_EXPORT KeyColumnArray {
   ///
   /// Only valid if this is a view into a varbinary type
   uint32_t* mutable_offsets() {
-    DCHECK(!metadata_.is_fixed_length);
-    DCHECK_EQ(metadata_.fixed_length, sizeof(uint32_t));
+    ARROW_DCHECK(!metadata_.is_fixed_length);
+    ARROW_DCHECK_EQ(metadata_.fixed_length, sizeof(uint32_t));
     return reinterpret_cast<uint32_t*>(mutable_data(kFixedLengthBuffer));
   }
   /// \brief Return a read-only version of the offsets buffer
   ///
   /// Only valid if this is a view into a varbinary type
   const uint32_t* offsets() const {
-    DCHECK(!metadata_.is_fixed_length);
-    DCHECK_EQ(metadata_.fixed_length, sizeof(uint32_t));
+    ARROW_DCHECK(!metadata_.is_fixed_length);
+    ARROW_DCHECK_EQ(metadata_.fixed_length, sizeof(uint32_t));
     return reinterpret_cast<const uint32_t*>(data(kFixedLengthBuffer));
   }
   /// \brief Return a mutable version of the large-offsets buffer
   ///
   /// Only valid if this is a view into a large varbinary type
   uint64_t* mutable_large_offsets() {
-    DCHECK(!metadata_.is_fixed_length);
-    DCHECK_EQ(metadata_.fixed_length, sizeof(uint64_t));
+    ARROW_DCHECK(!metadata_.is_fixed_length);
+    ARROW_DCHECK_EQ(metadata_.fixed_length, sizeof(uint64_t));
     return reinterpret_cast<uint64_t*>(mutable_data(kFixedLengthBuffer));
   }
   /// \brief Return a read-only version of the large-offsets buffer
   ///
   /// Only valid if this is a view into a large varbinary type
   const uint64_t* large_offsets() const {
-    DCHECK(!metadata_.is_fixed_length);
-    DCHECK_EQ(metadata_.fixed_length, sizeof(uint64_t));
+    ARROW_DCHECK(!metadata_.is_fixed_length);
+    ARROW_DCHECK_EQ(metadata_.fixed_length, sizeof(uint64_t));
     return reinterpret_cast<const uint64_t*>(data(kFixedLengthBuffer));
   }
   /// \brief Return the type metadata

--- a/cpp/src/arrow/compute/row/compare_internal.cc
+++ b/cpp/src/arrow/compute/row/compare_internal.cc
@@ -25,6 +25,7 @@
 #include "arrow/compute/util.h"
 #include "arrow/compute/util_internal.h"
 #include "arrow/util/bit_util.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/ubsan.h"
 
 namespace arrow {

--- a/cpp/src/arrow/compute/row/encode_internal.cc
+++ b/cpp/src/arrow/compute/row/encode_internal.cc
@@ -17,6 +17,7 @@
 
 #include "arrow/compute/row/encode_internal.h"
 #include "arrow/util/checked_cast.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 namespace compute {

--- a/cpp/src/arrow/compute/row/grouper.cc
+++ b/cpp/src/arrow/compute/row/grouper.cc
@@ -38,7 +38,7 @@
 #include "arrow/util/bitmap_ops.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/cpu_info.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/task_group.h"
 
 namespace arrow {

--- a/cpp/src/arrow/compute/row/row_encoder_internal.cc
+++ b/cpp/src/arrow/compute/row/row_encoder_internal.cc
@@ -18,7 +18,7 @@
 #include "arrow/compute/row/row_encoder_internal.h"
 
 #include "arrow/util/bitmap_writer.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 #include <memory>
 

--- a/cpp/src/arrow/compute/row/row_encoder_internal.h
+++ b/cpp/src/arrow/compute/row/row_encoder_internal.h
@@ -183,7 +183,7 @@ struct VarLengthKeyEncoder : KeyEncoder {
       encoded_ptr += sizeof(Offset);
     };
     if (data.is_array()) {
-      DCHECK_EQ(data.length(), batch_length);
+      ARROW_DCHECK_EQ(data.length(), batch_length);
       VisitArraySpanInline<T>(data.array, handle_next_valid_value,
                               handle_next_null_value);
     } else {

--- a/cpp/src/arrow/compute/row/row_internal.cc
+++ b/cpp/src/arrow/compute/row/row_internal.cc
@@ -18,6 +18,7 @@
 #include "arrow/compute/row/row_internal.h"
 
 #include "arrow/compute/util.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 namespace compute {

--- a/cpp/src/arrow/compute/row/row_test.cc
+++ b/cpp/src/arrow/compute/row/row_test.cc
@@ -21,6 +21,7 @@
 #include "arrow/compute/row/row_internal.h"
 #include "arrow/testing/generator.h"
 #include "arrow/testing/gtest_util.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 namespace compute {

--- a/cpp/src/arrow/compute/test_util_internal.cc
+++ b/cpp/src/arrow/compute/test_util_internal.cc
@@ -26,7 +26,7 @@
 #include "arrow/table.h"
 #include "arrow/testing/gtest_util.h"
 #include "arrow/type.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/vector.h"
 
 namespace arrow::compute {

--- a/cpp/src/arrow/csv/chunker.cc
+++ b/cpp/src/arrow/csv/chunker.cc
@@ -25,7 +25,7 @@
 
 #include "arrow/csv/lexing_internal.h"
 #include "arrow/status.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 namespace csv {

--- a/cpp/src/arrow/csv/column_builder.cc
+++ b/cpp/src/arrow/csv/column_builder.cc
@@ -35,7 +35,7 @@
 #include "arrow/status.h"
 #include "arrow/type.h"
 #include "arrow/type_fwd.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/task_group.h"
 
 namespace arrow {

--- a/cpp/src/arrow/csv/column_decoder.cc
+++ b/cpp/src/arrow/csv/column_decoder.cc
@@ -34,7 +34,7 @@
 #include "arrow/type.h"
 #include "arrow/type_fwd.h"
 #include "arrow/util/future.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 namespace csv {

--- a/cpp/src/arrow/csv/converter_test.cc
+++ b/cpp/src/arrow/csv/converter_test.cc
@@ -36,7 +36,7 @@
 #include "arrow/type_traits.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/decimal.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/value_parsing.h"
 
 namespace arrow {

--- a/cpp/src/arrow/csv/inference_internal.h
+++ b/cpp/src/arrow/csv/inference_internal.h
@@ -53,7 +53,7 @@ class InferStatus {
   bool can_loosen_type() const { return can_loosen_type_; }
 
   void LoosenType(const Status& conversion_error) {
-    DCHECK(can_loosen_type_);
+    ARROW_DCHECK(can_loosen_type_);
 
     switch (kind_) {
       case InferKind::Null:

--- a/cpp/src/arrow/csv/parser.cc
+++ b/cpp/src/arrow/csv/parser.cc
@@ -26,7 +26,7 @@
 #include "arrow/memory_pool.h"
 #include "arrow/result.h"
 #include "arrow/status.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/simd.h"
 
 namespace arrow {

--- a/cpp/src/arrow/csv/reader.cc
+++ b/cpp/src/arrow/csv/reader.cc
@@ -45,7 +45,7 @@
 #include "arrow/util/async_generator.h"
 #include "arrow/util/future.h"
 #include "arrow/util/iterator.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/task_group.h"
 #include "arrow/util/thread_pool.h"

--- a/cpp/src/arrow/csv/writer.cc
+++ b/cpp/src/arrow/csv/writer.cc
@@ -24,7 +24,7 @@
 #include "arrow/result.h"
 #include "arrow/stl_allocator.h"
 #include "arrow/util/iterator.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/visit_data_inline.h"
 #include "arrow/visit_type_inline.h"
 

--- a/cpp/src/arrow/dataset/dataset.cc
+++ b/cpp/src/arrow/dataset/dataset.cc
@@ -28,7 +28,7 @@
 #include "arrow/util/bit_util.h"
 #include "arrow/util/byte_size.h"
 #include "arrow/util/iterator.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/thread_pool.h"
 
 namespace arrow {

--- a/cpp/src/arrow/dataset/dataset_writer.cc
+++ b/cpp/src/arrow/dataset/dataset_writer.cc
@@ -28,7 +28,7 @@
 #include "arrow/result.h"
 #include "arrow/table.h"
 #include "arrow/util/future.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/map.h"
 #include "arrow/util/string.h"
 #include "arrow/util/tracing_internal.h"

--- a/cpp/src/arrow/dataset/file_base.cc
+++ b/cpp/src/arrow/dataset/file_base.cc
@@ -44,6 +44,7 @@
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/compression.h"
 #include "arrow/util/iterator.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/map.h"
 #include "arrow/util/string.h"

--- a/cpp/src/arrow/dataset/file_csv.cc
+++ b/cpp/src/arrow/dataset/file_csv.cc
@@ -40,7 +40,7 @@
 #include "arrow/util/async_generator.h"
 #include "arrow/util/bit_util.h"
 #include "arrow/util/iterator.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/tracing_internal.h"
 #include "arrow/util/utf8.h"
 

--- a/cpp/src/arrow/dataset/file_json.cc
+++ b/cpp/src/arrow/dataset/file_json.cc
@@ -38,7 +38,7 @@
 #include "arrow/util/bit_util.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/delimiting.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/thread_pool.h"
 
 namespace arrow {

--- a/cpp/src/arrow/dataset/file_json_test.cc
+++ b/cpp/src/arrow/dataset/file_json_test.cc
@@ -24,6 +24,7 @@
 #include "arrow/json/rapidjson_defs.h"
 #include "arrow/testing/gtest_util.h"
 #include "arrow/testing/util.h"
+#include "arrow/util/logging_internal.h"
 
 #include "rapidjson/ostreamwrapper.h"
 #include "rapidjson/writer.h"

--- a/cpp/src/arrow/dataset/file_parquet.cc
+++ b/cpp/src/arrow/dataset/file_parquet.cc
@@ -34,7 +34,7 @@
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/future.h"
 #include "arrow/util/iterator.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/range.h"
 #include "arrow/util/tracing_internal.h"
 #include "parquet/arrow/reader.h"

--- a/cpp/src/arrow/dataset/file_parquet_test.cc
+++ b/cpp/src/arrow/dataset/file_parquet_test.cc
@@ -37,6 +37,7 @@
 #include "arrow/type.h"
 #include "arrow/type_fwd.h"
 #include "arrow/util/io_util.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/range.h"
 
 #include "parquet/arrow/writer.h"

--- a/cpp/src/arrow/dataset/scan_node.cc
+++ b/cpp/src/arrow/dataset/scan_node.cc
@@ -34,7 +34,7 @@
 #include "arrow/status.h"
 #include "arrow/type.h"
 #include "arrow/util/checked_cast.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/string.h"
 #include "arrow/util/tracing_internal.h"
 #include "arrow/util/unreachable.h"

--- a/cpp/src/arrow/dataset/scanner.cc
+++ b/cpp/src/arrow/dataset/scanner.cc
@@ -42,7 +42,7 @@
 #include "arrow/util/async_generator.h"
 #include "arrow/util/config.h"
 #include "arrow/util/iterator.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/task_group.h"
 #include "arrow/util/thread_pool.h"
 #include "arrow/util/tracing_internal.h"

--- a/cpp/src/arrow/dataset/test_util_internal.h
+++ b/cpp/src/arrow/dataset/test_util_internal.h
@@ -1065,7 +1065,7 @@ class FileFormatFixtureMixinV2 : public ::testing::Test {
   }
 
   void CheckDatasetSchemaSet() {
-    DCHECK_NE(dataset_schema_, nullptr)
+    ARROW_DCHECK_NE(dataset_schema_, nullptr)
         << "call SetDatasetSchema before calling this method";
   }
 
@@ -1822,7 +1822,7 @@ struct ArithmeticDatasetFixture {
 
   /// \brief Creates a JSON RecordBatch
   static std::string JSONRecordBatch(int64_t n) {
-    DCHECK_GT(n, 0);
+    ARROW_DCHECK_GT(n, 0);
 
     auto record = JSONRecordFor(n);
 
@@ -1843,7 +1843,7 @@ struct ArithmeticDatasetFixture {
   }
 
   static std::unique_ptr<RecordBatchReader> GetRecordBatchReader(int64_t n) {
-    DCHECK_GT(n, 0);
+    ARROW_DCHECK_GT(n, 0);
 
     // Functor which generates `n` RecordBatch
     struct {

--- a/cpp/src/arrow/datum.cc
+++ b/cpp/src/arrow/datum.cc
@@ -30,7 +30,7 @@
 #include "arrow/scalar.h"
 #include "arrow/table.h"
 #include "arrow/util/byte_size.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/memory.h"
 
 namespace arrow {

--- a/cpp/src/arrow/device.cc
+++ b/cpp/src/arrow/device.cc
@@ -27,7 +27,7 @@
 #include "arrow/io/memory.h"
 #include "arrow/record_batch.h"
 #include "arrow/result.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 

--- a/cpp/src/arrow/engine/simple_extension_type_internal.h
+++ b/cpp/src/arrow/engine/simple_extension_type_internal.h
@@ -96,9 +96,9 @@ class SimpleExtensionType : public ExtensionType {
   }
 
   std::shared_ptr<Array> MakeArray(std::shared_ptr<ArrayData> data) const override {
-    DCHECK_EQ(data->type->id(), Type::EXTENSION);
-    DCHECK_EQ(static_cast<const ExtensionType&>(*data->type).extension_name(),
-              kExtensionName);
+    ARROW_DCHECK_EQ(data->type->id(), Type::EXTENSION);
+    ARROW_DCHECK_EQ(static_cast<const ExtensionType&>(*data->type).extension_name(),
+                    kExtensionName);
     return std::make_shared<ExtensionArray>(data);
   }
 

--- a/cpp/src/arrow/engine/substrait/expression_internal.cc
+++ b/cpp/src/arrow/engine/substrait/expression_internal.cc
@@ -58,7 +58,7 @@
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/decimal.h"
 #include "arrow/util/endian.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/small_vector.h"
 #include "arrow/util/string.h"

--- a/cpp/src/arrow/engine/substrait/extension_set.cc
+++ b/cpp/src/arrow/engine/substrait/extension_set.cc
@@ -31,7 +31,7 @@
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/hash_util.h"
 #include "arrow/util/hashing.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/string.h"
 
 namespace arrow {

--- a/cpp/src/arrow/engine/substrait/relation_internal.cc
+++ b/cpp/src/arrow/engine/substrait/relation_internal.cc
@@ -58,7 +58,7 @@
 #include "arrow/status.h"
 #include "arrow/type.h"
 #include "arrow/util/checked_cast.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/string.h"
 #include "arrow/util/uri.h"
 

--- a/cpp/src/arrow/extension/bool8.cc
+++ b/cpp/src/arrow/extension/bool8.cc
@@ -18,7 +18,7 @@
 #include <sstream>
 
 #include "arrow/extension/bool8.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow::extension {
 

--- a/cpp/src/arrow/extension/fixed_shape_tensor.cc
+++ b/cpp/src/arrow/extension/fixed_shape_tensor.cc
@@ -27,7 +27,7 @@
 #include "arrow/json/rapidjson_defs.h"  // IWYU pragma: keep
 #include "arrow/tensor.h"
 #include "arrow/util/int_util_overflow.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/print.h"
 #include "arrow/util/sort.h"
 #include "arrow/util/string.h"

--- a/cpp/src/arrow/extension/json.cc
+++ b/cpp/src/arrow/extension/json.cc
@@ -23,7 +23,7 @@
 #include "arrow/result.h"
 #include "arrow/status.h"
 #include "arrow/type_fwd.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow::extension {
 

--- a/cpp/src/arrow/extension/opaque.cc
+++ b/cpp/src/arrow/extension/opaque.cc
@@ -20,7 +20,7 @@
 #include <sstream>
 
 #include "arrow/json/rapidjson_defs.h"  // IWYU pragma: keep
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 #include <rapidjson/document.h>
 #include <rapidjson/error/en.h>

--- a/cpp/src/arrow/extension/uuid.cc
+++ b/cpp/src/arrow/extension/uuid.cc
@@ -18,7 +18,7 @@
 #include <sstream>
 
 #include "arrow/extension_type.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 #include "arrow/extension/uuid.h"
 

--- a/cpp/src/arrow/extension_type.cc
+++ b/cpp/src/arrow/extension_type.cc
@@ -37,7 +37,7 @@
 #include "arrow/status.h"
 #include "arrow/type.h"
 #include "arrow/util/checked_cast.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 

--- a/cpp/src/arrow/extension_type_test.cc
+++ b/cpp/src/arrow/extension_type_test.cc
@@ -38,7 +38,7 @@
 #include "arrow/testing/gtest_util.h"
 #include "arrow/type.h"
 #include "arrow/util/key_value_metadata.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -46,7 +46,7 @@
 #include "arrow/util/formatting.h"
 #include "arrow/util/future.h"
 #include "arrow/util/key_value_metadata.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/string.h"
 
 namespace arrow::fs {

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -40,7 +40,7 @@
 #include "arrow/util/future.h"
 #include "arrow/util/io_util.h"
 #include "arrow/util/key_value_metadata.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/pcg_random.h"
 #include "arrow/util/string.h"
 #include "arrow/util/unreachable.h"

--- a/cpp/src/arrow/filesystem/filesystem.cc
+++ b/cpp/src/arrow/filesystem/filesystem.cc
@@ -47,7 +47,7 @@
 #include "arrow/status.h"
 #include "arrow/util/async_generator.h"
 #include "arrow/util/checked_cast.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/parallel.h"
 #include "arrow/util/string.h"

--- a/cpp/src/arrow/filesystem/mockfs.cc
+++ b/cpp/src/arrow/filesystem/mockfs.cc
@@ -35,7 +35,7 @@
 #include "arrow/io/memory.h"
 #include "arrow/util/async_generator.h"
 #include "arrow/util/future.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/windows_fixup.h"
 
 namespace arrow {

--- a/cpp/src/arrow/filesystem/path_util.cc
+++ b/cpp/src/arrow/filesystem/path_util.cc
@@ -23,7 +23,7 @@
 #include "arrow/filesystem/util_internal.h"
 #include "arrow/result.h"
 #include "arrow/status.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/string.h"
 #include "arrow/util/uri.h"
 

--- a/cpp/src/arrow/filesystem/s3fs.cc
+++ b/cpp/src/arrow/filesystem/s3fs.cc
@@ -134,7 +134,7 @@
 #include "arrow/util/future.h"
 #include "arrow/util/io_util.h"
 #include "arrow/util/key_value_metadata.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/string.h"
 #include "arrow/util/task_group.h"
 #include "arrow/util/thread_pool.h"

--- a/cpp/src/arrow/flight/client.cc
+++ b/cpp/src/arrow/flight/client.cc
@@ -33,7 +33,7 @@
 #include "arrow/status.h"
 #include "arrow/table.h"
 #include "arrow/util/future.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 #include "arrow/flight/client_auth.h"
 #include "arrow/flight/serialization_internal.h"

--- a/cpp/src/arrow/flight/otel_logging.cc
+++ b/cpp/src/arrow/flight/otel_logging.cc
@@ -21,7 +21,7 @@
 #include "arrow/flight/otel_logging_internal.h"
 #include "arrow/result.h"
 #include "arrow/util/logger.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow::flight {
 

--- a/cpp/src/arrow/flight/transport/grpc/grpc_client.cc
+++ b/cpp/src/arrow/flight/transport/grpc/grpc_client.cc
@@ -41,7 +41,7 @@
 #include "arrow/result.h"
 #include "arrow/status.h"
 #include "arrow/util/base64.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/string.h"
 #include "arrow/util/uri.h"
 

--- a/cpp/src/arrow/flight/transport/grpc/serialization_internal.cc
+++ b/cpp/src/arrow/flight/transport/grpc/serialization_internal.cc
@@ -52,7 +52,7 @@
 #include "arrow/ipc/message.h"
 #include "arrow/ipc/writer.h"
 #include "arrow/util/bit_util.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 namespace flight {

--- a/cpp/src/arrow/gpu/cuda_context.cc
+++ b/cpp/src/arrow/gpu/cuda_context.cc
@@ -29,7 +29,7 @@
 #include "arrow/gpu/cuda_internal.h"
 #include "arrow/gpu/cuda_memory.h"
 #include "arrow/util/checked_cast.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 

--- a/cpp/src/arrow/gpu/cuda_internal.cc
+++ b/cpp/src/arrow/gpu/cuda_internal.cc
@@ -20,7 +20,7 @@
 #include <sstream>
 #include <string>
 
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 namespace cuda {

--- a/cpp/src/arrow/gpu/cuda_memory.cc
+++ b/cpp/src/arrow/gpu/cuda_memory.cc
@@ -31,7 +31,7 @@
 #include "arrow/io/memory.h"
 #include "arrow/memory_pool.h"
 #include "arrow/status.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 #include "arrow/gpu/cuda_context.h"
 #include "arrow/gpu/cuda_internal.h"

--- a/cpp/src/arrow/integration/json_integration.cc
+++ b/cpp/src/arrow/integration/json_integration.cc
@@ -31,7 +31,7 @@
 #include "arrow/result.h"
 #include "arrow/status.h"
 #include "arrow/type.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 using arrow::ipc::DictionaryFieldMapper;
 using arrow::ipc::DictionaryMemo;

--- a/cpp/src/arrow/integration/json_internal.cc
+++ b/cpp/src/arrow/integration/json_internal.cc
@@ -46,7 +46,7 @@
 #include "arrow/util/decimal.h"
 #include "arrow/util/formatting.h"
 #include "arrow/util/key_value_metadata.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/range.h"
 #include "arrow/util/span.h"
 #include "arrow/util/string.h"

--- a/cpp/src/arrow/io/buffered.cc
+++ b/cpp/src/arrow/io/buffered.cc
@@ -28,7 +28,7 @@
 #include "arrow/io/util_internal.h"
 #include "arrow/memory_pool.h"
 #include "arrow/status.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 namespace io {

--- a/cpp/src/arrow/io/caching.cc
+++ b/cpp/src/arrow/io/caching.cc
@@ -27,7 +27,7 @@
 #include "arrow/io/util_internal.h"
 #include "arrow/result.h"
 #include "arrow/util/future.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 namespace io {

--- a/cpp/src/arrow/io/compressed.cc
+++ b/cpp/src/arrow/io/compressed.cc
@@ -29,7 +29,7 @@
 #include "arrow/memory_pool.h"
 #include "arrow/status.h"
 #include "arrow/util/compression.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 

--- a/cpp/src/arrow/io/file.cc
+++ b/cpp/src/arrow/io/file.cc
@@ -55,7 +55,7 @@
 #include "arrow/status.h"
 #include "arrow/util/future.h"
 #include "arrow/util/io_util.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 

--- a/cpp/src/arrow/io/hdfs.cc
+++ b/cpp/src/arrow/io/hdfs.cc
@@ -36,7 +36,7 @@
 #include "arrow/result.h"
 #include "arrow/status.h"
 #include "arrow/util/io_util.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 using std::size_t;
 

--- a/cpp/src/arrow/io/hdfs_internal.cc
+++ b/cpp/src/arrow/io/hdfs_internal.cc
@@ -46,7 +46,7 @@
 #include "arrow/result.h"
 #include "arrow/status.h"
 #include "arrow/util/io_util.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 

--- a/cpp/src/arrow/io/interfaces.cc
+++ b/cpp/src/arrow/io/interfaces.cc
@@ -38,7 +38,7 @@
 #include "arrow/util/future.h"
 #include "arrow/util/io_util.h"
 #include "arrow/util/iterator.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/thread_pool.h"
 
 namespace arrow {

--- a/cpp/src/arrow/io/memory.cc
+++ b/cpp/src/arrow/io/memory.cc
@@ -29,7 +29,7 @@
 #include "arrow/status.h"
 #include "arrow/util/future.h"
 #include "arrow/util/io_util.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/memory.h"
 

--- a/cpp/src/arrow/io/memory_test.cc
+++ b/cpp/src/arrow/io/memory_test.cc
@@ -45,7 +45,7 @@
 #include "arrow/util/config.h"
 #include "arrow/util/future.h"
 #include "arrow/util/iterator.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/parallel.h"
 
 namespace arrow {

--- a/cpp/src/arrow/io/transform.cc
+++ b/cpp/src/arrow/io/transform.cc
@@ -28,7 +28,7 @@
 #include "arrow/io/util_internal.h"
 #include "arrow/result.h"
 #include "arrow/status.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 namespace io {

--- a/cpp/src/arrow/ipc/dictionary.cc
+++ b/cpp/src/arrow/ipc/dictionary.cc
@@ -33,7 +33,7 @@
 #include "arrow/status.h"
 #include "arrow/type.h"
 #include "arrow/util/checked_cast.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 

--- a/cpp/src/arrow/ipc/feather.cc
+++ b/cpp/src/arrow/ipc/feather.cc
@@ -45,7 +45,7 @@
 #include "arrow/type_traits.h"
 #include "arrow/util/bit_util.h"
 #include "arrow/util/checked_cast.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/visit_type_inline.h"
 
 #include "generated/feather_generated.h"

--- a/cpp/src/arrow/ipc/json_simple.cc
+++ b/cpp/src/arrow/ipc/json_simple.cc
@@ -37,7 +37,7 @@
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/decimal.h"
 #include "arrow/util/float16.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/value_parsing.h"
 
 #include "arrow/json/rapidjson_defs.h"

--- a/cpp/src/arrow/ipc/message.cc
+++ b/cpp/src/arrow/ipc/message.cc
@@ -36,7 +36,7 @@
 #include "arrow/status.h"
 #include "arrow/util/endian.h"
 #include "arrow/util/future.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/ubsan.h"
 
 #include "generated/Message_generated.h"

--- a/cpp/src/arrow/ipc/metadata_internal.cc
+++ b/cpp/src/arrow/ipc/metadata_internal.cc
@@ -37,7 +37,7 @@
 #include "arrow/type_traits.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/key_value_metadata.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/string.h"
 #include "arrow/util/ubsan.h"
 #include "arrow/visit_type_inline.h"

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -53,7 +53,7 @@
 #include "arrow/util/compression.h"
 #include "arrow/util/endian.h"
 #include "arrow/util/key_value_metadata.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/parallel.h"
 #include "arrow/util/string.h"
 #include "arrow/util/thread_pool.h"

--- a/cpp/src/arrow/ipc/test_common.cc
+++ b/cpp/src/arrow/ipc/test_common.cc
@@ -47,7 +47,7 @@
 #include "arrow/util/bitmap_builders.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/key_value_metadata.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/ree_util.h"
 
 namespace arrow {

--- a/cpp/src/arrow/ipc/writer.cc
+++ b/cpp/src/arrow/ipc/writer.cc
@@ -54,7 +54,7 @@
 #include "arrow/util/endian.h"
 #include "arrow/util/int_util_overflow.h"
 #include "arrow/util/key_value_metadata.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/parallel.h"
 #include "arrow/visit_array_inline.h"
 #include "arrow/visit_data_inline.h"

--- a/cpp/src/arrow/json/chunked_builder.cc
+++ b/cpp/src/arrow/json/chunked_builder.cc
@@ -28,7 +28,7 @@
 #include "arrow/json/converter.h"
 #include "arrow/table.h"
 #include "arrow/util/checked_cast.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/task_group.h"
 
 namespace arrow {

--- a/cpp/src/arrow/json/chunker.cc
+++ b/cpp/src/arrow/json/chunker.cc
@@ -27,7 +27,7 @@
 
 #include "arrow/buffer.h"
 #include "arrow/json/options.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 

--- a/cpp/src/arrow/json/converter.cc
+++ b/cpp/src/arrow/json/converter.cc
@@ -30,7 +30,7 @@
 #include "arrow/type.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/decimal.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/value_parsing.h"
 
 namespace arrow {

--- a/cpp/src/arrow/json/parser.cc
+++ b/cpp/src/arrow/json/parser.cc
@@ -37,7 +37,7 @@
 #include "arrow/type.h"
 #include "arrow/util/bitset_stack.h"
 #include "arrow/util/checked_cast.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/trie.h"
 #include "arrow/visit_type_inline.h"
 

--- a/cpp/src/arrow/json/reader.cc
+++ b/cpp/src/arrow/json/reader.cc
@@ -33,7 +33,7 @@
 #include "arrow/util/async_generator.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/iterator.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/task_group.h"
 #include "arrow/util/thread_pool.h"
 

--- a/cpp/src/arrow/memory_pool.cc
+++ b/cpp/src/arrow/memory_pool.cc
@@ -40,7 +40,7 @@
 #include "arrow/util/debug.h"
 #include "arrow/util/int_util_overflow.h"
 #include "arrow/util/io_util.h"
-#include "arrow/util/logging.h"  // IWYU pragma: keep
+#include "arrow/util/logging_internal.h"  // IWYU pragma: keep
 #include "arrow/util/string.h"
 #include "arrow/util/thread_pool.h"
 #include "arrow/util/ubsan.h"

--- a/cpp/src/arrow/memory_pool_jemalloc.cc
+++ b/cpp/src/arrow/memory_pool_jemalloc.cc
@@ -17,7 +17,7 @@
 
 #include "arrow/memory_pool_internal.h"
 #include "arrow/util/io_util.h"
-#include "arrow/util/logging.h"  // IWYU pragma: keep
+#include "arrow/util/logging_internal.h"  // IWYU pragma: keep
 
 // We can't put the jemalloc memory pool implementation into
 // memory_pool.c because jemalloc.h may redefine malloc() and its

--- a/cpp/src/arrow/record_batch.cc
+++ b/cpp/src/arrow/record_batch.cc
@@ -40,7 +40,7 @@
 #include "arrow/tensor.h"
 #include "arrow/type.h"
 #include "arrow/util/iterator.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/vector.h"
 #include "arrow/visit_type_inline.h"
 

--- a/cpp/src/arrow/scalar.cc
+++ b/cpp/src/arrow/scalar.cc
@@ -34,7 +34,7 @@
 #include "arrow/util/decimal.h"
 #include "arrow/util/formatting.h"
 #include "arrow/util/hashing.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/time.h"
 #include "arrow/util/unreachable.h"
 #include "arrow/util/utf8.h"

--- a/cpp/src/arrow/sparse_tensor.cc
+++ b/cpp/src/arrow/sparse_tensor.cc
@@ -26,7 +26,7 @@
 #include "arrow/compare.h"
 #include "arrow/type_traits.h"
 #include "arrow/util/checked_cast.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/visit_type_inline.h"
 
 namespace arrow {

--- a/cpp/src/arrow/sparse_tensor_test.cc
+++ b/cpp/src/arrow/sparse_tensor_test.cc
@@ -32,7 +32,7 @@
 #include "arrow/testing/gtest_util.h"
 #include "arrow/testing/util.h"
 #include "arrow/type.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/sort.h"
 
 namespace arrow {

--- a/cpp/src/arrow/table.cc
+++ b/cpp/src/arrow/table.cc
@@ -39,7 +39,7 @@
 #include "arrow/type_fwd.h"
 #include "arrow/type_traits.h"
 #include "arrow/util/checked_cast.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/vector.h"
 
 namespace arrow {

--- a/cpp/src/arrow/tensor.cc
+++ b/cpp/src/arrow/tensor.cc
@@ -34,7 +34,7 @@
 #include "arrow/type_traits.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/int_util_overflow.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/unreachable.h"
 #include "arrow/visit_type_inline.h"
 

--- a/cpp/src/arrow/testing/generator.cc
+++ b/cpp/src/arrow/testing/generator.cc
@@ -37,7 +37,7 @@
 #include "arrow/type.h"
 #include "arrow/type_traits.h"
 #include "arrow/util/checked_cast.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/string.h"
 

--- a/cpp/src/arrow/testing/gtest_util.cc
+++ b/cpp/src/arrow/testing/gtest_util.cc
@@ -65,7 +65,7 @@
 #include "arrow/util/config.h"
 #include "arrow/util/future.h"
 #include "arrow/util/io_util.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/thread_pool.h"
 #include "arrow/util/windows_compatibility.h"
 

--- a/cpp/src/arrow/testing/math.cc
+++ b/cpp/src/arrow/testing/math.cc
@@ -22,7 +22,7 @@
 
 #include <gtest/gtest.h>
 
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 namespace {

--- a/cpp/src/arrow/testing/random.cc
+++ b/cpp/src/arrow/testing/random.cc
@@ -44,7 +44,7 @@
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/decimal.h"
 #include "arrow/util/key_value_metadata.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/pcg_random.h"
 #include "arrow/util/string.h"
 #include "arrow/util/value_parsing.h"

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -43,7 +43,7 @@
 #include "arrow/util/hash_util.h"
 #include "arrow/util/hashing.h"
 #include "arrow/util/key_value_metadata.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/range.h"
 #include "arrow/util/string.h"
 #include "arrow/util/unreachable.h"

--- a/cpp/src/arrow/type_traits.cc
+++ b/cpp/src/arrow/type_traits.cc
@@ -17,7 +17,7 @@
 
 #include "arrow/type_traits.h"
 
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 

--- a/cpp/src/arrow/util/async_util.cc
+++ b/cpp/src/arrow/util/async_util.cc
@@ -18,7 +18,7 @@
 #include "arrow/util/async_util.h"
 
 #include "arrow/util/future.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/string.h"
 #include "arrow/util/tracing_internal.h"
 

--- a/cpp/src/arrow/util/atfork_internal.cc
+++ b/cpp/src/arrow/util/atfork_internal.cc
@@ -27,7 +27,7 @@
 #endif
 
 #include "arrow/util/io_util.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 namespace internal {

--- a/cpp/src/arrow/util/basic_decimal.cc
+++ b/cpp/src/arrow/util/basic_decimal.cc
@@ -33,7 +33,7 @@
 #include "arrow/util/endian.h"
 #include "arrow/util/int128_internal.h"
 #include "arrow/util/int_util_overflow.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/macros.h"
 
 namespace arrow {

--- a/cpp/src/arrow/util/bit_stream_utils_internal.h
+++ b/cpp/src/arrow/util/bit_stream_utils_internal.h
@@ -207,9 +207,9 @@ class BitReader {
 };
 
 inline bool BitWriter::PutValue(uint64_t v, int num_bits) {
-  DCHECK_LE(num_bits, 64);
+  ARROW_DCHECK_LE(num_bits, 64);
   if (num_bits < 64) {
-    DCHECK_EQ(v >> num_bits, 0) << "v = " << v << ", num_bits = " << num_bits;
+    ARROW_DCHECK_EQ(v >> num_bits, 0) << "v = " << v << ", num_bits = " << num_bits;
   }
 
   if (ARROW_PREDICT_FALSE(byte_offset_ * 8 + bit_offset_ + num_bits > max_bytes_ * 8))
@@ -228,13 +228,13 @@ inline bool BitWriter::PutValue(uint64_t v, int num_bits) {
     buffered_values_ =
         (num_bits - bit_offset_ == 64) ? 0 : (v >> (num_bits - bit_offset_));
   }
-  DCHECK_LT(bit_offset_, 64);
+  ARROW_DCHECK_LT(bit_offset_, 64);
   return true;
 }
 
 inline void BitWriter::Flush(bool align) {
   int num_bytes = static_cast<int>(bit_util::BytesForBits(bit_offset_));
-  DCHECK_LE(byte_offset_ + num_bytes, max_bytes_);
+  ARROW_DCHECK_LE(byte_offset_ + num_bytes, max_bytes_);
   auto buffered_values = arrow::bit_util::ToLittleEndian(buffered_values_);
   memcpy(buffer_ + byte_offset_, &buffered_values, num_bytes);
 
@@ -247,7 +247,7 @@ inline void BitWriter::Flush(bool align) {
 
 inline uint8_t* BitWriter::GetNextBytePtr(int num_bytes) {
   Flush(/* align */ true);
-  DCHECK_LE(byte_offset_, max_bytes_);
+  ARROW_DCHECK_LE(byte_offset_, max_bytes_);
   if (byte_offset_ + num_bytes > max_bytes_) return NULL;
   uint8_t* ptr = buffer_ + byte_offset_;
   byte_offset_ += num_bytes;
@@ -299,7 +299,7 @@ inline void GetValue_(int num_bits, T* v, int max_bytes, const uint8_t* buffer,
 #ifdef _MSC_VER
 #  pragma warning(pop)
 #endif
-    DCHECK_LE(*bit_offset, 64);
+    ARROW_DCHECK_LE(*bit_offset, 64);
   }
 }
 
@@ -312,8 +312,8 @@ inline bool BitReader::GetValue(int num_bits, T* v) {
 
 template <typename T>
 inline int BitReader::GetBatch(int num_bits, T* v, int batch_size) {
-  DCHECK(buffer_ != NULL);
-  DCHECK_LE(num_bits, static_cast<int>(sizeof(T) * 8)) << "num_bits: " << num_bits;
+  ARROW_DCHECK(buffer_ != NULL);
+  ARROW_DCHECK_LE(num_bits, static_cast<int>(sizeof(T) * 8)) << "num_bits: " << num_bits;
 
   int bit_offset = bit_offset_;
   int byte_offset = byte_offset_;
@@ -354,7 +354,7 @@ inline int BitReader::GetBatch(int num_bits, T* v, int batch_size) {
     byte_offset += num_unpacked * num_bits / 8;
   } else {
     // TODO: revisit this limit if necessary
-    DCHECK_LE(num_bits, 32);
+    ARROW_DCHECK_LE(num_bits, 32);
     const int buffer_size = 1024;
     uint32_t unpack_buffer[buffer_size];
     while (i < batch_size) {

--- a/cpp/src/arrow/util/bit_util.cc
+++ b/cpp/src/arrow/util/bit_util.cc
@@ -20,7 +20,7 @@
 #include <cstdint>
 #include <cstring>
 
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 namespace bit_util {

--- a/cpp/src/arrow/util/bitmap.cc
+++ b/cpp/src/arrow/util/bitmap.cc
@@ -25,7 +25,7 @@
 #include "arrow/array/array_primitive.h"
 #include "arrow/buffer.h"
 #include "arrow/util/bitmap_ops.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 namespace internal {

--- a/cpp/src/arrow/util/bitmap_ops.cc
+++ b/cpp/src/arrow/util/bitmap_ops.cc
@@ -29,7 +29,7 @@
 #include "arrow/util/bit_util.h"
 #include "arrow/util/bitmap_reader.h"
 #include "arrow/util/bitmap_writer.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 namespace internal {

--- a/cpp/src/arrow/util/bpacking.cc
+++ b/cpp/src/arrow/util/bpacking.cc
@@ -21,7 +21,7 @@
 #include "arrow/util/bpacking_default.h"
 #include "arrow/util/cpu_info.h"
 #include "arrow/util/dispatch.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 #if defined(ARROW_HAVE_RUNTIME_AVX2)
 #  include "arrow/util/bpacking_avx2.h"

--- a/cpp/src/arrow/util/bpacking_simd_internal.h
+++ b/cpp/src/arrow/util/bpacking_simd_internal.h
@@ -128,7 +128,7 @@ static int unpack32_specialized(const uint32_t* in, uint32_t* out, int batch_siz
       for (int i = 0; i < num_loops; ++i) in = UnpackBits::unpack32_32(in, out + i * 32);
       break;
     default:
-      DCHECK(false) << "Unsupported num_bits";
+      ARROW_DCHECK(false) << "Unsupported num_bits";
   }
 
   return batch_size;

--- a/cpp/src/arrow/util/byte_size.cc
+++ b/cpp/src/arrow/util/byte_size.cc
@@ -26,7 +26,7 @@
 #include "arrow/chunked_array.h"
 #include "arrow/record_batch.h"
 #include "arrow/table.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/ree_util.h"
 #include "arrow/visit_type_inline.h"
 

--- a/cpp/src/arrow/util/cache_internal.h
+++ b/cpp/src/arrow/util/cache_internal.h
@@ -53,7 +53,7 @@ class LruCache {
   }
 
   int32_t size() const {
-    DCHECK_EQ(items_.size(), map_.size());
+    ARROW_DCHECK_EQ(items_.size(), map_.size());
     return static_cast<int32_t>(items_.size());
   }
 
@@ -83,7 +83,7 @@ class LruCache {
       // Did we exceed the cache capacity?  If so, remove least recently used item
       if (static_cast<int32_t>(items_.size()) > capacity_) {
         const bool erased = map_.erase(*items_.back().key);
-        DCHECK(erased);
+        ARROW_DCHECK(erased);
         ARROW_UNUSED(erased);
         items_.pop_back();
       }

--- a/cpp/src/arrow/util/cancel.cc
+++ b/cpp/src/arrow/util/cancel.cc
@@ -26,7 +26,7 @@
 #include "arrow/result.h"
 #include "arrow/util/atfork_internal.h"
 #include "arrow/util/io_util.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/mutex.h"
 #include "arrow/util/visibility.h"
 

--- a/cpp/src/arrow/util/compression.cc
+++ b/cpp/src/arrow/util/compression.cc
@@ -25,7 +25,7 @@
 #include "arrow/status.h"
 #include "arrow/util/compression_internal.h"
 #include "arrow/util/config.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 namespace util {

--- a/cpp/src/arrow/util/compression_brotli.cc
+++ b/cpp/src/arrow/util/compression_brotli.cc
@@ -27,7 +27,7 @@
 
 #include "arrow/result.h"
 #include "arrow/status.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/macros.h"
 
 namespace arrow {

--- a/cpp/src/arrow/util/compression_bz2.cc
+++ b/cpp/src/arrow/util/compression_bz2.cc
@@ -31,7 +31,7 @@
 
 #include "arrow/result.h"
 #include "arrow/status.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/macros.h"
 
 namespace arrow {

--- a/cpp/src/arrow/util/compression_lz4.cc
+++ b/cpp/src/arrow/util/compression_lz4.cc
@@ -29,7 +29,7 @@
 #include "arrow/status.h"
 #include "arrow/util/bit_util.h"
 #include "arrow/util/endian.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/ubsan.h"
 

--- a/cpp/src/arrow/util/compression_snappy.cc
+++ b/cpp/src/arrow/util/compression_snappy.cc
@@ -25,7 +25,7 @@
 
 #include "arrow/result.h"
 #include "arrow/status.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/macros.h"
 
 using std::size_t;

--- a/cpp/src/arrow/util/compression_zlib.cc
+++ b/cpp/src/arrow/util/compression_zlib.cc
@@ -28,7 +28,7 @@
 
 #include "arrow/result.h"
 #include "arrow/status.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/macros.h"
 
 namespace arrow {

--- a/cpp/src/arrow/util/compression_zstd.cc
+++ b/cpp/src/arrow/util/compression_zstd.cc
@@ -25,7 +25,7 @@
 
 #include "arrow/result.h"
 #include "arrow/status.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/macros.h"
 
 using std::size_t;

--- a/cpp/src/arrow/util/cpu_info.cc
+++ b/cpp/src/arrow/util/cpu_info.cc
@@ -47,7 +47,7 @@
 
 #include "arrow/result.h"
 #include "arrow/util/io_util.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/string.h"
 
 #undef CPUINFO_ARCH_X86

--- a/cpp/src/arrow/util/decimal.cc
+++ b/cpp/src/arrow/util/decimal.cc
@@ -35,7 +35,7 @@
 #include "arrow/util/formatting.h"
 #include "arrow/util/int128_internal.h"
 #include "arrow/util/int_util_overflow.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/value_parsing.h"
 

--- a/cpp/src/arrow/util/delimiting.cc
+++ b/cpp/src/arrow/util/delimiting.cc
@@ -17,7 +17,7 @@
 
 #include "arrow/util/delimiting.h"
 #include "arrow/buffer.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 

--- a/cpp/src/arrow/util/fixed_width_internal.cc
+++ b/cpp/src/arrow/util/fixed_width_internal.cc
@@ -25,7 +25,7 @@
 #include "arrow/type.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/fixed_width_internal.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/small_vector.h"
 
 namespace arrow::util {

--- a/cpp/src/arrow/util/formatting.cc
+++ b/cpp/src/arrow/util/formatting.cc
@@ -19,7 +19,7 @@
 #include "arrow/util/config.h"
 #include "arrow/util/double_conversion.h"
 #include "arrow/util/float16.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 

--- a/cpp/src/arrow/util/future.cc
+++ b/cpp/src/arrow/util/future.cc
@@ -26,7 +26,7 @@
 
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/config.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/thread_pool.h"
 #include "arrow/util/tracing_internal.h"
 

--- a/cpp/src/arrow/util/hashing.cc
+++ b/cpp/src/arrow/util/hashing.cc
@@ -18,6 +18,7 @@
 #include "arrow/util/hashing.h"
 #include "arrow/util/bit_util.h"
 #include "arrow/util/bitmap_reader.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/macros.h"
 
 namespace arrow {

--- a/cpp/src/arrow/util/hashing.h
+++ b/cpp/src/arrow/util/hashing.h
@@ -226,14 +226,14 @@ class HashTable {
   };
 
   HashTable(MemoryPool* pool, uint64_t capacity) : entries_builder_(pool) {
-    DCHECK_NE(pool, nullptr);
+    ARROW_DCHECK_NE(pool, nullptr);
     // Minimum of 32 elements
     capacity = std::max<uint64_t>(capacity, 32UL);
     capacity_ = bit_util::NextPower2(capacity);
     capacity_mask_ = capacity_ - 1;
     size_ = 0;
 
-    DCHECK_OK(UpsizeBuffer(capacity_));
+    ARROW_DCHECK_OK(UpsizeBuffer(capacity_));
   }
 
   // Lookup with non-linear probing
@@ -511,7 +511,7 @@ class ScalarMemoTable : public MemoTable {
 
     other_hashtable.VisitEntries([this](const HashTableEntry* other_entry) {
       int32_t unused;
-      DCHECK_OK(this->GetOrInsert(other_entry->payload.value, &unused));
+      ARROW_DCHECK_OK(this->GetOrInsert(other_entry->payload.value, &unused));
     });
     // TODO: ARROW-17074 - implement proper error handling
     return Status::OK();
@@ -562,7 +562,7 @@ class SmallScalarMemoTable : public MemoTable {
       memo_index = static_cast<int32_t>(index_to_value_.size());
       index_to_value_.push_back(value);
       value_to_index_[value_index] = memo_index;
-      DCHECK_LT(memo_index, cardinality + 1);
+      ARROW_DCHECK_LT(memo_index, cardinality + 1);
       on_not_found(memo_index);
     } else {
       on_found(memo_index);
@@ -610,8 +610,8 @@ class SmallScalarMemoTable : public MemoTable {
 
   // Copy values starting from index `start` into `out_data`
   void CopyValues(int32_t start, Scalar* out_data) const {
-    DCHECK_GE(start, 0);
-    DCHECK_LE(static_cast<size_t>(start), index_to_value_.size());
+    ARROW_DCHECK_GE(start, 0);
+    ARROW_DCHECK_LE(static_cast<size_t>(start), index_to_value_.size());
     int64_t offset = start * static_cast<int32_t>(sizeof(Scalar));
     memcpy(out_data, index_to_value_.data() + offset, (size() - start) * sizeof(Scalar));
   }
@@ -644,8 +644,8 @@ class BinaryMemoTable : public MemoTable {
                            int64_t values_size = -1)
       : hash_table_(pool, static_cast<uint64_t>(entries)), binary_builder_(pool) {
     const int64_t data_size = (values_size < 0) ? entries * 4 : values_size;
-    DCHECK_OK(binary_builder_.Resize(entries));
-    DCHECK_OK(binary_builder_.ReserveData(data_size));
+    ARROW_DCHECK_OK(binary_builder_.Resize(entries));
+    ARROW_DCHECK_OK(binary_builder_.ReserveData(data_size));
   }
 
   int32_t Get(const void* data, builder_offset_type length) const {
@@ -711,7 +711,7 @@ class BinaryMemoTable : public MemoTable {
     int32_t memo_index = GetNull();
     if (memo_index == kKeyNotFound) {
       memo_index = null_index_ = size();
-      DCHECK_OK(binary_builder_.AppendNull());
+      ARROW_DCHECK_OK(binary_builder_.AppendNull());
       on_not_found(memo_index);
     } else {
       on_found(memo_index);
@@ -734,7 +734,7 @@ class BinaryMemoTable : public MemoTable {
   // Copy (n + 1) offsets starting from index `start` into `out_data`
   template <class Offset>
   void CopyOffsets(int32_t start, Offset* out_data) const {
-    DCHECK_LE(start, size());
+    ARROW_DCHECK_LE(start, size());
 
     const builder_offset_type* offsets = binary_builder_.offsets_data();
     const builder_offset_type delta =
@@ -763,7 +763,7 @@ class BinaryMemoTable : public MemoTable {
 
   // Same as above, but check output size in debug mode
   void CopyValues(int32_t start, int64_t out_size, uint8_t* out_data) const {
-    DCHECK_LE(start, size());
+    ARROW_DCHECK_LE(start, size());
 
     // The absolute byte offset of `start` value in the binary buffer.
     const builder_offset_type offset = binary_builder_.offset(start);
@@ -877,7 +877,7 @@ class BinaryMemoTable : public MemoTable {
   Status MergeTable(const BinaryMemoTable& other_table) {
     other_table.VisitValues(0, [this](std::string_view other_value) {
       int32_t unused;
-      DCHECK_OK(this->GetOrInsert(other_value, &unused));
+      ARROW_DCHECK_OK(this->GetOrInsert(other_value, &unused));
     });
     return Status::OK();
   }

--- a/cpp/src/arrow/util/hashing_test.cc
+++ b/cpp/src/arrow/util/hashing_test.cc
@@ -33,7 +33,7 @@
 #include "arrow/testing/gtest_util.h"
 #include "arrow/util/bit_util.h"
 #include "arrow/util/hashing.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 namespace internal {

--- a/cpp/src/arrow/util/io_util.cc
+++ b/cpp/src/arrow/util/io_util.cc
@@ -97,7 +97,7 @@
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/config.h"
 #include "arrow/util/io_util.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/mutex.h"
 
 // For filename conversion

--- a/cpp/src/arrow/util/key_value_metadata.cc
+++ b/cpp/src/arrow/util/key_value_metadata.cc
@@ -29,7 +29,7 @@
 #include "arrow/result.h"
 #include "arrow/status.h"
 #include "arrow/util/key_value_metadata.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/sort.h"
 
 using std::size_t;

--- a/cpp/src/arrow/util/list_util.cc
+++ b/cpp/src/arrow/util/list_util.cc
@@ -26,7 +26,7 @@
 #include "arrow/util/bit_run_reader.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/list_util.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/string.h"
 
 namespace arrow::list_util {

--- a/cpp/src/arrow/util/logger.cc
+++ b/cpp/src/arrow/util/logger.cc
@@ -21,6 +21,7 @@
 #include <unordered_map>
 
 #include "arrow/util/logger.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 namespace util {

--- a/cpp/src/arrow/util/logging.h
+++ b/cpp/src/arrow/util/logging.h
@@ -24,14 +24,14 @@
 
 #  define ARROW_IGNORE_EXPR(expr) ((void)(expr))
 
-#  define DCHECK(condition) ARROW_IGNORE_EXPR(condition)
-#  define DCHECK_OK(status) ARROW_IGNORE_EXPR(status)
-#  define DCHECK_EQ(val1, val2) ARROW_IGNORE_EXPR(val1)
-#  define DCHECK_NE(val1, val2) ARROW_IGNORE_EXPR(val1)
-#  define DCHECK_LE(val1, val2) ARROW_IGNORE_EXPR(val1)
-#  define DCHECK_LT(val1, val2) ARROW_IGNORE_EXPR(val1)
-#  define DCHECK_GE(val1, val2) ARROW_IGNORE_EXPR(val1)
-#  define DCHECK_GT(val1, val2) ARROW_IGNORE_EXPR(val1)
+#  define ARROW_DCHECK(condition) ARROW_IGNORE_EXPR(condition)
+#  define ARROW_DCHECK_OK(status) ARROW_IGNORE_EXPR(status)
+#  define ARROW_DCHECK_EQ(val1, val2) ARROW_IGNORE_EXPR(val1)
+#  define ARROW_DCHECK_NE(val1, val2) ARROW_IGNORE_EXPR(val1)
+#  define ARROW_DCHECK_LE(val1, val2) ARROW_IGNORE_EXPR(val1)
+#  define ARROW_DCHECK_LT(val1, val2) ARROW_IGNORE_EXPR(val1)
+#  define ARROW_DCHECK_GE(val1, val2) ARROW_IGNORE_EXPR(val1)
+#  define ARROW_DCHECK_GT(val1, val2) ARROW_IGNORE_EXPR(val1)
 
 #else  // !GANDIVA_IR
 
@@ -137,32 +137,6 @@ enum class ArrowLogLevel : int {
 #    define ARROW_DCHECK_GT ARROW_CHECK_GT
 
 #  endif  // NDEBUG
-
-// These are internal-use macros and should not be used in public headers.
-#  ifndef DCHECK
-#    define DCHECK ARROW_DCHECK
-#  endif
-#  ifndef DCHECK_OK
-#    define DCHECK_OK ARROW_DCHECK_OK
-#  endif
-#  ifndef DCHECK_EQ
-#    define DCHECK_EQ ARROW_DCHECK_EQ
-#  endif
-#  ifndef DCHECK_NE
-#    define DCHECK_NE ARROW_DCHECK_NE
-#  endif
-#  ifndef DCHECK_LE
-#    define DCHECK_LE ARROW_DCHECK_LE
-#  endif
-#  ifndef DCHECK_LT
-#    define DCHECK_LT ARROW_DCHECK_LT
-#  endif
-#  ifndef DCHECK_GE
-#    define DCHECK_GE ARROW_DCHECK_GE
-#  endif
-#  ifndef DCHECK_GT
-#    define DCHECK_GT ARROW_DCHECK_GT
-#  endif
 
 // This code is adapted from
 // https://github.com/ray-project/ray/blob/master/src/ray/util/logging.h.

--- a/cpp/src/arrow/util/logging_internal.h
+++ b/cpp/src/arrow/util/logging_internal.h
@@ -15,22 +15,32 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include "arrow/util/unreachable.h"
+#include "arrow/util/logging.h"
 
-#include "arrow/util/logging_internal.h"
+#pragma once
 
-#include <string_view>
-
-namespace arrow {
-
-[[noreturn]] void Unreachable(const char* message) {
-  DCHECK(false) << message;
-  std::abort();
-}
-
-[[noreturn]] void Unreachable(std::string_view message) {
-  DCHECK(false) << message;
-  std::abort();
-}
-
-}  // namespace arrow
+// These are internal-use macros and should not be used in public headers.
+#ifndef DCHECK
+#  define DCHECK ARROW_DCHECK
+#endif
+#ifndef DCHECK_OK
+#  define DCHECK_OK ARROW_DCHECK_OK
+#endif
+#ifndef DCHECK_EQ
+#  define DCHECK_EQ ARROW_DCHECK_EQ
+#endif
+#ifndef DCHECK_NE
+#  define DCHECK_NE ARROW_DCHECK_NE
+#endif
+#ifndef DCHECK_LE
+#  define DCHECK_LE ARROW_DCHECK_LE
+#endif
+#ifndef DCHECK_LT
+#  define DCHECK_LT ARROW_DCHECK_LT
+#endif
+#ifndef DCHECK_GE
+#  define DCHECK_GE ARROW_DCHECK_GE
+#endif
+#ifndef DCHECK_GT
+#  define DCHECK_GT ARROW_DCHECK_GT
+#endif

--- a/cpp/src/arrow/util/logging_test.cc
+++ b/cpp/src/arrow/util/logging_test.cc
@@ -21,7 +21,7 @@
 
 #include <gtest/gtest.h>
 
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 // This code is adapted from
 // https://github.com/ray-project/ray/blob/master/src/ray/util/logging_test.cc.

--- a/cpp/src/arrow/util/math_internal.cc
+++ b/cpp/src/arrow/util/math_internal.cc
@@ -19,7 +19,7 @@
 
 #include <cmath>
 
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow::internal {
 

--- a/cpp/src/arrow/util/mutex.cc
+++ b/cpp/src/arrow/util/mutex.cc
@@ -25,7 +25,7 @@
 #endif
 
 #include "arrow/util/config.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 namespace util {

--- a/cpp/src/arrow/util/ree_util.cc
+++ b/cpp/src/arrow/util/ree_util.cc
@@ -20,7 +20,7 @@
 
 #include "arrow/builder.h"
 #include "arrow/util/bit_util.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/ree_util.h"
 
 namespace arrow {

--- a/cpp/src/arrow/util/ree_util_test.cc
+++ b/cpp/src/arrow/util/ree_util_test.cc
@@ -22,7 +22,7 @@
 #include "arrow/compute/api_vector.h"
 #include "arrow/testing/gtest_util.h"
 #include "arrow/type_traits.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/ree_util.h"
 
 namespace arrow {

--- a/cpp/src/arrow/util/task_group.cc
+++ b/cpp/src/arrow/util/task_group.cc
@@ -25,7 +25,7 @@
 
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/config.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/thread_pool.h"
 
 namespace arrow {

--- a/cpp/src/arrow/util/tdigest.cc
+++ b/cpp/src/arrow/util/tdigest.cc
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include "arrow/status.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/math_constants.h"
 
 namespace arrow {

--- a/cpp/src/arrow/util/thread_pool.cc
+++ b/cpp/src/arrow/util/thread_pool.cc
@@ -29,7 +29,7 @@
 #include "arrow/util/atfork_internal.h"
 #include "arrow/util/config.h"
 #include "arrow/util/io_util.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/mutex.h"
 
 #include "arrow/util/tracing_internal.h"

--- a/cpp/src/arrow/util/trie.cc
+++ b/cpp/src/arrow/util/trie.cc
@@ -20,7 +20,7 @@
 #include <iostream>
 #include <utility>
 
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow {
 namespace internal {

--- a/cpp/src/arrow/util/union_util.cc
+++ b/cpp/src/arrow/util/union_util.cc
@@ -21,7 +21,7 @@
 
 #include "arrow/array/data.h"
 #include "arrow/util/checked_cast.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 namespace arrow::union_util {
 

--- a/cpp/src/arrow/util/utf8.cc
+++ b/cpp/src/arrow/util/utf8.cc
@@ -24,7 +24,7 @@
 #include <utility>
 
 #include "arrow/result.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/utf8_internal.h"
 #include "arrow/vendored/utfcpp/checked.h"
 

--- a/cpp/src/gandiva/decimal_ir.cc
+++ b/cpp/src/gandiva/decimal_ir.cc
@@ -20,6 +20,7 @@
 #include <utility>
 
 #include "arrow/status.h"
+#include "arrow/util/logging_internal.h"
 #include "gandiva/decimal_ir.h"
 #include "gandiva/decimal_type_util.h"
 

--- a/cpp/src/gandiva/decimal_type_util.cc
+++ b/cpp/src/gandiva/decimal_type_util.cc
@@ -16,7 +16,7 @@
 // under the License.
 
 #include "gandiva/decimal_type_util.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 namespace gandiva {
 

--- a/cpp/src/gandiva/decimal_xlarge.cc
+++ b/cpp/src/gandiva/decimal_xlarge.cc
@@ -29,7 +29,7 @@
 #include <vector>
 
 #include "arrow/util/basic_decimal.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "gandiva/decimal_type_util.h"
 
 #ifndef GANDIVA_UNIT_TEST

--- a/cpp/src/gandiva/engine.cc
+++ b/cpp/src/gandiva/engine.cc
@@ -32,7 +32,7 @@
 #include <utility>
 
 #include <arrow/util/io_util.h>
-#include <arrow/util/logging.h>
+#include <arrow/util/logging_internal.h>
 
 #if defined(_MSC_VER)
 #  pragma warning(push)

--- a/cpp/src/gandiva/expr_decomposer.cc
+++ b/cpp/src/gandiva/expr_decomposer.cc
@@ -23,6 +23,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "arrow/util/logging_internal.h"
 #include "gandiva/annotator.h"
 #include "gandiva/dex.h"
 #include "gandiva/function_holder_maker_registry.h"

--- a/cpp/src/gandiva/expression_registry.cc
+++ b/cpp/src/gandiva/expression_registry.cc
@@ -17,6 +17,7 @@
 
 #include "gandiva/expression_registry.h"
 
+#include "arrow/util/logging_internal.h"
 #include "gandiva/function_registry.h"
 #include "gandiva/llvm_types.h"
 

--- a/cpp/src/gandiva/function_ir_builder.cc
+++ b/cpp/src/gandiva/function_ir_builder.cc
@@ -17,6 +17,8 @@
 
 #include "gandiva/function_ir_builder.h"
 
+#include "arrow/util/logging_internal.h"
+
 namespace gandiva {
 
 llvm::Value* FunctionIRBuilder::BuildIfElse(llvm::Value* condition,

--- a/cpp/src/gandiva/function_signature.cc
+++ b/cpp/src/gandiva/function_signature.cc
@@ -25,7 +25,7 @@
 
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/hash_util.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/string.h"
 
 using arrow::internal::AsciiEqualsCaseInsensitive;

--- a/cpp/src/gandiva/hash_utils.cc
+++ b/cpp/src/gandiva/hash_utils.cc
@@ -17,7 +17,7 @@
 
 #include "gandiva/hash_utils.h"
 #include <cstring>
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "gandiva/gdv_function_stubs.h"
 #include "openssl/evp.h"
 

--- a/cpp/src/gandiva/llvm_generator.cc
+++ b/cpp/src/gandiva/llvm_generator.cc
@@ -21,6 +21,7 @@
 #include <utility>
 #include <vector>
 
+#include "arrow/util/logging_internal.h"
 #include "gandiva/bitmap_accumulator.h"
 #include "gandiva/decimal_ir.h"
 #include "gandiva/dex.h"

--- a/cpp/src/gandiva/precompiled/decimal_ops.cc
+++ b/cpp/src/gandiva/precompiled/decimal_ops.cc
@@ -23,7 +23,7 @@
 #include <cmath>
 #include <limits>
 
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "gandiva/decimal_type_util.h"
 #include "gandiva/decimal_xlarge.h"
 #include "gandiva/gdv_function_stubs.h"

--- a/cpp/src/gandiva/precompiled/extended_math_ops.cc
+++ b/cpp/src/gandiva/precompiled/extended_math_ops.cc
@@ -19,7 +19,7 @@
 #  define M_PI 3.14159265358979323846
 #endif
 
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "gandiva/precompiled/decimal_ops.h"
 
 extern "C" {

--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -16,7 +16,7 @@
 // under the License.
 
 // String functions
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/value_parsing.h"
 
 extern "C" {

--- a/cpp/src/gandiva/precompiled/testing.h
+++ b/cpp/src/gandiva/precompiled/testing.h
@@ -35,7 +35,7 @@ static inline gdv_timestamp StringToTimestamp(const std::string& s) {
   bool success = ::arrow::internal::ParseTimestampStrptime(
       s.c_str(), s.length(), "%Y-%m-%d %H:%M:%S", /*ignore_time_in_day=*/false,
       /*allow_trailing_chars=*/false, ::arrow::TimeUnit::SECOND, &out);
-  DCHECK(success);
+  ARROW_DCHECK(success);
   ARROW_UNUSED(success);
   return out * 1000;
 }

--- a/cpp/src/gandiva/precompiled/time_test.cc
+++ b/cpp/src/gandiva/precompiled/time_test.cc
@@ -17,6 +17,7 @@
 
 #include <gtest/gtest.h>
 
+#include "arrow/util/logging_internal.h"
 #include "gandiva/execution_context.h"
 #include "gandiva/precompiled/testing.h"
 #include "gandiva/precompiled/time_constants.h"

--- a/cpp/src/gandiva/tests/decimal_test.cc
+++ b/cpp/src/gandiva/tests/decimal_test.cc
@@ -21,6 +21,7 @@
 #include "arrow/memory_pool.h"
 #include "arrow/status.h"
 #include "arrow/util/decimal.h"
+#include "arrow/util/logging_internal.h"
 
 #include "gandiva/decimal_type_util.h"
 #include "gandiva/projector.h"

--- a/cpp/src/gandiva/tests/in_expr_test.cc
+++ b/cpp/src/gandiva/tests/in_expr_test.cc
@@ -19,6 +19,7 @@
 #include <cmath>
 
 #include "arrow/memory_pool.h"
+#include "arrow/util/logging_internal.h"
 #include "gandiva/filter.h"
 #include "gandiva/function_registry_common.h"
 #include "gandiva/tests/test_util.h"

--- a/cpp/src/gandiva/tests/test_util.cc
+++ b/cpp/src/gandiva/tests/test_util.cc
@@ -21,7 +21,7 @@
 #include <utility>
 
 #include "arrow/util/io_util.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "gandiva/function_holder.h"
 #include "gandiva/gdv_function_stubs.h"
 

--- a/cpp/src/gandiva/tests/utf8_test.cc
+++ b/cpp/src/gandiva/tests/utf8_test.cc
@@ -18,6 +18,7 @@
 #include <gtest/gtest.h>
 #include "arrow/memory_pool.h"
 #include "arrow/status.h"
+#include "arrow/util/logging_internal.h"
 
 #include "gandiva/projector.h"
 #include "gandiva/tests/test_util.h"

--- a/cpp/src/gandiva/tree_expr_test.cc
+++ b/cpp/src/gandiva/tree_expr_test.cc
@@ -18,6 +18,7 @@
 #include "gandiva/tree_expr_builder.h"
 
 #include <gtest/gtest.h>
+#include "arrow/util/logging_internal.h"
 #include "gandiva/annotator.h"
 #include "gandiva/dex.h"
 #include "gandiva/expr_decomposer.h"

--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -52,7 +52,7 @@
 #include "arrow/util/decimal.h"
 #include "arrow/util/future.h"
 #include "arrow/util/key_value_metadata.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/range.h"
 
 #ifdef ARROW_CSV

--- a/cpp/src/parquet/arrow/path_internal.cc
+++ b/cpp/src/parquet/arrow/path_internal.cc
@@ -102,7 +102,7 @@
 #include "arrow/util/bit_run_reader.h"
 #include "arrow/util/bit_util.h"
 #include "arrow/util/bitmap_visit.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/macros.h"
 #include "arrow/visit_array_inline.h"
 

--- a/cpp/src/parquet/arrow/reader.cc
+++ b/cpp/src/parquet/arrow/reader.cc
@@ -35,7 +35,7 @@
 #include "arrow/util/bit_util.h"
 #include "arrow/util/future.h"
 #include "arrow/util/iterator.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/parallel.h"
 #include "arrow/util/range.h"
 #include "arrow/util/tracing_internal.h"

--- a/cpp/src/parquet/arrow/reader_internal.cc
+++ b/cpp/src/parquet/arrow/reader_internal.cc
@@ -44,7 +44,7 @@
 #include "arrow/util/endian.h"
 #include "arrow/util/float16.h"
 #include "arrow/util/int_util_overflow.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/ubsan.h"
 
 #include "parquet/arrow/reader.h"

--- a/cpp/src/parquet/arrow/reconstruct_internal_test.cc
+++ b/cpp/src/parquet/arrow/reconstruct_internal_test.cc
@@ -33,7 +33,7 @@
 #include "arrow/testing/gtest_util.h"
 #include "arrow/type_fwd.h"
 #include "arrow/util/checked_cast.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 #include "parquet/arrow/reader.h"
 #include "parquet/arrow/schema.h"

--- a/cpp/src/parquet/arrow/schema.cc
+++ b/cpp/src/parquet/arrow/schema.cc
@@ -30,7 +30,7 @@
 #include "arrow/util/base64.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/key_value_metadata.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/string.h"
 #include "arrow/util/value_parsing.h"
 

--- a/cpp/src/parquet/arrow/writer.cc
+++ b/cpp/src/parquet/arrow/writer.cc
@@ -34,7 +34,7 @@
 #include "arrow/util/base64.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/key_value_metadata.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/parallel.h"
 
 #include "parquet/arrow/path_internal.h"

--- a/cpp/src/parquet/bloom_filter.cc
+++ b/cpp/src/parquet/bloom_filter.cc
@@ -20,7 +20,7 @@
 #include <memory>
 
 #include "arrow/result.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/macros.h"
 
 #include "generated/parquet_types.h"

--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -41,7 +41,7 @@
 #include "arrow/util/endian.h"
 #include "arrow/util/float16.h"
 #include "arrow/util/key_value_metadata.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/rle_encoding_internal.h"
 #include "arrow/util/type_traits.h"
 #include "arrow/visit_array_inline.h"

--- a/cpp/src/parquet/decoder.cc
+++ b/cpp/src/parquet/decoder.cc
@@ -39,7 +39,7 @@
 #include "arrow/util/byte_stream_split_internal.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/int_util_overflow.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/rle_encoding_internal.h"
 #include "arrow/util/spaced.h"
 #include "arrow/util/ubsan.h"

--- a/cpp/src/parquet/encoder.cc
+++ b/cpp/src/parquet/encoder.cc
@@ -37,7 +37,7 @@
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/hashing.h"
 #include "arrow/util/int_util_overflow.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/rle_encoding_internal.h"
 #include "arrow/util/spaced.h"
 #include "arrow/util/ubsan.h"

--- a/cpp/src/parquet/encryption/encryption.cc
+++ b/cpp/src/parquet/encryption/encryption.cc
@@ -22,7 +22,7 @@
 #include <map>
 #include <utility>
 
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/utf8.h"
 #include "parquet/encryption/encryption_internal.h"
 

--- a/cpp/src/parquet/file_deserialize_test.cc
+++ b/cpp/src/parquet/file_deserialize_test.cc
@@ -39,6 +39,7 @@
 #include "arrow/util/compression.h"
 #include "arrow/util/config.h"
 #include "arrow/util/crc32.h"
+#include "arrow/util/logging_internal.h"
 
 namespace parquet {
 

--- a/cpp/src/parquet/file_writer.cc
+++ b/cpp/src/parquet/file_writer.cc
@@ -24,7 +24,7 @@
 #include <vector>
 
 #include "arrow/util/key_value_metadata.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "parquet/column_writer.h"
 #include "parquet/encryption/encryption_internal.h"
 #include "parquet/encryption/internal_file_encryptor.h"

--- a/cpp/src/parquet/metadata.cc
+++ b/cpp/src/parquet/metadata.cc
@@ -30,7 +30,7 @@
 
 #include "arrow/io/memory.h"
 #include "arrow/util/key_value_metadata.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/pcg_random.h"
 #include "parquet/encryption/encryption_internal.h"
 #include "parquet/encryption/internal_file_decryptor.h"

--- a/cpp/src/parquet/page_index.cc
+++ b/cpp/src/parquet/page_index.cc
@@ -27,6 +27,7 @@
 #include "parquet/thrift_internal.h"
 
 #include "arrow/util/int_util_overflow.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/unreachable.h"
 
 #include <limits>

--- a/cpp/src/parquet/size_statistics.cc
+++ b/cpp/src/parquet/size_statistics.cc
@@ -24,7 +24,7 @@
 #include <string_view>
 #include <vector>
 
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "parquet/exception.h"
 #include "parquet/schema.h"
 

--- a/cpp/src/parquet/statistics.cc
+++ b/cpp/src/parquet/statistics.cc
@@ -31,7 +31,7 @@
 #include "arrow/util/bit_run_reader.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/float16.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/ubsan.h"
 #include "arrow/visit_data_inline.h"
 #include "parquet/encoding.h"

--- a/cpp/src/parquet/statistics_test.cc
+++ b/cpp/src/parquet/statistics_test.cc
@@ -35,6 +35,7 @@
 #include "arrow/util/bit_util.h"
 #include "arrow/util/bitmap_ops.h"
 #include "arrow/util/float16.h"
+#include "arrow/util/logging_internal.h"
 #include "arrow/util/ubsan.h"
 
 #include "parquet/column_reader.h"

--- a/cpp/src/parquet/thrift_internal.h
+++ b/cpp/src/parquet/thrift_internal.h
@@ -96,7 +96,7 @@ static inline Compression::type FromThriftUnsafe(format::CompressionCodec::type 
     case format::CompressionCodec::ZSTD:
       return Compression::ZSTD;
     default:
-      DCHECK(false) << "Cannot reach here";
+      ARROW_DCHECK(false) << "Cannot reach here";
       return Compression::UNCOMPRESSED;
   }
 }
@@ -272,10 +272,10 @@ static inline format::Type::type ToThrift(Type::type type) {
 
 static inline format::ConvertedType::type ToThrift(ConvertedType::type type) {
   // item 0 is NONE
-  DCHECK_NE(type, ConvertedType::NONE);
+  ARROW_DCHECK_NE(type, ConvertedType::NONE);
   // it is forbidden to emit "NA" (PARQUET-1990)
-  DCHECK_NE(type, ConvertedType::NA);
-  DCHECK_NE(type, ConvertedType::UNDEFINED);
+  ARROW_DCHECK_NE(type, ConvertedType::NA);
+  ARROW_DCHECK_NE(type, ConvertedType::UNDEFINED);
   return static_cast<format::ConvertedType::type>(static_cast<int>(type) - 1);
 }
 
@@ -307,7 +307,7 @@ static inline format::CompressionCodec::type ToThrift(Compression::type type) {
     case Compression::ZSTD:
       return format::CompressionCodec::ZSTD;
     default:
-      DCHECK(false) << "Cannot reach here";
+      ARROW_DCHECK(false) << "Cannot reach here";
       return format::CompressionCodec::UNCOMPRESSED;
   }
 }
@@ -319,7 +319,7 @@ static inline format::BoundaryOrder::type ToThrift(BoundaryOrder::type type) {
     case BoundaryOrder::Descending:
       return static_cast<format::BoundaryOrder::type>(type);
     default:
-      DCHECK(false) << "Cannot reach here";
+      ARROW_DCHECK(false) << "Cannot reach here";
       return format::BoundaryOrder::UNORDERED;
   }
 }

--- a/cpp/src/parquet/types.cc
+++ b/cpp/src/parquet/types.cc
@@ -24,7 +24,7 @@
 
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/compression.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 #include "parquet/exception.h"
 #include "parquet/types.h"

--- a/cpp/src/skyhook/cls/cls_skyhook.cc
+++ b/cpp/src/skyhook/cls/cls_skyhook.cc
@@ -24,7 +24,7 @@
 #include "arrow/dataset/file_parquet.h"
 #include "arrow/io/interfaces.h"
 #include "arrow/result.h"
-#include "arrow/util/logging.h"
+#include "arrow/util/logging_internal.h"
 
 #include "skyhook/protocol/skyhook_protocol.h"
 

--- a/python/pyarrow/src/arrow/python/arrow_to_pandas.cc
+++ b/python/pyarrow/src/arrow/python/arrow_to_pandas.cc
@@ -264,7 +264,8 @@ inline void set_numpy_metadata(int type, const DataType* datatype, PyArray_Descr
       const auto& timestamp_type = checked_cast<const TimestampType&>(*datatype);
       metadata->meta.base = internal::NumPyFrequency(timestamp_type.unit());
     } else {
-      ARROW_DCHECK(false) << "NPY_DATETIME views only supported for Arrow TIMESTAMP types";
+      ARROW_DCHECK(false)
+          << "NPY_DATETIME views only supported for Arrow TIMESTAMP types";
     }
   } else if (type == NPY_TIMEDELTA) {
     ARROW_DCHECK_EQ(datatype->id(), Type::DURATION);
@@ -1589,7 +1590,7 @@ class DatetimeWriter : public TypedPandasWriter<NPY_DATETIME> {
   Status CopyInto(std::shared_ptr<ChunkedArray> data, int64_t rel_placement) override {
     const auto& ts_type = checked_cast<const TimestampType&>(*data->type());
     ARROW_DCHECK_EQ(UNIT, ts_type.unit()) << "Should only call instances of this writer "
-                                    << "with arrays of the correct unit";
+                                          << "with arrays of the correct unit";
     ConvertNumericNullable<int64_t>(*data, kPandasTimestampNull,
                                     this->GetBlockColumnStart(rel_placement));
     return Status::OK();
@@ -1727,7 +1728,7 @@ class TimedeltaWriter : public TypedPandasWriter<NPY_TIMEDELTA> {
   Status CopyInto(std::shared_ptr<ChunkedArray> data, int64_t rel_placement) override {
     const auto& type = checked_cast<const DurationType&>(*data->type());
     ARROW_DCHECK_EQ(UNIT, type.unit()) << "Should only call instances of this writer "
-                                 << "with arrays of the correct unit";
+                                       << "with arrays of the correct unit";
     ConvertNumericNullable<int64_t>(*data, kPandasTimestampNull,
                                     this->GetBlockColumnStart(rel_placement));
     return Status::OK();

--- a/python/pyarrow/src/arrow/python/arrow_to_pandas.cc
+++ b/python/pyarrow/src/arrow/python/arrow_to_pandas.cc
@@ -264,10 +264,10 @@ inline void set_numpy_metadata(int type, const DataType* datatype, PyArray_Descr
       const auto& timestamp_type = checked_cast<const TimestampType&>(*datatype);
       metadata->meta.base = internal::NumPyFrequency(timestamp_type.unit());
     } else {
-      DCHECK(false) << "NPY_DATETIME views only supported for Arrow TIMESTAMP types";
+      ARROW_DCHECK(false) << "NPY_DATETIME views only supported for Arrow TIMESTAMP types";
     }
   } else if (type == NPY_TIMEDELTA) {
-    DCHECK_EQ(datatype->id(), Type::DURATION);
+    ARROW_DCHECK_EQ(datatype->id(), Type::DURATION);
     const auto& duration_type = checked_cast<const DurationType&>(*datatype);
     metadata->meta.base = internal::NumPyFrequency(duration_type.unit());
   }
@@ -466,7 +466,7 @@ class PandasWriter {
     // 1D array when there is only one column
     PyAcquireGIL lock;
 
-    DCHECK_EQ(1, num_columns_);
+    ARROW_DCHECK_EQ(1, num_columns_);
 
     npy_intp new_dims[1] = {static_cast<npy_intp>(num_rows_)};
     PyArray_Dims dims;
@@ -691,7 +691,7 @@ Status ConvertStruct(PandasOptions options, const ChunkedArray& data,
       }
       RETURN_NOT_OK(ConvertArrayToPandas(options, field, nullptr,
                                          fields_data[i + fields_data_offset].ref()));
-      DCHECK(PyArray_Check(fields_data[i + fields_data_offset].obj()));
+      ARROW_DCHECK(PyArray_Check(fields_data[i + fields_data_offset].obj()));
     }
 
     // Construct a dictionary for each row
@@ -723,7 +723,7 @@ Status ConvertStruct(PandasOptions options, const ChunkedArray& data,
           auto setitem_result =
               PyDict_SetItemString(dict_item.obj(), name.c_str(), field_value.obj());
           RETURN_IF_PYERROR();
-          DCHECK_EQ(setitem_result, 0);
+          ARROW_DCHECK_EQ(setitem_result, 0);
         }
         *out_values = dict_item.obj();
         // Grant ownership to the resulting array
@@ -792,7 +792,7 @@ enable_if_list_like<T, Status> ConvertListsLike(PandasOptions options,
   RETURN_NOT_OK(ConvertChunkedArrayToPandas(options, flat_column, nullptr,
                                             owned_numpy_array.ref()));
   PyObject* numpy_array = owned_numpy_array.obj();
-  DCHECK(PyArray_Check(numpy_array));
+  ARROW_DCHECK(PyArray_Check(numpy_array));
 
   int64_t chunk_offset = 0;
   for (int c = 0; c < data.num_chunks(); c++) {
@@ -1289,7 +1289,7 @@ struct ObjectWriterVisitor {
     RETURN_IF_PYERROR();
     auto to_date_offset = [&](const MonthDayNanoIntervalType::MonthDayNanos& interval,
                               PyObject** out) {
-      DCHECK(internal::BorrowPandasDataOffsetType() != nullptr);
+      ARROW_DCHECK(internal::BorrowPandasDataOffsetType() != nullptr);
       // DateOffset objects do not add nanoseconds component to pd.Timestamp.
       // as of  Pandas 1.3.3
       // (https://github.com/pandas-dev/pandas/issues/43892).
@@ -1588,7 +1588,7 @@ class DatetimeWriter : public TypedPandasWriter<NPY_DATETIME> {
 
   Status CopyInto(std::shared_ptr<ChunkedArray> data, int64_t rel_placement) override {
     const auto& ts_type = checked_cast<const TimestampType&>(*data->type());
-    DCHECK_EQ(UNIT, ts_type.unit()) << "Should only call instances of this writer "
+    ARROW_DCHECK_EQ(UNIT, ts_type.unit()) << "Should only call instances of this writer "
                                     << "with arrays of the correct unit";
     ConvertNumericNullable<int64_t>(*data, kPandasTimestampNull,
                                     this->GetBlockColumnStart(rel_placement));
@@ -1619,7 +1619,7 @@ class DatetimeMilliWriter : public DatetimeWriter<TimeUnit::MILLI> {
       ConvertNumericNullable<int64_t>(*data, kPandasTimestampNull, out_values);
     } else {
       const auto& ts_type = checked_cast<const TimestampType&>(*data->type());
-      DCHECK_EQ(TimeUnit::MILLI, ts_type.unit())
+      ARROW_DCHECK_EQ(TimeUnit::MILLI, ts_type.unit())
           << "Should only call instances of this writer "
           << "with arrays of the correct unit";
       ConvertNumericNullable<int64_t>(*data, kPandasTimestampNull, out_values);
@@ -1726,7 +1726,7 @@ class TimedeltaWriter : public TypedPandasWriter<NPY_TIMEDELTA> {
 
   Status CopyInto(std::shared_ptr<ChunkedArray> data, int64_t rel_placement) override {
     const auto& type = checked_cast<const DurationType&>(*data->type());
-    DCHECK_EQ(UNIT, type.unit()) << "Should only call instances of this writer "
+    ARROW_DCHECK_EQ(UNIT, type.unit()) << "Should only call instances of this writer "
                                  << "with arrays of the correct unit";
     ConvertNumericNullable<int64_t>(*data, kPandasTimestampNull,
                                     this->GetBlockColumnStart(rel_placement));
@@ -1817,7 +1817,7 @@ class CategoricalWriter
       RETURN_NOT_OK(this->AllocateNDArray(TRAITS::npy_type, 1));
       RETURN_NOT_OK(MakeZeroLengthArray(dict_type.value_type(), &dict));
     } else {
-      DCHECK_EQ(IndexType::type_id, dict_type.index_type()->id());
+      ARROW_DCHECK_EQ(IndexType::type_id, dict_type.index_type()->id());
       RETURN_NOT_OK(WriteIndices(*data, &dict));
     }
 
@@ -1920,7 +1920,7 @@ class CategoricalWriter
   }
 
   Status WriteIndices(const ChunkedArray& data, std::shared_ptr<Array>* out_dict) {
-    DCHECK_GT(data.num_chunks(), 0);
+    ARROW_DCHECK_GT(data.num_chunks(), 0);
 
     // Sniff the first chunk
     const auto& arr_first = checked_cast<const DictionaryArray&>(*data.chunk(0));
@@ -2031,7 +2031,7 @@ Status MakeWriter(const PandasOptions& options, PandasWriter::type writer_type,
               " not yet supported, index type: ", index_type.ToString());
         default:
           // Unreachable
-          DCHECK(false);
+          ARROW_DCHECK(false);
           break;
       }
     } break;
@@ -2311,7 +2311,7 @@ std::shared_ptr<ChunkedArray> GetStorageChunkedArray(std::shared_ptr<ChunkedArra
 Result<std::shared_ptr<ChunkedArray>> GetDecodedChunkedArray(
     std::shared_ptr<ChunkedArray> arr) {
   ARROW_ASSIGN_OR_RAISE(Datum decoded, compute::RunEndDecode(arr));
-  DCHECK(decoded.is_chunked_array());
+  ARROW_DCHECK(decoded.is_chunked_array());
   return decoded.chunked_array();
 };
 
@@ -2552,7 +2552,7 @@ Status ConvertChunkedArrayToPandas(const PandasOptions& options,
     const auto& dense_type =
         checked_cast<const DictionaryType&>(*arr->type()).value_type();
     RETURN_NOT_OK(DecodeDictionaries(options.pool, dense_type, &arr));
-    DCHECK_NE(arr->type()->id(), Type::DICTIONARY);
+    ARROW_DCHECK_NE(arr->type()->id(), Type::DICTIONARY);
 
     // The original Python DictionaryArray won't own the memory anymore
     // as we actually built a new array when we decoded the DictionaryArray
@@ -2601,7 +2601,7 @@ Status ConvertChunkedArrayToPandas(const PandasOptions& options,
   PandasWriter::type output_type;
   RETURN_NOT_OK(GetPandasWriterType(*arr, modified_options, &output_type));
   if (options.decode_dictionaries) {
-    DCHECK_NE(output_type, PandasWriter::CATEGORICAL);
+    ARROW_DCHECK_NE(output_type, PandasWriter::CATEGORICAL);
   }
 
   std::shared_ptr<PandasWriter> writer;

--- a/python/pyarrow/src/arrow/python/common.cc
+++ b/python/pyarrow/src/arrow/python/common.cc
@@ -122,8 +122,8 @@ class PythonErrorDetail : public StatusDetail {
     PyErr_NormalizeException(&exc_type, &exc_value, &exc_traceback);
     ARROW_CHECK(exc_type)
         << "PythonErrorDetail::FromPyError called without a Python error set";
-    DCHECK(PyType_Check(exc_type));
-    DCHECK(exc_value);  // Ensured by PyErr_NormalizeException, double-check
+    ARROW_DCHECK(PyType_Check(exc_type));
+    ARROW_DCHECK(exc_value);  // Ensured by PyErr_NormalizeException, double-check
     if (exc_traceback == nullptr) {
       // Needed by PyErr_Restore()
       Py_INCREF(Py_None);

--- a/python/pyarrow/src/arrow/python/datetime.cc
+++ b/python/pyarrow/src/arrow/python/datetime.cc
@@ -599,7 +599,7 @@ namespace {
 // operations.
 struct PyListAssigner {
  public:
-  explicit PyListAssigner(PyObject* list) : list_(list) { DCHECK(PyList_Check(list_)); }
+  explicit PyListAssigner(PyObject* list) : list_(list) { ARROW_DCHECK(PyList_Check(list_)); }
 
   PyListAssigner& operator*() { return *this; }
 

--- a/python/pyarrow/src/arrow/python/datetime.cc
+++ b/python/pyarrow/src/arrow/python/datetime.cc
@@ -599,7 +599,9 @@ namespace {
 // operations.
 struct PyListAssigner {
  public:
-  explicit PyListAssigner(PyObject* list) : list_(list) { ARROW_DCHECK(PyList_Check(list_)); }
+  explicit PyListAssigner(PyObject* list) : list_(list) {
+    ARROW_DCHECK(PyList_Check(list_));
+  }
 
   PyListAssigner& operator*() { return *this; }
 

--- a/python/pyarrow/src/arrow/python/decimal.cc
+++ b/python/pyarrow/src/arrow/python/decimal.cc
@@ -52,7 +52,8 @@ static Status InferDecimalPrecisionAndScale(PyObject* python_decimal, int32_t* p
   ARROW_DCHECK_NE(precision, NULLPTR);
   ARROW_DCHECK_NE(scale, NULLPTR);
 
-  // TODO(phillipc): Make sure we perform PyDecimal_Check(python_decimal) as a ARROW_DCHECK
+  // TODO(phillipc): Make sure we perform PyDecimal_Check(python_decimal) as a
+  // ARROW_DCHECK
   OwnedRef as_tuple(PyObject_CallMethod(python_decimal, const_cast<char*>("as_tuple"),
                                         const_cast<char*>("")));
   RETURN_IF_PYERROR();

--- a/python/pyarrow/src/arrow/python/decimal.cc
+++ b/python/pyarrow/src/arrow/python/decimal.cc
@@ -48,26 +48,26 @@ Status PythonDecimalToString(PyObject* python_decimal, std::string* out) {
 // \return The status of the operation
 static Status InferDecimalPrecisionAndScale(PyObject* python_decimal, int32_t* precision,
                                             int32_t* scale) {
-  DCHECK_NE(python_decimal, NULLPTR);
-  DCHECK_NE(precision, NULLPTR);
-  DCHECK_NE(scale, NULLPTR);
+  ARROW_DCHECK_NE(python_decimal, NULLPTR);
+  ARROW_DCHECK_NE(precision, NULLPTR);
+  ARROW_DCHECK_NE(scale, NULLPTR);
 
-  // TODO(phillipc): Make sure we perform PyDecimal_Check(python_decimal) as a DCHECK
+  // TODO(phillipc): Make sure we perform PyDecimal_Check(python_decimal) as a ARROW_DCHECK
   OwnedRef as_tuple(PyObject_CallMethod(python_decimal, const_cast<char*>("as_tuple"),
                                         const_cast<char*>("")));
   RETURN_IF_PYERROR();
-  DCHECK(PyTuple_Check(as_tuple.obj()));
+  ARROW_DCHECK(PyTuple_Check(as_tuple.obj()));
 
   OwnedRef digits(PyObject_GetAttrString(as_tuple.obj(), "digits"));
   RETURN_IF_PYERROR();
-  DCHECK(PyTuple_Check(digits.obj()));
+  ARROW_DCHECK(PyTuple_Check(digits.obj()));
 
   const auto num_digits = static_cast<int32_t>(PyTuple_Size(digits.obj()));
   RETURN_IF_PYERROR();
 
   OwnedRef py_exponent(PyObject_GetAttrString(as_tuple.obj(), "exponent"));
   RETURN_IF_PYERROR();
-  DCHECK(IsPyInteger(py_exponent.obj()));
+  ARROW_DCHECK(IsPyInteger(py_exponent.obj()));
 
   const auto exponent = static_cast<int32_t>(PyLong_AsLong(py_exponent.obj()));
   RETURN_IF_PYERROR();
@@ -90,13 +90,13 @@ static Status InferDecimalPrecisionAndScale(PyObject* python_decimal, int32_t* p
 
 PyObject* DecimalFromString(PyObject* decimal_constructor,
                             const std::string& decimal_string) {
-  DCHECK_NE(decimal_constructor, nullptr);
+  ARROW_DCHECK_NE(decimal_constructor, nullptr);
 
   auto string_size = decimal_string.size();
-  DCHECK_GT(string_size, 0);
+  ARROW_DCHECK_GT(string_size, 0);
 
   auto string_bytes = decimal_string.c_str();
-  DCHECK_NE(string_bytes, nullptr);
+  ARROW_DCHECK_NE(string_bytes, nullptr);
 
   return PyObject_CallFunction(decimal_constructor, const_cast<char*>("s#"), string_bytes,
                                static_cast<Py_ssize_t>(string_size));
@@ -117,7 +117,7 @@ Status DecimalFromStdString(const std::string& decimal_string,
   const int32_t scale = arrow_type.scale();
 
   if (scale != inferred_scale) {
-    DCHECK_NE(out, NULLPTR);
+    ARROW_DCHECK_NE(out, NULLPTR);
     ARROW_ASSIGN_OR_RAISE(*out, out->Rescale(inferred_scale, scale));
   }
 
@@ -135,8 +135,8 @@ template <typename ArrowDecimal>
 Status InternalDecimalFromPythonDecimal(PyObject* python_decimal,
                                         const DecimalType& arrow_type,
                                         ArrowDecimal* out) {
-  DCHECK_NE(python_decimal, NULLPTR);
-  DCHECK_NE(out, NULLPTR);
+  ARROW_DCHECK_NE(python_decimal, NULLPTR);
+  ARROW_DCHECK_NE(out, NULLPTR);
 
   std::string string;
   RETURN_NOT_OK(PythonDecimalToString(python_decimal, &string));
@@ -146,8 +146,8 @@ Status InternalDecimalFromPythonDecimal(PyObject* python_decimal,
 template <typename ArrowDecimal>
 Status InternalDecimalFromPyObject(PyObject* obj, const DecimalType& arrow_type,
                                    ArrowDecimal* out) {
-  DCHECK_NE(obj, NULLPTR);
-  DCHECK_NE(out, NULLPTR);
+  ARROW_DCHECK_NE(obj, NULLPTR);
+  ARROW_DCHECK_NE(out, NULLPTR);
 
   if (IsPyInteger(obj)) {
     // TODO: add a fast path for small-ish ints
@@ -206,7 +206,7 @@ bool PyDecimal_Check(PyObject* obj) {
   static OwnedRef decimal_type;
   if (!decimal_type.obj()) {
     ARROW_CHECK_OK(ImportDecimalType(&decimal_type));
-    DCHECK(PyType_Check(decimal_type.obj()));
+    ARROW_DCHECK(PyType_Check(decimal_type.obj()));
   }
   // PyObject_IsInstance() is slower as it has to check for virtual subclasses
   const int result =
@@ -216,7 +216,7 @@ bool PyDecimal_Check(PyObject* obj) {
 }
 
 bool PyDecimal_ISNAN(PyObject* obj) {
-  DCHECK(PyDecimal_Check(obj)) << "obj is not an instance of decimal.Decimal";
+  ARROW_DCHECK(PyDecimal_Check(obj)) << "obj is not an instance of decimal.Decimal";
   OwnedRef is_nan(
       PyObject_CallMethod(obj, const_cast<char*>("is_nan"), const_cast<char*>("")));
   return PyObject_IsTrue(is_nan.obj()) == 1;

--- a/python/pyarrow/src/arrow/python/extension_type.cc
+++ b/python/pyarrow/src/arrow/python/extension_type.cc
@@ -135,12 +135,12 @@ error:
 }
 
 std::shared_ptr<Array> PyExtensionType::MakeArray(std::shared_ptr<ArrayData> data) const {
-  DCHECK_EQ(data->type->id(), Type::EXTENSION);
+  ARROW_DCHECK_EQ(data->type->id(), Type::EXTENSION);
   return std::make_shared<ExtensionArray>(data);
 }
 
 std::string PyExtensionType::Serialize() const {
-  DCHECK(type_instance_);
+  ARROW_DCHECK(type_instance_);
   return serialized_;
 }
 
@@ -163,7 +163,7 @@ PyObject* PyExtensionType::GetInstance() const {
     PyErr_SetString(PyExc_TypeError, "Not an instance");
     return nullptr;
   }
-  DCHECK(PyWeakref_CheckRef(type_instance_.obj()));
+  ARROW_DCHECK(PyWeakref_CheckRef(type_instance_.obj()));
   PyObject* inst = PyWeakref_GET_OBJECT(type_instance_.obj());
   if (inst != Py_None) {
     // Cached instance still alive
@@ -202,7 +202,7 @@ Status PyExtensionType::FromClass(const std::shared_ptr<DataType> storage_type,
 }
 
 Status RegisterPyExtensionType(const std::shared_ptr<DataType>& type) {
-  DCHECK_EQ(type->id(), Type::EXTENSION);
+  ARROW_DCHECK_EQ(type->id(), Type::EXTENSION);
   auto ext_type = std::dynamic_pointer_cast<ExtensionType>(type);
   return RegisterExtensionType(ext_type);
 }

--- a/python/pyarrow/src/arrow/python/helpers.cc
+++ b/python/pyarrow/src/arrow/python/helpers.cc
@@ -94,12 +94,12 @@ Status PyFloat_AsHalf(PyObject* obj, npy_half* out) {
 namespace internal {
 
 std::string PyBytes_AsStdString(PyObject* obj) {
-  DCHECK(PyBytes_Check(obj));
+  ARROW_DCHECK(PyBytes_Check(obj));
   return std::string(PyBytes_AS_STRING(obj), PyBytes_GET_SIZE(obj));
 }
 
 Status PyUnicode_AsStdString(PyObject* obj, std::string* out) {
-  DCHECK(PyUnicode_Check(obj));
+  ARROW_DCHECK(PyUnicode_Check(obj));
   Py_ssize_t size;
   // The utf-8 representation is cached on the unicode object
   const char* data = PyUnicode_AsUTF8AndSize(obj, &size);
@@ -180,7 +180,7 @@ Result<OwnedRef> PyObjectToPyInt(PyObject* obj) {
     if (!ref) {
       RETURN_IF_PYERROR();
     }
-    DCHECK(ref);
+    ARROW_DCHECK(ref);
     return std::move(ref);
   }
   return Status::TypeError(

--- a/python/pyarrow/src/arrow/python/io.cc
+++ b/python/pyarrow/src/arrow/python/io.cc
@@ -220,7 +220,7 @@ Result<int64_t> PyReadableFile::Read(int64_t nbytes, void* out) {
     OwnedRef bytes;
     RETURN_NOT_OK(file_->Read(nbytes, bytes.ref()));
     PyObject* bytes_obj = bytes.obj();
-    DCHECK(bytes_obj != NULL);
+    ARROW_DCHECK(bytes_obj != NULL);
 
     Py_buffer py_buf;
     if (!PyObject_GetBuffer(bytes_obj, &py_buf, PyBUF_ANY_CONTIGUOUS)) {
@@ -246,7 +246,7 @@ Result<std::shared_ptr<Buffer>> PyReadableFile::Read(int64_t nbytes) {
     } else {
       RETURN_NOT_OK(file_->Read(nbytes, buffer_obj.ref()));
     }
-    DCHECK(buffer_obj.obj() != NULL);
+    ARROW_DCHECK(buffer_obj.obj() != NULL);
 
     return PyBuffer::FromPyObject(buffer_obj.obj());
   });

--- a/python/pyarrow/src/arrow/python/numpy_internal.h
+++ b/python/pyarrow/src/arrow/python/numpy_internal.h
@@ -43,7 +43,7 @@ class Ndarray1DIndexer {
 
   explicit Ndarray1DIndexer(PyArrayObject* arr) : Ndarray1DIndexer() {
     arr_ = arr;
-    DCHECK_EQ(1, PyArray_NDIM(arr)) << "Only works with 1-dimensional arrays";
+    ARROW_DCHECK_EQ(1, PyArray_NDIM(arr)) << "Only works with 1-dimensional arrays";
     data_ = reinterpret_cast<uint8_t*>(PyArray_DATA(arr));
     stride_ = PyArray_STRIDES(arr)[0];
   }

--- a/python/pyarrow/src/arrow/python/numpy_to_arrow.cc
+++ b/python/pyarrow/src/arrow/python/numpy_to_arrow.cc
@@ -837,7 +837,7 @@ Status NumPyConverter::Visit(const StructType& type) {
       }
       PyArray_Descr* sub_dtype =
           reinterpret_cast<PyArray_Descr*>(PyTuple_GET_ITEM(tup, 0));
-      DCHECK(PyObject_TypeCheck(sub_dtype, &PyArrayDescr_Type));
+      ARROW_DCHECK(PyObject_TypeCheck(sub_dtype, &PyArrayDescr_Type));
       int offset = static_cast<int>(PyLong_AsLong(PyTuple_GET_ITEM(tup, 1)));
       RETURN_IF_PYERROR();
       Py_INCREF(sub_dtype); /* PyArray_GetField() steals ref */
@@ -877,8 +877,8 @@ Status NumPyConverter::Visit(const StructType& type) {
   for (size_t chunk = 0; chunk < nchunks; chunk++) {
     // First group has the null bitmaps as Boolean Arrays
     const auto& null_data = groups[0][chunk]->data();
-    DCHECK_EQ(null_data->type->id(), Type::BOOL);
-    DCHECK_EQ(null_data->buffers.size(), 2);
+    ARROW_DCHECK_EQ(null_data->type->id(), Type::BOOL);
+    ARROW_DCHECK_EQ(null_data->buffers.size(), 2);
     const auto& null_buffer = null_data->buffers[1];
     // Careful: the rechunked null bitmap may have a non-zero offset
     // to its buffer, and it may not even start on a byte boundary
@@ -930,7 +930,7 @@ Status NdarrayToArrow(MemoryPool* pool, PyObject* ao, PyObject* mo, bool from_pa
   NumPyConverter converter(pool, ao, mo, type, from_pandas, cast_options);
   RETURN_NOT_OK(converter.Convert());
   const auto& output_arrays = converter.result();
-  DCHECK_GT(output_arrays.size(), 0);
+  ARROW_DCHECK_GT(output_arrays.size(), 0);
   *out = std::make_shared<ChunkedArray>(output_arrays);
   return Status::OK();
 }

--- a/python/pyarrow/src/arrow/python/pyarrow.cc
+++ b/python/pyarrow/src/arrow/python/pyarrow.cc
@@ -91,7 +91,7 @@ namespace internal {
 int check_status(const Status& status) { return ::pyarrow_internal_check_status(status); }
 
 PyObject* convert_status(const Status& status) {
-  DCHECK(!status.ok());
+  ARROW_DCHECK(!status.ok());
   return ::pyarrow_internal_convert_status(status);
 }
 

--- a/python/pyarrow/src/arrow/python/python_to_arrow.cc
+++ b/python/pyarrow/src/arrow/python/python_to_arrow.cc
@@ -542,7 +542,7 @@ class PyConverter : public Converter<PyObject*, PyConversionOptions> {
  public:
   // Iterate over the input values and defer the conversion to the Append method
   Status Extend(PyObject* values, int64_t size, int64_t offset = 0) override {
-    DCHECK_GE(size, offset);
+    ARROW_DCHECK_GE(size, offset);
     /// Ensure we've allocated enough space
     RETURN_NOT_OK(this->Reserve(size - offset));
     // Iterate over the items adding each one
@@ -554,7 +554,7 @@ class PyConverter : public Converter<PyObject*, PyConversionOptions> {
   // Convert and append a sequence of values masked with a numpy array
   Status ExtendMasked(PyObject* values, PyObject* mask, int64_t size,
                       int64_t offset = 0) override {
-    DCHECK_GE(size, offset);
+    ARROW_DCHECK_GE(size, offset);
     /// Ensure we've allocated enough space
     RETURN_NOT_OK(this->Reserve(size - offset));
     // Iterate over the items adding each one
@@ -1267,7 +1267,7 @@ Result<std::shared_ptr<ChunkedArray>> ConvertPySequence(PyObject* obj, PyObject*
   } else {
     options.strict = true;
   }
-  DCHECK_GE(size, 0);
+  ARROW_DCHECK_GE(size, 0);
 
   ARROW_ASSIGN_OR_RAISE(auto converter, (MakeConverter<PyConverter, PyConverterTrait>(
                                             options.type, options, pool)));

--- a/python/pyarrow/src/arrow/python/udf.cc
+++ b/python/pyarrow/src/arrow/python/udf.cc
@@ -271,7 +271,7 @@ struct PythonUdfHashAggregatorImpl : public HashUdfAggregator {
     // This is similar to GroupedListImpl
     // last array is the group id
     const ArraySpan& groups_array_data = batch[batch.num_values() - 1].array;
-    DCHECK_EQ(groups_array_data.offset, 0);
+    ARROW_DCHECK_EQ(groups_array_data.offset, 0);
     int64_t batch_num_values = groups_array_data.length;
     const auto* batch_groups = groups_array_data.GetValues<uint32_t>(1);
     RETURN_NOT_OK(groups.Append(batch_groups, batch_num_values));


### PR DESCRIPTION
### Rationale for this change

`arrow/util/logging.h` exports `DCHECK()` family macros as internal macros. They are conflicted with macros provided by glog when glog headers are included after `arrow/util/logging.h`.

### What changes are included in this PR?

* Move `DCHECK()` family macros to `arrow/util/logging_internal.h`
* Use `arrow/util/logging_internal.h` not `.../logging.h` in `*.cc`
* Use `ARROW_DCHECK*()` macros instead of `DCHECK*()` macros in headers including `*_internal.h`
* Use `ARROW_DCHECK*()` macros instead of `DCHECK*()` macros in examples
* Use `ARROW_DCHECK*()` macros instead of `DCHECK*()` macros in `python/`
 
### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #46011