### PR TITLE
GH-45714: [CI][R] Don't run tests that use reticulate on CRAN

### DIFF
--- a/ci/scripts/r_test.sh
+++ b/ci/scripts/r_test.sh
@@ -101,7 +101,7 @@ SCRIPT="as_cran <- !identical(tolower(Sys.getenv('NOT_CRAN')), 'true')
     build_args <- '--no-build-vignettes'
   }
 
-  if (requireNamespace('reticulate', quietly = TRUE) && reticulate::py_module_available('pyarrow')) {
+  if (!as_cran && requireNamespace('reticulate', quietly = TRUE) && reticulate::py_module_available('pyarrow')) {
       message('Running flight demo server for tests.')
       pid_flight <- sys::exec_background(
           'python',
@@ -130,7 +130,8 @@ echo "$SCRIPT" | ${R_BIN} --no-save
 
 AFTER=$(ls -alh ~/)
 if [ "$NOT_CRAN" != "true" ] && [ "$BEFORE" != "$AFTER" ]; then
-  ls -alh ~/.cmake/packages
+  # Ignore ~/.TinyTex/ and ~/R/ because it has many files.
+  find ~ -path ~/.TinyTeX -prune -or -path ~/R/ -prune -or -print
   exit 1
 fi
 popd

--- a/r/tests/testthat/helper-skip.R
+++ b/r/tests/testthat/helper-skip.R
@@ -57,6 +57,7 @@ skip_if_no_pyarrow <- function() {
     return()
   }
 
+  skip_on_cran()
   skip_on_linux_devel()
   skip_on_os("windows")
 


### PR DESCRIPTION
### Rationale for this change

reticulate may create some files in home directory. It's not desired on CRAN.

### What changes are included in this PR?

Disable tests that use reticulate.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #45714