### PR TITLE
GH-37891: [C++] Followup Buffer change to use sptr move

### DIFF
--- a/cpp/src/arrow/buffer.h
+++ b/cpp/src/arrow/buffer.h
@@ -111,10 +111,10 @@ class ARROW_EXPORT Buffer {
   /// This method makes no assertions about alignment or padding of the buffer but
   /// in general we expected buffers to be aligned and padded to 64 bytes.  In the future
   /// we might add utility methods to help determine if a buffer satisfies this contract.
-  Buffer(const std::shared_ptr<Buffer>& parent, const int64_t offset, const int64_t size)
+  Buffer(std::shared_ptr<Buffer> parent, const int64_t offset, const int64_t size)
       : Buffer(parent->data_ + offset, size) {
-    parent_ = parent;
-    SetMemoryManager(parent->memory_manager_);
+    parent_ = std::move(parent);
+    SetMemoryManager(parent_->memory_manager_);
   }
 
   uint8_t operator[](std::size_t i) const { return data_[i]; }

--- a/cpp/src/arrow/chunked_array.cc
+++ b/cpp/src/arrow/chunked_array.cc
@@ -83,7 +83,7 @@ Result<std::shared_ptr<ChunkedArray>> ChunkedArray::Make(ArrayVector chunks,
 Result<std::shared_ptr<ChunkedArray>> ChunkedArray::MakeEmpty(
     std::shared_ptr<DataType> type, MemoryPool* memory_pool) {
   std::vector<std::shared_ptr<Array>> new_chunks(1);
-  ARROW_ASSIGN_OR_RAISE(new_chunks[0], MakeEmptyArray(type, memory_pool));
+  ARROW_ASSIGN_OR_RAISE(new_chunks[0], MakeEmptyArray(std::move(type), memory_pool));
   return std::make_shared<ChunkedArray>(std::move(new_chunks));
 }
 
@@ -252,7 +252,7 @@ Result<std::shared_ptr<ChunkedArray>> ChunkedArray::View(
   for (int i = 0; i < this->num_chunks(); ++i) {
     ARROW_ASSIGN_OR_RAISE(out_chunks[i], chunks_[i]->View(type));
   }
-  return std::make_shared<ChunkedArray>(out_chunks, type);
+  return std::make_shared<ChunkedArray>(std::move(out_chunks), type);
 }
 
 std::string ChunkedArray::ToString() const {

--- a/cpp/src/arrow/record_batch.cc
+++ b/cpp/src/arrow/record_batch.cc
@@ -81,7 +81,7 @@ class SimpleRecordBatch : public RecordBatch {
     }
   }
 
-  SimpleRecordBatch(const std::shared_ptr<Schema>& schema, int64_t num_rows,
+  SimpleRecordBatch(std::shared_ptr<Schema> schema, int64_t num_rows,
                     std::vector<std::shared_ptr<ArrayData>> columns,
                     DeviceAllocationType device_type = DeviceAllocationType::kCPU,
                     std::shared_ptr<Device::SyncEvent> sync_event = nullptr)
@@ -216,8 +216,8 @@ class SimpleRecordBatch : public RecordBatch {
   std::shared_ptr<Device::SyncEvent> sync_event_;
 };
 
-RecordBatch::RecordBatch(const std::shared_ptr<Schema>& schema, int64_t num_rows)
-    : schema_(schema), num_rows_(num_rows) {}
+RecordBatch::RecordBatch(std::shared_ptr<Schema> schema, int64_t num_rows)
+    : schema_(std::move(schema)), num_rows_(num_rows) {}
 
 std::shared_ptr<RecordBatch> RecordBatch::Make(
     std::shared_ptr<Schema> schema, int64_t num_rows,

--- a/cpp/src/arrow/record_batch.h
+++ b/cpp/src/arrow/record_batch.h
@@ -295,7 +295,7 @@ class ARROW_EXPORT RecordBatch {
       MemoryPool* pool = default_memory_pool()) const;
 
  protected:
-  RecordBatch(const std::shared_ptr<Schema>& schema, int64_t num_rows);
+  RecordBatch(std::shared_ptr<Schema> schema, int64_t num_rows);
 
   std::shared_ptr<Schema> schema_;
   int64_t num_rows_;

--- a/cpp/src/arrow/table.cc
+++ b/cpp/src/arrow/table.cc
@@ -249,6 +249,7 @@ Table::Table() : num_rows_(0) {}
 
 std::vector<std::shared_ptr<Field>> Table::fields() const {
   std::vector<std::shared_ptr<Field>> result;
+  result.reserve(this->num_columns());
   for (int i = 0; i < this->num_columns(); ++i) {
     result.emplace_back(this->field(i));
   }
@@ -274,7 +275,7 @@ Result<std::shared_ptr<Table>> Table::MakeEmpty(std::shared_ptr<Schema> schema,
     ARROW_ASSIGN_OR_RAISE(empty_table[i],
                           ChunkedArray::MakeEmpty(schema->field(i)->type(), memory_pool));
   }
-  return Table::Make(schema, empty_table, 0);
+  return Table::Make(std::move(schema), empty_table, 0);
 }
 
 Result<std::shared_ptr<Table>> Table::FromRecordBatchReader(RecordBatchReader* reader) {

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -826,7 +826,7 @@ Result<std::shared_ptr<Field>> Field::MergeWith(const Field& other,
                                other.nullable());
     }
 
-    return std::make_shared<Field>(name_, promoted_type, nullable, metadata_);
+    return std::make_shared<Field>(name_, std::move(promoted_type), nullable, metadata_);
   }
   return Status::TypeError("Unable to merge: Field ", name(),
                            " has incompatible types: ", type()->ToString(), " vs ",


### PR DESCRIPTION
### Rationale for this change

Continue add some shared_ptr move case in basic classes

### What changes are included in this PR?

Continue add some shared_ptr move case in basic classes

### Are these changes tested?

Covered by existing

### Are there any user-facing changes?

Change a ctor type

* GitHub Issue: #37891