### PR TITLE
GH-46022: [C++] Fix build error with g++ 7.5.0

### DIFF
--- a/cpp/src/arrow/compute/kernels/pivot_internal.cc
+++ b/cpp/src/arrow/compute/kernels/pivot_internal.cc
@@ -150,7 +150,9 @@ Result<std::unique_ptr<PivotWiderKeyMapper>> PivotWiderKeyMapper::Make(
     const DataType& key_type, const PivotWiderOptions* options, ExecContext* ctx) {
   auto instance = std::make_unique<ConcretePivotWiderKeyMapper>();
   RETURN_NOT_OK(instance->Init(key_type, options, ctx));
-  return instance;
+  // We can remove this static_cast() once we drop support for g++
+  // 7.5.0 (we require C++20).
+  return static_cast<std::unique_ptr<PivotWiderKeyMapper>>(std::move(instance));
 }
 
 }  // namespace arrow::compute::internal


### PR DESCRIPTION
### Rationale for this change

We need explicit upcast for `std::unique_ptr<>` with g++ 7.5.0.

### What changes are included in this PR?

Add explicit upcast.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #46022