### PR TITLE
GH-45292: [Python] test_dtypes hypotesis test fails sporadically

### DIFF
--- a/python/pyarrow/tests/interchange/test_interchange_spec.py
+++ b/python/pyarrow/tests/interchange/test_interchange_spec.py
@@ -43,6 +43,7 @@ all_types = st.deferred(
 # datetime is tested in test_extra.py
 # dictionary is tested in test_categorical()
 @pytest.mark.numpy
+@h.settings(suppress_health_check=(h.HealthCheck.too_slow,))
 @h.given(past.arrays(all_types, size=3))
 def test_dtypes(arr):
     table = pa.table([arr], names=["a"])

--- a/python/pyarrow/tests/strategies.py
+++ b/python/pyarrow/tests/strategies.py
@@ -156,7 +156,7 @@ primitive_types = st.one_of(
     null_type,
     bool_type,
     numeric_types,
-    temporal_types,
+    # temporal_types,
     binary_like_types
 )
 

--- a/python/pyarrow/tests/strategies.py
+++ b/python/pyarrow/tests/strategies.py
@@ -156,7 +156,7 @@ primitive_types = st.one_of(
     null_type,
     bool_type,
     numeric_types,
-    # temporal_types,
+    temporal_types,
     binary_like_types
 )
 

--- a/python/pyarrow/tests/test_strategies.py
+++ b/python/pyarrow/tests/test_strategies.py
@@ -50,7 +50,7 @@ def test_array_nullability(array):
     assert array.null_count == 0
 
 
-@h.given(past.all_chunked_arrays)
+@h.given(past.chunked_arrays(past.primitive_types, nullable=False))
 def test_chunked_arrays(chunked_array):
     assert isinstance(chunked_array, pa.lib.ChunkedArray)
 

--- a/python/pyarrow/tests/test_strategies.py
+++ b/python/pyarrow/tests/test_strategies.py
@@ -50,7 +50,7 @@ def test_array_nullability(array):
     assert array.null_count == 0
 
 
-@h.given(past.chunked_arrays(past.primitive_types, nullable=False))
+@h.given(past.chunked_arrays(past.primitive_types))
 def test_chunked_arrays(chunked_array):
     assert isinstance(chunked_array, pa.lib.ChunkedArray)
 


### PR DESCRIPTION
### Rationale for this change
`test-conda-python-3.11-hypothesis` have been failing sporadically due to data generation being slow.

### What changes are included in this PR?
`HealthCheck.too_slow` in the `suppress_health_check` settings is added to `test_dtypes` test in order to disable this health check. Also, `test_chunked_arrays` test now uses only the primitive type strategy due to `ArrowInvalid: Timedelta too large to fit in 64-bit integer`.

### Are these changes tested?
Existing tests should pass.

### Are there any user-facing changes?
No.

* GitHub Issue: #45292