### PR TITLE
GH-45664: [C++] Allow LargeString,LargeBinary,FixedSizeBinary,StringView and BinaryView for RecordBatch::MakeStatisticsArray()

### DIFF
--- a/cpp/src/arrow/array/statistics.h
+++ b/cpp/src/arrow/array/statistics.h
@@ -60,6 +60,8 @@ struct ARROW_EXPORT ArrayStatistics {
           case Type::FIXED_SIZE_BINARY:
           case Type::LARGE_STRING:
           case Type::LARGE_BINARY:
+          case Type::BINARY_VIEW:
+          case Type::STRING_VIEW:
             return array_type;
           default:
             return utf8();

--- a/cpp/src/arrow/record_batch.cc
+++ b/cpp/src/arrow/record_batch.cc
@@ -564,7 +564,7 @@ struct StringBuilderVisitor {
                                                     ArrayBuilder* raw_builder,
                                                     const std::string& value) {
     using Builder = typename TypeTraits<DataType>::BuilderType;
-    Builder* builder = static_cast<Builder*>(raw_builder);
+    auto builder = static_cast<Builder*>(raw_builder);
     return builder->Append(value);
   }
 
@@ -697,8 +697,8 @@ Result<std::shared_ptr<Array>> RecordBatch::MakeStatisticsArray(
         return static_cast<DoubleBuilder*>(builder)->Append(value);
       }
       Status operator()(const std::string& value) {
-        StringBuilderVisitor visitor_builder;
-        return VisitTypeInline(*builder->type(), &visitor_builder, builder, value);
+        StringBuilderVisitor visitor;
+        return VisitTypeInline(*builder->type(), &visitor, builder, value);
       }
     } visitor;
     visitor.builder = values_builders[values_type_index].get();

--- a/cpp/src/arrow/record_batch_test.cc
+++ b/cpp/src/arrow/record_batch_test.cc
@@ -1246,17 +1246,18 @@ Result<std::shared_ptr<Array>> MakeStatisticsArray(
 }
 
 std::shared_ptr<Array> GenerateString(
-    const std::shared_ptr<::arrow::DataType>& data_type) {
+    const std::shared_ptr<DataType>& data_type) {
   if (data_type->id() == Type::FIXED_SIZE_BINARY) {
     auto byte_width = data_type->byte_width();
-    auto a = std::string(byte_width, 'a');
-    auto b = std::string(byte_width, 'b');
-    auto c = std::string(byte_width, 'c');
+    std::string a(byte_width, 'a');
+    std::string b(byte_width, 'b');
+    std::string c(byte_width, 'c');
     std::stringstream ss;
     ss << R"([")" << a << R"(",")" << b << R"(",")" << c << R"("])";
     return ArrayFromJSON(data_type, ss.str());
+  } else {
+    return ArrayFromJSON(data_type, R"(["a","b","c"])");
   }
-  return ArrayFromJSON(data_type, R"(["a","b","c"])");
 }
 
 };  // namespace
@@ -1471,7 +1472,7 @@ template <typename DataType>
 class TestRecordBatchMakeStatisticsArrayBinary : public ::testing::Test {
  public:
   void TestMaxApproximation() {
-    auto max = ArrayStatistics::ValueType{"c"};
+    ArrayStatistics::ValueType max("c");
     auto schema =
         ::arrow::schema({field("no-statistics", boolean()), field("string", type())});
     auto no_statistics_array = ArrayFromJSON(boolean(), "[true, false, true]");
@@ -1572,7 +1573,7 @@ TEST_F(TestRecordBatch, MakeStatisticsArrayDifferentSizeFixedSizeBinary) {
 // FixedSizeBinaryArrays with equal byte widths.
 TEST_F(TestRecordBatch, MakeStatisticsArraySameSizeFixedSizeBinary) {
   auto fixed_size_type = fixed_size_binary(2);
-  auto max = ArrayStatistics::ValueType{std::string(fixed_size_type->byte_width(), 'c')};
+  ArrayStatistics::ValueType max(std::string(fixed_size_type->byte_width(), 'c'));
 
   auto fixed_size_array1 = GenerateString(fixed_size_type);
   fixed_size_array1->data()->statistics = std::make_shared<ArrayStatistics>();

--- a/cpp/src/arrow/record_batch_test.cc
+++ b/cpp/src/arrow/record_batch_test.cc
@@ -1472,10 +1472,10 @@ class TestRecordBatchMakeStatisticsArrayBinary : public ::testing::Test {
  public:
   void TestMaxApproximation() {
     auto max = ArrayStatistics::ValueType{"c"};
-    auto schema = ::arrow::schema(
-        {field("no-statistics", boolean()), field("string", this->type())});
+    auto schema =
+        ::arrow::schema({field("no-statistics", boolean()), field("string", type())});
     auto no_statistics_array = ArrayFromJSON(boolean(), "[true, false, true]");
-    auto string_array = GenerateString(this->type());
+    auto string_array = GenerateString(type());
     string_array->data()->statistics = std::make_shared<ArrayStatistics>();
     string_array->data()->statistics->max = max;
 
@@ -1499,7 +1499,7 @@ class TestRecordBatchMakeStatisticsArrayBinary : public ::testing::Test {
                              {
                                  max,
                              }},
-                            {null(), this->type()}));
+                            {null(), type()}));
     AssertArraysEqual(*expected_statistics_array, *statistics_array, true);
   }
 

--- a/cpp/src/arrow/record_batch_test.cc
+++ b/cpp/src/arrow/record_batch_test.cc
@@ -1245,8 +1245,7 @@ Result<std::shared_ptr<Array>> MakeStatisticsArray(
   return std::make_shared<StructArray>(struct_type, n_columns, struct_arrays);
 }
 
-std::shared_ptr<Array> GenerateString(
-    const std::shared_ptr<DataType>& data_type) {
+std::shared_ptr<Array> GenerateString(const std::shared_ptr<DataType>& data_type) {
   if (data_type->id() == Type::FIXED_SIZE_BINARY) {
     auto byte_width = data_type->byte_width();
     std::string a(byte_width, 'a');

--- a/cpp/src/arrow/record_batch_test.cc
+++ b/cpp/src/arrow/record_batch_test.cc
@@ -1086,8 +1086,8 @@ Result<std::shared_ptr<Array>> BuildArray(const std::vector<ValueType>& values,
     const std::vector<ArrayStatistics::ValueType>& values_;
     const std::shared_ptr<DataType>& array_type;
     explicit Builder(const std::vector<ArrayStatistics::ValueType>& values,
-                     const std::shared_ptr<DataType>& string_type)
-        : values_(values), array_type(string_type) {}
+                     const std::shared_ptr<DataType>& array_type)
+        : values_(values), array_type(array_type) {}
 
     Result<std::shared_ptr<Array>> operator()(const bool&) {
       auto values = StatisticsValuesToRawValues<bool>(values_);
@@ -1579,6 +1579,10 @@ TEST_P(TestRecordBatchMakeStatisticsArrayFixedSizeBinaryCombination,
        FixedSizeBinaryCombination) {
   this->TestCombination();
 }
+
+// tuple(1, 2) tests whether RecordBatch::MakeStatistics can handle cases involving
+// different fixed_size_binary types.
+// tuple(2, 2) verifies if a single union array is created to include both values.
 INSTANTIATE_TEST_SUITE_P(FixedSizeBinaryCombination,
                          TestRecordBatchMakeStatisticsArrayFixedSizeBinaryCombination,
                          ::testing::Values(std::make_tuple(1, 2), std::make_tuple(2, 2)));

--- a/cpp/src/arrow/testing/gtest_util.h
+++ b/cpp/src/arrow/testing/gtest_util.h
@@ -182,6 +182,9 @@ using BaseBinaryArrowTypes =
 using BaseBinaryOrBinaryViewLikeArrowTypes =
     ::testing::Types<BinaryType, LargeBinaryType, BinaryViewType, StringType,
                      LargeStringType, StringViewType>;
+using AllBinaryOrBinrayViewLikeArrowTypes =
+    ::testing::Types<BinaryType, LargeBinaryType, BinaryViewType, FixedSizeBinaryType,
+                     StringType, LargeStringType, StringViewType>;
 
 using BinaryArrowTypes = ::testing::Types<BinaryType, LargeBinaryType>;
 


### PR DESCRIPTION
### Rationale for this change

MakeStatisticsArray in RecordBatch does not support StringView, BinaryView, LargeString, LargeBinary, FixedSizeBinary types.

### What changes are included in this PR?

The correction of MakeStatisticsArray in RecordBatch to support all arrow string types and relevant tests. Additionally, some changes applied to MakeStatisticsArray in record_batch_test.cc 

### Are these changes tested?

Yes, I run all relevant unit tests

### Are there any user-facing changes?

Yes. (Add support for `large_utf8`, `large_binary`, `fixed_size_binary`, `StringView`, and `BinaryView` to `RecordBatch::MakeStatisticsArray()`).

* GitHub Issue: #45664