### PR TITLE
GH-46023: [CI][MATLAB] libmexclass doesn't work with CMake 4.0.0

### DIFF
--- a/matlab/tools/cmake/BuildMatlabArrowInterface.cmake
+++ b/matlab/tools/cmake/BuildMatlabArrowInterface.cmake
@@ -24,7 +24,7 @@ set(MATLAB_ARROW_LIBMEXCLASS_CLIENT_FETCH_CONTENT_NAME libmexclass)
 # libmexclass is accessible for CI without permission issues.
 set(MATLAB_ARROW_LIBMEXCLASS_CLIENT_FETCH_CONTENT_GIT_REPOSITORY "https://github.com/mathworks/libmexclass.git")
 # Use a specific Git commit hash to avoid libmexclass version changing unexpectedly.
-set(MATLAB_ARROW_LIBMEXCLASS_CLIENT_FETCH_CONTENT_GIT_TAG "cac7c3630a086bd5ba41413af44c833cef189c09")
+set(MATLAB_ARROW_LIBMEXCLASS_CLIENT_FETCH_CONTENT_GIT_TAG "2a75a5e9bbb524a044572598e371c994cc715d3d")
 set(MATLAB_ARROW_LIBMEXCLASS_CLIENT_FETCH_CONTENT_SOURCE_SUBDIR "libmexclass/cpp")
 
 # ------------------------------------------


### PR DESCRIPTION
### Rationale for this change

See: https://github.com/apache/arrow/issues/46023

### What changes are included in this PR?

1. Bumped `mathworks/libmexclass` version to git commit `2a75a5e9bbb524a044572598e371c994cc715d3d`. This version of `mathworks/libmexclass` requires CMake version `3.6.0` or later, which is compatible with CMake 4.0.0 (used by `apache/arrow`.

### Are these changes tested?

Yes.

1. [Successful MATLAB CI job running in `mathworks/arrow`]( https://github.com/mathworks/arrow/actions/runs/14269264384).

### Are there any user-facing changes?

Yes.

1. Users will now need CMake version `3.6.0` or later to build the MATLAB interface.

### Notes

1. Thank you @sgilmore10 for your help with this pull request!

* GitHub Issue: #46023