### PR TITLE
GH-45860: [C++] Respect CPU affinity in cpu_count and ThreadPool default capacity

### DIFF
--- a/cpp/src/arrow/util/CMakeLists.txt
+++ b/cpp/src/arrow/util/CMakeLists.txt
@@ -54,6 +54,7 @@ add_arrow_test(utility-test
                cache_test.cc
                checked_cast_test.cc
                compression_test.cc
+               cpu_info_test.cc
                decimal_test.cc
                float16_test.cc
                fixed_width_test.cc

--- a/cpp/src/arrow/util/affinity.h
+++ b/cpp/src/arrow/util/affinity.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <thread>
+
+#ifdef __linux__
+#include <sched.h>
+#include <unistd.h>
+#endif
+
+namespace arrow {
+namespace internal {
+
+// Returns the number of CPUs the current process is allowed to use.
+// Falls back to std::thread::hardware_concurrency() if affinity is not available.
+inline int GetAffinityCpuCount() {
+#ifdef __linux__
+  cpu_set_t mask;
+  if (sched_getaffinity(0, sizeof(mask), &mask) == 0) {
+    return CPU_COUNT(&mask);
+  }
+#endif
+  return std::thread::hardware_concurrency();
+}
+
+}  // namespace internal
+}  // namespace arrow

--- a/cpp/src/arrow/util/cpu_info.cc
+++ b/cpp/src/arrow/util/cpu_info.cc
@@ -46,6 +46,7 @@
 #include <thread>
 
 #include "arrow/result.h"
+#include "arrow/util/affinity.h"
 #include "arrow/util/io_util.h"
 #include "arrow/util/logging_internal.h"
 #include "arrow/util/string.h"
@@ -513,7 +514,7 @@ struct CpuInfo::Impl {
     OsRetrieveCacheSize(&cache_sizes);
     OsRetrieveCpuInfo(&hardware_flags, &vendor, &model_name);
     original_hardware_flags = hardware_flags;
-    num_cores = std::max(static_cast<int>(std::thread::hardware_concurrency()), 1);
+    num_cores = std::max(GetAffinityCpuCount(), 1);
 
     // parse user simd level
     auto maybe_env_var = GetEnvVar("ARROW_USER_SIMD_LEVEL");

--- a/cpp/src/arrow/util/cpu_info_test.cc
+++ b/cpp/src/arrow/util/cpu_info_test.cc
@@ -1,0 +1,21 @@
+#include <gtest/gtest.h>
+#include "arrow/util/cpu_info.h"
+
+#ifdef __linux__
+#include <sched.h>
+#endif
+
+TEST(CpuInfoTest, CpuAffinity) {
+#ifdef __linux__
+  auto cpu_info = arrow::internal::CpuInfo::GetInstance();
+  int affinity_cores = cpu_info->num_cores();
+
+  cpu_set_t mask;
+  ASSERT_EQ(sched_getaffinity(0, sizeof(mask), &mask), 0);
+  int expected = CPU_COUNT(&mask);
+
+  ASSERT_EQ(affinity_cores, expected);
+#else
+  GTEST_SKIP() << "CpuInfo affinity check only applies on Linux.";
+#endif
+}

--- a/cpp/src/arrow/util/thread_pool.cc
+++ b/cpp/src/arrow/util/thread_pool.cc
@@ -26,6 +26,7 @@
 #include <thread>
 #include <vector>
 
+#include "arrow/util/affinity.h"
 #include "arrow/util/atfork_internal.h"
 #include "arrow/util/config.h"
 #include "arrow/util/io_util.h"
@@ -733,7 +734,7 @@ int ThreadPool::DefaultCapacity() {
   int capacity, limit;
   capacity = ParseOMPEnvVar("OMP_NUM_THREADS");
   if (capacity == 0) {
-    capacity = std::thread::hardware_concurrency();
+    capacity = GetAffinityCpuCount();
   }
   limit = ParseOMPEnvVar("OMP_THREAD_LIMIT");
   if (limit > 0) {


### PR DESCRIPTION
### Rationale for this change

Arrow’s current CPU thread count detection uses `std::thread::hardware_concurrency()` which does not take into account the process-level CPU affinity mask (e.g., set via `taskset`). This can lead to thread oversubscription and performance issues when Arrow runs in constrained environments.

This PR improves Arrow's behavior on Linux by making both `CpuInfo::num_cores()` and `ThreadPool::DefaultCapacity()` aware of CPU affinity.

### What changes are included in this PR?

- Added `affinity.h` to expose `GetAffinityCpuCount()` on Linux
- Updated `CpuInfo::Impl` in `cpu_info.cc` to use `GetAffinityCpuCount()` instead of raw `std::thread::hardware_concurrency()`
- Updated `ThreadPool::DefaultCapacity()` to use affinity-aware core count as the fallback when no environment variables are set
- Updated the corresponding test (`TestGlobalThreadPool.Capacity`) to match the new behavior across platforms
- Added a Linux-only unit test (`CpuInfoTest.CpuAffinity`) to validate that `CpuInfo` reflects `sched_getaffinity()`
- Used `#ifdef __linux__` to ensure cross-platform compatibility

### Are these changes tested?

- `CpuInfoTest.CpuAffinity` checks the affinity-aware logic against `sched_getaffinity()` on Linux.
- `TestGlobalThreadPool.Capacity` was updated to test the fallback behavior and env var overrides under the new logic.

### Are there any user-facing changes?

No

<!-- Remove the following sections if not applicable -->

<!-- No breaking API changes -->
<!-- No critical security or crash fix -->

* GitHub Issue: #45860