### PR TITLE
GH-46019: [Python] Raise TypeError on feather read_table if columns is not a Sequence

### DIFF
--- a/python/pyarrow/feather.py
+++ b/python/pyarrow/feather.py
@@ -16,6 +16,7 @@
 # under the License.
 
 
+from collections.abc import Sequence
 import os
 
 from pyarrow.pandas_compat import _pandas_api  # noqa
@@ -254,6 +255,10 @@ def read_table(source, columns=None, memory_map=False, use_threads=True):
 
     if columns is None:
         return reader.read()
+
+    if not isinstance(columns, Sequence):
+        raise TypeError("Columns must be a sequence but, got {}"
+                        .format(type(columns).__name__))
 
     column_types = [type(column) for column in columns]
     if all(map(lambda t: t == int, column_types)):

--- a/python/pyarrow/tests/test_feather.py
+++ b/python/pyarrow/tests/test_feather.py
@@ -811,7 +811,7 @@ def test_read_column_wrong_column_type(tempdir, version):
     path = str(tempdir / "data.feather")
     write_feather(table, path, version=version)
     columns_gen = (x for x in ['a', 'b', 'c'])
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match="Columns must be a sequence"):
         read_table(path, columns=columns_gen)
 
 

--- a/python/pyarrow/tests/test_feather.py
+++ b/python/pyarrow/tests/test_feather.py
@@ -805,6 +805,16 @@ def test_read_column_duplicated_in_file(tempdir):
         read_table(path, columns=['a', 'b'])
 
 
+def test_read_column_wrong_column_type(tempdir, version):
+    # duplicated columns in the column selection
+    table = pa.table([[1, 2, 3], [4, 5, 6], [7, 8, 9]], names=['a', 'b', 'c'])
+    path = str(tempdir / "data.feather")
+    write_feather(table, path, version=version)
+    columns_gen = (x for x in ['a', 'b', 'c'])
+    with pytest.raises(TypeError):
+        read_table(path, columns=columns_gen)
+
+
 def test_nested_types(compression):
     # https://issues.apache.org/jira/browse/ARROW-8860
     table = pa.table({'col': pa.StructArray.from_arrays(

--- a/python/pyarrow/tests/test_feather.py
+++ b/python/pyarrow/tests/test_feather.py
@@ -805,8 +805,7 @@ def test_read_column_duplicated_in_file(tempdir):
         read_table(path, columns=['a', 'b'])
 
 
-def test_read_column_wrong_column_type(tempdir, version):
-    # duplicated columns in the column selection
+def test_read_column_with_generator(tempdir, version):
     table = pa.table([[1, 2, 3], [4, 5, 6], [7, 8, 9]], names=['a', 'b', 'c'])
     path = str(tempdir / "data.feather")
     write_feather(table, path, version=version)


### PR DESCRIPTION
### Rationale for this change

Currently if columns is a generator it fails silently and it provides a non valid result.

### What changes are included in this PR?

Check whether input is or is not a Sequence and raise the appropriate `TypeError` exception.

### Are these changes tested?

Yes

### Are there any user-facing changes?

Yes, minor change where we might raise a `TypeError` when we were not doing it before.

* GitHub Issue: #46019