### PR TITLE
GH-46052: [C++][Benchmarking] Don't build grouper benchmark without ARROW_COMPUTE=ON

### DIFF
--- a/cpp/src/arrow/compute/row/CMakeLists.txt
+++ b/cpp/src/arrow/compute/row/CMakeLists.txt
@@ -20,4 +20,6 @@
 
 arrow_install_all_headers("arrow/compute/row")
 
-add_arrow_benchmark(grouper_benchmark PREFIX "arrow-compute")
+if(ARROW_COMPUTE)
+  add_arrow_benchmark(grouper_benchmark PREFIX "arrow-compute")
+endif()


### PR DESCRIPTION
### Rationale for this change

We should not build benchmark program that uses compute module features without `ARROW_COMPUTE=ON`.

### What changes are included in this PR?

Don't build `grouper_benchmark.cc` without `ARROW_COMPUTE=ON`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #46052