### PR TITLE
GH-46050: [R] Add windows to set of paths in Makevars.in

### DIFF
--- a/r/src/Makevars.in
+++ b/r/src/Makevars.in
@@ -31,4 +31,4 @@ PKG_LIBS=@libs@
 all: $(SHLIB) purify
 
 purify: $(SHLIB)
-	@rm -rf ../libarrow || true
+	@rm -rf ../{libarrow,windows} || true


### PR DESCRIPTION
### Rationale for this change
Prevent warnings on CRAN

### What changes are included in this PR?
Remove paths on windows analogous to linux.  

### Are these changes tested?
Yes, via winbuilder

### Are there any user-facing changes?
No
* GitHub Issue: #46050