### PR TITLE
GH-46058: [Python] Run Python in AppVeyor outside of source directory

### DIFF
--- a/ci/appveyor-cpp-build.bat
+++ b/ci/appveyor-cpp-build.bat
@@ -158,6 +158,6 @@ set PYARROW_TZDATA_PATH=%USERPROFILE%\Downloads\test\tzdata
 set AWS_EC2_METADATA_DISABLED=true
 set PYTHONDEVMODE=1
 
-python -m pytest -r sxX --durations=15 pyarrow/tests || exit /B
-
 popd
+
+python -m pytest -r sxX --durations=15 --pyargs pyarrow || exit /B


### PR DESCRIPTION
### Rationale for this change

Throughout most of CI, the Python pytest invocations are run outside of the source directory. AppVeyor CI is an exception, where tests are invoked directly within the Python source tree.

This works all the same given setuptools performs an in-place build of PyArrow. However, as we look at other build backends, this will need to change. Doing this work up front has no downside, but reduces the diff and troubleshooting that subsequent build backend implementations would need to perform

### What changes are included in this PR?

The AppVeyor CI batch script is modified to invoke pytest outside of the source tree

### Are these changes tested?

Yes

### Are there any user-facing changes?

No

* GitHub Issue: #46058