### PR TITLE
MINOR: [R] Update backwards compat job for 19.0.1.1

### DIFF
--- a/dev/tasks/r/github.linux.arrow.version.back.compat.yml
+++ b/dev/tasks/r/github.linux.arrow.version.back.compat.yml
@@ -85,7 +85,7 @@ jobs:
         config:
         # We use the R version that was released at the time of the arrow release in order
         # to make sure we can download binaries from RSPM.
-        - { old_arrow_version: '19.0.1', r: '4.4' }
+        - { old_arrow_version: '19.0.1.1', r: '4.4' }
         - { old_arrow_version: '18.1.0', r: '4.4' }
         - { old_arrow_version: '17.0.0', r: '4.4' }
         - { old_arrow_version: '16.1.0', r: '4.4' }


### PR DESCRIPTION
### Rationale for this change

We update this as part of the [release checklist](https://github.com/apache/arrow/issues/45950#issuecomment-2784080285).

### What changes are included in this PR?

- Replaced 19.0.1 with 19.0.1.1

### Are these changes tested?

No, but I feel pretty good about them.

### Are there any user-facing changes?

No.