### PR TITLE
GH-46065: [Release] Don't use `--verify-tag` for `gh release upload` in `02-source.sh`

### DIFF
--- a/dev/release/02-source.sh
+++ b/dev/release/02-source.sh
@@ -95,7 +95,6 @@ if [ ${SOURCE_UPLOAD} -gt 0 ]; then
   # Upload signed tarballs to GitHub Release
   gh release upload ${tag} \
      --repo "${GITHUB_REPOSITORY}" \
-     --verify-tag \
      signed-artifacts/*
 
   # check out the arrow RC folder


### PR DESCRIPTION
### Rationale for this change

`gh release upload` doesn't have `--verify-tag` option:

```console
$ gh release upload --help
Upload asset files to a GitHub Release.

To define a display label for an asset, append text starting with `#` after the
file name.


USAGE
  gh release upload <tag> <files>... [flags]

FLAGS
  --clobber   Overwrite existing assets of the same name

INHERITED FLAGS
      --help                     Show help for command
  -R, --repo [HOST/]OWNER/REPO   Select another repository using the [HOST/]OWNER/REPO format

LEARN MORE
  Use `gh <command> <subcommand> --help` for more information about a command.
  Read the manual at https://cli.github.com/manual
```

### What changes are included in this PR?

Remove `--verify-tag`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #46065