### PR TITLE
GH-46068: [Release] Remove needless `docs:rc` task from 05-binary-upload.sh

### DIFF
--- a/dev/release/05-binary-upload.sh
+++ b/dev/release/05-binary-upload.sh
@@ -136,9 +136,6 @@ if [ "${UPLOAD_DEBIAN}" -gt 0 ]; then
   rake_tasks+=(apt:rc:artifactory apt:rc)
   apt_targets+=(debian)
 fi
-if [ "${UPLOAD_DOCS}" -gt 0 ]; then
-  rake_tasks+=(docs:rc)
-fi
 if [ "${UPLOAD_R}" -gt 0 ]; then
   rake_tasks+=(r:rc)
 fi


### PR DESCRIPTION
### Rationale for this change

`docs:rc` task was removed by #45963.

### What changes are included in this PR?

Remove `docs:rc` task use.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #46068