### PR TITLE
GH-46070: [C++] Remove duplicate storage_type in JsonExtension

### DIFF
--- a/cpp/src/arrow/extension/json.h
+++ b/cpp/src/arrow/extension/json.h
@@ -31,7 +31,7 @@ namespace arrow::extension {
 class ARROW_EXPORT JsonExtensionType : public ExtensionType {
  public:
   explicit JsonExtensionType(const std::shared_ptr<DataType>& storage_type)
-      : ExtensionType(storage_type), storage_type_(storage_type) {}
+      : ExtensionType(storage_type) {}
 
   std::string extension_name() const override { return "arrow.json"; }
 
@@ -48,9 +48,6 @@ class ARROW_EXPORT JsonExtensionType : public ExtensionType {
   static Result<std::shared_ptr<DataType>> Make(std::shared_ptr<DataType> storage_type);
 
   static bool IsSupportedStorageType(Type::type type_id);
-
- private:
-  std::shared_ptr<DataType> storage_type_;
 };
 
 /// \brief Return a JsonExtensionType instance.


### PR DESCRIPTION
### Rationale for this change

Remove duplicate storage_type in JsonExtension

### What changes are included in this PR?

Remove duplicate storage_type in JsonExtension

### Are these changes tested?

Covered by existing

### Are there any user-facing changes?

no

* GitHub Issue: #46070