### PR TITLE
GH-46072: [Release] Disable sync in 05-binary-upload.sh

### DIFF
--- a/dev/release/binary-task.rb
+++ b/dev/release/binary-task.rb
@@ -2231,7 +2231,10 @@ APT::FTPArchive::Release::Description "#{apt_repository_description}";
                                                  rc: rc,
                                                  source: upload_target_dir,
                                                  staging: staging?,
-                                                 sync: true,
+                                                 # Don't remove old repodata
+                                                 # because our implementation
+                                                 # doesn't support it.
+                                                 sync: false,
                                                  sync_pattern: /\/repodata\//)
               uploader.upload
             end
@@ -2381,7 +2384,12 @@ APT::FTPArchive::Release::Description "#{apt_repository_description}";
                                                    distribution: distribution,
                                                    rc: rc,
                                                    source: upload_target_dir,
-                                                   sync: true,
+                                                   # Don't remove old
+                                                   # repodata. Because
+                                                   # removing files
+                                                   # aren't supported
+                                                   # on Maven repository.
+                                                   sync: false,
                                                    sync_pattern: /\/repodata\//)
             uploader.upload
           end


### PR DESCRIPTION
### Rationale for this change

A Yum repository uses hash value for metadata file name. e.g.: https://apache.jfrog.io/artifactory/arrow/almalinux/9/x86_64/repodata/00965b628ce7491674b8b0e20355e2c0e81c8d57b04b7e88ac2e6777aad09472-filelists.sqlite.bz2

We can remove old metadata files when update a Yum repository's metadata. But our Artifactory/Maven repository client implementation (`dev/release/binary-task.rb`) doesn't have a complete implementation for removing existing files. But our configuration enables the feature.

### What changes are included in this PR?

Disable the feature.

The feature was enabled by #45903 accidentally. Old implementation disables the feature. So this doesn't change the existing behavior. (Garbage will be increased in Yum repositories...)

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #46072