### PR TITLE
GH-45957: [C++][Python] Expose `allow_delayed_open` on S3FileSystem

### DIFF
--- a/cpp/src/arrow/filesystem/s3fs.cc
+++ b/cpp/src/arrow/filesystem/s3fs.cc
@@ -401,6 +401,9 @@ Result<S3Options> S3Options::FromUri(const Uri& uri, std::string* out_path) {
       options.scheme = kv.second;
     } else if (kv.first == "endpoint_override") {
       options.endpoint_override = kv.second;
+    } else if (kv.first == "allow_delayed_open") {
+      ARROW_ASSIGN_OR_RAISE(options.allow_delayed_open,
+                            ::arrow::internal::ParseBoolean(kv.second));
     } else if (kv.first == "allow_bucket_creation") {
       ARROW_ASSIGN_OR_RAISE(options.allow_bucket_creation,
                             ::arrow::internal::ParseBoolean(kv.second));
@@ -448,6 +451,7 @@ bool S3Options::Equals(const S3Options& other) const {
           proxy_options.Equals(other.proxy_options) &&
           credentials_kind == other.credentials_kind &&
           background_writes == other.background_writes &&
+          allow_delayed_open == other.allow_delayed_open &&
           allow_bucket_creation == other.allow_bucket_creation &&
           allow_bucket_deletion == other.allow_bucket_deletion &&
           tls_ca_file_path == other.tls_ca_file_path &&

--- a/python/pyarrow/_s3fs.pyx
+++ b/python/pyarrow/_s3fs.pyx
@@ -234,6 +234,12 @@ cdef class S3FileSystem(FileSystem):
             S3FileSystem(proxy_options={'scheme': 'http', 'host': 'localhost',
                                         'port': 8020, 'username': 'username',
                                         'password': 'password'})
+    allow_delayed_open : bool, default False
+        Whether to allow file-open methods to return before the actual open. This option
+        may reduce latency as it decreases the number of round trips.
+        The downside is failures such as opening a file in a non-existing bucket will
+        only be reported when actual I/O is done (at worst, when attempting to close the
+        file).
     allow_bucket_creation : bool, default False
         Whether to allow directory creation at the bucket-level. This option may also be
         passed in a URI query parameter.
@@ -279,6 +285,7 @@ cdef class S3FileSystem(FileSystem):
                  bint background_writes=True, default_metadata=None,
                  role_arn=None, session_name=None, external_id=None,
                  load_frequency=900, proxy_options=None,
+                 allow_delayed_open=False,
                  allow_bucket_creation=False, allow_bucket_deletion=False,
                  check_directory_existence_before_creation=False,
                  retry_strategy: S3RetryStrategy = AwsStandardS3RetryStrategy(
@@ -393,6 +400,7 @@ cdef class S3FileSystem(FileSystem):
                     "'proxy_options': expected 'dict' or 'str', "
                     f"got {type(proxy_options)} instead.")
 
+        options.value().allow_delayed_open = allow_delayed_open
         options.value().allow_bucket_creation = allow_bucket_creation
         options.value().allow_bucket_deletion = allow_bucket_deletion
         options.value().check_directory_existence_before_creation = check_directory_existence_before_creation
@@ -453,6 +461,7 @@ cdef class S3FileSystem(FileSystem):
                 external_id=frombytes(opts.external_id),
                 load_frequency=opts.load_frequency,
                 background_writes=opts.background_writes,
+                allow_delayed_open=opts.allow_delayed_open,
                 allow_bucket_creation=opts.allow_bucket_creation,
                 allow_bucket_deletion=opts.allow_bucket_deletion,
                 check_directory_existence_before_creation=opts.check_directory_existence_before_creation,

--- a/python/pyarrow/includes/libarrow_fs.pxd
+++ b/python/pyarrow/includes/libarrow_fs.pxd
@@ -155,6 +155,7 @@ cdef extern from "arrow/filesystem/api.h" namespace "arrow::fs" nogil:
         c_string endpoint_override
         c_string scheme
         c_bool background_writes
+        c_bool allow_delayed_open
         c_bool allow_bucket_creation
         c_bool allow_bucket_deletion
         c_bool check_directory_existence_before_creation

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -1230,6 +1230,11 @@ def test_s3_options(pickle_module):
     assert pickle_module.loads(pickle_module.dumps(fs2)) == fs2
     assert fs2 != fs
 
+    fs = S3FileSystem(allow_delayed_open=True)
+    assert isinstance(fs, S3FileSystem)
+    assert pickle_module.loads(pickle_module.dumps(fs)) == fs
+    assert pickle_module.loads(pickle_module.dumps(fs)) != S3FileSystem()
+
     fs = S3FileSystem(allow_bucket_creation=True, allow_bucket_deletion=True)
     assert isinstance(fs, S3FileSystem)
     assert pickle_module.loads(pickle_module.dumps(fs)) == fs
@@ -1835,9 +1840,17 @@ def test_s3_real_aws_region_selection():
     # Nonexistent bucket (hopefully, otherwise need to fix this test)
     with pytest.raises(IOError, match="Bucket '.*' not found"):
         FileSystem.from_uri('s3://x-arrow-nonexistent-bucket')
-    fs, path = FileSystem.from_uri(
-        's3://x-arrow-nonexistent-bucket?region=us-east-3')
+    fs, path = FileSystem.from_uri('s3://x-arrow-nonexistent-bucket?region=us-east-3')
     assert fs.region == 'us-east-3'
+
+    # allow_delayed_open has a side-effect of delaying errors until I/O is performed.
+    # region is required to bypass the lookup for a nonexistent bucket, allowing us to
+    # verify that errors are properly delayed until stream closure.
+    fs, path = FileSystem.from_uri(
+        's3://x-arrow-nonexistent-bucket/T.md?region=us-east-2&allow_delayed_open=true')
+    stream = fs.open_output_stream(path)
+    with pytest.raises(IOError):
+        stream.close()
 
 
 @pytest.mark.s3


### PR DESCRIPTION
### What changes are included in this PR?

1) Allow passing `allow_delayed_open` as URI parameter in S3 URIs
2) Expose the parameter `allow_delayed_open` to Python's `S3FileSystem` API

### Are these changes tested?

Yes, on the Python side.

### Are there any user-facing changes?

This PR contains a backwards compatible feature addition.

* GitHub Issue: #45957