### PR TITLE
GH-45716: [R][CI] Refactor skip_on_python_older_than to not initialize reticulate

### DIFF
--- a/r/tests/testthat/helper-skip.R
+++ b/r/tests/testthat/helper-skip.R
@@ -116,11 +116,16 @@ skip_on_python_older_than <- function(python_version) {
     return()
   }
 
-  if (!reticulate::py_available(initialize = TRUE)) {
+  # We want to be careful not to initialize reticulate in this helper function
+  config <- reticulate::py_discover_config()
+
+  # It isn't documented, but config should be NULL when py_discovery_config()
+  # fails to find a valid Python installation
+  if (is.null(config)) {
     skip("Python isn't available")
   }
 
-  if (reticulate::py_version() < python_version) {
+  if (config$version < python_version) {
     skip(paste("Python version:", reticulate::py_version()))
   }
 }


### PR DESCRIPTION
### Rationale for this change

This fixes our `test-r-offline-maximal` job which started failing because of a change in reticulate 1.41.0.

### What changes are included in this PR?

Changed internals of our skip_on_python_older_than helper.

### Are these changes tested?

Locally, need to test in CI before merging.

### Are there any user-facing changes?

No.
* GitHub Issue: #45716