### PR TITLE
GH-46081: [Release] Don't generate needless `uploaded-files.txt` for Maven repository

### DIFF
--- a/dev/release/binary-task.rb
+++ b/dev/release/binary-task.rb
@@ -1875,7 +1875,6 @@ APT::FTPArchive::Release::Description "#{apt_repository_description}";
                  upload_distribution_dir,
                  preserve: true,
                  verbose: verbose?)
-            write_uploaded_files(upload_distribution_dir)
             uploader =
               MavenRepositoryUploader.new(asf_user: asf_user,
                                           asf_password: asf_password,
@@ -2377,7 +2376,6 @@ APT::FTPArchive::Release::Description "#{apt_repository_description}";
                  upload_target_dir.to_s,
                  preserve: true,
                  verbose: verbose?)
-            write_uploaded_files(upload_target_dir)
 
             uploader = MavenRepositoryUploader.new(asf_user: asf_user,
                                                    asf_password: asf_password,


### PR DESCRIPTION
### Rationale for this change

`uploaded-files.txt` is for Artifactory. Artifactory doesn't have the staging feature. So we emulate the feature by `uploaded-files.txt`.

But Maven repository has the feature. So we don't need to generate `uploaded-files.txt`.

### What changes are included in this PR?

Don't generate `uploaded-files.txt`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #46081