### PR TITLE
GH-46085: [C++][FS][Azure] Treat a 403 when getting container properties like the container exists

### DIFF
--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -576,9 +576,8 @@ bool IsForbidden(const Storage::StorageException& e) {
   if (e.ErrorCode == "AuthorizationFailure" ||
       e.ReasonPhrase == "This request is not authorized to perform this operation.") {
     DCHECK_EQ(e.StatusCode, Http::HttpStatusCode::Forbidden);
-    return true;
   }
-  return false;
+  return e.StatusCode == Http::HttpStatusCode::Forbidden;
 }
 
 const auto kHierarchicalNamespaceIsDirectoryMetadataKey = "hdi_isFolder";

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -581,7 +581,6 @@ bool IsForbidden(const Storage::StorageException& e) {
   return false;
 }
 
-
 const auto kHierarchicalNamespaceIsDirectoryMetadataKey = "hdi_isFolder";
 const auto kFlatNamespaceIsDirectoryMetadataKey = "is_directory";
 
@@ -1455,11 +1454,11 @@ Result<FileInfo> GetContainerPropsAsFileInfo(const AzureLocation& location,
     }
 
     if (IsForbidden(exception)) {
-      // User delegated sas tokens don't allow for getting container properties. Assume the container exists
+      // User delegated sas tokens don't allow for getting container properties. Assume
+      // the container exists
       info.set_type(FileType::Directory);
       info.set_mtime(std::chrono::system_clock::now());
       return info;
-
     }
     return ExceptionToStatus(exception, "GetProperties for '", container_client.GetUrl(),
                              "' failed.");


### PR DESCRIPTION
### Rationale for this change

User delegated sas tokens in Azure (and some standard sas tokens) don't have permissions to query container properties. The assumption needs to be made that the container exists and let something further up the chain fail if the container doesn't exist. 

There is functionality that creates a new container, but it won't come into play because the sas token also does not have permission to do that either.

### What changes are included in this PR?

Return an fs item type of directory with a modified time of now when getting container properties returns a 403.

### Are these changes tested?

Yes, manually. Unsure how to integrate into automated test suite. Happy to discuss.

### Are there any user-facing changes?

No

* GitHub Issue: #46085