### PR TITLE
GH-32339: [C++][Python][Parquet] Implement direct reads of Parquet RLE encoded data into Arrow REE

### DIFF
--- a/cpp/src/arrow/dataset/file_parquet.cc
+++ b/cpp/src/arrow/dataset/file_parquet.cc
@@ -115,6 +115,10 @@ parquet::ArrowReaderProperties MakeArrowReaderProperties(
     auto column_index = metadata.schema()->ColumnIndex(name);
     properties.set_read_dictionary(column_index, true);
   }
+  for (const std::string& name : format.reader_options.ree_columns) {
+    auto column_index = metadata.schema()->ColumnIndex(name);
+    properties.set_read_ree(column_index, true);
+  }
   properties.set_coerce_int96_timestamp_unit(
       format.reader_options.coerce_int96_timestamp_unit);
   properties.set_binary_type(format.reader_options.binary_type);
@@ -445,6 +449,7 @@ bool ParquetFileFormat::Equals(const FileFormat& other) const {
 
   // FIXME implement comparison for decryption options
   return (reader_options.dict_columns == other_reader_options.dict_columns &&
+          reader_options.ree_columns == other_reader_options.ree_columns &&
           reader_options.coerce_int96_timestamp_unit ==
               other_reader_options.coerce_int96_timestamp_unit &&
           reader_options.binary_type == other_reader_options.binary_type &&

--- a/cpp/src/arrow/dataset/file_parquet.h
+++ b/cpp/src/arrow/dataset/file_parquet.h
@@ -89,6 +89,7 @@ class ARROW_DS_EXPORT ParquetFileFormat : public FileFormat {
     ///
     /// @{
     std::unordered_set<std::string> dict_columns;
+    std::unordered_set<std::string> ree_columns;
     arrow::TimeUnit::type coerce_int96_timestamp_unit = arrow::TimeUnit::NANO;
     Type::type binary_type = Type::BINARY;
     Type::type list_type = Type::LIST;

--- a/cpp/src/parquet/CMakeLists.txt
+++ b/cpp/src/parquet/CMakeLists.txt
@@ -406,7 +406,10 @@ add_parquet_test(arrow-reader-writer-test
                  SOURCES
                  arrow/arrow_reader_writer_test.cc
                  arrow/arrow_statistics_test.cc
-                 arrow/variant_test.cc)
+                 arrow/variant_test.cc
+                 EXTRA_LINK_LIBS
+                 arrow_compute_core_testing
+                 arrow_acero_testing)
 
 add_parquet_test(arrow-internals-test SOURCES arrow/path_internal_test.cc
                  arrow/reconstruct_internal_test.cc)

--- a/cpp/src/parquet/arrow/reader.cc
+++ b/cpp/src/parquet/arrow/reader.cc
@@ -462,7 +462,9 @@ class LeafReader : public ColumnReaderImpl {
     record_reader_ = RecordReader::Make(
         descr_, leaf_info, ctx_->pool,
         /*read_dictionary=*/field_->type()->id() == ::arrow::Type::DICTIONARY,
-        /*read_dense_for_nullable=*/false, /*arrow_type=*/type_for_reading);
+        /*read_dense_for_nullable=*/false,
+        /*read_run_end_encoded=*/field_->type()->id() == ::arrow::Type::RUN_END_ENCODED,
+        /*arrow_type=*/type_for_reading);
     NextRowGroup();
   }
 

--- a/cpp/src/parquet/arrow/reader_internal.cc
+++ b/cpp/src/parquet/arrow/reader_internal.cc
@@ -95,6 +95,7 @@ using ::arrow::util::SafeLoadAs;
 using parquet::internal::BinaryRecordReader;
 using parquet::internal::DictionaryRecordReader;
 using parquet::internal::RecordReader;
+using parquet::internal::ReeRecordReader;
 using parquet::schema::GroupNode;
 using parquet::schema::Node;
 using parquet::schema::PrimitiveNode;
@@ -566,6 +567,24 @@ Status TransferDictionary(RecordReader* reader, MemoryPool* pool,
   return Status::OK();
 }
 
+Status TransferRunEndEncoded(RecordReader* reader, MemoryPool* pool,
+                             const std::shared_ptr<DataType>& logical_value_type,
+                             bool nullable, std::shared_ptr<ChunkedArray>* out) {
+  auto ree_reader = dynamic_cast<ReeRecordReader*>(reader);
+  DCHECK(ree_reader);
+  std::shared_ptr<::arrow::Array> result = ree_reader->GetResult();
+  *out = std::make_shared<ChunkedArray>(result);
+  if (!logical_value_type->Equals(*(*out)->type())) {
+    ARROW_ASSIGN_OR_RAISE(*out, ViewOrCastChunkedArray(*out, pool, logical_value_type));
+  }
+  if (!nullable) {
+    ::arrow::ArrayVector chunks = (*out)->chunks();
+    ReconstructChunksWithoutNulls(&chunks);
+    *out = std::make_shared<ChunkedArray>(std::move(chunks), logical_value_type);
+  }
+  return Status::OK();
+}
+
 Status TransferBinary(RecordReader* reader, MemoryPool* pool,
                       const std::shared_ptr<Field>& logical_type_field,
                       std::shared_ptr<ChunkedArray>* out) {
@@ -574,6 +593,12 @@ Status TransferBinary(RecordReader* reader, MemoryPool* pool,
         reader, pool, ::arrow::dictionary(::arrow::int32(), logical_type_field->type()),
         logical_type_field->nullable(), out);
   }
+  if (reader->read_ree()) {
+    return TransferRunEndEncoded(
+        reader, pool, ::arrow::run_end_encoded(::arrow::int32(), logical_type_field->type()),
+        logical_type_field->nullable(), out);
+  }
+
   ::arrow::compute::ExecContext ctx(pool);
   ::arrow::compute::CastOptions cast_options;
   cast_options.allow_invalid_utf8 = true;  // avoid spending time validating UTF8 data
@@ -862,6 +887,11 @@ Status TransferColumnData(RecordReader* reader,
     case ::arrow::Type::DICTIONARY: {
       RETURN_NOT_OK(TransferDictionary(reader, pool, value_field->type(),
                                        value_field->nullable(), &chunked_result));
+      result = chunked_result;
+    } break;
+    case ::arrow::Type::RUN_END_ENCODED: {
+      RETURN_NOT_OK(TransferRunEndEncoded(reader, pool, value_field->type(),
+                                          value_field->nullable(), &chunked_result));
       result = chunked_result;
     } break;
     case ::arrow::Type::NA: {

--- a/cpp/src/parquet/arrow/schema.cc
+++ b/cpp/src/parquet/arrow/schema.cc
@@ -537,6 +537,11 @@ bool IsDictionaryReadSupported(const ArrowType& type) {
   return type.id() == ::arrow::Type::BINARY || type.id() == ::arrow::Type::STRING;
 }
 
+bool IsRunEndEncodedReadSupported(const ArrowType& type) {
+  // Only supported currently for BYTE_ARRAY types
+  return type.id() == ::arrow::Type::BINARY || type.id() == ::arrow::Type::STRING;
+}
+
 // ----------------------------------------------------------------------
 // Schema logic
 
@@ -548,6 +553,9 @@ bool IsDictionaryReadSupported(const ArrowType& type) {
   if (ctx->properties.read_dictionary(column_index) &&
       IsDictionaryReadSupported(*storage_type)) {
     return ::arrow::dictionary(::arrow::int32(), storage_type);
+  } else if (ctx->properties.read_ree(column_index) &&
+             IsRunEndEncodedReadSupported(*storage_type)) {
+    return ::arrow::run_end_encoded(::arrow::int32(), storage_type);
   }
   return storage_type;
 }

--- a/cpp/src/parquet/column_reader.cc
+++ b/cpp/src/parquet/column_reader.cc
@@ -34,6 +34,7 @@
 #include "arrow/array/builder_binary.h"
 #include "arrow/array/builder_dict.h"
 #include "arrow/array/builder_primitive.h"
+#include "arrow/array/builder_run_end.h"
 #include "arrow/chunked_array.h"
 #include "arrow/type.h"
 #include "arrow/util/bit_stream_utils_internal.h"
@@ -2074,6 +2075,47 @@ class ByteArrayChunkedRecordReader final : public TypedRecordReader<ByteArrayTyp
   typename EncodingTraits<ByteArrayType>::Accumulator accumulator_;
 };
 
+class ByteArrayReeRecordReader final : public TypedRecordReader<ByteArrayType>,
+                                       virtual public ReeRecordReader {
+ public:
+  ByteArrayReeRecordReader(const ColumnDescriptor* descr, LevelInfo leaf_info,
+                           ::arrow::MemoryPool* pool, bool read_dense_for_nullable)
+      : TypedRecordReader<ByteArrayType>(descr, leaf_info, pool,
+                                         read_dense_for_nullable) {
+    read_ree_ = true;
+    ARROW_DCHECK_EQ(descr_->physical_type(), Type::BYTE_ARRAY);
+    PARQUET_THROW_NOT_OK(::arrow::MakeBuilder(
+        ::arrow::default_memory_pool(),
+        ::arrow::run_end_encoded(::arrow::int32(), ::arrow::binary()), &builder_));
+  }
+
+  void ReadValuesDense(int64_t values_to_read) override {
+    int64_t num_decoded = this->current_decoder_->DecodeArrowNonNull(
+        static_cast<int>(values_to_read),
+        checked_cast<::arrow::RunEndEncodedBuilder*>(builder_.get()));
+    CheckNumberDecoded(num_decoded, values_to_read);
+    ResetValues();
+  }
+
+  void ReadValuesSpaced(int64_t values_to_read, int64_t null_count) override {
+    int64_t num_decoded = this->current_decoder_->DecodeArrow(
+        static_cast<int>(values_to_read), static_cast<int>(null_count),
+        valid_bits_->mutable_data(), values_written_,
+        checked_cast<::arrow::RunEndEncodedBuilder*>(builder_.get()));
+    CheckNumberDecoded(num_decoded, values_to_read - null_count);
+    ResetValues();
+  }
+
+  std::shared_ptr<::arrow::Array> GetResult() override {
+    std::shared_ptr<::arrow::Array> result;
+    PARQUET_THROW_NOT_OK(builder_->Finish(&result));
+    return result;
+  }
+
+ private:
+  std::unique_ptr<::arrow::ArrayBuilder> builder_;
+};
+
 /// ByteArrayDictionaryRecordReader reads into ::arrow::dictionary(index: int32,
 /// values: binary).
 ///
@@ -2171,11 +2213,14 @@ void TypedRecordReader<FLBAType>::DebugPrintState() {}
 
 std::shared_ptr<RecordReader> MakeByteArrayRecordReader(
     const ColumnDescriptor* descr, LevelInfo leaf_info, ::arrow::MemoryPool* pool,
-    bool read_dictionary, bool read_dense_for_nullable,
+    bool read_dictionary, bool read_dense_for_nullable, bool read_run_end_encoded,
     const std::shared_ptr<::arrow::DataType>& arrow_type) {
   if (read_dictionary) {
     return std::make_shared<ByteArrayDictionaryRecordReader>(descr, leaf_info, pool,
                                                              read_dense_for_nullable);
+  } else if (read_run_end_encoded) {
+    return std::make_shared<ByteArrayReeRecordReader>(
+        descr, leaf_info, pool, read_dense_for_nullable);
   } else {
     return std::make_shared<ByteArrayChunkedRecordReader>(
         descr, leaf_info, pool, read_dense_for_nullable, arrow_type);
@@ -2186,7 +2231,7 @@ std::shared_ptr<RecordReader> MakeByteArrayRecordReader(
 
 std::shared_ptr<RecordReader> RecordReader::Make(
     const ColumnDescriptor* descr, LevelInfo leaf_info, MemoryPool* pool,
-    bool read_dictionary, bool read_dense_for_nullable,
+    bool read_dictionary, bool read_dense_for_nullable, bool read_run_end_encoded,
     const std::shared_ptr<::arrow::DataType>& arrow_type) {
   switch (descr->physical_type()) {
     case Type::BOOLEAN:
@@ -2207,10 +2252,9 @@ std::shared_ptr<RecordReader> RecordReader::Make(
     case Type::DOUBLE:
       return std::make_shared<TypedRecordReader<DoubleType>>(descr, leaf_info, pool,
                                                              read_dense_for_nullable);
-    case Type::BYTE_ARRAY: {
+    case Type::BYTE_ARRAY:
       return MakeByteArrayRecordReader(descr, leaf_info, pool, read_dictionary,
-                                       read_dense_for_nullable, arrow_type);
-    }
+                                       read_dense_for_nullable, read_run_end_encoded, arrow_type);
     case Type::FIXED_LEN_BYTE_ARRAY:
       return std::make_shared<FLBARecordReader>(descr, leaf_info, pool,
                                                 read_dense_for_nullable);

--- a/cpp/src/parquet/column_reader.h
+++ b/cpp/src/parquet/column_reader.h
@@ -273,6 +273,7 @@ class PARQUET_EXPORT RecordReader {
       const ColumnDescriptor* descr, LevelInfo leaf_info,
       ::arrow::MemoryPool* pool = ::arrow::default_memory_pool(),
       bool read_dictionary = false, bool read_dense_for_nullable = false,
+      bool read_run_end_encoded = false,
       const std::shared_ptr<::arrow::DataType>& arrow_type = NULLPTR);
 
   virtual ~RecordReader() = default;
@@ -373,6 +374,9 @@ class PARQUET_EXPORT RecordReader {
   /// \brief True if reading directly as Arrow dictionary-encoded
   bool read_dictionary() const { return read_dictionary_; }
 
+  /// \brief True if reading directly as Arrow run-end-encoded
+  bool read_ree() const { return read_ree_; }
+
   /// \brief True if reading dense for nullable columns.
   bool read_dense_for_nullable() const { return read_dense_for_nullable_; }
 
@@ -424,6 +428,7 @@ class PARQUET_EXPORT RecordReader {
   int64_t levels_capacity_;
 
   bool read_dictionary_ = false;
+  bool read_ree_ = false;
   // If true, we will not leave any space for the null values in the values_
   // vector or fill nulls values in BinaryRecordReader/DictionaryRecordReader.
   //
@@ -442,6 +447,13 @@ class BinaryRecordReader : virtual public RecordReader {
 class DictionaryRecordReader : virtual public RecordReader {
  public:
   virtual std::shared_ptr<::arrow::ChunkedArray> GetResult() = 0;
+};
+
+/// \brief Read records directly to run-end-encoded Arrow form (int32
+/// run ends). Only valid for BYTE_ARRAY columns
+class ReeRecordReader : virtual public RecordReader {
+ public:
+  virtual std::shared_ptr<::arrow::Array> GetResult() = 0;
 };
 
 }  // namespace internal

--- a/cpp/src/parquet/file_reader.cc
+++ b/cpp/src/parquet/file_reader.cc
@@ -111,7 +111,7 @@ std::shared_ptr<ColumnReader> RowGroupReader::Column(int i) {
 }
 
 std::shared_ptr<internal::RecordReader> RowGroupReader::RecordReader(
-    int i, bool read_dictionary) {
+    int i, bool read_dictionary, bool read_ree) {
   if (i >= metadata()->num_columns()) {
     std::stringstream ss;
     ss << "Trying to read column index " << i << " but row group metadata has only "
@@ -126,7 +126,7 @@ std::shared_ptr<internal::RecordReader> RowGroupReader::RecordReader(
 
   auto reader = internal::RecordReader::Make(
       descr, level_info, contents_->properties()->memory_pool(), read_dictionary,
-      contents_->properties()->read_dense_for_nullable());
+      contents_->properties()->read_dense_for_nullable(), read_ree);
   reader->SetPageReader(std::move(page_reader));
   return reader;
 }
@@ -149,7 +149,8 @@ std::shared_ptr<internal::RecordReader> RowGroupReader::RecordReaderWithExposeEn
   return RecordReader(
       i,
       /*read_dictionary=*/encoding_to_expose == ExposedEncoding::DICTIONARY &&
-          IsColumnChunkFullyDictionaryEncoded(*metadata()->ColumnChunk(i)));
+          IsColumnChunkFullyDictionaryEncoded(*metadata()->ColumnChunk(i)),
+      /*read_ree=*/encoding_to_expose == ExposedEncoding::REE);
 }
 
 std::unique_ptr<PageReader> RowGroupReader::GetColumnPageReader(int i) {

--- a/cpp/src/parquet/file_reader.h
+++ b/cpp/src/parquet/file_reader.h
@@ -65,7 +65,8 @@ class PARQUET_EXPORT RowGroupReader {
   // EXPERIMENTAL: Construct a RecordReader for the indicated column of the row group.
   // Ownership is shared with the RowGroupReader.
   std::shared_ptr<internal::RecordReader> RecordReader(int i,
-                                                       bool read_dictionary = false);
+                                                       bool read_dictionary = false,
+                                                       bool read_ree = false);
 
   // Construct a ColumnReader, trying to enable exposed encoding.
   //
@@ -83,7 +84,7 @@ class PARQUET_EXPORT RowGroupReader {
 
   // Construct a RecordReader, trying to enable exposed encoding.
   //
-  // For dictionary encoding, currently we only support column chunks that are
+  // For dictionary and run-end encoding, currently we only support column chunks that are
   // fully dictionary encoded byte arrays. The caller should verify if the reader can read
   // and expose the dictionary by checking the reader's read_dictionary(). If a column
   // chunk uses dictionary encoding but then falls back to plain encoding, the returned

--- a/cpp/src/parquet/properties.h
+++ b/cpp/src/parquet/properties.h
@@ -1038,6 +1038,25 @@ class PARQUET_EXPORT ArrowReaderProperties {
     }
   }
 
+  /// \brief Set whether to read a particular column as run-end-encoded.
+  ///
+  /// This is only supported for columns with a Parquet physical type of
+  /// BYTE_ARRAY, such as string or binary types.
+  void set_read_ree(int column_index, bool read_ree) {
+    if (read_ree) {
+      read_ree_indices_.insert(column_index);
+    } else {
+      read_ree_indices_.erase(column_index);
+    }
+  }
+  bool read_ree(int column_index) const {
+    if (read_ree_indices_.find(column_index) != read_ree_indices_.end()) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
   /// \brief Set the Arrow binary type to read BYTE_ARRAY columns as.
   ///
   /// Allowed values are Type::BINARY, Type::LARGE_BINARY and Type::BINARY_VIEW.
@@ -1148,6 +1167,7 @@ class PARQUET_EXPORT ArrowReaderProperties {
  private:
   bool use_threads_;
   std::unordered_set<int> read_dict_indices_;
+  std::unordered_set<int> read_ree_indices_;
   int64_t batch_size_;
   bool pre_buffer_;
   ::arrow::io::IOContext io_context_;

--- a/cpp/src/parquet/types.h
+++ b/cpp/src/parquet/types.h
@@ -550,7 +550,8 @@ struct Encoding {
 // decoding, in which case the data read from the file is DICTIONARY encoded.
 enum class ExposedEncoding {
   NO_ENCODING = 0,  // data is not encoded, i.e. already decoded during reading
-  DICTIONARY = 1
+  DICTIONARY = 1,
+  REE = 2
 };
 
 /// \brief Return true if Parquet supports indicated compression type

--- a/python/pyarrow/_dataset_parquet.pyx
+++ b/python/pyarrow/_dataset_parquet.pyx
@@ -142,6 +142,9 @@ cdef class ParquetFileFormat(FileFormat):
         if read_options.dictionary_columns is not None:
             for column in read_options.dictionary_columns:
                 options.dict_columns.insert(tobytes(column))
+        if read_options.ree_columns is not None:
+            for column in read_options.ree_columns:
+                options.ree_columns.insert(tobytes(column))
         options.coerce_int96_timestamp_unit = \
             read_options._coerce_int96_timestamp_unit
         options.binary_type = read_options._binary_type
@@ -181,6 +184,7 @@ cdef class ParquetFileFormat(FileFormat):
         parquet_read_options = ParquetReadOptions(
             dictionary_columns={frombytes(col)
                                 for col in options.dict_columns},
+            ree_columns={frombytes(col) for col in options.ree_columns},
         )
         # Read options getter/setter works with strings so setting
         # the private property which uses the C Type
@@ -527,15 +531,18 @@ cdef class ParquetReadOptions(_Weakrefable):
 
     cdef public:
         set dictionary_columns
+        set ree_columns
         TimeUnit _coerce_int96_timestamp_unit
         Type _binary_type
         Type _list_type
 
     # Also see _PARQUET_READ_OPTIONS
     def __init__(self, dictionary_columns=None,
+                 ree_columns=None,
                  coerce_int96_timestamp_unit=None,
                  binary_type=None, list_type=None):
         self.dictionary_columns = set(dictionary_columns or set())
+        self.ree_columns = set(ree_columns or set())
         self.coerce_int96_timestamp_unit = coerce_int96_timestamp_unit
         self.binary_type = binary_type
         self.list_type = list_type
@@ -585,6 +592,7 @@ cdef class ParquetReadOptions(_Weakrefable):
         bool
         """
         return (self.dictionary_columns == other.dictionary_columns and
+                self.ree_columns == other.ree_columns and
                 self._coerce_int96_timestamp_unit ==
                 other._coerce_int96_timestamp_unit and
                 self._binary_type == other._binary_type and
@@ -600,6 +608,7 @@ cdef class ParquetReadOptions(_Weakrefable):
         return (
             f"<ParquetReadOptions"
             f" dictionary_columns={self.dictionary_columns}"
+            f" ree_columns={self.ree_columns}"
             f" coerce_int96_timestamp_unit={self.coerce_int96_timestamp_unit}"
             f" binary_type={self.binary_type}"
             f" list_type={self.list_type}"
@@ -721,7 +730,7 @@ cdef class ParquetFileWriteOptions(FileWriteOptions):
 
 
 cdef set _PARQUET_READ_OPTIONS = {
-    'dictionary_columns', 'coerce_int96_timestamp_unit', 'binary_type', 'list_type',
+    'dictionary_columns', 'ree_columns', 'coerce_int96_timestamp_unit', 'binary_type', 'list_type',
 }
 
 

--- a/python/pyarrow/includes/libarrow_dataset_parquet.pxd
+++ b/python/pyarrow/includes/libarrow_dataset_parquet.pxd
@@ -62,6 +62,7 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
     cdef cppclass CParquetFileFormatReaderOptions \
             "arrow::dataset::ParquetFileFormat::ReaderOptions":
         unordered_set[c_string] dict_columns
+        unordered_set[c_string] ree_columns
         TimeUnit coerce_int96_timestamp_unit
         Type binary_type
         Type list_type

--- a/python/pyarrow/includes/libparquet.pxd
+++ b/python/pyarrow/includes/libparquet.pxd
@@ -446,6 +446,8 @@ cdef extern from "parquet/api/reader.h" namespace "parquet" nogil:
         Type list_type()
         void set_read_dictionary(int column_index, c_bool read_dict)
         c_bool read_dictionary(int column_index)
+        void set_read_ree(int column_index, c_bool read_ree)
+        c_bool read_ree(int column_index)
         void set_batch_size(int64_t batch_size)
         int64_t batch_size()
         void set_pre_buffer(c_bool pre_buffer)

--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -265,6 +265,8 @@ class ParquetFile:
         If True, read Parquet logical types as Arrow extension types where possible,
         (e.g., read JSON as the canonical `arrow.json` extension type or UUID as
         the canonical `arrow.uuid` extension type).
+    read_ree : list
+        List of column names to read directly as an REE Encoded Array.
 
     Examples
     --------
@@ -314,7 +316,7 @@ class ParquetFile:
                  coerce_int96_timestamp_unit=None,
                  decryption_properties=None, thrift_string_size_limit=None,
                  thrift_container_size_limit=None, filesystem=None,
-                 page_checksum_verification=False, arrow_extensions_enabled=True):
+                 page_checksum_verification=False, arrow_extensions_enabled=True, read_ree=None):
 
         self._close_source = getattr(source, 'closed', True)
 
@@ -336,6 +338,7 @@ class ParquetFile:
             thrift_container_size_limit=thrift_container_size_limit,
             page_checksum_verification=page_checksum_verification,
             arrow_extensions_enabled=arrow_extensions_enabled,
+            read_ree=read_ree,
         )
         self.common_metadata = common_metadata
         self._nested_paths_by_prefix = self._build_nested_paths()
@@ -1350,7 +1353,8 @@ Examples
                  decryption_properties=None, thrift_string_size_limit=None,
                  thrift_container_size_limit=None,
                  page_checksum_verification=False,
-                 arrow_extensions_enabled=True):
+                 arrow_extensions_enabled=True,
+                 read_ree=None):
         import pyarrow.dataset as ds
 
         # map format arguments
@@ -1369,6 +1373,9 @@ Examples
                                 buffer_size=buffer_size)
         if read_dictionary is not None:
             read_options.update(dictionary_columns=read_dictionary)
+
+        if read_ree is not None:
+            read_options.update(ree_columns=read_ree)
 
         if decryption_properties is not None:
             read_options.update(decryption_properties=decryption_properties)
@@ -1846,7 +1853,8 @@ def read_table(source, *, columns=None, use_threads=True,
                decryption_properties=None, thrift_string_size_limit=None,
                thrift_container_size_limit=None,
                page_checksum_verification=False,
-               arrow_extensions_enabled=True):
+               arrow_extensions_enabled=True,
+               read_ree=None):
 
     try:
         dataset = ParquetDataset(
@@ -1868,6 +1876,7 @@ def read_table(source, *, columns=None, use_threads=True,
             thrift_container_size_limit=thrift_container_size_limit,
             page_checksum_verification=page_checksum_verification,
             arrow_extensions_enabled=arrow_extensions_enabled,
+            read_ree=read_ree
         )
     except ImportError:
         # fall back on ParquetFile for simple cases when pyarrow.dataset
@@ -1902,6 +1911,7 @@ def read_table(source, *, columns=None, use_threads=True,
             thrift_string_size_limit=thrift_string_size_limit,
             thrift_container_size_limit=thrift_container_size_limit,
             page_checksum_verification=page_checksum_verification,
+            read_ree=read_ree
         )
 
     return dataset.read(columns=columns, use_threads=use_threads,

--- a/python/pyarrow/tests/parquet/test_dataset.py
+++ b/python/pyarrow/tests/parquet/test_dataset.py
@@ -1179,6 +1179,45 @@ def test_dataset_read_dictionary(tempdir):
         assert c0.equals(ex_chunks[1])
         assert c1.equals(ex_chunks[0])
 
+def test_dataset_read_run_end_encoded(tempdir):
+    path = tempdir / "ARROW-32339-dataset"
+    t1 = pa.table([[util.rands(10) for i in range(5)] * 10], names=['f0'])
+    t2 = pa.table([[util.rands(10) for i in range(5)] * 10], names=['f0'])
+    pq.write_to_dataset(t1, root_path=str(path))
+    pq.write_to_dataset(t2, root_path=str(path))
+
+    result = pq.ParquetDataset(
+        path, read_ree=['f0']).read()
+
+    # The order of the chunks is non-deterministic
+    ex_chunks = [pc.run_end_encode(t1[0].chunk(0)),
+                 pc.run_end_encode(t2[0].chunk(0))]
+
+    assert result[0].num_chunks == 2
+    c0, c1 = result[0].chunk(0), result[0].chunk(1)
+    if c0.equals(ex_chunks[0]):
+        assert c1.equals(ex_chunks[1])
+    else:
+        assert c0.equals(ex_chunks[1])
+        assert c1.equals(ex_chunks[0])
+
+def test_dataset_to_batches_run_end_encoded(tempdir):
+    table = pa.table({'a': ["hello"] * 8})
+    filename = tempdir / "test.parquet"
+    pq.write_table(table, filename, row_group_size=2)
+    data_paths = [filename]
+    ree_column = "a"
+    schema = pq.read_schema(filename)
+    filtered_dataset = pa.dataset.FileSystemDataset.from_paths(
+        paths=data_paths,
+        schema=schema,
+        format=pa.dataset.ParquetFileFormat(
+            read_options=pa.dataset.ParquetReadOptions(ree_columns=[ree_column])
+        ),
+        filesystem=pa.fs.LocalFileSystem(),
+    )
+    batch = next(filtered_dataset.to_batches(use_threads=True))
+    assert batch
 
 def test_read_table_schema(tempdir):
     # test that schema keyword is passed through in read_table

--- a/python/pyarrow/tests/parquet/test_parquet_file.py
+++ b/python/pyarrow/tests/parquet/test_parquet_file.py
@@ -287,6 +287,16 @@ def test_pre_buffer(pre_buffer):
     assert pf.read().num_rows == N
 
 
+def test_iter_batches_read_ree(tempdir):
+    filename = tempdir / 'pandas_roundtrip.parquet'
+    arrow_table = pa.table({'col1': ["a", "b"], 'col2': [0, 1]})
+    _write_table(arrow_table, filename, version='2.6')
+    ree_col_name = "col1"
+    parquet_file = pq.ParquetFile(filename, read_ree = [ree_col_name])
+    batch = next(parquet_file.iter_batches())
+    assert pa.types.is_run_end_encoded(batch.schema.field(ree_col_name).type)
+
+
 def test_parquet_file_explicitly_closed(tempdir):
     """
     Unopened files should be closed explicitly after use,


### PR DESCRIPTION
### Rationale for this change
Parquet files often contain columns with highly repetitive values (e.g., status codes, categories, constant metadata fields). Currently, Arrow reads these into dense arrays, materializing every value and consuming significant memory.

This PR implements direct reads of Parquet RLE (Run Length Encoded) data into Arrow REE (Run End Encoded) representation as described in https://github.com/apache/arrow/issues/32339, using the existing `read_dictionary` API as inspiration for interface level changes. Like `read_dictionary`, this feature is currently only supported for columns with a Parquet physical type of `BYTE_ARRAY`, such as string or binary types.

Example usage:
 ```python
  import pyarrow.parquet as pq
  # These columns will be directly read as Arrow run-end-encoded without full materialization if their Parquet representation was run-length-encoded.
  table = pq.read_table('data.parquet', read_ree=['category', 'status']) 
```

This is a considerably hefty feature so please let me know if there's anything I can do to help the review process (e.g. by splitting this into multiple smaller PRs). The way I implemented this is by adding a `GetNextValueAndNumRepeats` API to the `RleBitPackedDecoder` which skips materialization of all values for `RleRun`s while still going through `BitPackedRun`s bit by bit. I'm definitely open to suggestions on other approaches here.

Regarding performance, I am anecdotally observing an order of magnitude (i.e. ~10x) speedup for reading columns which have lots of repeated values and a slight performance degredation for columns which contain purely unique values when read with this feature enabled (noting that the feature is toggled by the user, so presumably they would have a good understanding of the shape of their data to decide whether to enable/disable this feature). I haven't done any scientific benchmarking outside of this; let me know if that would be helpful.

### What changes are included in this PR?
1. Add `ArrowReaderProperties::set_read_ree()` / `read_ree()` methods to enable REE reading per-column
1. Implement `GetNextValueAndNumRepeats()` and `GetNextValueAndNumRepeatsSpaced()` methods in`RleBitPackedDecoder`
1. Add `ByteArrayReeRecordReader` for decoding Parquet `BYTE_ARRAY` columns to `RunEndEncodedArray`
1. Support REE decoding for both `Plain` and `RLE_DICTIONARY` encodings
1. Add Python bindings via `read_ree_columns` parameter in `ParquetDataset` and `ParquetFile`

### Are these changes tested?
Yes, through included C++ unit tests and pytests.

### Are there any user-facing changes?
Yes.

* GitHub Issue: #32339