### PR TITLE
GH-46077: [CI][C++] Disable -Werror on macos-13

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -228,19 +228,6 @@ jobs:
           brew uninstall pkg-config || :
           brew uninstall pkg-config@0.29.2 || :
           brew bundle --file=cpp/Brewfile
-          if [ "${{ matrix.macos-version }}" = "13" ]; then
-            # This is a workaround.
-            #
-            # Homebrew uses /usr/local as prefix. So XSimd installed
-            # by Homebrew also uses /usr/local/include. We want to
-            # include XSimd headers as system headers to ignore
-            # warnings in XSimd headers. But "-isystem
-            # /usr/local/include" isn't used by CMake because
-            # /usr/local/include is marked as the default include
-            # path. So we uninstall XSimd explicitly to use bundled
-            # XSimd.
-            brew uninstall xsimd
-          fi
       - name: Install MinIO
         run: |
           $(brew --prefix bash)/bin/bash \
@@ -268,6 +255,19 @@ jobs:
           restore-keys: cpp-ccache-macos-${{ matrix.macos-version }}-
       - name: Build
         run: |
+          if [ "${{ matrix.macos-version }}" = "13" ]; then
+            # This is a workaround.
+            #
+            # Homebrew uses /usr/local as prefix. So packages
+            # installed by Homebrew also use /usr/local/include. We
+            # want to include headers for packages installed by
+            # Homebrew as system headers to ignore warnings in them.
+            # But "-isystem /usr/local/include" isn't used by CMake
+            # because /usr/local/include is marked as the default
+            # include path. So we disable -Werror to avoid build error
+            # by warnings from packages installed by Homebrew.
+            export BUILD_WARNING_LEVEL=PRODUCTION
+          fi
           ci/scripts/cpp_build.sh $(pwd) $(pwd)/build
       - name: Test
         shell: bash

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -228,6 +228,19 @@ jobs:
           brew uninstall pkg-config || :
           brew uninstall pkg-config@0.29.2 || :
           brew bundle --file=cpp/Brewfile
+          if [ "${{ matrix.macos-version }}" = "13" ]; then
+            # This is a workaround.
+            #
+            # Homebrew uses /usr/local as prefix. So XSimd installed
+            # by Homebrew also uses /usr/local/include. We want to
+            # include XSimd headers as system headers to ignore
+            # warnings in XSimd headers. But "-isystem
+            # /usr/local/include" isn't used by CMake because
+            # /usr/local/include is marked as the default include
+            # path. So we uninstall XSimd explicitly to use bundled
+            # XSimd.
+            brew uninstall xsimd
+          fi
       - name: Install MinIO
         run: |
           $(brew --prefix bash)/bin/bash \

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -195,6 +195,20 @@ jobs:
           brew uninstall pkg-config || :
           brew uninstall pkg-config@0.29.2 || :
           brew bundle --file=cpp/Brewfile
+          if [ "${{ matrix.macos-version }}" = "13" ]; then
+            # This is a workaround.
+            #
+            # Homebrew uses /usr/local as prefix. So XSimd installed
+            # by Homebrew also uses /usr/local/include. We want to
+            # include XSimd headers as system headers to ignore
+            # warnings in XSimd headers. But "-isystem
+            # /usr/local/include" isn't used by CMake because
+            # /usr/local/include is marked as the default include
+            # path. So we uninstall XSimd explicitly to use bundled
+            # XSimd.
+            brew uninstall xsimd
+          fi
+
           python -m pip install \
             -r python/requirements-build.txt \
             -r python/requirements-test.txt

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -195,19 +195,6 @@ jobs:
           brew uninstall pkg-config || :
           brew uninstall pkg-config@0.29.2 || :
           brew bundle --file=cpp/Brewfile
-          if [ "${{ matrix.macos-version }}" = "13" ]; then
-            # This is a workaround.
-            #
-            # Homebrew uses /usr/local as prefix. So XSimd installed
-            # by Homebrew also uses /usr/local/include. We want to
-            # include XSimd headers as system headers to ignore
-            # warnings in XSimd headers. But "-isystem
-            # /usr/local/include" isn't used by CMake because
-            # /usr/local/include is marked as the default include
-            # path. So we uninstall XSimd explicitly to use bundled
-            # XSimd.
-            brew uninstall xsimd
-          fi
 
           python -m pip install \
             -r python/requirements-build.txt \
@@ -232,6 +219,20 @@ jobs:
       - name: Build
         shell: bash
         run: |
+          if [ "${{ matrix.macos-version }}" = "13" ]; then
+            # This is a workaround.
+            #
+            # Homebrew uses /usr/local as prefix. So packages
+            # installed by Homebrew also use /usr/local/include. We
+            # want to include headers for packages installed by
+            # Homebrew as system headers to ignore warnings in them.
+            # But "-isystem /usr/local/include" isn't used by CMake
+            # because /usr/local/include is marked as the default
+            # include path. So we disable -Werror to avoid build error
+            # by warnings from packages installed by Homebrew.
+            export BUILD_WARNING_LEVEL=PRODUCTION
+          fi
+
           python -m pip install wheel
           ci/scripts/cpp_build.sh $(pwd) $(pwd)/build
           ci/scripts/python_build.sh $(pwd) $(pwd)/build


### PR DESCRIPTION
### Rationale for this change

Our C++ build started failing with GitHub Actions runner macos-13 ([13.7.5 (22H527)](https://github.com/actions/runner-images/pull/11962)):

```text
FAILED: src/arrow/CMakeFiles/arrow_util.dir/util/utf8.cc.o 
/usr/local/bin/ccache /usr/bin/c++ -DARROW_HAVE_RUNTIME_AVX2 -DARROW_HAVE_RUNTIME_AVX512 -DARROW_HAVE_RUNTIME_BMI2 -DARROW_HAVE_RUNTIME_SSE4_2 -DARROW_HAVE_SSE4_2 -DARROW_WITH_TIMING_TESTS -DURI_STATIC_BUILD -I/Users/runner/work/arrow/arrow/build/cpp/src -I/Users/runner/work/arrow/arrow/cpp/src -I/Users/runner/work/arrow/arrow/cpp/src/generated -isystem /usr/local/Cellar/boost/1.87.0_1/include -isystem /usr/local/Cellar/brotli/1.1.0/include -isystem /usr/local/opt/lz4/include -fno-aligned-new  -Qunused-arguments -fcolor-diagnostics  -Wall -Wextra -Wdocumentation -DARROW_WARN_DOCUMENTATION -Wshorten-64-to-32 -Wno-missing-braces -Wno-unused-parameter -Wno-constant-logical-operand -Wno-return-stack-address -Wdate-time -Wno-unknown-warning-option -Wno-pass-failed -msse4.2  -g -Werror -O0 -ggdb -g1 -std=c++17 -mmacosx-version-min=12 -fPIC -MD -MT src/arrow/CMakeFiles/arrow_util.dir/util/utf8.cc.o -MF src/arrow/CMakeFiles/arrow_util.dir/util/utf8.cc.o.d -o src/arrow/CMakeFiles/arrow_util.dir/util/utf8.cc.o -c /Users/runner/work/arrow/arrow/cpp/src/arrow/util/utf8.cc
In file included from /Users/runner/work/arrow/arrow/cpp/src/arrow/util/utf8.cc:28:
In file included from /Users/runner/work/arrow/arrow/cpp/src/arrow/util/utf8_internal.h:28:
In file included from /usr/local/include/xsimd/xsimd.hpp:57:
/usr/local/include/xsimd/memory/xsimd_aligned_allocator.hpp:165:15: error: parameter 'hint' not found in the function declaration [-Werror,-Wdocumentation]
     * @param hint unused parameter provided for standard compliance.
              ^~~~
/usr/local/include/xsimd/memory/xsimd_aligned_allocator.hpp:186:15: error: parameter 'n' not found in the function declaration [-Werror,-Wdocumentation]
     * @param n number of objects earlier passed to allocate().
              ^
```

It's caused by warnings in XSimd headers. (There are similar warnings in RaipdJSON headers and so on.)

In general, warnings in external libraries are ignored by `-isystem`. But `-isystem /usr/local/include` isn't used in the runner.

I don't know what is the cause of this behavior change in the runner update. But CMake 3.31.6 -> 4.0.0 update may be related.

### What changes are included in this PR?

Disable `-Werror` because it's difficult to suppress warnings all packages installed by Homebrew.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #46077