### PR TITLE
GH-46054: [Python][Packaging] Re-enable pandas on Windows free-threaded wheel

### DIFF
--- a/ci/docker/python-free-threaded-wheel-windows-test-vs2022.dockerfile
+++ b/ci/docker/python-free-threaded-wheel-windows-test-vs2022.dockerfile
@@ -38,15 +38,12 @@ SHELL ["cmd", "/S", "/C"]
 RUN %PYTHON_CMD% -m pip install -U pip setuptools
 
 COPY python/requirements-wheel-test.txt C:/arrow/python/
-# Temporarily remove pandas from the requirements, see https://github.com/apache/arrow/issues/46041
-RUN findstr /V "pandas" C:\arrow\python\requirements-wheel-test.txt > C:\arrow\python\filtered-requirements-wheel-test.txt
 # Cython and Pandas wheels for 3.13 free-threaded are not released yet
-# hadolint ignore=DL3059
 RUN %PYTHON_CMD% -m pip install \
     --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \
     --pre \
     --prefer-binary \
-    -r C:/arrow/python/filtered-requirements-wheel-test.txt
+    -r C:/arrow/python/requirements-wheel-test.txt
 # cffi-based tests would crash when importing cffi.
 # hadolint ignore=DL3059
 RUN %PYTHON_CMD% -m pip uninstall -y cffi

--- a/ci/scripts/python_wheel_windows_test.bat
+++ b/ci/scripts/python_wheel_windows_test.bat
@@ -25,13 +25,7 @@ set PYARROW_TEST_GANDIVA=OFF
 set PYARROW_TEST_GCS=ON
 set PYARROW_TEST_HDFS=ON
 set PYARROW_TEST_ORC=ON
-@REM Temporarily skip pandas for free-threaded tests.
-@REM See https://github.com/apache/arrow/issues/46041
-if "%PYTHON_CMD%" neq "py -3.13t" (
-    set PYARROW_TEST_PANDAS=ON
-) else (
-    echo "Skip PYARROW_TEST_PANDAS for free-threaded"
-)
+set PYARROW_TEST_PANDAS=ON
 set PYARROW_TEST_PARQUET=ON
 set PYARROW_TEST_PARQUET_ENCRYPTION=ON
 set PYARROW_TEST_SUBSTRAIT=ON


### PR DESCRIPTION
### Rationale for this change

Pandas Windows-free threaded wheels are available again.

### What changes are included in this PR?

Reverts the change to temporarily disable and skip testing pandas for Windows free-threaded wheels.

### Are these changes tested?

Via archery

### Are there any user-facing changes?

No

* GitHub Issue: #46054