### PR TITLE
GH-46087: [FlightSQL] Allow returning column remarks in FlightSQL's CommandGetTables

### DIFF
--- a/cpp/src/arrow/flight/integration_tests/test_integration.cc
+++ b/cpp/src/arrow/flight/integration_tests/test_integration.cc
@@ -1167,6 +1167,7 @@ const std::shared_ptr<Schema>& GetQuerySchema() {
                         .IsSearchable(true)
                         .CatalogName("catalog_test")
                         .Precision(100)
+                        .Remarks("test column")
                         .Build()
                         .metadata_map())});
   return kSchema;
@@ -1187,6 +1188,7 @@ std::shared_ptr<Schema> GetQueryWithTransactionSchema() {
                         .IsSearchable(true)
                         .CatalogName("catalog_test")
                         .Precision(100)
+                        .Remarks("test column")
                         .Build()
                         .metadata_map())});
   return kSchema;

--- a/cpp/src/arrow/flight/integration_tests/test_integration.cc
+++ b/cpp/src/arrow/flight/integration_tests/test_integration.cc
@@ -1167,7 +1167,6 @@ const std::shared_ptr<Schema>& GetQuerySchema() {
                         .IsSearchable(true)
                         .CatalogName("catalog_test")
                         .Precision(100)
-                        .Remarks("test column")
                         .Build()
                         .metadata_map())});
   return kSchema;
@@ -1188,7 +1187,6 @@ std::shared_ptr<Schema> GetQueryWithTransactionSchema() {
                         .IsSearchable(true)
                         .CatalogName("catalog_test")
                         .Precision(100)
-                        .Remarks("test column")
                         .Build()
                         .metadata_map())});
   return kSchema;

--- a/cpp/src/arrow/flight/sql/column_metadata.cc
+++ b/cpp/src/arrow/flight/sql/column_metadata.cc
@@ -55,6 +55,7 @@ const char* ColumnMetadata::kIsAutoIncrement = "ARROW:FLIGHT:SQL:IS_AUTO_INCREME
 const char* ColumnMetadata::kIsCaseSensitive = "ARROW:FLIGHT:SQL:IS_CASE_SENSITIVE";
 const char* ColumnMetadata::kIsReadOnly = "ARROW:FLIGHT:SQL:IS_READ_ONLY";
 const char* ColumnMetadata::kIsSearchable = "ARROW:FLIGHT:SQL:IS_SEARCHABLE";
+const char* ColumnMetadata::kRemarks = "ARROW:FLIGHT:SQL:REMARKS";
 
 ColumnMetadata::ColumnMetadata(
     std::shared_ptr<const arrow::KeyValueMetadata> metadata_map)
@@ -112,6 +113,10 @@ arrow::Result<bool> ColumnMetadata::GetIsSearchable() const {
   std::string is_case_sensitive;
   ARROW_ASSIGN_OR_RAISE(is_case_sensitive, metadata_map_->Get(kIsAutoIncrement));
   return StringToBoolean(is_case_sensitive);
+}
+
+arrow::Result<std::string> ColumnMetadata::GetRemarks() const {
+  return metadata_map_->Get(kRemarks);
 }
 
 ColumnMetadata::ColumnMetadataBuilder ColumnMetadata::Builder() {
@@ -182,6 +187,12 @@ ColumnMetadata::ColumnMetadataBuilder& ColumnMetadata::ColumnMetadataBuilder::Is
 ColumnMetadata::ColumnMetadataBuilder&
 ColumnMetadata::ColumnMetadataBuilder::IsSearchable(bool is_searchable) {
   metadata_map_->Append(ColumnMetadata::kIsSearchable, BooleanToString(is_searchable));
+  return *this;
+}
+
+ColumnMetadata::ColumnMetadataBuilder& ColumnMetadata::ColumnMetadataBuilder::Remarks(
+    const std::string& remarks) {
+  metadata_map_->Append(ColumnMetadata::kRemarks, remarks);
   return *this;
 }
 

--- a/cpp/src/arrow/flight/sql/column_metadata.h
+++ b/cpp/src/arrow/flight/sql/column_metadata.h
@@ -114,7 +114,7 @@ class ARROW_FLIGHT_SQL_EXPORT ColumnMetadata {
   arrow::Result<bool> GetIsSearchable() const;
 
   /// \brief  Return the Remarks set in the KeyValueMetadata.
-  /// \return The IsSearchable.
+  /// \return The Remarks.
   arrow::Result<std::string> GetRemarks() const;
 
   /// \brief  Return the KeyValueMetadata.
@@ -177,7 +177,7 @@ class ARROW_FLIGHT_SQL_EXPORT ColumnMetadata {
     ColumnMetadataBuilder& IsSearchable(bool is_searchable);
 
     /// \brief Set the column description in the KeyValueMetadata object.
-    /// \param[in] remarks  The comment decripting column.
+    /// \param[in] remarks  The comment describing column.
     /// \return             A ColumnMetadataBuilder.
     ColumnMetadataBuilder& Remarks(const std::string& remarks);
 

--- a/cpp/src/arrow/flight/sql/column_metadata.h
+++ b/cpp/src/arrow/flight/sql/column_metadata.h
@@ -66,6 +66,9 @@ class ARROW_FLIGHT_SQL_EXPORT ColumnMetadata {
   /// \brief Constant variable to hold the value of the key that
   ///        will be used in the KeyValueMetadata class.
   static const char* kIsSearchable;
+  /// \brief Constant variable to hold the value of the key that
+  ///        will be used in the KeyValueMetadata class.
+  static const char* kRemarks;
 
   /// \brief Static initializer.
   static ColumnMetadataBuilder Builder();
@@ -109,6 +112,10 @@ class ARROW_FLIGHT_SQL_EXPORT ColumnMetadata {
   /// \brief  Return the IsSearchable set in the KeyValueMetadata.
   /// \return The IsSearchable.
   arrow::Result<bool> GetIsSearchable() const;
+
+  /// \brief  Return the Remarks set in the KeyValueMetadata.
+  /// \return The IsSearchable.
+  arrow::Result<std::string> GetRemarks() const;
 
   /// \brief  Return the KeyValueMetadata.
   /// \return The KeyValueMetadata.
@@ -168,6 +175,11 @@ class ARROW_FLIGHT_SQL_EXPORT ColumnMetadata {
     /// \param[in] is_searchable The IsSearchable.
     /// \return                  A ColumnMetadataBuilder.
     ColumnMetadataBuilder& IsSearchable(bool is_searchable);
+
+    /// \brief Set the column description in the KeyValueMetadata object.
+    /// \param[in] remarks  The comment decripting column.
+    /// \return             A ColumnMetadataBuilder.
+    ColumnMetadataBuilder& Remarks(const std::string& remarks);
 
     ColumnMetadata Build() const;
 

--- a/format/FlightSql.proto
+++ b/format/FlightSql.proto
@@ -1212,6 +1212,7 @@ message CommandGetDbSchemas {
  *  - ARROW:FLIGHT:SQL:IS_CASE_SENSITIVE - "1" indicates if the column is case-sensitive, "0" otherwise.
  *  - ARROW:FLIGHT:SQL:IS_READ_ONLY      - "1" indicates if the column is read only, "0" otherwise.
  *  - ARROW:FLIGHT:SQL:IS_SEARCHABLE     - "1" indicates if the column is searchable via WHERE clause, "0" otherwise.
+ *  - ARROW:FLIGHT:SQL:REMARKS           - A comment descripting column.
  * The returned data should be ordered by catalog_name, db_schema_name, table_name, then table_type, followed by table_schema if requested.
  */
 message CommandGetTables {
@@ -1678,6 +1679,7 @@ message ActionEndSavepointRequest {
  *    - ARROW:FLIGHT:SQL:IS_CASE_SENSITIVE - "1" indicates if the column is case-sensitive, "0" otherwise.
  *    - ARROW:FLIGHT:SQL:IS_READ_ONLY      - "1" indicates if the column is read only, "0" otherwise.
  *    - ARROW:FLIGHT:SQL:IS_SEARCHABLE     - "1" indicates if the column is searchable via WHERE clause, "0" otherwise.
+ *    - ARROW:FLIGHT:SQL:REMARKS           - A comment descripting column.
  *  - GetFlightInfo: execute the query.
  */
 message CommandStatementQuery {
@@ -1703,6 +1705,7 @@ message CommandStatementQuery {
  *    - ARROW:FLIGHT:SQL:IS_CASE_SENSITIVE - "1" indicates if the column is case-sensitive, "0" otherwise.
  *    - ARROW:FLIGHT:SQL:IS_READ_ONLY      - "1" indicates if the column is read only, "0" otherwise.
  *    - ARROW:FLIGHT:SQL:IS_SEARCHABLE     - "1" indicates if the column is searchable via WHERE clause, "0" otherwise.
+ *    - ARROW:FLIGHT:SQL:REMARKS           - A comment descripting column.
  *  - GetFlightInfo: execute the query.
  *  - DoPut: execute the query.
  */
@@ -1739,6 +1742,7 @@ message TicketStatementQuery {
  *    - ARROW:FLIGHT:SQL:IS_CASE_SENSITIVE - "1" indicates if the column is case-sensitive, "0" otherwise.
  *    - ARROW:FLIGHT:SQL:IS_READ_ONLY      - "1" indicates if the column is read only, "0" otherwise.
  *    - ARROW:FLIGHT:SQL:IS_SEARCHABLE     - "1" indicates if the column is searchable via WHERE clause, "0" otherwise.
+ *    - ARROW:FLIGHT:SQL:REMARKS           - A comment descripting column.
  *
  *    If the schema is retrieved after parameter values have been bound with DoPut, then the server should account
  *    for the parameters when determining the schema.
@@ -1857,7 +1861,7 @@ message DoPutPreparedStatementResult {
   // statement should be considered invalid, and all subsequent requests for this prepared
   // statement must use this new handle.
   // The updated handle allows implementing query parameters with stateless services.
-  // 
+  //
   // When an updated handle is not provided by the server, clients should contiue
   // using the previous handle provided by `ActionCreatePreparedStatementResonse`.
   optional bytes prepared_statement_handle = 1;

--- a/format/FlightSql.proto
+++ b/format/FlightSql.proto
@@ -1212,7 +1212,7 @@ message CommandGetDbSchemas {
  *  - ARROW:FLIGHT:SQL:IS_CASE_SENSITIVE - "1" indicates if the column is case-sensitive, "0" otherwise.
  *  - ARROW:FLIGHT:SQL:IS_READ_ONLY      - "1" indicates if the column is read only, "0" otherwise.
  *  - ARROW:FLIGHT:SQL:IS_SEARCHABLE     - "1" indicates if the column is searchable via WHERE clause, "0" otherwise.
- *  - ARROW:FLIGHT:SQL:REMARKS           - A comment descripting column.
+ *  - ARROW:FLIGHT:SQL:REMARKS           - A comment describing the column.
  * The returned data should be ordered by catalog_name, db_schema_name, table_name, then table_type, followed by table_schema if requested.
  */
 message CommandGetTables {
@@ -1679,7 +1679,7 @@ message ActionEndSavepointRequest {
  *    - ARROW:FLIGHT:SQL:IS_CASE_SENSITIVE - "1" indicates if the column is case-sensitive, "0" otherwise.
  *    - ARROW:FLIGHT:SQL:IS_READ_ONLY      - "1" indicates if the column is read only, "0" otherwise.
  *    - ARROW:FLIGHT:SQL:IS_SEARCHABLE     - "1" indicates if the column is searchable via WHERE clause, "0" otherwise.
- *    - ARROW:FLIGHT:SQL:REMARKS           - A comment descripting column.
+ *    - ARROW:FLIGHT:SQL:REMARKS           - A comment describing the column.
  *  - GetFlightInfo: execute the query.
  */
 message CommandStatementQuery {
@@ -1705,7 +1705,7 @@ message CommandStatementQuery {
  *    - ARROW:FLIGHT:SQL:IS_CASE_SENSITIVE - "1" indicates if the column is case-sensitive, "0" otherwise.
  *    - ARROW:FLIGHT:SQL:IS_READ_ONLY      - "1" indicates if the column is read only, "0" otherwise.
  *    - ARROW:FLIGHT:SQL:IS_SEARCHABLE     - "1" indicates if the column is searchable via WHERE clause, "0" otherwise.
- *    - ARROW:FLIGHT:SQL:REMARKS           - A comment descripting column.
+ *    - ARROW:FLIGHT:SQL:REMARKS           - A comment describing the column.
  *  - GetFlightInfo: execute the query.
  *  - DoPut: execute the query.
  */
@@ -1742,7 +1742,7 @@ message TicketStatementQuery {
  *    - ARROW:FLIGHT:SQL:IS_CASE_SENSITIVE - "1" indicates if the column is case-sensitive, "0" otherwise.
  *    - ARROW:FLIGHT:SQL:IS_READ_ONLY      - "1" indicates if the column is read only, "0" otherwise.
  *    - ARROW:FLIGHT:SQL:IS_SEARCHABLE     - "1" indicates if the column is searchable via WHERE clause, "0" otherwise.
- *    - ARROW:FLIGHT:SQL:REMARKS           - A comment descripting column.
+ *    - ARROW:FLIGHT:SQL:REMARKS           - A comment describing the column.
  *
  *    If the schema is retrieved after parameter values have been bound with DoPut, then the server should account
  *    for the parameters when determining the schema.

--- a/format/FlightSql.proto
+++ b/format/FlightSql.proto
@@ -1212,7 +1212,7 @@ message CommandGetDbSchemas {
  *  - ARROW:FLIGHT:SQL:IS_CASE_SENSITIVE - "1" indicates if the column is case-sensitive, "0" otherwise.
  *  - ARROW:FLIGHT:SQL:IS_READ_ONLY      - "1" indicates if the column is read only, "0" otherwise.
  *  - ARROW:FLIGHT:SQL:IS_SEARCHABLE     - "1" indicates if the column is searchable via WHERE clause, "0" otherwise.
- *  - ARROW:FLIGHT:SQL:REMARKS           - A comment describing the column.
+ *  - ARROW:FLIGHT:SQL:REMARKS           - A comment describing the column. This field has been added after all others, clients should be prepared to find it missing.
  * The returned data should be ordered by catalog_name, db_schema_name, table_name, then table_type, followed by table_schema if requested.
  */
 message CommandGetTables {
@@ -1679,7 +1679,7 @@ message ActionEndSavepointRequest {
  *    - ARROW:FLIGHT:SQL:IS_CASE_SENSITIVE - "1" indicates if the column is case-sensitive, "0" otherwise.
  *    - ARROW:FLIGHT:SQL:IS_READ_ONLY      - "1" indicates if the column is read only, "0" otherwise.
  *    - ARROW:FLIGHT:SQL:IS_SEARCHABLE     - "1" indicates if the column is searchable via WHERE clause, "0" otherwise.
- *    - ARROW:FLIGHT:SQL:REMARKS           - A comment describing the column.
+ *    - ARROW:FLIGHT:SQL:REMARKS           - A comment describing the column. This field has been added after all others, clients should be prepared to find it missing.
  *  - GetFlightInfo: execute the query.
  */
 message CommandStatementQuery {
@@ -1705,7 +1705,7 @@ message CommandStatementQuery {
  *    - ARROW:FLIGHT:SQL:IS_CASE_SENSITIVE - "1" indicates if the column is case-sensitive, "0" otherwise.
  *    - ARROW:FLIGHT:SQL:IS_READ_ONLY      - "1" indicates if the column is read only, "0" otherwise.
  *    - ARROW:FLIGHT:SQL:IS_SEARCHABLE     - "1" indicates if the column is searchable via WHERE clause, "0" otherwise.
- *    - ARROW:FLIGHT:SQL:REMARKS           - A comment describing the column.
+ *    - ARROW:FLIGHT:SQL:REMARKS           - A comment describing the column. This field has been added after all others, clients should be prepared to find it missing.
  *  - GetFlightInfo: execute the query.
  *  - DoPut: execute the query.
  */
@@ -1742,7 +1742,7 @@ message TicketStatementQuery {
  *    - ARROW:FLIGHT:SQL:IS_CASE_SENSITIVE - "1" indicates if the column is case-sensitive, "0" otherwise.
  *    - ARROW:FLIGHT:SQL:IS_READ_ONLY      - "1" indicates if the column is read only, "0" otherwise.
  *    - ARROW:FLIGHT:SQL:IS_SEARCHABLE     - "1" indicates if the column is searchable via WHERE clause, "0" otherwise.
- *    - ARROW:FLIGHT:SQL:REMARKS           - A comment describing the column.
+ *    - ARROW:FLIGHT:SQL:REMARKS           - A comment describing the column. This field has been added after all others, clients should be prepared to find it missing.
  *
  *    If the schema is retrieved after parameter values have been bound with DoPut, then the server should account
  *    for the parameters when determining the schema.


### PR DESCRIPTION
Resolves #46087

### Rationale for this change

FlightSQL allows returning various column metadata in `CommandGetTables`, but one thing that's missing is human-readable column description. This PR proposes adding a new `ARROW:FLIGHT:SQL:REMARKS` metadata property taht will contain a comment describing a column. This is inspired by JDBC's [`DatabaseMetaData#getColumns()`](https://docs.oracle.com/javase/8/docs/api/java/sql/DatabaseMetaData.html#getColumns-java.lang.String-java.lang.String-java.lang.String-java.lang.String-) method, and later on I'm planning on adding this change to arrow-java as well.

### What changes are included in this PR?

* A new column metadata property `ARROW:FLIGHT:SQL:REMARKS`
* C++ `ColumnMetadata` implementation

Please tell me if there's anything else in the other languages that I should add.

### Are these changes tested?

Covered by existing tests; no new test cases added.

### Are there any user-facing changes?

Yes, a couple new constants/methods added to the `ColumnMetadata` class and its builder

* GitHub Issue: #46087