### PR TITLE
GH-46090: [C++] Set default IPC option to enabled in Meson

### DIFF
--- a/cpp/meson.options
+++ b/cpp/meson.options
@@ -47,7 +47,7 @@ option(
     'ipc',
     type: 'boolean',
     description: 'Build the Arrow IPC extensions',
-    value: false,
+    value: true,
 )
 
 option(


### PR DESCRIPTION
### Rationale for this change

This matches the CMake configuration

### What changes are included in this PR?

The IPC option has been set to enabled by default

### Are these changes tested?

Yes

### Are there any user-facing changes?

No

* GitHub Issue: #46090