### PR TITLE
GH-46121: [Python] Add missing `column_index` argument to `ArrowReaderProperties::read_dictionary`'s Cython binding

### DIFF
--- a/python/pyarrow/_parquet.pxd
+++ b/python/pyarrow/_parquet.pxd
@@ -395,7 +395,7 @@ cdef extern from "parquet/api/reader.h" namespace "parquet" nogil:
     cdef cppclass ArrowReaderProperties:
         ArrowReaderProperties()
         void set_read_dictionary(int column_index, c_bool read_dict)
-        c_bool read_dictionary()
+        c_bool read_dictionary(int column_index)
         void set_batch_size(int64_t batch_size)
         int64_t batch_size()
         void set_pre_buffer(c_bool pre_buffer)


### PR DESCRIPTION
### Rationale for this change
This PR adds the missing `column_index` argument to `ArrowReaderProperties::read_dictionary`'s Cython binding to resolve the issue described in https://github.com/apache/arrow/issues/46121.

### What changes are included in this PR?
1. Add the missing `column_index` argument to `ArrowReaderProperties::read_dictionary`'s Cython binding.

### Are these changes tested?
No (I'm not sure where the tests for Cython bindings are; I'm happy to add a test if someone can point me in the right direction)

### Are there any user-facing changes?
Yes; this is a bug fix to a user facing API (though it's admittedly unlikely to be used).
* GitHub Issue: #46121