### PR TITLE
GH-46130: [Python] Remove `use_legacy_format` in favour of setting `IpcWriteOptions`

### DIFF
--- a/python/pyarrow/_flight.pyx
+++ b/python/pyarrow/_flight.pyx
@@ -95,8 +95,7 @@ def _munge_grpc_python_error(message):
 
 
 cdef IpcWriteOptions _get_options(options):
-    return <IpcWriteOptions> _get_legacy_format_default(
-        use_legacy_format=None, options=options)
+    return <IpcWriteOptions> _get_legacy_format_default(options=options)
 
 
 cdef class FlightCallOptions(_Weakrefable):

--- a/python/pyarrow/ipc.py
+++ b/python/pyarrow/ipc.py
@@ -59,12 +59,6 @@ sink : str, pyarrow.NativeFile, or file-like Python object
     Either a file path, or a writable file object.
 schema : pyarrow.Schema
     The Arrow schema for data to be written to the file.
-use_legacy_format : bool, default None
-    Deprecated in favor of setting options. Cannot be provided with
-    options.
-
-    If None, False will be used unless this default is overridden by
-    setting the environment variable ARROW_PRE_0_15_IPC_FORMAT=1
 options : pyarrow.ipc.IpcWriteOptions
     Options for IPC serialization.
 
@@ -80,8 +74,8 @@ class RecordBatchStreamWriter(lib._RecordBatchStreamWriter):
 
 {}""".format(_ipc_writer_class_doc)
 
-    def __init__(self, sink, schema, *, use_legacy_format=None, options=None):
-        options = _get_legacy_format_default(use_legacy_format, options)
+    def __init__(self, sink, schema, *,  options=None):
+        options = _get_legacy_format_default(options)
         self._open(sink, schema, options=options)
 
 
@@ -117,29 +111,22 @@ class RecordBatchFileWriter(lib._RecordBatchFileWriter):
 
 {}""".format(_ipc_writer_class_doc)
 
-    def __init__(self, sink, schema, *, use_legacy_format=None, options=None):
-        options = _get_legacy_format_default(use_legacy_format, options)
+    def __init__(self, sink, schema, *, options=None):
+        options = _get_legacy_format_default(options)
         self._open(sink, schema, options=options)
 
 
-def _get_legacy_format_default(use_legacy_format, options):
-    if use_legacy_format is not None and options is not None:
-        raise ValueError(
-            "Can provide at most one of options and use_legacy_format")
-    elif options:
+def _get_legacy_format_default(options):
+    if options:
         if not isinstance(options, IpcWriteOptions):
             raise TypeError("expected IpcWriteOptions, got {}"
                             .format(type(options)))
         return options
 
     metadata_version = MetadataVersion.V5
-    if use_legacy_format is None:
-        use_legacy_format = \
-            bool(int(os.environ.get('ARROW_PRE_0_15_IPC_FORMAT', '0')))
     if bool(int(os.environ.get('ARROW_PRE_1_0_METADATA_VERSION', '0'))):
         metadata_version = MetadataVersion.V4
-    return IpcWriteOptions(use_legacy_format=use_legacy_format,
-                           metadata_version=metadata_version)
+    return IpcWriteOptions(metadata_version=metadata_version)
 
 
 def _ensure_default_ipc_read_options(options):
@@ -150,9 +137,8 @@ def _ensure_default_ipc_read_options(options):
     return options or IpcReadOptions()
 
 
-def new_stream(sink, schema, *, use_legacy_format=None, options=None):
+def new_stream(sink, schema, *, options=None):
     return RecordBatchStreamWriter(sink, schema,
-                                   use_legacy_format=use_legacy_format,
                                    options=options)
 
 
@@ -191,9 +177,8 @@ def open_stream(source, *, options=None, memory_pool=None):
                                    memory_pool=memory_pool)
 
 
-def new_file(sink, schema, *, use_legacy_format=None, options=None):
+def new_file(sink, schema, *, options=None):
     return RecordBatchFileWriter(sink, schema,
-                                 use_legacy_format=use_legacy_format,
                                  options=options)
 
 

--- a/python/pyarrow/ipc.py
+++ b/python/pyarrow/ipc.py
@@ -74,7 +74,7 @@ class RecordBatchStreamWriter(lib._RecordBatchStreamWriter):
 
 {}""".format(_ipc_writer_class_doc)
 
-    def __init__(self, sink, schema, *,  options=None):
+    def __init__(self, sink, schema, *, options=None):
         options = _get_legacy_format_default(options)
         self._open(sink, schema, options=options)
 

--- a/python/pyarrow/ipc.py
+++ b/python/pyarrow/ipc.py
@@ -124,9 +124,12 @@ def _get_legacy_format_default(options):
         return options
 
     metadata_version = MetadataVersion.V5
+    use_legacy_format = \
+        bool(int(os.environ.get('ARROW_PRE_0_15_IPC_FORMAT', '0')))
     if bool(int(os.environ.get('ARROW_PRE_1_0_METADATA_VERSION', '0'))):
         metadata_version = MetadataVersion.V4
-    return IpcWriteOptions(metadata_version=metadata_version)
+    return IpcWriteOptions(use_legacy_format=use_legacy_format,
+                           metadata_version=metadata_version)
 
 
 def _ensure_default_ipc_read_options(options):

--- a/python/pyarrow/tests/test_ipc.py
+++ b/python/pyarrow/tests/test_ipc.py
@@ -119,7 +119,6 @@ class StreamFormatFixture(IpcFixture):
         return pa.ipc.new_stream(
             sink,
             schema,
-            use_legacy_format=self.use_legacy_ipc_format,
             options=self.options,
         )
 
@@ -403,9 +402,7 @@ def test_stream_write_table_batches(stream_fixture):
                                  ignore_index=True))
 
 
-@pytest.mark.parametrize('use_legacy_ipc_format', [False, True])
-def test_stream_simple_roundtrip(stream_fixture, use_legacy_ipc_format):
-    stream_fixture.use_legacy_ipc_format = use_legacy_ipc_format
+def test_stream_simple_roundtrip(stream_fixture):
     batches = stream_fixture.write_batches()
     file_contents = pa.BufferReader(stream_fixture.get_source())
     reader = pa.ipc.open_stream(file_contents)
@@ -503,15 +500,6 @@ def test_write_options():
         assert options.use_threads is False
 
 
-def test_write_options_legacy_exclusive(stream_fixture):
-    with pytest.raises(
-            ValueError,
-            match="provide at most one of options and use_legacy_format"):
-        stream_fixture.use_legacy_ipc_format = True
-        stream_fixture.options = pa.ipc.IpcWriteOptions()
-        stream_fixture.write_batches()
-
-
 @pytest.mark.parametrize('options', [
     pa.ipc.IpcWriteOptions(),
     pa.ipc.IpcWriteOptions(allow_64bit=True),
@@ -521,7 +509,6 @@ def test_write_options_legacy_exclusive(stream_fixture):
                            metadata_version=pa.ipc.MetadataVersion.V4),
 ])
 def test_stream_options_roundtrip(stream_fixture, options):
-    stream_fixture.use_legacy_ipc_format = None
     stream_fixture.options = options
     batches = stream_fixture.write_batches()
     file_contents = pa.BufferReader(stream_fixture.get_source())


### PR DESCRIPTION
### Rationale for this change
`use_legacy_format` in the ipc writer has been deprecated and can be removed.

### What changes are included in this PR?
`use_legacy_format` keyword is removed in favour of setting `IpcWriteOptions`.

### Are these changes tested?
Existing tests should pass.

### Are there any user-facing changes?
Deprecated functionality is removed.
* GitHub Issue: #46130