### PR TITLE
GH-46132: [C++][Parquet] Remove deprecated parquet APIs from 19.0.0

### DIFF
--- a/cpp/examples/arrow/parquet_read_write.cc
+++ b/cpp/examples/arrow/parquet_read_write.cc
@@ -67,7 +67,7 @@ arrow::Status ReadInBatches(std::string path_to_file) {
   ARROW_ASSIGN_OR_RAISE(arrow_reader, reader_builder.Build());
 
   std::shared_ptr<::arrow::RecordBatchReader> rb_reader;
-  ARROW_RETURN_NOT_OK(arrow_reader->GetRecordBatchReader(&rb_reader));
+  ARROW_ASSIGN_OR_RAISE(rb_reader, arrow_reader->GetRecordBatchReader());
 
   for (arrow::Result<std::shared_ptr<arrow::RecordBatch>> maybe_batch : *rb_reader) {
     // Operate on each batch...

--- a/cpp/src/arrow/filesystem/s3fs_benchmark.cc
+++ b/cpp/src/arrow/filesystem/s3fs_benchmark.cc
@@ -318,8 +318,8 @@ static void ParquetRead(benchmark::State& st, S3FileSystem* fs, const std::strin
       std::shared_ptr<Table> table;
       ASSERT_OK(reader->ReadTable(column_indices, &table));
     } else {
-      std::shared_ptr<RecordBatchReader> rb_reader;
-      ASSERT_OK(reader->GetRecordBatchReader({0}, column_indices, &rb_reader));
+      ASSERT_OK_AND_ASSIGN(auto rb_reader, reader->GetRecordBatchReader(
+                                               std::vector<int>{0}, column_indices));
       ASSERT_OK(rb_reader->ToTable());
     }
 

--- a/cpp/src/parquet/arrow/reader.cc
+++ b/cpp/src/parquet/arrow/reader.cc
@@ -1300,46 +1300,6 @@ std::shared_ptr<RowGroupReader> FileReaderImpl::RowGroup(int row_group_index) {
 // ----------------------------------------------------------------------
 // Public factory functions
 
-Status FileReader::GetRecordBatchReader(std::unique_ptr<RecordBatchReader>* out) {
-  ARROW_ASSIGN_OR_RAISE(*out, GetRecordBatchReader());
-  return Status::OK();
-}
-
-Status FileReader::GetRecordBatchReader(const std::vector<int>& row_group_indices,
-                                        std::unique_ptr<RecordBatchReader>* out) {
-  ARROW_ASSIGN_OR_RAISE(*out, GetRecordBatchReader(row_group_indices));
-  return Status::OK();
-}
-
-Status FileReader::GetRecordBatchReader(const std::vector<int>& row_group_indices,
-                                        const std::vector<int>& column_indices,
-                                        std::unique_ptr<RecordBatchReader>* out) {
-  ARROW_ASSIGN_OR_RAISE(*out, GetRecordBatchReader(row_group_indices, column_indices));
-  return Status::OK();
-}
-
-Status FileReader::GetRecordBatchReader(std::shared_ptr<RecordBatchReader>* out) {
-  ARROW_ASSIGN_OR_RAISE(auto tmp, GetRecordBatchReader());
-  out->reset(tmp.release());
-  return Status::OK();
-}
-
-Status FileReader::GetRecordBatchReader(const std::vector<int>& row_group_indices,
-                                        std::shared_ptr<RecordBatchReader>* out) {
-  ARROW_ASSIGN_OR_RAISE(auto tmp, GetRecordBatchReader(row_group_indices));
-  out->reset(tmp.release());
-  return Status::OK();
-}
-
-Status FileReader::GetRecordBatchReader(const std::vector<int>& row_group_indices,
-                                        const std::vector<int>& column_indices,
-                                        std::shared_ptr<RecordBatchReader>* out) {
-  ARROW_ASSIGN_OR_RAISE(auto tmp,
-                        GetRecordBatchReader(row_group_indices, column_indices));
-  out->reset(tmp.release());
-  return Status::OK();
-}
-
 Status FileReader::Make(::arrow::MemoryPool* pool,
                         std::unique_ptr<ParquetFileReader> reader,
                         const ArrowReaderProperties& properties,

--- a/cpp/src/parquet/arrow/reader.h
+++ b/cpp/src/parquet/arrow/reader.h
@@ -155,27 +155,8 @@ class PARQUET_EXPORT FileReader {
                                      std::shared_ptr<::arrow::ChunkedArray>* out) = 0;
 
   /// \brief Return a RecordBatchReader of all row groups and columns.
-  ///
-  /// \deprecated Deprecated in 19.0.0. Use arrow::Result version instead.
-  ARROW_DEPRECATED("Deprecated in 19.0.0. Use arrow::Result version instead.")
-  ::arrow::Status GetRecordBatchReader(std::unique_ptr<::arrow::RecordBatchReader>* out);
-
-  /// \brief Return a RecordBatchReader of all row groups and columns.
   virtual ::arrow::Result<std::unique_ptr<::arrow::RecordBatchReader>>
   GetRecordBatchReader() = 0;
-
-  /// \brief Return a RecordBatchReader of row groups selected from row_group_indices.
-  ///
-  /// Note that the ordering in row_group_indices matters. FileReaders must outlive
-  /// their RecordBatchReaders.
-  ///
-  /// \returns error Status if row_group_indices contains an invalid index
-  ///
-  /// \deprecated Deprecated in 19.0.0. Use arrow::Result version instead.
-  ARROW_DEPRECATED("Deprecated in 19.0.0. Use arrow::Result version instead.")
-  virtual ::arrow::Status GetRecordBatchReader(
-      const std::vector<int>& row_group_indices,
-      std::unique_ptr<::arrow::RecordBatchReader>* out);
 
   /// \brief Return a RecordBatchReader of row groups selected from row_group_indices.
   ///
@@ -185,21 +166,6 @@ class PARQUET_EXPORT FileReader {
   /// \returns error Result if row_group_indices contains an invalid index
   virtual ::arrow::Result<std::unique_ptr<::arrow::RecordBatchReader>>
   GetRecordBatchReader(const std::vector<int>& row_group_indices) = 0;
-
-  /// \brief Return a RecordBatchReader of row groups selected from
-  /// row_group_indices, whose columns are selected by column_indices.
-  ///
-  /// Note that the ordering in row_group_indices and column_indices
-  /// matter. FileReaders must outlive their RecordBatchReaders.
-  ///
-  /// \returns error Status if either row_group_indices or column_indices
-  ///     contains an invalid index
-  ///
-  /// \deprecated Deprecated in 19.0.0. Use arrow::Result version instead.
-  ARROW_DEPRECATED("Deprecated in 19.0.0. Use arrow::Result version instead.")
-  virtual ::arrow::Status GetRecordBatchReader(
-      const std::vector<int>& row_group_indices, const std::vector<int>& column_indices,
-      std::unique_ptr<::arrow::RecordBatchReader>* out);
 
   /// \brief Return a RecordBatchReader of row groups selected from
   /// row_group_indices, whose columns are selected by column_indices.
@@ -386,17 +352,6 @@ class PARQUET_EXPORT FileReaderBuilder {
 /// \defgroup parquet-arrow-reader-factories Factory functions for Parquet Arrow readers
 ///
 /// @{
-
-/// \brief Build FileReader from Arrow file and MemoryPool
-///
-/// Advanced settings are supported through the FileReaderBuilder class.
-///
-/// \deprecated Deprecated in 19.0.0. Use arrow::Result version instead.
-ARROW_DEPRECATED("Deprecated in 19.0.0. Use arrow::Result version instead.")
-PARQUET_EXPORT
-::arrow::Status OpenFile(std::shared_ptr<::arrow::io::RandomAccessFile>,
-                         ::arrow::MemoryPool* allocator,
-                         std::unique_ptr<FileReader>* reader);
 
 /// \brief Build FileReader from Arrow file and MemoryPool
 ///

--- a/cpp/src/parquet/arrow/writer.h
+++ b/cpp/src/parquet/arrow/writer.h
@@ -89,13 +89,6 @@ class PARQUET_EXPORT FileWriter {
   /// Returns an error if not all columns have been written.
   virtual ::arrow::Status NewRowGroup() = 0;
 
-  /// \brief Start a new row group.
-  ///
-  /// \deprecated Deprecated in 19.0.0.
-  ARROW_DEPRECATED(
-      "Deprecated in 19.0.0. Use NewRowGroup() without the `chunk_size` argument.")
-  virtual ::arrow::Status NewRowGroup(int64_t chunk_size) { return NewRowGroup(); }
-
   /// \brief Write ColumnChunk in row group using an array.
   virtual ::arrow::Status WriteColumnChunk(const ::arrow::Array& data) = 0;
 


### PR DESCRIPTION
### Rationale for this change
`GetRecordBatchReader` in reader.h and `NewRowGroup` with `chunk_size` in writer.h have been deprecated in 19.0.0.

### What changes are included in this PR?
Deprecated functions are removed.

### Are these changes tested?
Existing tests should pass.

### Are there any user-facing changes?
No, deprecated functionality is removed.

* GitHub Issue: #46132