### PR TITLE
GH-46134: [CI][C++] Explicit conversion of possible `absl::string_view` on protobuf  methods to `std::string`

### DIFF
--- a/cpp/src/arrow/engine/substrait/expression_internal.cc
+++ b/cpp/src/arrow/engine/substrait/expression_internal.cc
@@ -142,7 +142,7 @@ std::string EnumToString(int value, const google::protobuf::EnumDescriptor* desc
   if (value_desc == nullptr) {
     return "unknown";
   }
-  return value_desc->name();
+  return std::string(value_desc->name());
 }
 
 Result<compute::Expression> FromProto(const substrait::Expression::ReferenceSegment* ref,

--- a/cpp/src/arrow/engine/substrait/serde.cc
+++ b/cpp/src/arrow/engine/substrait/serde.cc
@@ -62,8 +62,8 @@ Status ParseFromBufferImpl(const Buffer& buf, const std::string& full_name,
 template <typename Message>
 Result<Message> ParseFromBuffer(const Buffer& buf) {
   Message message;
-  ARROW_RETURN_NOT_OK(
-      ParseFromBufferImpl(buf, Message::descriptor()->full_name(), &message));
+  ARROW_RETURN_NOT_OK(ParseFromBufferImpl(
+      buf, std::string(Message::descriptor()->full_name()), &message));
   return message;
 }
 

--- a/cpp/src/arrow/engine/substrait/util_internal.cc
+++ b/cpp/src/arrow/engine/substrait/util_internal.cc
@@ -30,7 +30,7 @@ std::string EnumToString(int value, const google::protobuf::EnumDescriptor& desc
   if (value_desc == nullptr) {
     return "unknown";
   }
-  return value_desc->name();
+  return std::string(value_desc->name());
 }
 
 std::unique_ptr<substrait::Version> CreateVersion() {


### PR DESCRIPTION
### Rationale for this change

Protobuf v30.2 uses `absl::string_view` instead of `const char*` as seen here:
https://github.com/protocolbuffers/protobuf/commit/a9ad51f5b6a19eacc934bcb51db6282ec1fabb8c
This is breaking on our CI.

### What changes are included in this PR?

Explicitly convert `google::protobuf::EnumValueDescriptor::name()` and `google::protobuf::Message::descriptor()->full_name()` from `absl::string_view` to `std::string`

### Are these changes tested?

Via CI, MinGW CI jobs use protobuf v30.2 and those are fixed with this change.

### Are there any user-facing changes?

No

* GitHub Issue: #46134