### PR TITLE
GH-46127: [CI][Release] Make 02-source.sh test passable on fork

### DIFF
--- a/dev/release/02-source-test.rb
+++ b/dev/release/02-source-test.rb
@@ -113,8 +113,9 @@ class SourceTest < Test::Unit::TestCase
                               "Content-Type" => "application/json",
                               "Authorization" => "Bearer #{github_token}")
     n_resolved_issues = JSON.parse(response.body)["data"]["search"]["issueCount"]
+    github_repository = ENV["GITHUB_REPOSITORY"] || "apache/arrow"
     github_api_url = "https://api.github.com"
-    verify_prs = URI("#{github_api_url}/repos/apache/arrow/pulls" +
+    verify_prs = URI("#{github_api_url}/repos/#{github_repository}/pulls" +
                      "?state=open" +
                      "&head=apache:release-#{@release_version}-rc0")
     verify_pr_url = nil


### PR DESCRIPTION
### Rationale for this change

`02-source.sh` checks `${GITHUB_REPOSITORY}` but `02-source-test.rb` doesn't check `ENV["GITHUB_REPOSITORY"]`. So actual and expected refer different repositories on fork.

### What changes are included in this PR?

`02-source-test.rb` checks `ENV["GITHUB_REPOSITORY"]`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #46127