### PR TITLE
GH-41672: [Python][Doc] Clarify docstring of FixedSizeListArray.values that it ignores the offset

### DIFF
--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -3628,7 +3628,7 @@ cdef class FixedSizeListArray(BaseListArray):
     def values(self):
         """
         Return the underlying array of values which backs the
-        FixedSizeListArray.
+        FixedSizeListArray ignoring the array's offset.
 
         Note even null elements are included.
 


### PR DESCRIPTION
### Rationale for this change

Update docstring to explicitly mention that FixedSizeListArray.values ignores the offset

### What changes are included in this PR?

Updated docstring to mention this

### Are these changes tested?

No

### Are there any user-facing changes?

No
* GitHub Issue: #41672