### PR TITLE
MINOR: [C++][Parquet] Fix incorrect comments about dictionary encoding fallback behaviour

### DIFF
--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -1686,7 +1686,7 @@ class TypedColumnWriterImpl : public ColumnWriterImpl,
       // Serialize the buffered Dictionary Indices
       FlushBufferedDataPages();
       fallback_ = true;
-      // Only PLAIN encoding is supported for fallback in V1
+      // Only PLAIN encoding is supported for fallback
       current_encoder_ = MakeEncoder(ParquetType::type_num, Encoding::PLAIN, false,
                                      descr_, properties_->memory_pool());
       current_value_encoder_ = dynamic_cast<ValueEncoderType*>(current_encoder_.get());

--- a/cpp/src/parquet/properties.h
+++ b/cpp/src/parquet/properties.h
@@ -383,8 +383,8 @@ class PARQUET_EXPORT WriterProperties {
 
     /// \brief Define the encoding that is used when we don't utilise dictionary encoding.
     //
-    /// This either apply if dictionary encoding is disabled or if we fallback
-    /// as the dictionary grew too large.
+    /// This is only applied if dictionary encoding is disabled. If the dictionary grows
+    /// too large we always fall back to the PLAIN encoding.
     Builder* encoding(Encoding::type encoding_type) {
       if (encoding_type == Encoding::PLAIN_DICTIONARY ||
           encoding_type == Encoding::RLE_DICTIONARY) {
@@ -397,8 +397,8 @@ class PARQUET_EXPORT WriterProperties {
 
     /// \brief Define the encoding that is used when we don't utilise dictionary encoding.
     //
-    /// This either apply if dictionary encoding is disabled or if we fallback
-    /// as the dictionary grew too large.
+    /// This is only applied if dictionary encoding is disabled. If the dictionary grows
+    /// too large we always fall back to the PLAIN encoding.
     Builder* encoding(const std::string& path, Encoding::type encoding_type) {
       if (encoding_type == Encoding::PLAIN_DICTIONARY ||
           encoding_type == Encoding::RLE_DICTIONARY) {
@@ -411,8 +411,8 @@ class PARQUET_EXPORT WriterProperties {
 
     /// \brief Define the encoding that is used when we don't utilise dictionary encoding.
     //
-    /// This either apply if dictionary encoding is disabled or if we fallback
-    /// as the dictionary grew too large.
+    /// This is only applied if dictionary encoding is disabled. If the dictionary grows
+    /// too large we always fall back to the PLAIN encoding.
     Builder* encoding(const std::shared_ptr<schema::ColumnPath>& path,
                       Encoding::type encoding_type) {
       return this->encoding(path->ToDotString(), encoding_type);


### PR DESCRIPTION
### Rationale for this change

Prevent confusion of developers reading the Parquet source code or generated API documentation.

### What changes are included in this PR?

Updates comments to make it clear that when the dictionary page gets too large, we always fall back to the plain encoding, regardless of the Parquet format version or specified encoding.

### Are these changes tested?

N/A

### Are there any user-facing changes?

No.