### PR TITLE
GH-46159: [CI][C++] Stop using possibly missing boost/process/v2.hpp on boost 1.88 and use individual includes

### DIFF
--- a/cpp/src/arrow/testing/process.cc
+++ b/cpp/src/arrow/testing/process.cc
@@ -39,29 +39,18 @@
 #      ifdef __APPLE__
 #        include <sys/sysctl.h>
 #      endif
-#      include <boost/process/v2/environment.hpp>
-#      include <boost/process/v2/error.hpp>
-#      include <boost/process/v2/execute.hpp>
-#      include <boost/process/v2/exit_code.hpp>
-#      include <boost/process/v2/pid.hpp>
-#      include <boost/process/v2/popen.hpp>
-#      include <boost/process/v2/process.hpp>
-#      include <boost/process/v2/process_handle.hpp>
 #      include <boost/process/v2/src.hpp>
-#      include <boost/process/v2/start_dir.hpp>
-#      include <boost/process/v2/stdio.hpp>
-#    else
-#      include <boost/process/v2/environment.hpp>
-#      include <boost/process/v2/error.hpp>
-#      include <boost/process/v2/execute.hpp>
-#      include <boost/process/v2/exit_code.hpp>
-#      include <boost/process/v2/pid.hpp>
-#      include <boost/process/v2/popen.hpp>
-#      include <boost/process/v2/process.hpp>
-#      include <boost/process/v2/process_handle.hpp>
-#      include <boost/process/v2/start_dir.hpp>
-#      include <boost/process/v2/stdio.hpp>
 #    endif
+#    include <boost/process/v2/environment.hpp>
+#    include <boost/process/v2/error.hpp>
+#    include <boost/process/v2/execute.hpp>
+#    include <boost/process/v2/exit_code.hpp>
+#    include <boost/process/v2/pid.hpp>
+#    include <boost/process/v2/popen.hpp>
+#    include <boost/process/v2/process.hpp>
+#    include <boost/process/v2/process_handle.hpp>
+#    include <boost/process/v2/start_dir.hpp>
+#    include <boost/process/v2/stdio.hpp>
 #    include <unordered_map>
 #  else
 // We need BOOST_USE_WINDOWS_H definition with MinGW when we use

--- a/cpp/src/arrow/testing/process.cc
+++ b/cpp/src/arrow/testing/process.cc
@@ -39,10 +39,28 @@
 #      ifdef __APPLE__
 #        include <sys/sysctl.h>
 #      endif
-#      include <boost/process/v2.hpp>
+#      include <boost/process/v2/environment.hpp>
+#      include <boost/process/v2/error.hpp>
+#      include <boost/process/v2/execute.hpp>
+#      include <boost/process/v2/exit_code.hpp>
+#      include <boost/process/v2/pid.hpp>
+#      include <boost/process/v2/popen.hpp>
+#      include <boost/process/v2/process.hpp>
+#      include <boost/process/v2/process_handle.hpp>
 #      include <boost/process/v2/src.hpp>
+#      include <boost/process/v2/start_dir.hpp>
+#      include <boost/process/v2/stdio.hpp>
 #    else
-#      include <boost/process/v2.hpp>
+#      include <boost/process/v2/environment.hpp>
+#      include <boost/process/v2/error.hpp>
+#      include <boost/process/v2/execute.hpp>
+#      include <boost/process/v2/exit_code.hpp>
+#      include <boost/process/v2/pid.hpp>
+#      include <boost/process/v2/popen.hpp>
+#      include <boost/process/v2/process.hpp>
+#      include <boost/process/v2/process_handle.hpp>
+#      include <boost/process/v2/start_dir.hpp>
+#      include <boost/process/v2/stdio.hpp>
 #    endif
 #    include <unordered_map>
 #  else


### PR DESCRIPTION
### Rationale for this change

Similar to https://github.com/apache/arrow/pull/46113 but for boost v2. 
The files `v1.hpp` and `v2.hpp` have been removed from `include/boost/process` on `1.88`:
https://github.com/boostorg/process/tree/develop/include/boost/process
but were available on `1.87`:
https://github.com/boostorg/process/blob/boost-1.87.0/include/boost/process/v1.hpp
https://github.com/boostorg/process/blob/boost-1.87.0/include/boost/process/v2.hpp

### What changes are included in this PR?

Stop using include for possible missing file and add individual includes

### Are these changes tested?

Via CI

### Are there any user-facing changes?

No

* GitHub Issue: #46159