### PR TITLE
GH-46163: [C++] Add vendored directory to Meson

### DIFF
--- a/cpp/src/arrow/meson.build
+++ b/cpp/src/arrow/meson.build
@@ -611,6 +611,7 @@ subdir('c')
 subdir('io')
 subdir('tensor')
 subdir('util')
+subdir('vendored')
 
 gflags_dep = dependency('gflags', include_type: 'system')
 if needs_integration or needs_tests

--- a/cpp/src/arrow/vendored/datetime/meson.build
+++ b/cpp/src/arrow/vendored/datetime/meson.build
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+install_headers(
+    ['date.h', 'ios.h', 'tz.h', 'tz_private.h', 'visibility.h'],
+    subdir: 'arrow/vendored/datetime',
+)

--- a/cpp/src/arrow/vendored/double-conversion/meson.build
+++ b/cpp/src/arrow/vendored/double-conversion/meson.build
@@ -1,0 +1,34 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+install_headers(
+    [
+        'bignum-dtoa.h',
+        'bignum.h',
+        'cached-powers.h',
+        'diy-fp.h',
+        'double-conversion.h',
+        'double-to-string.h',
+        'fast-dtoa.h',
+        'fixed-dtoa.h',
+        'ieee.h',
+        'string-to-double.h',
+        'strtod.h',
+        'utils.h',
+    ],
+    subdir: 'arrow/vendored/double-conversion',
+)

--- a/cpp/src/arrow/vendored/meson.build
+++ b/cpp/src/arrow/vendored/meson.build
@@ -1,0 +1,27 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+install_headers(
+    ['datetime.h', 'ProducerConsumerQueue.h', 'strptime.h', 'xxhash.h'],
+    subdir: 'arrow/vendored',
+)
+
+subdir('datetime')
+subdir('double-conversion')
+subdir('pcg')
+subdir('portable-snippets')
+subdir('xxhash')

--- a/cpp/src/arrow/vendored/pcg/meson.build
+++ b/cpp/src/arrow/vendored/pcg/meson.build
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+install_headers(
+    ['pcg_extras.hpp', 'pcg_random.hpp', 'pcg_uint128.hpp'],
+    subdir: 'arrow/vendored/pcg',
+)

--- a/cpp/src/arrow/vendored/portable-snippets/meson.build
+++ b/cpp/src/arrow/vendored/portable-snippets/meson.build
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+install_headers(
+    ['debug-trap.h', 'safe-math.h'],
+    subdir: 'arrow/vendored/portable-snippets',
+)

--- a/cpp/src/arrow/vendored/xxhash/meson.build
+++ b/cpp/src/arrow/vendored/xxhash/meson.build
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+install_headers(['xxhash.h'], subdir: 'arrow/vendored/xxhash')


### PR DESCRIPTION
### Rationale for this change

This continues adding support for Meson as a build system generator

### What changes are included in this PR?

This adds the vendored directory to the Meson configuration

### Are these changes tested?

Yes

### Are there any user-facing changes?

No

* GitHub Issue: #46163