### PR TITLE
GH-45531: [Python] Add the `dim_names` argument to `from_numpy_ndarray`

### DIFF
--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -17,6 +17,7 @@
 
 from cpython.pycapsule cimport PyCapsule_CheckExact, PyCapsule_GetPointer, PyCapsule_New
 
+from collections.abc import Sequence
 import os
 import warnings
 from cython import sizeof
@@ -4658,8 +4659,8 @@ cdef class FixedShapeTensorArray(ExtensionArray):
         if np.prod(obj.shape) == 0:
             raise ValueError("Expected a non-empty ndarray")
         if dim_names is not None:
-            if not hasattr(dim_names, '__iter__'):
-                raise TypeError("dim_names must be an iterable (e.g., list or tuple)")
+            if not isinstance(dim_names, Sequence):
+                raise TypeError("dim_names must be a tuple or list")
             if len(dim_names) != len(obj.shape[1:]):
                 raise ValueError(
                     (f"The length of dim_names ({len(dim_names)}) does not match"

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -1569,6 +1569,22 @@ def test_tensor_array_from_numpy(np_type_str):
     with pytest.raises(ValueError, match="Expected a non-empty ndarray"):
         pa.FixedShapeTensorArray.from_numpy_ndarray(arr.reshape((3, 0, 2)))
 
+    arr = np.array([[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]],
+                   dtype=np.dtype(np_type_str), order="C")
+    dim_names = ["a", "b"]
+    tensor_array_from_numpy = pa.FixedShapeTensorArray.from_numpy_ndarray(
+        arr, dim_names=dim_names)
+    assert tensor_array_from_numpy.type.dim_names == dim_names
+
+    with pytest.raises(ValueError, match="The length of dim_names"):
+        pa.FixedShapeTensorArray.from_numpy_ndarray(arr, dim_names=['only_one'])
+
+    with pytest.raises(TypeError, match="dim_names must be an iterable"):
+        pa.FixedShapeTensorArray.from_numpy_ndarray(arr, dim_names=123)
+
+    with pytest.raises(TypeError, match="Each element of dim_names must be a string"):
+        pa.FixedShapeTensorArray.from_numpy_ndarray(arr, dim_names=[0, 1])
+
 
 @pytest.mark.numpy
 @pytest.mark.parametrize("tensor_type", (

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -1579,8 +1579,12 @@ def test_tensor_array_from_numpy(np_type_str):
     with pytest.raises(ValueError, match="The length of dim_names"):
         pa.FixedShapeTensorArray.from_numpy_ndarray(arr, dim_names=['only_one'])
 
-    with pytest.raises(TypeError, match="dim_names must be an iterable"):
+    with pytest.raises(TypeError, match="dim_names must be a tuple or list"):
         pa.FixedShapeTensorArray.from_numpy_ndarray(arr, dim_names=123)
+
+    with pytest.raises(TypeError, match="dim_names must be a tuple or list"):
+        pa.FixedShapeTensorArray.from_numpy_ndarray(
+            arr, dim_names=(x for x in range(2)))
 
     with pytest.raises(TypeError, match="Each element of dim_names must be a string"):
         pa.FixedShapeTensorArray.from_numpy_ndarray(arr, dim_names=[0, 1])

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -1513,6 +1513,7 @@ def test_tensor_array_from_numpy(np_type_str):
     assert isinstance(tensor_array_from_numpy.type, pa.FixedShapeTensorType)
     assert tensor_array_from_numpy.type.value_type == arrow_type
     assert tensor_array_from_numpy.type.shape == [2, 3]
+    assert tensor_array_from_numpy.type.dim_names is None
 
     arr = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]],
                    dtype=np.dtype(np_type_str), order="F")
@@ -1527,6 +1528,7 @@ def test_tensor_array_from_numpy(np_type_str):
     tensor_array_from_numpy = pa.FixedShapeTensorArray.from_numpy_ndarray(arr)
     assert tensor_array_from_numpy.type.shape == [3, 4]
     assert tensor_array_from_numpy.type.permutation == [0, 1]
+    assert tensor_array_from_numpy.type.dim_names is None
     assert tensor_array_from_numpy.to_tensor() == pa.Tensor.from_numpy(arr)
 
     arr = as_strided(flat_arr, shape=(1, 2, 3, 2),
@@ -1534,6 +1536,7 @@ def test_tensor_array_from_numpy(np_type_str):
     tensor_array_from_numpy = pa.FixedShapeTensorArray.from_numpy_ndarray(arr)
     assert tensor_array_from_numpy.type.shape == [2, 2, 3]
     assert tensor_array_from_numpy.type.permutation == [0, 2, 1]
+    assert tensor_array_from_numpy.type.dim_names is None
     assert tensor_array_from_numpy.to_tensor() == pa.Tensor.from_numpy(arr)
 
     arr = flat_arr.reshape(1, 2, 3, 2)
@@ -1574,6 +1577,8 @@ def test_tensor_array_from_numpy(np_type_str):
     dim_names = ["a", "b"]
     tensor_array_from_numpy = pa.FixedShapeTensorArray.from_numpy_ndarray(
         arr, dim_names=dim_names)
+    assert tensor_array_from_numpy.type.value_type == arrow_type
+    assert tensor_array_from_numpy.type.shape == [2, 3]
     assert tensor_array_from_numpy.type.dim_names == dim_names
 
     with pytest.raises(ValueError, match="The length of dim_names"):


### PR DESCRIPTION
### Rationale for this change

The `FixedShapeTensorArray.from_numpy_ndarray` method did not pass `dim_names` to the `fixed_shape_tensor` constructor, which resulted in dimension names being lost when converting from a NumPy array. This change ensures that dimension names are properly preserved when constructing a tensor array from a NumPy ndarray.

### What changes are included in this PR?

- Added an optional `dim_names` parameter to `FixedShapeTensorArray.from_numpy_ndarray`.
- If provided, the `dim_names` are now passed to the `fixed_shape_tensor` constructor.

### Are these changes tested?

- Existing tests pass, confirming no regressions to current functionality.
- Additional unit tests have been added to verify that `dim_names` are correctly handled when specified.

### Are there any user-facing changes?

- The method `FixedShapeTensorArray.from_numpy_ndarray` now accepts an optional `dim_names` argument.
- This argument is optional, and the behavior remains unchanged when it is not provided.

* GitHub Issue: #45531