### PR TITLE
GH-46174: [Python] Failing tests in python minimal builds

### DIFF
--- a/python/pyarrow/tests/test_acero.py
+++ b/python/pyarrow/tests/test_acero.py
@@ -115,6 +115,25 @@ def test_filter(table_source):
         FilterNodeOptions(None)
 
 
+@pytest.mark.parametrize('source', [
+    pa.record_batch({"number": [1, 2, 3]}),
+    pa.table({"number": [1, 2, 3]})
+])
+def test_filter_all_rows(source):
+    # GH-46057: filtering all rows should return empty RecordBatch with same schema
+    result_expr = source.filter(pc.field("number") < 0)
+
+    assert result_expr.num_rows == 0
+    assert type(result_expr) is type(source)
+    assert result_expr.schema.equals(source.schema)
+
+    result_mask = source.filter(pa.array([False, False, False]))
+
+    assert result_mask.num_rows == 0
+    assert type(result_mask) is type(source)
+    assert result_mask.schema.equals(source.schema)
+
+
 def test_project(table_source):
     # default name from expression
     decl = Declaration.from_sequence([

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -1415,17 +1415,6 @@ def test_filter_record_batch():
     expected = pa.record_batch([pa.array(["a", None, "e"])], names=["a'"])
     assert result.equals(expected)
 
-    # GH-46057: filtering all rows should return empty RecordBatch with same schema
-    mask_empty_result = batch.filter(pa.array([False] * batch.num_rows))
-    assert mask_empty_result.num_rows == 0
-    assert isinstance(mask_empty_result, pa.RecordBatch)
-    assert mask_empty_result.schema.equals(batch.schema)
-
-    expr_empty_result = batch.filter(pc.field("a'") == "zzz")
-    assert expr_empty_result.num_rows == 0
-    assert isinstance(expr_empty_result, pa.RecordBatch)
-    assert expr_empty_result.schema.equals(batch.schema)
-
 
 def test_filter_table():
     table = pa.table([pa.array(["a", None, "c", "d", "e"])], names=["a"])
@@ -1444,17 +1433,6 @@ def test_filter_table():
         assert result.equals(expected_drop)
         result = table.filter(mask, null_selection_behavior="emit_null")
         assert result.equals(expected_null)
-
-    # GH-46057: filtering all rows should return empty table with same schema
-    mask_empty_result = table.filter(pa.array([False] * table.num_rows))
-    assert mask_empty_result.num_rows == 0
-    assert isinstance(mask_empty_result, pa.Table)
-    assert mask_empty_result.schema.equals(table.schema)
-
-    expr_empty_result = table.filter(pc.field("a") == "zzz")
-    assert expr_empty_result.num_rows == 0
-    assert isinstance(expr_empty_result, pa.Table)
-    assert expr_empty_result.schema.equals(table.schema)
 
 
 def test_filter_errors():


### PR DESCRIPTION
### Rationale for this change

There are tests failing in builds:

https://github.com/ursacomputing/crossbow/actions/runs/14504182772/job/40690374094#step:3:15238
https://github.com/ursacomputing/crossbow/actions/runs/14504182883/job/40690374677#step:3:13330

### What changes are included in this PR?

Tests that caused the failure are moved from `test_compute.py` to `test_acero.py.`

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No, only changes in the tests.

* GitHub Issue: #46174