### PR TITLE
GH-46189 [C#] Use pooled buffers in ArrowStreamWriter

### DIFF
--- a/csharp/src/Apache.Arrow.Compression/Lz4CompressionCodec.cs
+++ b/csharp/src/Apache.Arrow.Compression/Lz4CompressionCodec.cs
@@ -15,14 +15,9 @@
 
 using System;
 using System.IO;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
-using System.Threading;
-using System.Threading.Tasks;
 using Apache.Arrow.Ipc;
 using K4os.Compression.LZ4;
 using K4os.Compression.LZ4.Streams;
-using K4os.Compression.LZ4.Streams.Abstractions;
 
 namespace Apache.Arrow.Compression
 {
@@ -61,21 +56,6 @@ namespace Apache.Arrow.Compression
             encoder.WriteManyBytes(source.Span);
         }
 
-        public bool TryCompress(ReadOnlyMemory<byte> source, Memory<byte> destination, out int bytesWritten)
-        {
-            using var memoryStream = new MemoryStream(destination.Length);
-            using(var encoder = LZ4Frame.Encode(memoryStream, _settings, leaveOpen: true))
-            {
-                encoder.WriteManyBytes(source.Span);
-            }
-            bytesWritten = checked((int)memoryStream.Position);
-            if (bytesWritten > destination.Length)
-            {
-                return false;
-            }
-            memoryStream.GetBuffer().AsSpan(0, bytesWritten).CopyTo(destination.Span);
-            return true;
-        }
         public void Dispose()
         {
         }

--- a/csharp/src/Apache.Arrow.Compression/Lz4CompressionCodec.cs
+++ b/csharp/src/Apache.Arrow.Compression/Lz4CompressionCodec.cs
@@ -15,9 +15,14 @@
 
 using System;
 using System.IO;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
 using Apache.Arrow.Ipc;
 using K4os.Compression.LZ4;
 using K4os.Compression.LZ4.Streams;
+using K4os.Compression.LZ4.Streams.Abstractions;
 
 namespace Apache.Arrow.Compression
 {
@@ -33,7 +38,7 @@ namespace Apache.Arrow.Compression
                 {
                     _settings = new LZ4EncoderSettings
                     {
-                        CompressionLevel = (LZ4Level) compressionLevel,
+                        CompressionLevel = (LZ4Level) compressionLevel
                     };
                 }
                 else
@@ -56,6 +61,21 @@ namespace Apache.Arrow.Compression
             encoder.WriteManyBytes(source.Span);
         }
 
+        public bool TryCompress(ReadOnlyMemory<byte> source, Memory<byte> destination, out int bytesWritten)
+        {
+            using var memoryStream = new MemoryStream(destination.Length);
+            using(var encoder = LZ4Frame.Encode(memoryStream, _settings, leaveOpen: true))
+            {
+                encoder.WriteManyBytes(source.Span);
+            }
+            bytesWritten = checked((int)memoryStream.Position);
+            if (bytesWritten > destination.Length)
+            {
+                return false;
+            }
+            memoryStream.GetBuffer().AsSpan(0, bytesWritten).CopyTo(destination.Span);
+            return true;
+        }
         public void Dispose()
         {
         }

--- a/csharp/src/Apache.Arrow.Compression/ZstdCompressionCodec.cs
+++ b/csharp/src/Apache.Arrow.Compression/ZstdCompressionCodec.cs
@@ -52,6 +52,11 @@ namespace Apache.Arrow.Compression
             compressor.Write(source.Span);
         }
 
+        public bool TryCompress(ReadOnlyMemory<byte> source, Memory<byte> destination, out int bytesWritten)
+        {
+            return _compressor.TryWrap(source.Span, destination.Span, out bytesWritten);
+        }
+
         public void Dispose()
         {
             _decompressor.Dispose();

--- a/csharp/src/Apache.Arrow.Compression/ZstdCompressionCodec.cs
+++ b/csharp/src/Apache.Arrow.Compression/ZstdCompressionCodec.cs
@@ -20,7 +20,7 @@ using ZstdSharp;
 
 namespace Apache.Arrow.Compression
 {
-    internal sealed class ZstdCompressionCodec : ICompressionCodec
+    internal sealed class ZstdCompressionCodec : ITryCompressionCodec
     {
         private readonly Decompressor _decompressor;
         private readonly Compressor _compressor;

--- a/csharp/src/Apache.Arrow/Ipc/ArrowStreamWriter.cs
+++ b/csharp/src/Apache.Arrow/Ipc/ArrowStreamWriter.cs
@@ -87,35 +87,36 @@ namespace Apache.Arrow.Ipc
                 }
             }
 
-            public readonly struct Buffer
+            public readonly struct Buffer : IDisposable
             {
                 public readonly ReadOnlyMemory<byte> DataBuffer;
                 public readonly int Offset;
+                private readonly IDisposable _owner;
 
-                public Buffer(ReadOnlyMemory<byte> buffer, int offset)
+                public Buffer(ReadOnlyMemory<byte> buffer, int offset, IDisposable owner)
                 {
                     DataBuffer = buffer;
                     Offset = offset;
+                    _owner = owner;
                 }
+                public void Dispose() => _owner?.Dispose();
             }
 
             private readonly List<FieldNode> _fieldNodes;
             private readonly List<Buffer> _buffers;
             private readonly ICompressionCodec _compressionCodec;
             private readonly MemoryAllocator _allocator;
-            private readonly MemoryStream _compressionStream;
 
             public IReadOnlyList<FieldNode> FieldNodes => _fieldNodes;
             public IReadOnlyList<Buffer> Buffers => _buffers;
 
-            public List<long> VariadicCounts { get; private set; } 
+            public List<long> VariadicCounts { get; private set; }
             public int TotalLength { get; private set; }
 
             public ArrowRecordBatchFlatBufferBuilder(
-                ICompressionCodec compressionCodec, MemoryAllocator allocator, MemoryStream compressionStream)
+                ICompressionCodec compressionCodec, MemoryAllocator allocator)
             {
                 _compressionCodec = compressionCodec;
-                _compressionStream = compressionStream;
                 _allocator = allocator;
                 _fieldNodes = new List<FieldNode>();
                 _buffers = new List<Buffer>();
@@ -155,20 +156,20 @@ namespace Apache.Arrow.Ipc
             private void VisitPrimitiveArray<T>(PrimitiveArray<T> array)
                 where T : struct, IEquatable<T>
             {
-                _buffers.Add(CreateBitmapBuffer(array.NullBitmapBuffer, array.Offset, array.Length));
-                _buffers.Add(CreateSlicedBuffer<T>(array.ValueBuffer, array.Offset, array.Length));
+                _buffers.Add(CreateBitmapBuffer(array.NullBitmapBuffer, array.Offset, array.Length, false));
+                _buffers.Add(CreateSlicedBuffer<T>(array.ValueBuffer, array.Offset, array.Length, false));
             }
 
             public void Visit(BooleanArray array)
             {
-                _buffers.Add(CreateBitmapBuffer(array.NullBitmapBuffer, array.Offset, array.Length));
-                _buffers.Add(CreateBitmapBuffer(array.ValueBuffer, array.Offset, array.Length));
+                _buffers.Add(CreateBitmapBuffer(array.NullBitmapBuffer, array.Offset, array.Length, false));
+                _buffers.Add(CreateBitmapBuffer(array.ValueBuffer, array.Offset, array.Length, false));
             }
 
             public void Visit(ListArray array)
             {
-                _buffers.Add(CreateBitmapBuffer(array.NullBitmapBuffer, array.Offset, array.Length));
-                _buffers.Add(CreateBuffer(GetZeroBasedValueOffsets(array.ValueOffsetsBuffer, array.Offset, array.Length)));
+                _buffers.Add(CreateBitmapBuffer(array.NullBitmapBuffer, array.Offset, array.Length, false));
+                _buffers.Add(CreateBuffer(GetZeroBasedValueOffsets(array.ValueOffsetsBuffer, array.Offset, array.Length), true));
 
                 int valuesOffset = 0;
                 int valuesLength = 0;
@@ -191,9 +192,9 @@ namespace Apache.Arrow.Ipc
             {
                 var (valueOffsetsBuffer, minOffset, maxEnd) = GetZeroBasedListViewOffsets(array);
 
-                _buffers.Add(CreateBitmapBuffer(array.NullBitmapBuffer, array.Offset, array.Length));
-                _buffers.Add(CreateBuffer(valueOffsetsBuffer));
-                _buffers.Add(CreateSlicedBuffer<int>(array.SizesBuffer, array.Offset, array.Length));
+                _buffers.Add(CreateBitmapBuffer(array.NullBitmapBuffer, array.Offset, array.Length, false));
+                _buffers.Add(CreateBuffer(valueOffsetsBuffer, true));
+                _buffers.Add(CreateSlicedBuffer<int>(array.SizesBuffer, array.Offset, array.Length, false));
 
                 IArrowArray values = array.Values;
                 if (minOffset != 0 || values.Length != maxEnd)
@@ -206,8 +207,8 @@ namespace Apache.Arrow.Ipc
 
             public void Visit(LargeListArray array)
             {
-                _buffers.Add(CreateBitmapBuffer(array.NullBitmapBuffer, array.Offset, array.Length));
-                _buffers.Add(CreateBuffer(GetZeroBasedLongValueOffsets(array.ValueOffsetsBuffer, array.Offset, array.Length)));
+                _buffers.Add(CreateBitmapBuffer(array.NullBitmapBuffer, array.Offset, array.Length, false));
+                _buffers.Add(CreateBuffer(GetZeroBasedLongValueOffsets(array.ValueOffsetsBuffer, array.Offset, array.Length), true));
 
                 int valuesOffset = 0;
                 int valuesLength = 0;
@@ -228,7 +229,7 @@ namespace Apache.Arrow.Ipc
 
             public void Visit(FixedSizeListArray array)
             {
-                _buffers.Add(CreateBitmapBuffer(array.NullBitmapBuffer, array.Offset, array.Length));
+                _buffers.Add(CreateBitmapBuffer(array.NullBitmapBuffer, array.Offset, array.Length, false));
 
                 var listSize = ((FixedSizeListType)array.Data.DataType).ListSize;
                 var valuesSlice =
@@ -245,8 +246,8 @@ namespace Apache.Arrow.Ipc
 
             public void Visit(BinaryArray array)
             {
-                _buffers.Add(CreateBitmapBuffer(array.NullBitmapBuffer, array.Offset, array.Length));
-                _buffers.Add(CreateBuffer(GetZeroBasedValueOffsets(array.ValueOffsetsBuffer, array.Offset, array.Length)));
+                _buffers.Add(CreateBitmapBuffer(array.NullBitmapBuffer, array.Offset, array.Length, false));
+                _buffers.Add(CreateBuffer(GetZeroBasedValueOffsets(array.ValueOffsetsBuffer, array.Offset, array.Length), true));
 
                 int valuesOffset = 0;
                 int valuesLength = 0;
@@ -256,16 +257,16 @@ namespace Apache.Arrow.Ipc
                     valuesLength = array.ValueOffsets[array.Length] - valuesOffset;
                 }
 
-                _buffers.Add(CreateSlicedBuffer<byte>(array.ValueBuffer, valuesOffset, valuesLength));
+                _buffers.Add(CreateSlicedBuffer<byte>(array.ValueBuffer, valuesOffset, valuesLength, false));
             }
 
             public void Visit(BinaryViewArray array)
             {
-                _buffers.Add(CreateBitmapBuffer(array.NullBitmapBuffer, array.Offset, array.Length));
-                _buffers.Add(CreateSlicedBuffer<Scalars.BinaryView>(array.ViewsBuffer, array.Offset, array.Length));
+                _buffers.Add(CreateBitmapBuffer(array.NullBitmapBuffer, array.Offset, array.Length, false));
+                _buffers.Add(CreateSlicedBuffer<Scalars.BinaryView>(array.ViewsBuffer, array.Offset, array.Length, false));
                 for (int i = 0; i < array.DataBufferCount; i++)
                 {
-                    _buffers.Add(CreateBuffer(array.DataBuffer(i)));
+                    _buffers.Add(CreateBuffer(array.DataBuffer(i), false));
                 }
                 VariadicCounts = VariadicCounts ?? new List<long>();
                 VariadicCounts.Add(array.DataBufferCount);
@@ -273,8 +274,8 @@ namespace Apache.Arrow.Ipc
 
             public void Visit(LargeBinaryArray array)
             {
-                _buffers.Add(CreateBitmapBuffer(array.NullBitmapBuffer, array.Offset, array.Length));
-                _buffers.Add(CreateBuffer(GetZeroBasedLongValueOffsets(array.ValueOffsetsBuffer, array.Offset, array.Length)));
+                _buffers.Add(CreateBitmapBuffer(array.NullBitmapBuffer, array.Offset, array.Length, false));
+                _buffers.Add(CreateBuffer(GetZeroBasedLongValueOffsets(array.ValueOffsetsBuffer, array.Offset, array.Length), true));
 
                 int valuesOffset = 0;
                 int valuesLength = 0;
@@ -284,14 +285,14 @@ namespace Apache.Arrow.Ipc
                     valuesLength = checked((int)array.ValueOffsets[array.Length]) - valuesOffset;
                 }
 
-                _buffers.Add(CreateSlicedBuffer<byte>(array.ValueBuffer, valuesOffset, valuesLength));
+                _buffers.Add(CreateSlicedBuffer<byte>(array.ValueBuffer, valuesOffset, valuesLength, false));
             }
 
             public void Visit(FixedSizeBinaryArray array)
             {
                 var itemSize = ((FixedSizeBinaryType)array.Data.DataType).ByteWidth;
-                _buffers.Add(CreateBitmapBuffer(array.NullBitmapBuffer, array.Offset, array.Length));
-                _buffers.Add(CreateSlicedBuffer(array.ValueBuffer, itemSize, array.Offset, array.Length));
+                _buffers.Add(CreateBitmapBuffer(array.NullBitmapBuffer, array.Offset, array.Length, false));
+                _buffers.Add(CreateSlicedBuffer(array.ValueBuffer, itemSize, array.Offset, array.Length, false));
             }
 
             public void Visit(Decimal32Array array) => Visit(array as FixedSizeBinaryArray);
@@ -304,7 +305,7 @@ namespace Apache.Arrow.Ipc
 
             public void Visit(StructArray array)
             {
-                _buffers.Add(CreateBitmapBuffer(array.NullBitmapBuffer, array.Offset, array.Length));
+                _buffers.Add(CreateBitmapBuffer(array.NullBitmapBuffer, array.Offset, array.Length, false));
 
                 for (int i = 0; i < array.Fields.Count; i++)
                 {
@@ -315,12 +316,12 @@ namespace Apache.Arrow.Ipc
 
             public void Visit(UnionArray array)
             {
-                _buffers.Add(CreateSlicedBuffer<byte>(array.TypeBuffer, array.Offset, array.Length));
+                _buffers.Add(CreateSlicedBuffer<byte>(array.TypeBuffer, array.Offset, array.Length, false));
 
                 ArrowBuffer? offsets = (array as DenseUnionArray)?.ValueOffsetBuffer;
                 if (offsets != null)
                 {
-                    _buffers.Add(CreateSlicedBuffer<int>(offsets.Value, array.Offset, array.Length));
+                    _buffers.Add(CreateSlicedBuffer<int>(offsets.Value, array.Offset, array.Length, false));
                 }
 
                 for (int i = 0; i < array.Fields.Count; i++)
@@ -351,7 +352,7 @@ namespace Apache.Arrow.Ipc
                 {
                     // Array has been sliced, so we need to shift and adjust the offsets
                     var originalOffsets = valueOffsetsBuffer.Span.CastTo<int>().Slice(arrayOffset, arrayLength + 1);
-                    var firstOffset = arrayLength > 0 ? originalOffsets[0] : 0;
+                    int firstOffset = arrayLength > 0 ? originalOffsets[0] : 0;
 
                     var newValueOffsetsBuffer = _allocator.Allocate(requiredBytes);
                     var newValueOffsets = newValueOffsetsBuffer.Memory.Span.CastTo<int>();
@@ -371,8 +372,8 @@ namespace Apache.Arrow.Ipc
                 }
                 else
                 {
-                    // Use the full buffer
-                    return valueOffsetsBuffer;
+                    // Use the full buffer, but create a copy that is externally owned
+                    return new ArrowBuffer(valueOffsetsBuffer.Memory);
                 }
             }
 
@@ -393,7 +394,6 @@ namespace Apache.Arrow.Ipc
                     {
                         newValueOffsets[i] = originalOffsets[i] - firstOffset;
                     }
-
                     return new ArrowBuffer(newValueOffsetsBuffer);
                 }
                 else if (valueOffsetsBuffer.Length > requiredBytes)
@@ -404,8 +404,8 @@ namespace Apache.Arrow.Ipc
                 }
                 else
                 {
-                    // Use the full buffer
-                    return valueOffsetsBuffer;
+                    // Use the full buffer, create new buffer that is externally owned
+                    return new ArrowBuffer(valueOffsetsBuffer.Memory);
                 }
             }
 
@@ -439,12 +439,17 @@ namespace Apache.Arrow.Ipc
                 if (minOffset == 0)
                 {
                     // No need to adjust the offsets, but we may need to slice the offsets buffer.
-                    ArrowBuffer buffer = array.ValueOffsetsBuffer;
-                    if (array.Offset != 0 || buffer.Length > requiredBytes)
+                    ArrowBuffer buffer;
+                    if (array.Offset != 0 || array.ValueOffsetsBuffer.Length > requiredBytes)
                     {
                         var byteOffset = sizeof(int) * array.Offset;
-                        var sliceLength = Math.Min(requiredBytes, buffer.Length - byteOffset);
-                        buffer = new ArrowBuffer(buffer.Memory.Slice(byteOffset, sliceLength));
+                        var sliceLength = Math.Min(requiredBytes, array.ValueOffsetsBuffer.Length - byteOffset);
+                        buffer = new ArrowBuffer(array.ValueOffsetsBuffer.Memory.Slice(byteOffset, sliceLength));
+                    }
+                    else
+                    {
+                        // create a copy that's externally owned
+                        buffer = new ArrowBuffer(array.ValueOffsetsBuffer.Memory);
                     }
 
                     return (buffer, minOffset, maxEnd);
@@ -461,11 +466,11 @@ namespace Apache.Arrow.Ipc
                 return (new ArrowBuffer(newOffsetsBuffer), minOffset, maxEnd);
             }
 
-            private Buffer CreateBitmapBuffer(ArrowBuffer buffer, int offset, int length)
+            private Buffer CreateBitmapBuffer(ArrowBuffer buffer, int offset, int length, bool locallyOwned)
             {
                 if (buffer.IsEmpty)
                 {
-                    return CreateBuffer(buffer.Memory);
+                    return CreateBuffer(buffer, locallyOwned);
                 }
 
                 var paddedLength = CalculatePaddedBufferLength(BitUtility.ByteCount(length));
@@ -474,7 +479,7 @@ namespace Apache.Arrow.Ipc
                     var byteOffset = offset / 8;
                     var sliceLength = Math.Min(paddedLength, buffer.Length - byteOffset);
 
-                    return CreateBuffer(buffer.Memory.Slice(byteOffset, sliceLength));
+                    return CreateBuffer(buffer.Memory.Slice(byteOffset, sliceLength), locallyOwned ? buffer : null);
                 }
                 else
                 {
@@ -487,17 +492,17 @@ namespace Apache.Arrow.Ipc
                         BitUtility.SetBit(outputSpan, i, BitUtility.GetBit(inputSpan, offset + i));
                     }
 
-                    return CreateBuffer(memoryOwner.Memory);
+                    return CreateBuffer(memoryOwner);
                 }
             }
 
-            private Buffer CreateSlicedBuffer<T>(ArrowBuffer buffer, int offset, int length)
+            private Buffer CreateSlicedBuffer<T>(ArrowBuffer buffer, int offset, int length, bool owned)
                 where T : struct
             {
-                return CreateSlicedBuffer(buffer, Unsafe.SizeOf<T>(), offset, length);
+                return CreateSlicedBuffer(buffer, Unsafe.SizeOf<T>(), offset, length, owned);
             }
 
-            private Buffer CreateSlicedBuffer(ArrowBuffer buffer, int itemSize, int offset, int length)
+            private Buffer CreateSlicedBuffer(ArrowBuffer buffer, int itemSize, int offset, int length, bool owned)
             {
                 var byteLength = length * itemSize;
                 var paddedLength = CalculatePaddedBufferLength(byteLength);
@@ -505,23 +510,33 @@ namespace Apache.Arrow.Ipc
                 {
                     var byteOffset = offset * itemSize;
                     var sliceLength = Math.Min(paddedLength, buffer.Length - byteOffset);
-                    return CreateBuffer(buffer.Memory.Slice(byteOffset, sliceLength));
+                    return CreateBuffer(buffer.Memory.Slice(byteOffset, sliceLength),
+                        owned ? buffer : null);
                 }
 
-                return CreateBuffer(buffer.Memory);
+                return CreateBuffer(buffer, owned);
             }
 
-            private Buffer CreateBuffer(ArrowBuffer buffer)
+            private Buffer CreateBuffer(ArrowBuffer buffer, bool locallyOwned)
             {
-                return CreateBuffer(buffer.Memory);
+                if (locallyOwned)
+                {
+                    // this buffer is locally owned, we can dispose it
+                    return CreateBuffer(buffer.Memory, buffer);
+                }
+                return CreateBuffer(buffer.Memory, null);
             }
-
-            private Buffer CreateBuffer(ReadOnlyMemory<byte> buffer)
+            private Buffer CreateBuffer(IMemoryOwner<byte>  bufferOwner)
+            {
+                return CreateBuffer(bufferOwner.Memory, bufferOwner);
+            }
+            private Buffer CreateBuffer(ReadOnlyMemory<byte> buffer, IDisposable localBufferOwner)
             {
                 int offset = TotalLength;
                 const int UncompressedLengthSize = 8;
 
                 ReadOnlyMemory<byte> bufferToWrite;
+                IMemoryOwner<byte> bufferOwner=null;
                 if (_compressionCodec == null)
                 {
                     bufferToWrite = buffer;
@@ -529,40 +544,42 @@ namespace Apache.Arrow.Ipc
                 else if (buffer.Length == 0)
                 {
                     // Write zero length and skip compression
-                    var uncompressedLengthBytes = _allocator.Allocate(UncompressedLengthSize);
-                    BinaryPrimitives.WriteInt64LittleEndian(uncompressedLengthBytes.Memory.Span, 0);
-                    bufferToWrite = uncompressedLengthBytes.Memory;
+                    bufferOwner = _allocator.Allocate(UncompressedLengthSize);
+                    BinaryPrimitives.WriteInt64LittleEndian(bufferOwner.Memory.Span, 0);
+                    bufferToWrite = bufferOwner.Memory.Slice(0, UncompressedLengthSize);
+                    // the local source buffer owner can be disposed, it's memory is no longer needed
+                    localBufferOwner?.Dispose();
                 }
                 else
                 {
                     // See format/Message.fbs, and the BUFFER BodyCompressionMethod for documentation on how
                     // compressed buffers are stored.
-                    _compressionStream.Seek(0, SeekOrigin.Begin);
-                    _compressionStream.SetLength(0);
-                    _compressionCodec.Compress(buffer, _compressionStream);
-                    if (_compressionStream.Length < buffer.Length)
+                    int newBufferLength = UncompressedLengthSize + buffer.Length;
+                    bufferOwner = _allocator.Allocate(newBufferLength);
+
+                    if(_compressionCodec.TryCompress(buffer, bufferOwner.Memory.Slice(UncompressedLengthSize, buffer.Length), out int bytesWritten))
                     {
-                        var newBuffer = _allocator.Allocate((int) _compressionStream.Length + UncompressedLengthSize);
-                        BinaryPrimitives.WriteInt64LittleEndian(newBuffer.Memory.Span, buffer.Length);
-                        _compressionStream.Seek(0, SeekOrigin.Begin);
-                        _compressionStream.ReadFullBuffer(newBuffer.Memory.Slice(UncompressedLengthSize));
-                        bufferToWrite = newBuffer.Memory;
+                        // Write the uncompressed length to the start of the buffer
+                        BinaryPrimitives.WriteInt64LittleEndian(bufferOwner.Memory.Span, buffer.Length);
+                        bufferToWrite = bufferOwner.Memory.Slice(0, bytesWritten+UncompressedLengthSize);
                     }
                     else
                     {
+                        // TryCompress failed, because the buffer is too small.
                         // If the compressed buffer is larger than the uncompressed buffer, use the uncompressed
                         // buffer instead, and indicate this by setting the uncompressed length to -1
-                        var newBuffer = _allocator.Allocate(buffer.Length + UncompressedLengthSize);
-                        BinaryPrimitives.WriteInt64LittleEndian(newBuffer.Memory.Span, -1);
-                        buffer.CopyTo(newBuffer.Memory.Slice(UncompressedLengthSize));
-                        bufferToWrite = newBuffer.Memory;
+                        BinaryPrimitives.WriteInt64LittleEndian(bufferOwner.Memory.Span, -1);
+                        buffer.CopyTo(bufferOwner.Memory.Slice(UncompressedLengthSize));
+                        bufferToWrite = bufferOwner.Memory.Slice(0, newBufferLength);
                     }
+                    // the local source buffer owner can be disposed, it's memory was copied
+                    localBufferOwner?.Dispose();
                 }
 
                 int paddedLength = checked((int)BitUtility.RoundUpToMultipleOf8(bufferToWrite.Length));
                 TotalLength += paddedLength;
-
-                return new Buffer(bufferToWrite, offset);
+                // if the buffer is owned locally or allocated in the method, we can dispose it after writing the buffer to the stream
+                return new Buffer(bufferToWrite, offset, (IDisposable)bufferOwner ?? localBufferOwner);
             }
 
             public void Visit(IArrowArray array)
@@ -590,10 +607,8 @@ namespace Apache.Arrow.Ipc
         private readonly bool _leaveOpen;
         private readonly IpcOptions _options;
         private readonly MemoryAllocator _allocator;
-        // Reuse a single memory stream for writing compressed data to, to reduce memory allocations
-        private readonly MemoryStream _compressionStream = new MemoryStream();
 
-        private protected const Flatbuf.MetadataVersion CurrentMetadataVersion = Flatbuf.MetadataVersion.V5;
+        internal const Flatbuf.MetadataVersion CurrentMetadataVersion = Flatbuf.MetadataVersion.V5;
 
         private static readonly byte[] s_padding = new byte[64];
 
@@ -742,19 +757,17 @@ namespace Apache.Arrow.Ipc
 
             for (int i = 0; i < buffers.Count; i++)
             {
-                ReadOnlyMemory<byte> buffer = buffers[i].DataBuffer;
-                if (buffer.IsEmpty)
+                using var buffer = buffers[i]; // Dispose the buffer after writing
+                ReadOnlyMemory<byte> dataBuffer = buffer.DataBuffer;
+                if (dataBuffer.IsEmpty)
                     continue;
-
-                BaseStream.Write(buffer);
-
-                int paddedLength = checked((int)BitUtility.RoundUpToMultipleOf8(buffer.Length));
-                int padding = paddedLength - buffer.Length;
+                BaseStream.Write(dataBuffer);
+                int paddedLength = checked((int)BitUtility.RoundUpToMultipleOf8(dataBuffer.Length));
+                int padding = paddedLength - dataBuffer.Length;
                 if (padding > 0)
                 {
                     WritePadding(padding);
                 }
-
                 bodyLength += paddedLength;
             }
 
@@ -773,14 +786,15 @@ namespace Apache.Arrow.Ipc
 
             for (int i = 0; i < buffers.Count; i++)
             {
-                ReadOnlyMemory<byte> buffer = buffers[i].DataBuffer;
-                if (buffer.IsEmpty)
+                using var buffer = buffers[i]; // Dispose the buffer after writing
+                ReadOnlyMemory<byte> dataBuffer = buffer.DataBuffer;
+                if (dataBuffer.IsEmpty)
                     continue;
 
-                await BaseStream.WriteAsync(buffer, cancellationToken).ConfigureAwait(false);
+                await BaseStream.WriteAsync(dataBuffer, cancellationToken).ConfigureAwait(false);
 
-                int paddedLength = checked((int)BitUtility.RoundUpToMultipleOf8(buffer.Length));
-                int padding = paddedLength - buffer.Length;
+                int paddedLength = checked((int)BitUtility.RoundUpToMultipleOf8(dataBuffer.Length));
+                int padding = paddedLength - dataBuffer.Length;
                 if (padding > 0)
                 {
                     await WritePaddingAsync(padding).ConfigureAwait(false);
@@ -813,7 +827,7 @@ namespace Apache.Arrow.Ipc
                 ? _options.CompressionCodecFactory.CreateCodec(_options.CompressionCodec.Value, _options.CompressionLevel)
                 : null;
 
-            var recordBatchBuilder = new ArrowRecordBatchFlatBufferBuilder(compressionCodec, _allocator, _compressionStream);
+            var recordBatchBuilder = new ArrowRecordBatchFlatBufferBuilder(compressionCodec, _allocator);
 
             // Visit all arrays recursively
             for (int i = 0; i < fields.Count; i++)
@@ -1313,7 +1327,6 @@ namespace Apache.Arrow.Ipc
             {
                 BaseStream.Dispose();
             }
-            _compressionStream.Dispose();
         }
     }
 

--- a/csharp/src/Apache.Arrow/Ipc/ArrowStreamWriter.cs
+++ b/csharp/src/Apache.Arrow/Ipc/ArrowStreamWriter.cs
@@ -550,7 +550,7 @@ namespace Apache.Arrow.Ipc
                     bufferOwner = _allocator.Allocate(UncompressedLengthSize);
                     BinaryPrimitives.WriteInt64LittleEndian(bufferOwner.Memory.Span, 0);
                     bufferToWrite = bufferOwner.Memory.Slice(0, UncompressedLengthSize);
-                    // the local source buffer owner can be disposed, it's memory is no longer needed
+                    // the local source buffer owner can be disposed, its memory is no longer needed
                     localBufferOwner?.Dispose();
                 }
                 else

--- a/csharp/src/Apache.Arrow/Ipc/ArrowStreamWriter.cs
+++ b/csharp/src/Apache.Arrow/Ipc/ArrowStreamWriter.cs
@@ -575,7 +575,7 @@ namespace Apache.Arrow.Ipc
                         buffer.CopyTo(bufferOwner.Memory.Slice(UncompressedLengthSize));
                         bufferToWrite = bufferOwner.Memory.Slice(0, newBufferLength);
                     }
-                    // the local source buffer owner can be disposed, it's memory was copied
+                    // the local source buffer owner can be disposed, its memory was copied
                     localBufferOwner?.Dispose();
                 }
 

--- a/csharp/src/Apache.Arrow/Ipc/ICompressionCodec.cs
+++ b/csharp/src/Apache.Arrow/Ipc/ICompressionCodec.cs
@@ -44,5 +44,21 @@ namespace Apache.Arrow.Ipc
 #else
         ;
 #endif
+
+        /// <summary>
+        /// try to write compressed data to span
+        /// </summary>
+        /// <param name="source">The data to compress</param>
+        /// <param name="destination">Span to write compressed data to</param>
+        /// <param name="bytesWritten">The number of bytes written to the destination</param>
+        /// <returns>true if compressed was successful, false if the destination buffer is too small</returns>
+        bool TryCompress(ReadOnlyMemory<byte> source, Memory<byte> destination, out int bytesWritten)
+#if NET6_0_OR_GREATER
+        {
+            throw new NotImplementedException("This codec does not support compression");
+        }
+#else
+            ;
+#endif
     }
 }

--- a/csharp/src/Apache.Arrow/Ipc/ICompressionCodec.cs
+++ b/csharp/src/Apache.Arrow/Ipc/ICompressionCodec.cs
@@ -44,21 +44,5 @@ namespace Apache.Arrow.Ipc
 #else
         ;
 #endif
-
-        /// <summary>
-        /// try to write compressed data to span
-        /// </summary>
-        /// <param name="source">The data to compress</param>
-        /// <param name="destination">Span to write compressed data to</param>
-        /// <param name="bytesWritten">The number of bytes written to the destination</param>
-        /// <returns>true if compressed was successful, false if the destination buffer is too small</returns>
-        bool TryCompress(ReadOnlyMemory<byte> source, Memory<byte> destination, out int bytesWritten)
-#if NET6_0_OR_GREATER
-        {
-            throw new NotImplementedException("This codec does not support compression");
-        }
-#else
-            ;
-#endif
     }
 }

--- a/csharp/src/Apache.Arrow/Ipc/ITryCompressionCodec.cs
+++ b/csharp/src/Apache.Arrow/Ipc/ITryCompressionCodec.cs
@@ -20,7 +20,7 @@ namespace Apache.Arrow.Ipc
     public interface ITryCompressionCodec : ICompressionCodec
     {
         /// <summary>
-        /// try to write compressed data to span
+        /// Try to write compressed data to a fixed length memory span
         /// </summary>
         /// <param name="source">The data to compress</param>
         /// <param name="destination">Memory to write compressed data to</param>

--- a/csharp/src/Apache.Arrow/Ipc/ITryCompressionCodec.cs
+++ b/csharp/src/Apache.Arrow/Ipc/ITryCompressionCodec.cs
@@ -1,0 +1,32 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+
+namespace Apache.Arrow.Ipc
+{
+    public interface ITryCompressionCodec : ICompressionCodec
+    {
+        /// <summary>
+        /// try to write compressed data to span
+        /// </summary>
+        /// <param name="source">The data to compress</param>
+        /// <param name="destination">Span to write compressed data to</param>
+        /// <param name="bytesWritten">The number of bytes written to the destination</param>
+        /// <returns>true if compressed was successful, false if the destination buffer is too small</returns>
+        bool TryCompress(ReadOnlyMemory<byte> source, Memory<byte> destination, out int bytesWritten);
+
+    }
+}

--- a/csharp/src/Apache.Arrow/Ipc/ITryCompressionCodec.cs
+++ b/csharp/src/Apache.Arrow/Ipc/ITryCompressionCodec.cs
@@ -23,7 +23,7 @@ namespace Apache.Arrow.Ipc
         /// try to write compressed data to span
         /// </summary>
         /// <param name="source">The data to compress</param>
-        /// <param name="destination">Span to write compressed data to</param>
+        /// <param name="destination">Memory to write compressed data to</param>
         /// <param name="bytesWritten">The number of bytes written to the destination</param>
         /// <returns>true if compression was successful, false if the destination buffer is too small</returns>
         bool TryCompress(ReadOnlyMemory<byte> source, Memory<byte> destination, out int bytesWritten);

--- a/csharp/src/Apache.Arrow/Ipc/ITryCompressionCodec.cs
+++ b/csharp/src/Apache.Arrow/Ipc/ITryCompressionCodec.cs
@@ -25,7 +25,7 @@ namespace Apache.Arrow.Ipc
         /// <param name="source">The data to compress</param>
         /// <param name="destination">Span to write compressed data to</param>
         /// <param name="bytesWritten">The number of bytes written to the destination</param>
-        /// <returns>true if compressed was successful, false if the destination buffer is too small</returns>
+        /// <returns>true if compression was successful, false if the destination buffer is too small</returns>
         bool TryCompress(ReadOnlyMemory<byte> source, Memory<byte> destination, out int bytesWritten);
 
     }

--- a/csharp/test/Apache.Arrow.Tests/ArrowStreamWriterTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/ArrowStreamWriterTests.cs
@@ -731,7 +731,8 @@ namespace Apache.Arrow.Tests
             var slicedBatch = new RecordBatch(originalBatch.Schema, slicedArrays, sliceLength);
             var allocator = new TestMemoryAllocator();
             await TestRoundTripRecordBatchesAsync(new List<RecordBatch> () {slicedBatch}, null, false, allocator);
-            Assert.Equal(0,allocator.Statistics.Allocations);
+            if(sliceOffset % 8 != 0)
+                Assert.True(allocator.Statistics.Allocations > 0);
             Assert.Equal(0,allocator.Rented);
         }
     }

--- a/csharp/test/Apache.Arrow.Tests/ArrowStreamWriterTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/ArrowStreamWriterTests.cs
@@ -22,6 +22,7 @@ using System.Net;
 using System.Net.Sockets;
 using System.Threading.Tasks;
 using Apache.Arrow.Ipc;
+using Apache.Arrow.Memory;
 using Apache.Arrow.Types;
 using Xunit;
 
@@ -239,7 +240,7 @@ namespace Apache.Arrow.Tests
         {
             using (MemoryStream stream = new MemoryStream())
             {
-                using (var writer = new ArrowStreamWriter(stream, originalBatches[0].Schema, leaveOpen: true, options))
+                using (var writer = new ArrowStreamWriter(stream, originalBatches[0].Schema, leaveOpen: true, options, new TestMemoryAllocator()))
                 {
                     foreach (RecordBatch originalBatch in originalBatches)
                     {
@@ -261,11 +262,11 @@ namespace Apache.Arrow.Tests
             }
         }
 
-        private static async Task TestRoundTripRecordBatchesAsync(List<RecordBatch> originalBatches, IpcOptions options = null, bool strictCompare = true)
+        private static async Task TestRoundTripRecordBatchesAsync(List<RecordBatch> originalBatches, IpcOptions options = null, bool strictCompare = true, MemoryAllocator memoryAllocator = null)
         {
             using (MemoryStream stream = new MemoryStream())
             {
-                using (var writer = new ArrowStreamWriter(stream, originalBatches[0].Schema, leaveOpen: true, options))
+                using (var writer = new ArrowStreamWriter(stream, originalBatches[0].Schema, leaveOpen: true, options, memoryAllocator ??  new TestMemoryAllocator()))
                 {
                     foreach (RecordBatch originalBatch in originalBatches)
                     {
@@ -714,6 +715,24 @@ namespace Apache.Arrow.Tests
             RecordBatch readBatch = reader.ReadNextRecordBatch();
             Assert.Null(readBatch);
             SchemaComparer.Compare(originalBatch.Schema, reader.Schema);
+        }
+
+
+        [Theory]
+        [InlineData(0, 45)]
+        [InlineData(3, 45)]
+        [InlineData(16, 45)]
+        public async Task MemoryOwnerDisposalSlicedArray(int sliceOffset, int sliceLength)
+        {
+            var originalBatch = TestData.CreateSampleRecordBatch(length: 100);
+            var slicedArrays = originalBatch.Arrays
+                .Select(array => ArrowArrayFactory.Slice(array, sliceOffset, sliceLength))
+                .ToList();
+            var slicedBatch = new RecordBatch(originalBatch.Schema, slicedArrays, sliceLength);
+            var allocator = new TestMemoryAllocator();
+            await TestRoundTripRecordBatchesAsync(new List<RecordBatch> () {slicedBatch}, null, false, allocator);
+            Assert.Equal(0,allocator.Statistics.Allocations);
+            Assert.Equal(0,allocator.Rented);
         }
     }
 }

--- a/csharp/test/Apache.Arrow.Tests/TestMemoryAllocator.cs
+++ b/csharp/test/Apache.Arrow.Tests/TestMemoryAllocator.cs
@@ -16,9 +16,7 @@
 using System;
 using Apache.Arrow.Memory;
 using System.Buffers;
-using System.Diagnostics;
 using System.Threading;
-using Xunit;
 
 namespace Apache.Arrow.Tests
 {
@@ -26,6 +24,7 @@ namespace Apache.Arrow.Tests
     {
         private int _rented = 0;
         public int Rented => _rented;
+
         protected override IMemoryOwner<byte> AllocateInternal(int length, out int bytesAllocated)
         {
             var mem = MemoryPool<byte>.Shared.Rent(length);
@@ -33,16 +32,19 @@ namespace Apache.Arrow.Tests
             Interlocked.Increment(ref _rented);
             return new TestMemoryOwner(mem, this);
         }
+
         private class TestMemoryOwner : IMemoryOwner<byte>
         {
             private readonly IMemoryOwner<byte> _inner;
             private readonly TestMemoryAllocator _allocator;
             private bool _disposed;
+
             public TestMemoryOwner(IMemoryOwner<byte> inner, TestMemoryAllocator allocator)
             {
                 _inner = inner;
                 _allocator = allocator;
             }
+
             public Memory<byte> Memory
             {
                 get

--- a/csharp/test/Apache.Arrow.Tests/TestMemoryAllocator.cs
+++ b/csharp/test/Apache.Arrow.Tests/TestMemoryAllocator.cs
@@ -43,14 +43,6 @@ namespace Apache.Arrow.Tests
                 _inner = inner;
                 _allocator = allocator;
             }
-
-            ~TestMemoryOwner()
-            {
-                if(_disposed)
-                    return;
-                Assert.Fail("Memory owner was not disposed");
-            }
-
             public Memory<byte> Memory
             {
                 get

--- a/csharp/test/Apache.Arrow.Tests/TestMemoryAllocator.cs
+++ b/csharp/test/Apache.Arrow.Tests/TestMemoryAllocator.cs
@@ -13,17 +13,62 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using Apache.Arrow.Memory;
 using System.Buffers;
+using System.Diagnostics;
+using System.Threading;
+using Xunit;
 
 namespace Apache.Arrow.Tests
 {
     public class TestMemoryAllocator : MemoryAllocator
     {
+        private int _rented = 0;
+        public int Rented => _rented;
         protected override IMemoryOwner<byte> AllocateInternal(int length, out int bytesAllocated)
         {
-            bytesAllocated = length;
-            return MemoryPool<byte>.Shared.Rent(length);
+            var mem = MemoryPool<byte>.Shared.Rent(length);
+            bytesAllocated = mem.Memory.Length;
+            Interlocked.Increment(ref _rented);
+            return new TestMemoryOwner(mem, this);
+        }
+        private class TestMemoryOwner : IMemoryOwner<byte>
+        {
+            private readonly IMemoryOwner<byte> _inner;
+            private readonly TestMemoryAllocator _allocator;
+            private bool _disposed;
+            public TestMemoryOwner(IMemoryOwner<byte> inner, TestMemoryAllocator allocator)
+            {
+                _inner = inner;
+                _allocator = allocator;
+            }
+
+            ~TestMemoryOwner()
+            {
+                if(_disposed)
+                    return;
+                Assert.Fail("Memory owner was not disposed");
+            }
+
+            public Memory<byte> Memory
+            {
+                get
+                {
+                    if (_disposed)
+                        throw new ObjectDisposedException(nameof(TestMemoryOwner));
+                    return _inner.Memory;
+                }
+            }
+
+            public void Dispose()
+            {
+                if (_disposed)
+                    return;
+                _disposed = true;
+                Interlocked.Decrement(ref _allocator._rented);
+                _inner?.Dispose();
+            }
         }
     }
 }


### PR DESCRIPTION
### Rationale for this change
`ArrowStreamWriter` should not make large heap allocations for temporary buffers. Pooled buffers should be used. 
All allocations made by `MemoryAllocator` should be disposed before they are finalized.

### What changes are included in this PR?

- `ArrowStreamWriter` makes sure all temporary buffers are disposed.
- `ArrowStreamWriter` uses `MemoryAllocator` for decompression buffers instead of `MemoryStream`.
- Added `TryCompress` method to `ICompressionCodec` and implemented it.

### Are these changes tested?

Yes. 
- `MemoryOwnerDisposal` in `Apache.Arrow.Compression.Tests.ArrowStreamWriterTests`
- `MemoryOwnerDisposalSlicedArray` in `Apache.Arrow.Tests.ArrowStreamWriterTests`

### Are there any user-facing changes?

Yes. `ICompressionCodec` requires the implementation of a new method 'TryCompress'

**This PR includes breaking changes to public APIs.**

`ICompressionCodec` requires the implementation of a new method 'TryCompress'

* GitHub Issue: #46189