### PR TITLE
GH-46192: [C++] Add `substrait` dep to third party download script

### DIFF
--- a/cpp/thirdparty/versions.txt
+++ b/cpp/thirdparty/versions.txt
@@ -162,6 +162,7 @@ DEPENDENCIES=(
   "ARROW_RE2_URL re2-${ARROW_RE2_BUILD_VERSION}.tar.gz https://github.com/google/re2/archive/${ARROW_RE2_BUILD_VERSION}.tar.gz"
   "ARROW_S2N_TLS_URL s2n-${ARROW_S2N_TLS_BUILD_VERSION}.tar.gz https://github.com/aws/s2n-tls/archive/${ARROW_S2N_TLS_BUILD_VERSION}.tar.gz"
   "ARROW_SNAPPY_URL snappy-${ARROW_SNAPPY_BUILD_VERSION}.tar.gz https://github.com/google/snappy/archive/${ARROW_SNAPPY_BUILD_VERSION}.tar.gz"
+  "ARROW_SUBSTRAIT_URL substrait-${ARROW_SUBSTRAIT_BUILD_VERSION}.tar.gz https://github.com/substrait-io/substrait/archive/${ARROW_SUBSTRAIT_BUILD_VERSION}.tar.gz"
   "ARROW_THRIFT_URL thrift-${ARROW_THRIFT_BUILD_VERSION}.tar.gz https://www.apache.org/dyn/closer.lua/thrift/${ARROW_THRIFT_BUILD_VERSION}/thrift-${ARROW_THRIFT_BUILD_VERSION}.tar.gz?action=download"
   "ARROW_UTF8PROC_URL utf8proc-${ARROW_UTF8PROC_BUILD_VERSION}.tar.gz https://github.com/JuliaStrings/utf8proc/archive/${ARROW_UTF8PROC_BUILD_VERSION}.tar.gz"
   "ARROW_XSIMD_URL xsimd-${ARROW_XSIMD_BUILD_VERSION}.tar.gz https://github.com/xtensor-stack/xsimd/archive/${ARROW_XSIMD_BUILD_VERSION}.tar.gz"


### PR DESCRIPTION
### Rationale for this change
Fixes https://github.com/apache/arrow/issues/46192

### What changes are included in this PR?
Generates the following - 
```shell
$ ./cpp/thirdparty/download_dependencies.sh cpp/arrow-thirdparty
# Environment variables for offline Arrow build
...
export ARROW_SUBSTRAIT_URL=cpp/arrow-thirdparty/substrait-v0.44.0.tar.gz
...

$ ls -la cpp/arrow-thirdparty/substrait-v0.44.0.tar.gz
-rw-r--r--  1 user  group  131614 Apr 21 17:26 cpp/arrow-thirdparty/substrait-v0.44.0.tar.gz
```

### Are these changes tested?
Yes

### Are there any user-facing changes?
No

* GitHub Issue: #46192