### PR TITLE
GH-46197: [C++] Tests use legacy timezones

### DIFF
--- a/cpp/src/arrow/compute/kernels/scalar_temporal_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_temporal_test.cc
@@ -1878,7 +1878,7 @@ TEST_F(ScalarTemporalTest, TestLocalTimestamp) {
 TEST_F(ScalarTemporalTest, TestAssumeTimezone) {
   std::string timezone_utc = "UTC";
   std::string timezone_kolkata = "Asia/Kolkata";
-  std::string timezone_us_central = "US/Central";
+  std::string timezone_us_central = "America/Chicago";
   const char* times_utc = R"(["1970-01-01T00:00:00", null])";
   const char* times_kolkata = R"(["1970-01-01T05:30:00", null])";
   const char* times_us_central = R"(["1969-12-31T18:00:00", null])";
@@ -2004,7 +2004,7 @@ TEST_F(ScalarTemporalTest, Strftime) {
                    string_milliseconds, &options);
   CheckScalarUnary("strftime", timestamp(TimeUnit::MICRO, "Asia/Kolkata"), microseconds,
                    utf8(), string_microseconds, &options);
-  CheckScalarUnary("strftime", timestamp(TimeUnit::NANO, "US/Hawaii"), nanoseconds,
+  CheckScalarUnary("strftime", timestamp(TimeUnit::NANO, "Pacific/Honolulu"), nanoseconds,
                    utf8(), string_nanoseconds, &options);
 
   auto options_hms = StrftimeOptions("%H:%M:%S");

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -2336,7 +2336,7 @@ def test_extract_datetime_components(request):
                   "2008-12-28T00:00:00.0",
                   "2008-12-29T00:00:00.0",
                   "2012-01-01T01:02:03.0"]
-    timezones = ["UTC", "US/Central", "Asia/Kolkata",
+    timezones = ["UTC", "America/Chicago", "Asia/Kolkata",
                  "Etc/GMT-4", "Etc/GMT+4", "Australia/Broken_Hill"]
 
     # Test timezone naive timestamp array
@@ -2390,7 +2390,7 @@ def test_assume_timezone():
     ambiguous_array = pa.array(ambiguous, type=ts_type)
     nonexistent_array = pa.array(nonexistent, type=ts_type)
 
-    for timezone in ["UTC", "US/Central", "Asia/Kolkata"]:
+    for timezone in ["UTC", "America/Chicago", "Asia/Kolkata"]:
         options = pc.AssumeTimezoneOptions(timezone)
         ta = pa.array(timestamps, type=ts_type)
         expected = timestamps.tz_localize(timezone)
@@ -2583,7 +2583,7 @@ def test_round_temporal(unit):
     _check_temporal_rounding(ts, values, unit)
 
     timezones = ["Asia/Kolkata", "America/New_York", "Etc/GMT-4", "Etc/GMT+4",
-                 "Europe/Brussels", "Pacific/Marquesas", "US/Central", "UTC"]
+                 "Europe/Brussels", "Pacific/Marquesas", "America/Chicago", "UTC"]
 
     for timezone in timezones:
         ts_zoned = ts.dt.tz_localize("UTC").dt.tz_convert(timezone)


### PR DESCRIPTION
### Rationale for this change

Certain timezones (e.g. US/Central) are considered legacy and are not supported on some systems. See #46197 and [SO link](https://askubuntu.com/questions/1528510/after-installing-24-04-1-lts-on-my-desktop-computer-the-date-command-displays-u). We currently don't have a policy on this but we want to update our tests to avoid legacy cases.
If we absolutely wanted to we support legacy timezones we probably could by using https://github.com/eggert/tz/blob/ff5cbd52d9ef856ef9d0fd589fd726af1bcf3ce8/backward.

### What changes are included in this PR?

This removes legacy timezone examples from tests.

### Are these changes tested?

By definition, yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #46197