### PR TITLE
MINOR: [C++][Dev] Remove obsolete clang-tidy option

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -27,7 +27,6 @@ Checks: |
 # produce HeaderFilterRegex from cpp/build-support/lint_exclusions.txt with:
 # echo -n '^('; sed -e 's/*/\.*/g' cpp/build-support/lint_exclusions.txt | tr '\n' '|'; echo ')$'
 HeaderFilterRegex: '^(.*codegen.*|.*_generated.*|.*windows_compatibility.h|.*pyarrow_api.h|.*pyarrow_lib.h|.*python/config.h|.*python/platform.h|.*thirdparty/ae/.*|.*vendored/.*|.*RcppExports.cpp.*|)$'
-AnalyzeTemporaryDtors: true
 CheckOptions:
   - key:             google-readability-braces-around-statements.ShortStatementLines
     value:           '1'


### PR DESCRIPTION
### Rationale for this change

"AnalyzeTemporaryDtors" is obsolete and removed in recent clang-tidy versions.

### Are these changes tested?

No.

### Are there any user-facing changes?

No.
