### PR TITLE
GH-46128:[C++] Add CompactArray method to BinaryViewArray types

### DIFF
--- a/cpp/src/arrow/array/array_binary.cc
+++ b/cpp/src/arrow/array/array_binary.cc
@@ -17,14 +17,20 @@
 
 #include "arrow/array/array_binary.h"
 
+#include <cmath>
 #include <cstdint>
 #include <memory>
+#include <set>
+#include <vector>
 
 #include "arrow/array/array_base.h"
+#include "arrow/array/util.h"
 #include "arrow/array/validate.h"
 #include "arrow/type.h"
 #include "arrow/type_traits.h"
 #include "arrow/util/binary_view_util.h"
+#include "arrow/util/bit_run_reader.h"
+#include "arrow/util/bitmap.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/logging.h"
 
@@ -103,6 +109,390 @@ BinaryViewArray::BinaryViewArray(std::shared_ptr<DataType> type, int64_t length,
   buffers.insert(buffers.begin(), std::move(null_bitmap));
   SetData(
       ArrayData::Make(std::move(type), length, std::move(buffers), null_count, offset));
+}
+
+namespace {
+
+// TODO Should We move this to bitmap_ops.h and Remove from compute/kernels/util.s
+Result<std::shared_ptr<Buffer>> GetOrCopyNullBitmapBuffer(const ArrayData& in_array,
+                                                          MemoryPool* pool) {
+  if (in_array.buffers[0]->data() == nullptr) {
+    return nullptr;
+  } else if (in_array.offset == 0) {
+    return in_array.buffers[0];
+  } else if (in_array.offset % 8 == 0) {
+    return SliceBuffer(in_array.buffers[0], /*offset=*/in_array.offset / 8);
+  } else {
+    // If a non-zero offset, we need to shift the bitmap
+    return internal::CopyBitmap(pool, in_array.buffers[0]->data(), in_array.offset,
+                                in_array.length);
+  }
+}
+
+struct Interval {
+  int64_t start;
+  int64_t end;
+  int32_t offset = -1;
+};
+
+struct IntervalComparator {
+  bool operator()(const Interval& left, const Interval& right) const {
+    return left.start < right.start;
+  }
+};
+
+// inspired from boost::icl::interval_set
+class IntervalMerger {
+ public:
+  using IntervalSet = std::set<Interval, IntervalComparator>;
+  using Iterator = std::set<Interval, IntervalComparator>::iterator;
+
+  void AddInterval(const Interval& interval) {
+    auto [it, is_inserted] = interval_set.insert(interval);
+    if (is_inserted) {
+      JointLeft(it);
+      JoinRight(it);
+    } else {
+      if (it->end < interval.end) {
+        const_cast<int64_t&>(it->end) = interval.end;
+        JoinRight(it);
+      }
+    }
+  }
+
+  int64_t CalculateOffsetAndTotalSize() {
+    int64_t total_size = 0;
+    for (auto& it : interval_set) {
+      const_cast<int32_t&>(it.offset) = static_cast<int32_t>(total_size);
+      total_size += it.end - it.start;
+    }
+    return total_size;
+  }
+
+  // This method should be called After CalculateOffsetAndTotalSize
+  int32_t GetRelativeOffset(int32_t view_offset) const {
+    auto it = interval_set.lower_bound({view_offset});
+    if (it == interval_set.end()) {
+      --it;
+      // offset from the start of interval
+      auto offset_from_span = view_offset - it->start;
+      return static_cast<int32_t>(offset_from_span) + it->offset;
+    } else if (it->start == view_offset) {
+      // this is the case where view_offset refers to the beginning of interval
+      return it->offset;
+    } else {
+      --it;
+      // offset from the start of interval
+      auto offset_from_span = view_offset - it->start;
+      return static_cast<int32_t>(offset_from_span) + it->offset;
+    }
+  }
+
+  IntervalSet::const_iterator begin() const { return interval_set.cbegin(); }
+
+  IntervalSet::const_iterator end() const { return interval_set.cend(); }
+
+ private:
+  void JointLeft(Iterator& it) {
+    if (it == interval_set.begin()) {
+      return;
+    } else {
+      auto prev_it = std::prev(it);
+      if (Joinable(prev_it, it)) {
+        MergeIntoLeftAndAdvanceRight(prev_it, it);
+        it = prev_it;
+        return;
+      }
+    }
+  }
+
+  void JoinRight(Iterator& it) {
+    auto begin_iterator = std::next(it);
+    auto end_iterator = begin_iterator;
+    while (end_iterator != interval_set.end() && Joinable(it, end_iterator)) {
+      const_cast<int64_t&>(it->end) = std::max(it->end, end_iterator->end);
+      ++end_iterator;
+    }
+    interval_set.erase(begin_iterator, end_iterator);
+  }
+
+  // Update left with a new end value
+  // Advance right to the next iterator
+  void MergeIntoLeftAndAdvanceRight(Iterator& left, Iterator& right) {
+    Interval interval{right->start, right->end};
+    right = interval_set.erase(right);
+    const_cast<int64_t&>(left->end) = std::max(left->end, interval.end);
+  }
+
+  bool Joinable(Iterator left, Iterator right) {
+    return std::max(left->start, right->start) <= std::min(left->end, right->end);
+  }
+
+  IntervalSet interval_set;
+};
+
+class CompactArrayImpl {
+ public:
+  CompactArrayImpl(const std::shared_ptr<ArrayData>& src_array_data,
+                   double occupancy_threshold, MemoryPool* memory_pool)
+      : src_array_data_(src_array_data),
+        src_buffers_(src_array_data->buffers),
+        occupancy_threshold_(occupancy_threshold),
+        memory_pool_(memory_pool) {}
+
+  Result<std::shared_ptr<Array>> Compact() {
+    // Check occupancy_threshold Parameter Validity
+    if (ARROW_PREDICT_FALSE(ValidateOccupancyThreshold(occupancy_threshold_))) {
+      return Status::Invalid(
+          "occupancy_threshold must be between 0 and 1. Current value:",
+          occupancy_threshold_);
+    }
+
+    auto num_src_buffers = src_buffers_.size();
+
+    if (ARROW_PREDICT_FALSE(num_src_buffers < 2)) {
+      return Status::Invalid("The number of buffers in ArrayData is less than 2.");
+    } else if (num_src_buffers == 2) {
+      // Only the bitmap and view buffers are available.
+      // Should we copy the view buffer to reduce size if an offset is set?
+      dst_buffers_.insert(dst_buffers_.end(), src_buffers_.begin(), src_buffers_.end());
+      return MakeArray(ArrayData::Make(
+          src_array_data_->type, src_array_data_->length, std::move(dst_buffers_),
+          src_array_data_->null_count, src_array_data_->offset));
+    } else {
+      ARROW_RETURN_NOT_OK(AddBitmapBuffer());
+
+      ARROW_RETURN_NOT_OK(AddViewBuffer());
+
+      // Handle DataBuffer
+      auto buffer_infos = GenerateBufferInfos();
+
+      // Relocating buffers whose occupancy is non-zero and below the threshold.
+      ARROW_RETURN_NOT_OK(CompactDataBufferBasedBufferInfo(buffer_infos));
+
+      AdjustViewElementsBufferIndexAndOffset(buffer_infos);
+
+      return MakeArray(ArrayData::Make(src_array_data_->type, src_array_data_->length,
+                                       std::move(dst_buffers_)));
+    }
+  }
+
+ private:
+  struct BufferInfo {
+    // It is possible that total occupancy of a data buffer
+    // becomes higher than MAX_INT32_T.
+    int64_t total_size_occupied = 0;
+    int32_t new_index = -1;
+    // offset in new buffer
+    // it is used when buffer is compacted
+    int32_t base_new_offset = -1;
+    IntervalMerger interval_merger;
+    // True if occupancy is non-zero and
+    // less than or equal to the threshold.
+    bool should_be_relocated = false;
+  };
+
+  struct BufferIndexAndOffsetMapper {
+    // The buffer will be copied.
+    // Returns the index and offset in the new buffer.
+    std::pair<int32_t, int32_t> MergeBufferAndGetPosition(int64_t size) {
+      int32_t buffer_offset;
+      if (current_index == -1) {
+        buffer_offset = 0;
+        buffer_sizes.push_back(size);
+        indexes.push_back(-1);
+        current_index = static_cast<int32_t>(buffer_sizes.size()) - 1;
+      } else if (buffer_sizes[current_index] + size >
+                 std::numeric_limits<int32_t>::max()) {
+        buffer_sizes.push_back(size);
+        indexes.push_back(-1);
+        current_index = static_cast<int32_t>(buffer_sizes.size()) - 1;
+        buffer_offset = 0;
+      } else {
+        buffer_offset = static_cast<int32_t>(buffer_sizes[current_index]);
+        buffer_sizes[current_index] += size;
+      }
+      return std::make_pair(current_index, buffer_offset);
+    }
+
+    // The buffer will not be copied.
+    int32_t AppendBufferAndGetPosition(int64_t size, int32_t index) {
+      buffer_sizes.push_back(size);
+      indexes.push_back(index);
+      return static_cast<int32_t>(buffer_sizes.size()) - 1;
+    }
+
+    std::vector<int64_t> buffer_sizes{};
+
+    // Index from previous if it's not merged
+    // The value whether is -1 for  a merged buffer or
+    //  non-negative for  a non-merged-buffer.
+    std::vector<int32_t> indexes{};
+    // Uses for merging buffer to proper location
+    int32_t current_index = -1;
+  };
+
+  bool ValidateOccupancyThreshold(double occupancy_threshold) {
+    return std::signbit(occupancy_threshold) || std::isnan(occupancy_threshold) ||
+           occupancy_threshold > 1;
+  }
+
+  Status AddBitmapBuffer() {
+    if (src_array_data_->buffers[0] == nullptr) {
+      dst_buffers_.emplace_back(nullptr);
+    } else {
+      // Handle Bitmap Buffer
+      ARROW_ASSIGN_OR_RAISE(auto bitmap_buffer,
+                            GetOrCopyNullBitmapBuffer(*src_array_data_, memory_pool_));
+      dst_buffers_.push_back(bitmap_buffer);
+    }
+    return Status::OK();
+  }
+
+  Status AddViewBuffer() {
+    ARROW_ASSIGN_OR_RAISE(
+        auto view_buffer,
+        src_array_data_->buffers[1]->CopySlice(
+            src_array_data_->offset * BinaryViewType::kSize,
+            src_array_data_->length * BinaryViewType::kSize, memory_pool_));
+    dst_buffers_.push_back(view_buffer);
+    return Status::OK();
+  }
+
+  std::vector<BufferInfo> GenerateBufferInfos() {
+    using ViewType = BinaryViewType::c_type;
+
+    auto view_buffer = src_array_data_->GetValues<ViewType>(1);
+
+    // Ignore BitMap Buffer and View Buffer
+    std::vector<BufferInfo> buffer_info_array(src_buffers_.size() - 2);
+
+    auto visit = [&](int64_t position, int64_t length) {
+      for (int64_t i = position; i < position + length; ++i) {
+        auto& view = view_buffer[i];
+        if (!view.is_inline()) {
+          AddIntervalToBufferInfo(buffer_info_array, view);
+        }
+      }
+    };
+
+    internal::VisitSetBitRunsVoid(src_buffers_[0], src_array_data_->offset,
+                                  src_array_data_->length, visit);
+    return buffer_info_array;
+  }
+
+  void AddIntervalToBufferInfo(std::vector<BufferInfo>& buffer_infos,
+                               const BinaryViewType::c_type& c_type) {
+    auto& buffer_info = buffer_infos[c_type.ref.buffer_index];
+
+    buffer_info.interval_merger.AddInterval(
+        {c_type.ref.offset, static_cast<int64_t>(c_type.ref.offset) + c_type.ref.size});
+  }
+
+  // Relocating Buffers which their occupancies are less than threshold
+  Status CompactDataBufferBasedBufferInfo(std::vector<BufferInfo>& buffer_infos) {
+    auto num_src_data_buffers = static_cast<int32_t>(src_buffers_.size()) - 2;
+    BufferIndexAndOffsetMapper buffer_mapper;
+
+    for (int32_t i = 0; i < num_src_data_buffers; ++i) {
+      CalculateOccupancyAndOffset(buffer_infos[i]);
+      if (buffer_infos[i].total_size_occupied == 0) {
+        // Ignore adding to new buffer
+        buffer_infos[i].should_be_relocated = false;
+      } else if (static_cast<double>(buffer_infos[i].total_size_occupied) /
+                     static_cast<double>(src_buffers_[i + 2]->size()) <=
+                 occupancy_threshold_) {
+        // Calculate the size and offset in new Data Buffer
+        auto [index, offset] =
+            buffer_mapper.MergeBufferAndGetPosition(buffer_infos[i].total_size_occupied);
+        buffer_infos[i].new_index = index;
+        buffer_infos[i].base_new_offset = offset;
+        buffer_infos[i].should_be_relocated = true;
+      } else {
+        buffer_infos[i].new_index = buffer_mapper.AppendBufferAndGetPosition(
+            buffer_infos[i].total_size_occupied, i);
+        buffer_infos[i].should_be_relocated = false;
+      }
+    }
+
+    ARROW_RETURN_NOT_OK(GenerateDataBufferForDestination(buffer_mapper));
+    CopyDataBuffer(buffer_infos);
+    return Status::OK();
+  }
+
+  void CalculateOccupancyAndOffset(BufferInfo& info) {
+    info.total_size_occupied = info.interval_merger.CalculateOffsetAndTotalSize();
+  }
+
+  Status GenerateDataBufferForDestination(
+      const BufferIndexAndOffsetMapper& buffer_mapper) {
+    // First Allocated Or Added Buffer
+    dst_buffers_.reserve(buffer_mapper.buffer_sizes.size());
+    for (int32_t i = 0; i < static_cast<int32_t>(buffer_mapper.buffer_sizes.size());
+         ++i) {
+      if (buffer_mapper.indexes[i] == -1) {
+        ARROW_ASSIGN_OR_RAISE(
+            auto buffer, AllocateBuffer(buffer_mapper.buffer_sizes[i], memory_pool_));
+        dst_buffers_.push_back(std::move(buffer));
+      } else {
+        dst_buffers_.push_back(src_buffers_[2 + buffer_mapper.indexes[i]]);
+      }
+    }
+    return Status::OK();
+  }
+
+  void CopyDataBuffer(const std::vector<BufferInfo>& buffer_infos) {
+    for (int32_t i = 0; i < static_cast<int32_t>(buffer_infos.size()); ++i) {
+      auto& buffer_info = buffer_infos[i];
+      if (buffer_info.should_be_relocated) {
+        // +2 to ignore view and data buffer
+        const auto& src_data_buffers = src_buffers_[i + 2];
+        const auto& dst_data_buffer = dst_buffers_[buffer_info.new_index + 2];
+        for (auto interval : buffer_info.interval_merger) {
+          std::memcpy(dst_data_buffer->mutable_data() + buffer_info.base_new_offset +
+                          interval.offset,
+                      src_data_buffers->data() + interval.start,
+                      interval.end - interval.start);
+        }
+      }
+    }
+  }
+
+  void AdjustViewElementsBufferIndexAndOffset(
+      const std::vector<BufferInfo>& buffer_infos) {
+    auto view_buffer = dst_buffers_[1]->mutable_data_as<BinaryViewArray::c_type>();
+
+    auto Visitor = [&](int64_t position, int64_t number_of_elements) {
+      for (int64_t i = position; i < position + number_of_elements; ++i) {
+        auto& view = view_buffer[i];
+        if (!view.is_inline()) {
+          auto& info = buffer_infos[view.ref.buffer_index];
+          view.ref.buffer_index = info.new_index;
+
+          // Buffer is less than threshold and relocated
+          if (info.should_be_relocated) {
+            view.ref.offset = info.interval_merger.GetRelativeOffset(view.ref.offset) +
+                              info.base_new_offset;
+          }
+        }
+      }
+    };
+
+    internal::VisitSetBitRunsVoid(dst_buffers_[0], 0, src_array_data_->length, Visitor);
+  }
+
+  const std::shared_ptr<ArrayData> src_array_data_;
+  std::vector<std::shared_ptr<Buffer>>& src_buffers_;
+  std::vector<std::shared_ptr<Buffer>> dst_buffers_ = {};
+  double occupancy_threshold_;
+  MemoryPool* memory_pool_;
+};
+
+}  // namespace
+
+Result<std::shared_ptr<Array>> BinaryViewArray::CompactArray(double occupancy_threshold,
+                                                             MemoryPool* pool) const {
+  return CompactArrayImpl(this->data(), occupancy_threshold, pool).Compact();
 }
 
 std::string_view BinaryViewArray::GetView(int64_t i) const {

--- a/cpp/src/arrow/array/array_binary.cc
+++ b/cpp/src/arrow/array/array_binary.cc
@@ -171,7 +171,8 @@ class IntervalMerger {
 
   // This method should be called After CalculateOffsetAndTotalSize
   int32_t GetRelativeOffset(int32_t view_offset) const {
-    auto it = interval_set.lower_bound({view_offset});
+    // end and offset is included in comparison
+    auto it = interval_set.lower_bound({view_offset, -1, -1});
     if (it == interval_set.end()) {
       --it;
       // offset from the start of interval
@@ -386,7 +387,8 @@ class CompactArrayImpl {
     auto& buffer_info = buffer_infos[c_type.ref.buffer_index];
 
     buffer_info.interval_merger.AddInterval(
-        {c_type.ref.offset, static_cast<int64_t>(c_type.ref.offset) + c_type.ref.size});
+        {c_type.ref.offset, static_cast<int64_t>(c_type.ref.offset) + c_type.ref.size,
+         -1});
   }
 
   // Relocating Buffers which their occupancies are less than threshold

--- a/cpp/src/arrow/array/array_binary.cc
+++ b/cpp/src/arrow/array/array_binary.cc
@@ -279,7 +279,7 @@ class CompactArrayImpl {
     BufferIndexAndOffsetMapper buffer_mapper;
 
     for (int32_t i = 0; i < num_src_data_buffers; ++i) {
-      CalculateOccupancyAndOffset(buffer_infos[i]);
+      buffer_infos[i].total_size_occupied = CompactBufferAndGetTotalSize(buffer_infos[i]);
       if (buffer_infos[i].total_size_occupied == 0) {
         // Ignore adding to new buffer
         buffer_infos[i].should_be_relocated = false;
@@ -304,8 +304,8 @@ class CompactArrayImpl {
     return Status::OK();
   }
 
-  void CalculateOccupancyAndOffset(BufferInfo& info) {
-    info.total_size_occupied = info.interval_merger.CompactIntervalAndGetTotalSize();
+  int64_t CompactBufferAndGetTotalSize(BufferInfo& info) {
+    return info.interval_merger.CompactIntervalAndGetTotalSize();
   }
 
   Status GenerateDataBufferForDestination(

--- a/cpp/src/arrow/array/array_binary.h
+++ b/cpp/src/arrow/array/array_binary.h
@@ -32,6 +32,7 @@
 #include "arrow/buffer.h"
 #include "arrow/stl_iterator.h"
 #include "arrow/type.h"
+#include "arrow/type_fwd.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/visibility.h"
@@ -239,6 +240,11 @@ class ARROW_EXPORT BinaryViewArray : public FlatArray {
 
   IteratorType begin() const { return IteratorType(*this); }
   IteratorType end() const { return IteratorType(*this, length()); }
+
+  /// Compact data buffers with occupancy greater than zero and
+  /// less than or equal to occupancy_threshold. Remove zero-occupancy buffers.
+  Result<std::shared_ptr<Array>> CompactArray(
+      double occupancy_threshold = 0.25, MemoryPool* pool = default_memory_pool()) const;
 
  protected:
   using FlatArray::FlatArray;

--- a/cpp/src/arrow/array/array_binary_test.cc
+++ b/cpp/src/arrow/array/array_binary_test.cc
@@ -1019,7 +1019,7 @@ TYPED_TEST(TestBaseBinaryDataVisitor, Sliced) { this->TestSliced(); }
 namespace {
 
 // Should We  move this to arrow/testing/util.cc
-Result<std::shared_ptr<Buffer>> MakeRandomStringBuffer(int64_t size, int64_t seed = 12) {
+Result<std::shared_ptr<Buffer>> MakeRandomStringBuffer(int64_t size, uint32_t seed = 12) {
   ARROW_ASSIGN_OR_RAISE(auto buffer, AllocateBuffer(size));
   random_ascii(size, seed, buffer->mutable_data());
   return buffer;

--- a/cpp/src/arrow/testing/gtest_util.h
+++ b/cpp/src/arrow/testing/gtest_util.h
@@ -196,6 +196,8 @@ using StringArrowTypes = ::testing::Types<StringType, LargeStringType>;
 using StringOrStringViewArrowTypes =
     ::testing::Types<StringType, LargeStringType, StringViewType>;
 
+using BinaryViewLikeArrowTypes = ::testing::Types<BinaryViewType, StringViewType>;
+
 using ListArrowTypes = ::testing::Types<ListType, LargeListType>;
 
 using UnionArrowTypes = ::testing::Types<SparseUnionType, DenseUnionType>;

--- a/cpp/src/arrow/util/CMakeLists.txt
+++ b/cpp/src/arrow/util/CMakeLists.txt
@@ -58,6 +58,7 @@ add_arrow_test(utility-test
                float16_test.cc
                fixed_width_test.cc
                formatting_util_test.cc
+               interval_test.cc
                key_value_metadata_test.cc
                hashing_test.cc
                int_util_test.cc

--- a/cpp/src/arrow/util/bitmap_ops.cc
+++ b/cpp/src/arrow/util/bitmap_ops.cc
@@ -261,7 +261,6 @@ Result<std::shared_ptr<Buffer>> GetOrCopyNullBitmapBuffer(
   }
 }
 
-// TODO We should remove from compute/kernels/util.s
 Result<std::shared_ptr<Buffer>> GetOrCopyNullBitmapBuffer(MemoryPool* pool,
                                                           const ArrayData& array_data) {
   return GetOrCopyNullBitmapBuffer(pool, array_data.buffers[0], array_data.offset,

--- a/cpp/src/arrow/util/bitmap_ops.h
+++ b/cpp/src/arrow/util/bitmap_ops.h
@@ -27,11 +27,29 @@ namespace arrow {
 
 class Buffer;
 class MemoryPool;
+struct ArrayData;
 
 namespace internal {
 
 // ----------------------------------------------------------------------
 // Bitmap utilities
+
+/// \brief Return a bitmap buffer representing a bit range from an existing bitmap.
+///
+/// If possible, avoids copying by slicing or reusing the input buffer.
+/// Falls back to copying bits if the offset is not divisible by 8.
+///
+/// \param[in] pool Memory pool to allocate memory from.
+/// \param[in] null_buffer Source bitmap buffer.
+/// \param[in] offset Bit offset into the source data.
+///
+/// \return A sliced or copied bitmap buffer, depending on the alignment of the offset.
+ARROW_EXPORT Result<std::shared_ptr<Buffer>> GetOrCopyNullBitmapBuffer(
+    MemoryPool* pool, const std::shared_ptr<Buffer>& null_buffer, int64_t offset,
+    int64_t length);
+
+ARROW_EXPORT Result<std::shared_ptr<Buffer>> GetOrCopyNullBitmapBuffer(
+    MemoryPool* pool, const ArrayData& array_data);
 
 /// Copy a bit range of an existing bitmap
 ///

--- a/cpp/src/arrow/util/bitmap_ops.h
+++ b/cpp/src/arrow/util/bitmap_ops.h
@@ -48,6 +48,7 @@ ARROW_EXPORT Result<std::shared_ptr<Buffer>> GetOrCopyNullBitmapBuffer(
     MemoryPool* pool, const std::shared_ptr<Buffer>& null_buffer, int64_t offset,
     int64_t length);
 
+// TODO We should remove from compute/kernels/util_internal.h
 ARROW_EXPORT Result<std::shared_ptr<Buffer>> GetOrCopyNullBitmapBuffer(
     MemoryPool* pool, const ArrayData& array_data);
 

--- a/cpp/src/arrow/util/interval.h
+++ b/cpp/src/arrow/util/interval.h
@@ -1,0 +1,278 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <set>
+#include <sstream>
+
+namespace arrow::util {
+
+struct Interval {
+  mutable int64_t start;
+  mutable int64_t end;
+  mutable int32_t start_offset_in_compacted = -1;
+
+  bool operator==(const Interval& other) const {
+    return other.start == start && other.end == end;
+  }
+
+  bool operator!=(const Interval& other) const {
+    return other.start != start || other.end != end;
+  }
+};
+
+struct IntervalComparator {
+  bool operator()(const Interval& left, const Interval& right) const {
+    return left.start < right.start;
+  }
+};
+
+class IntervalMerger {
+ public:
+  using IntervalSet = std::set<Interval, IntervalComparator>;
+  using Iterator = std::set<Interval, IntervalComparator>::iterator;
+
+  void AddInterval(const Interval& interval) {
+    assert(interval.start < interval.end);
+    auto [it, is_slow_path_triggered] = TryFastInsert(interval);
+    if (is_slow_path_triggered) {
+      last_inserted_iterator = SlowInsert(interval);
+    } else {
+      last_inserted_iterator = it;
+    }
+  }
+
+  void AddInterval(int64_t s, int64_t end) { AddInterval({s, end, -1}); }
+
+  int64_t CompactIntervalAndGetTotalSize() {
+    int64_t total_size = 0;
+    for (auto& it : interval_set_) {
+      // Note: This method is used for intervals produced from StringView elements.
+      // These intervals cannot produce occupancy in a buffer where start_offset exceeds
+      // INT32_MAX.
+      assert(total_size <= std::numeric_limits<int32_t>::max());
+      it.start_offset_in_compacted = static_cast<int32_t>(total_size);
+      total_size += it.end - it.start;
+    }
+    return total_size;
+  }
+
+  // This method should be called After CompactIntervalAndGetTotalSize
+  int32_t GetCompactedPosition(int32_t view_offset) const {
+    auto it = interval_set_.lower_bound({view_offset, -1, -1});
+    if (it == interval_set_.end()) {
+      --it;
+      // offset from the start of interval
+      auto offset_from_span = view_offset - it->start;
+      return static_cast<int32_t>(offset_from_span) + it->start_offset_in_compacted;
+    } else if (it->start == view_offset) {
+      // this is the case where view_offset refers to the beginning of interval
+      return it->start_offset_in_compacted;
+    } else {
+      --it;
+      // offset from the start of interval
+      auto offset_from_span = view_offset - it->start;
+      return static_cast<int32_t>(offset_from_span) + it->start_offset_in_compacted;
+    }
+  }
+
+  IntervalSet::const_iterator begin() const { return interval_set_.cbegin(); }
+
+  IntervalSet::const_iterator end() const { return interval_set_.cend(); }
+
+  std::string ToString() const {
+    std::ostringstream sink;
+    for (auto& it : interval_set_) {
+      sink << it.start << "," << it.end << "," << it.start_offset_in_compacted << "\n";
+    }
+    return sink.str();
+  }
+  int64_t size() const { return static_cast<int64_t>(interval_set_.size()); }
+
+ private:
+  // Check whether insertion is possible in O(1) time complexity.
+  // Returns true if the slow path must be taken.
+  // The returned iterator is only valid if false is returned.
+  std::pair<Iterator, bool> TryFastInsert(const Interval& interval) {
+    if (last_inserted_iterator == interval_set_.end()) {
+      auto [it, is_inserted] = interval_set_.insert(interval);
+      return {it, false};
+    } else if (interval.start >= last_inserted_iterator->start) {
+      if (interval.start <= last_inserted_iterator->end) {
+        // The interval and last_inserted_iterator are joinable.
+        // Attempt to add or merge at last_inserted_iterator.
+        if (interval.end <= last_inserted_iterator->end) {
+          return {last_inserted_iterator, false};
+        } else {
+          // The interval and last_inserted_iterator are joinable.
+          // interval.end >= last_inserted_iterator->end
+          auto next_it = std::next(last_inserted_iterator);
+          if (next_it == interval_set_.end()) {
+            last_inserted_iterator->end = interval.end;
+            return {last_inserted_iterator, false};
+          } else if (interval.end < next_it->start) {
+            // The interval is not joinable with next_it.
+            last_inserted_iterator->end = interval.end;
+            return {last_inserted_iterator, false};
+          } else if (interval.end <= next_it->end) {
+            last_inserted_iterator->end = next_it->end;
+            interval_set_.erase(next_it);
+            return {last_inserted_iterator, false};
+          } else {
+            return {interval_set_.end(), true};
+          }
+        }
+      } else {
+        // Interval.start > last_inserted_iterator.start
+        // Interval and last_inserted_iterator are not joinable; however, it is checked
+        // whether insertion is possible.
+        auto next_it = std::next(last_inserted_iterator);
+        if (next_it == interval_set_.end()) {
+          auto it = interval_set_.insert(next_it, interval);
+          return {it, false};
+        } else if (next_it->start > interval.end) {
+          // There is no overlap with either the current or the next iterator.
+          auto it = interval_set_.insert(next_it, interval);
+          return {it, false};
+        } else if (next_it->end >= interval.end) {
+          // There is an overlap with the next iterator.
+          next_it->start = std::min(next_it->start, interval.start);
+          next_it->end = next_it->end;
+          return {next_it, false};
+        } else {
+          return {interval_set_.end(), true};
+        }
+      }
+    } else {
+      // interval.start is less than last_inserted_iterator->end.
+      // Handling fast insert for this case.
+      // This may be impractical due to the many states involved,
+      // but it attempts to address some of them here.
+      if (last_inserted_iterator == interval_set_.begin()) {
+        if (last_inserted_iterator->start <= interval.end) {
+          // The interval and last_inserted_iterator are joinable.
+          if (last_inserted_iterator->end >= interval.end) {
+            last_inserted_iterator->start = interval.start;
+            return {last_inserted_iterator, false};
+          } else {
+            return {interval_set_.end(), true};
+          }
+        } else {
+          auto it = interval_set_.insert(last_inserted_iterator, interval);
+          return {it, false};
+        }
+      } else {
+        return {interval_set_.end(), true};
+      }
+    }
+  }
+
+  Iterator SlowInsert(const Interval& interval) {
+    auto [it, should_continue] = MergeOrInsertInterval(interval);
+    if (should_continue) {
+      return JoinRight(it);
+    } else {
+      return it;
+    }
+  }
+
+  // Returns true if the merging process should continue.
+  std::pair<IntervalSet::iterator, bool> MergeOrInsertInterval(const Interval& interval) {
+    // The empty state is handled in the fast path.
+    auto it = interval_set_.lower_bound(interval);
+    if (it != interval_set_.end() && it->start == interval.start) {
+      if (it->end >= interval.end) {
+        return {it, false};
+      } else {
+        it->end = interval.end;
+        return {it, true};
+      }
+    } else if (it == interval_set_.begin()) {
+      // Since 'it' is the lower bound, it->start >= interval.start.
+      // Check for joinability.
+      if (it->start <= interval.end) {
+        // they are joinable
+        if (it->end >= interval.end) {
+          it->start = interval.start;
+          return {it, false};
+        } else {
+          it->end = interval.end;
+          it->start = interval.start;
+          return {it, true};
+        }
+      } else {
+        it = interval_set_.insert(it, interval);
+        return {it, false};
+      }
+    } else {
+      auto prev_it = std::prev(it);
+      // Check whether joinable.
+      if (interval.start <= prev_it->end) {
+        // There is an overlap between prev_it and interval.
+        prev_it->end = std::max(interval.end, prev_it->end);
+        return {prev_it, true};
+      } else if (it == interval_set_.end()) {
+        // There is no overlap between interval with prev_it.
+        it = interval_set_.insert(it, interval);
+        return {it, false};
+      } else if (it->start <= interval.end) {
+        // There is no overlap between interval with prev_it.
+        // There is an overlap between 'it' and interval.
+        it->end = std::max(it->end, interval.end);
+        // Note that this is safe because it is checked that the
+        // interval does not overlap with the previous iterator.
+        it->start = interval.start;
+        return {it, true};
+      } else {
+        it = interval_set_.insert(it, interval);
+        // It is not joinable with either the previous or current iterator,
+        // so the merging process can be finished here.
+        return {it, false};
+      }
+    }
+  }
+
+  Iterator JoinRight(Iterator& it) {
+    auto next_it = std::next(it);
+    if (next_it == interval_set_.end()) {
+      return it;
+    } else if (next_it->start > it->end) {
+      // They are not joinable.
+      return it;
+    } else {
+      auto end_it = interval_set_.upper_bound({it->end, -1});
+      // Note that 'it' is joinable with next_it,
+      // so the following operation will not result in an invalid state.
+      auto prev_end_it = std::prev(end_it);
+      it->end = std::max(prev_end_it->end, it->end);
+      // Since 'it' and 'next_it' are joinable, 'end_it' refers to at least one element
+      // ahead of 'next_it'.
+      interval_set_.erase(next_it, end_it);
+      return it;
+    }
+  }
+
+  IntervalSet interval_set_;
+  Iterator last_inserted_iterator = interval_set_.end();
+};
+
+}  // namespace arrow::util

--- a/cpp/src/arrow/util/interval.h
+++ b/cpp/src/arrow/util/interval.h
@@ -82,16 +82,16 @@ class IntervalMerger {
     if (it == interval_set_.end()) {
       --it;
       // offset from the start of interval
-      auto offset_from_span = view_offset - it->start;
-      return static_cast<int32_t>(offset_from_span) + it->start_offset_in_compacted;
+      auto relative_offset = view_offset - it->start;
+      return static_cast<int32_t>(relative_offset) + it->start_offset_in_compacted;
     } else if (it->start == view_offset) {
       // this is the case where view_offset refers to the beginning of interval
       return it->start_offset_in_compacted;
     } else {
       --it;
       // offset from the start of interval
-      auto offset_from_span = view_offset - it->start;
-      return static_cast<int32_t>(offset_from_span) + it->start_offset_in_compacted;
+      auto relative_offset = view_offset - it->start;
+      return static_cast<int32_t>(relative_offset) + it->start_offset_in_compacted;
     }
   }
 
@@ -106,6 +106,7 @@ class IntervalMerger {
     }
     return sink.str();
   }
+
   int64_t size() const { return static_cast<int64_t>(interval_set_.size()); }
 
  private:

--- a/cpp/src/arrow/util/interval_test.cc
+++ b/cpp/src/arrow/util/interval_test.cc
@@ -1,0 +1,329 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "arrow/testing/gtest_util.h"
+#include "arrow/util/interval.h"
+#include "arrow/util/range.h"
+
+namespace arrow::util {
+
+namespace {
+
+std::vector<Interval> IntervalsFromIntVector(const std::vector<int64_t>& raw_intervals) {
+  assert(raw_intervals.size() % 2 == 0);
+  std::vector<Interval> result;
+  for (int64_t i = 0; i < static_cast<int64_t>(raw_intervals.size()); i += 2) {
+    result.push_back({raw_intervals[i], raw_intervals[i + 1], -1});
+  }
+  return result;
+}
+
+void AssertIntervalsEqual(const IntervalMerger& interval_merger,
+                          const std::vector<int64_t>& raw_expected_intervals) {
+  auto merged_intervals = IntervalsFromIntVector(raw_expected_intervals);
+  ASSERT_EQ(merged_intervals.size(), interval_merger.size());
+  for (auto [expected_interval, actual_interval] :
+       ::arrow::internal::Zip(merged_intervals, interval_merger)) {
+    ASSERT_EQ(expected_interval, actual_interval);
+  }
+}
+
+}  // namespace
+
+class TestIntervalMerger : public ::testing::Test {};
+
+class TestIntervalMergerFastPath : public TestIntervalMerger {};
+
+TEST(TestIntervalMergerFastPath, GreaterOrEqualWithLastInsertedIteratorAndJoinable) {
+  IntervalMerger interval_merger;
+  // Init
+  interval_merger.AddInterval(100, 200);
+
+  // For all assertions below, interval.start >= last_inserted_iterator->start.
+
+  // Overlap: interval->end < last_inserted_iterator->end.
+  interval_merger.AddInterval(150, 170);
+  AssertIntervalsEqual(interval_merger, {100, 200});
+
+  // Overlap: interval->end > last_inserted_iterator->end and
+  // std::next(last_inserted_iterator_) is end.
+  interval_merger.AddInterval(160, 250);
+  AssertIntervalsEqual(interval_merger, {100, 250});
+
+  // No overlap; it is inserted solely to provide a next iterator for [100, 250].
+  interval_merger.AddInterval(300, 400);
+  AssertIntervalsEqual(interval_merger, {100, 250, 300, 400});
+
+  // Just referring last_inserted_iterator back to the interval [100, 250].
+  interval_merger.AddInterval(100, 250);
+
+  // Overlap: interval.end > last_inserted_iterator->end
+  // and  interval.end < std::next(last_inserted_iterator_end)->start
+  interval_merger.AddInterval(180, 260);
+  AssertIntervalsEqual(interval_merger, {100, 260, 300, 400});
+
+  // Overlap: interval.end > last_inserted_iterator->end
+  // and  interval.end > std::next(last_inserted_iterator_end)->start
+  // and interval.end < std::next(last_inserted_iterator_end)->end
+  interval_merger.AddInterval(200, 320);
+  AssertIntervalsEqual(interval_merger, {100, 400});
+
+  // No overlap; it is inserted solely to provide a next iterator for [100, 400].
+  interval_merger.AddInterval(500, 700);
+  AssertIntervalsEqual(interval_merger, {100, 400, 500, 700});
+
+  // Just referring last_inserted_iterator back to the interval [100, 400].
+  interval_merger.AddInterval(200, 320);
+  // Overlap: interval.end > last_inserted_iterator->end
+  // and  interval.end > std::next(last_inserted_iterator_end)->start
+  // and interval.end > std::next(last_inserted_iterator_end)->end
+  // which leads to taking the slow path.
+  interval_merger.AddInterval(210, 800);
+  AssertIntervalsEqual(interval_merger, {100, 800});
+}
+
+TEST(TestIntervalMergerFastPath, GreaterAndNotJoinableWithLastInsertedIterator) {
+  IntervalMerger interval_merger;
+  // Init
+  interval_merger.AddInterval(300, 500);
+  // No overlap, and std::next(last_inserted_iterator) is std::set::end().
+  interval_merger.AddInterval(1000, 1200);
+  AssertIntervalsEqual(interval_merger, {300, 500, 1000, 1200});
+
+  // Just updating last_inserted_iterator to have a next element.
+  interval_merger.AddInterval(700, 800);
+  AssertIntervalsEqual(interval_merger, {300, 500, 700, 800, 1000, 1200});
+
+  // Not joinable with last_inserted_iterator or its next.
+  interval_merger.AddInterval(900, 950);
+  AssertIntervalsEqual(interval_merger, {300, 500, 700, 800, 900, 950, 1000, 1200});
+
+  // Joinable with std::next(last_inserted_iterator).
+  // interval.end < std::next(last_inserted_iterator)->end.
+  interval_merger.AddInterval(970, 1100);
+  AssertIntervalsEqual(interval_merger, {300, 500, 700, 800, 900, 950, 970, 1200});
+
+  // Just updating last_inserted_iterator to have a next element.
+  interval_merger.AddInterval(100, 150);
+  AssertIntervalsEqual(interval_merger,
+                       {100, 150, 300, 500, 700, 800, 900, 950, 970, 1200});
+
+  // Joinable with std::next(last_inserted_iterator).
+  // interval.end > std::next(last_inserted_iterator)->end.
+  // which leads to taking the slow path.
+  interval_merger.AddInterval(170, 600);
+  AssertIntervalsEqual(interval_merger,
+                       {100, 150, 170, 600, 700, 800, 900, 950, 970, 1200});
+}
+
+TEST(TestIntervalMergerFastPath, lessThanAtBegin) {
+  IntervalMerger interval_merger;
+  // Init
+  interval_merger.AddInterval(500, 600);
+  // overlap and interval.end < last_inserted_iterator->end
+  interval_merger.AddInterval(300, 550);
+  AssertIntervalsEqual(interval_merger, {300, 600});
+
+  // For all assertions below, interval.start < last_inserted_iterator->start.
+
+  // Overlap: interval.end > last_inserted_iterator->end
+  interval_merger.AddInterval(200, 700);
+  AssertIntervalsEqual(interval_merger, {200, 700});
+
+  // No overlap
+  interval_merger.AddInterval(100, 150);
+  AssertIntervalsEqual(interval_merger, {100, 150, 200, 700});
+}
+
+class TestIntervalMergerTryInsertOrMerge : public TestIntervalMerger {};
+
+TEST_F(TestIntervalMergerTryInsertOrMerge, EqualStart) {
+  IntervalMerger interval_merger;
+  // First use fast path
+  interval_merger.AddInterval(500, 600);
+  interval_merger.AddInterval(700, 800);
+  interval_merger.AddInterval(1100, 1200);
+  interval_merger.AddInterval(1300, 1400);
+  interval_merger.AddInterval(1500, 1600);
+  interval_merger.AddInterval(1700, 1800);
+
+  // Slow path:
+  // inserted_interval = std::lower_bound(interval).
+  // For all assertions below, interval.start == inserted_interval->start.
+
+  // interval.end < inserted_interval.end
+  interval_merger.AddInterval(1300, 1350);
+  AssertIntervalsEqual(interval_merger, {500, 600, 700, 800, 1100, 1200, 1300, 1400, 1500,
+                                         1600, 1700, 1800});
+  // interval.end > inserted_interval.end
+  interval_merger.AddInterval(700, 850);
+  AssertIntervalsEqual(interval_merger, {500, 600, 700, 850, 1100, 1200, 1300, 1400, 1500,
+                                         1600, 1700, 1800});
+
+  // interval.end > inserted_interval.end and
+  // interval.end > std::next(inserted_interval.end)
+  // which leads to taking the slow path.
+  interval_merger.AddInterval(1500, 1750);
+  AssertIntervalsEqual(interval_merger,
+                       {500, 600, 700, 850, 1100, 1200, 1300, 1400, 1500, 1800});
+}
+
+TEST_F(TestIntervalMergerTryInsertOrMerge, InsertOrMergeAtBegin) {
+  IntervalMerger interval_merger;
+  // First use fast path
+  interval_merger.AddInterval(500, 600);
+  interval_merger.AddInterval(700, 800);
+  interval_merger.AddInterval(1100, 1200);
+
+  // Overlap
+  // interval.end < std::set::lower_bound(interval).end
+  interval_merger.AddInterval(300, 550);
+  AssertIntervalsEqual(interval_merger, {300, 600, 700, 800, 1100, 1200});
+
+  // Update the position of the last_inserted_iterator.
+  interval_merger.AddInterval(1100, 1200);
+  // interval.end > std::set::lower_bound(interval).end
+  interval_merger.AddInterval(200, 650);
+  AssertIntervalsEqual(interval_merger, {200, 650, 700, 800, 1100, 1200});
+
+  // Update the position of the last_inserted_iterator.
+  interval_merger.AddInterval(1100, 1200);
+  // No overlap
+  interval_merger.AddInterval(100, 150);
+  AssertIntervalsEqual(interval_merger, {100, 150, 200, 650, 700, 800, 1100, 1200});
+}
+
+TEST_F(TestIntervalMergerTryInsertOrMerge, InsertOrMergeAtMiddleOrEnd) {
+  IntervalMerger interval_merger;
+  // First use fast path
+  interval_merger.AddInterval(500, 800);
+  interval_merger.AddInterval(1200, 1500);
+  interval_merger.AddInterval(1700, 2000);
+  interval_merger.AddInterval(2200, 2500);
+  interval_merger.AddInterval(2700, 3000);
+  interval_merger.AddInterval(3200, 3500);
+
+  // overlap with std::prev(std::lower_bound(interval))
+  interval_merger.AddInterval(1800, 2100);
+  AssertIntervalsEqual(interval_merger, {500, 800, 1200, 1500, 1700, 2100, 2200, 2500,
+                                         2700, 3000, 3200, 3500});
+
+  // No overlap with std::prev(std::lower_bound(interval))
+  // and std::lower_bound(interval) is equal to std::set::end()
+  interval_merger.AddInterval(3700, 3750);
+  AssertIntervalsEqual(interval_merger, {500, 800, 1200, 1500, 1700, 2100, 2200, 2500,
+                                         2700, 3000, 3200, 3500, 3700, 3750});
+
+  // No overlap with std::prev(std::lower_bound(interval))
+  // and overlap with std::lower_bound(interval)
+  interval_merger.AddInterval(1600, 1750);
+  AssertIntervalsEqual(interval_merger, {500, 800, 1200, 1500, 1600, 2100, 2200, 2500,
+                                         2700, 3000, 3200, 3500, 3700, 3750});
+
+  // no overlap with std::prev(std::lower_bound(interval)) and
+  // std::lower_bound(interval)
+  interval_merger.AddInterval(900, 1000);
+  AssertIntervalsEqual(interval_merger, {500, 800, 900, 1000, 1200, 1500, 1600, 2100,
+                                         2200, 2500, 2700, 3000, 3200, 3500, 3700, 3750});
+}
+
+class TestIntervalMergerJoinRight : public TestIntervalMerger {};
+
+TEST_F(TestIntervalMergerJoinRight, MergeCornerCase) {
+  IntervalMerger interval_merger;
+  // First use fast path
+  interval_merger.AddInterval(1400, 1600);
+  interval_merger.AddInterval(900, 1000);
+  interval_merger.AddInterval(500, 800);
+
+  // next_it is std::sed::end()
+  interval_merger.AddInterval(1200, 1500);
+  AssertIntervalsEqual(interval_merger, {500, 800, 900, 1000, 1200, 1600});
+
+  // No overlap between next_it and it
+  interval_merger.AddInterval(700, 850);
+  AssertIntervalsEqual(interval_merger, {500, 850, 900, 1000, 1200, 1600});
+
+  // Check Corner case of next at end
+  interval_merger.AddInterval(870, 1400);
+  AssertIntervalsEqual(interval_merger, {500, 850, 870, 1600});
+
+  // Check begin case
+  interval_merger.AddInterval(450, 890);
+  AssertIntervalsEqual(interval_merger, {450, 1600});
+}
+
+TEST_F(TestIntervalMergerJoinRight, MergeCommonCase) {
+  IntervalMerger interval_merger;
+  // First use fast path
+  interval_merger.AddInterval(3000, 4000);
+  interval_merger.AddInterval(4000, 5000);
+  interval_merger.AddInterval(6000, 7000);
+
+  // Regular JoinRight
+  interval_merger.AddInterval(0, 10000);
+  AssertIntervalsEqual(interval_merger, {0, 10000});
+}
+
+TEST_F(TestIntervalMerger, CompressIntervals) {
+  IntervalMerger interval_merger;
+  interval_merger.AddInterval(3000, 4000);
+  interval_merger.AddInterval(5000, 8000);
+  interval_merger.AddInterval(3200, 4500);
+  interval_merger.AddInterval(10000, 12000);
+  interval_merger.AddInterval(15000, 20000);
+  AssertIntervalsEqual(interval_merger,
+                       {3000, 4500, 5000, 8000, 10000, 12000, 15000, 20000});
+
+  auto total_size = interval_merger.CompactIntervalAndGetTotalSize();
+  ASSERT_EQ(total_size, 11500);
+
+  std::vector<int32_t> offsets{0, 1500, 4500, 6500};
+
+  for (const auto& [interval, offset] :
+       ::arrow::internal::Zip(interval_merger, offsets)) {
+    ASSERT_EQ(interval.start_offset_in_compacted, offset);
+  }
+}
+
+TEST_F(TestIntervalMerger, GetCompactedPosition) {
+  IntervalMerger interval_merger;
+  interval_merger.AddInterval(3000, 4000);
+  interval_merger.AddInterval(5000, 8000);
+  interval_merger.AddInterval(3200, 4500);
+  interval_merger.AddInterval(10000, 12000);
+  interval_merger.AddInterval(15000, 20000);
+  AssertIntervalsEqual(interval_merger,
+                       {3000, 4500, 5000, 8000, 10000, 12000, 15000, 20000});
+  interval_merger.CompactIntervalAndGetTotalSize();
+  // Offsets are {0, 1500, 4500, 6500}
+
+  // Get Compacted offset from last interval
+  ASSERT_EQ(interval_merger.GetCompactedPosition(17000), 8500);
+
+  // Get Compacted offset from the start of interval
+  ASSERT_EQ(interval_merger.GetCompactedPosition(5000), 1500);
+
+  // Get Compacted offset from middle of an interval
+  ASSERT_EQ(interval_merger.GetCompactedPosition(11000), 5500);
+}
+
+}  // namespace arrow::util


### PR DESCRIPTION
### Rationale for this change
As we discussed [here](https://github.com/apache/arrow/issues/46128#issuecomment-2820665771), the following method copies only data that is used in data buffers to a new buffer
### What changes are included in this PR?
Add a new method the name of which is `CompactArray`
### Are these changes tested?
I run the relevant unit tests
### Are there any user-facing changes?
Yes, I add `ComapctArray` method to `BinaryViewArray` class
* GitHub Issue: #46128