### PR TITLE
GH-46177: [C++][Compute] Correct the behavior of cast compute functions regarding string types

### DIFF
--- a/cpp/src/arrow/compute/kernels/scalar_cast_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_string.cc
@@ -587,7 +587,8 @@ BinaryToBinaryCastExec(KernelContext* ctx, const ExecSpan& batch, ExecResult* ou
     }
   }
 
-  // This buffer is preallocated
+  ARROW_ASSIGN_OR_RAISE(output->buffers[1],
+                        ctx->Allocate((input.length + 1) * sizeof(output_offset_type)));
   auto* offsets = output->GetMutableValues<output_offset_type>(1);
   offsets[0] = static_cast<output_offset_type>(input.offset * width);
   for (int64_t i = 0; i < input.length; i++) {
@@ -717,7 +718,8 @@ void AddBinaryToBinaryCast(CastFunction* func) {
 
   DCHECK_OK(func->AddKernel(InType::type_id, {InputType(InType::type_id)}, out_ty,
                             BinaryToBinaryCastExec<OutType, InType>,
-                            NullHandling::COMPUTED_NO_PREALLOCATE));
+                            NullHandling::COMPUTED_NO_PREALLOCATE,
+                            MemAllocation::NO_PREALLOCATE));
 }
 
 template <typename OutType>

--- a/cpp/src/arrow/compute/kernels/scalar_cast_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_string.cc
@@ -742,7 +742,8 @@ void AddBinaryToFixedSizeBinaryCast(CastFunction* func) {
 
   DCHECK_OK(func->AddKernel(InType::type_id, {InputType(InType::type_id)}, resolver_fsb,
                             BinaryToBinaryCastExec<FixedSizeBinaryType, InType>,
-                            NullHandling::COMPUTED_NO_PREALLOCATE));
+                            NullHandling::COMPUTED_NO_PREALLOCATE,
+                            MemAllocation::NO_PREALLOCATE));
 }
 
 void AddBinaryToFixedSizeBinaryCast(CastFunction* func) {


### PR DESCRIPTION
Rationale for this change
There are eight compute functions for casting between string types. All, except the fixed-to-offset string function, assume the second buffer is not preallocated. However, the second buffer is preallocated when the output does not involve String/Binary view types

What changes are included in this PR?
1-I changed the way the kernel is created not to allocate Buffer for the second buffers 
2- Makes the behaviour of FixedSize to String types cast compute function likes the others.

Are these changes tested?
I run the relevant unit test.

Are there any user-facing changes?
No
* GitHub Issue: #46177