### PR TITLE
GH-46231: [C++][CMake] Fix `arrow_bundled_dependencies` to be externally accessible by FetchContent

### DIFF
--- a/cpp/cmake_modules/BuildUtils.cmake
+++ b/cpp/cmake_modules/BuildUtils.cmake
@@ -163,7 +163,7 @@ function(arrow_create_merged_static_lib output_target)
   message(STATUS "Creating bundled static library target ${output_target} at ${output_lib_path}"
   )
 
-  add_library(${output_target} STATIC IMPORTED)
+  add_library(${output_target} STATIC IMPORTED GLOBAL)
   set_target_properties(${output_target} PROPERTIES IMPORTED_LOCATION ${output_lib_path})
   add_dependencies(${output_target} ${output_target}_merge)
 endfunction()


### PR DESCRIPTION
### Rationale for this change

`arrow_bundled_dependencies` is an IMPORTED library which links to `arrow_bundled_dependencies_merge`. When arrow-cpp is used externally as a third-party dependency via CMake `FetchContent`, target `arrow_bundled_dependencies` is not accessible by the parent project (but `arrow_bundled_dependencies_merge` is). It is difficult for the parent project to locate the built product of `arrow_bundled_dependencies_merge` and install it.

### What changes are included in this PR?

Change `IMPORTED` library `arrow_bundled_dependencies` to be `GLOBAL`.

### Are these changes tested?

- Pass all CIs.
- Verified to work by https://github.com/apache/iceberg-cpp/pull/89

### Are there any user-facing changes?

I don't think so.

* GitHub Issue: #46231