### PR TITLE
GH-46233: [C++] Fix missing nested braces in QueuedTask initialization

### DIFF
--- a/cpp/src/arrow/util/thread_pool.cc
+++ b/cpp/src/arrow/util/thread_pool.cc
@@ -171,8 +171,8 @@ Status SerialExecutor::SpawnReal(TaskHints hints, FnOnce<void()> task,
           "Attempt to schedule a task on a serial executor that has already finished or "
           "been abandoned");
     }
-    state->task_queue.push(QueuedTask{std::move(task), std::move(stop_token),
-                                      std::move(stop_callback), hints.priority,
+    state->task_queue.push(QueuedTask{{std::move(task), std::move(stop_token),
+                                      std::move(stop_callback)}, hints.priority,
                                       state_->spawned_tasks_count_++});
   }
   state->wait_for_tasks.notify_one();
@@ -208,8 +208,8 @@ Status SerialExecutor::SpawnReal(TaskHints hints, FnOnce<void()> task,
         "been abandoned");
   }
 
-  state_->task_queue.push(QueuedTask{std::move(task), std::move(stop_token),
-                                     std::move(stop_callback), hints.priority,
+  state_->task_queue.push(QueuedTask{{std::move(task), std::move(stop_token),
+                                     std::move(stop_callback)}, hints.priority,
                                      state_->spawned_tasks_count_++});
 
   return Status::OK();

--- a/cpp/src/arrow/util/thread_pool.cc
+++ b/cpp/src/arrow/util/thread_pool.cc
@@ -171,9 +171,10 @@ Status SerialExecutor::SpawnReal(TaskHints hints, FnOnce<void()> task,
           "Attempt to schedule a task on a serial executor that has already finished or "
           "been abandoned");
     }
-    state->task_queue.push(QueuedTask{{std::move(task), std::move(stop_token),
-                                      std::move(stop_callback)}, hints.priority,
-                                      state_->spawned_tasks_count_++});
+    state->task_queue.push(
+        QueuedTask{{std::move(task), std::move(stop_token), std::move(stop_callback)},
+                   hints.priority,
+                   state_->spawned_tasks_count_++});
   }
   state->wait_for_tasks.notify_one();
   return Status::OK();
@@ -208,9 +209,10 @@ Status SerialExecutor::SpawnReal(TaskHints hints, FnOnce<void()> task,
         "been abandoned");
   }
 
-  state_->task_queue.push(QueuedTask{{std::move(task), std::move(stop_token),
-                                     std::move(stop_callback)}, hints.priority,
-                                     state_->spawned_tasks_count_++});
+  state_->task_queue.push(
+      QueuedTask{{std::move(task), std::move(stop_token), std::move(stop_callback)},
+                 hints.priority,
+                 state_->spawned_tasks_count_++});
 
   return Status::OK();
 }


### PR DESCRIPTION
### Rationale for this change
When building Arrow in Debug configuration with compilers that enforce -Wmissing-braces (e.g., Clang with -Werror enabled), an error occurs due to missing nested braces in the QueuedTask initialization. Adding the extra braces ensures compliance with strict compiler warnings and maintains successful builds across different platforms and configurations.

### What changes are included in this PR?
- Added an extra pair of braces around the first three parameters used to initialize the QueuedTask structure in `thread_pool.cc`.

### Are these changes tested?
Yes, the changes are covered by existing build and test processes. Building with -Werror enabled now succeeds without errors.

### Are there any user-facing changes?
No

* GitHub Issue: #46233