### PR TITLE
GH-46238: [Release][Python] Use array to avoid empty argument in `dev/release/post-11-python.sh`

### DIFF
--- a/dev/release/post-11-python.sh
+++ b/dev/release/post-11-python.sh
@@ -49,11 +49,12 @@ gh release download \
   --pattern "pyarrow-*.whl" \
   --repo "${GITHUB_REPOSITORY}"
 
+TWINE_ARGS=()
 if [ "${TEST_PYPI}" -gt 0 ]; then
-  TWINE_ARGS="--repository-url https://test.pypi.org/legacy/"
+  TWINE_ARGS+=("--repository-url" "https://test.pypi.org/legacy/")
 fi
 
-twine upload "${TWINE_ARGS}" "${tmp}"/*
+twine upload "${TWINE_ARGS[@]}" "${tmp}"/*
 
 rm -rf "${tmp}"
 


### PR DESCRIPTION
### Rationale for this change

```console
$ dev/release/post-11-python.sh 20.0.0
...
+ twine upload '' /tmp/arrow-post-python.AcTeC/pyarrow-20.0.0-cp310-cp310-macosx_12_0_arm64.whl ...
ERROR    InvalidDistribution: Cannot find file (or expand pattern): ''                              
```

### What changes are included in this PR?

Use array for `TWINE_ARGS` that may be empty.

### Are these changes tested?

Yes. I used this for 20.0.0.

### Are there any user-facing changes?

No.
* GitHub Issue: #46238