### PR TITLE
GH-46242: [Release] Don't show gpg signature when getting release time

### DIFF
--- a/dev/tasks/linux-packages/helper.rb
+++ b/dev/tasks/linux-packages/helper.rb
@@ -28,7 +28,7 @@ module Helper
     def latest_commit_time(git_directory)
       return nil unless git_directory?(git_directory)
       cd(git_directory) do
-        return Time.iso8601(`git log -n 1 --format=%aI`.chomp).utc
+        return Time.iso8601(`git log -n 1 --no-show-signature --format=%aI`.chomp).utc
       end
     end
 


### PR DESCRIPTION
### Rationale for this change
post-12-bumb-versions.sh doesn't work with git's log.showSignature=true

### What changes are included in this PR?
Don't show the signature

### Are these changes tested?
CI, locally

### Are there any user-facing changes?
No
* GitHub Issue: #46242