### PR TITLE
GH-46250: [Swift] Update `swift-tools-version` to 5.10

### DIFF
--- a/swift/Arrow/Package.swift
+++ b/swift/Arrow/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.7
+// swift-tools-version: 5.10
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 // Licensed to the Apache Software Foundation (ASF) under one

--- a/swift/ArrowFlight/Package.swift
+++ b/swift/ArrowFlight/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.7
+// swift-tools-version: 5.10
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 // Licensed to the Apache Software Foundation (ASF) under one

--- a/swift/CDataWGo/Package.swift
+++ b/swift/CDataWGo/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 5.10
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 // Licensed to the Apache Software Foundation (ASF) under one


### PR DESCRIPTION
### Rationale for this change

The `swift-tools-version` declares the minimum version of Swift, but `Arrow Swift` packages use inconsistent versions confusingly.
```
$ git grep swift-tools-version:
Arrow/Package.swift:// swift-tools-version:5.7
ArrowFlight/Package.swift:// swift-tools-version:5.7
CDataWGo/Package.swift:// swift-tools-version: 5.9
```

Since Apache Arrow CI validates these projects with `Swift 5.10`, we can update it to `5.10`.

https://github.com/apache/arrow/blob/0580deeab4731e41e5c993d2f5f068e462118c3a/ci/docker/ubuntu-swift.dockerfile#L18

As of now, Swift 6.1 is the latest version.
- https://www.swift.org/blog/swift-6.1-released/ (2025-03-31)
- https://www.swift.org/blog/swift-5.10-released/ (2025-03-05)
- https://www.swift.org/blog/swift-5.9-released/ (2023-09-18)
- https://www.swift.org/blog/swift-5.8-released/ (2023-03-30)
- https://www.swift.org/blog/swift-5.7-released/ (2022-09-12)

### What changes are included in this PR?

Update `swift-tools-version` to `5.10` consistently.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #46250