### PR TITLE
GH-46256: [C++][Python]Add Baidu advanced file system(AFS) support

### DIFF
--- a/cpp/src/arrow/filesystem/filesystem.cc
+++ b/cpp/src/arrow/filesystem/filesystem.cc
@@ -928,7 +928,7 @@ Result<std::shared_ptr<FileSystem>> FileSystemFromUriReal(const Uri& uri,
         "without GCS support");
 #endif
   }
-  if (scheme == "hdfs" || scheme == "viewfs") {
+  if (scheme == "hdfs" || scheme == "viewfs" || scheme == "afs") {
 #ifdef ARROW_HDFS
     ARROW_ASSIGN_OR_RAISE(auto options, HdfsOptions::FromUri(uri));
     if (out_path != nullptr) {

--- a/python/pyarrow/_hdfs.pyx
+++ b/python/pyarrow/_hdfs.pyx
@@ -72,7 +72,7 @@ cdef class HadoopFileSystem(FileSystem):
             CHdfsOptions options
             shared_ptr[CHadoopFileSystem] wrapped
 
-        if not host.startswith(('hdfs://', 'viewfs://')) and host != "default":
+        if not host.startswith(('hdfs://', 'viewfs://', 'afs://')) and host != "default":
             # TODO(kszucs): do more sanitization
             host = 'hdfs://{}'.format(host)
 


### PR DESCRIPTION

### Rationale for this change
Baidu advanced file system (AFS) is HDFS-compatible file system and implements all HDFS interfaces which is used by Baidu, Inc. The only deferent is AFS start with afs://, so we need to follow the HDFS processing when encountering a file system starting with afs:// in arrow.

### What changes are included in this PR?
This PR add conditional check on uri. When an uri start with afs://, Arrow will determine  it is HDFS and use the HDFS api to deal data .


### Are these changes tested?
Yes，and we've used in our AFS based data processing.


### Are there any user-facing changes?
No, hdfs:// and viewfs:// processing was not changed.


* GitHub Issue: #46256