### PR TITLE
GH-46259: [CI] Remove deprecated flag from mamba info

### DIFF
--- a/python/examples/minimal_build/build_conda.sh
+++ b/python/examples/minimal_build/build_conda.sh
@@ -41,7 +41,7 @@ function setup_miniconda() {
   LOCAL_PATH=$PATH
   export PATH="$MINICONDA/bin:$PATH"
 
-  mamba info -a
+  mamba info
 
   conda config --set show_channel_urls True
   conda config --show channels


### PR DESCRIPTION
### Rationale for this change

The flag `-a` is not part of the mamba info API anymore and the nightly CI job is currently failing.

### What changes are included in this PR?

Remove the `-a` on mamba info, it still shows relevant information:

```
       libmamba version : 2.0.8
          mamba version : 2.0.8
           curl version : libcurl/8.13.0 OpenSSL/3.4.1 zlib/1.3.1 zstd/1.5.7 libssh2/1.11.1 nghttp2/1.64.0
     libarchive version : libarchive 3.7.7 zlib/1.3.1 liblzma/5.6.3 bz2lib/1.0.8 liblz4/1.10.0 libzstd/1.5.6
       envs directories : /miniconda-for-arrow/envs
          package cache : /miniconda-for-arrow/pkgs
                          /root/.mamba/pkgs
            environment : base
           env location : /miniconda-for-arrow
      user config files : /root/.mambarc
 populated config files : /miniconda-for-arrow/.condarc
       virtual packages : __unix=0=0
                          __linux=6.11.0=0
                          __glibc=2.38=0
                          __archspec=1=x86_64_v4
               channels : https://conda.anaconda.org/conda-forge/linux-64
                          https://conda.anaconda.org/conda-forge/noarch
       base environment : /miniconda-for-arrow
               platform : linux-64

```

### Are these changes tested?

Yes via Archery

### Are there any user-facing changes?

No

* GitHub Issue: #46259