### PR TITLE
GH-46270: [C++][Parquet] Clarify docstring for `GeoStatistics::dimension_empty()`

### DIFF
--- a/cpp/src/parquet/geospatial/statistics.h
+++ b/cpp/src/parquet/geospatial/statistics.h
@@ -147,8 +147,9 @@ class PARQUET_EXPORT GeoStatistics {
 
   /// \brief Dimension emptiness in XYZM order
   ///
-  /// True for a given dimension if and only if zero non-NaN values were encountered
-  /// in that dimension and dimension_valid() is true for that dimension.
+  /// True for a given dimension if all values in that dimension were NaN
+  /// or there were no values in that dimension and dimension_valid()
+  /// is true.
   ///
   /// When calculating statistics, zero or more of these values may be true because
   /// this implementation calculates bounds for all dimensions; however, it may be


### PR DESCRIPTION
### Rationale for this change

The docstring for `dimension_empty()` was confusing!

### What changes are included in this PR?

The docstring describing what dimension emptiness is was updated.

### Are these changes tested?

No code changes!

### Are there any user-facing changes?

No!

* GitHub Issue: #46270