### PR TITLE
GH-46219: [C++][Parquet] Remove PARQUET_MINIMAL_DEPENDENCY option

### DIFF
--- a/cpp/cmake_modules/DefineOptions.cmake
+++ b/cpp/cmake_modules/DefineOptions.cmake
@@ -590,10 +590,6 @@ takes precedence over ccache if a storage backend is configured" ON)
   #----------------------------------------------------------------------
   set_option_category("Parquet")
 
-  define_option(PARQUET_MINIMAL_DEPENDENCY
-                "Depend only on Thirdparty headers to build libparquet.;\
-Always OFF if building binaries" OFF)
-
   define_option(PARQUET_BUILD_EXECUTABLES
                 "Build the Parquet executable CLI tools. Requires static libraries to be built."
                 OFF)

--- a/cpp/src/parquet/CMakeLists.txt
+++ b/cpp/src/parquet/CMakeLists.txt
@@ -257,24 +257,23 @@ else()
   set(PARQUET_SRCS ${PARQUET_SRCS} encryption/encryption_internal_nossl.cc)
 endif()
 
-if(NOT PARQUET_MINIMAL_DEPENDENCY)
-  list(APPEND PARQUET_SHARED_LINK_LIBS arrow_shared)
+list(APPEND PARQUET_SHARED_LINK_LIBS arrow_shared)
 
-  # Add RapidJSON libraries
-  list(APPEND PARQUET_SHARED_PRIVATE_LINK_LIBS RapidJSON)
-  list(APPEND PARQUET_STATIC_LINK_LIBS RapidJSON)
+# Add RapidJSON libraries
+list(APPEND PARQUET_SHARED_PRIVATE_LINK_LIBS RapidJSON)
+list(APPEND PARQUET_STATIC_LINK_LIBS RapidJSON)
 
-  # These are libraries that we will link privately with parquet_shared (as they
-  # do not need to be linked transitively by other linkers)
-  list(APPEND PARQUET_SHARED_PRIVATE_LINK_LIBS thrift::thrift)
+# These are libraries that we will link privately with parquet_shared (as they
+# do not need to be linked transitively by other linkers)
+list(APPEND PARQUET_SHARED_PRIVATE_LINK_LIBS thrift::thrift)
 
-  # Link publicly with parquet_static (because internal users need to
-  # transitively link all dependencies)
-  list(APPEND PARQUET_STATIC_LINK_LIBS thrift::thrift)
-  if(NOT THRIFT_VENDORED)
-    list(APPEND PARQUET_STATIC_INSTALL_INTERFACE_LIBS thrift::thrift)
-  endif()
+# Link publicly with parquet_static (because internal users need to
+# transitively link all dependencies)
+list(APPEND PARQUET_STATIC_LINK_LIBS thrift::thrift)
+if(NOT THRIFT_VENDORED)
+  list(APPEND PARQUET_STATIC_INSTALL_INTERFACE_LIBS thrift::thrift)
 endif()
+
 if(ARROW_WITH_OPENTELEMETRY)
   list(APPEND PARQUET_SHARED_PRIVATE_LINK_LIBS ${ARROW_OPENTELEMETRY_LIBS})
 endif()


### PR DESCRIPTION
### Rationale for this change

This option has been in our code base for some time but is not tested and may no longer work. The consensus in https://github.com/apache/arrow/issues/46219 was to remove it.

### What changes are included in this PR?

The option is removed!

### Are these changes tested?

Yes (covered by the Parquet builds that had previously not tested this option!)

### Are there any user-facing changes?

Yes, a build option was removed; however, I wasn't able to find where this build option was documented in the first place!

* GitHub Issue: #46219