### PR TITLE
GH-46205: [C++][Parquet][WIP] Read/Write null count statistics for UNKNOWN sort order

### DIFF
--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -1250,8 +1250,11 @@ class TypedColumnWriterImpl : public ColumnWriterImpl,
         page_statistics_ = MakeStatistics<ParquetType>(descr_, allocator_);
         chunk_statistics_ = MakeStatistics<ParquetType>(descr_, allocator_);
       }
+
       if (descr_->logical_type() != nullptr && descr_->logical_type()->is_geometry()) {
         chunk_geospatial_statistics_ = std::make_shared<geospatial::GeoStatistics>();
+        page_statistics_ = MakeStatistics<ParquetType>(descr_, allocator_);
+        chunk_statistics_ = MakeStatistics<ParquetType>(descr_, allocator_);
       }
     }
 

--- a/cpp/src/parquet/column_writer_test.cc
+++ b/cpp/src/parquet/column_writer_test.cc
@@ -1923,8 +1923,8 @@ TEST_F(TestGeometryValuesWriter, TestWriteAndRead) {
   }
 
   // Statistics are unset because the sort order is unknown
-  ASSERT_FALSE(metadata_accessor()->is_stats_set());
-  ASSERT_EQ(metadata_accessor()->statistics(), nullptr);
+  ASSERT_TRUE(metadata_accessor()->is_stats_set());
+  ASSERT_EQ(metadata_accessor()->statistics()->null_count(), 0);
 
   ASSERT_TRUE(metadata_accessor()->is_geo_stats_set());
   std::shared_ptr<geospatial::GeoStatistics> geospatial_statistics = metadata_geo_stats();
@@ -2007,9 +2007,11 @@ TEST_F(TestGeometryValuesWriter, TestWriteAndReadAllNull) {
     EXPECT_EQ(this->definition_levels_out_[i], 0);
   }
 
-  // Statistics are unset because the sort order is unknown
-  ASSERT_FALSE(metadata_accessor()->is_stats_set());
-  ASSERT_EQ(metadata_accessor()->statistics(), nullptr);
+  // Statistics are unset because the sort order is unknown?
+  ASSERT_TRUE(metadata_accessor()->is_stats_set());
+  ASSERT_FALSE(metadata_accessor()->statistics()->HasDistinctCount());
+  ASSERT_FALSE(metadata_accessor()->statistics()->HasMinMax());
+  ASSERT_EQ(metadata_accessor()->statistics()->null_count(), SMALL_SIZE);
 
   // GeoStatistics should exist but all components should be marked as uncalculated
   ASSERT_TRUE(metadata_accessor()->is_geo_stats_set());

--- a/cpp/src/parquet/metadata.cc
+++ b/cpp/src/parquet/metadata.cc
@@ -307,8 +307,10 @@ class ColumnChunkMetaData::ColumnChunkMetaDataImpl {
     DCHECK(writer_version_ != nullptr);
     // If the column statistics don't exist or column sort order is unknown
     // we cannot use the column stats
+    bool is_geometry =
+        descr_->logical_type() != nullptr && descr_->logical_type()->is_geometry();
     if (!column_metadata_->__isset.statistics ||
-        descr_->sort_order() == SortOrder::UNKNOWN) {
+        (descr_->sort_order() == SortOrder::UNKNOWN && !is_geometry)) {
       return false;
     }
     {
@@ -1552,8 +1554,8 @@ bool ApplicationVersion::HasCorrectStatistics(Type::type col_type,
     return true;
   }
 
-  // Unknown sort order has incorrect stats
-  if (SortOrder::UNKNOWN == sort_order) {
+  // Unknown sort order has incorrect stats if the min or the max are specified
+  if (SortOrder::UNKNOWN == sort_order && (statistics.has_min || statistics.has_max)) {
     return false;
   }
 


### PR DESCRIPTION
### Rationale for this change

Minimum and maximum values are not useful in the context of an unsorted converted or loigcal type; however, null counts are! Geometry is one example of an unsorted type where this type of information might be useful; however, there are others as well!

### What changes are included in this PR?

Early work-in-progress explorations to find the relevant pieces of code.

### Are these changes tested?

They will be once a general direction is decided on!

### Are there any user-facing changes?

Possibly!

* GitHub Issue: #46205