### PR TITLE
GH-46241: [Release][Packaging] Add support for regenerating metadata of APT repositories

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -197,6 +197,7 @@ repos:
           ?^c_glib/test/run-test\.sh$|
           ?^dev/release/05-binary-upload\.sh$|
           ?^dev/release/07-binary-verify\.sh$|
+          ?^dev/release/binary-recover\.sh$|
           ?^dev/release/post-03-binary\.sh$|
           ?^dev/release/post-10-docs\.sh$|
           ?^dev/release/post-11-python\.sh$|
@@ -214,6 +215,7 @@ repos:
         files: >-
           (
           ?^dev/release/05-binary-upload\.sh$|
+          ?^dev/release/binary-recover\.sh$|
           ?^dev/release/post-03-binary\.sh$|
           ?^dev/release/post-10-docs\.sh$|
           ?^dev/release/post-11-python\.sh$|

--- a/dev/release/binary-recover.sh
+++ b/dev/release/binary-recover.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -e
+set -o pipefail
+
+SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [ "$#" -ne 0 ]; then
+  echo "Usage: $0"
+  exit
+fi
+
+cd "${SOURCE_DIR}"
+
+if [ ! -f .env ]; then
+  echo "You must create $(pwd)/.env"
+  echo "You can use $(pwd)/.env.example as template"
+  exit 1
+fi
+# shellcheck source=SCRIPTDIR/.env.example
+. .env
+
+. utils-binary.sh
+
+# By default recover all artifacts.
+# To deactivate one category, deactivate the category and all of its dependents.
+# To explicitly select one category, set RECOVER_DEFAULT=0 RECOVER_X=1.
+: "${RECOVER_DEFAULT:=1}"
+: "${RECOVER_DEBIAN:=${RECOVER_DEFAULT}}"
+: "${RECOVER_UBUNTU:=${RECOVER_DEFAULT}}"
+
+rake_tasks=()
+apt_targets=()
+if [ "${RECOVER_DEBIAN}" -gt 0 ]; then
+  rake_tasks+=(apt:recover)
+  apt_targets+=(debian)
+fi
+if [ "${RECOVER_UBUNTU}" -gt 0 ]; then
+  rake_tasks+=(apt:recover)
+  apt_targets+=(ubuntu)
+fi
+
+tmp_dir=binary/tmp
+mkdir -p "${tmp_dir}"
+
+docker_run \
+  ./runner.sh \
+  rake \
+  --trace \
+  "${rake_tasks[@]}" \
+  APT_TARGETS="$(
+    IFS=,
+    echo "${apt_targets[*]}"
+  )" \
+  ARTIFACTORY_API_KEY="${ARTIFACTORY_API_KEY}" \
+  ARTIFACTS_DIR="${tmp_dir}/artifacts" \
+  RC="" \
+  STAGING="${STAGING:-no}" \
+  VERBOSE="${VERBOSE:-no}" \
+  VERSION=""


### PR DESCRIPTION
### Rationale for this change

In general, we don't need to use `dev/release/binary-recover.sh`. We need this only when we can't detect broken APT repositories in RC. But we must be able to detect it automatically. I'll propose it later.

We may document this when:

1. We add support for regenerating metadata for Yum repositories
2. We can't add a mechanism that detects broken APT/Yum repositories

### What changes are included in this PR?

1. Download all `.deb` (and related) files
2. Regenerate metadata of APT repositories from the downloaded files
3. Upload regenerated metadata of APT repositories

### Are these changes tested?

Yes. I fixed our broken APT repositories for 20.0.0 by this.

### Are there any user-facing changes?

No.
* GitHub Issue: #46241