### PR TITLE
GH-46262: [CI][Ruby] Don't update GCC of MSYS2

### DIFF
--- a/ci/scripts/msys2_setup.sh
+++ b/ci/scripts/msys2_setup.sh
@@ -29,7 +29,6 @@ case "${target}" in
     packages+=(${MINGW_PACKAGE_PREFIX}-brotli)
     packages+=(${MINGW_PACKAGE_PREFIX}-bzip2)
     packages+=(${MINGW_PACKAGE_PREFIX}-c-ares)
-    packages+=(${MINGW_PACKAGE_PREFIX}-cc)
     packages+=(${MINGW_PACKAGE_PREFIX}-ccache)
     packages+=(${MINGW_PACKAGE_PREFIX}-clang)
     packages+=(${MINGW_PACKAGE_PREFIX}-cmake)
@@ -69,15 +68,6 @@ case "${target}" in
     packages+=(${MINGW_PACKAGE_PREFIX}-gobject-introspection)
     packages+=(${MINGW_PACKAGE_PREFIX}-meson)
     packages+=(${MINGW_PACKAGE_PREFIX}-vala)
-    ;;
-esac
-
-case "${target}" in
-  cgo)
-    packages+=(${MINGW_PACKAGE_PREFIX}-arrow)
-    packages+=(${MINGW_PACKAGE_PREFIX}-gcc)
-    packages+=(${MINGW_PACKAGE_PREFIX}-toolchain)
-    packages+=(base-devel)
     ;;
 esac
 


### PR DESCRIPTION
### Rationale for this change

The current Ruby for Windows doesn't work with GCC 15.

See also: https://bugs.ruby-lang.org/issues/21286

### What changes are included in this PR?

Don't update GCC explicitly. We don't need to use the latest GCC for our CI. So we don't need to update GCC.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #46262