### PR TITLE
GH-46284: [Release][Packaging] Add missing APT metadata for .ddeb

### DIFF
--- a/dev/release/binary-task.rb
+++ b/dev/release/binary-task.rb
@@ -1490,7 +1490,7 @@ Dir::ArchiveDir ".";
 Dir::CacheDir ".";
 TreeDefault::Directory "pool/#{code_name}/#{component}";
 TreeDefault::SrcDirectory "pool/#{code_name}/#{component}";
-Default::Packages::Extensions ".deb";
+Default::Packages::Extensions ".deb .ddeb";
 Default::Packages::Compress ". gzip xz";
 Default::Sources::Compress ". gzip xz";
 Default::Contents::Compress "gzip";


### PR DESCRIPTION
### Rationale for this change

Ubuntu uses `.ddeb` extension for debug symbol packages. So we need to specify `.ddeb` for APT repository metadata target explicitly.

### What changes are included in this PR?

Add `.ddeb` to `Default::Packages::Exntesions` in `apt-ftparchive` configuration.

### Are these changes tested?

Yes.

I used this for ADBC 18 RC 0.
See also: https://github.com/apache/arrow-adbc/issues/2769

### Are there any user-facing changes?

No.
* GitHub Issue: #46284