### PR TITLE
GH-46290: [Swift] Upgrade `grpc-swift` to `1.25.0` and `swift-protobuf` to `1.29.0`

### DIFF
--- a/swift/ArrowFlight/Package.swift
+++ b/swift/ArrowFlight/Package.swift
@@ -32,8 +32,8 @@ let package = Package(
             targets: ["ArrowFlight"])
     ],
     dependencies: [
-        .package(url: "https://github.com/grpc/grpc-swift.git", from: "1.15.0"),
-        .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.6.0"),
+        .package(url: "https://github.com/grpc/grpc-swift.git", from: "1.25.0"),
+        .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.29.0"),
         .package(path: "../Arrow")
     ],
     targets: [


### PR DESCRIPTION
### Rationale for this change

The current dependencies of `ArrowFlight` are outdated about two years. We had better update them to bring the latest features and bug fixes.

- grpc-swift
    - https://github.com/grpc/grpc-swift/releases/tag/1.15.0 (2023-04-11)
    - https://github.com/grpc/grpc-swift/releases/tag/1.25.0 (2025-04-28)

- swift-protobuf
    - https://github.com/apple/swift-protobuf/releases/tag/1.25.0 (2023-10-27)
    - https://github.com/apple/swift-protobuf/releases/tag/1.29.0 (2025-02-24)

### What changes are included in this PR?

- Upgrade `grpc-swift` from `1.15.0` to `1.25.0`.
- Upgrade `swift-protobuf` from `1.25.0` to `1.29.0`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.

* GitHub Issue: #46290