### PR TITLE
GH-46289: [Release][Packaging] Verify APT/Yum repositories keeps working for old versions

### DIFF
--- a/.github/workflows/verify_rc.yml
+++ b/.github/workflows/verify_rc.yml
@@ -38,10 +38,44 @@ permissions:
 env:
   TEST_DEFAULT: "0"
   VERBOSE: "1"
-  RC_TAG: "${{ inputs.rc_tag || github.event_name == 'pull_request' && 'apache-arrow-20.0.0-rc0' || github.ref_name }}"
 
 jobs:
+  target:
+    runs-on: ubuntu-latest
+    timeout: 5
+    outputs:
+      version: ${{ steps.detect.outputs.version }}
+      rc: ${{ steps.detect.outputs.rc }}
+    steps:
+      - name: Detect
+        id: detect
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          case "${GITHUB_EVENT_NAME}" in
+            workflow_dispatch)
+              tag="${{ input.rc_tag }}"
+              ;;
+            pull_request)
+              env | sort
+              tag="$(gh release list \
+                       --jq '.[] | select(.isPrerelease) | .tagName' \
+                       --json tagName,isPrerelease \
+                       --repo ${GITHUB_REPOSITORY} | \
+                       head -n1)"
+              ;;
+            *)
+              tag="${GITHUB_REF_NAME}"
+              ;;
+          esac
+          package_id=${tag%-rc*}
+          version=${package_id#apache-arrow-}
+          rc=${tag#*-rc}
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+          echo "rc=${rc}" >> "${GITHUB_OUTPUT}"
+
   apt:
+    needs: target
     name: APT
     runs-on: ${{ matrix.runs-on }}
     timeout-minutes: 30
@@ -52,30 +86,35 @@ jobs:
           - ubuntu-latest
           - ubuntu-24.04-arm
     env:
+      RC: ${{ needs.target.outputs.rc }}
       TEST_APT: "1"
+      VERSION: ${{ needs.target.outputs.version }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Run
         run: |
-          package_id=${RC_TAG%-rc*}
-          version=${package_id#apache-arrow-}
-          rc=${RC_TAG#*-rc}
-          dev/release/verify-release-candidate.sh ${version} ${rc}
+          dev/release/verify-release-candidate.sh ${VERSION} ${RC}
+      - name: Verify the previous version
+        run: |
+          major_version=${VERSION%%.*}
+          previous_major_version$((major_version - 1))
+          previous_version=${previous_major_version}.0.0
+          rc=0 # This number isn't used for APT verification
+          dev/release/verify-release-candidate.sh ${previous_version} ${rc}
 
   binary:
     name: Binary
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
+      RC: ${{ needs.target.outputs.rc }}
       TEST_BINARY: "1"
+      VERSION: ${{ needs.target.outputs.version }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Run
         run: |
-          package_id=${RC_TAG%-rc*}
-          version=${package_id#apache-arrow-}
-          rc=${RC_TAG#*-rc}
-          dev/release/verify-release-candidate.sh ${version} ${rc}
+          dev/release/verify-release-candidate.sh ${VERSION} ${RC}
 
   wheels-linux:
     name: Wheels Linux
@@ -90,7 +129,9 @@ jobs:
           - ubuntu-22.04
           - ubuntu-24.04
     env:
+      RC: ${{ needs.target.outputs.rc }}
       TEST_WHEELS: "1"
+      VERSION: ${{ needs.target.outputs.version }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
@@ -100,9 +141,6 @@ jobs:
         run: python -m pip install -e dev/archery[docker]
       - name: Prepare
         run: |
-          package_id=${RC_TAG%-rc*}
-          echo "VERSION=${package_id#apache-arrow-}" >> ${GITHUB_ENV}
-          echo "RC=${RC_TAG#*-rc}" >> ${GITHUB_ENV}
           distro=${{ matrix.distro }}
           if [ "${distro}" = "conda" ]; then
             echo "SERVICE=${distro}-verify-rc" >> ${GITHUB_ENV}
@@ -136,17 +174,16 @@ jobs:
           - macos-13
           - macos-14
     env:
+      RC: ${{ needs.target.outputs.rc }}
       TEST_WHEELS: "1"
+      VERSION: ${{ needs.target.outputs.version }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Run
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          package_id=${RC_TAG%-rc*}
-          version=${package_id#apache-arrow-}
-          rc=${RC_TAG#*-rc}
-          dev/release/verify-release-candidate.sh ${version} ${rc}
+          dev/release/verify-release-candidate.sh ${VERSION} ${RC}
 
   wheels-windows:
     name: Wheels Windows
@@ -154,17 +191,13 @@ jobs:
     timeout-minutes: 45
     env:
       PYARROW_TEST_GDB: "OFF"
+      RC: ${{ needs.target.outputs.rc }}
       TEST_WHEELS: "1"
+      VERSION: ${{ needs.target.outputs.version }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: recursive
-      - name: Prepare
-        shell: bash
-        run: |
-          package_id=${RC_TAG%-rc*}
-          echo "VERSION=${package_id#apache-arrow-}" >> ${GITHUB_ENV}
-          echo "RC=${RC_TAG#*-rc}" >> ${GITHUB_ENV}
       - uses: conda-incubator/setup-miniconda@505e6394dae86d6a5c7fbb6e3fb8938e3e863830 # v3.1.1
       - name: Install System Dependencies
         run: |
@@ -191,12 +224,18 @@ jobs:
           - ubuntu-latest
           - ubuntu-24.04-arm
     env:
+      RC: ${{ needs.target.outputs.rc }}
       TEST_YUM: "1"
+      VERSION: ${{ needs.target.outputs.version }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Run
         run: |
-          package_id=${RC_TAG%-rc*}
-          version=${package_id#apache-arrow-}
-          rc=${RC_TAG#*-rc}
-          dev/release/verify-release-candidate.sh ${version} ${rc}
+          dev/release/verify-release-candidate.sh ${VERSION} ${RC}
+      - name: Verify the previous version
+        run: |
+          major_version=${VERSION%%.*}
+          previous_major_version$((major_version - 1))
+          previous_version=${previous_major_version}.0.0
+          rc=0 # This number isn't used for Yum verification
+          dev/release/verify-release-candidate.sh ${previous_version} ${rc}


### PR DESCRIPTION
### Rationale for this change

Our auto RC verification only verifies the current version. Our APT/Yum repositories provide not only new packages but also old packages. So we should verify whether APT/Yum keeps working for old packages too.

### What changes are included in this PR?

Run our RC verification scripts for the previous major release too only for APT/Yum verification.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #46289