### PR TITLE
GH-46296: [Swift] Fix `ProtoUtil.fromProto` to support `struct_`

### DIFF
--- a/swift/Arrow/Sources/Arrow/ProtoUtil.swift
+++ b/swift/Arrow/Sources/Arrow/ProtoUtil.swift
@@ -64,6 +64,8 @@ func fromProto( // swiftlint:disable:this cyclomatic_complexity
             let arrowUnit: ArrowTime64Unit = timeType.unit == .microsecond ? .microseconds : .nanoseconds
             arrowType = ArrowTypeTime64(arrowUnit)
         }
+    case .struct_:
+        arrowType = ArrowType(ArrowType.ArrowStruct)
     default:
         arrowType = ArrowType(ArrowType.ArrowUnknown)
     }


### PR DESCRIPTION
### Rationale for this change

`makeArrayHolder` supports `ArrowTypeId.strct`.

https://github.com/apache/arrow/blob/62c59c23352583980e894a43ec46335c4d55a7e1/swift/Arrow/Sources/Arrow/ArrowReaderHelper.swift#L189-L190

However, we cannot use `makeArrayHolder` if `fromProto` fails to handle `org_apache_arrow_flatbuf_Type_.struct_`.

https://github.com/apache/arrow/blob/62c59c23352583980e894a43ec46335c4d55a7e1/swift/Arrow/Sources/Arrow/ArrowReaderHelper.swift#L139-L148

### What changes are included in this PR?

This PR aims to fix `ProtoUtil.fromProto` to support `struct_`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #46296