### PR TITLE
GH-46224: [C++][Acero] Fix the hang in asof join

### DIFF
--- a/cpp/src/arrow/acero/asof_join_node.cc
+++ b/cpp/src/arrow/acero/asof_join_node.cc
@@ -641,12 +641,6 @@ class InputState : public util::SerialSequencingQueue::Processor {
         latest_ref_row_ = 0;
         std::ignore = queue_.TryPop();
         have_active_batch = !queue_.Empty();
-        // have_active_batch &= !queue_.TryPop();
-        // if (have_active_batch) {
-        //   DCHECK_GT(queue_.Front()->num_rows(), 0);  // empty batches disallowed
-        //   memo_.UpdateTime(GetTime(queue_.Front().get(), time_type_id_, time_col_index_,
-        //                            0));  // time changed
-        // }
       }
     }
     return have_active_batch;

--- a/cpp/src/arrow/acero/asof_join_node.cc
+++ b/cpp/src/arrow/acero/asof_join_node.cc
@@ -1423,27 +1423,9 @@ class AsofJoinNode : public ExecNode {
     ARROW_DCHECK(std_has(inputs_, input));
     size_t k = std_find(inputs_, input) - inputs_.begin();
 
-    if (k == 0) {
-      // static bool hang = true;
-      // if (hang) {
-      //   hang = false;
-      //   // Hang.
-      //   std::this_thread::sleep_for(std::chrono::milliseconds(3000));
-      // }
-      // std::this_thread::sleep_for(std::chrono::milliseconds(300));
-    }
-
     // Put into the sequencing queue
     ARROW_RETURN_NOT_OK(state_.at(k)->InsertBatch(std::move(batch)));
 
-    // if (k == 0) {
-    //   static int i = 0;
-    //   if (i == 1) {
-    //     PushProcess(true);
-    //     PushProcess(true);
-    //   }
-    //   i++;
-    // }
     PushProcess(true);
 
     return Status::OK();
@@ -1454,9 +1436,6 @@ class AsofJoinNode : public ExecNode {
       std::lock_guard<std::mutex> guard(gate_);
       ARROW_DCHECK(std_has(inputs_, input));
       size_t k = std_find(inputs_, input) - inputs_.begin();
-      // if (k == 0) {
-      //   std::this_thread::sleep_for(std::chrono::milliseconds(6000));
-      // }
       state_.at(k)->set_total_batches(total_batches);
     }
     // Trigger a process call

--- a/cpp/src/arrow/acero/asof_join_node.cc
+++ b/cpp/src/arrow/acero/asof_join_node.cc
@@ -639,7 +639,9 @@ class InputState : public util::SerialSequencingQueue::Processor {
         // hit the end of the batch, need to get the next batch if possible.
         ++batches_processed_;
         latest_ref_row_ = 0;
-        std::ignore = queue_.TryPop();
+        bool did_pop = queue_.TryPop().has_value();
+        DCHECK(did_pop);
+        ARROW_UNUSED(did_pop);
         have_active_batch = !queue_.Empty();
       }
     }

--- a/cpp/src/arrow/acero/asof_join_node_test.cc
+++ b/cpp/src/arrow/acero/asof_join_node_test.cc
@@ -1774,6 +1774,11 @@ TEST(AsofJoinTest, DestroyNonStartedAsofJoinNode) {
 // Reproduction of GH-46224: Hang when all left timestamps are greater than right
 // timestamps.
 TEST(AsofJoinTest, OneSideTsAllGreaterThanTheOther) {
+#if defined(ARROW_VALGRIND) || defined(ADDRESS_SANITIZER)
+  const int rounds = 1;
+#else
+  const int rounds = 42;
+#endif
   int64_t tolerance = 1;
   int64_t num_rows_big_ts = 1;
   int64_t num_rows_small_ts = ExecPlan::kMaxBatchSize + 1;
@@ -1805,7 +1810,7 @@ TEST(AsofJoinTest, OneSideTsAllGreaterThanTheOther) {
     ExecBatch exp_batch({c.left_col, col_null}, c.left_col->length());
 
     // Run moderate number of times to ensure that no hangs occur.
-    for (int i = 0; i < 42; ++i) {
+    for (int i = 0; i < rounds; ++i) {
       AsofJoinNodeOptions opts({{{"on"}, {}}, {{"on"}, {}}}, tolerance);
       auto left = Declaration("exec_batch_source",
                               ExecBatchSourceNodeOptions(left_schema, {left_batch}));

--- a/cpp/src/arrow/acero/asof_join_node_test.cc
+++ b/cpp/src/arrow/acero/asof_join_node_test.cc
@@ -1781,7 +1781,7 @@ TEST(AsofJoinTest, DeadLock) {
 
   ASSERT_OK_AND_ASSIGN(auto left_col,
                        gen::Constant(MakeScalar(n_right + 1))->Generate(n_left));
-  ASSERT_OK_AND_ASSIGN(auto right_col, gen::Step(0ll, 1ll)->Generate(n_right));
+  ASSERT_OK_AND_ASSIGN(auto right_col, gen::Step<int64_t>()->Generate(n_right));
 
   auto left_table = Table::Make(left_schema, {left_col});
   auto right_table = Table::Make(right_schema, {right_col});

--- a/cpp/src/arrow/acero/asof_join_node_test.cc
+++ b/cpp/src/arrow/acero/asof_join_node_test.cc
@@ -1771,7 +1771,9 @@ TEST(AsofJoinTest, DestroyNonStartedAsofJoinNode) {
       DeclarationToStatus(std::move(sink)));
 }
 
-TEST(AsofJoinTest, DeadLock) {
+// Reproduction of GH-46224: Hang when all left timestamps are greater than right
+// timestamps.
+TEST(AsofJoinTest, LeftGreaterThanRight) {
   int64_t n_left = 1;
   int64_t n_right = ExecPlan::kMaxBatchSize + 1;
   int64_t tolerance = 1;

--- a/cpp/src/arrow/acero/exec_plan.h
+++ b/cpp/src/arrow/acero/exec_plan.h
@@ -55,6 +55,7 @@ class ARROW_ACERO_EXPORT ExecPlan : public std::enable_shared_from_this<ExecPlan
  public:
   // This allows operators to rely on signed 16-bit indices
   static const uint32_t kMaxBatchSize = 1 << 15;
+  // static const uint32_t kMaxBatchSize = 1 << 2;
   using NodeVector = std::vector<ExecNode*>;
 
   virtual ~ExecPlan() = default;

--- a/cpp/src/arrow/acero/exec_plan.h
+++ b/cpp/src/arrow/acero/exec_plan.h
@@ -55,7 +55,6 @@ class ARROW_ACERO_EXPORT ExecPlan : public std::enable_shared_from_this<ExecPlan
  public:
   // This allows operators to rely on signed 16-bit indices
   static const uint32_t kMaxBatchSize = 1 << 15;
-  // static const uint32_t kMaxBatchSize = 1 << 2;
   using NodeVector = std::vector<ExecNode*>;
 
   virtual ~ExecPlan() = default;


### PR DESCRIPTION
### Rationale for this change

A hang of asof join is reported in #46224 . To explain the cause of the hang, I shall first brief the basic processing of asof join.

There is an outstanding processing thread for the asof join, whose lifespan is bound to the asof node. This thread will wait on a command queue. Once a command is pushed into the queue, the thread pops it and do one round of processing. The command is issued as the batches are received from either left or right side input of the asof join node. Each round of processing will advance the accumulated left and right inputs as much as possible to see if it is sufficient to output a batch (if yes, i.e., either side of the asof join can be concluded by the latest input timestamp, then emit it, otherwise adjust the internal state according to the latest input timestamp).

Notably, the processing is by design to advance the inputs "as much as possible". However there is a bug (seemingly since day 1) when advancing the right side input in a tricky condition: if all right side rows are at the times before the least time of the left rows, then advancing the right side input won't cross batches in one round of processing. This is OK (i.e., no hang) as long as there are enough commands issued into the queue to trigger enough rounds of processing. However if lucky enough, say, the left input batches come late, then the processing with consume some commands issued by the right side input but advance nothing (because the left side input is empty), resulting in insufficient commands to fully advance both the input.

### What changes are included in this PR?

Fix the issue that advancing the right side input won't cross batches when the minimal left time is bigger than all the right times.

### Are these changes tested?

Yes, added a dedicated case.

### Are there any user-facing changes?

None.

* GitHub Issue: #46224