### PR TITLE
GH-46296: [Swift] Add support for reading struct

### DIFF
--- a/swift/Arrow/Sources/Arrow/ArrowType.swift
+++ b/swift/Arrow/Sources/Arrow/ArrowType.swift
@@ -385,6 +385,8 @@ extension ArrowType.Info: Equatable {
             return lhsId == rhsId
         case (.timeInfo(let lhsId), .timeInfo(let rhsId)):
             return lhsId == rhsId
+        case (.complexInfo(let lhsId), .complexInfo(let rhsId)):
+            return lhsId == rhsId
         default:
             return false
         }

--- a/swift/Arrow/Sources/Arrow/ProtoUtil.swift
+++ b/swift/Arrow/Sources/Arrow/ProtoUtil.swift
@@ -64,6 +64,8 @@ func fromProto( // swiftlint:disable:this cyclomatic_complexity
             let arrowUnit: ArrowTime64Unit = timeType.unit == .microsecond ? .microseconds : .nanoseconds
             arrowType = ArrowTypeTime64(arrowUnit)
         }
+    case .struct_:
+        arrowType = ArrowType(ArrowType.ArrowStruct)
     default:
         arrowType = ArrowType(ArrowType.ArrowUnknown)
     }

--- a/swift/data-generator/swift-datagen/go.mod
+++ b/swift/data-generator/swift-datagen/go.mod
@@ -16,7 +16,8 @@
 
 module swift-datagen/main
 
-go 1.22.7
+go 1.23.0
+
 toolchain go1.24.1
 
 require github.com/apache/arrow-go/v18 v18.2.0

--- a/swift/data-generator/swift-datagen/main.go
+++ b/swift/data-generator/swift-datagen/main.go
@@ -82,7 +82,35 @@ func writeDoubleData() {
 	writeBytes(rec, "testdata_double.arrow")
 }
 
+func writeStructData() {
+	mem := memory.NewGoAllocator()
+
+	fields := []arrow.Field{
+		{Name: "my struct", Type: arrow.StructOf([]arrow.Field{
+			{Name: "my string", Type: arrow.BinaryTypes.String},
+			{Name: "my bool", Type: arrow.FixedWidthTypes.Boolean},
+		}...)},
+	}
+
+	schema := arrow.NewSchema(fields, nil)
+
+	bld := array.NewRecordBuilder(mem, schema)
+	defer bld.Release()
+
+	sb := bld.Field(0).(*array.StructBuilder)
+	f1b := sb.FieldBuilder(0).(*array.StringBuilder)
+	f2b := sb.FieldBuilder(1).(*array.BooleanBuilder)
+
+	sb.AppendValues([]bool{true, true, false})
+	f1b.AppendValues([]string{"0", "1", ""}, []bool{true, true, false})
+	f2b.AppendValues([]bool{false, true, false}, []bool{true, true, false})
+
+	rec := bld.NewRecord()
+	writeBytes(rec, "testdata_struct.arrow")
+}
+
 func main() {
 	writeBoolData()
 	writeDoubleData()
+	writeStructData()
 }


### PR DESCRIPTION
### Rationale for this change

`makeArrayHolder` supports `ArrowTypeId.strct`.

https://github.com/apache/arrow/blob/62c59c23352583980e894a43ec46335c4d55a7e1/swift/Arrow/Sources/Arrow/ArrowReaderHelper.swift#L189-L190

However, we cannot use `makeArrayHolder` if `fromProto` fails to handle `org_apache_arrow_flatbuf_Type_.struct_`.

https://github.com/apache/arrow/blob/62c59c23352583980e894a43ec46335c4d55a7e1/swift/Arrow/Sources/Arrow/ArrowReaderHelper.swift#L139-L148

### What changes are included in this PR?

This PR aims to fix `ProtoUtil.fromProto` to support `struct_`.

This PR also adds an unit test for it.

This is based on GH-46297.

### Known issues with Swift Arrow Reader

Currently the Swift Arrow reader requires a null buffer to be included in the list of buffers.  The reader will fail if the null buffer is missing.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.

* GitHub Issue: #46296

Co-authored-by: Dongjoon Hyun <dongjoon@apache.org>