### PR TITLE
GH-46299: [C++][Compute] Don't use `static inline const` for default options

### DIFF
--- a/cpp/src/arrow/compute/kernels/vector_rank.cc
+++ b/cpp/src/arrow/compute/kernels/vector_rank.cc
@@ -381,9 +381,13 @@ class RankMetaFunction : public RankMetaFunctionBase<RankMetaFunction> {
   }
 
   RankMetaFunction()
-      : RankMetaFunctionBase("rank", Arity::Unary(), rank_doc, &kDefaultOptions) {}
+      : RankMetaFunctionBase("rank", Arity::Unary(), rank_doc, GetDefaultOptions()) {}
 
-  static inline const auto kDefaultOptions = RankOptions::Defaults();
+ private:
+  static const RankOptions* GetDefaultOptions() {
+    static const auto kDefaultOptions = RankOptions::Defaults();
+    return &kDefaultOptions;
+  }
 };
 
 class RankQuantileMetaFunction : public RankMetaFunctionBase<RankQuantileMetaFunction> {
@@ -398,9 +402,13 @@ class RankQuantileMetaFunction : public RankMetaFunctionBase<RankQuantileMetaFun
 
   RankQuantileMetaFunction()
       : RankMetaFunctionBase("rank_quantile", Arity::Unary(), rank_quantile_doc,
-                             &kDefaultOptions) {}
+                             GetDefaultOptions()) {}
 
-  static inline const auto kDefaultOptions = RankQuantileOptions::Defaults();
+ private:
+  static const RankQuantileOptions* GetDefaultOptions() {
+    static const auto kDefaultOptions = RankQuantileOptions::Defaults();
+    return &kDefaultOptions;
+  }
 };
 
 class RankNormalMetaFunction : public RankMetaFunctionBase<RankNormalMetaFunction> {
@@ -415,9 +423,13 @@ class RankNormalMetaFunction : public RankMetaFunctionBase<RankNormalMetaFunctio
 
   RankNormalMetaFunction()
       : RankMetaFunctionBase("rank_normal", Arity::Unary(), rank_normal_doc,
-                             &kDefaultOptions) {}
+                             GetDefaultOptions()) {}
 
-  static inline const auto kDefaultOptions = RankQuantileOptions::Defaults();
+ private:
+  static const RankQuantileOptions* GetDefaultOptions() {
+    static const auto kDefaultOptions = RankQuantileOptions::Defaults();
+    return &kDefaultOptions;
+  }
 };
 
 }  // namespace

--- a/cpp/src/arrow/compute/kernels/vector_sort_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort_test.cc
@@ -30,6 +30,7 @@
 #include "arrow/array/concatenate.h"
 #include "arrow/compute/api_vector.h"
 #include "arrow/compute/kernels/test_util_internal.h"
+#include "arrow/compute/registry.h"
 #include "arrow/result.h"
 #include "arrow/table.h"
 #include "arrow/testing/gtest_util.h"
@@ -2317,6 +2318,11 @@ class TestRank : public BaseTestRank {
   }
 };
 
+TEST_F(TestRank, DefaultOptions) {
+  ASSERT_OK_AND_ASSIGN(auto function, GetFunctionRegistry()->GetFunction("rank"));
+  ASSERT_STREQ(function->default_options()->type_name(), "RankOptions");
+}
+
 TEST_F(TestRank, Real) {
   for (auto real_type : ::arrow::FloatingPointTypes()) {
     SetInput(ArrayFromJSON(real_type, "[2.1, 3.2, 1.0, 0.0, 5.5]"));
@@ -2635,6 +2641,12 @@ class TestRankQuantile : public BaseTestRank {
   }
 };
 
+TEST_F(TestRankQuantile, DefaultOptions) {
+  ASSERT_OK_AND_ASSIGN(auto function,
+                       GetFunctionRegistry()->GetFunction("rank_quantile"));
+  ASSERT_STREQ(function->default_options()->type_name(), "RankQuantileOptions");
+}
+
 TEST_F(TestRankQuantile, Real) {
   for (auto type : ::arrow::FloatingPointTypes()) {
     AssertRankQuantileNumeric(type);
@@ -2673,6 +2685,13 @@ TEST_F(TestRankQuantile, FixedSizeBinary) {
   // With nulls
   SetInput(ArrayFromJSON(type, R"([null, "abc", null, "def", null])"));
   AssertRankQuantile_N1N2N();
+}
+
+class TestRankNormal : public BaseTestRank {};
+
+TEST_F(TestRankNormal, DefaultOptions) {
+  ASSERT_OK_AND_ASSIGN(auto function, GetFunctionRegistry()->GetFunction("rank_normal"));
+  ASSERT_STREQ(function->default_options()->type_name(), "RankQuantileOptions");
 }
 
 }  // namespace compute


### PR DESCRIPTION
### Rationale for this change

We use static variables for compute function option types. For example:
https://github.com/apache/arrow/blob/068416bd411d6a8e2949f8ebcb2f80e2c302ef6b/cpp/src/arrow/compute/api_vector.cc#L127-L170

These option types are used for compute function options. For example: https://github.com/apache/arrow/blob/068416bd411d6a8e2949f8ebcb2f80e2c302ef6b/cpp/src/arrow/compute/api_vector.cc#L237

If we use `static inline const` for compute function options, these compute function options may be initialized BEFORE compute function option types.

We use `static inline const` only for `rank`, `rank_quantile` and `rank_normal`:

https://github.com/apache/arrow/blob/068416bd411d6a8e2949f8ebcb2f80e2c302ef6b/cpp/src/arrow/compute/kernels/vector_rank.cc#L382-L386

https://github.com/apache/arrow/blob/068416bd411d6a8e2949f8ebcb2f80e2c302ef6b/cpp/src/arrow/compute/kernels/vector_rank.cc#L399-L403

https://github.com/apache/arrow/blob/068416bd411d6a8e2949f8ebcb2f80e2c302ef6b/cpp/src/arrow/compute/kernels/vector_rank.cc#L416-L420

We can avoid this initialization order problem by deferring default compute function options initialization.

### What changes are included in this PR?

* Use `static function` instead of `static inline const` for default compute function options
* Add tests for default compute function options for `rank`, `rank_quantile` and `rank_normal`

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #46299