### PR TITLE
GH-35419: [GLib] Add GArrowFixedShapeTensorDataType

### DIFF
--- a/c_glib/arrow-glib/basic-data-type.cpp
+++ b/c_glib/arrow-glib/basic-data-type.cpp
@@ -2287,7 +2287,7 @@ garrow_fixed_shape_tensor_data_type_class_init(GArrowFixedShapeTensorDataTypeCla
 
 /**
  * garrow_fixed_shape_tensor_data_type_new:
- * @value_type: A #GArrowDataType.
+ * @value_type: A #GArrowDataType of individual tensor elements.
  * @size: The length of `shape`.
  * @psize: The length of `permutation`.
  * @shape: (array length=size): shape.

--- a/c_glib/arrow-glib/basic-data-type.cpp
+++ b/c_glib/arrow-glib/basic-data-type.cpp
@@ -2267,6 +2267,37 @@ garrow_string_view_data_type_new(void)
   return data_type;
 }
 
+G_DEFINE_TYPE(GArrowFixedShapeTensorDataType,
+              garrow_fixed_shape_tensor_data_type,
+              GARROW_TYPE_EXTENSION_DATA_TYPE)
+
+static void
+garrow_fixed_shape_tensor_data_type_init(GArrowFixedShapeTensorDataType *object)
+{
+}
+
+static void
+garrow_fixed_shape_tensor_data_type_class_init(GArrowFixedShapeTensorDataTypeClass *klass)
+{
+}
+
+/**
+ * garrow_fixed_shape_tensor_data_type_new:
+ *
+ * Returns: The newly created fixed shape tensor data type.
+ */
+GArrowFixedShapeTensorDataType *
+garrow_fixed_shape_tensor_data_type_new(void)
+{
+  auto arrow_data_type = arrow::GetExtensionType("arrow.fixed_shape_tensor");
+  GArrowFixedShapeTensorDataType *data_type = GARROW_FIXED_SHAPE_TENSOR_DATA_TYPE(
+    g_object_new(GARROW_TYPE_FIXED_SHAPE_TENSOR_DATA_TYPE,
+                 "data-type",
+                 &arrow_data_type,
+                 NULL));
+  return data_type;
+}
+
 G_END_DECLS
 
 GArrowDataType *

--- a/c_glib/arrow-glib/basic-data-type.cpp
+++ b/c_glib/arrow-glib/basic-data-type.cpp
@@ -2324,12 +2324,11 @@ garrow_fixed_shape_tensor_data_type_new(GArrowDataType *value_type,
     arrow_dim_names.push_back(dim_name[i]);
   }
 
-  auto arrow_data_type = arrow::extension::FixedShapeTensorType::Make(arrow_value_type,
+  auto arrow_data_type_result = arrow::extension::FixedShapeTensorType::Make(arrow_value_type,
                                                                       arrow_shape,
                                                                       arrow_permutation,
                                                                       arrow_dim_names);
-
-  if (!garrow::check(error, arrow_data_type, "[fixed-shape-tensor][new]")) {
+  if (!garrow::check(error, arrow_data_type_result, "[fixed-shape-tensor][new]")) {
     return NULL;
   }
 

--- a/c_glib/arrow-glib/basic-data-type.cpp
+++ b/c_glib/arrow-glib/basic-data-type.cpp
@@ -25,9 +25,8 @@
 #include <arrow-glib/field.hpp>
 #include <arrow-glib/type.hpp>
 
-#include <arrow/extension/fixed_shape_tensor.h>
-
 #include <arrow/c/bridge.h>
+#include <arrow/extension/fixed_shape_tensor.h>
 
 G_BEGIN_DECLS
 

--- a/c_glib/arrow-glib/basic-data-type.cpp
+++ b/c_glib/arrow-glib/basic-data-type.cpp
@@ -131,6 +131,8 @@ G_BEGIN_DECLS
  * #GArrowStringViewDataType is a class for the string view data type.
  *
  * #GArrowBinaryViewDataType is a class for the binary view data type.
+ *
+ * #GArrowFixedShapeTensorDataType is a class for the fixed shape tensor data type.
  */
 
 struct GArrowDataTypePrivate

--- a/c_glib/arrow-glib/basic-data-type.cpp
+++ b/c_glib/arrow-glib/basic-data-type.cpp
@@ -2332,7 +2332,7 @@ garrow_fixed_shape_tensor_data_type_new(GArrowDataType *value_type,
     return NULL;
   }
 
-  GArrowFixedShapeTensorDataType *data_type = GARROW_FIXED_SHAPE_TENSOR_DATA_TYPE(
+  auto data_type = GARROW_FIXED_SHAPE_TENSOR_DATA_TYPE(
     g_object_new(GARROW_TYPE_FIXED_SHAPE_TENSOR_DATA_TYPE,
                  "data-type",
                  &arrow_data_type.ValueUnsafe(),

--- a/c_glib/arrow-glib/basic-data-type.cpp
+++ b/c_glib/arrow-glib/basic-data-type.cpp
@@ -2288,11 +2288,14 @@ garrow_fixed_shape_tensor_data_type_class_init(GArrowFixedShapeTensorDataTypeCla
 /**
  * garrow_fixed_shape_tensor_data_type_new:
  * @value_type: A #GArrowDataType of individual tensor elements.
- * @size: The length of `shape`.
- * @psize: The length of `permutation`.
- * @shape: (array length=size): shape.
- * @permutation: (array length=psize): permutation.
- * @dim_name: (array length=size): dim_names.
+ * @shape: (array length=shape_length): A physical shape of the contained tensors as an array.
+ * @shape_length: The length of `shape`.
+ * @permutation: (array length=permutation_length): An indices of the desired ordering of the original
+ *    dimensions, defined as an array. This must be `NULL` or the same length array of `shape`.
+ * @permutation_length: The length of `permutation`.
+ * @dim_names: (array length=n_dim_names): Explicit names to tensor dimensions as an array.
+ *   This must be `NULL` or the same length array of `shape`.
+ * @n_dim_names. The length of `dim_names`.
  * @error: (nullable): Return location for a #GError or %NULL.
  *
  * Returns: The newly created fixed shape tensor data type.

--- a/c_glib/arrow-glib/basic-data-type.cpp
+++ b/c_glib/arrow-glib/basic-data-type.cpp
@@ -2291,12 +2291,12 @@ garrow_fixed_shape_tensor_data_type_class_init(GArrowFixedShapeTensorDataTypeCla
  * @shape: (array length=shape_length): A physical shape of the contained tensors as an
  * array.
  * @shape_length: The length of `shape`.
- * @permutation: (array length=permutation_length): An indices of the desired ordering of
- * the original dimensions, defined as an array. This must be `NULL` or the same length
- * array of `shape`.
+ * @permutation: (array length=permutation_length) (nullable): An indices of the desired
+ * ordering of the original dimensions, defined as an array. This must be `NULL` or the
+ * same length array of `shape`.
  * @permutation_length: The length of `permutation`.
- * @dim_names: (array length=n_dim_names): Explicit names to tensor dimensions as an
- * array. This must be `NULL` or the same length array of `shape`.
+ * @dim_names: (array length=n_dim_names) (nullable): Explicit names to tensor dimensions
+ * as an array. This must be `NULL` or the same length array of `shape`.
  * @n_dim_names. The length of `dim_names`.
  * @error: (nullable): Return location for a #GError or %NULL.
  *

--- a/c_glib/arrow-glib/basic-data-type.cpp
+++ b/c_glib/arrow-glib/basic-data-type.cpp
@@ -2292,11 +2292,11 @@ garrow_fixed_shape_tensor_data_type_class_init(GArrowFixedShapeTensorDataTypeCla
  *   array.
  * @shape_length: The length of `shape`.
  * @permutation: (array length=permutation_length) (nullable): An indices of the desired
- * ordering of the original dimensions, defined as an array. This must be `NULL` or the
- * same length array of `shape`.
+ *   ordering of the original dimensions, defined as an array. This must be `NULL` or
+ *   the same length array of `shape`.
  * @permutation_length: The length of `permutation`.
  * @dim_names: (array length=n_dim_names) (nullable): Explicit names to tensor dimensions
- * as an array. This must be `NULL` or the same length array of `shape`.
+ *   as an array. This must be `NULL` or the same length array of `shape`.
  * @n_dim_names. The length of `dim_names`.
  * @error: (nullable): Return location for a #GError or %NULL.
  *
@@ -2305,11 +2305,11 @@ garrow_fixed_shape_tensor_data_type_class_init(GArrowFixedShapeTensorDataTypeCla
 GArrowFixedShapeTensorDataType *
 garrow_fixed_shape_tensor_data_type_new(GArrowDataType *value_type,
                                         const gint64 *shape,
-                                        gint32 shape_length,
+                                        gsize shape_length,
                                         const gint64 *permutation,
-                                        gint32 permutation_length,
+                                        gsize permutation_length,
                                         const gchar **dim_names,
-                                        gint32 n_dim_names,
+                                        gsize n_dim_names,
                                         GError **error)
 {
   std::vector<int64_t> arrow_shape;

--- a/c_glib/arrow-glib/basic-data-type.cpp
+++ b/c_glib/arrow-glib/basic-data-type.cpp
@@ -2289,7 +2289,7 @@ garrow_fixed_shape_tensor_data_type_class_init(GArrowFixedShapeTensorDataTypeCla
  * garrow_fixed_shape_tensor_data_type_new:
  * @value_type: A #GArrowDataType of individual tensor elements.
  * @shape: (array length=shape_length): A physical shape of the contained tensors as an
- * array.
+ *   array.
  * @shape_length: The length of `shape`.
  * @permutation: (array length=permutation_length) (nullable): An indices of the desired
  * ordering of the original dimensions, defined as an array. This must be `NULL` or the

--- a/c_glib/arrow-glib/basic-data-type.h
+++ b/c_glib/arrow-glib/basic-data-type.h
@@ -802,4 +802,21 @@ GARROW_AVAILABLE_IN_19_0
 GArrowStringViewDataType *
 garrow_string_view_data_type_new(void);
 
+#define GARROW_TYPE_FIXED_SHAPE_TENSOR_DATA_TYPE                                         \
+  (garrow_fixed_shape_tensor_data_type_get_type())
+GARROW_AVAILABLE_IN_21_0
+G_DECLARE_DERIVABLE_TYPE(GArrowFixedShapeTensorDataType,
+                         garrow_fixed_shape_tensor_data_type,
+                         GARROW,
+                         FIXED_SHAPE_TENSOR_DATA_TYPE,
+                         GArrowExtensionDataType)
+struct _GArrowFixedShapeTensorDataTypeClass
+{
+  GArrowExtensionDataTypeClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_21_0
+GArrowFixedShapeTensorDataType *
+garrow_fixed_shape_tensor_data_type_new(void);
+
 G_END_DECLS

--- a/c_glib/arrow-glib/basic-data-type.h
+++ b/c_glib/arrow-glib/basic-data-type.h
@@ -817,6 +817,12 @@ struct _GArrowFixedShapeTensorDataTypeClass
 
 GARROW_AVAILABLE_IN_21_0
 GArrowFixedShapeTensorDataType *
-garrow_fixed_shape_tensor_data_type_new(void);
+garrow_fixed_shape_tensor_data_type_new(GArrowDataType *value_type,
+                                        gint32 size,
+                                        gint32 psize,
+                                        const gint64 *shape,
+                                        const gint64 *permutation,
+                                        const gchar **dim_name,
+                                        GError **error);
 
 G_END_DECLS

--- a/c_glib/arrow-glib/basic-data-type.h
+++ b/c_glib/arrow-glib/basic-data-type.h
@@ -818,11 +818,12 @@ struct _GArrowFixedShapeTensorDataTypeClass
 GARROW_AVAILABLE_IN_21_0
 GArrowFixedShapeTensorDataType *
 garrow_fixed_shape_tensor_data_type_new(GArrowDataType *value_type,
-                                        gint32 size,
-                                        gint32 psize,
                                         const gint64 *shape,
+                                        gint32 shape_length,
                                         const gint64 *permutation,
-                                        const gchar **dim_name,
+                                        gint32 permutation_length,
+                                        const gchar **dim_names,
+                                        gint32 n_dim_names,
                                         GError **error);
 
 G_END_DECLS

--- a/c_glib/arrow-glib/basic-data-type.h
+++ b/c_glib/arrow-glib/basic-data-type.h
@@ -819,11 +819,11 @@ GARROW_AVAILABLE_IN_21_0
 GArrowFixedShapeTensorDataType *
 garrow_fixed_shape_tensor_data_type_new(GArrowDataType *value_type,
                                         const gint64 *shape,
-                                        gint32 shape_length,
+                                        gsize shape_length,
                                         const gint64 *permutation,
-                                        gint32 permutation_length,
+                                        gsize permutation_length,
                                         const gchar **dim_names,
-                                        gint32 n_dim_names,
+                                        gsize n_dim_names,
                                         GError **error);
 
 G_END_DECLS

--- a/c_glib/test/test-fixed-shape-tensor-data-type.rb
+++ b/c_glib/test/test-fixed-shape-tensor-data-type.rb
@@ -18,26 +18,65 @@
 class TestFixedShapeTensorDataType < Test::Unit::TestCase
   def test_type
     data_type = Arrow::FixedShapeTensorDataType.new(Arrow::UInt64DataType.new,
-                                                    [3,4],
-                                                    [],
-                                                    ["x","y"])
+                                                    [3, 4],
+                                                    [1, 0],
+                                                    ["x", "y"])
     assert_equal(Arrow::Type::EXTENSION, data_type.id)
   end
 
   def test_name
     data_type = Arrow::FixedShapeTensorDataType.new(Arrow::UInt64DataType.new,
-                                                    [3,4],
-                                                    [],
-                                                    ["x","y"])
+                                                    [3, 4],
+                                                    [1, 0],
+                                                    ["x", "y"])
     assert_equal("extension", data_type.name)
     assert_equal("arrow.fixed_shape_tensor", data_type.extension_name)
   end
 
   def test_to_s
     data_type = Arrow::FixedShapeTensorDataType.new(Arrow::UInt64DataType.new,
-                                                    [3,4],
-                                                    [],
-                                                    ["x","y"])
+                                                    [3, 4],
+                                                    [1, 0],
+                                                    ["x", "y"])
     assert_true(data_type.to_s.start_with?("extension<arrow.fixed_shape_tensor"))
   end
+
+  def test_empty_shape
+    data_type = Arrow::FixedShapeTensorDataType.new(Arrow::UInt64DataType.new,
+                                                    [],
+                                                    [],
+                                                    [])
+    assert_equal(Arrow::Type::EXTENSION, data_type.id)
+  end
+
+  def test_mismatch_permutation_size
+    message =
+      "[fixed-shape-tensor][new]: Invalid: " +
+      "permutation size must match shape size. " +
+      "Expected: 2 Got: 1"
+    error = assert_raise(Arrow::Error::Invalid) do
+      Arrow::FixedShapeTensorDataType.new(Arrow::UInt64DataType.new,
+                                          [3, 4],
+                                          [1],
+                                          ["x", "y"])
+    end
+    assert_equal(message,
+                 error.message.lines.first.chomp)
+  end
+
+  def test_mismatch_dim_names_size
+    message =
+      "[fixed-shape-tensor][new]: Invalid: " +
+      "dim_names size must match shape size. " +
+      "Expected: 2 Got: 1"
+    error = assert_raise(Arrow::Error::Invalid) do
+      Arrow::FixedShapeTensorDataType.new(Arrow::UInt64DataType.new,
+                                          [3, 4],
+                                          [],
+                                          ["x"])
+    end
+    assert_equal(message,
+                 error.message.lines.first.chomp)
+  end
+
 end

--- a/c_glib/test/test-fixed-shape-tensor-data-type.rb
+++ b/c_glib/test/test-fixed-shape-tensor-data-type.rb
@@ -57,6 +57,7 @@ class TestFixedShapeTensorDataType < Test::Unit::TestCase
                                                     [3, 4],
                                                     [0, 1],
                                                     nil)
+    # TODO: Use Arrow::FixedShapeTensorDataType#dim_names
     assert_equal(Arrow::Type::EXTENSION, data_type.id)
   end
 

--- a/c_glib/test/test-fixed-shape-tensor-data-type.rb
+++ b/c_glib/test/test-fixed-shape-tensor-data-type.rb
@@ -17,18 +17,27 @@
 
 class TestFixedShapeTensorDataType < Test::Unit::TestCase
   def test_type
-    data_type = Arrow::FixedShapeTensorDataType.new(Arrow::UInt64DataType.new,[3,4],[],["x","y"])
+    data_type = Arrow::FixedShapeTensorDataType.new(Arrow::UInt64DataType.new,
+                                                    [3,4],
+                                                    [],
+                                                    ["x","y"])
     assert_equal(Arrow::Type::EXTENSION, data_type.id)
   end
 
   def test_name
-    data_type = Arrow::FixedShapeTensorDataType.new(Arrow::UInt64DataType.new,[3,4],[],["x","y"])
+    data_type = Arrow::FixedShapeTensorDataType.new(Arrow::UInt64DataType.new,
+                                                    [3,4],
+                                                    [],
+                                                    ["x","y"])
     assert_equal("extension", data_type.name)
     assert_equal("arrow.fixed_shape_tensor", data_type.extension_name)
   end
 
   def test_to_s
-    data_type = Arrow::FixedShapeTensorDataType.new(Arrow::UInt64DataType.new,[3,4],[],["x","y"])
+    data_type = Arrow::FixedShapeTensorDataType.new(Arrow::UInt64DataType.new,
+                                                    [3,4],
+                                                    [],
+                                                    ["x","y"])
     assert_true(data_type.to_s.start_with?("extension<arrow.fixed_shape_tensor"))
   end
 end

--- a/c_glib/test/test-fixed-shape-tensor-data-type.rb
+++ b/c_glib/test/test-fixed-shape-tensor-data-type.rb
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestFixedShapeTensorDataType < Test::Unit::TestCase
+  def test_type
+    data_type = Arrow::FixedShapeTensorDataType.new
+    assert_equal(Arrow::Type::EXTENSION, data_type.id)
+  end
+
+  def test_name
+    data_type = Arrow::FixedShapeTensorDataType.new
+    assert_equal("extension", data_type.name)
+    assert_equal("arrow.fixed_shape_tensor", data_type.extension_name)
+  end
+
+  # extension<arrow.fixed_shape_tensor[value_type=int64, shape=[]]>"
+  def test_to_s
+    data_type = Arrow::FixedShapeTensorDataType.new
+    assert_true(data_type.to_s.start_with?("extension<arrow.fixed_shape_tensor"))
+  end
+end

--- a/c_glib/test/test-fixed-shape-tensor-data-type.rb
+++ b/c_glib/test/test-fixed-shape-tensor-data-type.rb
@@ -16,7 +16,7 @@
 # under the License.
 
 class TestFixedShapeTensorDataType < Test::Unit::TestCase
-  def test_type
+  def test_id
     data_type = Arrow::FixedShapeTensorDataType.new(Arrow::UInt64DataType.new,
                                                     [3, 4],
                                                     [1, 0],
@@ -41,14 +41,6 @@ class TestFixedShapeTensorDataType < Test::Unit::TestCase
     assert do
       data_type.to_s.start_with?("extension<arrow.fixed_shape_tensor")
     end
-  end
-
-  def test_empty_shape
-    data_type = Arrow::FixedShapeTensorDataType.new(Arrow::UInt64DataType.new,
-                                                    [],
-                                                    [],
-                                                    [])
-    assert_equal(Arrow::Type::EXTENSION, data_type.id)
   end
 
   def test_nil_permutation
@@ -96,5 +88,4 @@ class TestFixedShapeTensorDataType < Test::Unit::TestCase
     assert_equal(message,
                  error.message.lines.first.chomp)
   end
-
 end

--- a/c_glib/test/test-fixed-shape-tensor-data-type.rb
+++ b/c_glib/test/test-fixed-shape-tensor-data-type.rb
@@ -48,6 +48,7 @@ class TestFixedShapeTensorDataType < Test::Unit::TestCase
                                                     [3, 4],
                                                     nil,
                                                     ["x", "y"])
+    # TODO: Use Arrow::FixedShapeTensorDataType#permutation
     assert_equal(Arrow::Type::EXTENSION, data_type.id)
   end
 

--- a/c_glib/test/test-fixed-shape-tensor-data-type.rb
+++ b/c_glib/test/test-fixed-shape-tensor-data-type.rb
@@ -38,7 +38,9 @@ class TestFixedShapeTensorDataType < Test::Unit::TestCase
                                                     [3, 4],
                                                     [1, 0],
                                                     ["x", "y"])
-    assert_true(data_type.to_s.start_with?("extension<arrow.fixed_shape_tensor"))
+    assert do
+      data_type.to_s.start_with?("extension<arrow.fixed_shape_tensor")
+    end
   end
 
   def test_empty_shape

--- a/c_glib/test/test-fixed-shape-tensor-data-type.rb
+++ b/c_glib/test/test-fixed-shape-tensor-data-type.rb
@@ -29,8 +29,8 @@ class TestFixedShapeTensorDataType < Test::Unit::TestCase
                                                     [3, 4],
                                                     [1, 0],
                                                     ["x", "y"])
-    assert_equal("extension", data_type.name)
-    assert_equal("arrow.fixed_shape_tensor", data_type.extension_name)
+    assert_equal(["extension", "arrow.fixed_shape_tensor"],
+                 [data_type.name, data_type.extension_name])
   end
 
   def test_to_s

--- a/c_glib/test/test-fixed-shape-tensor-data-type.rb
+++ b/c_glib/test/test-fixed-shape-tensor-data-type.rb
@@ -49,6 +49,22 @@ class TestFixedShapeTensorDataType < Test::Unit::TestCase
     assert_equal(Arrow::Type::EXTENSION, data_type.id)
   end
 
+  def test_nil_permutation
+    data_type = Arrow::FixedShapeTensorDataType.new(Arrow::UInt64DataType.new,
+                                                    [3, 4],
+                                                    nil,
+                                                    ["x", "y"])
+    assert_equal(Arrow::Type::EXTENSION, data_type.id)
+  end
+
+  def test_nil_dim_names
+    data_type = Arrow::FixedShapeTensorDataType.new(Arrow::UInt64DataType.new,
+                                                    [3, 4],
+                                                    [0, 1],
+                                                    nil)
+    assert_equal(Arrow::Type::EXTENSION, data_type.id)
+  end
+
   def test_mismatch_permutation_size
     message =
       "[fixed-shape-tensor][new]: Invalid: " +

--- a/c_glib/test/test-fixed-shape-tensor-data-type.rb
+++ b/c_glib/test/test-fixed-shape-tensor-data-type.rb
@@ -17,19 +17,18 @@
 
 class TestFixedShapeTensorDataType < Test::Unit::TestCase
   def test_type
-    data_type = Arrow::FixedShapeTensorDataType.new
+    data_type = Arrow::FixedShapeTensorDataType.new(Arrow::UInt64DataType.new,[3,4],[],["x","y"])
     assert_equal(Arrow::Type::EXTENSION, data_type.id)
   end
 
   def test_name
-    data_type = Arrow::FixedShapeTensorDataType.new
+    data_type = Arrow::FixedShapeTensorDataType.new(Arrow::UInt64DataType.new,[3,4],[],["x","y"])
     assert_equal("extension", data_type.name)
     assert_equal("arrow.fixed_shape_tensor", data_type.extension_name)
   end
 
-  # extension<arrow.fixed_shape_tensor[value_type=int64, shape=[]]>"
   def test_to_s
-    data_type = Arrow::FixedShapeTensorDataType.new
+    data_type = Arrow::FixedShapeTensorDataType.new(Arrow::UInt64DataType.new,[3,4],[],["x","y"])
     assert_true(data_type.to_s.start_with?("extension<arrow.fixed_shape_tensor"))
   end
 end


### PR DESCRIPTION
### Rationale for this change

The C++ API implemented FixedShapeTensor Extension DataType. GLib was not yet supported.

### What changes are included in this PR?

Implement GArrowFixedShapeTensorDataType.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #35419