### PR TITLE
GH-46306: [C++][Parquet] Should use LoadEnumSafe for geo enum

### DIFF
--- a/cpp/src/parquet/thrift_internal.h
+++ b/cpp/src/parquet/thrift_internal.h
@@ -309,25 +309,6 @@ static inline format::EdgeInterpolationAlgorithm::type ToThrift(
   }
 }
 
-static inline LogicalType::EdgeInterpolationAlgorithm FromThrift(
-    const format::EdgeInterpolationAlgorithm::type algorithm) {
-  switch (algorithm) {
-    case format::EdgeInterpolationAlgorithm::SPHERICAL:
-      return LogicalType::EdgeInterpolationAlgorithm::SPHERICAL;
-    case format::EdgeInterpolationAlgorithm::VINCENTY:
-      return LogicalType::EdgeInterpolationAlgorithm::VINCENTY;
-    case format::EdgeInterpolationAlgorithm::THOMAS:
-      return LogicalType::EdgeInterpolationAlgorithm::THOMAS;
-    case format::EdgeInterpolationAlgorithm::ANDOYER:
-      return LogicalType::EdgeInterpolationAlgorithm::ANDOYER;
-    case format::EdgeInterpolationAlgorithm::KARNEY:
-      return LogicalType::EdgeInterpolationAlgorithm::KARNEY;
-    default:
-      throw ParquetException("Unknown value for geometry algorithm: ",
-                             static_cast<int>(algorithm));
-  }
-}
-
 static inline EncryptionAlgorithm FromThrift(format::EncryptionAlgorithm encryption) {
   EncryptionAlgorithm encryption_algorithm;
 

--- a/cpp/src/parquet/thrift_internal.h
+++ b/cpp/src/parquet/thrift_internal.h
@@ -106,6 +106,25 @@ static inline BoundaryOrder::type FromThriftUnsafe(format::BoundaryOrder::type t
   return static_cast<BoundaryOrder::type>(type);
 }
 
+static inline GeometryLogicalType::EdgeInterpolationAlgorithm FromThriftUnsafe(
+    format::EdgeInterpolationAlgorithm::type type) {
+  switch (type) {
+    case format::EdgeInterpolationAlgorithm::SPHERICAL:
+      return GeometryLogicalType::EdgeInterpolationAlgorithm::SPHERICAL;
+    case format::EdgeInterpolationAlgorithm::VINCENTY:
+      return GeometryLogicalType::EdgeInterpolationAlgorithm::VINCENTY;
+    case format::EdgeInterpolationAlgorithm::THOMAS:
+      return GeometryLogicalType::EdgeInterpolationAlgorithm::THOMAS;
+    case format::EdgeInterpolationAlgorithm::ANDOYER:
+      return GeometryLogicalType::EdgeInterpolationAlgorithm::ANDOYER;
+    case format::EdgeInterpolationAlgorithm::KARNEY:
+      return GeometryLogicalType::EdgeInterpolationAlgorithm::KARNEY;
+    default:
+      ARROW_DCHECK(false) << "Cannot reach here";
+      return GeometryLogicalType::EdgeInterpolationAlgorithm::UNKNOWN;
+  }
+}
+
 namespace internal {
 
 template <typename T>
@@ -217,6 +236,15 @@ inline typename Compression::type LoadEnumSafe(const format::CompressionCodec::t
       static_cast<decltype(raw_value)>(format::CompressionCodec::LZ4_RAW);
   if (raw_value < min_value || raw_value > max_value) {
     return Compression::UNCOMPRESSED;
+  }
+  return FromThriftUnsafe(*in);
+}
+
+inline typename LogicalType::EdgeInterpolationAlgorithm LoadEnumSafe(
+    const format::EdgeInterpolationAlgorithm::type* in) {
+  if (ARROW_PREDICT_FALSE(*in < format::EdgeInterpolationAlgorithm::SPHERICAL ||
+                          *in > format::EdgeInterpolationAlgorithm::KARNEY)) {
+    return LogicalType::EdgeInterpolationAlgorithm::UNKNOWN;
   }
   return FromThriftUnsafe(*in);
 }

--- a/cpp/src/parquet/types.cc
+++ b/cpp/src/parquet/types.cc
@@ -501,7 +501,7 @@ std::shared_ptr<const LogicalType> LogicalType::FromThrift(
     if (!type.GEOGRAPHY.__isset.algorithm) {
       algorithm = LogicalType::EdgeInterpolationAlgorithm::SPHERICAL;
     } else {
-      algorithm = ::parquet::FromThrift(type.GEOGRAPHY.algorithm);
+      algorithm = LoadEnumSafe(&type.GEOGRAPHY.algorithm);
     }
 
     return GeographyLogicalType::Make(std::move(crs), algorithm);


### PR DESCRIPTION
### Rationale for this change

OSS-Fuzz reports an error about loading unknown enum.

### What changes are included in this PR?

Add LoadEnumSafe for geo enum

### Are these changes tested?

Covered by existing

### Are there any user-facing changes?

no

* GitHub Issue: #46306