### PR TITLE
GH-46310: [C++] Clean up -Wself-move warning

### DIFF
--- a/cpp/cmake_modules/SetupCxxFlags.cmake
+++ b/cpp/cmake_modules/SetupCxxFlags.cmake
@@ -318,6 +318,7 @@ if("${BUILD_WARNING_LEVEL}" STREQUAL "CHECKIN")
     set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wdate-time")
     set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wimplicit-fallthrough")
     string(APPEND CXX_ONLY_FLAGS " -Wredundant-move")
+    string(APPEND CXX_ONLY_FLAGS " -Wself-move")
     set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wunused-result")
   elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Intel" OR CMAKE_CXX_COMPILER_ID STREQUAL
                                                    "IntelLLVM")

--- a/cpp/src/arrow/util/small_vector_test.cc
+++ b/cpp/src/arrow/util/small_vector_test.cc
@@ -412,11 +412,6 @@ class TestSmallStaticVector : public ::testing::Test {
     IntVectorType<N> moved_moved_ints = std::move(moved_ints);
     ASSERT_EQ(moved_moved_ints.size(), 5);
     EXPECT_THAT(moved_moved_ints, ElementsAre(4, 5, 6, 7, 8));
-
-    // Move into itself
-    moved_moved_ints = std::move(moved_moved_ints);
-    ASSERT_EQ(moved_moved_ints.size(), 5);
-    EXPECT_THAT(moved_moved_ints, ElementsAre(4, 5, 6, 7, 8));
   }
 
   void TestMove() {


### PR DESCRIPTION
### Rationale for this change

This cleans up code that generates compiler warnings and relies on undefined behavior

### What changes are included in this PR?

Removal of self-move in the test suite

### Are these changes tested?

Yes

### Are there any user-facing changes?

No
* GitHub Issue: #46310