### PR TITLE
GH-46318: [Docs][C++] Add Extension Array/Type documents

### DIFF
--- a/docs/source/cpp/api.rst
+++ b/docs/source/cpp/api.rst
@@ -45,3 +45,4 @@ API Reference
    api/flightsql
    api/filesystem
    api/dataset
+   api/extension

--- a/docs/source/cpp/api.rst
+++ b/docs/source/cpp/api.rst
@@ -27,6 +27,7 @@ API Reference
    api/thread
    api/datatype
    api/array
+   api/extension
    api/scalar
    api/builder
    api/table
@@ -45,4 +46,3 @@ API Reference
    api/flightsql
    api/filesystem
    api/dataset
-   api/extension

--- a/docs/source/cpp/api/extension.rst
+++ b/docs/source/cpp/api/extension.rst
@@ -1,0 +1,63 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+.. or more contributor license agreements.  See the NOTICE file
+.. distributed with this work for additional information
+.. regarding copyright ownership.  The ASF licenses this file
+.. to you under the Apache License, Version 2.0 (the
+.. "License"); you may not use this file except in compliance
+.. with the License.  You may obtain a copy of the License at
+
+..   http://www.apache.org/licenses/LICENSE-2.0
+
+.. Unless required by applicable law or agreed to in writing,
+.. software distributed under the License is distributed on an
+.. "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+.. KIND, either express or implied.  See the License for the
+.. specific language governing permissions and limitations
+.. under the License.
+
+=========
+Extension
+=========
+
+Extension Type classes
+======================
+
+.. doxygenclass:: arrow::extension::Bool8Type
+   :project: arrow_cpp
+   :members:
+
+.. doxygenclass:: arrow::extension::FixedShapeTensorType
+   :project: arrow_cpp
+   :members:
+
+.. doxygenclass:: arrow::extension::OpaqueType
+   :project: arrow_cpp
+   :members:
+
+.. doxygenclass:: arrow::extension::JsonExtensionType
+   :project: arrow_cpp
+   :members:
+
+.. doxygenclass:: arrow::extension::UuidType
+   :project: arrow_cpp
+   :members:
+
+Extension Array classes
+=======================
+
+.. doxygenclass:: arrow::extension::Bool8Array
+   :project: arrow_cpp
+   :members:
+
+.. doxygenclass:: arrow::extension::FixedShapeTensorArray
+   :project: arrow_cpp
+   :members:
+
+.. doxygenclass:: arrow::extension::OpaqueArray
+   :project: arrow_cpp
+   :members:
+
+.. doxygenclass:: arrow::extension::UuidArray
+   :project: arrow_cpp
+   :members:
+


### PR DESCRIPTION
### Rationale for this change

There are no Extension Array/Type documentation in the [API Reference page](https://arrow.apache.org/docs/cpp/api.html).

### What changes are included in this PR?

Add Extension Array / Type API documents.

### Are these changes tested?

No. (Add document only)

### Are there any user-facing changes?

No.
* GitHub Issue: #46318