### PR TITLE
GH-46314: [C++][Parquet] Fix valgrind error when collecting parameterized tests for MakeWKBPoint

### DIFF
--- a/cpp/src/parquet/geospatial/util_internal_test.cc
+++ b/cpp/src/parquet/geospatial/util_internal_test.cc
@@ -507,14 +507,14 @@ INSTANTIATE_TEST_SUITE_P(
 
 struct MakeWKBPointTestCase {
   std::vector<double> xyzm;
-  bool has_z;
-  bool has_m;
+  bool has_z{};
+  bool has_m{};
 };
 
 class MakeWKBPointTestFixture : public testing::TestWithParam<MakeWKBPointTestCase> {};
 
 TEST_P(MakeWKBPointTestFixture, MakeWKBPoint) {
-  auto param = GetParam();
+  const auto& param = GetParam();
   std::string wkb = test::MakeWKBPoint(param.xyzm, param.has_z, param.has_m);
   WKBGeometryBounder bounder;
   ASSERT_NO_THROW(bounder.MergeGeometry(wkb));

--- a/cpp/src/parquet/geospatial/util_internal_test.cc
+++ b/cpp/src/parquet/geospatial/util_internal_test.cc
@@ -511,6 +511,11 @@ struct MakeWKBPointTestCase {
   bool has_m{};
 };
 
+std::ostream& operator<<(std::ostream& os, const MakeWKBPointTestCase& obj) {
+  os << "MakeWKBPointTestCase<has_z=" << obj.has_z << ", has_m=" << obj.has_m << ">";
+  return os;
+}
+
 class MakeWKBPointTestFixture : public testing::TestWithParam<MakeWKBPointTestCase> {};
 
 TEST_P(MakeWKBPointTestFixture, MakeWKBPoint) {


### PR DESCRIPTION
### Rationale for this change

The nightlies for valgrind report a use of an uninitialized value around MakeWKBPointTestCase.

### What changes are included in this PR?

A custom printer was added for the test case. I believe the sanitizer error was occurring because the bytes of the std::vector were being printed (and may not have been initialized yet).

### Are these changes tested?

Yes

### Are there any user-facing changes?

No!

* GitHub Issue: #46314