### PR TITLE
GH-46326: [C++][Parquet] Fix stack overflow in rapidjson value comparison to integer

### DIFF
--- a/cpp/src/parquet/geospatial/util_json_internal.cc
+++ b/cpp/src/parquet/geospatial/util_json_internal.cc
@@ -61,7 +61,8 @@ namespace {
           return "";
         } else if (identifier["authority"] == "EPSG" && identifier["code"] == "4326") {
           return "";
-        } else if (identifier["authority"] == "EPSG" && identifier["code"] == 4326) {
+        } else if (identifier["authority"] == "EPSG" && identifier["code"].IsInt() &&
+                   identifier["code"].GetInt() == 4326) {
           return "";
         }
       }


### PR DESCRIPTION
### Rationale for this change

test-ubuntu-22.04-cpp-20 nightly is failing with a segfault in the ParquetGeoArrowCrsLonLat test.

### What changes are included in this PR?

The integer comparison is updated to be more explicit such that it doesn't trigger the code path in rapidjson that results in unterminated recrusion.

### Are these changes tested?

Yes

### Are there any user-facing changes?

No!

* GitHub Issue: #46326