### PR TITLE
GH-46333: [CI] Explicitly pass `--yes` to `mamba clean`

### DIFF
--- a/ci/docker/conda-integration.dockerfile
+++ b/ci/docker/conda-integration.dockerfile
@@ -40,7 +40,7 @@ RUN mamba install -q -y \
         yarn=${yarn} \
         openjdk=${jdk} \
         zstd && \
-    mamba clean --all --force-pkgs-dirs
+    mamba clean --yes --all --force-pkgs-dirs
 
 # Install Rust with only the needed components
 # (rustfmt is needed for tonic-build to compile the protobuf definitions)


### PR DESCRIPTION
### Rationale for this change

CI is broken across multiple Arrow repos.

### What changes are included in this PR?

Explicitly pass `--yes` to `mamba clean`.

### Are these changes tested?

Yes

### Are there any user-facing changes?
No.

* GitHub Issue: #46333