### PR TITLE
GH-46338: [C++] Add compile step for Meson in cpp_build.sh

### DIFF
--- a/ci/scripts/cpp_build.sh
+++ b/ci/scripts/cpp_build.sh
@@ -282,13 +282,13 @@ else
     ${source_dir}
 fi
 
+: ${ARROW_BUILD_PARALLEL:=$[${n_jobs} + 1]}
 if [ "${ARROW_USE_MESON:-OFF}" = "ON" ]; then
-    time {
-      meson compile -j $[${n_jobs} + 1];
-      meson install;
-  }
+  time meson compile -j ${ARROW_BUILD_PARALLEL}
+  meson install
 else
-  export CMAKE_BUILD_PARALLEL_LEVEL=${CMAKE_BUILD_PARALLEL_LEVEL:-$[${n_jobs} + 1]}
+  : ${CMAKE_BUILD_PARALLEL_LEVEL:=${ARROW_BUILD_PARALLEL}}
+  export CMAKE_BUILD_PARALLEL_LEVEL
   time cmake --build . --target install
 fi
 

--- a/ci/scripts/cpp_build.sh
+++ b/ci/scripts/cpp_build.sh
@@ -283,7 +283,10 @@ else
 fi
 
 if [ "${ARROW_USE_MESON:-OFF}" = "ON" ]; then
-  time meson install
+    time {
+      meson compile -j $[${n_jobs} + 1];
+      meson install;
+  }
 else
   export CMAKE_BUILD_PARALLEL_LEVEL=${CMAKE_BUILD_PARALLEL_LEVEL:-$[${n_jobs} + 1]}
   time cmake --build . --target install


### PR DESCRIPTION
### Rationale for this change

This makes it possible to control the number of jobs used with Meson in the cpp_build.sh script

### What changes are included in this PR?

Updates to cpp_build.sh

### Are these changes tested?

Yes

### Are there any user-facing changes?

No
* GitHub Issue: #46338