### PR TITLE
GH-46333: [CI] Always pass `--yes` to `mamba clean`

### DIFF
--- a/ci/docker/conda-cpp.dockerfile
+++ b/ci/docker/conda-cpp.dockerfile
@@ -38,7 +38,7 @@ RUN mamba install -q -y \
         libnuma \
         python=${python} \
         valgrind && \
-    mamba clean --all
+    mamba clean --all --yes
 
 # We want to install the GCS testbench using the Conda base environment's Python,
 # because the test environment's Python may later change.

--- a/ci/docker/conda-python-cpython-debug.dockerfile
+++ b/ci/docker/conda-python-cpython-debug.dockerfile
@@ -23,6 +23,6 @@ FROM ${repo}:${arch}-conda-python-${python}
 # (Docker oddity: ARG needs to be repeated after FROM)
 ARG python=3.9
 RUN mamba install -y "conda-forge/label/python_debug::python=${python}[build=*_cpython]" && \
-    mamba clean --all
+    mamba clean --all --yes
 # Quick check that we do have a debug mode CPython
 RUN python -c "import sys; sys.gettotalrefcount()"

--- a/ci/docker/conda-python-hdfs.dockerfile
+++ b/ci/docker/conda-python-hdfs.dockerfile
@@ -26,7 +26,7 @@ RUN mamba install -q -y \
         maven=${maven} \
         openjdk=${jdk} \
         pandas && \
-    mamba clean --all
+    mamba clean --all --yes
 
 # installing libhdfs (JNI)
 ARG hdfs=3.2.1

--- a/ci/docker/conda-python-jpype.dockerfile
+++ b/ci/docker/conda-python-jpype.dockerfile
@@ -26,4 +26,4 @@ RUN mamba install -q -y \
         maven=${maven} \
         openjdk=${jdk} \
         jpype1 && \
-    mamba clean --all
+    mamba clean --all --yes

--- a/ci/docker/conda-python-pandas.dockerfile
+++ b/ci/docker/conda-python-pandas.dockerfile
@@ -29,7 +29,7 @@ COPY ci/conda_env_sphinx.txt /arrow/ci/
 RUN mamba install -q -y --file arrow/ci/conda_env_sphinx.txt && \
     # We can't install linuxdoc by mamba. We install linuxdoc by pip here.
     pip install linuxdoc && \
-    mamba clean --all
+    mamba clean --all --yes
 
 COPY ci/scripts/install_pandas.sh /arrow/ci/scripts/
 RUN mamba uninstall -q -y numpy && \

--- a/ci/docker/conda-python-spark.dockerfile
+++ b/ci/docker/conda-python-spark.dockerfile
@@ -30,7 +30,7 @@ RUN mamba install -q -y \
         openjdk=${jdk} \
         maven=${maven} \
         pandas && \
-    mamba clean --all && \
+    mamba clean --all --yes && \
     mamba uninstall -q -y numpy && \
     /arrow/ci/scripts/install_numpy.sh ${numpy}
 

--- a/ci/docker/conda-python.dockerfile
+++ b/ci/docker/conda-python.dockerfile
@@ -30,7 +30,7 @@ RUN mamba install -q -y \
         $([ "$python" == $(gdb --batch --eval-command 'python import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")') ] && echo "gdb") \
         "python=${python}.*=*_cp*" \
         nomkl && \
-    mamba clean --all
+    mamba clean --all --yes
 
 ENV ARROW_ACERO=ON \
     ARROW_BUILD_STATIC=OFF \

--- a/ci/docker/conda.dockerfile
+++ b/ci/docker/conda.dockerfile
@@ -38,7 +38,7 @@ ENV PATH=/opt/conda/bin:$PATH
 # create a conda environment
 ADD ci/conda_env_unix.txt /arrow/ci/
 RUN mamba create -n arrow --file arrow/ci/conda_env_unix.txt git && \
-    mamba clean --all
+    mamba clean --all --yes
 
 # activate the created environment by default
 RUN echo "conda activate arrow" >> ~/.profile


### PR DESCRIPTION
### Rationale for this change

Some CI builds can get stuck before `mamba clean` is asking for confirmation. See example here:
https://github.com/apache/arrow/actions/runs/14855669693/job/41708331720?pr=46332

This might depend on the Mamba version and whether it implements TTY detection reliably.

### What changes are included in this PR?

Always pass `--yes` to `mamba clean`.

### Are these changes tested?

Yes, by definition.

### Are there any user-facing changes?

No.
* GitHub Issue: #46333