### PR TITLE
GH-46336: [Release][Packaging] Add support for Reproducible Builds for source archive

### DIFF
--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt update
-          sudo apt install -y -V reprotest
+          sudo apt install -y -V gpg reprotest
       - name: Store Version and Release Candidate Number
         run: |
           if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
@@ -81,12 +81,22 @@ jobs:
           release_notes="Release Candidate: ${VERSION} RC${RC_NUM}"
           echo "RELEASE_CANDIDATE_NOTES=${release_notes}" >> ${GITHUB_ENV}
       - name: Create Release tarball
+        env:
+          ARROW_GPG_KEY_UID: A2AC7132B5DA7C273A7A147665F4A8CA9769ECD7
+          ARROW_GPG_SECRET_KEY: ${{ secrets.ARROW_GPG_SECRET_KEY }}
         run: |
           sudo reprotest \
             "dev/release/utils-create-release-tarball.sh ${VERSION} ${RC_NUM}" \
             apache-arrow-${VERSION}.tar.gz
           dev/release/utils-create-release-tarball.sh ${VERSION} ${RC_NUM}
           echo "RELEASE_TARBALL=apache-arrow-${VERSION}.tar.gz" >> ${GITHUB_ENV}
+          echo "${ARROW_GPG_SECRET_KEY}" | gpg --import
+          gpg \
+            --armor \
+            --detach-sign \
+            --local-user "${ARROW_GPG_SECRET_KEY}" \
+            --output "${RELEASE_TARBALL}.asc" \
+            "${RELEASE_TARBALL}"
           dev/release/utils-generate-checksum.sh "apache-arrow-${VERSION}.tar.gz"
       - name: Upload Artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -90,14 +90,16 @@ jobs:
             apache-arrow-${VERSION}.tar.gz
           dev/release/utils-create-release-tarball.sh ${VERSION} ${RC_NUM}
           echo "RELEASE_TARBALL=apache-arrow-${VERSION}.tar.gz" >> ${GITHUB_ENV}
-          echo "${ARROW_GPG_SECRET_KEY}" | gpg --import
-          gpg \
-            --armor \
-            --detach-sign \
-            --local-user "${ARROW_GPG_SECRET_KEY}" \
-            --output "${RELEASE_TARBALL}.asc" \
-            "${RELEASE_TARBALL}"
           dev/release/utils-generate-checksum.sh "apache-arrow-${VERSION}.tar.gz"
+          if [ -n "${ARROW_GPG_SECRET_KEY}" ]; then
+            echo "${ARROW_GPG_SECRET_KEY}" | gpg --import
+            gpg \
+              --armor \
+              --detach-sign \
+              --local-user "${ARROW_GPG_SECRET_KEY}" \
+              --output "${RELEASE_TARBALL}.asc" \
+              "${RELEASE_TARBALL}"
+          fi
       - name: Upload Artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:

--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -19,16 +19,25 @@ name: Release
 
 on:
   push:
+    branches:
+      - '**'
+      - '!dependabot/**'
     tags:
       # Trigger workflow when a tag whose name matches the pattern
       # "apache-arrow-{MAJOR}.{MINOR}.{PATCH}-rc{RC_NUM}" is pushed.
       - "apache-arrow-[0-9]+.[0-9]+.[0-9]+-rc[0-9]+"
+    paths:
+      - ".github/workflows/release_candidate.sh"
+      - "dev/release/utils-create-release-tarball.sh"
+      - "dev/release/utils-generate-checksum.sh"
+  pull_request:
+    paths:
+      - ".github/workflows/release_candidate.sh"
+      - "dev/release/utils-create-release-tarball.sh"
+      - "dev/release/utils-generate-checksum.sh"
 
 permissions:
   contents: write
-
-env:
-  GH_TOKEN: ${{ github.token }}
 
 jobs:
   publish:
@@ -40,12 +49,27 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y -V reprotest
       - name: Store Version and Release Candidate Number
         run: |
-          version_with_rc=${GITHUB_REF_NAME#apache-arrow-}
-          version=${version_with_rc%-rc*}
-          rc_num=${version_with_rc#${version}-rc}
-          echo "VERSION_WITH_RC=${version_with_rc}" >> ${GITHUB_ENV}
+          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            version_with_rc=${GITHUB_REF_NAME#apache-arrow-}
+            version=${version_with_rc%-rc*}
+            rc_num=${version_with_rc#${version}-rc}
+          else
+            version=$(grep '^set(ARROW_VERSION ' cpp/CMakeLists.txt | \
+                        grep -E -o '[0-9]+\.[0-9]+\.[0-9]+')
+            rc_num=0
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git tag \
+              -a \
+              "apache-arrow-${version}-rc${rc_num}" \
+              -m "Apache Arrow ${version} RC${rc_num}"
+          fi
           echo "VERSION=${version}" >> ${GITHUB_ENV}
           echo "RC_NUM=${rc_num}" >> ${GITHUB_ENV}
       - name: Create Release Candidate Title
@@ -58,10 +82,22 @@ jobs:
           echo "RELEASE_CANDIDATE_NOTES=${release_notes}" >> ${GITHUB_ENV}
       - name: Create Release tarball
         run: |
+          sudo reprotest \
+            "dev/release/utils-create-release-tarball.sh ${VERSION} ${RC_NUM}" \
+            apache-arrow-${VERSION}.tar.gz
           dev/release/utils-create-release-tarball.sh ${VERSION} ${RC_NUM}
           echo "RELEASE_TARBALL=apache-arrow-${VERSION}.tar.gz" >> ${GITHUB_ENV}
           dev/release/utils-generate-checksum.sh "apache-arrow-${VERSION}.tar.gz"
+      - name: Upload Artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: release-candidate
+          path: ${{ env.RELEASE_TARBALL }}*
       - name: Create GitHub Release
+        if: |
+          github.ref_type == 'tag'
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           gh release create ${GITHUB_REF_NAME} \
             --verify-tag \

--- a/dev/release/02-source.sh
+++ b/dev/release/02-source.sh
@@ -75,37 +75,14 @@ if [ ${SOURCE_RAT} -gt 0 ]; then
 fi
 
 if [ ${SOURCE_UPLOAD} -gt 0 ]; then
-  rm -rf signed-artifacts
-  mkdir -p signed-artifacts
-
-  # sign the artifacts
-  for artifact in artifacts/*; do
-    case "${artifact}" in
-      *.sha256|*.sha512)
-        continue
-        ;;
-    esac
-    gpg \
-      --armor \
-      --detach-sig \
-      --output signed-artifacts/$(basename ${artifact}).asc \
-      ${artifact}
-  done
-
-  # Upload signed tarballs to GitHub Release
-  gh release upload ${tag} \
-     --repo "${GITHUB_REPOSITORY}" \
-     signed-artifacts/*
-
   # check out the arrow RC folder
   svn co --depth=empty https://dist.apache.org/repos/dist/dev/arrow tmp
 
   # add the release candidate for the tag
   mkdir -p tmp/${tag}
 
-  # copy the rc tarball into the tmp dir
+  # copy the release candidate tarball and related files into the tmp dir
   cp artifacts/${tarball}* tmp/${tag}
-  cp signed-artifacts/${tarball}.asc tmp/${tag}
 
   # commit to svn
   svn add tmp/${tag}
@@ -113,7 +90,6 @@ if [ ${SOURCE_UPLOAD} -gt 0 ]; then
 
   # clean up
   rm -rf artifacts
-  rm -rf signed-artifacts
   rm -rf tmp
 
   echo "Success! The release candidate is available here:"

--- a/dev/release/utils-create-release-tarball.sh
+++ b/dev/release/utils-create-release-tarball.sh
@@ -85,8 +85,12 @@ touch -t "${csharp_mtime}" ${root_folder}/csharp
 
 # Create new tarball from modified source directory.
 #
+# We need to strip unreproducible information. See also:
+# https://reproducible-builds.org/docs/stripping-unreproducible-information/
+#
 # We need GNU tar for Reproducible Builds. We want to use the same
 # owner, group, mode, file order for Reproducible Builds.
+# See also: https://reproducible-builds.org/docs/archives/
 #
 # gzip --no-name is for omitting timestamp in .gz. It's also for
 # Reproducible Builds.


### PR DESCRIPTION
### Rationale for this change

See https://reproducible-builds.org/ for Reproducible Builds.

Automated Release Signing requires this:
https://infra.apache.org/release-signing.html#automated-release-signing

### What changes are included in this PR?

* Make `dev/release/utils-create-release-tarball.sh` reproducible
* Test it by reprotest: https://salsa.debian.org/reproducible-builds/reprotest
* Verify source archive reproducibility in RC verification script

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #46336