### PR TITLE
GH-46344: [CI][Python] Skip doctest for s3.get_file_info to avoid bucket restrictions

### DIFF
--- a/python/pyarrow/_s3fs.pyx
+++ b/python/pyarrow/_s3fs.pyx
@@ -270,7 +270,7 @@ cdef class S3FileSystem(FileSystem):
     >>> s3 = fs.S3FileSystem(region='us-west-2')
     >>> s3.get_file_info(fs.FileSelector(
     ...    'power-analysis-ready-datastore/power_901_constants.zarr/FROCEAN', recursive=True
-    ... ))
+    ... )) # doctest: +SKIP
     [<FileInfo for 'power-analysis-ready-datastore/power_901_constants.zarr/FROCEAN/.zarray...
 
     For usage of the methods see examples for :func:`~pyarrow.fs.LocalFileSystem`.


### PR DESCRIPTION
### Rationale for this change

The doctest jobs are currently failing due to ACCESS DENIED to the bucket listing.

### What changes are included in this PR?

Skip the doctest.

### Are these changes tested?

Via CI, existing job passes again.

### Are there any user-facing changes?

No

* GitHub Issue: #46344