### PR TITLE
GH-46149: [C++] Opening dataset fails with sshfs-3.7.3 due to F_RDADVISE error

### DIFF
--- a/cpp/src/arrow/io/caching.cc
+++ b/cpp/src/arrow/io/caching.cc
@@ -188,9 +188,12 @@ struct ReadRangeCache::Impl {
       entries = std::move(new_entries);
     }
     // Prefetch immediately, regardless of executor availability, if possible
-    // As this is optimisation only, failures should not be treated as fatal
-    ARROW_UNUSED(file->WillNeed(ranges));
-    return Status::OK();
+    Status st = file->WillNeed(ranges);
+    // As this is optimisation only, I/O failures should not be treated as fatal
+    if (st.IsIOError()) {
+      return Status::OK();
+    }
+    return st;
   }
 
   // Read the given range from the cache, blocking if needed. Cannot read a range

--- a/cpp/src/arrow/io/caching.cc
+++ b/cpp/src/arrow/io/caching.cc
@@ -188,8 +188,8 @@ struct ReadRangeCache::Impl {
       entries = std::move(new_entries);
     }
     // Prefetch immediately, regardless of executor availability, if possible
-    ARROW_UNUSED(file->WillNeed(ranges)); // As this is optimisation only, failures
-                                          // should not be treated as fatal
+    // As this is optimisation only, failures should not be treated as fatal
+    ARROW_UNUSED(file->WillNeed(ranges));
     return Status::OK();
   }
 

--- a/cpp/src/arrow/io/caching.cc
+++ b/cpp/src/arrow/io/caching.cc
@@ -188,7 +188,8 @@ struct ReadRangeCache::Impl {
       entries = std::move(new_entries);
     }
     // Prefetch immediately, regardless of executor availability, if possible
-    ARROW_UNUSED(file->WillNeed(ranges)); // As this is optimisation only, failures should not be treated as fatal
+    ARROW_UNUSED(file->WillNeed(ranges)); // As this is optimisation only, failures
+                                          // should not be treated as fatal
     return Status::OK();
   }
 

--- a/cpp/src/arrow/io/caching.cc
+++ b/cpp/src/arrow/io/caching.cc
@@ -188,7 +188,8 @@ struct ReadRangeCache::Impl {
       entries = std::move(new_entries);
     }
     // Prefetch immediately, regardless of executor availability, if possible
-    return file->WillNeed(ranges);
+    ARROW_UNUSED(file->WillNeed(ranges)); // As this is optimisation only, failures should not be treated as fatal
+    return Status::OK();
   }
 
   // Read the given range from the cache, blocking if needed. Cannot read a range

--- a/cpp/src/arrow/io/caching.cc
+++ b/cpp/src/arrow/io/caching.cc
@@ -188,7 +188,7 @@ struct ReadRangeCache::Impl {
       entries = std::move(new_entries);
     }
     // Prefetch immediately, regardless of executor availability, if possible
-    Status st = file->WillNeed(ranges);
+    auto st = file->WillNeed(ranges);
     // As this is optimisation only, I/O failures should not be treated as fatal
     if (st.IsIOError()) {
       return Status::OK();


### PR DESCRIPTION
### Rationale for this change

Fix a bug where cache optimisation errors prevent files being read

### What changes are included in this PR?

No longer treat `WillNeed` errors in `ReadRangeCache::Cache` as fatal

### Are these changes tested?

No

### Are there any user-facing changes?

No
* GitHub Issue: #46149