### PR TITLE
GH-42012: [Python] Add Schema with_field or set_field method

### DIFF
--- a/docs/source/python/data.rst
+++ b/docs/source/python/data.rst
@@ -147,6 +147,15 @@ Python:
 In some applications, you may not create schemas directly, only using the ones
 that are embedded in :ref:`IPC messages <ipc>`.
 
+Schemas are immutable, which means you can't update an existing schema, but you 
+can create a new one with updated values using :meth:`Schema.set`.
+
+.. ipython:: python
+
+   updated_field = pa.field('s0_new', pa.int64())
+   my_schema2 = my_schema.set(0, updated_field)
+   my_schema2
+
 .. _data.array:
 
 Arrays

--- a/docs/source/python/data.rst
+++ b/docs/source/python/data.rst
@@ -152,7 +152,7 @@ can create a new one with updated values using :meth:`Schema.set`.
 
 .. ipython:: python
 
-   updated_field = pa.field('s0_new', pa.int64())
+   updated_field = pa.field('field0_new', pa.int64())
    my_schema2 = my_schema.set(0, updated_field)
    my_schema2
 

--- a/docs/source/python/data.rst
+++ b/docs/source/python/data.rst
@@ -147,7 +147,7 @@ Python:
 In some applications, you may not create schemas directly, only using the ones
 that are embedded in :ref:`IPC messages <ipc>`.
 
-Schemas are immutable, which means you can't update an existing schema, but you 
+Schemas are immutable, which means you can't update an existing schema, but you
 can create a new one with updated values using :meth:`Schema.set`.
 
 .. ipython:: python

--- a/python/pyarrow/tests/test_schema.py
+++ b/python/pyarrow/tests/test_schema.py
@@ -462,6 +462,7 @@ def test_schema_add_remove_metadata():
     s4 = s3.remove_metadata()
     assert s4.metadata is None
 
+
 def test_schema_set_field():
     fields = [
         pa.field('foo', pa.int32()),
@@ -471,10 +472,14 @@ def test_schema_set_field():
     s1 = pa.schema(fields)
 
     s2 = s1.set(0, s1.field(0).with_type(pa.int64()))
-    
+
     assert s2.field(0).type == pa.int64()
     assert s1.field(0).type == pa.int32()
-s3 = s2.set(0, s2.field(1).with_nullable(False))
+
+    s3 = s2.set(0, s2.field(0).with_nullable(False))
+    assert s2.field(0).nullable is True
+    assert s3.field(0).nullable is False
+
 
 def test_schema_equals():
     fields = [

--- a/python/pyarrow/tests/test_schema.py
+++ b/python/pyarrow/tests/test_schema.py
@@ -474,7 +474,7 @@ def test_schema_set_field():
     
     assert s2.field(0).type == pa.int64()
     assert s1.field(0).type == pa.int32()
-
+s3 = s2.set(0, s2.field(1).with_nullable(False))
 
 def test_schema_equals():
     fields = [

--- a/python/pyarrow/tests/test_schema.py
+++ b/python/pyarrow/tests/test_schema.py
@@ -462,6 +462,22 @@ def test_schema_add_remove_metadata():
     s4 = s3.remove_metadata()
     assert s4.metadata is None
 
+def test_schema_set_field():
+    fields = [
+        pa.field('foo', pa.int32()),
+        pa.field('bar', pa.string()),
+        pa.field('baz', pa.list_(pa.int8()))
+    ]
+
+    new_field = pa.field('foo2', pa.int64())
+
+    s1 = pa.schema(fields)
+    s2 = pa.schema((new_field, fields[1], fields[2]))
+
+    new_schema = s1.set_field(0, new_field)
+    
+    assert new_schema.equals(s2)
+
 
 def test_schema_equals():
     fields = [

--- a/python/pyarrow/tests/test_schema.py
+++ b/python/pyarrow/tests/test_schema.py
@@ -468,15 +468,12 @@ def test_schema_set_field():
         pa.field('bar', pa.string()),
         pa.field('baz', pa.list_(pa.int8()))
     ]
-
-    new_field = pa.field('foo2', pa.int64())
-
     s1 = pa.schema(fields)
-    s2 = pa.schema((new_field, fields[1], fields[2]))
 
-    new_schema = s1.set_field(0, new_field)
+    s2 = s1.set(0, s1.field(0).with_type(pa.int64()))
     
-    assert new_schema.equals(s2)
+    assert s2.field(0).type == pa.int64()
+    assert s1.field(0).type == pa.int32()
 
 
 def test_schema_equals():


### PR DESCRIPTION
### Rationale for this change

Wasn't clear to users how to create a new schema based on an existing one

### What changes are included in this PR?

Add a test for creating a new schema based on existing one, update docs too

### Are these changes tested?

Yes

### Are there any user-facing changes?

No
* GitHub Issue: #42012