### PR TITLE
GH-46351: [Archery][Docs] Fix the cli argument parsing bug in docker subcommand

### DIFF
--- a/dev/archery/archery/docker/cli.py
+++ b/dev/archery/archery/docker/cli.py
@@ -28,12 +28,13 @@ from .core import DockerCompose, UndefinedImage
 def _mock_compose_calls(compose):
     from types import MethodType
     from subprocess import CompletedProcess
+    from itertools import chain
 
     def _mock(compose, command_tuple):
         def _execute(self, *args, **kwargs):
             params = [f'{k}={v}'
                       for k, v in self.config.params.items()]
-            command = ' '.join(params + command_tuple + args)
+            command = ' '.join(chain(params, command_tuple, args))
             click.echo(command)
             return CompletedProcess([], 0)
         return MethodType(_execute, compose)

--- a/docs/source/developers/continuous_integration/docker.rst
+++ b/docs/source/developers/continuous_integration/docker.rst
@@ -60,7 +60,7 @@ Archery calls the following docker compose commands:
 
 .. code:: bash
 
-    archery docker run --dry-run conda-python
+    archery docker --dry-run run conda-python
 
 **To disable the image pulling:**
 


### PR DESCRIPTION
### Rationale for this change

Resolve the issue described in https://github.com/apache/arrow/issues/46351.

### What changes are included in this PR?

* In python, a tuple cannot be concatenated directly to a list with '+'. Use itertools.chain() instead. ([dev/archery/archery/docker/cli.py](https://github.com/apache/arrow/pull/46352/files/db455b1d8bb6847ba43a668d3fa3b2a5da9e4ca3#diff-a9656b6fe9f7ba9a56479e1f2f6d756c3dd7fd8d082ca071bea0867c5ea83b4b))
* Fix the inappropriate example in documentation. 
([docs/source/developers/continuous_integration/docker.rst](https://github.com/apache/arrow/pull/46352/files/db455b1d8bb6847ba43a668d3fa3b2a5da9e4ca3#diff-695ee6af9f0226e7661b25fed0391cb61d4490a80de24e55fc676cfec63284db))

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #46351