### PR TITLE
GH-46355: [Python] Fix table.to_struct_array with an empty table

### DIFF
--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -4960,10 +4960,11 @@ cdef class Table(_Tabular):
         ChunkedArray
         """
         self._assert_cpu()
-        return chunked_array([
+        chunks = [
             batch.to_struct_array()
             for batch in self.to_batches(max_chunksize=max_chunksize)
-        ])
+        ]
+        return chunked_array(chunks, type=struct(self.schema))
 
     @staticmethod
     def from_batches(batches, Schema schema=None):

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -970,6 +970,22 @@ def test_table_to_struct_array_with_max_chunksize():
     ))
 
 
+def test_table_to_struct_array_for_empty_table():
+    table = pa.Table.from_arrays(
+        [
+            pa.array([], type=pa.int32()),
+            pa.array([], type=pa.float32()),
+        ], ["ints", "floats"]
+    )
+    result = table.to_struct_array()
+    assert result.equals(
+        pa.chunked_array(
+            [],
+            type=pa.struct({"ints": pa.int32(), "floats": pa.float32()}),
+        ),
+    )
+
+
 def check_tensors(tensor, expected_tensor, type, size):
     assert tensor.equals(expected_tensor)
     assert tensor.size == size


### PR DESCRIPTION
### Rationale for this change

Currently `pyarrow.Table.to_struct_array` fails if table is empty, this PR fixes that. See issue #46355 for the reproducible example.

### What changes are included in this PR?

Check if table is empty and create an empty chunked array using table schema for the array type

### Are these changes tested?

I added a test for that, it failed before I implemented the fix

### Are there any user-facing changes?

No
* GitHub Issue: #46355