### PR TITLE
GH-46363: [CI][Packaging] Use mono from community repository on Alpine instead of from testing

### DIFF
--- a/ci/docker/python-wheel-musllinux.dockerfile
+++ b/ci/docker/python-wheel-musllinux.dockerfile
@@ -37,7 +37,8 @@ RUN apk add --no-cache \
     unzip \
     wget \
     zip
-# Add mono from testing repo because it's not in the main repo
+# Add mono from community repo because it's not in the main repo.
+# We will be able to use the main repo once we move to alpine 3.22 or later.
 RUN apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community mono
 
 # A system Python is required for ninja and vcpkg in this Dockerfile.

--- a/ci/docker/python-wheel-musllinux.dockerfile
+++ b/ci/docker/python-wheel-musllinux.dockerfile
@@ -33,11 +33,12 @@ RUN apk add --no-cache \
     curl \
     flex \
     git \
-    mono \
     ninja \
     unzip \
     wget \
     zip
+# Add mono from testing repo because it's not in the main repo
+RUN apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/community mono
 
 # A system Python is required for ninja and vcpkg in this Dockerfile.
 # On musllinux_1_2 a system python is installed (3.12) but pip is not

--- a/ci/docker/python-wheel-musllinux.dockerfile
+++ b/ci/docker/python-wheel-musllinux.dockerfile
@@ -33,12 +33,11 @@ RUN apk add --no-cache \
     curl \
     flex \
     git \
+    mono \
     ninja \
     unzip \
     wget \
     zip
-# Add mono from testing repo because it's not in the main repo
-RUN apk add --no-cache --repository=https://dl-cdn.alpinelinux.org/alpine/edge/testing mono
 
 # A system Python is required for ninja and vcpkg in this Dockerfile.
 # On musllinux_1_2 a system python is installed (3.12) but pip is not

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1216,7 +1216,7 @@ services:
       args:
         arch: ${ARCH}
         arch_short: ${ARCH_SHORT}
-        base: quay.io/pypa/musllinux_1_2_${ARCH_ALIAS}:2025-05-08-87f462b
+        base: quay.io/pypa/musllinux_1_2_${ARCH_ALIAS}:2025-01-18-a325f1d
         musllinux: 1_2
         python: ${PYTHON}
         python_abi_tag: ${PYTHON_ABI_TAG}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1216,7 +1216,7 @@ services:
       args:
         arch: ${ARCH}
         arch_short: ${ARCH_SHORT}
-        base: quay.io/pypa/musllinux_1_2_${ARCH_ALIAS}:2025-01-18-a325f1d
+        base: quay.io/pypa/musllinux_1_2_${ARCH_ALIAS}:2025-05-08-87f462b
         musllinux: 1_2
         python: ${PYTHON}
         python_abi_tag: ${PYTHON_ABI_TAG}


### PR DESCRIPTION
### Rationale for this change

The wheels jobs for alpine are currently failing because mono can't be found on https://dl-cdn.alpinelinux.org/alpine/edge/testing

### What changes are included in this PR?

Mono seems to be part of the community repository for alpine now:
https://pkgs.alpinelinux.org/package/edge/community/x86_64/mono

### Are these changes tested?

Yes, via archery.

### Are there any user-facing changes?

No

* GitHub Issue: #46363