### PR TITLE
GH-46362: [CGLib][Packaging] Use -fPIE explicitly for g-ir-scanner

### DIFF
--- a/c_glib/arrow-cuda-glib/meson.build
+++ b/c_glib/arrow-cuda-glib/meson.build
@@ -76,8 +76,7 @@ endif
 
 if have_gi
     gir_dependencies = [declare_dependency(sources: arrow_glib_gir)]
-    gir_extra_args = [
-        '--warn-all',
+    gir_extra_args = gir_scanner_extra_args + [
         '--include-uninstalled=./arrow-glib/Arrow-1.0.gir',
     ]
     arrow_cuda_glib_gir = gnome.generate_gir(

--- a/c_glib/arrow-dataset-glib/meson.build
+++ b/c_glib/arrow-dataset-glib/meson.build
@@ -119,8 +119,7 @@ if have_gi
         libarrow_dataset_glib,
         dependencies: declare_dependency(sources: arrow_glib_gir),
         export_packages: 'arrow-dataset-glib',
-        extra_args: [
-            '--warn-all',
+        extra_args: gir_scanner_extra_args + [
             '--include-uninstalled=./arrow-glib/Arrow-1.0.gir',
         ],
         header: 'arrow-dataset-glib/arrow-dataset-glib.h',

--- a/c_glib/arrow-flight-glib/meson.build
+++ b/c_glib/arrow-flight-glib/meson.build
@@ -83,8 +83,7 @@ if have_gi
         libarrow_flight_glib,
         dependencies: declare_dependency(sources: arrow_glib_gir),
         export_packages: 'arrow-flight-glib',
-        extra_args: [
-            '--warn-all',
+        extra_args: gir_scanner_extra_args + [
             '--include-uninstalled=./arrow-glib/Arrow-1.0.gir',
         ],
         header: 'arrow-flight-glib/arrow-flight-glib.h',

--- a/c_glib/arrow-flight-sql-glib/meson.build
+++ b/c_glib/arrow-flight-sql-glib/meson.build
@@ -81,8 +81,7 @@ if have_gi
         libarrow_flight_sql_glib,
         dependencies: arrow_flight_sql_glib_gir_dependencies,
         export_packages: 'arrow-flight-sql-glib',
-        extra_args: [
-            '--warn-all',
+        extra_args: gir_scanner_extra_args + [
             '--include-uninstalled=./arrow-glib/Arrow-1.0.gir',
             '--include-uninstalled=./arrow-flight-glib/ArrowFlight-1.0.gir',
         ],

--- a/c_glib/arrow-glib/meson.build
+++ b/c_glib/arrow-glib/meson.build
@@ -266,7 +266,7 @@ if have_gi
     arrow_glib_gir = gnome.generate_gir(
         libarrow_glib,
         export_packages: 'arrow-glib',
-        extra_args: ['--warn-all'],
+        extra_args: gir_scanner_extra_args,
         header: 'arrow-glib/arrow-glib.h',
         identifier_prefix: 'GArrow',
         includes: ['GObject-2.0', 'Gio-2.0'],

--- a/c_glib/gandiva-glib/meson.build
+++ b/c_glib/gandiva-glib/meson.build
@@ -123,8 +123,7 @@ if have_gi
         libgandiva_glib,
         dependencies: declare_dependency(sources: arrow_glib_gir),
         export_packages: 'gandiva-glib',
-        extra_args: [
-            '--warn-all',
+        extra_args: gir_scanner_extra_args + [
             '--include-uninstalled=./arrow-glib/Arrow-1.0.gir',
         ],
         header: 'gandiva-glib/gandiva-glib.h',

--- a/c_glib/meson.build
+++ b/c_glib/meson.build
@@ -258,6 +258,19 @@ python = import('python')
 python3 = python.find_installation('python3')
 generate_version_header_py = project_source_root / 'tool' / 'generate-version-header.py'
 
+c_compiler = meson.get_compiler('c')
+# Specify -fPIE explicitly for g-ir-scanner because PIE is disabled by
+# default on AlmaLinux 9 RPM build by
+# LDFLAGS="-specs=/usr/lib/rpm/redhat/redhat-hardened-ld".
+gir_scanner_cflags = c_compiler.get_supported_arguments('-fPIE')
+if gir_scanner_cflags.length() == 0
+    gir_scanner_extra_args = []
+else
+    gir_scanner_extra_args = ['--cflags-begin'] + gir_scanner_cflags + [
+        '--cflags-end',
+    ]
+endif
+
 subdir('arrow-glib')
 if arrow_cuda.found()
     subdir('arrow-cuda-glib')

--- a/c_glib/parquet-glib/meson.build
+++ b/c_glib/parquet-glib/meson.build
@@ -97,8 +97,7 @@ if have_gi
         libparquet_glib,
         dependencies: declare_dependency(sources: arrow_glib_gir),
         export_packages: 'parquet-glib',
-        extra_args: [
-            '--warn-all',
+        extra_args: gir_scanner_extra_args + [
             '--include-uninstalled=./arrow-glib/Arrow-1.0.gir',
         ],
         header: 'parquet-glib/parquet-glib.h',


### PR DESCRIPTION
### Rationale for this change

Packaging jobs for almalinux-9 and centos-9 are currently failing because they disable PIE by default. The fail with:
> /usr/bin/ld: /build/rpmbuild/BUILD/apache-arrow-21.0.0.dev42/c_glib/build/tmp-introspectc57_mxf2/Arrow-1.0.o: relocation R_X86_64_32 against `.rodata' can not be used when making a PIE object; recompile with -fPIE

### What changes are included in this PR?

Add extra_args to build if `c_compiler.get_supported_arguments('-fPIE')`

### Are these changes tested?

Via CI

### Are there any user-facing changes?

No

* GitHub Issue: #46362