### PR TITLE
GH-46367: [C++] Prevent Meson from using git info if built as subproject

### DIFF
--- a/cpp/meson.build
+++ b/cpp/meson.build
@@ -47,12 +47,12 @@ cpp_args = cpp_compiler.get_supported_arguments(project_args)
 add_project_arguments(cpp_args, language: 'cpp')
 
 git_id = get_option('git_id')
-if git_id == ''
+if git_id == '' and not meson.is_subproject()
     git_id = run_command('git', 'log', '-n1', '--format=%H', check: false).stdout().strip()
 endif
 
 git_description = get_option('git_description')
-if git_description == ''
+if git_description == '' and not meson.is_subproject()
     git_description = run_command('git', 'describe', '--tags', check: false).stdout().strip()
 endif
 


### PR DESCRIPTION
### Rationale for this change

When used as a subproject, the Arrow Meson configuration may end up pulling git version information from the main project

### What changes are included in this PR?

This prevents Meson from gathering git information when Arrow is built as a subproject

### Are these changes tested?

Yes

### Are there any user-facing changes?

No
* GitHub Issue: #46367