### PR TITLE
GH-46378: [Docs] Remove references to autotune from the docs

### DIFF
--- a/docs/source/developers/continuous_integration/overview.rst
+++ b/docs/source/developers/continuous_integration/overview.rst
@@ -52,7 +52,6 @@ The ``.yml`` files in ``.github/workflows`` are workflows which are run on GitHu
 - ``comment_bot.yml`` - triggers certain actions by listening on github pull request comments for the following strings:
 
   - ``@github-actions crossbow submit ...`` - runs the specified Crossbow command
-  - ``@github-actions autotune`` - runs a number of stylers/formatters, builds some of the docs, and commits the results
   - ``@github-actions rebase`` - rebases the PR onto the main branch
 - ``dev.yml`` - runs any time there is activity on a PR, or a PR is merged; it runs the linter and tests that the PR can be merged
 - ``dev_pr.yml`` - runs any time a PR is opened or updated; checks the formatting of the PR title, adds assignee to the appropriate GitHub issue if needed (or adds a comment requesting the user to include the issue id in the title), and adds any relevant GitHub labels

--- a/docs/source/developers/cpp/development.rst
+++ b/docs/source/developers/cpp/development.rst
@@ -162,12 +162,6 @@ target that is executable from the root of the repository:
 
    $ docker compose run ubuntu-lint
 
-Alternatively, on an open pull request, the comment bot can format C++ code
-for you (it will push a commit to the branch that can then be pulled). Just
-comment the following::
-
-  @github-actions autotune
-
 Cleaning includes with include-what-you-use (IWYU)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/r/vignettes/developers/workflow.Rmd
+++ b/r/vignettes/developers/workflow.Rmd
@@ -61,11 +61,9 @@ To run the linter locally, install the `{lintr}` package (note, we currently use
 lintr::lint_package("arrow/r")
 ```
 
-You can automatically change the formatting of the code in the package using the [styler](https://styler.r-lib.org/) package. There are two ways to do this:
+You can automatically change the formatting of the code in the package using the [styler](https://styler.r-lib.org/) package.
 
-1. Use the comment bot to do this automatically with the command `@github-actions autotune` on a PR, and commit it back to the branch.
-
-2. Run the styler locally either via Makefile commands:
+Run the styler locally either via Makefile commands:
 
 ```bash
 make style # (for only the files changed)
@@ -212,12 +210,3 @@ See the `r:` group definition near the beginning of the [crossbow configuration]
 for a list of glob expression patterns that match names of items in the `tasks:`
 list below it.
 
-#### Run linting and documentation building tasks
-
-```
-@github-actions autotune
-```
-
-This will run and fix lint C++ linting errors, run R documentation (among other
-cleanup tasks), run styler on any changed R code, and commit the resulting
-updates to the branch.


### PR DESCRIPTION
### Rationale for this change

We removed broken dev functionality but it's still documented

### What changes are included in this PR?

Remove references to autotune in the docs

### Are these changes tested?

No

### Are there any user-facing changes?

Just docs
* GitHub Issue: #46378