### PR TITLE
GH-46380: [GLib] Add GArrowFixedShapeDataType#shape

### DIFF
--- a/c_glib/arrow-glib/basic-data-type.cpp
+++ b/c_glib/arrow-glib/basic-data-type.cpp
@@ -2352,7 +2352,7 @@ garrow_fixed_shape_tensor_data_type_new(GArrowDataType *value_type,
  * @data_type: A #GArrowFixedShapeTensorDataType.
  * @length: (out): Return location for the number of dimensions of the tensor.
  *
- * Returns: (array length=length): Shape of tensor elements.
+ * Returns: (array length=length): Shape of the tensor.
  */
 const gint64 *
 garrow_fixed_shape_tensor_data_type_get_shape(GArrowFixedShapeTensorDataType *data_type,

--- a/c_glib/arrow-glib/basic-data-type.cpp
+++ b/c_glib/arrow-glib/basic-data-type.cpp
@@ -2361,10 +2361,9 @@ garrow_fixed_shape_tensor_data_type_get_shape(GArrowFixedShapeTensorDataType *ob
   const auto priv = GARROW_DATA_TYPE_GET_PRIVATE(object);
   auto arrow_data_type =
     std::static_pointer_cast<arrow::extension::FixedShapeTensorType>(priv->data_type);
-  auto arrow_shape = arrow_data_type->shape();
 
-  *length = arrow_shape.size();
-  return arrow_shape.data();
+  *length = arrow_data_type->shape().size();
+  return arrow_data_type->shape().data();
 }
 
 G_END_DECLS

--- a/c_glib/arrow-glib/basic-data-type.cpp
+++ b/c_glib/arrow-glib/basic-data-type.cpp
@@ -2358,9 +2358,8 @@ const gint64 *
 garrow_fixed_shape_tensor_data_type_get_shape(GArrowFixedShapeTensorDataType *data_type,
                                               gsize *length)
 {
-  const auto priv = GARROW_DATA_TYPE_GET_PRIVATE(object);
   auto arrow_data_type =
-    std::static_pointer_cast<arrow::extension::FixedShapeTensorType>(priv->data_type);
+    std::static_pointer_cast<arrow::extension::FixedShapeTensorType>(garrow_data_type_get_raw(data_type));
 
   *length = arrow_data_type->shape().size();
   return arrow_data_type->shape().data();

--- a/c_glib/arrow-glib/basic-data-type.cpp
+++ b/c_glib/arrow-glib/basic-data-type.cpp
@@ -2363,7 +2363,7 @@ garrow_fixed_shape_tensor_data_type_get_shape(GArrowFixedShapeTensorDataType *ob
     std::static_pointer_cast<arrow::extension::FixedShapeTensorType>(priv->data_type);
   auto arrow_shape = arrow_data_type->shape();
 
-  gsize n_shape = arrow_shape.size();
+  *length = arrow_shape.size();
   auto shape = static_cast<gint64 *>(g_malloc_n(sizeof(gint64), n_shape));
 
   for (gsize i = 0; i < n_shape; ++i) {

--- a/c_glib/arrow-glib/basic-data-type.cpp
+++ b/c_glib/arrow-glib/basic-data-type.cpp
@@ -2347,6 +2347,34 @@ garrow_fixed_shape_tensor_data_type_new(GArrowDataType *value_type,
   return data_type;
 }
 
+/**
+ * garrow_fixed_shape_tensor_data_type_get_shapes:
+ * @object: A #GArrowDataType of individual tensor elements.
+ * @length: (out) (optional): return location for the number of elements in the returned
+ *   array
+ *
+ * Returns: (transfer full) (array length=length): Shape of tensor elements.
+ */
+gint64 *
+garrow_fixed_shape_tensor_data_type_get_shapes(GArrowFixedShapeTensorDataType *object,
+                                               gsize *length)
+{
+  const auto priv = GARROW_DATA_TYPE_GET_PRIVATE(object);
+  auto arrow_data_type =
+    std::static_pointer_cast<arrow::extension::FixedShapeTensorType>(priv->data_type);
+  auto arrow_shape = arrow_data_type->shape();
+
+  gsize n_shape = arrow_shape.size();
+  auto shape = static_cast<gint64 *>(g_malloc_n(sizeof(gint64), n_shape));
+
+  for (gsize i = 0; i < n_shape; ++i) {
+    shape[i] = arrow_shape[i];
+  }
+
+  *length = n_shape;
+  return shape;
+}
+
 G_END_DECLS
 
 GArrowDataType *

--- a/c_glib/arrow-glib/basic-data-type.cpp
+++ b/c_glib/arrow-glib/basic-data-type.cpp
@@ -2348,7 +2348,7 @@ garrow_fixed_shape_tensor_data_type_new(GArrowDataType *value_type,
 }
 
 /**
- * garrow_fixed_shape_tensor_data_type_get_shapes:
+ * garrow_fixed_shape_tensor_data_type_get_shape:
  * @object: A #GArrowDataType of individual tensor elements.
  * @length: (out) (optional): return location for the number of elements in the returned
  *   array
@@ -2356,8 +2356,8 @@ garrow_fixed_shape_tensor_data_type_new(GArrowDataType *value_type,
  * Returns: (transfer full) (array length=length): Shape of tensor elements.
  */
 gint64 *
-garrow_fixed_shape_tensor_data_type_get_shapes(GArrowFixedShapeTensorDataType *object,
-                                               gsize *length)
+garrow_fixed_shape_tensor_data_type_get_shape(GArrowFixedShapeTensorDataType *object,
+                                              gsize *length)
 {
   const auto priv = GARROW_DATA_TYPE_GET_PRIVATE(object);
   auto arrow_data_type =

--- a/c_glib/arrow-glib/basic-data-type.cpp
+++ b/c_glib/arrow-glib/basic-data-type.cpp
@@ -2350,8 +2350,7 @@ garrow_fixed_shape_tensor_data_type_new(GArrowDataType *value_type,
 /**
  * garrow_fixed_shape_tensor_data_type_get_shape:
  * @object: A #GArrowDataType of individual tensor elements.
- * @length: (out) (optional): return location for the number of elements in the returned
- *   array
+ * @length: (out): return location for the number of elements in the returned array.
  *
  * Returns: (transfer full) (array length=length): Shape of tensor elements.
  */

--- a/c_glib/arrow-glib/basic-data-type.cpp
+++ b/c_glib/arrow-glib/basic-data-type.cpp
@@ -2352,9 +2352,9 @@ garrow_fixed_shape_tensor_data_type_new(GArrowDataType *value_type,
  * @object: A #GArrowDataType of individual tensor elements.
  * @length: (out): return location for the number of elements in the returned array.
  *
- * Returns: (transfer full) (array length=length): Shape of tensor elements.
+ * Returns: (array length=length): Shape of tensor elements.
  */
-gint64 *
+const gint64 *
 garrow_fixed_shape_tensor_data_type_get_shape(GArrowFixedShapeTensorDataType *object,
                                               gsize *length)
 {

--- a/c_glib/arrow-glib/basic-data-type.cpp
+++ b/c_glib/arrow-glib/basic-data-type.cpp
@@ -2349,7 +2349,7 @@ garrow_fixed_shape_tensor_data_type_new(GArrowDataType *value_type,
 
 /**
  * garrow_fixed_shape_tensor_data_type_get_shape:
- * @object: A #GArrowDataType of individual tensor elements.
+ * @data_type: A #GArrowFixedShapeTensorDataType.
  * @length: (out): return location for the number of elements in the returned array.
  *
  * Returns: (array length=length): Shape of tensor elements.

--- a/c_glib/arrow-glib/basic-data-type.cpp
+++ b/c_glib/arrow-glib/basic-data-type.cpp
@@ -2364,14 +2364,7 @@ garrow_fixed_shape_tensor_data_type_get_shape(GArrowFixedShapeTensorDataType *ob
   auto arrow_shape = arrow_data_type->shape();
 
   *length = arrow_shape.size();
-  auto shape = static_cast<gint64 *>(g_malloc_n(sizeof(gint64), n_shape));
-
-  for (gsize i = 0; i < n_shape; ++i) {
-    shape[i] = arrow_shape[i];
-  }
-
-  *length = n_shape;
-  return shape;
+  return arrow_shape.data();
 }
 
 G_END_DECLS

--- a/c_glib/arrow-glib/basic-data-type.cpp
+++ b/c_glib/arrow-glib/basic-data-type.cpp
@@ -2358,12 +2358,12 @@ const gint64 *
 garrow_fixed_shape_tensor_data_type_get_shape(GArrowFixedShapeTensorDataType *data_type,
                                               gsize *length)
 {
-  auto arrow_data_type =
-    std::static_pointer_cast<arrow::extension::FixedShapeTensorType>(garrow_data_type_get_raw(data_type));
+  auto arrow_data_type = std::static_pointer_cast<arrow::extension::FixedShapeTensorType>(
+    garrow_data_type_get_raw(GARROW_DATA_TYPE(data_type)));
 
-  const auto& arrow_shape = arrow_data_type->shape();
-  *length = shape.size();
-  return shape.data();
+  const auto &arrow_shape = arrow_data_type->shape();
+  *length = arrow_shape.size();
+  return arrow_shape.data();
 }
 
 G_END_DECLS

--- a/c_glib/arrow-glib/basic-data-type.cpp
+++ b/c_glib/arrow-glib/basic-data-type.cpp
@@ -2355,7 +2355,7 @@ garrow_fixed_shape_tensor_data_type_new(GArrowDataType *value_type,
  * Returns: (array length=length): Shape of tensor elements.
  */
 const gint64 *
-garrow_fixed_shape_tensor_data_type_get_shape(GArrowFixedShapeTensorDataType *object,
+garrow_fixed_shape_tensor_data_type_get_shape(GArrowFixedShapeTensorDataType *data_type,
                                               gsize *length)
 {
   const auto priv = GARROW_DATA_TYPE_GET_PRIVATE(object);

--- a/c_glib/arrow-glib/basic-data-type.cpp
+++ b/c_glib/arrow-glib/basic-data-type.cpp
@@ -2361,8 +2361,9 @@ garrow_fixed_shape_tensor_data_type_get_shape(GArrowFixedShapeTensorDataType *da
   auto arrow_data_type =
     std::static_pointer_cast<arrow::extension::FixedShapeTensorType>(garrow_data_type_get_raw(data_type));
 
-  *length = arrow_data_type->shape().size();
-  return arrow_data_type->shape().data();
+  const auto& arrow_shape = arrow_data_type->shape();
+  *length = shape.size();
+  return shape.data();
 }
 
 G_END_DECLS

--- a/c_glib/arrow-glib/basic-data-type.cpp
+++ b/c_glib/arrow-glib/basic-data-type.cpp
@@ -2350,7 +2350,7 @@ garrow_fixed_shape_tensor_data_type_new(GArrowDataType *value_type,
 /**
  * garrow_fixed_shape_tensor_data_type_get_shape:
  * @data_type: A #GArrowFixedShapeTensorDataType.
- * @length: (out): return location for the number of elements in the returned array.
+ * @length: (out): Return location for the number of dimensions of the tensor.
  *
  * Returns: (array length=length): Shape of tensor elements.
  */

--- a/c_glib/arrow-glib/basic-data-type.h
+++ b/c_glib/arrow-glib/basic-data-type.h
@@ -828,6 +828,6 @@ garrow_fixed_shape_tensor_data_type_new(GArrowDataType *value_type,
 
 GARROW_AVAILABLE_IN_21_0
 const gint64 *
-garrow_fixed_shape_tensor_data_type_get_shape(GArrowFixedShapeTensorDataType *object,
+garrow_fixed_shape_tensor_data_type_get_shape(GArrowFixedShapeTensorDataType *data_type,
                                               gsize *length);
 G_END_DECLS

--- a/c_glib/arrow-glib/basic-data-type.h
+++ b/c_glib/arrow-glib/basic-data-type.h
@@ -827,7 +827,7 @@ garrow_fixed_shape_tensor_data_type_new(GArrowDataType *value_type,
                                         GError **error);
 
 GARROW_AVAILABLE_IN_21_0
-gint64 *
+const gint64 *
 garrow_fixed_shape_tensor_data_type_get_shape(GArrowFixedShapeTensorDataType *object,
                                               gsize *length);
 G_END_DECLS

--- a/c_glib/arrow-glib/basic-data-type.h
+++ b/c_glib/arrow-glib/basic-data-type.h
@@ -828,6 +828,6 @@ garrow_fixed_shape_tensor_data_type_new(GArrowDataType *value_type,
 
 GARROW_AVAILABLE_IN_21_0
 gint64 *
-garrow_fixed_shape_tensor_data_type_get_shapes(GArrowFixedShapeTensorDataType *object,
-                                               gsize *length);
+garrow_fixed_shape_tensor_data_type_get_shape(GArrowFixedShapeTensorDataType *object,
+                                              gsize *length);
 G_END_DECLS

--- a/c_glib/arrow-glib/basic-data-type.h
+++ b/c_glib/arrow-glib/basic-data-type.h
@@ -826,4 +826,8 @@ garrow_fixed_shape_tensor_data_type_new(GArrowDataType *value_type,
                                         gsize n_dim_names,
                                         GError **error);
 
+GARROW_AVAILABLE_IN_21_0
+gint64 *
+garrow_fixed_shape_tensor_data_type_get_shapes(GArrowFixedShapeTensorDataType *object,
+                                               gsize *length);
 G_END_DECLS

--- a/c_glib/test/test-fixed-shape-tensor-data-type.rb
+++ b/c_glib/test/test-fixed-shape-tensor-data-type.rb
@@ -32,7 +32,7 @@ class TestFixedShapeTensorDataType < Test::Unit::TestCase
                  [@data_type.name, @data_type.extension_name])
   end
 
-  def test_shape_size
+  def test_shape
     assert_equal([3, 4], @data_type.shape)
   end
 

--- a/c_glib/test/test-fixed-shape-tensor-data-type.rb
+++ b/c_glib/test/test-fixed-shape-tensor-data-type.rb
@@ -33,7 +33,7 @@ class TestFixedShapeTensorDataType < Test::Unit::TestCase
   end
 
   def test_shape_size
-    assert_equal([3, 4], @data_type.shapes)
+    assert_equal([3, 4], @data_type.shape)
   end
 
   def test_to_s

--- a/c_glib/test/test-fixed-shape-tensor-data-type.rb
+++ b/c_glib/test/test-fixed-shape-tensor-data-type.rb
@@ -16,30 +16,29 @@
 # under the License.
 
 class TestFixedShapeTensorDataType < Test::Unit::TestCase
+  def setup
+    @data_type = Arrow::FixedShapeTensorDataType.new(Arrow::UInt64DataType.new,
+                                                     [3, 4],
+                                                     [1, 0],
+                                                     ["x", "y"])
+  end
+
   def test_id
-    data_type = Arrow::FixedShapeTensorDataType.new(Arrow::UInt64DataType.new,
-                                                    [3, 4],
-                                                    [1, 0],
-                                                    ["x", "y"])
-    assert_equal(Arrow::Type::EXTENSION, data_type.id)
+    assert_equal(Arrow::Type::EXTENSION, @data_type.id)
   end
 
   def test_name
-    data_type = Arrow::FixedShapeTensorDataType.new(Arrow::UInt64DataType.new,
-                                                    [3, 4],
-                                                    [1, 0],
-                                                    ["x", "y"])
     assert_equal(["extension", "arrow.fixed_shape_tensor"],
-                 [data_type.name, data_type.extension_name])
+                 [@data_type.name, @data_type.extension_name])
+  end
+
+  def test_shape_size
+    assert_equal([3, 4], @data_type.shapes)
   end
 
   def test_to_s
-    data_type = Arrow::FixedShapeTensorDataType.new(Arrow::UInt64DataType.new,
-                                                    [3, 4],
-                                                    [1, 0],
-                                                    ["x", "y"])
     assert do
-      data_type.to_s.start_with?("extension<arrow.fixed_shape_tensor")
+      @data_type.to_s.start_with?("extension<arrow.fixed_shape_tensor")
     end
   end
 


### PR DESCRIPTION
### Rationale for this change

The C++ API implemented `FixedShapeTensor::shape()` instance method. GLib was not yet supported.

### What changes are included in this PR?

Add `GArrowFixedShapeTensorDataType#shape`  instance method.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.

* GitHub Issue: #46380