### PR TITLE
GH-45639: [C++][Statistics] Add support for ARROW:average_byte_width:{exac,approximate}

### DIFF
--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -3897,6 +3897,7 @@ class TestArrayDataStatistics : public ::testing::Test {
   void SetUp() {
     valids_ = {1, 0, 1, 1};
     null_count_ = std::count(valids_.begin(), valids_.end(), 0);
+    average_byte_width_ = 4.0;
     null_buffer_ = *internal::BytesToBits(valids_);
     values_ = {1, 0, 3, -4};
     min_ = *std::min_element(values_.begin(), values_.end());
@@ -3906,6 +3907,8 @@ class TestArrayDataStatistics : public ::testing::Test {
                             null_count_);
     data_->statistics = std::make_shared<ArrayStatistics>();
     data_->statistics->null_count = null_count_;
+    data_->statistics->average_byte_width = average_byte_width_;
+    data_->statistics->is_average_byte_width_exact = true;
     data_->statistics->min = min_;
     data_->statistics->is_min_exact = true;
     data_->statistics->max = max_;
@@ -3915,6 +3918,7 @@ class TestArrayDataStatistics : public ::testing::Test {
  protected:
   std::vector<uint8_t> valids_;
   size_t null_count_;
+  double average_byte_width_;
   std::shared_ptr<Buffer> null_buffer_;
   std::vector<int32_t> values_;
   int64_t min_;
@@ -3929,6 +3933,11 @@ TEST_F(TestArrayDataStatistics, MoveConstructor) {
 
   ASSERT_TRUE(moved_data.statistics->null_count.has_value());
   ASSERT_EQ(null_count_, moved_data.statistics->null_count.value());
+
+  ASSERT_TRUE(moved_data.statistics->average_byte_width.has_value());
+  ASSERT_DOUBLE_EQ(average_byte_width_,
+                   moved_data.statistics->average_byte_width.value());
+  ASSERT_TRUE(moved_data.statistics->is_average_byte_width_exact);
 
   ASSERT_TRUE(moved_data.statistics->min.has_value());
   ASSERT_TRUE(std::holds_alternative<int64_t>(moved_data.statistics->min.value()));
@@ -3946,6 +3955,11 @@ TEST_F(TestArrayDataStatistics, CopyConstructor) {
 
   ASSERT_TRUE(copied_data.statistics->null_count.has_value());
   ASSERT_EQ(null_count_, copied_data.statistics->null_count.value());
+
+  ASSERT_TRUE(copied_data.statistics->average_byte_width.has_value());
+  ASSERT_DOUBLE_EQ(average_byte_width_,
+                   copied_data.statistics->average_byte_width.value());
+  ASSERT_TRUE(copied_data.statistics->is_average_byte_width_exact);
 
   ASSERT_TRUE(copied_data.statistics->min.has_value());
   ASSERT_TRUE(std::holds_alternative<int64_t>(copied_data.statistics->min.value()));
@@ -3966,6 +3980,11 @@ TEST_F(TestArrayDataStatistics, MoveAssignment) {
   ASSERT_TRUE(moved_data.statistics->null_count.has_value());
   ASSERT_EQ(null_count_, moved_data.statistics->null_count.value());
 
+  ASSERT_TRUE(moved_data.statistics->average_byte_width.has_value());
+  ASSERT_DOUBLE_EQ(average_byte_width_,
+                   moved_data.statistics->average_byte_width.value());
+  ASSERT_TRUE(moved_data.statistics->is_average_byte_width_exact);
+
   ASSERT_TRUE(moved_data.statistics->min.has_value());
   ASSERT_TRUE(std::holds_alternative<int64_t>(moved_data.statistics->min.value()));
   ASSERT_EQ(min_, std::get<int64_t>(moved_data.statistics->min.value()));
@@ -3983,6 +4002,11 @@ TEST_F(TestArrayDataStatistics, CopyAssignment) {
 
   ASSERT_TRUE(copied_data.statistics->null_count.has_value());
   ASSERT_EQ(null_count_, copied_data.statistics->null_count.value());
+
+  ASSERT_TRUE(copied_data.statistics->average_byte_width.has_value());
+  ASSERT_DOUBLE_EQ(average_byte_width_,
+                   copied_data.statistics->average_byte_width.value());
+  ASSERT_TRUE(copied_data.statistics->is_average_byte_width_exact);
 
   ASSERT_TRUE(copied_data.statistics->min.has_value());
   ASSERT_TRUE(std::holds_alternative<int64_t>(copied_data.statistics->min.value()));

--- a/cpp/src/arrow/array/statistics.h
+++ b/cpp/src/arrow/array/statistics.h
@@ -78,6 +78,12 @@ struct ARROW_EXPORT ArrayStatistics {
   /// \brief The number of distinct values, may not be set
   std::optional<int64_t> distinct_count = std::nullopt;
 
+  /// \brief The average size in bytes of a row in an array, may not be set.
+  std::optional<double> average_byte_width = std::nullopt;
+
+  /// \brief Whether the average size in bytes is exact or not.
+  bool is_average_byte_width_exact = false;
+
   /// \brief The minimum value, may not be set
   std::optional<ValueType> min = std::nullopt;
 

--- a/cpp/src/arrow/array/statistics_test.cc
+++ b/cpp/src/arrow/array/statistics_test.cc
@@ -171,7 +171,7 @@ TEST_F(TestArrayStatisticsEqualityDoubleValue, ApproximateEquals) {
   ASSERT_TRUE(statistics1_.Equals(statistics2_, options_.atol(1e-3).use_atol(true)));
 }
 
-TEST_F(TestArrayStatisticsEqualityDoubleValue, DoubleAttributesCombination) {
+TEST_F(TestArrayStatisticsEqualityDoubleValue, AverageByteWidth) {
   statistics1_.average_byte_width = 4.2;
   ASSERT_FALSE(statistics1_.Equals(statistics2_));
   statistics2_.average_byte_width = 4.2;

--- a/cpp/src/arrow/array/statistics_test.cc
+++ b/cpp/src/arrow/array/statistics_test.cc
@@ -176,16 +176,6 @@ TEST_F(TestArrayStatisticsEqualityDoubleValue, DoubleAttributesCombination) {
   ASSERT_FALSE(statistics1_.Equals(statistics2_));
   statistics2_.average_byte_width = 4.2;
   ASSERT_TRUE(statistics1_.Equals(statistics2_));
-
-  statistics1_.min = 0.5;
-  ASSERT_FALSE(statistics1_.Equals(statistics2_));
-  statistics2_.min = 0.5;
-  ASSERT_TRUE(statistics1_.Equals(statistics2_));
-
-  statistics1_.max = 0.5;
-  ASSERT_FALSE(statistics1_.Equals(statistics2_));
-  statistics2_.max = 0.5;
-  ASSERT_TRUE(statistics1_.Equals(statistics2_));
 }
 
 }  // namespace arrow

--- a/cpp/src/arrow/array/statistics_test.cc
+++ b/cpp/src/arrow/array/statistics_test.cc
@@ -76,7 +76,7 @@ TEST(TestArrayStatistics, Max) {
   ASSERT_FALSE(statistics.is_max_exact);
 }
 
-TEST(TestArrayStatistics, EqualityNonDoulbeValue) {
+TEST(TestArrayStatistics, Equals) {
   ArrayStatistics statistics1;
   ArrayStatistics statistics2;
 
@@ -92,9 +92,11 @@ TEST(TestArrayStatistics, EqualityNonDoulbeValue) {
   statistics2.distinct_count = 2929;
   ASSERT_EQ(statistics1, statistics2);
 
-  // Although this assertion is meaningless without average_byte_width,
-  // the purpose here is simply to check whether is_average_byte_width_exact
-  // is included in the Equality.
+  statistics1.average_byte_width = 2.9;
+  ASSERT_NE(statistics1, statistics2);
+  statistics2.average_byte_width = 2.9;
+  ASSERT_EQ(statistics1, statistics2);
+
   statistics1.is_average_byte_width_exact = true;
   ASSERT_NE(statistics1, statistics2);
   statistics2.is_average_byte_width_exact = true;
@@ -169,13 +171,6 @@ TEST_F(TestArrayStatisticsEqualityDoubleValue, ApproximateEquals) {
   statistics2_.max = 0.5;
   ASSERT_FALSE(statistics1_.Equals(statistics2_, options_.atol(1e-3)));
   ASSERT_TRUE(statistics1_.Equals(statistics2_, options_.atol(1e-3).use_atol(true)));
-}
-
-TEST_F(TestArrayStatisticsEqualityDoubleValue, AverageByteWidth) {
-  statistics1_.average_byte_width = 4.2;
-  ASSERT_FALSE(statistics1_.Equals(statistics2_));
-  statistics2_.average_byte_width = 4.2;
-  ASSERT_TRUE(statistics1_.Equals(statistics2_));
 }
 
 }  // namespace arrow

--- a/cpp/src/arrow/array/statistics_test.cc
+++ b/cpp/src/arrow/array/statistics_test.cc
@@ -41,6 +41,17 @@ TEST(TestArrayStatistics, DistinctCount) {
   ASSERT_EQ(29, statistics.distinct_count.value());
 }
 
+TEST(TestArrayStatistics, AverageByteWidth) {
+  ArrayStatistics statistics;
+  ASSERT_FALSE(statistics.average_byte_width.has_value());
+  ASSERT_FALSE(statistics.is_average_byte_width_exact);
+  statistics.average_byte_width = 4.2;
+  ASSERT_TRUE(statistics.average_byte_width.has_value());
+  ASSERT_DOUBLE_EQ(4.2, statistics.average_byte_width.value());
+  statistics.is_average_byte_width_exact = true;
+  ASSERT_TRUE(statistics.is_average_byte_width_exact);
+}
+
 TEST(TestArrayStatistics, Min) {
   ArrayStatistics statistics;
   ASSERT_FALSE(statistics.min.has_value());
@@ -79,6 +90,14 @@ TEST(TestArrayStatistics, EqualityNonDoulbeValue) {
   statistics1.distinct_count = 2929;
   ASSERT_NE(statistics1, statistics2);
   statistics2.distinct_count = 2929;
+  ASSERT_EQ(statistics1, statistics2);
+
+  // Although this assertion is meaningless without average_byte_width,
+  // the purpose here is simply to check whether is_average_byte_width_exact
+  // is included in the Equality.
+  statistics1.is_average_byte_width_exact = true;
+  ASSERT_NE(statistics1, statistics2);
+  statistics2.is_average_byte_width_exact = true;
   ASSERT_EQ(statistics1, statistics2);
 
   statistics1.min = std::string("world");
@@ -150,6 +169,23 @@ TEST_F(TestArrayStatisticsEqualityDoubleValue, ApproximateEquals) {
   statistics2_.max = 0.5;
   ASSERT_FALSE(statistics1_.Equals(statistics2_, options_.atol(1e-3)));
   ASSERT_TRUE(statistics1_.Equals(statistics2_, options_.atol(1e-3).use_atol(true)));
+}
+
+TEST_F(TestArrayStatisticsEqualityDoubleValue, DoubleAttributesCombination) {
+  statistics1_.average_byte_width = 4.2;
+  ASSERT_FALSE(statistics1_.Equals(statistics2_));
+  statistics2_.average_byte_width = 4.2;
+  ASSERT_TRUE(statistics1_.Equals(statistics2_));
+
+  statistics1_.min = 0.5;
+  ASSERT_FALSE(statistics1_.Equals(statistics2_));
+  statistics2_.min = 0.5;
+  ASSERT_TRUE(statistics1_.Equals(statistics2_));
+
+  statistics1_.max = 0.5;
+  ASSERT_FALSE(statistics1_.Equals(statistics2_));
+  statistics2_.max = 0.5;
+  ASSERT_TRUE(statistics1_.Equals(statistics2_));
 }
 
 }  // namespace arrow

--- a/cpp/src/arrow/compare.cc
+++ b/cpp/src/arrow/compare.cc
@@ -1561,8 +1561,11 @@ bool ArrayStatisticsEqualsImpl(const ArrayStatistics& left, const ArrayStatistic
                                const EqualOptions& equal_options) {
   return left.null_count == right.null_count &&
          left.distinct_count == right.distinct_count &&
+         left.is_average_byte_width_exact == right.is_average_byte_width_exact &&
          left.is_min_exact == right.is_min_exact &&
          left.is_max_exact == right.is_max_exact &&
+         ArrayStatisticsValueTypeEquals(left.average_byte_width, right.average_byte_width,
+                                        equal_options) &&
          ArrayStatisticsValueTypeEquals(left.min, right.min, equal_options) &&
          ArrayStatisticsValueTypeEquals(left.max, right.max, equal_options);
 }


### PR DESCRIPTION
### Rationale for this change

`ARROW:average_byte_width:exact` and `ARROW:average_byte_width:approximate` statistics attributes are missing in `arrow::ArrayStatistics`.

### What changes are included in this PR?

Add `average_byte_width` and `is_average_byte_width_exact`  member variables to `arrow::ArrayStatistics`.

### Are these changes tested?
Yes, I run the relevant unit tests
### Are there any user-facing changes?
Yes
* GitHub Issue: #45639