### PR TITLE
GH-46386: [C++] Ensure using our CMake packages not Find*.cmake

### DIFF
--- a/cpp/src/arrow/ArrowTestingConfig.cmake.in
+++ b/cpp/src/arrow/ArrowTestingConfig.cmake.in
@@ -29,7 +29,7 @@
 set(ARROW_TESTING_SYSTEM_DEPENDENCIES "@ARROW_TESTING_SYSTEM_DEPENDENCIES@")
 
 include(CMakeFindDependencyMacro)
-find_dependency(Arrow)
+find_dependency(Arrow CONFIG)
 
 arrow_find_dependencies("${ARROW_TESTING_SYSTEM_DEPENDENCIES}")
 

--- a/cpp/src/arrow/acero/ArrowAceroConfig.cmake.in
+++ b/cpp/src/arrow/acero/ArrowAceroConfig.cmake.in
@@ -27,7 +27,7 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
-find_dependency(Arrow)
+find_dependency(Arrow CONFIG)
 
 include("${CMAKE_CURRENT_LIST_DIR}/ArrowAceroTargets.cmake")
 

--- a/cpp/src/arrow/dataset/ArrowDatasetConfig.cmake.in
+++ b/cpp/src/arrow/dataset/ArrowDatasetConfig.cmake.in
@@ -30,7 +30,12 @@ set(ARROW_DATASET_REQUIRED_DEPENDENCIES "@ARROW_DATASET_REQUIRED_DEPENDENCIES@")
 
 include(CMakeFindDependencyMacro)
 foreach(dependency ${ARROW_DATASET_REQUIRED_DEPENDENCIES})
-  find_dependency(${dependency})
+  # Currently all dependencies in ARROW_DATASET_REQUIRED_DEPENDENCIES
+  # are created by Apache Arrow C++. So we can use CONFIG for all
+  # dependencies. If ARROW_DATASET_REQUIRED_DEPENDENCIES may have
+  # dependencies not created by Apache Arrow C++, we need to revisit
+  # this CONFIG.
+  find_dependency(${dependency} CONFIG)
 endforeach()
 
 include("${CMAKE_CURRENT_LIST_DIR}/ArrowDatasetTargets.cmake")

--- a/cpp/src/arrow/engine/ArrowSubstraitConfig.cmake.in
+++ b/cpp/src/arrow/engine/ArrowSubstraitConfig.cmake.in
@@ -27,10 +27,10 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
-find_dependency(Arrow)
-find_dependency(ArrowAcero)
-find_dependency(ArrowDataset)
-find_dependency(Parquet)
+find_dependency(Arrow CONFIG)
+find_dependency(ArrowAcero CONFIG)
+find_dependency(ArrowDataset CONFIG)
+find_dependency(Parquet CONFIG)
 
 include("${CMAKE_CURRENT_LIST_DIR}/ArrowSubstraitTargets.cmake")
 

--- a/cpp/src/arrow/flight/ArrowFlightConfig.cmake.in
+++ b/cpp/src/arrow/flight/ArrowFlightConfig.cmake.in
@@ -29,7 +29,7 @@
 set(ARROW_FLIGHT_SYSTEM_DEPENDENCIES "@ARROW_FLIGHT_SYSTEM_DEPENDENCIES@")
 
 include(CMakeFindDependencyMacro)
-find_dependency(Arrow)
+find_dependency(Arrow CONFIG)
 
 if(ARROW_BUILD_STATIC)
   arrow_find_dependencies("${ARROW_FLIGHT_SYSTEM_DEPENDENCIES}")

--- a/cpp/src/arrow/flight/ArrowFlightTestingConfig.cmake.in
+++ b/cpp/src/arrow/flight/ArrowFlightTestingConfig.cmake.in
@@ -27,8 +27,8 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
-find_dependency(ArrowFlight)
-find_dependency(ArrowTesting)
+find_dependency(ArrowFlight CONFIG)
+find_dependency(ArrowTesting CONFIG)
 
 include("${CMAKE_CURRENT_LIST_DIR}/ArrowFlightTestingTargets.cmake")
 

--- a/cpp/src/arrow/flight/sql/ArrowFlightSqlConfig.cmake.in
+++ b/cpp/src/arrow/flight/sql/ArrowFlightSqlConfig.cmake.in
@@ -27,7 +27,7 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
-find_dependency(ArrowFlight)
+find_dependency(ArrowFlight CONFIG)
 
 include("${CMAKE_CURRENT_LIST_DIR}/ArrowFlightSqlTargets.cmake")
 

--- a/cpp/src/arrow/gpu/ArrowCUDAConfig.cmake.in
+++ b/cpp/src/arrow/gpu/ArrowCUDAConfig.cmake.in
@@ -27,7 +27,7 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
-find_dependency(Arrow)
+find_dependency(Arrow CONFIG)
 if(CMAKE_VERSION VERSION_LESS 3.17)
   find_package(CUDA REQUIRED)
   add_library(ArrowCUDA::cuda_driver SHARED IMPORTED)

--- a/cpp/src/gandiva/GandivaConfig.cmake.in
+++ b/cpp/src/gandiva/GandivaConfig.cmake.in
@@ -30,7 +30,7 @@ set(ARROW_LLVM_VERSIONS "@ARROW_LLVM_VERSIONS@")
 set(ARROW_ZSTD_SOURCE "@zstd_SOURCE@")
 
 include(CMakeFindDependencyMacro)
-find_dependency(Arrow)
+find_dependency(Arrow CONFIG)
 if(DEFINED CMAKE_MODULE_PATH)
   set(GANDIVA_CMAKE_MODULE_PATH_OLD ${CMAKE_MODULE_PATH})
 else()

--- a/cpp/src/parquet/ParquetConfig.cmake.in
+++ b/cpp/src/parquet/ParquetConfig.cmake.in
@@ -32,7 +32,7 @@
 set(PARQUET_SYSTEM_DEPENDENCIES "@PARQUET_SYSTEM_DEPENDENCIES@")
 
 include(CMakeFindDependencyMacro)
-find_dependency(Arrow)
+find_dependency(Arrow CONFIG)
 
 if(ARROW_BUILD_STATIC)
   arrow_find_dependencies("${PARQUET_SYSTEM_DEPENDENCIES}")


### PR DESCRIPTION
### Rationale for this change

If a downstream package has `FindArrow.cmake`, it may be used not our `ArrowConfig.cmake`.

### What changes are included in this PR?

Use `find_dependency(Arrow CONFIG)` instead of `find_dependency(Arrow)`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #46386