### PR TITLE
GH-46487: [C++] Refactor lz4 from ExternalProject to FetchContent

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -2677,7 +2677,9 @@ macro(build_lz4)
   # Make the dependency available - this will actually perform the download and configure
   fetchcontent_makeavailable(lz4_ep)
 
-  # Add lz4 as an interfece library so other targets can depend on it
+  # Use LZ4::lz4 as an imported library not an alias of lz4_static so other targets such as orc
+  # can depend on it as an external library. External libraries are ignored in
+  # install(TARGETS orc EXPORT orc_targets) and install(EXPORT orc_targets).
   add_library(LZ4::lz4 INTERFACE IMPORTED)
   target_link_libraries(LZ4::lz4 INTERFACE lz4_static)
 

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -4725,7 +4725,12 @@ function(build_orc)
                         INTERFACE_INCLUDE_DIRECTORIES)
     get_filename_component(ORC_SNAPPY_ROOT "${ORC_SNAPPY_INCLUDE_DIR}" DIRECTORY)
 
-    get_target_property(ORC_LZ4_ROOT LZ4::lz4 INTERFACE_INCLUDE_DIRECTORIES)
+    if(LZ4_VENDORED)
+      set(ORC_LZ4_TARGET lz4_static)
+    else()
+      set(ORC_LZ4_TARGET LZ4::lz4)
+    endif()
+    get_target_property(ORC_LZ4_ROOT ${ORC_LZ4_TARGET} INTERFACE_INCLUDE_DIRECTORIES)
     get_filename_component(ORC_LZ4_ROOT "${ORC_LZ4_ROOT}" DIRECTORY)
 
     get_target_property(ORC_ZSTD_ROOT ${ARROW_ZSTD_LIBZSTD} INTERFACE_INCLUDE_DIRECTORIES)
@@ -4751,8 +4756,8 @@ function(build_orc)
         "-DSNAPPY_HOME=${ORC_SNAPPY_ROOT}"
         "-DSNAPPY_LIBRARY=$<TARGET_FILE:${Snappy_TARGET}>"
         "-DLZ4_HOME=${ORC_LZ4_ROOT}"
-        "-DLZ4_LIBRARY=$<LZ4_TARGET>"
-        "-DLZ4_STATIC_LIB=$<LZ4_TARGET>"
+        "-DLZ4_LIBRARY=$<TARGET_FILE:${ORC_LZ4_TARGET}>"
+        "-DLZ4_STATIC_LIB=$<TARGET_FILE:${ORC_LZ4_TARGET}>"
         "-DLZ4_INCLUDE_DIR=${ORC_LZ4_ROOT}/include"
         "-DSNAPPY_INCLUDE_DIR=${ORC_SNAPPY_INCLUDE_DIR}"
         "-DZSTD_HOME=${ORC_ZSTD_ROOT}"

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -2677,26 +2677,8 @@ macro(build_lz4)
   # Make the dependency available - this will actually perform the download and configure
   fetchcontent_makeavailable(lz4_ep)
 
-  # Get the source and binary directories after fetching content
-  fetchcontent_getproperties(lz4_ep
-                             SOURCE_DIR LZ4_SOURCE_DIR
-                             BINARY_DIR LZ4_BINARY_DIR)
-
-  # Set up the imported library for compatibility with the rest of the build system
-  set(LZ4_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/_deps/lz4_ep-build")
-  set(LZ4_INCLUDE_DIR "${LZ4_SOURCE_DIR}/lib")
-
   # Since lz4 is now part of our build system, we can directly use the target
   add_library(LZ4::lz4 ALIAS lz4_static)
-
-  # Add lz4_static to the orc export set
-  if(NOT TARGET lz4_static)
-    message(FATAL_ERROR "Expected lz4_static target to be created by FetchContent")
-  endif()
-  if(NOT DEFINED CMAKE_EXPORT_NO_PACKAGE_REGISTRY)
-    set(CMAKE_EXPORT_NO_PACKAGE_REGISTRY ON)
-  endif()
-  install(TARGETS lz4_static EXPORT orc_targets)
 
   # Add to bundled static libs
   list(APPEND ARROW_BUNDLED_STATIC_LIBS LZ4::lz4)

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -2677,11 +2677,12 @@ macro(build_lz4)
   # Make the dependency available - this will actually perform the download and configure
   fetchcontent_makeavailable(lz4_ep)
 
-  # Since lz4 is now part of our build system, we can directly use the target
-  add_library(LZ4::lz4 ALIAS lz4_static)
+  # Add lz4 as an interfece library so other targets can depend on it
+  add_library(LZ4::lz4 INTERFACE IMPORTED)
+  target_link_libraries(LZ4::lz4 INTERFACE lz4_static)
 
   # Add to bundled static libs
-  list(APPEND ARROW_BUNDLED_STATIC_LIBS LZ4::lz4)
+  list(APPEND ARROW_BUNDLED_STATIC_LIBS lz4_static)
 endmacro()
 
 if(ARROW_WITH_LZ4)

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -2694,6 +2694,15 @@ if(ARROW_WITH_LZ4)
                      TRUE
                      PC_PACKAGE_NAMES
                      liblz4)
+
+  # Set the target name based on how LZ4 was resolved
+  if(TARGET lz4_static)
+    set(LZ4_TARGET lz4_static)
+  elseif(TARGET LZ4::lz4)
+    set(LZ4_TARGET LZ4::lz4)
+  else()
+    message(FATAL_ERROR "Unable to determine LZ4 target name")
+  endif()
 endif()
 
 macro(build_zstd)
@@ -4742,8 +4751,8 @@ function(build_orc)
         "-DSNAPPY_HOME=${ORC_SNAPPY_ROOT}"
         "-DSNAPPY_LIBRARY=$<TARGET_FILE:${Snappy_TARGET}>"
         "-DLZ4_HOME=${ORC_LZ4_ROOT}"
-        "-DLZ4_LIBRARY=$<TARGET_FILE:LZ4::lz4>"
-        "-DLZ4_STATIC_LIB=$<TARGET_FILE:LZ4::lz4>"
+        "-DLZ4_LIBRARY=$<LZ4_TARGET>"
+        "-DLZ4_STATIC_LIB=$<LZ4_TARGET>"
         "-DLZ4_INCLUDE_DIR=${ORC_LZ4_ROOT}/include"
         "-DSNAPPY_INCLUDE_DIR=${ORC_SNAPPY_INCLUDE_DIR}"
         "-DZSTD_HOME=${ORC_ZSTD_ROOT}"

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -2683,7 +2683,8 @@ macro(build_lz4)
   add_library(LZ4::lz4 INTERFACE IMPORTED)
   target_link_libraries(LZ4::lz4 INTERFACE lz4_static)
 
-  # Add to bundled static libs
+  # Add to bundled static libs.
+  # We must use lz4_static (not imported target) not LZ4::lz4 (imported target).
   list(APPEND ARROW_BUNDLED_STATIC_LIBS lz4_static)
 endmacro()
 


### PR DESCRIPTION
### Rationale for this change

`FetchContent` is easier to maintain than `ExternalProject` because we don't need to create import CMake targets manually with `FetchContent`.

### What changes are included in this PR?

Use `FetchContent` instead of `ExternalProject` for bundled LZ4.

### Are these changes tested?
Yes

### Are there any user-facing changes?
No

* GitHub Issue: #46487