### PR TITLE
GH-46394: [C++][R] gcc-UBSAN errors on CRAN 

### DIFF
--- a/cpp/src/arrow/csv/parser.cc
+++ b/cpp/src/arrow/csv/parser.cc
@@ -144,7 +144,11 @@ class ValueDescWriter {
 
  protected:
   ValueDescWriter(MemoryPool* pool, int64_t values_capacity)
-      : values_size_(0), values_capacity_(values_capacity), status_(Status::OK()) {
+      : values_size_(0),
+        values_capacity_(values_capacity),
+        quoted_(false),
+        saved_values_size_(0),
+        status_(Status::OK()) {
     status_ &= AllocateResizableBuffer(values_capacity_ * sizeof(*values_), pool)
                    .Value(&values_buffer_);
     if (status_.ok()) {

--- a/dev/tasks/r/github.linux.sanitizers.yml
+++ b/dev/tasks/r/github.linux.sanitizers.yml
@@ -1,0 +1,56 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+{% import 'macros.jinja' as macros with context %}
+
+{{ macros.github_header() }}
+
+jobs:
+  r-linux-sanitizers:
+    name: "rhub/{{ '${{ matrix.config.r_image }}' }}"
+    runs-on: ubuntu-latest
+    timeout-minutes: {{ timeout|default(60) }}
+{{ macros.github_set_env(env) }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          # See https://r-hub.github.io/containers/
+          - { r_image: "clang-asan", skip_vignettes: true }  
+          - { r_image: "clang-ubsan", skip_vignettes: true }  
+          - { r_image: "gcc-asan", skip_vignettes: true}  # includes both asan and ubsan
+    steps:
+      {{ macros.github_checkout_arrow()|indent }}
+      {{ macros.github_install_archery()|indent }}
+
+      - name: Docker Run
+        shell: bash
+        env:
+        {{ macros.github_set_sccache_envvars()|indent(8)}}
+        run: archery docker run -e SKIP_VIGNETTES={{ '${{ matrix.config.skip_vignettes }}' }} r-san
+      - name: Dump install logs
+        run: cat arrow/r/arrow.Rcheck/00install.out
+        if: always()
+      - name: Dump test logs
+        run: cat arrow/r/arrow.Rcheck/tests/testthat.Rout*
+        if: always()
+      - name: Save the test output
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-output-{{ "${{ matrix.config.r_image }}" }}
+          path: arrow/r/arrow.Rcheck/tests/testthat.Rout*

--- a/dev/tasks/r/github.linux.sanitizers.yml
+++ b/dev/tasks/r/github.linux.sanitizers.yml
@@ -24,7 +24,11 @@ jobs:
     name: "rhub/{{ '${{ matrix.config.r_image }}' }}"
     runs-on: ubuntu-latest
     timeout-minutes: {{ timeout|default(60) }}
-{{ macros.github_set_env(env) }}
+    env:
+      R_PRUNE_DEPS: TRUE
+      R_ORG: "rhub"
+      R_IMAGE: "{{ '${{ matrix.config.r_image }}' }}"
+      R_TAG: "latest"
     strategy:
       fail-fast: false
       matrix:

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1081,30 +1081,17 @@ tasks:
       r_tag: latest
       flags: "-e LIBARROW_MINIMAL=TRUE"
 
-  test-r-linux-sanitizer:
+  test-r-linux-sanitizers:
     ci: github
-    template: docker-tests/github.linux.yml
+    template: r/github.linux.sanitizers.yml
     params:
       env:
         R_PRUNE_DEPS: TRUE
-      image: ubuntu-r-sanitizer
-      timeout: 120
-
-  test-r-clang-asan:
-    ci: github
-    template: docker-tests/github.linux.yml
-    params:
-      env:
-        R_PRUNE_DEPS: TRUE
-      image: r-clang-asan
-
-  test-r-clang-ubsan:
-    ci: github
-    template: docker-tests/github.linux.yml
-    params:
-      env:
-        R_PRUNE_DEPS: TRUE
-      image: r-clang-ubsan
+        R_ORG: "rhub"
+        R_IMAGE: "{{ '${{ matrix.config.r_image }}' }}"
+        R_TAG: "latest"
+        ARROW_R_DEV: "TRUE"
+      timeout: 240 # 4 hours
 
   test-r-m1-san:
     ci: github

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1085,12 +1085,6 @@ tasks:
     ci: github
     template: r/github.linux.sanitizers.yml
     params:
-      env:
-        R_PRUNE_DEPS: TRUE
-        R_ORG: "rhub"
-        R_IMAGE: "{{ '${{ matrix.config.r_image }}' }}"
-        R_TAG: "latest"
-        ARROW_R_DEV: "TRUE"
       timeout: 240 # 4 hours
 
   test-r-m1-san:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -158,14 +158,12 @@ x-hierarchy:
   - ubuntu-cpp-sanitizer
   - ubuntu-cpp-thread-sanitizer
   - ubuntu-cpp-emscripten
-  - ubuntu-r-sanitizer
   - ubuntu-r-valgrind
   - ubuntu-swift
   - ubuntu-verify-rc
-  - r-clang-asan
-  - r-clang-ubsan
   - r
   - r-revdepcheck
+  - r-san
   # helper services
   - impala
   - postgres
@@ -1690,70 +1688,15 @@ services:
     command: >
       /bin/bash -c "/arrow/ci/scripts/r_test.sh /arrow"
 
-  ubuntu-r-sanitizer:
-    # Only amd64 supported
-    # Usage:
-    #   docker compose build ubuntu-r-sanitizer
-    #   docker compose run ubuntu-r-sanitizer
-    image: ${REPO}:amd64-ubuntu-r-sanitizer
-    cap_add:
-      # LeakSanitizer and gdb requires ptrace(2)
-      - SYS_PTRACE
+  r-san:
+    image: ${REPO}:r-${R_ORG}-${R_IMAGE}
     build:
       context: .
       dockerfile: ci/docker/linux-r.dockerfile
       cache_from:
-        - ${REPO}:amd64-ubuntu-r-sanitizer
+        - ${REPO}:r-${R_ORG}-${R_IMAGE}
       args:
-        base: wch1/r-debug:latest
-        cmake: ${CMAKE}
-        r_bin: RDsan
-        tz: ${TZ}
-        r_prune_deps: ${R_PRUNE_DEPS}
-    environment:
-      <<: [*common, *ccache]
-      ARROW_SOURCE_HOME: "/arrow"
-    volumes: *ubuntu-volumes
-    command: >
-      /bin/bash -c "
-        /arrow/ci/scripts/r_sanitize.sh /arrow"
-
-  r-clang-asan:
-    image: ${REPO}:r-rhub-clang-devel-latest
-    build:
-      context: .
-      dockerfile: ci/docker/linux-r.dockerfile
-      cache_from:
-        - ${REPO}:r-rhub-clang-devel-latest
-      args:
-        base: rhub/clang-asan
-        cmake: ${CMAKE}
-        r_dev: ${ARROW_R_DEV}
-        r_bin: R
-        tz: ${TZ}
-        r_prune_deps: ${R_PRUNE_DEPS}
-    shm_size: *shm-size
-    environment:
-      <<: *common
-      LIBARROW_DOWNLOAD: "false"
-      ARROW_SOURCE_HOME: "/arrow"
-      ARROW_R_DEV: ${ARROW_R_DEV}
-      ARROW_USE_PKG_CONFIG: "false"
-    volumes:
-      - .:/arrow:delegated
-    command: >
-      /bin/bash -c "
-        /arrow/ci/scripts/r_sanitize.sh /arrow"
-
-  r-clang-ubsan:
-    image: ${REPO}:r-rhub-clang-ubsan-devel-latest
-    build:
-      context: .
-      dockerfile: ci/docker/linux-r.dockerfile
-      cache_from:
-        - ${REPO}:r-rhub-clang-ubsan-devel-latest
-      args:
-        base: rhub/clang-ubsan
+        base: ${R_ORG}/${R_IMAGE}:${R_TAG}
         cmake: ${CMAKE}
         r_dev: ${ARROW_R_DEV}
         r_bin: R


### PR DESCRIPTION
### Rationale for this change

Fix gcc-UBSAN CI job to be correctly running, then fix the UBSAN error.

### What changes are included in this PR?

* Generalize our sanitizer jobs and use rhub's containers for this. wch/r-debug looks like it's out of date (hence why we didn't catch this), and it's easier to use a matrix of images with rhubarb anyway.
* Initialize the `_quoted` variable — we could also cast it to boolean where the UBSAN popped, but this seems to be enough.

### Are these changes tested?

Yes

### Are there any user-facing changes?

No
* GitHub Issue: #46394