### PR TITLE
GH-46398: [GLib] Add GArrowFixedShapeTensorDataType#n_dimensions

### DIFF
--- a/c_glib/arrow-glib/basic-data-type.cpp
+++ b/c_glib/arrow-glib/basic-data-type.cpp
@@ -2270,9 +2270,34 @@ garrow_string_view_data_type_new(void)
   return data_type;
 }
 
+enum {
+  PROP_NDIM = 1
+};
+
 G_DEFINE_TYPE(GArrowFixedShapeTensorDataType,
               garrow_fixed_shape_tensor_data_type,
               GARROW_TYPE_EXTENSION_DATA_TYPE)
+
+static void
+garrow_fixed_shape_tensor_data_type_get_property(GObject *object,
+                                                 guint prop_id,
+                                                 GValue *value,
+                                                 GParamSpec *pspec)
+{
+  switch (prop_id) {
+  case PROP_NDIM:
+    {
+      auto arrow_data_type =
+        std::static_pointer_cast<arrow::extension::FixedShapeTensorType>(
+          garrow_data_type_get_raw(GARROW_DATA_TYPE(object)));
+      g_value_set_uint64(value, arrow_data_type->ndim());
+    }
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
 
 static void
 garrow_fixed_shape_tensor_data_type_init(GArrowFixedShapeTensorDataType *object)
@@ -2282,6 +2307,19 @@ garrow_fixed_shape_tensor_data_type_init(GArrowFixedShapeTensorDataType *object)
 static void
 garrow_fixed_shape_tensor_data_type_class_init(GArrowFixedShapeTensorDataTypeClass *klass)
 {
+  GParamSpec *spec;
+
+  auto gobject_class = G_OBJECT_CLASS(klass);
+  gobject_class->get_property = garrow_fixed_shape_tensor_data_type_get_property;
+
+  spec = g_param_spec_uint64("ndim",
+                             "Ndim",
+                             "Number of dimensions of tensor elements",
+                             0,
+                             G_MAXUINT64,
+                             0,
+                             static_cast<GParamFlags>(G_PARAM_READABLE));
+  g_object_class_install_property(gobject_class, PROP_NDIM, spec);
 }
 
 /**

--- a/c_glib/arrow-glib/basic-data-type.cpp
+++ b/c_glib/arrow-glib/basic-data-type.cpp
@@ -2271,7 +2271,7 @@ garrow_string_view_data_type_new(void)
 }
 
 enum {
-  PROP_N_DIMS = 1
+  PROP_N_DIMENSIONS = 1
 };
 
 G_DEFINE_TYPE(GArrowFixedShapeTensorDataType,
@@ -2285,7 +2285,7 @@ garrow_fixed_shape_tensor_data_type_get_property(GObject *object,
                                                  GParamSpec *pspec)
 {
   switch (prop_id) {
-  case PROP_N_DIMS:
+  case PROP_N_DIMENSIONS:
     {
       auto arrow_data_type =
         std::static_pointer_cast<arrow::extension::FixedShapeTensorType>(
@@ -2312,14 +2312,14 @@ garrow_fixed_shape_tensor_data_type_class_init(GArrowFixedShapeTensorDataTypeCla
   auto gobject_class = G_OBJECT_CLASS(klass);
   gobject_class->get_property = garrow_fixed_shape_tensor_data_type_get_property;
 
-  spec = g_param_spec_uint64("n_dims",
-                             "Ndims",
+  spec = g_param_spec_uint64("n_dimensions",
+                             "NDimensions",
                              "Number of dimensions of tensor elements",
                              0,
                              G_MAXUINT64,
                              0,
                              static_cast<GParamFlags>(G_PARAM_READABLE));
-  g_object_class_install_property(gobject_class, PROP_N_DIMS, spec);
+  g_object_class_install_property(gobject_class, PROP_N_DIMENSIONS, spec);
 }
 
 /**

--- a/c_glib/arrow-glib/basic-data-type.cpp
+++ b/c_glib/arrow-glib/basic-data-type.cpp
@@ -2320,7 +2320,7 @@ garrow_fixed_shape_tensor_data_type_class_init(GArrowFixedShapeTensorDataTypeCla
    * Since: 21.0.0
    */
   spec = g_param_spec_uint64("n_dimensions",
-                             "NDimensions",
+                             "N dimensions",
                              "Number of dimensions of tensor elements",
                              0,
                              G_MAXUINT64,

--- a/c_glib/arrow-glib/basic-data-type.cpp
+++ b/c_glib/arrow-glib/basic-data-type.cpp
@@ -2312,6 +2312,13 @@ garrow_fixed_shape_tensor_data_type_class_init(GArrowFixedShapeTensorDataTypeCla
   auto gobject_class = G_OBJECT_CLASS(klass);
   gobject_class->get_property = garrow_fixed_shape_tensor_data_type_get_property;
 
+  /**
+   * GArrowFixedShapeTensorDataType::n-dimensions:
+   *
+   * The number of dimensions of tensor elements.
+   *
+   * Since: 21.0.0
+   */
   spec = g_param_spec_uint64("n_dimensions",
                              "NDimensions",
                              "Number of dimensions of tensor elements",

--- a/c_glib/arrow-glib/basic-data-type.cpp
+++ b/c_glib/arrow-glib/basic-data-type.cpp
@@ -2271,7 +2271,7 @@ garrow_string_view_data_type_new(void)
 }
 
 enum {
-  PROP_NDIM = 1
+  PROP_N_DIMS = 1
 };
 
 G_DEFINE_TYPE(GArrowFixedShapeTensorDataType,
@@ -2285,7 +2285,7 @@ garrow_fixed_shape_tensor_data_type_get_property(GObject *object,
                                                  GParamSpec *pspec)
 {
   switch (prop_id) {
-  case PROP_NDIM:
+  case PROP_N_DIMS:
     {
       auto arrow_data_type =
         std::static_pointer_cast<arrow::extension::FixedShapeTensorType>(
@@ -2312,14 +2312,14 @@ garrow_fixed_shape_tensor_data_type_class_init(GArrowFixedShapeTensorDataTypeCla
   auto gobject_class = G_OBJECT_CLASS(klass);
   gobject_class->get_property = garrow_fixed_shape_tensor_data_type_get_property;
 
-  spec = g_param_spec_uint64("ndim",
-                             "Ndim",
+  spec = g_param_spec_uint64("n_dims",
+                             "Ndims",
                              "Number of dimensions of tensor elements",
                              0,
                              G_MAXUINT64,
                              0,
                              static_cast<GParamFlags>(G_PARAM_READABLE));
-  g_object_class_install_property(gobject_class, PROP_NDIM, spec);
+  g_object_class_install_property(gobject_class, PROP_N_DIMS, spec);
 }
 
 /**

--- a/c_glib/test/test-fixed-shape-tensor-data-type.rb
+++ b/c_glib/test/test-fixed-shape-tensor-data-type.rb
@@ -32,8 +32,8 @@ class TestFixedShapeTensorDataType < Test::Unit::TestCase
                  [@data_type.name, @data_type.extension_name])
   end
 
-  def test_ndim
-    assert_equal(2, @data_type.ndim)
+  def test_ndims
+    assert_equal(2, @data_type.n_dims)
   end
 
   def test_shape

--- a/c_glib/test/test-fixed-shape-tensor-data-type.rb
+++ b/c_glib/test/test-fixed-shape-tensor-data-type.rb
@@ -32,6 +32,10 @@ class TestFixedShapeTensorDataType < Test::Unit::TestCase
                  [@data_type.name, @data_type.extension_name])
   end
 
+  def test_ndim
+    assert_equal(2, @data_type.ndim)
+  end
+
   def test_shape
     assert_equal([3, 4], @data_type.shape)
   end

--- a/c_glib/test/test-fixed-shape-tensor-data-type.rb
+++ b/c_glib/test/test-fixed-shape-tensor-data-type.rb
@@ -32,8 +32,8 @@ class TestFixedShapeTensorDataType < Test::Unit::TestCase
                  [@data_type.name, @data_type.extension_name])
   end
 
-  def test_n_dims
-    assert_equal(2, @data_type.n_dims)
+  def test_n_dimensions
+    assert_equal(2, @data_type.n_dimensions)
   end
 
   def test_shape

--- a/c_glib/test/test-fixed-shape-tensor-data-type.rb
+++ b/c_glib/test/test-fixed-shape-tensor-data-type.rb
@@ -32,7 +32,7 @@ class TestFixedShapeTensorDataType < Test::Unit::TestCase
                  [@data_type.name, @data_type.extension_name])
   end
 
-  def test_ndims
+  def test_n_dims
     assert_equal(2, @data_type.n_dims)
   end
 


### PR DESCRIPTION
### Rationale for this change

The C++ API implemented `FixedShapeTensor::ndim()` instance method. GLib was not yet supported.

### What changes are included in this PR?

Add `GArrowFixedShapeTensorDataType#n_dimensions` instance method.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #46398