### PR TITLE
GH-46400: [GLib] Add GArrowFixedShapeDataType#permutation

### DIFF
--- a/c_glib/arrow-glib/basic-data-type.cpp
+++ b/c_glib/arrow-glib/basic-data-type.cpp
@@ -2369,7 +2369,7 @@ garrow_fixed_shape_tensor_data_type_get_shape(GArrowFixedShapeTensorDataType *da
 /**
  * garrow_fixed_shape_tensor_data_type_get_permutation:
  * @data_type: A #GArrowFixedShapeTensorDataType.
- * @length: (out): Return location for the number of permutations of the tensor.
+ * @length: (out): Return location for the number of elements of permutation.
  *
  * Returns: (array length=length): Permutation of the tensor.
  */

--- a/c_glib/arrow-glib/basic-data-type.cpp
+++ b/c_glib/arrow-glib/basic-data-type.cpp
@@ -2369,7 +2369,7 @@ garrow_fixed_shape_tensor_data_type_get_shape(GArrowFixedShapeTensorDataType *da
 /**
  * garrow_fixed_shape_tensor_data_type_get_permutation:
  * @data_type: A #GArrowFixedShapeTensorDataType.
- * @length: (out): Return location for the number of dimensions of the tensor.
+ * @length: (out): Return location for the number of permutations of the tensor.
  *
  * Returns: (array length=length): Permutation of the tensor.
  */

--- a/c_glib/arrow-glib/basic-data-type.cpp
+++ b/c_glib/arrow-glib/basic-data-type.cpp
@@ -2366,6 +2366,24 @@ garrow_fixed_shape_tensor_data_type_get_shape(GArrowFixedShapeTensorDataType *da
   return arrow_shape.data();
 }
 
+/**
+ * garrow_fixed_shape_tensor_data_type_get_permutation:
+ * @data_type: A #GArrowFixedShapeTensorDataType.
+ * @length: (out): Return location for the number of dimensions of the tensor.
+ *
+ * Returns: (array length=length): Permutation of the tensor.
+ */
+const gint64 *
+garrow_fixed_shape_tensor_data_type_get_permutation(
+  GArrowFixedShapeTensorDataType *data_type, gsize *length)
+{
+  auto arrow_data_type = std::static_pointer_cast<arrow::extension::FixedShapeTensorType>(
+    garrow_data_type_get_raw(GARROW_DATA_TYPE(data_type)));
+
+  const auto &arrow_permutation = arrow_data_type->permutation();
+  *length = arrow_permutation.size();
+  return arrow_permutation.data();
+}
 G_END_DECLS
 
 GArrowDataType *

--- a/c_glib/arrow-glib/basic-data-type.h
+++ b/c_glib/arrow-glib/basic-data-type.h
@@ -830,4 +830,9 @@ GARROW_AVAILABLE_IN_21_0
 const gint64 *
 garrow_fixed_shape_tensor_data_type_get_shape(GArrowFixedShapeTensorDataType *data_type,
                                               gsize *length);
+
+GARROW_AVAILABLE_IN_21_0
+const gint64 *
+garrow_fixed_shape_tensor_data_type_get_permutation(
+  GArrowFixedShapeTensorDataType *data_type, gsize *length);
 G_END_DECLS

--- a/c_glib/test/test-fixed-shape-tensor-data-type.rb
+++ b/c_glib/test/test-fixed-shape-tensor-data-type.rb
@@ -36,6 +36,10 @@ class TestFixedShapeTensorDataType < Test::Unit::TestCase
     assert_equal([3, 4], @data_type.shape)
   end
 
+  def test_permutation
+    assert_equal([1, 0], @data_type.permutation)
+  end
+
   def test_to_s
     assert do
       @data_type.to_s.start_with?("extension<arrow.fixed_shape_tensor")
@@ -47,8 +51,7 @@ class TestFixedShapeTensorDataType < Test::Unit::TestCase
                                                     [3, 4],
                                                     nil,
                                                     ["x", "y"])
-    # TODO: Use Arrow::FixedShapeTensorDataType#permutation
-    assert_equal(Arrow::Type::EXTENSION, data_type.id)
+    assert_equal([], data_type.permutation)
   end
 
   def test_nil_dim_names


### PR DESCRIPTION
### Rationale for this change

The C++ API implemented `FixedShapeTensor::permutation()` instance method. GLib was not yet supported.

### What changes are included in this PR?

Add `GArrowFixedShapeDataType#permutation` instance method.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #46400