### PR TITLE
GH-46376: [Docs] Replace Xitter link with BlueSky link

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 [![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/arrow.svg)](https://bugs.chromium.org/p/oss-fuzz/issues/list?sort=-opened&can=1&q=proj:arrow)
 [![License](http://img.shields.io/:license-Apache%202-blue.svg)](https://github.com/apache/arrow/blob/main/LICENSE.txt)
-[![Twitter Follow](https://img.shields.io/twitter/follow/apachearrow.svg?style=social&label=Follow)](https://twitter.com/apachearrow)
+[![BlueSky Follow](https://img.shields.io/badge/bluesky-Follow-blue?logo=bluesky)](https://bsky.app/profile/arrow.apache.org)
 
 ## Powering In-Memory Analytics
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -357,9 +357,9 @@ html_theme_options = {
             "icon": "fa-brands fa-linkedin",
         },
         {
-            "name": "X",
-            "url": "https://twitter.com/ApacheArrow",
-            "icon": "fa-brands fa-square-x-twitter",
+            "name": "BlueSky",
+            "url": "https://bsky.app/profile/arrow.apache.org",
+            "icon": "fa-brands fa-bluesky",
         },
     ],
     "show_version_warning_banner": True,

--- a/docs/source/developers/release.rst
+++ b/docs/source/developers/release.rst
@@ -300,7 +300,7 @@ Be sure to go through on the following checklist:
 #. Update version in Apache Arrow Cookbook
 #. Announce the new release
 #. Publish release blog posts
-#. Announce the release on Twitter
+#. Announce the release on BlueSky
 #. Remove old artifacts
 
 .. dropdown:: Merge changes on release branch to maintenance branch for patch releases
@@ -703,7 +703,7 @@ Be sure to go through on the following checklist:
    Post about the release and link to the blog post on social media. The project
    has two official accounts:
 
-   * Twitter/X: `@ApacheArrow <https://twitter.com/ApacheArrow>`_
+   * BlueSky: `@arrow.apache.org <https://bsky.app/profile/arrow.apache.org>`_
    * LinkedIn: https://www.linkedin.com/company/apache-arrow/
 
    PMC members have access or can request access to post under these accounts.

--- a/r/_pkgdown.yml
+++ b/r/_pkgdown.yml
@@ -60,9 +60,9 @@ template:
     image:
       src: https://arrow.apache.org/img/arrow-logo_horizontal_black-txt_white-bg.png
       alt: "Apache Arrow logo, displaying the triple chevron image adjacent to the text"
-    twitter:
-      creator: "@apachearrow"
-      site: "@apachearrow"
+    BlueSky:
+      creator: "@arrow.apache.org"
+      site: "@arrow.apache.org"
       card: summary_large_image
 
 home:

--- a/r/_pkgdown.yml
+++ b/r/_pkgdown.yml
@@ -60,10 +60,6 @@ template:
     image:
       src: https://arrow.apache.org/img/arrow-logo_horizontal_black-txt_white-bg.png
       alt: "Apache Arrow logo, displaying the triple chevron image adjacent to the text"
-    BlueSky:
-      creator: "@arrow.apache.org"
-      site: "@arrow.apache.org"
-      card: summary_large_image
 
 home:
   title: Arrow R Package


### PR DESCRIPTION
### Rationale for this change

We moved from Xitter to BlueSky.

### What changes are included in this PR?

The docs are updated to point to new BlueSky account.

### Are these changes tested?

No, only docs change.

### Are there any user-facing changes?

No.

* GitHub Issue: #46376