### PR TITLE
GH-46407: [C++] Fix IPC serialization of sliced list arrays

### DIFF
--- a/cpp/src/arrow/ipc/feather_test.cc
+++ b/cpp/src/arrow/ipc/feather_test.cc
@@ -319,26 +319,23 @@ TEST_P(TestFeather, SliceBooleanRoundTrip) {
   CheckSlices(batch);
 }
 
-TEST_P(TestFeather, SliceListsRoundTrip) {
+TEST_P(TestFeather, SliceListRoundTrip) {
   if (GetParam().version == kFeatherV1Version) {
-    // IPC V1 does not support list<int>.
-    return;
+    GTEST_SKIP() << "Feather V1 does not support list types";
   }
   std::shared_ptr<RecordBatch> batch;
   ASSERT_OK(ipc::test::MakeListRecordBatchSized(600, &batch));
   CheckSlices(batch);
 }
 
-TEST_P(TestFeather, SliceListsViewRoundTrip) {
+TEST_P(TestFeather, SliceListViewRoundTrip) {
   if (GetParam().version == kFeatherV1Version) {
-    // IPC V1 does not support list<int>.
-    return;
+    GTEST_SKIP() << "Feather V1 does not support list view types";
   }
   std::shared_ptr<RecordBatch> batch;
   ASSERT_OK(ipc::test::MakeListViewRecordBatchSized(600, &batch));
   CheckSlices(batch);
 }
-
 
 INSTANTIATE_TEST_SUITE_P(
     FeatherTests, TestFeather,

--- a/cpp/src/arrow/ipc/feather_test.cc
+++ b/cpp/src/arrow/ipc/feather_test.cc
@@ -319,6 +319,27 @@ TEST_P(TestFeather, SliceBooleanRoundTrip) {
   CheckSlices(batch);
 }
 
+TEST_P(TestFeather, SliceListsRoundTrip) {
+  if (GetParam().version == kFeatherV1Version) {
+    // IPC V1 does not support list<int>.
+    return;
+  }
+  std::shared_ptr<RecordBatch> batch;
+  ASSERT_OK(ipc::test::MakeListRecordBatchSized(600, &batch));
+  CheckSlices(batch);
+}
+
+TEST_P(TestFeather, SliceListsViewRoundTrip) {
+  if (GetParam().version == kFeatherV1Version) {
+    // IPC V1 does not support list<int>.
+    return;
+  }
+  std::shared_ptr<RecordBatch> batch;
+  ASSERT_OK(ipc::test::MakeListViewRecordBatchSized(600, &batch));
+  CheckSlices(batch);
+}
+
+
 INSTANTIATE_TEST_SUITE_P(
     FeatherTests, TestFeather,
     ::testing::Values(TestParam(kFeatherV1Version), TestParam(kFeatherV2Version),

--- a/cpp/src/arrow/ipc/read_write_test.cc
+++ b/cpp/src/arrow/ipc/read_write_test.cc
@@ -584,13 +584,7 @@ TEST_F(TestIpcRoundTrip, AlienSlice) {
   // way": by slicing the value_offsets buffer, but keeping top-level offset at
   // 0.
 
-  // Values buffer [1, 2, 3, 4, 5]
-  TypedBufferBuilder<int32_t> values_builder;
-  ASSERT_OK(values_builder.Reserve(5));
-  for (int32_t i = 1; i <= 5; i++) {
-    ASSERT_OK(values_builder.Append(i));
-  }
-  ASSERT_OK_AND_ASSIGN(auto values_buffer, values_builder.Finish());
+  auto child_data = ArrayFromJSON(int32(), "[1, 2, 3, 4, 5]")->data();
 
   // Offsets buffer [2, 5]
   TypedBufferBuilder<int32_t> offsets_builder;
@@ -599,10 +593,6 @@ TEST_F(TestIpcRoundTrip, AlienSlice) {
   ASSERT_OK(offsets_builder.Append(5));
   ASSERT_OK_AND_ASSIGN(auto offsets_buffer, offsets_builder.Finish());
 
-  // Construct the (nested) array.
-  auto child_data = ArrayData::Make(arrow::int32(),
-                                    /*num_rows=*/5,
-                                    /*buffers=*/{nullptr, values_buffer});
   auto list_data = ArrayData::Make(list(int32()),
                                    /*num_rows=*/1,
                                    /*buffers=*/{nullptr, offsets_buffer});

--- a/cpp/src/arrow/ipc/read_write_test.cc
+++ b/cpp/src/arrow/ipc/read_write_test.cc
@@ -579,11 +579,10 @@ TEST_F(TestIpcRoundTrip, SpecificMetadataVersion) {
   TestMetadataVersion(MetadataVersion::V5);
 }
 
-TEST_F(TestIpcRoundTrip, AlienSlice) {
+TEST_F(TestIpcRoundTrip, ListWithSlicedValues) {
   // This tests serialization of a sliced ListArray that got sliced "the Rust
   // way": by slicing the value_offsets buffer, but keeping top-level offset at
   // 0.
-
   auto child_data = ArrayFromJSON(int32(), "[1, 2, 3, 4, 5]")->data();
 
   // Offsets buffer [2, 5]

--- a/cpp/src/arrow/ipc/test_common.cc
+++ b/cpp/src/arrow/ipc/test_common.cc
@@ -421,7 +421,7 @@ Status MakeNullRecordBatch(std::shared_ptr<RecordBatch>* out) {
   return Status::OK();
 }
 
-Status MakeListRecordBatch(std::shared_ptr<RecordBatch>* out) {
+Status MakeListRecordBatchSized(const int length, std::shared_ptr<RecordBatch>* out) {
   // Make the schema
   auto f0 = field("f0", list(int32()));
   auto f1 = field("f1", list(list(int32())));
@@ -431,7 +431,6 @@ Status MakeListRecordBatch(std::shared_ptr<RecordBatch>* out) {
   // Example data
 
   MemoryPool* pool = default_memory_pool();
-  const int length = 200;
   std::shared_ptr<Array> leaf_values, list_array, list_list_array, large_list_array;
   const bool include_nulls = true;
   RETURN_NOT_OK(MakeRandomInt32Array(1000, include_nulls, pool, &leaf_values));
@@ -446,7 +445,11 @@ Status MakeListRecordBatch(std::shared_ptr<RecordBatch>* out) {
   return Status::OK();
 }
 
-Status MakeListViewRecordBatch(std::shared_ptr<RecordBatch>* out) {
+Status MakeListRecordBatch(std::shared_ptr<RecordBatch>* out) {
+  return MakeListRecordBatchSized(200, out);
+}
+
+Status MakeListViewRecordBatchSized(const int length, std::shared_ptr<RecordBatch>* out) {
   // Make the schema
   auto f0 = field("f0", list_view(int32()));
   auto f1 = field("f1", list_view(list_view(int32())));
@@ -456,7 +459,6 @@ Status MakeListViewRecordBatch(std::shared_ptr<RecordBatch>* out) {
   // Example data
 
   MemoryPool* pool = default_memory_pool();
-  const int length = 200;
   std::shared_ptr<Array> leaf_values, list_array, list_list_array, large_list_array;
   const bool include_nulls = true;
   RETURN_NOT_OK(MakeRandomInt32Array(1000, include_nulls, pool, &leaf_values));
@@ -469,6 +471,10 @@ Status MakeListViewRecordBatch(std::shared_ptr<RecordBatch>* out) {
   *out =
       RecordBatch::Make(schema, length, {list_array, list_list_array, large_list_array});
   return Status::OK();
+}
+
+Status MakeListViewRecordBatch(std::shared_ptr<RecordBatch>* out) {
+  return MakeListRecordBatchSized(200, out);
 }
 
 Status MakeFixedSizeListRecordBatch(std::shared_ptr<RecordBatch>* out) {

--- a/cpp/src/arrow/ipc/test_common.h
+++ b/cpp/src/arrow/ipc/test_common.h
@@ -105,7 +105,13 @@ ARROW_TESTING_EXPORT
 Status MakeNullRecordBatch(std::shared_ptr<RecordBatch>* out);
 
 ARROW_TESTING_EXPORT
+Status MakeListRecordBatchSized(int length, std::shared_ptr<RecordBatch>* out);
+
+ARROW_TESTING_EXPORT
 Status MakeListRecordBatch(std::shared_ptr<RecordBatch>* out);
+
+ARROW_TESTING_EXPORT
+Status MakeListViewRecordBatchSized(int length, std::shared_ptr<RecordBatch>* out);
 
 ARROW_TESTING_EXPORT
 Status MakeListViewRecordBatch(std::shared_ptr<RecordBatch>* out);

--- a/cpp/src/arrow/ipc/writer.cc
+++ b/cpp/src/arrow/ipc/writer.cc
@@ -327,11 +327,9 @@ class RecordBatchSerializer {
     auto offsets = array.value_offsets();
 
     int64_t required_bytes = sizeof(offset_type) * (array.length() + 1);
-    if (array.offset() != 0) {
-      // If we have a non-zero offset, then the value offsets do not start at
-      // zero. We must a) create a new offsets array with shifted offsets and
-      // b) slice the values array accordingly
-
+    if (array.offset() != 0 || (array.length() > 0 && array.value_offset(0) > 0)) {
+      // If we have a non-zero offset, we must create a new offsets buffer with
+      // shifted offsets.
       ARROW_ASSIGN_OR_RAISE(auto shifted_offsets,
                             AllocateBuffer(required_bytes, options_.memory_pool));
 


### PR DESCRIPTION
### Rationale for this change

Arrow C++ slices arrays by bumping the top-level `offset` value.
However, Arrow Rust slices list arrays by slicing the `value_offsets`
buffer. When receiving a Rust Arrow Array in C++ (via the C data
interface), its IPC serialization fails to notice that the
`value_offsets` buffer needed to be updated, but it still updates the
`values` buffer.  This leads to a corrupt array on deserialization, with
an `value_offsets` buffer that points past the end of the values array.

This PR fixes the IPC serialization by also looking at value_offset(0) to
determine whether the `value_offsets` buffer needs reconstructing,
instead of only looking at offset().
This works because value_offset(int) is the offets buffer, shifted by the top-level offset.
We still need to check for offset(), to account for array starting with an empty list (multiple
zeroes at the start of the offsets buffer).

### What changes are included in this PR?

The fix and nothing else

### Are these changes tested?

Yes

### Are there any user-facing changes?

No (well, unless they are affected by the bug)

**This PR contains a "Critical Fix".** (the changes fix (b) a bug that caused incorrect or invalid data to be produced) : valid operations on valid data produce invalid data.

* GitHub Issue: #46407