### PR TITLE
GH-46375: [C++] Add adapters/orc to Meson configuration

### DIFF
--- a/cpp/meson.build
+++ b/cpp/meson.build
@@ -76,12 +76,13 @@ or needs_fuzzing
 or needs_integration
 )
 needs_json = get_option('json').enabled() or needs_testing
+needs_orc = get_option('orc').enabled()
 needs_brotli = get_option('brotli').enabled() or needs_fuzzing
 needs_bz2 = get_option('bz2').enabled()
-needs_lz4 = get_option('lz4').enabled()
-needs_snappy = get_option('snappy').enabled()
-needs_zlib = get_option('zlib').enabled()
-needs_zstd = get_option('zstd').enabled()
+needs_lz4 = get_option('lz4').enabled() or needs_orc
+needs_snappy = get_option('snappy').enabled() or needs_orc
+needs_zlib = get_option('zlib').enabled() or needs_orc
+needs_zstd = get_option('zstd').enabled() or needs_orc
 needs_utilities = get_option('utilities').enabled()
 
 subdir('src/arrow')

--- a/cpp/meson.options
+++ b/cpp/meson.options
@@ -61,6 +61,7 @@ option(
     description: 'Build with lz4 compression',
 )
 
+option('orc', type: 'feature', description: 'Build the Arrow ORC adapter')
 option(
     'package_kind',
     type: 'string',

--- a/cpp/src/arrow/adapters/orc/meson.build
+++ b/cpp/src/arrow/adapters/orc/meson.build
@@ -1,0 +1,32 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+install_headers(['adapter.h', 'options.h'], subdir: 'arrow/adapters/orc')
+
+pkg.generate(
+    filebase: 'arrow-orc',
+    name: 'Apache Arrow ORC',
+    description: 'ORC modules for Apache Arrow',
+    requires: ['arrow'],
+)
+
+exc = executable(
+    'arrow-orc-adapter-test',
+    sources: ['adapter_test.cc'],
+    dependencies: [arrow_test_dep, orc_dep],
+)
+test('arrow-orc-adapter-test', exc)

--- a/cpp/src/arrow/meson.build
+++ b/cpp/src/arrow/meson.build
@@ -456,6 +456,60 @@ if needs_json
     }
 endif
 
+if needs_orc
+    absel_base_dep = dependency('absl_base')
+    absel_strings_dep = dependency('absl_strings')
+    absel_string_view_dep = dependency('absl_string_view')
+    protobuf_proj = subproject('protobuf')
+    protobuf_lib = protobuf_proj.get_variable('libprotobuf')
+    protoc_lib = protobuf_proj.get_variable('libprotoc')
+    protoc = find_program('protoc')
+    protoc_path = protoc.full_path()
+    # Internally we could use protobuf_proj.get_variable('incdir')
+    # to get the include directory from protobuf, but Meson does
+    # not allow you to convert that to a string, which CMake requires
+    # As a workaround, we start with the protoc path and manipulate
+    # the path strings as needed
+    proto_root = meson.project_source_root() / 'subprojects' / 'protobuf-25.2'
+    absl_root = meson.project_source_root() / 'subprojects' / 'abseil-cpp-20240722.0'
+
+    cmake = import('cmake')
+    orc_opt = cmake.subproject_options()
+    orc_opt.add_cmake_defines(
+        {'STOP_BUILD_ON_WARNING': 'FALSE'},
+        {'BUILD_LIBHDFSPP': 'FALSE'},
+        {'BUILD_JAVA': 'FALSE'},
+        {'BUILD_TOOLS': 'FALSE'},
+        {'BUILD_CPP_TESTS': 'FALSE'},
+        {'INSTALL_VENDORED_LIBS': 'FALSE'},
+        {'PROTOBUF_HOME': proto_root / 'src'},
+        {'PROTOBUF_EXECUTABLE': protoc_path},
+        {'PROTOBUF_INCLUDE_DIR': proto_root / 'src'},
+        {'PROTOBUF_LIBRARY': protobuf_lib.full_path()},
+        {'PROTOC_LIBRARY': protoc_lib.full_path()},
+        # There seems to be a bug (?) in Orc where when providing your own
+        # protobuf library, the include directory is not propogated from protobuf
+        # to the orc library being built. This workaround sets the include path
+        # for proto globally, alongside abseil
+        {'CMAKE_CXX_FLAGS': '-I@0@ -I@1@'.format(proto_root / 'src', absl_root)},
+    )
+    orc_opt.append_compile_args('cpp', '-fPIC')
+    orc_proj = cmake.subproject('orc', options: orc_opt)
+    orc_dep = orc_proj.dependency('orc')
+    arrow_components += {
+        'arrow_orc': {
+            'sources': [
+                'adapters/orc/adapter.cc',
+                'adapters/orc/options.cc',
+                'adapters/orc/util.cc',
+            ],
+            'dependencies': [orc_dep],
+        },
+    }
+else
+    orc_dep = disabler()
+endif
+
 arrow_srcs = []
 include_dir = include_directories('..')
 arrow_includes = [include_dir]
@@ -722,6 +776,10 @@ endif
 
 if needs_json
     subdir('json')
+endif
+
+if needs_orc
+    subdir('adapters/orc')
 endif
 
 if needs_ipc

--- a/cpp/subprojects/abseil-cpp.wrap
+++ b/cpp/subprojects/abseil-cpp.wrap
@@ -1,0 +1,125 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[wrap-file]
+directory = abseil-cpp-20240722.0
+source_url = https://github.com/abseil/abseil-cpp/releases/download/20240722.0/abseil-cpp-20240722.0.tar.gz
+source_filename = abseil-cpp-20240722.0.tar.gz
+source_hash = f50e5ac311a81382da7fa75b97310e4b9006474f9560ac46f54a9967f07d4ae3
+patch_filename = abseil-cpp_20240722.0-3_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/abseil-cpp_20240722.0-3/get_patch
+patch_hash = 12dd8df1488a314c53e3751abd2750cf233b830651d168b6a9f15e7d0cf71f7b
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/abseil-cpp_20240722.0-3/abseil-cpp-20240722.0.tar.gz
+wrapdb_version = 20240722.0-3
+
+[provide]
+absl_base = absl_base_dep
+absl_container = absl_container_dep
+absl_debugging = absl_debugging_dep
+absl_log = absl_log_dep
+absl_flags = absl_flags_dep
+absl_hash = absl_hash_dep
+absl_crc = absl_crc_dep
+absl_numeric = absl_numeric_dep
+absl_profiling = absl_profiling_dep
+absl_random = absl_random_dep
+absl_status = absl_status_dep
+absl_strings = absl_strings_dep
+absl_synchronization = absl_synchronization_dep
+absl_time = absl_time_dep
+absl_types = absl_types_dep
+absl_algorithm_container = absl_base_dep
+absl_any_invocable = absl_base_dep
+absl_bad_any_cast_impl = absl_types_dep
+absl_bad_optional_access = absl_types_dep
+absl_bad_variant_access = absl_types_dep
+absl_bind_front = absl_base_dep
+absl_city = absl_hash_dep
+absl_civil_time = absl_time_dep
+absl_cleanup = absl_base_dep
+absl_cord = absl_strings_dep
+absl_cord_internal = absl_strings_dep
+absl_cordz_functions = absl_strings_dep
+absl_cordz_handle = absl_strings_dep
+absl_cordz_info = absl_strings_dep
+absl_cordz_sample_token = absl_strings_dep
+absl_core_headers = absl_base_dep
+absl_crc32c = absl_crc_dep
+absl_debugging_internal = absl_debugging_dep
+absl_demangle_internal = absl_debugging_dep
+absl_die_if_null = absl_log_dep
+absl_examine_stack = absl_debugging_dep
+absl_exponential_biased = absl_profiling_dep
+absl_failure_signal_handler = absl_debugging_dep
+absl_flags_commandlineflag = absl_flags_dep
+absl_flags_commandlineflag_internal = absl_flags_dep
+absl_flags_config = absl_flags_dep
+absl_flags_internal = absl_flags_dep
+absl_flags_marshalling = absl_flags_dep
+absl_flags_parse = absl_flags_dep
+absl_flags_private_handle_accessor = absl_flags_dep
+absl_flags_program_name = absl_flags_dep
+absl_flags_reflection = absl_flags_dep
+absl_flags_usage = absl_flags_dep
+absl_flags_usage_internal = absl_flags_dep
+absl_flat_hash_map = absl_container_dep
+absl_flat_hash_set = absl_container_dep
+absl_function_ref = absl_base_dep
+absl_graphcycles_internal = absl_synchronization_dep
+absl_hashtablez_sampler = absl_container_dep
+absl_inlined_vector = absl_container_dep
+absl_int128 = absl_numeric_dep
+absl_leak_check = absl_debugging_dep
+absl_log_initialize = absl_log_dep
+absl_log_internal_check_op = absl_log_dep
+absl_log_internal_message = absl_log_dep
+absl_log_severity = absl_base_dep
+absl_low_level_hash = absl_hash_dep
+absl_memory = absl_base_dep
+absl_optional = absl_types_dep
+absl_periodic_sampler = absl_profiling_dep
+absl_random_bit_gen_ref = absl_random_dep
+absl_random_distributions = absl_random_dep
+absl_random_internal_distribution_test_util = absl_random_dep
+absl_random_internal_platform = absl_random_dep
+absl_random_internal_pool_urbg = absl_random_dep
+absl_random_internal_randen = absl_random_dep
+absl_random_internal_randen_hwaes = absl_random_dep
+absl_random_internal_randen_hwaes_impl = absl_random_dep
+absl_random_internal_randen_slow = absl_random_dep
+absl_random_internal_seed_material = absl_random_dep
+absl_random_random = absl_random_dep
+absl_random_seed_gen_exception = absl_random_dep
+absl_random_seed_sequences = absl_random_dep
+absl_raw_hash_set = absl_container_dep
+absl_raw_logging_internal = absl_base_dep
+absl_scoped_set_env = absl_base_dep
+absl_span = absl_types_dep
+absl_spinlock_wait = absl_base_dep
+absl_stacktrace = absl_debugging_dep
+absl_statusor = absl_status_dep
+absl_str_format = absl_strings_dep
+absl_str_format_internal = absl_strings_dep
+absl_strerror = absl_base_dep
+absl_string_view = absl_strings_dep
+absl_strings_internal = absl_strings_dep
+absl_symbolize = absl_debugging_dep
+absl_throw_delegate = absl_base_dep
+absl_time_zone = absl_time_dep
+absl_type_traits = absl_base_dep
+absl_utility = absl_base_dep
+absl_variant = absl_types_dep

--- a/cpp/subprojects/orc.wrap
+++ b/cpp/subprojects/orc.wrap
@@ -1,0 +1,27 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[wrap-file]
+source_url = https://www.apache.org/dyn/closer.lua/orc/orc-1.9.6/orc-1.9.6.tar.gz?action=download
+source_fallback_url = https://dlcdn.apache.org/orc/orc-1.9.6/orc-1.9.6.tar.gz
+source_filename = orc-1.9.6.tar.gz
+source_hash = 4442944f53b6b4d48f0b6a1938a8f7d1233a92864d7d588201225c8977371754
+directory = orc-1.9.6
+method = cmake
+
+[provide]
+orc = orc_dep

--- a/cpp/subprojects/protobuf.wrap
+++ b/cpp/subprojects/protobuf.wrap
@@ -1,0 +1,33 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[wrap-file]
+directory = protobuf-25.2
+source_url = https://github.com/protocolbuffers/protobuf/releases/download/v25.2/protobuf-25.2.tar.gz
+source_filename = protobuf-25.2.tar.gz
+source_hash = 8ff511a64fc46ee792d3fe49a5a1bcad6f7dc50dfbba5a28b0e5b979c17f9871
+patch_filename = protobuf_25.2-2_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/protobuf_25.2-2/get_patch
+patch_hash = a2f5968097eb036c228b72258435d09e93dca4093d09acb5078a376d8155df46
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/protobuf_25.2-2/protobuf-25.2.tar.gz
+wrapdb_version = 25.2-2
+
+[provide]
+protobuf = protobuf_dep
+protobuf-lite = protobuf_lite_dep
+protoc = protoc_dep
+program_names = protoc


### PR DESCRIPTION
### Rationale for this change

This continues building out the functionality of the Meson integration

### What changes are included in this PR?

This adds the adapters/orc directory to Meson

### Are these changes tested?

Yes

### Are there any user-facing changes?

No
* GitHub Issue: #46375