### PR TITLE
[C++] Fix GCS filesystem getFileInfo method. (#46414)

### DIFF
--- a/cpp/src/arrow/filesystem/gcsfs.cc
+++ b/cpp/src/arrow/filesystem/gcsfs.cc
@@ -353,7 +353,9 @@ class GcsFileSystem::Impl {
     // matches the prefix we assume it is a directory.
     std::string canonical = internal::EnsureTrailingSlash(path.object);
     auto list_result = client_.ListObjects(path.bucket, gcs::Prefix(canonical));
-    if (list_result.begin() != list_result.end()) {
+    
+    // Check that the result is valid before determining whether the list is empty.
+    if (list_result.begin() != list_result.end() && *list_result.begin()) {
       // If there is at least one result it indicates this is a directory (at
       // least one object exists that starts with "path/")
       return FileInfo(path.full_path, FileType::Directory);


### PR DESCRIPTION
### Rationale for this change
Result<FileInfo> GetFileInfo(const GcsPath& path) method is changed.
Before this change, It return directory. However it should be return not found info.
So i added code that iterator is valid

### What changes are included in this PR?
AS-IS 
```cpp
if (list_result.begin() != list_result.end()) 
```

TO-BE
```cpp
if (list_result.begin() != list_result.end() && *list_result.begin()) 
```

### Are these changes tested?
Yes I did locally.

### Are there any user-facing changes?
No

origin issue.
https://github.com/apache/iceberg-python/issues/1952
https://github.com/apache/arrow/issues/46414