### PR TITLE
GH-46414: [C++] Fix GCS filesystem getFileInfo method

### DIFF
--- a/cpp/src/arrow/filesystem/gcsfs.cc
+++ b/cpp/src/arrow/filesystem/gcsfs.cc
@@ -353,7 +353,9 @@ class GcsFileSystem::Impl {
     // matches the prefix we assume it is a directory.
     std::string canonical = internal::EnsureTrailingSlash(path.object);
     auto list_result = client_.ListObjects(path.bucket, gcs::Prefix(canonical));
-    if (list_result.begin() != list_result.end()) {
+    
+    // Check that the result is valid before determining whether the list is empty.
+    if (list_result.begin() != list_result.end() && *list_result.begin()) {
       // If there is at least one result it indicates this is a directory (at
       // least one object exists that starts with "path/")
       return FileInfo(path.full_path, FileType::Directory);

--- a/cpp/src/arrow/filesystem/gcsfs.cc
+++ b/cpp/src/arrow/filesystem/gcsfs.cc
@@ -353,9 +353,10 @@ class GcsFileSystem::Impl {
     // matches the prefix we assume it is a directory.
     std::string canonical = internal::EnsureTrailingSlash(path.object);
     auto list_result = client_.ListObjects(path.bucket, gcs::Prefix(canonical));
-    
+
     // Check that the result is valid before determining whether the list is empty.
-    if (list_result.begin() != list_result.end() && *list_result.begin()) {
+    auto it = list_result.begin();
+    if (it != list_result.end() && *it) {
       // If there is at least one result it indicates this is a directory (at
       // least one object exists that starts with "path/")
       return FileInfo(path.full_path, FileType::Directory);

--- a/cpp/src/arrow/filesystem/gcsfs.cc
+++ b/cpp/src/arrow/filesystem/gcsfs.cc
@@ -354,14 +354,15 @@ class GcsFileSystem::Impl {
     std::string canonical = internal::EnsureTrailingSlash(path.object);
     auto list_result = client_.ListObjects(path.bucket, gcs::Prefix(canonical));
 
-    // Check that the result is valid before determining whether the list is empty.
-    auto it = list_result.begin();
-    if (it != list_result.end() && *it) {
-      // If there is at least one result it indicates this is a directory (at
-      // least one object exists that starts with "path/")
+    for (auto&& object_metadata : list_result) {
+      if (!object_metadata) {
+        continue;
+      }
+      // If there is at least one valid result, it indicates this is a
+      // directory (at least one object exists that starts with "path/")
       return FileInfo(path.full_path, FileType::Directory);
     }
-    // Return the original not-found info if there was no match.
+    // Return the original not-found info if there was no valid result.
     return info;
   }
 

--- a/cpp/src/arrow/filesystem/gcsfs_test.cc
+++ b/cpp/src/arrow/filesystem/gcsfs_test.cc
@@ -644,22 +644,12 @@ TEST_F(GcsIntegrationTest, GetFileInfo) {
 
   // check parent directories are recognized as directories.
   AssertFileInfo(fs.get(), PreexistingBucketPath() + "dir/", FileType::Directory);
-  AssertFileInfo(fs.get(), PreexistingBucketPath() + "dir/foo/", FileType::Directory);
-}
 
-TEST_F(GcsIntegrationTest, GetFileInfoWithoutPermission) {
-  auto options = GcsOptions::Defaults();
-  // Test with real GCS.
-  ASSERT_OK_AND_ASSIGN(auto fs, GcsFileSystem::Make(options));
-  // Without permission, always File typs is FileType::NotFound.
-  constexpr auto kTextFileName = "dir/foo/bar.txt";
-
-  // check this is the File without permission.
-  AssertFileInfo(fs.get(), PreexistingBucketPath() + kTextFileName, FileType::NotFound);
-
-  // check this is the directory without permission.
-  AssertFileInfo(fs.get(), PreexistingBucketPath() + "dir/", FileType::NotFound);
-  AssertFileInfo(fs.get(), PreexistingBucketPath() + "dir/foo/", FileType::NotFound);
+  // check not exists.
+  AssertFileInfo(fs.get(), PreexistingBucketPath() + "dir/foo/unexpected_dir/",
+                 FileType::NotFound);
+  AssertFileInfo(fs.get(), PreexistingBucketPath() + "dir/foo/not_bar.txt",
+                 FileType::NotFound);
 }
 
 TEST_F(GcsIntegrationTest, GetFileInfoObjectWithNestedStructure) {

--- a/cpp/src/arrow/filesystem/gcsfs_test.cc
+++ b/cpp/src/arrow/filesystem/gcsfs_test.cc
@@ -641,14 +641,14 @@ TEST_F(GcsIntegrationTest, GetFileInfoBucket) {
 //
 // The following test depends on real GCS access and is not suitable for CI/CD
 // environments. To run this test manually, set the environment variable:
-//     ARROW_RUN_REAL_GCS_TESTS=1
+//     ARROW_TEST_GCS_USE_REAL_SERVICE=1
 //
 // Example:
-//     ARROW_RUN_REAL_GCS_TESTS=1 ./debug/arrow-gcsfs-test
+//     ARROW_TEST_GCS_USE_REAL_SERVICE=1 ./debug/arrow-gcsfs-test
 TEST_F(GcsIntegrationTest, GetFileInfoWithoutPermission) {
-  if (!std::getenv("ARROW_RUN_REAL_GCS_TESTS")) {
+  if (!std::getenv("ARROW_TEST_GCS_USE_REAL_SERVICE")) {
     GTEST_SKIP() << "Skipping test that requires real GCS access. "
-                 << "Set ARROW_RUN_REAL_GCS_TESTS=1 to enable.";
+                 << "Set ARROW_TEST_GCS_USE_REAL_SERVICE=1 to enable.";
   }
   auto options = GcsOptions::Anonymous();
   options.retry_limit_seconds = 15;

--- a/cpp/src/arrow/filesystem/gcsfs_test.cc
+++ b/cpp/src/arrow/filesystem/gcsfs_test.cc
@@ -629,6 +629,15 @@ TEST_F(GcsIntegrationTest, GetFileInfoBucket) {
   ASSERT_RAISES(Invalid, fs->GetFileInfo("gs://" + PreexistingBucketName()));
 }
 
+// We intentionally do not test invalid permission with storage-testbench,
+// because the testbench does not enforce any permission checks (ACL/IAM).
+// See:
+// https://github.com/googleapis/storage-testbench?tab=readme-ov-file#what-is-this-testbench
+//
+// In real GCS environments, trying to access a bucket without permission
+// results in:
+//   - Error Code: 5
+//   - Status : NOT_FOUND
 TEST_F(GcsIntegrationTest, GetFileInfoWithoutPermission) {
   auto options = GcsOptions::Anonymous();
   options.retry_limit_seconds = 15;
@@ -636,9 +645,8 @@ TEST_F(GcsIntegrationTest, GetFileInfoWithoutPermission) {
   // Make the real GcsFileSystem.
   ASSERT_OK_AND_ASSIGN(auto fs, GcsFileSystem::Make(options));
   // Check FileInfo without permission.
-  AssertFileInfo(fs.get(), PreexistingBucketPath() + "dir/foo/unexpected_dir/",
-                 FileType::NotFound);
-  AssertFileInfo(fs.get(), PreexistingBucketPath() + "dir/foo/not_bar.txt",
+  AssertFileInfo(fs.get(), PreexistingBucketPath() + "dir/foo/", FileType::NotFound);
+  AssertFileInfo(fs.get(), PreexistingBucketPath() + "dir/foo/bar.txt",
                  FileType::NotFound);
 }
 

--- a/cpp/src/arrow/filesystem/gcsfs_test.cc
+++ b/cpp/src/arrow/filesystem/gcsfs_test.cc
@@ -647,14 +647,11 @@ TEST_F(GcsIntegrationTest, GetFileInfo) {
   AssertFileInfo(fs.get(), PreexistingBucketPath() + "dir/foo/", FileType::Directory);
 }
 
-TEST_F(GcsIntegrationTest, GetFileInfo_WithoutPermission) {
-  TimePoint expiration = std::chrono::system_clock::now() + std::chrono::minutes(5);
-  auto options =
-      GcsOptions::FromAccessToken(/*access_token=*/"invalid-access-token", expiration);
-  options.endpoint_override = "127.0.0.1:" + Testbench()->port();
-
+TEST_F(GcsIntegrationTest, GetFileInfoWithoutPermission) {
+  auto options = GcsOptions::Defaults();
+  // Test with real GCS.
   ASSERT_OK_AND_ASSIGN(auto fs, GcsFileSystem::Make(options));
-
+  // Without permission, always File typs is FileType::NotFound.
   constexpr auto kTextFileName = "dir/foo/bar.txt";
 
   // check this is the File without permission.

--- a/cpp/src/arrow/filesystem/gcsfs_test.cc
+++ b/cpp/src/arrow/filesystem/gcsfs_test.cc
@@ -629,22 +629,33 @@ TEST_F(GcsIntegrationTest, GetFileInfoBucket) {
   ASSERT_RAISES(Invalid, fs->GetFileInfo("gs://" + PreexistingBucketName()));
 }
 
-// We intentionally do not test invalid permission with storage-testbench,
+// We intentionally do not test invalid permissions with storage-testbench,
 // because the testbench does not enforce any permission checks (ACL/IAM).
 // See:
 // https://github.com/googleapis/storage-testbench?tab=readme-ov-file#what-is-this-testbench
 //
 // In real GCS environments, trying to access a bucket without permission
 // results in:
-//   - Error Code: 5
-//   - Status : NOT_FOUND
+//   - Error code: 5
+//   - Status    : NOT_FOUND
+//
+// The following test depends on real GCS access and is not suitable for CI/CD
+// environments. To run this test manually, set the environment variable:
+//     ARROW_RUN_REAL_GCS_TESTS=1
+//
+// Example:
+//     ARROW_RUN_REAL_GCS_TESTS=1 ./debug/arrow-gcsfs-test
 TEST_F(GcsIntegrationTest, GetFileInfoWithoutPermission) {
+  if (!std::getenv("ARROW_RUN_REAL_GCS_TESTS")) {
+    GTEST_SKIP() << "Skipping test that requires real GCS access. "
+                 << "Set ARROW_RUN_REAL_GCS_TESTS=1 to enable.";
+  }
   auto options = GcsOptions::Anonymous();
   options.retry_limit_seconds = 15;
   options.project_id = "test-only-invalid-project-id";
-  // Make the real GcsFileSystem.
+
   ASSERT_OK_AND_ASSIGN(auto fs, GcsFileSystem::Make(options));
-  // Check FileInfo without permission.
+
   AssertFileInfo(fs.get(), PreexistingBucketPath() + "dir/foo/", FileType::NotFound);
   AssertFileInfo(fs.get(), PreexistingBucketPath() + "dir/foo/bar.txt",
                  FileType::NotFound);


### PR DESCRIPTION
## Rationale for this change
Result GetFileInfo(const GcsPath& path) method is changed.
Before this change, It return directory. However it should be return not found info.
So i added code that iterator is valid

## What changes are included in this PR?
AS-IS
if (list_result.begin() != list_result.end()) 

TO-BE
if (list_result.begin() != list_result.end() && *list_result.begin()) 

## Are these changes tested?
Yes I did locally.

## Are there any user-facing changes?
No

* GitHub Issue: #46414