### PR TITLE
GH-46417: [C++][Parquet] Fix UB in LoadEnumSafe for EdgeInterpolationAlgorithm

### DIFF
--- a/cpp/src/parquet/thrift_internal.h
+++ b/cpp/src/parquet/thrift_internal.h
@@ -242,8 +242,9 @@ inline typename Compression::type LoadEnumSafe(const format::CompressionCodec::t
 
 inline typename LogicalType::EdgeInterpolationAlgorithm LoadEnumSafe(
     const format::EdgeInterpolationAlgorithm::type* in) {
-  if (ARROW_PREDICT_FALSE(*in < format::EdgeInterpolationAlgorithm::SPHERICAL ||
-                          *in > format::EdgeInterpolationAlgorithm::KARNEY)) {
+  const auto raw_value = internal::LoadEnumRaw(in);
+  if (ARROW_PREDICT_FALSE(raw_value < format::EdgeInterpolationAlgorithm::SPHERICAL ||
+                          raw_value > format::EdgeInterpolationAlgorithm::KARNEY)) {
     return LogicalType::EdgeInterpolationAlgorithm::UNKNOWN;
   }
   return FromThriftUnsafe(*in);


### PR DESCRIPTION
### Rationale for this change

The previous fix ( https://github.com/apache/arrow/pull/46307/ ) introduce an another ub.

### What changes are included in this PR?

Fix the ub with `internal::LoadEnumRaw` which casts enum to int.

### Are these changes tested?

Covered by existing

### Are there any user-facing changes?

no

* GitHub Issue: #46417