### PR TITLE
GH-46424: [C++][Parquet] Fix erroneous unit test skip

### DIFF
--- a/cpp/src/parquet/statistics_test.cc
+++ b/cpp/src/parquet/statistics_test.cc
@@ -34,6 +34,7 @@
 #include "arrow/type_traits.h"
 #include "arrow/util/bit_util.h"
 #include "arrow/util/bitmap_ops.h"
+#include "arrow/util/config.h"
 #include "arrow/util/float16.h"
 #include "arrow/util/logging_internal.h"
 #include "arrow/util/ubsan.h"


### PR DESCRIPTION
### Rationale for this change

Some unit tests check `ARROW_WITH_SNAPPY` as they require Snappy compression, but they didn't include the right header for this macro.

### Are these changes tested?

By definition yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #46424