### PR TITLE
Dev miniapp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+# Step 1: Use the Apache Arrow development image as base for the build stage
+FROM docker.io/apache/arrow-dev:amd64-ubuntu-jammy-package-apache-arrow as arrow-dev-image
+
+# Set environment variable for runtime
+ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+
+# Set working directory
+WORKDIR /arrowdev
+
+# Clone Arrow source and check out specific commit
+RUN git clone https://github.com/apache/arrow.git . && \
+    git checkout 409a016e5fdfa28cabd580b7ec81c42991c0748e
+
+# Build Arrow C++ libraries
+RUN cd /arrowdev/cpp && \
+    rm -rf build && \
+    mkdir build && cd build && \
+    cmake -GNinja \
+      -DARROW_WITH_SNAPPY=ON \
+      -DCMAKE_BUILD_TYPE=Debug \
+      -DCMAKE_INSTALL_PREFIX=$(pwd)/install \
+      -DARROW_PARQUET=ON \
+      -DPARQUET_REQUIRE_ENCRYPTION=ON \
+      -DARROW_PYTHON=ON \
+      -DARROW_COMPUTE=ON \
+      .. && \
+    ninja install
+
+# Set environment variables for Arrow and Parquet functionality
+ENV CMAKE_PREFIX_PATH=/arrowdev/cpp/build/install
+ENV ARROW_HOME=/arrowdev/cpp/build/install
+ENV LD_LIBRARY_PATH=$ARROW_HOME/lib:$LD_LIBRARY_PATH
+
+# Build Python bindings
+WORKDIR /arrowdev/python
+RUN pip install -r requirements-build.txt && \
+    rm -rf build/ && \
+    python3 setup.py build_ext --inplace
+
+# Test basic Parquet functionality
+RUN python3 -c "import pyarrow.parquet as pq; print('Parquet OK')"
+
+# Test Parquet encryption functionality
+RUN python3 -c "import pyarrow.parquet.encryption as ppe; print('Parquet encryption OK')"
+
+# Default shell for the build stage
+CMD ["bash"]

--- a/cpp/src/parquet/encryption/encryption_internal_test.cc
+++ b/cpp/src/parquet/encryption/encryption_internal_test.cc
@@ -35,7 +35,7 @@ class TestAesEncryption : public ::testing::Test {
   void EncryptionRoundTrip(ParquetCipher::type cipher_type, bool write_length) {
     bool metadata = false;
 
-    AesEncryptor encryptor(cipher_type, key_length_, metadata, write_length);
+    AesEncryptorImpl encryptor(cipher_type, key_length_, metadata, write_length);
 
     int32_t expected_ciphertext_len =
         encryptor.CiphertextLength(static_cast<int64_t>(plain_text_.size()));
@@ -83,7 +83,7 @@ class TestAesEncryption : public ::testing::Test {
     bool metadata = false;
     bool write_length = true;
 
-    AesEncryptor encryptor(cipher_type, key_length_, metadata, write_length);
+    AesEncryptorImpl encryptor(cipher_type, key_length_, metadata, write_length);
 
     int32_t expected_ciphertext_len =
         encryptor.CiphertextLength(static_cast<int64_t>(plain_text_.size()));

--- a/cpp/src/parquet/encryption/internal_file_decryptor.h
+++ b/cpp/src/parquet/encryption/internal_file_decryptor.h
@@ -28,7 +28,7 @@ namespace parquet {
 
 namespace encryption {
 class AesDecryptor;
-class AesEncryptor;
+class AesEncryptorImpl;
 }  // namespace encryption
 
 class ColumnCryptoMetaData;

--- a/cpp/src/parquet/encryption/internal_file_encryptor.cc
+++ b/cpp/src/parquet/encryption/internal_file_encryptor.cc
@@ -22,22 +22,22 @@
 namespace parquet {
 
 // Encryptor
-Encryptor::Encryptor(encryption::AesEncryptor* aes_encryptor, const std::string& key,
+Encryptor::Encryptor(encryption::EncryptorInterface* encryptor_interface, const std::string& key,
                      const std::string& file_aad, const std::string& aad,
                      ::arrow::MemoryPool* pool)
-    : aes_encryptor_(aes_encryptor),
+    : encryptor_interface_(encryptor_interface),
       key_(key),
       file_aad_(file_aad),
       aad_(aad),
       pool_(pool) {}
 
 int32_t Encryptor::CiphertextLength(int64_t plaintext_len) const {
-  return aes_encryptor_->CiphertextLength(plaintext_len);
+  return encryptor_interface_->CiphertextLength(plaintext_len);
 }
 
 int32_t Encryptor::Encrypt(::arrow::util::span<const uint8_t> plaintext,
                            ::arrow::util::span<uint8_t> ciphertext) {
-  return aes_encryptor_->Encrypt(plaintext, str2span(key_), str2span(aad_), ciphertext);
+  return encryptor_interface_->Encrypt(plaintext, str2span(key_), str2span(aad_), ciphertext);
 }
 
 // InternalFileEncryptor
@@ -53,9 +53,9 @@ std::shared_ptr<Encryptor> InternalFileEncryptor::GetFooterEncryptor() {
   ParquetCipher::type algorithm = properties_->algorithm().algorithm;
   std::string footer_aad = encryption::CreateFooterAad(properties_->file_aad());
   std::string footer_key = properties_->footer_key();
-  auto aes_encryptor = GetMetaAesEncryptor(algorithm, footer_key.size());
+  auto encryptor_interface = GetMetaEncryptor(algorithm, footer_key.size());
   footer_encryptor_ = std::make_shared<Encryptor>(
-      aes_encryptor, footer_key, properties_->file_aad(), footer_aad, pool_);
+    encryptor_interface, footer_key, properties_->file_aad(), footer_aad, pool_);
   return footer_encryptor_;
 }
 
@@ -67,9 +67,9 @@ std::shared_ptr<Encryptor> InternalFileEncryptor::GetFooterSigningEncryptor() {
   ParquetCipher::type algorithm = properties_->algorithm().algorithm;
   std::string footer_aad = encryption::CreateFooterAad(properties_->file_aad());
   std::string footer_signing_key = properties_->footer_key();
-  auto aes_encryptor = GetMetaAesEncryptor(algorithm, footer_signing_key.size());
+  auto encryptor_interface = GetMetaEncryptor(algorithm, footer_signing_key.size());
   footer_signing_encryptor_ = std::make_shared<Encryptor>(
-      aes_encryptor, footer_signing_key, properties_->file_aad(), footer_aad, pool_);
+    encryptor_interface, footer_signing_key, properties_->file_aad(), footer_aad, pool_);
   return footer_signing_encryptor_;
 }
 
@@ -109,12 +109,12 @@ InternalFileEncryptor::InternalFileEncryptor::GetColumnEncryptor(
   }
 
   ParquetCipher::type algorithm = properties_->algorithm().algorithm;
-  auto aes_encryptor = metadata ? GetMetaAesEncryptor(algorithm, key.size())
-                                : GetDataAesEncryptor(algorithm, key.size());
+  auto encryptor_interface = metadata ? GetMetaEncryptor(algorithm, key.size())
+                                : GetDataEncryptor(algorithm, key.size());
 
   std::string file_aad = properties_->file_aad();
   std::shared_ptr<Encryptor> encryptor =
-      std::make_shared<Encryptor>(aes_encryptor, key, file_aad, "", pool_);
+      std::make_shared<Encryptor>(encryptor_interface, key, file_aad, "", pool_);
   if (metadata)
     column_metadata_map_[column_path] = encryptor;
   else
@@ -133,22 +133,22 @@ int InternalFileEncryptor::MapKeyLenToEncryptorArrayIndex(int32_t key_len) const
   throw ParquetException("encryption key must be 16, 24 or 32 bytes in length");
 }
 
-encryption::AesEncryptor* InternalFileEncryptor::GetMetaAesEncryptor(
+encryption::EncryptorInterface* InternalFileEncryptor::GetMetaEncryptor(
     ParquetCipher::type algorithm, size_t key_size) {
   auto key_len = static_cast<int32_t>(key_size);
   int index = MapKeyLenToEncryptorArrayIndex(key_len);
   if (meta_encryptor_[index] == nullptr) {
-    meta_encryptor_[index] = encryption::AesEncryptor::Make(algorithm, key_len, true);
+    meta_encryptor_[index] = encryption::AesEncryptorImpl::Make(algorithm, key_len, true);
   }
   return meta_encryptor_[index].get();
 }
 
-encryption::AesEncryptor* InternalFileEncryptor::GetDataAesEncryptor(
+encryption::EncryptorInterface* InternalFileEncryptor::GetDataEncryptor(
     ParquetCipher::type algorithm, size_t key_size) {
   auto key_len = static_cast<int32_t>(key_size);
   int index = MapKeyLenToEncryptorArrayIndex(key_len);
   if (data_encryptor_[index] == nullptr) {
-    data_encryptor_[index] = encryption::AesEncryptor::Make(algorithm, key_len, false);
+    data_encryptor_[index] = encryption::AesEncryptorImpl::Make(algorithm, key_len, false);
   }
   return data_encryptor_[index].get();
 }

--- a/cpp/src/parquet/encryption/internal_file_encryptor.h
+++ b/cpp/src/parquet/encryption/internal_file_encryptor.h
@@ -28,7 +28,7 @@
 namespace parquet {
 
 namespace encryption {
-class AesEncryptor;
+class EncryptorInterface;
 }  // namespace encryption
 
 class FileEncryptionProperties;
@@ -36,7 +36,7 @@ class ColumnEncryptionProperties;
 
 class PARQUET_EXPORT Encryptor {
  public:
-  Encryptor(encryption::AesEncryptor* aes_encryptor, const std::string& key,
+  Encryptor(encryption::EncryptorInterface* encryptor_interface_, const std::string& key,
             const std::string& file_aad, const std::string& aad,
             ::arrow::MemoryPool* pool);
   const std::string& file_aad() { return file_aad_; }
@@ -61,7 +61,7 @@ class PARQUET_EXPORT Encryptor {
   }
 
  private:
-  encryption::AesEncryptor* aes_encryptor_;
+  encryption::EncryptorInterface* encryptor_interface_;
   std::string key_;
   std::string file_aad_;
   std::string aad_;
@@ -89,17 +89,17 @@ class InternalFileEncryptor {
 
   // Key must be 16, 24 or 32 bytes in length. Thus there could be up to three
   // types of meta_encryptors and data_encryptors.
-  std::unique_ptr<encryption::AesEncryptor> meta_encryptor_[3];
-  std::unique_ptr<encryption::AesEncryptor> data_encryptor_[3];
+  std::unique_ptr<encryption::EncryptorInterface> meta_encryptor_[3];
+  std::unique_ptr<encryption::EncryptorInterface> data_encryptor_[3];
 
   ::arrow::MemoryPool* pool_;
 
   std::shared_ptr<Encryptor> GetColumnEncryptor(const std::string& column_path,
                                                 bool metadata);
 
-  encryption::AesEncryptor* GetMetaAesEncryptor(ParquetCipher::type algorithm,
+  encryption::EncryptorInterface* GetMetaEncryptor(ParquetCipher::type algorithm,
                                                 size_t key_len);
-  encryption::AesEncryptor* GetDataAesEncryptor(ParquetCipher::type algorithm,
+  encryption::EncryptorInterface* GetDataEncryptor(ParquetCipher::type algorithm,
                                                 size_t key_len);
 
   int MapKeyLenToEncryptorArrayIndex(int32_t key_len) const;

--- a/cpp/src/parquet/encryption/key_toolkit_internal.cc
+++ b/cpp/src/parquet/encryption/key_toolkit_internal.cc
@@ -28,7 +28,7 @@ static constexpr const int32_t kAcceptableDataKeyLengths[] = {128, 192, 256};
 
 std::string EncryptKeyLocally(const std::string& key_bytes, const std::string& master_key,
                               const std::string& aad) {
-  AesEncryptor key_encryptor(ParquetCipher::AES_GCM_V1,
+  AesEncryptorImpl key_encryptor(ParquetCipher::AES_GCM_V1,
                              static_cast<int>(master_key.size()), false,
                              false /*write_length*/);
 

--- a/cpp/src/parquet/metadata.cc
+++ b/cpp/src/parquet/metadata.cc
@@ -740,7 +740,7 @@ class FileMetaData::FileMetaDataImpl {
     std::string key = file_decryptor_->GetFooterKey();
     std::string aad = encryption::CreateFooterAad(file_decryptor_->file_aad());
 
-    auto aes_encryptor = encryption::AesEncryptor::Make(file_decryptor_->algorithm(),
+    auto aes_encryptor = encryption::AesEncryptorImpl::Make(file_decryptor_->algorithm(),
                                                         static_cast<int>(key.size()),
                                                         true, false /*write_length*/);
 

--- a/python/scripts/tekdatum_mini_app.py
+++ b/python/scripts/tekdatum_mini_app.py
@@ -1,0 +1,136 @@
+"""
+parquet_playground.py
+
+@author sbrenes
+"""
+
+import base64
+import datetime
+import pyarrow
+import pyarrow.parquet as pp
+import pyarrow.parquet.encryption as ppe
+
+
+class FooKmsClient(ppe.KmsClient):
+
+    def __init__(self, kms_connection_config):
+        ppe.KmsClient.__init__(self)
+        self.master_keys_map = kms_connection_config.custom_kms_conf
+    
+    def wrap_key(self, key_bytes, master_key_identifier):
+        master_key_bytes = self.master_keys_map[master_key_identifier].encode('utf-8')
+        joint_key = b"".join([master_key_bytes, key_bytes])
+        return base64.b64encode(joint_key)
+
+    def unwrap_key(self, wrapped_key, master_key_identifier):
+        expected_master = self.master_keys_map[master_key_identifier]
+        decoded_key = base64.b64decode(wrapped_key)
+        master_key_bytes = decoded_key[:16]
+        decrypted_key = decoded_key[16:]
+        if (expected_master == master_key_bytes.decode('utf-8')):
+            return decrypted_key
+        raise ValueError(f"Bad master key used [{master_key_bytes}] - [{decrypted_key}]")
+
+
+
+def kms_client_factory(kms_connection_config):
+    return FooKmsClient(kms_connection_config)
+
+
+def write_parquet(table, location, encryption_config=None):
+    encryption_properties = None
+
+    if encryption_config:
+        crypto_factory = ppe.CryptoFactory(kms_client_factory)
+        encryption_properties = crypto_factory.file_encryption_properties(
+            get_kms_connection_config(), encryption_config)
+
+    writer = pp.ParquetWriter(location, table.schema, encryption_properties=encryption_properties)
+    writer.write_table(table)
+
+
+def encrypted_data_and_footer_sample(data_table):
+    parquet_path = "sample.parquet"
+    encryption_config = get_encryption_config()
+    write_parquet(data_table, parquet_path,
+                  encryption_config=encryption_config)
+    print(f"Written to [{parquet_path}]")
+
+
+def create_and_encrypt_parquet():
+    sample_data = {
+        "orderId": [1001, 1002, 1003],
+        "productId": [152, 268, 6548],
+        "price": [3.25, 6.48, 2.12],
+        "vat": [0.0, 0.2, 0.05]
+    }    
+    data_table = pyarrow.Table.from_pydict(sample_data)
+
+    print("\nPyarrow table created. Writing parquet.")
+
+    encrypted_data_and_footer_sample(data_table)
+
+
+def read_and_print_parquet():
+    print("\nNow reading parquet file")
+    parquet_path = "sample.parquet"
+
+    metadata = pp.read_metadata(parquet_path)
+    print("\nMetadata:")
+    print(metadata)
+
+    decryption_config = get_decryption_config()
+    read_data_table = read_parquet(parquet_path,
+                                   decryption_config=decryption_config)
+    data_frame = read_data_table.to_pandas()
+    print("\nData:")
+    print(data_frame.head())
+
+
+def read_parquet(location, decryption_config=None, read_metadata=False):
+    decryption_properties = None
+
+    if decryption_config:
+        crypto_factory = ppe.CryptoFactory(kms_client_factory)
+        decryption_properties = crypto_factory.file_decryption_properties(
+            get_kms_connection_config(), decryption_config)
+    
+    if read_metadata:
+        metadata = pp.read_metadata(location, decryption_properties=decryption_properties)
+        return metadata
+
+    data_table = pp.ParquetFile(location, decryption_properties=decryption_properties).read()
+    return data_table
+
+
+def get_kms_connection_config():
+    return ppe.KmsConnectionConfig(
+        custom_kms_conf={
+            "footer_key": "012footer_secret",
+            "orderid_key": "column_secret001",
+            "productid_key": "column_secret002"
+        }
+    )
+
+
+def get_encryption_config(plaintext_footer=True):
+    return ppe.EncryptionConfiguration(
+        footer_key = "footer_key",
+        column_keys = {
+            "orderid_key": ["orderId"],
+            "productid_key": ["productId"]
+        },
+        encryption_algorithm = "AES_GCM_V1",
+        cache_lifetime=datetime.timedelta(minutes=2.0),
+        data_key_length_bits = 128,
+        plaintext_footer=plaintext_footer
+    )
+
+def get_decryption_config():
+    return ppe.DecryptionConfiguration(cache_lifetime=datetime.timedelta(minutes=2.0))
+
+
+if __name__ == "__main__":
+    create_and_encrypt_parquet()
+    read_and_print_parquet()
+    print("\nPlayground finished!\n")


### PR DESCRIPTION
Start refactor of Encryptor classes.

I am not adding any new encryptors right now, just changing the structure of the current classes to inherit from the new interface.

In encryptor_internal.h:
- Added EncryptorInterface
- Deleted AesEncryptor
- Moved AesEncryptorImpl to this header file, along with AesCryptoContext, another class that AesEncryptorImpl was also inheriting from.
- Marked AesEncryptorImpl as implemeting EncryptorInterface.

Elsewhere, removed all references to AesEncryptor and changed them to AesEncryptorImpl.

In the main Encryptor wrapper, changed the reference from AesEncryptor to EncryptorInterface.

Tested with the mini app python script, everything works.