### PR TITLE
GH-46433: [GLib] Add GArrowFixedShapeDataType#dim_names

### DIFF
--- a/c_glib/arrow-glib/basic-data-type.cpp
+++ b/c_glib/arrow-glib/basic-data-type.cpp
@@ -2407,7 +2407,7 @@ garrow_fixed_shape_tensor_data_type_get_dim_names(
   for (size_t i = 0; i < n; ++i) {
     dim_names[i] = g_strndup(arrow_dim_names[i].data(), arrow_dim_names[i].size());
   }
-  dim_names[n] = NULL;
+  dim_names[n] = nullptr;
   return dim_names;
 }
 G_END_DECLS

--- a/c_glib/arrow-glib/basic-data-type.cpp
+++ b/c_glib/arrow-glib/basic-data-type.cpp
@@ -2384,6 +2384,32 @@ garrow_fixed_shape_tensor_data_type_get_permutation(
   *length = arrow_permutation.size();
   return arrow_permutation.data();
 }
+
+/**
+ * garrow_fixed_shape_tensor_data_type_get_dim_names:
+ * @data_type: A #GArrowFixedShapeTensorDataType.
+ *
+ * Returns: (array zero-terminated=1) (element-type utf8) (transfer full):
+ *   Dimention names of the tensor.
+ *
+ *   It's a %NULL-terminated string array. It must be freed with
+ *   g_strfreev() when no longer needed.
+ */
+gchar **
+garrow_fixed_shape_tensor_data_type_get_dim_names(
+  GArrowFixedShapeTensorDataType *data_type)
+{
+  auto arrow_data_type = std::static_pointer_cast<arrow::extension::FixedShapeTensorType>(
+    garrow_data_type_get_raw(GARROW_DATA_TYPE(data_type)));
+  const auto &arrow_dim_names = arrow_data_type->dim_names();
+  auto n = arrow_dim_names.size();
+  auto dim_names = g_new(gchar *, n + 1);
+  for (size_t i = 0; i < n; ++i) {
+    dim_names[i] = g_strndup(arrow_dim_names[i].data(), arrow_dim_names[i].size());
+  }
+  dim_names[n] = NULL;
+  return dim_names;
+}
 G_END_DECLS
 
 GArrowDataType *

--- a/c_glib/arrow-glib/basic-data-type.h
+++ b/c_glib/arrow-glib/basic-data-type.h
@@ -835,4 +835,9 @@ GARROW_AVAILABLE_IN_21_0
 const gint64 *
 garrow_fixed_shape_tensor_data_type_get_permutation(
   GArrowFixedShapeTensorDataType *data_type, gsize *length);
+
+GARROW_AVAILABLE_IN_21_0
+gchar **
+garrow_fixed_shape_tensor_data_type_get_dim_names(
+  GArrowFixedShapeTensorDataType *data_type);
 G_END_DECLS

--- a/c_glib/test/test-fixed-shape-tensor-data-type.rb
+++ b/c_glib/test/test-fixed-shape-tensor-data-type.rb
@@ -40,6 +40,10 @@ class TestFixedShapeTensorDataType < Test::Unit::TestCase
     assert_equal([1, 0], @data_type.permutation)
   end
 
+  def test_dim_names
+    assert_equal(["x", "y"], @data_type.dim_names)
+  end
+
   def test_to_s
     assert do
       @data_type.to_s.start_with?("extension<arrow.fixed_shape_tensor")
@@ -59,8 +63,7 @@ class TestFixedShapeTensorDataType < Test::Unit::TestCase
                                                     [3, 4],
                                                     [0, 1],
                                                     nil)
-    # TODO: Use Arrow::FixedShapeTensorDataType#dim_names
-    assert_equal(Arrow::Type::EXTENSION, data_type.id)
+    assert_equal([], data_type.dim_names)
   end
 
   def test_mismatch_permutation_size


### PR DESCRIPTION
### Rationale for this change

The C++ API implemented `FixedShapeTensor::dim_names()` instance method. GLib was not yet supported.

### What changes are included in this PR?

Add `GArrowFixedShapeDataType#dim_names` instance method.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.

* GitHub Issue: #46433