### PR TITLE
GH-46343: Avoid installing gdb 16.3 in conda-python image to fix CI

### DIFF
--- a/ci/docker/conda-python.dockerfile
+++ b/ci/docker/conda-python.dockerfile
@@ -27,7 +27,7 @@ COPY ci/conda_env_python.txt \
 # we need to install the conda-forge gdb instead (GH-38323).
 RUN mamba install -q -y \
         --file arrow/ci/conda_env_python.txt \
-        $([ "$python" == $(gdb --batch --eval-command 'python import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")') ] && echo "gdb") \
+        $([ "$python" == $(gdb --batch --eval-command 'python import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")') ] && echo "gdb<16.3") \
         "python=${python}.*=*_cp*" \
         nomkl && \
     mamba clean --all --yes


### PR DESCRIPTION
### Rationale for this change

The AMD64 Conda Python 3.10 Without Pandas job has been failing, see https://github.com/apache/arrow/issues/46343, and we tracked that down to an issue with gdb 16.3 and character encodings. An earlier version of gdb should work fine.

### What changes are included in this PR?

- Updated `conda-python.dockerfile` adding a gdb<16.3 requirement.

### Are these changes tested?

No, will test in CI.

### Are there any user-facing changes?

No.
* GitHub Issue: #46343