### PR TITLE
GH-37027: [C++] Add float16 kernels to if-else and vector-replace functions

### DIFF
--- a/cpp/src/arrow/compute/kernels/codegen_internal.h
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.h
@@ -1262,6 +1262,7 @@ KernelType GenerateTypeAgnosticPrimitive(detail::GetTypeId get_id) {
       return Generator<UInt8Type, Args...>::Exec;
     case Type::UINT16:
     case Type::INT16:
+    case Type::HALF_FLOAT:
       return Generator<UInt16Type, Args...>::Exec;
     case Type::UINT32:
     case Type::INT32:

--- a/cpp/src/arrow/compute/kernels/scalar_if_else.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else.cc
@@ -2870,7 +2870,7 @@ void RegisterScalarIfElse(FunctionRegistry* registry) {
     AddPrimitiveIfElseKernels(func, TemporalTypes());
     AddPrimitiveIfElseKernels(func, IntervalTypes());
     AddPrimitiveIfElseKernels(func, DurationTypes());
-    AddPrimitiveIfElseKernels(func, {boolean()});
+    AddPrimitiveIfElseKernels(func, {boolean(), float16()});
     AddNullIfElseKernel(func);
     AddBinaryIfElseKernels(func, BaseBinaryTypes());
     AddFixedWidthIfElseKernel<FixedSizeBinaryType>(func);
@@ -2886,7 +2886,7 @@ void RegisterScalarIfElse(FunctionRegistry* registry) {
     AddPrimitiveCaseWhenKernels(func, TemporalTypes());
     AddPrimitiveCaseWhenKernels(func, IntervalTypes());
     AddPrimitiveCaseWhenKernels(func, DurationTypes());
-    AddPrimitiveCaseWhenKernels(func, {boolean(), null()});
+    AddPrimitiveCaseWhenKernels(func, {boolean(), null(), float16()});
     AddCaseWhenKernel(func, Type::FIXED_SIZE_BINARY,
                       CaseWhenFunctor<FixedSizeBinaryType>::Exec);
     AddCaseWhenKernel(func, Type::DECIMAL128, CaseWhenFunctor<FixedSizeBinaryType>::Exec);
@@ -2902,7 +2902,7 @@ void RegisterScalarIfElse(FunctionRegistry* registry) {
     AddPrimitiveCoalesceKernels(func, TemporalTypes());
     AddPrimitiveCoalesceKernels(func, IntervalTypes());
     AddPrimitiveCoalesceKernels(func, DurationTypes());
-    AddPrimitiveCoalesceKernels(func, {boolean(), null()});
+    AddPrimitiveCoalesceKernels(func, {boolean(), null(), float16()});
     AddCoalesceKernel(func, Type::FIXED_SIZE_BINARY,
                       CoalesceFunctor<FixedSizeBinaryType>::Exec);
     AddCoalesceKernel(func, Type::DECIMAL128, CoalesceFunctor<FixedSizeBinaryType>::Exec);
@@ -2920,7 +2920,7 @@ void RegisterScalarIfElse(FunctionRegistry* registry) {
     AddPrimitiveChooseKernels(func, TemporalTypes());
     AddPrimitiveChooseKernels(func, IntervalTypes());
     AddPrimitiveChooseKernels(func, DurationTypes());
-    AddPrimitiveChooseKernels(func, {boolean(), null()});
+    AddPrimitiveChooseKernels(func, {boolean(), null(), float16()});
     AddChooseKernel(func, Type::FIXED_SIZE_BINARY,
                     ChooseFunctor<FixedSizeBinaryType>::Exec);
     AddChooseKernel(func, Type::DECIMAL128, ChooseFunctor<FixedSizeBinaryType>::Exec);

--- a/cpp/src/arrow/compute/kernels/scalar_if_else_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else_test.cc
@@ -80,9 +80,9 @@ using IntegralArrowTypes = ::testing::Types<Int32Type>;
 #else
 using IfElseNumericBasedTypes =
     ::testing::Types<UInt8Type, UInt16Type, UInt32Type, UInt64Type, Int8Type, Int16Type,
-                     Int32Type, Int64Type, HalfFloatType, FloatType, DoubleType, Date32Type, Date64Type,
-                     Time32Type, Time64Type, TimestampType, MonthIntervalType,
-                     DurationType>;
+                     Int32Type, Int64Type, HalfFloatType, FloatType, DoubleType, 
+                     Date32Type, Date64Type, Time32Type, Time64Type, TimestampType, 
+                     MonthIntervalType, DurationType>;
 #endif
 
 TYPED_TEST_SUITE(TestIfElsePrimitive, IfElseNumericBasedTypes);

--- a/cpp/src/arrow/compute/kernels/scalar_if_else_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else_test.cc
@@ -80,7 +80,7 @@ using IntegralArrowTypes = ::testing::Types<Int32Type>;
 #else
 using IfElseNumericBasedTypes =
     ::testing::Types<UInt8Type, UInt16Type, UInt32Type, UInt64Type, Int8Type, Int16Type,
-                     Int32Type, Int64Type, FloatType, DoubleType, Date32Type, Date64Type,
+                     Int32Type, Int64Type, HalfFloatType, FloatType, DoubleType, Date32Type, Date64Type,
                      Time32Type, Time64Type, TimestampType, MonthIntervalType,
                      DurationType>;
 #endif

--- a/cpp/src/arrow/compute/kernels/scalar_if_else_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else_test.cc
@@ -80,8 +80,8 @@ using IntegralArrowTypes = ::testing::Types<Int32Type>;
 #else
 using IfElseNumericBasedTypes =
     ::testing::Types<UInt8Type, UInt16Type, UInt32Type, UInt64Type, Int8Type, Int16Type,
-                     Int32Type, Int64Type, HalfFloatType, FloatType, DoubleType, 
-                     Date32Type, Date64Type, Time32Type, Time64Type, TimestampType, 
+                     Int32Type, Int64Type, HalfFloatType, FloatType, DoubleType,
+                     Date32Type, Date64Type, Time32Type, Time64Type, TimestampType,
                      MonthIntervalType, DurationType>;
 #endif
 

--- a/cpp/src/arrow/compute/kernels/vector_replace.cc
+++ b/cpp/src/arrow/compute/kernels/vector_replace.cc
@@ -843,6 +843,7 @@ void RegisterVectorFunction(FunctionRegistry* registry,
   }
   add_primitive_kernel(null());
   add_primitive_kernel(boolean());
+  add_primitive_kernel(float16());
   AddKernel(Type::FIXED_SIZE_BINARY,
             Functor<FixedSizeBinaryType>::GetSignature(Type::FIXED_SIZE_BINARY),
             Functor<FixedSizeBinaryType>::Exec, ChunkedFunctor<FixedSizeBinaryType>::Exec,

--- a/cpp/src/arrow/compute/kernels/vector_replace_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_replace_test.cc
@@ -24,6 +24,7 @@
 #include "arrow/compute/kernels/test_util_internal.h"
 #include "arrow/testing/generator.h"
 #include "arrow/testing/gtest_util.h"
+#include "arrow/type.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/key_value_metadata.h"
 
@@ -233,7 +234,7 @@ class TestReplaceBinary : public TestReplaceKernel<T> {
 
 using NumericBasedTypes =
     ::testing::Types<UInt8Type, UInt16Type, UInt32Type, UInt64Type, Int8Type, Int16Type,
-                     Int32Type, Int64Type, FloatType, DoubleType, Date32Type, Date64Type,
+                     Int32Type, Int64Type, HalfFloatType, FloatType, DoubleType, Date32Type, Date64Type,
                      Time32Type, Time64Type, TimestampType, MonthIntervalType>;
 
 TYPED_TEST_SUITE(TestReplaceNumeric, NumericBasedTypes);

--- a/cpp/src/arrow/compute/kernels/vector_replace_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_replace_test.cc
@@ -24,7 +24,6 @@
 #include "arrow/compute/kernels/test_util_internal.h"
 #include "arrow/testing/generator.h"
 #include "arrow/testing/gtest_util.h"
-#include "arrow/type.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/key_value_metadata.h"
 
@@ -234,8 +233,9 @@ class TestReplaceBinary : public TestReplaceKernel<T> {
 
 using NumericBasedTypes =
     ::testing::Types<UInt8Type, UInt16Type, UInt32Type, UInt64Type, Int8Type, Int16Type,
-                     Int32Type, Int64Type, HalfFloatType, FloatType, DoubleType, Date32Type, Date64Type,
-                     Time32Type, Time64Type, TimestampType, MonthIntervalType>;
+                     Int32Type, Int64Type, HalfFloatType, FloatType, DoubleType, 
+                     Date32Type, Date64Type, Time32Type, Time64Type, TimestampType, 
+                     MonthIntervalType>;
 
 TYPED_TEST_SUITE(TestReplaceNumeric, NumericBasedTypes);
 TYPED_TEST_SUITE(TestReplaceDecimal, DecimalArrowTypes);

--- a/cpp/src/arrow/compute/kernels/vector_replace_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_replace_test.cc
@@ -1491,6 +1491,7 @@ TYPED_TEST(TestFillNullNumeric, FillNullForwardLargeInput) {
   ASSERT_OK_AND_ASSIGN(auto array_null, MakeArrayOfNull(array_random->type(), len_null));
   auto array_null_filled =
       ConstantArrayGenerator::Numeric<TypeParam>(len_null, x_ptr[len_random - 1]);
+  ASSERT_NE(array_null_filled, nullptr);
   {
     ASSERT_OK_AND_ASSIGN(auto value_array,
                          Concatenate({array_random, array_null, array_random}));

--- a/cpp/src/arrow/compute/kernels/vector_replace_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_replace_test.cc
@@ -233,8 +233,8 @@ class TestReplaceBinary : public TestReplaceKernel<T> {
 
 using NumericBasedTypes =
     ::testing::Types<UInt8Type, UInt16Type, UInt32Type, UInt64Type, Int8Type, Int16Type,
-                     Int32Type, Int64Type, HalfFloatType, FloatType, DoubleType, 
-                     Date32Type, Date64Type, Time32Type, Time64Type, TimestampType, 
+                     Int32Type, Int64Type, HalfFloatType, FloatType, DoubleType,
+                     Date32Type, Date64Type, Time32Type, Time64Type, TimestampType,
                      MonthIntervalType>;
 
 TYPED_TEST_SUITE(TestReplaceNumeric, NumericBasedTypes);

--- a/cpp/src/arrow/testing/generator.cc
+++ b/cpp/src/arrow/testing/generator.cc
@@ -25,7 +25,6 @@
 #include <gtest/gtest.h>
 
 #include "arrow/array.h"
-#include "arrow/array/array_base.h"
 #include "arrow/buffer.h"
 #include "arrow/compute/exec.h"
 #include "arrow/datum.h"
@@ -93,7 +92,8 @@ std::shared_ptr<arrow::Array> ConstantArrayGenerator::Int64(int64_t size, int64_
   return ConstantArray<Int64Type>(size, value);
 }
 
-std::shared_ptr<arrow::Array> ConstantArrayGenerator::Float16(int64_t size, uint16_t value) {
+std::shared_ptr<arrow::Array> ConstantArrayGenerator::Float16(int64_t size, 
+                                                              uint16_t value) {
   return ConstantArray<HalfFloatType>(size, value);
 }
 

--- a/cpp/src/arrow/testing/generator.cc
+++ b/cpp/src/arrow/testing/generator.cc
@@ -25,6 +25,7 @@
 #include <gtest/gtest.h>
 
 #include "arrow/array.h"
+#include "arrow/array/array_base.h"
 #include "arrow/buffer.h"
 #include "arrow/compute/exec.h"
 #include "arrow/datum.h"
@@ -92,6 +93,10 @@ std::shared_ptr<arrow::Array> ConstantArrayGenerator::Int64(int64_t size, int64_
   return ConstantArray<Int64Type>(size, value);
 }
 
+std::shared_ptr<arrow::Array> ConstantArrayGenerator::Float16(int64_t size, uint16_t value) {
+  return ConstantArray<HalfFloatType>(size, value);
+}
+
 std::shared_ptr<arrow::Array> ConstantArrayGenerator::Float32(int64_t size, float value) {
   return ConstantArray<FloatType>(size, value);
 }
@@ -148,6 +153,8 @@ std::shared_ptr<arrow::Array> ConstantArrayGenerator::Zeroes(
       EXPECT_OK_AND_ASSIGN(auto viewed, Int32(size)->View(type));
       return viewed;
     }
+    case Type::HALF_FLOAT:
+      return Float16(size);
     case Type::FLOAT:
       return Float32(size);
     case Type::DOUBLE:

--- a/cpp/src/arrow/testing/generator.cc
+++ b/cpp/src/arrow/testing/generator.cc
@@ -92,7 +92,7 @@ std::shared_ptr<arrow::Array> ConstantArrayGenerator::Int64(int64_t size, int64_
   return ConstantArray<Int64Type>(size, value);
 }
 
-std::shared_ptr<arrow::Array> ConstantArrayGenerator::Float16(int64_t size, 
+std::shared_ptr<arrow::Array> ConstantArrayGenerator::Float16(int64_t size,
                                                               uint16_t value) {
   return ConstantArray<HalfFloatType>(size, value);
 }

--- a/cpp/src/arrow/testing/generator.h
+++ b/cpp/src/arrow/testing/generator.h
@@ -106,6 +106,14 @@ class ARROW_TESTING_EXPORT ConstantArrayGenerator {
   /// \return a generated Array
   static std::shared_ptr<Array> Int64(int64_t size, int64_t value = 0);
 
+  /// \brief Generates a constant Float16Array
+  ///
+  /// \param[in] size the size of the array to generate
+  /// \param[in] value to repeat
+  ///
+  /// \return a generated Array
+  static std::shared_ptr<Array> Float16(int64_t size, uint16_t value = 0);
+
   /// \brief Generates a constant Float32Array
   ///
   /// \param[in] size the size of the array to generate
@@ -151,6 +159,8 @@ class ARROW_TESTING_EXPORT ConstantArrayGenerator {
         return UInt64(size, static_cast<uint64_t>(value));
       case Type::INT64:
         return Int64(size, static_cast<int64_t>(value));
+      case Type::HALF_FLOAT:
+        return Float16(size, static_cast<uint16_t>(value));
       case Type::FLOAT:
         return Float32(size, static_cast<float>(value));
       case Type::DOUBLE:


### PR DESCRIPTION
### Rationale for this change

Support float16/halffloat type in some functions which are agnostic to the numeric value.
* Includes `replace_with_mask` as requested in #37027 

### What changes are included in this PR?

* Added a case to `GenerateTypeAgnosticPrimitive` for `HALF_FLOAT`
* Added `float16` kernels for `if_else`, `case_when`, `coalesce`, and `choose`
* Added `float16` kernels for `replace_with_mask`, `fill_null_forward`, `fill_null_backward`
* Add `HalfFloatType` to the list of types tested for the above functions

### Are these changes tested?

Yes

### Are there any user-facing changes?

Functions listed above now support float16
* GitHub Issue: #37027