### PR TITLE
GH-46450: [GLib] Add GArrowFixedShapeDataType#strides

### DIFF
--- a/c_glib/arrow-glib/basic-data-type.cpp
+++ b/c_glib/arrow-glib/basic-data-type.cpp
@@ -2410,6 +2410,24 @@ garrow_fixed_shape_tensor_data_type_get_dim_names(
   dim_names[n] = nullptr;
   return dim_names;
 }
+
+/**
+ * garrow_fixed_shape_tensor_data_type_get_strides:
+ * @data_type: A #GArrowFixedShapeTensorDataType.
+ * @length: (out): Return location for the number of strides of tensor shape.
+ *
+ * Returns: (array length=length): Strides in bytes for each tensor dimension.
+ */
+const gint64 *
+garrow_fixed_shape_tensor_data_type_get_strides(GArrowFixedShapeTensorDataType *data_type,
+                                                gsize *length)
+{
+  auto arrow_data_type = std::static_pointer_cast<arrow::extension::FixedShapeTensorType>(
+    garrow_data_type_get_raw(GARROW_DATA_TYPE(data_type)));
+  const auto &arrow_strides = arrow_data_type->strides();
+  *length = arrow_strides.size();
+  return arrow_strides.data();
+}
 G_END_DECLS
 
 GArrowDataType *

--- a/c_glib/arrow-glib/basic-data-type.cpp
+++ b/c_glib/arrow-glib/basic-data-type.cpp
@@ -2417,6 +2417,8 @@ garrow_fixed_shape_tensor_data_type_get_dim_names(
  * @length: (out): Return location for the number of strides of tensor shape.
  *
  * Returns: (array length=length): Strides in bytes for each tensor dimension.
+ *
+ * Since: 21.0.0
  */
 const gint64 *
 garrow_fixed_shape_tensor_data_type_get_strides(GArrowFixedShapeTensorDataType *data_type,

--- a/c_glib/arrow-glib/basic-data-type.h
+++ b/c_glib/arrow-glib/basic-data-type.h
@@ -840,4 +840,9 @@ GARROW_AVAILABLE_IN_21_0
 gchar **
 garrow_fixed_shape_tensor_data_type_get_dim_names(
   GArrowFixedShapeTensorDataType *data_type);
+
+GARROW_AVAILABLE_IN_21_0
+const gint64 *
+garrow_fixed_shape_tensor_data_type_get_strides(GArrowFixedShapeTensorDataType *data_type,
+                                                gsize *length);
 G_END_DECLS

--- a/c_glib/test/test-fixed-shape-tensor-data-type.rb
+++ b/c_glib/test/test-fixed-shape-tensor-data-type.rb
@@ -40,6 +40,10 @@ class TestFixedShapeTensorDataType < Test::Unit::TestCase
     assert_equal([1, 0], @data_type.permutation)
   end
 
+  def test_strides
+    assert_equal([8, 32], @data_type.strides)
+  end
+
   def test_dim_names
     assert_equal(["x", "y"], @data_type.dim_names)
   end
@@ -56,6 +60,7 @@ class TestFixedShapeTensorDataType < Test::Unit::TestCase
                                                     nil,
                                                     ["x", "y"])
     assert_equal([], data_type.permutation)
+    assert_equal([32, 8], data_type.strides)
   end
 
   def test_nil_dim_names

--- a/c_glib/test/test-fixed-shape-tensor-data-type.rb
+++ b/c_glib/test/test-fixed-shape-tensor-data-type.rb
@@ -59,8 +59,8 @@ class TestFixedShapeTensorDataType < Test::Unit::TestCase
                                                     [3, 4],
                                                     nil,
                                                     ["x", "y"])
-    assert_equal([], data_type.permutation)
-    assert_equal([32, 8], data_type.strides)
+    assert_equal([[], [32, 8]],
+                 [data_type.permutation, data_type.strides])
   end
 
   def test_nil_dim_names


### PR DESCRIPTION
### Rationale for this change

The C++ API implemented `FixedShapeTensor::strides()` instance method. GLib was not yet supported.

### What changes are included in this PR?

Add `GArrowFixedShapeDataType#strides` instance method.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.

* GitHub Issue: #46450