### PR TITLE
GH-40756: [C++] Remove dead Boost urls

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -607,8 +607,6 @@ else()
            # our currently used packages and doesn't fall out of sync with
            # ${ARROW_BOOST_BUILD_VERSION_UNDERSCORES}
            "${THIRDPARTY_MIRROR_URL}/boost_${ARROW_BOOST_BUILD_VERSION_UNDERSCORES}.tar.gz"
-           "https://boostorg.jfrog.io/artifactory/main/release/${ARROW_BOOST_BUILD_VERSION}/source/boost_${ARROW_BOOST_BUILD_VERSION_UNDERSCORES}.tar.gz"
-           "https://sourceforge.net/projects/boost/files/boost/${ARROW_BOOST_BUILD_VERSION}/boost_${ARROW_BOOST_BUILD_VERSION_UNDERSCORES}.tar.gz"
   )
 endif()
 


### PR DESCRIPTION
One of the URLs is dead (https://boostorg.jfrog.io/artifactory/main/release/1.81.0/source/boost_1_81_0.tar.gz) and the sourceforge link is to the non-trimmed version.  

We are seeing these multiple downloads and fails on CRAN — I believe they get cleaned up so aren't the cause of those runners running out of space (See: https://www.r-project.org/nosvn/R.check/r-release-macos-x86_64/arrow-00install.txt and https://www.r-project.org/nosvn/R.check/r-oldrel-macos-x86_64/arrow-00install.html), but it still isn't great to have it download things we know will fail.

### Rationale for this change
Don't download things we know will fail

### What changes are included in this PR?
Removed two URLs

### Are these changes tested?
Extensively.

### Are there any user-facing changes?
No.
* GitHub Issue: #40756