### PR TITLE
GH-46456: [GLib] Add missing `since:` tag

### DIFF
--- a/c_glib/arrow-glib/basic-data-type.cpp
+++ b/c_glib/arrow-glib/basic-data-type.cpp
@@ -2300,6 +2300,8 @@ garrow_fixed_shape_tensor_data_type_class_init(GArrowFixedShapeTensorDataTypeCla
  * @error: (nullable): Return location for a #GError or %NULL.
  *
  * Returns: The newly created fixed shape tensor data type.
+ *
+ * Since: 21.0.0
  */
 GArrowFixedShapeTensorDataType *
 garrow_fixed_shape_tensor_data_type_new(GArrowDataType *value_type,

--- a/c_glib/arrow-glib/basic-data-type.cpp
+++ b/c_glib/arrow-glib/basic-data-type.cpp
@@ -2353,6 +2353,8 @@ garrow_fixed_shape_tensor_data_type_new(GArrowDataType *value_type,
  * @length: (out): Return location for the number of dimensions of the tensor.
  *
  * Returns: (array length=length): Shape of the tensor.
+ *
+ * Since: 21.0.0
  */
 const gint64 *
 garrow_fixed_shape_tensor_data_type_get_shape(GArrowFixedShapeTensorDataType *data_type,
@@ -2372,6 +2374,8 @@ garrow_fixed_shape_tensor_data_type_get_shape(GArrowFixedShapeTensorDataType *da
  * @length: (out): Return location for the number of elements of permutation.
  *
  * Returns: (array length=length): Permutation of the tensor.
+ *
+ * Since: 21.0.0
  */
 const gint64 *
 garrow_fixed_shape_tensor_data_type_get_permutation(
@@ -2394,6 +2398,8 @@ garrow_fixed_shape_tensor_data_type_get_permutation(
  *
  *   It's a %NULL-terminated string array. It must be freed with
  *   g_strfreev() when no longer needed.
+ *
+ * Since: 21.0.0
  */
 gchar **
 garrow_fixed_shape_tensor_data_type_get_dim_names(


### PR DESCRIPTION
### Rationale for this change

#46434, #46401, #46381 implemented some instance methods for `GArrowFixedShapeTensorDataType` class.
In method comment, a `since` tag was required, but I forgot to add it. 

### What changes are included in this PR?

Add `Since:` tags.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No. (Add comment only)
* GitHub Issue: #46456