### PR TITLE
GH-46396: [C++][Documentation][Statistics] Revise the documentation to clarify that arrow::ArrayStatistics is ignored during arrow::Array comparisons

### DIFF
--- a/cpp/src/arrow/array/array_base.h
+++ b/cpp/src/arrow/array/array_base.h
@@ -123,6 +123,8 @@ class ARROW_EXPORT Array {
   const uint8_t* null_bitmap_data() const { return null_bitmap_data_; }
 
   /// Equality comparison with another array
+  ///
+  /// Note that arrow::ArrayStatistics is not included in the comparison.
   bool Equals(const Array& arr, const EqualOptions& = EqualOptions::Defaults()) const;
   bool Equals(const std::shared_ptr<Array>& arr,
               const EqualOptions& = EqualOptions::Defaults()) const;
@@ -134,6 +136,8 @@ class ARROW_EXPORT Array {
   /// Approximate equality comparison with another array
   ///
   /// epsilon is only used if this is FloatArray or DoubleArray
+  ///
+  /// Note that arrow::ArrayStatistics is not included in the comparison.
   bool ApproxEquals(const std::shared_ptr<Array>& arr,
                     const EqualOptions& = EqualOptions::Defaults()) const;
   bool ApproxEquals(const Array& arr,
@@ -141,6 +145,8 @@ class ARROW_EXPORT Array {
 
   /// Compare if the range of slots specified are equal for the given array and
   /// this array.  end_idx exclusive.  This methods does not bounds check.
+  ///
+  /// Note that arrow::ArrayStatistics is not included in the comparison.
   bool RangeEquals(int64_t start_idx, int64_t end_idx, int64_t other_start_idx,
                    const Array& other,
                    const EqualOptions& = EqualOptions::Defaults()) const;

--- a/cpp/src/arrow/compare.h
+++ b/cpp/src/arrow/compare.h
@@ -92,21 +92,29 @@ class EqualOptions {
 };
 
 /// Returns true if the arrays are exactly equal
+///
+/// Note that arrow::ArrayStatistics is not included in the comparison.
 ARROW_EXPORT bool ArrayEquals(const Array& left, const Array& right,
                               const EqualOptions& = EqualOptions::Defaults());
 
 /// Returns true if the arrays are approximately equal. For non-floating point
 /// types, this is equivalent to ArrayEquals(left, right)
+///
+/// Note that arrow::ArrayStatistics is not included in the comparison.
 ARROW_EXPORT bool ArrayApproxEquals(const Array& left, const Array& right,
                                     const EqualOptions& = EqualOptions::Defaults());
 
 /// Returns true if indicated equal-length segment of arrays are exactly equal
+///
+/// Note that arrow::ArrayStatistics is not included in the comparison.
 ARROW_EXPORT bool ArrayRangeEquals(const Array& left, const Array& right,
                                    int64_t start_idx, int64_t end_idx,
                                    int64_t other_start_idx,
                                    const EqualOptions& = EqualOptions::Defaults());
 
 /// Returns true if indicated equal-length segment of arrays are approximately equal
+///
+/// Note that arrow::ArrayStatistics is not included in the comparison.
 ARROW_EXPORT bool ArrayRangeApproxEquals(const Array& left, const Array& right,
                                          int64_t start_idx, int64_t end_idx,
                                          int64_t other_start_idx,


### PR DESCRIPTION
### Rationale for this change
as mentiond [here](https://github.com/apache/arrow/issues/46396#issuecomment-2873020124), The document should be clarified  that `arrow::ArrayStatistics` is not inlcuded in the `arrow::Array` comparasion
### What changes are included in this PR?
Add documets for` arrow::Array::Equals`, `arrow::Array::ApproxEquals`, `arrow::Array::EqualsRange`, `arrow::ArrayEquals`, `arrow::ArrayApproxEquals`, `arrow::ArrayRangeEquals`, and `arrow::ArrayRangeApproxEquals`
### Are these changes tested?
No
### Are there any user-facing changes?
No


* GitHub Issue: #46396