### PR TITLE
GH-43623: [R] remove libarrow backwards compatibility enforcement

### DIFF
--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -62,63 +62,6 @@ env:
   DOCKER_VOLUME_PREFIX: ".docker/"
 
 jobs:
-  ubuntu-minimum-cpp-version:
-    name: Check minimum supported Arrow C++ Version (${{ matrix.cpp_version }})
-    runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        include:
-          - cpp_version: "19.0.1"
-    steps:
-    - name: Checkout Arrow
-      uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
-      with:
-        path: src
-        submodules: recursive
-
-    - name: Install Arrow C++ (${{ matrix.cpp_version }})
-      run: |
-        sudo apt update
-        sudo apt install -y -V ca-certificates lsb-release wget
-        wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
-        sudo apt install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
-        sudo apt update
-        # We have to list all packages to avoid version conflicts.
-        sudo apt install -y -V libarrow-dev=${{ matrix.cpp_version }}-1 \
-                               libarrow-acero-dev=${{ matrix.cpp_version }}-1 \
-                               libparquet-dev=${{ matrix.cpp_version }}-1 \
-                               libarrow-dataset-dev=${{ matrix.cpp_version }}-1
-
-    - name: Install checkbashisms
-      run: |
-        sudo apt-get install devscripts
-
-    - uses: r-lib/actions/setup-r@v2
-      with:
-        use-public-rspm: true
-        install-r: false
-
-    - uses: r-lib/actions/setup-r-dependencies@v2
-      with:
-        extra-packages: any::rcmdcheck
-        needs: check
-        working-directory: src/r
-
-    - uses: r-lib/actions/check-r-package@v2
-      with:
-        working-directory: src/r
-      env:
-        LIBARROW_BINARY: "false"
-        LIBARROW_BUILD: "false"
-        ARROW_R_VERBOSE_TEST: "true"
-        ARROW_R_ALLOW_CPP_VERSION_MISMATCH: "true"
-
-    - name: Show install output
-      if: always()
-      run: find src/r/check -name '00install.out*' -exec cat '{}' \; || true
-      shell: bash
-
-
   ubuntu:
     name: AMD64 Ubuntu ${{ matrix.ubuntu }} R ${{ matrix.r }} Force-Tests ${{ matrix.force-tests }}
     runs-on: ubuntu-latest

--- a/r/PACKAGING.md
+++ b/r/PACKAGING.md
@@ -25,7 +25,7 @@ For a high-level overview of the Arrow release process see the [Apache Arrow Rel
 ## Before the Arrow Release Candidate Is Created
 
 - [ ] [Create a GitHub issue](https://github.com/apache/arrow/issues/new/) entitled `[R] CRAN packaging checklist for version X.Y.Z` and copy this checklist to the issue.
-- [ ] Review deprecated functions to advance their deprecation status, including removing preprocessor directives that no longer apply (search for `ARROW_VERSION_MAJOR` in r/src).
+- [ ] Review deprecated functions to advance their deprecation status.
 - [ ] Evaluate the status of any failing [nightly tests and nightly packaging builds](http://crossbow.voltrondata.com). These checks replicate most of the checks that CRAN runs, so we need them all to be passing or to understand that the failures may (though won't necessarily) result in a rejection from CRAN.
 - [ ] Check [current CRAN check results](https://cran.rstudio.org/web/checks/check_results_arrow.html).
 - [ ] Ensure the contents of the README are accurate and up to date.

--- a/r/src/altrep.cpp
+++ b/r/src/altrep.cpp
@@ -80,13 +80,8 @@ void DeletePointer(std::shared_ptr<T>* ptr) {
 template <typename T>
 using Pointer = cpp11::external_pointer<std::shared_ptr<T>, DeletePointer<T>>;
 
-#if ARROW_VERSION_MAJOR >= 18
 using ChunkResolver = arrow::ChunkResolver;
 using ChunkLocation = arrow::ChunkLocation;
-#else
-using ChunkResolver = arrow::internal::ChunkResolver;
-using ChunkLocation = arrow::internal::ChunkLocation;
-#endif
 
 class ArrowAltrepData {
  public:

--- a/r/src/extension-impl.cpp
+++ b/r/src/extension-impl.cpp
@@ -100,11 +100,7 @@ std::string RExtensionType::ToString(bool show_metadata) const {
   // In the event of an error (e.g., we are not on the main thread
   // and we are not inside RunWithCapturedR()), just call the default method
   if (!result.ok()) {
-#if ARROW_VERSION_MAJOR >= 16
     return ExtensionType::ToString(show_metadata);
-#else
-    return ExtensionType::ToString();
-#endif
   } else {
     return result.ValueUnsafe();
   }

--- a/r/src/filesystem.cpp
+++ b/r/src/filesystem.cpp
@@ -429,11 +429,7 @@ std::shared_ptr<fs::GcsFileSystem> fs___GcsFileSystem__Make(bool anonymous,
   }
 
   auto io_context = MainRThread::GetInstance().CancellableIOContext();
-#if ARROW_VERSION_MAJOR >= 18
   return ValueOrStop(fs::GcsFileSystem::Make(gcs_opts, io_context));
-#else
-  return fs::GcsFileSystem::Make(gcs_opts, io_context);
-#endif
 }
 
 // [[gcs::export]]


### PR DESCRIPTION
### Rationale for this change
Remove checks and enforcement of minimum versions. See discussion in the issue. This caused more confusion and discussion than it was helpful. We have the CI in git history if we need it.

### What changes are included in this PR?

Removing the CI job

### Are these changes tested?

They are the tests

### Are there any user-facing changes?

No, we are still technically compatible with 19.0.1, but we don't explicitly support that or use it anywhere. The R package version should match the libarrow version to ensure compatibility — using anything else might work but is off label.
* GitHub Issue: #43623