### PR TITLE
GH-46490: [CI][Dev] Add shellcheck ci/scripts/install_ccache.sh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -197,6 +197,7 @@ repos:
           ?^ci/scripts/conan_setup\.sh$|
           ?^ci/scripts/download_tz_database\.sh$|
           ?^ci/scripts/install_azurite\.sh$|
+          ?^ci/scripts/install_ccache\.sh$|
           ?^ci/scripts/install_ceph\.sh$|
           ?^ci/scripts/install_spark\.sh$|
           ?^ci/scripts/integration_dask\.sh$|

--- a/ci/scripts/install_ccache.sh
+++ b/ci/scripts/install_ccache.sh
@@ -32,23 +32,23 @@ case $(uname) in
   MINGW64*)
     url="https://github.com/ccache/ccache/releases/download/v${version}/ccache-${version}-windows-x86_64.zip"
     pushd /tmp/ccache
-    curl --fail --location --remote-name ${url}
-    unzip -j ccache-${version}-windows-x86_64.zip
+    curl --fail --location --remote-name "${url}"
+    unzip -j "ccache-${version}-windows-x86_64.zip"
     chmod +x ccache.exe
-    mv ccache.exe ${prefix}/bin/
+    mv ccache.exe "${prefix}/bin/"
     popd
     ;;
   *)
     url="https://github.com/ccache/ccache/archive/v${version}.tar.gz"
 
-    wget -q ${url} -O - | tar -xzf - --directory /tmp/ccache --strip-components=1
+    wget -q "${url}" -O - | tar -xzf - --directory /tmp/ccache --strip-components=1
 
     mkdir /tmp/ccache/build
     pushd /tmp/ccache/build
     cmake \
       -GNinja \
       -DCMAKE_BUILD_TYPE=Release \
-      -DCMAKE_INSTALL_PREFIX=${prefix} \
+      -DCMAKE_INSTALL_PREFIX="${prefix}" \
       -DZSTD_FROM_INTERNET=ON \
       ..
     ninja install


### PR DESCRIPTION
### Rationale for this change

shellcheck outputs the following error in `ci/scripts/install_ccache.sh`.

```
In ci/scripts/install_ccache.sh line 35:
    curl --fail --location --remote-name ${url}
                                         ^----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    curl --fail --location --remote-name "${url}"


In ci/scripts/install_ccache.sh line 36:
    unzip -j ccache-${version}-windows-x86_64.zip
                    ^--------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    unzip -j ccache-"${version}"-windows-x86_64.zip


In ci/scripts/install_ccache.sh line 38:
    mv ccache.exe ${prefix}/bin/
                  ^-------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    mv ccache.exe "${prefix}"/bin/


In ci/scripts/install_ccache.sh line 44:
    wget -q ${url} -O - | tar -xzf - --directory /tmp/ccache --strip-components=1
            ^----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    wget -q "${url}" -O - | tar -xzf - --directory /tmp/ccache --strip-components=1
```

### What changes are included in this PR?

Fix shellcheck error. (Quote variables)

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.

* GitHub Issue: #46490