### PR TITLE
GH-24833 [JS] Implement IPC RecordBatch body buffer compression

### DIFF
--- a/js/src/Arrow.dom.ts
+++ b/js/src/Arrow.dom.ts
@@ -76,6 +76,7 @@ export {
     RecordBatch,
     util,
     Builder, makeBuilder, builderThroughIterable, builderThroughAsyncIterable,
+    compressionRegistry, CompressionType,
 } from './Arrow.js';
 
 export {

--- a/js/src/Arrow.ts
+++ b/js/src/Arrow.ts
@@ -16,6 +16,7 @@
 // under the License.
 
 export { MessageHeader } from './fb/message-header.js';
+export { CompressionType } from './fb/compression-type.js';
 
 export {
     Type,
@@ -92,6 +93,7 @@ export type { ReadableSource, WritableSink } from './io/stream.js';
 export { RecordBatchReader, RecordBatchFileReader, RecordBatchStreamReader, AsyncRecordBatchFileReader, AsyncRecordBatchStreamReader } from './ipc/reader.js';
 export { RecordBatchWriter, RecordBatchFileWriter, RecordBatchStreamWriter, RecordBatchJSONWriter } from './ipc/writer.js';
 export { tableToIPC, tableFromIPC } from './ipc/serialization.js';
+export { compressionRegistry } from './ipc/compression.js';
 export { MessageReader, AsyncMessageReader, JSONMessageReader } from './ipc/message.js';
 export { Message } from './ipc/metadata/message.js';
 export { RecordBatch } from './recordbatch.js';

--- a/js/src/fb/body-compression.ts
+++ b/js/src/fb/body-compression.ts
@@ -33,7 +33,7 @@ static getSizePrefixedRootAsBodyCompression(bb:flatbuffers.ByteBuffer, obj?:Body
  * Compressor library.
  * For LZ4_FRAME, each compressed buffer must consist of a single frame.
  */
-codec():CompressionType {
+codec(): CompressionType {
   const offset = this.bb!.__offset(this.bb_pos, 4);
   return offset ? this.bb!.readInt8(this.bb_pos + offset) : CompressionType.LZ4_FRAME;
 }

--- a/js/src/ipc/compression.ts
+++ b/js/src/ipc/compression.ts
@@ -1,0 +1,48 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import { CompressionType } from '../fb/compression-type.js';
+
+export const LENGTH_NO_COMPRESSED_DATA: number = -1;
+export const LENGTH_OF_PREFIX_DATA: number = 8;
+
+export interface Codec {
+    encode?(data: Uint8Array): Uint8Array;
+    decode?(data: Uint8Array): Uint8Array;
+}
+
+class _CompressionRegistry {
+    protected declare registry: { [key in CompressionType]?: Codec };
+
+    constructor() {
+        this.registry = {};
+    }
+
+    set(compression: CompressionType, codec: Codec) {
+        this.registry[compression] = codec;
+    }
+
+    get(compression?: CompressionType): Codec | null {
+        if (compression !== undefined) {
+            return this.registry?.[compression] || null;
+        }
+        return null;
+    }
+
+}
+
+export const compressionRegistry = new _CompressionRegistry();

--- a/js/src/ipc/metadata/json.ts
+++ b/js/src/ipc/metadata/json.ts
@@ -42,7 +42,8 @@ export function recordBatchFromJSON(b: any) {
     return new RecordBatch(
         b['count'],
         fieldNodesFromJSON(b['columns']),
-        buffersFromJSON(b['columns'])
+        buffersFromJSON(b['columns']),
+        null
     );
 }
 

--- a/js/src/ipc/metadata/message.ts
+++ b/js/src/ipc/metadata/message.ts
@@ -158,8 +158,8 @@ export class RecordBatch {
     public get buffers() { return this._buffers; }
     public get compression() { return this._compression; }
     constructor(
-        length: bigint | number, 
-        nodes: FieldNode[], 
+        length: bigint | number,
+        nodes: FieldNode[],
         buffers: BufferRegion[],
         compression: _CompressionType | null
     ) {
@@ -308,8 +308,8 @@ function decodeSchema(_schema: _Schema, dictionaries: Map<number, DataType> = ne
 /** @ignore */
 function decodeRecordBatch(batch: _RecordBatch, version = MetadataVersion.V5) {
     const recordBatch = new RecordBatch(
-        batch.length(), 
-        decodeFieldNodes(batch), 
+        batch.length(),
+        decodeFieldNodes(batch),
         decodeBuffers(batch, version),
         batch.compression()?.codec() ?? null
     );

--- a/js/src/ipc/reader.ts
+++ b/js/src/ipc/reader.ts
@@ -370,7 +370,7 @@ abstract class RecordBatchReaderImpl<T extends TypeMap = any> implements RecordB
                     header.nodes,
                     buffers,
                     null
-                );                
+                );
             } else {
                 throw new Error('Record batch is compressed but codec not found');
             }
@@ -393,7 +393,7 @@ abstract class RecordBatchReaderImpl<T extends TypeMap = any> implements RecordB
         return new VectorLoader(body, header.nodes, header.buffers, this.dictionaries, this.schema.metadataVersion).visitMany(types);
     }
 
-    private _decompressBuffers(header: metadata.RecordBatch, body: Uint8Array, codec: Codec): { decommpressedBody: Uint8Array, buffers: metadata.BufferRegion[] } {
+    private _decompressBuffers(header: metadata.RecordBatch, body: Uint8Array, codec: Codec): { decommpressedBody: Uint8Array; buffers: metadata.BufferRegion[] } {
         const decompressedBuffers: Uint8Array[] = [];
         const newBufferRegions: metadata.BufferRegion[] = [];
 
@@ -404,13 +404,13 @@ abstract class RecordBatchReaderImpl<T extends TypeMap = any> implements RecordB
                 newBufferRegions.push(new metadata.BufferRegion(currentOffset, 0));
                 continue;
             }
-            const byteBuf = new flatbuffers.ByteBuffer(body.subarray(offset, offset + length))
-            let uncompressedLenth = bigIntToNumber(byteBuf.readInt64(0));
-            
-            
+            const byteBuf = new flatbuffers.ByteBuffer(body.subarray(offset, offset + length));
+            const uncompressedLenth = bigIntToNumber(byteBuf.readInt64(0));
+
+
             const bytes = byteBuf.bytes().subarray(LENGTH_OF_PREFIX_DATA);
-            
-            let decompressed = (uncompressedLenth === LENGTH_NO_COMPRESSED_DATA)
+
+            const decompressed = (uncompressedLenth === LENGTH_NO_COMPRESSED_DATA)
                 ? bytes
                 : codec.decode!(bytes);
 
@@ -425,14 +425,14 @@ abstract class RecordBatchReaderImpl<T extends TypeMap = any> implements RecordB
         const totalSize = currentOffset;
         const combined = new Uint8Array(totalSize);
 
-        for (let i = 0; i < decompressedBuffers.length; i++) {                  
-            combined.set(decompressedBuffers[i], newBufferRegions[i].offset);
+        for (const [i, decompressedBuffer] of decompressedBuffers.entries()) {
+            combined.set(decompressedBuffer, newBufferRegions[i].offset);
         }
 
         return {
             decommpressedBody: combined,
             buffers: newBufferRegions
-        }        
+        };
     }
 }
 

--- a/js/src/ipc/writer.ts
+++ b/js/src/ipc/writer.ts
@@ -252,7 +252,7 @@ export class RecordBatchWriter<T extends TypeMap = any> extends ReadableInterop<
 
     protected _writeRecordBatch(batch: RecordBatch<T>) {
         const { byteLength, nodes, bufferRegions, buffers } = VectorAssembler.assemble(batch);
-        const recordBatch = new metadata.RecordBatch(batch.numRows, nodes, bufferRegions);
+        const recordBatch = new metadata.RecordBatch(batch.numRows, nodes, bufferRegions, null);
         const message = Message.from(recordBatch, byteLength);
         return this
             ._writeDictionaries(batch)
@@ -262,7 +262,7 @@ export class RecordBatchWriter<T extends TypeMap = any> extends ReadableInterop<
 
     protected _writeDictionaryBatch(dictionary: Data, id: number, isDelta = false) {
         const { byteLength, nodes, bufferRegions, buffers } = VectorAssembler.assemble(new Vector([dictionary]));
-        const recordBatch = new metadata.RecordBatch(dictionary.length, nodes, bufferRegions);
+        const recordBatch = new metadata.RecordBatch(dictionary.length, nodes, bufferRegions, null);
         const dictionaryBatch = new metadata.DictionaryBatch(recordBatch, id, isDelta);
         const message = Message.from(dictionaryBatch, byteLength);
         return this


### PR DESCRIPTION
### Rationale for this change
This change introduces support for reading compressed Arrow IPC streams in JavaScript. The primary motivation is the need to read Arrow IPC Stream in the browser when they are transmitted over the network in a compressed format to reduce network load.

Several reasons support this enhancement:
- Personal need in other project to read compressed arrow IPC stream.
- Community demand, as seen in [Issue apache/arrow-js#109](https://github.com/apache/arrow-js/issues/109).
- A similar implementation was attempted in [PR apache/arrow#13076](https://github.com/apache/arrow/pull/13076) but was never merged. I am very grateful to @kylebarron .
- Other language implementations (e.g., C++, Python, Rust) already support IPC compression.

### What changes are included in this PR?
- Support for decoding compressed RecordBatch buffers during reading.
- Each buffer is decompressed individually, offsets are recalculated with 8-byte alignment, and a new metadata. RecordBatch is constructed before loading vectors.
- Only decompression is implemented; compression (writing) is not supported yet.
- Currently tested with the lz4 codec using the lz4js library. lz4-wasm was evaluated but rejected due to incompatibility with LZ4 Frame format.
- The decompression logic is isolated to _loadRecordBatch() in the RecordBatchReaderImpl class.
- A codec.decode function is retrieved from the compressionRegistry and applied per-buffer. So users can choose suitable lib.

#### Additional notes:
1. Codec compatibility caveats
Not all JavaScript LZ4 libraries are compatible with the Arrow IPC format. For example:
- lz4js works correctly as it supports the LZ4 Frame Format.
- lz4-wasm is not compatible, as it expects raw LZ4 blocks and fails to decompress LZ4 frame data.
This can result in silent or cryptic errors. To improve developer experience, we could:
- Wrap codec.decode calls in try/catch and surface a clearer error message if decompression fails.
- Add an optional check in compressionRegistry.set() to validate that the codec supports LZ4 Frame Format. One way would be to compress dummy data and inspect the first 4 bytes for the expected LZ4 Frame magic header (0x04 0x22 0x4D 0x18).
2. Reconstruction of metadata.RecordBatch
After decompressing the buffers, new BufferRegion entries are calculated to match the uncompressed data layout. A new metadata.RecordBatch is constructed with the updated buffer regions and passed into _loadVectors().
This introduces a mutation-like pattern that may break assumptions in the current design. However, it's necessary because:
- _loadVectors() depends strictly on the offsets in header.buffers, which no longer match the decompressed buffer layout.
- Without changing either _loadVectors() or metadata.RecordBatch, the current approach is the least intrusive.
3. Setting compression = null in new RecordBatch
When reconstructing the metadata, the compression field is explicitly set to null, since the data is already decompressed in memory.
This decision is somewhat debatable — feedback is welcome on whether it's better to retain the original compression metadata or to reflect the current state of the buffer (uncompressed). The current implementation assumes the latter.

### Are these changes tested?
- The changes were tested in the own project using LZ4-compressed Arrow stream.
- Test uncompressed, compressed and pseudo compressed(uncompressed data length = -1) data. 
- No unit tests are included in this PR yet.
- The decompression was verified with real-world data and the lz4js codec (lz4-wasm is not compatible).
- No issues were observed with alignment, vector loading, or decompression integrity.
- Exception handling is not yet added around codec.decode. This may be useful for catching codec incompatibility and providing better user feedback.

### Are there any user-facing changes?
Yes, Arrow JS users can now read compressed IPC stream, assuming they register an appropriate codec using compressionRegistry.set().

Example:
```ts
import { Codec, compressionRegistry } from 'apache-arrow';
import * as lz4 from 'lz4js';

  const lz4Codec: Codec = {
      encode(data: Uint8Array): Uint8Array { return lz4js.compress(data) },
      decode(data: Uint8Array): Uint8Array { return lz4js.decompress(data) }
  }; 

  compressionRegistry.set(CompressionType.LZ4_FRAME, lz4Codec);
```
This change does not affect writing or serialization.

**This PR includes breaking changes to public APIs.**
No. The change adds functionality but does not modify any existing API behavior.

**This PR contains a "Critical Fix".**
No. This is a new feature, not a critical fix.

### Checklist

- [x] All tests pass (`yarn test`)
- [x] Build completes (`yarn build`)
- [ ] I have added a new test for compressed batches
* GitHub Issue: apache/arrow-js#109
* GitHub Issue: #109