### PR TITLE
GH-46494: [CI][Dev] Add shellcheck files without change

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -208,14 +208,6 @@ repos:
           ?^cpp/build-support/build-zstd-lib\.sh$|
           ?^cpp/build-support/get-upstream-commit\.sh$|
           ?^cpp/build-support/update-thrift\.sh$|
-          ?^cpp/build/google_cloud_cpp_ep-prefix/src/google_cloud_cpp_ep/external/googleapis/renovate\.sh$|
-          ?^cpp/build/google_cloud_cpp_ep-prefix/src/google_cloud_cpp_ep/external/googleapis/update_libraries\.sh$|
-          ?^cpp/build/google_cloud_cpp_ep-prefix/src/google_cloud_cpp_ep/release/release\.sh$|
-          ?^cpp/build/substrait_ep-prefix/src/substrait_ep/ci/release/dry_run\.sh$|
-          ?^cpp/build/substrait_ep-prefix/src/substrait_ep/ci/release/prepare\.sh$|
-          ?^cpp/build/substrait_ep-prefix/src/substrait_ep/ci/release/publish\.sh$|
-          ?^cpp/build/substrait_ep-prefix/src/substrait_ep/ci/release/run\.sh$|
-          ?^cpp/build/substrait_ep-prefix/src/substrait_ep/ci/release/verify\.sh$|
           ?^cpp/examples/minimal_build/run\.sh$|
           ?^cpp/examples/tutorial_examples/run\.sh$|
           ?^dev/release/05-binary-upload\.sh$|

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -192,6 +192,7 @@ repos:
         # TODO: Remove this when we fix all lint failures
         files: >-
           (
+          ?^c_glib/test/run-test\.sh$|
           ?^ci/scripts/c_glib_build\.sh$|
           ?^ci/scripts/c_glib_test\.sh$|
           ?^ci/scripts/conan_setup\.sh$|
@@ -203,18 +204,31 @@ repos:
           ?^ci/scripts/integration_dask\.sh$|
           ?^ci/scripts/msys2_system_upgrade\.sh$|
           ?^ci/scripts/util_free_space\.sh$|
-          ?^c_glib/test/run-test\.sh$|
           ?^cpp/build-support/build-lz4-lib\.sh$|
           ?^cpp/build-support/build-zstd-lib\.sh$|
           ?^cpp/build-support/get-upstream-commit\.sh$|
           ?^cpp/build-support/update-thrift\.sh$|
+          ?^cpp/build/google_cloud_cpp_ep-prefix/src/google_cloud_cpp_ep/external/googleapis/renovate\.sh$|
+          ?^cpp/build/google_cloud_cpp_ep-prefix/src/google_cloud_cpp_ep/external/googleapis/update_libraries\.sh$|
+          ?^cpp/build/google_cloud_cpp_ep-prefix/src/google_cloud_cpp_ep/release/release\.sh$|
+          ?^cpp/build/substrait_ep-prefix/src/substrait_ep/ci/release/dry_run\.sh$|
+          ?^cpp/build/substrait_ep-prefix/src/substrait_ep/ci/release/prepare\.sh$|
+          ?^cpp/build/substrait_ep-prefix/src/substrait_ep/ci/release/publish\.sh$|
+          ?^cpp/build/substrait_ep-prefix/src/substrait_ep/ci/release/run\.sh$|
+          ?^cpp/build/substrait_ep-prefix/src/substrait_ep/ci/release/verify\.sh$|
+          ?^cpp/examples/minimal_build/run\.sh$|
+          ?^cpp/examples/tutorial_examples/run\.sh$|
           ?^dev/release/05-binary-upload\.sh$|
           ?^dev/release/07-binary-verify\.sh$|
           ?^dev/release/binary-recover\.sh$|
           ?^dev/release/post-03-binary\.sh$|
           ?^dev/release/post-10-docs\.sh$|
           ?^dev/release/post-11-python\.sh$|
+          ?^dev/release/setup-rhel-rebuilds\.sh$|
           ?^dev/release/utils-generate-checksum\.sh$|
+          ?^python/asv-install\.sh$|
+          ?^python/asv-uninstall\.sh$|
+          ?^swift/gen-protobuffers\.sh$|
           )
   - repo: https://github.com/scop/pre-commit-shfmt
     rev: v3.11.0-1


### PR DESCRIPTION
### Rationale for this change

We are trying to implement shellcheck on all sh files in #44748.

### What changes are included in this PR?

Add shell script files which are passed shellcheck without change.
Sort file names in alphabetical order. relocate `c_glib/test/run-test.sh`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #46494