### PR TITLE
GH-46507: [C++] Make the aws sdk S3 lowSpeedLimit configurable from arrow S3Options

### DIFF
--- a/cpp/src/arrow/filesystem/s3fs.cc
+++ b/cpp/src/arrow/filesystem/s3fs.cc
@@ -445,6 +445,7 @@ bool S3Options::Equals(const S3Options& other) const {
           : (!other.default_metadata || other.default_metadata->size() == 0);
   return (region == other.region && connect_timeout == other.connect_timeout &&
           request_timeout == other.request_timeout &&
+          low_speed_limit == other.low_speed_limit &&
           endpoint_override == other.endpoint_override && scheme == other.scheme &&
           role_arn == other.role_arn && session_name == other.session_name &&
           external_id == other.external_id && load_frequency == other.load_frequency &&
@@ -1128,6 +1129,9 @@ class ClientBuilder {
     if (options_.connect_timeout > 0) {
       client_config_.connectTimeoutMs =
           static_cast<long>(ceil(options_.connect_timeout * 1000));  // NOLINT runtime/int
+    }
+    if (options_.low_speed_limit >= 0) {
+      client_config_.lowSpeedLimit = options_.low_speed_limit;
     }
 
     client_config_.endpointOverride = ToAwsString(options_.endpoint_override);

--- a/cpp/src/arrow/filesystem/s3fs.h
+++ b/cpp/src/arrow/filesystem/s3fs.h
@@ -116,6 +116,14 @@ struct ARROW_EXPORT S3Options {
   /// This option is ignored on non-Windows, non-macOS systems.
   double request_timeout = -1;
 
+  /// \brief Minimum transfer rate in bytes per second
+  ///
+  /// If the transfer falls below the low_speed_limit during the request_timeout
+  /// period, the transfer will be considered too slow, and abort.
+  /// If negative, the AWS SDK default value is used (typically 1 byte/second).
+  /// This option is only for CURL clients.
+  int low_speed_limit = -1;
+
   /// If non-empty, override region with a connect string such as "localhost:9000"
   // XXX perhaps instead take a URL like "http://localhost:9000"?
   std::string endpoint_override;


### PR DESCRIPTION
### Rationale for this change
In extreme cases, a slow network response response from S3, Minio, etc will result in arrow returning curlCode: 28 timeout errors even before the request_timeout period has elapsed. This is because there is an additional setting used in the awssdk known as the lowSpeedLimit (used in the curl library) to abort the transfer if the transfer rate drops below some value (by default 1 byte / second). In such a case the user may want to disable this lowSpeedLimit to allow their reads to succeed despite the slow network throughputs.

### What changes are included in this PR?
add the low_speed_limit option to S3Options, and then include them in the client_config_ if they are >=0
`< 0` will use the default setting from the s3 sdk (like other options)
`0` disables the lowSpeedLimit
`> 0` will set the lowSpeedLimit to N bytes / s

### Are these changes tested?
They are tested our fork in arrow 13.0.0.0 but I have not tested with the latest code, as I'm unable to build main in my environment (it looks like a new build dependency on ninja was added and I'm not able to install it at the moment on my system). I have opened this PR via a clean cherry-pick of my changes.

### Are there any user-facing changes?
No, these settings are for advanced users of the C++ sdk with S3FS
* GitHub Issue: #46507