### PR TITLE
GH-46343: [CI] Avoid installing gdb 16.3 on python 3.10 jobs to fix CI

### DIFF
--- a/ci/docker/conda-python.dockerfile
+++ b/ci/docker/conda-python.dockerfile
@@ -23,11 +23,19 @@ FROM ${repo}:${arch}-conda-cpp
 ARG python=3.9
 COPY ci/conda_env_python.txt \
      /arrow/ci/
+# If the Python version being used is 3.10 we need to install gdb<16.3 (GH-46343).
 # If the Python version being tested is the same as the Python used by the system gdb,
 # we need to install the conda-forge gdb instead (GH-38323).
-RUN mamba install -q -y \
+RUN if [ "$python" == "3.10" ]; then \
+        GDB_PACKAGE="gdb<16.3"; \
+    elif [ "$python" == "$(gdb --batch --eval-command 'python import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')" ]; then \
+        GDB_PACKAGE="gdb"; \
+    else \
+        GDB_PACKAGE=""; \
+    fi && \
+    mamba install -q -y \
         --file arrow/ci/conda_env_python.txt \
-        $([ "$python" == $(gdb --batch --eval-command 'python import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")') ] && echo "gdb") \
+        $([[ -n "$GDB_PACKAGE" ]] && echo "$GDB_PACKAGE") \
         "python=${python}.*=*_cp*" \
         nomkl && \
     mamba clean --all --yes


### PR DESCRIPTION
### Rationale for this change

The Python 3.10 jobs are currently failing due to conda gdb==16.3 being installed and having an issue.

### What changes are included in this PR?

Pin gdb<16.3 for python==3.10 to fix CI.

### Are these changes tested?

On CI

### Are there any user-facing changes?

No

* GitHub Issue: #46343