### PR TITLE
GH-46350: [C++] Custom logging for S3 SDK

### DIFF
--- a/cpp/src/arrow/filesystem/s3fs.h
+++ b/cpp/src/arrow/filesystem/s3fs.h
@@ -383,11 +383,19 @@ class ARROW_EXPORT S3FileSystem : public FileSystem {
   std::shared_ptr<Impl> impl_;
 };
 
+class ARROW_EXPORT S3Logger {
+ public:
+  virtual void log(std::string& statement) = 0;
+};
+
 enum class S3LogLevel : int8_t { Off, Fatal, Error, Warn, Info, Debug, Trace };
 
 struct ARROW_EXPORT S3GlobalOptions {
   /// The log level for S3-originating messages.
   S3LogLevel log_level;
+
+  /// Optional logger class to use for the aws sdk
+  std::shared_ptr<S3Logger> logger;
 
   /// The number of threads to configure when creating AWS' I/O event loop
   ///


### PR DESCRIPTION
### Rationale for this change
Some applications have their own way of logging, however there is no way for the user to implement a custom logger to get more information from arrow, as it always logs to the console

### What changes are included in this PR?
- A virtual S3Logger class which the user can implement
- A wrapper class in arrow which implements Aws::Utils::Logging::DefaultLogSystem
The user can then add their own S3Logger derived class to S3GlobalOptions and they will be wrapped by WrappedS3Logger and given to S3 when we initialize
As I understand it, arrow doesn't want to expose aws headers directly, since a user may have linked their own awssdk at a different version. This approach works around that issue. I'm happy to retool it in a different direction with review feedback.

### Are these changes tested?
They are tested our fork in arrow 13.0.0.0 but I have not tested with the latest code, as I'm unable to build main in my environment (it looks like a new build dependency on ninja was added and I'm not able to install it at the moment on my system). I have opened this PR via a cherry-pick of my changes.

### Are there any user-facing changes?
No, these settings are for advanced users of the C++ sdk with S3FS
* GitHub Issue: #46350