### PR TITLE
GH-46512: [CI][C++] Install the llvm package explicitly on MSYS2

### DIFF
--- a/ci/scripts/msys2_setup.sh
+++ b/ci/scripts/msys2_setup.sh
@@ -38,6 +38,7 @@ case "${target}" in
     packages+=(${MINGW_PACKAGE_PREFIX}-gtest)
     packages+=(${MINGW_PACKAGE_PREFIX}-libutf8proc)
     packages+=(${MINGW_PACKAGE_PREFIX}-libxml2)
+    packages+=(${MINGW_PACKAGE_PREFIX}-llvm)
     packages+=(${MINGW_PACKAGE_PREFIX}-lz4)
     packages+=(${MINGW_PACKAGE_PREFIX}-ninja)
     packages+=(${MINGW_PACKAGE_PREFIX}-nlohmann-json)


### PR DESCRIPTION
### Rationale for this change

https://github.com/msys2/MINGW-packages/pull/24287 made the llvm package as an optional dependency of the clang package. We need the llvm package.

### What changes are included in this PR?

Install the llvm package explicitly.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #46512