### PR TITLE
GH-46526: [CI][Dev] Fix shellcheck SC2086 and SC2223 errors ci/scripts directory

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -285,9 +285,9 @@ repos:
           ?^ci/scripts/msys2_system_clean\.sh$|
           ?^ci/scripts/msys2_system_upgrade\.sh$|
           ?^ci/scripts/python_sdist_build\.sh$|
-          ?^ci/scripts/python_wheel_unix_test\.sh|$
-          ?^ci/scripts/r_build\.sh|$
-          ?^ci/scripts/r_revdepcheck\.sh|$
+          ?^ci/scripts/python_wheel_unix_test\.sh$|
+          ?^ci/scripts/r_build\.sh$|
+          ?^ci/scripts/r_revdepcheck\.sh$|
           ?^ci/scripts/release_test\.sh$|
           ?^ci/scripts/ruby_test\.sh$|
           ?^ci/scripts/rust_build\.sh$|

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -279,11 +279,15 @@ repos:
           ?^ci/scripts/install_python\.sh$|
           ?^ci/scripts/install_spark\.sh$|
           ?^ci/scripts/install_vcpkg\.sh$|
+          ?^ci/scripts/integration_arrow_build\.sh|$
           ?^ci/scripts/integration_dask\.sh$|
           ?^ci/scripts/matlab_build\.sh$|
           ?^ci/scripts/msys2_system_clean\.sh$|
           ?^ci/scripts/msys2_system_upgrade\.sh$|
           ?^ci/scripts/python_sdist_build\.sh$|
+          ?^ci/scripts/python_wheel_unix_test\.sh|$
+          ?^ci/scripts/r_build\.sh|$
+          ?^ci/scripts/r_revdepcheck\.sh|$
           ?^ci/scripts/release_test\.sh$|
           ?^ci/scripts/ruby_test\.sh$|
           ?^ci/scripts/rust_build\.sh$|

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -279,7 +279,7 @@ repos:
           ?^ci/scripts/install_python\.sh$|
           ?^ci/scripts/install_spark\.sh$|
           ?^ci/scripts/install_vcpkg\.sh$|
-          ?^ci/scripts/integration_arrow_build\.sh|$
+          ?^ci/scripts/integration_arrow_build\.sh$|
           ?^ci/scripts/integration_dask\.sh$|
           ?^ci/scripts/matlab_build\.sh$|
           ?^ci/scripts/msys2_system_clean\.sh$|

--- a/ci/scripts/integration_arrow_build.sh
+++ b/ci/scripts/integration_arrow_build.sh
@@ -22,34 +22,34 @@ set -e
 arrow_dir=${1}
 build_dir=${2}
 
-: ${ARROW_INTEGRATION_CPP:=ON}
-: ${ARROW_INTEGRATION_CSHARP:=ON}
+: "${ARROW_INTEGRATION_CPP:=ON}"
+: "${ARROW_INTEGRATION_CSHARP:=ON}"
 
-. ${arrow_dir}/ci/scripts/util_log.sh
+. "${arrow_dir}/ci/scripts/util_log.sh"
 
 github_actions_group_begin "Integration: Build: Rust"
-${arrow_dir}/ci/scripts/rust_build.sh ${arrow_dir} ${build_dir}
+"${arrow_dir}/ci/scripts/rust_build.sh" "${arrow_dir}" "${build_dir}"
 github_actions_group_end
 
 github_actions_group_begin "Integration: Build: nanoarrow"
-${arrow_dir}/ci/scripts/nanoarrow_build.sh ${arrow_dir} ${build_dir}
+"${arrow_dir}/ci/scripts/nanoarrow_build.sh" "${arrow_dir}" "${build_dir}"
 github_actions_group_end
 
 github_actions_group_begin "Integration: Build: Go"
 if [ "${ARCHERY_INTEGRATION_WITH_GO}" -gt "0" ]; then
-    ${arrow_dir}/go/ci/scripts/build.sh ${arrow_dir}/go
+    "${arrow_dir}/go/ci/scripts/build.sh" "${arrow_dir}/go"
 fi
 github_actions_group_end
 
 github_actions_group_begin "Integration: Build: C++"
 if [ "${ARROW_INTEGRATION_CPP}" == "ON" ]; then
-    ${arrow_dir}/ci/scripts/cpp_build.sh ${arrow_dir} ${build_dir}
+    "${arrow_dir}/ci/scripts/cpp_build.sh" "${arrow_dir}" "${build_dir}"
 fi
 github_actions_group_end
 
 github_actions_group_begin "Integration: Build: C#"
 if [ "${ARROW_INTEGRATION_CSHARP}" == "ON" ]; then
-    ${arrow_dir}/ci/scripts/csharp_build.sh ${arrow_dir} ${build_dir}
+    "${arrow_dir}/ci/scripts/csharp_build.sh" "${arrow_dir}" "${build_dir}"
 fi
 github_actions_group_end
 
@@ -58,8 +58,8 @@ if [ "${ARCHERY_INTEGRATION_WITH_JAVA}" -gt "0" ]; then
     export ARROW_JAVA_CDATA="ON"
     export JAVA_JNI_CMAKE_ARGS="-DARROW_JAVA_JNI_ENABLE_DEFAULT=OFF -DARROW_JAVA_JNI_ENABLE_C=ON"
 
-    ${arrow_dir}/java/ci/scripts/jni_build.sh "${arrow_dir}/java" "${ARROW_HOME}" "${build_dir}/java/" /tmp/dist/java
-    ${arrow_dir}/java/ci/scripts/build.sh "${arrow_dir}/java" "${build_dir}/java" /tmp/dist/java
+    "${arrow_dir}/java/ci/scripts/jni_build.sh" "${arrow_dir}/java" "${ARROW_HOME}" "${build_dir}/java/" /tmp/dist/java
+    "${arrow_dir}/java/ci/scripts/build.sh" "${arrow_dir}/java" "${build_dir}/java" /tmp/dist/java
 fi
 github_actions_group_end
 

--- a/ci/scripts/python_wheel_unix_test.sh
+++ b/ci/scripts/python_wheel_unix_test.sh
@@ -96,13 +96,13 @@ if [ "${CHECK_VERSION}" == "ON" ]; then
 fi
 
 if [ "${CHECK_WHEEL_CONTENT}" == "ON" ]; then
-  python "${source_dir}"/ci/scripts/python_wheel_validate_contents.py \
-    --path "${source_dir}"/python/repaired_wheels
+  python "${source_dir}/ci/scripts/python_wheel_validate_contents.py" \
+    --path "${source_dir}/python/repaired_wheels"
 fi
 
 if [ "${CHECK_UNITTESTS}" == "ON" ]; then
   # Install testing dependencies
-  python -m pip install -U -r "${source_dir}"/python/requirements-wheel-test.txt
+  python -m pip install -U -r "${source_dir}/python/requirements-wheel-test.txt"
 
   # Execute unittest, test dependencies must be installed
   python -c 'import pyarrow; pyarrow.create_library_symlinks()'

--- a/ci/scripts/python_wheel_unix_test.sh
+++ b/ci/scripts/python_wheel_unix_test.sh
@@ -28,15 +28,15 @@ fi
 
 source_dir=${1}
 
-: ${ARROW_AZURE:=ON}
-: ${ARROW_FLIGHT:=ON}
-: ${ARROW_GCS:=ON}
-: ${ARROW_S3:=ON}
-: ${ARROW_SUBSTRAIT:=ON}
-: ${CHECK_IMPORTS:=ON}
-: ${CHECK_WHEEL_CONTENT:=ON}
-: ${CHECK_UNITTESTS:=ON}
-: ${INSTALL_PYARROW:=ON}
+: "${ARROW_AZURE:=ON}"
+: "${ARROW_FLIGHT:=ON}"
+: "${ARROW_GCS:=ON}"
+: "${ARROW_S3:=ON}"
+: "${ARROW_SUBSTRAIT:=ON}"
+: "${CHECK_IMPORTS:=ON}"
+: "${CHECK_WHEEL_CONTENT:=ON}"
+: "${CHECK_UNITTESTS:=ON}"
+: "${INSTALL_PYARROW:=ON}"
 
 export PYARROW_TEST_ACERO=ON
 export PYARROW_TEST_AZURE=${ARROW_AZURE}
@@ -59,7 +59,7 @@ export PARQUET_TEST_DATA=${source_dir}/cpp/submodules/parquet-testing/data
 
 if [ "${INSTALL_PYARROW}" == "ON" ]; then
   # Install the built wheels
-  python -m pip install ${source_dir}/python/repaired_wheels/*.whl
+  python -m pip install "${source_dir}"/python/repaired_wheels/*.whl
 fi
 
 if [ "${CHECK_IMPORTS}" == "ON" ]; then
@@ -96,13 +96,13 @@ if [ "${CHECK_VERSION}" == "ON" ]; then
 fi
 
 if [ "${CHECK_WHEEL_CONTENT}" == "ON" ]; then
-  python ${source_dir}/ci/scripts/python_wheel_validate_contents.py \
-    --path ${source_dir}/python/repaired_wheels
+  python "${source_dir}"/ci/scripts/python_wheel_validate_contents.py \
+    --path "${source_dir}"/python/repaired_wheels
 fi
 
 if [ "${CHECK_UNITTESTS}" == "ON" ]; then
   # Install testing dependencies
-  python -m pip install -U -r ${source_dir}/python/requirements-wheel-test.txt
+  python -m pip install -U -r "${source_dir}"/python/requirements-wheel-test.txt
 
   # Execute unittest, test dependencies must be installed
   python -c 'import pyarrow; pyarrow.create_library_symlinks()'

--- a/ci/scripts/r_build.sh
+++ b/ci/scripts/r_build.sh
@@ -18,19 +18,19 @@
 
 set -ex
 
-: ${R_BIN:=R}
+: "${R_BIN:=R}"
 source_dir=${1}/r
 build_dir=${2}
 
-: ${BUILD_DOCS_R:=OFF}
+: "${BUILD_DOCS_R:=OFF}"
 
 # https://github.com/apache/arrow/issues/41429
 # TODO: We want to out-of-source build. This is a workaround. We copy
 # all needed files to the build directory from the source directory
 # and build in the build directory.
-rm -rf ${build_dir}/r
-cp -aL ${source_dir} ${build_dir}/r
-pushd ${build_dir}/r
+rm -rf "${build_dir}/r"
+cp -aL "${source_dir}" "${build_dir}/r"
+pushd "${build_dir}/r"
 
 # build first so that any stray compiled files in r/src are ignored
 ${R_BIN} CMD build .
@@ -41,12 +41,12 @@ else
 fi
 ${SUDO} \
   env \
-    PKG_CONFIG_PATH=${ARROW_HOME}/lib/pkgconfig:${PKG_CONFIG_PATH} \
-      ${R_BIN} CMD INSTALL ${INSTALL_ARGS} arrow*.tar.gz
+    PKG_CONFIG_PATH="${ARROW_HOME}/lib/pkgconfig:${PKG_CONFIG_PATH}" \
+      "${R_BIN}" CMD INSTALL "${INSTALL_ARGS}" arrow*.tar.gz
 
 if [ "${BUILD_DOCS_R}" == "ON" ]; then
   ${R_BIN} -e "pkgdown::build_site(install = FALSE)"
-  rsync -a docs/ ${build_dir}/docs/r
+  rsync -a docs/ "${build_dir}/docs/r"
 fi
 
 popd

--- a/ci/scripts/r_revdepcheck.sh
+++ b/ci/scripts/r_revdepcheck.sh
@@ -18,13 +18,13 @@
 
 set -ex
 
-: ${R_BIN:=R}
+: "${R_BIN:=R}"
 # When revdep runs with > 1 worker the checks for {targets} time out for 
 # some reason. 
-: ${ARROW_REVDEP_WORKERS:=1}
+: "${ARROW_REVDEP_WORKERS:=1}"
 # But we do want to use all cores while building arrow to speed up the 
 # installation so this is used to set MAKEFLAGS
-: ${N_JOBS:=$(nproc)}
+: "${N_JOBS:=$(nproc)}"
 source_dir=${1}/r
 
 # cpp building dependencies
@@ -78,7 +78,7 @@ apt install -y libxml2-dev \
 
 
 # We have to be in source_dir so that cpp source detection works
-pushd $source_dir
+pushd "$source_dir"
 
 printenv
 


### PR DESCRIPTION
### Rationale for this change

We are trying to implement shellcheck on all sh files in #44748.

### What changes are included in this PR?

SC2086 and SC2223 checks require quoting like `${arrow_dir}` -> `"${arrow_dir}"`.

```
In ci/scripts/integration_arrow_build.sh line 25:
: ${ARROW_INTEGRATION_CPP:=ON}
  ^--------------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/integration_arrow_build.sh line 29:
. ${arrow_dir}/ci/scripts/util_log.sh
  ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

```

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.

* GitHub Issue: #46526