### PR TITLE
GH-46513: [Archery] Add external library support in Archery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,4 +107,3 @@ java/.mvn/.develocity/
 # rat
 filtered_rat.txt
 rat.txt
-build

--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,4 @@ java/.mvn/.develocity/
 # rat
 filtered_rat.txt
 rat.txt
+build

--- a/cpp/src/arrow/integration/json_integration_test.cc
+++ b/cpp/src/arrow/integration/json_integration_test.cc
@@ -1184,10 +1184,15 @@ int main(int argc, char** argv) {
   int ret = 0;
 
   if (FLAGS_integration) {
-    arrow::Status result =
-        arrow::internal::integration::RunCommand(FLAGS_json, FLAGS_arrow, FLAGS_mode);
-    if (!result.ok()) {
-      std::cout << "Error message: " << result.ToString() << std::endl;
+    try {
+      const arrow::Status result =
+          arrow::internal::integration::RunCommand(FLAGS_json, FLAGS_arrow, FLAGS_mode);
+      if (!result.ok()) {
+        std::cerr << "Error message: " << result.ToString() << std::endl;
+        ret = 1;
+      }
+    } catch (const std::exception& e) {
+      std::cout << "Exception raised: " << e.what() << std::endl;
       ret = 1;
     }
   } else {
@@ -1195,5 +1200,6 @@ int main(int argc, char** argv) {
     ret = RUN_ALL_TESTS();
   }
   gflags::ShutDownCommandLineFlags();
+
   return ret;
 }

--- a/dev/archery/README.md
+++ b/dev/archery/README.md
@@ -49,3 +49,89 @@ Additionally, if you would prefer to install everything at once,
 the above subpackages.
 
 For some prior art on benchmarking in Arrow, see [this prototype](https://github.com/apache/arrow/tree/0409498819332fc479f8df38babe3426d707fb9e/dev/benchmarking).
+
+# Usage
+## Integration tests
+
+Archery provides comprehensive integration testing capabilities for Apache Arrow implementations across different languages and formats. The integration tests verify compatibility between Arrow implementations by testing IPC (Inter-Process Communication), Flight, and C Data Interface protocols.
+
+### Basic Usage
+
+Run all integration tests with default settings:
+```bash
+archery integration
+```
+
+Run only specific test types:
+```bash
+# Run only IPC tests
+archery integration --run-ipc
+
+# Run only Flight tests  
+archery integration --run-flight
+
+# Run only C Data Interface tests
+archery integration --run-c-data
+
+# Run multiple test types
+archery integration --run-ipc --run-flight
+```
+
+### Language Implementation Selection
+
+Control which Arrow implementations are tested:
+
+```bash
+# Test only C++ and Java implementations
+archery integration --with-cpp --with-java
+```
+
+### Test Filtering and Control
+
+Filter tests by name pattern:
+```bash
+# Only run tests containing "primitive" in their name
+archery integration --match primitive
+
+# Run tests serially instead of in parallel
+archery integration --serial
+
+# Stop on first error
+archery integration --stop-on-error
+```
+
+### Test Data and Scenarios
+
+The integration tests use various data scenarios:
+
+#### Generated Test Cases
+- **Primitive types**: Basic Arrow types (int8, int32, float64, bool, etc.)
+- **Nested types**: Lists, structs, maps, unions
+- **Dictionary encoding**: Dictionary-encoded arrays
+- **Decimal types**: High-precision decimal values (128-bit, 256-bit)
+- **Date/Time types**: Timestamps, dates, times, intervals
+- **Binary data**: Fixed-size binary, variable binary, string views
+- **Extension types**: Custom extension type implementations
+
+### Common Test Scenarios
+
+#### Testing External Implementation
+```bash
+# Test new implementation against established ones
+archery integration \
+    --with-external-library /path/to/external/impl/ \
+    --external-library-ipc-consumer \
+    --external-library-c-data-schema-importer \
+    --external-library-c-data-array-importer \
+    --external-library-c-data-array-exporter \
+    --external-library-c-data-schema-exporter \
+    --external-library-supports-releasing-memory \
+    --run-c-data \
+    --run-ipc \
+    --run-cpp
+```
+In this case, the external library path must contain the necessary shared libraries (e.g., `.so` or `.dll` files) for the C Data Interface tests. The name of the shared library should match the expected naming conventions for the Arrow C Data Interface: 'c_data_integration.[dll/so]'
+And for executables:
+- 'arrow-json-integration-test'
+- 'arrow-stream-to-file'
+- 'arrow-file-to-stream'

--- a/dev/archery/archery/cli.py
+++ b/dev/archery/archery/cli.py
@@ -16,7 +16,6 @@
 # under the License.
 
 from io import StringIO
-from typing import Optional
 import click
 import json
 import logging

--- a/dev/archery/archery/cli.py
+++ b/dev/archery/archery/cli.py
@@ -16,6 +16,7 @@
 # under the License.
 
 from io import StringIO
+from typing import Optional
 import click
 import json
 import logging
@@ -686,6 +687,27 @@ def _set_default(opt, default):
 @click.option('--with-rust', type=bool, default=False,
               help='Include Rust in integration tests',
               envvar="ARCHERY_INTEGRATION_WITH_RUST")
+@click.option('--with-external-library', type=click.Path(exists=True, file_okay=False, dir_okay=True, executable=False),
+              help='Include external library in integration tests',
+              envvar="ARCHERY_INTEGRATION_WITH_EXTERNAL_LIBRARY")
+@click.option('--external-library-IPC-producer', type=bool, default=False,
+              help='Set external library as supporting producing IPC in integration tests',
+              envvar="ARCHERY_INTEGRATION_EXTERNAL_LIBRARY_IPC_PRODUCER")
+@click.option('--external-library-IPC-consumer', type=bool, default=False,
+              help='Set external library as supporting consuming IPC in integration tests',
+              envvar="ARCHERY_INTEGRATION_EXTERNAL_LIBRARY_IPC_CONSUMER")
+@click.option('--external-library-c-data-schema-exporter', type=bool, default=False,
+                help='Set external library as supporting exporting C Data schema in integration tests',
+                envvar="ARCHERY_INTEGRATION_EXTERNAL_LIBRARY_C_DATA_SCHEMA_EXPORTER")
+@click.option('--external-library-c-data-schema-importer', type=bool, default=False,
+                help='Set external library as supporting importing C Data schema in integration tests',
+                envvar="ARCHERY_INTEGRATION_EXTERNAL_LIBRARY_C_DATA_SCHEMA_IMPORTER")
+@click.option('--external-library-c-data-array-exporter', type=bool, default=False,
+                help='Set external library as supporting exporting C Data array in integration tests',
+                envvar="ARCHERY_INTEGRATION_EXTERNAL_LIBRARY_C_DATA_ARRAY_EXPORTER")
+@click.option('--external-library-c-data-array-importer', type=bool, default=False,
+                help='Set external library as supporting importing C Data array in integration tests',
+                envvar="ARCHERY_INTEGRATION_EXTERNAL_LIBRARY_C_DATA_ARRAY_IMPORTER")
 @click.option('--target-implementations', default='',
               help=('Target implementations in this integration tests'),
               envvar="ARCHERY_INTEGRATION_TARGET_IMPLEMENTATIONS")
@@ -803,7 +825,7 @@ def integration(with_all=False, random_seed=12345, write_generated_json="",
                 "Need exactly one implementation to generate gold files; try --help")
         generate_gold_files(testers[0], write_gold_files)
     else:
-        if enabled_formats == 0:
+        if enabled_formats == False:
             raise click.UsageError(
                 "Need to enable at least one format to test "
                 "(IPC, Flight, C Data Interface); try --help")

--- a/dev/archery/archery/cli.py
+++ b/dev/archery/archery/cli.py
@@ -708,6 +708,9 @@ def _set_default(opt, default):
 @click.option('--external-library-c-data-array-importer', type=bool, default=False,
                 help='Set external library as supporting importing C Data array in integration tests',
                 envvar="ARCHERY_INTEGRATION_EXTERNAL_LIBRARY_C_DATA_ARRAY_IMPORTER")
+@click.option('--external-library-supports-releasing-memory', type=bool, default=False,
+              help='Set external library as supporting releasing memory in integration tests',
+              envvar="ARCHERY_INTEGRATION_EXTERNAL_LIBRARY_SUPPORTS_RELEASING_MEMORY")
 @click.option('--target-implementations', default='',
               help=('Target implementations in this integration tests'),
               envvar="ARCHERY_INTEGRATION_TARGET_IMPLEMENTATIONS")

--- a/dev/archery/archery/cli.py
+++ b/dev/archery/archery/cli.py
@@ -710,25 +710,25 @@ def validate_conditional_options(ctx, param: click.Option, value):
 @click.option('--with-external-library', type=click.Path(exists=True, file_okay=False, dir_okay=True, executable=False),
               help='Path to the external library to include in integration tests',
               envvar="ARCHERY_INTEGRATION_WITH_EXTERNAL_LIBRARY")
-@click.option('--external-library-ipc-producer', type=bool, default=False, callback=validate_conditional_options,
+@click.option('--external-library-ipc-producer', is_flag=True, default=False, callback=validate_conditional_options,
               help='Set external library as supporting producing IPC in integration tests. "arrow-json-integration-test", "arrow-stream-to-file" and "arrow-file-to-stream" executables must be present in the external library folder.',
               envvar="ARCHERY_INTEGRATION_EXTERNAL_LIBRARY_IPC_PRODUCER")
-@click.option('--external-library-ipc-consumer', type=bool, default=False, callback=validate_conditional_options,
+@click.option('--external-library-ipc-consumer', is_flag=True, default=False, callback=validate_conditional_options,
               help='Set external library as supporting consuming IPC in integration tests. "arrow-json-integration-test", "arrow-stream-to-file" and "arrow-file-to-stream" executables must be present in the external library folder.',
               envvar="ARCHERY_INTEGRATION_EXTERNAL_LIBRARY_IPC_CONSUMER")
-@click.option('--external-library-c-data-schema-exporter', type=bool, default=False, callback=validate_conditional_options,
+@click.option('--external-library-c-data-schema-exporter', is_flag=True, default=False, callback=validate_conditional_options,
                 help='Set external library as supporting exporting C Data schema in integration tests. "c_data_integration.[dll/so]" shared library must be present in the external library folder.',
                 envvar="ARCHERY_INTEGRATION_EXTERNAL_LIBRARY_C_DATA_SCHEMA_EXPORTER")
-@click.option('--external-library-c-data-schema-importer', type=bool, default=False, callback=validate_conditional_options,
+@click.option('--external-library-c-data-schema-importer', is_flag=True, default=False, callback=validate_conditional_options,
                 help='Set external library as supporting importing C Data schema in integration tests. "c_data_integration.[dll/so]" shared library must be present in the external library folder.',
                 envvar="ARCHERY_INTEGRATION_EXTERNAL_LIBRARY_C_DATA_SCHEMA_IMPORTER")
-@click.option('--external-library-c-data-array-exporter', type=bool, default=False, callback=validate_conditional_options,
+@click.option('--external-library-c-data-array-exporter', is_flag=True, default=False, callback=validate_conditional_options,
                 help='Set external library as supporting exporting C Data array in integration tests. "c_data_integration.[dll/so]" shared library must be present in the external library folder.',
                 envvar="ARCHERY_INTEGRATION_EXTERNAL_LIBRARY_C_DATA_ARRAY_EXPORTER")
-@click.option('--external-library-c-data-array-importer', type=bool, default=False, callback=validate_conditional_options,
+@click.option('--external-library-c-data-array-importer', is_flag=True, default=False, callback=validate_conditional_options,
                 help='Set external library as supporting importing C Data array in integration tests. "c_data_integration.[dll/so]" shared library must be present in the external library folder.',
                 envvar="ARCHERY_INTEGRATION_EXTERNAL_LIBRARY_C_DATA_ARRAY_IMPORTER")
-@click.option('--external-library-supports-releasing-memory', type=bool, default=False, callback=validate_conditional_options,
+@click.option('--external-library-supports-releasing-memory', is_flag=True, default=False, callback=validate_conditional_options,
               help='Set external library as supporting releasing memory in integration tests',
               envvar="ARCHERY_INTEGRATION_EXTERNAL_LIBRARY_SUPPORTS_RELEASING_MEMORY")
 @click.option('--target-implementations', default='',

--- a/dev/archery/archery/integration/runner.py
+++ b/dev/archery/archery/integration/runner.py
@@ -23,6 +23,7 @@ import glob
 import gzip
 import itertools
 import os
+from pathlib import Path
 import sys
 import tempfile
 import traceback
@@ -591,8 +592,8 @@ def get_static_json_files():
 
 def select_testers(with_cpp=True, with_java=True, with_js=True,
                    with_dotnet=True, with_go=True, with_rust=False,
-                   with_nanoarrow=False, target_implementations="",
-                   **kwargs):
+                   with_nanoarrow=False, with_external_library=None,
+                   target_implementations="",**kwargs):
     target_implementations = (target_implementations.split(",")
                               if target_implementations else [])
 
@@ -632,6 +633,19 @@ def select_testers(with_cpp=True, with_java=True, with_js=True,
     if with_rust:
         from .tester_rust import RustTester
         append_tester("rust", RustTester(**kwargs))
+
+    if with_external_library:
+        from .tester_external_library import ExternalLibraryTester
+
+        append_tester("external_library", ExternalLibraryTester(
+            path=Path(with_external_library),
+            is_producer_compatible=kwargs.get("external_library_ipc_produder", False),
+            is_consumer_compatible=kwargs.get("external_library_ipc_consumer", False),
+            is_c_data_schema_exporter_compatible=kwargs.get("external_library_c_data_schema_exporter", False),
+            is_c_data_array_exporter_compatible=kwargs.get("external_library_c_data_array_exporter", False),
+            is_c_data_schema_importer_compatible=kwargs.get("external_library_c_data_schema_importer", False),
+            is_c_data_array_importer_compatible=kwargs.get("external_library_c_data_array_importer", False),
+            **kwargs))
 
     return testers, other_testers
 

--- a/dev/archery/archery/integration/runner.py
+++ b/dev/archery/archery/integration/runner.py
@@ -645,6 +645,7 @@ def select_testers(with_cpp=True, with_java=True, with_js=True,
             is_c_data_array_exporter_compatible=kwargs.get("external_library_c_data_array_exporter", False),
             is_c_data_schema_importer_compatible=kwargs.get("external_library_c_data_schema_importer", False),
             is_c_data_array_importer_compatible=kwargs.get("external_library_c_data_array_importer", False),
+            supports_releasing_memory=kwargs.get("external_library_supports_releasing_memory", False),
             **kwargs))
 
     return testers, other_testers

--- a/dev/archery/archery/integration/runner.py
+++ b/dev/archery/archery/integration/runner.py
@@ -639,7 +639,7 @@ def select_testers(with_cpp=True, with_java=True, with_js=True,
 
         append_tester("external_library", ExternalLibraryTester(
             path=Path(with_external_library),
-            is_producer_compatible=kwargs.get("external_library_ipc_produder", False),
+            is_producer_compatible=kwargs.get("external_library_ipc_producer", False),
             is_consumer_compatible=kwargs.get("external_library_ipc_consumer", False),
             is_c_data_schema_exporter_compatible=kwargs.get("external_library_c_data_schema_exporter", False),
             is_c_data_array_exporter_compatible=kwargs.get("external_library_c_data_array_exporter", False),

--- a/dev/archery/archery/integration/tester_external_library.py
+++ b/dev/archery/archery/integration/tester_external_library.py
@@ -66,14 +66,14 @@ class ExternalLibraryTester(Tester):
     Executable and library must strictly follow the expected naming conventions
     """
 
-    PRODUCER = True
-    CONSUMER = True
+    PRODUCER = False
+    CONSUMER = False
     FLIGHT_SERVER = False
     FLIGHT_CLIENT = False
-    C_DATA_SCHEMA_EXPORTER = True
-    C_DATA_ARRAY_EXPORTER = True
-    C_DATA_SCHEMA_IMPORTER = True
-    C_DATA_ARRAY_IMPORTER = True
+    C_DATA_SCHEMA_EXPORTER = False
+    C_DATA_ARRAY_EXPORTER = False
+    C_DATA_SCHEMA_IMPORTER = False
+    C_DATA_ARRAY_IMPORTER = False
 
     _EXE_PATH: Path
     _INTEGRATION_EXE: Path

--- a/dev/archery/archery/integration/tester_external_library.py
+++ b/dev/archery/archery/integration/tester_external_library.py
@@ -16,14 +16,56 @@
 # under the License.
 
 from pathlib import Path
+from typing import Final
 from . import cdata
 from .tester import Tester, CDataExporter, CDataImporter
 from .util import run_cmd, log
-from typing import Final
 import functools
+
+_EXTERNAL_LIBRARY_C_DATA_EXPORT_SCHEMA_FROM_JSON_ENTRYPOINT = " const char* external_CDataIntegration_ExportSchemaFromJson(const char* json_path, struct ArrowSchema* out);"
+_EXTERNAL_LIBRARY_C_DATA_IMPORT_SCHEMA_AND_COMPARE_TO_JSON_ENTRYPOINT = "const char* external_CDataIntegration_ImportSchemaAndCompareToJson(const char* json_path, struct ArrowSchema* schema);"
+
+_EXTERNAL_LIBRARY_C_DATA_EXPORT_BATCH_FROM_JSON_ENTRYPOINT = "const char* external_CDataIntegration_ExportBatchFromJson(const char* json_path, int num_batch, struct ArrowArray* out);"
+_EXTERNAL_LIBRARY_C_DATA_IMPORT_BATCH_AND_COMPARE_TO_JSON_ENTRYPOINT = "const char* external_CDataIntegration_ImportBatchAndCompareToJson(const char* json_path, int num_batch, struct ArrowArray* batch);"
+
+_EXTERNAL_BYTES_ALLOCATED_ENTRYPOINT = "int64_t external_BytesAllocated(void);"
 
 
 class ExternalLibraryTester(Tester):
+    """
+    A tester for external Arrow libraries that implements integration testing capabilities.
+    This class provides a framework for testing external Arrow libraries by running
+    integration tests through external executables. It supports various Arrow features
+    including producers, consumers, C Data interface exporters/importers, and stream/file
+    operations.
+    Attributes:
+        PRODUCER (bool): Whether the library supports producing Arrow data.
+        CONSUMER (bool): Whether the library supports consuming Arrow data.
+        FLIGHT_SERVER (bool): Whether the library supports Flight server functionality.
+        FLIGHT_CLIENT (bool): Whether the library supports Flight client functionality.
+        C_DATA_SCHEMA_EXPORTER (bool): Whether the library supports C Data schema export.
+        C_DATA_ARRAY_EXPORTER (bool): Whether the library supports C Data array export.
+        C_DATA_SCHEMA_IMPORTER (bool): Whether the library supports C Data schema import.
+        C_DATA_ARRAY_IMPORTER (bool): Whether the library supports C Data array import.
+        name (str): The name identifier for this tester type.
+    Args:
+        path (Path): Path to the directory containing the external library and executables.
+        is_producer_compatible (bool): Whether the library can produce Arrow data.
+        is_consumer_compatible (bool): Whether the library can consume Arrow data.
+        is_c_data_schema_exporter_compatible (bool): C Data schema export compatibility.
+        is_c_data_array_exporter_compatible (bool): C Data array export compatibility.
+        is_c_data_schema_importer_compatible (bool): C Data schema import compatibility.
+        is_c_data_array_importer_compatible (bool): C Data array import compatibility.
+        supports_releasing_memory (bool): Whether the library supports memory release operations.
+        **args: Additional arguments passed to the parent Tester class.
+    The class manages external executables for:
+    - 'arrow-json-integration-test': Main integration testing executable
+    - 'arrow-stream-to-file': Converts Arrow streams to file format
+    - 'arrow-file-to-stream': Converts Arrow files to stream format
+    - 'c_data_integration.[dll/so]' library: C Data interface operations
+    Executable and library must strictly follow the expected naming conventions
+    """
+
     PRODUCER = True
     CONSUMER = True
     FLIGHT_SERVER = False
@@ -40,6 +82,8 @@ class ExternalLibraryTester(Tester):
     _INTEGRATION_DLL: Path
 
     _supports_releasing_memory: bool = True
+
+    _entrypoints: str
 
     name = "external_library"
 
@@ -69,6 +113,12 @@ class ExternalLibraryTester(Tester):
         self._FILE_TO_STREAM = path / "arrow-file-to-stream"
         self._INTEGRATION_DLL = self._EXE_PATH / (
             "c_data_integration" + cdata.dll_suffix
+        )
+        self._entrypoints = get_entrypoints(
+            is_c_data_schema_exporter_compatible,
+            is_c_data_array_exporter_compatible,
+            is_c_data_schema_importer_compatible,
+            is_c_data_array_importer_compatible,
         )
 
     def _run(self, arrow_path: str, json_path: str, command: str, quirks):
@@ -102,6 +152,7 @@ class ExternalLibraryTester(Tester):
         return ExternalLibraryCDataExporter(
             self.debug,
             self._INTEGRATION_DLL,
+            self._entrypoints,
             self._supports_releasing_memory,
             self.args,
         )
@@ -110,42 +161,68 @@ class ExternalLibraryTester(Tester):
         return ExternalLibraryCDataImporter(
             self.debug,
             self._INTEGRATION_DLL,
+            self._entrypoints,
             self._supports_releasing_memory,
             self.args,
         )
 
 
-_EXTERNAL_LIBRARY_C_DATA_ENTRYPOINTS = """
-    const char* external_CDataIntegration_ExportSchemaFromJson(
-        const char* json_path, struct ArrowSchema* out);
-
-    const char* external_CDataIntegration_ImportSchemaAndCompareToJson(
-        const char* json_path, struct ArrowSchema* schema);
-
-    const char* external_CDataIntegration_ExportBatchFromJson(
-        const char* json_path, int num_batch, struct ArrowArray* out);
-
-    const char* external_CDataIntegration_ImportBatchAndCompareToJson(
-        const char* json_path, int num_batch, struct ArrowArray* batch);
-
-    int64_t external_BytesAllocated(void);
+def get_entrypoints(
+    is_c_data_schema_exporter_compatible: bool,
+    is_c_data_array_exporter_compatible: bool,
+    is_c_data_schema_importer_compatible: bool,
+    is_c_data_array_importer_compatible: bool,
+) -> str:
     """
+    Get the entrypoints for the C Data integration library based on compatibility flags.
+    """
+    entrypoint_conditions = [
+        (
+            is_c_data_schema_exporter_compatible,
+            _EXTERNAL_LIBRARY_C_DATA_EXPORT_SCHEMA_FROM_JSON_ENTRYPOINT,
+        ),
+        (
+            is_c_data_array_exporter_compatible,
+            _EXTERNAL_LIBRARY_C_DATA_EXPORT_BATCH_FROM_JSON_ENTRYPOINT,
+        ),
+        (
+            is_c_data_schema_importer_compatible,
+            _EXTERNAL_LIBRARY_C_DATA_IMPORT_SCHEMA_AND_COMPARE_TO_JSON_ENTRYPOINT,
+        ),
+        (
+            is_c_data_array_importer_compatible,
+            _EXTERNAL_LIBRARY_C_DATA_IMPORT_BATCH_AND_COMPARE_TO_JSON_ENTRYPOINT,
+        ),
+    ]
+    return (
+        "\n".join(
+            entrypoint for condition, entrypoint in entrypoint_conditions if condition
+        )
+        + "\n"
+        + _EXTERNAL_BYTES_ALLOCATED_ENTRYPOINT
+    )
 
 
 @functools.lru_cache
-def _load_ffi(ffi, lib_path: Path):
-    ffi.cdef(_EXTERNAL_LIBRARY_C_DATA_ENTRYPOINTS)
+def _load_ffi(ffi, lib_path: Path, entrypoints: str):
+    ffi.cdef(entrypoints)
     dll = ffi.dlopen(str(lib_path))
     return dll
 
 
 class _CDataBase:
 
-    def __init__(self, debug: bool, integration_dll_path: Path, args):
+    def __init__(
+        self,
+        debug: bool,
+        integration_dll_path: Path,
+        entrypoints: str,
+        args,
+    ):
         self.debug = debug
         self.args = args
         self.ffi = cdata.ffi()
-        self.dll = _load_ffi(self.ffi, integration_dll_path)
+        self.dll = _load_ffi(self.ffi, integration_dll_path, entrypoints)
 
     def _check_external_library_error(self, na_error):
         """
@@ -170,11 +247,15 @@ class ExternalLibraryCDataExporter(CDataExporter, _CDataBase):
         self,
         debug: bool,
         integration_dll_path: Path,
+        entrypoints: str,
         supports_releasing_memory: bool,
         args,
     ):
         super().__init__(
-            debug=debug, integration_dll_path=integration_dll_path, args=args
+            debug=debug,
+            integration_dll_path=integration_dll_path,
+            entrypoints=entrypoints,
+            args=args,
         )
         self._supports_releasing_memory = supports_releasing_memory
 
@@ -205,11 +286,15 @@ class ExternalLibraryCDataImporter(CDataImporter, _CDataBase):
         self,
         debug: bool,
         integration_dll_path: Path,
+        entrypoints: str,
         supports_releasing_memory: bool,
         args,
     ):
         super().__init__(
-            debug=debug, integration_dll_path=integration_dll_path, args=args
+            debug=debug,
+            integration_dll_path=integration_dll_path,
+            entrypoints=entrypoints,
+            args=args,
         )
         self._supports_releasing_memory = supports_releasing_memory
 

--- a/dev/archery/archery/integration/tester_external_library.py
+++ b/dev/archery/archery/integration/tester_external_library.py
@@ -56,13 +56,13 @@ class ExternalLibraryTester(Tester):
         **args,
     ):
         super().__init__(**args)
-        self.is_producer_compatible = is_producer_compatible
-        self.is_consumer_compatible = is_consumer_compatible
-        self.is_c_data_schema_exporter_compatible = is_c_data_schema_exporter_compatible
-        self.is_c_data_array_exporter_compatible = is_c_data_array_exporter_compatible
-        self.is_c_data_schema_importer_compatible = is_c_data_schema_importer_compatible
-        self.is_c_data_array_importer_compatible = is_c_data_array_importer_compatible
-        self.supports_releasing_memory = supports_releasing_memory
+        self.PRODUCER = is_producer_compatible
+        self.CONSUMER = is_consumer_compatible
+        self.C_DATA_SCHEMA_EXPORTER = is_c_data_schema_exporter_compatible
+        self.C_DATA_ARRAY_EXPORTER = is_c_data_array_exporter_compatible
+        self.C_DATA_SCHEMA_IMPORTER = is_c_data_schema_importer_compatible
+        self.C_DATA_ARRAY_IMPORTER = is_c_data_array_importer_compatible
+        self._supports_releasing_memory = supports_releasing_memory
         self._EXE_PATH = path
         self._INTEGRATION_EXE = path / "arrow-json-integration-test"
         self._STREAM_TO_FILE = path / "arrow-stream-to-file"
@@ -100,12 +100,18 @@ class ExternalLibraryTester(Tester):
 
     def make_c_data_exporter(self):
         return ExternalLibraryCDataExporter(
-            self.debug, self._INTEGRATION_DLL, self.supports_releasing_memory, self.args
+            self.debug,
+            self._INTEGRATION_DLL,
+            self._supports_releasing_memory,
+            self.args,
         )
 
     def make_c_data_importer(self):
         return ExternalLibraryCDataImporter(
-            self.debug, self._INTEGRATION_DLL, self.supports_releasing_memory, self.args
+            self.debug,
+            self._INTEGRATION_DLL,
+            self._supports_releasing_memory,
+            self.args,
         )
 
 

--- a/dev/archery/archery/integration/tester_external_library.py
+++ b/dev/archery/archery/integration/tester_external_library.py
@@ -16,7 +16,6 @@
 # under the License.
 
 from pathlib import Path
-from typing import Final
 from . import cdata
 from .tester import Tester, CDataExporter, CDataImporter
 from .util import run_cmd, log

--- a/dev/archery/archery/integration/tester_external_library.py
+++ b/dev/archery/archery/integration/tester_external_library.py
@@ -107,9 +107,10 @@ class ExternalLibraryTester(Tester):
         self.C_DATA_ARRAY_IMPORTER = is_c_data_array_importer_compatible
         self._supports_releasing_memory = supports_releasing_memory
         self._EXE_PATH = path
-        self._INTEGRATION_EXE = path / "arrow-json-integration-test"
         self._STREAM_TO_FILE = path / "arrow-stream-to-file"
         self._FILE_TO_STREAM = path / "arrow-file-to-stream"
+        self._VALIDATE_EXE = path / "arrow-validate-integration"
+        self._JSON_TO_FILE_EXE = path / "arrow-json-to-file"
         self._INTEGRATION_DLL = self._EXE_PATH / (
             "c_data_integration" + cdata.dll_suffix
         )
@@ -134,17 +135,19 @@ class ExternalLibraryTester(Tester):
         run_cmd([self._INTEGRATION_EXE], env=env)
 
     def validate(self, json_path: str, arrow_path: str, quirks=None):
-        return self._run(arrow_path, json_path, "VALIDATE", quirks)
+        cmd = [self._VALIDATE_EXE, json_path, arrow_path]
+        self.run_shell_command(cmd)
 
     def json_to_file(self, json_path: str, arrow_path: str):
-        return self._run(arrow_path, json_path, "JSON_TO_ARROW", quirks=None)
+        cmd = [self._JSON_TO_FILE_EXE, json_path ,arrow_path]
+        self.run_shell_command(cmd)
 
     def stream_to_file(self, stream_path, file_path):
-        cmd = [self._STREAM_TO_FILE, "<", stream_path, ">", file_path]
+        cmd = [self._STREAM_TO_FILE, stream_path, file_path]
         self.run_shell_command(cmd)
 
     def file_to_stream(self, file_path, stream_path):
-        cmd = [self._FILE_TO_STREAM, file_path, ">", stream_path]
+        cmd = [self._FILE_TO_STREAM, file_path, stream_path]
         self.run_shell_command(cmd)
 
     def make_c_data_exporter(self):

--- a/dev/archery/archery/integration/tester_external_library.py
+++ b/dev/archery/archery/integration/tester_external_library.py
@@ -107,10 +107,10 @@ class ExternalLibraryTester(Tester):
         self.C_DATA_ARRAY_IMPORTER = is_c_data_array_importer_compatible
         self._supports_releasing_memory = supports_releasing_memory
         self._EXE_PATH = path
-        self._STREAM_TO_FILE = path / "arrow-stream-to-file"
-        self._FILE_TO_STREAM = path / "arrow-file-to-stream"
-        self._VALIDATE_EXE = path / "arrow-validate"
-        self._JSON_TO_FILE_EXE = path / "arrow-json-to-file"
+        self._STREAM_TO_FILE = path / "arrow_stream_to_file"
+        self._FILE_TO_STREAM = path / "arrow_file_to_stream"
+        self._VALIDATE_EXE = path / "arrow_validate"
+        self._JSON_TO_FILE_EXE = path / "arrow_json_to_file"
         self._INTEGRATION_DLL = self._EXE_PATH / (
             "c_data_integration" + cdata.dll_suffix
         )

--- a/dev/archery/archery/integration/tester_external_library.py
+++ b/dev/archery/archery/integration/tester_external_library.py
@@ -109,7 +109,7 @@ class ExternalLibraryTester(Tester):
         self._EXE_PATH = path
         self._STREAM_TO_FILE = path / "arrow-stream-to-file"
         self._FILE_TO_STREAM = path / "arrow-file-to-stream"
-        self._VALIDATE_EXE = path / "arrow-validate-integration"
+        self._VALIDATE_EXE = path / "arrow-validate"
         self._JSON_TO_FILE_EXE = path / "arrow-json-to-file"
         self._INTEGRATION_DLL = self._EXE_PATH / (
             "c_data_integration" + cdata.dll_suffix

--- a/dev/archery/archery/integration/tester_external_library.py
+++ b/dev/archery/archery/integration/tester_external_library.py
@@ -135,19 +135,19 @@ class ExternalLibraryTester(Tester):
         run_cmd([self._INTEGRATION_EXE], env=env)
 
     def validate(self, json_path: str, arrow_path: str, quirks=None):
-        cmd = [self._VALIDATE_EXE, json_path, arrow_path]
+        cmd = [str(self._VALIDATE_EXE), json_path, arrow_path]
         self.run_shell_command(cmd)
 
     def json_to_file(self, json_path: str, arrow_path: str):
-        cmd = [self._JSON_TO_FILE_EXE, json_path ,arrow_path]
+        cmd = [str(self._JSON_TO_FILE_EXE), json_path ,arrow_path]
         self.run_shell_command(cmd)
 
     def stream_to_file(self, stream_path, file_path):
-        cmd = [self._STREAM_TO_FILE, stream_path, file_path]
+        cmd = [str(self._STREAM_TO_FILE), stream_path, file_path]
         self.run_shell_command(cmd)
 
     def file_to_stream(self, file_path, stream_path):
-        cmd = [self._FILE_TO_STREAM, file_path, stream_path]
+        cmd = [str(self._FILE_TO_STREAM), file_path, stream_path]
         self.run_shell_command(cmd)
 
     def make_c_data_exporter(self):


### PR DESCRIPTION
### Rationale for this change

Address #46513:
Add the possibility to use a library which is not part of the "official" implementations, in the integration tests

### What changes are included in this PR?
Add new options in the CLI to be able to define the path to a library to test, and it's compatibility with the tests (IPC producer/consumer, c data array/schema impoter/exporter).
Add tester_external_library.py
Modify runner.py to use ExternalLibraryTester

### Are these changes tested?
Yes localy and on the Sparrow CI:
https://github.com/man-group/sparrow/pull/426/checks#step:9:1
https://github.com/man-group/sparrow/pull/426/checks#step:9:7051

### Are there any user-facing changes?
Yes, new options in the CLI and environment variable supported.
there is no breaking change.

* GitHub Issue: #46513