### PR TITLE
GH-43041: [C++][Python] Read/write Parquet BYTE_ARRAY as Large/View types directly

### DIFF
--- a/cpp/src/arrow/compute/expression_test.cc
+++ b/cpp/src/arrow/compute/expression_test.cc
@@ -67,8 +67,6 @@ const std::shared_ptr<Schema> kBoringSchema = schema({
     field("ts_s_utc", timestamp(TimeUnit::SECOND, "UTC")),
 });
 
-#define EXPECT_OK ARROW_EXPECT_OK
-
 Expression cast(Expression argument, std::shared_ptr<DataType> to_type) {
   return call("cast", {std::move(argument)},
               compute::CastOptions::Safe(std::move(to_type)));

--- a/cpp/src/arrow/dataset/file_parquet.cc
+++ b/cpp/src/arrow/dataset/file_parquet.cc
@@ -116,6 +116,7 @@ parquet::ArrowReaderProperties MakeArrowReaderProperties(
   }
   properties.set_coerce_int96_timestamp_unit(
       format.reader_options.coerce_int96_timestamp_unit);
+  properties.set_binary_type(format.reader_options.binary_type);
   return properties;
 }
 
@@ -443,7 +444,8 @@ bool ParquetFileFormat::Equals(const FileFormat& other) const {
   // FIXME implement comparison for decryption options
   return (reader_options.dict_columns == other_reader_options.dict_columns &&
           reader_options.coerce_int96_timestamp_unit ==
-              other_reader_options.coerce_int96_timestamp_unit);
+              other_reader_options.coerce_int96_timestamp_unit &&
+          reader_options.binary_type == other_reader_options.binary_type);
 }
 
 ParquetFileFormat::ParquetFileFormat(const parquet::ReaderProperties& reader_properties)

--- a/cpp/src/arrow/dataset/file_parquet.h
+++ b/cpp/src/arrow/dataset/file_parquet.h
@@ -90,6 +90,7 @@ class ARROW_DS_EXPORT ParquetFileFormat : public FileFormat {
     /// @{
     std::unordered_set<std::string> dict_columns;
     arrow::TimeUnit::type coerce_int96_timestamp_unit = arrow::TimeUnit::NANO;
+    Type::type binary_type = Type::BINARY;
     /// @}
   } reader_options;
 
@@ -242,8 +243,7 @@ class ARROW_DS_EXPORT ParquetFragmentScanOptions : public FragmentScanOptions {
   /// ScanOptions.
   std::shared_ptr<parquet::ReaderProperties> reader_properties;
   /// Arrow reader properties. Not all properties are respected: batch_size comes from
-  /// ScanOptions. Additionally, dictionary columns come from
-  /// ParquetFileFormat::ReaderOptions::dict_columns.
+  /// ScanOptions. Additionally, other options come from ParquetFileFormat::ReaderOptions.
   std::shared_ptr<parquet::ArrowReaderProperties> arrow_reader_properties;
   /// A configuration structure that provides decryption properties for a dataset
   std::shared_ptr<ParquetDecryptionConfig> parquet_decryption_config = NULLPTR;

--- a/cpp/src/arrow/testing/gtest_util.h
+++ b/cpp/src/arrow/testing/gtest_util.h
@@ -98,6 +98,10 @@
                           << _st.ToString();                            \
   } while (false)
 
+#define EXPECT_OK ARROW_EXPECT_OK
+
+#define EXPECT_OK_NO_THROW(expr) EXPECT_NO_THROW(EXPECT_OK(expr))
+
 #define ASSERT_NOT_OK(expr)                                                         \
   for (::arrow::Status _st = ::arrow::internal::GenericToStatus((expr)); _st.ok();) \
   FAIL() << "'" ARROW_STRINGIFY(expr) "' did not failed" << _st.ToString()

--- a/cpp/src/arrow/type_traits.h
+++ b/cpp/src/arrow/type_traits.h
@@ -1237,6 +1237,22 @@ constexpr bool is_binary(Type::type type_id) {
   return false;
 }
 
+/// \brief Check for a binary or binary view (non-string) type
+///
+/// \param[in] type_id the type-id to check
+/// \return whether type-id is a binary type one
+constexpr bool is_binary_or_binary_view(Type::type type_id) {
+  switch (type_id) {
+    case Type::BINARY:
+    case Type::LARGE_BINARY:
+    case Type::BINARY_VIEW:
+      return true;
+    default:
+      break;
+  }
+  return false;
+}
+
 /// \brief Check for a string type
 ///
 /// \param[in] type_id the type-id to check
@@ -1245,6 +1261,22 @@ constexpr bool is_string(Type::type type_id) {
   switch (type_id) {
     case Type::STRING:
     case Type::LARGE_STRING:
+      return true;
+    default:
+      break;
+  }
+  return false;
+}
+
+/// \brief Check for a string or string view type
+///
+/// \param[in] type_id the type-id to check
+/// \return whether type-id is a string type one
+constexpr bool is_string_or_string_view(Type::type type_id) {
+  switch (type_id) {
+    case Type::STRING:
+    case Type::LARGE_STRING:
+    case Type::STRING_VIEW:
       return true;
     default:
       break;

--- a/cpp/src/parquet/CMakeLists.txt
+++ b/cpp/src/parquet/CMakeLists.txt
@@ -369,11 +369,12 @@ configure_file(parquet_version.h.in "${CMAKE_CURRENT_BINARY_DIR}/parquet_version
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/parquet_version.h"
         DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/parquet")
 
+set_source_files_properties(public_api_test.cc PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
+
 add_parquet_test(internals-test
                  SOURCES
                  bloom_filter_reader_test.cc
                  bloom_filter_test.cc
-                 encoding_test.cc
                  geospatial/statistics_test.cc
                  geospatial/util_internal_test.cc
                  metadata_test.cc
@@ -384,7 +385,7 @@ add_parquet_test(internals-test
                  statistics_test.cc
                  types_test.cc)
 
-set_source_files_properties(public_api_test.cc PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
+add_parquet_test(encoding-test SOURCES encoding_test.cc)
 
 add_parquet_test(reader-test
                  SOURCES

--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -47,6 +47,7 @@
 #include "arrow/testing/gtest_util.h"
 #include "arrow/testing/random.h"
 #include "arrow/testing/util.h"
+#include "arrow/type_fwd.h"
 #include "arrow/type_traits.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/config.h"  // for ARROW_CSV definition
@@ -71,6 +72,7 @@
 #include "parquet/column_writer.h"
 #include "parquet/file_writer.h"
 #include "parquet/page_index.h"
+#include "parquet/properties.h"
 #include "parquet/test_util.h"
 
 using arrow::Array;
@@ -88,6 +90,7 @@ using arrow::DictionaryArray;
 using arrow::ListArray;
 using arrow::PrimitiveArray;
 using arrow::ResizableBuffer;
+using arrow::Result;
 using arrow::Scalar;
 using arrow::Status;
 using arrow::Table;
@@ -621,15 +624,28 @@ class ParquetIOTestBase : public ::testing::Test {
     return ParquetFileWriter::Open(sink_, schema);
   }
 
+  Result<std::unique_ptr<FileReader>> ReaderFromBuffer(
+      const std::shared_ptr<Buffer>& buffer,
+      const ArrowReaderProperties& properties = default_arrow_reader_properties()) {
+    FileReaderBuilder builder;
+    std::unique_ptr<FileReader> out;
+    RETURN_NOT_OK(builder.Open(std::make_shared<BufferReader>(buffer)));
+    RETURN_NOT_OK(builder.memory_pool(::arrow::default_memory_pool())
+                      ->properties(properties)
+                      ->Build(&out));
+    return out;
+  }
+
+  Result<std::unique_ptr<FileReader>> ReaderFromSink(
+      const ArrowReaderProperties& properties = default_arrow_reader_properties()) {
+    ARROW_ASSIGN_OR_RAISE(auto buffer, sink_->Finish());
+    return ReaderFromBuffer(buffer, properties);
+  }
+
   void ReaderFromSink(
       std::unique_ptr<FileReader>* out,
       const ArrowReaderProperties& properties = default_arrow_reader_properties()) {
-    ASSERT_OK_AND_ASSIGN(auto buffer, sink_->Finish());
-    FileReaderBuilder builder;
-    ASSERT_OK_NO_THROW(builder.Open(std::make_shared<BufferReader>(buffer)));
-    ASSERT_OK_NO_THROW(builder.memory_pool(::arrow::default_memory_pool())
-                           ->properties(properties)
-                           ->Build(out));
+    ASSERT_OK_NO_THROW(ReaderFromSink(properties).Value(out));
   }
 
   void ReadSingleColumnFile(std::unique_ptr<FileReader> file_reader,
@@ -647,14 +663,18 @@ class ParquetIOTestBase : public ::testing::Test {
     ASSERT_OK((*out)->ValidateFull());
   }
 
-  void ReadAndCheckSingleColumnFile(const Array& values) {
+  void ReadAndCheckSingleColumnFile(std::unique_ptr<FileReader> file_reader,
+                                    const Array& values) {
     std::shared_ptr<Array> out;
-
-    std::unique_ptr<FileReader> reader;
-    ReaderFromSink(&reader);
-    ReadSingleColumnFile(std::move(reader), &out);
-
+    ReadSingleColumnFile(std::move(file_reader), &out);
     AssertArraysEqual(values, *out);
+  }
+
+  void ReadAndCheckSingleColumnFile(
+      const Array& values,
+      const ArrowReaderProperties& properties = default_arrow_reader_properties()) {
+    ASSERT_OK_AND_ASSIGN(auto file_reader, ReaderFromSink(properties));
+    ReadAndCheckSingleColumnFile(std::move(file_reader), values);
   }
 
   void ReadTableFromFile(std::unique_ptr<FileReader> reader, bool expect_metadata,
@@ -776,8 +796,16 @@ class TestReadDecimals : public ParquetIOTestBase {
                              /*rep_levels=*/nullptr, byte_arrays.data());
     column_writer->Close();
     file_writer->Close();
+    ASSERT_OK_AND_ASSIGN(auto buffer, sink_->Finish());
 
-    ReadAndCheckSingleColumnFile(expected);
+    // The binary_type setting shouldn't affect the results
+    for (auto binary_type : {::arrow::Type::BINARY, ::arrow::Type::LARGE_BINARY,
+                             ::arrow::Type::BINARY_VIEW}) {
+      ArrowReaderProperties properties;
+      properties.set_binary_type(binary_type);
+      ASSERT_OK_AND_ASSIGN(auto reader, ReaderFromBuffer(buffer, properties));
+      ReadAndCheckSingleColumnFile(std::move(reader), expected);
+    }
   }
 };
 
@@ -1390,50 +1418,56 @@ TEST_F(TestStringParquetIO, EmptyStringColumnRequiredWrite) {
   AssertArraysEqual(*values, *chunked_array->chunk(0));
 }
 
-using TestLargeBinaryParquetIO = TestParquetIO<::arrow::LargeBinaryType>;
+class TestBinaryLikeParquetIO : public ParquetIOTestBase {
+ public:
+  void CheckRoundTrip(std::string_view json, ::arrow::Type::type binary_type,
+                      const std::shared_ptr<DataType>& specific_type,
+                      const std::shared_ptr<DataType>& fallback_type) {
+    const auto specific_array = ::arrow::ArrayFromJSON(specific_type, json);
+    const auto fallback_array = ::arrow::ArrayFromJSON(fallback_type, json);
 
-TEST_F(TestLargeBinaryParquetIO, Basics) {
-  const char* json = "[\"foo\", \"\", null, \"\xff\"]";
+    // When the original Arrow schema isn't stored, the array is decoded as
+    // the fallback type (since there is no specific Parquet logical
+    // type for it).
+    this->RoundTripSingleColumn(specific_array, /*expected=*/fallback_array,
+                                default_arrow_writer_properties());
 
-  const auto large_type = ::arrow::large_binary();
-  const auto narrow_type = ::arrow::binary();
-  const auto large_array = ::arrow::ArrayFromJSON(large_type, json);
-  const auto narrow_array = ::arrow::ArrayFromJSON(narrow_type, json);
+    // When the original Arrow schema isn't stored and a binary_type is set,
+    // the array is decoded as the specific type.
+    ArrowReaderProperties reader_properties;
+    reader_properties.set_binary_type(binary_type);
+    this->RoundTripSingleColumn(specific_array, /*expected=*/specific_array,
+                                default_arrow_writer_properties(), reader_properties);
+    this->RoundTripSingleColumn(fallback_array, /*expected=*/specific_array,
+                                default_arrow_writer_properties(), reader_properties);
 
-  // When the original Arrow schema isn't stored, a LargeBinary array
-  // is decoded as Binary (since there is no specific Parquet logical
-  // type for it).
-  this->RoundTripSingleColumn(large_array, narrow_array,
-                              default_arrow_writer_properties());
+    // When the original Arrow schema is stored, the array is decoded as the
+    // specific type.
+    const auto writer_properties =
+        ArrowWriterProperties::Builder().store_schema()->build();
+    this->RoundTripSingleColumn(specific_array, /*expected=*/specific_array,
+                                writer_properties);
+  }
+};
 
-  // When the original Arrow schema is stored, the LargeBinary array
-  // is read back as LargeBinary.
-  const auto arrow_properties =
-      ::parquet::ArrowWriterProperties::Builder().store_schema()->build();
-  this->RoundTripSingleColumn(large_array, large_array, arrow_properties);
+TEST_F(TestBinaryLikeParquetIO, LargeBinary) {
+  CheckRoundTrip("[\"foo\", \"\", null, \"\xff\"]", ::arrow::Type::LARGE_BINARY,
+                 ::arrow::large_binary(), ::arrow::binary());
 }
 
-using TestLargeStringParquetIO = TestParquetIO<::arrow::LargeStringType>;
+TEST_F(TestBinaryLikeParquetIO, BinaryView) {
+  CheckRoundTrip("[\"foo\", \"\", null, \"\xff\"]", ::arrow::Type::BINARY_VIEW,
+                 ::arrow::binary_view(), ::arrow::binary());
+}
 
-TEST_F(TestLargeStringParquetIO, Basics) {
-  const char* json = R"(["foo", "", null, "bar"])";
+TEST_F(TestBinaryLikeParquetIO, LargeString) {
+  CheckRoundTrip(R"(["foo", "", null, "bar"])", ::arrow::Type::LARGE_BINARY,
+                 ::arrow::large_utf8(), ::arrow::utf8());
+}
 
-  const auto large_type = ::arrow::large_utf8();
-  const auto narrow_type = ::arrow::utf8();
-  const auto large_array = ::arrow::ArrayFromJSON(large_type, json);
-  const auto narrow_array = ::arrow::ArrayFromJSON(narrow_type, json);
-
-  // When the original Arrow schema isn't stored, a LargeBinary array
-  // is decoded as Binary (since there is no specific Parquet logical
-  // type for it).
-  this->RoundTripSingleColumn(large_array, narrow_array,
-                              default_arrow_writer_properties());
-
-  // When the original Arrow schema is stored, the LargeBinary array
-  // is read back as LargeBinary.
-  const auto arrow_properties =
-      ::parquet::ArrowWriterProperties::Builder().store_schema()->build();
-  this->RoundTripSingleColumn(large_array, large_array, arrow_properties);
+TEST_F(TestBinaryLikeParquetIO, StringView) {
+  CheckRoundTrip(R"(["foo", "", null, "bar"])", ::arrow::Type::BINARY_VIEW,
+                 ::arrow::utf8_view(), ::arrow::utf8());
 }
 
 using TestJsonParquetIO = TestParquetIO<::arrow::extension::JsonExtensionType>;

--- a/cpp/src/parquet/arrow/reader.cc
+++ b/cpp/src/parquet/arrow/reader.cc
@@ -31,6 +31,7 @@
 #include "arrow/record_batch.h"
 #include "arrow/table.h"
 #include "arrow/type.h"
+#include "arrow/type_traits.h"
 #include "arrow/util/async_generator.h"
 #include "arrow/util/bit_util.h"
 #include "arrow/util/future.h"
@@ -451,8 +452,17 @@ class LeafReader : public ColumnReaderImpl {
         field_(std::move(field)),
         input_(std::move(input)),
         descr_(input_->descr()) {
+    const auto type_id = field_->type()->id();
+    // If binary-like, RecordReader is able to read directly as the concrete type
+    // so as to avoid offset limitations.
+    std::shared_ptr<DataType> type_for_reading =
+        (::arrow::is_base_binary_like(type_id) || ::arrow::is_binary_view_like(type_id))
+            ? field_->type()
+            : nullptr;
     record_reader_ = RecordReader::Make(
-        descr_, leaf_info, ctx_->pool, field_->type()->id() == ::arrow::Type::DICTIONARY);
+        descr_, leaf_info, ctx_->pool,
+        /*read_dictionary=*/field_->type()->id() == ::arrow::Type::DICTIONARY,
+        /*read_dense_for_nullable=*/false, /*arrow_type=*/type_for_reading);
     NextRowGroup();
   }
 

--- a/cpp/src/parquet/arrow/reader_internal.cc
+++ b/cpp/src/parquet/arrow/reader_internal.cc
@@ -883,6 +883,8 @@ Status TransferColumnData(RecordReader* reader,
     case ::arrow::Type::FIXED_SIZE_BINARY:
     case ::arrow::Type::BINARY:
     case ::arrow::Type::STRING:
+    case ::arrow::Type::BINARY_VIEW:
+    case ::arrow::Type::STRING_VIEW:
     case ::arrow::Type::LARGE_BINARY:
     case ::arrow::Type::LARGE_STRING: {
       RETURN_NOT_OK(TransferBinary(reader, pool, value_field, &chunked_result));

--- a/cpp/src/parquet/arrow/schema_internal.h
+++ b/cpp/src/parquet/arrow/schema_internal.h
@@ -21,17 +21,10 @@
 #include "arrow/type_fwd.h"
 #include "parquet/schema.h"
 
-namespace arrow {
-class DataType;
-}
-
 namespace parquet::arrow {
 
 using ::arrow::Result;
 
-Result<std::shared_ptr<::arrow::DataType>> FromByteArray(
-    const LogicalType& logical_type, bool use_known_arrow_extensions,
-    const std::shared_ptr<const ::arrow::KeyValueMetadata>& metadata = nullptr);
 Result<std::shared_ptr<::arrow::DataType>> FromFLBA(const LogicalType& logical_type,
                                                     int32_t physical_length);
 Result<std::shared_ptr<::arrow::DataType>> FromInt32(const LogicalType& logical_type);

--- a/cpp/src/parquet/column_reader.cc
+++ b/cpp/src/parquet/column_reader.cc
@@ -49,6 +49,7 @@
 #include "parquet/encoding.h"
 #include "parquet/encryption/encryption_internal.h"
 #include "parquet/encryption/internal_file_decryptor.h"
+#include "parquet/exception.h"
 #include "parquet/level_comparison.h"
 #include "parquet/level_conversion.h"
 #include "parquet/properties.h"
@@ -2069,11 +2070,35 @@ class ByteArrayChunkedRecordReader final : public TypedRecordReader<ByteArrayTyp
                                            virtual public BinaryRecordReader {
  public:
   ByteArrayChunkedRecordReader(const ColumnDescriptor* descr, LevelInfo leaf_info,
-                               ::arrow::MemoryPool* pool, bool read_dense_for_nullable)
+                               ::arrow::MemoryPool* pool, bool read_dense_for_nullable,
+                               std::shared_ptr<::arrow::DataType> arrow_type)
       : TypedRecordReader<ByteArrayType>(descr, leaf_info, pool,
                                          read_dense_for_nullable) {
     ARROW_DCHECK_EQ(descr_->physical_type(), Type::BYTE_ARRAY);
-    accumulator_.builder = std::make_unique<::arrow::BinaryBuilder>(pool);
+    auto arrow_binary_type = arrow_type ? arrow_type->id() : ::arrow::Type::BINARY;
+    switch (arrow_binary_type) {
+      case ::arrow::Type::BINARY:
+        accumulator_.builder = std::make_unique<::arrow::BinaryBuilder>(pool);
+        break;
+      case ::arrow::Type::STRING:
+        accumulator_.builder = std::make_unique<::arrow::StringBuilder>(pool);
+        break;
+      case ::arrow::Type::LARGE_BINARY:
+        accumulator_.builder = std::make_unique<::arrow::LargeBinaryBuilder>(pool);
+        break;
+      case ::arrow::Type::LARGE_STRING:
+        accumulator_.builder = std::make_unique<::arrow::LargeStringBuilder>(pool);
+        break;
+      case ::arrow::Type::BINARY_VIEW:
+        accumulator_.builder = std::make_unique<::arrow::BinaryViewBuilder>(pool);
+        break;
+      case ::arrow::Type::STRING_VIEW:
+        accumulator_.builder = std::make_unique<::arrow::StringViewBuilder>(pool);
+        break;
+      default:
+        throw ParquetException("cannot read Parquet BYTE_ARRAY as Arrow " +
+                               arrow_type->ToString());
+    }
   }
 
   ::arrow::ArrayVector GetBuilderChunks() override {
@@ -2202,26 +2227,25 @@ void TypedRecordReader<ByteArrayType>::DebugPrintState() {}
 template <>
 void TypedRecordReader<FLBAType>::DebugPrintState() {}
 
-std::shared_ptr<RecordReader> MakeByteArrayRecordReader(const ColumnDescriptor* descr,
-                                                        LevelInfo leaf_info,
-                                                        ::arrow::MemoryPool* pool,
-                                                        bool read_dictionary,
-                                                        bool read_dense_for_nullable) {
+std::shared_ptr<RecordReader> MakeByteArrayRecordReader(
+    const ColumnDescriptor* descr, LevelInfo leaf_info, ::arrow::MemoryPool* pool,
+    bool read_dictionary, bool read_dense_for_nullable,
+    std::shared_ptr<::arrow::DataType> arrow_type) {
   if (read_dictionary) {
     return std::make_shared<ByteArrayDictionaryRecordReader>(descr, leaf_info, pool,
                                                              read_dense_for_nullable);
   } else {
-    return std::make_shared<ByteArrayChunkedRecordReader>(descr, leaf_info, pool,
-                                                          read_dense_for_nullable);
+    return std::make_shared<ByteArrayChunkedRecordReader>(
+        descr, leaf_info, pool, read_dense_for_nullable, std::move(arrow_type));
   }
 }
 
 }  // namespace
 
-std::shared_ptr<RecordReader> RecordReader::Make(const ColumnDescriptor* descr,
-                                                 LevelInfo leaf_info, MemoryPool* pool,
-                                                 bool read_dictionary,
-                                                 bool read_dense_for_nullable) {
+std::shared_ptr<RecordReader> RecordReader::Make(
+    const ColumnDescriptor* descr, LevelInfo leaf_info, MemoryPool* pool,
+    bool read_dictionary, bool read_dense_for_nullable,
+    std::shared_ptr<::arrow::DataType> arrow_type) {
   switch (descr->physical_type()) {
     case Type::BOOLEAN:
       return std::make_shared<TypedRecordReader<BooleanType>>(descr, leaf_info, pool,
@@ -2243,7 +2267,7 @@ std::shared_ptr<RecordReader> RecordReader::Make(const ColumnDescriptor* descr,
                                                              read_dense_for_nullable);
     case Type::BYTE_ARRAY: {
       return MakeByteArrayRecordReader(descr, leaf_info, pool, read_dictionary,
-                                       read_dense_for_nullable);
+                                       read_dense_for_nullable, std::move(arrow_type));
     }
     case Type::FIXED_LEN_BYTE_ARRAY:
       return std::make_shared<FLBARecordReader>(descr, leaf_info, pool,

--- a/cpp/src/parquet/column_reader.cc
+++ b/cpp/src/parquet/column_reader.cc
@@ -2071,7 +2071,7 @@ class ByteArrayChunkedRecordReader final : public TypedRecordReader<ByteArrayTyp
  public:
   ByteArrayChunkedRecordReader(const ColumnDescriptor* descr, LevelInfo leaf_info,
                                ::arrow::MemoryPool* pool, bool read_dense_for_nullable,
-                               std::shared_ptr<::arrow::DataType> arrow_type)
+                               const std::shared_ptr<::arrow::DataType>& arrow_type)
       : TypedRecordReader<ByteArrayType>(descr, leaf_info, pool,
                                          read_dense_for_nullable) {
     ARROW_DCHECK_EQ(descr_->physical_type(), Type::BYTE_ARRAY);
@@ -2230,13 +2230,13 @@ void TypedRecordReader<FLBAType>::DebugPrintState() {}
 std::shared_ptr<RecordReader> MakeByteArrayRecordReader(
     const ColumnDescriptor* descr, LevelInfo leaf_info, ::arrow::MemoryPool* pool,
     bool read_dictionary, bool read_dense_for_nullable,
-    std::shared_ptr<::arrow::DataType> arrow_type) {
+    const std::shared_ptr<::arrow::DataType>& arrow_type) {
   if (read_dictionary) {
     return std::make_shared<ByteArrayDictionaryRecordReader>(descr, leaf_info, pool,
                                                              read_dense_for_nullable);
   } else {
     return std::make_shared<ByteArrayChunkedRecordReader>(
-        descr, leaf_info, pool, read_dense_for_nullable, std::move(arrow_type));
+        descr, leaf_info, pool, read_dense_for_nullable, arrow_type);
   }
 }
 
@@ -2245,7 +2245,7 @@ std::shared_ptr<RecordReader> MakeByteArrayRecordReader(
 std::shared_ptr<RecordReader> RecordReader::Make(
     const ColumnDescriptor* descr, LevelInfo leaf_info, MemoryPool* pool,
     bool read_dictionary, bool read_dense_for_nullable,
-    std::shared_ptr<::arrow::DataType> arrow_type) {
+    const std::shared_ptr<::arrow::DataType>& arrow_type) {
   switch (descr->physical_type()) {
     case Type::BOOLEAN:
       return std::make_shared<TypedRecordReader<BooleanType>>(descr, leaf_info, pool,
@@ -2267,7 +2267,7 @@ std::shared_ptr<RecordReader> RecordReader::Make(
                                                              read_dense_for_nullable);
     case Type::BYTE_ARRAY: {
       return MakeByteArrayRecordReader(descr, leaf_info, pool, read_dictionary,
-                                       read_dense_for_nullable, std::move(arrow_type));
+                                       read_dense_for_nullable, arrow_type);
     }
     case Type::FIXED_LEN_BYTE_ARRAY:
       return std::make_shared<FLBARecordReader>(descr, leaf_info, pool,

--- a/cpp/src/parquet/column_reader.h
+++ b/cpp/src/parquet/column_reader.h
@@ -272,7 +272,7 @@ class PARQUET_EXPORT RecordReader {
       const ColumnDescriptor* descr, LevelInfo leaf_info,
       ::arrow::MemoryPool* pool = ::arrow::default_memory_pool(),
       bool read_dictionary = false, bool read_dense_for_nullable = false,
-      std::shared_ptr<::arrow::DataType> arrow_type = NULLPTR);
+      const std::shared_ptr<::arrow::DataType>& arrow_type = NULLPTR);
 
   virtual ~RecordReader() = default;
 

--- a/cpp/src/parquet/column_reader.h
+++ b/cpp/src/parquet/column_reader.h
@@ -22,6 +22,8 @@
 #include <utility>
 #include <vector>
 
+#include "arrow/type_fwd.h"
+#include "arrow/util/macros.h"
 #include "parquet/exception.h"
 #include "parquet/level_conversion.h"
 #include "parquet/metadata.h"
@@ -31,9 +33,6 @@
 #include "parquet/types.h"
 
 namespace arrow {
-
-class Array;
-class ChunkedArray;
 
 namespace bit_util {
 class BitReader;
@@ -267,10 +266,13 @@ class PARQUET_EXPORT RecordReader {
   /// @param read_dictionary True if reading directly as Arrow dictionary-encoded
   /// @param read_dense_for_nullable True if reading dense and not leaving space for null
   /// values
+  /// @param arrow_type Which type to read this column as (optional). Currently
+  /// only used for byte array columns (see BinaryRecordReader::GetBuilderChunks).
   static std::shared_ptr<RecordReader> Make(
       const ColumnDescriptor* descr, LevelInfo leaf_info,
       ::arrow::MemoryPool* pool = ::arrow::default_memory_pool(),
-      bool read_dictionary = false, bool read_dense_for_nullable = false);
+      bool read_dictionary = false, bool read_dense_for_nullable = false,
+      std::shared_ptr<::arrow::DataType> arrow_type = NULLPTR);
 
   virtual ~RecordReader() = default;
 

--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -2395,7 +2395,8 @@ template <>
 Status TypedColumnWriterImpl<ByteArrayType>::WriteArrowDense(
     const int16_t* def_levels, const int16_t* rep_levels, int64_t num_levels,
     const ::arrow::Array& array, ArrowWriteContext* ctx, bool maybe_parent_nulls) {
-  if (!::arrow::is_base_binary_like(array.type()->id())) {
+  if (!::arrow::is_base_binary_like(array.type()->id()) &&
+      !::arrow::is_binary_view_like(array.type()->id())) {
     ARROW_UNSUPPORTED();
   }
 

--- a/cpp/src/parquet/decoder.cc
+++ b/cpp/src/parquet/decoder.cc
@@ -24,6 +24,7 @@
 #include <memory>
 #include <string>
 #include <string_view>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -33,6 +34,7 @@
 #include "arrow/array/builder_primitive.h"
 #include "arrow/type_traits.h"
 #include "arrow/util/bit_block_counter.h"
+#include "arrow/util/bit_run_reader.h"
 #include "arrow/util/bit_stream_utils_internal.h"
 #include "arrow/util/bit_util.h"
 #include "arrow/util/bitmap_ops.h"
@@ -62,6 +64,191 @@ using arrow::util::SafeLoadAs;
 
 namespace parquet {
 namespace {
+
+// A helper class to abstract away differences between EncodingTraits<DType>::Accumulator
+// for ByteArrayType and FLBAType.
+
+template <typename DType, typename ArrowType>
+struct ArrowBinaryHelper;
+
+template <>
+struct ArrowBinaryHelper<ByteArrayType, ::arrow::BinaryType> {
+  using Accumulator = typename EncodingTraits<ByteArrayType>::Accumulator;
+
+  explicit ArrowBinaryHelper(Accumulator* acc)
+      : acc_(acc),
+        builder_(checked_cast<::arrow::BinaryBuilder*>(acc->builder.get())),
+        chunk_space_remaining_(::arrow::kBinaryMemoryLimit -
+                               builder_->value_data_length()) {}
+
+  // Prepare will reserve the number of entries in the current chunk.
+  // If estimated_data_length is provided, it will also reserve the estimated data length.
+  Status Prepare(int64_t length, std::optional<int64_t> estimated_data_length = {}) {
+    entries_remaining_ = length;
+    RETURN_NOT_OK(builder_->Reserve(entries_remaining_));
+    if (estimated_data_length.has_value()) {
+      RETURN_NOT_OK(builder_->ReserveData(
+          std::min<int64_t>(*estimated_data_length, this->chunk_space_remaining_)));
+    }
+    return Status::OK();
+  }
+
+  // If a new chunk is created and estimated_remaining_data_length is provided,
+  // it will also reserve the estimated data length for this chunk.
+  Status AppendValue(const uint8_t* data, int32_t length,
+                     std::optional<int64_t> estimated_remaining_data_length = {}) {
+    DCHECK_GT(entries_remaining_, 0);
+
+    if (ARROW_PREDICT_FALSE(!CanFit(length))) {
+      // This element would exceed the capacity of a chunk
+      RETURN_NOT_OK(PushChunk());
+      // Reserve entries and data in new chunk
+      RETURN_NOT_OK(builder_->Reserve(entries_remaining_));
+      if (estimated_remaining_data_length.has_value()) {
+        RETURN_NOT_OK(builder_->ReserveData(
+            std::min<int64_t>(*estimated_remaining_data_length, chunk_space_remaining_)));
+      }
+    }
+    chunk_space_remaining_ -= length;
+    --entries_remaining_;
+    if (estimated_remaining_data_length.has_value()) {
+      // Assume Prepare() was already called with an estimated_data_length
+      builder_->UnsafeAppend(data, length);
+      return Status::OK();
+    } else {
+      return builder_->Append(data, length);
+    }
+  }
+
+  void UnsafeAppendNull() {
+    DCHECK_GT(entries_remaining_, 0);
+    --entries_remaining_;
+    builder_->UnsafeAppendNull();
+  }
+
+ private:
+  Status PushChunk() {
+    ARROW_ASSIGN_OR_RAISE(auto chunk, acc_->builder->Finish());
+    acc_->chunks.push_back(std::move(chunk));
+    chunk_space_remaining_ = ::arrow::kBinaryMemoryLimit;
+    return Status::OK();
+  }
+
+  bool CanFit(int64_t length) const { return length <= chunk_space_remaining_; }
+
+  Accumulator* acc_;
+  ::arrow::BinaryBuilder* builder_;
+  int64_t entries_remaining_;
+  int64_t chunk_space_remaining_;
+};
+
+template <typename ArrowBinaryType>
+struct ArrowBinaryHelper<ByteArrayType, ArrowBinaryType> {
+  using Accumulator = typename EncodingTraits<ByteArrayType>::Accumulator;
+  using BuilderType = typename ::arrow::TypeTraits<ArrowBinaryType>::BuilderType;
+
+  static constexpr bool kIsBinaryView =
+      ::arrow::is_binary_view_like_type<ArrowBinaryType>::value;
+
+  explicit ArrowBinaryHelper(Accumulator* acc)
+      : builder_(checked_cast<BuilderType*>(acc->builder.get())) {}
+
+  // Prepare will reserve the number of entries in the current chunk.
+  // If estimated_data_length is provided, it will also reserve the estimated data length,
+  // and the caller should better call `UnsafeAppend` instead of `Append` to avoid
+  // double-checking the data length.
+  Status Prepare(int64_t length, std::optional<int64_t> estimated_data_length = {}) {
+    RETURN_NOT_OK(builder_->Reserve(length));
+    // Avoid reserving data when reading into a binary-view array, because many
+    // values may be very short and not require any heap storage, which would make
+    // the initial allocation wasteful.
+    if (!kIsBinaryView && estimated_data_length.has_value()) {
+      RETURN_NOT_OK(builder_->ReserveData(*estimated_data_length));
+    }
+    return Status::OK();
+  }
+
+  Status AppendValue(const uint8_t* data, int32_t length,
+                     std::optional<int64_t> estimated_remaining_data_length = {}) {
+    if (!kIsBinaryView && estimated_remaining_data_length.has_value()) {
+      // Assume Prepare() was already called with an estimated_data_length
+      builder_->UnsafeAppend(data, length);
+      return Status::OK();
+    } else {
+      return builder_->Append(data, length);
+    }
+  }
+
+  void UnsafeAppendNull() { builder_->UnsafeAppendNull(); }
+
+ private:
+  BuilderType* builder_;
+};
+
+template <>
+struct ArrowBinaryHelper<FLBAType, ::arrow::FixedSizeBinaryType> {
+  using Accumulator = typename EncodingTraits<FLBAType>::Accumulator;
+
+  explicit ArrowBinaryHelper(Accumulator* acc) : acc_(acc) {}
+
+  Status Prepare(int64_t length, std::optional<int64_t> estimated_data_length = {}) {
+    return acc_->Reserve(length);
+  }
+
+  Status AppendValue(const uint8_t* data, int32_t length,
+                     std::optional<int64_t> estimated_remaining_data_length = {}) {
+    acc_->UnsafeAppend(data);
+    return Status::OK();
+  }
+
+  void UnsafeAppendNull() { acc_->UnsafeAppendNull(); }
+
+ private:
+  Accumulator* acc_;
+};
+
+// Call `func(&helper, args...)` where `helper` is a ArrowBinaryHelper<> instance
+// suitable for the Parquet DType and accumulator `acc`.
+template <typename DType, typename Function, typename... Args>
+auto DispatchArrowBinaryHelper(typename EncodingTraits<DType>::Accumulator* acc,
+                               int64_t length,
+                               std::optional<int64_t> estimated_data_length,
+                               Function&& func, Args&&... args) {
+  static_assert(std::is_same_v<DType, ByteArrayType> || std::is_same_v<DType, FLBAType>,
+                "unsupported DType");
+  if constexpr (std::is_same_v<DType, ByteArrayType>) {
+    switch (acc->builder->type()->id()) {
+      case ::arrow::Type::BINARY:
+      case ::arrow::Type::STRING: {
+        ArrowBinaryHelper<DType, ::arrow::BinaryType> helper(acc);
+        RETURN_NOT_OK(helper.Prepare(length, estimated_data_length));
+        return func(&helper, std::forward<Args>(args)...);
+      }
+      case ::arrow::Type::LARGE_BINARY:
+      case ::arrow::Type::LARGE_STRING: {
+        ArrowBinaryHelper<DType, ::arrow::LargeBinaryType> helper(acc);
+        RETURN_NOT_OK(helper.Prepare(length, estimated_data_length));
+        return func(&helper, std::forward<Args>(args)...);
+      }
+      case ::arrow::Type::BINARY_VIEW:
+      case ::arrow::Type::STRING_VIEW: {
+        ArrowBinaryHelper<DType, ::arrow::BinaryViewType> helper(acc);
+        RETURN_NOT_OK(helper.Prepare(length, estimated_data_length));
+        return func(&helper, std::forward<Args>(args)...);
+      }
+      default:
+        throw ParquetException(
+            "Unsupported Arrow builder type when reading from BYTE_ARRAY column: " +
+            acc->builder->type()->ToString());
+    }
+  } else {
+    ArrowBinaryHelper<DType, ::arrow::FixedSizeBinaryType> helper(acc);
+    RETURN_NOT_OK(helper.Prepare(length, estimated_data_length));
+    return func(&helper, std::forward<Args>(args)...);
+  }
+}
+
+// Internal decoder class hierarchy
 
 class DecoderImpl : virtual public Decoder {
  public:
@@ -416,146 +603,6 @@ int PlainBooleanDecoder::Decode(bool* buffer, int max_values) {
 
 // PLAIN decoder implementation for FIXED_LEN_BYTE_ARRAY and BYTE_ARRAY
 
-// A helper class to abstract away differences between EncodingTraits<DType>::Accumulator
-// for ByteArrayType and FLBAType.
-template <typename DType>
-struct ArrowBinaryHelper;
-
-template <>
-struct ArrowBinaryHelper<ByteArrayType> {
-  using Accumulator = typename EncodingTraits<ByteArrayType>::Accumulator;
-
-  ArrowBinaryHelper(Accumulator* acc, int64_t length)
-      : acc_(acc),
-        entries_remaining_(length),
-        chunk_space_remaining_(::arrow::kBinaryMemoryLimit -
-                               acc_->builder->value_data_length()) {}
-
-  // Prepare will reserve the number of entries remaining in the current chunk.
-  // If estimated_data_length is provided, it will also reserve the estimated data length,
-  // and the caller should better call `UnsafeAppend` instead of `Append` to avoid
-  // double-checking the data length.
-  Status Prepare(std::optional<int64_t> estimated_data_length = {}) {
-    RETURN_NOT_OK(acc_->builder->Reserve(entries_remaining_));
-    if (estimated_data_length.has_value()) {
-      RETURN_NOT_OK(acc_->builder->ReserveData(
-          std::min<int64_t>(*estimated_data_length, this->chunk_space_remaining_)));
-    }
-    return Status::OK();
-  }
-
-  Status PrepareNextInput(int64_t next_value_length) {
-    if (ARROW_PREDICT_FALSE(!CanFit(next_value_length))) {
-      // This element would exceed the capacity of a chunk
-      RETURN_NOT_OK(PushChunk());
-      RETURN_NOT_OK(acc_->builder->Reserve(entries_remaining_));
-    }
-    return Status::OK();
-  }
-
-  // If estimated_remaining_data_length is provided, it will also reserve the estimated
-  // data length, and the caller should better call `UnsafeAppend` instead of
-  // `Append` to avoid double-checking the data length.
-  Status PrepareNextInput(int64_t next_value_length,
-                          int64_t estimated_remaining_data_length) {
-    if (ARROW_PREDICT_FALSE(!CanFit(next_value_length))) {
-      // This element would exceed the capacity of a chunk
-      RETURN_NOT_OK(PushChunk());
-      RETURN_NOT_OK(acc_->builder->Reserve(entries_remaining_));
-      if (estimated_remaining_data_length) {
-        RETURN_NOT_OK(acc_->builder->ReserveData(
-            std::min<int64_t>(estimated_remaining_data_length, chunk_space_remaining_)));
-      }
-    }
-    return Status::OK();
-  }
-
-  void UnsafeAppend(const uint8_t* data, int32_t length) {
-    DCHECK(CanFit(length));
-    DCHECK_GT(entries_remaining_, 0);
-    chunk_space_remaining_ -= length;
-    --entries_remaining_;
-    acc_->builder->UnsafeAppend(data, length);
-  }
-
-  Status Append(const uint8_t* data, int32_t length) {
-    DCHECK(CanFit(length));
-    DCHECK_GT(entries_remaining_, 0);
-    chunk_space_remaining_ -= length;
-    --entries_remaining_;
-    return acc_->builder->Append(data, length);
-  }
-
-  void UnsafeAppendNull() {
-    --entries_remaining_;
-    acc_->builder->UnsafeAppendNull();
-  }
-
-  Status AppendNull() {
-    --entries_remaining_;
-    return acc_->builder->AppendNull();
-  }
-
- private:
-  Status PushChunk() {
-    ARROW_ASSIGN_OR_RAISE(auto chunk, acc_->builder->Finish());
-    acc_->chunks.push_back(std::move(chunk));
-    chunk_space_remaining_ = ::arrow::kBinaryMemoryLimit;
-    return Status::OK();
-  }
-
-  bool CanFit(int64_t length) const { return length <= chunk_space_remaining_; }
-
-  Accumulator* acc_;
-  int64_t entries_remaining_;
-  int64_t chunk_space_remaining_;
-};
-
-template <>
-struct ArrowBinaryHelper<FLBAType> {
-  using Accumulator = typename EncodingTraits<FLBAType>::Accumulator;
-
-  ArrowBinaryHelper(Accumulator* acc, int64_t length)
-      : acc_(acc), entries_remaining_(length) {}
-
-  Status Prepare(std::optional<int64_t> estimated_data_length = {}) {
-    return acc_->Reserve(entries_remaining_);
-  }
-
-  Status PrepareNextInput(int64_t next_value_length) { return Status::OK(); }
-
-  Status PrepareNextInput(int64_t next_value_length,
-                          int64_t estimated_remaining_data_length) {
-    return Status::OK();
-  }
-
-  void UnsafeAppend(const uint8_t* data, int32_t length) {
-    DCHECK_GT(entries_remaining_, 0);
-    --entries_remaining_;
-    acc_->UnsafeAppend(data);
-  }
-
-  Status Append(const uint8_t* data, int32_t length) {
-    DCHECK_GT(entries_remaining_, 0);
-    --entries_remaining_;
-    return acc_->Append(data);
-  }
-
-  void UnsafeAppendNull() {
-    --entries_remaining_;
-    acc_->UnsafeAppendNull();
-  }
-
-  Status AppendNull() {
-    --entries_remaining_;
-    return acc_->AppendNull();
-  }
-
- private:
-  Accumulator* acc_;
-  int64_t entries_remaining_;
-};
-
 template <>
 inline int PlainDecoder<ByteArrayType>::DecodeArrow(
     int num_values, int null_count, const uint8_t* valid_bits, int64_t valid_bits_offset,
@@ -654,43 +701,41 @@ class PlainByteArrayDecoder : public PlainDecoder<ByteArrayType>,
                           int64_t valid_bits_offset,
                           typename EncodingTraits<ByteArrayType>::Accumulator* out,
                           int* out_values_decoded) {
-    ArrowBinaryHelper<ByteArrayType> helper(out, num_values);
-    int values_decoded = 0;
+    auto visit_binary_helper = [&](auto* helper) {
+      int values_decoded = 0;
 
-    RETURN_NOT_OK(helper.Prepare(len_));
+      RETURN_NOT_OK(VisitNullBitmapInline(
+          valid_bits, valid_bits_offset, num_values, null_count,
+          [&]() {
+            if (ARROW_PREDICT_FALSE(len_ < 4)) {
+              return Status::Invalid(
+                  "Invalid or truncated PLAIN-encoded BYTE_ARRAY data");
+            }
+            auto value_len = SafeLoadAs<int32_t>(data_);
+            if (ARROW_PREDICT_FALSE(value_len < 0 || value_len > len_ - 4)) {
+              return Status::Invalid(
+                  "Invalid or truncated PLAIN-encoded BYTE_ARRAY data");
+            }
+            RETURN_NOT_OK(helper->AppendValue(data_ + 4, value_len,
+                                              /*estimated_remaining_data_length=*/len_));
+            auto increment = value_len + 4;
+            data_ += increment;
+            len_ -= increment;
+            ++values_decoded;
+            return Status::OK();
+          },
+          [&]() {
+            helper->UnsafeAppendNull();
+            return Status::OK();
+          }));
 
-    int i = 0;
-    RETURN_NOT_OK(VisitNullBitmapInline(
-        valid_bits, valid_bits_offset, num_values, null_count,
-        [&]() {
-          if (ARROW_PREDICT_FALSE(len_ < 4)) {
-            ParquetException::EofException();
-          }
-          auto value_len = SafeLoadAs<int32_t>(data_);
-          if (ARROW_PREDICT_FALSE(value_len < 0 || value_len > INT32_MAX - 4)) {
-            return Status::Invalid("Invalid or corrupted value_len '", value_len, "'");
-          }
-          auto increment = value_len + 4;
-          if (ARROW_PREDICT_FALSE(len_ < increment)) {
-            ParquetException::EofException();
-          }
-          RETURN_NOT_OK(helper.PrepareNextInput(value_len, len_));
-          helper.UnsafeAppend(data_ + 4, value_len);
-          data_ += increment;
-          len_ -= increment;
-          ++values_decoded;
-          ++i;
-          return Status::OK();
-        },
-        [&]() {
-          helper.UnsafeAppendNull();
-          ++i;
-          return Status::OK();
-        }));
+      num_values_ -= values_decoded;
+      *out_values_decoded = values_decoded;
+      return Status::OK();
+    };
 
-    num_values_ -= values_decoded;
-    *out_values_decoded = values_decoded;
-    return Status::OK();
+    return DispatchArrowBinaryHelper<ByteArrayType>(out, num_values, len_,
+                                                    visit_binary_helper);
   }
 
   template <typename BuilderType>
@@ -1145,7 +1190,9 @@ class DictByteArrayDecoderImpl : public DictDecoderImpl<ByteArrayType>,
                   typename EncodingTraits<ByteArrayType>::Accumulator* out) override {
     int result = 0;
     if (null_count == 0) {
-      PARQUET_THROW_NOT_OK(DecodeArrowDenseNonNull(num_values, out, &result));
+      PARQUET_THROW_NOT_OK(DecodeArrowDense(num_values, null_count,
+                                            /*valid_bits=*/nullptr, valid_bits_offset,
+                                            out, &result));
     } else {
       PARQUET_THROW_NOT_OK(DecodeArrowDense(num_values, null_count, valid_bits,
                                             valid_bits_offset, out, &result));
@@ -1161,101 +1208,54 @@ class DictByteArrayDecoderImpl : public DictDecoderImpl<ByteArrayType>,
     constexpr int32_t kBufferSize = 1024;
     int32_t indices[kBufferSize];
 
-    ArrowBinaryHelper<ByteArrayType> helper(out, num_values);
-    // The `len_` in the ByteArrayDictDecoder is the total length of the
-    // RLE/Bit-pack encoded data size, so, we cannot use `len_` to reserve
-    // space for binary data.
-    RETURN_NOT_OK(helper.Prepare());
+    auto visit_binary_helper = [&](auto* helper) {
+      const auto* dict_values = dictionary_->data_as<ByteArray>();
+      const int values_to_decode = num_values - null_count;
+      int values_decoded = 0;
+      int num_indices = 0;
+      int pos_indices = 0;
 
-    const auto* dict_values = dictionary_->data_as<ByteArray>();
-    int values_decoded = 0;
-    int num_indices = 0;
-    int pos_indices = 0;
-
-    auto visit_valid = [&](int64_t position) -> Status {
-      if (num_indices == pos_indices) {
-        // Refill indices buffer
-        const auto batch_size =
-            std::min<int32_t>(kBufferSize, num_values - null_count - values_decoded);
-        num_indices = idx_decoder_.GetBatch(indices, batch_size);
-        if (ARROW_PREDICT_FALSE(num_indices < 1)) {
-          return Status::Invalid("Invalid number of indices: ", num_indices);
-        }
-        pos_indices = 0;
-      }
-      const auto index = indices[pos_indices++];
-      RETURN_NOT_OK(IndexInBounds(index));
-      const auto& val = dict_values[index];
-      RETURN_NOT_OK(helper.PrepareNextInput(val.len));
-      RETURN_NOT_OK(helper.Append(val.ptr, static_cast<int32_t>(val.len)));
-      ++values_decoded;
-      return Status::OK();
-    };
-
-    auto visit_null = [&]() -> Status {
-      RETURN_NOT_OK(helper.AppendNull());
-      return Status::OK();
-    };
-
-    ::arrow::internal::BitBlockCounter bit_blocks(valid_bits, valid_bits_offset,
-                                                  num_values);
-    int64_t position = 0;
-    while (position < num_values) {
-      const auto block = bit_blocks.NextWord();
-      if (block.AllSet()) {
-        for (int64_t i = 0; i < block.length; ++i, ++position) {
-          ARROW_RETURN_NOT_OK(visit_valid(position));
-        }
-      } else if (block.NoneSet()) {
-        for (int64_t i = 0; i < block.length; ++i, ++position) {
-          ARROW_RETURN_NOT_OK(visit_null());
-        }
-      } else {
-        for (int64_t i = 0; i < block.length; ++i, ++position) {
-          if (bit_util::GetBit(valid_bits, valid_bits_offset + position)) {
-            ARROW_RETURN_NOT_OK(visit_valid(position));
-          } else {
-            ARROW_RETURN_NOT_OK(visit_null());
+      auto visit_bit_run = [&](int64_t position, int64_t length, bool valid) {
+        if (valid) {
+          while (length > 0) {
+            if (num_indices == pos_indices) {
+              // Refill indices buffer
+              const auto max_batch_size =
+                  std::min<int32_t>(kBufferSize, values_to_decode - values_decoded);
+              num_indices = idx_decoder_.GetBatch(indices, max_batch_size);
+              if (ARROW_PREDICT_FALSE(num_indices < 1)) {
+                return Status::Invalid("Invalid number of indices: ", num_indices);
+              }
+              pos_indices = 0;
+            }
+            const auto batch_size = std::min<int64_t>(num_indices - pos_indices, length);
+            for (int64_t j = 0; j < batch_size; ++j) {
+              const auto index = indices[pos_indices++];
+              RETURN_NOT_OK(IndexInBounds(index));
+              const auto& val = dict_values[index];
+              RETURN_NOT_OK(helper->AppendValue(val.ptr, static_cast<int32_t>(val.len)));
+            }
+            values_decoded += static_cast<int32_t>(batch_size);
+            length -= static_cast<int32_t>(batch_size);
+          }
+        } else {
+          for (int64_t i = 0; i < length; ++i) {
+            helper->UnsafeAppendNull();
           }
         }
-      }
-    }
+        return Status::OK();
+      };
 
-    *out_num_values = values_decoded;
-    return Status::OK();
-  }
-
-  Status DecodeArrowDenseNonNull(int num_values,
-                                 typename EncodingTraits<ByteArrayType>::Accumulator* out,
-                                 int* out_num_values) {
-    constexpr int32_t kBufferSize = 2048;
-    int32_t indices[kBufferSize];
-    int values_decoded = 0;
-
-    ArrowBinaryHelper<ByteArrayType> helper(out, num_values);
+      RETURN_NOT_OK(::arrow::internal::VisitBitRuns(valid_bits, valid_bits_offset,
+                                                    num_values, visit_bit_run));
+      *out_num_values = values_decoded;
+      return Status::OK();
+    };
     // The `len_` in the ByteArrayDictDecoder is the total length of the
     // RLE/Bit-pack encoded data size, so, we cannot use `len_` to reserve
     // space for binary data.
-    RETURN_NOT_OK(helper.Prepare());
-
-    const auto* dict_values = dictionary_->data_as<ByteArray>();
-
-    while (values_decoded < num_values) {
-      const int32_t batch_size =
-          std::min<int32_t>(kBufferSize, num_values - values_decoded);
-      const int num_indices = idx_decoder_.GetBatch(indices, batch_size);
-      if (num_indices == 0) ParquetException::EofException();
-      for (int i = 0; i < num_indices; ++i) {
-        auto idx = indices[i];
-        RETURN_NOT_OK(IndexInBounds(idx));
-        const auto& val = dict_values[idx];
-        RETURN_NOT_OK(helper.PrepareNextInput(val.len));
-        RETURN_NOT_OK(helper.Append(val.ptr, static_cast<int32_t>(val.len)));
-      }
-      values_decoded += num_indices;
-    }
-    *out_num_values = values_decoded;
-    return Status::OK();
+    return DispatchArrowBinaryHelper<ByteArrayType>(
+        out, num_values, /*estimated_data_length=*/{}, visit_binary_helper);
   }
 
   template <typename BuilderType>
@@ -1679,37 +1679,37 @@ class DeltaLengthByteArrayDecoder : public DecoderImpl,
                           int64_t valid_bits_offset,
                           typename EncodingTraits<ByteArrayType>::Accumulator* out,
                           int* out_num_values) {
-    ArrowBinaryHelper<ByteArrayType> helper(out, num_values);
-    RETURN_NOT_OK(helper.Prepare());
+    auto visit_binary_helper = [&](auto* helper) {
+      std::vector<ByteArray> values(num_values - null_count);
+      const int num_valid_values = Decode(values.data(), num_values - null_count);
+      if (ARROW_PREDICT_FALSE(num_values - null_count != num_valid_values)) {
+        throw ParquetException("Expected to decode ", num_values - null_count,
+                               " values, but decoded ", num_valid_values, " values.");
+      }
 
-    std::vector<ByteArray> values(num_values - null_count);
-    const int num_valid_values = Decode(values.data(), num_values - null_count);
-    if (ARROW_PREDICT_FALSE(num_values - null_count != num_valid_values)) {
-      throw ParquetException("Expected to decode ", num_values - null_count,
-                             " values, but decoded ", num_valid_values, " values.");
-    }
+      auto values_ptr = values.data();
+      int value_idx = 0;
 
-    auto values_ptr = values.data();
-    int value_idx = 0;
+      RETURN_NOT_OK(VisitNullBitmapInline(
+          valid_bits, valid_bits_offset, num_values, null_count,
+          [&]() {
+            const auto& val = values_ptr[value_idx];
+            RETURN_NOT_OK(helper->AppendValue(val.ptr, static_cast<int32_t>(val.len)));
+            ++value_idx;
+            return Status::OK();
+          },
+          [&]() {
+            helper->UnsafeAppendNull();
+            --null_count;
+            return Status::OK();
+          }));
 
-    RETURN_NOT_OK(VisitNullBitmapInline(
-        valid_bits, valid_bits_offset, num_values, null_count,
-        [&]() {
-          const auto& val = values_ptr[value_idx];
-          RETURN_NOT_OK(helper.PrepareNextInput(val.len));
-          RETURN_NOT_OK(helper.Append(val.ptr, static_cast<int32_t>(val.len)));
-          ++value_idx;
-          return Status::OK();
-        },
-        [&]() {
-          RETURN_NOT_OK(helper.AppendNull());
-          --null_count;
-          return Status::OK();
-        }));
-
-    DCHECK_EQ(null_count, 0);
-    *out_num_values = num_valid_values;
-    return Status::OK();
+      DCHECK_EQ(null_count, 0);
+      *out_num_values = num_valid_values;
+      return Status::OK();
+    };
+    return DispatchArrowBinaryHelper<ByteArrayType>(
+        out, num_values, /*estimated_data_length=*/{}, visit_binary_helper);
   }
 
   std::shared_ptr<::arrow::bit_util::BitReader> decoder_;
@@ -2005,34 +2005,34 @@ class DeltaByteArrayDecoderImpl : public DecoderImpl, public TypedDecoderImpl<DT
                           int64_t valid_bits_offset,
                           typename EncodingTraits<DType>::Accumulator* out,
                           int* out_num_values) {
-    ArrowBinaryHelper<DType> helper(out, num_values);
-    RETURN_NOT_OK(helper.Prepare());
+    auto visit_binary_helper = [&](auto* helper) {
+      std::vector<ByteArray> values(num_values);
+      const int num_valid_values = GetInternal(values.data(), num_values - null_count);
+      DCHECK_EQ(num_values - null_count, num_valid_values);
 
-    std::vector<ByteArray> values(num_values);
-    const int num_valid_values = GetInternal(values.data(), num_values - null_count);
-    DCHECK_EQ(num_values - null_count, num_valid_values);
+      auto values_ptr = reinterpret_cast<const ByteArray*>(values.data());
+      int value_idx = 0;
 
-    auto values_ptr = reinterpret_cast<const ByteArray*>(values.data());
-    int value_idx = 0;
+      RETURN_NOT_OK(VisitNullBitmapInline(
+          valid_bits, valid_bits_offset, num_values, null_count,
+          [&]() {
+            const auto& val = values_ptr[value_idx];
+            RETURN_NOT_OK(helper->AppendValue(val.ptr, static_cast<int32_t>(val.len)));
+            ++value_idx;
+            return Status::OK();
+          },
+          [&]() {
+            helper->UnsafeAppendNull();
+            --null_count;
+            return Status::OK();
+          }));
 
-    RETURN_NOT_OK(VisitNullBitmapInline(
-        valid_bits, valid_bits_offset, num_values, null_count,
-        [&]() {
-          const auto& val = values_ptr[value_idx];
-          RETURN_NOT_OK(helper.PrepareNextInput(val.len));
-          RETURN_NOT_OK(helper.Append(val.ptr, static_cast<int32_t>(val.len)));
-          ++value_idx;
-          return Status::OK();
-        },
-        [&]() {
-          RETURN_NOT_OK(helper.AppendNull());
-          --null_count;
-          return Status::OK();
-        }));
-
-    DCHECK_EQ(null_count, 0);
-    *out_num_values = num_valid_values;
-    return Status::OK();
+      DCHECK_EQ(null_count, 0);
+      *out_num_values = num_valid_values;
+      return Status::OK();
+    };
+    return DispatchArrowBinaryHelper<DType>(out, num_values, /*estimated_data_length=*/{},
+                                            visit_binary_helper);
   }
 
   MemoryPool* pool_;

--- a/cpp/src/parquet/encoder.cc
+++ b/cpp/src/parquet/encoder.cc
@@ -24,6 +24,7 @@
 #include <memory>
 #include <string>
 #include <string_view>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -66,6 +67,21 @@ namespace {
 // The Parquet spec isn't very clear whether ByteArray lengths are signed or
 // unsigned, but the Java implementation uses signed ints.
 constexpr size_t kMaxByteArraySize = std::numeric_limits<int32_t>::max();
+
+// Get the data size of a Array binary-like array
+template <typename ArrayType>
+int64_t GetBinaryDataSize(const ArrayType& array) {
+  return array.value_offset(array.length()) - array.value_offset(0);
+}
+
+template <>
+int64_t GetBinaryDataSize(const ::arrow::BinaryViewArray& array) {
+  int64_t total_size = 0;
+  ::arrow::VisitArraySpanInline<::arrow::BinaryViewType>(
+      *array.data(),
+      [&](std::string_view v) { total_size += static_cast<int64_t>(v.size()); }, [] {});
+  return total_size;
+}
 
 class EncoderImpl : virtual public Encoder {
  public:
@@ -158,8 +174,7 @@ class PlainEncoder : public EncoderImpl, virtual public TypedEncoder<DType> {
  protected:
   template <typename ArrayType>
   void PutBinaryArray(const ArrayType& array) {
-    const int64_t total_bytes =
-        array.value_offset(array.length()) - array.value_offset(0);
+    const int64_t total_bytes = GetBinaryDataSize(array);
     PARQUET_THROW_NOT_OK(sink_.Reserve(total_bytes + array.length() * sizeof(uint32_t)));
 
     PARQUET_THROW_NOT_OK(::arrow::VisitArraySpanInline<typename ArrayType::TypeClass>(
@@ -249,21 +264,24 @@ void PlainEncoder<DType>::Put(const ::arrow::Array& values) {
   ParquetException::NYI("direct put of " + values.type()->ToString());
 }
 
-void AssertBaseBinary(const ::arrow::Array& values) {
-  if (!::arrow::is_base_binary_like(values.type_id())) {
-    throw ParquetException("Only BaseBinaryArray and subclasses supported");
+void AssertVarLengthBinary(const ::arrow::Array& values) {
+  if (!::arrow::is_base_binary_like(values.type_id()) &&
+      !::arrow::is_binary_view_like(values.type_id())) {
+    throw ParquetException("Only binary-like data supported");
   }
 }
 
 template <>
 inline void PlainEncoder<ByteArrayType>::Put(const ::arrow::Array& values) {
-  AssertBaseBinary(values);
+  AssertVarLengthBinary(values);
 
   if (::arrow::is_binary_like(values.type_id())) {
     PutBinaryArray(checked_cast<const ::arrow::BinaryArray&>(values));
-  } else {
-    DCHECK(::arrow::is_large_binary_like(values.type_id()));
+  } else if (::arrow::is_large_binary_like(values.type_id())) {
     PutBinaryArray(checked_cast<const ::arrow::LargeBinaryArray&>(values));
+  } else {
+    DCHECK(::arrow::is_binary_view_like(values.type_id()));
+    PutBinaryArray(checked_cast<const ::arrow::BinaryViewArray&>(values));
   }
 }
 
@@ -752,12 +770,14 @@ void DictEncoderImpl<FLBAType>::Put(const ::arrow::Array& values) {
 
 template <>
 void DictEncoderImpl<ByteArrayType>::Put(const ::arrow::Array& values) {
-  AssertBaseBinary(values);
+  AssertVarLengthBinary(values);
   if (::arrow::is_binary_like(values.type_id())) {
     PutBinaryArray(checked_cast<const ::arrow::BinaryArray&>(values));
-  } else {
-    DCHECK(::arrow::is_large_binary_like(values.type_id()));
+  } else if (::arrow::is_large_binary_like(values.type_id())) {
     PutBinaryArray(checked_cast<const ::arrow::LargeBinaryArray&>(values));
+  } else {
+    DCHECK(::arrow::is_binary_view_like(values.type_id()));
+    PutBinaryArray(checked_cast<const ::arrow::BinaryViewArray&>(values));
   }
 }
 
@@ -803,14 +823,16 @@ void DictEncoderImpl<FLBAType>::PutDictionary(const ::arrow::Array& values) {
 
 template <>
 void DictEncoderImpl<ByteArrayType>::PutDictionary(const ::arrow::Array& values) {
-  AssertBaseBinary(values);
+  AssertVarLengthBinary(values);
   AssertCanPutDictionary(this, values);
 
   if (::arrow::is_binary_like(values.type_id())) {
     PutBinaryDictionaryArray(checked_cast<const ::arrow::BinaryArray&>(values));
-  } else {
-    DCHECK(::arrow::is_large_binary_like(values.type_id()));
+  } else if (::arrow::is_large_binary_like(values.type_id())) {
     PutBinaryDictionaryArray(checked_cast<const ::arrow::LargeBinaryArray&>(values));
+  } else {
+    DCHECK(::arrow::is_binary_view_like(values.type_id()));
+    PutBinaryDictionaryArray(checked_cast<const ::arrow::BinaryViewArray&>(values));
   }
 }
 
@@ -1304,11 +1326,15 @@ class DeltaLengthByteArrayEncoder : public EncoderImpl,
 };
 
 void DeltaLengthByteArrayEncoder::Put(const ::arrow::Array& values) {
-  AssertBaseBinary(values);
+  AssertVarLengthBinary(values);
   if (::arrow::is_binary_like(values.type_id())) {
     PutBinaryArray(checked_cast<const ::arrow::BinaryArray&>(values));
-  } else {
+  } else if (::arrow::is_large_binary_like(values.type_id())) {
     PutBinaryArray(checked_cast<const ::arrow::LargeBinaryArray&>(values));
+  } else if (::arrow::is_binary_view_like(values.type_id())) {
+    PutBinaryArray(checked_cast<const ::arrow::BinaryViewArray&>(values));
+  } else {
+    throw ParquetException("Only binary-like data supported");
   }
 }
 
@@ -1575,10 +1601,12 @@ void DeltaByteArrayEncoder<DType>::Put(const ::arrow::Array& values) {
     PutBinaryArray(checked_cast<const ::arrow::BinaryArray&>(values));
   } else if (::arrow::is_large_binary_like(values.type_id())) {
     PutBinaryArray(checked_cast<const ::arrow::LargeBinaryArray&>(values));
+  } else if (::arrow::is_binary_view_like(values.type_id())) {
+    PutBinaryArray(checked_cast<const ::arrow::BinaryViewArray&>(values));
   } else if (::arrow::is_fixed_size_binary(values.type_id())) {
     PutBinaryArray(checked_cast<const ::arrow::FixedSizeBinaryArray&>(values));
   } else {
-    throw ParquetException("Only BaseBinaryArray and subclasses supported");
+    throw ParquetException("Only binary-like data supported");
   }
 }
 

--- a/cpp/src/parquet/encoder.cc
+++ b/cpp/src/parquet/encoder.cc
@@ -1334,7 +1334,8 @@ void DeltaLengthByteArrayEncoder::Put(const ::arrow::Array& values) {
   } else if (::arrow::is_binary_view_like(values.type_id())) {
     PutBinaryArray(checked_cast<const ::arrow::BinaryViewArray&>(values));
   } else {
-    throw ParquetException("Only binary-like data supported");
+    throw ParquetException("Only binary-like data supported, got " +
+                           values.type()->ToString());
   }
 }
 

--- a/cpp/src/parquet/encoding.h
+++ b/cpp/src/parquet/encoding.h
@@ -126,11 +126,16 @@ struct EncodingTraits<ByteArrayType> {
   using Encoder = ByteArrayEncoder;
   using Decoder = ByteArrayDecoder;
 
-  using ArrowType = ::arrow::BinaryType;
-  /// \brief Internal helper class for decoding BYTE_ARRAY data where we can
-  /// overflow the capacity of a single arrow::BinaryArray
+  /// \brief Internal helper class for decoding BYTE_ARRAY data
+  ///
+  /// This class allows the caller to choose the concrete Arrow data type
+  /// by passing a corresponding `ArrayBuilder`.
+  /// Supported `ArrayBuilder` classes are `BinaryBuilder`, `LargeBinaryBuilder`
+  /// and `BinaryViewBuilder`.
+  /// If the builder is a `BinaryBuilder`, `chunks` can accumulate several
+  /// arrays as needed to work around the 32-bit offset limit.
   struct Accumulator {
-    std::unique_ptr<::arrow::BinaryBuilder> builder;
+    std::unique_ptr<::arrow::ArrayBuilder> builder;
     std::vector<std::shared_ptr<::arrow::Array>> chunks;
   };
   using DictAccumulator = ::arrow::Dictionary32Builder<::arrow::BinaryType>;

--- a/cpp/src/parquet/encryption/encryption_internal.cc
+++ b/cpp/src/parquet/encryption/encryption_internal.cc
@@ -23,6 +23,7 @@
 #include <openssl/rand.h>
 
 #include <algorithm>
+#include <array>
 #include <iostream>
 #include <memory>
 #include <sstream>

--- a/cpp/src/parquet/file_writer.cc
+++ b/cpp/src/parquet/file_writer.cc
@@ -23,6 +23,7 @@
 #include <utility>
 #include <vector>
 
+#include "arrow/util/endian.h"
 #include "arrow/util/key_value_metadata.h"
 #include "arrow/util/logging_internal.h"
 #include "parquet/column_writer.h"

--- a/cpp/src/parquet/geospatial/util_json_internal.h
+++ b/cpp/src/parquet/geospatial/util_json_internal.h
@@ -37,9 +37,10 @@ namespace parquet {
 ///
 /// The result of this function depends on whether or not "geoarrow.wkb" has been
 /// registered: if it has, the result will be the registered ExtensionType; if it has not,
-/// the result will be binary().
+/// the result will be the given storage_type.
 ::arrow::Result<std::shared_ptr<::arrow::DataType>> GeoArrowTypeFromLogicalType(
     const LogicalType& logical_type,
-    const std::shared_ptr<const ::arrow::KeyValueMetadata>& metadata);
+    const std::shared_ptr<const ::arrow::KeyValueMetadata>& metadata,
+    const std::shared_ptr<::arrow::DataType>& storage_type);
 
 }  // namespace parquet

--- a/cpp/src/parquet/statistics.cc
+++ b/cpp/src/parquet/statistics.cc
@@ -526,10 +526,14 @@ std::pair<ByteArray, ByteArray> GetMinMaxBinaryHelper(
   if (::arrow::is_binary_like(values.type_id())) {
     ::arrow::VisitArraySpanInline<::arrow::BinaryType>(
         *values.data(), std::move(valid_func), std::move(null_func));
-  } else {
-    DCHECK(::arrow::is_large_binary_like(values.type_id()));
+  } else if (::arrow::is_large_binary_like(values.type_id())) {
     ::arrow::VisitArraySpanInline<::arrow::LargeBinaryType>(
         *values.data(), std::move(valid_func), std::move(null_func));
+  } else if (::arrow::is_binary_view_like(values.type_id())) {
+    ::arrow::VisitArraySpanInline<::arrow::BinaryViewType>(
+        *values.data(), std::move(valid_func), std::move(null_func));
+  } else {
+    throw ParquetException("Only binary-like data supported");
   }
 
   return {min, max};

--- a/docs/source/cpp/parquet.rst
+++ b/docs/source/cpp/parquet.rst
@@ -418,33 +418,31 @@ Types
 Physical types
 ~~~~~~~~~~~~~~
 
-+--------------------------+-------------------------+------------+
-| Physical type            | Mapped Arrow type       | Notes      |
-+==========================+=========================+============+
-| BOOLEAN                  | Boolean                 |            |
-+--------------------------+-------------------------+------------+
-| INT32                    | Int32 / other           | \(1)       |
-+--------------------------+-------------------------+------------+
-| INT64                    | Int64 / other           | \(1)       |
-+--------------------------+-------------------------+------------+
-| INT96                    | Timestamp (nanoseconds) | \(2)       |
-+--------------------------+-------------------------+------------+
-| FLOAT                    | Float32                 |            |
-+--------------------------+-------------------------+------------+
-| DOUBLE                   | Float64                 |            |
-+--------------------------+-------------------------+------------+
-| BYTE_ARRAY               | Binary / other          | \(1) \(3)  |
-+--------------------------+-------------------------+------------+
-| FIXED_LENGTH_BYTE_ARRAY  | FixedSizeBinary / other | \(1)       |
-+--------------------------+-------------------------+------------+
++--------------------------+------------------------------------+------------+
+| Physical type            | Mapped Arrow type                  | Notes      |
++==========================+====================================+============+
+| BOOLEAN                  | Boolean                            |            |
++--------------------------+------------------------------------+------------+
+| INT32                    | Int32 / other                      | \(1)       |
++--------------------------+------------------------------------+------------+
+| INT64                    | Int64 / other                      | \(1)       |
++--------------------------+------------------------------------+------------+
+| INT96                    | Timestamp (nanoseconds)            | \(2)       |
++--------------------------+------------------------------------+------------+
+| FLOAT                    | Float32                            |            |
++--------------------------+------------------------------------+------------+
+| DOUBLE                   | Float64                            |            |
++--------------------------+------------------------------------+------------+
+| BYTE_ARRAY               | Binary / LargeBinary / BinaryView  | \(1)       |
++--------------------------+------------------------------------+------------+
+| FIXED_LENGTH_BYTE_ARRAY  | FixedSizeBinary / other            | \(1)       |
++--------------------------+------------------------------------+------------+
 
 * \(1) Can be mapped to other Arrow types, depending on the logical type
-  (see below).
+  (see table below).
 
 * \(2) On the write side, :func:`ArrowWriterProperties::support_deprecated_int96_timestamps`
   must be enabled.
-
-* \(3) On the write side, an Arrow LargeBinary can also mapped to BYTE_ARRAY.
 
 Logical types
 ~~~~~~~~~~~~~
@@ -475,11 +473,12 @@ physical type.
 | TIMESTAMP         | INT64                       | Timestamp (milli-, micro-  |         |
 |                   |                             | or nanoseconds)            |         |
 +-------------------+-----------------------------+----------------------------+---------+
-| STRING            | BYTE_ARRAY                  | Utf8                       | \(4)    |
+| STRING            | BYTE_ARRAY                  | String / LargeString /     |         |
+|                   |                             | StringView                 |         |
 +-------------------+-----------------------------+----------------------------+---------+
-| LIST              | Any                         | List                       | \(5)    |
+| LIST              | Any                         | List                       | \(4)    |
 +-------------------+-----------------------------+----------------------------+---------+
-| MAP               | Any                         | Map                        | \(6)    |
+| MAP               | Any                         | Map                        | \(5)    |
 +-------------------+-----------------------------+----------------------------+---------+
 | FLOAT16           | FIXED_LENGTH_BYTE_ARRAY     | HalfFloat                  |         |
 +-------------------+-----------------------------+----------------------------+---------+
@@ -490,12 +489,10 @@ physical type.
 
 * \(3) On the write side, an Arrow Date64 is also mapped to a Parquet DATE INT32.
 
-* \(4) On the write side, an Arrow LargeUtf8 is also mapped to a Parquet STRING.
-
-* \(5) On the write side, an Arrow LargeList or FixedSizedList is also mapped to
+* \(4) On the write side, an Arrow LargeList or FixedSizedList is also mapped to
   a Parquet LIST.
 
-* \(6) On the read side, a key with multiple values does not get deduplicated,
+* \(5) On the read side, a key with multiple values does not get deduplicated,
   in contradiction with the
   `Parquet specification <https://github.com/apache/parquet-format/blob/master/LogicalTypes.md#maps>`__.
 

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -32,6 +32,7 @@ from pyarrow.lib cimport (_Weakrefable, Buffer, Schema,
                           Table, KeyValueMetadata,
                           pyarrow_wrap_chunked_array,
                           pyarrow_wrap_schema,
+                          pyarrow_unwrap_data_type,
                           pyarrow_unwrap_metadata,
                           pyarrow_unwrap_schema,
                           pyarrow_wrap_table,
@@ -1551,7 +1552,8 @@ cdef class ParquetReader(_Weakrefable):
         self._metadata = None
 
     def open(self, object source not None, *, bint use_memory_map=False,
-             read_dictionary=None, FileMetaData metadata=None,
+             read_dictionary=None, binary_type=None,
+             FileMetaData metadata=None,
              int buffer_size=0, bint pre_buffer=False,
              coerce_int96_timestamp_unit=None,
              FileDecryptionProperties decryption_properties=None,
@@ -1567,6 +1569,7 @@ cdef class ParquetReader(_Weakrefable):
         source : str, pathlib.Path, pyarrow.NativeFile, or file-like object
         use_memory_map : bool, default False
         read_dictionary : iterable[int or str], optional
+        binary_type : pyarrow.DataType, optional
         metadata : FileMetaData, optional
         buffer_size : int, default 0
         pre_buffer : bool, default False
@@ -1617,6 +1620,10 @@ cdef class ParquetReader(_Weakrefable):
         arrow_props.set_pre_buffer(pre_buffer)
 
         properties.set_page_checksum_verification(page_checksum_verification)
+
+        if binary_type is not None:
+            c_binary_type = pyarrow_unwrap_data_type(binary_type)
+            arrow_props.set_binary_type(c_binary_type.get().id())
 
         if coerce_int96_timestamp_unit is None:
             # use the default defined in default_arrow_reader_properties()

--- a/python/pyarrow/includes/libarrow_dataset_parquet.pxd
+++ b/python/pyarrow/includes/libarrow_dataset_parquet.pxd
@@ -63,6 +63,7 @@ cdef extern from "arrow/dataset/api.h" namespace "arrow::dataset" nogil:
             "arrow::dataset::ParquetFileFormat::ReaderOptions":
         unordered_set[c_string] dict_columns
         TimeUnit coerce_int96_timestamp_unit
+        Type binary_type
 
     cdef cppclass CParquetFileFormat "arrow::dataset::ParquetFileFormat"(
             CFileFormat):

--- a/python/pyarrow/includes/libparquet.pxd
+++ b/python/pyarrow/includes/libparquet.pxd
@@ -18,8 +18,8 @@
 # distutils: language = c++
 
 from pyarrow.includes.common cimport *
-from pyarrow.includes.libarrow cimport (CChunkedArray, CScalar, CSchema, CStatus,
-                                        CTable, CMemoryPool, CBuffer,
+from pyarrow.includes.libarrow cimport (Type, CChunkedArray, CScalar, CSchema,
+                                        CStatus, CTable, CMemoryPool, CBuffer,
                                         CKeyValueMetadata, CRandomAccessFile,
                                         COutputStream, CCacheOptions,
                                         TimeUnit, CRecordBatchReader)
@@ -440,6 +440,8 @@ cdef extern from "parquet/api/reader.h" namespace "parquet" nogil:
 
     cdef cppclass ArrowReaderProperties:
         ArrowReaderProperties()
+        void set_binary_type(Type binary_type)
+        Type binary_type()
         void set_read_dictionary(int column_index, c_bool read_dict)
         c_bool read_dictionary(int column_index)
         void set_batch_size(int64_t batch_size)

--- a/python/pyarrow/lib.pxd
+++ b/python/pyarrow/lib.pxd
@@ -666,6 +666,8 @@ cdef shared_ptr[function[StreamWrapFunc]] make_streamwrap_func(
 # Default is allow_none=False
 cpdef DataType ensure_type(object type, bint allow_none=*)
 
+cdef DataType primitive_type(Type type)
+
 cdef timeunit_to_string(TimeUnit unit)
 cdef TimeUnit string_to_timeunit(unit) except *
 

--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -221,6 +221,10 @@ class ParquetFile:
         main file's metadata, no other uses at the moment.
     read_dictionary : list
         List of column names to read directly as DictionaryArray.
+    binary_type : pyarrow.DataType, default None
+        If given, Parquet binary columns will be read as this datatype.
+        This setting is ignored if a serialized Arrow schema is found in
+        the Parquet metadata.
     memory_map : bool, default False
         If the source is a file path, use a memory map to read file, which can
         improve performance in some environments.
@@ -300,8 +304,8 @@ class ParquetFile:
     """
 
     def __init__(self, source, *, metadata=None, common_metadata=None,
-                 read_dictionary=None, memory_map=False, buffer_size=0,
-                 pre_buffer=False, coerce_int96_timestamp_unit=None,
+                 read_dictionary=None, binary_type=None, memory_map=False,
+                 buffer_size=0, pre_buffer=False, coerce_int96_timestamp_unit=None,
                  decryption_properties=None, thrift_string_size_limit=None,
                  thrift_container_size_limit=None, filesystem=None,
                  page_checksum_verification=False, arrow_extensions_enabled=False):
@@ -319,6 +323,7 @@ class ParquetFile:
             source, use_memory_map=memory_map,
             buffer_size=buffer_size, pre_buffer=pre_buffer,
             read_dictionary=read_dictionary, metadata=metadata,
+            binary_type=binary_type,
             coerce_int96_timestamp_unit=coerce_int96_timestamp_unit,
             decryption_properties=decryption_properties,
             thrift_string_size_limit=thrift_string_size_limit,
@@ -1193,6 +1198,10 @@ read_dictionary : list, default None
     nested types, you must pass the full column "path", which could be
     something like level1.level2.list.item. Refer to the Parquet
     file's schema to obtain the paths.
+binary_type : pyarrow.DataType, default None
+    If given, Parquet binary columns will be read as this datatype.
+    This setting is ignored if a serialized Arrow schema is found in
+    the Parquet metadata.
 memory_map : bool, default False
     If the source is a file path, use a memory map to read file, which can
     improve performance in some environments.
@@ -1312,9 +1321,9 @@ Examples
 """
 
     def __init__(self, path_or_paths, filesystem=None, schema=None, *, filters=None,
-                 read_dictionary=None, memory_map=False, buffer_size=None,
-                 partitioning="hive", ignore_prefixes=None, pre_buffer=True,
-                 coerce_int96_timestamp_unit=None,
+                 read_dictionary=None, binary_type=None, memory_map=False,
+                 buffer_size=None, partitioning="hive", ignore_prefixes=None,
+                 pre_buffer=True, coerce_int96_timestamp_unit=None,
                  decryption_properties=None, thrift_string_size_limit=None,
                  thrift_container_size_limit=None,
                  page_checksum_verification=False,
@@ -1329,6 +1338,7 @@ Examples
             "thrift_container_size_limit": thrift_container_size_limit,
             "page_checksum_verification": page_checksum_verification,
             "arrow_extensions_enabled": arrow_extensions_enabled,
+            "binary_type": binary_type,
         }
         if buffer_size:
             read_options.update(use_buffered_stream=True,
@@ -1809,7 +1819,7 @@ Read data from a single Parquet file:
 
 def read_table(source, *, columns=None, use_threads=True,
                schema=None, use_pandas_metadata=False, read_dictionary=None,
-               memory_map=False, buffer_size=0, partitioning="hive",
+               binary_type=None, memory_map=False, buffer_size=0, partitioning="hive",
                filesystem=None, filters=None, ignore_prefixes=None,
                pre_buffer=True, coerce_int96_timestamp_unit=None,
                decryption_properties=None, thrift_string_size_limit=None,
@@ -1825,6 +1835,7 @@ def read_table(source, *, columns=None, use_threads=True,
             partitioning=partitioning,
             memory_map=memory_map,
             read_dictionary=read_dictionary,
+            binary_type=binary_type,
             buffer_size=buffer_size,
             filters=filters,
             ignore_prefixes=ignore_prefixes,
@@ -1860,6 +1871,7 @@ def read_table(source, *, columns=None, use_threads=True,
         # TODO test that source is not a directory or a list
         dataset = ParquetFile(
             source, read_dictionary=read_dictionary,
+            binary_type=binary_type,
             memory_map=memory_map, buffer_size=buffer_size,
             pre_buffer=pre_buffer,
             coerce_int96_timestamp_unit=coerce_int96_timestamp_unit,

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -845,6 +845,7 @@ def test_parquet_read_options():
     opts1 = ds.ParquetReadOptions()
     opts2 = ds.ParquetReadOptions(dictionary_columns=['a', 'b'])
     opts3 = ds.ParquetReadOptions(coerce_int96_timestamp_unit="ms")
+    opts4 = ds.ParquetReadOptions(binary_type=pa.binary_view())
 
     assert opts1.dictionary_columns == set()
 
@@ -853,9 +854,20 @@ def test_parquet_read_options():
     assert opts1.coerce_int96_timestamp_unit == "ns"
     assert opts3.coerce_int96_timestamp_unit == "ms"
 
+    assert opts1.binary_type == pa.binary()
+    assert opts4.binary_type == pa.binary_view()
+
     assert opts1 == opts1
     assert opts1 != opts2
     assert opts1 != opts3
+    assert opts1 != opts4
+
+    opts4.binary_type = None
+    assert opts4.binary_type == pa.binary()
+    assert opts1 == opts4
+    opts4.binary_type = pa.large_binary()
+    assert opts4.binary_type == pa.large_binary()
+    assert opts1 != opts4
 
 
 @pytest.mark.parquet
@@ -863,11 +875,14 @@ def test_parquet_file_format_read_options():
     pff1 = ds.ParquetFileFormat()
     pff2 = ds.ParquetFileFormat(dictionary_columns={'a'})
     pff3 = ds.ParquetFileFormat(coerce_int96_timestamp_unit="s")
+    pff4 = ds.ParquetFileFormat(binary_type=pa.binary_view())
 
     assert pff1.read_options == ds.ParquetReadOptions()
     assert pff2.read_options == ds.ParquetReadOptions(dictionary_columns=['a'])
     assert pff3.read_options == ds.ParquetReadOptions(
         coerce_int96_timestamp_unit="s")
+    assert pff4.read_options == ds.ParquetReadOptions(
+        binary_type=pa.binary_view())
 
 
 @pytest.mark.parquet


### PR DESCRIPTION
### Rationale for this change

Parquet has almost no support for LargeBinary and BinaryView data:
* on writing, those types are not supported at all
* on reading, data is decoded as regular Binary data with automatic chunking; if the stored Arrow schema points to a LargeBinary field, the data is later cast to that type

### What changes are included in this PR?

* Refactor the BYTE_ARRAY column decoders to allow decoding directly into a LargeBinaryBuilder or a BinaryViewBuilder
* Add a `binary_type` setting to `ArrowReaderProperties` to change the type that BYTE_ARRAY columns are decoded to by default
* Support reading Parquet GEOMETRY types with a LargeBinary or BinaryView storage
* Add benchmarks for reading and writing BinaryView data from/to Parquet
* Add the corresponding Python bindings

### Are these changes tested?

Yes.

### Are there any user-facing changes?

New APIs and improved functionality.

* GitHub Issue: #43041