### PR TITLE
GH-46435: [Parquet][C++] Fix uninitialized value in writer test

### DIFF
--- a/cpp/src/parquet/column_writer_test.cc
+++ b/cpp/src/parquet/column_writer_test.cc
@@ -1999,7 +1999,7 @@ TEST_F(TestGeometryValuesWriter, TestWriteAndReadAllNull) {
   std::fill(this->def_levels_.begin(), this->def_levels_.end(), 0);
   auto writer = this->BuildWriter(SMALL_SIZE);
   writer->WriteBatch(this->values_.size(), this->def_levels_.data(), nullptr,
-                     this->values_ptr_);
+                     this->values_.data());
 
   writer->Close();
   this->ReadColumn();


### PR DESCRIPTION
### Rationale for this change

The test-conda-cpp-valgrind nightly is failing.

### What changes are included in this PR?

The value pointer was fixed to point to the correct value source.

### Are these changes tested?

Yes

### Are there any user-facing changes?

No

* GitHub Issue: #46435