### PR TITLE
GH-44801: [Docs] Help visitors find other `apache/arrow-___` repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,13 @@ enable data systems to efficiently store, process, and move data.
 
 Major components of the project include:
 
- - [The Arrow Columnar In-Memory Format](https://arrow.apache.org/docs/dev/format/Columnar.html):
+ - [The Arrow Columnar Format](https://arrow.apache.org/docs/dev/format/Columnar.html):
    a standard and efficient in-memory representation of various datatypes, plain or nested
  - [The Arrow IPC Format](https://arrow.apache.org/docs/dev/format/Columnar.html#serialization-and-interprocess-communication-ipc):
    an efficient serialization of the Arrow format and associated metadata,
    for communication between processes and heterogeneous environments
+ - [ADBC (Arrow Database Connectivity)](https://github.com/apache/arrow-adbc/) `↗`: Arrow-powered API,
+   drivers, and libraries for access to databases and query engines
  - [The Arrow Flight RPC protocol](https://github.com/apache/arrow/tree/main/format/Flight.proto):
    based on the Arrow IPC format, a building block for remote services exchanging
    Arrow data with application-defined semantics (for example a storage server or a database)
@@ -44,13 +46,17 @@ Major components of the project include:
  - [C# .NET libraries](https://github.com/apache/arrow/tree/main/csharp)
  - [Gandiva](https://github.com/apache/arrow/tree/main/cpp/src/gandiva):
    an [LLVM](https://llvm.org)-based Arrow expression compiler, part of the C++ codebase
- - [Go libraries](https://github.com/apache/arrow-go)
- - [Java libraries](https://github.com/apache/arrow-java)
- - [JavaScript libraries](https://github.com/apache/arrow/tree/main/js)
+ - [Go libraries](https://github.com/apache/arrow-go) `↗`
+ - [Java libraries](https://github.com/apache/arrow-java) `↗`
+ - [JavaScript libraries](https://github.com/apache/arrow-js) `↗`
+ - [Julia implementation](https://github.com/apache/arrow-julia) `↗`
  - [Python libraries](https://github.com/apache/arrow/tree/main/python)
  - [R libraries](https://github.com/apache/arrow/tree/main/r)
  - [Ruby libraries](https://github.com/apache/arrow/tree/main/ruby)
- - [Rust libraries](https://github.com/apache/arrow-rs)
+ - [Rust libraries](https://github.com/apache/arrow-rs) `↗`
+
+The `↗` icon denotes that this component of the project is maintained in a separate
+repository.
 
 Arrow is an [Apache Software Foundation](https://www.apache.org) project. Learn more at
 [arrow.apache.org](https://arrow.apache.org).

--- a/docs/source/developers/guide/step_by_step/arrow_codebase.rst
+++ b/docs/source/developers/guide/step_by_step/arrow_codebase.rst
@@ -36,14 +36,16 @@ The `Apache Arrow repository <https://github.com/apache/arrow>`_ includes
 implementations for most of the libraries for which Arrow is available.
 
 Languages like GLib (``c_glib/``), C++ (``cpp/``), C# (``csharp/``),
-JavaScript (``js/``), MATLAB (``matlab/``), Python (``python/``), R (``r/``)
-and Ruby (``ruby/``) have their own subdirectories in the main folder as written here.
+MATLAB (``matlab/``), Python (``python/``), R (``r/``) and Ruby (``ruby/``)
+have their own subdirectories in the main folder as written here.
 
 The following language implementations have their own repositories:
 
 - `Rust <https://github.com/apache/arrow-rs>`_
 - `Go <https://github.com/apache/arrow-go>`_
 - `Java <https://github.com/apache/arrow-java>`_
+- `JavaScript <https://github.com/apache/arrow-js>`_
+- `Julia <https://github.com/apache/arrow-julia>`_
 
 In the **language-specific subdirectories** you can find the code
 connected to that language. For example:


### PR DESCRIPTION
Updates the README and a guide to help users find the separate `apache/arrow-___` repositories. Closes #44801.
* GitHub Issue: #44801