### PR TITLE
GH-46403: [C++] Add support for limiting element size when printing data

### DIFF
--- a/cpp/src/arrow/pretty_print.cc
+++ b/cpp/src/arrow/pretty_print.cc
@@ -59,9 +59,9 @@ class PrettyPrinter {
       : options_(options), indent_(options.indent), sink_(sink) {}
 
   inline void Write(std::string_view data);
-  inline void Write(std::string_view data, uint64_t max_chars);
+  inline void Write(std::string_view data, int max_chars);
   inline void WriteIndented(std::string_view data);
-  inline void WriteIndented(std::string_view data, uint64_t max_chars);
+  inline void WriteIndented(std::string_view data, int max_chars);
   inline void Newline();
   inline void Indent();
   inline void IndentAfterNewline();
@@ -110,9 +110,9 @@ void PrettyPrinter::Write(std::string_view data) {
   Write(data, options_.element_size_limit);
 }
 
-void PrettyPrinter::Write(std::string_view data, const uint64_t max_chars) {
+void PrettyPrinter::Write(std::string_view data, const int max_chars) {
   (*sink_) << data.substr(0, max_chars);
-  if (data.size() > max_chars) {
+  if (data.size() > static_cast<uint64_t>(max_chars)) {
     (*sink_) << " (... " << data.size() - max_chars << " chars omitted)";
   }
 }
@@ -122,7 +122,7 @@ void PrettyPrinter::WriteIndented(std::string_view data) {
   Write(data, options_.element_size_limit);
 }
 
-void PrettyPrinter::WriteIndented(std::string_view data, const uint64_t max_chars) {
+void PrettyPrinter::WriteIndented(std::string_view data, const int max_chars) {
   Indent();
   Write(data, max_chars);
 }

--- a/cpp/src/arrow/pretty_print.cc
+++ b/cpp/src/arrow/pretty_print.cc
@@ -110,10 +110,11 @@ void PrettyPrinter::Write(std::string_view data) {
   Write(data, options_.element_size_limit);
 }
 
-void PrettyPrinter::Write(std::string_view data, const int max_chars) {
+void PrettyPrinter::Write(std::string_view data, int max_chars) {
   (*sink_) << data.substr(0, max_chars);
-  if (data.size() > static_cast<uint64_t>(max_chars)) {
-    (*sink_) << " (... " << data.size() - max_chars << " chars omitted)";
+  if (data.size() > static_cast<size_t>(max_chars)) {
+    (*sink_) << " (... " << data.size() - static_cast<size_t>(max_chars)
+             << " chars omitted)";
   }
 }
 
@@ -122,7 +123,7 @@ void PrettyPrinter::WriteIndented(std::string_view data) {
   Write(data, options_.element_size_limit);
 }
 
-void PrettyPrinter::WriteIndented(std::string_view data, const int max_chars) {
+void PrettyPrinter::WriteIndented(std::string_view data, int max_chars) {
   Indent();
   Write(data, max_chars);
 }
@@ -192,7 +193,7 @@ class ArrayPrinter : public PrettyPrinter {
 
   template <typename ArrayType, typename Formatter>
   Status WritePrimitiveValues(const ArrayType& array, Formatter* formatter) {
-    auto appender = [&](std::string_view v) { this->Write(v); };
+    auto appender = [&](std::string_view v) { Write(v); };
     auto format_func = [&](int64_t i) {
       (*formatter)(array.GetView(i), appender);
       return Status::OK();

--- a/cpp/src/arrow/pretty_print.cc
+++ b/cpp/src/arrow/pretty_print.cc
@@ -59,9 +59,9 @@ class PrettyPrinter {
       : options_(options), indent_(options.indent), sink_(sink) {}
 
   inline void Write(std::string_view data);
-  inline void Write(std::string_view data, const int max_chars);
+  inline void Write(std::string_view data, uint64_t max_chars);
   inline void WriteIndented(std::string_view data);
-  inline void WriteIndented(std::string_view data, const int max_chars);
+  inline void WriteIndented(std::string_view data, uint64_t max_chars);
   inline void Newline();
   inline void Indent();
   inline void IndentAfterNewline();
@@ -110,15 +110,10 @@ void PrettyPrinter::Write(std::string_view data) {
   Write(data, options_.element_size_limit);
 }
 
-void PrettyPrinter::Write(std::string_view data, const int max_chars) {
-  int curr_max = max_chars;
-  for (auto c : data) {
-    if (curr_max-- > 0) {
-      sink_->put(c);
-    } else {
-      (*sink_) << " (... " << data.size() - max_chars << " chars omitted)";
-      return;
-    }
+void PrettyPrinter::Write(std::string_view data, const uint64_t max_chars) {
+  (*sink_) << data.substr(0, max_chars);
+  if (data.size() > max_chars) {
+    (*sink_) << " (... " << data.size() - max_chars << " chars omitted)";
   }
 }
 
@@ -127,7 +122,7 @@ void PrettyPrinter::WriteIndented(std::string_view data) {
   Write(data, options_.element_size_limit);
 }
 
-void PrettyPrinter::WriteIndented(std::string_view data, const int max_chars) {
+void PrettyPrinter::WriteIndented(std::string_view data, const uint64_t max_chars) {
   Indent();
   Write(data, max_chars);
 }

--- a/cpp/src/arrow/pretty_print.h
+++ b/cpp/src/arrow/pretty_print.h
@@ -58,14 +58,15 @@ struct ARROW_EXPORT PrettyPrintOptions {
   PrettyPrintOptions(int indent,  // NOLINT runtime/explicit
                      int window = 10, int indent_size = 2, std::string null_rep = "null",
                      bool skip_new_lines = false, bool truncate_metadata = true,
-                     int container_window = 2)
+                     int container_window = 2, int max_element_length = 100)
       : indent(indent),
         indent_size(indent_size),
         window(window),
         container_window(container_window),
         null_rep(std::move(null_rep)),
         skip_new_lines(skip_new_lines),
-        truncate_metadata(truncate_metadata) {}
+        truncate_metadata(truncate_metadata),
+        element_size_limit(max_element_length) {}
 
   /// Create a PrettyPrintOptions instance with default values
   static PrettyPrintOptions Defaults() { return PrettyPrintOptions(); }
@@ -98,6 +99,9 @@ struct ARROW_EXPORT PrettyPrintOptions {
 
   /// If true, display schema metadata when pretty-printing a Schema
   bool show_schema_metadata = true;
+
+  /// Limit each element to specified number of characters, defaults to 100
+  int element_size_limit = 100;
 
   /// Delimiters to use when printing an Array
   PrettyPrintDelimiters array_delimiters = PrettyPrintDelimiters::Defaults();

--- a/cpp/src/arrow/pretty_print.h
+++ b/cpp/src/arrow/pretty_print.h
@@ -58,7 +58,7 @@ struct ARROW_EXPORT PrettyPrintOptions {
   PrettyPrintOptions(int indent,  // NOLINT runtime/explicit
                      int window = 10, int indent_size = 2, std::string null_rep = "null",
                      bool skip_new_lines = false, bool truncate_metadata = true,
-                     int container_window = 2, int max_element_length = 100)
+                     int container_window = 2, int element_size_limit = 100)
       : indent(indent),
         indent_size(indent_size),
         window(window),
@@ -66,7 +66,7 @@ struct ARROW_EXPORT PrettyPrintOptions {
         null_rep(std::move(null_rep)),
         skip_new_lines(skip_new_lines),
         truncate_metadata(truncate_metadata),
-        element_size_limit(max_element_length) {}
+        element_size_limit(element_size_limit) {}
 
   /// Create a PrettyPrintOptions instance with default values
   static PrettyPrintOptions Defaults() { return PrettyPrintOptions(); }

--- a/cpp/src/arrow/pretty_print_test.cc
+++ b/cpp/src/arrow/pretty_print_test.cc
@@ -772,6 +772,11 @@ TEST_F(TestPrettyPrint, BinaryNoNewlines) {
   options.window = 2;
   expected = "[666F6F,626172,...,,FF]";
   CheckPrimitive<BinaryType, std::string>(options, is_valid, values, expected, false);
+
+  // With truncated element size
+  options.element_size_limit = 1;
+  expected = "[6+5,6+5,...,,F+1]";
+  CheckPrimitive<BinaryType, std::string>(options, is_valid, values, expected, false);
 }
 
 template <typename TypeClass>
@@ -1417,6 +1422,7 @@ lorem: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla accumsan 
           sapien commodo massa, vel volutpat orci nisi eu justo. Nulla non blandit
           sapien. Quisque pretium vestibulum urna eu vehicula.')";
   options.truncate_metadata = false;
+  options.element_size_limit = 10000;
   Check(*my_schema, options, expected_verbose);
 
   // Metadata that exactly fits

--- a/cpp/src/arrow/pretty_print_test.cc
+++ b/cpp/src/arrow/pretty_print_test.cc
@@ -25,6 +25,7 @@
 #include <memory>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "arrow/array.h"
@@ -47,37 +48,37 @@ class TestPrettyPrint : public ::testing::Test {
 };
 
 template <typename T>
-void CheckStream(const T& obj, const PrettyPrintOptions& options, const char* expected) {
+void CheckStream(const T& obj, const PrettyPrintOptions& options,
+                 std::string_view expected) {
   std::ostringstream sink;
   ASSERT_OK(PrettyPrint(obj, options, &sink));
   std::string result = sink.str();
-  ASSERT_EQ(std::string(expected, strlen(expected)), result);
+  ASSERT_EQ(expected, result);
 }
 
-void CheckArray(const Array& arr, const PrettyPrintOptions& options, const char* expected,
-                bool check_operator = true) {
+void CheckArray(const Array& arr, const PrettyPrintOptions& options,
+                std::string_view expected, bool check_operator = true) {
   ARROW_SCOPED_TRACE("For datatype: ", arr.type()->ToString());
   CheckStream(arr, options, expected);
 
-  if (options.indent == 0 && check_operator) {
+  if (options.indent == 0 && options.element_size_limit == 100 && check_operator) {
     std::stringstream ss;
     ss << arr;
-    std::string result = std::string(expected, strlen(expected));
-    ASSERT_EQ(result, ss.str());
+    ASSERT_EQ(expected, ss.str());
   }
 }
 
 template <typename T>
-void Check(const T& obj, const PrettyPrintOptions& options, const char* expected) {
+void Check(const T& obj, const PrettyPrintOptions& options, std::string_view expected) {
   std::string result;
   ASSERT_OK(PrettyPrint(obj, options, &result));
-  ASSERT_EQ(std::string(expected, strlen(expected)), result);
+  ASSERT_EQ(expected, result);
 }
 
 template <typename TYPE, typename C_TYPE>
 void CheckPrimitive(const std::shared_ptr<DataType>& type,
                     const PrettyPrintOptions& options, const std::vector<bool>& is_valid,
-                    const std::vector<C_TYPE>& values, const char* expected,
+                    const std::vector<C_TYPE>& values, std::string_view expected,
                     bool check_operator = true) {
   std::shared_ptr<Array> array;
   ArrayFromVector<TYPE, C_TYPE>(type, is_valid, values, &array);
@@ -86,7 +87,7 @@ void CheckPrimitive(const std::shared_ptr<DataType>& type,
 
 template <typename TYPE, typename C_TYPE>
 void CheckPrimitive(const PrettyPrintOptions& options, const std::vector<bool>& is_valid,
-                    const std::vector<C_TYPE>& values, const char* expected,
+                    const std::vector<C_TYPE>& values, std::string_view expected,
                     bool check_operator = true) {
   CheckPrimitive<TYPE, C_TYPE>(TypeTraits<TYPE>::type_singleton(), options, is_valid,
                                values, expected, check_operator);
@@ -158,12 +159,12 @@ TEST_F(TestPrettyPrint, PrimitiveType) {
   ])expected";
   CheckPrimitive<DoubleType, double>({2, 10}, is_valid, values2, ex2_in2);
 
-  std::vector<std::string> values3 = {"foo", "bar", "", "baz", ""};
+  std::vector<std::string> values3 = {"foo", "bar", "", "a longer string", ""};
   static const char* ex3 = R"expected([
   "foo",
   "bar",
   null,
-  "baz",
+  "a longer string",
   null
 ])expected";
   CheckPrimitive<StringType, std::string>({0, 10}, is_valid, values3, ex3);
@@ -172,19 +173,19 @@ TEST_F(TestPrettyPrint, PrimitiveType) {
     "foo",
     "bar",
     null,
-    "baz",
+    "a longer string",
     null
   ])expected";
   CheckPrimitive<StringType, std::string>({2, 10}, is_valid, values3, ex3_in2);
   CheckPrimitive<LargeStringType, std::string>({2, 10}, is_valid, values3, ex3_in2);
 
   PrettyPrintOptions options{2, 10};
-  options.element_size_limit = 2;
+  options.element_size_limit = 8;
   static const char* ex3_in3 = R"expected(  [
-    " (... 3 chars omitted)",
-    " (... 3 chars omitted)",
+    "foo",
+    "bar",
     null,
-    " (... 3 chars omitted)",
+    "a long (... 9 chars omitted)",
     null
   ])expected";
   CheckPrimitive<StringType, std::string>(options, is_valid, values3, ex3_in3);
@@ -1139,6 +1140,12 @@ TEST_F(TestPrettyPrint, DecimalTypes) {
 
     static const char* ex = "[\n  123.4567,\n  456.7891,\n  null\n]";
     CheckArray(*array, {0}, ex);
+
+    auto options = PrettyPrintOptions();
+    options.element_size_limit = 3;
+    static const char* ex_2 =
+        "[\n  123 (... 5 chars omitted),\n  456 (... 5 chars omitted),\n  null\n]";
+    CheckArray(*array, options, ex_2);
   }
 }
 

--- a/cpp/src/arrow/pretty_print_test.cc
+++ b/cpp/src/arrow/pretty_print_test.cc
@@ -177,6 +177,18 @@ TEST_F(TestPrettyPrint, PrimitiveType) {
   ])expected";
   CheckPrimitive<StringType, std::string>({2, 10}, is_valid, values3, ex3_in2);
   CheckPrimitive<LargeStringType, std::string>({2, 10}, is_valid, values3, ex3_in2);
+
+  PrettyPrintOptions options{2, 10};
+  options.element_size_limit = 2;
+  static const char* ex3_in3 = R"expected(  [
+    " (... 3 chars omitted)",
+    " (... 3 chars omitted)",
+    null,
+    " (... 3 chars omitted)",
+    null
+  ])expected";
+  CheckPrimitive<StringType, std::string>(options, is_valid, values3, ex3_in3);
+  CheckPrimitive<LargeStringType, std::string>(options, is_valid, values3, ex3_in3);
 }
 
 TEST_F(TestPrettyPrint, PrimitiveTypeNoNewlines) {
@@ -775,7 +787,8 @@ TEST_F(TestPrettyPrint, BinaryNoNewlines) {
 
   // With truncated element size
   options.element_size_limit = 1;
-  expected = "[6+5,6+5,...,,F+1]";
+  expected =
+      "[6 (... 5 chars omitted),6 (... 5 chars omitted),...,,F (... 1 chars omitted)]";
   CheckPrimitive<BinaryType, std::string>(options, is_valid, values, expected, false);
 }
 
@@ -1108,6 +1121,12 @@ TEST_F(TestPrettyPrint, FixedSizeBinaryType) {
   CheckArray(*array, {0, 10}, ex);
   static const char* ex_2 = "  [\n    666F6F,\n    ...\n    62617A\n  ]";
   CheckArray(*array, {2, 1}, ex_2);
+
+  auto options = PrettyPrintOptions{2, 1};
+  options.element_size_limit = 3;
+  static const char* ex_3 =
+      "  [\n    666 (... 3 chars omitted),\n    ...\n    626 (... 3 chars omitted)\n  ]";
+  CheckArray(*array, options, ex_3);
 }
 
 TEST_F(TestPrettyPrint, DecimalTypes) {

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1384,9 +1384,8 @@ cdef class Array(_PandasConvertible):
         skip_new_lines : bool
             If the array should be rendered as a single line of text
             or if each element should be on its own line.
-        element_size_limit : int
-            Maximum number of characters of a single element before it is truncated,
-            by default ``100``.
+        element_size_limit : int, default 100
+            Maximum number of characters of a single element before it is truncated.
         """
         cdef:
             c_string result

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1357,7 +1357,8 @@ cdef class Array(_PandasConvertible):
         return f'{type_format}\n{self}'
 
     def to_string(self, *, int indent=2, int top_level_indent=0, int window=10,
-                  int container_window=2, c_bool skip_new_lines=False):
+                  int container_window=2, c_bool skip_new_lines=False,
+                  int max_element_length=100):
         """
         Render a "pretty-printed" string representation of the Array.
 
@@ -1383,6 +1384,9 @@ cdef class Array(_PandasConvertible):
         skip_new_lines : bool
             If the array should be rendered as a single line of text
             or if each element should be on its own line.
+        max_element_length : int
+            Maximum length of a single element before it is truncated,
+            by default ``100``.
         """
         cdef:
             c_string result
@@ -1392,6 +1396,7 @@ cdef class Array(_PandasConvertible):
             options = PrettyPrintOptions(top_level_indent, window)
             options.skip_new_lines = skip_new_lines
             options.indent_size = indent
+            options.element_size_limit = max_element_length
             check_status(
                 PrettyPrint(
                     deref(self.ap),

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1358,7 +1358,7 @@ cdef class Array(_PandasConvertible):
 
     def to_string(self, *, int indent=2, int top_level_indent=0, int window=10,
                   int container_window=2, c_bool skip_new_lines=False,
-                  int max_element_length=100):
+                  int element_size_limit=100):
         """
         Render a "pretty-printed" string representation of the Array.
 
@@ -1384,7 +1384,7 @@ cdef class Array(_PandasConvertible):
         skip_new_lines : bool
             If the array should be rendered as a single line of text
             or if each element should be on its own line.
-        max_element_length : int
+        element_size_limit : int
             Maximum length of a single element before it is truncated,
             by default ``100``.
         """
@@ -1396,7 +1396,7 @@ cdef class Array(_PandasConvertible):
             options = PrettyPrintOptions(top_level_indent, window)
             options.skip_new_lines = skip_new_lines
             options.indent_size = indent
-            options.element_size_limit = max_element_length
+            options.element_size_limit = element_size_limit
             check_status(
                 PrettyPrint(
                     deref(self.ap),

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1385,7 +1385,7 @@ cdef class Array(_PandasConvertible):
             If the array should be rendered as a single line of text
             or if each element should be on its own line.
         element_size_limit : int
-            Maximum length of a single element before it is truncated,
+            Maximum number of characters of a single element before it is truncated,
             by default ``100``.
         """
         cdef:

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -652,6 +652,7 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         c_bool truncate_metadata
         c_bool show_field_metadata
         c_bool show_schema_metadata
+        int element_size_limit
 
         @staticmethod
         PrettyPrintOptions Defaults()

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -116,7 +116,7 @@ cdef class ChunkedArray(_PandasConvertible):
         return f"{type_format}\n{self}"
 
     def to_string(self, *, int indent=0, int window=5, int container_window=2,
-                  c_bool skip_new_lines=False, int max_element_length=100):
+                  c_bool skip_new_lines=False, int element_size_limit=100):
         """
         Render a "pretty-printed" string representation of the ChunkedArray
 
@@ -137,7 +137,7 @@ cdef class ChunkedArray(_PandasConvertible):
         skip_new_lines : bool
             If the array should be rendered as a single line of text
             or if each element should be on its own line.
-        max_element_length : int
+        element_size_limit : int
             Maximum length of a single element before it is truncated,
             by default ``100``.
         Examples
@@ -155,7 +155,7 @@ cdef class ChunkedArray(_PandasConvertible):
             options = PrettyPrintOptions(indent, window)
             options.skip_new_lines = skip_new_lines
             options.container_window = container_window
-            options.element_size_limit = max_element_length
+            options.element_size_limit = element_size_limit
             check_status(
                 PrettyPrint(
                     deref(self.chunked_array),

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -1,3 +1,4 @@
+
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -137,9 +138,9 @@ cdef class ChunkedArray(_PandasConvertible):
         skip_new_lines : bool
             If the array should be rendered as a single line of text
             or if each element should be on its own line.
-        element_size_limit : int
-            Maximum number of characters of a single element before it is truncated,
-            by default ``100``.
+        element_size_limit : int, default 100
+            Maximum number of characters of a single element before it is truncated.
+
         Examples
         --------
         >>> import pyarrow as pa

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -138,7 +138,7 @@ cdef class ChunkedArray(_PandasConvertible):
             If the array should be rendered as a single line of text
             or if each element should be on its own line.
         element_size_limit : int
-            Maximum length of a single element before it is truncated,
+            Maximum number of characters of a single element before it is truncated,
             by default ``100``.
         Examples
         --------

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -116,7 +116,7 @@ cdef class ChunkedArray(_PandasConvertible):
         return f"{type_format}\n{self}"
 
     def to_string(self, *, int indent=0, int window=5, int container_window=2,
-                  c_bool skip_new_lines=False):
+                  c_bool skip_new_lines=False, int max_element_length=100):
         """
         Render a "pretty-printed" string representation of the ChunkedArray
 
@@ -137,7 +137,9 @@ cdef class ChunkedArray(_PandasConvertible):
         skip_new_lines : bool
             If the array should be rendered as a single line of text
             or if each element should be on its own line.
-
+        max_element_length : int
+            Maximum length of a single element before it is truncated,
+            by default ``100``.
         Examples
         --------
         >>> import pyarrow as pa
@@ -153,6 +155,7 @@ cdef class ChunkedArray(_PandasConvertible):
             options = PrettyPrintOptions(indent, window)
             options.skip_new_lines = skip_new_lines
             options.container_window = container_window
+            options.element_size_limit = max_element_length
             check_status(
                 PrettyPrint(
                     deref(self.chunked_array),

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -75,8 +75,8 @@ def test_constructor_raises():
 
 
 def test_list_format():
-    arr = pa.array([[1], None, [2, 3, None]])
-    result = arr.to_string()
+    arr = pa.array([[1], None, [200, 3, None]])
+    result = arr.to_string(element_size_limit=2)
     expected = """\
 [
   [
@@ -84,7 +84,7 @@ def test_list_format():
   ],
   null,
   [
-    2,
+    20 (... 1 chars omitted),
     3,
     null
   ]

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -75,17 +75,32 @@ def test_constructor_raises():
 
 
 def test_list_format():
-    arr = pa.array([[1], None, [200, 3, None]])
-    result = arr.to_string(element_size_limit=2)
+    arr = pa.array([["foo"], None, ["bar", "a longer string", None]])
+    result = arr.to_string()
     expected = """\
 [
   [
-    1
+    "foo"
   ],
   null,
   [
-    20 (... 1 chars omitted),
-    3,
+    "bar",
+    "a longer string",
+    null
+  ]
+]"""
+    assert result == expected
+
+    result = arr.to_string(element_size_limit=10)
+    expected = """\
+[
+  [
+    "foo"
+  ],
+  null,
+  [
+    "bar",
+    "a longer (... 7 chars omitted)",
     null
   ]
 ]"""

--- a/python/pyarrow/tests/test_schema.py
+++ b/python/pyarrow/tests/test_schema.py
@@ -321,7 +321,7 @@ bar: string
   -- field metadata --
   key3: 'value3'
 -- schema metadata --
-lorem: '{lorem[:100]} (... 612 chars omitted)'"""
+lorem: '{lorem[:100]} (... {len(lorem) - 100} chars omitted)'"""
 
     assert my_schema.to_string(truncate_metadata=False,
                                show_field_metadata=False) == f"""\

--- a/python/pyarrow/tests/test_schema.py
+++ b/python/pyarrow/tests/test_schema.py
@@ -321,14 +321,14 @@ bar: string
   -- field metadata --
   key3: 'value3'
 -- schema metadata --
-lorem: '{lorem[:100]} (... {len(lorem) - 100} chars omitted)'"""
+lorem: '{lorem[:92]} (... {len(lorem) - 91} chars omitted)"""
 
     assert my_schema.to_string(truncate_metadata=False,
                                show_field_metadata=False) == f"""\
 foo: int32 not null
 bar: string
 -- schema metadata --
-lorem: '{lorem}'"""
+lorem: '{lorem[:92]} (... {len(lorem) - 91} chars omitted)"""
 
     assert my_schema.to_string(truncate_metadata=False,
                                show_schema_metadata=False) == """\

--- a/python/pyarrow/tests/test_schema.py
+++ b/python/pyarrow/tests/test_schema.py
@@ -313,7 +313,7 @@ f0: int32
 key: 'valuexxxxxxxxxxxxxxxxxxxxxxxxxxxxx\
 xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'"""
 
-    assert my_schema.to_string(truncate_metadata=False, max_element_length=100) == f"""\
+    assert my_schema.to_string(truncate_metadata=False) == f"""\
 foo: int32 not null
   -- field metadata --
   key1: 'value1'

--- a/python/pyarrow/tests/test_schema.py
+++ b/python/pyarrow/tests/test_schema.py
@@ -321,7 +321,7 @@ bar: string
   -- field metadata --
   key3: 'value3'
 -- schema metadata --
-lorem: '{lorem}'"""
+lorem: '{lorem[:100]} (... {len(lorem) - 100} chars omitted)'"""
 
     assert my_schema.to_string(truncate_metadata=False,
                                show_field_metadata=False) == f"""\

--- a/python/pyarrow/tests/test_schema.py
+++ b/python/pyarrow/tests/test_schema.py
@@ -313,7 +313,7 @@ f0: int32
 key: 'valuexxxxxxxxxxxxxxxxxxxxxxxxxxxxx\
 xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'"""
 
-    assert my_schema.to_string(truncate_metadata=False) == f"""\
+    assert my_schema.to_string(truncate_metadata=False, max_element_length=100) == f"""\
 foo: int32 not null
   -- field metadata --
   key1: 'value1'

--- a/python/pyarrow/tests/test_schema.py
+++ b/python/pyarrow/tests/test_schema.py
@@ -321,7 +321,7 @@ bar: string
   -- field metadata --
   key3: 'value3'
 -- schema metadata --
-lorem: '{lorem[:100]} (... {len(lorem) - 100} chars omitted)'"""
+lorem: '{lorem[:100]} (... 612 chars omitted)'"""
 
     assert my_schema.to_string(truncate_metadata=False,
                                show_field_metadata=False) == f"""\

--- a/python/pyarrow/tests/test_schema.py
+++ b/python/pyarrow/tests/test_schema.py
@@ -324,11 +324,12 @@ bar: string
 lorem: '{lorem[:92]} (... {len(lorem) - 91} chars omitted)"""
 
     assert my_schema.to_string(truncate_metadata=False,
-                               show_field_metadata=False) == f"""\
+                               show_field_metadata=False,
+                               max_element_length=50) == f"""\
 foo: int32 not null
 bar: string
 -- schema metadata --
-lorem: '{lorem[:92]} (... {len(lorem) - 91} chars omitted)"""
+lorem: '{lorem[:50 - 8]} (... {len(lorem) - (50 - 9)} chars omitted)"""
 
     assert my_schema.to_string(truncate_metadata=False,
                                show_schema_metadata=False) == """\

--- a/python/pyarrow/tests/test_schema.py
+++ b/python/pyarrow/tests/test_schema.py
@@ -325,7 +325,7 @@ lorem: '{lorem[:92]} (... {len(lorem) - 91} chars omitted)"""
 
     assert my_schema.to_string(truncate_metadata=False,
                                show_field_metadata=False,
-                               max_element_length=50) == f"""\
+                               element_size_limit=50) == f"""\
 foo: int32 not null
 bar: string
 -- schema metadata --

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -3580,8 +3580,7 @@ cdef class Schema(_Weakrefable):
         show_schema_metadata : boolean, default True
             Display Schema-level KeyValueMetadata
         element_size_limit : int, default 100
-            Maximum length of a single element before it is truncated
-
+            Maximum number of characters of a single element before it is truncated.
         Returns
         -------
         str : the formatted output

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -3566,7 +3566,7 @@ cdef class Schema(_Weakrefable):
         return pyarrow_wrap_schema(new_schema)
 
     def to_string(self, truncate_metadata=True, show_field_metadata=True,
-                  show_schema_metadata=True):
+                  show_schema_metadata=True, max_element_length=100):
         """
         Return human-readable representation of Schema
 
@@ -3579,6 +3579,8 @@ cdef class Schema(_Weakrefable):
             Display Field-level KeyValueMetadata
         show_schema_metadata : boolean, default True
             Display Schema-level KeyValueMetadata
+        max_element_length : int, default 100
+            Maximum length of a single element before it is truncated
 
         Returns
         -------
@@ -3592,6 +3594,7 @@ cdef class Schema(_Weakrefable):
         options.truncate_metadata = truncate_metadata
         options.show_field_metadata = show_field_metadata
         options.show_schema_metadata = show_schema_metadata
+        options.element_size_limit = max_element_length
 
         with nogil:
             check_status(

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -3581,6 +3581,7 @@ cdef class Schema(_Weakrefable):
             Display Schema-level KeyValueMetadata
         element_size_limit : int, default 100
             Maximum number of characters of a single element before it is truncated.
+
         Returns
         -------
         str : the formatted output

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -3566,7 +3566,7 @@ cdef class Schema(_Weakrefable):
         return pyarrow_wrap_schema(new_schema)
 
     def to_string(self, truncate_metadata=True, show_field_metadata=True,
-                  show_schema_metadata=True, max_element_length=100):
+                  show_schema_metadata=True, element_size_limit=100):
         """
         Return human-readable representation of Schema
 
@@ -3579,7 +3579,7 @@ cdef class Schema(_Weakrefable):
             Display Field-level KeyValueMetadata
         show_schema_metadata : boolean, default True
             Display Schema-level KeyValueMetadata
-        max_element_length : int, default 100
+        element_size_limit : int, default 100
             Maximum length of a single element before it is truncated
 
         Returns
@@ -3594,7 +3594,7 @@ cdef class Schema(_Weakrefable):
         options.truncate_metadata = truncate_metadata
         options.show_field_metadata = show_field_metadata
         options.show_schema_metadata = show_schema_metadata
-        options.element_size_limit = max_element_length
+        options.element_size_limit = element_size_limit
 
         with nogil:
             check_status(


### PR DESCRIPTION
### Rationale for this change

#46403

### What changes are included in this PR?

A new PrettyPrinter option is added to limit elements to 100 characters by default.

### Are these changes tested?

Yes

### Are there any user-facing changes?

Yes, the default length for outputted elements when stringifying them is now different so if a user was relying on ToString of an array with large elements that result may now be changed.

* GitHub Issue: #46403