### PR TITLE
GH-46538: [CI][Packaging][AlmaLinux8] Ensure pip3

### DIFF
--- a/dev/tasks/linux-packages/apache-arrow/yum/almalinux-8/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/yum/almalinux-8/Dockerfile
@@ -63,4 +63,5 @@ RUN \
     vala \
     which \
     zlib-devel && \
-  dnf clean ${quiet} all
+  dnf clean ${quiet} all && \
+  ln -s pip3.9 /usr/bin/pip3


### PR DESCRIPTION
### Rationale for this change

AlmaLinux 8's `python39-pip` provides only `pip3.9`. It no longer provides `pip3`.

### What changes are included in this PR?

Add `pip3` symbolic link.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #46538