### PR TITLE
GH-46537: [Docs][C++] Add RunEndEncodedArray, FlatArray, and PrimitiveArray API Docs

### DIFF
--- a/docs/source/cpp/api/array.rst
+++ b/docs/source/cpp/api/array.rst
@@ -34,6 +34,14 @@ Base classes
    :project: arrow_cpp
    :members:
 
+.. doxygenclass:: arrow::FlatArray
+   :project: arrow_cpp
+   :members:
+
+.. doxygenclass:: arrow::PrimitiveArray
+   :project: arrow_cpp
+   :members:
+
 Factory functions
 =================
 
@@ -84,6 +92,11 @@ Extension arrays
 .. doxygenclass:: arrow::ExtensionArray
    :members:
 
+Run-End Encoded Array
+---------------------
+
+.. doxygenclass:: arrow::RunEndEncodedArray
+   :members:
 
 Chunked Arrays
 ==============


### PR DESCRIPTION
### Rationale for this change

The [Array](https://arrow.apache.org/docs/cpp/api/array.html) section of the API Doc
does not explain `FlatArray`, `PrimitiveArray`, and `RunEndEncodedArray` .

### What changes are included in this PR?

Add `FlatArray`, `PrimitiveArray`, and `RunEndEncodedArray` API docs

### Are these changes tested?

No. (Document only)

### Are there any user-facing changes?

No.
* GitHub Issue: #46537