### PR TITLE
GH-43132: [CI] Fix pre-commit Rat check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,13 @@ repos:
       - id: rat
         name: Release Audit Tool
         language: system
-        entry: bash -c "git archive HEAD --prefix=apache-arrow/ --output=arrow-src.tar && ./dev/release/run-rat.sh arrow-src.tar"
+        entry: |
+          bash -c " \
+            git archive HEAD \
+              --prefix=apache-arrow/ \
+              --output=apache-arrow.tar.gz && \
+              dev/release/run-rat.sh apache-arrow.tar.gz && \
+            rm -f apache-arrow.tar.gz"
         always_run: true
         pass_filenames: false
   - repo: https://github.com/hadolint/hadolint

--- a/dev/release/run-rat.sh
+++ b/dev/release/run-rat.sh
@@ -31,7 +31,7 @@ RELEASE_DIR=$(cd "$(dirname "$BASH_SOURCE")"; pwd)
 
 # generate the rat report
 $RAT $1 > rat.txt
-python $RELEASE_DIR/check-rat-report.py $RELEASE_DIR/rat_exclude_files.txt rat.txt > filtered_rat.txt
+${PYTHON:-python3} $RELEASE_DIR/check-rat-report.py $RELEASE_DIR/rat_exclude_files.txt rat.txt > filtered_rat.txt
 cat filtered_rat.txt
 UNAPPROVED=`cat filtered_rat.txt  | grep "NOT APPROVED" | wc -l`
 


### PR DESCRIPTION
### Rationale for this change

* Rat doesn't accept `.tar`
* `python` may not exist

### What changes are included in this PR?

* Use `.tar.gz` not `.tar`
* Use `python3` not `python` as the default Python command name
* Accept custom Python command name by `${PYTHON}` 

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #43132