### PR TITLE
GH-46548: [CI][Dev][R] Use pre-commit for cpplint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -141,6 +141,22 @@ repos:
           (
           ?^r/src/arrowExports\.cpp$|
           )
+  - repo: https://github.com/cpplint/cpplint
+    rev: 1.6.1
+    hooks:
+      - id: cpplint
+        name: R (C++) Lint
+        alias: r-cpp-lint
+        args:
+          - "--verbose=2"
+        types_or:
+          - c++
+        files: >-
+          ^r/src/
+        exclude: >-
+          (
+          ?^r/src/arrowExports\.cpp$|
+          )
   - repo: https://github.com/rubocop/rubocop
     rev: "v1.71.0"
     hooks:


### PR DESCRIPTION
### Rationale for this change

We want to migrate to pre-commit from `archery lint`.

### What changes are included in this PR?

Use pre-commit for cpplint against `r/src/`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #46548