### PR TITLE
GH-46373: [Python] Exercise fallback case on tests for parquet.read_table in case dataset is not available

### DIFF
--- a/python/pyarrow/tests/parquet/test_basic.py
+++ b/python/pyarrow/tests/parquet/test_basic.py
@@ -169,6 +169,30 @@ def test_invalid_source():
         pq.ParquetFile(None)
 
 
+def test_read_table_without_dataset(tempdir):
+    from unittest import mock
+
+    class MockParquetDataset:
+        def __init__(self, *args, **kwargs):
+            raise ImportError("MockParquetDataset")
+
+    path = tempdir / "test.parquet"
+    table = pa.table({"a": [1, 2, 3]})
+    _write_table(table, path)
+
+    with mock.patch('pyarrow.parquet.core.ParquetDataset', new=MockParquetDataset):
+        with pytest.raises(ValueError, match="the 'filters' keyword"):
+            pq.read_table(path, filters=[('integer', '=', 1)])
+        with pytest.raises(ValueError, match="the 'partitioning' keyword"):
+            pq.read_table(path, partitioning=['week', 'color'])
+        with pytest.raises(ValueError, match="the 'schema' argument"):
+            pq.read_table(path, schema=table.schema)
+        with pytest.raises(OSError, match="is a directory"):
+            pq.read_table(tempdir)
+        result = pq.read_table(path)
+        assert result == table
+
+
 @pytest.mark.slow
 def test_file_with_over_int16_max_row_groups():
     # PARQUET-1857: Parquet encryption support introduced a INT16_MAX upper

--- a/python/pyarrow/tests/parquet/test_basic.py
+++ b/python/pyarrow/tests/parquet/test_basic.py
@@ -187,7 +187,8 @@ def test_read_table_without_dataset(tempdir):
             pq.read_table(path, partitioning=['week', 'color'])
         with pytest.raises(ValueError, match="the 'schema' argument"):
             pq.read_table(path, schema=table.schema)
-        with pytest.raises(OSError, match="is a directory"):
+        # Error message varies depending on OS
+        with pytest.raises(OSError):
             pq.read_table(tempdir)
         result = pq.read_table(path)
         assert result == table


### PR DESCRIPTION
### Rationale for this change

Since we merged:
- https://github.com/apache/arrow/pull/39112

The fallback case were dataset is not available is not being tested on parquet.read_table (I did validate myself with a breakpoint).

### What changes are included in this PR?

Adds a basic test that checks the exercises that code path and tests the read_table method from `ParquetFile` instead of `ParquetDataset` in case dataset is not available.

### Are these changes tested?

Yes via CI.

### Are there any user-facing changes?

No

* GitHub Issue: #46373