### PR TITLE
GH-46544: [CI][Dev][Python] Use pre-commit for autopep8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,17 +48,6 @@ repos:
           ?^ci/docker/python-.*-wheel-windows-test-vs2022.*\.dockerfile$|
           )
         types: []
-  - repo: https://github.com/pycqa/flake8
-    rev: 6.1.0
-    hooks:
-      - id: flake8
-        name: Python Format
-        files: ^(python|dev|c_glib|integration)/
-        types:
-          - file
-          - python
-        exclude: vendored
-        args: [--config, python/setup.cfg]
   - repo: https://github.com/MarcoGorelli/cython-lint
     rev: v0.12.5
     hooks:
@@ -121,6 +110,43 @@ repos:
         alias: matlab-cpp-format
         files: >-
           ^matlab/src/cpp/
+  - repo: https://github.com/hhatto/autopep8
+    rev: v2.3.2
+    hooks:
+      - id: autopep8
+        name: Python Format
+        alias: python-format
+        args:
+          - "--global-config"
+          - "python/setup.cfg"
+          - "--ignore-local-config"
+          - "--in-place"
+        files: >-
+          ^(c_glib|dev|python)/
+        types:
+          - file
+        types_or:
+          - cython
+          - python
+        exclude: >-
+          (
+          ?^python/pyarrow/vendored/|
+          )
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.1.0
+    hooks:
+      - id: flake8
+        name: Python Lint
+        alias: python-lint
+        args:
+          - "--config"
+          - "python/setup.cfg"
+        files: >-
+          ^(c_glib|dev|python)/
+        exclude: >-
+          (
+          ?^python/pyarrow/vendored/|
+          )
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v14.0.6
     hooks:

--- a/c_glib/tool/generate-version-header.py
+++ b/c_glib/tool/generate-version-header.py
@@ -26,32 +26,32 @@ import re
 
 def main():
     parser = argparse.ArgumentParser(
-            description="Generate C header with version macros")
+        description="Generate C header with version macros")
     parser.add_argument(
-            "--library",
-            required=True,
-            help="The library name to use in macro prefixes")
+        "--library",
+        required=True,
+        help="The library name to use in macro prefixes")
     parser.add_argument(
-            "--version",
-            required=True,
-            help="The library version number")
+        "--version",
+        required=True,
+        help="The library version number")
     parser.add_argument(
-            "--input",
-            type=Path,
-            required=True,
-            help="Path to the input template file")
+        "--input",
+        type=Path,
+        required=True,
+        help="Path to the input template file")
     parser.add_argument(
-            "--output",
-            type=Path,
-            required=True,
-            help="Path to the output file to generate")
+        "--output",
+        type=Path,
+        required=True,
+        help="Path to the output file to generate")
 
     args = parser.parse_args()
 
     with open(args.input, "r", encoding="utf-8") as input_file, \
             open(args.output, "w", encoding="utf-8") as output_file:
         write_header(
-                input_file, output_file, args.library, args.version)
+            input_file, output_file, args.library, args.version)
 
 
 def write_header(
@@ -70,13 +70,13 @@ def write_header(
     availability_macros = generate_availability_macros(library_name)
 
     replacements = {
-            "VERSION_MAJOR": str(version_major),
-            "VERSION_MINOR": str(version_minor),
-            "VERSION_MICRO": str(version_micro),
-            "VERSION_TAG": version_tag,
-            "ENCODED_VERSIONS": encoded_versions,
-            "VISIBILITY_MACROS": visibility_macros,
-            "AVAILABILITY_MACROS": availability_macros,
+        "VERSION_MAJOR": str(version_major),
+        "VERSION_MINOR": str(version_minor),
+        "VERSION_MICRO": str(version_micro),
+        "VERSION_TAG": version_tag,
+        "ENCODED_VERSIONS": encoded_versions,
+        "VISIBILITY_MACROS": visibility_macros,
+        "AVAILABILITY_MACROS": availability_macros,
     }
 
     output_file.write(re.sub(
@@ -140,35 +140,35 @@ def generate_availability_macros(library: str) -> str:
 
 
 ALL_VERSIONS = [
-        (21, 0),
-        (20, 0),
-        (19, 0),
-        (18, 0),
-        (17, 0),
-        (16, 0),
-        (15, 0),
-        (14, 0),
-        (13, 0),
-        (12, 0),
-        (11, 0),
-        (10, 0),
-        (9, 0),
-        (8, 0),
-        (7, 0),
-        (6, 0),
-        (5, 0),
-        (4, 0),
-        (3, 0),
-        (2, 0),
-        (1, 0),
-        (0, 17),
-        (0, 16),
-        (0, 15),
-        (0, 14),
-        (0, 13),
-        (0, 12),
-        (0, 11),
-        (0, 10),
+    (21, 0),
+    (20, 0),
+    (19, 0),
+    (18, 0),
+    (17, 0),
+    (16, 0),
+    (15, 0),
+    (14, 0),
+    (13, 0),
+    (12, 0),
+    (11, 0),
+    (10, 0),
+    (9, 0),
+    (8, 0),
+    (7, 0),
+    (6, 0),
+    (5, 0),
+    (4, 0),
+    (3, 0),
+    (2, 0),
+    (1, 0),
+    (0, 17),
+    (0, 16),
+    (0, 15),
+    (0, 14),
+    (0, 13),
+    (0, 12),
+    (0, 11),
+    (0, 10),
 ]
 
 

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -827,7 +827,7 @@ cdef class SortingColumn:
 
     def __repr__(self):
         return f"{self.__class__.__name__}(column_index={self.column_index}, " \
-               f"descending={self.descending}, nulls_first={self.nulls_first})"
+            f"descending={self.descending}, nulls_first={self.nulls_first})"
 
     def __eq__(self, SortingColumn other):
         return (self.column_index == other.column_index and

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -1597,7 +1597,7 @@ def test_filesystem_from_uri_s3(s3_server):
     host, port, access_key, secret_key = s3_server['connection']
 
     uri = f"s3://{access_key}:{secret_key}@mybucket/foo/bar?scheme=http&" \
-          f"endpoint_override={host}:{port}&allow_bucket_creation=True"
+        f"endpoint_override={host}:{port}&allow_bucket_creation=True"
 
     fs, path = FileSystem.from_uri(uri)
     assert isinstance(fs, S3FileSystem)


### PR DESCRIPTION
### Rationale for this change

We want to migrate to pre-commit from `archery lint`.

### What changes are included in this PR?

Use pre-commit for `autoepep8`.

The current `archery lint` configuration limits only the following patterns:

https://github.com/apache/arrow/blob/197afc02026d6ded3c45f25dcee15a94294cc5ca/dev/archery/archery/utils/lint.py#L190-L198

```python
    patterns = ["python/benchmarks/**/*.py",
                "python/examples/**/*.py",
                "python/pyarrow/**/*.py",
                "python/pyarrow/**/*.pyx",
                "python/pyarrow/**/*.pxd",
                "python/pyarrow/**/*.pxi",
                "dev/*.py",
                "dev/archery/**/*.py",
                "dev/release/**/*.py"]
```

But this configuration targets all Python and Cython files under `c_glib/`, `dev/` and `python/` except `python/pyarrow/vendored/**`.

So this includes some format fixes. 

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #46544