### PR TITLE
GH-46551: [C++] Use `std::string_view` for type schema API

### DIFF
--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -1329,9 +1329,9 @@ bool RunEndEncodedType::RunEndTypeValid(const DataType& run_end_type) {
 
 namespace {
 
-std::unordered_multimap<std::string, int> CreateNameToIndexMap(
+std::unordered_multimap<std::string_view, int> CreateNameToIndexMap(
     const FieldVector& fields) {
-  std::unordered_multimap<std::string, int> name_to_index;
+  std::unordered_multimap<std::string_view, int> name_to_index;
   for (size_t i = 0; i < fields.size(); ++i) {
     name_to_index.emplace(fields[i]->name(), static_cast<int>(i));
   }
@@ -1339,8 +1339,8 @@ std::unordered_multimap<std::string, int> CreateNameToIndexMap(
 }
 
 template <int NotFoundValue = -1, int DuplicateFoundValue = -1>
-int LookupNameIndex(const std::unordered_multimap<std::string, int>& name_to_index,
-                    const std::string& name) {
+int LookupNameIndex(const std::unordered_multimap<std::string_view, int>& name_to_index,
+                    std::string_view name) {
   auto p = name_to_index.equal_range(name);
   auto it = p.first;
   if (it == p.second) {
@@ -1362,7 +1362,7 @@ class StructType::Impl {
   explicit Impl(const FieldVector& fields)
       : name_to_index_(CreateNameToIndexMap(fields)) {}
 
-  const std::unordered_multimap<std::string, int> name_to_index_;
+  const std::unordered_multimap<std::string_view, int> name_to_index_;
 };
 
 StructType::StructType(const FieldVector& fields)
@@ -2279,7 +2279,7 @@ class Schema::Impl {
 
   FieldVector fields_;
   Endianness endianness_;
-  std::unordered_multimap<std::string, int> name_to_index_;
+  std::unordered_multimap<std::string_view, int> name_to_index_;
   std::shared_ptr<const KeyValueMetadata> metadata_;
 };
 
@@ -2363,16 +2363,16 @@ bool Schema::Equals(const std::shared_ptr<Schema>& other, bool check_metadata) c
   return Equals(*other, check_metadata);
 }
 
-std::shared_ptr<Field> Schema::GetFieldByName(const std::string& name) const {
+std::shared_ptr<Field> Schema::GetFieldByName(std::string_view name) const {
   int i = GetFieldIndex(name);
   return i == -1 ? nullptr : impl_->fields_[i];
 }
 
-int Schema::GetFieldIndex(const std::string& name) const {
+int Schema::GetFieldIndex(std::string_view name) const {
   return LookupNameIndex(impl_->name_to_index_, name);
 }
 
-std::vector<int> Schema::GetAllFieldIndices(const std::string& name) const {
+std::vector<int> Schema::GetAllFieldIndices(std::string_view name) const {
   std::vector<int> result;
   auto p = impl_->name_to_index_.equal_range(name);
   for (auto it = p.first; it != p.second; ++it) {
@@ -2384,7 +2384,7 @@ std::vector<int> Schema::GetAllFieldIndices(const std::string& name) const {
   return result;
 }
 
-Status Schema::CanReferenceFieldByName(const std::string& name) const {
+Status Schema::CanReferenceFieldByName(std::string_view name) const {
   if (GetFieldByName(name) == nullptr) {
     return Status::Invalid("Field named '", name,
                            "' not found or not unique in the schema.");
@@ -2399,7 +2399,7 @@ Status Schema::CanReferenceFieldsByNames(const std::vector<std::string>& names) 
   return Status::OK();
 }
 
-FieldVector Schema::GetAllFieldsByName(const std::string& name) const {
+FieldVector Schema::GetAllFieldsByName(std::string_view name) const {
   FieldVector result;
   auto p = impl_->name_to_index_.equal_range(name);
   for (auto it = p.first; it != p.second; ++it) {
@@ -2580,7 +2580,7 @@ class SchemaBuilder::Impl {
 
  private:
   FieldVector fields_;
-  std::unordered_multimap<std::string, int> name_to_index_;
+  std::unordered_multimap<std::string_view, int> name_to_index_;
   std::shared_ptr<const KeyValueMetadata> metadata_;
   ConflictPolicy policy_;
   Field::MergeOptions field_merge_options_;

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -2366,19 +2366,19 @@ class ARROW_EXPORT Schema : public detail::Fingerprintable,
   std::vector<std::string> field_names() const;
 
   /// Returns null if name not found
-  std::shared_ptr<Field> GetFieldByName(const std::string& name) const;
+  std::shared_ptr<Field> GetFieldByName(std::string_view name) const;
 
   /// \brief Return the indices of all fields having this name in sorted order
-  FieldVector GetAllFieldsByName(const std::string& name) const;
+  FieldVector GetAllFieldsByName(std::string_view name) const;
 
   /// Returns -1 if name not found
-  int GetFieldIndex(const std::string& name) const;
+  int GetFieldIndex(std::string_view name) const;
 
   /// Return the indices of all fields having this name
-  std::vector<int> GetAllFieldIndices(const std::string& name) const;
+  std::vector<int> GetAllFieldIndices(std::string_view name) const;
 
   /// Indicate if field named `name` can be found unambiguously in the schema.
-  Status CanReferenceFieldByName(const std::string& name) const;
+  Status CanReferenceFieldByName(std::string_view name) const;
 
   /// Indicate if fields named `names` can be found unambiguously in the schema.
   Status CanReferenceFieldsByNames(const std::vector<std::string>& names) const;


### PR DESCRIPTION
### Rationale for this change

This change implements #46551. It refactors several methods and data structures in the `cpp/src/arrow/type.cc` and `cpp/src/arrow/type.h` files to replace `std::string` with `std::string_view` for improved performance and memory efficiency when handling string-like data. The changes primarily impact schema-related functionality.

### What changes are included in this PR?

All changes to the public schema API that were required to have methods take `std::string_view` instead of `const std::string&`.

### Are these changes tested?

Yes. Locally, no test results were altered.

### Are there any user-facing changes?

Yes. The method signatures in `Schema` and related classes were changed to accept `std::string_view` instead of `std::string`, including `GetFieldByName`, `GetFieldIndex`, `GetAllFieldIndices`, `GetAllFieldsByName`, and `CanReferenceFieldByName`. 

**This PR includes breaking changes to public APIs.**
* GitHub Issue: #46551