### PR TITLE
GH-46556: [GLib] Add GArrowUUIDDataType

### DIFF
--- a/c_glib/arrow-glib/basic-data-type.cpp
+++ b/c_glib/arrow-glib/basic-data-type.cpp
@@ -136,7 +136,7 @@ G_BEGIN_DECLS
  *
  * #GArrowFixedShapeTensorDataType is a class for the fixed shape tensor data type.
  *
- * #GArrowUuidDataType is a class for UUID data type.
+ * #GArrowUUIDDataType is a class for UUID data type.
  */
 
 struct GArrowDataTypePrivate
@@ -2487,15 +2487,15 @@ garrow_fixed_shape_tensor_data_type_get_strides(GArrowFixedShapeTensorDataType *
   return arrow_strides.data();
 }
 
-G_DEFINE_TYPE(GArrowUuidDataType, garrow_uuid_data_type, GARROW_TYPE_EXTENSION_DATA_TYPE)
+G_DEFINE_TYPE(GArrowUUIDDataType, garrow_uuid_data_type, GARROW_TYPE_EXTENSION_DATA_TYPE)
 
 static void
-garrow_uuid_data_type_init(GArrowUuidDataType *object)
+garrow_uuid_data_type_init(GArrowUUIDDataType *object)
 {
 }
 
 static void
-garrow_uuid_data_type_class_init(GArrowUuidDataTypeClass *klass)
+garrow_uuid_data_type_class_init(GArrowUUIDDataTypeClass *klass)
 {
 }
 
@@ -2508,7 +2508,7 @@ garrow_uuid_data_type_class_init(GArrowUuidDataTypeClass *klass)
  *
  * Since: 21.0.0
  */
-GArrowUuidDataType *
+GArrowUUIDDataType *
 garrow_uuid_data_type_new(GError **error)
 {
   auto arrow_data_type_result = arrow::extension::UuidType::Make();

--- a/c_glib/arrow-glib/basic-data-type.cpp
+++ b/c_glib/arrow-glib/basic-data-type.cpp
@@ -2506,6 +2506,7 @@ garrow_uuid_data_type_class_init(GArrowUuidDataTypeClass *klass)
  * Returns: (nullable):
  *   The newly created UUID data type on success, %NULL on error.
  *
+ * Since: 21.0.0
  */
 GArrowUuidDataType *
 garrow_uuid_data_type_new(GError **error)

--- a/c_glib/arrow-glib/basic-data-type.cpp
+++ b/c_glib/arrow-glib/basic-data-type.cpp
@@ -27,6 +27,7 @@
 
 #include <arrow/c/bridge.h>
 #include <arrow/extension/fixed_shape_tensor.h>
+#include <arrow/extension/uuid.h>
 
 G_BEGIN_DECLS
 
@@ -134,6 +135,8 @@ G_BEGIN_DECLS
  * #GArrowBinaryViewDataType is a class for the binary view data type.
  *
  * #GArrowFixedShapeTensorDataType is a class for the fixed shape tensor data type.
+ *
+ * #GArrowUuidDataType is a class for UUID data type.
  */
 
 struct GArrowDataTypePrivate
@@ -2482,6 +2485,39 @@ garrow_fixed_shape_tensor_data_type_get_strides(GArrowFixedShapeTensorDataType *
   const auto &arrow_strides = arrow_data_type->strides();
   *length = arrow_strides.size();
   return arrow_strides.data();
+}
+
+G_DEFINE_TYPE(GArrowUuidDataType, garrow_uuid_data_type, GARROW_TYPE_EXTENSION_DATA_TYPE)
+
+static void
+garrow_uuid_data_type_init(GArrowUuidDataType *object)
+{
+}
+
+static void
+garrow_uuid_data_type_class_init(GArrowUuidDataTypeClass *klass)
+{
+}
+
+/*
+ * garrow_uuid_data_type_new:
+ * @error: (nullable): Return location for a #GError or %NULL.
+ *
+ * Returns: (nullable):
+ *   The newly created UUID data type on success, %NULL on error.
+ *
+ */
+GArrowUuidDataType *
+garrow_uuid_data_type_new(GError **error)
+{
+  auto arrow_data_type_result = arrow::extension::UuidType::Make();
+  if (garrow::check(error, arrow_data_type_result, "[uuid-data-type][new]")) {
+    auto arrow_data_type = *arrow_data_type_result;
+    return GARROW_UUID_DATA_TYPE(
+      g_object_new(GARROW_TYPE_UUID_DATA_TYPE, "data-type", &arrow_data_type, NULL));
+  } else {
+    return NULL;
+  }
 }
 G_END_DECLS
 

--- a/c_glib/arrow-glib/basic-data-type.h
+++ b/c_glib/arrow-glib/basic-data-type.h
@@ -848,17 +848,17 @@ garrow_fixed_shape_tensor_data_type_get_strides(GArrowFixedShapeTensorDataType *
 
 #define GARROW_TYPE_UUID_DATA_TYPE (garrow_uuid_data_type_get_type())
 GARROW_AVAILABLE_IN_21_0
-G_DECLARE_DERIVABLE_TYPE(GArrowUuidDataType,
+G_DECLARE_DERIVABLE_TYPE(GArrowUUIDDataType,
                          garrow_uuid_data_type,
                          GARROW,
                          UUID_DATA_TYPE,
                          GArrowExtensionDataType)
-struct _GArrowUuidDataTypeClass
+struct _GArrowUUIDDataTypeClass
 {
   GArrowExtensionDataTypeClass parent_class;
 };
 
 GARROW_AVAILABLE_IN_21_0
-GArrowUuidDataType *
+GArrowUUIDDataType *
 garrow_uuid_data_type_new(GError **error);
 G_END_DECLS

--- a/c_glib/arrow-glib/basic-data-type.h
+++ b/c_glib/arrow-glib/basic-data-type.h
@@ -845,4 +845,20 @@ GARROW_AVAILABLE_IN_21_0
 const gint64 *
 garrow_fixed_shape_tensor_data_type_get_strides(GArrowFixedShapeTensorDataType *data_type,
                                                 gsize *length);
+
+#define GARROW_TYPE_UUID_DATA_TYPE (garrow_uuid_data_type_get_type())
+GARROW_AVAILABLE_IN_21_0
+G_DECLARE_DERIVABLE_TYPE(GArrowUuidDataType,
+                         garrow_uuid_data_type,
+                         GARROW,
+                         UUID_DATA_TYPE,
+                         GArrowExtensionDataType)
+struct _GArrowUuidDataTypeClass
+{
+  GArrowExtensionDataTypeClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_21_0
+GArrowUuidDataType *
+garrow_uuid_data_type_new(GError **error);
 G_END_DECLS

--- a/c_glib/test/test-uuid-data-type.rb
+++ b/c_glib/test/test-uuid-data-type.rb
@@ -1,0 +1,38 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestUuidDataType < Test::Unit::TestCase
+  def setup
+    @data_type = Arrow::UuidDataType.new
+  end
+
+  def test_id
+    assert_equal(Arrow::Type::EXTENSION, @data_type.id)
+  end
+
+  def test_name
+    assert_equal(["extension", "arrow.uuid"],
+                 [@data_type.name, @data_type.extension_name])
+  end
+
+  def test_to_s
+    assert do
+      @data_type.to_s.start_with?("extension<arrow.uuid")
+    end
+  end
+
+end

--- a/c_glib/test/test-uuid-data-type.rb
+++ b/c_glib/test/test-uuid-data-type.rb
@@ -30,8 +30,6 @@ class TestUUIDDataType < Test::Unit::TestCase
   end
 
   def test_to_s
-    assert do
-      @data_type.to_s.start_with?("extension<arrow.uuid")
-    end
+    assert_equal("extension<arrow.uuid>", @data_type.to_s)
   end
 end

--- a/c_glib/test/test-uuid-data-type.rb
+++ b/c_glib/test/test-uuid-data-type.rb
@@ -15,9 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
-class TestUuidDataType < Test::Unit::TestCase
+class TestUUIDDataType < Test::Unit::TestCase
   def setup
-    @data_type = Arrow::UuidDataType.new
+    @data_type = Arrow::UUIDDataType.new
   end
 
   def test_id

--- a/c_glib/test/test-uuid-data-type.rb
+++ b/c_glib/test/test-uuid-data-type.rb
@@ -34,5 +34,4 @@ class TestUuidDataType < Test::Unit::TestCase
       @data_type.to_s.start_with?("extension<arrow.uuid")
     end
   end
-
 end


### PR DESCRIPTION
### Rationale for this change

GLib should be able to use `arrow::extension:UuidType`.

### What changes are included in this PR?

Add `GArrowUuidDataType`

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #46556