### PR TITLE
GH-46529: [C++] Convert static inline type trait functions to constexpr

### DIFF
--- a/cpp/src/arrow/tensor.h
+++ b/cpp/src/arrow/tensor.h
@@ -33,7 +33,7 @@
 
 namespace arrow {
 
-static inline bool is_tensor_supported(Type::type type_id) {
+constexpr bool is_tensor_supported(Type::type type_id) {
   switch (type_id) {
     case Type::UINT8:
     case Type::INT8:

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -178,7 +178,7 @@ class ARROW_EXPORT DataType : public std::enable_shared_from_this<DataType>,
   virtual DataTypeLayout layout() const = 0;
 
   /// \brief Return the type category
-  Type::type id() const { return id_; }
+  constexpr Type::type id() const { return id_; }
 
   /// \brief Return the type category of the storage type
   virtual Type::type storage_id() const { return id_; }

--- a/cpp/src/arrow/type_traits.h
+++ b/cpp/src/arrow/type_traits.h
@@ -1666,9 +1666,7 @@ constexpr bool is_base_binary_like(const DataType& type) {
 /// \return whether type is a binary-like type
 ///
 /// Convenience for checking using the type's id
-constexpr bool is_binary_like(const DataType& type) {
-  return is_binary_like(type.id());
-}
+constexpr bool is_binary_like(const DataType& type) { return is_binary_like(type.id()); }
 
 /// \brief Check for a large-binary-like type
 ///
@@ -1728,9 +1726,7 @@ constexpr bool is_interval(const DataType& type) { return is_interval(type.id())
 /// \return whether type is a dictionary type
 ///
 /// Convenience for checking using the type's id
-constexpr bool is_dictionary(const DataType& type) {
-  return is_dictionary(type.id());
-}
+constexpr bool is_dictionary(const DataType& type) { return is_dictionary(type.id()); }
 
 /// \brief Check for a fixed-size-binary type
 ///
@@ -1748,9 +1744,7 @@ constexpr bool is_fixed_size_binary(const DataType& type) {
 /// \return whether type is a fixed-width type
 ///
 /// Convenience for checking using the type's id
-constexpr bool is_fixed_width(const DataType& type) {
-  return is_fixed_width(type.id());
-}
+constexpr bool is_fixed_width(const DataType& type) { return is_fixed_width(type.id()); }
 
 /// \brief Check for a variable-length list type
 ///

--- a/cpp/src/arrow/type_traits.h
+++ b/cpp/src/arrow/type_traits.h
@@ -1491,7 +1491,7 @@ constexpr bool is_union(Type::type type_id) {
 ///
 /// For Type::FIXED_SIZE_BINARY, you will instead need to inspect the concrete
 /// DataType to get this information.
-static inline int bit_width(Type::type type_id) {
+constexpr int bit_width(Type::type type_id) {
   switch (type_id) {
     case Type::BOOL:
       return 1;
@@ -1547,7 +1547,7 @@ static inline int bit_width(Type::type type_id) {
 ///
 /// \param[in] type_id the type-id to check
 /// \return the offsets bit width, or 0 if the type does not have offsets
-static inline int offset_bit_width(Type::type type_id) {
+constexpr int offset_bit_width(Type::type type_id) {
   switch (type_id) {
     case Type::STRING:
     case Type::BINARY:
@@ -1596,7 +1596,7 @@ int RequiredValueAlignmentForBuffer(Type::type type_id, int buffer_index);
 /// \return whether type is an integer type
 ///
 /// Convenience for checking using the type's id
-static inline bool is_integer(const DataType& type) { return is_integer(type.id()); }
+constexpr bool is_integer(const DataType& type) { return is_integer(type.id()); }
 
 /// \brief Check for a signed integer type
 ///
@@ -1604,7 +1604,7 @@ static inline bool is_integer(const DataType& type) { return is_integer(type.id(
 /// \return whether type is a signed integer type
 ///
 /// Convenience for checking using the type's id
-static inline bool is_signed_integer(const DataType& type) {
+constexpr bool is_signed_integer(const DataType& type) {
   return is_signed_integer(type.id());
 }
 
@@ -1614,7 +1614,7 @@ static inline bool is_signed_integer(const DataType& type) {
 /// \return whether type is an unsigned integer type
 ///
 /// Convenience for checking using the type's id
-static inline bool is_unsigned_integer(const DataType& type) {
+constexpr bool is_unsigned_integer(const DataType& type) {
   return is_unsigned_integer(type.id());
 }
 
@@ -1624,7 +1624,7 @@ static inline bool is_unsigned_integer(const DataType& type) {
 /// \return whether type is a floating point type
 ///
 /// Convenience for checking using the type's id
-static inline bool is_floating(const DataType& type) { return is_floating(type.id()); }
+constexpr bool is_floating(const DataType& type) { return is_floating(type.id()); }
 
 /// \brief Check for a numeric type (number except boolean type)
 ///
@@ -1632,7 +1632,7 @@ static inline bool is_floating(const DataType& type) { return is_floating(type.i
 /// \return whether type is a numeric type
 ///
 /// Convenience for checking using the type's id
-static inline bool is_numeric(const DataType& type) { return is_numeric(type.id()); }
+constexpr bool is_numeric(const DataType& type) { return is_numeric(type.id()); }
 
 /// \brief Check for a decimal type
 ///
@@ -1640,7 +1640,7 @@ static inline bool is_numeric(const DataType& type) { return is_numeric(type.id(
 /// \return whether type is a decimal type
 ///
 /// Convenience for checking using the type's id
-static inline bool is_decimal(const DataType& type) { return is_decimal(type.id()); }
+constexpr bool is_decimal(const DataType& type) { return is_decimal(type.id()); }
 
 /// \brief Check for a primitive type
 ///
@@ -1648,7 +1648,7 @@ static inline bool is_decimal(const DataType& type) { return is_decimal(type.id(
 /// \return whether type is a primitive type
 ///
 /// Convenience for checking using the type's id
-static inline bool is_primitive(const DataType& type) { return is_primitive(type.id()); }
+constexpr bool is_primitive(const DataType& type) { return is_primitive(type.id()); }
 
 /// \brief Check for a binary or string-like type (except fixed-size binary)
 ///
@@ -1656,7 +1656,7 @@ static inline bool is_primitive(const DataType& type) { return is_primitive(type
 /// \return whether type is a binary or string-like type
 ///
 /// Convenience for checking using the type's id
-static inline bool is_base_binary_like(const DataType& type) {
+constexpr bool is_base_binary_like(const DataType& type) {
   return is_base_binary_like(type.id());
 }
 
@@ -1666,7 +1666,7 @@ static inline bool is_base_binary_like(const DataType& type) {
 /// \return whether type is a binary-like type
 ///
 /// Convenience for checking using the type's id
-static inline bool is_binary_like(const DataType& type) {
+constexpr bool is_binary_like(const DataType& type) {
   return is_binary_like(type.id());
 }
 
@@ -1676,7 +1676,7 @@ static inline bool is_binary_like(const DataType& type) {
 /// \return whether type is a large-binary-like type
 ///
 /// Convenience for checking using the type's id
-static inline bool is_large_binary_like(const DataType& type) {
+constexpr bool is_large_binary_like(const DataType& type) {
   return is_large_binary_like(type.id());
 }
 
@@ -1686,7 +1686,7 @@ static inline bool is_large_binary_like(const DataType& type) {
 /// \return whether type is a binary type
 ///
 /// Convenience for checking using the type's id
-static inline bool is_binary(const DataType& type) { return is_binary(type.id()); }
+constexpr bool is_binary(const DataType& type) { return is_binary(type.id()); }
 
 /// \brief Check for a string type
 ///
@@ -1694,7 +1694,7 @@ static inline bool is_binary(const DataType& type) { return is_binary(type.id())
 /// \return whether type is a string type
 ///
 /// Convenience for checking using the type's id
-static inline bool is_string(const DataType& type) { return is_string(type.id()); }
+constexpr bool is_string(const DataType& type) { return is_string(type.id()); }
 
 /// \brief Check for a binary-view-like type
 ///
@@ -1702,7 +1702,7 @@ static inline bool is_string(const DataType& type) { return is_string(type.id())
 /// \return whether type is a binary-view-like type
 ///
 /// Convenience for checking using the type's id
-static inline bool is_binary_view_like(const DataType& type) {
+constexpr bool is_binary_view_like(const DataType& type) {
   return is_binary_view_like(type.id());
 }
 
@@ -1712,7 +1712,7 @@ static inline bool is_binary_view_like(const DataType& type) {
 /// \return whether type is a temporal type
 ///
 /// Convenience for checking using the type's id
-static inline bool is_temporal(const DataType& type) { return is_temporal(type.id()); }
+constexpr bool is_temporal(const DataType& type) { return is_temporal(type.id()); }
 
 /// \brief Check for an interval type
 ///
@@ -1720,7 +1720,7 @@ static inline bool is_temporal(const DataType& type) { return is_temporal(type.i
 /// \return whether type is a interval type
 ///
 /// Convenience for checking using the type's id
-static inline bool is_interval(const DataType& type) { return is_interval(type.id()); }
+constexpr bool is_interval(const DataType& type) { return is_interval(type.id()); }
 
 /// \brief Check for a dictionary type
 ///
@@ -1728,7 +1728,7 @@ static inline bool is_interval(const DataType& type) { return is_interval(type.i
 /// \return whether type is a dictionary type
 ///
 /// Convenience for checking using the type's id
-static inline bool is_dictionary(const DataType& type) {
+constexpr bool is_dictionary(const DataType& type) {
   return is_dictionary(type.id());
 }
 
@@ -1738,7 +1738,7 @@ static inline bool is_dictionary(const DataType& type) {
 /// \return whether type is a fixed-size-binary type
 ///
 /// Convenience for checking using the type's id
-static inline bool is_fixed_size_binary(const DataType& type) {
+constexpr bool is_fixed_size_binary(const DataType& type) {
   return is_fixed_size_binary(type.id());
 }
 
@@ -1748,7 +1748,7 @@ static inline bool is_fixed_size_binary(const DataType& type) {
 /// \return whether type is a fixed-width type
 ///
 /// Convenience for checking using the type's id
-static inline bool is_fixed_width(const DataType& type) {
+constexpr bool is_fixed_width(const DataType& type) {
   return is_fixed_width(type.id());
 }
 
@@ -1758,7 +1758,7 @@ static inline bool is_fixed_width(const DataType& type) {
 /// \return whether type is a variable-length list type
 ///
 /// Convenience for checking using the type's id
-static inline bool is_var_length_list(const DataType& type) {
+constexpr bool is_var_length_list(const DataType& type) {
   return is_var_length_list(type.id());
 }
 
@@ -1768,7 +1768,7 @@ static inline bool is_var_length_list(const DataType& type) {
 /// \return whether type is a list-like type
 ///
 /// Convenience for checking using the type's id
-static inline bool is_list_like(const DataType& type) { return is_list_like(type.id()); }
+constexpr bool is_list_like(const DataType& type) { return is_list_like(type.id()); }
 
 /// \brief Check for a var-length list or list-view like type
 ///
@@ -1776,7 +1776,7 @@ static inline bool is_list_like(const DataType& type) { return is_list_like(type
 /// \return whether type is a var-length list or list-view like type
 ///
 /// Convenience for checking using the type's id
-static inline bool is_var_length_list_like(const DataType& type) {
+constexpr bool is_var_length_list_like(const DataType& type) {
   return is_var_length_list_like(type.id());
 }
 
@@ -1786,7 +1786,7 @@ static inline bool is_var_length_list_like(const DataType& type) {
 /// \return whether type is a list-view type
 ///
 /// Convenience for checking using the type's id
-static inline bool is_list_view(const DataType& type) { return is_list_view(type.id()); }
+constexpr bool is_list_view(const DataType& type) { return is_list_view(type.id()); }
 
 /// \brief Check for a nested type
 ///
@@ -1794,7 +1794,7 @@ static inline bool is_list_view(const DataType& type) { return is_list_view(type
 /// \return whether type is a nested type
 ///
 /// Convenience for checking using the type's id
-static inline bool is_nested(const DataType& type) { return is_nested(type.id()); }
+constexpr bool is_nested(const DataType& type) { return is_nested(type.id()); }
 
 /// \brief Check for a union type
 ///
@@ -1802,7 +1802,7 @@ static inline bool is_nested(const DataType& type) { return is_nested(type.id())
 /// \return whether type is a union type
 ///
 /// Convenience for checking using the type's id
-static inline bool is_union(const DataType& type) { return is_union(type.id()); }
+constexpr bool is_union(const DataType& type) { return is_union(type.id()); }
 
 /// @}
 

--- a/cpp/src/gandiva/arrow.h
+++ b/cpp/src/gandiva/arrow.h
@@ -55,7 +55,7 @@ static inline bool is_decimal_128(DataTypePtr type) {
   }
 }
 
-static inline bool IsArrowStringLiteral(arrow::Type::type type) {
+constexpr bool IsArrowStringLiteral(arrow::Type::type type) {
   return type == arrow::Type::STRING || type == arrow::Type::BINARY;
 }
 

--- a/cpp/src/parquet/thrift_internal.h
+++ b/cpp/src/parquet/thrift_internal.h
@@ -57,16 +57,16 @@ namespace parquet {
 
 // Unsafe enum converters (input is not checked for validity)
 
-static inline Type::type FromThriftUnsafe(format::Type::type type) {
+constexpr Type::type FromThriftUnsafe(format::Type::type type) {
   return static_cast<Type::type>(type);
 }
 
-static inline ConvertedType::type FromThriftUnsafe(format::ConvertedType::type type) {
+constexpr ConvertedType::type FromThriftUnsafe(format::ConvertedType::type type) {
   // item 0 is NONE
   return static_cast<ConvertedType::type>(static_cast<int>(type) + 1);
 }
 
-static inline Repetition::type FromThriftUnsafe(format::FieldRepetitionType::type type) {
+constexpr Repetition::type FromThriftUnsafe(format::FieldRepetitionType::type type) {
   return static_cast<Repetition::type>(type);
 }
 
@@ -74,11 +74,11 @@ static inline Encoding::type FromThriftUnsafe(format::Encoding::type type) {
   return static_cast<Encoding::type>(type);
 }
 
-static inline PageType::type FromThriftUnsafe(format::PageType::type type) {
+constexpr PageType::type FromThriftUnsafe(format::PageType::type type) {
   return static_cast<PageType::type>(type);
 }
 
-static inline Compression::type FromThriftUnsafe(format::CompressionCodec::type type) {
+constexpr Compression::type FromThriftUnsafe(format::CompressionCodec::type type) {
   switch (type) {
     case format::CompressionCodec::UNCOMPRESSED:
       return Compression::UNCOMPRESSED;
@@ -102,11 +102,11 @@ static inline Compression::type FromThriftUnsafe(format::CompressionCodec::type 
   }
 }
 
-static inline BoundaryOrder::type FromThriftUnsafe(format::BoundaryOrder::type type) {
+constexpr BoundaryOrder::type FromThriftUnsafe(format::BoundaryOrder::type type) {
   return static_cast<BoundaryOrder::type>(type);
 }
 
-static inline GeometryLogicalType::EdgeInterpolationAlgorithm FromThriftUnsafe(
+constexpr GeometryLogicalType::EdgeInterpolationAlgorithm FromThriftUnsafe(
     format::EdgeInterpolationAlgorithm::type type) {
   switch (type) {
     case format::EdgeInterpolationAlgorithm::SPHERICAL:
@@ -344,11 +344,11 @@ static inline SizeStatistics FromThrift(const format::SizeStatistics& size_stats
 // ----------------------------------------------------------------------
 // Convert Thrift enums from Parquet enums
 
-static inline format::Type::type ToThrift(Type::type type) {
+constexpr format::Type::type ToThrift(Type::type type) {
   return static_cast<format::Type::type>(type);
 }
 
-static inline format::ConvertedType::type ToThrift(ConvertedType::type type) {
+constexpr format::ConvertedType::type ToThrift(ConvertedType::type type) {
   // item 0 is NONE
   ARROW_DCHECK_NE(type, ConvertedType::NONE);
   // it is forbidden to emit "NA" (PARQUET-1990)
@@ -357,15 +357,15 @@ static inline format::ConvertedType::type ToThrift(ConvertedType::type type) {
   return static_cast<format::ConvertedType::type>(static_cast<int>(type) - 1);
 }
 
-static inline format::FieldRepetitionType::type ToThrift(Repetition::type type) {
+constexpr format::FieldRepetitionType::type ToThrift(Repetition::type type) {
   return static_cast<format::FieldRepetitionType::type>(type);
 }
 
-static inline format::Encoding::type ToThrift(Encoding::type type) {
+constexpr format::Encoding::type ToThrift(Encoding::type type) {
   return static_cast<format::Encoding::type>(type);
 }
 
-static inline format::CompressionCodec::type ToThrift(Compression::type type) {
+constexpr format::CompressionCodec::type ToThrift(Compression::type type) {
   switch (type) {
     case Compression::UNCOMPRESSED:
       return format::CompressionCodec::UNCOMPRESSED;
@@ -390,7 +390,7 @@ static inline format::CompressionCodec::type ToThrift(Compression::type type) {
   }
 }
 
-static inline format::BoundaryOrder::type ToThrift(BoundaryOrder::type type) {
+constexpr format::BoundaryOrder::type ToThrift(BoundaryOrder::type type) {
   switch (type) {
     case BoundaryOrder::Unordered:
     case BoundaryOrder::Ascending:


### PR DESCRIPTION
### Rationale for this change

As C++ versions have increased certain patterns that used to be optimal have been replaced with new more powerful forms.  In this scenario static inline functions can safely be replaced with constexpr.

### What changes are included in this PR?

Changing type trait related functions that are static inline to instead be constexpr.

### Are these changes tested?

Yes
* GitHub Issue: #46529