### PR TITLE
GH-46562: [GLib][CI] Enable ARROW_GLIB_WERROR by default

### DIFF
--- a/c_glib/tool/generate-version-header.py
+++ b/c_glib/tool/generate-version-header.py
@@ -49,7 +49,7 @@ def main():
     args = parser.parse_args()
 
     with open(args.input, "r", encoding="utf-8") as input_file, \
-            open(args.output, "w", encoding="utf-8") as output_file:
+            open(args.output, "w", encoding="utf-8", newline="\n") as output_file:
         write_header(
             input_file, output_file, args.library, args.version)
 

--- a/ci/scripts/c_glib_build.sh
+++ b/ci/scripts/c_glib_build.sh
@@ -77,18 +77,6 @@ meson setup \
       "${build_dir}" \
       "${source_dir}"
 
-SUBPROJECTS="
-arrow-dataset-glib
-arrow-flight-glib
-arrow-flight-sql-glib
-arrow-glib
-"
-
-for proj in ${SUBPROJECTS} ; do
-  python3 -c "import sys; f = sys.argv[1]; d = open(f).read().replace('\r\n', '\n'); open(f, 'w').write(d)" "${build_dir}/${proj}/version.h"
-  python3 -c "import sys; print(sys.stdin.read().replace('\r\n', '%CRCR%\n'), end='')" "${build_dir}/${proj}/version.h"
-done
-
 pushd "${build_dir}"
 ninja
 ninja install

--- a/ci/scripts/c_glib_build.sh
+++ b/ci/scripts/c_glib_build.sh
@@ -33,6 +33,8 @@ if [ -n "${MSYSTEM:-}" ]; then
   # Fix ARROW_HOME when running under MSYS2
   ARROW_HOME="$(cygpath --unix "${ARROW_HOME}")"
   export ARROW_HOME
+  # Force disable ARROW_GLIB_WERROR false
+  ARROW_GLIB_WERROR=false
 fi
 
 PATH="${ARROW_HOME}/bin:${PATH}"

--- a/ci/scripts/c_glib_build.sh
+++ b/ci/scripts/c_glib_build.sh
@@ -33,8 +33,6 @@ if [ -n "${MSYSTEM:-}" ]; then
   # Fix ARROW_HOME when running under MSYS2
   ARROW_HOME="$(cygpath --unix "${ARROW_HOME}")"
   export ARROW_HOME
-  # Force disable ARROW_GLIB_WERROR false
-  ARROW_GLIB_WERROR=false
 fi
 
 PATH="${ARROW_HOME}/bin:${PATH}"
@@ -78,6 +76,17 @@ meson setup \
       -Dwerror="${ARROW_GLIB_WERROR}" \
       "${build_dir}" \
       "${source_dir}"
+
+SUBPROJECTS="
+arrow-dataset-glib
+arrow-flight-glib
+arrow-flight-sql-glib
+arrow-glib
+"
+
+for proj in ${SUBPROJECTS} ; do
+  python3 -c "import sys; f = sys.argv[1]; d = open(f).read().replace('\r\n', '\n'); open(f, 'w').write(d)" "${build_dir}/${proj}/version.h"
+done
 
 pushd "${build_dir}"
 ninja

--- a/ci/scripts/c_glib_build.sh
+++ b/ci/scripts/c_glib_build.sh
@@ -23,7 +23,7 @@ source_dir=${1}/c_glib
 build_dir=${2}/c_glib
 build_root=${2}
 
-: "${ARROW_GLIB_WERROR:=false}"
+: "${ARROW_GLIB_WERROR:=true}"
 : "${ARROW_GLIB_VAPI:=true}"
 : "${BUILD_DOCS_C_GLIB:=OFF}"
 with_doc=$([ "${BUILD_DOCS_C_GLIB}" == "ON" ] && echo "true" || echo "false")

--- a/ci/scripts/c_glib_build.sh
+++ b/ci/scripts/c_glib_build.sh
@@ -86,6 +86,7 @@ arrow-glib
 
 for proj in ${SUBPROJECTS} ; do
   python3 -c "import sys; f = sys.argv[1]; d = open(f).read().replace('\r\n', '\n'); open(f, 'w').write(d)" "${build_dir}/${proj}/version.h"
+  python3 -c "import sys; print(sys.stdin.read().replace('\r\n', '%CRCR%\n'), end='')" "${build_dir}/${proj}/version.h"
 done
 
 pushd "${build_dir}"


### PR DESCRIPTION
### Rationale for this change

In GLib buiding, disabled `-Werror` compiler flag by default.

### What changes are included in this PR?

Change `-Werror` by default. This change makes debugging easier.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #46562