### PR TITLE
GH-46572: [Python] expose filter option to python for join

### DIFF
--- a/python/pyarrow/_acero.pyx
+++ b/python/pyarrow/_acero.pyx
@@ -273,7 +273,7 @@ cdef class _HashJoinNodeOptions(ExecNodeOptions):
 
     def _set_options(
         self, join_type, left_keys, right_keys, left_output=None, right_output=None,
-        output_suffix_for_left="", output_suffix_for_right="", Expression filter_expression=None,
+        output_suffix_for_left="", output_suffix_for_right="", Expression filter=None,
     ):
         cdef:
             CJoinType c_join_type
@@ -281,7 +281,7 @@ cdef class _HashJoinNodeOptions(ExecNodeOptions):
             vector[CFieldRef] c_right_keys
             vector[CFieldRef] c_left_output
             vector[CFieldRef] c_right_output
-            CExpression c_filter_expression
+            CExpression c_filter
 
         # join type
         if join_type == "left semi":
@@ -313,10 +313,10 @@ cdef class _HashJoinNodeOptions(ExecNodeOptions):
         for key in right_keys:
             c_right_keys.push_back(_ensure_field_ref(key))
 
-        if filter_expression is None:
-            c_filter_expression = _true
+        if filter is None:
+            c_filter = _true
         else:
-            c_filter_expression = filter_expression.unwrap()
+            c_filter = filter.unwrap()
 
         # left/right output fields
         if left_output is not None and right_output is not None:
@@ -329,7 +329,7 @@ cdef class _HashJoinNodeOptions(ExecNodeOptions):
                 new CHashJoinNodeOptions(
                     c_join_type, c_left_keys, c_right_keys,
                     c_left_output, c_right_output,
-                    c_filter_expression,
+                    c_filter,
                     <c_string>tobytes(output_suffix_for_left),
                     <c_string>tobytes(output_suffix_for_right)
                 )
@@ -338,7 +338,7 @@ cdef class _HashJoinNodeOptions(ExecNodeOptions):
             self.wrapped.reset(
                 new CHashJoinNodeOptions(
                     c_join_type, c_left_keys, c_right_keys,
-                    c_filter_expression,
+                    c_filter,
                     <c_string>tobytes(output_suffix_for_left),
                     <c_string>tobytes(output_suffix_for_right)
                 )
@@ -379,17 +379,17 @@ class HashJoinNodeOptions(_HashJoinNodeOptions):
     output_suffix_for_right : str
         Suffix added to names of output fields coming from right input,
         see `output_suffix_for_left` for details.
-    filter_expression: Expression
-        Expression that will be used during join operation.
+    filter: Expression
+        Residual filter which is applied to matching row.
     """
 
     def __init__(
         self, join_type, left_keys, right_keys, left_output=None, right_output=None,
-        output_suffix_for_left="", output_suffix_for_right="", filter_expression=None,
+        output_suffix_for_left="", output_suffix_for_right="", filter=None,
     ):
         self._set_options(
             join_type, left_keys, right_keys, left_output, right_output,
-            output_suffix_for_left, output_suffix_for_right, filter_expression
+            output_suffix_for_left, output_suffix_for_right, filter
         )
 
 

--- a/python/pyarrow/_acero.pyx
+++ b/python/pyarrow/_acero.pyx
@@ -272,8 +272,8 @@ class OrderByNodeOptions(_OrderByNodeOptions):
 cdef class _HashJoinNodeOptions(ExecNodeOptions):
 
     def _set_options(
-        self, join_type, left_keys, right_keys, Expression filter_expression=None, left_output=None, right_output=None,
-        output_suffix_for_left="", output_suffix_for_right="",
+        self, join_type, left_keys, right_keys, left_output=None, right_output=None,
+        output_suffix_for_left="", output_suffix_for_right="", Expression filter_expression=None,
     ):
         cdef:
             CJoinType c_join_type
@@ -379,15 +379,17 @@ class HashJoinNodeOptions(_HashJoinNodeOptions):
     output_suffix_for_right : str
         Suffix added to names of output fields coming from right input,
         see `output_suffix_for_left` for details.
+    filter_expression: Expression
+        Expression that will be used during join operation.
     """
 
     def __init__(
-        self, join_type, left_keys, right_keys, filter_expression=None, left_output=None, right_output=None,
-        output_suffix_for_left="", output_suffix_for_right=""
+        self, join_type, left_keys, right_keys, left_output=None, right_output=None,
+        output_suffix_for_left="", output_suffix_for_right="", filter_expression=None,
     ):
         self._set_options(
-            join_type, left_keys, right_keys, filter_expression, left_output, right_output,
-            output_suffix_for_left, output_suffix_for_right
+            join_type, left_keys, right_keys, left_output, right_output,
+            output_suffix_for_left, output_suffix_for_right, filter_expression
         )
 
 

--- a/python/pyarrow/_acero.pyx
+++ b/python/pyarrow/_acero.pyx
@@ -273,7 +273,7 @@ cdef class _HashJoinNodeOptions(ExecNodeOptions):
 
     def _set_options(
         self, join_type, left_keys, right_keys, left_output=None, right_output=None,
-        output_suffix_for_left="", output_suffix_for_right="", Expression filter=None,
+        output_suffix_for_left="", output_suffix_for_right="", Expression filter_expression=None,
     ):
         cdef:
             CJoinType c_join_type
@@ -281,7 +281,7 @@ cdef class _HashJoinNodeOptions(ExecNodeOptions):
             vector[CFieldRef] c_right_keys
             vector[CFieldRef] c_left_output
             vector[CFieldRef] c_right_output
-            CExpression c_filter
+            CExpression c_filter_expression
 
         # join type
         if join_type == "left semi":
@@ -313,10 +313,10 @@ cdef class _HashJoinNodeOptions(ExecNodeOptions):
         for key in right_keys:
             c_right_keys.push_back(_ensure_field_ref(key))
 
-        if filter is None:
-            c_filter = _true
+        if filter_expression is None:
+            c_filter_expression = _true
         else:
-            c_filter = filter.unwrap()
+            c_filter_expression = filter_expression.unwrap()
 
         # left/right output fields
         if left_output is not None and right_output is not None:
@@ -329,7 +329,7 @@ cdef class _HashJoinNodeOptions(ExecNodeOptions):
                 new CHashJoinNodeOptions(
                     c_join_type, c_left_keys, c_right_keys,
                     c_left_output, c_right_output,
-                    c_filter,
+                    c_filter_expression,
                     <c_string>tobytes(output_suffix_for_left),
                     <c_string>tobytes(output_suffix_for_right)
                 )
@@ -338,7 +338,7 @@ cdef class _HashJoinNodeOptions(ExecNodeOptions):
             self.wrapped.reset(
                 new CHashJoinNodeOptions(
                     c_join_type, c_left_keys, c_right_keys,
-                    c_filter,
+                    c_filter_expression,
                     <c_string>tobytes(output_suffix_for_left),
                     <c_string>tobytes(output_suffix_for_right)
                 )
@@ -379,17 +379,17 @@ class HashJoinNodeOptions(_HashJoinNodeOptions):
     output_suffix_for_right : str
         Suffix added to names of output fields coming from right input,
         see `output_suffix_for_left` for details.
-    filter: Expression
+    filter_expression : pyarrow.compute.Expression
         Residual filter which is applied to matching row.
     """
 
     def __init__(
         self, join_type, left_keys, right_keys, left_output=None, right_output=None,
-        output_suffix_for_left="", output_suffix_for_right="", filter=None,
+        output_suffix_for_left="", output_suffix_for_right="", filter_expression=None,
     ):
         self._set_options(
             join_type, left_keys, right_keys, left_output, right_output,
-            output_suffix_for_left, output_suffix_for_right, filter
+            output_suffix_for_left, output_suffix_for_right, filter_expression
         )
 
 

--- a/python/pyarrow/acero.py
+++ b/python/pyarrow/acero.py
@@ -83,7 +83,7 @@ def _perform_join(join_type, left_operand, left_keys,
                   right_operand, right_keys,
                   left_suffix=None, right_suffix=None,
                   use_threads=True, coalesce_keys=False,
-                  output_type=Table):
+                  output_type=Table, filter_expression=None):
     """
     Perform join of two tables or datasets.
 
@@ -114,6 +114,8 @@ def _perform_join(join_type, left_operand, left_keys,
         in the join result.
     output_type: Table or InMemoryDataset
         The output type for the exec plan result.
+    filter_expression: Expression
+        Expression that will be used during join operation.
 
     Returns
     -------
@@ -183,12 +185,14 @@ def _perform_join(join_type, left_operand, left_keys,
             join_type, left_keys, right_keys, left_columns, right_columns,
             output_suffix_for_left=left_suffix or "",
             output_suffix_for_right=right_suffix or "",
+            filter_expression=filter_expression,
         )
     else:
         join_opts = HashJoinNodeOptions(
             join_type, left_keys, right_keys,
             output_suffix_for_left=left_suffix or "",
             output_suffix_for_right=right_suffix or "",
+            filter_expression=filter_expression,
         )
     decl = Declaration(
         "hashjoin", options=join_opts, inputs=[left_source, right_source]

--- a/python/pyarrow/acero.py
+++ b/python/pyarrow/acero.py
@@ -83,7 +83,7 @@ def _perform_join(join_type, left_operand, left_keys,
                   right_operand, right_keys,
                   left_suffix=None, right_suffix=None,
                   use_threads=True, coalesce_keys=False,
-                  output_type=Table, filter=None):
+                  output_type=Table, filter_expression=None):
     """
     Perform join of two tables or datasets.
 
@@ -114,7 +114,7 @@ def _perform_join(join_type, left_operand, left_keys,
         in the join result.
     output_type: Table or InMemoryDataset
         The output type for the exec plan result.
-    filter: Expression
+    filter_expression : pyarrow.compute.Expression
         Residual filter which is applied to matching row.
 
     Returns
@@ -185,14 +185,14 @@ def _perform_join(join_type, left_operand, left_keys,
             join_type, left_keys, right_keys, left_columns, right_columns,
             output_suffix_for_left=left_suffix or "",
             output_suffix_for_right=right_suffix or "",
-            filter=filter,
+            filter_expression=filter_expression,
         )
     else:
         join_opts = HashJoinNodeOptions(
             join_type, left_keys, right_keys,
             output_suffix_for_left=left_suffix or "",
             output_suffix_for_right=right_suffix or "",
-            filter=filter,
+            filter_expression=filter_expression,
         )
     decl = Declaration(
         "hashjoin", options=join_opts, inputs=[left_source, right_source]

--- a/python/pyarrow/acero.py
+++ b/python/pyarrow/acero.py
@@ -185,14 +185,14 @@ def _perform_join(join_type, left_operand, left_keys,
             join_type, left_keys, right_keys, left_columns, right_columns,
             output_suffix_for_left=left_suffix or "",
             output_suffix_for_right=right_suffix or "",
-            filter_expression=filter,
+            filter=filter,
         )
     else:
         join_opts = HashJoinNodeOptions(
             join_type, left_keys, right_keys,
             output_suffix_for_left=left_suffix or "",
             output_suffix_for_right=right_suffix or "",
-            filter_expression=filter,
+            filter=filter,
         )
     decl = Declaration(
         "hashjoin", options=join_opts, inputs=[left_source, right_source]

--- a/python/pyarrow/acero.py
+++ b/python/pyarrow/acero.py
@@ -83,7 +83,7 @@ def _perform_join(join_type, left_operand, left_keys,
                   right_operand, right_keys,
                   left_suffix=None, right_suffix=None,
                   use_threads=True, coalesce_keys=False,
-                  output_type=Table, filter_expression=None):
+                  output_type=Table, filter=None):
     """
     Perform join of two tables or datasets.
 
@@ -114,8 +114,8 @@ def _perform_join(join_type, left_operand, left_keys,
         in the join result.
     output_type: Table or InMemoryDataset
         The output type for the exec plan result.
-    filter_expression: Expression
-        Expression that will be used during join operation.
+    filter: Expression
+        Residual filter which is applied to matching row.
 
     Returns
     -------
@@ -185,14 +185,14 @@ def _perform_join(join_type, left_operand, left_keys,
             join_type, left_keys, right_keys, left_columns, right_columns,
             output_suffix_for_left=left_suffix or "",
             output_suffix_for_right=right_suffix or "",
-            filter_expression=filter_expression,
+            filter_expression=filter,
         )
     else:
         join_opts = HashJoinNodeOptions(
             join_type, left_keys, right_keys,
             output_suffix_for_left=left_suffix or "",
             output_suffix_for_right=right_suffix or "",
-            filter_expression=filter_expression,
+            filter_expression=filter,
         )
     decl = Declaration(
         "hashjoin", options=join_opts, inputs=[left_source, right_source]

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -5631,7 +5631,7 @@ cdef class Table(_Tabular):
 
     def join(self, right_table, keys, right_keys=None, join_type="left outer",
              left_suffix=None, right_suffix=None, coalesce_keys=True,
-             use_threads=True, filter=None):
+             use_threads=True, filter_expression=None):
         """
         Perform a join between this table and another one.
 
@@ -5665,7 +5665,7 @@ cdef class Table(_Tabular):
             in the join result.
         use_threads : bool, default True
             Whether to use multithreading or not.
-        filter: Expression
+        filter_expression : pyarrow.compute.Expression
             Residual filter which is applied to matching row.
 
         Returns
@@ -5741,7 +5741,7 @@ cdef class Table(_Tabular):
 
         Inner join with intended mismatch filter expression:
 
-        >>> t1.join(t2, 'id', join_type="inner", filter=pc.equal(pc.field("n_legs"), 100))
+        >>> t1.join(t2, 'id', join_type="inner", filter_expression=pc.equal(pc.field("n_legs"), 100))
         pyarrow.Table
         id: int64
         year: int64
@@ -5761,7 +5761,7 @@ cdef class Table(_Tabular):
             left_suffix=left_suffix, right_suffix=right_suffix,
             use_threads=use_threads, coalesce_keys=coalesce_keys,
             output_type=Table,
-            filter=filter,
+            filter_expression=filter_expression,
         )
 
     def join_asof(self, right_table, on, by, tolerance, right_on=None, right_by=None):

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -5631,7 +5631,7 @@ cdef class Table(_Tabular):
 
     def join(self, right_table, keys, right_keys=None, join_type="left outer",
              left_suffix=None, right_suffix=None, coalesce_keys=True,
-             use_threads=True, filter_expression=None):
+             use_threads=True, filter=None):
         """
         Perform a join between this table and another one.
 
@@ -5665,8 +5665,8 @@ cdef class Table(_Tabular):
             in the join result.
         use_threads : bool, default True
             Whether to use multithreading or not.
-        filter_expression: Expression
-            Expression that will be used during join operation.
+        filter: Expression
+            Residual filter which is applied to matching row.
 
         Returns
         -------
@@ -5741,7 +5741,7 @@ cdef class Table(_Tabular):
 
         Inner join with intended mismatch filter expression:
 
-        >>> t1.join(t2, 'id', join_type="inner", filter_expression=pc.equal(pc.field("n_legs"), 100))
+        >>> t1.join(t2, 'id', join_type="inner", filter=pc.equal(pc.field("n_legs"), 100))
         pyarrow.Table
         id: int64
         year: int64
@@ -5761,7 +5761,7 @@ cdef class Table(_Tabular):
             left_suffix=left_suffix, right_suffix=right_suffix,
             use_threads=use_threads, coalesce_keys=coalesce_keys,
             output_type=Table,
-            filter_expression=filter_expression,
+            filter=filter,
         )
 
     def join_asof(self, right_table, on, by, tolerance, right_on=None, right_by=None):

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -5629,7 +5629,7 @@ cdef class Table(_Tabular):
         self._assert_cpu()
         return TableGroupBy(self, keys, use_threads=use_threads)
 
-    def join(self, right_table, keys, right_keys=None, join_type="left outer",
+    def join(self, right_table, keys, right_keys=None, filter_expression=None, join_type="left outer",
              left_suffix=None, right_suffix=None, coalesce_keys=True,
              use_threads=True):
         """

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -5629,9 +5629,9 @@ cdef class Table(_Tabular):
         self._assert_cpu()
         return TableGroupBy(self, keys, use_threads=use_threads)
 
-    def join(self, right_table, keys, right_keys=None, filter_expression=None, join_type="left outer",
+    def join(self, right_table, keys, right_keys=None, join_type="left outer",
              left_suffix=None, right_suffix=None, coalesce_keys=True,
-             use_threads=True):
+             use_threads=True, filter_expression=None):
         """
         Perform a join between this table and another one.
 
@@ -5665,6 +5665,8 @@ cdef class Table(_Tabular):
             in the join result.
         use_threads : bool, default True
             Whether to use multithreading or not.
+        filter_expression: Expression
+            Expression that will be used during join operation.
 
         Returns
         -------
@@ -5674,6 +5676,7 @@ cdef class Table(_Tabular):
         --------
         >>> import pandas as pd
         >>> import pyarrow as pa
+        >>> import pyarrow.compute as pc
         >>> df1 = pd.DataFrame({'id': [1, 2, 3],
         ...                     'year': [2020, 2022, 2019]})
         >>> df2 = pd.DataFrame({'id': [3, 4],
@@ -5724,7 +5727,7 @@ cdef class Table(_Tabular):
         n_legs: [[5,100]]
         animal: [["Brittle stars","Centipede"]]
 
-        Right anti join
+        Right anti join:
 
         >>> t1.join(t2, 'id', join_type="right anti")
         pyarrow.Table
@@ -5735,6 +5738,20 @@ cdef class Table(_Tabular):
         id: [[4]]
         n_legs: [[100]]
         animal: [["Centipede"]]
+
+        Inner join with intended mismatch filter expression:
+
+        >>> t1.join(t2, 'id', join_type="inner", filter_expression=pc.equal(pc.field("n_legs"), 100))
+        pyarrow.Table
+        id: int64
+        year: int64
+        n_legs: int64
+        animal: string
+        ----
+        id: []
+        year: []
+        n_legs: []
+        animal: []
         """
         self._assert_cpu()
         if right_keys is None:
@@ -5743,7 +5760,8 @@ cdef class Table(_Tabular):
             join_type, self, keys, right_table, right_keys,
             left_suffix=left_suffix, right_suffix=right_suffix,
             use_threads=use_threads, coalesce_keys=coalesce_keys,
-            output_type=Table
+            output_type=Table,
+            filter_expression=filter_expression,
         )
 
     def join_asof(self, right_table, on, by, tolerance, right_on=None, right_by=None):

--- a/python/pyarrow/tests/test_acero.py
+++ b/python/pyarrow/tests/test_acero.py
@@ -300,6 +300,24 @@ def test_order_by():
         _ = OrderByNodeOptions([("b", "ascending")], null_placement="start")
 
 
+def test_hash_join_with_filter():
+    left = pa.table({'key': [1, 2, 3], 'a': [4, 5, 6]})
+    left_source = Declaration("table_source", options=TableSourceNodeOptions(left))
+    right = pa.table({'key': [2, 3, 4], 'b': [4, 5, 6]})
+    right_source = Declaration("table_source", options=TableSourceNodeOptions(right))
+
+    join_opts = HashJoinNodeOptions(
+        "inner", left_keys="key", right_keys="key",
+        filter_expression=pc.equal(pc.field('a'), 5))
+    joined = Declaration(
+        "hashjoin", options=join_opts, inputs=[left_source, right_source])
+    result = joined.to_table()
+    expected = pa.table(
+        [[2], [5], [2], [4]],
+        names=["key", "a", "key", "b"])
+    assert result.equals(expected)
+
+
 def test_hash_join():
     left = pa.table({'key': [1, 2, 3], 'a': [4, 5, 6]})
     left_source = Declaration("table_source", options=TableSourceNodeOptions(left))

--- a/python/pyarrow/tests/test_acero.py
+++ b/python/pyarrow/tests/test_acero.py
@@ -370,7 +370,7 @@ def test_hash_join_with_residual_filter():
 
     join_opts = HashJoinNodeOptions(
         "inner", left_keys="key", right_keys="key",
-        filter=pc.equal(pc.field('a'), 5))
+        filter_expression=pc.equal(pc.field('a'), 5))
     joined = Declaration(
         "hashjoin", options=join_opts, inputs=[left_source, right_source])
     result = joined.to_table()
@@ -382,7 +382,7 @@ def test_hash_join_with_residual_filter():
     # test filter expression referencing columns from both side
     join_opts = HashJoinNodeOptions(
         "left outer", left_keys="key", right_keys="key",
-        filter=pc.equal(pc.field("a"), 5) | pc.equal(pc.field("b"), 10)
+        filter_expression=pc.equal(pc.field("a"), 5) | pc.equal(pc.field("b"), 10)
     )
     joined = Declaration(
         "hashjoin", options=join_opts, inputs=[left_source, right_source])
@@ -396,7 +396,7 @@ def test_hash_join_with_residual_filter():
     always_true = pc.scalar(True)
     join_opts = HashJoinNodeOptions(
         "inner", left_keys="key", right_keys="key",
-        filter=always_true)
+        filter_expression=always_true)
     joined = Declaration(
         "hashjoin", options=join_opts, inputs=[left_source, right_source])
     result = joined.to_table()
@@ -410,7 +410,7 @@ def test_hash_join_with_residual_filter():
     always_false = pc.scalar(False)
     join_opts = HashJoinNodeOptions(
         "inner", left_keys="key", right_keys="key",
-        filter=always_false)
+        filter_expression=always_false)
     joined = Declaration(
         "hashjoin", options=join_opts, inputs=[left_source, right_source])
     result = joined.to_table()

--- a/python/pyarrow/tests/test_acero.py
+++ b/python/pyarrow/tests/test_acero.py
@@ -300,71 +300,6 @@ def test_order_by():
         _ = OrderByNodeOptions([("b", "ascending")], null_placement="start")
 
 
-def test_hash_join_with_residual_filter():
-    left = pa.table({'key': [1, 2, 3], 'a': [4, 5, 6]})
-    left_source = Declaration("table_source", options=TableSourceNodeOptions(left))
-    right = pa.table({'key': [2, 3, 4], 'b': [4, 5, 6]})
-    right_source = Declaration("table_source", options=TableSourceNodeOptions(right))
-
-    join_opts = HashJoinNodeOptions(
-        "inner", left_keys="key", right_keys="key",
-        filter=pc.equal(pc.field('a'), 5))
-    joined = Declaration(
-        "hashjoin", options=join_opts, inputs=[left_source, right_source])
-    result = joined.to_table()
-    expected = pa.table(
-        [[2], [5], [2], [4]],
-        names=["key", "a", "key", "b"])
-    assert result.equals(expected)
-
-    # test filter expression referencing columns from both side
-    join_opts = HashJoinNodeOptions(
-        "left outer", left_keys="key", right_keys="key",
-        filter=pc.equal(pc.field("a"), 5) | pc.equal(pc.field("b"), 10)
-    )
-    joined = Declaration(
-        "hashjoin", options=join_opts, inputs=[left_source, right_source])
-    result = joined.to_table()
-    expected = pa.table(
-        [[2, 1, 3], [5, 4, 6], [2, None, None], [4, None, None]],
-        names=["key", "a", "key", "b"])
-    assert result.equals(expected)
-
-    # test with always true
-    always_true = pc.scalar(True)
-    join_opts = HashJoinNodeOptions(
-        "inner", left_keys="key", right_keys="key",
-        filter=always_true)
-    joined = Declaration(
-        "hashjoin", options=join_opts, inputs=[left_source, right_source])
-    result = joined.to_table()
-    expected = pa.table(
-        [[2, 3], [5, 6], [2, 3], [4, 5]],
-        names=["key", "a", "key", "b"]
-    )
-    assert result.equals(expected)
-
-    # test with always false
-    always_false = pc.scalar(False)
-    join_opts = HashJoinNodeOptions(
-        "inner", left_keys="key", right_keys="key",
-        filter=always_false)
-
-    joined = Declaration(
-        "hashjoin", options=join_opts, inputs=[left_source, right_source])
-    result = joined.to_table()
-    expected = pa.table(
-        [
-            pa.array([], type=pa.int64()),
-            pa.array([], type=pa.int64()),
-            pa.array([], type=pa.int64()),
-            pa.array([], type=pa.int64())
-        ],
-        names=["key", "a", "key", "b"]
-    )
-    assert result.equals(expected)
-
-
 def test_hash_join():
     left = pa.table({'key': [1, 2, 3], 'a': [4, 5, 6]})
     left_source = Declaration("table_source", options=TableSourceNodeOptions(left))
@@ -425,6 +360,70 @@ def test_hash_join():
         names=["key", "a", "b"]
     )
     assert result.sort_by("a").equals(expected)
+
+
+def test_hash_join_with_residual_filter():
+    left = pa.table({'key': [1, 2, 3], 'a': [4, 5, 6]})
+    left_source = Declaration("table_source", options=TableSourceNodeOptions(left))
+    right = pa.table({'key': [2, 3, 4], 'b': [4, 5, 6]})
+    right_source = Declaration("table_source", options=TableSourceNodeOptions(right))
+
+    join_opts = HashJoinNodeOptions(
+        "inner", left_keys="key", right_keys="key",
+        filter=pc.equal(pc.field('a'), 5))
+    joined = Declaration(
+        "hashjoin", options=join_opts, inputs=[left_source, right_source])
+    result = joined.to_table()
+    expected = pa.table(
+        [[2], [5], [2], [4]],
+        names=["key", "a", "key", "b"])
+    assert result.equals(expected)
+
+    # test filter expression referencing columns from both side
+    join_opts = HashJoinNodeOptions(
+        "left outer", left_keys="key", right_keys="key",
+        filter=pc.equal(pc.field("a"), 5) | pc.equal(pc.field("b"), 10)
+    )
+    joined = Declaration(
+        "hashjoin", options=join_opts, inputs=[left_source, right_source])
+    result = joined.to_table()
+    expected = pa.table(
+        [[2, 1, 3], [5, 4, 6], [2, None, None], [4, None, None]],
+        names=["key", "a", "key", "b"])
+    assert result.equals(expected)
+
+    # test with always true
+    always_true = pc.scalar(True)
+    join_opts = HashJoinNodeOptions(
+        "inner", left_keys="key", right_keys="key",
+        filter=always_true)
+    joined = Declaration(
+        "hashjoin", options=join_opts, inputs=[left_source, right_source])
+    result = joined.to_table()
+    expected = pa.table(
+        [[2, 3], [5, 6], [2, 3], [4, 5]],
+        names=["key", "a", "key", "b"]
+    )
+    assert result.equals(expected)
+
+    # test with always false
+    always_false = pc.scalar(False)
+    join_opts = HashJoinNodeOptions(
+        "inner", left_keys="key", right_keys="key",
+        filter=always_false)
+    joined = Declaration(
+        "hashjoin", options=join_opts, inputs=[left_source, right_source])
+    result = joined.to_table()
+    expected = pa.table(
+        [
+            pa.array([], type=pa.int64()),
+            pa.array([], type=pa.int64()),
+            pa.array([], type=pa.int64()),
+            pa.array([], type=pa.int64())
+        ],
+        names=["key", "a", "key", "b"]
+    )
+    assert result.equals(expected)
 
 
 def test_asof_join():

--- a/python/pyarrow/tests/test_acero.py
+++ b/python/pyarrow/tests/test_acero.py
@@ -317,6 +317,19 @@ def test_hash_join_with_filter():
         names=["key", "a", "key", "b"])
     assert result.equals(expected)
 
+    # left join
+    join_opts = HashJoinNodeOptions(
+        "left outer", left_keys="key", right_keys="key",
+        filter_expression=pc.equal(pc.field('a'), 5))
+    joined = Declaration(
+        "hashjoin", options=join_opts, inputs=[left_source, right_source])
+    result = joined.to_table()
+    expected = pa.table(
+        [[1, 2, 3], [4, 5, 6], [None, 2, None], [None, 4, None]],
+        names=["key", "a", "key", "b"]
+    )
+    assert result.sort_by("a").equals(expected)
+
 
 def test_hash_join():
     left = pa.table({'key': [1, 2, 3], 'a': [4, 5, 6]})

--- a/python/pyarrow/tests/test_acero.py
+++ b/python/pyarrow/tests/test_acero.py
@@ -330,39 +330,24 @@ def test_hash_join_with_residual_filter():
         names=["key", "a", "key", "b"])
     assert result.equals(expected)
 
-    left = pa.table({'l1': [1], 'l_str': ["alpha"]})
-    left_source = Declaration("table_source", options=TableSourceNodeOptions(left))
-    right = pa.table({'r1': [1], 'r_str': ["alpha"]})
-    right_source = Declaration("table_source", options=TableSourceNodeOptions(right))
-
     # test with always true
-    always_true = pc.equal(
-        pc.add(
-            pc.field("l1"),
-            pc.field("r1")
-        ), pa.scalar(2)
-    )
+    always_true = pc.scalar(True)
     join_opts = HashJoinNodeOptions(
-        "inner", left_keys="l_str", right_keys="r_str",
+        "inner", left_keys="key", right_keys="key",
         filter=always_true)
     joined = Declaration(
         "hashjoin", options=join_opts, inputs=[left_source, right_source])
     result = joined.to_table()
     expected = pa.table(
-        [[1], ["alpha"], [1], ["alpha"]],
-        names=["l1", "l_str", "r1", "r_str"]
+        [[2, 3], [5, 6], [2, 3], [4, 5]],
+        names=["key", "a", "key", "b"]
     )
     assert result.equals(expected)
 
     # test with always false
-    always_false = pc.equal(
-        pc.add(
-            pc.field("l1"),
-            pc.field("r1")
-        ), pa.scalar(3)
-    )
+    always_false = pc.scalar(False)
     join_opts = HashJoinNodeOptions(
-        "inner", left_keys="l_str", right_keys="r_str",
+        "inner", left_keys="key", right_keys="key",
         filter=always_false)
 
     joined = Declaration(
@@ -371,11 +356,11 @@ def test_hash_join_with_residual_filter():
     expected = pa.table(
         [
             pa.array([], type=pa.int64()),
-            pa.array([], type=pa.string()),
             pa.array([], type=pa.int64()),
-            pa.array([], type=pa.string())
+            pa.array([], type=pa.int64()),
+            pa.array([], type=pa.int64())
         ],
-        names=["l1", "l_str", "r1", "r_str"]
+        names=["key", "a", "key", "b"]
     )
     assert result.equals(expected)
 


### PR DESCRIPTION
### Rationale for this change

C++ implementation support filter while performing hash join, however, it didn't expose to python and I think it's good to have this, so other users can avoid additional filter op explicitly in their side. 

### What changes are included in this PR?

Support filter expression in python binding.

### Are these changes tested?

Yes, added new test `test_hash_join_with_filter`.

### Are there any user-facing changes?

It will expose one more argument for user, i.e., filter_expression for `Table.join` and `Datastet.join`

* GitHub Issue: #46572