### PR TITLE
GH-46569: [CI][Integration] Use apache/arrow-js for JS

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -30,11 +30,8 @@ on:
       - 'ci/**'
       - 'dev/archery/**'
       - 'docker-compose.yml'
-      - 'go/**'
       - 'integration/**'
-      - 'js/**'
       - 'cpp/**'
-      - 'java/**'
       - 'csharp/**'
       - 'format/**'
   pull_request:
@@ -44,12 +41,9 @@ on:
       - 'ci/**'
       - 'dev/archery/**'
       - 'docker-compose.yml'
-      - 'go/**'
       - 'integration/**'
-      - 'js/**'
       - 'cpp/**'
       - 'csharp/**'
-      - 'java/**'
       - 'format/**'
 
 concurrency:
@@ -72,30 +66,35 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout Arrow
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
           submodules: recursive
       - name: Checkout Arrow Rust
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: apache/arrow-rs
           path: rust
       - name: Checkout Arrow nanoarrow
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: apache/arrow-nanoarrow
           path: nanoarrow
       - name: Checkout Arrow Go
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: apache/arrow-go
           path: go
       - name: Checkout Arrow Java
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: apache/arrow-java
           path: java
+      - name: Checkout Arrow JS
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: apache/arrow-js
+          path: js
       - name: Free up disk space
         run: |
           ci/scripts/util_free_space.sh
@@ -121,6 +120,7 @@ jobs:
             -e ARCHERY_DEFAULT_BRANCH=${{ github.event.repository.default_branch }} \
             -e ARCHERY_INTEGRATION_WITH_GO=1 \
             -e ARCHERY_INTEGRATION_WITH_JAVA=1 \
+            -e ARCHERY_INTEGRATION_WITH_JS=1 \
             -e ARCHERY_INTEGRATION_WITH_NANOARROW=1 \
             -e ARCHERY_INTEGRATION_WITH_RUST=1 \
             conda-integration

--- a/ci/scripts/integration_arrow.sh
+++ b/ci/scripts/integration_arrow.sh
@@ -26,7 +26,6 @@ gold_dir=$arrow_dir/testing/data/arrow-ipc-stream/integration
 
 : ${ARROW_INTEGRATION_CPP:=ON}
 : ${ARROW_INTEGRATION_CSHARP:=ON}
-: ${ARROW_INTEGRATION_JS:=ON}
 
 : ${ARCHERY_INTEGRATION_TARGET_IMPLEMENTATIONS:=cpp,csharp,js}
 export ARCHERY_INTEGRATION_TARGET_IMPLEMENTATIONS
@@ -65,7 +64,6 @@ time archery integration \
     --run-flight \
     --with-cpp=$([ "$ARROW_INTEGRATION_CPP" == "ON" ] && echo "1" || echo "0") \
     --with-csharp=$([ "$ARROW_INTEGRATION_CSHARP" == "ON" ] && echo "1" || echo "0") \
-    --with-js=$([ "$ARROW_INTEGRATION_JS" == "ON" ] && echo "1" || echo "0") \
     --gold-dirs=$gold_dir/0.14.1 \
     --gold-dirs=$gold_dir/0.17.1 \
     --gold-dirs=$gold_dir/1.0.0-bigendian \

--- a/ci/scripts/integration_arrow_build.sh
+++ b/ci/scripts/integration_arrow_build.sh
@@ -24,7 +24,6 @@ build_dir=${2}
 
 : ${ARROW_INTEGRATION_CPP:=ON}
 : ${ARROW_INTEGRATION_CSHARP:=ON}
-: ${ARROW_INTEGRATION_JS:=ON}
 
 . ${arrow_dir}/ci/scripts/util_log.sh
 
@@ -65,7 +64,8 @@ fi
 github_actions_group_end
 
 github_actions_group_begin "Integration: Build: JavaScript"
-if [ "${ARROW_INTEGRATION_JS}" == "ON" ]; then
-    ${arrow_dir}/ci/scripts/js_build.sh ${arrow_dir} ${build_dir}
+if [ "${ARCHERY_INTEGRATION_WITH_JS}" -gt "0" ]; then
+    "${arrow_dir}/js/ci/scripts/build.sh" "${arrow_dir}/js"
+    cp -a "${arrow_dir}/js" "${build_dir}/js"
 fi
 github_actions_group_end

--- a/dev/archery/archery/cli.py
+++ b/dev/archery/archery/cli.py
@@ -735,7 +735,8 @@ def _set_default(opt, default):
               help='Include Java in integration tests',
               envvar="ARCHERY_INTEGRATION_WITH_JAVA")
 @click.option('--with-js', type=bool, default=False,
-              help='Include JavaScript in integration tests')
+              help='Include JavaScript in integration tests',
+              envvar="ARCHERY_INTEGRATION_WITH_JS")
 @click.option('--with-go', type=bool, default=False,
               help='Include Go in integration tests',
               envvar="ARCHERY_INTEGRATION_WITH_GO")


### PR DESCRIPTION
### Rationale for this change

We moved the JS implementation to apache/arrow-js.

### What changes are included in this PR?

Use apache/arrow-js for JS.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #46569