### PR TITLE
GH-45723: [C++] FixedSizeListBuilder should have UnsafeAppend methods

### DIFF
--- a/cpp/src/arrow/array/builder_nested.cc
+++ b/cpp/src/arrow/array/builder_nested.cc
@@ -200,7 +200,7 @@ void FixedSizeListBuilder::Reset() {
 
 Status FixedSizeListBuilder::Append() {
   RETURN_NOT_OK(Reserve(1));
-  UnsafeAppendToBitmap(true);
+  UnsafeAppend();
   return Status::OK();
 }
 
@@ -212,14 +212,26 @@ Status FixedSizeListBuilder::AppendValues(int64_t length, const uint8_t* valid_b
 
 Status FixedSizeListBuilder::AppendNull() {
   RETURN_NOT_OK(Reserve(1));
-  UnsafeAppendToBitmap(false);
+  UnsafeAppendNull();
   return value_builder_->AppendNulls(list_size_);
 }
 
 Status FixedSizeListBuilder::AppendNulls(int64_t length) {
   RETURN_NOT_OK(Reserve(length));
-  UnsafeAppendToBitmap(length, false);
+  UnsafeAppendNulls(length);
   return value_builder_->AppendNulls(list_size_ * length);
+}
+
+void FixedSizeListBuilder::UnsafeAppend() {
+  UnsafeAppendToBitmap(true);
+}
+
+void FixedSizeListBuilder::UnsafeAppendNull() {
+  UnsafeAppendToBitmap(false);
+}
+
+void FixedSizeListBuilder::UnsafeAppendNulls(int64_t length) {
+  UnsafeAppendToBitmap(length, false);
 }
 
 Status FixedSizeListBuilder::ValidateOverflow(int64_t new_elements) {

--- a/cpp/src/arrow/array/builder_nested.h
+++ b/cpp/src/arrow/array/builder_nested.h
@@ -694,6 +694,12 @@ class ARROW_EXPORT FixedSizeListBuilder : public ArrayBuilder {
   /// automatically.
   Status AppendNulls(int64_t length) final;
 
+  void UnsafeAppend();
+
+  void UnsafeAppendNull();
+
+  void UnsafeAppendNulls(int64_t length);
+
   Status ValidateOverflow(int64_t new_elements);
 
   Status AppendEmptyValue() final;


### PR DESCRIPTION
### Rationale for this change
Closes 45723
### What changes are included in this PR?
Adds the following methods to `FixedSizeListBuilder`:
- `void UnsafeAppend()`
- `void UnsafeAppendNull()`
- `void UnsafeAppendNulls(int64_t length)`

### Are these changes tested?

### Are there any user-facing changes?


* GitHub Issue: #45723