### PR TITLE
GH-46545: [CI][Dev][Python] Update pre-commit for cython-lint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,11 +48,6 @@ repos:
           ?^ci/docker/python-.*-wheel-windows-test-vs2022.*\.dockerfile$|
           )
         types: []
-  - repo: https://github.com/MarcoGorelli/cython-lint
-    rev: v0.12.5
-    hooks:
-      - id: cython-lint
-        args: [--no-pycodestyle]
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v14.0.6
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -147,6 +147,16 @@ repos:
           (
           ?^python/pyarrow/vendored/|
           )
+  - repo: https://github.com/MarcoGorelli/cython-lint
+    rev: v0.16.2
+    hooks:
+      - id: cython-lint
+        name: Python (Cython) Lint
+        alias: python-cython-lint
+        args:
+          - "--no-pycodestyle"
+        files: >-
+          ^python/
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v14.0.6
     hooks:


### PR DESCRIPTION
### Rationale for this change

`cython-lint` configuration is outdated.

### What changes are included in this PR?

* Update version
* Add name
* Add alias 

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #46545