### PR TITLE
GH-46547: [CI][Dev][R] Use pre-commit for lintr

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -53,6 +53,7 @@ jobs:
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: 3.12
+      - uses: r-lib/actions/setup-r@bd49c52ffe281809afa6f0fecbf37483c5dd0b93 # v2.11.3
       - name: Install pre-commit
         run: |
           python -m pip install pre-commit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -166,6 +166,20 @@ repos:
           ?.pb\.(cc|h)$|
           ?^cpp/src/generated/|
           )
+  - repo: local
+    hooks:
+      - id: lintr
+        name: R Lint
+        alias: r-lint
+        language: r
+        additional_dependencies:
+          - cyclocomp
+          - lintr
+        entry: |
+          Rscript r/tools/lint.R
+        pass_filenames: false
+        files: >-
+          ^r/.*\.(R|Rmd)$
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v14.0.6
     hooks:

--- a/r/tools/lint.R
+++ b/r/tools/lint.R
@@ -1,0 +1,26 @@
+#!/usr/bin/env Rscript
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+lints <- lintr::lint_package("r")
+if (length(lints) == 0) {
+  q("no")
+}
+
+print(lints)
+q("no", status=1)


### PR DESCRIPTION
### Rationale for this change

We want to migrate to pre-commit from `archery lint`.

### What changes are included in this PR?

Use pre-commit for lintr against `r/`.

This doesn't use https://github.com/lorenzwalthert/precommit because it doesn't include cyclocomp that we need.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #46547