### PR TITLE
GH-46585: [JS][Dev] Remove dependabot configuration for JS

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,13 +38,6 @@ updates:
     commit-message:
       prefix: "MINOR: [Swift] "
     open-pull-requests-limit: 10
-  - package-ecosystem: "npm"
-    directory: "/js/"
-    schedule:
-      interval: "monthly"
-    commit-message:
-      prefix: "MINOR: [JS] "
-    open-pull-requests-limit: 10
   - package-ecosystem: "nuget"
     directory: "/csharp/"
     schedule:


### PR DESCRIPTION
### Rationale for this change

We have migrated the arrow-js implementation. We don't require the dependabot config anymore.

### What changes are included in this PR?

Remove JS related configuration.

### Are these changes tested?

No

### Are there any user-facing changes?

No

* GitHub Issue: #46585