### PR TITLE
GH-46593: [CI][Integration] Disable nested log grouping

### DIFF
--- a/ci/scripts/util_log.sh
+++ b/ci/scripts/util_log.sh
@@ -17,10 +17,12 @@
 
 github_actions_group_begin() {
   echo "::group::$1"
+  echo "::stop-commands::arrow-log-grouping"
   set -x
 }
 
 github_actions_group_end() {
   set +x
+  echo "::arrow-log-grouping::"
   echo "::endgroup::"
 }


### PR DESCRIPTION
### Rationale for this change

GitHub Actions support log grouping:
https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#grouping-log-lines

But it doesn't support nested grouping.

If we nest grouping, some logs may not be grouped. See #46593 for example. 

### What changes are included in this PR?

Stop GitHub Actions workflow commands including grouping while grouping.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #46593