### PR TITLE
GH-46546: [CI][Dev][Python] Use pre-commit for numpydoc

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -166,6 +166,25 @@ repos:
           ?.pb\.(cc|h)$|
           ?^cpp/src/generated/|
           )
+  - repo: https://github.com/numpy/numpydoc
+    rev: v1.8.0
+    hooks:
+      - id: numpydoc-validation
+        name: Python (NumPy doc) Lint
+        alias: python-doc-lint
+        args:
+          - "--config=python"
+        files: >-
+          ^python/pyarrow/
+        exclude: >-
+          (
+          ?^python/pyarrow/interchange/from_dataframe\.py|
+          ?^python/pyarrow/jvm\.py|
+          ?^python/pyarrow/pandas_compat\.py|
+          ?^python/pyarrow/tests/|
+          ?^python/pyarrow/util\.py|
+          ?^python/pyarrow/vendored/|
+          )
   - repo: local
     hooks:
       - id: lintr

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -178,11 +178,11 @@ repos:
           ^python/pyarrow/
         exclude: >-
           (
-          ?^python/pyarrow/interchange/from_dataframe\.py|
-          ?^python/pyarrow/jvm\.py|
-          ?^python/pyarrow/pandas_compat\.py|
+          ?^python/pyarrow/interchange/from_dataframe\.py$|
+          ?^python/pyarrow/jvm\.py$|
+          ?^python/pyarrow/pandas_compat\.py$|
           ?^python/pyarrow/tests/|
-          ?^python/pyarrow/util\.py|
+          ?^python/pyarrow/util\.py$|
           ?^python/pyarrow/vendored/|
           )
   - repo: local

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -65,6 +65,21 @@ test = [
     'pandas'
 ]
 
+[tool.numpydoc_validation]
+checks = [
+    "GL10",
+    "PR01",
+    "PR03",
+    "PR04",
+    "PR05",
+    "PR10",
+    "RT03",
+    "YD01",
+]
+exclude = [
+    '\._.*$',
+]
+
 [tool.setuptools]
 zip-safe=false
 include-package-data=true


### PR DESCRIPTION
### Rationale for this change

We want to migrate to pre-commit from `archery lint`.

### What changes are included in this PR?

Use pre-commit for numpydoc but this doesn't support Cython files.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #46546