### PR TITLE
GH-46605: [CI][Release][C#] Update download URL for dotnet on verification script

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -385,7 +385,7 @@ install_csharp() {
     local dotnet_download_url=$( \
       curl -sL ${dotnet_download_thank_you_url} | \
         grep 'directLink' | \
-        grep -E -o 'https://download[^"]+' | \
+        grep -E -o 'https://builds.dotnet[^"]+' | \
         sed -n 2p)
     mkdir -p ${csharp_bin}
     curl -sL ${dotnet_download_url} | \


### PR DESCRIPTION
### Rationale for this change

The current verification jobs for dotnet are failing.

### What changes are included in this PR?

Microsoft seems to have updated their download URLs. Update accordingly see:
https://dotnet.microsoft.com/en-us/download/dotnet/thank-you/sdk-8.0.204-linux-x64-binaries

### Are these changes tested?

Yes, via archery.

### Are there any user-facing changes?

No

* GitHub Issue: #46605