### PR TITLE
GH-46613: [GLib] Add GArrowBaseListDataType

### DIFF
--- a/c_glib/arrow-glib/composite-data-type.cpp
+++ b/c_glib/arrow-glib/composite-data-type.cpp
@@ -753,9 +753,7 @@ garrow_run_end_encoded_data_type_get_value_data_type(
   return garrow_data_type_new_raw(&arrow_value_data_type);
 }
 
-G_DEFINE_TYPE(GArrowBaseListDataType,
-              garrow_base_list_data_type,
-              GARROW_TYPE_DATA_TYPE)
+G_DEFINE_TYPE(GArrowBaseListDataType, garrow_base_list_data_type, GARROW_TYPE_DATA_TYPE)
 
 static void
 garrow_base_list_data_type_init(GArrowBaseListDataType *object)

--- a/c_glib/arrow-glib/composite-data-type.cpp
+++ b/c_glib/arrow-glib/composite-data-type.cpp
@@ -64,7 +64,8 @@ static void
 garrow_base_list_data_type_class_init(GArrowBaseListDataTypeClass *klass)
 {
 }
-G_DEFINE_TYPE(GArrowListDataType, garrow_list_data_type, GARROW_TYPE_DATA_TYPE)
+
+G_DEFINE_TYPE(GArrowListDataType, garrow_list_data_type, GARROW_TYPE_BASE_LIST_DATA_TYPE)
 
 static void
 garrow_list_data_type_init(GArrowListDataType *object)

--- a/c_glib/arrow-glib/composite-data-type.cpp
+++ b/c_glib/arrow-glib/composite-data-type.cpp
@@ -32,6 +32,8 @@ G_BEGIN_DECLS
  * @title: Composite data type classes
  * @include: arrow-glib/arrow-glib.h
  *
+ * #GArrowBaseListDataType is a abstract class for list data type.
+ *
  * #GArrowListDataType is a class for list data type.
  *
  * #GArrowLargeListDataType is a class for 64-bit offsets list data type.
@@ -51,6 +53,17 @@ G_BEGIN_DECLS
  * #GArrowRunEndEncodedDataType is a class for run end encoded data type.
  */
 
+G_DEFINE_TYPE(GArrowBaseListDataType, garrow_base_list_data_type, GARROW_TYPE_DATA_TYPE)
+
+static void
+garrow_base_list_data_type_init(GArrowBaseListDataType *object)
+{
+}
+
+static void
+garrow_base_list_data_type_class_init(GArrowBaseListDataTypeClass *klass)
+{
+}
 G_DEFINE_TYPE(GArrowListDataType, garrow_list_data_type, GARROW_TYPE_DATA_TYPE)
 
 static void
@@ -753,15 +766,4 @@ garrow_run_end_encoded_data_type_get_value_data_type(
   return garrow_data_type_new_raw(&arrow_value_data_type);
 }
 
-G_DEFINE_TYPE(GArrowBaseListDataType, garrow_base_list_data_type, GARROW_TYPE_DATA_TYPE)
-
-static void
-garrow_base_list_data_type_init(GArrowBaseListDataType *object)
-{
-}
-
-static void
-garrow_base_list_data_type_class_init(GArrowBaseListDataTypeClass *klass)
-{
-}
 G_END_DECLS

--- a/c_glib/arrow-glib/composite-data-type.cpp
+++ b/c_glib/arrow-glib/composite-data-type.cpp
@@ -32,7 +32,7 @@ G_BEGIN_DECLS
  * @title: Composite data type classes
  * @include: arrow-glib/arrow-glib.h
  *
- * #GArrowBaseListDataType is a abstract class for list data type.
+ * #GArrowBaseListDataType is an abstract class for list data type.
  *
  * #GArrowListDataType is a class for list data type.
  *

--- a/c_glib/arrow-glib/composite-data-type.cpp
+++ b/c_glib/arrow-glib/composite-data-type.cpp
@@ -753,4 +753,17 @@ garrow_run_end_encoded_data_type_get_value_data_type(
   return garrow_data_type_new_raw(&arrow_value_data_type);
 }
 
+G_DEFINE_TYPE(GArrowBaseListDataType,
+              garrow_base_list_data_type,
+              GARROW_TYPE_DATA_TYPE)
+
+static void
+garrow_base_list_data_type_init(GArrowBaseListDataType *object)
+{
+}
+
+static void
+garrow_base_list_data_type_class_init(GArrowBaseListDataTypeClass *klass)
+{
+}
 G_END_DECLS

--- a/c_glib/arrow-glib/composite-data-type.h
+++ b/c_glib/arrow-glib/composite-data-type.h
@@ -241,8 +241,7 @@ GArrowDataType *
 garrow_run_end_encoded_data_type_get_value_data_type(
   GArrowRunEndEncodedDataType *data_type);
 
-#define GARROW_TYPE_BASE_LIST_DATA_TYPE \
-  (garrow_base_list_data_type_get_type())
+#define GARROW_TYPE_BASE_LIST_DATA_TYPE (garrow_base_list_data_type_get_type())
 GARROW_AVAILABLE_IN_21_0
 G_DECLARE_DERIVABLE_TYPE(GArrowBaseListDataType,
                          garrow_base_list_data_type,

--- a/c_glib/arrow-glib/composite-data-type.h
+++ b/c_glib/arrow-glib/composite-data-type.h
@@ -26,10 +26,25 @@
 
 G_BEGIN_DECLS
 
+#define GARROW_TYPE_BASE_LIST_DATA_TYPE (garrow_base_list_data_type_get_type())
+GARROW_AVAILABLE_IN_21_0
+G_DECLARE_DERIVABLE_TYPE(GArrowBaseListDataType,
+                         garrow_base_list_data_type,
+                         GARROW,
+                         BASE_LIST_DATA_TYPE,
+                         GArrowDataType)
+struct _GArrowBaseListDataTypeClass
+{
+  GArrowDataTypeClass parent_class;
+};
+
 #define GARROW_TYPE_LIST_DATA_TYPE (garrow_list_data_type_get_type())
 GARROW_AVAILABLE_IN_ALL
-G_DECLARE_DERIVABLE_TYPE(
-  GArrowListDataType, garrow_list_data_type, GARROW, LIST_DATA_TYPE, GArrowDataType)
+G_DECLARE_DERIVABLE_TYPE(GArrowListDataType,
+                         garrow_list_data_type,
+                         GARROW,
+                         LIST_DATA_TYPE,
+                         GArrowBaseListDataType)
 struct _GArrowListDataTypeClass
 {
   GArrowDataTypeClass parent_class;
@@ -241,15 +256,4 @@ GArrowDataType *
 garrow_run_end_encoded_data_type_get_value_data_type(
   GArrowRunEndEncodedDataType *data_type);
 
-#define GARROW_TYPE_BASE_LIST_DATA_TYPE (garrow_base_list_data_type_get_type())
-GARROW_AVAILABLE_IN_21_0
-G_DECLARE_DERIVABLE_TYPE(GArrowBaseListDataType,
-                         garrow_base_list_data_type,
-                         GARROW,
-                         BASE_LIST_DATA_TYPE,
-                         GArrowDataType)
-struct _GArrowBaseListDataTypeClass
-{
-  GArrowDataTypeClass parent_class;
-};
 G_END_DECLS

--- a/c_glib/arrow-glib/composite-data-type.h
+++ b/c_glib/arrow-glib/composite-data-type.h
@@ -47,7 +47,7 @@ G_DECLARE_DERIVABLE_TYPE(GArrowListDataType,
                          GArrowBaseListDataType)
 struct _GArrowListDataTypeClass
 {
-  GArrowDataTypeClass parent_class;
+  GArrowBaseListDataTypeClass parent_class;
 };
 
 GARROW_AVAILABLE_IN_ALL

--- a/c_glib/arrow-glib/composite-data-type.h
+++ b/c_glib/arrow-glib/composite-data-type.h
@@ -241,4 +241,16 @@ GArrowDataType *
 garrow_run_end_encoded_data_type_get_value_data_type(
   GArrowRunEndEncodedDataType *data_type);
 
+#define GARROW_TYPE_BASE_LIST_DATA_TYPE \
+  (garrow_base_list_data_type_get_type())
+GARROW_AVAILABLE_IN_21_0
+G_DECLARE_DERIVABLE_TYPE(GArrowBaseListDataType,
+                         garrow_base_list_data_type,
+                         GARROW,
+                         BASE_LIST_DATA_TYPE,
+                         GArrowDataType)
+struct _GArrowBaseListDataTypeClass
+{
+  GArrowDataTypeClass parent_class;
+};
 G_END_DECLS


### PR DESCRIPTION
### Rationale for this change

GLib should be able to use `arrow::BaseListType`.

### What changes are included in this PR?

Add `GArrowBaseListDataType` and use it as a base class of `GArrowListDataType`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #46613