### PR TITLE
[C++]: Refactor - move type singleton logic into type.cc/h and tests

### DIFF
--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -3553,4 +3553,59 @@ const std::vector<Type::type>& DecimalTypeIds() {
   return type_ids;
 }
 
+Result<std::shared_ptr<DataType>> type_singleton(Type::type id) {
+  switch (id) {
+    case Type::NA:
+      return TypeTraits<NullType>::type_singleton();
+    case Type::BOOL:
+      return TypeTraits<BooleanType>::type_singleton();
+    case Type::INT8:
+      return TypeTraits<Int8Type>::type_singleton();
+    case Type::INT16:
+      return TypeTraits<Int16Type>::type_singleton();
+    case Type::INT32:
+      return TypeTraits<Int32Type>::type_singleton();
+    case Type::INT64:
+      return TypeTraits<Int64Type>::type_singleton();
+    case Type::UINT8:
+      return TypeTraits<UInt8Type>::type_singleton();
+    case Type::UINT16:
+      return TypeTraits<UInt16Type>::type_singleton();
+    case Type::UINT32:
+      return TypeTraits<UInt32Type>::type_singleton();
+    case Type::UINT64:
+      return TypeTraits<UInt64Type>::type_singleton();
+    case Type::HALF_FLOAT:
+      return TypeTraits<HalfFloatType>::type_singleton();
+    case Type::FLOAT:
+      return TypeTraits<FloatType>::type_singleton();
+    case Type::DOUBLE:
+      return TypeTraits<DoubleType>::type_singleton();
+    case Type::STRING:
+      return TypeTraits<StringType>::type_singleton();
+    case Type::BINARY:
+      return TypeTraits<BinaryType>::type_singleton();
+    case Type::LARGE_STRING:
+      return TypeTraits<LargeStringType>::type_singleton();
+    case Type::LARGE_BINARY:
+      return TypeTraits<LargeBinaryType>::type_singleton();
+    case Type::DATE32:
+      return TypeTraits<Date32Type>::type_singleton();
+    case Type::DATE64:
+      return TypeTraits<Date64Type>::type_singleton();
+    case Type::DAY_TIME_INTERVAL:
+      return TypeTraits<DayTimeIntervalType>::type_singleton();
+    case Type::MONTH_INTERVAL:
+      return TypeTraits<MonthIntervalType>::type_singleton();
+    case Type::MONTH_DAY_NANO_INTERVAL:
+      return TypeTraits<MonthDayNanoIntervalType>::type_singleton();
+    case Type::BINARY_VIEW:
+      return TypeTraits<BinaryViewType>::type_singleton();
+    case Type::STRING_VIEW:
+      return TypeTraits<StringViewType>::type_singleton();
+    default:
+      return Status::NotImplemented("Type ", id, " requires parameters or is not supported");
+  }
+}
+
 }  // namespace arrow

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -2635,3 +2635,14 @@ ARROW_EXPORT
 const std::vector<Type::type>& DecimalTypeIds();
 
 }  // namespace arrow
+
+/// \brief Get a singleton instance of a DataType for a given Type::type id
+///
+/// This function returns a singleton instance of the appropriate DataType for
+/// the given Type::type id. For types that require parameters (like DECIMAL,
+/// TIMESTAMP, etc.), it returns a Status::NotImplemented error.
+///
+/// \param[in] id The Type::type id to get a singleton for
+/// \return A Result containing either a shared_ptr to the DataType or an error
+ARROW_EXPORT
+Result<std::shared_ptr<DataType>> type_singleton(Type::type id);

--- a/cpp/src/arrow/type_test.cc
+++ b/cpp/src/arrow/type_test.cc
@@ -2494,4 +2494,36 @@ TEST(TypesTest, TestMembership) {
 
 #undef TEST_PREDICATE
 
+TEST(TypeUtil, TypeSingleton) {
+  // Test parameter-free types
+  ASSERT_OK_AND_ASSIGN(auto null_type, type_singleton(Type::NA));
+  ASSERT_EQ(*null_type, *null());
+
+  ASSERT_OK_AND_ASSIGN(auto bool_type, type_singleton(Type::BOOL));
+  ASSERT_EQ(*bool_type, *boolean());
+
+  ASSERT_OK_AND_ASSIGN(auto int8_type, type_singleton(Type::INT8));
+  ASSERT_EQ(*int8_type, *int8());
+
+  ASSERT_OK_AND_ASSIGN(auto string_type, type_singleton(Type::STRING));
+  ASSERT_EQ(*string_type, *utf8());
+
+  // Test parameterized types
+  ASSERT_RAISES(NotImplemented, type_singleton(Type::TIMESTAMP));
+  ASSERT_RAISES(NotImplemented, type_singleton(Type::TIME32));
+  ASSERT_RAISES(NotImplemented, type_singleton(Type::TIME64));
+  ASSERT_RAISES(NotImplemented, type_singleton(Type::DURATION));
+  ASSERT_RAISES(NotImplemented, type_singleton(Type::DECIMAL128));
+  ASSERT_RAISES(NotImplemented, type_singleton(Type::FIXED_SIZE_BINARY));
+  ASSERT_RAISES(NotImplemented, type_singleton(Type::LIST));
+  ASSERT_RAISES(NotImplemented, type_singleton(Type::LARGE_LIST));
+  ASSERT_RAISES(NotImplemented, type_singleton(Type::FIXED_SIZE_LIST));
+  ASSERT_RAISES(NotImplemented, type_singleton(Type::STRUCT));
+  ASSERT_RAISES(NotImplemented, type_singleton(Type::SPARSE_UNION));
+  ASSERT_RAISES(NotImplemented, type_singleton(Type::DENSE_UNION));
+  ASSERT_RAISES(NotImplemented, type_singleton(Type::DICTIONARY));
+  ASSERT_RAISES(NotImplemented, type_singleton(Type::EXTENSION));
+  ASSERT_RAISES(NotImplemented, type_singleton(Type::MAP));
+}
+
 }  // namespace arrow


### PR DESCRIPTION
Rationale for this change
This PR addresses the feedback provided in issue [ #46531 ] (https://github.com/apache/arrow/issues/46531), refactoring the singleton logic to follow the project's file organization conventions.

What changes are included in this PR?
      Moved the singleton declaration to type.h      
      Moved the singleton definition to type.cc      
      Moved the corresponding test to type_test.cc

Are these changes tested?
✅ Yes, tests are included in type_test.cc.

Are there any user-facing changes?
❌ No, there are no user-facing or breaking changes in this PR.