### PR TITLE
GH-46611: [Python][C++] Allow building float16 arrays without numpy

### DIFF
--- a/python/pyarrow/includes/common.pxd
+++ b/python/pyarrow/includes/common.pxd
@@ -83,9 +83,6 @@ cdef extern from "<Python.h>":
     void Py_XDECREF(PyObject* o)
     Py_ssize_t Py_REFCNT(PyObject* o)
 
-cdef extern from "numpy/halffloat.h":
-    ctypedef uint16_t npy_half
-
 cdef extern from "arrow/api.h" namespace "arrow" nogil:
     # We can later add more of the common status factory methods as needed
     cdef CStatus CStatus_OK "arrow::Status::OK"()

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -1314,7 +1314,7 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
         uint64_t value
 
     cdef cppclass CHalfFloatScalar" arrow::HalfFloatScalar"(CScalar):
-        npy_half value
+        uint16_t value
 
     cdef cppclass CFloatScalar" arrow::FloatScalar"(CScalar):
         float value

--- a/python/pyarrow/includes/libarrow_python.pxd
+++ b/python/pyarrow/includes/libarrow_python.pxd
@@ -55,7 +55,7 @@ cdef extern from "arrow/python/arrow_to_pandas.h" namespace "arrow::py::MapConve
 cdef extern from "arrow/python/api.h" namespace "arrow::py" nogil:
     shared_ptr[CDataType] GetPrimitiveType(Type type)
 
-    object PyHalf_FromHalf(npy_half value)
+    object PyHalf_FromHalf(uint16_t value)
 
     cdef cppclass PyConversionOptions:
         PyConversionOptions()

--- a/python/pyarrow/includes/libarrow_python.pxd
+++ b/python/pyarrow/includes/libarrow_python.pxd
@@ -55,7 +55,7 @@ cdef extern from "arrow/python/arrow_to_pandas.h" namespace "arrow::py::MapConve
 cdef extern from "arrow/python/api.h" namespace "arrow::py" nogil:
     shared_ptr[CDataType] GetPrimitiveType(Type type)
 
-    object PyHalf_FromHalf(uint16_t value)
+    object PyFloat_FromHalf(uint16_t value)
 
     cdef cppclass PyConversionOptions:
         PyConversionOptions()

--- a/python/pyarrow/scalar.pxi
+++ b/python/pyarrow/scalar.pxi
@@ -388,7 +388,7 @@ cdef class HalfFloatScalar(Scalar):
             This parameter is ignored for non-nested Scalars.
         """
         cdef CHalfFloatScalar* sp = <CHalfFloatScalar*> self.wrapped.get()
-        return PyHalf_FromHalf(sp.value) if sp.is_valid else None
+        return PyFloat_FromHalf(sp.value) if sp.is_valid else None
 
 
 cdef class FloatScalar(Scalar):

--- a/python/pyarrow/src/arrow/python/helpers.cc
+++ b/python/pyarrow/src/arrow/python/helpers.cc
@@ -83,7 +83,6 @@ PyObject* PyFloat_FromHalf(uint16_t value) {
 
 Result<uint16_t> PyFloat_AsHalf(PyObject* obj) {
   if (PyFloat_Check(obj)) {
-    // Use Arrow's Float16 implementation instead of NumPy
     float float_val = static_cast<float>(PyFloat_AsDouble(obj));
     arrow::util::Float16 half_val = arrow::util::Float16::FromFloat(float_val);
     return half_val.bits();

--- a/python/pyarrow/src/arrow/python/helpers.cc
+++ b/python/pyarrow/src/arrow/python/helpers.cc
@@ -82,7 +82,6 @@ PyObject* PyFloat_FromHalf(uint16_t value) {
 }
 
 Result<uint16_t> PyFloat_AsHalf(PyObject* obj) {
-  uint16_t value;
   if (PyFloat_Check(obj)) {
     // Use Arrow's Float16 implementation instead of NumPy
     float float_val = static_cast<float>(PyFloat_AsDouble(obj));
@@ -91,10 +90,9 @@ Result<uint16_t> PyFloat_AsHalf(PyObject* obj) {
   } else if (has_numpy() && PyArray_IsScalar(obj, Half)) {
     return PyArrayScalar_VAL(obj, Half);
   } else {
-    return Status::Invalid("Could not convert expected float with type ",
-                           Py_TYPE(obj)->tp_name, ": to Float16");
+    return Status::TypeError("conversion to float16 expects a `float` or ",
+                             "`np.float16` object, got ", Py_TYPE(obj)->tp_name);
   }
-  return value;
 }
 
 namespace internal {

--- a/python/pyarrow/src/arrow/python/helpers.cc
+++ b/python/pyarrow/src/arrow/python/helpers.cc
@@ -78,8 +78,7 @@ std::shared_ptr<DataType> GetPrimitiveType(Type::type type) {
 PyObject* PyFloat_FromHalf(uint16_t value) {
   // Convert the uint16_t Float16 value to a PyFloat object
   arrow::util::Float16 half_val = arrow::util::Float16::FromBits(value);
-  PyObject* result = PyFloat_FromDouble(half_val.ToDouble());
-  return result;
+  return PyFloat_FromDouble(half_val.ToDouble());
 }
 
 Result<uint16_t> PyFloat_AsHalf(PyObject* obj) {
@@ -88,9 +87,9 @@ Result<uint16_t> PyFloat_AsHalf(PyObject* obj) {
     // Use Arrow's Float16 implementation instead of NumPy
     float float_val = static_cast<float>(PyFloat_AsDouble(obj));
     arrow::util::Float16 half_val = arrow::util::Float16::FromFloat(float_val);
-    value = half_val.bits();
+    return half_val.bits();
   } else if (has_numpy() && PyArray_IsScalar(obj, Half)) {
-    value = PyArrayScalar_VAL(obj, Half);
+    return PyArrayScalar_VAL(obj, Half);
   } else {
     return Status::Invalid("Could not convert expected float with type ",
                            Py_TYPE(obj)->tp_name, ": to Float16");

--- a/python/pyarrow/src/arrow/python/helpers.cc
+++ b/python/pyarrow/src/arrow/python/helpers.cc
@@ -83,8 +83,8 @@ PyObject* PyFloat_FromHalf(uint16_t value) {
 
 Result<uint16_t> PyFloat_AsHalf(PyObject* obj) {
   if (PyFloat_Check(obj)) {
-    float float_val = static_cast<float>(PyFloat_AsDouble(obj));
-    arrow::util::Float16 half_val = arrow::util::Float16::FromFloat(float_val);
+    double float_val = static_cast<float>(PyFloat_AsDouble(obj));
+    arrow::util::Float16 half_val = arrow::util::Float16::FromDouble(float_val);
     return half_val.bits();
   } else if (has_numpy() && PyArray_IsScalar(obj, Half)) {
     return PyArrayScalar_VAL(obj, Half);

--- a/python/pyarrow/src/arrow/python/helpers.cc
+++ b/python/pyarrow/src/arrow/python/helpers.cc
@@ -83,8 +83,8 @@ PyObject* PyFloat_FromHalf(uint16_t value) {
 
 Result<uint16_t> PyFloat_AsHalf(PyObject* obj) {
   if (PyFloat_Check(obj)) {
-    double float_val = static_cast<float>(PyFloat_AsDouble(obj));
-    arrow::util::Float16 half_val = arrow::util::Float16::FromDouble(float_val);
+    arrow::util::Float16 half_val =
+        arrow::util::Float16::FromDouble(PyFloat_AsDouble(obj));
     return half_val.bits();
   } else if (has_numpy() && PyArray_IsScalar(obj, Half)) {
     return PyArrayScalar_VAL(obj, Half);

--- a/python/pyarrow/src/arrow/python/helpers.cc
+++ b/python/pyarrow/src/arrow/python/helpers.cc
@@ -75,8 +75,16 @@ std::shared_ptr<DataType> GetPrimitiveType(Type::type type) {
   }
 }
 
-PyObject* PyHalf_FromHalf(uint16_t value) {
-  // Convert the uint16_t to a PyFloat object
+PyObject* PyHalf_FromHalf(npy_half value) {
+  PyObject* result = PyArrayScalar_New(Half);
+  if (result != NULL) {
+    PyArrayScalar_ASSIGN(result, Half, value);
+  }
+  return result;
+}
+
+PyObject* PyFloat_FromHalf(uint16_t value) {
+  // Convert the uint16_t Float16 value to a PyFloat object
   arrow::util::Float16 half_val = arrow::util::Float16::FromBits(value);
   PyObject* result = PyFloat_FromDouble(half_val.ToDouble());
   return result;

--- a/python/pyarrow/src/arrow/python/helpers.cc
+++ b/python/pyarrow/src/arrow/python/helpers.cc
@@ -76,10 +76,9 @@ std::shared_ptr<DataType> GetPrimitiveType(Type::type type) {
 }
 
 PyObject* PyHalf_FromHalf(uint16_t value) {
-  PyObject* result = PyArrayScalar_New(Half);
-  if (result != NULL) {
-    PyArrayScalar_ASSIGN(result, Half, value);
-  }
+  // Convert the uint16_t to a PyFloat object
+  arrow::util::Float16 half_val = arrow::util::Float16::FromBits(value);
+  PyObject* result = PyFloat_FromDouble(half_val.ToDouble());
   return result;
 }
 

--- a/python/pyarrow/src/arrow/python/helpers.h
+++ b/python/pyarrow/src/arrow/python/helpers.h
@@ -50,7 +50,7 @@ ARROW_PYTHON_EXPORT PyObject* PyHalf_FromHalf(npy_half value);
 // \brief Construct a Python float object from a uint16_t value.
 ARROW_PYTHON_EXPORT PyObject* PyFloat_FromHalf(uint16_t value);
 
-// \brief Convert a Python object to a uint16_t value.
+// \brief Convert a Python object to a half-float uint16_t value.
 ARROW_PYTHON_EXPORT Status PyFloat_AsHalf(PyObject* obj, uint16_t* out);
 
 namespace internal {

--- a/python/pyarrow/src/arrow/python/helpers.h
+++ b/python/pyarrow/src/arrow/python/helpers.h
@@ -43,11 +43,11 @@ class OwnedRef;
 // \return A shared pointer to DataType
 ARROW_PYTHON_EXPORT std::shared_ptr<DataType> GetPrimitiveType(Type::type type);
 
-// \brief Construct a np.float16 object from a npy_half value.
-ARROW_PYTHON_EXPORT PyObject* PyHalf_FromHalf(npy_half value);
+// \brief Construct a np.float16 object from a uint16_t value.
+ARROW_PYTHON_EXPORT PyObject* PyHalf_FromHalf(uint16_t value);
 
-// \brief Convert a Python object to a npy_half value.
-ARROW_PYTHON_EXPORT Status PyFloat_AsHalf(PyObject* obj, npy_half* out);
+// \brief Convert a Python object to a uint16_t value.
+ARROW_PYTHON_EXPORT Status PyFloat_AsHalf(PyObject* obj, uint16_t* out);
 
 namespace internal {
 

--- a/python/pyarrow/src/arrow/python/helpers.h
+++ b/python/pyarrow/src/arrow/python/helpers.h
@@ -43,8 +43,12 @@ class OwnedRef;
 // \return A shared pointer to DataType
 ARROW_PYTHON_EXPORT std::shared_ptr<DataType> GetPrimitiveType(Type::type type);
 
-// \brief Construct a np.float16 object from a uint16_t value.
-ARROW_PYTHON_EXPORT PyObject* PyHalf_FromHalf(uint16_t value);
+// \brief Construct a np.float16 object from a npy_half value.
+ARROW_DEPRECATED("Deprecated in 21.0.0. Will be removed in 23.0.0")
+ARROW_PYTHON_EXPORT PyObject* PyHalf_FromHalf(npy_half value);
+
+// \brief Construct a Python float object from a uint16_t value.
+ARROW_PYTHON_EXPORT PyObject* PyFloat_FromHalf(uint16_t value);
 
 // \brief Convert a Python object to a uint16_t value.
 ARROW_PYTHON_EXPORT Status PyFloat_AsHalf(PyObject* obj, uint16_t* out);

--- a/python/pyarrow/src/arrow/python/helpers.h
+++ b/python/pyarrow/src/arrow/python/helpers.h
@@ -41,7 +41,7 @@ class OwnedRef;
 // \return A shared pointer to DataType
 ARROW_PYTHON_EXPORT std::shared_ptr<DataType> GetPrimitiveType(Type::type type);
 
-// \brief Construct a Python float object from a uint16_t value.
+// \brief Construct a Python float object from a half-float uint16_t value.
 ARROW_PYTHON_EXPORT PyObject* PyFloat_FromHalf(uint16_t value);
 
 // \brief Convert a Python object to a half-float uint16_t value.

--- a/python/pyarrow/src/arrow/python/helpers.h
+++ b/python/pyarrow/src/arrow/python/helpers.h
@@ -43,15 +43,11 @@ class OwnedRef;
 // \return A shared pointer to DataType
 ARROW_PYTHON_EXPORT std::shared_ptr<DataType> GetPrimitiveType(Type::type type);
 
-// \brief Construct a np.float16 object from a npy_half value.
-ARROW_DEPRECATED("Deprecated in 21.0.0. Will be removed in 23.0.0")
-ARROW_PYTHON_EXPORT PyObject* PyHalf_FromHalf(npy_half value);
-
 // \brief Construct a Python float object from a uint16_t value.
 ARROW_PYTHON_EXPORT PyObject* PyFloat_FromHalf(uint16_t value);
 
 // \brief Convert a Python object to a half-float uint16_t value.
-ARROW_PYTHON_EXPORT Status PyFloat_AsHalf(PyObject* obj, uint16_t* out);
+ARROW_PYTHON_EXPORT Result<uint16_t> PyFloat_AsHalf(PyObject* obj);
 
 namespace internal {
 

--- a/python/pyarrow/src/arrow/python/helpers.h
+++ b/python/pyarrow/src/arrow/python/helpers.h
@@ -26,8 +26,6 @@
 
 #include "arrow/python/numpy_interop.h"
 
-#include <numpy/halffloat.h>
-
 #include "arrow/python/visibility.h"
 #include "arrow/type.h"
 #include "arrow/util/macros.h"

--- a/python/pyarrow/src/arrow/python/python_to_arrow.cc
+++ b/python/pyarrow/src/arrow/python/python_to_arrow.cc
@@ -229,9 +229,9 @@ class PyValue {
     if (internal::PyFloatScalar_Check(obj)) {
       return PyFloat_AsHalf(obj);
     } else if (internal::PyIntScalar_Check(obj)) {
-      float float_val{};
-      RETURN_NOT_OK(internal::IntegerScalarToFloat32Safe(obj, &float_val));
-      const auto half_val = arrow::util::Float16::FromFloat(float_val);
+      double float_val{};
+      RETURN_NOT_OK(internal::IntegerScalarToDoubleSafe(obj, &float_val));
+      const auto half_val = arrow::util::Float16::FromDouble(float_val);
       return half_val.bits();
     } else {
       return internal::InvalidValue(obj, "tried to convert to float16");

--- a/python/pyarrow/src/arrow/python/python_to_arrow.cc
+++ b/python/pyarrow/src/arrow/python/python_to_arrow.cc
@@ -226,7 +226,6 @@ class PyValue {
   }
 
   static Result<uint16_t> Convert(const HalfFloatType*, const O&, I obj) {
-    uint16_t value;
     if (internal::PyFloatScalar_Check(obj)) {
       return PyFloat_AsHalf(obj);
     } else if (internal::PyIntScalar_Check(obj)) {
@@ -237,7 +236,6 @@ class PyValue {
     } else {
       return internal::InvalidValue(obj, "tried to convert to float16");
     }
-    return value;
   }
 
   static Result<float> Convert(const FloatType*, const O&, I obj) {

--- a/python/pyarrow/src/arrow/python/python_to_arrow.cc
+++ b/python/pyarrow/src/arrow/python/python_to_arrow.cc
@@ -232,7 +232,7 @@ class PyValue {
     } else if (internal::PyIntScalar_Check(obj)) {
       float float_val{};
       RETURN_NOT_OK(internal::IntegerScalarToFloat32Safe(obj, &float_val));
-      arrow::util::Float16 half_val = arrow::util::Float16::FromFloat(float_val);
+      const auto half_val = arrow::util::Float16::FromFloat(float_val);
       value = half_val.bits();
     } else {
       return internal::InvalidValue(obj, "tried to convert to float16");

--- a/python/pyarrow/src/arrow/python/python_to_arrow.cc
+++ b/python/pyarrow/src/arrow/python/python_to_arrow.cc
@@ -228,7 +228,7 @@ class PyValue {
   static Result<uint16_t> Convert(const HalfFloatType*, const O&, I obj) {
     uint16_t value;
     if (internal::PyFloatScalar_Check(obj)) {
-      RETURN_NOT_OK(PyFloat_AsHalf(obj, &value));
+      ARROW_ASSIGN_OR_RAISE(value, PyFloat_AsHalf(obj));
     } else if (internal::PyIntScalar_Check(obj)) {
       float float_val{};
       RETURN_NOT_OK(internal::IntegerScalarToFloat32Safe(obj, &float_val));

--- a/python/pyarrow/src/arrow/python/python_to_arrow.cc
+++ b/python/pyarrow/src/arrow/python/python_to_arrow.cc
@@ -228,12 +228,12 @@ class PyValue {
   static Result<uint16_t> Convert(const HalfFloatType*, const O&, I obj) {
     uint16_t value;
     if (internal::PyFloatScalar_Check(obj)) {
-      ARROW_ASSIGN_OR_RAISE(value, PyFloat_AsHalf(obj));
+      return PyFloat_AsHalf(obj);
     } else if (internal::PyIntScalar_Check(obj)) {
       float float_val{};
       RETURN_NOT_OK(internal::IntegerScalarToFloat32Safe(obj, &float_val));
       const auto half_val = arrow::util::Float16::FromFloat(float_val);
-      value = half_val.bits();
+      return half_val.bits();
     } else {
       return internal::InvalidValue(obj, "tried to convert to float16");
     }

--- a/python/pyarrow/src/arrow/python/type_traits.h
+++ b/python/pyarrow/src/arrow/python/type_traits.h
@@ -29,6 +29,7 @@
 #include <numpy/halffloat.h>
 
 #include "arrow/type_fwd.h"
+#include "arrow/util/float16.h"
 #include "arrow/util/logging.h"
 
 namespace arrow {
@@ -87,15 +88,18 @@ NPY_INT_DECL(ULONGLONG, UInt64, uint64_t);
 
 template <>
 struct npy_traits<NPY_FLOAT16> {
-  typedef npy_half value_type;
+  typedef uint16_t value_type;
   using TypeClass = HalfFloatType;
   using BuilderClass = HalfFloatBuilder;
 
-  static constexpr npy_half na_sentinel = NPY_HALF_NAN;
+  static constexpr uint16_t na_sentinel =
+      std::numeric_limits<arrow::util::Float16>::quiet_NaN().bits();
 
   static constexpr bool supports_nulls = true;
 
-  static inline bool isnull(npy_half v) { return v == NPY_HALF_NAN; }
+  static inline bool isnull(uint16_t v) {
+    return arrow::util::Float16::FromBits(v).is_nan();
+  }
 };
 
 template <>
@@ -201,7 +205,8 @@ template <>
 struct arrow_traits<Type::HALF_FLOAT> {
   static constexpr int npy_type = NPY_FLOAT16;
   static constexpr bool supports_nulls = true;
-  static constexpr uint16_t na_value = NPY_HALF_NAN;
+  static constexpr uint16_t na_value =
+      std::numeric_limits<arrow::util::Float16>::quiet_NaN().bits();
   typedef typename npy_traits<NPY_FLOAT16>::value_type T;
 };
 

--- a/python/pyarrow/src/arrow/python/type_traits.h
+++ b/python/pyarrow/src/arrow/python/type_traits.h
@@ -26,8 +26,6 @@
 
 #include "arrow/python/numpy_interop.h"
 
-#include <numpy/halffloat.h>
-
 #include "arrow/type_fwd.h"
 #include "arrow/util/float16.h"
 #include "arrow/util/logging.h"

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -1666,9 +1666,9 @@ def test_floating_point_truncate_unsafe():
 
 def test_half_float_array_from_python():
     # GH-46611
-    arr = pa.array([1.0, 2.0, 3, None], type=pa.float16())
+    arr = pa.array([1.0, 2.0, 3, None, 12345.6789, 1.234567], type=pa.float16())
     assert arr.type == pa.float16()
-    assert arr.to_pylist() == [1.0, 2.0, 3.0, None]
+    assert arr.to_pylist() == [1.0, 2.0, 3.0, None, 12344.0, 1.234375]
     msg1 = "Could not convert 'a' with type str: tried to convert to float16"
     with pytest.raises(pa.ArrowInvalid, match=msg1):
         arr = pa.array(['a', 3, None], type=pa.float16())

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -1664,6 +1664,16 @@ def test_floating_point_truncate_unsafe():
         _check_cast_case(case, safe=False)
 
 
+def test_half_float_array_from_python():
+    # GH-46611
+    arr = pa.array([1.0, 2.0, 3, None], type=pa.float16())
+    assert arr.type == pa.float16()
+    assert arr.to_pylist() == [1.0, 2.0, 3.0, None]
+    msg1 = "Could not convert 'a' with type str: tried to convert to float16"
+    with pytest.raises(pa.ArrowInvalid, match=msg1):
+        arr = pa.array(['a', 3, None], type=pa.float16())
+
+
 def test_decimal_to_int_safe():
     safe_cases = [
         (
@@ -2281,10 +2291,11 @@ def test_array_conversions_no_sentinel_values():
 
     assert arr2.type == 'int8'
 
-    arr3 = pa.array(np.array([1, np.nan, 2, 3, np.nan, 4], dtype='float32'),
-                    type='float32')
-    assert arr3.type == 'float32'
-    assert arr3.null_count == 0
+    for ty in ['float16', 'float32', 'float64']:
+        arr3 = pa.array(np.array([1, np.nan, 2, 3, np.nan, 4], dtype=ty),
+                        type=ty)
+        assert arr3.type == ty
+        assert arr3.null_count == 0
 
 
 def test_time32_time64_from_integer():

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -1007,14 +1007,14 @@ class TestConvertPrimitiveTypes:
         arr = np.array([1.5, np.nan], dtype=np.float16)
         a = pa.array(arr, type=pa.float16())
         x, y = a.to_pylist()
-        assert isinstance(x, np.float16)
+        assert isinstance(x, float)
         assert x == 1.5
-        assert isinstance(y, np.float16)
+        assert isinstance(y, float)
         assert np.isnan(y)
 
         a = pa.array(arr, type=pa.float16(), from_pandas=True)
         x, y = a.to_pylist()
-        assert isinstance(x, np.float16)
+        assert isinstance(x, float)
         assert x == 1.5
         assert y is None
 

--- a/python/pyarrow/tests/test_scalars.py
+++ b/python/pyarrow/tests/test_scalars.py
@@ -42,6 +42,7 @@ import pyarrow.compute as pc
     (1, pa.uint32(), pa.UInt32Scalar),
     (1, pa.int64(), pa.Int64Scalar),
     (1, pa.uint64(), pa.UInt64Scalar),
+    (1.0, pa.float16(), pa.HalfFloatScalar),
     (1.0, None, pa.DoubleScalar),
     (1.0, pa.float32(), pa.FloatScalar),
     (decimal.Decimal("1.123"), None, pa.Decimal128Scalar),

--- a/python/pyarrow/tests/test_scalars.py
+++ b/python/pyarrow/tests/test_scalars.py
@@ -239,15 +239,12 @@ def test_numerics():
     assert str(s) == "1.5"
     assert s.as_py() == 1.5
 
-    if np is not None:
-        # float16
-        s = pa.scalar(np.float16(0.5), type='float16')
-        assert isinstance(s, pa.HalfFloatScalar)
-        # on numpy2 repr(np.float16(0.5)) == "np.float16(0.5)"
-        # on numpy1 repr(np.float16(0.5)) == "0.5"
-        assert repr(s) == f"<pyarrow.HalfFloatScalar: {np.float16(0.5)!r}>"
-        assert str(s) == "0.5"
-        assert s.as_py() == 0.5
+    # float16
+    s = pa.scalar(0.5, type='float16')
+    assert isinstance(s, pa.HalfFloatScalar)
+    assert repr(s) == "<pyarrow.HalfFloatScalar: 0.5>"
+    assert str(s) == "0.5"
+    assert s.as_py() == 0.5
 
 
 def test_decimal128():


### PR DESCRIPTION
### Rationale for this change

When we added Float16 we did not update pyarrow to be able to convert from Python objects to Arrow. Float16 required numpy and it crashed if numpy was not present.

### What changes are included in this PR?

Allow to not require numpy to generate float16 scalars and arrays on pyarrow and do not fail if numpy is not present.

### Are these changes tested?

Yes, new tests have been added

### Are there any user-facing changes?

No changes for old functionality. Users will be allowed to use float16 without requiring to use np.float16 and directly from Python objects

* GitHub Issue: #46611