### PR TITLE
GH-46610: [CI][Release] Use Python 3.12 on AlmaLinux 8

### DIFF
--- a/dev/release/setup-rhel-rebuilds.sh
+++ b/dev/release/setup-rhel-rebuilds.sh
@@ -42,7 +42,7 @@ dnf -y install \
   ninja-build \
   nodejs \
   openssl-devel \
-  python3.11-devel \
+  python3.12-devel \
   ruby-devel \
   sqlite-devel \
   vala-devel \
@@ -52,4 +52,3 @@ dnf -y install \
 npm install -g yarn
 
 python3 -m ensurepip --upgrade
-alternatives --set python /usr/bin/python3


### PR DESCRIPTION
### Rationale for this change

It seems that the default Python was changed to 3.12 from 3.11. 

### What changes are included in this PR?

Use Python 3.12 development package.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #46610