### PR TITLE
GH-46576: [C++] Suppress `codecvt_utf8` deprecation warning

### DIFF
--- a/cpp/cmake_modules/DefineOptions.cmake
+++ b/cpp/cmake_modules/DefineOptions.cmake
@@ -107,6 +107,10 @@ macro(tsort_bool_option_dependencies)
 endmacro()
 
 macro(resolve_option_dependencies)
+  # Arrow Flight SQL ODBC is available only for Windows for now.
+  if(NOT MSVC_TOOLCHAIN)
+    set(ARROW_FLIGHT_SQL_ODBC OFF)
+  endif()
   if(MSVC_TOOLCHAIN)
     set(ARROW_USE_GLOG OFF)
   endif()

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/attribute_utils.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/attribute_utils.h
@@ -58,7 +58,7 @@ inline SQLRETURN GetAttributeUTF8(const std::string& attributeValue, SQLPOINTER 
     *outputLenPtr = static_cast<O>(attributeValue.size());
   }
 
-  if (output && outputSize < attributeValue.size() + 1) {
+  if (output && outputSize < static_cast<O>(attributeValue.size() + 1)) {
     return SQL_SUCCESS_WITH_INFO;
   }
   return SQL_SUCCESS;
@@ -87,7 +87,8 @@ inline SQLRETURN GetAttributeSQLWCHAR(const std::string& attributeValue,
     *outputLenPtr = static_cast<O>(isLengthInBytes ? result : result / GetSqlWCharSize());
   }
 
-  if (output && outputSize < result + (isLengthInBytes ? GetSqlWCharSize() : 1)) {
+  if (output &&
+      outputSize < static_cast<O>(result + (isLengthInBytes ? GetSqlWCharSize() : 1))) {
     return SQL_SUCCESS_WITH_INFO;
   }
   return SQL_SUCCESS;


### PR DESCRIPTION
### Rationale for this change

Resolve warnings that get treated as errors by suppressing the warning.

### What changes are included in this PR?

1. Add `ARROW_SUPPRESS_DEPRECATION_WARNING` to code that use `codecvt_utf8`
2. Add explicit conversions for integer values in `cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/attribute_utils.h`

### Are these changes tested?
They are tested locally on my Windows environment. The build succeeds. 

### Are there any user-facing changes?

None

* GitHub Issue: #46576