### PR TITLE
GH-46578: [C++][Statistics] Fix the ownership handling of arrow::ArrayData::statistics in arrow::ArrayData::CopyTo and arrow::ArrayDataViewOrCopy

### DIFF
--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -3958,6 +3958,7 @@ TEST_F(TestArrayDataStatistics, CopyAssignment) {
 TEST_F(TestArrayDataStatistics, CopyTo) {
   ASSERT_OK_AND_ASSIGN(auto copied_data,
                        data_->CopyTo(arrow::default_cpu_memory_manager()));
+  ASSERT_NE(copied_data->statistics, data_->statistics);
 
   ASSERT_TRUE(copied_data->statistics->null_count.has_value());
   ASSERT_EQ(null_count_, copied_data->statistics->null_count.value());
@@ -3971,6 +3972,17 @@ TEST_F(TestArrayDataStatistics, CopyTo) {
   ASSERT_TRUE(std::holds_alternative<int64_t>(copied_data->statistics->max.value()));
   ASSERT_EQ(max_, std::get<int64_t>(copied_data->statistics->max.value()));
   ASSERT_TRUE(copied_data->statistics->is_max_exact);
+}
+TEST_F(TestArrayDataStatistics, CopyToNullArray) {
+  NullArray array(10);
+  auto& array_data = array.data();
+  auto statistics = std::make_shared<ArrayStatistics>();
+  statistics->null_count = 10;
+  array.data()->statistics = statistics;
+  ASSERT_OK_AND_ASSIGN(auto copied_array_data,
+                       array_data->CopyTo(arrow::default_cpu_memory_manager()));
+  ASSERT_NE(copied_array_data->statistics, array.statistics());
+  ASSERT_EQ(*copied_array_data->statistics, *array.statistics());
 }
 
 TEST_F(TestArrayDataStatistics, Slice) {

--- a/cpp/src/arrow/array/data.cc
+++ b/cpp/src/arrow/array/data.cc
@@ -173,7 +173,9 @@ Result<std::shared_ptr<ArrayData>> CopyToImpl(const ArrayData& data,
   } else {
     // Note that some types, like Null, use the same path for both copy and view
     // operations. In such cases, it is assumed that arrow::ArrayData is also copied.
-    output->statistics = std::make_shared<ArrayStatistics>(*data.statistics);
+    if (data.statistics != nullptr) {
+      output->statistics = std::make_shared<ArrayStatistics>(*data.statistics);
+    }
   }
 
   return output;

--- a/cpp/src/arrow/gpu/cuda_test.cc
+++ b/cpp/src/arrow/gpu/cuda_test.cc
@@ -1067,11 +1067,9 @@ TEST_F(TestArrayDataStatisticsViewOrCopyTO, CPUBufferAndCudaBufferPointToCpuMemo
   array_data->null_count = 4;
   ASSERT_TRUE(is_valid_as_array(array_data));
   {
-    // The view operation is applied to CudaBuffers because it's possible to obtain a
-    // host pointer from them.
-    // I ran this test on an RTX 3050 Mobile (which supports Unified Addressing), and
-    // the assertion passed. However, on GPUs that do not support Unified Addressing,
-    // the assertion is expected to fail.
+    // I ran this test on an RTX 3050 Mobile, which supports the device attribute
+    // cudaDevAttrCanUseHostPointerForRegisteredMem, and the assertion passed.
+    // On GPUs that do not support this attribute, the assertion is expected to fail.
     ASSERT_OK_AND_ASSIGN(auto viewed_array_data, array_data->ViewOrCopyTo(cpu_mm_));
     ASSERT_TRUE(is_statistics_shared(array_data, viewed_array_data));
   }
@@ -1132,11 +1130,10 @@ TEST_F(TestArrayDataStatisticsViewOrCopyTO, CudaHostBufferAndGpuBuffersPointToMe
   array_data->null_count = 4;
   ASSERT_TRUE(is_valid_as_array(array_data));
   {
-    // The view operation is applied to data_buffer because it's possible to obtain a
-    // host pointer from it.
-    // I ran this test on an RTX 3050 Mobile (which supports Unified Addressing), and
-    // the assertion passed. However, on GPUs that do not support Unified Addressing,
-    // the assertion is expected to fail.
+    // I ran this test on an RTX 3050 Mobile, which supports the device attribute
+    // cudaDevAttrCanUseHostPointerForRegisteredMem, and the assertion passed.
+    // On GPUs that do not support this attribute, the assertion is expected to fail.
+
     ASSERT_OK_AND_ASSIGN(auto viewed_array_data, array_data->ViewOrCopyTo(cpu_mm_));
     ASSERT_TRUE(is_statistics_shared(array_data, viewed_array_data));
   }
@@ -1158,8 +1155,10 @@ TEST_F(TestArrayDataStatisticsViewOrCopyTO, CudaBuffers) {
   statistics->max = 10;
   array_data->statistics = statistics;
   array_data->null_count = 4;
-  // Why does the assertion below fail
+  // Why does the assertion below fail? Is the bitmap_buffer on the GPU invalid,
+  // even though the other GPU-resident buffers are valid?
   // ASSERT_TRUE(is_valid_as_array(array_data));
+
   {
     // Since it's not possible to get  host pointers from CudaBuffers,
     // the buffers are copied.
@@ -1193,11 +1192,10 @@ TEST_F(TestArrayDataStatisticsViewOrCopyTO, CudaBuffersPointToCpuMemory) {
   // even though the other GPU-resident buffers are valid?
   // ASSERT_TRUE(is_valid_as_array(array_data));
   {
-    // The view operation is applied to CudaBuffers because it's possible to obtain a
-    // host pointer from them.
-    // Note that I ran this test on an RTX 3050 Mobile (which supports Unified
-    // Addressing), and the assertion passed. However, on GPUs that do not support Unified
-    // Addressing, the assertion is expected to fail.
+    // I ran this test on an RTX 3050 Mobile, which supports the device attribute
+    // cudaDevAttrCanUseHostPointerForRegisteredMem, and the assertion passed.
+    // On GPUs that do not support this attribute, the assertion is expected to fail.
+
     ASSERT_OK_AND_ASSIGN(auto viewed_data, array_data->ViewOrCopyTo(cpu_mm_));
     ASSERT_TRUE(is_statistics_shared(array_data, viewed_data));
   }

--- a/cpp/src/arrow/gpu/cuda_test.cc
+++ b/cpp/src/arrow/gpu/cuda_test.cc
@@ -965,6 +965,17 @@ class TestArrayDataStatisticsViewOrCopyTO : public TestCudaBase {
  protected:
   std::shared_ptr<CudaMemoryManager> my_cuda_mm_;
 };
+TEST_F(TestArrayDataStatisticsViewOrCopyTO, EmptyStatistics) {
+  ASSERT_OK_AND_ASSIGN(auto bitmap_buffer, GenerateCPUBitmapBuffer(10));
+  ASSERT_OK_AND_ASSIGN(auto data_buffer,
+                       GenerateCPUDataBuffer({1, 2, 3, 4, 5, 6, 7, 8, 9, 10}));
+  auto array_data = ArrayData::Make(int32(), 10, {bitmap_buffer, data_buffer});
+  auto statistics = std::make_shared<ArrayStatistics>();
+  ASSERT_TRUE(is_valid_as_array(array_data));
+
+  ASSERT_OK_AND_ASSIGN(auto viewed_array_data, array_data->ViewOrCopyTo(cpu_mm_));
+  ASSERT_TRUE(is_statistics_shared(array_data, viewed_array_data));
+}
 
 TEST_F(TestArrayDataStatisticsViewOrCopyTO, NullArray) {
   NullArray array(10);


### PR DESCRIPTION
### Rationale for this change
Fix the ownership management of `arrow::ArrayStatistics `within `arrow::ArrayData::ViewOrCopyTo` .
### What changes are included in this PR?
Correct ownership handling of `arrow::ArrayStatistics` in `arrow::ArrayData::ViewOrCopyTo.`
Add tests to verify whether` arrow::ArrayData::statistics` is shared or copied as expected.
### Are these changes tested?
Yes, I run the relevant unit tests.
### Are there any user-facing changes?
No
* GitHub Issue: #46578