### PR TITLE
GH-31603: [C++] Add SecureString implementation to arrow/util/

### DIFF
--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -515,6 +515,7 @@ set(ARROW_UTIL_SRCS
     util/memory.cc
     util/mutex.cc
     util/ree_util.cc
+    util/secure_string.cc
     util/string.cc
     util/string_builder.cc
     util/task_group.cc
@@ -572,6 +573,11 @@ endif()
 if(ARROW_USE_GLOG)
   foreach(ARROW_UTIL_TARGET ${ARROW_UTIL_TARGETS})
     target_link_libraries(${ARROW_UTIL_TARGET} PRIVATE glog::glog)
+  endforeach()
+endif()
+if(ARROW_USE_OPENSSL)
+  foreach(ARROW_UTIL_TARGET ${ARROW_UTIL_TARGETS})
+    target_link_libraries(${ARROW_UTIL_TARGET} PRIVATE ${ARROW_OPENSSL_LIBS})
   endforeach()
 endif()
 if(ARROW_USE_XSIMD)

--- a/cpp/src/arrow/util/CMakeLists.txt
+++ b/cpp/src/arrow/util/CMakeLists.txt
@@ -72,6 +72,7 @@ add_arrow_test(utility-test
                ree_util_test.cc
                reflection_test.cc
                rows_to_batches_test.cc
+               secure_string_test.cc
                small_vector_test.cc
                span_test.cc
                stl_util_test.cc

--- a/cpp/src/arrow/util/secure_string.cc
+++ b/cpp/src/arrow/util/secure_string.cc
@@ -1,0 +1,147 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#if defined(ARROW_USE_OPENSSL)
+#  include <openssl/crypto.h>
+#  include <openssl/opensslv.h>
+#endif
+#include <utility>
+#if defined(_WIN32)
+#  include <windows.h>
+#endif
+
+#include "arrow/util/secure_string.h"
+#include "arrow/util/span.h"
+
+namespace arrow::util {
+SecureString::SecureString(SecureString&& secret) noexcept
+    : secret_(std::move(secret.secret_)) {
+  secret.Dispose();
+}
+SecureString::SecureString(std::string&& secret) noexcept : secret_(std::move(secret)) {
+  SecureClear(&secret);
+}
+SecureString::SecureString(size_t n, char c) noexcept : secret_(n, c) {}
+
+SecureString& SecureString::operator=(SecureString&& secret) noexcept {
+  if (this == &secret) {
+    // self-assignment
+    return *this;
+  }
+  Dispose();
+  secret_ = std::move(secret.secret_);
+  secret.Dispose();
+  return *this;
+}
+SecureString& SecureString::operator=(const SecureString& secret) {
+  if (this == &secret) {
+    // self-assignment
+    return *this;
+  }
+  Dispose();
+  secret_ = secret.secret_;
+  return *this;
+}
+SecureString& SecureString::operator=(std::string&& secret) noexcept {
+  Dispose();
+  // if secret is local string (length <= 15 characters), copies local buffer, resets to 0
+  // - requires secure cleaning the local buffer
+  // if secret is longer, moves the pointer to secret_, resets to 0 and uses local buffer
+  // - does not require cleaning anything
+  secret_ = std::move(secret);
+  // cleans only the local buffer of secret as this always is a local string by now
+  SecureClear(&secret);
+  return *this;
+}
+
+bool SecureString::operator==(const SecureString& other) const {
+  return secret_ == other.secret_;
+}
+
+bool SecureString::operator!=(const SecureString& other) const {
+  return secret_ != other.secret_;
+}
+
+bool SecureString::empty() const { return secret_.empty(); }
+std::size_t SecureString::size() const { return secret_.size(); }
+std::size_t SecureString::length() const { return secret_.length(); }
+
+::arrow::util::span<uint8_t> SecureString::as_span() {
+  return {reinterpret_cast<uint8_t*>(secret_.data()), secret_.size()};
+}
+::arrow::util::span<const uint8_t> SecureString::as_span() const {
+  return {reinterpret_cast<const uint8_t*>(secret_.data()), secret_.size()};
+}
+std::string_view SecureString::as_view() const {
+  return {secret_.data(), secret_.size()};
+}
+
+void SecureString::Dispose() { SecureClear(&secret_); }
+void SecureString::SecureClear(std::string* secret) {
+  secret->clear();
+  SecureClear(reinterpret_cast<uint8_t*>(secret->data()), secret->capacity());
+}
+inline void SecureString::SecureClear(uint8_t* data, size_t size) {
+  // There is various prior art for this:
+  // https://www.cryptologie.net/article/419/zeroing-memory-compiler-optimizations-and-memset_s/
+  // - libb2's `secure_zero_memory` at
+  // https://github.com/BLAKE2/libb2/blob/30d45a17c59dc7dbf853da3085b71d466275bd0a/src/blake2-impl.h#L140-L160
+  // - libsodium's `sodium_memzero` at
+  // https://github.com/jedisct1/libsodium/blob/be58b2e6664389d9c7993b55291402934b43b3ca/src/libsodium/sodium/utils.c#L78:L101
+  // Note:
+  // https://www.daemonology.net/blog/2014-09-06-zeroing-buffers-is-insufficient.html
+#if defined(_WIN32)
+  // SecureZeroMemory is meant to not be optimized away
+  SecureZeroMemory(data, size);
+#elif defined(__STDC_LIB_EXT1__)
+  // memset_s is meant to not be optimized away
+  memset_s(data, size, 0, size);
+#elif defined(OPENSSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x30000000
+  // rely on some implementation in OpenSSL cryptographic library
+  OPENSSL_cleanse(data, size);
+#elif defined(__GLIBC__) && (__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 25))
+  // explicit_bzero is meant to not be optimized away
+  explicit_bzero(data, size);
+#else
+  // Volatile pointer to memset function is an attempt to avoid
+  // that the compiler optimizes away the memset function call.
+  // pretty much what OPENSSL_cleanse above does
+  // https://github.com/openssl/openssl/blob/3423c30db3aa044f46e1f0270e2ecd899415bf5f/crypto/mem_clr.c#L22
+  static const volatile auto memset_v = &memset;
+  memset_v(data, 0, size);
+
+#  if defined(__GNUC__) || defined(__clang__)
+  // __asm__ only supported by GCC and Clang
+  // not supported by MSVC on the ARM and x64 processors
+  // https://en.cppreference.com/w/c/language/asm.html
+  // https://en.cppreference.com/w/cpp/language/asm.html
+
+  // Additional attempt on top of volatile memset_v above
+  // to avoid that the compiler optimizes away the memset function call.
+  // Assembler code that tells the compiler 'data' has side effects.
+  // https://gcc.gnu.org/onlinedocs/gcc/Extended-Asm.html:
+  // - "volatile": the asm produces side effects
+  // - "memory": effectively forms a read/write memory barrier for the compiler
+  __asm__ __volatile__(""          /* no actual code */
+                       :           /* no output */
+                       : "r"(data) /* input */
+                       : "memory" /* memory side effects beyond input and output */);
+#  endif
+#endif
+}
+
+}  // namespace arrow::util

--- a/cpp/src/arrow/util/secure_string.cc
+++ b/cpp/src/arrow/util/secure_string.cc
@@ -34,9 +34,9 @@
 
 namespace arrow::util {
 
-SecureString::SecureString(SecureString&& secret) noexcept
-    : secret_(std::move(secret.secret_)) {
-  secret.Dispose();
+SecureString::SecureString(SecureString&& other) noexcept
+    : secret_(std::move(other.secret_)) {
+  other.Dispose();
 }
 
 SecureString::SecureString(std::string&& secret) noexcept : secret_(std::move(secret)) {
@@ -45,24 +45,24 @@ SecureString::SecureString(std::string&& secret) noexcept : secret_(std::move(se
 
 SecureString::SecureString(size_t n, char c) noexcept : secret_(n, c) {}
 
-SecureString& SecureString::operator=(SecureString&& secret) noexcept {
-  if (this == &secret) {
+SecureString& SecureString::operator=(SecureString&& other) noexcept {
+  if (this == &other) {
     // self-assignment
     return *this;
   }
   Dispose();
-  secret_ = std::move(secret.secret_);
-  secret.Dispose();
+  secret_ = std::move(other.secret_);
+  other.Dispose();
   return *this;
 }
 
-SecureString& SecureString::operator=(const SecureString& secret) {
-  if (this == &secret) {
+SecureString& SecureString::operator=(const SecureString& other) {
+  if (this == &other) {
     // self-assignment
     return *this;
   }
   Dispose();
-  secret_ = secret.secret_;
+  secret_ = other.secret_;
   return *this;
 }
 

--- a/cpp/src/arrow/util/secure_string.cc
+++ b/cpp/src/arrow/util/secure_string.cc
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+// __STDC_WANT_LIB_EXT1__ and string.h are required by memset_s:
+// https://en.cppreference.com/w/c/string/byte/memset
 #define __STDC_WANT_LIB_EXT1__ 1
 #include <string.h>
 #include <utility>
@@ -29,8 +31,8 @@
 #  include <windows.h>
 #endif
 
-#include "arrow/util/secure_string.h"
 #include "arrow/util/logging.h"
+#include "arrow/util/secure_string.h"
 #include "arrow/util/span.h"
 
 namespace arrow::util {
@@ -52,8 +54,8 @@ namespace arrow::util {
 ///
 /// Thus, after a std::move(string), calling SecureClear(std::string*) only
 /// securely clears the **local buffer** of the string. Therefore, std::move(string)
-/// must move the pointer of long string into SecureString (which later clears the string).
-/// Otherwise, the content of the string cannot be securely cleared.
+/// must move the pointer of long string into SecureString (which later clears the
+/// string). Otherwise, the content of the string cannot be securely cleared.
 ///
 /// This condition is checked by secure_move.
 

--- a/cpp/src/arrow/util/secure_string.cc
+++ b/cpp/src/arrow/util/secure_string.cc
@@ -139,8 +139,11 @@ std::string_view SecureString::as_view() const {
 void SecureString::Dispose() { SecureClear(&secret_); }
 
 void SecureString::SecureClear(std::string* secret) {
-  secret->clear();
+  // in case of non-local strings (long strings), this order is vital
+  // first clear the string buffer
   SecureClear(reinterpret_cast<uint8_t*>(secret->data()), secret->capacity());
+  // then reset the string size (moves from the non-local to the local string buffer)
+  secret->clear();
 }
 
 inline void SecureString::SecureClear(uint8_t* data, size_t size) {

--- a/cpp/src/arrow/util/secure_string.cc
+++ b/cpp/src/arrow/util/secure_string.cc
@@ -38,7 +38,7 @@
 namespace arrow::util {
 
 /// Note:
-/// A string std::string is securely moved into a SecureString in two steps:
+/// A std::string is securely moved into a SecureString in two steps:
 /// 1. the std::string is moved via std::move(string)
 /// 2. the std::string is securely cleared
 ///
@@ -139,10 +139,8 @@ std::string_view SecureString::as_view() const {
 void SecureString::Dispose() { SecureClear(&secret_); }
 
 void SecureString::SecureClear(std::string* secret) {
-  // in case of non-local strings (long strings), this order is vital
-  // first clear the string buffer
+  // call SecureClear first just in case secret->clear() frees some memory
   SecureClear(reinterpret_cast<uint8_t*>(secret->data()), secret->capacity());
-  // then reset the string size (moves from the non-local to the local string buffer)
   secret->clear();
 }
 

--- a/cpp/src/arrow/util/secure_string.cc
+++ b/cpp/src/arrow/util/secure_string.cc
@@ -70,6 +70,12 @@ void SecureMove(std::string& string, std::string& dst) {
 }
 }  // namespace
 
+void SecureString::SecureClear(std::string* secret) {
+  // call SecureClear first just in case secret->clear() frees some memory
+  SecureClear(reinterpret_cast<uint8_t*>(secret->data()), secret->capacity());
+  secret->clear();
+}
+
 inline void SecureString::SecureClear(uint8_t* data, size_t size) {
   // There is various prior art for this:
   // https://www.cryptologie.net/article/419/zeroing-memory-compiler-optimizations-and-memset_s/
@@ -188,11 +194,5 @@ std::string_view SecureString::as_view() const {
 }
 
 void SecureString::Dispose() { SecureClear(&secret_); }
-
-void SecureString::SecureClear(std::string* secret) {
-  // call SecureClear first just in case secret->clear() frees some memory
-  SecureClear(reinterpret_cast<uint8_t*>(secret->data()), secret->capacity());
-  secret->clear();
-}
 
 }  // namespace arrow::util

--- a/cpp/src/arrow/util/secure_string.cc
+++ b/cpp/src/arrow/util/secure_string.cc
@@ -15,13 +15,16 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#define __STDC_WANT_LIB_EXT1__ 1
+#include <string.h>
+#include <utility>
+
 #if defined(ARROW_USE_OPENSSL)
 #  include <openssl/crypto.h>
 #  include <openssl/opensslv.h>
 #endif
-#define __STDC_WANT_LIB_EXT1__ 1
-#include <string.h>
-#include <utility>
+
+#include "arrow/util/windows_compatibility.h"
 #if defined(_WIN32)
 #  include <windows.h>
 #endif
@@ -30,13 +33,16 @@
 #include "arrow/util/span.h"
 
 namespace arrow::util {
+
 SecureString::SecureString(SecureString&& secret) noexcept
     : secret_(std::move(secret.secret_)) {
   secret.Dispose();
 }
+
 SecureString::SecureString(std::string&& secret) noexcept : secret_(std::move(secret)) {
   SecureClear(&secret);
 }
+
 SecureString::SecureString(size_t n, char c) noexcept : secret_(n, c) {}
 
 SecureString& SecureString::operator=(SecureString&& secret) noexcept {
@@ -49,6 +55,7 @@ SecureString& SecureString::operator=(SecureString&& secret) noexcept {
   secret.Dispose();
   return *this;
 }
+
 SecureString& SecureString::operator=(const SecureString& secret) {
   if (this == &secret) {
     // self-assignment
@@ -58,11 +65,16 @@ SecureString& SecureString::operator=(const SecureString& secret) {
   secret_ = secret.secret_;
   return *this;
 }
+
 SecureString& SecureString::operator=(std::string&& secret) noexcept {
   Dispose();
-  // if secret is local string (length <= 15 characters), copies local buffer, resets to 0
+  // std::string implementation may distinguish between local string (a very short string)
+  // and non-local (longer) strings. The former stores the string in a local buffer, the
+  // latter stores a pointer to allocated memory that stores the string.
+  //
+  // If secret is a local string, copies local buffer, resets size to 0
   // - requires secure cleaning the local buffer
-  // if secret is longer, moves the pointer to secret_, resets to 0 and uses local buffer
+  // If secret is longer, moves the pointer to secret_, resets to 0, uses local buffer
   // - does not require cleaning anything
   secret_ = std::move(secret);
   // cleans only the local buffer of secret as this always is a local string by now
@@ -79,24 +91,32 @@ bool SecureString::operator!=(const SecureString& other) const {
 }
 
 bool SecureString::empty() const { return secret_.empty(); }
+
 std::size_t SecureString::size() const { return secret_.size(); }
+
 std::size_t SecureString::length() const { return secret_.length(); }
 
-::arrow::util::span<uint8_t> SecureString::as_span() {
+std::size_t SecureString::capacity() const { return secret_.capacity(); }
+
+span<uint8_t> SecureString::as_span() {
   return {reinterpret_cast<uint8_t*>(secret_.data()), secret_.size()};
 }
-::arrow::util::span<const uint8_t> SecureString::as_span() const {
+
+span<const uint8_t> SecureString::as_span() const {
   return {reinterpret_cast<const uint8_t*>(secret_.data()), secret_.size()};
 }
+
 std::string_view SecureString::as_view() const {
   return {secret_.data(), secret_.size()};
 }
 
 void SecureString::Dispose() { SecureClear(&secret_); }
+
 void SecureString::SecureClear(std::string* secret) {
   secret->clear();
   SecureClear(reinterpret_cast<uint8_t*>(secret->data()), secret->capacity());
 }
+
 inline void SecureString::SecureClear(uint8_t* data, size_t size) {
   // There is various prior art for this:
   // https://www.cryptologie.net/article/419/zeroing-memory-compiler-optimizations-and-memset_s/

--- a/cpp/src/arrow/util/secure_string.cc
+++ b/cpp/src/arrow/util/secure_string.cc
@@ -19,6 +19,8 @@
 #  include <openssl/crypto.h>
 #  include <openssl/opensslv.h>
 #endif
+#define __STDC_WANT_LIB_EXT1__ 1
+#include <string.h>
 #include <utility>
 #if defined(_WIN32)
 #  include <windows.h>

--- a/cpp/src/arrow/util/secure_string.h
+++ b/cpp/src/arrow/util/secure_string.h
@@ -21,7 +21,7 @@
 #include <string>
 
 #include "arrow/util/span.h"
-#include "parquet/platform.h"
+#include "arrow/util/visibility.h"
 
 namespace arrow::util {
 /**
@@ -34,7 +34,7 @@ namespace arrow::util {
  * not noticing the need to securely erasing the argument after invoking the constructor /
  * calling the assignment operator.
  */
-class PARQUET_EXPORT SecureString {
+class ARROW_EXPORT SecureString {
  public:
   SecureString() noexcept = default;
   SecureString(SecureString&&) noexcept;
@@ -54,9 +54,10 @@ class PARQUET_EXPORT SecureString {
   [[nodiscard]] bool empty() const;
   [[nodiscard]] std::size_t size() const;
   [[nodiscard]] std::size_t length() const;
+  [[nodiscard]] std::size_t capacity() const;
 
-  [[nodiscard]] ::arrow::util::span<uint8_t> as_span();
-  [[nodiscard]] ::arrow::util::span<const uint8_t> as_span() const;
+  [[nodiscard]] span<uint8_t> as_span();
+  [[nodiscard]] span<const uint8_t> as_span() const;
   [[nodiscard]] std::string_view as_view() const;
 
   void Dispose();

--- a/cpp/src/arrow/util/secure_string.h
+++ b/cpp/src/arrow/util/secure_string.h
@@ -1,0 +1,71 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+#include "arrow/util/span.h"
+#include "parquet/platform.h"
+
+namespace arrow::util {
+/**
+ * A secure string that ensures the wrapped string is cleared from memory on
+ * deconstruction. This class can only be created from std::string that are securely
+ * erased after creation.
+ *
+ * Note: This class does not provide a constructor / assignment operator that copies a
+ * std::string because that would allow code to create a SecureString while accidentally
+ * not noticing the need to securely erasing the argument after invoking the constructor /
+ * calling the assignment operator.
+ */
+class PARQUET_EXPORT SecureString {
+ public:
+  SecureString() noexcept = default;
+  SecureString(SecureString&&) noexcept;
+  SecureString(const SecureString&) = default;
+  explicit SecureString(std::string&&) noexcept;
+  explicit SecureString(size_t, char) noexcept;
+
+  SecureString& operator=(SecureString&&) noexcept;
+  SecureString& operator=(const SecureString&);
+  SecureString& operator=(std::string&& secret) noexcept;
+
+  bool operator==(const SecureString&) const;
+  bool operator!=(const SecureString&) const;
+
+  ~SecureString() { Dispose(); }
+
+  [[nodiscard]] bool empty() const;
+  [[nodiscard]] std::size_t size() const;
+  [[nodiscard]] std::size_t length() const;
+
+  [[nodiscard]] ::arrow::util::span<uint8_t> as_span();
+  [[nodiscard]] ::arrow::util::span<const uint8_t> as_span() const;
+  [[nodiscard]] std::string_view as_view() const;
+
+  void Dispose();
+
+  static void SecureClear(std::string*);
+  static void SecureClear(uint8_t* data, size_t size);
+
+ private:
+  std::string secret_;
+};
+
+}  // namespace arrow::util

--- a/cpp/src/arrow/util/secure_string.h
+++ b/cpp/src/arrow/util/secure_string.h
@@ -44,7 +44,7 @@ class ARROW_EXPORT SecureString {
 
   SecureString& operator=(SecureString&&) noexcept;
   SecureString& operator=(const SecureString&);
-  SecureString& operator=(std::string&& secret) noexcept;
+  SecureString& operator=(std::string&&) noexcept;
 
   bool operator==(const SecureString&) const;
   bool operator!=(const SecureString&) const;

--- a/cpp/src/arrow/util/secure_string_test.cc
+++ b/cpp/src/arrow/util/secure_string_test.cc
@@ -113,10 +113,10 @@ TEST(TestSecureString, AssertSecurelyCleared) {
   auto capture = Reporter(test_info_);
 
   auto short_zeros = std::string(10, '\0');
-  AssertSecurelyCleared(std::string_view(short_zeros));
+  ASSERT_NO_FATAL_FAILURE(AssertSecurelyCleared(std::string_view(short_zeros)));
 
   auto large_zeros = std::string(1000, '\0');
-  AssertSecurelyCleared(large_zeros);
+  ASSERT_NO_FATAL_FAILURE(AssertSecurelyCleared(large_zeros));
 
   auto no_zeros = std::string("abcdefghijklmnopqrstuvwxyz");
   CAPTURE_TEST_RESULT(capture, AssertSecurelyCleared(no_zeros));
@@ -132,7 +132,7 @@ TEST(TestSecureString, AssertSecurelyCleared) {
 
   auto some_zeros = no_zeros;
   some_zeros = std::string(10, '\0');
-  AssertSecurelyCleared(some_zeros, 10);
+  ASSERT_NO_FATAL_FAILURE(AssertSecurelyCleared(some_zeros, 10));
   CAPTURE_TEST_RESULT(capture, AssertSecurelyCleared(some_zeros));
   ASSERT_EQ(capture.result().type(), testing::TestPartResult::kFatalFailure);
   ASSERT_EQ(std::string(capture.result().message()),
@@ -144,7 +144,8 @@ TEST(TestSecureString, AssertSecurelyCleared) {
             "\"\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\0\\"
             "0\\0\"\n");
 
-  AssertSecurelyCleared(some_zeros, "12345678901234567890123456");
+  ASSERT_NO_FATAL_FAILURE(
+      AssertSecurelyCleared(some_zeros, "12345678901234567890123456"));
   CAPTURE_TEST_RESULT(capture, AssertSecurelyCleared(StringArea(some_zeros), no_zeros));
   ASSERT_EQ(capture.result().type(), testing::TestPartResult::kFatalFailure);
   ASSERT_EQ(std::string(capture.result().message()),
@@ -159,8 +160,8 @@ TEST(TestSecureString, SecureClearString) {
     std::string tiny("abc");
     auto old_area = StringArea(tiny);
     SecureString::SecureClear(&tiny);
-    AssertSecurelyCleared(tiny);
-    AssertSecurelyCleared(old_area);
+    ASSERT_NO_FATAL_FAILURE(AssertSecurelyCleared(tiny));
+    ASSERT_NO_FATAL_FAILURE(AssertSecurelyCleared(old_area));
   }
 
   // long string
@@ -169,8 +170,8 @@ TEST(TestSecureString, SecureClearString) {
     large.resize(512, 'y');
     auto old_area = StringArea(large);
     SecureString::SecureClear(&large);
-    AssertSecurelyCleared(large);
-    AssertSecurelyCleared(old_area);
+    ASSERT_NO_FATAL_FAILURE(AssertSecurelyCleared(large));
+    ASSERT_NO_FATAL_FAILURE(AssertSecurelyCleared(old_area));
   }
 
   // empty string
@@ -181,8 +182,8 @@ TEST(TestSecureString, SecureClearString) {
     empty.resize(0);
     auto old_area = StringArea(empty);
     SecureString::SecureClear(&empty);
-    AssertSecurelyCleared(empty);
-    AssertSecurelyCleared(old_area);
+    ASSERT_NO_FATAL_FAILURE(AssertSecurelyCleared(empty));
+    ASSERT_NO_FATAL_FAILURE(AssertSecurelyCleared(old_area));
   }
 }
 
@@ -191,8 +192,8 @@ TEST(TestSecureString, Construct) {
   std::string string("hello world");
   auto old_string = StringArea(string);
   SecureString secret_from_string(std::move(string));
-  AssertSecurelyCleared(string);
-  AssertSecurelyCleared(old_string);
+  ASSERT_NO_FATAL_FAILURE(AssertSecurelyCleared(string));
+  ASSERT_NO_FATAL_FAILURE(AssertSecurelyCleared(old_string));
   ASSERT_FALSE(secret_from_string.empty());
 
   // move-constructing from a secure string securely clears that secure string
@@ -200,7 +201,7 @@ TEST(TestSecureString, Construct) {
   auto old_secret_from_string_value = std::string(secret_from_string.as_view());
   SecureString secret_from_move_secret(std::move(secret_from_string));
   ASSERT_TRUE(secret_from_string.empty());
-  AssertSecurelyCleared(old_secret_from_string_view);
+  ASSERT_NO_FATAL_FAILURE(AssertSecurelyCleared(old_secret_from_string_view));
   ASSERT_FALSE(secret_from_move_secret.empty());
   ASSERT_EQ(secret_from_move_secret.as_view(),
             std::string_view(old_secret_from_string_value));
@@ -247,12 +248,12 @@ TEST(TestSecureString, Assign) {
 
         ASSERT_FALSE(string.empty());
         ASSERT_TRUE(string_copy.empty());
-        AssertSecurelyCleared(string_copy);
+        ASSERT_NO_FATAL_FAILURE(AssertSecurelyCleared(string_copy));
         auto secret_from_string_view = secret_from_string.as_view();
         // the secure string can reuse the string_copy's string buffer after assignment
         // then, string_copy's string buffer is obviously not cleared
         if (secret_from_string_view.data() != old_string_copy_area.data()) {
-          AssertSecurelyCleared(old_string_copy_area, string);
+          ASSERT_NO_FATAL_FAILURE(AssertSecurelyCleared(old_string_copy_area, string));
         }
         ASSERT_FALSE(secret_from_string.empty());
         ASSERT_EQ(secret_from_string.size(), string.size());
@@ -260,11 +261,12 @@ TEST(TestSecureString, Assign) {
         ASSERT_EQ(secret_from_string_view, std::string_view(string));
         if (secret_from_string_view.data() == old_secret_from_string_area.data()) {
           // when secure string reuses the buffer, the old value must be cleared
-          AssertSecurelyCleared(old_secret_from_string_area, secret_from_string.size());
+          ASSERT_NO_FATAL_FAILURE(AssertSecurelyCleared(old_secret_from_string_area,
+                                                        secret_from_string.size()));
         } else {
           // when secure string has a new buffer, the old buffer must be cleared
-          AssertSecurelyCleared(old_secret_from_string_area,
-                                old_secret_from_string_value);
+          ASSERT_NO_FATAL_FAILURE(AssertSecurelyCleared(old_secret_from_string_area,
+                                                        old_secret_from_string_value));
         }
       }
     }
@@ -295,8 +297,8 @@ TEST(TestSecureString, Assign) {
         // the secure string can reuse the string_copy's string buffer after assignment
         // then, string_copy's string buffer is obviously not cleared
         if (old_secret_string_area.data() != secret_from_move_secret_view.data()) {
-          AssertSecurelyCleared(old_secret_string_area,
-                                old_secret_from_move_secret_value);
+          ASSERT_NO_FATAL_FAILURE(AssertSecurelyCleared(
+              old_secret_string_area, old_secret_from_move_secret_value));
         }
         ASSERT_FALSE(secret_from_move_secret.empty());
         ASSERT_EQ(secret_from_move_secret.size(), string.size());
@@ -305,12 +307,12 @@ TEST(TestSecureString, Assign) {
         if (old_secret_from_move_secret_area.data() ==
             secret_from_move_secret_view.data()) {
           // when secure string reuses the buffer, the old value must be cleared
-          AssertSecurelyCleared(old_secret_from_move_secret_area,
-                                secret_from_move_secret.size());
+          ASSERT_NO_FATAL_FAILURE(AssertSecurelyCleared(old_secret_from_move_secret_area,
+                                                        secret_from_move_secret.size()));
         } else {
           // when secure string has a new buffer, the old buffer must be cleared
-          AssertSecurelyCleared(old_secret_from_move_secret_area,
-                                old_secret_from_move_secret_value);
+          ASSERT_NO_FATAL_FAILURE(AssertSecurelyCleared(
+              old_secret_from_move_secret_area, old_secret_from_move_secret_value));
         }
       }
     }
@@ -342,12 +344,12 @@ TEST(TestSecureString, Assign) {
         if (old_secret_from_copy_secret_area.data() ==
             secret_from_copy_secret.as_view().data()) {
           // when secure string reuses the buffer, the old value must be cleared
-          AssertSecurelyCleared(old_secret_from_copy_secret_area,
-                                secret_from_copy_secret.size());
+          ASSERT_NO_FATAL_FAILURE(AssertSecurelyCleared(old_secret_from_copy_secret_area,
+                                                        secret_from_copy_secret.size()));
         } else {
           // when secure string has a new buffer, the old buffer must be cleared
-          AssertSecurelyCleared(old_secret_from_copy_secret_area,
-                                old_secret_from_copy_secret_value);
+          ASSERT_NO_FATAL_FAILURE(AssertSecurelyCleared(
+              old_secret_from_copy_secret_area, old_secret_from_copy_secret_value));
         }
       }
     }
@@ -355,7 +357,9 @@ TEST(TestSecureString, Assign) {
 }
 
 TEST(TestSecureString, Deconstruct) {
-#if !defined(ARROW_VALGRIND) && !defined(ARROW_USE_ASAN)
+#if defined(ARROW_VALGRIND) || defined(ARROW_USE_ASAN)
+  GTEST_SKIP() << "Test accesses deallocated memory";
+#else
   // We use a very short and a very long string as memory management of short and long
   // strings behaves differently.
   std::vector<std::string> strings = {"short secret", std::string(1024, 'x')};
@@ -371,9 +375,9 @@ TEST(TestSecureString, Deconstruct) {
       // deconstruct secret on leaving this context
     }
     // assert secret memory is cleared on deconstruction
-    AssertSecurelyCleared(view, old_string_value);
+    ASSERT_NO_FATAL_FAILURE(AssertSecurelyCleared(view, old_string_value));
     // so is the string (tested more thoroughly elsewhere)
-    AssertSecurelyCleared(string);
+    ASSERT_NO_FATAL_FAILURE(AssertSecurelyCleared(string));
   }
 #endif
 }

--- a/cpp/src/arrow/util/secure_string_test.cc
+++ b/cpp/src/arrow/util/secure_string_test.cc
@@ -112,6 +112,8 @@ TEST(TestSecureString, AssertSecurelyCleared) {
 
   // check short string with zeros and non-zeros after string length
   auto short_some_zeros = std::string(short_zeros.length() + 3, '*');
+  short_zeros.resize(short_zeros.capacity(), '*');  // for string buffers longer than 8
+  short_zeros.resize(8);  // now the string buffer is filled with '*' after the string
   short_some_zeros = short_zeros;
   // string buffer in short_some_zeros can be larger than short_zeros.length() + 3
   // assert only the area that we can control
@@ -129,6 +131,8 @@ TEST(TestSecureString, AssertSecurelyCleared) {
   // check long string with zeros and non-zeros after string length
   auto zeros = std::string(32, '\0');
   auto long_some_zeros = std::string(zeros.length() + 10, '*');
+  zeros.resize(zeros.capacity(), '*');  // for string buffers longer than 32
+  zeros.resize(32);  // now the string buffer is filled with '*' after the string
   long_some_zeros = zeros;
   // string buffer in long_some_zeros can be larger than zeros.length() + 10
   // assert only the area that we can control

--- a/cpp/src/arrow/util/secure_string_test.cc
+++ b/cpp/src/arrow/util/secure_string_test.cc
@@ -1,0 +1,339 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gtest/gtest.h>
+#include <algorithm>
+#include <vector>
+
+#include "arrow/util/secure_string.h"
+
+namespace arrow::util::test {
+
+std::string_view StringArea(const std::string& string) {
+  return {string.data(), string.capacity()};
+}
+
+void AssertSecurelyCleared(const std::string_view area) {
+  // the entire area is filled with zeros
+  std::string zeros(area.size(), '\0');
+  ASSERT_EQ(area, std::string_view(zeros));
+}
+
+void AssertSecurelyCleared(const std::string& string) {
+  AssertSecurelyCleared(StringArea(string));
+}
+
+/**
+ * Checks the area has been securely cleared after some position.
+ */
+void AssertSecurelyCleared(const std::string_view area, const size_t pos) {
+  // the area after pos is filled with zeros
+  if (pos < area.size()) {
+    std::string zeros(area.size() - pos, '\0');
+    ASSERT_EQ(area.substr(pos), std::string_view(zeros));
+  }
+}
+
+/**
+ * Checks the area has been securely cleared from the secret value.
+ * Assumes the area has been released, so it might have been reclaimed and changed after
+ * cleaning. We cannot check for all-zeros, best we can check here is no secret character
+ * has leaked. If by any chance the modification produced a former key character at the
+ * right position, this will be false negative / flaky. Therefore, we check for three
+ * consecutive secret characters before we fail.
+ */
+void AssertSecurelyCleared(const std::string_view area, const std::string& secret_value) {
+  auto leaks = 0;
+  for (size_t i = 0; i < secret_value.size(); i++) {
+    if (area[i] == secret_value[i]) {
+      leaks++;
+    } else {
+      if (leaks >= 3) {
+        break;
+      }
+      leaks = 0;
+    }
+  }
+  if (leaks >= 3) {
+    FAIL() << leaks << " characters of secret leaked into " << area;
+  }
+}
+
+TEST(TestSecureString, SecureClearString) {
+  // short string
+  {
+    std::string tiny("abc");
+    auto old_area = StringArea(tiny);
+    SecureString::SecureClear(&tiny);
+    AssertSecurelyCleared(tiny);
+    AssertSecurelyCleared(old_area);
+  }
+
+  // long string
+  {
+    std::string large(1024, 'x');
+    large.resize(512, 'y');
+    auto old_area = StringArea(large);
+    SecureString::SecureClear(&large);
+    AssertSecurelyCleared(large);
+    AssertSecurelyCleared(old_area);
+  }
+
+  // empty string
+  {
+    // this creates an empty string with some non-zero characters in the string buffer
+    // we test that all those characters are securely cleared
+    std::string empty("abcdef");
+    empty.resize(0);
+    auto old_area = StringArea(empty);
+    SecureString::SecureClear(&empty);
+    AssertSecurelyCleared(empty);
+    AssertSecurelyCleared(old_area);
+  }
+}
+
+TEST(TestSecureString, Construct) {
+  // move-constructing from a string securely clears that string
+  std::string string("hello world");
+  auto old_string = StringArea(string);
+  SecureString secret_from_string(std::move(string));
+  AssertSecurelyCleared(string);
+  AssertSecurelyCleared(old_string);
+  ASSERT_FALSE(secret_from_string.empty());
+
+  // move-constructing from a secure string securely clears that secure string
+  auto old_secret_from_string_view = secret_from_string.as_view();
+  auto old_secret_from_string_value = std::string(secret_from_string.as_view());
+  SecureString secret_from_move_secret(std::move(secret_from_string));
+  ASSERT_TRUE(secret_from_string.empty());
+  AssertSecurelyCleared(old_secret_from_string_view);
+  ASSERT_FALSE(secret_from_move_secret.empty());
+  ASSERT_EQ(secret_from_move_secret.as_view(),
+            std::string_view(old_secret_from_string_value));
+
+  // copy-constructing from a secure string does not modify that secure string
+  SecureString secret_from_secret(secret_from_move_secret);
+  ASSERT_FALSE(secret_from_move_secret.empty());
+  ASSERT_EQ(secret_from_move_secret.as_view(),
+            std::string_view(old_secret_from_string_value));
+  ASSERT_FALSE(secret_from_secret.empty());
+  ASSERT_EQ(secret_from_secret, secret_from_move_secret);
+}
+
+TEST(TestSecureString, Assign) {
+  // we initialize with the first string and iteratively assign the subsequent values
+  // the first two values are local (15 chars and less), the remainder are non-local
+  // strings (larger than 15 chars) memory management of short and long strings behaves
+  // differently
+  std::vector<std::string> test_strings = {
+      "secret", "another secret", "a much longer secret", std::string(1024, 'x')};
+
+  // assert test string configuration
+  ASSERT_GE(test_strings.size(), 4);
+  for (size_t i = 1; i < test_strings.size(); i++) {
+    // we expect first two strings to be local strings
+    if (i <= 1) {
+      ASSERT_LT(test_strings[i].size(), 15 / sizeof(char));
+    } else {
+      ASSERT_GE(test_strings[i].size(), 15 / sizeof(char));
+    }
+    // the strings are increasing in size
+    if (i > 0) {
+      ASSERT_TRUE(test_strings[i].size() > test_strings[i - 1].size());
+    }
+  }
+
+  std::vector<std::string> reverse_strings = std::vector(test_strings);
+  reverse(reverse_strings.begin(), reverse_strings.end());
+
+  for (auto vec : {test_strings, reverse_strings}) {
+    auto init_string = vec[0];
+    auto strings = std::vector<std::string>(vec.begin() + 1, vec.end());
+
+    {
+      // an initialized secure string
+      std::string init_string_copy(init_string);
+      SecureString secret_from_string(std::move(init_string_copy));
+
+      // move-assigning from a string securely clears that string
+      // the earlier value of the secure string is securely cleared
+      for (auto string : strings) {
+        auto string_copy = std::string(string);
+        auto old_string_copy_area = StringArea(string_copy);
+        ASSERT_FALSE(string.empty());
+        ASSERT_FALSE(string_copy.empty());
+        auto old_secret_from_string_area = secret_from_string.as_view();
+        auto old_secret_from_string_value = std::string(secret_from_string.as_view());
+
+        secret_from_string = std::move(string_copy);
+
+        ASSERT_FALSE(string.empty());
+        ASSERT_TRUE(string_copy.empty());
+        AssertSecurelyCleared(string_copy);
+        auto secret_from_string_view = secret_from_string.as_view();
+        // the secure string can reuse the string_copy's string buffer after assignment
+        // then, string_copy's string buffer is obviously not cleared
+        if (secret_from_string_view.data() != old_string_copy_area.data()) {
+          AssertSecurelyCleared(old_string_copy_area, string);
+        }
+        ASSERT_FALSE(secret_from_string.empty());
+        ASSERT_EQ(secret_from_string.size(), string.size());
+        ASSERT_EQ(secret_from_string.length(), string.length());
+        ASSERT_EQ(secret_from_string_view, std::string_view(string));
+        if (secret_from_string_view.data() == old_secret_from_string_area.data()) {
+          // when secure string reuses the buffer, the old value must be cleared
+          AssertSecurelyCleared(old_secret_from_string_area, secret_from_string.size());
+        } else {
+          // when secure string has a new buffer, the old buffer must be cleared
+          AssertSecurelyCleared(old_secret_from_string_area,
+                                old_secret_from_string_value);
+        }
+      }
+    }
+
+    {
+      // an initialized secure string
+      std::string init_string_copy(init_string);
+      SecureString secret_from_move_secret(std::move(init_string_copy));
+
+      // move-assigning from a secure string securely clears that secure string
+      // the earlier value of the secure string is securely cleared
+      for (auto string : strings) {
+        auto string_copy = std::string(string);
+        SecureString secret_string(std::move(string_copy));
+        ASSERT_FALSE(string.empty());
+        ASSERT_TRUE(string_copy.empty());
+        ASSERT_FALSE(secret_string.empty());
+        auto old_secret_string_area = secret_string.as_view();
+        auto old_secret_string_value = std::string(secret_string.as_view());
+        auto old_secret_from_move_secret_area = secret_from_move_secret.as_view();
+        auto old_secret_from_move_secret_value =
+            std::string(secret_from_move_secret.as_view());
+
+        secret_from_move_secret = std::move(secret_string);
+
+        ASSERT_TRUE(secret_string.empty());
+        // the secure string can reuse the string_copy's string buffer after assignment
+        // then, string_copy's string buffer is obviously not cleared
+        if (old_secret_string_area.data() != secret_from_move_secret.as_view().data()) {
+          AssertSecurelyCleared(old_secret_string_area,
+                                old_secret_from_move_secret_value);
+        }
+        ASSERT_FALSE(secret_from_move_secret.empty());
+        ASSERT_EQ(secret_from_move_secret.size(), string.size());
+        ASSERT_EQ(secret_from_move_secret.length(), string.length());
+        ASSERT_EQ(secret_from_move_secret.as_view(), std::string_view(string));
+        if (old_secret_from_move_secret_area.data() ==
+            secret_from_move_secret.as_view().data()) {
+          // when secure string reuses the buffer, the old value must be cleared
+          AssertSecurelyCleared(old_secret_from_move_secret_area,
+                                secret_from_move_secret.size());
+        } else {
+          // when secure string has a new buffer, the old buffer must be cleared
+          AssertSecurelyCleared(old_secret_from_move_secret_area,
+                                old_secret_from_move_secret_value);
+        }
+      }
+    }
+
+    {
+      // an initialized secure string
+      std::string init_string_copy(init_string);
+      SecureString secret_from_copy_secret(std::move(init_string_copy));
+
+      for (auto string : strings) {
+        // copy-assigning from a secure string does not modify that secure string
+        // the earlier value of the secure string is securely cleared
+        auto string_copy = std::string(string);
+        SecureString secret_string(std::move(string_copy));
+        ASSERT_FALSE(string.empty());
+        ASSERT_TRUE(string_copy.empty());
+        ASSERT_FALSE(secret_string.empty());
+        auto old_secret_from_copy_secret_area = secret_from_copy_secret.as_view();
+        auto old_secret_from_copy_secret_value =
+            std::string(secret_from_copy_secret.as_view());
+
+        secret_from_copy_secret = secret_string;
+
+        ASSERT_FALSE(secret_string.empty());
+        ASSERT_FALSE(secret_from_copy_secret.empty());
+        ASSERT_EQ(secret_from_copy_secret.size(), string.size());
+        ASSERT_EQ(secret_from_copy_secret.length(), string.length());
+        ASSERT_EQ(secret_from_copy_secret.as_view(), std::string_view(string));
+        if (old_secret_from_copy_secret_area.data() ==
+            secret_from_copy_secret.as_view().data()) {
+          // when secure string reuses the buffer, the old value must be cleared
+          AssertSecurelyCleared(old_secret_from_copy_secret_area,
+                                secret_from_copy_secret.size());
+        } else {
+          // when secure string has a new buffer, the old buffer must be cleared
+          AssertSecurelyCleared(old_secret_from_copy_secret_area,
+                                old_secret_from_copy_secret_value);
+        }
+      }
+    }
+  }
+}
+
+TEST(TestSecureString, Compare) {
+  ASSERT_TRUE(SecureString("") == SecureString(""));
+  ASSERT_FALSE(SecureString("") != SecureString(""));
+
+  ASSERT_TRUE(SecureString("hello world") == SecureString("hello world"));
+  ASSERT_FALSE(SecureString("hello world") != SecureString("hello world"));
+
+  ASSERT_FALSE(SecureString("hello world") == SecureString("hello worlds"));
+  ASSERT_TRUE(SecureString("hello world") != SecureString("hello worlds"));
+}
+
+TEST(TestSecureString, Cardinality) {
+  ASSERT_TRUE(SecureString("").empty());
+  ASSERT_EQ(SecureString("").size(), 0);
+  ASSERT_EQ(SecureString("").length(), 0);
+
+  ASSERT_FALSE(SecureString("hello world").empty());
+  ASSERT_EQ(SecureString("hello world").size(), 11);
+  ASSERT_EQ(SecureString("hello world").length(), 11);
+}
+
+TEST(TestSecureString, AsSpan) {
+  SecureString secret("hello world");
+  const SecureString& const_secret(secret);
+  auto const_span = const_secret.as_span();
+  auto mutual_span = secret.as_span();
+
+  std::string expected = "hello world";
+  ::arrow::util::span expected_span = {reinterpret_cast<uint8_t*>(expected.data()),
+                                       expected.size()};
+  ASSERT_EQ(const_span, expected_span);
+  ASSERT_EQ(mutual_span, expected_span);
+
+  // modify secret through mutual span
+  // the const span shares the same secret, so it is changed as well
+  mutual_span[0] = 'H';
+  expected_span[0] = 'H';
+  ASSERT_EQ(const_span, expected_span);
+  ASSERT_EQ(mutual_span, expected_span);
+}
+
+TEST(TestSecureString, AsView) {
+  const SecureString secret = SecureString("hello world");
+  const std::string_view view = secret.as_view();
+  ASSERT_EQ(view, "hello world");
+}
+
+}  // namespace arrow::util::test

--- a/cpp/src/arrow/util/secure_string_test.cc
+++ b/cpp/src/arrow/util/secure_string_test.cc
@@ -135,30 +135,14 @@ TEST(TestSecureString, Construct) {
 }
 
 TEST(TestSecureString, Assign) {
-  // we initialize with the first string and iteratively assign the subsequent values
-  // the first two values are local (15 chars and less), the remainder are non-local
-  // strings (larger than 15 chars) memory management of short and long strings behaves
-  // differently
+  // We initialize with the first string and iteratively assign the subsequent values.
+  // The first two values are local (very short strings), the remainder are non-local
+  // strings. Memory management of short and long strings behaves differently.
   std::vector<std::string> test_strings = {
       "secret", "another secret", "a much longer secret", std::string(1024, 'x')};
 
-  // assert test string configuration
-  ASSERT_GE(test_strings.size(), 4);
-  for (size_t i = 1; i < test_strings.size(); i++) {
-    // we expect first two strings to be local strings
-    if (i <= 1) {
-      ASSERT_LT(test_strings[i].size(), 15 / sizeof(char));
-    } else {
-      ASSERT_GE(test_strings[i].size(), 15 / sizeof(char));
-    }
-    // the strings are increasing in size
-    if (i > 0) {
-      ASSERT_TRUE(test_strings[i].size() > test_strings[i - 1].size());
-    }
-  }
-
   std::vector<std::string> reverse_strings = std::vector(test_strings);
-  reverse(reverse_strings.begin(), reverse_strings.end());
+  std::reverse(reverse_strings.begin(), reverse_strings.end());
 
   for (auto vec : {test_strings, reverse_strings}) {
     auto init_string = vec[0];
@@ -227,18 +211,19 @@ TEST(TestSecureString, Assign) {
         secret_from_move_secret = std::move(secret_string);
 
         ASSERT_TRUE(secret_string.empty());
+        auto secret_from_move_secret_view = secret_from_move_secret.as_view();
         // the secure string can reuse the string_copy's string buffer after assignment
         // then, string_copy's string buffer is obviously not cleared
-        if (old_secret_string_area.data() != secret_from_move_secret.as_view().data()) {
+        if (old_secret_string_area.data() != secret_from_move_secret_view.data()) {
           AssertSecurelyCleared(old_secret_string_area,
                                 old_secret_from_move_secret_value);
         }
         ASSERT_FALSE(secret_from_move_secret.empty());
         ASSERT_EQ(secret_from_move_secret.size(), string.size());
         ASSERT_EQ(secret_from_move_secret.length(), string.length());
-        ASSERT_EQ(secret_from_move_secret.as_view(), std::string_view(string));
+        ASSERT_EQ(secret_from_move_secret_view, std::string_view(string));
         if (old_secret_from_move_secret_area.data() ==
-            secret_from_move_secret.as_view().data()) {
+            secret_from_move_secret_view.data()) {
           // when secure string reuses the buffer, the old value must be cleared
           AssertSecurelyCleared(old_secret_from_move_secret_area,
                                 secret_from_move_secret.size());
@@ -314,20 +299,19 @@ TEST(TestSecureString, AsSpan) {
   SecureString secret("hello world");
   const SecureString& const_secret(secret);
   auto const_span = const_secret.as_span();
-  auto mutual_span = secret.as_span();
+  auto mutable_span = secret.as_span();
 
   std::string expected = "hello world";
-  ::arrow::util::span expected_span = {reinterpret_cast<uint8_t*>(expected.data()),
-                                       expected.size()};
+  span expected_span = {reinterpret_cast<uint8_t*>(expected.data()), expected.size()};
   ASSERT_EQ(const_span, expected_span);
-  ASSERT_EQ(mutual_span, expected_span);
+  ASSERT_EQ(mutable_span, expected_span);
 
   // modify secret through mutual span
   // the const span shares the same secret, so it is changed as well
-  mutual_span[0] = 'H';
+  mutable_span[0] = 'H';
   expected_span[0] = 'H';
   ASSERT_EQ(const_span, expected_span);
-  ASSERT_EQ(mutual_span, expected_span);
+  ASSERT_EQ(mutable_span, expected_span);
 }
 
 TEST(TestSecureString, AsView) {

--- a/cpp/src/arrow/util/secure_string_test.cc
+++ b/cpp/src/arrow/util/secure_string_test.cc
@@ -171,7 +171,7 @@ TEST(TestSecureString, Assign) {
 
       // move-assigning from a string securely clears that string
       // the earlier value of the secure string is securely cleared
-      for (auto string : strings) {
+      for (const auto& string : strings) {
         auto string_copy = std::string(string);
         auto old_string_copy_area = StringArea(string_copy);
         ASSERT_FALSE(string.empty());
@@ -212,7 +212,7 @@ TEST(TestSecureString, Assign) {
 
       // move-assigning from a secure string securely clears that secure string
       // the earlier value of the secure string is securely cleared
-      for (auto string : strings) {
+      for (const auto& string : strings) {
         auto string_copy = std::string(string);
         SecureString secret_string(std::move(string_copy));
         ASSERT_FALSE(string.empty());
@@ -255,7 +255,7 @@ TEST(TestSecureString, Assign) {
       std::string init_string_copy(init_string);
       SecureString secret_from_copy_secret(std::move(init_string_copy));
 
-      for (auto string : strings) {
+      for (const auto& string : strings) {
         // copy-assigning from a secure string does not modify that secure string
         // the earlier value of the secure string is securely cleared
         auto string_copy = std::string(string);

--- a/cpp/src/arrow/util/secure_string_test.cc
+++ b/cpp/src/arrow/util/secure_string_test.cc
@@ -87,6 +87,8 @@ std::string_view StringArea(const std::string& string) {
 #endif
 }
 
+#undef COMPARE
+
 TEST(TestSecureString, AssertSecurelyCleared) {
   // This tests AssertSecurelyCleared helper methods is actually able to identify secret
   // leakage. It retrieves assertion results and asserts result type and message.


### PR DESCRIPTION
### Rationale for this change
Arrow deals with secrets like encryption / decryption keys which must be kept private. One way of leaking such secrets is through memory allocation where another process allocates memory that previously hold the secret, because that memory was not cleared before being freed.

### What changes are included in this PR?
Uses various implementations of securely clearing memory, notably
- `SecureZeroMemory`(Windows)
- `memset_s`(STDC)
- `OPENSSL_cleanse` (OpenSSL >= 3)
- `explicit_bzero`(glibc 2.25+)
- volatile `memset` (fallback).

### Are these changes tested?
Unit tests.

### Are there any user-facing changes?
This only adds the `SecureString` class and tests. Using this new infrastructure is done in follow-up pull requests.

* GitHub Issue: #31603