### PR TITLE
GH-46627: [Swift] Support `Decimal128`

### DIFF
--- a/swift/Arrow/Sources/Arrow/ArrowBufferBuilder.swift
+++ b/swift/Arrow/Sources/Arrow/ArrowBufferBuilder.swift
@@ -118,7 +118,7 @@ public class FixedBufferBuilder<T>: ValuesBufferBuilder<T>, ArrowBufferBuilder {
         return [nulls, values]
     }
 
-    fileprivate static func defaultValueForType() throws -> T {
+    fileprivate static func defaultValueForType() throws -> T { // swiftlint:disable:this cyclomatic_complexity
         let type = T.self
         if type == Int8.self {
             return Int8(0) as! T // swiftlint:disable:this force_cast
@@ -140,6 +140,8 @@ public class FixedBufferBuilder<T>: ValuesBufferBuilder<T>, ArrowBufferBuilder {
             return Float(0) as! T // swiftlint:disable:this force_cast
         } else if type == Double.self {
             return Double(0) as! T // swiftlint:disable:this force_cast
+        } else if type == Decimal.self {
+            return Decimal(0) as! T  // swiftlint:disable:this force_cast
         }
 
         throw ArrowError.unknownType("Unable to determine default value")

--- a/swift/Arrow/Sources/Arrow/ArrowDecoder.swift
+++ b/swift/Arrow/Sources/Arrow/ArrowDecoder.swift
@@ -164,7 +164,8 @@ private struct ArrowUnkeyedDecoding: UnkeyedDecodingContainer {
             type == UInt8.self || type == UInt16.self ||
             type == UInt32.self || type == UInt64.self ||
             type == String.self || type == Double.self ||
-            type == Float.self || type == Date.self {
+            type == Float.self || type == Date.self ||
+            type == Decimal.self || type == Decimal?.self {
             defer {increment()}
             return try self.decoder.doDecode(self.currentIndex)!
         } else {
@@ -263,8 +264,12 @@ private struct ArrowKeyedDecoding<Key: CodingKey>: KeyedDecodingContainerProtoco
         return try self.decoder.doDecode(key)!
     }
 
+    func decode(_ type: Decimal.Type, forKey key: Key) throws -> Decimal {
+        return try self.decoder.doDecode(key)!
+    }
+
     func decode<T>(_ type: T.Type, forKey key: Key) throws -> T where T: Decodable {
-        if ArrowArrayBuilders.isValidBuilderType(type) || type == Date.self {
+        if ArrowArrayBuilders.isValidBuilderType(type) || type == Date.self || type == Decimal.self {
             return try self.decoder.doDecode(key)!
         } else {
             throw ArrowError.invalid("Type \(type) is currently not supported")
@@ -366,8 +371,12 @@ private struct ArrowSingleValueDecoding: SingleValueDecodingContainer {
         return try self.decoder.doDecode(self.decoder.singleRBCol)!
     }
 
+    func decode(_ type: Decimal.Type) throws -> Decimal {
+        return try self.decoder.doDecode(self.decoder.singleRBCol)!
+    }
+
     func decode<T>(_ type: T.Type) throws -> T where T: Decodable {
-        if ArrowArrayBuilders.isValidBuilderType(type) || type == Date.self {
+        if ArrowArrayBuilders.isValidBuilderType(type) || type == Date.self || type == Decimal.self {
             return try self.decoder.doDecode(self.decoder.singleRBCol)!
         } else {
             throw ArrowError.invalid("Type \(type) is currently not supported")

--- a/swift/Arrow/Sources/Arrow/ArrowReaderHelper.swift
+++ b/swift/Arrow/Sources/Arrow/ArrowReaderHelper.swift
@@ -44,6 +44,20 @@ private func makeStringHolder(_ buffers: [ArrowBuffer],
     }
 }
 
+private func makeDecimalHolder(_ field: ArrowField,
+                               buffers: [ArrowBuffer],
+                               nullCount: UInt
+) -> Result<ArrowArrayHolder, ArrowError> {
+    do {
+        let arrowData = try ArrowData(field.type, buffers: buffers, nullCount: nullCount)
+        return .success(ArrowArrayHolderImpl(try Decimal128Array(arrowData)))
+    } catch let error as ArrowError {
+        return .failure(error)
+    } catch {
+        return .failure(.unknownError("\(error)"))
+    }
+}
+
 private func makeDateHolder(_ field: ArrowField,
                             buffers: [ArrowBuffer],
                             nullCount: UInt
@@ -178,6 +192,8 @@ func makeArrayHolder( // swiftlint:disable:this cyclomatic_complexity
         return makeFixedHolder(Float.self, field: field, buffers: buffers, nullCount: nullCount)
     case .double:
         return makeFixedHolder(Double.self, field: field, buffers: buffers, nullCount: nullCount)
+    case .decimal128:
+        return makeDecimalHolder(field, buffers: buffers, nullCount: nullCount)
     case .string:
         return makeStringHolder(buffers, nullCount: nullCount)
     case .binary:
@@ -203,7 +219,7 @@ func makeBuffer(_ buffer: org_apache_arrow_flatbuf_Buffer, fileData: Data,
 
 func isFixedPrimitive(_ type: org_apache_arrow_flatbuf_Type_) -> Bool {
     switch type {
-    case .int, .bool, .floatingpoint, .date, .time:
+    case .int, .bool, .floatingpoint, .date, .time, .decimal:
         return true
     default:
         return false
@@ -243,6 +259,12 @@ func findArrowType( // swiftlint:disable:this cyclomatic_complexity function_bod
         default:
             return ArrowType(ArrowType.ArrowUnknown)
         }
+    case .decimal:
+        let dataType = field.type(type: org_apache_arrow_flatbuf_Decimal.self)!
+        if dataType.bitWidth == 128 {
+            return ArrowType(ArrowType.ArrowDecimal128)
+        }
+        return ArrowType(ArrowType.ArrowUnknown)
     case .utf8:
         return ArrowType(ArrowType.ArrowString)
     case .binary:

--- a/swift/Arrow/Sources/Arrow/ProtoUtil.swift
+++ b/swift/Arrow/Sources/Arrow/ProtoUtil.swift
@@ -44,6 +44,15 @@ func fromProto( // swiftlint:disable:this cyclomatic_complexity function_body_le
         } else if floatType.precision == .double {
             arrowType = ArrowType(ArrowType.ArrowDouble)
         }
+    case .decimal:
+        let decimalType = field.type(type: org_apache_arrow_flatbuf_Decimal.self)!
+        if decimalType.bitWidth == 128 && decimalType.precision <= 38 {
+            let arrowDecimal128 = ArrowTypeId.decimal128(decimalType.precision, decimalType.scale)
+            arrowType = ArrowType(ArrowType.Info.primitiveInfo(arrowDecimal128))
+        } else {
+            // Unsupport yet
+            arrowType = ArrowType(ArrowType.ArrowUnknown)
+        }
     case .utf8:
         arrowType = ArrowType(ArrowType.ArrowString)
     case .binary:


### PR DESCRIPTION
### Rationale for this change

This PR aims to support `Decimal128` for Decimal type.

### What changes are included in this PR?

There are two decimal types; `Decimal128` and `Decimal256`. Since Apache Spark uses `Decimal128`, this PR focus on `Decimal128`.

### Are these changes tested?

Pass the CIs.

### Are there any user-facing changes?

Previously, `Decimal` type was not supported.

* GitHub Issue: apache/arrow-swift#17
* GitHub Issue: #17