### PR TITLE
GH-46623: [C++][Compute] Fix the failure of large memory test in arrow-compute-row-test

### DIFF
--- a/cpp/src/arrow/compute/row/compare_test.cc
+++ b/cpp/src/arrow/compute/row/compare_test.cc
@@ -386,8 +386,8 @@ TEST(KeyCompare, LARGE_MEMORY_TEST(CompareColumnsToRowsOver4GBFixedLength)) {
       RowTableImpl row_table_right,
       RepeatRowTableUntil(MakeRowTableFromExecBatch(batch_left).ValueUnsafe(),
                           num_rows_row_table));
-  // The row table must not contain a third buffer.
-  ASSERT_EQ(row_table_right.var_length_rows(), NULLPTR);
+  // The row table must be fixed length.
+  ASSERT_TRUE(row_table_right.metadata().is_fixed_length);
   // The row data must be greater than 4GB.
   ASSERT_GT(row_table_right.buffer_size(1), k4GB);
 


### PR DESCRIPTION
### Rationale for this change

In #45336 we refined the row table buffer accessors and enforced the validation on who can call the `var_length_rows()` method. However a legacy test `CompareColumnsToRowsOver4GBFixedLength` is leveraging this accessor to assert this buffer being null.

### What changes are included in this PR?

We can just check if the row table is fixed length.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

None.

* GitHub Issue: #46623