### PR TITLE
MINOR: [R][Release] Backport news changes from maint-20.0.0.1-r

### DIFF
--- a/r/NEWS.md
+++ b/r/NEWS.md
@@ -22,8 +22,9 @@
 ## Minor improvements and fixes
 
 - Added bindings for atan, sinh, cosh, tanh, asinh, acosh, and tanh, and expm1 (#44953)
-- Expose an option `check_directory_existence_before_creation` in `S3FileSystem` 
+- Expose an option `check_directory_existence_before_creation` in `S3FileSystem`
   to reduce I/O calls on cloud storage (@HaochengLIU, #41998)
+
 # arrow 20.0.0.1
 
 ## Minor improvements and fixes

--- a/r/NEWS.md
+++ b/r/NEWS.md
@@ -24,6 +24,12 @@
 - Added bindings for atan, sinh, cosh, tanh, asinh, acosh, and tanh, and expm1 (#44953)
 - Expose an option `check_directory_existence_before_creation` in `S3FileSystem` 
   to reduce I/O calls on cloud storage (@HaochengLIU, #41998)
+# arrow 20.0.0.1
+
+## Minor improvements and fixes
+
+- Updated internal C++ code to comply with CRAN's gcc-UBSAN checks
+  ([#46394](https://github.com/apache/arrow/issues/46394))
 
 # arrow 20.0.0
 

--- a/r/NEWS.md
+++ b/r/NEWS.md
@@ -27,6 +27,16 @@
 
 # arrow 20.0.0
 
+## Minor improvements and fixes
+
+- Binary Arrays now inherit from `blob::blob` in addition to `arrow_binary` when
+  [converted to R
+  objects](https://arrow.apache.org/docs/r/articles/data_types.html#translations-from-arrow-to-r).
+  This change is the first step in eventually deprecating the `arrow_binary`
+  class in favor of the `blob` class in the
+  [`blob`](https://cran.r-project.org/package=blob) package (See
+  [GH-45709](https://github.com/apache/arrow/issues/45709)).
+
 # arrow 19.0.1.1
 
 ## Minor improvements and fixes


### PR DESCRIPTION
### Rationale for this change

I edited NEWS.md for the 20.0.0.X release and we need to backport those changes.

### What changes are included in this PR?

I cherry-picked:

- 736e6cc03d7e74adfc349e2d848d238ded75b4a7
- bd7024da91c6caa1b2c42993fa4afd44751deeac

and made one small whitespace change since I was already in the file.

### Are these changes tested?

No.

### Are there any user-facing changes?

No.