### PR TITLE
MINOR: [R][Docs] Fix package title text not showing

### DIFF
--- a/r/_pkgdown.yml
+++ b/r/_pkgdown.yml
@@ -56,6 +56,12 @@ template:
           data-consent-screen-disclaimer="By clicking &quot;I agree, let's chat&quot;, you consent to the use of the AI assistant in accordance with kapa.ai's [Privacy Policy](https://www.kapa.ai/content/privacy-policy). This service uses reCAPTCHA, which requires your consent to Google's [Privacy Policy](https://policies.google.com/privacy) and [Terms of Service](https://policies.google.com/terms). By proceeding, you explicitly agree to both kapa.ai's and Google's privacy policies."
       ></script>
       <!-- End Kapa AI -->
+      <!-- Make the package title visible and white. This overcomes an issue with pkgdown and the cosmo theme we use. More straightforward options were attempted but none worked. -->
+      <style>
+        .navbar-brand {
+          color: white !important;
+        }
+      </style>
   opengraph:
     image:
       src: https://arrow.apache.org/img/arrow-logo_horizontal_black-txt_white-bg.png

--- a/r/_pkgdown.yml
+++ b/r/_pkgdown.yml
@@ -56,12 +56,6 @@ template:
           data-consent-screen-disclaimer="By clicking &quot;I agree, let's chat&quot;, you consent to the use of the AI assistant in accordance with kapa.ai's [Privacy Policy](https://www.kapa.ai/content/privacy-policy). This service uses reCAPTCHA, which requires your consent to Google's [Privacy Policy](https://policies.google.com/privacy) and [Terms of Service](https://policies.google.com/terms). By proceeding, you explicitly agree to both kapa.ai's and Google's privacy policies."
       ></script>
       <!-- End Kapa AI -->
-      <!-- Make the package title visible and white. This overcomes an issue with pkgdown and the cosmo theme we use. More straightforward options were attempted but none worked. -->
-      <style>
-        .navbar-brand {
-          color: white !important;
-        }
-      </style>
   opengraph:
     image:
       src: https://arrow.apache.org/img/arrow-logo_horizontal_black-txt_white-bg.png

--- a/r/pkgdown/extra.css
+++ b/r/pkgdown/extra.css
@@ -1,6 +1,8 @@
 /* Section text in navbar */
 .navbar-dark, .navbar[data-bs-theme="dark"] {
   --bs-navbar-color: #d9d9d9;
+  --bs-navbar-brand-hover-color: #d9d9d9 !important;
+  --bs-navbar-brand-color: #d9d9d9 !important;
 }
 
 /* Version number in navbar */


### PR DESCRIPTION
### Rationale for this change

On the current docs, the title of the package doesn't show up. It would be good if it did. I tried various sanctioned things but none worked. I am chalking it up as something to do with the cosmo theme we're using and a limitation of pkgdown's customization ability.

![image](https://github.com/user-attachments/assets/ffbc2540-f11e-4e68-8ac6-2e6de4ce8b70)

### What changes are included in this PR?

pkgdown will now insert a hard-coded CSS style to make the package text show up in white.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.