### PR TITLE
GH-44208: [R] Adding test to ensure bit64's new semantic works with arrow

### DIFF
--- a/r/tests/testthat/test-Array.R
+++ b/r/tests/testthat/test-Array.R
@@ -353,17 +353,18 @@ test_that("array supports integer64", {
 })
 
 test_that("array supports integer64 with new sematics", {
-  options(integer64_semantics="new")
-  x <- bit64::as.integer64(1:10) + MAX_INT 
-  expect_array_roundtrip(x, int64())
+  withr::with_options(list(integer64_semantics = "new"), {
+    x <- bit64::as.integer64(1:10) + MAX_INT
+    expect_array_roundtrip(x, int64())
 
-  x[4] <- NA
-  expect_array_roundtrip(x, int64())
+    x[4] <- NA
+    expect_array_roundtrip(x, int64())
 
-  # all NA int64 (ARROW-3795)
-  all_na <- arrow_array(bit64::as.integer64(NA))
-  expect_type_equal(all_na, int64())
-  expect_true(as.vector(is.na(all_na)))
+    # all NA int64 (ARROW-3795)
+    all_na <- arrow_array(bit64::as.integer64(NA))
+    expect_type_equal(all_na, int64())
+    expect_true(as.vector(is.na(all_na)))
+  }
 })
 
 test_that("array supports hms difftime", {

--- a/r/tests/testthat/test-Array.R
+++ b/r/tests/testthat/test-Array.R
@@ -352,6 +352,20 @@ test_that("array supports integer64", {
   expect_true(as.vector(is.na(all_na)))
 })
 
+test_that("array supports integer64 with new sematics", {
+  options(integer64_semantics="new")
+  x <- bit64::as.integer64(1:10) + MAX_INT 
+  expect_array_roundtrip(x, int64())
+
+  x[4] <- NA
+  expect_array_roundtrip(x, int64())
+
+  # all NA int64 (ARROW-3795)
+  all_na <- arrow_array(bit64::as.integer64(NA))
+  expect_type_equal(all_na, int64())
+  expect_true(as.vector(is.na(all_na)))
+})
+
 test_that("array supports hms difftime", {
   time <- hms::hms(56, 34, 12)
   expect_array_roundtrip(c(time, time), time32("s"))


### PR DESCRIPTION
### Rationale for this change
Based on the #44208 issue, we want to make sure that we have test for new semantic of bit64

### What changes are included in this PR?
New test

### Are these changes tested?
NA

### Are there any user-facing changes?
No

* GitHub Issue: #44208