### PR TITLE
GH-46146: [C++] Merge metadata in SchemaBuidler::AddMetadata

### DIFF
--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -2641,7 +2641,8 @@ Status SchemaBuilder::AddSchemas(const std::vector<std::shared_ptr<Schema>>& sch
 }
 
 Status SchemaBuilder::AddMetadata(const KeyValueMetadata& metadata) {
-  impl_->metadata_ = metadata.Copy();
+  impl_->metadata_ =
+      impl_->metadata_ ? impl_->metadata_->Merge(metadata) : metadata.Copy();
   return Status::OK();
 }
 

--- a/cpp/src/arrow/type_test.cc
+++ b/cpp/src/arrow/type_test.cc
@@ -751,8 +751,11 @@ TEST(TestSchemaBuilder, WithMetadata) {
 
   SchemaBuilder builder;
   ASSERT_OK(builder.AddMetadata(*metadata));
-  ASSERT_OK(builder.AddMetadata(*metadata2));
   ASSERT_OK_AND_ASSIGN(auto schema, builder.Finish());
+  AssertSchemaEqual(schema, ::arrow::schema({})->WithMetadata(metadata));
+
+  ASSERT_OK(builder.AddMetadata(*metadata2));
+  ASSERT_OK_AND_ASSIGN(schema, builder.Finish());
   AssertSchemaEqual(schema, ::arrow::schema({})->WithMetadata(merged_metadata));
 
   ASSERT_OK(builder.AddField(f0));

--- a/cpp/src/arrow/type_test.cc
+++ b/cpp/src/arrow/type_test.cc
@@ -746,25 +746,28 @@ TEST(TestSchemaBuilder, WithMetadata) {
   auto f0 = field("f0", int32());
   auto f1 = field("f1", uint8(), false);
   auto metadata = key_value_metadata({{"foo", "bar"}});
+  auto metadata2 = key_value_metadata({{"foo2", "bar2"}});
+  auto merged_metadata = metadata->Merge(*metadata2);
 
   SchemaBuilder builder;
   ASSERT_OK(builder.AddMetadata(*metadata));
+  ASSERT_OK(builder.AddMetadata(*metadata2));
   ASSERT_OK_AND_ASSIGN(auto schema, builder.Finish());
-  AssertSchemaEqual(schema, ::arrow::schema({})->WithMetadata(metadata));
+  AssertSchemaEqual(schema, ::arrow::schema({})->WithMetadata(merged_metadata));
 
   ASSERT_OK(builder.AddField(f0));
   ASSERT_OK_AND_ASSIGN(schema, builder.Finish());
-  AssertSchemaEqual(schema, ::arrow::schema({f0})->WithMetadata(metadata));
+  AssertSchemaEqual(schema, ::arrow::schema({f0})->WithMetadata(merged_metadata));
 
-  SchemaBuilder other_builder{::arrow::schema({})->WithMetadata(metadata)};
+  SchemaBuilder other_builder{::arrow::schema({})->WithMetadata(merged_metadata)};
   ASSERT_OK(other_builder.AddField(f1));
   ASSERT_OK_AND_ASSIGN(schema, other_builder.Finish());
-  AssertSchemaEqual(schema, ::arrow::schema({f1})->WithMetadata(metadata));
+  AssertSchemaEqual(schema, ::arrow::schema({f1})->WithMetadata(merged_metadata));
 
   other_builder.Reset();
-  ASSERT_OK(other_builder.AddField(f1->WithMetadata(metadata)));
+  ASSERT_OK(other_builder.AddField(f1->WithMetadata(merged_metadata)));
   ASSERT_OK_AND_ASSIGN(schema, other_builder.Finish());
-  AssertSchemaEqual(schema, ::arrow::schema({f1->WithMetadata(metadata)}));
+  AssertSchemaEqual(schema, ::arrow::schema({f1->WithMetadata(merged_metadata)}));
 }
 
 TEST(TestSchemaBuilder, IncrementalConstruction) {


### PR DESCRIPTION
### Rationale for this change

`arrow::SchemaBuidler::AddMetadata()` replaces metadata not adds metadata.

### What changes are included in this PR?

Add metadata when calling `SchemaBuidler::AddMetadata()`.

### Are these changes tested?

Manually build pass.

### Are there any user-facing changes?

**This PR includes breaking changes to public APIs.**

`arrow::SchemaBuidler::AddMetadata()` adds not replaces the given metadata. If an existing code calls `AddMetadata()` multiple times, the behavior will be changed.  

* GitHub Issue: #46146