### PR TITLE
GH-46515: [C++] Enable Multi Blocks in arrow::BinaryViewBuilder::AppendArraySlice

### DIFF
--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -1086,7 +1086,7 @@ class TestBinaryViewBuilderAppendArraySlice : public TestArray {
   void AssertAppendArraySliceWithArrayAndSpanOffset(const std::shared_ptr<Array>& src) {
     // Ensure even length to simplify calculations in
     // AppendArraySliceWithArrayAndSpanOffset
-    ASSERT_TRUE(src->length() % 2 == 0);
+    ASSERT_EQ(src->length() % 2, 0);
     ASSERT_OK_AND_ASSIGN(auto dst, AppendArraySliceWithArrayAndSpanOffset(src));
     ASSERT_OK(dst->ValidateFull());
     AssertArraysEqual(*dst, *src);

--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -977,7 +977,7 @@ TEST_F(TestArray, TestAppendArraySlice) {
     ASSERT_EQ(8, result->null_count());
   }
 }
-class TestBinaryViewBuilderAppendArraySlice : public TestArray {
+class TestArrayBinaryViewBuilderAppendArraySlice : public TestArray {
  public:
   struct StringOptions {
     int64_t size = 0;
@@ -987,7 +987,7 @@ class TestBinaryViewBuilderAppendArraySlice : public TestArray {
     double null_probability = 0.0;
   };
 
-  TestBinaryViewBuilderAppendArraySlice() : TestArray(), generator_(12) {}
+  TestArrayBinaryViewBuilderAppendArraySlice() : TestArray(), generator_(12) {}
 
   void SetUp() override {
     TestArray::SetUp();
@@ -1004,7 +1004,7 @@ class TestBinaryViewBuilderAppendArraySlice : public TestArray {
   Result<std::shared_ptr<Array>> AppendArraySliceWithSpanOffset(
       const std::shared_ptr<Array>& array) {
     const ArraySpan span(*array->data());
-    for (int i = 0; i < array->length(); i++) {
+    for (int i = 0; i < array->length(); ++i) {
       ARROW_RETURN_NOT_OK(builder_.AppendArraySlice(span, i, 1));
     }
     return builder_.Finish();
@@ -1012,7 +1012,7 @@ class TestBinaryViewBuilderAppendArraySlice : public TestArray {
 
   Result<std::shared_ptr<Array>> AppendArraySliceWithArrayOffset(
       const std::shared_ptr<Array>& array) {
-    for (int i = 0; i < array->length(); i++) {
+    for (int i = 0; i < array->length(); ++i) {
       auto slice = array->Slice(i, 1);
       const ArraySpan span(*slice->data());
       ARROW_RETURN_NOT_OK(builder_.AppendArraySlice(span, 0, 1));
@@ -1097,7 +1097,7 @@ class TestBinaryViewBuilderAppendArraySlice : public TestArray {
   random::RandomArrayGenerator generator_;
 };
 
-TEST_F(TestBinaryViewBuilderAppendArraySlice, Inline) {
+TEST_F(TestArrayBinaryViewBuilderAppendArraySlice, Inline) {
   StringOptions options{};
   options.size = 16;
   options.min_length = 0;
@@ -1120,7 +1120,7 @@ TEST_F(TestBinaryViewBuilderAppendArraySlice, Inline) {
   }
 }
 
-TEST_F(TestBinaryViewBuilderAppendArraySlice, NonInline) {
+TEST_F(TestArrayBinaryViewBuilderAppendArraySlice, NonInline) {
   StringOptions options{};
   options.size = 200;
   options.min_length = 13;
@@ -1144,7 +1144,7 @@ TEST_F(TestBinaryViewBuilderAppendArraySlice, NonInline) {
   }
 }
 
-TEST_F(TestBinaryViewBuilderAppendArraySlice, NonInlineAndInline) {
+TEST_F(TestArrayBinaryViewBuilderAppendArraySlice, NonInlineAndInline) {
   StringOptions options{};
   options.size = 200;
   options.min_length = 0;
@@ -1168,7 +1168,7 @@ TEST_F(TestBinaryViewBuilderAppendArraySlice, NonInlineAndInline) {
   }
 }
 
-TEST_F(TestBinaryViewBuilderAppendArraySlice, NonInlineAndInlineAndAppend) {
+TEST_F(TestArrayBinaryViewBuilderAppendArraySlice, NonInlineAndInlineAndAppend) {
   StringOptions options{};
   options.size = 200;
   options.min_length = 0;
@@ -1213,7 +1213,7 @@ TEST_F(TestBinaryViewBuilderAppendArraySlice, NonInlineAndInlineAndAppend) {
 }
 
 // Check the state of arrow::internal::StringHeapBuilder::current_block_
-TEST_F(TestBinaryViewBuilderAppendArraySlice, Reset) {
+TEST_F(TestArrayBinaryViewBuilderAppendArraySlice, Reset) {
   StringOptions options{};
   options.size = 200;
   options.min_length = 0;
@@ -1263,6 +1263,10 @@ TEST_F(TestBinaryViewBuilderAppendArraySlice, Reset) {
   view_1 = view_buffer[0];
   view_2 = view_buffer[1];
   view_3 = view_buffer[2];
+
+  ASSERT_EQ(view_1.ref.buffer_index, 0);
+  ASSERT_EQ(view_2.ref.buffer_index, 0);
+  ASSERT_EQ(view_3.ref.buffer_index, 1);
 }
 
 TEST_F(TestArray, ValidateBuffersPrimitive) {

--- a/cpp/src/arrow/array/builder_binary.cc
+++ b/cpp/src/arrow/array/builder_binary.cc
@@ -81,13 +81,13 @@ Status BinaryViewBuilder::AppendArraySlice(const ArraySpan& array, int64_t offse
         if (view.is_inline()) {
           data_builder_.UnsafeAppend(&view, 1);
         } else {
-          auto dst_buffer_index = TryAddBufferAndGetIndex(
+          auto dst_data_buffer_index = TryAddBufferAndGetIndex(
               buffer_index_map, view.ref.buffer_index, data_heap_builder_,
               data_buffers[view.ref.buffer_index]);
           auto dst_view_index = data_builder_.length();
           data_builder_.UnsafeAppend(&view, 1);
           data_builder_.mutable_data()[dst_view_index].ref.buffer_index =
-              dst_buffer_index;
+              dst_data_buffer_index;
         }
       },
       [&]() { UnsafeAppendNull(); });

--- a/cpp/src/arrow/array/builder_binary.h
+++ b/cpp/src/arrow/array/builder_binary.h
@@ -533,7 +533,7 @@ class ARROW_EXPORT StringHeapBuilder {
       current_offset_ = 0;
       current_out_buffer_ = new_block->mutable_data();
       blocks_.emplace_back(std::move(new_block));
-      current_block_ = static_cast<int32_t>(blocks_.size() - 1);
+      current_block_ = static_cast<int64_t>(blocks_.size() - 1);
     }
     return Status::OK();
   }


### PR DESCRIPTION
### Rationale for this change
As noted [here](https://github.com/apache/arrow/pull/46229#issuecomment-2893318530), `arrow::BinaryViewBuilder::AppendArraySlice` does not support cases where the total length of elements in the input array exceeds the maximum value of` int32_t`.
### What changes are included in this PR?
This PR updates` arrow::BinaryViewBuilder::AppendArraySlice `to correctly handle `{StringView, BinaryView}Array `inputs where the total length of non-inlined elements exceeds the maximum value of int32_t.
### Are these changes tested?
Yes, the relevant unit tests were run and passed.
### Are there any user-facing changes?
No.


* GitHub Issue: #46515