### PR TITLE
GH-46656: [CI][Dev] Fix shellcheck SC2034 and SC2086 errors in ci/scripts directory

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -276,6 +276,7 @@ repos:
           ?^ci/scripts/install_ceph\.sh$|
           ?^ci/scripts/install_chromedriver\.sh$|
           ?^ci/scripts/install_cmake\.sh$|
+          ?^ci/scripts/install_conda\.sh$|
           ?^ci/scripts/install_emscripten\.sh$|
           ?^ci/scripts/install_iwyu\.sh$|
           ?^ci/scripts/install_ninja\.sh$|
@@ -286,9 +287,11 @@ repos:
           ?^ci/scripts/install_vcpkg\.sh$|
           ?^ci/scripts/integration_arrow_build\.sh$|
           ?^ci/scripts/integration_dask\.sh$|
+          ?^ci/scripts/integration_spark\.sh$|
           ?^ci/scripts/matlab_build\.sh$|
           ?^ci/scripts/msys2_system_clean\.sh$|
           ?^ci/scripts/msys2_system_upgrade\.sh$|
+          ?^ci/scripts/nanoarrow_build\.sh$|
           ?^ci/scripts/python_sdist_build\.sh$|
           ?^ci/scripts/python_wheel_unix_test\.sh$|
           ?^ci/scripts/r_build\.sh$|

--- a/ci/scripts/install_conda.sh
+++ b/ci/scripts/install_conda.sh
@@ -32,7 +32,7 @@ installer=$1
 version=$2
 prefix=$3
 
-download_url=https://github.com/conda-forge/miniforge/releases/latest/download/${installer^}-${platform}-${arch}.sh
+download_url=https://github.com/conda-forge/miniforge/releases/${version}/download/${installer^}-${platform}-${arch}.sh
 
 echo "Downloading Miniconda installer from ${download_url} ..."
 

--- a/ci/scripts/install_conda.sh
+++ b/ci/scripts/install_conda.sh
@@ -27,8 +27,6 @@ fi
 arch=$(uname -m)
 platform=$(uname)
 installer=$1
-# SC2034 (warning): version appears unused.
-# shellcheck disable=SC2034
 version=$2
 prefix=$3
 

--- a/ci/scripts/install_conda.sh
+++ b/ci/scripts/install_conda.sh
@@ -27,6 +27,8 @@ fi
 arch=$(uname -m)
 platform=$(uname)
 installer=$1
+# SC2034 (warning): version appears unused.
+# shellcheck disable=SC2034
 version=$2
 prefix=$3
 
@@ -34,12 +36,12 @@ download_url=https://github.com/conda-forge/miniforge/releases/latest/download/$
 
 echo "Downloading Miniconda installer from ${download_url} ..."
 
-wget -nv ${download_url} -O /tmp/installer.sh
-bash /tmp/installer.sh -b -p ${prefix}
+wget -nv "${download_url}" -O /tmp/installer.sh
+bash /tmp/installer.sh -b -p "${prefix}"
 rm /tmp/installer.sh
 
 # Like "conda init", but for POSIX sh rather than bash
-ln -s ${prefix}/etc/profile.d/conda.sh /etc/profile.d/conda.sh
+ln -s "${prefix}/etc/profile.d/conda.sh" /etc/profile.d/conda.sh
 
 export PATH=/opt/conda/bin:$PATH
 

--- a/ci/scripts/integration_spark.sh
+++ b/ci/scripts/integration_spark.sh
@@ -23,15 +23,13 @@ set -eu
 source_dir=${1}
 spark_dir=${2}
 
-# SC2034 (warning): spark_version appears unused.
-# shellcheck disable=SC2034
 # Spark branch to checkout
 spark_version=${SPARK_VERSION:-master}
 
 # Use old behavior that always dropped timezones.
 export PYARROW_IGNORE_TIMEZONE=1
 
-if [ "${SPARK_VERSION:1:2}" == "2." ]; then
+if [ "${spark_version:1:2}" == "2." ]; then
   # https://github.com/apache/spark/blob/master/docs/sql-pyspark-pandas-with-arrow.md#compatibility-setting-for-pyarrow--0150-and-spark-23x-24x
   export ARROW_PRE_0_15_IPC_FORMAT=1
 fi
@@ -40,7 +38,7 @@ export MAVEN_OPTS="-Xss256m -Xmx2g -XX:ReservedCodeCacheSize=1g -Dorg.slf4j.simp
 export MAVEN_OPTS="${MAVEN_OPTS} -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
 
 pushd "${spark_dir}"
-  echo "Building Spark ${SPARK_VERSION}"
+  echo "Building Spark ${spark_version}"
 
   # Build Spark only
   build/mvn -B -DskipTests package
@@ -54,7 +52,7 @@ pushd "${spark_dir}"
     "pyspark.sql.tests.arrow.test_arrow_map"
     "pyspark.sql.tests.arrow.test_arrow_python_udf")
 
-  case "${SPARK_VERSION}" in
+  case "${spark_version}" in
     v1.*|v2.*|v3.0.*|v3.1.*|v3.2.*|v3.3.*)
       old_test_modules=true
       ;;

--- a/ci/scripts/integration_spark.sh
+++ b/ci/scripts/integration_spark.sh
@@ -18,13 +18,14 @@
 # exit on any error
 set -eu
 
-# SC2034 (warning): source_dir appears unused.
-# shellcheck disable=SC2034
-source_dir=${1}
-spark_dir=${2}
+if [  "$#" -lt 2 ]; then
+  echo "Usage: $0 <spark_version> <spark_dir>"
+  exit 1
+fi
 
 # Spark branch to checkout
-spark_version=${SPARK_VERSION:-master}
+spark_version=${1}
+spark_dir=${2}
 
 # Use old behavior that always dropped timezones.
 export PYARROW_IGNORE_TIMEZONE=1

--- a/ci/scripts/integration_spark.sh
+++ b/ci/scripts/integration_spark.sh
@@ -18,9 +18,13 @@
 # exit on any error
 set -eu
 
+# SC2034 (warning): source_dir appears unused.
+# shellcheck disable=SC2034
 source_dir=${1}
 spark_dir=${2}
 
+# SC2034 (warning): spark_version appears unused.
+# shellcheck disable=SC2034
 # Spark branch to checkout
 spark_version=${SPARK_VERSION:-master}
 
@@ -35,7 +39,7 @@ fi
 export MAVEN_OPTS="-Xss256m -Xmx2g -XX:ReservedCodeCacheSize=1g -Dorg.slf4j.simpleLogger.defaultLogLevel=warn"
 export MAVEN_OPTS="${MAVEN_OPTS} -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"
 
-pushd ${spark_dir}
+pushd "${spark_dir}"
   echo "Building Spark ${SPARK_VERSION}"
 
   # Build Spark only

--- a/ci/scripts/nanoarrow_build.sh
+++ b/ci/scripts/nanoarrow_build.sh
@@ -21,7 +21,7 @@ set -e
 
 arrow_dir=${1}
 source_dir=${arrow_dir}/nanoarrow
-build_dir=${source_dir}/nanoarrow
+build_dir=${2}/nanoarrow
 
 # This file is used to build the nanoarrow binaries needed for the archery
 # integration tests. Testing of the nanoarrow implementation in normal CI is handled

--- a/ci/scripts/nanoarrow_build.sh
+++ b/ci/scripts/nanoarrow_build.sh
@@ -19,6 +19,8 @@
 
 set -e
 
+# SC2034 (warning): arrow_dir appears unused.
+# shellcheck disable=SC2034
 arrow_dir=${1}
 source_dir=${1}/nanoarrow
 build_dir=${2}/nanoarrow
@@ -43,10 +45,10 @@ fi
 
 set -x
 
-mkdir -p ${build_dir}
-pushd ${build_dir}
+mkdir -p "${build_dir}"
+pushd "${build_dir}"
 
-cmake ${source_dir} \
+cmake "${source_dir}" \
   -DNANOARROW_IPC=ON \
   -DNANOARROW_IPC_WITH_ZSTD=ON \
   -DNANOARROW_BUILD_INTEGRATION_TESTS=ON

--- a/ci/scripts/nanoarrow_build.sh
+++ b/ci/scripts/nanoarrow_build.sh
@@ -19,11 +19,9 @@
 
 set -e
 
-# SC2034 (warning): arrow_dir appears unused.
-# shellcheck disable=SC2034
 arrow_dir=${1}
-source_dir=${1}/nanoarrow
-build_dir=${2}/nanoarrow
+source_dir=${arrow_dir}/nanoarrow
+build_dir=${source_dir}/nanoarrow
 
 # This file is used to build the nanoarrow binaries needed for the archery
 # integration tests. Testing of the nanoarrow implementation in normal CI is handled


### PR DESCRIPTION
### Rationale for this change

We are trying to implement shellcheck on all sh files in #44748.

### What changes are included in this PR?

* SC2034 unused variable error. Use variable properly like `${1}` -> `${arrow_dir}`.
* SC2086 check require quoting like `${download_url}` -> `"${download_url}"`.

```
In ci/scripts/install_conda.sh line 30:
version=$2
^-----^ SC2034 (warning): version appears unused. Verify use (or export if used externally).


In ci/scripts/install_conda.sh line 37:
wget -nv ${download_url} -O /tmp/installer.sh
         ^-------------^ SC2086 (info): Double quote to prevent globbing and word splitting.
```

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #46656