### PR TITLE
GH-46659: [C++] Fix export of extension arrays with binary view/string view storage

### DIFF
--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -586,12 +586,8 @@ struct ArrayExporter {
       ++buffers_begin;
     }
 
-    Type::type storage_id =
-        data->type->id() == Type::EXTENSION
-            ? (checked_cast<const ExtensionType&>(*data->type).storage_type()->id())
-            : data->type->id();
-    bool need_variadic_buffer_sizes =
-        data->type->storage_id() == Type::BINARY_VIEW || storage_id == Type::STRING_VIEW;
+    bool need_variadic_buffer_sizes = data->type->storage_id() == Type::BINARY_VIEW ||
+                                      data->type->storage_id() == Type::STRING_VIEW;
     if (need_variadic_buffer_sizes) {
       ++n_buffers;
     }

--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -533,7 +533,7 @@ namespace {
 struct ExportedArrayPrivateData : PoolAllocationMixin<ExportedArrayPrivateData> {
   // The buffers are owned by the ArrayData member
   SmallVector<const void*, 3> buffers_;
-  struct ArrowArray dictionary_ {};
+  struct ArrowArray dictionary_{};
   SmallVector<struct ArrowArray, 1> children_;
   SmallVector<struct ArrowArray*, 4> child_pointers_;
 
@@ -586,8 +586,12 @@ struct ArrayExporter {
       ++buffers_begin;
     }
 
+    Type::type storage_id =
+        data->type->id() == Type::EXTENSION
+            ? (checked_cast<const ExtensionType&>(*data->type).storage_type()->id())
+            : data->type->id();
     bool need_variadic_buffer_sizes =
-        data->type->id() == Type::BINARY_VIEW || data->type->id() == Type::STRING_VIEW;
+        storage_id == Type::BINARY_VIEW || storage_id == Type::STRING_VIEW;
     if (need_variadic_buffer_sizes) {
       ++n_buffers;
     }

--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -591,7 +591,7 @@ struct ArrayExporter {
             ? (checked_cast<const ExtensionType&>(*data->type).storage_type()->id())
             : data->type->id();
     bool need_variadic_buffer_sizes =
-        storage_id == Type::BINARY_VIEW || storage_id == Type::STRING_VIEW;
+        data->type->storage_id() == Type::BINARY_VIEW || storage_id == Type::STRING_VIEW;
     if (need_variadic_buffer_sizes) {
       ++n_buffers;
     }

--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -533,7 +533,7 @@ namespace {
 struct ExportedArrayPrivateData : PoolAllocationMixin<ExportedArrayPrivateData> {
   // The buffers are owned by the ArrayData member
   SmallVector<const void*, 3> buffers_;
-  struct ArrowArray dictionary_{};
+  struct ArrowArray dictionary_ {};
   SmallVector<struct ArrowArray, 1> children_;
   SmallVector<struct ArrowArray*, 4> child_pointers_;
 

--- a/cpp/src/arrow/c/bridge_test.cc
+++ b/cpp/src/arrow/c/bridge_test.cc
@@ -581,13 +581,9 @@ struct ArrayExportChecker {
       ++expected_buffers;
     }
 
-    Type::type storage_id = expected_data.type->id() == Type::EXTENSION
-                                ? (checked_cast<const ExtensionType&>(*expected_data.type)
-                                       .storage_type()
-                                       ->id())
-                                : expected_data.type->id();
     bool has_variadic_buffer_sizes =
-        storage_id == Type::STRING_VIEW || storage_id == Type::BINARY_VIEW;
+        expected_data.type->storage_id() == Type::BINARY_VIEW ||
+        expected_data.type->storage_id() == Type::STRING_VIEW;
     ASSERT_EQ(c_export->n_buffers, expected_n_buffers + has_variadic_buffer_sizes);
     ASSERT_NE(c_export->buffers, nullptr);
 

--- a/cpp/src/arrow/c/bridge_test.cc
+++ b/cpp/src/arrow/c/bridge_test.cc
@@ -1230,8 +1230,8 @@ TEST_F(TestArrayExport, MoveSeveralChildren) {
 }
 
 TEST_F(TestArrayExport, ExportArrayAndType) {
-  struct ArrowSchema c_schema{};
-  struct ArrowArray c_array{};
+  struct ArrowSchema c_schema {};
+  struct ArrowArray c_array {};
   SchemaExportGuard schema_guard(&c_schema);
   ArrayExportGuard array_guard(&c_array);
 
@@ -1248,8 +1248,8 @@ TEST_F(TestArrayExport, ExportArrayAndType) {
 }
 
 TEST_F(TestArrayExport, ExportRecordBatch) {
-  struct ArrowSchema c_schema{};
-  struct ArrowArray c_array{};
+  struct ArrowSchema c_schema {};
+  struct ArrowArray c_array {};
 
   auto schema = ::arrow::schema(
       {field("ints", int16()), field("bools", boolean(), /*nullable=*/false)});
@@ -1708,8 +1708,8 @@ TEST_F(TestDeviceArrayExport, ExportArrayAndType) {
   std::shared_ptr<Device> device = std::make_shared<MyDevice>(1);
   auto mm = device->default_memory_manager();
 
-  struct ArrowSchema c_schema{};
-  struct ArrowDeviceArray c_array{};
+  struct ArrowSchema c_schema {};
+  struct ArrowDeviceArray c_array {};
   SchemaExportGuard schema_guard(&c_schema);
   ArrayExportGuard array_guard(&c_array.array);
 
@@ -1730,8 +1730,8 @@ TEST_F(TestDeviceArrayExport, ExportRecordBatch) {
   std::shared_ptr<Device> device = std::make_shared<MyDevice>(1);
   auto mm = device->default_memory_manager();
 
-  struct ArrowSchema c_schema{};
-  struct ArrowDeviceArray c_array{};
+  struct ArrowSchema c_schema {};
+  struct ArrowDeviceArray c_array {};
 
   auto schema = ::arrow::schema(
       {field("ints", int16()), field("bools", boolean(), /*nullable=*/false)});
@@ -3595,7 +3595,7 @@ class TestSchemaRoundtrip : public ::testing::Test {
   void TestWithTypeFactory(TypeFactory&& factory,
                            ExpectedTypeFactory&& factory_expected) {
     std::shared_ptr<DataType> type, actual;
-    struct ArrowSchema c_schema{};  // zeroed
+    struct ArrowSchema c_schema {};  // zeroed
     SchemaExportGuard schema_guard(&c_schema);
 
     auto orig_bytes = pool_->bytes_allocated();
@@ -3626,7 +3626,7 @@ class TestSchemaRoundtrip : public ::testing::Test {
   template <typename SchemaFactory>
   void TestWithSchemaFactory(SchemaFactory&& factory) {
     std::shared_ptr<Schema> schema, actual;
-    struct ArrowSchema c_schema{};  // zeroed
+    struct ArrowSchema c_schema {};  // zeroed
     SchemaExportGuard schema_guard(&c_schema);
 
     auto orig_bytes = pool_->bytes_allocated();
@@ -3841,8 +3841,8 @@ class TestArrayRoundtrip : public ::testing::Test {
   void TestWithArrayFactory(ArrayFactory&& factory,
                             ExpectedArrayFactory&& factory_expected) {
     std::shared_ptr<Array> array;
-    struct ArrowArray c_array{};
-    struct ArrowSchema c_schema{};
+    struct ArrowArray c_array {};
+    struct ArrowSchema c_schema {};
     ArrayExportGuard array_guard(&c_array);
     SchemaExportGuard schema_guard(&c_schema);
 
@@ -3886,8 +3886,8 @@ class TestArrayRoundtrip : public ::testing::Test {
   template <typename BatchFactory>
   void TestWithBatchFactory(BatchFactory&& factory) {
     std::shared_ptr<RecordBatch> batch;
-    struct ArrowArray c_array{};
-    struct ArrowSchema c_schema{};
+    struct ArrowArray c_array {};
+    struct ArrowSchema c_schema {};
     ArrayExportGuard array_guard(&c_array);
     SchemaExportGuard schema_guard(&c_schema);
 
@@ -4160,7 +4160,7 @@ TEST_F(TestArrayRoundtrip, RegisteredExtensionNoMetadata) {
       KeyValueMetadata::Make({"ARROW:extension:name"}, {ext_type->extension_name()});
   auto ext_field = field("", ext_type->storage_type(), true, std::move(ext_metadata));
 
-  struct ArrowSchema c_schema{};
+  struct ArrowSchema c_schema {};
   SchemaExportGuard schema_guard(&c_schema);
   ASSERT_OK(ExportField(*ext_field, &c_schema));
 
@@ -4281,8 +4281,8 @@ class TestDeviceArrayRoundtrip : public ::testing::Test {
   void TestWithArrayFactory(ArrayFactory&& factory,
                             ExpectedArrayFactory&& factory_expected) {
     std::shared_ptr<Array> array;
-    struct ArrowDeviceArray c_array{};
-    struct ArrowSchema c_schema{};
+    struct ArrowDeviceArray c_array {};
+    struct ArrowSchema c_schema {};
     ArrayExportGuard array_guard(&c_array.array);
     SchemaExportGuard schema_guard(&c_schema);
 
@@ -4330,8 +4330,8 @@ class TestDeviceArrayRoundtrip : public ::testing::Test {
     auto mm = device->default_memory_manager();
 
     std::shared_ptr<RecordBatch> batch;
-    struct ArrowDeviceArray c_array{};
-    struct ArrowSchema c_schema{};
+    struct ArrowDeviceArray c_array {};
+    struct ArrowSchema c_schema {};
     ArrayExportGuard array_guard(&c_array.array);
     SchemaExportGuard schema_guard(&c_schema);
 

--- a/cpp/src/arrow/testing/extension_type.h
+++ b/cpp/src/arrow/testing/extension_type.h
@@ -132,7 +132,6 @@ class ARROW_TESTING_EXPORT DictExtensionType : public ExtensionType {
   std::string Serialize() const override { return "dict-extension-serialized"; }
 };
 
-
 class ARROW_TESTING_EXPORT BinaryViewExtensionType : public ExtensionType {
  public:
   BinaryViewExtensionType() : ExtensionType(binary_view()) {}

--- a/cpp/src/arrow/testing/extension_type.h
+++ b/cpp/src/arrow/testing/extension_type.h
@@ -146,7 +146,7 @@ class ARROW_TESTING_EXPORT BinaryViewExtensionType : public ExtensionType {
       std::shared_ptr<DataType> storage_type,
       const std::string& serialized) const override;
 
-  std::string Serialize() const override { return "binary_view_serializeds"; }
+  std::string Serialize() const override { return "binary_view_serialized"; }
 };
 
 // A minimal extension type that does not error when passed blank extension information

--- a/cpp/src/arrow/testing/extension_type.h
+++ b/cpp/src/arrow/testing/extension_type.h
@@ -132,6 +132,24 @@ class ARROW_TESTING_EXPORT DictExtensionType : public ExtensionType {
   std::string Serialize() const override { return "dict-extension-serialized"; }
 };
 
+
+class ARROW_TESTING_EXPORT BinaryViewExtensionType : public ExtensionType {
+ public:
+  BinaryViewExtensionType() : ExtensionType(binary_view()) {}
+
+  std::string extension_name() const override { return "binary_view"; }
+
+  bool ExtensionEquals(const ExtensionType& other) const override;
+
+  std::shared_ptr<Array> MakeArray(std::shared_ptr<ArrayData> data) const override;
+
+  Result<std::shared_ptr<DataType>> Deserialize(
+      std::shared_ptr<DataType> storage_type,
+      const std::string& serialized) const override;
+
+  std::string Serialize() const override { return "binary_view_serializeds"; }
+};
+
 // A minimal extension type that does not error when passed blank extension information
 class ARROW_TESTING_EXPORT MetadataOptionalExtensionType : public ExtensionType {
  public:
@@ -189,6 +207,9 @@ std::shared_ptr<DataType> list_extension_type();
 
 ARROW_TESTING_EXPORT
 std::shared_ptr<DataType> dict_extension_type();
+
+ARROW_TESTING_EXPORT
+std::shared_ptr<DataType> binary_view_extension_type();
 
 ARROW_TESTING_EXPORT
 std::shared_ptr<DataType> complex128();


### PR DESCRIPTION
### Rationale for this change

Extension arrays exported with binary view/string view storage did not export the variadic sizes buffer which resulted in crashes when reimporting.

### What changes are included in this PR?

The expression that controlled whether the variadic sizes buffer was written was updated.

### Are these changes tested?

Yes, a test was added

### Are there any user-facing changes?

No
* GitHub Issue: #46659