### PR TITLE
GH-46662: [CI][Dev] Fix shellcheck SC2148 errors in ci/scripts directory

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -299,7 +299,9 @@ repos:
           ?^ci/scripts/release_test\.sh$|
           ?^ci/scripts/ruby_test\.sh$|
           ?^ci/scripts/rust_build\.sh$|
+          ?^ci/scripts/util_enable_core_dumps\.sh$|
           ?^ci/scripts/util_free_space\.sh$|
+          ?^ci/scripts/util_log\.sh$|
           ?^cpp/build-support/build-lz4-lib\.sh$|
           ?^cpp/build-support/build-zstd-lib\.sh$|
           ?^cpp/build-support/get-upstream-commit\.sh$|

--- a/ci/scripts/util_enable_core_dumps.sh
+++ b/ci/scripts/util_enable_core_dumps.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/ci/scripts/util_enable_core_dumps.sh
+++ b/ci/scripts/util_enable_core_dumps.sh
@@ -1,4 +1,4 @@
-# shellcheck disable=SC2148
+# shellcheck shell=bash
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/ci/scripts/util_enable_core_dumps.sh
+++ b/ci/scripts/util_enable_core_dumps.sh
@@ -1,4 +1,5 @@
-#!/usr/bin/env bash
+# shellcheck disable=SC2148
+#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/ci/scripts/util_log.sh
+++ b/ci/scripts/util_log.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information

--- a/ci/scripts/util_log.sh
+++ b/ci/scripts/util_log.sh
@@ -1,4 +1,4 @@
-# shellcheck disable=SC2148
+# shellcheck shell=bash
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file

--- a/ci/scripts/util_log.sh
+++ b/ci/scripts/util_log.sh
@@ -1,4 +1,5 @@
-#!/usr/bin/env bash
+# shellcheck disable=SC2148
+#
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information


### PR DESCRIPTION
### Rationale for this change

We are trying to implement shellcheck on all sh files in #44748.

### What changes are included in this PR?

* SC2148: Add `shellcheck shell=bash` in `util_*` files
```
In ci/scripts/util_enable_core_dumps.sh line 1:
# Licensed to the Apache Software Foundation (ASF) under one
^-- SC2148 (error): Tips depend on target shell and yours is unknown. Add a shebang or a 'shell' directive.
```

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.

* GitHub Issue: #46662