### PR TITLE
GH-46665: [CI][Crossbow][C++] Use apache/arrow for Alpine Linux

### DIFF
--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -85,7 +85,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           case "${GITHUB_EVENT_NAME}" in
-            push|workflow_dispatch)
+            push|schedule)
               ci_extra=true
               ;;
             pull_request)
@@ -114,6 +114,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - image: alpine-linux-cpp
+            runs-on: ubuntu-latest
+            title: AMD64 Alpine Linux
           - image: conda-cpp
             run-options: >-
               -e ARROW_USE_MESON=ON
@@ -122,7 +125,7 @@ jobs:
     env:
       ARCHERY_DEBUG: 1
       ARROW_ENABLE_TIMING_TESTS: OFF
-      # DOCKER_VOLUME_PREFIX: ".docker/"
+      DOCKER_VOLUME_PREFIX: ".docker/"
     steps:
       - name: Checkout Arrow
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -635,8 +635,7 @@ tasks:
 
 ############################## Docker tests ##################################
 
-{% for image in ["alpine-linux-cpp",
-                 "conda-cpp",
+{% for image in ["conda-cpp",
                  "debian-c-glib",
                  "ubuntu-c-glib",
                  "debian-ruby",


### PR DESCRIPTION
### Rationale for this change

We don't want to depend on external CI such as ursacomputing/crossbow with Crossbow as much as possible for easy to maintain.

### What changes are included in this PR?

Use `CI: Extra` label to run C++ tests on Alpine Linux in apache/arrow.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #46665