### PR TITLE
GH-46636: [R] Fix evaluation of external objects not in global environment in `case_when()`

### DIFF
--- a/r/NEWS.md
+++ b/r/NEWS.md
@@ -25,7 +25,7 @@
 - Expose an option `check_directory_existence_before_creation` in `S3FileSystem`
   to reduce I/O calls on cloud storage (@HaochengLIU, #41998)
 - `case_when()` now correctly detects objects that are not in the global 
-  environment (@etiennebacher, #46567).
+  environment (@etiennebacher, #46667).
 
 # arrow 20.0.0.1
 

--- a/r/NEWS.md
+++ b/r/NEWS.md
@@ -24,6 +24,8 @@
 - Added bindings for atan, sinh, cosh, tanh, asinh, acosh, and tanh, and expm1 (#44953)
 - Expose an option `check_directory_existence_before_creation` in `S3FileSystem`
   to reduce I/O calls on cloud storage (@HaochengLIU, #41998)
+- `case_when()` now correctly detects objects that are not in the global 
+  environment (@etiennebacher, #46567).
 
 # arrow 20.0.0.1
 

--- a/r/R/dplyr-eval.R
+++ b/r/R/dplyr-eval.R
@@ -30,7 +30,7 @@ arrow_eval <- function(expr, mask) {
   #   regular dplyr may work
   # * validation_error: the expression is known to be not valid, so don't
   #   recommend retrying with regular dplyr
-  tryCatch(eval_tidy(expr, mask), error = function(e) {
+  tryCatch(eval_tidy(expr, mask, env = mask), error = function(e) {
     # Inspect why the expression failed, and add the expr as the `call`
     # for better error messages
     msg <- conditionMessage(e)

--- a/r/tests/testthat/test-dplyr-funcs-conditional.R
+++ b/r/tests/testthat/test-dplyr-funcs-conditional.R
@@ -491,3 +491,20 @@ test_that("coalesce()", {
     class = "validation_error"
   )
 })
+
+test_that("external objects are found when they're not in the global environment, #46636", {
+  dat <- arrow_table(x = c("a", "b"))
+  pattern <- "a"
+  expect_identical(
+    dat |>
+      mutate(x2 = case_when(x == pattern ~ "foo")) |>
+      collect(),
+    tibble(x = c("a", "b"), x2 = c("foo", NA))
+  )
+  expect_identical(
+    dat |>
+      mutate(x2 = if_else(x == pattern, "foo", NA_character_)) |>
+      collect(),
+    tibble(x = c("a", "b"), x2 = c("foo", NA))
+  )
+})

--- a/r/tests/testthat/test-dplyr-funcs-conditional.R
+++ b/r/tests/testthat/test-dplyr-funcs-conditional.R
@@ -496,14 +496,14 @@ test_that("external objects are found when they're not in the global environment
   dat <- arrow_table(x = c("a", "b"))
   pattern <- "a"
   expect_identical(
-    dat |>
-      mutate(x2 = case_when(x == pattern ~ "foo")) |>
+    dat %>%
+      mutate(x2 = case_when(x == pattern ~ "foo")) %>%
       collect(),
     tibble(x = c("a", "b"), x2 = c("foo", NA))
   )
   expect_identical(
-    dat |>
-      mutate(x2 = if_else(x == pattern, "foo", NA_character_)) |>
+    dat %>%
+      mutate(x2 = if_else(x == pattern, "foo", NA_character_)) %>%
       collect(),
     tibble(x = c("a", "b"), x2 = c("foo", NA))
   )


### PR DESCRIPTION
### Rationale for this change

When a script is called in an environment that isn't the global environment (for instance with `source("my-script.R", local = new.env())`, `case_when()` would fail to detect external objects used in conditions.

This PR fixes this behavior.

Fixes #46636 

### What changes are included in this PR?

When evaluating expressions in `dplyr` functions, `eval_tidy()` now takes into account `mask` as an environment where it should look for external objects.

@thisisnic suggested in #46636 that the bug might be due to https://github.com/apache/arrow/blob/main/r/R/dplyr-funcs-conditional.R#L116 but I couldn't find a way to fix it there.

### Are these changes tested?

I added a test for this scenario. I ensured it failed before the change and succeeds after.

### Are there any user-facing changes?

There is one user-facing, non-breaking change, illustrated both in the related issue and in the new test.

* GitHub Issue: #46636