### PR TITLE
GH-46528: [Dev][CI] Increase lint job timeout

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -43,7 +43,7 @@ jobs:
     name: Lint C++, Python, R, Docker, RAT
     runs-on: ubuntu-24.04
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - name: Checkout Arrow
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0


### PR DESCRIPTION
### Rationale for this change

We have been adding more linters to our pre-commit tool and this seems to be timing out consistently on CI now.

### What changes are included in this PR?

Increase the timeout

### Are these changes tested?

Yes, CI

### Are there any user-facing changes?

No
* GitHub Issue: #46528