### PR TITLE
MINOR: [C++] Remove deprecated inclusion

### DIFF
--- a/cpp/src/arrow/dataset/test_util_internal.h
+++ b/cpp/src/arrow/dataset/test_util_internal.h
@@ -18,7 +18,6 @@
 #pragma once
 
 #include <algorithm>
-#include <ciso646>
 #include <functional>
 #include <memory>
 #include <ostream>


### PR DESCRIPTION
### What changes are included in this PR?

The `<ciso646>` inclusion is deprecated in C++20 and doesn't actually serve a purpose, remove it.

### Are these changes tested?

Compilation  passes on CI.

### Are there any user-facing changes?

No.