### PR TITLE
GH-46674: [C++] Construct Array from ExtensionType Scalar

### DIFF
--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -815,6 +815,23 @@ TEST_F(TestArray, TestMakeArrayFromMapScalar) {
   AssertAppendScalar(pool_, std::make_shared<MapScalar>(scalar));
 }
 
+TEST_F(TestArray, TestMakeArrayFromScalar_SmallintExtensionType) {
+  auto ext_type = std::make_shared<SmallintType>();
+  auto storage_scalar = std::make_shared<Int16Scalar>(42);
+  auto ext_scalar = std::make_shared<ExtensionScalar>(ext_type, storage_scalar);
+
+  ASSERT_OK_AND_ASSIGN(auto arr, MakeArrayFromScalar(*ext_scalar, 3));
+  ASSERT_EQ(arr->type()->id(), Type::EXTENSION);
+  ASSERT_EQ(arr->length(), 3);
+
+  auto ext_arr = std::static_pointer_cast<ExtensionArray>(arr);
+  ASSERT_EQ(ext_arr->storage()->type_id(), Type::INT16);
+  auto int_arr = std::static_pointer_cast<Int16Array>(ext_arr->storage());
+  for (int i = 0; i < 3; ++i) {
+    ASSERT_EQ(int_arr->Value(i), 42);
+  }
+}
+
 void CheckSpanRoundTrip(const Array& array) {
   ArraySpan span;
   span.SetMembers(*array.data());

--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -815,7 +815,7 @@ TEST_F(TestArray, TestMakeArrayFromMapScalar) {
   AssertAppendScalar(pool_, std::make_shared<MapScalar>(scalar));
 }
 
-TEST_F(TestArray, TestMakeArrayFromScalar_SmallintExtensionType) {
+TEST_F(TestArray, TestMakeArrayFromScalarSmallintExtensionType) {
   auto ext_type = std::make_shared<SmallintType>();
   auto storage_scalar = std::make_shared<Int16Scalar>(42);
   auto ext_scalar = std::make_shared<ExtensionScalar>(storage_scalar, ext_type);

--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -818,7 +818,7 @@ TEST_F(TestArray, TestMakeArrayFromMapScalar) {
 TEST_F(TestArray, TestMakeArrayFromScalar_SmallintExtensionType) {
   auto ext_type = std::make_shared<SmallintType>();
   auto storage_scalar = std::make_shared<Int16Scalar>(42);
-  auto ext_scalar = std::make_shared<ExtensionScalar>(ext_type, storage_scalar);
+  auto ext_scalar = std::make_shared<ExtensionScalar>(storage_scalar, ext_type);
 
   ASSERT_OK_AND_ASSIGN(auto arr, MakeArrayFromScalar(*ext_scalar, 3));
   ASSERT_EQ(arr->type()->id(), Type::EXTENSION);

--- a/cpp/src/arrow/array/util.cc
+++ b/cpp/src/arrow/array/util.cc
@@ -829,7 +829,17 @@ class RepeatedArrayFactory {
   }
 
   Status Visit(const ExtensionType& type) {
-    return Status::NotImplemented("construction from scalar of type ", *scalar_.type);
+    // Retrieve the underlying storage scalar from the ExtensionScalar
+    const auto& ext_scalar = checked_cast<const ExtensionScalar&>(scalar_);
+    const auto& storage_scalar = ext_scalar.value;
+
+    // Create an array from the storage scalar
+    ARROW_ASSIGN_OR_RAISE(auto storage_array,
+                          MakeArrayFromScalar(*storage_scalar, length_, pool_));
+
+    // Wrap the storage array in the ExtensionType
+    out_ = type.MakeArray(storage_array->data());
+    return Status::OK();
   }
 
   Result<std::shared_ptr<Buffer>> CreateUnionTypeCodes(int8_t type_code) {

--- a/cpp/src/arrow/array/util.cc
+++ b/cpp/src/arrow/array/util.cc
@@ -837,8 +837,10 @@ class RepeatedArrayFactory {
     ARROW_ASSIGN_OR_RAISE(auto storage_array,
                           MakeArrayFromScalar(*storage_scalar, length_, pool_));
 
-    // Wrap the storage array in the ExtensionType
-    out_ = type.MakeArray(storage_array->data());
+    auto ext_type = std::static_pointer_cast<ExtensionType>(ext_scalar.type);
+
+    out_ = type.WrapArray(ext_type, storage_array);
+
     return Status::OK();
   }
 


### PR DESCRIPTION
### Rationale for this change

We get a segfault when we try to create an Expression from an ExtensionType Scalar due to calling MakeArrayFromScalar on an ExtensionType Scalar, which wasn't implemented before.

### What changes are included in this PR?

Implementation of creating an array from an extension type scalar.

Make Array from storage type but using scalar data

### Are these changes tested?

Yes

### Are there any user-facing changes?

Yes

* GitHub Issue: #46674