### PR TITLE
GH-46673: [CI][R][Docs] Accept empty INSTALL_ARGS again

### DIFF
--- a/ci/scripts/r_build.sh
+++ b/ci/scripts/r_build.sh
@@ -24,6 +24,12 @@ build_dir=${2}
 
 : "${BUILD_DOCS_R:=OFF}"
 
+# Split words safely using read and a here string (Bash only)
+#
+# This statement split INSTALL_ARGS="--foo --bar" and set
+# R_INSTALL_ARGS as array like ['--foo', '--bar'] in Python.
+# This way SC2086 shellcheck safe.
+# See also: https://www.shellcheck.net/wiki/SC2086
 read -r -a R_INSTALL_ARGS <<< "${INSTALL_ARGS:-}"
 
 # https://github.com/apache/arrow/issues/41429
@@ -41,6 +47,13 @@ if [ -x "$(command -v sudo)" ]; then
 else
   SUDO=
 fi
+
+# "${R_INSTALL_ARGS[@]}" extracts array variable.
+#
+# when the variable empty:
+#   -> CMD INSTALL arrow*.tar.gz
+# when the variable set ['--foo', '--bar']:
+#   -> CMD INSTALL --foo --bar arrow*.tar.gz
 ${SUDO} \
   env \
     PKG_CONFIG_PATH="${ARROW_HOME}/lib/pkgconfig:${PKG_CONFIG_PATH}" \

--- a/ci/scripts/r_build.sh
+++ b/ci/scripts/r_build.sh
@@ -24,6 +24,12 @@ build_dir=${2}
 
 : "${BUILD_DOCS_R:=OFF}"
 
+if [ -z "${INSTALL_ARGS}" ] ; then
+  R_INSTALL_ARGS=()
+else
+  read -r -a R_INSTALL_ARGS <<< "$INSTALL_ARGS"
+fi
+
 # https://github.com/apache/arrow/issues/41429
 # TODO: We want to out-of-source build. This is a workaround. We copy
 # all needed files to the build directory from the source directory
@@ -42,7 +48,7 @@ fi
 ${SUDO} \
   env \
     PKG_CONFIG_PATH="${ARROW_HOME}/lib/pkgconfig:${PKG_CONFIG_PATH}" \
-      "${R_BIN}" CMD INSTALL "${INSTALL_ARGS}" arrow*.tar.gz
+      "${R_BIN}" CMD INSTALL "${R_INSTALL_ARGS[@]}" arrow*.tar.gz
 
 if [ "${BUILD_DOCS_R}" == "ON" ]; then
   ${R_BIN} -e "pkgdown::build_site(install = FALSE)"

--- a/ci/scripts/r_build.sh
+++ b/ci/scripts/r_build.sh
@@ -44,7 +44,6 @@ if [ -x "$(command -v sudo)" ]; then
 else
   SUDO=
 fi
-
 ${SUDO} \
   env \
     PKG_CONFIG_PATH="${ARROW_HOME}/lib/pkgconfig:${PKG_CONFIG_PATH}" \

--- a/ci/scripts/r_build.sh
+++ b/ci/scripts/r_build.sh
@@ -24,7 +24,7 @@ build_dir=${2}
 
 : "${BUILD_DOCS_R:=OFF}"
 
-if [ -z "${INSTALL_ARGS}" ] ; then
+if [ -z "${INSTALL_ARGS}" ]; then
   R_INSTALL_ARGS=()
 else
   read -r -a R_INSTALL_ARGS <<< "$INSTALL_ARGS"

--- a/ci/scripts/r_build.sh
+++ b/ci/scripts/r_build.sh
@@ -24,7 +24,7 @@ build_dir=${2}
 
 : "${BUILD_DOCS_R:=OFF}"
 
-read -r -a R_INSTALL_ARGS <<< "$INSTALL_ARGS"
+read -r -a R_INSTALL_ARGS <<< "${INSTALL_ARGS:-}"
 
 # https://github.com/apache/arrow/issues/41429
 # TODO: We want to out-of-source build. This is a workaround. We copy

--- a/ci/scripts/r_build.sh
+++ b/ci/scripts/r_build.sh
@@ -24,11 +24,7 @@ build_dir=${2}
 
 : "${BUILD_DOCS_R:=OFF}"
 
-if [ -z "${INSTALL_ARGS}" ]; then
-  R_INSTALL_ARGS=()
-else
-  read -r -a R_INSTALL_ARGS <<< "$INSTALL_ARGS"
-fi
+read -r -a R_INSTALL_ARGS <<< "$INSTALL_ARGS"
 
 # https://github.com/apache/arrow/issues/41429
 # TODO: We want to out-of-source build. This is a workaround. We copy

--- a/ci/scripts/r_build.sh
+++ b/ci/scripts/r_build.sh
@@ -24,13 +24,10 @@ build_dir=${2}
 
 : "${BUILD_DOCS_R:=OFF}"
 
-# Split words safely using read and a here string (Bash only)
-#
-# This statement split INSTALL_ARGS="--foo --bar" and set
-# R_INSTALL_ARGS as array like ['--foo', '--bar'] in Python.
-# This way SC2086 shellcheck safe.
-# See also: https://www.shellcheck.net/wiki/SC2086
-read -r -a R_INSTALL_ARGS <<< "${INSTALL_ARGS:-}"
+R_INSTALL_ARGS=()
+for arg in ${INSTALL_ARGS:-}; do
+  R_INSTALL_ARGS+=("${arg}")
+done
 
 # https://github.com/apache/arrow/issues/41429
 # TODO: We want to out-of-source build. This is a workaround. We copy
@@ -48,12 +45,6 @@ else
   SUDO=
 fi
 
-# "${R_INSTALL_ARGS[@]}" extracts array variable.
-#
-# when the variable empty:
-#   -> CMD INSTALL arrow*.tar.gz
-# when the variable set ['--foo', '--bar']:
-#   -> CMD INSTALL --foo --bar arrow*.tar.gz
 ${SUDO} \
   env \
     PKG_CONFIG_PATH="${ARROW_HOME}/lib/pkgconfig:${PKG_CONFIG_PATH}" \


### PR DESCRIPTION
### Rationale for this change

This PR fixes the bug introduced in #46527.

If the environment variable `INSTALL_ARGS` doesn't set,
the R command should execute,
`CMD INSTALL arrow*tar.gz`. 

After #46527 change, It executed  
`CMD INSTALL '' arrow*tar.gz`

### What changes are included in this PR?

Split `INSTALL_ARGS` to `R_INSTALL_ARGS` as array and use `"${R_INSTALL_ARGS[@]}"`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #46673