### PR TITLE
GH-46688: [Ruby] Fix a typo

### DIFF
--- a/ruby/red-arrow/ext/arrow/extconf.rb
+++ b/ruby/red-arrow/ext/arrow/extconf.rb
@@ -50,7 +50,7 @@ unless PKGConfig.have_package("arrow-glib",
                               Arrow::Version::MAJOR,
                               Arrow::Version::MINOR,
                               Arrow::Version::MICRO)
-  verison = [
+  version = [
     Arrow::Version::MAJOR,
     Arrow::Version::MINOR,
     Arrow::Version::MICRO,


### PR DESCRIPTION
### Rationale for this change

There is a typo.

FYI: This is not a critical because this typo exists in code that is only executed in an error case.

### What changes are included in this PR?

Fix a typo.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #46688