### PR TITLE
GH-45332: [C++] Improve build time through forward Declarations

### DIFF
--- a/cpp/src/arrow/array/array_base.cc
+++ b/cpp/src/arrow/array/array_base.cc
@@ -76,6 +76,7 @@ bool Array::IsValid(int64_t i) const {
   }
   return data_->null_count != data_->length;
 }
+
 const std::shared_ptr<DataType>& Array::type() const { return data_->type; }
 
 Type::type Array::type_id() const { return data_->type->id(); }
@@ -93,6 +94,7 @@ DeviceAllocationType Array::device_type() const { return data_->device_type(); }
 const std::shared_ptr<ArrayStatistics>& Array::statistics() const {
   return data_->statistics;
 }
+
 void Array::SetData(const std::shared_ptr<ArrayData>& data) {
   if (data->buffers.size() > 0) {
     null_bitmap_data_ = data->GetValuesSafe<uint8_t>(0, /*offset=*/0);
@@ -379,6 +381,7 @@ Result<std::shared_ptr<Array>> Array::ViewOrCopyTo(
 NullArray::NullArray(int64_t length) {
   SetData(ArrayData::Make(null(), length, {nullptr}, length));
 }
+
 void NullArray::SetData(const std::shared_ptr<ArrayData>& data) {
   null_bitmap_data_ = NULLPTR;
   data->null_count = data->length;

--- a/cpp/src/arrow/array/array_base.h
+++ b/cpp/src/arrow/array/array_base.h
@@ -263,8 +263,8 @@ class ARROW_EXPORT PrimitiveArray : public FlatArray {
  protected:
   PrimitiveArray(const std::shared_ptr<DataType>& type, int64_t length,
                  const std::shared_ptr<Buffer>& data,
-                 const std::shared_ptr<Buffer>& null_bitmap, int64_t null_count,
-                 int64_t offset);
+                 const std::shared_ptr<Buffer>& null_bitmap = NULLPTR,
+                 int64_t null_count = kUnknownNullCount, int64_t offset = 0);
 
   PrimitiveArray() : raw_values_(NULLPTR) {}
 

--- a/cpp/src/arrow/array/array_binary.cc
+++ b/cpp/src/arrow/array/array_binary.cc
@@ -146,6 +146,7 @@ StringViewArray::StringViewArray(std::shared_ptr<ArrayData> data) {
   ARROW_CHECK_EQ(data->type->id(), Type::STRING_VIEW);
   SetData(std::move(data));
 }
+
 void BinaryViewArray::SetData(std::shared_ptr<ArrayData> data) {
   FlatArray::SetData(std::move(data));
   raw_values_ = data_->GetValuesSafe<c_type>(1);

--- a/cpp/src/arrow/array/array_primitive.cc
+++ b/cpp/src/arrow/array/array_primitive.cc
@@ -33,9 +33,14 @@ namespace arrow {
 
 PrimitiveArray::PrimitiveArray(const std::shared_ptr<DataType>& type, int64_t length,
                                const std::shared_ptr<Buffer>& data,
-                               const std::shared_ptr<Buffer>& null_bitmap,
-                               int64_t null_count, int64_t offset) {
+                               const std::shared_ptr<Buffer>& null_bitmap = NULLPTR,
+                               int64_t null_count = kUnknownNullCount, int64_t offset = 0) {
   SetData(ArrayData::Make(type, length, {null_bitmap, data}, null_count, offset));
+}
+
+void PrimitiveArray::SetData(const std::shared_ptr<ArrayData>& data) {
+  this->Array::SetData(data);
+  raw_values_ = data->GetValuesSafe<uint8_t>(1, /*offset=*/0);
 }
 
 // ----------------------------------------------------------------------

--- a/cpp/src/arrow/array/array_primitive.cc
+++ b/cpp/src/arrow/array/array_primitive.cc
@@ -33,8 +33,8 @@ namespace arrow {
 
 PrimitiveArray::PrimitiveArray(const std::shared_ptr<DataType>& type, int64_t length,
                                const std::shared_ptr<Buffer>& data,
-                               const std::shared_ptr<Buffer>& null_bitmap = NULLPTR,
-                               int64_t null_count = kUnknownNullCount, int64_t offset = 0) {
+                               const std::shared_ptr<Buffer>& null_bitmap,
+                               int64_t null_count, int64_t offset) {
   SetData(ArrayData::Make(type, length, {null_bitmap, data}, null_count, offset));
 }
 

--- a/cpp/src/arrow/array/data.h
+++ b/cpp/src/arrow/array/data.h
@@ -50,12 +50,6 @@ ARROW_EXPORT bool DictionaryMayHaveLogicalNulls(const ArrayData& data);
 
 }  // namespace internal
 
-// When slicing, we do not know the null count of the sliced range without
-// doing some computation. To avoid doing this eagerly, we set the null count
-// to -1 (any negative number will do). When Array::null_count is called the
-// first time, the null count will be computed. See ARROW-33
-constexpr int64_t kUnknownNullCount = -1;
-
 // ----------------------------------------------------------------------
 // Generic array data container
 

--- a/cpp/src/arrow/c/dlpack.cc
+++ b/cpp/src/arrow/c/dlpack.cc
@@ -18,6 +18,7 @@
 #include "arrow/c/dlpack.h"
 
 #include "arrow/array/array_base.h"
+#include "arrow/array/data.h"
 #include "arrow/c/dlpack_abi.h"
 #include "arrow/device.h"
 #include "arrow/type.h"

--- a/cpp/src/arrow/c/dlpack_test.cc
+++ b/cpp/src/arrow/c/dlpack_test.cc
@@ -18,6 +18,7 @@
 #include <gtest/gtest.h>
 
 #include "arrow/array/array_base.h"
+#include "arrow/array/data.h"
 #include "arrow/c/dlpack.h"
 #include "arrow/c/dlpack_abi.h"
 #include "arrow/memory_pool.h"

--- a/cpp/src/arrow/type_fwd.h
+++ b/cpp/src/arrow/type_fwd.h
@@ -69,6 +69,7 @@ using FieldVector = std::vector<std::shared_ptr<Field>>;
 
 class Array;
 struct ArrayData;
+struct ArrayStatistics;
 struct ArraySpan;
 class ArrayBuilder;
 struct Scalar;

--- a/cpp/src/arrow/type_fwd.h
+++ b/cpp/src/arrow/type_fwd.h
@@ -784,4 +784,10 @@ constexpr int kDeviceAllocationTypeMax = 16;
 
 class DeviceAllocationTypeSet;
 
+// When slicing, we do not know the null count of the sliced range without
+// doing some computation. To avoid doing this eagerly, we set the null count
+// to -1 (any negative number will do). When Array::null_count is called the
+// first time, the null count will be computed. See ARROW-33
+constexpr int64_t kUnknownNullCount = -1;
+
 }  // namespace arrow


### PR DESCRIPTION
### Rationale for this change

When reviewing the output of ClangBuildAnalyzer, it appears that the arrow/array/data.h header is considered to be the most expensive include:

```
**** Expensive headers:
157903 ms: /home/simple/code/cpp/arrow/cpp/src/arrow/array/data.h (included 388 times, avg 406 ms), included via:
  78x: array.h array_base.h 
  21x: array_base.h 
  21x: exec_plan.h exec.h 
  15x: test_util.h extension_type.h array_base.h 
  10x: api_scalar.h datum.h 
  10x: api_aggregate.h datum.h 
  ...

122962 ms: /home/simple/code/cpp/arrow/cpp/build/_deps/googletest-src/googletest/include/gtest/gtest.h (included 235 times, avg 523 ms), included via:
  124x: <direct include>
  45x: gmock.h gmock-actions.h gmock-internal-utils.h 
  29x: gmock-matchers.h gmock-internal-utils.h 
  10x: gtest_util.h 
  6x: test_util_internal.h gmock.h gmock-actions.h gmock-internal-utils.h 
  3x: test_common.h gtest_util.h 
  ...

113797 ms: /home/simple/code/cpp/arrow/cpp/src/arrow/array/statistics.h (included 390 times, avg 291 ms), included via:
  78x: array.h array_base.h data.h 
  21x: array_base.h data.h 
  21x: exec_plan.h exec.h data.h 
  15x: test_util.h extension_type.h array_base.h data.h 
  10x: api_aggregate.h datum.h data.h 
  10x: api_scalar.h datum.h data.h 
  ...
```

### What changes are included in this PR?

- Replace "data.h" header with `ArrayData` foward declarations
- Replace "statistics.h" header with `ArrayStatistics`foward declarations
 
### Are these changes tested?

Manually build pass.

### Are there any user-facing changes?

No, only an API improvement.

* GitHub Issue: #45332