### PR TITLE
GH-46693: [CI] Update GitHub hosted runner from deprecated windows-2019 to windows-2022

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -375,7 +375,7 @@ jobs:
 
   windows-mingw:
     name: AMD64 Windows MinGW ${{ matrix.msystem_upper }} C++
-    runs-on: windows-2019
+    runs-on: windows-2022
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     # Build may take 1h+ without cache.
     timeout-minutes: 120

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -73,7 +73,7 @@ jobs:
         run: ci/scripts/csharp_test.sh $(pwd)
 
   windows:
-    name: AMD64 Windows 2019 18.04 C# ${{ matrix.dotnet }}
+    name: AMD64 Windows C# ${{ matrix.dotnet }}
     runs-on: windows-2022
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     timeout-minutes: 15

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -74,7 +74,7 @@ jobs:
 
   windows:
     name: AMD64 Windows 2019 18.04 C# ${{ matrix.dotnet }}
-    runs-on: windows-2019
+    runs-on: windows-2022
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     timeout-minutes: 15
     strategy:

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -196,7 +196,7 @@ jobs:
 
   windows-cpp:
     name: AMD64 Windows C++ RTools ${{ matrix.config.rtools }} ${{ matrix.config.arch }}
-    runs-on: windows-2019
+    runs-on: windows-2022
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     timeout-minutes: 90
     strategy:
@@ -248,7 +248,7 @@ jobs:
   windows-r:
     needs: [windows-cpp]
     name: AMD64 Windows R ${{ matrix.config.rversion }}
-    runs-on: windows-2019
+    runs-on: windows-2022
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     timeout-minutes: 75
     strategy:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -201,7 +201,7 @@ jobs:
 
   windows-mingw:
     name: AMD64 Windows MinGW ${{ matrix.mingw-n-bits }} GLib & Ruby
-    runs-on: windows-2019
+    runs-on: windows-2022
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     timeout-minutes: 90
     strategy:

--- a/dev/release/verify-release-candidate.bat
+++ b/dev/release/verify-release-candidate.bat
@@ -69,7 +69,7 @@ call conda create --no-shortcuts -c conda-forge -f -q -y -p %_VERIFICATION_CONDA
 
 call activate %_VERIFICATION_CONDA_ENV% || exit /B 1
 
-set GENERATOR=Visual Studio 16 2019
+set GENERATOR=Visual Studio 17 2022
 set ARCHITECTURE=x64
 set CONFIGURATION=release
 
@@ -84,7 +84,7 @@ mkdir !ARROW_SOURCE!\cpp\build
 pushd !ARROW_SOURCE!\cpp\build
 
 @rem This is the path for Visual Studio Community 2017
-call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\Common7\Tools\VsDevCmd.bat" -arch=amd64
+call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
 
 @rem NOTE(wesm): not using Ninja for now to be able to more easily control the
 @rem generator used

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -632,6 +632,7 @@ tasks:
       env:
         PYARROW_TEST_GDB: "OFF"
       script: "verify-release-candidate.bat"
+      timeout: 120
 
 ############################## Docker tests ##################################
 

--- a/dev/tasks/vcpkg-tests/cpp-build-vcpkg.bat
+++ b/dev/tasks/vcpkg-tests/cpp-build-vcpkg.bat
@@ -51,7 +51,7 @@ pushd cpp\build
 @rem TODO(ianmcook): Add -DARROW_BUILD_BENCHMARKS=ON after the issue described
 @rem at https://github.com/google/benchmark/issues/1046 is resolved
 
-cmake -G "Visual Studio 16 2019" -A x64 ^
+cmake -G "Visual Studio 17 2022" -A x64 ^
       -DARROW_BOOST_USE_SHARED=ON ^
       -DARROW_BUILD_SHARED=ON ^
       -DARROW_BUILD_STATIC=OFF ^

--- a/dev/tasks/vcpkg-tests/github.windows.yml
+++ b/dev/tasks/vcpkg-tests/github.windows.yml
@@ -22,7 +22,7 @@
 jobs:
   test-vcpkg-win:
     name: Install build deps with vcpkg and build Arrow C++
-    runs-on: windows-2019
+    runs-on: windows-2022
     env:
       VCPKG_BINARY_SOURCES: 'clear;nuget,GitHub,readwrite'
       VCPKG_DEFAULT_TRIPLET: 'x64-windows'

--- a/dev/tasks/verify-rc/github.win.yml
+++ b/dev/tasks/verify-rc/github.win.yml
@@ -22,7 +22,7 @@
 jobs:
   verify:
     name: "Verify release candidate Windows source"
-    runs-on: windows-2019
+    runs-on: windows-2022
     {% if env is defined %}
     env:
     {% for key, value in env.items() %}

--- a/dev/tasks/verify-rc/github.win.yml
+++ b/dev/tasks/verify-rc/github.win.yml
@@ -29,7 +29,7 @@ jobs:
       {{ key }}: {{ value }}
     {% endfor %}
     {% endif %}
-    timeout-minutes: 60
+    timeout-minutes: {{ timeout|default(60) }}
 
     steps:
       {{ macros.github_checkout_arrow(fetch_depth=0)|indent }}

--- a/docs/source/developers/cpp/windows.rst
+++ b/docs/source/developers/cpp/windows.rst
@@ -170,12 +170,12 @@ an out of source build by generating a MSVC solution:
    cd cpp
    mkdir build
    cd build
-   cmake .. -G "Visual Studio 15 2017" -A x64 ^
+   cmake .. -G "Visual Studio 16 2019" -A x64 ^
          -DARROW_BUILD_TESTS=ON
    cmake --build . --config Release
 
 For newer versions of Visual Studio, specify the generator
-``Visual Studio 16 2019`` or see ``cmake --help`` for available
+``Visual Studio 17 2022`` or see ``cmake --help`` for available
 generators.
 
 Building with Ninja and sccache


### PR DESCRIPTION
### Rationale for this change

GitHub is deprecating windows-2019 hosted runners, see:
- https://github.com/actions/runner-images/issues/12045

### What changes are included in this PR?

Update our images to use windows-2022 and Visual Studio 17 2022 (where necessary)

### Are these changes tested?

Yes via CI.

### Are there any user-facing changes?
No

* GitHub Issue: #46693