### PR TITLE
GH-46439: [C++] Remove unneeded namespace prefix in test_util_internal.h

### DIFF
--- a/cpp/src/arrow/dataset/test_util_internal.h
+++ b/cpp/src/arrow/dataset/test_util_internal.h
@@ -2140,8 +2140,8 @@ class WriteFileSystemDatasetMixin : public MakeFileSystemDatasetMixin {
         actual_struct = std::dynamic_pointer_cast<Array>(struct_array);
       }
 
-      auto expected_struct = arrow::ArrayFromJSON(
-          struct_(expected_physical_schema_->fields()), file_contents->second);
+      auto expected_struct = ArrayFromJSON(struct_(expected_physical_schema_->fields()),
+                                           file_contents->second);
 
       AssertArraysEqual(*expected_struct, *actual_struct, /*verbose=*/true);
     }


### PR DESCRIPTION
### Rationale for this change

Addresses https://github.com/apache/arrow/pull/46180#discussion_r2089101500. One of three PRs to resolve https://github.com/apache/arrow/issues/46439.

### What changes are included in this PR?

- Remove unneeded namespace prefix in test_util_internal.h.

### Are these changes tested?

Yes. Impacted tests still pass.

### Are there any user-facing changes?

No.
* GitHub Issue: #46439