### PR TITLE
GH-46439: [C++] Use result pattern for all FromJSONString Helpers

### DIFF
--- a/cpp/examples/arrow/from_json_string_example.cc
+++ b/cpp/examples/arrow/from_json_string_example.cc
@@ -68,15 +68,15 @@ arrow::Status RunExample() {
           "[[11, 22], null, [null, 33]]"));
 
   // ChunkedArrayFromJSONString
-  std::shared_ptr<arrow::ChunkedArray> chunked_array;
-  ARROW_RETURN_NOT_OK(ChunkedArrayFromJSONString(
-      arrow::int32(), {"[5, 10]", "[null]", "[16]"}, &chunked_array));
+  ARROW_ASSIGN_OR_RAISE(
+      auto chunked_array,
+      ChunkedArrayFromJSONString(arrow::int32(), {"[5, 10]", "[null]", "[16]"}));
 
   // DictArrayFromJSONString
-  std::shared_ptr<arrow::Array> dict_array;
-  ARROW_RETURN_NOT_OK(DictArrayFromJSONString(
-      dictionary(arrow::int32(), arrow::utf8()), "[0, 1, 0, 2, 0, 3]",
-      R"(["k1", "k2", "k3", "k4"])", &dict_array));
+  ARROW_ASSIGN_OR_RAISE(
+      auto dict_array,
+      DictArrayFromJSONString(dictionary(arrow::int32(), arrow::utf8()),
+                              "[0, 1, 0, 2, 0, 3]", R"(["k1", "k2", "k3", "k4"])"));
 
   return arrow::Status::OK();
 }

--- a/cpp/src/arrow/json/from_string.cc
+++ b/cpp/src/arrow/json/from_string.cc
@@ -1047,8 +1047,7 @@ Result<std::shared_ptr<Scalar>> ScalarFromJSONString(
   RETURN_NOT_OK(converter->AppendValue(json_doc));
   RETURN_NOT_OK(converter->Finish(&array));
   DCHECK_EQ(array->length(), 1);
-  ARROW_ASSIGN_OR_RAISE(auto out, array->GetScalar(0));
-  return out;
+  return array->GetScalar(0);
 }
 
 Result<std::shared_ptr<Scalar>> DictScalarFromJSONString(

--- a/cpp/src/arrow/json/from_string.cc
+++ b/cpp/src/arrow/json/from_string.cc
@@ -1030,9 +1030,7 @@ Result<std::shared_ptr<Array>> DictArrayFromJSONString(
                         ArrayFromJSONString(dictionary_type.index_type(), indices_json));
   ARROW_ASSIGN_OR_RAISE(auto dictionary, ArrayFromJSONString(dictionary_type.value_type(),
                                                              dictionary_json));
-  ARROW_ASSIGN_OR_RAISE(auto out, DictionaryArray::FromArrays(type, std::move(indices),
-                                                              std::move(dictionary)));
-  return out;
+  return DictionaryArray::FromArrays(type, std::move(indices), std::move(dictionary)));
 }
 
 Result<std::shared_ptr<Scalar>> ScalarFromJSONString(

--- a/cpp/src/arrow/json/from_string.cc
+++ b/cpp/src/arrow/json/from_string.cc
@@ -1028,7 +1028,7 @@ Result<std::shared_ptr<Array>> DictArrayFromJSONString(
                         ArrayFromJSONString(dictionary_type.index_type(), indices_json));
   ARROW_ASSIGN_OR_RAISE(auto dictionary, ArrayFromJSONString(dictionary_type.value_type(),
                                                              dictionary_json));
-  return DictionaryArray::FromArrays(type, std::move(indices), std::move(dictionary)));
+  return DictionaryArray::FromArrays(type, std::move(indices), std::move(dictionary));
 }
 
 Result<std::shared_ptr<Scalar>> ScalarFromJSONString(

--- a/cpp/src/arrow/json/from_string.cc
+++ b/cpp/src/arrow/json/from_string.cc
@@ -1012,9 +1012,7 @@ Result<std::shared_ptr<ChunkedArray>> ChunkedArrayFromJSONString(
     out_chunks.emplace_back();
     ARROW_ASSIGN_OR_RAISE(out_chunks.back(), ArrayFromJSONString(type, chunk_json));
   }
-  std::shared_ptr<ChunkedArray> out =
-      std::make_shared<ChunkedArray>(std::move(out_chunks), type);
-  return out;
+  return std::make_shared<ChunkedArray>(std::move(out_chunks), type);
 }
 
 Result<std::shared_ptr<Array>> DictArrayFromJSONString(

--- a/cpp/src/arrow/json/from_string.cc
+++ b/cpp/src/arrow/json/from_string.cc
@@ -1069,8 +1069,7 @@ Result<std::shared_ptr<Scalar>> DictScalarFromJSONString(
   ARROW_ASSIGN_OR_RAISE(
       dictionary, ArrayFromJSONString(dictionary_type.value_type(), dictionary_json));
 
-  auto out = DictionaryScalar::Make(std::move(index), std::move(dictionary));
-  return out;
+  return DictionaryScalar::Make(std::move(index), std::move(dictionary));
 }
 
 }  // namespace json

--- a/cpp/src/arrow/json/from_string.cc
+++ b/cpp/src/arrow/json/from_string.cc
@@ -1004,23 +1004,22 @@ Result<std::shared_ptr<Array>> ArrayFromJSONString(const std::shared_ptr<DataTyp
   return ArrayFromJSONString(type, std::string_view(json_string));
 }
 
-Status ChunkedArrayFromJSONString(const std::shared_ptr<DataType>& type,
-                                  const std::vector<std::string>& json_strings,
-                                  std::shared_ptr<ChunkedArray>* out) {
+Result<std::shared_ptr<ChunkedArray>> ChunkedArrayFromJSONString(
+    const std::shared_ptr<DataType>& type, const std::vector<std::string>& json_strings) {
   ArrayVector out_chunks;
   out_chunks.reserve(json_strings.size());
   for (const std::string& chunk_json : json_strings) {
     out_chunks.emplace_back();
     ARROW_ASSIGN_OR_RAISE(out_chunks.back(), ArrayFromJSONString(type, chunk_json));
   }
-  *out = std::make_shared<ChunkedArray>(std::move(out_chunks), type);
-  return Status::OK();
+  std::shared_ptr<ChunkedArray> out =
+      std::make_shared<ChunkedArray>(std::move(out_chunks), type);
+  return out;
 }
 
-Status DictArrayFromJSONString(const std::shared_ptr<DataType>& type,
-                               std::string_view indices_json,
-                               std::string_view dictionary_json,
-                               std::shared_ptr<Array>* out) {
+Result<std::shared_ptr<Array>> DictArrayFromJSONString(
+    const std::shared_ptr<DataType>& type, std::string_view indices_json,
+    std::string_view dictionary_json) {
   if (type->id() != Type::DICTIONARY) {
     return Status::TypeError("DictArrayFromJSON requires dictionary type, got ", *type);
   }
@@ -1031,13 +1030,13 @@ Status DictArrayFromJSONString(const std::shared_ptr<DataType>& type,
                         ArrayFromJSONString(dictionary_type.index_type(), indices_json));
   ARROW_ASSIGN_OR_RAISE(auto dictionary, ArrayFromJSONString(dictionary_type.value_type(),
                                                              dictionary_json));
-
-  return DictionaryArray::FromArrays(type, std::move(indices), std::move(dictionary))
-      .Value(out);
+  ARROW_ASSIGN_OR_RAISE(auto out, DictionaryArray::FromArrays(type, std::move(indices),
+                                                              std::move(dictionary)));
+  return out;
 }
 
-Status ScalarFromJSONString(const std::shared_ptr<DataType>& type,
-                            std::string_view json_string, std::shared_ptr<Scalar>* out) {
+Result<std::shared_ptr<Scalar>> ScalarFromJSONString(
+    const std::shared_ptr<DataType>& type, std::string_view json_string) {
   std::shared_ptr<JSONConverter> converter;
   RETURN_NOT_OK(GetConverter(type, &converter));
 
@@ -1052,13 +1051,13 @@ Status ScalarFromJSONString(const std::shared_ptr<DataType>& type,
   RETURN_NOT_OK(converter->AppendValue(json_doc));
   RETURN_NOT_OK(converter->Finish(&array));
   DCHECK_EQ(array->length(), 1);
-  return array->GetScalar(0).Value(out);
+  ARROW_ASSIGN_OR_RAISE(auto out, array->GetScalar(0));
+  return out;
 }
 
-Status DictScalarFromJSONString(const std::shared_ptr<DataType>& type,
-                                std::string_view index_json,
-                                std::string_view dictionary_json,
-                                std::shared_ptr<Scalar>* out) {
+Result<std::shared_ptr<Scalar>> DictScalarFromJSONString(
+    const std::shared_ptr<DataType>& type, std::string_view index_json,
+    std::string_view dictionary_json) {
   if (type->id() != Type::DICTIONARY) {
     return Status::TypeError("DictScalarFromJSONString requires dictionary type, got ",
                              *type);
@@ -1066,14 +1065,14 @@ Status DictScalarFromJSONString(const std::shared_ptr<DataType>& type,
 
   const auto& dictionary_type = checked_cast<const DictionaryType&>(*type);
 
-  std::shared_ptr<Scalar> index;
   std::shared_ptr<Array> dictionary;
-  RETURN_NOT_OK(ScalarFromJSONString(dictionary_type.index_type(), index_json, &index));
+  ARROW_ASSIGN_OR_RAISE(auto index,
+                        ScalarFromJSONString(dictionary_type.index_type(), index_json));
   ARROW_ASSIGN_OR_RAISE(
       dictionary, ArrayFromJSONString(dictionary_type.value_type(), dictionary_json));
 
-  *out = DictionaryScalar::Make(std::move(index), std::move(dictionary));
-  return Status::OK();
+  auto out = DictionaryScalar::Make(std::move(index), std::move(dictionary));
+  return out;
 }
 
 }  // namespace json

--- a/cpp/src/arrow/json/from_string.h
+++ b/cpp/src/arrow/json/from_string.h
@@ -84,7 +84,6 @@ Result<std::shared_ptr<ChunkedArray>> ChunkedArrayFromJSONString(
 ///     R"(["k1", "k2", "k3", "k4"])");
 /// \endcode
 ARROW_EXPORT
-ARROW_EXPORT
 Result<std::shared_ptr<Array>> DictArrayFromJSONString(const std::shared_ptr<DataType>&,
                                                        std::string_view indices_json,
                                                        std::string_view dictionary_json);

--- a/cpp/src/arrow/json/from_string.h
+++ b/cpp/src/arrow/json/from_string.h
@@ -68,9 +68,8 @@ Result<std::shared_ptr<Array>> ArrayFromJSONString(const std::shared_ptr<DataTyp
 /// \brief Create a ChunkedArray from a JSON string
 ///
 /// \code {.cpp}
-/// std::shared_ptr<ChunkedArray> chunked_array =
-///     ChunkedArrayFromJSONString(int64(), {R"([5, 10])", R"([null])", R"([16])"})
-///         .ValueOrDie();
+/// Result<std::shared_ptr<ChunkedArray>> chunked_array_result =
+///     ChunkedArrayFromJSONString(int64(), {R"([5, 10])", R"([null])", R"([16])"});
 /// \endcode
 ARROW_EXPORT
 Result<std::shared_ptr<ChunkedArray>> ChunkedArrayFromJSONString(

--- a/cpp/src/arrow/json/from_string.h
+++ b/cpp/src/arrow/json/from_string.h
@@ -47,7 +47,7 @@ namespace json {
 /// \brief Create an Array from a JSON string
 ///
 /// \code {.cpp}
-/// Result<std::shared_ptr<Array>> array =
+/// Result<std::shared_ptr<Array>> maybe_array =
 ///     ArrayFromJSONString(int64(), "[2, 3, null, 7, 11]");
 /// \endcode
 ARROW_EXPORT
@@ -67,7 +67,7 @@ Result<std::shared_ptr<Array>> ArrayFromJSONString(const std::shared_ptr<DataTyp
 /// \brief Create a ChunkedArray from a JSON string
 ///
 /// \code {.cpp}
-/// Result<std::shared_ptr<ChunkedArray>> chunked_array =
+/// Result<std::shared_ptr<ChunkedArray>> maybe_chunked_array =
 ///     ChunkedArrayFromJSONString(int64(), {R"([5, 10])", R"([null])", R"([16])"});
 /// \endcode
 ARROW_EXPORT
@@ -77,7 +77,7 @@ Result<std::shared_ptr<ChunkedArray>> ChunkedArrayFromJSONString(
 /// \brief Create a DictionaryArray from a JSON string
 ///
 /// \code {.cpp}
-/// Result<std::shared_ptr<Array>> dict_array =
+/// Result<std::shared_ptr<Array>> maybe_dict_array =
 ///     DictArrayFromJSONString(dictionary(int32(), utf8()), "[0, 1, 0, 2, 0, 3]",
 ///     R"(["k1", "k2", "k3", "k4"])");
 /// \endcode
@@ -88,7 +88,7 @@ Result<std::shared_ptr<Array>> DictArrayFromJSONString(const std::shared_ptr<Dat
 
 /// \brief Create a Scalar from a JSON string
 /// \code {.cpp}
-/// Result<std::shared_ptr<Scalar>> scalar =
+/// Result<std::shared_ptr<Scalar>> maybe_scalar =
 ///     ScalarFromJSONString(float64(), "42", &scalar);
 /// \endcode
 ARROW_EXPORT
@@ -97,7 +97,7 @@ Result<std::shared_ptr<Scalar>> ScalarFromJSONString(const std::shared_ptr<DataT
 
 /// \brief Create a DictionaryScalar from a JSON string
 /// \code {.cpp}
-/// Result<std::shared_ptr<Scalar>> dict_scalar =
+/// Result<std::shared_ptr<Scalar>> maybe_dict_scalar =
 ///     DictScalarFromJSONString(dictionary(int32(), utf8()), "3", R"(["k1", "k2", "k3",
 ///     "k4"])", &scalar);
 /// \endcode

--- a/cpp/src/arrow/json/from_string.h
+++ b/cpp/src/arrow/json/from_string.h
@@ -67,7 +67,7 @@ Result<std::shared_ptr<Array>> ArrayFromJSONString(const std::shared_ptr<DataTyp
 /// \brief Create a ChunkedArray from a JSON string
 ///
 /// \code {.cpp}
-/// Result<std::shared_ptr<ChunkedArray>> chunked_array_result =
+/// Result<std::shared_ptr<ChunkedArray>> chunked_array =
 ///     ChunkedArrayFromJSONString(int64(), {R"([5, 10])", R"([null])", R"([16])"});
 /// \endcode
 ARROW_EXPORT

--- a/cpp/src/arrow/json/from_string.h
+++ b/cpp/src/arrow/json/from_string.h
@@ -47,9 +47,8 @@ namespace json {
 /// \brief Create an Array from a JSON string
 ///
 /// \code {.cpp}
-/// std::shared_ptr<Array> array = ArrayFromJSONString(
-///     int64(), "[2, 3, null, 7, 11]"
-/// ).ValueOrDie();
+/// Result<std::shared_ptr<Array>> array =
+///     ArrayFromJSONString(int64(), "[2, 3, null, 7, 11]");
 /// \endcode
 ARROW_EXPORT
 Result<std::shared_ptr<Array>> ArrayFromJSONString(const std::shared_ptr<DataType>&,
@@ -78,7 +77,7 @@ Result<std::shared_ptr<ChunkedArray>> ChunkedArrayFromJSONString(
 /// \brief Create a DictionaryArray from a JSON string
 ///
 /// \code {.cpp}
-/// std::shared_ptr<Array> dict_array =
+/// Result<std::shared_ptr<Array>> dict_array =
 ///     DictArrayFromJSONString(dictionary(int32(), utf8()), "[0, 1, 0, 2, 0, 3]",
 ///     R"(["k1", "k2", "k3", "k4"])");
 /// \endcode
@@ -89,7 +88,7 @@ Result<std::shared_ptr<Array>> DictArrayFromJSONString(const std::shared_ptr<Dat
 
 /// \brief Create a Scalar from a JSON string
 /// \code {.cpp}
-/// std::shared_ptr<Scalar> scalar =
+/// Result<std::shared_ptr<Scalar>> scalar =
 ///     ScalarFromJSONString(float64(), "42", &scalar);
 /// \endcode
 ARROW_EXPORT
@@ -98,7 +97,7 @@ Result<std::shared_ptr<Scalar>> ScalarFromJSONString(const std::shared_ptr<DataT
 
 /// \brief Create a DictionaryScalar from a JSON string
 /// \code {.cpp}
-/// std::shared_ptr<Scalar> dict_scalar =
+/// Result<std::shared_ptr<Scalar>> dict_scalar =
 ///     DictScalarFromJSONString(dictionary(int32(), utf8()), "3", R"(["k1", "k2", "k3",
 ///     "k4"])", &scalar);
 /// \endcode

--- a/cpp/src/arrow/json/from_string.h
+++ b/cpp/src/arrow/json/from_string.h
@@ -48,7 +48,7 @@ namespace json {
 ///
 /// \code {.cpp}
 /// std::shared_ptr<Array> array = ArrayFromJSONString(
-///   int64(), "[2, 3, null, 7, 11]"
+///     int64(), "[2, 3, null, 7, 11]"
 /// ).ValueOrDie();
 /// \endcode
 ARROW_EXPORT
@@ -68,52 +68,46 @@ Result<std::shared_ptr<Array>> ArrayFromJSONString(const std::shared_ptr<DataTyp
 /// \brief Create a ChunkedArray from a JSON string
 ///
 /// \code {.cpp}
-/// std::shared_ptr<ChunkedArray> chunked_array;
-/// ChunkedArrayFromJSONString(
-///   int64(), {R"([5, 10])", R"([null])", R"([16])"}, &chunked_array
-/// );
+/// std::shared_ptr<ChunkedArray> chunked_array =
+///     ChunkedArrayFromJSONString(int64(), {R"([5, 10])", R"([null])", R"([16])"})
+///         .ValueOrDie();
 /// \endcode
 ARROW_EXPORT
-Status ChunkedArrayFromJSONString(const std::shared_ptr<DataType>& type,
-                                  const std::vector<std::string>& json_strings,
-                                  std::shared_ptr<ChunkedArray>* out);
+Result<std::shared_ptr<ChunkedArray>> ChunkedArrayFromJSONString(
+    const std::shared_ptr<DataType>& type, const std::vector<std::string>& json_strings);
 
 /// \brief Create a DictionaryArray from a JSON string
 ///
 /// \code {.cpp}
-/// std::shared_ptr<Array> array;
-/// DictArrayFromJSONString(
-///   dictionary(int32(), utf8()),
-///   "[0, 1, 0, 2, 0, 3]", R"(["k1", "k2", "k3", "k4"])",
-///   &array
-/// );
+/// std::shared_ptr<Array> dict_array =
+///     DictArrayFromJSONString(dictionary(int32(), utf8()), "[0, 1, 0, 2, 0, 3]",
+///     R"(["k1", "k2", "k3", "k4"])");
 /// \endcode
 ARROW_EXPORT
-Status DictArrayFromJSONString(const std::shared_ptr<DataType>&,
-                               std::string_view indices_json,
-                               std::string_view dictionary_json,
-                               std::shared_ptr<Array>* out);
+ARROW_EXPORT
+Result<std::shared_ptr<Array>> DictArrayFromJSONString(const std::shared_ptr<DataType>&,
+                                                       std::string_view indices_json,
+                                                       std::string_view dictionary_json);
 
 /// \brief Create a Scalar from a JSON string
 /// \code {.cpp}
-/// std::shared_ptr<Scalar> scalar;
-/// ScalarFromJSONString(float64(), "42", &scalar);
+/// std::shared_ptr<Scalar> scalar =
+///     ScalarFromJSONString(float64(), "42", &scalar);
 /// \endcode
 ARROW_EXPORT
-Status ScalarFromJSONString(const std::shared_ptr<DataType>&, std::string_view json,
-                            std::shared_ptr<Scalar>* out);
+Result<std::shared_ptr<Scalar>> ScalarFromJSONString(const std::shared_ptr<DataType>&,
+                                                     std::string_view json);
 
 /// \brief Create a DictionaryScalar from a JSON string
 /// \code {.cpp}
-/// std::shared_ptr<Scalar> scalar;
-/// DictScalarFromJSONString(dictionary(int32(), utf8()), "3", R"(["k1", "k2", "k3",
-/// "k4"])", &scalar);
+/// std::shared_ptr<Scalar> dict_scalar =
+///     DictScalarFromJSONString(dictionary(int32(), utf8()), "3", R"(["k1", "k2", "k3",
+///     "k4"])", &scalar);
 /// \endcode
 ARROW_EXPORT
-Status DictScalarFromJSONString(const std::shared_ptr<DataType>&,
-                                std::string_view index_json,
-                                std::string_view dictionary_json,
-                                std::shared_ptr<Scalar>* out);
+Result<std::shared_ptr<Scalar>> DictScalarFromJSONString(
+    const std::shared_ptr<DataType>&, std::string_view index_json,
+    std::string_view dictionary_json);
 
 /// @}
 

--- a/cpp/src/arrow/json/from_string_test.cc
+++ b/cpp/src/arrow/json/from_string_test.cc
@@ -1498,7 +1498,6 @@ TEST(TestChunkedArrayFromJSON, Basics) {
 
 TEST(TestScalarFromJSON, Basics) {
   // Sanity check for common types (not exhaustive)
-  std::shared_ptr<Scalar> scalar;
   AssertJSONScalar<Int64Type>(int64(), "4", true, 4);
   AssertJSONScalar<Int64Type>(int64(), "null", false, 0);
   AssertJSONScalar<StringType, std::shared_ptr<Buffer>>(utf8(), R"("")", true,
@@ -1515,14 +1514,13 @@ TEST(TestScalarFromJSON, Basics) {
   AssertJSONScalar<BooleanType, bool>(boolean(), "1", true, true);
   AssertJSONScalar<DoubleType>(float64(), "1.0", true, 1.0);
   AssertJSONScalar<DoubleType>(float64(), "-0.0", true, -0.0);
-  ASSERT_OK(ScalarFromJSONString(float64(), "NaN"));
-  ASSERT_TRUE(std::isnan(checked_cast<DoubleScalar&>(*scalar).value));
-  ASSERT_OK(ScalarFromJSONString(float64(), "Inf"));
-  ASSERT_TRUE(std::isinf(checked_cast<DoubleScalar&>(*scalar).value));
+  ASSERT_OK_AND_ASSIGN(auto nan_scalar, ScalarFromJSONString(float64(), "NaN"));
+  ASSERT_TRUE(std::isnan(checked_cast<DoubleScalar&>(*nan_scalar).value));
+  ASSERT_OK_AND_ASSIGN(auto inf_scalar, ScalarFromJSONString(float64(), "Inf"));
+  ASSERT_TRUE(std::isinf(checked_cast<DoubleScalar&>(*inf_scalar).value));
 }
 
 TEST(TestScalarFromJSON, Errors) {
-  std::shared_ptr<Scalar> scalar;
   ASSERT_RAISES(Invalid, ScalarFromJSONString(int64(), "[0]"));
   ASSERT_RAISES(Invalid, ScalarFromJSONString(int64(), "[9223372036854775808]"));
   ASSERT_RAISES(Invalid, ScalarFromJSONString(int64(), "[-9223372036854775809]"));

--- a/cpp/src/arrow/json/from_string_test.cc
+++ b/cpp/src/arrow/json/from_string_test.cc
@@ -149,9 +149,9 @@ template <typename T, typename C_TYPE = typename T::c_type>
 void AssertJSONScalar(const std::shared_ptr<DataType>& type, const std::string& json,
                       const bool is_valid, const C_TYPE value) {
   SCOPED_TRACE(json);
-  std::shared_ptr<Scalar> actual, expected;
+  std::shared_ptr<Scalar> expected;
 
-  ASSERT_OK(ScalarFromJSONString(type, json, &actual));
+  ASSERT_OK_AND_ASSIGN(auto actual, ScalarFromJSONString(type, json));
   if (is_valid) {
     ASSERT_OK_AND_ASSIGN(expected, MakeScalar(type, value));
   } else {
@@ -1471,30 +1471,29 @@ TEST(TestDictArrayFromJSON, Basics) {
 
 TEST(TestDictArrayFromJSON, Errors) {
   auto type = dictionary(int32(), utf8());
-  std::shared_ptr<Array> array;
 
-  ASSERT_RAISES(Invalid, DictArrayFromJSONString(type, "[\"not a valid index\"]",
-                                                 "[\"\"]", &array));
-  ASSERT_RAISES(Invalid, DictArrayFromJSONString(type, "[0, 1]", "[1]",
-                                                 &array));  // dict value isn't string
+  ASSERT_RAISES(Invalid,
+                DictArrayFromJSONString(type, "[\"not a valid index\"]", "[\"\"]"));
+  ASSERT_RAISES(Invalid, DictArrayFromJSONString(type, "[0, 1]",
+                                                 "[1]"));  // dict value isn't string
 }
 
 TEST(TestChunkedArrayFromJSON, Basics) {
   auto type = int32();
-  std::shared_ptr<ChunkedArray> chunked_array;
-  ASSERT_OK(ChunkedArrayFromJSONString(type, {}, &chunked_array));
+  ASSERT_OK_AND_ASSIGN(auto chunked_array, ChunkedArrayFromJSONString(type, {}));
   ASSERT_OK(chunked_array->ValidateFull());
   ASSERT_EQ(chunked_array->num_chunks(), 0);
   AssertTypeEqual(type, chunked_array->type());
 
-  ASSERT_OK(ChunkedArrayFromJSONString(type, {"[1, 2]", "[3, null, 4]"}, &chunked_array));
-  ASSERT_OK(chunked_array->ValidateFull());
-  ASSERT_EQ(chunked_array->num_chunks(), 2);
+  ASSERT_OK_AND_ASSIGN(auto chunked_array_two,
+                       ChunkedArrayFromJSONString(type, {"[1, 2]", "[3, null, 4]"}));
+  ASSERT_OK(chunked_array_two->ValidateFull());
+  ASSERT_EQ(chunked_array_two->num_chunks(), 2);
   std::shared_ptr<Array> expected_chunk;
   ASSERT_OK_AND_ASSIGN(expected_chunk, ArrayFromJSONString(type, "[1, 2]"));
-  AssertArraysEqual(*expected_chunk, *chunked_array->chunk(0), /*verbose=*/true);
+  AssertArraysEqual(*expected_chunk, *chunked_array_two->chunk(0), /*verbose=*/true);
   ASSERT_OK_AND_ASSIGN(expected_chunk, ArrayFromJSONString(type, "[3, null, 4]"));
-  AssertArraysEqual(*expected_chunk, *chunked_array->chunk(1), /*verbose=*/true);
+  AssertArraysEqual(*expected_chunk, *chunked_array_two->chunk(1), /*verbose=*/true);
 }
 
 TEST(TestScalarFromJSON, Basics) {
@@ -1516,25 +1515,23 @@ TEST(TestScalarFromJSON, Basics) {
   AssertJSONScalar<BooleanType, bool>(boolean(), "1", true, true);
   AssertJSONScalar<DoubleType>(float64(), "1.0", true, 1.0);
   AssertJSONScalar<DoubleType>(float64(), "-0.0", true, -0.0);
-  ASSERT_OK(ScalarFromJSONString(float64(), "NaN", &scalar));
+  ASSERT_OK(ScalarFromJSONString(float64(), "NaN"));
   ASSERT_TRUE(std::isnan(checked_cast<DoubleScalar&>(*scalar).value));
-  ASSERT_OK(ScalarFromJSONString(float64(), "Inf", &scalar));
+  ASSERT_OK(ScalarFromJSONString(float64(), "Inf"));
   ASSERT_TRUE(std::isinf(checked_cast<DoubleScalar&>(*scalar).value));
 }
 
 TEST(TestScalarFromJSON, Errors) {
   std::shared_ptr<Scalar> scalar;
-  ASSERT_RAISES(Invalid, ScalarFromJSONString(int64(), "[0]", &scalar));
-  ASSERT_RAISES(Invalid, ScalarFromJSONString(int64(), "[9223372036854775808]", &scalar));
-  ASSERT_RAISES(Invalid,
-                ScalarFromJSONString(int64(), "[-9223372036854775809]", &scalar));
-  ASSERT_RAISES(Invalid,
-                ScalarFromJSONString(uint64(), "[18446744073709551616]", &scalar));
-  ASSERT_RAISES(Invalid, ScalarFromJSONString(uint64(), "[-1]", &scalar));
-  ASSERT_RAISES(Invalid, ScalarFromJSONString(binary(), "0", &scalar));
-  ASSERT_RAISES(Invalid, ScalarFromJSONString(binary(), "[]", &scalar));
-  ASSERT_RAISES(Invalid, ScalarFromJSONString(boolean(), "0.0", &scalar));
-  ASSERT_RAISES(Invalid, ScalarFromJSONString(boolean(), "\"true\"", &scalar));
+  ASSERT_RAISES(Invalid, ScalarFromJSONString(int64(), "[0]"));
+  ASSERT_RAISES(Invalid, ScalarFromJSONString(int64(), "[9223372036854775808]"));
+  ASSERT_RAISES(Invalid, ScalarFromJSONString(int64(), "[-9223372036854775809]"));
+  ASSERT_RAISES(Invalid, ScalarFromJSONString(uint64(), "[18446744073709551616]"));
+  ASSERT_RAISES(Invalid, ScalarFromJSONString(uint64(), "[-1]"));
+  ASSERT_RAISES(Invalid, ScalarFromJSONString(binary(), "0"));
+  ASSERT_RAISES(Invalid, ScalarFromJSONString(binary(), "[]"));
+  ASSERT_RAISES(Invalid, ScalarFromJSONString(boolean(), "0.0"));
+  ASSERT_RAISES(Invalid, ScalarFromJSONString(boolean(), "\"true\""));
 }
 
 TEST(TestDictScalarFromJSONString, Basics) {
@@ -1553,12 +1550,11 @@ TEST(TestDictScalarFromJSONString, Basics) {
 
 TEST(TestDictScalarFromJSONString, Errors) {
   auto type = dictionary(int32(), utf8());
-  std::shared_ptr<Scalar> scalar;
 
-  ASSERT_RAISES(Invalid, DictScalarFromJSONString(type, "\"not a valid index\"", "[\"\"]",
-                                                  &scalar));
-  ASSERT_RAISES(Invalid, DictScalarFromJSONString(type, "0", "[1]",
-                                                  &scalar));  // dict value isn't string
+  ASSERT_RAISES(Invalid,
+                DictScalarFromJSONString(type, "\"not a valid index\"", "[\"\"]"));
+  ASSERT_RAISES(Invalid,
+                DictScalarFromJSONString(type, "0", "[1]"));  // dict value isn't string
 }
 
 }  // namespace json

--- a/cpp/src/arrow/testing/gtest_util.cc
+++ b/cpp/src/arrow/testing/gtest_util.cc
@@ -387,15 +387,14 @@ std::shared_ptr<Array> ArrayFromJSON(const std::shared_ptr<DataType>& type,
 std::shared_ptr<Array> DictArrayFromJSON(const std::shared_ptr<DataType>& type,
                                          std::string_view indices_json,
                                          std::string_view dictionary_json) {
-  std::shared_ptr<Array> out;
-  ABORT_NOT_OK(json::DictArrayFromJSONString(type, indices_json, dictionary_json, &out));
+  EXPECT_OK_AND_ASSIGN(
+      auto out, json::DictArrayFromJSONString(type, indices_json, dictionary_json));
   return out;
 }
 
 std::shared_ptr<ChunkedArray> ChunkedArrayFromJSON(const std::shared_ptr<DataType>& type,
                                                    const std::vector<std::string>& json) {
-  std::shared_ptr<ChunkedArray> out;
-  ABORT_NOT_OK(json::ChunkedArrayFromJSONString(type, json, &out));
+  EXPECT_OK_AND_ASSIGN(auto out, json::ChunkedArrayFromJSONString(type, json));
   return out;
 }
 
@@ -411,16 +410,15 @@ std::shared_ptr<RecordBatch> RecordBatchFromJSON(const std::shared_ptr<Schema>& 
 
 std::shared_ptr<Scalar> ScalarFromJSON(const std::shared_ptr<DataType>& type,
                                        std::string_view json) {
-  std::shared_ptr<Scalar> out;
-  ABORT_NOT_OK(json::ScalarFromJSONString(type, json, &out));
+  EXPECT_OK_AND_ASSIGN(auto out, json::ScalarFromJSONString(type, json));
   return out;
 }
 
 std::shared_ptr<Scalar> DictScalarFromJSON(const std::shared_ptr<DataType>& type,
                                            std::string_view index_json,
                                            std::string_view dictionary_json) {
-  std::shared_ptr<Scalar> out;
-  ABORT_NOT_OK(json::DictScalarFromJSONString(type, index_json, dictionary_json, &out));
+  EXPECT_OK_AND_ASSIGN(auto out,
+                       json::DictScalarFromJSONString(type, index_json, dictionary_json));
   return out;
 }
 

--- a/python/pyarrow/src/arrow/python/gdb.cc
+++ b/python/pyarrow/src/arrow/python/gdb.cc
@@ -479,13 +479,12 @@ void TestSession() {
       key_value_metadata({"key1", "key2", "key3"}, {"value1", "value2", "value3"}));
 
   // Table
-  ChunkedArrayVector table_columns{2};
-  ARROW_CHECK_OK(
-      ChunkedArrayFromJSONString(int32(), {"[1, 2, 3]", "[4, 5]"}, &table_columns[0]));
-  ARROW_CHECK_OK(ChunkedArrayFromJSONString(
-      utf8(), {R"(["abc", null])", R"(["def"])", R"(["ghi", "jkl"])"},
-      &table_columns[1]));
-  auto table = Table::Make(batch_schema, table_columns);
+  ASSERT_OK_AND_ASSIGN(auto col1,
+                       ChunkedArrayFromJSONString(int32(), {"[1, 2, 3]", "[4, 5]"}));
+  ASSERT_OK_AND_ASSIGN(
+      auto col2, ChunkedArrayFromJSONString(
+                     utf8(), {R"(["abc", null])", R"(["def"])", R"(["ghi", "jkl"])"}));
+  auto table = Table::Make(batch_schema, {col1, col2});
 
   // Datum
   Datum empty_datum{};

--- a/python/pyarrow/src/arrow/python/gdb.cc
+++ b/python/pyarrow/src/arrow/python/gdb.cc
@@ -364,8 +364,8 @@ void TestSession() {
                                         /*is_valid=*/false};
 
   auto heap_map_scalar =
-      ScalarFromJSONString(map(utf8(), int32()), R"([["a", 5], ["b", 6]])");
-  auto heap_map_scalar_null = MakeNullScalar(heap_map_scalar.ValueOrDie()->type);
+      *ScalarFromJSONString(map(utf8(), int32()), R"([["a", 5], ["b", 6]])");
+  auto heap_map_scalar_null = MakeNullScalar(heap_map_scalar->type);
 
   // Array and ArrayData
   auto heap_null_array = SliceArrayFromJSON(null(), "[null, null]");

--- a/python/pyarrow/src/arrow/python/gdb.cc
+++ b/python/pyarrow/src/arrow/python/gdb.cc
@@ -363,9 +363,9 @@ void TestSession() {
   ExtensionScalar extension_scalar_null{extension_scalar.value, extension_scalar_type,
                                         /*is_valid=*/false};
 
-  std::shared_ptr<Scalar> heap_map_scalar;
-  ARROW_CHECK_OK(ScalarFromJSONString(map(utf8(), int32()), R"([["a", 5], ["b", 6]])",
-                                      &heap_map_scalar));
+  ASSERT_OK_AND_ASSIGN(
+      auto heap_map_scalar,
+      ScalarFromJSONString(map(utf8(), int32()), R"([["a", 5], ["b", 6]])"));
   auto heap_map_scalar_null = MakeNullScalar(heap_map_scalar->type);
 
   // Array and ArrayData

--- a/python/pyarrow/src/arrow/python/gdb.cc
+++ b/python/pyarrow/src/arrow/python/gdb.cc
@@ -363,10 +363,9 @@ void TestSession() {
   ExtensionScalar extension_scalar_null{extension_scalar.value, extension_scalar_type,
                                         /*is_valid=*/false};
 
-  ASSERT_OK_AND_ASSIGN(
-      auto heap_map_scalar,
-      ScalarFromJSONString(map(utf8(), int32()), R"([["a", 5], ["b", 6]])"));
-  auto heap_map_scalar_null = MakeNullScalar(heap_map_scalar->type);
+  auto heap_map_scalar =
+      ScalarFromJSONString(map(utf8(), int32()), R"([["a", 5], ["b", 6]])");
+  auto heap_map_scalar_null = MakeNullScalar(heap_map_scalar.ValueOrDie()->type);
 
   // Array and ArrayData
   auto heap_null_array = SliceArrayFromJSON(null(), "[null, null]");
@@ -479,12 +478,10 @@ void TestSession() {
       key_value_metadata({"key1", "key2", "key3"}, {"value1", "value2", "value3"}));
 
   // Table
-  ASSERT_OK_AND_ASSIGN(auto col1,
-                       ChunkedArrayFromJSONString(int32(), {"[1, 2, 3]", "[4, 5]"}));
-  ASSERT_OK_AND_ASSIGN(
-      auto col2, ChunkedArrayFromJSONString(
-                     utf8(), {R"(["abc", null])", R"(["def"])", R"(["ghi", "jkl"])"}));
-  auto table = Table::Make(batch_schema, {col1, col2});
+  auto col1 = ChunkedArrayFromJSONString(int32(), {"[1, 2, 3]", "[4, 5]"});
+  auto col2 = ChunkedArrayFromJSONString(
+      utf8(), {R"(["abc", null])", R"(["def"])", R"(["ghi", "jkl"])"});
+  auto table = Table::Make(batch_schema, {*col1, *col2});
 
   // Datum
   Datum empty_datum{};


### PR DESCRIPTION
### Rationale for this change

https://github.com/apache/arrow/issues/45908 brought these helpers into the public API but didn't consider changes to their API. This PR makes all the helpers use the standard Result-pattern to make them more ergonomic. We can do this now without a breaking change because this and https://github.com/apache/arrow/issues/45908 will be part of Arrow 21.

### What changes are included in this PR?

- Refactored all FromJSONString helpers to use the Result pattern (instead of using outparams)

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #46439