### PR TITLE
GH-46699: [CI][Dev] fix shellcheck errors in the ci/scripts/cpp_test.sh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -268,6 +268,7 @@ repos:
           ?^ci/scripts/c_glib_build\.sh$|
           ?^ci/scripts/c_glib_test\.sh$|
           ?^ci/scripts/conan_setup\.sh$|
+          ?^ci/scripts/cpp_test\.sh$|
           ?^ci/scripts/csharp_build\.sh$|
           ?^ci/scripts/csharp_pack\.sh$|
           ?^ci/scripts/download_tz_database\.sh$|

--- a/ci/scripts/cpp_test.sh
+++ b/ci/scripts/cpp_test.sh
@@ -19,7 +19,7 @@
 
 set -ex
 
-if [[ $# < 2 ]]; then
+if [[ $# -lt 2 ]]; then
   echo "Usage: $0 <Arrow dir> <build dir> [ctest args ...]"
   exit 1
 fi
@@ -84,7 +84,7 @@ if [ "${ARROW_EMSCRIPTEN:-OFF}" = "ON" ]; then
   n_jobs=1 # avoid spurious fails on emscripten due to loading too many big executables
 fi
 
-pushd ${build_dir}
+pushd "${build_dir}"
 
 if [ -z "${PYTHON}" ] && ! which python > /dev/null 2>&1; then
   export PYTHON="${PYTHON:-python3}"
@@ -100,15 +100,15 @@ else
   ctest \
     --label-regex unittest \
     --output-on-failure \
-    --parallel ${n_jobs} \
+    --parallel "${n_jobs}" \
     --repeat until-pass:3 \
-    --timeout ${ARROW_CTEST_TIMEOUT:-300} \
+    --timeout "${ARROW_CTEST_TIMEOUT:-300}" \
     "${ctest_options[@]}" \
     "$@"
 fi
 
 if [ "${ARROW_BUILD_EXAMPLES}" == "ON" ]; then
-    examples=$(find ${binary_output_dir} -executable -name "*example")
+    examples=$(find "${binary_output_dir}" -executable -name "*example")
     if [ "${examples}" == "" ]; then
         echo "=================="
         echo "No examples found!"
@@ -126,12 +126,12 @@ fi
 
 if [ "${ARROW_FUZZING}" == "ON" ]; then
     # Fuzzing regression tests
-    ${binary_output_dir}/arrow-ipc-stream-fuzz ${ARROW_TEST_DATA}/arrow-ipc-stream/crash-*
-    ${binary_output_dir}/arrow-ipc-stream-fuzz ${ARROW_TEST_DATA}/arrow-ipc-stream/*-testcase-*
-    ${binary_output_dir}/arrow-ipc-file-fuzz ${ARROW_TEST_DATA}/arrow-ipc-file/*-testcase-*
-    ${binary_output_dir}/arrow-ipc-tensor-stream-fuzz ${ARROW_TEST_DATA}/arrow-ipc-tensor-stream/*-testcase-*
+    "${binary_output_dir}/arrow-ipc-stream-fuzz" "${ARROW_TEST_DATA}"/arrow-ipc-stream/crash-*
+    "${binary_output_dir}/arrow-ipc-stream-fuzz" "${ARROW_TEST_DATA}"/arrow-ipc-stream/*-testcase-*
+    "${binary_output_dir}/arrow-ipc-file-fuzz" "${ARROW_TEST_DATA}"/arrow-ipc-file/*-testcase-*
+    "${binary_output_dir}/arrow-ipc-tensor-stream-fuzz" "${ARROW_TEST_DATA}"/arrow-ipc-tensor-stream/*-testcase-*
     if [ "${ARROW_PARQUET}" == "ON" ]; then
-      ${binary_output_dir}/parquet-arrow-fuzz ${ARROW_TEST_DATA}/parquet/fuzzing/*-testcase-*
+      "${binary_output_dir}/parquet-arrow-fuzz" "${ARROW_TEST_DATA}"/parquet/fuzzing/*-testcase-*
     fi
 fi
 


### PR DESCRIPTION
### Rationale for this change

`ci/scripts/cpp_test.sh` violates two shellcheck rules.

* SC2071: `< is for string comparisons. Use -lt instead.`
* SC2086: `Double quote to prevent globbing and word splitting.`

```
./ci/scripts/cpp_test.sh

In ./ci/scripts/cpp_test.sh line 22:
if [[ $# < 2 ]]; then
         ^-- SC2071 (error): < is for string comparisons. Use -lt instead.


In ./ci/scripts/cpp_test.sh line 87:
pushd ${build_dir}
      ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
pushd "${build_dir}"


In ./ci/scripts/cpp_test.sh line 103:
    --parallel ${n_jobs} \
               ^-------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    --parallel "${n_jobs}" \


In ./ci/scripts/cpp_test.sh line 105:
    --timeout ${ARROW_CTEST_TIMEOUT:-300} \
              ^-------------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    --timeout "${ARROW_CTEST_TIMEOUT:-300}" \


In ./ci/scripts/cpp_test.sh line 111:
    examples=$(find ${binary_output_dir} -executable -name "*example")
                    ^------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    examples=$(find "${binary_output_dir}" -executable -name "*example")


In ./ci/scripts/cpp_test.sh line 129:
    ${binary_output_dir}/arrow-ipc-stream-fuzz ${ARROW_TEST_DATA}/arrow-ipc-stream/crash-*
    ^------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                               ^----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    "${binary_output_dir}"/arrow-ipc-stream-fuzz "${ARROW_TEST_DATA}"/arrow-ipc-stream/crash-*


In ./ci/scripts/cpp_test.sh line 130:
    ${binary_output_dir}/arrow-ipc-stream-fuzz ${ARROW_TEST_DATA}/arrow-ipc-stream/*-testcase-*
    ^------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                               ^----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    "${binary_output_dir}"/arrow-ipc-stream-fuzz "${ARROW_TEST_DATA}"/arrow-ipc-stream/*-testcase-*


In ./ci/scripts/cpp_test.sh line 131:
    ${binary_output_dir}/arrow-ipc-file-fuzz ${ARROW_TEST_DATA}/arrow-ipc-file/*-testcase-*
    ^------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                             ^----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    "${binary_output_dir}"/arrow-ipc-file-fuzz "${ARROW_TEST_DATA}"/arrow-ipc-file/*-testcase-*


In ./ci/scripts/cpp_test.sh line 132:
    ${binary_output_dir}/arrow-ipc-tensor-stream-fuzz ${ARROW_TEST_DATA}/arrow-ipc-tensor-stream/*-testcase-*
    ^------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                                      ^----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    "${binary_output_dir}"/arrow-ipc-tensor-stream-fuzz "${ARROW_TEST_DATA}"/arrow-ipc-tensor-stream/*-testcase-*


In ./ci/scripts/cpp_test.sh line 134:
      ${binary_output_dir}/parquet-arrow-fuzz ${ARROW_TEST_DATA}/parquet/fuzzing/*-testcase-*
      ^------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                              ^----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
      "${binary_output_dir}"/parquet-arrow-fuzz "${ARROW_TEST_DATA}"/parquet/fuzzing/*-testcase-*

For more information:
  https://www.shellcheck.net/wiki/SC2071 -- < is for string comparisons. Use ...
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
```

### What changes are included in this PR?

* Use `-lt` instead of `<`
* Quote variables.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #46699