### PR TITLE
GH-46691: [CI][Packaging] Update platform tag on generated wheel name to match newest auditwheel naming

### DIFF
--- a/ci/docker/python-wheel-manylinux.dockerfile
+++ b/ci/docker/python-wheel-manylinux.dockerfile
@@ -114,7 +114,9 @@ RUN --mount=type=secret,id=github_repository_owner \
       rm -rf ~/.config/NuGet/
 
 # Make sure auditwheel is up-to-date
-RUN pipx upgrade auditwheel
+# Force upgrade version to 6.4.0 or later to ensure platform tags order is correct
+# See https://github.com/apache/arrow/pull/46705
+RUN pipx upgrade auditwheel>=6.4.0
 
 # Configure Python for applications running in the bash shell of this Dockerfile
 ARG python=3.9

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -902,7 +902,8 @@ test_linux_wheels() {
       if ! VENV_ENV=wheel-${pyver}-${platform} PYTHON_VERSION=${pyver} maybe_setup_virtualenv; then
         continue
       fi
-      pip install pyarrow-${TEST_PYARROW_VERSION:-${VERSION}}-cp${pyver/.}-cp${python/.}-${platform}.whl
+      find . -name pyarrow-${TEST_PYARROW_VERSION:-${VERSION}}-cp${pyver/.}-cp${python/.}-*.whl | grep -E "${platform}" | \
+        xargs pip install
       ARROW_GCS=${check_gcs} \
         ARROW_VERSION=${VERSION} \
         CHECK_VERSION=${check_version} \

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -882,7 +882,7 @@ test_linux_wheels() {
   fi
 
   local python_versions="${TEST_PYTHON_VERSIONS:-3.9 3.10 3.11 3.12 3.13}"
-  local platform_tags="${TEST_WHEEL_PLATFORM_TAGS:-manylinux_2_17_${arch}.manylinux2014_${arch} manylinux_2_28_${arch}}"
+  local platform_tags="${TEST_WHEEL_PLATFORM_TAGS:-manylinux2014_${arch}.manylinux_2_17_${arch} manylinux_2_28_${arch}}"
 
   if [ "${SOURCE_KIND}" != "local" ]; then
     local wheel_content="OFF"
@@ -902,8 +902,7 @@ test_linux_wheels() {
       if ! VENV_ENV=wheel-${pyver}-${platform} PYTHON_VERSION=${pyver} maybe_setup_virtualenv; then
         continue
       fi
-      find . -name pyarrow-${TEST_PYARROW_VERSION:-${VERSION}}-cp${pyver/.}-cp${python/.}-*.whl | grep -E "${platform}" | \
-        xargs pip install
+      pip install pyarrow-${TEST_PYARROW_VERSION:-${VERSION}}-cp${pyver/.}-cp${python/.}-${platform}.whl
       ARROW_GCS=${check_gcs} \
         ARROW_VERSION=${VERSION} \
         CHECK_VERSION=${check_version} \

--- a/dev/tasks/python-wheels/github.linux.yml
+++ b/dev/tasks/python-wheels/github.linux.yml
@@ -101,7 +101,7 @@ jobs:
             -e TEST_DEFAULT=0 \
             -e TEST_PYARROW_VERSION={{ arrow.no_rc_version }} \
             -e TEST_PYTHON_VERSIONS={{ python_version }} \
-            -e TEST_WHEEL_PLATFORM_TAGS={{ wheel_platform_tag }} \
+            -e TEST_WHEEL_PLATFORM_TAGS="{{ wheel_platform_tag }}" \
             -e TEST_WHEELS=1 \
             almalinux-verify-rc
 
@@ -116,7 +116,7 @@ jobs:
             -e TEST_DEFAULT=0 \
             -e TEST_PYARROW_VERSION={{ arrow.no_rc_version }} \
             -e TEST_PYTHON_VERSIONS={{ python_version }} \
-            -e TEST_WHEEL_PLATFORM_TAGS={{ wheel_platform_tag }} \
+            -e TEST_WHEEL_PLATFORM_TAGS="{{ wheel_platform_tag }}"" \
             -e TEST_WHEELS=1 \
             ubuntu-verify-rc
 
@@ -131,7 +131,7 @@ jobs:
             -e TEST_DEFAULT=0 \
             -e TEST_PYARROW_VERSION={{ arrow.no_rc_version }} \
             -e TEST_PYTHON_VERSIONS={{ python_version }} \
-            -e TEST_WHEEL_PLATFORM_TAGS={{ wheel_platform_tag }} \
+            -e TEST_WHEEL_PLATFORM_TAGS="{{ wheel_platform_tag }}"" \
             -e TEST_WHEELS=1 \
             ubuntu-verify-rc
 

--- a/dev/tasks/python-wheels/github.linux.yml
+++ b/dev/tasks/python-wheels/github.linux.yml
@@ -116,7 +116,7 @@ jobs:
             -e TEST_DEFAULT=0 \
             -e TEST_PYARROW_VERSION={{ arrow.no_rc_version }} \
             -e TEST_PYTHON_VERSIONS={{ python_version }} \
-            -e TEST_WHEEL_PLATFORM_TAGS="{{ wheel_platform_tag }}"" \
+            -e TEST_WHEEL_PLATFORM_TAGS="{{ wheel_platform_tag }}" \
             -e TEST_WHEELS=1 \
             ubuntu-verify-rc
 
@@ -131,7 +131,7 @@ jobs:
             -e TEST_DEFAULT=0 \
             -e TEST_PYARROW_VERSION={{ arrow.no_rc_version }} \
             -e TEST_PYTHON_VERSIONS={{ python_version }} \
-            -e TEST_WHEEL_PLATFORM_TAGS="{{ wheel_platform_tag }}"" \
+            -e TEST_WHEEL_PLATFORM_TAGS="{{ wheel_platform_tag }}" \
             -e TEST_WHEELS=1 \
             ubuntu-verify-rc
 

--- a/dev/tasks/python-wheels/github.linux.yml
+++ b/dev/tasks/python-wheels/github.linux.yml
@@ -101,7 +101,7 @@ jobs:
             -e TEST_DEFAULT=0 \
             -e TEST_PYARROW_VERSION={{ arrow.no_rc_version }} \
             -e TEST_PYTHON_VERSIONS={{ python_version }} \
-            -e TEST_WHEEL_PLATFORM_TAGS="{{ wheel_platform_tag }}" \
+            -e TEST_WHEEL_PLATFORM_TAGS={{ wheel_platform_tag }} \
             -e TEST_WHEELS=1 \
             almalinux-verify-rc
 
@@ -116,7 +116,7 @@ jobs:
             -e TEST_DEFAULT=0 \
             -e TEST_PYARROW_VERSION={{ arrow.no_rc_version }} \
             -e TEST_PYTHON_VERSIONS={{ python_version }} \
-            -e TEST_WHEEL_PLATFORM_TAGS="{{ wheel_platform_tag }}" \
+            -e TEST_WHEEL_PLATFORM_TAGS={{ wheel_platform_tag }} \
             -e TEST_WHEELS=1 \
             ubuntu-verify-rc
 
@@ -131,7 +131,7 @@ jobs:
             -e TEST_DEFAULT=0 \
             -e TEST_PYARROW_VERSION={{ arrow.no_rc_version }} \
             -e TEST_PYTHON_VERSIONS={{ python_version }} \
-            -e TEST_WHEEL_PLATFORM_TAGS="{{ wheel_platform_tag }}" \
+            -e TEST_WHEEL_PLATFORM_TAGS={{ wheel_platform_tag }} \
             -e TEST_WHEELS=1 \
             ubuntu-verify-rc
 

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -223,9 +223,9 @@ tasks:
 
 {############################## Wheel Linux ##################################}
 
-{% for wheel_kind, arch, version, platform_tag in [("manylinux", "amd64", "2014", "manylinux(2014|_2_17)_x86_64.manylinux(2014|_2_17)_x86_64"),
+{% for wheel_kind, arch, version, platform_tag in [("manylinux", "amd64", "2014", "manylinux2014_x86_64.manylinux_2_17_x86_64"),
                                                    ("manylinux", "amd64", "2-28", "manylinux_2_28_x86_64"),
-                                                   ("manylinux", "arm64", "2014", "manylinux(2014|_2_17)_aarch64.manylinux(2014|_2_17)_aarch64"),
+                                                   ("manylinux", "arm64", "2014", "manylinux2014_aarch64.manylinux_2_17_aarch64"),
                                                    ("manylinux", "arm64", "2-28", "manylinux_2_28_aarch64"),
                                                    ("musllinux", "amd64", "1-2", "musllinux_1_2_x86_64"),
                                                    ("musllinux", "arm64", "1-2", "musllinux_1_2_aarch64")] %}

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -223,9 +223,9 @@ tasks:
 
 {############################## Wheel Linux ##################################}
 
-{% for wheel_kind, arch, version, platform_tag in [("manylinux", "amd64", "2014", "manylinux_2_17_x86_64.manylinux2014_x86_64"),
+{% for wheel_kind, arch, version, platform_tag in [("manylinux", "amd64", "2014", "manylinux2014_x86_64.manylinux_2_17_x86_64"),
                                                    ("manylinux", "amd64", "2-28", "manylinux_2_28_x86_64"),
-                                                   ("manylinux", "arm64", "2014", "manylinux_2_17_aarch64.manylinux2014_aarch64"),
+                                                   ("manylinux", "arm64", "2014", "manylinux2014_aarch64.manylinux_2_17_aarch64"),
                                                    ("manylinux", "arm64", "2-28", "manylinux_2_28_aarch64"),
                                                    ("musllinux", "amd64", "1-2", "musllinux_1_2_x86_64"),
                                                    ("musllinux", "arm64", "1-2", "musllinux_1_2_aarch64")] %}

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -223,9 +223,9 @@ tasks:
 
 {############################## Wheel Linux ##################################}
 
-{% for wheel_kind, arch, version, platform_tag in [("manylinux", "amd64", "2014", "manylinux2014_x86_64.manylinux_2_17_x86_64"),
+{% for wheel_kind, arch, version, platform_tag in [("manylinux", "amd64", "2014", "manylinux(2014|2_17)_x86_64.manylinux_(2014|2_17)_x86_64"),
                                                    ("manylinux", "amd64", "2-28", "manylinux_2_28_x86_64"),
-                                                   ("manylinux", "arm64", "2014", "manylinux2014_aarch64.manylinux_2_17_aarch64"),
+                                                   ("manylinux", "arm64", "2014", "manylinux(2014|2_17)_aarch64.manylinux_(2014|2_17)_aarch64"),
                                                    ("manylinux", "arm64", "2-28", "manylinux_2_28_aarch64"),
                                                    ("musllinux", "amd64", "1-2", "musllinux_1_2_x86_64"),
                                                    ("musllinux", "arm64", "1-2", "musllinux_1_2_aarch64")] %}

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -223,9 +223,9 @@ tasks:
 
 {############################## Wheel Linux ##################################}
 
-{% for wheel_kind, arch, version, platform_tag in [("manylinux", "amd64", "2014", "manylinux(2014|2_17)_x86_64.manylinux_(2014|2_17)_x86_64"),
+{% for wheel_kind, arch, version, platform_tag in [("manylinux", "amd64", "2014", "manylinux(2014|_2_17)_x86_64.manylinux(2014|_2_17)_x86_64"),
                                                    ("manylinux", "amd64", "2-28", "manylinux_2_28_x86_64"),
-                                                   ("manylinux", "arm64", "2014", "manylinux(2014|2_17)_aarch64.manylinux_(2014|2_17)_aarch64"),
+                                                   ("manylinux", "arm64", "2014", "manylinux(2014|_2_17)_aarch64.manylinux(2014|_2_17)_aarch64"),
                                                    ("manylinux", "arm64", "2-28", "manylinux_2_28_aarch64"),
                                                    ("musllinux", "amd64", "1-2", "musllinux_1_2_x86_64"),
                                                    ("musllinux", "arm64", "1-2", "musllinux_1_2_aarch64")] %}


### PR DESCRIPTION
### Rationale for this change

The new version of auditwheel has added improvements to detect libc / platform on the wheels:
- https://github.com/pypa/auditwheel/pull/548

This has updated the ordering of the platform tags for some of the generated wheels. For the case of our manylinux_2014 and libc 2.17 but only for Python 3.13 amd64 and 3.13t arm64. The rest are using the old order.

### What changes are included in this PR?

Force the newest version and update to new order of platform tags.

### Are these changes tested?

Via archery.

### Are there any user-facing changes?

No

* GitHub Issue: #46691