### PR TITLE
GH-46704: [C++] Fix OSS-Fuzz build failure

### DIFF
--- a/cpp/build-support/fuzzing/pack_corpus.py
+++ b/cpp/build-support/fuzzing/pack_corpus.py
@@ -27,7 +27,7 @@ import zipfile
 
 
 def process_dir(corpus_dir, zip_output):
-    seen = set()
+    seen_hashes = {}
 
     for child in corpus_dir.iterdir():
         if not child.is_file():
@@ -35,10 +35,12 @@ def process_dir(corpus_dir, zip_output):
         with child.open('rb') as f:
             data = f.read()
         arcname = hashlib.sha1(data).hexdigest()
-        if arcname in seen:
-            raise ValueError(f"Duplicate hash: {arcname} (in file {child})")
+        if arcname in seen_hashes:
+            raise ValueError(
+                f"Duplicate hash: {arcname} (in file {child}), "
+                f"already seen in file {seen_hashes[arcname]}")
         zip_output.writestr(str(arcname), data)
-        seen.add(arcname)
+        seen_hashes[arcname] = child
 
 
 def main(corpus_dir, zip_output_name):

--- a/cpp/src/arrow/ipc/test_common.cc
+++ b/cpp/src/arrow/ipc/test_common.cc
@@ -474,7 +474,7 @@ Status MakeListViewRecordBatchSized(const int length, std::shared_ptr<RecordBatc
 }
 
 Status MakeListViewRecordBatch(std::shared_ptr<RecordBatch>* out) {
-  return MakeListRecordBatchSized(200, out);
+  return MakeListViewRecordBatchSized(200, out);
 }
 
 Status MakeFixedSizeListRecordBatch(std::shared_ptr<RecordBatch>* out) {


### PR DESCRIPTION
### Rationale for this change

PR #46408 included a typo that changed list-view IPC tests to use the same data as list tests. This was detected as a duplicate corpus file by the OSS-Fuzz CI build.

### What changes are included in this PR?

Undo mistake that led to using the same test data for lists and list-views. Also fix a regression in the CUDA tests, due to reading non-CPU memory when fetching the first offset in a list/binary array.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.

* GitHub Issue: #46704