### PR TITLE
GH-46714: [C++] Use hidden symbol visibility in Meson configuration

### DIFF
--- a/cpp/src/arrow/acero/meson.build
+++ b/cpp/src/arrow/acero/meson.build
@@ -81,6 +81,7 @@ arrow_acero_lib = library(
     'arrow-acero',
     sources: arrow_acero_srcs,
     dependencies: [arrow_compute_dep, arrow_dep],
+    gnu_symbol_visibility: 'hidden',
 )
 
 arrow_acero_dep = declare_dependency(link_with: [arrow_acero_lib])

--- a/cpp/src/arrow/array/array_base.h
+++ b/cpp/src/arrow/array/array_base.h
@@ -265,9 +265,9 @@ class ARROW_EXPORT Array {
 
  private:
   ARROW_DISALLOW_COPY_AND_ASSIGN(Array);
-
-  ARROW_FRIEND_EXPORT friend void PrintTo(const Array& x, std::ostream* os);
 };
+
+ARROW_EXPORT void PrintTo(const Array& x, std::ostream* os);
 
 static inline std::ostream& operator<<(std::ostream& os, const Array& x) {
   os << x.ToString();

--- a/cpp/src/arrow/compute/expression.cc
+++ b/cpp/src/arrow/compute/expression.cc
@@ -219,7 +219,7 @@ void PrintTo(const Expression& expr, std::ostream* os) {
 }
 
 bool Expression::Equals(const Expression& other) const {
-  if (Identical(*this, other)) return true;
+  if (Expression::Identical(*this, other)) return true;
 
   if (impl_ == nullptr || other.impl_ == nullptr) return false;
 
@@ -260,7 +260,7 @@ bool Expression::Equals(const Expression& other) const {
   return false;
 }
 
-ARROW_EXPORT bool Identical(const Expression& l, const Expression& r) {
+bool Expression::Identical(const Expression& l, const Expression& r) {
   return l.impl_ == r.impl_;
 }
 
@@ -1454,7 +1454,7 @@ Result<Expression> SimplifyWithGuarantee(Expression expr,
                                   return inequality->Simplify(std::move(expr));
                                 }));
 
-      if (Identical(simplified, expr)) continue;
+      if (Expression::Identical(simplified, expr)) continue;
 
       expr = std::move(simplified);
       RETURN_NOT_OK(CanonicalizeAndFoldConstants());
@@ -1465,7 +1465,7 @@ Result<Expression> SimplifyWithGuarantee(Expression expr,
           auto simplified,
           SimplifyIsValidGuarantee(std::move(expr), *CallNotNull(guarantee)));
 
-      if (Identical(simplified, expr)) continue;
+      if (Expression::Identical(simplified, expr)) continue;
 
       expr = std::move(simplified);
       RETURN_NOT_OK(CanonicalizeAndFoldConstants());

--- a/cpp/src/arrow/compute/expression.cc
+++ b/cpp/src/arrow/compute/expression.cc
@@ -260,7 +260,9 @@ bool Expression::Equals(const Expression& other) const {
   return false;
 }
 
-bool Identical(const Expression& l, const Expression& r) { return l.impl_ == r.impl_; }
+ARROW_EXPORT bool Identical(const Expression& l, const Expression& r) {
+  return l.impl_ == r.impl_;
+}
 
 size_t Expression::hash() const {
   if (auto lit = literal()) {

--- a/cpp/src/arrow/compute/expression.h
+++ b/cpp/src/arrow/compute/expression.h
@@ -132,11 +132,11 @@ class ARROW_EXPORT Expression {
   explicit Expression(Datum literal);
   explicit Expression(Parameter parameter);
 
+  static bool Identical(const Expression& l, const Expression& r);
+
  private:
   using Impl = std::variant<Datum, Parameter, Call>;
   std::shared_ptr<Impl> impl_;
-
-  ARROW_FRIEND_EXPORT friend bool Identical(const Expression& l, const Expression& r);
 };
 
 inline bool operator==(const Expression& l, const Expression& r) { return l.Equals(r); }

--- a/cpp/src/arrow/compute/expression_test.cc
+++ b/cpp/src/arrow/compute/expression_test.cc
@@ -990,7 +990,7 @@ TEST(Expression, ExecuteDictionaryTransparent) {
 void ExpectIdenticalIfUnchanged(Expression modified, Expression original) {
   if (modified == original) {
     // no change -> must be identical
-    EXPECT_TRUE(Identical(modified, original)) << "  " << original.ToString();
+    EXPECT_TRUE(Expression::Identical(modified, original)) << "  " << original.ToString();
   }
 }
 

--- a/cpp/src/arrow/compute/kernels/ree_util_internal.h
+++ b/cpp/src/arrow/compute/kernels/ree_util_internal.h
@@ -27,6 +27,7 @@
 #include "arrow/array/data.h"
 #include "arrow/compute/exec.h"
 #include "arrow/compute/kernel.h"
+#include "arrow/compute/visibility.h"
 #include "arrow/result.h"
 #include "arrow/status.h"
 #include "arrow/type_traits.h"
@@ -346,7 +347,7 @@ Result<std::shared_ptr<ArrayData>> PreallocateRunEndsArray(
 /// \param has_validity_buffer a validity buffer must be allocated
 /// \param length the length of the values array
 /// \param data_buffer_size the size of the data buffer for string and binary types
-Result<std::shared_ptr<ArrayData>> PreallocateValuesArray(
+ARROW_COMPUTE_EXPORT Result<std::shared_ptr<ArrayData>> PreallocateValuesArray(
     const std::shared_ptr<DataType>& value_type, bool has_validity_buffer, int64_t length,
     MemoryPool* pool, int64_t data_buffer_size);
 
@@ -362,7 +363,7 @@ Result<std::shared_ptr<ArrayData>> PreallocateValuesArray(
 /// data.child_data[1].buffer[0] != NULLPTR
 ///
 /// \param data_buffer_size the size of the data buffer for string and binary types
-Result<std::shared_ptr<ArrayData>> PreallocateREEArray(
+ARROW_COMPUTE_EXPORT Result<std::shared_ptr<ArrayData>> PreallocateREEArray(
     std::shared_ptr<RunEndEncodedType> ree_type, bool has_validity_buffer,
     int64_t logical_length, int64_t physical_length, MemoryPool* pool,
     int64_t data_buffer_size);
@@ -377,7 +378,7 @@ Result<std::shared_ptr<ArrayData>> PreallocateREEArray(
 /// - run_ends fits in the run-end type without overflow
 void WriteSingleRunEnd(ArrayData* run_ends_data, int64_t run_end);
 
-Result<std::shared_ptr<ArrayData>> MakeNullREEArray(
+ARROW_COMPUTE_EXPORT Result<std::shared_ptr<ArrayData>> MakeNullREEArray(
     const std::shared_ptr<DataType>& run_end_type, int64_t logical_length,
     MemoryPool* pool);
 

--- a/cpp/src/arrow/compute/util.h
+++ b/cpp/src/arrow/compute/util.h
@@ -149,7 +149,7 @@ Result<Expression> ModifyExpression(Expression expr, const PreVisit& pre,
     ARROW_ASSIGN_OR_RAISE(auto modified_argument,
                           ModifyExpression(call->arguments[i], pre, post_call));
 
-    if (Identical(modified_argument, call->arguments[i])) {
+    if (Expression::Identical(modified_argument, call->arguments[i])) {
       continue;
     }
 

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -1354,7 +1354,7 @@ bool IsDfsEmulator(const AzureOptions& options) {
 
 namespace internal {
 
-Result<HNSSupport> CheckIfHierarchicalNamespaceIsEnabled(
+ARROW_EXPORT Result<HNSSupport> CheckIfHierarchicalNamespaceIsEnabled(
     const DataLake::DataLakeFileSystemClient& adlfs_client, const AzureOptions& options) {
   try {
     auto directory_client = adlfs_client.GetDirectoryClient("");

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -1354,7 +1354,7 @@ bool IsDfsEmulator(const AzureOptions& options) {
 
 namespace internal {
 
-ARROW_EXPORT Result<HNSSupport> CheckIfHierarchicalNamespaceIsEnabled(
+Result<HNSSupport> CheckIfHierarchicalNamespaceIsEnabled(
     const DataLake::DataLakeFileSystemClient& adlfs_client, const AzureOptions& options) {
   try {
     auto directory_client = adlfs_client.GetDirectoryClient("");

--- a/cpp/src/arrow/filesystem/azurefs_internal.h
+++ b/cpp/src/arrow/filesystem/azurefs_internal.h
@@ -70,7 +70,7 @@ enum class HierarchicalNamespaceSupport {
 /// account.
 /// \return kEnabled/kDisabled/kContainerNotFound (kUnknown is never
 /// returned).
-Result<HierarchicalNamespaceSupport> CheckIfHierarchicalNamespaceIsEnabled(
+ARROW_EXPORT Result<HierarchicalNamespaceSupport> CheckIfHierarchicalNamespaceIsEnabled(
     const Azure::Storage::Files::DataLake::DataLakeFileSystemClient& adlfs_client,
     const arrow::fs::AzureOptions& options);
 

--- a/cpp/src/arrow/filesystem/mockfs.cc
+++ b/cpp/src/arrow/filesystem/mockfs.cc
@@ -255,12 +255,12 @@ class MockFSInputStream : public io::BufferReader {
 
 }  // namespace
 
-std::ostream& operator<<(std::ostream& os, const MockDirInfo& di) {
+ARROW_EXPORT std::ostream& operator<<(std::ostream& os, const MockDirInfo& di) {
   return os << "'" << di.full_path << "' [mtime=" << di.mtime.time_since_epoch().count()
             << "]";
 }
 
-std::ostream& operator<<(std::ostream& os, const MockFileInfo& di) {
+ARROW_EXPORT std::ostream& operator<<(std::ostream& os, const MockFileInfo& di) {
   return os << "'" << di.full_path << "' [mtime=" << di.mtime.time_since_epoch().count()
             << ", size=" << di.data.length() << "]";
 }

--- a/cpp/src/arrow/meson.build
+++ b/cpp/src/arrow/meson.build
@@ -422,6 +422,7 @@ arrow_lib = library(
     include_directories: arrow_includes,
     dependencies: arrow_deps,
     install: true,
+    gnu_symbol_visibility: 'hidden',
 )
 
 arrow_dep = declare_dependency(

--- a/cpp/src/arrow/meson.build
+++ b/cpp/src/arrow/meson.build
@@ -423,6 +423,7 @@ arrow_lib = library(
     dependencies: arrow_deps,
     install: true,
     gnu_symbol_visibility: 'hidden',
+    cpp_shared_args: ['-DARROW_EXPORTING'],
 )
 
 arrow_dep = declare_dependency(
@@ -485,6 +486,7 @@ if needs_compute
         sources: arrow_compute_lib_sources,
         dependencies: arrow_dep,
         install: true,
+        cpp_shared_args: ['-DARROW_COMPUTE_EXPORTING'],
     )
     arrow_compute_dep = declare_dependency(
         link_with: arrow_compute_lib,

--- a/cpp/src/arrow/util/decimal.cc
+++ b/cpp/src/arrow/util/decimal.cc
@@ -1110,10 +1110,6 @@ Result<Decimal32> Decimal32::FromBigEndian(const uint8_t* bytes, int32_t length)
   return Decimal32(value);
 }
 
-Status Decimal32::ToArrowStatus(DecimalStatus dstatus) const {
-  return arrow::ToArrowStatus(dstatus, 32);
-}
-
 ARROW_EXPORT std::ostream& operator<<(std::ostream& os, const Decimal32& decimal) {
   os << decimal.ToIntegerString();
   return os;
@@ -1135,10 +1131,6 @@ Result<Decimal64> Decimal64::FromBigEndian(const uint8_t* bytes, int32_t length)
 
   const auto value = bit_util::FromBigEndian(result);
   return Decimal64(value);
-}
-
-Status Decimal64::ToArrowStatus(DecimalStatus dstatus) const {
-  return arrow::ToArrowStatus(dstatus, 64);
 }
 
 ARROW_EXPORT std::ostream& operator<<(std::ostream& os, const Decimal64& decimal) {
@@ -1197,10 +1189,6 @@ Result<Decimal128> Decimal128::FromBigEndian(const uint8_t* bytes, int32_t lengt
   }
 
   return Decimal128(high, static_cast<uint64_t>(low));
-}
-
-Status Decimal128::ToArrowStatus(DecimalStatus dstatus) const {
-  return arrow::ToArrowStatus(dstatus, 128);
 }
 
 ARROW_EXPORT std::ostream& operator<<(std::ostream& os, const Decimal128& decimal) {

--- a/cpp/src/arrow/util/decimal.cc
+++ b/cpp/src/arrow/util/decimal.cc
@@ -1110,7 +1110,11 @@ Result<Decimal32> Decimal32::FromBigEndian(const uint8_t* bytes, int32_t length)
   return Decimal32(value);
 }
 
-std::ostream& operator<<(std::ostream& os, const Decimal32& decimal) {
+Status Decimal32::ToArrowStatus(DecimalStatus dstatus) const {
+  return arrow::ToArrowStatus(dstatus, 32);
+}
+
+ARROW_EXPORT std::ostream& operator<<(std::ostream& os, const Decimal32& decimal) {
   os << decimal.ToIntegerString();
   return os;
 }
@@ -1133,7 +1137,11 @@ Result<Decimal64> Decimal64::FromBigEndian(const uint8_t* bytes, int32_t length)
   return Decimal64(value);
 }
 
-std::ostream& operator<<(std::ostream& os, const Decimal64& decimal) {
+Status Decimal64::ToArrowStatus(DecimalStatus dstatus) const {
+  return arrow::ToArrowStatus(dstatus, 64);
+}
+
+ARROW_EXPORT std::ostream& operator<<(std::ostream& os, const Decimal64& decimal) {
   os << decimal.ToIntegerString();
   return os;
 }
@@ -1191,7 +1199,11 @@ Result<Decimal128> Decimal128::FromBigEndian(const uint8_t* bytes, int32_t lengt
   return Decimal128(high, static_cast<uint64_t>(low));
 }
 
-std::ostream& operator<<(std::ostream& os, const Decimal128& decimal) {
+Status Decimal128::ToArrowStatus(DecimalStatus dstatus) const {
+  return arrow::ToArrowStatus(dstatus, 128);
+}
+
+ARROW_EXPORT std::ostream& operator<<(std::ostream& os, const Decimal128& decimal) {
   os << decimal.ToIntegerString();
   return os;
 }
@@ -1440,7 +1452,7 @@ double Decimal256::ToDouble(int32_t scale) const {
   return Decimal256RealConversion::ToReal<double>(*this, scale);
 }
 
-std::ostream& operator<<(std::ostream& os, const Decimal256& decimal) {
+ARROW_EXPORT std::ostream& operator<<(std::ostream& os, const Decimal256& decimal) {
   os << decimal.ToIntegerString();
   return os;
 }

--- a/cpp/src/arrow/util/float16.cc
+++ b/cpp/src/arrow/util/float16.cc
@@ -220,7 +220,9 @@ Float16 Float16::FromDouble(double d) {
   return FromBits(BinaryConverter<uint64_t>::ToBinary16(d_bits));
 }
 
-std::ostream& operator<<(std::ostream& os, Float16 arg) { return (os << arg.ToFloat()); }
+ARROW_EXPORT std::ostream& operator<<(std::ostream& os, Float16 arg) {
+  return (os << arg.ToFloat());
+}
 
 }  // namespace util
 }  // namespace arrow


### PR DESCRIPTION
### Rationale for this change

This will eventually make it easier to support Windows through the Meson configuration, while also providing the documented benefits of hidden symbol visibility

### What changes are included in this PR?

Meson libraries have been set to use hidden symbol visibility, and corresponding definitions have been updated to use the ARROW_EXPORT macro

### Are these changes tested?

Yes

### Are there any user-facing changes?

No
* GitHub Issue: #46714