### PR TITLE
GH-46717: [R][Docs] Add missing "internal" keywords for internal function

### DIFF
--- a/r/R/dplyr-funcs-agg.R
+++ b/r/R/dplyr-funcs-agg.R
@@ -204,6 +204,7 @@ find_arrow_mask <- function() {
 #'   group_by(cyl) |>
 #'   summarize(x = one(disp))
 #' }
+#' @keywords internal
 one <- function(...) {
   set_agg(
     fun = "one",

--- a/r/man/one.Rd
+++ b/r/man/one.Rd
@@ -10,10 +10,10 @@ one(...)
 \item{...}{Unquoted column name to pull values from.}
 }
 \description{
-Returns one arbitrary value from the input for each group. The
-function is biased towards non-null values: if there is at least one non-null
-value for a certain group, that value is returned, and only if all the values
-are null for the group will the function return null.
+Returns one arbitrary value from the input for each group. The function is
+biased towards non-null values: if there is at least one non-null value for a
+certain group, that value is returned, and only if all the values are null
+for the group will the function return null.
 }
 \examples{
 \dontrun{
@@ -23,3 +23,4 @@ mtcars |>
   summarize(x = one(disp))
 }
 }
+\keyword{internal}


### PR DESCRIPTION
### Rationale for this change

pkgdown generation was failing due to a function not being included in the list of functions to document

### What changes are included in this PR?

Update roxygen header to not generate that function or trigger the pkgdown check

### Are these changes tested?

Nah, but I'll trigger CI to check

### Are there any user-facing changes?

No
* GitHub Issue: #46717