### PR TITLE
GH-46726: [CI][Dev] fix shellcheck errors in the ci/scripts/conan_build.sh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -299,7 +299,6 @@ repos:
           ?^c_glib/test/run-test\.sh$|
           ?^ci/scripts/c_glib_build\.sh$|
           ?^ci/scripts/c_glib_test\.sh$|
-          ?^ci/scripts/conan_build\.sh$|
           ?^ci/scripts/conan_setup\.sh$|
           ?^ci/scripts/cpp_test\.sh$|
           ?^ci/scripts/csharp_build\.sh$|

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -299,6 +299,7 @@ repos:
           ?^c_glib/test/run-test\.sh$|
           ?^ci/scripts/c_glib_build\.sh$|
           ?^ci/scripts/c_glib_test\.sh$|
+          ?^ci/scripts/conan_build\.sh$|
           ?^ci/scripts/conan_setup\.sh$|
           ?^ci/scripts/cpp_test\.sh$|
           ?^ci/scripts/csharp_build\.sh$|

--- a/ci/scripts/conan_build.sh
+++ b/ci/scripts/conan_build.sh
@@ -37,48 +37,48 @@ else
   conan_args+=(--options arrow/*:parquet=False)
 fi
 if [ -n "${ARROW_CONAN_WITH_BROTLI:-}" ]; then
-  conan_args+=(--options "arrow/*:with_brotli=${ARROW_CONAN_WITH_BROTLI}")
+  conan_args+=(--options arrow/*:with_brotli=${ARROW_CONAN_WITH_BROTLI})
 fi
 if [ -n "${ARROW_CONAN_WITH_BZ2:-}" ]; then
-  conan_args+=(--options "arrow/*:with_bz2=${ARROW_CONAN_WITH_BZ2}")
+  conan_args+=(--options arrow/*:with_bz2=${ARROW_CONAN_WITH_BZ2})
 fi
 if [ -n "${ARROW_CONAN_WITH_FLIGHT_RPC:-}" ]; then
-  conan_args+=(--options "arrow/*:with_flight_rpc=${ARROW_CONAN_WITH_FLIGHT_RPC}")
-  conan_args+=(--options "arrow/*:with_grpc=${ARROW_CONAN_WITH_FLIGHT_RPC}")
-  conan_args+=(--options "arrow/*:with_protobuf=${ARROW_CONAN_WITH_FLIGHT_RPC}")
-  conan_args+=(--options "arrow/*:with_re2=${ARROW_CONAN_WITH_FLIGHT_RPC}")
+  conan_args+=(--options arrow/*:with_flight_rpc=${ARROW_CONAN_WITH_FLIGHT_RPC})
+  conan_args+=(--options arrow/*:with_grpc=${ARROW_CONAN_WITH_FLIGHT_RPC})
+  conan_args+=(--options arrow/*:with_protobuf=${ARROW_CONAN_WITH_FLIGHT_RPC})
+  conan_args+=(--options arrow/*:with_re2=${ARROW_CONAN_WITH_FLIGHT_RPC})
 fi
 if [ -n "${ARROW_CONAN_WITH_GLOG:-}" ]; then
-  conan_args+=(--options "arrow/*:with_glog=${ARROW_CONAN_WITH_GLOG}")
+  conan_args+=(--options arrow/*:with_glog=${ARROW_CONAN_WITH_GLOG})
 fi
 if [ -n "${ARROW_CONAN_WITH_JEMALLOC:-}" ]; then
-  conan_args+=(--options "arrow/*:with_jemalloc=${ARROW_CONAN_WITH_JEMALLOC}")
+  conan_args+=(--options arrow/*:with_jemalloc=${ARROW_CONAN_WITH_JEMALLOC})
 fi
 if [ -n "${ARROW_CONAN_WITH_JSON:-}" ]; then
-  conan_args+=(--options "arrow/*:with_json=${ARROW_CONAN_WITH_JSON}")
+  conan_args+=(--options arrow/*:with_json=${ARROW_CONAN_WITH_JSON})
 fi
 if [ -n "${ARROW_CONAN_WITH_LZ4:-}" ]; then
-  conan_args+=(--options "arrow/*:with_lz4=${ARROW_CONAN_WITH_LZ4}")
+  conan_args+=(--options arrow/*:with_lz4=${ARROW_CONAN_WITH_LZ4})
 fi
 if [ -n "${ARROW_CONAN_WITH_SNAPPY:-}" ]; then
-  conan_args+=(--options "arrow/*:with_snappy=${ARROW_CONAN_WITH_SNAPPY}")
+  conan_args+=(--options arrow/*:with_snappy=${ARROW_CONAN_WITH_SNAPPY})
 fi
 if [ -n "${ARROW_CONAN_WITH_ZSTD:-}" ]; then
-  conan_args+=(--options "arrow/*:with_zstd=${ARROW_CONAN_WITH_ZSTD}")
+  conan_args+=(--options arrow/*:with_zstd=${ARROW_CONAN_WITH_ZSTD})
 fi
 
-version=$(grep '^set(ARROW_VERSION ' "${ARROW_HOME}/cpp/CMakeLists.txt" | \
+version=$(grep '^set(ARROW_VERSION ' ${ARROW_HOME}/cpp/CMakeLists.txt | \
             grep -E -o '([0-9.]*)')
-conan_args+=(--version "${version}")
+conan_args+=(--version ${version})
 
 rm -rf ~/.conan/data/arrow/
-rm -rf "${build_dir}/conan" || sudo rm -rf "${build_dir}/conan"
-mkdir -p "${build_dir}/conan" || sudo mkdir -p "${build_dir}/conan"
-if [ -w "${build_dir}" ]; then
-  cp -a "${source_dir}"/ci/conan/* "${build_dir}/conan/"
+rm -rf ${build_dir}/conan || sudo rm -rf ${build_dir}/conan
+mkdir -p ${build_dir}/conan || sudo mkdir -p ${build_dir}/conan
+if [ -w ${build_dir} ]; then
+  cp -a ${source_dir}/ci/conan/* ${build_dir}/conan/
 else
-  sudo cp -a "${source_dir}"/ci/conan/* "${build_dir}/conan/"
-  sudo chown -R "$(id -u):$(id -g)" "${build_dir}/conan/"
+  sudo cp -a ${source_dir}/ci/conan/* ${build_dir}/conan/
+  sudo chown -R $(id -u):$(id -g) ${build_dir}/conan/
 fi
-cd "${build_dir}/conan/all"
+cd ${build_dir}/conan/all
 conan create . "${conan_args[@]}" "$@"

--- a/ci/scripts/conan_build.sh
+++ b/ci/scripts/conan_build.sh
@@ -30,16 +30,11 @@ conan_args=()
 conan_args+=(--build=missing)
 if [ -n "${ARROW_CONAN_PARQUET:-}" ]; then
   conan_args+=(--options "arrow/*:parquet=${ARROW_CONAN_PARQUET}")
-<<<<<<< HEAD
   conan_args+=(--options "arrow/*:with_boost=${ARROW_CONAN_PARQUET}")
   conan_args+=(--options "arrow/*:with_json=${ARROW_CONAN_PARQUET}")
   conan_args+=(--options "arrow/*:with_thrift=${ARROW_CONAN_PARQUET}")
 else
   conan_args+=(--options arrow/*:parquet=False)
-=======
-  conan_args+=(--options "arrow/*:with_thrift=${ARROW_CONAN_PARQUET}")
-  conan_args+=(--options "arrow/*:with_boost=${ARROW_CONAN_PARQUET}")
->>>>>>> 7bd880b934 (Reapply "GH-46726: [CI][Dev] fix shellcheck errors in the ci/scripts/conan_build.sh")
 fi
 if [ -n "${ARROW_CONAN_WITH_BROTLI:-}" ]; then
   conan_args+=(--options "arrow/*:with_brotli=${ARROW_CONAN_WITH_BROTLI}")

--- a/ci/scripts/conan_build.sh
+++ b/ci/scripts/conan_build.sh
@@ -37,34 +37,34 @@ else
   conan_args+=(--options arrow/*:parquet=False)
 fi
 if [ -n "${ARROW_CONAN_WITH_BROTLI:-}" ]; then
-  conan_args+=(--options arrow/*:with_brotli="${ARROW_CONAN_WITH_BROTLI}")
+  conan_args+=(--options "arrow/*:with_brotli=${ARROW_CONAN_WITH_BROTLI}")
 fi
 if [ -n "${ARROW_CONAN_WITH_BZ2:-}" ]; then
   conan_args+=(--options arrow/*:with_bz2="${ARROW_CONAN_WITH_BZ2}")
 fi
 if [ -n "${ARROW_CONAN_WITH_FLIGHT_RPC:-}" ]; then
-  conan_args+=(--options arrow/*:with_flight_rpc="${ARROW_CONAN_WITH_FLIGHT_RPC}")
-  conan_args+=(--options arrow/*:with_grpc="${ARROW_CONAN_WITH_FLIGHT_RPC}")
-  conan_args+=(--options arrow/*:with_protobuf="${ARROW_CONAN_WITH_FLIGHT_RPC}")
-  conan_args+=(--options arrow/*:with_re2="${ARROW_CONAN_WITH_FLIGHT_RPC}")
+  conan_args+=(--options "arrow/*:with_flight_rpc=${ARROW_CONAN_WITH_FLIGHT_RPC}")
+  conan_args+=(--options "arrow/*:with_grpc=${ARROW_CONAN_WITH_FLIGHT_RPC}")
+  conan_args+=(--options "arrow/*:with_protobuf=${ARROW_CONAN_WITH_FLIGHT_RPC}")
+  conan_args+=(--options "arrow/*:with_re2=${ARROW_CONAN_WITH_FLIGHT_RPC}")
 fi
 if [ -n "${ARROW_CONAN_WITH_GLOG:-}" ]; then
-  conan_args+=(--options arrow/*:with_glog="${ARROW_CONAN_WITH_GLOG}")
+  conan_args+=(--options "arrow/*:with_glog=${ARROW_CONAN_WITH_GLOG}")
 fi
 if [ -n "${ARROW_CONAN_WITH_JEMALLOC:-}" ]; then
-  conan_args+=(--options arrow/*:with_jemalloc="${ARROW_CONAN_WITH_JEMALLOC}")
+  conan_args+=(--options "arrow/*:with_jemalloc=${ARROW_CONAN_WITH_JEMALLOC}")
 fi
 if [ -n "${ARROW_CONAN_WITH_JSON:-}" ]; then
-  conan_args+=(--options arrow/*:with_json="${ARROW_CONAN_WITH_JSON}")
+  conan_args+=(--options "arrow/*:with_json=${ARROW_CONAN_WITH_JSON}")
 fi
 if [ -n "${ARROW_CONAN_WITH_LZ4:-}" ]; then
-  conan_args+=(--options arrow/*:with_lz4="${ARROW_CONAN_WITH_LZ4}")
+  conan_args+=(--options "arrow/*:with_lz4=${ARROW_CONAN_WITH_LZ4}")
 fi
 if [ -n "${ARROW_CONAN_WITH_SNAPPY:-}" ]; then
-  conan_args+=(--options arrow/*:with_snappy="${ARROW_CONAN_WITH_SNAPPY}")
+  conan_args+=(--options "arrow/*:with_snappy=${ARROW_CONAN_WITH_SNAPPY}")
 fi
 if [ -n "${ARROW_CONAN_WITH_ZSTD:-}" ]; then
-  conan_args+=(--options arrow/*:with_zstd="${ARROW_CONAN_WITH_ZSTD}")
+  conan_args+=(--options "arrow/*:with_zstd=${ARROW_CONAN_WITH_ZSTD}")
 fi
 
 version=$(grep '^set(ARROW_VERSION ' "${ARROW_HOME}/cpp/CMakeLists.txt" | \
@@ -78,7 +78,7 @@ if [ -w "${build_dir}" ]; then
   cp -a "${source_dir}"/ci/conan/* "${build_dir}/conan/"
 else
   sudo cp -a "${source_dir}"/ci/conan/* "${build_dir}/conan/"
-  sudo chown -R "$(id -u)":"$(id -g)" "${build_dir}/conan/"
+  sudo chown -R "$(id -u):$(id -g)" "${build_dir}/conan/"
 fi
 cd "${build_dir}/conan/all"
 conan create . "${conan_args[@]}" "$@"

--- a/ci/scripts/conan_build.sh
+++ b/ci/scripts/conan_build.sh
@@ -29,56 +29,56 @@ export ARROW_HOME=${source_dir}
 conan_args=()
 conan_args+=(--build=missing)
 if [ -n "${ARROW_CONAN_PARQUET:-}" ]; then
-  conan_args+=(--options arrow/*:parquet=${ARROW_CONAN_PARQUET})
-  conan_args+=(--options arrow/*:with_boost=${ARROW_CONAN_PARQUET})
-  conan_args+=(--options arrow/*:with_json=${ARROW_CONAN_PARQUET})
-  conan_args+=(--options arrow/*:with_thrift=${ARROW_CONAN_PARQUET})
+  conan_args+=(--options "arrow/*:parquet=${ARROW_CONAN_PARQUET}")
+  conan_args+=(--options "arrow/*:with_boost=${ARROW_CONAN_PARQUET}")
+  conan_args+=(--options "arrow/*:with_json=${ARROW_CONAN_PARQUET}")
+  conan_args+=(--options "arrow/*:with_thrift=${ARROW_CONAN_PARQUET}")
 else
   conan_args+=(--options arrow/*:parquet=False)
 fi
 if [ -n "${ARROW_CONAN_WITH_BROTLI:-}" ]; then
-  conan_args+=(--options arrow/*:with_brotli=${ARROW_CONAN_WITH_BROTLI})
+  conan_args+=(--options arrow/*:with_brotli="${ARROW_CONAN_WITH_BROTLI}")
 fi
 if [ -n "${ARROW_CONAN_WITH_BZ2:-}" ]; then
-  conan_args+=(--options arrow/*:with_bz2=${ARROW_CONAN_WITH_BZ2})
+  conan_args+=(--options arrow/*:with_bz2="${ARROW_CONAN_WITH_BZ2}")
 fi
 if [ -n "${ARROW_CONAN_WITH_FLIGHT_RPC:-}" ]; then
-  conan_args+=(--options arrow/*:with_flight_rpc=${ARROW_CONAN_WITH_FLIGHT_RPC})
-  conan_args+=(--options arrow/*:with_grpc=${ARROW_CONAN_WITH_FLIGHT_RPC})
-  conan_args+=(--options arrow/*:with_protobuf=${ARROW_CONAN_WITH_FLIGHT_RPC})
-  conan_args+=(--options arrow/*:with_re2=${ARROW_CONAN_WITH_FLIGHT_RPC})
+  conan_args+=(--options arrow/*:with_flight_rpc="${ARROW_CONAN_WITH_FLIGHT_RPC}")
+  conan_args+=(--options arrow/*:with_grpc="${ARROW_CONAN_WITH_FLIGHT_RPC}")
+  conan_args+=(--options arrow/*:with_protobuf="${ARROW_CONAN_WITH_FLIGHT_RPC}")
+  conan_args+=(--options arrow/*:with_re2="${ARROW_CONAN_WITH_FLIGHT_RPC}")
 fi
 if [ -n "${ARROW_CONAN_WITH_GLOG:-}" ]; then
-  conan_args+=(--options arrow/*:with_glog=${ARROW_CONAN_WITH_GLOG})
+  conan_args+=(--options arrow/*:with_glog="${ARROW_CONAN_WITH_GLOG}")
 fi
 if [ -n "${ARROW_CONAN_WITH_JEMALLOC:-}" ]; then
-  conan_args+=(--options arrow/*:with_jemalloc=${ARROW_CONAN_WITH_JEMALLOC})
+  conan_args+=(--options arrow/*:with_jemalloc="${ARROW_CONAN_WITH_JEMALLOC}")
 fi
 if [ -n "${ARROW_CONAN_WITH_JSON:-}" ]; then
-  conan_args+=(--options arrow/*:with_json=${ARROW_CONAN_WITH_JSON})
+  conan_args+=(--options arrow/*:with_json="${ARROW_CONAN_WITH_JSON}")
 fi
 if [ -n "${ARROW_CONAN_WITH_LZ4:-}" ]; then
-  conan_args+=(--options arrow/*:with_lz4=${ARROW_CONAN_WITH_LZ4})
+  conan_args+=(--options arrow/*:with_lz4="${ARROW_CONAN_WITH_LZ4}")
 fi
 if [ -n "${ARROW_CONAN_WITH_SNAPPY:-}" ]; then
-  conan_args+=(--options arrow/*:with_snappy=${ARROW_CONAN_WITH_SNAPPY})
+  conan_args+=(--options arrow/*:with_snappy="${ARROW_CONAN_WITH_SNAPPY}")
 fi
 if [ -n "${ARROW_CONAN_WITH_ZSTD:-}" ]; then
-  conan_args+=(--options arrow/*:with_zstd=${ARROW_CONAN_WITH_ZSTD})
+  conan_args+=(--options arrow/*:with_zstd="${ARROW_CONAN_WITH_ZSTD}")
 fi
 
-version=$(grep '^set(ARROW_VERSION ' ${ARROW_HOME}/cpp/CMakeLists.txt | \
+version=$(grep '^set(ARROW_VERSION ' "${ARROW_HOME}/cpp/CMakeLists.txt" | \
             grep -E -o '([0-9.]*)')
-conan_args+=(--version ${version})
+conan_args+=(--version "${version}")
 
 rm -rf ~/.conan/data/arrow/
-rm -rf ${build_dir}/conan || sudo rm -rf ${build_dir}/conan
-mkdir -p ${build_dir}/conan || sudo mkdir -p ${build_dir}/conan
-if [ -w ${build_dir} ]; then
-  cp -a ${source_dir}/ci/conan/* ${build_dir}/conan/
+rm -rf "${build_dir}/conan" || sudo rm -rf "${build_dir}/conan"
+mkdir -p "${build_dir}/conan" || sudo mkdir -p "${build_dir}/conan"
+if [ -w "${build_dir}" ]; then
+  cp -a "${source_dir}"/ci/conan/* "${build_dir}/conan/"
 else
-  sudo cp -a ${source_dir}/ci/conan/* ${build_dir}/conan/
-  sudo chown -R $(id -u):$(id -g) ${build_dir}/conan/
+  sudo cp -a "${source_dir}"/ci/conan/* "${build_dir}/conan/"
+  sudo chown -R "$(id -u)":"$(id -g)" "${build_dir}/conan/"
 fi
-cd ${build_dir}/conan/all
+cd "${build_dir}/conan/all"
 conan create . "${conan_args[@]}" "$@"

--- a/ci/scripts/conan_build.sh
+++ b/ci/scripts/conan_build.sh
@@ -34,7 +34,7 @@ if [ -n "${ARROW_CONAN_PARQUET:-}" ]; then
   conan_args+=(--options "arrow/*:with_json=${ARROW_CONAN_PARQUET}")
   conan_args+=(--options "arrow/*:with_thrift=${ARROW_CONAN_PARQUET}")
 else
-  conan_args+=(--options arrow/*:parquet=False)
+  conan_args+=(--options "arrow/*:parquet=False")
 fi
 if [ -n "${ARROW_CONAN_WITH_BROTLI:-}" ]; then
   conan_args+=(--options "arrow/*:with_brotli=${ARROW_CONAN_WITH_BROTLI}")

--- a/ci/scripts/conan_build.sh
+++ b/ci/scripts/conan_build.sh
@@ -40,7 +40,7 @@ if [ -n "${ARROW_CONAN_WITH_BROTLI:-}" ]; then
   conan_args+=(--options "arrow/*:with_brotli=${ARROW_CONAN_WITH_BROTLI}")
 fi
 if [ -n "${ARROW_CONAN_WITH_BZ2:-}" ]; then
-  conan_args+=(--options arrow/*:with_bz2="${ARROW_CONAN_WITH_BZ2}")
+  conan_args+=(--options "arrow/*:with_bz2=${ARROW_CONAN_WITH_BZ2}")
 fi
 if [ -n "${ARROW_CONAN_WITH_FLIGHT_RPC:-}" ]; then
   conan_args+=(--options "arrow/*:with_flight_rpc=${ARROW_CONAN_WITH_FLIGHT_RPC}")

--- a/ci/scripts/conan_build.sh
+++ b/ci/scripts/conan_build.sh
@@ -30,55 +30,60 @@ conan_args=()
 conan_args+=(--build=missing)
 if [ -n "${ARROW_CONAN_PARQUET:-}" ]; then
   conan_args+=(--options "arrow/*:parquet=${ARROW_CONAN_PARQUET}")
+<<<<<<< HEAD
   conan_args+=(--options "arrow/*:with_boost=${ARROW_CONAN_PARQUET}")
   conan_args+=(--options "arrow/*:with_json=${ARROW_CONAN_PARQUET}")
   conan_args+=(--options "arrow/*:with_thrift=${ARROW_CONAN_PARQUET}")
 else
   conan_args+=(--options arrow/*:parquet=False)
+=======
+  conan_args+=(--options "arrow/*:with_thrift=${ARROW_CONAN_PARQUET}")
+  conan_args+=(--options "arrow/*:with_boost=${ARROW_CONAN_PARQUET}")
+>>>>>>> 7bd880b934 (Reapply "GH-46726: [CI][Dev] fix shellcheck errors in the ci/scripts/conan_build.sh")
 fi
 if [ -n "${ARROW_CONAN_WITH_BROTLI:-}" ]; then
-  conan_args+=(--options arrow/*:with_brotli=${ARROW_CONAN_WITH_BROTLI})
+  conan_args+=(--options "arrow/*:with_brotli=${ARROW_CONAN_WITH_BROTLI}")
 fi
 if [ -n "${ARROW_CONAN_WITH_BZ2:-}" ]; then
-  conan_args+=(--options arrow/*:with_bz2=${ARROW_CONAN_WITH_BZ2})
+  conan_args+=(--options "arrow/*:with_bz2=${ARROW_CONAN_WITH_BZ2}")
 fi
 if [ -n "${ARROW_CONAN_WITH_FLIGHT_RPC:-}" ]; then
-  conan_args+=(--options arrow/*:with_flight_rpc=${ARROW_CONAN_WITH_FLIGHT_RPC})
-  conan_args+=(--options arrow/*:with_grpc=${ARROW_CONAN_WITH_FLIGHT_RPC})
-  conan_args+=(--options arrow/*:with_protobuf=${ARROW_CONAN_WITH_FLIGHT_RPC})
-  conan_args+=(--options arrow/*:with_re2=${ARROW_CONAN_WITH_FLIGHT_RPC})
+  conan_args+=(--options "arrow/*:with_flight_rpc=${ARROW_CONAN_WITH_FLIGHT_RPC}")
+  conan_args+=(--options "arrow/*:with_grpc=${ARROW_CONAN_WITH_FLIGHT_RPC}")
+  conan_args+=(--options "arrow/*:with_protobuf=${ARROW_CONAN_WITH_FLIGHT_RPC}")
+  conan_args+=(--options "arrow/*:with_re2=${ARROW_CONAN_WITH_FLIGHT_RPC}")
 fi
 if [ -n "${ARROW_CONAN_WITH_GLOG:-}" ]; then
-  conan_args+=(--options arrow/*:with_glog=${ARROW_CONAN_WITH_GLOG})
+  conan_args+=(--options "arrow/*:with_glog=${ARROW_CONAN_WITH_GLOG}")
 fi
 if [ -n "${ARROW_CONAN_WITH_JEMALLOC:-}" ]; then
-  conan_args+=(--options arrow/*:with_jemalloc=${ARROW_CONAN_WITH_JEMALLOC})
+  conan_args+=(--options "arrow/*:with_jemalloc=${ARROW_CONAN_WITH_JEMALLOC}")
 fi
 if [ -n "${ARROW_CONAN_WITH_JSON:-}" ]; then
-  conan_args+=(--options arrow/*:with_json=${ARROW_CONAN_WITH_JSON})
+  conan_args+=(--options "arrow/*:with_json=${ARROW_CONAN_WITH_JSON}")
 fi
 if [ -n "${ARROW_CONAN_WITH_LZ4:-}" ]; then
-  conan_args+=(--options arrow/*:with_lz4=${ARROW_CONAN_WITH_LZ4})
+  conan_args+=(--options "arrow/*:with_lz4=${ARROW_CONAN_WITH_LZ4}")
 fi
 if [ -n "${ARROW_CONAN_WITH_SNAPPY:-}" ]; then
-  conan_args+=(--options arrow/*:with_snappy=${ARROW_CONAN_WITH_SNAPPY})
+  conan_args+=(--options "arrow/*:with_snappy=${ARROW_CONAN_WITH_SNAPPY}")
 fi
 if [ -n "${ARROW_CONAN_WITH_ZSTD:-}" ]; then
-  conan_args+=(--options arrow/*:with_zstd=${ARROW_CONAN_WITH_ZSTD})
+  conan_args+=(--options "arrow/*:with_zstd=${ARROW_CONAN_WITH_ZSTD}")
 fi
 
-version=$(grep '^set(ARROW_VERSION ' ${ARROW_HOME}/cpp/CMakeLists.txt | \
+version=$(grep '^set(ARROW_VERSION ' "${ARROW_HOME}/cpp/CMakeLists.txt" | \
             grep -E -o '([0-9.]*)')
-conan_args+=(--version ${version})
+conan_args+=(--version "${version}")
 
 rm -rf ~/.conan/data/arrow/
-rm -rf ${build_dir}/conan || sudo rm -rf ${build_dir}/conan
-mkdir -p ${build_dir}/conan || sudo mkdir -p ${build_dir}/conan
-if [ -w ${build_dir} ]; then
-  cp -a ${source_dir}/ci/conan/* ${build_dir}/conan/
+rm -rf "${build_dir}/conan" || sudo rm -rf "${build_dir}/conan"
+mkdir -p "${build_dir}/conan" || sudo mkdir -p "${build_dir}/conan"
+if [ -w "${build_dir}" ]; then
+  cp -a "${source_dir}"/ci/conan/* "${build_dir}/conan/"
 else
-  sudo cp -a ${source_dir}/ci/conan/* ${build_dir}/conan/
-  sudo chown -R $(id -u):$(id -g) ${build_dir}/conan/
+  sudo cp -a "${source_dir}"/ci/conan/* "${build_dir}/conan/"
+  sudo chown -R "$(id -u):$(id -g)" "${build_dir}/conan/"
 fi
-cd ${build_dir}/conan/all
+cd "${build_dir}/conan/all"
 conan create . "${conan_args[@]}" "$@"


### PR DESCRIPTION
### Rationale for this change

This is the sub issue #44748.

  * SC2046 -- Quote this to prevent word splitt...
  * SC2206 -- Quote to prevent word splitting/g...
  * SC2086 -- Double quote to prevent globbing ...

```
In ci/scripts/conan_build.sh line 32:
  conan_args+=(--options arrow/*:parquet=${ARROW_CONAN_PARQUET})
                                         ^--------------------^ SC2206 (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.


In ci/scripts/conan_build.sh line 33:
  conan_args+=(--options arrow/*:with_thrift=${ARROW_CONAN_PARQUET})
                                             ^--------------------^ SC2206 (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.


In ci/scripts/conan_build.sh line 34:
  conan_args+=(--options arrow/*:with_boost=${ARROW_CONAN_PARQUET})
                                            ^--------------------^ SC2206 (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.


In ci/scripts/conan_build.sh line 37:
  conan_args+=(--options arrow/*:with_brotli=${ARROW_CONAN_WITH_BROTLI})
                                             ^------------------------^ SC2206 (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.


In ci/scripts/conan_build.sh line 40:
  conan_args+=(--options arrow/*:with_bz2=${ARROW_CONAN_WITH_BZ2})
                                          ^---------------------^ SC2206 (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.


In ci/scripts/conan_build.sh line 43:
  conan_args+=(--options arrow/*:with_flight_rpc=${ARROW_CONAN_WITH_FLIGHT_RPC})
                                                 ^----------------------------^ SC2206 (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.


In ci/scripts/conan_build.sh line 44:
  conan_args+=(--options arrow/*:with_grpc=${ARROW_CONAN_WITH_FLIGHT_RPC})
                                           ^----------------------------^ SC2206 (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.


In ci/scripts/conan_build.sh line 45:
  conan_args+=(--options arrow/*:with_protobuf=${ARROW_CONAN_WITH_FLIGHT_RPC})
                                               ^----------------------------^ SC2206 (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.


In ci/scripts/conan_build.sh line 46:
  conan_args+=(--options arrow/*:with_re2=${ARROW_CONAN_WITH_FLIGHT_RPC})
                                          ^----------------------------^ SC2206 (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.


In ci/scripts/conan_build.sh line 49:
  conan_args+=(--options arrow/*:with_glog=${ARROW_CONAN_WITH_GLOG})
                                           ^----------------------^ SC2206 (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.


In ci/scripts/conan_build.sh line 52:
  conan_args+=(--options arrow/*:with_jemalloc=${ARROW_CONAN_WITH_JEMALLOC})
                                               ^--------------------------^ SC2206 (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.


In ci/scripts/conan_build.sh line 55:
  conan_args+=(--options arrow/*:with_json=${ARROW_CONAN_WITH_JSON})
                                           ^----------------------^ SC2206 (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.


In ci/scripts/conan_build.sh line 58:
  conan_args+=(--options arrow/*:with_lz4=${ARROW_CONAN_WITH_LZ4})
                                          ^---------------------^ SC2206 (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.


In ci/scripts/conan_build.sh line 61:
  conan_args+=(--options arrow/*:with_snappy=${ARROW_CONAN_WITH_SNAPPY})
                                             ^------------------------^ SC2206 (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.


In ci/scripts/conan_build.sh line 64:
  conan_args+=(--options arrow/*:with_zstd=${ARROW_CONAN_WITH_ZSTD})
                                           ^----------------------^ SC2206 (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.


In ci/scripts/conan_build.sh line 67:
version=$(grep '^set(ARROW_VERSION ' ${ARROW_HOME}/cpp/CMakeLists.txt | \
                                     ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
version=$(grep '^set(ARROW_VERSION ' "${ARROW_HOME}"/cpp/CMakeLists.txt | \


In ci/scripts/conan_build.sh line 69:
conan_args+=(--version ${version})
                       ^--------^ SC2206 (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.


In ci/scripts/conan_build.sh line 72:
rm -rf ${build_dir}/conan || sudo rm -rf ${build_dir}/conan
       ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                         ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
rm -rf "${build_dir}"/conan || sudo rm -rf "${build_dir}"/conan


In ci/scripts/conan_build.sh line 73:
mkdir -p ${build_dir}/conan || sudo mkdir -p ${build_dir}/conan
         ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                             ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
mkdir -p "${build_dir}"/conan || sudo mkdir -p "${build_dir}"/conan


In ci/scripts/conan_build.sh line 74:
if [ -w ${build_dir} ]; then
        ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
if [ -w "${build_dir}" ]; then


In ci/scripts/conan_build.sh line 75:
  cp -a ${source_dir}/ci/conan/* ${build_dir}/conan/
        ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                 ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
  cp -a "${source_dir}"/ci/conan/* "${build_dir}"/conan/


In ci/scripts/conan_build.sh line 77:
  sudo cp -a ${source_dir}/ci/conan/* ${build_dir}/conan/
             ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                      ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
  sudo cp -a "${source_dir}"/ci/conan/* "${build_dir}"/conan/


In ci/scripts/conan_build.sh line 78:
  sudo chown -R $(id -u):$(id -g) ${build_dir}/conan/
                ^------^ SC2046 (warning): Quote this to prevent word splitting.
                         ^------^ SC2046 (warning): Quote this to prevent word splitting.
                                  ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
  sudo chown -R $(id -u):$(id -g) "${build_dir}"/conan/


In ci/scripts/conan_build.sh line 80:
cd ${build_dir}/conan/all
   ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
cd "${build_dir}"/conan/all

For more information:
  https://www.shellcheck.net/wiki/SC2046 -- Quote this to prevent word splitt...
  https://www.shellcheck.net/wiki/SC2206 -- Quote to prevent word splitting/g...
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
```

### What changes are included in this PR?

Add quote like `"${ARROW_CONAN_PARQUET}"`

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #46726