### PR TITLE
GH-46606: [Python] Do not require numpy when normalizing slice

### DIFF
--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -584,7 +584,7 @@ def _normalize_slice(object arrow_obj, slice key):
     start, stop, step = key.indices(n)
 
     if step != 1:
-        indices = np.arange(start, stop, step)
+        indices = list(range(start, stop, step))
         return arrow_obj.take(indices)
     else:
         length = max(stop - start, 0)

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -585,6 +585,8 @@ def _normalize_slice(object arrow_obj, slice key):
 
     if step != 1:
         indices = list(range(start, stop, step))
+        if len(indices) == 0:
+            return arrow_obj.slice(0, 0)
         return arrow_obj.take(indices)
     else:
         length = max(stop - start, 0)

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -488,7 +488,6 @@ def test_array_slice():
                 assert res.to_numpy().tolist() == expected
 
 
-@pytest.mark.numpy
 def test_array_slice_negative_step():
     # ARROW-2714
     np_arr = np.arange(20)
@@ -496,7 +495,7 @@ def test_array_slice_negative_step():
     chunked_arr = pa.chunked_array([arr])
 
     cases = [
-        slice(None, None, -1),
+        slice(None, None, -1),  # GH-46606
         slice(None, 6, -2),
         slice(10, 6, -2),
         slice(8, None, -2),
@@ -520,13 +519,6 @@ def test_array_slice_negative_step():
         result = chunked_arr[case]
         expected = pa.chunked_array([np_arr[case]])
         assert result.equals(expected)
-
-
-def test_slicing_with_non_trivial_step():
-    # https://github.com/apache/arrow/issues/46606
-    arr = pa.array([1.2, 3.5, None])
-    assert arr[-1:] == pa.array([None], type=pa.float64())
-    assert arr[::-1] == pa.array([None, 3.5, 1.2])
 
 
 def test_array_diff():

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -4270,5 +4270,5 @@ def test_non_cpu_array():
 def test_slicing_with_non_trivial_step():
     # https://github.com/apache/arrow/issues/46606
     arr = pa.array([1.2, 3.5, None])
-    assert arr[-1:] == pa.array([None])
+    assert arr[-1:] == pa.array([None], type=pa.float64())
     assert arr[::-1] == pa.array([None, 3.5, 1.2])

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -4266,3 +4266,9 @@ def test_non_cpu_array():
         arr.tolist()
     with pytest.raises(NotImplementedError):
         arr.validate(full=True)
+
+def test_slicing_with_non_trivial_step():
+    # https://github.com/apache/arrow/issues/46606
+    arr = pa.array([1.2, 3.5, None])
+    assert arr[-1:] == pa.array([None])
+    assert arr[::-1] == pa.array([None, 3.5, 1.2])

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -490,8 +490,8 @@ def test_array_slice():
 
 def test_array_slice_negative_step():
     # ARROW-2714
-    np_arr = np.arange(20)
-    arr = pa.array(np_arr)
+    values = list(range(20))
+    arr = pa.array(values)
     chunked_arr = pa.chunked_array([arr])
 
     cases = [
@@ -509,7 +509,7 @@ def test_array_slice_negative_step():
 
     for case in cases:
         result = arr[case]
-        expected = pa.array(np_arr[case])
+        expected = pa.array(values[case], type=arr.type)
         assert result.equals(expected)
 
         result = pa.record_batch([arr], names=['f0'])[case]
@@ -517,7 +517,7 @@ def test_array_slice_negative_step():
         assert result.equals(expected)
 
         result = chunked_arr[case]
-        expected = pa.chunked_array([np_arr[case]])
+        expected = pa.chunked_array([values[case]], type=arr.type)
         assert result.equals(expected)
 
 

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -522,6 +522,13 @@ def test_array_slice_negative_step():
         assert result.equals(expected)
 
 
+def test_slicing_with_non_trivial_step():
+    # https://github.com/apache/arrow/issues/46606
+    arr = pa.array([1.2, 3.5, None])
+    assert arr[-1:] == pa.array([None], type=pa.float64())
+    assert arr[::-1] == pa.array([None, 3.5, 1.2])
+
+
 def test_array_diff():
     # ARROW-6252
     arr1 = pa.array(['foo'], type=pa.utf8())
@@ -4266,9 +4273,3 @@ def test_non_cpu_array():
         arr.tolist()
     with pytest.raises(NotImplementedError):
         arr.validate(full=True)
-
-def test_slicing_with_non_trivial_step():
-    # https://github.com/apache/arrow/issues/46606
-    arr = pa.array([1.2, 3.5, None])
-    assert arr[-1:] == pa.array([None], type=pa.float64())
-    assert arr[::-1] == pa.array([None, 3.5, 1.2])


### PR DESCRIPTION
### Rationale for this change

Slicing an array in non-trivial steps raises an exception when Numpy is not installed.
#46606 

### What changes are included in this PR?

I changed `np.arange(...)` to `list(range(...))` In `python/pyarrow/array.pxi`

### Are these changes tested?

Yes

### Are there any user-facing changes?

No

* GitHub Issue: #46606