### PR TITLE
GH-46736: [CI] Disable Parquet in conan-minimum

### DIFF
--- a/ci/scripts/conan_build.sh
+++ b/ci/scripts/conan_build.sh
@@ -30,8 +30,11 @@ conan_args=()
 conan_args+=(--build=missing)
 if [ -n "${ARROW_CONAN_PARQUET:-}" ]; then
   conan_args+=(--options arrow/*:parquet=${ARROW_CONAN_PARQUET})
-  conan_args+=(--options arrow/*:with_thrift=${ARROW_CONAN_PARQUET})
   conan_args+=(--options arrow/*:with_boost=${ARROW_CONAN_PARQUET})
+  conan_args+=(--options arrow/*:with_json=${ARROW_CONAN_PARQUET})
+  conan_args+=(--options arrow/*:with_thrift=${ARROW_CONAN_PARQUET})
+else
+  conan_args+=(--options arrow/*:parquet=False)
 fi
 if [ -n "${ARROW_CONAN_WITH_BROTLI:-}" ]; then
   conan_args+=(--options arrow/*:with_brotli=${ARROW_CONAN_WITH_BROTLI})


### PR DESCRIPTION
### Rationale for this change

#45459 introduced RapidJSON dependency to Parquet support. Conan recipe enables Parquet by default but it doesn't enable RapidJSON by default. So we can't find RapidJSON.

### What changes are included in this PR?

Disable Parquet by default.

We should report "Parquet support requires RapidJSON support" to Conan when we release 21.0.0.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #46736