### PR TITLE
GH-46761: [C++] Add executable detection on FreeBSD

### DIFF
--- a/cpp/src/arrow/testing/process.cc
+++ b/cpp/src/arrow/testing/process.cc
@@ -281,6 +281,8 @@ class Process::Impl {
 
 #  if defined(__linux__)
     path = filesystem::canonical("/proc/self/exe", error_code);
+#  elif defined(__FreeBSD__)
+    path = filesystem::canonical("/proc/curproc/file", error_code);
 #  elif defined(__APPLE__)
     char buf[PATH_MAX + 1];
     uint32_t bufsize = sizeof(buf);


### PR DESCRIPTION
### Rationale for this change

`arrow::util::Process::Impl::ResolveCurrentExecutable()` isn't available on FreeBSD:

https://github.com/apache/arrow/blob/b630f48f8464e770341e053e2fb328bd857bf72e/cpp/src/arrow/testing/process.cc#L275-L307

### What changes are included in this PR?

Use `/proc/curproc/file` on FreeBSD.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #46761