### PR TITLE
GH-46764: [C++][Gandiva] Fix wrong `.bc` depends

### DIFF
--- a/cpp/cmake_modules/GandivaAddBitcode.cmake
+++ b/cpp/cmake_modules/GandivaAddBitcode.cmake
@@ -71,5 +71,5 @@ function(gandiva_add_bitcode SOURCE)
   endif()
   add_custom_command(OUTPUT ${BC_FILE}
                      COMMAND ${PRECOMPILE_COMMAND}
-                     DEPENDS ${SOURCE_FILE})
+                     DEPENDS ${SOURCE})
 endfunction()


### PR DESCRIPTION
### Rationale for this change

The `SOURCE_FILE` variable doesn't exist in this context.

### What changes are included in this PR?

Fix a typo.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #46764