### PR TITLE
GH-46516: [CI][Python] Force Cython>3.1.1 for docs builds

### DIFF
--- a/ci/conda_env_sphinx.txt
+++ b/ci/conda_env_sphinx.txt
@@ -17,8 +17,8 @@
 
 # Requirements for building the documentation
 breathe
-doxygen
 cython>3.1.1
+doxygen
 ipython
 linkify-it-py
 # We can't install linuxdoc by conda. We install linuxdoc by pip in

--- a/ci/conda_env_sphinx.txt
+++ b/ci/conda_env_sphinx.txt
@@ -18,6 +18,7 @@
 # Requirements for building the documentation
 breathe
 doxygen
+cython>3.1.1
 ipython
 linkify-it-py
 # We can't install linuxdoc by conda. We install linuxdoc by pip in

--- a/ci/scripts/python_build.sh
+++ b/ci/scripts/python_build.sh
@@ -78,6 +78,13 @@ export PYARROW_PARALLEL=${n_jobs}
 export CMAKE_PREFIX_PATH
 export LD_LIBRARY_PATH=${ARROW_HOME}/lib:${LD_LIBRARY_PATH}
 
+# https://github.com/apache/arrow/issues/46516
+# If we are building docs we force Cython>3.1.1 to avoid numpydoc
+# failures due to Cython docstring being wrongly generated.
+if [ "${BUILD_DOCS_PYTHON}" == "ON" ]; then
+  ${PYTHON:-python} -m pip install Cython>3.1.1
+fi
+
 # https://github.com/apache/arrow/issues/41429
 # TODO: We want to out-of-source build. This is a workaround. We copy
 # all needed files to the build directory from the source directory

--- a/ci/scripts/python_build.sh
+++ b/ci/scripts/python_build.sh
@@ -82,7 +82,7 @@ export LD_LIBRARY_PATH=${ARROW_HOME}/lib:${LD_LIBRARY_PATH}
 # If we are building docs we force Cython>3.1.1 to avoid numpydoc
 # failures due to Cython docstring being wrongly generated.
 if [ "${BUILD_DOCS_PYTHON}" == "ON" ]; then
-  ${PYTHON:-python} -m pip install Cython>3.1.1
+  ${PYTHON:-python} -m pip install --upgrade Cython>3.1.1
 fi
 
 # https://github.com/apache/arrow/issues/41429

--- a/ci/scripts/python_build.sh
+++ b/ci/scripts/python_build.sh
@@ -78,13 +78,6 @@ export PYARROW_PARALLEL=${n_jobs}
 export CMAKE_PREFIX_PATH
 export LD_LIBRARY_PATH=${ARROW_HOME}/lib:${LD_LIBRARY_PATH}
 
-# https://github.com/apache/arrow/issues/46516
-# If we are building docs we force Cython>3.1.1 to avoid numpydoc
-# failures due to Cython docstring being wrongly generated.
-if [ "${BUILD_DOCS_PYTHON}" == "ON" ]; then
-  ${PYTHON:-python} -m pip install --upgrade Cython>3.1.1
-fi
-
 # https://github.com/apache/arrow/issues/41429
 # TODO: We want to out-of-source build. This is a workaround. We copy
 # all needed files to the build directory from the source directory

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,6 +3,7 @@
 #
 
 breathe
+cython>3.1.1
 ipython
 linuxdoc
 myst-parser[linkify]

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -4464,7 +4464,7 @@ def float16():
     to a python list, the types of its elements will be ``np.float16``
 
     >>> [type(val) for val in a.to_pylist()]
-    [<class 'numpy.float16'>, <class 'numpy.float16'>]
+    [<class 'float'>, <class 'float'>]
     """
     return primitive_type(_Type_HALF_FLOAT)
 


### PR DESCRIPTION
### Rationale for this change

Due to a change of behaviour on Cython for 3.1 the docstrings generated fail when being tested with numpydoc. The issue was fixed on Cython==3.1.2.
- https://github.com/cython/cython/issues/6904

### What changes are included in this PR?

- Pin Cython>3.1.1 for the docs requirements (both conda and pip)
- Fix doctest failure that was introduced in the interim when the CI job had been failing.

### Are these changes tested?

Via CI.

### Are there any user-facing changes?

No

* GitHub Issue: #46516