### PR TITLE
GH-46773: [GLib] Add GArrowFixedSizeListDataType

### DIFF
--- a/c_glib/arrow-glib/basic-data-type.cpp
+++ b/c_glib/arrow-glib/basic-data-type.cpp
@@ -2652,6 +2652,9 @@ garrow_data_type_new_raw(std::shared_ptr<arrow::DataType> *arrow_data_type)
     }
     type = GARROW_TYPE_EXTENSION_DATA_TYPE;
     break;
+  case arrow::Type::type::FIXED_SIZE_LIST:
+    type = GARROW_TYPE_FIXED_SIZE_LIST_DATA_TYPE;
+    break;
   case arrow::Type::type::RUN_END_ENCODED:
     type = GARROW_TYPE_RUN_END_ENCODED_DATA_TYPE;
     break;

--- a/c_glib/arrow-glib/composite-data-type.cpp
+++ b/c_glib/arrow-glib/composite-data-type.cpp
@@ -784,7 +784,7 @@ garrow_fixed_size_list_data_type_class_init(GArrowFixedSizeListDataTypeClass *kl
 /**
  * garrow_fixed_size_list_data_type_new_data_type:
  * @data_type: The data type of elements.
- * @list_size: The size of value.
+ * @list_size: The size of each list.
  *
  * Returns: A newly created fixed size list data type.
  *

--- a/c_glib/arrow-glib/composite-data-type.cpp
+++ b/c_glib/arrow-glib/composite-data-type.cpp
@@ -786,7 +786,7 @@ garrow_fixed_size_list_data_type_class_init(GArrowFixedSizeListDataTypeClass *kl
  * @data_type: The data type of elements.
  * @list_size: The size of value.
  *
- * Returns: (transfer full) : The newly created fixed size list data type.
+ * Returns: A newly created fixed size list data type.
  *
  * Since: 21.0.0
  */

--- a/c_glib/arrow-glib/composite-data-type.cpp
+++ b/c_glib/arrow-glib/composite-data-type.cpp
@@ -817,9 +817,6 @@ garrow_fixed_size_list_data_type_new_field(GArrowField *field, gint32 list_size)
   auto arrow_fixed_size_list_data_type =
     arrow::fixed_size_list(arrow_field, list_size);
   return GARROW_FIXED_SIZE_LIST_DATA_TYPE(
-    g_object_new(GARROW_TYPE_FIXED_SIZE_LIST_DATA_TYPE,
-                 "data-type",
-                 &arrow_fixed_size_list_data_type,
-                 nullptr));
+    garrow_data_type_new_raw(&arrow_fixed_size_list_data_type));
 }
 G_END_DECLS

--- a/c_glib/arrow-glib/composite-data-type.cpp
+++ b/c_glib/arrow-glib/composite-data-type.cpp
@@ -815,7 +815,7 @@ garrow_fixed_size_list_data_type_new_field(GArrowField *field, gint32 list_size)
 {
   auto arrow_field = garrow_field_get_raw(field);
   auto arrow_fixed_size_list_data_type =
-    std::make_shared<arrow::FixedSizeListType>(arrow_field, list_size);
+    arrow::fixed_size_list(arrow_field, list_size);
   return GARROW_FIXED_SIZE_LIST_DATA_TYPE(
     g_object_new(GARROW_TYPE_FIXED_SIZE_LIST_DATA_TYPE,
                  "data-type",

--- a/c_glib/arrow-glib/composite-data-type.cpp
+++ b/c_glib/arrow-glib/composite-data-type.cpp
@@ -794,7 +794,7 @@ GArrowFixedSizeListDataType *
 garrow_fixed_size_list_data_type_new_data_type(GArrowDataType *value_type,
                                                gint32 list_size)
 {
-  auto arrow_data_type = garrow_data_type_get_raw(value_type);
+  auto arrow_value_type = garrow_data_type_get_raw(value_type);
   auto arrow_fixed_size_list_data_type =
     arrow::fixed_size_list(arrow_data_type, list_size);
   return GARROW_FIXED_SIZE_LIST_DATA_TYPE(

--- a/c_glib/arrow-glib/composite-data-type.cpp
+++ b/c_glib/arrow-glib/composite-data-type.cpp
@@ -795,7 +795,6 @@ garrow_fixed_size_list_data_type_new_data_type(GArrowDataType *value_type,
                                                gint32 list_size)
 {
   auto arrow_data_type = garrow_data_type_get_raw(data_type);
-
   auto arrow_fixed_size_list_data_type =
     std::make_shared<arrow::FixedSizeListType>(arrow_data_type, list_size);
   return GARROW_FIXED_SIZE_LIST_DATA_TYPE(

--- a/c_glib/arrow-glib/composite-data-type.cpp
+++ b/c_glib/arrow-glib/composite-data-type.cpp
@@ -783,7 +783,7 @@ garrow_fixed_size_list_data_type_class_init(GArrowFixedSizeListDataTypeClass *kl
 
 /**
  * garrow_fixed_size_list_data_type_new_data_type:
- * @data_type: The data type of elements.
+ * @value_type: The data type of an element of each list.
  * @list_size: The size of each list.
  *
  * Returns: A newly created fixed size list data type.

--- a/c_glib/arrow-glib/composite-data-type.cpp
+++ b/c_glib/arrow-glib/composite-data-type.cpp
@@ -806,7 +806,7 @@ garrow_fixed_size_list_data_type_new_data_type(GArrowDataType *value_type,
  * @field: The field of elements.
  * @list_size: The size of value.
  *
- * Returns: (transfer full) : The newly created fixed size list data type.
+ * Returns: A newly created fixed size list data type.
  *
  * Since: 21.0.0
  */

--- a/c_glib/arrow-glib/composite-data-type.cpp
+++ b/c_glib/arrow-glib/composite-data-type.cpp
@@ -794,7 +794,7 @@ GArrowFixedSizeListDataType *
 garrow_fixed_size_list_data_type_new_data_type(GArrowDataType *value_type,
                                                gint32 list_size)
 {
-  auto arrow_data_type = garrow_data_type_get_raw(data_type);
+  auto arrow_data_type = garrow_data_type_get_raw(value_type);
   auto arrow_fixed_size_list_data_type =
     arrow::fixed_size_list(arrow_data_type, list_size);
   return GARROW_FIXED_SIZE_LIST_DATA_TYPE(
@@ -814,8 +814,7 @@ GArrowFixedSizeListDataType *
 garrow_fixed_size_list_data_type_new_field(GArrowField *field, gint32 list_size)
 {
   auto arrow_field = garrow_field_get_raw(field);
-  auto arrow_fixed_size_list_data_type =
-    arrow::fixed_size_list(arrow_field, list_size);
+  auto arrow_fixed_size_list_data_type = arrow::fixed_size_list(arrow_field, list_size);
   return GARROW_FIXED_SIZE_LIST_DATA_TYPE(
     garrow_data_type_new_raw(&arrow_fixed_size_list_data_type));
 }

--- a/c_glib/arrow-glib/composite-data-type.cpp
+++ b/c_glib/arrow-glib/composite-data-type.cpp
@@ -827,7 +827,7 @@ garrow_fixed_size_list_data_type_class_init(GArrowFixedSizeListDataTypeClass *kl
   spec = g_param_spec_int("list-size",
                           "List size",
                           "The list size of the elements",
-                          G_MININT,
+                          0,
                           G_MAXINT,
                           0,
                           G_PARAM_READABLE);

--- a/c_glib/arrow-glib/composite-data-type.cpp
+++ b/c_glib/arrow-glib/composite-data-type.cpp
@@ -767,4 +767,64 @@ garrow_run_end_encoded_data_type_get_value_data_type(
   return garrow_data_type_new_raw(&arrow_value_data_type);
 }
 
+G_DEFINE_TYPE(GArrowFixedSizeListDataType,
+              garrow_fixed_size_list_data_type,
+              GARROW_TYPE_BASE_LIST_DATA_TYPE)
+
+static void
+garrow_fixed_size_list_data_type_init(GArrowFixedSizeListDataType *object)
+{
+}
+
+static void
+garrow_fixed_size_list_data_type_class_init(GArrowFixedSizeListDataTypeClass *klass)
+{
+}
+
+/**
+ * garrow_fixed_size_list_data_type_new_data_type:
+ * @data_type: The data type of elements.
+ * @list_size: The size of value.
+ *
+ * Returns: (transfer full) : The newly created fixed size list data type.
+ *
+ * Since: 21.0.0
+ */
+GArrowFixedSizeListDataType *
+garrow_fixed_size_list_data_type_new_data_type(GArrowDataType *data_type,
+                                               gint32 list_size)
+{
+  auto arrow_data_type = garrow_data_type_get_raw(data_type);
+
+  auto arrow_fixed_size_list_data_type =
+    std::make_shared<arrow::FixedSizeListType>(arrow_data_type, list_size);
+  return GARROW_FIXED_SIZE_LIST_DATA_TYPE(
+    g_object_new(GARROW_TYPE_FIXED_SIZE_LIST_DATA_TYPE,
+                 "data-type",
+                 &arrow_fixed_size_list_data_type,
+                 nullptr));
+}
+
+/**
+ * garrow_fixed_size_list_data_type_new_field:
+ * @field: The field of elements.
+ * @list_size: The size of value.
+ *
+ * Returns: (transfer full) : The newly created fixed size list data type.
+ *
+ * Since: 21.0.0
+ */
+GArrowFixedSizeListDataType *
+garrow_fixed_size_list_data_type_new_field(GArrowField *field, gint32 list_size)
+{
+  auto arrow_field = garrow_field_get_raw(field);
+
+  auto arrow_fixed_size_list_data_type =
+    std::make_shared<arrow::FixedSizeListType>(arrow_field, list_size);
+  return GARROW_FIXED_SIZE_LIST_DATA_TYPE(
+    g_object_new(GARROW_TYPE_FIXED_SIZE_LIST_DATA_TYPE,
+                 "data-type",
+                 &arrow_fixed_size_list_data_type,
+                 nullptr));
+}
 G_END_DECLS

--- a/c_glib/arrow-glib/composite-data-type.cpp
+++ b/c_glib/arrow-glib/composite-data-type.cpp
@@ -796,14 +796,14 @@ garrow_fixed_size_list_data_type_new_data_type(GArrowDataType *value_type,
 {
   auto arrow_value_type = garrow_data_type_get_raw(value_type);
   auto arrow_fixed_size_list_data_type =
-    arrow::fixed_size_list(arrow_data_type, list_size);
+    arrow::fixed_size_list(arrow_value_type, list_size);
   return GARROW_FIXED_SIZE_LIST_DATA_TYPE(
     garrow_data_type_new_raw(&arrow_fixed_size_list_data_type));
 }
 
 /**
  * garrow_fixed_size_list_data_type_new_field:
- * @field: The field for elements.
+ * @field: The field of an element of each list.
  * @list_size: The size of value.
  *
  * Returns: A newly created fixed size list data type.

--- a/c_glib/arrow-glib/composite-data-type.cpp
+++ b/c_glib/arrow-glib/composite-data-type.cpp
@@ -51,6 +51,8 @@ G_BEGIN_DECLS
  * #GArrowDictionaryDataType is a class for dictionary data type.
  *
  * #GArrowRunEndEncodedDataType is a class for run end encoded data type.
+ *
+ * #GArrowFixedSizeListDataType is a class for fixed size list data type.
  */
 
 G_DEFINE_TYPE(GArrowBaseListDataType, garrow_base_list_data_type, GARROW_TYPE_DATA_TYPE)

--- a/c_glib/arrow-glib/composite-data-type.cpp
+++ b/c_glib/arrow-glib/composite-data-type.cpp
@@ -791,7 +791,7 @@ garrow_fixed_size_list_data_type_class_init(GArrowFixedSizeListDataTypeClass *kl
  * Since: 21.0.0
  */
 GArrowFixedSizeListDataType *
-garrow_fixed_size_list_data_type_new_data_type(GArrowDataType *data_type,
+garrow_fixed_size_list_data_type_new_data_type(GArrowDataType *value_type,
                                                gint32 list_size)
 {
   auto arrow_data_type = garrow_data_type_get_raw(data_type);

--- a/c_glib/arrow-glib/composite-data-type.cpp
+++ b/c_glib/arrow-glib/composite-data-type.cpp
@@ -796,7 +796,7 @@ garrow_fixed_size_list_data_type_new_data_type(GArrowDataType *value_type,
 {
   auto arrow_data_type = garrow_data_type_get_raw(data_type);
   auto arrow_fixed_size_list_data_type =
-    std::make_shared<arrow::FixedSizeListType>(arrow_data_type, list_size);
+    arrow::fixed_size_list(arrow_data_type, list_size);
   return GARROW_FIXED_SIZE_LIST_DATA_TYPE(
     g_object_new(GARROW_TYPE_FIXED_SIZE_LIST_DATA_TYPE,
                  "data-type",

--- a/c_glib/arrow-glib/composite-data-type.cpp
+++ b/c_glib/arrow-glib/composite-data-type.cpp
@@ -803,7 +803,7 @@ garrow_fixed_size_list_data_type_new_data_type(GArrowDataType *value_type,
 
 /**
  * garrow_fixed_size_list_data_type_new_field:
- * @field: The field of elements.
+ * @field: The field for elements.
  * @list_size: The size of value.
  *
  * Returns: A newly created fixed size list data type.

--- a/c_glib/arrow-glib/composite-data-type.cpp
+++ b/c_glib/arrow-glib/composite-data-type.cpp
@@ -814,7 +814,6 @@ GArrowFixedSizeListDataType *
 garrow_fixed_size_list_data_type_new_field(GArrowField *field, gint32 list_size)
 {
   auto arrow_field = garrow_field_get_raw(field);
-
   auto arrow_fixed_size_list_data_type =
     std::make_shared<arrow::FixedSizeListType>(arrow_field, list_size);
   return GARROW_FIXED_SIZE_LIST_DATA_TYPE(

--- a/c_glib/arrow-glib/composite-data-type.cpp
+++ b/c_glib/arrow-glib/composite-data-type.cpp
@@ -861,7 +861,7 @@ garrow_fixed_size_list_data_type_new_data_type(GArrowDataType *value_type,
 
 /**
  * garrow_fixed_size_list_data_type_new_field:
- * @field: The field of an element of each list.
+ * @field: The field of lists.
  * @list_size: The size of value.
  *
  * Returns: A newly created fixed size list data type.

--- a/c_glib/arrow-glib/composite-data-type.cpp
+++ b/c_glib/arrow-glib/composite-data-type.cpp
@@ -80,7 +80,8 @@ garrow_base_list_data_type_get_field(GArrowBaseListDataType *base_list_data_type
 {
   auto data_type = GARROW_DATA_TYPE(base_list_data_type);
   auto arrow_data_type = garrow_data_type_get_raw(data_type);
-  auto arrow_base_list_data_type = std::static_pointer_cast<arrow::BaseListType>(arrow_data_type);
+  auto arrow_base_list_data_type =
+    std::static_pointer_cast<arrow::BaseListType>(arrow_data_type);
 
   auto arrow_field = arrow_base_list_data_type->value_field();
   return garrow_field_new_raw(&arrow_field, nullptr);
@@ -823,13 +824,13 @@ garrow_fixed_size_list_data_type_class_init(GArrowFixedSizeListDataTypeClass *kl
   gobject_class = G_OBJECT_CLASS(klass);
   gobject_class->get_property = garrow_fixed_size_list_data_type_get_property;
 
-  spec =  g_param_spec_int("list-size",
-                           "List size",
-                           "The list size of the elements",
-                           G_MININT,
-                           G_MAXINT,
-                           0,
-                           G_PARAM_READABLE);
+  spec = g_param_spec_int("list-size",
+                          "List size",
+                          "The list size of the elements",
+                          G_MININT,
+                          G_MAXINT,
+                          0,
+                          G_PARAM_READABLE);
   g_object_class_install_property(gobject_class, PROP_LIST_SIZE, spec);
 }
 

--- a/c_glib/arrow-glib/composite-data-type.cpp
+++ b/c_glib/arrow-glib/composite-data-type.cpp
@@ -798,10 +798,7 @@ garrow_fixed_size_list_data_type_new_data_type(GArrowDataType *value_type,
   auto arrow_fixed_size_list_data_type =
     arrow::fixed_size_list(arrow_data_type, list_size);
   return GARROW_FIXED_SIZE_LIST_DATA_TYPE(
-    g_object_new(GARROW_TYPE_FIXED_SIZE_LIST_DATA_TYPE,
-                 "data-type",
-                 &arrow_fixed_size_list_data_type,
-                 nullptr));
+    garrow_data_type_new_raw(&arrow_fixed_size_list_data_type));
 }
 
 /**

--- a/c_glib/arrow-glib/composite-data-type.h
+++ b/c_glib/arrow-glib/composite-data-type.h
@@ -256,4 +256,25 @@ GArrowDataType *
 garrow_run_end_encoded_data_type_get_value_data_type(
   GArrowRunEndEncodedDataType *data_type);
 
+#define GARROW_TYPE_FIXED_SIZE_LIST_DATA_TYPE                                            \
+  (garrow_fixed_size_list_data_type_get_type())
+GARROW_AVAILABLE_IN_21_0
+G_DECLARE_DERIVABLE_TYPE(GArrowFixedSizeListDataType,
+                         garrow_fixed_size_list_data_type,
+                         GARROW,
+                         FIXED_SIZE_LIST_DATA_TYPE,
+                         GArrowBaseListDataType)
+struct _GArrowFixedSizeListDataTypeClass
+{
+  GArrowBaseListDataTypeClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_21_0
+GArrowFixedSizeListDataType *
+garrow_fixed_size_list_data_type_new_data_type(GArrowDataType *data_type,
+                                               gint32 list_size);
+
+GARROW_AVAILABLE_IN_21_0
+GArrowFixedSizeListDataType *
+garrow_fixed_size_list_data_type_new_field(GArrowField *field, gint32 list_size);
 G_END_DECLS

--- a/c_glib/arrow-glib/composite-data-type.h
+++ b/c_glib/arrow-glib/composite-data-type.h
@@ -271,7 +271,7 @@ struct _GArrowFixedSizeListDataTypeClass
 
 GARROW_AVAILABLE_IN_21_0
 GArrowFixedSizeListDataType *
-garrow_fixed_size_list_data_type_new_data_type(GArrowDataType *data_type,
+garrow_fixed_size_list_data_type_new_data_type(GArrowDataType *value_type,
                                                gint32 list_size);
 
 GARROW_AVAILABLE_IN_21_0

--- a/c_glib/arrow-glib/composite-data-type.h
+++ b/c_glib/arrow-glib/composite-data-type.h
@@ -38,6 +38,10 @@ struct _GArrowBaseListDataTypeClass
   GArrowDataTypeClass parent_class;
 };
 
+GARROW_AVAILABLE_IN_21_0
+GArrowField *
+garrow_base_list_data_type_get_field(GArrowBaseListDataType *base_list_data_type);
+
 #define GARROW_TYPE_LIST_DATA_TYPE (garrow_list_data_type_get_type())
 GARROW_AVAILABLE_IN_ALL
 G_DECLARE_DERIVABLE_TYPE(GArrowListDataType,

--- a/c_glib/test/test-fixed-size-list-data-type.rb
+++ b/c_glib/test/test-fixed-size-list-data-type.rb
@@ -23,7 +23,7 @@ class TestFixedSizeListDataType < Test::Unit::TestCase
       @field_name = "bool_field"
     end
 
-    def test_new_field
+    def test_field
       field = Arrow::Field.new(@list_name, @list_type)
       data_type = Arrow::FixedSizeListDataType.new(field, @list_size);
       assert_equal(Arrow::Type::FIXED_SIZE_LIST, data_type.id);

--- a/c_glib/test/test-fixed-size-list-data-type.rb
+++ b/c_glib/test/test-fixed-size-list-data-type.rb
@@ -18,7 +18,7 @@
 class TestFixedSizeListDataType < Test::Unit::TestCase
   sub_test_case(".new") do
     def setup
-      @list_type = Arrow::BooleanDataType.new
+      @value_type = Arrow::BooleanDataType.new
       @list_size = 5
       @field_name = "bool_field"
     end

--- a/c_glib/test/test-fixed-size-list-data-type.rb
+++ b/c_glib/test/test-fixed-size-list-data-type.rb
@@ -26,14 +26,14 @@ class TestFixedSizeListDataType < Test::Unit::TestCase
     def test_field
       field = Arrow::Field.new(@field_name, @value_type)
       data_type = Arrow::FixedSizeListDataType.new(field, @list_size)
-      assert_equal([Arrow::Type::FIXED_SIZE_LIST, "fixed_size_list<bool_field: bool>[5]"],
-                   [data_type.id, data_type.to_s])
+      # TODO: check value_field and list_size separately.
+      assert_equal("fixed_size_list<bool_field: bool>[5]", data_type.to_s)
     end
 
     def test_data_type
       data_type = Arrow::FixedSizeListDataType.new(@value_type, @list_size)
-      assert_equal([Arrow::Type::FIXED_SIZE_LIST, "fixed_size_list<item: bool>[5]"],
-                   [data_type.id, data_type.to_s])
+      # TODO: check value_field and list_size separately.
+      assert_equal("fixed_size_list<item: bool>[5]", data_type.to_s)
     end
   end
 

--- a/c_glib/test/test-fixed-size-list-data-type.rb
+++ b/c_glib/test/test-fixed-size-list-data-type.rb
@@ -26,11 +26,13 @@ class TestFixedSizeListDataType < Test::Unit::TestCase
     def test_field
       field = Arrow::Field.new(@field_name, @value_type)
       data_type = Arrow::FixedSizeListDataType.new(field, @list_size);
+      assert_equal(Arrow::Type::BOOLEAN, field.data_type.id);
       assert_equal(Arrow::Type::FIXED_SIZE_LIST, data_type.id);
     end
 
     def test_data_type
       data_type = Arrow::FixedSizeListDataType.new(@value_type, @list_size);
+      assert_equal(Arrow::Type::BOOLEAN, @value_type.id);
       assert_equal(Arrow::Type::FIXED_SIZE_LIST, data_type.id);
     end
   end

--- a/c_glib/test/test-fixed-size-list-data-type.rb
+++ b/c_glib/test/test-fixed-size-list-data-type.rb
@@ -29,7 +29,7 @@ class TestFixedSizeListDataType < Test::Unit::TestCase
       assert_equal(Arrow::Type::FIXED_SIZE_LIST, data_type.id);
     end
 
-    def test_new_data_type
+    def test_data_type
       data_type = Arrow::FixedSizeListDataType.new(@list_type, @list_size);
       assert_equal(Arrow::Type::FIXED_SIZE_LIST, data_type.id);
     end

--- a/c_glib/test/test-fixed-size-list-data-type.rb
+++ b/c_glib/test/test-fixed-size-list-data-type.rb
@@ -20,7 +20,7 @@ class TestFixedSizeListDataType < Test::Unit::TestCase
     def setup
       @list_type = Arrow::BooleanDataType.new
       @list_size = 5
-      @list_name = "bool_field"
+      @field_name = "bool_field"
     end
 
     def test_new_field

--- a/c_glib/test/test-fixed-size-list-data-type.rb
+++ b/c_glib/test/test-fixed-size-list-data-type.rb
@@ -37,7 +37,7 @@ class TestFixedSizeListDataType < Test::Unit::TestCase
   sub_test_case("instance_methods") do
     def setup
       @list_size = 5
-      @value_type =Arrow::BooleanDataType.new
+      @value_type = Arrow::BooleanDataType.new
       @data_type = Arrow::FixedSizeListDataType.new(@value_type, @list_size)
     end
 

--- a/c_glib/test/test-fixed-size-list-data-type.rb
+++ b/c_glib/test/test-fixed-size-list-data-type.rb
@@ -25,15 +25,15 @@ class TestFixedSizeListDataType < Test::Unit::TestCase
 
     def test_field
       field = Arrow::Field.new(@field_name, @value_type)
-      data_type = Arrow::FixedSizeListDataType.new(field, @list_size);
-      assert_equal(Arrow::Type::BOOLEAN, field.data_type.id);
-      assert_equal(Arrow::Type::FIXED_SIZE_LIST, data_type.id);
+      data_type = Arrow::FixedSizeListDataType.new(field, @list_size)
+      assert_equal([Arrow::Type::FIXED_SIZE_LIST, "fixed_size_list<bool_field: bool>[5]"],
+                   [data_type.id, data_type.to_s])
     end
 
     def test_data_type
-      data_type = Arrow::FixedSizeListDataType.new(@value_type, @list_size);
-      assert_equal(Arrow::Type::BOOLEAN, @value_type.id);
-      assert_equal(Arrow::Type::FIXED_SIZE_LIST, data_type.id);
+      data_type = Arrow::FixedSizeListDataType.new(@value_type, @list_size)
+      assert_equal([Arrow::Type::FIXED_SIZE_LIST, "fixed_size_list<item: bool>[5]"],
+                   [data_type.id, data_type.to_s])
     end
   end
 

--- a/c_glib/test/test-fixed-size-list-data-type.rb
+++ b/c_glib/test/test-fixed-size-list-data-type.rb
@@ -24,13 +24,13 @@ class TestFixedSizeListDataType < Test::Unit::TestCase
     end
 
     def test_field
-      field = Arrow::Field.new(@list_name, @list_type)
+      field = Arrow::Field.new(@field_name, @value_type)
       data_type = Arrow::FixedSizeListDataType.new(field, @list_size);
       assert_equal(Arrow::Type::FIXED_SIZE_LIST, data_type.id);
     end
 
     def test_data_type
-      data_type = Arrow::FixedSizeListDataType.new(@list_type, @list_size);
+      data_type = Arrow::FixedSizeListDataType.new(@value_type, @list_size);
       assert_equal(Arrow::Type::FIXED_SIZE_LIST, data_type.id);
     end
   end

--- a/c_glib/test/test-fixed-size-list-data-type.rb
+++ b/c_glib/test/test-fixed-size-list-data-type.rb
@@ -1,0 +1,51 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestFixedSizeListDataType < Test::Unit::TestCase
+  sub_test_case(".new") do
+    def setup
+      @list_type = Arrow::BooleanDataType.new
+      @list_size = 5
+      @list_name = "bool_field"
+    end
+
+    def test_new_field
+      field = Arrow::Field.new(@list_name, @list_type)
+      data_type = Arrow::FixedSizeListDataType.new(field, @list_size);
+      assert_equal(Arrow::Type::FIXED_SIZE_LIST, data_type.id);
+    end
+
+    def test_new_data_type
+      data_type = Arrow::FixedSizeListDataType.new(@list_type, @list_size);
+      assert_equal(Arrow::Type::FIXED_SIZE_LIST, data_type.id);
+    end
+  end
+
+  sub_test_case(".instance_method") do
+    def setup
+      @data_type = Arrow::FixedSizeListDataType.new(Arrow::BooleanDataType.new, 5)
+    end
+
+    def test_name
+      assert_equal("fixed_size_list", @data_type.name);
+    end
+
+    def test_to_s
+      assert_equal("fixed_size_list<item: bool>[5]", @data_type.to_s)
+    end
+  end
+end

--- a/c_glib/test/test-fixed-size-list-data-type.rb
+++ b/c_glib/test/test-fixed-size-list-data-type.rb
@@ -17,29 +17,28 @@
 
 class TestFixedSizeListDataType < Test::Unit::TestCase
   sub_test_case(".new") do
-    def setup
-      @value_type = Arrow::BooleanDataType.new
-      @list_size = 5
-      @field_name = "bool_field"
-    end
-
     def test_field
-      field = Arrow::Field.new(@field_name, @value_type)
-      data_type = Arrow::FixedSizeListDataType.new(field, @list_size)
-      # TODO: check value_field and list_size separately.
-      assert_equal("fixed_size_list<bool_field: bool>[5]", data_type.to_s)
+      list_size = 5
+      field_name = "bool_field"
+      field = Arrow::Field.new("bool_field", Arrow::BooleanDataType.new)
+      data_type = Arrow::FixedSizeListDataType.new(field, list_size)
+      assert_equal([field, list_size], [data_type.field, data_type.list_size])
     end
 
     def test_data_type
-      data_type = Arrow::FixedSizeListDataType.new(@value_type, @list_size)
-      # TODO: check value_field and list_size separately.
-      assert_equal("fixed_size_list<item: bool>[5]", data_type.to_s)
+      value_type = Arrow::BooleanDataType.new
+      list_size = 5
+      data_type = Arrow::FixedSizeListDataType.new(value_type, list_size)
+      field = Arrow::Field.new("item", value_type)
+      assert_equal([field, list_size], [data_type.field, data_type.list_size])
     end
   end
 
   sub_test_case("instance_methods") do
     def setup
-      @data_type = Arrow::FixedSizeListDataType.new(Arrow::BooleanDataType.new, 5)
+      @list_size = 5
+      @value_type =Arrow::BooleanDataType.new
+      @data_type = Arrow::FixedSizeListDataType.new(@value_type, @list_size)
     end
 
     def test_name
@@ -48,6 +47,15 @@ class TestFixedSizeListDataType < Test::Unit::TestCase
 
     def test_to_s
       assert_equal("fixed_size_list<item: bool>[5]", @data_type.to_s)
+    end
+
+    def test_list_size
+      assert_equal(@list_size, @data_type.list_size)
+    end
+
+    def test_field
+      field = Arrow::Field.new("item", @value_type)
+      assert_equal(field, @data_type.field)
     end
   end
 end

--- a/c_glib/test/test-fixed-size-list-data-type.rb
+++ b/c_glib/test/test-fixed-size-list-data-type.rb
@@ -35,7 +35,7 @@ class TestFixedSizeListDataType < Test::Unit::TestCase
     end
   end
 
-  sub_test_case(".instance_method") do
+  sub_test_case("instance_methods") do
     def setup
       @data_type = Arrow::FixedSizeListDataType.new(Arrow::BooleanDataType.new, 5)
     end


### PR DESCRIPTION
### Rationale for this change

GLib should be able to use `arrow::FixedSizeListType`.

### What changes are included in this PR?

Add `GArrowFixedSizeListDataType`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #46773