### PR TITLE
GH-46767: [C++] Enable EqualOptions::use_atol_ for arrow::Array, arrow::Scalar, arrow::RecordBatch, and arrow::ChuckedArray

### DIFF
--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -2069,6 +2069,24 @@ void CheckApproxEquals() {
 }
 
 template <typename TYPE>
+void CheckFloatApproxEqualsWithAtol() {
+  using c_type = typename TYPE::c_type;
+  auto type = TypeTraits<TYPE>::type_singleton();
+  std::shared_ptr<Array> a, b;
+  ArrayFromVector<TYPE>(type, {true}, {static_cast<c_type>(0.5)}, &a);
+  ArrayFromVector<TYPE>(type, {true}, {static_cast<c_type>(0.6)}, &b);
+  auto options = EqualOptions::Defaults().atol(0.2);
+
+  ASSERT_FALSE(a->Equals(b));
+  ASSERT_TRUE(a->Equals(b, options.use_atol(true)));
+  ASSERT_TRUE(a->ApproxEquals(b, options));
+
+  ASSERT_FALSE(a->RangeEquals(0, 1, 0, b, options));
+  ASSERT_TRUE(a->RangeEquals(0, 1, 0, b, options.use_atol(true)));
+  ASSERT_TRUE(ArrayRangeApproxEquals(*a, *b, 0, 1, 0, options));
+}
+
+template <typename TYPE>
 void CheckSliceApproxEquals() {
   using T = typename TYPE::c_type;
 
@@ -2270,6 +2288,11 @@ void CheckFloatingZeroEquality() {
 TEST(TestPrimitiveAdHoc, FloatingApproxEquals) {
   CheckApproxEquals<FloatType>();
   CheckApproxEquals<DoubleType>();
+}
+
+TEST(TestPrimitiveAdHoc, FloatingApproxEqualsWithAtol) {
+  CheckFloatApproxEqualsWithAtol<FloatType>();
+  CheckFloatApproxEqualsWithAtol<DoubleType>();
 }
 
 TEST(TestPrimitiveAdHoc, FloatingSliceApproxEquals) {

--- a/cpp/src/arrow/array/statistics_test.cc
+++ b/cpp/src/arrow/array/statistics_test.cc
@@ -148,7 +148,6 @@ TEST_F(TestArrayStatisticsEqualityDoubleValue, NaN) {
 TEST_F(TestArrayStatisticsEqualityDoubleValue, ApproximateEquals) {
   statistics1_.max = 0.5001f;
   statistics2_.max = 0.5;
-
   ASSERT_FALSE(statistics1_.Equals(statistics2_, options_.atol(1e-3)));
   ASSERT_TRUE(statistics1_.Equals(statistics2_, options_.atol(1e-3).use_atol(true)));
 }

--- a/cpp/src/arrow/array/statistics_test.cc
+++ b/cpp/src/arrow/array/statistics_test.cc
@@ -148,8 +148,9 @@ TEST_F(TestArrayStatisticsEqualityDoubleValue, NaN) {
 TEST_F(TestArrayStatisticsEqualityDoubleValue, ApproximateEquals) {
   statistics1_.max = 0.5001f;
   statistics2_.max = 0.5;
-  ASSERT_FALSE(statistics1_.Equals(statistics2_, options_.atol(1e-3).use_atol(false)));
-  ASSERT_TRUE(statistics1_.Equals(statistics2_, options_.atol(1e-3)));
+
+  ASSERT_FALSE(statistics1_.Equals(statistics2_, options_.atol(1e-3)));
+  ASSERT_TRUE(statistics1_.Equals(statistics2_, options_.atol(1e-3).use_atol(true)));
 }
 
 }  // namespace arrow

--- a/cpp/src/arrow/chunked_array.cc
+++ b/cpp/src/arrow/chunked_array.cc
@@ -98,8 +98,27 @@ DeviceAllocationTypeSet ChunkedArray::device_types() const {
   }
   return set;
 }
+namespace {
+
+bool mayHaveNaN(const arrow::DataType& type) {
+  if (type.num_fields() == 0) {
+    return is_floating(type.id());
+  } else {
+    for (const auto& field : type.fields()) {
+      if (mayHaveNaN(*field->type())) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+}  //  namespace
 
 bool ChunkedArray::Equals(const ChunkedArray& other, const EqualOptions& opts) const {
+  if (this == &other && !mayHaveNaN(*type_)) {
+    return true;
+  }
   if (length_ != other.length()) {
     return false;
   }
@@ -125,59 +144,17 @@ bool ChunkedArray::Equals(const ChunkedArray& other, const EqualOptions& opts) c
       .ok();
 }
 
-namespace {
-
-bool mayHaveNaN(const arrow::DataType& type) {
-  if (type.num_fields() == 0) {
-    return is_floating(type.id());
-  } else {
-    for (const auto& field : type.fields()) {
-      if (mayHaveNaN(*field->type())) {
-        return true;
-      }
-    }
-  }
-  return false;
-}
-
-}  //  namespace
-
 bool ChunkedArray::Equals(const std::shared_ptr<ChunkedArray>& other,
                           const EqualOptions& opts) const {
   if (!other) {
     return false;
-  }
-  if (this == other.get() && !mayHaveNaN(*type_)) {
-    return true;
   }
   return Equals(*other.get(), opts);
 }
 
 bool ChunkedArray::ApproxEquals(const ChunkedArray& other,
                                 const EqualOptions& equal_options) const {
-  if (length_ != other.length()) {
-    return false;
-  }
-  if (null_count_ != other.null_count()) {
-    return false;
-  }
-  // We cannot toggle check_metadata here yet, so we don't check it
-  if (!type_->Equals(*other.type_, /*check_metadata=*/false)) {
-    return false;
-  }
-
-  // Check contents of the underlying arrays. This checks for equality of
-  // the underlying data independently of the chunk size.
-  return internal::ApplyBinaryChunked(
-             *this, other,
-             [&](const Array& left_piece, const Array& right_piece,
-                 int64_t ARROW_ARG_UNUSED(position)) {
-               if (!left_piece.ApproxEquals(right_piece, equal_options)) {
-                 return Status::Invalid("Unequal piece");
-               }
-               return Status::OK();
-             })
-      .ok();
+  return Equals(other, equal_options.use_atol(true));
 }
 
 Result<std::shared_ptr<Scalar>> ChunkedArray::GetScalar(int64_t index) const {

--- a/cpp/src/arrow/chunked_array_test.cc
+++ b/cpp/src/arrow/chunked_array_test.cc
@@ -181,6 +181,7 @@ TEST_F(TestChunkedArray, EqualsSameAddressWithNaNs) {
   ASSERT_OK_AND_ASSIGN(auto chunked_array_without_nan2, ChunkedArray::Make(chunks4));
   ASSERT_TRUE(chunked_array_without_nan2->Equals(chunked_array_without_nan2));
 }
+
 TEST_F(TestChunkedArray, ApproxEquals) {
   auto chunk_1 = ArrayFromJSON(float64(), R"([0.0, 0.1, 0.5])");
   auto chunk_2 = ArrayFromJSON(float64(), R"([0.0, 0.1, 0.5001])");
@@ -192,6 +193,7 @@ TEST_F(TestChunkedArray, ApproxEquals) {
   ASSERT_TRUE(chunked_array_1->Equals(chunked_array_2, options.use_atol(true)));
   ASSERT_TRUE(chunked_array_1->ApproxEquals(*chunked_array_2, options));
 }
+
 TEST_F(TestChunkedArray, SliceEquals) {
   random::RandomArrayGenerator gen(42);
 

--- a/cpp/src/arrow/chunked_array_test.cc
+++ b/cpp/src/arrow/chunked_array_test.cc
@@ -181,7 +181,17 @@ TEST_F(TestChunkedArray, EqualsSameAddressWithNaNs) {
   ASSERT_OK_AND_ASSIGN(auto chunked_array_without_nan2, ChunkedArray::Make(chunks4));
   ASSERT_TRUE(chunked_array_without_nan2->Equals(chunked_array_without_nan2));
 }
+TEST_F(TestChunkedArray, ApproxEquals) {
+  auto chunk_1 = ArrayFromJSON(float64(), R"([0.0, 0.1, 0.5])");
+  auto chunk_2 = ArrayFromJSON(float64(), R"([0.0, 0.1, 0.5001])");
+  ASSERT_OK_AND_ASSIGN(auto chunked_array_1, ChunkedArray::Make({chunk_1}));
+  ASSERT_OK_AND_ASSIGN(auto chunked_array_2, ChunkedArray::Make({chunk_2}));
+  auto options = EqualOptions::Defaults().atol(1e-3);
 
+  ASSERT_FALSE(chunked_array_1->Equals(chunked_array_2));
+  ASSERT_TRUE(chunked_array_1->Equals(chunked_array_2, options.use_atol(true)));
+  ASSERT_TRUE(chunked_array_1->ApproxEquals(*chunked_array_2, options));
+}
 TEST_F(TestChunkedArray, SliceEquals) {
   random::RandomArrayGenerator gen(42);
 

--- a/cpp/src/arrow/compare.cc
+++ b/cpp/src/arrow/compare.cc
@@ -1155,9 +1155,8 @@ bool ScalarEquals(const Scalar& left, const Scalar& right, const EqualOptions& o
 bool ArrayRangeEquals(const Array& left, const Array& right, int64_t left_start_idx,
                       int64_t left_end_idx, int64_t right_start_idx,
                       const EqualOptions& options) {
-  const bool floating_approximate = false;
   return ArrayRangeEquals(left, right, left_start_idx, left_end_idx, right_start_idx,
-                          options, floating_approximate);
+                          options, options.use_atol());
 }
 
 bool ArrayRangeApproxEquals(const Array& left, const Array& right, int64_t left_start_idx,
@@ -1169,8 +1168,7 @@ bool ArrayRangeApproxEquals(const Array& left, const Array& right, int64_t left_
 }
 
 bool ArrayEquals(const Array& left, const Array& right, const EqualOptions& opts) {
-  const bool floating_approximate = false;
-  return ArrayEquals(left, right, opts, floating_approximate);
+  return ArrayEquals(left, right, opts, opts.use_atol());
 }
 
 bool ArrayApproxEquals(const Array& left, const Array& right, const EqualOptions& opts) {
@@ -1179,8 +1177,7 @@ bool ArrayApproxEquals(const Array& left, const Array& right, const EqualOptions
 }
 
 bool ScalarEquals(const Scalar& left, const Scalar& right, const EqualOptions& options) {
-  const bool floating_approximate = false;
-  return ScalarEquals(left, right, options, floating_approximate);
+  return ScalarEquals(left, right, options, options.use_atol());
 }
 
 bool ScalarApproxEquals(const Scalar& left, const Scalar& right,

--- a/cpp/src/arrow/compare.h
+++ b/cpp/src/arrow/compare.h
@@ -60,6 +60,9 @@ class EqualOptions {
   }
 
   /// Whether the "atol" property is used in the comparison.
+  ///
+  /// This option only affects the Equals methods
+  /// and has no effect on ApproxEquals methods.
   bool use_atol() const { return use_atol_; }
 
   /// Return a new EqualOptions object with the "use_atol" property changed.
@@ -99,7 +102,7 @@ class EqualOptions {
   double atol_ = kDefaultAbsoluteTolerance;
   bool nans_equal_ = false;
   bool signed_zeros_equal_ = true;
-  bool use_atol_ = true;
+  bool use_atol_ = false;
 
   std::ostream* diff_sink_ = NULLPTR;
 };

--- a/cpp/src/arrow/record_batch_test.cc
+++ b/cpp/src/arrow/record_batch_test.cc
@@ -136,7 +136,10 @@ TEST_F(TestRecordBatch, ApproxEqualOptions) {
   EXPECT_FALSE(b1->ApproxEquals(*b2, EqualOptions::Defaults().nans_equal(false)));
   EXPECT_FALSE(b1->ApproxEquals(*b2, EqualOptions::Defaults().nans_equal(true)));
 
-  EXPECT_TRUE(b1->ApproxEquals(*b2, EqualOptions::Defaults().nans_equal(true).atol(0.1)));
+  auto options = EqualOptions::Defaults().nans_equal(true).atol(0.1);
+  EXPECT_FALSE(b1->Equals(*b2, false, options));
+  EXPECT_TRUE(b1->Equals(*b2, false, options.use_atol(true)));
+  EXPECT_TRUE(b1->ApproxEquals(*b2, options));
 }
 
 TEST_F(TestRecordBatch, Validate) {

--- a/cpp/src/arrow/scalar_test.cc
+++ b/cpp/src/arrow/scalar_test.cc
@@ -387,6 +387,14 @@ class TestRealScalar : public ::testing::Test {
     ASSERT_FALSE(scalar_zero_->ApproxEquals(*scalar_neg_zero_, options));
   }
 
+  void TestUseAtol() {
+    auto options = EqualOptions::Defaults().atol(0.2f);
+
+    ASSERT_FALSE(scalar_val_->Equals(*scalar_other_, options));
+    ASSERT_TRUE(scalar_val_->Equals(*scalar_other_, options.use_atol(true)));
+    ASSERT_TRUE(scalar_val_->ApproxEquals(*scalar_other_, options));
+  }
+
   void TestStructOf() {
     auto ty = struct_({field("float", type_)});
 
@@ -521,6 +529,8 @@ TYPED_TEST(TestRealScalar, NanEquals) { this->TestNanEquals(); }
 TYPED_TEST(TestRealScalar, SignedZeroEquals) { this->TestSignedZeroEquals(); }
 
 TYPED_TEST(TestRealScalar, ApproxEquals) { this->TestApproxEquals(); }
+
+TYPED_TEST(TestRealScalar, UseAtol) { this->TestUseAtol(); }
 
 TYPED_TEST(TestRealScalar, StructOf) { this->TestStructOf(); }
 


### PR DESCRIPTION
### Rationale for this change

Enable EqualOptions::use_atol for` arrow::Array` and `arrow::Scalar`.

### What changes are included in this PR?

- Changed the default value of EqualOptions::use_atol to false.
- Enabled `EqualOptions::use_atol_` for the following methods.
  - `arrow::ScalarEquals`
  - ` arrow::ArrayRangeEquals`
  - `arrow:: ArrayEquals`

### Are these changes tested?

Yes, I ran the relevant unit tests.

### Are there any user-facing changes? 

The default value of `EqualOptions::use_atol ` is changed to false

**This PR includes breaking changes to public APIs.** (If there are any breaking changes to public APIs, please explain which changes are breaking. If not, you can remove this.)


* GitHub Issue: #46767