### PR TITLE
MINOR: [Docs] Fix Typos in Documentation and Protobuf Comments

### DIFF
--- a/docs/source/format/CDeviceDataInterface.rst
+++ b/docs/source/format/CDeviceDataInterface.rst
@@ -848,7 +848,7 @@ This producer-provided structure has the following fields:
   If a non-zero value is returned from this, it should be followed only by the producer calling
   the ``on_error`` callback of the ``ArrowAsyncDeviceStreamHandler``. Because calling this method
   is likely to be separate from the current control flow, returning a non-zero value to signal
-  an error occuring allows the current thread to decide handle the case accordingly, while still
+  an error occurring allows the current thread to decide handle the case accordingly, while still
   allowing all error logging and handling to be centralized in the
   :c:member:`ArrowAsyncDeviceStreamHandler.on_error` callback.
 

--- a/docs/source/format/Flight.rst
+++ b/docs/source/format/Flight.rst
@@ -409,7 +409,7 @@ data is returned in by respecting the ``Accept`` header in the request.
 If multiple formats are requested and supported, the choice of which to
 use is server-specific. If none of the requested content-types are
 supported, the server may respond with either 406 (Not Acceptable),
-415 (Unsupported Media Type), or successfuly respond with a different
+415 (Unsupported Media Type), or successfully respond with a different
 format that it does support, along with the correct ``Content-Type``
 header.
 

--- a/format/FlightSql.proto
+++ b/format/FlightSql.proto
@@ -1862,7 +1862,7 @@ message DoPutPreparedStatementResult {
   // statement must use this new handle.
   // The updated handle allows implementing query parameters with stateless services.
   //
-  // When an updated handle is not provided by the server, clients should contiue
+  // When an updated handle is not provided by the server, clients should continue
   // using the previous handle provided by `ActionCreatePreparedStatementResonse`.
   optional bytes prepared_statement_handle = 1;
 }


### PR DESCRIPTION
### Rationale for this change

There are some typos in documents and Protobuf comments.

###  What changes are included in this PR?

This pull request corrects several typographical errors in the documentation and protobuf comments. Specifically:
- Fixed the spelling of "occuring" to "occurring" in `CDeviceDataInterface.rst`.
- Fixed the spelling of "successfully" in `Flight.rst`.
- Fixed the spelling of "continue" in `FlightSql.proto`.

These changes improve the clarity and professionalism of the documentation and code comments. No functional code changes are included.

### Are these changes tested?

No.

### Are there any user-facing changes?

No.