### PR TITLE
GH-46785: [CI][Dev][C++] Suppress needless outputs of cpplint with pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,6 +77,7 @@ repos:
         alias: cpp
         name: C++ Lint
         args:
+          - "--quiet"
           - "--verbose=2"
         types_or:
           - c++


### PR DESCRIPTION
### Rationale for this change

If cpplint outputs "Done ..." for each file, it's difficult that we find lint errors. 

### What changes are included in this PR?

Suppress "Done ..." messages.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #46785