### PR TITLE
GH-46788: [C++][Parquet] Enable SIMD for byte stream split with 2 streams

### DIFF
--- a/cpp/src/arrow/util/byte_stream_split_internal.h
+++ b/cpp/src/arrow/util/byte_stream_split_internal.h
@@ -431,6 +431,10 @@ template <int kNumStreams>
 void inline ByteStreamSplitDecodeSimd(const uint8_t* data, int width, int64_t num_values,
                                       int64_t stride, uint8_t* out) {
 #  if defined(ARROW_HAVE_AVX2)
+  // Not implemented
+  if constexpr (kNumStreams == 2) {
+    return ByteStreamSplitDecodeSimd128<2>(data, width, num_values, stride, out);
+  }
   return ByteStreamSplitDecodeAvx2<kNumStreams>(data, width, num_values, stride, out);
 #  elif defined(ARROW_HAVE_SSE4_2) || defined(ARROW_HAVE_NEON)
   return ByteStreamSplitDecodeSimd128<kNumStreams>(data, width, num_values, stride, out);
@@ -444,6 +448,11 @@ void inline ByteStreamSplitEncodeSimd(const uint8_t* raw_values, int width,
                                       const int64_t num_values,
                                       uint8_t* output_buffer_raw) {
 #  if defined(ARROW_HAVE_AVX2)
+  // Not implemented
+  if constexpr (kNumStreams == 2) {
+    return ByteStreamSplitEncodeSimd128<kNumStreams>(raw_values, width, num_values,
+                                                     output_buffer_raw);
+  }
   return ByteStreamSplitEncodeAvx2<kNumStreams>(raw_values, width, num_values,
                                                 output_buffer_raw);
 #  elif defined(ARROW_HAVE_SSE4_2) || defined(ARROW_HAVE_NEON)
@@ -602,7 +611,7 @@ inline void ByteStreamSplitEncode(const uint8_t* raw_values, int width,
       memcpy(out, raw_values, num_values);
       return;
     case 2:
-      return ByteStreamSplitEncodeSimd128<2>(raw_values, width, num_values, out);
+      return ByteStreamSplitEncodePerhapsSimd<2>(raw_values, width, num_values, out);
     case 4:
       return ByteStreamSplitEncodePerhapsSimd<4>(raw_values, width, num_values, out);
     case 8:
@@ -626,7 +635,7 @@ inline void ByteStreamSplitDecode(const uint8_t* data, int width, int64_t num_va
       memcpy(out, data, num_values);
       return;
     case 2:
-      return ByteStreamSplitDecodeSimd128<2>(data, width, num_values, stride, out);
+      return ByteStreamSplitDecodePerhapsSimd<2>(data, width, num_values, stride, out);
     case 4:
       return ByteStreamSplitDecodePerhapsSimd<4>(data, width, num_values, stride, out);
     case 8:

--- a/cpp/src/arrow/util/byte_stream_split_internal.h
+++ b/cpp/src/arrow/util/byte_stream_split_internal.h
@@ -355,12 +355,8 @@ template <int kNumStreams>
 void ByteStreamSplitEncodeAvx2(const uint8_t* raw_values, int width,
                                const int64_t num_values, uint8_t* output_buffer_raw) {
   assert(width == kNumStreams);
-  static_assert(kNumStreams == 4 || kNumStreams == 8, "Invalid number of streams.");
+  static_assert(kNumStreams == 4, "Invalid number of streams.");
   constexpr int kBlockSize = sizeof(__m256i) * kNumStreams;
-
-  if constexpr (kNumStreams == 8)  // Back to SSE, currently no path for double.
-    return ByteStreamSplitEncodeSimd128<kNumStreams>(raw_values, width, num_values,
-                                                     output_buffer_raw);
 
   const int64_t size = num_values * kNumStreams;
   if (size < kBlockSize)  // Back to SSE for small size
@@ -449,7 +445,7 @@ void inline ByteStreamSplitEncodeSimd(const uint8_t* raw_values, int width,
                                       uint8_t* output_buffer_raw) {
 #  if defined(ARROW_HAVE_AVX2)
   // Not implemented
-  if constexpr (kNumStreams == 2) {
+  if constexpr (kNumStreams == 2 || kNumStreams == 8) {
     return ByteStreamSplitEncodeSimd128<kNumStreams>(raw_values, width, num_values,
                                                      output_buffer_raw);
   } else {

--- a/cpp/src/arrow/util/byte_stream_split_internal.h
+++ b/cpp/src/arrow/util/byte_stream_split_internal.h
@@ -217,12 +217,12 @@ void ByteStreamSplitEncodeSimd128(const uint8_t* raw_values, int width,
     // We first make byte-level shuffling, until we have gather enough bytes together
     // and in the correct order to use a bigger data type.
     //
-    // clang-format off
-    // Stage 0: A0B0C0D0 A1B1C1D1 A2B2C2D2 A3B3C3D3 | A4B4C4D4 A5B5C5D5 A6B6C6D6 A7B7C7D7 | ...
-    // Stage 1: A0A4B0B4 C0C4D0D4 A1A5B1B5 C1C5D1D5 | A2A6B2B6 C2C6D2D6 A3A7B3B7 C3C7D3D7 | ...
-    // Stage 2: A0A2A4A6 B0B2B4B6 C0C2C4C6 D0D2D4D6 | A1A3A5A7 B1B3B5B7 C1C3C5C7 D1D3D5D7 | ...
-    // Stage 3: A0A1A2A3 A4A5A6A7 B0B1B2B3 B4B5B6B7 | C0C1C2C3 C4C5C6C7 D0D1D2D3 D4D5D6D7 | ...
-    // clang-format on
+    // Example with 32bit data on 128 bit register:
+    //
+    // 0: A0B0C0D0 A1B1C1D1 A2B2C2D2 A3B3C3D3 | A4B4C4D4 A5B5C5D5 A6B6C6D6 A7B7C7D7 | ...
+    // 1: A0A4B0B4 C0C4D0D4 A1A5B1B5 C1C5D1D5 | A2A6B2B6 C2C6D2D6 A3A7B3B7 C3C7D3D7 | ...
+    // 2: A0A2A4A6 B0B2B4B6 C0C2C4C6 D0D2D4D6 | A1A3A5A7 B1B3B5B7 C1C3C5C7 D1D3D5D7 | ...
+    // 3: A0A1A2A3 A4A5A6A7 B0B1B2B3 B4B5B6B7 | C0C1C2C3 C4C5C6C7 D0D1D2D3 D4D5D6D7 | ...
     //
     // The shuffling of bytes is performed through the unpack intrinsics.
     // In my measurements this gives better performance then an implementation
@@ -241,11 +241,10 @@ void ByteStreamSplitEncodeSimd128(const uint8_t* raw_values, int width,
     // We know have the bytes packed in a larger data type and in the correct order to
     // start using a bigger data type
     //
-    // Example run for 32-bit variables it's int64_t with NumBytes=8 bytes:
+    // Example with 32bit data on 128 bit register.
+    // The large data type is int64_t with NumBytes=8 bytes:
     //
-    // clang-format off
-    // Stage 4: A0A1A2A3 A4A5A6A7 A8A9AAAB ACADAEAF | B0B1B2B3 B4B5B6B7 B8B9BABB BCBDBEBF | ...
-    // clang-format on
+    // 4: A0A1A2A3 A4A5A6A7 A8A9AAAB ACADAEAF | B0B1B2B3 B4B5B6B7 B8B9BABB BCBDBEBF | ...
     constexpr int kNumStreamsHalf = kNumStreams / 2;
     for (int step = NumStepsByte; step < NumSteps; ++step) {
       for (int i = 0; i < kNumStreamsHalf; ++i) {

--- a/cpp/src/arrow/util/byte_stream_split_internal.h
+++ b/cpp/src/arrow/util/byte_stream_split_internal.h
@@ -199,13 +199,13 @@ void ByteStreamSplitEncodeSimd128(const uint8_t* raw_values, int width,
   constexpr int kNumStepsLarge =
       ReversePow2(static_cast<int>(simd_batch::size) / kNumBytes);
   // Total number of steps
-  constexpr int NumSteps = kNumStepsByte + kNumStepsLarge;
+  constexpr int kNumSteps = kNumStepsByte + kNumStepsLarge;
 
   // Two step shuffling algorithm that starts with bytes and ends with a larger data type.
   // An algorithm similar to the decoding one with log2(simd_batch::size) + 1 stages is
   // also valid but not as performant.
   for (int64_t block_index = 0; block_index < num_blocks; ++block_index) {
-    simd_batch stage[NumSteps + 1][kNumStreams];
+    simd_batch stage[kNumSteps + 1][kNumStreams];
 
     // First copy the data to stage 0.
     for (int i = 0; i < kNumStreams; ++i) {
@@ -245,7 +245,7 @@ void ByteStreamSplitEncodeSimd128(const uint8_t* raw_values, int width,
     //
     // 4: A0A1A2A3 A4A5A6A7 A8A9AAAB ACADAEAF | B0B1B2B3 B4B5B6B7 B8B9BABB BCBDBEBF | ...
     constexpr int kNumStreamsHalf = kNumStreams / 2;
-    for (int step = kNumStepsByte; step < NumSteps; ++step) {
+    for (int step = kNumStepsByte; step < kNumSteps; ++step) {
       for (int i = 0; i < kNumStreamsHalf; ++i) {
         stage[step + 1][i * 2] =
             zip_lo_n<kNumBytes>(stage[step][i], stage[step][i + kNumStreamsHalf]);
@@ -257,7 +257,7 @@ void ByteStreamSplitEncodeSimd128(const uint8_t* raw_values, int width,
     // Save the encoded data to the output buffer
     for (int i = 0; i < kNumStreams; ++i) {
       xsimd::store_unaligned(&output_buffer_streams[i][block_index * simd_batch::size],
-                             stage[NumSteps][i]);
+                             stage[kNumSteps][i]);
     }
   }
 }

--- a/cpp/src/arrow/util/byte_stream_split_internal.h
+++ b/cpp/src/arrow/util/byte_stream_split_internal.h
@@ -85,10 +85,10 @@ void ByteStreamSplitDecodeSimd128(const uint8_t* data, int width, int64_t num_va
   // Stage 1: AAAA BBBB CCCC DDDD
   // Stage 2: ACAC ACAC BDBD BDBD
   // Stage 3: ABCD ABCD ABCD ABCD
-  simd_batch stage[kNumStreamsLog2 + 1][kNumStreams];
   constexpr int kNumStreamsHalf = kNumStreams / 2U;
 
   for (int64_t i = 0; i < num_blocks; ++i) {
+    simd_batch stage[kNumStreamsLog2 + 1][kNumStreams];
     for (int j = 0; j < kNumStreams; ++j) {
       stage[0][j] = simd_batch::load_unaligned(&data[i * simd_batch::size + j * stride]);
     }

--- a/cpp/src/arrow/util/byte_stream_split_internal.h
+++ b/cpp/src/arrow/util/byte_stream_split_internal.h
@@ -197,7 +197,8 @@ void ByteStreamSplitEncodeSimd128(const uint8_t* raw_values, int width,
   // Number of steps in the first part of the algorithm with byte-level zipping
   constexpr int NumStepsByte = ReversePow2(NumValuesInBatch) + 1;
   // Number of steps in the first part of the algorithm with large data type zipping
-  constexpr int NumStepsLarge = ReversePow2(static_cast<int>(sizeof(simd_batch)) / NumBytes);
+  constexpr int NumStepsLarge =
+      ReversePow2(static_cast<int>(sizeof(simd_batch)) / NumBytes);
   // Total number of steps
   constexpr int NumSteps = NumStepsByte + NumStepsLarge;
 

--- a/cpp/src/arrow/util/byte_stream_split_internal.h
+++ b/cpp/src/arrow/util/byte_stream_split_internal.h
@@ -433,8 +433,9 @@ void inline ByteStreamSplitDecodeSimd(const uint8_t* data, int width, int64_t nu
   // Not implemented
   if constexpr (kNumStreams == 2) {
     return ByteStreamSplitDecodeSimd128<2>(data, width, num_values, stride, out);
+  } else {
+    return ByteStreamSplitDecodeAvx2<kNumStreams>(data, width, num_values, stride, out);
   }
-  return ByteStreamSplitDecodeAvx2<kNumStreams>(data, width, num_values, stride, out);
 #  elif defined(ARROW_HAVE_SSE4_2) || defined(ARROW_HAVE_NEON)
   return ByteStreamSplitDecodeSimd128<kNumStreams>(data, width, num_values, stride, out);
 #  else
@@ -451,9 +452,10 @@ void inline ByteStreamSplitEncodeSimd(const uint8_t* raw_values, int width,
   if constexpr (kNumStreams == 2) {
     return ByteStreamSplitEncodeSimd128<kNumStreams>(raw_values, width, num_values,
                                                      output_buffer_raw);
+  } else {
+    return ByteStreamSplitEncodeAvx2<kNumStreams>(raw_values, width, num_values,
+                                                  output_buffer_raw);
   }
-  return ByteStreamSplitEncodeAvx2<kNumStreams>(raw_values, width, num_values,
-                                                output_buffer_raw);
 #  elif defined(ARROW_HAVE_SSE4_2) || defined(ARROW_HAVE_NEON)
   return ByteStreamSplitEncodeSimd128<kNumStreams>(raw_values, width, num_values,
                                                    output_buffer_raw);

--- a/cpp/src/arrow/util/byte_stream_split_internal.h
+++ b/cpp/src/arrow/util/byte_stream_split_internal.h
@@ -197,7 +197,7 @@ void ByteStreamSplitEncodeSimd128(const uint8_t* raw_values, int width,
   // Number of steps in the first part of the algorithm with byte-level zipping
   constexpr int NumStepsByte = ReversePow2(NumValuesInBatch) + 1;
   // Number of steps in the first part of the algorithm with large data type zipping
-  constexpr int NumStepsLarge = ReversePow2(sizeof(simd_batch) / NumBytes);
+  constexpr int NumStepsLarge = ReversePow2(static_cast<int>(sizeof(simd_batch)) / NumBytes);
   // Total number of steps
   constexpr int NumSteps = NumStepsByte + NumStepsLarge;
 

--- a/cpp/src/arrow/util/byte_stream_split_test.cc
+++ b/cpp/src/arrow/util/byte_stream_split_test.cc
@@ -136,7 +136,7 @@ class TestByteStreamSplitSpecialized : public ::testing::Test {
     return input;
   }
 
-  template <bool kSimdImplemented = (kWidth == 4 || kWidth == 8)>
+  template <bool kSimdImplemented = (kWidth == 2 || kWidth == 4 || kWidth == 8)>
   static std::vector<DecodeFunc> MakeDecodeFuncs() {
     std::vector<DecodeFunc> funcs;
     funcs.push_back({"scalar_dynamic", &ByteStreamSplitDecodeScalarDynamic});
@@ -146,7 +146,10 @@ class TestByteStreamSplitSpecialized : public ::testing::Test {
       funcs.push_back({"simd", &ByteStreamSplitDecodeSimd<kWidth>});
       funcs.push_back({"simd128", &ByteStreamSplitDecodeSimd128<kWidth>});
 #  if defined(ARROW_HAVE_AVX2)
-      funcs.push_back({"avx2", &ByteStreamSplitDecodeAvx2<kWidth>});
+      // The only available implementations
+      if constexpr (kWidth == 4 || kWidth == 8) {
+        funcs.push_back({"avx2", &ByteStreamSplitDecodeAvx2<kWidth>});
+      }
 #  endif
     }
 #endif  // defined(ARROW_HAVE_SIMD_SPLIT)
@@ -164,7 +167,10 @@ class TestByteStreamSplitSpecialized : public ::testing::Test {
       funcs.push_back({"simd", &ByteStreamSplitEncodeSimd<kWidth>});
       funcs.push_back({"simd128", &ByteStreamSplitEncodeSimd128<kWidth>});
 #  if defined(ARROW_HAVE_AVX2)
-      funcs.push_back({"avx2", &ByteStreamSplitEncodeAvx2<kWidth>});
+      // The only available implementation
+      if constexpr (kWidth == 4) {
+        funcs.push_back({"avx2", &ByteStreamSplitEncodeAvx2<kWidth>});
+      }
 #  endif
     }
 #endif  // defined(ARROW_HAVE_SIMD_SPLIT)

--- a/cpp/src/arrow/util/type_traits.h
+++ b/cpp/src/arrow/util/type_traits.h
@@ -42,5 +42,32 @@ template <typename T>
 struct is_null_pointer : std::is_same<std::nullptr_t, typename std::remove_cv<T>::type> {
 };
 
+template <int kNumBytes>
+struct SizedIntImpl;
+
+template <>
+struct SizedIntImpl<1> {
+  using type = int8_t;
+};
+
+template <>
+struct SizedIntImpl<2> {
+  using type = int16_t;
+};
+
+template <>
+struct SizedIntImpl<4> {
+  using type = int32_t;
+};
+
+template <>
+struct SizedIntImpl<8> {
+  using type = int64_t;
+};
+
+// Map a number of bytes to a type
+template <int kNumBytes>
+using SizedInt = typename SizedIntImpl<kNumBytes>::type;
+
 }  // namespace internal
 }  // namespace arrow

--- a/cpp/src/parquet/encoding_benchmark.cc
+++ b/cpp/src/parquet/encoding_benchmark.cc
@@ -510,7 +510,7 @@ BENCHMARK(BM_ByteStreamSplitEncode_Double_Scalar)->Apply(ByteStreamSplitApply);
 
 #if defined(ARROW_HAVE_SSE4_2)
 static void BM_ByteStreamSplitDecode_Int16_Sse2(benchmark::State& state) {
-  BM_ByteStreamSplitDecode<float>(
+  BM_ByteStreamSplitDecode<int16_t>(
       state, ::arrow::util::internal::ByteStreamSplitDecodeSimd128<sizeof(int16_t)>);
 }
 
@@ -525,7 +525,7 @@ static void BM_ByteStreamSplitDecode_Double_Sse2(benchmark::State& state) {
 }
 
 static void BM_ByteStreamSplitEncode_Int16_Sse2(benchmark::State& state) {
-  BM_ByteStreamSplitEncode<float>(
+  BM_ByteStreamSplitEncode<int16_t>(
       state, ::arrow::util::internal::ByteStreamSplitEncodeSimd128<sizeof(int16_t)>);
 }
 
@@ -549,7 +549,7 @@ BENCHMARK(BM_ByteStreamSplitEncode_Double_Sse2)->Apply(ByteStreamSplitApply);
 
 #if defined(ARROW_HAVE_AVX2)
 static void BM_ByteStreamSplitDecode_Int16_Avx2(benchmark::State& state) {
-  BM_ByteStreamSplitDecode<float>(
+  BM_ByteStreamSplitDecode<int16_t>(
       state, ::arrow::util::internal::ByteStreamSplitDecodeAvx2<sizeof(int16_t)>);
 }
 
@@ -564,7 +564,7 @@ static void BM_ByteStreamSplitDecode_Double_Avx2(benchmark::State& state) {
 }
 
 static void BM_ByteStreamSplitEncode_Int16_Avx2(benchmark::State& state) {
-  BM_ByteStreamSplitEncode<float>(
+  BM_ByteStreamSplitEncode<int16_t>(
       state, ::arrow::util::internal::ByteStreamSplitEncodeAvx2<sizeof(int16_t)>);
 }
 

--- a/cpp/src/parquet/encoding_benchmark.cc
+++ b/cpp/src/parquet/encoding_benchmark.cc
@@ -548,11 +548,6 @@ BENCHMARK(BM_ByteStreamSplitEncode_Double_Sse2)->Apply(ByteStreamSplitApply);
 #endif
 
 #if defined(ARROW_HAVE_AVX2)
-static void BM_ByteStreamSplitDecode_Int16_Avx2(benchmark::State& state) {
-  BM_ByteStreamSplitDecode<int16_t>(
-      state, ::arrow::util::internal::ByteStreamSplitDecodeAvx2<sizeof(int16_t)>);
-}
-
 static void BM_ByteStreamSplitDecode_Float_Avx2(benchmark::State& state) {
   BM_ByteStreamSplitDecode<float>(
       state, ::arrow::util::internal::ByteStreamSplitDecodeAvx2<sizeof(float)>);
@@ -563,27 +558,14 @@ static void BM_ByteStreamSplitDecode_Double_Avx2(benchmark::State& state) {
       state, ::arrow::util::internal::ByteStreamSplitDecodeAvx2<sizeof(double)>);
 }
 
-static void BM_ByteStreamSplitEncode_Int16_Avx2(benchmark::State& state) {
-  BM_ByteStreamSplitEncode<int16_t>(
-      state, ::arrow::util::internal::ByteStreamSplitEncodeAvx2<sizeof(int16_t)>);
-}
-
 static void BM_ByteStreamSplitEncode_Float_Avx2(benchmark::State& state) {
   BM_ByteStreamSplitEncode<float>(
       state, ::arrow::util::internal::ByteStreamSplitEncodeAvx2<sizeof(float)>);
 }
 
-static void BM_ByteStreamSplitEncode_Double_Avx2(benchmark::State& state) {
-  BM_ByteStreamSplitEncode<double>(
-      state, ::arrow::util::internal::ByteStreamSplitEncodeAvx2<sizeof(double)>);
-}
-
-BENCHMARK(BM_ByteStreamSplitDecode_Int16_Avx2)->Apply(ByteStreamSplitApply);
 BENCHMARK(BM_ByteStreamSplitDecode_Float_Avx2)->Apply(ByteStreamSplitApply);
 BENCHMARK(BM_ByteStreamSplitDecode_Double_Avx2)->Apply(ByteStreamSplitApply);
-BENCHMARK(BM_ByteStreamSplitEncode_Int16_Avx2)->Apply(ByteStreamSplitApply);
 BENCHMARK(BM_ByteStreamSplitEncode_Float_Avx2)->Apply(ByteStreamSplitApply);
-BENCHMARK(BM_ByteStreamSplitEncode_Double_Avx2)->Apply(ByteStreamSplitApply);
 #endif
 
 #if defined(ARROW_HAVE_NEON)

--- a/cpp/src/parquet/encoding_benchmark.cc
+++ b/cpp/src/parquet/encoding_benchmark.cc
@@ -19,6 +19,7 @@
 
 #include <array>
 #include <cmath>
+#include <cstdint>
 #include <limits>
 #include <random>
 
@@ -508,6 +509,11 @@ BENCHMARK(BM_ByteStreamSplitEncode_Float_Scalar)->Apply(ByteStreamSplitApply);
 BENCHMARK(BM_ByteStreamSplitEncode_Double_Scalar)->Apply(ByteStreamSplitApply);
 
 #if defined(ARROW_HAVE_SSE4_2)
+static void BM_ByteStreamSplitDecode_Int16_Sse2(benchmark::State& state) {
+  BM_ByteStreamSplitDecode<float>(
+      state, ::arrow::util::internal::ByteStreamSplitDecodeSimd128<sizeof(int16_t)>);
+}
+
 static void BM_ByteStreamSplitDecode_Float_Sse2(benchmark::State& state) {
   BM_ByteStreamSplitDecode<float>(
       state, ::arrow::util::internal::ByteStreamSplitDecodeSimd128<sizeof(float)>);
@@ -516,6 +522,11 @@ static void BM_ByteStreamSplitDecode_Float_Sse2(benchmark::State& state) {
 static void BM_ByteStreamSplitDecode_Double_Sse2(benchmark::State& state) {
   BM_ByteStreamSplitDecode<double>(
       state, ::arrow::util::internal::ByteStreamSplitDecodeSimd128<sizeof(double)>);
+}
+
+static void BM_ByteStreamSplitEncode_Int16_Sse2(benchmark::State& state) {
+  BM_ByteStreamSplitEncode<float>(
+      state, ::arrow::util::internal::ByteStreamSplitEncodeSimd128<sizeof(int16_t)>);
 }
 
 static void BM_ByteStreamSplitEncode_Float_Sse2(benchmark::State& state) {
@@ -528,13 +539,20 @@ static void BM_ByteStreamSplitEncode_Double_Sse2(benchmark::State& state) {
       state, ::arrow::util::internal::ByteStreamSplitEncodeSimd128<sizeof(double)>);
 }
 
+BENCHMARK(BM_ByteStreamSplitDecode_Int16_Sse2)->Apply(ByteStreamSplitApply);
 BENCHMARK(BM_ByteStreamSplitDecode_Float_Sse2)->Apply(ByteStreamSplitApply);
 BENCHMARK(BM_ByteStreamSplitDecode_Double_Sse2)->Apply(ByteStreamSplitApply);
+BENCHMARK(BM_ByteStreamSplitEncode_Int16_Sse2)->Apply(ByteStreamSplitApply);
 BENCHMARK(BM_ByteStreamSplitEncode_Float_Sse2)->Apply(ByteStreamSplitApply);
 BENCHMARK(BM_ByteStreamSplitEncode_Double_Sse2)->Apply(ByteStreamSplitApply);
 #endif
 
 #if defined(ARROW_HAVE_AVX2)
+static void BM_ByteStreamSplitDecode_Int16_Avx2(benchmark::State& state) {
+  BM_ByteStreamSplitDecode<float>(
+      state, ::arrow::util::internal::ByteStreamSplitDecodeAvx2<sizeof(int16_t)>);
+}
+
 static void BM_ByteStreamSplitDecode_Float_Avx2(benchmark::State& state) {
   BM_ByteStreamSplitDecode<float>(
       state, ::arrow::util::internal::ByteStreamSplitDecodeAvx2<sizeof(float)>);
@@ -543,6 +561,11 @@ static void BM_ByteStreamSplitDecode_Float_Avx2(benchmark::State& state) {
 static void BM_ByteStreamSplitDecode_Double_Avx2(benchmark::State& state) {
   BM_ByteStreamSplitDecode<double>(
       state, ::arrow::util::internal::ByteStreamSplitDecodeAvx2<sizeof(double)>);
+}
+
+static void BM_ByteStreamSplitEncode_Int16_Avx2(benchmark::State& state) {
+  BM_ByteStreamSplitEncode<float>(
+      state, ::arrow::util::internal::ByteStreamSplitEncodeAvx2<sizeof(int16_t)>);
 }
 
 static void BM_ByteStreamSplitEncode_Float_Avx2(benchmark::State& state) {
@@ -555,13 +578,20 @@ static void BM_ByteStreamSplitEncode_Double_Avx2(benchmark::State& state) {
       state, ::arrow::util::internal::ByteStreamSplitEncodeAvx2<sizeof(double)>);
 }
 
+BENCHMARK(BM_ByteStreamSplitDecode_Int16_Avx2)->Apply(ByteStreamSplitApply);
 BENCHMARK(BM_ByteStreamSplitDecode_Float_Avx2)->Apply(ByteStreamSplitApply);
 BENCHMARK(BM_ByteStreamSplitDecode_Double_Avx2)->Apply(ByteStreamSplitApply);
+BENCHMARK(BM_ByteStreamSplitEncode_Int16_Avx2)->Apply(ByteStreamSplitApply);
 BENCHMARK(BM_ByteStreamSplitEncode_Float_Avx2)->Apply(ByteStreamSplitApply);
 BENCHMARK(BM_ByteStreamSplitEncode_Double_Avx2)->Apply(ByteStreamSplitApply);
 #endif
 
 #if defined(ARROW_HAVE_NEON)
+static void BM_ByteStreamSplitDecode_Int16_Neon(benchmark::State& state) {
+  BM_ByteStreamSplitDecode<int16_t>(
+      state, ::arrow::util::internal::ByteStreamSplitDecodeSimd128<sizeof(int16_t)>);
+}
+
 static void BM_ByteStreamSplitDecode_Float_Neon(benchmark::State& state) {
   BM_ByteStreamSplitDecode<float>(
       state, ::arrow::util::internal::ByteStreamSplitDecodeSimd128<sizeof(float)>);
@@ -570,6 +600,11 @@ static void BM_ByteStreamSplitDecode_Float_Neon(benchmark::State& state) {
 static void BM_ByteStreamSplitDecode_Double_Neon(benchmark::State& state) {
   BM_ByteStreamSplitDecode<double>(
       state, ::arrow::util::internal::ByteStreamSplitDecodeSimd128<sizeof(double)>);
+}
+
+static void BM_ByteStreamSplitEncode_Int16_Neon(benchmark::State& state) {
+  BM_ByteStreamSplitEncode<int16_t>(
+      state, ::arrow::util::internal::ByteStreamSplitEncodeSimd128<sizeof(int16_t)>);
 }
 
 static void BM_ByteStreamSplitEncode_Float_Neon(benchmark::State& state) {
@@ -582,8 +617,10 @@ static void BM_ByteStreamSplitEncode_Double_Neon(benchmark::State& state) {
       state, ::arrow::util::internal::ByteStreamSplitEncodeSimd128<sizeof(double)>);
 }
 
+BENCHMARK(BM_ByteStreamSplitDecode_Int16_Neon)->Range(MIN_RANGE, MAX_RANGE);
 BENCHMARK(BM_ByteStreamSplitDecode_Float_Neon)->Range(MIN_RANGE, MAX_RANGE);
 BENCHMARK(BM_ByteStreamSplitDecode_Double_Neon)->Range(MIN_RANGE, MAX_RANGE);
+BENCHMARK(BM_ByteStreamSplitEncode_Int16_Neon)->Range(MIN_RANGE, MAX_RANGE);
 BENCHMARK(BM_ByteStreamSplitEncode_Float_Neon)->Range(MIN_RANGE, MAX_RANGE);
 BENCHMARK(BM_ByteStreamSplitEncode_Double_Neon)->Range(MIN_RANGE, MAX_RANGE);
 #endif


### PR DESCRIPTION
### Rationale for this change
Performance improvements for split stream encoding with two streams.
`f16` are often used in machine learning for instance.

### What changes are included in this PR?
- `ByteStreamSplitDecodeSimd128` was a straightforward beneficial change.
- `ByteStreamSplitEncodeSimd128` was significantly refactor to make it more generic. With the new implementation, we can investigate merging it with the `avx2` version.
### Are these changes tested?
Yes with existing tests.

### Are there any user-facing changes?
No.

* GitHub Issue: #46788