### PR TITLE
GH-46787: [CI][Integration] Use Node.js 20

### DIFF
--- a/ci/docker/conda-integration.dockerfile
+++ b/ci/docker/conda-integration.dockerfile
@@ -21,7 +21,7 @@ FROM ${repo}:${arch}-conda-cpp
 
 ARG arch=amd64
 ARG maven=3.8.7
-ARG node=16
+ARG node=20
 ARG yarn=1.22
 ARG jdk=11
 


### PR DESCRIPTION
### Rationale for this change

Node.js 18 reached EOL on 2025-04-30: https://github.com/nodejs/release#release-schedule

### What changes are included in this PR?

Use Node.js 20.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #46787