### PR TITLE
GH-46794: [CI][Dev] Fix shellcheck errors in the ci/scripts/csharp_test.sh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -305,6 +305,7 @@ repos:
           ?^ci/scripts/cpp_test\.sh$|
           ?^ci/scripts/csharp_build\.sh$|
           ?^ci/scripts/csharp_pack\.sh$|
+          ?^ci/scripts/csharp_test\.sh$|
           ?^ci/scripts/download_tz_database\.sh$|
           ?^ci/scripts/install_azurite\.sh$|
           ?^ci/scripts/install_ccache\.sh$|

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -305,7 +305,6 @@ repos:
           ?^ci/scripts/cpp_test\.sh$|
           ?^ci/scripts/csharp_build\.sh$|
           ?^ci/scripts/csharp_pack\.sh$|
-          ?^ci/scripts/csharp_test\.sh$|
           ?^ci/scripts/download_tz_database\.sh$|
           ?^ci/scripts/install_azurite\.sh$|
           ?^ci/scripts/install_ccache\.sh$|

--- a/ci/scripts/csharp_test.sh
+++ b/ci/scripts/csharp_test.sh
@@ -30,8 +30,9 @@ if [ -z "${PYTHON}" ]; then
   fi
 fi
 ${PYTHON} -m pip install pyarrow find-libpython
-export PYTHONNET_PYDLL=$(${PYTHON} -m find_libpython)
+PYTHONNET_PYDLL=$(${PYTHON} -m find_libpython)
+export PYTHONNET_PYDLL
 
-pushd ${source_dir}
+pushd "${source_dir}"
 dotnet test
 popd

--- a/ci/scripts/csharp_test.sh
+++ b/ci/scripts/csharp_test.sh
@@ -31,8 +31,6 @@ if [ -z "${PYTHON}" ]; then
 fi
 ${PYTHON} -m pip install pyarrow find-libpython
 PYTHONNET_PYDLL=$(${PYTHON} -m find_libpython)
-echo "PYTHON is: $PYTHON"
-echo "find_libpython output: \"$(${PYTHON} -m find_libpython)\""
 export PYTHONNET_PYDLL
 
 pushd "${source_dir}"

--- a/ci/scripts/csharp_test.sh
+++ b/ci/scripts/csharp_test.sh
@@ -35,4 +35,3 @@ export PYTHONNET_PYDLL=$(${PYTHON} -m find_libpython)
 pushd ${source_dir}
 dotnet test
 popd
-

--- a/ci/scripts/csharp_test.sh
+++ b/ci/scripts/csharp_test.sh
@@ -35,3 +35,4 @@ export PYTHONNET_PYDLL=$(${PYTHON} -m find_libpython)
 pushd ${source_dir}
 dotnet test
 popd
+

--- a/ci/scripts/csharp_test.sh
+++ b/ci/scripts/csharp_test.sh
@@ -31,6 +31,8 @@ if [ -z "${PYTHON}" ]; then
 fi
 ${PYTHON} -m pip install pyarrow find-libpython
 PYTHONNET_PYDLL=$(${PYTHON} -m find_libpython)
+echo "PYTHON is: $PYTHON"
+echo "find_libpython output: \"$(${PYTHON} -m find_libpython)\""
 export PYTHONNET_PYDLL
 
 pushd "${source_dir}"

--- a/ci/scripts/csharp_test.sh
+++ b/ci/scripts/csharp_test.sh
@@ -30,9 +30,8 @@ if [ -z "${PYTHON}" ]; then
   fi
 fi
 ${PYTHON} -m pip install pyarrow find-libpython
-PYTHONNET_PYDLL=$(${PYTHON} -m find_libpython)
-export PYTHONNET_PYDLL
+export PYTHONNET_PYDLL=$(${PYTHON} -m find_libpython)
 
-pushd "${source_dir}"
+pushd ${source_dir}
 dotnet test
 popd


### PR DESCRIPTION
### Rationale for this change

This is the sub issue #44748.

* SC2155: Declare and assign separately to avoid masking return values.
* SC2086: Double quote to prevent globbing and word splitting.


```
shellcheck ci/scripts/csharp_test.sh

In ci/scripts/csharp_test.sh line 33:
export PYTHONNET_PYDLL=$(${PYTHON} -m find_libpython)
       ^-------------^ SC2155 (warning): Declare and assign separately to avoid masking return values.


In ci/scripts/csharp_test.sh line 35:
pushd ${source_dir}
      ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
pushd "${source_dir}"

For more information:
  https://www.shellcheck.net/wiki/SC2155 -- Declare and assign separately to ...
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
```

### What changes are included in this PR?

* Declare and assign a variable separately.
* Quoting like `"${source_dir}"`

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #46794