### PR TITLE
GH-46798: [CI][Dev] Add support for pre-commit 2.17.0

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -41,7 +41,8 @@ jobs:
 
   lint:
     name: Lint C++, Python, R, Docker, RAT
-    runs-on: ubuntu-24.04
+    # Use Ubuntu 22.04 to ensure working pre-commit on Ubuntu 22.04.
+    runs-on: ubuntu-22.04
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     timeout-minutes: 15
     steps:
@@ -49,15 +50,13 @@ jobs:
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
         with:
           fetch-depth: 0
-      - name: Setup Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
-        with:
-          python-version: 3.12
-      - uses: r-lib/actions/setup-r@bd49c52ffe281809afa6f0fecbf37483c5dd0b93 # v2.11.3
       - name: Install pre-commit
         run: |
-          python -m pip install pre-commit
-          pre-commit run --show-diff-on-failure --color=always
+          sudo apt update
+          sudo apt install -y -V \
+            pre-commit \
+            r-cran-xml2 \
+            ruby-dev
       - name: Cache pre-commit
         uses: actions/cache@v4
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -357,7 +357,10 @@ repos:
           ?^swift/gen-protobuffers\.sh$|
           )
   - repo: https://github.com/scop/pre-commit-shfmt
-    rev: v3.11.0-1
+    # v3.11.0-1 or later requires pre-commit 3.2.0 or later but Ubuntu
+    # 22.04 ships pre-commit 2.17.0. We can use update this rev after
+    # Ubuntu 22.04 reached EOL (June 2027).
+    rev: v3.10.0-1
     hooks:
       - id: shfmt
         alias: shell


### PR DESCRIPTION
### Rationale for this change

Ubuntu 22.04 ships pre-commit 2.17.0. So we should support pre-commit 2.17.0 for easy to develop.

### What changes are included in this PR?

* Use a bit older shfmt pre-commit configuration for pre-commit 2.17.0
* Use Ubuntu 22.04 on CI to ensure working on Ubuntu 22.04

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #46798