### PR TITLE
GH-46801: [Dev] Remove some leftovers for Java, Go, JS and Swift on some config files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -50,15 +50,6 @@ indent_style = space
 indent_size = 2
 indent_style = space
 
-[*.go]
-indent_size = 8
-indent_style = tab
-tab_width = 8
-
-[*.{js,ts}]
-indent_size = 4
-indent_style = space
-
 [*.{py,pyx,pxd,pxi}]
 indent_size = 4
 indent_style = space

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -34,16 +34,12 @@
 /cpp/src/arrow/flight/ @lidavidm
 /cpp/src/parquet @wgtmac
 /csharp/ @curthagenlocher
-/go/ @zeroshade
-/java/ @lidavidm
-/js/ @domoritz @trxcllnt
 /matlab/ @kevingurney @kou @sgilmore10
 /python/ @AlenkaF @raulcd @rok 
 /python/pyarrow/_flight.pyx @lidavidm
 /python/pyarrow/**/*gandiva* @wjones127
 /r/ @jonkeane @thisisnic
 /ruby/ @kou
-/swift/ @kou
 
 # Docs
 # /docs/

--- a/.github/workflows/dev_pr/labeler.yml
+++ b/.github/workflows/dev_pr/labeler.yml
@@ -30,16 +30,6 @@
   - any-glob-to-any-file:
     - csharp/**/*
 
-"Component: Go":
-- changed-files:
-  - any-glob-to-any-file:
-    - go/**/*
-
-"Component: JavaScript":
-- changed-files:
-  - any-glob-to-any-file:
-    - js/**/*
-
 "Component: MATLAB":
 - changed-files:
   - any-glob-to-any-file:
@@ -59,11 +49,6 @@
 - changed-files:
   - any-glob-to-any-file:
     - ruby/**/*
-
-"Component: Swift":
-- changed-files:
-  - any-glob-to-any-file:
-    - swift/**/*
 
 "Component: FlightRPC":
 - changed-files:


### PR DESCRIPTION
### Rationale for this change

The config for Java, Go, JS and Swift on those files is not relevant anymore.

### What changes are included in this PR?

Remove references for those implementations from labeler, codeowners and editorconfig files.

### Are these changes tested?

No

### Are there any user-facing changes?

No

* GitHub Issue: #46801