### PR TITLE
GH-46809: [CI][Packaging] Stop trying to add headers from arrow/compu…

### DIFF
--- a/dev/tasks/linux-packages/apache-arrow/yum/arrow.spec.in
+++ b/dev/tasks/linux-packages/apache-arrow/yum/arrow.spec.in
@@ -320,7 +320,6 @@ Libraries and header files for Apache Arrow C++.
 %{_datadir}/gdb/auto-load/
 %{_includedir}/arrow/
 %exclude %{_includedir}/arrow/acero/
-%exclude %{_includedir}/arrow/compute/kernels
 %exclude %{_includedir}/arrow/compute/row
 %exclude %{_includedir}/arrow/dataset/
 %if %{use_flight}
@@ -363,7 +362,6 @@ Libraries and header files for Apache Arrow Compute
 %defattr(-,root,root,-)
 %doc README.md
 %license LICENSE.txt NOTICE.txt
-%{_includedir}/arrow/compute/kernels
 %{_includedir}/arrow/compute/row
 %{_libdir}/cmake/ArrowCompute/
 %{_libdir}/libarrow_compute.a


### PR DESCRIPTION
### Rationale for this change

The PR to split the Arrow compute kernels into its own shared library had some headers at arrow/compute/kernels during development. Those were moved to arrow/compute on this commit:
https://github.com/apache/arrow/pull/46261/commits/1d90aeb9c370f8e258fcd5c55648845ad189cb99

We missed to update the RPM packages in the interim as there are no public headers to be installed anymore from `arrow/compute/kernels`

### What changes are included in this PR?

Stop trying to include or exclude `/arrow/compute/kernels` headers on RPM package

### Are these changes tested?

Yes, via archery

### Are there any user-facing changes?

No

* GitHub Issue: #46809