### PR TITLE
GH-46805: [CI][Dev] Fix caching for R hooks in lint job

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -63,7 +63,7 @@ jobs:
           path: |
             ~/.cache/pre-commit
             ~/.local/share/renv/cache
-          key: pre-commit-v2-${{ hashFiles('.pre-commit-config.yaml') }}
+          key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
       - name: Run pre-commit
         run: |
           pre-commit run --all-files --color=always --show-diff-on-failure

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -62,8 +62,8 @@ jobs:
         with:
           path: |
             ~/.cache/pre-commit
-            ~/local/share/renv/cache
-          key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+            ~/.local/share/renv/cache
+          key: pre-commit-v2-${{ hashFiles('.pre-commit-config.yaml') }}
       - name: Run pre-commit
         run: |
           pre-commit run --all-files --color=always --show-diff-on-failure

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -55,7 +55,7 @@ jobs:
           sudo apt update
           sudo apt install -y -V \
             pre-commit \
-            r-cran-xml2 \
+            r-base \
             ruby-dev
       - name: Cache pre-commit
         uses: actions/cache@v4

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -60,7 +60,9 @@ jobs:
       - name: Cache pre-commit
         uses: actions/cache@v4
         with:
-          path: ~/.cache/pre-commit
+          path: |
+            ~/.cache/pre-commit
+            ~/local/share/renv/cache
           key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
       - name: Run pre-commit
         run: |


### PR DESCRIPTION
### Rationale for this change
The lint job is failing, because of the R hooks missing packages. This happens because the library of the environment symlinks the R packages from the separate `renv` cache in `.local`.

### What changes are included in this PR?
- also cache renv cache
- only install r-base (saves ~30s) as we need to install all required packages through renv anyway

### Are these changes tested?
CI

### Are there any user-facing changes?
CI no longer :x:

* GitHub Issue: #46805