### PR TITLE
GH-46816: [Docs] Fix links to Swift docs and source

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Major components of the project include:
  - [R libraries](https://github.com/apache/arrow/tree/main/r)
  - [Ruby libraries](https://github.com/apache/arrow/tree/main/ruby)
  - [Rust libraries](https://github.com/apache/arrow-rs) `↗`
+ - [Swift libraries](https://github.com/apache/arrow-swift) `↗`
 
 The `↗` icon denotes that this component of the project is maintained in a separate
 repository.

--- a/docs/source/implementations.rst
+++ b/docs/source/implementations.rst
@@ -71,8 +71,8 @@ documentation and source code for these libraries.
      - `Rust Docs <https://docs.rs/arrow/latest>`_ :fa:`external-link-alt`
      - `Rust Source <https://github.com/apache/arrow-rs>`_
    * - Swift
-     - `Swift Docs <https://github.com/apache/arrow/blob/main/swift/Arrow/README.md>`_ :fa:`external-link-alt`
-     - `Swift Source <https://github.com/apache/arrow/tree/main/swift>`_
+     - `Swift Docs <https://github.com/apache/arrow-swift/blob/main/Arrow/README.md>`_ :fa:`external-link-alt`
+     - `Swift Source <https://github.com/apache/arrow-swift>`_
 
 In addition to the libraries listed above, the Arrow project hosts the
 **nanoarrow** subproject which provides a set of lightweight libraries
@@ -121,6 +121,6 @@ The source files for the Cookbook are maintained in the
    R <https://arrow.apache.org/docs/r>
    Ruby <https://github.com/apache/arrow/blob/main/ruby/README.md>
    Rust <https://docs.rs/crate/arrow/>
-   Swift <https://github.com/apache/arrow/blob/main/swift/Arrow/README.md>
+   Swift <https://github.com/apache/arrow-swift/blob/main/Arrow/README.md>
    nanoarrow <https://arrow.apache.org/nanoarrow/>
    Implementation Status <status>


### PR DESCRIPTION
Closes #46816
* GitHub Issue: #46816