### PR TITLE
GH-46818: [Docs][C++] Add missing method description in type.h

### DIFF
--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -1019,7 +1019,7 @@ class ARROW_EXPORT DecimalType : public FixedSizeBinaryType {
   /// The decimal precision is a positive integer smaller or equal
   /// than the concrete decimal's type `kMaxPrecision`.
   int32_t precision() const { return precision_; }
-  /// \brief Returns the scale
+  /// \brief Return the number of digits after the decimal point "."
   int32_t scale() const { return scale_; }
 
   /// \brief Returns the number of bytes needed for precision.
@@ -1342,18 +1342,29 @@ class ARROW_EXPORT MapType : public ListType {
 
   explicit MapType(std::shared_ptr<Field> value_field, bool keys_sorted = false);
 
-  /// Validating constructor
+  /// \brief Constructs a MapType, which is a logical type representing a map of key-value
+  /// pairs.
+  ///
+  /// value_field is a Field containing a StructType with exactly two fields.
+  ///
+  /// * The StructType field itself must not be nullable.
+  /// * The first field represents the map key and must not be nullable.
+  /// * The second field represents the map item and may be nullable.
+  ///
+  /// \param[in] value_field StructType with exactly two fields(key,item)
+  /// \param[in] keys_sorted The keys for each map item should appear in sorted order in
+  /// the map data.
   static Result<std::shared_ptr<DataType>> Make(std::shared_ptr<Field> value_field,
                                                 bool keys_sorted = false);
 
-  /// \brief Returns the key field
+  /// \brief Returns the field representing the map key.
   std::shared_ptr<Field> key_field() const { return value_type()->field(0); }
-  /// \brief Returns the key type
+  /// \brief Returns the data type of the map key.
   std::shared_ptr<DataType> key_type() const { return key_field()->type(); }
 
-  /// \brief Returns the item field
+  /// \brief Returns the field representing the item.
   std::shared_ptr<Field> item_field() const { return value_type()->field(1); }
-  /// \brief Returns the item type
+  /// \brief Returns the data type of the item.
   std::shared_ptr<DataType> item_type() const { return item_field()->type(); }
 
   std::string ToString(bool show_metadata = false) const override;
@@ -1401,7 +1412,7 @@ class ARROW_EXPORT FixedSizeListType : public BaseListType {
 
   std::string name() const override { return "fixed_size_list"; }
 
-  /// \brief Returns the list size
+  /// TODO: (DOC) \brief Returns the list size
   int32_t list_size() const { return list_size_; }
 
  protected:
@@ -1525,7 +1536,7 @@ class ARROW_EXPORT SparseUnionType : public UnionType {
 
   SparseUnionType(FieldVector fields, std::vector<int8_t> type_codes);
 
-  /// A constructor variant that validates input parameters
+  /// TODO: (DOC) A constructor variant that validates input parameters
   static Result<std::shared_ptr<DataType>> Make(FieldVector fields,
                                                 std::vector<int8_t> type_codes);
 
@@ -1554,7 +1565,7 @@ class ARROW_EXPORT DenseUnionType : public UnionType {
 
   DenseUnionType(FieldVector fields, std::vector<int8_t> type_codes);
 
-  /// A constructor variant that validates input parameters
+  /// TODO: (DOC)  A constructor variant that validates input parameters
   static Result<std::shared_ptr<DataType>> Make(FieldVector fields,
                                                 std::vector<int8_t> type_codes);
 
@@ -1577,9 +1588,9 @@ class ARROW_EXPORT RunEndEncodedType : public NestedType {
     return DataTypeLayout({DataTypeLayout::AlwaysNull()});
   }
 
-  /// \brief Returns the run-end encoded type
+  /// TODO: (DOC)  \brief Returns the run-end encoded type
   const std::shared_ptr<DataType>& run_end_type() const { return fields()[0]->type(); }
-  /// \brief Returns the run-end encoded value type
+  /// TODO: (DOC)  \brief Returns the run-end encoded value type
   const std::shared_ptr<DataType>& value_type() const { return fields()[1]->type(); }
 
   std::string ToString(bool show_metadata = false) const override;
@@ -1794,7 +1805,7 @@ class ARROW_EXPORT IntervalType : public TemporalType, public ParametricType {
  public:
   enum type { MONTHS, DAY_TIME, MONTH_DAY_NANO };
 
-  /// \brief Returns the interval type
+  /// TODO: (DOC) \brief Returns the interval type
   virtual type interval_type() const = 0;
 
  protected:
@@ -1929,7 +1940,7 @@ class ARROW_EXPORT DurationType : public TemporalType, public ParametricType {
   std::string ToString(bool show_metadata = false) const override;
   std::string name() const override { return "duration"; }
 
-  /// \brief Returns the unit
+  /// TODO: (DOC) \brief Returns the unit
   TimeUnit::type unit() const { return unit_; }
 
  protected:
@@ -1956,7 +1967,7 @@ class ARROW_EXPORT DictionaryType : public FixedWidthType {
   DictionaryType(const std::shared_ptr<DataType>& index_type,
                  const std::shared_ptr<DataType>& value_type, bool ordered = false);
 
-  // A constructor variant that validates its input parameters
+  /// TODO: (DOC)  A constructor variant that validates its input parameters
   static Result<std::shared_ptr<DataType>> Make(
       const std::shared_ptr<DataType>& index_type,
       const std::shared_ptr<DataType>& value_type, bool ordered = false);
@@ -1968,12 +1979,12 @@ class ARROW_EXPORT DictionaryType : public FixedWidthType {
 
   DataTypeLayout layout() const override;
 
-  /// \brief Returns the index type
+  /// TODO: (DOC) \brief Returns the index type
   const std::shared_ptr<DataType>& index_type() const { return index_type_; }
-  /// \brief Returns the value type
+  /// TODO: (DOC) \brief Returns the value type
   const std::shared_ptr<DataType>& value_type() const { return value_type_; }
 
-  /// \brief Returns the ordered
+  /// TODO: (DOC) \brief Returns the ordered
   bool ordered() const { return ordered_; }
 
  protected:
@@ -2388,10 +2399,10 @@ class ARROW_EXPORT Schema : public detail::Fingerprintable,
   /// Return the ith schema element. Does not boundscheck
   const std::shared_ptr<Field>& field(int i) const;
 
-  /// \brief Returns fields
+  /// TODO: (DOC)  \brief Returns fields
   const FieldVector& fields() const;
 
-  /// \brief Returns field names
+  /// TODO: (DOC) \brief Returns field names
   std::vector<std::string> field_names() const;
 
   /// Returns null if name not found

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -1357,7 +1357,11 @@ class ARROW_EXPORT MapType : public ListType {
 
   std::string name() const override { return "map"; }
 
-  /// \brief Returns the keys sorted
+  /// \brief Return the keys_sorted flag
+  ///
+  /// If keys_sorted is true, then the keys for each map item should appear
+  /// in sorted order in the map data. If keys_sorted is false, then no assumption
+  /// can be made on keys order.
   bool keys_sorted() const { return keys_sorted_; }
 
  private:

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -1014,7 +1014,10 @@ class ARROW_EXPORT DecimalType : public FixedSizeBinaryType {
   static Result<std::shared_ptr<DataType>> Make(Type::type type_id, int32_t precision,
                                                 int32_t scale);
 
-  /// \brief Returns the precision
+  /// \brief Return the decimal precision
+  ///
+  /// The decimal precision is a positive integer smaller or equal
+  /// than the concrete decimal's type `kMaxPrecision`.
   int32_t precision() const { return precision_; }
   /// \brief Returns the scale
   int32_t scale() const { return scale_; }

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -1014,7 +1014,9 @@ class ARROW_EXPORT DecimalType : public FixedSizeBinaryType {
   static Result<std::shared_ptr<DataType>> Make(Type::type type_id, int32_t precision,
                                                 int32_t scale);
 
+  /// \brief Returns the precision
   int32_t precision() const { return precision_; }
+  /// \brief Returns the scale
   int32_t scale() const { return scale_; }
 
   /// \brief Returns the number of bytes needed for precision.
@@ -1337,20 +1339,25 @@ class ARROW_EXPORT MapType : public ListType {
 
   explicit MapType(std::shared_ptr<Field> value_field, bool keys_sorted = false);
 
-  // Validating constructor
+  /// Validating constructor
   static Result<std::shared_ptr<DataType>> Make(std::shared_ptr<Field> value_field,
                                                 bool keys_sorted = false);
 
+  /// \brief Returns the key field
   std::shared_ptr<Field> key_field() const { return value_type()->field(0); }
+  /// \brief Returns the key type
   std::shared_ptr<DataType> key_type() const { return key_field()->type(); }
 
+  /// \brief Returns the item field
   std::shared_ptr<Field> item_field() const { return value_type()->field(1); }
+  /// \brief Returns the item type
   std::shared_ptr<DataType> item_type() const { return item_field()->type(); }
 
   std::string ToString(bool show_metadata = false) const override;
 
   std::string name() const override { return "map"; }
 
+  /// \brief Returns the keys sorted
   bool keys_sorted() const { return keys_sorted_; }
 
  private:
@@ -1387,6 +1394,7 @@ class ARROW_EXPORT FixedSizeListType : public BaseListType {
 
   std::string name() const override { return "fixed_size_list"; }
 
+  /// \brief Returns the list size
   int32_t list_size() const { return list_size_; }
 
  protected:
@@ -1471,8 +1479,10 @@ class ARROW_EXPORT UnionType : public NestedType {
   /// An array mapping logical type ids to physical child ids.
   const std::vector<int>& child_ids() const { return child_ids_; }
 
+  /// \brief Returns the max type code
   uint8_t max_type_code() const;
 
+  /// \brief Returns the mode
   UnionMode::type mode() const;
 
  protected:
@@ -1508,7 +1518,7 @@ class ARROW_EXPORT SparseUnionType : public UnionType {
 
   SparseUnionType(FieldVector fields, std::vector<int8_t> type_codes);
 
-  // A constructor variant that validates input parameters
+  /// A constructor variant that validates input parameters
   static Result<std::shared_ptr<DataType>> Make(FieldVector fields,
                                                 std::vector<int8_t> type_codes);
 
@@ -1537,7 +1547,7 @@ class ARROW_EXPORT DenseUnionType : public UnionType {
 
   DenseUnionType(FieldVector fields, std::vector<int8_t> type_codes);
 
-  // A constructor variant that validates input parameters
+  /// A constructor variant that validates input parameters
   static Result<std::shared_ptr<DataType>> Make(FieldVector fields,
                                                 std::vector<int8_t> type_codes);
 
@@ -1560,13 +1570,16 @@ class ARROW_EXPORT RunEndEncodedType : public NestedType {
     return DataTypeLayout({DataTypeLayout::AlwaysNull()});
   }
 
+  /// \brief Returns the run-end encoded type
   const std::shared_ptr<DataType>& run_end_type() const { return fields()[0]->type(); }
+  /// \brief Returns the run-end encoded value type
   const std::shared_ptr<DataType>& value_type() const { return fields()[1]->type(); }
 
   std::string ToString(bool show_metadata = false) const override;
 
   std::string name() const override { return "run_end_encoded"; }
 
+  /// \brief Returns run-end encoded type is valid
   static bool RunEndTypeValid(const DataType& run_end_type);
 
  private:
@@ -1599,6 +1612,7 @@ class ARROW_EXPORT TemporalType : public FixedWidthType {
 /// \brief Base type class for date data
 class ARROW_EXPORT DateType : public TemporalType {
  public:
+  /// \brief Returns the unit
   virtual DateUnit unit() const = 0;
 
  protected:
@@ -1773,6 +1787,7 @@ class ARROW_EXPORT IntervalType : public TemporalType, public ParametricType {
  public:
   enum type { MONTHS, DAY_TIME, MONTH_DAY_NANO };
 
+  /// \brief Returns the interval type
   virtual type interval_type() const = 0;
 
  protected:
@@ -1907,6 +1922,7 @@ class ARROW_EXPORT DurationType : public TemporalType, public ParametricType {
   std::string ToString(bool show_metadata = false) const override;
   std::string name() const override { return "duration"; }
 
+  /// \brief Returns the unit
   TimeUnit::type unit() const { return unit_; }
 
  protected:
@@ -1945,9 +1961,12 @@ class ARROW_EXPORT DictionaryType : public FixedWidthType {
 
   DataTypeLayout layout() const override;
 
+  /// \brief Returns the index type
   const std::shared_ptr<DataType>& index_type() const { return index_type_; }
+  /// \brief Returns the value type
   const std::shared_ptr<DataType>& value_type() const { return value_type_; }
 
+  /// \brief Returns the ordered
   bool ordered() const { return ordered_; }
 
  protected:
@@ -2362,8 +2381,10 @@ class ARROW_EXPORT Schema : public detail::Fingerprintable,
   /// Return the ith schema element. Does not boundscheck
   const std::shared_ptr<Field>& field(int i) const;
 
+  /// \brief Returns fields
   const FieldVector& fields() const;
 
+  /// \brief Returns field names
   std::vector<std::string> field_names() const;
 
   /// Returns null if name not found


### PR DESCRIPTION
### Rationale for this change

This is the sub issue #46808

Since EXTRACT_ALL is set YES in Doxygen, I expect that methods without comments will also be included in the API Doc, but some methods are not documented.

For example `FixedSizeListType::list_size`

### What changes are included in this PR?

Add missing method description in the `type.h` file

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #46818