### PR TITLE
GH-46820: [CI][Integration] Use Node.js 20 by default

### DIFF
--- a/.env
+++ b/.env
@@ -65,7 +65,7 @@ KARTOTHEK=latest
 # LLVM 12 and GCC 11 reports -Wmismatched-new-delete.
 LLVM=18
 MAVEN=3.8.7
-NODE=18
+NODE=20
 NUMBA=latest
 NUMPY=latest
 PANDAS=latest

--- a/ci/docker/conda-integration.dockerfile
+++ b/ci/docker/conda-integration.dockerfile
@@ -20,10 +20,12 @@ ARG arch=amd64
 FROM ${repo}:${arch}-conda-cpp
 
 ARG arch=amd64
+# We need to synchronize the following values with the values in .env
+# and services.conda-integration in docker-compose.yml.
 ARG maven=3.8.7
 ARG node=20
 ARG yarn=1.22
-ARG jdk=11
+ARG jdk=17
 
 # Install Archery and integration dependencies
 COPY ci/conda_env_archery.txt /arrow/ci/

--- a/ci/scripts/integration_arrow.sh
+++ b/ci/scripts/integration_arrow.sh
@@ -27,7 +27,7 @@ gold_dir=$arrow_dir/testing/data/arrow-ipc-stream/integration
 : ${ARROW_INTEGRATION_CPP:=ON}
 : ${ARROW_INTEGRATION_CSHARP:=ON}
 
-: ${ARCHERY_INTEGRATION_TARGET_IMPLEMENTATIONS:=cpp,csharp,js}
+: ${ARCHERY_INTEGRATION_TARGET_IMPLEMENTATIONS:=cpp,csharp}
 export ARCHERY_INTEGRATION_TARGET_IMPLEMENTATIONS
 
 . ${arrow_dir}/ci/scripts/util_log.sh


### PR DESCRIPTION
### Rationale for this change

We're using `NODE=XX` in `.env` as the default Node.js version.

### What changes are included in this PR?

Use `NODE=20` in `.env`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #46820