### PR TITLE
GH-46609: [Release][CI] Use System GTest for macos verification

### DIFF
--- a/dev/archery/archery/integration/datagen.py
+++ b/dev/archery/archery/integration/datagen.py
@@ -609,9 +609,9 @@ class BinaryField(PrimitiveField):
 
         sizes = self._random_sizes(size)
 
-        for i, nbytes in enumerate(sizes):
+        for i, np_nbytes in enumerate(sizes):
             if is_valid[i]:
-                values.append(random_bytes(nbytes))
+                values.append(random_bytes(int(np_nbytes)))
             else:
                 values.append(b"")
 

--- a/dev/archery/archery/integration/datagen.py
+++ b/dev/archery/archery/integration/datagen.py
@@ -611,6 +611,9 @@ class BinaryField(PrimitiveField):
 
         for i, np_nbytes in enumerate(sizes):
             if is_valid[i]:
+                # We have to cast to int because Python 3.13.4 has a bug
+                # on random_bytes. See the comment here:
+                # https://github.com/apache/arrow/pull/46823#issuecomment-2979376852
                 values.append(random_bytes(int(np_nbytes)))
             else:
                 values.append(b"")

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -512,15 +512,6 @@ test_and_install_cpp() {
     ARROW_BUILD_TESTS=ON
   fi
 
-  case "$(uname)" in
-     Linux)
-      GTest_SOURCE=BUNDLED
-      ;;
-    Darwin)
-      GTest_SOURCE=SYSTEM
-      ;;
-  esac
-
   cmake \
     -DARROW_BOOST_USE_SHARED=ON \
     -DARROW_BUILD_EXAMPLES=OFF \
@@ -557,7 +548,7 @@ test_and_install_cpp() {
     -DCMAKE_INSTALL_LIBDIR=lib \
     -DCMAKE_INSTALL_PREFIX=$ARROW_HOME \
     -DCMAKE_UNITY_BUILD=${CMAKE_UNITY_BUILD:-OFF} \
-    -DGTest_SOURCE=${GTest_SOURCE} \
+    -DGTest_SOURCE=${GTest_SOURCE:-BUNDLED} \
     -DPARQUET_BUILD_EXAMPLES=ON \
     -DPARQUET_BUILD_EXECUTABLES=ON \
     -DPARQUET_REQUIRE_ENCRYPTION=ON \

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -512,6 +512,15 @@ test_and_install_cpp() {
     ARROW_BUILD_TESTS=ON
   fi
 
+  case "$(uname)" in
+     Linux)
+      GTest_SOURCE=BUNDLED
+      ;;
+    Darwin)
+      GTest_SOURCE=SYSTEM
+      ;;
+  esac
+
   cmake \
     -DARROW_BOOST_USE_SHARED=ON \
     -DARROW_BUILD_EXAMPLES=OFF \
@@ -548,7 +557,7 @@ test_and_install_cpp() {
     -DCMAKE_INSTALL_LIBDIR=lib \
     -DCMAKE_INSTALL_PREFIX=$ARROW_HOME \
     -DCMAKE_UNITY_BUILD=${CMAKE_UNITY_BUILD:-OFF} \
-    -DGTest_SOURCE=BUNDLED \
+    -DGTest_SOURCE=${GTest_SOURCE} \
     -DPARQUET_BUILD_EXAMPLES=ON \
     -DPARQUET_BUILD_EXECUTABLES=ON \
     -DPARQUET_REQUIRE_ENCRYPTION=ON \

--- a/dev/tasks/verify-rc/github.macos.yml
+++ b/dev/tasks/verify-rc/github.macos.yml
@@ -89,6 +89,8 @@ jobs:
           PYTHON_VERSION: "3.12"
           {% endif %}
           USE_CONDA: 1
+        {% else %}
+          GTest_SOURCE: SYSTEM
         {% endif %}
         run: |
           arrow/dev/release/verify-release-candidate.sh {{ release|default("") }} {{ rc|default("") }}


### PR DESCRIPTION
### Rationale for this change

Our system GoogleTest (installed by Homebrew) and the bundled GoogleTest are mixed and we get some CI failures.

### What changes are included in this PR?

Use the system GoogleTest on our verification CI jobs for macOS.
The PR also contains a minor fix on gendata due to a small bug on a Python version.

### Are these changes tested?

Yes, via archery.

### Are there any user-facing changes?

No

* GitHub Issue: #46609