### PR TITLE
GH-46827: [C++] Update Meson Configuration for compute shared lib

### DIFF
--- a/cpp/src/arrow/acero/meson.build
+++ b/cpp/src/arrow/acero/meson.build
@@ -80,12 +80,12 @@ arrow_acero_srcs = [
 arrow_acero_lib = library(
     'arrow-acero',
     sources: arrow_acero_srcs,
-    dependencies: [arrow_dep],
+    dependencies: [arrow_dep, arrow_compute_dep],
 )
 
 arrow_acero_dep = declare_dependency(link_with: [arrow_acero_lib])
 
-arrow_acero_testing_sources = ['test_nodes.cc', 'test_util_internal.cc'] + arrow_compute_testing_srcs
+arrow_acero_testing_sources = ['test_nodes.cc', 'test_util_internal.cc']
 
 arrow_acero_tests = {
     'plan-test': {'sources': ['plan_test.cc', 'test_nodes_test.cc']},
@@ -110,7 +110,7 @@ foreach key, val : arrow_acero_tests
     exc = executable(
         'arrow-acero-@0@'.format(key),
         sources: val['sources'] + arrow_acero_testing_sources,
-        dependencies: [arrow_acero_dep, arrow_test_dep],
+        dependencies: [arrow_acero_dep, arrow_compute_test_dep],
     )
     test(key, exc)
 endforeach
@@ -133,7 +133,19 @@ foreach key, val : arrow_acero_benchmarks
     exc = executable(
         key,
         sources: val['sources'] + arrow_acero_testing_sources,
-        dependencies: [arrow_acero_dep, arrow_benchmark_dep, gmock_dep],
+        dependencies: [
+            arrow_acero_dep,
+            arrow_compute_test_dep,
+            arrow_benchmark_dep,
+            gmock_dep,
+        ],
     )
     benchmark(key, exc)
 endforeach
+
+pkg.generate(
+    filebase: 'arrow-acero',
+    name: 'Apache Arrow Acero Engine',
+    description: 'Apache Arrow\'s Acero Engine',
+    requires: ['arrow', 'arrow-compute'],
+)

--- a/cpp/src/arrow/acero/meson.build
+++ b/cpp/src/arrow/acero/meson.build
@@ -80,7 +80,7 @@ arrow_acero_srcs = [
 arrow_acero_lib = library(
     'arrow-acero',
     sources: arrow_acero_srcs,
-    dependencies: [arrow_dep, arrow_compute_dep],
+    dependencies: [arrow_compute_dep, arrow_dep],
 )
 
 arrow_acero_dep = declare_dependency(link_with: [arrow_acero_lib])
@@ -147,5 +147,5 @@ pkg.generate(
     filebase: 'arrow-acero',
     name: 'Apache Arrow Acero Engine',
     description: 'Apache Arrow\'s Acero Engine',
-    requires: ['arrow', 'arrow-compute'],
+    requires: ['arrow-compute'],
 )

--- a/cpp/src/arrow/c/meson.build
+++ b/cpp/src/arrow/c/meson.build
@@ -15,10 +15,16 @@
 # specific language governing permissions and limitations
 # under the License.
 
+if needs_compute
+    arrow_c_bridge_deps = [arrow_compute_test_dep]
+else
+    arrow_c_bridge_deps = []
+endif
+
 exc = executable(
     'arrow-c-bridge-test',
     sources: ['bridge_test.cc'],
-    dependencies: [arrow_test_dep],
+    dependencies: arrow_c_bridge_deps,
 )
 test('arrow-c-bridge-test', exc)
 

--- a/cpp/src/arrow/compute/CMakeLists.txt
+++ b/cpp/src/arrow/compute/CMakeLists.txt
@@ -50,7 +50,7 @@ if(ARROW_TESTING AND ARROW_COMPUTE)
   # arrow_compute_core_testing so that is also included correctly
   target_link_libraries(arrow_compute_testing
                         PUBLIC $<TARGET_OBJECTS:arrow_compute_core_testing>
-                        PUBLIC ${ARROW_GTEST_GTEST_MAIN})
+                        PUBLIC ${ARROW_GTEST_GTEST})
 endif()
 
 set(ARROW_COMPUTE_TEST_PREFIX "arrow-compute")

--- a/cpp/src/arrow/compute/CMakeLists.txt
+++ b/cpp/src/arrow/compute/CMakeLists.txt
@@ -48,7 +48,7 @@ if(ARROW_TESTING AND ARROW_COMPUTE)
   add_library(arrow_compute_testing OBJECT ${ARROW_COMPUTE_TESTING_SRCS})
   # Even though this is still just an object library we still need to "link"
   # arrow_compute_core_testing so that is also included correctly
-  if(WIN32)
+  if(WIN32 AND (CMAKE_SIZEOF_VOID_P EQUAL 4))
     target_link_libraries(arrow_compute_testing
                           PUBLIC $<TARGET_OBJECTS:arrow_compute_core_testing>
                           PUBLIC ${ARROW_GTEST_GTEST_MAIN})

--- a/cpp/src/arrow/compute/CMakeLists.txt
+++ b/cpp/src/arrow/compute/CMakeLists.txt
@@ -48,9 +48,16 @@ if(ARROW_TESTING AND ARROW_COMPUTE)
   add_library(arrow_compute_testing OBJECT ${ARROW_COMPUTE_TESTING_SRCS})
   # Even though this is still just an object library we still need to "link"
   # arrow_compute_core_testing so that is also included correctly
-  target_link_libraries(arrow_compute_testing
-                        PUBLIC $<TARGET_OBJECTS:arrow_compute_core_testing>
-                        PUBLIC ${ARROW_GTEST_GTEST})
+  if(WIN32)
+    target_link_libraries(arrow_compute_testing
+                          PUBLIC $<TARGET_OBJECTS:arrow_compute_core_testing>
+                          PUBLIC ${ARROW_GTEST_GTEST_MAIN})
+  else()
+    target_link_libraries(arrow_compute_testing
+                          PUBLIC $<TARGET_OBJECTS:arrow_compute_core_testing>
+                          PUBLIC ${ARROW_GTEST_GTEST})
+  endif()
+
 endif()
 
 set(ARROW_COMPUTE_TEST_PREFIX "arrow-compute")

--- a/cpp/src/arrow/compute/kernels/meson.build
+++ b/cpp/src/arrow/compute/kernels/meson.build
@@ -26,16 +26,10 @@ endif
 
 exc = executable(
     'arrow-scalar-cast-test',
-    sources: ['scalar_cast_test.cc'] + arrow_compute_testing_srcs + kernel_testing_srcs,
-    dependencies: [arrow_test_dep],
+    sources: ['scalar_cast_test.cc'] + kernel_testing_srcs,
+    dependencies: [arrow_compute_test_dep],
 )
 test('arrow-scalar-cast-test', exc)
-
-if needs_compute
-    arrow_compute_test_dep = declare_dependency(dependencies: [arrow_test_dep])
-else
-    arrow_compute_test_dep = disabler()
-endif
 
 # ----------------------------------------------------------------------
 # Scalar kernels
@@ -71,7 +65,7 @@ scalar_kernel_tests = {
 foreach key, val : scalar_kernel_tests
     exc = executable(
         key,
-        sources: val['sources'] + arrow_compute_testing_srcs + kernel_testing_srcs,
+        sources: val['sources'] + kernel_testing_srcs,
         dependencies: [arrow_compute_test_dep],
     )
     test(key, exc)
@@ -126,7 +120,7 @@ vector_kernel_tests = {
 foreach key, val : vector_kernel_tests
     exc = executable(
         key,
-        sources: val['sources'] + arrow_compute_testing_srcs + kernel_testing_srcs,
+        sources: val['sources'] + kernel_testing_srcs,
         dependencies: [arrow_compute_test_dep],
     )
     test(key, exc)
@@ -157,7 +151,7 @@ endforeach
 # Aggregates
 exc = executable(
     'arrow-compute-aggregate-test',
-    sources: ['aggregate_test.cc'] + arrow_compute_testing_srcs + kernel_testing_srcs,
+    sources: ['aggregate_test.cc'] + kernel_testing_srcs,
     dependencies: [arrow_compute_test_dep, filesystem_dep],
 )
 test('arrow-compute-aggregate-test', exc)

--- a/cpp/src/arrow/compute/meson.build
+++ b/cpp/src/arrow/compute/meson.build
@@ -41,15 +41,48 @@ install_headers(
 if needs_compute
     pkg.generate(
         filebase: 'arrow-compute',
-        name: 'Apache Arrow Compute',
-        description: 'All compute kernels for Apache Arrow',
+        name: 'Apache Arrow Compute Kernels',
+        description: 'Apache Arrow\'s Compute Kernels',
         requires: ['arrow'],
     )
 endif
 
-arrow_compute_testing_srcs = []
+# Define arrow_compute_core_testing object library for common test files requiring
+# only core compute. No extra kernels are required.
 if needs_testing
-    arrow_compute_testing_srcs += files('test_util_internal.cc')
+    arrow_compute_core_test_lib = library(
+        'arrow-compute-core-testing',
+        sources: files('test_util_internal.cc'),
+        dependencies: arrow_test_dep,
+    )
+    arrow_compute_core_test_dep = declare_dependency(
+        link_with: arrow_compute_core_test_lib,
+    )
+else
+    arrow_compute_core_test_dep = disabler()
+endif
+
+# Define arrow_compute_testing object library for test files requiring extra kernels.
+if needs_testing and needs_compute
+    arrow_compute_testing_lib = library(
+        'arrow-compute-testing',
+        sources: files('test_env.cc'),
+        dependencies: [
+            arrow_compute_dep,
+            arrow_compute_core_test_dep,
+            arrow_test_dep_no_main,
+        ],
+    )
+    arrow_compute_test_dep = declare_dependency(
+        link_with: arrow_compute_testing_lib,
+        dependencies: [
+            arrow_compute_dep,
+            arrow_compute_core_test_dep,
+            arrow_test_dep_no_main,
+        ],
+    )
+else
+    arrow_compute_test_dep = disabler()
 endif
 
 exc = executable(
@@ -59,15 +92,13 @@ exc = executable(
         'exec_test.cc',
         'kernel_test.cc',
         'registry_test.cc',
-    ] + arrow_compute_testing_srcs,
-    dependencies: [arrow_test_dep],
+    ],
+    dependencies: [arrow_test_dep, arrow_compute_core_test_dep],
 )
 test('arrow-internals-test', exc)
 
 compute_tests = {
-    'arrow-compute-expression-test': {
-        'sources': ['expression_test.cc'] + arrow_compute_testing_srcs,
-    },
+    'arrow-compute-expression-test': {'sources': ['expression_test.cc']},
     'arrow-compute-row-test': {
         'sources': [
             'key_hash_test.cc',
@@ -77,7 +108,7 @@ compute_tests = {
             'row/row_encoder_internal_test.cc',
             'row/row_test.cc',
             'util_internal_test.cc',
-        ] + arrow_compute_testing_srcs,
+        ],
     },
 }
 
@@ -96,16 +127,14 @@ compute_tests = {
 #  - value_counts
 #
 # Also see: GH-34388, GH-34615
-if needs_compute
-    foreach key, val : compute_tests
-        exc = executable(
-            key,
-            sources: val['sources'],
-            dependencies: [arrow_test_dep],
-        )
-        test(key, exc)
-    endforeach
-endif
+foreach key, val : compute_tests
+    exc = executable(
+        key,
+        sources: val['sources'],
+        dependencies: [arrow_compute_test_dep],
+    )
+    test(key, exc)
+endforeach
 
 exc = executable(
     'arrow-compute-function-benchmark',

--- a/cpp/src/arrow/compute/meson.build
+++ b/cpp/src/arrow/compute/meson.build
@@ -93,7 +93,7 @@ exc = executable(
         'kernel_test.cc',
         'registry_test.cc',
     ],
-    dependencies: [arrow_test_dep, arrow_compute_core_test_dep],
+    dependencies: [arrow_compute_core_test_dep, arrow_test_dep],
 )
 test('arrow-internals-test', exc)
 

--- a/cpp/src/arrow/compute/row/meson.build
+++ b/cpp/src/arrow/compute/row/meson.build
@@ -24,6 +24,6 @@ if needs_compute
     exc = executable(
         'arrow-compute-grouper-benchmark',
         sources: ['grouper_benchmark.cc'],
-        dependencies: [arrow_benchmark_dep],
+        dependencies: [arrow_compute_dep, arrow_benchmark_dep],
     )
 endif

--- a/cpp/src/arrow/compute/test_env.cc
+++ b/cpp/src/arrow/compute/test_env.cc
@@ -34,9 +34,10 @@ class ComputeKernelEnvironment : public ::testing::Environment {
 };
 
 }  // namespace
-
-// Initialize the compute module
-::testing::Environment* compute_kernels_env =
-    ::testing::AddGlobalTestEnvironment(new ComputeKernelEnvironment);
-
 }  // namespace arrow::compute
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::AddGlobalTestEnvironment(new arrow::compute::ComputeKernelEnvironment);
+  return RUN_ALL_TESTS();
+}

--- a/cpp/src/arrow/compute/test_env.cc
+++ b/cpp/src/arrow/compute/test_env.cc
@@ -34,10 +34,19 @@ class ComputeKernelEnvironment : public ::testing::Environment {
 };
 
 }  // namespace
+
+#ifdef _WIN32
+// Initialize the compute module
+::testing::Environment* compute_kernels_env =
+    ::testing::AddGlobalTestEnvironment(new ComputeKernelEnvironment);
+#endif
+
 }  // namespace arrow::compute
 
+#ifndef _WIN32
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   ::testing::AddGlobalTestEnvironment(new arrow::compute::ComputeKernelEnvironment);
   return RUN_ALL_TESTS();
 }
+#endif

--- a/cpp/src/arrow/compute/test_env.cc
+++ b/cpp/src/arrow/compute/test_env.cc
@@ -35,7 +35,7 @@ class ComputeKernelEnvironment : public ::testing::Environment {
 
 }  // namespace
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(_WIN64)
 // Initialize the compute module
 ::testing::Environment* compute_kernels_env =
     ::testing::AddGlobalTestEnvironment(new ComputeKernelEnvironment);
@@ -43,7 +43,7 @@ class ComputeKernelEnvironment : public ::testing::Environment {
 
 }  // namespace arrow::compute
 
-#ifndef _WIN32
+#if !(defined(_WIN32) && !defined(_WIN64))
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   ::testing::AddGlobalTestEnvironment(new arrow::compute::ComputeKernelEnvironment);

--- a/cpp/src/arrow/meson.build
+++ b/cpp/src/arrow/meson.build
@@ -45,6 +45,38 @@ arrow_components = {
             'array/validate.cc',
         ],
     },
+    'arrow_compute': {
+        'sources': [
+            'compute/api_aggregate.cc',
+            'compute/api_scalar.cc',
+            'compute/api_vector.cc',
+            'compute/cast.cc',
+            'compute/exec.cc',
+            'compute/expression.cc',
+            'compute/function.cc',
+            'compute/function_internal.cc',
+            'compute/kernel.cc',
+            'compute/ordering.cc',
+            'compute/registry.cc',
+            'compute/kernels/chunked_internal.cc',
+            'compute/kernels/codegen_internal.cc',
+            'compute/kernels/ree_util_internal.cc',
+            'compute/kernels/scalar_cast_boolean.cc',
+            'compute/kernels/scalar_cast_dictionary.cc',
+            'compute/kernels/scalar_cast_extension.cc',
+            'compute/kernels/scalar_cast_internal.cc',
+            'compute/kernels/scalar_cast_nested.cc',
+            'compute/kernels/scalar_cast_numeric.cc',
+            'compute/kernels/scalar_cast_string.cc',
+            'compute/kernels/scalar_cast_temporal.cc',
+            'compute/kernels/util_internal.cc',
+            'compute/kernels/vector_hash.cc',
+            'compute/kernels/vector_selection.cc',
+            'compute/kernels/vector_selection_filter_internal.cc',
+            'compute/kernels/vector_selection_internal.cc',
+            'compute/kernels/vector_selection_take_internal.cc',
+        ],
+    },
     'arrow_io': {
         'sources': [
             'io/buffered.cc',
@@ -260,88 +292,6 @@ if needs_csv
     arrow_testing_srcs += ['csv/test_common.cc']
 endif
 
-arrow_compute_sources = [
-    'compute/api_aggregate.cc',
-    'compute/api_scalar.cc',
-    'compute/api_vector.cc',
-    'compute/cast.cc',
-    'compute/exec.cc',
-    'compute/expression.cc',
-    'compute/function.cc',
-    'compute/function_internal.cc',
-    'compute/kernel.cc',
-    'compute/ordering.cc',
-    'compute/registry.cc',
-    'compute/kernels/chunked_internal.cc',
-    'compute/kernels/codegen_internal.cc',
-    'compute/kernels/ree_util_internal.cc',
-    'compute/kernels/scalar_cast_boolean.cc',
-    'compute/kernels/scalar_cast_dictionary.cc',
-    'compute/kernels/scalar_cast_extension.cc',
-    'compute/kernels/scalar_cast_internal.cc',
-    'compute/kernels/scalar_cast_nested.cc',
-    'compute/kernels/scalar_cast_numeric.cc',
-    'compute/kernels/scalar_cast_string.cc',
-    'compute/kernels/scalar_cast_temporal.cc',
-    'compute/kernels/util_internal.cc',
-    'compute/kernels/vector_hash.cc',
-    'compute/kernels/vector_selection.cc',
-    'compute/kernels/vector_selection_filter_internal.cc',
-    'compute/kernels/vector_selection_internal.cc',
-    'compute/kernels/vector_selection_take_internal.cc',
-]
-
-if needs_compute
-    arrow_compute_sources += [
-        'compute/kernels/aggregate_basic.cc',
-        'compute/kernels/aggregate_mode.cc',
-        'compute/kernels/aggregate_pivot.cc',
-        'compute/kernels/aggregate_quantile.cc',
-        'compute/kernels/aggregate_tdigest.cc',
-        'compute/kernels/aggregate_var_std.cc',
-        'compute/kernels/hash_aggregate.cc',
-        'compute/kernels/hash_aggregate_numeric.cc',
-        'compute/kernels/hash_aggregate_pivot.cc',
-        'compute/kernels/pivot_internal.cc',
-        'compute/kernels/scalar_arithmetic.cc',
-        'compute/kernels/scalar_boolean.cc',
-        'compute/kernels/scalar_compare.cc',
-        'compute/kernels/scalar_if_else.cc',
-        'compute/kernels/scalar_nested.cc',
-        'compute/kernels/scalar_random.cc',
-        'compute/kernels/scalar_round.cc',
-        'compute/kernels/scalar_set_lookup.cc',
-        'compute/kernels/scalar_string_ascii.cc',
-        'compute/kernels/scalar_string_utf8.cc',
-        'compute/kernels/scalar_temporal_binary.cc',
-        'compute/kernels/scalar_temporal_unary.cc',
-        'compute/kernels/scalar_validity.cc',
-        'compute/kernels/vector_array_sort.cc',
-        'compute/kernels/vector_cumulative_ops.cc',
-        'compute/kernels/vector_nested.cc',
-        'compute/kernels/vector_pairwise.cc',
-        'compute/kernels/vector_rank.cc',
-        'compute/kernels/vector_replace.cc',
-        'compute/kernels/vector_run_end_encode.cc',
-        'compute/kernels/vector_select_k.cc',
-        'compute/kernels/vector_sort.cc',
-        'compute/kernels/vector_statistics.cc',
-        'compute/kernels/vector_swizzle.cc',
-        'compute/key_hash_internal.cc',
-        'compute/key_map_internal.cc',
-        'compute/light_array_internal.cc',
-        'compute/row/encode_internal.cc',
-        'compute/row/compare_internal.cc',
-        'compute/row/grouper.cc',
-        'compute/row/row_encoder_internal.cc',
-        'compute/row/row_internal.cc',
-        'compute/util.cc',
-        'compute/util_internal.cc',
-    ]
-endif
-
-arrow_components += {'arrow-compute': {'sources': arrow_compute_sources}}
-
 if needs_json or needs_integration
     rapidjson_dep = dependency('rapidjson', include_type: 'system')
 else
@@ -478,6 +428,71 @@ arrow_dep = declare_dependency(
     include_directories: [include_dir],
     link_with: arrow_lib,
 )
+
+if needs_compute
+    arrow_compute_lib_sources = [
+        'compute/initialize.cc',
+        'compute/kernels/aggregate_basic.cc',
+        'compute/kernels/aggregate_mode.cc',
+        'compute/kernels/aggregate_pivot.cc',
+        'compute/kernels/aggregate_quantile.cc',
+        'compute/kernels/aggregate_tdigest.cc',
+        'compute/kernels/aggregate_var_std.cc',
+        'compute/kernels/hash_aggregate.cc',
+        'compute/kernels/hash_aggregate_numeric.cc',
+        'compute/kernels/hash_aggregate_pivot.cc',
+        'compute/kernels/pivot_internal.cc',
+        'compute/kernels/scalar_arithmetic.cc',
+        'compute/kernels/scalar_boolean.cc',
+        'compute/kernels/scalar_compare.cc',
+        'compute/kernels/scalar_if_else.cc',
+        'compute/kernels/scalar_nested.cc',
+        'compute/kernels/scalar_random.cc',
+        'compute/kernels/scalar_round.cc',
+        'compute/kernels/scalar_set_lookup.cc',
+        'compute/kernels/scalar_string_ascii.cc',
+        'compute/kernels/scalar_string_utf8.cc',
+        'compute/kernels/scalar_temporal_binary.cc',
+        'compute/kernels/scalar_temporal_unary.cc',
+        'compute/kernels/scalar_validity.cc',
+        'compute/kernels/util_internal.cc',
+        'compute/kernels/vector_array_sort.cc',
+        'compute/kernels/vector_cumulative_ops.cc',
+        'compute/kernels/vector_nested.cc',
+        'compute/kernels/vector_pairwise.cc',
+        'compute/kernels/vector_rank.cc',
+        'compute/kernels/vector_replace.cc',
+        'compute/kernels/vector_run_end_encode.cc',
+        'compute/kernels/vector_select_k.cc',
+        'compute/kernels/vector_sort.cc',
+        'compute/kernels/vector_statistics.cc',
+        'compute/kernels/vector_swizzle.cc',
+        'compute/key_hash_internal.cc',
+        'compute/key_map_internal.cc',
+        'compute/light_array_internal.cc',
+        'compute/row/encode_internal.cc',
+        'compute/row/compare_internal.cc',
+        'compute/row/grouper.cc',
+        'compute/row/row_encoder_internal.cc',
+        'compute/row/row_internal.cc',
+        'compute/util.cc',
+        'compute/util_internal.cc',
+    ]
+
+    arrow_compute_lib = library(
+        'arrow-compute',
+        sources: arrow_compute_lib_sources,
+        dependencies: arrow_dep,
+        install: true,
+    )
+    arrow_compute_dep = declare_dependency(
+        link_with: arrow_compute_lib,
+        include_directories: include_dir,
+        dependencies: arrow_dep,
+    )
+else
+    arrow_compute_dep = disabler()
+endif
 
 # Meson does not allow you to glob for headers to install. See also
 # https://mesonbuild.com/FAQ.html#why-cant-i-specify-target-files-with-a-wildcard
@@ -696,8 +711,8 @@ pkg.generate(
 subdir('testing')
 
 subdir('array')
-subdir('c')
 subdir('compute')
+subdir('c')
 subdir('io')
 subdir('tensor')
 subdir('util')

--- a/cpp/subprojects/gtest.wrap
+++ b/cpp/subprojects/gtest.wrap
@@ -16,15 +16,15 @@
 # under the License.
 
 [wrap-file]
-directory = googletest-1.15.2
-source_url = https://github.com/google/googletest/archive/refs/tags/v1.15.2.tar.gz
-source_filename = gtest-1.15.2.tar.gz
-source_hash = 7b42b4d6ed48810c5362c265a17faebe90dc2373c885e5216439d37927f02926
-patch_filename = gtest_1.15.2-1_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/gtest_1.15.2-1/get_patch
-patch_hash = b41cba05fc61d47b2ba5bf95732eb86ce2b67303f291b68a9587b7563c318141
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/gtest_1.15.2-1/gtest-1.15.2.tar.gz
-wrapdb_version = 1.15.2-1
+directory = googletest-1.17.0
+source_url = https://github.com/google/googletest/archive/refs/tags/v1.17.0.tar.gz
+source_filename = googletest-1.17.0.tar.gz
+source_hash = 65fab701d9829d38cb77c14acdc431d2108bfdbf8979e40eb8ae567edf10b27c
+patch_filename = gtest_1.17.0-3_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/gtest_1.17.0-3/get_patch
+patch_hash = 3e2799683f27c6dce138b7bae823416581c467ddde755c9a516c0863225f0ceb
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/gtest_1.17.0-3/googletest-1.17.0.tar.gz
+wrapdb_version = 1.17.0-3
 
 [provide]
 gtest = gtest_dep


### PR DESCRIPTION
### Rationale for this change

The major factor of the compute sources in https://github.com/apache/arrow/pull/46261 addressed updates to the CMake configuration but not Meson. This is a follow up to get the Meson builds working again

### What changes are included in this PR?

Meson configuration files are updated to reflect new source structure. gtest has also been bumped to a new WrapDB version, which fixes some undefined behavior that was compounded by updates to the compute test structure

### Are these changes tested?

Yes

### Are there any user-facing changes?

No
* GitHub Issue: #46827