### PR TITLE
GH-46833: [Python] Expose ConfigureManagedIdentityCredential and ConfigureClientSecretCredential to AzureFileSystem on PyArrow

### DIFF
--- a/python/pyarrow/_azurefs.pyx
+++ b/python/pyarrow/_azurefs.pyx
@@ -108,9 +108,9 @@ cdef class AzureFileSystem(FileSystem):
         c_string client_secret
 
     def __init__(self, account_name, *, account_key=None, blob_storage_authority=None,
-                 dfs_storage_authority=None, blob_storage_scheme=None,
-                 dfs_storage_scheme=None, sas_token=None,
-                 tenant_id=None, client_id=None, client_secret=None):
+                 blob_storage_scheme=None, client_id=None, client_secret=None,
+                 dfs_storage_authority=None, dfs_storage_scheme=None,
+                 sas_token=None, tenant_id=None):
         cdef:
             CAzureOptions options
             shared_ptr[CAzureFileSystem] wrapped
@@ -178,11 +178,11 @@ cdef class AzureFileSystem(FileSystem):
                 account_name=frombytes(opts.account_name),
                 account_key=frombytes(self.account_key),
                 blob_storage_authority=frombytes(opts.blob_storage_authority),
-                dfs_storage_authority=frombytes(opts.dfs_storage_authority),
                 blob_storage_scheme=frombytes(opts.blob_storage_scheme),
+                client_id=frombytes(self.client_id),
+                client_secret=frombytes(self.client_secret),
+                dfs_storage_authority=frombytes(opts.dfs_storage_authority),
                 dfs_storage_scheme=frombytes(opts.dfs_storage_scheme),
                 sas_token=frombytes(self.sas_token),
-                tenant_id=frombytes(self.tenant_id),
-                client_id=frombytes(self.client_id),
-                client_secret=frombytes(self.client_secret)
+                tenant_id=frombytes(self.tenant_id)
             ),))

--- a/python/pyarrow/includes/libarrow_fs.pxd
+++ b/python/pyarrow/includes/libarrow_fs.pxd
@@ -254,6 +254,7 @@ cdef extern from "arrow/filesystem/api.h" namespace "arrow::fs" nogil:
         CStatus ConfigureDefaultCredential()
         CStatus ConfigureAccountKeyCredential(c_string account_key)
         CStatus ConfigureSASCredential(c_string sas_token)
+        CStatus ConfigureManagedIdentityCredential(c_string client_id)
         CStatus ConfigureClientSecretCredential(c_string tenant_id,
                                                 c_string client_id,
                                                 c_string client_secret)

--- a/python/pyarrow/includes/libarrow_fs.pxd
+++ b/python/pyarrow/includes/libarrow_fs.pxd
@@ -254,6 +254,9 @@ cdef extern from "arrow/filesystem/api.h" namespace "arrow::fs" nogil:
         CStatus ConfigureDefaultCredential()
         CStatus ConfigureAccountKeyCredential(c_string account_key)
         CStatus ConfigureSASCredential(c_string sas_token)
+        CStatus ConfigureClientSecretCredential(c_string tenant_id,
+                                                c_string client_id,
+                                                c_string client_secret)
 
     cdef cppclass CAzureFileSystem "arrow::fs::AzureFileSystem":
         @staticmethod

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -1496,20 +1496,6 @@ def test_azurefs_options(pickle_module):
     with pytest.raises(ValueError, match="client_id must be specified"):
         AzureFileSystem(
             account_name='fake-account-name',
-            tenant_id='fake-tenant-id',
-            client_secret='fake-client-secret'
-        )
-
-    ambiguous_msg = (
-        "Ambiguous Azure credential configuration: "
-        "You provided client_id and one of tenant_id or client_secret. "
-        "For ClientSecretCredential, provide tenant_id, client_id, and client_secret. "
-        "For ManagedIdentityCredential, provide only client_id."
-    )
-
-    with pytest.raises(ValueError, match="client_id must be specified"):
-        AzureFileSystem(
-            account_name='fake-account-name',
             tenant_id='fake-tenant-id'
         )
 
@@ -1519,7 +1505,13 @@ def test_azurefs_options(pickle_module):
             client_secret='fake-client-secret'
         )
 
-    with pytest.raises(ValueError, match=ambiguous_msg):
+    invalid_msg = (
+        "Invalid Azure credential configuration: "
+        "For ManagedIdentityCredential, provide only client_id. "
+        "For ClientSecretCredential, provide tenant_id, client_id, and client_secret."
+    )
+
+    with pytest.raises(ValueError, match=invalid_msg):
         AzureFileSystem(
             account_name='fake-account-name',
             client_id='fake-client-id',
@@ -1533,7 +1525,7 @@ def test_azurefs_options(pickle_module):
             client_secret='fake-client-secret'
         )
 
-    with pytest.raises(ValueError, match=ambiguous_msg):
+    with pytest.raises(ValueError, match=invalid_msg):
         AzureFileSystem(
             account_name='fake-account-name',
             tenant_id='fake-tenant-id',

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -1475,6 +1475,38 @@ def test_azurefs_options(pickle_module):
     assert pickle_module.loads(pickle_module.dumps(fs4)) == fs4
     assert fs4 != fs3
 
+    fs5 = AzureFileSystem(
+        account_name='fake-account-name',
+        tenant_id='fake-tenant-id',
+        client_id='fake-client-id',
+        client_secret='fake-client-secret'
+    )
+    assert isinstance(fs5, AzureFileSystem)
+    assert pickle_module.loads(pickle_module.dumps(fs5)) == fs5
+    assert fs5 != fs4
+
+    error_msg = "All of tenant_id, client_id, and client_secret must be provided"
+    with pytest.raises(ValueError, match=error_msg):
+        AzureFileSystem(
+            account_name='fake-account-name',
+            client_id='fake-client-id',
+            client_secret='fake-client-secret'
+        )
+
+    with pytest.raises(ValueError, match=error_msg):
+        AzureFileSystem(
+            account_name='fake-account-name',
+            tenant_id='fake-tenant-id',
+            client_secret='fake-client-secret'
+        )
+
+    with pytest.raises(ValueError, match=error_msg):
+        AzureFileSystem(
+            account_name='fake-account-name',
+            tenant_id='fake-tenant-id',
+            client_id='fake-client-id'
+        )
+
     with pytest.raises(ValueError):
         AzureFileSystem(account_name='fake-account-name', account_key='fakeaccount',
                         sas_token='fakesastoken')

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -1496,39 +1496,44 @@ def test_azurefs_options(pickle_module):
     with pytest.raises(ValueError, match="client_id must be specified"):
         AzureFileSystem(
             account_name='fake-account-name',
-            tenant_id=None,
-            client_secret=None
+            tenant_id='fake-tenant-id',
+            client_secret='fake-client-secret'
         )
 
-    error_msg1 = "Both of tenant_id and client_secret must be specified"
-    with pytest.raises(ValueError, match=error_msg1):
+    ambiguous_msg = (
+        "Ambiguous Azure credential configuration: "
+        "You provided client_id and one of tenant_id or client_secret. "
+        "For ClientSecretCredential, provide tenant_id, client_id, and client_secret. "
+        "For ManagedIdentityCredential, provide only client_id."
+    )
+
+    with pytest.raises(ValueError, match="client_id must be specified"):
         AzureFileSystem(
             account_name='fake-account-name',
             tenant_id='fake-tenant-id'
         )
 
-    with pytest.raises(ValueError, match=error_msg1):
+    with pytest.raises(ValueError, match="client_id must be specified"):
         AzureFileSystem(
             account_name='fake-account-name',
             client_secret='fake-client-secret'
         )
 
-    error_msg2 = "All of tenant_id, client_id, and client_secret must be provided"
-    with pytest.raises(ValueError, match=error_msg2):
+    with pytest.raises(ValueError, match=ambiguous_msg):
         AzureFileSystem(
             account_name='fake-account-name',
             client_id='fake-client-id',
             client_secret='fake-client-secret'
         )
 
-    with pytest.raises(ValueError, match=error_msg2):
+    with pytest.raises(ValueError, match="client_id must be specified"):
         AzureFileSystem(
             account_name='fake-account-name',
             tenant_id='fake-tenant-id',
             client_secret='fake-client-secret'
         )
 
-    with pytest.raises(ValueError, match=error_msg2):
+    with pytest.raises(ValueError, match=ambiguous_msg):
         AzureFileSystem(
             account_name='fake-account-name',
             tenant_id='fake-tenant-id',

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -1485,22 +1485,50 @@ def test_azurefs_options(pickle_module):
     assert pickle_module.loads(pickle_module.dumps(fs5)) == fs5
     assert fs5 != fs4
 
-    error_msg = "All of tenant_id, client_id, and client_secret must be provided"
-    with pytest.raises(ValueError, match=error_msg):
+    fs6 = AzureFileSystem(
+        account_name='fake-account-name',
+        client_id='fake-client-id'
+    )
+    assert isinstance(fs6, AzureFileSystem)
+    assert pickle_module.loads(pickle_module.dumps(fs6)) == fs6
+    assert fs6 != fs5
+
+    with pytest.raises(ValueError, match="client_id must be specified"):
+        AzureFileSystem(
+            account_name='fake-account-name',
+            tenant_id=None,
+            client_secret=None
+        )
+
+    error_msg1 = "Both of tenant_id and client_secret must be specified"
+    with pytest.raises(ValueError, match=error_msg1):
+        AzureFileSystem(
+            account_name='fake-account-name',
+            tenant_id='fake-tenant-id'
+        )
+
+    with pytest.raises(ValueError, match=error_msg1):
+        AzureFileSystem(
+            account_name='fake-account-name',
+            client_secret='fake-client-secret'
+        )
+
+    error_msg2 = "All of tenant_id, client_id, and client_secret must be provided"
+    with pytest.raises(ValueError, match=error_msg2):
         AzureFileSystem(
             account_name='fake-account-name',
             client_id='fake-client-id',
             client_secret='fake-client-secret'
         )
 
-    with pytest.raises(ValueError, match=error_msg):
+    with pytest.raises(ValueError, match=error_msg2):
         AzureFileSystem(
             account_name='fake-account-name',
             tenant_id='fake-tenant-id',
             client_secret='fake-client-secret'
         )
 
-    with pytest.raises(ValueError, match=error_msg):
+    with pytest.raises(ValueError, match=error_msg2):
         AzureFileSystem(
             account_name='fake-account-name',
             tenant_id='fake-tenant-id',


### PR DESCRIPTION
### Rationale for this change

`ClientSecretCredential` is another method to authenticate to Azure resources using Service Principle (SP). We work on AzureML, where there are two main types of compute ComputeInstance (personal VM) and ComputeCluster. In context of AzureML you can work interactively on ComputeInstance, where pyarrow  defaults to`DefaultAzureCredential` when reading/writing data over `abfss://` protocol. However when running AzureML "jobs" which is run non-interactively execution, the context (network) is different and `DefaultAzureCredential` doesn't work. An alternative method for non-interactive job is to use Service Principle i.e `ClientSecretCredential`.  This way we can create `AzureFileSystem` object and give it pyarrow `dataset`

### What changes are included in this PR?

Adding ConfigureClientSecretCredential to AzureFilesystem, which is already implemented at the C++, but hasn't been propagated to python library. This pull request just propagates C++ method to pyarrow

### Are these changes tested?

Yes, test have been included in the relevant file 

### Are there any user-facing changes?

Docs of `AzureFileSystem` have been updated in the code. It would be amazing for those changes to surface on the website, which I'm happy to try to help with if needed

* GitHub Issue: #46833