### PR TITLE
GH-46841  [C++][Gandiva] Fix date trunc edge case

### DIFF
--- a/cpp/src/gandiva/precompiled/time.cc
+++ b/cpp/src/gandiva/precompiled/time.cc
@@ -442,10 +442,12 @@ EXTRACT_MINUTE_TIME(time32)
 
 EXTRACT_HOUR_TIME(time32)
 
-#define DATE_TRUNC_FIXED_UNIT(NAME, TYPE, NMILLIS_IN_UNIT) \
-  FORCE_INLINE                                             \
-  gdv_##TYPE NAME##_##TYPE(gdv_##TYPE millis) {            \
-    return ((millis / NMILLIS_IN_UNIT) * NMILLIS_IN_UNIT); \
+#define DATE_TRUNC_FIXED_UNIT(NAME, TYPE, NMILLIS_IN_UNIT)                        \
+  FORCE_INLINE                                                                    \
+  gdv_##TYPE NAME##_##TYPE(gdv_##TYPE millis) {                                   \
+    return millis >= 0 ? ((millis / NMILLIS_IN_UNIT) * NMILLIS_IN_UNIT)           \
+                       : (((millis - NMILLIS_IN_UNIT + 1) / NMILLIS_IN_UNIT) *    \
+                          NMILLIS_IN_UNIT);                                       \
   }
 
 #define DATE_TRUNC_WEEK(TYPE)                                               \

--- a/cpp/src/gandiva/precompiled/time.cc
+++ b/cpp/src/gandiva/precompiled/time.cc
@@ -442,13 +442,12 @@ EXTRACT_MINUTE_TIME(time32)
 
 EXTRACT_HOUR_TIME(time32)
 
-#define DATE_TRUNC_FIXED_UNIT(NAME, TYPE, NMILLIS_IN_UNIT)                        \
-  FORCE_INLINE                                                                    \
-  gdv_##TYPE NAME##_##TYPE(gdv_##TYPE millis) {                                   \
-    return millis >= 0 ? ((millis / NMILLIS_IN_UNIT) * NMILLIS_IN_UNIT)           \
-                       : (((millis - NMILLIS_IN_UNIT + 1) / NMILLIS_IN_UNIT) *    \
-                          NMILLIS_IN_UNIT);                                       \
-  }
+#define DATE_TRUNC_FIXED_UNIT(NAME, TYPE, NMILLIS_IN_UNIT)                               \
+  FORCE_INLINE                                                                           \
+  gdv_##TYPE NAME##_##TYPE(gdv_##TYPE millis) {                                          \
+    return millis >= 0                                                                   \
+               ? ((millis / NMILLIS_IN_UNIT) * NMILLIS_IN_UNIT)                          \
+               : (((millis - NMILLIS_IN_UNIT + 1) / NMILLIS_IN_UNIT) * NMILLIS_IN_UNIT); \
 
 #define DATE_TRUNC_WEEK(TYPE)                                               \
   FORCE_INLINE                                                              \

--- a/cpp/src/gandiva/precompiled/time.cc
+++ b/cpp/src/gandiva/precompiled/time.cc
@@ -448,6 +448,7 @@ EXTRACT_HOUR_TIME(time32)
     return millis >= 0                                                                   \
                ? ((millis / NMILLIS_IN_UNIT) * NMILLIS_IN_UNIT)                          \
                : (((millis - NMILLIS_IN_UNIT + 1) / NMILLIS_IN_UNIT) * NMILLIS_IN_UNIT); \
+  }
 
 #define DATE_TRUNC_WEEK(TYPE)                                               \
   FORCE_INLINE                                                              \

--- a/cpp/src/gandiva/precompiled/time_test.cc
+++ b/cpp/src/gandiva/precompiled/time_test.cc
@@ -399,7 +399,7 @@ TEST(TestTime, TimeStampTrunc) {
             StringToTimestamp("1930-04-01 00:00:00"));
   EXPECT_EQ(date_trunc_Year_date64(StringToTimestamp("1930-05-15 12:34:56")),
             StringToTimestamp("1930-01-01 00:00:00"));
-  EXPECT_EQ(date_trunc_Decade_date64(StringToTimestamp("1930-05-15 12:34:56")),
+  EXPECT_EQ(date_trunc_Decade_date64(StringToTimestamp("1931-05-15 12:34:56")),
             StringToTimestamp("1930-01-01 00:00:00"));
   EXPECT_EQ(date_trunc_Century_date64(StringToTimestamp("1930-05-15 12:34:56")),
             StringToTimestamp("1901-01-01 00:00:00"));

--- a/cpp/src/gandiva/precompiled/time_test.cc
+++ b/cpp/src/gandiva/precompiled/time_test.cc
@@ -364,7 +364,7 @@ TEST(TestTime, TimeStampTrunc) {
   EXPECT_EQ(date_trunc_Week_timestamp(StringToTimestamp("2000-03-06 10:10:10")),
             StringToTimestamp("2000-03-06 00:00:00"));
 
-// Test dates before epoch (1970-01-01)
+  // Test dates before epoch (1970-01-01)
   EXPECT_EQ(date_trunc_Second_date64(StringToTimestamp("1969-12-31 23:45:15")),
             StringToTimestamp("1969-12-31 23:45:15"));
   EXPECT_EQ(date_trunc_Minute_date64(StringToTimestamp("1969-12-31 23:45:15")),

--- a/cpp/src/gandiva/precompiled/time_test.cc
+++ b/cpp/src/gandiva/precompiled/time_test.cc
@@ -363,6 +363,46 @@ TEST(TestTime, TimeStampTrunc) {
             StringToTimestamp("2000-02-28 00:00:00"));
   EXPECT_EQ(date_trunc_Week_timestamp(StringToTimestamp("2000-03-06 10:10:10")),
             StringToTimestamp("2000-03-06 00:00:00"));
+
+// Test dates before epoch (1970-01-01)
+  EXPECT_EQ(date_trunc_Second_date64(StringToTimestamp("1969-12-31 23:45:15")),
+            StringToTimestamp("1969-12-31 23:45:15"));
+  EXPECT_EQ(date_trunc_Minute_date64(StringToTimestamp("1969-12-31 23:45:15")),
+            StringToTimestamp("1969-12-31 23:45:00"));
+  EXPECT_EQ(date_trunc_Hour_date64(StringToTimestamp("1969-12-31 23:45:15")),
+            StringToTimestamp("1969-12-31 23:00:00"));
+  EXPECT_EQ(date_trunc_Day_date64(StringToTimestamp("1969-12-31 23:45:15")),
+            StringToTimestamp("1969-12-31 00:00:00"));
+  EXPECT_EQ(date_trunc_Month_date64(StringToTimestamp("1969-12-31 23:45:15")),
+            StringToTimestamp("1969-12-01 00:00:00"));
+  EXPECT_EQ(date_trunc_Quarter_date64(StringToTimestamp("1969-12-31 23:45:15")),
+            StringToTimestamp("1969-10-01 00:00:00"));
+  EXPECT_EQ(date_trunc_Year_date64(StringToTimestamp("1969-12-31 23:45:15")),
+            StringToTimestamp("1969-01-01 00:00:00"));
+  EXPECT_EQ(date_trunc_Decade_date64(StringToTimestamp("1969-12-31 23:45:15")),
+            StringToTimestamp("1960-01-01 00:00:00"));
+
+  // Test date further in the past
+  EXPECT_EQ(date_trunc_Second_date64(StringToTimestamp("1930-05-15 12:34:56")),
+            StringToTimestamp("1930-05-15 12:34:56"));
+  EXPECT_EQ(date_trunc_Minute_date64(StringToTimestamp("1930-05-15 12:34:56")),
+            StringToTimestamp("1930-05-15 12:34:00"));
+  EXPECT_EQ(date_trunc_Hour_date64(StringToTimestamp("1930-05-15 12:34:56")),
+            StringToTimestamp("1930-05-15 12:00:00"));
+  EXPECT_EQ(date_trunc_Day_date64(StringToTimestamp("1930-05-15 12:34:56")),
+            StringToTimestamp("1930-05-15 00:00:00"));
+  EXPECT_EQ(date_trunc_Day_date64(StringToTimestamp("1940-02-29 12:00:00")),
+            StringToTimestamp("1940-02-29 00:00:00"));
+  EXPECT_EQ(date_trunc_Month_date64(StringToTimestamp("1930-05-15 12:34:56")),
+            StringToTimestamp("1930-05-01 00:00:00"));
+  EXPECT_EQ(date_trunc_Quarter_date64(StringToTimestamp("1930-05-15 12:34:56")),
+            StringToTimestamp("1930-04-01 00:00:00"));
+  EXPECT_EQ(date_trunc_Year_date64(StringToTimestamp("1930-05-15 12:34:56")),
+            StringToTimestamp("1930-01-01 00:00:00"));
+  EXPECT_EQ(date_trunc_Decade_date64(StringToTimestamp("1930-05-15 12:34:56")),
+            StringToTimestamp("1930-01-01 00:00:00"));
+  EXPECT_EQ(date_trunc_Century_date64(StringToTimestamp("1930-05-15 12:34:56")),
+            StringToTimestamp("1901-01-01 00:00:00"));
 }
 
 TEST(TestTime, TimeStampAdd) {


### PR DESCRIPTION
### Rationale for this change
Fixes an edge case where certain dates would round the wrong direction when truncated.

### What changes are included in this PR?
Fix to date trunc for Gandiva and a unit test.

### Are these changes tested?
yes. unit test.

### Are there any user-facing changes?
Yes, a bug fix in date trunc calculation.

* GitHub Issue: #46841