### PR TITLE
GH-46843: [C++] Don't use unity build for bundled AWS SDK for C++

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -5114,6 +5114,7 @@ function(build_awssdk)
   prepare_fetchcontent()
   set(BUILD_DEPS OFF)
   set(BUILD_TOOL OFF)
+  set(CMAKE_UNITY_BUILD OFF) # Unity build causes some build errors.
   set(ENABLE_TESTING OFF)
   set(IN_SOURCE_BUILD ON)
   set(MINIMIZE_SIZE ON)


### PR DESCRIPTION
### Rationale for this change

AWS SDK for C++ related products don't support unity build.

### What changes are included in this PR?

Always disable unity build only for AWS SDK for C++ related products.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #46843