### PR TITLE
GH-46846: [CI][Dev] Fix shellcheck errors in the ci/scripts/install_dask.sh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -315,6 +315,7 @@ repos:
           ?^ci/scripts/install_chromedriver\.sh$|
           ?^ci/scripts/install_cmake\.sh$|
           ?^ci/scripts/install_conda\.sh$|
+          ?^ci/scripts/install_dask\.sh$|
           ?^ci/scripts/install_emscripten\.sh$|
           ?^ci/scripts/install_iwyu\.sh$|
           ?^ci/scripts/install_ninja\.sh$|

--- a/ci/scripts/install_dask.sh
+++ b/ci/scripts/install_dask.sh
@@ -30,9 +30,9 @@ if [ "${dask}" = "upstream_devel" ]; then
   pip install "dask[dataframe] @ git+https://github.com/dask/dask.git"
   pip install -U git+https://github.com/dask-contrib/dask-expr.git
 elif [ "${dask}" = "latest" ]; then
-  pip install dask[dataframe]
+  pip install "dask[dataframe]"
 else
-  pip install dask[dataframe]==${dask}
+  pip install "dask[dataframe]==${dask}"
 fi
 
 # additional dependencies needed for dask's s3 tests


### PR DESCRIPTION
### Rationale for this change

This is the sub issue #44748.

* SC2102 (info): Ranges can only match single chars (mentioned due to duplicates).
* SC2086 (info): Double quote to prevent globbing and word splitting.

```
shellcheck ci/scripts/install_dask.sh

In ci/scripts/install_dask.sh line 33:
  pip install dask[dataframe]
                  ^---------^ SC2102 (info): Ranges can only match single chars (mentioned due to duplicates).


In ci/scripts/install_dask.sh line 35:
  pip install dask[dataframe]==${dask}
                  ^---------^ SC2102 (info): Ranges can only match single chars (mentioned due to duplicates).
                               ^-----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
  pip install dask[dataframe]=="${dask}"

For more information:
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
  https://www.shellcheck.net/wiki/SC2102 -- Ranges can only match single char...
```

### What changes are included in this PR?

Quote varibles

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #46846