### PR TITLE
GH-46343: [CI][Python] Remove workaround for gdb packaging issue

### DIFF
--- a/ci/docker/conda-python.dockerfile
+++ b/ci/docker/conda-python.dockerfile
@@ -23,19 +23,11 @@ FROM ${repo}:${arch}-conda-cpp
 ARG python=3.9
 COPY ci/conda_env_python.txt \
      /arrow/ci/
-# If the Python version being used is 3.10 we need to install gdb<16.3 (GH-46343).
 # If the Python version being tested is the same as the Python used by the system gdb,
 # we need to install the conda-forge gdb instead (GH-38323).
-RUN if [ "$python" == "3.10" ]; then \
-        GDB_PACKAGE="gdb<16.3"; \
-    elif [ "$python" == "$(gdb --batch --eval-command 'python import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')" ]; then \
-        GDB_PACKAGE="gdb"; \
-    else \
-        GDB_PACKAGE=""; \
-    fi && \
-    mamba install -q -y \
+RUN mamba install -q -y \
         --file arrow/ci/conda_env_python.txt \
-        $([[ -n "$GDB_PACKAGE" ]] && echo "$GDB_PACKAGE") \
+        $([ "$python" == $(gdb --batch --eval-command 'python import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")') ] && echo "gdb") \
         "python=${python}.*=*_cp*" \
         nomkl && \
     mamba clean --all --yes


### PR DESCRIPTION
### Rationale for this change

In https://github.com/apache/arrow/pull/46511 we skipped installing gdb on conda-based Python 3.10 CI jobs, to work around https://github.com/conda-forge/gdb-feedstock/issues/83

Now that conda-forge has fixed the issue, we can re-enable gdb on those builds.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #46343