### PR TITLE
MINOR: [Ruby] Simplify dense union array RecordBatch creation in tests

### DIFF
--- a/ruby/red-arrow/test/raw-records/test-dense-union-array.rb
+++ b/ruby/red-arrow/test/raw-records/test-dense-union-array.rb
@@ -36,7 +36,8 @@ module RawRecordsDenseUnionArrayTests
   end
 
   def build_record_batch(type, records)
-    Arrow::RecordBatch.new(build_schema(type, [0, 1]), records)
+    type_codes = [0, 1]
+    Arrow::RecordBatch.new(build_schema(type, type_codes), records)
   end
 
   def remove_field_names(records)


### PR DESCRIPTION
### Rationale for this change

Addressing TODO comment in test, replace manual construction of DenseUnionArray with direct `RecordBatch.new` call.

### What changes are included in this PR?

This change simplifies the `build_record_batch`  in test/raw-records/test-dense-union-array.rb

### Are these changes tested?

Yes

### Are there any user-facing changes?

No, this is a test-only change.