### PR TITLE
GH-44900: [Python] Support fsspec filesystem URIs

### DIFF
--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -44,7 +44,7 @@ from pyarrow._parquet import (ParquetReader, Statistics,  # noqa
                               FileEncryptionProperties,
                               FileDecryptionProperties,
                               SortingColumn)
-from pyarrow.fs import (LocalFileSystem, FileSystem, FileType,
+from pyarrow.fs import (LocalFileSystem, FileType,
                         _resolve_filesystem_and_path, _ensure_filesystem)
 from pyarrow.util import guid, _is_path_like, _stringify_path, _deprecate_api
 
@@ -1392,14 +1392,9 @@ Examples
         self._base_dir = None
         if not isinstance(path_or_paths, list):
             if _is_path_like(path_or_paths):
-                path_or_paths = _stringify_path(path_or_paths)
-                if filesystem is None:
-                    # path might be a URI describing the FileSystem as well
-                    try:
-                        filesystem, path_or_paths = FileSystem.from_uri(
-                            path_or_paths)
-                    except ValueError:
-                        filesystem = LocalFileSystem(use_mmap=memory_map)
+                filesystem, path_or_paths = _resolve_filesystem_and_path(
+                    path_or_paths, filesystem, memory_map=memory_map
+                )
                 finfo = filesystem.get_file_info(path_or_paths)
                 if finfo.type == FileType.Directory:
                     self._base_dir = path_or_paths

--- a/python/pyarrow/tests/parquet/test_parquet_file.py
+++ b/python/pyarrow/tests/parquet/test_parquet_file.py
@@ -365,3 +365,16 @@ def test_read_undefined_logical_type(parquet_test_datadir):
         b"unknown string 2",
         b"unknown string 3"
     ]
+
+
+def test_parquet_file_fsspec_in_uri():
+    pytest.importorskip("fsspec")
+
+    table = pa.table({"a": range(10)})
+    pq.write_table(table, "fsspec+memory://example.parquet")
+    table2 = pq.read_table("fsspec+memory://example.parquet")
+    assert table.equals(table2)
+
+    msg = "Unrecognized filesystem type in URI"
+    with pytest.raises(pa.ArrowInvalid, match=msg):
+        pq.read_table("non-existing://example.parquet")


### PR DESCRIPTION
### Rationale for this change
It would be convenient to read parquet files from fsspec filesystems using schemes available in the [fsspec registry](https://filesystem-spec.readthedocs.io/en/latest/_modules/fsspec/registry.html) using URIs, without explicitly specifying the filesystem object.

### What changes are included in this PR?
This changes are based on https://github.com/apache/arrow/pull/45089. In this PR `_resolve_filesystem_and_path()` can recognize the scheme used in the URI together with the fsspec prefix. For example:

```python
>>> table = pa.table({"a": range(10)})
>>> pq.write_table(table, "fsspec+memory://example.parquet")
>>> pq.read_table("fsspec+memory://example.parquet")
pyarrow.Table
a: int64
----
a: [[0,1,2,3,4,5,6,7,8,9]]
```

### Are these changes tested?
Yes.

### Are there any user-facing changes?
No.

* GitHub Issue: #44900