### PR TITLE
GH-46854: [CI][MATLAB][Packaging] Add support for MATLAB `R2025a` in CI and crossbow packaging workflows

### DIFF
--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Install MATLAB
         uses: matlab-actions/setup-matlab@v2
         with:
-          release: R2024b
+          release: R2025a
       - name: Install ccache
         run: sudo apt-get install ccache
       - name: Setup ccache
@@ -107,7 +107,7 @@ jobs:
       - name: Install MATLAB
         uses: matlab-actions/setup-matlab@v2
         with:
-          release: R2024b
+          release: R2025a
       - name: Install ccache
         run: brew install ccache
       - name: Setup ccache
@@ -146,7 +146,7 @@ jobs:
       - name: Install MATLAB
         uses: matlab-actions/setup-matlab@v2
         with:
-          release: R2024b
+          release: R2025a
       - name: Download Timezone Database
         shell: bash
         run: ci/scripts/download_tz_database.sh

--- a/dev/tasks/matlab/github.yml
+++ b/dev/tasks/matlab/github.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install MATLAB
         uses: matlab-actions/setup-matlab@v2
         with:
-          release: R2024b
+          release: R2025a
       - name: Build MATLAB Interface
         env:
         {{ macros.github_set_sccache_envvars()|indent(8) }}
@@ -73,7 +73,7 @@ jobs:
       - name: Install MATLAB
         uses: matlab-actions/setup-matlab@v2
         with:
-          release: R2024b
+          release: R2025a
       - name: Build MATLAB Interface
         env:
         {{ macros.github_set_sccache_envvars()|indent(8) }}
@@ -99,7 +99,7 @@ jobs:
       - name: Install MATLAB
         uses: matlab-actions/setup-matlab@v2
         with:
-          release: R2024b
+          release: R2025a
       - name: Install sccache
         shell: bash
         run: arrow/ci/scripts/install_sccache.sh pc-windows-msvc $(pwd)/sccache
@@ -146,7 +146,7 @@ jobs:
       - name: Install MATLAB
         uses: matlab-actions/setup-matlab@v2
         with:
-          release: R2024b
+          release: R2025a
       - name: Run commands
         env:
           MATLABPATH: arrow/matlab/tools


### PR DESCRIPTION
### Rationale for this change

MATLAB [R2025a](https://www.mathworks.com/products/new_products/latest_features.html) is now available for use with the [matlab-actions/setup-matlab](https://github.com/matlab-actions/setup-matlab) GitHub Action.

We should update the [matlab.yml CI workflow](https://github.com/apache/arrow/blob/28cf7a4b3d662d8faef69ec26d9720cf8746c498/.github/workflows/matlab.yml#L62), as well as the [crossbow packaging workflows for the MATLAB MLTBX files](https://github.com/apache/arrow/blob/28cf7a4b3d662d8faef69ec26d9720cf8746c498/dev/tasks/matlab/github.yml#L34) to build against R2025a.

### What changes are included in this PR?

1. Updated the `.github/workflows/matlab.yml` CI workflow file to build the MATLAB Interface against MATLAB R2025a.
2. Updated the `dev/tasks/matlab/github.yml` crossbow packaging workflow to build the MATLAB MLTBX files against MATLAB R2025a.

### Are these changes tested?

1. MATLAB CI checks [successfully passed on all platforms](https://github.com/apache/arrow/actions/runs/15742712528/job/44371848305?pr=46855)
2. Crossbow job: https://github.com/ursacomputing/crossbow/actions/runs/15742741282/job/44371945623

### Are there any user-facing changes?

Yes. 

1. All changes to the MATLAB interface will now be built against R2025a.
3. The MATLAB MLTBX release artifacts will now be built against R2025a.


* GitHub Issue: #46854