### PR TITLE
GH-46777: [C++] Use SimplifyIsIn only when the value_set of the expression is lower than a threshold

### DIFF
--- a/cpp/src/arrow/compute/expression.cc
+++ b/cpp/src/arrow/compute/expression.cc
@@ -1342,8 +1342,6 @@ struct Inequality {
       return call->function_name == "is_valid" ? literal(true) : literal(false);
     }
 
-    auto options = checked_pointer_cast<SetLookupOptions>(call->options);
-
     if (call->function_name == "is_in") {
       ARROW_ASSIGN_OR_RAISE(std::optional<Expression> result,
                             SimplifyIsIn(guarantee, call));

--- a/cpp/src/arrow/compute/expression.cc
+++ b/cpp/src/arrow/compute/expression.cc
@@ -1271,7 +1271,7 @@ struct Inequality {
     // in order to use the simplification.
     // If the set is large there are performance implications, see:
     // https://github.com/apache/arrow/issues/46777
-    static constexpr int16_t kIsInSimplificationMaxValueSet = 50;
+    constexpr int16_t kIsInSimplificationMaxValueSet = 50;
     if (options->value_set.length() > kIsInSimplificationMaxValueSet) {
       return std::nullopt;
     }

--- a/cpp/src/arrow/compute/expression.cc
+++ b/cpp/src/arrow/compute/expression.cc
@@ -1333,7 +1333,13 @@ struct Inequality {
       return call->function_name == "is_valid" ? literal(true) : literal(false);
     }
 
-    if (call->function_name == "is_in") {
+    // The maximum number of values in the expression set of values
+    // in order to use the SimplifyIsIn function.
+    static constexpr int16_t kIsInSimplificationMaxValueSet = 50;
+    auto options = checked_pointer_cast<SetLookupOptions>(call->options);
+
+    if (call->function_name == "is_in" &&
+        options->value_set.length() <= kIsInSimplificationMaxValueSet) {
       ARROW_ASSIGN_OR_RAISE(std::optional<Expression> result,
                             SimplifyIsIn(guarantee, call));
       return result.value_or(expr);

--- a/cpp/src/arrow/compute/expression_test.cc
+++ b/cpp/src/arrow/compute/expression_test.cc
@@ -80,6 +80,16 @@ Expression add(Expression l, Expression r) {
   return call("add", {std::move(l), std::move(r)});
 }
 
+std::string make_range_json(int start, int end) {
+  std::string result = "[";
+  for (int i = start; i <= end; ++i) {
+    if (i > start) result += ",";
+    result += std::to_string(i);
+  }
+  result += "]";
+  return result;
+}
+
 const auto no_change = std::nullopt;
 
 TEST(ExpressionUtils, Comparison) {
@@ -1679,6 +1689,15 @@ TEST(Expression, SimplifyIsIn) {
     Simplify{is_in(field_ref("u32"), int64(), "[1,3,5,7,9]", null_matching)}
         .WithGuarantee(greater(field_ref("u32"), literal(3)))
         .Expect(is_in(field_ref("u32"), int64(), "[5,7,9]", null_matching));
+
+    Simplify{is_in(field_ref("u32"), int64(), make_range_json(1, 40), null_matching)}
+        .WithGuarantee(greater(field_ref("u32"), literal(10)))
+        .Expect(is_in(field_ref("u32"), int64(), make_range_json(11, 40), null_matching));
+
+    // For large ranges we don't do any simplification
+    Simplify{is_in(field_ref("u32"), int64(), make_range_json(1, 100), null_matching)}
+        .WithGuarantee(greater(field_ref("u32"), literal(3)))
+        .ExpectUnchanged();
   }
 
   Simplify{

--- a/cpp/src/arrow/compute/expression_test.cc
+++ b/cpp/src/arrow/compute/expression_test.cc
@@ -1694,7 +1694,8 @@ TEST(Expression, SimplifyIsIn) {
         .WithGuarantee(greater(field_ref("u32"), literal(10)))
         .Expect(is_in(field_ref("u32"), int64(), make_range_json(11, 40), null_matching));
 
-    // For large ranges we don't do any simplification
+    // For large ranges we don't do any simplification, see
+    // `kIsInSimplificationMaxValueSet` in expression.cc.
     Simplify{is_in(field_ref("u32"), int64(), make_range_json(1, 100), null_matching)}
         .WithGuarantee(greater(field_ref("u32"), literal(3)))
         .ExpectUnchanged();


### PR DESCRIPTION
### Rationale for this change

Using `SimplifyIsIn` when the value set is large has a substantial performance penalty.

### What changes are included in this PR?

Ensure we do not use the simplification when the value_set on the expression is higher than a threshold (50).

### Are these changes tested?

I've tested locally that the reproducer goes back to pre change levels.
```
$ python read.py 
=== PYARROW VERSION 20 ===
Retrieved 10,000,000 rows in 3.08 seconds.
```

I have added a test for large sets and validate the expression is not being modified.

### Are there any user-facing changes?

No

* GitHub Issue: #46777