### PR TITLE
GH-37561: [Ruby] Add empty chunked array tests for Arrow::Table#each_raw_records

### DIFF
--- a/ruby/red-arrow/test/raw-records/test-dense-union-array.rb
+++ b/ruby/red-arrow/test/raw-records/test-dense-union-array.rb
@@ -529,7 +529,13 @@ class EachRawRecordTableDenseUnionArrayTest < Test::Unit::TestCase
   include RawRecordsDenseUnionArrayTests
 
   def build(type, records)
-    build_record_batch(type, records).to_table
+    record_batch = build_record_batch(type, records)
+    # Multiple chunks
+    record_batches = [
+      record_batch,
+      record_batch.slice(record_batch.length, 0), # Empty chunk
+    ]
+    Arrow::Table.new(record_batch.schema, record_batches)
   end
 
   def actual_records(target)

--- a/ruby/red-arrow/test/raw-records/test-dictionary-array.rb
+++ b/ruby/red-arrow/test/raw-records/test-dictionary-array.rb
@@ -340,7 +340,14 @@ class EachRawRecordTableDictionaryArraysTest < Test::Unit::TestCase
   include RawRecordsDictionaryArrayTests
 
   def build(array)
-    build_record_batch(array).to_table
+    record_batch = build_record_batch(array)
+    # Multiple chunks
+    record_batches = [
+      record_batch.slice(0, 2),
+      record_batch.slice(2, 0), # Empty chunk
+      record_batch.slice(2, record_batch.length - 2),
+    ]
+    Arrow::Table.new(record_batch.schema, record_batches)
   end
 
   def actual_records(target)

--- a/ruby/red-arrow/test/raw-records/test-list-array.rb
+++ b/ruby/red-arrow/test/raw-records/test-list-array.rb
@@ -627,7 +627,14 @@ class EachRawRecordTableListArrayTest < Test::Unit::TestCase
   include RawRecordsListArrayTests
 
   def build(type, records)
-    Arrow::Table.new(build_schema(type), records)
+    record_batch = Arrow::RecordBatch.new(build_schema(type), records)
+    # Multiple chunks
+    record_batches = [
+      record_batch.slice(0, 2),
+      record_batch.slice(2, 0), # Empty chunk
+      record_batch.slice(2, record_batch.length - 2),
+    ]
+    Arrow::Table.new(record_batch.schema, record_batches)
   end
 
   def actual_records(target)

--- a/ruby/red-arrow/test/raw-records/test-map-array.rb
+++ b/ruby/red-arrow/test/raw-records/test-map-array.rb
@@ -507,7 +507,14 @@ class EachRawRecordTableMapArrayTest < Test::Unit::TestCase
   include RawRecordsMapArrayTests
 
   def build(type, records)
-    Arrow::Table.new(build_schema(type), records)
+    record_batch = Arrow::RecordBatch.new(build_schema(type), records)
+    # Multiple chunks
+    record_batches = [
+      record_batch.slice(0, 2),
+      record_batch.slice(2, 0), # Empty chunk
+      record_batch.slice(2, record_batch.length - 2),
+    ]
+    Arrow::Table.new(record_batch.schema, record_batches)
   end
 
   def actual_records(target)

--- a/ruby/red-arrow/test/raw-records/test-multiple-columns.rb
+++ b/ruby/red-arrow/test/raw-records/test-multiple-columns.rb
@@ -65,9 +65,10 @@ class EachRawRecordTableMultipleColumnsTest < Test::Unit::TestCase
 
   def build(schema, records)
     record_batch = Arrow::RecordBatch.new(schema, records)
+    # Multiple chunks
     record_batches = [
       record_batch.slice(0, 2),
-      record_batch.slice(2, 0),
+      record_batch.slice(2, 0), # Empty chunk
       record_batch.slice(2, record_batch.length - 2),
     ]
 

--- a/ruby/red-arrow/test/raw-records/test-sparse-union-array.rb
+++ b/ruby/red-arrow/test/raw-records/test-sparse-union-array.rb
@@ -555,7 +555,13 @@ class EachRawRecordTableSparseUnionArrayTest < Test::Unit::TestCase
   include RawRecordsSparseUnionArrayTests
 
   def build(type, records)
-    build_record_batch(type, records).to_table
+    record_batch = build_record_batch(type, records)
+    # Multiple chunks
+    record_batches = [
+      record_batch,
+      record_batch.slice(record_batch.length, 0), # Empty chunk
+    ]
+    Arrow::Table.new(record_batch.schema, record_batches)
   end
 
   def actual_records(target)

--- a/ruby/red-arrow/test/raw-records/test-struct-array.rb
+++ b/ruby/red-arrow/test/raw-records/test-struct-array.rb
@@ -528,7 +528,14 @@ class EachRawRecordTableStructArrayTest < Test::Unit::TestCase
   include RawRecordsStructArrayTests
 
   def build(type, records)
-    Arrow::Table.new(build_schema(type), records)
+    record_batch = Arrow::RecordBatch.new(build_schema(type), records)
+    # Multiple chunks
+    record_batches = [
+      record_batch.slice(0, 2),
+      record_batch.slice(2, 0), # Empty chunk
+      record_batch.slice(2, record_batch.length - 2),
+    ]
+    Arrow::Table.new(record_batch.schema, record_batches)
   end
 
   def actual_records(target)


### PR DESCRIPTION
### Rationale for this change

Some test cases currently don't consider an empty chunked array.
Therefore, we add empty chunk test patterns to all test cases about `Arrow::Table#each_raw_records`.

### What changes are included in this PR?

This PR adds empty chunked array test patterns to 7 test files in the test/raw-records/ directory:
- test-dense-union-array.rb
- test-dictionary-array.rb
- test-list-array.rb
- test-map-array.rb
- test-sparse-union-array.rb
- test-struct-array.rb
- test-table.rb

Each EachRawRecordTable*Test class now creates a table with multiple chunks, including an empty chunk,
following the pattern established in test-basic-arrays.rb.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.

* GitHub Issue: #37561