### PR TITLE
[C++][Parquet] Remove prototypes of removed parquet:arrow::FileReader::GetRecordBatchReader()

### DIFF
--- a/cpp/src/parquet/arrow/reader.h
+++ b/cpp/src/parquet/arrow/reader.h
@@ -179,25 +179,6 @@ class PARQUET_EXPORT FileReader {
   GetRecordBatchReader(const std::vector<int>& row_group_indices,
                        const std::vector<int>& column_indices) = 0;
 
-  /// \brief Return a RecordBatchReader of row groups selected from
-  /// row_group_indices, whose columns are selected by column_indices.
-  ///
-  /// Note that the ordering in row_group_indices and column_indices
-  /// matter. FileReaders must outlive their RecordBatchReaders.
-  ///
-  /// \param row_group_indices which row groups to read (order determines read order).
-  /// \param column_indices which columns to read (order determines output schema).
-  /// \param[out] out record batch stream from parquet data.
-  ///
-  /// \returns error Status if either row_group_indices or column_indices
-  ///     contains an invalid index
-  ::arrow::Status GetRecordBatchReader(const std::vector<int>& row_group_indices,
-                                       const std::vector<int>& column_indices,
-                                       std::shared_ptr<::arrow::RecordBatchReader>* out);
-  ::arrow::Status GetRecordBatchReader(const std::vector<int>& row_group_indices,
-                                       std::shared_ptr<::arrow::RecordBatchReader>* out);
-  ::arrow::Status GetRecordBatchReader(std::shared_ptr<::arrow::RecordBatchReader>* out);
-
   /// \brief Return a generator of record batches.
   ///
   /// The FileReader must outlive the generator, so this requires that you pass in a


### PR DESCRIPTION
### Rationale for this change

Consistency between headers and implementations

### What changes are included in this PR?

Commit f7bc27132ea84c4639528d73a9c289c7a1db154f removed implementation of those 3 methods. Technically they were not formally deprecated in 19.0.0, although I suspect this was an oversight as the virtual method they rely on was deprecated.

### Are these changes tested?

N/A

### Are there any user-facing changes?

Yes

**This PR includes breaking changes to public APIs.** 

CC @AlenkaF 