### PR TITLE
GH-46871: [C++][Parquet] Restore implementation of 3 arrow::FileReader::GetRecordBatchReader() functions

### DIFF
--- a/cpp/src/parquet/arrow/reader.cc
+++ b/cpp/src/parquet/arrow/reader.cc
@@ -1310,6 +1310,28 @@ std::shared_ptr<RowGroupReader> FileReaderImpl::RowGroup(int row_group_index) {
 // ----------------------------------------------------------------------
 // Public factory functions
 
+Status FileReader::GetRecordBatchReader(std::shared_ptr<RecordBatchReader>* out) {
+  ARROW_ASSIGN_OR_RAISE(auto tmp, GetRecordBatchReader());
+  out->reset(tmp.release());
+  return Status::OK();
+}
+
+Status FileReader::GetRecordBatchReader(const std::vector<int>& row_group_indices,
+                                        std::shared_ptr<RecordBatchReader>* out) {
+  ARROW_ASSIGN_OR_RAISE(auto tmp, GetRecordBatchReader(row_group_indices));
+  out->reset(tmp.release());
+  return Status::OK();
+}
+
+Status FileReader::GetRecordBatchReader(const std::vector<int>& row_group_indices,
+                                        const std::vector<int>& column_indices,
+                                        std::shared_ptr<RecordBatchReader>* out) {
+  ARROW_ASSIGN_OR_RAISE(auto tmp,
+                        GetRecordBatchReader(row_group_indices, column_indices));
+  out->reset(tmp.release());
+  return Status::OK();
+}
+
 Status FileReader::Make(::arrow::MemoryPool* pool,
                         std::unique_ptr<ParquetFileReader> reader,
                         const ArrowReaderProperties& properties,


### PR DESCRIPTION
### Rationale for this change

Those functions were accidentally removed in f7bc27132ea84c4639528d73a9c289c7a1db154f whereas only the variants using unique_ptr<> were intended for removal.

### What changes are included in this PR?

Restore the implementation of 3 functions whose prototype is still available

### Are these changes tested?

Apparently no

### Are there any user-facing changes?

No (unbreak a unreleased regression)

Cf https://github.com/apache/arrow/pull/46867#issuecomment-2989160864 for discussion

* GitHub Issue: #46871