### PR TITLE
GH-44502: [R] Negative fractional dates must be converted to integers by floor, not trunc

### DIFF
--- a/r/src/r_to_arrow.cpp
+++ b/r/src/r_to_arrow.cpp
@@ -595,11 +595,13 @@ class RPrimitiveConverter<T, enable_if_t<is_date_type<T>::value>>
     return VisitVector(it, size, append_null, append_value);
   }
 
-  static int FromRDate(const Date32Type*, double from) { return static_cast<int>(from); }
+  static int FromRDate(const Date32Type*, double from) { 
+    return static_cast<int>(std::floor(from)); // Use floor for sub-day precision
+  }
 
   static int64_t FromRDate(const Date64Type*, double from) {
     constexpr int64_t kMilliSecondsPerDay = 86400000;
-    return static_cast<int64_t>(from * kMilliSecondsPerDay);
+    return static_cast<int64_t>(std::floor(from * kMilliSecondsPerDay)); // Use floor for sub-day precision
   }
 
   static int FromPosixct(const Date32Type*, double from) {

--- a/r/src/r_to_arrow.cpp
+++ b/r/src/r_to_arrow.cpp
@@ -595,13 +595,13 @@ class RPrimitiveConverter<T, enable_if_t<is_date_type<T>::value>>
     return VisitVector(it, size, append_null, append_value);
   }
 
-  static int FromRDate(const Date32Type*, double from) { 
-    return static_cast<int>(std::floor(from)); // Use floor for sub-day precision
+  static int FromRDate(const Date32Type*, double from) {
+    return static_cast<int>(std::floor(from));
   }
 
   static int64_t FromRDate(const Date64Type*, double from) {
     constexpr int64_t kMilliSecondsPerDay = 86400000;
-    return static_cast<int64_t>(std::floor(from * kMilliSecondsPerDay)); // Use floor for sub-day precision
+    return static_cast<int64_t>(std::floor(from * kMilliSecondsPerDay));
   }
 
   static int FromPosixct(const Date32Type*, double from) {

--- a/r/tests/testthat/test-Array.R
+++ b/r/tests/testthat/test-Array.R
@@ -1397,3 +1397,9 @@ test_that("Can convert R integer/double to decimal (ARROW-11631)", {
     "Conversion to decimal from non-integer/double"
   )
 })
+
+test_that("Array handles sub-day precision Date correctly", {
+  d <- as.Date(-0.1)
+  arr <- arrow_array(d)
+  expect_equal(as.vector(arr), as.Date("1969-12-31"))
+})

--- a/r/tests/testthat/test-Array.R
+++ b/r/tests/testthat/test-Array.R
@@ -1398,7 +1398,7 @@ test_that("Can convert R integer/double to decimal (ARROW-11631)", {
   )
 })
 
-test_that("Array handles sub-day precision Date correctly", {
+test_that("Array handles negative fractional dates correctly (GH-46873)", {
   d <- as.Date(-0.1)
   arr <- arrow_array(d)
   expect_equal(as.vector(arr), as.Date("1969-12-31"))


### PR DESCRIPTION
### Rationale for this change

Sub-day precision Dates specified as negative fractional values converted to wrong value if not floored first

### What changes are included in this PR?

Ensure they are converted with `floor()`

### Are these changes tested?

Yes

### Are there any user-facing changes?

Yes
* GitHub Issue: #44502