### PR TITLE
GH-46094: [C++][Docs] Add note to RleDecoder::Get's doc comment

### DIFF
--- a/cpp/src/arrow/util/rle_encoding_internal.h
+++ b/cpp/src/arrow/util/rle_encoding_internal.h
@@ -112,6 +112,12 @@ class RleDecoder {
   }
 
   /// Gets the next value.  Returns false if there are no more.
+  ///
+  /// NB: Because the encoding only supports literal runs with lengths
+  /// that are multiples of 8, RleEncoder sometimes pads the end of its
+  /// input with zeros. Since the encoding does not differentiate between
+  /// input values and padding, Get() returns true even for these padding
+  /// values.
   template <typename T>
   bool Get(T* val);
 


### PR DESCRIPTION
### Rationale for this change

The behavior of `RleDecoder::Get` caused some confusion in https://github.com/apache/arrow/issues/46094.

### What changes are included in this PR?

Improvement to `RleDecoder::Get`'s doc comment.

### Are these changes tested?

N/A

### Are there any user-facing changes?

No.
* GitHub Issue: #46094