### PR TITLE
GH-45713: [GLib] Add garrow_chunked_array_(import|export)()

### DIFF
--- a/c_glib/arrow-glib/chunked-array.h
+++ b/c_glib/arrow-glib/chunked-array.h
@@ -83,4 +83,12 @@ GARROW_AVAILABLE_IN_4_0
 GArrowArray *
 garrow_chunked_array_combine(GArrowChunkedArray *chunked_array, GError **error);
 
+GARROW_AVAILABLE_IN_21_0
+GArrowChunkedArray *
+garrow_chunked_array_import(gpointer c_abi_array_stream, GError **error);
+
+GARROW_AVAILABLE_IN_21_0
+gpointer
+garrow_chunked_array_export(GArrowChunkedArray *chunked_array, GError **error);
+
 G_END_DECLS

--- a/c_glib/test/test-chunked-array.rb
+++ b/c_glib/test/test-chunked-array.rb
@@ -144,4 +144,15 @@ class TestChunkedArray < Test::Unit::TestCase
     assert_equal(build_boolean_array([true, false, nil]),
                  chunked_array.combine)
   end
+
+  def test_export_import
+    chunks = [
+      build_boolean_array([true, false, true]),
+      build_boolean_array([false, nil]),
+    ]
+    original_chunked_array = Arrow::ChunkedArray.new(chunks)
+    c_abi_array_stream = original_chunked_array.export
+    assert_equal(original_chunked_array,
+                 Arrow::ChunkedArray.import(c_abi_array_stream))
+  end
 end


### PR DESCRIPTION
### Rationale for this change

The GLib bindings were missing C data interface
functions for ChunkedArray import|export operations.

### What changes are included in this PR?

This PR added the follwoings.
- Add garrow_chunked_array_import()
- Add garrow_chunked_array_export()
- Add round-trip test with boolean chunked array data

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.

* GitHub Issue: #45713