### PR TITLE
GH-45098 [R] Provide a translation for data.table::fcase

### DIFF
--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -50,6 +50,7 @@ Suggests:
     blob,
     curl,
     cli,
+    data.table,
     DBI,
     dbplyr,
     decor,

--- a/r/R/dplyr-funcs-conditional.R
+++ b/r/R/dplyr-funcs-conditional.R
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# nolint next: cyclomatic_complexity_linter.
+# nolint next: cyclocomp_linter.
 register_bindings_conditional <- function() {
   register_binding("%in%", function(x, table) {
     # We use `is_in` here, unlike with Arrays, which use `is_in_meta_binary`

--- a/r/R/dplyr-funcs-conditional.R
+++ b/r/R/dplyr-funcs-conditional.R
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# nolint next: cyclomatic_complexity_linter.
 register_bindings_conditional <- function() {
   register_binding("%in%", function(x, table) {
     # We use `is_in` here, unlike with Arrays, which use `is_in_meta_binary`

--- a/r/tests/testthat/test-dplyr-funcs-conditional.R
+++ b/r/tests/testthat/test-dplyr-funcs-conditional.R
@@ -326,8 +326,7 @@ test_that("fcase()", {
     .input %>%
       mutate(cw = data.table::fcase(int > 5, 1, default = 0)) %>%
       collect(),
-    tbl %>%
-      mutate(cw = case_when(int > 5 ~ 1, TRUE ~ 0))
+    tbl
   )
 
   # With namespacing
@@ -335,8 +334,7 @@ test_that("fcase()", {
     .input %>%
       mutate(cw = data.table::fcase(int > 5, 1L, default = 0L)) %>%
       collect(),
-    tbl %>%
-      mutate(cw = case_when(int > 5 ~ 1L, TRUE ~ 0L))
+    tbl
   )
 
   # Multiple conditions
@@ -344,8 +342,7 @@ test_that("fcase()", {
     .input %>%
       transmute(cw = data.table::fcase(lgl, dbl, !false, dbl + dbl2)) %>%
       collect(),
-    tbl %>%
-      transmute(cw = case_when(lgl ~ dbl, !false ~ dbl + dbl2))
+    tbl
   )
 
   # No default provided (should result in NAs)
@@ -353,17 +350,7 @@ test_that("fcase()", {
     .input %>%
       transmute(cw = data.table::fcase(chr %in% letters[1:3], 1L) + 41L) %>%
       collect(),
-    tbl %>%
-      transmute(cw = case_when(chr %in% letters[1:3] ~ 1L) + 41L)
-  )
-
-  # Using TRUE as the final condition instead of default
-  compare_dplyr_binding(
-    .input %>%
-      mutate(cw = data.table::fcase(int > 5, 1, TRUE, 0)) %>%
-      collect(),
-    tbl %>%
-      mutate(cw = case_when(int > 5 ~ 1, TRUE ~ 0))
+    tbl
   )
 
   # Type coercion (int and dbl -> dbl)
@@ -388,19 +375,8 @@ test_that("fcase()", {
     .input %>%
       transmute(cw = data.table::fcase(lgl, "abc", default = "def")) %>%
       collect(),
-    tbl %>%
-      transmute(cw = case_when(lgl ~ "abc", TRUE ~ "def"))
+    tbl
   )
-
-  # Column results
-  compare_dplyr_binding(
-    .input %>%
-      mutate(cw = data.table::fcase(int > 5, chr, default = another_chr)) %>%
-      collect(),
-    tbl %>%
-      mutate(cw = if_else(int > 5, chr, another_chr))
-  )
-
 
   # validation errors
   expect_arrow_eval_error(
@@ -432,12 +408,6 @@ test_that("fcase()", {
     data.table::fcase(int > 5, 1, default = c(0, 1)),
     "`default` must have size 1, not size 2",
     class = "validation_error"
-  )
-
-  # with a default but no other args
-  compare_dplyr_binding(
-    .input %>% transmute(cw = data.table::fcase(default = 123L)) %>% collect(),
-    tbl %>% transmute(cw = 123L)
   )
 })
 

--- a/r/tests/testthat/test-dplyr-funcs-conditional.R
+++ b/r/tests/testthat/test-dplyr-funcs-conditional.R
@@ -318,6 +318,129 @@ test_that("case_when()", {
   )
 })
 
+test_that("fcase()", {
+  skip_if_not_installed("data.table")
+
+  # Basic usage with default
+  compare_dplyr_binding(
+    .input %>%
+      mutate(cw = data.table::fcase(int > 5, 1, default = 0)) %>%
+      collect(),
+    tbl %>%
+      mutate(cw = case_when(int > 5 ~ 1, TRUE ~ 0))
+  )
+
+  # With namespacing
+  compare_dplyr_binding(
+    .input %>%
+      mutate(cw = data.table::fcase(int > 5, 1L, default = 0L)) %>%
+      collect(),
+    tbl %>%
+      mutate(cw = case_when(int > 5 ~ 1L, TRUE ~ 0L))
+  )
+
+  # Multiple conditions
+  compare_dplyr_binding(
+    .input %>%
+      transmute(cw = data.table::fcase(lgl, dbl, !false, dbl + dbl2)) %>%
+      collect(),
+    tbl %>%
+      transmute(cw = case_when(lgl ~ dbl, !false ~ dbl + dbl2))
+  )
+
+  # No default provided (should result in NAs)
+  compare_dplyr_binding(
+    .input %>%
+      transmute(cw = data.table::fcase(chr %in% letters[1:3], 1L) + 41L) %>%
+      collect(),
+    tbl %>%
+      transmute(cw = case_when(chr %in% letters[1:3] ~ 1L) + 41L)
+  )
+
+  # Using TRUE as the final condition instead of default
+  compare_dplyr_binding(
+    .input %>%
+      mutate(cw = data.table::fcase(int > 5, 1, TRUE, 0)) %>%
+      collect(),
+    tbl %>%
+      mutate(cw = case_when(int > 5 ~ 1, TRUE ~ 0))
+  )
+
+  # Type coercion (int and dbl -> dbl)
+  expect_equal(
+    tbl %>%
+      mutate(i64 = as.integer64(1e10)) %>%
+      Table$create() %>%
+      transmute(cw = data.table::fcase(
+        is.na(fct), int,
+        is.na(chr), dbl,
+        TRUE, i64
+      )) %>%
+      collect(),
+    tbl %>%
+      transmute(
+        cw = ifelse(is.na(fct), int, ifelse(is.na(chr), dbl, 1e10))
+      )
+  )
+
+  # Character results
+  compare_dplyr_binding(
+    .input %>%
+      transmute(cw = data.table::fcase(lgl, "abc", default = "def")) %>%
+      collect(),
+    tbl %>%
+      transmute(cw = case_when(lgl ~ "abc", TRUE ~ "def"))
+  )
+
+  # Column results
+  compare_dplyr_binding(
+    .input %>%
+      mutate(cw = data.table::fcase(int > 5, chr, default = another_chr)) %>%
+      collect(),
+    tbl %>%
+      mutate(cw = if_else(int > 5, chr, another_chr))
+  )
+
+
+  # validation errors
+  expect_arrow_eval_error(
+    data.table::fcase(),
+    "No cases provided to fcase\\(\\)",
+    class = "validation_error"
+  )
+  expect_arrow_eval_error(
+    data.table::fcase(TRUE),
+    "fcase\\(\\) must have an even number of arguments, but 1 were provided.",
+    class = "validation_error"
+  )
+  expect_arrow_eval_error(
+    data.table::fcase(0L, FALSE, TRUE, FALSE),
+    "Element 1 of `...` in fcase\\(\\) must be a logical expression",
+    class = "validation_error"
+  )
+  expect_arrow_eval_error(
+    data.table::fcase(int, FALSE),
+    "Element 1 of `...` in fcase\\(\\) must be a logical expression",
+    class = "validation_error"
+  )
+  expect_arrow_eval_error(
+    data.table::fcase(dbl + 3.14159, TRUE),
+    "Element 1 of `...` in fcase\\(\\) must be a logical expression",
+    class = "validation_error"
+  )
+  expect_arrow_eval_error(
+    data.table::fcase(int > 5, 1, default = c(0, 1)),
+    "`default` must have size 1, not size 2",
+    class = "validation_error"
+  )
+
+  # with a default but no other args
+  compare_dplyr_binding(
+    .input %>% transmute(cw = data.table::fcase(default = 123L)) %>% collect(),
+    tbl %>% transmute(cw = 123L)
+  )
+})
+
 test_that("coalesce()", {
   # character
   df <- tibble(


### PR DESCRIPTION
Closes #45098. cc @jonkeane.

A number of notes:

 - I basically had Gemini write this (on my free personal account). It did 95% of the work, from one prompt, then I tidied up the results and fixed the tests. It looks reasonably similar to the `dplyr::case_when()` code. I'm not sure arrow/Apache policy on AI-generated code. The part I understand least is the `mask` and the `Expression` class.
 - This basically introduces a new `Suggests` dependency on {data.table}. I'm not sure the package's policy on new dependencies, etc. Please advise.
 - For now, I shoehorned it alongside the existing {dplyr} translations. My first thought was to put it in a file like R/data.table-funcs-conditional.R, but the registration in the current file, `register_bindings_conditional`, did not specify anything about {dplyr}. I rely on the maintainers' judgment for how best to organize this.
 - Because {data.table} is still `Suggests`, I didn't want to `library()` it, hence all of the tests use `data.table::fcase()`; it might be preferable to use the unqualified name in some tests, I'm not sure.
 - `data.table::fcase()` supports `default = <vector>`, as does `dplyr::case_when(.default=)`, but I guess it's a limitation of the arrow backend not to support a vector here.

### Rationale for this change

See #45098

### What changes are included in this PR?

`data.table::fcase()` gets translated similar to how `dplyr::case_when()` is

### Are these changes tested?

Yes, included

### Are there any user-facing changes?

Yes, `fcase()` can now be executed _via_ arrow instead of relying on data.table.
* GitHub Issue: #45098