### PR TITLE
GH-46881: [CI][Dev] Fix shellcheck errors in the ci/scripts/install_gcs_testbench.sh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -317,6 +317,7 @@ repos:
           ?^ci/scripts/install_conda\.sh$|
           ?^ci/scripts/install_dask\.sh$|
           ?^ci/scripts/install_emscripten\.sh$|
+          ?^ci/scripts/install_gcs_testbench\.sh$|
           ?^ci/scripts/install_iwyu\.sh$|
           ?^ci/scripts/install_ninja\.sh$|
           ?^ci/scripts/install_numpy\.sh$|

--- a/ci/scripts/install_gcs_testbench.sh
+++ b/ci/scripts/install_gcs_testbench.sh
@@ -35,19 +35,19 @@ case "$(uname -m)" in
 esac
 
 version=$1
-if [[ "${version}" -eq "default" ]]; then
+if [[ "${version}" = "default" ]]; then
   version="v0.39.0"
 fi
 
 # The Python to install pipx with
-: ${PIPX_BASE_PYTHON:=$(which python3)}
+: "${PIPX_BASE_PYTHON:=$(which python3)}"
 # The Python to install the GCS testbench with
-: ${PIPX_PYTHON:=${PIPX_BASE_PYTHON:-$(which python3)}}
+: "${PIPX_PYTHON:=${PIPX_BASE_PYTHON:-$(which python3)}}"
 
 export PIP_BREAK_SYSTEM_PACKAGES=1
 ${PIPX_BASE_PYTHON} -m pip install -U pipx
 
-pipx_flags=(--verbose --python ${PIPX_PYTHON})
+pipx_flags=(--verbose --python "${PIPX_PYTHON}")
 if [[ $(id -un) == "root" ]]; then
   # Install globally as /root/.local/bin is typically not in $PATH
   pipx_flags+=(--global)
@@ -55,5 +55,5 @@ fi
 if [[ -n "${PIPX_PIP_ARGS}" ]]; then
   pipx_flags+=(--pip-args "'${PIPX_PIP_ARGS}'")
 fi
-${PIPX_BASE_PYTHON} -m pipx install ${pipx_flags[@]} \
+${PIPX_BASE_PYTHON} -m pipx install "${pipx_flags[@]}" \
   "https://github.com/googleapis/storage-testbench/archive/${version}.tar.gz"


### PR DESCRIPTION
### Rationale for this change

This is the sub issue #44748.

* SC2068: Double quote array expansions to avoid re-splitting elements.
* SC2154: default is referenced but not assigned.
* SC2206: Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.
* SC2223: This default assignment may cause DoS due to globbing. Quote it.
* SC2309: -eq treats this as a variable. Use = to compare as string (or expand explicitly with $var).


```
In ci/scripts/install_gcs_testbench.sh line 38:
if [[ "${version}" -eq "default" ]]; then
                       ^-------^ SC2154 (warning): default is referenced but not assigned.
                       ^-------^ SC2309 (warning): -eq treats this as a variable. Use = to compare as string (or expand explicitly with $var).


In ci/scripts/install_gcs_testbench.sh line 43:
: ${PIPX_BASE_PYTHON:=$(which python3)}
  ^-- SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/install_gcs_testbench.sh line 45:
: ${PIPX_PYTHON:=${PIPX_BASE_PYTHON:-$(which python3)}}
  ^-- SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/install_gcs_testbench.sh line 50:
pipx_flags=(--verbose --python ${PIPX_PYTHON})
                               ^------------^ SC2206 (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.


In ci/scripts/install_gcs_testbench.sh line 58:
${PIPX_BASE_PYTHON} -m pipx install ${pipx_flags[@]} \
                                    ^--------------^ SC2068 (error): Double quote array expansions to avoid re-splitting elements.

For more information:
  https://www.shellcheck.net/wiki/SC2068 -- Double quote array expansions to ...
  https://www.shellcheck.net/wiki/SC2154 -- default is referenced but not ass...
  https://www.shellcheck.net/wiki/SC2206 -- Quote to prevent word splitting/g...
```

### What changes are included in this PR?

* Use `=` instead of `-eq` for comparing string.
* Quoting variables.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #46881