### PR TITLE
GH-45290: [Docs][Release] Change show_version_warning_banner substitution

### DIFF
--- a/dev/release/post-09-docs.sh
+++ b/dev/release/post-09-docs.sh
@@ -85,6 +85,10 @@ find docs \
   -exec \
   sed -i.bak \
   -e "s/DOCUMENTATION_OPTIONS.show_version_warning_banner = true/DOCUMENTATION_OPTIONS.show_version_warning_banner = false/g" \
+  -e '/^[[:space:]]\{8\}DOCUMENTATION_OPTIONS\.show_version_warning_banner =[[:space:]]*$/{
+N
+s/^\([[:space:]]\{8\}DOCUMENTATION_OPTIONS\.show_version_warning_banner =[[:space:]]*\)\n[[:space:]]\{12\}true;/\1\n            false;/g
+}'
   {} \;
 find ./ -name '*.bak' -delete
 popd
@@ -108,6 +112,10 @@ if [ "$is_major_release" = "yes" ]; then
     sed -i.bak \
     -e "s/DOCUMENTATION_OPTIONS.theme_switcher_version_match = '';/DOCUMENTATION_OPTIONS.theme_switcher_version_match = '${previous_series}';/g" \
     -e "s/DOCUMENTATION_OPTIONS.show_version_warning_banner = false/DOCUMENTATION_OPTIONS.show_version_warning_banner = true/g" \
+    -e '/^[[:space:]]\{8\}DOCUMENTATION_OPTIONS\.show_version_warning_banner =[[:space:]]*$/{
+N
+s/^\([[:space:]]\{8\}DOCUMENTATION_OPTIONS\.show_version_warning_banner =[[:space:]]*\)\n[[:space:]]\{12\}false;/\1\n            true;/g
+}' \
     {} \;
   find ./ -name '*.bak' -delete
   popd

--- a/dev/release/post-09-docs.sh
+++ b/dev/release/post-09-docs.sh
@@ -88,7 +88,7 @@ find docs \
   -e '/^[[:space:]]\{8\}DOCUMENTATION_OPTIONS\.show_version_warning_banner =[[:space:]]*$/{
 N
 s/^\([[:space:]]\{8\}DOCUMENTATION_OPTIONS\.show_version_warning_banner =[[:space:]]*\)\n[[:space:]]\{12\}true;/\1\n            false;/g
-}'
+}' \
   {} \;
 find ./ -name '*.bak' -delete
 popd


### PR DESCRIPTION
### Rationale for this change
Stable and dev docs are not correctly updated and need manual intervention due to the [upstream change](https://github.com/pydata/pydata-sphinx-theme/pull/2049) in version warning banner.

### What changes are included in this PR?
Another sed substitution is added.

### Are these changes tested?
I have tested locally with

```
> sed -i .bak -e '/^[[:space:]]\{8\}DOCUMENTATION_OPTIONS\.show_version_warning_banner =[[:space:]]*$/{
N
s/^\([[:space:]]\{8\}DOCUMENTATION_OPTIONS\.show_version_warning_banner =[[:space:]]*\)\n[[:space:]]\{12\}false;/\1\n            true;/g
}' index.html
```

### Are there any user-facing changes?
No.
* GitHub Issue: #45290