### PR TITLE
GH-46877: [MATLAB] Add `arrow.tabular.Table.fromRecordBatches` static method

### DIFF
--- a/matlab/src/cpp/arrow/matlab/error/error.h
+++ b/matlab/src/cpp/arrow/matlab/error/error.h
@@ -253,5 +253,6 @@ static const char* IPC_RECORD_BATCH_READ_INVALID_INDEX = "arrow:io:ipc:InvalidIn
 static const char* IPC_RECORD_BATCH_READ_FAILED = "arrow:io:ipc:ReadFailed";
 static const char* IPC_TABLE_READ_FAILED = "arrow:io:ipc:TableReadFailed";
 static const char* IPC_END_OF_STREAM = "arrow:io:ipc:EndOfStream";
+static const char* TABLE_MAKE_UNKNOWN_METHOD = "arrow:table:UnknownMakeMethod";
 
 }  // namespace arrow::matlab::error

--- a/matlab/src/cpp/arrow/matlab/tabular/proxy/table.cc
+++ b/matlab/src/cpp/arrow/matlab/tabular/proxy/table.cc
@@ -140,7 +140,7 @@ libmexclass::proxy::MakeResult from_record_batches(const mda::StructArray& opts)
   // This function can only be invoked if there's at least 1 RecordBatch,
   // so this should be safe.
   auto schema = record_batches[0]->schema();
-  // We've already validated the schemas are consistent.
+  // The MATLAB client code should have already validated that the schemas are consistent.
   // Just create a vector of columns.
   size_t num_columns = schema->num_fields();
   std::vector<std::shared_ptr<ChunkedArray>> columns(num_columns);

--- a/matlab/src/cpp/arrow/matlab/tabular/proxy/table.cc
+++ b/matlab/src/cpp/arrow/matlab/tabular/proxy/table.cc
@@ -166,7 +166,7 @@ libmexclass::proxy::MakeResult Table::make(
 
   if (method[0] == u"FromArrays") {
     return from_arrays(opts);
-  } else if (method[0] == u"FromRecordBatches") {
+  } else if (method[0] == u"from_record_batches") {
     return from_record_batches(opts);
   } else {
     const std::string error_msg = "Unknown method";

--- a/matlab/src/cpp/arrow/matlab/tabular/proxy/table.cc
+++ b/matlab/src/cpp/arrow/matlab/tabular/proxy/table.cc
@@ -141,7 +141,7 @@ libmexclass::proxy::MakeResult from_record_batches(const mda::StructArray& opts)
   // so this should be safe.
   auto schema = record_batches[0]->schema();
   // The MATLAB client code should have already validated that the schemas are consistent.
-  // Just create a vector of columns.
+  // Create a vector of columns.
   size_t num_columns = schema->num_fields();
   std::vector<std::shared_ptr<ChunkedArray>> columns(num_columns);
 

--- a/matlab/src/cpp/arrow/matlab/tabular/proxy/table.cc
+++ b/matlab/src/cpp/arrow/matlab/tabular/proxy/table.cc
@@ -164,7 +164,7 @@ libmexclass::proxy::MakeResult Table::make(
   mda::StructArray opts = constructor_arguments[0];
   const mda::StringArray method = opts[0]["Method"];
 
-  if (method[0] == u"FromArrays") {
+  if (method[0] == u"from_arrays") {
     return from_arrays(opts);
   } else if (method[0] == u"from_record_batches") {
     return from_record_batches(opts);

--- a/matlab/src/cpp/arrow/matlab/tabular/proxy/table.cc
+++ b/matlab/src/cpp/arrow/matlab/tabular/proxy/table.cc
@@ -24,9 +24,9 @@
 
 #include "arrow/matlab/error/error.h"
 #include "arrow/matlab/tabular/get_row_as_string.h"
+#include "arrow/matlab/tabular/proxy/record_batch.h"
 #include "arrow/matlab/tabular/proxy/schema.h"
 #include "arrow/matlab/tabular/proxy/table.h"
-#include "arrow/matlab/tabular/proxy/record_batch.h"
 
 #include "arrow/type.h"
 #include "arrow/util/utf8.h"
@@ -73,7 +73,6 @@ Table::Table(std::shared_ptr<arrow::Table> table) : table{table} {
 
 std::shared_ptr<arrow::Table> Table::unwrap() { return table; }
 
-
 void Table::toString(libmexclass::proxy::method::Context& context) {
   MATLAB_ASSIGN_OR_ERROR_WITH_CONTEXT(const auto utf16_string,
                                       arrow::util::UTF8StringToUTF16(table->ToString()),
@@ -84,87 +83,87 @@ void Table::toString(libmexclass::proxy::method::Context& context) {
 }
 
 namespace {
-  libmexclass::proxy::MakeResult from_arrays(const mda::StructArray& opts) {
-    using ArrayProxy = arrow::matlab::array::proxy::Array;
-    using TableProxy = arrow::matlab::tabular::proxy::Table;
+libmexclass::proxy::MakeResult from_arrays(const mda::StructArray& opts) {
+  using ArrayProxy = arrow::matlab::array::proxy::Array;
+  using TableProxy = arrow::matlab::tabular::proxy::Table;
 
-    const mda::TypedArray<uint64_t> arrow_array_proxy_ids = opts[0]["ArrayProxyIDs"];
-    const mda::StringArray column_names = opts[0]["ColumnNames"];
+  const mda::TypedArray<uint64_t> arrow_array_proxy_ids = opts[0]["ArrayProxyIDs"];
+  const mda::StringArray column_names = opts[0]["ColumnNames"];
 
-    std::vector<std::shared_ptr<arrow::Array>> arrow_arrays;
-    // Retrieve all of the Arrow Array Proxy instances from the libmexclass ProxyManager.
-    for (const auto& arrow_array_proxy_id : arrow_array_proxy_ids) {
-      auto proxy = libmexclass::proxy::ProxyManager::getProxy(arrow_array_proxy_id);
-      auto arrow_array_proxy = std::static_pointer_cast<ArrayProxy>(proxy);
-      auto arrow_array = arrow_array_proxy->unwrap();
-      arrow_arrays.push_back(arrow_array);
-    }
-
-    std::vector<std::shared_ptr<Field>> fields;
-    for (size_t i = 0; i < arrow_arrays.size(); ++i) {
-      const auto type = arrow_arrays[i]->type();
-      const auto column_name_utf16 = std::u16string(column_names[i]);
-      MATLAB_ASSIGN_OR_ERROR(const auto column_name_utf8,
-                            arrow::util::UTF16StringToUTF8(column_name_utf16),
-                            error::UNICODE_CONVERSION_ERROR_ID);
-      fields.push_back(std::make_shared<arrow::Field>(column_name_utf8, type));
-    }
-
-    arrow::SchemaBuilder schema_builder;
-    MATLAB_ERROR_IF_NOT_OK(schema_builder.AddFields(fields),
-                          error::SCHEMA_BUILDER_ADD_FIELDS_ERROR_ID);
-    MATLAB_ASSIGN_OR_ERROR(const auto schema, schema_builder.Finish(),
-                          error::SCHEMA_BUILDER_FINISH_ERROR_ID);
-    const auto num_rows = arrow_arrays.size() == 0 ? 0 : arrow_arrays[0]->length();
-    const auto table = arrow::Table::Make(schema, arrow_arrays, num_rows);
-    return std::make_shared<TableProxy>(table);
+  std::vector<std::shared_ptr<arrow::Array>> arrow_arrays;
+  // Retrieve all of the Arrow Array Proxy instances from the libmexclass ProxyManager.
+  for (const auto& arrow_array_proxy_id : arrow_array_proxy_ids) {
+    auto proxy = libmexclass::proxy::ProxyManager::getProxy(arrow_array_proxy_id);
+    auto arrow_array_proxy = std::static_pointer_cast<ArrayProxy>(proxy);
+    auto arrow_array = arrow_array_proxy->unwrap();
+    arrow_arrays.push_back(arrow_array);
   }
 
-  libmexclass::proxy::MakeResult from_record_batches(const mda::StructArray& opts) {
-    using RecordBatchProxy = arrow::matlab::tabular::proxy::RecordBatch;
-    using TableProxy = arrow::matlab::tabular::proxy::Table;
-
-    size_t num_rows = 0;
-    const mda::TypedArray<uint64_t> record_batch_proxy_ids = opts[0]["RecordBatchProxyIDs"];
-
-    std::vector<std::shared_ptr<arrow::RecordBatch>> record_batches;
-    // Retrieve all of the Arrow RecordBatch Proxy instances from the libmexclass ProxyManager.
-    for (const auto& proxy_id : record_batch_proxy_ids) {
-      auto proxy = libmexclass::proxy::ProxyManager::getProxy(proxy_id);
-      auto record_batch_proxy = std::static_pointer_cast<RecordBatch>(proxy);
-      auto record_batch = record_batch_proxy->unwrap();
-      record_batches.push_back(record_batch);
-      num_rows += record_batches.back()->num_rows();
-    }
-
-    // This function can only be invoked if there's at least 1 RecordBatch,
-    // so this should be safe.
-    auto schema = record_batches[0]->schema();
-    // We've already validated the schemas are consistent.
-    // Just create a vector of columns.
-    size_t num_columns = schema->num_fields();
-    std::vector<std::shared_ptr<ChunkedArray>> columns(num_columns);
-
-    size_t num_batches = record_batches.size();
-
-    for (size_t i = 0; i < num_columns; ++i) {
-      std::vector<std::shared_ptr<Array>> column_arrays(num_batches);
-      for (size_t j = 0; j < num_batches; ++j) {
-        column_arrays[j] = record_batches[j]->column(i);
-      }
-      columns[i] = std::make_shared<ChunkedArray>(column_arrays, schema->field(i)->type());
-    }
-    const auto table = arrow::Table::Make(std::move(schema), std::move(columns), num_rows);
-    return std::make_shared<TableProxy>(table);
+  std::vector<std::shared_ptr<Field>> fields;
+  for (size_t i = 0; i < arrow_arrays.size(); ++i) {
+    const auto type = arrow_arrays[i]->type();
+    const auto column_name_utf16 = std::u16string(column_names[i]);
+    MATLAB_ASSIGN_OR_ERROR(const auto column_name_utf8,
+                           arrow::util::UTF16StringToUTF8(column_name_utf16),
+                           error::UNICODE_CONVERSION_ERROR_ID);
+    fields.push_back(std::make_shared<arrow::Field>(column_name_utf8, type));
   }
-} // anonymous namespace
+
+  arrow::SchemaBuilder schema_builder;
+  MATLAB_ERROR_IF_NOT_OK(schema_builder.AddFields(fields),
+                         error::SCHEMA_BUILDER_ADD_FIELDS_ERROR_ID);
+  MATLAB_ASSIGN_OR_ERROR(const auto schema, schema_builder.Finish(),
+                         error::SCHEMA_BUILDER_FINISH_ERROR_ID);
+  const auto num_rows = arrow_arrays.size() == 0 ? 0 : arrow_arrays[0]->length();
+  const auto table = arrow::Table::Make(schema, arrow_arrays, num_rows);
+  return std::make_shared<TableProxy>(table);
+}
+
+libmexclass::proxy::MakeResult from_record_batches(const mda::StructArray& opts) {
+  using RecordBatchProxy = arrow::matlab::tabular::proxy::RecordBatch;
+  using TableProxy = arrow::matlab::tabular::proxy::Table;
+
+  size_t num_rows = 0;
+  const mda::TypedArray<uint64_t> record_batch_proxy_ids = opts[0]["RecordBatchProxyIDs"];
+
+  std::vector<std::shared_ptr<arrow::RecordBatch>> record_batches;
+  // Retrieve all of the Arrow RecordBatch Proxy instances from the libmexclass
+  // ProxyManager.
+  for (const auto& proxy_id : record_batch_proxy_ids) {
+    auto proxy = libmexclass::proxy::ProxyManager::getProxy(proxy_id);
+    auto record_batch_proxy = std::static_pointer_cast<RecordBatch>(proxy);
+    auto record_batch = record_batch_proxy->unwrap();
+    record_batches.push_back(record_batch);
+    num_rows += record_batches.back()->num_rows();
+  }
+
+  // This function can only be invoked if there's at least 1 RecordBatch,
+  // so this should be safe.
+  auto schema = record_batches[0]->schema();
+  // We've already validated the schemas are consistent.
+  // Just create a vector of columns.
+  size_t num_columns = schema->num_fields();
+  std::vector<std::shared_ptr<ChunkedArray>> columns(num_columns);
+
+  size_t num_batches = record_batches.size();
+
+  for (size_t i = 0; i < num_columns; ++i) {
+    std::vector<std::shared_ptr<Array>> column_arrays(num_batches);
+    for (size_t j = 0; j < num_batches; ++j) {
+      column_arrays[j] = record_batches[j]->column(i);
+    }
+    columns[i] = std::make_shared<ChunkedArray>(column_arrays, schema->field(i)->type());
+  }
+  const auto table = arrow::Table::Make(std::move(schema), std::move(columns), num_rows);
+  return std::make_shared<TableProxy>(table);
+}
+}  // anonymous namespace
 
 libmexclass::proxy::MakeResult Table::make(
     const libmexclass::proxy::FunctionArguments& constructor_arguments) {
-  
   mda::StructArray opts = constructor_arguments[0];
   const mda::StringArray method = opts[0]["Method"];
-  
+
   if (method[0] == u"FromArrays") {
     return from_arrays(opts);
   } else if (method[0] == u"FromRecordBatches") {
@@ -172,7 +171,7 @@ libmexclass::proxy::MakeResult Table::make(
   } else {
     const std::string error_msg = "Unknown method";
     return libmexclass::error::Error{error::TABLE_NUMERIC_INDEX_WITH_EMPTY_TABLE,
-                                   error_msg};
+                                     error_msg};
   }
 }
 

--- a/matlab/src/cpp/arrow/matlab/tabular/proxy/table.cc
+++ b/matlab/src/cpp/arrow/matlab/tabular/proxy/table.cc
@@ -137,11 +137,9 @@ libmexclass::proxy::MakeResult from_record_batches(const mda::StructArray& opts)
     num_rows += record_batches.back()->num_rows();
   }
 
-  // This function can only be invoked if there's at least 1 RecordBatch,
-  // so this should be safe.
+  // The MATLAB client code that calls this function is responsible for pre-validating
+  // that this function is called with at least one RecordBatch.
   auto schema = record_batches[0]->schema();
-  // The MATLAB client code should have already validated that the schemas are consistent.
-  // Create a vector of columns.
   size_t num_columns = schema->num_fields();
   std::vector<std::shared_ptr<ChunkedArray>> columns(num_columns);
 

--- a/matlab/src/cpp/arrow/matlab/tabular/proxy/table.cc
+++ b/matlab/src/cpp/arrow/matlab/tabular/proxy/table.cc
@@ -169,8 +169,12 @@ libmexclass::proxy::MakeResult Table::make(
   } else if (method[0] == u"from_record_batches") {
     return from_record_batches(opts);
   } else {
-    const std::string error_msg = "Unknown method";
-    return libmexclass::error::Error{error::TABLE_NUMERIC_INDEX_WITH_EMPTY_TABLE,
+    const auto method_name_utf16 = std::u16string(method[0]);
+    MATLAB_ASSIGN_OR_ERROR(const auto method_name_utf8,
+                            arrow::util::UTF16StringToUTF8(method_name_utf16),
+                            error::UNICODE_CONVERSION_ERROR_ID);
+    const std::string error_msg = "Unknown make method: " + method_name_utf8;
+    return libmexclass::error::Error{error::TABLE_MAKE_UNKNOWN_METHOD,
                                      error_msg};
   }
 }

--- a/matlab/src/cpp/arrow/matlab/tabular/proxy/table.cc
+++ b/matlab/src/cpp/arrow/matlab/tabular/proxy/table.cc
@@ -169,11 +169,10 @@ libmexclass::proxy::MakeResult Table::make(
   } else {
     const auto method_name_utf16 = std::u16string(method[0]);
     MATLAB_ASSIGN_OR_ERROR(const auto method_name_utf8,
-                            arrow::util::UTF16StringToUTF8(method_name_utf16),
-                            error::UNICODE_CONVERSION_ERROR_ID);
+                           arrow::util::UTF16StringToUTF8(method_name_utf16),
+                           error::UNICODE_CONVERSION_ERROR_ID);
     const std::string error_msg = "Unknown make method: " + method_name_utf8;
-    return libmexclass::error::Error{error::TABLE_MAKE_UNKNOWN_METHOD,
-                                     error_msg};
+    return libmexclass::error::Error{error::TABLE_MAKE_UNKNOWN_METHOD, error_msg};
   }
 }
 

--- a/matlab/src/matlab/+arrow/+tabular/Table.m
+++ b/matlab/src/matlab/+arrow/+tabular/Table.m
@@ -139,7 +139,7 @@ classdef Table < matlab.mixin.CustomDisplay & matlab.mixin.Scalar
             validateColumnNames(opts.ColumnNames, numColumns);
 
             arrayProxyIDs = getArrayProxyIDs(arrowArrays);
-            args = struct(Method="FromArrays", ArrayProxyIDs=arrayProxyIDs, ColumnNames=opts.ColumnNames);
+            args = struct(Method="from_arrays", ArrayProxyIDs=arrayProxyIDs, ColumnNames=opts.ColumnNames);
             proxyName = "arrow.tabular.proxy.Table";
             proxy = arrow.internal.proxy.create(proxyName, args);
             arrowTable = arrow.tabular.Table(proxy);

--- a/matlab/src/matlab/+arrow/+tabular/Table.m
+++ b/matlab/src/matlab/+arrow/+tabular/Table.m
@@ -161,7 +161,7 @@ classdef Table < matlab.mixin.CustomDisplay & matlab.mixin.Scalar
                 if ~isempty(badIndex)
                     badIndex = badIndex + 1;
                     expectedSchema = arrow.tabular.internal.display.getSchemaString(firstSchema);
-                    unexpectedSchema = arrow.tabular.internal.display.getSchemaString(batches{badIndex}.Schema);
+                    inconsistentSchema = arrow.tabular.internal.display.getSchemaString(batches{inconsistentSchemaIndex }.Schema);
                     msg = "Schema of RecordBatch %d is\n\n\t%s\n\nExpected RecordBatch Schema to be\n\n\t%s";
                     msg = compose(msg, badIndex, unexpectedSchema, expectedSchema);
                     error("arrow:Table:FromRecordBatches:InconsistentSchema", msg);

--- a/matlab/src/matlab/+arrow/+tabular/Table.m
+++ b/matlab/src/matlab/+arrow/+tabular/Table.m
@@ -170,7 +170,7 @@ classdef Table < matlab.mixin.CustomDisplay & matlab.mixin.Scalar
 
             % TODO: Rename getArrayProxyIDs to getProxyIDs
             proxyIDs = arrow.array.internal.getArrayProxyIDs(batches);
-            args = struct(Method="FromRecordBatches", RecordBatchProxyIDs=proxyIDs);
+            args = struct(Method="from_record_batches", RecordBatchProxyIDs=proxyIDs);
             proxyName = "arrow.tabular.proxy.Table";
             proxy = arrow.internal.proxy.create(proxyName, args);
             arrowTable = arrow.tabular.Table(proxy);

--- a/matlab/src/matlab/+arrow/+tabular/Table.m
+++ b/matlab/src/matlab/+arrow/+tabular/Table.m
@@ -153,7 +153,7 @@ classdef Table < matlab.mixin.CustomDisplay & matlab.mixin.Scalar
                 msg = "The fromRecordBatches method requires at least one RecordBatch to be supplied.";
                 error("arrow:Table:FromRecordBatches:ZeroBatches", msg);
             elseif numel(batches) > 1
-                % Verify the RecordBatches have consistent Schema values.
+                % Verify that all supplied RecordBatches have a consistent Schema.
                 firstSchema = batches{1}.Schema;
                 otherSchemas = cellfun(@(rb) rb.Schema, batches(2:end), UniformOutput=false);
                 idx = cellfun(@(other) ~isequal(firstSchema, other), otherSchemas, UniformOutput=true);

--- a/matlab/src/matlab/+arrow/+tabular/Table.m
+++ b/matlab/src/matlab/+arrow/+tabular/Table.m
@@ -157,7 +157,7 @@ classdef Table < matlab.mixin.CustomDisplay & matlab.mixin.Scalar
                 firstSchema = batches{1}.Schema;
                 otherSchemas = cellfun(@(rb) rb.Schema, batches(2:end), UniformOutput=false);
                 idx = cellfun(@(other) ~isequal(firstSchema, other), otherSchemas, UniformOutput=true);
-                badIndex = find(idx, 1,"first");
+                inconsistentSchemaIndex = find(idx, 1,"first");
                 if ~isempty(badIndex)
                     badIndex = badIndex + 1;
                     expectedSchema = arrow.tabular.internal.display.getSchemaString(firstSchema);

--- a/matlab/src/matlab/+arrow/+tabular/Table.m
+++ b/matlab/src/matlab/+arrow/+tabular/Table.m
@@ -158,12 +158,12 @@ classdef Table < matlab.mixin.CustomDisplay & matlab.mixin.Scalar
                 otherSchemas = cellfun(@(rb) rb.Schema, batches(2:end), UniformOutput=false);
                 idx = cellfun(@(other) ~isequal(firstSchema, other), otherSchemas, UniformOutput=true);
                 inconsistentSchemaIndex = find(idx, 1,"first");
-                if ~isempty(badIndex)
-                    badIndex = badIndex + 1;
+                if ~isempty(inconsistentSchemaIndex)
+                    inconsistentSchemaIndex = inconsistentSchemaIndex + 1;
                     expectedSchema = arrow.tabular.internal.display.getSchemaString(firstSchema);
-                    inconsistentSchema = arrow.tabular.internal.display.getSchemaString(batches{inconsistentSchemaIndex }.Schema);
-                    msg = "Schema of RecordBatch %d is\n\n\t%s\n\nExpected RecordBatch Schema to be\n\n\t%s";
-                    msg = compose(msg, badIndex, unexpectedSchema, expectedSchema);
+                    inconsistentSchema = arrow.tabular.internal.display.getSchemaString(batches{inconsistentSchemaIndex}.Schema);
+                    msg = "All RecordBatches must have a the same Schema.\n\nSchema of RecordBatch %d is\n\n\t%s\n\nExpected RecordBatch Schema to be\n\n\t%s";
+                    msg = compose(msg, inconsistentSchemaIndex, inconsistentSchema, expectedSchema);
                     error("arrow:Table:FromRecordBatches:InconsistentSchema", msg);
                 end
             end

--- a/matlab/src/matlab/+arrow/+tabular/Table.m
+++ b/matlab/src/matlab/+arrow/+tabular/Table.m
@@ -150,7 +150,7 @@ classdef Table < matlab.mixin.CustomDisplay & matlab.mixin.Scalar
                 batches(1, 1) arrow.tabular.RecordBatch
             end
             if numel(batches) == 0
-                msg = "Must supply at least one RecordBatch";
+                msg = "Must supply at least one RecordBatch.";
                 error("arrow:Table:FromRecordBatches:ZeroBatches", msg);
             elseif numel(batches) > 1
                 % Verify the RecordBatches have consistent Schema values.

--- a/matlab/src/matlab/+arrow/+tabular/Table.m
+++ b/matlab/src/matlab/+arrow/+tabular/Table.m
@@ -150,7 +150,7 @@ classdef Table < matlab.mixin.CustomDisplay & matlab.mixin.Scalar
                 batches(1, 1) arrow.tabular.RecordBatch
             end
             if numel(batches) == 0
-                msg = "Must supply at least one RecordBatch.";
+                msg = "The fromRecordBatches method requires at least one RecordBatch to be supplied.";
                 error("arrow:Table:FromRecordBatches:ZeroBatches", msg);
             elseif numel(batches) > 1
                 % Verify the RecordBatches have consistent Schema values.

--- a/matlab/src/matlab/+arrow/+tabular/Table.m
+++ b/matlab/src/matlab/+arrow/+tabular/Table.m
@@ -162,7 +162,7 @@ classdef Table < matlab.mixin.CustomDisplay & matlab.mixin.Scalar
                     inconsistentSchemaIndex = inconsistentSchemaIndex + 1;
                     expectedSchema = arrow.tabular.internal.display.getSchemaString(firstSchema);
                     inconsistentSchema = arrow.tabular.internal.display.getSchemaString(batches{inconsistentSchemaIndex}.Schema);
-                    msg = "All RecordBatches must have a the same Schema.\n\nSchema of RecordBatch %d is\n\n\t%s\n\nExpected RecordBatch Schema to be\n\n\t%s";
+                    msg = "All RecordBatches must have the same Schema.\n\nSchema of RecordBatch %d is\n\n\t%s\n\nExpected RecordBatch Schema to be\n\n\t%s";
                     msg = compose(msg, inconsistentSchemaIndex, inconsistentSchema, expectedSchema);
                     error("arrow:Table:FromRecordBatches:InconsistentSchema", msg);
                 end

--- a/matlab/src/matlab/+arrow/table.m
+++ b/matlab/src/matlab/+arrow/table.m
@@ -20,14 +20,7 @@ function arrowTable = table(matlabTable)
         % ambiguous name parsing issue with MATLAB table type and arrow.table.
         matlabTable {istable} = table.empty(0, 0)
     end
-
     arrowArrays = arrow.tabular.internal.decompose(matlabTable);
-    arrayProxyIDs = arrow.array.internal.getArrayProxyIDs(arrowArrays);
-
     columnNames = string(matlabTable.Properties.VariableNames);
-    args = struct(ArrayProxyIDs=arrayProxyIDs, ColumnNames=columnNames);
-    proxyName = "arrow.tabular.proxy.Table";
-    proxy = arrow.internal.proxy.create(proxyName, args);
-
-    arrowTable = arrow.tabular.Table(proxy);
+    arrowTable = arrow.tabular.Table.fromArrays(arrowArrays{:}, ColumnNames=columnNames);
 end

--- a/matlab/test/arrow/tabular/tTable.m
+++ b/matlab/test/arrow/tabular/tTable.m
@@ -702,7 +702,7 @@ classdef tTable < matlab.unittest.TestCase
 
         function FromRecordBatchesInconsistentSchemaError(testCase)
             % Verify the arrow.tabular.Table.fromRecordBatches function
-            % throws an exception if the Schemas of the provided 
+            % throws an `arrow:Table:FromRecordBatches:InconsistentSchem` exception if the Schemas of the provided 
             % RecordBatches are not consistent.
             import arrow.tabular.Table
             matlabTable1 = table("A", 1);

--- a/matlab/test/arrow/tabular/tTable.m
+++ b/matlab/test/arrow/tabular/tTable.m
@@ -664,13 +664,12 @@ classdef tTable < matlab.unittest.TestCase
             testCase.verifyFalse(isequal(t1, t2, t3, t4));
         end
 
-
         function FromRecordBatchesZeroInputsError(testCase)
             % Verify the arrow.tabular.Table.fromRecordBatches function
             % throws an exception if called with zero input arguments.
             import arrow.tabular.Table
             fcn = @() Table.fromRecordBatches();
-            testCase.verifyError(fcn, "MATLAB:narginchk:notEnoughInputs");
+            testCase.verifyError(fcn, "arrow:Table:FromRecordBatches:ZeroBatches");
         end
 
         function FromRecordBatchesOneInput(testCase)
@@ -699,6 +698,20 @@ classdef tTable < matlab.unittest.TestCase
 
             arrowTable = Table.fromRecordBatches(recordBatch1, recordBatch2, recordBatch3);
             testCase.verifyTable(arrowTable, ["Number", "Letter"], ["arrow.type.Float64Type", "arrow.type.StringType"], [matlabTable1; matlabTable2; matlabTable3]);
+        end
+
+        function FromRecordBatchesInconsistentSchemaError(testCase)
+            % Verify the arrow.tabular.Table.fromRecordBatches function
+            % throws an expcetion if the RecordBatches provided do not have
+            % consistent Schemas.
+            import arrow.tabular.Table
+            matlabTable1 = table("A", 1);
+            matlabTable2 = table(2, "B");
+            recordBatch1 = arrow.recordBatch(matlabTable1);
+            recordBatch2 = arrow.recordBatch(matlabTable2);
+
+            fcn = @() Table.fromRecordBatches(recordBatch1, recordBatch2);
+            testCase.verifyError(fcn, "arrow:Table:FromRecordBatches:InconsistentSchema");
         end
     end
 

--- a/matlab/test/arrow/tabular/tTable.m
+++ b/matlab/test/arrow/tabular/tTable.m
@@ -666,7 +666,7 @@ classdef tTable < matlab.unittest.TestCase
 
         function FromRecordBatchesZeroInputsError(testCase)
             % Verify the arrow.tabular.Table.fromRecordBatches function
-            % throws an exception if called with zero input arguments.
+            % throws an `arrow:Table:FromRecordBatches:ZeroBatches` exception if called with zero input arguments.
             import arrow.tabular.Table
             fcn = @() Table.fromRecordBatches();
             testCase.verifyError(fcn, "arrow:Table:FromRecordBatches:ZeroBatches");

--- a/matlab/test/arrow/tabular/tTable.m
+++ b/matlab/test/arrow/tabular/tTable.m
@@ -664,6 +664,42 @@ classdef tTable < matlab.unittest.TestCase
             testCase.verifyFalse(isequal(t1, t2, t3, t4));
         end
 
+
+        function FromRecordBatchesZeroInputsError(testCase)
+            % Verify the arrow.tabular.Table.fromRecordBatches function
+            % throws an exception if called with zero input arguments.
+            import arrow.tabular.Table
+            fcn = @() Table.fromRecordBatches();
+            testCase.verifyError(fcn, "MATLAB:narginchk:notEnoughInputs");
+        end
+
+        function FromRecordBatchesOneInput(testCase)
+            % Verify the arrow.tabular.Table.fromRecordBatches function
+            % returns the expected arrow.tabular.Table instance when 
+            % provided a single RecordBatch as input.
+            import arrow.tabular.Table
+            matlabTable = table([1; 2], ["A"; "B"], VariableNames=["Number" "Letter"]);
+            recordBatch = arrow.recordBatch(matlabTable);
+            arrowTable = Table.fromRecordBatches(recordBatch);
+            testCase.verifyTable(arrowTable, ["Number", "Letter"], ["arrow.type.Float64Type", "arrow.type.StringType"], matlabTable);
+        end
+
+        function FromRecordBatchesMultipleInputs(testCase)
+            % Verify the arrow.tabular.Table.fromRecordBatches function
+            % returns the expected arrow.tabular.Table instance when 
+            % provided a single RecordBatch as input.
+            import arrow.tabular.Table
+            matlabTable1 = table([1; 2], ["A"; "B"], VariableNames=["Number" "Letter"]);
+            matlabTable2 = table([10; 20; 30], ["A1"; "B1"; "C1"], VariableNames=["Number" "Letter"]);
+            matlabTable3 = table([100; 200], ["A2"; "B2"], VariableNames=["Number" "Letter"]);
+
+            recordBatch1 = arrow.recordBatch(matlabTable1);
+            recordBatch2 = arrow.recordBatch(matlabTable2);
+            recordBatch3 = arrow.recordBatch(matlabTable3);
+
+            arrowTable = Table.fromRecordBatches(recordBatch1, recordBatch2, recordBatch3);
+            testCase.verifyTable(arrowTable, ["Number", "Letter"], ["arrow.type.Float64Type", "arrow.type.StringType"], [matlabTable1; matlabTable2; matlabTable3]);
+        end
     end
 
     methods

--- a/matlab/test/arrow/tabular/tTable.m
+++ b/matlab/test/arrow/tabular/tTable.m
@@ -686,7 +686,7 @@ classdef tTable < matlab.unittest.TestCase
         function FromRecordBatchesMultipleInputs(testCase)
             % Verify the arrow.tabular.Table.fromRecordBatches function
             % returns the expected arrow.tabular.Table instance when 
-            % provided a single RecordBatch as input.
+            % provided mulitple RecordBatches as input.
             import arrow.tabular.Table
             matlabTable1 = table([1; 2], ["A"; "B"], VariableNames=["Number" "Letter"]);
             matlabTable2 = table([10; 20; 30], ["A1"; "B1"; "C1"], VariableNames=["Number" "Letter"]);
@@ -702,8 +702,8 @@ classdef tTable < matlab.unittest.TestCase
 
         function FromRecordBatchesInconsistentSchemaError(testCase)
             % Verify the arrow.tabular.Table.fromRecordBatches function
-            % throws an expcetion if the RecordBatches provided do not have
-            % consistent Schemas.
+            % throws an exception if the Schemas of the provided 
+            % RecordBatches are not consistent.
             import arrow.tabular.Table
             matlabTable1 = table("A", 1);
             matlabTable2 = table(2, "B");

--- a/matlab/test/arrow/tabular/tTable.m
+++ b/matlab/test/arrow/tabular/tTable.m
@@ -666,7 +666,8 @@ classdef tTable < matlab.unittest.TestCase
 
         function FromRecordBatchesZeroInputsError(testCase)
             % Verify the arrow.tabular.Table.fromRecordBatches function
-            % throws an `arrow:Table:FromRecordBatches:ZeroBatches` exception if called with zero input arguments.
+            % throws an `arrow:Table:FromRecordBatches:ZeroBatches` 
+            % exception if called with zero input arguments.
             import arrow.tabular.Table
             fcn = @() Table.fromRecordBatches();
             testCase.verifyError(fcn, "arrow:Table:FromRecordBatches:ZeroBatches");
@@ -702,8 +703,9 @@ classdef tTable < matlab.unittest.TestCase
 
         function FromRecordBatchesInconsistentSchemaError(testCase)
             % Verify the arrow.tabular.Table.fromRecordBatches function
-            % throws an `arrow:Table:FromRecordBatches:InconsistentSchem` exception if the Schemas of the provided 
-            % RecordBatches are inconsistent
+            % throws an `arrow:Table:FromRecordBatches:InconsistentSchema`
+            % exception if the Schemas of the provided  RecordBatches are 
+            % inconsistent.
             import arrow.tabular.Table
             matlabTable1 = table("A", 1);
             matlabTable2 = table(2, "B");

--- a/matlab/test/arrow/tabular/tTable.m
+++ b/matlab/test/arrow/tabular/tTable.m
@@ -703,7 +703,7 @@ classdef tTable < matlab.unittest.TestCase
         function FromRecordBatchesInconsistentSchemaError(testCase)
             % Verify the arrow.tabular.Table.fromRecordBatches function
             % throws an `arrow:Table:FromRecordBatches:InconsistentSchem` exception if the Schemas of the provided 
-            % RecordBatches are not consistent.
+            % RecordBatches are inconsistent
             import arrow.tabular.Table
             matlabTable1 = table("A", 1);
             matlabTable2 = table(2, "B");


### PR DESCRIPTION
### Rationale for this change

This change makes it possible to create an `arrow.tabular.Table` instance from a list of `arrow.tabular.RecordBatch` instances whose `Schema`s are consistent.

### What changes are included in this PR?

Added a new static method called `fromRecordBatches` to the MATLAB class `arrow.tabular.Table`. This method should construct an `arrow.tabular.Table` from a variable number of `arrow.tabular.RecordBatch`es.

**Usage Example**
```matlab
>> rb1 = arrow.recordBatch(table([1:5]', [6:10]'));
>> rb2 = arrow.recordBatch(table([11:15]', [16:20]'));

>> table = arrow.tabular.Table.fromRecordBatches(rb1, rb2)

table = 

  Arrow Table with 10 rows and 2 columns:

    Schema:

        Var1: Float64 | Var2: Float64

    First Row:

        1 | 6
```

**Error Message Examples**
```matlab
% Error message when fromRecordBatches is called with zero input arguments
>> arrow.tabular.Table.fromRecordBatches()
Error using arrow.tabular.Table.fromRecordBatches (line 154)
The fromRecordBatches method requires at least one RecordBatch to be supplied.

% Error message when fromRecordBatches is given RecordBatches whose Schemas are inconsistent.
>> rb1 = arrow.recordBatch(table(1, 2, VariableNames=["Num1", "Num2"]));
>> rb2 = arrow.recordBatch(table(1, "A", VariableNames=["Num1", "Letter1"]));
>> arrow.tabular.Table.fromRecordBatches(rb1, rb2)
Error using arrow.tabular.Table.fromRecordBatches (line 167)
All RecordBatches must have the same Schema.

Schema of RecordBatch 2 is

	Num1: Float64 | Letter1: String

Expected RecordBatch Schema to be

	Num1: Float64 | Num2: Float64
```

### Are these changes tested?

Yes. Added four new test cases to the MATLAB test class `tTable`:

1. `FromRecordBatchesZeroInputsError`
2. `FromRecordBatchesOneInput`
3. `FromRecordBatchesMultipleInputs`
4. `FromRecordBatchesInconsistentSchemaError`

### Are there any user-facing changes?

Yes. Users can now create an `arrow.tabular.Table` instance via the static method `fromRecordBatches`.
* GitHub Issue: #46877