### PR TITLE
GH-41496: [Python][Azure][Docs] Turn on azure on debian-docs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1839,6 +1839,7 @@ services:
       ARROW_HOME: "/tmp/local"
       ARROW_JAVA_SKIP_GIT_PLUGIN:
       ARROW_SUBSTRAIT: "ON"
+      ARROW_AZURE: "ON"
       BUILD_DOCS_C_GLIB: "ON"
       BUILD_DOCS_CPP: "ON"
       BUILD_DOCS_PYTHON: "ON"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1833,12 +1833,12 @@ services:
       - SYS_ADMIN
     environment:
       <<: [*common, *ccache]
+      ARROW_AZURE: "ON"
       ARROW_CUDA: "ON"
       ARROW_CXX_FLAGS_DEBUG: "-g1"
       ARROW_C_FLAGS_DEBUG: "-g1"
       ARROW_HOME: "/tmp/local"
       ARROW_SUBSTRAIT: "ON"
-      ARROW_AZURE: "ON"
       BUILD_DOCS_C_GLIB: "ON"
       BUILD_DOCS_CPP: "ON"
       BUILD_DOCS_PYTHON: "ON"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1837,7 +1837,6 @@ services:
       ARROW_CXX_FLAGS_DEBUG: "-g1"
       ARROW_C_FLAGS_DEBUG: "-g1"
       ARROW_HOME: "/tmp/local"
-      ARROW_JAVA_SKIP_GIT_PLUGIN:
       ARROW_SUBSTRAIT: "ON"
       ARROW_AZURE: "ON"
       BUILD_DOCS_C_GLIB: "ON"


### PR DESCRIPTION
### Rationale for this change

AzureFilesystem is added to the source Python api docs but the refrence isn't updated yet: https://arrow.apache.org/docs/dev/python/api/filesystems.html

### What changes are included in this PR?
Turn on Azure when building documentation.

### Are these changes tested?
Yes, with CI.

### Are there any user-facing changes?
No.

* GitHub Issue: #41496