### PR TITLE
GH-44435: [GLib] Add distinct count support to GArrowArrayStatistics

### DIFF
--- a/c_glib/arrow-glib/basic-array.cpp
+++ b/c_glib/arrow-glib/basic-array.cpp
@@ -512,23 +512,6 @@ garrow_array_statistics_get_distinct_count(GArrowArrayStatistics *statistics)
   }
 }
 
-/**
- * garrow_array_statistics_set_distinct_count:
- * @statistics: A #GArrowArrayStatistics.
- * @distinct_count: The distinct count value to set.
- *
- * Sets the distinct count for the array statistics.
- *
- * Since: 21.0.0
- */
-void
-garrow_array_statistics_set_distinct_count(GArrowArrayStatistics *statistics,
-                                           gint64 distinct_count)
-{
-  auto priv = GARROW_ARRAY_STATISTICS_GET_PRIVATE(statistics);
-  priv->statistics.distinct_count = distinct_count;
-}
-
 typedef struct GArrowArrayPrivate_
 {
   std::shared_ptr<arrow::Array> array;

--- a/c_glib/arrow-glib/basic-array.cpp
+++ b/c_glib/arrow-glib/basic-array.cpp
@@ -476,6 +476,59 @@ garrow_array_statistics_get_null_count(GArrowArrayStatistics *statistics)
   }
 }
 
+/**
+ * garrow_array_statistics_has_distinct_count:
+ * @statistics: A #GArrowArrayStatistics.
+ *
+ * Returns: %TRUE if the distinct count is available, %FALSE otherwise.
+ *
+ * Since: 21.0.0
+ */
+gboolean
+garrow_array_statistics_has_distinct_count(GArrowArrayStatistics *statistics)
+{
+  auto priv = GARROW_ARRAY_STATISTICS_GET_PRIVATE(statistics);
+  return priv->statistics.distinct_count.has_value();
+}
+
+/**
+ * garrow_array_statistics_get_distinct_count:
+ * @statistics: A #GArrowArrayStatistics.
+ *
+ * Returns: 0 or larger value if @statistics has a valid distinct count value,
+ *   -1 otherwise.
+ *
+ * Since: 21.0.0
+ */
+gint64
+garrow_array_statistics_get_distinct_count(GArrowArrayStatistics *statistics)
+{
+  auto priv = GARROW_ARRAY_STATISTICS_GET_PRIVATE(statistics);
+  const auto &distinct_count = priv->statistics.distinct_count;
+  if (distinct_count) {
+    return distinct_count.value();
+  } else {
+    return -1;
+  }
+}
+
+/**
+ * garrow_array_statistics_set_distinct_count:
+ * @statistics: A #GArrowArrayStatistics.
+ * @distinct_count: The distinct count value to set.
+ *
+ * Sets the distinct count for the array statistics.
+ *
+ * Since: 21.0.0
+ */
+void
+garrow_array_statistics_set_distinct_count(GArrowArrayStatistics *statistics,
+                                           gint64 distinct_count)
+{
+  auto priv = GARROW_ARRAY_STATISTICS_GET_PRIVATE(statistics);
+  priv->statistics.distinct_count = distinct_count;
+}
+
 typedef struct GArrowArrayPrivate_
 {
   std::shared_ptr<arrow::Array> array;

--- a/c_glib/arrow-glib/basic-array.h
+++ b/c_glib/arrow-glib/basic-array.h
@@ -64,10 +64,6 @@ garrow_array_statistics_has_distinct_count(GArrowArrayStatistics *statistics);
 GARROW_AVAILABLE_IN_21_0
 gint64
 garrow_array_statistics_get_distinct_count(GArrowArrayStatistics *statistics);
-GARROW_AVAILABLE_IN_21_0
-void
-garrow_array_statistics_set_distinct_count(GArrowArrayStatistics *statistics,
-                                           gint64 distinct_count);
 
 GARROW_AVAILABLE_IN_6_0
 GArrowArray *

--- a/c_glib/arrow-glib/basic-array.h
+++ b/c_glib/arrow-glib/basic-array.h
@@ -58,6 +58,17 @@ GARROW_AVAILABLE_IN_20_0
 gint64
 garrow_array_statistics_get_null_count(GArrowArrayStatistics *statistics);
 
+GARROW_AVAILABLE_IN_21_0
+gboolean
+garrow_array_statistics_has_distinct_count(GArrowArrayStatistics *statistics);
+GARROW_AVAILABLE_IN_21_0
+gint64
+garrow_array_statistics_get_distinct_count(GArrowArrayStatistics *statistics);
+GARROW_AVAILABLE_IN_21_0
+void
+garrow_array_statistics_set_distinct_count(GArrowArrayStatistics *statistics,
+                                           gint64 distinct_count);
+
 GARROW_AVAILABLE_IN_6_0
 GArrowArray *
 garrow_array_import(gpointer c_abi_array, GArrowDataType *data_type, GError **error);

--- a/c_glib/test/test-array-statistics.rb
+++ b/c_glib/test/test-array-statistics.rb
@@ -49,8 +49,13 @@ class TestArrayStatistics < Test::Unit::TestCase
     assert_equal(1, @statistics.null_count)
   end
 
-  test("#distinct_count") do
-    assert_equal(false, @statistics.has_distinct_count?)
+  test("#has_distinct_count?") do
+    assert do
+      !@statistics.has_distinct_count?
+    end
+  end
+
+  test ("#distinct_count") do
     assert_equal(-1, @statistics.distinct_count)
   end
 end

--- a/c_glib/test/test-array-statistics.rb
+++ b/c_glib/test/test-array-statistics.rb
@@ -48,4 +48,12 @@ class TestArrayStatistics < Test::Unit::TestCase
   test("#null_count") do
     assert_equal(1, @statistics.null_count)
   end
+
+  test("#distinct_count") do
+    assert_equal(false, @statistics.has_distinct_count?)
+    assert_equal(-1, @statistics.distinct_count)
+    @statistics.set_distinct_count(2)
+    assert_equal(true, @statistics.has_distinct_count?)
+    assert_equal(2, @statistics.distinct_count)
+  end
 end

--- a/c_glib/test/test-array-statistics.rb
+++ b/c_glib/test/test-array-statistics.rb
@@ -52,8 +52,5 @@ class TestArrayStatistics < Test::Unit::TestCase
   test("#distinct_count") do
     assert_equal(false, @statistics.has_distinct_count?)
     assert_equal(-1, @statistics.distinct_count)
-    @statistics.set_distinct_count(2)
-    assert_equal(true, @statistics.has_distinct_count?)
-    assert_equal(2, @statistics.distinct_count)
   end
 end


### PR DESCRIPTION
### Rationale for this change

The GLib bindings were missing methods to handle distinct count statistics in GArrowArrayStatistics.

### What changes are included in this PR?

This PR adds the following:
- Add garrow_array_statistics_has_distinct_count()
- Add garrow_array_statistics_get_distinct_count()
- Add tests for distinct count

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.

* GitHub Issue: #44435 