### PR TITLE
GH-46895: [CI][Dev] Fix shellcheck errors in the ci/scripts/install_minio.sh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -319,6 +319,7 @@ repos:
           ?^ci/scripts/install_emscripten\.sh$|
           ?^ci/scripts/install_gcs_testbench\.sh$|
           ?^ci/scripts/install_iwyu\.sh$|
+          ?^ci/scripts/install_minio\.sh$|
           ?^ci/scripts/install_ninja\.sh$|
           ?^ci/scripts/install_numpy\.sh$|
           ?^ci/scripts/install_pandas\.sh$|

--- a/ci/scripts/install_minio.sh
+++ b/ci/scripts/install_minio.sh
@@ -34,7 +34,7 @@ archs=([x86_64]=amd64
        [s390x]=s390x)
 
 arch=$(uname -m)
-if [ -z ${archs[$arch]} ]; then
+if [ -z "${archs[$arch]}" ]; then
   echo "Unsupported architecture: ${arch}"
   exit 0
 fi
@@ -71,23 +71,23 @@ download()
   local output=$1
   local url=$2
 
-  mkdir -p $(dirname ${output})
+  mkdir -p "$(dirname "${output}")"
   if type wget > /dev/null 2>&1; then
-    wget -nv --output-document ${output} ${url}
+    wget -nv --output-document "${output}" "${url}"
   else
-    curl --fail --location --output ${output} ${url}
+    curl --fail --location --output "${output}" "${url}"
   fi
 }
 
 if [[ ! -x ${prefix}/bin/minio ]]; then
   url="https://dl.min.io/server/minio/release/${platform}-${arch}/archive/${minio_version}"
   echo "Fetching ${url}..."
-  download ${prefix}/bin/minio ${url}
-  chmod +x ${prefix}/bin/minio
+  download "${prefix}/bin/minio" "${url}"
+  chmod +x "${prefix}/bin/minio"
 fi
 if [[ ! -x ${prefix}/bin/mc ]]; then
   url="https://dl.min.io/client/mc/release/${platform}-${arch}/archive/${mc_version}"
   echo "Fetching ${url}..."
-  download ${prefix}/bin/mc ${url}
-  chmod +x ${prefix}/bin/mc
+  download "${prefix}/bin/mc" "${url}"
+  chmod +x "${prefix}/bin/mc"
 fi


### PR DESCRIPTION
### Rationale for this change

This is the sub issue #44748.

* SC2046: Quote this to prevent word splitting.
* SC2086: Double quote to prevent globbing and word splitting.


```
shellcheck ci/scripts/install_minio.sh

In ci/scripts/install_minio.sh line 37:
if [ -z ${archs[$arch]} ]; then
        ^-------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
if [ -z "${archs[$arch]}" ]; then


In ci/scripts/install_minio.sh line 74:
  mkdir -p $(dirname ${output})
           ^------------------^ SC2046 (warning): Quote this to prevent word splitting.
                     ^-------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
  mkdir -p $(dirname "${output}")


In ci/scripts/install_minio.sh line 76:
    wget -nv --output-document ${output} ${url}
                               ^-------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                         ^----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    wget -nv --output-document "${output}" "${url}"


In ci/scripts/install_minio.sh line 78:
    curl --fail --location --output ${output} ${url}
                                    ^-------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                              ^----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    curl --fail --location --output "${output}" "${url}"


In ci/scripts/install_minio.sh line 85:
  download ${prefix}/bin/minio ${url}
           ^-------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                               ^----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
  download "${prefix}"/bin/minio "${url}"


In ci/scripts/install_minio.sh line 86:
  chmod +x ${prefix}/bin/minio
           ^-------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
  chmod +x "${prefix}"/bin/minio


In ci/scripts/install_minio.sh line 91:
  download ${prefix}/bin/mc ${url}
           ^-------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                            ^----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
  download "${prefix}"/bin/mc "${url}"


In ci/scripts/install_minio.sh line 92:
  chmod +x ${prefix}/bin/mc
           ^-------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
  chmod +x "${prefix}"/bin/mc

For more information:
  https://www.shellcheck.net/wiki/SC2046 -- Quote this to prevent word splitt...
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
```


### What changes are included in this PR?

* Quote variables.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #46895