### PR TITLE
GH-46897: [Docs][C++][Python] Fix asof join documentation

### DIFF
--- a/cpp/src/arrow/acero/options.h
+++ b/cpp/src/arrow/acero/options.h
@@ -701,7 +701,8 @@ class ARROW_ACERO_EXPORT AsofJoinNodeOptions : public ExecNodeOptions {
     ///
     /// The input table must be sorted by the "on" key. Must be a single field of a common
     /// type. An inexact match is used on the "on" key, i.e. a row is considered a
-    /// match if and only if `right.on - left.on` is between 0 and `tolerance`.
+    /// match if and only if `right.on - left.on` is in the range
+    /// `[min(0, tolerance), max(0, tolerance)]`.
     /// Currently, the "on" key must be of an integer, date, or timestamp type.
     FieldRef on_key;
     /// \brief "by" key for the join.
@@ -723,8 +724,8 @@ class ARROW_ACERO_EXPORT AsofJoinNodeOptions : public ExecNodeOptions {
   /// \see `Keys` for details.
   std::vector<Keys> input_keys;
   /// \brief Tolerance for inexact "on" key matching. A right row is considered a match
-  /// with a left row if `right.on - left.on` is between 0 and `tolerance`. `tolerance`
-  /// may be:
+  /// with a left row if `right.on - left.on` is in the range `[min(0, tolerance), max(0, tolerance)]`.
+  /// `tolerance` may be:
   /// - negative, in which case a past-as-of-join occurs (match iff
   ///   `tolerance <= right.on - left.on <= 0`);
   /// - or positive, in which case a future-as-of-join occurs (match iff

--- a/cpp/src/arrow/acero/options.h
+++ b/cpp/src/arrow/acero/options.h
@@ -724,8 +724,8 @@ class ARROW_ACERO_EXPORT AsofJoinNodeOptions : public ExecNodeOptions {
   /// \see `Keys` for details.
   std::vector<Keys> input_keys;
   /// \brief Tolerance for inexact "on" key matching. A right row is considered a match
-  /// with a left row if `right.on - left.on` is in the range `[min(0, tolerance), max(0, tolerance)]`.
-  /// `tolerance` may be:
+  /// with a left row if `right.on - left.on` is in the range
+  /// `[min(0, tolerance), max(0, tolerance)]`. `tolerance` may be:
   /// - negative, in which case a past-as-of-join occurs (match iff
   ///   `tolerance <= right.on - left.on <= 0`);
   /// - or positive, in which case a future-as-of-join occurs (match iff

--- a/cpp/src/arrow/acero/options.h
+++ b/cpp/src/arrow/acero/options.h
@@ -700,8 +700,8 @@ class ARROW_ACERO_EXPORT AsofJoinNodeOptions : public ExecNodeOptions {
     /// \brief "on" key for the join.
     ///
     /// The input table must be sorted by the "on" key. Must be a single field of a common
-    /// type. Inexact match is used on the "on" key. i.e., a row is considered a match iff
-    /// left_on - tolerance <= right_on <= left_on.
+    /// type. An inexact match is used on the "on" key, i.e. a row is considered a
+    /// match if and only if `right.on - left.on` is between 0 and `tolerance`.
     /// Currently, the "on" key must be of an integer, date, or timestamp type.
     FieldRef on_key;
     /// \brief "by" key for the join.
@@ -723,10 +723,14 @@ class ARROW_ACERO_EXPORT AsofJoinNodeOptions : public ExecNodeOptions {
   /// \see `Keys` for details.
   std::vector<Keys> input_keys;
   /// \brief Tolerance for inexact "on" key matching. A right row is considered a match
-  /// with the left row if `right.on - left.on <= tolerance`. The `tolerance` may be:
-  /// - negative, in which case a past-as-of-join occurs;
-  /// - or positive, in which case a future-as-of-join occurs;
-  /// - or zero, in which case an exact-as-of-join occurs.
+  /// with a left row if `right.on - left.on` is between 0 and `tolerance`. `tolerance`
+  /// may be:
+  /// - negative, in which case a past-as-of-join occurs (match iff
+  ///   `tolerance <= right.on - left.on <= 0`);
+  /// - or positive, in which case a future-as-of-join occurs (match iff
+  ///   `0 <= right.on - left.on <= tolerance`);
+  /// - or zero, in which case an exact-as-of-join occurs (match iff
+  ///   `right.on == left.on`).
   ///
   /// The tolerance is interpreted in the same units as the "on" key.
   int64_t tolerance;

--- a/python/pyarrow/_acero.pyx
+++ b/python/pyarrow/_acero.pyx
@@ -446,7 +446,8 @@ class AsofJoinNodeOptions(_AsofJoinNodeOptions):
         Can be a string column name or a field expression.
 
         An inexact match is used on the "on" key, i.e. a row is considered a
-        match if and only if left_on - tolerance <= right_on <= left_on.
+        match if and only if ``right.on - left.on`` is in the range
+        ``[min(0, tolerance), max(0, tolerance)]``.
 
         The input dataset must be sorted by the "on" key. Must be a single
         field of a common type.

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -945,8 +945,8 @@ cdef class Dataset(_Weakrefable):
             of the join operation left side.
 
             An inexact match is used on the "on" key, i.e. a row is considered a
-            match if and only if ``right.on - left.on`` is between 0 and
-            ``tolerance``.
+            match if and only if ``right.on - left.on`` is in the range
+            ``[min(0, tolerance), max(0, tolerance)]``.
 
             The input table must be sorted by the "on" key. Must be a single
             field of a common type.
@@ -958,8 +958,8 @@ cdef class Dataset(_Weakrefable):
             only for the matches in these columns.
         tolerance : int
             The tolerance for inexact "on" key matching. A right row is considered
-            a match with a left row if ``right.on - left.on`` is between 0
-            and ``tolerance``. ``tolerance`` may be:
+            a match with a left row if ``right.on - left.on`` is in the range
+            ``[min(0, tolerance), max(0, tolerance)]``. ``tolerance`` may be:
 
             - negative, in which case a past-as-of-join occurs
               (match iff ``tolerance <= right.on - left.on <= 0``);

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -945,7 +945,8 @@ cdef class Dataset(_Weakrefable):
             of the join operation left side.
 
             An inexact match is used on the "on" key, i.e. a row is considered a
-            match if and only if left_on - tolerance <= right_on <= left_on.
+            match if and only if ``right.on - left.on`` is between 0 and
+            ``tolerance``.
 
             The input table must be sorted by the "on" key. Must be a single
             field of a common type.
@@ -957,12 +958,15 @@ cdef class Dataset(_Weakrefable):
             only for the matches in these columns.
         tolerance : int
             The tolerance for inexact "on" key matching. A right row is considered
-            a match with the left row `right.on - left.on <= tolerance`. The
-            `tolerance` may be:
-
-            - negative, in which case a past-as-of-join occurs;
-            - or positive, in which case a future-as-of-join occurs;
-            - or zero, in which case an exact-as-of-join occurs.
+            a match with a left row if ``right.on - left.on`` is between 0
+            and ``tolerance``. ``tolerance`` may be:
+            
+            - negative, in which case a past-as-of-join occurs
+              (match iff ``tolerance <= right.on - left.on <= 0``);
+            - or positive, in which case a future-as-of-join occurs
+              (match iff ``0 <= right.on - left.on <= tolerance``);
+            - or zero, in which case an exact-as-of-join occurs
+              (match iff ``right.on == left.on``).
 
             The tolerance is interpreted in the same units as the "on" key.
         right_on : str or list[str], default None

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -960,7 +960,7 @@ cdef class Dataset(_Weakrefable):
             The tolerance for inexact "on" key matching. A right row is considered
             a match with a left row if ``right.on - left.on`` is between 0
             and ``tolerance``. ``tolerance`` may be:
-            
+
             - negative, in which case a past-as-of-join occurs
               (match iff ``tolerance <= right.on - left.on <= 0``);
             - or positive, in which case a future-as-of-join occurs

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -5809,7 +5809,7 @@ cdef class Table(_Tabular):
             The tolerance for inexact "on" key matching. A right row is considered
             a match with a left row if ``right.on - left.on`` is between 0
             and ``tolerance``. ``tolerance`` may be:
-            
+
             - negative, in which case a past-as-of-join occurs
               (match iff ``tolerance <= right.on - left.on <= 0``);
             - or positive, in which case a future-as-of-join occurs

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -5794,8 +5794,8 @@ cdef class Table(_Tabular):
             of the join operation left side.
 
             An inexact match is used on the "on" key, i.e. a row is considered a
-            match if and only if ``right.on - left.on`` is between 0 and
-            ``tolerance``.
+            match if and only if ``right.on - left.on`` is in the range
+            ``[min(0, tolerance), max(0, tolerance)]``.
 
             The input dataset must be sorted by the "on" key. Must be a single
             field of a common type.
@@ -5807,8 +5807,8 @@ cdef class Table(_Tabular):
             only for the matches in these columns.
         tolerance : int
             The tolerance for inexact "on" key matching. A right row is considered
-            a match with a left row if ``right.on - left.on`` is between 0
-            and ``tolerance``. ``tolerance`` may be:
+            a match with a left row if ``right.on - left.on`` is in the range
+            ``[min(0, tolerance), max(0, tolerance)]``. ``tolerance`` may be:
 
             - negative, in which case a past-as-of-join occurs
               (match iff ``tolerance <= right.on - left.on <= 0``);

--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -5794,7 +5794,8 @@ cdef class Table(_Tabular):
             of the join operation left side.
 
             An inexact match is used on the "on" key, i.e. a row is considered a
-            match if and only if left_on - tolerance <= right_on <= left_on.
+            match if and only if ``right.on - left.on`` is between 0 and
+            ``tolerance``.
 
             The input dataset must be sorted by the "on" key. Must be a single
             field of a common type.
@@ -5806,12 +5807,15 @@ cdef class Table(_Tabular):
             only for the matches in these columns.
         tolerance : int
             The tolerance for inexact "on" key matching. A right row is considered
-            a match with the left row ``right.on - left.on <= tolerance``. The
-            ``tolerance`` may be:
-
-            - negative, in which case a past-as-of-join occurs;
-            - or positive, in which case a future-as-of-join occurs;
-            - or zero, in which case an exact-as-of-join occurs.
+            a match with a left row if ``right.on - left.on`` is between 0
+            and ``tolerance``. ``tolerance`` may be:
+            
+            - negative, in which case a past-as-of-join occurs
+              (match iff ``tolerance <= right.on - left.on <= 0``);
+            - or positive, in which case a future-as-of-join occurs
+              (match iff ``0 <= right.on - left.on <= tolerance``);
+            - or zero, in which case an exact-as-of-join occurs
+              (match iff ``right.on == left.on``).
 
             The tolerance is interpreted in the same units as the "on" key.
         right_on : str or list[str], default None


### PR DESCRIPTION
### Rationale for this change

The asof join documentation is currently incorrect. Here is a copy of https://github.com/apache/arrow/issues/46897 for convenience:

There are two issues with the asof join docs:
1. In the doc for the `on` parameter, it says "a row is considered a match if and only if left_on - tolerance <= right_on <= left_on." This is incorrect because a join with positive tolerance results in right_on values that are _greater_ than or equal to left_on. Also, the inequality does not make sense for negative tolerances.
2. In the doc for the `tolerance` parameter, it says "A right row is considered a match with the left row `right.on - left.on <= tolerance`." This does not mention that the difference must also be greater than or equal to 0. Also, the inequality is only correct for non-negative `tolerance`s.

### What changes are included in this PR?

This PR updates the asof join documentation for `pyarrow.Table`, `pyarrow.Dataset` and `acero::AsofJoinNodeOptions`.

### Are these changes tested?

N/A

### Are there any user-facing changes?

It updates the documentation.

* GitHub Issue: #46897