### PR TITLE
GH-46899: [CI][Dev] Fix shellcheck errors in the ci/scripts/install_numba.sh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -321,6 +321,7 @@ repos:
           ?^ci/scripts/install_iwyu\.sh$|
           ?^ci/scripts/install_minio\.sh$|
           ?^ci/scripts/install_ninja\.sh$|
+          ?^ci/scripts/install_numba\.sh$|
           ?^ci/scripts/install_numpy\.sh$|
           ?^ci/scripts/install_pandas\.sh$|
           ?^ci/scripts/install_python\.sh$|

--- a/ci/scripts/install_numba.sh
+++ b/ci/scripts/install_numba.sh
@@ -27,8 +27,8 @@ fi
 numba=$1
 
 if [ -n "${ARROW_PYTHON_VENV:-}" ]; then
-  # This comment avoids shellcheck SC1091 error.
-  # https://www.shellcheck.net/wiki/SC1091
+  # We don't need to follow this external file.
+  # See also: https://www.shellcheck.net/wiki/SC1091
   #
   # shellcheck source=/dev/null
   . "${ARROW_PYTHON_VENV}/bin/activate"

--- a/ci/scripts/install_numba.sh
+++ b/ci/scripts/install_numba.sh
@@ -27,6 +27,10 @@ fi
 numba=$1
 
 if [ -n "${ARROW_PYTHON_VENV:-}" ]; then
+  # This comment avoids shellcheck SC1091 error.
+  # https://www.shellcheck.net/wiki/SC1091
+  #
+  # shellcheck source=/dev/null
   . "${ARROW_PYTHON_VENV}/bin/activate"
 fi
 
@@ -35,5 +39,5 @@ if [ "${numba}" = "master" ]; then
 elif [ "${numba}" = "latest" ]; then
   pip install numba
 else
-  pip install numba==${numba}
+  pip install "numba==${numba}"
 fi


### PR DESCRIPTION
### Rationale for this change

This is the sub issue #44748.

```
% shellcheck ci/scripts/install_numba.sh

In ci/scripts/install_numba.sh line 30:
  . "${ARROW_PYTHON_VENV}/bin/activate"
    ^-- SC1091 (info): Not following: ./bin/activate: openBinaryFile: does not exist (No such file or directory)


In ci/scripts/install_numba.sh line 38:
  pip install numba==${numba}
                     ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
  pip install numba=="${numba}"

For more information:
  https://www.shellcheck.net/wiki/SC1091 -- Not following: ./bin/activate: op...
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
```

### What changes are included in this PR?

* SC1091: set `/dev/null` as dummy file.
* SC2086: Quote variables. 

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #46899