### PR TITLE
GH-46901: [C++] Support modulo compute kernel

### DIFF
--- a/cpp/src/arrow/compute/api_scalar.cc
+++ b/cpp/src/arrow/compute/api_scalar.cc
@@ -787,6 +787,7 @@ Result<Datum> RoundToMultiple(const Datum& arg, RoundToMultipleOptions options,
 SCALAR_ARITHMETIC_BINARY(Add, "add", "add_checked")
 SCALAR_ARITHMETIC_BINARY(Divide, "divide", "divide_checked")
 SCALAR_ARITHMETIC_BINARY(Logb, "logb", "logb_checked")
+SCALAR_ARITHMETIC_BINARY(Modulo, "modulo", "modulo_checked")
 SCALAR_ARITHMETIC_BINARY(Multiply, "multiply", "multiply_checked")
 SCALAR_ARITHMETIC_BINARY(Power, "power", "power_checked")
 SCALAR_ARITHMETIC_BINARY(ShiftLeft, "shift_left", "shift_left_checked")

--- a/cpp/src/arrow/compute/api_scalar.h
+++ b/cpp/src/arrow/compute/api_scalar.h
@@ -632,6 +632,21 @@ Result<Datum> Subtract(const Datum& left, const Datum& right,
                        ArithmeticOptions options = ArithmeticOptions(),
                        ExecContext* ctx = NULLPTR);
 
+/// \brief Get the modulo of dividing two values.
+/// Array values must be the same length.
+/// If either argument is null the result will be null.
+/// For integer types, if there is a zero divisor, an error will be raised.
+///
+/// \param[in] left the dividend
+/// \param[in] right the divisor
+/// \param[in] options arithmetic options (enable/disable overflow checking), optional
+/// \param[in] ctx the function execution context, optional
+/// \return the elementwise remainder
+ARROW_EXPORT
+Result<Datum> Modulo(const Datum& left, const Datum& right,
+                     ArithmeticOptions options = ArithmeticOptions(),
+                     ExecContext* ctx = NULLPTR);
+
 /// \brief Multiply two values. Array values must be the same length. If either
 /// factor is null the result will be null.
 ///

--- a/cpp/src/arrow/compute/kernels/base_arithmetic_internal.h
+++ b/cpp/src/arrow/compute/kernels/base_arithmetic_internal.h
@@ -477,7 +477,7 @@ struct Modulo {
   static enable_if_integer_value<T> Call(KernelContext*, Arg0 left, Arg1 right,
                                          Status* st) {
     if (ARROW_PREDICT_FALSE(right == 0)) {
-      *st = Status::Invalid("Divide by zero");
+      *st = Status::Invalid("Modulo by zero");
       return 0;
     }
 
@@ -506,9 +506,9 @@ struct ModuloChecked {
     T result;
     if (ARROW_PREDICT_FALSE(ModuloWithOverflow(left, right, &result))) {
       if (right == 0) {
-        *st = Status::Invalid("divide by zero");
+        *st = Status::Invalid("Modulo by zero");
       } else {
-        *st = Status::Invalid("overflow");
+        *st = Status::Invalid("Overflow");
       }
     }
     return result;

--- a/cpp/src/arrow/compute/kernels/base_arithmetic_internal.h
+++ b/cpp/src/arrow/compute/kernels/base_arithmetic_internal.h
@@ -31,6 +31,7 @@ namespace arrow {
 
 using internal::AddWithOverflow;
 using internal::DivideWithOverflow;
+using internal::ModuloWithOverflow;
 using internal::MultiplyWithOverflow;
 using internal::NegateWithOverflow;
 using internal::SubtractWithOverflow;
@@ -462,6 +463,62 @@ struct FloatingDivideChecked {
     return Call<double>(ctx, static_cast<double>(left), static_cast<double>(right), st);
   }
   // TODO: Add decimal
+};
+
+struct Modulo {
+  template <typename T, typename Arg0, typename Arg1>
+  static enable_if_floating_value<T> Call(KernelContext*, Arg0 left, Arg1 right,
+                                          Status* st) {
+    *st = Status::Invalid("Not implemented");
+    return 0;
+  }
+
+  template <typename T, typename Arg0, typename Arg1>
+  static enable_if_integer_value<T> Call(KernelContext*, Arg0 left, Arg1 right,
+                                         Status* st) {
+    if (ARROW_PREDICT_FALSE(right == 0)) {
+      *st = Status::Invalid("Divide by zero");
+      return 0;
+    }
+
+    return left % right;
+  }
+
+  template <typename T, typename Arg0, typename Arg1>
+  static enable_if_decimal_value<T> Call(KernelContext* ctx, Arg0 left, Arg1 right,
+                                         Status* st) {
+    return Divide::Call<T>(ctx, left, right, st);
+  }
+};
+
+struct ModuloChecked {
+  template <typename T, typename Arg0, typename Arg1>
+  static enable_if_floating_value<T> Call(KernelContext*, Arg0 left, Arg1 right,
+                                          Status* st) {
+    *st = Status::Invalid("Not implemented");
+    return 0;
+  }
+
+  template <typename T, typename Arg0, typename Arg1>
+  static enable_if_integer_value<T> Call(KernelContext*, Arg0 left, Arg1 right,
+                                         Status* st) {
+    static_assert(std::is_same<T, Arg0>::value && std::is_same<T, Arg1>::value, "");
+    T result;
+    if (ARROW_PREDICT_FALSE(ModuloWithOverflow(left, right, &result))) {
+      if (right == 0) {
+        *st = Status::Invalid("divide by zero");
+      } else {
+        *st = Status::Invalid("overflow");
+      }
+    }
+    return result;
+  }
+
+  template <typename T, typename Arg0, typename Arg1>
+  static enable_if_decimal_value<T> Call(KernelContext* ctx, Arg0 left, Arg1 right,
+                                         Status* st) {
+    return Divide::Call<T>(ctx, left, right, st);
+  }
 };
 
 struct Negate {

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
@@ -937,7 +937,7 @@ TYPED_TEST(TestBinaryArithmeticSigned, Modulo) {
 TYPED_TEST(TestBinaryArithmeticIntegral, ModuloByZero) {
   for (auto check_overflow : {false, true}) {
     this->SetOverflowCheck(check_overflow);
-    this->AssertBinopRaises(Modulo, "[3, 2, 6]", "[1, 1, 0]", "divide by zero");
+    this->AssertBinopRaises(Modulo, "[3, 2, 6]", "[1, 1, 0]", "Modulo by zero");
   }
 }
 

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
@@ -900,6 +900,47 @@ TYPED_TEST(TestBinaryArithmeticSigned, DivideOverflowRaises) {
   this->AssertBinop(Divide, MakeArray(min), MakeArray(-1), "[0]");
 }
 
+TYPED_TEST(TestBinaryArithmeticIntegral, Modulo) {
+  for (auto check_overflow : {false, true}) {
+    this->SetOverflowCheck(check_overflow);
+
+    // Empty arrays
+    this->AssertBinop(Modulo, "[]", "[]", "[]");
+    // Ordinary arrays
+    this->AssertBinop(Modulo, "[3, 2, 6]", "[1, 1, 2]", "[0, 0, 0]");
+    // Array with nulls
+    this->AssertBinop(Modulo, "[null, 10, 30, null, 20]", "[1, 4, 2, 5, 10]",
+                      "[null, 2, 0, null, 0]");
+    // Scalar % Array
+    this->AssertBinop(Modulo, 33, "[null, 1, 3, null, 2]", "[null, 0, 0, null, 1]");
+    // Array % Scalar
+    this->AssertBinop(Modulo, "[null, 10, 30, null, 2]", 3, "[null, 1, 0, null, 2]");
+    // Scalar % Scalar
+    this->AssertBinop(Modulo, 16, 7, 2);
+  }
+}
+
+TYPED_TEST(TestBinaryArithmeticSigned, Modulo) {
+  // Ordinary arrays
+  this->AssertBinop(Modulo, "[-3, 2, -7]", "[1, 1, 2]", "[0, 0, -1]");
+  // Array with nulls
+  this->AssertBinop(Modulo, "[null, 10, 30, null, -21]", "[1, 4, 2, 5, 10]",
+                    "[null, 2, 0, null, -1]");
+  // Scalar % Array
+  this->AssertBinop(Modulo, 33, "[null, -1, -3, null, 2]", "[null, 0, 0, null, 1]");
+  // Array % Scalar
+  this->AssertBinop(Modulo, "[null, 10, 30, null, 2]", 3, "[null, 1, 0, null, 2]");
+  // Scalar % Scalar
+  this->AssertBinop(Modulo, -17, -8, -1);
+}
+
+TYPED_TEST(TestBinaryArithmeticIntegral, ModuloByZero) {
+  for (auto check_overflow : {false, true}) {
+    this->SetOverflowCheck(check_overflow);
+    this->AssertBinopRaises(Modulo, "[3, 2, 6]", "[1, 1, 0]", "divide by zero");
+  }
+}
+
 TYPED_TEST(TestBinaryArithmeticFloating, Power) {
   using CType = typename TestFixture::CType;
   auto max = std::numeric_limits<CType>::max();

--- a/cpp/src/arrow/util/basic_decimal.cc
+++ b/cpp/src/arrow/util/basic_decimal.cc
@@ -1398,6 +1398,14 @@ BasicDecimal256 operator/(const BasicDecimal256& left, const BasicDecimal256& ri
   return result;
 }
 
+BasicDecimal256 operator%(const BasicDecimal256& left, const BasicDecimal256& right) {
+  BasicDecimal256 remainder;
+  BasicDecimal256 result;
+  auto s = left.Divide(right, &result, &remainder);
+  DCHECK_EQ(s, DecimalStatus::kSuccess);
+  return remainder;
+}
+
 // Explicitly instantiate template base class, for DLL linking on Windows
 template class GenericBasicDecimal<BasicDecimal128, 128>;
 template class GenericBasicDecimal<BasicDecimal256, 256>;

--- a/cpp/src/arrow/util/basic_decimal.h
+++ b/cpp/src/arrow/util/basic_decimal.h
@@ -883,5 +883,7 @@ ARROW_EXPORT BasicDecimal256 operator*(const BasicDecimal256& left,
                                        const BasicDecimal256& right);
 ARROW_EXPORT BasicDecimal256 operator/(const BasicDecimal256& left,
                                        const BasicDecimal256& right);
+ARROW_EXPORT BasicDecimal256 operator%(const BasicDecimal256& left,
+                                       const BasicDecimal256& right);
 
 }  // namespace arrow

--- a/cpp/src/arrow/util/int_util_overflow.h
+++ b/cpp/src/arrow/util/int_util_overflow.h
@@ -59,6 +59,7 @@ OPS_WITH_OVERFLOW(AddWithOverflow, add)
 OPS_WITH_OVERFLOW(SubtractWithOverflow, sub)
 OPS_WITH_OVERFLOW(MultiplyWithOverflow, mul)
 OPS_WITH_OVERFLOW(DivideWithOverflow, div)
+OPS_WITH_OVERFLOW(ModuloWithOverflow, mod)
 
 #undef OP_WITH_OVERFLOW
 #undef OPS_WITH_OVERFLOW


### PR DESCRIPTION
### Rationale for this change

Support for calculating elementwise remainder.

### What changes are included in this PR?

This PR adds new kernel function `modulo`, `modulo_checked`

### Are these changes tested?

Yes, test code are included.

### Are there any user-facing changes?

There is a new compute kernel `modulo` available.

Closes: #46901 

* GitHub Issue: #46901