### PR TITLE
GH-46909: [CI][Dev] Fix shellcheck errors in the ci/scripts/install_sccache.sh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -325,6 +325,7 @@ repos:
           ?^ci/scripts/install_numpy\.sh$|
           ?^ci/scripts/install_pandas\.sh$|
           ?^ci/scripts/install_python\.sh$|
+          ?^ci/scripts/install_sccache\.sh$|
           ?^ci/scripts/install_spark\.sh$|
           ?^ci/scripts/install_vcpkg\.sh$|
           ?^ci/scripts/integration_arrow_build\.sh$|

--- a/ci/scripts/install_sccache.sh
+++ b/ci/scripts/install_sccache.sh
@@ -19,7 +19,7 @@
 
 set -e
 
-if [  "$#" -lt 1 -o "$#" -gt 3 ]; then
+if [  "$#" -lt 1 ] || [ "$#" -gt 3 ]; then
     echo "Usage: $0 <build> <prefix> <version>"
     echo "Will default to version=0.3.0 "
     exit 1
@@ -39,8 +39,8 @@ SCCACHE_URL="https://github.com/mozilla/sccache/releases/download/v$VERSION/scca
 SCCACHE_ARCHIVE=sccache.tar.gz
 
 # Download archive and checksum
-curl -L $SCCACHE_URL --output $SCCACHE_ARCHIVE
-curl -L $SCCACHE_URL.sha256 --output $SCCACHE_ARCHIVE.sha256
+curl -L "$SCCACHE_URL" --output $SCCACHE_ARCHIVE
+curl -L "${SCCACHE_URL}.sha256" --output $SCCACHE_ARCHIVE.sha256
 echo "  $SCCACHE_ARCHIVE" >> $SCCACHE_ARCHIVE.sha256
 
 SHA_ARGS="--check --status"
@@ -50,19 +50,19 @@ if sha256sum --version 2>&1 | grep -q BusyBox; then
   SHA_ARGS="-sc"
 fi
 
-sha256sum $SHA_ARGS $SCCACHE_ARCHIVE.sha256
+sha256sum "$SHA_ARGS" $SCCACHE_ARCHIVE.sha256
 
-if [ ! -d $PREFIX ]; then
-    mkdir -p $PREFIX
+if [ ! -d "$PREFIX" ]; then
+    mkdir -p "$PREFIX"
 fi
 
 # Extract only the sccache binary into $PREFIX and ignore README and LICENSE.
 # --wildcards doesn't work on busybox.
-tar -xzvf $SCCACHE_ARCHIVE --strip-component=1 --directory $PREFIX --exclude="sccache*/*E*E*"
-chmod a+x $PREFIX/sccache
+tar -xzvf $SCCACHE_ARCHIVE --strip-component=1 --directory "$PREFIX" --exclude="sccache*/*E*E*"
+chmod a+x "${PREFIX}/sccache"
 
 if [ -n "${GITHUB_PATH}" ]; then
-    echo "$PREFIX" >> $GITHUB_PATH
+    echo "$PREFIX" >> "$GITHUB_PATH"
     # Add executable for windows as mingw workaround.
-    echo "SCCACHE_PATH=$PREFIX/sccache.exe" >> $GITHUB_ENV
+    echo "SCCACHE_PATH=$PREFIX/sccache.exe" >> "$GITHUB_ENV"
 fi

--- a/ci/scripts/install_sccache.sh
+++ b/ci/scripts/install_sccache.sh
@@ -47,7 +47,7 @@ SHA_ARGS=(--check --status)
 
 # Busybox sha256sum uses different flags
 if sha256sum --version 2>&1 | grep -q BusyBox; then
-  SHA_ARGS+=(-sc)
+  SHA_ARGS="-sc"
 fi
 
 sha256sum "${SHA_ARGS[@]}" $SCCACHE_ARCHIVE.sha256

--- a/ci/scripts/install_sccache.sh
+++ b/ci/scripts/install_sccache.sh
@@ -43,14 +43,14 @@ curl -L "$SCCACHE_URL" --output $SCCACHE_ARCHIVE
 curl -L "${SCCACHE_URL}.sha256" --output $SCCACHE_ARCHIVE.sha256
 echo "  $SCCACHE_ARCHIVE" >> $SCCACHE_ARCHIVE.sha256
 
-SHA_ARGS="--check --status"
+SHA_ARGS=(--check --status)
 
 # Busybox sha256sum uses different flags
 if sha256sum --version 2>&1 | grep -q BusyBox; then
-  SHA_ARGS="-sc"
+  SHA_ARGS+=(-sc)
 fi
 
-sha256sum "$SHA_ARGS" $SCCACHE_ARCHIVE.sha256
+sha256sum "${SHA_ARGS[@]}" $SCCACHE_ARCHIVE.sha256
 
 if [ ! -d "$PREFIX" ]; then
     mkdir -p "$PREFIX"

--- a/ci/scripts/install_sccache.sh
+++ b/ci/scripts/install_sccache.sh
@@ -47,7 +47,7 @@ SHA_ARGS=(--check --status)
 
 # Busybox sha256sum uses different flags
 if sha256sum --version 2>&1 | grep -q BusyBox; then
-  SHA_ARGS="-sc"
+  SHA_ARGS=(-sc)
 fi
 
 sha256sum "${SHA_ARGS[@]}" $SCCACHE_ARCHIVE.sha256

--- a/ci/scripts/install_sccache.sh
+++ b/ci/scripts/install_sccache.sh
@@ -19,7 +19,7 @@
 
 set -e
 
-if [  "$#" -lt 1 ] || [ "$#" -gt 3 ]; then
+if [  "$#" -lt 2 ] || [ "$#" -gt 3 ]; then
     echo "Usage: $0 <build> <prefix> <version>"
     echo "Will default to version=0.3.0 "
     exit 1


### PR DESCRIPTION
### Rationale for this change

This is the sub issue #44748.

```
shellcheck ci/scripts/install_sccache.sh

In ci/scripts/install_sccache.sh line 22:
if [  "$#" -lt 1 -o "$#" -gt 3 ]; then
                 ^-- SC2166 (warning): Prefer [ p ] || [ q ] as [ p -o q ] is not well defined.


In ci/scripts/install_sccache.sh line 42:
curl -L $SCCACHE_URL --output $SCCACHE_ARCHIVE
        ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
curl -L "$SCCACHE_URL" --output $SCCACHE_ARCHIVE


In ci/scripts/install_sccache.sh line 43:
curl -L $SCCACHE_URL.sha256 --output $SCCACHE_ARCHIVE.sha256
        ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
curl -L "$SCCACHE_URL".sha256 --output $SCCACHE_ARCHIVE.sha256


In ci/scripts/install_sccache.sh line 53:
sha256sum $SHA_ARGS $SCCACHE_ARCHIVE.sha256
          ^-------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
sha256sum "$SHA_ARGS" $SCCACHE_ARCHIVE.sha256


In ci/scripts/install_sccache.sh line 55:
if [ ! -d $PREFIX ]; then
          ^-----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
if [ ! -d "$PREFIX" ]; then


In ci/scripts/install_sccache.sh line 56:
    mkdir -p $PREFIX
             ^-----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    mkdir -p "$PREFIX"


In ci/scripts/install_sccache.sh line 61:
tar -xzvf $SCCACHE_ARCHIVE --strip-component=1 --directory $PREFIX --exclude="sccache*/*E*E*"
                                                           ^-----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
tar -xzvf $SCCACHE_ARCHIVE --strip-component=1 --directory "$PREFIX" --exclude="sccache*/*E*E*"


In ci/scripts/install_sccache.sh line 62:
chmod a+x $PREFIX/sccache
          ^-----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
chmod a+x "$PREFIX"/sccache


In ci/scripts/install_sccache.sh line 65:
    echo "$PREFIX" >> $GITHUB_PATH
                      ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    echo "$PREFIX" >> "$GITHUB_PATH"


In ci/scripts/install_sccache.sh line 67:
    echo "SCCACHE_PATH=$PREFIX/sccache.exe" >> $GITHUB_ENV
                                               ^---------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    echo "SCCACHE_PATH=$PREFIX/sccache.exe" >> "$GITHUB_ENV"

For more information:
  https://www.shellcheck.net/wiki/SC2166 -- Prefer [ p ] || [ q ] as [ p -o q...
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
```

### What changes are included in this PR?

* SC2086: Use multiple tests.
* SC2086: Quoting variables.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #46909