### PR TITLE
GH-46916: [R] Test for negative fractional dates fails on older R versions due to change in base R as.Date()

### DIFF
--- a/r/tests/testthat/test-Array.R
+++ b/r/tests/testthat/test-Array.R
@@ -1401,5 +1401,5 @@ test_that("Can convert R integer/double to decimal (ARROW-11631)", {
 test_that("Array handles negative fractional dates correctly (GH-46873)", {
   d <- as.Date(-0.1, origin = "1970-01-01")
   arr <- arrow_array(d)
-  expect_equal(as.vector(arr), as.Date("1969-12-31"))
+  expect_equal(as.vector(arr), as.Date("1969-12-31", origin = "1970-01-01"))
 })

--- a/r/tests/testthat/test-Array.R
+++ b/r/tests/testthat/test-Array.R
@@ -1399,6 +1399,7 @@ test_that("Can convert R integer/double to decimal (ARROW-11631)", {
 })
 
 test_that("Array handles negative fractional dates correctly (GH-46873)", {
+  # `origin` must be specified for compatibility with R versions < 4.2.0
   d <- as.Date(-0.1, origin = "1970-01-01")
   arr <- arrow_array(d)
   expect_equal(as.vector(arr), as.Date("1969-12-31", origin = "1970-01-01"))

--- a/r/tests/testthat/test-Array.R
+++ b/r/tests/testthat/test-Array.R
@@ -1260,7 +1260,7 @@ test_that("concat_arrays works", {
 
   concat_int <- concat_arrays(arrow_array(1:3), arrow_array(4:5))
   expect_true(concat_int$type == int32())
-  expect_equal(concat_int,  arrow_array(1:5))
+  expect_equal(concat_int, arrow_array(1:5))
 
   concat_int64 <- concat_arrays(
     arrow_array(1:3),

--- a/r/tests/testthat/test-Array.R
+++ b/r/tests/testthat/test-Array.R
@@ -1399,7 +1399,7 @@ test_that("Can convert R integer/double to decimal (ARROW-11631)", {
 })
 
 test_that("Array handles negative fractional dates correctly (GH-46873)", {
-  d <- as.Date(-0.1)
+  d <- as.Date(-0.1, origin = "1970-01-01")
   arr <- arrow_array(d)
   expect_equal(as.vector(arr), as.Date("1969-12-31"))
 })


### PR DESCRIPTION
### Rationale for this change

Test in #46873 fails on older R versions

### What changes are included in this PR?

Update test to be compatible with R versions

### Are these changes tested?

Yeah

### Are there any user-facing changes?

Nah
* GitHub Issue: #46916