### PR TITLE
GH-46888: [C++] Remove override of default buildtype in Meson config

### DIFF
--- a/cpp/meson.build
+++ b/cpp/meson.build
@@ -22,12 +22,7 @@ project(
     version: '21.0.0-SNAPSHOT',
     license: 'Apache-2.0',
     meson_version: '>=1.3.0',
-    default_options: [
-        'buildtype=release',
-        'c_std=gnu11,c11',
-        'warning_level=2',
-        'cpp_std=c++17',
-    ],
+    default_options: ['c_std=gnu11,c11', 'warning_level=2', 'cpp_std=c++17'],
 )
 
 project_args = [


### PR DESCRIPTION
### Rationale for this change

When used as a subproject in another project, this setting is either entirely ignored or problematic, depending on the Meson version used (see some upstream discussion in https://github.com/mesonbuild/wrapdb/issues/2208)

### What changes are included in this PR?

Removes the override of the default build type in the Meson configuration, setting it back to its normal "debug" build

### Are these changes tested?

Yes

### Are there any user-facing changes?

No