### PR TITLE
GH-37577: [MATLAB] Create a superclass for `DateType`-related MATLAB tests

### DIFF
--- a/matlab/test/arrow/type/hDateType.m
+++ b/matlab/test/arrow/type/hDateType.m
@@ -1,4 +1,5 @@
-% Test class for the arrow.type.DateType interface.
+% Test class that contains shared unit tests for classes that subclass
+% arrow.type.DateType.
 
 % Licensed to the Apache Software Foundation (ASF) under one or more
 % contributor license agreements.  See the NOTICE file distributed with

--- a/matlab/test/arrow/type/hDateType.m
+++ b/matlab/test/arrow/type/hDateType.m
@@ -25,7 +25,7 @@ classdef hDateType < hFixedWidthType
     methods (Test)
         function TestClass(testCase)
             % Verify ArrowType is an object of the expected class type.
-            name = string(class(testCase.ConstructionFcn()));
+            name = string(class(testCase.ArrowType()));
             testCase.verifyEqual(name, testCase.ClassName);
         end
 

--- a/matlab/test/arrow/type/hDateType.m
+++ b/matlab/test/arrow/type/hDateType.m
@@ -20,6 +20,7 @@ classdef hDateType < hFixedWidthType
 
     properties(Abstract)
         DefaultDateUnit(1, 1) arrow.type.DateUnit
+        ConstructionFcn
         ClassConstructorFcn
     end
 
@@ -43,6 +44,25 @@ classdef hDateType < hFixedWidthType
             array = arrow.array([1, 2, 3]);
             proxy = array.Proxy;
             testCase.verifyError(@() testCase.ClassConstructorFcn(proxy), "arrow:proxy:ProxyNameMismatch");
+        end
+
+        function IsEqualTrue(testCase)
+            % Verifies the isequal method returns true if both conditions
+            % listed below are satisfied:
+            %
+            % 1. All input arguments have the same class type (either
+            %       arrow.type.Date32Type or arrow.type.Date64Type).
+            % 2. All inputs have the same size.
+
+            % Scalar arrays
+            dateType1 = testCase.ConstructionFcn();
+            dateType2 = arrow.ConstructionFcn();
+            testCase.verifyTrue(isequal(dateType1, dateType2));
+
+            % Non-scalar arrays
+            typeArray1 = [dateType1 dateType1];
+            typeArray2 = [dateType2 dateType2];
+            testCase.verifyTrue(isequal(typeArray1, typeArray2));
         end
     end
 

--- a/matlab/test/arrow/type/hDateType.m
+++ b/matlab/test/arrow/type/hDateType.m
@@ -24,21 +24,21 @@ classdef hDateType < hFixedWidthType
 
     methods (Test)
         function TestClass(testCase)
-            % Verify ArrowType is an object of the expected class type.
+            % Verify ArrowType is an instance of the expected class type.
             name = string(class(testCase.ArrowType()));
             testCase.verifyEqual(name, testCase.ClassName);
         end
 
         function DateUnitNoSetter(testCase)
-            % Verify that an error is thrown when trying to set the value
-            % of the DateUnit property.
+            % Verify an exception is thrown when attempting to modify
+            % the DateUnit property.
             type = testCase.ConstructionFcn();
             testCase.verifyError(@() setfield(type, "DateUnit", "Millisecond"), "MATLAB:class:SetProhibited");
         end
 
         function InvalidProxy(testCase)
-            % Verify that an error is thrown when a Proxy of an unexpected
-            % type is passed to its constructor.
+            % Verify that an exception is thrown when a Proxy of an 
+            % unexpected type is passed to the DateType's constructor.
             array = arrow.array([1, 2, 3]);
             proxy = array.Proxy;
             testCase.verifyError(@() testCase.ClassConstructorFcn(proxy), "arrow:proxy:ProxyNameMismatch");

--- a/matlab/test/arrow/type/hDateType.m
+++ b/matlab/test/arrow/type/hDateType.m
@@ -1,0 +1,48 @@
+% Test class for the arrow.type.DateType interface.
+
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
+classdef hDateType < hFixedWidthType
+
+    properties(Abstract)
+        DefaultDateUnit(1, 1) arrow.type.DateUnit
+        ClassConstructorFcn
+    end
+
+    methods (Test)
+        function TestClass(testCase)
+            % Verify ArrowType is an object of the expected class type.
+            name = string(class(testCase.ConstructionFcn()));
+            testCase.verifyEqual(name, testCase.ClassName);
+        end
+
+        function DateUnitNoSetter(testCase)
+            % Verify that an error is thrown when trying to set the value
+            % of the DateUnit property.
+            type = testCase.ConstructionFcn();
+            testCase.verifyError(@() setfield(type, "DateUnit", "Millisecond"), "MATLAB:class:SetProhibited");
+        end
+
+        function InvalidProxy(testCase)
+            % Verify that an error is thrown when a Proxy of an unexpected
+            % type is passed to construction method.
+            array = arrow.array([1, 2, 3]);
+            proxy = array.Proxy;
+            testCase.verifyError(@() testCase.ClassConstructorFcn(proxy), "arrow:proxy:ProxyNameMismatch");
+        end
+    end
+
+end

--- a/matlab/test/arrow/type/hDateType.m
+++ b/matlab/test/arrow/type/hDateType.m
@@ -56,7 +56,7 @@ classdef hDateType < hFixedWidthType
 
             % Scalar arrays
             dateType1 = testCase.ConstructionFcn();
-            dateType2 = arrow.ConstructionFcn();
+            dateType2 = testCase.ConstructionFcn();
             testCase.verifyTrue(isequal(dateType1, dateType2));
 
             % Non-scalar arrays
@@ -74,7 +74,7 @@ classdef hDateType < hFixedWidthType
             % 2. All inputs have the same size.
 
             % Pass a different arrow.type.Type subclass to isequal.
-            dateType = testCase.ClassConstructorFcn();
+            dateType = testCase.ConstructionFcn();
             int32Type = arrow.int32();
             testCase.verifyFalse(isequal(dateType, int32Type));
             testCase.verifyFalse(isequal([dateType dateType], [int32Type int32Type]));

--- a/matlab/test/arrow/type/hDateType.m
+++ b/matlab/test/arrow/type/hDateType.m
@@ -64,6 +64,27 @@ classdef hDateType < hFixedWidthType
             typeArray2 = [dateType2 dateType2];
             testCase.verifyTrue(isequal(typeArray1, typeArray2));
         end
+
+        function IsEqualFalse(testCase)
+            % Verifies the isequal method returns false when at least of
+            % these conditions is not satisfied:
+            %
+            % 1. All input arguments have the same class type (either
+            %       arrow.type.Date32Type or arrow.type.Date64Type).
+            % 2. All inputs have the same size.
+
+            % Pass a different arrow.type.Type subclass to isequal.
+            dateType = testCase.ClassConstructorFcn();
+            int32Type = arrow.int32();
+            testCase.verifyFalse(isequal(dateType, int32Type));
+            testCase.verifyFalse(isequal([dateType dateType], [int32Type int32Type]));
+
+            % The array sizes are not equal.
+            typeArray1 = [dateType dateType];
+            typeArray2 = [dateType dateType]';
+            testCase.verifyFalse(isequal(typeArray1, typeArray2));
+        end
+
     end
 
 end

--- a/matlab/test/arrow/type/hDateType.m
+++ b/matlab/test/arrow/type/hDateType.m
@@ -38,7 +38,7 @@ classdef hDateType < hFixedWidthType
 
         function InvalidProxy(testCase)
             % Verify that an error is thrown when a Proxy of an unexpected
-            % type is passed to construction method.
+            % type is passed to its constructor.
             array = arrow.array([1, 2, 3]);
             proxy = array.Proxy;
             testCase.verifyError(@() testCase.ClassConstructorFcn(proxy), "arrow:proxy:ProxyNameMismatch");

--- a/matlab/test/arrow/type/tDate32Type.m
+++ b/matlab/test/arrow/type/tDate32Type.m
@@ -18,51 +18,13 @@
 classdef tDate32Type < hDateType
 
     properties
-        ConstructionFcn = @arrow.date32
         ArrowType = arrow.date32
         TypeID = arrow.type.ID.Date32
         BitWidth = int32(32)
         ClassName = "arrow.type.Date32Type"
         DefaultDateUnit = arrow.type.DateUnit.Day
+        ConstructionFcn = @arrow.date32
         ClassConstructorFcn = @arrow.type.Date32Type
-    end
-
-    methods(Test)
-
-        function IsEqualTrue(testCase)
-            % Verifies isequal method of arrow.type.Date32Type returns true if
-            % these conditions are met:
-            %
-            % 1. All input arguments have a class type arrow.type.Date32Type
-            % 2. All inputs have the same size
-
-            % Scalar Date32Type arrays
-            date32Type1 = arrow.date32();
-            date32Type2 = arrow.date32();
-            testCase.verifyTrue(isequal(date32Type1, date32Type2));
-
-            % Non-scalar Date32Type arrays
-            typeArray1 = [date32Type1 date32Type1];
-            typeArray2 = [date32Type2 date32Type2];
-            testCase.verifyTrue(isequal(typeArray1, typeArray2));
-        end
-
-        function IsEqualFalse(testCase)
-            % Verifies the isequal method of arrow.type.Date32Type returns
-            % false when expected.
-            
-            % Pass a different arrow.type.Type subclass to isequal
-            date32Type = arrow.date32();
-            int32Type = arrow.int32();
-            testCase.verifyFalse(isequal(date32Type, int32Type));
-            testCase.verifyFalse(isequal([date32Type date32Type], [int32Type int32Type]));
-
-            % Date32Type arrays have different sizes
-            typeArray1 = [date32Type date32Type];
-            typeArray2 = [date32Type date32Type]';
-            testCase.verifyFalse(isequal(typeArray1, typeArray2));
-        end
-    
     end
 
 end

--- a/matlab/test/arrow/type/tDate32Type.m
+++ b/matlab/test/arrow/type/tDate32Type.m
@@ -15,7 +15,7 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef tDate32Type < hFixedWidthType
+classdef tDate32Type < hDateType
 
     properties
         ConstructionFcn = @arrow.date32
@@ -23,37 +23,11 @@ classdef tDate32Type < hFixedWidthType
         TypeID = arrow.type.ID.Date32
         BitWidth = int32(32)
         ClassName = "arrow.type.Date32Type"
+        DefaultDateUnit = arrow.type.DateUnit.Day
+        ClassConstructorFcn = @arrow.type.Date32Type
     end
 
     methods(Test)
-        function TestClass(testCase)
-            % Verify ArrowType is an object of the expected class type.
-            name = string(class(testCase.ArrowType));
-            testCase.verifyEqual(name, testCase.ClassName);
-        end
-
-        function DefaultDateUnit(testCase)
-            % Verify the default DateUnit is Day.
-            type = testCase.ArrowType;
-            actualUnit = type.DateUnit;
-            expectedUnit = arrow.type.DateUnit.Day;
-            testCase.verifyEqual(actualUnit, expectedUnit);
-        end
-
-        function DateUnitNoSetter(testCase)
-            % Verify that an error is thrown when trying to set the value
-            % of the DateUnit property.
-            type = arrow.date32();
-            testCase.verifyError(@() setfield(type, "DateUnit", "Millisecond"), "MATLAB:class:SetProhibited");
-        end
-
-        function InvalidProxy(testCase)
-            % Verify that an error is thrown when a Proxy of an unexpected
-            % type is passed to the arrow.type.Date32Type constructor.
-            array = arrow.array([1, 2, 3]);
-            proxy = array.Proxy;
-            testCase.verifyError(@() arrow.type.Date32Type(proxy), "arrow:proxy:ProxyNameMismatch");
-        end
 
         function IsEqualTrue(testCase)
             % Verifies isequal method of arrow.type.Date32Type returns true if

--- a/matlab/test/arrow/type/tDate64Type.m
+++ b/matlab/test/arrow/type/tDate64Type.m
@@ -18,51 +18,13 @@
 classdef tDate64Type < hDateType
 
     properties
-        ConstructionFcn = @arrow.date64
         ArrowType = arrow.date64
         TypeID = arrow.type.ID.Date64
         BitWidth = int32(64)
         ClassName = "arrow.type.Date64Type"
         DefaultDateUnit = arrow.type.DateUnit.Millisecond
+        ConstructionFcn = @arrow.date64
         ClassConstructorFcn = @arrow.type.Date64Type
-    end
-
-    methods(Test)
-
-        function IsEqualTrue(testCase)
-            % Verifies isequal method of arrow.type.Date64Type returns true if
-            % these conditions are met:
-            %
-            % 1. All input arguments have a class type arrow.type.Date64Type
-            % 2. All inputs have the same size
-
-            % Scalar Date64Type arrays
-            date64Type1 = arrow.date64();
-            date64Type2 = arrow.date64();
-            testCase.verifyTrue(isequal(date64Type1, date64Type2));
-
-            % Non-scalar Date64Type arrays
-            typeArray1 = [date64Type1 date64Type1];
-            typeArray2 = [date64Type2 date64Type2];
-            testCase.verifyTrue(isequal(typeArray1, typeArray2));
-        end
-
-        function IsEqualFalse(testCase)
-            % Verifies the isequal method of arrow.type.Date64Type returns
-            % false when expected.
-
-            % Pass a different arrow.type.Type subclass to isequal
-            date64Type = arrow.date64();
-            int32Type = arrow.int32();
-            testCase.verifyFalse(isequal(date64Type, int32Type));
-            testCase.verifyFalse(isequal([date64Type date64Type], [int32Type int32Type]));
-
-            % Date64Type arrays have different sizes
-            typeArray1 = [date64Type date64Type];
-            typeArray2 = [date64Type date64Type]';
-            testCase.verifyFalse(isequal(typeArray1, typeArray2));
-        end
-
     end
 
 end

--- a/matlab/test/arrow/type/tDate64Type.m
+++ b/matlab/test/arrow/type/tDate64Type.m
@@ -15,7 +15,7 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef tDate64Type < hFixedWidthType
+classdef tDate64Type < hDateType
 
     properties
         ConstructionFcn = @arrow.date64
@@ -23,37 +23,11 @@ classdef tDate64Type < hFixedWidthType
         TypeID = arrow.type.ID.Date64
         BitWidth = int32(64)
         ClassName = "arrow.type.Date64Type"
+        DefaultDateUnit = arrow.type.DateUnit.Millisecond
+        ClassConstructorFcn = @arrow.type.Date64Type
     end
 
     methods(Test)
-        function TestClass(testCase)
-            % Verify ArrowType is an object of the expected class type.
-            name = string(class(testCase.ArrowType));
-            testCase.verifyEqual(name, testCase.ClassName);
-        end
-
-        function DefaultDateUnit(testCase)
-            % Verify the default DateUnit is Millisecond.
-            type = testCase.ArrowType;
-            actualUnit = type.DateUnit;
-            expectedUnit = arrow.type.DateUnit.Millisecond;
-            testCase.verifyEqual(actualUnit, expectedUnit);
-        end
-
-        function DateUnitNoSetter(testCase)
-            % Verify that an error is thrown when trying to set the value
-            % of the DateUnit property.
-            type = arrow.date64();
-            testCase.verifyError(@() setfield(type, "DateUnit", "Day"), "MATLAB:class:SetProhibited");
-        end
-
-        function InvalidProxy(testCase)
-            % Verify that an error is thrown when a Proxy of an unexpected
-            % type is passed to the arrow.type.Date64Type constructor.
-            array = arrow.array([1, 2, 3]);
-            proxy = array.Proxy;
-            testCase.verifyError(@() arrow.type.Date64Type(proxy), "arrow:proxy:ProxyNameMismatch");
-        end
 
         function IsEqualTrue(testCase)
             % Verifies isequal method of arrow.type.Date64Type returns true if


### PR DESCRIPTION
### Rationale for this change

Many of the tests for `Date32Type` and `Date64Type` are similar. To reduce code duplication, we could consider adding a shared superclass for `DateType`-related tests.

### What changes are included in this PR?

1. Added  abstract MATLAB test class `hDataType`. This class contains shared unit tests for `arrow.type.Date32Type` and `arrow.type.Date64Type`.
2. Updated both `tDate32Type` and `tDate64Type` to inherit from `hDataType`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.

* GitHub Issue: #37577