### PR TITLE
GH-46811: [C++][Python] Fix crash on FileReaderImpl::GetRecordBatchReader

### DIFF
--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -579,6 +579,9 @@ class ParquetFile:
         4       5  Brittle stars
         5     100      Centipede
         """
+        if batch_size <= 0:
+            raise ValueError("batch_size must be greater than zero")
+
         if row_groups is None:
             row_groups = range(0, self.metadata.num_row_groups)
         column_indices = self._get_column_indices(

--- a/python/pyarrow/tests/parquet/test_parquet_file.py
+++ b/python/pyarrow/tests/parquet/test_parquet_file.py
@@ -430,3 +430,14 @@ def test_fsspec_uri_raises_if_fsspec_is_not_available():
         "`fsspec` is required to handle `fsspec+<filesystem>://` and `hf://` URIs.")
     with pytest.raises(ImportError, match=msg):
         pq.read_table("fsspec+memory://example.parquet")
+
+
+def test_iter_batches_raises_batch_size_zero(tempdir):
+    # See https://github.com/apache/arrow/issues/46811
+    schema = pa.schema([])
+    empty_table = pa.Table.from_batches([], schema=schema)
+    parquet_file_path = tempdir / "empty_file.parquet"
+    pq.write_table(empty_table, parquet_file_path)
+    parquet_file = pq.ParquetFile(parquet_file_path)
+    with pytest.raises(ValueError):
+        parquet_file.iter_batches(batch_size=0)


### PR DESCRIPTION
### Rationale for this change

Fixes https://github.com/apache/arrow/issues/46811.

### What changes are included in this PR?

- Added check to return Invalid when batch_size <= 0.

### Are these changes tested?

Exercised in CI.

### Are there any user-facing changes?

**This PR contains a "Critical Fix".** 
* GitHub Issue: #46811