### PR TITLE
GH-46911: [Packaging] Add support for AlmaLinux 10

### DIFF
--- a/dev/release/binary-task.rb
+++ b/dev/release/binary-task.rb
@@ -1870,6 +1870,7 @@ APT::FTPArchive::Release::Description "#{apt_repository_description}";
 
   def available_yum_targets
     [
+      ["almalinux", "10"],
       ["almalinux", "9"],
       ["almalinux", "8"],
       ["amazon-linux", "2023"],
@@ -2548,6 +2549,8 @@ class LocalBinaryTask < BinaryTask
     # Disable aarch64 targets by default for now
     # because they require some setups on host.
     [
+      "almalinux-10",
+      # "almalinux-10-aarch64",
       "almalinux-9",
       # "almalinux-9-aarch64",
       "almalinux-8",

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -258,7 +258,8 @@ test_yum() {
 
   case "$(arch)" in
     "x86_64")
-      for target in "almalinux:9" \
+      for target in "almalinux:10" \
+                    "almalinux:9" \
                     "almalinux:8" \
                     "amazonlinux:2023" \
                     "quay.io/centos/centos:stream9" \
@@ -279,7 +280,8 @@ test_yum() {
       done
       ;;
     "aarch64")
-      for target in "arm64v8/almalinux:9" \
+      for target in "arm64v8/almalinux:10" \
+                    "arm64v8/almalinux:9" \
                     "arm64v8/almalinux:8" \
                     "arm64v8/amazonlinux:2023" \
                     "quay.io/centos/centos:stream9" \

--- a/dev/tasks/linux-packages/apache-arrow-release/yum/almalinux-10/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow-release/yum/almalinux-10/Dockerfile
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+FROM almalinux:10
+
+ARG DEBUG
+
+RUN \
+  quiet=$([ "${DEBUG}" = "yes" ] || echo "--quiet") && \
+  dnf install -y ${quiet} \
+    rpmdevtools && \
+  dnf clean ${quiet} all

--- a/dev/tasks/linux-packages/apache-arrow/yum/almalinux-10-aarch64/from
+++ b/dev/tasks/linux-packages/apache-arrow/yum/almalinux-10-aarch64/from
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+arm64v8/almalinux:10

--- a/dev/tasks/linux-packages/apache-arrow/yum/almalinux-10/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/yum/almalinux-10/Dockerfile
@@ -1,0 +1,68 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+ARG FROM=almalinux:10
+FROM ${FROM}
+
+ARG DEBUG
+
+RUN \
+  quiet=$([ "${DEBUG}" = "yes" ] || echo "--quiet") && \
+  dnf install -y ${quiet} epel-release && \
+  dnf install --enablerepo=crb -y ${quiet} \
+    bison \
+    boost-devel \
+    brotli-devel \
+    bzip2-devel \
+    c-ares-devel \
+    ccache \
+    clang \
+    cmake \
+    curl-devel \
+    flex \
+    gcc-c++ \
+    gflags-devel \
+    git \
+    gobject-introspection-devel \
+    grpc-devel \
+    json-devel \
+    libarchive \
+    liborc-devel \
+    libxml2-devel \
+    libzstd-devel \
+    llvm-devel \
+    llvm-static \
+    lz4-devel \
+    make \
+    ncurses-devel \
+    ninja-build \
+    openssl-devel \
+    pkg-config \
+    python3 \
+    python3-pip \
+    rapidjson-devel \
+    re2-devel \
+    rpmdevtools \
+    snappy-devel \
+    tar \
+    thrift-devel \
+    utf8proc-devel \
+    vala \
+    which \
+    xsimd-devel \
+    zlib-devel && \
+  dnf clean ${quiet} all

--- a/dev/tasks/linux-packages/apache-arrow/yum/arrow.spec.in
+++ b/dev/tasks/linux-packages/apache-arrow/yum/arrow.spec.in
@@ -79,8 +79,9 @@
 %define use_s3 0
 %define use_vala (%{_rhel} >= 8 || %{is_amazon_linux})
 
-%define have_grpc (%{_amzn} >= 2023)
+%define have_grpc (%{_rhel} >= 10 || %{_amzn} >= 2023)
 %define have_lz4_libs (%{_rhel} >= 8 || %{_amzn} >= 2023)
+%define have_orc (%{_rhel} >= 10)
 %define have_rapidjson (%{_rhel} != 8)
 %define have_re2 (%{_rhel} >= 8 || %{_amzn} >= 2023)
 %define have_thrift (%{_rhel} >= 8)
@@ -297,6 +298,9 @@ Requires:	json-devel
 Requires:	libzstd-devel
 Requires:	lz4-devel %{lz4_requirement}
 Requires:	openssl-devel
+%if %{have_orc}
+Requires:	liborc-devel
+%endif
 %if %{have_rapidjson}
 Requires:	rapidjson-devel
 %endif

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -396,7 +396,8 @@ tasks:
   {% endfor %}
 {% endfor %}
 
-{% for target in ["almalinux-9",
+{% for target in ["almalinux-10",
+                  "almalinux-9",
                   "almalinux-8",
                   "amazon-linux-2023",
                   "centos-9-stream",


### PR DESCRIPTION
### Rationale for this change

AlmaLinux 10 has been released: https://almalinux.org/blog/2025-05-27-welcoming-almalinux-10/

### What changes are included in this PR?

Add packages for AlmaLinux 10.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #46911