### PR TITLE
GH-39759: [Docs] Update pydata-sphinx-theme to 0.16.1

### DIFF
--- a/ci/conda_env_sphinx.txt
+++ b/ci/conda_env_sphinx.txt
@@ -26,7 +26,7 @@ linkify-it-py
 # linuxdoc
 myst-parser
 numpydoc
-pydata-sphinx-theme=0.14
+pydata-sphinx-theme=0.16
 sphinx-autobuild
 sphinx-design
 sphinx-copybutton

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,7 +8,7 @@ ipython
 linuxdoc
 myst-parser[linkify]
 numpydoc
-pydata-sphinx-theme~=0.14
+pydata-sphinx-theme~=0.16
 sphinx-autobuild
 sphinx-copybutton
 sphinx-design

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -363,7 +363,7 @@ html_theme_options = {
     ],
     "show_version_warning_banner": True,
     "switcher": {
-        "json_url": "https://arrow.apache.org/docs/_static/versions.json",
+        "json_url": "/docs/_static/versions.json",
         "version_match": switcher_version,
     },
 }

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -363,7 +363,7 @@ html_theme_options = {
     ],
     "show_version_warning_banner": True,
     "switcher": {
-        "json_url": "/docs/_static/versions.json",
+        "json_url": "https://arrow.apache.org/docs/_static/versions.json",
         "version_match": switcher_version,
     },
 }


### PR DESCRIPTION
### Rationale for this change
Update our dev docs build to use the latest `pydata-sphinx-theme` as we still have it pinned to version `0.14.x` while the package is currently on stable `0.16.1` version.

### What changes are included in this PR?
Updated dev docs build uses the latest `pydata-sphinx-theme`.

### Are these changes tested?
Yes, docs preview and CI job.

### Are there any user-facing changes?
No.
* GitHub Issue: #39759