### PR TITLE
GH-46947: [R][Packaging] Add src/arrow/flight/sql/odbc to source excludes

### DIFF
--- a/r/bootstrap.R
+++ b/r/bootstrap.R
@@ -60,6 +60,7 @@ if (dir.exists("../cpp")) {
       "^src/gandiva",
       "^src/jni",
       "^src/skyhook",
+      "^src/arrow/flight/sql/odbc",
       "_test\\.cc"
     )
   )


### PR DESCRIPTION
### Rationale for this change

We bundle the C++ source with the R package tarball so users can build from source as a fallback option. CRAN checks the submitted tarball for long filenames to support Windows and files recently added under cpp/src/arrow/flight/sql/odbc cause us to get NOTEs about this. We don't need to include these files so we can exclude them.

### What changes are included in this PR?

Updated exclusions list.

### Are these changes tested?

Yes, by CI. See crossbow runs below.

### Are there any user-facing changes?

No.
* GitHub Issue: #46947