### PR TITLE
GH-45616: [R][CI] Remove whitespace in operator literal

### DIFF
--- a/r/src/filesystem.cpp
+++ b/r/src/filesystem.cpp
@@ -438,7 +438,7 @@ std::shared_ptr<fs::GcsFileSystem> fs___GcsFileSystem__Make(bool anonymous,
 
 // [[gcs::export]]
 cpp11::list fs___GcsFileSystem__options(const std::shared_ptr<fs::GcsFileSystem>& fs) {
-  using cpp11::literals::operator"" _nm;
+  using cpp11::literals::operator""_nm;
 
   cpp11::writable::list out;
 


### PR DESCRIPTION
### Rationale for this change

Closes https://github.com/apache/arrow/issues/45616.

### What changes are included in this PR?

- Removed whitespace in r/src/filesystem.cpp

### Are these changes tested?

No, will test on CI.

### Are there any user-facing changes?

No.
* GitHub Issue: #45616