### PR TITLE
MINOR: [R] Fix lint errors

### DIFF
--- a/r/tests/testthat/test-Array.R
+++ b/r/tests/testthat/test-Array.R
@@ -352,7 +352,7 @@ test_that("array supports integer64", {
   expect_true(as.vector(is.na(all_na)))
 })
 
-test_that("array supports integer64 with new sematics", {
+test_that("array supports integer64 with new semantics", {
   withr::with_options(list(integer64_semantics = "new"), {
     x <- bit64::as.integer64(1:10) + MAX_INT
     expect_array_roundtrip(x, int64())
@@ -364,7 +364,7 @@ test_that("array supports integer64 with new sematics", {
     all_na <- arrow_array(bit64::as.integer64(NA))
     expect_type_equal(all_na, int64())
     expect_true(as.vector(is.na(all_na)))
-  }
+  })
 })
 
 test_that("array supports hms difftime", {


### PR DESCRIPTION
### Rationale for this change

They are introduced by #46651

https://github.com/apache/arrow/actions/runs/15987292796/job/45094044698#step:5:18

```text
R Lint...................................................................Failed
- hook id: lintr
- exit code: 1

Error: Not lint free
tests/testthat/test-Array.R:355:57: style: [brace_linter] Opening curly braces should never go on their own line and should always be followed by a new line.
test_that("array supports integer64 with new sematics", {
                                                        ^

tests/testthat/test-Array.R:356:58: style: [brace_linter] Opening curly braces should never go on their own line and should always be followed by a new line.
  withr::with_options(list(integer64_semantics = "new"), {
                                                         ^

Error: estthat/test-Array.R:368:1: error: [error] unexpected '}'
})
^
Execution halted
25h
```

### What changes are included in this PR?

* Add missing `)`
* Fix a typo

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.