### PR TITLE
GH-46959: [Python][Packaging] Drop support for manylinux2014

### DIFF
--- a/ci/docker/python-wheel-manylinux.dockerfile
+++ b/ci/docker/python-wheel-manylinux.dockerfile
@@ -25,27 +25,11 @@ ARG manylinux
 ENV LINUX_WHEEL_KIND='manylinux'
 ENV LINUX_WHEEL_VERSION=${manylinux}
 
-# Ensure dnf is installed, especially for the manylinux2014 base
-RUN if [ "${LINUX_WHEEL_VERSION}" = "2014" ]; then \
-      sed -i \
-        -e 's/^mirrorlist/#mirrorlist/' \
-        -e 's/^#baseurl/baseurl/' \
-        -e 's/mirror\.centos\.org/vault.centos.org/' \
-        /etc/yum.repos.d/*.repo; \
-      if [ "${arch}" != "amd64" ]; then \
-        sed -i \
-          -e 's,vault\.centos\.org/centos,vault.centos.org/altarch,' \
-          /etc/yum.repos.d/CentOS-SCLo-scl-rh.repo; \
-      fi; \
-    fi
-RUN yum install -y dnf
-
 # Install basic dependencies
 RUN dnf install -y git flex curl autoconf zip perl-IPC-Cmd wget
 
-# A system Python is required for ninja and vcpkg in this Dockerfile.
-# On manylinux2014 base images, system Python is 2.7.5, while
-# on manylinux_2_28, no system python is installed.
+# A system Python is required for Ninja and vcpkg in this Dockerfile.
+# On manylinux_2_28 base images, no system Python is installed.
 # We therefore override the PATH with Python 3.8 in /opt/python
 # so that we have a consistent Python version across base images.
 ENV CPYTHON_VERSION=cp39

--- a/ci/docker/python-wheel-manylinux.dockerfile
+++ b/ci/docker/python-wheel-manylinux.dockerfile
@@ -30,7 +30,7 @@ RUN dnf install -y git flex curl autoconf zip perl-IPC-Cmd wget
 
 # A system Python is required for Ninja and vcpkg in this Dockerfile.
 # On manylinux_2_28 base images, no system Python is installed.
-# We therefore override the PATH with Python 3.8 in /opt/python
+# We therefore override the PATH with Python 3.9 in /opt/python
 # so that we have a consistent Python version across base images.
 ENV CPYTHON_VERSION=cp39
 ENV PATH=/opt/python/${CPYTHON_VERSION}-${CPYTHON_VERSION}/bin:${PATH}

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -892,7 +892,7 @@ test_linux_wheels() {
   fi
 
   local python_versions="${TEST_PYTHON_VERSIONS:-3.9 3.10 3.11 3.12 3.13}"
-  local platform_tags="${TEST_WHEEL_PLATFORM_TAGS:-manylinux2014_${arch}.manylinux_2_17_${arch} manylinux_2_28_${arch}}"
+  local platform_tags="${TEST_WHEEL_PLATFORM_TAGS:-manylinux_2_28_${arch}}"
 
   if [ "${SOURCE_KIND}" != "local" ]; then
     local wheel_content="OFF"

--- a/dev/tasks/python-wheels/github.linux.yml
+++ b/dev/tasks/python-wheels/github.linux.yml
@@ -63,10 +63,7 @@ jobs:
         env:
           GITHUB_TOKEN: {{ '${{ secrets.GITHUB_TOKEN }}' }}
         run: |
-          if [ "{{ linux_wheel_version }}" = "2014" ] && [ "{{ arch }}" = "arm64" ]; then
-            # We can't use NuGet on manylinux2014_aarch64 because Mono is old.
-            :
-          elif [ "{{ linux_wheel_kind }}" = "musllinux" ] && [ "{{ arch }}" = "arm64" ]; then
+          if [ "{{ linux_wheel_kind }}" = "musllinux" ] && [ "{{ arch }}" = "arm64" ]; then
             # We can't use NuGet on musl arm systems because the official NuGet binary for arm doesn't exist.
             :
           else

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -223,9 +223,7 @@ tasks:
 
 {############################## Wheel Linux ##################################}
 
-{% for wheel_kind, arch, version, platform_tag in [("manylinux", "amd64", "2014", "manylinux2014_x86_64.manylinux_2_17_x86_64"),
-                                                   ("manylinux", "amd64", "2-28", "manylinux_2_28_x86_64"),
-                                                   ("manylinux", "arm64", "2014", "manylinux2014_aarch64.manylinux_2_17_aarch64"),
+{% for wheel_kind, arch, version, platform_tag in [("manylinux", "amd64", "2-28", "manylinux_2_28_x86_64"),
                                                    ("manylinux", "arm64", "2-28", "manylinux_2_28_aarch64"),
                                                    ("musllinux", "amd64", "1-2", "musllinux_1_2_x86_64"),
                                                    ("musllinux", "arm64", "1-2", "musllinux_1_2_aarch64")] %}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -164,7 +164,6 @@ x-hierarchy:
   # helper services
   - impala
   - postgres
-  - python-wheel-manylinux-2014
   - python-wheel-manylinux-2-28
   - python-wheel-musllinux-1-2
   - python-wheel-manylinux-test-imports
@@ -195,8 +194,6 @@ volumes:
     name: ${ARCH}-fedora-${FEDORA}-ccache
   maven-cache:
     name: maven-cache
-  python-wheel-manylinux2014-ccache:
-    name: python-wheel-manylinux2014-ccache
   python-wheel-manylinux-2-28-ccache:
     name: python-wheel-manylinux-2-28-ccache
   python-wheel-musllinux-1-2-ccache:
@@ -1137,31 +1134,6 @@ services:
     command: *python-command
 
   ############################ Python wheels ##################################
-
-  # See available versions at:
-  #    https://quay.io/repository/pypa/manylinux2014_x86_64?tab=tags
-  python-wheel-manylinux-2014:
-    image: ${REPO}:${ARCH}-python-${PYTHON}-wheel-manylinux-2014-vcpkg-${VCPKG}
-    build:
-      args:
-        arch: ${ARCH}
-        arch_short: ${ARCH_SHORT}
-        base: quay.io/pypa/manylinux2014_${ARCH_ALIAS}:2024-08-03-32dfa47
-        manylinux: 2014
-        python: ${PYTHON}
-        python_abi_tag: ${PYTHON_ABI_TAG}
-        vcpkg: ${VCPKG}
-      context: .
-      dockerfile: ci/docker/python-wheel-manylinux.dockerfile
-      cache_from:
-        - ${REPO}:${ARCH}-python-${PYTHON}-wheel-manylinux-2014-vcpkg-${VCPKG}
-      secrets: *vcpkg-build-secrets
-    environment:
-      <<: [*common, *ccache]
-    volumes:
-      - .:/arrow:delegated
-      - ${DOCKER_VOLUME_PREFIX}python-wheel-manylinux2014-ccache:/ccache:delegated
-    command: /arrow/ci/scripts/python_wheel_xlinux_build.sh
 
   # See available versions at:
   #    https://quay.io/repository/pypa/manylinux_2_28_x86_64?tab=tags

--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -317,7 +317,7 @@ get_macos_openssl_dir <- function() {
   openssl_root_dir
 }
 
-# (built with newer devtoolset but older glibc (2.17) for broader compatibility,# like manylinux2014)
+# (built with newer devtoolset but older glibc (2.17) for broader compatibility, like manylinux2014)
 determine_binary_from_stderr <- function(errs) {
   if (is.null(attr(errs, "status"))) {
     # There was no error in compiling: so we found libcurl and OpenSSL >= 1.1,


### PR DESCRIPTION
### Rationale for this change

We can cover all supported platforms by manylinux_2_28. Amazon Linux 2 needs manylinux2014 and it's still maintained (it'll reach EOL on 2026-06-30) but we dropped support for Amazon Linux 2. See also: #36282

### What changes are included in this PR?

Remove manylinux2014 related codes.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #46959