### PR TITLE
GH-46964: [CI][Packaging][Conan] Ensure using upper case for config suffix

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -2882,7 +2882,7 @@ if(ARROW_WITH_BZ2)
     if(BZIP2_TYPE STREQUAL "INTERFACE_LIBRARY")
       # Conan
       string(APPEND ARROW_PC_LIBS_PRIVATE
-             " $<TARGET_FILE:CONAN_LIB::bzip2_bz2_$<CONFIG>>")
+             " $<TARGET_FILE:CONAN_LIB::bzip2_bz2_$<UPPER_CASE:$<CONFIG>>>")
     else()
       string(APPEND ARROW_PC_LIBS_PRIVATE " $<TARGET_FILE:BZip2::BZip2>")
     endif()


### PR DESCRIPTION
### Rationale for this change

Conan uses upper case for config suffix: https://github.com/conan-io/conan/blob/3bc93e28d46f071da45d11f5256c6af52404b756/conan/tools/cmake/cmakedeps/templates/__init__.py#L69

#45306 stopped upcasing configuration name. So `$<CONFIG>` may not upper case. 

### What changes are included in this PR?

Ensure using upper case configuration name for Conan bzip2 target.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #46964