### PR TITLE
GH-46969: [C++] Call InitializeUTF8() to avoid test failure in debug mode

### DIFF
--- a/cpp/src/parquet/reader_test.cc
+++ b/cpp/src/parquet/reader_test.cc
@@ -44,6 +44,7 @@
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/config.h"
 #include "arrow/util/range.h"
+#include "arrow/util/utf8_internal.h"
 
 #include "parquet/column_reader.h"
 #include "parquet/column_scanner.h"
@@ -1093,6 +1094,8 @@ Column 1
 
 class TestJSONWithLocalFile : public ::testing::Test {
  public:
+  static void SetUpTestCase() { ::arrow::util::InitializeUTF8(); }
+
   static std::string ReadFromLocalFile(std::string_view local_file_name) {
     std::stringstream ss;
     // empty list means print all

--- a/cpp/src/parquet/types_test.cc
+++ b/cpp/src/parquet/types_test.cc
@@ -20,6 +20,7 @@
 #include <string>
 
 #include "arrow/util/endian.h"
+#include "arrow/util/utf8_internal.h"
 #include "parquet/types.h"
 
 namespace parquet {
@@ -73,6 +74,8 @@ TEST(TestConvertedTypeToString, ConvertedTypes) {
 #endif
 
 TEST(TypePrinter, StatisticsTypes) {
+  ::arrow::util::InitializeUTF8();
+
   std::string smin;
   std::string smax;
   int32_t int_min = 1024;


### PR DESCRIPTION
### Rationale for this change

Some test cases fail in the debug mode with the complaint: `Check failed: (utf8_large_table[0]) == (0) InitializeUTF8() must be called before calling UTF8 routines`.

### What changes are included in this PR?

Explicitly call InitializeUTF8() in those failed tests.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.

* GitHub Issue: #46969