### PR TITLE
GH-46739: [C++] Fix Float16 signed zero/NaN equality comparisons

### DIFF
--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -2120,36 +2120,16 @@ void CheckSliceApproxEquals() {
   ASSERT_TRUE(slice1->ApproxEquals(slice2));
 }
 
-template <typename ARROW_TYPE>
-auto GetFloat(double d) {
-  if constexpr (std::is_same_v<ARROW_TYPE, HalfFloatType>) {
-    const auto h = Float16::FromDouble(d);
-    // Double check that nan/inf/sign are preserved
-    if (std::isnan(d)) {
-      EXPECT_TRUE(h.is_nan());
-    }
-    if (std::isinf(d)) {
-      EXPECT_TRUE(h.is_infinity());
-    }
-    if (std::signbit(d)) {
-      EXPECT_TRUE(h.signbit());
-    }
-    return h.bits();
-  } else {
-    return static_cast<typename ARROW_TYPE::c_type>(d);
-  }
-}
-
 template <typename TYPE>
 void CheckFloatingNanEquality() {
   std::shared_ptr<Array> a, b;
   std::shared_ptr<DataType> type = TypeTraits<TYPE>::type_singleton();
 
-  const auto nan_value = GetFloat<TYPE>(NAN);
+  const auto nan_value = RealToCType<TYPE>(NAN);
 
   // NaN in a null entry
-  ArrayFromVector<TYPE>(type, {true, false}, {GetFloat<TYPE>(0.5), nan_value}, &a);
-  ArrayFromVector<TYPE>(type, {true, false}, {GetFloat<TYPE>(0.5), nan_value}, &b);
+  ArrayFromVector<TYPE>(type, {true, false}, {RealToCType<TYPE>(0.5), nan_value}, &a);
+  ArrayFromVector<TYPE>(type, {true, false}, {RealToCType<TYPE>(0.5), nan_value}, &b);
   ASSERT_TRUE(a->Equals(b));
   ASSERT_TRUE(b->Equals(a));
   ASSERT_TRUE(a->ApproxEquals(b));
@@ -2160,8 +2140,8 @@ void CheckFloatingNanEquality() {
   ASSERT_TRUE(b->RangeEquals(a, 1, 2, 1));
 
   // NaN in a valid entry
-  ArrayFromVector<TYPE>(type, {false, true}, {GetFloat<TYPE>(0.5), nan_value}, &a);
-  ArrayFromVector<TYPE>(type, {false, true}, {GetFloat<TYPE>(0.5), nan_value}, &b);
+  ArrayFromVector<TYPE>(type, {false, true}, {RealToCType<TYPE>(0.5), nan_value}, &a);
+  ArrayFromVector<TYPE>(type, {false, true}, {RealToCType<TYPE>(0.5), nan_value}, &b);
   ASSERT_FALSE(a->Equals(b));
   ASSERT_FALSE(b->Equals(a));
   ASSERT_TRUE(a->Equals(b, EqualOptions().nans_equal(true)));
@@ -2180,9 +2160,9 @@ void CheckFloatingNanEquality() {
   ASSERT_TRUE(b->RangeEquals(a, 0, 1, 0));
 
   // NaN != non-NaN
-  ArrayFromVector<TYPE>(type, {false, true}, {GetFloat<TYPE>(0.5), nan_value}, &a);
-  ArrayFromVector<TYPE>(type, {false, true}, {GetFloat<TYPE>(0.5), GetFloat<TYPE>(0.0)},
-                        &b);
+  ArrayFromVector<TYPE>(type, {false, true}, {RealToCType<TYPE>(0.5), nan_value}, &a);
+  ArrayFromVector<TYPE>(type, {false, true},
+                        {RealToCType<TYPE>(0.5), RealToCType<TYPE>(0.0)}, &b);
   ASSERT_FALSE(a->Equals(b));
   ASSERT_FALSE(b->Equals(a));
   ASSERT_FALSE(a->Equals(b, EqualOptions().nans_equal(true)));
@@ -2206,14 +2186,14 @@ void CheckFloatingInfinityEquality() {
   std::shared_ptr<Array> a, b;
   std::shared_ptr<DataType> type = TypeTraits<TYPE>::type_singleton();
 
-  const auto infinity = GetFloat<TYPE>(std::numeric_limits<double>::infinity());
+  const auto infinity = RealToCType<TYPE>(std::numeric_limits<double>::infinity());
 
   for (auto nans_equal : {false, true}) {
     // Infinity in a null entry
     ArrayFromVector<TYPE>(type, {true, false},
-                          {GetFloat<TYPE>(0.5), GetFloat<TYPE>(infinity)}, &a);
+                          {RealToCType<TYPE>(0.5), RealToCType<TYPE>(infinity)}, &a);
     ArrayFromVector<TYPE>(type, {true, false},
-                          {GetFloat<TYPE>(0.5), GetFloat<TYPE>(-infinity)}, &b);
+                          {RealToCType<TYPE>(0.5), RealToCType<TYPE>(-infinity)}, &b);
     ASSERT_TRUE(a->Equals(b));
     ASSERT_TRUE(b->Equals(a));
     ASSERT_TRUE(a->ApproxEquals(b, EqualOptions().atol(1e-5).nans_equal(nans_equal)));
@@ -2225,9 +2205,9 @@ void CheckFloatingInfinityEquality() {
 
     // Infinity in a valid entry
     ArrayFromVector<TYPE>(type, {false, true},
-                          {GetFloat<TYPE>(0.5), GetFloat<TYPE>(infinity)}, &a);
+                          {RealToCType<TYPE>(0.5), RealToCType<TYPE>(infinity)}, &a);
     ArrayFromVector<TYPE>(type, {false, true},
-                          {GetFloat<TYPE>(0.5), GetFloat<TYPE>(infinity)}, &b);
+                          {RealToCType<TYPE>(0.5), RealToCType<TYPE>(infinity)}, &b);
     ASSERT_TRUE(a->Equals(b));
     ASSERT_TRUE(b->Equals(a));
     ASSERT_TRUE(a->ApproxEquals(b, EqualOptions().atol(1e-5).nans_equal(nans_equal)));
@@ -2245,9 +2225,9 @@ void CheckFloatingInfinityEquality() {
 
     // Infinity != non-infinity
     ArrayFromVector<TYPE>(type, {false, true},
-                          {GetFloat<TYPE>(0.5), GetFloat<TYPE>(-infinity)}, &a);
-    ArrayFromVector<TYPE>(type, {false, true}, {GetFloat<TYPE>(0.5), GetFloat<TYPE>(0.0)},
-                          &b);
+                          {RealToCType<TYPE>(0.5), RealToCType<TYPE>(-infinity)}, &a);
+    ArrayFromVector<TYPE>(type, {false, true},
+                          {RealToCType<TYPE>(0.5), RealToCType<TYPE>(0.0)}, &b);
     ASSERT_FALSE(a->Equals(b));
     ASSERT_FALSE(b->Equals(a));
     ASSERT_FALSE(a->ApproxEquals(b, EqualOptions().atol(1e-5).nans_equal(nans_equal)));
@@ -2256,9 +2236,9 @@ void CheckFloatingInfinityEquality() {
     ASSERT_FALSE(b->ApproxEquals(a, EqualOptions().atol(1e-5).nans_equal(nans_equal)));
     // Infinity != Negative infinity
     ArrayFromVector<TYPE>(type, {true, true},
-                          {GetFloat<TYPE>(0.5), GetFloat<TYPE>(-infinity)}, &a);
+                          {RealToCType<TYPE>(0.5), RealToCType<TYPE>(-infinity)}, &a);
     ArrayFromVector<TYPE>(type, {true, true},
-                          {GetFloat<TYPE>(0.5), GetFloat<TYPE>(infinity)}, &b);
+                          {RealToCType<TYPE>(0.5), RealToCType<TYPE>(infinity)}, &b);
     ASSERT_FALSE(a->Equals(b));
     ASSERT_FALSE(b->Equals(a));
     ASSERT_FALSE(a->ApproxEquals(b));
@@ -2281,10 +2261,10 @@ void CheckFloatingZeroEquality() {
   std::shared_ptr<Array> a, b;
   std::shared_ptr<DataType> type = TypeTraits<TYPE>::type_singleton();
 
-  ArrayFromVector<TYPE>(type, {true, false}, {GetFloat<TYPE>(0.0), GetFloat<TYPE>(1.0)},
-                        &a);
-  ArrayFromVector<TYPE>(type, {true, false}, {GetFloat<TYPE>(0.0), GetFloat<TYPE>(1.0)},
-                        &b);
+  ArrayFromVector<TYPE>(type, {true, false},
+                        {RealToCType<TYPE>(0.0), RealToCType<TYPE>(1.0)}, &a);
+  ArrayFromVector<TYPE>(type, {true, false},
+                        {RealToCType<TYPE>(0.0), RealToCType<TYPE>(1.0)}, &b);
   ASSERT_TRUE(a->Equals(b));
   ASSERT_TRUE(b->Equals(a));
   for (auto nans_equal : {false, true}) {
@@ -2300,10 +2280,10 @@ void CheckFloatingZeroEquality() {
     }
   }
 
-  ArrayFromVector<TYPE>(type, {true, false}, {GetFloat<TYPE>(0.0), GetFloat<TYPE>(1.0)},
-                        &a);
-  ArrayFromVector<TYPE>(type, {true, false}, {GetFloat<TYPE>(-0.0), GetFloat<TYPE>(1.0)},
-                        &b);
+  ArrayFromVector<TYPE>(type, {true, false},
+                        {RealToCType<TYPE>(0.0), RealToCType<TYPE>(1.0)}, &a);
+  ArrayFromVector<TYPE>(type, {true, false},
+                        {RealToCType<TYPE>(-0.0), RealToCType<TYPE>(1.0)}, &b);
   for (auto nans_equal : {false, true}) {
     auto opts = EqualOptions().nans_equal(nans_equal);
     ASSERT_TRUE(a->Equals(b, opts));

--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -2120,10 +2120,13 @@ void CheckSliceApproxEquals() {
   ASSERT_TRUE(slice1->ApproxEquals(slice2));
 }
 
+template <typename ArrowType>
+using NumericArgType = std::conditional_t<is_half_float_type<ArrowType>::value, Float16,
+                                          typename ArrowType::c_type>;
+
 template <typename TYPE>
 void CheckFloatingNanEquality() {
-  using V =
-      std::conditional_t<is_half_float_type<TYPE>::value, Float16, typename TYPE::c_type>;
+  using V = NumericArgType<TYPE>;
   std::shared_ptr<Array> a, b;
   std::shared_ptr<DataType> type = TypeTraits<TYPE>::type_singleton();
 
@@ -2184,8 +2187,7 @@ void CheckFloatingNanEquality() {
 
 template <typename TYPE>
 void CheckFloatingInfinityEquality() {
-  using V =
-      std::conditional_t<is_half_float_type<TYPE>::value, Float16, typename TYPE::c_type>;
+  using V = NumericArgType<TYPE>;
   std::shared_ptr<Array> a, b;
   std::shared_ptr<DataType> type = TypeTraits<TYPE>::type_singleton();
 
@@ -2253,8 +2255,7 @@ void CheckFloatingInfinityEquality() {
 
 template <typename TYPE>
 void CheckFloatingZeroEquality() {
-  using V =
-      std::conditional_t<is_half_float_type<TYPE>::value, Float16, typename TYPE::c_type>;
+  using V = NumericArgType<TYPE>;
   std::shared_ptr<Array> a, b;
   std::shared_ptr<DataType> type = TypeTraits<TYPE>::type_singleton();
 

--- a/cpp/src/arrow/compare.cc
+++ b/cpp/src/arrow/compare.cc
@@ -110,7 +110,7 @@ struct FloatingEquality<uint16_t, Flags> {
   bool operator()(uint16_t x, uint16_t y) const {
     Float16 f_x = Float16::FromBits(x);
     Float16 f_y = Float16::FromBits(y);
-    if (x == y) {
+    if (f_x == f_y) {
       return Flags::signed_zeros_equal || (f_x.signbit() == f_y.signbit());
     }
     if (Flags::nans_equal && f_x.is_nan() && f_y.is_nan()) {
@@ -171,7 +171,8 @@ void VisitFloatingEquality(const EqualOptions& options, bool floating_approximat
 }
 
 inline bool IdentityImpliesEqualityNansNotEqual(const DataType& type) {
-  if (type.id() == Type::FLOAT || type.id() == Type::DOUBLE) {
+  if (type.id() == Type::FLOAT || type.id() == Type::DOUBLE ||
+      type.id() == Type::HALF_FLOAT) {
     return false;
   }
   for (const auto& child : type.fields()) {

--- a/cpp/src/arrow/scalar.h
+++ b/cpp/src/arrow/scalar.h
@@ -37,6 +37,7 @@
 #include "arrow/type_traits.h"
 #include "arrow/util/compare.h"
 #include "arrow/util/decimal.h"
+#include "arrow/util/float16.h"
 #include "arrow/util/visibility.h"
 #include "arrow/visit_type_inline.h"
 
@@ -245,6 +246,12 @@ struct ARROW_EXPORT UInt64Scalar : public NumericScalar<UInt64Type> {
 
 struct ARROW_EXPORT HalfFloatScalar : public NumericScalar<HalfFloatType> {
   using NumericScalar<HalfFloatType>::NumericScalar;
+
+  explicit HalfFloatScalar(util::Float16 value)
+      : NumericScalar(value.bits(), float16()) {}
+
+  HalfFloatScalar(util::Float16 value, std::shared_ptr<DataType> type)
+      : NumericScalar(value.bits(), std::move(type)) {}
 };
 
 struct ARROW_EXPORT FloatScalar : public NumericScalar<FloatType> {
@@ -966,6 +973,18 @@ struct MakeScalarImpl {
     // `static_cast<ValueRef>` makes a rvalue if ValueRef is `ValueType&&`
     out_ = std::make_shared<ScalarType>(
         static_cast<ValueType>(static_cast<ValueRef>(value_)), std::move(type_));
+    return Status::OK();
+  }
+
+  // This isn't captured by the generic case above because `util::Float16` isn't implicity
+  // convertible to `uint16_t` (HalfFloat's ValueType)
+  template <typename T>
+  std::enable_if_t<std::is_same_v<std::remove_reference_t<ValueRef>, util::Float16> &&
+                       is_half_float_type<T>::value,
+                   Status>
+  Visit(const T& t) {
+    out_ = std::make_shared<HalfFloatScalar>(static_cast<ValueRef>(value_),
+                                             std::move(type_));
     return Status::OK();
   }
 

--- a/cpp/src/arrow/scalar.h
+++ b/cpp/src/arrow/scalar.h
@@ -979,7 +979,7 @@ struct MakeScalarImpl {
   // This isn't captured by the generic case above because `util::Float16` isn't implicity
   // convertible to `uint16_t` (HalfFloat's ValueType)
   template <typename T>
-  std::enable_if_t<std::is_same_v<std::remove_reference_t<ValueRef>, util::Float16> &&
+  std::enable_if_t<std::is_same_v<std::decay_t<ValueRef>, util::Float16> &&
                        is_half_float_type<T>::value,
                    Status>
   Visit(const T& t) {

--- a/cpp/src/arrow/scalar_test.cc
+++ b/cpp/src/arrow/scalar_test.cc
@@ -230,6 +230,11 @@ TYPED_TEST(TestNumericScalar, Basics) {
   T value = static_cast<T>(1);
 
   auto scalar_val = std::make_shared<ScalarType>(value);
+  if constexpr (is_half_float_type<TypeParam>::value) {
+    ASSERT_EQ(value, Float16::FromBits(scalar_val->value));
+  } else {
+    ASSERT_EQ(value, scalar_val->value);
+  }
   ASSERT_TRUE(scalar_val->is_valid);
   ASSERT_OK(scalar_val->ValidateFull());
 
@@ -241,11 +246,9 @@ TYPED_TEST(TestNumericScalar, Basics) {
   ASSERT_NE(*scalar_other, *scalar_val);
 
   if constexpr (is_half_float_type<TypeParam>::value) {
-    ASSERT_EQ(value, Float16::FromBits(scalar_val->value));
     scalar_val->value = other_value.bits();
     ASSERT_EQ(other_value, Float16::FromBits(scalar_val->value));
   } else {
-    ASSERT_EQ(value, scalar_val->value);
     scalar_val->value = other_value;
     ASSERT_EQ(other_value, scalar_val->value);
   }
@@ -294,7 +297,7 @@ TYPED_TEST(TestNumericScalar, Hashing) {
   std::unordered_set<std::shared_ptr<Scalar>, Scalar::Hash, Scalar::PtrsEqual> set;
   set.emplace(std::make_shared<ScalarType>());
   for (int i = 0; i < 10; ++i) {
-    set.emplace(std::make_shared<ScalarType>(static_cast<T>(i)));
+    ASSERT_TRUE(set.emplace(std::make_shared<ScalarType>(static_cast<T>(i))).second);
   }
 
   ASSERT_FALSE(set.emplace(std::make_shared<ScalarType>()).second);

--- a/cpp/src/arrow/scalar_test.cc
+++ b/cpp/src/arrow/scalar_test.cc
@@ -299,26 +299,6 @@ TYPED_TEST(TestNumericScalar, MakeScalar) {
   AssertParseScalar(type, "3", ScalarType(3));
 }
 
-template <typename ARROW_TYPE>
-auto GetFloat(double d) {
-  if constexpr (std::is_same_v<ARROW_TYPE, HalfFloatType>) {
-    const auto h = Float16::FromDouble(d);
-    // Double check that nan/inf/sign are preserved
-    if (std::isnan(d)) {
-      EXPECT_TRUE(h.is_nan());
-    }
-    if (std::isinf(d)) {
-      EXPECT_TRUE(h.is_infinity());
-    }
-    if (std::signbit(d)) {
-      EXPECT_TRUE(h.signbit());
-    }
-    return h.bits();
-  } else {
-    return static_cast<typename ARROW_TYPE::c_type>(d);
-  }
-}
-
 template <typename T>
 class TestRealScalar : public ::testing::Test {
  public:
@@ -328,21 +308,22 @@ class TestRealScalar : public ::testing::Test {
   void SetUp() {
     type_ = TypeTraits<T>::type_singleton();
 
-    scalar_val_ = std::make_shared<ScalarType>(GetFloat<T>(1));
+    scalar_val_ = std::make_shared<ScalarType>(RealToCType<T>(1));
     ASSERT_TRUE(scalar_val_->is_valid);
 
-    scalar_other_ = std::make_shared<ScalarType>(GetFloat<T>(1.1));
+    scalar_other_ = std::make_shared<ScalarType>(RealToCType<T>(1.1));
     ASSERT_TRUE(scalar_other_->is_valid);
 
-    scalar_zero_ = std::make_shared<ScalarType>(GetFloat<T>(0.0));
-    scalar_other_zero_ = std::make_shared<ScalarType>(GetFloat<T>(0.0));
-    scalar_neg_zero_ = std::make_shared<ScalarType>(GetFloat<T>(-0.0));
+    scalar_zero_ = std::make_shared<ScalarType>(RealToCType<T>(0.0));
+    scalar_other_zero_ = std::make_shared<ScalarType>(RealToCType<T>(0.0));
+    scalar_neg_zero_ = std::make_shared<ScalarType>(RealToCType<T>(-0.0));
 
-    const CType nan_value = GetFloat<T>(std::numeric_limits<double>::quiet_NaN());
+    const CType nan_value = RealToCType<T>(std::numeric_limits<double>::quiet_NaN());
     scalar_nan_ = std::make_shared<ScalarType>(nan_value);
     ASSERT_TRUE(scalar_nan_->is_valid);
 
-    const CType other_nan_value = GetFloat<T>(std::numeric_limits<double>::quiet_NaN());
+    const CType other_nan_value =
+        RealToCType<T>(std::numeric_limits<double>::quiet_NaN());
     scalar_other_nan_ = std::make_shared<ScalarType>(other_nan_value);
     ASSERT_TRUE(scalar_other_nan_->is_valid);
   }

--- a/cpp/src/arrow/scalar_test.cc
+++ b/cpp/src/arrow/scalar_test.cc
@@ -323,28 +323,28 @@ TYPED_TEST(TestNumericScalar, MakeScalar) {
 template <typename T>
 class TestRealScalar : public ::testing::Test {
  public:
-  using CType = typename T::c_type;
+  using ValueType =
+      std::conditional_t<is_half_float_type<T>::value, Float16, typename T::c_type>;
   using ScalarType = typename TypeTraits<T>::ScalarType;
 
   void SetUp() {
     type_ = TypeTraits<T>::type_singleton();
 
-    scalar_val_ = std::make_shared<ScalarType>(RealToCType<T>(1));
+    scalar_val_ = std::make_shared<ScalarType>(static_cast<ValueType>(1));
     ASSERT_TRUE(scalar_val_->is_valid);
 
-    scalar_other_ = std::make_shared<ScalarType>(RealToCType<T>(1.1));
+    scalar_other_ = std::make_shared<ScalarType>(static_cast<ValueType>(1.1));
     ASSERT_TRUE(scalar_other_->is_valid);
 
-    scalar_zero_ = std::make_shared<ScalarType>(RealToCType<T>(0.0));
-    scalar_other_zero_ = std::make_shared<ScalarType>(RealToCType<T>(0.0));
-    scalar_neg_zero_ = std::make_shared<ScalarType>(RealToCType<T>(-0.0));
+    scalar_zero_ = std::make_shared<ScalarType>(static_cast<ValueType>(0.0));
+    scalar_other_zero_ = std::make_shared<ScalarType>(static_cast<ValueType>(0.0));
+    scalar_neg_zero_ = std::make_shared<ScalarType>(static_cast<ValueType>(-0.0));
 
-    const CType nan_value = RealToCType<T>(std::numeric_limits<double>::quiet_NaN());
+    const auto nan_value = std::numeric_limits<ValueType>::quiet_NaN();
     scalar_nan_ = std::make_shared<ScalarType>(nan_value);
     ASSERT_TRUE(scalar_nan_->is_valid);
 
-    const CType other_nan_value =
-        RealToCType<T>(std::numeric_limits<double>::quiet_NaN());
+    const auto other_nan_value = std::numeric_limits<ValueType>::quiet_NaN();
     scalar_other_nan_ = std::make_shared<ScalarType>(other_nan_value);
     ASSERT_TRUE(scalar_other_nan_->is_valid);
   }

--- a/cpp/src/arrow/scalar_test.cc
+++ b/cpp/src/arrow/scalar_test.cc
@@ -206,18 +206,10 @@ TEST(TestScalar, IdentityCast) {
 template <typename ARROW_TYPE>
 struct NumericHelper {
   using ArgType = typename ARROW_TYPE::c_type;
-  template <typename T>
-  static T Arg(T v) {
-    return v;
-  }
 };
 template <>
 struct NumericHelper<HalfFloatType> {
   using ArgType = Float16;
-  template <typename T>
-  static ArgType Arg(T v) {
-    return static_cast<ArgType>(v);
-  }
 };
 
 template <typename T>
@@ -232,8 +224,7 @@ using NumericArrowTypesPlusHalfFloat =
 TYPED_TEST_SUITE(TestNumericScalar, NumericArrowTypesPlusHalfFloat);
 
 TYPED_TEST(TestNumericScalar, Basics) {
-  using Helper = NumericHelper<TypeParam>;
-  using T = typename Helper::ArgType;
+  using T = typename NumericHelper<TypeParam>::ArgType;
   using ScalarType = typename TypeTraits<TypeParam>::ScalarType;
 
   T value = static_cast<T>(1);
@@ -284,16 +275,16 @@ TYPED_TEST(TestNumericScalar, Basics) {
   ASSERT_OK(two->ValidateFull());
 
   ASSERT_TRUE(null->Equals(*null_value));
-  ASSERT_TRUE(one->Equals(ScalarType(Helper::Arg(1))));
-  ASSERT_FALSE(one->Equals(ScalarType(Helper::Arg(2))));
-  ASSERT_TRUE(two->Equals(ScalarType(Helper::Arg(2))));
-  ASSERT_FALSE(two->Equals(ScalarType(Helper::Arg(3))));
+  ASSERT_TRUE(one->Equals(ScalarType(static_cast<T>(1))));
+  ASSERT_FALSE(one->Equals(ScalarType(static_cast<T>(2))));
+  ASSERT_TRUE(two->Equals(ScalarType(static_cast<T>(2))));
+  ASSERT_FALSE(two->Equals(ScalarType(static_cast<T>(3))));
 
   ASSERT_TRUE(null->ApproxEquals(*null_value));
-  ASSERT_TRUE(one->ApproxEquals(ScalarType(Helper::Arg(1))));
-  ASSERT_FALSE(one->ApproxEquals(ScalarType(Helper::Arg(2))));
-  ASSERT_TRUE(two->ApproxEquals(ScalarType(Helper::Arg(2))));
-  ASSERT_FALSE(two->ApproxEquals(ScalarType(Helper::Arg(3))));
+  ASSERT_TRUE(one->ApproxEquals(ScalarType(static_cast<T>(1))));
+  ASSERT_FALSE(one->ApproxEquals(ScalarType(static_cast<T>(2))));
+  ASSERT_TRUE(two->ApproxEquals(ScalarType(static_cast<T>(2))));
+  ASSERT_FALSE(two->ApproxEquals(ScalarType(static_cast<T>(3))));
 }
 
 TYPED_TEST(TestNumericScalar, Hashing) {
@@ -313,18 +304,17 @@ TYPED_TEST(TestNumericScalar, Hashing) {
 }
 
 TYPED_TEST(TestNumericScalar, MakeScalar) {
-  using Helper = NumericHelper<TypeParam>;
-  using T = typename Helper::ArgType;
+  using T = typename NumericHelper<TypeParam>::ArgType;
   using ScalarType = typename TypeTraits<TypeParam>::ScalarType;
   auto type = TypeTraits<TypeParam>::type_singleton();
 
   std::shared_ptr<Scalar> three = MakeScalar(static_cast<T>(3));
   ASSERT_OK(three->ValidateFull());
-  ASSERT_EQ(ScalarType(Helper::Arg(3)), *three);
+  ASSERT_EQ(ScalarType(static_cast<T>(3)), *three);
 
-  AssertMakeScalar(ScalarType(Helper::Arg(3)), type, static_cast<T>(3));
+  AssertMakeScalar(ScalarType(static_cast<T>(3)), type, static_cast<T>(3));
 
-  AssertParseScalar(type, "3", ScalarType(Helper::Arg(3)));
+  AssertParseScalar(type, "3", ScalarType(static_cast<T>(3)));
 }
 
 template <typename T>

--- a/cpp/src/arrow/testing/gtest_util.h
+++ b/cpp/src/arrow/testing/gtest_util.h
@@ -18,7 +18,6 @@
 #pragma once
 
 #include <algorithm>
-#include <cmath>
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
@@ -40,7 +39,6 @@
 #include "arrow/testing/visibility.h"
 #include "arrow/type_fwd.h"
 #include "arrow/type_traits.h"
-#include "arrow/util/float16.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/string_util.h"
 #include "arrow/util/type_fwd.h"
@@ -573,22 +571,5 @@ ARROW_TESTING_EXPORT std::shared_ptr<ArrayData> UnalignBuffers(const ArrayData& 
 ///
 /// This method does not recurse into the dictionary or children
 ARROW_TESTING_EXPORT std::shared_ptr<Array> UnalignBuffers(const Array& array);
-
-/// \brief Convert a floating point value to it's corresponding C Type
-///
-/// Useful when testing HalfFloat (uint16_t) values alongside native floating point types
-template <typename ARROW_TYPE>
-auto RealToCType(double d) {
-  if constexpr (is_half_float_type<ARROW_TYPE>::value) {
-    const auto h = util::Float16::FromDouble(d);
-    // Double check that nan/inf/sign are preserved
-    EXPECT_EQ(h.is_nan(), std::isnan(d));
-    EXPECT_EQ(h.is_infinity(), std::isinf(d));
-    EXPECT_EQ(h.signbit(), std::signbit(d));
-    return h.bits();
-  } else {
-    return static_cast<typename ARROW_TYPE::c_type>(d);
-  }
-}
 
 }  // namespace arrow

--- a/cpp/src/arrow/testing/random.cc
+++ b/cpp/src/arrow/testing/random.cc
@@ -252,16 +252,14 @@ std::shared_ptr<Array> RandomArrayGenerator::Date64(int64_t size, int64_t min,
                                                       memory_pool);
 }
 
-std::shared_ptr<Array> RandomArrayGenerator::Float16(int64_t size, int16_t min,
-                                                     int16_t max, double null_probability,
+std::shared_ptr<Array> RandomArrayGenerator::Float16(int64_t size, uint16_t min,
+                                                     uint16_t max,
+                                                     double null_probability,
                                                      int64_t alignment,
                                                      MemoryPool* memory_pool) {
   using OptionType =
       GenerateOptions<uint16_t, std::uniform_int_distribution<uint16_t>, HalfFloatType>;
-  // FIXME: Not sure why the input min/max are signed when Float16's ctype is uint16_t
-  uint16_t umin = static_cast<uint16_t>(min);
-  uint16_t umax = static_cast<uint16_t>(max);
-  OptionType options(seed(), umin, umax, null_probability, /*nan_probability=*/0);
+  OptionType options(seed(), min, max, null_probability, /*nan_probability=*/0);
   return GenerateNumericArray<HalfFloatType, OptionType>(size, options, alignment,
                                                          memory_pool);
 }

--- a/cpp/src/arrow/testing/random.cc
+++ b/cpp/src/arrow/testing/random.cc
@@ -103,7 +103,7 @@ struct GenerateOptions {
     pcg32_fast rng(seed_++);
     DistributionType dist(min_, max_);
 
-    if constexpr (std::is_same_v<ArrowType, HalfFloatType>) {
+    if constexpr (is_half_float_type<ArrowType>::value) {
       // Special handling is required to prevent generating Float16 NaNs
       std::generate(data, data + n, [&] {
         Float16 f;

--- a/cpp/src/arrow/testing/random.cc
+++ b/cpp/src/arrow/testing/random.cc
@@ -1157,8 +1157,6 @@ std::shared_ptr<Array> RandomArrayGenerator::ArrayOf(const Field& field, int64_t
           GetMetadata<double>(field.metadata().get(), "nan_probability", 0);
       VALIDATE_MIN_MAX(min_value, max_value);
       VALIDATE_RANGE(nan_probability, 0.0, 1.0);
-      ARROW_LOG(INFO) << "min = " << min_value.ToFloat();
-      ARROW_LOG(INFO) << "max = " << max_value.ToFloat();
       return Float16(length, min_value, max_value, null_probability, nan_probability,
                      alignment, memory_pool);
     }

--- a/cpp/src/arrow/testing/random.h
+++ b/cpp/src/arrow/testing/random.h
@@ -28,6 +28,7 @@
 #include "arrow/testing/uniform_real.h"
 #include "arrow/testing/visibility.h"
 #include "arrow/type.h"
+#include "arrow/util/float16.h"
 
 namespace arrow {
 
@@ -198,8 +199,30 @@ class ARROW_TESTING_EXPORT RandomArrayGenerator {
   /// \param[in] memory_pool memory pool to allocate memory from
   ///
   /// \return a generated Array
+  ///
+  /// \deprecated Deprecated in 22.0.0. Use the other Float16() method that accepts
+  /// nan_probability as a parameter
+  ARROW_DEPRECATED(
+      "Deprecated in 22.0.0. Use the other Float16() method that accepts nan_probability "
+      "as a parameter")
   std::shared_ptr<Array> Float16(int64_t size, uint16_t min, uint16_t max,
                                  double null_probability = 0,
+                                 int64_t alignment = kDefaultBufferAlignment,
+                                 MemoryPool* memory_pool = default_memory_pool());
+
+  /// \brief Generate a random HalfFloatArray
+  ///
+  /// \param[in] size the size of the array to generate
+  /// \param[in] min the lower bound of the uniform distribution
+  /// \param[in] max the upper bound of the uniform distribution
+  /// \param[in] null_probability the probability of a value being null
+  /// \param[in] nan_probability the probability of a value being NaN
+  /// \param[in] alignment alignment for memory allocations (in bytes)
+  /// \param[in] memory_pool memory pool to allocate memory from
+  ///
+  /// \return a generated Array
+  std::shared_ptr<Array> Float16(int64_t size, util::Float16 min, util::Float16 max,
+                                 double null_probability = 0, double nan_probability = 0,
                                  int64_t alignment = kDefaultBufferAlignment,
                                  MemoryPool* memory_pool = default_memory_pool());
 
@@ -281,8 +304,9 @@ class ARROW_TESTING_EXPORT RandomArrayGenerator {
         return Int64(size, static_cast<int64_t>(min), static_cast<int64_t>(max),
                      null_probability, alignment, memory_pool);
       case Type::HALF_FLOAT:
-        return Float16(size, static_cast<int16_t>(min), static_cast<int16_t>(max),
-                       null_probability, alignment, memory_pool);
+        return Float16(size, util::Float16::FromBits(static_cast<uint16_t>(min)),
+                       util::Float16::FromBits(static_cast<uint16_t>(max)),
+                       null_probability, /*nan_probability=*/0, alignment, memory_pool);
       case Type::FLOAT:
         return Float32(size, static_cast<float>(min), static_cast<float>(max),
                        null_probability, /*nan_probability=*/0, alignment, memory_pool);

--- a/cpp/src/arrow/testing/random.h
+++ b/cpp/src/arrow/testing/random.h
@@ -198,7 +198,7 @@ class ARROW_TESTING_EXPORT RandomArrayGenerator {
   /// \param[in] memory_pool memory pool to allocate memory from
   ///
   /// \return a generated Array
-  std::shared_ptr<Array> Float16(int64_t size, int16_t min, int16_t max,
+  std::shared_ptr<Array> Float16(int64_t size, uint16_t min, uint16_t max,
                                  double null_probability = 0,
                                  int64_t alignment = kDefaultBufferAlignment,
                                  MemoryPool* memory_pool = default_memory_pool());

--- a/cpp/src/arrow/type_fwd.h
+++ b/cpp/src/arrow/type_fwd.h
@@ -46,6 +46,7 @@ class Future;
 namespace util {
 class Codec;
 class CodecOptions;
+class Float16;
 }  // namespace util
 
 class Buffer;

--- a/cpp/src/arrow/type_traits.h
+++ b/cpp/src/arrow/type_traits.h
@@ -317,6 +317,11 @@ struct TypeTraits<HalfFloatType> {
 };
 
 template <>
+struct CTypeTraits<util::Float16> : public TypeTraits<HalfFloatType> {
+  using ArrowType = HalfFloatType;
+};
+
+template <>
 struct TypeTraits<Decimal32Type> {
   using ArrayType = Decimal32Array;
   using BuilderType = Decimal32Builder;


### PR DESCRIPTION
### Rationale for this change

Equality comparisons between half-floats (used in their scalar/array `Equals` methods) do not properly handle `EqualOptions::nans_equal` and `EqualOptions::signed_zeros_equal`.
 
### What changes are included in this PR?

- Internal fixes to the current comparison behavior and additional tests as needed
- Prevents Float16 NaNs from being randomly generated by test utilities by default (matching behavior for float/double)

### Are these changes tested?

Yes

### Are there any user-facing changes?

No

* GitHub Issue: #46739