### PR TITLE
GH-46974: [Integration][Archery] Add support for ARROW_JS_ROOT

### DIFF
--- a/ci/scripts/integration_arrow.sh
+++ b/ci/scripts/integration_arrow.sh
@@ -47,6 +47,7 @@ fi
 github_actions_group_end
 
 export ARROW_BUILD_ROOT=${build_dir}
+export ARROW_JS_ROOT=${build_dir}/js
 
 # Get more detailed context on crashes
 export PYTHONFAULTHANDLER=1

--- a/dev/archery/archery/integration/tester_js.py
+++ b/dev/archery/archery/integration/tester_js.py
@@ -16,20 +16,12 @@
 # under the License.
 
 import os
-from pathlib import Path
 
 from .tester import Tester
 from .util import run_cmd, log
 
 
-ARROW_BUILD_ROOT = os.environ.get(
-    'ARROW_BUILD_ROOT',
-    Path(__file__).resolve().parents[4]
-)
-ARROW_JS_ROOT = os.environ.get(
-    'ARROW_JS_ROOT',
-    os.path.join(ARROW_BUILD_ROOT, 'js')
-)
+ARROW_JS_ROOT = os.environ['ARROW_JS_ROOT']
 _EXE_PATH = os.path.join(ARROW_JS_ROOT, 'bin')
 _VALIDATE = os.path.join(_EXE_PATH, 'integration.ts')
 _JSON_TO_ARROW = os.path.join(_EXE_PATH, 'json-to-arrow.ts')

--- a/dev/archery/archery/integration/tester_js.py
+++ b/dev/archery/archery/integration/tester_js.py
@@ -26,7 +26,10 @@ ARROW_BUILD_ROOT = os.environ.get(
     'ARROW_BUILD_ROOT',
     Path(__file__).resolve().parents[4]
 )
-ARROW_JS_ROOT = os.path.join(ARROW_BUILD_ROOT, 'js')
+ARROW_JS_ROOT = os.environ.get(
+    'ARROW_JS_ROOT',
+    os.path.join(ARROW_BUILD_ROOT, 'js')
+)
 _EXE_PATH = os.path.join(ARROW_JS_ROOT, 'bin')
 _VALIDATE = os.path.join(_EXE_PATH, 'integration.ts')
 _JSON_TO_ARROW = os.path.join(_EXE_PATH, 'json-to-arrow.ts')


### PR DESCRIPTION
### Rationale for this change

If we can specify the JS implementation directory by an environment variable, it's useful. Because developers don't need to copy the JS implementation to `apache/arrow/js`. 

### What changes are included in this PR?

Refer `ARROW_JS_ROOT` before using the default JS implementation directory.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #46974