### PR TITLE
GH-46986: [CI][C++] Fix a build error with C++20

### DIFF
--- a/cpp/src/arrow/compute/kernels/scalar_string_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_test.cc
@@ -2271,7 +2271,7 @@ TYPED_TEST(TestStringKernels, UTF8ZeroFill) {
                    R"(["xxx1", "-xx2", "+xx3"])", &options);
 
   // Non-ASCII padding character
-  options = ZeroFillOptions{/*width=*/5, u8"💠"};
+  options = ZeroFillOptions{/*width=*/5, "💠"};
   this->CheckUnary("utf8_zero_fill", R"(["1", "-2", "+3"])", this->type(),
                    R"(["💠💠💠💠1", "-💠💠💠2", "+💠💠💠3"])", &options);
 


### PR DESCRIPTION
### Rationale for this change

We can't convert `u8"..."` to `std::string` automatically with C++20 because C++20 uses `std::u8string` for UTF-8 string.

This is related to #46815.

### What changes are included in this PR?

Remove needless `u8` prefix.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #46986