### PR TITLE
GH-46989: [CI][R] Use Ubuntu 20.04 instead of OpenSUSE for R 4.1

### DIFF
--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1012,8 +1012,8 @@ tasks:
 
 {% for r_org, r_image, r_tag in [("rhub", "ubuntu-release", "latest"),
                                  ("rocker", "r-ver", "latest"),
-                                 ("rstudio", "r-base", "4.2-noble"),
-                                 ("rstudio", "r-base", "4.1-noble")] %}
+                                 ("rstudio", "r-base", "4.2-focal"),
+                                 ("rstudio", "r-base", "4.1-focal")] %}
   test-r-{{ r_org }}-{{ r_image }}-{{ r_tag }}:
     ci: azure
     template: r/azure.linux.yml

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -1012,8 +1012,8 @@ tasks:
 
 {% for r_org, r_image, r_tag in [("rhub", "ubuntu-release", "latest"),
                                  ("rocker", "r-ver", "latest"),
-                                 ("rstudio", "r-base", "4.2-focal"),
-                                 ("rstudio", "r-base", "4.1-opensuse155")] %}
+                                 ("rstudio", "r-base", "4.2-noble"),
+                                 ("rstudio", "r-base", "4.1-noble")] %}
   test-r-{{ r_org }}-{{ r_image }}-{{ r_tag }}:
     ci: azure
     template: r/azure.linux.yml

--- a/docs/source/developers/cpp/building.rst
+++ b/docs/source/developers/cpp/building.rst
@@ -39,7 +39,7 @@ out-of-source. If you are not familiar with this terminology:
 
 Building requires:
 
-* A C++17-enabled compiler. On Linux, gcc 7.1 and higher should be
+* A C++17-enabled compiler. On Linux, gcc 9 and higher should be
   sufficient. For Windows, at least Visual Studio VS2017 is required.
 * CMake 3.25 or higher
 * On Linux and macOS, either ``make`` or ``ninja`` build utilities

--- a/docs/source/developers/cpp/building.rst
+++ b/docs/source/developers/cpp/building.rst
@@ -39,7 +39,7 @@ out-of-source. If you are not familiar with this terminology:
 
 Building requires:
 
-* A C++17-enabled compiler. On Linux, gcc 9 and higher should be
+* A C++17-enabled compiler. On Linux, gcc 7.1 and higher should be
   sufficient. For Windows, at least Visual Studio VS2017 is required.
 * CMake 3.25 or higher
 * On Linux and macOS, either ``make`` or ``ninja`` build utilities


### PR DESCRIPTION
### Rationale for this change

OpenSUSE 15.5 ships old GCC (7.5) that doesn't have enough C++17 support.

### What changes are included in this PR?

Use Ubuntu 20.04 that ships GCC 9.3  instead of OpenSUSE 15.5.

Ubuntu 20.04 reached EOL but we can use it for now.

We discussed why we need OpenSUSE 15.5 based job at https://github.com/apache/arrow/issues/45718#issuecomment-2743538384 . We have the job because https://arrow.apache.org/docs/developers/cpp/building.html said "gcc 7.1 and higher should be sufficient".

We need require GCC 9 or later with #46813.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #46989