### PR TITLE
GH-46942: [Docs] Replace the directive versionadded with note

### DIFF
--- a/docs/source/format/Columnar.rst
+++ b/docs/source/format/Columnar.rst
@@ -482,7 +482,7 @@ will be represented as follows: ::
 Variable-size Binary View Layout
 --------------------------------
 
-.. versionadded:: Arrow Columnar Format 1.4
+.. note:: New in version Arrow Columnar Format 1.4
 
 Each value in this layout consists of 0 or more bytes. These bytes'
 locations are indicated using a **views** buffer, which may point to one
@@ -628,7 +628,7 @@ will be represented as follows: ::
 ListView Layout
 ~~~~~~~~~~~~~~~
 
-.. versionadded:: Arrow Columnar Format 1.4
+.. note:: New in version Arrow Columnar Format 1.4
 
 The ListView layout is defined by three buffers: a validity bitmap, an offsets
 buffer, and an additional sizes buffer. Sizes and offsets have the identical bit
@@ -1085,7 +1085,7 @@ below.
 Run-End Encoded Layout
 ----------------------
 
-.. versionadded:: Arrow Columnar Format 1.3
+.. note:: New in version Arrow Columnar Format 1.3
 
 Run-end encoding (REE) is a variation of run-length encoding (RLE). These
 encodings are well-suited for representing data containing sequences of the
@@ -1360,7 +1360,7 @@ memory size rather than the padded size.
 Variadic buffers
 ----------------
 
-.. versionadded:: Arrow Columnar Format 1.4
+.. note:: New in version Arrow Columnar Format 1.4
 
 Some types such as Utf8View are represented using a variable number of buffers.
 For each such Field in the pre-ordered flattened logical schema, there will be


### PR DESCRIPTION
### Rationale for this change

The Sphinx directive `versionadded` expects a `version` argument and an optional description of the change ([docs](https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-versionadded)). The Columnar Format docs pass "Arrow Columnar Format" (unquoted) to the directive, causing only "Arrow" to be rendered as version.

Fixes #46942

### What changes are included in this PR?

Replaces `versionadded` with `note`, following the suggestion in https://github.com/apache/arrow/issues/46942#issuecomment-3021312826.

### Are these changes tested?

[Yes:](http://crossbow.voltrondata.com/pr_docs/46997/format/Columnar.html#arrow-columnar-format)
<img width="765" height="124" alt="Screenshot 2025-07-28 at 13 10 58" src="https://github.com/user-attachments/assets/dd2222b3-c463-4b73-ab1d-fbd99e46a390" />

(The initial commits also tested if the label could be quoted or its whitespaces escaped to prevent it from getting broken up.)

### Are there any user-facing changes?

Docs only.
* GitHub Issue: #46942
