### PR TITLE
GH-46998: [C++] Fix mockfs.cc compiling error with C++23

### DIFF
--- a/cpp/src/arrow/filesystem/mockfs.cc
+++ b/cpp/src/arrow/filesystem/mockfs.cc
@@ -108,10 +108,7 @@ struct Directory {
     return p.second;
   }
 
-  void AssignEntry(const std::string& s, std::unique_ptr<Entry> entry) {
-    DCHECK(!s.empty());
-    entries[s] = std::move(entry);
-  }
+  void AssignEntry(const std::string& s, std::unique_ptr<Entry> entry);
 
   bool DeleteEntry(const std::string& s) { return entries.erase(s) > 0; }
 
@@ -186,6 +183,11 @@ class Entry : public EntryBase {
  private:
   ARROW_DISALLOW_COPY_AND_ASSIGN(Entry);
 };
+
+void Directory::AssignEntry(const std::string& s, std::unique_ptr<Entry> entry) {
+  DCHECK(!s.empty());
+  entries[s] = std::move(entry);
+}
 
 ////////////////////////////////////////////////////////////////////////////
 // Streams


### PR DESCRIPTION
### Rationale for this change

When compiling with C++23, mockfs.cc fails due to a static assertion failure, as described in issue #46998.

### What changes are included in this PR?

Move the implementation of AssignEntry after the definition of Entry.

### Are these changes tested?

Yes, I test the changes with C++23, and the error gone.

### Are there any user-facing changes?

No, the changes are within an anonymous namespace.

* GitHub Issue: #46998