### PR TITLE
GH-47040: [C++] Refine reset of Span to be reusable

### DIFF
--- a/cpp/src/arrow/util/tracing.cc
+++ b/cpp/src/arrow/util/tracing.cc
@@ -37,7 +37,9 @@ bool Span::valid() const {
   return static_cast<::arrow::internal::tracing::SpanImpl*>(details.get())->valid();
 }
 
-void Span::reset() { details.reset(); }
+void Span::reset() {
+  static_cast<::arrow::internal::tracing::SpanImpl*>(details.get())->reset();
+}
 
 #else
 

--- a/cpp/src/arrow/util/tracing_internal.h
+++ b/cpp/src/arrow/util/tracing_internal.h
@@ -110,6 +110,7 @@ class SpanImpl : public ::arrow::util::tracing::SpanDetails {
  public:
   ~SpanImpl() override = default;
   bool valid() const { return ot_span != nullptr; }
+  void reset() { ot_span = nullptr; }
   opentelemetry::nostd::shared_ptr<opentelemetry::trace::Span> ot_span;
 };
 

--- a/cpp/src/arrow/util/tracing_test.cc
+++ b/cpp/src/arrow/util/tracing_test.cc
@@ -46,6 +46,33 @@ TEST(Tracing, OtLifetime) {
   }));
 }
 
+// This test checks that the Span valid invariant is maintained:
+// 1. Span is invalid before START_SPAN
+// 2. Span is valid after START_SPAN
+// 3. Span is invalid after reset
+// 4. Span can be restarted after reset
+TEST(Tracing, ValidInvariant) {
+  Span span;
+
+  EXPECT_FALSE(span.valid());
+
+  START_SPAN(span, "TestSpan");
+
+  EXPECT_TRUE(span.valid());
+
+  span.reset();
+
+  EXPECT_FALSE(span.valid());
+
+  span.reset();
+
+  EXPECT_FALSE(span.valid());
+  {
+    START_SPAN(span, "TestSpan2");
+    EXPECT_TRUE(span.valid());
+  }
+}
+
 #endif
 
 }  // namespace tracing


### PR DESCRIPTION
### Rationale for this change

Original reset will cause Span can't be used again, e.g.
```
Span span;
span.reset();
span.valid(); // crash
RewrapSpan(span, ..); // crash
```
Instead of reset the pointer to SpanImpl, maybe we should reset content inside SpanImpl.

### What changes are included in this PR?

Add reset function in SpanImpl and reimplement reset of Span

### Are these changes tested?

No

### Are there any user-facing changes?

No

* GitHub Issue: #47040