### PR TITLE
GH-46995: [CI][R][C++] Use system memory allocator in sanitizer jobs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1660,8 +1660,9 @@ services:
     environment:
       <<: *common
       LIBARROW_DOWNLOAD: "false"
-      ARROW_SOURCE_HOME: "/arrow"
+      ARROW_MIMALLOC: "OFF"
       ARROW_R_DEV: ${ARROW_R_DEV}
+      ARROW_SOURCE_HOME: "/arrow"
       ARROW_USE_PKG_CONFIG: "false"
     volumes:
       - .:/arrow:delegated


### PR DESCRIPTION
### Rationale for this change

If we use non system memory allocator in sanitizer jobs, it may report false positives.

### What changes are included in this PR?

Disable mimalloc in sanitizer jobs.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #46995