### PR TITLE
GH-46946: [Python] Raise error if Arrow C++ is built without CSV

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -457,6 +457,8 @@ endif()
 # Check for only Arrow C++ options
 if(ARROW_CSV)
   list(APPEND PYARROW_CPP_SRCS ${PYARROW_CPP_SOURCE_DIR}/csv.cc)
+else()
+  message(FATAL_ERROR "You must build Arrow C++ with ARROW_CSV=ON")
 endif()
 
 if(ARROW_FILESYSTEM)


### PR DESCRIPTION
### Rationale for this change
Currently PyArrow fails compiling if Arrow C++ is built without CSV support.

### What changes are included in this PR?
A `message(FATAL_ERROR "...")` is added in `python/CMakeLists.txt` if Arrow C++ was built with `ARROW_CSV=OFF`.

### Are these changes tested?
Yes, with green CI.

### Are there any user-facing changes?
No.

* GitHub Issue: #46946