### PR TITLE
GH-47009: [C#] ExportedAllocationOwner should use 64-bit integer to track total allocated memory.

### DIFF
--- a/csharp/src/Apache.Arrow/Memory/ExportedAllocationOwner.cs
+++ b/csharp/src/Apache.Arrow/Memory/ExportedAllocationOwner.cs
@@ -24,7 +24,7 @@ namespace Apache.Arrow.Memory
     internal sealed class ExportedAllocationOwner : INativeAllocationOwner, IDisposable
     {
         private readonly List<IntPtr> _pointers = new List<IntPtr>();
-        private int _allocationSize;
+        private long _allocationSize;
         private long _referenceCount;
         private bool _disposed;
 

--- a/csharp/test/Apache.Arrow.Tests/CDataInterfaceDataTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/CDataInterfaceDataTests.cs
@@ -110,5 +110,34 @@ namespace Apache.Arrow.Tests
             }
             CArrowArray.Free(cArray);
         }
+
+        [Fact]
+        public unsafe void ExportRecordBatch_LargerThan2GB_Succeeds()
+        {
+            RecordBatch GetTestRecordBatch()
+            {
+                const int rows = 50_000;
+                var doubles = new double[rows];
+                for (var i = 0; i < rows; ++i)
+                {
+                    doubles[i] = i * 1.1;
+                }
+
+                var batchBuilder = new RecordBatch.Builder();
+                for (var i = 0; i < 10_000; i++)
+                {
+                    batchBuilder.Append($"doubles{i}", true, ab => ab.Double(b => b.Append(doubles)));
+                }
+
+                return batchBuilder.Build();
+            }
+
+            RecordBatch batch = GetTestRecordBatch();
+
+            CArrowArray* cArray = CArrowArray.Create();
+            CArrowArrayExporter.ExportRecordBatch(batch, cArray);
+
+            CArrowArray.Free(cArray);
+        }
     }
 }


### PR DESCRIPTION
### Rationale for this change
Fixes https://github.com/apache/arrow/issues/47009

### What changes are included in this PR?
`ExportedAllocationOwner` now uses a 64-bit (instead of 32-bit) variable to track total allocated memory.

### Are these changes tested?
yes

### Are there any user-facing changes?
**This PR contains a "Critical Fix".** 
Previously, it wasn't possible to export Record Batches larger than 2GB, it resulted in overflowing the integer variable that was used to track allocated memory.


* GitHub Issue: #47009