### PR TITLE
GH-38214: [MATLAB] Add a common `arrow.tabular.Tabular` MATLAB interface

### DIFF
--- a/matlab/src/matlab/+arrow/+tabular/RecordBatch.m
+++ b/matlab/src/matlab/+arrow/+tabular/RecordBatch.m
@@ -1,7 +1,6 @@
 %RECORDBATCH A tabular data structure representing a set of 
 %arrow.array.Array objects with a fixed schema.
 
-
 % Licensed to the Apache Software Foundation (ASF) under one or more
 % contributor license agreements.  See the NOTICE file distributed with
 % this work for additional information regarding copyright ownership.
@@ -17,18 +16,11 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef RecordBatch < matlab.mixin.CustomDisplay & ...
-                       matlab.mixin.Scalar
+classdef RecordBatch < arrow.tabular.Tabular
 
-    properties (Dependent, SetAccess=private, GetAccess=public)
-        NumRows
-        NumColumns
-        ColumnNames
-        Schema
-    end
-
-    properties (Hidden, SetAccess=private, GetAccess=public)
-        Proxy
+    properties(Access = protected)
+        % TODO: add comment
+        ColumnProxyToArrayFcn = @makTypedArrayFromProxyInfo
     end
 
     methods
@@ -37,70 +29,7 @@ classdef RecordBatch < matlab.mixin.CustomDisplay & ...
                 proxy(1, 1) libmexclass.proxy.Proxy {validate(proxy, "arrow.tabular.proxy.RecordBatch")}
             end
             import arrow.internal.proxy.validate
-            obj.Proxy = proxy;
-        end
-
-        function numRows = get.NumRows(obj)
-            numRows = obj.Proxy.getNumRows();
-        end
-
-        function numColumns = get.NumColumns(obj)
-            numColumns = obj.Proxy.getNumColumns();
-        end
-
-        function columnNames = get.ColumnNames(obj)
-            columnNames = obj.Proxy.getColumnNames();
-        end
-
-        function schema = get.Schema(obj)
-            proxyID = obj.Proxy.getSchema();
-            proxy = libmexclass.proxy.Proxy(Name="arrow.tabular.proxy.Schema", ID=proxyID);
-            schema = arrow.tabular.Schema(proxy);
-        end
-
-        function arrowArray = column(obj, idx)
-            import arrow.internal.validate.*
-
-            idx = index.numericOrString(idx, "int32", AllowNonScalar=false);
-
-            if isnumeric(idx)
-                args = struct(Index=idx);
-                proxyInfo = obj.Proxy.getColumnByIndex(args);
-            else
-                args = struct(Name=idx);
-                proxyInfo = obj.Proxy.getColumnByName(args);
-            end
-            
-            traits = arrow.type.traits.traits(arrow.type.ID(proxyInfo.TypeID));
-            proxy = libmexclass.proxy.Proxy(Name=traits.ArrayProxyClassName, ID=proxyInfo.ProxyID);
-            arrowArray = traits.ArrayConstructor(proxy);
-        end
-
-        function T = table(obj)
-            import arrow.tabular.internal.*
-
-            numColumns = obj.NumColumns;
-            matlabArrays = cell(1, numColumns);
-            
-            for ii = 1:numColumns
-                arrowArray = obj.column(ii);
-                matlabArrays{ii} = toMATLAB(arrowArray);
-            end
-
-            validVariableNames = makeValidVariableNames(obj.ColumnNames);
-            validDimensionNames = makeValidDimensionNames(validVariableNames);
-
-            T = table(matlabArrays{:}, ...
-                VariableNames=validVariableNames, ...
-                DimensionNames=validDimensionNames);
-        end
-
-        function T = toMATLAB(obj)
-            T = obj.table();
-        end
-
-        function tf = isequal(obj, varargin)
-            tf = arrow.tabular.internal.isequal(obj, varargin{:});
+            obj@arrow.tabular.Tabular(proxy);
         end
 
         function export(obj, cArrowArrayAddress, cArrowSchemaAddress)
@@ -117,19 +46,6 @@ classdef RecordBatch < matlab.mixin.CustomDisplay & ...
         end
     end
 
-    methods (Access = private)
-        function str = toString(obj)
-            str = obj.Proxy.toString();
-        end
-    end
-
-    methods (Access=protected)
-        function displayScalarObject(obj)
-            className = matlab.mixin.CustomDisplay.getClassNameForHeader(obj);
-            tabularDisplay = arrow.tabular.internal.display.getTabularDisplay(obj, className);
-            disp(tabularDisplay + newline);
-        end
-    end
 
     methods (Static, Access=public)
         function recordBatch = fromArrays(arrowArrays, opts)
@@ -164,4 +80,11 @@ classdef RecordBatch < matlab.mixin.CustomDisplay & ...
             recordBatch = importer.import(cArray, cSchema);
         end
     end
+end
+
+
+function array = makTypedArrayFromProxyInfo(proxyInfo)
+    traits = arrow.type.traits.traits(arrow.type.ID(proxyInfo.TypeID));
+    proxy = libmexclass.proxy.Proxy(Name=traits.ArrayProxyClassName, ID=proxyInfo.ProxyID);
+    array = traits.ArrayConstructor(proxy);
 end

--- a/matlab/src/matlab/+arrow/+tabular/RecordBatch.m
+++ b/matlab/src/matlab/+arrow/+tabular/RecordBatch.m
@@ -42,7 +42,7 @@ classdef RecordBatch < arrow.tabular.Tabular
     end
 
     methods (Access=protected)
-        function column = constructColumnFromProxy(proxyInfo)
+        function column = constructColumnFromProxy(~, proxyInfo)
             traits = arrow.type.traits.traits(arrow.type.ID(proxyInfo.TypeID));
             proxy = libmexclass.proxy.Proxy(Name=traits.ArrayProxyClassName, ID=proxyInfo.ProxyID);
             column = traits.ArrayConstructor(proxy);

--- a/matlab/src/matlab/+arrow/+tabular/RecordBatch.m
+++ b/matlab/src/matlab/+arrow/+tabular/RecordBatch.m
@@ -18,11 +18,6 @@
 
 classdef RecordBatch < arrow.tabular.Tabular
 
-    properties(Access = protected)
-        % TODO: add comment
-        ColumnProxyToArrayFcn = @makTypedArrayFromProxyInfo
-    end
-
     methods
         function obj = RecordBatch(proxy)
             arguments
@@ -46,6 +41,13 @@ classdef RecordBatch < arrow.tabular.Tabular
         end
     end
 
+    methods (Access=protected)
+        function column = constructColumnFromProxy(proxyInfo)
+            traits = arrow.type.traits.traits(arrow.type.ID(proxyInfo.TypeID));
+            proxy = libmexclass.proxy.Proxy(Name=traits.ArrayProxyClassName, ID=proxyInfo.ProxyID);
+            column = traits.ArrayConstructor(proxy);
+        end
+    end
 
     methods (Static, Access=public)
         function recordBatch = fromArrays(arrowArrays, opts)
@@ -80,11 +82,4 @@ classdef RecordBatch < arrow.tabular.Tabular
             recordBatch = importer.import(cArray, cSchema);
         end
     end
-end
-
-
-function array = makTypedArrayFromProxyInfo(proxyInfo)
-    traits = arrow.type.traits.traits(arrow.type.ID(proxyInfo.TypeID));
-    proxy = libmexclass.proxy.Proxy(Name=traits.ArrayProxyClassName, ID=proxyInfo.ProxyID);
-    array = traits.ArrayConstructor(proxy);
 end

--- a/matlab/src/matlab/+arrow/+tabular/RecordBatch.m
+++ b/matlab/src/matlab/+arrow/+tabular/RecordBatch.m
@@ -19,6 +19,7 @@
 classdef RecordBatch < arrow.tabular.Tabular
 
     methods
+
         function obj = RecordBatch(proxy)
             arguments
                 proxy(1, 1) libmexclass.proxy.Proxy {validate(proxy, "arrow.tabular.proxy.RecordBatch")}
@@ -39,17 +40,21 @@ classdef RecordBatch < arrow.tabular.Tabular
             );
             obj.Proxy.exportToC(args);
         end
+
     end
 
     methods (Access=protected)
+
         function column = constructColumnFromProxy(~, proxyInfo)
             traits = arrow.type.traits.traits(arrow.type.ID(proxyInfo.TypeID));
             proxy = libmexclass.proxy.Proxy(Name=traits.ArrayProxyClassName, ID=proxyInfo.ProxyID);
             column = traits.ArrayConstructor(proxy);
         end
+
     end
 
     methods (Static, Access=public)
+
         function recordBatch = fromArrays(arrowArrays, opts)
             arguments(Repeating)
                 arrowArrays(1, 1) arrow.array.Array
@@ -81,5 +86,7 @@ classdef RecordBatch < arrow.tabular.Tabular
             importer = arrow.c.internal.RecordBatchImporter();
             recordBatch = importer.import(cArray, cSchema);
         end
+
     end
+
 end

--- a/matlab/src/matlab/+arrow/+tabular/Table.m
+++ b/matlab/src/matlab/+arrow/+tabular/Table.m
@@ -15,11 +15,6 @@
 
 classdef Table < arrow.tabular.Tabular
 
-   properties(Access = protected)
-        % TODO: add comment
-        ColumnProxyToArrayFcn = @makeChunkedArrayFromProxyID
-    end
-
     methods
 
         function obj = Table(proxy)

--- a/matlab/src/matlab/+arrow/+tabular/Table.m
+++ b/matlab/src/matlab/+arrow/+tabular/Table.m
@@ -28,6 +28,7 @@ classdef Table < arrow.tabular.Tabular
     end
 
     methods (Access=protected)
+
         function column = constructColumnFromProxy(~, proxyInfo)
             proxy = libmexclass.proxy.Proxy(Name="arrow.array.proxy.ChunkedArray", ID=proxyInfo);
             column = arrow.array.ChunkedArray(proxy);

--- a/matlab/src/matlab/+arrow/+tabular/Table.m
+++ b/matlab/src/matlab/+arrow/+tabular/Table.m
@@ -28,7 +28,7 @@ classdef Table < arrow.tabular.Tabular
     end
 
     methods (Access=protected)
-        function column = constructColumnFromProxy(proxyInfo)
+        function column = constructColumnFromProxy(~, proxyInfo)
             proxy = libmexclass.proxy.Proxy(Name="arrow.array.proxy.ChunkedArray", ID=proxyInfo);
             column = arrow.array.ChunkedArray(proxy);
         end

--- a/matlab/src/matlab/+arrow/+tabular/Table.m
+++ b/matlab/src/matlab/+arrow/+tabular/Table.m
@@ -1,6 +1,3 @@
-%TABLE A tabular data structure representing a set of
-% arrow.array.ChunkedArray objects with a fixed schema.
-
 % Licensed to the Apache Software Foundation (ASF) under one or more
 % contributor license agreements.  See the NOTICE file distributed with
 % this work for additional information regarding copyright ownership.
@@ -16,17 +13,11 @@
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
 
-classdef Table < matlab.mixin.CustomDisplay & matlab.mixin.Scalar
+classdef Table < arrow.tabular.Tabular
 
-    properties (Dependent, SetAccess=private, GetAccess=public)
-        NumRows
-        NumColumns
-        ColumnNames
-        Schema
-    end
-
-    properties (Hidden, SetAccess=private, GetAccess=public)
-        Proxy
+   properties(Access = protected)
+        % TODO: add comment
+        ColumnProxyToArrayFcn = @makeChunkedArrayFromProxyID
     end
 
     methods
@@ -36,86 +27,7 @@ classdef Table < matlab.mixin.CustomDisplay & matlab.mixin.Scalar
                 proxy(1, 1) libmexclass.proxy.Proxy {validate(proxy, "arrow.tabular.proxy.Table")}
             end
             import arrow.internal.proxy.validate
-            obj.Proxy = proxy;
-        end
-
-        function numColumns = get.NumColumns(obj)
-            numColumns = obj.Proxy.getNumColumns();
-        end
-
-        function numRows = get.NumRows(obj)
-            numRows = obj.Proxy.getNumRows();
-        end
-
-        function columnNames = get.ColumnNames(obj)
-            columnNames = obj.Proxy.getColumnNames();
-        end
-
-        function schema = get.Schema(obj)
-            proxyID = obj.Proxy.getSchema();
-            proxy = libmexclass.proxy.Proxy(Name="arrow.tabular.proxy.Schema", ID=proxyID);
-            schema = arrow.tabular.Schema(proxy);
-        end
-
-        function chunkedArray = column(obj, idx)
-            import arrow.internal.validate.*
-
-            idx = index.numericOrString(idx, "int32", AllowNonScalar=false);
-
-            if isnumeric(idx)
-                args = struct(Index=idx);
-                proxyID = obj.Proxy.getColumnByIndex(args);
-            else
-                args = struct(Name=idx);
-                proxyID = obj.Proxy.getColumnByName(args);
-            end
-
-            proxy = libmexclass.proxy.Proxy(Name="arrow.array.proxy.ChunkedArray", ID=proxyID);
-            chunkedArray = arrow.array.ChunkedArray(proxy);
-        end
-
-        function T = table(obj)
-            import arrow.tabular.internal.*
-
-            numColumns = obj.NumColumns;
-            matlabArrays = cell(1, numColumns);
-
-            for ii = 1:numColumns
-                chunkedArray = obj.column(ii);
-                matlabArrays{ii} = toMATLAB(chunkedArray);
-            end
-
-            validVariableNames = makeValidVariableNames(obj.ColumnNames);
-            validDimensionNames = makeValidDimensionNames(validVariableNames);
-
-            T = table(matlabArrays{:}, ...
-                VariableNames=validVariableNames, ...
-                DimensionNames=validDimensionNames);
-        end
-
-        function T = toMATLAB(obj)
-            T = obj.table();
-        end
-
-        function tf = isequal(obj, varargin)
-            tf = arrow.tabular.internal.isequal(obj, varargin{:});
-        end
-
-    end
-
-    methods (Access = private)
-
-        function str = toString(obj)
-            str = obj.Proxy.toString();
-        end
-
-    end
-
-    methods (Access=protected)
-        function displayScalarObject(obj)
-            className = matlab.mixin.CustomDisplay.getClassNameForHeader(obj);
-            tabularDisplay = arrow.tabular.internal.display.getTabularDisplay(obj, className);
-            disp(tabularDisplay + newline);
+            obj@arrow.tabular.Tabular(proxy);
         end
 
     end
@@ -178,4 +90,9 @@ classdef Table < matlab.mixin.CustomDisplay & matlab.mixin.Scalar
 
     end
 
+end
+
+function chunkedArray = makeChunkedArrayFromProxyID(proxyID)
+    proxy = libmexclass.proxy.Proxy(Name="arrow.array.proxy.ChunkedArray", ID=proxyID);
+    chunkedArray = arrow.array.ChunkedArray(proxy);
 end

--- a/matlab/src/matlab/+arrow/+tabular/Table.m
+++ b/matlab/src/matlab/+arrow/+tabular/Table.m
@@ -32,6 +32,13 @@ classdef Table < arrow.tabular.Tabular
 
     end
 
+    methods (Access=protected)
+        function column = constructColumnFromProxy(proxyInfo)
+            proxy = libmexclass.proxy.Proxy(Name="arrow.array.proxy.ChunkedArray", ID=proxyInfo);
+            column = arrow.array.ChunkedArray(proxy);
+        end
+    end
+
     methods (Static, Access=public)
 
         function arrowTable = fromArrays(arrowArrays, opts)
@@ -90,9 +97,4 @@ classdef Table < arrow.tabular.Tabular
 
     end
 
-end
-
-function chunkedArray = makeChunkedArrayFromProxyID(proxyID)
-    proxy = libmexclass.proxy.Proxy(Name="arrow.array.proxy.ChunkedArray", ID=proxyID);
-    chunkedArray = arrow.array.ChunkedArray(proxy);
 end

--- a/matlab/src/matlab/+arrow/+tabular/Tabular.m
+++ b/matlab/src/matlab/+arrow/+tabular/Tabular.m
@@ -1,4 +1,4 @@
-%TABULAR Interface for tabular data structure.
+%TABULAR Interface that represents a tabular data structure.
 
 % Licensed to the Apache Software Foundation (ASF) under one or more
 % contributor license agreements.  See the NOTICE file distributed with

--- a/matlab/src/matlab/+arrow/+tabular/Tabular.m
+++ b/matlab/src/matlab/+arrow/+tabular/Tabular.m
@@ -1,3 +1,5 @@
+%TABULAR Interface for tabular data structure.
+
 % Licensed to the Apache Software Foundation (ASF) under one or more
 % contributor license agreements.  See the NOTICE file distributed with
 % this work for additional information regarding copyright ownership.

--- a/matlab/src/matlab/+arrow/+tabular/Tabular.m
+++ b/matlab/src/matlab/+arrow/+tabular/Tabular.m
@@ -33,7 +33,7 @@ classdef Tabular < matlab.mixin.CustomDisplay & matlab.mixin.Scalar
         % appropriate MATLAB class from the proxyInfo argument. The
         % template method arrow.tabular.Tabular/column() invokes this
         % method.
-        column = constructColumnFromProxy(proxyInfo)
+        column = constructColumnFromProxy(obj, proxyInfo)
     end
 
     methods

--- a/matlab/src/matlab/+arrow/+tabular/Tabular.m
+++ b/matlab/src/matlab/+arrow/+tabular/Tabular.m
@@ -27,12 +27,15 @@ classdef Tabular < matlab.mixin.CustomDisplay & matlab.mixin.Scalar
     properties (Hidden, SetAccess=private, GetAccess=public)
         Proxy
     end
-
-    properties(Access = protected, Abstract)
-        % TODO: add comment
-        ColumnProxyToArrayFcn
-    end
     
+    methods(Access=protected, Abstract)
+        % constructColumnFromProxy must construct an instance of the
+        % appropriate MATLAB class from the proxyInfo argument. The
+        % template method arrow.tabular.Tabular/column() invokes this
+        % method.
+        column = constructColumnFromProxy(proxyInfo)
+    end
+
     methods
         function obj = Tabular(proxy)
             arguments
@@ -73,7 +76,7 @@ classdef Tabular < matlab.mixin.CustomDisplay & matlab.mixin.Scalar
                 proxyInfo = obj.Proxy.getColumnByName(args);
             end
 
-            array = obj.ColumnProxyToArrayFcn(proxyInfo);
+            array = obj.constructColumnFromProxy(proxyInfo);
         end
 
         function T = table(obj)

--- a/matlab/src/matlab/+arrow/+tabular/Tabular.m
+++ b/matlab/src/matlab/+arrow/+tabular/Tabular.m
@@ -37,6 +37,7 @@ classdef Tabular < matlab.mixin.CustomDisplay & matlab.mixin.Scalar
     end
 
     methods
+
         function obj = Tabular(proxy)
             arguments
                 proxy(1, 1) libmexclass.proxy.Proxy
@@ -108,6 +109,7 @@ classdef Tabular < matlab.mixin.CustomDisplay & matlab.mixin.Scalar
     end
 
     methods (Access = private)
+
         function str = toString(obj)
             str = obj.Proxy.toString();
         end
@@ -115,6 +117,7 @@ classdef Tabular < matlab.mixin.CustomDisplay & matlab.mixin.Scalar
     end
 
     methods (Access=protected)
+
         function displayScalarObject(obj)
             className = matlab.mixin.CustomDisplay.getClassNameForHeader(obj);
             tabularDisplay = arrow.tabular.internal.display.getTabularDisplay(obj, className);
@@ -122,4 +125,5 @@ classdef Tabular < matlab.mixin.CustomDisplay & matlab.mixin.Scalar
         end
 
     end
+
 end

--- a/matlab/src/matlab/+arrow/+tabular/Tabular.m
+++ b/matlab/src/matlab/+arrow/+tabular/Tabular.m
@@ -1,0 +1,120 @@
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
+classdef Tabular < matlab.mixin.CustomDisplay & matlab.mixin.Scalar
+
+    properties (Dependent, SetAccess=private, GetAccess=public)
+        NumRows
+        NumColumns
+        ColumnNames
+        Schema
+    end
+
+    properties (Hidden, SetAccess=private, GetAccess=public)
+        Proxy
+    end
+
+    properties(Access = protected, Abstract)
+        % TODO: add comment
+        ColumnProxyToArrayFcn
+    end
+    
+    methods
+        function obj = Tabular(proxy)
+            arguments
+                proxy(1, 1) libmexclass.proxy.Proxy
+            end
+            import arrow.internal.proxy.validate
+            obj.Proxy = proxy;
+        end
+
+        function numColumns = get.NumColumns(obj)
+            numColumns = obj.Proxy.getNumColumns();
+        end
+
+        function numRows = get.NumRows(obj)
+            numRows = obj.Proxy.getNumRows();
+        end
+
+        function columnNames = get.ColumnNames(obj)
+            columnNames = obj.Proxy.getColumnNames();
+        end
+
+        function schema = get.Schema(obj)
+            proxyID = obj.Proxy.getSchema();
+            proxy = libmexclass.proxy.Proxy(Name="arrow.tabular.proxy.Schema", ID=proxyID);
+            schema = arrow.tabular.Schema(proxy);
+        end
+
+        function array = column(obj, idx)
+            import arrow.internal.validate.*
+
+            idx = index.numericOrString(idx, "int32", AllowNonScalar=false);
+
+            if isnumeric(idx)
+                args = struct(Index=idx);
+                proxyInfo = obj.Proxy.getColumnByIndex(args);
+            else
+                args = struct(Name=idx);
+                proxyInfo = obj.Proxy.getColumnByName(args);
+            end
+
+            array = obj.ColumnProxyToArrayFcn(proxyInfo);
+        end
+
+        function T = table(obj)
+            import arrow.tabular.internal.*
+
+            numColumns = obj.NumColumns;
+            matlabArrays = cell(1, numColumns);
+
+            for ii = 1:numColumns
+                matlabArrays{ii} = toMATLAB(obj.column(ii));
+            end
+
+            validVariableNames = makeValidVariableNames(obj.ColumnNames);
+            validDimensionNames = makeValidDimensionNames(validVariableNames);
+
+            T = table(matlabArrays{:}, ...
+                VariableNames=validVariableNames, ...
+                DimensionNames=validDimensionNames);
+        end
+
+        function T = toMATLAB(obj)
+            T = obj.table();
+        end
+
+        function tf = isequal(obj, varargin)
+            tf = arrow.tabular.internal.isequal(obj, varargin{:});
+        end
+
+    end
+
+    methods (Access = private)
+        function str = toString(obj)
+            str = obj.Proxy.toString();
+        end
+
+    end
+
+    methods (Access=protected)
+        function displayScalarObject(obj)
+            className = matlab.mixin.CustomDisplay.getClassNameForHeader(obj);
+            tabularDisplay = arrow.tabular.internal.display.getTabularDisplay(obj, className);
+            disp(tabularDisplay + newline);
+        end
+
+    end
+end


### PR DESCRIPTION
### Rationale for this change

Currently, the properties and methods of `arrow.tabular.RecordBatch` and `arrow.tabular.Table` are very similar. To simplify implementation of these classes, reduce code duplication, and ensure design consistency, it might be helpful to factor out the common tabular functionality into an `arrow.tabular.Tabular` interface that both classes implement.

### What changes are included in this PR?

1. Defined a `arrow.tabular.Tabular` interface that contains the tabular functionality shared by `arrow.tabular.Table` and `arrow.tabular.RecordBatch`.
2. Updated `arrow.tabular.Table` and `arrow.tabular.RecordBatch` to implement the `arrow.tabular.Tabular` interface.

### Are these changes tested?

Yes. These changes are covered by existing cases defined in `tTable.m` and `tRecordBatch`.

### Are there any user-facing changes?

No.


* GitHub Issue: #38214