### PR TITLE
GH-35644: [MATLAB] Add tests verifying `arrow.array.<Type>Array.fromMATLAB()` throws an exception if given an array with the wrong type. 

### DIFF
--- a/matlab/test/arrow/array/hNumericArray.m
+++ b/matlab/test/arrow/array/hNumericArray.m
@@ -102,6 +102,14 @@ classdef hNumericArray < matlab.unittest.TestCase
             tc.verifyError(fcn, "arrow:array:InvalidShape");
         end
 
+        function ErrorIfInvalidType(tc)
+            data = 1:3;
+            if tc.ArrowType.ID == arrow.type.ID.Float64
+                data = single(data);
+            end
+            tc.verifyError(@() tc.ArrowArrayConstructorFcn(data), "arrow:array:InvalidType");
+        end
+
         function AllowNDimensionalEmptyArray(tc)
             data = tc.MatlabArrayFcn(reshape([], [1 0 0]));
             A = tc.ArrowArrayConstructorFcn(data);

--- a/matlab/test/arrow/array/tBooleanArray.m
+++ b/matlab/test/arrow/array/tBooleanArray.m
@@ -139,6 +139,11 @@ classdef tBooleanArray < matlab.unittest.TestCase
             tc.verifyError(fcn, "arrow:array:InvalidShape");
         end
 
+        function ErrorIfNotLogical(tc)
+            data = [1 0 1];
+            tc.verifyError(@() tc.ArrowArrayConstructorFcn(data), "arrow:array:InvalidType");
+        end
+
         function AllowNDimensionalEmptyArray(tc)
             data = tc.MatlabArrayFcn(reshape([], [1 0 0]));
             A = tc.ArrowArrayConstructorFcn(data);

--- a/matlab/test/arrow/array/tTimestampArray.m
+++ b/matlab/test/arrow/array/tTimestampArray.m
@@ -164,6 +164,12 @@ classdef tTimestampArray < matlab.unittest.TestCase
             testCase.verifyError(fcn, "arrow:array:InvalidShape");
         end
 
+        function ErrorIfNotDatetime(testCase)
+            data = seconds(1:4);
+            fcn = @() testCase.ArrowArrayConstructorFcn(data);
+            testCase.verifyError(fcn, "arrow:array:InvalidType");
+        end
+
         function EmptyDatetimeVector(testCase)
             import arrow.array.TimestampArray
 


### PR DESCRIPTION
### Rationale for this change

This PR closes a test coverage gap for `arrow.array.<Type>Array.fromMATLAB(data)`. 

### What changes are included in this PR?

1. Added `hNumericArray/ErrorIfInvalidType`, which verifies `arrow.array.<Type>Array.fromMATLAB(data)` throws an exception if `data` has an unexpected type.
2. Added tBooleanArray/ErrorIfNotLogical`, which verifies `arrow.array.BooleanArray.fromMATLAB(data)` throws an exception if `data` is not a `logical` array.
3.  Added tTimestampArray/ErrorIfNotLogical`, which verifies `arrow.array.TimestampArray.fromMATLAB(data)` throws an exception if `data` is not a `datetime` array.

### Are these changes tested?

This is a test-only PR. 

### Are there any user-facing changes?

No.

* GitHub Issue: #35644