### PR TITLE
GH-47025: [C++][Docs] Increase minimum gcc for building from 7.1 to 9

### DIFF
--- a/docs/source/developers/cpp/building.rst
+++ b/docs/source/developers/cpp/building.rst
@@ -39,7 +39,7 @@ out-of-source. If you are not familiar with this terminology:
 
 Building requires:
 
-* A C++17-enabled compiler. On Linux, gcc 7.1 and higher should be
+* A C++17-enabled compiler. On Linux, gcc 9 and higher should be
   sufficient. For Windows, at least Visual Studio VS2017 is required.
 * CMake 3.25 or higher
 * On Linux and macOS, either ``make`` or ``ninja`` build utilities


### PR DESCRIPTION
### Rationale for this change

See https://github.com/apache/arrow/issues/47025.

### What changes are included in this PR?

- Updated developer docs on building Arrow C++

### Are these changes tested?

No.

### Are there any user-facing changes?

Yes. Users should be advised about the change.
* GitHub Issue: #47025