### PR TITLE
GH-47015: [CI][C++] Use mold on conda-cpp to work around issues with GNU ld

### DIFF
--- a/ci/docker/conda-cpp.dockerfile
+++ b/ci/docker/conda-cpp.dockerfile
@@ -27,6 +27,7 @@ RUN /arrow/ci/scripts/install_minio.sh latest /opt/conda
 ARG python=3.10
 
 # install the required conda packages into the test environment
+# use `mold` to work around issues with GNU `ld` (GH-47015).
 COPY ci/conda_env_cpp.txt \
      ci/conda_env_gandiva.txt \
      /arrow/ci/
@@ -36,6 +37,7 @@ RUN mamba install -q -y \
         compilers \
         doxygen \
         libnuma \
+        mold \
         python=${python} \
         valgrind && \
     mamba clean --all --yes
@@ -73,6 +75,7 @@ ENV ARROW_ACERO=ON \
     ARROW_S3_MODULE=ON \
     ARROW_SUBSTRAIT=ON \
     ARROW_USE_CCACHE=ON \
+    ARROW_USE_MOLD=ON \
     ARROW_WITH_BROTLI=ON \
     ARROW_WITH_BZ2=ON \
     ARROW_WITH_LZ4=ON \


### PR DESCRIPTION
### Rationale for this change

A particular combination of `gcc`, GNU `ld` and specific compiler flags leads to crashes when calling `std::call_once` in some compilation units:
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=60662

The problem disappears when using another linker such `ld.gold` (which has been removed from GNU binutils) and `mold`.

### What changes are included in this PR?

Use `mold` on conda-based C++ builds.

### Are these changes tested?

By existing CI jobs.

### Are there any user-facing changes?

No.

* GitHub Issue: #47015