### PR TITLE
GH-47029: [Archery] Fix generation of RunEndsField

### DIFF
--- a/dev/archery/archery/integration/datagen.py
+++ b/dev/archery/archery/integration/datagen.py
@@ -215,7 +215,7 @@ class RunEndsField(IntegerField):
             values = [size]
             runs_count = 1
         else:
-            runs_count = rng.integers(1, size)
+            runs_count = int(size / 2)
             values = rng.choice(range(1, size), size=runs_count - 1, replace=False)
             values = sorted(values)
             values.append(size)
@@ -1164,7 +1164,7 @@ class RunEndEncodedField(Field):
         ]
 
     def generate_column(self, size, name=None):
-        values = self.values_field.generate_column(size)
+        values = self.values_field.generate_column(int(size/2))
         run_ends = self.run_ends_field.generate_column(size)
         if name is None:
             name = self.name

--- a/dev/archery/archery/integration/datagen.py
+++ b/dev/archery/archery/integration/datagen.py
@@ -208,10 +208,12 @@ class RunEndsField(IntegerField):
                 f"Size {size} exceeds the maximum for bit width {self.bit_width}."
             )
         rng = np.random.default_rng()
-        runs_count = rng.integers(1, size + 1)
-        if runs_count == 1:
+        if size == 0:
+            values = []
+        elif size == 1:
             values = [size]
         else:
+            runs_count = rng.integers(1, size)
             values = rng.choice(range(1, size), size=runs_count - 1, replace=False)
             values = sorted(values)
             values.append(size)

--- a/dev/archery/archery/integration/datagen.py
+++ b/dev/archery/archery/integration/datagen.py
@@ -227,7 +227,7 @@ class RunEndsField(IntegerField):
 
         if name is None:
             name = self.name
-        return PrimitiveColumn(name, runs_count, is_valid, values)
+        return PrimitiveColumn(name, int(runs_count), is_valid, values)
 
 
 class DateField(IntegerField):

--- a/dev/archery/archery/integration/datagen.py
+++ b/dev/archery/archery/integration/datagen.py
@@ -210,8 +210,10 @@ class RunEndsField(IntegerField):
         rng = np.random.default_rng()
         if size == 0:
             values = []
+            runs_count = 0
         elif size == 1:
             values = [size]
+            runs_count = 1
         else:
             runs_count = rng.integers(1, size)
             values = rng.choice(range(1, size), size=runs_count - 1, replace=False)

--- a/dev/archery/archery/integration/datagen.py
+++ b/dev/archery/archery/integration/datagen.py
@@ -219,7 +219,7 @@ class RunEndsField(IntegerField):
             values = rng.choice(range(1, size), size=runs_count - 1, replace=False)
             values = sorted(values)
             values.append(size)
-        
+
         values = list(map(int if self.bit_width < 64 else str, values))
         # RunEnds cannot be null, as such self.nullable == False and this
         # will generate a validity map of all ones.


### PR DESCRIPTION
### Rationale for this change
Fix incorrect array generation in Archery

### What changes are included in this PR?
Fix an issue issue in Archery Integration which generate wrong number of values for run-end encoded.

### Are these changes tested?
In the CI

### Are there any user-facing changes?
The JSONs generated by Archery integration

* GitHub Issue: #47029