### PR TITLE
GH-47037: [CI][C++] Fix Fedora 39 CI jobs

### DIFF
--- a/ci/docker/fedora-39-cpp.dockerfile
+++ b/ci/docker/fedora-39-cpp.dockerfile
@@ -64,7 +64,6 @@ RUN dnf update -y && \
         utf8proc-devel \
         wget \
         which \
-        xsimd-devel \
         zlib-devel
 
 COPY ci/scripts/install_minio.sh /arrow/ci/scripts/
@@ -108,4 +107,5 @@ ENV ARROW_ACERO=ON \
     PARQUET_BUILD_EXAMPLES=ON \
     PARQUET_BUILD_EXECUTABLES=ON \
     PATH=/usr/lib/ccache/:$PATH \
-    PYARROW_TEST_GANDIVA=OFF
+    PYARROW_TEST_GANDIVA=OFF \
+    xsimd_SOURCE=BUNDLED


### PR DESCRIPTION
### Rationale for this change

The system package for xsimd is too old on Fedora 39, use bundled version instead.

### Are these changes tested?

By existing CI jobs.

### Are there any user-facing changes?

No.
* GitHub Issue: #47037