### PR TITLE
GH-47039: [C++] Bump RapidJSON dependency in Meson configuration

### DIFF
--- a/cpp/src/arrow/meson.build
+++ b/cpp/src/arrow/meson.build
@@ -293,7 +293,8 @@ if needs_csv
 endif
 
 if needs_json or needs_integration
-    rapidjson_dep = dependency('rapidjson', include_type: 'system')
+    rapidjson_proj = subproject('rapidjson')
+    rapidjson_dep = rapidjson_proj.get_variable('rapidjson_dep')
 else
     rapidjson_dep = disabler()
 endif

--- a/cpp/src/arrow/meson.build
+++ b/cpp/src/arrow/meson.build
@@ -293,8 +293,11 @@ if needs_csv
 endif
 
 if needs_json or needs_integration
-    rapidjson_proj = subproject('rapidjson')
-    rapidjson_dep = rapidjson_proj.get_variable('rapidjson_dep')
+    rapidjson_dep = dependency(
+        'rapidjson',
+        method: 'system',
+        fallback: ['rapidjson', 'rapidjson_dep'],
+    )
 else
     rapidjson_dep = disabler()
 endif

--- a/cpp/src/arrow/meson.build
+++ b/cpp/src/arrow/meson.build
@@ -294,8 +294,7 @@ endif
 
 if needs_json or needs_integration
     rapidjson_dep = dependency(
-        'rapidjson',
-        method: 'system',
+        'RapidJSON',
         fallback: ['rapidjson', 'rapidjson_dep'],
     )
 else

--- a/cpp/subprojects/packagefiles/rapidjson/meson.build
+++ b/cpp/subprojects/packagefiles/rapidjson/meson.build
@@ -15,13 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-[wrap-file]
-directory = rapidjson-232389d4f1012dddec4ef84861face2d2ba85709
-source_url = https://github.com/miloyip/rapidjson/archive/232389d4f1012dddec4ef84861face2d2ba85709.tar.gz
-source_filename = rapidjson-232389d4f1012dddec4ef84861face2d2ba85709.tar.gz
-source_hash = b9290a9a6d444c8e049bd589ab804e0ccf2b05dc5984a19ed5ae75d090064806
-source_fallback_url = https://apache.jfrog.io/artifactory/arrow/thirdparty/7.0.0/rapidjson-232389d4f1012dddec4ef84861face2d2ba85709.tar.gz
-patch_directory = rapidjson
+project('rapidjson', 'cpp')
 
-[provide]
-rapidjson = rapidjson_dep
+rapidjson_dep = declare_dependency(include_directories: 'include')

--- a/cpp/subprojects/rapidjson.wrap
+++ b/cpp/subprojects/rapidjson.wrap
@@ -17,7 +17,7 @@
 
 [wrap-file]
 directory = rapidjson-232389d4f1012dddec4ef84861face2d2ba85709
-source_url = https://github.com/miloyip/rapidjson/archive/232389d4f1012dddec4ef84861face2d2ba85709.tar.gz
+source_url = https://github.com/Tencent/rapidjson/archive/232389d4f1012dddec4ef84861face2d2ba85709.tar.gz
 source_filename = rapidjson-232389d4f1012dddec4ef84861face2d2ba85709.tar.gz
 source_hash = b9290a9a6d444c8e049bd589ab804e0ccf2b05dc5984a19ed5ae75d090064806
 source_fallback_url = https://apache.jfrog.io/artifactory/arrow/thirdparty/7.0.0/rapidjson-232389d4f1012dddec4ef84861face2d2ba85709.tar.gz


### PR DESCRIPTION
### Rationale for this change

The Meson configuration is unusable on gcc 14.2 given issues with the RapidJSON release of 1.1.0 (released in 2016)

### What changes are included in this PR?

Bumps the RapidJSON version to a commit hash that matches what is used in CMake by default

### Are these changes tested?

Yes

### Are there any user-facing changes?

No
* GitHub Issue: #47039