### PR TITLE
GH-47045: [CI][C++] Use Fedora 42 instead of 39

### DIFF
--- a/.env
+++ b/.env
@@ -49,7 +49,7 @@ ULIMIT_CORE=-1
 ALMALINUX=8
 ALPINE_LINUX=3.18
 DEBIAN=12
-FEDORA=39
+FEDORA=42
 UBUNTU=22.04
 
 # Default versions for various dependencies

--- a/ci/docker/fedora-42-cpp.dockerfile
+++ b/ci/docker/fedora-42-cpp.dockerfile
@@ -16,7 +16,7 @@
 # under the License.
 
 ARG arch
-FROM ${arch}/fedora:39
+FROM ${arch}/fedora:42
 ARG arch
 
 # install dependencies
@@ -64,6 +64,7 @@ RUN dnf update -y && \
         utf8proc-devel \
         wget \
         which \
+        xsimd-devel \
         zlib-devel
 
 COPY ci/scripts/install_minio.sh /arrow/ci/scripts/
@@ -107,5 +108,4 @@ ENV ARROW_ACERO=ON \
     PARQUET_BUILD_EXAMPLES=ON \
     PARQUET_BUILD_EXECUTABLES=ON \
     PATH=/usr/lib/ccache/:$PATH \
-    PYARROW_TEST_GANDIVA=OFF \
-    xsimd_SOURCE=BUNDLED
+    PYARROW_TEST_GANDIVA=OFF

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -766,12 +766,12 @@ tasks:
       flags: "-e CMAKE_CXX_STANDARD=20"
       image: debian-cpp
 
-  test-fedora-39-cpp:
+  test-fedora-42-cpp:
     ci: github
     template: docker-tests/github.linux.yml
     params:
       env:
-        FEDORA: 39
+        FEDORA: 42
       image: fedora-cpp
 
 {% for cpp_standard in [20] %}
@@ -906,12 +906,12 @@ tasks:
         UBUNTU: 24.04
       image: ubuntu-python
 
-  test-fedora-39-python-3:
+  test-fedora-42-python-3:
     ci: github
     template: docker-tests/github.linux.yml
     params:
       env:
-        FEDORA: 39
+        FEDORA: 42
       image: fedora-python
 
   test-r-linux-valgrind:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -722,7 +722,7 @@ services:
     #   docker compose run --rm fedora-cpp
     # Parameters:
     #   ARCH: amd64, arm64v8, ...
-    #   FEDORA: 39
+    #   FEDORA: 42
     image: ${REPO}:${ARCH}-fedora-${FEDORA}-cpp
     build:
       context: .
@@ -1042,7 +1042,7 @@ services:
     #   docker compose run --rm fedora-python
     # Parameters:
     #   ARCH: amd64, arm64v8, ...
-    #   FEDORA: 39
+    #   FEDORA: 42
     image: ${REPO}:${ARCH}-fedora-${FEDORA}-python-3
     build:
       context: .

--- a/python/examples/minimal_build/Dockerfile.fedora
+++ b/python/examples/minimal_build/Dockerfile.fedora
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM fedora:39
+FROM fedora:42
 
 RUN dnf update -y && \
     dnf install -y \


### PR DESCRIPTION
### Rationale for this change

Fedora 39 reached EOL on 2024-11-26: https://docs.fedoraproject.org/en-US/releases/eol/

### What changes are included in this PR?

Use Fedora 42 that is the latest release.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #47045