### PR TITLE
GH-47047: [CI][C++] Use Google Cloud Storage Testbench v0.55.0

### DIFF
--- a/ci/scripts/install_gcs_testbench.bat
+++ b/ci/scripts/install_gcs_testbench.bat
@@ -17,7 +17,7 @@
 
 @echo on
 
-set GCS_TESTBENCH_VERSION="v0.40.0"
+set GCS_TESTBENCH_VERSION="v0.55.0"
 
 set PIPX_FLAGS=--verbose
 if NOT "%PIPX_PYTHON%"=="" (

--- a/ci/scripts/install_gcs_testbench.sh
+++ b/ci/scripts/install_gcs_testbench.sh
@@ -36,7 +36,7 @@ esac
 
 version=$1
 if [[ "${version}" = "default" ]]; then
-  version="v0.39.0"
+  version="v0.55.0"
 fi
 
 # The Python to install pipx with


### PR DESCRIPTION
### Rationale for this change

v0.55.0 is the latest version. v0.39.0 depends on old grpcio (1.59.0) that doesn't provide wheels for Python 3.13.

### What changes are included in this PR?

Update the default Google Cloud Storage Testbench version.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #47047