### PR TITLE
GH-47033: [C++][Compute] Never use custom gtest main with MSVC

### DIFF
--- a/cpp/src/arrow/compute/CMakeLists.txt
+++ b/cpp/src/arrow/compute/CMakeLists.txt
@@ -48,7 +48,7 @@ if(ARROW_TESTING AND ARROW_COMPUTE)
   add_library(arrow_compute_testing OBJECT ${ARROW_COMPUTE_TESTING_SRCS})
   # Even though this is still just an object library we still need to "link"
   # arrow_compute_core_testing so that is also included correctly
-  if(MSVC AND MSVC_VERSION LESS 1930)
+  if(MSVC)
     target_link_libraries(arrow_compute_testing
                           PUBLIC $<TARGET_OBJECTS:arrow_compute_core_testing>
                           PUBLIC ${ARROW_GTEST_GTEST_MAIN})

--- a/cpp/src/arrow/compute/test_env.cc
+++ b/cpp/src/arrow/compute/test_env.cc
@@ -35,7 +35,7 @@ class ComputeKernelEnvironment : public ::testing::Environment {
 
 }  // namespace
 
-#if defined(_MSC_VER) && _MSC_VER < 1930
+#ifdef _MSC_VER
 // Initialize the compute module
 ::testing::Environment* compute_kernels_env =
     ::testing::AddGlobalTestEnvironment(new ComputeKernelEnvironment);
@@ -43,7 +43,7 @@ class ComputeKernelEnvironment : public ::testing::Environment {
 
 }  // namespace arrow::compute
 
-#if !(defined(_MSC_VER) && _MSC_VER < 1930)
+#ifndef _MSC_VER
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   ::testing::AddGlobalTestEnvironment(new arrow::compute::ComputeKernelEnvironment);


### PR DESCRIPTION
### Rationale for this change

If we use custom gtest main with MSVC, it always reports "SEH exception".

### What changes are included in this PR?

Remove MSVC version check.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.

* GitHub Issue: #47033