### PR TITLE
GH-38532: [MATLAB] Add a `validate` method to all `arrow.array.Array` classes

### DIFF
--- a/matlab/src/cpp/arrow/matlab/array/proxy/array.h
+++ b/matlab/src/cpp/arrow/matlab/array/proxy/array.h
@@ -47,6 +47,8 @@ class Array : public libmexclass::proxy::Proxy {
 
   void exportToC(libmexclass::proxy::method::Context& context);
 
+  void validate(libmexclass::proxy::method::Context& context);
+
   std::shared_ptr<arrow::Array> array;
 };
 

--- a/matlab/src/cpp/arrow/matlab/array/proxy/list_array.h
+++ b/matlab/src/cpp/arrow/matlab/array/proxy/list_array.h
@@ -32,7 +32,6 @@ class ListArray : public arrow::matlab::array::proxy::Array {
  protected:
   void getValues(libmexclass::proxy::method::Context& context);
   void getOffsets(libmexclass::proxy::method::Context& context);
-  void validate(libmexclass::proxy::method::Context& context);
 };
 
 }  // namespace arrow::matlab::array::proxy

--- a/matlab/src/matlab/+arrow/+array/Array.m
+++ b/matlab/src/matlab/+arrow/+array/Array.m
@@ -53,6 +53,20 @@ classdef (Abstract) Array < matlab.mixin.CustomDisplay & ...
             proxy = libmexclass.proxy.Proxy(Name=traits.TypeProxyClassName, ID=typeStruct.ProxyID);
             type = traits.TypeConstructor(proxy);
         end
+
+        function validate(obj, opts)
+             arguments
+                obj
+                opts.ValidationMode(1, 1) arrow.array.ValidationMode = arrow.array.ValidationMode.Minimal
+             end
+
+             if opts.ValidationMode == arrow.array.ValidationMode.None
+                 id = "arrow:array:InvalidValidationMode";
+                 msg = "Invalid ValidationMode. ValidationMode must be ""Minimum"" or ""Full"".";
+                 error(id, msg);
+             end
+             obj.Proxy.validate(struct(ValidationMode=uint8(opts.ValidationMode)));
+        end
     end
 
     methods (Access = private)

--- a/matlab/src/matlab/+arrow/+array/Array.m
+++ b/matlab/src/matlab/+arrow/+array/Array.m
@@ -57,15 +57,15 @@ classdef (Abstract) Array < matlab.mixin.CustomDisplay & ...
         function validate(obj, opts)
              arguments
                 obj
-                opts.ValidationMode(1, 1) arrow.array.ValidationMode = arrow.array.ValidationMode.Minimal
+                opts.Mode(1, 1) arrow.array.ValidationMode = arrow.array.ValidationMode.Minimal
              end
 
-             if opts.ValidationMode == arrow.array.ValidationMode.None
+             if opts.Mode == arrow.array.ValidationMode.None
                  id = "arrow:array:InvalidValidationMode";
-                 msg = "Invalid ValidationMode. ValidationMode must be ""Minimum"" or ""Full"".";
+                 msg = "Invalid Mode. Mode must be ""Minimal"" or ""Full"".";
                  error(id, msg);
              end
-             obj.Proxy.validate(struct(ValidationMode=uint8(opts.ValidationMode)));
+             obj.Proxy.validate(struct(ValidationMode=uint8(opts.Mode)));
         end
     end
 

--- a/matlab/test/arrow/array/tValidateArray.m
+++ b/matlab/test/arrow/array/tValidateArray.m
@@ -80,7 +80,7 @@ classdef tValidateArray < matlab.unittest.TestCase
         function ValidationModeFullPasses(test)
             % Verify arrow.array.Array/validate() does not throw an
             % exception if ValidationMode="Full" and the array passes
-            % the "full" validtion checks.
+            % the "full" validation checks.
             offsets = arrow.array(int32([0 1 3]));
             values = arrow.array([1 2 3]);
             array = arrow.array.ListArray.fromArrays(offsets, values, ValidationMode="None");

--- a/matlab/test/arrow/array/tValidateArray.m
+++ b/matlab/test/arrow/array/tValidateArray.m
@@ -95,7 +95,6 @@ classdef tValidateArray < matlab.unittest.TestCase
             array = arrow.array.ListArray.fromArrays(offsets, values, ValidationMode="None");
             fcn = @() array.validate();
             test.verifyWarningFree(fcn, "arrow:array:ValidateMinimalFailed")
-
         end
     end
 

--- a/matlab/test/arrow/array/tValidateArray.m
+++ b/matlab/test/arrow/array/tValidateArray.m
@@ -54,7 +54,7 @@ classdef tValidateArray < matlab.unittest.TestCase
 
         function ValidationModeMinimalPasses(test)
             % Verify arrow.array.Array/validate() does not throw an
-            % exception if ValidationMode="Minimal" the array passes the
+            % exception if ValidationMode="Minimal" and the array passes the
             % "Miminal" validtion checks.
             offsets = arrow.array(int32([0 1 0]));
             values = arrow.array([1 2 3]);

--- a/matlab/test/arrow/array/tValidateArray.m
+++ b/matlab/test/arrow/array/tValidateArray.m
@@ -25,7 +25,7 @@ classdef tValidateArray < matlab.unittest.TestCase
             % pair.
             array = arrow.array.Float64Array.fromMATLAB(1:5);
 
-            % Cannot convert "abc" to a ValidtionMode value
+            % Cannot convert "abc" to a ValidationMode value
             fcn = @() array.validate(ValidationMode="abc");
             test.verifyError(fcn, "MATLAB:validation:UnableToConvert");
 

--- a/matlab/test/arrow/array/tValidateArray.m
+++ b/matlab/test/arrow/array/tValidateArray.m
@@ -1,0 +1,102 @@
+%TVALIDATEARRAY Test class for the arrow.array.Array/validate() method.
+
+% Licensed to the Apache Software Foundation (ASF) under one or more
+% contributor license agreements.  See the NOTICE file distributed with
+% this work for additional information regarding copyright ownership.
+% The ASF licenses this file to you under the Apache License, Version
+% 2.0 (the "License"); you may not use this file except in compliance
+% with the License.  You may obtain a copy of the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS,
+% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+% implied.  See the License for the specific language governing
+% permissions and limitations under the License.
+
+classdef tValidateArray < matlab.unittest.TestCase
+
+    methods (Test)
+
+        function InvalidValidationModeInput(test)
+            % Verify arrow.array.Array/validate() throws an exception if
+            % provided an invalid value for the ValidationMode name-value 
+            % pair.
+            array = arrow.array.Float64Array.fromMATLAB(1:5);
+
+            % Cannot convert "abc" to a ValidtionMode value
+            fcn = @() array.validate(ValidationMode="abc");
+            test.verifyError(fcn, "MATLAB:validation:UnableToConvert");
+
+            % ValidtionMode must be scalar
+            modes = [arrow.array.ValidationMode.Full arrow.array.ValidationMode.Minimal];
+            fcn = @() array.validate(ValidationMode=modes);
+            test.verifyError(fcn, "MATLAB:validation:IncompatibleSize");
+
+            % ValidationMode.None is not supported
+            mode = arrow.array.ValidationMode.None;
+            fcn = @() array.validate(ValidationMode=mode);
+            test.verifyError(fcn, "arrow:array:InvalidValidationMode");
+        end
+
+        function ValidationModeMinimalFails(test)
+            % Verify arrow.array.Array/validate() throws an exception 
+            % with the ID is arrow:array:ValidateMinimalFailed if
+            % ValidationMode="Minimal" and the array fails the "Minimal"
+            % validation checks.
+            offsets = arrow.array(int32([0 1 3 4 5]));
+            values = arrow.array([1 2 3]);
+            array = arrow.array.ListArray.fromArrays(offsets, values, ValidationMode="None");
+            fcn = @() array.validate(ValidationMode="Minimal");
+            test.verifyError(fcn, "arrow:array:ValidateMinimalFailed")
+        end
+
+        function ValidationModeMinimalPasses(test)
+            % Verify arrow.array.Array/validate() does not throw an
+            % exception if ValidationMode="Minimal" the array passes the
+            % "Miminal" validtion checks.
+            offsets = arrow.array(int32([0 1 0]));
+            values = arrow.array([1 2 3]);
+            % NOTE: the array is actually invalid, but it passes the
+            % "Minimal" validation checks.
+            array = arrow.array.ListArray.fromArrays(offsets, values, ValidationMode="None");
+            fcn = @() array.validate(ValidationMode="Minimal");
+            test.verifyWarningFree(fcn, "arrow:array:ValidateMinimalFailed")
+        end
+
+        function ValidationModeFullFails(test)
+            % Verify arrow.array.Array/validate() throws an exception 
+            % with the ID is arrow:array:ValidateFullFailed if
+            % ValidationMode="Full" and the array fails the "Full"
+            % validation checks.
+            offsets = arrow.array(int32([0 1 0]));
+            values = arrow.array([1 2 3]);
+            array = arrow.array.ListArray.fromArrays(offsets, values, ValidationMode="None");
+            fcn = @() array.validate(ValidationMode="Full");
+            test.verifyError(fcn, "arrow:array:ValidateFullFailed")
+        end
+
+        function ValidationModeFullPasses(test)
+            % Verify arrow.array.Array/validate() does not throw an
+            % exception if ValidationMode="Full" and the array passes
+            % the "full" validtion checks.
+            offsets = arrow.array(int32([0 1 3]));
+            values = arrow.array([1 2 3]);
+            array = arrow.array.ListArray.fromArrays(offsets, values, ValidationMode="None");
+            fcn = @() array.validate(ValidationMode="Full");
+            test.verifyWarningFree(fcn);
+        end
+
+        function DefaultValidationModeIsMimimal(test)
+            % Verify the default ValidationMode value is "Minimal".
+            offsets = arrow.array(int32([0 1 2 3]));
+            values = arrow.array([1 2 3]);
+            array = arrow.array.ListArray.fromArrays(offsets, values, ValidationMode="None");
+            fcn = @() array.validate();
+            test.verifyWarningFree(fcn, "arrow:array:ValidateMinimalFailed")
+
+        end
+    end
+
+end

--- a/matlab/test/arrow/array/tValidateArray.m
+++ b/matlab/test/arrow/array/tValidateArray.m
@@ -29,7 +29,7 @@ classdef tValidateArray < matlab.unittest.TestCase
             fcn = @() array.validate(ValidationMode="abc");
             test.verifyError(fcn, "MATLAB:validation:UnableToConvert");
 
-            % ValidtionMode must be scalar
+            % ValidationMode must be scalar
             modes = [arrow.array.ValidationMode.Full arrow.array.ValidationMode.Minimal];
             fcn = @() array.validate(ValidationMode=modes);
             test.verifyError(fcn, "MATLAB:validation:IncompatibleSize");

--- a/matlab/test/arrow/array/tValidateArray.m
+++ b/matlab/test/arrow/array/tValidateArray.m
@@ -42,7 +42,7 @@ classdef tValidateArray < matlab.unittest.TestCase
 
         function ValidationModeMinimalFails(test)
             % Verify arrow.array.Array/validate() throws an exception 
-            % with the ID is arrow:array:ValidateMinimalFailed if
+            % with the ID arrow:array:ValidateMinimalFailed if
             % ValidationMode="Minimal" and the array fails the "Minimal"
             % validation checks.
             offsets = arrow.array(int32([0 1 3 4 5]));

--- a/matlab/test/arrow/array/tValidateArray.m
+++ b/matlab/test/arrow/array/tValidateArray.m
@@ -19,80 +19,80 @@ classdef tValidateArray < matlab.unittest.TestCase
 
     methods (Test)
 
-        function InvalidValidationModeInput(test)
+        function InvalidModeInput(test)
             % Verify arrow.array.Array/validate() throws an exception if
-            % provided an invalid value for the ValidationMode name-value 
+            % provided an invalid value for the Mode name-value 
             % pair.
             array = arrow.array.Float64Array.fromMATLAB(1:5);
 
             % Cannot convert "abc" to a ValidationMode value
-            fcn = @() array.validate(ValidationMode="abc");
+            fcn = @() array.validate(Mode="abc");
             test.verifyError(fcn, "MATLAB:validation:UnableToConvert");
 
-            % ValidationMode must be scalar
+            % Mode must be scalar
             modes = [arrow.array.ValidationMode.Full arrow.array.ValidationMode.Minimal];
-            fcn = @() array.validate(ValidationMode=modes);
+            fcn = @() array.validate(Mode=modes);
             test.verifyError(fcn, "MATLAB:validation:IncompatibleSize");
 
             % ValidationMode.None is not supported
             mode = arrow.array.ValidationMode.None;
-            fcn = @() array.validate(ValidationMode=mode);
+            fcn = @() array.validate(Mode=mode);
             test.verifyError(fcn, "arrow:array:InvalidValidationMode");
         end
 
         function ValidationModeMinimalFails(test)
             % Verify arrow.array.Array/validate() throws an exception 
             % with the ID arrow:array:ValidateMinimalFailed if
-            % ValidationMode="Minimal" and the array fails the "Minimal"
+            % Mode="Minimal" and the array fails the "Minimal"
             % validation checks.
             offsets = arrow.array(int32([0 1 3 4 5]));
             values = arrow.array([1 2 3]);
             array = arrow.array.ListArray.fromArrays(offsets, values, ValidationMode="None");
-            fcn = @() array.validate(ValidationMode="Minimal");
+            fcn = @() array.validate(Mode="Minimal");
             test.verifyError(fcn, "arrow:array:ValidateMinimalFailed")
         end
 
         function ValidationModeMinimalPasses(test)
             % Verify arrow.array.Array/validate() does not throw an
-            % exception if ValidationMode="Minimal" and the array passes the
+            % exception if Mode="Minimal" and the array passes the
             % "Minimal" validation checks.
             offsets = arrow.array(int32([0 1 0]));
             values = arrow.array([1 2 3]);
             % NOTE: the array is actually invalid, but it passes the
             % "Minimal" validation checks.
-            array = arrow.array.ListArray.fromArrays(offsets, values, ValidationMode="None");
-            fcn = @() array.validate(ValidationMode="Minimal");
+            array = arrow.array.ListArray.fromArrays(offsets, values);
+            fcn = @() array.validate(Mode="Minimal");
             test.verifyWarningFree(fcn, "arrow:array:ValidateMinimalFailed")
         end
 
         function ValidationModeFullFails(test)
             % Verify arrow.array.Array/validate() throws an exception 
             % with the ID arrow:array:ValidateFullFailed if
-            % ValidationMode="Full" and the array fails the "Full"
+            % Mode="Full" and the array fails the "Full"
             % validation checks.
             offsets = arrow.array(int32([0 1 0]));
             values = arrow.array([1 2 3]);
-            array = arrow.array.ListArray.fromArrays(offsets, values, ValidationMode="None");
-            fcn = @() array.validate(ValidationMode="Full");
+            array = arrow.array.ListArray.fromArrays(offsets, values);
+            fcn = @() array.validate(Mode="Full");
             test.verifyError(fcn, "arrow:array:ValidateFullFailed")
         end
 
         function ValidationModeFullPasses(test)
             % Verify arrow.array.Array/validate() does not throw an
-            % exception if ValidationMode="Full" and the array passes
+            % exception if Mode="Full" and the array passes
             % the "full" validation checks.
             offsets = arrow.array(int32([0 1 3]));
             values = arrow.array([1 2 3]);
-            array = arrow.array.ListArray.fromArrays(offsets, values, ValidationMode="None");
-            fcn = @() array.validate(ValidationMode="Full");
+            array = arrow.array.ListArray.fromArrays(offsets, values);
+            fcn = @() array.validate(Mode="Full");
             test.verifyWarningFree(fcn);
         end
 
         function DefaultValidationModeIsMimimal(test)
-            % Verify the default ValidationMode value is "Minimal".
+            % Verify the default Mode value is "Minimal".
             offsets = arrow.array(int32([0 1 2 3]));
             values = arrow.array([1 2 3]);
-            array = arrow.array.ListArray.fromArrays(offsets, values, ValidationMode="None");
+            array = arrow.array.ListArray.fromArrays(offsets, values);
             fcn = @() array.validate();
             test.verifyWarningFree(fcn, "arrow:array:ValidateMinimalFailed")
         end

--- a/matlab/test/arrow/array/tValidateArray.m
+++ b/matlab/test/arrow/array/tValidateArray.m
@@ -67,7 +67,7 @@ classdef tValidateArray < matlab.unittest.TestCase
 
         function ValidationModeFullFails(test)
             % Verify arrow.array.Array/validate() throws an exception 
-            % with the ID is arrow:array:ValidateFullFailed if
+            % with the ID arrow:array:ValidateFullFailed if
             % ValidationMode="Full" and the array fails the "Full"
             % validation checks.
             offsets = arrow.array(int32([0 1 0]));

--- a/matlab/test/arrow/array/tValidateArray.m
+++ b/matlab/test/arrow/array/tValidateArray.m
@@ -55,7 +55,7 @@ classdef tValidateArray < matlab.unittest.TestCase
         function ValidationModeMinimalPasses(test)
             % Verify arrow.array.Array/validate() does not throw an
             % exception if ValidationMode="Minimal" and the array passes the
-            % "Miminal" validtion checks.
+            % "Minimal" validation checks.
             offsets = arrow.array(int32([0 1 0]));
             values = arrow.array([1 2 3]);
             % NOTE: the array is actually invalid, but it passes the


### PR DESCRIPTION

### Rationale for this change

As a follow up to #38531 (see https://github.com/apache/arrow/pull/38531#discussion_r1377981403), we should consider adding a `validate` method to all `arrow.array.Array` classes, which would allow users to explicitly validate the contents of an `arrow.array.Array` after it is created.

### What changes are included in this PR?

Added `validate()` as a method to `arrow.array.Array`. This method has one name-value pair which is called `ValidationMode`. `ValidationMode` can either be specified as `"minimal"` or `"full"`. By default, `ValidationMode="minimal"`.

**Example Usage:**

```matlab
>> offsets = arrow.array(int32([0 1 0]));
>> values = arrow.array(1:3);
>> array = arrow.array.ListArray.fromArrays(offsets, values);
>> array.validate(ValidationMode="full")
>> array.validate(ValidationMode="full")
Error using .  (line 63)
Offset invariant failure: non-monotonic offset at slot 2: 0 < 1

Error in arrow.array.Array/validate (line 68)
             obj.Proxy.validate(struct(ValidationMode=uint8(opts.ValidationMode)));
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

```

### Are these changes tested?

Yes. Added a MATLAB test class called `tValidateArray.m`.

### Are there any user-facing changes?

Yes. There is a new public method that is accessible via any subclass of `arrow.array.Array`. 

* GitHub Issue: #38532