### PR TITLE
GH-38211: [MATLAB] Add support for creating an empty `arrow.tabular.RecordBatch` by calling `arrow.recordBatch` with no input arguments

### DIFF
--- a/matlab/src/matlab/+arrow/recordBatch.m
+++ b/matlab/src/matlab/+arrow/recordBatch.m
@@ -16,7 +16,7 @@
 % permissions and limitations under the License.
 function rb = recordBatch(T)
     arguments
-        T table
+        T table = table.empty(0, 0)
     end
 
     arrowArrays = arrow.tabular.internal.decompose(T);

--- a/matlab/test/arrow/tabular/tRecordBatch.m
+++ b/matlab/test/arrow/tabular/tRecordBatch.m
@@ -25,6 +25,17 @@ classdef tRecordBatch < matlab.unittest.TestCase
             tc.verifyEqual(className, "arrow.tabular.RecordBatch");
         end
 
+        function ConvenienceFunctionZeroArguments(tc)
+            % Verify the arrow.recordBatch function returns an 
+            % arrow.tabular.RecordBatch instance with zero rows and zero
+            % columns if called with zero input arguments.
+            recordBatch = arrow.recordBatch();
+            className = string(class(recordBatch));
+            tc.verifyEqual(className, "arrow.tabular.RecordBatch");
+            tc.verifyEqual(recordBatch.NumRows, int64(0));
+            tc.verifyEqual(recordBatch.NumColumns, int32(0));
+        end
+
         function SupportedTypes(tc)
             % Create a table all supported MATLAB types.
             import arrow.internal.test.tabular.createTableWithSupportedTypes

--- a/matlab/test/arrow/tabular/tRecordBatch.m
+++ b/matlab/test/arrow/tabular/tRecordBatch.m
@@ -25,7 +25,7 @@ classdef tRecordBatch < matlab.unittest.TestCase
             tc.verifyEqual(className, "arrow.tabular.RecordBatch");
         end
 
-        function ConvenienceFunctionZeroArguments(tc)
+        function ConvenienceConstructorZeroArguments(tc)
             % Verify the arrow.recordBatch function returns an 
             % arrow.tabular.RecordBatch instance with zero rows and zero
             % columns if called with zero input arguments.


### PR DESCRIPTION
### Rationale for this change

Currently, the `arrow.table` construction function will return an empty `arrow.tabular.Table` if no input arguments are passed  to the function. However, `arrow.recordBatch` throws an error in this case. We should consider making `arrow.recordBatch` behave consistently with `arrow.table` in this case.

This should be relatively straightforward to implement. We can just set the input argument `T` to default to `table.empty(0,0)` in the `arguments` block of the `recordBatch` function, in the same way that `arrow.table` does:

https://github.com/apache/arrow/blob/73454b7040fbea3a187c1bfabd7ea02d46ca3c41/matlab/src/matlab/%2Barrow/table.m#L21

### What changes are included in this PR?

Updated the `arrow.recordBatch` function to return an `arrow.tabular.RecordBatch` instance with zero columns and zero rows if called with zero input arguments. Before this change, the `arrow.recordBatch` function would throw an error if called with zero input arguments.

**Example Usage:**
```matlab
>> rb = arrow.recordBatch()

rb = 

  Arrow RecordBatch with 0 rows and 0 columns
```

### Are these changes tested?

Yes. Added a new test case to `tRecordBatch` called `ConvenienceConstructorZeroArguments`.

### Are there any user-facing changes?

Yes. Users can now call `arrow.recordBatch` with zero input arguments.

* GitHub Issue: #38211