### PR TITLE
GH-47061: [Release] Fix wrong variable name for signing

### DIFF
--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -96,7 +96,7 @@ jobs:
             gpg \
               --armor \
               --detach-sign \
-              --local-user "${ARROW_GPG_SECRET_KEY}" \
+              --local-user "${ARROW_GPG_KEY_UID}" \
               --output "${RELEASE_TARBALL}.asc" \
               "${RELEASE_TARBALL}"
           fi


### PR DESCRIPTION
### Rationale for this change

We must use GPG key ID not GPG key itself for `gpg --local-user`.

### What changes are included in this PR?

Use `ARROW_GPG_KEY_UID`.

### Are these changes tested?

No.

### Are there any user-facing changes?

No.
* GitHub Issue: #47061