### PR TITLE
GH-47065: [Release] Fix timeout key in verify_rc.yml

### DIFF
--- a/.github/workflows/verify_rc.yml
+++ b/.github/workflows/verify_rc.yml
@@ -42,7 +42,7 @@ env:
 jobs:
   target:
     runs-on: ubuntu-latest
-    timeout: 5
+    timeout-minutes: 5
     outputs:
       version: ${{ steps.detect.outputs.version }}
       rc: ${{ steps.detect.outputs.rc }}


### PR DESCRIPTION
### Rationale for this change

We must use `timeout-minutes` not `timeout` for timeout.

### What changes are included in this PR?

Fix key.

### Are these changes tested?

No.

### Are there any user-facing changes?

No.
* GitHub Issue: #47065