### PR TITLE
GH-47067: [Release] Fix wrong GitHub Actions context in verify_rc.yml

### DIFF
--- a/.github/workflows/verify_rc.yml
+++ b/.github/workflows/verify_rc.yml
@@ -54,10 +54,9 @@ jobs:
         run: |
           case "${GITHUB_EVENT_NAME}" in
             workflow_dispatch)
-              tag="${{ input.rc_tag }}"
+              tag="${{ inputs.rc_tag }}"
               ;;
             pull_request)
-              env | sort
               tag="$(gh release list \
                        --jq '.[] | select(.isPrerelease) | .tagName' \
                        --json tagName,isPrerelease \


### PR DESCRIPTION
### Rationale for this change

We must use `inputs` not `input` for inputs for workflow dispatch: https://docs.github.com/en/actions/reference/contexts-reference#inputs-context

### What changes are included in this PR?

Fix the context name.

### Are these changes tested?

No.

### Are there any user-facing changes?

No.
* GitHub Issue: #47067