### PR TITLE
GH-47074: [Release] Use reproducible mtime for csharp/ in source archive

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -791,7 +791,7 @@ ensure_source_directory() {
       fetch_archive ${dist_name}
       git clone https://github.com/${GITHUB_REPOSITORY}.git arrow
       pushd arrow
-      dev/release/utils-create-release-tarball.sh ${VERSION} ${RC_NUMBER}
+      "${SOURCE_DIR}/utils-create-release-tarball.sh" ${VERSION} ${RC_NUMBER}
       if ! cmp ${dist_name}.tar.gz ../${dist_name}.tar.gz; then
         echo "Source archive isn't reproducible"
         return 1


### PR DESCRIPTION
### Rationale for this change

The current source archive creation is reproducible when we use the same Git working tree.

But it's not reproducible when we use different Git working trees.

### What changes are included in this PR?

Use the committer date of the target commit instead of the `charp/` mtime in the current Git working tree for `csharp/` in the source archive.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #47074