### PR TITLE
GH-47078: [Release] Ensure using cloned apache/arrow for reproducible check

### DIFF
--- a/dev/release/utils-create-release-tarball.sh
+++ b/dev/release/utils-create-release-tarball.sh
@@ -39,7 +39,7 @@ tag=apache-arrow-${version}-rc${rc}
 root_folder=apache-arrow-${version}
 tarball=apache-arrow-${version}.tar.gz
 
-: ${release_hash:=$(git rev-list --max-count=1 ${tag})}
+: ${release_hash:=$(git -C "${SOURCE_TOP_DIR}" rev-list --max-count=1 ${tag})}
 
 rm -rf ${root_folder}
 
@@ -110,7 +110,6 @@ gtar_options=(
 if [ -n "${SOURCE_DATE_EPOCH:-}" ]; then
   gtar_options+=(--mtime="$(date +%Y-%m-%dT%H:%M:%S --date=@${SOURCE_DATE_EPOCH})")
 fi
-set -x
 ${gtar} \
   "${gtar_options[@]}" \
   -cf \

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -791,7 +791,7 @@ ensure_source_directory() {
       fetch_archive ${dist_name}
       git clone https://github.com/${GITHUB_REPOSITORY}.git arrow
       pushd arrow
-      "${SOURCE_DIR}/utils-create-release-tarball.sh" ${VERSION} ${RC_NUMBER}
+      dev/release/utils-create-release-tarball.sh ${VERSION} ${RC_NUMBER}
       if ! cmp ${dist_name}.tar.gz ../${dist_name}.tar.gz; then
         echo "Source archive isn't reproducible"
         return 1


### PR DESCRIPTION
### Rationale for this change

We need to use `dev/release/utils-create-release-tarball.sh` that exists in the target apache/arrow directory.

### What changes are included in this PR?

Use `dev/release/utils-create-release-tarball.sh` in cloned apache/arrow.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #47078