### PR TITLE
GH-47085 [C++][Parquet] increase default compression level for zstd

### DIFF
--- a/cpp/src/arrow/util/compression_internal.h
+++ b/cpp/src/arrow/util/compression_internal.h
@@ -69,9 +69,7 @@ std::unique_ptr<Codec> MakeLz4RawCodec(
 std::unique_ptr<Codec> MakeLz4HadoopRawCodec();
 
 // ZSTD codec.
-
-// XXX level = 1 probably doesn't compress very much
-constexpr int kZSTDDefaultCompressionLevel = 1;
+constexpr int kZSTDDefaultCompressionLevel = 9;
 
 std::unique_ptr<Codec> MakeZSTDCodec(
     int compression_level = kZSTDDefaultCompressionLevel);


### PR DESCRIPTION
### Rationale for this change

The default value for ZSTD compression is very low (level 1) this number is not aligned to the other compression types for example GZIP and Brotli both have relatively high levels of level 9 and 8 respectively

### Are these changes tested?

I have been manually testing the compression levels with osgeo/gdal's `compression_level` flag

### Are there any user-facing changes?

This will change the default compression speed for ZSTD to be slightly slower (500ms -> 1.5 seconds compared with brotli's 6 seconds), but give significantly smaller files (approx 30-40% smaller than level 1) on my 110MB test parquet

Fixes: https://github.com/OSGeo/gdal/issues/12750
Fixes: https://github.com/apache/arrow/issues/47085

* GitHub Issue: #47085