### PR TITLE
GH-45902: [Python][Parquet] Expose ParquetWriter properties and arrow_properties

### DIFF
--- a/cpp/src/parquet/arrow/writer.cc
+++ b/cpp/src/parquet/arrow/writer.cc
@@ -471,7 +471,11 @@ class FileWriterImpl : public FileWriter {
     return Status::OK();
   }
 
-  const WriterProperties& properties() const { return *writer_->properties(); }
+  const WriterProperties& properties() const override { return *writer_->properties(); }
+
+  const ArrowWriterProperties& arrow_properties() const override {
+    return *arrow_properties_;
+  }
 
   ::arrow::MemoryPool* memory_pool() const override {
     return column_write_context_.memory_pool;

--- a/cpp/src/parquet/arrow/writer.h
+++ b/cpp/src/parquet/arrow/writer.h
@@ -141,6 +141,12 @@ class PARQUET_EXPORT FileWriter {
       const std::shared_ptr<const ::arrow::KeyValueMetadata>& key_value_metadata) = 0;
   /// \brief Return the file metadata, only available after calling Close().
   virtual const std::shared_ptr<FileMetaData> metadata() const = 0;
+
+  /// \brief Return the WriterProperties used to create this writer.
+  virtual const WriterProperties& properties() const = 0;
+
+  /// \brief Return the ArrowWriterProperties used to create this writer.
+  virtual const ArrowWriterProperties& arrow_properties() const = 0;
 };
 
 /// \brief Write Parquet file metadata only to indicated Arrow OutputStream

--- a/python/pyarrow/includes/libparquet.pxd
+++ b/python/pyarrow/includes/libparquet.pxd
@@ -506,6 +506,9 @@ cdef extern from "parquet/api/writer.h" namespace "parquet" nogil:
             Builder* disable_content_defined_chunking()
             Builder* content_defined_chunking_options(CdcOptions options)
             shared_ptr[WriterProperties] build()
+        ParquetVersion version()
+        c_string created_by()
+        const ColumnProperties& default_column_properties() const
 
     cdef cppclass ArrowWriterProperties:
         cppclass Builder:
@@ -521,6 +524,8 @@ cdef extern from "parquet/api/writer.h" namespace "parquet" nogil:
             Builder* set_engine_version(ArrowWriterEngineVersion version)
             shared_ptr[ArrowWriterProperties] build()
         c_bool support_deprecated_int96_timestamps()
+        c_bool store_schema()
+        ArrowWriterEngineVersion engine_version()
 
 cdef extern from "parquet/arrow/reader.h" namespace "parquet::arrow" nogil:
     cdef cppclass FileReader:
@@ -590,7 +595,11 @@ cdef extern from "parquet/arrow/schema.h" namespace "parquet::arrow" nogil:
 
 
 cdef extern from "parquet/properties.h" namespace "parquet" nogil:
-    cdef enum ArrowWriterEngineVersion:
+    cdef cppclass ColumnProperties:
+        c_bool dictionary_enabled() const
+        c_bool statistics_enabled() const
+
+    cdef enum ArrowWriterEngineVersion "parquet::ArrowWriterProperties::EngineVersion":
         V1 "parquet::ArrowWriterProperties::V1",
         V2 "parquet::ArrowWriterProperties::V2"
 
@@ -617,6 +626,8 @@ cdef extern from "parquet/arrow/writer.h" namespace "parquet::arrow" nogil:
         CStatus AddKeyValueMetadata(const shared_ptr[const CKeyValueMetadata]& key_value_metadata)
 
         const shared_ptr[CFileMetaData] metadata() const
+        const WriterProperties& properties() const
+        const ArrowWriterProperties& arrow_properties() const
 
     CStatus WriteMetaDataFile(
         const CFileMetaData& file_metadata,

--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -1190,6 +1190,20 @@ Examples
         assert self.is_open
         self.writer.add_key_value_metadata(key_value_metadata)
 
+    @property
+    def properties(self):
+        """
+        Return the WriterProperties used to create this writer.
+        """
+        return self.writer.properties
+
+    @property
+    def arrow_properties(self):
+        """
+        Return the ArrowWriterProperties used to create this writer.
+        """
+        return self.writer.arrow_properties
+
 
 def _get_pandas_index_columns(keyvalues):
     return (json.loads(keyvalues[b'pandas'].decode('utf8'))


### PR DESCRIPTION
### Rationale for this change

Exposes `ParquetWriter` properties via `writer.properties` and `writer.arrow_properties`
(see https://github.com/apache/arrow/issues/45902)

### What changes are included in this PR?

See above

### Are these changes tested?

Yes

### Are there any user-facing changes?

Yes, properties are available via `writer.properties` and `writer.arrow_properties`

* GitHub Issue: #45902