### PR TITLE
GH-47088: [CI][Dev] Fix shellcheck errors in the ci/scripts/integration_arrow.sh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -329,6 +329,7 @@ repos:
           ?^ci/scripts/install_spark\.sh$|
           ?^ci/scripts/install_vcpkg\.sh$|
           ?^ci/scripts/integration_arrow_build\.sh$|
+          ?^ci/scripts/integration_arrow\.sh$|
           ?^ci/scripts/integration_dask\.sh$|
           ?^ci/scripts/integration_spark\.sh$|
           ?^ci/scripts/matlab_build\.sh$|

--- a/ci/scripts/integration_arrow.sh
+++ b/ci/scripts/integration_arrow.sh
@@ -24,16 +24,16 @@ build_dir=${2}
 
 gold_dir=$arrow_dir/testing/data/arrow-ipc-stream/integration
 
-: ${ARROW_INTEGRATION_CPP:=ON}
-: ${ARROW_INTEGRATION_CSHARP:=ON}
+: "${ARROW_INTEGRATION_CPP:=ON}"
+: "${ARROW_INTEGRATION_CSHARP:=ON}"
 
-: ${ARCHERY_INTEGRATION_TARGET_IMPLEMENTATIONS:=cpp,csharp}
+: "${ARCHERY_INTEGRATION_TARGET_IMPLEMENTATIONS:=cpp,csharp}"
 export ARCHERY_INTEGRATION_TARGET_IMPLEMENTATIONS
 
-. ${arrow_dir}/ci/scripts/util_log.sh
+. "${arrow_dir}/ci/scripts/util_log.sh"
 
 github_actions_group_begin "Integration: Prepare: Archery"
-pip install -e $arrow_dir/dev/archery[integration]
+pip install -e "$arrow_dir/dev/archery[integration]"
 github_actions_group_end
 
 github_actions_group_begin "Integration: Prepare: Dependencies"
@@ -58,16 +58,19 @@ export PYTHONFAULTHANDLER=1
 export GOMEMLIMIT=200MiB
 export GODEBUG=gctrace=1,clobberfree=1
 
+ARCHERY_WITH_CPP=$([ "$ARROW_INTEGRATION_CPP" == "ON" ] && echo "1" || echo "0")
+ARCHERY_WITH_CSHARP=$([ "$ARROW_INTEGRATION_CSHARP" == "ON" ] && echo "1" || echo "0")
+
 # Rust can be enabled by exporting ARCHERY_INTEGRATION_WITH_RUST=1
 time archery integration \
     --run-c-data \
     --run-ipc \
     --run-flight \
-    --with-cpp=$([ "$ARROW_INTEGRATION_CPP" == "ON" ] && echo "1" || echo "0") \
-    --with-csharp=$([ "$ARROW_INTEGRATION_CSHARP" == "ON" ] && echo "1" || echo "0") \
-    --gold-dirs=$gold_dir/0.14.1 \
-    --gold-dirs=$gold_dir/0.17.1 \
-    --gold-dirs=$gold_dir/1.0.0-bigendian \
-    --gold-dirs=$gold_dir/1.0.0-littleendian \
-    --gold-dirs=$gold_dir/2.0.0-compression \
-    --gold-dirs=$gold_dir/4.0.0-shareddict \
+    --with-cpp="${ARCHERY_WITH_CPP}" \
+    --with-csharp="${ARCHERY_WITH_CSHARP}"\
+    --gold-dirs="$gold_dir/0.14.1" \
+    --gold-dirs="$gold_dir/0.17.1" \
+    --gold-dirs="$gold_dir/1.0.0-bigendian" \
+    --gold-dirs="$gold_dir/1.0.0-littleendian" \
+    --gold-dirs="$gold_dir/2.0.0-compression" \
+    --gold-dirs="$gold_dir/4.0.0-shareddict" \


### PR DESCRIPTION
### Rationale for this change

This is the sub issue #44748.

* SC2046: Quote this to prevent word splitting.
* SC2086: Double quote to prevent globbing and word splitting.
* SC2102: Ranges can only match single chars (mentioned due to duplicates).
* SC2223: This default assignment may cause DoS due to globbing. Quote it.

```
ci/scripts/integration_arrow.sh

In ci/scripts/integration_arrow.sh line 27:
: ${ARROW_INTEGRATION_CPP:=ON}
  ^--------------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/integration_arrow.sh line 28:
: ${ARROW_INTEGRATION_CSHARP:=ON}
  ^-----------------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/integration_arrow.sh line 30:
: ${ARCHERY_INTEGRATION_TARGET_IMPLEMENTATIONS:=cpp,csharp}
  ^-- SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/integration_arrow.sh line 33:
. ${arrow_dir}/ci/scripts/util_log.sh
  ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
. "${arrow_dir}"/ci/scripts/util_log.sh


In ci/scripts/integration_arrow.sh line 36:
pip install -e $arrow_dir/dev/archery[integration]
               ^--------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                     ^-----------^ SC2102 (info): Ranges can only match single chars (mentioned due to duplicates).

Did you mean:
pip install -e "$arrow_dir"/dev/archery[integration]


In ci/scripts/integration_arrow.sh line 66:
    --with-cpp=$([ "$ARROW_INTEGRATION_CPP" == "ON" ] && echo "1" || echo "0") \
               ^-- SC2046 (warning): Quote this to prevent word splitting.


In ci/scripts/integration_arrow.sh line 67:
    --with-csharp=$([ "$ARROW_INTEGRATION_CSHARP" == "ON" ] && echo "1" || echo "0") \
                  ^-- SC2046 (warning): Quote this to prevent word splitting.


In ci/scripts/integration_arrow.sh line 68:
    --gold-dirs=$gold_dir/0.14.1 \
                ^-------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    --gold-dirs="$gold_dir"/0.14.1 \


In ci/scripts/integration_arrow.sh line 69:
    --gold-dirs=$gold_dir/0.17.1 \
                ^-------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    --gold-dirs="$gold_dir"/0.17.1 \


In ci/scripts/integration_arrow.sh line 70:
    --gold-dirs=$gold_dir/1.0.0-bigendian \
                ^-------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    --gold-dirs="$gold_dir"/1.0.0-bigendian \


In ci/scripts/integration_arrow.sh line 71:
    --gold-dirs=$gold_dir/1.0.0-littleendian \
                ^-------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    --gold-dirs="$gold_dir"/1.0.0-littleendian \


In ci/scripts/integration_arrow.sh line 72:
    --gold-dirs=$gold_dir/2.0.0-compression \
                ^-------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    --gold-dirs="$gold_dir"/2.0.0-compression \


In ci/scripts/integration_arrow.sh line 73:
    --gold-dirs=$gold_dir/4.0.0-shareddict \
                ^-------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    --gold-dirs="$gold_dir"/4.0.0-shareddict \

For more information:
  https://www.shellcheck.net/wiki/SC2046 -- Quote this to prevent word splitt...
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
  https://www.shellcheck.net/wiki/SC2102 -- Ranges can only match single char...

```

### What changes are included in this PR?

Quote variables.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #47088