### PR TITLE
GH-47030: [C++][Parquet] Add setting to limit the number of rows written per page

### DIFF
--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -1150,11 +1150,11 @@ void ColumnWriterImpl::FlushBufferedDataPages() {
 // ----------------------------------------------------------------------
 // TypedColumnWriter
 
-template <typename Action>
+template <typename Action, typename GetBufferedRows>
 inline void DoInBatches(const int16_t* def_levels, const int16_t* rep_levels,
                         int64_t num_levels, int64_t batch_size, Action&& action,
                         bool pages_change_on_record_boundaries, int64_t max_rows_per_page,
-                        const std::function<int64_t()>& curr_page_buffered_rows) {
+                        GetBufferedRows&& curr_page_buffered_rows) {
   int64_t offset = 0;
   while (offset < num_levels) {
     int64_t min_batch_size = std::min(batch_size, num_levels - offset);
@@ -1186,7 +1186,7 @@ inline void DoInBatches(const int16_t* def_levels, const int16_t* rep_levels,
       check_page_limit_end_offset = last_record_begin_offset;
     }
 
-    ARROW_DCHECK_LT(offset, end_offset);
+    ARROW_DCHECK_LE(offset, end_offset);
     ARROW_DCHECK_LE(check_page_limit_end_offset, end_offset);
 
     if (end_offset < num_levels) {

--- a/cpp/src/parquet/column_writer_test.cc
+++ b/cpp/src/parquet/column_writer_test.cc
@@ -37,6 +37,7 @@
 #include "parquet/file_writer.h"
 #include "parquet/geospatial/statistics.h"
 #include "parquet/metadata.h"
+#include "parquet/page_index.h"
 #include "parquet/platform.h"
 #include "parquet/properties.h"
 #include "parquet/statistics.h"
@@ -108,7 +109,8 @@ class TestPrimitiveWriter : public PrimitiveTypedTest<TestType> {
       const ColumnProperties& column_properties = ColumnProperties(),
       const ParquetVersion::type version = ParquetVersion::PARQUET_1_0,
       const ParquetDataPageVersion data_page_version = ParquetDataPageVersion::V1,
-      bool enable_checksum = false, int64_t page_size = kDefaultDataPageSize) {
+      bool enable_checksum = false, int64_t page_size = kDefaultDataPageSize,
+      int64_t max_rows_per_page = kDefaultMaxRowsPerPage) {
     sink_ = CreateOutputStream();
     WriterProperties::Builder wp_builder;
     wp_builder.version(version)->data_page_version(data_page_version);
@@ -125,6 +127,7 @@ class TestPrimitiveWriter : public PrimitiveTypedTest<TestType> {
     }
     wp_builder.max_statistics_size(column_properties.max_statistics_size());
     wp_builder.data_pagesize(page_size);
+    wp_builder.max_rows_per_page(max_rows_per_page);
     writer_properties_ = wp_builder.build();
 
     metadata_ = ColumnChunkMetaDataBuilder::Make(writer_properties_, this->descr_);
@@ -498,6 +501,44 @@ void TestPrimitiveWriter<FLBAType>::ReadColumnFully(Compression::type compressio
              this->values_out_[i + values_read_].ptr, this->descr_->type_length());
       this->values_out_[i + values_read_].ptr =
           data_ptr + this->descr_->type_length() * i;
+    }
+    data_buffer_.emplace_back(std::move(data));
+
+    values_read_ += values_read_recently;
+  }
+  this->SyncValuesOut();
+}
+
+template <>
+void TestPrimitiveWriter<ByteArrayType>::ReadColumnFully(Compression::type compression,
+                                                         bool page_checksum_verify) {
+  int64_t total_values = static_cast<int64_t>(this->values_out_.size());
+  BuildReader(total_values, compression, page_checksum_verify);
+  this->data_buffer_.clear();
+
+  values_read_ = 0;
+  while (values_read_ < total_values) {
+    int64_t values_read_recently = 0;
+    reader_->ReadBatch(
+        static_cast<int>(this->values_out_.size()) - static_cast<int>(values_read_),
+        definition_levels_out_.data() + values_read_,
+        repetition_levels_out_.data() + values_read_,
+        this->values_out_ptr_ + values_read_, &values_read_recently);
+
+    // Compute the total length of the data
+    int64_t total_length = 0;
+    for (int64_t i = 0; i < values_read_recently; i++) {
+      total_length += this->values_out_[i + values_read_].len;
+    }
+
+    // Copy contents of the pointers
+    std::vector<uint8_t> data(total_length);
+    uint8_t* data_ptr = data.data();
+    for (int64_t i = 0; i < values_read_recently; i++) {
+      const ByteArray& value = this->values_out_ptr_[i + values_read_];
+      memcpy(data_ptr, value.ptr, value.len);
+      this->values_out_[i + values_read_].ptr = data_ptr;
+      data_ptr += value.len;
     }
     data_buffer_.emplace_back(std::move(data));
 
@@ -2073,6 +2114,165 @@ TEST_F(TestGeometryValuesWriter, TestWriteAndReadAllNull) {
   EXPECT_THAT(geospatial_statistics->dimension_valid(),
               ::testing::ElementsAre(false, false, false, false));
   EXPECT_EQ(geospatial_statistics->geometry_types(), std::nullopt);
+}
+
+template <typename TestType>
+class TestColumnWriterMaxRowsPerPage : public TestPrimitiveWriter<TestType> {
+ public:
+  TypedColumnWriter<TestType>* BuildWriter(
+      int64_t max_rows_per_page = kDefaultMaxRowsPerPage,
+      int64_t page_size = kDefaultDataPageSize) {
+    this->sink_ = CreateOutputStream();
+    this->writer_properties_ = WriterProperties::Builder()
+                                   .max_rows_per_page(max_rows_per_page)
+                                   ->data_pagesize(page_size)
+                                   ->enable_write_page_index()
+                                   ->build();
+    file_writer_ = ParquetFileWriter::Open(
+        this->sink_, std::static_pointer_cast<GroupNode>(this->schema_.schema_root()),
+        this->writer_properties_);
+    return static_cast<TypedColumnWriter<TestType>*>(
+        file_writer_->AppendRowGroup()->NextColumn());
+  }
+
+  void CloseWriter() const { file_writer_->Close(); }
+
+  void BuildReader() {
+    ASSERT_OK_AND_ASSIGN(auto buffer, this->sink_->Finish());
+    file_reader_ = ParquetFileReader::Open(
+        std::make_shared<::arrow::io::BufferReader>(buffer), default_reader_properties());
+    this->reader_ = std::static_pointer_cast<TypedColumnReader<TestType>>(
+        file_reader_->RowGroup(0)->Column(0));
+  }
+
+  void VerifyMaxRowsPerPage(int64_t max_rows_per_page) const {
+    auto file_meta = file_reader_->metadata();
+    int64_t num_row_groups = file_meta->num_row_groups();
+    ASSERT_EQ(num_row_groups, 1);
+
+    auto page_index_reader = file_reader_->GetPageIndexReader();
+    ASSERT_NE(page_index_reader, nullptr);
+
+    auto row_group_page_index_reader = page_index_reader->RowGroup(0);
+    ASSERT_NE(row_group_page_index_reader, nullptr);
+
+    auto offset_index = row_group_page_index_reader->GetOffsetIndex(0);
+    ASSERT_NE(offset_index, nullptr);
+    size_t num_pages = offset_index->page_locations().size();
+    for (size_t j = 1; j < num_pages; ++j) {
+      int64_t page_rows = offset_index->page_locations()[j].first_row_index -
+                          offset_index->page_locations()[j - 1].first_row_index;
+      EXPECT_LE(page_rows, max_rows_per_page);
+    }
+    if (num_pages != 0) {
+      int64_t last_page_rows = file_meta->RowGroup(0)->num_rows() -
+                               offset_index->page_locations().back().first_row_index;
+      EXPECT_LE(last_page_rows, max_rows_per_page);
+    }
+  }
+
+ private:
+  std::shared_ptr<ParquetFileWriter> file_writer_;
+  std::shared_ptr<ParquetFileReader> file_reader_;
+};
+
+TYPED_TEST_SUITE(TestColumnWriterMaxRowsPerPage, TestTypes);
+
+TYPED_TEST(TestColumnWriterMaxRowsPerPage, Optional) {
+  for (int64_t max_rows_per_page : {1, 10, 100}) {
+    this->SetUpSchema(Repetition::OPTIONAL);
+    this->GenerateData(SMALL_SIZE);
+    std::vector<int16_t> definition_levels(SMALL_SIZE, 1);
+    definition_levels[1] = 0;
+
+    auto writer = this->BuildWriter(max_rows_per_page);
+    writer->WriteBatch(this->values_.size(), definition_levels.data(), nullptr,
+                       this->values_ptr_);
+    this->CloseWriter();
+
+    this->BuildReader();
+    ASSERT_NO_FATAL_FAILURE(this->VerifyMaxRowsPerPage(max_rows_per_page));
+  }
+}
+
+TYPED_TEST(TestColumnWriterMaxRowsPerPage, OptionalSpaced) {
+  for (int64_t max_rows_per_page : {1, 10, 100}) {
+    this->SetUpSchema(Repetition::OPTIONAL);
+
+    this->GenerateData(SMALL_SIZE);
+    std::vector<int16_t> definition_levels(SMALL_SIZE, 1);
+    std::vector<uint8_t> valid_bits(::arrow::bit_util::BytesForBits(SMALL_SIZE), 255);
+
+    definition_levels[SMALL_SIZE - 1] = 0;
+    ::arrow::bit_util::ClearBit(valid_bits.data(), SMALL_SIZE - 1);
+    definition_levels[1] = 0;
+    ::arrow::bit_util::ClearBit(valid_bits.data(), 1);
+
+    auto writer = this->BuildWriter(max_rows_per_page);
+    writer->WriteBatchSpaced(this->values_.size(), definition_levels.data(), nullptr,
+                             valid_bits.data(), 0, this->values_ptr_);
+    this->CloseWriter();
+
+    this->BuildReader();
+    ASSERT_NO_FATAL_FAILURE(this->VerifyMaxRowsPerPage(max_rows_per_page));
+  }
+}
+
+TYPED_TEST(TestColumnWriterMaxRowsPerPage, Repeated) {
+  for (int64_t max_rows_per_page : {1, 10, 100}) {
+    this->SetUpSchema(Repetition::REPEATED);
+
+    this->GenerateData(SMALL_SIZE);
+    std::vector<int16_t> definition_levels(SMALL_SIZE);
+    std::vector<int16_t> repetition_levels(SMALL_SIZE);
+
+    // Generate levels to include variable-sized lists, null lists, and empty lists
+    for (int i = 0; i < SMALL_SIZE; i++) {
+      int list_length = (i % 5) + 1;
+      bool is_null = false;
+      if (i % 17 == 0) {
+        is_null = true;
+        list_length = 0;
+      } else if (i % 13 == 0) {
+        list_length = 0;
+      }
+
+      if (is_null) {
+        definition_levels[i] = 0;
+        repetition_levels[i] = 0;
+      } else if (list_length == 0) {
+        definition_levels[i] = 1;
+        repetition_levels[i] = 0;
+      } else {
+        for (int j = 0; j < list_length && i + j < SMALL_SIZE; j++) {
+          definition_levels[i + j] = 1;
+          repetition_levels[i + j] = (j == 0) ? 0 : 1;
+        }
+        i += list_length - 1;
+      }
+    }
+
+    auto writer = this->BuildWriter(max_rows_per_page);
+    writer->WriteBatch(this->values_.size(), definition_levels.data(),
+                       repetition_levels.data(), this->values_ptr_);
+    this->CloseWriter();
+
+    this->BuildReader();
+    ASSERT_NO_FATAL_FAILURE(this->VerifyMaxRowsPerPage(max_rows_per_page));
+  }
+}
+
+TYPED_TEST(TestColumnWriterMaxRowsPerPage, RequiredLargeChunk) {
+  for (int64_t max_rows_per_page : {10, 100, 10000}) {
+    this->GenerateData(LARGE_SIZE);
+
+    auto writer = this->BuildWriter(max_rows_per_page);
+    writer->WriteBatch(this->values_.size(), nullptr, nullptr, this->values_ptr_);
+    this->CloseWriter();
+
+    this->BuildReader();
+    ASSERT_NO_FATAL_FAILURE(this->VerifyMaxRowsPerPage(max_rows_per_page));
+  }
 }
 
 }  // namespace test

--- a/cpp/src/parquet/column_writer_test.cc
+++ b/cpp/src/parquet/column_writer_test.cc
@@ -2231,22 +2231,15 @@ TYPED_TEST(TestColumnWriterMaxRowsPerPage, Repeated) {
     std::vector<int16_t> definition_levels(SMALL_SIZE);
     std::vector<int16_t> repetition_levels(SMALL_SIZE);
 
-    // Generate levels to include variable-sized lists, null lists, and empty lists
+    // Generate levels to include variable-sized lists and empty lists
     for (int i = 0; i < SMALL_SIZE; i++) {
       int list_length = (i % 5) + 1;
-      bool is_null = false;
-      if (i % 17 == 0) {
-        is_null = true;
-        list_length = 0;
-      } else if (i % 13 == 0) {
+      if (i % 13 == 0 || i % 17 == 0) {
         list_length = 0;
       }
 
-      if (is_null) {
+      if (list_length == 0) {
         definition_levels[i] = 0;
-        repetition_levels[i] = 0;
-      } else if (list_length == 0) {
-        definition_levels[i] = 1;
         repetition_levels[i] = 0;
       } else {
         for (int j = 0; j < list_length && i + j < SMALL_SIZE; j++) {

--- a/cpp/src/parquet/column_writer_test.cc
+++ b/cpp/src/parquet/column_writer_test.cc
@@ -2159,16 +2159,21 @@ class TestColumnWriterMaxRowsPerPage : public TestPrimitiveWriter<TestType> {
     auto offset_index = row_group_page_index_reader->GetOffsetIndex(0);
     ASSERT_NE(offset_index, nullptr);
     size_t num_pages = offset_index->page_locations().size();
+    int64_t num_rows = 0;
     for (size_t j = 1; j < num_pages; ++j) {
       int64_t page_rows = offset_index->page_locations()[j].first_row_index -
                           offset_index->page_locations()[j - 1].first_row_index;
       EXPECT_LE(page_rows, max_rows_per_page);
+      num_rows += page_rows;
     }
     if (num_pages != 0) {
       int64_t last_page_rows = file_meta->RowGroup(0)->num_rows() -
                                offset_index->page_locations().back().first_row_index;
       EXPECT_LE(last_page_rows, max_rows_per_page);
+      num_rows += last_page_rows;
     }
+
+    EXPECT_EQ(num_rows, file_meta->RowGroup(0)->num_rows());
   }
 
  private:

--- a/cpp/src/parquet/properties.h
+++ b/cpp/src/parquet/properties.h
@@ -155,8 +155,7 @@ class PARQUET_EXPORT ReaderProperties {
 ReaderProperties PARQUET_EXPORT default_reader_properties();
 
 static constexpr int64_t kDefaultDataPageSize = 1024 * 1024;
-/// FIXME: Switch the default value to 20000 will break UTs.
-static constexpr int64_t kDefaultMaxRowsPerPage = 1000000;
+static constexpr int64_t kDefaultMaxRowsPerPage = 20'000;
 static constexpr bool DEFAULT_IS_DICTIONARY_ENABLED = true;
 static constexpr int64_t DEFAULT_DICTIONARY_PAGE_SIZE_LIMIT = kDefaultDataPageSize;
 static constexpr int64_t DEFAULT_WRITE_BATCH_SIZE = 1024;
@@ -427,7 +426,7 @@ class PARQUET_EXPORT WriterProperties {
     }
 
     /// Specify the maximum number of rows per data page.
-    /// Default 1M rows.
+    /// Default 20K rows.
     Builder* max_rows_per_page(int64_t max_rows) {
       max_rows_per_page_ = max_rows;
       return this;

--- a/cpp/src/parquet/size_statistics_test.cc
+++ b/cpp/src/parquet/size_statistics_test.cc
@@ -140,6 +140,7 @@ class SizeStatisticsRoundTripTest : public ::testing::Test {
     auto writer_properties = WriterProperties::Builder()
                                  .max_row_group_length(max_row_group_length)
                                  ->data_pagesize(page_size)
+                                 ->max_rows_per_page(std::numeric_limits<int64_t>::max())
                                  ->write_batch_size(write_batch_size)
                                  ->enable_write_page_index()
                                  ->enable_statistics()


### PR DESCRIPTION
### Rationale for this change

Currently only page size is limited. We need to limit number of rows per page too.

### What changes are included in this PR?

Add `parquet::WriterProperties::max_rows_per_page(int64_t max_rows)` to limit number of rows per data page.

### Are these changes tested?

Yes

### Are there any user-facing changes?

Yes, users are allowed to set this config value.
* GitHub Issue: #47030