### PR TITLE
GH-41110: [C#] Handle empty stream in ArrowStreamReaderImplementation

### DIFF
--- a/csharp/src/Apache.Arrow/Ipc/ArrowStreamReaderImplementation.cs
+++ b/csharp/src/Apache.Arrow/Ipc/ArrowStreamReaderImplementation.cs
@@ -186,7 +186,7 @@ namespace Apache.Arrow.Ipc
 
             // Figure out length of schema
             int schemaMessageLength = ReadMessageLength(throwOnFullRead: true, returnOnEmptyStream: true);
-            if(schemaMessageLength == 0)
+            if (schemaMessageLength == 0)
             {
                 return;
             }
@@ -208,7 +208,7 @@ namespace Apache.Arrow.Ipc
             {
                 int bytesRead = await BaseStream.ReadFullBufferAsync(lengthBuffer, cancellationToken)
                     .ConfigureAwait(false);
-                if (bytesRead == 0)
+                if (bytesRead == 0 && returnOnEmptyStream)
                 {
                     return 0;
                 }

--- a/csharp/src/Apache.Arrow/Ipc/ArrowStreamReaderImplementation.cs
+++ b/csharp/src/Apache.Arrow/Ipc/ArrowStreamReaderImplementation.cs
@@ -55,6 +55,9 @@ namespace Apache.Arrow.Ipc
 
         protected async ValueTask<RecordBatch> ReadRecordBatchAsync(CancellationToken cancellationToken = default)
         {
+            if (BaseStream.Length == 0)
+                return null;
+
             await ReadSchemaAsync().ConfigureAwait(false);
 
             ReadResult result = default;
@@ -103,6 +106,9 @@ namespace Apache.Arrow.Ipc
 
         protected RecordBatch ReadRecordBatch()
         {
+            if (BaseStream.Length == 0)
+                return null;
+
             ReadSchema();
 
             ReadResult result = default;

--- a/csharp/src/Apache.Arrow/Ipc/ArrowStreamReaderImplementation.cs
+++ b/csharp/src/Apache.Arrow/Ipc/ArrowStreamReaderImplementation.cs
@@ -55,9 +55,6 @@ namespace Apache.Arrow.Ipc
 
         protected async ValueTask<RecordBatch> ReadRecordBatchAsync(CancellationToken cancellationToken = default)
         {
-            if (BaseStream.Length == 0)
-                return null;
-
             await ReadSchemaAsync().ConfigureAwait(false);
 
             ReadResult result = default;
@@ -71,7 +68,7 @@ namespace Apache.Arrow.Ipc
 
         protected async ValueTask<ReadResult> ReadMessageAsync(CancellationToken cancellationToken)
         {
-            int messageLength = await ReadMessageLengthAsync(throwOnFullRead: false, cancellationToken)
+            int messageLength = await ReadMessageLengthAsync(throwOnFullRead: false, returnOnEmptyStream: false, cancellationToken)
                 .ConfigureAwait(false);
 
             if (messageLength == 0)
@@ -106,9 +103,6 @@ namespace Apache.Arrow.Ipc
 
         protected RecordBatch ReadRecordBatch()
         {
-            if (BaseStream.Length == 0)
-                return null;
-
             ReadSchema();
 
             ReadResult result = default;
@@ -122,8 +116,7 @@ namespace Apache.Arrow.Ipc
 
         protected ReadResult ReadMessage()
         {
-            int messageLength = ReadMessageLength(throwOnFullRead: false);
-
+            int messageLength = ReadMessageLength(throwOnFullRead: false, returnOnEmptyStream: false);
             if (messageLength == 0)
             {
                 // reached end
@@ -166,8 +159,12 @@ namespace Apache.Arrow.Ipc
             }
 
             // Figure out length of schema
-            int schemaMessageLength = await ReadMessageLengthAsync(throwOnFullRead: true, cancellationToken)
+            int schemaMessageLength = await ReadMessageLengthAsync(throwOnFullRead: true, returnOnEmptyStream: true, cancellationToken)
                 .ConfigureAwait(false);
+            if (schemaMessageLength == 0)
+            {
+                return;
+            }
 
             using (ArrayPool<byte>.Shared.RentReturn(schemaMessageLength, out Memory<byte> buff))
             {
@@ -188,7 +185,11 @@ namespace Apache.Arrow.Ipc
             }
 
             // Figure out length of schema
-            int schemaMessageLength = ReadMessageLength(throwOnFullRead: true);
+            int schemaMessageLength = ReadMessageLength(throwOnFullRead: true, returnOnEmptyStream: true);
+            if(schemaMessageLength == 0)
+            {
+                return;
+            }
 
             using (ArrayPool<byte>.Shared.RentReturn(schemaMessageLength, out Memory<byte> buff))
             {
@@ -200,13 +201,17 @@ namespace Apache.Arrow.Ipc
             }
         }
 
-        private async ValueTask<int> ReadMessageLengthAsync(bool throwOnFullRead, CancellationToken cancellationToken = default)
+        private async ValueTask<int> ReadMessageLengthAsync(bool throwOnFullRead, bool returnOnEmptyStream, CancellationToken cancellationToken = default)
         {
             int messageLength = 0;
             using (ArrayPool<byte>.Shared.RentReturn(4, out Memory<byte> lengthBuffer))
             {
                 int bytesRead = await BaseStream.ReadFullBufferAsync(lengthBuffer, cancellationToken)
                     .ConfigureAwait(false);
+                if (bytesRead == 0)
+                {
+                    return 0;
+                }
                 if (throwOnFullRead)
                 {
                     EnsureFullRead(lengthBuffer, bytesRead);
@@ -239,12 +244,16 @@ namespace Apache.Arrow.Ipc
             return messageLength;
         }
 
-        private int ReadMessageLength(bool throwOnFullRead)
+        private int ReadMessageLength(bool throwOnFullRead, bool returnOnEmptyStream)
         {
             int messageLength = 0;
             using (ArrayPool<byte>.Shared.RentReturn(4, out Memory<byte> lengthBuffer))
             {
                 int bytesRead = BaseStream.ReadFullBuffer(lengthBuffer);
+                if (bytesRead == 0 && returnOnEmptyStream)
+                {
+                    return 0;
+                }
                 if (throwOnFullRead)
                 {
                     EnsureFullRead(lengthBuffer, bytesRead);

--- a/csharp/test/Apache.Arrow.Tests/ArrowStreamReaderTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/ArrowStreamReaderTests.cs
@@ -131,6 +131,19 @@ namespace Apache.Arrow.Tests
             await verificationFunc(reader, originalBatch);
         }
 
+        [Fact]
+        public void ReadRecordBatch_EmptyStream()
+        {
+            using (MemoryStream stream = new())
+            {
+                ArrowStreamReader reader = new ArrowStreamReader(stream);
+                RecordBatch readBatch = reader.ReadNextRecordBatch();
+                Assert.Null(readBatch);
+
+                //ArrowReaderVerifier.VerifyReader(reader, originalBatch: null);
+            }
+        }
+
         [Theory]
         [InlineData(true, true)]
         [InlineData(true, false)]
@@ -143,6 +156,20 @@ namespace Apache.Arrow.Tests
                 ArrowReaderVerifier.VerifyReader(reader, originalBatch);
                 return Task.CompletedTask;
             }, writeEnd, createDictionaryArray);
+        }
+
+        [Fact]
+        public async Task ReadRecordBatchAsync_EmptyStream()
+        {
+            using (MemoryStream stream = new())
+            {
+                ArrowStreamReader reader = new ArrowStreamReader(stream);
+
+                RecordBatch readBatch = await reader.ReadNextRecordBatchAsync();
+                Assert.Null(readBatch);
+
+                //await ArrowReaderVerifier.VerifyReaderAsync(reader, originalBatch: null);
+            }
         }
 
         [Theory]

--- a/csharp/test/Apache.Arrow.Tests/ArrowStreamReaderTests.cs
+++ b/csharp/test/Apache.Arrow.Tests/ArrowStreamReaderTests.cs
@@ -136,11 +136,9 @@ namespace Apache.Arrow.Tests
         {
             using (MemoryStream stream = new())
             {
-                ArrowStreamReader reader = new ArrowStreamReader(stream);
+                ArrowStreamReader reader = new(stream);
                 RecordBatch readBatch = reader.ReadNextRecordBatch();
                 Assert.Null(readBatch);
-
-                //ArrowReaderVerifier.VerifyReader(reader, originalBatch: null);
             }
         }
 
@@ -163,12 +161,9 @@ namespace Apache.Arrow.Tests
         {
             using (MemoryStream stream = new())
             {
-                ArrowStreamReader reader = new ArrowStreamReader(stream);
-
+                ArrowStreamReader reader = new(stream);
                 RecordBatch readBatch = await reader.ReadNextRecordBatchAsync();
                 Assert.Null(readBatch);
-
-                //await ArrowReaderVerifier.VerifyReaderAsync(reader, originalBatch: null);
             }
         }
 


### PR DESCRIPTION
### Rationale for this change
Fixing #41110.

### What changes are included in this PR?
Handle empty stream in `ArrowStreamReaderImplementation`. Similar changes have *not* been made to `ArrowMemoryReaderImplementation` or `ArrowFileReaderImplementation`.

### Are these changes tested?
Two basic unit tests have been created to validate the new behavior. This might not be sufficient to cover all cases where an empty stream should be handled without an exception occurring.

Original change by @voidstar69; this takes his change and applies the PR feedback to it.

* GitHub Issue: #41110