### PR TITLE
GH-38572: [Docs][MATLAB] Update `arrow/matlab/README.md` with the latest change.

### DIFF
--- a/matlab/README.md
+++ b/matlab/README.md
@@ -129,11 +129,9 @@ matlabArray =
 
 arrowArray = 
 
-[
-  1,
-  2,
-  3
-]
+  Float64Array with 3 elements and 0 null values:
+
+    1 | 2 | 3
 ```
 
 #### Create a MATLAB `logical` array from an Arrow `BooleanArray`
@@ -143,11 +141,9 @@ arrowArray =
 
 arrowArray = 
 
-[
-  true,
-  false,
-  true
-]
+  BooleanArray with 3 elements and 0 null values:
+
+    true | false | true
 
 >> matlabArray = toMATLAB(arrowArray)
 
@@ -185,13 +181,9 @@ validElements =
 
 arrowArray = 
 
-[
-  122,
-  null,
-  127,
-  null,
-  127
-]
+  Int8Array with 5 elements and 2 null values:
+
+    122 | null | 127 | null | 127
 ```
 
 ### Arrow `RecordBatch` class
@@ -214,23 +206,17 @@ matlabTable =
 
 >> arrowRecordBatch = arrow.recordBatch(matlabTable)
 
-arrowRecordBatch =
+arrowRecordBatch = 
 
-Var1:   [
-    "A",
-    "B",
-    "C"
-  ]
-Var2:   [
-    1,
-    2,
-    3
-  ]
-Var3:   [
-    true,
-    false,
-    true
-  ]
+  Arrow RecordBatch with 3 rows and 3 columns:
+
+    Schema:
+
+        Var1: String | Var2: Float64 | Var3: Boolean
+
+    First Row:
+
+        "A" | 1 | true
 ```
 
 #### Create a MATLAB `table` from an Arrow `RecordBatch`
@@ -238,23 +224,17 @@ Var3:   [
 ```matlab
 >> arrowRecordBatch
 
-arrowRecordBatch =
+arrowRecordBatch = 
 
-Var1:   [
-    "A",
-    "B",
-    "C"
-  ]
-Var2:   [
-    1,
-    2,
-    3
-  ]
-Var3:   [
-    true,
-    false,
-    true
-  ]
+  Arrow RecordBatch with 3 rows and 3 columns:
+
+    Schema:
+
+        Var1: String | Var2: Float64 | Var3: Boolean
+
+    First Row:
+
+        "A" | 1 | true
 
 >> matlabTable = table(arrowRecordBatch)
 
@@ -276,53 +256,41 @@ matlabTable =
 ```matlab
 >> stringArray = arrow.array(["A", "B", "C"])
 
-stringArray =
+stringArray = 
 
-[
-  "A",
-  "B",
-  "C"
-]
+  StringArray with 3 elements and 0 null values:
+
+    "A" | "B" | "C"
 
 >> timestampArray = arrow.array([datetime(1997, 01, 01), datetime(1998, 01, 01), datetime(1999, 01, 01)])
 
-timestampArray =
+timestampArray = 
 
-[
-  1997-01-01 00:00:00.000000,
-  1998-01-01 00:00:00.000000,
-  1999-01-01 00:00:00.000000
-]
+  TimestampArray with 3 elements and 0 null values:
+
+    1997-01-01 00:00:00.000000 | 1998-01-01 00:00:00.000000 | 1999-01-01 00:00:00.000000
 
 >> booleanArray = arrow.array([true, false, true])
 
-booleanArray =
+booleanArray = 
 
-[
-  true,
-  false,
-  true
-]
+  BooleanArray with 3 elements and 0 null values:
+
+    true | false | true
 
 >> arrowRecordBatch = arrow.tabular.RecordBatch.fromArrays(stringArray, timestampArray, booleanArray)
 
-arrowRecordBatch =
+arrowRecordBatch = 
 
-Column1:   [
-    "A",
-    "B",
-    "C"
-  ]
-Column2:   [
-    1997-01-01 00:00:00.000000,
-    1998-01-01 00:00:00.000000,
-    1999-01-01 00:00:00.000000
-  ]
-Column3:   [
-    true,
-    false,
-    true
-  ]
+  Arrow RecordBatch with 3 rows and 3 columns:
+
+    Schema:
+
+        Column1: String | Column2: Timestamp | Column3: Boolean
+
+    First Row:
+
+        "A" | 1997-01-01 00:00:00.000000 | true
 ```
 
 #### Extract a column from a `RecordBatch` by index
@@ -330,33 +298,25 @@ Column3:   [
 ```matlab
 >> arrowRecordBatch = arrow.tabular.RecordBatch.fromArrays(stringArray, timestampArray, booleanArray)
 
-arrowRecordBatch =
+arrowRecordBatch = 
 
-Column1:   [
-    "A",
-    "B",
-    "C"
-  ]
-Column2:   [
-    1997-01-01 00:00:00.000000,
-    1998-01-01 00:00:00.000000,
-    1999-01-01 00:00:00.000000
-  ]
-Column3:   [
-    true,
-    false,
-    true
-  ]
+  Arrow RecordBatch with 3 rows and 3 columns:
+
+    Schema:
+
+        Column1: String | Column2: Timestamp | Column3: Boolean
+
+    First Row:
+
+        "A" | 1997-01-01 00:00:00.000000 | true
 
 >> timestampArray = arrowRecordBatch.column(2)
 
-timestampArray =
+timestampArray = 
 
-[
-  1997-01-01 00:00:00.000000,
-  1998-01-01 00:00:00.000000,
-  1999-01-01 00:00:00.000000
-]
+  TimestampArray with 3 elements and 0 null values:
+
+    1997-01-01 00:00:00.000000 | 1998-01-01 00:00:00.000000 | 1999-01-01 00:00:00.000000
 ```
 
 ### Arrow `Type` classes (i.e. `arrow.type.<Type>`)
@@ -423,9 +383,12 @@ ans =
 ```matlab
 >> field = arrow.field("Number", arrow.int8())
 
-field =
+field = 
 
-Number: int8
+  Field with properties:
+
+    Name: "Number"
+    Type: [1x1 arrow.type.Int8Type]
 
 >> field.Name
 
@@ -448,9 +411,12 @@ ans =
 ```matlab
 >> field = arrow.field("Letter", arrow.string())
 
-field =
+field = 
 
-Letter: string
+  Field with properties:
+
+    Name: "Letter"
+    Type: [1x1 arrow.type.StringType]
 
 >> field.Name
 
@@ -472,17 +438,21 @@ ans =
 ```matlab
 >> arrowSchema
 
-arrowSchema =
+arrowSchema = 
 
-Letter: string
-Number: double
+  Arrow Schema with 2 fields:
+
+    Letter: String | Number: Int8
 
 % Specify the field to extract by its index (i.e. 2)
 >> field = arrowSchema.field(2)
 
-field =
+field = 
 
-Number: double
+  Field with properties:
+
+    Name: "Number"
+    Type: [1x1 arrow.type.Int8Type]
 ```
 
 #### Extract an Arrow `Field` from an Arrow `Schema` by name
@@ -490,17 +460,21 @@ Number: double
 ```matlab
 >> arrowSchema
 
-arrowSchema =
+arrowSchema = 
 
-Letter: string
-Number: double
+  Arrow Schema with 2 fields:
+
+    Letter: String | Number: Int8
 
 % Specify the field to extract by its name (i.e. "Letter")
 >> field = arrowSchema.field("Letter")
 
-field =
+field = 
 
-Letter: string
+  Field with properties:
+
+    Name: "Letter"
+    Type: [1x1 arrow.type.StringType]
 ```
 
 ### Arrow `Schema` class
@@ -510,22 +484,29 @@ Letter: string
 ```matlab
 >> letter = arrow.field("Letter", arrow.string())
 
-letter =
+letter = 
 
-Letter: string
+  Field with properties:
+
+    Name: "Letter"
+    Type: [1x1 arrow.type.StringType]
 
 >> number = arrow.field("Number", arrow.int8())
 
-number =
+number = 
 
-Number: int8
+  Field with properties:
+
+    Name: "Number"
+    Type: [1x1 arrow.type.Int8Type]
 
 >> schema = arrow.schema([letter, number])
 
-schema =
+schema = 
 
-Letter: string
-Number: int8
+  Arrow Schema with 2 fields:
+
+    Letter: String | Number: Int8
 ```
 
 #### Get the `Schema` of an Arrow `RecordBatch`
@@ -546,25 +527,25 @@ matlabTable =
 
 >> arrowRecordBatch = arrow.recordBatch(matlabTable)
 
-arrowRecordBatch =
+arrowRecordBatch = 
 
-Letter:   [
-    "A",
-    "B",
-    "C"
-  ]
-Number:   [
-    1,
-    2,
-    3
-  ]
+  Arrow RecordBatch with 3 rows and 2 columns:
+
+    Schema:
+
+        Letter: String | Number: Float64
+
+    First Row:
+
+        "A" | 1
 
 >> arrowSchema = arrowRecordBatch.Schema
 
-arrowSchema =
+arrowSchema = 
 
-Letter: string
-Number: double
+  Arrow Schema with 2 fields:
+
+    Letter: String | Number: Float64
 ```
 
 ### Feather V1

--- a/matlab/README.md
+++ b/matlab/README.md
@@ -110,6 +110,8 @@ To run the MATLAB tests, start MATLAB in the `arrow/matlab` directory and call t
 >> runtests("test", IncludeSubFolders=true);
 ```
 
+Refer to [Testing Guidelines](doc/testing_guidelines_for_the_matlab_interface_to_apache_arrow.md) for more information.
+
 ## Usage
 
 Included below are some example code snippets that illustrate how to use the MATLAB interface.

--- a/matlab/README.md
+++ b/matlab/README.md
@@ -53,6 +53,10 @@ Supported `arrow.array.Array` types are included in the table below.
 | `datetime`        | `TimestampArray` |
 | `duration`        | `Time32Array`    |
 | `duration`        | `Time64Array`    |
+| `datetime`        | `Date32Array`    |
+| `datetime`        | `Date64Array`    |
+| `cell`            | `ListArray`      |
+| `table`           | `StructArray`    |
 
 ## Prerequisites
 

--- a/matlab/README.md
+++ b/matlab/README.md
@@ -51,10 +51,10 @@ Supported `arrow.array.Array` types are included in the table below.
 | `logical`         | `BooleanArray`   |
 | `string`          | `StringArray`    |
 | `datetime`        | `TimestampArray` |
-| `duration`        | `Time32Array`    |
-| `duration`        | `Time64Array`    |
 | `datetime`        | `Date32Array`    |
 | `datetime`        | `Date64Array`    |
+| `duration`        | `Time32Array`    |
+| `duration`        | `Time64Array`    |
 | `cell`            | `ListArray`      |
 | `table`           | `StructArray`    |
 

--- a/matlab/doc/matlab_interface_for_apache_arrow_design.md
+++ b/matlab/doc/matlab_interface_for_apache_arrow_design.md
@@ -293,6 +293,8 @@ To ensure code quality, we would like to include the following testing infrastru
 
 **Note**: To test internal C++ code, we can use a [MEX function] to call the C++ code from a MATLAB Class-Based Unit Test.
 
+More information on testing is included in [Testing Guidelines](testing_guidelines_for_the_matlab_interface_to_apache_arrow.md).
+
 ## Documentation 
 To ensure usability, discoverability, and accessibility, we would like to include high quality documentation for the MATLAB Interface for Apache Arrow. 
 


### PR DESCRIPTION
### Rationale for this change

The documentation for the MATLAB interface hasn't been updated in a while and is out of date.

This PR includes several miscellaneous updates and enhancements to the documentation.

### What changes are included in this PR?

1. Updated the display output for the various `arrow.*` types used in the code snippets in [matlab/README.md](https://github.com/apache/arrow/blob/main/matlab/README.md).
2. Updated the table of supported `arrow.array.Array` types in [matlab/README.md](https://github.com/apache/arrow/blob/main/matlab/README.md).
3. Added a link to the [Testing Guidelines](https://github.com/apache/arrow/blob/main/matlab/doc/testing_guidelines_for_the_matlab_interface_to_apache_arrow.md) in the Testing section of [matlab/README.md](https://github.com/apache/arrow/blob/main/matlab/README.md)
4. Added a link to the [Testing Guidelines](https://github.com/apache/arrow/blob/main/matlab/doc/testing_guidelines_for_the_matlab_interface_to_apache_arrow.md) in [matlab_interface_for_apache_arrow.md](https://github.com/apache/arrow/blob/main/matlab/doc/matlab_interface_for_apache_arrow_design.md).

### Are these changes tested?

N/A. 

This is a documentation only change.

I visually inspected the rendered Markdown for all modified documents to ensure they updated contents display as expected.

### Are there any user-facing changes?

Yes.

1. This PR updates the user-facing documentation for the MATLAB interface. [matlab/README.md](https://github.com/apache/arrow/blob/main/matlab/README.md) and [matlab/doc/matlab_interface_for_apache_arrow.md](https://github.com/apache/arrow/blob/main/matlab/doc/matlab_interface_for_apache_arrow_design.md) have been modified as described above in the "What changes are included in this PR?" section.

### Future Directions

1. Consider deleting or re-purposing `matlab/doc/matlab_interface_for_apache_arrow_design.md`. This document is fairly old and may no longer be the most effective way to document the MATLAB interface.
2. Consider using shorter filenames for `matlab_interface_for_apache_arrow_design.md` and/or `testing_guidelines_for_the_matlab_interface_to_apache_arrow.md`.
3. #28149 - consider moving code snippets in `README.md` to an `examples/` directory to simplify `README.md`.
4. Consider adding more developer-oriented documentation (e.g. like "`contributing.md`" to help guide and encourage new contributors to the MATLAB interface).
* GitHub Issue: #38572