### PR TITLE
GH-47099: [C++][Parquet] Add missing `pragma warning(pop)` to `parquet/platform.h`

### DIFF
--- a/cpp/src/parquet/column_reader.cc
+++ b/cpp/src/parquet/column_reader.cc
@@ -57,6 +57,11 @@
 #include "parquet/thrift_internal.h"  // IWYU pragma: keep
 #include "parquet/windows_fixup.h"    // for OPTIONAL
 
+#ifdef _MSC_VER
+// disable warning about inheritance via dominance in the diamond pattern
+#  pragma warning(disable : 4250)
+#endif
+
 using arrow::MemoryPool;
 using arrow::internal::AddWithOverflow;
 using arrow::internal::checked_cast;

--- a/cpp/src/parquet/decoder.cc
+++ b/cpp/src/parquet/decoder.cc
@@ -53,6 +53,11 @@
 #include "parquet/schema.h"
 #include "parquet/types.h"
 
+#ifdef _MSC_VER
+// disable warning about inheritance via dominance in the diamond pattern
+#  pragma warning(disable : 4250)
+#endif
+
 namespace bit_util = arrow::bit_util;
 
 using arrow::Status;

--- a/cpp/src/parquet/encoder.cc
+++ b/cpp/src/parquet/encoder.cc
@@ -49,6 +49,11 @@
 #include "parquet/schema.h"
 #include "parquet/types.h"
 
+#ifdef _MSC_VER
+// disable warning about inheritance via dominance in the diamond pattern
+#  pragma warning(disable : 4250)
+#endif
+
 namespace bit_util = arrow::bit_util;
 
 using arrow::Status;

--- a/cpp/src/parquet/exception.h
+++ b/cpp/src/parquet/exception.h
@@ -26,6 +26,21 @@
 #include "arrow/util/string_util.h"
 #include "parquet/platform.h"
 
+#if defined(_WIN32) || defined(__CYGWIN__)
+#  if defined(_MSC_VER)
+#    pragma warning(push)
+// Disable warning for STL types usage in DLL interface
+// https://web.archive.org/web/20130317015847/http://connect.microsoft.com/VisualStudio/feedback/details/696593/vc-10-vs-2010-basic-string-exports
+#    pragma warning(disable : 4275 4251)
+// Disable diamond inheritance warnings
+#    pragma warning(disable : 4250)
+// Disable macro redefinition warnings
+#    pragma warning(disable : 4005)
+// Disable extern before exported template warnings
+#    pragma warning(disable : 4910)
+#  endif
+#endif
+
 // PARQUET-1085
 #if !defined(ARROW_UNUSED)
 #  define ARROW_UNUSED(x) UNUSED(x)
@@ -84,7 +99,7 @@
 
 namespace parquet {
 
-class PARQUET_EXPORT ParquetException : public std::exception {
+class ParquetException : public std::exception {
  public:
   PARQUET_NORETURN static void EofException(const std::string& msg = "") {
     static std::string prefix = "Unexpected end of stream";
@@ -156,3 +171,9 @@ void ThrowNotOk(StatusReturnBlock&& b) {
 }
 
 }  // namespace parquet
+
+#if defined(_WIN32) || defined(__CYGWIN__)
+#  if defined(_MSC_VER)
+#    pragma warning(pop)
+#  endif
+#endif

--- a/cpp/src/parquet/exception.h
+++ b/cpp/src/parquet/exception.h
@@ -26,19 +26,17 @@
 #include "arrow/util/string_util.h"
 #include "parquet/platform.h"
 
-#if defined(_WIN32) || defined(__CYGWIN__)
-#  if defined(_MSC_VER)
-#    pragma warning(push)
+#if defined(_MSC_VER)
+#  pragma warning(push)
 // Disable warning for STL types usage in DLL interface
 // https://web.archive.org/web/20130317015847/http://connect.microsoft.com/VisualStudio/feedback/details/696593/vc-10-vs-2010-basic-string-exports
-#    pragma warning(disable : 4275 4251)
+#  pragma warning(disable : 4275 4251)
 // Disable diamond inheritance warnings
-#    pragma warning(disable : 4250)
+#  pragma warning(disable : 4250)
 // Disable macro redefinition warnings
-#    pragma warning(disable : 4005)
+#  pragma warning(disable : 4005)
 // Disable extern before exported template warnings
-#    pragma warning(disable : 4910)
-#  endif
+#  pragma warning(disable : 4910)
 #endif
 
 // PARQUET-1085
@@ -172,8 +170,6 @@ void ThrowNotOk(StatusReturnBlock&& b) {
 
 }  // namespace parquet
 
-#if defined(_WIN32) || defined(__CYGWIN__)
-#  if defined(_MSC_VER)
-#    pragma warning(pop)
-#  endif
+#if defined(_MSC_VER)
+#  pragma warning(pop)
 #endif

--- a/cpp/src/parquet/exception.h
+++ b/cpp/src/parquet/exception.h
@@ -99,7 +99,7 @@
 
 namespace parquet {
 
-class ParquetException : public std::exception {
+class PARQUET_EXPORT ParquetException : public std::exception {
  public:
   PARQUET_NORETURN static void EofException(const std::string& msg = "") {
     static std::string prefix = "Unexpected end of stream";

--- a/cpp/src/parquet/exception.h
+++ b/cpp/src/parquet/exception.h
@@ -26,7 +26,7 @@
 #include "arrow/util/string_util.h"
 #include "parquet/platform.h"
 
-#if defined(_MSC_VER)
+#ifdef _MSC_VER
 #  pragma warning(push)
 // Disable warning for STL types usage in DLL interface
 // https://web.archive.org/web/20130317015847/http://connect.microsoft.com/VisualStudio/feedback/details/696593/vc-10-vs-2010-basic-string-exports
@@ -170,6 +170,6 @@ void ThrowNotOk(StatusReturnBlock&& b) {
 
 }  // namespace parquet
 
-#if defined(_MSC_VER)
+#ifdef _MSC_VER
 #  pragma warning(pop)
 #endif

--- a/cpp/src/parquet/exception.h
+++ b/cpp/src/parquet/exception.h
@@ -84,7 +84,7 @@
 
 namespace parquet {
 
-class ParquetException : public std::exception {
+class PARQUET_EXPORT ParquetException : public std::exception {
  public:
   PARQUET_NORETURN static void EofException(const std::string& msg = "") {
     static std::string prefix = "Unexpected end of stream";

--- a/cpp/src/parquet/hasher.h
+++ b/cpp/src/parquet/hasher.h
@@ -22,7 +22,7 @@
 
 namespace parquet {
 // Abstract class for hash
-class Hasher {
+class PARQUET_EXPORT Hasher {
  public:
   /// Compute hash for 32 bits value by using its plain encoding result.
   ///

--- a/cpp/src/parquet/platform.h
+++ b/cpp/src/parquet/platform.h
@@ -111,8 +111,6 @@ std::shared_ptr<ResizableBuffer> AllocateBuffer(
 
 }  // namespace parquet
 
-#if defined(_WIN32) || defined(__CYGWIN__)
-#  if defined(_MSC_VER)
-#    pragma warning(pop)
-#  endif
+#if defined(_MSC_VER)
+#  pragma warning(pop)
 #endif

--- a/cpp/src/parquet/platform.h
+++ b/cpp/src/parquet/platform.h
@@ -110,3 +110,9 @@ std::shared_ptr<ResizableBuffer> AllocateBuffer(
     ::arrow::MemoryPool* pool = ::arrow::default_memory_pool(), int64_t size = 0);
 
 }  // namespace parquet
+
+#if defined(_WIN32) || defined(__CYGWIN__)
+#  if defined(_MSC_VER)
+#    pragma warning(pop)
+#  endif
+#endif

--- a/cpp/src/parquet/platform.h
+++ b/cpp/src/parquet/platform.h
@@ -28,7 +28,7 @@
 
 #if defined(_WIN32) || defined(__CYGWIN__)
 
-#  if defined(_MSC_VER)
+#  ifdef _MSC_VER
 #    pragma warning(push)
 // Disable warning for STL types usage in DLL interface
 // https://web.archive.org/web/20130317015847/http://connect.microsoft.com/VisualStudio/feedback/details/696593/vc-10-vs-2010-basic-string-exports
@@ -111,6 +111,6 @@ std::shared_ptr<ResizableBuffer> AllocateBuffer(
 
 }  // namespace parquet
 
-#if defined(_MSC_VER)
+#ifdef _MSC_VER
 #  pragma warning(pop)
 #endif

--- a/cpp/src/parquet/types.cc
+++ b/cpp/src/parquet/types.cc
@@ -39,6 +39,11 @@
 
 #include "generated/parquet_types.h"
 
+#ifdef _MSC_VER
+// disable warning about inheritance via dominance in the diamond pattern
+#  pragma warning(disable : 4250)
+#endif
+
 using arrow::internal::checked_cast;
 using arrow::util::Codec;
 


### PR DESCRIPTION
### Rationale for this change

The missing pragma is causing warnings downstream see #47099 

### What changes are included in this PR?

* Add the missing `pragma warning(pop)`
* Use `pragma warning(disable : 4250)` explicitly in other `.cc`/`.h`
* Add missing `PARQUET_EXPORT`

### Are these changes tested?

Yes.

### Are there any user-facing changes?

The developer should see less warnings otherwise, no.

* GitHub Issue: #47099