### PR TITLE
GH-45055: [C++][Flight] Update Flight Server RecordBatchStreamImpl to reuse ipc::RecordBatchWriter with custom IpcPayloadWriter instead of manually generating FlightPayload

### DIFF
--- a/cpp/src/arrow/flight/server.cc
+++ b/cpp/src/arrow/flight/server.cc
@@ -316,18 +316,9 @@ class RecordBatchStream::RecordBatchStreamImpl {
         payload->ipc_message.metadata = nullptr;
         return Status::OK();
       }
-      // Check if writer is already initialized.
       if (!writer_) {
-        // Create new writer with the batch's schema
-        auto payload_writer =
-            std::make_unique<ServerRecordBatchPayloadWriter>(&payload_list_);
-        ARROW_ASSIGN_OR_RAISE(
-            writer_, ipc::internal::OpenRecordBatchWriter(std::move(payload_writer),
-                                                          batch->schema(), options_));
-        if (!payload_list_.empty()) {
-          // Drop Schema message we want new Dictionary or RecordBatch messages only.
-          payload_list_.pop_front();
-        }
+        return Status::UnknownError(
+            "Writer should be initialized before reading Next batches");
       }
       // One WriteRecordBatch call might generate multiple payloads, so we
       // need to collect them in a list.

--- a/cpp/src/arrow/flight/server.cc
+++ b/cpp/src/arrow/flight/server.cc
@@ -32,6 +32,7 @@
 #include <thread>
 #include <utility>
 
+#include "arrow/array.h"
 #include "arrow/device.h"
 #include "arrow/flight/transport.h"
 #include "arrow/flight/transport/grpc/grpc_server.h"
@@ -275,138 +276,118 @@ Status FlightServerBase::GetSchema(const ServerCallContext& context,
 
 class RecordBatchStream::RecordBatchStreamImpl {
  public:
+  // Stages of the stream when producing payloads
+  enum class Stage {
+    NEW,          // The stream has been created, but Next has not been called yet
+    DICTIONARY,   // Dictionaries have been collected, and are being sent
+    RECORD_BATCH  // Initial have been sent
+  };
+
   RecordBatchStreamImpl(const std::shared_ptr<RecordBatchReader>& reader,
                         const ipc::IpcWriteOptions& options)
-      : reader_(reader), options_(options) {}
+      : reader_(reader), mapper_(*reader_->schema()), ipc_options_(options) {}
 
   std::shared_ptr<Schema> schema() { return reader_->schema(); }
 
   Status GetSchemaPayload(FlightPayload* payload) {
-    if (!writer_) {
-      // Create the IPC writer on first call
-      auto payload_writer = std::make_unique<ServerRecordBatchPayloadWriter>(
-          &record_batch_payload_, &other_payload_);
-      auto writer_result = ipc::internal::OpenRecordBatchWriter(
-          std::move(payload_writer), reader_->schema(), options_);
-
-      if (!writer_result.ok()) {
-        return writer_result.status();
-      }
-      writer_ = std::move(writer_result).ValueOrDie();
-    }
-
-    // Return the current payload (schema)
-    if (other_payload_.has_value()) {
-      *payload = std::move(other_payload_.value());
-      other_payload_.reset();
-      return Status::OK();
-    }
-    return Status::UnknownError("No schema payload generated");
+    return ipc::GetSchemaPayload(*reader_->schema(), ipc_options_, mapper_,
+                                 &payload->ipc_message);
   }
 
   Status Next(FlightPayload* payload) {
-    if (!writer_) {
-      return Status::Invalid("Writer not initialized");
+    if (stage_ == Stage::NEW) {
+      RETURN_NOT_OK(reader_->ReadNext(&current_batch_));
+      if (!current_batch_) {
+        // Signal that iteration is over
+        payload->ipc_message.metadata = nullptr;
+        return Status::OK();
+      }
+      ARROW_ASSIGN_OR_RAISE(dictionaries_,
+                            ipc::CollectDictionaries(*current_batch_, mapper_));
+      stage_ = Stage::DICTIONARY;
     }
 
-    // If we have record batch payload from a previous call, return it
-    if (record_batch_payload_.has_value()) {
-      *payload = std::move(record_batch_payload_.value());
-      record_batch_payload_.reset();
-      return Status::OK();
+    if (stage_ == Stage::DICTIONARY) {
+      if (dictionary_index_ == static_cast<int>(dictionaries_.size())) {
+        stage_ = Stage::RECORD_BATCH;
+        return ipc::GetRecordBatchPayload(*current_batch_, ipc_options_,
+                                          &payload->ipc_message);
+      } else {
+        return GetNextDictionary(payload);
+      }
     }
 
-    // Read next batch
-    std::shared_ptr<RecordBatch> batch;
-    RETURN_NOT_OK(reader_->ReadNext(&batch));
+    RETURN_NOT_OK(reader_->ReadNext(&current_batch_));
 
-    if (!batch) {
-      // End of stream
-      RETURN_NOT_OK(writer_->Close());
+    // TODO(ARROW-10787): Delta dictionaries
+    if (!current_batch_) {
+      // Signal that iteration is over
       payload->ipc_message.metadata = nullptr;
       return Status::OK();
+    } else {
+      std::vector<std::pair<int64_t, std::shared_ptr<Array>>> new_dictionaries;
+      ARROW_ASSIGN_OR_RAISE(new_dictionaries,
+                            ipc::CollectDictionaries(*current_batch_, mapper_));
+      // Only send dictionaries if there are changes
+      if (ShouldSendDictionaryUpdate(new_dictionaries)) {
+        dictionaries_ = std::move(new_dictionaries);
+        dictionary_index_ = 0;
+        stage_ = Stage::DICTIONARY;
+        return GetNextDictionary(payload);
+      }
+      return ipc::GetRecordBatchPayload(*current_batch_, ipc_options_,
+                                        &payload->ipc_message);
     }
-
-    RETURN_NOT_OK(writer_->WriteRecordBatch(*batch));
-
-    // prioritize other_payload_ for the dictionary payload
-    if (other_payload_.has_value()) {
-      *payload = std::move(other_payload_.value());
-      other_payload_.reset();
-      return Status::OK();
-    } else if (record_batch_payload_.has_value()) {
-      *payload = std::move(record_batch_payload_.value());
-      record_batch_payload_.reset();
-      return Status::OK();
-    }
-
-    return Status::UnknownError("IPC writer didn't produce any payloads");
   }
 
-  Status Close() {
-    if (writer_) {
-      RETURN_NOT_OK(writer_->Close());
-    }
-    return reader_->Close();
-  }
+  Status Close() { return reader_->Close(); }
 
  private:
-  // Simple payload writer that uses two pointers
-  class ServerRecordBatchPayloadWriter : public ipc::internal::IpcPayloadWriter {
-   public:
-    explicit ServerRecordBatchPayloadWriter(
-        std::optional<FlightPayload>* record_batch_payload,
-        std::optional<FlightPayload>* other_payload)
-        : record_batch_payload_(record_batch_payload),
-          other_payload_(other_payload),
-          first_payload_(true) {}
+  Status GetNextDictionary(FlightPayload* payload) {
+    const auto& it = dictionaries_[dictionary_index_++];
+    return ipc::GetDictionaryPayload(it.first, it.second, ipc_options_,
+                                     &payload->ipc_message);
+  }
 
-    Status Start() override { return Status::OK(); }
+  bool ShouldSendDictionaryUpdate(
+      const std::vector<std::pair<int64_t, std::shared_ptr<Array>>>& new_dictionaries) {
+    const auto equal_options = EqualOptions().nans_equal(true);
 
-    Status WritePayload(const ipc::IpcPayload& ipc_payload) override {
-      FlightPayload payload;
-      payload.ipc_message = ipc_payload;
+    for (const auto& pair : new_dictionaries) {
+      int64_t dictionary_id = pair.first;
+      const auto& dictionary_array = pair.second;
+      bool found = false;
+      std::shared_ptr<Array> found_dictionary = nullptr;
 
-      if (first_payload_) {
-        if (ipc_payload.type != ipc::MessageType::SCHEMA) {
-          return Status::Invalid("First IPC message should be schema");
+      for (const auto& dict_pair : dictionaries_) {
+        if (dict_pair.first == dictionary_id) {
+          found = true;
+          found_dictionary = dict_pair.second;
+          break;
         }
-        first_payload_ = false;
       }
-
-      if (payload.ipc_message.type == ipc::MessageType::RECORD_BATCH) {
-        // Store in record batch payload
-        if (record_batch_payload_->has_value()) {
-          return Status::Invalid("Record batch payload already set");
+      if (found) {
+        if (!dictionary_array->Equals(found_dictionary, equal_options)) {
+          // dictionary has changed
+          return true;
         }
-        *record_batch_payload_ = std::move(payload);
-      } else if (payload.ipc_message.type == ipc::MessageType::DICTIONARY_BATCH ||
-                 payload.ipc_message.type == ipc::MessageType::SCHEMA) {
-        // Store in other payload
-        if (other_payload_->has_value()) {
-          return Status::Invalid("Other payload already set");
-        }
-        *other_payload_ = std::move(payload);
       } else {
-        return Status::Invalid(
-            "Only RECORD_BATCH, DICTIONARY_BATCH, and SCHEMA messages are supported");
+        // New dictionary
+        return true;
       }
-      return Status::OK();
     }
+    return false;
+  }
 
-    Status Close() override { return Status::OK(); }
-
-   private:
-    std::optional<FlightPayload>* record_batch_payload_;
-    std::optional<FlightPayload>* other_payload_;
-    bool first_payload_;
-  };
-
+  Stage stage_ = Stage::NEW;
   std::shared_ptr<RecordBatchReader> reader_;
-  ipc::IpcWriteOptions options_;
-  std::unique_ptr<ipc::RecordBatchWriter> writer_;
-  std::optional<FlightPayload> record_batch_payload_;
-  std::optional<FlightPayload> other_payload_;
+  ipc::DictionaryFieldMapper mapper_;
+  ipc::IpcWriteOptions ipc_options_;
+  std::shared_ptr<RecordBatch> current_batch_;
+  std::vector<std::pair<int64_t, std::shared_ptr<Array>>> dictionaries_;
+
+  // Index of next dictionary to send
+  int dictionary_index_ = 0;
 };
 
 FlightMetadataWriter::~FlightMetadataWriter() = default;

--- a/cpp/src/arrow/flight/server.cc
+++ b/cpp/src/arrow/flight/server.cc
@@ -293,13 +293,13 @@ class RecordBatchStream::RecordBatchStreamImpl {
                                                         reader_->schema(), options_));
     }
 
-    // Return the current payload (schema)
-    if (!payload_list_.empty()) {
-      *payload = std::move(payload_list_.front());
-      payload_list_.pop_front();
-      return Status::OK();
+    // Return the expected schema payload.
+    if (payload_list_.empty()) {
+      return Status::UnknownError("No schema payload generated");
     }
-    return Status::UnknownError("No schema payload generated");
+    *payload = std::move(payload_list_.front());
+    payload_list_.pop_front();
+    return Status::OK();
   }
 
   Status Next(FlightPayload* payload) {

--- a/cpp/src/arrow/flight/server.cc
+++ b/cpp/src/arrow/flight/server.cc
@@ -316,12 +316,8 @@ class RecordBatchStream::RecordBatchStreamImpl {
         payload->ipc_message.metadata = nullptr;
         return Status::OK();
       }
-      // Check if writer is already initialized or if schema has changed.
-      // To recreate the writer.
-      if (!writer_ || !batch->schema()->Equals(*reader_->schema())) {
-        if (writer_) {
-          RETURN_NOT_OK(writer_->Close());
-        }
+      // Check if writer is already initialized.
+      if (!writer_) {
         // Create new writer with the batch's schema
         auto payload_writer =
             std::make_unique<ServerRecordBatchPayloadWriter>(&payload_list_);
@@ -329,8 +325,7 @@ class RecordBatchStream::RecordBatchStreamImpl {
             writer_, ipc::internal::OpenRecordBatchWriter(std::move(payload_writer),
                                                           batch->schema(), options_));
         if (!payload_list_.empty()) {
-          // Drop Schema message if it was generated.
-          // We want new Dictionary or RecordBatch messages only.
+          // Drop Schema message we want new Dictionary or RecordBatch messages only.
           payload_list_.pop_front();
         }
       }

--- a/cpp/src/arrow/flight/server.cc
+++ b/cpp/src/arrow/flight/server.cc
@@ -329,9 +329,7 @@ class RecordBatchStream::RecordBatchStreamImpl {
 
     // Check if writer is already initialized or if schema has changed.
     // To recreate the writer.
-    // TODO: Investigate why schema changed is needed for a flight-sql specific test.
     if (!writer_ || !batch->schema()->Equals(*reader_->schema())) {
-      // Close current writer
       if (writer_) {
         RETURN_NOT_OK(writer_->Close());
       }
@@ -376,7 +374,7 @@ class RecordBatchStream::RecordBatchStreamImpl {
   }
 
  private:
-  // Simple payload writer that uses two pointers
+  // Simple payload writer that uses a list of generated payloads.
   class ServerRecordBatchPayloadWriter : public ipc::internal::IpcPayloadWriter {
    public:
     explicit ServerRecordBatchPayloadWriter(std::list<FlightPayload>* payload_list)

--- a/cpp/src/arrow/flight/sql/example/sqlite_tables_schema_batch_reader.cc
+++ b/cpp/src/arrow/flight/sql/example/sqlite_tables_schema_batch_reader.cc
@@ -102,7 +102,10 @@ Status SqliteTablesWithSchemaBatchReader::ReadNext(std::shared_ptr<RecordBatch>*
   std::shared_ptr<Array> schema_array;
   ARROW_RETURN_NOT_OK(schema_builder.Finish(&schema_array));
 
-  ARROW_ASSIGN_OR_RAISE(*batch, first_batch->AddColumn(4, "table_schema", schema_array));
+  std::shared_ptr<Field> schema_field =
+      arrow::field("table_schema", schema_array->type(), false);
+
+  ARROW_ASSIGN_OR_RAISE(*batch, first_batch->AddColumn(4, schema_field, schema_array));
 
   return Status::OK();
 }

--- a/python/pyarrow/tests/test_flight.py
+++ b/python/pyarrow/tests/test_flight.py
@@ -114,10 +114,12 @@ def simple_ints_table():
 
 def simple_dicts_table():
     dict_values = pa.array(["foo", "baz", "quux"], type=pa.utf8())
+    new_dict_values = pa.array(["bar", "qux"], type=pa.utf8())
     data = [
         pa.chunked_array([
             pa.DictionaryArray.from_arrays([1, 0, None], dict_values),
-            pa.DictionaryArray.from_arrays([2, 1], dict_values)
+            pa.DictionaryArray.from_arrays([2, 1], dict_values),
+            pa.DictionaryArray.from_arrays([0, 1], new_dict_values)
         ])
     ]
     return pa.Table.from_arrays(data, names=['some_dicts'])


### PR DESCRIPTION
### Rationale for this change

Currently Dictionary replacement or deltas are not supported in DoGet as seen on the original issue.
We could replicate the `ipc::WriteDictionaries` code but instead of replicating this logic we can also update our flight server `RecordBatchStreamImpl` to reuse `ipc::RecordBatchWriter` and just update the payload to match the flight payload.

### What changes are included in this PR?

Updated logic on `arrow::flight::RecordBatchStream::RecordBatchStreamImpl` to use an `ipc::RecordBatchWriter` and a custom `ipc::IpcPayloadWriter` instead of manually buidling the payloads.

### Are these changes tested?

Yes via CI. Test data for some Python tests has been updated to validate dictionary replacement is working now. On main the updated test fails with:
```python
>               assert data.equals(table)
E               assert False
E                +  where False = equals(pyarrow.Table\nsome_dicts: dictionary<values=string, indices=int64, ordered=0>\n----\nsome_dicts: [  -- dictionary:\n["foo...\n[1,0,null],  -- dictionary:\n["foo","baz","quux"]  -- indices:\n[2,1],  -- dictionary:\n["bar","qux"]  -- indices:\n[0,1]])
E                +    where equals = pyarrow.Table\nsome_dicts: dictionary<values=string, indices=int64, ordered=0>\n----\nsome_dicts: [  -- dictionary:\n["foo...ull],  -- dictionary:\n["foo","baz","quux"]  -- indices:\n[2,1],  -- dictionary:\n["foo","baz","quux"]  -- indices:\n[0,1]].equals

pyarrow/tests/test_flight.py:1319: AssertionError
================================================================================== short test summary info ===================================================================================
FAILED pyarrow/tests/test_flight.py::test_flight_do_get_dicts - assert False
FAILED pyarrow/tests/test_flight.py::test_flight_domain_socket - assert False

```

### Are there any user-facing changes?

No

* GitHub Issue: #45055