### PR TITLE
MINOR: [Docs][R] Add link to book to R README

### DIFF
--- a/r/README.md
+++ b/r/README.md
@@ -92,6 +92,7 @@ API and higher-level access through a dplyr backend and familiar R functions.
 There are a few additional resources that you may find useful for getting started with arrow:
 
 - The official [Arrow R package documentation](https://arrow.apache.org/docs/r/)
+- [Scaling Up With R and Arrow](https://arrowrbook.com)
 - [Arrow for R cheatsheet](https://github.com/apache/arrow/blob/-/r/cheatsheet/arrow-cheatsheet.pdf)
 - [Apache Arrow R Cookbook](https://arrow.apache.org/cookbook/r/index.html)
 - R for Data Science [Chapter on Arrow](https://r4ds.hadley.nz/arrow)


### PR DESCRIPTION
### Rationale for this change

List of resources for more help in README didn't have a link to "Scaling Up With R and Arrow"

### What changes are included in this PR?

Add link to Scaling Up With R and Arrow to R README

### Are these changes tested?

Nope

### Are there any user-facing changes?

Nope