### PR TITLE
GH-47124: [C++][Dataset] Fix DatasetWriter deadlock on concurrent WriteRecordBatch

### DIFF
--- a/cpp/src/arrow/dataset/dataset_writer.cc
+++ b/cpp/src/arrow/dataset/dataset_writer.cc
@@ -54,7 +54,7 @@ class Throttle {
 
   bool Unthrottled() const { return max_value_ <= 0; }
 
-  Future<> Acquire(uint64_t values) {
+  std::optional<Future<>> Acquire(uint64_t values) {
     if (Unthrottled()) {
       return Future<>::MakeFinished();
     }
@@ -64,6 +64,8 @@ class Throttle {
       backpressure_ = Future<>::Make();
     } else {
       current_value_ += values;
+      DCHECK(backpressure_.is_finished());
+      return std::nullopt;
     }
     return backpressure_;
   }
@@ -71,9 +73,6 @@ class Throttle {
   void Release(uint64_t values) {
     if (Unthrottled()) {
       return;
-    }
-    if(current_value_<values){
-      std::cout<<"Release: "<<current_value_<<"<"<<values<<std::endl;
     }
     Future<> to_complete;
     {
@@ -666,7 +665,7 @@ class DatasetWriter::DatasetWriterImpl {
                                                        directory, prefix);
             }));
     std::shared_ptr<DatasetWriterDirectoryQueue> dir_queue = dir_queue_itr->second;
-    Future<> backpressure;
+    std::optional<Future<>> backpressure;
     while (batch) {
       // Keep opening new files until batch is done.
       std::shared_ptr<RecordBatch> remainder;
@@ -685,13 +684,13 @@ class DatasetWriter::DatasetWriterImpl {
       }
       backpressure =
           writer_state_->rows_in_flight_throttle.Acquire(next_chunk->num_rows());
-      if (!backpressure.is_finished()) {
+      if (backpressure) {
         EVENT_ON_CURRENT_SPAN("DatasetWriter::Backpressure::TooManyRowsQueued");
         break;
       }
       if (will_open_file) {
         backpressure = writer_state_->open_files_throttle.Acquire(1);
-        if (!backpressure.is_finished()) {
+        if (backpressure) {
           EVENT_ON_CURRENT_SPAN("DatasetWriter::Backpressure::TooManyOpenFiles");
           writer_state_->rows_in_flight_throttle.Release(next_chunk->num_rows());
           RETURN_NOT_OK(TryCloseLargestFile());
@@ -715,7 +714,8 @@ class DatasetWriter::DatasetWriterImpl {
     }
 
     if (batch) {
-      return backpressure.Then([this, batch, directory, prefix] {
+      DCHECK(backpressure);
+      return backpressure->Then([this, batch, directory, prefix] {
         return DoWriteRecordBatch(batch, directory, prefix);
       });
     }

--- a/cpp/src/arrow/dataset/dataset_writer.cc
+++ b/cpp/src/arrow/dataset/dataset_writer.cc
@@ -22,7 +22,6 @@
 #include <mutex>
 #include <unordered_map>
 #include <unordered_set>
-#include <iostream>
 
 #include "arrow/filesystem/path_util.h"
 #include "arrow/record_batch.h"

--- a/cpp/src/arrow/dataset/dataset_writer.cc
+++ b/cpp/src/arrow/dataset/dataset_writer.cc
@@ -61,12 +61,11 @@ class Throttle {
     if (current_value_ >= max_value_) {
       in_waiting_ = values;
       backpressure_ = Future<>::Make();
-    } else {
-      current_value_ += values;
-      DCHECK(backpressure_.is_finished());
-      return std::nullopt;
+      return backpressure_;
     }
-    return backpressure_;
+    current_value_ += values;
+    DCHECK(backpressure_.is_finished());
+    return std::nullopt;
   }
 
   void Release(uint64_t values) {

--- a/cpp/src/arrow/dataset/dataset_writer.cc
+++ b/cpp/src/arrow/dataset/dataset_writer.cc
@@ -22,6 +22,7 @@
 #include <mutex>
 #include <unordered_map>
 #include <unordered_set>
+#include <iostream>
 
 #include "arrow/filesystem/path_util.h"
 #include "arrow/record_batch.h"
@@ -70,6 +71,9 @@ class Throttle {
   void Release(uint64_t values) {
     if (Unthrottled()) {
       return;
+    }
+    if(current_value_<values){
+      std::cout<<"Release: "<<current_value_<<"<"<<values<<std::endl;
     }
     Future<> to_complete;
     {

--- a/cpp/src/arrow/dataset/dataset_writer_test.cc
+++ b/cpp/src/arrow/dataset/dataset_writer_test.cc
@@ -20,7 +20,6 @@
 #include <chrono>
 #include <mutex>
 #include <optional>
-#include <random>
 #include <thread>
 #include <vector>
 

--- a/cpp/src/arrow/dataset/dataset_writer_test.cc
+++ b/cpp/src/arrow/dataset/dataset_writer_test.cc
@@ -277,6 +277,9 @@ TEST_F(DatasetWriterTestFixture, BatchGreaterThanMaxRowsQueued) {
 }
 
 TEST_F(DatasetWriterTestFixture, BatchWriteConcurrent) {
+#ifndef ARROW_ENABLE_THREADING
+  GTEST_SKIP() << "Test requires threading support";
+#endif
   auto dataset_writer = MakeDatasetWriter(/*max_rows=*/5);
 
   for (int threads = 1; threads < 5; threads++) {

--- a/cpp/src/arrow/dataset/dataset_writer_test.cc
+++ b/cpp/src/arrow/dataset/dataset_writer_test.cc
@@ -280,32 +280,30 @@ TEST_F(DatasetWriterTestFixture, BatchGreaterThanMaxRowsQueued) {
 #pragma GCC push_options
 #pragma GCC optimize ("O0")
 TEST_F(DatasetWriterTestFixture, BatchWriteConcurrent) {
-  auto dataset_writer = MakeDatasetWriter(/*max_rows=*/200);
+  auto dataset_writer = MakeDatasetWriter(/*max_rows=*/5);
 
-  
-  for(int threads=20;threads>1;threads--){
-    for(int iter=2;iter<100;iter*=2){
-      for(int batch=2;batch<5000;batch*=2){
-        std::cout<<threads<<" "<<iter<<" "<<batch<<std::endl;
+
+  for(int threads=1;threads<5;threads++){
+    for(int iter=2;iter<=256;iter*=2){
+      for(int batch=2;batch<=64;batch*=2){
         std::vector<std::thread> workers;
         for(int i=0;i<threads;++i){
           workers.push_back(std::thread(
-          [&](){
+          [&,i=i](){
             for(int j=0;j<iter;++j){
               while(paused_){SleepABit();};
-              dataset_writer->WriteRecordBatch(MakeBatch(batch/threads), "");
+              dataset_writer->WriteRecordBatch(MakeBatch(batch+i+10*j), "");
             }
           }));
         }
         for (std::thread &t: workers) {
           if (t.joinable()) {
             t.join();
-          }      
+          }
           while(paused_){SleepABit();};
         }
       }
     }
-
   }
   EndWriterChecked(dataset_writer.get());
   ASSERT_EQ(paused_, false);

--- a/cpp/src/arrow/dataset/dataset_writer_test.cc
+++ b/cpp/src/arrow/dataset/dataset_writer_test.cc
@@ -277,8 +277,6 @@ TEST_F(DatasetWriterTestFixture, BatchGreaterThanMaxRowsQueued) {
   ASSERT_EQ(paused_, false);
 }
 
-#pragma GCC push_options
-#pragma GCC optimize("O0")
 TEST_F(DatasetWriterTestFixture, BatchWriteConcurrent) {
   auto dataset_writer = MakeDatasetWriter(/*max_rows=*/5);
 
@@ -310,7 +308,6 @@ TEST_F(DatasetWriterTestFixture, BatchWriteConcurrent) {
   EndWriterChecked(dataset_writer.get());
   ASSERT_EQ(paused_, false);
 }
-#pragma GCC pop_options
 
 TEST_F(DatasetWriterTestFixture, MaxRowsOneWrite) {
   write_options_.max_rows_per_file = 10;

--- a/cpp/src/arrow/dataset/dataset_writer_test.cc
+++ b/cpp/src/arrow/dataset/dataset_writer_test.cc
@@ -292,7 +292,7 @@ TEST_F(DatasetWriterTestFixture, BatchWriteConcurrent) {
               while (paused_) {
                 SleepABit();
               }
-              dataset_writer->WriteRecordBatch(MakeBatch(batch + i + 10 * j), "");
+              dataset_writer->WriteRecordBatch(MakeBatch(0, batch + i + 10 * j), "");
             }
           }));
         }

--- a/cpp/src/arrow/dataset/dataset_writer_test.cc
+++ b/cpp/src/arrow/dataset/dataset_writer_test.cc
@@ -233,7 +233,7 @@ class DatasetWriterTestFixture : public testing::Test {
   util::AsyncTaskScheduler* scheduler_;
   Future<> scheduler_finished_;
   FileSystemDatasetWriteOptions write_options_;
-  bool paused_{false};
+  std::atomic_bool paused_{false};
   uint64_t counter_ = 0;
 };
 

--- a/cpp/src/arrow/dataset/dataset_writer_test.cc
+++ b/cpp/src/arrow/dataset/dataset_writer_test.cc
@@ -20,9 +20,9 @@
 #include <chrono>
 #include <mutex>
 #include <optional>
-#include <vector>
 #include <random>
 #include <thread>
+#include <vector>
 
 #include "arrow/array/builder_primitive.h"
 #include "arrow/dataset/file_ipc.h"
@@ -278,29 +278,31 @@ TEST_F(DatasetWriterTestFixture, BatchGreaterThanMaxRowsQueued) {
 }
 
 #pragma GCC push_options
-#pragma GCC optimize ("O0")
+#pragma GCC optimize("O0")
 TEST_F(DatasetWriterTestFixture, BatchWriteConcurrent) {
   auto dataset_writer = MakeDatasetWriter(/*max_rows=*/5);
 
-
-  for(int threads=1;threads<5;threads++){
-    for(int iter=2;iter<=256;iter*=2){
-      for(int batch=2;batch<=64;batch*=2){
+  for (int threads = 1; threads < 5; threads++) {
+    for (int iter = 2; iter <= 256; iter *= 2) {
+      for (int batch = 2; batch <= 64; batch *= 2) {
         std::vector<std::thread> workers;
-        for(int i=0;i<threads;++i){
-          workers.push_back(std::thread(
-          [&,i=i](){
-            for(int j=0;j<iter;++j){
-              while(paused_){SleepABit();};
-              dataset_writer->WriteRecordBatch(MakeBatch(batch+i+10*j), "");
+        for (int i = 0; i < threads; ++i) {
+          workers.push_back(std::thread([&, i = i]() {
+            for (int j = 0; j < iter; ++j) {
+              while (paused_) {
+                SleepABit();
+              }
+              dataset_writer->WriteRecordBatch(MakeBatch(batch + i + 10 * j), "");
             }
           }));
         }
-        for (std::thread &t: workers) {
+        for (std::thread& t : workers) {
           if (t.joinable()) {
             t.join();
           }
-          while(paused_){SleepABit();};
+          while (paused_) {
+            SleepABit();
+          }
         }
       }
     }


### PR DESCRIPTION
### Rationale for this change

Throttle is accessed twice - once in Acquire and again using future. As a result current_value_ may not be increased due to throttle being applied and shorty after the returned future may become finished. That leads to issue described in #47124 
https://github.com/apache/arrow/blob/c8fe26898ce49c58514f511be58afddce176826b/cpp/src/arrow/dataset/dataset_writer.cc#L682-L684

### What changes are included in this PR?

Change throttle API to return optional (akin to [ThrottledAsyncTaskScheduler ::Throttle](https://github.com/gitmodimo/arrow/blob/3ebe7ee1828793d0a619bcd773eb4d990ccb6b3c/cpp/src/arrow/util/async_util.h#L243)) and prevent race.

### Are these changes tested?

Yes

### Are there any user-facing changes?

No

* GitHub Issue: #47124