### PR TITLE
GH-47131: [C#] Fix day off by 1 in Date64Array

### DIFF
--- a/csharp/src/Apache.Arrow/Arrays/Date64Array.cs
+++ b/csharp/src/Apache.Arrow/Arrays/Date64Array.cs
@@ -65,12 +65,7 @@ namespace Apache.Arrow
 
             protected override long Convert(DateTimeOffset dateTimeOffset)
             {
-                // The internal value stored for a DateTimeOffset can be thought of as the number of milliseconds,
-                // in multiples of 86400000, that have passed since the UNIX epoch.  It is not the same as what would
-                // result from encoding the date from the DateTimeOffset.Date property.
-                long millis = dateTimeOffset.ToUnixTimeMilliseconds();
-                long days = millis / MillisecondsPerDay;
-                return (millis < 0 ? days - 1 : days) * MillisecondsPerDay;
+                return new DateTimeOffset(dateTimeOffset.UtcDateTime.Date, TimeSpan.Zero).ToUnixTimeMilliseconds();
             }
 
 #if NET6_0_OR_GREATER

--- a/csharp/test/Apache.Arrow.Tests/TestDateAndTimeData.cs
+++ b/csharp/test/Apache.Arrow.Tests/TestDateAndTimeData.cs
@@ -36,7 +36,7 @@ namespace Apache.Arrow.Tests
 
         private static readonly TimeSpan[] _exampleTimes =
         {
-            new TimeSpan(0, 0, 1), new TimeSpan(12, 0, 0), new TimeSpan(23, 59, 59),
+            new TimeSpan(0, 0, 0), new TimeSpan(0, 0, 1), new TimeSpan(12, 0, 0), new TimeSpan(23, 59, 59),
         };
 
         private static readonly DateTimeKind[] _exampleKinds =


### PR DESCRIPTION
### Rationale for this change
`Date64Array.Convert(DateTimeOffset)` substracts one day on date times that are at 00:00 am and < 1970.
For example, 01/01/1969 00:00:00 gets converted to 12/31/1968 whereas the expected result is 01/01/1969.

### What changes are included in this PR?
Fix to the described bug.

### Are these changes tested?
Yes

### Are there any user-facing changes?
No

**This PR contains a "Critical Fix".** 
* GitHub Issue: #47131