### PR TITLE
MINOR: [Release] Minor updates to post-release scripts

### DIFF
--- a/dev/release/post-13-homebrew.sh
+++ b/dev/release/post-13-homebrew.sh
@@ -42,7 +42,7 @@ git fetch --all --prune --tags --force
 
 branch=apache-arrow-${version}
 echo "Creating branch: ${branch}"
-git checkout master
+git checkout main
 git branch -D ${branch} || :
 git checkout -b ${branch}
 

--- a/dev/release/post-15-conan.sh
+++ b/dev/release/post-15-conan.sh
@@ -64,15 +64,20 @@ sha256sum=$(curl \
               cut -d' ' -f1)
 sed \
   -i.bak \
-  -e "1a\ \ \"${version}\":" \
-  -e "1a\ \ \ \ folder:\ all" \
+  -e "1a\\
+\  \"${version}\":" \
+  -e "1a\\
+\    folder:\ all" \
   ${recipes_arrow}/config.yml
 rm ${recipes_arrow}/config.yml.bak
 sed \
   -i.bak \
-  -e "1a\ \ \"${version}\":" \
-  -e "1a\ \ \ \ url: \"${tar_gz_url}\"" \
-  -e "1a\ \ \ \ sha256: \"${sha256sum}\"" \
+  -e "1a\\
+\  \"${version}\":" \
+  -e "1a\\
+\    url: \"${tar_gz_url}\"" \
+  -e "1a\\
+\    sha256: \"${sha256sum}\"" \
   ${recipes_arrow}/all/conandata.yml
 rm ${recipes_arrow}/all/conandata.yml.bak
 git add ${recipes_arrow}/config.yml

--- a/dev/release/post-15-conan.sh
+++ b/dev/release/post-15-conan.sh
@@ -62,13 +62,21 @@ sha256sum=$(curl \
               --location \
               "https://www.apache.org/dyn/closer.lua?action=download&filename=arrow/arrow-${version}/apache-arrow-${version}.tar.gz.sha256" | \
               cut -d' ' -f1)
-sed \
+
+# Use gsed on macOS and sed otherwise
+if [ "$(uname)" == "Darwin" ]; then
+  SED_BIN_NAME <- "gsed"
+else
+  SED_BIN_NAME <- "sed"
+fi
+
+SED_BIN_NAME \
   -i.bak \
   -e "1a\ \ \"${version}\":" \
   -e "1a\ \ \ \ folder:\ all" \
   ${recipes_arrow}/config.yml
 rm ${recipes_arrow}/config.yml.bak
-sed \
+SED_BIN_NAME \
   -i.bak \
   -e "1a\ \ \"${version}\":" \
   -e "1a\ \ \ \ url: \"${tar_gz_url}\"" \

--- a/dev/release/post-15-conan.sh
+++ b/dev/release/post-15-conan.sh
@@ -62,21 +62,13 @@ sha256sum=$(curl \
               --location \
               "https://www.apache.org/dyn/closer.lua?action=download&filename=arrow/arrow-${version}/apache-arrow-${version}.tar.gz.sha256" | \
               cut -d' ' -f1)
-
-# Use gsed on macOS and sed otherwise
-if [ "$(uname)" == "Darwin" ]; then
-  SED_BIN_NAME <- "gsed"
-else
-  SED_BIN_NAME <- "sed"
-fi
-
-SED_BIN_NAME \
+sed \
   -i.bak \
   -e "1a\ \ \"${version}\":" \
   -e "1a\ \ \ \ folder:\ all" \
   ${recipes_arrow}/config.yml
 rm ${recipes_arrow}/config.yml.bak
-SED_BIN_NAME \
+sed \
   -i.bak \
   -e "1a\ \ \"${version}\":" \
   -e "1a\ \ \ \ url: \"${tar_gz_url}\"" \


### PR DESCRIPTION
### Rationale for this change

Just doing some maintenance on post-release scripts.

### What changes are included in this PR?

Updates two of our release scripts to make them work correctly.

1. post-13-homebrew.sh: Homebrew changed their default branch to main recently, see https://github.com/Homebrew/homebrew-core/pull/228218.
2. post-15-conan.sh: Makes the sed usage portable so it runs equally well on macOS.

### Are these changes tested?

Yes. I ran them myself during the 21.0.0 post-release tasks.

### Are there any user-facing changes?

No.