### PR TITLE
GH-46374: [Python][Doc] Improve docs to specify that source argument on parquet.read_table can also be a list of strings

### DIFF
--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -1679,10 +1679,11 @@ _read_table_docstring = """
 
 Parameters
 ----------
-source : str, pyarrow.NativeFile, or file-like object
-    If a string passed, can be a single file name or directory name. For
-    file-like objects, only read a single file. Use pyarrow.BufferReader to
-    read a file contained in a bytes or buffer-like object.
+source : str, list of str, pyarrow.NativeFile, or file-like object
+    If a string is passed, can be a single file name or directory name. If a
+    list of strings is passed, should be file names. For file-like objects,
+    only read a single file. Use pyarrow.BufferReader to read a file contained
+    in a bytes or buffer-like object.
 columns : list
     If not None, only these columns will be read from the file. A column
     name may be a prefix of a nested field, e.g. 'a' will select 'a.b',


### PR DESCRIPTION
See #46374

### What changes are included in this PR?

The docstring for `parquet.read_table` doesn't specify that the source can be a list of strings:
This is regarding the change for _read_table_docstring which source can be a list of string as well
### Are there any user-facing changes?

Only docs changed.
* GitHub Issue: #46374