### PR TITLE
GH-47143: [Dev] Ignore `apache-arrow.tar.gz`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,7 @@
 # under the License.
 
 apache-rat-*.jar
-arrow-src.tar
-arrow-src.tar.gz
+apache-arrow.tar.gz
 
 # Compiled source
 *.a


### PR DESCRIPTION
### Rationale for this change
The `Rat` check was changed in https://github.com/apache/arrow/pull/46541, but didn't update the corresponding `.gitignore`.

### What changes are included in this PR?
Explicitly ignore `apache-arrow.tar.gz` so that someone who need to fix licence headers doesn't accidentally commit the tar file.

### Are these changes tested?
Locally yes.

### Are there any user-facing changes?
No.

* GitHub Issue: #47143