### PR TITLE
GH-47153: [Docs][C++] Update cmake target table in build_system.rst with newly added targets

### DIFF
--- a/docs/source/cpp/build_system.rst
+++ b/docs/source/cpp/build_system.rst
@@ -118,6 +118,10 @@ This is the list of available ones and the respective targets created:
 +===============================================+========================================================+=====================================================+
 | ``find_package(ArrowCUDA REQUIRED)``          | ``ArrowCUDA::arrow_cuda_shared``                       | ``ArrowCUDA::arrow_cuda_static``                    |
 +-----------------------------------------------+--------------------------------------------------------+-----------------------------------------------------+
+| ``find_package(ArrowAcero REQUIRED)``         | ``ArrowAcero::arrow_acero_shared``                     | ``ArrowAcero::arrow_acero_static``                  |
++-----------------------------------------------+--------------------------------------------------------+-----------------------------------------------------+
+| ``find_package(ArrowCompute REQUIRED)``       | ``ArrowCompute::arrow_compute_shared``                 | ``ArrowCompute::arrow_compute_static``              |
++-----------------------------------------------+--------------------------------------------------------+-----------------------------------------------------+
 | ``find_package(ArrowDataset REQUIRED)``       | ``ArrowDataset::arrow_dataset_shared``                 | ``ArrowDataset::arrow_dataset_static``              |
 +-----------------------------------------------+--------------------------------------------------------+-----------------------------------------------------+
 | ``find_package(ArrowFlight REQUIRED)``        | ``ArrowFlight::arrow_flight_shared``                   | ``ArrowFlight::arrow_flight_static``                |


### PR DESCRIPTION
### Rationale for this change

We were missing documentation for some of the newer CMake packages and targets we've split out. This adds documentation for those (acero, compute).

### What changes are included in this PR?

- Updates the table in build_system.rst to include ArrowAcero and ArrowCompute

### Are these changes tested?

No, will render in CI though for others to see.

### Are there any user-facing changes?

No.
* GitHub Issue: #47153