### PR TITLE
MINOR: [Release] Fix issue in post-14-vcpkg.sh causing x-add-version to fail

### DIFF
--- a/dev/release/post-14-vcpkg.sh
+++ b/dev/release/post-14-vcpkg.sh
@@ -61,16 +61,29 @@ sha512sum=$(curl \
               --location \
               "https://www.apache.org/dyn/closer.lua?action=download&filename=arrow/arrow-${version}/apache-arrow-${version}.tar.gz.sha512" | \
               cut -d' ' -f1)
+
+# update "version"
 sed \
   -i.bak \
   -e "s/^  \"version\": \".*\",$/  \"version\": \"${version}\",/" \
   ${port_arrow}/vcpkg.json
 rm ${port_arrow}/vcpkg.json.bak
+
+# remove "port-version"
+# if we don't remove this, x-add-version fails
+sed \
+  -i.bak \
+  -e "/^.*\"port-version\":.*$/d" \
+  ${port_arrow}/vcpkg.json
+rm ${port_arrow}/vcpkg.json.bak
+
+# update portfile
 sed \
   -i.bak \
   -e "s/^    SHA512 .*$/    SHA512 ${sha512sum}/" \
   ${port_arrow}/portfile.cmake
 rm ${port_arrow}/portfile.cmake.bak
+
 git add ${port_arrow}/vcpkg.json
 git add ${port_arrow}/portfile.cmake
 git commit -m "[arrow] Update to ${version}"


### PR DESCRIPTION
### Rationale for this change

I ran into this running post-14-vcpkg.sh for the 21.0.0 release in https://github.com/microsoft/vcpkg/pull/46477#pullrequestreview-3036678763. If "port-version" exists in vcpkg.json, x-add-version fails with,

```
warning: In arrow, 21.0.0 is a completely new version, so there should be no "port-version". Remove "port-version" and try again. To skip this check, rerun with --skip-version-format-check .
```

This looks like a warning but it's actually a hard error and will cause your upstream PR to bounce.

### What changes are included in this PR?

The script now removes the "port-version" field by default. I think the reason this worked sometimes and not others was because the field is supposed to be absent when 0 and it's usually 0 so our scripts don't need to update it.

### Are these changes tested?

Yes. Locally.

### Are there any user-facing changes?

No.
