### PR TITLE
MINOR: [Release] Make post-11-bump-versions.sh work on macOS

### DIFF
--- a/dev/release/post-11-bump-versions.sh
+++ b/dev/release/post-11-bump-versions.sh
@@ -53,7 +53,19 @@ esac
 
 if [ ${BUMP_UPDATE_LOCAL_DEFAULT_BRANCH} -gt 0 ]; then
   echo "Updating local default branch"
-  git fetch --all --prune --tags --force -j$(nproc)
+  case "$(uname)" in
+    Linux)
+      n_jobs=$(nproc)
+      ;;
+    Darwin)
+      n_jobs=$(sysctl -n hw.ncpu)
+      ;;
+    *)
+      n_jobs=${NPROC:-0} # see git-config, 0 means "reasonable default"
+      ;;
+  esac
+
+  git fetch --all --prune --tags --force -j"$n_jobs"
   git checkout ${DEFAULT_BRANCH}
   git rebase apache/${DEFAULT_BRANCH}
 fi


### PR DESCRIPTION
### Rationale for this change

The script doesn't run out of the box on macOS. since `nproc` is not available.

### What changes are included in this PR?

Makes the determination of the number of jobs dynamic and platform-specific.

### Are these changes tested?

On macOS, yes.

### Are there any user-facing changes?

No.