### PR TITLE
MINOR: [Python][Docs] Fix typo in types.pxi

### DIFF
--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -4198,7 +4198,7 @@ def timestamp(unit, tz=None):
         one of 's' [second], 'ms' [millisecond], 'us' [microsecond], or 'ns'
         [nanosecond]
     tz : str, default None
-        Time zone name. None indicates time zone naive
+        Time zone name. None indicates time zone native
 
     Examples
     --------


### PR DESCRIPTION
naive  -> native

### Rationale for this change

naive timezone does not make sense. It should be native timezone.

### What changes are included in this PR?

typo fix

### Are these changes tested?

No test needed.

### Are there any user-facing changes?

Yes, documentation.
