### PR TITLE
GH-47162: [Dev][Release][GLib] Fix indent in generate-version-header.py

### DIFF
--- a/c_glib/tool/generate-version-header.py
+++ b/c_glib/tool/generate-version-header.py
@@ -140,7 +140,7 @@ def generate_availability_macros(library: str) -> str:
 
 
 ALL_VERSIONS = [
-        (22, 0),
+    (22, 0),
     (21, 0),
     (20, 0),
     (19, 0),

--- a/dev/release/post-11-bump-versions-test.rb
+++ b/dev/release/post-11-bump-versions-test.rb
@@ -291,7 +291,7 @@ class PostBumpVersionsTest < Test::Unit::TestCase
           {
             path: "c_glib/tool/generate-version-header.py",
             hunks: [
-              ["+        (#{@next_major_version}, 0),"],
+              ["+    (#{@next_major_version}, 0),"],
             ],
           },
           {

--- a/dev/release/utils-prepare.sh
+++ b/dev/release/utils-prepare.sh
@@ -49,7 +49,7 @@ update_versions() {
      [ "${next_version}" = "${major_version}.0.0" ] && \
      ! grep -q -F "(${major_version}, 0)" tool/generate-version-header.py; then
     sed -i.bak -E -e \
-      "s/^ALL_VERSIONS = \[$/&\\n        (${major_version}, 0),/" \
+      "s/^ALL_VERSIONS = \[$/&\\n    (${major_version}, 0),/" \
       tool/generate-version-header.py
     rm -f tool/generate-version-header.py.bak
     git add tool/generate-version-header.py


### PR DESCRIPTION
### Rationale for this change

GH-46552 changed indent size used in `c_glib/tool/generate-version-header.py` but we forgot to update `dev/release/utils-prepare.sh`.

### What changes are included in this PR?

* Fix indent of auto generate code in `dev/release/utils-prepare.sh`
* Fix indent of auto generated code in `c_glib/tool/generate-version-header.py`

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #47162