### PR TITLE
GH-47165: [Python] Update s3 test with new non-existent bucket

### DIFF
--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -1900,8 +1900,9 @@ def test_s3_real_aws_region_selection():
     # Reading from the wrong region may still work for public buckets...
 
     # Nonexistent bucket (hopefully, otherwise need to fix this test)
+    # Increment by one if someone decides to create this bucket.
     with pytest.raises(IOError, match="Bucket '.*' not found"):
-        FileSystem.from_uri('s3://x-arrow-nonexistent-bucket')
+        FileSystem.from_uri('s3://x-arrow-nonexistent-bucket-1')
     fs, path = FileSystem.from_uri('s3://x-arrow-nonexistent-bucket?region=us-east-3')
     assert fs.region == 'us-east-3'
 

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -1899,10 +1899,12 @@ def test_s3_real_aws_region_selection():
     assert fs.region == 'us-east-2'
     # Reading from the wrong region may still work for public buckets...
 
-    # Nonexistent bucket (hopefully, otherwise need to fix this test)
-    # Increment by one if someone decides to create this bucket.
+    # Nonexistent bucket. This bucket can't exist as AWS imposes that
+    # Bucket names must not contain two adjacent periods.
+    # Hopefully this won't fail in the future if a new validation rule applies.
+    # See: https://github.com/apache/arrow/pull/47166
     with pytest.raises(IOError, match="Bucket '.*' not found"):
-        FileSystem.from_uri('s3://x-arrow-nonexistent-bucket-1')
+        FileSystem.from_uri('s3://x-arrow..nonexistent-bucket')
     fs, path = FileSystem.from_uri('s3://x-arrow-nonexistent-bucket?region=us-east-3')
     assert fs.region == 'us-east-3'
 


### PR DESCRIPTION
### Rationale for this change

Tests are failing because the bucket exists now.

### What changes are included in this PR?

Update bucket name to non-existing bucket so it raises the expected exception again.

### Are these changes tested?

Yes

### Are there any user-facing changes?

No

* GitHub Issue: #47165