### PR TITLE
GH-47053: [C++] Stricter data validation on Run-end encoded

### DIFF
--- a/cpp/src/arrow/util/ree_util.cc
+++ b/cpp/src/arrow/util/ree_util.cc
@@ -196,9 +196,10 @@ Status ValidateRunEndEncodedChildren(const RunEndEncodedType& type,
     return Status::Invalid("Null count must be 0 for run ends array, but is ",
                            run_ends_data->GetNullCount());
   }
-  if (run_ends_data->length > values_data->length) {
-    return Status::Invalid("Length of run_ends is greater than the length of values: ",
-                           run_ends_data->length, " > ", values_data->length);
+  if (run_ends_data->length != values_data->length) {
+    return Status::Invalid("Length of run_ends (", run_ends_data->length,
+                           ") does not match the length of values (", values_data->length,
+                           ")");
   }
   if (run_ends_data->length == 0) {
     if (logical_length == 0) {


### PR DESCRIPTION
## TBD
Still under clarification on the issue

### Rationale for this change

Stricter validation on Run-end encoded could help identify some programming errors as the one found on https://github.com/apache/arrow/issues/47029

### What changes are included in this PR?

When doing REE validation ensure equality between `run_ends_data->length` and `values_data->length`

### Are these changes tested?

Yes

### Are there any user-facing changes?

No

* GitHub Issue: #47053