### PR TITLE
GH-47137: [Python] Switch to `[dependency-groups]`

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -56,7 +56,7 @@ Documentation = "https://arrow.apache.org/docs/python"
 Repository = "https://github.com/apache/arrow"
 Issues = "https://github.com/apache/arrow/issues"
 
-[project.optional-dependencies]
+[dependency-groups]
 test = [
     'pytest',
     'hypothesis',


### PR DESCRIPTION
### Rationale for this change
Modern packaging requires non-user facing dependencies to be placed in a `dependency-groups` as per [PEP 735](https://peps.python.org/pep-0735.)

### What changes are included in this PR?
Changes the `project.optional-dependencies` to `dependency-groups`.

### Are these changes tested?
Not locally yet. I've tried searching for use of the word `test`. Obviously this comes up a lot in the code base, so testing in CI here.

### Are there any user-facing changes?
Not really, no. The only difference is people would have to do `pip install --group test pyarrow` rather than `pip install pyarrow[test]`.
* GitHub Issue: #47137