### PR TITLE
GH-47075: [Release][Dev] Use GH_TOKEN as GitHub token environment variable

### DIFF
--- a/.github/workflows/comment_bot.yml
+++ b/.github/workflows/comment_bot.yml
@@ -49,7 +49,7 @@ jobs:
         run: pip install -e arrow/dev/archery[bot]
       - name: Handle GitHub comment event
         env:
-          ARROW_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CROSSBOW_GITHUB_TOKEN: ${{ secrets.CROSSBOW_GITHUB_TOKEN }}
         run: |
           archery --debug trigger-bot \

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -107,10 +107,9 @@ jobs:
           gem install test-unit
           pip install "cython>=3" setuptools pytest requests setuptools-scm
       - name: Run Release Test
-        env:
-          ARROW_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: |
+          echo "GH_TOKEN=${{ secrets.GITHUB_TOKEN }}" > dev/release/.env
           ci/scripts/release_test.sh $(pwd)
       - name: Run Merge Script Test
         shell: bash

--- a/.github/workflows/pr_bot.yml
+++ b/.github/workflows/pr_bot.yml
@@ -89,7 +89,7 @@ jobs:
         run: pip install -e arrow/dev/archery[bot]
       - name: Handle PR workflow event
         env:
-          ARROW_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           if [ "${GITHUB_EVENT_NAME}" = "workflow_run" ]; then
             # workflow_run is executed on PR review. Update to original event.

--- a/dev/README.md
+++ b/dev/README.md
@@ -56,7 +56,7 @@ for configuring your tokens: environment variables or a configuration file.
 #### Pass tokens via Environment Variables
 
 The merge script uses the GitHub REST API. You must set a
-`ARROW_GITHUB_API_TOKEN` environment variable to use a
+`GH_TOKEN` environment variable to use a
 [Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token).
 You need to add `workflow` scope to the Personal Access Token.
 

--- a/dev/archery/archery/bot.py
+++ b/dev/archery/archery/bot.py
@@ -359,7 +359,7 @@ def _clone_arrow_and_crossbow(dest, crossbow_repo, arrow_repo_url, pr_number):
     git.clone(crossbow_url, str(queue_path))
 
     # 3. initialize crossbow objects
-    github_token = os.environ['CROSSBOW_GITHUB_TOKEN']
+    github_token = os.environ.get('GH_TOKEN', os.environ['CROSSBOW_GITHUB_TOKEN'])
     arrow = Repo(arrow_path)
     queue = Queue(queue_path, github_token=github_token, require_https=True)
 

--- a/dev/archery/archery/bot.py
+++ b/dev/archery/archery/bot.py
@@ -359,7 +359,7 @@ def _clone_arrow_and_crossbow(dest, crossbow_repo, arrow_repo_url, pr_number):
     git.clone(crossbow_url, str(queue_path))
 
     # 3. initialize crossbow objects
-    github_token = os.environ.get('GH_TOKEN', os.environ['CROSSBOW_GITHUB_TOKEN'])
+    github_token = os.environ.get('CROSSBOW_GITHUB_TOKEN', os.environ['GH_TOKEN'])
     arrow = Repo(arrow_path)
     queue = Queue(queue_path, github_token=github_token, require_https=True)
 

--- a/dev/archery/archery/cli.py
+++ b/dev/archery/archery/cli.py
@@ -815,7 +815,7 @@ def integration(with_all=False, random_seed=12345, **args):
 
 
 @archery.command()
-@click.option('--arrow-token', envvar='ARROW_GITHUB_TOKEN',
+@click.option('--arrow-token', envvar=['GH_TOKEN', 'ARROW_GITHUB_TOKEN'],
               help='OAuth token for responding comment in the arrow repo')
 @click.option('--committers-file', '-c', type=click.File('r', encoding='utf8'))
 @click.option('--event-name', '-n', required=True)

--- a/dev/archery/archery/crossbow/cli.py
+++ b/dev/archery/archery/crossbow/cli.py
@@ -35,7 +35,7 @@ _default_config_path = _default_arrow_path / "dev" / "tasks" / "tasks.yml"
 
 @click.group()
 @click.option('--github-token', '-t', default=None,
-              envvar=['GH_TOKEN', 'CROSSBOW_GITHUB_TOKEN'],
+              envvar=['CROSSBOW_GITHUB_TOKEN', 'GH_TOKEN'],
               help='OAuth token for GitHub authentication')
 @click.option('--arrow-path', '-a',
               type=click.Path(), default=_default_arrow_path,

--- a/dev/archery/archery/crossbow/cli.py
+++ b/dev/archery/archery/crossbow/cli.py
@@ -35,7 +35,7 @@ _default_config_path = _default_arrow_path / "dev" / "tasks" / "tasks.yml"
 
 @click.group()
 @click.option('--github-token', '-t', default=None,
-              envvar="CROSSBOW_GITHUB_TOKEN",
+              envvar=['GH_TOKEN', 'CROSSBOW_GITHUB_TOKEN'],
               help='OAuth token for GitHub authentication')
 @click.option('--arrow-path', '-a',
               type=click.Path(), default=_default_arrow_path,

--- a/dev/archery/archery/crossbow/core.py
+++ b/dev/archery/archery/crossbow/core.py
@@ -291,7 +291,7 @@ class Repo:
         if github_token is None:
             raise RuntimeError(
                 'Could not determine GitHub token. Please set the '
-                'CROSSBOW_GITHUB_TOKEN environment variable to a '
+                'CROSSBOW_GITHUB_TOKEN or GH_TOKEN environment variable to a '
                 'valid GitHub access token or pass one to --github-token.'
             )
         callbacks = GitRemoteCallbacks(github_token)

--- a/dev/archery/archery/crossbow/core.py
+++ b/dev/archery/archery/crossbow/core.py
@@ -291,7 +291,7 @@ class Repo:
         if github_token is None:
             raise RuntimeError(
                 'Could not determine GitHub token. Please set the '
-                'CROSSBOW_GITHUB_TOKEN or GH_TOKEN environment variable to a '
+                'GH_TOKEN or CROSSBOW_GITHUB_TOKEN environment variable to a '
                 'valid GitHub access token or pass one to --github-token.'
             )
         callbacks = GitRemoteCallbacks(github_token)

--- a/dev/archery/archery/crossbow/core.py
+++ b/dev/archery/archery/crossbow/core.py
@@ -291,7 +291,7 @@ class Repo:
         if github_token is None:
             raise RuntimeError(
                 'Could not determine GitHub token. Please set the '
-                'GH_TOKEN or CROSSBOW_GITHUB_TOKEN environment variable to a '
+                'CROSSBOW_GITHUB_TOKEN or GH_TOKEN environment variable to a '
                 'valid GitHub access token or pass one to --github-token.'
             )
         callbacks = GitRemoteCallbacks(github_token)

--- a/dev/archery/archery/release/cli.py
+++ b/dev/archery/archery/release/cli.py
@@ -28,7 +28,7 @@ from .core import IssueTracker, Release
               callback=validate_arrow_sources,
               help="Specify Arrow source directory.")
 @click.option('--github-token', '-t', default=None,
-              envvar="CROSSBOW_GITHUB_TOKEN",
+              envvar=['GH_TOKEN', 'CROSSBOW_GITHUB_TOKEN'],
               help='OAuth token for GitHub authentication')
 @click.pass_obj
 def release(obj, src, github_token):

--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -259,6 +259,9 @@ class GitHubAPI(object):
             token = os.environ.get('GH_TOKEN')
         if not token:
             token = os.environ.get('ARROW_GITHUB_API_TOKEN')
+            if token:
+                print('ARROW_GITHUB_API_TOKEN environment variable is '
+                      'deprecated. Use GH_TOKEN environment variable instead.')
         if not token:
             token = cmd.prompt('Env GH_TOKEN nor '
                                'ARROW_GITHUB_API_TOKEN not set, '

--- a/dev/merge_arrow_pr.py
+++ b/dev/merge_arrow_pr.py
@@ -30,7 +30,8 @@
 # variables.
 #
 # Configuration environment variables:
-#   - ARROW_GITHUB_API_TOKEN: a GitHub API token to use for API requests
+#   - GH_TOKEN: a GitHub API token to use for API requests
+#   - ARROW_GITHUB_API_TOKEN: Same as GH_TOKEN. For backward compatibility.
 #   - ARROW_GITHUB_ORG: the GitHub organisation ('apache' by default)
 #   - DEBUG: use for testing to avoid pushing to apache (0 by default)
 
@@ -255,9 +256,12 @@ class GitHubAPI(object):
         if "github" in config.sections():
             token = config["github"]["api_token"]
         if not token:
+            token = os.environ.get('GH_TOKEN')
+        if not token:
             token = os.environ.get('ARROW_GITHUB_API_TOKEN')
         if not token:
-            token = cmd.prompt('Env ARROW_GITHUB_API_TOKEN not set, '
+            token = cmd.prompt('Env GH_TOKEN nor '
+                               'ARROW_GITHUB_API_TOKEN not set, '
                                'please enter your GitHub API token '
                                '(GitHub personal access token):')
         headers = {

--- a/dev/release/.env.example
+++ b/dev/release/.env.example
@@ -31,7 +31,7 @@
 # You must set this.
 #ARTIFACTORY_API_KEY=secret
 
-# The GitHub token to upload artifacts to GitHub Release.
+# The GitHub token used in numerous release scripts.
 #
 # You must set this.
 #GH_TOKEN=secret

--- a/dev/release/01-prepare-test.rb
+++ b/dev/release/01-prepare-test.rb
@@ -28,6 +28,8 @@ class PrepareTest < Test::Unit::TestCase
     Dir.mktmpdir do |dir|
       @test_git_repository = Pathname(dir) + "arrow"
       git("clone", @original_git_repository.to_s, @test_git_repository.to_s)
+      FileUtils.cp((top_dir + "dev" + "release" + ".env").to_s,
+                   (@test_git_repository + "dev" + "release").to_s)
       Dir.chdir(@test_git_repository) do
         @release_branch = "testing-release-#{@release_version}-rc0"
         git("checkout", "-b", @release_branch, @current_commit)

--- a/dev/release/01-prepare.sh
+++ b/dev/release/01-prepare.sh
@@ -26,7 +26,8 @@ if [ "$#" -ne 3 ]; then
   exit 1
 fi
 
-. $SOURCE_DIR/utils-prepare.sh
+. "${SOURCE_DIR}/utils-env.sh"
+. "${SOURCE_DIR}/utils-prepare.sh"
 
 version=$1
 next_version=$2

--- a/dev/release/02-source-test.rb
+++ b/dev/release/02-source-test.rb
@@ -26,6 +26,7 @@ class SourceTest < Test::Unit::TestCase
     @archive_name = "apache-arrow-#{@release_version}.tar.gz"
     @script = File.expand_path("dev/release/02-source.sh")
     @tarball_script = File.expand_path("dev/release/utils-create-release-tarball.sh")
+    @env = File.expand_path("dev/release/.env")
 
     Dir.mktmpdir do |dir|
       Dir.chdir(dir) do
@@ -96,7 +97,7 @@ class SourceTest < Test::Unit::TestCase
   end
 
   def test_vote
-    github_token = ENV["ARROW_GITHUB_API_TOKEN"]
+    github_token = File.read(@env)[/^GH_TOKEN=(.*)$/, 1]
     uri = URI.parse("https://api.github.com/graphql")
     n_issues_query = {
       "query" => <<-QUERY,

--- a/dev/release/03-binary-submit.sh
+++ b/dev/release/03-binary-submit.sh
@@ -19,10 +19,14 @@
 
 set -eu
 
+SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 if [ "$#" -ne 2 ]; then
   echo "Usage: $0 <version> <rc-num>"
   exit
 fi
+
+. "${SOURCE_DIR}/utils-env.sh"
 
 version=$1
 rc=$2

--- a/dev/release/05-binary-upload.sh
+++ b/dev/release/05-binary-upload.sh
@@ -31,6 +31,9 @@ if [ "$#" -ne 2 ]; then
   exit
 fi
 
+. "${SOURCE_DIR}/utils-env.sh"
+. "${SOURCE_DIR}/utils-binary.sh"
+
 version=$1
 rc=$2
 
@@ -54,16 +57,6 @@ if [ ! -d "${ARROW_ARTIFACTS_DIR}" ]; then
 fi
 
 cd "${SOURCE_DIR}"
-
-if [ ! -f .env ]; then
-  echo "You must create $(pwd)/.env"
-  echo "You can use $(pwd)/.env.example as template"
-  exit 1
-fi
-# shellcheck source=SCRIPTDIR/.env.example
-. .env
-
-. utils-binary.sh
 
 # By default upload all artifacts.
 # To deactivate one category, deactivate the category and all of its dependents.

--- a/dev/release/06-matlab-upload.sh
+++ b/dev/release/06-matlab-upload.sh
@@ -28,22 +28,13 @@ if [ $# -ne 2 ]; then
   exit
 fi
 
+. "${SOURCE_DIR}/utils-env.sh"
+
 version=$1
 rc=$2
 
 : ${UPLOAD_DEFAULT=1}
 : ${UPLOAD_FORCE_SIGN=${UPLOAD_DEFAULT}}
-
-if [ ${UPLOAD_FORCE_SIGN} -gt 0 ]; then
-  pushd "${SOURCE_DIR}"
-  if [ ! -f .env ]; then
-    echo "You must create $(pwd)/.env"
-    echo "You can use $(pwd)/.env.example as template"
-    exit 1
-  fi
-  . .env
-  popd
-fi
 
 version_with_rc="${version}-rc${rc}"
 crossbow_job_prefix="release-${version_with_rc}"

--- a/dev/release/07-binary-verify.sh
+++ b/dev/release/07-binary-verify.sh
@@ -21,10 +21,14 @@ set -e
 set -u
 set -o pipefail
 
+SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 if [ "$#" -ne 2 ]; then
   echo "Usage: $0 <version> <rc-num>"
   exit
 fi
+
+. "${SOURCE_DIR}/utils-env.sh"
 
 version=$1
 rc=$2

--- a/dev/release/post-03-binary.sh
+++ b/dev/release/post-03-binary.sh
@@ -27,20 +27,13 @@ if [ "$#" -ne 2 ]; then
   exit
 fi
 
+. "${SOURCE_DIR}/utils-env.sh"
+. "${SOURCE_DIR}/utils-binary.sh"
+
 version=$1
 rc=$2
 
 cd "${SOURCE_DIR}"
-
-if [ ! -f .env ]; then
-  echo "You must create $(pwd)/.env"
-  echo "You can use $(pwd)/.env.example as template"
-  exit 1
-fi
-# shellcheck source=SCRIPTDIR/.env.example
-. .env
-
-. utils-binary.sh
 
 # By default deploy all artifacts.
 # To deactivate one category, deactivate the category and all of its dependents.

--- a/dev/release/post-05-update-gh-release-notes.sh
+++ b/dev/release/post-05-update-gh-release-notes.sh
@@ -36,7 +36,7 @@ WORKFLOW="release.yml"
 
 # Wait for the GitHub Workflow that creates the GitHub Release
 # to finish before updating the release notes.
-"$SOURCE_DIR/utils-watch-gh-workflow.sh" "${TAG}" "${WORKFLOW}"
+"${SOURCE_DIR}/utils-watch-gh-workflow.sh" "${TAG}" "${WORKFLOW}"
 
 # Update the Release Notes section
 RELEASE_NOTES_URL="https://arrow.apache.org/release/${VERSION}.html"

--- a/dev/release/post-05-update-gh-release-notes.sh
+++ b/dev/release/post-05-update-gh-release-notes.sh
@@ -20,21 +20,23 @@
 set -e
 set -o pipefail
 
+SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 if [ "$#" -ne 1 ]; then
     echo "Usage: $0 <version>"
     exit 1
 fi
 
+. "${SOURCE_DIR}/utils-env.sh"
 
 VERSION=$1
 REPOSITORY="apache/arrow"
 TAG="apache-arrow-${VERSION}"
 WORKFLOW="release.yml"
-SOURCE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # Wait for the GitHub Workflow that creates the GitHub Release
 # to finish before updating the release notes.
-. $SOURCE_DIR/utils-watch-gh-workflow.sh ${TAG} ${WORKFLOW}
+$SOURCE_DIR/utils-watch-gh-workflow.sh ${TAG} ${WORKFLOW}
 
 # Update the Release Notes section
 RELEASE_NOTES_URL="https://arrow.apache.org/release/${VERSION}.html"

--- a/dev/release/post-05-update-gh-release-notes.sh
+++ b/dev/release/post-05-update-gh-release-notes.sh
@@ -36,7 +36,7 @@ WORKFLOW="release.yml"
 
 # Wait for the GitHub Workflow that creates the GitHub Release
 # to finish before updating the release notes.
-$SOURCE_DIR/utils-watch-gh-workflow.sh ${TAG} ${WORKFLOW}
+"$SOURCE_DIR/utils-watch-gh-workflow.sh" "${TAG}" "${WORKFLOW}"
 
 # Update the Release Notes section
 RELEASE_NOTES_URL="https://arrow.apache.org/release/${VERSION}.html"

--- a/dev/release/post-11-bump-versions-test.rb
+++ b/dev/release/post-11-bump-versions-test.rb
@@ -28,6 +28,8 @@ class PostBumpVersionsTest < Test::Unit::TestCase
     Dir.mktmpdir do |dir|
       @test_git_repository = Pathname(dir) + "arrow"
       git("clone", @original_git_repository.to_s, @test_git_repository.to_s)
+      FileUtils.cp((top_dir + "dev" + "release" + ".env").to_s,
+                   (@test_git_repository + "dev" + "release").to_s)
       Dir.chdir(@test_git_repository) do
         unless git_tags.include?("apache-arrow-#{@release_version}")
           git("tag", "apache-arrow-#{@release_version}")

--- a/dev/release/utils-env.sh
+++ b/dev/release/utils-env.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+# shellcheck shell=bash
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
@@ -17,40 +17,13 @@
 # specific language governing permissions and limitations
 # under the License.
 
-set -ex
-set -o pipefail
-
 SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-: "${GITHUB_REPOSITORY:=apache/arrow}"
-: "${TEST_PYPI:=0}"
 
-if [ "$#" -ne 1 ]; then
-  echo "Usage: $0 <version>"
-  exit
+if [ ! -f "${SOURCE_DIR}/.env" ]; then
+  echo "You must create ${SOURCE_DIR}/.env"
+  echo "You can use ${SOURCE_DIR}/.env.example as template"
+  exit 1
 fi
-
-. "${SOURCE_DIR}/utils-env.sh"
-
-version=$1
-
-cd "${SOURCE_DIR}"
-
-tmp=$(mktemp -d -t "arrow-post-python.XXXXX")
-gh release download \
-  "apache-arrow-${version}" \
-  --dir "${tmp}" \
-  --pattern "pyarrow-*.tar.gz" \
-  --pattern "pyarrow-*.whl" \
-  --repo "${GITHUB_REPOSITORY}"
-
-TWINE_ARGS=()
-if [ "${TEST_PYPI}" -gt 0 ]; then
-  TWINE_ARGS+=("--repository-url" "https://test.pypi.org/legacy/")
-fi
-
-twine upload "${TWINE_ARGS[@]}" "${tmp}"/*
-
-rm -rf "${tmp}"
-
-echo "Success! The released PyPI packages are available here:"
-echo "  https://pypi.org/project/pyarrow/${version}"
+# shellcheck source=SCRIPTDIR/.env.example
+. ${SOURCE_DIR}/.env
+export GH_TOKEN

--- a/dev/release/utils-env.sh
+++ b/dev/release/utils-env.sh
@@ -25,5 +25,5 @@ if [ ! -f "${SOURCE_DIR}/.env" ]; then
   exit 1
 fi
 # shellcheck source=SCRIPTDIR/.env.example
-. ${SOURCE_DIR}/.env
+. "${SOURCE_DIR}/.env"
 export GH_TOKEN

--- a/docs/source/developers/continuous_integration/crossbow.rst
+++ b/docs/source/developers/continuous_integration/crossbow.rst
@@ -80,8 +80,8 @@ to step 3:
 
 1. `Create the queue repository`_
 
-2. Enable `Travis CI`_ and `Azure Pipelines`_ integrations for the newly
-   created queue repository.
+2. Enable `Azure Pipelines`_ integrations for the newly created queue
+   repository.
 
 3. Clone either `ursacomputing/crossbow`_ if you are using that, or the newly
    created repository next to the arrow repository:
@@ -104,33 +104,22 @@ to step 3:
 
    .. code:: bash
 
-      export CROSSBOW_GITHUB_TOKEN=<token>
+      export GH_TOKEN=<token>
 
    or pass as an argument to the CLI script ``--github-token``
 
-6. Add the previously created GitHub token to **Travis CI**:
-
-   Use ``CROSSBOW_GITHUB_TOKEN`` encrypted environment variable. You can
-   set it at the following URL, where ``ghuser`` is the GitHub
-   username and ``ghrepo`` is the GitHub repository name (typically
-   ``crossbow``):
-
-   ``https://travis-ci.com/<ghuser>/<ghrepo>/settings``
-
-   - Confirm the `auto cancellation`_ feature is turned off for branch builds. This should be the default setting.
-
-7. Install Python (minimum supported version is 3.9):
+6. Install Python (minimum supported version is 3.9):
 
    | Miniconda is preferred, see installation instructions:
    | https://conda.io/docs/user-guide/install/index.html
 
-8. Install the archery toolset containing crossbow itself:
+7. Install the archery toolset containing crossbow itself:
 
    .. code::
 
       $ pip install -e "arrow/dev/archery[crossbow]"
 
-9. Try running it:
+8. Try running it:
 
    .. code::
 

--- a/docs/source/developers/release.rst
+++ b/docs/source/developers/release.rst
@@ -66,7 +66,6 @@ default branch after the release maintenance branch has been created.
 
     - The GPG key needs to be added to this `SVN repo <https://dist.apache.org/repos/dist/dev/arrow/>`_ and `this one <https://dist.apache.org/repos/dist/release/arrow/>`_.
     - Have the build requirements for cpp and c_glib installed.
-    - Set the ``CROSSBOW_GITHUB_TOKEN`` environment variable to automatically create the verify release Pull Request.
     - Install ``en_US.UTF-8`` locale. You can confirm available locales by ``locale -a``.
     - Install Python 3 as python
     - Create dev/release/.env from dev/release/.env.example. See the comments in dev/release/.env.example how to set each variable.


### PR DESCRIPTION
### Rationale for this change

We have many environment variables for GitHub token: `GH_TOKEN`, `ARROW_GITHUB_API_TOKEN` and `CROSSBOW_GITHUB_TOKEN`

It's difficult to maintain. For example, we may forget to define one of them. 

### What changes are included in this PR?

Use `GH_TOKEN` as unified environment variable for GitHub token.

We can still use `ARROW_GITHUB_API_TOKEN` and `CROSSBOW_GITHUB_TOKEN` for backward compatibility but `GH_TOKEN` is recommended.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #47075