### PR TITLE
GH-47084: [Release] Stop using https://dist.apache.org/repos/dist/dev/arrow/KEYS

### DIFF
--- a/dev/release/.env.example
+++ b/dev/release/.env.example
@@ -18,7 +18,6 @@
 # The GPG key ID to sign artifacts. The GPG key ID must be registered
 # to both of the followings:
 #
-#   * https://dist.apache.org/repos/dist/dev/arrow/KEYS
 #   * https://dist.apache.org/repos/dist/release/arrow/KEYS
 #
 # See these files how to import your GPG key ID to these files.

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -100,26 +100,30 @@ detect_cuda() {
   return $((${n_gpus} < 1))
 }
 
-ARROW_DIST_URL='https://dist.apache.org/repos/dist/dev/arrow'
+ARROW_RC_URL="https://dist.apache.org/repos/dist/dev/arrow"
+ARROW_KEYS_URL="https://www.apache.org/dyn/closer.lua?action=download&filename=arrow/KEYS"
 
-download_dist_file() {
+download_file() {
   curl \
     --silent \
     --show-error \
     --fail \
     --location \
-    --remote-name $ARROW_DIST_URL/$1
+    --output "$2" \
+    "$1"
 }
 
 download_rc_file() {
-  download_dist_file apache-arrow-${VERSION}-rc${RC_NUMBER}/$1
+  download_file \
+    "${ARROW_RC_URL}/apache-arrow-${VERSION}-rc${RC_NUMBER}/$1" \
+    "$1"
 }
 
 import_gpg_keys() {
   if [ "${GPGKEYS_ALREADY_IMPORTED:-0}" -gt 0 ]; then
     return 0
   fi
-  download_dist_file KEYS
+  download_file "${ARROW_KEYS_URL}" KEYS
   gpg --import KEYS
 
   GPGKEYS_ALREADY_IMPORTED=1


### PR DESCRIPTION
### Rationale for this change

We only need https://dist.apache.org/repos/dist/release/arrow/KEYS .

### What changes are included in this PR?

Always use https://dist.apache.org/repos/dist/release/arrow/KEYS .

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #47084