### PR TITLE
GH-47186: [CI][Dev] Fix shellcheck errors in the ci/scripts/integration_skyhook.sh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -332,6 +332,7 @@ repos:
           ?^ci/scripts/integration_arrow\.sh$|
           ?^ci/scripts/integration_dask\.sh$|
           ?^ci/scripts/integration_hdfs\.sh$|
+          ?^ci/scripts/integration_skyhook\.sh$|
           ?^ci/scripts/integration_spark\.sh$|
           ?^ci/scripts/matlab_build\.sh$|
           ?^ci/scripts/msys2_system_clean\.sh$|

--- a/ci/scripts/integration_skyhook.sh
+++ b/ci/scripts/integration_skyhook.sh
@@ -34,7 +34,7 @@ DIR=/tmp/integration_skyhook
 
 # set environment variables
 pkill ceph || true
-rm -rf ${DIR}/*
+rm -rf "${DIR:?}"/*
 LOG_DIR=${DIR}/log
 MON_DATA=${DIR}/mon
 MDS_DATA=${DIR}/mds
@@ -44,6 +44,8 @@ mkdir -p ${LOG_DIR} ${MON_DATA} ${OSD_DATA} ${MDS_DATA} ${MOUNTPT}
 MDS_NAME="Z"
 MON_NAME="a"
 MGR_NAME="x"
+# Unused variable
+# shellcheck disable=SC2034
 MIRROR_ID="m"
 
 # cluster wide parameters
@@ -88,9 +90,9 @@ ceph-mon --id ${MON_NAME}
 
 # start an osd
 OSD_ID=$(ceph osd create)
-ceph osd crush add osd.${OSD_ID} 1 root=default
-ceph-osd --id ${OSD_ID} --mkjournal --mkfs
-ceph-osd --id ${OSD_ID} || ceph-osd --id ${OSD_ID} || ceph-osd --id ${OSD_ID}
+ceph osd crush add "osd.${OSD_ID}" 1 root=default
+ceph-osd --id "${OSD_ID}" --mkjournal --mkfs
+ceph-osd --id "${OSD_ID}" || ceph-osd --id "${OSD_ID}" || ceph-osd --id "${OSD_ID}"
 
 # start an mds for cephfs
 ceph auth get-or-create mds.${MDS_NAME} mon 'profile mds' mgr 'profile mds' mds 'allow *' osd 'allow *' > ${MDS_DATA}/keyring
@@ -100,7 +102,7 @@ ceph fs new cephfs cephfs_metadata cephfs_data
 ceph fs ls
 ceph-mds -i ${MDS_NAME}
 ceph status
-while [[ ! $(ceph mds stat | grep "up:active") ]]; do sleep 1; done
+while ! ceph mds stat | grep -q "up:active"; do sleep 1; done
 
 # start a manager
 ceph-mgr --id ${MGR_NAME}
@@ -112,7 +114,7 @@ ceph status
 apt update
 apt install -y python3-pip
 
-pushd ${ARROW_BUILD_DIR}
+pushd "${ARROW_BUILD_DIR}"
     # create the rados-classes, if not there already
     mkdir -p /usr/lib/x86_64-linux-gnu/rados-classes/
     cp debug/libcls_skyhook* /usr/lib/x86_64-linux-gnu/rados-classes/


### PR DESCRIPTION
### Rationale for this change

This is the sub issue #44748.

* SC2034: MIRROR_ID appears unused. Verify use (or export if used externally).
* SC2086: Double quote to prevent globbing and word splitting.
* SC2115:  Use "${var:?}" to ensure this never expands to /* .
* SC2143: Use grep -q instead of comparing output with [ -n .. ].

```
ci/scripts/integration_skyhook.sh

In ci/scripts/integration_skyhook.sh line 37:
rm -rf ${DIR}/*
       ^------^ SC2115 (warning): Use "${var:?}" to ensure this never expands to /* .


In ci/scripts/integration_skyhook.sh line 47:
MIRROR_ID="m"
^-------^ SC2034 (warning): MIRROR_ID appears unused. Verify use (or export if used externally).


In ci/scripts/integration_skyhook.sh line 91:
ceph osd crush add osd.${OSD_ID} 1 root=default
                       ^-------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
ceph osd crush add osd."${OSD_ID}" 1 root=default


In ci/scripts/integration_skyhook.sh line 92:
ceph-osd --id ${OSD_ID} --mkjournal --mkfs
              ^-------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
ceph-osd --id "${OSD_ID}" --mkjournal --mkfs


In ci/scripts/integration_skyhook.sh line 93:
ceph-osd --id ${OSD_ID} || ceph-osd --id ${OSD_ID} || ceph-osd --id ${OSD_ID}
              ^-------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                         ^-------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                                                    ^-------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
ceph-osd --id "${OSD_ID}" || ceph-osd --id "${OSD_ID}" || ceph-osd --id "${OSD_ID}"


In ci/scripts/integration_skyhook.sh line 103:
while [[ ! $(ceph mds stat | grep "up:active") ]]; do sleep 1; done
           ^-- SC2143 (style): Use grep -q instead of comparing output with [ -n .. ].


In ci/scripts/integration_skyhook.sh line 115:
pushd ${ARROW_BUILD_DIR}
      ^----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
pushd "${ARROW_BUILD_DIR}"

For more information:
  https://www.shellcheck.net/wiki/SC2034 -- MIRROR_ID appears unused. Verify ...
  https://www.shellcheck.net/wiki/SC2115 -- Use "${var:?}" to ensure this nev...
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
```

### What changes are included in this PR?

* SC2034: disable shellcheck
* SC2086: Quote variables
* SC2115:  Use `${var:?}` 
* SC2143: Use `grep -q`

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #47186