### PR TITLE
GH-47189: [C++][Parquet] Fix ParquetFilePrinter to produce valid JSON statistics

### DIFF
--- a/cpp/src/parquet/printer.cc
+++ b/cpp/src/parquet/printer.cc
@@ -168,8 +168,10 @@ void ParquetFilePrinter::DebugPrint(std::ostream& stream, std::list<int> selecte
         std::string min = stats->min(), max = stats->max();
         stream << ", Null Values: " << stats->null_count
                << ", Distinct Values: " << stats->distinct_count << std::endl
-               << "  Max: " << FormatStatValue(descr->physical_type(), max)
-               << ", Min: " << FormatStatValue(descr->physical_type(), min);
+               << "  Max: "
+               << FormatStatValue(descr->physical_type(), max, descr->logical_type())
+               << ", Min: "
+               << FormatStatValue(descr->physical_type(), min, descr->logical_type());
       } else {
         stream << "  Statistics Not Set";
       }
@@ -334,9 +336,12 @@ void ParquetFilePrinter::JSONPrint(std::ostream& stream, std::list<int> selected
         if (stats->HasMinMax()) {
           std::string min = stats->EncodeMin(), max = stats->EncodeMax();
           stream << ", "
-                 << R"("Max": ")" << FormatStatValue(descr->physical_type(), max)
+                 << R"("Max": ")"
+                 << FormatStatValue(descr->physical_type(), max, descr->logical_type())
                  << "\", "
-                 << R"("Min": ")" << FormatStatValue(descr->physical_type(), min) << "\"";
+                 << R"("Min": ")"
+                 << FormatStatValue(descr->physical_type(), min, descr->logical_type())
+                 << "\"";
         }
         stream << " },";
       } else {

--- a/cpp/src/parquet/types.cc
+++ b/cpp/src/parquet/types.cc
@@ -170,13 +170,6 @@ std::string FormatNonUTF8Value(::std::string_view val) {
 
 std::string FormatStatValue(Type::type parquet_type, ::std::string_view val,
                             const std::shared_ptr<const LogicalType>& logical_type) {
-  std::stringstream result;
-
-  if (logical_type != nullptr && logical_type->is_decimal()) {
-    return FormatDecimalValue(parquet_type, val, logical_type);
-  }
-
-  // Default handling for non-decimal types or when decimal processing fails
   const char* bytes = val.data();
   switch (parquet_type) {
     case Type::BOOLEAN: {
@@ -201,10 +194,11 @@ std::string FormatStatValue(Type::type parquet_type, ::std::string_view val,
       return FormatNumericValue<float>(val);
     }
     case Type::INT96: {
+      std::stringstream result;
       std::array<int32_t, 3> values{};
       std::memcpy(values.data(), bytes, 3 * sizeof(int32_t));
       result << values[0] << " " << values[1] << " " << values[2];
-      break;
+      return result.str();
     }
     case Type::BYTE_ARRAY:
     case Type::FIXED_LEN_BYTE_ARRAY: {
@@ -222,7 +216,7 @@ std::string FormatStatValue(Type::type parquet_type, ::std::string_view val,
     default:
       break;
   }
-  return result.str();
+  return "";
 }
 
 std::string EncodingToString(Encoding::type t) {

--- a/cpp/src/parquet/types.cc
+++ b/cpp/src/parquet/types.cc
@@ -18,6 +18,7 @@
 #include <array>
 #include <cmath>
 #include <cstdint>
+#include <iomanip>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -25,6 +26,7 @@
 #include "arrow/json/rapidjson_defs.h"  // IWYU pragma: keep
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/compression.h"
+#include "arrow/util/decimal.h"
 #include "arrow/util/logging_internal.h"
 
 #include <rapidjson/document.h>
@@ -96,40 +98,107 @@ bool PageCanUseChecksum(PageType::type pageType) {
   }
 }
 
-std::string FormatStatValue(Type::type parquet_type, ::std::string_view val) {
-  std::stringstream result;
+namespace {
 
-  const char* bytes = val.data();
+template <typename T>
+std::enable_if_t<std::is_arithmetic_v<T>, std::string> FormatNumericValue(
+    ::std::string_view val) {
+  std::stringstream result;
+  T value{};
+  std::memcpy(&value, val.data(), sizeof(T));
+  result << value;
+  return result.str();
+}
+
+std::string FormatDecimalValue(Type::type parquet_type, ::std::string_view val,
+                               const std::shared_ptr<const LogicalType>& logical_type) {
+  ARROW_DCHECK(logical_type != nullptr && logical_type->is_decimal());
+
+  const auto& decimal_type =
+      ::arrow::internal::checked_cast<const DecimalLogicalType&>(*logical_type);
+  const int32_t scale = decimal_type.scale();
+
+  std::stringstream result;
   switch (parquet_type) {
-    case Type::BOOLEAN: {
-      bool value{};
-      std::memcpy(&value, bytes, sizeof(bool));
-      result << value;
-      break;
-    }
     case Type::INT32: {
-      int32_t value{};
-      std::memcpy(&value, bytes, sizeof(int32_t));
-      result << value;
+      int32_t int_value{};
+      std::memcpy(&int_value, val.data(), sizeof(int32_t));
+      ::arrow::Decimal128 decimal_value(int_value);
+      result << decimal_value.ToString(scale);
       break;
     }
     case Type::INT64: {
-      int64_t value{};
-      std::memcpy(&value, bytes, sizeof(int64_t));
-      result << value;
+      int64_t long_value{};
+      std::memcpy(&long_value, val.data(), sizeof(int64_t));
+      ::arrow::Decimal128 decimal_value(long_value);
+      result << decimal_value.ToString(scale);
       break;
+    }
+    case Type::FIXED_LEN_BYTE_ARRAY:
+    case Type::BYTE_ARRAY: {
+      auto decimal_result = ::arrow::Decimal128::FromBigEndian(
+          reinterpret_cast<const uint8_t*>(val.data()), static_cast<int32_t>(val.size()));
+      if (!decimal_result.ok()) {
+        throw ParquetException("Failed to parse decimal value: ",
+                               decimal_result.status().message());
+      }
+      result << decimal_result.ValueUnsafe().ToString(scale);
+      break;
+    }
+    default:
+      throw ParquetException("Unsupported decimal type: ", TypeToString(parquet_type));
+  }
+
+  return result.str();
+}
+
+std::string FormatNonUTF8Value(::std::string_view val) {
+  if (val.empty()) {
+    return "";
+  }
+
+  std::stringstream result;
+  result << "0x" << std::hex;
+  for (const auto& c : val) {
+    result << std::setw(2) << std::setfill('0')
+           << static_cast<int>(static_cast<unsigned char>(c));
+  }
+  return result.str();
+}
+
+}  // namespace
+
+std::string FormatStatValue(Type::type parquet_type, ::std::string_view val,
+                            const std::shared_ptr<const LogicalType>& logical_type) {
+  std::stringstream result;
+
+  if (logical_type != nullptr && logical_type->is_decimal()) {
+    return FormatDecimalValue(parquet_type, val, logical_type);
+  }
+
+  // Default handling for non-decimal types or when decimal processing fails
+  const char* bytes = val.data();
+  switch (parquet_type) {
+    case Type::BOOLEAN: {
+      return FormatNumericValue<bool>(val);
+    }
+    case Type::INT32: {
+      if (logical_type != nullptr && logical_type->is_decimal()) {
+        return FormatDecimalValue(parquet_type, val, logical_type);
+      }
+      return FormatNumericValue<int32_t>(val);
+    }
+    case Type::INT64: {
+      if (logical_type != nullptr && logical_type->is_decimal()) {
+        return FormatDecimalValue(parquet_type, val, logical_type);
+      }
+      return FormatNumericValue<int64_t>(val);
     }
     case Type::DOUBLE: {
-      double value{};
-      std::memcpy(&value, bytes, sizeof(double));
-      result << value;
-      break;
+      return FormatNumericValue<double>(val);
     }
     case Type::FLOAT: {
-      float value{};
-      std::memcpy(&value, bytes, sizeof(float));
-      result << value;
-      break;
+      return FormatNumericValue<float>(val);
     }
     case Type::INT96: {
       std::array<int32_t, 3> values{};
@@ -139,8 +208,15 @@ std::string FormatStatValue(Type::type parquet_type, ::std::string_view val) {
     }
     case Type::BYTE_ARRAY:
     case Type::FIXED_LEN_BYTE_ARRAY: {
-      result << val;
-      break;
+      if (logical_type != nullptr) {
+        if (logical_type->is_decimal()) {
+          return FormatDecimalValue(parquet_type, val, logical_type);
+        }
+        if (logical_type->is_string()) {
+          return std::string(val);
+        }
+      }
+      return FormatNonUTF8Value(val);
     }
     case Type::UNDEFINED:
     default:
@@ -1730,7 +1806,7 @@ format::LogicalType LogicalType::Impl::Geometry::ToThrift() const {
   format::LogicalType type;
   format::GeometryType geometry_type;
 
-  // Canonially export crs of "" as an unset CRS
+  // Canonically export crs of "" as an unset CRS
   if (!crs_.empty()) {
     geometry_type.__set_crs(crs_);
   }
@@ -1825,7 +1901,7 @@ format::LogicalType LogicalType::Impl::Geography::ToThrift() const {
   format::LogicalType type;
   format::GeographyType geography_type;
 
-  // Canonially export crs of "" as an unset CRS
+  // Canonically export crs of "" as an unset CRS
   if (!crs_.empty()) {
     geography_type.__set_crs(crs_);
   }

--- a/cpp/src/parquet/types.h
+++ b/cpp/src/parquet/types.h
@@ -853,8 +853,9 @@ PARQUET_EXPORT std::string TypeToString(Type::type t);
 
 PARQUET_EXPORT std::string TypeToString(Type::type t, int type_length);
 
-PARQUET_EXPORT std::string FormatStatValue(Type::type parquet_type,
-                                           ::std::string_view val);
+PARQUET_EXPORT std::string FormatStatValue(
+    Type::type parquet_type, ::std::string_view val,
+    const std::shared_ptr<const LogicalType>& logical_type = NULLPTR);
 
 PARQUET_EXPORT int GetTypeByteSize(Type::type t);
 

--- a/cpp/src/parquet/types_test.cc
+++ b/cpp/src/parquet/types_test.cc
@@ -127,6 +127,7 @@ TEST(TypePrinter, StatisticsTypes) {
   ASSERT_EQ(smax, FormatStatValue(Type::BYTE_ARRAY, smax, LogicalType::String()));
   ASSERT_EQ("0x696a6b6c6d6e6f7000", FormatStatValue(Type::BYTE_ARRAY, smax));
 
+  // String
   smin = std::string("abcdefgh");
   smax = std::string("ijklmnop");
   ASSERT_EQ(smin,
@@ -136,6 +137,7 @@ TEST(TypePrinter, StatisticsTypes) {
   ASSERT_EQ("0x6162636465666768", FormatStatValue(Type::FIXED_LEN_BYTE_ARRAY, smin));
   ASSERT_EQ("0x696a6b6c6d6e6f70", FormatStatValue(Type::FIXED_LEN_BYTE_ARRAY, smax));
 
+  // Decimal
   int32_t int32_decimal = 1024;
   smin = std::string(reinterpret_cast<char*>(&int32_decimal), sizeof(int32_t));
   ASSERT_EQ("10.24", FormatStatValue(Type::INT32, smin, LogicalType::Decimal(6, 2)));
@@ -153,6 +155,12 @@ TEST(TypePrinter, StatisticsTypes) {
                                           LogicalType::Decimal(10, 4)));
   ASSERT_EQ("0x11223344", FormatStatValue(Type::BYTE_ARRAY, smin));
   ASSERT_EQ("0x11223344", FormatStatValue(Type::FIXED_LEN_BYTE_ARRAY, smin));
+
+  // Float16
+  bytes = {0x1c, 0x50};
+  smin = std::string(bytes.begin(), bytes.end());
+  ASSERT_EQ("32.875",
+            FormatStatValue(Type::FIXED_LEN_BYTE_ARRAY, smin, LogicalType::Float16()));
 }
 
 TEST(TestInt96Timestamp, Decoding) {

--- a/cpp/src/parquet/types_test.cc
+++ b/cpp/src/parquet/types_test.cc
@@ -117,17 +117,42 @@ TEST(TypePrinter, StatisticsTypes) {
 
   smin = std::string("abcdef");
   smax = std::string("ijklmnop");
-  ASSERT_STREQ("abcdef", FormatStatValue(Type::BYTE_ARRAY, smin).c_str());
-  ASSERT_STREQ("ijklmnop", FormatStatValue(Type::BYTE_ARRAY, smax).c_str());
+  ASSERT_EQ(smin, FormatStatValue(Type::BYTE_ARRAY, smin, LogicalType::String()));
+  ASSERT_EQ(smax, FormatStatValue(Type::BYTE_ARRAY, smax, LogicalType::String()));
+  ASSERT_EQ("0x616263646566", FormatStatValue(Type::BYTE_ARRAY, smin));
+  ASSERT_EQ("0x696a6b6c6d6e6f70", FormatStatValue(Type::BYTE_ARRAY, smax));
 
   // PARQUET-1357: FormatStatValue truncates binary statistics on zero character
   smax.push_back('\0');
-  ASSERT_EQ(smax, FormatStatValue(Type::BYTE_ARRAY, smax));
+  ASSERT_EQ(smax, FormatStatValue(Type::BYTE_ARRAY, smax, LogicalType::String()));
+  ASSERT_EQ("0x696a6b6c6d6e6f7000", FormatStatValue(Type::BYTE_ARRAY, smax));
 
   smin = std::string("abcdefgh");
   smax = std::string("ijklmnop");
-  ASSERT_STREQ("abcdefgh", FormatStatValue(Type::FIXED_LEN_BYTE_ARRAY, smin).c_str());
-  ASSERT_STREQ("ijklmnop", FormatStatValue(Type::FIXED_LEN_BYTE_ARRAY, smax).c_str());
+  ASSERT_EQ(smin,
+            FormatStatValue(Type::FIXED_LEN_BYTE_ARRAY, smin, LogicalType::String()));
+  ASSERT_EQ(smax,
+            FormatStatValue(Type::FIXED_LEN_BYTE_ARRAY, smax, LogicalType::String()));
+  ASSERT_EQ("0x6162636465666768", FormatStatValue(Type::FIXED_LEN_BYTE_ARRAY, smin));
+  ASSERT_EQ("0x696a6b6c6d6e6f70", FormatStatValue(Type::FIXED_LEN_BYTE_ARRAY, smax));
+
+  int32_t int32_decimal = 1024;
+  smin = std::string(reinterpret_cast<char*>(&int32_decimal), sizeof(int32_t));
+  ASSERT_EQ("10.24", FormatStatValue(Type::INT32, smin, LogicalType::Decimal(6, 2)));
+
+  int64_t int64_decimal = 102'400'000'000;
+  smin = std::string(reinterpret_cast<char*>(&int64_decimal), sizeof(int64_t));
+  ASSERT_EQ("10240000.0000",
+            FormatStatValue(Type::INT64, smin, LogicalType::Decimal(18, 4)));
+
+  std::vector<char> bytes = {0x11, 0x22, 0x33, 0x44};
+  smin = std::string(bytes.begin(), bytes.end());
+  ASSERT_EQ("28745.4020",
+            FormatStatValue(Type::BYTE_ARRAY, smin, LogicalType::Decimal(10, 4)));
+  ASSERT_EQ("28745.4020", FormatStatValue(Type::FIXED_LEN_BYTE_ARRAY, smin,
+                                          LogicalType::Decimal(10, 4)));
+  ASSERT_EQ("0x11223344", FormatStatValue(Type::BYTE_ARRAY, smin));
+  ASSERT_EQ("0x11223344", FormatStatValue(Type::FIXED_LEN_BYTE_ARRAY, smin));
 }
 
 TEST(TestInt96Timestamp, Decoding) {


### PR DESCRIPTION
### Rationale for this change

ParquetFilePrinter uses FormatStatValue to print min/max stats. If stats contain non-UTF8 data, produced JSON is invalid.

### What changes are included in this PR?

Make FormatStatValue aware of logical type and print hex values for binary data.

### Are these changes tested?

Added test case to validate json output.

### Are there any user-facing changes?

Yes, users may see hex values for binary values instead of char values in the past.

* GitHub Issue: #47189