### PR TITLE
GH-47191: [R] Turn GCS back on by default on MacOS source builds

### DIFF
--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -580,6 +580,7 @@ build_libarrow <- function(src_dir, dst_dir) {
     env_var_list <- c(
       env_var_list,
       ARROW_S3 = Sys.getenv("ARROW_S3", "ON"),
+      ARROW_GCS = Sys.getenv("ARROW_GCS", "ON"),
       ARROW_WITH_ZSTD = Sys.getenv("ARROW_WITH_ZSTD", "ON")
     )
   }


### PR DESCRIPTION
### Rationale for this change

GCS wasn't on by default on MacOS source builds

### What changes are included in this PR?

Turn it on

### Are these changes tested?

Nah

### Are there any user-facing changes?

Nope
* GitHub Issue: #47191