### PR TITLE
GH-47193: [R] Update R Makefile to exclude flight odbc from cpp sync 

### DIFF
--- a/r/Makefile
+++ b/r/Makefile
@@ -42,7 +42,7 @@ deps:
 # we must rename .env to dotenv and then replace references to it in cpp/CMakeLists.txt
 sync-cpp:
 	cp ../NOTICE.txt inst/NOTICE.txt
-	rsync --archive --delete --exclude 'apidoc' --exclude 'build' --exclude 'build-support/boost_*' --exclude 'examples' --exclude 'src/gandiva' --exclude 'src/jni' --exclude 'src/skyhook' --exclude 'submodules' --exclude '**/*_test.cc' ../cpp tools/
+	rsync --archive --delete --exclude 'apidoc' --exclude 'build' --exclude 'build-support/boost_*' --exclude 'examples' --exclude 'src/gandiva' --exclude 'src/arrow/flight/sql/odbc*' --exclude 'src/jni' --exclude 'src/skyhook' --exclude 'submodules' --exclude '**/*_test.cc' ../cpp tools/
 	cp -p ../.env tools/dotenv
 	cp -p ../NOTICE.txt tools/
 	cp -p ../LICENSE.txt tools/


### PR DESCRIPTION
### Rationale for this change

Unnecessary files being synced and causing portability warnings

### What changes are included in this PR?

Don't sync 'em

### Are these changes tested?

Nope

### Are there any user-facing changes?

Nope
* GitHub Issue: #47193