### PR TITLE
GH-46927: [Python][Docs] Add missing accepted types to MessageReader.open_stream()

### DIFF
--- a/python/pyarrow/ipc.pxi
+++ b/python/pyarrow/ipc.pxi
@@ -455,8 +455,8 @@ cdef class MessageReader(_Weakrefable):
 
         Parameters
         ----------
-        source : bytes/buffer-like, pyarrow.NativeFile, or file-like Python object
-            A readable source, like an InputStream
+        source : bytes/buffer-like, pyarrow.NativeFile, pathlib.Path, or file-like Python object
+            A readable source, like an InputStreams open_Stream
         """
         cdef:
             MessageReader result = MessageReader.__new__(MessageReader)

--- a/python/pyarrow/ipc.pxi
+++ b/python/pyarrow/ipc.pxi
@@ -456,7 +456,7 @@ cdef class MessageReader(_Weakrefable):
         Parameters
         ----------
         source : bytes/buffer-like, pyarrow.NativeFile, pathlib.Path, or file-like Python object
-            A readable source, like an InputStreams open_Stream
+            A readable source, like an InputStreams
         """
         cdef:
             MessageReader result = MessageReader.__new__(MessageReader)


### PR DESCRIPTION

### Rationale for this change
The source didn't have the correct detailed information, so I added the details.

### What changes are included in this PR?

### Are these changes tested?
Not needed as this is just adding details onto the documentation. 

### Are there any user-facing changes?
No


* GitHub Issue: #46927