### PR TITLE
GH-46982: [C++] Remove Boost dependency from hdfs_test

### DIFF
--- a/cpp/src/arrow/io/CMakeLists.txt
+++ b/cpp/src/arrow/io/CMakeLists.txt
@@ -28,9 +28,7 @@ if(ARROW_HDFS)
                  PREFIX
                  "arrow-io"
                  EXTRA_LINK_LIBS
-                 arrow::hadoop
-                 Boost::filesystem
-                 Boost::system)
+                 arrow::hadoop)
 endif()
 
 add_arrow_test(memory_test PREFIX "arrow-io")

--- a/cpp/src/arrow/io/hdfs_test.cc
+++ b/cpp/src/arrow/io/hdfs_test.cc
@@ -22,7 +22,6 @@
 #include <filesystem>
 #include <iostream>
 #include <memory>
-#include <random>
 #include <sstream>  // IWYU pragma: keep
 #include <string>
 #include <thread>

--- a/cpp/src/arrow/io/hdfs_test.cc
+++ b/cpp/src/arrow/io/hdfs_test.cc
@@ -41,24 +41,6 @@
 namespace arrow {
 namespace io {
 
-std::string RandomPath(const std::string& prefix, int rand_length) {
-  static const char charset[] =
-      "0123456789"
-      "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-      "abcdefghijklmnopqrstuvwxyz";
-  std::string result = prefix;
-  result.reserve(prefix.size() + rand_length);
-
-  std::mt19937 rng(static_cast<unsigned>(std::time(nullptr)));
-  std::uniform_int_distribution<> dist(0, sizeof(charset) - 2);
-
-  for (int i = 0; i < rand_length; ++i) {
-    result += charset[dist(rng)];
-  }
-
-  return result;
-}
-
 std::vector<uint8_t> RandomData(int64_t size) {
   std::vector<uint8_t> buffer(size);
   random_bytes(size, 0, buffer.data());
@@ -105,8 +87,12 @@ class TestHadoopFileSystem : public ::testing::Test {
 
     client_ = nullptr;
     scratch_dir_ =
-        (std::filesystem::temp_directory_path() / RandomPath("arrow-hdfs/scratch-", 4))
-            .string();
+        (std::filesystem::temp_directory_path() / "arrow-hdfs/scratch-").string();
+    int random_size = 4;
+    scratch_dir_.resize(scratch_dir_.size() + random_size, '%');
+    random_alnum(
+        random_size, 0,
+        reinterpret_cast<uint8_t*>(&scratch_dir_[scratch_dir_.size() - random_size]));
 
     loaded_driver_ = false;
 

--- a/cpp/src/arrow/io/hdfs_test.cc
+++ b/cpp/src/arrow/io/hdfs_test.cc
@@ -52,7 +52,7 @@ std::string RandomPath(const std::string& prefix, int rand_length) {
   std::mt19937 rng(static_cast<unsigned>(std::time(nullptr)));
   std::uniform_int_distribution<> dist(0, sizeof(charset) - 2);
 
-  for (size_t i = 0; i < rand_length; ++i) {
+  for (int i = 0; i < rand_length; ++i) {
     result += charset[dist(rng)];
   }
 

--- a/cpp/src/arrow/testing/util.cc
+++ b/cpp/src/arrow/testing/util.cc
@@ -90,6 +90,16 @@ void random_ascii(int64_t n, uint32_t seed, uint8_t* out) {
   rand_uniform_int(n, seed, static_cast<int32_t>('A'), static_cast<int32_t>('z'), out);
 }
 
+void random_alnum(int64_t n, uint32_t seed, uint8_t* out) {
+  static const char charset[] =
+      "0123456789"
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+      "abcdefghijklmnopqrstuvwxyz";
+  pcg32_fast gen(seed);
+  std::uniform_int_distribution<uint32_t> d(0, sizeof(charset) - 2);
+  std::generate(out, out + n, [&d, &gen] { return charset[d(gen)]; });
+}
+
 int64_t CountNulls(const std::vector<uint8_t>& valid_bytes) {
   return static_cast<int64_t>(std::count(valid_bytes.cbegin(), valid_bytes.cend(), '\0'));
 }

--- a/cpp/src/arrow/testing/util.h
+++ b/cpp/src/arrow/testing/util.h
@@ -64,6 +64,7 @@ ARROW_TESTING_EXPORT void random_bytes(int64_t n, uint32_t seed, uint8_t* out);
 ARROW_TESTING_EXPORT std::string random_string(int64_t n, uint32_t seed);
 ARROW_TESTING_EXPORT int32_t DecimalSize(int32_t precision);
 ARROW_TESTING_EXPORT void random_ascii(int64_t n, uint32_t seed, uint8_t* out);
+ARROW_TESTING_EXPORT void random_alnum(int64_t n, uint32_t seed, uint8_t* out);
 ARROW_TESTING_EXPORT int64_t CountNulls(const std::vector<uint8_t>& valid_bytes);
 
 ARROW_TESTING_EXPORT Status MakeRandomByteBuffer(int64_t length, MemoryPool* pool,


### PR DESCRIPTION
### Rationale for this change
resolve #46982

### What changes are included in this PR?
remove boost dependency from hdfs_test

### Are these changes tested?
partially, not tested with hdfs

### Are there any user-facing changes?
no


* GitHub Issue: #46982