### PR TITLE
GH-46835: [C++] Add more configuration options to arrow::EqualOptions

### DIFF
--- a/cpp/src/arrow/compare.h
+++ b/cpp/src/arrow/compare.h
@@ -83,6 +83,37 @@ class EqualOptions {
     return res;
   }
 
+  /// Whether the \ref arrow::Schema property is used in the comparison.
+  ///
+  /// This option only affects the Equals methods
+  /// and has no effect on ApproxEquals methods.
+  bool use_schema() const { return use_schema_; }
+
+  /// Return a new EqualOptions object with the "use_schema_" property changed.
+  /// Setting this option is false making the value of \ref EqualOptions::use_metadata_
+  /// is ignored.
+  EqualOptions use_schema(bool v) const {
+    auto res = EqualOptions(*this);
+    res.use_schema_ = v;
+    return res;
+  }
+
+  /// Whether the "metadata" in \ref arrow::Schema is used in the comparison.
+  ///
+  /// This option only affects the Equals methods
+  /// and has no effect on the ApproxEquals methods.
+  ///
+  /// Note: This option is only considered when \ref arrow::EqualOptions::use_schema_ is
+  /// set to true.
+  bool use_metadata() const { return use_metadata_; }
+
+  /// Return a new EqualOptions object with the "use_metadata" property changed.
+  EqualOptions use_metadata(bool v) const {
+    auto res = EqualOptions(*this);
+    res.use_metadata_ = v;
+    return res;
+  }
+
   /// The ostream to which a diff will be formatted if arrays disagree.
   /// If this is null (the default) no diff will be formatted.
   std::ostream* diff_sink() const { return diff_sink_; }
@@ -103,6 +134,8 @@ class EqualOptions {
   bool nans_equal_ = false;
   bool signed_zeros_equal_ = true;
   bool use_atol_ = false;
+  bool use_schema_ = true;
+  bool use_metadata_ = false;
 
   std::ostream* diff_sink_ = NULLPTR;
 };

--- a/cpp/src/arrow/compare.h
+++ b/cpp/src/arrow/compare.h
@@ -90,6 +90,7 @@ class EqualOptions {
   bool use_schema() const { return use_schema_; }
 
   /// Return a new EqualOptions object with the "use_schema_" property changed.
+  ///
   /// Setting this option is false making the value of \ref EqualOptions::use_metadata_
   /// is ignored.
   EqualOptions use_schema(bool v) const {

--- a/cpp/src/arrow/compare.h
+++ b/cpp/src/arrow/compare.h
@@ -104,7 +104,7 @@ class EqualOptions {
   /// This option only affects the Equals methods
   /// and has no effect on the ApproxEquals methods.
   ///
-  /// Note: This option is only considered when \ref arrow::EqualOptions::use_schema_ is
+  /// Note: This option is only considered when \ref arrow::EqualOptions::use_schema is
   /// set to true.
   bool use_metadata() const { return use_metadata_; }
 

--- a/cpp/src/arrow/compare.h
+++ b/cpp/src/arrow/compare.h
@@ -91,7 +91,7 @@ class EqualOptions {
 
   /// Return a new EqualOptions object with the "use_schema_" property changed.
   ///
-  /// Setting this option is false making the value of \ref EqualOptions::use_metadata_
+  /// Setting this option is false making the value of \ref EqualOptions::use_metadata
   /// is ignored.
   EqualOptions use_schema(bool v) const {
     auto res = EqualOptions(*this);

--- a/cpp/src/arrow/record_batch.h
+++ b/cpp/src/arrow/record_batch.h
@@ -118,14 +118,22 @@ class ARROW_EXPORT RecordBatch {
   static Result<std::shared_ptr<RecordBatch>> FromStructArray(
       const std::shared_ptr<Array>& array, MemoryPool* pool = default_memory_pool());
 
-  /// \brief Determine if two record batches are exactly equal
+  /// \brief Determine if two record batches are equal
   ///
   /// \param[in] other the RecordBatch to compare with
-  /// \param[in] check_metadata if true, check that Schema metadata is the same
+  /// \param[in] check_metadata if true, the schema metadata will be compared,
+  ///            regardless of the value set in \ref EqualOptions::use_metadata_
   /// \param[in] opts the options for equality comparisons
   /// \return true if batches are equal
   bool Equals(const RecordBatch& other, bool check_metadata = false,
               const EqualOptions& opts = EqualOptions::Defaults()) const;
+
+  /// \brief Determine if two record batches are equal
+  ///
+  /// \param[in] other the RecordBatch to compare with
+  /// \param[in] opts the options for equality comparisons
+  /// \return true if batches are equal
+  bool Equals(const RecordBatch& other, const EqualOptions& opts) const;
 
   /// \brief Determine if two record batches are approximately equal
   ///
@@ -133,7 +141,9 @@ class ARROW_EXPORT RecordBatch {
   /// \param[in] opts the options for equality comparisons
   /// \return true if batches are approximately equal
   bool ApproxEquals(const RecordBatch& other,
-                    const EqualOptions& opts = EqualOptions::Defaults()) const;
+                    const EqualOptions& opts = EqualOptions::Defaults()) const {
+    return Equals(other, opts.use_schema(false).use_atol(true));
+  }
 
   /// \return the record batch's schema
   const std::shared_ptr<Schema>& schema() const { return schema_; }

--- a/cpp/src/arrow/record_batch_test.cc
+++ b/cpp/src/arrow/record_batch_test.cc
@@ -115,7 +115,7 @@ TEST_F(TestRecordBatchEqualOptions, MetadataAndSchema) {
   auto metadata = key_value_metadata({"foo"}, {"bar"});
 
   auto schema0_f0_f1_f2 = schema({f0, f1, f2});
-  auto schema1_f0_f1_f2_with_metadat = schema({f0, f1, f2}, metadata);
+  auto schema1_f0_f1_f2_with_metadata = schema({f0, f1, f2}, metadata);
   auto schema2_f0_f1_f2b = schema({f0, f1, f2b});
 
   random::RandomArrayGenerator gen(42);
@@ -126,8 +126,8 @@ TEST_F(TestRecordBatchEqualOptions, MetadataAndSchema) {
 
   // All RecordBatches have the same values but different schemas.
   auto b0_f0_f1_f2 = RecordBatch::Make(schema0_f0_f1_f2, length, {a0, a1, a2});
-  auto b1_f0_f1_f2_with_metadat =
-      RecordBatch::Make(schema1_f0_f1_f2_with_metadat, length, {a0, a1, a2});
+  auto b1_f0_f1_f2_with_metadata =
+      RecordBatch::Make(schema1_f0_f1_f2_with_metadata, length, {a0, a1, a2});
   auto b2_f0_f1_f2b = RecordBatch::Make(schema2_f0_f1_f2b, length, {a0, a1, a2});
 
   auto options = EqualOptions::Defaults();
@@ -138,21 +138,21 @@ TEST_F(TestRecordBatchEqualOptions, MetadataAndSchema) {
   ASSERT_TRUE(b0_f0_f1_f2->ApproxEquals(*b2_f0_f1_f2b, options.use_schema(true)));
 
   // Different metadata
-  ASSERT_TRUE(b0_f0_f1_f2->Equals(*b1_f0_f1_f2_with_metadat));
-  ASSERT_TRUE(b0_f0_f1_f2->Equals(*b1_f0_f1_f2_with_metadat, options));
-  ASSERT_FALSE(b0_f0_f1_f2->Equals(*b1_f0_f1_f2_with_metadat,
+  ASSERT_TRUE(b0_f0_f1_f2->Equals(*b1_f0_f1_f2_with_metadata));
+  ASSERT_TRUE(b0_f0_f1_f2->Equals(*b1_f0_f1_f2_with_metadata, options));
+  ASSERT_FALSE(b0_f0_f1_f2->Equals(*b1_f0_f1_f2_with_metadata,
                                    /*check_metadata=*/true));
-  ASSERT_FALSE(b0_f0_f1_f2->Equals(*b1_f0_f1_f2_with_metadat,
+  ASSERT_FALSE(b0_f0_f1_f2->Equals(*b1_f0_f1_f2_with_metadata,
                                    /*check_metadata=*/true, options.use_schema(true)));
-  ASSERT_TRUE(b0_f0_f1_f2->Equals(*b1_f0_f1_f2_with_metadat,
+  ASSERT_TRUE(b0_f0_f1_f2->Equals(*b1_f0_f1_f2_with_metadata,
                                   /*check_metadata=*/true, options.use_schema(false)));
-  ASSERT_TRUE(b0_f0_f1_f2->Equals(*b1_f0_f1_f2_with_metadat,
+  ASSERT_TRUE(b0_f0_f1_f2->Equals(*b1_f0_f1_f2_with_metadata,
                                   options.use_schema(true).use_metadata(false)));
-  ASSERT_FALSE(b0_f0_f1_f2->Equals(*b1_f0_f1_f2_with_metadat,
+  ASSERT_FALSE(b0_f0_f1_f2->Equals(*b1_f0_f1_f2_with_metadata,
                                    options.use_schema(true).use_metadata(true)));
-  ASSERT_TRUE(b0_f0_f1_f2->Equals(*b1_f0_f1_f2_with_metadat,
+  ASSERT_TRUE(b0_f0_f1_f2->Equals(*b1_f0_f1_f2_with_metadata,
                                   options.use_schema(false).use_metadata(true)));
-  ASSERT_TRUE(b0_f0_f1_f2->ApproxEquals(*b1_f0_f1_f2_with_metadat,
+  ASSERT_TRUE(b0_f0_f1_f2->ApproxEquals(*b1_f0_f1_f2_with_metadata,
                                         options.use_schema(true).use_metadata(true)));
 }
 

--- a/docs/source/cpp/api/utilities.rst
+++ b/docs/source/cpp/api/utilities.rst
@@ -43,6 +43,12 @@ Iterators
 .. doxygenclass:: arrow::VectorIterator
    :members:
 
+Comparison
+==========
+
+.. doxygenclass:: arrow::EqualOptions
+   :members:
+
 Compression
 ===========
 


### PR DESCRIPTION
### Rationale for this change

Parameterizing the comparison of `metadata` and `arrow::Schema` via `arrow::EqualOptions`.

### What changes are included in this PR?

* Added two attributes to `arrow::EqualOptions` for parameterizing the comparison of `metadata` and `schema`.

### Are these changes tested?

Yes, I ran the relevant unit tests.

### Are there any user-facing changes?

* Added `use_schema()` to `arrow::EqualOptions`.
* Added `use_metadata()` to `arrow::EqualOptions`.
* Added a new overload for `arrow::RecordBatch::Equals` that accepts only another `arrow::RecordBatch` and an `arrow::EqualOptions` instance.
* GitHub Issue: #46835