### PR TITLE
GH-47395: [R] Update fedora-clang to install latest clang version to match CRAN setup

### DIFF
--- a/.env
+++ b/.env
@@ -87,6 +87,7 @@ R_CUSTOM_CCACHE=false
 ARROW_R_DEV=TRUE
 R_PRUNE_DEPS=FALSE
 TZ=UTC
+R_UPDATE_CLANG=FALSE
 
 # Used through docker-compose.yml and serves as the default version for the
 # ci/scripts/install_vcpkg.sh script. Prefer to use short SHAs to keep the

--- a/.env
+++ b/.env
@@ -87,7 +87,6 @@ R_CUSTOM_CCACHE=false
 ARROW_R_DEV=TRUE
 R_PRUNE_DEPS=FALSE
 TZ=UTC
-R_UPDATE_CLANG=FALSE
 
 # Used through docker-compose.yml and serves as the default version for the
 # ci/scripts/install_vcpkg.sh script. Prefer to use short SHAs to keep the

--- a/ci/docker/linux-r.dockerfile
+++ b/ci/docker/linux-r.dockerfile
@@ -33,6 +33,9 @@ ENV R_PRUNE_DEPS=${r_prune_deps}
 ARG r_custom_ccache=false
 ENV R_CUSTOM_CCACHE=${r_custom_ccache}
 
+ARG r_update_clang=false
+ENV R_UPDATE_CLANG=${r_update_clang}
+
 ARG tz="UTC"
 ENV TZ=${tz}
 

--- a/ci/docker/linux-r.dockerfile
+++ b/ci/docker/linux-r.dockerfile
@@ -33,9 +33,6 @@ ENV R_PRUNE_DEPS=${r_prune_deps}
 ARG r_custom_ccache=false
 ENV R_CUSTOM_CCACHE=${r_custom_ccache}
 
-ARG r_update_clang=false
-ENV R_UPDATE_CLANG=${r_update_clang}
-
 ARG tz="UTC"
 ENV TZ=${tz}
 

--- a/ci/scripts/r_docker_configure.sh
+++ b/ci/scripts/r_docker_configure.sh
@@ -67,6 +67,18 @@ sloppiness = include_file_ctime
 hash_dir = false" >> ~/.ccache/ccache.conf
 fi
 
+# Update clang version to latest available
+: ${R_UPDATE_CLANG:=FALSE}
+R_UPDATE_CLANG=`echo $R_UPDATE_CLANG | tr '[:upper:]' '[:lower:]'`
+if [ ${R_UPDATE_CLANG} = "true" ]; then
+  apt-get update &&
+  apt-get install -y curl gnupg &&
+  curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /etc/apt/trusted.gpg.d/llvm.gpg &&
+  echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-20 main" > /etc/apt/sources.list.d/llvm20.list &&
+  apt-get update &&
+  apt-get install -y clang-20 lld-20
+fi
+
 if [ -f "${ARROW_SOURCE_HOME}/ci/scripts/r_install_system_dependencies.sh" ]; then
   "${ARROW_SOURCE_HOME}/ci/scripts/r_install_system_dependencies.sh"
 fi

--- a/ci/scripts/r_docker_configure.sh
+++ b/ci/scripts/r_docker_configure.sh
@@ -67,18 +67,6 @@ sloppiness = include_file_ctime
 hash_dir = false" >> ~/.ccache/ccache.conf
 fi
 
-# Update clang version to latest available
-: ${R_UPDATE_CLANG:=FALSE}
-R_UPDATE_CLANG=`echo $R_UPDATE_CLANG | tr '[:upper:]' '[:lower:]'`
-if [ ${R_UPDATE_CLANG} = "true" ]; then
-  apt-get update &&
-  apt-get install -y curl gnupg &&
-  curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /etc/apt/trusted.gpg.d/llvm.gpg &&
-  echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-20 main" > /etc/apt/sources.list.d/llvm20.list &&
-  apt-get update &&
-  apt-get install -y clang-20 lld-20
-fi
-
 if [ -f "${ARROW_SOURCE_HOME}/ci/scripts/r_install_system_dependencies.sh" ]; then
   "${ARROW_SOURCE_HOME}/ci/scripts/r_install_system_dependencies.sh"
 fi
@@ -86,6 +74,18 @@ fi
 # Install rsync for bundling cpp source and curl to make sure it is installed on all images,
 # cmake is now a listed sys req.
 $PACKAGE_MANAGER install -y rsync cmake curl
+
+# Update clang version to latest available
+: ${R_UPDATE_CLANG:=FALSE}
+R_UPDATE_CLANG=`echo $R_UPDATE_CLANG | tr '[:upper:]' '[:lower:]'`
+if [ ${R_UPDATE_CLANG} = "true" ]; then
+  $PACKAGE_MANAGER install update -y &&
+  $PACKAGE_MANAGER install install -y gnupg &&
+  curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /etc/apt/trusted.gpg.d/llvm.gpg &&
+  echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-20 main" > /etc/apt/sources.list.d/llvm20.list &&
+  $PACKAGE_MANAGER install update -y &&
+  $PACKAGE_MANAGER install install -y clang-20 lld-20
+fi
 
 # Workaround for html help install failure; see https://github.com/r-lib/devtools/issues/2084#issuecomment-530912786
 Rscript -e 'x <- file.path(R.home("doc"), "html"); if (!file.exists(x)) {dir.create(x, recursive=TRUE); file.copy(system.file("html/R.css", package="stats"), x)}'

--- a/ci/scripts/r_docker_configure.sh
+++ b/ci/scripts/r_docker_configure.sh
@@ -75,7 +75,9 @@ fi
 # cmake is now a listed sys req.
 $PACKAGE_MANAGER install -y rsync cmake curl
 
-# Update clang version to latest available
+# Update clang version to latest available.
+# This is only for rhub/clang20. If we change the base image from rhub/clang20,
+# we need to update this part too.
 if [ "$R_UPDATE_CLANG" = true ]; then
   apt update -y
   apt install -y gnupg

--- a/ci/scripts/r_docker_configure.sh
+++ b/ci/scripts/r_docker_configure.sh
@@ -76,7 +76,6 @@ fi
 $PACKAGE_MANAGER install -y rsync cmake curl
 
 # Update clang version to latest available
-
 if [ "$R_UPDATE_CLANG" = true ]; then
   apt update -y &&
   apt install -y gnupg &&

--- a/ci/scripts/r_docker_configure.sh
+++ b/ci/scripts/r_docker_configure.sh
@@ -77,11 +77,11 @@ $PACKAGE_MANAGER install -y rsync cmake curl
 
 # Update clang version to latest available
 if [ "$R_UPDATE_CLANG" = true ]; then
-  apt update -y &&
-  apt install -y gnupg &&
-  curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /etc/apt/trusted.gpg.d/llvm.gpg &&
-  echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-20 main" > /etc/apt/sources.list.d/llvm20.list &&
-  apt update -y &&
+  apt update -y
+  apt install -y gnupg
+  curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /etc/apt/trusted.gpg.d/llvm.gpg
+  echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-20 main" > /etc/apt/sources.list.d/llvm20.list
+  apt update -y
   apt install -y clang-20 lld-20
 fi
 

--- a/ci/scripts/r_docker_configure.sh
+++ b/ci/scripts/r_docker_configure.sh
@@ -78,6 +78,7 @@ $PACKAGE_MANAGER install -y rsync cmake curl
 # Update clang version to latest available
 : ${R_UPDATE_CLANG:=FALSE}
 R_UPDATE_CLANG=`echo $R_UPDATE_CLANG | tr '[:upper:]' '[:lower:]'`
+echo "R_UPDATE_CLANG=${R_UPDATE_CLANG}"
 if [ ${R_UPDATE_CLANG} = "true" ]; then
   $PACKAGE_MANAGER install update -y &&
   $PACKAGE_MANAGER install install -y gnupg &&

--- a/ci/scripts/r_docker_configure.sh
+++ b/ci/scripts/r_docker_configure.sh
@@ -76,16 +76,14 @@ fi
 $PACKAGE_MANAGER install -y rsync cmake curl
 
 # Update clang version to latest available
-: ${R_UPDATE_CLANG:=FALSE}
-R_UPDATE_CLANG=`echo $R_UPDATE_CLANG | tr '[:upper:]' '[:lower:]'`
-echo "R_UPDATE_CLANG=${R_UPDATE_CLANG}"
-if [ ${R_UPDATE_CLANG} = "true" ]; then
-  $PACKAGE_MANAGER install update -y &&
-  $PACKAGE_MANAGER install install -y gnupg &&
+
+if [ "$R_UPDATE_CLANG" = true ]; then
+  apt update -y &&
+  apt install -y gnupg &&
   curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /etc/apt/trusted.gpg.d/llvm.gpg &&
   echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-20 main" > /etc/apt/sources.list.d/llvm20.list &&
-  $PACKAGE_MANAGER install update -y &&
-  $PACKAGE_MANAGER install install -y clang-20 lld-20
+  apt update -y &&
+  apt install -y clang-20 lld-20
 fi
 
 # Workaround for html help install failure; see https://github.com/r-lib/devtools/issues/2084#issuecomment-530912786

--- a/dev/tasks/r/github.linux.cran.yml
+++ b/dev/tasks/r/github.linux.cran.yml
@@ -23,6 +23,7 @@ jobs:
   as-cran:
     name: "rhub/{{ '${{ matrix.config.r_image }}' }}"
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:

--- a/dev/tasks/r/github.linux.cran.yml
+++ b/dev/tasks/r/github.linux.cran.yml
@@ -47,7 +47,7 @@ jobs:
         env:
         {{ macros.github_set_sccache_envvars()|indent(8)}}
         # setting ARROW_SOURCE_HOME='' here ensures that we use the cpp source copied into tools/
-        run: archery docker run -e ARROW_SOURCE_HOME='' -e SKIP_VIGNETTES={{ '${{ matrix.config.skip_vignettes }}' }} -e R_UPDATE_CLANG={{ '${{ matrix.config.r_update_clang }}' }} rhub/{{ '${{ matrix.config.r_image }}' }}
+        run: archery docker run -e ARROW_SOURCE_HOME='' -e SKIP_VIGNETTES={{ '${{ matrix.config.skip_vignettes }}' }} -e R_UPDATE_CLANG={{ '${{ matrix.config.r_update_clang }}' }} r
       - name: Dump install logs
         run: cat arrow/r/check/arrow.Rcheck/00install.out
         if: always()

--- a/dev/tasks/r/github.linux.cran.yml
+++ b/dev/tasks/r/github.linux.cran.yml
@@ -32,7 +32,7 @@ jobs:
           - { r_image: "ubuntu-clang" }  # ~ r-devel-linux-x86_64-debian-clang
           - { r_image: "ubuntu-next" }  # ~ r-patched-linux-x86_64
           - { r_image: "ubuntu-release" }  # ~ r-release-linux-x86_64
-          - { r_image: "clang20", skip_vignettes: true }  # ~ r-devel-linux-x86_64-fedora-clang
+          - { r_image: "clang20", skip_vignettes: true, r_update_clang: true }  # ~ r-devel-linux-x86_64-fedora-clang
     env:
       R_ORG: "rhub"
       R_IMAGE: {{ '${{ matrix.config.r_image }}' }}
@@ -47,20 +47,7 @@ jobs:
         env:
         {{ macros.github_set_sccache_envvars()|indent(8)}}
         # setting ARROW_SOURCE_HOME='' here ensures that we use the cpp source copied into tools/
-        run: |
-          archery docker run \
-            -e ARROW_SOURCE_HOME='' \
-            -e SKIP_VIGNETTES={{ '${{ matrix.config.skip_vignettes }}' }} \
-            r \
-            "bash -c '
-              apt-get update &&
-              apt-get install -y curl gnupg &&
-              curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /etc/apt/trusted.gpg.d/llvm.gpg &&
-              echo \"deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-20 main\" > /etc/apt/sources.list.d/llvm20.list &&
-              apt-get update &&
-              apt-get install -y clang-20 lld-20 &&
-              exec \"\$@\"
-            ' --"
+        run: archery docker run -e ARROW_SOURCE_HOME='' -e SKIP_VIGNETTES={{ '${{ matrix.config.skip_vignettes }}' }} -e R_UPDATE_CLANG={{ '${{ matrix.config.r_update_clang }}' }} rhub/{{ '${{ matrix.config.r_image }}' }}
       - name: Dump install logs
         run: cat arrow/r/check/arrow.Rcheck/00install.out
         if: always()

--- a/dev/tasks/r/github.linux.cran.yml
+++ b/dev/tasks/r/github.linux.cran.yml
@@ -38,6 +38,7 @@ jobs:
       R_IMAGE: {{ '${{ matrix.config.r_image }}' }}
       R_TAG: "latest"
       ARROW_R_DEV: "FALSE"
+      R_UPDATE_CLANG: {{ '${{ matrix.config.r_update_clang | default(false) }}' }}
     steps:
       {{ macros.github_checkout_arrow()|indent }}
       {{ macros.github_install_archery()|indent }}
@@ -47,7 +48,7 @@ jobs:
         env:
         {{ macros.github_set_sccache_envvars()|indent(8)}}
         # setting ARROW_SOURCE_HOME='' here ensures that we use the cpp source copied into tools/
-        run: archery docker run -e ARROW_SOURCE_HOME='' -e SKIP_VIGNETTES={{ '${{ matrix.config.skip_vignettes }}' }} -e R_UPDATE_CLANG={{ '${{ matrix.config.r_update_clang }}' }} r
+        run: archery docker run -e ARROW_SOURCE_HOME='' -e SKIP_VIGNETTES={{ '${{ matrix.config.skip_vignettes }}' }} r
       - name: Dump install logs
         run: cat arrow/r/check/arrow.Rcheck/00install.out
         if: always()

--- a/dev/tasks/r/github.linux.cran.yml
+++ b/dev/tasks/r/github.linux.cran.yml
@@ -46,16 +46,16 @@ jobs:
         shell: bash
         env:
         {{ macros.github_set_sccache_envvars()|indent(8)}}
-        # try this with new clang20 to try to reproduce error
-        run: |
-          apt-get update
-          apt-get install -y curl gnupg lld-20 clang-20
-          curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /etc/apt/trusted.gpg.d/llvm.gpg
-          echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-20 main" > /etc/apt/sources.list.d/llvm20.list
-          apt-get update
-          apt-get install -y clang-20 lld-20
         # setting ARROW_SOURCE_HOME='' here ensures that we use the cpp source copied into tools/
-        run: archery docker run -e ARROW_SOURCE_HOME='' -e SKIP_VIGNETTES={{ '${{ matrix.config.skip_vignettes }}' }} r
+        run: |
+          archery docker run -e ARROW_SOURCE_HOME='' -e SKIP_VIGNETTES={{ '${{ matrix.config.skip_vignettes }}' }} r bash -c "
+              apt-get update &&
+              apt-get install -y curl gnupg &&
+              curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /etc/apt/trusted.gpg.d/llvm.gpg &&
+              echo 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-20 main' > /etc/apt/sources.list.d/llvm20.list &&
+              apt-get update &&
+              apt-get install -y clang-20 lld-20 &&
+              exec \"\$@\"" --
       - name: Dump install logs
         run: cat arrow/r/check/arrow.Rcheck/00install.out
         if: always()

--- a/dev/tasks/r/github.linux.cran.yml
+++ b/dev/tasks/r/github.linux.cran.yml
@@ -46,6 +46,14 @@ jobs:
         shell: bash
         env:
         {{ macros.github_set_sccache_envvars()|indent(8)}}
+        # try this with new clang20 to try to reproduce error
+        run: |
+          apt-get update
+          apt-get install -y curl gnupg lld-20 clang-20
+          curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /etc/apt/trusted.gpg.d/llvm.gpg
+          echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-20 main" > /etc/apt/sources.list.d/llvm20.list
+          apt-get update
+          apt-get install -y clang-20 lld-20
         # setting ARROW_SOURCE_HOME='' here ensures that we use the cpp source copied into tools/
         run: archery docker run -e ARROW_SOURCE_HOME='' -e SKIP_VIGNETTES={{ '${{ matrix.config.skip_vignettes }}' }} r
       - name: Dump install logs

--- a/dev/tasks/r/github.linux.cran.yml
+++ b/dev/tasks/r/github.linux.cran.yml
@@ -38,7 +38,7 @@ jobs:
       R_IMAGE: {{ '${{ matrix.config.r_image }}' }}
       R_TAG: "latest"
       ARROW_R_DEV: "FALSE"
-      R_UPDATE_CLANG: {{ '${{ matrix.config.r_update_clang | default(false) }}' }}
+      R_UPDATE_CLANG: {{ '${{ matrix.config.r_update_clang }}' }}
     steps:
       {{ macros.github_checkout_arrow()|indent }}
       {{ macros.github_install_archery()|indent }}

--- a/dev/tasks/r/github.linux.cran.yml
+++ b/dev/tasks/r/github.linux.cran.yml
@@ -48,14 +48,19 @@ jobs:
         {{ macros.github_set_sccache_envvars()|indent(8)}}
         # setting ARROW_SOURCE_HOME='' here ensures that we use the cpp source copied into tools/
         run: |
-          archery docker run -e ARROW_SOURCE_HOME='' -e SKIP_VIGNETTES={{ '${{ matrix.config.skip_vignettes }}' }} r bash -c "
+          archery docker run \
+            -e ARROW_SOURCE_HOME='' \
+            -e SKIP_VIGNETTES={{ '${{ matrix.config.skip_vignettes }}' }} \
+            r \
+            "bash -c '
               apt-get update &&
               apt-get install -y curl gnupg &&
               curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /etc/apt/trusted.gpg.d/llvm.gpg &&
-              echo 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-20 main' > /etc/apt/sources.list.d/llvm20.list &&
+              echo \"deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-20 main\" > /etc/apt/sources.list.d/llvm20.list &&
               apt-get update &&
               apt-get install -y clang-20 lld-20 &&
-              exec \"\$@\"" --
+              exec \"\$@\"
+            ' --"
       - name: Dump install logs
         run: cat arrow/r/check/arrow.Rcheck/00install.out
         if: always()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1631,6 +1631,7 @@ services:
         tz: ${TZ}
         r_prune_deps: ${R_PRUNE_DEPS}
         r_custom_ccache: ${R_CUSTOM_CCACHE}
+        r_update_clang: ${R_UPDATE_CLANG}
     shm_size: *shm-size
     environment:
       <<: [*common, *sccache]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1631,7 +1631,6 @@ services:
         tz: ${TZ}
         r_prune_deps: ${R_PRUNE_DEPS}
         r_custom_ccache: ${R_CUSTOM_CCACHE}
-        r_update_clang: ${R_UPDATE_CLANG}
     shm_size: *shm-size
     environment:
       <<: [*common, *sccache]

--- a/r/configure
+++ b/r/configure
@@ -402,9 +402,14 @@ if [ "$_LIBARROW_FOUND" != "false" ] && [ "$_LIBARROW_FOUND" != "" ]; then
     set_pkg_vars ${_LIBARROW_FOUND}
   fi
 else
-  # To make it easier to debug which code path was taken add a specific 
+  # To make it easier to debug which code path was taken add a specific
   # message to the log in addition to the 'NOTE'
   echo "*** Failed to find Arrow C++ libraries."
+fi
+
+# If using Clang, suppress GNU variadic macro warning from Thrift
+if ${R_HOME}/bin/R CMD config CXX | grep -q clang; then
+  PKG_CFLAGS="$PKG_CFLAGS -Wno-gnu-zero-variadic-macro-arguments"
 fi
 
 # Test that we can compile something with those flags

--- a/r/configure
+++ b/r/configure
@@ -408,9 +408,9 @@ else
 fi
 
 # If using Clang, suppress GNU variadic macro warning from Thrift
-if ${R_HOME}/bin/R CMD config CXX | grep -q clang; then
-  PKG_CFLAGS="$PKG_CFLAGS -Wno-gnu-zero-variadic-macro-arguments"
-fi
+#if ${R_HOME}/bin/R CMD config CXX | grep -q clang; then
+#  PKG_CFLAGS="$PKG_CFLAGS -Wno-gnu-zero-variadic-macro-arguments"
+#fi
 
 # Test that we can compile something with those flags
 CXX17="`${R_HOME}/bin/R CMD config CXX17` -E"

--- a/r/configure
+++ b/r/configure
@@ -407,11 +407,6 @@ else
   echo "*** Failed to find Arrow C++ libraries."
 fi
 
-# If using Clang, suppress GNU variadic macro warning from Thrift
-#if ${R_HOME}/bin/R CMD config CXX | grep -q clang; then
-#  PKG_CFLAGS="$PKG_CFLAGS -Wno-gnu-zero-variadic-macro-arguments"
-#fi
-
 # Test that we can compile something with those flags
 CXX17="`${R_HOME}/bin/R CMD config CXX17` -E"
 CXX17FLAGS=`"${R_HOME}"/bin/R CMD config CXX17FLAGS`


### PR DESCRIPTION
### Rationale for this change

Unnecessary warnings causing noise

### What changes are included in this PR?

Suppress warnings

### Are these changes tested?

Nope though I'll test on CI once we get a job with the right version of clang created

### Are there any user-facing changes?

Well...no.
* GitHub Issue: #47395