### PR TITLE
GH-47211: [CI][R] Disable non-system memory allocators when on linux-devel

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1657,10 +1657,11 @@ services:
         tz: ${TZ}
         r_prune_deps: ${R_PRUNE_DEPS}
     shm_size: *shm-size
+    # These environment variables are *not* set by CRAN, so we should be careful about adding
+    # to them. I.E. if we have to add something here to have CI pass, it will likely fail on CRAN.
     environment:
       <<: *common
       LIBARROW_DOWNLOAD: "false"
-      ARROW_MIMALLOC: "OFF"
       ARROW_R_DEV: ${ARROW_R_DEV}
       ARROW_SOURCE_HOME: "/arrow"
       ARROW_USE_PKG_CONFIG: "false"

--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -585,6 +585,11 @@ build_libarrow <- function(src_dir, dst_dir) {
     )
   }
 
+  if (on_linux_dev) {
+    # Disable mimalloc on linux devel builds, since mimalloc has spurious sanitizer failures
+    env_var_list <- c(env_var_list, Sys.getenv("ARROW_WITH_ZSTD", "OFF"))
+  }
+
   env_var_list <- with_cloud_support(env_var_list)
 
   # turn_off_all_optional_features() needs to happen after
@@ -917,6 +922,7 @@ is_release <- is.na(dev_version) || dev_version < "100"
 
 on_macos <- tolower(Sys.info()[["sysname"]]) == "darwin"
 on_windows <- tolower(Sys.info()[["sysname"]]) == "windows"
+on_linux_dev <-  tolower(Sys.info()[["sysname"]]) == "linux" && grepl("devel", R.version.string)
 
 # For local debugging, set ARROW_R_DEV=TRUE to make this script print more
 quietly <- !env_is("ARROW_R_DEV", "true")

--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -587,7 +587,7 @@ build_libarrow <- function(src_dir, dst_dir) {
 
   if (on_linux_dev) {
     # Disable mimalloc on linux devel builds, since mimalloc has spurious sanitizer failures
-    env_var_list <- c(env_var_list, Sys.getenv("ARROW_WITH_ZSTD", "OFF"))
+    env_var_list <- c(env_var_list, ARROW_MIMALLOC = Sys.getenv("ARROW_MIMALLOC", "OFF"))
   }
 
   env_var_list <- with_cloud_support(env_var_list)


### PR DESCRIPTION
### Rationale for this change
We need to disable these at buildtime, so that they are *also* disabled on CRAN.

Resolves #47211

### What changes are included in this PR?
Remove the env var set in CI, set the flag when building

### Are these changes tested?
They are tests

### Are there any user-facing changes?
Hopefully no!

* GitHub Issue: #47211