### PR TITLE
GH-47213: [R] Allow C++ binary on Debian

### DIFF
--- a/r/tools/nixlibs-allowlist.txt
+++ b/r/tools/nixlibs-allowlist.txt
@@ -1,3 +1,4 @@
+debian
 ubuntu
 centos
 redhat


### PR DESCRIPTION
### Rationale for this change

Our C++ binaries for R at https://apache.jfrog.io/ui/native/arrow/r/ can be used on Debian.

### What changes are included in this PR?

Allow Debian.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #47213