### PR TITLE
GH-47213: [R] Require CMake 3.26 or later

### DIFF
--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -29,7 +29,7 @@ BugReports: https://github.com/apache/arrow/issues
 Encoding: UTF-8
 Language: en-US
 SystemRequirements: C++17; for AWS S3 support on Linux, libcurl and openssl (optional);
-    cmake >= 3.25 (build-time only, and only for full source build)
+    cmake >= 3.26 (build-time only, and only for full source build)
 Biarch: true
 Imports:
     assertthat,

--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -636,7 +636,7 @@ build_libarrow <- function(src_dir, dst_dir) {
   invisible(status)
 }
 
-ensure_cmake <- function(cmake_minimum_required = "3.25") {
+ensure_cmake <- function(cmake_minimum_required = "3.26") {
   cmake <- find_cmake(version_required = cmake_minimum_required)
 
   if (is.null(cmake)) {


### PR DESCRIPTION
### Rationale for this change

We may need to build bundled Apache Thrift. It requires CMake 3.26 or later.

### What changes are included in this PR?

Require CMake 3.26 or later.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #47213