### PR TITLE
GH-47175: [C++] Require xsimd 13.0.0 or later

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -2549,7 +2549,7 @@ if(ARROW_USE_XSIMD)
                      IS_RUNTIME_DEPENDENCY
                      FALSE
                      REQUIRED_VERSION
-                     "8.1.0")
+                     "13.0.0")
 
   if(xsimd_SOURCE STREQUAL "BUNDLED")
     set(ARROW_XSIMD arrow::xsimd)


### PR DESCRIPTION
### Rationale for this change

We need xsimd 13.0.0 or later since https://github.com/apache/arrow/pull/46963 .

### What changes are included in this PR?

Require 13.0.0 or later for system xsimd.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #47175