### PR TITLE
GH-47223: [Release] Use "upstream" as apache/arrow{,-site} remote name

### DIFF
--- a/dev/release/post-01-tag.sh
+++ b/dev/release/post-01-tag.sh
@@ -32,4 +32,4 @@ rc=$2
 release_tag=apache-arrow-${version}
 release_candidate_tag=${release_tag}-rc${rc}
 git tag -a ${release_tag} ${release_candidate_tag} -m "[Release] Apache Arrow Release ${version}"
-git push apache ${release_tag}
+git push upstream ${release_tag}

--- a/dev/release/post-04-website.sh
+++ b/dev/release/post-04-website.sh
@@ -47,7 +47,7 @@ pushd "${ARROW_SITE_DIR}"
 source "${SOURCE_DIR}/git-vars.sh"
 git fetch --all --prune --tags --force -j$(nproc)
 git checkout ${DEFAULT_BRANCH}
-git rebase apache/${DEFAULT_BRANCH}
+git rebase upstream/${DEFAULT_BRANCH}
 git branch -D ${branch_name} || :
 git checkout -b ${branch_name}
 popd

--- a/dev/release/post-09-docs.sh
+++ b/dev/release/post-09-docs.sh
@@ -51,7 +51,7 @@ git checkout "${DEFAULT_BRANCH}"
 git clean -d -f -x
 git branch -D asf-site || :
 git checkout -b asf-site origin/asf-site
-git rebase apache/asf-site
+git rebase upstream/asf-site
 git branch -D "${branch_name}" || :
 git checkout -b "${branch_name}"
 # list and remove previous versioned docs

--- a/dev/release/post-11-bump-versions.sh
+++ b/dev/release/post-11-bump-versions.sh
@@ -67,7 +67,7 @@ if [ ${BUMP_UPDATE_LOCAL_DEFAULT_BRANCH} -gt 0 ]; then
 
   git fetch --all --prune --tags --force -j"$n_jobs"
   git checkout ${DEFAULT_BRANCH}
-  git rebase apache/${DEFAULT_BRANCH}
+  git rebase upstream/${DEFAULT_BRANCH}
 fi
 
 if [ ${BUMP_VERSION_POST_TAG} -gt 0 ]; then
@@ -87,12 +87,12 @@ fi
 
 if [ ${BUMP_PUSH} -gt 0 ]; then
   echo "Pushing changes to the default branch in apache/arrow"
-  git push apache ${DEFAULT_BRANCH}
+  git push upstream ${DEFAULT_BRANCH}
 fi
 
 if [ ${BUMP_TAG} -gt 0 -a ${is_major_release} -gt 0 ]; then
   dev_tag=apache-arrow-${next_version}.dev
   echo "Tagging ${dev_tag}"
   git tag ${dev_tag} ${DEFAULT_BRANCH}
-  git push apache ${dev_tag}
+  git push upstream ${dev_tag}
 fi

--- a/docs/source/developers/release.rst
+++ b/docs/source/developers/release.rst
@@ -162,7 +162,7 @@ Create or update the corresponding maintenance branch
             # of the release respectively. As an example 9.0.0
             archery release cherry-pick X.Y.Z --execute
             # Push the maintenance branch to the remote repository
-            git push -u apache maint-X.Y.Z
+            git push -u upstream maint-X.Y.Z
 
    .. tab-item:: Follow up Release Candidates
 
@@ -175,7 +175,7 @@ Create or update the corresponding maintenance branch
             # Update the maintenance branch with the previous commits
             archery release cherry-pick X.Y.Z --continue --execute
             # Push the updated maintenance branch to the remote repository
-            git push -u apache maint-X.Y.Z
+            git push -u upstream maint-X.Y.Z
 
 Optional: Test Before Creating a Release Candidate
 --------------------------------------------------
@@ -210,9 +210,9 @@ Create the Release Candidate branch from the updated maintenance branch
     dev/release/01-prepare.sh <version> <next-version> <rc-number>
 
     # Push the release candidate tag
-    git push -u apache apache-arrow-<version>-rc<rc-number>
+    git push -u upstream apache-arrow-<version>-rc<rc-number>
     # Push the release candidate branch in order to trigger verification jobs later
-    git push -u apache release-<version>-rc<rc-number>
+    git push -u upstream release-<version>-rc<rc-number>
 
 Build source and binaries and submit them
 -----------------------------------------
@@ -314,8 +314,8 @@ Be sure to go through on the following checklist:
       git checkout maint-X.Y.Z
       # git merge release-10.0.0-rc0
       git merge release-X.Y.Z-rcN
-      # git push -u apache maint-10.0.0
-      git push -u apache maint-X.Y.Z
+      # git push -u upstream maint-10.0.0
+      git push -u upstream maint-X.Y.Z
 
 .. dropdown:: Add the new release to the Apache Reporter System
    :animate: fade-in-slide-down
@@ -374,8 +374,8 @@ Be sure to go through on the following checklist:
       # git clone git@github.com:kou/arrow-site.git ../
       git clone git@github.com:<YOUR_GITHUB_ID>/arrow-site.git ../
       cd ../arrow-site
-      ## Add git@github.com:apache/arrow-site.git as "apache" remote.
-      git remote add apache git@github.com:apache/arrow-site.git
+      ## Add git@github.com:apache/arrow-site.git as "upstream" remote.
+      git remote add upstream git@github.com:apache/arrow-site.git
       cd -
 
       ## Generate a release note for the new version, update the
@@ -623,8 +623,8 @@ Be sure to go through on the following checklist:
       # git clone git@github.com:kou/arrow-site.git ../
       git clone git@github.com:<YOUR_GITHUB_ID>/arrow-site.git ../
       cd ../arrow-site
-      ## Add git@github.com:apache/arrow-site.git as "apache" remote.
-      git remote add apache git@github.com:apache/arrow-site.git
+      ## Add git@github.com:apache/arrow-site.git as "upstream" remote.
+      git remote add upstream git@github.com:apache/arrow-site.git
       cd -
 
       # dev/release/post-09-docs.sh 10.0.0 9.0.0


### PR DESCRIPTION
### Rationale for this change

"upstream" is a common remote name for upstream repository.

### What changes are included in this PR?

Use "upstream" not "apache" for apache/arrow and apache/arrow-site remote name.

### Are these changes tested?

No.

### Are there any user-facing changes?

No.
* GitHub Issue: #47223