### PR TITLE
GH-47243: [C++] Initialize arrow::compute in execution_plan_documentation_examples

### DIFF
--- a/cpp/examples/arrow/dataset_documentation_example.cc
+++ b/cpp/examples/arrow/dataset_documentation_example.cc
@@ -33,6 +33,7 @@
 #include <parquet/arrow/writer.h>
 #include "arrow/compute/expression.h"
 
+#include <filesystem>
 #include <iostream>
 #include <vector>
 
@@ -376,13 +377,9 @@ arrow::Status RunDatasetDocumentation(const std::string& format_name,
 }
 
 int main(int argc, char** argv) {
-  if (argc < 3) {
-    // Fake success for CI purposes.
-    return EXIT_SUCCESS;
-  }
-
-  std::string uri = argv[1];
-  std::string format_name = argv[2];
+  std::string uri =
+      argc > 1 ? argv[1] : "file://" + std::filesystem::temp_directory_path().string();
+  std::string format_name = argc > 2 ? argv[2] : "parquet";
   std::string mode = argc > 3 ? argv[3] : "no_filter";
 
   auto status = RunDatasetDocumentation(format_name, uri, mode);

--- a/cpp/examples/arrow/dataset_documentation_example.cc
+++ b/cpp/examples/arrow/dataset_documentation_example.cc
@@ -33,7 +33,6 @@
 #include <parquet/arrow/writer.h>
 #include "arrow/compute/expression.h"
 
-#include <filesystem>
 #include <iostream>
 #include <vector>
 
@@ -377,9 +376,13 @@ arrow::Status RunDatasetDocumentation(const std::string& format_name,
 }
 
 int main(int argc, char** argv) {
-  std::string uri =
-      argc > 1 ? argv[1] : "file://" + std::filesystem::temp_directory_path().string();
-  std::string format_name = argc > 2 ? argv[2] : "parquet";
+  if (argc < 3) {
+    // Fake success for CI purposes.
+    return EXIT_SUCCESS;
+  }
+
+  std::string uri = argv[1];
+  std::string format_name = argv[2];
   std::string mode = argc > 3 ? argv[3] : "no_filter";
 
   auto status = RunDatasetDocumentation(format_name, uri, mode);

--- a/cpp/examples/arrow/dataset_documentation_example.cc
+++ b/cpp/examples/arrow/dataset_documentation_example.cc
@@ -19,8 +19,8 @@
 // intended to be paired with the documentation.
 
 #include <arrow/api.h>
+#include <arrow/compute/api.h>
 #include <arrow/compute/cast.h>
-#include <arrow/compute/initialize.h>
 #include <arrow/dataset/dataset.h>
 #include <arrow/dataset/discovery.h>
 #include <arrow/dataset/file_base.h>

--- a/cpp/examples/arrow/dataset_documentation_example.cc
+++ b/cpp/examples/arrow/dataset_documentation_example.cc
@@ -20,6 +20,7 @@
 
 #include <arrow/api.h>
 #include <arrow/compute/cast.h>
+#include <arrow/compute/initialize.h>
 #include <arrow/dataset/dataset.h>
 #include <arrow/dataset/discovery.h>
 #include <arrow/dataset/file_base.h>
@@ -326,6 +327,8 @@ arrow::Result<std::shared_ptr<arrow::Table>> FilterPartitionedDataset(
 
 arrow::Status RunDatasetDocumentation(const std::string& format_name,
                                       const std::string& uri, const std::string& mode) {
+  ARROW_RETURN_NOT_OK(arrow::compute::Initialize());
+
   std::string base_path;
   std::shared_ptr<ds::FileFormat> format;
   std::string root_path;

--- a/cpp/examples/arrow/execution_plan_documentation_examples.cc
+++ b/cpp/examples/arrow/execution_plan_documentation_examples.cc
@@ -827,12 +827,17 @@ enum ExampleMode {
 int main(int argc, char** argv) {
   if (argc < 3) {
     // Fake success for CI purposes.
+    std::cout << "Usage: " << argv[0] << " base_save_path mode" << std::endl;
     return EXIT_SUCCESS;
   }
 
   std::string base_save_path = argv[1];
   int mode = std::atoi(argv[2]);
-  arrow::Status status;
+  arrow::Status status = arrow::compute::Initialize();
+  if (!status.ok()) {
+    std::cout << "Error occurred: " << status.message() << std::endl;
+    return EXIT_FAILURE;
+  }
   // ensure arrow::dataset node factories are in the registry
   arrow::dataset::internal::Initialize();
   switch (mode) {

--- a/cpp/examples/arrow/execution_plan_documentation_examples.cc
+++ b/cpp/examples/arrow/execution_plan_documentation_examples.cc
@@ -825,14 +825,8 @@ enum ExampleMode {
 };
 
 int main(int argc, char** argv) {
-  if (argc < 3) {
-    // Fake success for CI purposes.
-    std::cout << "Usage: " << argv[0] << " base_save_path mode" << std::endl;
-    return EXIT_SUCCESS;
-  }
-
-  std::string base_save_path = argv[1];
-  int mode = std::atoi(argv[2]);
+  int mode = argc > 1 ? std::atoi(argv[2]) : SOURCE_SINK;
+  std::string base_save_path = argc > 2 ? argv[2] : "";
   arrow::Status status = arrow::compute::Initialize();
   if (!status.ok()) {
     std::cout << "Error occurred: " << status.message() << std::endl;


### PR DESCRIPTION
### Rationale for this change
fix example running error
```

        ****** Scan Example ******

Error occurred: No function registered with name: make_struct
```

### What changes are included in this PR?
call arrow::compute::initialize ahead

### Are these changes tested?
yes

### Are there any user-facing changes?
no


* GitHub Issue: #47243