### PR TITLE
GH-47230: [C++] Fixes C++23 compatibility issues

### DIFF
--- a/cpp/src/arrow/filesystem/mockfs.cc
+++ b/cpp/src/arrow/filesystem/mockfs.cc
@@ -54,6 +54,7 @@ Status ValidatePath(std::string_view s) {
 ////////////////////////////////////////////////////////////////////////////
 // Filesystem structure
 
+struct Directory;
 class Entry;
 
 struct File {
@@ -80,38 +81,19 @@ struct Directory {
   TimePoint mtime;
   std::map<std::string, std::unique_ptr<Entry>> entries;
 
-  Directory(std::string name, TimePoint mtime) : name(std::move(name)), mtime(mtime) {}
-  Directory(Directory&& other) noexcept
-      : name(std::move(other.name)),
-        mtime(other.mtime),
-        entries(std::move(other.entries)) {}
+  Directory(std::string name, TimePoint mtime);
+  Directory(Directory&& other) noexcept;
 
-  Directory& operator=(Directory&& other) noexcept {
-    name = std::move(other.name);
-    mtime = other.mtime;
-    entries = std::move(other.entries);
-    return *this;
-  }
+  Directory& operator=(Directory&& other) noexcept;
 
-  Entry* Find(const std::string& s) {
-    auto it = entries.find(s);
-    if (it != entries.end()) {
-      return it->second.get();
-    } else {
-      return nullptr;
-    }
-  }
+  Entry* Find(const std::string& s);
 
-  bool CreateEntry(const std::string& s, std::unique_ptr<Entry> entry) {
-    DCHECK(!s.empty());
-    auto p = entries.emplace(s, std::move(entry));
-    return p.second;
-  }
+  bool CreateEntry(const std::string& s, std::unique_ptr<Entry> entry);
 
   void AssignEntry(const std::string& s, std::unique_ptr<Entry> entry);
 
-  bool DeleteEntry(const std::string& s) { return entries.erase(s) > 0; }
-
+  bool DeleteEntry(const std::string& s);
+  
  private:
   ARROW_DISALLOW_COPY_AND_ASSIGN(Directory);
 };
@@ -120,7 +102,7 @@ struct Directory {
 using EntryBase = std::variant<std::nullptr_t, File, Directory>;
 
 class Entry : public EntryBase {
- public:
+public:
   Entry(Entry&&) = default;
   Entry& operator=(Entry&&) = default;
   explicit Entry(Directory&& v) : EntryBase(std::move(v)) {}
@@ -180,14 +162,44 @@ class Entry : public EntryBase {
     }
   }
 
- private:
+private:
   ARROW_DISALLOW_COPY_AND_ASSIGN(Entry);
 };
+
+Directory::Directory(std::string name, TimePoint mtime) : name(std::move(name)), mtime(mtime) {}
+Directory::Directory(Directory&& other) noexcept
+    : name(std::move(other.name)),
+      mtime(other.mtime),
+      entries(std::move(other.entries)) {}
+
+Directory& Directory::operator=(Directory&& other) noexcept {
+  name = std::move(other.name);
+  mtime = other.mtime;
+  entries = std::move(other.entries);
+  return *this;
+}
+
+Entry* Directory::Find(const std::string& s) {
+  auto it = entries.find(s);
+  if (it != entries.end()) {
+    return it->second.get();
+  } else {
+    return nullptr;
+  }
+}
+
+bool Directory::CreateEntry(const std::string& s, std::unique_ptr<Entry> entry) {
+  DCHECK(!s.empty());
+  auto p = entries.emplace(s, std::move(entry));
+  return p.second;
+}
 
 void Directory::AssignEntry(const std::string& s, std::unique_ptr<Entry> entry) {
   DCHECK(!s.empty());
   entries[s] = std::move(entry);
 }
+
+bool Directory::DeleteEntry(const std::string& s) { return entries.erase(s) > 0; }
 
 ////////////////////////////////////////////////////////////////////////////
 // Streams


### PR DESCRIPTION
### Rationale for this change
This change improves compilation times and supports C++23 compatibility.

### What changes are included in this PR?
Moves constructor, move constructor, move assignment operator, and member function implementations (Find, CreateEntry, AssignEntry, DeleteEntry) from inline definitions in the header to the source file. Also fixes duplicate "public:" access specifier in Entry class. 

### Are these changes tested?

### Are there any user-facing changes?

Closes #47230 
