### PR TITLE
GH-47232: [Ruby] Suppress warnings in test with Ruby 3.5

### DIFF
--- a/ruby/red-arrow/test/test-buffer.rb
+++ b/ruby/red-arrow/test/test-buffer.rb
@@ -20,10 +20,12 @@ class BufferTest < Test::Unit::TestCase
     test("GC") do
       data = "Hello"
       data_id = data.object_id
+      weak_map = ObjectSpace::WeakMap.new
+      weak_map[data_id] = data
       _buffer = Arrow::Buffer.new(data)
       data = nil
       GC.start
-      assert_equal("Hello", ObjectSpace._id2ref(data_id))
+      assert_equal("Hello", weak_map[data_id])
     end
   end
 

--- a/ruby/red-arrow/test/test-ractor.rb
+++ b/ruby/red-arrow/test/test-ractor.rb
@@ -29,6 +29,11 @@ class RactorTest < Test::Unit::TestCase
       recived_chunked_array.chunks
     end
     ractor.send(chunked_array)
-    assert_equal([array], ractor.take)
+    unless ractor.respond_to?(:value) # For Ruby < 3.5
+      def ractor.value
+        take
+      end
+    end
+    assert_equal([array], ractor.value)
   end
 end


### PR DESCRIPTION
### Rationale for this change

```text
ruby/red-arrow/test/test-buffer.rb:26: warning: ObjectSpace._id2ref is deprecated
```

```text
ruby/red-arrow/test/test-ractor.rb:32: warning: Ractor#take was deprecated and use Ractor#value instead. This method will be removed after the end of Aug 2025
```

### What changes are included in this PR?

* Use `ObjectSpace::WeakMap` instead of `ObjectSapce._id2ref`
* Use `Ractor#value` instead of `Ractor#take`

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #47232