### PR TITLE
GH-47235: [C++] Add missing RapidJSON dependency to testing in Meson

### DIFF
--- a/cpp/src/arrow/meson.build
+++ b/cpp/src/arrow/meson.build
@@ -572,7 +572,13 @@ endif
 arrow_test_lib = static_library(
     'arrow_testing',
     sources: arrow_testing_srcs,
-    dependencies: [arrow_dep, filesystem_dep, gmock_dep, gtest_main_dep],
+    dependencies: [
+        arrow_dep,
+        filesystem_dep,
+        gmock_dep,
+        gtest_main_dep,
+        rapidjson_dep,
+    ],
 )
 
 if needs_tests


### PR DESCRIPTION
### Rationale for this change

When RapidJSON is not available on the system, this configuration fails to compile

### What changes are included in this PR?

Adds explicit dependency on RapidJSON to arrow testing sources

### Are these changes tested?

Yes

### Are there any user-facing changes?

No
* GitHub Issue: #47235