### PR TITLE
GH-47244: [CI][Dev] Fix shellcheck errors in the ci/scripts/msys2_setup.sh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -334,6 +334,7 @@ repos:
           ?^ci/scripts/integration_hdfs\.sh$|
           ?^ci/scripts/integration_spark\.sh$|
           ?^ci/scripts/matlab_build\.sh$|
+          ?^ci/scripts/msys2_setup\.sh$|
           ?^ci/scripts/msys2_system_clean\.sh$|
           ?^ci/scripts/msys2_system_upgrade\.sh$|
           ?^ci/scripts/nanoarrow_build\.sh$|

--- a/ci/scripts/msys2_setup.sh
+++ b/ci/scripts/msys2_setup.sh
@@ -24,33 +24,33 @@ target=$1
 packages=()
 case "${target}" in
   cpp|c_glib|ruby)
-    packages+=(${MINGW_PACKAGE_PREFIX}-aws-sdk-cpp)
-    packages+=(${MINGW_PACKAGE_PREFIX}-boost)
-    packages+=(${MINGW_PACKAGE_PREFIX}-brotli)
-    packages+=(${MINGW_PACKAGE_PREFIX}-bzip2)
-    packages+=(${MINGW_PACKAGE_PREFIX}-c-ares)
-    packages+=(${MINGW_PACKAGE_PREFIX}-ccache)
-    packages+=(${MINGW_PACKAGE_PREFIX}-clang)
-    packages+=(${MINGW_PACKAGE_PREFIX}-cmake)
-    packages+=(${MINGW_PACKAGE_PREFIX}-double-conversion)
-    packages+=(${MINGW_PACKAGE_PREFIX}-gflags)
-    packages+=(${MINGW_PACKAGE_PREFIX}-grpc)
-    packages+=(${MINGW_PACKAGE_PREFIX}-gtest)
-    packages+=(${MINGW_PACKAGE_PREFIX}-libutf8proc)
-    packages+=(${MINGW_PACKAGE_PREFIX}-libxml2)
-    packages+=(${MINGW_PACKAGE_PREFIX}-llvm)
-    packages+=(${MINGW_PACKAGE_PREFIX}-lz4)
-    packages+=(${MINGW_PACKAGE_PREFIX}-ninja)
-    packages+=(${MINGW_PACKAGE_PREFIX}-nlohmann-json)
-    packages+=(${MINGW_PACKAGE_PREFIX}-protobuf)
-    packages+=(${MINGW_PACKAGE_PREFIX}-rapidjson)
-    packages+=(${MINGW_PACKAGE_PREFIX}-re2)
-    packages+=(${MINGW_PACKAGE_PREFIX}-snappy)
-    packages+=(${MINGW_PACKAGE_PREFIX}-sqlite3)
-    packages+=(${MINGW_PACKAGE_PREFIX}-thrift)
-    packages+=(${MINGW_PACKAGE_PREFIX}-xsimd)
-    packages+=(${MINGW_PACKAGE_PREFIX}-uriparser)
-    packages+=(${MINGW_PACKAGE_PREFIX}-zstd)
+    packages+=("${MINGW_PACKAGE_PREFIX}-aws-sdk-cpp")
+    packages+=("${MINGW_PACKAGE_PREFIX}-boost")
+    packages+=("${MINGW_PACKAGE_PREFIX}-brotli")
+    packages+=("${MINGW_PACKAGE_PREFIX}-bzip2")
+    packages+=("${MINGW_PACKAGE_PREFIX}-c-ares")
+    packages+=("${MINGW_PACKAGE_PREFIX}-ccache")
+    packages+=("${MINGW_PACKAGE_PREFIX}-clang")
+    packages+=("${MINGW_PACKAGE_PREFIX}-cmake")
+    packages+=("${MINGW_PACKAGE_PREFIX}-double-conversion")
+    packages+=("${MINGW_PACKAGE_PREFIX}-gflags")
+    packages+=("${MINGW_PACKAGE_PREFIX}-grpc")
+    packages+=("${MINGW_PACKAGE_PREFIX}-gtest")
+    packages+=("${MINGW_PACKAGE_PREFIX}-libutf8proc")
+    packages+=("${MINGW_PACKAGE_PREFIX}-libxml2")
+    packages+=("${MINGW_PACKAGE_PREFIX}-llvm")
+    packages+=("${MINGW_PACKAGE_PREFIX}-lz4")
+    packages+=("${MINGW_PACKAGE_PREFIX}-ninja")
+    packages+=("${MINGW_PACKAGE_PREFIX}-nlohmann-json")
+    packages+=("${MINGW_PACKAGE_PREFIX}-protobuf")
+    packages+=("${MINGW_PACKAGE_PREFIX}-rapidjson")
+    packages+=("${MINGW_PACKAGE_PREFIX}-re2")
+    packages+=("${MINGW_PACKAGE_PREFIX}-snappy")
+    packages+=("${MINGW_PACKAGE_PREFIX}-sqlite3")
+    packages+=("${MINGW_PACKAGE_PREFIX}-thrift")
+    packages+=("${MINGW_PACKAGE_PREFIX}-xsimd")
+    packages+=("${MINGW_PACKAGE_PREFIX}-uriparser")
+    packages+=("${MINGW_PACKAGE_PREFIX}-zstd")
 
     if [ "${target}" != "ruby" ]; then
       # We don't update the exiting packages for Ruby because
@@ -58,17 +58,17 @@ case "${target}" in
       # OpenSSL and zlib separately. They should be ABI compatible
       # with packages installed by MSYS2. If we specify packages
       # explicitly here, the existing packages may be updated.
-      packages+=(${MINGW_PACKAGE_PREFIX}-openssl)
-      packages+=(${MINGW_PACKAGE_PREFIX}-zlib)
+      packages+=("${MINGW_PACKAGE_PREFIX}-openssl")
+      packages+=("${MINGW_PACKAGE_PREFIX}-zlib")
     fi
   ;;
 esac
 
 case "${target}" in
   c_glib|ruby)
-    packages+=(${MINGW_PACKAGE_PREFIX}-gobject-introspection)
-    packages+=(${MINGW_PACKAGE_PREFIX}-meson)
-    packages+=(${MINGW_PACKAGE_PREFIX}-vala)
+    packages+=("${MINGW_PACKAGE_PREFIX}-gobject-introspection")
+    packages+=("${MINGW_PACKAGE_PREFIX}-meson")
+    packages+=("${MINGW_PACKAGE_PREFIX}-vala")
     ;;
 esac
 
@@ -78,6 +78,7 @@ pacman \
   --sync \
   "${packages[@]}"
 
-"$(dirname $0)/ccache_setup.sh"
-echo "CCACHE_DIR=$(cygpath --absolute --windows ccache)" >> $GITHUB_ENV
-echo "PIP_CACHE_DIR=$(pip cache dir)" >> $GITHUB_ENV
+ccache_dir=$(dirname "$0")
+"${ccache_dir}/ccache_setup.sh"
+echo "CCACHE_DIR=$(cygpath --absolute --windows ccache)" >> "$GITHUB_ENV"
+echo "PIP_CACHE_DIR=$(pip cache dir)" >> "$GITHUB_ENV"


### PR DESCRIPTION
### Rationale for this change

This is the sub issue #44748.

* SC2206: Quote to prevent word splitting/globbing
* SC2086: Double quote to prevent globbing

```
shellcheck ci/scripts/msys2_setup.sh

In ci/scripts/msys2_setup.sh line 27:
    packages+=(${MINGW_PACKAGE_PREFIX}-aws-sdk-cpp)
               ^---------------------^ SC2206 (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.


In ci/scripts/msys2_setup.sh line 28:
    packages+=(${MINGW_PACKAGE_PREFIX}-boost)
               ^---------------------^ SC2206 (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.


In ci/scripts/msys2_setup.sh line 29:
    packages+=(${MINGW_PACKAGE_PREFIX}-brotli)
               ^---------------------^ SC2206 (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.


In ci/scripts/msys2_setup.sh line 30:
    packages+=(${MINGW_PACKAGE_PREFIX}-bzip2)
               ^---------------------^ SC2206 (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.


In ci/scripts/msys2_setup.sh line 31:
    packages+=(${MINGW_PACKAGE_PREFIX}-c-ares)
               ^---------------------^ SC2206 (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.


In ci/scripts/msys2_setup.sh line 32:
    packages+=(${MINGW_PACKAGE_PREFIX}-ccache)
               ^---------------------^ SC2206 (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.


In ci/scripts/msys2_setup.sh line 33:
    packages+=(${MINGW_PACKAGE_PREFIX}-clang)
               ^---------------------^ SC2206 (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.


In ci/scripts/msys2_setup.sh line 34:
    packages+=(${MINGW_PACKAGE_PREFIX}-cmake)
               ^---------------------^ SC2206 (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.


In ci/scripts/msys2_setup.sh line 35:
    packages+=(${MINGW_PACKAGE_PREFIX}-double-conversion)
               ^---------------------^ SC2206 (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.


In ci/scripts/msys2_setup.sh line 36:
    packages+=(${MINGW_PACKAGE_PREFIX}-gflags)
               ^---------------------^ SC2206 (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.


In ci/scripts/msys2_setup.sh line 37:
    packages+=(${MINGW_PACKAGE_PREFIX}-grpc)
               ^---------------------^ SC2206 (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.


In ci/scripts/msys2_setup.sh line 38:
    packages+=(${MINGW_PACKAGE_PREFIX}-gtest)
               ^---------------------^ SC2206 (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.


In ci/scripts/msys2_setup.sh line 39:
    packages+=(${MINGW_PACKAGE_PREFIX}-libutf8proc)
               ^---------------------^ SC2206 (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.


In ci/scripts/msys2_setup.sh line 40:
    packages+=(${MINGW_PACKAGE_PREFIX}-libxml2)
               ^---------------------^ SC2206 (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.


In ci/scripts/msys2_setup.sh line 41:
    packages+=(${MINGW_PACKAGE_PREFIX}-llvm)
               ^---------------------^ SC2206 (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.


In ci/scripts/msys2_setup.sh line 42:
    packages+=(${MINGW_PACKAGE_PREFIX}-lz4)
               ^---------------------^ SC2206 (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.


In ci/scripts/msys2_setup.sh line 43:
    packages+=(${MINGW_PACKAGE_PREFIX}-ninja)
               ^---------------------^ SC2206 (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.


In ci/scripts/msys2_setup.sh line 44:
    packages+=(${MINGW_PACKAGE_PREFIX}-nlohmann-json)
               ^---------------------^ SC2206 (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.


In ci/scripts/msys2_setup.sh line 45:
    packages+=(${MINGW_PACKAGE_PREFIX}-protobuf)
               ^---------------------^ SC2206 (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.


In ci/scripts/msys2_setup.sh line 46:
    packages+=(${MINGW_PACKAGE_PREFIX}-rapidjson)
               ^---------------------^ SC2206 (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.


In ci/scripts/msys2_setup.sh line 47:
    packages+=(${MINGW_PACKAGE_PREFIX}-re2)
               ^---------------------^ SC2206 (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.


In ci/scripts/msys2_setup.sh line 48:
    packages+=(${MINGW_PACKAGE_PREFIX}-snappy)
               ^---------------------^ SC2206 (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.


In ci/scripts/msys2_setup.sh line 49:
    packages+=(${MINGW_PACKAGE_PREFIX}-sqlite3)
               ^---------------------^ SC2206 (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.


In ci/scripts/msys2_setup.sh line 50:
    packages+=(${MINGW_PACKAGE_PREFIX}-thrift)
               ^---------------------^ SC2206 (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.


In ci/scripts/msys2_setup.sh line 51:
    packages+=(${MINGW_PACKAGE_PREFIX}-xsimd)
               ^---------------------^ SC2206 (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.


In ci/scripts/msys2_setup.sh line 52:
    packages+=(${MINGW_PACKAGE_PREFIX}-uriparser)
               ^---------------------^ SC2206 (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.


In ci/scripts/msys2_setup.sh line 53:
    packages+=(${MINGW_PACKAGE_PREFIX}-zstd)
               ^---------------------^ SC2206 (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.


In ci/scripts/msys2_setup.sh line 61:
      packages+=(${MINGW_PACKAGE_PREFIX}-openssl)
                 ^---------------------^ SC2206 (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.


In ci/scripts/msys2_setup.sh line 62:
      packages+=(${MINGW_PACKAGE_PREFIX}-zlib)
                 ^---------------------^ SC2206 (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.


In ci/scripts/msys2_setup.sh line 69:
    packages+=(${MINGW_PACKAGE_PREFIX}-gobject-introspection)
               ^---------------------^ SC2206 (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.


In ci/scripts/msys2_setup.sh line 70:
    packages+=(${MINGW_PACKAGE_PREFIX}-meson)
               ^---------------------^ SC2206 (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.


In ci/scripts/msys2_setup.sh line 71:
    packages+=(${MINGW_PACKAGE_PREFIX}-vala)
               ^---------------------^ SC2206 (warning): Quote to prevent word splitting/globbing, or split robustly with mapfile or read -a.


In ci/scripts/msys2_setup.sh line 81:
"$(dirname $0)/ccache_setup.sh"
           ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
"$(dirname "$0")/ccache_setup.sh"


In ci/scripts/msys2_setup.sh line 82:
echo "CCACHE_DIR=$(cygpath --absolute --windows ccache)" >> $GITHUB_ENV
                                                            ^---------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
echo "CCACHE_DIR=$(cygpath --absolute --windows ccache)" >> "$GITHUB_ENV"


In ci/scripts/msys2_setup.sh line 83:
echo "PIP_CACHE_DIR=$(pip cache dir)" >> $GITHUB_ENV
                                         ^---------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
echo "PIP_CACHE_DIR=$(pip cache dir)" >> "$GITHUB_ENV"

For more information:
  https://www.shellcheck.net/wiki/SC2206 -- Quote to prevent word splitting/g...
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
```

### What changes are included in this PR?

Quote variables.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #47244