### PR TITLE
MINOR: [R] Update backwards compat job for 21.0.0

### DIFF
--- a/dev/tasks/r/github.linux.arrow.version.back.compat.yml
+++ b/dev/tasks/r/github.linux.arrow.version.back.compat.yml
@@ -73,7 +73,9 @@ jobs:
         config:
         # We use the R version that was released at the time of the arrow release in order
         # to make sure we can download binaries from RSPM.
-        - { old_arrow_version: '19.0.1.1', r: '4.4' }
+        - { old_arrow_version: '20.0.0.2', r: '4.5' }
+        - { old_arrow_version: '20.0.0', r: '4.5' }
+        - { old_arrow_version: '19.0.1', r: '4.4' }
         - { old_arrow_version: '18.1.0', r: '4.4' }
         - { old_arrow_version: '17.0.0', r: '4.4' }
         - { old_arrow_version: '16.1.0', r: '4.4' }


### PR DESCRIPTION
### Rationale for this change

Add previous version of R package to backward compatibility job so we can ensure we don't make breaking changes

### What changes are included in this PR?

Add 21.0.0 to CI job

### Are these changes tested?

No

### Are there any user-facing changes?

No