### PR TITLE
MINOR: [Release] Make post-08-remove-old-artifacts.sh crossplatform

### DIFF
--- a/dev/release/post-08-remove-old-artifacts.sh
+++ b/dev/release/post-08-remove-old-artifacts.sh
@@ -43,7 +43,7 @@ old_releases=$(
   grep -E '^arrow-[0-9]' | \
   sort --version-sort --reverse | \
   tail -n +2 | \
-  tac
+  sort --version-sort
 )
 for old_release_version in $old_releases; do
   echo "Remove old release: ${old_release_version}"

--- a/dev/release/post-08-remove-old-artifacts.sh
+++ b/dev/release/post-08-remove-old-artifacts.sh
@@ -42,8 +42,7 @@ old_releases=$(
   svn ls ${release_base_url}/ | \
   grep -E '^arrow-[0-9]' | \
   sort --version-sort --reverse | \
-  tail -n +2 | \
-  sort --version-sort
+  tail -n +2
 )
 for old_release_version in $old_releases; do
   echo "Remove old release: ${old_release_version}"


### PR DESCRIPTION
### Rationale for this change

`dev/release/post-08-remove-old-artifacts.sh` uses [`tac`](https://man7.org/linux/man-pages/man1/tac.1.html) which may not be available on non-Linuxes. We should be able to get its same behavior with more common utilities.

### What changes are included in this PR?

Swaps the call to `tac` with `sort --version-sort` which should be equivalent.

### Are these changes tested?

Yes. This shouldn't impact which artifacts are removed, just the order in which they are.

### Are there any user-facing changes?

No.
