### PR TITLE
GH-47258: [Release] Set `date:` for apache/arrow-site's `_release/${VERSION}.md`

### DIFF
--- a/dev/release/post-04-website.sh
+++ b/dev/release/post-04-website.sh
@@ -95,6 +95,7 @@ cat <<ANNOUNCE > "${announce_file}"
 ---
 layout: default
 title: Apache Arrow ${version} Release
+date: "${release_date_iso8601}"
 permalink: /release/${version}.html
 ---
 <!--


### PR DESCRIPTION
### Rationale for this change

We want to avoid needless Jekyll built site changes. If we don't specify date explicitly, the current time is used. It always causes some changes.

See also: https://github.com/apache/arrow-site/issues/689

### What changes are included in this PR?

Set `date: ` explicitly.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.

* GitHub Issue: #47258