### PR TITLE
GH-47208: [C++][CI] Add a CI job for C++23

### DIFF
--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -124,6 +124,7 @@ jobs:
               -e ARROW_USE_MESON=ON
             runs-on: ubuntu-latest
             title: AMD64 Ubuntu Meson
+          # TODO: We should remove this "continue-on-error: true" once GH-47207 is resolved
           - continue-on-error: true
             image: debian-cpp
             run-options: >-

--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -124,6 +124,12 @@ jobs:
               -e ARROW_USE_MESON=ON
             runs-on: ubuntu-latest
             title: AMD64 Ubuntu Meson
+          - continue-on-error: true
+            image: debian-cpp
+            run-options: >-
+              -e CMAKE_CXX_STANDARD=23
+            runs-on: ubuntu-latest
+            title: AMD64 Debian C++23
     env:
       ARCHERY_DEBUG: 1
       ARROW_ENABLE_TIMING_TESTS: OFF
@@ -147,6 +153,7 @@ jobs:
       - name: Setup Archery
         run: python3 -m pip install -e dev/archery[docker]
       - name: Execute Docker Build
+        continue-on-error: ${{ matrix.continue-on-error || false }}
         env:
           ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}
           ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
### Rationale for this change

We want to add support for C++23.

### What changes are included in this PR?

Add a CI job for C++23 as an extra job but its failure is ignored for now. Because we aren't C++23 ready for now.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #47208