### PR TITLE
GH-47265: [Ruby] Fix wrong `Time` object detection

### DIFF
--- a/ruby/red-arrow/lib/arrow/timestamp-array-builder.rb
+++ b/ruby/red-arrow/lib/arrow/timestamp-array-builder.rb
@@ -30,7 +30,7 @@ module Arrow
     end
 
     def convert_to_arrow_value(value)
-      if value.respond_to?(:to_time) and not value.is_a?(Time)
+      if value.respond_to?(:to_time) and not value.is_a?(::Time)
         value = value.to_time
       end
 


### PR DESCRIPTION
### Rationale for this change

We can't use `Time` to refer `::Time` in `Arrow` namespace because there is `Arrow::Time`.

### What changes are included in this PR?

Use `::Time` to refer the top-level `Time`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #47265