### PR TITLE
GH-47271: [C++][Acero] Buffers returned by filter node use the default memory pool

### DIFF
--- a/cpp/src/arrow/acero/filter_node.cc
+++ b/cpp/src/arrow/acero/filter_node.cc
@@ -100,7 +100,7 @@ class FilterNode : public MapNode {
     auto values = batch.values;
     for (auto& value : values) {
       if (value.is_scalar()) continue;
-      ARROW_ASSIGN_OR_RAISE(value, Filter(value, mask, FilterOptions::Defaults()));
+      ARROW_ASSIGN_OR_RAISE(value, Filter(value, mask, FilterOptions::Defaults(), plan()->query_context()->exec_context()));
     }
     return ExecBatch::Make(std::move(values));
   }


### PR DESCRIPTION
### Rationale for this change
We found a bug where our MemoryPool was not used by the Acero FilterNode to allocate the output. We traced this down to the FilterNode not passing on the exec_context to the Filter function which then in turn uses the default memory pool to allocate new Buffers.

### What changes are included in this PR?
There is a one line change that passes the exec_context in the FilterNode to the Filter function.

### Are these changes tested?
Yes.

### Are there any user-facing changes?
No.

**This PR contains a "Critical Fix".** 
In our case, this leads to a crash because the wrong memory pool is used.

* GitHub Issue: #47271