### PR TITLE
GH-47273: [CI][Dev] Fix shellcheck errors in the ci/scripts/python_benchmark.sh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -338,6 +338,7 @@ repos:
           ?^ci/scripts/msys2_system_clean\.sh$|
           ?^ci/scripts/msys2_system_upgrade\.sh$|
           ?^ci/scripts/nanoarrow_build\.sh$|
+          ?^ci/scripts/python_benchmark\.sh$|
           ?^ci/scripts/python_sdist_build\.sh$|
           ?^ci/scripts/python_wheel_unix_test\.sh$|
           ?^ci/scripts/r_build\.sh$|

--- a/ci/scripts/python_benchmark.sh
+++ b/ci/scripts/python_benchmark.sh
@@ -43,4 +43,4 @@ git fetch --depth=100 origin "${DEFAULT_BRANCH}:${DEFAULT_BRANCH}"
 asv machine --yes
 # Run benchmarks on the changeset being tested
 asv run --no-pull --show-stderr --quick HEAD^!
-popd # $ARROW_PYTHON_DIR
+popd  # $ARROW_PYTHON_DIR

--- a/ci/scripts/python_benchmark.sh
+++ b/ci/scripts/python_benchmark.sh
@@ -16,6 +16,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+set -e
 
 # Check the ASV benchmarking setup.
 # Unfortunately this won't ensure that all benchmarks succeed
@@ -34,7 +35,7 @@ export PYARROW_WITH_PARQUET=1
 export PYARROW_WITH_ORC=0
 export PYARROW_WITH_GANDIVA=0
 
-pushd "$ARROW_PYTHON_DIR" || exit 1
+pushd "$ARROW_PYTHON_DIR"
 # Workaround for https://github.com/airspeed-velocity/asv/issues/631
 DEFAULT_BRANCH=$(git rev-parse --abbrev-ref origin/HEAD | sed s@origin/@@)
 git fetch --depth=100 origin "${DEFAULT_BRANCH}:${DEFAULT_BRANCH}"
@@ -42,4 +43,4 @@ git fetch --depth=100 origin "${DEFAULT_BRANCH}:${DEFAULT_BRANCH}"
 asv machine --yes
 # Run benchmarks on the changeset being tested
 asv run --no-pull --show-stderr --quick HEAD^!
-popd || exit # $ARROW_PYTHON_DIR
+popd # $ARROW_PYTHON_DIR

--- a/ci/scripts/python_benchmark.sh
+++ b/ci/scripts/python_benchmark.sh
@@ -20,8 +20,13 @@
 # Check the ASV benchmarking setup.
 # Unfortunately this won't ensure that all benchmarks succeed
 # (see https://github.com/airspeed-velocity/asv/issues/449)
+#
+# We don't need to follow this external file.
+# See also: https://www.shellcheck.net/wiki/SC1091
+#
+# shellcheck source=/dev/null
 source deactivate
-conda create -y -q -n pyarrow_asv python=$PYTHON_VERSION
+conda create -y -q -n pyarrow_asv python="$PYTHON_VERSION"
 conda activate pyarrow_asv
 pip install -q git+https://github.com/pitrou/asv.git@customize_commands
 
@@ -29,12 +34,12 @@ export PYARROW_WITH_PARQUET=1
 export PYARROW_WITH_ORC=0
 export PYARROW_WITH_GANDIVA=0
 
-pushd $ARROW_PYTHON_DIR
+pushd "$ARROW_PYTHON_DIR" || exit 1
 # Workaround for https://github.com/airspeed-velocity/asv/issues/631
 DEFAULT_BRANCH=$(git rev-parse --abbrev-ref origin/HEAD | sed s@origin/@@)
-git fetch --depth=100 origin $DEFAULT_BRANCH:$DEFAULT_BRANCH
+git fetch --depth=100 origin "${DEFAULT_BRANCH}:${DEFAULT_BRANCH}"
 # Generate machine information (mandatory)
 asv machine --yes
 # Run benchmarks on the changeset being tested
 asv run --no-pull --show-stderr --quick HEAD^!
-popd  # $ARROW_PYTHON_DIR
+popd || exit # $ARROW_PYTHON_DIR


### PR DESCRIPTION
### Rationale for this change

This is the sub issue #44748.

* SC1091: Not following
* SC2086: Double quote to prevent globbing and word splitting.
* SC2164: Use `cd ... || exit` in case `cd` fails


```
shellcheck ci/scripts/python_benchmark.sh

In ci/scripts/python_benchmark.sh line 23:
source deactivate
       ^--------^ SC1091 (info): Not following: deactivate: openBinaryFile: does not exist (No such file or directory)


In ci/scripts/python_benchmark.sh line 24:
conda create -y -q -n pyarrow_asv python=$PYTHON_VERSION
                                         ^-------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
conda create -y -q -n pyarrow_asv python="$PYTHON_VERSION"


In ci/scripts/python_benchmark.sh line 32:
pushd $ARROW_PYTHON_DIR
^---------------------^ SC2164 (warning): Use 'pushd ... || exit' or 'pushd ... || return' in case pushd fails.
      ^---------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
pushd "$ARROW_PYTHON_DIR" || exit


In ci/scripts/python_benchmark.sh line 35:
git fetch --depth=100 origin $DEFAULT_BRANCH:$DEFAULT_BRANCH
                             ^-------------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                             ^-------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
git fetch --depth=100 origin "$DEFAULT_BRANCH":"$DEFAULT_BRANCH"


In ci/scripts/python_benchmark.sh line 40:
popd  # $ARROW_PYTHON_DIR
^--^ SC2164 (warning): Use 'popd ... || exit' or 'popd ... || return' in case popd fails.

Did you mean:
popd || exit  # $ARROW_PYTHON_DIR

For more information:
  https://www.shellcheck.net/wiki/SC2164 -- Use 'popd ... || exit' or 'popd ....
  https://www.shellcheck.net/wiki/SC1091 -- Not following: deactivate: openBi...
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
```

### What changes are included in this PR?

* SC1091:  disable test
* SC2086: Quote variables.
* SC2164: Use `... || exit`

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #47273