### PR TITLE
GH-45449: [R][CI] Remove OpenSSL 1.x builds 

### DIFF
--- a/dev/tasks/r/github.packages.yml
+++ b/dev/tasks/r/github.packages.yml
@@ -57,7 +57,7 @@ jobs:
           path: arrow/r/arrow_*.tar.gz
 
   macos-cpp:
-    name: C++ Binary macOS OpenSSL {{ '${{ matrix.openssl }}' }} {{ '${{ matrix.platform.arch }}' }}
+    name: C++ Binary macOS {{ '${{ matrix.platform.arch }}' }}
 
     runs-on: {{ '${{ matrix.platform.runs_on }}' }}
 
@@ -68,15 +68,13 @@ jobs:
         platform:
           - { runs_on: macos-13, arch: "x86_64" }
           - { runs_on: macos-14, arch: "arm64" }
-        openssl: ['3.0', '1.1']
-
     steps:
       {{ macros.github_checkout_arrow(action_v="3")|indent }}
       {{ macros.github_change_r_pkg_version(is_fork, '${{ needs.source.outputs.pkg_version }}')|indent }}
       - name: Install Deps
         run: |
           brew install sccache ninja
-          brew install openssl@{{ '${{ matrix.openssl }}' }}
+          brew install openssl@3.0
       - name: Build libarrow
         shell: bash
         env:
@@ -89,7 +87,7 @@ jobs:
           LIBARROW_MINIMAL: false
         run: |
           sccache --start-server
-          export EXTRA_CMAKE_FLAGS="-DOPENSSL_ROOT_DIR=$(brew --prefix openssl@{{ '${{ matrix.openssl }}' }})"
+          export EXTRA_CMAKE_FLAGS="-DOPENSSL_ROOT_DIR=$(brew --prefix openssl@3.0)"
           cd arrow
           r/inst/build_arrow_static.sh
       - name: Bundle libarrow
@@ -108,11 +106,11 @@ jobs:
       - name: Upload binary artifact
         uses: actions/upload-artifact@v4
         with:
-          name: r-lib__libarrow__bin__darwin-{{ '${{ matrix.platform.arch }}' }}-openssl-{{ '${{ matrix.openssl }}' }}
+          name: r-lib__libarrow__bin__darwin-{{ '${{ matrix.platform.arch }}' }}
           path: arrow/r/libarrow/dist/arrow-*.zip*
 
   linux-cpp:
-    name: C++ Binary Linux OpenSSL {{ '${{ matrix.openssl }}' }}
+    name: C++ Binary Linux
     runs-on: ubuntu-latest
     needs: source
     strategy:
@@ -122,13 +120,6 @@ jobs:
           - openssl: "3.0"
             os: ubuntu
             ubuntu: "22.04"
-          - extra-cmake-flags: >-
-              -DCMAKE_INCLUDE_PATH=/usr/include/openssl11
-              -DCMAKE_LIBRARY_PATH=/usr/lib64/openssl11
-            openssl: "1.1"
-            os: centos
-          - openssl: "1.0"
-            os: centos
     steps:
       {{ macros.github_checkout_arrow()|indent }}
       {{ macros.github_change_r_pkg_version(is_fork, '${{ needs.source.outputs.pkg_version }}')|indent }}
@@ -163,7 +154,7 @@ jobs:
       - name: Upload binary artifact
         uses: actions/upload-artifact@v4
         with:
-          name: r-lib__libarrow__bin__linux-openssl-{{ '${{ matrix.openssl }}' }}
+          name: r-lib__libarrow__bin__linux
           path: arrow/r/libarrow/dist/arrow-*.zip*
 
   windows-cpp:

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -532,12 +532,8 @@ tasks:
       custom_version: Unset
     artifacts:
       - r-lib__libarrow__bin__windows__arrow-{no_rc_r_version}\.zip
-      - r-lib__libarrow__bin__linux-openssl-1.0__arrow-{no_rc_r_version}\.zip
-      - r-lib__libarrow__bin__linux-openssl-1.1__arrow-{no_rc_r_version}\.zip
       - r-lib__libarrow__bin__linux-openssl-3.0__arrow-{no_rc_r_version}\.zip
-      - r-lib__libarrow__bin__darwin-arm64-openssl-1.1__arrow-{no_rc_r_version}\.zip
       - r-lib__libarrow__bin__darwin-arm64-openssl-3.0__arrow-{no_rc_r_version}\.zip
-      - r-lib__libarrow__bin__darwin-x86_64-openssl-1.1__arrow-{no_rc_r_version}\.zip
       - r-lib__libarrow__bin__darwin-x86_64-openssl-3.0__arrow-{no_rc_r_version}\.zip
       - r-pkg__bin__windows__contrib__4.5__arrow_{no_rc_r_version}\.zip
       - r-pkg__bin__windows__contrib__4.4__arrow_{no_rc_r_version}\.zip

--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -28,7 +28,7 @@ URL: https://github.com/apache/arrow/, https://arrow.apache.org/docs/r/
 BugReports: https://github.com/apache/arrow/issues
 Encoding: UTF-8
 Language: en-US
-SystemRequirements: C++17; for AWS S3 support on Linux, libcurl and openssl (optional);
+SystemRequirements: C++17; for AWS S3 support on Linux, libcurl and openssl > 3.0.0 (optional);
     cmake >= 3.25 (build-time only, and only for full source build)
 Biarch: true
 Imports:

--- a/r/vignettes/developers/install_details.Rmd
+++ b/r/vignettes/developers/install_details.Rmd
@@ -103,7 +103,7 @@ package, as development version numbers do not change with every commit.
 If libarrow is not found on the system, the R package installation
 script will next attempt to download prebuilt libarrow binaries
 that match your both your local operating system, required
-dependencies (e.g. openssl version) and arrow R package version.
+dependencies, and arrow R package version.
 
 These are used automatically on many Linux distributions (x86_64 architecture only),
 according to the [allowlist](https://github.com/apache/arrow/blob/main/r/tools/nixlibs-allowlist.txt).

--- a/r/vignettes/developers/setup.Rmd
+++ b/r/vignettes/developers/setup.Rmd
@@ -71,7 +71,7 @@ There are five major steps to the process.
 
 ### Step 1 - Install dependencies
 
-When building libarrow, by default, system dependencies will be used if suitable versions are found.  If system dependencies are not present, libarrow will build them during its own build process. The only dependencies that you need to install _outside_ of the build process are [cmake](https://cmake.org/) (for configuring the build) and [openssl](https://www.openssl.org/) if you are building with S3 support.
+When building libarrow, by default, system dependencies will be used if suitable versions are found.  If system dependencies are not present, libarrow will build them during its own build process. The only dependencies that you need to install _outside_ of the build process are [cmake](https://cmake.org/) (for configuring the build) and [openssl](https://www.openssl.org/) version >= 3.0.0 if you are building with S3 support.
 
 For a faster build, you may choose to pre-install more C++ library dependencies (such as [lz4](http://lz4.github.io/lz4/), [zstd](https://facebook.github.io/zstd/), etc.) on the system  so that they don't need to be built from source in the libarrow build.
 


### PR DESCRIPTION
### Rationale for this change

### What changes are included in this PR?

### Are these changes tested?

### Are there any user-facing changes?


* GitHub Issue: #45449