### PR TITLE
GH-47277: [R] Disable building OpenSSL 1.X binaries

### DIFF
--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -298,7 +298,7 @@ env:
       path: repo/libarrow/bin/windows
   {% endif %}
   {% if get_nix %}
-    {% for openssl_version in ["1.0", "1.1", "3.0"] %}
+    {% for openssl_version in ["3.0"] %}
   - name: Get Linux OpenSSL {{ openssl_version }} binary
     uses: actions/download-artifact@v4
     with:
@@ -307,7 +307,7 @@ env:
     {% endfor %}
   {% endif %}
   {% if get_mac %}
-    {% for openssl_version in ["1.1", "3.0"] %}
+    {% for openssl_version in ["3.0"] %}
       {% for arch in ["x86_64", "arm64"] %}
   - name: Get macOS {{ arch }} OpenSSL {{ openssl_version }} binary
     uses: actions/download-artifact@v4

--- a/dev/tasks/r/github.packages.yml
+++ b/dev/tasks/r/github.packages.yml
@@ -68,7 +68,7 @@ jobs:
         platform:
           - { runs_on: macos-13, arch: "x86_64" }
           - { runs_on: macos-14, arch: "arm64" }
-        openssl: ['3.0', '1.1']
+        openssl: ['3.0']
 
     steps:
       {{ macros.github_checkout_arrow(action_v="3")|indent }}
@@ -122,13 +122,7 @@ jobs:
           - openssl: "3.0"
             os: ubuntu
             ubuntu: "22.04"
-          - extra-cmake-flags: >-
-              -DCMAKE_INCLUDE_PATH=/usr/include/openssl11
-              -DCMAKE_LIBRARY_PATH=/usr/lib64/openssl11
-            openssl: "1.1"
-            os: centos
-          - openssl: "1.0"
-            os: centos
+
     steps:
       {{ macros.github_checkout_arrow()|indent }}
       {{ macros.github_change_r_pkg_version(is_fork, '${{ needs.source.outputs.pkg_version }}')|indent }}

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -532,12 +532,8 @@ tasks:
       custom_version: Unset
     artifacts:
       - r-lib__libarrow__bin__windows__arrow-{no_rc_r_version}\.zip
-      - r-lib__libarrow__bin__linux-openssl-1.0__arrow-{no_rc_r_version}\.zip
-      - r-lib__libarrow__bin__linux-openssl-1.1__arrow-{no_rc_r_version}\.zip
       - r-lib__libarrow__bin__linux-openssl-3.0__arrow-{no_rc_r_version}\.zip
-      - r-lib__libarrow__bin__darwin-arm64-openssl-1.1__arrow-{no_rc_r_version}\.zip
       - r-lib__libarrow__bin__darwin-arm64-openssl-3.0__arrow-{no_rc_r_version}\.zip
-      - r-lib__libarrow__bin__darwin-x86_64-openssl-1.1__arrow-{no_rc_r_version}\.zip
       - r-lib__libarrow__bin__darwin-x86_64-openssl-3.0__arrow-{no_rc_r_version}\.zip
       - r-pkg__bin__windows__contrib__4.5__arrow_{no_rc_r_version}\.zip
       - r-pkg__bin__windows__contrib__4.4__arrow_{no_rc_r_version}\.zip


### PR DESCRIPTION
### Rationale for this change

Nightlies failing to build with openSSL < 3.0

### What changes are included in this PR?

Ditch those builds while we figure out if we need to drop support or not in the more complex #47280

### Are these changes tested?

No but I'll check if things build 

### Are there any user-facing changes?

Yup, no nightly binaries if you've got openSSL < 3 but they've not been built since mid-July anyway, so not really
* GitHub Issue: #47277