### PR TITLE
GH-47268: [C++][Compute] Fix discarded bad status for call binding

### DIFF
--- a/cpp/src/arrow/compute/expression.cc
+++ b/cpp/src/arrow/compute/expression.cc
@@ -566,9 +566,8 @@ Result<Expression> BindNonRecursive(Expression::Call call, bool insert_implicit_
   Result<const Kernel*> maybe_exact_match = call.function->DispatchExact(types);
   if (maybe_exact_match.ok()) {
     call.kernel = *maybe_exact_match;
-    if (FinishBind().ok()) {
-      return Expression(std::move(call));
-    }
+    RETURN_NOT_OK(FinishBind());
+    return Expression(std::move(call));
   }
 
   if (!insert_implicit_casts) {

--- a/cpp/src/arrow/compute/expression.cc
+++ b/cpp/src/arrow/compute/expression.cc
@@ -545,66 +545,61 @@ Result<Expression> BindNonRecursive(Expression::Call call, bool insert_implicit_
   std::vector<TypeHolder> types = GetTypes(call.arguments);
   ARROW_ASSIGN_OR_RAISE(call.function, GetFunction(call, exec_context));
 
-  auto FinishBind = [&] {
-    compute::KernelContext kernel_context(exec_context, call.kernel);
-    if (call.kernel->init) {
-      const FunctionOptions* options =
-          call.options ? call.options.get() : call.function->default_options();
-      ARROW_ASSIGN_OR_RAISE(
-          call.kernel_state,
-          call.kernel->init(&kernel_context, {call.kernel, types, options}));
-
-      kernel_context.SetState(call.kernel_state.get());
-    }
-
-    ARROW_ASSIGN_OR_RAISE(
-        call.type, call.kernel->signature->out_type().Resolve(&kernel_context, types));
-    return Status::OK();
-  };
-
   // First try and bind exactly
   Result<const Kernel*> maybe_exact_match = call.function->DispatchExact(types);
   if (maybe_exact_match.ok()) {
     call.kernel = *maybe_exact_match;
-    RETURN_NOT_OK(FinishBind());
-    return Expression(std::move(call));
-  }
-
-  if (!insert_implicit_casts) {
-    return maybe_exact_match.status();
-  }
-
-  // If exact binding fails, and we are allowed to cast, then prefer casting literals
-  // first.  Since DispatchBest generally prefers up-casting the best way to do this is
-  // first down-cast the literals as much as possible
-  types = GetTypesWithSmallestLiteralRepresentation(call.arguments);
-  ARROW_ASSIGN_OR_RAISE(call.kernel, call.function->DispatchBest(&types));
-
-  for (size_t i = 0; i < types.size(); ++i) {
-    if (types[i] == call.arguments[i].type()) continue;
-
-    if (const Datum* lit = call.arguments[i].literal()) {
-      ARROW_ASSIGN_OR_RAISE(Datum new_lit, compute::Cast(*lit, types[i].GetSharedPtr()));
-      call.arguments[i] = literal(std::move(new_lit));
-      continue;
+  } else {
+    if (!insert_implicit_casts) {
+      return maybe_exact_match.status();
     }
 
-    // construct an implicit cast Expression with which to replace this argument
-    Expression::Call implicit_cast;
-    implicit_cast.function_name = "cast";
-    implicit_cast.arguments = {std::move(call.arguments[i])};
+    // If exact binding fails, and we are allowed to cast, then prefer casting literals
+    // first.  Since DispatchBest generally prefers up-casting the best way to do this is
+    // first down-cast the literals as much as possible
+    types = GetTypesWithSmallestLiteralRepresentation(call.arguments);
+    ARROW_ASSIGN_OR_RAISE(call.kernel, call.function->DispatchBest(&types));
 
-    // TODO(wesm): Use TypeHolder in options
-    implicit_cast.options = std::make_shared<compute::CastOptions>(
-        compute::CastOptions::Safe(types[i].GetSharedPtr()));
+    for (size_t i = 0; i < types.size(); ++i) {
+      if (types[i] == call.arguments[i].type()) continue;
 
-    ARROW_ASSIGN_OR_RAISE(
-        call.arguments[i],
-        BindNonRecursive(std::move(implicit_cast),
-                         /*insert_implicit_casts=*/false, exec_context));
+      if (const Datum* lit = call.arguments[i].literal()) {
+        ARROW_ASSIGN_OR_RAISE(Datum new_lit,
+                              compute::Cast(*lit, types[i].GetSharedPtr()));
+        call.arguments[i] = literal(std::move(new_lit));
+        continue;
+      }
+
+      // construct an implicit cast Expression with which to replace this argument
+      Expression::Call implicit_cast;
+      implicit_cast.function_name = "cast";
+      implicit_cast.arguments = {std::move(call.arguments[i])};
+
+      // TODO(wesm): Use TypeHolder in options
+      implicit_cast.options = std::make_shared<compute::CastOptions>(
+          compute::CastOptions::Safe(types[i].GetSharedPtr()));
+
+      ARROW_ASSIGN_OR_RAISE(
+          call.arguments[i],
+          BindNonRecursive(std::move(implicit_cast),
+                           /*insert_implicit_casts=*/false, exec_context));
+    }
   }
 
-  RETURN_NOT_OK(FinishBind());
+  compute::KernelContext kernel_context(exec_context, call.kernel);
+  if (call.kernel->init) {
+    const FunctionOptions* options =
+        call.options ? call.options.get() : call.function->default_options();
+    ARROW_ASSIGN_OR_RAISE(
+        call.kernel_state,
+        call.kernel->init(&kernel_context, {call.kernel, types, options}));
+
+    kernel_context.SetState(call.kernel_state.get());
+  }
+
+  ARROW_ASSIGN_OR_RAISE(
+      call.type, call.kernel->signature->out_type().Resolve(&kernel_context, types));
+
   return Expression(std::move(call));
 }
 


### PR DESCRIPTION
### Rationale for this change

Faithfully propagate the bad status thrown in call expression binding.

### What changes are included in this PR?

Early return when status is bad.

### Are these changes tested?

UT included.

### Are there any user-facing changes?

None.

* GitHub Issue: #47268