### PR TITLE
GH-47096: [CI][R] Drop support for R 4.0

### DIFF
--- a/dev/tasks/r/github.linux.versions.yml
+++ b/dev/tasks/r/github.linux.versions.yml
@@ -30,9 +30,9 @@ jobs:
         r_version:
           # We test devel, release, and oldrel in regular CI.
           # This is for older versions
-          - "4.0"
           - "4.1"
           - "4.2"
+          - "4.3"
     env:
       R_ORG: "rstudio"
       R_IMAGE: "r-base"

--- a/dev/tasks/r/github.packages.yml
+++ b/dev/tasks/r/github.packages.yml
@@ -313,7 +313,6 @@ jobs:
           # fedora-clang-devel cannot use binaries bc of libc++ (uncomment to see the error)
           # - {image: "rhub/fedora-clang-devel", libarrow_binary: "TRUE"}
           - {image: "rhub/ubuntu-release"} # currently ubuntu-22.04
-          - {image: "rstudio/r-base:4.0-jammy"}
           - {image: "rstudio/r-base:4.1-jammy"}
           - {image: "rstudio/r-base:4.2-jammy"}
           - {image: "rstudio/r-base:4.3-noble"}

--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -22,7 +22,7 @@ Description: 'Apache' 'Arrow' <https://arrow.apache.org/> is a cross-language
     language-independent columnar memory format for flat and hierarchical data,
     organized for efficient analytic operations on modern hardware. This
     package provides an interface to the 'Arrow C++' library.
-Depends: R (>= 4.0)
+Depends: R (>= 4.1)
 License: Apache License (>= 2.0)
 URL: https://github.com/apache/arrow/, https://arrow.apache.org/docs/r/
 BugReports: https://github.com/apache/arrow/issues


### PR DESCRIPTION
### Rationale for this change

R 4.0 jobs are failing because purrr 1.1.0 requires R 4.1 or later

### What changes are included in this PR?

Drop 4.0 support

### Are these changes tested?

Will fire off the CI

### Are there any user-facing changes?

Only if you're on R 4.0
* GitHub Issue: #47096