### PR TITLE
GH-47289: [CI][Dev] Fix shellcheck errors in the ci/scripts/python_build_emscripten.sh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -338,6 +338,7 @@ repos:
           ?^ci/scripts/msys2_system_clean\.sh$|
           ?^ci/scripts/msys2_system_upgrade\.sh$|
           ?^ci/scripts/nanoarrow_build\.sh$|
+          ?^ci/scripts/python_build_emscripten\.sh$|
           ?^ci/scripts/python_sdist_build\.sh$|
           ?^ci/scripts/python_wheel_unix_test\.sh$|
           ?^ci/scripts/r_build\.sh$|
@@ -348,7 +349,6 @@ repos:
           ?^ci/scripts/util_enable_core_dumps\.sh$|
           ?^ci/scripts/util_free_space\.sh$|
           ?^ci/scripts/util_log\.sh$|
-          ?^python_build_emscripten\.sh$|
           ?^cpp/build-support/build-lz4-lib\.sh$|
           ?^cpp/build-support/build-zstd-lib\.sh$|
           ?^cpp/build-support/get-upstream-commit\.sh$|

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -348,6 +348,7 @@ repos:
           ?^ci/scripts/util_enable_core_dumps\.sh$|
           ?^ci/scripts/util_free_space\.sh$|
           ?^ci/scripts/util_log\.sh$|
+          ?^python_build_emscripten\.sh$|
           ?^cpp/build-support/build-lz4-lib\.sh$|
           ?^cpp/build-support/build-zstd-lib\.sh$|
           ?^cpp/build-support/get-upstream-commit\.sh$|

--- a/ci/scripts/python_build_emscripten.sh
+++ b/ci/scripts/python_build_emscripten.sh
@@ -22,19 +22,22 @@ set -ex
 arrow_dir=${1}
 build_dir=${2}
 
-
+# We don't need to follow this external file.
+# See also: https://www.shellcheck.net/wiki/SC1090
+#
+# shellcheck source=/dev/null
 source ~/emsdk/emsdk_env.sh
 
 source_dir=${arrow_dir}/python
 python_build_dir=${build_dir}/python
 
-rm -rf ${python_build_dir}
-cp -aL ${source_dir} ${python_build_dir}
+rm -rf "${python_build_dir}"
+cp -aL "${source_dir}" "${python_build_dir}"
 
 # conda sets LDFLAGS / CFLAGS etc. which break
 # emcmake so we unset them
 unset LDFLAGS CFLAGS CXXFLAGS CPPFLAGS
 
-pushd ${python_build_dir}
+pushd "${python_build_dir}"
 pyodide build
 popd


### PR DESCRIPTION
### Rationale for this change

* SC1090: Can't follow non-constant source. Use a directive to specify location
* SC2086: Double quote to prevent globbing and word splitting

```
In ci/scripts/python_build_emscripten.sh line 26:
source ~/emsdk/emsdk_env.sh
       ^------------------^ SC1090 (warning): ShellCheck can't follow non-constant source. Use a directive to specify location.


In ci/scripts/python_build_emscripten.sh line 31:
rm -rf ${python_build_dir}
       ^-----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
rm -rf "${python_build_dir}"


In ci/scripts/python_build_emscripten.sh line 32:
cp -aL ${source_dir} ${python_build_dir}
       ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                     ^-----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
cp -aL "${source_dir}" "${python_build_dir}"


In ci/scripts/python_build_emscripten.sh line 38:
pushd ${python_build_dir}
      ^-----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
pushd "${python_build_dir}"

For more information:
  https://www.shellcheck.net/wiki/SC1090 -- ShellCheck can't follow non-const...
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
```  

### What changes are included in this PR?

* SC1090: disable source file check.
* SC2086: Quote variables.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #47289