### PR TITLE
GH-47112: [Parquet][C++] Rle BitPacked parser

### DIFF
--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -26,5 +26,7 @@ filter = -readability/alt_tokens
 filter = -readability/casting
 filter = -readability/todo
 filter = -runtime/references
+# Let the formatter do the job for whitespaces
 filter = -whitespace/comments
+filter = -whitespace/braces
 linelength = 90

--- a/cpp/src/arrow/util/bit_run_reader.h
+++ b/cpp/src/arrow/util/bit_run_reader.h
@@ -52,6 +52,8 @@ inline bool operator!=(const BitRun& lhs, const BitRun& rhs) {
 
 class BitRunReaderLinear {
  public:
+  BitRunReaderLinear() = default;
+
   BitRunReaderLinear(const uint8_t* bitmap, int64_t start_offset, int64_t length)
       : reader_(bitmap, start_offset, length) {}
 
@@ -74,6 +76,8 @@ class BitRunReaderLinear {
 /// in a bitmap.
 class ARROW_EXPORT BitRunReader {
  public:
+  BitRunReader() = default;
+
   /// \brief Constructs new BitRunReader.
   ///
   /// \param[in] bitmap source data

--- a/cpp/src/arrow/util/bit_stream_utils_internal.h
+++ b/cpp/src/arrow/util/bit_stream_utils_internal.h
@@ -190,10 +190,10 @@ class BitReader {
   }
 
   /// Maximum byte length of a vlq encoded int
-  static constexpr int kMaxVlqByteLengthForInt32 = MaxLEB128ByteLenFor<int32_t>;
+  static constexpr int kMaxVlqByteLengthForInt32 = kMaxLEB128ByteLenFor<int32_t>;
 
   /// Maximum byte length of a vlq encoded int64
-  static constexpr int kMaxVlqByteLengthForInt64 = MaxLEB128ByteLenFor<int64_t>;
+  static constexpr int kMaxVlqByteLengthForInt64 = kMaxLEB128ByteLenFor<int64_t>;
 
  private:
   const uint8_t* buffer_;
@@ -452,18 +452,18 @@ inline bool BitWriter::PutVlqInt(uint32_t v) {
 inline bool BitReader::GetVlqInt(uint32_t* v) {
   // The data that we will pass to the LEB128 parser
   // In all case, we read an byte-aligned value, skipping remaining bits
-  uint8_t const* data = NULLPTR;
+  const uint8_t* data = NULLPTR;
   int max_size = 0;
 
   // Number of bytes left in the buffered values, not including the current
   // byte (i.e., there may be an additional fraction of a byte).
-  int const bytes_left_in_cache =
+  const int bytes_left_in_cache =
       sizeof(buffered_values_) - static_cast<int>(bit_util::BytesForBits(bit_offset_));
 
   // If there are clearly enough bytes left we can try to parse from the cache
   if (bytes_left_in_cache >= kMaxVlqByteLengthForInt32) {
     max_size = bytes_left_in_cache;
-    data = reinterpret_cast<uint8_t const*>(&buffered_values_) +
+    data = reinterpret_cast<const uint8_t*>(&buffered_values_) +
            bit_util::BytesForBits(bit_offset_);
     // Otherwise, we try straight from buffer (ignoring few bytes that may be cached)
   } else {
@@ -496,7 +496,7 @@ inline bool BitReader::GetZigZagVlqInt(int32_t* v) {
 }
 
 inline bool BitWriter::PutVlqInt(uint64_t v) {
-  constexpr auto kMaxBytes = bit_util::MaxLEB128ByteLenFor<decltype(v)>;
+  constexpr auto kMaxBytes = bit_util::kMaxLEB128ByteLenFor<decltype(v)>;
 
   uint8_t leb128[kMaxBytes] = {};
   auto const bytes_written = bit_util::WriteLEB128(v, leb128, kMaxBytes);

--- a/cpp/src/arrow/util/bit_stream_utils_internal.h
+++ b/cpp/src/arrow/util/bit_stream_utils_internal.h
@@ -128,14 +128,14 @@ inline uint64_t ReadLittleEndianWord(const uint8_t* buffer, int bytes_remaining)
 /// bytes in one read (e.g. encoded int).
 class BitReader {
  public:
-  BitReader() = default;
+  BitReader() noexcept = default;
 
   /// 'buffer' is the buffer to read from.  The buffer's length is 'buffer_len'.
   BitReader(const uint8_t* buffer, int buffer_len) : BitReader() {
     Reset(buffer, buffer_len);
   }
 
-  void Reset(const uint8_t* buffer, int buffer_len) {
+  void Reset(const uint8_t* buffer, int buffer_len) noexcept {
     buffer_ = buffer;
     max_bytes_ = buffer_len;
     byte_offset_ = 0;

--- a/cpp/src/arrow/util/bit_stream_utils_internal.h
+++ b/cpp/src/arrow/util/bit_stream_utils_internal.h
@@ -471,14 +471,14 @@ inline bool BitReader::GetVlqInt(uint32_t* v) {
     data = buffer_ + (max_bytes_ - max_size);
   }
 
-  auto const read = bit_util::ParseLeadingLEB128(data, max_size, v);
-  if (ARROW_PREDICT_FALSE(read == 0)) {
+  const auto bytes_read = bit_util::ParseLeadingLEB128(data, max_size, v);
+  if (ARROW_PREDICT_FALSE(bytes_read == 0)) {
     // Corrupt LEB128
     return false;
   }
 
-  // Advance for the bytes we have read + the bit we skipped
-  return Advance((8 * read) + (bit_offset_ % 8));
+  // Advance for the bytes we have read + the bits we skipped
+  return Advance((8 * bytes_read) + (bit_offset_ % 8));
 }
 
 inline bool BitWriter::PutZigZagVlqInt(int32_t v) {

--- a/cpp/src/arrow/util/bit_stream_utils_internal.h
+++ b/cpp/src/arrow/util/bit_stream_utils_internal.h
@@ -190,10 +190,10 @@ class BitReader {
   }
 
   /// Maximum byte length of a vlq encoded int
-  static constexpr int kMaxVlqByteLength = 5;
+  static constexpr int kMaxVlqByteLengthForInt32 = MaxLEB128ByteLenFor<int32_t>;
 
   /// Maximum byte length of a vlq encoded int64
-  static constexpr int kMaxVlqByteLengthForInt64 = 10;
+  static constexpr int kMaxVlqByteLengthForInt64 = MaxLEB128ByteLenFor<int64_t>;
 
  private:
   const uint8_t* buffer_;
@@ -452,7 +452,7 @@ inline bool BitWriter::PutVlqInt(uint32_t v) {
 inline bool BitReader::GetVlqInt(uint32_t* v) {
   uint32_t tmp = 0;
 
-  for (int i = 0; i < kMaxVlqByteLength; i++) {
+  for (int i = 0; i < kMaxVlqByteLengthForInt32; i++) {
     uint8_t byte = 0;
     if (ARROW_PREDICT_FALSE(!GetAligned<uint8_t>(1, &byte))) {
       return false;

--- a/cpp/src/arrow/util/bit_util.h
+++ b/cpp/src/arrow/util/bit_util.h
@@ -435,7 +435,7 @@ constexpr int32_t ParseLeadingLEB128(uint8_t const* data, int32_t max_data_size,
   // Read as many bytes as the could be for the give output
   for (int32_t i = 0; i < MaxLEB128ByteLenFor<Int>; i++) {
     // We have not finished reading a valid LEB128, yet we run out of data
-    if (i >= max_data_size) {
+    if (ARROW_PREDICT_FALSE(i >= max_data_size)) {
       return 0;
     }
 

--- a/cpp/src/arrow/util/bit_util.h
+++ b/cpp/src/arrow/util/bit_util.h
@@ -398,7 +398,7 @@ constexpr int32_t WriteLEB128(Int value, uint8_t* out, int32_t max_out_size) {
   // Write as many bytes as we could be for the given input
   while ((value & kHigh7Mask) != Int(0)) {
     // We do not have enough room to write the LEB128
-    if (out - out_first >= max_out_size) {
+    if (ARROW_PREDICT_FALSE(out - out_first >= max_out_size)) {
       return 0;
     }
 
@@ -410,7 +410,7 @@ constexpr int32_t WriteLEB128(Int value, uint8_t* out, int32_t max_out_size) {
   }
 
   // We do not have enough room to write the LEB128
-  if (out - out_first >= max_out_size) {
+  if (ARROW_PREDICT_FALSE(out - out_first >= max_out_size)) {
     return 0;
   }
 

--- a/cpp/src/arrow/util/bit_util.h
+++ b/cpp/src/arrow/util/bit_util.h
@@ -365,5 +365,10 @@ void PackBits(const uint32_t* values, uint8_t* out) {
   }
 }
 
+constexpr int64_t MaxLEB128ByteLen(int64_t n_bits) { return CeilDiv(n_bits, 7); }
+
+template <typename Int>
+constexpr int64_t MaxLEB128ByteLenFor = MaxLEB128ByteLen(sizeof(Int) * 8);
+
 }  // namespace bit_util
 }  // namespace arrow

--- a/cpp/src/arrow/util/bit_util.h
+++ b/cpp/src/arrow/util/bit_util.h
@@ -368,11 +368,11 @@ void PackBits(const uint32_t* values, uint8_t* out) {
 constexpr int64_t MaxLEB128ByteLen(int64_t n_bits) { return CeilDiv(n_bits, 7); }
 
 template <typename Int>
-constexpr int64_t MaxLEB128ByteLenFor = MaxLEB128ByteLen(sizeof(Int) * 8);
+constexpr int64_t kMaxLEB128ByteLenFor = MaxLEB128ByteLen(sizeof(Int) * 8);
 
 /// Write a integer as LEB128
 ///
-/// Write the input value as LEB128 into the outptu buffer and return the number of bytes
+/// Write the input value as LEB128 into the outptut buffer and return the number of bytes
 /// written.
 /// If the output buffer size is insufficient, return 0 but the output may have been
 /// written to.
@@ -385,9 +385,9 @@ constexpr int32_t WriteLEB128(Int value, uint8_t* out, int32_t max_out_size) {
   constexpr Int kHigh7Mask = ~kLow7Mask;
   constexpr uint8_t kContinuationBit = 0x80;
 
-  auto const out_first = out;
+  const auto out_first = out;
 
-  // Write as many bytes as the could be for the given input
+  // Write as many bytes as we could be for the given input
   while ((value & kHigh7Mask) != Int(0)) {
     // We do not have enough room to write the LEB128
     if (out - out_first >= max_out_size) {
@@ -424,9 +424,9 @@ constexpr int32_t WriteLEB128(Int value, uint8_t* out, int32_t max_out_size) {
 /// \see https://en.wikipedia.org/wiki/LEB128
 /// \see MaxLEB128ByteLenFor
 template <typename Int>
-constexpr int32_t ParseLeadingLEB128(uint8_t const* data, int32_t max_data_size,
+constexpr int32_t ParseLeadingLEB128(const uint8_t* data, int32_t max_data_size,
                                      Int* out) {
-  constexpr auto kMaxBytes = static_cast<int32_t>(MaxLEB128ByteLenFor<Int>);
+  constexpr auto kMaxBytes = static_cast<int32_t>(kMaxLEB128ByteLenFor<Int>);
   static_assert(kMaxBytes >= 1);
   constexpr uint8_t kLow7Mask = 0x7F;
   constexpr uint8_t kContinuationBit = 0x80;
@@ -439,7 +439,7 @@ constexpr int32_t ParseLeadingLEB128(uint8_t const* data, int32_t max_data_size,
   // Iteratively building the value
   std::make_unsigned_t<Int> value = 0;
 
-  // Read as many bytes as the could be for the give output
+  // Read as many bytes as we could be for the given output.
   for (int32_t i = 0; i < kMaxBytes - 1; i++) {
     // We have not finished reading a valid LEB128, yet we run out of data
     if (ARROW_PREDICT_FALSE(i >= max_data_size)) {
@@ -447,7 +447,7 @@ constexpr int32_t ParseLeadingLEB128(uint8_t const* data, int32_t max_data_size,
     }
 
     // Read the byte and set its 7 LSB to in the final value
-    uint8_t const byte = data[i];
+    const uint8_t byte = data[i];
     value |= static_cast<Int>(byte & kLow7Mask) << (7 * i);
 
     // Check for lack of continuation flag in MSB
@@ -465,7 +465,7 @@ constexpr int32_t ParseLeadingLEB128(uint8_t const* data, int32_t max_data_size,
     return 0;
   }
 
-  uint8_t const byte = data[last];
+  const uint8_t byte = data[last];
 
   // Need to check if there are bits that would overflow the output.
   // Also checks that there is no continuation.

--- a/cpp/src/arrow/util/bit_util.h
+++ b/cpp/src/arrow/util/bit_util.h
@@ -376,6 +376,7 @@ constexpr int64_t kMaxLEB128ByteLenFor = MaxLEB128ByteLen(sizeof(Int) * 8);
 /// written.
 /// If the output buffer size is insufficient, return 0 but the output may have been
 /// written to.
+/// The input value can be a signed integer, but must be non negative.
 ///
 /// \see https://en.wikipedia.org/wiki/LEB128
 /// \see MaxLEB128ByteLenFor
@@ -384,6 +385,13 @@ constexpr int32_t WriteLEB128(Int value, uint8_t* out, int32_t max_out_size) {
   constexpr Int kLow7Mask = Int(0x7F);
   constexpr Int kHigh7Mask = ~kLow7Mask;
   constexpr uint8_t kContinuationBit = 0x80;
+
+  // This encoding does not work for negative values
+  if constexpr (std::is_signed_v<Int>) {
+    if (ARROW_PREDICT_FALSE(value < 0)) {
+      return 0;
+    }
+  }
 
   const auto out_first = out;
 

--- a/cpp/src/arrow/util/bit_util_test.cc
+++ b/cpp/src/arrow/util/bit_util_test.cc
@@ -1999,9 +1999,14 @@ TEST(BitUtil, RoundUpToPowerOf2) {
 
 /// Test the maximum number of bytes needed to write a LEB128 of a give size.
 TEST(LEB128, MaxLEB128ByteLenFor) {
+  EXPECT_EQ(bit_util::kMaxLEB128ByteLenFor<int8_t>, 2);
+  EXPECT_EQ(bit_util::kMaxLEB128ByteLenFor<uint8_t>, 2);
   EXPECT_EQ(bit_util::kMaxLEB128ByteLenFor<int16_t>, 3);
+  EXPECT_EQ(bit_util::kMaxLEB128ByteLenFor<uint16_t>, 3);
   EXPECT_EQ(bit_util::kMaxLEB128ByteLenFor<int32_t>, 5);
+  EXPECT_EQ(bit_util::kMaxLEB128ByteLenFor<uint32_t>, 5);
   EXPECT_EQ(bit_util::kMaxLEB128ByteLenFor<int64_t>, 10);
+  EXPECT_EQ(bit_util::kMaxLEB128ByteLenFor<uint64_t>, 10);
 }
 
 /// Utility function to test LEB128 encoding with known input value and expected byte
@@ -2037,6 +2042,7 @@ TEST(LEB128, WriteEdgeCases) {
   // Three byte value 16384, encoded in larger buffer
   TestLEB128Encode(16384U, {0x80, 0x80, 0x01}, 10);
   // Two byte boundary values
+  TestLEB128Encode(128U, {0x80, 0x01}, 2);
   TestLEB128Encode(129U, {0x81, 0x01}, 2);
   TestLEB128Encode(16383U, {0xFF, 0x7F}, 2);
   // Error case: Buffer too small for value 128 (needs 2 bytes but only 1 provided)
@@ -2060,14 +2066,6 @@ void TestLEB128Decode(const std::vector<uint8_t>& data, Int expected_value,
   if (expected_bytes_read > 0) {
     EXPECT_EQ(result, expected_value);
   }
-}
-
-template <typename Int>
-void TestLEB128Decode(const std::vector<uint8_t>& data, Int expected_value,
-                      std::size_t expected_bytes_read) {
-  ASSERT_LE(expected_bytes_read, std::numeric_limits<int32_t>::max());
-  return TestLEB128Decode(data, expected_value,
-                          static_cast<int32_t>(expected_bytes_read));
 }
 
 /// Test decoding from known LEB128 byte sequences with edge case parameters.
@@ -2129,48 +2127,48 @@ TEST(LEB128, KnownSuccessfulValues) {
     if (data.value <= static_cast<uint64_t>(std::numeric_limits<int8_t>::max())) {
       const auto val = static_cast<int8_t>(data.value);
       TestLEB128Encode(val, data.bytes, data.bytes.size());
-      TestLEB128Decode(data.bytes, val, data.bytes.size());
+      TestLEB128Decode(data.bytes, val, static_cast<int32_t>(data.bytes.size()));
     }
     if (data.value <= static_cast<uint64_t>(std::numeric_limits<uint8_t>::max())) {
       const auto val = static_cast<uint8_t>(data.value);
       TestLEB128Encode(val, data.bytes, data.bytes.size());
-      TestLEB128Decode(data.bytes, val, data.bytes.size());
+      TestLEB128Decode(data.bytes, val, static_cast<int32_t>(data.bytes.size()));
     }
 
     // 16 bits
     if (data.value <= static_cast<uint64_t>(std::numeric_limits<int16_t>::max())) {
       const auto val = static_cast<int16_t>(data.value);
       TestLEB128Encode(val, data.bytes, data.bytes.size());
-      TestLEB128Decode(data.bytes, val, data.bytes.size());
+      TestLEB128Decode(data.bytes, val, static_cast<int32_t>(data.bytes.size()));
     }
     if (data.value <= static_cast<uint64_t>(std::numeric_limits<uint16_t>::max())) {
       const auto val = static_cast<uint16_t>(data.value);
       TestLEB128Encode(val, data.bytes, data.bytes.size());
-      TestLEB128Decode(data.bytes, val, data.bytes.size());
+      TestLEB128Decode(data.bytes, val, static_cast<int32_t>(data.bytes.size()));
     }
 
     // 32 bits
     if (data.value <= static_cast<uint64_t>(std::numeric_limits<int32_t>::max())) {
       const auto val = static_cast<int32_t>(data.value);
       TestLEB128Encode(val, data.bytes, data.bytes.size());
-      TestLEB128Decode(data.bytes, val, data.bytes.size());
+      TestLEB128Decode(data.bytes, val, static_cast<int32_t>(data.bytes.size()));
     }
     if (data.value <= static_cast<uint64_t>(std::numeric_limits<uint32_t>::max())) {
       const auto val = static_cast<uint32_t>(data.value);
       TestLEB128Encode(val, data.bytes, data.bytes.size());
-      TestLEB128Decode(data.bytes, val, data.bytes.size());
+      TestLEB128Decode(data.bytes, val, static_cast<int32_t>(data.bytes.size()));
     }
 
     // 64 bits
     if (data.value <= static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
       const auto val = static_cast<int64_t>(data.value);
       TestLEB128Encode(val, data.bytes, data.bytes.size());
-      TestLEB128Decode(data.bytes, val, data.bytes.size());
+      TestLEB128Decode(data.bytes, val, static_cast<int32_t>(data.bytes.size()));
     }
     if (data.value <= static_cast<uint64_t>(std::numeric_limits<uint64_t>::max())) {
       const auto val = static_cast<uint64_t>(data.value);
       TestLEB128Encode(val, data.bytes, data.bytes.size());
-      TestLEB128Decode(data.bytes, val, data.bytes.size());
+      TestLEB128Decode(data.bytes, val, static_cast<int32_t>(data.bytes.size()));
     }
   }
 }

--- a/cpp/src/arrow/util/bit_util_test.cc
+++ b/cpp/src/arrow/util/bit_util_test.cc
@@ -2115,7 +2115,7 @@ TEST(BitStreamUtil, LEB128) {
 }
 
 static void TestZigZag(int32_t v, std::array<uint8_t, 5> buffer_expect) {
-  uint8_t buffer[bit_util::BitReader::kMaxVlqByteLengthForInt32] = {};
+  uint8_t buffer[bit_util::kMaxLEB128ByteLenFor<int32_t>] = {};
   bit_util::BitWriter writer(buffer, sizeof(buffer));
   writer.PutZigZagVlqInt(v);
   // WARNING: The reader reads and caches the input when created, so it must be created
@@ -2139,10 +2139,12 @@ TEST(BitStreamUtil, ZigZag) {
 }
 
 static void TestZigZag64(int64_t v, std::array<uint8_t, 10> buffer_expect) {
-  uint8_t buffer[bit_util::BitReader::kMaxVlqByteLengthForInt64] = {};
+  uint8_t buffer[bit_util::kMaxLEB128ByteLenFor<int64_t>] = {};
   bit_util::BitWriter writer(buffer, sizeof(buffer));
-  bit_util::BitReader reader(buffer, sizeof(buffer));
   writer.PutZigZagVlqInt(v);
+  // WARNING: The reader reads and caches the input when created, so it must be created
+  // after the data is written in the buffer.
+  bit_util::BitReader reader(buffer, sizeof(buffer));
   EXPECT_THAT(buffer, testing::ElementsAreArray(buffer_expect));
   int64_t result = 0;
   EXPECT_TRUE(reader.GetZigZagVlqInt(&result));

--- a/cpp/src/arrow/util/bit_util_test.cc
+++ b/cpp/src/arrow/util/bit_util_test.cc
@@ -2007,7 +2007,7 @@ TEST(LEB128, MaxLEB128ByteLenFor) {
 /// Utility function to test LEB128 encoding with known input value and expected byte
 /// array
 template <typename Int>
-void TestLEB128Encode(Int input_value, std::vector<uint8_t> const& expected_data,
+void TestLEB128Encode(Int input_value, const std::vector<uint8_t>& expected_data,
                       std::size_t buffer_size) {
   std::vector<uint8_t> buffer(buffer_size);
   auto bytes_written = bit_util::WriteLEB128(input_value, buffer.data(),
@@ -2051,7 +2051,7 @@ TEST(LEB128, WriteEdgeCases) {
 
 /// Utility function to test LEB128 decoding with known byte array and expected result
 template <typename Int>
-void TestLEB128Decode(std::vector<uint8_t> const& data, Int expected_value,
+void TestLEB128Decode(const std::vector<uint8_t>& data, Int expected_value,
                       int32_t expected_bytes_read) {
   Int result = 0;
   auto bytes_read = bit_util::ParseLeadingLEB128(
@@ -2063,7 +2063,7 @@ void TestLEB128Decode(std::vector<uint8_t> const& data, Int expected_value,
 }
 
 template <typename Int>
-void TestLEB128Decode(std::vector<uint8_t> const& data, Int expected_value,
+void TestLEB128Decode(const std::vector<uint8_t>& data, Int expected_value,
                       std::size_t expected_bytes_read) {
   ASSERT_LE(expected_bytes_read, std::numeric_limits<int32_t>::max());
   return TestLEB128Decode(data, expected_value,

--- a/cpp/src/arrow/util/bit_util_test.cc
+++ b/cpp/src/arrow/util/bit_util_test.cc
@@ -1998,7 +1998,7 @@ TEST(BitUtil, RoundUpToPowerOf2) {
 #undef S64
 
 /// Test the maximum number of bytes needed to write a LEB128 of a give size.
-TEST(BitStreamUtil, MaxLEB128ByteLenFor) {
+TEST(LEB128, MaxLEB128ByteLenFor) {
   EXPECT_EQ(bit_util::kMaxLEB128ByteLenFor<int16_t>, 3);
   EXPECT_EQ(bit_util::kMaxLEB128ByteLenFor<int32_t>, 5);
   EXPECT_EQ(bit_util::kMaxLEB128ByteLenFor<int64_t>, 10);
@@ -2027,47 +2027,15 @@ void TestLEB128Encode(Int input_value, std::vector<uint8_t> const& expected_data
   }
 }
 
-/// Test encoding to known LEB128 byte sequences
-TEST(WriteLEB128Test, KnownArrayValues) {
+/// Test encoding to known LEB128 byte sequences with edge cases parameters.
+/// \see LEB128.KnownSuccessfulValues for other known values tested.
+TEST(LEB128, WriteEdgeCases) {
   // Single byte value 0
   TestLEB128Encode(0U, {0x00}, 1);
   // Single byte value 127
   TestLEB128Encode(127U, {0x7F}, 1);
-  // Two byte value 128
-  TestLEB128Encode(128U, {0x80, 0x01}, 2);
-  // Two byte value 128 as signed type
-  TestLEB128Encode(128, {0x80, 0x01}, 2);
-  // Two byte value 300
-  TestLEB128Encode(300U, {0xAC, 0x02}, 2);
-  // Three byte value 16384
-  TestLEB128Encode(16384U, {0x80, 0x80, 0x01}, 3);
-  // Four byte value 268435455
-  TestLEB128Encode(268435455U, {0xFF, 0xFF, 0xFF, 0x7F}, 4);
-  // Two bytes uint8_t max value
-  TestLEB128Encode(std::numeric_limits<uint8_t>::max(), {0xFF, 0x01}, 2);
-  // One bytes int8_t max value
-  TestLEB128Encode(std::numeric_limits<int8_t>::max(), {0x7F}, 2);
-  // Three bytes uint16_t max value
-  TestLEB128Encode(std::numeric_limits<uint16_t>::max(), {0xFF, 0xFF, 0x03}, 3);
-  // Three bytes int16_t max value
-  TestLEB128Encode(std::numeric_limits<int16_t>::max(), {0xFF, 0xFF, 0x01}, 3);
-  // Five byte uint32_t max value
-  TestLEB128Encode(std::numeric_limits<uint32_t>::max(), {0xFF, 0xFF, 0xFF, 0xFF, 0x0F},
-                   5);
-  // Five byte int32_t max value
-  TestLEB128Encode(std::numeric_limits<int32_t>::max(), {0xFF, 0xFF, 0xFF, 0xFF, 0x7}, 5);
-  // Ten bytes uint64_t max value
-  TestLEB128Encode(std::numeric_limits<uint64_t>::max(),
-                   {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x01}, 10);
-  // Nine bytes int64_t max value
-  TestLEB128Encode(std::numeric_limits<int64_t>::max(),
-                   {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F}, 10);
   // Three byte value 16384, encoded in larger buffer
   TestLEB128Encode(16384U, {0x80, 0x80, 0x01}, 10);
-  // Various single byte values
-  TestLEB128Encode(1U, {0x01}, 1);
-  TestLEB128Encode(63U, {0x3F}, 1);
-  TestLEB128Encode(64U, {0x40}, 1);
   // Two byte boundary values
   TestLEB128Encode(129U, {0x81, 0x01}, 2);
   TestLEB128Encode(16383U, {0xFF, 0x7F}, 2);
@@ -2094,31 +2062,25 @@ void TestLEB128Decode(std::vector<uint8_t> const& data, Int expected_value,
   }
 }
 
-/// Test decoding from known LEB128 byte sequences
-TEST(BitStreamUtil, LEB128) {
+template <typename Int>
+void TestLEB128Decode(std::vector<uint8_t> const& data, Int expected_value,
+                      std::size_t expected_bytes_read) {
+  ASSERT_LE(expected_bytes_read, std::numeric_limits<int32_t>::max());
+  return TestLEB128Decode(data, expected_value,
+                          static_cast<int32_t>(expected_bytes_read));
+}
+
+/// Test decoding from known LEB128 byte sequences with edge case parameters.
+/// \see LEB128.KnownSuccessfulValues for other known values tested.
+TEST(LEB128, ReadEdgeCases) {
   // Single byte value 0
   TestLEB128Decode({0x00}, 0U, 1);
   // Single byte value 127
   TestLEB128Decode({0x7F}, 127U, 1);
-  // Two byte value 128
-  TestLEB128Decode({0x80, 0x01}, 128U, 2);
-  // Two byte value 300
-  TestLEB128Decode({0xAC, 0x02}, 300U, 2);
-  // Three byte value 16384
-  TestLEB128Decode({0x80, 0x80, 0x01}, 16384U, 3);
   // Three byte value 16384, with remaining data
   TestLEB128Decode({0x80, 0x80, 0x01, 0x80, 0x00}, 16384U, 3);
   // Four byte value 268435455
   TestLEB128Decode({0xFF, 0xFF, 0xFF, 0x7F}, 268435455U, 4);
-  // Five byte uint32_t max value
-  TestLEB128Decode({0xFF, 0xFF, 0xFF, 0xFF, 0x0F}, std::numeric_limits<uint32_t>::max(),
-                   5);
-  // uint64_t value requiring 10 bytes
-  TestLEB128Decode({0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x01},
-                   18446744073709551615ULL, 10);
-  // int32_t with maximum size (31 bits of 1)
-  TestLEB128Decode({0xFF, 0xFF, 0xFF, 0xFF, 0x7}, std::numeric_limits<int32_t>::max(), 5);
-
   // Error case: Truncated sequence (continuation bit set but no more data)
   TestLEB128Decode({0x80}, 0U, 0);
   // Error case: Input has exactly the maximum number of bytes for a int32_t (5),
@@ -2126,6 +2088,91 @@ TEST(BitStreamUtil, LEB128) {
   TestLEB128Decode({0xFF, 0xFF, 0xFF, 0xFF, 0x7F}, int32_t{}, 0);
   // Error case: Oversized sequence for uint32_t (too many bytes)
   TestLEB128Decode({0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x01}, 0U, 0);
+}
+
+struct KnownLEB128Encoding {
+  uint64_t value;
+  std::vector<uint8_t> bytes;
+};
+
+static const std::vector<KnownLEB128Encoding> KnownLEB128EncodingValues{
+    {0, {0x00}},
+    {1, {0x01}},
+    {63, {0x3F}},
+    {64, {0x40}},
+    {127U, {0x7F}},
+    {128, {0x80, 0x01}},
+    {300, {0xAC, 0x02}},
+    {16384, {0x80, 0x80, 0x01}},
+    {268435455, {0xFF, 0xFF, 0xFF, 0x7F}},
+    {static_cast<uint64_t>(std::numeric_limits<uint8_t>::max()), {0xFF, 0x01}},
+    {static_cast<uint64_t>(std::numeric_limits<int8_t>::max()), {0x7F}},
+    {static_cast<uint64_t>(std::numeric_limits<uint16_t>::max()), {0xFF, 0xFF, 0x03}},
+    {static_cast<uint64_t>(std::numeric_limits<int16_t>::max()), {0xFF, 0xFF, 0x01}},
+    {static_cast<uint64_t>(std::numeric_limits<uint32_t>::max()),
+     {0xFF, 0xFF, 0xFF, 0xFF, 0x0F}},
+    {static_cast<uint64_t>(std::numeric_limits<int32_t>::max()),
+     {0xFF, 0xFF, 0xFF, 0xFF, 0x7}},
+    {static_cast<uint64_t>(std::numeric_limits<uint64_t>::max()),
+     {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x01}},
+    {static_cast<uint64_t>(std::numeric_limits<int64_t>::max()),
+     {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F}},
+};
+
+/// Test encoding and decoding to known LEB128 byte sequences with all possible
+/// integer sizes and signess.
+TEST(LEB128, KnownSuccessfulValues) {
+  for (const auto& data : KnownLEB128EncodingValues) {
+    SCOPED_TRACE("Testing value " + std::to_string(data.value));
+
+    // 8 bits
+    if (data.value <= static_cast<uint64_t>(std::numeric_limits<int8_t>::max())) {
+      const auto val = static_cast<int8_t>(data.value);
+      TestLEB128Encode(val, data.bytes, data.bytes.size());
+      TestLEB128Decode(data.bytes, val, data.bytes.size());
+    }
+    if (data.value <= static_cast<uint64_t>(std::numeric_limits<uint8_t>::max())) {
+      const auto val = static_cast<uint8_t>(data.value);
+      TestLEB128Encode(val, data.bytes, data.bytes.size());
+      TestLEB128Decode(data.bytes, val, data.bytes.size());
+    }
+
+    // 16 bits
+    if (data.value <= static_cast<uint64_t>(std::numeric_limits<int16_t>::max())) {
+      const auto val = static_cast<int16_t>(data.value);
+      TestLEB128Encode(val, data.bytes, data.bytes.size());
+      TestLEB128Decode(data.bytes, val, data.bytes.size());
+    }
+    if (data.value <= static_cast<uint64_t>(std::numeric_limits<uint16_t>::max())) {
+      const auto val = static_cast<uint16_t>(data.value);
+      TestLEB128Encode(val, data.bytes, data.bytes.size());
+      TestLEB128Decode(data.bytes, val, data.bytes.size());
+    }
+
+    // 32 bits
+    if (data.value <= static_cast<uint64_t>(std::numeric_limits<int32_t>::max())) {
+      const auto val = static_cast<int32_t>(data.value);
+      TestLEB128Encode(val, data.bytes, data.bytes.size());
+      TestLEB128Decode(data.bytes, val, data.bytes.size());
+    }
+    if (data.value <= static_cast<uint64_t>(std::numeric_limits<uint32_t>::max())) {
+      const auto val = static_cast<uint32_t>(data.value);
+      TestLEB128Encode(val, data.bytes, data.bytes.size());
+      TestLEB128Decode(data.bytes, val, data.bytes.size());
+    }
+
+    // 64 bits
+    if (data.value <= static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
+      const auto val = static_cast<int64_t>(data.value);
+      TestLEB128Encode(val, data.bytes, data.bytes.size());
+      TestLEB128Decode(data.bytes, val, data.bytes.size());
+    }
+    if (data.value <= static_cast<uint64_t>(std::numeric_limits<uint64_t>::max())) {
+      const auto val = static_cast<uint64_t>(data.value);
+      TestLEB128Encode(val, data.bytes, data.bytes.size());
+      TestLEB128Decode(data.bytes, val, data.bytes.size());
+    }
+  }
 }
 
 static void TestZigZag(int32_t v, std::array<uint8_t, 5> buffer_expect) {

--- a/cpp/src/arrow/util/bit_util_test.cc
+++ b/cpp/src/arrow/util/bit_util_test.cc
@@ -2091,6 +2091,10 @@ TEST(BitStreamUtil, LEB128) {
   TestLEB128Decode(
       std::array<uint8_t, 10>{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x01},
       18446744073709551615ULL, 10);
+  // int32_t with maximum size (31 bits of 1)
+  TestLEB128Decode(std::array<uint8_t, 5>{0xFF, 0xFF, 0xFF, 0xFF, 0x7},
+                   std::numeric_limits<int32_t>::max(), 5);
+
   // Error case: Truncated sequence (continuation bit set but no more data)
   TestLEB128Decode(std::array<uint8_t, 1>{0x80}, 0U, 0);
   // Error case: Input over the maximum number of bytes for a int32_t (5), but the

--- a/cpp/src/arrow/util/bit_util_test.cc
+++ b/cpp/src/arrow/util/bit_util_test.cc
@@ -1997,8 +1997,15 @@ TEST(BitUtil, RoundUpToPowerOf2) {
 #undef U64
 #undef S64
 
+/// Test the maximum number of bytes needed to write a LEB128 of a give size.
+TEST(BitStreamUtil, MaxLEB128ByteLenFor) {
+  EXPECT_EQ(bit_util::MaxLEB128ByteLenFor<int16_t>, 3);
+  EXPECT_EQ(bit_util::MaxLEB128ByteLenFor<int32_t>, 5);
+  EXPECT_EQ(bit_util::MaxLEB128ByteLenFor<int64_t>, 10);
+}
+
 static void TestZigZag(int32_t v, std::array<uint8_t, 5> buffer_expect) {
-  uint8_t buffer[bit_util::BitReader::kMaxVlqByteLength] = {};
+  uint8_t buffer[bit_util::BitReader::kMaxVlqByteLengthForInt32] = {};
   bit_util::BitWriter writer(buffer, sizeof(buffer));
   bit_util::BitReader reader(buffer, sizeof(buffer));
   writer.PutZigZagVlqInt(v);

--- a/cpp/src/arrow/util/bit_util_test.cc
+++ b/cpp/src/arrow/util/bit_util_test.cc
@@ -2093,6 +2093,9 @@ TEST(BitStreamUtil, LEB128) {
       18446744073709551615ULL, 10);
   // Error case: Truncated sequence (continuation bit set but no more data)
   TestLEB128Decode(std::array<uint8_t, 1>{0x80}, 0U, 0);
+  // Error case: Input over the maximum number of bytes for a int32_t (5), but the
+  // overflow none the less (7 * 5 = 35 bits of data).
+  TestLEB128Decode(std::array<uint8_t, 5>{0xFF, 0xFF, 0xFF, 0xFF, 0x7F}, int32_t{}, 0);
   // Error case: Oversized sequence for uint32_t (too many bytes)
   TestLEB128Decode(std::array<uint8_t, 6>{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x01}, 0U, 0);
 }

--- a/cpp/src/arrow/util/bitmap_reader.h
+++ b/cpp/src/arrow/util/bitmap_reader.h
@@ -31,6 +31,8 @@ namespace internal {
 
 class BitmapReader {
  public:
+  BitmapReader() = default;
+
   BitmapReader(const uint8_t* bitmap, int64_t start_offset, int64_t length)
       : bitmap_(bitmap), position_(0), length_(length) {
     current_byte_ = 0;

--- a/cpp/src/arrow/util/rle_encoding_internal.h
+++ b/cpp/src/arrow/util/rle_encoding_internal.h
@@ -734,7 +734,7 @@ auto GetSpacedRle(Converter& converter, typename Converter::out_type* out,
       validity_run.length -= update_size;
     }
 
-    if (validity_run.length == 0) {
+    if (ARROW_PREDICT_TRUE(validity_run.length == 0)) {
       validity_run = validity_reader.NextRun();
     }
   }

--- a/cpp/src/arrow/util/rle_encoding_internal.h
+++ b/cpp/src/arrow/util/rle_encoding_internal.h
@@ -1282,7 +1282,7 @@ auto RleBitPackedParser::PeekImpl(Handler&& handler) const
         bit_util::CeilDiv(internal::max_size_for_v<values_count_type>, 8);
     if (ARROW_PREDICT_FALSE(count == 0 || count > kMaxCount)) {
       // Illegal number of encoded values
-      return {};
+      return {0, ControlFlow::Break};
     }
 
     const auto values_count = static_cast<values_count_type>(count * 8);
@@ -1302,7 +1302,7 @@ auto RleBitPackedParser::PeekImpl(Handler&& handler) const
           count == 0 ||
           count > static_cast<uint32_t>(std::numeric_limits<values_count_type>::max()))) {
     // Illegal number of encoded values
-    return {};
+    return {0, ControlFlow::Break};
   }
 
   const auto values_count = static_cast<values_count_type>(count);

--- a/cpp/src/arrow/util/rle_encoding_internal.h
+++ b/cpp/src/arrow/util/rle_encoding_internal.h
@@ -449,7 +449,7 @@ class RleBitPackedEncoder {
                                        MAX_VALUES_PER_LITERAL_RUN * bit_width));
     /// Up to kMaxVlqByteLength indicator and a single 'bit_width' value.
     int max_repeated_run_size =
-        ::arrow::bit_util::BitReader::kMaxVlqByteLengthForInt32 +
+        bit_util::kMaxLEB128ByteLenFor<int32_t> +
         static_cast<int>(::arrow::bit_util::BytesForBits(bit_width));
     return std::max(max_literal_run_size, max_repeated_run_size);
   }

--- a/cpp/src/arrow/util/rle_encoding_internal.h
+++ b/cpp/src/arrow/util/rle_encoding_internal.h
@@ -741,7 +741,7 @@ auto GetSpacedRle(Converter& converter, typename Converter::out_type* out,
 
   value_type const value = decoder.Value();
   if (ARROW_PREDICT_FALSE(!converter.InputIsValid(value))) {
-    return {batch.ValuesRead(), batch.NullRead()};
+    return {0, 0};
   }
   converter.WriteRepeated(out, out + batch.TotalRead(), value);
   auto const actual_values_read = decoder.Advance(batch.ValuesRead());

--- a/cpp/src/arrow/util/rle_encoding_internal.h
+++ b/cpp/src/arrow/util/rle_encoding_internal.h
@@ -196,7 +196,7 @@ class RleEncoder {
                                        MAX_VALUES_PER_LITERAL_RUN * bit_width));
     /// Up to kMaxVlqByteLength indicator and a single 'bit_width' value.
     int max_repeated_run_size =
-        ::arrow::bit_util::BitReader::kMaxVlqByteLength +
+        ::arrow::bit_util::BitReader::kMaxVlqByteLengthForInt32 +
         static_cast<int>(::arrow::bit_util::BytesForBits(bit_width));
     return std::max(max_literal_run_size, max_repeated_run_size);
   }

--- a/cpp/src/arrow/util/rle_encoding_internal.h
+++ b/cpp/src/arrow/util/rle_encoding_internal.h
@@ -1426,11 +1426,12 @@ void RleDecoder<T>::Reset(run_type const& run) noexcept {
     // If we memcpy + FromLittleEndian, we have potential undefined behavior
     // if the bool value isn't 0 or 1.
     value_ = *run.RawDataPtr() & 1;
+  } else {
+    // Memcopy is required to avoid undefined behavior.
+    value_ = {};
+    std::memcpy(&value_, run.RawDataPtr(), run.RawDataSize());
+    value_ = ::arrow::bit_util::FromLittleEndian(value_);
   }
-  // Memcopy is required to avoid undefined behavior.
-  std::memset(&value_, 0, sizeof(value_type));
-  std::memcpy(&value_, run.RawDataPtr(), run.RawDataSize());
-  value_ = ::arrow::bit_util::FromLittleEndian(value_);
 }
 
 template <typename T>

--- a/cpp/src/arrow/util/rle_encoding_internal.h
+++ b/cpp/src/arrow/util/rle_encoding_internal.h
@@ -1346,7 +1346,7 @@ auto RleBitPackedParser::PeekImpl(Handler&& handler) const
     -> std::pair<raw_data_size_type, ControlFlow> {
   ARROW_DCHECK(!Exhausted());
 
-  constexpr auto kMaxSize = bit_util::MaxLEB128ByteLenFor<uint32_t>;
+  constexpr auto kMaxSize = bit_util::kMaxLEB128ByteLenFor<uint32_t>;
   uint32_t run_len_type = 0;
   auto const header_bytes = bit_util::ParseLeadingLEB128(data_, kMaxSize, &run_len_type);
 

--- a/cpp/src/arrow/util/rle_encoding_internal.h
+++ b/cpp/src/arrow/util/rle_encoding_internal.h
@@ -1299,7 +1299,7 @@ inline auto RleBitPackedParser::PeekCount() const
   uint32_t run_len_type = 0;
   auto const header_bytes = bit_util::ParseLeadingLEB128(data_, kMaxSize, &run_len_type);
 
-  if (header_bytes == 0) {
+  if (ARROW_PREDICT_FALSE(header_bytes == 0)) {
     // Malfomrmed LEB128 data
     return {};
   }

--- a/cpp/src/arrow/util/rle_encoding_internal.h
+++ b/cpp/src/arrow/util/rle_encoding_internal.h
@@ -444,10 +444,10 @@ class RleBitPackedEncoder {
   /// This is the maximum length of a single run for 'bit_width'.
   /// It is not valid to pass a buffer less than this length.
   static int MinBufferSize(int bit_width) {
-    /// 1 indicator byte and MAX_VALUES_PER_LITERAL_RUN 'bit_width' values.
+    // 1 indicator byte and MAX_VALUES_PER_LITERAL_RUN 'bit_width' values.
     int max_literal_run_size = 1 + static_cast<int>(::arrow::bit_util::BytesForBits(
                                        MAX_VALUES_PER_LITERAL_RUN * bit_width));
-    /// Up to kMaxVlqByteLength indicator and a single 'bit_width' value.
+    // Up to kMaxVlqByteLength indicator and a single 'bit_width' value.
     int max_repeated_run_size =
         bit_util::kMaxLEB128ByteLenFor<int32_t> +
         static_cast<int>(::arrow::bit_util::BytesForBits(bit_width));
@@ -956,7 +956,7 @@ auto RleBitPackedDecoder<T>::GetSpaced(Converter converter,
       return batch.TotalRead();
     }
 
-    /// We finished the remaining run
+    // We finished the remaining run
     ARROW_DCHECK(RunRemaining() == 0);
   }
 
@@ -1145,7 +1145,7 @@ auto RleBitPackedDecoder<T>::GetBatchWithDict(const V* dictionary,
       return values_read;
     }
 
-    /// We finished the remaining run
+    // We finished the remaining run
     ARROW_DCHECK(RunRemaining() == 0);
   }
 
@@ -1290,7 +1290,7 @@ auto RleBitPackedParser::PeekImpl(Handler&& handler) const
     constexpr auto kMaxCount =
         bit_util::CeilDiv(internal::max_size_for_v<values_count_type>, 8);
     if (ARROW_PREDICT_FALSE(count == 0 || count > kMaxCount)) {
-      /// Illegal number of encoded values
+      // Illegal number of encoded values
       return {};
     }
 
@@ -1310,7 +1310,7 @@ auto RleBitPackedParser::PeekImpl(Handler&& handler) const
   if (ARROW_PREDICT_FALSE(
           count == 0 ||
           count > static_cast<uint32_t>(std::numeric_limits<values_count_type>::max()))) {
-    /// Illegal number of encoded values
+    // Illegal number of encoded values
     return {};
   }
 

--- a/cpp/src/arrow/util/rle_encoding_internal.h
+++ b/cpp/src/arrow/util/rle_encoding_internal.h
@@ -102,13 +102,13 @@ class RleRun {
   using DecoderType = RleRunDecoder<T>;
 
   constexpr RleRun() noexcept = default;
-  constexpr RleRun(RleRun const&) noexcept = default;
+  constexpr RleRun(const RleRun&) noexcept = default;
   constexpr RleRun(RleRun&&) noexcept = default;
 
   explicit RleRun(raw_data_const_pointer data, values_count_type values_count,
                   bit_size_type value_bit_width) noexcept;
 
-  constexpr RleRun& operator=(RleRun const&) noexcept = default;
+  constexpr RleRun& operator=(const RleRun&) noexcept = default;
   constexpr RleRun& operator=(RleRun&&) noexcept = default;
 
   /// The number of repeated values in this run.
@@ -151,13 +151,13 @@ class BitPackedRun {
   using DecoderType = BitPackedRunDecoder<T>;
 
   constexpr BitPackedRun() noexcept = default;
-  constexpr BitPackedRun(BitPackedRun const&) noexcept = default;
+  constexpr BitPackedRun(const BitPackedRun&) noexcept = default;
   constexpr BitPackedRun(BitPackedRun&&) noexcept = default;
 
   constexpr BitPackedRun(raw_data_const_pointer data, values_count_type values_count,
                          bit_size_type value_bit_width) noexcept;
 
-  constexpr BitPackedRun& operator=(BitPackedRun const&) noexcept = default;
+  constexpr BitPackedRun& operator=(const BitPackedRun&) noexcept = default;
   constexpr BitPackedRun& operator=(BitPackedRun&&) noexcept = default;
 
   [[nodiscard]] constexpr values_count_type ValuesCount() const noexcept;
@@ -255,9 +255,9 @@ class RleRunDecoder {
 
   constexpr RleRunDecoder() noexcept = default;
 
-  explicit RleRunDecoder(run_type const& run) noexcept;
+  explicit RleRunDecoder(const run_type& run) noexcept;
 
-  void Reset(run_type const& run) noexcept;
+  void Reset(const run_type& run) noexcept;
 
   /// Return the number of values that can be advanced.
   [[nodiscard]] values_count_type Remaining() const;
@@ -296,9 +296,9 @@ class BitPackedRunDecoder {
 
   BitPackedRunDecoder() noexcept = default;
 
-  explicit BitPackedRunDecoder(run_type const& run) noexcept;
+  explicit BitPackedRunDecoder(const run_type& run) noexcept;
 
-  void Reset(run_type const& run) noexcept;
+  void Reset(const run_type& run) noexcept;
 
   /// Return the number of values that can be advanced.
   [[nodiscard]] constexpr values_count_type Remaining() const;
@@ -739,7 +739,7 @@ auto RunGetSpaced(Converter* converter, typename Converter::out_type* out,
 
   auto batch = BatchCounter::FromBatchSizeAndNulls(batch_size, null_count);
 
-  values_count_type const values_available = decoder->Remaining();
+  const values_count_type values_available = decoder->Remaining();
   ARROW_DCHECK_GT(values_available, 0);
   auto values_remaining_run = [&]() {
     auto out = values_available - batch.ValuesRead();
@@ -775,7 +775,7 @@ auto RunGetSpaced(Converter* converter, typename Converter::out_type* out,
     }
   }
 
-  value_type const value = decoder->Value();
+  const value_type value = decoder->Value();
   if (ARROW_PREDICT_FALSE(!converter->InputIsValid(value))) {
     return {0, 0};
   }
@@ -801,7 +801,7 @@ auto RunGetSpaced(Converter* converter, typename Converter::out_type* out,
 
   auto batch = BatchCounter::FromBatchSizeAndNulls(batch_size, null_count);
 
-  values_count_type const values_available = decoder->Remaining();
+  const values_count_type values_available = decoder->Remaining();
   ARROW_DCHECK_GT(values_available, 0);
   auto run_values_remaining = [&]() {
     auto out = values_available - batch.ValuesRead();
@@ -1274,8 +1274,8 @@ auto RleBitPackedParser::PeekImpl(Handler&& handler) const
     return {};
   }
 
-  bool const is_bit_packed = run_len_type & 1;
-  uint32_t const count = run_len_type >> 1;
+  const bool is_bit_packed = run_len_type & 1;
+  const uint32_t count = run_len_type >> 1;
   if (is_bit_packed) {
     using values_count_type = BitPackedRun::values_count_type;
     constexpr auto kMaxCount =
@@ -1333,12 +1333,12 @@ void RleBitPackedParser::Parse(Handler&& handler) {
  ****************/
 
 template <typename T>
-RleRunDecoder<T>::RleRunDecoder(run_type const& run) noexcept {
+RleRunDecoder<T>::RleRunDecoder(const run_type& run) noexcept {
   Reset(run);
 }
 
 template <typename T>
-void RleRunDecoder<T>::Reset(run_type const& run) noexcept {
+void RleRunDecoder<T>::Reset(const run_type& run) noexcept {
   remaining_count_ = run.ValuesCount();
   if constexpr (std::is_same_v<value_type, bool>) {
     // ARROW-18031:  just check the LSB of the next byte and move on.
@@ -1393,12 +1393,12 @@ auto RleRunDecoder<T>::GetBatch(value_type* out, values_count_type batch_size)
  **********************/
 
 template <typename T>
-BitPackedRunDecoder<T>::BitPackedRunDecoder(run_type const& run) noexcept {
+BitPackedRunDecoder<T>::BitPackedRunDecoder(const run_type& run) noexcept {
   Reset(run);
 }
 
 template <typename T>
-void BitPackedRunDecoder<T>::Reset(run_type const& run) noexcept {
+void BitPackedRunDecoder<T>::Reset(const run_type& run) noexcept {
   value_bit_width_ = run.ValuesBitWidth();
   remaining_count_ = run.ValuesCount();
   ARROW_DCHECK_GE(value_bit_width_, 0);

--- a/cpp/src/arrow/util/rle_encoding_internal.h
+++ b/cpp/src/arrow/util/rle_encoding_internal.h
@@ -842,6 +842,67 @@ bool RleBitPackedDecoder<T>::NextCounts() {
   return true;
 }
 
+/************
+ *  RleRun  *
+ ************/
+
+inline RleRun::RleRun(raw_data_const_pointer data, values_count_type values_count,
+                      bit_size_type value_bit_width) noexcept
+    : values_count_(values_count), value_bit_width_(value_bit_width) {
+  ARROW_DCHECK_GE(value_bit_width, 0);
+  ARROW_DCHECK_GE(values_count, 0);
+  std::copy(data, data + RawDataSize(), data_.begin());
+}
+
+constexpr auto RleRun::ValuesCount() const noexcept -> values_count_type {
+  return values_count_;
+}
+
+constexpr auto RleRun::ValuesBitWidth() const noexcept -> bit_size_type {
+  return value_bit_width_;
+}
+
+constexpr auto RleRun::RawDataPtr() const noexcept -> raw_data_const_pointer {
+  return data_.data();
+}
+
+constexpr auto RleRun::RawDataSize() const noexcept -> raw_data_size_type {
+  auto out = bit_util::BytesForBits(value_bit_width_);
+  ARROW_DCHECK_LE(out, std::numeric_limits<raw_data_size_type>::max());
+  return static_cast<raw_data_size_type>(out);
+};
+
+/******************
+ *  BitPackedRun  *
+ ******************/
+
+constexpr BitPackedRun::BitPackedRun(raw_data_const_pointer data,
+                                     values_count_type values_count,
+                                     bit_size_type value_bit_width) noexcept
+    : data_(data), values_count_(values_count), value_bit_width_(value_bit_width) {
+  ARROW_CHECK_GE(value_bit_width_, 0);
+  ARROW_CHECK_GE(values_count_, 0);
+}
+
+constexpr auto BitPackedRun::ValuesCount() const noexcept -> values_count_type {
+  return values_count_;
+}
+
+constexpr auto BitPackedRun::ValuesBitWidth() const noexcept -> bit_size_type {
+  return value_bit_width_;
+}
+
+constexpr auto BitPackedRun::RawDataPtr() const noexcept -> raw_data_const_pointer {
+  return data_;
+}
+
+constexpr auto BitPackedRun::RawDataSize() const noexcept -> raw_data_size_type {
+  auto out = bit_util::BytesForBits(static_cast<int64_t>(value_bit_width_) *
+                                    static_cast<int64_t>(values_count_));
+  ARROW_CHECK_LE(out, std::numeric_limits<raw_data_size_type>::max());
+  return static_cast<raw_data_size_type>(out);
+}
+
 /****************
  *  RleDecoder  *
  ****************/

--- a/cpp/src/arrow/util/rle_encoding_internal.h
+++ b/cpp/src/arrow/util/rle_encoding_internal.h
@@ -890,7 +890,9 @@ auto RunGetSpaced(Converter* converter, typename Converter::out_type* out,
   while (run_values_remaining() > 0 && batch.values_remaining() > 0) {
     // Pull a batch of values from the bit packed encoded data and store it in a local
     // buffer to benefit from unpacking intrinsics and data locality.
-    static constexpr rle_size_t kBufferCapacity = 1024 / sizeof(value_type);
+    // Quick benchmarking on a linux x86-64 cloud instance show that this previously
+    // hard-coded value is appropriate.
+    static constexpr rle_size_t kBufferCapacity = 1024;
     std::array<value_type, kBufferCapacity> buffer = {};
 
     rle_size_t buffer_start = 0;

--- a/cpp/src/arrow/util/rle_encoding_internal.h
+++ b/cpp/src/arrow/util/rle_encoding_internal.h
@@ -838,74 +838,10 @@ static_assert(min(5, 41) == 5);
 
 template <typename Converter, typename BitRunReader, typename BitRun,
           typename values_count_type, typename value_type>
-auto GetSpacedBitPackedIdentity(Converter& converter, typename Converter::out_type* out,
-                                values_count_type batch_size,
-                                values_count_type null_count,
-                                BitRunReader&& validity_reader, BitRun&& validity_run,
-                                BitPackedDecoder<value_type>& decoder)
-    -> std::pair<values_count_type, values_count_type> {
-  ARROW_DCHECK_GT(batch_size, 0);
-  // The equality case is handled in the main loop in GetSpaced
-  ARROW_DCHECK_LT(null_count, batch_size);
-
-  auto batch = BatchCounter::FromBatchSizeAndNulls(batch_size, null_count);
-
-  values_count_type const values_available = decoder.Remaining();
-  ARROW_DCHECK_GT(values_available, 0);
-  auto run_values_remaining = [&]() {
-    auto out = values_available - batch.ValuesRead();
-    ARROW_DCHECK_GE(out, 0);
-    return out;
-  };
-
-  while (run_values_remaining() > 0 && batch.ValuesRemaining() > 0) {
-    ARROW_DCHECK_GE(validity_run.length, 0);
-    ARROW_DCHECK_LT(validity_run.length, max_size_for_v<values_count_type>);
-    ARROW_DCHECK_LE(validity_run.length, batch.TotalRemaining());
-    auto const validity_run_length = static_cast<values_count_type>(validity_run.length);
-
-    // Copy as much as possible from the buffer into the output while not exceeding
-    // validity run
-    if (validity_run.set) {
-      auto const requested_read = std::min(validity_run_length, run_values_remaining());
-      // Since this is identity, we can write directly to the output
-      auto const actual_read = decoder.GetBatch(out, requested_read);
-
-      if (ARROW_PREDICT_FALSE(!converter.InputIsValid(out, actual_read))) {
-        return {batch.ValuesRead(), batch.NullRead()};
-      }
-
-      batch.AccrueReadValues(actual_read);
-      out += actual_read;
-      validity_run.length -= actual_read;
-
-      // Simply write zeros in the output
-    } else {
-      auto const update_size = std::min(validity_run_length, batch.NullRemaining());
-      converter.WriteZero(out, out + update_size);
-      batch.AccrueReadNulls(update_size);
-      out += update_size;
-      validity_run.length -= update_size;
-    }
-
-    if (validity_run.length == 0) {
-      validity_run = validity_reader.NextRun();
-    }
-  }
-
-  ARROW_DCHECK_EQ(values_available - decoder.Remaining(), batch.ValuesRead());
-  ARROW_DCHECK_LE(batch.TotalRead(), batch_size);
-  ARROW_DCHECK_LE(batch.NullRead(), batch.NullCount());
-
-  return {batch.ValuesRead(), batch.NullRead()};
-}
-
-template <typename Converter, typename BitRunReader, typename BitRun,
-          typename values_count_type, typename value_type>
-auto GetSpacedBitPackedDefault(Converter& converter, typename Converter::out_type* out,
-                               values_count_type batch_size, values_count_type null_count,
-                               BitRunReader&& validity_reader, BitRun&& validity_run,
-                               BitPackedDecoder<value_type>& decoder)
+auto RunGetSpaced(Converter& converter, typename Converter::out_type* out,
+                  values_count_type batch_size, values_count_type null_count,
+                  BitRunReader&& validity_reader, BitRun&& validity_run,
+                  BitPackedDecoder<value_type>& decoder)
     -> std::pair<values_count_type, values_count_type> {
   ARROW_DCHECK_GT(batch_size, 0);
   // The equality case is handled in the main loop in GetSpaced
@@ -985,26 +921,6 @@ auto GetSpacedBitPackedDefault(Converter& converter, typename Converter::out_typ
   ARROW_DCHECK_LE(batch.NullRead(), batch.NullCount());
 
   return {batch.ValuesRead(), batch.NullRead()};
-}
-
-/// Overload for GetSpaced for a single run in a BitPackedDecoder
-template <typename Converter, typename BitRunReader, typename BitRun,
-          typename values_count_type, typename value_type>
-auto RunGetSpaced(Converter& converter, typename Converter::out_type* out,
-                  values_count_type batch_size, values_count_type null_count,
-                  BitRunReader&& validity_reader, BitRun&& validity_run,
-                  BitPackedDecoder<value_type>& decoder)
-    -> std::pair<values_count_type, values_count_type> {
-  if constexpr (Converter::kIsIdentity) {
-    // An optimization
-    return GetSpacedBitPackedIdentity(converter, out, batch_size, null_count,
-                                      std::forward<BitRunReader>(validity_reader),
-                                      std::forward<BitRun>(validity_run), decoder);
-  } else {
-    return GetSpacedBitPackedDefault(converter, out, batch_size, null_count,
-                                     std::forward<BitRunReader>(validity_reader),
-                                     std::forward<BitRun>(validity_run), decoder);
-  }
 }
 
 /// Overload for GetSpaced for a single run in a decoder variant

--- a/cpp/src/arrow/util/rle_encoding_internal.h
+++ b/cpp/src/arrow/util/rle_encoding_internal.h
@@ -102,8 +102,6 @@ class RleRun {
   using DecoderType = RleRunDecoder<T>;
 
   constexpr RleRun() noexcept = default;
-  constexpr RleRun(const RleRun&) noexcept = default;
-  constexpr RleRun(RleRun&&) noexcept = default;
 
   explicit RleRun(raw_data_const_pointer data, values_count_type values_count,
                   bit_size_type value_bit_width) noexcept
@@ -112,9 +110,6 @@ class RleRun {
     ARROW_DCHECK_GE(values_count, 0);
     std::copy(data, data + raw_data_size(), data_.begin());
   }
-
-  constexpr RleRun& operator=(const RleRun&) noexcept = default;
-  constexpr RleRun& operator=(RleRun&&) noexcept = default;
 
   /// The number of repeated values in this run.
   constexpr values_count_type values_count() const noexcept { return values_count_; }
@@ -160,8 +155,6 @@ class BitPackedRun {
   using DecoderType = BitPackedRunDecoder<T>;
 
   constexpr BitPackedRun() noexcept = default;
-  constexpr BitPackedRun(const BitPackedRun&) noexcept = default;
-  constexpr BitPackedRun(BitPackedRun&&) noexcept = default;
 
   constexpr BitPackedRun(raw_data_const_pointer data, values_count_type values_count,
                          bit_size_type value_bit_width) noexcept
@@ -169,9 +162,6 @@ class BitPackedRun {
     ARROW_CHECK_GE(value_bit_width_, 0);
     ARROW_CHECK_GE(values_count_, 0);
   }
-
-  constexpr BitPackedRun& operator=(const BitPackedRun&) noexcept = default;
-  constexpr BitPackedRun& operator=(BitPackedRun&&) noexcept = default;
 
   constexpr values_count_type values_count() const noexcept { return values_count_; }
 

--- a/cpp/src/arrow/util/rle_encoding_test.cc
+++ b/cpp/src/arrow/util/rle_encoding_test.cc
@@ -416,18 +416,6 @@ void TestRleBitPackedParser(std::vector<uint8_t> bytes,
       bit_width);
   EXPECT_FALSE(parser.Exhausted());
 
-  // Peek return the same data
-  auto run1 = parser.Peek();
-  EXPECT_TRUE(run1.has_value());
-  auto run2 = parser.Peek();
-  EXPECT_TRUE(run2.has_value());
-  auto ptr1 = std::visit([](auto const& r) { return r.RawDataPtr(); }, run1.value());
-  auto size1 = std::visit([](auto const& r) { return r.RawDataSize(); }, run1.value());
-  auto ptr2 = std::visit([](auto const& r) { return r.RawDataPtr(); }, run2.value());
-  auto size2 = std::visit([](auto const& r) { return r.RawDataSize(); }, run2.value());
-  EXPECT_TRUE(std::equal(ptr1, ptr1 + size1, ptr2, ptr2 + size2));
-  EXPECT_FALSE(parser.Exhausted());
-
   // Try to decode all data of all runs in the decoded vector
   decltype(expected) decoded = {};
   auto rle_decoder = RleRunDecoder<T>();

--- a/cpp/src/arrow/util/rle_encoding_test.cc
+++ b/cpp/src/arrow/util/rle_encoding_test.cc
@@ -240,7 +240,7 @@ void ValidateRle(const std::vector<int>& values, int bit_width,
 
   // Verify read
   {
-    RleDecoder<uint64_t> decoder(buffer, len, bit_width);
+    RleBitPackedDecoder<uint64_t> decoder(buffer, len, bit_width);
     for (size_t i = 0; i < values.size(); ++i) {
       uint64_t val;
       bool result = decoder.Get(&val);
@@ -251,7 +251,7 @@ void ValidateRle(const std::vector<int>& values, int bit_width,
 
   // Verify batch read
   {
-    RleDecoder<int> decoder(buffer, len, bit_width);
+    RleBitPackedDecoder<int> decoder(buffer, len, bit_width);
     std::vector<int> values_read(values.size());
     ASSERT_EQ(values.size(),
               decoder.GetBatch(values_read.data(), static_cast<int>(values.size())));
@@ -282,7 +282,7 @@ bool CheckRoundTrip(const std::vector<int>& values, int bit_width) {
   int out = 0;
 
   {
-    RleDecoder<int> decoder(buffer, encoded_len, bit_width);
+    RleBitPackedDecoder<int> decoder(buffer, encoded_len, bit_width);
     for (size_t i = 0; i < values.size(); ++i) {
       EXPECT_TRUE(decoder.Get(&out));
       if (values[i] != out) {
@@ -293,7 +293,7 @@ bool CheckRoundTrip(const std::vector<int>& values, int bit_width) {
 
   // Verify batch read
   {
-    RleDecoder<int> decoder(buffer, encoded_len, bit_width);
+    RleBitPackedDecoder<int> decoder(buffer, encoded_len, bit_width);
     std::vector<int> values_read(values.size());
     if (static_cast<int>(values.size()) !=
         decoder.GetBatch(values_read.data(), static_cast<int>(values.size()))) {
@@ -419,7 +419,7 @@ TEST(Rle, BitWidthZeroRepeated) {
   uint8_t buffer[1];
   const int num_values = 15;
   buffer[0] = num_values << 1;  // repeated indicator byte
-  RleDecoder<uint8_t> decoder(buffer, sizeof(buffer), 0);
+  RleBitPackedDecoder<uint8_t> decoder(buffer, sizeof(buffer), 0);
   uint8_t val;
   for (int i = 0; i < num_values; ++i) {
     bool result = decoder.Get(&val);
@@ -433,7 +433,7 @@ TEST(Rle, BitWidthZeroLiteral) {
   uint8_t buffer[1];
   const int num_groups = 4;
   buffer[0] = num_groups << 1 | 1;  // literal indicator byte
-  RleDecoder<uint8_t> decoder = {buffer, sizeof(buffer), 0};
+  RleBitPackedDecoder<uint8_t> decoder = {buffer, sizeof(buffer), 0};
   const int num_values = num_groups * 8;
   uint8_t val;
   for (int i = 0; i < num_values; ++i) {
@@ -538,7 +538,7 @@ TEST(BitRle, Overflow) {
     EXPECT_LE(bytes_written, len);
     EXPECT_GT(num_added, 0);
 
-    RleDecoder<uint32_t> decoder(buffer.data(), bytes_written, bit_width);
+    RleBitPackedDecoder<uint32_t> decoder(buffer.data(), bytes_written, bit_width);
     parity = true;
     uint32_t v;
     for (int i = 0; i < num_added; ++i) {
@@ -575,7 +575,7 @@ void CheckRoundTripSpaced(const Array& data, int bit_width) {
   int encoded_size = encoder.Flush();
 
   // Verify batch read
-  RleDecoder<T> decoder(buffer.data(), encoded_size, bit_width);
+  RleBitPackedDecoder<T> decoder(buffer.data(), encoded_size, bit_width);
   std::vector<T> values_read(num_values);
 
   if (num_values != decoder.GetBatchSpaced(

--- a/cpp/src/arrow/util/rle_encoding_test.cc
+++ b/cpp/src/arrow/util/rle_encoding_test.cc
@@ -217,21 +217,21 @@ TEST(Rle, RleRun) {
   RleRun::values_count_type value_count = 12;
 
   // 12 times the value 21 fitting over 5 bits
-  auto const run_5 = RleRun(value.data(), value_count, /* value_bit_width= */ 5);
+  const auto run_5 = RleRun(value.data(), value_count, /* value_bit_width= */ 5);
   EXPECT_EQ(run_5.ValuesCount(), value_count);
   EXPECT_EQ(run_5.ValuesBitWidth(), 5);
   EXPECT_EQ(run_5.RawDataSize(), 1);  // 5 bits fit in one byte
   EXPECT_EQ(*run_5.RawDataPtr(), 21);
 
   // 12 times the value 21 fitting over 16 bits
-  auto const run_8 = RleRun(value.data(), value_count, /* value_bit_width= */ 8);
+  const auto run_8 = RleRun(value.data(), value_count, /* value_bit_width= */ 8);
   EXPECT_EQ(run_8.ValuesCount(), value_count);
   EXPECT_EQ(run_8.ValuesBitWidth(), 8);
   EXPECT_EQ(run_8.RawDataSize(), 1);  // 8 bits fit in 1 byte
   EXPECT_EQ(*run_8.RawDataPtr(), 21);
 
   // 12 times the value {21, 2} fitting over 10 bits
-  auto const run_10 = RleRun(value.data(), value_count, /* value_bit_width= */ 10);
+  const auto run_10 = RleRun(value.data(), value_count, /* value_bit_width= */ 10);
 
   EXPECT_EQ(run_10.ValuesCount(), value_count);
   EXPECT_EQ(run_10.ValuesBitWidth(), 10);
@@ -240,7 +240,7 @@ TEST(Rle, RleRun) {
   EXPECT_EQ(*(run_10.RawDataPtr() + 1), 2);
 
   // 12 times the value {21, 2} fitting over 32 bits
-  auto const run_32 = RleRun(value.data(), value_count, /* value_bit_width= */ 32);
+  const auto run_32 = RleRun(value.data(), value_count, /* value_bit_width= */ 32);
   EXPECT_EQ(run_32.ValuesCount(), value_count);
   EXPECT_EQ(run_32.ValuesBitWidth(), 32);
   EXPECT_EQ(run_32.RawDataSize(), 4);  // 32 bits fit in 4 bytes
@@ -257,7 +257,7 @@ TEST(BitPacked, BitPackedRun) {
 
   // 16 values of 1 bit for a total of 16 bits
   BitPackedRun::values_count_type value_count_1 = 16;
-  auto const run_1 = BitPackedRun(value.data(), value_count_1, /* value_bit_width= */ 1);
+  const auto run_1 = BitPackedRun(value.data(), value_count_1, /* value_bit_width= */ 1);
   EXPECT_EQ(run_1.ValuesCount(), value_count_1);
   EXPECT_EQ(run_1.ValuesBitWidth(), 1);
   EXPECT_EQ(run_1.RawDataSize(), 2);  // 16 bits fit in 2 bytes
@@ -267,7 +267,7 @@ TEST(BitPacked, BitPackedRun) {
 
   // 8 values of 3 bits for a total of 24 bits
   BitPackedRun::values_count_type value_count_3 = 8;
-  auto const run_3 = BitPackedRun(value.data(), value_count_3, /* value_bit_width= */ 3);
+  const auto run_3 = BitPackedRun(value.data(), value_count_3, /* value_bit_width= */ 3);
   EXPECT_EQ(run_3.ValuesCount(), value_count_3);
   EXPECT_EQ(run_3.ValuesBitWidth(), 3);
   EXPECT_EQ(run_3.RawDataSize(), 3);  // 24 bits fit in 3 bytes
@@ -282,7 +282,7 @@ void TestRleDecoder(std::vector<uint8_t> bytes, RleRun::values_count_type value_
   // Pre-requisite for this test
   EXPECT_GT(value_count, 6);
 
-  auto const run = RleRun(bytes.data(), value_count, bit_width);
+  const auto run = RleRun(bytes.data(), value_count, bit_width);
 
   auto decoder = RleRunDecoder<T>(run);
   std::vector<T> vals = {0, 0};
@@ -344,7 +344,7 @@ void TestBitPackedDecoder(std::vector<uint8_t> bytes,
   // Pre-requisite for this test
   EXPECT_GT(value_count, 6);
 
-  auto const run = BitPackedRun(bytes.data(), value_count, bit_width);
+  const auto run = BitPackedRun(bytes.data(), value_count, bit_width);
 
   auto decoder = BitPackedRunDecoder<T>(run);
   std::vector<T> vals = {0, 0};
@@ -432,8 +432,8 @@ void TestRleBitPackedParser(std::vector<uint8_t> bytes,
     auto OnRleRun(RleRun run) {
       rle_decoder_ptr_->Reset(run);
 
-      auto const n_decoded = decoded_ptr_->size();
-      auto const n_to_decode = rle_decoder_ptr_->Remaining();
+      const auto n_decoded = decoded_ptr_->size();
+      const auto n_to_decode = rle_decoder_ptr_->Remaining();
       decoded_ptr_->resize(n_decoded + n_to_decode);
       EXPECT_EQ(rle_decoder_ptr_->GetBatch(decoded_ptr_->data() + n_decoded, n_to_decode),
                 n_to_decode);
@@ -445,8 +445,8 @@ void TestRleBitPackedParser(std::vector<uint8_t> bytes,
     auto OnBitPackedRun(BitPackedRun run) {
       bit_packed_decoder_ptr_->Reset(run);
 
-      auto const n_decoded = decoded_ptr_->size();
-      auto const n_to_decode = bit_packed_decoder_ptr_->Remaining();
+      const auto n_decoded = decoded_ptr_->size();
+      const auto n_to_decode = bit_packed_decoder_ptr_->Remaining();
       decoded_ptr_->resize(n_decoded + n_to_decode);
       EXPECT_EQ(bit_packed_decoder_ptr_->GetBatch(decoded_ptr_->data() + n_decoded,
                                                   n_to_decode),
@@ -865,10 +865,10 @@ void CheckRoundTrip(const Array& data, int bit_width, bool spaced, int32_t parts
   using ArrayType = typename TypeTraits<Type>::ArrayType;
   using value_type = typename Type::c_type;
 
-  int const data_size = static_cast<int>(data.length());
-  int const data_values_count =
+  const int data_size = static_cast<int>(data.length());
+  const int data_values_count =
       static_cast<int>(data.length() - spaced * data.null_count());
-  int const buffer_size = RleBitPackedEncoder::MaxBufferSize(bit_width, data_size);
+  const int buffer_size = RleBitPackedEncoder::MaxBufferSize(bit_width, data_size);
   ASSERT_GE(parts, 1);
   ASSERT_LE(parts, data_size);
 
@@ -905,7 +905,7 @@ void CheckRoundTrip(const Array& data, int bit_width, bool spaced, int32_t parts
   int32_t actual_read_count = 0;
   int32_t requested_read_count = 0;
   while (requested_read_count < data_size) {
-    auto const remaining = data_size - requested_read_count;
+    const auto remaining = data_size - requested_read_count;
     auto to_read = data_size / parts;
     if (remaining / to_read == 1) {
       to_read = remaining;
@@ -1006,7 +1006,7 @@ struct DataTestRleBitPacked {
 
     std::vector<std::shared_ptr<::arrow::Array>> arrays = {};
 
-    for (auto const& dyn_part : parts) {
+    for (const auto& dyn_part : parts) {
       if (auto* part = std::get_if<RandomPart>(&dyn_part)) {
         auto arr = rand.Numeric<ArrowType>(part->size, /* min= */ value_type(0),
                                            part->max, part->null_probability);

--- a/cpp/src/arrow/util/rle_encoding_test.cc
+++ b/cpp/src/arrow/util/rle_encoding_test.cc
@@ -218,36 +218,36 @@ TEST(Rle, RleRun) {
 
   // 12 times the value 21 fitting over 5 bits
   const auto run_5 = RleRun(value.data(), value_count, /* value_bit_width= */ 5);
-  EXPECT_EQ(run_5.ValuesCount(), value_count);
-  EXPECT_EQ(run_5.ValuesBitWidth(), 5);
-  EXPECT_EQ(run_5.RawDataSize(), 1);  // 5 bits fit in one byte
-  EXPECT_EQ(*run_5.RawDataPtr(), 21);
+  EXPECT_EQ(run_5.values_count(), value_count);
+  EXPECT_EQ(run_5.values_bit_width(), 5);
+  EXPECT_EQ(run_5.raw_data_size(), 1);  // 5 bits fit in one byte
+  EXPECT_EQ(*run_5.raw_data_ptr(), 21);
 
   // 12 times the value 21 fitting over 8 bits
   const auto run_8 = RleRun(value.data(), value_count, /* value_bit_width= */ 8);
-  EXPECT_EQ(run_8.ValuesCount(), value_count);
-  EXPECT_EQ(run_8.ValuesBitWidth(), 8);
-  EXPECT_EQ(run_8.RawDataSize(), 1);  // 8 bits fit in 1 byte
-  EXPECT_EQ(*run_8.RawDataPtr(), 21);
+  EXPECT_EQ(run_8.values_count(), value_count);
+  EXPECT_EQ(run_8.values_bit_width(), 8);
+  EXPECT_EQ(run_8.raw_data_size(), 1);  // 8 bits fit in 1 byte
+  EXPECT_EQ(*run_8.raw_data_ptr(), 21);
 
   // 12 times the value 533 (21 + 2 * 2^8) fitting over 10 bits
   const auto run_10 = RleRun(value.data(), value_count, /* value_bit_width= */ 10);
 
-  EXPECT_EQ(run_10.ValuesCount(), value_count);
-  EXPECT_EQ(run_10.ValuesBitWidth(), 10);
-  EXPECT_EQ(run_10.RawDataSize(), 2);  // 10 bits fit in 2 bytes
-  EXPECT_EQ(*(run_10.RawDataPtr() + 0), 21);
-  EXPECT_EQ(*(run_10.RawDataPtr() + 1), 2);
+  EXPECT_EQ(run_10.values_count(), value_count);
+  EXPECT_EQ(run_10.values_bit_width(), 10);
+  EXPECT_EQ(run_10.raw_data_size(), 2);  // 10 bits fit in 2 bytes
+  EXPECT_EQ(*(run_10.raw_data_ptr() + 0), 21);
+  EXPECT_EQ(*(run_10.raw_data_ptr() + 1), 2);
 
   // 12 times the value 533 (21 + 2 * 2^8) fitting over 32 bits
   const auto run_32 = RleRun(value.data(), value_count, /* value_bit_width= */ 32);
-  EXPECT_EQ(run_32.ValuesCount(), value_count);
-  EXPECT_EQ(run_32.ValuesBitWidth(), 32);
-  EXPECT_EQ(run_32.RawDataSize(), 4);  // 32 bits fit in 4 bytes
-  EXPECT_EQ(*(run_32.RawDataPtr() + 0), 21);
-  EXPECT_EQ(*(run_32.RawDataPtr() + 1), 2);
-  EXPECT_EQ(*(run_32.RawDataPtr() + 2), 0);
-  EXPECT_EQ(*(run_32.RawDataPtr() + 3), 0);
+  EXPECT_EQ(run_32.values_count(), value_count);
+  EXPECT_EQ(run_32.values_bit_width(), 32);
+  EXPECT_EQ(run_32.raw_data_size(), 4);  // 32 bits fit in 4 bytes
+  EXPECT_EQ(*(run_32.raw_data_ptr() + 0), 21);
+  EXPECT_EQ(*(run_32.raw_data_ptr() + 1), 2);
+  EXPECT_EQ(*(run_32.raw_data_ptr() + 2), 0);
+  EXPECT_EQ(*(run_32.raw_data_ptr() + 3), 0);
 }
 
 /// A BitPacked run is a simple class owning some data and its size.
@@ -258,18 +258,18 @@ TEST(BitPacked, BitPackedRun) {
   // 16 values of 1 bit for a total of 16 bits
   BitPackedRun::values_count_type value_count_1 = 16;
   const auto run_1 = BitPackedRun(value.data(), value_count_1, /* value_bit_width= */ 1);
-  EXPECT_EQ(run_1.ValuesCount(), value_count_1);
-  EXPECT_EQ(run_1.ValuesBitWidth(), 1);
-  EXPECT_EQ(run_1.RawDataSize(), 2);  // 16 bits fit in 2 bytes
-  EXPECT_EQ(run_1.RawDataPtr(), value.data());
+  EXPECT_EQ(run_1.values_count(), value_count_1);
+  EXPECT_EQ(run_1.values_bit_width(), 1);
+  EXPECT_EQ(run_1.raw_data_size(), 2);  // 16 bits fit in 2 bytes
+  EXPECT_EQ(run_1.raw_data_ptr(), value.data());
 
   // 8 values of 3 bits for a total of 24 bits
   BitPackedRun::values_count_type value_count_3 = 8;
   const auto run_3 = BitPackedRun(value.data(), value_count_3, /* value_bit_width= */ 3);
-  EXPECT_EQ(run_3.ValuesCount(), value_count_3);
-  EXPECT_EQ(run_3.ValuesBitWidth(), 3);
-  EXPECT_EQ(run_3.RawDataSize(), 3);  // 24 bits fit in 3 bytes
-  EXPECT_EQ(run_3.RawDataPtr(), value.data());
+  EXPECT_EQ(run_3.values_count(), value_count_3);
+  EXPECT_EQ(run_3.values_bit_width(), 3);
+  EXPECT_EQ(run_3.raw_data_size(), 3);  // 24 bits fit in 3 bytes
+  EXPECT_EQ(run_3.raw_data_ptr(), value.data());
 }
 
 template <typename T>
@@ -283,28 +283,28 @@ void TestRleDecoder(std::vector<uint8_t> bytes, RleRun::values_count_type value_
   auto decoder = RleRunDecoder<T>(run);
   std::vector<T> vals = {0, 0};
 
-  EXPECT_EQ(decoder.Remaining(), value_count);
+  EXPECT_EQ(decoder.remaining(), value_count);
 
   typename decltype(decoder)::values_count_type read = 0;
   EXPECT_EQ(decoder.Get(vals.data()), 1);
   read += 1;
   EXPECT_EQ(vals.at(0), expected_value);
-  EXPECT_EQ(decoder.Remaining(), value_count - read);
+  EXPECT_EQ(decoder.remaining(), value_count - read);
 
   EXPECT_EQ(decoder.Advance(3), 3);
   read += 3;
-  EXPECT_EQ(decoder.Remaining(), value_count - read);
+  EXPECT_EQ(decoder.remaining(), value_count - read);
 
   vals = {0, 0};
   EXPECT_EQ(decoder.GetBatch(vals.data(), 2), vals.size());
   EXPECT_EQ(vals.at(0), expected_value);
   EXPECT_EQ(vals.at(1), expected_value);
   read += static_cast<decltype(read)>(vals.size());
-  EXPECT_EQ(decoder.Remaining(), value_count - read);
+  EXPECT_EQ(decoder.remaining(), value_count - read);
 
   // Exhaust iteration
   EXPECT_EQ(decoder.Advance(value_count - read), value_count - read);
-  EXPECT_EQ(decoder.Remaining(), 0);
+  EXPECT_EQ(decoder.remaining(), 0);
   EXPECT_EQ(decoder.Advance(1), 0);
   vals = {0, 0};
   EXPECT_EQ(decoder.Get(vals.data()), 0);
@@ -312,7 +312,7 @@ void TestRleDecoder(std::vector<uint8_t> bytes, RleRun::values_count_type value_
 
   // Reset the decoder
   decoder.Reset(run);
-  EXPECT_EQ(decoder.Remaining(), value_count);
+  EXPECT_EQ(decoder.remaining(), value_count);
   vals = {0, 0};
   EXPECT_EQ(decoder.GetBatch(vals.data(), 2), vals.size());
   EXPECT_EQ(vals.at(0), expected_value);
@@ -345,28 +345,28 @@ void TestBitPackedDecoder(std::vector<uint8_t> bytes,
   auto decoder = BitPackedRunDecoder<T>(run);
   std::vector<T> vals = {0, 0};
 
-  EXPECT_EQ(decoder.Remaining(), value_count);
+  EXPECT_EQ(decoder.remaining(), value_count);
 
   typename decltype(decoder)::values_count_type read = 0;
   EXPECT_EQ(decoder.Get(vals.data()), 1);
   EXPECT_EQ(vals.at(0), expected.at(0 + read));
   read += 1;
-  EXPECT_EQ(decoder.Remaining(), value_count - read);
+  EXPECT_EQ(decoder.remaining(), value_count - read);
 
   EXPECT_EQ(decoder.Advance(3), 3);
   read += 3;
-  EXPECT_EQ(decoder.Remaining(), value_count - read);
+  EXPECT_EQ(decoder.remaining(), value_count - read);
 
   vals = {0, 0};
   EXPECT_EQ(decoder.GetBatch(vals.data(), 2), vals.size());
   EXPECT_EQ(vals.at(0), expected.at(0 + read));
   EXPECT_EQ(vals.at(1), expected.at(1 + read));
   read += static_cast<decltype(read)>(vals.size());
-  EXPECT_EQ(decoder.Remaining(), value_count - read);
+  EXPECT_EQ(decoder.remaining(), value_count - read);
 
   // Exhaust iteration
   EXPECT_EQ(decoder.Advance(value_count - read), value_count - read);
-  EXPECT_EQ(decoder.Remaining(), 0);
+  EXPECT_EQ(decoder.remaining(), 0);
   EXPECT_EQ(decoder.Advance(1), 0);
   vals = {0, 0};
   EXPECT_EQ(decoder.Get(vals.data()), 0);
@@ -375,7 +375,7 @@ void TestBitPackedDecoder(std::vector<uint8_t> bytes,
   // Reset the decoder
   decoder.Reset(run);
   read = 0;
-  EXPECT_EQ(decoder.Remaining(), value_count);
+  EXPECT_EQ(decoder.remaining(), value_count);
   vals = {0, 0};
   EXPECT_EQ(decoder.GetBatch(vals.data(), 2), vals.size());
   EXPECT_EQ(vals.at(0), expected.at(0 + read));
@@ -413,7 +413,7 @@ void TestRleBitPackedParser(std::vector<uint8_t> bytes,
   auto parser = RleBitPackedParser(
       bytes.data(), static_cast<BitPackedRun::raw_data_size_type>(bytes.size()),
       bit_width);
-  EXPECT_FALSE(parser.Exhausted());
+  EXPECT_FALSE(parser.exhausted());
 
   // Try to decode all data of all runs in the decoded vector
   decltype(expected) decoded = {};
@@ -429,11 +429,11 @@ void TestRleBitPackedParser(std::vector<uint8_t> bytes,
       rle_decoder_ptr_->Reset(run);
 
       const auto n_decoded = decoded_ptr_->size();
-      const auto n_to_decode = rle_decoder_ptr_->Remaining();
+      const auto n_to_decode = rle_decoder_ptr_->remaining();
       decoded_ptr_->resize(n_decoded + n_to_decode);
       EXPECT_EQ(rle_decoder_ptr_->GetBatch(decoded_ptr_->data() + n_decoded, n_to_decode),
                 n_to_decode);
-      EXPECT_EQ(rle_decoder_ptr_->Remaining(), 0);
+      EXPECT_EQ(rle_decoder_ptr_->remaining(), 0);
 
       return RleBitPackedParser::ControlFlow::Continue;
     }
@@ -442,12 +442,12 @@ void TestRleBitPackedParser(std::vector<uint8_t> bytes,
       bit_packed_decoder_ptr_->Reset(run);
 
       const auto n_decoded = decoded_ptr_->size();
-      const auto n_to_decode = bit_packed_decoder_ptr_->Remaining();
+      const auto n_to_decode = bit_packed_decoder_ptr_->remaining();
       decoded_ptr_->resize(n_decoded + n_to_decode);
       EXPECT_EQ(bit_packed_decoder_ptr_->GetBatch(decoded_ptr_->data() + n_decoded,
                                                   n_to_decode),
                 n_to_decode);
-      EXPECT_EQ(bit_packed_decoder_ptr_->Remaining(), 0);
+      EXPECT_EQ(bit_packed_decoder_ptr_->remaining(), 0);
 
       return RleBitPackedParser::ControlFlow::Continue;
     }
@@ -456,7 +456,7 @@ void TestRleBitPackedParser(std::vector<uint8_t> bytes,
   // Iterate over all runs
   parser.Parse(handler);
 
-  EXPECT_TRUE(parser.Exhausted());
+  EXPECT_TRUE(parser.exhausted());
   EXPECT_EQ(decoded.size(), expected.size());
   EXPECT_EQ(decoded, expected);
 }

--- a/cpp/src/arrow/util/rle_encoding_test.cc
+++ b/cpp/src/arrow/util/rle_encoding_test.cc
@@ -911,29 +911,30 @@ void CheckRoundTrip(const Array& data, int bit_width,
       to_read = remaining;
     }
 
-    auto* out = values_read.data() + requested_read_count;
-    auto* dict_out = dict_read.data() + requested_read_count;
-
     auto read = 0;
     if constexpr (kSpaced) {
       // We need to slice the input array get the proper null count and bitmap
       auto data_remaining = data.Slice(requested_read_count, to_read);
 
       if (dict) {
+        auto* out = dict_read.data() + requested_read_count;
         read = decoder.GetBatchWithDictSpaced(
-            dict->raw_values(), static_cast<int32_t>(dict->length()), dict_out, to_read,
+            dict->raw_values(), static_cast<int32_t>(dict->length()), out, to_read,
             static_cast<int32_t>(data_remaining->null_count()),
             data_remaining->null_bitmap_data(), data_remaining->offset());
       } else {
+        auto* out = values_read.data() + requested_read_count;
         read = decoder.GetBatchSpaced(
             to_read, static_cast<int32_t>(data_remaining->null_count()),
             data_remaining->null_bitmap_data(), data_remaining->offset(), out);
       }
     } else {
       if (dict) {
+        auto* out = dict_read.data() + requested_read_count;
         read = decoder.GetBatchWithDict(
-            dict->raw_values(), static_cast<int32_t>(dict->length()), dict_out, to_read);
+            dict->raw_values(), static_cast<int32_t>(dict->length()), out, to_read);
       } else {
+        auto* out = values_read.data() + requested_read_count;
         read = decoder.GetBatch(out, to_read);
       }
     }

--- a/cpp/src/parquet/column_reader.cc
+++ b/cpp/src/parquet/column_reader.cc
@@ -113,7 +113,7 @@ int LevelDecoder::SetData(Encoding::type encoding, int16_t max_level,
       }
       const uint8_t* decoder_data = data + 4;
       if (!rle_decoder_) {
-        rle_decoder_ = std::make_unique<::arrow::util::RleDecoder<int16_t>>(
+        rle_decoder_ = std::make_unique<::arrow::util::RleBitPackedDecoder<int16_t>>(
             decoder_data, num_bytes, bit_width_);
       } else {
         rle_decoder_->Reset(decoder_data, num_bytes, bit_width_);
@@ -157,8 +157,8 @@ void LevelDecoder::SetDataV2(int32_t num_bytes, int16_t max_level,
   bit_width_ = bit_util::Log2(max_level + 1);
 
   if (!rle_decoder_) {
-    rle_decoder_ =
-        std::make_unique<::arrow::util::RleDecoder<int16_t>>(data, num_bytes, bit_width_);
+    rle_decoder_ = std::make_unique<::arrow::util::RleBitPackedDecoder<int16_t>>(
+        data, num_bytes, bit_width_);
   } else {
     rle_decoder_->Reset(data, num_bytes, bit_width_);
   }

--- a/cpp/src/parquet/column_reader.cc
+++ b/cpp/src/parquet/column_reader.cc
@@ -113,8 +113,8 @@ int LevelDecoder::SetData(Encoding::type encoding, int16_t max_level,
       }
       const uint8_t* decoder_data = data + 4;
       if (!rle_decoder_) {
-        rle_decoder_ = std::make_unique<::arrow::util::RleDecoder>(decoder_data,
-                                                                   num_bytes, bit_width_);
+        rle_decoder_ = std::make_unique<::arrow::util::RleDecoder<int16_t>>(
+            decoder_data, num_bytes, bit_width_);
       } else {
         rle_decoder_->Reset(decoder_data, num_bytes, bit_width_);
       }
@@ -158,7 +158,7 @@ void LevelDecoder::SetDataV2(int32_t num_bytes, int16_t max_level,
 
   if (!rle_decoder_) {
     rle_decoder_ =
-        std::make_unique<::arrow::util::RleDecoder>(data, num_bytes, bit_width_);
+        std::make_unique<::arrow::util::RleDecoder<int16_t>>(data, num_bytes, bit_width_);
   } else {
     rle_decoder_->Reset(data, num_bytes, bit_width_);
   }

--- a/cpp/src/parquet/column_reader.h
+++ b/cpp/src/parquet/column_reader.h
@@ -39,6 +39,7 @@ class BitReader;
 }  // namespace bit_util
 
 namespace util {
+template <typename T>
 class RleDecoder;
 }  // namespace util
 
@@ -95,7 +96,7 @@ class PARQUET_EXPORT LevelDecoder {
   int bit_width_;
   int num_values_remaining_;
   Encoding::type encoding_;
-  std::unique_ptr<::arrow::util::RleDecoder> rle_decoder_;
+  std::unique_ptr<::arrow::util::RleDecoder<int16_t>> rle_decoder_;
   std::unique_ptr<::arrow::bit_util::BitReader> bit_packed_decoder_;
   int16_t max_level_;
 };

--- a/cpp/src/parquet/column_reader.h
+++ b/cpp/src/parquet/column_reader.h
@@ -40,7 +40,7 @@ class BitReader;
 
 namespace util {
 template <typename T>
-class RleDecoder;
+class RleBitPackedDecoder;
 }  // namespace util
 
 }  // namespace arrow
@@ -96,7 +96,7 @@ class PARQUET_EXPORT LevelDecoder {
   int bit_width_;
   int num_values_remaining_;
   Encoding::type encoding_;
-  std::unique_ptr<::arrow::util::RleDecoder<int16_t>> rle_decoder_;
+  std::unique_ptr<::arrow::util::RleBitPackedDecoder<int16_t>> rle_decoder_;
   std::unique_ptr<::arrow::bit_util::BitReader> bit_packed_decoder_;
   int16_t max_level_;
 };

--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -70,7 +70,7 @@ using arrow::bit_util::BitWriter;
 using arrow::internal::checked_cast;
 using arrow::internal::checked_pointer_cast;
 using arrow::util::Float16;
-using arrow::util::RleEncoder;
+using arrow::util::RleBitPackedEncoder;
 
 namespace bit_util = arrow::bit_util;
 
@@ -168,7 +168,7 @@ void LevelEncoder::Init(Encoding::type encoding, int16_t max_level,
   encoding_ = encoding;
   switch (encoding) {
     case Encoding::RLE: {
-      rle_encoder_ = std::make_unique<RleEncoder>(data, data_size, bit_width_);
+      rle_encoder_ = std::make_unique<RleBitPackedEncoder>(data, data_size, bit_width_);
       break;
     }
     case Encoding::BIT_PACKED: {
@@ -190,8 +190,8 @@ int LevelEncoder::MaxBufferSize(Encoding::type encoding, int16_t max_level,
     case Encoding::RLE: {
       // TODO: Due to the way we currently check if the buffer is full enough,
       // we need to have MinBufferSize as head room.
-      num_bytes = RleEncoder::MaxBufferSize(bit_width, num_buffered_values) +
-                  RleEncoder::MinBufferSize(bit_width);
+      num_bytes = RleBitPackedEncoder::MaxBufferSize(bit_width, num_buffered_values) +
+                  RleBitPackedEncoder::MinBufferSize(bit_width);
       break;
     }
     case Encoding::BIT_PACKED: {

--- a/cpp/src/parquet/column_writer.h
+++ b/cpp/src/parquet/column_writer.h
@@ -36,7 +36,7 @@ class BitWriter;
 }  // namespace bit_util
 
 namespace util {
-class RleEncoder;
+class RleBitPackedEncoder;
 class CodecOptions;
 }  // namespace util
 
@@ -80,7 +80,7 @@ class PARQUET_EXPORT LevelEncoder {
   int bit_width_;
   int rle_length_;
   Encoding::type encoding_;
-  std::unique_ptr<::arrow::util::RleEncoder> rle_encoder_;
+  std::unique_ptr<::arrow::util::RleBitPackedEncoder> rle_encoder_;
   std::unique_ptr<::arrow::bit_util::BitWriter> bit_packed_encoder_;
 };
 

--- a/cpp/src/parquet/decoder.cc
+++ b/cpp/src/parquet/decoder.cc
@@ -861,7 +861,8 @@ class DictDecoderImpl : public TypedDecoderImpl<Type>, public DictDecoder<Type> 
     this->num_values_ = num_values;
     if (len == 0) {
       // Initialize dummy decoder to avoid crashes later on
-      idx_decoder_ = ::arrow::util::RleDecoder<int32_t>(data, len, /*bit_width=*/1);
+      idx_decoder_ =
+          ::arrow::util::RleBitPackedDecoder<int32_t>(data, len, /*bit_width=*/1);
       return;
     }
     uint8_t bit_width = *data;
@@ -869,7 +870,7 @@ class DictDecoderImpl : public TypedDecoderImpl<Type>, public DictDecoder<Type> 
       throw ParquetException("Invalid or corrupted bit_width " +
                              std::to_string(bit_width) + ". Maximum allowed is 32.");
     }
-    idx_decoder_ = ::arrow::util::RleDecoder<int32_t>(++data, --len, bit_width);
+    idx_decoder_ = ::arrow::util::RleBitPackedDecoder<int32_t>(++data, --len, bit_width);
   }
 
   int Decode(T* buffer, int num_values) override {
@@ -1003,7 +1004,7 @@ class DictDecoderImpl : public TypedDecoderImpl<Type>, public DictDecoder<Type> 
   // BinaryDictionary32Builder
   std::shared_ptr<ResizableBuffer> indices_scratch_space_;
 
-  ::arrow::util::RleDecoder<int32_t> idx_decoder_;
+  ::arrow::util::RleBitPackedDecoder<int32_t> idx_decoder_;
 };
 
 template <typename Type>
@@ -1810,9 +1811,9 @@ class RleBooleanDecoder : public TypedDecoderImpl<BooleanType>, public BooleanDe
 
     auto decoder_data = data + 4;
     if (decoder_ == nullptr) {
-      decoder_ =
-          std::make_shared<::arrow::util::RleDecoder<bool>>(decoder_data, num_bytes,
-                                                            /*bit_width=*/1);
+      decoder_ = std::make_shared<::arrow::util::RleBitPackedDecoder<bool>>(
+          decoder_data, num_bytes,
+          /*bit_width=*/1);
     } else {
       decoder_->Reset(decoder_data, num_bytes, /*bit_width=*/1);
     }
@@ -1899,7 +1900,7 @@ class RleBooleanDecoder : public TypedDecoderImpl<BooleanType>, public BooleanDe
   }
 
  private:
-  std::shared_ptr<::arrow::util::RleDecoder<bool>> decoder_;
+  std::shared_ptr<::arrow::util::RleBitPackedDecoder<bool>> decoder_;
 };
 
 // ----------------------------------------------------------------------

--- a/cpp/src/parquet/decoder.cc
+++ b/cpp/src/parquet/decoder.cc
@@ -861,7 +861,7 @@ class DictDecoderImpl : public TypedDecoderImpl<Type>, public DictDecoder<Type> 
     this->num_values_ = num_values;
     if (len == 0) {
       // Initialize dummy decoder to avoid crashes later on
-      idx_decoder_ = ::arrow::util::RleDecoder(data, len, /*bit_width=*/1);
+      idx_decoder_ = ::arrow::util::RleDecoder<int32_t>(data, len, /*bit_width=*/1);
       return;
     }
     uint8_t bit_width = *data;
@@ -869,7 +869,7 @@ class DictDecoderImpl : public TypedDecoderImpl<Type>, public DictDecoder<Type> 
       throw ParquetException("Invalid or corrupted bit_width " +
                              std::to_string(bit_width) + ". Maximum allowed is 32.");
     }
-    idx_decoder_ = ::arrow::util::RleDecoder(++data, --len, bit_width);
+    idx_decoder_ = ::arrow::util::RleDecoder<int32_t>(++data, --len, bit_width);
   }
 
   int Decode(T* buffer, int num_values) override {
@@ -1003,7 +1003,7 @@ class DictDecoderImpl : public TypedDecoderImpl<Type>, public DictDecoder<Type> 
   // BinaryDictionary32Builder
   std::shared_ptr<ResizableBuffer> indices_scratch_space_;
 
-  ::arrow::util::RleDecoder idx_decoder_;
+  ::arrow::util::RleDecoder<int32_t> idx_decoder_;
 };
 
 template <typename Type>
@@ -1810,8 +1810,9 @@ class RleBooleanDecoder : public TypedDecoderImpl<BooleanType>, public BooleanDe
 
     auto decoder_data = data + 4;
     if (decoder_ == nullptr) {
-      decoder_ = std::make_shared<::arrow::util::RleDecoder>(decoder_data, num_bytes,
-                                                             /*bit_width=*/1);
+      decoder_ =
+          std::make_shared<::arrow::util::RleDecoder<bool>>(decoder_data, num_bytes,
+                                                            /*bit_width=*/1);
     } else {
       decoder_->Reset(decoder_data, num_bytes, /*bit_width=*/1);
     }
@@ -1898,7 +1899,7 @@ class RleBooleanDecoder : public TypedDecoderImpl<BooleanType>, public BooleanDe
   }
 
  private:
-  std::shared_ptr<::arrow::util::RleDecoder> decoder_;
+  std::shared_ptr<::arrow::util::RleDecoder<bool>> decoder_;
 };
 
 // ----------------------------------------------------------------------
@@ -2123,7 +2124,7 @@ class DeltaByteArrayDecoderImpl : public TypedDecoderImpl<DType> {
   int num_valid_values_{0};
   uint32_t prefix_len_offset_{0};
   std::shared_ptr<ResizableBuffer> buffered_prefix_length_;
-  // buffer for decoded strings, which gurantees the lifetime of the decoded strings
+  // buffer for decoded strings, which guarantees the lifetime of the decoded strings
   // until the next call of Decode.
   std::shared_ptr<ResizableBuffer> buffered_data_;
 };

--- a/cpp/src/parquet/encoder.cc
+++ b/cpp/src/parquet/encoder.cc
@@ -438,8 +438,8 @@ int RlePreserveBufferSize(int num_values, int bit_width) {
   // is called, we have to reserve an extra "RleEncoder::MinBufferSize"
   // bytes. These extra bytes won't be used but not reserving them
   // would cause the encoder to fail.
-  return ::arrow::util::RleEncoder::MaxBufferSize(bit_width, num_values) +
-         ::arrow::util::RleEncoder::MinBufferSize(bit_width);
+  return ::arrow::util::RleBitPackedEncoder::MaxBufferSize(bit_width, num_values) +
+         ::arrow::util::RleBitPackedEncoder::MinBufferSize(bit_width);
 }
 
 /// See the dictionary encoding section of
@@ -476,7 +476,7 @@ class DictEncoderImpl : public EncoderImpl, virtual public DictEncoder<DType> {
     ++buffer;
     --buffer_len;
 
-    ::arrow::util::RleEncoder encoder(buffer, buffer_len, bit_width());
+    ::arrow::util::RleBitPackedEncoder encoder(buffer, buffer_len, bit_width());
 
     for (int32_t index : buffered_indices_) {
       if (ARROW_PREDICT_FALSE(!encoder.Put(index))) return -1;
@@ -1717,8 +1717,9 @@ std::shared_ptr<Buffer> RleBooleanEncoder::FlushValues() {
   int rle_buffer_size_max = MaxRleBufferSize();
   std::shared_ptr<ResizableBuffer> buffer =
       AllocateBuffer(this->pool_, rle_buffer_size_max + kRleLengthInBytes);
-  ::arrow::util::RleEncoder encoder(buffer->mutable_data() + kRleLengthInBytes,
-                                    rle_buffer_size_max, /*bit_width*/ kBitWidth);
+  ::arrow::util::RleBitPackedEncoder encoder(buffer->mutable_data() + kRleLengthInBytes,
+                                             rle_buffer_size_max,
+                                             /*bit_width*/ kBitWidth);
 
   for (bool value : buffered_append_values_) {
     encoder.Put(value ? 1 : 0);


### PR DESCRIPTION
### Rationale for this change

### What changes are included in this PR?
New independent abstractions:
- A `BitPackedRun` to describe the encoded bytes in a bit packed run.
- A minimal `BitPackedDecoder` that can decode this type of run (no dict/spaced methods).
- A `RleRun` to describe the encoded value in a RLE run.
- A minimal `RleDecoder` that can decode this type of run (no dict/spaced methods).
- A `RleBitPackedParser` that read the encoded headers and emits different runs.

These new abstractions are then plugged into `RleBitPackedDecoder` (formerly `RleDecode`) to keep the compatibility with the rest of Arrow (improvements to using the parser independently can come in follow-up PR).

Misc changes:
- Separation of LEB128 reading/writing from `BitReader` into a free functions, and add check for a special case for handling undefined behavior overflow.

### Are these changes tested?
Yes, on top of the existing tests, many more unit tests have been added.

### Are there any user-facing changes?
API changes to internal classes.

* GitHub Issue: #47112