### PR TITLE
MINOR: [C++][Compute] Fix kernel docstring typo

### DIFF
--- a/cpp/src/arrow/compute/kernel.h
+++ b/cpp/src/arrow/compute/kernel.h
@@ -364,7 +364,7 @@ class ARROW_EXPORT KernelSignature {
                                                OutputType out_type,
                                                bool is_varargs = false);
 
-  /// \brief Return true if the signature if compatible with the list of input
+  /// \brief Return true if the signature is compatible with the list of input
   /// value descriptors.
   bool MatchesInputs(const std::vector<TypeHolder>& types) const;
 


### PR DESCRIPTION
### Rationale for this change

Typo.

### What changes are included in this PR?

`if` -> `is`

### Are these changes tested?

No need.

### Are there any user-facing changes?

None.