### PR TITLE
GH-47283: [C++] Fix flight visibility issue in Meson configuration

### DIFF
--- a/cpp/src/arrow/flight/meson.build
+++ b/cpp/src/arrow/flight/meson.build
@@ -64,7 +64,6 @@ flight_proto_files = custom_target(
     ],
 )
 
-grpc_cpp = dependency('grpc++')
 grpc_cpp_plugin = find_program('grpc_cpp_plugin')
 flight_proto_grpc_files = custom_target(
     'arrow-flight-proto-grpc-files',

--- a/cpp/src/arrow/flight/meson.build
+++ b/cpp/src/arrow/flight/meson.build
@@ -64,6 +64,7 @@ flight_proto_files = custom_target(
     ],
 )
 
+grpc_cpp = dependency('grpc++')
 grpc_cpp_plugin = find_program('grpc_cpp_plugin')
 flight_proto_grpc_files = custom_target(
     'arrow-flight-proto-grpc-files',
@@ -135,6 +136,7 @@ if needs_testing
             'test_util.cc',
         ],
         dependencies: [arrow_test_dep, arrow_flight_dep, thread_dep],
+        gnu_symbol_visibility: 'hidden',
     )
 
     arrow_flight_test_dep = declare_dependency(
@@ -194,12 +196,12 @@ if needs_benchmarks
     executable(
         'arrow-flight-perf-server',
         sources: ['perf_server.cc'] + flight_proto_files,
-        dependencies: flight_test_dep_no_main,
+        dependencies: [flight_test_dep_no_main, arrow_testing_dep],
     )
 
     executable(
         'arrow-flight-benchmark',
         sources: ['flight_benchmark.cc'] + flight_proto_files,
-        dependencies: flight_test_dep_no_main,
+        dependencies: [flight_test_dep_no_main, arrow_testing_dep],
     )
 endif

--- a/cpp/src/arrow/integration/meson.build
+++ b/cpp/src/arrow/integration/meson.build
@@ -20,13 +20,7 @@ install_headers(['json_integration.h'])
 exc = executable(
     'arrow-json-integration-test',
     sources: ['json_integration_test.cc'],
-    dependencies: [
-        arrow_dep,
-        arrow_testing_dep,
-        rapidjson_dep,
-        gflags_dep,
-        gtest_dep,
-    ],
+    dependencies: [arrow_test_dep_no_main, rapidjson_dep, gflags_dep],
 )
 
 if needs_tests

--- a/cpp/src/arrow/meson.build
+++ b/cpp/src/arrow/meson.build
@@ -573,7 +573,7 @@ if needs_testing
     arrow_testing_lib = static_library(
         'arrow_testing',
         sources: arrow_testing_srcs,
-        dependencies: [arrow_dep, filesystem_dep, gmock_dep, gtest_main_dep],
+        dependencies: [arrow_dep, filesystem_dep, gmock_dep, gtest_dep],
     )
 
     arrow_testing_dep = declare_dependency(link_with: [arrow_testing_lib])

--- a/cpp/src/arrow/meson.build
+++ b/cpp/src/arrow/meson.build
@@ -569,20 +569,36 @@ else
     gmock_dep = disabler()
 endif
 
-arrow_test_lib = static_library(
-    'arrow_testing',
-    sources: arrow_testing_srcs,
-    dependencies: [arrow_dep, filesystem_dep, gmock_dep, gtest_main_dep],
-)
+if needs_testing
+    arrow_testing_lib = static_library(
+        'arrow_testing',
+        sources: arrow_testing_srcs,
+        dependencies: [arrow_dep, filesystem_dep, gmock_dep, gtest_main_dep],
+    )
+
+    arrow_testing_dep = declare_dependency(link_with: [arrow_testing_lib])
+else
+    arrow_testing_dep = disabler()
+endif
 
 if needs_tests
     arrow_test_dep = declare_dependency(
-        link_with: [arrow_test_lib],
-        dependencies: [arrow_dep, filesystem_dep, gmock_dep, gtest_main_dep],
+        dependencies: [
+            arrow_dep,
+            arrow_testing_dep,
+            filesystem_dep,
+            gmock_dep,
+            gtest_main_dep,
+        ],
     )
     arrow_test_dep_no_main = declare_dependency(
-        link_with: [arrow_test_lib],
-        dependencies: [arrow_dep, filesystem_dep, gmock_dep, gtest_dep],
+        dependencies: [
+            arrow_dep,
+            arrow_testing_dep,
+            filesystem_dep,
+            gmock_dep,
+            gtest_dep,
+        ],
     )
 else
     arrow_test_dep = disabler()
@@ -655,8 +671,12 @@ if needs_benchmarks
     )
 
     arrow_benchmark_dep = declare_dependency(
-        link_with: [arrow_test_lib],
-        dependencies: [arrow_dep, benchmark_main_dep, gtest_dep],
+        dependencies: [
+            arrow_dep,
+            arrow_testing_dep,
+            benchmark_main_dep,
+            gtest_dep,
+        ],
     )
 else
     arrow_benchmark_dep = disabler()

--- a/cpp/src/arrow/util/meson.build
+++ b/cpp/src/arrow/util/meson.build
@@ -236,13 +236,7 @@ endif
 exc = executable(
     'arrow-utility-test',
     sources: utility_test_srcs,
-    dependencies: [
-        arrow_dep,
-        arrow_testing_dep,
-        filesystem_dep,
-        gtest_dep,
-        gmock_dep,
-    ],
+    dependencies: arrow_test_dep_no_main,
     implicit_include_directories: false,
 )
 test('arrow-utility-test', exc)

--- a/cpp/src/arrow/util/meson.build
+++ b/cpp/src/arrow/util/meson.build
@@ -236,8 +236,13 @@ endif
 exc = executable(
     'arrow-utility-test',
     sources: utility_test_srcs,
-    dependencies: [arrow_dep, filesystem_dep, gtest_dep, gmock_dep],
-    link_with: [arrow_test_lib],
+    dependencies: [
+        arrow_dep,
+        arrow_testing_dep,
+        filesystem_dep,
+        gtest_dep,
+        gmock_dep,
+    ],
     implicit_include_directories: false,
 )
 test('arrow-utility-test', exc)

--- a/cpp/subprojects/google-benchmark.wrap
+++ b/cpp/subprojects/google-benchmark.wrap
@@ -20,11 +20,11 @@ directory = benchmark-1.8.4
 source_url = https://github.com/google/benchmark/archive/refs/tags/v1.8.4.tar.gz
 source_filename = benchmark-1.8.4.tar.gz
 source_hash = 3e7059b6b11fb1bbe28e33e02519398ca94c1818874ebed18e504dc6f709be45
-patch_filename = google-benchmark_1.8.4-1_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/google-benchmark_1.8.4-1/get_patch
-patch_hash = 77cdae534fe12b6783c1267de3673d3462b229054519034710d581b419e73cca
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/google-benchmark_1.8.4-1/benchmark-1.8.4.tar.gz
-wrapdb_version = 1.8.4-1
+patch_filename = google-benchmark_1.8.4-3_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/google-benchmark_1.8.4-3/get_patch
+patch_hash = 657aee778629725cf9104bbfc32dba0c9c6825d5202e600ad81c7251ae684468
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/google-benchmark_1.8.4-3/benchmark-1.8.4.tar.gz
+wrapdb_version = 1.8.4-3
 
 [provide]
 benchmark = google_benchmark_dep

--- a/cpp/subprojects/re2.wrap
+++ b/cpp/subprojects/re2.wrap
@@ -15,20 +15,16 @@
 # specific language governing permissions and limitations
 # under the License.
 
-install_headers(['json_integration.h'])
+[wrap-file]
+directory = re2-2023-03-01
+source_url = https://github.com/google/re2/archive/2023-03-01.tar.gz
+source_filename = re2-2023-03-01.tar.gz
+source_hash = 7a9a4824958586980926a300b4717202485c4b4115ac031822e29aa4ef207e48
+patch_filename = re2_20230301-3_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/re2_20230301-3/get_patch
+patch_hash = 9d5036080272a886fee0dec9ea415129ae57ee6bad4b56991b29ed355c0d97e3
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/re2_20230301-3/re2-2023-03-01.tar.gz
+wrapdb_version = 20230301-3
 
-exc = executable(
-    'arrow-json-integration-test',
-    sources: ['json_integration_test.cc'],
-    dependencies: [
-        arrow_dep,
-        arrow_testing_dep,
-        rapidjson_dep,
-        gflags_dep,
-        gtest_dep,
-    ],
-)
-
-if needs_tests
-    test('arrow-json-integration-test', exc)
-endif
+[provide]
+re2 = re2_dep


### PR DESCRIPTION
### Rationale for this change

The meson configuration is missing some symbols for flight that appear to come from the testing library. 

### What changes are included in this PR?

Updates to the Meson configuration

### Are these changes tested?

Yes

### Are there any user-facing changes?

No
* GitHub Issue: #47283