### PR TITLE
GH-47277: [C++] r-binary-packages nightly failures due to incompatibility with old compiler

### DIFF
--- a/cpp/src/arrow/util/secure_string.h
+++ b/cpp/src/arrow/util/secure_string.h
@@ -36,7 +36,7 @@ namespace arrow::util {
  */
 class ARROW_EXPORT SecureString {
  public:
-  SecureString() noexcept = default;
+  SecureString() = default;
   SecureString(SecureString&&) noexcept;
   SecureString(const SecureString&) = default;
   explicit SecureString(std::string&&) noexcept;


### PR DESCRIPTION
### Rationale for this change

The `r-binary-packages` job (specifically [C++ Binary Linux OpenSSL 1.0](https://github.com/ursacomputing/crossbow/actions/runs/16314662786/job/46077638701#logs) and 1.1) has been failing since 15th July with this error:

```
/arrow/cpp/src/parquet/encryption/encryption.h:175:62: error: use of deleted function 'arrow::util::SecureString::SecureString()'
         : column_path_(std::move(path)), encrypted_(encrypted) {}
                                                              ^
In file included from /arrow/cpp/src/parquet/encryption/encryption.h:26,
                 from /arrow/cpp/src/parquet/properties.h:30,
                 from /arrow/cpp/src/parquet/arrow/path_internal.cc:109:
```

### What changes are included in this PR?

Remove the unconditional `noexcept` from `SecureString`’s default constructor so its exception specification now matches `std::string`’s on all libstdc++ versions.

### Are these changes tested?

No but I'll run the failing CI job

### Are there any user-facing changes?

No
* GitHub Issue: #47277