### PR TITLE
GH-47303: [C++] Don't install arrow-compute.pc twice

### DIFF
--- a/cpp/src/arrow/compute/CMakeLists.txt
+++ b/cpp/src/arrow/compute/CMakeLists.txt
@@ -19,11 +19,6 @@ add_custom_target(arrow-compute-tests)
 
 arrow_install_all_headers("arrow/compute")
 
-if(ARROW_COMPUTE)
-  # pkg-config support
-  arrow_add_pkg_config("arrow-compute")
-endif()
-
 #
 # Unit tests
 #


### PR DESCRIPTION
### Rationale for this change

Both of

https://github.com/apache/arrow/blob/97c9bfcdf8a9b864414fb5457a1c3f7a5747a3f1/cpp/src/arrow/CMakeLists.txt#L845-L866

and

https://github.com/apache/arrow/blob/97c9bfcdf8a9b864414fb5457a1c3f7a5747a3f1/cpp/src/arrow/compute/CMakeLists.txt#L22-L25

install `arrow-compute.pc`.

We don't need to install `arrow-compute.pc` multiple times.

### What changes are included in this PR?

Remove `arrow_add_pkg_config("arrow-compute")`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #47303