### PR TITLE
GH-47306: [CI][Dev] Fix shellcheck errors in the ci/scripts/python_build.sh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -339,6 +339,7 @@ repos:
           ?^ci/scripts/msys2_system_upgrade\.sh$|
           ?^ci/scripts/nanoarrow_build\.sh$|
           ?^ci/scripts/python_build_emscripten\.sh$|
+          ?^ci/scripts/python_build\.sh$|
           ?^ci/scripts/python_sdist_build\.sh$|
           ?^ci/scripts/python_wheel_unix_test\.sh$|
           ?^ci/scripts/r_build\.sh$|

--- a/ci/scripts/python_build.sh
+++ b/ci/scripts/python_build.sh
@@ -25,13 +25,17 @@ build_dir=${2}
 source_dir=${arrow_dir}/python
 python_build_dir=${build_dir}/python
 
-: ${BUILD_DOCS_PYTHON:=OFF}
+: "${BUILD_DOCS_PYTHON:=OFF}"
 
 if [ -x "$(command -v git)" ]; then
-  git config --global --add safe.directory ${arrow_dir}
+  git config --global --add safe.directory "${arrow_dir}"
 fi
 
 if [ -n "${ARROW_PYTHON_VENV:-}" ]; then
+  # We don't need to follow this external file.
+  # See also: https://www.shellcheck.net/wiki/SC1091
+  #
+  # shellcheck source=/dev/null
   . "${ARROW_PYTHON_VENV}/bin/activate"
 fi
 
@@ -50,7 +54,7 @@ case "$(uname)" in
     ;;
 esac
 
-if [ ! -z "${CONDA_PREFIX}" ]; then
+if [ -n "${CONDA_PREFIX}" ]; then
   echo -e "===\n=== Conda environment for build\n==="
   conda list
 fi
@@ -74,7 +78,7 @@ export PYARROW_WITH_SUBSTRAIT=${ARROW_SUBSTRAIT:-OFF}
 
 export PYARROW_PARALLEL=${n_jobs}
 
-: ${CMAKE_PREFIX_PATH:=${ARROW_HOME}}
+: "${CMAKE_PREFIX_PATH:=${ARROW_HOME}}"
 export CMAKE_PREFIX_PATH
 export LD_LIBRARY_PATH=${ARROW_HOME}/lib:${LD_LIBRARY_PATH}
 
@@ -82,9 +86,9 @@ export LD_LIBRARY_PATH=${ARROW_HOME}/lib:${LD_LIBRARY_PATH}
 # TODO: We want to out-of-source build. This is a workaround. We copy
 # all needed files to the build directory from the source directory
 # and build in the build directory.
-rm -rf ${python_build_dir}
-cp -aL ${source_dir} ${python_build_dir}
-pushd ${python_build_dir}
+rm -rf "${python_build_dir}"
+cp -aL "${source_dir}" "${python_build_dir}"
+pushd "${python_build_dir}"
 # - Cannot call setup.py as it may install in the wrong directory
 #   on Debian/Ubuntu (ARROW-15243).
 # - Cannot use build isolation as we want to use specific dependency versions
@@ -98,22 +102,21 @@ if [ "${BUILD_DOCS_PYTHON}" == "ON" ]; then
   #
   # Copy docs/source because the "autosummary_generate = True"
   # configuration generates files to docs/source/python/generated/.
-  rm -rf ${python_build_dir}/docs/source
-  mkdir -p ${python_build_dir}/docs
-  cp -a ${arrow_dir}/docs/source ${python_build_dir}/docs/
-  rm -rf ${python_build_dir}/format
-  cp -a ${arrow_dir}/format ${python_build_dir}/
-  rm -rf ${python_build_dir}/cpp/examples
-  mkdir -p ${python_build_dir}/cpp
-  cp -a ${arrow_dir}/cpp/examples ${python_build_dir}/cpp/
-  rm -rf ${python_build_dir}/ci
-  cp -a ${arrow_dir}/ci/ ${python_build_dir}/
-  ncpus=$(python -c "import os; print(os.cpu_count())")
+  rm -rf "${python_build_dir}/docs/source"
+  mkdir -p "${python_build_dir}/docs"
+  cp -a "${arrow_dir}/docs/source" "${python_build_dir}/docs/"
+  rm -rf "${python_build_dir}/format"
+  cp -a "${arrow_dir}/format" "${python_build_dir}/"
+  rm -rf "${python_build_dir}/cpp/examples"
+  mkdir -p "${python_build_dir}/cpp"
+  cp -a "${arrow_dir}/cpp/examples" "${python_build_dir}/cpp/"
+  rm -rf "${python_build_dir}/ci"
+  cp -a "${arrow_dir}/ci/" "${python_build_dir}/"
   export ARROW_CPP_DOXYGEN_XML=${build_dir}/cpp/apidoc/xml
-  pushd ${build_dir}
+  pushd "${build_dir}"
   sphinx-build \
     -b html \
-    ${python_build_dir}/docs/source \
-    ${build_dir}/docs
+    "${python_build_dir}/docs/source" \
+    "${build_dir}/docs"
   popd
 fi


### PR DESCRIPTION
### Rationale for this change

This is the sub issue #44748.

* SC1091: Not following: ./bin/activate: openBinaryFile: does not exist
* SC2034: foo appears unused
* SC2086: Double quote to prevent globbing and word splitting
* SC2223: This default assignment may cause DoS due to globbing. Quote it.
* SC2236: Use `-n` instead of `! -z`


```
shellcheck ci/scripts/python_build.sh

In ci/scripts/python_build.sh line 28:
: ${BUILD_DOCS_PYTHON:=OFF}
  ^-----------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_build.sh line 31:
  git config --global --add safe.directory ${arrow_dir}
                                           ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
  git config --global --add safe.directory "${arrow_dir}"


In ci/scripts/python_build.sh line 35:
  . "${ARROW_PYTHON_VENV}/bin/activate"
    ^-- SC1091 (info): Not following: ./bin/activate: openBinaryFile: does not exist (No such file or directory)


In ci/scripts/python_build.sh line 53:
if [ ! -z "${CONDA_PREFIX}" ]; then
     ^-- SC2236 (style): Use -n instead of ! -z.


In ci/scripts/python_build.sh line 77:
: ${CMAKE_PREFIX_PATH:=${ARROW_HOME}}
  ^-- SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/python_build.sh line 85:
rm -rf ${python_build_dir}
       ^-----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
rm -rf "${python_build_dir}"


In ci/scripts/python_build.sh line 86:
cp -aL ${source_dir} ${python_build_dir}
       ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                     ^-----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
cp -aL "${source_dir}" "${python_build_dir}"


In ci/scripts/python_build.sh line 87:
pushd ${python_build_dir}
      ^-----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
pushd "${python_build_dir}"


In ci/scripts/python_build.sh line 101:
  rm -rf ${python_build_dir}/docs/source
         ^-----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
  rm -rf "${python_build_dir}"/docs/source


In ci/scripts/python_build.sh line 102:
  mkdir -p ${python_build_dir}/docs
           ^-----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
  mkdir -p "${python_build_dir}"/docs


In ci/scripts/python_build.sh line 103:
  cp -a ${arrow_dir}/docs/source ${python_build_dir}/docs/
        ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                 ^-----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
  cp -a "${arrow_dir}"/docs/source "${python_build_dir}"/docs/


In ci/scripts/python_build.sh line 104:
  rm -rf ${python_build_dir}/format
         ^-----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
  rm -rf "${python_build_dir}"/format


In ci/scripts/python_build.sh line 105:
  cp -a ${arrow_dir}/format ${python_build_dir}/
        ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                            ^-----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
  cp -a "${arrow_dir}"/format "${python_build_dir}"/


In ci/scripts/python_build.sh line 106:
  rm -rf ${python_build_dir}/cpp/examples
         ^-----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
  rm -rf "${python_build_dir}"/cpp/examples


In ci/scripts/python_build.sh line 107:
  mkdir -p ${python_build_dir}/cpp
           ^-----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
  mkdir -p "${python_build_dir}"/cpp


In ci/scripts/python_build.sh line 108:
  cp -a ${arrow_dir}/cpp/examples ${python_build_dir}/cpp/
        ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                  ^-----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
  cp -a "${arrow_dir}"/cpp/examples "${python_build_dir}"/cpp/


In ci/scripts/python_build.sh line 109:
  rm -rf ${python_build_dir}/ci
         ^-----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
  rm -rf "${python_build_dir}"/ci


In ci/scripts/python_build.sh line 110:
  cp -a ${arrow_dir}/ci/ ${python_build_dir}/
        ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                         ^-----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
  cp -a "${arrow_dir}"/ci/ "${python_build_dir}"/


In ci/scripts/python_build.sh line 111:
  ncpus=$(python -c "import os; print(os.cpu_count())")
  ^---^ SC2034 (warning): ncpus appears unused. Verify use (or export if used externally).


In ci/scripts/python_build.sh line 113:
  pushd ${build_dir}
        ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
  pushd "${build_dir}"


In ci/scripts/python_build.sh line 116:
    ${python_build_dir}/docs/source \
    ^-----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    "${python_build_dir}"/docs/source \


In ci/scripts/python_build.sh line 117:
    ${build_dir}/docs
    ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
    "${build_dir}"/docs

For more information:
  https://www.shellcheck.net/wiki/SC2034 -- ncpus appears unused. Verify use ...
  https://www.shellcheck.net/wiki/SC1091 -- Not following: ./bin/activate: op...
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
```

### What changes are included in this PR?

* SC1091: Skip file check
* SC2034: remove the variable
* SC2086: Quote variables
* SC2223: Quote variables
* SC2236: Use `-n` instead of `! -z`


### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #47306