### PR TITLE
GH-47321: [CI][Dev] Fix shellcheck errors in the ci/scripts/python_sdist_test.sh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -341,6 +341,7 @@ repos:
           ?^ci/scripts/python_build_emscripten\.sh$|
           ?^ci/scripts/python_build\.sh$|
           ?^ci/scripts/python_sdist_build\.sh$|
+          ?^ci/scripts/python_sdist_test\.sh$|
           ?^ci/scripts/python_wheel_unix_test\.sh$|
           ?^ci/scripts/r_build\.sh$|
           ?^ci/scripts/r_revdepcheck\.sh$|

--- a/ci/scripts/python_sdist_test.sh
+++ b/ci/scripts/python_sdist_test.sh
@@ -53,13 +53,17 @@ fi
 if [ -n "${PYARROW_VERSION:-}" ]; then
   sdist="${arrow_dir}/python/dist/pyarrow-${PYARROW_VERSION}.tar.gz"
 else
-  sdist=$(ls ${arrow_dir}/python/dist/pyarrow-*.tar.gz | sort -r | head -n1)
+  sdist=$( find "${arrow_dir}/python/dist/" -maxdepth 1 -name 'pyarrow-*.tar.gz' -print | sort -r | head -n1 )
 fi
 
 if [ -n "${ARROW_PYTHON_VENV:-}" ]; then
+  # We don't need to follow this external file.
+  # See also: https://www.shellcheck.net/wiki/SC1091
+  #
+  # shellcheck source=/dev/null
   . "${ARROW_PYTHON_VENV}/bin/activate"
 fi
 
-${PYTHON:-python} -m pip install ${sdist}
+${PYTHON:-python} -m pip install "${sdist}"
 
-pytest -r s ${PYTEST_ARGS:-} --pyargs pyarrow
+pytest -r s "${PYTEST_ARGS:-}" --pyargs pyarrow

--- a/ci/scripts/python_sdist_test.sh
+++ b/ci/scripts/python_sdist_test.sh
@@ -53,7 +53,7 @@ fi
 if [ -n "${PYARROW_VERSION:-}" ]; then
   sdist="${arrow_dir}/python/dist/pyarrow-${PYARROW_VERSION}.tar.gz"
 else
-  sdist=$( find "${arrow_dir}/python/dist/" -maxdepth 1 -name 'pyarrow-*.tar.gz' -print | sort -r | head -n1 )
+  sdist=$(echo "${arrow_dir}"/python/dist/pyarrow-*.tar.gz | sort -r | head -n1)
 fi
 
 if [ -n "${ARROW_PYTHON_VENV:-}" ]; then


### PR DESCRIPTION
### Rationale for this change

This is the sub issue #44748.

* SC1091: Not following
* SC2012: Use `find` instead of `ls` to better handle non-alphanumeric filenames.
* SC2086: Double quote to prevent globbing and word splitting

```
heck ci/scripts/python_sdist_test.sh

In ci/scripts/python_sdist_test.sh line 56:
  sdist=$(ls ${arrow_dir}/python/dist/pyarrow-*.tar.gz | sort -r | head -n1)
          ^-- SC2012 (info): Use find instead of ls to better handle non-alphanumeric filenames.
             ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
  sdist=$(ls "${arrow_dir}"/python/dist/pyarrow-*.tar.gz | sort -r | head -n1)


In ci/scripts/python_sdist_test.sh line 60:
  . "${ARROW_PYTHON_VENV}/bin/activate"
    ^-- SC1091 (info): Not following: ./bin/activate: openBinaryFile: does not exist (No such file or directory)


In ci/scripts/python_sdist_test.sh line 63:
${PYTHON:-python} -m pip install ${sdist}
                                 ^------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
${PYTHON:-python} -m pip install "${sdist}"


In ci/scripts/python_sdist_test.sh line 65:
pytest -r s ${PYTEST_ARGS:-} --pyargs pyarrow
            ^--------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
pytest -r s "${PYTEST_ARGS:-}" --pyargs pyarrow

For more information:
  https://www.shellcheck.net/wiki/SC1091 -- Not following: ./bin/activate: op...
  https://www.shellcheck.net/wiki/SC2012 -- Use find instead of ls to better ...
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
```


### What changes are included in this PR?

* SC1091: Skip file check
* SC2012: Use `find` instead of `ls` command
* SC2086: Quote variables

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.

* GitHub Issue: #47321