### PR TITLE
GH-41108: [Docs] Remove Sphinx pin

### DIFF
--- a/ci/conda_env_sphinx.txt
+++ b/ci/conda_env_sphinx.txt
@@ -33,6 +33,6 @@ sphinx-copybutton
 sphinx-lint
 sphinxcontrib-jquery
 sphinxcontrib-mermaid
-sphinx==6.2
+sphinx
 pytest-cython
 pandas

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -14,5 +14,5 @@ sphinx-copybutton
 sphinx-design
 sphinx-lint
 sphinxcontrib-mermaid
-sphinx==6.2
+sphinx
 pandas

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -273,7 +273,9 @@ language = "en"
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
-exclude_patterns = exclude_patterns + ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = exclude_patterns + ['_build', 'Thumbs.db', '.DS_Store',
+                                       'developers/cpp/img/async.md',
+                                       '**/README.md',]
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.

--- a/docs/source/implementations.rst
+++ b/docs/source/implementations.rst
@@ -114,7 +114,7 @@ The source files for the Cookbook are maintained in the
    C# <https://github.com/apache/arrow/blob/main/csharp/README.md>
    Go <https://arrow.apache.org/go/>
    Java <java/index>
-   JavaScript <https://arrow.apache.org/docs/js>
+   JavaScript <https://arrow.apache.org/js/current/>
    Julia <https://arrow.apache.org/julia/>
    MATLAB <https://github.com/apache/arrow/blob/main/matlab/README.md>
    Python <python/index>


### PR DESCRIPTION
### Rationale for this change
Sphinx has been pinned for a while and it is safe to remove the pin now.

### What changes are included in this PR?
Sphinx pin is removed and some minor changes to `exclude_patterns` and an external link are added to reduce couple of build warnings.

### Are these changes tested?
Yes, with CI. The docs build should succeed and the preview build should be run.

### Are there any user-facing changes?
No.
* GitHub Issue: #41108