### PR TITLE
GH-47332: [C++][Compute] Fix the issue that the arguments of function call become invalid before wrapping results

### DIFF
--- a/cpp/src/arrow/compute/expression.cc
+++ b/cpp/src/arrow/compute/expression.cc
@@ -795,8 +795,7 @@ Result<Datum> ExecuteScalarExpression(const Expression& expr, const ExecBatch& i
   RETURN_NOT_OK(executor->Init(&kernel_context, {kernel, types, options}));
 
   compute::detail::DatumAccumulator listener;
-  RETURN_NOT_OK(
-      executor->Execute(ExecBatch(std::move(arguments), input_length), &listener));
+  RETURN_NOT_OK(executor->Execute(ExecBatch(arguments, input_length), &listener));
   const auto out = executor->WrapResults(arguments, listener.values());
 #ifndef NDEBUG
   DCHECK_OK(executor->CheckResultType(out, call->function_name.c_str()));

--- a/cpp/src/arrow/compute/expression_test.cc
+++ b/cpp/src/arrow/compute/expression_test.cc
@@ -953,13 +953,13 @@ TEST(Expression, ExecuteChunkedArray) {
   ExecBatch batch{inputs, 3};
 
   ASSERT_OK_AND_ASSIGN(Datum res, ExecuteScalarExpression(expr, batch));
+  ASSERT_TRUE(res.is_chunked_array());
 
-  AssertDatumsEqual(res, ArrayFromJSON(float64(),
-                                       R"([
+  AssertDatumsEqual(res, ChunkedArrayFromJSON(float64(), {R"([
     9.5,
     1,
     3.75
-  ])"));
+  ])"}));
 }
 
 TEST(Expression, ExecuteDictionaryTransparent) {


### PR DESCRIPTION
### Rationale for this change

An obvious wrong use of `std::move()`.

### What changes are included in this PR?

Remove it.

### Are these changes tested?

Yes, by extending the existing test.

### Are there any user-facing changes?

None.
* GitHub Issue: #47332