### PR TITLE
GH-47338: [C++][Python] Remove deprecated string-based Parquet encryption methods

### DIFF
--- a/cpp/src/parquet/encryption/encryption.cc
+++ b/cpp/src/parquet/encryption/encryption.cc
@@ -44,13 +44,8 @@ void StringKeyIdRetriever::PutKey(std::string key_id, SecureString key) {
   key_map_.insert({std::move(key_id), std::move(key)});
 }
 
-SecureString StringKeyIdRetriever::GetKeyById(const std::string& key_id) {
+SecureString StringKeyIdRetriever::GetKey(const std::string& key_id) {
   return key_map_.at(key_id);
-}
-
-ColumnEncryptionProperties::Builder* ColumnEncryptionProperties::Builder::key(
-    std::string column_key) {
-  return key(SecureString(std::move(column_key)));
 }
 
 ColumnEncryptionProperties::Builder* ColumnEncryptionProperties::Builder::key(
@@ -92,11 +87,6 @@ FileDecryptionProperties::Builder* FileDecryptionProperties::Builder::column_key
 
   column_decryption_properties_ = std::move(column_decryption_properties);
   return this;
-}
-
-FileDecryptionProperties::Builder* FileDecryptionProperties::Builder::footer_key(
-    std::string footer_key) {
-  return this->footer_key(SecureString(std::move(footer_key)));
 }
 
 FileDecryptionProperties::Builder* FileDecryptionProperties::Builder::footer_key(

--- a/cpp/src/parquet/encryption/file_key_unwrapper.cc
+++ b/cpp/src/parquet/encryption/file_key_unwrapper.cc
@@ -69,7 +69,7 @@ FileKeyUnwrapper::FileKeyUnwrapper(
       kms_connection_config.key_access_token(), cache_entry_lifetime_seconds_);
 }
 
-SecureString FileKeyUnwrapper::GetKeyById(const std::string& key_metadata_bytes) {
+SecureString FileKeyUnwrapper::GetKey(const std::string& key_metadata_bytes) {
   // key_metadata is expected to be in UTF8 encoding
   ::arrow::util::InitializeUTF8();
   if (!::arrow::util::ValidateUTF8(
@@ -110,7 +110,7 @@ KeyWithMasterId FileKeyUnwrapper::GetDataEncryptionKey(const KeyMaterial& key_ma
 
   SecureString data_key;
   if (!double_wrapping) {
-    data_key = kms_client->UnWrapKey(encoded_wrapped_dek, master_key_id);
+    data_key = kms_client->UnwrapKey(encoded_wrapped_dek, master_key_id);
   } else {
     // Get Key Encryption Key
     const std::string& encoded_kek_id = key_material.kek_id();
@@ -118,7 +118,7 @@ KeyWithMasterId FileKeyUnwrapper::GetDataEncryptionKey(const KeyMaterial& key_ma
 
     const SecureString kek_bytes = kek_per_kek_id_->GetOrInsert(
         encoded_kek_id, [kms_client, encoded_wrapped_kek, master_key_id]() {
-          return kms_client->UnWrapKey(encoded_wrapped_kek, master_key_id);
+          return kms_client->UnwrapKey(encoded_wrapped_kek, master_key_id);
         });
 
     // Decrypt the data key

--- a/cpp/src/parquet/encryption/file_key_unwrapper.h
+++ b/cpp/src/parquet/encryption/file_key_unwrapper.h
@@ -65,7 +65,7 @@ class PARQUET_EXPORT FileKeyUnwrapper : public DecryptionKeyRetriever {
                    std::shared_ptr<FileKeyMaterialStore> key_material_store);
 
   /// Get the data key from key metadata
-  ::arrow::util::SecureString GetKeyById(const std::string& key_metadata_bytes) override;
+  ::arrow::util::SecureString GetKey(const std::string& key_metadata_bytes) override;
 
   /// Get the data key along with the master key id from key material
   KeyWithMasterId GetDataEncryptionKey(const KeyMaterial& key_material);

--- a/cpp/src/parquet/encryption/internal_file_decryptor.cc
+++ b/cpp/src/parquet/encryption/internal_file_decryptor.cc
@@ -78,7 +78,7 @@ const SecureString& InternalFileDecryptor::GetFooterKey() {
     if (properties_->key_retriever() == nullptr)
       throw ParquetException("No footer key or key retriever");
     try {
-      footer_key_ = properties_->key_retriever()->GetKeyById(footer_key_metadata_);
+      footer_key_ = properties_->key_retriever()->GetKey(footer_key_metadata_);
     } catch (KeyAccessDeniedException& e) {
       std::stringstream ss;
       ss << "Footer key: access denied " << e.what() << "\n";
@@ -117,7 +117,7 @@ SecureString InternalFileDecryptor::GetColumnKey(const std::string& column_path,
   if (column_key.empty() && !column_key_metadata.empty() &&
       properties_->key_retriever() != nullptr) {
     try {
-      column_key = properties_->key_retriever()->GetKeyById(column_key_metadata);
+      column_key = properties_->key_retriever()->GetKey(column_key_metadata);
     } catch (KeyAccessDeniedException& e) {
       std::stringstream ss;
       ss << "HiddenColumnException, path=" + column_path + " " << e.what() << "\n";

--- a/cpp/src/parquet/encryption/key_wrapping_test.cc
+++ b/cpp/src/parquet/encryption/key_wrapping_test.cc
@@ -86,10 +86,10 @@ class KeyWrappingTest : public ::testing::Test {
     FileKeyUnwrapper unwrapper(&key_toolkit, kms_connection_config_,
                                cache_entry_lifetime_seconds, readable_file_path,
                                file_system);
-    SecureString footer_key = unwrapper.GetKeyById(key_metadata_json_footer);
+    SecureString footer_key = unwrapper.GetKey(key_metadata_json_footer);
     ASSERT_EQ(footer_key, kFooterEncryptionKey);
 
-    SecureString column_key = unwrapper.GetKeyById(key_metadata_json_column);
+    SecureString column_key = unwrapper.GetKey(key_metadata_json_column);
     ASSERT_EQ(column_key, kColumnEncryptionKey1);
   }
 

--- a/cpp/src/parquet/encryption/kms_client.h
+++ b/cpp/src/parquet/encryption/kms_client.h
@@ -84,42 +84,12 @@ class PARQUET_EXPORT KmsClient {
   ///
   /// Encrypts it with the master key, encodes the result
   /// and potentially adds a KMS-specific metadata.
-  ///
-  /// \deprecated Deprecated since 22.0.0. Implement
-  ///             WrapKey(const SecureString&, const std::string&) instead.
-  ARROW_DEPRECATED(
-      "Deprecated in 22.0.0. "
-      "Implement WrapKey(const SecureString&, const std::string&) instead.")
-  virtual std::string WrapKey(const std::string& key_bytes,
-                              const std::string& master_key_identifier) {
-    throw ParquetException("Not implemented");
-  }
-
-  /// \copydoc WrapKey(const std::string&, const std::string&)
   virtual std::string WrapKey(const ::arrow::util::SecureString& key_bytes,
-                              const std::string& master_key_identifier) {
-    ARROW_SUPPRESS_DEPRECATION_WARNING
-    auto key = WrapKey(std::string(key_bytes.as_view()), master_key_identifier);
-    ARROW_UNSUPPRESS_DEPRECATION_WARNING
-    return key;
-  }
+                              const std::string& master_key_identifier) = 0;
 
   /// \brief Decrypts (unwraps) a key with the master key.
-  /// \deprecated Deprecated since 22.0.0. Implement UnWrapKey instead.
-  ARROW_DEPRECATED("Deprecated in 22.0.0. Implement UnWrapKey instead.")
-  virtual std::string UnwrapKey(const std::string& wrapped_key,
-                                const std::string& master_key_identifier) {
-    throw ParquetException("Not implemented");
-  }
-
-  /// \copydoc UnwrapKey(const std::string&, const std::string&)
-  virtual ::arrow::util::SecureString UnWrapKey(
-      const std::string& wrapped_key, const std::string& master_key_identifier) {
-    ARROW_SUPPRESS_DEPRECATION_WARNING
-    auto key = ::arrow::util::SecureString(UnwrapKey(wrapped_key, master_key_identifier));
-    ARROW_UNSUPPRESS_DEPRECATION_WARNING
-    return key;
-  }
+  virtual ::arrow::util::SecureString UnwrapKey(
+      const std::string& wrapped_key, const std::string& master_key_identifier) = 0;
 
   virtual ~KmsClient() {}
 };

--- a/cpp/src/parquet/encryption/local_wrap_kms_client.cc
+++ b/cpp/src/parquet/encryption/local_wrap_kms_client.cc
@@ -84,7 +84,7 @@ std::string LocalWrapKmsClient::WrapKey(const SecureString& key_bytes,
   return LocalKeyWrap::CreateSerialized(encrypted_encoded_key);
 }
 
-SecureString LocalWrapKmsClient::UnWrapKey(const std::string& wrapped_key,
+SecureString LocalWrapKmsClient::UnwrapKey(const std::string& wrapped_key,
                                            const std::string& master_key_identifier) {
   LocalKeyWrap key_wrap = LocalKeyWrap::Parse(wrapped_key);
   const std::string& master_key_version = key_wrap.master_key_version();

--- a/cpp/src/parquet/encryption/local_wrap_kms_client.h
+++ b/cpp/src/parquet/encryption/local_wrap_kms_client.h
@@ -38,7 +38,7 @@ class PARQUET_EXPORT LocalWrapKmsClient : public KmsClient {
   std::string WrapKey(const ::arrow::util::SecureString& key_bytes,
                       const std::string& master_key_identifier) override;
 
-  ::arrow::util::SecureString UnWrapKey(
+  ::arrow::util::SecureString UnwrapKey(
       const std::string& wrapped_key, const std::string& master_key_identifier) override;
 
  protected:

--- a/cpp/src/parquet/encryption/properties_test.cc
+++ b/cpp/src/parquet/encryption/properties_test.cc
@@ -224,9 +224,9 @@ TEST(TestDecryptionProperties, UseKeyRetriever) {
   std::shared_ptr<parquet::FileDecryptionProperties> props = builder.build();
 
   auto out_key_retriever = props->key_retriever();
-  ASSERT_EQ(kFooterEncryptionKey, out_key_retriever->GetKeyById("kf"));
-  ASSERT_EQ(kColumnEncryptionKey1, out_key_retriever->GetKeyById("kc1"));
-  ASSERT_EQ(kColumnEncryptionKey2, out_key_retriever->GetKeyById("kc2"));
+  ASSERT_EQ(kFooterEncryptionKey, out_key_retriever->GetKey("kf"));
+  ASSERT_EQ(kColumnEncryptionKey1, out_key_retriever->GetKey("kc1"));
+  ASSERT_EQ(kColumnEncryptionKey2, out_key_retriever->GetKey("kc2"));
 }
 
 TEST(TestDecryptionProperties, SupplyAadPrefix) {

--- a/cpp/src/parquet/encryption/test_in_memory_kms.cc
+++ b/cpp/src/parquet/encryption/test_in_memory_kms.cc
@@ -79,7 +79,7 @@ std::string TestOnlyInServerWrapKms::WrapKey(const SecureString& key_bytes,
   return internal::EncryptKeyLocally(key_bytes, master_key, aad);
 }
 
-SecureString TestOnlyInServerWrapKms::UnWrapKey(
+SecureString TestOnlyInServerWrapKms::UnwrapKey(
     const std::string& wrapped_key, const std::string& master_key_identifier) {
   if (unwrapping_master_key_map_.find(master_key_identifier) ==
       unwrapping_master_key_map_.end()) {

--- a/cpp/src/parquet/encryption/test_in_memory_kms.h
+++ b/cpp/src/parquet/encryption/test_in_memory_kms.h
@@ -56,7 +56,7 @@ class TestOnlyInServerWrapKms : public KmsClient {
   std::string WrapKey(const ::arrow::util::SecureString& key_bytes,
                       const std::string& master_key_identifier) override;
 
-  ::arrow::util::SecureString UnWrapKey(
+  ::arrow::util::SecureString UnwrapKey(
       const std::string& wrapped_key, const std::string& master_key_identifier) override;
 
   static void StartKeyRotation(

--- a/python/pyarrow/_parquet_encryption.pyx
+++ b/python/pyarrow/_parquet_encryption.pyx
@@ -303,8 +303,7 @@ cdef class KmsConnectionConfig(_Weakrefable):
 cdef void _cb_wrap_key(
         handler, const CSecureString& key,
         const c_string& master_key_identifier, c_string* out) except *:
-    cdef:
-        cpp_string_view view = key.as_view()
+    view = <cpp_string_view>key.as_view()
     key_bytes = <bytes>PyBytes_FromStringAndSize(view.data(), view.size())
     mkid_str = frombytes(master_key_identifier)
     wrapped_key = handler.wrap_key(key_bytes, mkid_str)
@@ -314,13 +313,10 @@ cdef void _cb_wrap_key(
 cdef void _cb_unwrap_key(
         handler, const c_string& wrapped_key,
         const c_string& master_key_identifier, CSecureString& out) except *:
-    cdef:
-        c_string cstr
-
     mkid_str = frombytes(master_key_identifier)
     wk_str = frombytes(wrapped_key)
     key = handler.unwrap_key(wk_str, mkid_str)
-    cstr = tobytes(key)
+    cstr = <c_string>tobytes(key)
     out = CSecureString(move(cstr))
 
 

--- a/python/pyarrow/_parquet_encryption.pyx
+++ b/python/pyarrow/_parquet_encryption.pyx
@@ -312,12 +312,12 @@ cdef void _cb_wrap_key(
 
 cdef void _cb_unwrap_key(
         handler, const c_string& wrapped_key,
-        const c_string& master_key_identifier, CSecureString& out) except *:
+        const c_string& master_key_identifier, CSecureString* out) except *:
     mkid_str = frombytes(master_key_identifier)
     wk_str = frombytes(wrapped_key)
     key = handler.unwrap_key(wk_str, mkid_str)
     cstr = <c_string>tobytes(key)
-    out = CSecureString(move(cstr))
+    out[0] = CSecureString(move(cstr))
 
 
 cdef class KmsClient(_Weakrefable):

--- a/python/pyarrow/_parquet_encryption.pyx
+++ b/python/pyarrow/_parquet_encryption.pyx
@@ -20,18 +20,13 @@
 
 from datetime import timedelta
 
+from cpython.bytes cimport PyBytes_FromStringAndSize
 from cython.operator cimport dereference as deref
 
 from pyarrow.includes.common cimport *
 from pyarrow.includes.libarrow cimport *
 from pyarrow.lib cimport _Weakrefable
 from pyarrow.lib import tobytes, frombytes
-
-
-cdef extern from "Python.h":
-    # To let us get a PyObject* and avoid Cython auto-ref-counting
-    PyObject* PyBytes_FromStringAndSizeNative" PyBytes_FromStringAndSize"(
-        char *v, Py_ssize_t len) except NULL
 
 
 cdef ParquetCipher cipher_from_name(name):
@@ -310,8 +305,7 @@ cdef void _cb_wrap_key(
         const c_string& master_key_identifier, c_string* out) except *:
     cdef:
         cpp_string_view view = key.as_view()
-    key_bytes = PyObject_to_object(
-        PyBytes_FromStringAndSizeNative(view.data(), view.size()))
+    key_bytes = <bytes>PyBytes_FromStringAndSize(view.data(), view.size())
     mkid_str = frombytes(master_key_identifier)
     wrapped_key = handler.wrap_key(key_bytes, mkid_str)
     out[0] = tobytes(wrapped_key)

--- a/python/pyarrow/_parquet_encryption.pyx
+++ b/python/pyarrow/_parquet_encryption.pyx
@@ -319,16 +319,15 @@ cdef void _cb_wrap_key(
 
 cdef void _cb_unwrap_key(
         handler, const c_string& wrapped_key,
-        const c_string& master_key_identifier, CSecureString* out) except *:
+        const c_string& master_key_identifier, CSecureString& out) except *:
+    cdef:
+        c_string cstr
+
     mkid_str = frombytes(master_key_identifier)
     wk_str = frombytes(wrapped_key)
     key = handler.unwrap_key(wk_str, mkid_str)
-
-    cdef:
-        c_string cstr = tobytes(key)
-        CSecureString css = CSecureString(move(cstr))
-
-    out[0] = css
+    cstr = tobytes(key)
+    out = CSecureString(move(cstr))
 
 
 cdef class KmsClient(_Weakrefable):

--- a/python/pyarrow/_parquet_encryption.pyx
+++ b/python/pyarrow/_parquet_encryption.pyx
@@ -319,14 +319,14 @@ cdef void _cb_wrap_key(
 
 cdef void _cb_unwrap_key(
         handler, const c_string& wrapped_key,
-        const c_string& master_key_identifier, shared_ptr[CSecureString]* out) except *:
+        const c_string& master_key_identifier, CSecureString* out) except *:
     mkid_str = frombytes(master_key_identifier)
     wk_str = frombytes(wrapped_key)
     key = handler.unwrap_key(wk_str, mkid_str)
 
     cdef:
         c_string cstr = tobytes(key)
-        shared_ptr[CSecureString] css = shared_ptr[CSecureString](new CSecureString(move(cstr)))
+        CSecureString css = CSecureString(move(cstr))
 
     out[0] = css
 

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -3130,6 +3130,15 @@ cdef extern from "arrow/util/iterator.h" namespace "arrow" nogil:
         RangeIterator end()
     CIterator[T] MakeVectorIterator[T](vector[T] v)
 
+
+cdef extern from "arrow/util/secure_string.h" namespace "arrow" nogil:
+    cdef cppclass CSecureString" arrow::util::SecureString":
+        CSecureString(c_string s)
+        CSecureString(const CSecureString& s)
+        CSecureString(size_t n, char c)
+        cpp_string_view as_view()
+
+
 cdef extern from "arrow/util/thread_pool.h" namespace "arrow" nogil:
     int GetCpuThreadPoolCapacity()
     CStatus SetCpuThreadPoolCapacity(int threads)

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -3133,6 +3133,7 @@ cdef extern from "arrow/util/iterator.h" namespace "arrow" nogil:
 
 cdef extern from "arrow/util/secure_string.h" namespace "arrow" nogil:
     cdef cppclass CSecureString" arrow::util::SecureString":
+        CSecureString()
         CSecureString(c_string s)
         CSecureString(const CSecureString& s)
         CSecureString(size_t n, char c)

--- a/python/pyarrow/includes/libparquet_encryption.pxd
+++ b/python/pyarrow/includes/libparquet_encryption.pxd
@@ -18,6 +18,7 @@
 # distutils: language = c++
 
 from pyarrow.includes.common cimport *
+from pyarrow.includes.libarrow cimport CSecureString
 from pyarrow._parquet cimport (ParquetCipher,
                                CFileEncryptionProperties,
                                CFileDecryptionProperties,
@@ -28,10 +29,10 @@ from pyarrow._parquet cimport (ParquetCipher,
 cdef extern from "parquet/encryption/kms_client.h" \
         namespace "parquet::encryption" nogil:
     cdef cppclass CKmsClient" parquet::encryption::KmsClient":
-        c_string WrapKey(const c_string& key_bytes,
+        c_string WrapKey(const CSecureString& key,
                          const c_string& master_key_identifier) except +
-        c_string UnwrapKey(const c_string& wrapped_key,
-                           const c_string& master_key_identifier) except +
+        CSecureString UnwrapKey(const c_string& wrapped_key,
+                                const c_string& master_key_identifier) except +
 
     cdef cppclass CKeyAccessToken" parquet::encryption::KeyAccessToken":
         CKeyAccessToken(const c_string value)
@@ -49,9 +50,9 @@ cdef extern from "parquet/encryption/kms_client.h" \
 # Callbacks for implementing Python kms clients
 # Use typedef to emulate syntax for std::function<void(..)>
 ctypedef void CallbackWrapKey(
-    object, const c_string&, const c_string&, c_string*)
+    object, const CSecureString&, const c_string&, c_string*)
 ctypedef void CallbackUnwrapKey(
-    object, const c_string&, const c_string&, c_string*)
+    object, const c_string&, const c_string&, shared_ptr[CSecureString]*)
 
 cdef extern from "parquet/encryption/kms_client_factory.h" \
         namespace "parquet::encryption" nogil:

--- a/python/pyarrow/includes/libparquet_encryption.pxd
+++ b/python/pyarrow/includes/libparquet_encryption.pxd
@@ -52,7 +52,7 @@ cdef extern from "parquet/encryption/kms_client.h" \
 ctypedef void CallbackWrapKey(
     object, const CSecureString&, const c_string&, c_string*)
 ctypedef void CallbackUnwrapKey(
-    object, const c_string&, const c_string&, CSecureString*)
+    object, const c_string&, const c_string&, CSecureString&)
 
 cdef extern from "parquet/encryption/kms_client_factory.h" \
         namespace "parquet::encryption" nogil:

--- a/python/pyarrow/includes/libparquet_encryption.pxd
+++ b/python/pyarrow/includes/libparquet_encryption.pxd
@@ -52,7 +52,7 @@ cdef extern from "parquet/encryption/kms_client.h" \
 ctypedef void CallbackWrapKey(
     object, const CSecureString&, const c_string&, c_string*)
 ctypedef void CallbackUnwrapKey(
-    object, const c_string&, const c_string&, CSecureString&)
+    object, const c_string&, const c_string&, CSecureString*)
 
 cdef extern from "parquet/encryption/kms_client_factory.h" \
         namespace "parquet::encryption" nogil:

--- a/python/pyarrow/includes/libparquet_encryption.pxd
+++ b/python/pyarrow/includes/libparquet_encryption.pxd
@@ -52,7 +52,7 @@ cdef extern from "parquet/encryption/kms_client.h" \
 ctypedef void CallbackWrapKey(
     object, const CSecureString&, const c_string&, c_string*)
 ctypedef void CallbackUnwrapKey(
-    object, const c_string&, const c_string&, shared_ptr[CSecureString]*)
+    object, const c_string&, const c_string&, CSecureString*)
 
 cdef extern from "parquet/encryption/kms_client_factory.h" \
         namespace "parquet::encryption" nogil:

--- a/python/pyarrow/src/arrow/python/parquet_encryption.cc
+++ b/python/pyarrow/src/arrow/python/parquet_encryption.cc
@@ -47,7 +47,7 @@ std::string PyKmsClient::WrapKey(const ::arrow::util::SecureString& key,
     const std::string& wrapped_key, const std::string& master_key_identifier) {
   arrow::util::SecureString unwrapped;
   auto st = SafeCallIntoPython([&]() -> Status {
-    vtable_.unwrap_key(handler_.obj(), wrapped_key, master_key_identifier, &unwrapped);
+    vtable_.unwrap_key(handler_.obj(), wrapped_key, master_key_identifier, unwrapped);
     return CheckPyError();
   });
   if (!st.ok()) {

--- a/python/pyarrow/src/arrow/python/parquet_encryption.cc
+++ b/python/pyarrow/src/arrow/python/parquet_encryption.cc
@@ -45,7 +45,7 @@ std::string PyKmsClient::WrapKey(const ::arrow::util::SecureString& key,
 
 ::arrow::util::SecureString PyKmsClient::UnwrapKey(
     const std::string& wrapped_key, const std::string& master_key_identifier) {
-  std::shared_ptr<arrow::util::SecureString> unwrapped;
+  arrow::util::SecureString unwrapped;
   auto st = SafeCallIntoPython([&]() -> Status {
     vtable_.unwrap_key(handler_.obj(), wrapped_key, master_key_identifier, &unwrapped);
     return CheckPyError();
@@ -53,7 +53,7 @@ std::string PyKmsClient::WrapKey(const ::arrow::util::SecureString& key,
   if (!st.ok()) {
     throw ::parquet::ParquetStatusException(st);
   }
-  return *unwrapped;
+  return unwrapped;
 }
 
 PyKmsClientFactory::PyKmsClientFactory(PyObject* handler, PyKmsClientFactoryVtable vtable)

--- a/python/pyarrow/src/arrow/python/parquet_encryption.cc
+++ b/python/pyarrow/src/arrow/python/parquet_encryption.cc
@@ -47,7 +47,7 @@ std::string PyKmsClient::WrapKey(const ::arrow::util::SecureString& key,
     const std::string& wrapped_key, const std::string& master_key_identifier) {
   arrow::util::SecureString unwrapped;
   auto st = SafeCallIntoPython([&]() -> Status {
-    vtable_.unwrap_key(handler_.obj(), wrapped_key, master_key_identifier, unwrapped);
+    vtable_.unwrap_key(handler_.obj(), wrapped_key, master_key_identifier, &unwrapped);
     return CheckPyError();
   });
   if (!st.ok()) {

--- a/python/pyarrow/src/arrow/python/parquet_encryption.h
+++ b/python/pyarrow/src/arrow/python/parquet_encryption.h
@@ -22,6 +22,7 @@
 #include "arrow/python/common.h"
 #include "arrow/python/visibility.h"
 #include "arrow/util/macros.h"
+#include "arrow/util/secure_string.h"
 #include "parquet/encryption/crypto_factory.h"
 #include "parquet/encryption/kms_client.h"
 #include "parquet/encryption/kms_client_factory.h"
@@ -56,11 +57,12 @@ namespace encryption {
 /// Python.
 class ARROW_PYTHON_PARQUET_ENCRYPTION_EXPORT PyKmsClientVtable {
  public:
-  std::function<void(PyObject*, const std::string& key_bytes,
+  std::function<void(PyObject*, const ::arrow::util::SecureString& key,
                      const std::string& master_key_identifier, std::string* out)>
       wrap_key;
   std::function<void(PyObject*, const std::string& wrapped_key,
-                     const std::string& master_key_identifier, std::string* out)>
+                     const std::string& master_key_identifier,
+                     std::shared_ptr<::arrow::util::SecureString>* out)>
       unwrap_key;
 };
 
@@ -71,11 +73,11 @@ class ARROW_PYTHON_PARQUET_ENCRYPTION_EXPORT PyKmsClient
   PyKmsClient(PyObject* handler, PyKmsClientVtable vtable);
   ~PyKmsClient() override;
 
-  std::string WrapKey(const std::string& key_bytes,
+  std::string WrapKey(const ::arrow::util::SecureString& key,
                       const std::string& master_key_identifier) override;
 
-  std::string UnwrapKey(const std::string& wrapped_key,
-                        const std::string& master_key_identifier) override;
+  ::arrow::util::SecureString UnwrapKey(
+      const std::string& wrapped_key, const std::string& master_key_identifier) override;
 
  private:
   OwnedRefNoGIL handler_;

--- a/python/pyarrow/src/arrow/python/parquet_encryption.h
+++ b/python/pyarrow/src/arrow/python/parquet_encryption.h
@@ -62,7 +62,7 @@ class ARROW_PYTHON_PARQUET_ENCRYPTION_EXPORT PyKmsClientVtable {
       wrap_key;
   std::function<void(PyObject*, const std::string& wrapped_key,
                      const std::string& master_key_identifier,
-                     std::shared_ptr<::arrow::util::SecureString>* out)>
+                     ::arrow::util::SecureString* out)>
       unwrap_key;
 };
 

--- a/python/pyarrow/src/arrow/python/parquet_encryption.h
+++ b/python/pyarrow/src/arrow/python/parquet_encryption.h
@@ -62,7 +62,7 @@ class ARROW_PYTHON_PARQUET_ENCRYPTION_EXPORT PyKmsClientVtable {
       wrap_key;
   std::function<void(PyObject*, const std::string& wrapped_key,
                      const std::string& master_key_identifier,
-                     ::arrow::util::SecureString& out)>
+                     ::arrow::util::SecureString* out)>
       unwrap_key;
 };
 

--- a/python/pyarrow/src/arrow/python/parquet_encryption.h
+++ b/python/pyarrow/src/arrow/python/parquet_encryption.h
@@ -62,7 +62,7 @@ class ARROW_PYTHON_PARQUET_ENCRYPTION_EXPORT PyKmsClientVtable {
       wrap_key;
   std::function<void(PyObject*, const std::string& wrapped_key,
                      const std::string& master_key_identifier,
-                     ::arrow::util::SecureString* out)>
+                     ::arrow::util::SecureString& out)>
       unwrap_key;
 };
 


### PR DESCRIPTION
### Rationale for this change
Passing encryption keys to Parquet via strings is insecure. Users are encouraged to use the `SecureString` based methods introduced in #46017 instead. To enforce this migration, deprecated methods are removed.

### What changes are included in this PR?
Remove deprecated string-based methods.

### Are these changes tested?
Existing Parquet encryption tests.

### Are there any user-facing changes?
C++ user code that passes encryption keys to Parquet is affected and has to be adjusted. Python user code is not affected.

**This PR includes breaking changes to public APIs.**
* GitHub Issue: #47338