### PR TITLE
GH-47259: [Dev] Use "issue type" not "issue label" for issue type

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -17,7 +17,7 @@
 
 name: Bug Report
 description: File a bug report
-labels: ["Type: bug"]
+type: Bug
 assignees: []
 body:
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -17,7 +17,7 @@
 
 name: Enhancement Request
 description: Request an enhancement to the project
-labels: ["Type: enhancement"]
+type: Feature
 assignees: []
 body:
   - type: markdown


### PR DESCRIPTION
### Rationale for this change

GitHub introduced the "issue type" feature for issue type:

* https://docs.github.com/en/issues/tracking-your-work-with-issues/configuring-issues/managing-issue-types-in-an-organization
* https://github.blog/changelog/2025-01-13-evolving-github-issues-public-preview/

Let's use it not custom "issue label"s such as "Type: bug" and "Type: enhancement" for issue type.

### What changes are included in this PR?

Use `type:` instead of `labels:` in issue templates.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #47259