### PR TITLE
GH-47130: [Packaging][deb] Fix upgrade from 20.0.0-1

### DIFF
--- a/dev/release/verify-apt.sh
+++ b/dev/release/verify-apt.sh
@@ -84,9 +84,6 @@ esac
 
 if [ "${TYPE}" = "local" ]; then
   case "${VERSION}" in
-    *-dev*)
-      package_version="$(echo "${VERSION}" | sed -e 's/-dev\(.*\)$/~dev\1/g')"
-      ;;
     *-rc*)
       package_version="$(echo "${VERSION}" | sed -e 's/-rc.*$//g')"
       ;;
@@ -111,7 +108,7 @@ fi
 
 if [ "${TYPE}" = "local" ]; then
   sed \
-    -i"" \
+    -i.bak \
     -e "s,^URIs: .*$,URIs: file://${local_prefix}/apt/repositories/${distribution},g" \
     /etc/apt/sources.list.d/apache-arrow.sources
   keys="${local_prefix}/KEYS"
@@ -126,15 +123,11 @@ if [ "${TYPE}" = "local" ]; then
       --armor \
       --export > /usr/share/keyrings/apache-arrow-apt-source.asc
   fi
-else
-  case "${TYPE}" in
-    rc)
-      sed \
-        -i"" \
-        -e "s,^URIs: \\(.*\\)/,URIs: \\1-${suffix}/,g" \
-        /etc/apt/sources.list.d/apache-arrow.sources
-      ;;
-  esac
+elif [ "${TYPE}" = "rc" ]; then
+  sed \
+    -i.bak \
+    -e "s,^URIs: \\(.*\\)/,URIs: \\1-${suffix}/,g" \
+    /etc/apt/sources.list.d/apache-arrow.sources
 fi
 
 apt update
@@ -226,4 +219,121 @@ echo "::group::Test Apache Parquet"
 ${APT_INSTALL} libparquet-glib-dev=${package_version}
 ${APT_INSTALL} libparquet-glib-doc=${package_version}
 ruby -r gi -e "p GI.load('Parquet')"
+echo "::endgroup::"
+
+echo "::group::Prepare downgrade test"
+can_downgrade=false
+if [ -f /etc/apt/sources.list.d/apache-arrow.sources.bak ]; then
+  mv /etc/apt/sources.list.d/apache-arrow.sources \
+     /etc/apt/sources.list.d/apache-arrow-current.sources
+  mv /etc/apt/sources.list.d/apache-arrow.sources{.bak,}
+  cp -a /usr/share/keyrings/apache-arrow-apt-source{,-current}.asc
+  sed \
+    -i.bak \
+    -e 's/\.asc$/-current.asc/g' \
+    /etc/apt/sources.list.d/apache-arrow-current.sources
+  if curl \
+       --fail \
+       --output "apache-arrow-apt-source-latest.deb" \
+       https://packages.apache.org/artifactory/arrow/${distribution}/apache-arrow-apt-source-latest-${code_name}.deb; then
+    ${APT_INSTALL} --allow-downgrades ./apache-arrow-apt-source-latest.deb
+    apt update
+    can_downgrade=true
+  fi
+fi
+
+# 22.0.0.dev54 -> 22
+# 22.0.0 -> 22
+current_major_version=${package_version%%.*}
+# 22 -> 21
+previous_major_version=$[current_major_version -1]
+# 22 -> 21
+previous_package_version="${previous_major_version}.0.0-1"
+echo "::endgroup::"
+
+if [ "${can_downgrade}" != "true" ]; then
+  exit 0
+fi
+
+echo "::group::Downgrade Gandiva"
+${APT_INSTALL} --allow-downgrades \
+  gir1.2-arrow-1.0=${previous_package_version} \
+  gir1.2-gandiva-1.0=${previous_package_version} \
+  libarrow${previous_major_version}00=${previous_package_version} \
+  libarrow-acero${previous_major_version}00=${previous_package_version} \
+  libarrow-acero-dev=${previous_package_version} \
+  libarrow-compute${previous_major_version}00=${previous_package_version} \
+  libarrow-compute-dev=${previous_package_version} \
+  libarrow-dev=${previous_package_version} \
+  libarrow-glib${previous_major_version}00=${previous_package_version} \
+  libarrow-glib-dev=${previous_package_version} \
+  libgandiva${previous_major_version}00=${previous_package_version} \
+  libgandiva-dev=${previous_package_version} \
+  libgandiva-glib${previous_major_version}00=${previous_package_version} \
+  libgandiva-glib-dev=${previous_package_version} \
+  libparquet${previous_major_version}00=${previous_package_version} \
+  libparquet-dev=${previous_package_version}
+echo "::endgroup::"
+
+echo "::group::Downgrade Apache Arrow Flight SQL"
+${APT_INSTALL} --allow-downgrades \
+  gir1.2-arrow-1.0=${previous_package_version} \
+  gir1.2-arrow-flight-1.0=${previous_package_version} \
+  gir1.2-arrow-flight-sql-1.0=${previous_package_version} \
+  libarrow${previous_major_version}00=${previous_package_version} \
+  libarrow-acero${previous_major_version}00=${previous_package_version} \
+  libarrow-acero-dev=${previous_package_version} \
+  libarrow-compute${previous_major_version}00=${previous_package_version} \
+  libarrow-compute-dev=${previous_package_version} \
+  libarrow-dev=${previous_package_version} \
+  libarrow-flight${previous_major_version}00=${previous_package_version} \
+  libarrow-flight-dev=${previous_package_version} \
+  libarrow-flight-glib${previous_major_version}00=${previous_package_version} \
+  libarrow-flight-glib-dev=${previous_package_version} \
+  libarrow-flight-sql-dev=${previous_package_version} \
+  libarrow-flight-sql-glib-dev=${previous_package_version} \
+  libarrow-glib${previous_major_version}00=${previous_package_version} \
+  libarrow-glib-dev=${previous_package_version}
+echo "::endgroup::"
+
+echo "::group::Downgrade Apache Arrow Dataset"
+${APT_INSTALL} --allow-downgrades \
+  gir1.2-arrow-1.0=${previous_package_version} \
+  gir1.2-arrow-dataset-1.0=${previous_package_version} \
+  gir1.2-parquet-1.0=${previous_package_version} \
+  libarrow${previous_major_version}00=${previous_package_version} \
+  libarrow-acero${previous_major_version}00=${previous_package_version} \
+  libarrow-acero-dev=${previous_package_version} \
+  libarrow-compute${previous_major_version}00=${previous_package_version} \
+  libarrow-compute-dev=${previous_package_version} \
+  libarrow-dataset${previous_major_version}00=${previous_package_version} \
+  libarrow-dataset-dev=${previous_package_version} \
+  libarrow-dataset-glib${previous_major_version}00=${previous_package_version} \
+  libarrow-dataset-glib-dev=${previous_package_version} \
+  libarrow-dev=${previous_package_version} \
+  libarrow-glib${previous_major_version}00=${previous_package_version} \
+  libarrow-glib-dev=${previous_package_version} \
+  libparquet${previous_major_version}00=${previous_package_version} \
+  libparquet-dev=${previous_package_version} \
+  libparquet-glib${previous_major_version}00=${previous_package_version} \
+  libparquet-glib-dev=${previous_package_version}
+echo "::endgroup::"
+
+
+echo "::group::Prepare upgrade test"
+mv /etc/apt/sources.list.d/apache-arrow-current.sources \
+   /etc/apt/sources.list.d/apache-arrow.sources
+apt update
+echo "::endgroup::"
+
+echo "::group::Upgrade Gandiva"
+${APT_INSTALL} libgandiva-glib-dev=${package_version}
+echo "::endgroup::"
+
+echo "::group::Upgrade Apache Arrow Flight SQL"
+${APT_INSTALL} libarrow-flight-sql-glib-dev=${package_version}
+echo "::endgroup::"
+
+echo "::group::Upgrade Apache Arrow Dataset"
+${APT_INSTALL} libarrow-dataset-dev=${package_version}
 echo "::endgroup::"

--- a/dev/tasks/linux-packages/apache-arrow/debian/control.in
+++ b/dev/tasks/linux-packages/apache-arrow/debian/control.in
@@ -180,7 +180,10 @@ Architecture: any
 Multi-Arch: same
 Depends:
   ${misc:Depends},
-  libarrow-compute2200 (= ${binary:Version})
+  libarrow-compute2200 (= ${binary:Version}),
+  libarrow-dev (= ${binary:Version})
+Replaces: libarrow-dev (<< 21.0.0-1)
+Breaks: libarrow-dev (<< 21.0.0-1)
 Description: Apache Arrow is a data processing library for analysis
  .
  This package provides C++ header files for compute module.
@@ -191,8 +194,8 @@ Architecture: @CUDA_ARCHITECTURE@
 Multi-Arch: same
 Depends:
   ${misc:Depends},
-  libarrow-dev (= ${binary:Version}),
-  libarrow-cuda2200 (= ${binary:Version})
+  libarrow-cuda2200 (= ${binary:Version}),
+  libarrow-dev (= ${binary:Version})
 Description: Apache Arrow is a data processing library for analysis
  .
  This package provides C++ header files for CUDA support.
@@ -204,7 +207,7 @@ Multi-Arch: same
 Depends:
   ${misc:Depends},
   libarrow-acero2200 (= ${binary:Version}),
-  libparquet-dev (= ${binary:Version})
+  libarrow-compute-dev (= ${binary:Version})
 Description: Apache Arrow is a data processing library for analysis
  .
  This package provides C++ header files for Acero module.
@@ -282,7 +285,8 @@ Multi-Arch: same
 Pre-Depends: ${misc:Pre-Depends}
 Depends:
   ${misc:Depends},
-  ${shlibs:Depends}
+  ${shlibs:Depends},
+  libarrow2200 (= ${binary:Version})
 Description: Apache Parquet is a columnar storage format
  .
  This package provides C++ library files to process Apache Parquet format.
@@ -321,7 +325,7 @@ Pre-Depends: ${misc:Pre-Depends}
 Depends:
   ${misc:Depends},
   ${shlibs:Depends},
-  libarrow2200 (= ${binary:Version})
+  libarrow-acero2200 (= ${binary:Version})
 Description: Apache Arrow is a data processing library for analysis
  .
  This package provides GLib based library files.
@@ -332,7 +336,8 @@ Architecture: any
 Multi-Arch: same
 Depends:
   ${gir:Depends},
-  ${misc:Depends}
+  ${misc:Depends},
+  libarrow-glib2200 (= ${binary:Version})
 Description: Apache Arrow is a data processing library for analysis
  .
  This package provides GObject Introspection typelib files.
@@ -343,11 +348,9 @@ Architecture: any
 Multi-Arch: same
 Depends:
   ${misc:Depends},
-  libglib2.0-dev,
-  libarrow-compute-dev (= ${binary:Version}),
+  gir1.2-arrow-1.0 (= ${binary:Version}),
   libarrow-acero-dev (= ${binary:Version}),
-  libarrow-glib2200 (= ${binary:Version}),
-  gir1.2-arrow-1.0 (= ${binary:Version})
+  libglib2.0-dev
 Suggests: libarrow-glib-doc
 Description: Apache Arrow is a data processing library for analysis
  .
@@ -372,8 +375,8 @@ Pre-Depends: ${misc:Pre-Depends}
 Depends:
   ${misc:Depends},
   ${shlibs:Depends},
-  libarrow-glib2200 (= ${binary:Version}),
-  libarrow-cuda2200 (= ${binary:Version})
+  libarrow-cuda2200 (= ${binary:Version}),
+  libarrow-glib2200 (= ${binary:Version})
 Description: Apache Arrow is a data processing library for analysis
  .
  This package provides GLib based library files for CUDA support.
@@ -385,7 +388,8 @@ Multi-Arch: same
 Depends:
   ${gir:Depends},
   ${misc:Depends},
-  gir1.2-arrow-1.0 (= ${binary:Version})
+  gir1.2-arrow-1.0 (= ${binary:Version}),
+  libarrow-cuda-glib2200 (= ${binary:Version})
 Description: Apache Arrow is a data processing library for analysis
  .
  This package provides GObject Introspection typelib files for CUDA support.
@@ -396,10 +400,9 @@ Architecture: @CUDA_ARCHITECTURE@
 Multi-Arch: same
 Depends:
   ${misc:Depends},
+  gir1.2-arrow-cuda-1.0 (= ${binary:Version}),
   libarrow-cuda-dev (= ${binary:Version}),
-  libarrow-glib-dev (= ${binary:Version}),
-  libarrow-cuda-glib2200 (= ${binary:Version}),
-  gir1.2-arrow-cuda-1.0 (= ${binary:Version})
+  libarrow-glib-dev (= ${binary:Version})
 Description: Apache Arrow is a data processing library for analysis
  .
  This package provides GLib based header files for CUDA support.
@@ -412,8 +415,8 @@ Pre-Depends: ${misc:Pre-Depends}
 Depends:
   ${misc:Depends},
   ${shlibs:Depends},
-  libarrow-glib2200 (= ${binary:Version}),
-  libarrow-dataset2200 (= ${binary:Version})
+  libarrow-dataset2200 (= ${binary:Version}),
+  libarrow-glib2200 (= ${binary:Version})
 Description: Apache Arrow is a data processing library for analysis
  .
  This package provides GLib based library files for dataset module.
@@ -425,7 +428,8 @@ Multi-Arch: same
 Depends:
   ${gir:Depends},
   ${misc:Depends},
-  gir1.2-arrow-1.0 (= ${binary:Version})
+  gir1.2-arrow-1.0 (= ${binary:Version}),
+  libarrow-dataset-glib2200 (= ${binary:Version})
 Description: Apache Arrow is a data processing library for analysis
  .
  This package provides GObject Introspection typelib files for dataset module.
@@ -436,10 +440,9 @@ Architecture: any
 Multi-Arch: same
 Depends:
   ${misc:Depends},
+  gir1.2-arrow-dataset-1.0 (= ${binary:Version}),
   libarrow-dataset-dev (= ${binary:Version}),
-  libarrow-glib-dev (= ${binary:Version}),
-  libarrow-dataset-glib2200 (= ${binary:Version}),
-  gir1.2-arrow-dataset-1.0 (= ${binary:Version})
+  libarrow-glib-dev (= ${binary:Version})
 Description: Apache Arrow is a data processing library for analysis
  .
  This package provides GLib based header files for dataset module.
@@ -476,7 +479,8 @@ Multi-Arch: same
 Depends:
   ${gir:Depends},
   ${misc:Depends},
-  gir1.2-arrow-1.0 (= ${binary:Version})
+  gir1.2-arrow-1.0 (= ${binary:Version}),
+  libarrow-flight-glib2200 (= ${binary:Version})
 Description: Apache Arrow is a data processing library for analysis
  .
  This package provides GObject Introspection typelib files for Apache Arrow
@@ -488,10 +492,9 @@ Architecture: any
 Multi-Arch: same
 Depends:
   ${misc:Depends},
+  gir1.2-arrow-flight-1.0 (= ${binary:Version}),
   libarrow-flight-dev (= ${binary:Version}),
-  libarrow-glib-dev (= ${binary:Version}),
-  libarrow-flight-glib2200 (= ${binary:Version}),
-  gir1.2-arrow-flight-1.0 (= ${binary:Version})
+  libarrow-glib-dev (= ${binary:Version})
 Description: Apache Arrow is a data processing library for analysis
  .
  This package provides GLib based header files for Apache Arrow Flight.
@@ -528,7 +531,8 @@ Multi-Arch: same
 Depends:
   ${gir:Depends},
   ${misc:Depends},
-  gir1.2-arrow-flight-1.0 (= ${binary:Version})
+  gir1.2-arrow-flight-1.0 (= ${binary:Version}),
+  libarrow-flight-sql-glib2200 (= ${binary:Version})
 Description: Apache Arrow is a data processing library for analysis
  .
  This package provides GObject Introspection typelib files for Apache Arrow
@@ -540,10 +544,9 @@ Architecture: any
 Multi-Arch: same
 Depends:
   ${misc:Depends},
-  libarrow-flight-sql-dev (= ${binary:Version}),
+  gir1.2-arrow-flight-sql-1.0 (= ${binary:Version}),
   libarrow-flight-glib-dev (= ${binary:Version}),
-  libarrow-flight-sql-glib2200 (= ${binary:Version}),
-  gir1.2-arrow-flight-sql-1.0 (= ${binary:Version})
+  libarrow-flight-sql-dev (= ${binary:Version})
 Description: Apache Arrow is a data processing library for analysis
  .
  This package provides GLib based header files for Apache Arrow Flight SQL.
@@ -581,7 +584,8 @@ Multi-Arch: same
 Depends:
   ${gir:Depends},
   ${misc:Depends},
-  gir1.2-arrow-1.0 (= ${binary:Version})
+  gir1.2-arrow-1.0 (= ${binary:Version}),
+  libgandiva-glib2200 (= ${binary:Version})
 Description: Gandiva is a toolset for compiling and evaluating expressions
  on Arrow Data.
  .
@@ -593,10 +597,9 @@ Architecture: any
 Multi-Arch: same
 Depends:
   ${misc:Depends},
-  libgandiva-dev (= ${binary:Version}),
+  gir1.2-gandiva-1.0 (= ${binary:Version}),
   libarrow-glib-dev (= ${binary:Version}),
-  libgandiva-glib2200 (= ${binary:Version}),
-  gir1.2-gandiva-1.0 (= ${binary:Version})
+  libgandiva-dev (= ${binary:Version})
 Description: Gandiva is a toolset for compiling and evaluating expressions
  on Arrow Data.
  .
@@ -635,7 +638,8 @@ Multi-Arch: same
 Depends:
   ${gir:Depends},
   ${misc:Depends},
-  gir1.2-arrow-1.0 (= ${binary:Version})
+  gir1.2-arrow-1.0 (= ${binary:Version}),
+  libparquet-glib2200 (= ${binary:Version})
 Description: Apache Parquet is a columnar storage format
  .
  This package provides GObject Introspection typelib files.
@@ -646,10 +650,9 @@ Architecture: any
 Multi-Arch: same
 Depends:
   ${misc:Depends},
+  gir1.2-parquet-1.0 (= ${binary:Version}),
   libarrow-glib-dev (= ${binary:Version}),
-  libparquet-dev (= ${binary:Version}),
-  libparquet-glib2200 (= ${binary:Version}),
-  gir1.2-parquet-1.0 (= ${binary:Version})
+  libparquet-dev (= ${binary:Version})
 Suggests: libparquet-glib-doc
 Description: Apache Parquet is a columnar storage format
  .


### PR DESCRIPTION
### Rationale for this change

We split `libarrow-dev` to `libarrow-compute-dev` but we forgot to add `Replaces:`/`Breaks:` to `libarrow-compute-dev`. So `apt upgrade` from 20.0.0-1 is failed.

### What changes are included in this PR?

* Add missing `Replaces:`/`Breaks:` to `libarrow-compute-dev` for smooth upgrade.
   See also:  https://www.debian.org/doc/debian-policy/ch-relationships.html#overwriting-files-in-other-packages
* Add downgrade/upgrade tests.
* Add missing explicit versioned dependencies (`XXX (= ${binary:Version})`).

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #47130