### PR TITLE
GH-47344: [C++] Enable fuzzing option in Meson CI

### DIFF
--- a/ci/scripts/cpp_build.sh
+++ b/ci/scripts/cpp_build.sh
@@ -143,7 +143,6 @@ if [ "${ARROW_USE_MESON:-OFF}" = "ON" ]; then
     --prefix=${MESON_PREFIX:-${ARROW_HOME}} \
     --buildtype=${ARROW_BUILD_TYPE:-debug} \
     -Dauto_features=enabled \
-    -Dfuzzing=disabled \
     -Dgcs=disabled \
     -Ds3=disabled \
     . \


### PR DESCRIPTION
### Rationale for this change

This option was disabled originally because it required Meson 1.8, which was not yet available in CI. Currently, Meson 1.8.3 is used by CI, so that restriction is no longer required.

### What changes are included in this PR?

CI now tests the fuzzing option in Meson

### Are these changes tested?

Yes

### Are there any user-facing changes?

No
* GitHub Issue: #47344