### PR TITLE
GH-47348: [C++][Python] Make S3FileSystem pickle-able with retry strategy

### DIFF
--- a/cpp/src/arrow/filesystem/s3fs.cc
+++ b/cpp/src/arrow/filesystem/s3fs.cc
@@ -233,7 +233,8 @@ class AwsRetryStrategy : public S3RetryStrategy {
     Aws::Client::AWSError<Aws::Client::CoreErrors> error = DetailToError(detail);
     return std::visit(
         [&](const auto& strategy) {
-          return strategy->ShouldRetry(error, attempted_retries);
+          return strategy->ShouldRetry(
+              error, static_cast<long>(attempted_retries));  // NOLINT: runtime/int
         },
         retry_strategy_);
   }
@@ -243,7 +244,8 @@ class AwsRetryStrategy : public S3RetryStrategy {
     Aws::Client::AWSError<Aws::Client::CoreErrors> error = DetailToError(detail);
     return std::visit(
         [&](const auto& strategy) {
-          return strategy->CalculateDelayBeforeNextRetry(error, attempted_retries);
+          return strategy->CalculateDelayBeforeNextRetry(
+              error, static_cast<long>(attempted_retries));  // NOLINT: runtime/int
         },
         retry_strategy_);
   }

--- a/cpp/src/arrow/filesystem/s3fs.h
+++ b/cpp/src/arrow/filesystem/s3fs.h
@@ -86,6 +86,11 @@ class ARROW_EXPORT S3RetryStrategy {
   /// Returns the time in milliseconds the S3 client should sleep for until retrying.
   virtual int64_t CalculateDelayBeforeNextRetry(const AWSErrorDetail& error,
                                                 int64_t attempted_retries) = 0;
+  /// Returns true if this retry strategy is equal to another retry strategy.
+  /// By default, it returns true if the two objects are of the same type.
+  virtual bool Equals(const S3RetryStrategy& other) const {
+    return typeid(*this) == typeid(other);
+  }
   /// Returns a stock AWS Default retry strategy.
   static std::shared_ptr<S3RetryStrategy> GetAwsDefaultRetryStrategy(
       int64_t max_attempts);

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -1226,14 +1226,34 @@ def test_s3_options(pickle_module):
     assert isinstance(fs, S3FileSystem)
     assert pickle_module.loads(pickle_module.dumps(fs)) == fs
 
-    # Note that the retry strategy won't survive pickling for now
-    fs = S3FileSystem(
+    # Test S3FileSystem with different retry strategies
+    # They are equal only when the retry strategy is from the same class
+    # and the same parameters
+    fs_std_5 = S3FileSystem(
         retry_strategy=AwsStandardS3RetryStrategy(max_attempts=5))
-    assert isinstance(fs, S3FileSystem)
+    assert isinstance(fs_std_5, S3FileSystem)
+    assert pickle_module.loads(pickle_module.dumps(fs_std_5)) == fs_std_5
+    assert fs_std_5.retry_strategy.max_attempts == 5
 
-    fs = S3FileSystem(
+    fs_std_10 = S3FileSystem(
+        retry_strategy=AwsStandardS3RetryStrategy(max_attempts=10))
+    assert isinstance(fs_std_10, S3FileSystem)
+    assert pickle_module.loads(pickle_module.dumps(fs_std_10)) == fs_std_10
+    assert fs_std_10.retry_strategy.max_attempts == 10
+    assert fs_std_10 != fs_std_5
+
+    fs_std_10_2 = S3FileSystem(
+        retry_strategy=AwsStandardS3RetryStrategy(max_attempts=10))
+    assert isinstance(fs_std_10_2, S3FileSystem)
+    assert pickle_module.loads(pickle_module.dumps(fs_std_10_2)) == fs_std_10_2
+    assert fs_std_10_2 == fs_std_10
+
+    fs_def_5 = S3FileSystem(
         retry_strategy=AwsDefaultS3RetryStrategy(max_attempts=5))
-    assert isinstance(fs, S3FileSystem)
+    assert isinstance(fs_def_5, S3FileSystem)
+    assert pickle_module.loads(pickle_module.dumps(fs_def_5)) == fs_def_5
+    assert fs_def_5.retry_strategy.max_attempts == 5
+    assert fs_def_5 != fs_std_5
 
     fs2 = S3FileSystem(role_arn='role')
     assert isinstance(fs2, S3FileSystem)


### PR DESCRIPTION
### Rationale for this change

This change fixes the serialization/deserialization (and equality) of `S3FileSystem`. Previously, the `retry_strategy` parameter is missed in the serialization. This affects other distributed libraries like Ray to incorrectly reconstruct a `S3FileSystem` with no retry_strategy parameter in other processes.

### What changes are included in this PR?

The changes can be summarized in two parts, one in pyarrow and one in c++ library.

For pyarrow, this PR adds `retry_strategy` in `S3FileSystem.__reduce__` and a property method to allow access to `retry_strategy` (a python object). Since `S3FileSystem` is a cdef class but `AWSDefaultRetryStrategy` etc are not, `object` type is used for simplicity.

In C++, an `Equals` method is added to `S3RetryStrategy` in C++. This allows the equality comparison in both c++ and python to consider retry strategy properly, e.g., comparing `S3Options` and `S3FileSystem` with retry strategy taken into account. For now, the comparison returns true when they are the same class and parameters (implemented for `AwsDefaultRetryStrategy` and `AwsStandardRetryStrategy`)

### Are these changes tested?

[Python] Updated the unit tests to test for `retry_strategy`.
The new `retry_strategy` property is used to verify the correct reconstruction.

[C++] New tests are added for `AwsRetryStrategy` Equals() method.

### Are there any user-facing changes?

No.
* GitHub Issue: #47348