### PR TITLE
GH-47349: [C++] Include request ID in AWS S3 Error

### DIFF
--- a/cpp/src/arrow/filesystem/s3_internal.h
+++ b/cpp/src/arrow/filesystem/s3_internal.h
@@ -189,8 +189,12 @@ Status ErrorToStatus(const std::string& prefix, const std::string& operation,
                          "'.";
     }
   }
+
+  auto request_id = error.GetRequestId();
+  auto request_str = request_id.empty() ? "" : (" (Request ID: " + request_id + ")");
+
   return Status::IOError(prefix, "AWS Error ", ss.str(), " during ", operation,
-                         " operation: ", error.GetMessage(),
+                         " operation: ", error.GetMessage(), request_str,
                          wrong_region_msg.value_or(""));
 }
 

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -293,6 +293,16 @@ _minio_limited_policy = """{
             "Resource": [
                 "arn:aws:s3:::*"
             ]
+
+        },
+        {
+            "Effect": "Deny",
+            "Action": [
+                "s3:DeleteObject"
+            ],
+            "Resource": [
+                "arn:aws:s3:::no-delete-bucket*"
+            ]
         }
     ]
 }"""
@@ -533,6 +543,20 @@ def test_s3fs_limited_permissions_create_bucket(s3_server):
 
     with pytest.raises(pa.ArrowIOError, match="Would delete bucket"):
         fs.delete_dir('existing-bucket')
+
+    with pytest.raises(OSError, match="Request ID:"):
+        fs.copy_file("existing-bucket/test-file", "existing-bucket/test-file-copy")
+
+    with pytest.raises(pa.ArrowIOError, match="Request ID:"):
+        with fs.open_output_stream("non-existing-bucket/test-file") as f:
+            f.write(b"test")
+
+    # Create a file in the protected bucket then try to delete it
+    with fs.open_output_stream("no-delete-bucket/test-file") as f:
+        f.write(b"test")
+
+    with pytest.raises(OSError, match="Request ID:"):
+        fs.delete_file("no-delete-bucket/test-file")
 
 
 def test_file_info_constructor():

--- a/python/pyarrow/tests/util.py
+++ b/python/pyarrow/tests/util.py
@@ -419,6 +419,9 @@ def _configure_s3_limited_user(s3_server, policy, username, password):
         # ... and a sample bucket for that user to write to
         _run_mc_command(mcdir, 'mb', 'myminio/existing-bucket',
                         '--ignore-existing')
+        # Create a protected bucket for testing no-delete-bucket policy
+        _run_mc_command(mcdir, 'mb', 'myminio/no-delete-bucket',
+                        '--ignore-existing')
 
     except FileNotFoundError:
         pytest.skip("Configuring limited s3 user failed")


### PR DESCRIPTION
### Rationale for this change

It is a uuid useful for debugging with AWS support team.

Indeed, `minio` errors will print out a request ID by default.

### What changes are included in this PR?

The request ID is appended to the end of the error message.

### Are these changes tested?

New Python tests added where Request ID is expected.

### Are there any user-facing changes?

No

* GitHub Issue: #47349