### PR TITLE
GH-43355: [C++] Don't require `__once_proxy` in `symbols.map`

### DIFF
--- a/cpp/src/gandiva/symbols.map
+++ b/cpp/src/gandiva/symbols.map
@@ -21,7 +21,7 @@
   local:
     # devtoolset / static-libstdc++ symbols
     __cxa_*;
-    __once_proxy;
+    __once_proxy*;
 
     extern "C++" {
       # devtoolset or -static-libstdc++ - the Red Hat devtoolset statically
@@ -32,4 +32,3 @@
       *std::__once_call*;
     };
 };
-

--- a/cpp/src/parquet/symbols.map
+++ b/cpp/src/parquet/symbols.map
@@ -21,7 +21,7 @@
   local:
     # devtoolset / static-libstdc++ symbols
     __cxa_*;
-    __once_proxy;
+    __once_proxy*;
 
     extern "C++" {
       # boost


### PR DESCRIPTION
### Rationale for this change

We refer `__once_proxy` in `cpp/src/{gandiva,parquet}/symbols.map` but some environments don't have `__once_proxy`.  If `__once_proxy` doesn't exist, we got a build failure.

### What changes are included in this PR?

Use `__once_proxy*` not `__once_proxy` to accept no `__once_proxy`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #43355