### PR TITLE
GH-47365: [GLib] Add GArrowFixedSizeListArray

### DIFF
--- a/c_glib/arrow-glib/basic-array.cpp
+++ b/c_glib/arrow-glib/basic-array.cpp
@@ -3988,6 +3988,9 @@ garrow_array_new_raw_valist(std::shared_ptr<arrow::Array> *arrow_array,
       }
     }
     break;
+  case arrow::Type::type::FIXED_SIZE_LIST:
+    type = GARROW_TYPE_FIXED_SIZE_LIST_ARRAY;
+    break;
   case arrow::Type::type::RUN_END_ENCODED:
     type = GARROW_TYPE_RUN_END_ENCODED_ARRAY;
     break;

--- a/c_glib/arrow-glib/composite-array.cpp
+++ b/c_glib/arrow-glib/composite-array.cpp
@@ -2091,11 +2091,14 @@ garrow_fixed_size_list_array_new_list_size(GArrowArray *value_array,
                                           arrow_null_bitmap,
                                           n_nulls);
 
-  garrow::check(error,
-                arrow_fixed_size_list_array_result,
-                "[fixed-size-list-array][new-list-size]");
-  std::shared_ptr<arrow::Array> arrow_array = *arrow_fixed_size_list_array_result;
-  return GARROW_FIXED_SIZE_LIST_ARRAY(garrow_array_new_raw(&arrow_array));
+  if (garrow::check(error,
+                   arrow_fixed_size_list_array_result,
+                   "[fixed-size-list-array][new-list-size]")) {
+    auto arrow_array = *arrow_fixed_size_list_array_result;
+    return GARROW_FIXED_SIZE_LIST_ARRAY(garrow_array_new_raw(&arrow_array));
+  } else {
+    return nullptr;
+  }
 }
 
 /**

--- a/c_glib/arrow-glib/composite-array.cpp
+++ b/c_glib/arrow-glib/composite-array.cpp
@@ -2060,7 +2060,7 @@ garrow_fixed_size_list_array_class_init(GArrowFixedSizeListArrayClass *klass)
 
 /**
  * garrow_fixed_size_list_array_new_list_size
- * @value_array: The value of the fixed list size array.
+ * @value_array: The value of the fixed size list array.
  * @list_size: The list size of the fixed list size array.
  * @null_bitmap: (nullable): The bitmap that shows null elements. The
  *   N-th element is null when the N-th bit is 0, not null otherwise.

--- a/c_glib/arrow-glib/composite-array.cpp
+++ b/c_glib/arrow-glib/composite-array.cpp
@@ -2061,7 +2061,7 @@ garrow_fixed_size_list_array_class_init(GArrowFixedSizeListArrayClass *klass)
 /**
  * garrow_fixed_size_list_array_new_list_size
  * @value_array: The value of the fixed size list array.
- * @list_size: The list size of the fixed list size array.
+ * @list_size: The list size of the fixed size list array.
  * @null_bitmap: (nullable): The bitmap that shows null elements. The
  *   N-th element is null when the N-th bit is 0, not null otherwise.
  *   If the array has no null elements, the bitmap must be %NULL and

--- a/c_glib/arrow-glib/composite-array.cpp
+++ b/c_glib/arrow-glib/composite-array.cpp
@@ -2148,7 +2148,7 @@ garrow_fixed_size_list_array_new_data_type(GArrowArray *value_array,
  *
  * Returns: (transfer full): The element array.
  *
- *   It should be freed with g_free() when no longer needed.
+ *   It should be freed with g_object_unref() when no longer needed.
  *
  * Since: 22.0.0
  */

--- a/c_glib/arrow-glib/composite-array.cpp
+++ b/c_glib/arrow-glib/composite-array.cpp
@@ -2082,7 +2082,7 @@ garrow_fixed_size_list_array_new_list_size(GArrowArray *value_array,
                                            gint64 n_nulls,
                                            GError **error)
 {
-  std::shared_ptr<arrow::Array> arrow_value_array = garrow_array_get_raw(value_array);
+  auto arrow_value_array = garrow_array_get_raw(value_array);
   auto arrow_null_bitmap = garrow_buffer_get_raw(null_bitmap);
 
   auto arrow_fixed_size_list_array_result =

--- a/c_glib/arrow-glib/composite-array.cpp
+++ b/c_glib/arrow-glib/composite-array.cpp
@@ -2159,7 +2159,6 @@ garrow_fixed_size_list_array_get_values(GArrowFixedSizeListArray *array)
   auto arrow_fixed_size_list_array =
     std::static_pointer_cast<arrow::FixedSizeListArray>(arrow_array);
   auto arrow_value_array = arrow_fixed_size_list_array->values();
-
   return garrow_array_new_raw(&arrow_value_array);
 }
 G_END_DECLS

--- a/c_glib/arrow-glib/composite-array.h
+++ b/c_glib/arrow-glib/composite-array.h
@@ -312,4 +312,34 @@ GARROW_AVAILABLE_IN_13_0
 gint64
 garrow_run_end_encoded_array_find_physical_length(GArrowRunEndEncodedArray *array);
 
+#define GARROW_TYPE_FIXED_SIZE_LIST_ARRAY (garrow_fixed_size_list_array_get_type())
+GARROW_AVAILABLE_IN_22_0
+G_DECLARE_DERIVABLE_TYPE(GArrowFixedSizeListArray,
+                         garrow_fixed_size_list_array,
+                         GARROW,
+                         FIXED_SIZE_LIST_ARRAY,
+                         GArrowArray)
+struct _GArrowFixedSizeListArrayClass
+{
+  GArrowArrayClass parent_class;
+};
+
+GArrowFixedSizeListArray *
+garrow_fixed_size_list_array_new_list_size(GArrowArray *value_array,
+                                           gint32 list_size,
+                                           GArrowBuffer *null_bitmap,
+                                           gint64 n_nulls,
+                                           GError **error);
+
+GARROW_AVAILABLE_IN_22_0
+GArrowFixedSizeListArray *
+garrow_fixed_size_list_array_new_data_type(GArrowArray *value_array,
+                                           GArrowDataType *data_type,
+                                           GArrowBuffer *null_bitmap,
+                                           gint64 n_nulls,
+                                           GError **error);
+
+GARROW_AVAILABLE_IN_22_0
+GArrowArray *
+garrow_fixed_size_list_array_get_values(GArrowFixedSizeListArray *array);
 G_END_DECLS

--- a/c_glib/test/test-fixed-size-list-array.rb
+++ b/c_glib/test/test-fixed-size-list-array.rb
@@ -35,7 +35,7 @@ class TestFixedSizeListArray < Test::Unit::TestCase
                     array.value_data_type.list_size, array.values])
     end
 
-    def new_data_type
+    def test_new_data_type
       data_type = Arrow::FixedSizeListDataType.new(Arrow::UInt8DataType.new, list_elem_size)
 
       array = Arrow::FixedSizeListArray.new(@value_array, data_type, @null_bitmap, @null_count)

--- a/c_glib/test/test-fixed-size-list-array.rb
+++ b/c_glib/test/test-fixed-size-list-array.rb
@@ -1,0 +1,44 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestFixedSizeListArray < Test::Unit::TestCase
+  include Helper::Buildable
+
+  sub_test_case(".new") do
+    def setup
+      @array_length = 3
+      @list_elem_size = 4
+      @value_array = build_uint8_array([10, 20, 30, 40, nil, nil, nil, nil, 50, 60, 70, 80])
+      @null_bitmap = Arrow::Buffer.new([0b101].pack("C*"))
+      @null_count = 1
+    end
+
+    def test_new_array
+      array = Arrow::FixedSizeListArray.new(@value_array, @list_elem_size, @null_bitmap, @null_count)
+      assert_equal([@array_length, Arrow::UInt8DataType.new, @list_elem_size, @value_array],
+                   [array.length, array.value_data_type.field.data_type, array.value_data_type.list_size, array.values])
+    end
+
+    def new_data_type
+      data_type = Arrow::FixedSizeListDataType.new(Arrow::UInt8DataType.new, list_elem_size)
+
+      array = Arrow::FixedSizeListArray.new(@value_array, data_type, @null_bitmap, @null_count)
+      assert_equal([@array_length, Arrow::UInt8DataType.new, @list_elem_size, @value_array],
+                   [array.length, array.value_data_type.field.data_type, array.value_data_type.list_size, array.values])
+    end
+  end
+end

--- a/c_glib/test/test-fixed-size-list-array.rb
+++ b/c_glib/test/test-fixed-size-list-array.rb
@@ -28,9 +28,11 @@ class TestFixedSizeListArray < Test::Unit::TestCase
     end
 
     def test_new_array
-      array = Arrow::FixedSizeListArray.new(@value_array, @list_elem_size, @null_bitmap, @null_count)
+      array = Arrow::FixedSizeListArray.new(@value_array, @list_elem_size, @null_bitmap,
+                                            @null_count)
       assert_equal([@array_length, Arrow::UInt8DataType.new, @list_elem_size, @value_array],
-                   [array.length, array.value_data_type.field.data_type, array.value_data_type.list_size, array.values])
+                   [array.length, array.value_data_type.field.data_type,
+                    array.value_data_type.list_size, array.values])
     end
 
     def new_data_type
@@ -38,7 +40,8 @@ class TestFixedSizeListArray < Test::Unit::TestCase
 
       array = Arrow::FixedSizeListArray.new(@value_array, data_type, @null_bitmap, @null_count)
       assert_equal([@array_length, Arrow::UInt8DataType.new, @list_elem_size, @value_array],
-                   [array.length, array.value_data_type.field.data_type, array.value_data_type.list_size, array.values])
+                   [array.length, array.value_data_type.field.data_type,
+                    array.value_data_type.list_size, array.values])
     end
   end
 end


### PR DESCRIPTION
### Rationale for this change

GLib should be able to use `arrow::FixedSizeListArray`.

### What changes are included in this PR?

Add `GArrowFixedSizeListArray`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #47365