### PR TITLE
GH-47376: [C++][Compute] Support selective execution for kernels

### DIFF
--- a/cpp/src/arrow/compute/CMakeLists.txt
+++ b/cpp/src/arrow/compute/CMakeLists.txt
@@ -174,6 +174,8 @@ add_arrow_compute_test(row_test
                        EXTRA_LINK_LIBS
                        arrow_compute_testing)
 
+add_arrow_compute_benchmark(exec_benchmark)
+
 add_arrow_compute_benchmark(function_benchmark)
 
 add_subdirectory(kernels)

--- a/cpp/src/arrow/compute/exec.cc
+++ b/cpp/src/arrow/compute/exec.cc
@@ -881,7 +881,7 @@ class ScalarExecutor : public KernelExecutorImpl<ScalarKernel> {
   // Execute a single batch with a selection vector "densely" for a kernel that doesn't
   // support selective execution. "Densely" here means that we first gather the rows
   // indicated by the selection vector into a contiguous ExecBatch, execute that, and
-  // then scatter the result back to the original row positions.
+  // then scatter the result back to the original row positions in the output.
   Status ExecuteSelectiveDense(const ExecBatch& batch, ExecListener* listener) {
     DCHECK(batch.selection_vector && !kernel_->selective_exec);
 

--- a/cpp/src/arrow/compute/exec.cc
+++ b/cpp/src/arrow/compute/exec.cc
@@ -839,6 +839,7 @@ class ScalarExecutor : public KernelExecutorImpl<ScalarKernel> {
     return ExecuteBatch(batch, listener);
   }
 
+ protected:
   Datum WrapResults(const std::vector<Datum>& inputs,
                     const std::vector<Datum>& outputs) override {
     // If execution yielded multiple chunks (because large arrays were split
@@ -851,7 +852,6 @@ class ScalarExecutor : public KernelExecutorImpl<ScalarKernel> {
     }
   }
 
- protected:
   // Execute a single batch either non-selectively (batch doesn't contain a selection
   // vector) or selectively (kernel supports selective execution).
   Status ExecuteBatch(const ExecBatch& batch, ExecListener* listener) {

--- a/cpp/src/arrow/compute/exec.cc
+++ b/cpp/src/arrow/compute/exec.cc
@@ -898,11 +898,11 @@ class ScalarExecutor : public KernelExecutorImpl<ScalarKernel> {
       if (batch[i].is_scalar()) {
         // XXX: Skip gather for scalars since it is not currently supported by Take.
         values[i] = batch[i];
-        continue;
+      } else {
+        ARROW_ASSIGN_OR_RAISE(values[i],
+                              Take(batch[i], *batch.selection_vector->data(),
+                                   TakeOptions{/*boundcheck=*/false}, exec_context()));
       }
-      ARROW_ASSIGN_OR_RAISE(values[i],
-                            Take(batch[i], *batch.selection_vector->data(),
-                                 TakeOptions{/*boundcheck=*/false}, exec_context()));
     }
     ARROW_ASSIGN_OR_RAISE(
         ExecBatch input,

--- a/cpp/src/arrow/compute/exec.cc
+++ b/cpp/src/arrow/compute/exec.cc
@@ -486,12 +486,9 @@ bool ExecSpanIterator::Next(ExecSpan* span, SelectionVectorSpan* selection_span)
     auto indices_begin = selection_vector_->indices() + selection_position_;
     auto indices_end = selection_vector_->indices() + selection_vector_->length();
     DCHECK_LE(indices_begin, indices_end);
-    auto chunk_row_id_end = position_ + iteration_size;
-    int64_t num_indices = 0;
-    while (indices_begin + num_indices < indices_end &&
-           *(indices_begin + num_indices) < chunk_row_id_end) {
-      ++num_indices;
-    }
+    auto indices_limit = std::lower_bound(
+        indices_begin, indices_end, static_cast<int32_t>(position_ + iteration_size));
+    int64_t num_indices = indices_limit - indices_begin;
     selection_span->SetSlice(selection_position_, num_indices,
                              static_cast<int32_t>(position_));
     selection_position_ += num_indices;

--- a/cpp/src/arrow/compute/exec.cc
+++ b/cpp/src/arrow/compute/exec.cc
@@ -839,7 +839,6 @@ class ScalarExecutor : public KernelExecutorImpl<ScalarKernel> {
     return ExecuteBatch(batch, listener);
   }
 
- protected:
   Datum WrapResults(const std::vector<Datum>& inputs,
                     const std::vector<Datum>& outputs) override {
     // If execution yielded multiple chunks (because large arrays were split
@@ -852,6 +851,7 @@ class ScalarExecutor : public KernelExecutorImpl<ScalarKernel> {
     }
   }
 
+ protected:
   // Execute a single batch either non-selectively (batch doesn't contain a selection
   // vector) or selectively (kernel supports selective execution).
   Status ExecuteBatch(const ExecBatch& batch, ExecListener* listener) {

--- a/cpp/src/arrow/compute/exec.cc
+++ b/cpp/src/arrow/compute/exec.cc
@@ -50,6 +50,7 @@
 #include "arrow/util/logging_internal.h"
 #include "arrow/util/thread_pool.h"
 #include "arrow/util/vector.h"
+#include "arrow/visit_data_inline.h"
 
 namespace arrow {
 
@@ -359,6 +360,7 @@ Status ExecSpanIterator::Init(const ExecBatch& batch, int64_t max_chunksize,
   have_all_scalars_ = CheckIfAllScalar(batch);
   promote_if_all_scalars_ = promote_if_all_scalars;
   position_ = 0;
+  selection_position_ = 0;
   length_ = batch.length;
   chunk_indexes_.clear();
   chunk_indexes_.resize(args_->size(), 0);
@@ -367,6 +369,12 @@ Status ExecSpanIterator::Init(const ExecBatch& batch, int64_t max_chunksize,
   value_offsets_.clear();
   value_offsets_.resize(args_->size(), 0);
   max_chunksize_ = std::min(length_, max_chunksize);
+  selection_vector_ = batch.selection_vector.get();
+  if (selection_vector_) {
+    selection_length_ = selection_vector_->length();
+  } else {
+    selection_length_ = 0;
+  }
   return Status::OK();
 }
 
@@ -403,7 +411,7 @@ int64_t ExecSpanIterator::GetNextChunkSpan(int64_t iteration_size, ExecSpan* spa
   return iteration_size;
 }
 
-bool ExecSpanIterator::Next(ExecSpan* span) {
+bool ExecSpanIterator::Next(ExecSpan* span, SelectionVectorSpan* selection_span) {
   if (!initialized_) {
     span->length = 0;
 
@@ -442,6 +450,13 @@ bool ExecSpanIterator::Next(ExecSpan* span) {
       PromoteExecSpanScalars(span);
     }
 
+    if (!have_all_scalars_ || promote_if_all_scalars_) {
+      if (selection_vector_) {
+        DCHECK_NE(selection_span, nullptr);
+        *selection_span = SelectionVectorSpan(selection_vector_->indices());
+      }
+    }
+
     initialized_ = true;
   } else if (position_ == length_) {
     // We've emitted at least one span and we're at the end so we are done
@@ -463,6 +478,23 @@ bool ExecSpanIterator::Next(ExecSpan* span) {
       arr->SetSlice(value_positions_[i] + value_offsets_[i], iteration_size);
       value_positions_[i] += iteration_size;
     }
+  }
+
+  // Then the selection span
+  if (selection_vector_) {
+    DCHECK_NE(selection_span, nullptr);
+    auto indices_begin = selection_vector_->indices() + selection_position_;
+    auto indices_end = selection_vector_->indices() + selection_vector_->length();
+    DCHECK_LE(indices_begin, indices_end);
+    auto chunk_row_id_end = position_ + iteration_size;
+    int64_t num_indices = 0;
+    while (indices_begin + num_indices < indices_end &&
+           *(indices_begin + num_indices) < chunk_row_id_end) {
+      ++num_indices;
+    }
+    selection_span->SetSlice(selection_position_, num_indices,
+                             static_cast<int32_t>(position_));
+    selection_position_ += num_indices;
   }
 
   position_ += iteration_size;
@@ -694,7 +726,14 @@ std::shared_ptr<ChunkedArray> ToChunkedArray(const std::vector<Datum>& values,
       // Skip empty chunks
       continue;
     }
-    arrays.emplace_back(val.make_array());
+    if (val.is_chunked_array()) {
+      for (const auto& chunk : val.chunked_array()->chunks()) {
+        arrays.emplace_back(chunk);
+      }
+    } else {
+      DCHECK(val.is_array());
+      arrays.emplace_back(val.make_array());
+    }
   }
   return std::make_shared<ChunkedArray>(std::move(arrays), type.GetSharedPtr());
 }
@@ -781,16 +820,44 @@ class KernelExecutorImpl : public KernelExecutor {
 class ScalarExecutor : public KernelExecutorImpl<ScalarKernel> {
  public:
   Status Execute(const ExecBatch& batch, ExecListener* listener) override {
-    RETURN_NOT_OK(span_iterator_.Init(batch, exec_context()->exec_chunksize()));
-
     if (batch.length == 0) {
       // For zero-length batches, we do nothing except return a zero-length
       // array of the correct output type
       ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Array> result,
                             MakeArrayOfNull(output_type_.GetSharedPtr(), /*length=*/0,
                                             exec_context()->memory_pool()));
+      RETURN_NOT_OK(span_iterator_.Init(batch, exec_context()->exec_chunksize()));
       return EmitResult(result->data(), listener);
     }
+
+    if (batch.selection_vector && !kernel_->selective_exec) {
+      // If the batch contains a selection vector but the kernel does not support
+      // selective execution, we need to execute the batch in a "dense" manner.
+      return ExecuteSelectiveDense(batch, listener);
+    }
+
+    return ExecuteBatch(batch, listener);
+  }
+
+  Datum WrapResults(const std::vector<Datum>& inputs,
+                    const std::vector<Datum>& outputs) override {
+    // If execution yielded multiple chunks (because large arrays were split
+    // based on the ExecContext parameters, then the result is a ChunkedArray
+    if (HaveChunkedArray(inputs) || outputs.size() > 1) {
+      return ToChunkedArray(outputs, output_type_);
+    } else {
+      // Outputs have just one element
+      return outputs[0];
+    }
+  }
+
+ protected:
+  // Execute a single batch either non-selectively (batch doesn't contain a selection
+  // vector) or selectively (kernel supports selective execution).
+  Status ExecuteBatch(const ExecBatch& batch, ExecListener* listener) {
+    DCHECK(!batch.selection_vector || kernel_->selective_exec);
+
+    RETURN_NOT_OK(span_iterator_.Init(batch, exec_context()->exec_chunksize()));
 
     // If the executor is configured to produce a single large Array output for
     // kernels supporting preallocation, then we do so up front and then
@@ -811,19 +878,46 @@ class ScalarExecutor : public KernelExecutorImpl<ScalarKernel> {
     }
   }
 
-  Datum WrapResults(const std::vector<Datum>& inputs,
-                    const std::vector<Datum>& outputs) override {
-    // If execution yielded multiple chunks (because large arrays were split
-    // based on the ExecContext parameters, then the result is a ChunkedArray
-    if (HaveChunkedArray(inputs) || outputs.size() > 1) {
-      return ToChunkedArray(outputs, output_type_);
-    } else {
-      // Outputs have just one element
-      return outputs[0];
+  // Execute a single batch with a selection vector "densely" for a kernel that doesn't
+  // support selective execution. "Densely" here means that we first gather the rows
+  // indicated by the selection vector into a contiguous ExecBatch, execute that, and
+  // then scatter the result back to the original row positions.
+  Status ExecuteSelectiveDense(const ExecBatch& batch, ExecListener* listener) {
+    DCHECK(batch.selection_vector && !kernel_->selective_exec);
+
+    if (CheckIfAllScalar(batch)) {
+      // For all-scalar batch, we can skip the gather/scatter steps as if there is no
+      // selection vector - the result is a scalar anyway.
+      ExecBatch input = batch;
+      input.selection_vector = nullptr;
+      return ExecuteBatch(input, listener);
     }
+
+    std::vector<Datum> values(batch.num_values());
+    for (int i = 0; i < batch.num_values(); ++i) {
+      if (batch[i].is_scalar()) {
+        // XXX: Skip gather for scalars since it is not currently supported by Take.
+        values[i] = batch[i];
+        continue;
+      }
+      ARROW_ASSIGN_OR_RAISE(values[i],
+                            Take(batch[i], *batch.selection_vector->data(),
+                                 TakeOptions{/*boundcheck=*/false}, exec_context()));
+    }
+    ARROW_ASSIGN_OR_RAISE(
+        ExecBatch input,
+        ExecBatch::Make(std::move(values), batch.selection_vector->length()));
+
+    DatumAccumulator dense_listener;
+    RETURN_NOT_OK(ExecuteBatch(input, &dense_listener));
+    Datum dense_result = WrapResults(input.values, dense_listener.values());
+
+    ARROW_ASSIGN_OR_RAISE(auto result,
+                          Scatter(dense_result, *batch.selection_vector->data(),
+                                  ScatterOptions{/*max_index=*/batch.length - 1}));
+    return listener->OnResult(std::move(result));
   }
 
- protected:
   Status EmitResult(std::shared_ptr<ArrayData> out, ExecListener* listener) {
     if (span_iterator_.have_all_scalars()) {
       // ARROW-16757 We boxed scalar inputs as ArraySpan, so now we have to
@@ -842,6 +936,11 @@ class ScalarExecutor : public KernelExecutorImpl<ScalarKernel> {
     // eventually skip the creation of ArrayData altogether
     std::shared_ptr<ArrayData> preallocation;
     ExecSpan input;
+    SelectionVectorSpan selection;
+    SelectionVectorSpan* selection_ptr = nullptr;
+    if (span_iterator_.have_selection_vector()) {
+      selection_ptr = &selection;
+    }
     ExecResult output;
     ArraySpan* output_span = output.array_span_mutable();
 
@@ -853,10 +952,10 @@ class ScalarExecutor : public KernelExecutorImpl<ScalarKernel> {
       output_span->SetMembers(*preallocation);
       output_span->offset = 0;
       int64_t result_offset = 0;
-      while (span_iterator_.Next(&input)) {
+      while (span_iterator_.Next(&input, selection_ptr)) {
         // Set absolute output span position and length
         output_span->SetSlice(result_offset, input.length);
-        RETURN_NOT_OK(ExecuteSingleSpan(input, &output));
+        RETURN_NOT_OK(ExecuteSingleSpan(input, selection_ptr, &output));
         result_offset = span_iterator_.position();
       }
 
@@ -866,10 +965,10 @@ class ScalarExecutor : public KernelExecutorImpl<ScalarKernel> {
       // Fully preallocating, but not contiguously
       // We preallocate (maybe) only for the output of processing the current
       // chunk
-      while (span_iterator_.Next(&input)) {
+      while (span_iterator_.Next(&input, selection_ptr)) {
         ARROW_ASSIGN_OR_RAISE(preallocation, PrepareOutput(input.length));
         output_span->SetMembers(*preallocation);
-        RETURN_NOT_OK(ExecuteSingleSpan(input, &output));
+        RETURN_NOT_OK(ExecuteSingleSpan(input, selection_ptr, &output));
         // Emit the result for this chunk
         RETURN_NOT_OK(EmitResult(std::move(preallocation), listener));
       }
@@ -877,7 +976,8 @@ class ScalarExecutor : public KernelExecutorImpl<ScalarKernel> {
     }
   }
 
-  Status ExecuteSingleSpan(const ExecSpan& input, ExecResult* out) {
+  Status ExecuteSingleSpan(const ExecSpan& input, const SelectionVectorSpan* selection,
+                           ExecResult* out) {
     ArraySpan* result_span = out->array_span_mutable();
     if (output_type_.type->id() == Type::NA) {
       result_span->null_count = result_span->length;
@@ -888,7 +988,7 @@ class ScalarExecutor : public KernelExecutorImpl<ScalarKernel> {
     } else if (kernel_->null_handling == NullHandling::OUTPUT_NOT_NULL) {
       result_span->null_count = 0;
     }
-    RETURN_NOT_OK(kernel_->exec(kernel_ctx_, input, out));
+    RETURN_NOT_OK(ExecuteKernel(input, selection, out));
     // Output type didn't change
     DCHECK(out->is_array_span());
     return Status::OK();
@@ -903,8 +1003,13 @@ class ScalarExecutor : public KernelExecutorImpl<ScalarKernel> {
     // We will eventually delete the Scalar output path per
     // ARROW-16757.
     ExecSpan input;
+    SelectionVectorSpan selection;
+    SelectionVectorSpan* selection_ptr = nullptr;
+    if (span_iterator_.have_selection_vector()) {
+      selection_ptr = &selection;
+    }
     ExecResult output;
-    while (span_iterator_.Next(&input)) {
+    while (span_iterator_.Next(&input, selection_ptr)) {
       ARROW_ASSIGN_OR_RAISE(output.value, PrepareOutput(input.length));
       DCHECK(output.is_array_data());
 
@@ -917,7 +1022,7 @@ class ScalarExecutor : public KernelExecutorImpl<ScalarKernel> {
         out_arr->null_count = 0;
       }
 
-      RETURN_NOT_OK(kernel_->exec(kernel_ctx_, input, &output));
+      RETURN_NOT_OK(ExecuteKernel(input, selection_ptr, &output));
 
       // Output type didn't change
       DCHECK(output.is_array_data());
@@ -981,6 +1086,17 @@ class ScalarExecutor : public KernelExecutorImpl<ScalarKernel> {
         (exec_context()->preallocate_contiguous() && kernel_->can_write_into_slices &&
          preallocating_all_buffers_);
     return Status::OK();
+  }
+
+  // Actually invoke the kernel on the given input span, either selectively if there is a
+  // selection or non-selectively otherwise.
+  Status ExecuteKernel(const ExecSpan& input, const SelectionVectorSpan* selection,
+                       ExecResult* out) {
+    if (selection) {
+      DCHECK_NE(kernel_->selective_exec, nullptr);
+      return kernel_->selective_exec(kernel_ctx_, input, *selection, out);
+    }
+    return kernel_->exec(kernel_ctx_, input, out);
   }
 
   // Used to account for the case where we do not preallocate a
@@ -1345,18 +1461,53 @@ const CpuInfo* ExecContext::cpu_info() const { return CpuInfo::GetInstance(); }
 
 SelectionVector::SelectionVector(std::shared_ptr<ArrayData> data)
     : data_(std::move(data)) {
-  DCHECK_EQ(Type::INT32, data_->type->id());
-  DCHECK_EQ(0, data_->GetNullCount());
+  DCHECK_NE(data_, nullptr);
+  DCHECK_EQ(data_->type->id(), Type::INT32);
   indices_ = data_->GetValues<int32_t>(1);
 }
 
 SelectionVector::SelectionVector(const Array& arr) : SelectionVector(arr.data()) {}
 
-int32_t SelectionVector::length() const { return static_cast<int32_t>(data_->length); }
+int64_t SelectionVector::length() const { return data_->length; }
 
-Result<std::shared_ptr<SelectionVector>> SelectionVector::FromMask(
-    const BooleanArray& arr) {
-  return Status::NotImplemented("FromMask");
+Status SelectionVector::Validate(int64_t values_length) const {
+  if (data_ == nullptr) {
+    return Status::Invalid("SelectionVector not initialized");
+  }
+  ARROW_CHECK_NE(indices_, nullptr);
+  if (data_->type->id() != Type::INT32) {
+    return Status::Invalid("SelectionVector must be of type int32");
+  }
+  if (data_->GetNullCount() != 0) {
+    return Status::Invalid("SelectionVector cannot contain nulls");
+  }
+  for (int64_t i = 1; i < length(); ++i) {
+    if (indices_[i - 1] > indices_[i]) {
+      return Status::Invalid("SelectionVector indices must be sorted");
+    }
+  }
+  for (int64_t i = 0; i < length(); ++i) {
+    if (indices_[i] < 0) {
+      return Status::Invalid("SelectionVector indices must be non-negative");
+    }
+  }
+  if (values_length >= 0) {
+    for (int64_t i = 0; i < length(); ++i) {
+      if (indices_[i] >= values_length) {
+        return Status::Invalid("SelectionVector index ", indices_[i],
+                               " >= values length ", values_length);
+      }
+    }
+  }
+  return Status::OK();
+}
+
+void SelectionVectorSpan::SetSlice(int64_t offset, int64_t length,
+                                   int32_t index_back_shift) {
+  DCHECK_NE(indices_, nullptr);
+  offset_ = offset;
+  length_ = length;
+  index_back_shift_ = index_back_shift;
 }
 
 Result<Datum> CallFunction(const std::string& func_name, const std::vector<Datum>& args,

--- a/cpp/src/arrow/compute/exec_benchmark.cc
+++ b/cpp/src/arrow/compute/exec_benchmark.cc
@@ -1,0 +1,188 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "benchmark/benchmark.h"
+
+#include "arrow/compute/exec_internal.h"
+#include "arrow/compute/expression.h"
+#include "arrow/compute/function_internal.h"
+#include "arrow/compute/kernels/codegen_internal.h"
+#include "arrow/compute/registry.h"
+#include "arrow/testing/generator.h"
+#include "arrow/util/logging.h"
+
+namespace arrow::compute {
+
+namespace {
+
+// A trivial kernel that just keeps the CPU busy for a specified number of iterations per
+// input row. Has both regular and selective variants. Used to benchmark the overhead of
+// the execution framework.
+
+struct SpinOptions : public FunctionOptions {
+  explicit SpinOptions(int64_t count = 0);
+  static constexpr char kTypeName[] = "SpinOptions";
+  static SpinOptions Defaults() { return SpinOptions(); }
+  int64_t count = 0;
+};
+
+static auto kSpinOptionsType = internal::GetFunctionOptionsType<SpinOptions>(
+    arrow::internal::DataMember("count", &SpinOptions::count));
+
+SpinOptions::SpinOptions(int64_t count)
+    : FunctionOptions(kSpinOptionsType), count(count) {}
+
+const SpinOptions* GetDefaultSpinOptions() {
+  static const auto kDefaultSpinOptions = SpinOptions::Defaults();
+  return &kDefaultSpinOptions;
+}
+
+using SpinState = internal::OptionsWrapper<SpinOptions>;
+
+inline void Spin(volatile int64_t count) {
+  while (count-- > 0) {
+    // Do nothing, just burn CPU cycles.
+  }
+}
+
+Status SpinExec(KernelContext* ctx, const ExecSpan& span, ExecResult* out) {
+  ARROW_CHECK_EQ(span.num_values(), 1);
+  const auto& arg = span[0];
+  ARROW_CHECK(arg.is_array());
+
+  int64_t count = SpinState::Get(ctx).count;
+  for (int64_t i = 0; i < arg.length(); ++i) {
+    Spin(count);
+  }
+  *out->array_data_mutable() = *arg.array.ToArrayData();
+  return Status::OK();
+}
+
+Status SpinSelectiveExec(KernelContext* ctx, const ExecSpan& span,
+                         const SelectionVectorSpan& selection_span, ExecResult* out) {
+  ARROW_CHECK_EQ(span.num_values(), 1);
+  const auto& arg = span[0];
+  ARROW_CHECK(arg.is_array());
+
+  int64_t count = SpinState::Get(ctx).count;
+  detail::VisitSelectionVectorSpanInline(selection_span, [&](int64_t i) { Spin(count); });
+  *out->array_data_mutable() = *arg.array.ToArrayData();
+  return Status::OK();
+}
+
+Status RegisterSpinFunction() {
+  auto registry = GetFunctionRegistry();
+
+  if (registry->CanAddFunctionOptionsType(kSpinOptionsType).ok()) {
+    RETURN_NOT_OK(registry->AddFunctionOptionsType(kSpinOptionsType));
+  }
+
+  auto register_spin_function = [&](std::string name, ArrayKernelExec exec,
+                                    ArrayKernelSelectiveExec selective_exec) {
+    auto func = std::make_shared<ScalarFunction>(
+        std::move(name), Arity::Unary(), FunctionDoc::Empty(), GetDefaultSpinOptions());
+    ScalarKernel kernel({InputType::Any()}, internal::FirstType, exec, selective_exec,
+                        SpinState::Init);
+    kernel.can_write_into_slices = false;
+    kernel.null_handling = NullHandling::COMPUTED_NO_PREALLOCATE;
+    kernel.mem_allocation = MemAllocation::NO_PREALLOCATE;
+    RETURN_NOT_OK(func->AddKernel(kernel));
+    if (registry->CanAddFunction(func, /*allow_overwrite=*/false).ok()) {
+      RETURN_NOT_OK(registry->AddFunction(std::move(func)));
+    }
+    return Status::OK();
+  };
+
+  // Register two variants, one with selective exec and one without.
+  RETURN_NOT_OK(register_spin_function("spin_selective", SpinExec, SpinSelectiveExec));
+  RETURN_NOT_OK(register_spin_function("spin", SpinExec, /*selective_exec=*/nullptr));
+
+  return Status::OK();
+}
+
+std::shared_ptr<SelectionVector> MakeSelectionVectorTo(int64_t length) {
+  auto res = gen::Step<int32_t>()->Generate(length);
+  ARROW_CHECK_OK(res.status());
+  auto arr = res.ValueUnsafe();
+  return std::make_shared<SelectionVector>(*arr);
+}
+
+}  // namespace
+
+void BenchmarkExec(benchmark::State& state, std::string spin_function,
+                   int64_t kernel_intensity, std::shared_ptr<Array> input,
+                   std::shared_ptr<SelectionVector> selection = nullptr) {
+  static auto registered = RegisterSpinFunction();
+  ARROW_CHECK_OK(registered);
+
+  auto expr =
+      call(std::move(spin_function), {field_ref(0)}, SpinOptions(kernel_intensity));
+  auto bound = expr.Bind(*schema({field("", input->type())})).ValueOrDie();
+  auto length = input->length();
+  auto batch = ExecBatch{{std::move(input)}, length, std::move(selection)};
+
+  for (auto _ : state) {
+    ARROW_CHECK_OK(ExecuteScalarExpression(bound, batch).status());
+  }
+
+  state.SetItemsProcessed(state.iterations() * length);
+}
+
+// Baseline: Run the spin kernel without selection vector.
+static void BM_ExecBaseline(benchmark::State& state) {
+  const int64_t kernel_intensity = state.range(0);
+  const int64_t num_rows = state.range(1);
+
+  auto input = ConstantArrayGenerator::Int32(num_rows, 0);
+  BenchmarkExec(state, "spin", kernel_intensity, std::move(input));
+}
+
+// Selective: Run the spin kernel with a selection vector, either sparsely or densely,
+// depending on whether the spin kernel has a selective exec implementation.
+static void BM_ExecSelective(benchmark::State& state, std::string spin_function) {
+  const int64_t selectivity = state.range(0);
+  ARROW_CHECK(selectivity >= 0 && selectivity <= 100);
+  const int64_t kernel_intensity = state.range(1);
+  const int64_t num_rows = state.range(2);
+
+  auto input = ConstantArrayGenerator::Int32(num_rows, 0);
+  auto selection =
+      MakeSelectionVectorTo(static_cast<int64_t>(num_rows * selectivity / 100));
+  BenchmarkExec(state, std::move(spin_function), kernel_intensity, std::move(input),
+                std::move(selection));
+}
+
+const char* kSelectivityArgName = "selectivity";
+const std::vector<int64_t> kSelectivityArg{0, 20, 50, 100};
+const char* kKernelIntensityArgName = "kernel_intensity";
+const std::vector<int64_t> kKernelIntensityArg = benchmark::CreateDenseRange(0, 100, 20);
+const char* kNumRowsArgName = "num_rows";
+const std::vector<int64_t> kNumRowsArg{4096};
+
+BENCHMARK(BM_ExecBaseline)
+    ->ArgNames({kKernelIntensityArgName, kNumRowsArgName})
+    ->ArgsProduct({kKernelIntensityArg, kNumRowsArg});
+
+BENCHMARK_CAPTURE(BM_ExecSelective, sparse, "spin_selective")
+    ->ArgNames({kSelectivityArgName, kKernelIntensityArgName, kNumRowsArgName})
+    ->ArgsProduct({kSelectivityArg, kKernelIntensityArg, kNumRowsArg});
+
+BENCHMARK_CAPTURE(BM_ExecSelective, dense, "spin")
+    ->ArgNames({kSelectivityArgName, kKernelIntensityArgName, kNumRowsArgName})
+    ->ArgsProduct({kSelectivityArg, kKernelIntensityArg, kNumRowsArg});
+
+}  // namespace arrow::compute

--- a/cpp/src/arrow/compute/exec_internal.h
+++ b/cpp/src/arrow/compute/exec_internal.h
@@ -29,6 +29,7 @@
 #include "arrow/compute/kernel.h"
 #include "arrow/status.h"
 #include "arrow/util/visibility.h"
+#include "arrow/visit_data_inline.h"
 
 namespace arrow {
 namespace compute {
@@ -57,21 +58,22 @@ class ARROW_EXPORT ExecSpanIterator {
   Status Init(const ExecBatch& batch, int64_t max_chunksize = kDefaultMaxChunksize,
               bool promote_if_all_scalars = true);
 
-  /// \brief Compute the next span by updating the state of the
-  /// previous span object. You must keep passing in the previous
-  /// value for the results to be consistent. If you need to process
-  /// in parallel, make a copy of the in-use ExecSpan while it's being
-  /// used by another thread and pass it into Next. This function
-  /// always populates at least one span. If you call this function
-  /// with a blank ExecSpan after the first iteration, it will not
-  /// work correctly (maybe we will change this later). Return false
-  /// if the iteration is exhausted
-  bool Next(ExecSpan* span);
+  /// \brief Compute the next span of the data and optionally the selection by updating
+  /// the state of the previous span objects. You must keep passing in the previous value
+  /// for the results to be consistent. If you need to process in parallel, make a copy of
+  /// the in-use ExecSpan while it's being used by another thread and pass it into Next.
+  /// This function always populates at least one span. If you call this function with a
+  /// blank ExecSpan after the first iteration, it will not work correctly (maybe we will
+  /// change this later). Return false if the iteration is exhausted
+  bool Next(ExecSpan* span, SelectionVectorSpan* selection_span = NULLPTR);
 
   int64_t length() const { return length_; }
+  int64_t selection_length() const { return selection_length_; }
   int64_t position() const { return position_; }
+  int64_t selection_position() const { return selection_position_; }
 
   bool have_all_scalars() const { return have_all_scalars_; }
+  bool have_selection_vector() const { return selection_vector_ != NULLPTR; }
 
  private:
   ExecSpanIterator(const std::vector<Datum>& args, int64_t length, int64_t max_chunksize);
@@ -83,6 +85,7 @@ class ARROW_EXPORT ExecSpanIterator {
   bool have_all_scalars_ = false;
   bool promote_if_all_scalars_ = true;
   const std::vector<Datum>* args_;
+  SelectionVector* selection_vector_ = NULLPTR;
   std::vector<int> chunk_indexes_;
   std::vector<int64_t> value_positions_;
 
@@ -93,6 +96,8 @@ class ARROW_EXPORT ExecSpanIterator {
   std::vector<int64_t> value_offsets_;
   int64_t position_ = 0;
   int64_t length_ = 0;
+  int64_t selection_length_ = 0;
+  int64_t selection_position_ = 0;
   int64_t max_chunksize_;
 };
 
@@ -148,6 +153,7 @@ class ARROW_EXPORT KernelExecutor {
   static std::unique_ptr<KernelExecutor> MakeScalarAggregate();
 };
 
+ARROW_EXPORT
 int64_t InferBatchLength(const std::vector<Datum>& values, bool* all_same);
 
 /// \brief Populate validity bitmap with the intersection of the nullity of the
@@ -164,6 +170,25 @@ Status PropagateNulls(KernelContext* ctx, const ExecSpan& batch, ArrayData* out)
 
 ARROW_EXPORT
 void PropagateNullsSpans(const ExecSpan& batch, ArraySpan* out);
+
+template <typename OnSelectionFn>
+typename ::arrow::internal::call_traits::enable_if_return<OnSelectionFn, Status>::type
+VisitSelectionVectorSpanInline(const SelectionVectorSpan& selection,
+                               OnSelectionFn&& on_selection) {
+  for (int64_t i = 0; i < selection.length(); ++i) {
+    RETURN_NOT_OK(on_selection(selection[i]));
+  }
+  return Status::OK();
+}
+
+template <typename OnSelectionFn>
+typename ::arrow::internal::call_traits::enable_if_return<OnSelectionFn, void>::type
+VisitSelectionVectorSpanInline(const SelectionVectorSpan& selection,
+                               OnSelectionFn&& on_selection) {
+  for (int64_t i = 0; i < selection.length(); ++i) {
+    on_selection(selection[i]);
+  }
+}
 
 }  // namespace detail
 }  // namespace compute

--- a/cpp/src/arrow/compute/exec_internal.h
+++ b/cpp/src/arrow/compute/exec_internal.h
@@ -28,8 +28,8 @@
 #include "arrow/compute/exec.h"
 #include "arrow/compute/kernel.h"
 #include "arrow/status.h"
+#include "arrow/util/functional.h"
 #include "arrow/util/visibility.h"
-#include "arrow/visit_data_inline.h"
 
 namespace arrow {
 namespace compute {

--- a/cpp/src/arrow/compute/expression.cc
+++ b/cpp/src/arrow/compute/expression.cc
@@ -770,12 +770,19 @@ Result<Datum> ExecuteScalarExpression(const Expression& expr, const ExecBatch& i
   }
 
   int64_t input_length;
+  std::shared_ptr<SelectionVector> input_selection_vector = nullptr;
   if (!arguments.empty() && all_scalar) {
     // all inputs are scalar, so use a 1-long batch to avoid
     // computing input.length equivalent outputs
     input_length = 1;
   } else {
     input_length = input.length;
+    input_selection_vector = input.selection_vector;
+#ifndef NDEBUG
+    if (input_selection_vector) {
+      RETURN_NOT_OK(input_selection_vector->Validate(input.length));
+    }
+#endif
   }
 
   auto executor = compute::detail::KernelExecutor::MakeScalar();
@@ -789,7 +796,8 @@ Result<Datum> ExecuteScalarExpression(const Expression& expr, const ExecBatch& i
   RETURN_NOT_OK(executor->Init(&kernel_context, {kernel, types, options}));
 
   compute::detail::DatumAccumulator listener;
-  RETURN_NOT_OK(executor->Execute(ExecBatch(arguments, input_length), &listener));
+  RETURN_NOT_OK(executor->Execute(
+      ExecBatch(arguments, input_length, std::move(input_selection_vector)), &listener));
   const auto out = executor->WrapResults(arguments, listener.values());
 #ifndef NDEBUG
   DCHECK_OK(executor->CheckResultType(out, call->function_name.c_str()));

--- a/cpp/src/arrow/compute/function.cc
+++ b/cpp/src/arrow/compute/function.cc
@@ -412,6 +412,14 @@ Status Function::Validate() const {
 Status ScalarFunction::AddKernel(std::vector<InputType> in_types, OutputType out_type,
                                  ArrayKernelExec exec, KernelInit init,
                                  std::shared_ptr<MatchConstraint> constraint) {
+  return AddKernel(std::move(in_types), std::move(out_type), std::move(exec),
+                   /*selective_exec=*/nullptr, std::move(init), std::move(constraint));
+}
+
+Status ScalarFunction::AddKernel(std::vector<InputType> in_types, OutputType out_type,
+                                 ArrayKernelExec exec,
+                                 ArrayKernelSelectiveExec selective_exec, KernelInit init,
+                                 std::shared_ptr<MatchConstraint> constraint) {
   RETURN_NOT_OK(CheckArity(in_types.size()));
 
   if (arity_.is_varargs && in_types.size() != 1) {
@@ -419,7 +427,7 @@ Status ScalarFunction::AddKernel(std::vector<InputType> in_types, OutputType out
   }
   auto sig = KernelSignature::Make(std::move(in_types), std::move(out_type),
                                    arity_.is_varargs, std::move(constraint));
-  kernels_.emplace_back(std::move(sig), exec, init);
+  kernels_.emplace_back(std::move(sig), exec, selective_exec, init);
   return Status::OK();
 }
 

--- a/cpp/src/arrow/compute/function.h
+++ b/cpp/src/arrow/compute/function.h
@@ -304,11 +304,19 @@ class ARROW_EXPORT ScalarFunction : public detail::FunctionImpl<ScalarKernel> {
                                            std::move(doc), default_options),
         is_pure_(is_pure) {}
 
-  /// \brief Add a kernel with given input/output types, no required state
-  /// initialization, preallocation for fixed-width types, and default null
-  /// handling (intersect validity bitmaps of inputs).
+  /// \brief Add a kernel with given input/output types and exec API, no selective exec
+  /// API, no required state initialization, preallocation for fixed-width types, and
+  /// default null handling (intersect validity bitmaps of inputs).
   Status AddKernel(std::vector<InputType> in_types, OutputType out_type,
                    ArrayKernelExec exec, KernelInit init = NULLPTR,
+                   std::shared_ptr<MatchConstraint> constraint = NULLPTR);
+
+  /// \brief Add a kernel with given input/output types, exec and selective exec APIs, no
+  /// required state initialization, preallocation for fixed-width types, and default null
+  /// handling (intersect validity bitmaps of inputs).
+  Status AddKernel(std::vector<InputType> in_types, OutputType out_type,
+                   ArrayKernelExec exec, ArrayKernelSelectiveExec selective_exec,
+                   KernelInit init = NULLPTR,
                    std::shared_ptr<MatchConstraint> constraint = NULLPTR);
 
   /// \brief Add a kernel (function implementation). Returns error if the

--- a/cpp/src/arrow/compute/kernel.h
+++ b/cpp/src/arrow/compute/kernel.h
@@ -555,6 +555,13 @@ struct ARROW_EXPORT Kernel {
 /// employed this may not be possible.
 using ArrayKernelExec = Status (*)(KernelContext*, const ExecSpan&, ExecResult*);
 
+/// \brief The optional scalar kernel selective execution API for SCALAR kernel types.
+/// It's like ArrayKernelExec but with an additional SelectionVectorSpan argument. When a
+/// selection vector is specified in the batch, this API will be preferred, if provided,
+/// over ArrayKernelExec.
+using ArrayKernelSelectiveExec = Status (*)(KernelContext*, const ExecSpan&,
+                                            const SelectionVectorSpan&, ExecResult*);
+
 /// \brief Kernel data structure for implementations of ScalarFunction. In
 /// addition to the members found in Kernel, contains the null handling
 /// and memory pre-allocation preferences.
@@ -562,18 +569,36 @@ struct ARROW_EXPORT ScalarKernel : public Kernel {
   ScalarKernel() = default;
 
   ScalarKernel(std::shared_ptr<KernelSignature> sig, ArrayKernelExec exec,
+               ArrayKernelSelectiveExec selective_exec, KernelInit init = NULLPTR)
+      : Kernel(std::move(sig), std::move(init)),
+        exec(std::move(exec)),
+        selective_exec(std::move(selective_exec)) {}
+
+  ScalarKernel(std::vector<InputType> in_types, OutputType out_type, ArrayKernelExec exec,
+               ArrayKernelSelectiveExec selective_exec, KernelInit init = NULLPTR)
+      : Kernel(std::move(in_types), std::move(out_type), std::move(init)),
+        exec(std::move(exec)),
+        selective_exec(std::move(selective_exec)) {}
+
+  ScalarKernel(std::shared_ptr<KernelSignature> sig, ArrayKernelExec exec,
                KernelInit init = NULLPTR)
-      : Kernel(std::move(sig), init), exec(exec) {}
+      : ScalarKernel(std::move(sig), std::move(exec), NULLPTR, std::move(init)) {}
 
   ScalarKernel(std::vector<InputType> in_types, OutputType out_type, ArrayKernelExec exec,
                KernelInit init = NULLPTR)
-      : Kernel(std::move(in_types), std::move(out_type), std::move(init)), exec(exec) {}
+      : ScalarKernel(std::move(in_types), std::move(out_type), std::move(exec), NULLPTR,
+                     std::move(init)) {}
 
   /// \brief Perform a single invocation of this kernel. Depending on the
   /// implementation, it may only write into preallocated memory, while in some
   /// cases it will allocate its own memory. Any required state is managed
   /// through the KernelContext.
   ArrayKernelExec exec;
+
+  /// \brief Perform a single invocation of this kernel with a selection of indices. If
+  /// not provided, exec will be used with an enclosing gather/scatter pair instead, aka
+  /// "densely".
+  ArrayKernelSelectiveExec selective_exec;
 
   /// \brief Writing execution results into larger contiguous allocations
   /// requires that the kernel be able to write into sliced output ArrayData*,

--- a/cpp/src/arrow/compute/kernel.h
+++ b/cpp/src/arrow/compute/kernel.h
@@ -595,9 +595,11 @@ struct ARROW_EXPORT ScalarKernel : public Kernel {
   /// through the KernelContext.
   ArrayKernelExec exec;
 
-  /// \brief Perform a single invocation of this kernel with a selection of indices. If
-  /// not provided, exec will be used with an enclosing gather/scatter pair instead, aka
-  /// "densely".
+  /// \brief Optional and similar to `exec`, but providing a specialized implementation
+  /// that takes a selection vector argument and performs the computation only on the
+  /// selected indices. When this specialized kernel is not provided we fallback to
+  /// logic that gathers all selected values into a dense array, call `exec` on it
+  /// and then scather the values on the output array.
   ArrayKernelSelectiveExec selective_exec;
 
   /// \brief Writing execution results into larger contiguous allocations

--- a/cpp/src/arrow/compute/test_util_internal.cc
+++ b/cpp/src/arrow/compute/test_util_internal.cc
@@ -24,6 +24,7 @@
 #include "arrow/record_batch.h"
 #include "arrow/scalar.h"
 #include "arrow/table.h"
+#include "arrow/testing/generator.h"
 #include "arrow/testing/gtest_util.h"
 #include "arrow/type.h"
 #include "arrow/util/logging_internal.h"
@@ -118,6 +119,17 @@ void ValidateOutput(const Datum& output) {
     default:
       break;
   }
+}
+
+std::shared_ptr<SelectionVector> SelectionVectorFromJSON(const std::string& json) {
+  return std::make_shared<SelectionVector>(*ArrayFromJSON(int32(), json));
+}
+
+std::shared_ptr<SelectionVector> MakeSelectionVectorTo(int64_t length) {
+  auto res = gen::Step<int32_t>()->Generate(length);
+  DCHECK_OK(res.status());
+  auto arr = res.ValueUnsafe();
+  return std::make_shared<SelectionVector>(*arr);
 }
 
 }  // namespace arrow::compute

--- a/cpp/src/arrow/compute/test_util_internal.h
+++ b/cpp/src/arrow/compute/test_util_internal.h
@@ -39,4 +39,8 @@ ExecBatch ExecBatchFromJSON(const std::vector<TypeHolder>& types,
 
 void ValidateOutput(const Datum& output);
 
+std::shared_ptr<SelectionVector> SelectionVectorFromJSON(const std::string& json);
+
+std::shared_ptr<SelectionVector> MakeSelectionVectorTo(int64_t length);
+
 }  // namespace arrow::compute


### PR DESCRIPTION
### Rationale for this change

In order to support special form (#47374), being able to "selective"-ly execute the kernel becomes a prerequisite. As mentioned in #47374, we need an incremental way to add selective kernels on demand, meanwhile accommodate arbitrary legacy kernels to be executed selectively in a general manner.

### What changes are included in this PR?

1. Enrich the selection vector/span functionalities.
2. Introduce an optional API `ArrayKernelSelectiveExec(KernelContext*, const ExecSpan&, const SelectionVectorSpan&, ExecResult*)` in the kernel. This is the entry for selectively executing the kernel on a batch with a given selection vector. The kernel author can provide a dedicated implementation for such kernel API so the kernel can be executed "sparse"-ly - only the rows indicated by the selection vector will be processed. Otherwise the selective execution will fall back to a general "dense" way - gather the selected rows into a new contiguous (dense) batch, execute the kernel using the non-selective exec API, then scatter the result back to the original row positions.
3. Extend `ScalarExecutor` with dense execution ability.

### Are these changes tested?

Tested and benchmarked.

### Are there any user-facing changes?

None.

* GitHub Issue: #47376