### PR TITLE
GH-47375: [C++][Compute] Move scatter function into compute core

### DIFF
--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -739,7 +739,8 @@ set(ARROW_COMPUTE_SRCS
     compute/kernels/vector_selection.cc
     compute/kernels/vector_selection_filter_internal.cc
     compute/kernels/vector_selection_internal.cc
-    compute/kernels/vector_selection_take_internal.cc)
+    compute/kernels/vector_selection_take_internal.cc
+    compute/kernels/vector_swizzle.cc)
 
 if(ARROW_COMPUTE)
   # If libarrow_compute.a is only built, "pkg-config --cflags --libs
@@ -789,7 +790,6 @@ if(ARROW_COMPUTE)
        compute/kernels/vector_select_k.cc
        compute/kernels/vector_sort.cc
        compute/kernels/vector_statistics.cc
-       compute/kernels/vector_swizzle.cc
        compute/key_hash_internal.cc
        compute/key_map_internal.cc
        compute/light_array_internal.cc

--- a/cpp/src/arrow/compute/initialize.cc
+++ b/cpp/src/arrow/compute/initialize.cc
@@ -54,7 +54,6 @@ Status RegisterComputeKernels() {
   internal::RegisterVectorRunEndDecode(registry);
   internal::RegisterVectorPairwise(registry);
   internal::RegisterVectorStatistics(registry);
-  internal::RegisterVectorSwizzle(registry);
 
   // Aggregate functions
   internal::RegisterHashAggregateBasic(registry);

--- a/cpp/src/arrow/compute/registry.cc
+++ b/cpp/src/arrow/compute/registry.cc
@@ -287,6 +287,7 @@ static std::unique_ptr<FunctionRegistry> CreateBuiltInRegistry() {
   RegisterDictionaryDecode(registry.get());
   RegisterVectorHash(registry.get());
   RegisterVectorSelection(registry.get());
+  RegisterVectorSwizzle(registry.get());
 
   RegisterScalarOptions(registry.get());
   RegisterVectorOptions(registry.get());


### PR DESCRIPTION
### Rationale for this change

In order to support special form (#47374), the kernels have to respect the selection vector. Currently none of the kernels does. And it's almost impossible for us to make all existing kernels to respect the selection vector at once (and we probably never will). Thus we need an incremental way to add selection-vector-aware kernels on demand, meanwhile accommodate legacy (selection-vector-non-aware) kernels to be executed "selection-vector-aware"-ly in a general manner - the idea is to first "gather" selected rows from the batch into a new batch, evaluate the expression on the new batch, then "scatter" the result rows into the positions where they belong in the original batch.

This makes the `take` and `scatter` functions dependencies of the exec facilities, which is in compute core (libarrow). And `take` is already in compute core. Now we need to move `scatter`.

I'm implementing the selective execution of kernels in #47377, including invoking `take` and `scatter` as explained above. And I have to write tests of that in `exec_test.cc` which is deliberately declared to be NOT depending on libarrow_compute.

### What changes are included in this PR?

Move scatter compute function into compute core.

### Are these changes tested?

Yes. Manually tested.

### Are there any user-facing changes?

None.
* GitHub Issue: #47375