### PR TITLE
GH-47384: [C++][Acero]  Isolate BackpressureHandler from ExecNode

### DIFF
--- a/cpp/src/arrow/acero/asof_join_node.cc
+++ b/cpp/src/arrow/acero/asof_join_node.cc
@@ -514,9 +514,9 @@ class InputState : public util::SerialSequencingQueue::Processor {
     std::unique_ptr<BackpressureControl> backpressure_control =
         std::make_unique<BackpressureController>(
             /*node=*/asof_input, /*output=*/asof_node, backpressure_counter);
-    ARROW_ASSIGN_OR_RAISE(
-        auto handler, BackpressureHandler::Make(asof_input, low_threshold, high_threshold,
-                                                std::move(backpressure_control)));
+    ARROW_ASSIGN_OR_RAISE(auto handler,
+                          BackpressureHandler::Make(low_threshold, high_threshold,
+                                                    std::move(backpressure_control)));
     return std::make_unique<InputState>(index, tolerance, must_hash, may_rehash,
                                         key_hasher, asof_node, std::move(handler), schema,
                                         time_col_index, key_col_index);
@@ -763,10 +763,10 @@ class InputState : public util::SerialSequencingQueue::Processor {
     total_batches_ = n;
   }
 
-  Status ForceShutdown() {
+  void ForceShutdown() {
     // Force the upstream input node to unpause. Necessary to avoid deadlock when we
     // terminate the process thread
-    return queue_.ForceShutdown();
+    queue_.ForceShutdown();
   }
 
  private:
@@ -1047,7 +1047,7 @@ class AsofJoinNode : public ExecNode {
             st = output_->InputFinished(this, batches_produced_);
           }
           for (const auto& s : state_) {
-            st &= s->ForceShutdown();
+            s->ForceShutdown();
           }
         }));
   }

--- a/cpp/src/arrow/acero/asof_join_node.cc
+++ b/cpp/src/arrow/acero/asof_join_node.cc
@@ -1046,8 +1046,10 @@ class AsofJoinNode : public ExecNode {
           if (st.ok()) {
             st = output_->InputFinished(this, batches_produced_);
           }
-          for (const auto& s : state_) {
+          for (size_t i = 0; i < state_.size(); ++i) {
+            const auto& s = state_[i];
             s->ForceShutdown();
+            st &= inputs_[i]->StopProducing();
           }
         }));
   }
@@ -1499,8 +1501,11 @@ class AsofJoinNode : public ExecNode {
     if (st.ok()) {
       st = output_->InputFinished(this, batches_produced_);
     }
-    for (const auto& s : state_) {
-      st &= s->ForceShutdown();
+
+    for (size_t i = 0; i < state_.size(); ++i) {
+      const auto& s = state_[i];
+      s->ForceShutdown();
+      st &= inputs_[i]->StopProducing();
     }
   }
 

--- a/cpp/src/arrow/acero/concurrent_queue_internal.h
+++ b/cpp/src/arrow/acero/concurrent_queue_internal.h
@@ -175,7 +175,7 @@ class BackpressureConcurrentQueue : private ConcurrentQueue<T> {
 
  private:
   BackpressureHandler handler_;
-  bool shutdown_{false};
+  std::atomic<bool> shutdown_{false};
 };
 
 }  // namespace arrow::acero

--- a/cpp/src/arrow/acero/concurrent_queue_internal.h
+++ b/cpp/src/arrow/acero/concurrent_queue_internal.h
@@ -113,7 +113,7 @@ class ConcurrentQueue {
 };
 
 template <typename T>
-class BackpressureConcurrentQueue : public ConcurrentQueue<T> {
+class BackpressureConcurrentQueue : private ConcurrentQueue<T> {
  private:
   struct DoHandle {
     explicit DoHandle(BackpressureConcurrentQueue& queue)
@@ -134,6 +134,9 @@ class BackpressureConcurrentQueue : public ConcurrentQueue<T> {
   explicit BackpressureConcurrentQueue(BackpressureHandler handler)
       : handler_(std::move(handler)) {}
 
+  using ConcurrentQueue<T>::Empty;
+  using ConcurrentQueue<T>::Front;
+
   // Pops the last item from the queue but waits if the queue is empty until new items are
   // pushed.
   T WaitAndPop() {
@@ -152,6 +155,7 @@ class BackpressureConcurrentQueue : public ConcurrentQueue<T> {
 
   // Pushes an item to the queue
   void Push(const T& item) {
+    if (shutdown_) return;
     std::unique_lock<std::mutex> lock(ConcurrentQueue<T>::GetMutex());
     DoHandle do_handle(*this);
     ConcurrentQueue<T>::PushUnlocked(item);
@@ -164,10 +168,14 @@ class BackpressureConcurrentQueue : public ConcurrentQueue<T> {
     ConcurrentQueue<T>::ClearUnlocked();
   }
 
-  Status ForceShutdown() { return handler_.ForceShutdown(); }
+  void ForceShutdown() {
+    shutdown_ = true;
+    Clear();
+  }
 
  private:
   BackpressureHandler handler_;
+  bool shutdown_{false};
 };
 
 }  // namespace arrow::acero

--- a/cpp/src/arrow/acero/sorted_merge_node.cc
+++ b/cpp/src/arrow/acero/sorted_merge_node.cc
@@ -119,7 +119,7 @@ class InputState {
     std::unique_ptr<arrow::acero::BackpressureControl> backpressure_control =
         std::make_unique<BackpressureController>(input, output, backpressure_counter);
     ARROW_ASSIGN_OR_RAISE(auto handler,
-                          BackpressureHandler::Make(input, low_threshold, high_threshold,
+                          BackpressureHandler::Make(low_threshold, high_threshold,
                                                     std::move(backpressure_control)));
     return PtrType(new InputState(index, std::move(handler), schema, time_col_index));
   }

--- a/cpp/src/arrow/acero/util_test.cc
+++ b/cpp/src/arrow/acero/util_test.cc
@@ -304,7 +304,9 @@ TEST(BackpressureConcurrentQueue, BackpressureTest) {
 TEST(BackpressureConcurrentQueue, BackpressureTestStayUnpaused) {
   BackpressureTestExecNode dummy_node;
   auto ctrl = std::make_unique<TestBackpressureControl>(&dummy_node);
-  ASSERT_OK_AND_ASSIGN(auto handler, BackpressureHandler::Make(/*low_threshold=*/2, /*high_threshold=*/4, std::move(ctrl)));
+  ASSERT_OK_AND_ASSIGN(
+      auto handler, BackpressureHandler::Make(/*low_threshold=*/2, /*high_threshold=*/4,
+                                              std::move(ctrl)));
   BackpressureConcurrentQueue<int> queue(std::move(handler));
 
   queue.Push(6);

--- a/cpp/src/arrow/acero/util_test.cc
+++ b/cpp/src/arrow/acero/util_test.cc
@@ -263,8 +263,7 @@ class TestBackpressureControl : public BackpressureControl {
 TEST(BackpressureConcurrentQueue, BasicTest) {
   BackpressureTestExecNode dummy_node;
   auto ctrl = std::make_unique<TestBackpressureControl>(&dummy_node);
-  ASSERT_OK_AND_ASSIGN(auto handler,
-                       BackpressureHandler::Make(&dummy_node, 2, 4, std::move(ctrl)));
+  ASSERT_OK_AND_ASSIGN(auto handler, BackpressureHandler::Make(2, 4, std::move(ctrl)));
   BackpressureConcurrentQueue<int> queue(std::move(handler));
 
   ConcurrentQueueBasicTest(queue);
@@ -275,8 +274,7 @@ TEST(BackpressureConcurrentQueue, BasicTest) {
 TEST(BackpressureConcurrentQueue, BackpressureTest) {
   BackpressureTestExecNode dummy_node;
   auto ctrl = std::make_unique<TestBackpressureControl>(&dummy_node);
-  ASSERT_OK_AND_ASSIGN(auto handler,
-                       BackpressureHandler::Make(&dummy_node, 2, 4, std::move(ctrl)));
+  ASSERT_OK_AND_ASSIGN(auto handler, BackpressureHandler::Make(2, 4, std::move(ctrl)));
   BackpressureConcurrentQueue<int> queue(std::move(handler));
 
   queue.Push(6);
@@ -299,9 +297,6 @@ TEST(BackpressureConcurrentQueue, BackpressureTest) {
   queue.Push(11);
   ASSERT_TRUE(dummy_node.paused);
   ASSERT_FALSE(dummy_node.stopped);
-  ASSERT_OK(queue.ForceShutdown());
-  ASSERT_FALSE(dummy_node.paused);
-  ASSERT_TRUE(dummy_node.stopped);
 }
 
 }  // namespace acero

--- a/cpp/src/arrow/acero/util_test.cc
+++ b/cpp/src/arrow/acero/util_test.cc
@@ -297,6 +297,9 @@ TEST(BackpressureConcurrentQueue, BackpressureTest) {
   queue.Push(11);
   ASSERT_TRUE(dummy_node.paused);
   ASSERT_FALSE(dummy_node.stopped);
+  queue.ForceShutdown();
+  ASSERT_FALSE(dummy_node.paused);
+  ASSERT_TRUE(dummy_node.stopped);
 }
 
 }  // namespace acero

--- a/cpp/src/arrow/acero/util_test.cc
+++ b/cpp/src/arrow/acero/util_test.cc
@@ -299,7 +299,6 @@ TEST(BackpressureConcurrentQueue, BackpressureTest) {
   ASSERT_FALSE(dummy_node.stopped);
   queue.ForceShutdown();
   ASSERT_FALSE(dummy_node.paused);
-  ASSERT_TRUE(dummy_node.stopped);
 }
 
 }  // namespace acero

--- a/cpp/src/arrow/acero/util_test.cc
+++ b/cpp/src/arrow/acero/util_test.cc
@@ -301,5 +301,23 @@ TEST(BackpressureConcurrentQueue, BackpressureTest) {
   ASSERT_FALSE(dummy_node.paused);
 }
 
+TEST(BackpressureConcurrentQueue, BackpressureTestStayPaused) {
+  BackpressureTestExecNode dummy_node;
+  auto ctrl = std::make_unique<TestBackpressureControl>(&dummy_node);
+  ASSERT_OK_AND_ASSIGN(auto handler, BackpressureHandler::Make(2, 4, std::move(ctrl)));
+  BackpressureConcurrentQueue<int> queue(std::move(handler));
+
+  queue.Push(6);
+  queue.Push(7);
+  queue.Push(8);
+  ASSERT_FALSE(dummy_node.paused);
+  ASSERT_FALSE(dummy_node.stopped);
+  queue.ForceShutdown();
+  for (int i = 0; i < 10; ++i) {
+    queue.Push(i);
+  }
+  ASSERT_FALSE(dummy_node.paused);
+}
+
 }  // namespace acero
 }  // namespace arrow

--- a/cpp/src/arrow/acero/util_test.cc
+++ b/cpp/src/arrow/acero/util_test.cc
@@ -304,7 +304,7 @@ TEST(BackpressureConcurrentQueue, BackpressureTest) {
 TEST(BackpressureConcurrentQueue, BackpressureTestStayUnpaused) {
   BackpressureTestExecNode dummy_node;
   auto ctrl = std::make_unique<TestBackpressureControl>(&dummy_node);
-  ASSERT_OK_AND_ASSIGN(auto handler, BackpressureHandler::Make(2, 4, std::move(ctrl)));
+  ASSERT_OK_AND_ASSIGN(auto handler, BackpressureHandler::Make(/*low_threshold=*/2, /*high_threshold=*/4, std::move(ctrl)));
   BackpressureConcurrentQueue<int> queue(std::move(handler));
 
   queue.Push(6);

--- a/cpp/src/arrow/acero/util_test.cc
+++ b/cpp/src/arrow/acero/util_test.cc
@@ -301,7 +301,7 @@ TEST(BackpressureConcurrentQueue, BackpressureTest) {
   ASSERT_FALSE(dummy_node.paused);
 }
 
-TEST(BackpressureConcurrentQueue, BackpressureTestStayPaused) {
+TEST(BackpressureConcurrentQueue, BackpressureTestStayUnpaused) {
   BackpressureTestExecNode dummy_node;
   auto ctrl = std::make_unique<TestBackpressureControl>(&dummy_node);
   ASSERT_OK_AND_ASSIGN(auto handler, BackpressureHandler::Make(2, 4, std::move(ctrl)));


### PR DESCRIPTION
### Rationale for this change
Current BackpressureHandler needs to be provided with ExecNode, however the backpressure concept can be applied outside of ExecNode. It is currently needed to Facilitate ForceShutdown in AsofJoinNode. Current implementation however is not elegant and may  still lead to deadlock  after ForceShutdown in extreme case - when several batched get pushed after ForceShutdown and exceed the threshold.

### What changes are included in this PR?
-Remove ForceShutdown from BackpressureHandler.
-Reimplement ForceShutdown in BackpressureConcurrentQueue  as onetime nonrecoverable queue clear that effectively unpauses source using handler.

### Are these changes tested?
There is no new functionality. Current tests should cover it.

### Are there any user-facing changes?
No
* GitHub Issue: #47384