### PR TITLE
GH-47390: [C++][Acero] Allow for any type of scalar in Pivot longer features

### DIFF
--- a/cpp/src/arrow/acero/options.cc
+++ b/cpp/src/arrow/acero/options.cc
@@ -18,6 +18,7 @@
 #include "arrow/acero/options.h"
 #include "arrow/acero/exec_plan.h"
 #include "arrow/io/util_internal.h"
+#include "arrow/scalar.h"
 #include "arrow/table.h"
 #include "arrow/util/async_generator.h"
 #include "arrow/util/logging.h"
@@ -61,6 +62,17 @@ ExecBatchIteratorMaker VecToItMaker(std::vector<ExecBatch> batches) {
       [batches_ptr = std::move(batches_ptr)] { return MakeVectorIterator(*batches_ptr); };
 }
 }  // namespace
+
+PivotLongerRowTemplate::PivotLongerRowTemplate(
+    std::vector<std::string> feature_values,
+    std::vector<std::optional<FieldRef>> measurement_values)
+    : measurement_values(std::move(measurement_values)) {
+  this->feature_values.reserve(feature_values.size());
+  for (auto& feature_value : feature_values) {
+    this->feature_values.push_back(
+        std::make_shared<StringScalar>(std::move(feature_value)));
+  }
+}
 
 ExecBatchSourceNodeOptions::ExecBatchSourceNodeOptions(
     std::shared_ptr<Schema> schema, std::vector<ExecBatch> batches,

--- a/cpp/src/arrow/acero/options.h
+++ b/cpp/src/arrow/acero/options.h
@@ -780,7 +780,7 @@ class ARROW_ACERO_EXPORT TableSinkNodeOptions : public ExecNodeOptions {
 
 /// \brief a row template that describes one row that will be generated for each input row
 struct ARROW_ACERO_EXPORT PivotLongerRowTemplate {
-  PivotLongerRowTemplate(std::vector<std::string> feature_values,
+  PivotLongerRowTemplate(std::vector<std::shared_ptr<Scalar>> feature_values,
                          std::vector<std::optional<FieldRef>> measurement_values)
       : feature_values(std::move(feature_values)),
         measurement_values(std::move(measurement_values)) {}
@@ -788,7 +788,7 @@ struct ARROW_ACERO_EXPORT PivotLongerRowTemplate {
   /// column name
   ///
   /// These will be used to populate the feature columns
-  std::vector<std::string> feature_values;
+  std::vector<std::shared_ptr<Scalar>> feature_values;
   /// The fields containing the measurements to use for this row
   ///
   /// These will be used to populate the measurement columns.  If nullopt then nulls

--- a/cpp/src/arrow/acero/options.h
+++ b/cpp/src/arrow/acero/options.h
@@ -784,6 +784,8 @@ struct ARROW_ACERO_EXPORT PivotLongerRowTemplate {
                          std::vector<std::optional<FieldRef>> measurement_values)
       : feature_values(std::move(feature_values)),
         measurement_values(std::move(measurement_values)) {}
+  PivotLongerRowTemplate(std::vector<std::string> feature_values,
+                         std::vector<std::optional<FieldRef>> measurement_values);
   /// A (typically unique) set of feature values for the template, usually derived from a
   /// column name
   ///

--- a/cpp/src/arrow/acero/pivot_longer_node.cc
+++ b/cpp/src/arrow/acero/pivot_longer_node.cc
@@ -109,8 +109,7 @@ class PivotLongerNode : public ExecNode, public TracedNode {
       for (std::size_t i = 0; i < row_template.feature_values.size(); i++) {
         if (!row_template.feature_values[i]) {
           return Status::Invalid("Feature value at column ",
-                                 options.feature_field_names[i],
-                                 " must not be null");
+                                 options.feature_field_names[i], " must not be null");
         }
         if (feature_types[i]) {
           if (!feature_types[i]->Equals(row_template.feature_values[i]->type)) {

--- a/cpp/src/arrow/acero/pivot_longer_node.cc
+++ b/cpp/src/arrow/acero/pivot_longer_node.cc
@@ -109,7 +109,7 @@ class PivotLongerNode : public ExecNode, public TracedNode {
       for (std::size_t i = 0; i < row_template.feature_values.size(); i++) {
         if (feature_types[i]) {
           if (!feature_types[i]->Equals(row_template.feature_values[i]->type)) {
-            return Status::Invalid(
+            return Status::TypeError(
                 "Mixed feature types at column ", options.feature_field_names[i],
                 ".  Some row templates had the type ", feature_types[i]->ToString(),
                 " but later row templates had the type ",

--- a/cpp/src/arrow/acero/pivot_longer_node.cc
+++ b/cpp/src/arrow/acero/pivot_longer_node.cc
@@ -107,6 +107,11 @@ class PivotLongerNode : public ExecNode, public TracedNode {
       }
 
       for (std::size_t i = 0; i < row_template.feature_values.size(); i++) {
+        if (!row_template.feature_values[i]) {
+          return Status::Invalid("Feature value at column ",
+                                 options.feature_field_names[i],
+                                 " must not be null");
+        }
         if (feature_types[i]) {
           if (!feature_types[i]->Equals(row_template.feature_values[i]->type)) {
             return Status::TypeError(

--- a/cpp/src/arrow/acero/pivot_longer_node_test.cc
+++ b/cpp/src/arrow/acero/pivot_longer_node_test.cc
@@ -198,8 +198,8 @@ TEST(PivotLongerNode, ExamplesFromTidyr2) {
   PivotLongerNodeOptions options;
   options.feature_field_names = {"week"};
   options.measurement_field_names = {"rank"};
-  options.row_templates = {{{std::make_shared<StringScalar>("1")}, {{2}}},
-                           {{std::make_shared<StringScalar>("2")}, {{3}}}};
+  options.row_templates = {{{std::make_shared<UInt32Scalar>(1)}, {{2}}},
+                           {{std::make_shared<UInt32Scalar>(2)}, {{3}}}};
 
   Declaration plan = Declaration::Sequence(
       {{"table_source", TableSourceNodeOptions(std::move(input))},
@@ -212,14 +212,14 @@ TEST(PivotLongerNode, ExamplesFromTidyr2) {
                        DeclarationToTable(std::move(plan)));
 
   std::shared_ptr<Schema> expected_schema =
-      schema({field("artist", utf8()), field("track", utf8()), field("week", utf8()),
+      schema({field("artist", utf8()), field("track", utf8()), field("week", uint32()),
               field("rank", float64())});
   std::shared_ptr<Table> expected = TableFromJSON(expected_schema, {{
                                                                        R"([
-        ["2 Pac", "Baby Don't Cry", "1", 87],
-        ["2Ge+her", "The Hardest Part Of", "1", 91],
-        ["2 Pac", "Baby Don't Cry", "2", 82],
-        ["2Ge+her", "The Hardest Part Of", "2", 87]
+        ["2 Pac", "Baby Don't Cry", 1, 87],
+        ["2Ge+her", "The Hardest Part Of", 1, 91],
+        ["2 Pac", "Baby Don't Cry", 2, 82],
+        ["2Ge+her", "The Hardest Part Of", 2, 87]
     ])"}});
 
   AssertTablesEqual(*expected, *output, /*same_chunk_layout=*/false);

--- a/cpp/src/arrow/acero/pivot_longer_node_test.cc
+++ b/cpp/src/arrow/acero/pivot_longer_node_test.cc
@@ -77,7 +77,8 @@ TEST(PivotLongerNode, Basic) {
   AssertSchemaEqual(expected_out_schema, output->schema());
 }
 
-void CheckError(const PivotLongerNodeOptions& options, const std::string& message) {
+void CheckError(const PivotLongerNodeOptions& options, const std::string& message,
+                StatusCode code = StatusCode::Invalid) {
   std::shared_ptr<Table> input = gen::Gen({gen::Step(), gen::Random(boolean())})
                                      ->FailOnError()
                                      ->Table(/*rows_per_chunk=*/1, /*num_chunks=*/1);
@@ -88,44 +89,43 @@ void CheckError(const PivotLongerNodeOptions& options, const std::string& messag
   });
 
   ASSERT_THAT(DeclarationToStatus(std::move(plan)),
-              Raises(StatusCode::Invalid, testing::HasSubstr(message)));
+              Raises(code, testing::HasSubstr(message)));
 }
 
 TEST(PivotLongerNode, Error) {
   PivotLongerNodeOptions options;
   CheckError(options, "There must be at least one row template");
 
-  options.row_templates = {{{}, {{0}}}};
+  options.row_templates = {{std::vector<std::string>{}, {{0}}}};
   CheckError(options, "at least one feature column and one measurement column");
 
   options.feature_field_names = {"feat1"};
   options.measurement_field_names = {"meas1"};
-  options.row_templates = {{{}, {{0}}}};
+  options.row_templates = {{std::vector<std::string>{}, {{0}}}};
   CheckError(options,
              "There were names given for 1 feature columns but one of the row templates "
              "only had 0 feature values");
 
-  options.row_templates = {{{std::make_shared<StringScalar>("x")}, {}}};
+  options.row_templates = {{{"x"}, {}}};
   CheckError(
       options,
       "There were names given for 1 measurement columns but one of the row templates "
       "only had 0 field references");
 
-  options.row_templates = {{{std::make_shared<StringScalar>("x")}, {{0}}},
-                           {{std::make_shared<StringScalar>("y")}, {{1}}}};
+  options.row_templates = {{{"x"}, {{0}}}, {{"y"}, {{1}}}};
   CheckError(
       options,
       "Some row templates had the type uint32 but later row templates had the type bool");
 
-  options.row_templates = {{{std::make_shared<StringScalar>("x")}, {std::nullopt}},
-                           {{std::make_shared<StringScalar>("y")}, {std::nullopt}}};
+  options.row_templates = {{{"x"}, {std::nullopt}}, {{"y"}, {std::nullopt}}};
   CheckError(options, "All row templates had nullopt");
 
   options.row_templates = {{{std::make_shared<StringScalar>("x")}, {{0}}},
                            {{std::make_shared<UInt32Scalar>(1)}, {{0}}}};
   CheckError(options,
              "Some row templates had the type string but later row templates had the "
-             "type uint32");
+             "type uint32",
+             StatusCode::TypeError);
 }
 
 // The following examples are smaller versions of examples taken from
@@ -145,11 +145,11 @@ TEST(PivotLongerNode, ExamplesFromTidyr1) {
   PivotLongerNodeOptions options;
   options.feature_field_names = {"income"};
   options.measurement_field_names = {"count"};
-  options.row_templates = {{{std::make_shared<StringScalar>("<$10k")}, {{1}}},
-                           {{std::make_shared<StringScalar>("$10k-20k")}, {{2}}},
-                           {{std::make_shared<StringScalar>("$20k-30k")}, {{3}}},
-                           {{std::make_shared<StringScalar>("$30k-40k")}, {{4}}},
-                           {{std::make_shared<StringScalar>("$40k-50k")}, {{5}}}};
+  options.row_templates = {{{"<$10k"}, {{1}}},
+                           {{"$10k-20k"}, {{2}}},
+                           {{"$20k-30k"}, {{3}}},
+                           {{"$30k-40k"}, {{4}}},
+                           {{"$40k-50k"}, {{5}}}};
 
   Declaration plan = Declaration::Sequence(
       {{"table_source", TableSourceNodeOptions(std::move(input))},
@@ -238,13 +238,7 @@ TEST(PivotLongerNode, ExamplesFromTidyr3) {
   PivotLongerNodeOptions options;
   options.feature_field_names = {"diagnosis", "gender", "age"};
   options.measurement_field_names = {"count"};
-  options.row_templates = {
-      {{std::make_shared<StringScalar>("sp"), std::make_shared<StringScalar>("m"),
-        std::make_shared<StringScalar>("014")},
-       {{1}}},
-      {{std::make_shared<StringScalar>("sp"), std::make_shared<StringScalar>("m"),
-        std::make_shared<StringScalar>("1524")},
-       {{2}}}};
+  options.row_templates = {{{"sp", "m", "014"}, {{1}}}, {{"sp", "m", "1524"}, {{2}}}};
 
   Declaration plan = Declaration::Sequence(
       {{"table_source", TableSourceNodeOptions(std::move(input))},
@@ -283,8 +277,7 @@ TEST(PivotLongerNode, ExamplesFromTidyr4) {
   PivotLongerNodeOptions options;
   options.feature_field_names = {"set"};
   options.measurement_field_names = {"x", "y"};
-  options.row_templates = {{{std::make_shared<StringScalar>("1")}, {{0}, {2}}},
-                           {{std::make_shared<StringScalar>("2")}, {{1}, {3}}}};
+  options.row_templates = {{{"1"}, {{0}, {2}}}, {{"2"}, {{1}, {3}}}};
 
   Declaration plan = Declaration::Sequence(
       {{"table_source", TableSourceNodeOptions(std::move(input))},


### PR DESCRIPTION
### Rationale for this change
Allow supplying any scalar as feature

### What changes are included in this PR?
Support scalar in PivotLonger 

### Are these changes tested?
Yes

### Are there any user-facing changes?
Yes. 

**This PR includes breaking changes to public APIs.**

`PivotLongerRowTemplate::feature_values` is now a `std::vector<std::shared_ptr<Scalar>>` while it used to be `std::vector<std::string>`).
The `PivotLongerRowTemplate` still allows passing a vector of strings, though.

* GitHub Issue: #47390