### PR TITLE
GH-47370: [Python] Require Cython 3.1

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -105,7 +105,7 @@ jobs:
         shell: bash
         run: |
           gem install test-unit
-          pip install "cython>=3" setuptools pytest requests setuptools-scm
+          pip install "cython>=3.1" setuptools pytest requests setuptools-scm
       - name: Run Release Test
         shell: bash
         run: |

--- a/ci/conda_env_python.txt
+++ b/ci/conda_env_python.txt
@@ -20,7 +20,7 @@
 # Not a direct dependency of s3fs, but needed for our s3fs fixture
 boto3
 cffi
-cython>=3
+cython>=3.1
 cloudpickle
 fsspec
 hypothesis

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -17,7 +17,7 @@
 
 [build-system]
 requires = [
-    "cython >= 3",
+    "cython >= 3.1",
     # Starting with NumPy 1.25, NumPy is (by default) as far back compatible
     # as oldest-support-numpy was (customizable with a NPY_TARGET_VERSION
     # define).  For older Python versions (where NumPy 1.25 is not yet available)

--- a/python/requirements-build.txt
+++ b/python/requirements-build.txt
@@ -1,4 +1,4 @@
-cython>=3
+cython>=3.1
 oldest-supported-numpy>=0.14; python_version<'3.9'
 numpy>=1.25; python_version>='3.9'
 setuptools_scm>=8

--- a/python/requirements-wheel-build.txt
+++ b/python/requirements-wheel-build.txt
@@ -1,4 +1,4 @@
-cython>=3
+cython>=3.1
 oldest-supported-numpy>=0.14; python_version<'3.9'
 numpy>=2.0.0; python_version>='3.9'
 setuptools_scm

--- a/python/setup.py
+++ b/python/setup.py
@@ -48,9 +48,9 @@ is_emscripten = (
 )
 
 
-if Cython.__version__ < '3':
+if Cython.__version__ < '3.1':
     raise Exception(
-        'Please update your Cython version. Supported Cython >= 3')
+        'Please update your Cython version. Supported Cython >= 3.1')
 
 setup_dir = os.path.abspath(os.path.dirname(__file__))
 


### PR DESCRIPTION
### Rationale for this change

Upgrading Cython to version 3.1

### What changes are included in this PR?

Replace all mentions of earlier versions with 3.1

### Are these changes tested?

Nah but I'll run CI

### Are there any user-facing changes?

Only if they're using Cython < 3.1
* GitHub Issue: #47370