### PR TITLE
GH-47389: [Python] CSV and JSON options lack a nice repr/str

### DIFF
--- a/python/pyarrow/_csv.pyx
+++ b/python/pyarrow/_csv.pyx
@@ -1148,37 +1148,27 @@ cdef class ConvertOptions(_Weakrefable):
         except TypeError:
             return False
 
+    def _repr_base(self):
+        return (f"""
+check_utf8={self.check_utf8}
+column_types={self.column_types}
+null_values={self.null_values}
+true_values={self.true_values}
+false_values={self.false_values}
+decimal_point={self.decimal_point!r}
+strings_can_be_null={self.strings_can_be_null}
+quoted_strings_can_be_null={self.quoted_strings_can_be_null}
+include_columns={self.include_columns}
+include_missing_columns={self.include_missing_columns}
+auto_dict_encode={self.auto_dict_encode}
+auto_dict_max_cardinality={self.auto_dict_max_cardinality}
+timestamp_parsers={[str(i) for i in self.timestamp_parsers]}""")
+
     def __repr__(self):
-        return (f"<pyarrow.csv.ConvertOptions("
-                f"check_utf8={self.check_utf8}, "
-                f"column_types={self.column_types}, "
-                f"null_values={self.null_values}, "
-                f"true_values={self.true_values}, "
-                f"false_values={self.false_values}, "
-                f"decimal_point={self.decimal_point!r}, "
-                f"strings_can_be_null={self.strings_can_be_null}, "
-                f"quoted_strings_can_be_null={self.quoted_strings_can_be_null}, "
-                f"include_columns={self.include_columns}, "
-                f"include_missing_columns={self.include_missing_columns}, "
-                f"auto_dict_encode={self.auto_dict_encode}, "
-                f"auto_dict_max_cardinality={self.auto_dict_max_cardinality}, "
-                f"timestamp_parsers={self.timestamp_parsers})>")
+        return (f"<pyarrow.csv.ConvertOptions>({self._repr_base()})")
 
     def __str__(self):
-        return (f"ConvertOptions("
-                f"check_utf8={self.check_utf8}, "
-                f"column_types={self.column_types}, "
-                f"null_values={self.null_values}, "
-                f"true_values={self.true_values}, "
-                f"false_values={self.false_values}, "
-                f"decimal_point={self.decimal_point!r}, "
-                f"strings_can_be_null={self.strings_can_be_null}, "
-                f"quoted_strings_can_be_null={self.quoted_strings_can_be_null}, "
-                f"include_columns={self.include_columns}, "
-                f"include_missing_columns={self.include_missing_columns}, "
-                f"auto_dict_encode={self.auto_dict_encode}, "
-                f"auto_dict_max_cardinality={self.auto_dict_max_cardinality}, "
-                f"timestamp_parsers={self.timestamp_parsers})")
+        return (f"ConvertOptions({self._repr_base()})")
 
 
 cdef _get_reader(input_file, ReadOptions read_options,

--- a/python/pyarrow/_csv.pyx
+++ b/python/pyarrow/_csv.pyx
@@ -333,14 +333,14 @@ cdef class ReadOptions(_Weakrefable):
             return False
 
     def __repr__(self):
-        return (f"<pyarrow.csv.ReadOptions "
-                f"use_threads={self.use_threads} "
-                f"block_size={self.block_size} "
-                f"skip_rows={self.skip_rows} "
-                f"skip_rows_after_names={self.skip_rows_after_names} "
-                f"column_names={self.column_names} "
-                f"autogenerate_column_names={self.autogenerate_column_names} "
-                f"encoding='{self.encoding}'>")
+        return (f"<pyarrow.csv.ReadOptions("
+                f"use_threads={self.use_threads}, "
+                f"block_size={self.block_size}, "
+                f"skip_rows={self.skip_rows}, "
+                f"skip_rows_after_names={self.skip_rows_after_names}, "
+                f"column_names={self.column_names}, "
+                f"autogenerate_column_names={self.autogenerate_column_names}, "
+                f"encoding='{self.encoding}')>")
 
     def __str__(self):
         return (f"ReadOptions("
@@ -606,13 +606,13 @@ cdef class ParseOptions(_Weakrefable):
             return False
 
     def __repr__(self):
-        return (f"<pyarrow.csv.ParseOptions "
-                f"delimiter={self.delimiter!r} "
-                f"quote_char={self.quote_char!r} "
-                f"double_quote={self.double_quote} "
-                f"escape_char={self.escape_char!r} "
-                f"newlines_in_values={self.newlines_in_values} "
-                f"ignore_empty_lines={self.ignore_empty_lines}>")
+        return (f"<pyarrow.csv.ParseOptions("
+                f"delimiter={self.delimiter!r}, "
+                f"quote_char={self.quote_char!r}, "
+                f"double_quote={self.double_quote}, "
+                f"escape_char={self.escape_char!r}, "
+                f"newlines_in_values={self.newlines_in_values}, "
+                f"ignore_empty_lines={self.ignore_empty_lines})>")
 
     def __str__(self):
         return (f"ParseOptions("
@@ -1147,20 +1147,20 @@ cdef class ConvertOptions(_Weakrefable):
             return False
 
     def __repr__(self):
-        return (f"<pyarrow.csv.ConvertOptions "
-                f"check_utf8={self.check_utf8} "
-                f"column_types={self.column_types} "
-                f"null_values={self.null_values} "
-                f"true_values={self.true_values} "
-                f"false_values={self.false_values} "
-                f"decimal_point={self.decimal_point!r} "
-                f"strings_can_be_null={self.strings_can_be_null} "
-                f"quoted_strings_can_be_null={self.quoted_strings_can_be_null} "
-                f"include_columns={self.include_columns} "
-                f"include_missing_columns={self.include_missing_columns} "
-                f"auto_dict_encode={self.auto_dict_encode} "
-                f"auto_dict_max_cardinality={self.auto_dict_max_cardinality} "
-                f"timestamp_parsers={self.timestamp_parsers}>")
+        return (f"<pyarrow.csv.ConvertOptions("
+                f"check_utf8={self.check_utf8}, "
+                f"column_types={self.column_types}, "
+                f"null_values={self.null_values}, "
+                f"true_values={self.true_values}, "
+                f"false_values={self.false_values}, "
+                f"decimal_point={self.decimal_point!r}, "
+                f"strings_can_be_null={self.strings_can_be_null}, "
+                f"quoted_strings_can_be_null={self.quoted_strings_can_be_null}, "
+                f"include_columns={self.include_columns}, "
+                f"include_missing_columns={self.include_missing_columns}, "
+                f"auto_dict_encode={self.auto_dict_encode}, "
+                f"auto_dict_max_cardinality={self.auto_dict_max_cardinality}, "
+                f"timestamp_parsers={self.timestamp_parsers})>")
 
     def __str__(self):
         return (f"ConvertOptions("
@@ -1530,11 +1530,11 @@ cdef class WriteOptions(_Weakrefable):
         check_status(self.options.get().Validate())
 
     def __repr__(self):
-        return (f"<pyarrow.csv.WriteOptions "
-                f"include_header={self.include_header} "
-                f"batch_size={self.batch_size} "
-                f"delimiter={self.delimiter!r} "
-                f"quoting_style='{self.quoting_style}'>")
+        return (f"<pyarrow.csv.WriteOptions("
+                f"include_header={self.include_header}, "
+                f"batch_size={self.batch_size}, "
+                f"delimiter={self.delimiter!r}, "
+                f"quoting_style='{self.quoting_style}')>")
 
     def __str__(self):
         return (f"WriteOptions("

--- a/python/pyarrow/_csv.pyx
+++ b/python/pyarrow/_csv.pyx
@@ -332,6 +332,26 @@ cdef class ReadOptions(_Weakrefable):
         except TypeError:
             return False
 
+    def __repr__(self):
+        return (f"<pyarrow.csv.ReadOptions "
+                f"use_threads={self.use_threads} "
+                f"block_size={self.block_size} "
+                f"skip_rows={self.skip_rows} "
+                f"skip_rows_after_names={self.skip_rows_after_names} "
+                f"column_names={self.column_names} "
+                f"autogenerate_column_names={self.autogenerate_column_names} "
+                f"encoding='{self.encoding}'>")
+
+    def __str__(self):
+        return (f"ReadOptions("
+                f"use_threads={self.use_threads}, "
+                f"block_size={self.block_size}, "
+                f"skip_rows={self.skip_rows}, "
+                f"skip_rows_after_names={self.skip_rows_after_names}, "
+                f"column_names={self.column_names}, "
+                f"autogenerate_column_names={self.autogenerate_column_names}, "
+                f"encoding='{self.encoding}')")
+
 
 cdef class ParseOptions(_Weakrefable):
     """
@@ -584,6 +604,24 @@ cdef class ParseOptions(_Weakrefable):
             return self.equals(other)
         except TypeError:
             return False
+
+    def __repr__(self):
+        return (f"<pyarrow.csv.ParseOptions "
+                f"delimiter={self.delimiter!r} "
+                f"quote_char={self.quote_char!r} "
+                f"double_quote={self.double_quote} "
+                f"escape_char={self.escape_char!r} "
+                f"newlines_in_values={self.newlines_in_values} "
+                f"ignore_empty_lines={self.ignore_empty_lines}>")
+
+    def __str__(self):
+        return (f"ParseOptions("
+                f"delimiter={self.delimiter!r}, "
+                f"quote_char={self.quote_char!r}, "
+                f"double_quote={self.double_quote}, "
+                f"escape_char={self.escape_char!r}, "
+                f"newlines_in_values={self.newlines_in_values}, "
+                f"ignore_empty_lines={self.ignore_empty_lines})")
 
 
 cdef class _ISO8601(_Weakrefable):
@@ -1108,6 +1146,38 @@ cdef class ConvertOptions(_Weakrefable):
         except TypeError:
             return False
 
+    def __repr__(self):
+        return (f"<pyarrow.csv.ConvertOptions "
+                f"check_utf8={self.check_utf8} "
+                f"column_types={self.column_types} "
+                f"null_values={self.null_values} "
+                f"true_values={self.true_values} "
+                f"false_values={self.false_values} "
+                f"decimal_point={self.decimal_point!r} "
+                f"strings_can_be_null={self.strings_can_be_null} "
+                f"quoted_strings_can_be_null={self.quoted_strings_can_be_null} "
+                f"include_columns={self.include_columns} "
+                f"include_missing_columns={self.include_missing_columns} "
+                f"auto_dict_encode={self.auto_dict_encode} "
+                f"auto_dict_max_cardinality={self.auto_dict_max_cardinality} "
+                f"timestamp_parsers={self.timestamp_parsers}>")
+
+    def __str__(self):
+        return (f"ConvertOptions("
+                f"check_utf8={self.check_utf8}, "
+                f"column_types={self.column_types}, "
+                f"null_values={self.null_values}, "
+                f"true_values={self.true_values}, "
+                f"false_values={self.false_values}, "
+                f"decimal_point={self.decimal_point!r}, "
+                f"strings_can_be_null={self.strings_can_be_null}, "
+                f"quoted_strings_can_be_null={self.quoted_strings_can_be_null}, "
+                f"include_columns={self.include_columns}, "
+                f"include_missing_columns={self.include_missing_columns}, "
+                f"auto_dict_encode={self.auto_dict_encode}, "
+                f"auto_dict_max_cardinality={self.auto_dict_max_cardinality}, "
+                f"timestamp_parsers={self.timestamp_parsers})")
+
 
 cdef _get_reader(input_file, ReadOptions read_options,
                  shared_ptr[CInputStream]* out):
@@ -1458,6 +1528,20 @@ cdef class WriteOptions(_Weakrefable):
 
     def validate(self):
         check_status(self.options.get().Validate())
+
+    def __repr__(self):
+        return (f"<pyarrow.csv.WriteOptions "
+                f"include_header={self.include_header} "
+                f"batch_size={self.batch_size} "
+                f"delimiter={self.delimiter!r} "
+                f"quoting_style='{self.quoting_style}'>")
+
+    def __str__(self):
+        return (f"WriteOptions("
+                f"include_header={self.include_header}, "
+                f"batch_size={self.batch_size}, "
+                f"delimiter={self.delimiter!r}, "
+                f"quoting_style='{self.quoting_style}')")
 
 
 cdef _get_write_options(WriteOptions write_options, CCSVWriteOptions* out):

--- a/python/pyarrow/_csv.pyx
+++ b/python/pyarrow/_csv.pyx
@@ -612,7 +612,8 @@ cdef class ParseOptions(_Weakrefable):
                 f"double_quote={self.double_quote}, "
                 f"escape_char={self.escape_char!r}, "
                 f"newlines_in_values={self.newlines_in_values}, "
-                f"ignore_empty_lines={self.ignore_empty_lines})>")
+                f"ignore_empty_lines={self.ignore_empty_lines}, "
+                f"invalid_row_handler={self.invalid_row_handler})>")
 
     def __str__(self):
         return (f"ParseOptions("
@@ -621,7 +622,8 @@ cdef class ParseOptions(_Weakrefable):
                 f"double_quote={self.double_quote}, "
                 f"escape_char={self.escape_char!r}, "
                 f"newlines_in_values={self.newlines_in_values}, "
-                f"ignore_empty_lines={self.ignore_empty_lines})")
+                f"ignore_empty_lines={self.ignore_empty_lines}, "
+                f"invalid_row_handler={self.invalid_row_handler})")
 
 
 cdef class _ISO8601(_Weakrefable):

--- a/python/pyarrow/_csv.pyx
+++ b/python/pyarrow/_csv.pyx
@@ -605,25 +605,21 @@ cdef class ParseOptions(_Weakrefable):
         except TypeError:
             return False
 
+    def _repr_base(self):
+        return (f"""
+delimiter={self.delimiter!r}
+quote_char={self.quote_char!r}
+double_quote={self.double_quote}
+escape_char={self.escape_char!r}
+newlines_in_values={self.newlines_in_values}
+ignore_empty_lines={self.ignore_empty_lines}
+invalid_row_handler={getattr(self.invalid_row_handler, '__name__', self.invalid_row_handler)}""")
+
     def __repr__(self):
-        return (f"<pyarrow.csv.ParseOptions("
-                f"delimiter={self.delimiter!r}, "
-                f"quote_char={self.quote_char!r}, "
-                f"double_quote={self.double_quote}, "
-                f"escape_char={self.escape_char!r}, "
-                f"newlines_in_values={self.newlines_in_values}, "
-                f"ignore_empty_lines={self.ignore_empty_lines}, "
-                f"invalid_row_handler={self.invalid_row_handler})>")
+        return (f"<pyarrow.csv.ParseOptions>({self._repr_base()})")
 
     def __str__(self):
-        return (f"ParseOptions("
-                f"delimiter={self.delimiter!r}, "
-                f"quote_char={self.quote_char!r}, "
-                f"double_quote={self.double_quote}, "
-                f"escape_char={self.escape_char!r}, "
-                f"newlines_in_values={self.newlines_in_values}, "
-                f"ignore_empty_lines={self.ignore_empty_lines}, "
-                f"invalid_row_handler={self.invalid_row_handler})")
+        return (f"ParseOptions({self._repr_base()})")
 
 
 cdef class _ISO8601(_Weakrefable):

--- a/python/pyarrow/_csv.pyx
+++ b/python/pyarrow/_csv.pyx
@@ -332,25 +332,21 @@ cdef class ReadOptions(_Weakrefable):
         except TypeError:
             return False
 
+    def _repr_base(self):
+        return (f"""
+use_threads={self.use_threads}
+block_size={self.block_size}
+skip_rows={self.skip_rows}
+skip_rows_after_names={self.skip_rows_after_names}
+column_names={self.column_names}
+autogenerate_column_names={self.autogenerate_column_names}
+encoding='{self.encoding}'""")
+
     def __repr__(self):
-        return (f"<pyarrow.csv.ReadOptions("
-                f"use_threads={self.use_threads}, "
-                f"block_size={self.block_size}, "
-                f"skip_rows={self.skip_rows}, "
-                f"skip_rows_after_names={self.skip_rows_after_names}, "
-                f"column_names={self.column_names}, "
-                f"autogenerate_column_names={self.autogenerate_column_names}, "
-                f"encoding='{self.encoding}')>")
+        return (f"<pyarrow.csv.ReadOptions>({self._repr_base()})")
 
     def __str__(self):
-        return (f"ReadOptions("
-                f"use_threads={self.use_threads}, "
-                f"block_size={self.block_size}, "
-                f"skip_rows={self.skip_rows}, "
-                f"skip_rows_after_names={self.skip_rows_after_names}, "
-                f"column_names={self.column_names}, "
-                f"autogenerate_column_names={self.autogenerate_column_names}, "
-                f"encoding='{self.encoding}')")
+        return (f"ReadOptions({self._repr_base()})")
 
 
 cdef class ParseOptions(_Weakrefable):

--- a/python/pyarrow/_csv.pyx
+++ b/python/pyarrow/_csv.pyx
@@ -613,7 +613,8 @@ double_quote={self.double_quote}
 escape_char={self.escape_char!r}
 newlines_in_values={self.newlines_in_values}
 ignore_empty_lines={self.ignore_empty_lines}
-invalid_row_handler={getattr(self.invalid_row_handler, '__name__', self.invalid_row_handler)}""")
+invalid_row_handler={getattr(self.invalid_row_handler, '__name__',
+                             self.invalid_row_handler)}""")
 
     def __repr__(self):
         return (f"<pyarrow.csv.ParseOptions>({self._repr_base()})")
@@ -1517,19 +1518,18 @@ cdef class WriteOptions(_Weakrefable):
     def validate(self):
         check_status(self.options.get().Validate())
 
+    def _repr_base(self):
+        return (f"""
+include_header={self.include_header}
+batch_size={self.batch_size}
+delimiter={self.delimiter!r}
+quoting_style='{self.quoting_style}'""")
+
     def __repr__(self):
-        return (f"<pyarrow.csv.WriteOptions("
-                f"include_header={self.include_header}, "
-                f"batch_size={self.batch_size}, "
-                f"delimiter={self.delimiter!r}, "
-                f"quoting_style='{self.quoting_style}')>")
+        return (f"<pyarrow.csv.WriteOptions>({self._repr_base()})")
 
     def __str__(self):
-        return (f"WriteOptions("
-                f"include_header={self.include_header}, "
-                f"batch_size={self.batch_size}, "
-                f"delimiter={self.delimiter!r}, "
-                f"quoting_style='{self.quoting_style}')")
+        return (f"WriteOptions({self._repr_base()})")
 
 
 cdef _get_write_options(WriteOptions write_options, CCSVWriteOptions* out):

--- a/python/pyarrow/_csv.pyx
+++ b/python/pyarrow/_csv.pyx
@@ -334,13 +334,13 @@ cdef class ReadOptions(_Weakrefable):
 
     def _repr_base(self):
         return (f"""
-use_threads={self.use_threads}
-block_size={self.block_size}
-skip_rows={self.skip_rows}
-skip_rows_after_names={self.skip_rows_after_names}
-column_names={self.column_names}
-autogenerate_column_names={self.autogenerate_column_names}
-encoding='{self.encoding}'""")
+    use_threads={self.use_threads},
+    block_size={self.block_size},
+    skip_rows={self.skip_rows},
+    skip_rows_after_names={self.skip_rows_after_names},
+    column_names={self.column_names},
+    autogenerate_column_names={self.autogenerate_column_names},
+    encoding={self.encoding!r}""")
 
     def __repr__(self):
         return (f"<pyarrow.csv.ReadOptions>({self._repr_base()})")
@@ -603,14 +603,14 @@ cdef class ParseOptions(_Weakrefable):
 
     def _repr_base(self):
         return (f"""
-delimiter={self.delimiter!r}
-quote_char={self.quote_char!r}
-double_quote={self.double_quote}
-escape_char={self.escape_char!r}
-newlines_in_values={self.newlines_in_values}
-ignore_empty_lines={self.ignore_empty_lines}
-invalid_row_handler={getattr(self.invalid_row_handler, '__name__',
-                             self.invalid_row_handler)}""")
+    delimiter={self.delimiter!r},
+    quote_char={self.quote_char!r},
+    double_quote={self.double_quote},
+    escape_char={self.escape_char!r},
+    newlines_in_values={self.newlines_in_values},
+    ignore_empty_lines={self.ignore_empty_lines},
+    invalid_row_handler={getattr(self.invalid_row_handler, '__name__',
+                                 self.invalid_row_handler)}""")
 
     def __repr__(self):
         return (f"<pyarrow.csv.ParseOptions>({self._repr_base()})")
@@ -1143,19 +1143,19 @@ cdef class ConvertOptions(_Weakrefable):
 
     def _repr_base(self):
         return (f"""
-check_utf8={self.check_utf8}
-column_types={self.column_types}
-null_values={self.null_values}
-true_values={self.true_values}
-false_values={self.false_values}
-decimal_point={self.decimal_point!r}
-strings_can_be_null={self.strings_can_be_null}
-quoted_strings_can_be_null={self.quoted_strings_can_be_null}
-include_columns={self.include_columns}
-include_missing_columns={self.include_missing_columns}
-auto_dict_encode={self.auto_dict_encode}
-auto_dict_max_cardinality={self.auto_dict_max_cardinality}
-timestamp_parsers={[str(i) for i in self.timestamp_parsers]}""")
+    check_utf8={self.check_utf8},
+    column_types={self.column_types},
+    null_values={self.null_values},
+    true_values={self.true_values},
+    false_values={self.false_values},
+    decimal_point={self.decimal_point!r},
+    strings_can_be_null={self.strings_can_be_null},
+    quoted_strings_can_be_null={self.quoted_strings_can_be_null},
+    include_columns={self.include_columns},
+    include_missing_columns={self.include_missing_columns},
+    auto_dict_encode={self.auto_dict_encode},
+    auto_dict_max_cardinality={self.auto_dict_max_cardinality},
+    timestamp_parsers={[str(i) for i in self.timestamp_parsers]}""")
 
     def __repr__(self):
         return (f"<pyarrow.csv.ConvertOptions>({self._repr_base()})")
@@ -1516,10 +1516,10 @@ cdef class WriteOptions(_Weakrefable):
 
     def _repr_base(self):
         return (f"""
-include_header={self.include_header}
-batch_size={self.batch_size}
-delimiter={self.delimiter!r}
-quoting_style='{self.quoting_style}'""")
+    include_header={self.include_header},
+    batch_size={self.batch_size},
+    delimiter={self.delimiter!r},
+    quoting_style={self.quoting_style!r}""")
 
     def __repr__(self):
         return (f"<pyarrow.csv.WriteOptions>({self._repr_base()})")

--- a/python/pyarrow/_json.pyx
+++ b/python/pyarrow/_json.pyx
@@ -106,14 +106,14 @@ cdef class ReadOptions(_Weakrefable):
             return False
 
     def __repr__(self):
-        return (f"<pyarrow.json.ReadOptions("
-                f"use_threads={self.use_threads}, "
-                f"block_size={self.block_size})>")
+        return (f"""<pyarrow.json.ReadOptions>(
+use_threads={self.use_threads}
+block_size={self.block_size})""")
 
     def __str__(self):
-        return (f"ReadOptions("
-                f"use_threads={self.use_threads}, "
-                f"block_size={self.block_size})")
+        return (f"""ReadOptions(
+use_threads={self.use_threads}
+block_size={self.block_size})""")
 
     @staticmethod
     cdef ReadOptions wrap(CJSONReadOptions options):
@@ -254,17 +254,17 @@ cdef class ParseOptions(_Weakrefable):
         except TypeError:
             return False
 
+    def _repr_base(self):
+        return (f"""
+explicit_schema={self.explicit_schema}
+newlines_in_values={self.newlines_in_values}
+unexpected_field_behavior='{self.unexpected_field_behavior}'""")
+
     def __repr__(self):
-        return (f"<pyarrow.json.ParseOptions("
-                f"explicit_schema={self.explicit_schema}, "
-                f"newlines_in_values={self.newlines_in_values}, "
-                f"unexpected_field_behavior='{self.unexpected_field_behavior}')>")
+        return (f"<pyarrow.json.ParseOptions>({self._repr_base()})")
 
     def __str__(self):
-        return (f"ParseOptions("
-                f"explicit_schema={self.explicit_schema}, "
-                f"newlines_in_values={self.newlines_in_values}, "
-                f"unexpected_field_behavior='{self.unexpected_field_behavior}')")
+        return (f"ParseOptions({self._repr_base()})")
 
     @staticmethod
     cdef ParseOptions wrap(CJSONParseOptions options):

--- a/python/pyarrow/_json.pyx
+++ b/python/pyarrow/_json.pyx
@@ -105,6 +105,16 @@ cdef class ReadOptions(_Weakrefable):
         except TypeError:
             return False
 
+    def __repr__(self):
+        return (f"<pyarrow.json.ReadOptions "
+                f"use_threads={self.use_threads} "
+                f"block_size={self.block_size}>")
+
+    def __str__(self):
+        return (f"ReadOptions("
+                f"use_threads={self.use_threads}, "
+                f"block_size={self.block_size})")
+
     @staticmethod
     cdef ReadOptions wrap(CJSONReadOptions options):
         out = ReadOptions()
@@ -243,6 +253,18 @@ cdef class ParseOptions(_Weakrefable):
             return self.equals(other)
         except TypeError:
             return False
+
+    def __repr__(self):
+        return (f"<pyarrow.json.ParseOptions "
+                f"explicit_schema={self.explicit_schema} "
+                f"newlines_in_values={self.newlines_in_values} "
+                f"unexpected_field_behavior='{self.unexpected_field_behavior}'>")
+
+    def __str__(self):
+        return (f"ParseOptions("
+                f"explicit_schema={self.explicit_schema}, "
+                f"newlines_in_values={self.newlines_in_values}, "
+                f"unexpected_field_behavior='{self.unexpected_field_behavior}')")
 
     @staticmethod
     cdef ParseOptions wrap(CJSONParseOptions options):

--- a/python/pyarrow/_json.pyx
+++ b/python/pyarrow/_json.pyx
@@ -106,9 +106,9 @@ cdef class ReadOptions(_Weakrefable):
             return False
 
     def __repr__(self):
-        return (f"<pyarrow.json.ReadOptions "
-                f"use_threads={self.use_threads} "
-                f"block_size={self.block_size}>")
+        return (f"<pyarrow.json.ReadOptions("
+                f"use_threads={self.use_threads}, "
+                f"block_size={self.block_size})>")
 
     def __str__(self):
         return (f"ReadOptions("
@@ -255,10 +255,10 @@ cdef class ParseOptions(_Weakrefable):
             return False
 
     def __repr__(self):
-        return (f"<pyarrow.json.ParseOptions "
-                f"explicit_schema={self.explicit_schema} "
-                f"newlines_in_values={self.newlines_in_values} "
-                f"unexpected_field_behavior='{self.unexpected_field_behavior}'>")
+        return (f"<pyarrow.json.ParseOptions("
+                f"explicit_schema={self.explicit_schema}, "
+                f"newlines_in_values={self.newlines_in_values}, "
+                f"unexpected_field_behavior='{self.unexpected_field_behavior}')>")
 
     def __str__(self):
         return (f"ParseOptions("

--- a/python/pyarrow/_json.pyx
+++ b/python/pyarrow/_json.pyx
@@ -107,13 +107,13 @@ cdef class ReadOptions(_Weakrefable):
 
     def __repr__(self):
         return (f"""<pyarrow.json.ReadOptions>(
-use_threads={self.use_threads}
-block_size={self.block_size})""")
+    use_threads={self.use_threads},
+    block_size={self.block_size})""")
 
     def __str__(self):
         return (f"""ReadOptions(
-use_threads={self.use_threads}
-block_size={self.block_size})""")
+    use_threads={self.use_threads},
+    block_size={self.block_size})""")
 
     @staticmethod
     cdef ReadOptions wrap(CJSONReadOptions options):
@@ -256,9 +256,9 @@ cdef class ParseOptions(_Weakrefable):
 
     def _repr_base(self):
         return (f"""
-explicit_schema={self.explicit_schema}
-newlines_in_values={self.newlines_in_values}
-unexpected_field_behavior='{self.unexpected_field_behavior}'""")
+    explicit_schema={self.explicit_schema},
+    newlines_in_values={self.newlines_in_values},
+    unexpected_field_behavior={self.unexpected_field_behavior!r}""")
 
     def __repr__(self):
         return (f"<pyarrow.json.ParseOptions>({self._repr_base()})")

--- a/python/pyarrow/tests/test_csv.py
+++ b/python/pyarrow/tests/test_csv.py
@@ -213,25 +213,18 @@ def test_read_options(pickle_module):
         opts.column_names = ('a', 'b')
         opts.validate()
 
-    expected_repr = ("<pyarrow.csv.ReadOptions("
-                     f"use_threads={opts.use_threads}, "
-                     f"block_size={opts.block_size}, "
-                     f"skip_rows={opts.skip_rows}, "
-                     f"skip_rows_after_names={opts.skip_rows_after_names}, "
-                     f"column_names={opts.column_names}, "
-                     f"autogenerate_column_names={opts.autogenerate_column_names}, "
-                     f"encoding='{opts.encoding}')>")
-    assert repr(opts) == expected_repr
+    expected_repr_inner = """
+use_threads=True
+block_size=1048576
+skip_rows=0
+skip_rows_after_names=0
+column_names=['a', 'b']
+autogenerate_column_names=True
+encoding='utf8'"""
 
-    expected_str = (f"ReadOptions("
-                    f"use_threads={opts.use_threads}, "
-                    f"block_size={opts.block_size}, "
-                    f"skip_rows={opts.skip_rows}, "
-                    f"skip_rows_after_names={opts.skip_rows_after_names}, "
-                    f"column_names={opts.column_names}, "
-                    f"autogenerate_column_names={opts.autogenerate_column_names}, "
-                    f"encoding='{opts.encoding}')")
-    assert str(opts) == expected_str
+    assert repr(opts) == f"<pyarrow.csv.ReadOptions>({expected_repr_inner})"
+    assert str(opts) == f"ReadOptions({expected_repr_inner})"
+
 
 
 def test_parse_options(pickle_module):

--- a/python/pyarrow/tests/test_csv.py
+++ b/python/pyarrow/tests/test_csv.py
@@ -213,6 +213,26 @@ def test_read_options(pickle_module):
         opts.column_names = ('a', 'b')
         opts.validate()
 
+    expected_repr = ("<pyarrow.csv.ReadOptions("
+                     f"use_threads={opts.use_threads}, "
+                     f"block_size={opts.block_size}, "
+                     f"skip_rows={opts.skip_rows}, "
+                     f"skip_rows_after_names={opts.skip_rows_after_names}, "
+                     f"column_names={opts.column_names}, "
+                     f"autogenerate_column_names={opts.autogenerate_column_names}, "
+                     f"encoding='{opts.encoding}')>")
+    assert repr(opts) == expected_repr
+
+    expected_str = (f"ReadOptions("
+                    f"use_threads={opts.use_threads}, "
+                    f"block_size={opts.block_size}, "
+                    f"skip_rows={opts.skip_rows}, "
+                    f"skip_rows_after_names={opts.skip_rows_after_names}, "
+                    f"column_names={opts.column_names}, "
+                    f"autogenerate_column_names={opts.autogenerate_column_names}, "
+                    f"encoding='{opts.encoding}')")
+    assert str(opts) == expected_str
+
 
 def test_parse_options(pickle_module):
     cls = ParseOptions
@@ -272,6 +292,24 @@ def test_parse_options(pickle_module):
         opts = cls()
         opts.escape_char = "\r"
         opts.validate()
+
+    expected_repr = ("<pyarrow.csv.ParseOptions("
+                     f"delimiter={opts.delimiter!r}, "
+                     f"quote_char={opts.quote_char!r}, "
+                     f"double_quote={opts.double_quote}, "
+                     f"escape_char={opts.escape_char!r}, "
+                     f"newlines_in_values={opts.newlines_in_values}, "
+                     f"ignore_empty_lines={opts.ignore_empty_lines})>")
+    assert repr(opts) == expected_repr
+
+    expected_str = (f"ParseOptions("
+                    f"delimiter={opts.delimiter!r}, "
+                    f"quote_char={opts.quote_char!r}, "
+                    f"double_quote={opts.double_quote}, "
+                    f"escape_char={opts.escape_char!r}, "
+                    f"newlines_in_values={opts.newlines_in_values}, "
+                    f"ignore_empty_lines={opts.ignore_empty_lines})")
+    assert str(opts) == expected_str
 
 
 def test_convert_options(pickle_module):
@@ -354,6 +392,38 @@ def test_convert_options(pickle_module):
     assert opts.auto_dict_max_cardinality == 999
     assert opts.timestamp_parsers == [ISO8601, '%Y-%m-%d']
 
+    expected_repr = ("<pyarrow.csv.ConvertOptions("
+                     f"check_utf8={opts.check_utf8}, "
+                     f"column_types={opts.column_types}, "
+                     f"null_values={opts.null_values}, "
+                     f"true_values={opts.true_values}, "
+                     f"false_values={opts.false_values}, "
+                     f"decimal_point={opts.decimal_point!r}, "
+                     f"strings_can_be_null={opts.strings_can_be_null}, "
+                     f"quoted_strings_can_be_null={opts.quoted_strings_can_be_null}, "
+                     f"include_columns={opts.include_columns}, "
+                     f"include_missing_columns={opts.include_missing_columns}, "
+                     f"auto_dict_encode={opts.auto_dict_encode}, "
+                     f"auto_dict_max_cardinality={opts.auto_dict_max_cardinality}, "
+                     f"timestamp_parsers={opts.timestamp_parsers})>")
+    assert repr(opts) == expected_repr
+
+    expected_str = (f"ConvertOptions("
+                    f"check_utf8={opts.check_utf8}, "
+                    f"column_types={opts.column_types}, "
+                    f"null_values={opts.null_values}, "
+                    f"true_values={opts.true_values}, "
+                    f"false_values={opts.false_values}, "
+                    f"decimal_point={opts.decimal_point!r}, "
+                    f"strings_can_be_null={opts.strings_can_be_null}, "
+                    f"quoted_strings_can_be_null={opts.quoted_strings_can_be_null}, "
+                    f"include_columns={opts.include_columns}, "
+                    f"include_missing_columns={opts.include_missing_columns}, "
+                    f"auto_dict_encode={opts.auto_dict_encode}, "
+                    f"auto_dict_max_cardinality={opts.auto_dict_max_cardinality}, "
+                    f"timestamp_parsers={opts.timestamp_parsers})")
+    assert str(opts) == expected_str
+
 
 def test_write_options():
     cls = WriteOptions
@@ -377,6 +447,21 @@ def test_write_options():
         opts = cls()
         opts.batch_size = 0
         opts.validate()
+
+    expected_repr = ("<pyarrow.csv.WriteOptions("
+                     f"include_header={opts.include_header}, "
+                     f"batch_size={opts.batch_size}, "
+                     f"delimiter={opts.delimiter!r}, "
+                     f"quoting_style='{opts.quoting_style}')>")
+    assert repr(opts) == expected_repr
+
+    # Test str
+    expected_str = (f"WriteOptions("
+                    f"include_header={opts.include_header}, "
+                    f"batch_size={opts.batch_size}, "
+                    f"delimiter={opts.delimiter!r}, "
+                    f"quoting_style='{opts.quoting_style}')")
+    assert str(opts) == expected_str
 
 
 class BaseTestCSV(abc.ABC):

--- a/python/pyarrow/tests/test_csv.py
+++ b/python/pyarrow/tests/test_csv.py
@@ -299,7 +299,8 @@ def test_parse_options(pickle_module):
                      f"double_quote={opts.double_quote}, "
                      f"escape_char={opts.escape_char!r}, "
                      f"newlines_in_values={opts.newlines_in_values}, "
-                     f"ignore_empty_lines={opts.ignore_empty_lines})>")
+                     f"ignore_empty_lines={opts.ignore_empty_lines}, "
+                     f"invalid_row_handler={opts.invalid_row_handler})>")
     assert repr(opts) == expected_repr
 
     expected_str = (f"ParseOptions("
@@ -308,7 +309,8 @@ def test_parse_options(pickle_module):
                     f"double_quote={opts.double_quote}, "
                     f"escape_char={opts.escape_char!r}, "
                     f"newlines_in_values={opts.newlines_in_values}, "
-                    f"ignore_empty_lines={opts.ignore_empty_lines})")
+                    f"ignore_empty_lines={opts.ignore_empty_lines}, "
+                    f"invalid_row_handler={opts.invalid_row_handler})")
     assert str(opts) == expected_str
 
 

--- a/python/pyarrow/tests/test_csv.py
+++ b/python/pyarrow/tests/test_csv.py
@@ -427,19 +427,14 @@ def test_write_options():
         opts.batch_size = 0
         opts.validate()
 
-    expected_repr = ("<pyarrow.csv.WriteOptions("
-                     f"include_header={opts.include_header}, "
-                     f"batch_size={opts.batch_size}, "
-                     f"delimiter={opts.delimiter!r}, "
-                     f"quoting_style='{opts.quoting_style}')>")
-    assert repr(opts) == expected_repr
+    expected_repr_inner = """
+include_header=True
+batch_size=0
+delimiter=','
+quoting_style='needed'"""
 
-    expected_str = (f"WriteOptions("
-                    f"include_header={opts.include_header}, "
-                    f"batch_size={opts.batch_size}, "
-                    f"delimiter={opts.delimiter!r}, "
-                    f"quoting_style='{opts.quoting_style}')")
-    assert str(opts) == expected_str
+    assert repr(opts) == f"<pyarrow.csv.WriteOptions>({expected_repr_inner})"
+    assert str(opts) == f"WriteOptions({expected_repr_inner})"
 
 
 class BaseTestCSV(abc.ABC):

--- a/python/pyarrow/tests/test_csv.py
+++ b/python/pyarrow/tests/test_csv.py
@@ -293,25 +293,17 @@ def test_parse_options(pickle_module):
         opts.escape_char = "\r"
         opts.validate()
 
-    expected_repr = ("<pyarrow.csv.ParseOptions("
-                     f"delimiter={opts.delimiter!r}, "
-                     f"quote_char={opts.quote_char!r}, "
-                     f"double_quote={opts.double_quote}, "
-                     f"escape_char={opts.escape_char!r}, "
-                     f"newlines_in_values={opts.newlines_in_values}, "
-                     f"ignore_empty_lines={opts.ignore_empty_lines}, "
-                     f"invalid_row_handler={opts.invalid_row_handler})>")
-    assert repr(opts) == expected_repr
+    expected_repr_inner = r"""
+delimiter=','
+quote_char='"'
+double_quote=True
+escape_char='\r'
+newlines_in_values=False
+ignore_empty_lines=True
+invalid_row_handler=None"""
 
-    expected_str = (f"ParseOptions("
-                    f"delimiter={opts.delimiter!r}, "
-                    f"quote_char={opts.quote_char!r}, "
-                    f"double_quote={opts.double_quote}, "
-                    f"escape_char={opts.escape_char!r}, "
-                    f"newlines_in_values={opts.newlines_in_values}, "
-                    f"ignore_empty_lines={opts.ignore_empty_lines}, "
-                    f"invalid_row_handler={opts.invalid_row_handler})")
-    assert str(opts) == expected_str
+    assert repr(opts) == f"<pyarrow.csv.ParseOptions>({expected_repr_inner})"
+    assert str(opts) == f"ParseOptions({expected_repr_inner})"
 
 
 def test_convert_options(pickle_module):

--- a/python/pyarrow/tests/test_csv.py
+++ b/python/pyarrow/tests/test_csv.py
@@ -226,7 +226,6 @@ encoding='utf8'"""
     assert str(opts) == f"ReadOptions({expected_repr_inner})"
 
 
-
 def test_parse_options(pickle_module):
     cls = ParseOptions
     skip_handler = InvalidRowHandler('skip')

--- a/python/pyarrow/tests/test_csv.py
+++ b/python/pyarrow/tests/test_csv.py
@@ -394,37 +394,22 @@ def test_convert_options(pickle_module):
     assert opts.auto_dict_max_cardinality == 999
     assert opts.timestamp_parsers == [ISO8601, '%Y-%m-%d']
 
-    expected_repr = ("<pyarrow.csv.ConvertOptions("
-                     f"check_utf8={opts.check_utf8}, "
-                     f"column_types={opts.column_types}, "
-                     f"null_values={opts.null_values}, "
-                     f"true_values={opts.true_values}, "
-                     f"false_values={opts.false_values}, "
-                     f"decimal_point={opts.decimal_point!r}, "
-                     f"strings_can_be_null={opts.strings_can_be_null}, "
-                     f"quoted_strings_can_be_null={opts.quoted_strings_can_be_null}, "
-                     f"include_columns={opts.include_columns}, "
-                     f"include_missing_columns={opts.include_missing_columns}, "
-                     f"auto_dict_encode={opts.auto_dict_encode}, "
-                     f"auto_dict_max_cardinality={opts.auto_dict_max_cardinality}, "
-                     f"timestamp_parsers={opts.timestamp_parsers})>")
-    assert repr(opts) == expected_repr
-
-    expected_str = (f"ConvertOptions("
-                    f"check_utf8={opts.check_utf8}, "
-                    f"column_types={opts.column_types}, "
-                    f"null_values={opts.null_values}, "
-                    f"true_values={opts.true_values}, "
-                    f"false_values={opts.false_values}, "
-                    f"decimal_point={opts.decimal_point!r}, "
-                    f"strings_can_be_null={opts.strings_can_be_null}, "
-                    f"quoted_strings_can_be_null={opts.quoted_strings_can_be_null}, "
-                    f"include_columns={opts.include_columns}, "
-                    f"include_missing_columns={opts.include_missing_columns}, "
-                    f"auto_dict_encode={opts.auto_dict_encode}, "
-                    f"auto_dict_max_cardinality={opts.auto_dict_max_cardinality}, "
-                    f"timestamp_parsers={opts.timestamp_parsers})")
-    assert str(opts) == expected_str
+    expected_repr_inner = ("""
+check_utf8=True
+column_types={'a': DataType(null)}
+null_values=['N', 'nn']
+true_values=['T', 'tt']
+false_values=['F', 'ff']
+decimal_point='.'
+strings_can_be_null=False
+quoted_strings_can_be_null=True
+include_columns=[]
+include_missing_columns=False
+auto_dict_encode=False
+auto_dict_max_cardinality=999
+timestamp_parsers=['ISO8601', '%Y-%m-%d']""")
+    assert repr(opts) == f"<pyarrow.csv.ConvertOptions>({expected_repr_inner})"
+    assert str(opts) == f"ConvertOptions({expected_repr_inner})"
 
 
 def test_write_options():

--- a/python/pyarrow/tests/test_csv.py
+++ b/python/pyarrow/tests/test_csv.py
@@ -455,7 +455,6 @@ def test_write_options():
                      f"quoting_style='{opts.quoting_style}')>")
     assert repr(opts) == expected_repr
 
-    # Test str
     expected_str = (f"WriteOptions("
                     f"include_header={opts.include_header}, "
                     f"batch_size={opts.batch_size}, "

--- a/python/pyarrow/tests/test_csv.py
+++ b/python/pyarrow/tests/test_csv.py
@@ -214,13 +214,13 @@ def test_read_options(pickle_module):
         opts.validate()
 
     expected_repr_inner = """
-use_threads=True
-block_size=1048576
-skip_rows=0
-skip_rows_after_names=0
-column_names=['a', 'b']
-autogenerate_column_names=True
-encoding='utf8'"""
+    use_threads=True,
+    block_size=1048576,
+    skip_rows=0,
+    skip_rows_after_names=0,
+    column_names=['a', 'b'],
+    autogenerate_column_names=True,
+    encoding='utf8'"""
 
     assert repr(opts) == f"<pyarrow.csv.ReadOptions>({expected_repr_inner})"
     assert str(opts) == f"ReadOptions({expected_repr_inner})"
@@ -286,13 +286,13 @@ def test_parse_options(pickle_module):
         opts.validate()
 
     expected_repr_inner = r"""
-delimiter=','
-quote_char='"'
-double_quote=True
-escape_char='\r'
-newlines_in_values=False
-ignore_empty_lines=True
-invalid_row_handler=None"""
+    delimiter=',',
+    quote_char='"',
+    double_quote=True,
+    escape_char='\r',
+    newlines_in_values=False,
+    ignore_empty_lines=True,
+    invalid_row_handler=None"""
 
     assert repr(opts) == f"<pyarrow.csv.ParseOptions>({expected_repr_inner})"
     assert str(opts) == f"ParseOptions({expected_repr_inner})"
@@ -379,19 +379,19 @@ def test_convert_options(pickle_module):
     assert opts.timestamp_parsers == [ISO8601, '%Y-%m-%d']
 
     expected_repr_inner = ("""
-check_utf8=True
-column_types={'a': DataType(null)}
-null_values=['N', 'nn']
-true_values=['T', 'tt']
-false_values=['F', 'ff']
-decimal_point='.'
-strings_can_be_null=False
-quoted_strings_can_be_null=True
-include_columns=[]
-include_missing_columns=False
-auto_dict_encode=False
-auto_dict_max_cardinality=999
-timestamp_parsers=['ISO8601', '%Y-%m-%d']""")
+    check_utf8=True,
+    column_types={'a': DataType(null)},
+    null_values=['N', 'nn'],
+    true_values=['T', 'tt'],
+    false_values=['F', 'ff'],
+    decimal_point='.',
+    strings_can_be_null=False,
+    quoted_strings_can_be_null=True,
+    include_columns=[],
+    include_missing_columns=False,
+    auto_dict_encode=False,
+    auto_dict_max_cardinality=999,
+    timestamp_parsers=['ISO8601', '%Y-%m-%d']""")
     assert repr(opts) == f"<pyarrow.csv.ConvertOptions>({expected_repr_inner})"
     assert str(opts) == f"ConvertOptions({expected_repr_inner})"
 
@@ -420,10 +420,10 @@ def test_write_options():
         opts.validate()
 
     expected_repr_inner = """
-include_header=True
-batch_size=0
-delimiter=','
-quoting_style='needed'"""
+    include_header=True,
+    batch_size=0,
+    delimiter=',',
+    quoting_style='needed'"""
 
     assert repr(opts) == f"<pyarrow.csv.WriteOptions>({expected_repr_inner})"
     assert str(opts) == f"WriteOptions({expected_repr_inner})"

--- a/python/pyarrow/tests/test_json.py
+++ b/python/pyarrow/tests/test_json.py
@@ -80,6 +80,16 @@ def test_read_options(pickle_module):
     assert opts.block_size == 1234
     assert opts.use_threads is False
 
+    expected_repr = ("<pyarrow.json.ReadOptions("
+                     f"use_threads={opts.use_threads}, "
+                     f"block_size={opts.block_size})>")
+    assert repr(opts) == expected_repr
+
+    expected_str = (f"ReadOptions("
+                    f"use_threads={opts.use_threads}, "
+                    f"block_size={opts.block_size})")
+    assert str(opts) == expected_str
+
     check_options_class_pickling(cls, pickler=pickle_module,
                                  block_size=1234,
                                  use_threads=False)
@@ -93,6 +103,18 @@ def test_parse_options(pickle_module):
 
     opts.newlines_in_values = True
     assert opts.newlines_in_values is True
+
+    expected_repr = ("<pyarrow.json.ParseOptions("
+                     f"explicit_schema={opts.explicit_schema}, "
+                     f"newlines_in_values={opts.newlines_in_values}, "
+                     f"unexpected_field_behavior='{opts.unexpected_field_behavior}')>")
+    assert repr(opts) == expected_repr
+
+    expected_str = (f"ParseOptions("
+                    f"explicit_schema={opts.explicit_schema}, "
+                    f"newlines_in_values={opts.newlines_in_values}, "
+                    f"unexpected_field_behavior='{opts.unexpected_field_behavior}')")
+    assert str(opts) == expected_str
 
     schema = pa.schema([pa.field('foo', pa.int32())])
     opts.explicit_schema = schema

--- a/python/pyarrow/tests/test_json.py
+++ b/python/pyarrow/tests/test_json.py
@@ -80,15 +80,12 @@ def test_read_options(pickle_module):
     assert opts.block_size == 1234
     assert opts.use_threads is False
 
-    expected_repr = ("<pyarrow.json.ReadOptions("
-                     f"use_threads={opts.use_threads}, "
-                     f"block_size={opts.block_size})>")
-    assert repr(opts) == expected_repr
+    expected_repr_inner = """
+use_threads=False
+block_size=1234"""
 
-    expected_str = (f"ReadOptions("
-                    f"use_threads={opts.use_threads}, "
-                    f"block_size={opts.block_size})")
-    assert str(opts) == expected_str
+    assert repr(opts) == f"<pyarrow.json.ReadOptions>({expected_repr_inner})"
+    assert str(opts) == f"ReadOptions({expected_repr_inner})"
 
     check_options_class_pickling(cls, pickler=pickle_module,
                                  block_size=1234,
@@ -104,17 +101,13 @@ def test_parse_options(pickle_module):
     opts.newlines_in_values = True
     assert opts.newlines_in_values is True
 
-    expected_repr = ("<pyarrow.json.ParseOptions("
-                     f"explicit_schema={opts.explicit_schema}, "
-                     f"newlines_in_values={opts.newlines_in_values}, "
-                     f"unexpected_field_behavior='{opts.unexpected_field_behavior}')>")
-    assert repr(opts) == expected_repr
+    expected_repr_inner = """
+explicit_schema=None
+newlines_in_values=True
+unexpected_field_behavior='infer'"""
 
-    expected_str = (f"ParseOptions("
-                    f"explicit_schema={opts.explicit_schema}, "
-                    f"newlines_in_values={opts.newlines_in_values}, "
-                    f"unexpected_field_behavior='{opts.unexpected_field_behavior}')")
-    assert str(opts) == expected_str
+    assert repr(opts) == f"<pyarrow.json.ParseOptions>({expected_repr_inner})"
+    assert str(opts) == f"ParseOptions({expected_repr_inner})"
 
     schema = pa.schema([pa.field('foo', pa.int32())])
     opts.explicit_schema = schema

--- a/python/pyarrow/tests/test_json.py
+++ b/python/pyarrow/tests/test_json.py
@@ -81,8 +81,8 @@ def test_read_options(pickle_module):
     assert opts.use_threads is False
 
     expected_repr_inner = """
-use_threads=False
-block_size=1234"""
+    use_threads=False,
+    block_size=1234"""
 
     assert repr(opts) == f"<pyarrow.json.ReadOptions>({expected_repr_inner})"
     assert str(opts) == f"ReadOptions({expected_repr_inner})"
@@ -102,9 +102,9 @@ def test_parse_options(pickle_module):
     assert opts.newlines_in_values is True
 
     expected_repr_inner = """
-explicit_schema=None
-newlines_in_values=True
-unexpected_field_behavior='infer'"""
+    explicit_schema=None,
+    newlines_in_values=True,
+    unexpected_field_behavior='infer'"""
 
     assert repr(opts) == f"<pyarrow.json.ParseOptions>({expected_repr_inner})"
     assert str(opts) == f"ParseOptions({expected_repr_inner})"


### PR DESCRIPTION
### Rationale for this change

CSV and JSON options lack a nice repr/str dunder method

### What changes are included in this PR?

Add both these methods

### Are these changes tested?

Will be once it's ready for review

### Are there any user-facing changes?

No
* GitHub Issue: #47389