### PR TITLE
GH-47402: [CI][Dev] Fix shellcheck errors in the ci/scripts/python_test_emscripten.sh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -342,6 +342,7 @@ repos:
           ?^ci/scripts/python_build\.sh$|
           ?^ci/scripts/python_sdist_build\.sh$|
           ?^ci/scripts/python_sdist_test\.sh$|
+          ?^ci/scripts/python_test_emscripten\.sh$|
           ?^ci/scripts/python_wheel_unix_test\.sh$|
           ?^ci/scripts/r_build\.sh$|
           ?^ci/scripts/r_revdepcheck\.sh$|

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -342,7 +342,6 @@ repos:
           ?^ci/scripts/python_build\.sh$|
           ?^ci/scripts/python_sdist_build\.sh$|
           ?^ci/scripts/python_sdist_test\.sh$|
-          ?^ci/scripts/python_test_emscripten\.sh$|
           ?^ci/scripts/python_wheel_unix_test\.sh$|
           ?^ci/scripts/r_build\.sh$|
           ?^ci/scripts/r_revdepcheck\.sh$|

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -332,6 +332,7 @@ repos:
           ?^ci/scripts/python_build\.sh$|
           ?^ci/scripts/python_sdist_build\.sh$|
           ?^ci/scripts/python_sdist_test\.sh$|
+          ?^ci/scripts/python_test_emscripten\.sh$|
           ?^ci/scripts/python_wheel_unix_test\.sh$|
           ?^ci/scripts/python_test_type_annotations\.sh$|
           ?^ci/scripts/python_test\.sh$|

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -332,7 +332,6 @@ repos:
           ?^ci/scripts/python_build\.sh$|
           ?^ci/scripts/python_sdist_build\.sh$|
           ?^ci/scripts/python_sdist_test\.sh$|
-          ?^ci/scripts/python_test_emscripten\.sh$|
           ?^ci/scripts/python_wheel_unix_test\.sh$|
           ?^ci/scripts/python_test_type_annotations\.sh$|
           ?^ci/scripts/python_test\.sh$|

--- a/ci/scripts/python_test_emscripten.sh
+++ b/ci/scripts/python_test_emscripten.sh
@@ -25,14 +25,15 @@ set -ex
 build_dir=${1}/python
 pyodide_dist_dir=${2}
 
-cd ${build_dir}
+cd "${build_dir}"
 
 # note: this uses the newest wheel in dist
+# shellcheck disable=SC2012
 pyodide_wheel=$(ls -t dist/pyarrow*.whl | head -1)
 
 echo "-------------- Running emscripten tests in Node ----------------------"
-python scripts/run_emscripten_tests.py ${pyodide_wheel} --dist-dir=${pyodide_dist_dir} --runtime=node
+python scripts/run_emscripten_tests.py "${pyodide_wheel}" --dist-dir="${pyodide_dist_dir}" --runtime=node
 
 echo "-------------- Running emscripten tests in Chrome --------------------"
-python scripts/run_emscripten_tests.py ${pyodide_wheel} --dist-dir=${pyodide_dist_dir} --runtime=chrome
+python scripts/run_emscripten_tests.py "${pyodide_wheel}" --dist-dir="${pyodide_dist_dir}" --runtime=chrome
 

--- a/ci/scripts/python_test_emscripten.sh
+++ b/ci/scripts/python_test_emscripten.sh
@@ -25,15 +25,14 @@ set -ex
 build_dir=${1}/python
 pyodide_dist_dir=${2}
 
-cd "${build_dir}"
+cd ${build_dir}
 
 # note: this uses the newest wheel in dist
-# shellcheck disable=SC2012
 pyodide_wheel=$(ls -t dist/pyarrow*.whl | head -1)
 
 echo "-------------- Running emscripten tests in Node ----------------------"
-python scripts/run_emscripten_tests.py "${pyodide_wheel}" --dist-dir="${pyodide_dist_dir}" --runtime=node
+python scripts/run_emscripten_tests.py ${pyodide_wheel} --dist-dir=${pyodide_dist_dir} --runtime=node
 
 echo "-------------- Running emscripten tests in Chrome --------------------"
-python scripts/run_emscripten_tests.py "${pyodide_wheel}" --dist-dir="${pyodide_dist_dir}" --runtime=chrome
+python scripts/run_emscripten_tests.py ${pyodide_wheel} --dist-dir=${pyodide_dist_dir} --runtime=chrome
 


### PR DESCRIPTION
### Rationale for this change

This is the sub issue #44748.

* SC2086: Double quote to prevent globbing and word splitting
* SC2012: Use find instead of ls to better handle non-alphanumeric filenames

```
shellcheck ci/scripts/python_test_emscripten.sh

In ci/scripts/python_test_emscripten.sh line 28:
cd ${build_dir}
   ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
cd "${build_dir}"


In ci/scripts/python_test_emscripten.sh line 31:
pyodide_wheel=$(ls -t dist/pyarrow*.whl | head -1)
                ^---------------------^ SC2012 (info): Use find instead of ls to better handle non-alphanumeric filenames.


In ci/scripts/python_test_emscripten.sh line 34:
python scripts/run_emscripten_tests.py ${pyodide_wheel} --dist-dir=${pyodide_dist_dir} --runtime=node
                                       ^--------------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                                                   ^-----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
python scripts/run_emscripten_tests.py "${pyodide_wheel}" --dist-dir="${pyodide_dist_dir}" --runtime=node


In ci/scripts/python_test_emscripten.sh line 37:
python scripts/run_emscripten_tests.py ${pyodide_wheel} --dist-dir=${pyodide_dist_dir} --runtime=chrome
                                       ^--------------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                                                   ^-----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean:
python scripts/run_emscripten_tests.py "${pyodide_wheel}" --dist-dir="${pyodide_dist_dir}" --runtime=chrome

For more information:
  https://www.shellcheck.net/wiki/SC2012 -- Use find instead of ls to better ...
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
```

### What changes are included in this PR?

* SC2086: Quote variables.
* SC2012: skip shellcheck.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #47402