### PR TITLE
GH-47404: [Ruby] Remove needless `require "extpp/setup"`

### DIFF
--- a/ruby/red-arrow/lib/arrow/ruby.rb
+++ b/ruby/red-arrow/lib/arrow/ruby.rb
@@ -15,7 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-require "extpp/setup"
 require "gio2"
 
 require_relative "loader"


### PR DESCRIPTION
### Rationale for this change

It's no longer needed with recent extpp.

### What changes are included in this PR?

Remove needless `require "extpp/setup"`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #47404