### PR TITLE
GH-26727: [C++][Flight] Use ipc::RecordBatchWriter with custom IpcPayloadWriter for TransportMessageWriter (DoExchange)

### DIFF
--- a/cpp/src/arrow/flight/transport_server.cc
+++ b/cpp/src/arrow/flight/transport_server.cc
@@ -228,7 +228,9 @@ class TransportMessageWriter final : public FlightMessageWriter {
     payload.app_metadata = app_metadata;
     ARROW_ASSIGN_OR_RAISE(auto success, stream_->WriteData(payload));
     if (!success) {
-      return Close();
+      ARROW_RETURN_NOT_OK(Close());
+      return MakeFlightError(FlightStatusCode::Internal,
+                             "Could not write metadata to stream (client disconnect?)");
     }
     // Those messages are not written through the batch writer,
     // count them separately to include them in the stats.

--- a/cpp/src/arrow/flight/transport_server.cc
+++ b/cpp/src/arrow/flight/transport_server.cc
@@ -163,7 +163,9 @@ class TransportMessageReader final : public FlightMessageReader {
 
 /// \brief An IpcPayloadWriter for ServerDataStream.
 ///
-/// TODO: Fill details
+/// To support app_metadata and reuse the existing IPC infrastructure,
+/// this takes a pointer to a buffer to be combined with the IPC
+/// payload when writing a Flight payload.
 class TransportMessagePayloadWriter : public ipc::internal::IpcPayloadWriter {
  public:
   TransportMessagePayloadWriter(ServerDataStream* stream,
@@ -223,15 +225,15 @@ class TransportMessageWriter final : public FlightMessageWriter {
   }
 
   Status WriteMetadata(std::shared_ptr<Buffer> app_metadata) override {
-    FlightPayload payload;
+    FlightPayload payload{};
     payload.app_metadata = app_metadata;
     ARROW_ASSIGN_OR_RAISE(auto success, stream_->WriteData(payload));
-    // Those messages are not written through the batch writer,
-    // count them separately for stats.
-    extra_metadata_messages_++;
     if (!success) {
       return Close();
     }
+    // Those messages are not written through the batch writer,
+    // count them separately for stats.
+    extra_metadata_messages_++;
     return Status::OK();
   }
 

--- a/cpp/src/arrow/flight/transport_server.cc
+++ b/cpp/src/arrow/flight/transport_server.cc
@@ -182,8 +182,9 @@ class TransportMessagePayloadWriter : public ipc::internal::IpcPayloadWriter {
     }
     ARROW_ASSIGN_OR_RAISE(auto success, stream_->WriteData(payload));
     if (!success) {
-      return arrow::Status(arrow::StatusCode::IOError,
-                           "Could not write record batch to stream");
+      return MakeFlightError(
+          FlightStatusCode::Internal,
+          "Could not write record batch to stream (client disconnect?)");
     }
     return arrow::Status::OK();
   }

--- a/cpp/src/arrow/flight/transport_server.cc
+++ b/cpp/src/arrow/flight/transport_server.cc
@@ -232,8 +232,8 @@ class TransportMessageWriter final : public FlightMessageWriter {
       return Close();
     }
     // Those messages are not written through the batch writer,
-    // count them separately for stats.
-    extra_metadata_messages_++;
+    // count them separately to include them in the stats.
+    extra_messages_++;
     return Status::OK();
   }
 
@@ -258,7 +258,7 @@ class TransportMessageWriter final : public FlightMessageWriter {
   ipc::WriteStats stats() const override {
     ARROW_CHECK_NE(batch_writer_, nullptr);
     auto write_stats = batch_writer_->stats();
-    write_stats.num_messages += extra_metadata_messages_;
+    write_stats.num_messages += extra_messages_;
     return write_stats;
   }
 
@@ -275,7 +275,7 @@ class TransportMessageWriter final : public FlightMessageWriter {
   std::shared_ptr<Buffer> app_metadata_;
   ::arrow::ipc::IpcWriteOptions ipc_options_;
   bool started_ = false;
-  int64_t extra_metadata_messages_ = 0;
+  int64_t extra_messages_ = 0;
 };
 
 /// \brief Adapt TransportDataStream to the FlightMetadataWriter

--- a/python/pyarrow/tests/test_flight.py
+++ b/python/pyarrow/tests/test_flight.py
@@ -2548,6 +2548,7 @@ def test_flight_dictionary_deltas_do_exchange():
 
                 options = pa.ipc.IpcWriteOptions(emit_dictionary_deltas=True)
                 writer.begin(expected_table.schema, options=options)
+                # TODO: GH-47422: Inspect ReaderStats once exposed and validate deltas
                 writer.write_table(expected_table)
 
     with DeltaFlightServer() as server, \
@@ -2569,4 +2570,5 @@ def test_flight_dictionary_deltas_do_exchange():
             writer.done_writing()
             received_table = reader.read_all()
 
+        # TODO: GH-47422: Inspect ReaderStats once exposed and validate deltas
         assert received_table.equals(expected_table)

--- a/python/pyarrow/tests/test_flight.py
+++ b/python/pyarrow/tests/test_flight.py
@@ -114,12 +114,12 @@ def simple_ints_table():
 
 def simple_dicts_table():
     dict_values = pa.array(["foo", "baz", "quux"], type=pa.utf8())
-    new_dict_values = pa.array(["bar", "qux"], type=pa.utf8())
+    new_dict_values = pa.array(["foo", "baz", "quux", "new"], type=pa.utf8())
     data = [
         pa.chunked_array([
             pa.DictionaryArray.from_arrays([1, 0, None], dict_values),
             pa.DictionaryArray.from_arrays([2, 1], dict_values),
-            pa.DictionaryArray.from_arrays([0, 1], new_dict_values)
+            pa.DictionaryArray.from_arrays([0, 3], new_dict_values)
         ])
     ]
     return pa.Table.from_arrays(data, names=['some_dicts'])


### PR DESCRIPTION
### Rationale for this change

The Flight Server DoExchange method currently does not support Dictionary replacement or Dictionary Deltas, similar to how the client currently behaves or how we do for DoGet we should use an `ipc::RecordBatchWriter` with a custom `IpcPayloadWriter` instead of reimplementing Dictionary Replacement / Deltas logic.

### What changes are included in this PR?

Removes manually generation of individual ipc Payloads and uses an `ipc::RecordBatchWriter` and a custom  `TransportMessagePayloadWriter` to modify the `IpcPayloads` into `FlightPayloads`.

### Are these changes tested?

Yes, existing tests cover the DoExchange functionality and new test for Python has been added where Dictionary deltas are being send via DoExchange. The test was failing before this change because the dictionary wasn't updated:
```python
            received_table = reader.read_all()
            expected_table = simple_dicts_table()
>           assert received_table.equals(expected_table)
E           assert False
E            +  where False = equals(pyarrow.Table\nsome_dicts: dictionary<values=string, indices=int64, ordered=0>\n----\nsome_dicts: [  -- dictionary:\n["foo... -- dictionary:\n["foo","baz","quux"]  -- indices:\n[2,1],  -- dictionary:\n["foo","baz","quux","new"]  -- indices:\n[0,3]])
E            +    where equals = pyarrow.Table\nsome_dicts: dictionary<values=string, indices=int64, ordered=0>\n----\nsome_dicts: [  -- dictionary:\n["foo...ull],  -- dictionary:\n["foo","baz","quux"]  -- indices:\n[2,1],  -- dictionary:\n["foo","baz","quux"]  -- indices:\n[0,3]].equals

pyarrow/tests/test_flight.py:2596: AssertionError
================================================================================== short test summary info ===================================================================================
FAILED pyarrow/tests/test_flight.py::test_flight_dictionary_deltas_do_exchange - assert False

```

### Are there any user-facing changes?

No, only that the expected dictionary replacement/deltas will work for DoExchange.

* GitHub Issue: #26727