### PR TITLE
GH-47412: [C++] Use inlineshidden visibility in Meson configuration

### DIFF
--- a/cpp/src/arrow/acero/meson.build
+++ b/cpp/src/arrow/acero/meson.build
@@ -81,7 +81,7 @@ arrow_acero_lib = library(
     'arrow-acero',
     sources: arrow_acero_srcs,
     dependencies: [arrow_compute_dep, arrow_dep, threads_dep],
-    gnu_symbol_visibility: 'hidden',
+    gnu_symbol_visibility: 'inlineshidden',
 )
 
 arrow_acero_dep = declare_dependency(link_with: [arrow_acero_lib])

--- a/cpp/src/arrow/flight/meson.build
+++ b/cpp/src/arrow/flight/meson.build
@@ -118,6 +118,7 @@ arrow_flight = library(
         thread_dep,
     ],
     cpp_args: '-DARROW_FLIGHT_EXPORTING',
+    gnu_symbol_visibility: 'inlineshidden',
 )
 
 arrow_flight_dep = declare_dependency(
@@ -135,7 +136,7 @@ if needs_testing
             'test_util.cc',
         ],
         dependencies: [arrow_test_dep, arrow_flight_dep, thread_dep],
-        gnu_symbol_visibility: 'hidden',
+        gnu_symbol_visibility: 'inlineshidden',
     )
 
     arrow_flight_test_dep = declare_dependency(

--- a/cpp/src/arrow/flight/meson.build
+++ b/cpp/src/arrow/flight/meson.build
@@ -52,6 +52,22 @@ fs = import('fs')
 protoc = find_program('protoc')
 
 flight_proto_path = fs.parent(meson.project_source_root()) / 'format'
+
+# To ensure messages from proto files are created correctly, we need to
+# pass in dllexport_decl=<...> . Unfortunately, it doesn't appear that we
+# can just pass in dllexport_decl=ARROW_FLIGHT_EXPORT, as the visibility
+# macro won't be easily available to the generated proto file. See also
+# https://github.com/protocolbuffers/protobuf/issues/19422
+if cpp_compiler.get_id() == 'msvc'
+    if get_option('default_library') != 'static'
+        proto_visibility = 'dllexport_decl=__declspec(dllexport):'
+    else
+        proto_visibility = ''
+    endif
+else
+    proto_visibility = 'dllexport_decl=__attribute__((visibility("default"))):'
+endif
+
 flight_proto_files = custom_target(
     'arrow-flight-proto-files',
     input: [flight_proto_path / 'Flight.proto'],
@@ -59,7 +75,7 @@ flight_proto_files = custom_target(
     command: [
         protoc,
         '--proto_path=' + flight_proto_path,
-        '--cpp_out=' + meson.current_build_dir(),
+        '--cpp_out=@0@@1@'.format(proto_visibility, meson.current_build_dir()),
         '@INPUT@',
     ],
 )
@@ -117,7 +133,8 @@ arrow_flight = library(
         abseil_sync_dep,
         thread_dep,
     ],
-    cpp_args: '-DARROW_FLIGHT_EXPORTING',
+    cpp_shared_args: ['-DARROW_FLIGHT_EXPORTING'],
+    cpp_static_args: ['-DARROW_FLIGHT_STATIC'],
     gnu_symbol_visibility: 'inlineshidden',
 )
 
@@ -136,6 +153,8 @@ if needs_testing
             'test_util.cc',
         ],
         dependencies: [arrow_test_dep, arrow_flight_dep, thread_dep],
+        cpp_shared_args: ['-DARROW_FLIGHT_EXPORTING'],
+        cpp_static_args: ['-DARROW_FLIGHT_STATIC'],
         gnu_symbol_visibility: 'inlineshidden',
     )
 

--- a/cpp/src/arrow/flight/serialization_internal.h
+++ b/cpp/src/arrow/flight/serialization_internal.h
@@ -99,69 +99,86 @@ Status UnpackProtoAction(const Action& action, google::protobuf::Message* out);
 
 // These functions depend on protobuf types which are not exported in the Flight DLL.
 
-Status FromProto(const google::protobuf::Timestamp& pb_timestamp, Timestamp* timestamp);
-Status FromProto(const pb::ActionType& pb_type, ActionType* type);
-Status FromProto(const pb::Action& pb_action, Action* action);
-Status FromProto(const pb::Result& pb_result, Result* result);
-Status FromProto(const pb::CancelFlightInfoResult& pb_result,
-                 CancelFlightInfoResult* result);
-Status FromProto(const pb::Criteria& pb_criteria, Criteria* criteria);
-Status FromProto(const pb::Location& pb_location, Location* location);
-Status FromProto(const pb::Ticket& pb_ticket, Ticket* ticket);
-Status FromProto(const pb::FlightData& pb_data, FlightDescriptor* descriptor,
-                 std::unique_ptr<ipc::Message>* message);
-Status FromProto(const pb::FlightDescriptor& pb_descr, FlightDescriptor* descr);
-Status FromProto(const pb::FlightEndpoint& pb_endpoint, FlightEndpoint* endpoint);
-Status FromProto(const pb::RenewFlightEndpointRequest& pb_request,
-                 RenewFlightEndpointRequest* request);
-Status FromProto(const pb::FlightInfo& pb_info, FlightInfo::Data* info);
-Status FromProto(const pb::FlightInfo& pb_info, std::unique_ptr<FlightInfo>* info);
-Status FromProto(const pb::PollInfo& pb_info, PollInfo* info);
-Status FromProto(const pb::PollInfo& pb_info, std::unique_ptr<PollInfo>* info);
-Status FromProto(const pb::CancelFlightInfoRequest& pb_request,
-                 CancelFlightInfoRequest* request);
-Status FromProto(const pb::SchemaResult& pb_result, SchemaResult* result);
-Status FromProto(const pb::BasicAuth& pb_basic_auth, BasicAuth* info);
-Status FromProto(const pb::SetSessionOptionsRequest& pb_request,
-                 SetSessionOptionsRequest* request);
-Status FromProto(const pb::SetSessionOptionsResult& pb_result,
-                 SetSessionOptionsResult* result);
-Status FromProto(const pb::GetSessionOptionsRequest& pb_request,
-                 GetSessionOptionsRequest* request);
-Status FromProto(const pb::GetSessionOptionsResult& pb_result,
-                 GetSessionOptionsResult* result);
-Status FromProto(const pb::CloseSessionRequest& pb_request, CloseSessionRequest* request);
-Status FromProto(const pb::CloseSessionResult& pb_result, CloseSessionResult* result);
+ARROW_FLIGHT_EXPORT Status FromProto(const google::protobuf::Timestamp& pb_timestamp,
+                                     Timestamp* timestamp);
+ARROW_FLIGHT_EXPORT Status FromProto(const pb::ActionType& pb_type, ActionType* type);
+ARROW_FLIGHT_EXPORT Status FromProto(const pb::Action& pb_action, Action* action);
+ARROW_FLIGHT_EXPORT Status FromProto(const pb::Result& pb_result, Result* result);
+ARROW_FLIGHT_EXPORT Status FromProto(const pb::CancelFlightInfoResult& pb_result,
+                                     CancelFlightInfoResult* result);
+ARROW_FLIGHT_EXPORT Status FromProto(const pb::Criteria& pb_criteria, Criteria* criteria);
+ARROW_FLIGHT_EXPORT Status FromProto(const pb::Location& pb_location, Location* location);
+ARROW_FLIGHT_EXPORT Status FromProto(const pb::Ticket& pb_ticket, Ticket* ticket);
+ARROW_FLIGHT_EXPORT Status FromProto(const pb::FlightData& pb_data,
+                                     FlightDescriptor* descriptor,
+                                     std::unique_ptr<ipc::Message>* message);
+ARROW_FLIGHT_EXPORT Status FromProto(const pb::FlightDescriptor& pb_descr,
+                                     FlightDescriptor* descr);
+ARROW_FLIGHT_EXPORT Status FromProto(const pb::FlightEndpoint& pb_endpoint,
+                                     FlightEndpoint* endpoint);
+ARROW_FLIGHT_EXPORT Status FromProto(const pb::RenewFlightEndpointRequest& pb_request,
+                                     RenewFlightEndpointRequest* request);
+ARROW_FLIGHT_EXPORT Status FromProto(const pb::FlightInfo& pb_info,
+                                     FlightInfo::Data* info);
+ARROW_FLIGHT_EXPORT Status FromProto(const pb::FlightInfo& pb_info,
+                                     std::unique_ptr<FlightInfo>* info);
+ARROW_FLIGHT_EXPORT Status FromProto(const pb::PollInfo& pb_info, PollInfo* info);
+ARROW_FLIGHT_EXPORT Status FromProto(const pb::PollInfo& pb_info,
+                                     std::unique_ptr<PollInfo>* info);
+ARROW_FLIGHT_EXPORT Status FromProto(const pb::CancelFlightInfoRequest& pb_request,
+                                     CancelFlightInfoRequest* request);
+ARROW_FLIGHT_EXPORT Status FromProto(const pb::SchemaResult& pb_result,
+                                     SchemaResult* result);
+ARROW_FLIGHT_EXPORT Status FromProto(const pb::BasicAuth& pb_basic_auth, BasicAuth* info);
+ARROW_FLIGHT_EXPORT Status FromProto(const pb::SetSessionOptionsRequest& pb_request,
+                                     SetSessionOptionsRequest* request);
+ARROW_FLIGHT_EXPORT Status FromProto(const pb::SetSessionOptionsResult& pb_result,
+                                     SetSessionOptionsResult* result);
+ARROW_FLIGHT_EXPORT Status FromProto(const pb::GetSessionOptionsRequest& pb_request,
+                                     GetSessionOptionsRequest* request);
+ARROW_FLIGHT_EXPORT Status FromProto(const pb::GetSessionOptionsResult& pb_result,
+                                     GetSessionOptionsResult* result);
+ARROW_FLIGHT_EXPORT Status FromProto(const pb::CloseSessionRequest& pb_request,
+                                     CloseSessionRequest* request);
+ARROW_FLIGHT_EXPORT Status FromProto(const pb::CloseSessionResult& pb_result,
+                                     CloseSessionResult* result);
 
-Status ToProto(const Timestamp& timestamp, google::protobuf::Timestamp* pb_timestamp);
-Status ToProto(const FlightDescriptor& descr, pb::FlightDescriptor* pb_descr);
-Status ToProto(const FlightEndpoint& endpoint, pb::FlightEndpoint* pb_endpoint);
-Status ToProto(const RenewFlightEndpointRequest& request,
-               pb::RenewFlightEndpointRequest* pb_request);
-Status ToProto(const FlightInfo& info, pb::FlightInfo* pb_info);
-Status ToProto(const PollInfo& info, pb::PollInfo* pb_info);
-Status ToProto(const CancelFlightInfoRequest& request,
-               pb::CancelFlightInfoRequest* pb_request);
-Status ToProto(const ActionType& type, pb::ActionType* pb_type);
-Status ToProto(const Action& action, pb::Action* pb_action);
-Status ToProto(const Result& result, pb::Result* pb_result);
-Status ToProto(const CancelFlightInfoResult& result,
-               pb::CancelFlightInfoResult* pb_result);
-Status ToProto(const Criteria& criteria, pb::Criteria* pb_criteria);
-Status ToProto(const Location& location, pb::Location* pb_location);
-Status ToProto(const SchemaResult& result, pb::SchemaResult* pb_result);
-Status ToProto(const Ticket& ticket, pb::Ticket* pb_ticket);
-Status ToProto(const BasicAuth& basic_auth, pb::BasicAuth* pb_basic_auth);
-Status ToProto(const SetSessionOptionsRequest& request,
-               pb::SetSessionOptionsRequest* pb_request);
-Status ToProto(const SetSessionOptionsResult& result,
-               pb::SetSessionOptionsResult* pb_result);
-Status ToProto(const GetSessionOptionsRequest& request,
-               pb::GetSessionOptionsRequest* pb_request);
-Status ToProto(const GetSessionOptionsResult& result,
-               pb::GetSessionOptionsResult* pb_result);
-Status ToProto(const CloseSessionRequest& request, pb::CloseSessionRequest* pb_request);
-Status ToProto(const CloseSessionResult& result, pb::CloseSessionResult* pb_result);
+ARROW_FLIGHT_EXPORT Status ToProto(const Timestamp& timestamp,
+                                   google::protobuf::Timestamp* pb_timestamp);
+ARROW_FLIGHT_EXPORT Status ToProto(const FlightDescriptor& descr,
+                                   pb::FlightDescriptor* pb_descr);
+ARROW_FLIGHT_EXPORT Status ToProto(const FlightEndpoint& endpoint,
+                                   pb::FlightEndpoint* pb_endpoint);
+ARROW_FLIGHT_EXPORT Status ToProto(const RenewFlightEndpointRequest& request,
+                                   pb::RenewFlightEndpointRequest* pb_request);
+ARROW_FLIGHT_EXPORT Status ToProto(const FlightInfo& info, pb::FlightInfo* pb_info);
+ARROW_FLIGHT_EXPORT Status ToProto(const PollInfo& info, pb::PollInfo* pb_info);
+ARROW_FLIGHT_EXPORT Status ToProto(const CancelFlightInfoRequest& request,
+                                   pb::CancelFlightInfoRequest* pb_request);
+ARROW_FLIGHT_EXPORT Status ToProto(const ActionType& type, pb::ActionType* pb_type);
+ARROW_FLIGHT_EXPORT Status ToProto(const Action& action, pb::Action* pb_action);
+ARROW_FLIGHT_EXPORT Status ToProto(const Result& result, pb::Result* pb_result);
+ARROW_FLIGHT_EXPORT Status ToProto(const CancelFlightInfoResult& result,
+                                   pb::CancelFlightInfoResult* pb_result);
+ARROW_FLIGHT_EXPORT Status ToProto(const Criteria& criteria, pb::Criteria* pb_criteria);
+ARROW_FLIGHT_EXPORT Status ToProto(const Location& location, pb::Location* pb_location);
+ARROW_FLIGHT_EXPORT Status ToProto(const SchemaResult& result,
+                                   pb::SchemaResult* pb_result);
+ARROW_FLIGHT_EXPORT Status ToProto(const Ticket& ticket, pb::Ticket* pb_ticket);
+ARROW_FLIGHT_EXPORT Status ToProto(const BasicAuth& basic_auth,
+                                   pb::BasicAuth* pb_basic_auth);
+ARROW_FLIGHT_EXPORT Status ToProto(const SetSessionOptionsRequest& request,
+                                   pb::SetSessionOptionsRequest* pb_request);
+ARROW_FLIGHT_EXPORT Status ToProto(const SetSessionOptionsResult& result,
+                                   pb::SetSessionOptionsResult* pb_result);
+ARROW_FLIGHT_EXPORT Status ToProto(const GetSessionOptionsRequest& request,
+                                   pb::GetSessionOptionsRequest* pb_request);
+ARROW_FLIGHT_EXPORT Status ToProto(const GetSessionOptionsResult& result,
+                                   pb::GetSessionOptionsResult* pb_result);
+ARROW_FLIGHT_EXPORT Status ToProto(const CloseSessionRequest& request,
+                                   pb::CloseSessionRequest* pb_request);
+ARROW_FLIGHT_EXPORT Status ToProto(const CloseSessionResult& result,
+                                   pb::CloseSessionResult* pb_result);
 
 Status ToPayload(const FlightDescriptor& descr, std::shared_ptr<Buffer>* out);
 

--- a/cpp/src/arrow/flight/transport/grpc/customize_grpc.h
+++ b/cpp/src/arrow/flight/transport/grpc/customize_grpc.h
@@ -22,6 +22,7 @@
 
 #include "arrow/flight/platform.h"
 #include "arrow/flight/type_fwd.h"
+#include "arrow/flight/visibility.h"
 #include "arrow/util/config.h"
 
 // Silence protobuf warnings
@@ -63,8 +64,8 @@ namespace grpc {
 
 // Read internal::FlightData from grpc::ByteBuffer containing FlightData
 // protobuf without copying
-::grpc::Status FlightDataDeserialize(::grpc::ByteBuffer* buffer,
-                                     arrow::flight::internal::FlightData* out);
+ARROW_FLIGHT_EXPORT ::grpc::Status FlightDataDeserialize(
+    ::grpc::ByteBuffer* buffer, arrow::flight::internal::FlightData* out);
 }  // namespace grpc
 }  // namespace transport
 }  // namespace flight

--- a/cpp/src/arrow/meson.build
+++ b/cpp/src/arrow/meson.build
@@ -426,7 +426,7 @@ arrow_lib = library(
     include_directories: arrow_includes,
     dependencies: arrow_deps,
     install: true,
-    gnu_symbol_visibility: 'hidden',
+    gnu_symbol_visibility: 'inlineshidden',
     cpp_shared_args: ['-DARROW_EXPORTING'],
 )
 
@@ -489,6 +489,7 @@ if needs_compute
         sources: arrow_compute_lib_sources,
         dependencies: arrow_dep,
         install: true,
+        gnu_symbol_visibility: 'inlineshidden',
         cpp_shared_args: ['-DARROW_COMPUTE_EXPORTING'],
     )
     arrow_compute_dep = declare_dependency(


### PR DESCRIPTION
### Rationale for this change

I was under the false impression that 'hidden' visibility hid the most symbols from shared libraries. As it turns out, 'inlineshidden' performs the most symbol hiding, so we can achieve the best hygeine and smallest libraries from that option.

A local release build shows the following library sizes on main:

21M	src/arrow/libarrow-compute.so
16M	src/arrow/libarrow.so
21M	src/arrow/flight/libarrow-flight.so
2.5M	src/arrow/acero/libarrow-acero.so

With this PR showing a small improvement in some libraries:

21M	src/arrow/libarrow-compute.so
16M	src/arrow/libarrow.so
20M	src/arrow/flight/libarrow-flight.so
2.4M	src/arrow/acero/libarrow-acero.so

### What changes are included in this PR?

Usage of 'hidden' has been replaced with 'inlineshidden'. I also added hidden symbol visibility to the compute library, where it was errantly missing before

### Are these changes tested?

Yes

### Are there any user-facing changes?

No
* GitHub Issue: #47412