### PR TITLE
GH-47373: [C++] Raise for invalid decimal precision input from the C Data Interface

### DIFF
--- a/cpp/src/arrow/c/bridge.cc
+++ b/cpp/src/arrow/c/bridge.cc
@@ -1259,15 +1259,15 @@ struct SchemaImporter {
       return f_parser_.Invalid();
     }
     if (prec_scale.size() == 2) {
-      type_ = decimal128(prec_scale[0], prec_scale[1]);
+      ARROW_ASSIGN_OR_RAISE(type_, Decimal128Type::Make(prec_scale[0], prec_scale[1]));
     } else if (prec_scale[2] == 32) {
-      type_ = decimal32(prec_scale[0], prec_scale[1]);
+      ARROW_ASSIGN_OR_RAISE(type_, Decimal32Type::Make(prec_scale[0], prec_scale[1]));
     } else if (prec_scale[2] == 64) {
-      type_ = decimal64(prec_scale[0], prec_scale[1]);
+      ARROW_ASSIGN_OR_RAISE(type_, Decimal64Type::Make(prec_scale[0], prec_scale[1]));
     } else if (prec_scale[2] == 128) {
-      type_ = decimal128(prec_scale[0], prec_scale[1]);
+      ARROW_ASSIGN_OR_RAISE(type_, Decimal128Type::Make(prec_scale[0], prec_scale[1]));
     } else if (prec_scale[2] == 256) {
-      type_ = decimal256(prec_scale[0], prec_scale[1]);
+      ARROW_ASSIGN_OR_RAISE(type_, Decimal256Type::Make(prec_scale[0], prec_scale[1]));
     } else {
       return f_parser_.Invalid();
     }

--- a/cpp/src/arrow/c/bridge_test.cc
+++ b/cpp/src/arrow/c/bridge_test.cc
@@ -2357,6 +2357,34 @@ TEST_F(TestSchemaImport, DictionaryError) {
   CheckImportError();
 }
 
+TEST_F(TestSchemaImport, DecimalError) {
+  // Decimal precision out of bounds
+  FillPrimitive("d:0,10");
+  CheckImportError();
+  FillPrimitive("d:39,10");
+  CheckImportError();
+
+  FillPrimitive("d:0,4,32");
+  CheckImportError();
+  FillPrimitive("d:10,4,32");
+  CheckImportError();
+
+  FillPrimitive("d:0,4,64");
+  CheckImportError();
+  FillPrimitive("d:19,4,64");
+  CheckImportError();
+
+  FillPrimitive("d:0,10,128");
+  CheckImportError();
+  FillPrimitive("d:39,10,128");
+  CheckImportError();
+
+  FillPrimitive("d:0,4,256");
+  CheckImportError();
+  FillPrimitive("d:77,4,256");
+  CheckImportError();
+}
+
 TEST_F(TestSchemaImport, ExtensionError) {
   ExtensionTypeGuard guard(uuid());
 


### PR DESCRIPTION
### Rationale for this change

This fixes an issue where invalid decimal precision data passed through the C Data Interface would cause the program to abort.

### What changes are included in this PR?

The aborting decimal constructor is replaced with a factory function call that will validate the precision input and propogate up and error accordingly

### Are these changes tested?

Yes

### Are there any user-facing changes?

No
* GitHub Issue: #47373