### PR TITLE
GH-47279: [C++] Implement GetByteRangesArray for view types

### DIFF
--- a/cpp/src/arrow/util/byte_size.cc
+++ b/cpp/src/arrow/util/byte_size.cc
@@ -201,7 +201,7 @@ struct GetByteRangesArray {
     RETURN_NOT_OK(range_offsets->Append(sizeof(c_type) * offset));
     RETURN_NOT_OK(range_lengths->Append(sizeof(c_type) * length));
 
-    for (std::size_t i = 2; i < input.buffers.size(); i++) {
+    for (int i = 2; i < input.buffers.size(); i++) {
       const Buffer& buf = *input.buffers[i];
       RETURN_NOT_OK(range_starts->Append(reinterpret_cast<uint64_t>(buf.data())));
       RETURN_NOT_OK(range_offsets->Append(0));

--- a/cpp/src/arrow/util/byte_size.cc
+++ b/cpp/src/arrow/util/byte_size.cc
@@ -269,7 +269,7 @@ struct GetByteRangesArray {
     // Producing exact byte size would require linear scan of all values in view buffer
     GetByteRangesArray child{*input.child_data[0],
                              0,
-                             (*input.child_data[0]).length,
+                             input.child_data[0]->length,
                              range_starts,
                              range_offsets,
                              range_lengths};

--- a/cpp/src/arrow/util/byte_size.cc
+++ b/cpp/src/arrow/util/byte_size.cc
@@ -267,12 +267,9 @@ struct GetByteRangesArray {
     // 2. Reference a value multiple times without repeating it in the data buffer
     //
     // Producing exact byte size would require linear scan of all values in view buffer
-    GetByteRangesArray child{*input.child_data[0],
-                             0,
-                             input.child_data[0]->length,
-                             range_starts,
-                             range_offsets,
-                             range_lengths};
+    GetByteRangesArray child{
+        *input.child_data[0], 0, input.child_data[0]->length, range_starts, range_offsets,
+        range_lengths};
     return VisitTypeInline(*type.value_type(), &child);
   }
 

--- a/cpp/src/arrow/util/byte_size.cc
+++ b/cpp/src/arrow/util/byte_size.cc
@@ -201,6 +201,12 @@ struct GetByteRangesArray {
     RETURN_NOT_OK(range_offsets->Append(sizeof(c_type) * offset));
     RETURN_NOT_OK(range_lengths->Append(sizeof(c_type) * length));
 
+    // The following calculation is an over/under estimate of the size since views buffer
+    // might
+    // 1. Not reference all the values in data buffers (the array was filtered without gc)
+    // 2. Reference a value multiple times without repeating it in the data buffer
+    //
+    // Producing exact byte size would require linear scan of all values in view buffer
     for (int i = 2; i < input.buffers.size(); i++) {
       const Buffer& buf = *input.buffers[i];
       RETURN_NOT_OK(range_starts->Append(reinterpret_cast<uint64_t>(buf.data())));
@@ -255,6 +261,12 @@ struct GetByteRangesArray {
     RETURN_NOT_OK(range_offsets->Append(sizeof(offset_type) * offset));
     RETURN_NOT_OK(range_lengths->Append(sizeof(offset_type) * length));
 
+    // The following calculation is an over/under estimate of the byte size since views
+    // buffer might
+    // 1. Not reference all the values in data buffers (the array was filtered without gc)
+    // 2. Reference a value multiple times without repeating it in the data buffer
+    //
+    // Producing exact byte size would require linear scan of all values in view buffer
     GetByteRangesArray child{*input.child_data[0],
                              0,
                              (*input.child_data[0]).length,

--- a/cpp/src/arrow/util/byte_size.cc
+++ b/cpp/src/arrow/util/byte_size.cc
@@ -261,7 +261,7 @@ struct GetByteRangesArray {
     RETURN_NOT_OK(range_offsets->Append(sizeof(offset_type) * offset));
     RETURN_NOT_OK(range_lengths->Append(sizeof(offset_type) * length));
 
-    // The following calculation is an over/under estimate of the byte size since views
+    // The following calculation is an over estimate of the byte size since views
     // buffer might
     // 1. Not reference all the values in data buffers (the array was filtered without gc)
     // 2. Reference a value multiple times without repeating it in the data buffer

--- a/cpp/src/arrow/util/byte_size.cc
+++ b/cpp/src/arrow/util/byte_size.cc
@@ -201,7 +201,7 @@ struct GetByteRangesArray {
     RETURN_NOT_OK(range_offsets->Append(sizeof(c_type) * offset));
     RETURN_NOT_OK(range_lengths->Append(sizeof(c_type) * length));
 
-    // The following calculation is an over/under estimate of the size since views buffer
+    // The following calculation is an over estimate of the size since views buffer
     // might
     // 1. Not reference all the values in data buffers (the array was filtered without gc)
     // 2. Reference a value multiple times without repeating it in the data buffer

--- a/cpp/src/arrow/util/byte_size.cc
+++ b/cpp/src/arrow/util/byte_size.cc
@@ -207,7 +207,7 @@ struct GetByteRangesArray {
     // 2. Reference a value multiple times without repeating it in the data buffer
     //
     // Producing exact byte size would require linear scan of all values in view buffer
-    for (int i = 2; i < input.buffers.size(); i++) {
+    for (size_t i = 2; i < input.buffers.size(); i++) {
       const Buffer& buf = *input.buffers[i];
       RETURN_NOT_OK(range_starts->Append(reinterpret_cast<uint64_t>(buf.data())));
       RETURN_NOT_OK(range_offsets->Append(0));

--- a/cpp/src/arrow/util/byte_size_test.cc
+++ b/cpp/src/arrow/util/byte_size_test.cc
@@ -326,6 +326,11 @@ TEST(ByteRanges, StringViewType) {
   std::shared_ptr<Array> str_view_with_nulls = ArrayFromJSON(
       utf8_view(), R"(["short", null, "another long string that requires a buffer"])");
   CheckBufferRanges(str_view_with_nulls, {{0, 0, 1}, {1, 0, 48}, {2, 0, 42}});
+
+  CheckBufferRanges(str_view_arr->Slice(1, 1), {{0, 16, 16}, {1, 0, 38}});
+  CheckBufferRanges(str_view_arr->Slice(0, 1), {{0, 0, 16}, {1, 0, 38}});
+  CheckBufferRanges(str_view_with_nulls->Slice(2, 1),
+                    {{0, 0, 1}, {1, 32, 16}, {2, 0, 42}});
 }
 
 TEST(ByteRanges, BinaryViewType) {
@@ -337,6 +342,10 @@ TEST(ByteRanges, BinaryViewType) {
   std::shared_ptr<Array> bin_view_with_nulls =
       ArrayFromJSON(binary_view(), R"(["AB", null, "CDEFGHIJKLMNOPQRSTUVWXYZ"])");
   CheckBufferRanges(bin_view_with_nulls, {{0, 0, 1}, {1, 0, 48}, {2, 0, 24}});
+
+  CheckBufferRanges(bin_view_arr->Slice(1, 1), {{0, 16, 16}, {1, 0, 22}});
+  CheckBufferRanges(bin_view_with_nulls->Slice(2, 1),
+                    {{0, 0, 1}, {1, 32, 16}, {2, 0, 24}});
 }
 
 using ListViewArrowTypes = ::testing::Types<ListViewType, LargeListViewType>;
@@ -359,6 +368,15 @@ TYPED_TEST(ByteRangesListView, Basic) {
                                            {1, 0, 3 * sizeof(offset_type)},
                                            {2, 0, 3 * sizeof(offset_type)},
                                            {3, 0, 20}});
+  CheckBufferRanges(list_view_arr->Slice(2, 1),
+                    {{0, 2 * sizeof(offset_type), sizeof(offset_type)},
+                     {1, 2 * sizeof(offset_type), sizeof(offset_type)},
+                     {2, 0, 16}});
+  CheckBufferRanges(list_view_with_nulls->Slice(2, 1),
+                    {{0, 0, 1},
+                     {1, 2 * sizeof(offset_type), sizeof(offset_type)},
+                     {2, 2 * sizeof(offset_type), sizeof(offset_type)},
+                     {3, 0, 20}});
 }
 
 TYPED_TEST(ByteRangesListView, NestedListView) {


### PR DESCRIPTION
### Rationale for this change

- Fix https://github.com/apache/arrow/issues/47279

### What changes are included in this PR?

Add missing visit methods to GetByteRangesArray. The returned results are over
estimates since there's no cheap way to estimate offsets of the child
arrays/buffers. We can compute exact value if we are willing to check every
offset/view

### Are these changes tested?

Added tests

### Are there any user-facing changes?

No


* GitHub Issue: #47279