### PR TITLE
MINOR: [C++] Fix grammar typo in visibility.h

### DIFF
--- a/cpp/src/arrow/util/visibility.h
+++ b/cpp/src/arrow/util/visibility.h
@@ -36,7 +36,7 @@
 #    define ARROW_DLLIMPORT __declspec(dllimport)
 #  endif
 
-// _declspec(dllexport) even when the #included by a non-arrow source
+// _declspec(dllexport) even when #included by a non-arrow source
 #  define ARROW_FORCE_EXPORT ARROW_DLLEXPORT
 
 #  ifdef ARROW_STATIC


### PR DESCRIPTION
### Rationale for this change

Tiny grammar mistake

### What changes are included in this PR?

Just the above typo fix

### Are these changes tested?

Yes

### Are there any user-facing changes?

No

