### PR TITLE
GH-47356: [R] NEWS file states version 20.0.0.1 but release package number on CRAN is 20.0.0.2

### DIFF
--- a/r/NEWS.md
+++ b/r/NEWS.md
@@ -45,7 +45,7 @@
   if you were building the R package from source with different R package and Arrow C++ versions.
 - Require CMake 3.25 or greater in bundled build script for full-source builds (#46834). This shouldn't affect most users.
 
-# arrow 20.0.0.1
+# arrow 20.0.0.2
 
 ## Minor improvements and fixes
 


### PR DESCRIPTION
### Rationale for this change

R NEWS file has wrong version number

### What changes are included in this PR?

Swap for correct number

### Are these changes tested?

No

### Are there any user-facing changes?

No
* GitHub Issue: #47356