### PR TITLE
GH-47269: [C++][Acero] Support for multi threaded input: ScalarAggregateNode , GroupByNode

### DIFF
--- a/cpp/src/arrow/acero/CMakeLists.txt
+++ b/cpp/src/arrow/acero/CMakeLists.txt
@@ -33,6 +33,7 @@ set(ARROW_ACERO_REQUIRED_DEPENDENCIES Arrow ArrowCompute)
 
 set(ARROW_ACERO_SRCS
     accumulation_queue.cc
+    backpressure.cc
     scalar_aggregate_node.cc
     groupby_aggregate_node.cc
     aggregate_internal.cc
@@ -173,6 +174,7 @@ function(add_arrow_acero_test REL_TEST_NAME)
                  ${ARG_UNPARSED_ARGUMENTS})
 endfunction()
 
+add_arrow_acero_test(backpressure_test SOURCES backpressure_test.cc)
 add_arrow_acero_test(plan_test SOURCES plan_test.cc test_nodes_test.cc)
 add_arrow_acero_test(source_node_test SOURCES source_node_test.cc)
 add_arrow_acero_test(fetch_node_test SOURCES fetch_node_test.cc)

--- a/cpp/src/arrow/acero/accumulation_queue.h
+++ b/cpp/src/arrow/acero/accumulation_queue.h
@@ -21,7 +21,7 @@
 #include <functional>
 #include <optional>
 #include <vector>
-
+#include "arrow/acero/backpressure_handler.h"
 #include "arrow/acero/visibility.h"
 #include "arrow/compute/exec.h"
 #include "arrow/result.h"
@@ -141,6 +141,11 @@ class ARROW_ACERO_EXPORT SerialSequencingQueue {
     /// TODO: Could add backpressure if needed but right now all uses of this should
     ///       be pretty fast and so are unlikely to block.
     virtual Status Process(ExecBatch batch) = 0;
+
+    static std::unique_ptr<Processor> MakeBackpressureWrapper(Processor* processor,
+                                                              BackpressureHandler handler,
+                                                              ExecPlan* plan,
+                                                              bool requires_io = true);
   };
 
   virtual ~SerialSequencingQueue() = default;

--- a/cpp/src/arrow/acero/accumulation_queue.h
+++ b/cpp/src/arrow/acero/accumulation_queue.h
@@ -145,7 +145,7 @@ class ARROW_ACERO_EXPORT SerialSequencingQueue {
     /// Wrapper for processor with backpressure
     ///
     /// This wrapper adds backpressure logic acting on number of sequenced batches.
-    //  Also batches are Processes on new scheduled tasks. The tasks will be scheduled on
+    //  Also batches are Processed on new scheduled tasks. The tasks will be scheduled on
     /// IO executor when requires_io==true.
     static std::unique_ptr<Processor> MakeBackpressureWrapper(Processor* processor,
                                                               BackpressureHandler handler,

--- a/cpp/src/arrow/acero/accumulation_queue.h
+++ b/cpp/src/arrow/acero/accumulation_queue.h
@@ -127,7 +127,7 @@ class ARROW_ACERO_EXPORT SequencingQueue {
 class ARROW_ACERO_EXPORT SerialSequencingQueue {
  public:
   /// Strategy that describes how to handle items
-  class Processor {
+  class ARROW_ACERO_EXPORT Processor {
    public:
     virtual ~Processor() = default;
     /// Process the batch
@@ -142,10 +142,15 @@ class ARROW_ACERO_EXPORT SerialSequencingQueue {
     ///       be pretty fast and so are unlikely to block.
     virtual Status Process(ExecBatch batch) = 0;
 
+    /// Wrapper for processor with backpressure
+    ///
+    /// This wrapper adds backpressure logic acting on number of sequenced batches.
+    //  Also batches are Processes on new scheduled tasks. The tasks will be scheduled on
+    /// IO executor when requires_io==true.
     static std::unique_ptr<Processor> MakeBackpressureWrapper(Processor* processor,
                                                               BackpressureHandler handler,
                                                               ExecPlan* plan,
-                                                              bool requires_io = true);
+                                                              bool requires_io = false);
   };
 
   virtual ~SerialSequencingQueue() = default;

--- a/cpp/src/arrow/acero/aggregate_internal.cc
+++ b/cpp/src/arrow/acero/aggregate_internal.cc
@@ -214,12 +214,12 @@ Result<std::shared_ptr<Schema>> MakeOutputSchema(
     ARROW_ASSIGN_OR_RAISE(auto args,
                           ScalarAggregateNode::MakeAggregateNodeArgs(
                               input_schema, keys, segment_keys, aggregates, exec_ctx,
-                              /*concurrency=*/1, /*is_cpu_parallel=*/false));
+                              /*concurrency=*/1));
     return std::move(args.output_schema);
   } else {
-    ARROW_ASSIGN_OR_RAISE(auto args, GroupByNode::MakeAggregateNodeArgs(
-                                         input_schema, keys, segment_keys, aggregates,
-                                         exec_ctx, /*is_cpu_parallel=*/false));
+    ARROW_ASSIGN_OR_RAISE(
+        auto args, GroupByNode::MakeAggregateNodeArgs(input_schema, keys, segment_keys,
+                                                      aggregates, exec_ctx));
     return std::move(args.output_schema);
   }
 }

--- a/cpp/src/arrow/acero/aggregate_node_test.cc
+++ b/cpp/src/arrow/acero/aggregate_node_test.cc
@@ -573,7 +573,7 @@ class BackpressureTestExecNode : public ExecNode {
     ++total_batches_;
     ARROW_RETURN_NOT_OK(output_->InputReceived(this, std::move(batch)));
     if (total_batches_ == total_batches_received)
-      return output_->InputFinished(this, total_batches_);
+      return output_->InputFinished(this, static_cast<int>(total_batches_));
     return Status::OK();
   }
   Status InputFinished(ExecNode* input, int total_batches) override {

--- a/cpp/src/arrow/acero/aggregate_node_test.cc
+++ b/cpp/src/arrow/acero/aggregate_node_test.cc
@@ -14,23 +14,36 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-#include "arrow/acero/exec_plan.h"
-#include "arrow/acero/options.h"
-
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
+#include "arrow/acero/exec_plan.h"
+#include "arrow/acero/options.h"
+#include "arrow/status.h"
+#include "arrow/testing/future_util.h"
+#include "arrow/testing/generator.h"
+#include "arrow/testing/gtest_util.h"
+#include "arrow/testing/matchers.h"
+#include "arrow/testing/random.h"
 
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
 #include <memory>
+#include <utility>
+#include <vector>
 
+#include "arrow/acero/aggregate_internal.h"
+#include "arrow/acero/test_nodes.h"
 #include "arrow/acero/test_util_internal.h"
-#include "arrow/compute/api_aggregate.h"
+#include "arrow/compute/ordering.h"
 #include "arrow/compute/test_util_internal.h"
 #include "arrow/result.h"
-#include "arrow/table.h"
 #include "arrow/testing/gtest_util.h"
+#include "arrow/testing/random.h"
+#include "arrow/type_fwd.h"
 #include "arrow/util/bit_util.h"
 #include "arrow/util/string.h"
-
 namespace arrow {
 
 using compute::ExecBatchFromJSON;
@@ -45,6 +58,18 @@ Result<std::shared_ptr<Table>> TableGroupBy(
       {{"table_source", TableSourceNodeOptions(std::move(table))},
        {"aggregate", AggregateNodeOptions(std::move(aggregates), std::move(keys))}});
   return DeclarationToTable(std::move(plan), use_threads, memory_pool);
+}
+
+std::vector<ExecBatch> TestExecBatches(const std::vector<TypeHolder>& types,
+                                       std::vector<std::string> json_batches,
+                                       bool implicit_ordering = true) {
+  std::vector<ExecBatch> batches;
+  int64_t index = 0;
+  for (auto&& el : json_batches) {
+    batches.push_back(ExecBatchFromJSON(types, el));
+    if (implicit_ordering) batches.back().index = index++;
+  }
+  return batches;
 }
 
 TEST(GroupByConvenienceFunc, Basic) {
@@ -233,6 +258,98 @@ TEST(GroupByNode, BasicParallel) {
                                       out_batches.batches);
 }
 
+TEST(GroupByNode, ParallelOrderedAggregator) {
+  // const int64_t num_batches = 8;
+
+  std::vector<ExecBatch> batches = TestExecBatches({int64(), int64()}, {R"([
+    [0,999],
+    [0,1]
+  ])",
+                                                                        R"([
+    [1,333],
+    [1,1]
+  ])",
+                                                                        R"([
+    [2,111],
+    [2,1]
+  ])"});
+  static constexpr random::SeedType kTestSeed = 42;
+  static constexpr int kMaxJitterMod = 3;
+  RegisterTestNodes();
+  Declaration plan = Declaration::Sequence(
+      {{"exec_batch_source",
+        ExecBatchSourceNodeOptions(
+            schema({field("key1", int64()), field("value", int64())}), batches)},
+       {"jitter", JitterNodeOptions(kTestSeed, kMaxJitterMod)},
+       {"aggregate",
+        AggregateNodeOptions{/*aggregates=*/
+                             {{"hash_first", nullptr, "value", "mean(value)"}},
+                             {"key1"},
+                             {}}}});
+  ASSERT_OK_AND_ASSIGN(BatchesWithCommonSchema out_batches,
+                       DeclarationToExecBatches(plan));
+  ExecBatch expected_batch = ExecBatchFromJSON({int64(), int64()},
+                                               R"([
+    [0, 999],
+    [1, 333],
+    [2, 111] 
+    ])");
+
+  AssertExecBatchesEqual(out_batches.schema, {expected_batch}, out_batches.batches);
+}
+
+TEST(GroupByNode, ParallelSegmentedAggregatorGroupBy) {
+  std::vector<ExecBatch> batches =
+      TestExecBatches({utf8(), int64(), int64(), int64()}, {R"([
+    ["x",0,1,1],
+    ["y",0,1,2],
+    ["z",0,1,3]
+  ])",
+                                                            R"([
+    ["x",1,2,1],
+    ["y",1,2,2],
+    ["z",1,3,3]
+  ])",
+                                                            R"([
+    ["x",2,3,1],
+    ["y",2,3,2],
+    ["z",2,3,3]
+  ])"});
+
+  Ordering order({compute::SortKey("key2", compute::SortOrder::Ascending),
+                  compute::SortKey("key1", compute::SortOrder::Ascending)});
+  static constexpr random::SeedType kTestSeed = 42;
+  static constexpr int kMaxJitterMod = 3;
+  RegisterTestNodes();
+  Declaration plan = Declaration::Sequence(
+      {{"exec_batch_source",
+        ExecBatchSourceNodeOptions(
+            schema({field("key1", utf8()), field("key2", int64()), field("key3", int64()),
+                    field("value", int64())}),
+            batches)},
+       {"order_by", OrderByNodeOptions(order)},
+       {"jitter", JitterNodeOptions(kTestSeed, kMaxJitterMod)},
+       {"aggregate",
+        AggregateNodeOptions{/*aggregates=*/
+                             {{"hash_mean", nullptr, "value", "mean(value)"}},
+                             {"key1"},
+                             {"key2"}}}});
+
+  ASSERT_OK_AND_ASSIGN(BatchesWithCommonSchema out_batches,
+                       DeclarationToExecBatches(plan));
+  std::vector<ExecBatch> batches_ex = TestExecBatches({int64(), utf8(), float64()}, {R"([
+    [0,"x" , 1],[0,"y" , 2],[0,"z" , 3]
+    ])",
+                                                                                     R"([ 
+    [1,"x" , 1],[1,"y" , 2],[1,"z" , 3]
+    ])",
+                                                                                     R"([
+    [2,"x" , 1],[2,"y" , 2],[2,"z" , 3]
+    ])"});
+
+  AssertExecBatchesEqual(out_batches.schema, batches_ex, out_batches.batches);
+}
+
 TEST(ScalarAggregateNode, AnyAll) {
   // GH-43768: boolean_any and boolean_all with constant input should work well
   // when min_count != 0.
@@ -302,6 +419,307 @@ TEST(ScalarAggregateNode, BasicParallel) {
       ExecBatchFromJSON({int64()}, "[[" + std::to_string(num_batches) + "]]");
   AssertExecBatchesEqualIgnoringOrder(out_batches.schema, {expected_batch},
                                       out_batches.batches);
+}
+
+TEST(ScalarAggregateNode, ParallelOrderedAggregator) {
+  std::vector<ExecBatch> batches = TestExecBatches({int64(), int64()}, {R"([
+    [0,999],
+    [0,1]
+  ])",
+                                                                        R"([
+    [1,999],
+    [1,1]
+  ])",
+                                                                        R"([
+    [2,999],
+    [2,1]
+  ])"});
+
+  static constexpr random::SeedType kTestSeed = 42;
+  static constexpr int kMaxJitterMod = 3;
+  RegisterTestNodes();
+
+  Declaration plan = Declaration::Sequence(
+      {{"exec_batch_source",
+        ExecBatchSourceNodeOptions(
+            schema({field("key1", int64()), field("value", int64())}), batches)},
+       {"jitter", JitterNodeOptions(kTestSeed, kMaxJitterMod)},
+       {"aggregate",
+        AggregateNodeOptions{/*aggregates=*/
+                             {{"first", nullptr, "value", "mean(value)"}}}}});
+
+  ASSERT_OK_AND_ASSIGN(BatchesWithCommonSchema out_batches,
+                       DeclarationToExecBatches(plan));
+
+  ExecBatch expected_batch = ExecBatchFromJSON({int64()}, R"([ [999] ])");
+  AssertExecBatchesEqual(out_batches.schema, {expected_batch}, out_batches.batches);
+}
+
+TEST(ScalarAggregateNode, ParallelSegmentedAggregator) {
+  std::vector<ExecBatch> batches = TestExecBatches({int64(), int64(), int64()},
+                                                   {R"([
+    [0,1,999],
+    [0,2,1]
+  ])",
+                                                    R"([
+    [1,11,499],
+    [1,12,1]
+  ])",
+                                                    R"([
+    [2,21,299],
+    [2,22,1]
+  ])"},
+                                                   true);
+
+  static constexpr random::SeedType kTestSeed = 42;
+  static constexpr int kMaxJitterMod = 3;
+  RegisterTestNodes();
+
+  Declaration plan = Declaration::Sequence(
+      {{"exec_batch_source",
+        ExecBatchSourceNodeOptions(schema({field("key1", int64()), field("key2", int64()),
+                                           field("value", int64())}),
+                                   batches)},
+       {"jitter", JitterNodeOptions(kTestSeed, kMaxJitterMod)},
+       {"aggregate", AggregateNodeOptions{/*aggregates=*/
+                                          {{"mean", nullptr, "value", "mean(value)"}},
+                                          {},
+                                          {FieldRef("key1")}}}});
+
+  ASSERT_OK_AND_ASSIGN(BatchesWithCommonSchema out_batches,
+                       DeclarationToExecBatches(plan));
+  auto expected_batch = TestExecBatches(
+      {int64(), float64()}, {R"([[0 , 500]])", R"([[1 , 250]])", R"([[2 , 150]])"});
+  AssertExecBatchesEqual(out_batches.schema, expected_batch, out_batches.batches);
+}
+
+TEST(ScalarAggregateNode, ParallelSegmentedAggregatorKeySorted) {
+  std::vector<ExecBatch> batches = TestExecBatches({int64(), int64(), int64(), int64()},
+                                                   {R"([
+    [0,1,1,999],
+    [0,2,1,1]
+  ])",
+                                                    R"([
+    [1,11,2,499],
+    [1,12,2,1]
+  ])",
+                                                    R"([
+    [2,21,3,299],
+    [2,22,3,1]
+  ])"},
+                                                   true);
+
+  static constexpr random::SeedType kTestSeed = 42;
+  static constexpr int kMaxJitterMod = 3;
+  RegisterTestNodes();
+  Ordering order({compute::SortKey("key1", compute::SortOrder::Ascending),
+                  compute::SortKey("key3", compute::SortOrder::Ascending)});
+
+  Declaration plan = Declaration::Sequence(
+      {{"exec_batch_source",
+        ExecBatchSourceNodeOptions(
+            schema({field("key1", int64()), field("key2", int64()),
+                    field("key3", int64()), field("value", int64())}),
+            batches)},
+       {"order_by", OrderByNodeOptions{order}},
+       {"jitter", JitterNodeOptions(kTestSeed, kMaxJitterMod)},
+       {"aggregate", AggregateNodeOptions{/*aggregates=*/
+                                          {{"mean", nullptr, "value", "mean(value)"}},
+                                          {},
+                                          {FieldRef("key1")}}}});
+
+  ASSERT_OK_AND_ASSIGN(BatchesWithCommonSchema out_batches,
+                       DeclarationToExecBatches(plan));
+  auto expected_batch = TestExecBatches(
+      {int64(), float64()}, {R"([[0 , 500]])", R"([[1 , 250]])", R"([[2 , 150]])"});
+  AssertExecBatchesEqual(out_batches.schema, expected_batch, out_batches.batches);
+}
+
+class BackpressureTestExecNode;
+
+class BackpressureTestNodeOptions : public ExecNodeOptions {
+ public:
+  explicit BackpressureTestNodeOptions(Ordering order) : order_(std::move(order)) {
+    is_paused_ = std::make_shared<bool>(false);
+  }
+  std::shared_ptr<bool> is_paused_;
+  Ordering order_;
+  static constexpr std::string_view kName = "backpressure";
+  bool is_paused() { return *is_paused_; }
+};
+
+class BackpressureTestExecNode : public ExecNode {
+ public:
+  BackpressureTestExecNode(ExecPlan* plan, NodeVector inputs,
+                           std::shared_ptr<Schema> output_schema,
+                           const BackpressureTestNodeOptions& _options)
+      : ExecNode(plan, inputs, {"something"}, output_schema),
+        is_paused_(_options.is_paused_),
+        order_(std::move(_options.order_)),
+        options(_options) {}
+
+  static Result<ExecNode*> Make(ExecPlan* plan, std::vector<ExecNode*> inputs,
+                                const ExecNodeOptions& options) {
+    const BackpressureTestNodeOptions& bb =
+        static_cast<const BackpressureTestNodeOptions&>(options);
+    auto input = inputs[0];
+    return input->plan()->EmplaceNode<BackpressureTestExecNode>(
+        plan, inputs, inputs[0]->output_schema(), bb);
+  }
+
+  const char* kind_name() const override { return "BackpressureTestNode"; }
+
+  Status InputReceived(ExecNode* input, ExecBatch batch) override {
+    ++total_batches_;
+    ARROW_RETURN_NOT_OK(output_->InputReceived(this, std::move(batch)));
+    if (total_batches_ == total_batches_received)
+      return output_->InputFinished(this, total_batches_);
+    return Status::OK();
+  }
+  Status InputFinished(ExecNode* input, int total_batches) override {
+    (void)input;
+    total_batches_received = total_batches;
+    return Status::OK();
+  }
+  Status StartProducing() override { return Status::OK(); }
+
+  Status Init() { return Status::OK(); }
+
+  const Ordering& ordering() const override { return order_; }
+
+  Status DoConsume(const ExecSpan& batch, size_t thread_index) { return Status::OK(); }
+
+  void PauseProducing(ExecNode* output, int32_t counter) override {
+    inputs_[0]->PauseProducing(this, counter);
+    *is_paused_ = true;
+  }
+
+  void ResumeProducing(ExecNode* output, int32_t counter) override {
+    inputs_[0]->ResumeProducing(this, counter);
+    *is_paused_ = false;
+  }
+
+ protected:
+  Status StopProducingImpl() override { return Status::OK(); }
+
+ public:
+  int64_t total_batches_ = 0;
+  int64_t total_batches_received = 0;
+  std::shared_ptr<bool> is_paused_;
+  Ordering order_;
+  const BackpressureTestNodeOptions& options;
+};
+
+TEST(ExecPlanExecution, SequenceQueueBackpressure) {
+  static std::once_flag registered;
+  std::call_once(registered, [] {
+    ExecFactoryRegistry* registry = default_exec_factory_registry();
+    (void)registry->AddFactory(std::string(BackpressureTestNodeOptions::kName),
+                               BackpressureTestExecNode::Make);
+  });
+
+  // BackpressureCountingNode::Register();
+  RegisterTestNodes();
+  std::vector<ExecBatch> batches =
+      gen::Gen({{"key1", gen::Step(0, 1)}, {"value", gen::Random(int32())}})
+          ->FailOnError()
+          ->ExecBatches(5, 30);
+
+  constexpr uint32_t kPauseIfAbove = 8;
+  constexpr uint32_t kResumeIfBelow = 4;
+  uint32_t pause_if_above_bytes =
+      kPauseIfAbove * static_cast<uint32_t>(batches[0].TotalBufferSize());
+  uint32_t resume_if_below_bytes =
+      kResumeIfBelow * static_cast<uint32_t>(batches[0].TotalBufferSize());
+
+  EXPECT_OK_AND_ASSIGN(std::shared_ptr<ExecPlan> plan, ExecPlan::Make());
+  PushGenerator<std::optional<ExecBatch>> batch_producer;
+  AsyncGenerator<std::optional<ExecBatch>> sink_gen;
+  Ordering order({compute::SortKey("key1", compute::SortOrder::Ascending)});
+
+  // BackpressureCounters options;
+  // BackpressureCountingNodeOptions opc(&options);
+
+  BackpressureTestNodeOptions options(order);
+
+  BackpressureMonitor* backpressure_monitor;
+  BackpressureOptions backpressure_options(resume_if_below_bytes, pause_if_above_bytes);
+  std::shared_ptr<Schema> schema_ =
+      schema({field("key1", int32()), field("value", int32())});
+  ARROW_EXPECT_OK(
+      acero::Declaration::Sequence(
+          {
+              {"source", SourceNodeOptions(schema_, batch_producer, order)},
+              {"backpressure", options},
+              {"aggregate",
+               AggregateNodeOptions{/*aggregates=*/
+                                    {{"mean", nullptr, "value", "mean(value)"}},
+                                    {},
+                                    {FieldRef("key1")}}},
+              {"sink", SinkNodeOptions{&sink_gen,
+                                       /*schema=*/nullptr, backpressure_options,
+                                       &backpressure_monitor}},
+          })
+          .AddToPlan(plan.get()));
+  plan->StartProducing();
+
+  // set indexes to match the order
+  for (size_t i = 0; i < batches.size(); ++i) {
+    batches[i].index = i;
+  }
+  // lets reverse first indexes to fill the SequenceQueue with
+  // enough batches to trigger the Backpressure when all the required indexes will be
+  // present in the SequenceQueue to emit the batches
+  std::reverse(batches.begin(), batches.begin() + kPauseIfAbove + 1);
+
+  // lets push few first batches
+  uint32_t count = 0;
+  for (; count < kPauseIfAbove; count++) {
+    batch_producer.producer().Push(batches[count]);
+  }
+  SleepABit();
+  // at this point there isn't a idex 0 in the queue so nothing happens.
+  ASSERT_FALSE(options.is_paused());
+  // we push the batch with 0 index to be processed
+  batch_producer.producer().Push(batches[count++]);
+  SleepABit();
+  // we let the precesses run
+  BusyWait(5, [&] { return options.is_paused(); });
+  SleepABit();
+  //  at this point Node shoule trigger backpressure Pause signal.
+  ASSERT_TRUE(options.is_paused());
+
+  // we give it some time to process the batches and wait for the backPressure release
+  // signal.
+  BusyWait(5, [&] { return !options.is_paused(); });
+  SleepABit();
+  ASSERT_FALSE(options.is_paused());
+
+  // we push the rest of the batches in order
+  for (uint32_t i = count; i < batches.size(); i++) {
+    batch_producer.producer().Push(batches[i]);
+  }
+  SleepABit();
+  BusyWait(5, [&] { return options.is_paused(); });
+  SleepABit();
+  // BackPressure should also be triggered since we will push like 20+ batches which
+  // will tiger the back pressure
+  ASSERT_TRUE(options.is_paused());
+
+  ASSERT_FINISHES_OK(sink_gen());
+  BusyWait(10, [&] { return !options.is_paused(); });
+  //  the BackPressure shoule be released here
+  ASSERT_FALSE(options.is_paused());
+
+  // Cleanup
+  batch_producer.producer().Push(IterationEnd<std::optional<ExecBatch>>());
+  plan->StopProducing();
+
+  auto fut = plan->finished();
+  ASSERT_TRUE(fut.Wait(kDefaultAssertFinishesWaitSeconds));
+  if (!fut.status().ok()) {
+    ASSERT_TRUE(fut.status().IsCancelled());
+  }
 }
 
 }  // namespace acero

--- a/cpp/src/arrow/acero/aggregate_node_test.cc
+++ b/cpp/src/arrow/acero/aggregate_node_test.cc
@@ -649,7 +649,7 @@ TEST(ExecPlanExecution, SequenceQueueBackpressure) {
   ARROW_EXPECT_OK(
       acero::Declaration::Sequence(
           {
-              {"source", SourceNodeOptions(schema_, batch_producer, order)},
+              {"source", SourceNodeOptions(schema_, batch_producer)},
               {"backpressure", options},
               {"aggregate",
                AggregateNodeOptions{/*aggregates=*/
@@ -685,7 +685,6 @@ TEST(ExecPlanExecution, SequenceQueueBackpressure) {
   SleepABit();
   // we let the precesses run
   BusyWait(5, [&] { return options.is_paused(); });
-  SleepABit();
   //  at this point Node shoule trigger backpressure Pause signal.
   ASSERT_TRUE(options.is_paused());
 
@@ -701,7 +700,6 @@ TEST(ExecPlanExecution, SequenceQueueBackpressure) {
   }
   SleepABit();
   BusyWait(5, [&] { return options.is_paused(); });
-  SleepABit();
   // BackPressure should also be triggered since we will push like 20+ batches which
   // will tiger the back pressure
   ASSERT_TRUE(options.is_paused());

--- a/cpp/src/arrow/acero/asof_join_node.cc
+++ b/cpp/src/arrow/acero/asof_join_node.cc
@@ -46,6 +46,7 @@
 #ifndef NDEBUG
 #  include "arrow/compute/function_internal.h"
 #endif
+#include "arrow/acero/backpressure.h"
 #include "arrow/acero/time_series_util.h"
 #include "arrow/compute/key_hash_internal.h"
 #include "arrow/compute/light_array_internal.h"
@@ -457,21 +458,6 @@ class KeyHasher {
   LightContext ctx_;
   std::vector<KeyColumnArray> column_arrays_;
   arrow::util::TempVectorStack stack_;
-};
-
-class BackpressureController : public BackpressureControl {
- public:
-  BackpressureController(ExecNode* node, ExecNode* output,
-                         std::atomic<int32_t>& backpressure_counter)
-      : node_(node), output_(output), backpressure_counter_(backpressure_counter) {}
-
-  void Pause() override { node_->PauseProducing(output_, ++backpressure_counter_); }
-  void Resume() override { node_->ResumeProducing(output_, ++backpressure_counter_); }
-
- private:
-  ExecNode* node_;
-  ExecNode* output_;
-  std::atomic<int32_t>& backpressure_counter_;
 };
 
 class InputState : public util::SerialSequencingQueue::Processor {

--- a/cpp/src/arrow/acero/backpressure.cc
+++ b/cpp/src/arrow/acero/backpressure.cc
@@ -1,0 +1,91 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/acero/backpressure.h"
+namespace arrow::acero {
+BackpressureCombiner::BackpressureCombiner(
+    std::unique_ptr<BackpressureControl> backpressure_control)
+    : backpressure_control_(std::move(backpressure_control)) {}
+
+// Called from Source nodes
+void BackpressureCombiner::Pause(Source* output, bool strong_connection) {
+  std::lock_guard<std::mutex> lg(mutex_);
+  auto& paused_ = strong_connection ? strong_paused_ : weak_paused_;
+  auto& paused_count_ = strong_connection ? strong_paused_count_ : weak_paused_count_;
+
+  if (!paused_[output]) {
+    paused_[output] = true;
+    paused_count_++;
+    UpdatePauseStateUnlocked();
+  }
+}
+
+// Called from Source nodes
+void BackpressureCombiner::Resume(Source* output, bool strong_connection) {
+  std::lock_guard<std::mutex> lg(mutex_);
+  auto& paused_ = strong_connection ? strong_paused_ : weak_paused_;
+  auto& paused_count_ = strong_connection ? strong_paused_count_ : weak_paused_count_;
+  if (paused_.find(output) == paused_.end()) {
+    paused_[output] = false;
+    UpdatePauseStateUnlocked();
+  }
+  if (paused_[output]) {
+    paused_[output] = false;
+    paused_count_--;
+    UpdatePauseStateUnlocked();
+  }
+}
+
+void BackpressureCombiner::UpdatePauseStateUnlocked() {
+  bool should_be_paused =
+      strong_paused_count_ > 0 || weak_paused_count_ == weak_paused_.size();
+  if (should_be_paused) {
+    if (!paused) {
+      backpressure_control_->Pause();
+      paused = true;
+    }
+  } else {
+    if (paused) {
+      backpressure_control_->Resume();
+      paused = false;
+    }
+  }
+}
+
+BackpressureCombiner::Source::Source(BackpressureCombiner* ctrl, bool strong_connection) {
+  if (ctrl) {
+    AddController(ctrl, strong_connection);
+  }
+}
+
+void BackpressureCombiner::Source::AddController(BackpressureCombiner* ctrl,
+                                                 bool strong_connection) {
+  ctrl->Resume(this, strong_connection);  // populate map in controller
+  connections_.push_back(Connection{ctrl, strong_connection});
+}
+void BackpressureCombiner::Source::Pause() {
+  for (auto& conn_ : connections_) {
+    conn_.ctrl->Pause(this, conn_.strong);
+  }
+}
+void BackpressureCombiner::Source::Resume() {
+  for (auto& conn_ : connections_) {
+    conn_.ctrl->Resume(this, conn_.strong);
+  }
+}
+
+}  // namespace arrow::acero

--- a/cpp/src/arrow/acero/backpressure.cc
+++ b/cpp/src/arrow/acero/backpressure.cc
@@ -64,7 +64,8 @@ void BackpressureCombiner::Resume(Source* output, bool strong_connection) {
 
 void BackpressureCombiner::UpdatePauseStateUnlocked() {
   bool should_be_paused =
-      strong_paused_count_ > 0 || weak_paused_count_ == weak_paused_.size();
+      strong_paused_count_ > 0 ||
+      (weak_paused_count_ > 0 && weak_paused_count_ == weak_paused_.size());
   if (should_be_paused) {
     if (!paused) {
       backpressure_control_->Pause();

--- a/cpp/src/arrow/acero/backpressure.cc
+++ b/cpp/src/arrow/acero/backpressure.cc
@@ -16,7 +16,19 @@
 // under the License.
 
 #include "arrow/acero/backpressure.h"
+#include "arrow/acero/exec_plan.h"
+
 namespace arrow::acero {
+BackpressureController::BackpressureController(ExecNode* node, ExecNode* output,
+                                               std::atomic<int32_t>& backpressure_counter)
+    : node_(node), output_(output), backpressure_counter_(backpressure_counter) {}
+void BackpressureController::Pause() {
+  node_->PauseProducing(output_, ++backpressure_counter_);
+}
+void BackpressureController::Resume() {
+  node_->ResumeProducing(output_, ++backpressure_counter_);
+}
+
 BackpressureCombiner::BackpressureCombiner(
     std::unique_ptr<BackpressureControl> backpressure_control)
     : backpressure_control_(std::move(backpressure_control)) {}

--- a/cpp/src/arrow/acero/backpressure.h
+++ b/cpp/src/arrow/acero/backpressure.h
@@ -21,6 +21,21 @@
 #include <mutex>
 namespace arrow::acero {
 
+// Generic backpressure controller for ExecNode
+class BackpressureController : public BackpressureControl {
+ public:
+  BackpressureController(ExecNode* node, ExecNode* output,
+                         std::atomic<int32_t>& backpressure_counter);
+
+  void Pause() override;
+  void Resume() override;
+
+ private:
+  ExecNode* node_;
+  ExecNode* output_;
+  std::atomic<int32_t>& backpressure_counter_;
+};
+
 // Provides infrastructure of combining multiple backpressure sources and propagate the
 // result into BackpressureControl There are two types of Source: strong - pause on any
 // strong Source within controller

--- a/cpp/src/arrow/acero/backpressure.h
+++ b/cpp/src/arrow/acero/backpressure.h
@@ -53,8 +53,8 @@ class BackpressureControlWrapper : public BackpressureControl {
 // strong Source within controller
 class ARROW_ACERO_EXPORT BackpressureCombiner {
  public:
-  explicit BackpressureCombiner(
-      std::unique_ptr<BackpressureControl> backpressure_control);
+  explicit BackpressureCombiner(std::unique_ptr<BackpressureControl> backpressure_control,
+                                bool pause_on_any = true);
 
   // Instances of Source can be used as usual BackpresureControl.
   // Source can be connected with one or more BackpressureCombiner
@@ -62,31 +62,26 @@ class ARROW_ACERO_EXPORT BackpressureCombiner {
    public:
     // strong - strong_connection=true
     // weak - strong_connection=false
-    explicit Source(BackpressureCombiner* ctrl = nullptr, bool strong_connection = true);
-    void AddController(BackpressureCombiner* ctrl, bool strong_connection = true);
+    explicit Source(BackpressureCombiner* ctrl = nullptr);
+    void AddController(BackpressureCombiner* ctrl);
     void Pause() override;
     void Resume() override;
 
    private:
-    struct Connection {
-      BackpressureCombiner* ctrl;
-      bool strong;
-    };
-    std::vector<Connection> connections_;
+    std::vector<BackpressureCombiner*> connections_;
   };
 
  private:
   friend class Source;
-  void Pause(Source* output, bool strong_connection);
-  void Resume(Source* output, bool strong_connection);
+  void Pause(Source* output);
+  void Resume(Source* output);
 
   void UpdatePauseStateUnlocked();
+  bool pause_on_any_;
   std::unique_ptr<BackpressureControl> backpressure_control_;
   std::mutex mutex_;
-  std::unordered_map<Source*, bool> strong_paused_;
-  std::unordered_map<Source*, bool> weak_paused_;
-  size_t strong_paused_count_{0};
-  size_t weak_paused_count_{0};
+  std::unordered_map<Source*, bool> paused_;
+  size_t paused_count_{0};
   bool paused{false};
 };
 

--- a/cpp/src/arrow/acero/backpressure.h
+++ b/cpp/src/arrow/acero/backpressure.h
@@ -49,15 +49,21 @@ class BackpressureControlWrapper : public BackpressureControl {
 };
 
 // Provides infrastructure of combining multiple backpressure sources and propagate the
-// result into BackpressureControl There are two types of Source: strong - pause on any
-// strong Source within controller
+// result into BackpressureControl There are two logic scheme of backpressure:
+// 1. Default pause_on_any=true - pause on any source is propagated - OR logic
+// 2. pause_on_any=false - pause is propagated only when all sources are paused - AND
+// logic
 class ARROW_ACERO_EXPORT BackpressureCombiner {
  public:
   explicit BackpressureCombiner(std::unique_ptr<BackpressureControl> backpressure_control,
                                 bool pause_on_any = true);
 
   // Instances of Source can be used as usual BackpresureControl.
-  // Source can be connected with one or more BackpressureCombiner
+  // That means that BackpressureCombiner::Source can use another BackpressureCombiner
+  // as backpressure_control
+  // This enabled building more complex backpressure logic using AND/OR operations.
+  // Source can also be connected with more BackpressureCombiners to facilitate
+  // propagation of backpressure to multiple inputs.
   class ARROW_ACERO_EXPORT Source : public BackpressureControl {
    public:
     // strong - strong_connection=true

--- a/cpp/src/arrow/acero/backpressure.h
+++ b/cpp/src/arrow/acero/backpressure.h
@@ -22,7 +22,7 @@
 namespace arrow::acero {
 
 // Generic backpressure controller for ExecNode
-class BackpressureController : public BackpressureControl {
+class ARROW_ACERO_EXPORT BackpressureController : public BackpressureControl {
  public:
   BackpressureController(ExecNode* node, ExecNode* output,
                          std::atomic<int32_t>& backpressure_counter);
@@ -34,6 +34,18 @@ class BackpressureController : public BackpressureControl {
   ExecNode* node_;
   ExecNode* output_;
   std::atomic<int32_t>& backpressure_counter_;
+};
+
+template <typename T>
+class ARROW_ACERO_EXPORT BackpressureControlWrapper : public BackpressureControl {
+ public:
+  explicit BackpressureControlWrapper(T* obj) : obj_(obj) {}
+
+  void Pause() override { obj_->Pause(); }
+  void Resume() override { obj_->Resume(); }
+
+ private:
+  T* obj_;
 };
 
 // Provides infrastructure of combining multiple backpressure sources and propagate the

--- a/cpp/src/arrow/acero/backpressure.h
+++ b/cpp/src/arrow/acero/backpressure.h
@@ -1,0 +1,66 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+#include "arrow/acero/options.h"
+
+#include <mutex>
+namespace arrow::acero {
+
+// Provides infrastructure of combining multiple backpressure sources and propagate the
+// result into BackpressureControl There are two types of Source: strong - pause on any
+// strong Source within controller
+class ARROW_ACERO_EXPORT BackpressureCombiner {
+ public:
+  explicit BackpressureCombiner(
+      std::unique_ptr<BackpressureControl> backpressure_control);
+
+  // Instances of Source can be used as usual BackpresureControl.
+  // Source can be connected with one or more BackpressureCombiner
+  class ARROW_ACERO_EXPORT Source : public BackpressureControl {
+   public:
+    // strong - strong_connection=true
+    // weak - strong_connection=false
+    explicit Source(BackpressureCombiner* ctrl = nullptr, bool strong_connection = true);
+    void AddController(BackpressureCombiner* ctrl, bool strong_connection = true);
+    void Pause() override;
+    void Resume() override;
+
+   private:
+    struct Connection {
+      BackpressureCombiner* ctrl;
+      bool strong;
+    };
+    std::vector<Connection> connections_;
+  };
+
+ private:
+  friend class Source;
+  void Pause(Source* output, bool strong_connection);
+  void Resume(Source* output, bool strong_connection);
+
+  void UpdatePauseStateUnlocked();
+  std::unique_ptr<BackpressureControl> backpressure_control_;
+  std::mutex mutex_;
+  std::unordered_map<Source*, bool> strong_paused_;
+  std::unordered_map<Source*, bool> weak_paused_;
+  size_t strong_paused_count_{0};
+  size_t weak_paused_count_{0};
+  bool paused{false};
+};
+
+}  // namespace arrow::acero

--- a/cpp/src/arrow/acero/backpressure.h
+++ b/cpp/src/arrow/acero/backpressure.h
@@ -37,7 +37,7 @@ class ARROW_ACERO_EXPORT BackpressureController : public BackpressureControl {
 };
 
 template <typename T>
-class ARROW_ACERO_EXPORT BackpressureControlWrapper : public BackpressureControl {
+class BackpressureControlWrapper : public BackpressureControl {
  public:
   explicit BackpressureControlWrapper(T* obj) : obj_(obj) {}
 

--- a/cpp/src/arrow/acero/backpressure_test.cc
+++ b/cpp/src/arrow/acero/backpressure_test.cc
@@ -81,5 +81,44 @@ TEST(BackpressureCombiner, Basic) {
   ASSERT_FALSE(paused);
 }
 
+TEST(BackpressureCombiner, OnlyStrong) {
+  std::atomic<bool> paused{false};
+  BackpressureCombiner combiner(std::make_unique<MonitorBackpressureControl>(paused));
+  BackpressureCombiner::Source strong_source1(&combiner);
+  BackpressureCombiner::Source strong_source2;
+  strong_source2.AddController(&combiner);
+
+  // Any strong causes pause
+  ASSERT_FALSE(paused);
+  strong_source1.Pause();
+  ASSERT_TRUE(paused);
+  strong_source2.Pause();
+  ASSERT_TRUE(paused);
+  strong_source1.Resume();
+  ASSERT_TRUE(paused);
+  strong_source2.Resume();
+  ASSERT_FALSE(paused);
+}
+
+TEST(BackpressureCombiner, OnlyWeak) {
+  std::atomic<bool> paused{false};
+  BackpressureCombiner combiner(std::make_unique<MonitorBackpressureControl>(paused));
+
+  BackpressureCombiner::Source weak_source1(&combiner, false);
+  BackpressureCombiner::Source weak_source2;
+  weak_source2.AddController(&combiner, false);
+
+  // All weak cause pause
+  ASSERT_FALSE(paused);
+  weak_source1.Pause();
+  ASSERT_FALSE(paused);
+  weak_source2.Pause();
+  ASSERT_TRUE(paused);
+  weak_source1.Resume();
+  ASSERT_FALSE(paused);
+  weak_source2.Resume();
+  ASSERT_FALSE(paused);
+}
+
 }  // namespace acero
 }  // namespace arrow

--- a/cpp/src/arrow/acero/backpressure_test.cc
+++ b/cpp/src/arrow/acero/backpressure_test.cc
@@ -31,7 +31,7 @@ class MonitorBackpressureControl : public acero::BackpressureControl {
 };
 
 TEST(BackpressureCombiner, Basic) {
-  std::atomic<bool> paused;
+  std::atomic<bool> paused{false};
   BackpressureCombiner combiner(std::make_unique<MonitorBackpressureControl>(paused));
 
   BackpressureCombiner::Source weak_source1(&combiner, false);

--- a/cpp/src/arrow/acero/backpressure_test.cc
+++ b/cpp/src/arrow/acero/backpressure_test.cc
@@ -1,0 +1,85 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gtest/gtest.h>
+
+#include "arrow/acero/backpressure.h"
+
+namespace arrow {
+namespace acero {
+
+class MonitorBackpressureControl : public acero::BackpressureControl {
+ public:
+  explicit MonitorBackpressureControl(std::atomic<bool>& paused) : paused(paused) {}
+  virtual void Pause() { paused = true; }
+  virtual void Resume() { paused = false; }
+  std::atomic<bool>& paused;
+};
+
+TEST(BackpressureCombiner, Basic) {
+  std::atomic<bool> paused;
+  BackpressureCombiner combiner(std::make_unique<MonitorBackpressureControl>(paused));
+
+  BackpressureCombiner::Source weak_source1(&combiner, false);
+  BackpressureCombiner::Source weak_source2;
+  weak_source2.AddController(&combiner, false);
+  BackpressureCombiner::Source strong_source1(&combiner);
+  BackpressureCombiner::Source strong_source2;
+  strong_source2.AddController(&combiner);
+
+  // Any strong causes pause
+  ASSERT_FALSE(paused);
+  strong_source1.Pause();
+  ASSERT_TRUE(paused);
+  strong_source2.Pause();
+  ASSERT_TRUE(paused);
+  strong_source1.Resume();
+  ASSERT_TRUE(paused);
+  strong_source2.Resume();
+  ASSERT_FALSE(paused);
+
+  // All weak cause pause
+  ASSERT_FALSE(paused);
+  weak_source1.Pause();
+  ASSERT_FALSE(paused);
+  weak_source2.Pause();
+  ASSERT_TRUE(paused);
+  weak_source1.Resume();
+  ASSERT_FALSE(paused);
+  weak_source2.Resume();
+  ASSERT_FALSE(paused);
+
+  // mixed use
+  strong_source1.Pause();
+  ASSERT_TRUE(paused);
+
+  ASSERT_TRUE(paused);
+  weak_source1.Pause();
+  ASSERT_TRUE(paused);
+  weak_source2.Pause();
+
+  strong_source1.Resume();
+  ASSERT_TRUE(paused);
+
+  weak_source1.Resume();
+  ASSERT_FALSE(paused);
+  weak_source2.Resume();
+  ASSERT_FALSE(paused);
+}
+
+}  // namespace acero
+}  // namespace arrow

--- a/cpp/src/arrow/acero/groupby_aggregate_node.cc
+++ b/cpp/src/arrow/acero/groupby_aggregate_node.cc
@@ -65,13 +65,28 @@ namespace acero {
 namespace aggregate {
 
 Status GroupByNode::Init() {
+  auto backpressure_controller_ =
+      std::make_unique<BackpressureController>(inputs_[0], this, backpressure_counter_);
+  backpressure_combiner_ =
+      std::make_unique<BackpressureCombiner>(std::move(backpressure_controller_));
+  backpressure_source_output_ =
+      std::make_unique<BackpressureCombiner::Source>(backpressure_combiner_.get());
+
+  if (segmenter_->key_types().size() == 0) {
+    backpressure_source_output_ = std::make_unique<BackpressureCombiner::Source>(nullptr);
+  } else {
+    backpressure_source_output_ =
+        std::make_unique<BackpressureCombiner::Source>(backpressure_combiner_.get());
+  }
+
   if (!ordering_.is_unordered()) {
+    auto backpressure_source_sequencer_ =
+        std::make_unique<BackpressureCombiner::Source>(backpressure_combiner_.get());
+
     constexpr size_t low_threshold = 4, high_threshold = 8;
-    std::unique_ptr<arrow::acero::BackpressureControl> backpressure_control =
-        std::make_unique<BackpressureController>(inputs_[0], this);
-    ARROW_ASSIGN_OR_RAISE(auto handler,
-                          BackpressureHandler::Make(this, low_threshold, high_threshold,
-                                                    std::move(backpressure_control)));
+    ARROW_ASSIGN_OR_RAISE(auto handler, BackpressureHandler::Make(
+                                            this, low_threshold, high_threshold,
+                                            std::move(backpressure_source_sequencer_)));
 
     processor_ = acero::util::SerialSequencingQueue::Processor::MakeBackpressureWrapper(
         this, std::move(handler), plan_, false);

--- a/cpp/src/arrow/acero/hash_aggregate_test.cc
+++ b/cpp/src/arrow/acero/hash_aggregate_test.cc
@@ -39,6 +39,7 @@
 #include "arrow/compute/cast.h"
 #include "arrow/compute/exec.h"
 #include "arrow/compute/exec_internal.h"
+#include "arrow/compute/ordering.h"
 #include "arrow/compute/registry.h"
 #include "arrow/compute/row/grouper.h"
 #include "arrow/table.h"
@@ -315,7 +316,8 @@ Result<Datum> RunGroupBy(const BatchesWithSchema& input,
       Declaration::Sequence(
           {
               {"source",
-               SourceNodeOptions{input.schema, input.gen(use_threads, /*slow=*/false)}},
+               SourceNodeOptions{input.schema, input.gen(use_threads, /*slow=*/false),
+                                 Ordering::Implicit()}},
               {"aggregate", AggregateNodeOptions{aggregates, std::move(keys),
                                                  std::move(segment_keys)}},
               {"sink", SinkNodeOptions{&sink_gen}},

--- a/cpp/src/arrow/acero/meson.build
+++ b/cpp/src/arrow/acero/meson.build
@@ -51,6 +51,7 @@ arrow_acero_srcs = [
     'groupby_aggregate_node.cc',
     'aggregate_internal.cc',
     'asof_join_node.cc',
+    'backpressure.cc',
     'bloom_filter.cc',
     'exec_plan.cc',
     'fetch_node.cc',
@@ -89,6 +90,7 @@ arrow_acero_dep = declare_dependency(link_with: [arrow_acero_lib])
 arrow_acero_testing_sources = ['test_nodes.cc', 'test_util_internal.cc']
 
 arrow_acero_tests = {
+    'backpressure-test': {'sources': ['backpressure_test.cc']},
     'plan-test': {'sources': ['plan_test.cc', 'test_nodes_test.cc']},
     'source-node-test': {'sources': ['source_node_test.cc']},
     'fetch-node-test': {'sources': ['fetch_node_test.cc']},

--- a/cpp/src/arrow/acero/plan_test.cc
+++ b/cpp/src/arrow/acero/plan_test.cc
@@ -1651,12 +1651,13 @@ TEST(ExecPlanExecution, SegmentedAggregationWithMultiThreading) {
   data.schema = schema({field("i32", int32())});
   Declaration plan = Declaration::Sequence(
       {{"source",
-        SourceNodeOptions{data.schema, data.gen(/*parallel=*/false, /*slow=*/false)}},
+        SourceNodeOptions{data.schema, data.gen(/*parallel=*/false, /*slow=*/false),
+                          Ordering::Unordered()}},
        {"aggregate", AggregateNodeOptions{/*aggregates=*/{
                                               {"count", nullptr, "i32", "count(i32)"},
                                           },
                                           /*keys=*/{}, /*segment_keys=*/{"i32"}}}});
-  EXPECT_RAISES_WITH_MESSAGE_THAT(NotImplemented, HasSubstr("multi-threaded"),
+  EXPECT_RAISES_WITH_MESSAGE_THAT(Invalid, HasSubstr("meaningful ordering"),
                                   DeclarationToExecBatches(std::move(plan)));
 }
 
@@ -1674,7 +1675,8 @@ TEST(ExecPlanExecution, SegmentedAggregationWithOneSegment) {
 
   Declaration plan = Declaration::Sequence(
       {{"source",
-        SourceNodeOptions{data.schema, data.gen(/*parallel=*/false, /*slow=*/false)}},
+        SourceNodeOptions{data.schema, data.gen(/*parallel=*/false, /*slow=*/false),
+                          Ordering::Implicit()}},
        {"aggregate", AggregateNodeOptions{/*aggregates=*/{
                                               {"hash_sum", nullptr, "c", "sum(c)"},
                                               {"hash_mean", nullptr, "c", "mean(c)"},
@@ -1703,7 +1705,8 @@ TEST(ExecPlanExecution, SegmentedAggregationWithTwoSegments) {
 
   Declaration plan = Declaration::Sequence(
       {{"source",
-        SourceNodeOptions{data.schema, data.gen(/*parallel=*/false, /*slow=*/false)}},
+        SourceNodeOptions{data.schema, data.gen(/*parallel=*/false, /*slow=*/false),
+                          Ordering::Implicit()}},
        {"aggregate", AggregateNodeOptions{/*aggregates=*/{
                                               {"hash_sum", nullptr, "c", "sum(c)"},
                                               {"hash_mean", nullptr, "c", "mean(c)"},
@@ -1733,7 +1736,8 @@ TEST(ExecPlanExecution, SegmentedAggregationWithBatchCrossingSegment) {
 
   Declaration plan = Declaration::Sequence(
       {{"source",
-        SourceNodeOptions{data.schema, data.gen(/*parallel=*/false, /*slow=*/false)}},
+        SourceNodeOptions{data.schema, data.gen(/*parallel=*/false, /*slow=*/false),
+                          Ordering::Implicit()}},
        {"aggregate", AggregateNodeOptions{/*aggregates=*/{
                                               {"hash_sum", nullptr, "c", "sum(c)"},
                                               {"hash_mean", nullptr, "c", "mean(c)"},

--- a/cpp/src/arrow/acero/sorted_merge_node.cc
+++ b/cpp/src/arrow/acero/sorted_merge_node.cc
@@ -24,6 +24,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "arrow/acero/backpressure.h"
 #include "arrow/acero/concurrent_queue_internal.h"
 #include "arrow/acero/exec_plan.h"
 #include "arrow/acero/exec_plan_internal.h"
@@ -81,21 +82,6 @@ using col_index_t = int;
 
 constexpr bool kNewTask = true;
 constexpr bool kPoisonPill = false;
-
-class BackpressureController : public BackpressureControl {
- public:
-  BackpressureController(ExecNode* node, ExecNode* output,
-                         std::atomic<int32_t>& backpressure_counter)
-      : node_(node), output_(output), backpressure_counter_(backpressure_counter) {}
-
-  void Pause() override { node_->PauseProducing(output_, ++backpressure_counter_); }
-  void Resume() override { node_->ResumeProducing(output_, ++backpressure_counter_); }
-
- private:
-  ExecNode* node_;
-  ExecNode* output_;
-  std::atomic<int32_t>& backpressure_counter_;
-};
 
 /// InputState corresponds to an input. Input record batches are queued up in InputState
 /// until processed and turned into output record batches.

--- a/python/pyarrow/tests/test_table.py
+++ b/python/pyarrow/tests/test_table.py
@@ -2978,15 +2978,12 @@ def test_table_group_by():
 
 @pytest.mark.acero
 def test_table_group_by_first():
-    # "first" is an ordered aggregation -> requires to specify use_threads=False
     table1 = pa.table({'a': [1, 2, 3, 4], 'b': ['a', 'b'] * 2})
     table2 = pa.table({'a': [1, 2, 3, 4], 'b': ['b', 'a'] * 2})
     table = pa.concat_tables([table1, table2])
 
-    with pytest.raises(NotImplementedError):
-        table.group_by("b").aggregate([("a", "first")])
+    result = table.group_by("b", use_threads=True).aggregate([("a", "first")])
 
-    result = table.group_by("b", use_threads=False).aggregate([("a", "first")])
     expected = pa.table({"b": ["a", "b"], "a_first": [1, 2]})
     assert result.equals(expected)
 


### PR DESCRIPTION
Rationale for this change

Lack of multi threading inputs support (batches were incoming not in order if they were ordered) with nodes like ScalarAggregateNode and GroupByNode previously resolved by disabling multi threading when using them.
    Lack of ordering information on output of nodes ScalarAggregateNode and GroupByNode when input was ordered.

What changes are included in this PR?
- added sequencer to input of ScalarAggregateNode and GroupByNode, (enables only it self when input is ordered).
- added support for propagate ordering to ScalarAggregateNode and GroupByNode.
- added BackPressure support when using Segmented keys.

Are these changes tested?

Yes
Are there any user-facing changes?

Yes. Users of those node must assert ordering on input where apropriate.
* GitHub Issue: #47269