### PR TITLE
GH-46690: [GLib][CI] Use Meson 1.8.4 or later

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -157,11 +157,9 @@ jobs:
       - name: Install Homebrew Dependencies
         shell: bash
         run: |
-          # pkg-config formula is deprecated but it's still installed
-          # in GitHub Actions runner now. We can remove this once
-          # pkg-config formula is removed from GitHub Actions runner.
-          brew uninstall pkg-config || :
-          brew uninstall pkg-config@0.29.2 || :
+          # We can remove this once GitHub hosted runners include
+          # Meson 1.8.4 or later by default.
+          brew update
           brew bundle --file=cpp/Brewfile
           brew bundle --file=c_glib/Brewfile
           # For Meson.


### PR DESCRIPTION
### Rationale for this change

Meson 1.8.3 has wrong detection logic. It breaks our CI.

See also: https://github.com/mesonbuild/meson/issues/14856

### What changes are included in this PR?

Use Meson 1.8.4 or later by explicit `brew update`.

We can remove the explicit `brew update` once GitHub hosted runners include Meson 1.8.4 or later by default.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #46690