### PR TITLE
GH-47422: [Python][C++][Flight] Expose ipc::ReadStats in Flight MetadataRecordBatchReader

### DIFF
--- a/cpp/src/arrow/flight/client.cc
+++ b/cpp/src/arrow/flight/client.cc
@@ -261,7 +261,9 @@ class ClientStreamReader : public FlightStreamReader {
   }
 
   arrow::ipc::ReadStats stats() const override {
-    ARROW_CHECK_NE(batch_reader_, nullptr);
+    if (batch_reader_ == nullptr) {
+      return ipc::ReadStats{};
+    }
     return batch_reader_->stats();
   }
 

--- a/cpp/src/arrow/flight/client.cc
+++ b/cpp/src/arrow/flight/client.cc
@@ -225,6 +225,7 @@ class ClientStreamReader : public FlightStreamReader {
       out.app_metadata = data->app_metadata;
       out.data = nullptr;
       peekable_reader_->Next(&data);
+      extra_messages_++;
       return out;
     }
 
@@ -261,10 +262,15 @@ class ClientStreamReader : public FlightStreamReader {
   }
 
   arrow::ipc::ReadStats stats() const override {
+    ipc::ReadStats stats;
     if (batch_reader_ == nullptr) {
-      return ipc::ReadStats{};
+      stats = ipc::ReadStats{};
+      stats.num_messages = extra_messages_;
+      return stats;
     }
-    return batch_reader_->stats();
+    stats = batch_reader_->stats();
+    stats.num_messages += extra_messages_;
+    return stats;
   }
 
   arrow::Result<std::shared_ptr<Table>> ToTable() override {
@@ -288,6 +294,7 @@ class ClientStreamReader : public FlightStreamReader {
   std::shared_ptr<internal::PeekableFlightDataReader> peekable_reader_;
   std::shared_ptr<ipc::RecordBatchStreamReader> batch_reader_;
   std::shared_ptr<Buffer> app_metadata_;
+  int64_t extra_messages_ = 0;
 };
 
 FlightMetadataReader::~FlightMetadataReader() = default;
@@ -468,6 +475,7 @@ class ClientStreamWriter : public FlightStreamWriter {
     if (!success) {
       return Close();
     }
+    extra_messages_++;
     return Status::OK();
   }
 
@@ -520,7 +528,9 @@ class ClientStreamWriter : public FlightStreamWriter {
 
   ipc::WriteStats stats() const override {
     ARROW_CHECK_NE(batch_writer_, nullptr);
-    return batch_writer_->stats();
+    auto write_stats = batch_writer_->stats();
+    write_stats.num_messages += extra_messages_;
+    return write_stats;
   }
 
  private:
@@ -538,6 +548,7 @@ class ClientStreamWriter : public FlightStreamWriter {
   bool closed_;
   // Close() is expected to be idempotent
   Status final_status_;
+  int64_t extra_messages_ = 0;
 
   // Temporary state to construct the IPC payload writer
   ipc::IpcWriteOptions write_options_;

--- a/cpp/src/arrow/flight/client.cc
+++ b/cpp/src/arrow/flight/client.cc
@@ -259,6 +259,12 @@ class ClientStreamReader : public FlightStreamReader {
     }
     return batches;
   }
+
+  arrow::ipc::ReadStats stats() const override {
+    ARROW_CHECK_NE(batch_reader_, nullptr);
+    return batch_reader_->stats();
+  }
+
   arrow::Result<std::shared_ptr<Table>> ToTable() override {
     return ToTable(stop_token_);
   }
@@ -278,7 +284,7 @@ class ClientStreamReader : public FlightStreamReader {
   StopToken stop_token_;
   std::shared_ptr<MemoryManager> memory_manager_;
   std::shared_ptr<internal::PeekableFlightDataReader> peekable_reader_;
-  std::shared_ptr<ipc::RecordBatchReader> batch_reader_;
+  std::shared_ptr<ipc::RecordBatchStreamReader> batch_reader_;
   std::shared_ptr<Buffer> app_metadata_;
 };
 

--- a/cpp/src/arrow/flight/client.h
+++ b/cpp/src/arrow/flight/client.h
@@ -141,6 +141,9 @@ class ARROW_FLIGHT_EXPORT FlightStreamReader : public MetadataRecordBatchReader 
   using MetadataRecordBatchReader::ToTable;
   /// \brief Consume entire stream as a Table
   arrow::Result<std::shared_ptr<Table>> ToTable(const StopToken& stop_token);
+
+  /// \brief Return current read statistics
+  virtual arrow::ipc::ReadStats stats() const = 0;
 };
 
 // Silence warning

--- a/cpp/src/arrow/flight/client.h
+++ b/cpp/src/arrow/flight/client.h
@@ -142,6 +142,7 @@ class ARROW_FLIGHT_EXPORT FlightStreamReader : public MetadataRecordBatchReader 
   /// \brief Consume entire stream as a Table
   arrow::Result<std::shared_ptr<Table>> ToTable(const StopToken& stop_token);
 
+  using MetadataRecordBatchReader::stats;
   /// \brief Return current read statistics
   virtual arrow::ipc::ReadStats stats() const = 0;
 };

--- a/cpp/src/arrow/flight/transport_server.cc
+++ b/cpp/src/arrow/flight/transport_server.cc
@@ -154,10 +154,15 @@ class TransportMessageReader final : public FlightMessageReader {
     return Status::OK();
   }
 
+  ipc::ReadStats stats() const override {
+    ARROW_CHECK_NE(batch_reader_, nullptr);
+    return batch_reader_->stats();
+  }
+
   FlightDescriptor descriptor_;
   std::shared_ptr<internal::PeekableFlightDataReader> peekable_reader_;
   std::shared_ptr<MemoryManager> memory_manager_;
-  std::shared_ptr<RecordBatchReader> batch_reader_;
+  std::shared_ptr<ipc::RecordBatchStreamReader> batch_reader_;
   std::shared_ptr<Buffer> app_metadata_;
 };
 

--- a/cpp/src/arrow/flight/transport_server.cc
+++ b/cpp/src/arrow/flight/transport_server.cc
@@ -137,6 +137,13 @@ class TransportMessageReader final : public FlightMessageReader {
     return out;
   }
 
+  ipc::ReadStats stats() const override {
+    if (batch_reader_ == nullptr) {
+      return ipc::ReadStats{};
+    }
+    return batch_reader_->stats();
+  }
+
  private:
   /// Ensure we are set up to read data.
   Status EnsureDataStarted() {
@@ -152,11 +159,6 @@ class TransportMessageReader final : public FlightMessageReader {
           batch_reader_, ipc::RecordBatchStreamReader::Open(std::move(message_reader)));
     }
     return Status::OK();
-  }
-
-  ipc::ReadStats stats() const override {
-    ARROW_CHECK_NE(batch_reader_, nullptr);
-    return batch_reader_->stats();
   }
 
   FlightDescriptor descriptor_;

--- a/cpp/src/arrow/flight/types.h
+++ b/cpp/src/arrow/flight/types.h
@@ -35,7 +35,6 @@
 #include "arrow/flight/type_fwd.h"
 #include "arrow/flight/visibility.h"
 #include "arrow/ipc/options.h"
-#include "arrow/ipc/reader.h"
 #include "arrow/ipc/writer.h"
 #include "arrow/result.h"
 #include "arrow/status.h"
@@ -48,6 +47,7 @@ class Table;
 
 namespace ipc {
 class DictionaryMemo;
+struct ReadStats;
 }  // namespace ipc
 
 namespace util {

--- a/cpp/src/arrow/flight/types.h
+++ b/cpp/src/arrow/flight/types.h
@@ -35,6 +35,7 @@
 #include "arrow/flight/type_fwd.h"
 #include "arrow/flight/visibility.h"
 #include "arrow/ipc/options.h"
+#include "arrow/ipc/reader.h"
 #include "arrow/ipc/writer.h"
 #include "arrow/result.h"
 #include "arrow/status.h"
@@ -1179,6 +1180,9 @@ class ARROW_FLIGHT_EXPORT MetadataRecordBatchReader {
 
   /// \brief Consume entire stream as a Table
   virtual arrow::Result<std::shared_ptr<Table>> ToTable();
+
+  /// \brief Return current read statistics
+  virtual arrow::ipc::ReadStats stats() const = 0;
 };
 
 /// \brief Convert a MetadataRecordBatchReader to a regular RecordBatchReader.

--- a/python/pyarrow/_flight.pyx
+++ b/python/pyarrow/_flight.pyx
@@ -1118,6 +1118,19 @@ cdef class _MetadataRecordBatchReader(_Weakrefable, _ReadPandasMixin):
 
         return reader
 
+    @property
+    def stats(self):
+        """
+        Current Flight read statistics.
+
+        Returns
+        -------
+        ReadStats
+        """
+        if not self.reader:
+            raise ValueError("Operation on closed reader")
+        return _wrap_read_stats((<CMetadataRecordBatchReader*> self.reader.get()).stats())
+
 
 cdef class MetadataRecordBatchReader(_MetadataRecordBatchReader):
     """The base class for readers for Flight streams.

--- a/python/pyarrow/includes/libarrow_flight.pxd
+++ b/python/pyarrow/includes/libarrow_flight.pxd
@@ -202,6 +202,7 @@ cdef extern from "arrow/flight/api.h" namespace "arrow" nogil:
         CResult[shared_ptr[CSchema]] GetSchema()
         CResult[CFlightStreamChunk] Next()
         CResult[shared_ptr[CTable]] ToTable()
+        CIpcReadStats stats() const
 
     CResult[shared_ptr[CRecordBatchReader]] MakeRecordBatchReader\
         " arrow::flight::MakeRecordBatchReader"(

--- a/python/pyarrow/ipc.pxi
+++ b/python/pyarrow/ipc.pxi
@@ -125,7 +125,6 @@ class ReadStats(_ReadStats):
     __slots__ = ()
 
 
-@staticmethod
 cdef _wrap_read_stats(CIpcReadStats c):
     return ReadStats(c.num_messages, c.num_record_batches,
                      c.num_dictionary_batches, c.num_dictionary_deltas,

--- a/python/pyarrow/lib.pxd
+++ b/python/pyarrow/lib.pxd
@@ -48,6 +48,9 @@ cdef class IpcReadOptions(_Weakrefable):
         CIpcReadOptions c_options
 
 
+cdef _wrap_read_stats(CIpcReadStats c)
+
+
 cdef class Message(_Weakrefable):
     cdef:
         unique_ptr[CMessage] message

--- a/python/pyarrow/tests/test_flight.py
+++ b/python/pyarrow/tests/test_flight.py
@@ -36,7 +36,7 @@ except ImportError:
 import pytest
 import pyarrow as pa
 
-from pyarrow.lib import IpcReadOptions, tobytes
+from pyarrow.lib import IpcReadOptions, ReadStats, tobytes
 from pyarrow.util import find_free_port
 from pyarrow.tests import util
 
@@ -185,6 +185,7 @@ class MetadataFlightServer(FlightServerBase):
     def do_put(self, context, descriptor, reader, writer):
         counter = 0
         expected_data = [-10, -5, 0, 5, 10]
+        assert reader.stats.num_messages == 1
         for batch, buf in reader:
             assert batch.equals(pa.RecordBatch.from_arrays(
                 [pa.array([expected_data[counter]])],
@@ -195,6 +196,8 @@ class MetadataFlightServer(FlightServerBase):
             assert counter == client_counter
             writer.write(struct.pack('<i', counter))
             counter += 1
+        assert reader.stats.num_messages == 6
+        assert reader.stats.num_record_batches == 5
 
     @staticmethod
     def number_batches(table):
@@ -1170,8 +1173,17 @@ def test_flight_do_get_dicts():
 
     with ConstantFlightServer() as server, \
             flight.connect(('localhost', server.port)) as client:
-        data = client.do_get(flight.Ticket(b'dicts')).read_all()
+        reader = client.do_get(flight.Ticket(b'dicts'))
+        assert reader.stats.num_messages == 1
+        data = reader.read_all()
         assert data.equals(table)
+        assert reader.stats == ReadStats(
+            num_messages=6,
+            num_record_batches=3,
+            num_dictionary_batches=2,
+            num_dictionary_deltas=0,
+            num_replaced_dictionaries=1
+        )
 
 
 def test_flight_do_get_ticket():
@@ -2090,6 +2102,8 @@ def test_doexchange_put():
             assert chunk.data is None
             expected_buf = str(len(batches)).encode("utf-8")
             assert chunk.app_metadata == expected_buf
+            # TODO: Investigate segfault
+            # assert reader.stats == {}
 
 
 def test_doexchange_echo():
@@ -2539,36 +2553,60 @@ def test_headers_trailers():
 
 
 def test_flight_dictionary_deltas_do_exchange():
+    expected_dict_deltas_stats = ReadStats(
+        num_messages=6,
+        num_record_batches=3,
+        num_dictionary_batches=2,
+        num_dictionary_deltas=1,
+        num_replaced_dictionaries=0
+    )
+    expected_dict_replacement_stats = ReadStats(
+        num_messages=6,
+        num_record_batches=3,
+        num_dictionary_batches=2,
+        num_dictionary_deltas=0,
+        num_replaced_dictionaries=1
+    )
+
     class DeltaFlightServer(ConstantFlightServer):
         def do_exchange(self, context, descriptor, reader, writer):
+            expected_table = simple_dicts_table()
+            received_table = reader.read_all()
+            assert received_table.equals(expected_table)
             if descriptor.command == b'dict_deltas':
-                expected_table = simple_dicts_table()
-                received_table = reader.read_all()
-                assert received_table.equals(expected_table)
+                assert reader.stats == expected_dict_deltas_stats
 
                 options = pa.ipc.IpcWriteOptions(emit_dictionary_deltas=True)
                 writer.begin(expected_table.schema, options=options)
-                # TODO: GH-47422: Inspect ReaderStats once exposed and validate deltas
+                writer.write_table(expected_table)
+            if descriptor.command == b'dict_replacement':
+                assert reader.stats == expected_dict_replacement_stats
+
+                writer.begin(expected_table.schema)
                 writer.write_table(expected_table)
 
     with DeltaFlightServer() as server, \
             FlightClient(('localhost', server.port)) as client:
         expected_table = simple_dicts_table()
+        for command in [b"dict_deltas", b"dict_replacement"]:
+            descriptor = flight.FlightDescriptor.for_command(command)
+            writer, reader = client.do_exchange(
+                descriptor,
+                options=flight.FlightCallOptions(
+                    write_options=pa.ipc.IpcWriteOptions(
+                        emit_dictionary_deltas=True)
+                )
+            )
+            # Send client table with dictionary updates
+            with writer:
+                writer.begin(expected_table.schema, options=pa.ipc.IpcWriteOptions(
+                    emit_dictionary_deltas=(command == b"dict_deltas")))
+                writer.write_table(expected_table)
+                writer.done_writing()
+                received_table = reader.read_all()
 
-        descriptor = flight.FlightDescriptor.for_command(b"dict_deltas")
-        writer, reader = client.do_exchange(descriptor,
-                                            options=flight.FlightCallOptions(
-                                                write_options=pa.ipc.IpcWriteOptions(
-                                                    emit_dictionary_deltas=True)
-                                            )
-                                            )
-        # Send client table with dictionary updates (deltas should be sent)
-        with writer:
-            writer.begin(expected_table.schema, options=pa.ipc.IpcWriteOptions(
-                emit_dictionary_deltas=True))
-            writer.write_table(expected_table)
-            writer.done_writing()
-            received_table = reader.read_all()
-
-        # TODO: GH-47422: Inspect ReaderStats once exposed and validate deltas
-        assert received_table.equals(expected_table)
+            assert received_table.equals(expected_table)
+            if command == b"dict_deltas":
+                assert reader.stats == expected_dict_deltas_stats
+            elif command == b"dict_replacement":
+                assert reader.stats == expected_dict_replacement_stats

--- a/python/pyarrow/tests/test_flight.py
+++ b/python/pyarrow/tests/test_flight.py
@@ -2152,7 +2152,8 @@ def test_doexchange_echo():
                 chunk = reader.read_chunk()
                 assert chunk.data == batch
                 assert chunk.app_metadata == buf
-                assert reader.stats.num_record_batches == num_batches + i + 1
+                num_batches += 1
+                assert reader.stats.num_record_batches == num_batches
 
 
 def test_doexchange_echo_v4():

--- a/python/pyarrow/tests/test_flight.py
+++ b/python/pyarrow/tests/test_flight.py
@@ -2109,8 +2109,7 @@ def test_doexchange_put():
             assert chunk.data is None
             expected_buf = str(len(batches)).encode("utf-8")
             assert chunk.app_metadata == expected_buf
-            # Metadata only message is not counted as an ipc data message
-            assert reader.stats.num_messages == 0
+            assert reader.stats.num_messages == 1
 
 
 def test_doexchange_echo():

--- a/python/pyarrow/tests/test_flight.py
+++ b/python/pyarrow/tests/test_flight.py
@@ -2109,7 +2109,8 @@ def test_doexchange_put():
             assert chunk.data is None
             expected_buf = str(len(batches)).encode("utf-8")
             assert chunk.app_metadata == expected_buf
-            assert reader.stats.num_messages == 1
+            # Metadata only message is not counted as an ipc data message
+            assert reader.stats.num_messages == 0
 
 
 def test_doexchange_echo():


### PR DESCRIPTION
### Rationale for this change

Now that we have implemented dictionary replacement / dictionary deltas on DoGet/DoExchange, exposing ReadStatistics can help us easily understand / debug / diagnose much better what are the different messages being sent.

### What changes are included in this PR?

Add API to expose `arrow::ipc::ReadStats stats()` on `MetadataRecordBatchReader`. As we are mainly using `RecordBatchStreamReader` everywhere now, the stats are already populated so we just have to expose them.
Add also Python bindings.

### Are these changes tested?

Yes via several Python tests we are validating the stats are retrieved and the results are the expected ones.

### Are there any user-facing changes?

No breaking changes, new API to retrieve Statistics from the readers.

* GitHub Issue: #47422