### PR TITLE
[C++][Acero] Exec_context not passed to Filter from FilterNode

### DIFF
--- a/cpp/src/arrow/acero/filter_node.cc
+++ b/cpp/src/arrow/acero/filter_node.cc
@@ -100,7 +100,7 @@ class FilterNode : public MapNode {
     auto values = batch.values;
     for (auto& value : values) {
       if (value.is_scalar()) continue;
-      ARROW_ASSIGN_OR_RAISE(value, Filter(value, mask, FilterOptions::Defaults()));
+      ARROW_ASSIGN_OR_RAISE(value, Filter(value, mask, FilterOptions::Defaults(), plan()->query_context()->exec_context()));
     }
     return ExecBatch::Make(std::move(values));
   }


### PR DESCRIPTION
### Rationale for this change

When using a Acero with a non-default execution context and memory pool, I noticed that the ```FilterNode``` did not use the ```MemoryPool``` as intended but instead falls back to the default Arrow mi-malloc memory pool. As a consequence, any output data of the filter is not allocated with the intended memory pool.  As all other Acero Nodes did take the execution context and MemoryPool into account, this seems like a bug to me.

### What changes are included in this PR?

I changed the ```ProcessBatch``` function of the ```FilterNode``` such that is passes its execution context to the underlying ```Filter``` operator instead of using the default parameter in the ```Filter``` constructor.

The same code and behavior is already present in other nodes. See for example the [ProjectNode](https://github.com/apache/arrow/blob/main/cpp/src/arrow/acero/project_node.cc#L99).

### Are these changes tested?

Yes. After including the change from this PR, filtering in Acero takes the MemoryPool from the execution context into account as intended.

### Are there any user-facing changes?

No. For users with the default execution context no changes are noticeable. For users that use a non-default context this is now used as intended.
