### PR TITLE
GH-47446: [C++] Update Meson configuration with compute swizzle change

### DIFF
--- a/cpp/src/arrow/meson.build
+++ b/cpp/src/arrow/meson.build
@@ -75,6 +75,7 @@ arrow_components = {
             'compute/kernels/vector_selection_filter_internal.cc',
             'compute/kernels/vector_selection_internal.cc',
             'compute/kernels/vector_selection_take_internal.cc',
+            'compute/kernels/vector_swizzle.cc',
         ],
     },
     'arrow_io': {
@@ -471,7 +472,6 @@ if needs_compute
         'compute/kernels/vector_select_k.cc',
         'compute/kernels/vector_sort.cc',
         'compute/kernels/vector_statistics.cc',
-        'compute/kernels/vector_swizzle.cc',
         'compute/key_hash_internal.cc',
         'compute/key_map_internal.cc',
         'compute/light_array_internal.cc',


### PR DESCRIPTION
### Rationale for this change

The Meson configuration for compute was broken after the vector swizzle change was introduced; this gets the Meson configuration at parity with CMake again

### What changes are included in this PR?

Move `vector_swizzle.cc` to `libarrow` from `libarrow_compute`.

See also: #47378

### Are these changes tested?

Yes 
### Are there any user-facing changes?

No
* GitHub Issue: #47446