### PR TITLE
GH-47451: [Python][CI] Install tzdata-legacy in newer python-wheel-manylinux-test images

### DIFF
--- a/ci/docker/python-wheel-manylinux-test.dockerfile
+++ b/ci/docker/python-wheel-manylinux-test.dockerfile
@@ -28,7 +28,8 @@ RUN pip install -r /arrow/python/requirements-wheel-test.txt
 RUN apt-get update -y -q && \
     apt-get install -y -q \
         build-essential \
-        python3-dev && \
+        python3-dev \
+        tzdata-legacy && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists*
 


### PR DESCRIPTION
### Rationale for this change

The newer underlying docker image doesn't contain required timezones.

### What changes are included in this PR?

Install `tzdata-legacy` on the docker image so timezones are available. This is already being done on other images.

### Are these changes tested?

Yes, locally and via CI the failing jobs are now successful.

### Are there any user-facing changes?

No

* GitHub Issue: #47451