### PR TITLE
Update host validation for HDFS connection (correctly fix #25324)

### DIFF
--- a/python/pyarrow/_hdfs.pyx
+++ b/python/pyarrow/_hdfs.pyx
@@ -72,9 +72,13 @@ cdef class HadoopFileSystem(FileSystem):
             CHdfsOptions options
             shared_ptr[CHadoopFileSystem] wrapped
 
-        if not host.startswith(('hdfs://', 'viewfs://')) and host != "default":
+        if not host.startswith(('hdfs://', 'viewfs://')):
             # TODO(kszucs): do more sanitization
             host = f'hdfs://{host}'
+
+        # Allow from_uri with hdfs://default
+        if host == 'hdfs://default':
+            host = 'default'
 
         options.ConfigureEndPoint(tobytes(host), int(port))
         options.ConfigureReplication(replication)


### PR DESCRIPTION
Refactor host validation to allow 'hdfs://default' as a valid input to correctly fix #25324 when used via `from_uri()`.

### Rationale for this change

While `fs.HadoopFileSystem()` could be created with the special host 'default' to make the underlying hdfs library to search for the correct URL in $HADOOP_CONF_DIR/core-site.xml, the fix does not work using `from_uri()`. This is because `from_uri()` has to have a complete protocol URI (hdfs://default), but the underlying hdfs library must have exactly 'default', without the URI type. The code includes the previous fix and fixes also this case.

### What changes are included in this PR?

A correct fix of #25324 for the `from_uri()` case.

### Are these changes tested?

Yes

### Are there any user-facing changes?

Yes, now the `from_uri()` function should work with `hdfs://default...` URI.

