### PR TITLE
GH-47102: [Statistics][C++] Implement Statistics specification attribute ARROW:max_byte_width:{exact,approximate} Component: C++ 

### DIFF
--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -3911,6 +3911,7 @@ class TestArrayDataStatistics : public ::testing::Test {
     valids_ = {1, 0, 1, 1};
     null_count_ = std::count(valids_.begin(), valids_.end(), 0);
     distinct_count_ = 3.0;
+    max_byte_width_ = 4.0;
     average_byte_width_ = 4.0;
     null_buffer_ = *internal::BytesToBits(valids_);
     values_ = {1, 0, 3, -4};
@@ -3922,6 +3923,7 @@ class TestArrayDataStatistics : public ::testing::Test {
     data_->statistics = std::make_shared<ArrayStatistics>();
     data_->statistics->null_count = null_count_;
     data_->statistics->distinct_count = distinct_count_;
+    data_->statistics->max_byte_width = max_byte_width_;
     data_->statistics->average_byte_width = average_byte_width_;
     data_->statistics->is_average_byte_width_exact = true;
     data_->statistics->min = min_;
@@ -3934,6 +3936,7 @@ class TestArrayDataStatistics : public ::testing::Test {
   std::vector<uint8_t> valids_;
   size_t null_count_;
   double distinct_count_;
+  double max_byte_width_;
   double average_byte_width_;
   std::shared_ptr<Buffer> null_buffer_;
   std::vector<int32_t> values_;
@@ -3953,6 +3956,10 @@ TEST_F(TestArrayDataStatistics, MoveConstructor) {
   ASSERT_TRUE(moved_data.statistics->distinct_count.has_value());
   ASSERT_DOUBLE_EQ(distinct_count_,
                    std::get<double>(moved_data.statistics->distinct_count.value()));
+
+  ASSERT_TRUE(moved_data.statistics->max_byte_width.has_value());
+  ASSERT_DOUBLE_EQ(max_byte_width_,
+                   std::get<double>(moved_data.statistics->max_byte_width.value()));
 
   ASSERT_TRUE(moved_data.statistics->average_byte_width.has_value());
   ASSERT_DOUBLE_EQ(average_byte_width_,
@@ -3979,6 +3986,10 @@ TEST_F(TestArrayDataStatistics, CopyConstructor) {
   ASSERT_TRUE(copied_data.statistics->distinct_count.has_value());
   ASSERT_DOUBLE_EQ(distinct_count_,
                    std::get<double>(copied_data.statistics->distinct_count.value()));
+
+  ASSERT_TRUE(copied_data.statistics->max_byte_width.has_value());
+  ASSERT_DOUBLE_EQ(max_byte_width_,
+                   std::get<double>(copied_data.statistics->max_byte_width.value()));
 
   ASSERT_TRUE(copied_data.statistics->average_byte_width.has_value());
   ASSERT_DOUBLE_EQ(average_byte_width_,
@@ -4008,6 +4019,10 @@ TEST_F(TestArrayDataStatistics, MoveAssignment) {
   ASSERT_DOUBLE_EQ(distinct_count_,
                    std::get<double>(moved_data.statistics->distinct_count.value()));
 
+  ASSERT_TRUE(moved_data.statistics->max_byte_width.has_value());
+  ASSERT_DOUBLE_EQ(max_byte_width_,
+                   std::get<double>(moved_data.statistics->max_byte_width.value()));
+
   ASSERT_TRUE(moved_data.statistics->average_byte_width.has_value());
   ASSERT_DOUBLE_EQ(average_byte_width_,
                    moved_data.statistics->average_byte_width.value());
@@ -4034,6 +4049,10 @@ TEST_F(TestArrayDataStatistics, CopyAssignment) {
   ASSERT_TRUE(copied_data.statistics->distinct_count.has_value());
   ASSERT_DOUBLE_EQ(distinct_count_,
                    std::get<double>(copied_data.statistics->distinct_count.value()));
+
+  ASSERT_TRUE(copied_data.statistics->max_byte_width.has_value());
+  ASSERT_DOUBLE_EQ(max_byte_width_,
+                   std::get<double>(copied_data.statistics->max_byte_width.value()));
 
   ASSERT_TRUE(copied_data.statistics->average_byte_width.has_value());
   ASSERT_DOUBLE_EQ(average_byte_width_,

--- a/cpp/src/arrow/array/statistics.h
+++ b/cpp/src/arrow/array/statistics.h
@@ -83,7 +83,7 @@ struct ARROW_EXPORT ArrayStatistics {
   /// and when set to `double`, it represents `approximate_distinct_count`.
   std::optional<CountType> distinct_count = std::nullopt;
 
-  /// \brief The maximum length in bytes among the rows of an array, may not be set
+  /// \brief The maximum length in bytes of the rows in an array; may not be set
   /// Note: when the type is `int64_t`, it represents `max_byte_width_exact`,
   /// and when the type is `double`, it represents `max_byte_width_approximate`.
   std::optional<SizeType> max_byte_width = std::nullopt;

--- a/cpp/src/arrow/array/statistics.h
+++ b/cpp/src/arrow/array/statistics.h
@@ -84,8 +84,8 @@ struct ARROW_EXPORT ArrayStatistics {
   std::optional<CountType> distinct_count = std::nullopt;
 
   /// \brief The maximum length in bytes among the rows of an array, may not be set
-  /// \Note When the type is `int64_t`, it represents `max_byte_width_exact`,
-  ///  and when the type is `double`, it represents `max_byte_width_approximate`.
+  /// Note: when the type is `int64_t`, it represents `max_byte_width_exact`,
+  /// and when the type is `double`, it represents `max_byte_width_approximate`.
   std::optional<SizeType> max_byte_width = std::nullopt;
 
   /// \brief The average size in bytes of a row in an array, may not be set.

--- a/cpp/src/arrow/array/statistics.h
+++ b/cpp/src/arrow/array/statistics.h
@@ -41,6 +41,7 @@ struct ARROW_EXPORT ArrayStatistics {
   using ValueType = std::variant<bool, int64_t, uint64_t, double, std::string>;
   using NumericType = std::variant<int64_t, double>;
   using CountType = NumericType;
+  using SizeType = NumericType;
 
   static const std::shared_ptr<DataType>& ValueToArrowType(
       const std::optional<ValueType>& value,
@@ -81,6 +82,11 @@ struct ARROW_EXPORT ArrayStatistics {
   /// Note: when set to `int64_t`, it represents `exact_distinct_count`,
   /// and when set to `double`, it represents `approximate_distinct_count`.
   std::optional<CountType> distinct_count = std::nullopt;
+
+  /// \brief The maximum length in bytes among the rows of an array, may not be set
+  /// \Note When the type is `int64_t`, it represents `max_byte_width_exact`,
+  ///  and when the type is `double`, it represents `max_byte_width_approximate`.
+  std::optional<SizeType> max_byte_width = std::nullopt;
 
   /// \brief The average size in bytes of a row in an array, may not be set.
   std::optional<double> average_byte_width = std::nullopt;

--- a/cpp/src/arrow/array/statistics_test.cc
+++ b/cpp/src/arrow/array/statistics_test.cc
@@ -49,6 +49,22 @@ TEST(TestArrayStatistics, DistinctCountApproximate) {
   ASSERT_DOUBLE_EQ(29.0, std::get<double>(statistics.distinct_count.value()));
 }
 
+TEST(TestArrayStatistics, MaxByteWidthExact) {
+  ArrayStatistics statistics;
+  ASSERT_FALSE(statistics.max_byte_width.has_value());
+  statistics.max_byte_width = static_cast<int64_t>(5);
+  ASSERT_TRUE(statistics.max_byte_width.has_value());
+  ASSERT_EQ(5, std::get<int64_t>(statistics.max_byte_width.value()));
+}
+
+TEST(TestArrayStatistics, MaxByteWidthApproximate) {
+  ArrayStatistics statistics;
+  ASSERT_FALSE(statistics.max_byte_width.has_value());
+  statistics.max_byte_width = 5.0;
+  ASSERT_TRUE(statistics.max_byte_width.has_value());
+  ASSERT_DOUBLE_EQ(5.0, std::get<double>(statistics.max_byte_width.value()));
+}
+
 TEST(TestArrayStatistics, AverageByteWidth) {
   ArrayStatistics statistics;
   ASSERT_FALSE(statistics.average_byte_width.has_value());
@@ -105,6 +121,18 @@ TEST(TestArrayStatistics, Equals) {
   statistics1.distinct_count = 2930.5;
   ASSERT_NE(statistics1, statistics2);
   statistics2.distinct_count = 2930.5;
+  ASSERT_EQ(statistics1, statistics2);
+
+  // Test MAX_BYTE_WIDTH_EXACT
+  statistics1.max_byte_width = static_cast<int64_t>(5);
+  ASSERT_NE(statistics1, statistics2);
+  statistics2.max_byte_width = static_cast<int64_t>(5);
+  ASSERT_EQ(statistics1, statistics2);
+
+  // Test MAX_BYTE_WIDTH_APPROXIMATE
+  statistics1.max_byte_width = 5.0;
+  ASSERT_NE(statistics1, statistics2);
+  statistics2.max_byte_width = 5.0;
   ASSERT_EQ(statistics1, statistics2);
 
   statistics1.average_byte_width = 2.9;

--- a/cpp/src/arrow/compare.cc
+++ b/cpp/src/arrow/compare.cc
@@ -1566,6 +1566,8 @@ bool ArrayStatisticsEqualsImpl(const ArrayStatistics& left, const ArrayStatistic
   return left.null_count == right.null_count &&
          ArrayStatisticsOptionalValueEquals(left.distinct_count, right.distinct_count,
                                             equal_options) &&
+         ArrayStatisticsOptionalValueEquals(left.max_byte_width, right.max_byte_width,
+                                            equal_options) &&
          left.is_average_byte_width_exact == right.is_average_byte_width_exact &&
          left.is_min_exact == right.is_min_exact &&
          left.is_max_exact == right.is_max_exact &&

--- a/cpp/src/arrow/record_batch.cc
+++ b/cpp/src/arrow/record_batch.cc
@@ -564,6 +564,22 @@ Status EnumerateStatistics(const RecordBatch& record_batch, OnStatistics on_stat
       statistics.start_new_column = false;
     }
 
+    if (column_statistics->max_byte_width.has_value()) {
+      statistics.nth_statistics++;
+      if (std::holds_alternative<int64_t>(column_statistics->max_byte_width.value())) {
+        statistics.key = ARROW_STATISTICS_KEY_MAX_BYTE_WIDTH_EXACT;
+        statistics.type = int64();
+        statistics.value = std::get<int64_t>(column_statistics->max_byte_width.value());
+      } else {
+        statistics.key = ARROW_STATISTICS_KEY_MAX_BYTE_WIDTH_APPROXIMATE;
+        statistics.type = float64();
+        statistics.value = std::get<double>(column_statistics->max_byte_width.value());
+      }
+
+      RETURN_NOT_OK(on_statistics(statistics));
+      statistics.start_new_column = false;
+    }
+
     if (column_statistics->average_byte_width.has_value()) {
       statistics.nth_statistics++;
       if (column_statistics->is_average_byte_width_exact) {


### PR DESCRIPTION

### Rationale for this change
Add` max_byte_width statistics{exact,approxiamte} `statistics attributes
### What changes are included in this PR?
Add `arrow::ArrayStatistics::max_byte_width` with relevant unit tests
### Are these changes tested?
Yes, I ran the related unit tests
### Are there any user-facing changes?
Yes, Add  `arrow::ArrayStatistics::max_byte_width`


* GitHub Issue: #47102