### PR TITLE
GH-47449: [C++][Parquet] Do not drop all Statistics if SortOrder is UNKNOWN

### DIFF
--- a/cpp/src/parquet/metadata.cc
+++ b/cpp/src/parquet/metadata.cc
@@ -327,10 +327,7 @@ class ColumnChunkMetaData::ColumnChunkMetaDataImpl {
   // 2) Statistics must not be corrupted
   inline bool is_stats_set() const {
     DCHECK(writer_version_ != nullptr);
-    // If the column statistics don't exist or column sort order is unknown
-    // we cannot use the column stats
-    if (!column_metadata_->__isset.statistics ||
-        descr_->sort_order() == SortOrder::UNKNOWN) {
+    if (!column_metadata_->__isset.statistics) {
       return false;
     }
     {
@@ -338,6 +335,10 @@ class ColumnChunkMetaData::ColumnChunkMetaDataImpl {
       if (possible_encoded_stats_ == nullptr) {
         possible_encoded_stats_ =
             std::make_shared<EncodedStatistics>(FromThrift(column_metadata_->statistics));
+        if (descr_->sort_order() == SortOrder::UNKNOWN) {
+          // If the column SortOrder is Unknown we can't trust max/min.
+          possible_encoded_stats_->ClearMinMax();
+        }
       }
     }
     return writer_version_->HasCorrectStatistics(type(), *possible_encoded_stats_,
@@ -1586,11 +1587,6 @@ bool ApplicationVersion::HasCorrectStatistics(Type::type col_type,
   // parquet-mr during the same time as PARQUET-251, see PARQUET-297
   if (application_ == "unknown") {
     return true;
-  }
-
-  // Unknown sort order has incorrect stats
-  if (SortOrder::UNKNOWN == sort_order) {
-    return false;
   }
 
   // PARQUET-251

--- a/cpp/src/parquet/statistics.cc
+++ b/cpp/src/parquet/statistics.cc
@@ -337,7 +337,7 @@ CleanStatistic(std::pair<T, T> min_max, LogicalType::Type::type) {
 }
 
 std::optional<std::pair<Int96, Int96>> CleanStatistic(std::pair<Int96, Int96> min_max,
-                                                 LogicalType::Type::type) {
+                                                      LogicalType::Type::type) {
   return min_max;
 }
 

--- a/cpp/src/parquet/statistics.cc
+++ b/cpp/src/parquet/statistics.cc
@@ -336,6 +336,11 @@ CleanStatistic(std::pair<T, T> min_max, LogicalType::Type::type) {
   return min_max;
 }
 
+optional<std::pair<Int96, Int96>> CleanStatistic(std::pair<Int96, Int96> min_max,
+                                                 LogicalType::Type::type) {
+  return min_max;
+}
+
 // In case of floating point types, the following rules are applied (as per
 // upstream parquet-mr):
 // - If any of min/max is NaN, return nothing.
@@ -991,6 +996,8 @@ std::shared_ptr<Comparator> DoMakeComparator(Type::type physical_type,
       default:
         ParquetException::NYI("Unsigned Compare not implemented");
     }
+  } else if (SortOrder::UNKNOWN == sort_order) {
+    return nullptr;
   } else {
     throw ParquetException("UNKNOWN Sort Order");
   }
@@ -1104,6 +1111,7 @@ std::shared_ptr<Statistics> Statistics::Make(
     MAKE_STATS(BOOLEAN, BooleanType);
     MAKE_STATS(INT32, Int32Type);
     MAKE_STATS(INT64, Int64Type);
+    MAKE_STATS(INT96, Int96Type);
     MAKE_STATS(FLOAT, FloatType);
     MAKE_STATS(DOUBLE, DoubleType);
     MAKE_STATS(BYTE_ARRAY, ByteArrayType);

--- a/cpp/src/parquet/statistics.cc
+++ b/cpp/src/parquet/statistics.cc
@@ -580,7 +580,7 @@ class TypedStatisticsImpl : public TypedStatistics<DType> {
         logical_type_(LogicalTypeId(descr_)) {
     try {
       comparator_ = MakeComparator<DType>(descr);
-    } catch (const std::exception& e) {
+    } catch (const ParquetException&) {
       comparator_ = nullptr;
     }
     TypedStatisticsImpl::Reset();

--- a/cpp/src/parquet/statistics.cc
+++ b/cpp/src/parquet/statistics.cc
@@ -336,7 +336,7 @@ CleanStatistic(std::pair<T, T> min_max, LogicalType::Type::type) {
   return min_max;
 }
 
-optional<std::pair<Int96, Int96>> CleanStatistic(std::pair<Int96, Int96> min_max,
+std::optional<std::pair<Int96, Int96>> CleanStatistic(std::pair<Int96, Int96> min_max,
                                                  LogicalType::Type::type) {
   return min_max;
 }

--- a/cpp/src/parquet/statistics.h
+++ b/cpp/src/parquet/statistics.h
@@ -163,6 +163,14 @@ class PARQUET_EXPORT EncodedStatistics {
     }
   }
 
+  // Clear Min Max.
+  void ClearMinMax() {
+    has_max = false;
+    max_.clear();
+    has_min = false;
+    min_.clear();
+  }
+
   bool is_set() const {
     return has_min || has_max || has_null_count || has_distinct_count;
   }

--- a/cpp/src/parquet/statistics_test.cc
+++ b/cpp/src/parquet/statistics_test.cc
@@ -296,7 +296,7 @@ TEST(Comparison, UnknownSortOrder) {
                           ConvertedType::INTERVAL, 12);
   ColumnDescriptor descr(node, 0, 0);
 
-  ASSERT_THROW(Comparator::Make(&descr), ParquetException);
+  ASSERT_EQ(Comparator::Make(&descr), nullptr);
 }
 
 // ----------------------------------------------------------------------

--- a/cpp/src/parquet/statistics_test.cc
+++ b/cpp/src/parquet/statistics_test.cc
@@ -296,7 +296,7 @@ TEST(Comparison, UnknownSortOrder) {
                           ConvertedType::INTERVAL, 12);
   ColumnDescriptor descr(node, 0, 0);
 
-  ASSERT_EQ(Comparator::Make(&descr), nullptr);
+  ASSERT_THROW(Comparator::Make(&descr), ParquetException);
 }
 
 // ----------------------------------------------------------------------


### PR DESCRIPTION
### Rationale for this change

Currently we drop all statistics if `SortOrder` is `UNKNOWN`. This seems too broad and there are some statistics, like `null_count` that could be maintained.

https://github.com/apache/arrow/blob/6f6138b7eedece0841b04f4e235e3bedf5a3ee29/cpp/src/parquet/metadata.cc#L330-L335

Clearing `min/max` but allowing to keep `null_count` when `SortOrder` is `UNKNOWN` would allow users to use them.

### What changes are included in this PR?

Maintain Statistics when reading them if `SortOrder::UNKNOWK` but clear min/max

### Are these changes tested?

Yes, there is a file on parquet-testing which allows us to validate this exact scenario.

### Are there any user-facing changes?

No changes to APIs, users will be able to read statistics on this case.

* GitHub Issue: #47449