### PR TITLE
GH-43904: [CI][Python] Stop uploading nightly wheels to gemfury

### DIFF
--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -123,32 +123,6 @@ env:
       CROSSBOW_GITHUB_TOKEN: {{ '${{ secrets.CROSSBOW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}' }}
 {% endmacro %}
 
-{%- macro github_upload_gemfury(pattern) -%}
-  {%- if arrow.is_default_branch() -%}
-  - name: Set up Ruby
-    uses: ruby/setup-ruby@v1
-    with:
-      ruby-version: "ruby"
-  - name: Install gemfury client
-    run: |
-      gem install gemfury
-  - name: Upload package to Gemfury
-    shell: bash
-    run: |
-      if $(fury versions --as=${CROSSBOW_GEMFURY_ORG} --api-token=${CROSSBOW_GEMFURY_TOKEN} pyarrow | grep --fixed-strings -q "{{ arrow.no_rc_version }}"); then
-        echo "Version {{ arrow.no_rc_version }} already exists. Avoid pushing version."
-      else
-        fury push \
-          --api-token=${CROSSBOW_GEMFURY_TOKEN} \
-          --as=${CROSSBOW_GEMFURY_ORG} \
-          {{ pattern }}
-      fi
-    env:
-      CROSSBOW_GEMFURY_TOKEN: {{ '${{ secrets.CROSSBOW_GEMFURY_TOKEN }}' }}
-      CROSSBOW_GEMFURY_ORG: {{ '${{ secrets.CROSSBOW_GEMFURY_ORG }}' }}
-  {% endif %}
-{% endmacro %}
-
 {%- macro github_upload_wheel_scientific_python(pattern) -%}
   {%- if arrow.is_default_branch() -%}
   - name: Upload wheel to Anaconda scientific-python

--- a/dev/tasks/python-sdist/github.yml
+++ b/dev/tasks/python-sdist/github.yml
@@ -43,4 +43,3 @@ jobs:
           PYARROW_VERSION: {{ arrow.no_rc_version }}
 
       {{ macros.github_upload_releases("arrow/python/dist/*.tar.gz")|indent }}
-      {{ macros.github_upload_gemfury("arrow/python/dist/*.tar.gz")|indent }}

--- a/dev/tasks/python-wheels/github.linux.yml
+++ b/dev/tasks/python-wheels/github.linux.yml
@@ -133,7 +133,6 @@ jobs:
             ubuntu-verify-rc
 
       {{ macros.github_upload_releases("arrow/python/repaired_wheels/*.whl")|indent }}
-      {{ macros.github_upload_gemfury("arrow/python/repaired_wheels/*.whl")|indent }}
       {{ macros.github_upload_wheel_scientific_python("arrow/python/repaired_wheels/*.whl")|indent }}
 
       {% if arrow.is_default_branch() %}

--- a/dev/tasks/python-wheels/github.osx.yml
+++ b/dev/tasks/python-wheels/github.osx.yml
@@ -140,5 +140,4 @@ jobs:
           arch -{{ arch }} arrow/ci/scripts/python_wheel_unix_test.sh $(pwd)/arrow
 
       {{ macros.github_upload_releases("arrow/python/repaired_wheels/*.whl")|indent }}
-      {{ macros.github_upload_gemfury("arrow/python/repaired_wheels/*.whl")|indent }}
       {{ macros.github_upload_wheel_scientific_python("arrow/python/repaired_wheels/*.whl")|indent }}

--- a/dev/tasks/python-wheels/github.windows.yml
+++ b/dev/tasks/python-wheels/github.windows.yml
@@ -90,7 +90,6 @@ jobs:
           archery docker run %TEST_IMAGE_PREFIX%-wheel-windows-test
 
       {{ macros.github_upload_releases("arrow/python/repaired_wheels/*.whl")|indent }}
-      {{ macros.github_upload_gemfury("arrow/python/repaired_wheels/*.whl")|indent }}
       {{ macros.github_upload_wheel_scientific_python("arrow/python/repaired_wheels/*.whl")|indent }}
 
       {% if arrow.is_default_branch() %}


### PR DESCRIPTION
### Rationale for this change

We started uploading nightly wheels to the scientific python channel on anaconda:
https://anaconda.org/scientific-python-nightly-wheels/pyarrow
Which are the documented nightlies:
https://arrow.apache.org/docs/dev/developers/python.html#installing-nightly-packages
We updated the documentation and have been deprecating with a long release cycle.

Uploading wheels to gemfury sometimes fail due to trying to upload the same version of the wheels.

### What changes are included in this PR?

Stop uploading nightly wheels to gemfury.

### Are these changes tested?

No

### Are there any user-facing changes?

Yes, nightly wheels will not be available on gemfury anymore.

* GitHub Issue: #43904