### PR TITLE
GH-47469: [C++][Gandiva] Add support for LLVM 21.1.0

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -177,6 +177,7 @@ set(ARROW_DOC_DIR "share/doc/${PROJECT_NAME}")
 set(BUILD_SUPPORT_DIR "${CMAKE_SOURCE_DIR}/build-support")
 
 set(ARROW_LLVM_VERSIONS
+    "21.1"
     "20.1"
     "19.1"
     "18.1"

--- a/cpp/src/gandiva/llvm_types.h
+++ b/cpp/src/gandiva/llvm_types.h
@@ -56,7 +56,7 @@ class GANDIVA_EXPORT LLVMTypes {
   llvm::Type* double_type() { return llvm::Type::getDoubleTy(context_); }
 
   llvm::PointerType* ptr_type(llvm::Type* type) {
-    return llvm::PointerType::get(type, 0);
+    return llvm::PointerType::get(context_, 0);
   }
 
   llvm::PointerType* i8_ptr_type() { return ptr_type(i8_type()); }

--- a/cpp/src/gandiva/llvm_types.h
+++ b/cpp/src/gandiva/llvm_types.h
@@ -56,7 +56,11 @@ class GANDIVA_EXPORT LLVMTypes {
   llvm::Type* double_type() { return llvm::Type::getDoubleTy(context_); }
 
   llvm::PointerType* ptr_type(llvm::Type* type) {
+#if LLVM_VERSION_MAJOR >= 21
     return llvm::PointerType::get(context_, 0);
+#else
+    return llvm::PointerType::get(type, 0);
+#endif
   }
 
   llvm::PointerType* i8_ptr_type() { return ptr_type(i8_type()); }


### PR DESCRIPTION
### Rationale for this change

LLVM 21.1 was released and some of our CI jobs are failing.

### What changes are included in this PR?

* Accept LLVM 21.1
* Don't use deprecated API

Two of the related commits that changed APIs on LLVM are:
- https://github.com/llvm/llvm-project/commit/034f2b380bd2d84e8cfbcb647b50602711d170c7
- https://github.com/llvm/llvm-project/commit/b18e5b6a36399f11ba1152875b6892900c5afdaf

### Are these changes tested?

Yes on CI

### Are there any user-facing changes?

No

* GitHub Issue: #47469