### PR TITLE
GH-41336: [C++][Compute] Fix case_when kernel dispatch for decimals with different precisions and scales

### DIFF
--- a/cpp/src/arrow/compute/expression_test.cc
+++ b/cpp/src/arrow/compute/expression_test.cc
@@ -717,6 +717,51 @@ TEST(Expression, BindWithImplicitCasts) {
                 call("is_in", {cast(field_ref("dict_str"), utf8())}, in_a));
 }
 
+TEST(Expression, BindWithImplicitCastsForCaseWhenOnDecimal) {
+  auto exciting_schema = schema(
+      {field("a", struct_({field("", boolean())})),
+       field("dec128_20_3", decimal128(20, 3)), field("dec128_21_3", decimal128(21, 3)),
+       field("dec128_20_1", decimal128(20, 1)), field("dec128_21_1", decimal128(21, 1)),
+       field("dec256_20_3", decimal256(20, 3)), field("dec256_21_3", decimal256(21, 3)),
+       field("dec256_20_1", decimal256(20, 1)), field("dec256_21_1", decimal256(21, 1))});
+  ExpectBindsTo(call("case_when", {field_ref("a"), field_ref("dec128_20_3"),
+                                   field_ref("dec128_21_3")}),
+                call("case_when",
+                     {field_ref("a"), cast(field_ref("dec128_20_3"), decimal128(21, 3)),
+                      field_ref("dec128_21_3")}),
+                /*bound_out=*/nullptr, *exciting_schema);
+  ExpectBindsTo(call("case_when", {field_ref("a"), field_ref("dec128_20_1"),
+                                   field_ref("dec128_21_3")}),
+                call("case_when",
+                     {field_ref("a"), cast(field_ref("dec128_20_1"), decimal128(22, 3)),
+                      cast(field_ref("dec128_21_3"), decimal128(22, 3))}),
+                /*bound_out=*/nullptr, *exciting_schema);
+  ExpectBindsTo(call("case_when", {field_ref("a"), field_ref("dec128_20_3"),
+                                   field_ref("dec128_21_1")}),
+                call("case_when",
+                     {field_ref("a"), cast(field_ref("dec128_20_3"), decimal128(23, 3)),
+                      cast(field_ref("dec128_21_1"), decimal128(23, 3))}),
+                /*bound_out=*/nullptr, *exciting_schema);
+  ExpectBindsTo(call("case_when", {field_ref("a"), field_ref("dec128_20_3"),
+                                   field_ref("dec256_21_3")}),
+                call("case_when",
+                     {field_ref("a"), cast(field_ref("dec128_20_3"), decimal256(21, 3)),
+                      field_ref("dec256_21_3")}),
+                /*bound_out=*/nullptr, *exciting_schema);
+  ExpectBindsTo(call("case_when", {field_ref("a"), field_ref("dec256_20_1"),
+                                   field_ref("dec128_21_3")}),
+                call("case_when",
+                     {field_ref("a"), cast(field_ref("dec256_20_1"), decimal256(22, 3)),
+                      cast(field_ref("dec128_21_3"), decimal256(22, 3))}),
+                /*bound_out=*/nullptr, *exciting_schema);
+  ExpectBindsTo(call("case_when", {field_ref("a"), field_ref("dec256_20_3"),
+                                   field_ref("dec256_21_1")}),
+                call("case_when",
+                     {field_ref("a"), cast(field_ref("dec256_20_3"), decimal256(23, 3)),
+                      cast(field_ref("dec256_21_1"), decimal256(23, 3))}),
+                /*bound_out=*/nullptr, *exciting_schema);
+}
+
 TEST(Expression, BindNestedCall) {
   auto expr = add(field_ref("a"),
                   call("subtract", {call("multiply", {field_ref("b"), field_ref("c")}),

--- a/cpp/src/arrow/compute/kernel.cc
+++ b/cpp/src/arrow/compute/kernel.cc
@@ -478,7 +478,7 @@ std::string OutputType::ToString() const {
 // ----------------------------------------------------------------------
 // MatchConstraint
 
-std::shared_ptr<MatchConstraint> MakeConstraint(
+std::shared_ptr<MatchConstraint> MatchConstraint::Make(
     std::function<bool(const std::vector<TypeHolder>&)> matches) {
   class FunctionMatchConstraint : public MatchConstraint {
    public:

--- a/cpp/src/arrow/compute/kernel.h
+++ b/cpp/src/arrow/compute/kernel.h
@@ -356,11 +356,11 @@ class ARROW_EXPORT MatchConstraint {
 
   /// \brief Return true if the input types satisfy the constraint.
   virtual bool Matches(const std::vector<TypeHolder>& types) const = 0;
-};
 
-/// \brief Convenience function to create a MatchConstraint from a match function.
-ARROW_EXPORT std::shared_ptr<MatchConstraint> MakeConstraint(
-    std::function<bool(const std::vector<TypeHolder>&)> matches);
+  /// \brief Convenience function to create a MatchConstraint from a match function.
+  static std::shared_ptr<MatchConstraint> Make(
+      std::function<bool(const std::vector<TypeHolder>&)> matches);
+};
 
 /// \brief Constraint that all input types are decimal types and have the same scale.
 ARROW_EXPORT std::shared_ptr<MatchConstraint> DecimalsHaveSameScale();

--- a/cpp/src/arrow/compute/kernel_test.cc
+++ b/cpp/src/arrow/compute/kernel_test.cc
@@ -313,7 +313,7 @@ TEST(OutputType, Resolve) {
 TEST(MatchConstraint, ConvenienceMaker) {
   {
     auto always_match =
-        MakeConstraint([](const std::vector<TypeHolder>& types) { return true; });
+        MatchConstraint::Make([](const std::vector<TypeHolder>& types) { return true; });
 
     ASSERT_TRUE(always_match->Matches({}));
     ASSERT_TRUE(always_match->Matches({int8(), int16(), int32()}));
@@ -321,7 +321,7 @@ TEST(MatchConstraint, ConvenienceMaker) {
 
   {
     auto always_false =
-        MakeConstraint([](const std::vector<TypeHolder>& types) { return false; });
+        MatchConstraint::Make([](const std::vector<TypeHolder>& types) { return false; });
 
     ASSERT_FALSE(always_false->Matches({}));
     ASSERT_FALSE(always_false->Matches({int8(), int16(), int32()}));

--- a/cpp/src/arrow/compute/kernels/scalar_if_else.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else.cc
@@ -1459,12 +1459,9 @@ struct CaseWhenFunction : ScalarFunction {
           DCHECK(std::all_of(types.begin() + 1, types.end(), [](const TypeHolder& type) {
             return is_decimal(type.id());
           }));
-          const auto& ty1 = checked_cast<const DecimalType&>(*types[1].type);
           return std::all_of(
-              types.begin() + 2, types.end(), [&ty1](const TypeHolder& type) {
-                const auto& ty = checked_cast<const DecimalType&>(*type.type);
-                return ty1.Equals(ty);
-              });
+              types.begin() + 2, types.end(),
+              [&types](const TypeHolder& type) { return type == types[1]; });
         });
     return constraint;
   }

--- a/cpp/src/arrow/compute/kernels/scalar_if_else.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else.cc
@@ -1455,7 +1455,7 @@ struct CaseWhenFunction : ScalarFunction {
   static std::shared_ptr<MatchConstraint> DecimalMatchConstraint() {
     static auto constraint =
         MatchConstraint::Make([](const std::vector<TypeHolder>& types) -> bool {
-          DCHECK_GE(types.size(), 3);
+          DCHECK_GE(types.size(), 2);
           DCHECK(std::all_of(types.begin() + 1, types.end(), [](const TypeHolder& type) {
             return is_decimal(type.id());
           }));

--- a/cpp/src/arrow/compute/kernels/scalar_if_else.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else.cc
@@ -1451,6 +1451,23 @@ struct CaseWhenFunction : ScalarFunction {
     if (auto kernel = DispatchExactImpl(this, *types)) return kernel;
     return arrow::compute::detail::NoMatchingKernel(this, *types);
   }
+
+  static std::shared_ptr<MatchConstraint> DecimalMatchConstraint() {
+    static auto constraint =
+        MatchConstraint::Make([](const std::vector<TypeHolder>& types) -> bool {
+          DCHECK_GE(types.size(), 3);
+          DCHECK(std::all_of(types.begin() + 1, types.end(), [](const TypeHolder& type) {
+            return is_decimal(type.id());
+          }));
+          const auto& ty1 = checked_cast<const DecimalType&>(*types[1].type);
+          return std::all_of(
+              types.begin() + 2, types.end(), [&ty1](const TypeHolder& type) {
+                const auto& ty = checked_cast<const DecimalType&>(*type.type);
+                return ty1.Equals(ty);
+              });
+        });
+    return constraint;
+  }
 };
 
 // Implement a 'case when' (SQL)/'select' (NumPy) function for any scalar conditions
@@ -2712,10 +2729,11 @@ struct ChooseFunction : ScalarFunction {
 };
 
 void AddCaseWhenKernel(const std::shared_ptr<CaseWhenFunction>& scalar_function,
-                       detail::GetTypeId get_id, ArrayKernelExec exec) {
+                       detail::GetTypeId get_id, ArrayKernelExec exec,
+                       std::shared_ptr<MatchConstraint> constraint = nullptr) {
   ScalarKernel kernel(
       KernelSignature::Make({InputType(Type::STRUCT), InputType(get_id.id)}, LastType,
-                            /*is_varargs=*/true),
+                            /*is_varargs=*/true, std::move(constraint)),
       exec);
   if (is_fixed_width(get_id.id)) {
     kernel.null_handling = NullHandling::COMPUTED_PREALLOCATE;
@@ -2890,8 +2908,10 @@ void RegisterScalarIfElse(FunctionRegistry* registry) {
     AddPrimitiveCaseWhenKernels(func, {boolean(), null(), float16()});
     AddCaseWhenKernel(func, Type::FIXED_SIZE_BINARY,
                       CaseWhenFunctor<FixedSizeBinaryType>::Exec);
-    AddCaseWhenKernel(func, Type::DECIMAL128, CaseWhenFunctor<FixedSizeBinaryType>::Exec);
-    AddCaseWhenKernel(func, Type::DECIMAL256, CaseWhenFunctor<FixedSizeBinaryType>::Exec);
+    AddCaseWhenKernel(func, Type::DECIMAL128, CaseWhenFunctor<FixedSizeBinaryType>::Exec,
+                      CaseWhenFunction::DecimalMatchConstraint());
+    AddCaseWhenKernel(func, Type::DECIMAL256, CaseWhenFunctor<FixedSizeBinaryType>::Exec,
+                      CaseWhenFunction::DecimalMatchConstraint());
     AddBinaryCaseWhenKernels(func, BaseBinaryTypes());
     AddNestedCaseWhenKernels(func);
     DCHECK_OK(registry->AddFunction(std::move(func)));


### PR DESCRIPTION
### Rationale for this change

Another case of decimal kernels not able to suppress exact matching when precisions and scales of the arguments differ, causing wrong result type. After #47297, we have a systematic way to do that and guide the matching to go to the "best match" (applying implicit casts).

### What changes are included in this PR?

Simply added a constraint match that checks if the precisions and scales of the decimal arguments are the same. Also added corresponding tests in forms of both expression (exact match first, then best match) and function call (best match only).

### Are these changes tested?

Yes.

### Are there any user-facing changes?

None.
* GitHub Issue: #41336