### PR TITLE
GH-47367: [Packaging][Python] Patch vcpkg to show logs and install newer Windows SDK for vs_buildtools

### DIFF
--- a/.env
+++ b/.env
@@ -97,7 +97,7 @@ VCPKG="f7423ee180c4b7f40d43402c2feb3859161ef625"    # 2024.06.15 Release
 # ci/docker/python-*-windows-*.dockerfile or the vcpkg config.
 # This is a workaround for our CI problem that "archery docker build" doesn't
 # use pulled built images in dev/tasks/python-wheels/github.windows.yml.
-PYTHON_WHEEL_WINDOWS_IMAGE_REVISION=2025-02-25
+PYTHON_WHEEL_WINDOWS_IMAGE_REVISION=2025-09-03-trigger-rebuild
 PYTHON_WHEEL_WINDOWS_TEST_IMAGE_REVISION=2025-02-25
 
 # Use conanio/${CONAN_BASE}:{CONAN_VERSION} for "docker compose run --rm conan".

--- a/.env
+++ b/.env
@@ -97,8 +97,8 @@ VCPKG="f7423ee180c4b7f40d43402c2feb3859161ef625"    # 2024.06.15 Release
 # ci/docker/python-*-windows-*.dockerfile or the vcpkg config.
 # This is a workaround for our CI problem that "archery docker build" doesn't
 # use pulled built images in dev/tasks/python-wheels/github.windows.yml.
-PYTHON_WHEEL_WINDOWS_IMAGE_REVISION=2025-09-03-trigger-rebuild
-PYTHON_WHEEL_WINDOWS_TEST_IMAGE_REVISION=2025-02-25
+PYTHON_WHEEL_WINDOWS_IMAGE_REVISION=2025-09-04
+PYTHON_WHEEL_WINDOWS_TEST_IMAGE_REVISION=2025-09-04
 
 # Use conanio/${CONAN_BASE}:{CONAN_VERSION} for "docker compose run --rm conan".
 # See https://github.com/conan-io/conan-docker-tools#readme and

--- a/ci/docker/python-wheel-windows-test-vs2022-base.dockerfile
+++ b/ci/docker/python-wheel-windows-test-vs2022-base.dockerfile
@@ -33,8 +33,10 @@ RUN `
     curl -SL --output vs_buildtools.exe https://aka.ms/vs/17/release/vs_buildtools.exe `
     && (start /w vs_buildtools.exe --quiet --wait --norestart --nocache `
     --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools" `
-    --includeRecommended ^ `
-    --add Microsoft.VisualStudio.Workload.VCTools ^ `
+    --add Microsoft.VisualStudio.Component.VC.CoreBuildTools `
+    --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
+    --add Microsoft.VisualStudio.Component.Windows11SDK.26100 `
+    --add Microsoft.VisualStudio.Component.VC.CMake.Project `
     || IF "%ERRORLEVEL%"=="3010" EXIT 0) `
     && del /q vs_buildtools.exe
 

--- a/ci/docker/python-wheel-windows-test-vs2022-base.dockerfile
+++ b/ci/docker/python-wheel-windows-test-vs2022-base.dockerfile
@@ -34,6 +34,7 @@ RUN `
     && (start /w vs_buildtools.exe --quiet --wait --norestart --nocache `
     --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools" `
     --includeRecommended ^ `
+    --add Microsoft.VisualStudio.Workload.VCTools ^ `
     || IF "%ERRORLEVEL%"=="3010" EXIT 0) `
     && del /q vs_buildtools.exe
 

--- a/ci/docker/python-wheel-windows-test-vs2022-base.dockerfile
+++ b/ci/docker/python-wheel-windows-test-vs2022-base.dockerfile
@@ -34,7 +34,6 @@ RUN `
     && (start /w vs_buildtools.exe --quiet --wait --norestart --nocache `
     --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools" `
     --includeRecommended ^ `
-    --add Microsoft.VisualStudio.Workload.VCTools ^ `
     || IF "%ERRORLEVEL%"=="3010" EXIT 0) `
     && del /q vs_buildtools.exe
 

--- a/ci/docker/python-wheel-windows-test-vs2022-base.dockerfile
+++ b/ci/docker/python-wheel-windows-test-vs2022-base.dockerfile
@@ -34,9 +34,7 @@ RUN `
     && (start /w vs_buildtools.exe --quiet --wait --norestart --nocache `
     --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools" `
     --includeRecommended ^ `
-    --add Microsoft.VisualStudio.Component.Windows10SDK.20348 `
     --add Microsoft.VisualStudio.Workload.VCTools ^ `
-    --add Microsoft.VisualStudio.Workload.VisualStudioExtensionBuildTools ^ `
     || IF "%ERRORLEVEL%"=="3010" EXIT 0) `
     && del /q vs_buildtools.exe
 

--- a/ci/docker/python-wheel-windows-test-vs2022-base.dockerfile
+++ b/ci/docker/python-wheel-windows-test-vs2022-base.dockerfile
@@ -34,10 +34,7 @@ RUN `
     && (start /w vs_buildtools.exe --quiet --wait --norestart --nocache `
     --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools" `
     --includeRecommended ^ `
-    --add Microsoft.VisualStudio.Component.VC.CoreBuildTools `
-    --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
     --add Microsoft.VisualStudio.Component.Windows10SDK.20348 `
-    --add Microsoft.VisualStudio.Component.VC.CMake.Project `
     --add Microsoft.VisualStudio.Workload.VCTools ^ `
     --add Microsoft.VisualStudio.Workload.VisualStudioExtensionBuildTools ^ `
     || IF "%ERRORLEVEL%"=="3010" EXIT 0) `

--- a/ci/docker/python-wheel-windows-test-vs2022-base.dockerfile
+++ b/ci/docker/python-wheel-windows-test-vs2022-base.dockerfile
@@ -37,6 +37,8 @@ RUN `
     --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
     --add Microsoft.VisualStudio.Component.Windows10SDK.20348 `
     --add Microsoft.VisualStudio.Component.VC.CMake.Project `
+    --add Microsoft.VisualStudio.Workload.VCTools ^ `
+    --add Microsoft.VisualStudio.Workload.VisualStudioExtensionBuildTools ^ `
     || IF "%ERRORLEVEL%"=="3010" EXIT 0) `
     && del /q vs_buildtools.exe
 

--- a/ci/docker/python-wheel-windows-test-vs2022-base.dockerfile
+++ b/ci/docker/python-wheel-windows-test-vs2022-base.dockerfile
@@ -33,6 +33,7 @@ RUN `
     curl -SL --output vs_buildtools.exe https://aka.ms/vs/17/release/vs_buildtools.exe `
     && (start /w vs_buildtools.exe --quiet --wait --norestart --nocache `
     --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools" `
+    --includeRecommended ^ `
     --add Microsoft.VisualStudio.Component.VC.CoreBuildTools `
     --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
     --add Microsoft.VisualStudio.Component.Windows10SDK.20348 `

--- a/ci/docker/python-wheel-windows-vs2022-base.dockerfile
+++ b/ci/docker/python-wheel-windows-vs2022-base.dockerfile
@@ -66,7 +66,6 @@ RUN `
   && (start /w vs_buildtools.exe --quiet --wait --norestart --nocache `
   --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools" `
   --includeRecommended ^ `
-  --add Microsoft.VisualStudio.Component.Windows10SDK.20348 `
   --add Microsoft.VisualStudio.Workload.VCTools ^ `
   || IF "%ERRORLEVEL%"=="3010" EXIT 0) `
   && del /q vs_buildtools.exe

--- a/ci/docker/python-wheel-windows-vs2022-base.dockerfile
+++ b/ci/docker/python-wheel-windows-vs2022-base.dockerfile
@@ -52,7 +52,7 @@
 # NOTE: You must update PYTHON_WHEEL_WINDOWS_IMAGE_REVISION in .env
 # when you update this file.
 
-FROM mcr.microsoft.com/windows/servercore:ltsc2022
+FROM mcr.microsoft.com/windows/servercore:ltsc2022-KB5051979
 
 # Ensure we in a command shell and not Powershell
 SHELL ["cmd", "/S", "/C"]

--- a/ci/docker/python-wheel-windows-vs2022-base.dockerfile
+++ b/ci/docker/python-wheel-windows-vs2022-base.dockerfile
@@ -65,6 +65,7 @@ RUN `
   curl -SL --output vs_buildtools.exe https://aka.ms/vs/17/release/vs_buildtools.exe `
   && (start /w vs_buildtools.exe --quiet --wait --norestart --nocache `
   --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools" `
+  --includeRecommended ^ `
   --add Microsoft.VisualStudio.Component.VC.ATLMFC ^ `
   --add Microsoft.VisualStudio.Component.VC.CoreBuildTools `
   --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `

--- a/ci/docker/python-wheel-windows-vs2022-base.dockerfile
+++ b/ci/docker/python-wheel-windows-vs2022-base.dockerfile
@@ -65,8 +65,10 @@ RUN `
   curl -SL --output vs_buildtools.exe https://aka.ms/vs/17/release/vs_buildtools.exe `
   && (start /w vs_buildtools.exe --quiet --wait --norestart --nocache `
   --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools" `
-  --includeRecommended ^ `
-  --add Microsoft.VisualStudio.Workload.VCTools ^ `
+  --add Microsoft.VisualStudio.Component.VC.CoreBuildTools `
+  --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
+  --add Microsoft.VisualStudio.Component.Windows11SDK.26100 `
+  --add Microsoft.VisualStudio.Component.VC.CMake.Project `
   || IF "%ERRORLEVEL%"=="3010" EXIT 0) `
   && del /q vs_buildtools.exe
 

--- a/ci/docker/python-wheel-windows-vs2022-base.dockerfile
+++ b/ci/docker/python-wheel-windows-vs2022-base.dockerfile
@@ -52,7 +52,7 @@
 # NOTE: You must update PYTHON_WHEEL_WINDOWS_IMAGE_REVISION in .env
 # when you update this file.
 
-FROM mcr.microsoft.com/windows/servercore:ltsc2022-KB5051979
+FROM mcr.microsoft.com/windows/servercore:ltsc2022
 
 # Ensure we in a command shell and not Powershell
 SHELL ["cmd", "/S", "/C"]
@@ -71,6 +71,7 @@ RUN `
   --add Microsoft.VisualStudio.Component.VC.CMake.Project `
   || IF "%ERRORLEVEL%"=="3010" EXIT 0) `
   && del /q vs_buildtools.exe
+RUN call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
 
 # Install choco CLI
 #

--- a/ci/docker/python-wheel-windows-vs2022-base.dockerfile
+++ b/ci/docker/python-wheel-windows-vs2022-base.dockerfile
@@ -66,11 +66,7 @@ RUN `
   && (start /w vs_buildtools.exe --quiet --wait --norestart --nocache `
   --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools" `
   --includeRecommended ^ `
-  --add Microsoft.VisualStudio.Component.VC.ATLMFC ^ `
-  --add Microsoft.VisualStudio.Component.VC.CoreBuildTools `
-  --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
   --add Microsoft.VisualStudio.Component.Windows10SDK.20348 `
-  --add Microsoft.VisualStudio.Component.VC.CMake.Project `
   --add Microsoft.VisualStudio.Workload.VCTools ^ `
   --add Microsoft.VisualStudio.Workload.VisualStudioExtensionBuildTools ^ `
   || IF "%ERRORLEVEL%"=="3010" EXIT 0) `

--- a/ci/docker/python-wheel-windows-vs2022-base.dockerfile
+++ b/ci/docker/python-wheel-windows-vs2022-base.dockerfile
@@ -66,6 +66,7 @@ RUN `
   && (start /w vs_buildtools.exe --quiet --wait --norestart --nocache `
   --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools" `
   --includeRecommended ^ `
+  --add Microsoft.VisualStudio.Workload.VCTools ^ `
   || IF "%ERRORLEVEL%"=="3010" EXIT 0) `
   && del /q vs_buildtools.exe
 

--- a/ci/docker/python-wheel-windows-vs2022-base.dockerfile
+++ b/ci/docker/python-wheel-windows-vs2022-base.dockerfile
@@ -66,7 +66,6 @@ RUN `
   && (start /w vs_buildtools.exe --quiet --wait --norestart --nocache `
   --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools" `
   --includeRecommended ^ `
-  --add Microsoft.VisualStudio.Workload.VCTools ^ `
   || IF "%ERRORLEVEL%"=="3010" EXIT 0) `
   && del /q vs_buildtools.exe
 

--- a/ci/docker/python-wheel-windows-vs2022-base.dockerfile
+++ b/ci/docker/python-wheel-windows-vs2022-base.dockerfile
@@ -65,13 +65,16 @@ RUN `
   curl -SL --output vs_buildtools.exe https://aka.ms/vs/17/release/vs_buildtools.exe `
   && (start /w vs_buildtools.exe --quiet --wait --norestart --nocache `
   --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools" `
+  --includeRecommended --includeOptional ^ `
+  --add Microsoft.VisualStudio.Component.VC.ATLMFC ^ `
   --add Microsoft.VisualStudio.Component.VC.CoreBuildTools `
   --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
   --add Microsoft.VisualStudio.Component.Windows10SDK.20348 `
   --add Microsoft.VisualStudio.Component.VC.CMake.Project `
+  --add Microsoft.VisualStudio.Workload.VCTools ^ `
+  --add Microsoft.VisualStudio.Workload.VisualStudioExtensionBuildTools ^ `
   || IF "%ERRORLEVEL%"=="3010" EXIT 0) `
   && del /q vs_buildtools.exe
-RUN call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
 
 # Install choco CLI
 #

--- a/ci/docker/python-wheel-windows-vs2022-base.dockerfile
+++ b/ci/docker/python-wheel-windows-vs2022-base.dockerfile
@@ -65,7 +65,6 @@ RUN `
   curl -SL --output vs_buildtools.exe https://aka.ms/vs/17/release/vs_buildtools.exe `
   && (start /w vs_buildtools.exe --quiet --wait --norestart --nocache `
   --installPath "%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools" `
-  --includeRecommended --includeOptional ^ `
   --add Microsoft.VisualStudio.Component.VC.ATLMFC ^ `
   --add Microsoft.VisualStudio.Component.VC.CoreBuildTools `
   --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `

--- a/ci/docker/python-wheel-windows-vs2022-base.dockerfile
+++ b/ci/docker/python-wheel-windows-vs2022-base.dockerfile
@@ -68,7 +68,6 @@ RUN `
   --includeRecommended ^ `
   --add Microsoft.VisualStudio.Component.Windows10SDK.20348 `
   --add Microsoft.VisualStudio.Workload.VCTools ^ `
-  --add Microsoft.VisualStudio.Workload.VisualStudioExtensionBuildTools ^ `
   || IF "%ERRORLEVEL%"=="3010" EXIT 0) `
   && del /q vs_buildtools.exe
 

--- a/ci/scripts/install_vcpkg.sh
+++ b/ci/scripts/install_vcpkg.sh
@@ -26,6 +26,7 @@ fi
 
 arrow_dir=$(cd -- "$(dirname -- "$0")/../.." && pwd -P)
 default_vcpkg_ports_patch="${arrow_dir}/ci/vcpkg/ports.patch"
+vcpkg_patch="${arrow_dir}/ci/vcpkg/vcpkg.patch"
 
 vcpkg_destination=$1
 vcpkg_version=${2:-}
@@ -41,6 +42,11 @@ git clone --shallow-since=2021-04-01 https://github.com/microsoft/vcpkg "${vcpkg
 pushd "${vcpkg_destination}"
 
 git checkout "${vcpkg_version}"
+
+if [ -f "${vcpkg_patch}" ]; then
+  git apply --verbose --ignore-whitespace "${vcpkg_patch}"
+  echo "Patch successfully applied to the VCPKG files!"
+fi
 
 if [[ "${OSTYPE:-}" == "msys" ]]; then
   ./bootstrap-vcpkg.bat -disableMetrics

--- a/ci/scripts/install_vcpkg.sh
+++ b/ci/scripts/install_vcpkg.sh
@@ -43,10 +43,8 @@ pushd "${vcpkg_destination}"
 
 git checkout "${vcpkg_version}"
 
-if [ -f "${vcpkg_patch}" ]; then
-  git apply --verbose --ignore-whitespace "${vcpkg_patch}"
-  echo "Patch successfully applied to the VCPKG files!"
-fi
+git apply --verbose --ignore-whitespace "${vcpkg_patch}"
+echo "Patch successfully applied to the VCPKG files!"
 
 if [[ "${OSTYPE:-}" == "msys" ]]; then
   ./bootstrap-vcpkg.bat -disableMetrics

--- a/ci/vcpkg/vcpkg.patch
+++ b/ci/vcpkg/vcpkg.patch
@@ -15,13 +15,15 @@ index 60fd5b587a..35616dc6f5 100644
 +            string(STRIP "${file}" file_stripped)
 +
 +            # Print filename
-+            message(STATUS "Build Failed. Content of ${file_stripped}:")
++            message(STATUS "===")
++            message(STATUS "=== Build Failed. Content of ${file_stripped}:")
 +
 +            # Read the content of the file
 +            file(READ ${file_stripped} file_content)
 +
 +            # Print the content
 +            message(STATUS "${file_content}")
++            message(STATUS "=== End of content of ${file_stripped}")
 +        endforeach()
 +        # ---
          message(FATAL_ERROR

--- a/ci/vcpkg/vcpkg.patch
+++ b/ci/vcpkg/vcpkg.patch
@@ -1,0 +1,58 @@
+diff --git a/scripts/cmake/vcpkg_execute_build_process.cmake b/scripts/cmake/vcpkg_execute_build_process.cmake
+index 60fd5b587a..35616dc6f5 100644
+--- a/scripts/cmake/vcpkg_execute_build_process.cmake
++++ b/scripts/cmake/vcpkg_execute_build_process.cmake
+@@ -131,6 +131,24 @@ function(vcpkg_execute_build_process)
+             endif()
+         endforeach()
+         z_vcpkg_prettify_command_line(pretty_command ${arg_COMMAND})
++        # --- Try to print error logs
++        # Split the string by newline characters
++        string(REGEX MATCHALL "[^\n]+" file_list ${stringified_logs})
++
++        # Iterate over the list and print content of each file
++        foreach(file IN LISTS file_list)
++            string(STRIP "${file}" file_stripped)
++
++            # Print filename
++            message(STATUS "Build Failed. Content of ${file_stripped}:")
++
++            # Read the content of the file
++            file(READ ${file_stripped} file_content)
++
++            # Print the content
++            message(STATUS "${file_content}")
++        endforeach()
++        # ---
+         message(FATAL_ERROR
+             "  Command failed: ${pretty_command}\n"
+             "  Working Directory: ${arg_WORKING_DIRECTORY}\n"
+diff --git a/scripts/cmake/vcpkg_execute_required_process.cmake b/scripts/cmake/vcpkg_execute_required_process.cmake
+index 830aa409fd..f02b3fbf59 100644
+--- a/scripts/cmake/vcpkg_execute_required_process.cmake
++++ b/scripts/cmake/vcpkg_execute_required_process.cmake
+@@ -109,6 +109,24 @@ Halting portfile execution.
+         endforeach()
+ 
+         z_vcpkg_prettify_command_line(pretty_command ${arg_COMMAND})
++        # --- Try to print error logs
++        # Split the string by newline characters
++        string(REGEX MATCHALL "[^\n]+" file_list ${stringified_logs})
++
++        # Iterate over the list and print content of each file
++        foreach(file IN LISTS file_list)
++            string(STRIP "${file}" file_stripped)
++
++            # Print filename
++            message(STATUS "Build Failed. Content of ${file_stripped}:")
++
++            # Read the content of the file
++            file(READ ${file_stripped} file_content)
++
++            # Print the content
++            message(STATUS "${file_content}")
++        endforeach()
++        # ---
+         message(FATAL_ERROR
+             "  Command failed: ${pretty_command}\n"
+             "  Working Directory: ${arg_WORKING_DIRECTORY}\n"

--- a/ci/vcpkg/vcpkg.patch
+++ b/ci/vcpkg/vcpkg.patch
@@ -1,8 +1,8 @@
 diff --git a/scripts/cmake/vcpkg_execute_build_process.cmake b/scripts/cmake/vcpkg_execute_build_process.cmake
-index 60fd5b587a..35616dc6f5 100644
+index 60fd5b587a..c8dc021af8 100644
 --- a/scripts/cmake/vcpkg_execute_build_process.cmake
 +++ b/scripts/cmake/vcpkg_execute_build_process.cmake
-@@ -131,6 +131,24 @@ function(vcpkg_execute_build_process)
+@@ -131,6 +131,26 @@ function(vcpkg_execute_build_process)
              endif()
          endforeach()
          z_vcpkg_prettify_command_line(pretty_command ${arg_COMMAND})
@@ -30,10 +30,10 @@ index 60fd5b587a..35616dc6f5 100644
              "  Command failed: ${pretty_command}\n"
              "  Working Directory: ${arg_WORKING_DIRECTORY}\n"
 diff --git a/scripts/cmake/vcpkg_execute_required_process.cmake b/scripts/cmake/vcpkg_execute_required_process.cmake
-index 830aa409fd..f02b3fbf59 100644
+index 830aa409fd..90452d857b 100644
 --- a/scripts/cmake/vcpkg_execute_required_process.cmake
 +++ b/scripts/cmake/vcpkg_execute_required_process.cmake
-@@ -109,6 +109,24 @@ Halting portfile execution.
+@@ -109,6 +109,26 @@ Halting portfile execution.
          endforeach()
  
          z_vcpkg_prettify_command_line(pretty_command ${arg_COMMAND})
@@ -46,13 +46,15 @@ index 830aa409fd..f02b3fbf59 100644
 +            string(STRIP "${file}" file_stripped)
 +
 +            # Print filename
-+            message(STATUS "Build Failed. Content of ${file_stripped}:")
++            message(STATUS "===")
++            message(STATUS "=== Build Failed. Content of ${file_stripped}:")
 +
 +            # Read the content of the file
 +            file(READ ${file_stripped} file_content)
 +
 +            # Print the content
 +            message(STATUS "${file_content}")
++            message(STATUS "=== End of content of ${file_stripped}")
 +        endforeach()
 +        # ---
          message(FATAL_ERROR


### PR DESCRIPTION
### Rationale for this change

Our Windows wheels have been failing for a long time with some errors finding header files:
```
 Python313\Lib\subprocess.py:419: CalledProcessError
---------------------------- Captured stdout call -----------------------------
Compiling extensions.pyx because it changed.
[1/1] Cythonizing extensions.pyx
Extension module: <setuptools.extension.Extension('extensions') at 0x24849772490> ['C:\\Python313\\Lib\\site-packages\\numpy\\_core\\include', 'C:\\Python313\\Lib\\site-packages\\pyarrow\\include'] ['arrow_python', 'arrow'] ['C:\\Python313\\Lib\\site-packages\\pyarrow', 'C:\\Python313\\Lib\\site-packages\\pyarrow.libs']
running build_ext
building 'extensions' extension
creating build\temp.win-amd64-cpython-313\Release
"C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.44.35207\bin\HostX86\x64\cl.exe" /c /nologo /O2 /W3 /GL /DNDEBUG /MD -IC:\Python313\Lib\site-packages\numpy\_core\include -IC:\Python313\Lib\site-packages\pyarrow\include -IC:\Python313\include -IC:\Python313\Include "-IC:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.44.35207\include" "-IC:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\VS\include" /EHsc /Tpextensions.cpp /Fobuild\temp.win-amd64-cpython-313\Release\extensions.obj -D_ENABLE_EXTENDED_ALIGNED_STORAGE /std:c++17
extensions.cpp
C:\Python313\include\pyconfig.h(59): fatal error C1083: Cannot open include file: 'io.h': No such file or directory
```

We also couldn't re-build our images because vcpkg was failing to build dependencies.

### What changes are included in this PR?

When installing through vs_buildtools the different components we were using a deprecated Windows SDK. Installing VCTools with all recommended packages fixes both the vcpkg build and the test failures on the wheel but due to image size we have decided to only upgrade the Windows SDK at the moment.

Link to MSVC VCTools package:
https://learn.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-build-tools?view=vs-2022#desktop-development-with-c

In order to understand the vcpkg failure I patched vcpkg so it prints the build log error. Patching vcpkg is also part of the PR so it can be used in the future.

### Are these changes tested?

Yes

### Are there any user-facing changes?

No
* GitHub Issue: #47367