### PR TITLE
GH-47472: [Doc] Add third-party implementations section

### DIFF
--- a/docs/source/implementations.rst
+++ b/docs/source/implementations.rst
@@ -85,6 +85,35 @@ designed to help produce and consume Arrow data.
      - `nanoarrow Docs <https://arrow.apache.org/nanoarrow>`_ :fa:`external-link-alt`
      - `nanoarrow Source <http://github.com/apache/arrow-nanoarrow>`_
 
+Third-party Implementations
+============================
+
+The following open-source projects provide additional implementations of Apache Arrow:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Project
+     - Language
+     - Description
+     - Docs
+     - Source
+   * - cuDF
+     - Python/C++/CUDA
+     - GPU DataFrames with Apache Arrow compatibility
+     - `cuDF Docs <https://docs.rapids.ai/api/cudf/stable/>`_ :fa:`external-link-alt`
+     - `cuDF Source <https://github.com/rapidsai/cudf>`_ :fa:`external-link-alt`
+   * - Sparrow
+     - C++
+     - C++20 implementation of Apache Arrow
+     - `Sparrow Docs <https://github.com/man-group/sparrow>`_ :fa:`external-link-alt`
+     - `Sparrow Source <https://github.com/man-group/sparrow>`_ :fa:`external-link-alt`
+   * - arro3
+     - Python
+     - Python library for Apache Arrow using WebAssembly
+     - `arro3 Docs <https://github.com/kylebarron/arro3>`_ :fa:`external-link-alt`
+     - `arro3 Source <https://github.com/kylebarron/arro3>`_ :fa:`external-link-alt`
+
 Implementation Status
 =====================
 


### PR DESCRIPTION
### Rationale for this change

This PR addresses issue #47472 by adding a new section to list third-party open source implementations of Apache Arrow.

### What changes are included in this PR?

- Added a new "Third-party Implementations" section to 
- Included three implementations mentioned in the issue discussion:
  - cuDF: GPU DataFrames with Apache Arrow compatibility
  - Sparrow: C++20 implementation of Apache Arrow  
  - arro3: Python library for Apache Arrow using WebAssembly

### Are these changes tested?

The changes are documentation-only and follow the existing RST formatting patterns in the file.

### Are there any user-facing changes?

Yes - users will now see a new section listing third-party implementations in the documentation.

Closes #47472
* GitHub Issue: #47472