### PR TITLE
GH-47491: [C++] Don't set include directories to found targets

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -4651,8 +4651,10 @@ function(build_orc)
     get_filename_component(Protobuf_ROOT "${PROTOBUF_INCLUDE_DIR}" DIRECTORY)
     set(PROTOBUF_HOME ${Protobuf_ROOT})
     # ORC uses this.
-    target_include_directories(${ARROW_PROTOBUF_LIBPROTOC}
-                               INTERFACE "${PROTOBUF_INCLUDE_DIR}")
+    if(PROTOBUF_VENDORED)
+      target_include_directories(${ARROW_PROTOBUF_LIBPROTOC}
+                                 INTERFACE "${PROTOBUF_INCLUDE_DIR}")
+    endif()
     set(PROTOBUF_EXECUTABLE ${ARROW_PROTOBUF_PROTOC})
     set(PROTOBUF_LIBRARY ${ARROW_PROTOBUF_LIBPROTOBUF})
     set(PROTOC_LIBRARY ${ARROW_PROTOBUF_LIBPROTOC})


### PR DESCRIPTION
### Rationale for this change

We can't set include directories to targets that aren't created by our CMake configuration.

### What changes are included in this PR?

Set include directories to libprotoc target only when we use bundled Protobuf.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #47491