### PR TITLE
GH-47485: [C++][CI] Work around Valgrind failure on Azure tests

### DIFF
--- a/cpp/valgrind.supp
+++ b/cpp/valgrind.supp
@@ -75,3 +75,10 @@
     ...
     fun:*gcm_cipher*
 }
+{
+    <Azure>:curl shared handle deallocation fails (GH-47485)
+    Memcheck:Leak
+    fun:calloc
+    fun:curl_share_init
+    fun:*Azure*CurlConnection*
+}


### PR DESCRIPTION
### Rationale for this change

The Azure tests fail because of a likely bug in the Azure SDK, which tries to deallocate a curl shared handler while it's still in use, and doesn't report deallocation errors (reported upstream at https://github.com/Azure/azure-sdk-for-cpp/issues/6722).

### What changes are included in this PR?

Add a dedicated Valgrind suppression to ignore the corresponding memory leak.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #47485