### PR TITLE
GH-47559: [Python] Fix missing argument in pyarrow fs

### DIFF
--- a/python/pyarrow/fs.py
+++ b/python/pyarrow/fs.py
@@ -382,7 +382,7 @@ class FSSpecHandler(FileSystemHandler):
         self._delete_dir_contents(path, missing_dir_ok)
 
     def delete_root_dir_contents(self):
-        self._delete_dir_contents("/")
+        self._delete_dir_contents("/", True)
 
     def delete_file(self, path):
         # fs.rm correctly raises IsADirectoryError when `path` is a directory

--- a/python/pyarrow/fs.py
+++ b/python/pyarrow/fs.py
@@ -382,7 +382,7 @@ class FSSpecHandler(FileSystemHandler):
         self._delete_dir_contents(path, missing_dir_ok)
 
     def delete_root_dir_contents(self):
-        self._delete_dir_contents("/", True)
+        self._delete_dir_contents("/", False)
 
     def delete_file(self, path):
         # fs.rm correctly raises IsADirectoryError when `path` is a directory

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -906,6 +906,9 @@ def _check_root_dir_contents(config):
     fs.delete_dir_contents("", accept_root_dir=True)
     fs.delete_dir_contents("/", accept_root_dir=True)
     fs.delete_dir_contents("//", accept_root_dir=True)
+
+    fs.delete_root_dir_contents()
+
     with pytest.raises(pa.ArrowIOError):
         fs.delete_dir(d)
 

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -2216,8 +2216,8 @@ def test_fsspec_delete_root_dir_contents():
     fs = FSSpecHandler(MemoryFileSystem())
 
     # Create some files and directories
-    fs.create_dir("test_dir")
-    fs.create_dir("test_dir/subdir")
+    fs.create_dir("test_dir", recursive=True)
+    fs.create_dir("test_dir/subdir", recursive=True)
 
     with fs.open_output_stream("test_file.txt") as stream:
         stream.write(b"test content")
@@ -2226,17 +2226,20 @@ def test_fsspec_delete_root_dir_contents():
         stream.write(b"nested content")
 
     # Verify files exist before deletion
-    assert fs.get_file_info("test_file.txt").type == FileType.File
-    assert fs.get_file_info("test_dir").type == FileType.Directory
-    assert fs.get_file_info("test_dir/nested_file.txt").type == FileType.File
+    def get_type(path):
+        return fs.get_file_info([path])[0].type
+
+    assert get_type("test_file.txt") == FileType.File
+    assert get_type("test_dir") == FileType.Directory
+    assert get_type("test_dir/nested_file.txt") == FileType.File
 
     # Delete root directory contents
     fs.delete_root_dir_contents()
 
     # Assert all files and directories are deleted
-    assert fs.get_file_info("test_file.txt").type == FileType.NotFound
-    assert fs.get_file_info("test_dir").type == FileType.NotFound
-    assert fs.get_file_info("test_dir/nested_file.txt").type == FileType.NotFound
+    assert get_type("test_file.txt") == FileType.NotFound
+    assert get_type("test_dir") == FileType.NotFound
+    assert get_type("test_dir/nested_file.txt") == FileType.NotFound
 
 
 def test_huggingface_filesystem_from_uri():

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -2206,6 +2206,7 @@ def test_fsspec_filesystem_from_uri():
     expected_fs = PyFileSystem(FSSpecHandler(LocalFileSystem()))
     assert fs == expected_fs
 
+
 def test_fsspec_delete_root_dir_contents():
     try:
         from fsspec.implementations.memory import MemoryFileSystem
@@ -2213,25 +2214,25 @@ def test_fsspec_delete_root_dir_contents():
         pytest.skip("fsspec not installed")
 
     fs, _ = FileSystem.from_uri("fsspec+memory://")
-    
+
     # Create some files and directories
     fs.create_dir("test_dir")
     fs.create_dir("test_dir/subdir")
-    
+
     with fs.open_output_stream("test_file.txt") as stream:
         stream.write(b"test content")
-    
+
     with fs.open_output_stream("test_dir/nested_file.txt") as stream:
         stream.write(b"nested content")
-    
+
     # Verify files exist before deletion
     assert fs.get_file_info("test_file.txt").type == FileType.File
     assert fs.get_file_info("test_dir").type == FileType.Directory
     assert fs.get_file_info("test_dir/nested_file.txt").type == FileType.File
-    
+
     # Delete root directory contents
     fs.delete_dir_contents("", accept_root_dir=True)
-    
+
     # Assert all files and directories are deleted
     assert fs.get_file_info("test_file.txt").type == FileType.NotFound
     assert fs.get_file_info("test_dir").type == FileType.NotFound

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -2213,7 +2213,7 @@ def test_fsspec_delete_root_dir_contents():
     except ImportError:
         pytest.skip("fsspec not installed")
 
-    fs, _ = FileSystem.from_uri("fsspec+memory://")
+    fs = MemoryFileSystem()
 
     # Create some files and directories
     fs.create_dir("test_dir")

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -2213,7 +2213,7 @@ def test_fsspec_delete_root_dir_contents():
     except ImportError:
         pytest.skip("fsspec not installed")
 
-    fs = MemoryFileSystem()
+    fs = FSSpecHandler(MemoryFileSystem())
 
     # Create some files and directories
     fs.create_dir("test_dir")
@@ -2231,7 +2231,7 @@ def test_fsspec_delete_root_dir_contents():
     assert fs.get_file_info("test_dir/nested_file.txt").type == FileType.File
 
     # Delete root directory contents
-    fs.delete_dir_contents("", accept_root_dir=True)
+    fs.delete_root_dir_contents()
 
     # Assert all files and directories are deleted
     assert fs.get_file_info("test_file.txt").type == FileType.NotFound

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -914,7 +914,6 @@ def _check_root_dir_contents(config):
 def test_delete_root_dir_contents(mockfs, py_mockfs):
     _check_root_dir_contents(mockfs)
     _check_root_dir_contents(py_mockfs)
-    py_mockfs.delete_root_dir_contents()
 
 
 def test_copy_file(fs, pathfn):

--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -2219,10 +2219,10 @@ def test_fsspec_delete_root_dir_contents():
     fs.create_dir("test_dir", recursive=True)
     fs.create_dir("test_dir/subdir", recursive=True)
 
-    with fs.open_output_stream("test_file.txt") as stream:
+    with fs.open_output_stream("test_file.txt", metadata={}) as stream:
         stream.write(b"test content")
 
-    with fs.open_output_stream("test_dir/nested_file.txt") as stream:
+    with fs.open_output_stream("test_dir/nested_file.txt", metadata={}) as stream:
         stream.write(b"nested content")
 
     # Verify files exist before deletion


### PR DESCRIPTION


### Rationale for this change

Fix a syntax error in Python. The argument is required.

### What changes are included in this PR?

* Fix a syntax error in pyarrow fs

### Are these changes tested?

Yes

### Are there any user-facing changes?

No
* GitHub Issue: #47559