### PR TITLE
GH-47500: [C++] Add QualifierAlignment to clang-format options

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -20,3 +20,4 @@ ColumnLimit: 90
 DerivePointerAlignment: false
 IncludeBlocks: Preserve
 IndentPPDirectives: AfterHash
+QualifierAlignment: Left

--- a/cpp/examples/parquet/low_level_api/encryption_reader_writer_all_crypto_options.cc
+++ b/cpp/examples/parquet/low_level_api/encryption_reader_writer_all_crypto_options.cc
@@ -420,7 +420,7 @@ void InteropTestReadEncryptedParquetFiles(std::string root_path) {
   for (unsigned example_id = 0; example_id < vector_of_decryption_configurations.size();
        ++example_id) {
     PrintDecryptionConfiguration(example_id + 1);
-    for (auto const& file : files_in_directory) {
+    for (const auto& file : files_in_directory) {
       std::string exception_msg = "";
       if (!FileNameEndsWith(file, "parquet.encrypted"))  // Skip non encrypted files
         continue;

--- a/cpp/src/arrow/array/builder_nested.cc
+++ b/cpp/src/arrow/array/builder_nested.cc
@@ -48,7 +48,7 @@ template class BaseListViewBuilder<LargeListViewType>;
 // MapBuilder
 
 MapBuilder::MapBuilder(MemoryPool* pool, const std::shared_ptr<ArrayBuilder>& key_builder,
-                       std::shared_ptr<ArrayBuilder> const& item_builder,
+                       const std::shared_ptr<ArrayBuilder>& item_builder,
                        const std::shared_ptr<DataType>& type)
     : ArrayBuilder(pool), key_builder_(key_builder), item_builder_(item_builder) {
   auto map_type = internal::checked_cast<const MapType*>(type.get());

--- a/cpp/src/arrow/array/builder_nested.h
+++ b/cpp/src/arrow/array/builder_nested.h
@@ -51,7 +51,7 @@ class VarLengthListLikeBuilder : public ArrayBuilder {
   /// Use this constructor to incrementally build the value array along with offsets and
   /// null bitmap.
   VarLengthListLikeBuilder(MemoryPool* pool,
-                           std::shared_ptr<ArrayBuilder> const& value_builder,
+                           const std::shared_ptr<ArrayBuilder>& value_builder,
                            const std::shared_ptr<DataType>& type,
                            int64_t alignment = kDefaultBufferAlignment)
       : ArrayBuilder(pool, alignment),
@@ -60,7 +60,7 @@ class VarLengthListLikeBuilder : public ArrayBuilder {
         value_field_(type->field(0)->WithType(NULLPTR)) {}
 
   VarLengthListLikeBuilder(MemoryPool* pool,
-                           std::shared_ptr<ArrayBuilder> const& value_builder,
+                           const std::shared_ptr<ArrayBuilder>& value_builder,
                            int64_t alignment = kDefaultBufferAlignment)
       : VarLengthListLikeBuilder(pool, value_builder,
                                  std::make_shared<TYPE>(value_builder->type()),
@@ -647,13 +647,13 @@ class ARROW_EXPORT FixedSizeListBuilder : public ArrayBuilder {
   /// Use this constructor to define the built array's type explicitly. If value_builder
   /// has indeterminate type, this builder will also.
   FixedSizeListBuilder(MemoryPool* pool,
-                       std::shared_ptr<ArrayBuilder> const& value_builder,
+                       const std::shared_ptr<ArrayBuilder>& value_builder,
                        int32_t list_size);
 
   /// Use this constructor to infer the built array's type. If value_builder has
   /// indeterminate type, this builder will also.
   FixedSizeListBuilder(MemoryPool* pool,
-                       std::shared_ptr<ArrayBuilder> const& value_builder,
+                       const std::shared_ptr<ArrayBuilder>& value_builder,
                        const std::shared_ptr<DataType>& type);
 
   Status Resize(int64_t capacity) override;

--- a/cpp/src/arrow/compute/api_aggregate.h
+++ b/cpp/src/arrow/compute/api_aggregate.h
@@ -48,7 +48,7 @@ class ExecContext;
 class ARROW_EXPORT ScalarAggregateOptions : public FunctionOptions {
  public:
   explicit ScalarAggregateOptions(bool skip_nulls = true, uint32_t min_count = 1);
-  static constexpr char const kTypeName[] = "ScalarAggregateOptions";
+  static constexpr const char kTypeName[] = "ScalarAggregateOptions";
   static ScalarAggregateOptions Defaults() { return ScalarAggregateOptions{}; }
 
   /// If true (the default), null values are ignored. Otherwise, if any value is null,
@@ -72,7 +72,7 @@ class ARROW_EXPORT CountOptions : public FunctionOptions {
     ALL,
   };
   explicit CountOptions(CountMode mode = CountMode::ONLY_VALID);
-  static constexpr char const kTypeName[] = "CountOptions";
+  static constexpr const char kTypeName[] = "CountOptions";
   static CountOptions Defaults() { return CountOptions{}; }
 
   CountMode mode;
@@ -85,7 +85,7 @@ class ARROW_EXPORT CountOptions : public FunctionOptions {
 class ARROW_EXPORT ModeOptions : public FunctionOptions {
  public:
   explicit ModeOptions(int64_t n = 1, bool skip_nulls = true, uint32_t min_count = 0);
-  static constexpr char const kTypeName[] = "ModeOptions";
+  static constexpr const char kTypeName[] = "ModeOptions";
   static ModeOptions Defaults() { return ModeOptions{}; }
 
   int64_t n = 1;
@@ -103,7 +103,7 @@ class ARROW_EXPORT ModeOptions : public FunctionOptions {
 class ARROW_EXPORT VarianceOptions : public FunctionOptions {
  public:
   explicit VarianceOptions(int ddof = 0, bool skip_nulls = true, uint32_t min_count = 0);
-  static constexpr char const kTypeName[] = "VarianceOptions";
+  static constexpr const char kTypeName[] = "VarianceOptions";
   static VarianceOptions Defaults() { return VarianceOptions{}; }
 
   int ddof = 0;
@@ -119,7 +119,7 @@ class ARROW_EXPORT SkewOptions : public FunctionOptions {
  public:
   explicit SkewOptions(bool skip_nulls = true, bool biased = true,
                        uint32_t min_count = 0);
-  static constexpr char const kTypeName[] = "SkewOptions";
+  static constexpr const char kTypeName[] = "SkewOptions";
   static SkewOptions Defaults() { return SkewOptions{}; }
 
   /// If true (the default), null values are ignored. Otherwise, if any value is null,
@@ -154,7 +154,7 @@ class ARROW_EXPORT QuantileOptions : public FunctionOptions {
                            enum Interpolation interpolation = LINEAR,
                            bool skip_nulls = true, uint32_t min_count = 0);
 
-  static constexpr char const kTypeName[] = "QuantileOptions";
+  static constexpr const char kTypeName[] = "QuantileOptions";
   static QuantileOptions Defaults() { return QuantileOptions{}; }
 
   /// probability level of quantile must be between 0 and 1 inclusive
@@ -178,7 +178,7 @@ class ARROW_EXPORT TDigestOptions : public FunctionOptions {
   explicit TDigestOptions(std::vector<double> q, uint32_t delta = 100,
                           uint32_t buffer_size = 500, bool skip_nulls = true,
                           uint32_t min_count = 0);
-  static constexpr char const kTypeName[] = "TDigestOptions";
+  static constexpr const char kTypeName[] = "TDigestOptions";
   static TDigestOptions Defaults() { return TDigestOptions{}; }
 
   /// probability level of quantile must be between 0 and 1 inclusive
@@ -268,7 +268,7 @@ class ARROW_EXPORT PivotWiderOptions : public FunctionOptions {
                              UnexpectedKeyBehavior unexpected_key_behavior = kIgnore);
   // Default constructor for serialization
   PivotWiderOptions();
-  static constexpr char const kTypeName[] = "PivotWiderOptions";
+  static constexpr const char kTypeName[] = "PivotWiderOptions";
   static PivotWiderOptions Defaults() { return PivotWiderOptions{}; }
 
   /// The values expected in the pivot key column
@@ -283,7 +283,7 @@ class ARROW_EXPORT IndexOptions : public FunctionOptions {
   explicit IndexOptions(std::shared_ptr<Scalar> value);
   // Default constructor for serialization
   IndexOptions();
-  static constexpr char const kTypeName[] = "IndexOptions";
+  static constexpr const char kTypeName[] = "IndexOptions";
 
   std::shared_ptr<Scalar> value;
 };

--- a/cpp/src/arrow/compute/api_scalar.h
+++ b/cpp/src/arrow/compute/api_scalar.h
@@ -41,14 +41,14 @@ namespace compute {
 class ARROW_EXPORT ArithmeticOptions : public FunctionOptions {
  public:
   explicit ArithmeticOptions(bool check_overflow = false);
-  static constexpr char const kTypeName[] = "ArithmeticOptions";
+  static constexpr const char kTypeName[] = "ArithmeticOptions";
   bool check_overflow;
 };
 
 class ARROW_EXPORT ElementWiseAggregateOptions : public FunctionOptions {
  public:
   explicit ElementWiseAggregateOptions(bool skip_nulls = true);
-  static constexpr char const kTypeName[] = "ElementWiseAggregateOptions";
+  static constexpr const char kTypeName[] = "ElementWiseAggregateOptions";
   static ElementWiseAggregateOptions Defaults() { return ElementWiseAggregateOptions{}; }
   bool skip_nulls;
 };
@@ -83,7 +83,7 @@ class ARROW_EXPORT RoundOptions : public FunctionOptions {
  public:
   explicit RoundOptions(int64_t ndigits = 0,
                         RoundMode round_mode = RoundMode::HALF_TO_EVEN);
-  static constexpr char const kTypeName[] = "RoundOptions";
+  static constexpr const char kTypeName[] = "RoundOptions";
   static RoundOptions Defaults() { return RoundOptions(); }
   /// Rounding precision (number of digits to round to)
   int64_t ndigits;
@@ -94,7 +94,7 @@ class ARROW_EXPORT RoundOptions : public FunctionOptions {
 class ARROW_EXPORT RoundBinaryOptions : public FunctionOptions {
  public:
   explicit RoundBinaryOptions(RoundMode round_mode = RoundMode::HALF_TO_EVEN);
-  static constexpr char const kTypeName[] = "RoundBinaryOptions";
+  static constexpr const char kTypeName[] = "RoundBinaryOptions";
   static RoundBinaryOptions Defaults() { return RoundBinaryOptions(); }
   /// Rounding and tie-breaking mode
   RoundMode round_mode;
@@ -120,7 +120,7 @@ class ARROW_EXPORT RoundTemporalOptions : public FunctionOptions {
                                 bool week_starts_monday = true,
                                 bool ceil_is_strictly_greater = false,
                                 bool calendar_based_origin = false);
-  static constexpr char const kTypeName[] = "RoundTemporalOptions";
+  static constexpr const char kTypeName[] = "RoundTemporalOptions";
   static RoundTemporalOptions Defaults() { return RoundTemporalOptions(); }
 
   /// Number of units to round to
@@ -156,7 +156,7 @@ class ARROW_EXPORT RoundToMultipleOptions : public FunctionOptions {
                                   RoundMode round_mode = RoundMode::HALF_TO_EVEN);
   explicit RoundToMultipleOptions(std::shared_ptr<Scalar> multiple,
                                   RoundMode round_mode = RoundMode::HALF_TO_EVEN);
-  static constexpr char const kTypeName[] = "RoundToMultipleOptions";
+  static constexpr const char kTypeName[] = "RoundToMultipleOptions";
   static RoundToMultipleOptions Defaults() { return RoundToMultipleOptions(); }
   /// Rounding scale (multiple to round to).
   ///
@@ -182,7 +182,7 @@ class ARROW_EXPORT JoinOptions : public FunctionOptions {
   };
   explicit JoinOptions(NullHandlingBehavior null_handling = EMIT_NULL,
                        std::string null_replacement = "");
-  static constexpr char const kTypeName[] = "JoinOptions";
+  static constexpr const char kTypeName[] = "JoinOptions";
   static JoinOptions Defaults() { return JoinOptions(); }
   NullHandlingBehavior null_handling;
   std::string null_replacement;
@@ -192,7 +192,7 @@ class ARROW_EXPORT MatchSubstringOptions : public FunctionOptions {
  public:
   explicit MatchSubstringOptions(std::string pattern, bool ignore_case = false);
   MatchSubstringOptions();
-  static constexpr char const kTypeName[] = "MatchSubstringOptions";
+  static constexpr const char kTypeName[] = "MatchSubstringOptions";
 
   /// The exact substring (or regex, depending on kernel) to look for inside input values.
   std::string pattern;
@@ -203,7 +203,7 @@ class ARROW_EXPORT MatchSubstringOptions : public FunctionOptions {
 class ARROW_EXPORT SplitOptions : public FunctionOptions {
  public:
   explicit SplitOptions(int64_t max_splits = -1, bool reverse = false);
-  static constexpr char const kTypeName[] = "SplitOptions";
+  static constexpr const char kTypeName[] = "SplitOptions";
 
   /// Maximum number of splits allowed, or unlimited when -1
   int64_t max_splits;
@@ -216,7 +216,7 @@ class ARROW_EXPORT SplitPatternOptions : public FunctionOptions {
   explicit SplitPatternOptions(std::string pattern, int64_t max_splits = -1,
                                bool reverse = false);
   SplitPatternOptions();
-  static constexpr char const kTypeName[] = "SplitPatternOptions";
+  static constexpr const char kTypeName[] = "SplitPatternOptions";
 
   /// The exact substring to split on.
   std::string pattern;
@@ -230,7 +230,7 @@ class ARROW_EXPORT ReplaceSliceOptions : public FunctionOptions {
  public:
   explicit ReplaceSliceOptions(int64_t start, int64_t stop, std::string replacement);
   ReplaceSliceOptions();
-  static constexpr char const kTypeName[] = "ReplaceSliceOptions";
+  static constexpr const char kTypeName[] = "ReplaceSliceOptions";
 
   /// Index to start slicing at
   int64_t start;
@@ -245,7 +245,7 @@ class ARROW_EXPORT ReplaceSubstringOptions : public FunctionOptions {
   explicit ReplaceSubstringOptions(std::string pattern, std::string replacement,
                                    int64_t max_replacements = -1);
   ReplaceSubstringOptions();
-  static constexpr char const kTypeName[] = "ReplaceSubstringOptions";
+  static constexpr const char kTypeName[] = "ReplaceSubstringOptions";
 
   /// Pattern to match, literal, or regular expression depending on which kernel is used
   std::string pattern;
@@ -259,7 +259,7 @@ class ARROW_EXPORT ExtractRegexOptions : public FunctionOptions {
  public:
   explicit ExtractRegexOptions(std::string pattern);
   ExtractRegexOptions();
-  static constexpr char const kTypeName[] = "ExtractRegexOptions";
+  static constexpr const char kTypeName[] = "ExtractRegexOptions";
 
   /// Regular expression with named capture fields
   std::string pattern;
@@ -269,7 +269,7 @@ class ARROW_EXPORT ExtractRegexSpanOptions : public FunctionOptions {
  public:
   explicit ExtractRegexSpanOptions(std::string pattern);
   ExtractRegexSpanOptions();
-  static constexpr char const kTypeName[] = "ExtractRegexSpanOptions";
+  static constexpr const char kTypeName[] = "ExtractRegexSpanOptions";
 
   /// Regular expression with named capture fields
   std::string pattern;
@@ -303,7 +303,7 @@ class ARROW_EXPORT SetLookupOptions : public FunctionOptions {
   // DEPRECATED(will be removed after removing of skip_nulls)
   explicit SetLookupOptions(Datum value_set, bool skip_nulls);
 
-  static constexpr char const kTypeName[] = "SetLookupOptions";
+  static constexpr const char kTypeName[] = "SetLookupOptions";
 
   /// The set of values to look up input values into.
   Datum value_set;
@@ -330,7 +330,7 @@ class ARROW_EXPORT StructFieldOptions : public FunctionOptions {
   explicit StructFieldOptions(std::initializer_list<int>);
   explicit StructFieldOptions(FieldRef field_ref);
   StructFieldOptions();
-  static constexpr char const kTypeName[] = "StructFieldOptions";
+  static constexpr const char kTypeName[] = "StructFieldOptions";
 
   /// The FieldRef specifying what to extract from struct or union.
   FieldRef field_ref;
@@ -341,7 +341,7 @@ class ARROW_EXPORT StrptimeOptions : public FunctionOptions {
   explicit StrptimeOptions(std::string format, TimeUnit::type unit,
                            bool error_is_null = false);
   StrptimeOptions();
-  static constexpr char const kTypeName[] = "StrptimeOptions";
+  static constexpr const char kTypeName[] = "StrptimeOptions";
 
   /// The desired format string.
   std::string format;
@@ -356,7 +356,7 @@ class ARROW_EXPORT StrftimeOptions : public FunctionOptions {
   explicit StrftimeOptions(std::string format, std::string locale = "C");
   StrftimeOptions();
 
-  static constexpr char const kTypeName[] = "StrftimeOptions";
+  static constexpr const char kTypeName[] = "StrftimeOptions";
 
   static constexpr const char* kDefaultFormat = "%Y-%m-%dT%H:%M:%S";
 
@@ -371,7 +371,7 @@ class ARROW_EXPORT PadOptions : public FunctionOptions {
   explicit PadOptions(int64_t width, std::string padding = " ",
                       bool lean_left_on_odd_padding = true);
   PadOptions();
-  static constexpr char const kTypeName[] = "PadOptions";
+  static constexpr const char kTypeName[] = "PadOptions";
 
   /// The desired string length.
   int64_t width;
@@ -387,7 +387,7 @@ class ARROW_EXPORT ZeroFillOptions : public FunctionOptions {
  public:
   explicit ZeroFillOptions(int64_t width, std::string padding = "0");
   ZeroFillOptions();
-  static constexpr char const kTypeName[] = "ZeroFillOptions";
+  static constexpr const char kTypeName[] = "ZeroFillOptions";
 
   /// The desired string length.
   int64_t width;
@@ -399,7 +399,7 @@ class ARROW_EXPORT TrimOptions : public FunctionOptions {
  public:
   explicit TrimOptions(std::string characters);
   TrimOptions();
-  static constexpr char const kTypeName[] = "TrimOptions";
+  static constexpr const char kTypeName[] = "TrimOptions";
 
   /// The individual characters to be trimmed from the string.
   std::string characters;
@@ -410,7 +410,7 @@ class ARROW_EXPORT SliceOptions : public FunctionOptions {
   explicit SliceOptions(int64_t start, int64_t stop = std::numeric_limits<int64_t>::max(),
                         int64_t step = 1);
   SliceOptions();
-  static constexpr char const kTypeName[] = "SliceOptions";
+  static constexpr const char kTypeName[] = "SliceOptions";
   int64_t start, stop, step;
 };
 
@@ -420,7 +420,7 @@ class ARROW_EXPORT ListSliceOptions : public FunctionOptions {
                             int64_t step = 1,
                             std::optional<bool> return_fixed_size_list = std::nullopt);
   ListSliceOptions();
-  static constexpr char const kTypeName[] = "ListSliceOptions";
+  static constexpr const char kTypeName[] = "ListSliceOptions";
   /// The start of list slicing.
   int64_t start;
   /// Optional stop of list slicing. If not set, then slice to end. (NotImplemented)
@@ -436,7 +436,7 @@ class ARROW_EXPORT ListSliceOptions : public FunctionOptions {
 class ARROW_EXPORT NullOptions : public FunctionOptions {
  public:
   explicit NullOptions(bool nan_is_null = false);
-  static constexpr char const kTypeName[] = "NullOptions";
+  static constexpr const char kTypeName[] = "NullOptions";
   static NullOptions Defaults() { return NullOptions{}; }
 
   bool nan_is_null;
@@ -463,7 +463,7 @@ class ARROW_EXPORT MakeStructOptions : public FunctionOptions {
                     std::vector<std::shared_ptr<const KeyValueMetadata>> m);
   explicit MakeStructOptions(std::vector<std::string> n);
   MakeStructOptions();
-  static constexpr char const kTypeName[] = "MakeStructOptions";
+  static constexpr const char kTypeName[] = "MakeStructOptions";
 
   /// Names for wrapped columns
   std::vector<std::string> field_names;
@@ -478,7 +478,7 @@ class ARROW_EXPORT MakeStructOptions : public FunctionOptions {
 struct ARROW_EXPORT DayOfWeekOptions : public FunctionOptions {
  public:
   explicit DayOfWeekOptions(bool count_from_zero = true, uint32_t week_start = 1);
-  static constexpr char const kTypeName[] = "DayOfWeekOptions";
+  static constexpr const char kTypeName[] = "DayOfWeekOptions";
   static DayOfWeekOptions Defaults() { return DayOfWeekOptions(); }
 
   /// Number days from 0 if true and from 1 if false
@@ -511,7 +511,7 @@ struct ARROW_EXPORT AssumeTimezoneOptions : public FunctionOptions {
                                  Ambiguous ambiguous = AMBIGUOUS_RAISE,
                                  Nonexistent nonexistent = NONEXISTENT_RAISE);
   AssumeTimezoneOptions();
-  static constexpr char const kTypeName[] = "AssumeTimezoneOptions";
+  static constexpr const char kTypeName[] = "AssumeTimezoneOptions";
 
   /// Timezone to convert timestamps from
   std::string timezone;
@@ -526,7 +526,7 @@ struct ARROW_EXPORT WeekOptions : public FunctionOptions {
  public:
   explicit WeekOptions(bool week_starts_monday = true, bool count_from_zero = false,
                        bool first_week_is_fully_in_year = false);
-  static constexpr char const kTypeName[] = "WeekOptions";
+  static constexpr const char kTypeName[] = "WeekOptions";
   static WeekOptions Defaults() { return WeekOptions{}; }
   static WeekOptions ISODefaults() {
     return WeekOptions{/*week_starts_monday*/ true,
@@ -555,7 +555,7 @@ struct ARROW_EXPORT Utf8NormalizeOptions : public FunctionOptions {
 
   explicit Utf8NormalizeOptions(Form form = NFC);
   static Utf8NormalizeOptions Defaults() { return Utf8NormalizeOptions(); }
-  static constexpr char const kTypeName[] = "Utf8NormalizeOptions";
+  static constexpr const char kTypeName[] = "Utf8NormalizeOptions";
 
   /// The Unicode normalization form to apply
   Form form;
@@ -570,7 +570,7 @@ class ARROW_EXPORT RandomOptions : public FunctionOptions {
 
   RandomOptions(Initializer initializer, uint64_t seed);
   RandomOptions();
-  static constexpr char const kTypeName[] = "RandomOptions";
+  static constexpr const char kTypeName[] = "RandomOptions";
   static RandomOptions Defaults() { return RandomOptions(); }
 
   /// The type of initialization for random number generation - system or provided seed.
@@ -594,7 +594,7 @@ class ARROW_EXPORT MapLookupOptions : public FunctionOptions {
   explicit MapLookupOptions(std::shared_ptr<Scalar> query_key, Occurrence occurrence);
   MapLookupOptions();
 
-  constexpr static char const kTypeName[] = "MapLookupOptions";
+  constexpr static const char kTypeName[] = "MapLookupOptions";
 
   /// The key to lookup in the map
   std::shared_ptr<Scalar> query_key;

--- a/cpp/src/arrow/compute/api_vector.h
+++ b/cpp/src/arrow/compute/api_vector.h
@@ -44,7 +44,7 @@ class ARROW_EXPORT FilterOptions : public FunctionOptions {
   };
 
   explicit FilterOptions(NullSelectionBehavior null_selection = DROP);
-  static constexpr char const kTypeName[] = "FilterOptions";
+  static constexpr const char kTypeName[] = "FilterOptions";
   static FilterOptions Defaults() { return FilterOptions(); }
 
   NullSelectionBehavior null_selection_behavior = DROP;
@@ -53,7 +53,7 @@ class ARROW_EXPORT FilterOptions : public FunctionOptions {
 class ARROW_EXPORT TakeOptions : public FunctionOptions {
  public:
   explicit TakeOptions(bool boundscheck = true);
-  static constexpr char const kTypeName[] = "TakeOptions";
+  static constexpr const char kTypeName[] = "TakeOptions";
   static TakeOptions BoundsCheck() { return TakeOptions(true); }
   static TakeOptions NoBoundsCheck() { return TakeOptions(false); }
   static TakeOptions Defaults() { return BoundsCheck(); }
@@ -73,7 +73,7 @@ class ARROW_EXPORT DictionaryEncodeOptions : public FunctionOptions {
   };
 
   explicit DictionaryEncodeOptions(NullEncodingBehavior null_encoding = MASK);
-  static constexpr char const kTypeName[] = "DictionaryEncodeOptions";
+  static constexpr const char kTypeName[] = "DictionaryEncodeOptions";
   static DictionaryEncodeOptions Defaults() { return DictionaryEncodeOptions(); }
 
   NullEncodingBehavior null_encoding_behavior = MASK;
@@ -83,7 +83,7 @@ class ARROW_EXPORT DictionaryEncodeOptions : public FunctionOptions {
 class ARROW_EXPORT RunEndEncodeOptions : public FunctionOptions {
  public:
   explicit RunEndEncodeOptions(std::shared_ptr<DataType> run_end_type = int32());
-  static constexpr char const kTypeName[] = "RunEndEncodeOptions";
+  static constexpr const char kTypeName[] = "RunEndEncodeOptions";
   static RunEndEncodeOptions Defaults() { return RunEndEncodeOptions(); }
 
   std::shared_ptr<DataType> run_end_type;
@@ -93,7 +93,7 @@ class ARROW_EXPORT ArraySortOptions : public FunctionOptions {
  public:
   explicit ArraySortOptions(SortOrder order = SortOrder::Ascending,
                             NullPlacement null_placement = NullPlacement::AtEnd);
-  static constexpr char const kTypeName[] = "ArraySortOptions";
+  static constexpr const char kTypeName[] = "ArraySortOptions";
   static ArraySortOptions Defaults() { return ArraySortOptions(); }
 
   /// Sorting order
@@ -107,7 +107,7 @@ class ARROW_EXPORT SortOptions : public FunctionOptions {
   explicit SortOptions(std::vector<SortKey> sort_keys = {},
                        NullPlacement null_placement = NullPlacement::AtEnd);
   explicit SortOptions(const Ordering& ordering);
-  static constexpr char const kTypeName[] = "SortOptions";
+  static constexpr const char kTypeName[] = "SortOptions";
   static SortOptions Defaults() { return SortOptions(); }
   /// Convenience constructor to create an ordering from SortOptions
   ///
@@ -127,7 +127,7 @@ class ARROW_EXPORT SortOptions : public FunctionOptions {
 class ARROW_EXPORT SelectKOptions : public FunctionOptions {
  public:
   explicit SelectKOptions(int64_t k = -1, std::vector<SortKey> sort_keys = {});
-  static constexpr char const kTypeName[] = "SelectKOptions";
+  static constexpr const char kTypeName[] = "SelectKOptions";
   static SelectKOptions Defaults() { return SelectKOptions(); }
 
   static SelectKOptions TopKDefault(int64_t k, std::vector<std::string> key_names = {}) {
@@ -184,7 +184,7 @@ class ARROW_EXPORT RankOptions : public FunctionOptions {
                        Tiebreaker tiebreaker = RankOptions::First)
       : RankOptions({SortKey("", order)}, null_placement, tiebreaker) {}
 
-  static constexpr char const kTypeName[] = "RankOptions";
+  static constexpr const char kTypeName[] = "RankOptions";
   static RankOptions Defaults() { return RankOptions(); }
 
   /// Column key(s) to order by and how to order by these sort keys.
@@ -205,7 +205,7 @@ class ARROW_EXPORT RankQuantileOptions : public FunctionOptions {
                                NullPlacement null_placement = NullPlacement::AtEnd)
       : RankQuantileOptions({SortKey("", order)}, null_placement) {}
 
-  static constexpr char const kTypeName[] = "RankQuantileOptions";
+  static constexpr const char kTypeName[] = "RankQuantileOptions";
   static RankQuantileOptions Defaults() { return RankQuantileOptions(); }
 
   /// Column key(s) to order by and how to order by these sort keys.
@@ -220,7 +220,7 @@ class ARROW_EXPORT PartitionNthOptions : public FunctionOptions {
   explicit PartitionNthOptions(int64_t pivot,
                                NullPlacement null_placement = NullPlacement::AtEnd);
   PartitionNthOptions() : PartitionNthOptions(0) {}
-  static constexpr char const kTypeName[] = "PartitionNthOptions";
+  static constexpr const char kTypeName[] = "PartitionNthOptions";
 
   /// The index into the equivalent sorted array of the partition pivot element.
   int64_t pivot;
@@ -232,7 +232,7 @@ class ARROW_EXPORT WinsorizeOptions : public FunctionOptions {
  public:
   WinsorizeOptions(double lower_limit, double upper_limit);
   WinsorizeOptions() : WinsorizeOptions(0, 1) {}
-  static constexpr char const kTypeName[] = "WinsorizeOptions";
+  static constexpr const char kTypeName[] = "WinsorizeOptions";
 
   /// The quantile below which all values are replaced with the quantile's value.
   ///
@@ -254,7 +254,7 @@ class ARROW_EXPORT CumulativeOptions : public FunctionOptions {
   explicit CumulativeOptions(bool skip_nulls = false);
   explicit CumulativeOptions(double start, bool skip_nulls = false);
   explicit CumulativeOptions(std::shared_ptr<Scalar> start, bool skip_nulls = false);
-  static constexpr char const kTypeName[] = "CumulativeOptions";
+  static constexpr const char kTypeName[] = "CumulativeOptions";
   static CumulativeOptions Defaults() { return CumulativeOptions(); }
 
   /// Optional starting value for cumulative operation computation, default depends on the
@@ -276,7 +276,7 @@ using CumulativeSumOptions = CumulativeOptions;  // For backward compatibility
 class ARROW_EXPORT PairwiseOptions : public FunctionOptions {
  public:
   explicit PairwiseOptions(int64_t periods = 1);
-  static constexpr char const kTypeName[] = "PairwiseOptions";
+  static constexpr const char kTypeName[] = "PairwiseOptions";
   static PairwiseOptions Defaults() { return PairwiseOptions(); }
 
   /// Periods to shift for applying the binary operation, accepts negative values.
@@ -287,7 +287,7 @@ class ARROW_EXPORT PairwiseOptions : public FunctionOptions {
 class ARROW_EXPORT ListFlattenOptions : public FunctionOptions {
  public:
   explicit ListFlattenOptions(bool recursive = false);
-  static constexpr char const kTypeName[] = "ListFlattenOptions";
+  static constexpr const char kTypeName[] = "ListFlattenOptions";
   static ListFlattenOptions Defaults() { return ListFlattenOptions(); }
 
   /// \brief If true, the list is flattened recursively until a non-list
@@ -300,7 +300,7 @@ class ARROW_EXPORT InversePermutationOptions : public FunctionOptions {
  public:
   explicit InversePermutationOptions(int64_t max_index = -1,
                                      std::shared_ptr<DataType> output_type = NULLPTR);
-  static constexpr char const kTypeName[] = "InversePermutationOptions";
+  static constexpr const char kTypeName[] = "InversePermutationOptions";
   static InversePermutationOptions Defaults() { return InversePermutationOptions(); }
 
   /// \brief The max value in the input indices to allow. The length of the function's
@@ -319,7 +319,7 @@ class ARROW_EXPORT InversePermutationOptions : public FunctionOptions {
 class ARROW_EXPORT ScatterOptions : public FunctionOptions {
  public:
   explicit ScatterOptions(int64_t max_index = -1);
-  static constexpr char const kTypeName[] = "ScatterOptions";
+  static constexpr const char kTypeName[] = "ScatterOptions";
   static ScatterOptions Defaults() { return ScatterOptions(); }
 
   /// \brief The max value in the input indices to allow. The length of the function's

--- a/cpp/src/arrow/compute/cast.h
+++ b/cpp/src/arrow/compute/cast.h
@@ -45,7 +45,7 @@ class ARROW_EXPORT CastOptions : public FunctionOptions {
  public:
   explicit CastOptions(bool safe = true);
 
-  static constexpr char const kTypeName[] = "CastOptions";
+  static constexpr const char kTypeName[] = "CastOptions";
   static CastOptions Safe(TypeHolder to_type = {}) {
     CastOptions safe(true);
     safe.to_type = std::move(to_type);

--- a/cpp/src/arrow/compute/kernels/ree_util_internal.h
+++ b/cpp/src/arrow/compute/kernels/ree_util_internal.h
@@ -145,7 +145,7 @@ class ReadWriteValue<ArrowType, in_has_validity_buffer, out_has_validity_buffer,
                      enable_if_fixed_size_binary<ArrowType>> {
  public:
   // Every value is represented as a pointer to byte_width_ bytes
-  using ValueRepr = uint8_t const*;
+  using ValueRepr = const uint8_t*;
 
  private:
   const uint8_t* input_validity_;

--- a/cpp/src/arrow/compute/row/compare_internal_avx2.cc
+++ b/cpp/src/arrow/compute/row/compare_internal_avx2.cc
@@ -272,8 +272,8 @@ inline uint64_t CompareSelected8_avx2(const uint8_t* left_base, const uint8_t* r
       ARROW_DCHECK(false);
   }
 
-  __m128i right_lo = _mm256_i64gather_epi32((int const*)right_base, offset_right_lo, 1);
-  __m128i right_hi = _mm256_i64gather_epi32((int const*)right_base, offset_right_hi, 1);
+  __m128i right_lo = _mm256_i64gather_epi32((const int*)right_base, offset_right_lo, 1);
+  __m128i right_hi = _mm256_i64gather_epi32((const int*)right_base, offset_right_hi, 1);
   __m256i right = _mm256_set_m128i(right_hi, right_lo);
   if (column_width != sizeof(uint32_t)) {
     constexpr uint32_t mask = column_width == 0 || column_width == 1 ? 0xff : 0xffff;
@@ -318,8 +318,8 @@ inline uint64_t Compare8_avx2(const uint8_t* left_base, const uint8_t* right_bas
       ARROW_DCHECK(false);
   }
 
-  __m128i right_lo = _mm256_i64gather_epi32((int const*)right_base, offset_right_lo, 1);
-  __m128i right_hi = _mm256_i64gather_epi32((int const*)right_base, offset_right_hi, 1);
+  __m128i right_lo = _mm256_i64gather_epi32((const int*)right_base, offset_right_lo, 1);
+  __m128i right_hi = _mm256_i64gather_epi32((const int*)right_base, offset_right_hi, 1);
   __m256i right = _mm256_set_m128i(right_hi, right_lo);
   if (column_width != sizeof(uint32_t)) {
     constexpr uint32_t mask = column_width == 0 || column_width == 1 ? 0xff : 0xffff;

--- a/cpp/src/arrow/engine/substrait/expression_internal.cc
+++ b/cpp/src/arrow/engine/substrait/expression_internal.cc
@@ -669,7 +669,7 @@ Result<Datum> FromProto(const substrait::Expression::Literal& lit,
       for (int i = 0; i < map.key_values_size(); ++i) {
         const auto& kv = map.key_values(i);
 
-        static const std::array<char const*, 4> kMissing = {"key and value", "value",
+        static const std::array<const char*, 4> kMissing = {"key and value", "value",
                                                             "key", nullptr};
         if (auto missing = kMissing[kv.has_key() + kv.has_value() * 2]) {
           return Status::Invalid("While converting to MapScalar encountered missing ",

--- a/cpp/src/arrow/engine/substrait/extension_set.cc
+++ b/cpp/src/arrow/engine/substrait/extension_set.cc
@@ -175,7 +175,7 @@ void SubstraitCall::SetValueArg(int index, compute::Expression value_arg) {
   value_args_[index] = std::move(value_arg);
 }
 
-std::optional<std::vector<std::string> const*> SubstraitCall::GetOption(
+std::optional<const std::vector<std::string>*> SubstraitCall::GetOption(
     std::string_view option_name) const {
   auto opt = options_.find(std::string(option_name));
   if (opt == options_.end()) {
@@ -762,11 +762,11 @@ Result<Enum> ParseOptionOrElse(const SubstraitCall& call, std::string_view optio
                                const EnumParser<Enum>& parser,
                                const std::vector<Enum>& implemented_options,
                                Enum fallback) {
-  std::optional<std::vector<std::string> const*> enum_arg = call.GetOption(option_name);
+  std::optional<const std::vector<std::string>*> enum_arg = call.GetOption(option_name);
   if (!enum_arg.has_value()) {
     return fallback;
   }
-  std::vector<std::string> const* prefs = *enum_arg;
+  const std::vector<std::string>* prefs = *enum_arg;
   for (const std::string& pref : *prefs) {
     ARROW_ASSIGN_OR_RAISE(Enum parsed, parser.Parse(pref));
     for (Enum implemented_opt : implemented_options) {

--- a/cpp/src/arrow/engine/substrait/extension_set.h
+++ b/cpp/src/arrow/engine/substrait/extension_set.h
@@ -141,7 +141,7 @@ class ARROW_ENGINE_EXPORT SubstraitCall {
   Result<compute::Expression> GetValueArg(int index) const;
   bool HasValueArg(int index) const;
   void SetValueArg(int index, compute::Expression value_arg);
-  std::optional<std::vector<std::string> const*> GetOption(
+  std::optional<const std::vector<std::string>*> GetOption(
       std::string_view option_name) const;
   void SetOption(std::string_view option_name,
                  const std::vector<std::string_view>& option_preferences);

--- a/cpp/src/arrow/engine/substrait/type_internal.cc
+++ b/cpp/src/arrow/engine/substrait/type_internal.cc
@@ -203,7 +203,7 @@ Result<std::pair<std::shared_ptr<DataType>, bool>> FromProto(
     case substrait::Type::kMap: {
       const auto& map = type.map();
 
-      static const std::array<char const*, 4> kMissing = {"key and value", "value", "key",
+      static const std::array<const char*, 4> kMissing = {"key and value", "value", "key",
                                                           nullptr};
       if (auto missing = kMissing[map.has_key() + map.has_value() * 2]) {
         return Status::Invalid("While converting to MapType encountered missing ",

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -290,9 +290,9 @@ struct PreexistingData {
 
  public:
   const std::string container_name;
-  static constexpr char const* kObjectName = "test-object-name";
+  static constexpr const char* kObjectName = "test-object-name";
 
-  static constexpr char const* kLoremIpsum = R"""(
+  static constexpr const char* kLoremIpsum = R"""(
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
 incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis
 nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
@@ -323,7 +323,7 @@ culpa qui officia deserunt mollit anim id est laborum.
   static std::string RandomContainerName(RNG& rng) { return RandomChars(32, rng); }
 
   static std::string RandomChars(int count, RNG& rng) {
-    auto const fillers = std::string("abcdefghijlkmnopqrstuvwxyz0123456789");
+    const auto fillers = std::string("abcdefghijlkmnopqrstuvwxyz0123456789");
     std::uniform_int_distribution<int> d(0, static_cast<int>(fillers.size()) - 1);
     std::string s;
     std::generate_n(std::back_inserter(s), count, [&] { return fillers[d(rng)]; });
@@ -987,7 +987,7 @@ class TestAzureFileSystem : public ::testing::Test {
   void UploadLines(const std::vector<std::string>& lines, const std::string& path,
                    int total_size) {
     ASSERT_OK_AND_ASSIGN(auto output, fs()->OpenOutputStream(path, {}));
-    for (auto const& line : lines) {
+    for (const auto& line : lines) {
       ASSERT_OK(output->Write(line.data(), line.size()));
     }
     ASSERT_OK(output->Close());
@@ -1041,9 +1041,9 @@ class TestAzureFileSystem : public ::testing::Test {
     };
   }
 
-  char const* kSubData = "sub data";
-  char const* kSomeData = "some data";
-  char const* kOtherData = "other data";
+  const char* kSubData = "sub data";
+  const char* kSomeData = "some data";
+  const char* kOtherData = "other data";
 
   void SetUpSmallFileSystemTree() {
     // Set up test containers
@@ -3126,8 +3126,8 @@ TEST_F(TestAzuriteFileSystem, OpenInputFileMixedReadVsReadAt) {
     }
 
     // Verify random reads interleave too.
-    auto const index = PreexistingData::RandomIndex(kLineCount, rng_);
-    auto const position = index * kLineWidth;
+    const auto index = PreexistingData::RandomIndex(kLineCount, rng_);
+    const auto position = index * kLineWidth;
     ASSERT_OK_AND_ASSIGN(size, file->ReadAt(position, buffer.size(), buffer.data()));
     EXPECT_EQ(size, kLineWidth);
     auto actual = std::string{buffer.begin(), buffer.end()};
@@ -3160,8 +3160,8 @@ TEST_F(TestAzuriteFileSystem, OpenInputFileRandomSeek) {
   for (int i = 0; i != 32; ++i) {
     SCOPED_TRACE("Iteration " + std::to_string(i));
     // Verify sequential reads work as expected.
-    auto const index = PreexistingData::RandomIndex(kLineCount, rng_);
-    auto const position = index * kLineWidth;
+    const auto index = PreexistingData::RandomIndex(kLineCount, rng_);
+    const auto position = index * kLineWidth;
     ASSERT_OK(file->Seek(position));
     ASSERT_OK_AND_ASSIGN(auto actual, file->Read(kLineWidth));
     EXPECT_EQ(lines[index], actual->ToString());
@@ -3197,7 +3197,7 @@ TEST_F(TestAzuriteFileSystem, OpenInputFileInfo) {
   auto constexpr kStart = 16;
   ASSERT_OK_AND_ASSIGN(size, file->ReadAt(kStart, buffer.size(), buffer.data()));
 
-  auto const expected = std::string(PreexistingData::kLoremIpsum).substr(kStart);
+  const auto expected = std::string(PreexistingData::kLoremIpsum).substr(kStart);
   EXPECT_EQ(std::string(buffer.data(), size), expected);
 }
 

--- a/cpp/src/arrow/filesystem/gcsfs.cc
+++ b/cpp/src/arrow/filesystem/gcsfs.cc
@@ -62,7 +62,7 @@ struct GcsPath {
       return Status::Invalid(
           "Expected a GCS object path of the form 'bucket/key...', got a URI: '", s, "'");
     }
-    auto const first_sep = s.find_first_of(internal::kSep);
+    const auto first_sep = s.find_first_of(internal::kSep);
     if (first_sep == 0) {
       return Status::Invalid("Path cannot start with a separator ('", s, "')");
     }
@@ -384,7 +384,7 @@ class GcsFileSystem::Impl {
     auto include_trailing = select.recursive ? gcs::IncludeTrailingDelimiter(false)
                                              : gcs::IncludeTrailingDelimiter(true);
     FileInfoVector result;
-    for (auto const& o :
+    for (const auto& o :
          client_.ListObjects(p.bucket, prefix, delimiter, include_trailing)) {
       if (!o.ok()) {
         if (select.allow_not_found &&
@@ -441,7 +441,7 @@ class GcsFileSystem::Impl {
   }
 
   Status CreateDirMarkerRecursive(const std::string& bucket, const std::string& name) {
-    auto get_parent = [](std::string const& path) {
+    auto get_parent = [](const std::string& path) {
       return std::move(internal::GetAbstractPathParent(path).first);
     };
     // Find the list of missing parents. In the process we discover if any elements in
@@ -478,7 +478,7 @@ class GcsFileSystem::Impl {
 
     // Note that the list of parents are sorted from deepest to most shallow, this is
     // convenient because as soon as we find a directory we can stop the iteration.
-    for (auto const& d : missing_parents) {
+    for (const auto& d : missing_parents) {
       auto o = CreateDirMarker(bucket, d);
       if (o) {
         if (IsDirectory(*o)) continue;

--- a/cpp/src/arrow/filesystem/gcsfs_internal.cc
+++ b/cpp/src/arrow/filesystem/gcsfs_internal.cc
@@ -168,7 +168,7 @@ Result<gcs::WithObjectMetadata> ToObjectMetadata(
     return gcs::WithObjectMetadata{};
   }
 
-  static auto const setters = [] {
+  static const auto setters = [] {
     using setter = std::function<Status(gcs::ObjectMetadata&, const std::string&)>;
     return std::unordered_map<std::string, setter>{
         {"Cache-Control",
@@ -237,7 +237,7 @@ Result<gcs::WithObjectMetadata> ToObjectMetadata(
 }
 
 Result<std::shared_ptr<const KeyValueMetadata>> FromObjectMetadata(
-    gcs::ObjectMetadata const& m) {
+    const gcs::ObjectMetadata& m) {
   auto format_time = [](std::chrono::system_clock::time_point tp) {
     return absl::FormatTime(absl::RFC3339_full, absl::FromChrono(tp),
                             absl::UTCTimeZone());
@@ -278,7 +278,7 @@ Result<std::shared_ptr<const KeyValueMetadata>> FromObjectMetadata(
   result->Append("Content-Disposition", m.content_disposition());
   result->Append("Content-Language", m.content_language());
   result->Append("Cache-Control", m.cache_control());
-  for (auto const& kv : m.metadata()) {
+  for (const auto& kv : m.metadata()) {
     result->Append("metadata." + kv.first, kv.second);
   }
   // Skip "acl" because it is overly complex

--- a/cpp/src/arrow/filesystem/gcsfs_internal.h
+++ b/cpp/src/arrow/filesystem/gcsfs_internal.h
@@ -60,7 +60,7 @@ ARROW_EXPORT Result<google::cloud::storage::WithObjectMetadata> ToObjectMetadata
     const std::shared_ptr<const KeyValueMetadata>& metadata);
 
 ARROW_EXPORT Result<std::shared_ptr<const KeyValueMetadata>> FromObjectMetadata(
-    google::cloud::storage::ObjectMetadata const& m);
+    const google::cloud::storage::ObjectMetadata& m);
 
 ARROW_EXPORT std::int64_t Depth(std::string_view path);
 

--- a/cpp/src/arrow/filesystem/gcsfs_test.cc
+++ b/cpp/src/arrow/filesystem/gcsfs_test.cc
@@ -54,7 +54,7 @@ using ::testing::Pair;
 using ::testing::UnorderedElementsAre;
 using ::testing::UnorderedElementsAreArray;
 
-auto const* kLoremIpsum = R"""(
+const auto* kLoremIpsum = R"""(
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
 incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis
 nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
@@ -227,7 +227,7 @@ class GcsIntegrationTest : public ::testing::Test {
     constexpr auto kFilesPerFolder = 2;
     auto base_dir = internal::ConcatAbstractPath(PreexistingBucketPath(), "b");
     auto result = Hierarchy{base_dir, {}};
-    for (auto const* f : kTestFolders) {
+    for (const auto* f : kTestFolders) {
       const auto folder = internal::ConcatAbstractPath(PreexistingBucketPath(), f);
       RETURN_NOT_OK(fs->CreateDir(folder, true));
       result.contents.push_back(arrow::fs::Dir(folder));
@@ -246,7 +246,7 @@ class GcsIntegrationTest : public ::testing::Test {
   std::vector<arrow::fs::FileInfo> static CleanupDirectoryNames(
       std::vector<arrow::fs::FileInfo> expected) {
     std::transform(expected.begin(), expected.end(), expected.begin(),
-                   [](FileInfo const& info) {
+                   [](const FileInfo& info) {
                      if (!info.IsDirectory()) return info;
                      return Dir(std::string(internal::RemoveTrailingSlash(info.path())));
                    });
@@ -255,7 +255,7 @@ class GcsIntegrationTest : public ::testing::Test {
 
  private:
   std::string RandomChars(std::size_t count) {
-    auto const fillers = std::string("abcdefghijlkmnopqrstuvwxyz0123456789");
+    const auto fillers = std::string("abcdefghijlkmnopqrstuvwxyz0123456789");
     std::uniform_int_distribution<std::size_t> d(0, fillers.size() - 1);
     std::string s;
     std::generate_n(std::back_inserter(s), count, [&] { return fillers[d(generator_)]; });
@@ -423,7 +423,7 @@ TEST(GcsFileSystem, OptionsAsGoogleCloudOptions) {
   a.retry_limit_seconds = 40.5;
   a.project_id = "test-only-invalid-project-id";
 
-  auto const o1 = internal::AsGoogleCloudOptions(a);
+  const auto o1 = internal::AsGoogleCloudOptions(a);
   EXPECT_TRUE(o1.has<google::cloud::UnifiedCredentialsOption>());
   EXPECT_TRUE(o1.has<gcs::RetryPolicyOption>());
   EXPECT_EQ(o1.get<gcs::RestEndpointOption>(), "http://localhost:8080");
@@ -434,7 +434,7 @@ TEST(GcsFileSystem, OptionsAsGoogleCloudOptions) {
   a.retry_limit_seconds.reset();
   a.project_id.reset();
 
-  auto const o2 = internal::AsGoogleCloudOptions(a);
+  const auto o2 = internal::AsGoogleCloudOptions(a);
   EXPECT_TRUE(o2.has<google::cloud::UnifiedCredentialsOption>());
   EXPECT_FALSE(o2.has<gcs::RetryPolicyOption>());
   EXPECT_FALSE(o2.has<gcs::RestEndpointOption>());
@@ -885,7 +885,7 @@ TEST_F(GcsIntegrationTest, DeleteDirSuccess) {
   ASSERT_OK(fs->DeleteDir(hierarchy.base_dir));
   arrow::fs::AssertFileInfo(fs.get(), PreexistingBucketName(), FileType::Directory);
   arrow::fs::AssertFileInfo(fs.get(), PreexistingObjectPath(), FileType::File);
-  for (auto const& info : hierarchy.contents) {
+  for (const auto& info : hierarchy.contents) {
     const auto expected_type = fs::internal::IsAncestorOf(hierarchy.base_dir, info.path())
                                    ? FileType::NotFound
                                    : info.type();
@@ -912,7 +912,7 @@ TEST_F(GcsIntegrationTest, DeleteDirContentsSuccess) {
   arrow::fs::AssertFileInfo(fs.get(), hierarchy.base_dir, FileType::Directory);
   arrow::fs::AssertFileInfo(fs.get(), PreexistingBucketName(), FileType::Directory);
   arrow::fs::AssertFileInfo(fs.get(), PreexistingObjectPath(), FileType::File);
-  for (auto const& info : hierarchy.contents) {
+  for (const auto& info : hierarchy.contents) {
     auto expected_type = FileType::NotFound;
     if (info.path() == hierarchy.base_dir ||
         !fs::internal::IsAncestorOf(hierarchy.base_dir, info.path())) {
@@ -1296,7 +1296,7 @@ TEST_F(GcsIntegrationTest, OpenInputFileMixedReadVsReadAt) {
       PreexistingBucketPath() + "OpenInputFileMixedReadVsReadAt/object-name";
   std::shared_ptr<io::OutputStream> output;
   ASSERT_OK_AND_ASSIGN(output, fs->OpenOutputStream(path, {}));
-  for (auto const& line : lines) {
+  for (const auto& line : lines) {
     ASSERT_OK(output->Write(line.data(), line.size()));
   }
   ASSERT_OK(output->Close());
@@ -1320,8 +1320,8 @@ TEST_F(GcsIntegrationTest, OpenInputFileMixedReadVsReadAt) {
     }
 
     // Verify random reads interleave too.
-    auto const index = RandomIndex(kLineCount);
-    auto const position = index * kLineWidth;
+    const auto index = RandomIndex(kLineCount);
+    const auto position = index * kLineWidth;
     ASSERT_OK_AND_ASSIGN(size, file->ReadAt(position, buffer.size(), buffer.data()));
     EXPECT_EQ(size, kLineWidth);
     auto actual = std::string{buffer.begin(), buffer.end()};
@@ -1347,7 +1347,7 @@ TEST_F(GcsIntegrationTest, OpenInputFileRandomSeek) {
   const auto path = PreexistingBucketPath() + "OpenInputFileRandomSeek/object-name";
   std::shared_ptr<io::OutputStream> output;
   ASSERT_OK_AND_ASSIGN(output, fs->OpenOutputStream(path, {}));
-  for (auto const& line : lines) {
+  for (const auto& line : lines) {
     ASSERT_OK(output->Write(line.data(), line.size()));
   }
   ASSERT_OK(output->Close());
@@ -1357,8 +1357,8 @@ TEST_F(GcsIntegrationTest, OpenInputFileRandomSeek) {
   for (int i = 0; i != 32; ++i) {
     SCOPED_TRACE("Iteration " + std::to_string(i));
     // Verify sequential reads work as expected.
-    auto const index = RandomIndex(kLineCount);
-    auto const position = index * kLineWidth;
+    const auto index = RandomIndex(kLineCount);
+    const auto position = index * kLineWidth;
     ASSERT_OK(file->Seek(position));
     ASSERT_OK_AND_ASSIGN(auto actual, file->Read(kLineWidth));
     EXPECT_EQ(lines[index], actual->ToString());
@@ -1395,7 +1395,7 @@ TEST_F(GcsIntegrationTest, OpenInputFileInfo) {
   auto constexpr kStart = 16;
   ASSERT_OK_AND_ASSIGN(size, file->ReadAt(kStart, buffer.size(), buffer.data()));
 
-  auto const expected = std::string(kLoremIpsum).substr(kStart);
+  const auto expected = std::string(kLoremIpsum).substr(kStart);
   EXPECT_EQ(std::string(buffer.data(), size), expected);
 }
 

--- a/cpp/src/arrow/flight/server_tracing_middleware.cc
+++ b/cpp/src/arrow/flight/server_tracing_middleware.cc
@@ -190,7 +190,7 @@ std::vector<TracingServerMiddleware::TraceKey> TracingServerMiddleware::GetTrace
     const {
   return impl_->GetTraceContext();
 }
-constexpr char const TracingServerMiddleware::kMiddlewareName[];
+constexpr const char TracingServerMiddleware::kMiddlewareName[];
 
 std::shared_ptr<ServerMiddlewareFactory> MakeTracingServerMiddlewareFactory() {
   return std::make_shared<TracingServerMiddlewareFactory>();

--- a/cpp/src/arrow/flight/server_tracing_middleware.h
+++ b/cpp/src/arrow/flight/server_tracing_middleware.h
@@ -42,7 +42,7 @@ class ARROW_FLIGHT_EXPORT TracingServerMiddleware : public ServerMiddleware {
  public:
   ~TracingServerMiddleware();
 
-  static constexpr char const kMiddlewareName[] =
+  static constexpr const char kMiddlewareName[] =
       "arrow::flight::TracingServerMiddleware";
 
   std::string name() const override { return kMiddlewareName; }

--- a/cpp/src/arrow/flight/sql/server_session_middleware.h
+++ b/cpp/src/arrow/flight/sql/server_session_middleware.h
@@ -33,7 +33,7 @@ namespace arrow {
 namespace flight {
 namespace sql {
 
-static constexpr char const kSessionCookieName[] = "arrow_flight_session_id";
+static constexpr const char kSessionCookieName[] = "arrow_flight_session_id";
 
 class ARROW_FLIGHT_SQL_EXPORT FlightSession {
  protected:
@@ -59,7 +59,7 @@ class ARROW_FLIGHT_SQL_EXPORT FlightSession {
 /// transport bug.
 class ARROW_FLIGHT_SQL_EXPORT ServerSessionMiddleware : public ServerMiddleware {
  public:
-  static constexpr char const kMiddlewareName[] =
+  static constexpr const char kMiddlewareName[] =
       "arrow::flight::sql::ServerSessionMiddleware";
 
   std::string name() const override { return kMiddlewareName; }

--- a/cpp/src/arrow/io/hdfs_internal.cc
+++ b/cpp/src/arrow/io/hdfs_internal.cc
@@ -58,7 +58,7 @@ namespace io::internal {
 namespace {
 
 template <bool Required, typename T>
-Status SetSymbol(void* handle, char const* name, T** symbol) {
+Status SetSymbol(void* handle, const char* name, T** symbol) {
   if (*symbol != nullptr) return Status::OK();
 
   auto maybe_symbol = ::arrow::internal::GetSymbolAs<T>(handle, name);

--- a/cpp/src/arrow/ipc/message.cc
+++ b/cpp/src/arrow/ipc/message.cc
@@ -305,8 +305,8 @@ Status ReadFieldsSubset(int64_t offset, int32_t metadata_length,
   }
   internal::IoRecordedRandomAccessFile io_recorded_random_access_file(required_size);
   RETURN_NOT_OK(fields_loader(batch, &io_recorded_random_access_file));
-  auto const& read_ranges = io_recorded_random_access_file.GetReadRanges();
-  for (auto const& range : read_ranges) {
+  const auto& read_ranges = io_recorded_random_access_file.GetReadRanges();
+  for (const auto& range : read_ranges) {
     auto read_result = file->ReadAt(offset + metadata_length + range.offset, range.length,
                                     body->mutable_data() + range.offset);
     if (!read_result.ok()) {

--- a/cpp/src/arrow/record_batch.h
+++ b/cpp/src/arrow/record_batch.h
@@ -381,8 +381,8 @@ class ARROW_EXPORT RecordBatchReader {
     using iterator_category = std::input_iterator_tag;
     using difference_type = std::ptrdiff_t;
     using value_type = std::shared_ptr<RecordBatch>;
-    using pointer = value_type const*;
-    using reference = value_type const&;
+    using pointer = const value_type*;
+    using reference = const value_type&;
 
     RecordBatchReaderIterator() : batch_(RecordBatchEnd()), reader_(NULLPTR) {}
 

--- a/cpp/src/arrow/sparse_tensor.cc
+++ b/cpp/src/arrow/sparse_tensor.cc
@@ -301,7 +301,7 @@ Status ValidateSparseCSXIndex(const std::shared_ptr<DataType>& indptr_type,
                               const std::shared_ptr<DataType>& indices_type,
                               const std::vector<int64_t>& indptr_shape,
                               const std::vector<int64_t>& indices_shape,
-                              char const* type_name) {
+                              const char* type_name) {
   if (!is_integer(indptr_type->id())) {
     return Status::TypeError("Type of ", type_name, " indptr must be integer");
   }
@@ -325,7 +325,7 @@ void CheckSparseCSXIndexValidity(const std::shared_ptr<DataType>& indptr_type,
                                  const std::shared_ptr<DataType>& indices_type,
                                  const std::vector<int64_t>& indptr_shape,
                                  const std::vector<int64_t>& indices_shape,
-                                 char const* type_name) {
+                                 const char* type_name) {
   ARROW_CHECK_OK(ValidateSparseCSXIndex(indptr_type, indices_type, indptr_shape,
                                         indices_shape, type_name));
 }

--- a/cpp/src/arrow/sparse_tensor.h
+++ b/cpp/src/arrow/sparse_tensor.h
@@ -208,14 +208,14 @@ Status ValidateSparseCSXIndex(const std::shared_ptr<DataType>& indptr_type,
                               const std::shared_ptr<DataType>& indices_type,
                               const std::vector<int64_t>& indptr_shape,
                               const std::vector<int64_t>& indices_shape,
-                              char const* type_name);
+                              const char* type_name);
 
 ARROW_EXPORT
 void CheckSparseCSXIndexValidity(const std::shared_ptr<DataType>& indptr_type,
                                  const std::shared_ptr<DataType>& indices_type,
                                  const std::vector<int64_t>& indptr_shape,
                                  const std::vector<int64_t>& indices_shape,
-                                 char const* type_name);
+                                 const char* type_name);
 
 template <typename SparseIndexType, SparseMatrixCompressedAxis COMPRESSED_AXIS>
 class SparseCSXIndex : public SparseIndexBase<SparseIndexType> {
@@ -344,7 +344,7 @@ class ARROW_EXPORT SparseCSRIndex
       internal::SparseCSXIndex<SparseCSRIndex, internal::SparseMatrixCompressedAxis::ROW>;
 
   static constexpr SparseTensorFormat::type format_id = SparseTensorFormat::CSR;
-  static constexpr char const* kTypeName = "SparseCSRIndex";
+  static constexpr const char* kTypeName = "SparseCSRIndex";
 
   using SparseCSXIndex::kCompressedAxis;
   using SparseCSXIndex::Make;
@@ -375,7 +375,7 @@ class ARROW_EXPORT SparseCSCIndex
                                internal::SparseMatrixCompressedAxis::COLUMN>;
 
   static constexpr SparseTensorFormat::type format_id = SparseTensorFormat::CSC;
-  static constexpr char const* kTypeName = "SparseCSCIndex";
+  static constexpr const char* kTypeName = "SparseCSCIndex";
 
   using SparseCSXIndex::kCompressedAxis;
   using SparseCSXIndex::Make;
@@ -398,7 +398,7 @@ class ARROW_EXPORT SparseCSCIndex
 class ARROW_EXPORT SparseCSFIndex : public internal::SparseIndexBase<SparseCSFIndex> {
  public:
   static constexpr SparseTensorFormat::type format_id = SparseTensorFormat::CSF;
-  static constexpr char const* kTypeName = "SparseCSFIndex";
+  static constexpr const char* kTypeName = "SparseCSFIndex";
 
   /// \brief Make SparseCSFIndex from raw properties
   static Result<std::shared_ptr<SparseCSFIndex>> Make(

--- a/cpp/src/arrow/stl.h
+++ b/cpp/src/arrow/stl.h
@@ -92,7 +92,7 @@ using CBuilderType =
 template <typename ValueCType, typename Range>
 inline Status AppendListValues(CBuilderType<ValueCType>& value_builder,
                                Range&& cell_range) {
-  for (auto const& value : cell_range) {
+  for (const auto& value : cell_range) {
     ARROW_RETURN_NOT_OK(ConversionTraits<ValueCType>::AppendRow(value_builder, value));
   }
   return Status::OK();
@@ -441,12 +441,12 @@ Status TableFromTupleRange(MemoryPool* pool, Range&& rows,
   std::vector<std::unique_ptr<ArrayBuilder>> builders(n_columns);
   ARROW_RETURN_NOT_OK(internal::CreateBuildersRecursive<row_type>::Make(pool, &builders));
 
-  for (auto const& row : rows) {
+  for (const auto& row : rows) {
     ARROW_RETURN_NOT_OK(internal::RowIterator<row_type>::Append(builders, row));
   }
 
   std::vector<std::shared_ptr<Array>> arrays;
-  for (auto const& builder : builders) {
+  for (const auto& builder : builders) {
     std::shared_ptr<Array> array;
     ARROW_RETURN_NOT_OK(builder->Finish(&array));
     arrays.emplace_back(array);

--- a/cpp/src/arrow/tensor.cc
+++ b/cpp/src/arrow/tensor.cc
@@ -485,12 +485,12 @@ namespace {
 template <typename TYPE>
 int64_t StridedTensorCountNonZero(int dim_index, int64_t offset, const Tensor& tensor) {
   using c_type = typename TYPE::c_type;
-  c_type const zero = c_type(0);
+  const c_type zero = c_type(0);
   int64_t nnz = 0;
   if (dim_index == tensor.ndim() - 1) {
     for (int64_t i = 0; i < tensor.shape()[dim_index]; ++i) {
-      auto const* ptr = tensor.raw_data() + offset + i * tensor.strides()[dim_index];
-      auto& elem = *reinterpret_cast<c_type const*>(ptr);
+      const auto* ptr = tensor.raw_data() + offset + i * tensor.strides()[dim_index];
+      auto& elem = *reinterpret_cast<const c_type*>(ptr);
       if (elem != zero) ++nnz;
     }
     return nnz;
@@ -505,9 +505,9 @@ int64_t StridedTensorCountNonZero(int dim_index, int64_t offset, const Tensor& t
 template <typename TYPE>
 int64_t ContiguousTensorCountNonZero(const Tensor& tensor) {
   using c_type = typename TYPE::c_type;
-  auto* data = reinterpret_cast<c_type const*>(tensor.raw_data());
+  auto* data = reinterpret_cast<const c_type*>(tensor.raw_data());
   return std::count_if(data, data + tensor.size(),
-                       [](c_type const& x) { return x != 0; });
+                       [](const c_type& x) { return x != 0; });
 }
 
 template <typename TYPE>

--- a/cpp/src/arrow/util/bit_util.h
+++ b/cpp/src/arrow/util/bit_util.h
@@ -333,7 +333,7 @@ void ClearBitmap(uint8_t* data, int64_t offset, int64_t length);
 /// ex:
 /// ref: https://stackoverflow.com/a/59523400
 template <typename Word>
-constexpr Word PrecedingWordBitmask(unsigned int const i) {
+constexpr Word PrecedingWordBitmask(const unsigned int i) {
   return static_cast<Word>(static_cast<Word>(i < sizeof(Word) * 8)
                            << (i & (sizeof(Word) * 8 - 1))) -
          1;

--- a/cpp/src/arrow/util/byte_stream_split_internal.h
+++ b/cpp/src/arrow/util/byte_stream_split_internal.h
@@ -120,7 +120,7 @@ void ByteStreamSplitDecodeSimd(const uint8_t* data, int width, int64_t num_value
 
 // Like xsimd::zip_lo, but zip groups of kNumBytes at once.
 template <typename Arch, int kNumBytes>
-auto zip_lo_n(xsimd::batch<int8_t, Arch> const& a, xsimd::batch<int8_t, Arch> const& b)
+auto zip_lo_n(const xsimd::batch<int8_t, Arch>& a, const xsimd::batch<int8_t, Arch>& b)
     -> xsimd::batch<int8_t, Arch> {
   using arrow::internal::SizedInt;
   using simd_batch = xsimd::batch<int8_t, Arch>;
@@ -144,7 +144,7 @@ auto zip_lo_n(xsimd::batch<int8_t, Arch> const& a, xsimd::batch<int8_t, Arch> co
 
 // Like xsimd::zip_hi, but zip groups of kNumBytes at once.
 template <typename Arch, int kNumBytes>
-auto zip_hi_n(xsimd::batch<int8_t, Arch> const& a, xsimd::batch<int8_t, Arch> const& b)
+auto zip_hi_n(const xsimd::batch<int8_t, Arch>& a, const xsimd::batch<int8_t, Arch>& b)
     -> xsimd::batch<int8_t, Arch> {
   using simd_batch = xsimd::batch<int8_t, Arch>;
   using arrow::internal::SizedInt;

--- a/cpp/src/arrow/util/crc32_test.cc
+++ b/cpp/src/arrow/util/crc32_test.cc
@@ -34,7 +34,7 @@ TEST(Crc32Test, Basic) {
   constexpr size_t TEST_CRC32_LENGTH = 9;
   std::array<unsigned char, TEST_CRC32_LENGTH> std_data = {0x31, 0x32, 0x33, 0x34, 0x35,
                                                            0x36, 0x37, 0x38, 0x39};
-  size_t const std_data_len = sizeof(std_data) / sizeof(std_data[0]);
+  const size_t std_data_len = sizeof(std_data) / sizeof(std_data[0]);
   EXPECT_EQ(TEST_CRC32_RESULT, internal::crc32(0, &std_data[0], std_data_len));
 
   for (size_t i = 1; i < std_data_len - 1; ++i) {

--- a/cpp/src/arrow/util/span.h
+++ b/cpp/src/arrow/util/span.h
@@ -90,7 +90,7 @@ writing code which would break when it is replaced by std::span.)");
     return out;
   }
 
-  constexpr bool operator==(span const& other) const {
+  constexpr bool operator==(const span& other) const {
     if (size_ != other.size_) return false;
 
     if constexpr (std::is_integral_v<T>) {
@@ -106,7 +106,7 @@ writing code which would break when it is replaced by std::span.)");
       return true;
     }
   }
-  constexpr bool operator!=(span const& other) const { return !(*this == other); }
+  constexpr bool operator!=(const span& other) const { return !(*this == other); }
 
  private:
   T* data_{};
@@ -121,7 +121,7 @@ span(T*, size_t) -> span<T>;
 
 template <typename T>
 constexpr span<std::byte const> as_bytes(span<T> s) {
-  return {reinterpret_cast<std::byte const*>(s.data()), s.size_bytes()};
+  return {reinterpret_cast<const std::byte*>(s.data()), s.size_bytes()};
 }
 
 template <typename T>

--- a/cpp/src/gandiva/context_helper.cc
+++ b/cpp/src/gandiva/context_helper.cc
@@ -60,7 +60,7 @@ arrow::Status ExportedContextFunctions::AddMappings(Engine* engine) const {
 
 extern "C" {
 
-void gdv_fn_context_set_error_msg(int64_t context_ptr, char const* err_msg) {
+void gdv_fn_context_set_error_msg(int64_t context_ptr, const char* err_msg) {
   auto context = reinterpret_cast<gandiva::ExecutionContext*>(context_ptr);
   context->set_error_msg(err_msg);
 }

--- a/cpp/src/gandiva/decimal_scalar.h
+++ b/cpp/src/gandiva/decimal_scalar.h
@@ -61,7 +61,7 @@ class DecimalScalar128 : public BasicDecimalScalar128 {
 namespace std {
 template <>
 struct hash<gandiva::DecimalScalar128> {
-  std::size_t operator()(gandiva::DecimalScalar128 const& s) const noexcept {
+  std::size_t operator()(const gandiva::DecimalScalar128& s) const noexcept {
     arrow::BasicDecimal128 dvalue(s.value());
 
     static const int kSeedValue = 4;

--- a/cpp/src/gandiva/engine.cc
+++ b/cpp/src/gandiva/engine.cc
@@ -145,7 +145,7 @@ Result<llvm::orc::JITTargetMachineBuilder> MakeTargetMachineBuilder(
 #else
   using CodeGenOptLevel = llvm::CodeGenOpt::Level;
 #endif
-  auto const opt_level =
+  const auto opt_level =
       conf.optimize() ? CodeGenOptLevel::Aggressive : CodeGenOptLevel::None;
   jtmb.setCodeGenOptLevel(opt_level);
   return jtmb;
@@ -386,7 +386,7 @@ llvm::Module* Engine::module() {
 
 // Handling for pre-compiled IR libraries.
 Status Engine::LoadPreCompiledIR() {
-  auto const bitcode = llvm::StringRef(reinterpret_cast<const char*>(kPrecompiledBitcode),
+  const auto bitcode = llvm::StringRef(reinterpret_cast<const char*>(kPrecompiledBitcode),
                                        kPrecompiledBitcodeSize);
 
   /// Read from file into memory buffer.
@@ -409,14 +409,14 @@ Status Engine::LoadPreCompiledIR() {
 }
 
 static llvm::MemoryBufferRef AsLLVMMemoryBuffer(const arrow::Buffer& arrow_buffer) {
-  auto const data = reinterpret_cast<const char*>(arrow_buffer.data());
-  auto const size = arrow_buffer.size();
+  const auto data = reinterpret_cast<const char*>(arrow_buffer.data());
+  const auto size = arrow_buffer.size();
   return {llvm::StringRef(data, size), "external_bitcode"};
 }
 
 Status Engine::LoadExternalPreCompiledIR() {
-  auto const& buffers = function_registry_->GetBitcodeBuffers();
-  for (auto const& buffer : buffers) {
+  const auto& buffers = function_registry_->GetBitcodeBuffers();
+  for (const auto& buffer : buffers) {
     auto llvm_memory_buffer_ref = AsLLVMMemoryBuffer(*buffer);
     auto module_or_error = llvm::parseBitcodeFile(llvm_memory_buffer_ref, *context());
     ARROW_RETURN_NOT_OK(VerifyAndLinkModule(*module_, std::move(module_or_error)));
@@ -580,7 +580,7 @@ Result<void*> Engine::CompiledFunction(const std::string& function) {
 
 void Engine::AddGlobalMappingForFunc(const std::string& name, llvm::Type* ret_type,
                                      const std::vector<llvm::Type*>& args, void* func) {
-  auto const prototype = llvm::FunctionType::get(ret_type, args, /*is_var_arg*/ false);
+  const auto prototype = llvm::FunctionType::get(ret_type, args, /*is_var_arg*/ false);
   llvm::Function::Create(prototype, llvm::GlobalValue::ExternalLinkage, name, module());
   AddAbsoluteSymbol(*lljit_, name, func);
 }

--- a/cpp/src/gandiva/exported_funcs_registry_test.cc
+++ b/cpp/src/gandiva/exported_funcs_registry_test.cc
@@ -22,7 +22,7 @@
 namespace gandiva {
 TEST(ExportedFuncsRegistry, RegistrationOnlyOnce) {
   gandiva::RegisterExportedFuncs();
-  auto const& registered_list = ExportedFuncsRegistry::Registered();
+  const auto& registered_list = ExportedFuncsRegistry::Registered();
   EXPECT_EQ(registered_list.size(), 6);
 }
 }  // namespace gandiva

--- a/cpp/src/gandiva/external_c_functions.cc
+++ b/cpp/src/gandiva/external_c_functions.cc
@@ -27,7 +27,7 @@ size_t GetNumArgs(const gandiva::FunctionSignature& sig,
   auto num_args = 0;
   num_args += func.NeedsContext() ? 1 : 0;
   num_args += func.NeedsFunctionHolder() ? 1 : 0;
-  for (auto const& arg : sig.param_types()) {
+  for (const auto& arg : sig.param_types()) {
     num_args += arg->id() == arrow::Type::STRING ? 2 : 1;
   }
   num_args += sig.ret_type()->id() == arrow::Type::STRING ? 1 : 0;
@@ -47,7 +47,7 @@ arrow::Result<std::pair<std::vector<llvm::Type*>, llvm::Type*>> MapToLLVMSignatu
   if (func.NeedsFunctionHolder()) {
     arg_llvm_types.push_back(types->i64_type());
   }
-  for (auto const& arg : sig.param_types()) {
+  for (const auto& arg : sig.param_types()) {
     arg_llvm_types.push_back(types->IRType(arg->id()));
     if (arg->id() == arrow::Type::STRING) {
       // string type needs an additional length argument
@@ -65,10 +65,10 @@ arrow::Result<std::pair<std::vector<llvm::Type*>, llvm::Type*>> MapToLLVMSignatu
 
 namespace gandiva {
 Status ExternalCFunctions::AddMappings(Engine* engine) const {
-  auto const& c_funcs = function_registry_->GetCFunctions();
-  auto const types = engine->types();
+  const auto& c_funcs = function_registry_->GetCFunctions();
+  const auto types = engine->types();
   for (auto& [func, func_ptr] : c_funcs) {
-    for (auto const& sig : func.signatures()) {
+    for (const auto& sig : func.signatures()) {
       ARROW_ASSIGN_OR_RAISE(auto llvm_signature, MapToLLVMSignature(sig, func, types));
       auto& [args, ret_llvm_type] = llvm_signature;
       engine->AddGlobalMappingForFunc(func.pc_name(), ret_llvm_type, args, func_ptr);

--- a/cpp/src/gandiva/function_registry.cc
+++ b/cpp/src/gandiva/function_registry.cc
@@ -80,7 +80,7 @@ FunctionRegistry::iterator FunctionRegistry::back() const {
 
 const NativeFunction* FunctionRegistry::LookupSignature(
     const FunctionSignature& signature) const {
-  auto const got = pc_registry_map_.find(&signature);
+  const auto got = pc_registry_map_.find(&signature);
   return got == pc_registry_map_.end() ? nullptr : got->second;
 }
 
@@ -90,8 +90,8 @@ Status FunctionRegistry::Add(NativeFunction func) {
                                  kMaxFunctionSignatures);
   }
   pc_registry_.emplace_back(std::move(func));
-  auto const& last_func = pc_registry_.back();
-  for (auto const& func_signature : last_func.signatures()) {
+  const auto& last_func = pc_registry_.back();
+  for (const auto& func_signature : last_func.signatures()) {
     pc_registry_map_.emplace(&func_signature, &last_func);
   }
   return arrow::Status::OK();
@@ -118,7 +118,7 @@ arrow::Status FunctionRegistry::Register(
     std::optional<FunctionHolderMaker> function_holder_maker) {
   if (function_holder_maker.has_value()) {
     // all signatures should have the same base name, use the first signature's base name
-    auto const& func_base_name = func.signatures().begin()->base_name();
+    const auto& func_base_name = func.signatures().begin()->base_name();
     ARROW_RETURN_NOT_OK(holder_maker_registry_.Register(
         func_base_name, std::move(function_holder_maker).value()));
   }
@@ -143,11 +143,11 @@ const FunctionHolderMakerRegistry& FunctionRegistry::GetFunctionHolderMakerRegis
 
 arrow::Result<std::shared_ptr<FunctionRegistry>> MakeDefaultFunctionRegistry() {
   auto registry = std::make_shared<FunctionRegistry>();
-  for (auto const& funcs :
+  for (const auto& funcs :
        {GetArithmeticFunctionRegistry(), GetDateTimeFunctionRegistry(),
         GetHashFunctionRegistry(), GetMathOpsFunctionRegistry(),
         GetStringFunctionRegistry(), GetDateTimeArithmeticFunctionRegistry()}) {
-    for (auto const& func_signature : funcs) {
+    for (const auto& func_signature : funcs) {
       ARROW_RETURN_NOT_OK(registry->Add(func_signature));
     }
   }

--- a/cpp/src/gandiva/gdv_string_function_stubs.cc
+++ b/cpp/src/gandiva/gdv_string_function_stubs.cc
@@ -169,7 +169,7 @@ CAST_VARLEN_TYPE_FROM_NUMERIC(VARBINARY)
 
 GDV_FORCE_INLINE
 void gdv_fn_set_error_for_invalid_utf8(int64_t execution_context, char val) {
-  char const* fmt = "unexpected byte \\%02hhx encountered while decoding utf8 string";
+  const char* fmt = "unexpected byte \\%02hhx encountered while decoding utf8 string";
   int size = static_cast<int>(strlen(fmt)) + 64;
   char* error = reinterpret_cast<char*>(malloc(size));
   snprintf(error, size, fmt, (unsigned char)val);

--- a/cpp/src/gandiva/llvm_generator_test.cc
+++ b/cpp/src/gandiva/llvm_generator_test.cc
@@ -107,7 +107,7 @@ TEST_F(TestLLVMGenerator, TestAdd) {
                                         SelectionVector::MODE_NONE));
 
   ASSERT_OK(generator->engine_->FinalizeModule());
-  auto const& ir = generator->engine_->ir();
+  const auto& ir = generator->engine_->ir();
   EXPECT_THAT(ir, testing::HasSubstr("vector.body"));
 
   ASSERT_OK_AND_ASSIGN(auto fn_ptr, generator->engine_->CompiledFunction(fn_name));

--- a/cpp/src/gandiva/llvm_types.h
+++ b/cpp/src/gandiva/llvm_types.h
@@ -121,7 +121,7 @@ class GANDIVA_EXPORT LLVMTypes {
 
   std::vector<arrow::Type::type> GetSupportedArrowTypes() {
     std::vector<arrow::Type::type> retval;
-    for (auto const& element : arrow_id_to_llvm_type_map_) {
+    for (const auto& element : arrow_id_to_llvm_type_map_) {
       retval.push_back(element.first);
     }
     return retval;

--- a/cpp/src/gandiva/precompiled/arithmetic_ops.cc
+++ b/cpp/src/gandiva/precompiled/arithmetic_ops.cc
@@ -109,7 +109,7 @@ PMOD_OP(pmod, float64, float64, float64)
 
 gdv_float64 mod_float64_float64(int64_t context, gdv_float64 x, gdv_float64 y) {
   if (y == 0.0) {
-    char const* err_msg = "divide by zero error";
+    const char* err_msg = "divide by zero error";
     gdv_fn_context_set_error_msg(context, err_msg);
     return 0.0;
   }
@@ -351,7 +351,7 @@ NUMERIC_BOOL_DATE_FUNCTION(IS_NOT_DISTINCT_FROM)
   FORCE_INLINE                                                                           \
   gdv_##TYPE divide_##TYPE##_##TYPE(gdv_int64 context, gdv_##TYPE in1, gdv_##TYPE in2) { \
     if (in2 == 0) {                                                                      \
-      char const* err_msg = "divide by zero error";                                      \
+      const char* err_msg = "divide by zero error";                                      \
       gdv_fn_context_set_error_msg(context, err_msg);                                    \
       return 0;                                                                          \
     }                                                                                    \
@@ -430,7 +430,7 @@ void negative_decimal(gdv_int64 context, int64_t high_bits, uint64_t low_bits,
   FORCE_INLINE                                                                        \
   gdv_##TYPE div_##TYPE##_##TYPE(gdv_int64 context, gdv_##TYPE in1, gdv_##TYPE in2) { \
     if (in2 == 0) {                                                                   \
-      char const* err_msg = "divide by zero error";                                   \
+      const char* err_msg = "divide by zero error";                                   \
       gdv_fn_context_set_error_msg(context, err_msg);                                 \
       return 0;                                                                       \
     }                                                                                 \
@@ -448,7 +448,7 @@ DIV(uint64)
   FORCE_INLINE                                                                        \
   gdv_##TYPE div_##TYPE##_##TYPE(gdv_int64 context, gdv_##TYPE in1, gdv_##TYPE in2) { \
     if (in2 == 0) {                                                                   \
-      char const* err_msg = "divide by zero error";                                   \
+      const char* err_msg = "divide by zero error";                                   \
       gdv_fn_context_set_error_msg(context, err_msg);                                 \
       return 0;                                                                       \
     }                                                                                 \

--- a/cpp/src/gandiva/precompiled/decimal_ops.cc
+++ b/cpp/src/gandiva/precompiled/decimal_ops.cc
@@ -351,7 +351,7 @@ BasicDecimal128 Divide(int64_t context, const BasicDecimalScalar128& x,
                        const BasicDecimalScalar128& y, int32_t out_precision,
                        int32_t out_scale, bool* overflow) {
   if (y.value() == 0) {
-    char const* err_msg = "divide by zero error";
+    const char* err_msg = "divide by zero error";
     gdv_fn_context_set_error_msg(context, err_msg);
     return 0;
   }
@@ -396,7 +396,7 @@ BasicDecimal128 Mod(int64_t context, const BasicDecimalScalar128& x,
                     const BasicDecimalScalar128& y, int32_t out_precision,
                     int32_t out_scale, bool* overflow) {
   if (y.value() == 0) {
-    char const* err_msg = "divide by zero error";
+    const char* err_msg = "divide by zero error";
     gdv_fn_context_set_error_msg(context, err_msg);
     return 0;
   }

--- a/cpp/src/gandiva/precompiled/extended_math_ops.cc
+++ b/cpp/src/gandiva/precompiled/extended_math_ops.cc
@@ -80,7 +80,7 @@ ENUMERIC_TYPES_UNARY(LOG10, float64)
 
 FORCE_INLINE
 void set_error_for_logbase(int64_t execution_context, double base) {
-  char const* prefix = "divide by zero error with log of base";
+  const char* prefix = "divide by zero error with log of base";
   int size = static_cast<int>(strlen(prefix)) + 64;
   char* error = reinterpret_cast<char*>(malloc(size));
   snprintf(error, size, "%s %f", prefix, base);

--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -152,7 +152,7 @@ gdv_int32 utf8_char_length(char c) {
 
 FORCE_INLINE
 void set_error_for_invalid_utf(int64_t execution_context, char val) {
-  char const* fmt = "unexpected byte \\%02hhx encountered while decoding utf8 string";
+  const char* fmt = "unexpected byte \\%02hhx encountered while decoding utf8 string";
   int size = static_cast<int>(strlen(fmt)) + 64;
   char* error = reinterpret_cast<char*>(malloc(size));
   snprintf(error, size, fmt, (unsigned char)val);

--- a/cpp/src/gandiva/regex_functions_holder_test.cc
+++ b/cpp/src/gandiva/regex_functions_holder_test.cc
@@ -48,7 +48,7 @@ class TestLikeHolder : public ::testing::Test {
 };
 
 TEST_F(TestLikeHolder, TestMatchAny) {
-  EXPECT_OK_AND_ASSIGN(auto const like_holder, LikeHolder::Make("ab%", regex_op));
+  EXPECT_OK_AND_ASSIGN(const auto like_holder, LikeHolder::Make("ab%", regex_op));
 
   auto& like = *like_holder;
   EXPECT_TRUE(like("ab"));
@@ -60,7 +60,7 @@ TEST_F(TestLikeHolder, TestMatchAny) {
 }
 
 TEST_F(TestLikeHolder, TestMatchOne) {
-  EXPECT_OK_AND_ASSIGN(auto const like_holder, LikeHolder::Make("ab_", regex_op));
+  EXPECT_OK_AND_ASSIGN(const auto like_holder, LikeHolder::Make("ab_", regex_op));
 
   auto& like = *like_holder;
   EXPECT_TRUE(like("abc"));
@@ -72,7 +72,7 @@ TEST_F(TestLikeHolder, TestMatchOne) {
 }
 
 TEST_F(TestLikeHolder, TestPcreSpecial) {
-  EXPECT_OK_AND_ASSIGN(auto const like_holder, LikeHolder::Make(".*ab_", regex_op));
+  EXPECT_OK_AND_ASSIGN(const auto like_holder, LikeHolder::Make(".*ab_", regex_op));
 
   auto& like = *like_holder;
   EXPECT_TRUE(like(".*abc"));  // . and * aren't special in sql regex
@@ -80,7 +80,7 @@ TEST_F(TestLikeHolder, TestPcreSpecial) {
 }
 
 TEST_F(TestLikeHolder, TestPcreSpecialWithNewLine) {
-  EXPECT_OK_AND_ASSIGN(auto const like_holder, LikeHolder::Make("%Space1.%", regex_op));
+  EXPECT_OK_AND_ASSIGN(const auto like_holder, LikeHolder::Make("%Space1.%", regex_op));
 
   auto& like = *like_holder;
   EXPECT_TRUE(
@@ -95,14 +95,14 @@ TEST_F(TestLikeHolder, TestRegexEscape) {
 }
 
 TEST_F(TestLikeHolder, TestDot) {
-  EXPECT_OK_AND_ASSIGN(auto const like_holder, LikeHolder::Make("abc.", regex_op));
+  EXPECT_OK_AND_ASSIGN(const auto like_holder, LikeHolder::Make("abc.", regex_op));
 
   auto& like = *like_holder;
   EXPECT_FALSE(like("abcd"));
 }
 
 TEST_F(TestLikeHolder, TestMatchWithNewLine) {
-  EXPECT_OK_AND_ASSIGN(auto const like_holder, LikeHolder::Make("%abc%", regex_op));
+  EXPECT_OK_AND_ASSIGN(const auto like_holder, LikeHolder::Make("%abc%", regex_op));
 
   auto& like = *like_holder;
   EXPECT_TRUE(like("abc\nd"));
@@ -191,7 +191,7 @@ TEST_F(TestLikeHolder, TestOptimise) {
 }
 
 TEST_F(TestLikeHolder, TestMatchOneEscape) {
-  EXPECT_OK_AND_ASSIGN(auto const like_holder, LikeHolder::Make("ab\\_", "\\", regex_op));
+  EXPECT_OK_AND_ASSIGN(const auto like_holder, LikeHolder::Make("ab\\_", "\\", regex_op));
 
   auto& like = *like_holder;
 
@@ -205,7 +205,7 @@ TEST_F(TestLikeHolder, TestMatchOneEscape) {
 }
 
 TEST_F(TestLikeHolder, TestMatchManyEscape) {
-  EXPECT_OK_AND_ASSIGN(auto const like_holder, LikeHolder::Make("ab\\%", "\\", regex_op));
+  EXPECT_OK_AND_ASSIGN(const auto like_holder, LikeHolder::Make("ab\\%", "\\", regex_op));
 
   auto& like = *like_holder;
 
@@ -219,7 +219,7 @@ TEST_F(TestLikeHolder, TestMatchManyEscape) {
 }
 
 TEST_F(TestLikeHolder, TestMatchEscape) {
-  EXPECT_OK_AND_ASSIGN(auto const like_holder,
+  EXPECT_OK_AND_ASSIGN(const auto like_holder,
                        LikeHolder::Make("ab\\\\", "\\", regex_op));
 
   auto& like = *like_holder;
@@ -230,7 +230,7 @@ TEST_F(TestLikeHolder, TestMatchEscape) {
 }
 
 TEST_F(TestLikeHolder, TestEmptyEscapeChar) {
-  EXPECT_OK_AND_ASSIGN(auto const like_holder, LikeHolder::Make("ab\\_", "", regex_op));
+  EXPECT_OK_AND_ASSIGN(const auto like_holder, LikeHolder::Make("ab\\_", "", regex_op));
 
   auto& like = *like_holder;
 
@@ -259,7 +259,7 @@ class TestILikeHolder : public ::testing::Test {
 TEST_F(TestILikeHolder, TestMatchAny) {
   regex_op.set_case_sensitive(false);
 
-  EXPECT_OK_AND_ASSIGN(auto const like_holder, LikeHolder::Make("ab%", regex_op));
+  EXPECT_OK_AND_ASSIGN(const auto like_holder, LikeHolder::Make("ab%", regex_op));
 
   auto& like = *like_holder;
   EXPECT_TRUE(like("ab"));
@@ -272,7 +272,7 @@ TEST_F(TestILikeHolder, TestMatchAny) {
 
 TEST_F(TestILikeHolder, TestMatchOne) {
   regex_op.set_case_sensitive(false);
-  EXPECT_OK_AND_ASSIGN(auto const like_holder, LikeHolder::Make("Ab_", regex_op));
+  EXPECT_OK_AND_ASSIGN(const auto like_holder, LikeHolder::Make("Ab_", regex_op));
 
   auto& like = *like_holder;
   EXPECT_TRUE(like("abc"));
@@ -285,7 +285,7 @@ TEST_F(TestILikeHolder, TestMatchOne) {
 
 TEST_F(TestILikeHolder, TestPcreSpecial) {
   regex_op.set_case_sensitive(false);
-  EXPECT_OK_AND_ASSIGN(auto const like_holder, LikeHolder::Make(".*aB_", regex_op));
+  EXPECT_OK_AND_ASSIGN(const auto like_holder, LikeHolder::Make(".*aB_", regex_op));
 
   auto& like = *like_holder;
   EXPECT_TRUE(like(".*Abc"));  // . and * aren't special in sql regex
@@ -294,7 +294,7 @@ TEST_F(TestILikeHolder, TestPcreSpecial) {
 
 TEST_F(TestILikeHolder, TestDot) {
   regex_op.set_case_sensitive(false);
-  EXPECT_OK_AND_ASSIGN(auto const like_holder, LikeHolder::Make("aBc.", regex_op));
+  EXPECT_OK_AND_ASSIGN(const auto like_holder, LikeHolder::Make("aBc.", regex_op));
 
   auto& like = *like_holder;
   EXPECT_FALSE(like("abcd"));
@@ -306,7 +306,7 @@ class TestReplaceHolder : public ::testing::Test {
 };
 
 TEST_F(TestReplaceHolder, TestMultipleReplace) {
-  EXPECT_OK_AND_ASSIGN(auto const replace_holder, ReplaceHolder::Make("ana"));
+  EXPECT_OK_AND_ASSIGN(const auto replace_holder, ReplaceHolder::Make("ana"));
 
   std::string input_string = "banana";
   std::string replace_string;
@@ -351,7 +351,7 @@ TEST_F(TestReplaceHolder, TestMultipleReplace) {
 }
 
 TEST_F(TestReplaceHolder, TestNoMatchPattern) {
-  EXPECT_OK_AND_ASSIGN(auto const replace_holder, ReplaceHolder::Make("ana"));
+  EXPECT_OK_AND_ASSIGN(const auto replace_holder, ReplaceHolder::Make("ana"));
 
   std::string input_string = "apple";
   std::string replace_string;
@@ -368,7 +368,7 @@ TEST_F(TestReplaceHolder, TestNoMatchPattern) {
 }
 
 TEST_F(TestReplaceHolder, TestReplaceSameSize) {
-  EXPECT_OK_AND_ASSIGN(auto const replace_holder, ReplaceHolder::Make("a"));
+  EXPECT_OK_AND_ASSIGN(const auto replace_holder, ReplaceHolder::Make("a"));
 
   std::string input_string = "ananindeua";
   std::string replace_string = "b";
@@ -571,7 +571,7 @@ TEST_F(TestExtractHolder, TestNoMatches) {
 
 TEST_F(TestExtractHolder, TestInvalidRange) {
   // Pattern to match of two group of letters
-  EXPECT_OK_AND_ASSIGN(auto const extract_holder, ExtractHolder::Make(R"((\w+) (\w+))"));
+  EXPECT_OK_AND_ASSIGN(const auto extract_holder, ExtractHolder::Make(R"((\w+) (\w+))"));
 
   std::string input_string = "John Doe";
   int32_t extract_index = -1;

--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -271,7 +271,7 @@ struct test_traits {};
 template <>
 struct test_traits<::arrow::BooleanType> {
   static constexpr ParquetType::type parquet_enum = ParquetType::BOOLEAN;
-  static uint8_t const value;
+  static const uint8_t value;
 };
 
 const uint8_t test_traits<::arrow::BooleanType>::value(1);
@@ -279,7 +279,7 @@ const uint8_t test_traits<::arrow::BooleanType>::value(1);
 template <>
 struct test_traits<::arrow::UInt8Type> {
   static constexpr ParquetType::type parquet_enum = ParquetType::INT32;
-  static uint8_t const value;
+  static const uint8_t value;
 };
 
 const uint8_t test_traits<::arrow::UInt8Type>::value(64);
@@ -287,7 +287,7 @@ const uint8_t test_traits<::arrow::UInt8Type>::value(64);
 template <>
 struct test_traits<::arrow::Int8Type> {
   static constexpr ParquetType::type parquet_enum = ParquetType::INT32;
-  static int8_t const value;
+  static const int8_t value;
 };
 
 const int8_t test_traits<::arrow::Int8Type>::value(-64);
@@ -295,7 +295,7 @@ const int8_t test_traits<::arrow::Int8Type>::value(-64);
 template <>
 struct test_traits<::arrow::UInt16Type> {
   static constexpr ParquetType::type parquet_enum = ParquetType::INT32;
-  static uint16_t const value;
+  static const uint16_t value;
 };
 
 const uint16_t test_traits<::arrow::UInt16Type>::value(1024);
@@ -303,7 +303,7 @@ const uint16_t test_traits<::arrow::UInt16Type>::value(1024);
 template <>
 struct test_traits<::arrow::Int16Type> {
   static constexpr ParquetType::type parquet_enum = ParquetType::INT32;
-  static int16_t const value;
+  static const int16_t value;
 };
 
 const int16_t test_traits<::arrow::Int16Type>::value(-1024);
@@ -311,7 +311,7 @@ const int16_t test_traits<::arrow::Int16Type>::value(-1024);
 template <>
 struct test_traits<::arrow::UInt32Type> {
   static constexpr ParquetType::type parquet_enum = ParquetType::INT32;
-  static uint32_t const value;
+  static const uint32_t value;
 };
 
 const uint32_t test_traits<::arrow::UInt32Type>::value(1024);
@@ -319,7 +319,7 @@ const uint32_t test_traits<::arrow::UInt32Type>::value(1024);
 template <>
 struct test_traits<::arrow::Int32Type> {
   static constexpr ParquetType::type parquet_enum = ParquetType::INT32;
-  static int32_t const value;
+  static const int32_t value;
 };
 
 const int32_t test_traits<::arrow::Int32Type>::value(-1024);
@@ -327,7 +327,7 @@ const int32_t test_traits<::arrow::Int32Type>::value(-1024);
 template <>
 struct test_traits<::arrow::UInt64Type> {
   static constexpr ParquetType::type parquet_enum = ParquetType::INT64;
-  static uint64_t const value;
+  static const uint64_t value;
 };
 
 const uint64_t test_traits<::arrow::UInt64Type>::value(1024);
@@ -335,7 +335,7 @@ const uint64_t test_traits<::arrow::UInt64Type>::value(1024);
 template <>
 struct test_traits<::arrow::Int64Type> {
   static constexpr ParquetType::type parquet_enum = ParquetType::INT64;
-  static int64_t const value;
+  static const int64_t value;
 };
 
 const int64_t test_traits<::arrow::Int64Type>::value(-1024);
@@ -343,7 +343,7 @@ const int64_t test_traits<::arrow::Int64Type>::value(-1024);
 template <>
 struct test_traits<::arrow::TimestampType> {
   static constexpr ParquetType::type parquet_enum = ParquetType::INT64;
-  static int64_t const value;
+  static const int64_t value;
 };
 
 const int64_t test_traits<::arrow::TimestampType>::value(14695634030000);
@@ -351,7 +351,7 @@ const int64_t test_traits<::arrow::TimestampType>::value(14695634030000);
 template <>
 struct test_traits<::arrow::Date32Type> {
   static constexpr ParquetType::type parquet_enum = ParquetType::INT32;
-  static int32_t const value;
+  static const int32_t value;
 };
 
 const int32_t test_traits<::arrow::Date32Type>::value(170000);
@@ -359,7 +359,7 @@ const int32_t test_traits<::arrow::Date32Type>::value(170000);
 template <>
 struct test_traits<::arrow::FloatType> {
   static constexpr ParquetType::type parquet_enum = ParquetType::FLOAT;
-  static float const value;
+  static const float value;
 };
 
 const float test_traits<::arrow::FloatType>::value(2.1f);
@@ -367,7 +367,7 @@ const float test_traits<::arrow::FloatType>::value(2.1f);
 template <>
 struct test_traits<::arrow::DoubleType> {
   static constexpr ParquetType::type parquet_enum = ParquetType::DOUBLE;
-  static double const value;
+  static const double value;
 };
 
 const double test_traits<::arrow::DoubleType>::value(4.2);

--- a/cpp/src/parquet/encoding_test.cc
+++ b/cpp/src/parquet/encoding_test.cc
@@ -1922,12 +1922,12 @@ TYPED_TEST(TestDeltaBitPackEncoding, DeltaBitPackedWrapping) {
                                1};
   const int num_values = static_cast<int>(int_values.size());
 
-  auto const encoder = MakeTypedEncoder<TypeParam>(
+  const auto encoder = MakeTypedEncoder<TypeParam>(
       Encoding::DELTA_BINARY_PACKED, /*use_dictionary=*/false, this->descr_.get());
   encoder->Put(int_values, num_values);
-  auto const encoded = encoder->FlushValues();
+  const auto encoded = encoder->FlushValues();
 
-  auto const decoder =
+  const auto decoder =
       MakeTypedDecoder<TypeParam>(Encoding::DELTA_BINARY_PACKED, this->descr_.get());
 
   std::vector<T> decoded(num_values);
@@ -1959,10 +1959,10 @@ TYPED_TEST(TestDeltaBitPackEncoding, DeltaBitPackedSize) {
     return (idx % 2) == 1 ? 0 : (idx % 4) == 0 ? 1 : -1;
   });
 
-  auto const encoder = MakeTypedEncoder<TypeParam>(
+  const auto encoder = MakeTypedEncoder<TypeParam>(
       Encoding::DELTA_BINARY_PACKED, /*use_dictionary=*/false, this->descr_.get());
   encoder->Put(int_values, num_values);
-  auto const encoded = encoder->FlushValues();
+  const auto encoded = encoder->FlushValues();
 
   ASSERT_EQ(encoded->size(), encoded_size);
 }

--- a/cpp/src/parquet/encryption/encryption.cc
+++ b/cpp/src/parquet/encryption/encryption.cc
@@ -292,7 +292,7 @@ FileEncryptionProperties::FileEncryptionProperties(
 
   uint8_t aad_file_unique[kAadFileUniqueLength];
   encryption::RandBytes(aad_file_unique, kAadFileUniqueLength);
-  std::string aad_file_unique_str(reinterpret_cast<char const*>(aad_file_unique),
+  std::string aad_file_unique_str(reinterpret_cast<const char*>(aad_file_unique),
                                   kAadFileUniqueLength);
 
   bool supply_aad_prefix = false;

--- a/cpp/src/parquet/encryption/encryption_internal.cc
+++ b/cpp/src/parquet/encryption/encryption_internal.cc
@@ -704,7 +704,7 @@ static std::string ShortToBytesLe(int16_t input) {
   output[1] = static_cast<int8_t>(0xff & (input >> 8));
   output[0] = static_cast<int8_t>(0xff & (input));
 
-  return std::string(reinterpret_cast<char const*>(output), 2);
+  return std::string(reinterpret_cast<const char*>(output), 2);
 }
 
 static void CheckPageOrdinal(int32_t page_ordinal) {
@@ -722,7 +722,7 @@ std::string CreateModuleAad(const std::string& file_aad, int8_t module_type,
   const int16_t page_ordinal_short = static_cast<int16_t>(page_ordinal);
   int8_t type_ordinal_bytes[1];
   type_ordinal_bytes[0] = module_type;
-  std::string type_ordinal_bytes_str(reinterpret_cast<char const*>(type_ordinal_bytes),
+  std::string type_ordinal_bytes_str(reinterpret_cast<const char*>(type_ordinal_bytes),
                                      1);
   if (kFooter == module_type) {
     std::string result = file_aad + type_ordinal_bytes_str;

--- a/cpp/src/parquet/encryption/key_toolkit.cc
+++ b/cpp/src/parquet/encryption/key_toolkit.cc
@@ -87,7 +87,7 @@ void KeyToolkit::RotateMasterKeys(
                                             std::string(KeyMaterial::kFooterKeyIdInFile));
 
   // Rotate column keys
-  for (auto const& key_id_in_file : file_key_id_set) {
+  for (const auto& key_id_in_file : file_key_id_set) {
     if (key_id_in_file == std::string(KeyMaterial::kFooterKeyIdInFile)) {
       continue;
     }


### PR DESCRIPTION
Use the [QualifierAlignment](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#qualifieralignment) clang-format option to make our code style more uniform.

* GitHub Issue: #47500