### PR TITLE
GH-47506: [CI][Packaging] Fix Amazon Linux 2023 packages verification

### DIFF
--- a/dev/release/verify-yum.sh
+++ b/dev/release/verify-yum.sh
@@ -87,7 +87,14 @@ case "${distribution}-${distribution_version}" in
   amzn-*)
     distribution_prefix="amazon-linux"
     enablerepo_epel=""
-    install_command="dnf install -y"
+    # gcc-c++ installs kernel6.12-headers as a dependency
+    # automatically. But it conflicts with kernel-headers that is
+    # grpc-devel dependency. If we use "--allowerasing" when we
+    # install grpc-devel (via arrow-flight-devel), kernel6.12-headers
+    # is replaced with kernel-headers automatically. gcc-c++ works
+    # with kernel-headers too. So using kernel-headers is not a
+    # problem.
+    install_command="dnf install -y --allowerasing"
     info_command="dnf info"
     ;;
   centos-7)


### PR DESCRIPTION
### Rationale for this change

`gcc-c++` installs `kernel6.12-headers` automatically but it conflicts with `kernel-headers` that is required by `grpc-devel`.

### What changes are included in this PR?

Use `--allowerasing` to use `kernel-headers` when we install `grpc-devel`.

`gcc-c++` works with either `kernel6.12-headers` or `kernel-headers`. So this is not a problem.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #47506