### PR TITLE
GH-47505: [CI][C#][Integration] Use apache/arrow-dotnet

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -95,6 +95,11 @@ jobs:
         with:
           repository: apache/arrow-js
           path: js
+      - name: Checkout Arrow .NET
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          repository: apache/arrow-dotnet
+          path: dotnet
       - name: Free up disk space
         run: |
           ci/scripts/util_free_space.sh
@@ -118,6 +123,7 @@ jobs:
           source ci/scripts/util_enable_core_dumps.sh
           archery docker run \
             -e ARCHERY_DEFAULT_BRANCH=${{ github.event.repository.default_branch }} \
+            -e ARCHERY_INTEGRATION_WITH_DOTNET=1 \
             -e ARCHERY_INTEGRATION_WITH_GO=1 \
             -e ARCHERY_INTEGRATION_WITH_JAVA=1 \
             -e ARCHERY_INTEGRATION_WITH_JS=1 \

--- a/ci/scripts/integration_arrow.sh
+++ b/ci/scripts/integration_arrow.sh
@@ -25,9 +25,8 @@ build_dir=${2}
 gold_dir=$arrow_dir/testing/data/arrow-ipc-stream/integration
 
 : "${ARROW_INTEGRATION_CPP:=ON}"
-: "${ARROW_INTEGRATION_CSHARP:=ON}"
 
-: "${ARCHERY_INTEGRATION_TARGET_IMPLEMENTATIONS:=cpp,csharp}"
+: "${ARCHERY_INTEGRATION_TARGET_IMPLEMENTATIONS:=cpp}"
 export ARCHERY_INTEGRATION_TARGET_IMPLEMENTATIONS
 
 . "${arrow_dir}/ci/scripts/util_log.sh"
@@ -38,7 +37,7 @@ github_actions_group_end
 
 github_actions_group_begin "Integration: Prepare: Dependencies"
 # For C Data Interface testing
-if [ "${ARROW_INTEGRATION_CSHARP}" == "ON" ]; then
+if [ "${ARCHERY_INTEGRATION_WITH_DOTNET}" -gt "0" ]; then
     pip install pythonnet
 fi
 if [ "${ARCHERY_INTEGRATION_WITH_JAVA}" -gt "0" ]; then
@@ -59,7 +58,6 @@ export GOMEMLIMIT=200MiB
 export GODEBUG=gctrace=1,clobberfree=1
 
 ARCHERY_WITH_CPP=$([ "$ARROW_INTEGRATION_CPP" == "ON" ] && echo "1" || echo "0")
-ARCHERY_WITH_CSHARP=$([ "$ARROW_INTEGRATION_CSHARP" == "ON" ] && echo "1" || echo "0")
 
 # Rust can be enabled by exporting ARCHERY_INTEGRATION_WITH_RUST=1
 time archery integration \
@@ -67,7 +65,6 @@ time archery integration \
     --run-ipc \
     --run-flight \
     --with-cpp="${ARCHERY_WITH_CPP}" \
-    --with-csharp="${ARCHERY_WITH_CSHARP}"\
     --gold-dirs="$gold_dir/0.14.1" \
     --gold-dirs="$gold_dir/0.17.1" \
     --gold-dirs="$gold_dir/1.0.0-bigendian" \

--- a/ci/scripts/integration_arrow_build.sh
+++ b/ci/scripts/integration_arrow_build.sh
@@ -23,7 +23,6 @@ arrow_dir=${1}
 build_dir=${2}
 
 : "${ARROW_INTEGRATION_CPP:=ON}"
-: "${ARROW_INTEGRATION_CSHARP:=ON}"
 
 . "${arrow_dir}/ci/scripts/util_log.sh"
 
@@ -47,9 +46,10 @@ if [ "${ARROW_INTEGRATION_CPP}" == "ON" ]; then
 fi
 github_actions_group_end
 
-github_actions_group_begin "Integration: Build: C#"
-if [ "${ARROW_INTEGRATION_CSHARP}" == "ON" ]; then
-    "${arrow_dir}/ci/scripts/csharp_build.sh" "${arrow_dir}" "${build_dir}"
+github_actions_group_begin "Integration: Build: .NET"
+if [ "${ARCHERY_INTEGRATION_WITH_DOTNET}" -gt "0" ]; then
+    "${arrow_dir}/dotnet/ci/scripts/build.sh" "${arrow_dir}/dotnet"
+    cp -a "${arrow_dir}/dotnet" "${build_dir}/dotnet"
 fi
 github_actions_group_end
 

--- a/dev/archery/archery/cli.py
+++ b/dev/archery/archery/cli.py
@@ -670,8 +670,9 @@ def _set_default(opt, default):
               help="Seed for PRNG when generating test data")
 @click.option('--with-cpp', type=bool, default=False,
               help='Include C++ in integration tests')
-@click.option('--with-csharp', type=bool, default=False,
-              help='Include C# in integration tests')
+@click.option('--with-dotnet', type=bool, default=False,
+              help='Include .NET in integration tests',
+              envvar="ARCHERY_INTEGRATION_WITH_DOTNET")
 @click.option('--with-java', type=bool, default=False,
               help='Include Java in integration tests',
               envvar="ARCHERY_INTEGRATION_WITH_JAVA")
@@ -783,7 +784,7 @@ def integration(with_all=False, random_seed=12345, **args):
 
     gen_path = args['write_generated_json']
 
-    implementations = ['cpp', 'csharp', 'java', 'js', 'go', 'nanoarrow', 'rust']
+    implementations = ['cpp', 'dotnet', 'java', 'js', 'go', 'nanoarrow', 'rust']
     formats = ['ipc', 'flight', 'c_data']
 
     enabled_implementations = 0

--- a/dev/archery/archery/integration/datagen.py
+++ b/dev/archery/archery/integration/datagen.py
@@ -1429,7 +1429,7 @@ class File(object):
         self.path = path
 
     def skip_tester(self, tester):
-        """Skip this test for the given tester (such as 'C#').
+        """Skip this test for the given tester (such as '.NET').
         """
         self.skipped_testers.add(tester)
         return self
@@ -1951,23 +1951,23 @@ def get_generated_json_files(tempdir=None):
         # TODO(https://github.com/apache/arrow-nanoarrow/issues/622)
         .skip_tester('nanoarrow')
         # TODO(https://github.com/apache/arrow/issues/38045)
-        .skip_format(SKIP_FLIGHT, 'C#'),
+        .skip_format(SKIP_FLIGHT, '.NET'),
 
         generate_dictionary_unsigned_case()
         .skip_tester('nanoarrow')
         .skip_tester('Java')  # TODO(ARROW-9377)
         # TODO(https://github.com/apache/arrow/issues/38045)
-        .skip_format(SKIP_FLIGHT, 'C#'),
+        .skip_format(SKIP_FLIGHT, '.NET'),
 
         generate_nested_dictionary_case()
         # TODO(https://github.com/apache/arrow-nanoarrow/issues/622)
         .skip_tester('nanoarrow')
         .skip_tester('Java')  # TODO(ARROW-7779)
         # TODO(https://github.com/apache/arrow/issues/38045)
-        .skip_format(SKIP_FLIGHT, 'C#'),
+        .skip_format(SKIP_FLIGHT, '.NET'),
 
         generate_run_end_encoded_case()
-        .skip_tester('C#')
+        .skip_tester('.NET')
         .skip_tester('JS')
         # TODO(https://github.com/apache/arrow-nanoarrow/issues/618)
         .skip_tester('nanoarrow')
@@ -1980,7 +1980,7 @@ def get_generated_json_files(tempdir=None):
         .skip_tester('Rust'),
 
         generate_list_view_case()
-        .skip_tester('C#')     # Doesn't support large list views
+        .skip_tester('.NET')     # Doesn't support large list views
         .skip_tester('JS')
         # TODO(https://github.com/apache/arrow-nanoarrow/issues/618)
         .skip_tester('nanoarrow')
@@ -1992,7 +1992,7 @@ def get_generated_json_files(tempdir=None):
         .skip_format(SKIP_C_SCHEMA, 'C++')
         .skip_format(SKIP_C_ARRAY, 'C++')
         # TODO(https://github.com/apache/arrow/issues/38045)
-        .skip_format(SKIP_FLIGHT, 'C#'),
+        .skip_format(SKIP_FLIGHT, '.NET'),
     ]
 
     generated_paths = []

--- a/dev/archery/archery/integration/runner.py
+++ b/dev/archery/archery/integration/runner.py
@@ -193,7 +193,7 @@ class IntegrationRunner(object):
                 skip_testers.add("Java")
                 skip_testers.add("JS")
             if prefix == '1.0.0-bigendian' or prefix == '1.0.0-littleendian':
-                skip_testers.add("C#")
+                skip_testers.add(".NET")
                 skip_testers.add("Java")
                 skip_testers.add("JS")
                 skip_testers.add("Rust")
@@ -207,7 +207,7 @@ class IntegrationRunner(object):
             # disable specific compression type tests.
 
             if prefix == '4.0.0-shareddict':
-                skip_testers.add("C#")
+                skip_testers.add(".NET")
                 # https://github.com/apache/arrow-nanoarrow/issues/622
                 skip_testers.add("nanoarrow")
 
@@ -590,7 +590,7 @@ def get_static_json_files():
 
 
 def run_all_tests(with_cpp=True, with_java=True, with_js=True,
-                  with_csharp=True, with_go=True, with_rust=False,
+                  with_dotnet=True, with_go=True, with_rust=False,
                   with_nanoarrow=False, run_ipc=False, run_flight=False,
                   run_c_data=False, tempdir=None, target_implementations="",
                   **kwargs):
@@ -619,9 +619,9 @@ def run_all_tests(with_cpp=True, with_java=True, with_js=True,
         from .tester_js import JSTester
         append_tester("js", JSTester(**kwargs))
 
-    if with_csharp:
-        from .tester_csharp import CSharpTester
-        append_tester("csharp", CSharpTester(**kwargs))
+    if with_dotnet:
+        from .tester_dotnet import DotNetTester
+        append_tester("dotnet", DotNetTester(**kwargs))
 
     if with_go:
         from .tester_go import GoTester
@@ -644,42 +644,42 @@ def run_all_tests(with_cpp=True, with_java=True, with_js=True,
         Scenario(
             "auth:basic_proto",
             description="Authenticate using the BasicAuth protobuf.",
-            skip_testers={"C#"},
+            skip_testers={".NET"},
         ),
         Scenario(
             "middleware",
             description="Ensure headers are propagated via middleware.",
-            skip_testers={"C#"},
+            skip_testers={".NET"},
         ),
         Scenario(
             "ordered",
             description="Ensure FlightInfo.ordered is supported.",
-            skip_testers={"JS", "C#", "Rust"},
+            skip_testers={"JS", ".NET", "Rust"},
         ),
         Scenario(
             "expiration_time:do_get",
             description=("Ensure FlightEndpoint.expiration_time with "
                          "DoGet is working as expected."),
-            skip_testers={"JS", "C#", "Rust"},
+            skip_testers={"JS", ".NET", "Rust"},
         ),
         Scenario(
             "expiration_time:list_actions",
             description=("Ensure FlightEndpoint.expiration_time related "
                          "pre-defined actions is working with ListActions "
                          "as expected."),
-            skip_testers={"JS", "C#", "Rust"},
+            skip_testers={"JS", ".NET", "Rust"},
         ),
         Scenario(
             "expiration_time:cancel_flight_info",
             description=("Ensure FlightEndpoint.expiration_time and "
                          "CancelFlightInfo are working as expected."),
-            skip_testers={"JS", "C#", "Rust"},
+            skip_testers={"JS", ".NET", "Rust"},
         ),
         Scenario(
             "expiration_time:renew_flight_endpoint",
             description=("Ensure FlightEndpoint.expiration_time and "
                          "RenewFlightEndpoint are working as expected."),
-            skip_testers={"JS", "C#", "Rust"},
+            skip_testers={"JS", ".NET", "Rust"},
         ),
         Scenario(
             "do_exchange:echo",
@@ -690,37 +690,37 @@ def run_all_tests(with_cpp=True, with_java=True, with_js=True,
         Scenario(
             "location:reuse_connection",
             description="Ensure arrow-flight-reuse-connection is accepted.",
-            skip_testers={"JS", "C#", "Rust"},
+            skip_testers={"JS", ".NET", "Rust"},
         ),
         Scenario(
             "session_options",
             description="Ensure Flight SQL Sessions work as expected.",
-            skip_testers={"JS", "C#", "Rust"}
+            skip_testers={"JS", ".NET", "Rust"}
         ),
         Scenario(
             "poll_flight_info",
             description="Ensure PollFlightInfo is supported.",
-            skip_testers={"JS", "C#", "Rust"}
+            skip_testers={"JS", ".NET", "Rust"}
         ),
         Scenario(
             "app_metadata_flight_info_endpoint",
             description="Ensure support FlightInfo and Endpoint app_metadata",
-            skip_testers={"JS", "C#", "Rust"}
+            skip_testers={"JS", ".NET", "Rust"}
         ),
         Scenario(
             "flight_sql",
             description="Ensure Flight SQL protocol is working as expected.",
-            skip_testers={"Rust", "C#"}
+            skip_testers={"Rust", ".NET"}
         ),
         Scenario(
             "flight_sql:extension",
             description="Ensure Flight SQL extensions work as expected.",
-            skip_testers={"Rust", "C#"}
+            skip_testers={"Rust", ".NET"}
         ),
         Scenario(
             "flight_sql:ingestion",
             description="Ensure Flight SQL ingestion works as expected.",
-            skip_testers={"JS", "C#", "Rust"}
+            skip_testers={"JS", ".NET", "Rust"}
         ),
     ]
 

--- a/dev/archery/archery/integration/tester_dotnet.py
+++ b/dev/archery/archery/integration/tester_dotnet.py
@@ -25,7 +25,7 @@ from .util import run_cmd, log
 from ..utils.source import ARROW_ROOT_DEFAULT
 
 
-_ARTIFACTS_PATH = os.path.join(ARROW_ROOT_DEFAULT, "csharp/artifacts")
+_ARTIFACTS_PATH = os.path.join(ARROW_ROOT_DEFAULT, "dotnet/artifacts")
 _BUILD_SUBDIR = "Debug/net8.0"
 
 _EXE_PATH = os.path.join(_ARTIFACTS_PATH,
@@ -94,7 +94,7 @@ class _CDataBase:
         CDataInterface.RunGC()
 
 
-class CSharpCDataExporter(CDataExporter, _CDataBase):
+class DotNetCDataExporter(CDataExporter, _CDataBase):
 
     def export_schema_from_json(self, json_path, c_schema_ptr):
         from Apache.Arrow.IntegrationTest import CDataInterface
@@ -120,7 +120,7 @@ class CSharpCDataExporter(CDataExporter, _CDataBase):
         self._run_gc()
 
 
-class CSharpCDataImporter(CDataImporter, _CDataBase):
+class DotNetCDataImporter(CDataImporter, _CDataBase):
 
     def import_schema_and_compare_to_json(self, json_path, c_schema_ptr):
         from Apache.Arrow.IntegrationTest import CDataInterface
@@ -152,7 +152,7 @@ class CSharpCDataImporter(CDataImporter, _CDataBase):
         self._run_gc()
 
 
-class CSharpTester(Tester):
+class DotNetTester(Tester):
     PRODUCER = True
     CONSUMER = True
     FLIGHT_SERVER = True
@@ -162,7 +162,7 @@ class CSharpTester(Tester):
     C_DATA_ARRAY_EXPORTER = True
     C_DATA_ARRAY_IMPORTER = True
 
-    name = 'C#'
+    name = '.NET'
 
     def _run(self, json_path=None, arrow_path=None, command='validate'):
         cmd = [_EXE_PATH]
@@ -199,10 +199,10 @@ class CSharpTester(Tester):
         self.run_shell_command(cmd)
 
     def make_c_data_exporter(self):
-        return CSharpCDataExporter(self.debug, self.args)
+        return DotNetCDataExporter(self.debug, self.args)
 
     def make_c_data_importer(self):
-        return CSharpCDataImporter(self.debug, self.args)
+        return DotNetCDataImporter(self.debug, self.args)
 
     def flight_request(self, port, json_path=None, scenario_name=None):
         cmd = [_FLIGHT_EXE_PATH, 'client', '--port', f'{port}']


### PR DESCRIPTION
### Rationale for this change

We're moving the C# implementation to apache/arrow-dotnet.

### What changes are included in this PR?

Use apache/arrow-dotnet instead of `csharp/` in apache/arrow.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #47505