### PR TITLE
GH-47509: [CI][Packaging][Linux] Enable Docker build cache

### DIFF
--- a/dev/tasks/linux-packages/package-task.rb
+++ b/dev/tasks/linux-packages/package-task.rb
@@ -120,6 +120,7 @@ class PackageTask
     build_command_line = [
       "docker",
       "build",
+      "--build-arg", "BUILDKIT_INLINE_CACHE=1",
       "--cache-from", image,
       "--tag", image,
     ]


### PR DESCRIPTION
### Rationale for this change

We need `--build-arg BUILDKIT_INLINE_CACHE=1` to embed cache information to built images. If we don't use this, `--cache-from` doesn't work.

### What changes are included in this PR?

Add missing `--build-arg BUILDKIT_INLINE_CACHE=1`.

### Are these changes tested?

No. We need to push built images to test this but we push built images after this is merged.

### Are there any user-facing changes?

No.
* GitHub Issue: #47509