### PR TITLE
MINOR: [Docs] Fix typos

### DIFF
--- a/r/R/dplyr-summarize.R
+++ b/r/R/dplyr-summarize.R
@@ -105,7 +105,7 @@ do_arrow_summarize <- function(.data, ..., .groups = NULL) {
     # variables from the mask, which would be a bit tortured (even for me).
     # So we'll check here.
     # We can tell the expression is invalid if it references fields not in
-    # the schema of the data after summarize(). Evaulating its type will
+    # the schema of the data after summarize(). Evaluating its type will
     # throw an error if it's invalid.
     tryCatch(post_mutate[[post]]$type(out$.data$schema), error = function(e) {
       arrow_not_supported(

--- a/r/README.md
+++ b/r/README.md
@@ -46,7 +46,7 @@ There are some special cases to note:
 
 - If you are compiling arrow from source, please note that as of version 10.0.0, arrow requires C++17 to build. This has implications on Windows and CentOS 7. For Windows users it means you need to be running an R version of 4.0 or later. On CentOS 7, it means you need to install a newer compiler than the default system compiler gcc. See the [installation details article](https://arrow.apache.org/docs/r/articles/developers/install_details.html) for guidance.
 
-- Development versions of arrow are released nightly. For information on how to installl nightly builds please see the [installing nightly builds](https://arrow.apache.org/docs/r/articles/install_nightly.html) article.
+- Development versions of arrow are released nightly. For information on how to install nightly builds please see the [installing nightly builds](https://arrow.apache.org/docs/r/articles/install_nightly.html) article.
 
 ## What can the arrow package do?
 


### PR DESCRIPTION
### Rationale for this change
Improve readability and clarity by fixing minor typos/wording in a code comment and in the R README. No functional behavior is affected.

### What changes are included in this PR?
- `r/R/dplyr-summarize.R`: Correct typo from `Evaulating` to `Evaluating`.
- `r/README.md`: Correct typo from `installl` to `install`.

### Are these changes tested?
Not applicable. These are documentation/comment-only changes; no runtime logic is modified.

### Are there any user-facing changes?
No user-facing behavior changes. Documentation readability is slightly improved.

**This PR includes breaking changes to public APIs.**
No.

**This PR contains a "Critical Fix".**
No.