### PR TITLE
GH-47512: [C++] Bump meson-fmt in pre-commit to 1.9.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -391,8 +391,13 @@ repos:
           ?^dev/release/post-09-python\.sh$|
           )
   - repo: https://github.com/trim21/pre-commit-mirror-meson
-    rev: v1.6.1
+    rev: v1.9.0
     hooks:
       - id: meson-fmt
         alias: cpp
         args: ['--inplace']
+        files: >-
+          (
+          ?.*meson\.build$|
+          ?.*meson\.options$|
+          )

--- a/cpp/meson.build
+++ b/cpp/meson.build
@@ -66,10 +66,10 @@ needs_flight = get_option('flight').enabled()
 needs_ipc = get_option('ipc').enabled() or needs_tests or needs_acero or needs_benchmarks or needs_flight
 needs_fuzzing = get_option('fuzzing').enabled()
 needs_testing = (get_option('testing').enabled()
-or needs_tests
-or needs_benchmarks
-or needs_fuzzing
-or needs_integration
+    or needs_tests
+    or needs_benchmarks
+    or needs_fuzzing
+    or needs_integration
 )
 needs_json = get_option('json').enabled() or needs_testing
 needs_brotli = get_option('brotli').enabled() or needs_fuzzing

--- a/cpp/meson.options
+++ b/cpp/meson.options
@@ -15,20 +15,40 @@
 # specific language governing permissions and limitations
 # under the License.
 
-option('acero', type: 'feature', description: 'Build the Arrow Acero Engine Module')
+option(
+    'acero',
+    type: 'feature',
+    description: 'Build the Arrow Acero Engine Module',
+)
 option(
     'azure',
     type: 'feature',
     description: 'Build Arrow with Azure support (requires the Azure SDK for C++)',
 )
 
-option('benchmarks', type: 'feature', description: 'Build the Arrow micro benchmarks')
+option(
+    'benchmarks',
+    type: 'feature',
+    description: 'Build the Arrow micro benchmarks',
+)
 option('brotli', type: 'feature', description: 'Build with Brotli compression')
 option('bz2', type: 'feature', description: 'Build with BZ2 compression')
-option('compute', type: 'feature', description: 'Build all Arrow Compute kernels')
+option(
+    'compute',
+    type: 'feature',
+    description: 'Build all Arrow Compute kernels',
+)
 option('csv', type: 'feature', description: 'Build the Arrow CSV Parser Module')
-option('filesystem', type: 'feature', description: 'Build the Arrow Filesystem Layer')
-option('fuzzing', type: 'feature', description: 'Build Arrow Fuzzing executables')
+option(
+    'filesystem',
+    type: 'feature',
+    description: 'Build the Arrow Filesystem Layer',
+)
+option(
+    'fuzzing',
+    type: 'feature',
+    description: 'Build Arrow Fuzzing executables',
+)
 
 option(
     'gcs',
@@ -62,11 +82,7 @@ option(
 option('git_id', type: 'string')
 option('git_description', type: 'string')
 
-option(
-    'lz4',
-    type: 'feature',
-    description: 'Build with lz4 compression',
-)
+option('lz4', type: 'feature', description: 'Build with lz4 compression')
 
 option(
     'package_kind',
@@ -87,9 +103,21 @@ option(
     description: 'Build Arrow with TensorFlow support enabled',
 )
 
-option('testing', type: 'feature', description: 'Build the Arrow testing libraries')
-option('tests', type: 'feature', description: 'Build the Arrow googletest unit tests')
+option(
+    'testing',
+    type: 'feature',
+    description: 'Build the Arrow testing libraries',
+)
+option(
+    'tests',
+    type: 'feature',
+    description: 'Build the Arrow googletest unit tests',
+)
 
-option('utilities', type: 'feature', description: 'Build Arrow commandline utilities')
+option(
+    'utilities',
+    type: 'feature',
+    description: 'Build Arrow commandline utilities',
+)
 option('zlib', type: 'feature', description: 'Build with zlib compression')
 option('zstd', type: 'feature', description: 'Build with zstd compression')

--- a/cpp/src/arrow/ipc/meson.build
+++ b/cpp/src/arrow/ipc/meson.build
@@ -74,9 +74,9 @@ exc = executable(
 benchmark('arrow-ipc-read-write-benchmark', exc)
 
 if needs_fuzzing or (needs_utilities
-and needs_testing
-and needs_lz4
-and needs_zstd
+    and needs_testing
+    and needs_lz4
+    and needs_zstd
 )
     fuzz_corpus_exc = executable(
         'arrow-ipc-generate-fuzz-corpus',


### PR DESCRIPTION
### Rationale for this change

This improves the readability of parenthesized multi-line expressions in Meson configuration files

### What changes are included in this PR?

meson-fmt in pre-commit has been bumped to version 1.9.0, and files have been cleaned accordingly

### Are these changes tested?

Yes

### Are there any user-facing changes?

No
* GitHub Issue: #47512