### PR TITLE
GH-47514: [C++][Parquet] Add unpack tests and benchmarks

### DIFF
--- a/cpp/src/arrow/util/CMakeLists.txt
+++ b/cpp/src/arrow/util/CMakeLists.txt
@@ -117,8 +117,8 @@ add_arrow_test(crc32-test
                Boost::headers)
 
 add_arrow_benchmark(bit_block_counter_benchmark)
-add_arrow_benchmark(bit_util_benchmark SOURCES bit_util_benchmark.cc
-                    bpacking_benchmark.cc)
+add_arrow_benchmark(bit_util_benchmark)
+add_arrow_benchmark(bpacking_benchmark)
 add_arrow_benchmark(bitmap_reader_benchmark)
 add_arrow_benchmark(cache_benchmark)
 add_arrow_benchmark(compression_benchmark)

--- a/cpp/src/arrow/util/CMakeLists.txt
+++ b/cpp/src/arrow/util/CMakeLists.txt
@@ -117,7 +117,8 @@ add_arrow_test(crc32-test
                Boost::headers)
 
 add_arrow_benchmark(bit_block_counter_benchmark)
-add_arrow_benchmark(bit_util_benchmark)
+add_arrow_benchmark(bit_util_benchmark SOURCES bit_util_benchmark.cc
+                    bpacking_benchmark.cc)
 add_arrow_benchmark(bitmap_reader_benchmark)
 add_arrow_benchmark(cache_benchmark)
 add_arrow_benchmark(compression_benchmark)

--- a/cpp/src/arrow/util/CMakeLists.txt
+++ b/cpp/src/arrow/util/CMakeLists.txt
@@ -98,6 +98,7 @@ add_arrow_test(bit-utility-test
                SOURCES
                bit_block_counter_test.cc
                bit_util_test.cc
+               bpacking_test.cc
                rle_encoding_test.cc)
 
 add_arrow_test(threading-utility-test

--- a/cpp/src/arrow/util/bit_stream_utils_internal.h
+++ b/cpp/src/arrow/util/bit_stream_utils_internal.h
@@ -25,6 +25,7 @@
 
 #include "arrow/util/bit_util.h"
 #include "arrow/util/bpacking_internal.h"
+#include "arrow/util/endian.h"
 #include "arrow/util/logging.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/ubsan.h"

--- a/cpp/src/arrow/util/bit_stream_utils_internal.h
+++ b/cpp/src/arrow/util/bit_stream_utils_internal.h
@@ -340,8 +340,8 @@ inline int BitReader::GetBatch(int num_bits, T* v, int batch_size) {
 
   if (sizeof(T) == 4) {
     int num_unpacked =
-        internal::unpack32(reinterpret_cast<const uint32_t*>(buffer + byte_offset),
-                           reinterpret_cast<uint32_t*>(v + i), batch_size - i, num_bits);
+        internal::unpack32(buffer + byte_offset, reinterpret_cast<uint32_t*>(v + i),
+                           batch_size - i, num_bits);
     i += num_unpacked;
     byte_offset += num_unpacked * num_bits / 8;
   } else if (sizeof(T) == 8 && num_bits > 32) {
@@ -361,8 +361,7 @@ inline int BitReader::GetBatch(int num_bits, T* v, int batch_size) {
     while (i < batch_size) {
       int unpack_size = std::min(buffer_size, batch_size - i);
       int num_unpacked =
-          internal::unpack32(reinterpret_cast<const uint32_t*>(buffer + byte_offset),
-                             unpack_buffer, unpack_size, num_bits);
+          internal::unpack32(buffer + byte_offset, unpack_buffer, unpack_size, num_bits);
       if (num_unpacked == 0) {
         break;
       }

--- a/cpp/src/arrow/util/bpacking.cc
+++ b/cpp/src/arrow/util/bpacking.cc
@@ -36,8 +36,6 @@
 namespace arrow {
 namespace internal {
 
-namespace {
-
 int unpack32_default(const uint32_t* in, uint32_t* out, int batch_size, int num_bits) {
   batch_size = batch_size / 32 * 32;
   int num_loops = batch_size / 32;
@@ -149,6 +147,8 @@ int unpack32_default(const uint32_t* in, uint32_t* out, int batch_size, int num_
   return batch_size;
 }
 
+namespace {
+
 struct Unpack32DynamicFunction {
   using FunctionType = decltype(&unpack32_default);
 
@@ -176,8 +176,6 @@ int unpack32(const uint32_t* in, uint32_t* out, int batch_size, int num_bits) {
   return dispatch.func(in, out, batch_size, num_bits);
 #endif
 }
-
-namespace {
 
 int unpack64_default(const uint8_t* in, uint64_t* out, int batch_size, int num_bits) {
   batch_size = batch_size / 32 * 32;
@@ -385,8 +383,6 @@ int unpack64_default(const uint8_t* in, uint64_t* out, int batch_size, int num_b
 
   return batch_size;
 }
-
-}  // namespace
 
 int unpack64(const uint8_t* in, uint64_t* out, int batch_size, int num_bits) {
   // TODO: unpack64_neon, unpack64_avx2 and unpack64_avx512

--- a/cpp/src/arrow/util/bpacking.cc
+++ b/cpp/src/arrow/util/bpacking.cc
@@ -36,7 +36,9 @@
 namespace arrow {
 namespace internal {
 
-int unpack32_default(const uint32_t* in, uint32_t* out, int batch_size, int num_bits) {
+int unpack32_default(const uint8_t* in_, uint32_t* out, int batch_size, int num_bits) {
+  const uint32_t* in = reinterpret_cast<const uint32_t*>(in_);
+
   batch_size = batch_size / 32 * 32;
   int num_loops = batch_size / 32;
 
@@ -168,7 +170,7 @@ struct Unpack32DynamicFunction {
 
 }  // namespace
 
-int unpack32(const uint32_t* in, uint32_t* out, int batch_size, int num_bits) {
+int unpack32(const uint8_t* in, uint32_t* out, int batch_size, int num_bits) {
 #if defined(ARROW_HAVE_NEON)
   return unpack32_neon(in, out, batch_size, num_bits);
 #else

--- a/cpp/src/arrow/util/bpacking.cc
+++ b/cpp/src/arrow/util/bpacking.cc
@@ -36,7 +36,7 @@
 namespace arrow {
 namespace internal {
 
-int unpack32_default(const uint8_t* in_, uint32_t* out, int batch_size, int num_bits) {
+int unpack32_scalar(const uint8_t* in_, uint32_t* out, int batch_size, int num_bits) {
   const uint32_t* in = reinterpret_cast<const uint32_t*>(in_);
 
   batch_size = batch_size / 32 * 32;
@@ -152,10 +152,10 @@ int unpack32_default(const uint8_t* in_, uint32_t* out, int batch_size, int num_
 namespace {
 
 struct Unpack32DynamicFunction {
-  using FunctionType = decltype(&unpack32_default);
+  using FunctionType = decltype(&unpack32_scalar);
 
   static std::vector<std::pair<DispatchLevel, FunctionType>> implementations() {
-    return {{DispatchLevel::NONE, unpack32_default}
+    return {{DispatchLevel::NONE, unpack32_scalar}
 #if defined(ARROW_HAVE_RUNTIME_AVX2)
             ,
             {DispatchLevel::AVX2, unpack32_avx2}
@@ -179,7 +179,7 @@ int unpack32(const uint8_t* in, uint32_t* out, int batch_size, int num_bits) {
 #endif
 }
 
-int unpack64_default(const uint8_t* in, uint64_t* out, int batch_size, int num_bits) {
+int unpack64_scalar(const uint8_t* in, uint64_t* out, int batch_size, int num_bits) {
   batch_size = batch_size / 32 * 32;
   int num_loops = batch_size / 32;
 
@@ -388,7 +388,7 @@ int unpack64_default(const uint8_t* in, uint64_t* out, int batch_size, int num_b
 
 int unpack64(const uint8_t* in, uint64_t* out, int batch_size, int num_bits) {
   // TODO: unpack64_neon, unpack64_avx2 and unpack64_avx512
-  return unpack64_default(in, out, batch_size, num_bits);
+  return unpack64_scalar(in, out, batch_size, num_bits);
 }
 
 }  // namespace internal

--- a/cpp/src/arrow/util/bpacking64_default_internal.h
+++ b/cpp/src/arrow/util/bpacking64_default_internal.h
@@ -26,11 +26,10 @@
 
 #pragma once
 
-#include "arrow/util/bit_util.h"
+#include "arrow/util/endian.h"
 #include "arrow/util/ubsan.h"
 
-namespace arrow {
-namespace internal {
+namespace arrow::internal {
 
 inline const uint8_t* unpack0_64(const uint8_t* in, uint64_t* out) {
   for (int k = 0; k < 32; k += 1) {
@@ -5638,5 +5637,4 @@ inline const uint8_t* unpack64_64(const uint8_t* in, uint64_t* out) {
   return in;
 }
 
-}  // namespace internal
-}  // namespace arrow
+}  // namespace arrow::internal

--- a/cpp/src/arrow/util/bpacking_avx2.cc
+++ b/cpp/src/arrow/util/bpacking_avx2.cc
@@ -19,13 +19,11 @@
 #include "arrow/util/bpacking_simd256_generated_internal.h"
 #include "arrow/util/bpacking_simd_internal.h"
 
-namespace arrow {
-namespace internal {
+namespace arrow::internal {
 
-int unpack32_avx2(const uint32_t* in, uint32_t* out, int batch_size, int num_bits) {
-  return unpack32_specialized<UnpackBits256<DispatchLevel::AVX2>>(in, out, batch_size,
-                                                                  num_bits);
+int unpack32_avx2(const uint8_t* in, uint32_t* out, int batch_size, int num_bits) {
+  return unpack32_specialized<UnpackBits256<DispatchLevel::AVX2>>(
+      reinterpret_cast<const uint32_t*>(in), out, batch_size, num_bits);
 }
 
-}  // namespace internal
-}  // namespace arrow
+}  // namespace arrow::internal

--- a/cpp/src/arrow/util/bpacking_avx2_internal.h
+++ b/cpp/src/arrow/util/bpacking_avx2_internal.h
@@ -17,12 +17,10 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
-namespace arrow {
-namespace internal {
+namespace arrow::internal {
 
-int unpack32_avx2(const uint32_t* in, uint32_t* out, int batch_size, int num_bits);
+int unpack32_avx2(const uint8_t* in, uint32_t* out, int batch_size, int num_bits);
 
-}  // namespace internal
-}  // namespace arrow
+}  // namespace arrow::internal

--- a/cpp/src/arrow/util/bpacking_avx2_internal.h
+++ b/cpp/src/arrow/util/bpacking_avx2_internal.h
@@ -17,10 +17,13 @@
 
 #pragma once
 
+#include "arrow/util/visibility.h"
+
 #include <cstdint>
 
 namespace arrow::internal {
 
-int unpack32_avx2(const uint8_t* in, uint32_t* out, int batch_size, int num_bits);
+ARROW_EXPORT int unpack32_avx2(const uint8_t* in, uint32_t* out, int batch_size,
+                               int num_bits);
 
 }  // namespace arrow::internal

--- a/cpp/src/arrow/util/bpacking_avx512.cc
+++ b/cpp/src/arrow/util/bpacking_avx512.cc
@@ -19,13 +19,11 @@
 #include "arrow/util/bpacking_simd512_generated_internal.h"
 #include "arrow/util/bpacking_simd_internal.h"
 
-namespace arrow {
-namespace internal {
+namespace arrow::internal {
 
-int unpack32_avx512(const uint32_t* in, uint32_t* out, int batch_size, int num_bits) {
-  return unpack32_specialized<UnpackBits512<DispatchLevel::AVX512>>(in, out, batch_size,
-                                                                    num_bits);
+int unpack32_avx512(const uint8_t* in, uint32_t* out, int batch_size, int num_bits) {
+  return unpack32_specialized<UnpackBits512<DispatchLevel::AVX512>>(
+      reinterpret_cast<const uint32_t*>(in), out, batch_size, num_bits);
 }
 
-}  // namespace internal
-}  // namespace arrow
+}  // namespace arrow::internal

--- a/cpp/src/arrow/util/bpacking_avx512_internal.h
+++ b/cpp/src/arrow/util/bpacking_avx512_internal.h
@@ -17,12 +17,10 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
-namespace arrow {
-namespace internal {
+namespace arrow::internal {
 
-int unpack32_avx512(const uint32_t* in, uint32_t* out, int batch_size, int num_bits);
+int unpack32_avx512(const uint8_t* in, uint32_t* out, int batch_size, int num_bits);
 
-}  // namespace internal
-}  // namespace arrow
+}  // namespace arrow::internal

--- a/cpp/src/arrow/util/bpacking_avx512_internal.h
+++ b/cpp/src/arrow/util/bpacking_avx512_internal.h
@@ -17,10 +17,13 @@
 
 #pragma once
 
+#include "arrow/util/visibility.h"
+
 #include <cstdint>
 
 namespace arrow::internal {
 
-int unpack32_avx512(const uint8_t* in, uint32_t* out, int batch_size, int num_bits);
+ARROW_EXPORT int unpack32_avx512(const uint8_t* in, uint32_t* out, int batch_size,
+                                 int num_bits);
 
 }  // namespace arrow::internal

--- a/cpp/src/arrow/util/bpacking_benchmark.cc
+++ b/cpp/src/arrow/util/bpacking_benchmark.cc
@@ -124,9 +124,9 @@ void BM_UnpackUint64(benchmark::State& state, bool aligned, UnpackFunc<uint64_t>
   return BM_Unpack<uint64_t>(state, aligned, unpack, skip, std::move(skip_msg));
 }
 
-BENCHMARK_CAPTURE(BM_UnpackUint32, ScalarUnaligned, false, unpack32_default)
+BENCHMARK_CAPTURE(BM_UnpackUint32, ScalarUnaligned, false, unpack32_scalar)
     ->ArgsProduct(kBitWidthsNumValues32);
-BENCHMARK_CAPTURE(BM_UnpackUint64, ScalarUnaligned, false, unpack64_default)
+BENCHMARK_CAPTURE(BM_UnpackUint64, ScalarUnaligned, false, unpack64_scalar)
     ->ArgsProduct(bitWidthsNumValues64);
 
 #if defined(ARROW_HAVE_RUNTIME_AVX2)

--- a/cpp/src/arrow/util/bpacking_benchmark.cc
+++ b/cpp/src/arrow/util/bpacking_benchmark.cc
@@ -104,7 +104,7 @@ constexpr int32_t kMinRange = 64;
 constexpr int32_t kMaxRange = 32768;
 constexpr std::initializer_list<int64_t> kBitWidths32 = {1, 2, 8, 20};
 constexpr std::initializer_list<int64_t> kBitWidths64 = {1, 2, 8, 20, 47};
-static const std::vector<std::vector<int64_t>> bitWidthsNumValues32 = {
+static const std::vector<std::vector<int64_t>> kBitWidthsNumValues32 = {
     kBitWidths32,
     benchmark::CreateRange(kMinRange, kMaxRange, /*multi=*/32),
 };
@@ -124,38 +124,38 @@ void BM_UnpackUint64(benchmark::State& state, bool aligned, UnpackFunc<uint64_t>
   return BM_Unpack<uint64_t>(state, aligned, unpack, skip, std::move(skip_msg));
 }
 
-BENCHMARK_CAPTURE(BM_UnpackUint32, unpack32_default_unaligned, false, unpack32_default)
-    ->ArgsProduct(bitWidthsNumValues32);
-BENCHMARK_CAPTURE(BM_UnpackUint64, unpack64_default_unaligned, false, unpack64_default)
+BENCHMARK_CAPTURE(BM_UnpackUint32, ScalarUnaligned, false, unpack32_default)
+    ->ArgsProduct(kBitWidthsNumValues32);
+BENCHMARK_CAPTURE(BM_UnpackUint64, ScalarUnaligned, false, unpack64_default)
     ->ArgsProduct(bitWidthsNumValues64);
 
 #if defined(ARROW_HAVE_RUNTIME_AVX2)
-BENCHMARK_CAPTURE(BM_UnpackUint32, unpack32_avx2_unaligned, false, unpack32_avx2,
+BENCHMARK_CAPTURE(BM_UnpackUint32, Avx2Unaligned, false, unpack32_avx2,
                   !CpuInfo::GetInstance()->IsSupported(CpuInfo::AVX2),
                   "Avx2 not available")
     ->ArgsProduct(bitWidthsNumValues32);
 #endif
 
 #if defined(ARROW_HAVE_RUNTIME_AVX512)
-BENCHMARK_CAPTURE(BM_UnpackUint32, unpack32_avx512_unaligned, false, unpack32_avx512,
+BENCHMARK_CAPTURE(BM_UnpackUint32, Avx512Unaligned, false, unpack32_avx512,
                   !CpuInfo::GetInstance()->IsSupported(CpuInfo::AVX512),
                   "Avx512 not available")
     ->ArgsProduct(bitWidthsNumValues32);
 #endif
 
 #if defined(ARROW_HAVE_NEON)
-BENCHMARK_CAPTURE(BM_UnpackUint32, unpack32_neon_unaligned, false, unpack32_neon)
-    ->ArgsProduct(bitWidthsNumValues32);
+BENCHMARK_CAPTURE(BM_UnpackUint32, NeonUnaligned, false, unpack32_neon)
+    ->ArgsProduct(kBitWidthsNumValues32);
 #endif
 
-BENCHMARK_CAPTURE(BM_UnpackUint32, unpack32_aligned, true, unpack32)
-    ->ArgsProduct(bitWidthsNumValues32);
-BENCHMARK_CAPTURE(BM_UnpackUint32, unpack32_unaligned, false, unpack32)
-    ->ArgsProduct(bitWidthsNumValues32);
+BENCHMARK_CAPTURE(BM_UnpackUint32, DynamicAligned, true, unpack32)
+    ->ArgsProduct(kBitWidthsNumValues32);
+BENCHMARK_CAPTURE(BM_UnpackUint32, DynamicUnaligned, false, unpack32)
+    ->ArgsProduct(kBitWidthsNumValues32);
 
-BENCHMARK_CAPTURE(BM_UnpackUint64, unpack64_aligned, true, unpack64)
+BENCHMARK_CAPTURE(BM_UnpackUint64, DynamicAligned, true, unpack64)
     ->ArgsProduct(bitWidthsNumValues64);
-BENCHMARK_CAPTURE(BM_UnpackUint64, unpack64_unaligned, false, unpack64)
+BENCHMARK_CAPTURE(BM_UnpackUint64, DynamicUnaligned, false, unpack64)
     ->ArgsProduct(bitWidthsNumValues64);
 
 }  // namespace

--- a/cpp/src/arrow/util/bpacking_benchmark.cc
+++ b/cpp/src/arrow/util/bpacking_benchmark.cc
@@ -1,0 +1,140 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <stdexcept>
+#include <vector>
+
+#include <benchmark/benchmark.h>
+
+#include "arrow/testing/util.h"
+#include "arrow/util/bpacking_internal.h"
+
+#if defined(ARROW_HAVE_RUNTIME_AVX2)
+#  include "arrow/util/bpacking_avx2_internal.h"
+#endif
+#if defined(ARROW_HAVE_RUNTIME_AVX512)
+#  include "arrow/util/bpacking_avx512_internal.h"
+#endif
+#if defined(ARROW_HAVE_NEON)
+#  include "arrow/util/bpacking_neon_internal.h"
+#endif
+
+namespace arrow::internal {
+namespace {
+
+template <typename Int>
+using UnpackFunc = int (*)(const uint8_t*, Int*, int, int);
+
+/// Get the number of bytes associate with a packing.
+constexpr int32_t getNumBytes(int32_t num_values, int32_t bit_width) {
+  auto const num_bits = num_values * bit_width;
+  if (num_bits % 8 != 0) {
+    throw std::invalid_argument("Must pack a multiple of 8 bits.");
+  }
+  return num_bits / 8;
+}
+
+/// Generate random bytes as packed integers.
+std::vector<uint8_t> generateRandomPackedValues(int32_t num_values, int32_t bit_width) {
+  constexpr uint32_t kSeed = 3214;
+  auto const num_bytes = getNumBytes(num_values, bit_width);
+
+  std::vector<uint8_t> out(num_bytes);
+  random_bytes(num_bytes, kSeed, out.data());
+
+  return out;
+}
+
+const uint8_t* getNextAlignedByte(const uint8_t* ptr, std::size_t alignment) {
+  auto addr = reinterpret_cast<std::uintptr_t>(ptr);
+
+  if (addr % alignment == 0) {
+    return ptr;
+  }
+
+  auto remainder = addr % alignment;
+  auto bytes_to_add = alignment - remainder;
+
+  return ptr + bytes_to_add;
+}
+
+template <typename Int>
+void BM_Unpack(benchmark::State& state, bool aligned, UnpackFunc<Int> unpack) {
+  auto const bit_width = static_cast<int32_t>(state.range(0));
+  auto const num_values = static_cast<int32_t>(state.range(1));
+  constexpr int32_t kExtraValues = sizeof(Int) * 8;
+
+  auto const packed = generateRandomPackedValues(num_values + kExtraValues, bit_width);
+  const uint8_t* packed_ptr =
+      getNextAlignedByte(packed.data(), sizeof(Int)) + (aligned ? 0 : 1);
+
+  std::vector<Int> unpacked(num_values, 0);
+
+  for (auto _ : state) {
+    unpack(packed_ptr, unpacked.data(), num_values, bit_width);
+    benchmark::ClobberMemory();
+  }
+  state.SetItemsProcessed(num_values);
+}
+
+constexpr int32_t MIN_RANGE = 64;
+constexpr int32_t MAX_RANGE = 32768;
+constexpr std::initializer_list<int64_t> kBitWidths32 = {1, 8, 20};
+constexpr std::initializer_list<int64_t> kBitWidths64 = {1, 8, 20, 47};
+static const std::vector<std::vector<int64_t>> bitWidthsNumValues32 = {
+    kBitWidths32,
+    benchmark::CreateRange(MIN_RANGE, MAX_RANGE, /*multi=*/8),
+};
+static const std::vector<std::vector<int64_t>> bitWidthsNumValues64 = {
+    kBitWidths64,
+    benchmark::CreateRange(MIN_RANGE, MAX_RANGE, /*multi=*/8),
+};
+
+BENCHMARK_CAPTURE(BM_Unpack<uint32_t>, unpack32_default_unaligned, false,
+                  unpack32_default)
+    ->ArgsProduct(bitWidthsNumValues32);
+BENCHMARK_CAPTURE(BM_Unpack<uint64_t>, unpack64_default_unaligned, false,
+                  unpack64_default)
+    ->ArgsProduct(bitWidthsNumValues64);
+
+#if defined(ARROW_HAVE_RUNTIME_AVX2)
+BENCHMARK_CAPTURE(BM_Unpack<uint32_t>, unpack32_avx2_unaligned, false, unpack32_avx2)
+    ->ArgsProduct(bitWidthsNumValues32);
+#endif
+
+#if defined(ARROW_HAVE_RUNTIME_AVX512)
+BENCHMARK_CAPTURE(BM_Unpack<uint32_t>, unpack32_avx512_unaligned, false, unpack32_avx512)
+    ->ArgsProduct(bitWidthsNumValues32);
+#endif
+
+#if defined(ARROW_HAVE_NEON)
+BENCHMARK_CAPTURE(BM_Unpack<uint32_t>, unpack32_neon_unaligned, false, unpack32_neon)
+    ->ArgsProduct(bitWidthsNumValues32);
+#endif
+
+BENCHMARK_CAPTURE(BM_Unpack<uint32_t>, unpack32_aligned, true, unpack32)
+    ->ArgsProduct(bitWidthsNumValues32);
+BENCHMARK_CAPTURE(BM_Unpack<uint32_t>, unpack32_unaligned, false, unpack32)
+    ->ArgsProduct(bitWidthsNumValues32);
+
+BENCHMARK_CAPTURE(BM_Unpack<uint64_t>, unpack64_aligned, true, unpack64)
+    ->ArgsProduct(bitWidthsNumValues64);
+BENCHMARK_CAPTURE(BM_Unpack<uint64_t>, unpack64_unaligned, false, unpack64)
+    ->ArgsProduct(bitWidthsNumValues64);
+
+}  // namespace
+}  // namespace arrow::internal

--- a/cpp/src/arrow/util/bpacking_benchmark.cc
+++ b/cpp/src/arrow/util/bpacking_benchmark.cc
@@ -104,36 +104,43 @@ static const std::vector<std::vector<int64_t>> bitWidthsNumValues64 = {
     benchmark::CreateRange(MIN_RANGE, MAX_RANGE, /*multi=*/8),
 };
 
-BENCHMARK_CAPTURE(BM_Unpack<uint32_t>, unpack32_default_unaligned, false,
-                  unpack32_default)
+/// Nudge for MSVC template inside BENCHMARK_CAPTURE macro.
+void BM_UnpackUint32(benchmark::State& state, bool aligned, UnpackFunc<uint32_t> unpack) {
+  return BM_Unpack<uint32_t>(state, aligned, unpack);
+}
+/// Nudge for MSVC template inside BENCHMARK_CAPTURE macro.
+void BM_UnpackUint64(benchmark::State& state, bool aligned, UnpackFunc<uint64_t> unpack) {
+  return BM_Unpack<uint64_t>(state, aligned, unpack);
+}
+
+BENCHMARK_CAPTURE(BM_UnpackUint32, unpack32_default_unaligned, false, unpack32_default)
     ->ArgsProduct(bitWidthsNumValues32);
-BENCHMARK_CAPTURE(BM_Unpack<uint64_t>, unpack64_default_unaligned, false,
-                  unpack64_default)
+BENCHMARK_CAPTURE(BM_UnpackUint64, unpack64_default_unaligned, false, unpack64_default)
     ->ArgsProduct(bitWidthsNumValues64);
 
 #if defined(ARROW_HAVE_AVX2)
-BENCHMARK_CAPTURE(BM_Unpack<uint32_t>, unpack32_avx2_unaligned, false, unpack32_avx2)
+BENCHMARK_CAPTURE(BM_UnpackUint32, unpack32_avx2_unaligned, false, unpack32_avx2)
     ->ArgsProduct(bitWidthsNumValues32);
 #endif
 
 #if defined(ARROW_HAVE_AVX512)
-BENCHMARK_CAPTURE(BM_Unpack<uint32_t>, unpack32_avx512_unaligned, false, unpack32_avx512)
+BENCHMARK_CAPTURE(BM_UnpackUint32, unpack32_avx512_unaligned, false, unpack32_avx512)
     ->ArgsProduct(bitWidthsNumValues32);
 #endif
 
 #if defined(ARROW_HAVE_NEON)
-BENCHMARK_CAPTURE(BM_Unpack<uint32_t>, unpack32_neon_unaligned, false, unpack32_neon)
+BENCHMARK_CAPTURE(BM_UnpackUint32, unpack32_neon_unaligned, false, unpack32_neon)
     ->ArgsProduct(bitWidthsNumValues32);
 #endif
 
-BENCHMARK_CAPTURE(BM_Unpack<uint32_t>, unpack32_aligned, true, unpack32)
+BENCHMARK_CAPTURE(BM_UnpackUint32, unpack32_aligned, true, unpack32)
     ->ArgsProduct(bitWidthsNumValues32);
-BENCHMARK_CAPTURE(BM_Unpack<uint32_t>, unpack32_unaligned, false, unpack32)
+BENCHMARK_CAPTURE(BM_UnpackUint32, unpack32_unaligned, false, unpack32)
     ->ArgsProduct(bitWidthsNumValues32);
 
-BENCHMARK_CAPTURE(BM_Unpack<uint64_t>, unpack64_aligned, true, unpack64)
+BENCHMARK_CAPTURE(BM_UnpackUint64, unpack64_aligned, true, unpack64)
     ->ArgsProduct(bitWidthsNumValues64);
-BENCHMARK_CAPTURE(BM_Unpack<uint64_t>, unpack64_unaligned, false, unpack64)
+BENCHMARK_CAPTURE(BM_UnpackUint64, unpack64_unaligned, false, unpack64)
     ->ArgsProduct(bitWidthsNumValues64);
 
 }  // namespace

--- a/cpp/src/arrow/util/bpacking_benchmark.cc
+++ b/cpp/src/arrow/util/bpacking_benchmark.cc
@@ -42,7 +42,7 @@ using UnpackFunc = int (*)(const uint8_t*, Int*, int, int);
 
 /// Get the number of bytes associate with a packing.
 constexpr int32_t GetNumBytes(int32_t num_values, int32_t bit_width) {
-  auto const num_bits = num_values * bit_width;
+  const auto num_bits = num_values * bit_width;
   if (num_bits % 8 != 0) {
     throw std::invalid_argument("Must pack a multiple of 8 bits.");
   }
@@ -52,7 +52,7 @@ constexpr int32_t GetNumBytes(int32_t num_values, int32_t bit_width) {
 /// Generate random bytes as packed integers.
 std::vector<uint8_t> GenerateRandomPackedValues(int32_t num_values, int32_t bit_width) {
   constexpr uint32_t kSeed = 3214;
-  auto const num_bytes = GetNumBytes(num_values, bit_width);
+  const auto num_bytes = GetNumBytes(num_values, bit_width);
 
   std::vector<uint8_t> out(num_bytes);
   random_bytes(num_bytes, kSeed, out.data());
@@ -80,14 +80,14 @@ void BM_Unpack(benchmark::State& state, bool aligned, UnpackFunc<Int> unpack, bo
     state.SkipWithMessage(skip_msg);
   }
 
-  auto const bit_width = static_cast<int32_t>(state.range(0));
-  auto const num_values = static_cast<int32_t>(state.range(1));
+  const auto bit_width = static_cast<int32_t>(state.range(0));
+  const auto num_values = static_cast<int32_t>(state.range(1));
 
   // Assume std::vector allocation is likely be aligned for greater than a byte.
   // So we allocate more values than necessary and skip to the next byte with the
   // desired (non) alignment to test the proper condition.
   constexpr int32_t kExtraValues = sizeof(Int) * 8;
-  auto const packed = GenerateRandomPackedValues(num_values + kExtraValues, bit_width);
+  const auto packed = GenerateRandomPackedValues(num_values + kExtraValues, bit_width);
   const uint8_t* packed_ptr =
       GetNextAlignedByte(packed.data(), sizeof(Int)) + (aligned ? 0 : 1);
 

--- a/cpp/src/arrow/util/bpacking_benchmark.cc
+++ b/cpp/src/arrow/util/bpacking_benchmark.cc
@@ -23,10 +23,10 @@
 #include "arrow/testing/util.h"
 #include "arrow/util/bpacking_internal.h"
 
-#if defined(ARROW_HAVE_RUNTIME_AVX2)
+#if defined(ARROW_HAVE_AVX2)
 #  include "arrow/util/bpacking_avx2_internal.h"
 #endif
-#if defined(ARROW_HAVE_RUNTIME_AVX512)
+#if defined(ARROW_HAVE_AVX512)
 #  include "arrow/util/bpacking_avx512_internal.h"
 #endif
 #if defined(ARROW_HAVE_NEON)
@@ -111,12 +111,12 @@ BENCHMARK_CAPTURE(BM_Unpack<uint64_t>, unpack64_default_unaligned, false,
                   unpack64_default)
     ->ArgsProduct(bitWidthsNumValues64);
 
-#if defined(ARROW_HAVE_RUNTIME_AVX2)
+#if defined(ARROW_HAVE_AVX2)
 BENCHMARK_CAPTURE(BM_Unpack<uint32_t>, unpack32_avx2_unaligned, false, unpack32_avx2)
     ->ArgsProduct(bitWidthsNumValues32);
 #endif
 
-#if defined(ARROW_HAVE_RUNTIME_AVX512)
+#if defined(ARROW_HAVE_AVX512)
 BENCHMARK_CAPTURE(BM_Unpack<uint32_t>, unpack32_avx512_unaligned, false, unpack32_avx512)
     ->ArgsProduct(bitWidthsNumValues32);
 #endif

--- a/cpp/src/arrow/util/bpacking_benchmark.cc
+++ b/cpp/src/arrow/util/bpacking_benchmark.cc
@@ -108,7 +108,7 @@ static const std::vector<std::vector<int64_t>> kBitWidthsNumValues32 = {
     kBitWidths32,
     benchmark::CreateRange(kMinRange, kMaxRange, /*multi=*/32),
 };
-static const std::vector<std::vector<int64_t>> bitWidthsNumValues64 = {
+static const std::vector<std::vector<int64_t>> kBitWidthsNumValues64 = {
     kBitWidths64,
     benchmark::CreateRange(kMinRange, kMaxRange, /*multi=*/32),
 };
@@ -127,20 +127,20 @@ void BM_UnpackUint64(benchmark::State& state, bool aligned, UnpackFunc<uint64_t>
 BENCHMARK_CAPTURE(BM_UnpackUint32, ScalarUnaligned, false, unpack32_scalar)
     ->ArgsProduct(kBitWidthsNumValues32);
 BENCHMARK_CAPTURE(BM_UnpackUint64, ScalarUnaligned, false, unpack64_scalar)
-    ->ArgsProduct(bitWidthsNumValues64);
+    ->ArgsProduct(kBitWidthsNumValues64);
 
 #if defined(ARROW_HAVE_RUNTIME_AVX2)
 BENCHMARK_CAPTURE(BM_UnpackUint32, Avx2Unaligned, false, unpack32_avx2,
                   !CpuInfo::GetInstance()->IsSupported(CpuInfo::AVX2),
                   "Avx2 not available")
-    ->ArgsProduct(bitWidthsNumValues32);
+    ->ArgsProduct(kBitWidthsNumValues32);
 #endif
 
 #if defined(ARROW_HAVE_RUNTIME_AVX512)
 BENCHMARK_CAPTURE(BM_UnpackUint32, Avx512Unaligned, false, unpack32_avx512,
                   !CpuInfo::GetInstance()->IsSupported(CpuInfo::AVX512),
                   "Avx512 not available")
-    ->ArgsProduct(bitWidthsNumValues32);
+    ->ArgsProduct(kBitWidthsNumValues32);
 #endif
 
 #if defined(ARROW_HAVE_NEON)
@@ -154,9 +154,9 @@ BENCHMARK_CAPTURE(BM_UnpackUint32, DynamicUnaligned, false, unpack32)
     ->ArgsProduct(kBitWidthsNumValues32);
 
 BENCHMARK_CAPTURE(BM_UnpackUint64, DynamicAligned, true, unpack64)
-    ->ArgsProduct(bitWidthsNumValues64);
+    ->ArgsProduct(kBitWidthsNumValues64);
 BENCHMARK_CAPTURE(BM_UnpackUint64, DynamicUnaligned, false, unpack64)
-    ->ArgsProduct(bitWidthsNumValues64);
+    ->ArgsProduct(kBitWidthsNumValues64);
 
 }  // namespace
 }  // namespace arrow::internal

--- a/cpp/src/arrow/util/bpacking_internal.h
+++ b/cpp/src/arrow/util/bpacking_internal.h
@@ -24,13 +24,13 @@
 namespace arrow::internal {
 
 /// The scalar 32 bit unpacking.
-int unpack32_default(const uint32_t* in, uint32_t* out, int batch_size, int num_bits);
+int unpack32_default(const uint8_t* in, uint32_t* out, int batch_size, int num_bits);
 
 /// The scalar 64 bit unpacking.
 int unpack64_default(const uint8_t* in, uint64_t* out, int batch_size, int num_bits);
 
 ARROW_EXPORT
-int unpack32(const uint32_t* in, uint32_t* out, int batch_size, int num_bits);
+int unpack32(const uint8_t* in, uint32_t* out, int batch_size, int num_bits);
 ARROW_EXPORT
 int unpack64(const uint8_t* in, uint64_t* out, int batch_size, int num_bits);
 

--- a/cpp/src/arrow/util/bpacking_internal.h
+++ b/cpp/src/arrow/util/bpacking_internal.h
@@ -24,12 +24,12 @@
 namespace arrow::internal {
 
 /// The scalar 32 bit unpacking.
-ARROW_EXPORT int unpack32_default(const uint8_t* in, uint32_t* out, int batch_size,
-                                  int num_bits);
+ARROW_EXPORT int unpack32_scalar(const uint8_t* in, uint32_t* out, int batch_size,
+                                 int num_bits);
 
 /// The scalar 64 bit unpacking.
-ARROW_EXPORT int unpack64_default(const uint8_t* in, uint64_t* out, int batch_size,
-                                  int num_bits);
+ARROW_EXPORT int unpack64_scalar(const uint8_t* in, uint64_t* out, int batch_size,
+                                 int num_bits);
 
 ARROW_EXPORT
 int unpack32(const uint8_t* in, uint32_t* out, int batch_size, int num_bits);

--- a/cpp/src/arrow/util/bpacking_internal.h
+++ b/cpp/src/arrow/util/bpacking_internal.h
@@ -24,10 +24,12 @@
 namespace arrow::internal {
 
 /// The scalar 32 bit unpacking.
-int unpack32_default(const uint8_t* in, uint32_t* out, int batch_size, int num_bits);
+ARROW_EXPORT int unpack32_default(const uint8_t* in, uint32_t* out, int batch_size,
+                                  int num_bits);
 
 /// The scalar 64 bit unpacking.
-int unpack64_default(const uint8_t* in, uint64_t* out, int batch_size, int num_bits);
+ARROW_EXPORT int unpack64_default(const uint8_t* in, uint64_t* out, int batch_size,
+                                  int num_bits);
 
 ARROW_EXPORT
 int unpack32(const uint8_t* in, uint32_t* out, int batch_size, int num_bits);

--- a/cpp/src/arrow/util/bpacking_internal.h
+++ b/cpp/src/arrow/util/bpacking_internal.h
@@ -17,18 +17,21 @@
 
 #pragma once
 
-#include "arrow/util/endian.h"
 #include "arrow/util/visibility.h"
 
-#include <stdint.h>
+#include <cstdint>
 
-namespace arrow {
-namespace internal {
+namespace arrow::internal {
+
+/// The scalar 32 bit unpacking.
+int unpack32_default(const uint32_t* in, uint32_t* out, int batch_size, int num_bits);
+
+/// The scalar 64 bit unpacking.
+int unpack64_default(const uint8_t* in, uint64_t* out, int batch_size, int num_bits);
 
 ARROW_EXPORT
 int unpack32(const uint32_t* in, uint32_t* out, int batch_size, int num_bits);
 ARROW_EXPORT
 int unpack64(const uint8_t* in, uint64_t* out, int batch_size, int num_bits);
 
-}  // namespace internal
-}  // namespace arrow
+}  // namespace arrow::internal

--- a/cpp/src/arrow/util/bpacking_neon.cc
+++ b/cpp/src/arrow/util/bpacking_neon.cc
@@ -19,13 +19,11 @@
 #include "arrow/util/bpacking_simd128_generated_internal.h"
 #include "arrow/util/bpacking_simd_internal.h"
 
-namespace arrow {
-namespace internal {
+namespace arrow::internal {
 
-int unpack32_neon(const uint32_t* in, uint32_t* out, int batch_size, int num_bits) {
-  return unpack32_specialized<UnpackBits128<DispatchLevel::NEON>>(in, out, batch_size,
-                                                                  num_bits);
+int unpack32_neon(const uint8_t* in, uint32_t* out, int batch_size, int num_bits) {
+  return unpack32_specialized<UnpackBits128<DispatchLevel::NEON>>(
+      reinterpret_cast<const uint32_t*>(in), out, batch_size, num_bits);
 }
 
-}  // namespace internal
-}  // namespace arrow
+}  // namespace arrow::internal

--- a/cpp/src/arrow/util/bpacking_neon_internal.h
+++ b/cpp/src/arrow/util/bpacking_neon_internal.h
@@ -17,12 +17,10 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
-namespace arrow {
-namespace internal {
+namespace arrow::internal {
 
-int unpack32_neon(const uint32_t* in, uint32_t* out, int batch_size, int num_bits);
+int unpack32_neon(const uint8_t* in, uint32_t* out, int batch_size, int num_bits);
 
-}  // namespace internal
-}  // namespace arrow
+}  // namespace arrow::internal

--- a/cpp/src/arrow/util/bpacking_neon_internal.h
+++ b/cpp/src/arrow/util/bpacking_neon_internal.h
@@ -17,10 +17,13 @@
 
 #pragma once
 
+#include "arrow/util/visibility.h"
+
 #include <cstdint>
 
 namespace arrow::internal {
 
-int unpack32_neon(const uint8_t* in, uint32_t* out, int batch_size, int num_bits);
+ARROW_EXPORT int unpack32_neon(const uint8_t* in, uint32_t* out, int batch_size,
+                               int num_bits);
 
 }  // namespace arrow::internal

--- a/cpp/src/arrow/util/bpacking_test.cc
+++ b/cpp/src/arrow/util/bpacking_test.cc
@@ -221,8 +221,8 @@ INSTANTIATE_TEST_SUITE_P(
                       TestUnpackSize{2048, 16}, TestUnpackSize{2048, 31},
                       TestUnpackSize{2048, 32}));
 
-TEST_P(TestUnpack, unpack32Default) { this->TestAll(&unpack32_default); }
-TEST_P(TestUnpack, unpack64Default) { this->TestAll(&unpack64_default); }
+TEST_P(TestUnpack, unpack32Default) { this->TestAll(&unpack32_scalar); }
+TEST_P(TestUnpack, unpack64Default) { this->TestAll(&unpack64_scalar); }
 
 #if defined(ARROW_HAVE_RUNTIME_AVX2)
 TEST_P(TestUnpack, unpack32Avx2) {

--- a/cpp/src/arrow/util/bpacking_test.cc
+++ b/cpp/src/arrow/util/bpacking_test.cc
@@ -25,10 +25,10 @@
 #include "arrow/util/bpacking_internal.h"
 #include "arrow/util/logging.h"
 
-#if defined(ARROW_HAVE_RUNTIME_AVX2)
+#if defined(ARROW_HAVE_AVX2)
 #  include "arrow/util/bpacking_avx2_internal.h"
 #endif
-#if defined(ARROW_HAVE_RUNTIME_AVX512)
+#if defined(ARROW_HAVE_AVX512)
 #  include "arrow/util/bpacking_avx512_internal.h"
 #endif
 #if defined(ARROW_HAVE_NEON)
@@ -160,11 +160,11 @@ TEST_P(UnpackingRandomRoundTrip, unpack64Default) {
   this->testRoundtrip(&unpack64_default);
 }
 
-#if defined(ARROW_HAVE_RUNTIME_AVX2)
+#if defined(ARROW_HAVE_AVX2)
 TEST_P(UnpackingRandomRoundTrip, unpack32Avx2) { this->testRoundtrip(&unpack32_avx2); }
 #endif
 
-#if defined(ARROW_HAVE_RUNTIME_AVX512)
+#if defined(ARROW_HAVE_AVX512)
 TEST_P(UnpackingRandomRoundTrip, unpack32Avx512) {
   this->testRoundtrip(&unpack32_avx512);
 }

--- a/cpp/src/arrow/util/bpacking_test.cc
+++ b/cpp/src/arrow/util/bpacking_test.cc
@@ -1,0 +1,141 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <stdexcept>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include "arrow/testing/util.h"
+#include "arrow/util/bit_stream_utils_internal.h"
+#include "arrow/util/bpacking_internal.h"
+#include "arrow/util/bpacking_neon_internal.h"
+#include "arrow/util/logging.h"
+
+namespace arrow::internal {
+
+template <typename Int>
+using UnpackFunc = int (*)(const uint8_t*, Int*, int, int);
+
+/// Generate random bytes as packed integers.
+std::vector<uint8_t> generateRandomPackedValues(int32_t num_values, int32_t bit_width) {
+  constexpr uint32_t kSeed = 3214;
+
+  auto const num_bits = num_values * bit_width;
+  if (num_bits % 8 != 0) {
+    throw std::invalid_argument("Must generate a multiple of 8 bits.");
+  }
+  auto const num_bytes = num_bits / 8;
+
+  std::vector<uint8_t> out(num_bytes);
+  random_bytes(num_bytes, kSeed, out.data());
+
+  return out;
+}
+
+/// Convenience wrapper to unpack into a vector
+template <typename Int>
+std::vector<Int> unpackValues(std::vector<uint8_t> const& packed, int32_t num_values,
+                              int32_t bit_width, UnpackFunc<Int> unpack) {
+  std::vector<Int> out(num_values);
+  int values_read = unpack(packed.data(), out.data(), num_values, bit_width);
+  ARROW_DCHECK_GE(values_read, 0);
+  out.resize(values_read);
+  return out;
+}
+
+/// Use BitWriter to pack values into a vector.
+template <typename Int>
+std::vector<uint8_t> packValues(std::vector<Int> const& values, int32_t num_values,
+                                int32_t bit_width) {
+  auto const num_bits = num_values * bit_width;
+  if (num_bits % 8 != 0) {
+    throw std::invalid_argument("Must generate a multiple of 8 bits.");
+  }
+  auto const num_bytes = num_bits / 8;
+
+  std::vector<uint8_t> out(static_cast<std::size_t>(num_bytes));
+  bit_util::BitWriter writer(out.data(), num_bytes);
+  for (auto const& v : values) {
+    bool written = writer.PutValue(v, bit_width);
+    if (!written) {
+      throw std::runtime_error("Cannot write move values");
+    }
+  }
+
+  return out;
+}
+
+template <typename Int>
+void checkUnpackPackRoundtrip(std::vector<uint8_t> const& packed, int32_t num_values,
+                              int32_t bit_width, UnpackFunc<Int> unpack) {
+  auto const unpacked = unpackValues(packed, num_values, bit_width, unpack);
+  EXPECT_EQ(unpacked.size(), num_values);
+  auto const roundtrip = packValues(unpacked, num_values, bit_width);
+  EXPECT_EQ(packed.size(), roundtrip.size());
+  EXPECT_EQ(packed, roundtrip);
+}
+
+struct UnpackingData {
+  int32_t num_values;
+  int32_t bit_width;
+};
+
+class UnpackingRandomRoundTrip : public ::testing::TestWithParam<UnpackingData> {
+ protected:
+  template <typename Int>
+  void testRoundtrip(UnpackFunc<Int> unpack) {
+    auto [num_values, bit_width] = GetParam();
+    auto const original = generateRandomPackedValues(num_values, bit_width);
+    checkUnpackPackRoundtrip(original, num_values, bit_width, unpack);
+  }
+};
+
+INSTANTIATE_TEST_SUITE_P(
+    MutpliesOf64Values, UnpackingRandomRoundTrip,
+    ::testing::Values(UnpackingData{64, 1}, UnpackingData{128, 1}, UnpackingData{2048, 1},
+                      UnpackingData{64, 31}, UnpackingData{128, 31},
+                      UnpackingData{2048, 31}, UnpackingData{64000, 7},
+                      UnpackingData{64000, 8}, UnpackingData{64000, 13},
+                      UnpackingData{64000, 16}, UnpackingData{64000, 31},
+                      UnpackingData{64000, 32}));
+
+TEST_P(UnpackingRandomRoundTrip, unpack32Default) {
+  this->testRoundtrip(&unpack32_default);
+}
+TEST_P(UnpackingRandomRoundTrip, unpack64Default) {
+  this->testRoundtrip(&unpack64_default);
+}
+
+#if defined(ARROW_HAVE_RUNTIME_AVX2)
+TEST_P(UnpackingRandomRoundTrip, unpack32Avx2) { this->testRoundtrip(&unpack32_avx2); }
+#endif
+
+#if defined(ARROW_HAVE_RUNTIME_AVX512)
+TEST_P(UnpackingRandomRoundTrip, unpack32Avx512) {
+  this->testRoundtrip(&unpack32_avx512);
+}
+#endif
+
+#if defined(ARROW_HAVE_NEON)
+TEST_P(UnpackingRandomRoundTrip, unpack32Neon) { this->testRoundtrip(&unpack32_neon); }
+#endif
+
+TEST_P(UnpackingRandomRoundTrip, unpack32) { this->testRoundtrip(&unpack32); }
+TEST_P(UnpackingRandomRoundTrip, unpack64) { this->testRoundtrip(&unpack64); }
+
+}  // namespace arrow::internal

--- a/cpp/src/arrow/util/bpacking_test.cc
+++ b/cpp/src/arrow/util/bpacking_test.cc
@@ -44,7 +44,7 @@ using UnpackFunc = int (*)(const uint8_t*, Int*, int, int);
 
 /// Get the number of bytes associate with a packing.
 Result<int32_t> GetNumBytes(int32_t num_values, int32_t bit_width) {
-  auto const num_bits = num_values * bit_width;
+  const auto num_bits = num_values * bit_width;
   if (num_bits % 8 != 0) {
     return Status::NotImplemented(
         "The unpack functions only work on a multiple of 8 bits.");
@@ -76,13 +76,13 @@ std::vector<Int> UnpackValues(const uint8_t* packed, int32_t num_values,
 
 /// Use BitWriter to pack values into a vector.
 template <typename Int>
-std::vector<uint8_t> PackValues(std::vector<Int> const& values, int32_t num_values,
+std::vector<uint8_t> PackValues(const std::vector<Int>& values, int32_t num_values,
                                 int32_t bit_width) {
   EXPECT_OK_AND_ASSIGN(const auto num_bytes, GetNumBytes(num_values, bit_width));
 
   std::vector<uint8_t> out(static_cast<std::size_t>(num_bytes));
   bit_util::BitWriter writer(out.data(), num_bytes);
-  for (auto const& v : values) {
+  for (const auto& v : values) {
     bool written = writer.PutValue(v, bit_width);
     if (!written) {
       throw std::runtime_error("Cannot write move values");
@@ -97,9 +97,9 @@ void CheckUnpackPackRoundtrip(const uint8_t* packed, int32_t num_values,
                               int32_t bit_width, UnpackFunc<Int> unpack) {
   EXPECT_OK_AND_ASSIGN(const auto num_bytes, GetNumBytes(num_values, bit_width));
 
-  auto const unpacked = UnpackValues(packed, num_values, bit_width, unpack);
+  const auto unpacked = UnpackValues(packed, num_values, bit_width, unpack);
   EXPECT_EQ(unpacked.size(), num_values);
-  auto const roundtrip = PackValues(unpacked, num_values, bit_width);
+  const auto roundtrip = PackValues(unpacked, num_values, bit_width);
   EXPECT_EQ(num_bytes, roundtrip.size());
   for (int i = 0; i < num_bytes; ++i) {
     EXPECT_EQ(packed[i], roundtrip[i]) << "differ in position " << i;

--- a/cpp/src/arrow/util/bpacking_test.cc
+++ b/cpp/src/arrow/util/bpacking_test.cc
@@ -221,11 +221,11 @@ INSTANTIATE_TEST_SUITE_P(
                       TestUnpackSize{2048, 16}, TestUnpackSize{2048, 31},
                       TestUnpackSize{2048, 32}));
 
-TEST_P(TestUnpack, unpack32Default) { this->TestAll(&unpack32_scalar); }
-TEST_P(TestUnpack, unpack64Default) { this->TestAll(&unpack64_scalar); }
+TEST_P(TestUnpack, Unpack32Scalar) { this->TestAll(&unpack32_scalar); }
+TEST_P(TestUnpack, Unpack64Scalar) { this->TestAll(&unpack64_scalar); }
 
 #if defined(ARROW_HAVE_RUNTIME_AVX2)
-TEST_P(TestUnpack, unpack32Avx2) {
+TEST_P(TestUnpack, Unpack32Avx2) {
   if (!CpuInfo::GetInstance()->IsSupported(CpuInfo::AVX2)) {
     GTEST_SKIP() << "Test requires AVX2";
   }
@@ -234,7 +234,7 @@ TEST_P(TestUnpack, unpack32Avx2) {
 #endif
 
 #if defined(ARROW_HAVE_RUNTIME_AVX512)
-TEST_P(TestUnpack, unpack32Avx512) {
+TEST_P(TestUnpack, Unpack32Avx512) {
   if (!CpuInfo::GetInstance()->IsSupported(CpuInfo::AVX512)) {
     GTEST_SKIP() << "Test requires AVX512";
   }
@@ -243,10 +243,10 @@ TEST_P(TestUnpack, unpack32Avx512) {
 #endif
 
 #if defined(ARROW_HAVE_NEON)
-TEST_P(TestUnpack, unpack32Neon) { this->TestAll(&unpack32_neon); }
+TEST_P(TestUnpack, Unpack32Neon) { this->TestAll(&unpack32_neon); }
 #endif
 
-TEST_P(TestUnpack, unpack32) { this->TestAll(&unpack32); }
-TEST_P(TestUnpack, unpack64) { this->TestAll(&unpack64); }
+TEST_P(TestUnpack, Unpack32) { this->TestAll(&unpack32); }
+TEST_P(TestUnpack, Unpack64) { this->TestAll(&unpack64); }
 
 }  // namespace arrow::internal

--- a/cpp/src/arrow/util/bpacking_test.cc
+++ b/cpp/src/arrow/util/bpacking_test.cc
@@ -25,10 +25,11 @@
 #include "arrow/util/bpacking_internal.h"
 #include "arrow/util/logging.h"
 
-#if defined(ARROW_HAVE_AVX2)
+#if defined(ARROW_HAVE_RUNTIME_AVX2)
 #  include "arrow/util/bpacking_avx2_internal.h"
+#  include "arrow/util/cpu_info.h"
 #endif
-#if defined(ARROW_HAVE_AVX512)
+#if defined(ARROW_HAVE_RUNTIME_AVX512)
 #  include "arrow/util/bpacking_avx512_internal.h"
 #endif
 #if defined(ARROW_HAVE_NEON)
@@ -41,7 +42,7 @@ template <typename Int>
 using UnpackFunc = int (*)(const uint8_t*, Int*, int, int);
 
 /// Get the number of bytes associate with a packing.
-constexpr int32_t getNumBytes(int32_t num_values, int32_t bit_width) {
+constexpr int32_t GetNumBytes(int32_t num_values, int32_t bit_width) {
   auto const num_bits = num_values * bit_width;
   if (num_bits % 8 != 0) {
     throw std::invalid_argument("Must pack a multiple of 8 bits.");
@@ -50,9 +51,9 @@ constexpr int32_t getNumBytes(int32_t num_values, int32_t bit_width) {
 }
 
 /// Generate random bytes as packed integers.
-std::vector<uint8_t> generateRandomPackedValues(int32_t num_values, int32_t bit_width) {
+std::vector<uint8_t> GenerateRandomPackedValues(int32_t num_values, int32_t bit_width) {
   constexpr uint32_t kSeed = 3214;
-  auto const num_bytes = getNumBytes(num_values, bit_width);
+  auto const num_bytes = GetNumBytes(num_values, bit_width);
 
   std::vector<uint8_t> out(num_bytes);
   random_bytes(num_bytes, kSeed, out.data());
@@ -62,7 +63,7 @@ std::vector<uint8_t> generateRandomPackedValues(int32_t num_values, int32_t bit_
 
 /// Convenience wrapper to unpack into a vector
 template <typename Int>
-std::vector<Int> unpackValues(const uint8_t* packed, int32_t num_values,
+std::vector<Int> UnpackValues(const uint8_t* packed, int32_t num_values,
                               int32_t bit_width, UnpackFunc<Int> unpack) {
   std::vector<Int> out(num_values);
   int values_read = unpack(packed, out.data(), num_values, bit_width);
@@ -73,9 +74,9 @@ std::vector<Int> unpackValues(const uint8_t* packed, int32_t num_values,
 
 /// Use BitWriter to pack values into a vector.
 template <typename Int>
-std::vector<uint8_t> packValues(std::vector<Int> const& values, int32_t num_values,
+std::vector<uint8_t> PackValues(std::vector<Int> const& values, int32_t num_values,
                                 int32_t bit_width) {
-  auto const num_bytes = getNumBytes(num_values, bit_width);
+  auto const num_bytes = GetNumBytes(num_values, bit_width);
 
   std::vector<uint8_t> out(static_cast<std::size_t>(num_bytes));
   bit_util::BitWriter writer(out.data(), num_bytes);
@@ -90,20 +91,20 @@ std::vector<uint8_t> packValues(std::vector<Int> const& values, int32_t num_valu
 }
 
 template <typename Int>
-void checkUnpackPackRoundtrip(const uint8_t* packed, int32_t num_values,
+void CheckUnpackPackRoundtrip(const uint8_t* packed, int32_t num_values,
                               int32_t bit_width, UnpackFunc<Int> unpack) {
-  auto const num_bytes = getNumBytes(num_values, bit_width);
+  auto const num_bytes = GetNumBytes(num_values, bit_width);
 
-  auto const unpacked = unpackValues(packed, num_values, bit_width, unpack);
+  auto const unpacked = UnpackValues(packed, num_values, bit_width, unpack);
   EXPECT_EQ(unpacked.size(), num_values);
-  auto const roundtrip = packValues(unpacked, num_values, bit_width);
+  auto const roundtrip = PackValues(unpacked, num_values, bit_width);
   EXPECT_EQ(num_bytes, roundtrip.size());
   for (int i = 0; i < num_bytes; ++i) {
     EXPECT_EQ(packed[i], roundtrip[i]) << "differ in position " << i;
   }
 }
 
-const uint8_t* getNextAlignedByte(const uint8_t* ptr, std::size_t alignment) {
+const uint8_t* GetNextAlignedByte(const uint8_t* ptr, std::size_t alignment) {
   auto addr = reinterpret_cast<std::uintptr_t>(ptr);
 
   if (addr % alignment == 0) {
@@ -124,23 +125,26 @@ struct UnpackingData {
 class UnpackingRandomRoundTrip : public ::testing::TestWithParam<UnpackingData> {
  protected:
   template <typename Int>
-  void testRoundtripAlignment(UnpackFunc<Int> unpack, std::size_t alignment_offset) {
+  void TestRoundtripAlignment(UnpackFunc<Int> unpack, std::size_t alignment_offset) {
     auto [num_values, bit_width] = GetParam();
+
+    // Assume std::vector allocation is likely be aligned for greater than a byte.
+    // So we allocate more values than necessary and skip to the next byte with the
+    // desired (non) alignment to test the proper condition.
     constexpr int32_t kExtraValues = sizeof(Int) * 8;
-
-    auto const packed = generateRandomPackedValues(num_values + kExtraValues, bit_width);
+    auto const packed = GenerateRandomPackedValues(num_values + kExtraValues, bit_width);
     const uint8_t* packed_unaligned =
-        getNextAlignedByte(packed.data(), sizeof(Int)) + alignment_offset;
+        GetNextAlignedByte(packed.data(), sizeof(Int)) + alignment_offset;
 
-    checkUnpackPackRoundtrip(packed_unaligned, num_values, bit_width, unpack);
+    CheckUnpackPackRoundtrip(packed_unaligned, num_values, bit_width, unpack);
   }
 
   template <typename Int>
-  void testRoundtrip(UnpackFunc<Int> unpack) {
+  void TestRoundtrip(UnpackFunc<Int> unpack) {
     // Aligned test
-    testRoundtripAlignment(unpack, 0);
+    TestRoundtripAlignment(unpack, 0);
     // Unaligned test
-    testRoundtripAlignment(unpack, 1);
+    TestRoundtripAlignment(unpack, 1);
   }
 };
 
@@ -154,27 +158,35 @@ INSTANTIATE_TEST_SUITE_P(
                       UnpackingData{64000, 32}));
 
 TEST_P(UnpackingRandomRoundTrip, unpack32Default) {
-  this->testRoundtrip(&unpack32_default);
+  this->TestRoundtrip(&unpack32_default);
 }
 TEST_P(UnpackingRandomRoundTrip, unpack64Default) {
-  this->testRoundtrip(&unpack64_default);
+  this->TestRoundtrip(&unpack64_default);
 }
 
-#if defined(ARROW_HAVE_AVX2)
-TEST_P(UnpackingRandomRoundTrip, unpack32Avx2) { this->testRoundtrip(&unpack32_avx2); }
+#if defined(ARROW_HAVE_RUNTIME_AVX2)
+TEST_P(UnpackingRandomRoundTrip, unpack32Avx2) {
+  if (!CpuInfo::GetInstance()->IsSupported(CpuInfo::AVX2)) {
+    GTEST_SKIP() << "Test requires AVX2";
+  }
+  this->testRoundtrip(&unpack32_avx2);
+}
 #endif
 
-#if defined(ARROW_HAVE_AVX512)
+#if defined(ARROW_HAVE_RUNTIME_AVX512)
 TEST_P(UnpackingRandomRoundTrip, unpack32Avx512) {
+  if (!CpuInfo::GetInstance()->IsSupported(CpuInfo::AVX512)) {
+    GTEST_SKIP() << "Test requires AVX512";
+  }
   this->testRoundtrip(&unpack32_avx512);
 }
 #endif
 
 #if defined(ARROW_HAVE_NEON)
-TEST_P(UnpackingRandomRoundTrip, unpack32Neon) { this->testRoundtrip(&unpack32_neon); }
+TEST_P(UnpackingRandomRoundTrip, unpack32Neon) { this->TestRoundtrip(&unpack32_neon); }
 #endif
 
-TEST_P(UnpackingRandomRoundTrip, unpack32) { this->testRoundtrip(&unpack32); }
-TEST_P(UnpackingRandomRoundTrip, unpack64) { this->testRoundtrip(&unpack64); }
+TEST_P(UnpackingRandomRoundTrip, unpack32) { this->TestRoundtrip(&unpack32); }
+TEST_P(UnpackingRandomRoundTrip, unpack64) { this->TestRoundtrip(&unpack64); }
 
 }  // namespace arrow::internal


### PR DESCRIPTION
### Rationale for this change
Tests and benchmarks make it easier to iterate and compare improvements.

### What changes are included in this PR?
- New tests
- New benchmarks
- !Uniform API between ``unpackDD_XXX`` functions for genericity in tests/benchmarks.
  Also results in safer API suggesting that the data may not be aligned.

### Are these changes tested?
Yes very much.

### Are there any user-facing changes?
No.

* GitHub Issue: #47514
* GitHub Issue: #39594