### PR TITLE
GH-46858: [C++] Change HalfFloatScalar::ValueType to Float16

### DIFF
--- a/cpp/src/arrow/compute/kernels/scalar_round.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_round.cc
@@ -69,7 +69,8 @@ struct IsPositiveVisitor {
 
   template <typename... Ts>
   Status Visit(const NumericScalar<Ts...>& scalar) {
-    result = scalar.value > 0;
+    using V = typename NumericScalar<Ts...>::ValueType;
+    result = scalar.value > static_cast<V>(0);
     return Status::OK();
   }
   template <typename... Ts>

--- a/cpp/src/arrow/dataset/file_json_test.cc
+++ b/cpp/src/arrow/dataset/file_json_test.cc
@@ -74,7 +74,11 @@ struct WriteVisitor {
   template <typename T>
   enable_if_physical_unsigned_integer<T, Status> Visit(const T*) {
     const auto& scalar = checked_cast<const NumericScalar<T>&>(scalar_);
-    return OK(writer_.Uint64(scalar.value));
+    if constexpr (is_half_float_type<T>::value) {
+      return OK(writer_.Uint64(scalar.value.bits()));
+    } else {
+      return OK(writer_.Uint64(scalar.value));
+    }
   }
 
   template <typename T>

--- a/cpp/src/arrow/engine/substrait/expression_internal.cc
+++ b/cpp/src/arrow/engine/substrait/expression_internal.cc
@@ -846,7 +846,7 @@ struct ScalarToProtoImpl {
   }
   Status Visit(const HalfFloatScalar& s) {
     google::protobuf::UInt32Value value;
-    value.set_value(s.value);
+    value.set_value(s.value.bits());
     return EncodeUserDefined(*s.type, value);
   }
   Status Visit(const FloatScalar& s) { return Primitive(&Lit::set_fp32, s); }

--- a/cpp/src/arrow/scalar.cc
+++ b/cpp/src/arrow/scalar.cc
@@ -64,8 +64,8 @@ namespace {
 struct ScalarHashImpl {
   Status Visit(const NullScalar& s) { return Status::OK(); }
 
-  template <typename T>
-  Status Visit(const internal::PrimitiveScalar<T>& s) {
+  template <typename... Ts>
+  Status Visit(const internal::PrimitiveScalar<Ts...>& s) {
     return ValueHash(s);
   }
 
@@ -258,8 +258,8 @@ struct ScalarValidateImpl {
     return Status::OK();
   }
 
-  template <typename T>
-  Status Visit(const internal::PrimitiveScalar<T>& s) {
+  template <typename... Ts>
+  Status Visit(const internal::PrimitiveScalar<Ts...>& s) {
     return Status::OK();
   }
 
@@ -1111,7 +1111,8 @@ enable_if_number<To, Result<std::shared_ptr<Scalar>>> CastImpl(
 template <typename To, typename From>
 enable_if_boolean<To, Result<std::shared_ptr<Scalar>>> CastImpl(
     const NumericScalar<From>& from, std::shared_ptr<DataType> to_type) {
-  constexpr auto zero = static_cast<typename From::c_type>(0);
+  using ValueType = typename NumericScalar<From>::ValueType;
+  const auto zero = static_cast<ValueType>(0);
   return std::make_shared<BooleanScalar>(from.value != zero, std::move(to_type));
 }
 

--- a/cpp/src/arrow/scalar_test.cc
+++ b/cpp/src/arrow/scalar_test.cc
@@ -225,11 +225,7 @@ TYPED_TEST(TestNumericScalar, Basics) {
   T value = static_cast<T>(1);
 
   auto scalar_val = std::make_shared<ScalarType>(value);
-  if constexpr (is_half_float_type<TypeParam>::value) {
-    ASSERT_EQ(value, Float16::FromBits(scalar_val->value));
-  } else {
-    ASSERT_EQ(value, scalar_val->value);
-  }
+  ASSERT_EQ(value, scalar_val->value);
   ASSERT_TRUE(scalar_val->is_valid);
   ASSERT_OK(scalar_val->ValidateFull());
 
@@ -240,13 +236,8 @@ TYPED_TEST(TestNumericScalar, Basics) {
   auto scalar_other = std::make_shared<ScalarType>(other_value);
   ASSERT_NE(*scalar_other, *scalar_val);
 
-  if constexpr (is_half_float_type<TypeParam>::value) {
-    scalar_val->value = other_value.bits();
-    ASSERT_EQ(other_value, Float16::FromBits(scalar_val->value));
-  } else {
-    scalar_val->value = other_value;
-    ASSERT_EQ(other_value, scalar_val->value);
-  }
+  scalar_val->value = other_value;
+  ASSERT_EQ(other_value, scalar_val->value);
   ASSERT_EQ(*scalar_other, *scalar_val);
 
   ScalarType stack_val;

--- a/cpp/src/arrow/util/float16.h
+++ b/cpp/src/arrow/util/float16.h
@@ -92,6 +92,10 @@ class ARROW_EXPORT Float16 {
 
   explicit operator float() const { return ToFloat(); }
   explicit operator double() const { return ToDouble(); }
+  template <typename T, typename std::enable_if_t<std::is_integral_v<T>>* = NULLPTR>
+  explicit operator T() const {
+    return static_cast<T>(ToFloat());
+  }
 
   /// \brief Copy the value's bytes in native-endian byte order
   void ToBytes(uint8_t* dest) const { std::memcpy(dest, &bits_, sizeof(bits_)); }
@@ -203,4 +207,11 @@ class std::numeric_limits<arrow::util::Float16> {
   static constexpr T infinity() { return T::FromBits(0b0111110000000000); }
 
   static constexpr T quiet_NaN() { return T::FromBits(0b0111111111111111); }
+};
+
+template <>
+struct std::hash<arrow::util::Float16> {
+  size_t operator()(const arrow::util::Float16& f) const noexcept {
+    return std::hash<uint16_t>{}(f.bits());
+  }
 };

--- a/cpp/src/arrow/util/formatting.h
+++ b/cpp/src/arrow/util/formatting.h
@@ -32,6 +32,7 @@
 #include "arrow/status.h"
 #include "arrow/type_fwd.h"
 #include "arrow/type_traits.h"
+#include "arrow/util/float16.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/string.h"
 #include "arrow/util/time.h"
@@ -319,6 +320,16 @@ template <>
 class StringFormatter<HalfFloatType> : public FloatToStringFormatterMixin<HalfFloatType> {
  public:
   using FloatToStringFormatterMixin::FloatToStringFormatterMixin;
+
+  template <typename T, typename Appender>
+  Return<Appender> operator()(T value, Appender&& append) {
+    auto&& base = static_cast<FloatToStringFormatterMixin&>(*this);
+    return base(bits(value), std::forward<Appender&&>(append));
+  }
+
+ private:
+  static constexpr value_type bits(value_type v) { return v; }
+  static constexpr value_type bits(util::Float16 v) { return v.bits(); }
 };
 
 template <>


### PR DESCRIPTION
### Rationale for this change

This should reduce friction when working with half-float scalars since `util::Float16`, unlike `uint16_t`, mimics the behavior of a native floating point type.

### What changes are included in this PR?

Changes the type of `HalfFloatScalar::value` to `util::Float16`. Miscellaneous adjustments are made elsewhere as needed.

### Are these changes tested?

Yes

### Are there any user-facing changes?

Yes, the changes to `HalfFloatScalar` are breaking.

* GitHub Issue: #46858