### PR TITLE
GH-45722: [C++] Add UnsafeAppend methods to StructBuilder

### DIFF
--- a/cpp/src/arrow/array/array_struct_test.cc
+++ b/cpp/src/arrow/array/array_struct_test.cc
@@ -751,7 +751,7 @@ TEST(TestFieldRef, GetChildren) {
 TEST(TestStructBuilderUnsafe, UnsafeAppend) {
   auto int_type = int32();
   auto str_type = utf8();
-  auto struct_type = struct_({field("a", int_type), field("b", str_type)});
+  auto struct_type = struct_({field("int", int_type), field("str", str_type)});
   auto pool = default_memory_pool();
   std::shared_ptr<Array> final_array;
   auto int_builder = std::make_shared<Int32Builder>(pool);
@@ -768,13 +768,13 @@ TEST(TestStructBuilderUnsafe, UnsafeAppend) {
   ASSERT_OK(int_builder->Append(2));
   ASSERT_OK(str_builder->Append("arrow"));
 
-  ASSERT_OK(builder.Finish(&final_array));
+  ASSERT_OK_AND_ASSIGN(auto final_array, builder.Finish());
   ASSERT_EQ(2, final_array->length());
   ASSERT_EQ(0, final_array->null_count());
-  auto expected_json = R"([{"a": 1, "b": "hello"}, {"a": 2, "b": "arrow"}])";
 
+  auto expected_json = R"([{"a": 1, "b": "hello"}, {"a": 2, "b": "arrow"}])";
   auto expected_array = ArrayFromJSON(struct_type, expected_json);
-  AssertArraysEqual(*final_array, *expected_array);
+  AssertArraysEqual(*expected_array, *final_array);
 }
 
 TEST(TestStructBuilderUnsafe, UnsafeAppendNull) {

--- a/cpp/src/arrow/array/array_struct_test.cc
+++ b/cpp/src/arrow/array/array_struct_test.cc
@@ -748,8 +748,7 @@ TEST(TestFieldRef, GetChildren) {
   AssertArraysEqual(*a, *expected_a);
 }
 
-TEST(TestStructBuilder, UnsafeAppend) {
-  
+TEST(TestStructBuilderUnsafe, UnsafeAppend) {
   auto int_type = int32();
   auto str_type = utf8();
   auto struct_type = struct_({field("a", int_type), field("b", str_type)});
@@ -758,7 +757,9 @@ TEST(TestStructBuilder, UnsafeAppend) {
   auto int_builder = std::make_shared<Int32Builder>(pool);
   auto str_builder = std::make_shared<StringBuilder>(pool);
   StructBuilder builder(struct_type, pool, {int_builder, str_builder});
-  
+
+  ASSERT_OK(builder.Reserve(2));
+
   builder.UnsafeAppend();
   ASSERT_OK(int_builder->Append(1));
   ASSERT_OK(str_builder->Append("hello"));
@@ -766,17 +767,17 @@ TEST(TestStructBuilder, UnsafeAppend) {
   builder.UnsafeAppend();
   ASSERT_OK(int_builder->Append(2));
   ASSERT_OK(str_builder->Append("arrow"));
-  
+
   ASSERT_OK(builder.Finish(&final_array));
   ASSERT_EQ(2, final_array->length());
   ASSERT_EQ(0, final_array->null_count());
   auto expected_json = R"([{"a": 1, "b": "hello"}, {"a": 2, "b": "arrow"}])";
+
   auto expected_array = ArrayFromJSON(struct_type, expected_json);
-  ASSERT_TRUE(final_array->Equals(expected_array));
+  AssertArraysEqual(*final_array, *expected_array);
 }
 
-TEST(TestStructBuilder, UnsafeAppendNull) {
-  
+TEST(TestStructBuilderUnsafe, UnsafeAppendNull) {
   auto int_type = int32();
   auto str_type = utf8();
   auto struct_type = struct_({field("a", int_type), field("b", str_type)});
@@ -785,6 +786,8 @@ TEST(TestStructBuilder, UnsafeAppendNull) {
   auto int_builder = std::make_shared<Int32Builder>(pool);
   auto str_builder = std::make_shared<StringBuilder>(pool);
   StructBuilder builder(struct_type, pool, {int_builder, str_builder});
+
+  ASSERT_OK(builder.Reserve(3));
 
   builder.UnsafeAppend();
   ASSERT_OK(int_builder->Append(1));
@@ -801,12 +804,12 @@ TEST(TestStructBuilder, UnsafeAppendNull) {
   ASSERT_EQ(1, final_array->null_count());
   ASSERT_TRUE(final_array->IsNull(1));
   auto expected_json = R"([{"a": 1, "b": "hello"}, null, {"a": 2, "b": "arrow"}])";
+
   auto expected_array = ArrayFromJSON(struct_type, expected_json);
-  ASSERT_TRUE(final_array->Equals(expected_array));
+  AssertArraysEqual(*final_array, *expected_array);
 }
 
-TEST(TestStructBuilder, UnsafeAppendNulls) {
-  
+TEST(TestStructBuilderUnsafe, UnsafeAppendNulls) {
   auto int_type = int32();
   auto str_type = utf8();
   auto struct_type = struct_({field("a", int_type), field("b", str_type)});
@@ -815,6 +818,8 @@ TEST(TestStructBuilder, UnsafeAppendNulls) {
   auto int_builder = std::make_shared<Int32Builder>(pool);
   auto str_builder = std::make_shared<StringBuilder>(pool);
   StructBuilder builder(struct_type, pool, {int_builder, str_builder});
+
+  ASSERT_OK(builder.Reserve(4));
 
   builder.UnsafeAppend();
   ASSERT_OK(int_builder->Append(1));
@@ -827,13 +832,10 @@ TEST(TestStructBuilder, UnsafeAppendNulls) {
   ASSERT_OK(str_builder->Append("arrow"));
 
   ASSERT_OK(builder.Finish(&final_array));
-  ASSERT_EQ(4, final_array->length());
-  ASSERT_EQ(2, final_array->null_count());
-  ASSERT_TRUE(final_array->IsNull(1));
-  ASSERT_TRUE(final_array->IsNull(2));
-  auto expected_json = R"([{"a": 1, "b": "hello"}, null, null, {"a": 2, "b": "arrow"}])";
-  auto expected_array = ArrayFromJSON(struct_type, expected_json);
-  ASSERT_TRUE(final_array->Equals(expected_array));
+
+  auto expected_array = ArrayFromJSON(
+      struct_type, R"([{"a": 1, "b": "hello"}, null, null, {"a": 2, "b": "arrow"}])");
+  AssertArraysEqual(*final_array, *expected_array);
 }
 
-} // namespace arrow
+}  // namespace arrow

--- a/cpp/src/arrow/array/builder_nested.h
+++ b/cpp/src/arrow/array/builder_nested.h
@@ -771,7 +771,6 @@ class ARROW_EXPORT StructBuilder : public ArrayBuilder {
     return Status::OK();
   }
 
-  /// This method is "unsafe" because it does not update the null bitmap.
   /// It doesn't check the capacity. Caller is responsible for calling Reserve()
   /// beforehand.
   void UnsafeAppend(bool is_valid = true) { UnsafeAppendToBitmap(is_valid); }
@@ -785,7 +784,6 @@ class ARROW_EXPORT StructBuilder : public ArrayBuilder {
     return Append(false);
   }
 
-  /// This method is "unsafe" because it does not check for capacity.
   /// The caller is responsible for calling Reserve() beforehand to ensure
   /// there is enough space. This method will append nulls to all child
   /// builders to maintain a consistent state.

--- a/cpp/src/arrow/array/builder_nested.h
+++ b/cpp/src/arrow/array/builder_nested.h
@@ -814,13 +814,10 @@ class ARROW_EXPORT StructBuilder : public ArrayBuilder {
   /// builders to maintain a consistent state.
   /// param length The number of null slots to append.
   Status UnsafeAppendNulls(int64_t length) {
-    for (int64_t i = 0; i < length; ++i) {
-      UnsafeAppend(false);
-    }
-
     for (const auto& child : children_) {
       ARROW_RETURN_NOT_OK(child->AppendEmptyValues(length));
     }
+    UnsafeAppendToBitmap(length, false);
     return Status::OK();
   }
 


### PR DESCRIPTION

### Rationale for this change
StructBuilder class was missing UnsafeAppend() , UnsafeAppendNull(), UnsafeAppendNulls()  methods that were standard to other builders.

### What changes are included in this PR?
Added three new public methods to the StructBuilder class in cpp/src/arrow/array/builder_nested.h:

void UnsafeAppend()

Status UnsafeAppendNull()

Status UnsafeAppendNulls(int64_t length)

Refactored the existing Append() methods to use a centralized private UnsafeAppend(bool is_valid) function, improving maintainability and reducing code duplication, based on reviewer feedback.

### Are these changes tested?
Yes. A new test suite, TestStructBuilderUnsafe, has been added to cpp/src/arrow/array/array_struct_test.cc. This suite contains three new unit tests, one for each of the new unsafe methods, which validate their correctness and handling of nulls. All new and existing tests are passing locally.

### Are there any user-facing changes?
Yes, this PR introduces new public methods to the StructBuilder API. The changes are purely additive and do not alter or remove any existing functionality, so they are not breaking.

* GitHub Issue: #45722