### PR TITLE
GH-41239: [C++] Support to write csv header without quotes

### DIFF
--- a/cpp/src/arrow/csv/options.h
+++ b/cpp/src/arrow/csv/options.h
@@ -188,9 +188,6 @@ struct ARROW_EXPORT WriteOptions {
   /// Whether to write an initial header line with column names
   bool include_header = true;
 
-  /// \brief Quoting style of header
-  QuotingStyle quoting_header = QuotingStyle::Needed;
-
   /// \brief Maximum number of rows processed at a time
   ///
   /// The CSV writer converts and writes data in batches of N rows.
@@ -211,6 +208,9 @@ struct ARROW_EXPORT WriteOptions {
 
   /// \brief Quoting style
   QuotingStyle quoting_style = QuotingStyle::Needed;
+
+  /// \brief Quoting style of header
+  QuotingStyle quoting_header = QuotingStyle::Needed;
 
   /// Create write options with default values
   static WriteOptions Defaults();

--- a/cpp/src/arrow/csv/options.h
+++ b/cpp/src/arrow/csv/options.h
@@ -210,6 +210,9 @@ struct ARROW_EXPORT WriteOptions {
   QuotingStyle quoting_style = QuotingStyle::Needed;
 
   /// \brief Quoting style of header
+  ///
+  /// Note that `QuotingStyle::Needed` and `QuotingStyle::AllValid` have the same
+  /// effect of quoting all column names.
   QuotingStyle quoting_header = QuotingStyle::Needed;
 
   /// Create write options with default values

--- a/cpp/src/arrow/csv/options.h
+++ b/cpp/src/arrow/csv/options.h
@@ -188,6 +188,9 @@ struct ARROW_EXPORT WriteOptions {
   /// Whether to write an initial header line with column names
   bool include_header = true;
 
+  /// \brief Quoting style of header
+  QuotingStyle quoting_header = QuotingStyle::Needed;
+
   /// \brief Maximum number of rows processed at a time
   ///
   /// The CSV writer converts and writes data in batches of N rows.

--- a/cpp/src/arrow/csv/writer.cc
+++ b/cpp/src/arrow/csv/writer.cc
@@ -634,6 +634,9 @@ class CSVWriterImpl : public ipc::RecordBatchWriter {
           memcpy(next, col_name.data(), col_name.size());
           next += col_name.size();
           break;
+        // The behavior of the Needed quoting_style in CSV data depends on the data type.
+        // And it is always quoted when the data type is binary. To avoid semantic
+        // differences, the behavior of Need and AllValid should be consistent.
         case QuotingStyle::Needed:
         case QuotingStyle::AllValid:
           *next++ = '"';

--- a/cpp/src/arrow/csv/writer.cc
+++ b/cpp/src/arrow/csv/writer.cc
@@ -18,7 +18,6 @@
 #include "arrow/csv/writer.h"
 #include "arrow/array.h"
 #include "arrow/compute/cast.h"
-#include "arrow/csv/options.h"
 #include "arrow/io/interfaces.h"
 #include "arrow/ipc/writer.h"
 #include "arrow/record_batch.h"

--- a/cpp/src/arrow/csv/writer.cc
+++ b/cpp/src/arrow/csv/writer.cc
@@ -18,6 +18,7 @@
 #include "arrow/csv/writer.h"
 #include "arrow/array.h"
 #include "arrow/compute/cast.h"
+#include "arrow/csv/options.h"
 #include "arrow/io/interfaces.h"
 #include "arrow/ipc/writer.h"
 #include "arrow/record_batch.h"
@@ -105,7 +106,8 @@ int64_t CountQuotes(std::string_view s) {
 
 // Matching quote pair character length.
 constexpr int64_t kQuoteCount = 2;
-constexpr int64_t kQuoteDelimiterCount = kQuoteCount + /*end_char*/ 1;
+// Matching delimiter character length.
+constexpr int64_t kDelimiterCount = 1;
 
 // Interface for generating CSV data per column.
 // The intended usage is to iteratively call UpdateRowLengths for a column and
@@ -174,6 +176,32 @@ char* Escape(std::string_view s, char* out) {
     }
   }
   return out;
+}
+
+int64_t StopAtStructuralChar(const uint8_t* data, const int64_t buffer_size,
+                             const char delimiter) {
+  int64_t offset = 0;
+#if defined(ARROW_HAVE_SSE4_2) || defined(ARROW_HAVE_NEON)
+  // _mm_cmpistrc gives slightly better performance than the naive approach,
+  // probably doesn't deserve the effort
+  using simd_batch = xsimd::make_sized_batch_t<uint8_t, 16>;
+  while ((offset + 16) <= buffer_size) {
+    const auto v = simd_batch::load_unaligned(data + offset);
+    if (xsimd::any((v == '\n') | (v == '\r') | (v == '"') | (v == delimiter))) {
+      break;
+    }
+    offset += 16;
+  }
+#endif
+  while (offset < buffer_size) {
+    // error happened or remaining bytes to check
+    const char c = static_cast<char>(data[offset]);
+    if (c == '\n' || c == '\r' || c == '"' || c == delimiter) {
+      break;
+    }
+    ++offset;
+  }
+  return offset;
 }
 
 // Populator used for non-string/binary types, or when unquoted strings/binary types are
@@ -268,35 +296,18 @@ class UnquotedColumnPopulator : public ColumnPopulator {
     // scan the underlying string array buffer as a single big string
     const uint8_t* const data = array.raw_data() + array.value_offset(0);
     const int64_t buffer_size = array.total_values_length();
-    int64_t offset = 0;
-#if defined(ARROW_HAVE_SSE4_2) || defined(ARROW_HAVE_NEON)
-    // _mm_cmpistrc gives slightly better performance than the naive approach,
-    // probably doesn't deserve the effort
-    using simd_batch = xsimd::make_sized_batch_t<uint8_t, 16>;
-    while ((offset + 16) <= buffer_size) {
-      const auto v = simd_batch::load_unaligned(data + offset);
-      if (xsimd::any((v == '\n') | (v == '\r') | (v == '"') | (v == delimiter))) {
-        break;
-      }
-      offset += 16;
-    }
-#endif
-    while (offset < buffer_size) {
-      // error happened or remaining bytes to check
-      const char c = static_cast<char>(data[offset]);
-      if (c == '\n' || c == '\r' || c == '"' || c == delimiter) {
-        // extract the offending string from array per offset
-        const auto* offsets = array.raw_value_offsets();
-        const auto index =
-            std::upper_bound(offsets, offsets + array.length(), offset + offsets[0]) -
-            offsets;
-        DCHECK_GT(index, 0);
-        return Status::Invalid(
-            "CSV values may not contain structural characters if quoting style is "
-            "\"None\". See RFC4180. Invalid value: ",
-            array.GetView(index - 1));
-      }
-      ++offset;
+    if (int64_t offset = StopAtStructuralChar(data, buffer_size, delimiter);
+        offset != buffer_size) {
+      // extract the offending string from array per offset
+      const auto* offsets = array.raw_value_offsets();
+      const auto index =
+          std::upper_bound(offsets, offsets + array.length(), offset + offsets[0]) -
+          offsets;
+      DCHECK_GT(index, 0);
+      return Status::Invalid(
+          "CSV values may not contain structural characters if quoting style is "
+          "\"None\". See RFC4180. Invalid value: ",
+          array.GetView(index - 1));
     }
     return Status::OK();
   }
@@ -578,26 +589,59 @@ class CSVWriterImpl : public ipc::RecordBatchWriter {
     return Status::OK();
   }
 
-  int64_t CalculateHeaderSize() const {
+  int64_t CalculateHeaderSize(QuotingStyle quoting_style) const {
     int64_t header_length = 0;
     for (int col = 0; col < schema_->num_fields(); col++) {
       const std::string& col_name = schema_->field(col)->name();
       header_length += col_name.size();
-      header_length += CountQuotes(col_name);
+      switch (quoting_style) {
+        case QuotingStyle::None:
+          break;
+        case QuotingStyle::Needed:
+        case QuotingStyle::AllValid:
+          header_length += CountQuotes(col_name);
+          break;
+      }
     }
-    // header_length + ([quotes + ','] * schema_->num_fields()) + (eol - ',')
-    return header_length + (kQuoteDelimiterCount * schema_->num_fields()) +
-           (options_.eol.size() - 1);
+    header_length += kDelimiterCount * (schema_->num_fields() - 1) + options_.eol.size();
+    switch (quoting_style) {
+      case QuotingStyle::None:
+        break;
+      case QuotingStyle::Needed:
+      case QuotingStyle::AllValid:
+        header_length += kQuoteCount * schema_->num_fields();
+        break;
+    }
+    return header_length;
   }
 
   Status WriteHeader() {
     // Only called once, as part of initialization
-    RETURN_NOT_OK(data_buffer_->Resize(CalculateHeaderSize(), /*shrink_to_fit=*/false));
+    RETURN_NOT_OK(data_buffer_->Resize(CalculateHeaderSize(options_.quoting_header),
+                                       /*shrink_to_fit=*/false));
     char* next = reinterpret_cast<char*>(data_buffer_->mutable_data());
     for (int col = 0; col < schema_->num_fields(); ++col) {
-      *next++ = '"';
-      next = Escape(schema_->field(col)->name(), next);
-      *next++ = '"';
+      const std::string& col_name = schema_->field(col)->name();
+      switch (options_.quoting_header) {
+        case QuotingStyle::None:
+          if (StopAtStructuralChar(reinterpret_cast<const uint8_t*>(col_name.c_str()),
+                                   col_name.length(), options_.delimiter) !=
+              static_cast<int64_t>(col_name.length())) {
+            return Status::Invalid(
+                "CSV header may not contain structural characters if quoting style is "
+                "\"None\". See RFC4180. Invalid value: ",
+                col_name);
+          }
+          memcpy(next, col_name.data(), col_name.size());
+          next += col_name.size();
+          break;
+        case QuotingStyle::Needed:
+        case QuotingStyle::AllValid:
+          *next++ = '"';
+          next = Escape(schema_->field(col)->name(), next);
+          *next++ = '"';
+          break;
+      }
       if (col != schema_->num_fields() - 1) {
         *next++ = options_.delimiter;
       }

--- a/cpp/src/arrow/csv/writer_test.cc
+++ b/cpp/src/arrow/csv/writer_test.cc
@@ -93,8 +93,9 @@ std::vector<WriterTestParams> GenerateTestCases() {
   auto dummy_schema = schema({field("a", uint8())});
   std::string dummy_batch_data = R"([{"a": null}])";
 
-  auto no_structral_header = schema({field("a ", uint64()), field("b", int32())});
-  std::string expected_no_structral_header = std::string(R"(a ,b)") + "\n";
+  auto header_without_structral_charaters =
+      schema({field("a ", uint64()), field("b", int32())});
+  std::string expected_header_without_structral_charaters = std::string(R"(a ,b)") + "\n";
   auto expected_status_no_quotes_with_structural_in_header = [](const char* header) {
     return Status::Invalid(
         "CSV header may not contain structural characters if quoting "
@@ -291,12 +292,12 @@ std::vector<WriterTestParams> GenerateTestCases() {
        DefaultTestOptions(/*include_header=*/false, /*null_string=*/"",
                           QuotingStyle::Needed, /*eol=*/";", /*delimiter=*/';'),
        /*expected_output*/ "", expected_status_illegal_delimiter(';')},
-      {no_structral_header, "[]",
+      {header_without_structral_charaters, "[]",
        DefaultTestOptions(/*include_header=*/true, /*null_string=*/"",
                           QuotingStyle::Needed, /*eol=*/"\n",
                           /*delimiter=*/',', /*batch_size=*/5,
                           /*quoting_header=*/QuotingStyle::None),
-       expected_no_structral_header},
+       expected_header_without_structral_charaters},
       {abc_schema, "[]",
        DefaultTestOptions(/*include_header=*/true, /*null_string=*/"",
                           QuotingStyle::Needed, /*eol=*/"\n",

--- a/cpp/src/arrow/csv/writer_test.cc
+++ b/cpp/src/arrow/csv/writer_test.cc
@@ -93,9 +93,10 @@ std::vector<WriterTestParams> GenerateTestCases() {
   auto dummy_schema = schema({field("a", uint8())});
   std::string dummy_batch_data = R"([{"a": null}])";
 
-  auto header_without_structral_charaters =
+  auto header_without_structural_charaters =
       schema({field("a ", uint64()), field("b", int32())});
-  std::string expected_header_without_structral_charaters = std::string(R"(a ,b)") + "\n";
+  std::string expected_header_without_structural_charaters =
+      std::string(R"(a ,b)") + "\n";
   auto expected_status_no_quotes_with_structural_in_header = [](const char* header) {
     return Status::Invalid(
         "CSV header may not contain structural characters if quoting "
@@ -292,12 +293,12 @@ std::vector<WriterTestParams> GenerateTestCases() {
        DefaultTestOptions(/*include_header=*/false, /*null_string=*/"",
                           QuotingStyle::Needed, /*eol=*/";", /*delimiter=*/';'),
        /*expected_output*/ "", expected_status_illegal_delimiter(';')},
-      {header_without_structral_charaters, "[]",
+      {header_without_structural_charaters, "[]",
        DefaultTestOptions(/*include_header=*/true, /*null_string=*/"",
                           QuotingStyle::Needed, /*eol=*/"\n",
                           /*delimiter=*/',', /*batch_size=*/5,
                           /*quoting_header=*/QuotingStyle::None),
-       expected_header_without_structral_charaters},
+       expected_header_without_structural_charaters},
       {abc_schema, "[]",
        DefaultTestOptions(/*include_header=*/true, /*null_string=*/"",
                           QuotingStyle::Needed, /*eol=*/"\n",

--- a/cpp/src/arrow/csv/writer_test.cc
+++ b/cpp/src/arrow/csv/writer_test.cc
@@ -61,10 +61,12 @@ WriteOptions DefaultTestOptions(bool include_header = false,
                                 const std::string& null_string = "",
                                 QuotingStyle quoting_style = QuotingStyle::Needed,
                                 const std::string& eol = "\n", char delimiter = ',',
-                                int batch_size = 5) {
+                                int batch_size = 5,
+                                QuotingStyle quoting_header = QuotingStyle::Needed) {
   WriteOptions options;
   options.batch_size = batch_size;
   options.include_header = include_header;
+  options.quoting_header = quoting_header;
   options.null_string = null_string;
   options.eol = eol;
   options.quoting_style = quoting_style;
@@ -90,6 +92,15 @@ std::vector<WriterTestParams> GenerateTestCases() {
   // Dummy schema and data for testing invalid options.
   auto dummy_schema = schema({field("a", uint8())});
   std::string dummy_batch_data = R"([{"a": null}])";
+
+  auto no_structral_header = schema({field("a ", uint64()), field("b", int32())});
+  std::string expected_no_structral_header = std::string(R"(a ,b)") + "\n";
+  auto expected_status_no_quotes_with_structural_in_header = [](const char* header) {
+    return Status::Invalid(
+        "CSV header may not contain structural characters if quoting "
+        "style is \"None\". See RFC4180. Invalid value: ",
+        header);
+  };
 
   // Schema to test various types.
   auto abc_schema = schema({
@@ -279,7 +290,20 @@ std::vector<WriterTestParams> GenerateTestCases() {
       {schema_custom_delimiter, batch_custom_delimiter,
        DefaultTestOptions(/*include_header=*/false, /*null_string=*/"",
                           QuotingStyle::Needed, /*eol=*/";", /*delimiter=*/';'),
-       /*expected_output*/ "", expected_status_illegal_delimiter(';')}};
+       /*expected_output*/ "", expected_status_illegal_delimiter(';')},
+      {no_structral_header, "[]",
+       DefaultTestOptions(/*include_header=*/true, /*null_string=*/"",
+                          QuotingStyle::Needed, /*eol=*/"\n",
+                          /*delimiter=*/',', /*batch_size=*/5,
+                          /*quoting_header=*/QuotingStyle::None),
+       expected_no_structral_header},
+      {abc_schema, "[]",
+       DefaultTestOptions(/*include_header=*/true, /*null_string=*/"",
+                          QuotingStyle::Needed, /*eol=*/"\n",
+                          /*delimiter=*/',', /*batch_size=*/5,
+                          /*quoting_header=*/QuotingStyle::None),
+       "", expected_status_no_quotes_with_structural_in_header("b\"")},
+  };
 }
 
 class TestWriteCSV : public ::testing::TestWithParam<WriterTestParams> {


### PR DESCRIPTION
### Rationale for this change

Give an option to determine whether to write quotes in csv header in C++ code.

### What changes are included in this PR?

1. Add `QuotingStyle quoting_header` option in `WriteOptions` to determine whether to write quotes in `CSVWriterImpl::WriteHeader`.
2. Move part of the code in `UnquotedColumnPopulator::CheckStringArrayHasNoStructuralChars` into a new function to reuse the logic of checking structural characters.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Add `QuotingStyle quoting_header` option in `WriteOptions`.

* GitHub Issue: #41239