### PR TITLE
GH-47552: [C++] Fix creating wrong object by `FixedShapeTensorType::MakeArray()`

### DIFF
--- a/cpp/src/arrow/extension/fixed_shape_tensor.cc
+++ b/cpp/src/arrow/extension/fixed_shape_tensor.cc
@@ -202,7 +202,7 @@ std::shared_ptr<Array> FixedShapeTensorType::MakeArray(
   DCHECK_EQ(data->type->id(), Type::EXTENSION);
   DCHECK_EQ("arrow.fixed_shape_tensor",
             internal::checked_cast<const ExtensionType&>(*data->type).extension_name());
-  return std::make_shared<ExtensionArray>(data);
+  return std::make_shared<FixedShapeTensorArray>(data);
 }
 
 Result<std::shared_ptr<Tensor>> FixedShapeTensorType::MakeTensor(


### PR DESCRIPTION
### Rationale for this change

The builder should return the correct type.

### What changes are included in this PR?

One liner

### Are these changes tested?

Yes

### Are there any user-facing changes?

No
* GitHub Issue: #47552