### PR TITLE
GH-47534: [C++] Detect conda-installed packages in Meson CI

### DIFF
--- a/ci/scripts/cpp_build.sh
+++ b/ci/scripts/cpp_build.sh
@@ -142,7 +142,7 @@ if [ "${ARROW_USE_MESON:-OFF}" = "ON" ]; then
   meson setup \
     --prefix=${MESON_PREFIX:-${ARROW_HOME}} \
     --buildtype=${ARROW_BUILD_TYPE:-debug} \
-    -Dpkg_config_path="${CONDA_PREFIX}/lib/pkgconfig/" \
+    --pkg-config-path="${CONDA_PREFIX}/lib/pkgconfig/" \
     -Dauto_features=enabled \
     -Dfuzzing=disabled \
     -Dgcs=disabled \

--- a/ci/scripts/cpp_build.sh
+++ b/ci/scripts/cpp_build.sh
@@ -142,6 +142,7 @@ if [ "${ARROW_USE_MESON:-OFF}" = "ON" ]; then
   meson setup \
     --prefix=${MESON_PREFIX:-${ARROW_HOME}} \
     --buildtype=${ARROW_BUILD_TYPE:-debug} \
+    -Dpkg_config_path="${CONDA_PREFIX}/lib/pkgconfig/" \
     -Dauto_features=enabled \
     -Dfuzzing=disabled \
     -Dgcs=disabled \


### PR DESCRIPTION
### Rationale for this change

This detects conda-installed packages in Meson CI, so that dependencies which are installed via conda do not need to be built from scratch

### What changes are included in this PR?

An update to the meson setup invocation

### Are these changes tested?

Yes

### Are there any user-facing changes?

No
* GitHub Issue: #47534