### PR TITLE
GH-47537: [C++] Use pkgconfig name for benchmark in Meson

### DIFF
--- a/cpp/src/arrow/meson.build
+++ b/cpp/src/arrow/meson.build
@@ -670,7 +670,8 @@ endforeach
 
 if needs_benchmarks
     benchmark_main_dep = dependency(
-        'benchmark-main',
+        'benchmark_main',
+        fallback: ['google-benchmark', 'google_benchmark_main_dep'],
         default_options: {'tests': 'disabled'},
     )
 


### PR DESCRIPTION
### Rationale for this change

Because of an inconsistency in the name of the pkgconfig file for google benchmark and the dependency exposed by Meson, Meson will always ignore a system install and fallback to building google benchmark locally. We can instead patch our Meson configuration to workaround the inconsistent naming

### What changes are included in this PR?

We use the proper pkgconfig exposed name to find the dependency, and fallback to the Meson subproject / variable name combination as necessary

### Are these changes tested?

Yes

### Are there any user-facing changes?

No
* GitHub Issue: #47537