### PR TITLE
GH-47539: [C++] Detect Snappy and bzip2 in Meson CI

### DIFF
--- a/cpp/src/arrow/meson.build
+++ b/cpp/src/arrow/meson.build
@@ -223,7 +223,16 @@ endif
 
 if needs_bz2
     arrow_util_srcs += ['util/compression_bz2.cc']
-    arrow_util_deps += dependency('bzip2')
+    bzip2 = cpp_compiler.find_library(
+        'bz2',
+        has_headers: ['bzlib.h'],
+        required: false,
+    )
+    if bzip2.found()
+        arrow_util_deps += bzip2
+    else
+        arrow_util_deps += dependency('bzip2')
+    endif
 endif
 
 if needs_lz4
@@ -233,7 +242,7 @@ endif
 
 if needs_snappy
     arrow_util_srcs += ['util/compression_snappy.cc']
-    arrow_util_deps += dependency('snappy')
+    arrow_util_deps += dependency('snappy', 'Snappy')
 endif
 
 if needs_zlib


### PR DESCRIPTION
### Rationale for this change

This should help find system-provided installs of Snappy and bzip2, so that they don't need to be built as subprojects

### What changes are included in this PR?

Changes to the Meson configuration to detect these libraries

### Are these changes tested?

Yes

### Are there any user-facing changes?

No
* GitHub Issue: #47539