### PR TITLE
GH-47431: [C++] Improve Meson configuration for WrapDB distribution

### DIFF
--- a/cpp/src/arrow/acero/meson.build
+++ b/cpp/src/arrow/acero/meson.build
@@ -84,7 +84,11 @@ arrow_acero_lib = library(
     gnu_symbol_visibility: 'hidden',
 )
 
-arrow_acero_dep = declare_dependency(link_with: [arrow_acero_lib])
+arrow_acero_dep = declare_dependency(
+    dependencies: [arrow_compute_dep],
+    link_with: [arrow_acero_lib],
+)
+meson.override_dependency('arrow-acero', arrow_acero_dep)
 
 arrow_acero_testing_sources = ['test_nodes.cc', 'test_util_internal.cc']
 
@@ -145,6 +149,7 @@ foreach key, val : arrow_acero_benchmarks
 endforeach
 
 pkg.generate(
+    arrow_acero_lib,
     filebase: 'arrow-acero',
     name: 'Apache Arrow Acero Engine',
     description: 'Apache Arrow\'s Acero Engine',

--- a/cpp/src/arrow/adapters/tensorflow/meson.build
+++ b/cpp/src/arrow/adapters/tensorflow/meson.build
@@ -17,6 +17,12 @@
 
 install_headers(['convert.h'], subdir: 'arrow/adapters/tensorflow')
 
+arrow_tensorflow_dep = declare_dependency(
+    include_directories: include_directories('.'),
+    dependencies: arrow_dep,
+)
+meson.override_dependency('arrow-tensorflow', arrow_tensorflow_dep)
+
 pkg.generate(
     filebase: 'arrow-tensorflow',
     name: 'Apache Arrow Tensorflow',

--- a/cpp/src/arrow/csv/meson.build
+++ b/cpp/src/arrow/csv/meson.build
@@ -62,6 +62,11 @@ install_headers(
     subdir: 'arrow/csv',
 )
 
+arrow_csv_dep = declare_dependency(
+    include_directories: include_directories('.'),
+    dependencies: arrow_dep,
+)
+meson.override_dependency('arrow-csv', arrow_csv_dep)
 
 pkg.generate(
     filebase: 'arrow-csv',

--- a/cpp/src/arrow/filesystem/meson.build
+++ b/cpp/src/arrow/filesystem/meson.build
@@ -34,6 +34,12 @@ install_headers(
     subdir: 'arrow/filesystem',
 )
 
+arrow_filesystem_dep = declare_dependency(
+    include_directories: include_directories('.'),
+    dependencies: arrow_dep,
+)
+meson.override_dependency('arrow-filesystem', arrow_filesystem_dep)
+
 pkg.generate(
     filebase: 'arrow-filesystem',
     name: 'Apache Arrow Filesystem',

--- a/cpp/src/arrow/json/meson.build
+++ b/cpp/src/arrow/json/meson.build
@@ -55,6 +55,12 @@ install_headers(
     subdir: 'arrow/json',
 )
 
+arrow_json_dep = declare_dependency(
+    include_directories: include_directories('.'),
+    dependencies: arrow_dep,
+)
+meson.override_dependency('arrow-json', arrow_json_dep)
+
 pkg.generate(
     filebase: 'arrow-json',
     name: 'Apache Arrow JSON',

--- a/cpp/src/arrow/meson.build
+++ b/cpp/src/arrow/meson.build
@@ -433,6 +433,7 @@ arrow_dep = declare_dependency(
     include_directories: [include_dir],
     link_with: arrow_lib,
 )
+meson.override_dependency('arrow', arrow_dep)
 
 if needs_compute
     arrow_compute_lib_sources = [
@@ -496,6 +497,7 @@ if needs_compute
         include_directories: include_dir,
         dependencies: arrow_dep,
     )
+    meson.override_dependency('arrow-compute', arrow_compute_dep)
 else
     arrow_compute_dep = disabler()
 endif
@@ -580,6 +582,7 @@ if needs_testing
     )
 
     arrow_testing_dep = declare_dependency(link_with: [arrow_testing_lib])
+    meson.override_dependency('arrow-testing', arrow_testing_dep)
 else
     arrow_testing_dep = disabler()
 endif


### PR DESCRIPTION
### Rationale for this change

These changes make it easier for downstream users to consume Arrow and its individual components, whether they are available on the system or need to be built from source.

### What changes are included in this PR?

Various updates to the Meson configuration to provide dependencies for wrapdb, clean up various semantics

### Are these changes tested?

Yes

### Are there any user-facing changes?

No
* GitHub Issue: #47431