### PR TITLE
GH-47543: [C++] Search for system install of Azure libraries with Meson

### DIFF
--- a/cpp/src/arrow/meson.build
+++ b/cpp/src/arrow/meson.build
@@ -318,30 +318,81 @@ if needs_filesystem
 
     if needs_azure
         arrow_filesystem_srcs += ['filesystem/azurefs.cc']
-        cmake = import('cmake')
-        azure_opt = cmake.subproject_options()
-        azure_opt.add_cmake_defines(
-            {'BUILD_PERFORMANCE_TESTS': 'FALSE'},
-            {'BUILD_SAMPLES': 'FALSE'},
-            {'BUILD_TESTING': 'FALSE'},
-            {'BUILD_WINDOWS_UWP': 'TRUE'},
-            {'CMAKE_UNITY_BUILD': 'FALSE'},
-            {'DISABLE_AZURE_CORE_OPENTELEMETRY': 'TRUE'},
-            {'ENV{AZURE_SDK_DISABLE_AUTO_VCPKG}': 'TRUE'},
-            {'WARNINGS_AS_ERRORS': 'FALSE'},
-        )
-        azure_opt.append_compile_args('cpp', '-fPIC')
-        azure_proj = cmake.subproject('azure', options: azure_opt)
 
-        azure_dep = declare_dependency(
-            dependencies: [
-                azure_proj.dependency('azure-core'),
-                azure_proj.dependency('azure-identity'),
-                azure_proj.dependency('azure-storage-blobs'),
-                azure_proj.dependency('azure-storage-common'),
-                azure_proj.dependency('azure-storage-files-datalake'),
-            ],
+        azure_core_dep = dependency(
+            'azure-core-cpp',
+            allow_fallback: false,
+            modules: ['Azure::azure-core'],
+            required: false,
         )
+        azure_identity_dep = dependency(
+            'azure-identity-cpp',
+            allow_fallback: false,
+            modules: ['Azure::azure-identity'],
+            required: false,
+        )
+        azure_storage_blobs_dep = dependency(
+            'azure-storage-blobs-cpp',
+            allow_fallback: false,
+            modules: ['Azure::azure-storage-blobs'],
+            required: false,
+        )
+        azure_storage_common_dep = dependency(
+            'azure-storage-common-cpp',
+            allow_fallback: false,
+            modules: ['Azure::azure-storage-common'],
+            required: false,
+        )
+        azure_storage_files_datalake_dep = dependency(
+            'azure-storage-files-datalake-cpp',
+            allow_fallback: false,
+            modules: ['Azure::azure-storage-files-datalake'],
+            required: false,
+        )
+
+        if (
+            azure_core_dep.found()
+            and azure_identity_dep.found()
+            and azure_storage_blobs_dep.found()
+            and azure_storage_common_dep.found()
+            and azure_storage_files_datalake_dep.found()
+        )
+            azure_dep = declare_dependency(
+                dependencies: [
+                    azure_core_dep,
+                    azure_identity_dep,
+                    azure_storage_blobs_dep,
+                    azure_storage_common_dep,
+                    azure_storage_files_datalake_dep,
+                ],
+            )
+        else
+            cmake = import('cmake')
+            azure_opt = cmake.subproject_options()
+            azure_opt.add_cmake_defines(
+                {'BUILD_PERFORMANCE_TESTS': 'FALSE'},
+                {'BUILD_SAMPLES': 'FALSE'},
+                {'BUILD_TESTING': 'FALSE'},
+                {'BUILD_WINDOWS_UWP': 'TRUE'},
+                {'CMAKE_UNITY_BUILD': 'FALSE'},
+                {'DISABLE_AZURE_CORE_OPENTELEMETRY': 'TRUE'},
+                {'ENV{AZURE_SDK_DISABLE_AUTO_VCPKG}': 'TRUE'},
+                {'WARNINGS_AS_ERRORS': 'FALSE'},
+            )
+            azure_opt.append_compile_args('cpp', '-fPIC')
+            azure_proj = cmake.subproject('azure', options: azure_opt)
+
+            azure_dep = declare_dependency(
+                dependencies: [
+                    azure_proj.dependency('azure-core'),
+                    azure_proj.dependency('azure-identity'),
+                    azure_proj.dependency('azure-storage-blobs'),
+                    azure_proj.dependency('azure-storage-common'),
+                    azure_proj.dependency('azure-storage-files-datalake'),
+                ],
+            )
+        endif
+
         arrow_filesystem_deps += [azure_dep]
     endif
 


### PR DESCRIPTION
### Rationale for this change

The current Meson configuration always builds Azure as a subproject. However, if it is available on the system, we can cut down on build time by adding some extra logic.

### What changes are included in this PR?

Updates to the Meson configuration to search for azure libraries on the system

### Are these changes tested?

Yes

### Are there any user-facing changes?

No

* GitHub Issue: #47543