### PR TITLE
GH-47548: [C++] Bump Meson wrap version of google-benchmark

### DIFF
--- a/cpp/src/arrow/meson.build
+++ b/cpp/src/arrow/meson.build
@@ -680,7 +680,6 @@ endforeach
 if needs_benchmarks
     benchmark_main_dep = dependency(
         'benchmark_main',
-        fallback: ['google-benchmark', 'google_benchmark_main_dep'],
         default_options: {'tests': 'disabled'},
     )
 

--- a/cpp/subprojects/google-benchmark.wrap
+++ b/cpp/subprojects/google-benchmark.wrap
@@ -20,12 +20,11 @@ directory = benchmark-1.8.4
 source_url = https://github.com/google/benchmark/archive/refs/tags/v1.8.4.tar.gz
 source_filename = benchmark-1.8.4.tar.gz
 source_hash = 3e7059b6b11fb1bbe28e33e02519398ca94c1818874ebed18e504dc6f709be45
-patch_filename = google-benchmark_1.8.4-3_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/google-benchmark_1.8.4-3/get_patch
-patch_hash = 657aee778629725cf9104bbfc32dba0c9c6825d5202e600ad81c7251ae684468
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/google-benchmark_1.8.4-3/benchmark-1.8.4.tar.gz
-wrapdb_version = 1.8.4-3
+patch_filename = google-benchmark_1.8.4-4_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/google-benchmark_1.8.4-4/get_patch
+patch_hash = d1af464d29eb42442c41bc0629f94dbc2e390d9a8656461a14adfee84bcb6250
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/google-benchmark_1.8.4-4/benchmark-1.8.4.tar.gz
+wrapdb_version = 1.8.4-4
 
 [provide]
-benchmark = google_benchmark_dep
-benchmark-main = google_benchmark_main_dep
+dependency_names = benchmark, benchmark_main


### PR DESCRIPTION
### Rationale for this change

Updating our wrap entry for google benchmark can help simplify our Meson configuration, so that we don't need to track the variable name provided upstream

### What changes are included in this PR?

Updated wrap file for google-benchmark along with the simplification of our configuration

### Are these changes tested?

Yes

### Are there any user-facing changes?

No
* GitHub Issue: #47548