### PR TITLE
GH-47550: [Python] Use SPDX convention for license metadata on PyPI

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -32,9 +32,8 @@ dynamic = ["version"]
 requires-python = ">=3.10"
 description = "Python library for Apache Arrow"
 readme = {file = "README.md", content-type = "text/markdown"}
-license = {text = "Apache Software License"}
+license = "Apache-2.0"
 classifiers  = [
-    'License :: OSI Approved :: Apache Software License',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',


### PR DESCRIPTION
### Rationale for this change

This is to address #47550 (as per [PEP 639](https://peps.python.org/pep-0639/#spdx-license-expression-syntax), SPDX license expressions are now the standard for Python packages).

### What changes are included in this PR?

Update to SPDX license metadata for the Python package (changes in pyproject.toml). Also remove license from the list of classifiers (this is deprecated). License files are currently specified in setup.cfg, there is no need to change these.

### Are these changes tested?

There are no code changes. Python package build will need to be tested - can this happen in CI?

### Are there any user-facing changes?

No in that there are no code changes. Yes in that the Python package metadata is public.

* GitHub Issue: #47550