### PR TITLE
GH-35508: 

### DIFF
--- a/cpp/src/arrow/acero/hash_aggregate_test.cc
+++ b/cpp/src/arrow/acero/hash_aggregate_test.cc
@@ -1271,9 +1271,13 @@ TEST_P(GroupBy, TDigest) {
   auto keep_nulls_min_count =
       std::make_shared<TDigestOptions>(/*q=*/0.5, /*delta=*/100, /*buffer_size=*/500,
                                        /*skip_nulls=*/false, /*min_count=*/3);
+  auto scaler_0 = std::make_shared<TDigestOptions>(
+      /*q=*/0.5, /*delta=*/100, /*buffer_size=*/500,
+      /*skip_nulls=*/true, /*min_count=*/3, /*scaler=*/TDigestOptions::K0);
   ASSERT_OK_AND_ASSIGN(Datum aggregated_and_grouped,
                        GroupByTest(
                            {
+                               batch->GetColumnByName("argument"),
                                batch->GetColumnByName("argument"),
                                batch->GetColumnByName("argument"),
                                batch->GetColumnByName("argument"),
@@ -1292,6 +1296,7 @@ TEST_P(GroupBy, TDigest) {
                                {"hash_tdigest", keep_nulls},
                                {"hash_tdigest", min_count},
                                {"hash_tdigest", keep_nulls_min_count},
+                               {"hash_tdigest", scaler_0},
                            },
                            false));
 
@@ -1304,13 +1309,14 @@ TEST_P(GroupBy, TDigest) {
                         field("hash_tdigest", fixed_size_list(float64(), 1)),
                         field("hash_tdigest", fixed_size_list(float64(), 1)),
                         field("hash_tdigest", fixed_size_list(float64(), 1)),
+                        field("hash_tdigest", fixed_size_list(float64(), 1)),
                     }),
                     R"([
-    [1,    [1.0],  [1.0, 3.0, 3.0],    [1.0, 3.0, 3.0],    [null], [null], [null]],
-    [2,    [0.0],  [0.0, 0.0, 0.0],    [0.0, 0.0, 0.0],    [0.0],  [0.0],  [0.0] ],
-    [3,    [null], [null, null, null], [null, null, null], [null], [null], [null]],
-    [4,    [1.0],  [1.0, 1.0, 1.0],    [1.0, 1.0, 1.0],    [null], [1.0],  [null]],
-    [null, [1.0],  [1.0, 4.0, 4.0],    [1.0, 4.0, 4.0],    [1.0],  [null], [null]]
+    [1,    [1.0],  [1.0, 3.0, 3.0],    [1.0, 3.0, 3.0],    [null], [null], [null], [null]],
+    [2,    [0.0],  [0.0, 0.0, 0.0],    [0.0, 0.0, 0.0],    [0.0],  [0.0],  [0.0],  [0.0]],
+    [3,    [null], [null, null, null], [null, null, null], [null], [null], [null], [null]],
+    [4,    [1.0],  [1.0, 1.0, 1.0],    [1.0, 1.0, 1.0],    [null], [1.0],  [null], [1.0]],
+    [null, [1.0],  [1.0, 4.0, 4.0],    [1.0, 4.0, 4.0],    [1.0],  [null], [null], [null]]
   ])"),
       aggregated_and_grouped,
       /*verbose=*/true);

--- a/cpp/src/arrow/compute/api_aggregate.cc
+++ b/cpp/src/arrow/compute/api_aggregate.cc
@@ -70,6 +70,22 @@ struct EnumTraits<compute::QuantileOptions::Interpolation>
 };
 
 template <>
+struct EnumTraits<compute::TDigestOptions::Scaler>
+    : BasicEnumTraits<compute::TDigestOptions::Scaler, compute::TDigestOptions::K0,
+                      compute::TDigestOptions::K1> {
+  static std::string name() { return "TDigestOptions::Scaler"; }
+  static std::string value_name(compute::TDigestOptions::Scaler value) {
+    switch (value) {
+      case compute::TDigestOptions::K0:
+        return "K0";
+      case compute::TDigestOptions::K1:
+        return "K1";
+    }
+    return "<INVALID>";
+  }
+};
+
+template <>
 struct EnumTraits<compute::PivotWiderOptions::UnexpectedKeyBehavior>
     : BasicEnumTraits<compute::PivotWiderOptions::UnexpectedKeyBehavior,
                       compute::PivotWiderOptions::kIgnore,
@@ -123,7 +139,8 @@ static auto kTDigestOptionsType = GetFunctionOptionsType<TDigestOptions>(
     DataMember("q", &TDigestOptions::q), DataMember("delta", &TDigestOptions::delta),
     DataMember("buffer_size", &TDigestOptions::buffer_size),
     DataMember("skip_nulls", &TDigestOptions::skip_nulls),
-    DataMember("min_count", &TDigestOptions::min_count));
+    DataMember("min_count", &TDigestOptions::min_count),
+    DataMember("scaler", &TDigestOptions::scaler));
 static auto kPivotOptionsType = GetFunctionOptionsType<PivotWiderOptions>(
     DataMember("key_names", &PivotWiderOptions::key_names),
     DataMember("unexpected_key_behavior", &PivotWiderOptions::unexpected_key_behavior));
@@ -179,21 +196,24 @@ QuantileOptions::QuantileOptions(std::vector<double> q, enum Interpolation inter
 constexpr char QuantileOptions::kTypeName[];
 
 TDigestOptions::TDigestOptions(double q, uint32_t delta, uint32_t buffer_size,
-                               bool skip_nulls, uint32_t min_count)
+                               bool skip_nulls, uint32_t min_count, enum Scaler scaler)
     : FunctionOptions(internal::kTDigestOptionsType),
       q{q},
       delta{delta},
       buffer_size{buffer_size},
       skip_nulls{skip_nulls},
-      min_count{min_count} {}
+      min_count{min_count},
+      scaler{scaler} {}
 TDigestOptions::TDigestOptions(std::vector<double> q, uint32_t delta,
-                               uint32_t buffer_size, bool skip_nulls, uint32_t min_count)
+                               uint32_t buffer_size, bool skip_nulls, uint32_t min_count,
+                               enum Scaler scaler)
     : FunctionOptions(internal::kTDigestOptionsType),
       q{std::move(q)},
       delta{delta},
       buffer_size{buffer_size},
       skip_nulls{skip_nulls},
-      min_count{min_count} {}
+      min_count{min_count},
+      scaler{scaler} {}
 constexpr char TDigestOptions::kTypeName[];
 
 PivotWiderOptions::PivotWiderOptions(std::vector<std::string> key_names,

--- a/cpp/src/arrow/compute/api_aggregate.cc
+++ b/cpp/src/arrow/compute/api_aggregate.cc
@@ -141,6 +141,16 @@ static auto kTDigestOptionsType = GetFunctionOptionsType<TDigestOptions>(
     DataMember("skip_nulls", &TDigestOptions::skip_nulls),
     DataMember("min_count", &TDigestOptions::min_count),
     DataMember("scaler", &TDigestOptions::scaler));
+static auto kTDigestMapOptionsType = GetFunctionOptionsType<TDigestMapOptions>(
+    DataMember("delta", &TDigestMapOptions::delta),
+    DataMember("buffer_size", &TDigestMapOptions::buffer_size),
+    DataMember("skip_nulls", &TDigestMapOptions::skip_nulls),
+    DataMember("scaler", &TDigestMapOptions::scaler));
+static auto kTDigestReduceOptionsType = GetFunctionOptionsType<TDigestReduceOptions>(
+    DataMember("scaler", &TDigestReduceOptions::scaler));
+static auto kTDigestQuantileOptionsType = GetFunctionOptionsType<TDigestQuantileOptions>(
+    DataMember("q", &TDigestQuantileOptions::q),
+    DataMember("min_count", &TDigestQuantileOptions::min_count));
 static auto kPivotOptionsType = GetFunctionOptionsType<PivotWiderOptions>(
     DataMember("key_names", &PivotWiderOptions::key_names),
     DataMember("unexpected_key_behavior", &PivotWiderOptions::unexpected_key_behavior));
@@ -216,6 +226,30 @@ TDigestOptions::TDigestOptions(std::vector<double> q, uint32_t delta,
       scaler{scaler} {}
 constexpr char TDigestOptions::kTypeName[];
 
+TDigestMapOptions::TDigestMapOptions(uint32_t delta, uint32_t buffer_size,
+                                     bool skip_nulls, Scaler scaler)
+    : FunctionOptions(internal::kTDigestMapOptionsType),
+      delta{delta},
+      buffer_size{buffer_size},
+      skip_nulls{skip_nulls},
+      scaler{scaler} {}
+constexpr char TDigestMapOptions::kTypeName[];
+
+TDigestReduceOptions::TDigestReduceOptions(Scaler scaler)
+    : FunctionOptions(internal::kTDigestReduceOptionsType), scaler{scaler} {}
+constexpr char TDigestReduceOptions::kTypeName[];
+
+TDigestQuantileOptions::TDigestQuantileOptions(double q, uint32_t min_count)
+    : FunctionOptions(internal::kTDigestQuantileOptionsType),
+      q{q},
+      min_count{min_count} {}
+
+TDigestQuantileOptions::TDigestQuantileOptions(std::vector<double> q, uint32_t min_count)
+    : FunctionOptions(internal::kTDigestQuantileOptionsType),
+      q{std::move(q)},
+      min_count{min_count} {}
+constexpr char TDigestReduceOptions::kTypeName[];
+
 PivotWiderOptions::PivotWiderOptions(std::vector<std::string> key_names,
                                      UnexpectedKeyBehavior unexpected_key_behavior)
     : FunctionOptions(internal::kPivotOptionsType),
@@ -237,6 +271,9 @@ void RegisterAggregateOptions(FunctionRegistry* registry) {
   DCHECK_OK(registry->AddFunctionOptionsType(kSkewOptionsType));
   DCHECK_OK(registry->AddFunctionOptionsType(kQuantileOptionsType));
   DCHECK_OK(registry->AddFunctionOptionsType(kTDigestOptionsType));
+  DCHECK_OK(registry->AddFunctionOptionsType(kTDigestMapOptionsType));
+  DCHECK_OK(registry->AddFunctionOptionsType(kTDigestReduceOptionsType));
+  DCHECK_OK(registry->AddFunctionOptionsType(kTDigestQuantileOptionsType));
   DCHECK_OK(registry->AddFunctionOptionsType(kPivotOptionsType));
   DCHECK_OK(registry->AddFunctionOptionsType(kIndexOptionsType));
 }
@@ -319,6 +356,11 @@ Result<Datum> Quantile(const Datum& value, const QuantileOptions& options,
 Result<Datum> TDigest(const Datum& value, const TDigestOptions& options,
                       ExecContext* ctx) {
   return CallFunction("tdigest", {value}, &options, ctx);
+}
+
+Result<Datum> TDigestMap(const Datum& value, const TDigestMapOptions& options,
+                         ExecContext* ctx) {
+  return CallFunction("tdigest_map", {value}, &options, ctx);
 }
 
 Result<Datum> Index(const Datum& value, const IndexOptions& options, ExecContext* ctx) {

--- a/cpp/src/arrow/compute/api_aggregate.cc
+++ b/cpp/src/arrow/compute/api_aggregate.cc
@@ -150,7 +150,8 @@ static auto kTDigestReduceOptionsType = GetFunctionOptionsType<TDigestReduceOpti
     DataMember("scaler", &TDigestReduceOptions::scaler));
 static auto kTDigestQuantileOptionsType = GetFunctionOptionsType<TDigestQuantileOptions>(
     DataMember("q", &TDigestQuantileOptions::q),
-    DataMember("min_count", &TDigestQuantileOptions::min_count));
+    DataMember("min_count", &TDigestQuantileOptions::min_count),
+    DataMember("scaler", &TDigestQuantileOptions::scaler));
 static auto kPivotOptionsType = GetFunctionOptionsType<PivotWiderOptions>(
     DataMember("key_names", &PivotWiderOptions::key_names),
     DataMember("unexpected_key_behavior", &PivotWiderOptions::unexpected_key_behavior));
@@ -239,15 +240,19 @@ TDigestReduceOptions::TDigestReduceOptions(Scaler scaler)
     : FunctionOptions(internal::kTDigestReduceOptionsType), scaler{scaler} {}
 constexpr char TDigestReduceOptions::kTypeName[];
 
-TDigestQuantileOptions::TDigestQuantileOptions(double q, uint32_t min_count)
+TDigestQuantileOptions::TDigestQuantileOptions(double q, uint32_t min_count,
+                                               Scaler scaler)
     : FunctionOptions(internal::kTDigestQuantileOptionsType),
       q{q},
-      min_count{min_count} {}
+      min_count{min_count},
+      scaler{scaler} {}
 
-TDigestQuantileOptions::TDigestQuantileOptions(std::vector<double> q, uint32_t min_count)
+TDigestQuantileOptions::TDigestQuantileOptions(std::vector<double> q, uint32_t min_count,
+                                               Scaler scaler)
     : FunctionOptions(internal::kTDigestQuantileOptionsType),
       q{std::move(q)},
-      min_count{min_count} {}
+      min_count{min_count},
+      scaler{scaler} {}
 constexpr char TDigestReduceOptions::kTypeName[];
 
 PivotWiderOptions::PivotWiderOptions(std::vector<std::string> key_names,
@@ -361,6 +366,16 @@ Result<Datum> TDigest(const Datum& value, const TDigestOptions& options,
 Result<Datum> TDigestMap(const Datum& value, const TDigestMapOptions& options,
                          ExecContext* ctx) {
   return CallFunction("tdigest_map", {value}, &options, ctx);
+}
+
+Result<Datum> TDigestReduce(const Datum& value, const TDigestReduceOptions& options,
+                            ExecContext* ctx) {
+  return CallFunction("tdigest_reduce", {value}, &options, ctx);
+}
+
+Result<Datum> TDigestQuantile(const Datum& value, const TDigestQuantileOptions& options,
+                              ExecContext* ctx) {
+  return CallFunction("tdigest_quantile", {value}, &options, ctx);
 }
 
 Result<Datum> Index(const Datum& value, const IndexOptions& options, ExecContext* ctx) {

--- a/cpp/src/arrow/compute/api_aggregate.cc
+++ b/cpp/src/arrow/compute/api_aggregate.cc
@@ -384,6 +384,12 @@ Result<Datum> TDigestQuantile(const Datum& value, const TDigestQuantileOptions& 
   return CallFunction("tdigest_quantile", {value}, &options, ctx);
 }
 
+Result<Datum> TDigestQuantileElementWise(const Datum& value,
+                                         const TDigestQuantileOptions& options,
+                                         ExecContext* ctx) {
+  return CallFunction("tdigest_quantile_element_wise", {value}, &options, ctx);
+}
+
 Result<Datum> Index(const Datum& value, const IndexOptions& options, ExecContext* ctx) {
   return CallFunction("index", {value}, &options, ctx);
 }

--- a/cpp/src/arrow/compute/api_aggregate.cc
+++ b/cpp/src/arrow/compute/api_aggregate.cc
@@ -147,9 +147,11 @@ static auto kTDigestMapOptionsType = GetFunctionOptionsType<TDigestMapOptions>(
     DataMember("skip_nulls", &TDigestMapOptions::skip_nulls),
     DataMember("scaler", &TDigestMapOptions::scaler));
 static auto kTDigestReduceOptionsType = GetFunctionOptionsType<TDigestReduceOptions>(
+    DataMember("delta", &TDigestReduceOptions::delta),
     DataMember("scaler", &TDigestReduceOptions::scaler));
 static auto kTDigestQuantileOptionsType = GetFunctionOptionsType<TDigestQuantileOptions>(
     DataMember("q", &TDigestQuantileOptions::q),
+    DataMember("delta", &TDigestQuantileOptions::delta),
     DataMember("min_count", &TDigestQuantileOptions::min_count),
     DataMember("scaler", &TDigestQuantileOptions::scaler));
 static auto kPivotOptionsType = GetFunctionOptionsType<PivotWiderOptions>(
@@ -236,24 +238,28 @@ TDigestMapOptions::TDigestMapOptions(uint32_t delta, uint32_t buffer_size,
       scaler{scaler} {}
 constexpr char TDigestMapOptions::kTypeName[];
 
-TDigestReduceOptions::TDigestReduceOptions(Scaler scaler)
-    : FunctionOptions(internal::kTDigestReduceOptionsType), scaler{scaler} {}
+TDigestReduceOptions::TDigestReduceOptions(uint32_t delta, Scaler scaler)
+    : FunctionOptions(internal::kTDigestReduceOptionsType),
+      delta(delta),
+      scaler{scaler} {}
 constexpr char TDigestReduceOptions::kTypeName[];
 
-TDigestQuantileOptions::TDigestQuantileOptions(double q, uint32_t min_count,
-                                               Scaler scaler)
+TDigestQuantileOptions::TDigestQuantileOptions(double q, uint32_t delta,
+                                               uint32_t min_count, Scaler scaler)
     : FunctionOptions(internal::kTDigestQuantileOptionsType),
       q{q},
+      delta(delta),
       min_count{min_count},
       scaler{scaler} {}
 
-TDigestQuantileOptions::TDigestQuantileOptions(std::vector<double> q, uint32_t min_count,
-                                               Scaler scaler)
+TDigestQuantileOptions::TDigestQuantileOptions(std::vector<double> q, uint32_t delta,
+                                               uint32_t min_count, Scaler scaler)
     : FunctionOptions(internal::kTDigestQuantileOptionsType),
       q{std::move(q)},
+      delta(delta),
       min_count{min_count},
       scaler{scaler} {}
-constexpr char TDigestReduceOptions::kTypeName[];
+constexpr char TDigestQuantileOptions::kTypeName[];
 
 PivotWiderOptions::PivotWiderOptions(std::vector<std::string> key_names,
                                      UnexpectedKeyBehavior unexpected_key_behavior)

--- a/cpp/src/arrow/compute/api_aggregate.h
+++ b/cpp/src/arrow/compute/api_aggregate.h
@@ -172,12 +172,17 @@ class ARROW_EXPORT QuantileOptions : public FunctionOptions {
 /// By default, returns the median value.
 class ARROW_EXPORT TDigestOptions : public FunctionOptions {
  public:
+  enum Scaler {
+    K0 = 0,
+    K1,
+  };
+
   explicit TDigestOptions(double q = 0.5, uint32_t delta = 100,
                           uint32_t buffer_size = 500, bool skip_nulls = true,
-                          uint32_t min_count = 0);
+                          uint32_t min_count = 0, enum Scaler scaler = K0);
   explicit TDigestOptions(std::vector<double> q, uint32_t delta = 100,
                           uint32_t buffer_size = 500, bool skip_nulls = true,
-                          uint32_t min_count = 0);
+                          uint32_t min_count = 0, enum Scaler scaler = K0);
   static constexpr char const kTypeName[] = "TDigestOptions";
   static TDigestOptions Defaults() { return TDigestOptions{}; }
 
@@ -192,6 +197,8 @@ class ARROW_EXPORT TDigestOptions : public FunctionOptions {
   bool skip_nulls;
   /// If less than this many non-null values are observed, emit null.
   uint32_t min_count;
+  /// select scaler implementation
+  enum Scaler scaler;
 };
 
 /// \brief Control Pivot kernel behavior

--- a/cpp/src/arrow/compute/api_aggregate.h
+++ b/cpp/src/arrow/compute/api_aggregate.h
@@ -244,8 +244,12 @@ class ARROW_EXPORT TDigestReduceOptions : public FunctionOptions {
 /// By default, returns the median value.
 class ARROW_EXPORT TDigestQuantileOptions : public FunctionOptions {
  public:
-  explicit TDigestQuantileOptions(double q = 0.5, uint32_t min_count = 0);
-  explicit TDigestQuantileOptions(std::vector<double> q, uint32_t min_count = 0);
+  using Scaler = TDigestOptions::Scaler;
+
+  explicit TDigestQuantileOptions(double q = 0.5, uint32_t min_count = 0,
+                                  Scaler scaler = Scaler::K1);
+  explicit TDigestQuantileOptions(std::vector<double> q, uint32_t min_count = 0,
+                                  Scaler scaler = Scaler::K1);
   static constexpr char const kTypeName[] = "TDigestQuantileOptions";
   static TDigestQuantileOptions Defaults() { return TDigestQuantileOptions{}; }
 
@@ -253,6 +257,8 @@ class ARROW_EXPORT TDigestQuantileOptions : public FunctionOptions {
   std::vector<double> q;
   /// If less than this many non-null values are observed, emit null.
   uint32_t min_count;
+  /// select scaler implementation
+  Scaler scaler;
 };
 
 /// \brief Control Pivot kernel behavior
@@ -643,7 +649,7 @@ Result<Datum> TDigest(const Datum& value,
 /// \brief Calculate centroids of a numeric array with T-Digest algorithm
 ///
 /// \param[in] value input datum, expecting Array or ChunkedArray
-/// \param[in] options see TDigestOptions for more information
+/// \param[in] options see TDigestMapOptions for more information
 /// \param[in] ctx the function execution context, optional
 /// \return resulting struct of mean and weight arrays
 ///
@@ -653,6 +659,36 @@ ARROW_EXPORT
 Result<Datum> TDigestMap(const Datum& value,
                          const TDigestMapOptions& options = TDigestMapOptions::Defaults(),
                          ExecContext* ctx = NULLPTR);
+
+/// \brief Merge multiple centroid sets into one
+///
+/// \param[in] value input centroid sets, expecting Scalar, Array or ChunkedArray of
+/// centroid structs \param[in] options see TDigestReduceOptions for more information
+/// \param[in] ctx the function execution context, optional
+/// \return resulting struct of mean and weight arrays
+///
+/// \since 22.0.0
+/// \note API not yet finalized
+ARROW_EXPORT
+Result<Datum> TDigestReduce(
+    const Datum& value,
+    const TDigestReduceOptions& options = TDigestReduceOptions::Defaults(),
+    ExecContext* ctx = NULLPTR);
+
+/// \brief Calculate the approximate quantiles using centroids with T-Digest algorithm
+///
+/// \param[in] value input centroid sets, expecting Scalar, Array or ChunkedArray of
+/// centroid structs \param[in] options see TDigestQuantileOptions for more information
+/// \param[in] ctx the function execution context, optional
+/// \return resulting struct of mean and weight arrays
+///
+/// \since 22.0.0
+/// \note API not yet finalized
+ARROW_EXPORT
+Result<Datum> TDigestQuantile(
+    const Datum& value,
+    const TDigestQuantileOptions& options = TDigestQuantileOptions::Defaults(),
+    ExecContext* ctx = NULLPTR);
 
 /// \brief Find the first index of a value in an array.
 ///

--- a/cpp/src/arrow/compute/api_aggregate.h
+++ b/cpp/src/arrow/compute/api_aggregate.h
@@ -694,6 +694,21 @@ Result<Datum> TDigestQuantile(
     const TDigestQuantileOptions& options = TDigestQuantileOptions::Defaults(),
     ExecContext* ctx = NULLPTR);
 
+/// \brief Calculate the approximate quantiles using centroids with T-Digest algorithm
+///
+/// \param[in] value input centroid sets, expecting Scalar, Array or ChunkedArray of
+/// centroid structs \param[in] options see TDigestQuantileOptions for more information
+/// \param[in] ctx the function execution context, optional
+/// \return resulting struct of mean and weight arrays
+///
+/// \since 22.0.0
+/// \note API not yet finalized
+ARROW_EXPORT
+Result<Datum> TDigestQuantileElementWise(
+    const Datum& value,
+    const TDigestQuantileOptions& options = TDigestQuantileOptions::Defaults(),
+    ExecContext* ctx = NULLPTR);
+
 /// \brief Find the first index of a value in an array.
 ///
 /// \param[in] value The array to search.

--- a/cpp/src/arrow/compute/api_aggregate.h
+++ b/cpp/src/arrow/compute/api_aggregate.h
@@ -231,10 +231,12 @@ class ARROW_EXPORT TDigestReduceOptions : public FunctionOptions {
  public:
   using Scaler = TDigestOptions::Scaler;
 
-  explicit TDigestReduceOptions(Scaler scaler = Scaler::K1);
+  explicit TDigestReduceOptions(uint32_t delta = 100, Scaler scaler = Scaler::K1);
   static constexpr char const kTypeName[] = "TDigestReduceOptions";
   static TDigestReduceOptions Defaults() { return TDigestReduceOptions{}; }
 
+  /// compression parameter, default 100
+  uint32_t delta;
   /// select scaler implementation
   Scaler scaler;
 };
@@ -246,15 +248,17 @@ class ARROW_EXPORT TDigestQuantileOptions : public FunctionOptions {
  public:
   using Scaler = TDigestOptions::Scaler;
 
-  explicit TDigestQuantileOptions(double q = 0.5, uint32_t min_count = 0,
-                                  Scaler scaler = Scaler::K1);
-  explicit TDigestQuantileOptions(std::vector<double> q, uint32_t min_count = 0,
-                                  Scaler scaler = Scaler::K1);
+  explicit TDigestQuantileOptions(double q = 0.5, uint32_t delta = 100,
+                                  uint32_t min_count = 0, Scaler scaler = Scaler::K1);
+  explicit TDigestQuantileOptions(std::vector<double> q, uint32_t delta = 100,
+                                  uint32_t min_count = 0, Scaler scaler = Scaler::K1);
   static constexpr char const kTypeName[] = "TDigestQuantileOptions";
   static TDigestQuantileOptions Defaults() { return TDigestQuantileOptions{}; }
 
   /// probability level of quantile must be between 0 and 1 inclusive
   std::vector<double> q;
+  /// compression parameter, default 100
+  uint32_t delta;
   /// If less than this many non-null values are observed, emit null.
   uint32_t min_count;
   /// select scaler implementation

--- a/cpp/src/arrow/compute/kernels/aggregate_tdigest.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_tdigest.cc
@@ -21,7 +21,6 @@
 #include "arrow/compute/registry_internal.h"
 #include "arrow/util/bit_run_reader.h"
 #include "arrow/util/tdigest_internal.h"
-
 namespace arrow {
 namespace compute {
 namespace internal {
@@ -34,29 +33,141 @@ using arrow::internal::TDigestScalerK1;
 using arrow::internal::VisitSetBitRunsVoid;
 
 struct TDigestBaseImpl : public ScalarAggregator {
-  TDigestBaseImpl(std::unique_ptr<TDigest::Scaler> scaler, uint32_t buffer_size)
+  explicit TDigestBaseImpl(std::unique_ptr<TDigest::Scaler> scaler, uint32_t buffer_size)
       : tdigest{std::move(scaler), buffer_size}, count{0}, all_valid{true} {
     auto output_size = tdigest.delta();
     out_type = struct_({field("mean", fixed_size_list(float64(), output_size), false),
                         field("weight", fixed_size_list(float64(), output_size), false),
-                        field("count", int64(), false)});
+                        field("count", uint64(), false)});
+  }
+
+  Status MergeFrom(KernelContext*, KernelState&& src) override {
+    const auto& other = checked_cast<const TDigestBaseImpl&>(src);
+    if (!this->all_valid || !other.all_valid) {
+      this->all_valid = false;
+      return Status::OK();
+    }
+    this->tdigest.Merge(other.tdigest);
+    this->count += other.count;
+    return Status::OK();
+  }
+
+  static Result<std::unique_ptr<TDigest::Scaler>> MakeScaler(
+      TDigestOptions::Scaler scaler, uint32_t delta) {
+    switch (scaler) {
+      case TDigestOptions::K0:
+        return std::make_unique<TDigestScalerK0>(delta);
+      case TDigestOptions::K1:
+        return std::make_unique<TDigestScalerK1>(delta);
+    }
+    return Status::NotImplemented("Invalid TDigest scaler");
   }
 
   TDigest tdigest;
-  int64_t count;
+  uint64_t count;
   bool all_valid;
   std::shared_ptr<DataType> out_type;
 };
 
-template <typename ArrowType>
-struct TDigestMapperImpl : public TDigestBaseImpl {
-  using ThisType = TDigestMapperImpl<ArrowType>;
+struct TDigestQuantileFinalizer : public TDigestBaseImpl {
+  template <typename... Args>
+  explicit TDigestQuantileFinalizer(std::vector<double> q, uint32_t min_count,
+                                    Args&&... args)
+      : TDigestBaseImpl(std::forward<Args>(args)...),
+        q(std::move(q)),
+        min_count(min_count) {}
+
+  Status Finalize(KernelContext* ctx, Datum* out) override {
+    const int64_t out_length = q.size();
+    auto out_data = ArrayData::Make(float64(), out_length, 0);
+    out_data->buffers.resize(2, nullptr);
+    ARROW_ASSIGN_OR_RAISE(out_data->buffers[1],
+                          ctx->Allocate(out_length * sizeof(double)));
+    double* out_buffer = out_data->template GetMutableValues<double>(1);
+
+    if (this->tdigest.is_empty() || !this->all_valid || this->count < min_count) {
+      ARROW_ASSIGN_OR_RAISE(out_data->buffers[0], ctx->AllocateBitmap(out_length));
+      std::memset(out_data->buffers[0]->mutable_data(), 0x00,
+                  out_data->buffers[0]->size());
+      std::fill(out_buffer, out_buffer + out_length, 0.0);
+      out_data->null_count = out_length;
+    } else {
+      for (int64_t i = 0; i < out_length; ++i) {
+        out_buffer[i] = this->tdigest.Quantile(this->q[i]);
+      }
+    }
+    *out = Datum(std::move(out_data));
+    return Status::OK();
+  }
+
+  std::vector<double> q;
+  uint32_t min_count;
+};
+
+struct TDigestCentroidFinalizer : public TDigestBaseImpl {
+  template <typename... Args>
+  explicit TDigestCentroidFinalizer(Args&&... args)
+      : TDigestBaseImpl(std::forward<Args>(args)...) {}
+
+  Status Finalize(KernelContext* ctx, Datum* out) override {
+    if (!this->all_valid) {
+      *out = MakeNullScalar(out_type);
+    } else {
+      // Float64Array
+      const int64_t out_length = tdigest.delta();
+      auto mean_data = ArrayData::Make(float64(), out_length, 0);
+      mean_data->buffers.resize(2, nullptr);
+      ARROW_ASSIGN_OR_RAISE(mean_data->buffers[1],
+                            ctx->Allocate(out_length * sizeof(double)));
+      double* mean_buffer = mean_data->template GetMutableValues<double>(1);
+
+      auto weight_data = ArrayData::Make(float64(), out_length, 0);
+      weight_data->buffers.resize(2, nullptr);
+      ARROW_ASSIGN_OR_RAISE(weight_data->buffers[1],
+                            ctx->Allocate(out_length * sizeof(double)));
+      double* weight_buffer = weight_data->template GetMutableValues<double>(1);
+
+      ARROW_ASSIGN_OR_RAISE(auto bitmap, ctx->AllocateBitmap(out_length));
+      auto bitmap_data = bitmap->mutable_data();
+      bit_util::SetBitsTo(bitmap_data, 0, out_length, true);
+      mean_data->buffers[0] = bitmap;
+      weight_data->buffers[0] = bitmap;
+
+      for (int64_t i = 0; i < out_length; ++i) {
+        auto maybe_c = this->tdigest.GetCentroid(i);
+        if (maybe_c) {
+          std::tie(mean_buffer[i], weight_buffer[i]) = *std::move(maybe_c);
+        } else {
+          bit_util::SetBitsTo(bitmap_data, i, out_length, false);
+          auto null_count = out_length - i;
+          std::fill(mean_buffer + i, mean_buffer + out_length, 0.0);
+          std::fill(weight_buffer + i, weight_buffer + out_length, 0.0);
+          mean_data->SetNullCount(null_count);
+          weight_data->SetNullCount(null_count);
+          break;
+        }
+      }
+
+      auto mean = std::make_shared<FixedSizeListScalar>(MakeArray(mean_data));
+      auto weight = std::make_shared<FixedSizeListScalar>(MakeArray(weight_data));
+      auto count = std::make_shared<UInt64Scalar>(this->count);
+      *out = std::make_shared<StructScalar>(
+          std::vector<std::shared_ptr<Scalar>>{mean, weight, count}, out_type);
+    }
+
+    return Status::OK();
+  }
+};
+
+template <typename ArrowType, typename TDigestFinalizer_T>
+struct TDigestInputConsumerImpl : public TDigestFinalizer_T {
   using ArrayType = typename TypeTraits<ArrowType>::ArrayType;
   using CType = typename TypeTraits<ArrowType>::CType;
 
-  TDigestMapperImpl(bool skip_nulls, uint32_t buffer_size, const DataType& in_type,
-                    std::unique_ptr<TDigest::Scaler> scaler)
-      : TDigestBaseImpl(std::move(scaler), buffer_size),
+  template <typename... Args>
+  explicit TDigestInputConsumerImpl(bool skip_nulls, const DataType& in_type,
+                                    Args&&... args)
+      : TDigestFinalizer_T(std::forward<Args>(args)...),
         skip_nulls{skip_nulls},
         decimal_scale{0} {
     if (is_decimal_type<ArrowType>::value) {
@@ -108,138 +219,110 @@ struct TDigestMapperImpl : public TDigestBaseImpl {
   int32_t decimal_scale;
 };
 
-template <typename ArrowType>
-struct TDigestImpl : public TDigestMapperImpl<ArrowType> {
-  using ThisType = TDigestImpl<ArrowType>;
-  using ArrayType = typename TypeTraits<ArrowType>::ArrayType;
-  using CType = typename TypeTraits<ArrowType>::CType;
+template <typename TDigestFinalizer_T>
+struct TDigestCentroidConsumerImpl : public TDigestFinalizer_T {
+  template <typename... Args>
+  explicit TDigestCentroidConsumerImpl(Args&&... args)
+      : TDigestFinalizer_T(std::forward<Args>(args)...) {}
 
-  using TDigestBaseImpl::all_valid;
-  using TDigestBaseImpl::count;
-  using TDigestBaseImpl::out_type;
-  using TDigestBaseImpl::tdigest;
+  Status Consume(const Scalar* scalar) {
+    const auto* input_struct_scalar = checked_cast<const StructScalar*>(scalar);
+    auto mean_array =
+        checked_cast<const FixedSizeListScalar*>(input_struct_scalar->value[0].get())
+            ->value;
+    auto weight_array =
+        checked_cast<const FixedSizeListScalar*>(input_struct_scalar->value[1].get())
+            ->value;
+    auto count = checked_cast<const UInt64Scalar*>(input_struct_scalar->value[2].get());
+    auto mean_double_array = checked_cast<const DoubleArray*>(mean_array.get());
+    auto weight_double_array = checked_cast<const DoubleArray*>(weight_array.get());
+    DCHECK_EQ(mean_double_array->length(), this->tdigest.delta());
+    DCHECK_EQ(weight_double_array->length(), this->tdigest.delta());
+    for (int64_t i = 0; i < this->tdigest.delta(); i++) {
+      if (mean_double_array->IsNull(i)) {
+        break;
+      }
+      DCHECK(weight_double_array->IsValid(i));
 
-  TDigestImpl(const TDigestOptions& options, const DataType& in_type,
-              std::unique_ptr<TDigest::Scaler> scaler)
-      : TDigestMapperImpl<ArrowType>(options.skip_nulls, options.buffer_size, in_type,
-                                     std::move(scaler)),
-        options{options} {}
-
-  Status MergeFrom(KernelContext*, KernelState&& src) override {
-    const auto& other = checked_cast<const ThisType&>(src);
-    if (!this->all_valid || !other.all_valid) {
+      this->tdigest.NanAdd(mean_double_array->Value(i), weight_double_array->Value(i));
+    }
+    this->count += count->value;
+    return Status::OK();
+  }
+  Status Consume(KernelContext*, const ExecSpan& batch) override {
+    if (!this->all_valid) return Status::OK();
+    if (batch[0].null_count() > 0) {
       this->all_valid = false;
       return Status::OK();
     }
-    this->tdigest.Merge(other.tdigest);
-    this->count += other.count;
-    return Status::OK();
-  }
-
-  Status Finalize(KernelContext* ctx, Datum* out) override {
-    const int64_t out_length = options.q.size();
-    auto out_data = ArrayData::Make(float64(), out_length, 0);
-    out_data->buffers.resize(2, nullptr);
-    ARROW_ASSIGN_OR_RAISE(out_data->buffers[1],
-                          ctx->Allocate(out_length * sizeof(double)));
-    double* out_buffer = out_data->template GetMutableValues<double>(1);
-
-    if (this->tdigest.is_empty() || !this->all_valid || this->count < options.min_count) {
-      ARROW_ASSIGN_OR_RAISE(out_data->buffers[0], ctx->AllocateBitmap(out_length));
-      std::memset(out_data->buffers[0]->mutable_data(), 0x00,
-                  out_data->buffers[0]->size());
-      std::fill(out_buffer, out_buffer + out_length, 0.0);
-      out_data->null_count = out_length;
-    } else {
-      for (int64_t i = 0; i < out_length; ++i) {
-        out_buffer[i] = this->tdigest.Quantile(this->options.q[i]);
+    if (batch[0].is_array()) {
+      std::shared_ptr<Array> array = MakeArray(batch[0].array.ToArrayData());
+      for (int i = 0; i < array->length(); ++i) {
+        ARROW_ASSIGN_OR_RAISE(auto scalar, array->GetScalar(0));
+        ARROW_RETURN_NOT_OK(Consume(scalar.get()));
       }
+    } else {
+      const Scalar* scalar = batch[0].scalar;
+      ARROW_RETURN_NOT_OK(Consume(scalar));
     }
-    *out = Datum(std::move(out_data));
     return Status::OK();
   }
-
-  const TDigestOptions options;
 };
 
 template <typename ArrowType>
-struct TDigestMapImpl : public TDigestMapperImpl<ArrowType> {
-  using ThisType = TDigestMapImpl<ArrowType>;
-  using ArrayType = typename TypeTraits<ArrowType>::ArrayType;
-  using CType = typename TypeTraits<ArrowType>::CType;
+struct TDigestImpl
+    : public TDigestInputConsumerImpl<ArrowType, TDigestQuantileFinalizer> {
+  // using TDigestBaseImpl::all_valid;
+  // using TDigestBaseImpl::count;
+  // using TDigestBaseImpl::out_type;
+  // using TDigestBaseImpl::tdigest;
 
-  using TDigestBaseImpl::all_valid;
-  using TDigestBaseImpl::count;
-  using TDigestBaseImpl::out_type;
-  using TDigestBaseImpl::tdigest;
+  explicit TDigestImpl(const TDigestOptions& options, const DataType& in_type,
+                       std::unique_ptr<TDigest::Scaler> scaler)
+      : TDigestInputConsumerImpl<ArrowType, TDigestQuantileFinalizer>(
+            // TDigestInputConsumerImpl
+            options.skip_nulls, in_type,
+            // TDigestQuantileFinalizer
+            options.q, options.min_count,
+            // TDigestBaseImpl
+            std::move(scaler), options.buffer_size) {}
+};
 
-  TDigestMapImpl(const TDigestMapOptions& options, const DataType& in_type,
-                 std::unique_ptr<TDigest::Scaler> scaler)
-      : TDigestMapperImpl<ArrowType>(options.skip_nulls, options.buffer_size, in_type,
-                                     std::move(scaler)),
-        options{options} {}
+template <typename ArrowType>
+struct TDigestMapImpl
+    : public TDigestInputConsumerImpl<ArrowType, TDigestCentroidFinalizer> {
+  explicit TDigestMapImpl(const TDigestMapOptions& options, const DataType& in_type,
+                          std::unique_ptr<TDigest::Scaler> scaler)
+      : TDigestInputConsumerImpl<ArrowType, TDigestCentroidFinalizer>(
 
-  Status MergeFrom(KernelContext*, KernelState&& src) override {
-    const auto& other = checked_cast<const ThisType&>(src);
-    if (!this->all_valid || !other.all_valid) {
-      this->all_valid = false;
-      return Status::OK();
-    }
-    this->tdigest.Merge(other.tdigest);
-    this->count += other.count;
-    return Status::OK();
-  }
+            // TDigestInputConsumerImpl
+            options.skip_nulls, in_type,
+            // TDigestCentroidFinalizer
+            // TDigestBaseImpl
+            std::move(scaler), options.buffer_size) {}
+};
 
-  Status Finalize(KernelContext* ctx, Datum* out) override {
-    if (!this->all_valid) {
-      *out = MakeNullScalar(out_type);
-    } else {
-      // Float64Array
-      const int64_t out_length = tdigest.delta();
-      auto mean_data = ArrayData::Make(float64(), out_length, 0);
-      mean_data->buffers.resize(2, nullptr);
-      ARROW_ASSIGN_OR_RAISE(mean_data->buffers[1],
-                            ctx->Allocate(out_length * sizeof(double)));
-      double* mean_buffer = mean_data->template GetMutableValues<double>(1);
+struct TDigestReduceImpl : public TDigestCentroidConsumerImpl<TDigestCentroidFinalizer> {
+  explicit TDigestReduceImpl(const TDigestReduceOptions& options,
+                             std::unique_ptr<TDigest::Scaler> scaler, uint32_t size)
+      : TDigestCentroidConsumerImpl<TDigestCentroidFinalizer>(
+            // TDigestCentroidConsumerImpl
+            // TDigestCentroidFinalizer
+            // TDigestBaseImpl
+            std::move(scaler), size) {}
+};
 
-      auto weight_data = ArrayData::Make(float64(), out_length, 0);
-      weight_data->buffers.resize(2, nullptr);
-      ARROW_ASSIGN_OR_RAISE(weight_data->buffers[1],
-                            ctx->Allocate(out_length * sizeof(double)));
-      double* weight_buffer = weight_data->template GetMutableValues<double>(1);
+struct TDigestQuantileImpl
+    : public TDigestCentroidConsumerImpl<TDigestQuantileFinalizer> {
+  explicit TDigestQuantileImpl(const TDigestQuantileOptions& options,
+                               std::unique_ptr<TDigest::Scaler> scaler, uint32_t size)
+      : TDigestCentroidConsumerImpl<TDigestQuantileFinalizer>(
 
-      ARROW_ASSIGN_OR_RAISE(auto bitmap, ctx->AllocateBitmap(out_length));
-      auto bitmap_data = bitmap->mutable_data();
-      bit_util::SetBitsTo(bitmap_data, 0, out_length, true);
-      mean_data->buffers[0] = bitmap;
-      weight_data->buffers[0] = bitmap;
-
-      for (int64_t i = 0; i < out_length; ++i) {
-        auto maybe_c = this->tdigest.GetCentroid(i);
-        if (maybe_c) {
-          std::tie(mean_buffer[i], weight_buffer[i]) = *std::move(maybe_c);
-        } else {
-          bit_util::SetBitsTo(bitmap_data, i, out_length, false);
-          auto null_count = out_length - i;
-          std::fill(mean_buffer + i, mean_buffer + out_length, 0.0);
-          std::fill(weight_buffer + i, weight_buffer + out_length, 0.0);
-          mean_data->SetNullCount(null_count);
-          weight_data->SetNullCount(null_count);
-          break;
-        }
-      }
-
-      auto mean = std::make_shared<FixedSizeListScalar>(MakeArray(mean_data));
-      auto weight = std::make_shared<FixedSizeListScalar>(MakeArray(weight_data));
-      auto count = std::make_shared<Int64Scalar>(this->count);
-      *out = std::make_shared<StructScalar>(
-          std::vector<std::shared_ptr<Scalar>>{mean, weight, count}, out_type);
-    }
-
-    return Status::OK();
-  }
-
-  const TDigestMapOptions options;
+            // TDigestCentroidConsumerImpl
+            // TDigestQuantileFinalizer
+            options.q, options.min_count,
+            // TDigestBaseImpl
+            std::move(scaler), size) {}
 };
 
 template <template <typename> typename TDigestImpl_T, typename TDigestOptions_T>
@@ -263,31 +346,66 @@ struct TDigestInitState {
 
   template <typename Type>
   enable_if_number<Type, Status> Visit(const Type&) {
-    ARROW_ASSIGN_OR_RAISE(auto scaler, MakeScaler());
+    ARROW_ASSIGN_OR_RAISE(auto scaler,
+                          TDigestBaseImpl::MakeScaler(options.scaler, options.delta));
     state.reset(new TDigestImpl_T<Type>(options, in_type, std::move(scaler)));
     return Status::OK();
   }
 
   template <typename Type>
   enable_if_decimal<Type, Status> Visit(const Type&) {
-    ARROW_ASSIGN_OR_RAISE(auto scaler, MakeScaler());
+    ARROW_ASSIGN_OR_RAISE(auto scaler,
+                          TDigestBaseImpl::MakeScaler(options.scaler, options.delta));
     state.reset(new TDigestImpl_T<Type>(options, in_type, std::move(scaler)));
     return Status::OK();
-  }
-
-  Result<std::unique_ptr<TDigest::Scaler>> MakeScaler() {
-    switch (options.scaler) {
-      case TDigestOptions::K0:
-        return std::make_unique<TDigestScalerK0>(options.delta);
-      case TDigestOptions::K1:
-        return std::make_unique<TDigestScalerK1>(options.delta);
-    }
-    return Status::NotImplemented("Invalid TDigest scaler");
   }
 
   Result<std::unique_ptr<KernelState>> Create() {
     RETURN_NOT_OK(VisitTypeInline(in_type, this));
     return std::move(state);
+  }
+};
+
+struct TDigestCentroidTypeMatcher : public TypeMatcher {
+  ~TDigestCentroidTypeMatcher() override = default;
+
+  static Result<uint32_t> getDelta(const DataType& type) {
+    if (Type::STRUCT == type.id()) {
+      const auto& input_struct_type = checked_cast<const StructType&>(type);
+      if (3 == input_struct_type.num_fields()) {
+        if (Type::FIXED_SIZE_LIST == input_struct_type.field(0)->type()->id() &&
+            input_struct_type.field(0)->type()->Equals(
+                input_struct_type.field(1)->type()) &&
+            Type::UINT64 == input_struct_type.field(2)->type()->id()) {
+          auto fsl = checked_cast<const FixedSizeListType*>(
+              input_struct_type.field(0)->type().get());
+          return fsl->list_size();
+        }
+      }
+    }
+    return Status::Invalid("Type ", type.ToString(), " does not match ",
+                           ToStringStatic());
+  }
+
+  bool Matches(const DataType& type) const override { return getDelta(type).ok(); }
+
+  static std::string ToStringStatic() {
+    return "struct{mean:fixed_size_list<item: double>[N], weight:fixed_size_list<item: "
+           "double>[N], count:int64}";
+  }
+  std::string ToString() const override { return ToStringStatic(); }
+
+  bool Equals(const TypeMatcher& other) const override {
+    if (this == &other) {
+      return true;
+    }
+    auto casted = dynamic_cast<const TDigestCentroidTypeMatcher*>(&other);
+    return casted != nullptr;
+  }
+
+  static std::shared_ptr<TDigestCentroidTypeMatcher> getMatcher() {
+    static auto matcher = std::make_shared<TDigestCentroidTypeMatcher>();
+    return matcher;
   }
 };
 
@@ -305,6 +423,24 @@ Result<std::unique_ptr<KernelState>> TDigestMapInit(KernelContext* ctx,
   return visitor.Create();
 }
 
+Result<std::unique_ptr<KernelState>> TDigestReduceInit(KernelContext* ctx,
+                                                       const KernelInitArgs& args) {
+  ARROW_ASSIGN_OR_RAISE(uint32_t delta,
+                        TDigestCentroidTypeMatcher::getDelta(*args.inputs[0].type));
+  auto options = static_cast<const TDigestReduceOptions&>(*args.options);
+  ARROW_ASSIGN_OR_RAISE(auto scaler, TDigestBaseImpl::MakeScaler(options.scaler, delta));
+  return std::make_unique<TDigestReduceImpl>(options, std::move(scaler), delta);
+}
+
+Result<std::unique_ptr<KernelState>> TDigestQuantileInit(KernelContext* ctx,
+                                                         const KernelInitArgs& args) {
+  ARROW_ASSIGN_OR_RAISE(uint32_t delta,
+                        TDigestCentroidTypeMatcher::getDelta(*args.inputs[0].type));
+  auto options = static_cast<const TDigestQuantileOptions&>(*args.options);
+  ARROW_ASSIGN_OR_RAISE(auto scaler, TDigestBaseImpl::MakeScaler(options.scaler, delta));
+  return std::make_unique<TDigestQuantileImpl>(options, std::move(scaler), delta);
+}
+
 void AddTDigestKernels(KernelInit init,
                        const std::vector<std::shared_ptr<DataType>>& types,
                        ScalarAggregateFunction* func) {
@@ -314,8 +450,8 @@ void AddTDigestKernels(KernelInit init,
   }
 }
 
-Result<TypeHolder> TDigestMapType(KernelContext* ctx,
-                                  const std::vector<TypeHolder>& types) {
+Result<TypeHolder> TDigestMapReduceType(KernelContext* ctx,
+                                        const std::vector<TypeHolder>& types) {
   auto base = checked_cast<TDigestBaseImpl*>(ctx->state());
   return base->out_type;
 }
@@ -324,9 +460,21 @@ void AddTDigestMapKernels(KernelInit init,
                           const std::vector<std::shared_ptr<DataType>>& types,
                           ScalarAggregateFunction* func) {
   for (const auto& ty : types) {
-    auto sig = KernelSignature::Make({InputType(ty->id())}, TDigestMapType);
+    auto sig = KernelSignature::Make({InputType(ty->id())}, TDigestMapReduceType);
     AddAggKernel(std::move(sig), init, func);
   }
+}
+
+void AddTDigestReduceKernels(KernelInit init, ScalarAggregateFunction* func) {
+  auto sig = KernelSignature::Make({InputType(TDigestCentroidTypeMatcher::getMatcher())},
+                                   TDigestMapReduceType);
+  AddAggKernel(std::move(sig), init, func);
+}
+
+void AddTDigestQuantileKernels(KernelInit init, ScalarAggregateFunction* func) {
+  auto sig = KernelSignature::Make({InputType(TDigestCentroidTypeMatcher::getMatcher())},
+                                   float64());
+  AddAggKernel(std::move(sig), init, func);
 }
 
 const FunctionDoc tdigest_doc{
@@ -338,6 +486,22 @@ const FunctionDoc tdigest_doc{
     "TDigestOptions"};
 
 const FunctionDoc tdigest_map_doc{
+    "Calculate centroids with T-Digest algorithm",
+    ("By default, 0.5 quantile (median) is returned.\n"
+     "Nulls and NaNs are ignored.\n"
+     "An array of nulls is returned if there is no valid data point."),
+    {"array"},
+    "TDigestMapOptions"};
+
+const FunctionDoc tdigest_reduce_doc{
+    "Merge multiple centroid sets to single set with T-Digest algorithm",
+    ("By default, 0.5 quantile (median) is returned.\n"
+     "Nulls and NaNs are ignored.\n"
+     "An array of nulls is returned if there is no valid data point."),
+    {"array"},
+    "TDigestMapOptions"};
+
+const FunctionDoc tdigest_quantile_doc{
     "Calculate centroids with T-Digest algorithm",
     ("By default, 0.5 quantile (median) is returned.\n"
      "Nulls and NaNs are ignored.\n"
@@ -367,6 +531,22 @@ std::shared_ptr<ScalarAggregateFunction> AddTDigestMapAggKernels() {
       "tdigest_map", Arity::Unary(), tdigest_map_doc, &default_tdigest_options);
   AddTDigestMapKernels(TDigestMapInit, NumericTypes(), func.get());
   AddTDigestMapKernels(TDigestMapInit, {decimal128(1, 1), decimal256(1, 1)}, func.get());
+  return func;
+}
+
+std::shared_ptr<ScalarAggregateFunction> AddTDigestReduceAggKernels() {
+  static auto default_tdigest_options = TDigestReduceOptions::Defaults();
+  auto func = std::make_shared<ScalarAggregateFunction>(
+      "tdigest_reduce", Arity::Unary(), tdigest_reduce_doc, &default_tdigest_options);
+  AddTDigestReduceKernels(TDigestReduceInit, func.get());
+  return func;
+}
+
+std::shared_ptr<ScalarAggregateFunction> AddTDigestQuantileAggKernels() {
+  static auto default_tdigest_options = TDigestMapOptions::Defaults();
+  auto func = std::make_shared<ScalarAggregateFunction>(
+      "tdigest_quantile", Arity::Unary(), tdigest_quantile_doc, &default_tdigest_options);
+  AddTDigestQuantileKernels(TDigestQuantileInit, func.get());
   return func;
 }
 
@@ -414,6 +594,10 @@ void RegisterScalarAggregateTDigest(FunctionRegistry* registry) {
   DCHECK_OK(registry->AddFunction(tdigest));
   auto tdigest_map = AddTDigestMapAggKernels();
   DCHECK_OK(registry->AddFunction(tdigest_map));
+  auto tdigest_merge = AddTDigestReduceAggKernels();
+  DCHECK_OK(registry->AddFunction(tdigest_merge));
+  auto tdigest_quantile = AddTDigestQuantileAggKernels();
+  DCHECK_OK(registry->AddFunction(tdigest_quantile));
 
   auto approx_median = AddApproximateMedianAggKernels(tdigest.get());
   DCHECK_OK(registry->AddFunction(approx_median));

--- a/cpp/src/arrow/compute/kernels/aggregate_tdigest.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_tdigest.cc
@@ -397,9 +397,9 @@ struct TDigestCentroidTypeMatcher : public TypeMatcher {
         if (Type::FIXED_SIZE_LIST == input_struct_type.field(0)->type()->id() &&
             input_struct_type.field(0)->type()->Equals(
                 input_struct_type.field(1)->type()) &&
-            Type::UINT64 == input_struct_type.field(2)->type()->id() &&
+            Type::DOUBLE == input_struct_type.field(2)->type()->id() &&
             Type::DOUBLE == input_struct_type.field(3)->type()->id() &&
-            Type::DOUBLE == input_struct_type.field(4)->type()->id()) {
+            Type::UINT64 == input_struct_type.field(4)->type()->id()) {
           auto fsl = checked_cast<const FixedSizeListType*>(
               input_struct_type.field(0)->type().get());
           return fsl->list_size();

--- a/cpp/src/arrow/compute/kernels/aggregate_test.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_test.cc
@@ -4559,8 +4559,8 @@ TEST(TestTDigestMapKernel, Options) {
   auto output_type =
       struct_({field("mean", fixed_size_list(float64(), 5), false),
                field("weight", fixed_size_list(float64(), 5), false),
-               field("count", uint64(), false), field("min", float64(), true),
-               field("max", float64(), true)});
+               field("min", float64(), true), field("max", float64(), true),
+               field("count", uint64(), false)});
   TDigestMapOptions keep_nulls(/*delta=*/5, /*buffer_size=*/500,
                                /*skip_nulls=*/false,
                                /*scaler=*/TDigestMapOptions::Scaler::K0);
@@ -4572,31 +4572,31 @@ TEST(TestTDigestMapKernel, Options) {
       TDigestMap(ArrayFromJSON(input_type, "[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]"), keep_nulls),
       ResultWith(ScalarFromJSON(output_type,
                                 "{\"mean\":[1.5, 3.5, 5.5, null, null],\"weight\":[2, 2, "
-                                "2, null, null],\"count\":6,\"min\":1.0,\"max\":6.0}")));
+                                "2, null, null],\"min\":1.0,\"max\":6.0,\"count\":6}")));
   EXPECT_THAT(
       TDigestMap(ArrayFromJSON(input_type, "[1.0, 2.0, 3.0, 4.0, 5.0]"), keep_nulls),
       ResultWith(ScalarFromJSON(output_type,
                                 "{\"mean\":[1.5, 3.5, 5.0, null, null],\"weight\":[2, 2, "
-                                "1, null, null],\"count\":5,\"min\":1.0,\"max\":5.0}")));
+                                "1, null, null],\"min\":1.0,\"max\":5.0,\"count\":5}")));
   EXPECT_THAT(
       TDigestMap(ArrayFromJSON(input_type, "[1.0, 2.0, 3.0, 4.0]"), keep_nulls),
       ResultWith(ScalarFromJSON(
           output_type,
           "{\"mean\":[1.0, 2.0, 3.0, 4.0, "
-          "null],\"weight\":[1,1,1,1,null],\"count\":4,\"min\":1.0,\"max\":4.0}")));
+          "null],\"weight\":[1,1,1,1,null],\"min\":1.0,\"max\":4.0,\"count\":4}")));
 
   EXPECT_THAT(
       TDigestMap(ArrayFromJSON(input_type, "[1.0, 2.0, 3.0]"), keep_nulls),
       ResultWith(ScalarFromJSON(output_type,
                                 "{\"mean\":[1.0,2.0,3.0,null,null],\"weight\":[1,"
-                                "1,1,null,null],\"count\":3,\"min\":1.0,\"max\":3.0}")));
+                                "1,1,null,null],\"min\":1.0,\"max\":3.0,\"count\":3}")));
   EXPECT_THAT(TDigestMap(ArrayFromJSON(input_type, "[1.0, 2.0, 3.0, null]"), keep_nulls),
               ResultWith(ScalarFromJSON(output_type, "null")));
   EXPECT_THAT(TDigestMap(ScalarFromJSON(input_type, "1.0"), keep_nulls),
               ResultWith(ScalarFromJSON(
                   output_type,
                   "{\"mean\":[1.0,null,null,null,null],\"weight\":["
-                  "1,null,null,null,null],\"count\":1,\"min\":1.0,\"max\":1.0}")));
+                  "1,null,null,null,null],\"min\":1.0,\"max\":1.0,\"count\":1}")));
   EXPECT_THAT(TDigestMap(ScalarFromJSON(input_type, "null"), keep_nulls),
               ResultWith(ScalarFromJSON(output_type, "null")));
 
@@ -4604,61 +4604,60 @@ TEST(TestTDigestMapKernel, Options) {
       TDigestMap(ArrayFromJSON(input_type, "[1.0, 2.0, 3.0, null]"), skip_nulls),
       ResultWith(ScalarFromJSON(output_type,
                                 "{\"mean\":[1.0,2.0,3.0,null,null],\"weight\":[1,"
-                                "1,1,null,null],\"count\":3,\"min\":1.0,\"max\":3.0}")));
+                                "1,1,null,null],\"min\":1.0,\"max\":3.0,\"count\":3}")));
   EXPECT_THAT(TDigestMap(ArrayFromJSON(input_type, "[1.0, 2.0, null]"), skip_nulls),
               ResultWith(ScalarFromJSON(
                   output_type,
                   "{\"mean\":[1.0,2.0,null,null,null],\"weight\":["
-                  "1,1,null,null,null],\"count\":2,\"min\":1.0,\"max\":2.0}")));
+                  "1,1,null,null,null],\"min\":1.0,\"max\":2.0,\"count\":2}")));
   EXPECT_THAT(TDigestMap(ScalarFromJSON(input_type, "1.0"), skip_nulls),
               ResultWith(ScalarFromJSON(
                   output_type,
                   "{\"mean\":[1.0,null,null,null,null],\"weight\":["
-                  "1,null,null,null,null],\"count\":1,\"min\":1.0,\"max\":1.0}")));
+                  "1,null,null,null,null],\"min\":1.0,\"max\":1.0,\"count\":1}")));
   EXPECT_THAT(TDigestMap(ScalarFromJSON(input_type, "null"), skip_nulls),
               ResultWith(ScalarFromJSON(
                   output_type,
                   "{\"mean\":[null,null,null,null,null],\"weight\":"
-                  "[null,null,null,null,null],\"count\":0,\"min\":null,\"max\":null}")));
+                  "[null,null,null,null,null],\"min\":null,\"max\":null,\"count\":0}")));
 }
 
 TEST(TestTDigestReduceKernel, Basic) {
   auto type = struct_({field("mean", fixed_size_list(float64(), 5), false),
                        field("weight", fixed_size_list(float64(), 5), false),
-                       field("count", uint64(), false), field("min", float64(), true),
-                       field("max", float64(), true)});
+                       field("min", float64(), true), field("max", float64(), true),
+                       field("count", uint64(), false)});
   TDigestReduceOptions options(/*scaler=*/TDigestMapOptions::Scaler::K0);
   EXPECT_THAT(
       TDigestReduce(
           ArrayFromJSON(type,
                         "["
                         "{\"mean\":[1.5, 3.5, 5.5, null, null],\"weight\":[2, "
-                        "2, 2, null, null],\"count\":6,\"min\":1.0,\"max\":6.0},"
+                        "2, 2, null, null],\"min\":1.0,\"max\":6.0,\"count\":6},"
                         "{\"mean\":[1.5, 3.5, 5.5, null, null],\"weight\":[2, "
-                        "2, 2, null, null],\"count\":6,\"min\":1.0,\"max\":6.0}"
+                        "2, 2, null, null],\"min\":1.0,\"max\":6.0,\"count\":6}"
                         "]"),
           options),
       ResultWith(ScalarFromJSON(type,
                                 "{\"mean\":[1.5, 3.5, 5.5, null, null],\"weight\":[4, 4, "
-                                "4, null, null],\"count\":12,\"min\":1.0,\"max\":6.0}")));
+                                "4, null, null],\"min\":1.0,\"max\":6.0,\"count\":12}")));
 
   EXPECT_THAT(
       TDigestReduce(
           ScalarFromJSON(type,
                          "{\"mean\":[1.5, 3.5, 5.5, null, null],\"weight\":[2, "
-                         "2, 2, null, null],\"count\":6,\"min\":1.0,\"max\":6.0}"),
+                         "2, 2, null, null],\"min\":1.0,\"max\":6.0,\"count\":6}"),
           options),
       ResultWith(ScalarFromJSON(type,
                                 "{\"mean\":[1.5, 3.5, 5.5, null, null],\"weight\":[2, 2, "
-                                "2, null, null],\"count\":6,\"min\":1.0,\"max\":6.0}")));
+                                "2, null, null],\"min\":1.0,\"max\":6.0,\"count\":6}")));
 }
 
 TEST(TestTDigestQuantileKernel, Basic) {
-  auto input_type =
-      struct_({field("mean", fixed_size_list(float64(), 5), false),
-               field("weight", fixed_size_list(float64(), 5), false),
-               field("count", uint64(), false), field("min", float64(), true),
-               field("max", float64(), true)});
+  auto input_type = struct_({field("mean", fixed_size_list(float64(), 5), false),
+                             field("weight", fixed_size_list(float64(), 5), false),
+                             field("min", float64(), true), field("max", float64(), true),
+                             field("count", uint64(), false)});
 
   auto output_type = float64();
 
@@ -4666,9 +4665,9 @@ TEST(TestTDigestQuantileKernel, Basic) {
       ArrayFromJSON(input_type,
                     "["
                     "{\"mean\":[1.5, 3.5, 5.5, null, null],\"weight\":[2, "
-                    "2, 2, null, null],\"count\":6,\"min\":1.0,\"max\":6.0},"
+                    "2, 2, null, null],\"min\":1.0,\"max\":6.0,\"count\":6},"
                     "{\"mean\":[1.5, 3.5, 5.5, null, null],\"weight\":[2, "
-                    "2, 2, null, null],\"count\":6,\"min\":1.0,\"max\":6.0}"
+                    "2, 2, null, null],\"min\":1.0,\"max\":6.0,\"count\":6}"
                     "]");
 
   TDigestQuantileOptions multiple(/*q=*/{0.1, 0.5, 0.9}, /*min_count=*/12);
@@ -4681,11 +4680,10 @@ TEST(TestTDigestQuantileKernel, Basic) {
 }
 
 TEST(TestTDigestMapReduceQuantileKernel, Basic) {
-  auto input_type =
-      struct_({field("mean", fixed_size_list(float64(), 5), false),
-               field("weight", fixed_size_list(float64(), 5), false),
-               field("count", uint64(), false), field("min", float64(), true),
-               field("max", float64(), true)});
+  auto input_type = struct_({field("mean", fixed_size_list(float64(), 5), false),
+                             field("weight", fixed_size_list(float64(), 5), false),
+                             field("min", float64(), true), field("max", float64(), true),
+                             field("count", uint64(), false)});
 
   auto output_type = float64();
 
@@ -4693,9 +4691,9 @@ TEST(TestTDigestMapReduceQuantileKernel, Basic) {
       ArrayFromJSON(input_type,
                     "["
                     "{\"mean\":[1.5, 3.5, 5.5, null, null],\"weight\":[2, "
-                    "2, 2, null, null],\"count\":6,\"min\":1.0,\"max\":6.0},"
+                    "2, 2, null, null],\"min\":1.0,\"max\":6.0,\"count\":6},"
                     "{\"mean\":[1.5, 3.5, 5.5, null, null],\"weight\":[2, "
-                    "2, 2, null, null],\"count\":6,\"min\":1.0,\"max\":6.0}"
+                    "2, 2, null, null],\"min\":1.0,\"max\":6.0,\"count\":6}"
                     "]");
 
   TDigestQuantileOptions multiple(/*q=*/{0.1, 0.5, 0.9}, /*min_count=*/12);

--- a/cpp/src/arrow/compute/kernels/aggregate_test.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_test.cc
@@ -4640,6 +4640,32 @@ TEST(TestTDigestReduceKernel, Basic) {
               ResultWith(ScalarFromJSON(type,
                                         "{\"mean\":[1.5, 3.5, 5.5],\"weight\":[2, 2, "
                                         "2],\"min\":1.0,\"max\":6.0,\"count\":6}")));
+
+  EXPECT_THAT(TDigestReduce(
+                  ArrayFromJSON(
+                      type,
+                      "["
+                      "{\"mean\":[],\"weight\":[],\"min\":null,\"max\":null,\"count\":0},"
+                      "{\"mean\":[1.5, 3.5, 5.5],\"weight\":[2, 2, "
+                      "2],\"min\":1.0,\"max\":6.0,\"count\":6}"
+                      "]"),
+                  options),
+              ResultWith(ScalarFromJSON(type,
+                                        "{\"mean\":[1.5, 3.5, 5.5],\"weight\":[2, 2, "
+                                        "2],\"min\":1.0,\"max\":6.0,\"count\":6}")));
+
+  EXPECT_THAT(TDigestReduce(
+                  ArrayFromJSON(
+                      type,
+                      "["
+                      "{\"mean\":[1.5, 3.5, 5.5],\"weight\":[2, 2, "
+                      "2],\"min\":1.0,\"max\":6.0,\"count\":6},"
+                      "{\"mean\":[],\"weight\":[],\"min\":null,\"max\":null,\"count\":0}"
+                      "]"),
+                  options),
+              ResultWith(ScalarFromJSON(type,
+                                        "{\"mean\":[1.5, 3.5, 5.5],\"weight\":[2, "
+                                        "2, 2],\"min\":1.0,\"max\":6.0,\"count\":6}")));
 }
 
 TEST(TestTDigestQuantileKernel, Basic) {

--- a/cpp/src/arrow/compute/kernels/aggregate_test.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_test.cc
@@ -4557,8 +4557,8 @@ TEST(TestTDigestKernel, Options) {
 TEST(TestTDigestMapKernel, Options) {
   auto input_type = float64();
   auto output_type =
-      struct_({field("mean", fixed_size_list(float64(), 5), false),
-               field("weight", fixed_size_list(float64(), 5), false),
+      struct_({field("mean", list(field("item", float64(), false)), false),
+               field("weight", list(field("item", float64(), false)), false),
                field("min", float64(), true), field("max", float64(), true),
                field("count", uint64(), false)});
   TDigestMapOptions keep_nulls(/*delta=*/5, /*buffer_size=*/500,
@@ -4571,107 +4571,96 @@ TEST(TestTDigestMapKernel, Options) {
   EXPECT_THAT(
       TDigestMap(ArrayFromJSON(input_type, "[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]"), keep_nulls),
       ResultWith(ScalarFromJSON(output_type,
-                                "{\"mean\":[1.5, 3.5, 5.5, null, null],\"weight\":[2, 2, "
-                                "2, null, null],\"min\":1.0,\"max\":6.0,\"count\":6}")));
+                                "{\"mean\":[1.5, 3.5, 5.5],\"weight\":[2, 2, "
+                                "2],\"min\":1.0,\"max\":6.0,\"count\":6}")));
   EXPECT_THAT(
       TDigestMap(ArrayFromJSON(input_type, "[1.0, 2.0, 3.0, 4.0, 5.0]"), keep_nulls),
       ResultWith(ScalarFromJSON(output_type,
-                                "{\"mean\":[1.5, 3.5, 5.0, null, null],\"weight\":[2, 2, "
-                                "1, null, null],\"min\":1.0,\"max\":5.0,\"count\":5}")));
-  EXPECT_THAT(
-      TDigestMap(ArrayFromJSON(input_type, "[1.0, 2.0, 3.0, 4.0]"), keep_nulls),
-      ResultWith(ScalarFromJSON(
-          output_type,
-          "{\"mean\":[1.0, 2.0, 3.0, 4.0, "
-          "null],\"weight\":[1,1,1,1,null],\"min\":1.0,\"max\":4.0,\"count\":4}")));
+                                "{\"mean\":[1.5, 3.5, 5.0],\"weight\":[2, 2, "
+                                "1],\"min\":1.0,\"max\":5.0,\"count\":5}")));
+  EXPECT_THAT(TDigestMap(ArrayFromJSON(input_type, "[1.0, 2.0, 3.0, 4.0]"), keep_nulls),
+              ResultWith(ScalarFromJSON(
+                  output_type,
+                  "{\"mean\":[1.0, 2.0, 3.0, "
+                  "4.0],\"weight\":[1,1,1,1],\"min\":1.0,\"max\":4.0,\"count\":4}")));
 
-  EXPECT_THAT(
-      TDigestMap(ArrayFromJSON(input_type, "[1.0, 2.0, 3.0]"), keep_nulls),
-      ResultWith(ScalarFromJSON(output_type,
-                                "{\"mean\":[1.0,2.0,3.0,null,null],\"weight\":[1,"
-                                "1,1,null,null],\"min\":1.0,\"max\":3.0,\"count\":3}")));
+  EXPECT_THAT(TDigestMap(ArrayFromJSON(input_type, "[1.0, 2.0, 3.0]"), keep_nulls),
+              ResultWith(ScalarFromJSON(output_type,
+                                        "{\"mean\":[1.0,2.0,3.0],\"weight\":[1,"
+                                        "1,1],\"min\":1.0,\"max\":3.0,\"count\":3}")));
   EXPECT_THAT(TDigestMap(ArrayFromJSON(input_type, "[1.0, 2.0, 3.0, null]"), keep_nulls),
               ResultWith(ScalarFromJSON(output_type, "null")));
   EXPECT_THAT(TDigestMap(ScalarFromJSON(input_type, "1.0"), keep_nulls),
-              ResultWith(ScalarFromJSON(
-                  output_type,
-                  "{\"mean\":[1.0,null,null,null,null],\"weight\":["
-                  "1,null,null,null,null],\"min\":1.0,\"max\":1.0,\"count\":1}")));
+              ResultWith(ScalarFromJSON(output_type,
+                                        "{\"mean\":[1.0],\"weight\":["
+                                        "1],\"min\":1.0,\"max\":1.0,\"count\":1}")));
   EXPECT_THAT(TDigestMap(ScalarFromJSON(input_type, "null"), keep_nulls),
               ResultWith(ScalarFromJSON(output_type, "null")));
 
-  EXPECT_THAT(
-      TDigestMap(ArrayFromJSON(input_type, "[1.0, 2.0, 3.0, null]"), skip_nulls),
-      ResultWith(ScalarFromJSON(output_type,
-                                "{\"mean\":[1.0,2.0,3.0,null,null],\"weight\":[1,"
-                                "1,1,null,null],\"min\":1.0,\"max\":3.0,\"count\":3}")));
+  EXPECT_THAT(TDigestMap(ArrayFromJSON(input_type, "[1.0, 2.0, 3.0, null]"), skip_nulls),
+              ResultWith(ScalarFromJSON(output_type,
+                                        "{\"mean\":[1.0,2.0,3.0],\"weight\":[1,"
+                                        "1,1],\"min\":1.0,\"max\":3.0,\"count\":3}")));
   EXPECT_THAT(TDigestMap(ArrayFromJSON(input_type, "[1.0, 2.0, null]"), skip_nulls),
-              ResultWith(ScalarFromJSON(
-                  output_type,
-                  "{\"mean\":[1.0,2.0,null,null,null],\"weight\":["
-                  "1,1,null,null,null],\"min\":1.0,\"max\":2.0,\"count\":2}")));
+              ResultWith(ScalarFromJSON(output_type,
+                                        "{\"mean\":[1.0,2.0],\"weight\":["
+                                        "1,1],\"min\":1.0,\"max\":2.0,\"count\":2}")));
   EXPECT_THAT(TDigestMap(ScalarFromJSON(input_type, "1.0"), skip_nulls),
-              ResultWith(ScalarFromJSON(
-                  output_type,
-                  "{\"mean\":[1.0,null,null,null,null],\"weight\":["
-                  "1,null,null,null,null],\"min\":1.0,\"max\":1.0,\"count\":1}")));
+              ResultWith(ScalarFromJSON(output_type,
+                                        "{\"mean\":[1.0],\"weight\":["
+                                        "1],\"min\":1.0,\"max\":1.0,\"count\":1}")));
   EXPECT_THAT(TDigestMap(ScalarFromJSON(input_type, "null"), skip_nulls),
-              ResultWith(ScalarFromJSON(
-                  output_type,
-                  "{\"mean\":[null,null,null,null,null],\"weight\":"
-                  "[null,null,null,null,null],\"min\":null,\"max\":null,\"count\":0}")));
+              ResultWith(ScalarFromJSON(output_type,
+                                        "{\"mean\":[],\"weight\":"
+                                        "[],\"min\":null,\"max\":null,\"count\":0}")));
 }
 
 TEST(TestTDigestReduceKernel, Basic) {
-  auto type = struct_({field("mean", fixed_size_list(float64(), 5), false),
-                       field("weight", fixed_size_list(float64(), 5), false),
+  auto type = struct_({field("mean", list(field("item", float64(), false)), false),
+                       field("weight", list(field("item", float64(), false)), false),
                        field("min", float64(), true), field("max", float64(), true),
                        field("count", uint64(), false)});
-  TDigestReduceOptions options(/*scaler=*/TDigestMapOptions::Scaler::K0);
-  EXPECT_THAT(
-      TDigestReduce(
-          ArrayFromJSON(type,
-                        "["
-                        "{\"mean\":[1.5, 3.5, 5.5, null, null],\"weight\":[2, "
-                        "2, 2, null, null],\"min\":1.0,\"max\":6.0,\"count\":6},"
-                        "{\"mean\":[1.5, 3.5, 5.5, null, null],\"weight\":[2, "
-                        "2, 2, null, null],\"min\":1.0,\"max\":6.0,\"count\":6}"
-                        "]"),
-          options),
-      ResultWith(ScalarFromJSON(type,
-                                "{\"mean\":[1.5, 3.5, 5.5, null, null],\"weight\":[4, 4, "
-                                "4, null, null],\"min\":1.0,\"max\":6.0,\"count\":12}")));
+  TDigestReduceOptions options(/*delta=*/5, /*scaler=*/TDigestMapOptions::Scaler::K0);
+  EXPECT_THAT(TDigestReduce(ArrayFromJSON(type,
+                                          "["
+                                          "{\"mean\":[1.5, 3.5, 5.5],\"weight\":[2, "
+                                          "2, 2],\"min\":1.0,\"max\":6.0,\"count\":6},"
+                                          "{\"mean\":[1.5, 3.5, 5.5],\"weight\":[2, "
+                                          "2, 2],\"min\":1.0,\"max\":6.0,\"count\":6}"
+                                          "]"),
+                            options),
+              ResultWith(ScalarFromJSON(type,
+                                        "{\"mean\":[1.5, 3.5, 5.5],\"weight\":[4, 4, "
+                                        "4],\"min\":1.0,\"max\":6.0,\"count\":12}")));
 
-  EXPECT_THAT(
-      TDigestReduce(
-          ScalarFromJSON(type,
-                         "{\"mean\":[1.5, 3.5, 5.5, null, null],\"weight\":[2, "
-                         "2, 2, null, null],\"min\":1.0,\"max\":6.0,\"count\":6}"),
-          options),
-      ResultWith(ScalarFromJSON(type,
-                                "{\"mean\":[1.5, 3.5, 5.5, null, null],\"weight\":[2, 2, "
-                                "2, null, null],\"min\":1.0,\"max\":6.0,\"count\":6}")));
+  EXPECT_THAT(TDigestReduce(ScalarFromJSON(type,
+                                           "{\"mean\":[1.5, 3.5, 5.5],\"weight\":[2, "
+                                           "2, 2],\"min\":1.0,\"max\":6.0,\"count\":6}"),
+                            options),
+              ResultWith(ScalarFromJSON(type,
+                                        "{\"mean\":[1.5, 3.5, 5.5],\"weight\":[2, 2, "
+                                        "2],\"min\":1.0,\"max\":6.0,\"count\":6}")));
 }
 
 TEST(TestTDigestQuantileKernel, Basic) {
-  auto input_type = struct_({field("mean", fixed_size_list(float64(), 5), false),
-                             field("weight", fixed_size_list(float64(), 5), false),
-                             field("min", float64(), true), field("max", float64(), true),
-                             field("count", uint64(), false)});
+  auto input_type =
+      struct_({field("mean", list(field("item", float64(), false)), false),
+               field("weight", list(field("item", float64(), false)), false),
+               field("min", float64(), true), field("max", float64(), true),
+               field("count", uint64(), false)});
 
   auto output_type = float64();
 
-  auto input_array =
-      ArrayFromJSON(input_type,
-                    "["
-                    "{\"mean\":[1.5, 3.5, 5.5, null, null],\"weight\":[2, "
-                    "2, 2, null, null],\"min\":1.0,\"max\":6.0,\"count\":6},"
-                    "{\"mean\":[1.5, 3.5, 5.5, null, null],\"weight\":[2, "
-                    "2, 2, null, null],\"min\":1.0,\"max\":6.0,\"count\":6}"
-                    "]");
+  auto input_array = ArrayFromJSON(input_type,
+                                   "["
+                                   "{\"mean\":[1.5, 3.5, 5.5],\"weight\":[2, "
+                                   "2, 2],\"min\":1.0,\"max\":6.0,\"count\":6},"
+                                   "{\"mean\":[1.5, 3.5, 5.5],\"weight\":[2, "
+                                   "2, 2],\"min\":1.0,\"max\":6.0,\"count\":6}"
+                                   "]");
 
-  TDigestQuantileOptions multiple(/*q=*/{0.1, 0.5, 0.9}, /*min_count=*/12);
-  TDigestQuantileOptions min_count(/*q=*/0.5, /*min_count=*/13);
+  TDigestQuantileOptions multiple(/*q=*/{0.1, 0.5, 0.9}, /*delta=*/5, /*min_count=*/12);
+  TDigestQuantileOptions min_count(/*q=*/0.5, /*delta=*/5, /*min_count=*/13);
 
   EXPECT_THAT(TDigestQuantile(input_array, multiple),
               ResultWith(ArrayFromJSON(output_type, "[1.5666666666666667, 3.5, 5.5]")));
@@ -4680,24 +4669,24 @@ TEST(TestTDigestQuantileKernel, Basic) {
 }
 
 TEST(TestTDigestMapReduceQuantileKernel, Basic) {
-  auto input_type = struct_({field("mean", fixed_size_list(float64(), 5), false),
-                             field("weight", fixed_size_list(float64(), 5), false),
-                             field("min", float64(), true), field("max", float64(), true),
-                             field("count", uint64(), false)});
+  auto input_type =
+      struct_({field("mean", list(field("item", float64(), false)), false),
+               field("weight", list(field("item", float64(), false)), false),
+               field("min", float64(), true), field("max", float64(), true),
+               field("count", uint64(), false)});
 
   auto output_type = float64();
 
-  auto input_array =
-      ArrayFromJSON(input_type,
-                    "["
-                    "{\"mean\":[1.5, 3.5, 5.5, null, null],\"weight\":[2, "
-                    "2, 2, null, null],\"min\":1.0,\"max\":6.0,\"count\":6},"
-                    "{\"mean\":[1.5, 3.5, 5.5, null, null],\"weight\":[2, "
-                    "2, 2, null, null],\"min\":1.0,\"max\":6.0,\"count\":6}"
-                    "]");
+  auto input_array = ArrayFromJSON(input_type,
+                                   "["
+                                   "{\"mean\":[1.5, 3.5, 5.5],\"weight\":[2, "
+                                   "2, 2],\"min\":1.0,\"max\":6.0,\"count\":6},"
+                                   "{\"mean\":[1.5, 3.5, 5.5],\"weight\":[2, "
+                                   "2, 2],\"min\":1.0,\"max\":6.0,\"count\":6}"
+                                   "]");
 
-  TDigestQuantileOptions multiple(/*q=*/{0.1, 0.5, 0.9}, /*min_count=*/12);
-  TDigestQuantileOptions min_count(/*q=*/0.5, /*min_count=*/13);
+  TDigestQuantileOptions multiple(/*q=*/{0.1, 0.5, 0.9}, /*delta=*/5, /*min_count=*/12);
+  TDigestQuantileOptions min_count(/*q=*/0.5, /*delta=*/5, /*min_count=*/13);
 
   EXPECT_THAT(TDigestQuantile(input_array, multiple),
               ResultWith(ArrayFromJSON(output_type, "[1.5666666666666667, 3.5, 5.5]")));

--- a/cpp/src/arrow/compute/kernels/aggregate_test.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_test.cc
@@ -4566,8 +4566,7 @@ TEST(TestTDigestMapKernel, Options) {
                                          field("weight", float64(), false)}),
                                 false)),
                      false),
-               field("min", float64(), true), field("max", float64(), true),
-               field("count", uint64(), false)});
+               field("min", float64(), true), field("max", float64(), true)});
   TDigestMapOptions keep_nulls(/*delta=*/5, /*buffer_size=*/500,
                                /*skip_nulls=*/false,
                                /*scaler=*/TDigestMapOptions::Scaler::K0);
@@ -4580,32 +4579,32 @@ TEST(TestTDigestMapKernel, Options) {
       ResultWith(ScalarFromJSON(
           output_type,
           "{\"centroids\":[{\"mean\":1.5,\"weight\":2}, {\"mean\":3.5,\"weight\":2}, "
-          "{\"mean\":5.5,\"weight\":2}],\"min\":1.0,\"max\":6.0,\"count\":6}")));
+          "{\"mean\":5.5,\"weight\":2}],\"min\":1.0,\"max\":6.0}")));
   EXPECT_THAT(
       TDigestMap(ArrayFromJSON(input_type, "[1.0, 2.0, 3.0, 4.0, 5.0]"), keep_nulls),
       ResultWith(ScalarFromJSON(
           output_type,
           "{\"centroids\":[{\"mean\":1.5,\"weight\":2}, {\"mean\":3.5,\"weight\":2}, "
-          "{\"mean\":5.0,\"weight\":1}],\"min\":1.0,\"max\":5.0,\"count\":5}")));
+          "{\"mean\":5.0,\"weight\":1}],\"min\":1.0,\"max\":5.0}")));
   EXPECT_THAT(TDigestMap(ArrayFromJSON(input_type, "[1.0, 2.0, 3.0, 4.0]"), keep_nulls),
               ResultWith(ScalarFromJSON(
                   output_type,
                   "{\"centroids\":[{\"mean\":1.0,\"weight\":1}, "
                   "{\"mean\":2.0,\"weight\":1}, {\"mean\":3.0,\"weight\":1}, "
-                  "{\"mean\":4.0,\"weight\":1}],\"min\":1.0,\"max\":4.0,\"count\":4}")));
+                  "{\"mean\":4.0,\"weight\":1}],\"min\":1.0,\"max\":4.0}")));
 
   EXPECT_THAT(
       TDigestMap(ArrayFromJSON(input_type, "[1.0, 2.0, 3.0]"), keep_nulls),
       ResultWith(ScalarFromJSON(
           output_type,
           "{\"centroids\":[{\"mean\":1.0,\"weight\":1}, {\"mean\":2.0,\"weight\":1}, "
-          "{\"mean\":3.0,\"weight\":1}],\"min\":1.0,\"max\":3.0,\"count\":3}")));
+          "{\"mean\":3.0,\"weight\":1}],\"min\":1.0,\"max\":3.0}")));
   EXPECT_THAT(TDigestMap(ArrayFromJSON(input_type, "[1.0, 2.0, 3.0, null]"), keep_nulls),
               ResultWith(ScalarFromJSON(output_type, "null")));
   EXPECT_THAT(TDigestMap(ScalarFromJSON(input_type, "1.0"), keep_nulls),
               ResultWith(ScalarFromJSON(output_type,
                                         "{\"centroids\":[{\"mean\":1.0,\"weight\":1}],"
-                                        "\"min\":1.0,\"max\":1.0,\"count\":1}")));
+                                        "\"min\":1.0,\"max\":1.0}")));
   EXPECT_THAT(TDigestMap(ScalarFromJSON(input_type, "null"), keep_nulls),
               ResultWith(ScalarFromJSON(output_type, "null")));
 
@@ -4614,20 +4613,19 @@ TEST(TestTDigestMapKernel, Options) {
       ResultWith(ScalarFromJSON(
           output_type,
           "{\"centroids\":[{\"mean\":1.0,\"weight\":1}, {\"mean\":2.0,\"weight\":1}, "
-          "{\"mean\":3.0,\"weight\":1}],\"min\":1.0,\"max\":3.0,\"count\":3}")));
+          "{\"mean\":3.0,\"weight\":1}],\"min\":1.0,\"max\":3.0}")));
   EXPECT_THAT(TDigestMap(ArrayFromJSON(input_type, "[1.0, 2.0, null]"), skip_nulls),
               ResultWith(ScalarFromJSON(
                   output_type,
                   "{\"centroids\":[{\"mean\":1.0,\"weight\":1}, "
-                  "{\"mean\":2.0,\"weight\":1}],\"min\":1.0,\"max\":2.0,\"count\":2}")));
+                  "{\"mean\":2.0,\"weight\":1}],\"min\":1.0,\"max\":2.0}")));
   EXPECT_THAT(TDigestMap(ScalarFromJSON(input_type, "1.0"), skip_nulls),
               ResultWith(ScalarFromJSON(output_type,
                                         "{\"centroids\":[{\"mean\":1.0,\"weight\":1}],"
-                                        "\"min\":1.0,\"max\":1.0,\"count\":1}")));
-  EXPECT_THAT(
-      TDigestMap(ScalarFromJSON(input_type, "null"), skip_nulls),
-      ResultWith(ScalarFromJSON(
-          output_type, "{\"centroids\":[],\"min\":null,\"max\":null,\"count\":0}")));
+                                        "\"min\":1.0,\"max\":1.0}")));
+  EXPECT_THAT(TDigestMap(ScalarFromJSON(input_type, "null"), skip_nulls),
+              ResultWith(ScalarFromJSON(output_type,
+                                        "{\"centroids\":[],\"min\":null,\"max\":null}")));
 }
 
 TEST(TestTDigestReduceKernel, Basic) {
@@ -4637,8 +4635,7 @@ TEST(TestTDigestReduceKernel, Basic) {
                                                  field("weight", float64(), false)}),
                                         false)),
                              false),
-                       field("min", float64(), true), field("max", float64(), true),
-                       field("count", uint64(), false)});
+                       field("min", float64(), true), field("max", float64(), true)});
   TDigestReduceOptions options(/*delta=*/5, /*scaler=*/TDigestMapOptions::Scaler::K0);
   EXPECT_THAT(
       TDigestReduce(
@@ -4646,42 +4643,42 @@ TEST(TestTDigestReduceKernel, Basic) {
               type,
               "["
               "{\"centroids\":[{\"mean\":1.5,\"weight\":2}, {\"mean\":3.5,\"weight\":2}, "
-              "{\"mean\":5.5,\"weight\":2}],\"min\":1.0,\"max\":6.0,\"count\":6},"
+              "{\"mean\":5.5,\"weight\":2}],\"min\":1.0,\"max\":6.0},"
               "{\"centroids\":[{\"mean\":1.5,\"weight\":2}, {\"mean\":3.5,\"weight\":2}, "
-              "{\"mean\":5.5,\"weight\":2}],\"min\":1.0,\"max\":6.0,\"count\":6}"
+              "{\"mean\":5.5,\"weight\":2}],\"min\":1.0,\"max\":6.0}"
               "]"),
           options),
       ResultWith(ScalarFromJSON(
           type,
           "{\"centroids\":[{\"mean\":1.5,\"weight\":4}, {\"mean\":3.5,\"weight\":4}, "
-          "{\"mean\":5.5,\"weight\":4}],\"min\":1.0,\"max\":6.0,\"count\":12}")));
+          "{\"mean\":5.5,\"weight\":4}],\"min\":1.0,\"max\":6.0}")));
 
   EXPECT_THAT(
       TDigestReduce(
           ScalarFromJSON(
               type,
               "{\"centroids\":[{\"mean\":1.5,\"weight\":2}, {\"mean\":3.5,\"weight\":2}, "
-              "{\"mean\":5.5,\"weight\":2}],\"min\":1.0,\"max\":6.0,\"count\":6}"),
+              "{\"mean\":5.5,\"weight\":2}],\"min\":1.0,\"max\":6.0}"),
           options),
       ResultWith(ScalarFromJSON(
           type,
           "{\"centroids\":[{\"mean\":1.5,\"weight\":2}, {\"mean\":3.5,\"weight\":2}, "
-          "{\"mean\":5.5,\"weight\":2}],\"min\":1.0,\"max\":6.0,\"count\":6}")));
+          "{\"mean\":5.5,\"weight\":2}],\"min\":1.0,\"max\":6.0}")));
 
   EXPECT_THAT(
       TDigestReduce(
           ArrayFromJSON(
               type,
               "["
-              "{\"centroids\":[],\"min\":null,\"max\":null,\"count\":0},"
+              "{\"centroids\":[],\"min\":null,\"max\":null},"
               "{\"centroids\":[{\"mean\":1.5,\"weight\":2}, {\"mean\":3.5,\"weight\":2}, "
-              "{\"mean\":5.5,\"weight\":2}],\"min\":1.0,\"max\":6.0,\"count\":6}"
+              "{\"mean\":5.5,\"weight\":2}],\"min\":1.0,\"max\":6.0}"
               "]"),
           options),
       ResultWith(ScalarFromJSON(
           type,
           "{\"centroids\":[{\"mean\":1.5,\"weight\":2}, {\"mean\":3.5,\"weight\":2}, "
-          "{\"mean\":5.5,\"weight\":2}],\"min\":1.0,\"max\":6.0,\"count\":6}")));
+          "{\"mean\":5.5,\"weight\":2}],\"min\":1.0,\"max\":6.0}")));
 
   EXPECT_THAT(
       TDigestReduce(
@@ -4689,14 +4686,14 @@ TEST(TestTDigestReduceKernel, Basic) {
               type,
               "["
               "{\"centroids\":[{\"mean\":1.5,\"weight\":2}, {\"mean\":3.5,\"weight\":2}, "
-              "{\"mean\":5.5,\"weight\":2}],\"min\":1.0,\"max\":6.0,\"count\":6},"
-              "{\"centroids\":[],\"min\":null,\"max\":null,\"count\":0}"
+              "{\"mean\":5.5,\"weight\":2}],\"min\":1.0,\"max\":6.0},"
+              "{\"centroids\":[],\"min\":null,\"max\":null}"
               "]"),
           options),
       ResultWith(ScalarFromJSON(
           type,
           "{\"centroids\":[{\"mean\":1.5,\"weight\":2}, {\"mean\":3.5,\"weight\":2}, "
-          "{\"mean\":5.5,\"weight\":2}],\"min\":1.0,\"max\":6.0,\"count\":6}")));
+          "{\"mean\":5.5,\"weight\":2}],\"min\":1.0,\"max\":6.0}")));
 }
 
 TEST(TestTDigestQuantileKernel, Basic) {
@@ -4707,8 +4704,7 @@ TEST(TestTDigestQuantileKernel, Basic) {
                                          field("weight", float64(), false)}),
                                 false)),
                      false),
-               field("min", float64(), true), field("max", float64(), true),
-               field("count", uint64(), false)});
+               field("min", float64(), true), field("max", float64(), true)});
 
   auto output_type = float64();
 
@@ -4716,9 +4712,9 @@ TEST(TestTDigestQuantileKernel, Basic) {
       input_type,
       "["
       "{\"centroids\":[{\"mean\":1.5,\"weight\":2}, {\"mean\":3.5,\"weight\":2}, "
-      "{\"mean\":5.5,\"weight\":2}],\"min\":1.0,\"max\":6.0,\"count\":6},"
+      "{\"mean\":5.5,\"weight\":2}],\"min\":1.0,\"max\":6.0},"
       "{\"centroids\":[{\"mean\":1.5,\"weight\":2}, {\"mean\":3.5,\"weight\":2}, "
-      "{\"mean\":5.5,\"weight\":2}],\"min\":1.0,\"max\":6.0,\"count\":6}"
+      "{\"mean\":5.5,\"weight\":2}],\"min\":1.0,\"max\":6.0}"
       "]");
 
   TDigestQuantileOptions multiple(/*q=*/{0.1, 0.5, 0.9}, /*delta=*/5, /*min_count=*/12);
@@ -4738,15 +4734,14 @@ TEST(TestTDigestQuantileKernel, Scalar) {
                                          field("weight", float64(), false)}),
                                 false)),
                      false),
-               field("min", float64(), true), field("max", float64(), true),
-               field("count", uint64(), false)});
+               field("min", float64(), true), field("max", float64(), true)});
 
   auto output_type = float64();
 
   auto input_scalar = ScalarFromJSON(
       input_type,
       "{\"centroids\":[{\"mean\":1.5,\"weight\":2}, {\"mean\":3.5,\"weight\":2}, "
-      "{\"mean\":5.5,\"weight\":2}],\"min\":1.0,\"max\":6.0,\"count\":6}");
+      "{\"mean\":5.5,\"weight\":2}],\"min\":1.0,\"max\":6.0}");
 
   TDigestQuantileOptions multiple(/*q=*/{0.1, 0.5, 0.9}, /*delta=*/5, /*min_count=*/6);
   TDigestQuantileOptions min_count(/*q=*/0.5, /*delta=*/5, /*min_count=*/7);
@@ -4765,8 +4760,7 @@ TEST(TestTDigestQuantileKernel, ElementWise) {
                                          field("weight", float64(), false)}),
                                 false)),
                      false),
-               field("min", float64(), true), field("max", float64(), true),
-               field("count", uint64(), false)});
+               field("min", float64(), true), field("max", float64(), true)});
 
   auto output_type_multiple = fixed_size_list(float64(), 3);
   auto output_type_single = fixed_size_list(float64(), 1);
@@ -4774,10 +4768,10 @@ TEST(TestTDigestQuantileKernel, ElementWise) {
   auto input_array = ArrayFromJSON(
       input_type,
       "["
+      "{\"centroids\":[{\"mean\":1.5,\"weight\":3}, {\"mean\":3.5,\"weight\":3}, "
+      "{\"mean\":5.5,\"weight\":3}],\"min\":1.0,\"max\":6.0},"
       "{\"centroids\":[{\"mean\":1.5,\"weight\":2}, {\"mean\":3.5,\"weight\":2}, "
-      "{\"mean\":5.5,\"weight\":2}],\"min\":1.0,\"max\":6.0,\"count\":7},"
-      "{\"centroids\":[{\"mean\":1.5,\"weight\":2}, {\"mean\":3.5,\"weight\":2}, "
-      "{\"mean\":5.5,\"weight\":2}],\"min\":1.0,\"max\":6.0,\"count\":6}"
+      "{\"mean\":5.5,\"weight\":2}],\"min\":1.0,\"max\":6.0}"
       "]");
 
   TDigestQuantileOptions multiple(/*q=*/{0.1, 0.5, 0.9}, /*delta=*/5, /*min_count=*/5);
@@ -4805,8 +4799,7 @@ TEST(TestTDigestMapReduceQuantileKernel, Basic) {
                                          field("weight", float64(), false)}),
                                 false)),
                      false),
-               field("min", float64(), true), field("max", float64(), true),
-               field("count", uint64(), false)});
+               field("min", float64(), true), field("max", float64(), true)});
 
   auto output_type = float64();
 
@@ -4814,9 +4807,9 @@ TEST(TestTDigestMapReduceQuantileKernel, Basic) {
       input_type,
       "["
       "{\"centroids\":[{\"mean\":1.5,\"weight\":2}, {\"mean\":3.5,\"weight\":2}, "
-      "{\"mean\":5.5,\"weight\":2}],\"min\":1.0,\"max\":6.0,\"count\":6},"
+      "{\"mean\":5.5,\"weight\":2}],\"min\":1.0,\"max\":6.0},"
       "{\"centroids\":[{\"mean\":1.5,\"weight\":2}, {\"mean\":3.5,\"weight\":2}, "
-      "{\"mean\":5.5,\"weight\":2}],\"min\":1.0,\"max\":6.0,\"count\":6}"
+      "{\"mean\":5.5,\"weight\":2}],\"min\":1.0,\"max\":6.0}"
       "]");
 
   TDigestQuantileOptions multiple(/*q=*/{0.1, 0.5, 0.9}, /*delta=*/5, /*min_count=*/12);

--- a/cpp/src/arrow/util/tdigest.cc
+++ b/cpp/src/arrow/util/tdigest.cc
@@ -403,5 +403,10 @@ void TDigest::MergeInput() const {
   }
 }
 
+TDigestScalerK0::TDigestScalerK0(uint32_t delta)
+    : Scaler(delta), delta_norm(delta / 2.0) {}
+TDigestScalerK1::TDigestScalerK1(uint32_t delta)
+    : Scaler(delta), delta_norm(delta / (2.0 * M_PI)) {}
+
 }  // namespace internal
 }  // namespace arrow

--- a/cpp/src/arrow/util/tdigest.cc
+++ b/cpp/src/arrow/util/tdigest.cc
@@ -123,6 +123,8 @@ class TDigest::TDigestImpl {
     Reset();
   }
 
+  uint32_t delta() const { return merger_.delta(); }
+
   void Reset() {
     tdigests_[0].resize(0);
     tdigests_[1].resize(0);
@@ -316,6 +318,15 @@ class TDigest::TDigestImpl {
     return Lerp(td[ci_left].mean, td[ci_right].mean, diff);
   }
 
+  std::optional<std::pair<double, double>> GetCentroid(size_t i) const {
+    const auto& td = tdigests_[current_];
+    if (td.size() > i) {
+      auto& c = td[i];
+      return std::make_pair(c.mean, c.weight);
+    }
+    return std::nullopt;
+  }
+
   double Mean() const {
     double sum = 0;
     for (const auto& centroid : tdigests_[current_]) {
@@ -349,6 +360,8 @@ TDigest::TDigest(std::unique_ptr<Scaler> scaler, uint32_t buffer_size)
 TDigest::~TDigest() = default;
 TDigest::TDigest(TDigest&&) = default;
 TDigest& TDigest::operator=(TDigest&&) = default;
+
+uint32_t TDigest::delta() const { return impl_->delta(); }
 
 void TDigest::Reset() {
   input_.resize(0);
@@ -386,6 +399,11 @@ void TDigest::Merge(const TDigest& other) {
 double TDigest::Quantile(double q) const {
   MergeInput();
   return impl_->Quantile(q);
+}
+
+std::optional<std::pair<double, double>> TDigest::GetCentroid(size_t i) const {
+  MergeInput();
+  return impl_->GetCentroid(i);
 }
 
 double TDigest::Mean() const {

--- a/cpp/src/arrow/util/tdigest.cc
+++ b/cpp/src/arrow/util/tdigest.cc
@@ -327,14 +327,13 @@ class TDigest::TDigestImpl {
     return Lerp(td[ci_left].mean, td[ci_right].mean, diff);
   }
 
-  std::optional<std::pair<double, double>> GetCentroid(size_t i) const {
+  std::pair<double, double> GetCentroid(size_t i) const {
     const auto& td = tdigests_[current_];
-    if (td.size() > i) {
-      auto& c = td[i];
-      return std::make_pair(c.mean, c.weight);
-    }
-    return std::nullopt;
+    auto& c = td[i];
+    return std::make_pair(c.mean, c.weight);
   }
+
+  size_t GetCentroidCount() const { return tdigests_[current_].size(); }
 
   double Mean() const {
     double sum = 0;
@@ -414,9 +413,14 @@ double TDigest::Quantile(double q) const {
   return impl_->Quantile(q);
 }
 
-std::optional<std::pair<double, double>> TDigest::GetCentroid(size_t i) const {
+std::pair<double, double> TDigest::GetCentroid(size_t i) const {
   MergeInput();
   return impl_->GetCentroid(i);
+}
+
+size_t TDigest::GetCentroidCount() const {
+  MergeInput();
+  return impl_->GetCentroidCount();
 }
 
 void TDigest::SetMinMax(double min, double max) { impl_->SetMinMax(min, max); }

--- a/cpp/src/arrow/util/tdigest.cc
+++ b/cpp/src/arrow/util/tdigest.cc
@@ -234,7 +234,9 @@ class TDigest::TDigestImpl {
 
   // merge input data with current tdigest
   void MergeInput(std::vector<std::pair<double, double>>& input) {
-    total_weight_ += input.size();
+    for (const auto& i : input) {
+      total_weight_ += i.second;
+    }
 
     std::sort(input.begin(), input.end(),
               [](const std::pair<double, double>& lhs,
@@ -341,6 +343,10 @@ class TDigest::TDigestImpl {
     }
     return total_weight_ == 0 ? NAN : sum / total_weight_;
   }
+  void SetMinMax(double min, double max) {
+    min_ = std::min(min_, min);
+    max_ = std::max(max_, max);
+  }
 
   double total_weight() const { return total_weight_; }
 
@@ -412,6 +418,8 @@ std::optional<std::pair<double, double>> TDigest::GetCentroid(size_t i) const {
   MergeInput();
   return impl_->GetCentroid(i);
 }
+
+void TDigest::SetMinMax(double min, double max) { impl_->SetMinMax(min, max); }
 
 double TDigest::Mean() const {
   MergeInput();

--- a/cpp/src/arrow/util/tdigest.cc
+++ b/cpp/src/arrow/util/tdigest.cc
@@ -430,6 +430,11 @@ double TDigest::Mean() const {
   return impl_->Mean();
 }
 
+double TDigest::TotalWeight() const {
+  MergeInput();
+  return impl_->total_weight();
+}
+
 bool TDigest::is_empty() const {
   return input_.size() == 0 && impl_->total_weight() == 0;
 }

--- a/cpp/src/arrow/util/tdigest_internal.h
+++ b/cpp/src/arrow/util/tdigest_internal.h
@@ -105,7 +105,8 @@ class ARROW_EXPORT TDigest {
 
   // calculate quantile
   double Quantile(double q) const;
-  std::optional<std::pair<double, double>> GetCentroid(size_t i) const;
+  std::pair<double, double> GetCentroid(size_t i) const;
+  size_t GetCentroidCount() const;
 
   void SetMinMax(double min, double max);
   double Min() const { return Quantile(0); }

--- a/cpp/src/arrow/util/tdigest_internal.h
+++ b/cpp/src/arrow/util/tdigest_internal.h
@@ -107,6 +107,7 @@ class ARROW_EXPORT TDigest {
   double Quantile(double q) const;
   std::optional<std::pair<double, double>> GetCentroid(size_t i) const;
 
+  void SetMinMax(double min, double max);
   double Min() const { return Quantile(0); }
   double Max() const { return Quantile(1); }
   double Mean() const;

--- a/cpp/src/arrow/util/tdigest_internal.h
+++ b/cpp/src/arrow/util/tdigest_internal.h
@@ -112,7 +112,7 @@ class ARROW_EXPORT TDigest {
 
 // scale function K0: linear function, as baseline
 struct ARROW_EXPORT TDigestScalerK0 : public TDigest::Scaler {
-  explicit TDigestScalerK0(uint32_t delta) : Scaler(delta), delta_norm(delta / 2.0) {}
+  explicit TDigestScalerK0(uint32_t delta);
 
   double K(double q) const override { return delta_norm * q; }
   double Q(double k) const { return k / delta_norm; }
@@ -123,8 +123,7 @@ struct ARROW_EXPORT TDigestScalerK0 : public TDigest::Scaler {
 
 // scale function K1
 struct ARROW_EXPORT TDigestScalerK1 : public TDigest::Scaler {
-  explicit TDigestScalerK1(uint32_t delta)
-      : Scaler(delta), delta_norm(delta / (2.0 * M_PI)) {}
+  explicit TDigestScalerK1(uint32_t delta);
 
   double K(double q) const override { return delta_norm * std::asin(2 * q - 1); }
   double Q(double k) const { return (std::sin(k / delta_norm) + 1) / 2; }

--- a/cpp/src/arrow/util/tdigest_internal.h
+++ b/cpp/src/arrow/util/tdigest_internal.h
@@ -49,7 +49,7 @@ class ARROW_EXPORT TDigest {
   };
 
   explicit TDigest(uint32_t delta = 100, uint32_t buffer_size = 500);
-  explicit TDigest(std::unique_ptr<Scaler> scaler, uint32_t buffer_size = 500);
+  explicit TDigest(std::shared_ptr<Scaler> scaler, uint32_t buffer_size = 500);
   ~TDigest();
   TDigest(TDigest&&);
   TDigest& operator=(TDigest&&);

--- a/cpp/src/arrow/util/tdigest_internal.h
+++ b/cpp/src/arrow/util/tdigest_internal.h
@@ -24,6 +24,7 @@
 
 #include <cmath>
 #include <memory>
+#include <optional>
 #include <vector>
 
 #include "arrow/util/logging.h"
@@ -53,6 +54,7 @@ class ARROW_EXPORT TDigest {
   TDigest(TDigest&&);
   TDigest& operator=(TDigest&&);
 
+  uint32_t delta() const;
   // reset and re-use this tdigest
   void Reset();
 
@@ -90,6 +92,7 @@ class ARROW_EXPORT TDigest {
 
   // calculate quantile
   double Quantile(double q) const;
+  std::optional<std::pair<double, double>> GetCentroid(size_t i) const;
 
   double Min() const { return Quantile(0); }
   double Max() const { return Quantile(1); }

--- a/cpp/src/arrow/util/tdigest_internal.h
+++ b/cpp/src/arrow/util/tdigest_internal.h
@@ -112,6 +112,7 @@ class ARROW_EXPORT TDigest {
   double Min() const { return Quantile(0); }
   double Max() const { return Quantile(1); }
   double Mean() const;
+  double TotalWeight() const;
 
   // check if this tdigest contains no valid data points
   bool is_empty() const;


### PR DESCRIPTION
### Rationale for this change
Tdigest algorithm enables merging multiple centroid sets that allow efficient map-reduce implementation. This PR enables user to make reduce step outside of aggregator and in result enables incremental tdigest calculation.
Also option to select different scaler function is added.

### What changes are included in this PR?
This change introduces 3 new aggregate functions:

`tdigest_map`- functionally the same as tdigest but instead of quantiles outputs centroids_vector as fixed_size_list of length delta (with nullable values) each element would be struct{double mean; double weight}
`tdigest_reduce` - function that takes vector of centroids_vectors and output merged centroids_vector
`tdigest_quantile` - function that takes centroids_vector and calculates quantiles as tdigest does

### Are these changes tested?
Yes
### Are there any user-facing changes?
No

* GitHub Issue: #35508