### PR TITLE
GH-47554: [C++] Fix Meson Parquet symbol visibility issues

### DIFF
--- a/cpp/src/arrow/meson.build
+++ b/cpp/src/arrow/meson.build
@@ -488,8 +488,7 @@ arrow_lib = library(
     include_directories: arrow_includes,
     dependencies: arrow_deps,
     install: true,
-    # TODO: re-enable symbol visibility
-    #gnu_symbol_visibility: 'inlineshidden',
+    gnu_symbol_visibility: 'inlineshidden',
     cpp_shared_args: ['-DARROW_EXPORTING'],
 )
 

--- a/cpp/src/arrow/util/byte_stream_split_internal.h
+++ b/cpp/src/arrow/util/byte_stream_split_internal.h
@@ -452,8 +452,9 @@ inline void ByteStreamSplitDecodeScalarDynamic(const uint8_t* data, int width,
 }
 
 template <int kNumStreams>
-void ByteStreamSplitDecodeSimdDispatch(const uint8_t* data, int width, int64_t num_values,
-                                       int64_t stride, uint8_t* out);
+ARROW_EXPORT void ByteStreamSplitDecodeSimdDispatch(const uint8_t* data, int width,
+                                                    int64_t num_values, int64_t stride,
+                                                    uint8_t* out);
 
 extern template ARROW_TEMPLATE_EXPORT void ByteStreamSplitDecodeSimdDispatch<2>(
     const uint8_t*, int, int64_t, int64_t, uint8_t*);

--- a/cpp/src/arrow/util/visibility.h
+++ b/cpp/src/arrow/util/visibility.h
@@ -78,7 +78,7 @@
 #  endif
 
 #  define ARROW_FRIEND_EXPORT
-#  define ARROW_TEMPLATE_EXPORT
+#  define ARROW_TEMPLATE_EXPORT ARROW_EXPORT
 
 // [[gnu::visibility("default")]] even when #included by a non-arrow source
 #  define ARROW_FORCE_EXPORT [[gnu::visibility("default")]]

--- a/cpp/src/arrow/util/visibility.h
+++ b/cpp/src/arrow/util/visibility.h
@@ -67,6 +67,11 @@
 #    ifndef ARROW_NO_EXPORT
 #      define ARROW_NO_EXPORT [[gnu::visibility("hidden")]]
 #    endif
+#    if defined(__clang__)
+#      define ARROW_TEMPLATE_EXPORT
+#    else
+#      define ARROW_TEMPLATE_EXPORT ARROW_EXPORT
+#    endif
 #  else
 // Not C++, or not gcc/clang
 #    ifndef ARROW_EXPORT
@@ -75,10 +80,10 @@
 #    ifndef ARROW_NO_EXPORT
 #      define ARROW_NO_EXPORT
 #    endif
+#    define ARROW_TEMPLATE_EXPORT
 #  endif
 
 #  define ARROW_FRIEND_EXPORT
-#  define ARROW_TEMPLATE_EXPORT ARROW_EXPORT
 
 // [[gnu::visibility("default")]] even when #included by a non-arrow source
 #  define ARROW_FORCE_EXPORT [[gnu::visibility("default")]]

--- a/cpp/src/arrow/util/visibility.h
+++ b/cpp/src/arrow/util/visibility.h
@@ -67,6 +67,10 @@
 #    ifndef ARROW_NO_EXPORT
 #      define ARROW_NO_EXPORT [[gnu::visibility("hidden")]]
 #    endif
+// The C++ language does not have clear rules for how to export explicit template
+// instantiations, and clang/gcc have differing syntax. See
+// https://github.com/llvm/llvm-project/issues/29464 and
+// https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2017/p0537r0.html
 #    if defined(__clang__)
 #      define ARROW_TEMPLATE_EXPORT
 #    else

--- a/cpp/src/parquet/meson.build
+++ b/cpp/src/parquet/meson.build
@@ -89,7 +89,7 @@ endif
 
 parquet_deps = [arrow_dep, rapidjson_dep, thrift_dep]
 
-if needs_parquet_encryption or get_option('parquet_require_encryption') == 'auto'
+if needs_parquet_encryption or get_option('parquet_require_encryption').auto()
     openssl_dep = dependency('openssl', required: needs_parquet_encryption)
 else
     openssl_dep = disabler()
@@ -120,8 +120,7 @@ parquet_lib = library(
     'arrow-parquet',
     sources: parquet_srcs,
     dependencies: parquet_deps,
-    # TODO: enable hidden visibility by default
-    #gnu_symbol_visibility: 'inlineshidden',
+    gnu_symbol_visibility: 'inlineshidden',
 )
 
 parquet_dep = declare_dependency(link_with: parquet_lib)
@@ -270,6 +269,19 @@ if needs_parquet_encryption
 endif
 
 parquet_test_dep = [parquet_dep, arrow_test_dep, thrift_dep]
+
+if get_option('default_library') != 'static'
+    parquet_test_support_lib = static_library(
+        'parquet-test-support',
+        sources: files('../generated/parquet_types.cpp'),
+        dependencies: [thrift_dep],
+        include_directories: include_directories('..'),
+    )
+    parquet_test_support_dep = declare_dependency(
+        link_with: [parquet_test_support_lib],
+    )
+    parquet_test_dep += [parquet_test_support_dep]
+endif
 
 foreach key, val : parquet_tests
     test_name = 'parquet-@0@'.format(key)

--- a/cpp/src/parquet/meson.build
+++ b/cpp/src/parquet/meson.build
@@ -268,8 +268,6 @@ if needs_parquet_encryption
     }
 endif
 
-parquet_test_dep = [parquet_dep, arrow_test_dep, thrift_dep]
-
 if get_option('default_library') != 'static'
     parquet_test_support_lib = static_library(
         'parquet-test-support',
@@ -280,8 +278,17 @@ if get_option('default_library') != 'static'
     parquet_test_support_dep = declare_dependency(
         link_with: [parquet_test_support_lib],
     )
-    parquet_test_dep += [parquet_test_support_dep]
+else
+    parquet_test_support_dep = declare_dependency()
 endif
+
+
+parquet_test_dep = [
+    parquet_dep,
+    parquet_test_support_dep,
+    arrow_test_dep,
+    thrift_dep,
+]
 
 foreach key, val : parquet_tests
     test_name = 'parquet-@0@'.format(key)
@@ -313,7 +320,12 @@ parquet_benchmarks = {
     'size_stats_benchmark': {'sources': files('arrow/size_stats_benchmark.cc')},
 }
 
-parquet_benchmark_dep = [parquet_dep, arrow_benchmark_dep, thrift_dep]
+parquet_benchmark_dep = [
+    parquet_dep,
+    parquet_test_support_dep,
+    arrow_benchmark_dep,
+    thrift_dep,
+]
 
 foreach key, val : parquet_benchmarks
     benchmark_name = 'parquet-@0@'.format(key)


### PR DESCRIPTION
### Rationale for this change

This fixes symbol export visibility issues with the Parquet option enabled

### What changes are included in this PR?

Updates to the Meson configuration, and one definition to get symbol exports to work

### Are these changes tested?

Yes

### Are there any user-facing changes?

No
* GitHub Issue: #47554