### PR TITLE
GH-47564: [C++] Update expected L2 CPU cache range to 32KiB-64MiB

### DIFF
--- a/cpp/src/arrow/util/io_util_test.cc
+++ b/cpp/src/arrow/util/io_util_test.cc
@@ -1096,7 +1096,7 @@ TEST(CpuInfo, Basic) {
   const auto l2 = ci->CacheSize(CpuInfo::CacheLevel::L2);
   const auto l3 = ci->CacheSize(CpuInfo::CacheLevel::L3);
   ASSERT_TRUE(l1 >= 4 * 1024 && l1 <= 512 * 1024) << "unexpected L1 size: " << l1;
-  ASSERT_TRUE(l2 >= 32 * 1024 && l2 <= 12 * 1024 * 1024) << "unexpected L2 size: " << l2;
+  ASSERT_TRUE(l2 >= 32 * 1024 && l2 <= 64 * 1024 * 1024) << "unexpected L2 size: " << l2;
   ASSERT_TRUE(l3 >= 256 * 1024 && l3 <= 1024 * 1024 * 1024)
       << "unexpected L3 size: " << l3;
   ASSERT_LE(l1, l2) << "L1 cache size " << l1 << " larger than L2 " << l2;


### PR DESCRIPTION
### Rationale for this change
On newer Apple silicon CPUs there is more L2 CPU cache than expected by the current unit tests. This results in the unit test failing:
```
/tmp/nix-build-arrow-cpp-20.0.0.drv-0/source/cpp/src/arrow/util/io_util_test.cc:1099: Failure
Value of: l2 >= 32 * 1024 && l2 <= 12 * 1024 * 1024
  Actual: false
Expected: true
unexpected L2 size: 16777216
[  FAILED  ] CpuInfo.Basic (0 ms)
```

### What changes are included in this PR?
The expected L2 CPU cache range is increased to 32KiB-64MiB to accommodate newer CPUs.

### Are these changes tested?
Yes.

### Are there any user-facing changes?
No.
* GitHub Issue: #47564