### PR TITLE
GH-47565: [C++] Document how to use Arrow in Meson build system

### DIFF
--- a/docs/source/cpp/build_system.rst
+++ b/docs/source/cpp/build_system.rst
@@ -156,15 +156,15 @@ into an executable linked with the Arrow C++ shared library:
 
 .. code-block:: meson
 
-    project('my-example-project', 'cpp')
+   project('my-example-project', 'cpp')
 
-    arrow_dep = dependency('arrow')
+   arrow_dep = dependency('arrow')
 
-    executable(
-        'my_example',
-        sources: ['my_example.cc'],
-        dependencies: [arrow_dep],
-    )
+   executable(
+       'my_example',
+       sources: ['my_example.cc'],
+       dependencies: [arrow_dep],
+   )
 
 To setup and compile, run the following commands from your project root:
 
@@ -211,18 +211,18 @@ Meson to build the compute library while compiling a local copy of Arrow:
 
 .. code-block:: meson
 
-    project('my-example-project', 'cpp')
+   project('my-example-project', 'cpp')
 
-    arrow_compute_dep = dependency(
-        'arrow-compute',
-        default_options: ['compute=enabled'],
-    )
+   arrow_compute_dep = dependency(
+       'arrow-compute',
+       default_options: ['compute=enabled'],
+   )
 
-    executable(
-        'my_example',
-        sources: ['my_example.cc'],
-        dependencies: [arrow_compute_dep],
-    )
+   executable(
+       'my_example',
+       sources: ['my_example.cc'],
+       dependencies: [arrow_compute_dep],
+   )
 
 pkg-config
 ==========


### PR DESCRIPTION
### Rationale for this change

With the recent addition of the Arrow project to the Meson wrapdb, users of the Meson build system can now link against Arrow with trivial effort, whether Arrow is system-installed or needs to be built locally.  We have no documentation currently showing this, so it would be nice to add.

### What changes are included in this PR?

A new section in the build_system.rst docs showing how to use Meson

### Are these changes tested?

Yes

### Are there any user-facing changes?

No
* GitHub Issue: #47565