### PR TITLE
GH-47584: [C++][CI] Remove "large memory" mark from TestListArray::TestOverflowCheck

### DIFF
--- a/cpp/src/arrow/array/array_list_test.cc
+++ b/cpp/src/arrow/array/array_list_test.cc
@@ -982,11 +982,7 @@ TYPED_TEST(TestListArray, ValidateDimensions) { this->TestValidateDimensions(); 
 
 TYPED_TEST(TestListArray, CornerCases) { this->TestCornerCases(); }
 
-#ifndef ARROW_LARGE_MEMORY_TESTS
-TYPED_TEST(TestListArray, DISABLED_TestOverflowCheck) { this->TestOverflowCheck(); }
-#else
 TYPED_TEST(TestListArray, TestOverflowCheck) { this->TestOverflowCheck(); }
-#endif
 
 class TestListConversions : public ::testing::Test {
  private:


### PR DESCRIPTION
### Rationale for this change

As found out in https://github.com/apache/arrow/issues/46600#issuecomment-2915420681 : the one test that is marked "large memory" in array_list_test.cc actually shows a very small memory consumption.

### What changes are included in this PR?

Make test unconditional.

### Are these changes tested?

Yes, by construction.

### Are there any user-facing changes?

No.
* GitHub Issue: #47584