### PR TITLE
GH-47590: [C++] Use W functions explicitly for Windows UNICODE compatibility

### DIFF
--- a/cpp/src/arrow/util/cpu_info.cc
+++ b/cpp/src/arrow/util/cpu_info.cc
@@ -82,7 +82,7 @@ void OsRetrieveCacheSize(std::array<int64_t, kCacheLevels>* cache_sizes) {
   typedef BOOL(WINAPI * GetLogicalProcessorInformationFuncPointer)(void*, void*);
   GetLogicalProcessorInformationFuncPointer func_pointer =
       (GetLogicalProcessorInformationFuncPointer)GetProcAddress(
-          GetModuleHandle("kernel32"), "GetLogicalProcessorInformation");
+          GetModuleHandleW(L"kernel32"), "GetLogicalProcessorInformation");
 
   if (!func_pointer) {
     ARROW_LOG(WARNING) << "Failed to find procedure GetLogicalProcessorInformation";

--- a/cpp/src/arrow/util/io_util.cc
+++ b/cpp/src/arrow/util/io_util.cc
@@ -1448,7 +1448,7 @@ Status MemoryMapRemap(void* addr, size_t old_size, size_t new_size, int fildes,
 
   SetFilePointer(h, new_size_low, &new_size_high, FILE_BEGIN);
   SetEndOfFile(h);
-  fm = CreateFileMapping(h, NULL, PAGE_READWRITE, 0, 0, "");
+  fm = CreateFileMappingW(h, NULL, PAGE_READWRITE, 0, 0, L"");
   if (fm == NULL) {
     return StatusFromMmapErrno("CreateFileMapping failed");
   }


### PR DESCRIPTION
### Rationale for this change

Windows build breaks when UNICODE is defined. The codebase mixes explicit Wide APIs with generic ones, causing compile errors.

### What changes are included in this PR?

Fixed two API calls to use explicit Wide versions:
- `cpu_info.cc`: `GetModuleHandle("kernel32")` → `GetModuleHandleW(L"kernel32")`
- `io_util.cc`: `CreateFileMapping(..., "")` → `CreateFileMappingW(..., L"")`

### Are these changes tested?

Yes. Built on Windows 11 with MSVC 2022.

Tested with:
```
cmake .. --preset ninja-debug-minimal -DCMAKE_CXX_FLAGS="-DUNICODE -D_UNICODE"
cmake --build .
```

Build completes successfully:
```
[197/197] Linking CXX shared library debug\arrow.dll
```

Also verified the build still works without UNICODE defined.

### Are there any user-facing changes?

No. Just fixes a compile error.

- [#47590 ](https://github.com/apache/arrow/issues/47590)
* GitHub Issue: #47590