### PR TITLE
GH-47602: [Python] Make Schema hashable even when it has metadata

### DIFF
--- a/python/pyarrow/tests/test_schema.py
+++ b/python/pyarrow/tests/test_schema.py
@@ -482,6 +482,28 @@ def test_schema_set_field():
     assert s3.field(0).nullable is False
 
 
+def test_schema_hash_metadata():
+    fields = [
+        pa.field("foo", pa.int32()),
+    ]
+
+    schema1 = pa.schema(fields, metadata={b'foo': b'bar'})
+    schema2 = pa.schema(fields, metadata={b'foo': b'bar'})
+    schema3 = pa.schema(fields, metadata={b'foo_different': b'bar'})
+    schema4 = pa.schema(fields, metadata={b'foo': b'bar_different'})
+
+    assert hash(schema1) == hash(schema2)
+    assert hash(schema1) != hash(schema3)
+    assert hash(schema1) != hash(schema4)
+    assert hash(schema3) != hash(schema4)
+
+    schema_empty1 = pa.schema(fields, metadata={})
+    schema_empty2 = pa.schema(fields, metadata=None)
+
+    assert hash(schema_empty1) == hash(schema_empty2)
+    assert hash(schema_empty1) != hash(schema1)
+
+
 def test_schema_equals():
     fields = [
         pa.field('foo', pa.int32()),

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -2918,7 +2918,7 @@ cdef class Schema(_Weakrefable):
         return schema, (list(self), self.metadata)
 
     def __hash__(self):
-        return hash((tuple(self), self.metadata))
+        return hash((tuple(self), frozenset(self.metadata.items() if self.metadata else {})))
 
     def __sizeof__(self):
         size = 0

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -2918,7 +2918,8 @@ cdef class Schema(_Weakrefable):
         return schema, (list(self), self.metadata)
 
     def __hash__(self):
-        return hash((tuple(self), frozenset(self.metadata.items() if self.metadata else {})))
+        metadata = frozenset(self.metadata.items() if self.metadata else {})
+        return hash((tuple(self), metadata))
 
     def __sizeof__(self):
         size = 0


### PR DESCRIPTION
### Rationale for this change

In Python, `pyarrow.Schema` before was not hashable when it has `metadata` set.

```
>>> import pyarrow
>>> schema = pyarrow.schema([], metadata={b"1": b"1"})
>>> hash(schema)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "pyarrow/types.pxi", line 2921, in pyarrow.lib.Schema.__hash__
TypeError: unhashable type: 'dict'
```

This is because the metadata (which is a dict) was tried to be hashed as-is, which doesn't work.

### What changes are included in this PR?

Slightly change how hashes are computed for Schema, by converting the `dict[str, str]` to the frozenset of key- and value tuples. 

For reference, this is faster than computing the hash of a sorted tuple of key- and value tuples (https://stackoverflow.com/a/6014481/10070873).

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Besides that `Schema` now correctly is hashable, no.
* GitHub Issue: #47602