### PR TITLE
GH-46137: [C++] Replace grpc-cpp conda package with libgrpc

### DIFF
--- a/ci/conda_env_cpp.txt
+++ b/ci/conda_env_cpp.txt
@@ -31,8 +31,8 @@ gflags
 glog
 gmock>=1.10.0
 google-cloud-cpp>=1.34.0
-grpc-cpp<=1.50.1
 gtest>=1.10.0
+libgrpc
 libprotobuf
 libutf8proc
 lz4-c
@@ -40,7 +40,7 @@ make
 meson
 ninja
 nodejs
-orc
+orc<2.1.0
 pkg-config
 python
 rapidjson

--- a/docs/source/developers/cpp/development.rst
+++ b/docs/source/developers/cpp/development.rst
@@ -214,7 +214,7 @@ When building, set the environment variables ``gRPC_ROOT`` and/or
 ``Protobuf_ROOT`` and/or ``c-ares_ROOT``.
 
 We are developing against recent versions of gRPC, and the versions. The
-``grpc-cpp`` package available from https://conda-forge.org/ is one reliable
+``libgrpc`` package available from https://conda-forge.org/ is one reliable
 way to obtain gRPC in a cross-platform way. You may try using system libraries
 for gRPC and Protobuf, but these are likely to be too old. On macOS, you can
 try `Homebrew <https://brew.sh/>`_:

--- a/python/asv.conf.json
+++ b/python/asv.conf.json
@@ -90,7 +90,7 @@
         "cmake": [],
         "cython": [],
         "flatbuffers": [],
-        "grpc-cpp": [],
+        "libgrpc": [],
         "libprotobuf": [],
         "lz4-c": [],
         "ninja": [],


### PR DESCRIPTION
### Rationale for this change

The grpc-cpp conda package appears abandoned and is artificially pinning other dependencies to older versions (ex: orc). The more recent libgrpc conda package appears to be where the development is going forward

### What changes are included in this PR?

Replaced grpc-cpp with libgrpc

### Are these changes tested?

Yes

### Are there any user-facing changes?

No

* GitHub Issue: #46137