### PR TITLE
GH-47620: [CI][C++] Use Ubuntu 24.04 for ASAN UBSAN job

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -93,8 +93,8 @@ jobs:
             image: ubuntu-cpp-sanitizer
             llvm: 14
             runs-on: ubuntu-latest
-            title: AMD64 Ubuntu 22.04 C++ ASAN UBSAN
-            ubuntu: 22.04
+            title: AMD64 Ubuntu 24.04 C++ ASAN UBSAN
+            ubuntu: 24.04
           - arch: arm64v8
             clang-tools: 14
             image: ubuntu-cpp

--- a/ci/docker/ubuntu-22.04-cpp.dockerfile
+++ b/ci/docker/ubuntu-22.04-cpp.dockerfile
@@ -173,9 +173,6 @@ RUN /arrow/ci/scripts/install_minio.sh latest /usr/local
 COPY ci/scripts/install_gcs_testbench.sh /arrow/ci/scripts/
 RUN /arrow/ci/scripts/install_gcs_testbench.sh default
 
-COPY ci/scripts/install_azurite.sh /arrow/ci/scripts/
-RUN /arrow/ci/scripts/install_azurite.sh
-
 COPY ci/scripts/install_ceph.sh /arrow/ci/scripts/
 RUN /arrow/ci/scripts/install_ceph.sh
 

--- a/ci/scripts/install_azurite.sh
+++ b/ci/scripts/install_azurite.sh
@@ -20,18 +20,16 @@
 set -e
 
 node_version="$(node --version)"
-echo "node version = ${node_version}"
+echo "Node.js version = ${node_version}"
 
 case "${node_version}" in
-  v12*)
-    # Pin azurite to 3.29.0 due to https://github.com/apache/arrow/issues/41505
-    azurite_version=v3.29.0
-    ;;
-  *)
-    azurite_version=latest
+  v12.*)
+    echo "Node.js is too old. We can't install Azurite."
+    exit
     ;;
 esac
 
+azurite_version=latest
 case "$(uname)" in
   Darwin)
     npm install -g azurite@${azurite_version}
@@ -46,5 +44,4 @@ case "$(uname)" in
     which azurite
     ;;
 esac
-
-echo "azurite version = $(azurite --version)"
+echo "Azurite version = $(azurite --version)"

--- a/ci/scripts/install_azurite.sh
+++ b/ci/scripts/install_azurite.sh
@@ -22,13 +22,6 @@ set -e
 node_version="$(node --version)"
 echo "Node.js version = ${node_version}"
 
-case "${node_version}" in
-  v12.*)
-    echo "Node.js is too old. We can't install Azurite."
-    exit
-    ;;
-esac
-
 azurite_version=latest
 case "$(uname)" in
   Darwin)

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -157,7 +157,6 @@ class AzuriteEnv : public AzureEnvImpl<AzuriteEnv> {
   std::unique_ptr<TemporaryDir> temp_dir_;
   arrow::internal::PlatformFilename debug_log_path_;
   std::unique_ptr<util::Process> server_process_;
-  arrow::Status status_;
 
   using AzureEnvImpl::AzureEnvImpl;
 

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -181,7 +181,10 @@ class AzuriteEnv : public AzureEnvImpl<AzuriteEnv> {
                                     // For old Azurite. We can't install the latest
                                     // Azurite with old Node.js on old Ubuntu.
                                     "--skipApiVersionCheck"});
-    ARROW_RETURN_NOT_OK(self->server_process_->Execute());
+    auto status = self->server_process_->Execute();
+    if (status.ok()) {
+      GTEST_SKIP() << "Failed to run Azurite: " << status.ToString();
+    }
     return self;
   }
 

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -892,9 +892,13 @@ class TestAzureFileSystem : public ::testing::Test {
   }
 
   void SetUp() override {
-    auto make_options = [this]() -> Result<AzureOptions> {
-      ARROW_ASSIGN_OR_RAISE(auto env, GetAzureEnv());
-      EXPECT_THAT(env, NotNull());
+    auto env_result = GetAzureEnv();
+    if (!env_result.ok()) {
+      GTEST_SKIP() << "Failed to setup: " << env_result.status().ToString();
+    }
+    auto env = *env_result;
+    EXPECT_THAT(env, NotNull());
+    auto make_options = [this, &env]() -> Result<AzureOptions> {
       ARROW_ASSIGN_OR_RAISE(debug_log_start_, env->GetDebugLogSize());
       return MakeOptions(env);
     };

--- a/cpp/src/arrow/filesystem/azurefs_test.cc
+++ b/cpp/src/arrow/filesystem/azurefs_test.cc
@@ -423,11 +423,8 @@ class TestGeneric : public ::testing::Test, public GenericFileSystemTest {
 class TestAzuriteGeneric : public TestGeneric {
  public:
   void SetUp() override {
-    auto env_result = AzuriteEnv::GetInstance();
-    if (!env_result.ok()) {
-      GTEST_SKIP() << "Failed to setup: " << env_result.status().ToString();
-    }
-    SetUpInternal(*env_result);
+    ASSERT_OK_AND_ASSIGN(auto env, AzuriteEnv::GetInstance());
+    SetUpInternal(env);
   }
 
  protected:
@@ -891,13 +888,9 @@ class TestAzureFileSystem : public ::testing::Test {
   }
 
   void SetUp() override {
-    auto env_result = GetAzureEnv();
-    if (!env_result.ok()) {
-      GTEST_SKIP() << "Failed to setup: " << env_result.status().ToString();
-    }
-    auto env = *env_result;
-    EXPECT_THAT(env, NotNull());
-    auto make_options = [this, &env]() -> Result<AzureOptions> {
+    auto make_options = [this]() -> Result<AzureOptions> {
+      ARROW_ASSIGN_OR_RAISE(auto env, GetAzureEnv());
+      EXPECT_THAT(env, NotNull());
       ARROW_ASSIGN_OR_RAISE(debug_log_start_, env->GetDebugLogSize());
       return MakeOptions(env);
     };


### PR DESCRIPTION
### Rationale for this change

Ubuntu 22.04 ships old Node.js (12). It's too old for Azurite.

### What changes are included in this PR?

Use Ubuntu 24.04 instead of 22.04. Ubuntu 24.04 ships newer Node.js (18) that can be used for Azurite.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #47620