### PR TITLE
GH-46928: [C++] Retry on EINTR while opening file in FileOpenReadable

### DIFF
--- a/cpp/src/arrow/util/io_util.cc
+++ b/cpp/src/arrow/util/io_util.cc
@@ -1070,11 +1070,10 @@ Result<FileDescriptor> FileOpenReadable(const PlatformFilename& file_name) {
   }
   fd = FileDescriptor(ret);
 #else
-  int ret = open(file_name.ToNative().c_str(), O_RDONLY);
-  if (ret < 0) {
-    return IOErrorFromErrno(errno, "Failed to open local file '", file_name.ToString(),
-                            "'");
-  }
+  int64_t ret;
+  do {
+    ret = static_cast<int64_t>(open(file_name.ToNative().c_str(), O_RDONLY));
+  } while (ret == -1 && errno == EINTR);
   // open(O_RDONLY) succeeds on directories, check for it
   fd = FileDescriptor(ret);
   struct stat st;

--- a/cpp/src/arrow/util/io_util.cc
+++ b/cpp/src/arrow/util/io_util.cc
@@ -1070,10 +1070,14 @@ Result<FileDescriptor> FileOpenReadable(const PlatformFilename& file_name) {
   }
   fd = FileDescriptor(ret);
 #else
-  int64_t ret;
+  int ret;
   do {
-    ret = static_cast<int64_t>(open(file_name.ToNative().c_str(), O_RDONLY));
+    ret = open(file_name.ToNative().c_str(), O_RDONLY);
   } while (ret == -1 && errno == EINTR);
+  if (ret == -1) {
+    return IOErrorFromErrno(errno, "Failed to open local file '", file_name.ToString(),
+                            "'");
+  }
   // open(O_RDONLY) succeeds on directories, check for it
   fd = FileDescriptor(ret);
   struct stat st;
@@ -1136,7 +1140,10 @@ Result<FileDescriptor> FileOpenWritable(const PlatformFilename& file_name,
     oflag |= O_RDWR;
   }
 
-  int ret = open(file_name.ToNative().c_str(), oflag, 0666);
+  int ret;
+  do {
+    ret = open(file_name.ToNative().c_str(), oflag, 0666);
+  } while (ret == -1 && errno == EINTR);
   if (ret == -1) {
     return IOErrorFromErrno(errno, "Failed to open local file '", file_name.ToString(),
                             "'");


### PR DESCRIPTION
### Rationale for this change
File open should be retried when it fails due to EINTR 

### What changes are included in this PR?
checking the errno and retrying file open inside FileOpenReadable. This is already done at other places in io_util.cc

### Are these changes tested?
No, hard to reproduce

### Are there any user-facing changes?
On slow file systems like FUSE, file open would be retried instead of exiting on receiving interrupt.

* GitHub Issue: #46928