### PR TITLE
GH-47646: [C++][FlightRPC] Follow Naming Convention

### DIFF
--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/binary_array_accessor.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/binary_array_accessor.cc
@@ -56,8 +56,8 @@ inline RowStatus MoveSingleCellToBinaryBuffer(ColumnBinding* binding, BinaryArra
     value_offset = -1;
   }
 
-  if (binding->strlen_buffer) {
-    binding->strlen_buffer[i] = static_cast<ssize_t>(remaining_length);
+  if (binding->str_len_buffer) {
+    binding->str_len_buffer[i] = static_cast<ssize_t>(remaining_length);
   }
 
   return result;
@@ -72,7 +72,7 @@ BinaryArrayFlightSqlAccessor<TARGET_TYPE>::BinaryArrayFlightSqlAccessor(Array* a
 
 template <>
 RowStatus
-BinaryArrayFlightSqlAccessor<odbcabstraction::CDataType_BINARY>::MoveSingleCell_impl(
+BinaryArrayFlightSqlAccessor<odbcabstraction::CDataType_BINARY>::MoveSingleCellImpl(
     ColumnBinding* binding, int64_t arrow_row, int64_t i, int64_t& value_offset,
     bool update_value_offset, odbcabstraction::Diagnostics& diagnostics) {
   return MoveSingleCellToBinaryBuffer(binding, this->GetArray(), arrow_row, i,
@@ -80,7 +80,7 @@ BinaryArrayFlightSqlAccessor<odbcabstraction::CDataType_BINARY>::MoveSingleCell_
 }
 
 template <CDataType TARGET_TYPE>
-size_t BinaryArrayFlightSqlAccessor<TARGET_TYPE>::GetCellLength_impl(
+size_t BinaryArrayFlightSqlAccessor<TARGET_TYPE>::GetCellLengthImpl(
     ColumnBinding* binding) const {
   return binding->buffer_length;
 }

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/binary_array_accessor.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/binary_array_accessor.h
@@ -34,11 +34,11 @@ class BinaryArrayFlightSqlAccessor
  public:
   explicit BinaryArrayFlightSqlAccessor(Array* array);
 
-  RowStatus MoveSingleCell_impl(ColumnBinding* binding, int64_t arrow_row, int64_t i,
-                                int64_t& value_offset, bool update_value_offset,
-                                odbcabstraction::Diagnostics& diagnostics);
+  RowStatus MoveSingleCellImpl(ColumnBinding* binding, int64_t arrow_row, int64_t i,
+                               int64_t& value_offset, bool update_value_offset,
+                               odbcabstraction::Diagnostics& diagnostics);
 
-  size_t GetCellLength_impl(ColumnBinding* binding) const;
+  size_t GetCellLengthImpl(ColumnBinding* binding) const;
 };
 
 }  // namespace flight_sql

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/binary_array_accessor_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/binary_array_accessor_test.cc
@@ -35,12 +35,12 @@ TEST(BinaryArrayAccessor, Test_CDataType_BINARY_Basic) {
 
   BinaryArrayFlightSqlAccessor<odbcabstraction::CDataType_BINARY> accessor(array.get());
 
-  size_t max_strlen = 64;
-  std::vector<char> buffer(values.size() * max_strlen);
-  std::vector<ssize_t> strlen_buffer(values.size());
+  size_t max_str_len = 64;
+  std::vector<char> buffer(values.size() * max_str_len);
+  std::vector<ssize_t> str_len_buffer(values.size());
 
   ColumnBinding binding(odbcabstraction::CDataType_BINARY, 0, 0, buffer.data(),
-                        max_strlen, strlen_buffer.data());
+                        max_str_len, str_len_buffer.data());
 
   int64_t value_offset = 0;
   odbcabstraction::Diagnostics diagnostics("Foo", "Foo", OdbcVersion::V_3);
@@ -49,12 +49,13 @@ TEST(BinaryArrayAccessor, Test_CDataType_BINARY_Basic) {
                                      diagnostics, nullptr));
 
   for (int i = 0; i < values.size(); ++i) {
-    ASSERT_EQ(values[i].length(), strlen_buffer[i]);
+    ASSERT_EQ(values[i].length(), str_len_buffer[i]);
     // Beware that CDataType_BINARY values are not null terminated.
     // It's safe to create a std::string from this data because we know it's
     // ASCII, this doesn't work with arbitrary binary data.
-    ASSERT_EQ(values[i], std::string(buffer.data() + i * max_strlen,
-                                     buffer.data() + i * max_strlen + strlen_buffer[i]));
+    ASSERT_EQ(values[i],
+              std::string(buffer.data() + i * max_str_len,
+                          buffer.data() + i * max_str_len + str_len_buffer[i]));
   }
 }
 
@@ -65,12 +66,12 @@ TEST(BinaryArrayAccessor, Test_CDataType_BINARY_Truncation) {
 
   BinaryArrayFlightSqlAccessor<odbcabstraction::CDataType_BINARY> accessor(array.get());
 
-  size_t max_strlen = 8;
-  std::vector<char> buffer(values.size() * max_strlen);
-  std::vector<ssize_t> strlen_buffer(values.size());
+  size_t max_str_len = 8;
+  std::vector<char> buffer(values.size() * max_str_len);
+  std::vector<ssize_t> str_len_buffer(values.size());
 
   ColumnBinding binding(odbcabstraction::CDataType_BINARY, 0, 0, buffer.data(),
-                        max_strlen, strlen_buffer.data());
+                        max_str_len, str_len_buffer.data());
 
   std::stringstream ss;
   int64_t value_offset = 0;
@@ -83,13 +84,13 @@ TEST(BinaryArrayAccessor, Test_CDataType_BINARY_Truncation) {
     int64_t original_value_offset = value_offset;
     ASSERT_EQ(1, accessor.GetColumnarData(&binding, 0, 1, value_offset, true, diagnostics,
                                           nullptr));
-    ASSERT_EQ(values[0].length() - original_value_offset, strlen_buffer[0]);
+    ASSERT_EQ(values[0].length() - original_value_offset, str_len_buffer[0]);
 
     int64_t chunk_length = 0;
     if (value_offset == -1) {
-      chunk_length = strlen_buffer[0];
+      chunk_length = str_len_buffer[0];
     } else {
-      chunk_length = max_strlen;
+      chunk_length = max_str_len;
     }
 
     // Beware that CDataType_BINARY values are not null terminated.

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/boolean_array_accessor.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/boolean_array_accessor.cc
@@ -29,7 +29,7 @@ BooleanArrayFlightSqlAccessor<TARGET_TYPE>::BooleanArrayFlightSqlAccessor(Array*
                         BooleanArrayFlightSqlAccessor<TARGET_TYPE>>(array) {}
 
 template <CDataType TARGET_TYPE>
-RowStatus BooleanArrayFlightSqlAccessor<TARGET_TYPE>::MoveSingleCell_impl(
+RowStatus BooleanArrayFlightSqlAccessor<TARGET_TYPE>::MoveSingleCellImpl(
     ColumnBinding* binding, int64_t arrow_row, int64_t i, int64_t& value_offset,
     bool update_value_offset, odbcabstraction::Diagnostics& diagnostics) {
   typedef unsigned char c_type;
@@ -38,15 +38,15 @@ RowStatus BooleanArrayFlightSqlAccessor<TARGET_TYPE>::MoveSingleCell_impl(
   auto* buffer = static_cast<c_type*>(binding->buffer);
   buffer[i] = value ? 1 : 0;
 
-  if (binding->strlen_buffer) {
-    binding->strlen_buffer[i] = static_cast<ssize_t>(GetCellLength_impl(binding));
+  if (binding->str_len_buffer) {
+    binding->str_len_buffer[i] = static_cast<ssize_t>(GetCellLengthImpl(binding));
   }
 
   return odbcabstraction::RowStatus_SUCCESS;
 }
 
 template <CDataType TARGET_TYPE>
-size_t BooleanArrayFlightSqlAccessor<TARGET_TYPE>::GetCellLength_impl(
+size_t BooleanArrayFlightSqlAccessor<TARGET_TYPE>::GetCellLengthImpl(
     ColumnBinding* binding) const {
   return sizeof(unsigned char);
 }

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/boolean_array_accessor.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/boolean_array_accessor.h
@@ -35,11 +35,11 @@ class BooleanArrayFlightSqlAccessor
  public:
   explicit BooleanArrayFlightSqlAccessor(Array* array);
 
-  RowStatus MoveSingleCell_impl(ColumnBinding* binding, int64_t arrow_row, int64_t i,
-                                int64_t& value_offset, bool update_value_offset,
-                                odbcabstraction::Diagnostics& diagnostics);
+  RowStatus MoveSingleCellImpl(ColumnBinding* binding, int64_t arrow_row, int64_t i,
+                               int64_t& value_offset, bool update_value_offset,
+                               odbcabstraction::Diagnostics& diagnostics);
 
-  size_t GetCellLength_impl(ColumnBinding* binding) const;
+  size_t GetCellLengthImpl(ColumnBinding* binding) const;
 };
 
 }  // namespace flight_sql

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/boolean_array_accessor_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/boolean_array_accessor_test.cc
@@ -35,10 +35,10 @@ TEST(BooleanArrayFlightSqlAccessor, Test_BooleanArray_CDataType_BIT) {
   BooleanArrayFlightSqlAccessor<odbcabstraction::CDataType_BIT> accessor(array.get());
 
   std::vector<char> buffer(values.size());
-  std::vector<ssize_t> strlen_buffer(values.size());
+  std::vector<ssize_t> str_len_buffer(values.size());
 
   ColumnBinding binding(odbcabstraction::CDataType_BIT, 0, 0, buffer.data(), 0,
-                        strlen_buffer.data());
+                        str_len_buffer.data());
 
   int64_t value_offset = 0;
   odbcabstraction::Diagnostics diagnostics("Foo", "Foo", OdbcVersion::V_3);
@@ -47,7 +47,7 @@ TEST(BooleanArrayFlightSqlAccessor, Test_BooleanArray_CDataType_BIT) {
                                      diagnostics, nullptr));
 
   for (int i = 0; i < values.size(); ++i) {
-    ASSERT_EQ(sizeof(unsigned char), strlen_buffer[i]);
+    ASSERT_EQ(sizeof(unsigned char), str_len_buffer[i]);
     ASSERT_EQ(values[i] ? 1 : 0, buffer[i]);
   }
 }

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/common.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/common.h
@@ -33,13 +33,13 @@ inline size_t CopyFromArrayValuesToBinding(ARRAY_TYPE* array, ColumnBinding* bin
                                            int64_t starting_row, int64_t cells) {
   constexpr ssize_t element_size = sizeof(typename ARRAY_TYPE::value_type);
 
-  if (binding->strlen_buffer) {
+  if (binding->str_len_buffer) {
     for (int64_t i = 0; i < cells; ++i) {
       int64_t current_row = starting_row + i;
       if (array->IsNull(current_row)) {
-        binding->strlen_buffer[i] = odbcabstraction::NULL_DATA;
+        binding->str_len_buffer[i] = odbcabstraction::NULL_DATA;
       } else {
-        binding->strlen_buffer[i] = element_size;
+        binding->str_len_buffer[i] = element_size;
       }
     }
   } else {

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/date_array_accessor.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/date_array_accessor.cc
@@ -60,7 +60,7 @@ DateArrayFlightSqlAccessor<TARGET_TYPE, ARROW_ARRAY>::DateArrayFlightSqlAccessor
                         DateArrayFlightSqlAccessor<TARGET_TYPE, ARROW_ARRAY>>(array) {}
 
 template <CDataType TARGET_TYPE, typename ARROW_ARRAY>
-RowStatus DateArrayFlightSqlAccessor<TARGET_TYPE, ARROW_ARRAY>::MoveSingleCell_impl(
+RowStatus DateArrayFlightSqlAccessor<TARGET_TYPE, ARROW_ARRAY>::MoveSingleCellImpl(
     ColumnBinding* binding, int64_t arrow_row, int64_t cell_counter,
     int64_t& value_offset, bool update_value_offset,
     odbcabstraction::Diagnostics& diagnostics) {
@@ -74,16 +74,16 @@ RowStatus DateArrayFlightSqlAccessor<TARGET_TYPE, ARROW_ARRAY>::MoveSingleCell_i
   buffer[cell_counter].month = date.tm_mon + 1;
   buffer[cell_counter].day = date.tm_mday;
 
-  if (binding->strlen_buffer) {
-    binding->strlen_buffer[cell_counter] =
-        static_cast<ssize_t>(GetCellLength_impl(binding));
+  if (binding->str_len_buffer) {
+    binding->str_len_buffer[cell_counter] =
+        static_cast<ssize_t>(GetCellLengthImpl(binding));
   }
 
   return odbcabstraction::RowStatus_SUCCESS;
 }
 
 template <CDataType TARGET_TYPE, typename ARROW_ARRAY>
-size_t DateArrayFlightSqlAccessor<TARGET_TYPE, ARROW_ARRAY>::GetCellLength_impl(
+size_t DateArrayFlightSqlAccessor<TARGET_TYPE, ARROW_ARRAY>::GetCellLengthImpl(
     ColumnBinding* binding) const {
   return sizeof(DATE_STRUCT);
 }

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/date_array_accessor.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/date_array_accessor.h
@@ -34,12 +34,12 @@ class DateArrayFlightSqlAccessor
  public:
   explicit DateArrayFlightSqlAccessor(Array* array);
 
-  RowStatus MoveSingleCell_impl(ColumnBinding* binding, int64_t arrow_row,
-                                int64_t cell_counter, int64_t& value_offset,
-                                bool update_value_offset,
-                                odbcabstraction::Diagnostics& diagnostics);
+  RowStatus MoveSingleCellImpl(ColumnBinding* binding, int64_t arrow_row,
+                               int64_t cell_counter, int64_t& value_offset,
+                               bool update_value_offset,
+                               odbcabstraction::Diagnostics& diagnostics);
 
-  size_t GetCellLength_impl(ColumnBinding* binding) const;
+  size_t GetCellLengthImpl(ColumnBinding* binding) const;
 };
 
 }  // namespace flight_sql

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/date_array_accessor_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/date_array_accessor_test.cc
@@ -51,10 +51,10 @@ TEST(DateArrayAccessor, Test_Date32Array_CDataType_DATE) {
       dynamic_cast<NumericArray<Date32Type>*>(array.get()));
 
   std::vector<tagDATE_STRUCT> buffer(values.size());
-  std::vector<ssize_t> strlen_buffer(values.size());
+  std::vector<ssize_t> str_len_buffer(values.size());
 
   ColumnBinding binding(odbcabstraction::CDataType_DATE, 0, 0, buffer.data(), 0,
-                        strlen_buffer.data());
+                        str_len_buffer.data());
 
   int64_t value_offset = 0;
   odbcabstraction::Diagnostics diagnostics("Foo", "Foo", OdbcVersion::V_3);
@@ -63,7 +63,7 @@ TEST(DateArrayAccessor, Test_Date32Array_CDataType_DATE) {
                                      diagnostics, nullptr));
 
   for (size_t i = 0; i < values.size(); ++i) {
-    ASSERT_EQ(sizeof(DATE_STRUCT), strlen_buffer[i]);
+    ASSERT_EQ(sizeof(DATE_STRUCT), str_len_buffer[i]);
 
     ASSERT_EQ(expected[i].year, buffer[i].year);
     ASSERT_EQ(expected[i].month, buffer[i].month);
@@ -89,10 +89,10 @@ TEST(DateArrayAccessor, Test_Date64Array_CDataType_DATE) {
       dynamic_cast<NumericArray<Date64Type>*>(array.get()));
 
   std::vector<tagDATE_STRUCT> buffer(values.size());
-  std::vector<ssize_t> strlen_buffer(values.size());
+  std::vector<ssize_t> str_len_buffer(values.size());
 
   ColumnBinding binding(odbcabstraction::CDataType_DATE, 0, 0, buffer.data(), 0,
-                        strlen_buffer.data());
+                        str_len_buffer.data());
 
   int64_t value_offset = 0;
   odbcabstraction::Diagnostics diagnostics("Foo", "Foo", OdbcVersion::V_3);
@@ -101,7 +101,7 @@ TEST(DateArrayAccessor, Test_Date64Array_CDataType_DATE) {
                                      diagnostics, nullptr));
 
   for (size_t i = 0; i < values.size(); ++i) {
-    ASSERT_EQ(sizeof(DATE_STRUCT), strlen_buffer[i]);
+    ASSERT_EQ(sizeof(DATE_STRUCT), str_len_buffer[i]);
     ASSERT_EQ(expected[i].year, buffer[i].year);
     ASSERT_EQ(expected[i].month, buffer[i].month);
     ASSERT_EQ(expected[i].day, buffer[i].day);

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/decimal_array_accessor.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/decimal_array_accessor.cc
@@ -42,9 +42,9 @@ DecimalArrayFlightSqlAccessor<ARROW_ARRAY, TARGET_TYPE>::DecimalArrayFlightSqlAc
 template <>
 RowStatus
 DecimalArrayFlightSqlAccessor<Decimal128Array, odbcabstraction::CDataType_NUMERIC>::
-    MoveSingleCell_impl(ColumnBinding* binding, int64_t arrow_row, int64_t i,
-                        int64_t& value_offset, bool update_value_offset,
-                        odbcabstraction::Diagnostics& diagnostics) {
+    MoveSingleCellImpl(ColumnBinding* binding, int64_t arrow_row, int64_t i,
+                       int64_t& value_offset, bool update_value_offset,
+                       odbcabstraction::Diagnostics& diagnostics) {
   auto result = &(static_cast<NUMERIC_STRUCT*>(binding->buffer)[i]);
   int32_t original_scale = data_type_->scale();
 
@@ -74,15 +74,15 @@ DecimalArrayFlightSqlAccessor<Decimal128Array, odbcabstraction::CDataType_NUMERI
 
   result->precision = data_type_->precision();
 
-  if (binding->strlen_buffer) {
-    binding->strlen_buffer[i] = static_cast<ssize_t>(GetCellLength_impl(binding));
+  if (binding->str_len_buffer) {
+    binding->str_len_buffer[i] = static_cast<ssize_t>(GetCellLengthImpl(binding));
   }
 
   return odbcabstraction::RowStatus_SUCCESS;
 }
 
 template <typename ARROW_ARRAY, CDataType TARGET_TYPE>
-size_t DecimalArrayFlightSqlAccessor<ARROW_ARRAY, TARGET_TYPE>::GetCellLength_impl(
+size_t DecimalArrayFlightSqlAccessor<ARROW_ARRAY, TARGET_TYPE>::GetCellLengthImpl(
     ColumnBinding* binding) const {
   return sizeof(NUMERIC_STRUCT);
 }

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/decimal_array_accessor.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/decimal_array_accessor.h
@@ -37,11 +37,11 @@ class DecimalArrayFlightSqlAccessor
  public:
   explicit DecimalArrayFlightSqlAccessor(Array* array);
 
-  RowStatus MoveSingleCell_impl(ColumnBinding* binding, int64_t arrow_row, int64_t i,
-                                int64_t& value_offset, bool update_value_offset,
-                                odbcabstraction::Diagnostics& diagnostics);
+  RowStatus MoveSingleCellImpl(ColumnBinding* binding, int64_t arrow_row, int64_t i,
+                               int64_t& value_offset, bool update_value_offset,
+                               odbcabstraction::Diagnostics& diagnostics);
 
-  size_t GetCellLength_impl(ColumnBinding* binding) const;
+  size_t GetCellLengthImpl(ColumnBinding* binding) const;
 
  private:
   Decimal128Type* data_type_;

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/decimal_array_accessor_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/decimal_array_accessor_test.cc
@@ -84,10 +84,10 @@ void AssertNumericOutput(int input_precision, int input_scale,
       accessor(array.get());
 
   std::vector<NUMERIC_STRUCT> buffer(values.size());
-  std::vector<ssize_t> strlen_buffer(values.size());
+  std::vector<ssize_t> str_len_buffer(values.size());
 
   ColumnBinding binding(odbcabstraction::CDataType_NUMERIC, output_precision,
-                        output_scale, buffer.data(), 0, strlen_buffer.data());
+                        output_scale, buffer.data(), 0, str_len_buffer.data());
 
   int64_t value_offset = 0;
   odbcabstraction::Diagnostics diagnostics("Foo", "Foo", OdbcVersion::V_3);
@@ -96,7 +96,7 @@ void AssertNumericOutput(int input_precision, int input_scale,
                                      diagnostics, nullptr));
 
   for (int i = 0; i < values.size(); ++i) {
-    ASSERT_EQ(sizeof(NUMERIC_STRUCT), strlen_buffer[i]);
+    ASSERT_EQ(sizeof(NUMERIC_STRUCT), str_len_buffer[i]);
 
     ASSERT_EQ(output_precision, buffer[i].precision);
     ASSERT_EQ(output_scale, buffer[i].scale);

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/primitive_array_accessor.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/primitive_array_accessor.cc
@@ -39,7 +39,7 @@ PrimitiveArrayFlightSqlAccessor<
           array) {}
 
 template <typename ARROW_ARRAY, CDataType TARGET_TYPE>
-size_t PrimitiveArrayFlightSqlAccessor<ARROW_ARRAY, TARGET_TYPE>::GetColumnarData_impl(
+size_t PrimitiveArrayFlightSqlAccessor<ARROW_ARRAY, TARGET_TYPE>::GetColumnarDataImpl(
     ColumnBinding* binding, int64_t starting_row, int64_t cells, int64_t& value_offset,
     bool update_value_offset, odbcabstraction::Diagnostics& diagnostics,
     uint16_t* row_status_array) {
@@ -48,7 +48,7 @@ size_t PrimitiveArrayFlightSqlAccessor<ARROW_ARRAY, TARGET_TYPE>::GetColumnarDat
 }
 
 template <typename ARROW_ARRAY, CDataType TARGET_TYPE>
-size_t PrimitiveArrayFlightSqlAccessor<ARROW_ARRAY, TARGET_TYPE>::GetCellLength_impl(
+size_t PrimitiveArrayFlightSqlAccessor<ARROW_ARRAY, TARGET_TYPE>::GetCellLengthImpl(
     ColumnBinding* binding) const {
   return sizeof(typename ARROW_ARRAY::TypeClass::c_type);
 }

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/primitive_array_accessor.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/primitive_array_accessor.h
@@ -35,12 +35,12 @@ class PrimitiveArrayFlightSqlAccessor
  public:
   explicit PrimitiveArrayFlightSqlAccessor(Array* array);
 
-  size_t GetColumnarData_impl(ColumnBinding* binding, int64_t starting_row, int64_t cells,
-                              int64_t& value_offset, bool update_value_offset,
-                              odbcabstraction::Diagnostics& diagnostics,
-                              uint16_t* row_status_array);
+  size_t GetColumnarDataImpl(ColumnBinding* binding, int64_t starting_row, int64_t cells,
+                             int64_t& value_offset, bool update_value_offset,
+                             odbcabstraction::Diagnostics& diagnostics,
+                             uint16_t* row_status_array);
 
-  size_t GetCellLength_impl(ColumnBinding* binding) const;
+  size_t GetCellLengthImpl(ColumnBinding* binding) const;
 };
 
 }  // namespace flight_sql

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/primitive_array_accessor_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/primitive_array_accessor_test.cc
@@ -48,10 +48,10 @@ void TestPrimitiveArraySqlAccessor() {
   PrimitiveArrayFlightSqlAccessor<ARROW_ARRAY, TARGET_TYPE> accessor(array.get());
 
   std::vector<c_type> buffer(values.size());
-  std::vector<ssize_t> strlen_buffer(values.size());
+  std::vector<ssize_t> str_len_buffer(values.size());
 
   ColumnBinding binding(TARGET_TYPE, 0, 0, buffer.data(), values.size(),
-                        strlen_buffer.data());
+                        str_len_buffer.data());
 
   int64_t value_offset = 0;
   driver::odbcabstraction::Diagnostics diagnostics("Dummy", "Dummy",
@@ -61,7 +61,7 @@ void TestPrimitiveArraySqlAccessor() {
                                      diagnostics, nullptr));
 
   for (int i = 0; i < values.size(); ++i) {
-    ASSERT_EQ(sizeof(c_type), strlen_buffer[i]);
+    ASSERT_EQ(sizeof(c_type), str_len_buffer[i]);
     ASSERT_EQ(values[i], buffer[i]);
   }
 }

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/string_array_accessor.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/string_array_accessor.cc
@@ -31,11 +31,11 @@ using odbcabstraction::RowStatus;
 namespace {
 
 #if defined _WIN32 || defined _WIN64
-std::string utf8_to_clocale(const char* utf8str, int len) {
+std::string Utf8ToCLocale(const char* utf8_str, int len) {
   thread_local boost::locale::generator g;
   g.locale_cache_enabled(true);
   std::locale loc = g(boost::locale::util::get_system_locale());
-  return boost::locale::conv::from_utf<char>(utf8str, utf8str + len, loc);
+  return boost::locale::conv::from_utf<char>(utf8_str, utf8_str + len, loc);
 }
 #endif
 
@@ -69,7 +69,7 @@ inline RowStatus MoveSingleCellToCharBuffer(std::vector<uint8_t>& buffer,
 #if defined _WIN32 || defined _WIN64
     // Convert to C locale string
     if (last_retrieved_arrow_row != arrow_row) {
-      clocale_str = utf8_to_clocale(raw_value, raw_value_length);
+      clocale_str = Utf8ToCLocale(raw_value, raw_value_length);
       last_retrieved_arrow_row = arrow_row;
     }
     const char* clocale_data = clocale_str.data();
@@ -112,8 +112,8 @@ inline RowStatus MoveSingleCellToCharBuffer(std::vector<uint8_t>& buffer,
     }
   }
 
-  if (binding->strlen_buffer) {
-    binding->strlen_buffer[i] = static_cast<ssize_t>(remaining_length);
+  if (binding->str_len_buffer) {
+    binding->str_len_buffer[i] = static_cast<ssize_t>(remaining_length);
   }
 
   return result;
@@ -129,7 +129,7 @@ StringArrayFlightSqlAccessor<TARGET_TYPE, CHAR_TYPE>::StringArrayFlightSqlAccess
       last_arrow_row_(-1) {}
 
 template <CDataType TARGET_TYPE, typename CHAR_TYPE>
-RowStatus StringArrayFlightSqlAccessor<TARGET_TYPE, CHAR_TYPE>::MoveSingleCell_impl(
+RowStatus StringArrayFlightSqlAccessor<TARGET_TYPE, CHAR_TYPE>::MoveSingleCellImpl(
     ColumnBinding* binding, int64_t arrow_row, int64_t i, int64_t& value_offset,
     bool update_value_offset, odbcabstraction::Diagnostics& diagnostics) {
   return MoveSingleCellToCharBuffer<CHAR_TYPE>(buffer_, last_arrow_row_,
@@ -142,7 +142,7 @@ RowStatus StringArrayFlightSqlAccessor<TARGET_TYPE, CHAR_TYPE>::MoveSingleCell_i
 }
 
 template <CDataType TARGET_TYPE, typename CHAR_TYPE>
-size_t StringArrayFlightSqlAccessor<TARGET_TYPE, CHAR_TYPE>::GetCellLength_impl(
+size_t StringArrayFlightSqlAccessor<TARGET_TYPE, CHAR_TYPE>::GetCellLengthImpl(
     ColumnBinding* binding) const {
   return binding->buffer_length;
 }

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/string_array_accessor.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/string_array_accessor.h
@@ -41,11 +41,11 @@ class StringArrayFlightSqlAccessor
  public:
   explicit StringArrayFlightSqlAccessor(Array* array);
 
-  RowStatus MoveSingleCell_impl(ColumnBinding* binding, int64_t arrow_row, int64_t i,
-                                int64_t& value_offset, bool update_value_offset,
-                                odbcabstraction::Diagnostics& diagnostics);
+  RowStatus MoveSingleCellImpl(ColumnBinding* binding, int64_t arrow_row, int64_t i,
+                               int64_t& value_offset, bool update_value_offset,
+                               odbcabstraction::Diagnostics& diagnostics);
 
-  size_t GetCellLength_impl(ColumnBinding* binding) const;
+  size_t GetCellLengthImpl(ColumnBinding* binding) const;
 
  private:
   std::vector<uint8_t> buffer_;

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/string_array_accessor_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/string_array_accessor_test.cc
@@ -37,12 +37,12 @@ TEST(StringArrayAccessor, Test_CDataType_CHAR_Basic) {
   StringArrayFlightSqlAccessor<odbcabstraction::CDataType_CHAR, char> accessor(
       array.get());
 
-  size_t max_strlen = 64;
-  std::vector<char> buffer(values.size() * max_strlen);
-  std::vector<ssize_t> strlen_buffer(values.size());
+  size_t max_str_len = 64;
+  std::vector<char> buffer(values.size() * max_str_len);
+  std::vector<ssize_t> str_len_buffer(values.size());
 
-  ColumnBinding binding(odbcabstraction::CDataType_CHAR, 0, 0, buffer.data(), max_strlen,
-                        strlen_buffer.data());
+  ColumnBinding binding(odbcabstraction::CDataType_CHAR, 0, 0, buffer.data(), max_str_len,
+                        str_len_buffer.data());
 
   int64_t value_offset = 0;
   odbcabstraction::Diagnostics diagnostics("Foo", "Foo", OdbcVersion::V_3);
@@ -51,8 +51,8 @@ TEST(StringArrayAccessor, Test_CDataType_CHAR_Basic) {
                                      diagnostics, nullptr));
 
   for (int i = 0; i < values.size(); ++i) {
-    ASSERT_EQ(values[i].length(), strlen_buffer[i]);
-    ASSERT_EQ(values[i], std::string(buffer.data() + i * max_strlen));
+    ASSERT_EQ(values[i].length(), str_len_buffer[i]);
+    ASSERT_EQ(values[i], std::string(buffer.data() + i * max_str_len));
   }
 }
 
@@ -64,12 +64,12 @@ TEST(StringArrayAccessor, Test_CDataType_CHAR_Truncation) {
   StringArrayFlightSqlAccessor<odbcabstraction::CDataType_CHAR, char> accessor(
       array.get());
 
-  size_t max_strlen = 8;
-  std::vector<char> buffer(values.size() * max_strlen);
-  std::vector<ssize_t> strlen_buffer(values.size());
+  size_t max_str_len = 8;
+  std::vector<char> buffer(values.size() * max_str_len);
+  std::vector<ssize_t> str_len_buffer(values.size());
 
-  ColumnBinding binding(odbcabstraction::CDataType_CHAR, 0, 0, buffer.data(), max_strlen,
-                        strlen_buffer.data());
+  ColumnBinding binding(odbcabstraction::CDataType_CHAR, 0, 0, buffer.data(), max_str_len,
+                        str_len_buffer.data());
 
   std::stringstream ss;
   int64_t value_offset = 0;
@@ -82,7 +82,7 @@ TEST(StringArrayAccessor, Test_CDataType_CHAR_Truncation) {
     int64_t original_value_offset = value_offset;
     ASSERT_EQ(1, accessor.GetColumnarData(&binding, 0, 1, value_offset, true, diagnostics,
                                           nullptr));
-    ASSERT_EQ(values[0].length() - original_value_offset, strlen_buffer[0]);
+    ASSERT_EQ(values[0].length() - original_value_offset, str_len_buffer[0]);
 
     ss << buffer.data();
   } while (value_offset < static_cast<int64_t>(values[0].length()) && value_offset != -1);
@@ -97,12 +97,12 @@ TEST(StringArrayAccessor, Test_CDataType_WCHAR_Basic) {
 
   auto accessor = CreateWCharStringArrayAccessor(array.get());
 
-  size_t max_strlen = 64;
-  std::vector<uint8_t> buffer(values.size() * max_strlen);
-  std::vector<ssize_t> strlen_buffer(values.size());
+  size_t max_str_len = 64;
+  std::vector<uint8_t> buffer(values.size() * max_str_len);
+  std::vector<ssize_t> str_len_buffer(values.size());
 
-  ColumnBinding binding(odbcabstraction::CDataType_WCHAR, 0, 0, buffer.data(), max_strlen,
-                        strlen_buffer.data());
+  ColumnBinding binding(odbcabstraction::CDataType_WCHAR, 0, 0, buffer.data(),
+                        max_str_len, str_len_buffer.data());
 
   int64_t value_offset = 0;
   odbcabstraction::Diagnostics diagnostics("Foo", "Foo", OdbcVersion::V_3);
@@ -111,11 +111,11 @@ TEST(StringArrayAccessor, Test_CDataType_WCHAR_Basic) {
                                       diagnostics, nullptr));
 
   for (int i = 0; i < values.size(); ++i) {
-    ASSERT_EQ(values[i].length() * GetSqlWCharSize(), strlen_buffer[i]);
+    ASSERT_EQ(values[i].length() * GetSqlWCharSize(), str_len_buffer[i]);
     std::vector<uint8_t> expected;
     Utf8ToWcs(values[i].c_str(), &expected);
-    uint8_t* start = buffer.data() + i * max_strlen;
-    auto actual = std::vector<uint8_t>(start, start + strlen_buffer[i]);
+    uint8_t* start = buffer.data() + i * max_str_len;
+    auto actual = std::vector<uint8_t>(start, start + str_len_buffer[i]);
     ASSERT_EQ(expected, actual);
   }
 }
@@ -127,12 +127,12 @@ TEST(StringArrayAccessor, Test_CDataType_WCHAR_Truncation) {
 
   auto accessor = CreateWCharStringArrayAccessor(array.get());
 
-  size_t max_strlen = 8;
-  std::vector<uint8_t> buffer(values.size() * max_strlen);
-  std::vector<ssize_t> strlen_buffer(values.size());
+  size_t max_str_len = 8;
+  std::vector<uint8_t> buffer(values.size() * max_str_len);
+  std::vector<ssize_t> str_len_buffer(values.size());
 
-  ColumnBinding binding(odbcabstraction::CDataType_WCHAR, 0, 0, buffer.data(), max_strlen,
-                        strlen_buffer.data());
+  ColumnBinding binding(odbcabstraction::CDataType_WCHAR, 0, 0, buffer.data(),
+                        max_str_len, str_len_buffer.data());
 
   std::basic_stringstream<uint8_t> ss;
   int64_t value_offset = 0;
@@ -147,7 +147,7 @@ TEST(StringArrayAccessor, Test_CDataType_WCHAR_Truncation) {
     ASSERT_EQ(1, accessor->GetColumnarData(&binding, 0, 1, value_offset, true,
                                            diagnostics, nullptr));
     ASSERT_EQ(values[0].length() * GetSqlWCharSize() - original_value_offset,
-              strlen_buffer[0]);
+              str_len_buffer[0]);
 
     size_t length = value_offset - original_value_offset;
     if (value_offset == -1) {

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/time_array_accessor.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/time_array_accessor.cc
@@ -97,7 +97,7 @@ TimeArrayFlightSqlAccessor<TARGET_TYPE, ARROW_ARRAY, UNIT>::TimeArrayFlightSqlAc
           array) {}
 
 template <CDataType TARGET_TYPE, typename ARROW_ARRAY, TimeUnit::type UNIT>
-RowStatus TimeArrayFlightSqlAccessor<TARGET_TYPE, ARROW_ARRAY, UNIT>::MoveSingleCell_impl(
+RowStatus TimeArrayFlightSqlAccessor<TARGET_TYPE, ARROW_ARRAY, UNIT>::MoveSingleCellImpl(
     ColumnBinding* binding, int64_t arrow_row, int64_t cell_counter,
     int64_t& value_offset, bool update_value_offset,
     odbcabstraction::Diagnostics& diagnostic) {
@@ -114,15 +114,15 @@ RowStatus TimeArrayFlightSqlAccessor<TARGET_TYPE, ARROW_ARRAY, UNIT>::MoveSingle
   buffer[cell_counter].minute = time.tm_min;
   buffer[cell_counter].second = time.tm_sec;
 
-  if (binding->strlen_buffer) {
-    binding->strlen_buffer[cell_counter] =
-        static_cast<ssize_t>(GetCellLength_impl(binding));
+  if (binding->str_len_buffer) {
+    binding->str_len_buffer[cell_counter] =
+        static_cast<ssize_t>(GetCellLengthImpl(binding));
   }
   return odbcabstraction::RowStatus_SUCCESS;
 }
 
 template <CDataType TARGET_TYPE, typename ARROW_ARRAY, TimeUnit::type UNIT>
-size_t TimeArrayFlightSqlAccessor<TARGET_TYPE, ARROW_ARRAY, UNIT>::GetCellLength_impl(
+size_t TimeArrayFlightSqlAccessor<TARGET_TYPE, ARROW_ARRAY, UNIT>::GetCellLengthImpl(
     ColumnBinding* binding) const {
   return sizeof(TIME_STRUCT);
 }

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/time_array_accessor.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/time_array_accessor.h
@@ -37,12 +37,12 @@ class TimeArrayFlightSqlAccessor
  public:
   explicit TimeArrayFlightSqlAccessor(Array* array);
 
-  RowStatus MoveSingleCell_impl(ColumnBinding* binding, int64_t arrow_row,
-                                int64_t cell_counter, int64_t& value_offset,
-                                bool update_value_offset,
-                                odbcabstraction::Diagnostics& diagnostic);
+  RowStatus MoveSingleCellImpl(ColumnBinding* binding, int64_t arrow_row,
+                               int64_t cell_counter, int64_t& value_offset,
+                               bool update_value_offset,
+                               odbcabstraction::Diagnostics& diagnostic);
 
-  size_t GetCellLength_impl(ColumnBinding* binding) const;
+  size_t GetCellLengthImpl(ColumnBinding* binding) const;
 };
 
 }  // namespace flight_sql

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/time_array_accessor_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/time_array_accessor_test.cc
@@ -50,10 +50,10 @@ TEST(TEST_TIME32, TIME_WITH_SECONDS) {
       accessor(time32_array.get());
 
   std::vector<TIME_STRUCT> buffer(t32_values.size());
-  std::vector<ssize_t> strlen_buffer(t32_values.size());
+  std::vector<ssize_t> str_len_buffer(t32_values.size());
 
   ColumnBinding binding(odbcabstraction::CDataType_TIME, 0, 0, buffer.data(), 0,
-                        strlen_buffer.data());
+                        str_len_buffer.data());
 
   int64_t value_offset = 0;
   odbcabstraction::Diagnostics diagnostics("Foo", "Foo", OdbcVersion::V_3);
@@ -62,7 +62,7 @@ TEST(TEST_TIME32, TIME_WITH_SECONDS) {
                                      diagnostics, nullptr));
 
   for (size_t i = 0; i < t32_values.size(); ++i) {
-    ASSERT_EQ(sizeof(TIME_STRUCT), strlen_buffer[i]);
+    ASSERT_EQ(sizeof(TIME_STRUCT), str_len_buffer[i]);
 
     tm time{};
 
@@ -86,10 +86,10 @@ TEST(TEST_TIME32, TIME_WITH_MILLI) {
       accessor(time32_array.get());
 
   std::vector<TIME_STRUCT> buffer(t32_values.size());
-  std::vector<ssize_t> strlen_buffer(t32_values.size());
+  std::vector<ssize_t> str_len_buffer(t32_values.size());
 
   ColumnBinding binding(odbcabstraction::CDataType_TIME, 0, 0, buffer.data(), 0,
-                        strlen_buffer.data());
+                        str_len_buffer.data());
 
   int64_t value_offset = 0;
   odbcabstraction::Diagnostics diagnostics("Foo", "Foo", OdbcVersion::V_3);
@@ -98,12 +98,12 @@ TEST(TEST_TIME32, TIME_WITH_MILLI) {
                                      diagnostics, nullptr));
 
   for (size_t i = 0; i < t32_values.size(); ++i) {
-    ASSERT_EQ(sizeof(TIME_STRUCT), strlen_buffer[i]);
+    ASSERT_EQ(sizeof(TIME_STRUCT), str_len_buffer[i]);
 
     tm time{};
 
-    auto convertedValue = t32_values[i] / odbcabstraction::MILLI_TO_SECONDS_DIVISOR;
-    GetTimeForSecondsSinceEpoch(convertedValue, time);
+    auto converted_value = t32_values[i] / odbcabstraction::MILLI_TO_SECONDS_DIVISOR;
+    GetTimeForSecondsSinceEpoch(converted_value, time);
 
     ASSERT_EQ(buffer[i].hour, time.tm_hour);
     ASSERT_EQ(buffer[i].minute, time.tm_min);
@@ -125,10 +125,10 @@ TEST(TEST_TIME64, TIME_WITH_MICRO) {
       accessor(time64_array.get());
 
   std::vector<TIME_STRUCT> buffer(t64_values.size());
-  std::vector<ssize_t> strlen_buffer(t64_values.size());
+  std::vector<ssize_t> str_len_buffer(t64_values.size());
 
   ColumnBinding binding(odbcabstraction::CDataType_TIME, 0, 0, buffer.data(), 0,
-                        strlen_buffer.data());
+                        str_len_buffer.data());
 
   int64_t value_offset = 0;
   odbcabstraction::Diagnostics diagnostics("Foo", "Foo", OdbcVersion::V_3);
@@ -137,7 +137,7 @@ TEST(TEST_TIME64, TIME_WITH_MICRO) {
                                      diagnostics, nullptr));
 
   for (size_t i = 0; i < t64_values.size(); ++i) {
-    ASSERT_EQ(sizeof(TIME_STRUCT), strlen_buffer[i]);
+    ASSERT_EQ(sizeof(TIME_STRUCT), str_len_buffer[i]);
 
     tm time{};
 
@@ -162,10 +162,10 @@ TEST(TEST_TIME64, TIME_WITH_NANO) {
       accessor(time64_array.get());
 
   std::vector<TIME_STRUCT> buffer(t64_values.size());
-  std::vector<ssize_t> strlen_buffer(t64_values.size());
+  std::vector<ssize_t> str_len_buffer(t64_values.size());
 
   ColumnBinding binding(odbcabstraction::CDataType_TIME, 0, 0, buffer.data(), 0,
-                        strlen_buffer.data());
+                        str_len_buffer.data());
 
   int64_t value_offset = 0;
   odbcabstraction::Diagnostics diagnostics("Foo", "Foo", OdbcVersion::V_3);
@@ -174,12 +174,12 @@ TEST(TEST_TIME64, TIME_WITH_NANO) {
                                      diagnostics, nullptr));
 
   for (size_t i = 0; i < t64_values.size(); ++i) {
-    ASSERT_EQ(sizeof(TIME_STRUCT), strlen_buffer[i]);
+    ASSERT_EQ(sizeof(TIME_STRUCT), str_len_buffer[i]);
 
     tm time{};
 
-    const auto convertedValue = t64_values[i] / odbcabstraction::NANO_TO_SECONDS_DIVISOR;
-    GetTimeForSecondsSinceEpoch(convertedValue, time);
+    const auto converted_value = t64_values[i] / odbcabstraction::NANO_TO_SECONDS_DIVISOR;
+    GetTimeForSecondsSinceEpoch(converted_value, time);
 
     ASSERT_EQ(buffer[i].hour, time.tm_hour);
     ASSERT_EQ(buffer[i].minute, time.tm_min);

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/timestamp_array_accessor.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/timestamp_array_accessor.cc
@@ -81,7 +81,7 @@ TimestampArrayFlightSqlAccessor<TARGET_TYPE, UNIT>::TimestampArrayFlightSqlAcces
                         TimestampArrayFlightSqlAccessor<TARGET_TYPE, UNIT>>(array) {}
 
 template <CDataType TARGET_TYPE, TimeUnit::type UNIT>
-RowStatus TimestampArrayFlightSqlAccessor<TARGET_TYPE, UNIT>::MoveSingleCell_impl(
+RowStatus TimestampArrayFlightSqlAccessor<TARGET_TYPE, UNIT>::MoveSingleCellImpl(
     ColumnBinding* binding, int64_t arrow_row, int64_t cell_counter,
     int64_t& value_offset, bool update_value_offset,
     odbcabstraction::Diagnostics& diagnostics) {
@@ -113,16 +113,16 @@ RowStatus TimestampArrayFlightSqlAccessor<TARGET_TYPE, UNIT>::MoveSingleCell_imp
   buffer[cell_counter].second = timestamp.tm_sec;
   buffer[cell_counter].fraction = CalculateFraction(UNIT, value);
 
-  if (binding->strlen_buffer) {
-    binding->strlen_buffer[cell_counter] =
-        static_cast<ssize_t>(GetCellLength_impl(binding));
+  if (binding->str_len_buffer) {
+    binding->str_len_buffer[cell_counter] =
+        static_cast<ssize_t>(GetCellLengthImpl(binding));
   }
 
   return odbcabstraction::RowStatus_SUCCESS;
 }
 
 template <CDataType TARGET_TYPE, TimeUnit::type UNIT>
-size_t TimestampArrayFlightSqlAccessor<TARGET_TYPE, UNIT>::GetCellLength_impl(
+size_t TimestampArrayFlightSqlAccessor<TARGET_TYPE, UNIT>::GetCellLengthImpl(
     ColumnBinding* binding) const {
   return sizeof(TIMESTAMP_STRUCT);
 }

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/timestamp_array_accessor.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/timestamp_array_accessor.h
@@ -36,12 +36,12 @@ class TimestampArrayFlightSqlAccessor
  public:
   explicit TimestampArrayFlightSqlAccessor(Array* array);
 
-  RowStatus MoveSingleCell_impl(ColumnBinding* binding, int64_t arrow_row,
-                                int64_t cell_counter, int64_t& value_offset,
-                                bool update_value_offset,
-                                odbcabstraction::Diagnostics& diagnostics);
+  RowStatus MoveSingleCellImpl(ColumnBinding* binding, int64_t arrow_row,
+                               int64_t cell_counter, int64_t& value_offset,
+                               bool update_value_offset,
+                               odbcabstraction::Diagnostics& diagnostics);
 
-  size_t GetCellLength_impl(ColumnBinding* binding) const;
+  size_t GetCellLengthImpl(ColumnBinding* binding) const;
 };
 
 }  // namespace flight_sql

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/timestamp_array_accessor_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/timestamp_array_accessor_test.cc
@@ -74,18 +74,18 @@ TEST(TEST_TIMESTAMP, TIMESTAMP_WITH_MILLI) {
       accessor(timestamp_array.get());
 
   std::vector<TIMESTAMP_STRUCT> buffer(values.size());
-  std::vector<ssize_t> strlen_buffer(values.size());
+  std::vector<ssize_t> str_len_buffer(values.size());
 
   int64_t value_offset = 0;
   ColumnBinding binding(odbcabstraction::CDataType_TIMESTAMP, 0, 0, buffer.data(), 0,
-                        strlen_buffer.data());
+                        str_len_buffer.data());
   odbcabstraction::Diagnostics diagnostics("Foo", "Foo", OdbcVersion::V_3);
   ASSERT_EQ(values.size(),
             accessor.GetColumnarData(&binding, 0, values.size(), value_offset, false,
                                      diagnostics, nullptr));
 
   for (size_t i = 0; i < values.size(); ++i) {
-    ASSERT_EQ(sizeof(TIMESTAMP_STRUCT), strlen_buffer[i]);
+    ASSERT_EQ(sizeof(TIMESTAMP_STRUCT), str_len_buffer[i]);
 
     ASSERT_EQ(buffer[i].year, expected[i].year);
     ASSERT_EQ(buffer[i].month, expected[i].month);
@@ -111,11 +111,11 @@ TEST(TEST_TIMESTAMP, TIMESTAMP_WITH_SECONDS) {
       accessor(timestamp_array.get());
 
   std::vector<TIMESTAMP_STRUCT> buffer(values.size());
-  std::vector<ssize_t> strlen_buffer(values.size());
+  std::vector<ssize_t> str_len_buffer(values.size());
 
   int64_t value_offset = 0;
   ColumnBinding binding(odbcabstraction::CDataType_TIMESTAMP, 0, 0, buffer.data(), 0,
-                        strlen_buffer.data());
+                        str_len_buffer.data());
   odbcabstraction::Diagnostics diagnostics("Foo", "Foo", OdbcVersion::V_3);
 
   ASSERT_EQ(values.size(),
@@ -123,7 +123,7 @@ TEST(TEST_TIMESTAMP, TIMESTAMP_WITH_SECONDS) {
                                      diagnostics, nullptr));
 
   for (size_t i = 0; i < values.size(); ++i) {
-    ASSERT_EQ(sizeof(TIMESTAMP_STRUCT), strlen_buffer[i]);
+    ASSERT_EQ(sizeof(TIMESTAMP_STRUCT), str_len_buffer[i]);
     tm date{};
 
     auto converted_time = values[i];
@@ -152,11 +152,11 @@ TEST(TEST_TIMESTAMP, TIMESTAMP_WITH_MICRO) {
       accessor(timestamp_array.get());
 
   std::vector<TIMESTAMP_STRUCT> buffer(values.size());
-  std::vector<ssize_t> strlen_buffer(values.size());
+  std::vector<ssize_t> str_len_buffer(values.size());
 
   int64_t value_offset = 0;
   ColumnBinding binding(odbcabstraction::CDataType_TIMESTAMP, 0, 0, buffer.data(), 0,
-                        strlen_buffer.data());
+                        str_len_buffer.data());
   odbcabstraction::Diagnostics diagnostics("Foo", "Foo", OdbcVersion::V_3);
 
   ASSERT_EQ(values.size(),
@@ -164,7 +164,7 @@ TEST(TEST_TIMESTAMP, TIMESTAMP_WITH_MICRO) {
                                      diagnostics, nullptr));
 
   for (size_t i = 0; i < values.size(); ++i) {
-    ASSERT_EQ(sizeof(TIMESTAMP_STRUCT), strlen_buffer[i]);
+    ASSERT_EQ(sizeof(TIMESTAMP_STRUCT), str_len_buffer[i]);
 
     tm date{};
 
@@ -196,11 +196,11 @@ TEST(TEST_TIMESTAMP, TIMESTAMP_WITH_NANO) {
       accessor(timestamp_array.get());
 
   std::vector<TIMESTAMP_STRUCT> buffer(values.size());
-  std::vector<ssize_t> strlen_buffer(values.size());
+  std::vector<ssize_t> str_len_buffer(values.size());
 
   int64_t value_offset = 0;
   ColumnBinding binding(odbcabstraction::CDataType_TIMESTAMP, 0, 0, buffer.data(), 0,
-                        strlen_buffer.data());
+                        str_len_buffer.data());
 
   odbcabstraction::Diagnostics diagnostics("Foo", "Foo", OdbcVersion::V_3);
   ASSERT_EQ(values.size(),
@@ -208,7 +208,7 @@ TEST(TEST_TIMESTAMP, TIMESTAMP_WITH_NANO) {
                                      diagnostics, nullptr));
 
   for (size_t i = 0; i < values.size(); ++i) {
-    ASSERT_EQ(sizeof(TIMESTAMP_STRUCT), strlen_buffer[i]);
+    ASSERT_EQ(sizeof(TIMESTAMP_STRUCT), str_len_buffer[i]);
     tm date{};
 
     auto converted_time = values[i] / odbcabstraction::NANO_TO_SECONDS_DIVISOR;

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/types.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/accessors/types.h
@@ -37,7 +37,7 @@ class FlightSqlResultSet;
 
 struct ColumnBinding {
   void* buffer;
-  ssize_t* strlen_buffer;
+  ssize_t* str_len_buffer;
   size_t buffer_length;
   CDataType target_type;
   int precision;
@@ -46,13 +46,13 @@ struct ColumnBinding {
   ColumnBinding() = default;
 
   ColumnBinding(CDataType target_type, int precision, int scale, void* buffer,
-                size_t buffer_length, ssize_t* strlen_buffer)
+                size_t buffer_length, ssize_t* str_len_buffer)
       : target_type(target_type),
         precision(precision),
         scale(scale),
         buffer(buffer),
         buffer_length(buffer_length),
-        strlen_buffer(strlen_buffer) {}
+        str_len_buffer(str_len_buffer) {}
 };
 
 /// \brief Accessor interface meant to provide a way of populating data of a
@@ -86,31 +86,31 @@ class FlightSqlAccessor : public Accessor {
                          int64_t& value_offset, bool update_value_offset,
                          odbcabstraction::Diagnostics& diagnostics,
                          uint16_t* row_status_array) override {
-    return static_cast<DERIVED*>(this)->GetColumnarData_impl(
+    return static_cast<DERIVED*>(this)->GetColumnarDataImpl(
         binding, starting_row, cells, value_offset, update_value_offset, diagnostics,
         row_status_array);
   }
 
   size_t GetCellLength(ColumnBinding* binding) const override {
-    return static_cast<const DERIVED*>(this)->GetCellLength_impl(binding);
+    return static_cast<const DERIVED*>(this)->GetCellLengthImpl(binding);
   }
 
  protected:
-  size_t GetColumnarData_impl(ColumnBinding* binding, int64_t starting_row, int64_t cells,
-                              int64_t& value_offset, bool update_value_offset,
-                              odbcabstraction::Diagnostics& diagnostics,
-                              uint16_t* row_status_array) {
+  size_t GetColumnarDataImpl(ColumnBinding* binding, int64_t starting_row, int64_t cells,
+                             int64_t& value_offset, bool update_value_offset,
+                             odbcabstraction::Diagnostics& diagnostics,
+                             uint16_t* row_status_array) {
     for (int64_t i = 0; i < cells; ++i) {
       int64_t current_arrow_row = starting_row + i;
       if (array_->IsNull(current_arrow_row)) {
-        if (binding->strlen_buffer) {
-          binding->strlen_buffer[i] = odbcabstraction::NULL_DATA;
+        if (binding->str_len_buffer) {
+          binding->str_len_buffer[i] = odbcabstraction::NULL_DATA;
         } else {
           throw odbcabstraction::NullWithoutIndicatorException();
         }
       } else {
         // TODO: Optimize this by creating different versions of MoveSingleCell
-        // depending on if strlen_buffer is null.
+        // depending on if str_len_buffer is null.
         auto row_status = MoveSingleCell(binding, current_arrow_row, i, value_offset,
                                          update_value_offset, diagnostics);
         if (row_status_array) {
@@ -131,11 +131,11 @@ class FlightSqlAccessor : public Accessor {
                                             int64_t i, int64_t& value_offset,
                                             bool update_value_offset,
                                             odbcabstraction::Diagnostics& diagnostics) {
-    return static_cast<DERIVED*>(this)->MoveSingleCell_impl(
+    return static_cast<DERIVED*>(this)->MoveSingleCellImpl(
         binding, arrow_row, i, value_offset, update_value_offset, diagnostics);
   }
 
-  odbcabstraction::RowStatus MoveSingleCell_impl(
+  odbcabstraction::RowStatus MoveSingleCellImpl(
       ColumnBinding* binding, int64_t arrow_row, int64_t i, int64_t& value_offset,
       bool update_value_offset, odbcabstraction::Diagnostics& diagnostics) {
     std::stringstream ss;

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/config/configuration.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/config/configuration.cc
@@ -167,12 +167,12 @@ const driver::odbcabstraction::Connection::ConnPropertyMap& Configuration::GetPr
 }
 
 std::vector<std::string_view> Configuration::GetCustomKeys() const {
-  driver::odbcabstraction::Connection::ConnPropertyMap copyProps(properties);
+  driver::odbcabstraction::Connection::ConnPropertyMap copy_props(properties);
   for (auto& key : FlightSqlConnection::ALL_KEYS) {
-    copyProps.erase(key);
+    copy_props.erase(key);
   }
   std::vector<std::string_view> keys;
-  boost::copy(copyProps | boost::adaptors::map_keys, std::back_inserter(keys));
+  boost::copy(copy_props | boost::adaptors::map_keys, std::back_inserter(keys));
   return keys;
 }
 

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/config/configuration.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/config/configuration.cc
@@ -139,15 +139,15 @@ void Configuration::LoadDsn(const std::string& dsn) {
   }
 }
 
-void Configuration::Clear() { this->properties.clear(); }
+void Configuration::Clear() { this->properties_.clear(); }
 
 bool Configuration::IsSet(const std::string_view& key) const {
-  return 0 != this->properties.count(key);
+  return 0 != this->properties_.count(key);
 }
 
 const std::string& Configuration::Get(const std::string_view& key) const {
-  const auto itr = this->properties.find(key);
-  if (itr == this->properties.cend()) {
+  const auto itr = this->properties_.find(key);
+  if (itr == this->properties_.cend()) {
     static const std::string empty("");
     return empty;
   }
@@ -157,17 +157,17 @@ const std::string& Configuration::Get(const std::string_view& key) const {
 void Configuration::Set(const std::string_view& key, const std::string& value) {
   const std::string copy = boost::trim_copy(value);
   if (!copy.empty()) {
-    this->properties[key] = value;
+    this->properties_[key] = value;
   }
 }
 
 const driver::odbcabstraction::Connection::ConnPropertyMap& Configuration::GetProperties()
     const {
-  return this->properties;
+  return this->properties_;
 }
 
 std::vector<std::string_view> Configuration::GetCustomKeys() const {
-  driver::odbcabstraction::Connection::ConnPropertyMap copy_props(properties);
+  driver::odbcabstraction::Connection::ConnPropertyMap copy_props(properties_);
   for (auto& key : FlightSqlConnection::ALL_KEYS) {
     copy_props.erase(key);
   }

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/config/connection_string_parser.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/config/connection_string_parser.cc
@@ -31,7 +31,7 @@ namespace driver {
 namespace flight_sql {
 namespace config {
 
-ConnectionStringParser::ConnectionStringParser(Configuration& cfg) : cfg(cfg) {
+ConnectionStringParser::ConnectionStringParser(Configuration& cfg) : cfg_(cfg) {
   // No-op.
 }
 
@@ -73,7 +73,7 @@ void ConnectionStringParser::ParseConnectionString(const char* str, size_t len,
         value = value.substr(1, value.size() - 2);
       }
 
-      cfg.Set(key, value);
+      cfg_.Set(key, value);
     }
 
     if (!attr_begin) break;

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_auth_method.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_auth_method.cc
@@ -88,14 +88,15 @@ class UserPasswordAuthMethod : public FlightSqlAuthMethod {
         client_.AuthenticateBasicToken(auth_call_options, user_, password_);
 
     if (!bearer_result.ok()) {
-      const auto& flightStatus =
+      const auto& flight_status =
           arrow::flight::FlightStatusDetail::UnwrapStatus(bearer_result.status());
-      if (flightStatus != nullptr) {
-        if (flightStatus->code() == arrow::flight::FlightStatusCode::Unauthenticated) {
+      if (flight_status != nullptr) {
+        if (flight_status->code() == arrow::flight::FlightStatusCode::Unauthenticated) {
           throw AuthenticationException(
               "Failed to authenticate with user and password: " +
               bearer_result.status().ToString());
-        } else if (flightStatus->code() == arrow::flight::FlightStatusCode::Unavailable) {
+        } else if (flight_status->code() ==
+                   arrow::flight::FlightStatusCode::Unavailable) {
           throw CommunicationException(bearer_result.status().message());
         }
       }
@@ -134,12 +135,13 @@ class TokenAuthMethod : public FlightSqlAuthMethod {
         call_options,
         std::unique_ptr<arrow::flight::ClientAuthHandler>(new NoOpClientAuthHandler()));
     if (!status.ok()) {
-      const auto& flightStatus = arrow::flight::FlightStatusDetail::UnwrapStatus(status);
-      if (flightStatus != nullptr) {
-        if (flightStatus->code() == arrow::flight::FlightStatusCode::Unauthenticated) {
+      const auto& flight_status = arrow::flight::FlightStatusDetail::UnwrapStatus(status);
+      if (flight_status != nullptr) {
+        if (flight_status->code() == arrow::flight::FlightStatusCode::Unauthenticated) {
           throw AuthenticationException("Failed to authenticate with token: " + token_ +
                                         " Message: " + status.message());
-        } else if (flightStatus->code() == arrow::flight::FlightStatusCode::Unavailable) {
+        } else if (flight_status->code() ==
+                   arrow::flight::FlightStatusCode::Unavailable) {
           throw CommunicationException(status.message());
         }
       }

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_connection.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_connection.cc
@@ -201,9 +201,9 @@ void FlightSqlConnection::Connect(const ConnPropertyMap& properties,
 
 void FlightSqlConnection::PopulateMetadataSettings(
     const Connection::ConnPropertyMap& conn_property_map) {
-  metadata_settings_.string_column_length_ = GetStringColumnLength(conn_property_map);
-  metadata_settings_.use_wide_char_ = GetUseWideChar(conn_property_map);
-  metadata_settings_.chunk_buffer_capacity_ = GetChunkBufferCapacity(conn_property_map);
+  metadata_settings_.string_column_length = GetStringColumnLength(conn_property_map);
+  metadata_settings_.use_wide_char = GetUseWideChar(conn_property_map);
+  metadata_settings_.chunk_buffer_capacity = GetChunkBufferCapacity(conn_property_map);
 }
 
 boost::optional<int32_t> FlightSqlConnection::GetStringColumnLength(

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_connection.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_connection.cc
@@ -139,18 +139,19 @@ Connection::ConnPropertyMap::const_iterator TrackMissingRequiredProperty(
 }  // namespace
 
 std::shared_ptr<FlightSqlSslConfig> LoadFlightSslConfigs(
-    const Connection::ConnPropertyMap& connPropertyMap) {
+    const Connection::ConnPropertyMap& conn_property_map) {
   bool use_encryption =
-      AsBool(connPropertyMap, FlightSqlConnection::USE_ENCRYPTION).value_or(true);
+      AsBool(conn_property_map, FlightSqlConnection::USE_ENCRYPTION).value_or(true);
   bool disable_cert =
-      AsBool(connPropertyMap, FlightSqlConnection::DISABLE_CERTIFICATE_VERIFICATION)
+      AsBool(conn_property_map, FlightSqlConnection::DISABLE_CERTIFICATE_VERIFICATION)
           .value_or(false);
   bool use_system_trusted =
-      AsBool(connPropertyMap, FlightSqlConnection::USE_SYSTEM_TRUST_STORE)
+      AsBool(conn_property_map, FlightSqlConnection::USE_SYSTEM_TRUST_STORE)
           .value_or(SYSTEM_TRUST_STORE_DEFAULT);
 
-  auto trusted_certs_iterator = connPropertyMap.find(FlightSqlConnection::TRUSTED_CERTS);
-  auto trusted_certs = trusted_certs_iterator != connPropertyMap.end()
+  auto trusted_certs_iterator =
+      conn_property_map.find(FlightSqlConnection::TRUSTED_CERTS);
+  auto trusted_certs = trusted_certs_iterator != conn_property_map.end()
                            ? trusted_certs_iterator->second
                            : "";
 
@@ -223,7 +224,7 @@ boost::optional<int32_t> FlightSqlConnection::GetStringColumnLength(
   return boost::none;
 }
 
-bool FlightSqlConnection::GetUseWideChar(const ConnPropertyMap& connPropertyMap) {
+bool FlightSqlConnection::GetUseWideChar(const ConnPropertyMap& conn_property_map) {
 #if defined _WIN32 || defined _WIN64
   // Windows should use wide chars by default
   bool default_value = true;
@@ -231,15 +232,15 @@ bool FlightSqlConnection::GetUseWideChar(const ConnPropertyMap& connPropertyMap)
   // Mac and Linux should not use wide chars by default
   bool default_value = false;
 #endif
-  return AsBool(connPropertyMap, FlightSqlConnection::USE_WIDE_CHAR)
+  return AsBool(conn_property_map, FlightSqlConnection::USE_WIDE_CHAR)
       .value_or(default_value);
 }
 
 size_t FlightSqlConnection::GetChunkBufferCapacity(
-    const ConnPropertyMap& connPropertyMap) {
+    const ConnPropertyMap& conn_property_map) {
   size_t default_value = 5;
   try {
-    return AsInt32(1, connPropertyMap, FlightSqlConnection::CHUNK_BUFFER_CAPACITY)
+    return AsInt32(1, conn_property_map, FlightSqlConnection::CHUNK_BUFFER_CAPACITY)
         .value_or(default_value);
   } catch (const std::exception& e) {
     diagnostics_.AddWarning(
@@ -295,18 +296,18 @@ FlightClientOptions FlightSqlConnection::BuildFlightClientOptions(
   // Persist state information using cookies if the FlightProducer supports it.
   options.middleware.push_back(arrow::flight::GetCookieFactory());
 
-  if (ssl_config->useEncryption()) {
-    if (ssl_config->shouldDisableCertificateVerification()) {
+  if (ssl_config->UseEncryption()) {
+    if (ssl_config->ShouldDisableCertificateVerification()) {
       options.disable_server_verification =
-          ssl_config->shouldDisableCertificateVerification();
+          ssl_config->ShouldDisableCertificateVerification();
     } else {
-      if (ssl_config->useSystemTrustStore()) {
+      if (ssl_config->UseSystemTrustStore()) {
         const std::string certs = GetCerts();
 
         options.tls_root_certs = certs;
-      } else if (!ssl_config->getTrustedCerts().empty()) {
+      } else if (!ssl_config->GetTrustedCerts().empty()) {
         arrow::flight::CertKeyPair cert_key_pair;
-        ssl_config->populateOptionsWithCerts(&cert_key_pair);
+        ssl_config->PopulateOptionsWithCerts(&cert_key_pair);
         options.tls_root_certs = cert_key_pair.pem_cert;
       }
     }
@@ -334,7 +335,7 @@ Location FlightSqlConnection::BuildLocation(
   const int& port = boost::lexical_cast<int>(port_iter->second);
 
   Location location;
-  if (ssl_config->useEncryption()) {
+  if (ssl_config->UseEncryption()) {
     AddressInfo address_info;
     char host_name_info[NI_MAXHOST] = "";
     bool operation_result = false;

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_connection.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_connection.h
@@ -33,10 +33,10 @@ class FlightSqlSslConfig;
 
 /// \brief Create an instance of the FlightSqlSslConfig class, from the properties passed
 ///        into the map.
-/// \param connPropertyMap the map with the Connection properties.
-/// \return                An instance of the FlightSqlSslConfig.
+/// \param conn_property_map the map with the Connection properties.
+/// \return                  An instance of the FlightSqlSslConfig.
 std::shared_ptr<FlightSqlSslConfig> LoadFlightSslConfigs(
-    const odbcabstraction::Connection::ConnPropertyMap& connPropertyMap);
+    const odbcabstraction::Connection::ConnPropertyMap& conn_property_map);
 
 class FlightSqlConnection : public odbcabstraction::Connection {
  private:
@@ -50,7 +50,7 @@ class FlightSqlConnection : public odbcabstraction::Connection {
   odbcabstraction::OdbcVersion odbc_version_;
   bool closed_;
 
-  void PopulateMetadataSettings(const Connection::ConnPropertyMap& connPropertyMap);
+  void PopulateMetadataSettings(const Connection::ConnPropertyMap& conn_property_map);
 
  public:
   static const std::vector<std::string_view> ALL_KEYS;
@@ -113,11 +113,12 @@ class FlightSqlConnection : public odbcabstraction::Connection {
   /// \note Visible for testing
   void SetClosed(bool is_closed);
 
-  boost::optional<int32_t> GetStringColumnLength(const ConnPropertyMap& connPropertyMap);
+  boost::optional<int32_t> GetStringColumnLength(
+      const ConnPropertyMap& conn_property_map);
 
-  bool GetUseWideChar(const ConnPropertyMap& connPropertyMap);
+  bool GetUseWideChar(const ConnPropertyMap& conn_property_map);
 
-  size_t GetChunkBufferCapacity(const ConnPropertyMap& connPropertyMap);
+  size_t GetChunkBufferCapacity(const ConnPropertyMap& conn_property_map);
 };
 }  // namespace flight_sql
 }  // namespace driver

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_connection_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_connection_test.cc
@@ -32,20 +32,20 @@ TEST(AttributeTests, SetAndGetAttribute) {
   connection.SetClosed(false);
 
   connection.SetAttribute(Connection::CONNECTION_TIMEOUT, static_cast<uint32_t>(200));
-  const boost::optional<Connection::Attribute> firstValue =
+  const boost::optional<Connection::Attribute> first_value =
       connection.GetAttribute(Connection::CONNECTION_TIMEOUT);
 
-  EXPECT_TRUE(firstValue);
+  EXPECT_TRUE(first_value);
 
-  EXPECT_EQ(boost::get<uint32_t>(*firstValue), static_cast<uint32_t>(200));
+  EXPECT_EQ(boost::get<uint32_t>(*first_value), static_cast<uint32_t>(200));
 
   connection.SetAttribute(Connection::CONNECTION_TIMEOUT, static_cast<uint32_t>(300));
 
-  const boost::optional<Connection::Attribute> changeValue =
+  const boost::optional<Connection::Attribute> change_value =
       connection.GetAttribute(Connection::CONNECTION_TIMEOUT);
 
-  EXPECT_TRUE(changeValue);
-  EXPECT_EQ(boost::get<uint32_t>(*changeValue), static_cast<uint32_t>(300));
+  EXPECT_TRUE(change_value);
+  EXPECT_EQ(boost::get<uint32_t>(*change_value), static_cast<uint32_t>(300));
 
   connection.Close();
 }

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_result_set.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_result_set.cc
@@ -49,7 +49,7 @@ FlightSqlResultSet::FlightSqlResultSet(
     const odbcabstraction::MetadataSettings& metadata_settings)
     : metadata_settings_(metadata_settings),
       chunk_buffer_(flight_sql_client, call_options, flight_info,
-                    metadata_settings_.chunk_buffer_capacity_),
+                    metadata_settings_.chunk_buffer_capacity),
       transformer_(transformer),
       metadata_(transformer
                     ? new FlightSqlResultSetMetadata(transformer->GetTransformedSchema(),
@@ -69,7 +69,7 @@ FlightSqlResultSet::FlightSqlResultSet(
   }
 
   for (size_t i = 0; i < columns_.size(); ++i) {
-    columns_[i] = FlightSqlResultSetColumn(metadata_settings.use_wide_char_);
+    columns_[i] = FlightSqlResultSetColumn(metadata_settings.use_wide_char);
   }
 }
 
@@ -121,10 +121,10 @@ size_t FlightSqlResultSet::Move(size_t rows, size_t bind_offset, size_t bind_typ
 
     for (auto& column : columns_) {
       // There can be unbound columns.
-      if (!column.is_bound_) continue;
+      if (!column.is_bound) continue;
 
       auto* accessor = column.GetAccessorForBinding();
-      ColumnBinding shifted_binding = column.binding_;
+      ColumnBinding shifted_binding = column.binding;
       uint16_t* shifted_row_status_array =
           row_status_array ? &row_status_array[fetched_rows] : nullptr;
 
@@ -260,14 +260,14 @@ void FlightSqlResultSet::BindColumn(int column_n, int16_t target_type, int preci
                                     ssize_t* str_len_buffer) {
   auto& column = columns_[column_n - 1];
   if (buffer == nullptr) {
-    if (column.is_bound_) {
+    if (column.is_bound) {
       num_binding_--;
     }
     column.ResetBinding();
     return;
   }
 
-  if (!column.is_bound_) {
+  if (!column.is_bound) {
     num_binding_++;
   }
 

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_result_set.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_result_set.cc
@@ -143,9 +143,10 @@ size_t FlightSqlResultSet::Move(size_t rows, size_t bind_offset, size_t bind_typ
                 accessor->GetCellLength(&shifted_binding) * fetched_rows + bind_offset;
           }
 
-          if (shifted_binding.strlen_buffer) {
-            shifted_binding.strlen_buffer = reinterpret_cast<ssize_t*>(
-                reinterpret_cast<uint8_t*>(&shifted_binding.strlen_buffer[fetched_rows]) +
+          if (shifted_binding.str_len_buffer) {
+            shifted_binding.str_len_buffer = reinterpret_cast<ssize_t*>(
+                reinterpret_cast<uint8_t*>(
+                    &shifted_binding.str_len_buffer[fetched_rows]) +
                 bind_offset);
           }
 
@@ -162,9 +163,9 @@ size_t FlightSqlResultSet::Move(size_t rows, size_t bind_offset, size_t bind_typ
                                      bind_offset + bind_type * fetched_rows;
           }
 
-          if (shifted_binding.strlen_buffer) {
-            shifted_binding.strlen_buffer = reinterpret_cast<ssize_t*>(
-                reinterpret_cast<uint8_t*>(shifted_binding.strlen_buffer) + bind_offset +
+          if (shifted_binding.str_len_buffer) {
+            shifted_binding.str_len_buffer = reinterpret_cast<ssize_t*>(
+                reinterpret_cast<uint8_t*>(shifted_binding.str_len_buffer) + bind_offset +
                 bind_type * fetched_rows);
           }
 
@@ -182,9 +183,9 @@ size_t FlightSqlResultSet::Move(size_t rows, size_t bind_offset, size_t bind_typ
                   static_cast<uint8_t*>(shifted_binding.buffer) + bind_type;
             }
 
-            if (shifted_binding.strlen_buffer) {
-              shifted_binding.strlen_buffer = reinterpret_cast<ssize_t*>(
-                  reinterpret_cast<uint8_t*>(shifted_binding.strlen_buffer) + bind_type);
+            if (shifted_binding.str_len_buffer) {
+              shifted_binding.str_len_buffer = reinterpret_cast<ssize_t*>(
+                  reinterpret_cast<uint8_t*>(shifted_binding.str_len_buffer) + bind_type);
             }
 
             if (shifted_row_status_array) {
@@ -228,7 +229,7 @@ void FlightSqlResultSet::Cancel() {
 
 bool FlightSqlResultSet::GetData(int column_n, int16_t target_type, int precision,
                                  int scale, void* buffer, size_t buffer_length,
-                                 ssize_t* strlen_buffer) {
+                                 ssize_t* str_len_buffer) {
   reset_get_data_ = true;
   // Check if the offset is already at the end.
   int64_t& value_offset = get_data_offsets_[column_n - 1];
@@ -237,7 +238,7 @@ bool FlightSqlResultSet::GetData(int column_n, int16_t target_type, int precisio
   }
 
   ColumnBinding binding(ConvertCDataTypeFromV2ToV3(target_type), precision, scale, buffer,
-                        buffer_length, strlen_buffer);
+                        buffer_length, str_len_buffer);
 
   auto& column = columns_[column_n - 1];
   Accessor* accessor = column.GetAccessorForGetData(binding.target_type);
@@ -256,7 +257,7 @@ std::shared_ptr<ResultSetMetadata> FlightSqlResultSet::GetMetadata() { return me
 
 void FlightSqlResultSet::BindColumn(int column_n, int16_t target_type, int precision,
                                     int scale, void* buffer, size_t buffer_length,
-                                    ssize_t* strlen_buffer) {
+                                    ssize_t* str_len_buffer) {
   auto& column = columns_[column_n - 1];
   if (buffer == nullptr) {
     if (column.is_bound_) {
@@ -271,7 +272,7 @@ void FlightSqlResultSet::BindColumn(int column_n, int16_t target_type, int preci
   }
 
   ColumnBinding binding(ConvertCDataTypeFromV2ToV3(target_type), precision, scale, buffer,
-                        buffer_length, strlen_buffer);
+                        buffer_length, str_len_buffer);
   column.SetBinding(binding, schema_->field(column_n - 1)->type()->id());
 }
 

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_result_set.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_result_set.h
@@ -74,7 +74,7 @@ class FlightSqlResultSet : public ResultSet {
   void Cancel() override;
 
   bool GetData(int column_n, int16_t target_type, int precision, int scale, void* buffer,
-               size_t buffer_length, ssize_t* strlen_buffer) override;
+               size_t buffer_length, ssize_t* str_len_buffer) override;
 
   size_t Move(size_t rows, size_t bind_offset, size_t bind_type,
               uint16_t* row_status_array) override;
@@ -82,7 +82,7 @@ class FlightSqlResultSet : public ResultSet {
   std::shared_ptr<ResultSetMetadata> GetMetadata() override;
 
   void BindColumn(int column_n, int16_t target_type, int precision, int scale,
-                  void* buffer, size_t buffer_length, ssize_t* strlen_buffer) override;
+                  void* buffer, size_t buffer_length, ssize_t* str_len_buffer) override;
 };
 
 }  // namespace flight_sql

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_result_set_column.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_result_set_column.cc
@@ -50,7 +50,7 @@ std::unique_ptr<Accessor> FlightSqlResultSetColumn::CreateAccessor(
 Accessor* FlightSqlResultSetColumn::GetAccessorForTargetType(CDataType target_type) {
   // Cast the original array to a type matching the target_type.
   if (target_type == odbcabstraction::CDataType_DEFAULT) {
-    target_type = ConvertArrowTypeToC(original_array_->type_id(), use_wide_char_);
+    target_type = ConvertArrowTypeToC(original_array_->type_id(), use_wide_char);
   }
 
   cached_accessor_ = CreateAccessor(target_type);
@@ -58,33 +58,33 @@ Accessor* FlightSqlResultSetColumn::GetAccessorForTargetType(CDataType target_ty
 }
 
 FlightSqlResultSetColumn::FlightSqlResultSetColumn(bool use_wide_char)
-    : use_wide_char_(use_wide_char), is_bound_(false) {}
+    : use_wide_char(use_wide_char), is_bound(false) {}
 
 void FlightSqlResultSetColumn::SetBinding(const ColumnBinding& new_binding,
                                           arrow::Type::type arrow_type) {
-  binding_ = new_binding;
-  is_bound_ = true;
+  binding = new_binding;
+  is_bound = true;
 
-  if (binding_.target_type == odbcabstraction::CDataType_DEFAULT) {
-    binding_.target_type = ConvertArrowTypeToC(arrow_type, use_wide_char_);
+  if (binding.target_type == odbcabstraction::CDataType_DEFAULT) {
+    binding.target_type = ConvertArrowTypeToC(arrow_type, use_wide_char);
   }
 
   // Overwrite the binding if the caller is using SQL_C_NUMERIC and has used zero
   // precision if it is zero (this is precision unset and will always fail).
-  if (binding_.precision == 0 &&
-      binding_.target_type == odbcabstraction::CDataType_NUMERIC) {
-    binding_.precision = arrow::Decimal128Type::kMaxPrecision;
+  if (binding.precision == 0 &&
+      binding.target_type == odbcabstraction::CDataType_NUMERIC) {
+    binding.precision = arrow::Decimal128Type::kMaxPrecision;
   }
 
   // Rebuild the accessor and casted array if the target type changed.
   if (original_array_ &&
-      (!cached_casted_array_ || cached_accessor_->target_type_ != binding_.target_type)) {
-    cached_accessor_ = CreateAccessor(binding_.target_type);
+      (!cached_casted_array_ || cached_accessor_->target_type_ != binding.target_type)) {
+    cached_accessor_ = CreateAccessor(binding.target_type);
   }
 }
 
 void FlightSqlResultSetColumn::ResetBinding() {
-  is_bound_ = false;
+  is_bound = false;
   cached_casted_array_.reset();
   cached_accessor_.reset();
 }

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_result_set_column.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_result_set_column.h
@@ -40,15 +40,15 @@ class FlightSqlResultSetColumn {
   FlightSqlResultSetColumn() = default;
   explicit FlightSqlResultSetColumn(bool use_wide_char);
 
-  ColumnBinding binding_;
-  bool use_wide_char_;
-  bool is_bound_;
+  ColumnBinding binding;
+  bool use_wide_char;
+  bool is_bound;
 
   inline Accessor* GetAccessorForBinding() { return cached_accessor_.get(); }
 
   inline Accessor* GetAccessorForGetData(CDataType target_type) {
     if (target_type == odbcabstraction::CDataType_DEFAULT) {
-      target_type = ConvertArrowTypeToC(original_array_->type_id(), use_wide_char_);
+      target_type = ConvertArrowTypeToC(original_array_->type_id(), use_wide_char);
     }
 
     if (cached_accessor_ && cached_accessor_->target_type_ == target_type) {
@@ -65,8 +65,8 @@ class FlightSqlResultSetColumn {
     original_array_ = std::move(array);
     if (cached_accessor_) {
       cached_accessor_ = CreateAccessor(cached_accessor_->target_type_);
-    } else if (is_bound_) {
-      cached_accessor_ = CreateAccessor(binding_.target_type);
+    } else if (is_bound) {
+      cached_accessor_ = CreateAccessor(binding.target_type);
     } else {
       cached_casted_array_.reset();
       cached_accessor_.reset();

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_result_set_metadata.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_result_set_metadata.cc
@@ -74,7 +74,7 @@ size_t FlightSqlResultSetMetadata::GetPrecision(int column_position) {
 
   int32_t column_size = GetFieldPrecision(field).ValueOrElse([] { return 0; });
   SqlDataType data_type_v3 =
-      GetDataTypeFromArrowField_V3(field, metadata_settings_.use_wide_char_);
+      GetDataTypeFromArrowFieldV3(field, metadata_settings_.use_wide_char_);
 
   return GetColumnSize(data_type_v3, column_size).value_or(0);
 }
@@ -85,16 +85,16 @@ size_t FlightSqlResultSetMetadata::GetScale(int column_position) {
 
   int32_t type_scale = metadata.GetScale().ValueOrElse([] { return 0; });
   SqlDataType data_type_v3 =
-      GetDataTypeFromArrowField_V3(field, metadata_settings_.use_wide_char_);
+      GetDataTypeFromArrowFieldV3(field, metadata_settings_.use_wide_char_);
 
   return GetTypeScale(data_type_v3, type_scale).value_or(0);
 }
 
 uint16_t FlightSqlResultSetMetadata::GetDataType(int column_position) {
   const std::shared_ptr<Field>& field = schema_->field(column_position - 1);
-  const SqlDataType conciseType =
-      GetDataTypeFromArrowField_V3(field, metadata_settings_.use_wide_char_);
-  return GetNonConciseDataType(conciseType);
+  const SqlDataType concise_type =
+      GetDataTypeFromArrowFieldV3(field, metadata_settings_.use_wide_char_);
+  return GetNonConciseDataType(concise_type);
 }
 
 driver::odbcabstraction::Nullability FlightSqlResultSetMetadata::IsNullable(
@@ -135,7 +135,7 @@ size_t FlightSqlResultSetMetadata::GetColumnDisplaySize(int column_position) {
   int32_t column_size = metadata_settings_.string_column_length_.value_or(
       GetFieldPrecision(field).ValueOr(DefaultLengthForVariableLengthColumns));
   SqlDataType data_type_v3 =
-      GetDataTypeFromArrowField_V3(field, metadata_settings_.use_wide_char_);
+      GetDataTypeFromArrowFieldV3(field, metadata_settings_.use_wide_char_);
 
   return GetDisplaySize(data_type_v3, column_size).value_or(odbcabstraction::NO_TOTAL);
 }
@@ -154,7 +154,7 @@ uint16_t FlightSqlResultSetMetadata::GetConciseType(int column_position) {
   const std::shared_ptr<Field>& field = schema_->field(column_position - 1);
 
   const SqlDataType sqlColumnType =
-      GetDataTypeFromArrowField_V3(field, metadata_settings_.use_wide_char_);
+      GetDataTypeFromArrowFieldV3(field, metadata_settings_.use_wide_char_);
   return sqlColumnType;
 }
 
@@ -164,7 +164,7 @@ size_t FlightSqlResultSetMetadata::GetLength(int column_position) {
   int32_t column_size = metadata_settings_.string_column_length_.value_or(
       GetFieldPrecision(field).ValueOr(DefaultLengthForVariableLengthColumns));
   SqlDataType data_type_v3 =
-      GetDataTypeFromArrowField_V3(field, metadata_settings_.use_wide_char_);
+      GetDataTypeFromArrowFieldV3(field, metadata_settings_.use_wide_char_);
 
   return flight_sql::GetLength(data_type_v3, column_size)
       .value_or(DefaultLengthForVariableLengthColumns);
@@ -191,7 +191,7 @@ std::string FlightSqlResultSetMetadata::GetLocalTypeName(int column_position) {
 size_t FlightSqlResultSetMetadata::GetNumPrecRadix(int column_position) {
   const std::shared_ptr<Field>& field = schema_->field(column_position - 1);
   SqlDataType data_type_v3 =
-      GetDataTypeFromArrowField_V3(field, metadata_settings_.use_wide_char_);
+      GetDataTypeFromArrowFieldV3(field, metadata_settings_.use_wide_char_);
 
   return GetRadixFromSqlDataType(data_type_v3).value_or(odbcabstraction::NO_TOTAL);
 }
@@ -203,7 +203,7 @@ size_t FlightSqlResultSetMetadata::GetOctetLength(int column_position) {
   int32_t column_size = metadata_settings_.string_column_length_.value_or(
       GetFieldPrecision(field).ValueOr(DefaultLengthForVariableLengthColumns));
   SqlDataType data_type_v3 =
-      GetDataTypeFromArrowField_V3(field, metadata_settings_.use_wide_char_);
+      GetDataTypeFromArrowFieldV3(field, metadata_settings_.use_wide_char_);
 
   // Workaround to get the precision for Decimal and Numeric types, since server doesn't
   // return it currently.

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_result_set_metadata.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_result_set_metadata.cc
@@ -74,7 +74,7 @@ size_t FlightSqlResultSetMetadata::GetPrecision(int column_position) {
 
   int32_t column_size = GetFieldPrecision(field).ValueOrElse([] { return 0; });
   SqlDataType data_type_v3 =
-      GetDataTypeFromArrowFieldV3(field, metadata_settings_.use_wide_char_);
+      GetDataTypeFromArrowFieldV3(field, metadata_settings_.use_wide_char);
 
   return GetColumnSize(data_type_v3, column_size).value_or(0);
 }
@@ -85,7 +85,7 @@ size_t FlightSqlResultSetMetadata::GetScale(int column_position) {
 
   int32_t type_scale = metadata.GetScale().ValueOrElse([] { return 0; });
   SqlDataType data_type_v3 =
-      GetDataTypeFromArrowFieldV3(field, metadata_settings_.use_wide_char_);
+      GetDataTypeFromArrowFieldV3(field, metadata_settings_.use_wide_char);
 
   return GetTypeScale(data_type_v3, type_scale).value_or(0);
 }
@@ -93,7 +93,7 @@ size_t FlightSqlResultSetMetadata::GetScale(int column_position) {
 uint16_t FlightSqlResultSetMetadata::GetDataType(int column_position) {
   const std::shared_ptr<Field>& field = schema_->field(column_position - 1);
   const SqlDataType concise_type =
-      GetDataTypeFromArrowFieldV3(field, metadata_settings_.use_wide_char_);
+      GetDataTypeFromArrowFieldV3(field, metadata_settings_.use_wide_char);
   return GetNonConciseDataType(concise_type);
 }
 
@@ -132,10 +132,10 @@ std::string FlightSqlResultSetMetadata::GetColumnLabel(int column_position) {
 size_t FlightSqlResultSetMetadata::GetColumnDisplaySize(int column_position) {
   const std::shared_ptr<Field>& field = schema_->field(column_position - 1);
 
-  int32_t column_size = metadata_settings_.string_column_length_.value_or(
+  int32_t column_size = metadata_settings_.string_column_length.value_or(
       GetFieldPrecision(field).ValueOr(DefaultLengthForVariableLengthColumns));
   SqlDataType data_type_v3 =
-      GetDataTypeFromArrowFieldV3(field, metadata_settings_.use_wide_char_);
+      GetDataTypeFromArrowFieldV3(field, metadata_settings_.use_wide_char);
 
   return GetDisplaySize(data_type_v3, column_size).value_or(odbcabstraction::NO_TOTAL);
 }
@@ -154,17 +154,17 @@ uint16_t FlightSqlResultSetMetadata::GetConciseType(int column_position) {
   const std::shared_ptr<Field>& field = schema_->field(column_position - 1);
 
   const SqlDataType sqlColumnType =
-      GetDataTypeFromArrowFieldV3(field, metadata_settings_.use_wide_char_);
+      GetDataTypeFromArrowFieldV3(field, metadata_settings_.use_wide_char);
   return sqlColumnType;
 }
 
 size_t FlightSqlResultSetMetadata::GetLength(int column_position) {
   const std::shared_ptr<Field>& field = schema_->field(column_position - 1);
 
-  int32_t column_size = metadata_settings_.string_column_length_.value_or(
+  int32_t column_size = metadata_settings_.string_column_length.value_or(
       GetFieldPrecision(field).ValueOr(DefaultLengthForVariableLengthColumns));
   SqlDataType data_type_v3 =
-      GetDataTypeFromArrowFieldV3(field, metadata_settings_.use_wide_char_);
+      GetDataTypeFromArrowFieldV3(field, metadata_settings_.use_wide_char);
 
   return flight_sql::GetLength(data_type_v3, column_size)
       .value_or(DefaultLengthForVariableLengthColumns);
@@ -191,7 +191,7 @@ std::string FlightSqlResultSetMetadata::GetLocalTypeName(int column_position) {
 size_t FlightSqlResultSetMetadata::GetNumPrecRadix(int column_position) {
   const std::shared_ptr<Field>& field = schema_->field(column_position - 1);
   SqlDataType data_type_v3 =
-      GetDataTypeFromArrowFieldV3(field, metadata_settings_.use_wide_char_);
+      GetDataTypeFromArrowFieldV3(field, metadata_settings_.use_wide_char);
 
   return GetRadixFromSqlDataType(data_type_v3).value_or(odbcabstraction::NO_TOTAL);
 }
@@ -200,10 +200,10 @@ size_t FlightSqlResultSetMetadata::GetOctetLength(int column_position) {
   const std::shared_ptr<Field>& field = schema_->field(column_position - 1);
   arrow::flight::sql::ColumnMetadata metadata = GetMetadata(field);
 
-  int32_t column_size = metadata_settings_.string_column_length_.value_or(
+  int32_t column_size = metadata_settings_.string_column_length.value_or(
       GetFieldPrecision(field).ValueOr(DefaultLengthForVariableLengthColumns));
   SqlDataType data_type_v3 =
-      GetDataTypeFromArrowFieldV3(field, metadata_settings_.use_wide_char_);
+      GetDataTypeFromArrowFieldV3(field, metadata_settings_.use_wide_char);
 
   // Workaround to get the precision for Decimal and Numeric types, since server doesn't
   // return it currently.

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_ssl_config.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_ssl_config.cc
@@ -24,30 +24,30 @@
 namespace driver {
 namespace flight_sql {
 
-FlightSqlSslConfig::FlightSqlSslConfig(bool disableCertificateVerification,
-                                       const std::string& trustedCerts,
-                                       bool systemTrustStore, bool useEncryption)
-    : trustedCerts_(trustedCerts),
-      useEncryption_(useEncryption),
-      disableCertificateVerification_(disableCertificateVerification),
-      systemTrustStore_(systemTrustStore) {}
+FlightSqlSslConfig::FlightSqlSslConfig(bool disable_certificate_verification,
+                                       const std::string& trusted_certs,
+                                       bool system_trust_store, bool use_encryption)
+    : trusted_certs_(trusted_certs),
+      use_encryption_(use_encryption),
+      disable_certificate_verification_(disable_certificate_verification),
+      system_trust_store_(system_trust_store) {}
 
-bool FlightSqlSslConfig::useEncryption() const { return useEncryption_; }
+bool FlightSqlSslConfig::UseEncryption() const { return use_encryption_; }
 
-bool FlightSqlSslConfig::shouldDisableCertificateVerification() const {
-  return disableCertificateVerification_;
+bool FlightSqlSslConfig::ShouldDisableCertificateVerification() const {
+  return disable_certificate_verification_;
 }
 
-const std::string& FlightSqlSslConfig::getTrustedCerts() const { return trustedCerts_; }
+const std::string& FlightSqlSslConfig::GetTrustedCerts() const { return trusted_certs_; }
 
-bool FlightSqlSslConfig::useSystemTrustStore() const { return systemTrustStore_; }
+bool FlightSqlSslConfig::UseSystemTrustStore() const { return system_trust_store_; }
 
-void FlightSqlSslConfig::populateOptionsWithCerts(arrow::flight::CertKeyPair* out) {
+void FlightSqlSslConfig::PopulateOptionsWithCerts(arrow::flight::CertKeyPair* out) {
   try {
-    std::ifstream cert_file(trustedCerts_);
+    std::ifstream cert_file(trusted_certs_);
     if (!cert_file) {
       throw odbcabstraction::DriverException("Could not open certificate: " +
-                                             trustedCerts_);
+                                             trusted_certs_);
     }
     std::stringstream cert;
     cert << cert_file.rdbuf();

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_ssl_config.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_ssl_config.h
@@ -28,35 +28,36 @@ namespace flight_sql {
 ///        a SSL connection.
 class FlightSqlSslConfig {
  public:
-  FlightSqlSslConfig(bool disableCertificateVerification, const std::string& trustedCerts,
-                     bool systemTrustStore, bool useEncryption);
+  FlightSqlSslConfig(bool disable_certificate_verification,
+                     const std::string& trusted_certs, bool system_trust_store,
+                     bool use_encryption);
 
   /// \brief  Tells if ssl is enabled. By default it will be true.
   /// \return Whether ssl is enabled.
-  bool useEncryption() const;
+  bool UseEncryption() const;
 
   /// \brief  Tells if disable certificate verification is enabled.
   /// \return Whether disable certificate verification is enabled.
-  bool shouldDisableCertificateVerification() const;
+  bool ShouldDisableCertificateVerification() const;
 
   /// \brief  The path to the trusted certificate.
   /// \return Certificate path.
-  const std::string& getTrustedCerts() const;
+  const std::string& GetTrustedCerts() const;
 
   /// \brief  Tells if we need to check if the certificate is in the system trust store.
   /// \return Whether to use the system trust store.
-  bool useSystemTrustStore() const;
+  bool UseSystemTrustStore() const;
 
   /// \brief Loads the certificate file and extract the certificate file from it
   ///        and create the object CertKeyPair with it on.
   /// \param out A CertKeyPair with the cert on it.
-  void populateOptionsWithCerts(arrow::flight::CertKeyPair* out);
+  void PopulateOptionsWithCerts(arrow::flight::CertKeyPair* out);
 
  private:
-  const std::string trustedCerts_;
-  const bool useEncryption_;
-  const bool disableCertificateVerification_;
-  const bool systemTrustStore_;
+  const std::string trusted_certs_;
+  const bool use_encryption_;
+  const bool disable_certificate_verification_;
+  const bool system_trust_store_;
 };
 }  // namespace flight_sql
 }  // namespace driver

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_statement.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_statement.cc
@@ -257,7 +257,7 @@ std::shared_ptr<ResultSet> FlightSqlStatement::GetTypeInfo_V2(int16_t data_type)
 
   auto flight_info = result.ValueOrDie();
 
-  auto transformer = std::make_shared<GetTypeInfo_Transformer>(
+  auto transformer = std::make_shared<GetTypeInfoTransformer>(
       metadata_settings_, odbcabstraction::V_2, data_type);
 
   current_result_set_ =
@@ -275,7 +275,7 @@ std::shared_ptr<ResultSet> FlightSqlStatement::GetTypeInfo_V3(int16_t data_type)
 
   auto flight_info = result.ValueOrDie();
 
-  auto transformer = std::make_shared<GetTypeInfo_Transformer>(
+  auto transformer = std::make_shared<GetTypeInfoTransformer>(
       metadata_settings_, odbcabstraction::V_3, data_type);
 
   current_result_set_ =

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_statement_get_columns.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_statement_get_columns.cc
@@ -113,7 +113,7 @@ Result<std::shared_ptr<RecordBatch>> TransformInner(
       }
 
       odbcabstraction::SqlDataType data_type_v3 =
-          GetDataTypeFromArrowFieldV3(field, metadata_settings.use_wide_char_);
+          GetDataTypeFromArrowFieldV3(field, metadata_settings.use_wide_char);
 
       ColumnMetadata metadata(field->metadata());
 

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_statement_get_columns.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_statement_get_columns.cc
@@ -78,7 +78,7 @@ std::shared_ptr<Schema> GetColumns_V2_Schema() {
   });
 }
 
-Result<std::shared_ptr<RecordBatch>> Transform_inner(
+Result<std::shared_ptr<RecordBatch>> TransformInner(
     const odbcabstraction::OdbcVersion odbc_version,
     const std::shared_ptr<RecordBatch>& original,
     const optional<std::string>& column_name_pattern,
@@ -113,7 +113,7 @@ Result<std::shared_ptr<RecordBatch>> Transform_inner(
       }
 
       odbcabstraction::SqlDataType data_type_v3 =
-          GetDataTypeFromArrowField_V3(field, metadata_settings.use_wide_char_);
+          GetDataTypeFromArrowFieldV3(field, metadata_settings.use_wide_char_);
 
       ColumnMetadata metadata(field->metadata());
 
@@ -233,7 +233,7 @@ GetColumns_Transformer::GetColumns_Transformer(
 std::shared_ptr<RecordBatch> GetColumns_Transformer::Transform(
     const std::shared_ptr<RecordBatch>& original) {
   const Result<std::shared_ptr<RecordBatch>>& result =
-      Transform_inner(odbc_version_, original, column_name_pattern_, metadata_settings_);
+      TransformInner(odbc_version_, original, column_name_pattern_, metadata_settings_);
   ThrowIfNotOK(result.status());
 
   return result.ValueOrDie();

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_statement_get_type_info.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_statement_get_type_info.cc
@@ -90,7 +90,7 @@ Result<std::shared_ptr<RecordBatch>> TransformInner(
   while (reader.Next()) {
     auto data_type_v3 = EnsureRightSqlCharType(
         static_cast<odbcabstraction::SqlDataType>(reader.GetDataType()),
-        metadata_settings_.use_wide_char_);
+        metadata_settings_.use_wide_char);
     int16_t data_type_v2 = ConvertSqlDataTypeFromV3ToV2(data_type_v3);
 
     if (data_type != odbcabstraction::ALL_TYPES && data_type_v3 != data_type &&
@@ -124,7 +124,7 @@ Result<std::shared_ptr<RecordBatch>> TransformInner(
     data.maximum_scale = reader.GetMaximumScale();
     data.sql_data_type = EnsureRightSqlCharType(
         static_cast<odbcabstraction::SqlDataType>(reader.GetSqlDataType()),
-        metadata_settings_.use_wide_char_);
+        metadata_settings_.use_wide_char);
     data.sql_datetime_sub =
         GetSqlDateTimeSubCode(static_cast<odbcabstraction::SqlDataType>(data.data_type));
     data.num_prec_radix = reader.GetNumPrecRadix();

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_statement_get_type_info.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_statement_get_type_info.cc
@@ -78,12 +78,12 @@ std::shared_ptr<Schema> GetTypeInfo_V2_Schema() {
   });
 }
 
-Result<std::shared_ptr<RecordBatch>> Transform_inner(
+Result<std::shared_ptr<RecordBatch>> TransformInner(
     const odbcabstraction::OdbcVersion odbc_version,
     const std::shared_ptr<RecordBatch>& original, int data_type,
     const MetadataSettings& metadata_settings_) {
-  GetTypeInfo_RecordBatchBuilder builder(odbc_version);
-  GetTypeInfo_RecordBatchBuilder::Data data;
+  GetTypeInfoRecordBatchBuilder builder(odbc_version);
+  GetTypeInfoRecordBatchBuilder::Data data;
 
   GetTypeInfoReader reader(original);
 
@@ -137,11 +137,11 @@ Result<std::shared_ptr<RecordBatch>> Transform_inner(
 }
 }  // namespace
 
-GetTypeInfo_RecordBatchBuilder::GetTypeInfo_RecordBatchBuilder(
+GetTypeInfoRecordBatchBuilder::GetTypeInfoRecordBatchBuilder(
     odbcabstraction::OdbcVersion odbc_version)
     : odbc_version_(odbc_version) {}
 
-Result<std::shared_ptr<RecordBatch>> GetTypeInfo_RecordBatchBuilder::Build() {
+Result<std::shared_ptr<RecordBatch>> GetTypeInfoRecordBatchBuilder::Build() {
   ARROW_ASSIGN_OR_RAISE(auto TYPE_NAME_Array, TYPE_NAME_Builder_.Finish())
   ARROW_ASSIGN_OR_RAISE(auto DATA_TYPE_Array, DATA_TYPE_Builder_.Finish())
   ARROW_ASSIGN_OR_RAISE(auto COLUMN_SIZE_Array, COLUMN_SIZE_Builder_.Finish())
@@ -179,8 +179,8 @@ Result<std::shared_ptr<RecordBatch>> GetTypeInfo_RecordBatchBuilder::Build() {
   return RecordBatch::Make(schema, num_rows_, arrays);
 }
 
-Status GetTypeInfo_RecordBatchBuilder::Append(
-    const GetTypeInfo_RecordBatchBuilder::Data& data) {
+Status GetTypeInfoRecordBatchBuilder::Append(
+    const GetTypeInfoRecordBatchBuilder::Data& data) {
   ARROW_RETURN_NOT_OK(AppendToBuilder(TYPE_NAME_Builder_, data.type_name));
   ARROW_RETURN_NOT_OK(AppendToBuilder(DATA_TYPE_Builder_, data.data_type));
   ARROW_RETURN_NOT_OK(AppendToBuilder(COLUMN_SIZE_Builder_, data.column_size));
@@ -208,23 +208,23 @@ Status GetTypeInfo_RecordBatchBuilder::Append(
   return Status::OK();
 }
 
-GetTypeInfo_Transformer::GetTypeInfo_Transformer(
+GetTypeInfoTransformer::GetTypeInfoTransformer(
     const MetadataSettings& metadata_settings,
     const odbcabstraction::OdbcVersion odbc_version, int data_type)
     : metadata_settings_(metadata_settings),
       odbc_version_(odbc_version),
       data_type_(data_type) {}
 
-std::shared_ptr<RecordBatch> GetTypeInfo_Transformer::Transform(
+std::shared_ptr<RecordBatch> GetTypeInfoTransformer::Transform(
     const std::shared_ptr<RecordBatch>& original) {
   const Result<std::shared_ptr<RecordBatch>>& result =
-      Transform_inner(odbc_version_, original, data_type_, metadata_settings_);
+      TransformInner(odbc_version_, original, data_type_, metadata_settings_);
   ThrowIfNotOK(result.status());
 
   return result.ValueOrDie();
 }
 
-std::shared_ptr<Schema> GetTypeInfo_Transformer::GetTransformedSchema() {
+std::shared_ptr<Schema> GetTypeInfoTransformer::GetTransformedSchema() {
   return odbc_version_ == odbcabstraction::V_3 ? GetTypeInfo_V3_Schema()
                                                : GetTypeInfo_V2_Schema();
 }

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_statement_get_type_info.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_statement_get_type_info.h
@@ -34,7 +34,7 @@ using arrow::StringBuilder;
 using odbcabstraction::MetadataSettings;
 using std::optional;
 
-class GetTypeInfo_RecordBatchBuilder {
+class GetTypeInfoRecordBatchBuilder {
  private:
   odbcabstraction::OdbcVersion odbc_version_;
 
@@ -82,23 +82,23 @@ class GetTypeInfo_RecordBatchBuilder {
     optional<int16_t> interval_precision;
   };
 
-  explicit GetTypeInfo_RecordBatchBuilder(odbcabstraction::OdbcVersion odbc_version);
+  explicit GetTypeInfoRecordBatchBuilder(odbcabstraction::OdbcVersion odbc_version);
 
   Result<std::shared_ptr<RecordBatch>> Build();
 
   Status Append(const Data& data);
 };
 
-class GetTypeInfo_Transformer : public RecordBatchTransformer {
+class GetTypeInfoTransformer : public RecordBatchTransformer {
  private:
   const MetadataSettings& metadata_settings_;
   odbcabstraction::OdbcVersion odbc_version_;
   int data_type_;
 
  public:
-  explicit GetTypeInfo_Transformer(const MetadataSettings& metadata_settings,
-                                   odbcabstraction::OdbcVersion odbc_version,
-                                   int data_type);
+  explicit GetTypeInfoTransformer(const MetadataSettings& metadata_settings,
+                                  odbcabstraction::OdbcVersion odbc_version,
+                                  int data_type);
 
   std::shared_ptr<RecordBatch> Transform(
       const std::shared_ptr<RecordBatch>& original) override;

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_stream_chunk_buffer.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_stream_chunk_buffer.cc
@@ -38,10 +38,10 @@ FlightStreamChunkBuffer::FlightStreamChunkBuffer(
 
     BlockingQueue<Result<FlightStreamChunk>>::Supplier supplier = [=] {
       auto result = stream_reader_ptr->Next();
-      bool isNotOk = !result.ok();
-      bool isNotEmpty = result.ok() && (result.ValueOrDie().data != nullptr);
+      bool is_not_ok = !result.ok();
+      bool is_not_empty = result.ok() && (result.ValueOrDie().data != nullptr);
 
-      return boost::make_optional(isNotOk || isNotEmpty, std::move(result));
+      return boost::make_optional(is_not_ok || is_not_empty, std::move(result));
     };
     queue_.AddProducer(std::move(supplier));
   }

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/include/flight_sql/config/configuration.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/include/flight_sql/config/configuration.h
@@ -69,7 +69,7 @@ class Configuration {
   std::vector<std::string_view> GetCustomKeys() const;
 
  private:
-  driver::odbcabstraction::Connection::ConnPropertyMap properties;
+  driver::odbcabstraction::Connection::ConnPropertyMap properties_;
 };
 
 }  // namespace config

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/include/flight_sql/config/connection_string_parser.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/include/flight_sql/config/connection_string_parser.h
@@ -70,7 +70,7 @@ class ConnectionStringParser {
   ConnectionStringParser& operator=(const ConnectionStringParser&) = delete;
 
   /** Configuration. */
-  Configuration& cfg;
+  Configuration& cfg_;
 };
 
 }  // namespace config

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/include/flight_sql/ui/add_property_window.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/include/flight_sql/ui/add_property_window.h
@@ -63,7 +63,7 @@ class AddPropertyWindow : public CustomWindow {
 
   void OnCreate() override;
 
-  bool OnMessage(UINT msg, WPARAM wParam, LPARAM lParam) override;
+  bool OnMessage(UINT msg, WPARAM wparam, LPARAM lparam) override;
 
   /**
    * Get the property from the dialog.
@@ -76,26 +76,26 @@ class AddPropertyWindow : public CustomWindow {
   /**
    * Create property edit boxes.
    *
-   * @param posX X position.
-   * @param posY Y position.
-   * @param sizeX Width.
+   * @param pos_x X position.
+   * @param pos_y Y position.
+   * @param size_x Width.
    * @return Size by Y.
    */
-  int CreateEdits(int posX, int posY, int sizeX);
+  int CreateEdits(int pos_x, int pos_y, int size_x);
 
   void CheckEnableOk();
 
   std::vector<std::unique_ptr<Window> > labels;
 
   /** Ok button. */
-  std::unique_ptr<Window> okButton;
+  std::unique_ptr<Window> ok_button;
 
   /** Cancel button. */
-  std::unique_ptr<Window> cancelButton;
+  std::unique_ptr<Window> cancel_button;
 
-  std::unique_ptr<Window> keyEdit;
+  std::unique_ptr<Window> key_edit;
 
-  std::unique_ptr<Window> valueEdit;
+  std::unique_ptr<Window> value_edit;
 
   std::string key;
 
@@ -110,7 +110,7 @@ class AddPropertyWindow : public CustomWindow {
   /** Flag indicating whether OK option was selected. */
   bool accepted;
 
-  bool isInitialized;
+  bool is_initialized;
 };
 
 }  // namespace config

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/include/flight_sql/ui/add_property_window.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/include/flight_sql/ui/add_property_window.h
@@ -85,32 +85,32 @@ class AddPropertyWindow : public CustomWindow {
 
   void CheckEnableOk();
 
-  std::vector<std::unique_ptr<Window> > labels;
+  std::vector<std::unique_ptr<Window> > labels_;
 
   /** Ok button. */
-  std::unique_ptr<Window> ok_button;
+  std::unique_ptr<Window> ok_button_;
 
   /** Cancel button. */
-  std::unique_ptr<Window> cancel_button;
+  std::unique_ptr<Window> cancel_button_;
 
-  std::unique_ptr<Window> key_edit;
+  std::unique_ptr<Window> key_edit_;
 
-  std::unique_ptr<Window> value_edit;
+  std::unique_ptr<Window> value_edit_;
 
-  std::string key;
+  std::string key_;
 
-  std::string value;
+  std::string value_;
 
   /** Window width. */
-  int width;
+  int width_;
 
   /** Window height. */
-  int height;
+  int height_;
 
   /** Flag indicating whether OK option was selected. */
-  bool accepted;
+  bool accepted_;
 
-  bool is_initialized;
+  bool is_initialized_;
 };
 
 }  // namespace config

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/include/flight_sql/ui/custom_window.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/include/flight_sql/ui/custom_window.h
@@ -62,10 +62,10 @@ class CustomWindow : public Window {
    * Constructor.
    *
    * @param parent Parent window.
-   * @param className Window class name.
+   * @param class_name Window class name.
    * @param title Window title.
    */
-  CustomWindow(Window* parent, const char* className, const char* title);
+  CustomWindow(Window* parent, const char* class_name, const char* title);
 
   /**
    * Destructor.
@@ -77,12 +77,12 @@ class CustomWindow : public Window {
    * Pure virtual. Should be defined by user.
    *
    * @param msg Message.
-   * @param wParam Word-sized parameter.
-   * @param lParam Long parameter.
+   * @param wparam Word-sized parameter.
+   * @param lparam Long parameter.
    * @return Should return true if the message has been
    *     processed by the handler and false otherwise.
    */
-  virtual bool OnMessage(UINT msg, WPARAM wParam, LPARAM lParam) = 0;
+  virtual bool OnMessage(UINT msg, WPARAM wparam, LPARAM lparam) = 0;
 
   /**
    * Callback that is called upon window creation.
@@ -97,11 +97,11 @@ class CustomWindow : public Window {
    *
    * @param hwnd Window handle.
    * @param msg Message.
-   * @param wParam Word-sized parameter.
-   * @param lParam Long parameter.
+   * @param wparam Word-sized parameter.
+   * @param lparam Long parameter.
    * @return Operation result.
    */
-  static LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
+  static LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam);
 };
 
 }  // namespace config

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/include/flight_sql/ui/dsn_configuration_window.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/include/flight_sql/ui/dsn_configuration_window.h
@@ -90,56 +90,56 @@ class DsnConfigurationWindow : public CustomWindow {
 
   void OnCreate() override;
 
-  bool OnMessage(UINT msg, WPARAM wParam, LPARAM lParam) override;
+  bool OnMessage(UINT msg, WPARAM wparam, LPARAM lparam) override;
 
  private:
   /**
    * Create connection settings group box.
    *
-   * @param posX X position.
-   * @param posY Y position.
-   * @param sizeX Width.
+   * @param pos_x X position.
+   * @param pos_y Y position.
+   * @param size_x Width.
    * @return Size by Y.
    */
-  int CreateConnectionSettingsGroup(int posX, int posY, int sizeX);
+  int CreateConnectionSettingsGroup(int pos_x, int pos_y, int size_x);
 
   /**
    * Create aythentication settings group box.
    *
-   * @param posX X position.
-   * @param posY Y position.
-   * @param sizeX Width.
+   * @param pos_x X position.
+   * @param pos_y Y position.
+   * @param size_x Width.
    * @return Size by Y.
    */
-  int CreateAuthSettingsGroup(int posX, int posY, int sizeX);
+  int CreateAuthSettingsGroup(int pos_x, int pos_y, int size_x);
 
   /**
    * Create Encryption settings group box.
    *
-   * @param posX X position.
-   * @param posY Y position.
-   * @param sizeX Width.
+   * @param pos_x X position.
+   * @param pos_y Y position.
+   * @param size_x Width.
    * @return Size by Y.
    */
-  int CreateEncryptionSettingsGroup(int posX, int posY, int sizeX);
+  int CreateEncryptionSettingsGroup(int pos_x, int pos_y, int size_x);
 
   /**
    * Create advanced properties group box.
    *
-   * @param posX X position.
-   * @param posY Y position.
-   * @param sizeX Width.
+   * @param pos_x X position.
+   * @param pos_y Y position.
+   * @param size_x Width.
    * @return Size by Y.
    */
-  int CreatePropertiesGroup(int posX, int posY, int sizeX);
+  int CreatePropertiesGroup(int pos_x, int pos_y, int size_x);
 
-  void SelectTab(int tabIndex);
+  void SelectTab(int tab_index);
 
   void CheckEnableOk();
 
   void CheckAuthType();
 
-  void SaveParameters(Configuration& targetConfig);
+  void SaveParameters(Configuration& target_config);
 
   /** Window width. */
   int width;
@@ -147,66 +147,66 @@ class DsnConfigurationWindow : public CustomWindow {
   /** Window height. */
   int height;
 
-  std::unique_ptr<Window> tabControl;
+  std::unique_ptr<Window> tab_control;
 
-  std::unique_ptr<Window> commonContent;
+  std::unique_ptr<Window> common_content;
 
-  std::unique_ptr<Window> advancedContent;
+  std::unique_ptr<Window> advanced_content;
 
   /** Connection settings group box. */
-  std::unique_ptr<Window> connectionSettingsGroupBox;
+  std::unique_ptr<Window> connection_settings_group_box;
 
   /** Authentication settings group box. */
-  std::unique_ptr<Window> authSettingsGroupBox;
+  std::unique_ptr<Window> auth_settings_group_box;
 
   /** Encryption settings group box. */
-  std::unique_ptr<Window> encryptionSettingsGroupBox;
+  std::unique_ptr<Window> encryption_settings_group_box;
 
   std::vector<std::unique_ptr<Window> > labels;
 
   /** Test button. */
-  std::unique_ptr<Window> testButton;
+  std::unique_ptr<Window> test_button;
 
   /** Ok button. */
-  std::unique_ptr<Window> okButton;
+  std::unique_ptr<Window> ok_button;
 
   /** Cancel button. */
-  std::unique_ptr<Window> cancelButton;
+  std::unique_ptr<Window> cancel_button;
 
   /** DSN name edit field. */
-  std::unique_ptr<Window> nameEdit;
+  std::unique_ptr<Window> name_edit;
 
-  std::unique_ptr<Window> serverEdit;
+  std::unique_ptr<Window> server_edit;
 
-  std::unique_ptr<Window> portEdit;
+  std::unique_ptr<Window> port_edit;
 
-  std::unique_ptr<Window> authTypeComboBox;
+  std::unique_ptr<Window> auth_type_combo_box;
 
   /** User edit. */
-  std::unique_ptr<Window> userEdit;
+  std::unique_ptr<Window> user_edit;
 
   /** Password edit. */
-  std::unique_ptr<Window> passwordEdit;
+  std::unique_ptr<Window> password_edit;
 
-  std::unique_ptr<Window> authTokenEdit;
+  std::unique_ptr<Window> auth_token_edit;
 
-  std::unique_ptr<Window> enableEncryptionCheckBox;
+  std::unique_ptr<Window> enable_encryption_check_box;
 
-  std::unique_ptr<Window> certificateEdit;
+  std::unique_ptr<Window> certificate_edit;
 
-  std::unique_ptr<Window> certificateBrowseButton;
+  std::unique_ptr<Window> certificate_browse_button;
 
-  std::unique_ptr<Window> useSystemCertStoreCheckBox;
+  std::unique_ptr<Window> use_system_cert_store_check_box;
 
-  std::unique_ptr<Window> disableCertVerificationCheckBox;
+  std::unique_ptr<Window> disable_cert_verification_check_box;
 
-  std::unique_ptr<Window> propertyGroupBox;
+  std::unique_ptr<Window> property_group_box;
 
-  std::unique_ptr<Window> propertyList;
+  std::unique_ptr<Window> property_list;
 
-  std::unique_ptr<Window> addButton;
+  std::unique_ptr<Window> add_button;
 
-  std::unique_ptr<Window> deleteButton;
+  std::unique_ptr<Window> delete_button;
 
   /** Configuration. */
   Configuration& config;
@@ -214,7 +214,7 @@ class DsnConfigurationWindow : public CustomWindow {
   /** Flag indicating whether OK option was selected. */
   bool accepted;
 
-  bool isInitialized;
+  bool is_initialized;
 };
 
 }  // namespace config

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/include/flight_sql/ui/dsn_configuration_window.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/include/flight_sql/ui/dsn_configuration_window.h
@@ -142,79 +142,75 @@ class DsnConfigurationWindow : public CustomWindow {
   void SaveParameters(Configuration& target_config);
 
   /** Window width. */
-  int width;
+  int width_;
 
   /** Window height. */
-  int height;
+  int height_;
 
-  std::unique_ptr<Window> tab_control;
-
-  std::unique_ptr<Window> common_content;
-
-  std::unique_ptr<Window> advanced_content;
+  std::unique_ptr<Window> tab_control_;
 
   /** Connection settings group box. */
-  std::unique_ptr<Window> connection_settings_group_box;
+  std::unique_ptr<Window> connection_settings_group_box_;
 
   /** Authentication settings group box. */
-  std::unique_ptr<Window> auth_settings_group_box;
+  std::unique_ptr<Window> auth_settings_group_box_;
 
   /** Encryption settings group box. */
-  std::unique_ptr<Window> encryption_settings_group_box;
+  std::unique_ptr<Window> encryption_settings_group_box_;
 
-  std::vector<std::unique_ptr<Window> > labels;
+  std::vector<std::unique_ptr<Window> > labels_;
 
   /** Test button. */
-  std::unique_ptr<Window> test_button;
+  std::unique_ptr<Window> test_button_;
 
   /** Ok button. */
-  std::unique_ptr<Window> ok_button;
+  std::unique_ptr<Window> ok_button_;
 
   /** Cancel button. */
-  std::unique_ptr<Window> cancel_button;
+  std::unique_ptr<Window> cancel_button_;
 
   /** DSN name edit field. */
-  std::unique_ptr<Window> name_edit;
+  std::unique_ptr<Window> name_edit_;
 
-  std::unique_ptr<Window> server_edit;
+  std::unique_ptr<Window> server_edit_;
 
-  std::unique_ptr<Window> port_edit;
+  std::unique_ptr<Window> port_edit_;
 
-  std::unique_ptr<Window> auth_type_combo_box;
+  std::unique_ptr<Window> auth_type_combo_box_;
 
   /** User edit. */
-  std::unique_ptr<Window> user_edit;
+  std::unique_ptr<Window> user_edit_;
 
   /** Password edit. */
-  std::unique_ptr<Window> password_edit;
+  std::unique_ptr<Window> password_edit_;
 
-  std::unique_ptr<Window> auth_token_edit;
+  std::unique_ptr<Window> auth_token_edit_;
 
-  std::unique_ptr<Window> enable_encryption_check_box;
+  std::unique_ptr<Window> enable_encryption_check_box_;
 
-  std::unique_ptr<Window> certificate_edit;
+  std::unique_ptr<Window> certificate_edit_;
 
-  std::unique_ptr<Window> certificate_browse_button;
+  std::unique_ptr<Window> certificate_browse_button_;
 
-  std::unique_ptr<Window> use_system_cert_store_check_box;
+  std::unique_ptr<Window> use_system_cert_store_check_box_;
 
-  std::unique_ptr<Window> disable_cert_verification_check_box;
+  std::unique_ptr<Window> disable_cert_verification_check_box_;
 
-  std::unique_ptr<Window> property_group_box;
+  std::unique_ptr<Window> property_group_box_;
 
-  std::unique_ptr<Window> property_list;
+  std::unique_ptr<Window> property_list_;
 
-  std::unique_ptr<Window> add_button;
+  std::unique_ptr<Window> add_button_;
 
-  std::unique_ptr<Window> delete_button;
+  std::unique_ptr<Window> delete_button_;
 
   /** Configuration. */
-  Configuration& config;
+  Configuration& config_;
 
   /** Flag indicating whether OK option was selected. */
-  bool accepted;
+  bool accepted_;
 
-  bool is_initialized;
+  bool is_initialized_;
 };
 
 }  // namespace config

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/include/flight_sql/ui/window.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/include/flight_sql/ui/window.h
@@ -198,7 +198,7 @@ class Window {
    *
    * @return Window handle.
    */
-  HWND GetHandle() const { return handle; }
+  HWND GetHandle() const { return handle_; }
 
   void SetVisible(bool isVisible);
 
@@ -283,22 +283,22 @@ class Window {
    *
    * @param value Window handle.
    */
-  void SetHandle(HWND value) { handle = value; }
+  void SetHandle(HWND value) { handle_ = value; }
 
   /** Window class name. */
-  std::string class_name;
+  std::string class_name_;
 
   /** Window title. */
-  std::string title;
+  std::string title_;
 
   /** Window handle. */
-  HWND handle;
+  HWND handle_;
 
   /** Window parent. */
-  Window* parent;
+  Window* parent_;
 
   /** Specifies whether window has been created by the thread and needs destruction. */
-  bool created;
+  bool created_;
 
  private:
   Window(const Window& window) = delete;

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/include/flight_sql/ui/window.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/include/flight_sql/ui/window.h
@@ -41,10 +41,10 @@ class Window {
    * Constructor for a new window that is going to be created.
    *
    * @param parent Parent window handle.
-   * @param className Window class name.
+   * @param class_name Window class name.
    * @param title Window title.
    */
-  Window(Window* parent, const char* className, const char* title);
+  Window(Window* parent, const char* class_name, const char* title);
 
   /**
    * Constructor for the existing window.
@@ -62,13 +62,13 @@ class Window {
    * Create window.
    *
    * @param style Window style.
-   * @param posX Window x position.
-   * @param posY Window y position.
+   * @param pos_x Window x position.
+   * @param pos_y Window y position.
    * @param width Window width.
    * @param height Window height.
    * @param id ID for child window.
    */
-  void Create(DWORD style, int posX, int posY, int width, int height, int id);
+  void Create(DWORD style, int pos_x, int pos_y, int width, int height, int id);
 
   /**
    * Create child tab controlwindow.
@@ -81,100 +81,101 @@ class Window {
   /**
    * Create child list view window.
    *
-   * @param posX Position by X coordinate.
-   * @param posY Position by Y coordinate.
-   * @param sizeX Size by X coordinate.
-   * @param sizeY Size by Y coordinate.
+   * @param pos_x Position by X coordinate.
+   * @param pos_y Position by Y coordinate.
+   * @param size_x Size by X coordinate.
+   * @param size_y Size by Y coordinate.
    * @param id ID to be assigned to the created window.
    * @return Auto pointer containing new window.
    */
-  std::unique_ptr<Window> CreateList(int posX, int posY, int sizeX, int sizeY, int id);
+  std::unique_ptr<Window> CreateList(int pos_x, int pos_y, int size_x, int size_y,
+                                     int id);
 
   /**
    * Create child group box window.
    *
-   * @param posX Position by X coordinate.
-   * @param posY Position by Y coordinate.
-   * @param sizeX Size by X coordinate.
-   * @param sizeY Size by Y coordinate.
+   * @param pos_x Position by X coordinate.
+   * @param pos_y Position by Y coordinate.
+   * @param size_x Size by X coordinate.
+   * @param size_y Size by Y coordinate.
    * @param title Title.
    * @param id ID to be assigned to the created window.
    * @return Auto pointer containing new window.
    */
-  std::unique_ptr<Window> CreateGroupBox(int posX, int posY, int sizeX, int sizeY,
+  std::unique_ptr<Window> CreateGroupBox(int pos_x, int pos_y, int size_x, int size_y,
                                          const char* title, int id);
 
   /**
    * Create child label window.
    *
-   * @param posX Position by X coordinate.
-   * @param posY Position by Y coordinate.
-   * @param sizeX Size by X coordinate.
-   * @param sizeY Size by Y coordinate.
+   * @param pos_x Position by X coordinate.
+   * @param pos_y Position by Y coordinate.
+   * @param size_x Size by X coordinate.
+   * @param size_y Size by Y coordinate.
    * @param title Title.
    * @param id ID to be assigned to the created window.
    * @return Auto pointer containing new window.
    */
-  std::unique_ptr<Window> CreateLabel(int posX, int posY, int sizeX, int sizeY,
+  std::unique_ptr<Window> CreateLabel(int pos_x, int pos_y, int size_x, int size_y,
                                       const char* title, int id);
 
   /**
    * Create child Edit window.
    *
-   * @param posX Position by X coordinate.
-   * @param posY Position by Y coordinate.
-   * @param sizeX Size by X coordinate.
-   * @param sizeY Size by Y coordinate.
+   * @param pos_x Position by X coordinate.
+   * @param pos_y Position by Y coordinate.
+   * @param size_x Size by X coordinate.
+   * @param size_y Size by Y coordinate.
    * @param title Title.
    * @param id ID to be assigned to the created window.
    * @param style Window style.
    * @return Auto pointer containing new window.
    */
-  std::unique_ptr<Window> CreateEdit(int posX, int posY, int sizeX, int sizeY,
+  std::unique_ptr<Window> CreateEdit(int pos_x, int pos_y, int size_x, int size_y,
                                      const char* title, int id, int style = 0);
 
   /**
    * Create child button window.
    *
-   * @param posX Position by X coordinate.
-   * @param posY Position by Y coordinate.
-   * @param sizeX Size by X coordinate.
-   * @param sizeY Size by Y coordinate.
+   * @param pos_x Position by X coordinate.
+   * @param pos_y Position by Y coordinate.
+   * @param size_x Size by X coordinate.
+   * @param size_y Size by Y coordinate.
    * @param title Title.
    * @param id ID to be assigned to the created window.
    * @param style Window style.
    * @return Auto pointer containing new window.
    */
-  std::unique_ptr<Window> CreateButton(int posX, int posY, int sizeX, int sizeY,
+  std::unique_ptr<Window> CreateButton(int pos_x, int pos_y, int size_x, int size_y,
                                        const char* title, int id, int style = 0);
 
   /**
    * Create child CheckBox window.
    *
-   * @param posX Position by X coordinate.
-   * @param posY Position by Y coordinate.
-   * @param sizeX Size by X coordinate.
-   * @param sizeY Size by Y coordinate.
+   * @param pos_x Position by X coordinate.
+   * @param pos_y Position by Y coordinate.
+   * @param size_x Size by X coordinate.
+   * @param size_y Size by Y coordinate.
    * @param title Title.
    * @param id ID to be assigned to the created window.
    * @param state Checked state of checkbox
    * @return Auto pointer containing new window.
    */
-  std::unique_ptr<Window> CreateCheckBox(int posX, int posY, int sizeX, int sizeY,
+  std::unique_ptr<Window> CreateCheckBox(int pos_x, int pos_y, int size_x, int size_y,
                                          const char* title, int id, bool state);
 
   /**
    * Create child ComboBox window.
    *
-   * @param posX Position by X coordinate.
-   * @param posY Position by Y coordinate.
-   * @param sizeX Size by X coordinate.
-   * @param sizeY Size by Y coordinate.
+   * @param pos_x Position by X coordinate.
+   * @param pos_y Position by Y coordinate.
+   * @param size_x Size by X coordinate.
+   * @param size_y Size by Y coordinate.
    * @param title Title.
    * @param id ID to be assigned to the created window.
    * @return Auto pointer containing new window.
    */
-  std::unique_ptr<Window> CreateComboBox(int posX, int posY, int sizeX, int sizeY,
+  std::unique_ptr<Window> CreateComboBox(int pos_x, int pos_y, int size_x, int size_y,
                                          const char* title, int id);
 
   /**
@@ -285,7 +286,7 @@ class Window {
   void SetHandle(HWND value) { handle = value; }
 
   /** Window class name. */
-  std::string className;
+  std::string class_name;
 
   /** Window title. */
   std::string title;

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/main.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/main.cc
@@ -28,6 +28,7 @@
 #include <memory>
 #include "arrow/flight/api.h"
 #include "arrow/flight/sql/api.h"
+#include "arrow/util/logging.h"
 
 using arrow::Status;
 using arrow::flight::FlightClient;
@@ -48,18 +49,18 @@ void TestBindColumn(const std::shared_ptr<Connection>& connection) {
   const std::shared_ptr<ResultSet>& result_set = statement->GetResultSet();
 
   const int batch_size = 100;
-  const int max_strlen = 1000;
+  const int max_str_len = 1000;
 
-  char IncidntNum[batch_size][max_strlen];
-  ssize_t IncidntNum_length[batch_size];
+  char incidnt_num[batch_size][max_str_len];
+  ssize_t incidnt_num_length[batch_size];
 
-  char Category[batch_size][max_strlen];
-  ssize_t Category_length[batch_size];
+  char category[batch_size][max_str_len];
+  ssize_t category_length[batch_size];
 
-  result_set->BindColumn(1, driver::odbcabstraction::CDataType_CHAR, 0, 0, IncidntNum,
-                         max_strlen, IncidntNum_length);
-  result_set->BindColumn(2, driver::odbcabstraction::CDataType_CHAR, 0, 0, Category,
-                         max_strlen, Category_length);
+  result_set->BindColumn(1, driver::odbcabstraction::CDataType_CHAR, 0, 0, incidnt_num,
+                         max_str_len, incidnt_num_length);
+  result_set->BindColumn(2, driver::odbcabstraction::CDataType_CHAR, 0, 0, category,
+                         max_str_len, category_length);
 
   size_t total = 0;
   while (true) {
@@ -70,8 +71,8 @@ void TestBindColumn(const std::shared_ptr<Connection>& connection) {
     std::cout << "Total:" << total << std::endl;
 
     for (int i = 0; i < fetched_rows; ++i) {
-      std::cout << "Row[" << i << "] IncidntNum: '" << IncidntNum[i] << "', Category: '"
-                << Category[i] << "'" << std::endl;
+      ARROW_LOG(DEBUG) << "Row[" << i << "] incidnt_num: '" << incidnt_num[i]
+                       << "', Category: '" << category[i] << "'";
     }
 
     if (fetched_rows < batch_size) break;
@@ -114,34 +115,34 @@ void TestBindColumnBigInt(const std::shared_ptr<Connection>& connection) {
   const int batch_size = 100;
   const int max_strlen = 1000;
 
-  char IncidntNum[batch_size][max_strlen];
-  ssize_t IncidntNum_length[batch_size];
+  char incidnt_num[batch_size][max_strlen];
+  ssize_t incidnt_num_length[batch_size];
 
   double double_field[batch_size];
   ssize_t double_field_length[batch_size];
 
-  char Category[batch_size][max_strlen];
-  ssize_t Category_length[batch_size];
+  char category[batch_size][max_strlen];
+  ssize_t category_length[batch_size];
 
-  result_set->BindColumn(1, driver::odbcabstraction::CDataType_CHAR, 0, 0, IncidntNum,
-                         max_strlen, IncidntNum_length);
+  result_set->BindColumn(1, driver::odbcabstraction::CDataType_CHAR, 0, 0, incidnt_num,
+                         max_strlen, incidnt_num_length);
   result_set->BindColumn(2, driver::odbcabstraction::CDataType_DOUBLE, 0, 0, double_field,
                          max_strlen, double_field_length);
-  result_set->BindColumn(3, driver::odbcabstraction::CDataType_CHAR, 0, 0, Category,
-                         max_strlen, Category_length);
+  result_set->BindColumn(3, driver::odbcabstraction::CDataType_CHAR, 0, 0, category,
+                         max_strlen, category_length);
 
   size_t total = 0;
   while (true) {
     size_t fetched_rows = result_set->Move(batch_size, 0, 0, nullptr);
-    std::cout << "Fetched " << fetched_rows << " rows." << std::endl;
+    ARROW_LOG(DEBUG) << "Fetched " << fetched_rows << " rows.";
 
     total += fetched_rows;
-    std::cout << "Total:" << total << std::endl;
+    ARROW_LOG(DEBUG) << "Total:" << total;
 
     for (int i = 0; i < fetched_rows; ++i) {
-      std::cout << "Row[" << i << "] IncidntNum: '" << IncidntNum[i] << "', "
-                << "double_field: '" << double_field[i] << "', "
-                << "Category: '" << Category[i] << "'" << std::endl;
+      ARROW_LOG(DEBUG) << "Row[" << i << "] incidnt_num: '" << incidnt_num[i] << "', "
+                       << "double_field: '" << double_field[i] << "', "
+                       << "category: '" << category[i] << "'";
     }
 
     if (fetched_rows < batch_size) break;

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/system_dsn.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/system_dsn.cc
@@ -81,10 +81,10 @@ void PostLastInstallerError() {
 
   std::stringstream buf;
   buf << "Message: \"" << msg << "\", Code: " << code;
-  std::string errorMsg = buf.str();
+  std::string error_msg = buf.str();
 
-  MessageBox(NULL, errorMsg.c_str(), "Error!", MB_ICONEXCLAMATION | MB_OK);
-  SQLPostInstallerError(code, errorMsg.c_str());
+  MessageBox(NULL, error_msg.c_str(), "Error!", MB_ICONEXCLAMATION | MB_OK);
+  SQLPostInstallerError(code, error_msg.c_str());
 }
 
 /**

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/ui/add_property_window.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/ui/add_property_window.cc
@@ -34,10 +34,10 @@ namespace config {
 
 AddPropertyWindow::AddPropertyWindow(Window* parent)
     : CustomWindow(parent, "AddProperty", "Add Property"),
-      width(300),
-      height(120),
-      accepted(false),
-      is_initialized(false) {
+      width_(300),
+      height_(120),
+      accepted_(false),
+      is_initialized_(false) {
   // No-op.
 }
 
@@ -48,13 +48,15 @@ AddPropertyWindow::~AddPropertyWindow() {
 void AddPropertyWindow::Create() {
   // Finding out parent position.
   RECT parent_rect;
-  GetWindowRect(parent->GetHandle(), &parent_rect);
+  GetWindowRect(parent_->GetHandle(), &parent_rect);
 
   // Positioning window to the center of parent window.
-  const int pos_x = parent_rect.left + (parent_rect.right - parent_rect.left - width) / 2;
-  const int pos_y = parent_rect.top + (parent_rect.bottom - parent_rect.top - height) / 2;
+  const int pos_x =
+      parent_rect.left + (parent_rect.right - parent_rect.left - width_) / 2;
+  const int pos_y =
+      parent_rect.top + (parent_rect.bottom - parent_rect.top - height_) / 2;
 
-  RECT desired_rect = {pos_x, pos_y, pos_x + width, pos_y + height};
+  RECT desired_rect = {pos_x, pos_y, pos_x + width_, pos_y + height_};
   AdjustWindowRect(&desired_rect, WS_BORDER | WS_CAPTION | WS_SYSMENU | WS_THICKFRAME,
                    FALSE);
 
@@ -62,7 +64,7 @@ void AddPropertyWindow::Create() {
                  desired_rect.right - desired_rect.left,
                  desired_rect.bottom - desired_rect.top, 0);
 
-  if (!handle) {
+  if (!handle_) {
     std::stringstream buf;
     buf << "Can not create window, error code: " << GetLastError();
     throw odbcabstraction::DriverException(buf.str());
@@ -70,9 +72,9 @@ void AddPropertyWindow::Create() {
 }
 
 bool AddPropertyWindow::GetProperty(std::string& key, std::string& value) {
-  if (accepted) {
-    key = this->key;
-    value = this->value;
+  if (accepted_) {
+    key = this->key_;
+    value = this->value_;
     return true;
   }
   return false;
@@ -80,18 +82,18 @@ bool AddPropertyWindow::GetProperty(std::string& key, std::string& value) {
 
 void AddPropertyWindow::OnCreate() {
   int group_pos_y = MARGIN;
-  int group_size_y = width - 2 * MARGIN;
+  int group_size_y = width_ - 2 * MARGIN;
 
   group_pos_y += INTERVAL + CreateEdits(MARGIN, group_pos_y, group_size_y);
 
-  int cancel_pos_x = width - MARGIN - BUTTON_WIDTH;
+  int cancel_pos_x = width_ - MARGIN - BUTTON_WIDTH;
   int ok_pos_x = cancel_pos_x - INTERVAL - BUTTON_WIDTH;
 
-  ok_button = CreateButton(ok_pos_x, group_pos_y, BUTTON_WIDTH, BUTTON_HEIGHT, "Ok",
-                           ChildId::OK_BUTTON, BS_DEFPUSHBUTTON);
-  cancel_button = CreateButton(cancel_pos_x, group_pos_y, BUTTON_WIDTH, BUTTON_HEIGHT,
-                               "Cancel", ChildId::CANCEL_BUTTON);
-  is_initialized = true;
+  ok_button_ = CreateButton(ok_pos_x, group_pos_y, BUTTON_WIDTH, BUTTON_HEIGHT, "Ok",
+                            ChildId::OK_BUTTON, BS_DEFPUSHBUTTON);
+  cancel_button_ = CreateButton(cancel_pos_x, group_pos_y, BUTTON_WIDTH, BUTTON_HEIGHT,
+                                "Cancel", ChildId::CANCEL_BUTTON);
+  is_initialized_ = true;
   CheckEnableOk();
 }
 
@@ -103,16 +105,16 @@ int AddPropertyWindow::CreateEdits(int pos_x, int pos_y, int size_x) {
 
   int row_pos = pos_y;
 
-  labels.push_back(
+  labels_.push_back(
       CreateLabel(pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT, "Key:", ChildId::KEY_LABEL));
-  key_edit =
+  key_edit_ =
       CreateEdit(edit_pos_x, row_pos, edit_size_x, ROW_HEIGHT, "", ChildId::KEY_EDIT);
 
   row_pos += INTERVAL + ROW_HEIGHT;
 
-  labels.push_back(CreateLabel(pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT,
-                               "Value:", ChildId::VALUE_LABEL));
-  value_edit =
+  labels_.push_back(CreateLabel(pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT,
+                                "Value:", ChildId::VALUE_LABEL));
+  value_edit_ =
       CreateEdit(edit_pos_x, row_pos, edit_size_x, ROW_HEIGHT, "", ChildId::VALUE_EDIT);
 
   row_pos += INTERVAL + ROW_HEIGHT;
@@ -121,11 +123,11 @@ int AddPropertyWindow::CreateEdits(int pos_x, int pos_y, int size_x) {
 }
 
 void AddPropertyWindow::CheckEnableOk() {
-  if (!is_initialized) {
+  if (!is_initialized_) {
     return;
   }
 
-  ok_button->SetEnabled(!key_edit->IsTextEmpty() && !value_edit->IsTextEmpty());
+  ok_button_->SetEnabled(!key_edit_->IsTextEmpty() && !value_edit_->IsTextEmpty());
 }
 
 bool AddPropertyWindow::OnMessage(UINT msg, WPARAM wparam, LPARAM lparam) {
@@ -133,9 +135,9 @@ bool AddPropertyWindow::OnMessage(UINT msg, WPARAM wparam, LPARAM lparam) {
     case WM_COMMAND: {
       switch (LOWORD(wparam)) {
         case ChildId::OK_BUTTON: {
-          key_edit->GetText(key);
-          value_edit->GetText(value);
-          accepted = true;
+          key_edit_->GetText(key_);
+          value_edit_->GetText(value_);
+          accepted_ = true;
           PostMessage(GetHandle(), WM_CLOSE, 0, 0);
 
           break;
@@ -163,7 +165,7 @@ bool AddPropertyWindow::OnMessage(UINT msg, WPARAM wparam, LPARAM lparam) {
     }
 
     case WM_DESTROY: {
-      PostQuitMessage(accepted ? Result::OK : Result::CANCEL);
+      PostQuitMessage(accepted_ ? Result::OK : Result::CANCEL);
 
       break;
     }

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/ui/add_property_window.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/ui/add_property_window.cc
@@ -37,7 +37,7 @@ AddPropertyWindow::AddPropertyWindow(Window* parent)
       width(300),
       height(120),
       accepted(false),
-      isInitialized(false) {
+      is_initialized(false) {
   // No-op.
 }
 
@@ -47,20 +47,20 @@ AddPropertyWindow::~AddPropertyWindow() {
 
 void AddPropertyWindow::Create() {
   // Finding out parent position.
-  RECT parentRect;
-  GetWindowRect(parent->GetHandle(), &parentRect);
+  RECT parent_rect;
+  GetWindowRect(parent->GetHandle(), &parent_rect);
 
   // Positioning window to the center of parent window.
-  const int posX = parentRect.left + (parentRect.right - parentRect.left - width) / 2;
-  const int posY = parentRect.top + (parentRect.bottom - parentRect.top - height) / 2;
+  const int pos_x = parent_rect.left + (parent_rect.right - parent_rect.left - width) / 2;
+  const int pos_y = parent_rect.top + (parent_rect.bottom - parent_rect.top - height) / 2;
 
-  RECT desiredRect = {posX, posY, posX + width, posY + height};
-  AdjustWindowRect(&desiredRect, WS_BORDER | WS_CAPTION | WS_SYSMENU | WS_THICKFRAME,
+  RECT desired_rect = {pos_x, pos_y, pos_x + width, pos_y + height};
+  AdjustWindowRect(&desired_rect, WS_BORDER | WS_CAPTION | WS_SYSMENU | WS_THICKFRAME,
                    FALSE);
 
-  Window::Create(WS_OVERLAPPED | WS_SYSMENU, desiredRect.left, desiredRect.top,
-                 desiredRect.right - desiredRect.left,
-                 desiredRect.bottom - desiredRect.top, 0);
+  Window::Create(WS_OVERLAPPED | WS_SYSMENU, desired_rect.left, desired_rect.top,
+                 desired_rect.right - desired_rect.left,
+                 desired_rect.bottom - desired_rect.top, 0);
 
   if (!handle) {
     std::stringstream buf;
@@ -79,61 +79,62 @@ bool AddPropertyWindow::GetProperty(std::string& key, std::string& value) {
 }
 
 void AddPropertyWindow::OnCreate() {
-  int groupPosY = MARGIN;
-  int groupSizeY = width - 2 * MARGIN;
+  int group_pos_y = MARGIN;
+  int group_size_y = width - 2 * MARGIN;
 
-  groupPosY += INTERVAL + CreateEdits(MARGIN, groupPosY, groupSizeY);
+  group_pos_y += INTERVAL + CreateEdits(MARGIN, group_pos_y, group_size_y);
 
-  int cancelPosX = width - MARGIN - BUTTON_WIDTH;
-  int okPosX = cancelPosX - INTERVAL - BUTTON_WIDTH;
+  int cancel_pos_x = width - MARGIN - BUTTON_WIDTH;
+  int ok_pos_x = cancel_pos_x - INTERVAL - BUTTON_WIDTH;
 
-  okButton = CreateButton(okPosX, groupPosY, BUTTON_WIDTH, BUTTON_HEIGHT, "Ok",
-                          ChildId::OK_BUTTON, BS_DEFPUSHBUTTON);
-  cancelButton = CreateButton(cancelPosX, groupPosY, BUTTON_WIDTH, BUTTON_HEIGHT,
-                              "Cancel", ChildId::CANCEL_BUTTON);
-  isInitialized = true;
+  ok_button = CreateButton(ok_pos_x, group_pos_y, BUTTON_WIDTH, BUTTON_HEIGHT, "Ok",
+                           ChildId::OK_BUTTON, BS_DEFPUSHBUTTON);
+  cancel_button = CreateButton(cancel_pos_x, group_pos_y, BUTTON_WIDTH, BUTTON_HEIGHT,
+                               "Cancel", ChildId::CANCEL_BUTTON);
+  is_initialized = true;
   CheckEnableOk();
 }
 
-int AddPropertyWindow::CreateEdits(int posX, int posY, int sizeX) {
+int AddPropertyWindow::CreateEdits(int pos_x, int pos_y, int size_x) {
   enum { LABEL_WIDTH = 30 };
 
-  const int editSizeX = sizeX - LABEL_WIDTH - INTERVAL;
-  const int editPosX = posX + LABEL_WIDTH + INTERVAL;
+  const int edit_size_x = size_x - LABEL_WIDTH - INTERVAL;
+  const int edit_pos_x = pos_x + LABEL_WIDTH + INTERVAL;
 
-  int rowPos = posY;
-
-  labels.push_back(
-      CreateLabel(posX, rowPos, LABEL_WIDTH, ROW_HEIGHT, "Key:", ChildId::KEY_LABEL));
-  keyEdit = CreateEdit(editPosX, rowPos, editSizeX, ROW_HEIGHT, "", ChildId::KEY_EDIT);
-
-  rowPos += INTERVAL + ROW_HEIGHT;
+  int row_pos = pos_y;
 
   labels.push_back(
-      CreateLabel(posX, rowPos, LABEL_WIDTH, ROW_HEIGHT, "Value:", ChildId::VALUE_LABEL));
-  valueEdit =
-      CreateEdit(editPosX, rowPos, editSizeX, ROW_HEIGHT, "", ChildId::VALUE_EDIT);
+      CreateLabel(pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT, "Key:", ChildId::KEY_LABEL));
+  key_edit =
+      CreateEdit(edit_pos_x, row_pos, edit_size_x, ROW_HEIGHT, "", ChildId::KEY_EDIT);
 
-  rowPos += INTERVAL + ROW_HEIGHT;
+  row_pos += INTERVAL + ROW_HEIGHT;
 
-  return rowPos - posY;
+  labels.push_back(CreateLabel(pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT,
+                               "Value:", ChildId::VALUE_LABEL));
+  value_edit =
+      CreateEdit(edit_pos_x, row_pos, edit_size_x, ROW_HEIGHT, "", ChildId::VALUE_EDIT);
+
+  row_pos += INTERVAL + ROW_HEIGHT;
+
+  return row_pos - pos_y;
 }
 
 void AddPropertyWindow::CheckEnableOk() {
-  if (!isInitialized) {
+  if (!is_initialized) {
     return;
   }
 
-  okButton->SetEnabled(!keyEdit->IsTextEmpty() && !valueEdit->IsTextEmpty());
+  ok_button->SetEnabled(!key_edit->IsTextEmpty() && !value_edit->IsTextEmpty());
 }
 
-bool AddPropertyWindow::OnMessage(UINT msg, WPARAM wParam, LPARAM lParam) {
+bool AddPropertyWindow::OnMessage(UINT msg, WPARAM wparam, LPARAM lparam) {
   switch (msg) {
     case WM_COMMAND: {
-      switch (LOWORD(wParam)) {
+      switch (LOWORD(wparam)) {
         case ChildId::OK_BUTTON: {
-          keyEdit->GetText(key);
-          valueEdit->GetText(value);
+          key_edit->GetText(key);
+          value_edit->GetText(value);
           accepted = true;
           PostMessage(GetHandle(), WM_CLOSE, 0, 0);
 
@@ -148,7 +149,7 @@ bool AddPropertyWindow::OnMessage(UINT msg, WPARAM wParam, LPARAM lParam) {
 
         case ChildId::KEY_EDIT:
         case ChildId::VALUE_EDIT: {
-          if (HIWORD(wParam) == EN_CHANGE) {
+          if (HIWORD(wparam) == EN_CHANGE) {
             CheckEnableOk();
           }
           break;

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/ui/custom_window.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/ui/custom_window.cc
@@ -46,22 +46,22 @@ Result::Type ProcessMessages(Window& window) {
   return static_cast<Result::Type>(msg.wParam);
 }
 
-LRESULT CALLBACK CustomWindow::WndProc(HWND hwnd, UINT msg, WPARAM wParam,
-                                       LPARAM lParam) {
+LRESULT CALLBACK CustomWindow::WndProc(HWND hwnd, UINT msg, WPARAM wparam,
+                                       LPARAM lparam) {
   CustomWindow* window =
       reinterpret_cast<CustomWindow*>(GetWindowLongPtr(hwnd, GWLP_USERDATA));
 
   switch (msg) {
     case WM_NCCREATE: {
-      _ASSERT(lParam != NULL);
+      _ASSERT(lparam != NULL);
 
-      CREATESTRUCT* createStruct = reinterpret_cast<CREATESTRUCT*>(lParam);
+      CREATESTRUCT* create_struct = reinterpret_cast<CREATESTRUCT*>(lparam);
 
-      LONG_PTR longSelfPtr = reinterpret_cast<LONG_PTR>(createStruct->lpCreateParams);
+      LONG_PTR long_self_ptr = reinterpret_cast<LONG_PTR>(create_struct->lpCreateParams);
 
-      SetWindowLongPtr(hwnd, GWLP_USERDATA, longSelfPtr);
+      SetWindowLongPtr(hwnd, GWLP_USERDATA, long_self_ptr);
 
-      return DefWindowProc(hwnd, msg, wParam, lParam);
+      return DefWindowProc(hwnd, msg, wparam, lparam);
     }
 
     case WM_CREATE: {
@@ -78,13 +78,13 @@ LRESULT CALLBACK CustomWindow::WndProc(HWND hwnd, UINT msg, WPARAM wParam,
       break;
   }
 
-  if (window && window->OnMessage(msg, wParam, lParam)) return 0;
+  if (window && window->OnMessage(msg, wparam, lparam)) return 0;
 
-  return DefWindowProc(hwnd, msg, wParam, lParam);
+  return DefWindowProc(hwnd, msg, wparam, lparam);
 }
 
-CustomWindow::CustomWindow(Window* parent, const char* className, const char* title)
-    : Window(parent, className, title) {
+CustomWindow::CustomWindow(Window* parent, const char* class_name, const char* title)
+    : Window(parent, class_name, title) {
   WNDCLASS wcx;
 
   wcx.style = CS_HREDRAW | CS_VREDRAW;
@@ -96,7 +96,7 @@ CustomWindow::CustomWindow(Window* parent, const char* className, const char* ti
   wcx.hCursor = LoadCursor(NULL, IDC_ARROW);
   wcx.hbrBackground = (HBRUSH)COLOR_WINDOW;
   wcx.lpszMenuName = NULL;
-  wcx.lpszClassName = className;
+  wcx.lpszClassName = class_name;
 
   if (!RegisterClass(&wcx)) {
     std::stringstream buf;
@@ -105,7 +105,7 @@ CustomWindow::CustomWindow(Window* parent, const char* className, const char* ti
   }
 }
 
-CustomWindow::~CustomWindow() { UnregisterClass(className.c_str(), GetHInstance()); }
+CustomWindow::~CustomWindow() { UnregisterClass(class_name.c_str(), GetHInstance()); }
 
 }  // namespace config
 }  // namespace flight_sql

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/ui/custom_window.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/ui/custom_window.cc
@@ -105,7 +105,7 @@ CustomWindow::CustomWindow(Window* parent, const char* class_name, const char* t
   }
 }
 
-CustomWindow::~CustomWindow() { UnregisterClass(class_name.c_str(), GetHInstance()); }
+CustomWindow::~CustomWindow() { UnregisterClass(class_name_.c_str(), GetHInstance()); }
 
 }  // namespace config
 }  // namespace flight_sql

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/ui/dsn_configuration_window.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/ui/dsn_configuration_window.cc
@@ -33,19 +33,19 @@
 
 namespace {
 std::string TestConnection(const driver::flight_sql::config::Configuration& config) {
-  std::unique_ptr<driver::flight_sql::FlightSqlConnection> flightSqlConn(
+  std::unique_ptr<driver::flight_sql::FlightSqlConnection> flight_sql_conn(
       new driver::flight_sql::FlightSqlConnection(driver::odbcabstraction::V_3));
 
-  std::vector<std::string_view> missingProperties;
-  flightSqlConn->Connect(config.GetProperties(), missingProperties);
+  std::vector<std::string_view> missing_properties;
+  flight_sql_conn->Connect(config.GetProperties(), missing_properties);
 
   // This should have been checked before enabling the Test button.
-  assert(missingProperties.empty());
-  std::string serverName =
-      boost::get<std::string>(flightSqlConn->GetInfo(SQL_SERVER_NAME));
-  std::string serverVersion =
-      boost::get<std::string>(flightSqlConn->GetInfo(SQL_DBMS_VER));
-  return "Server Name: " + serverName + "\n" + "Server Version: " + serverVersion;
+  assert(missing_properties.empty());
+  std::string server_name =
+      boost::get<std::string>(flight_sql_conn->GetInfo(SQL_SERVER_NAME));
+  std::string server_version =
+      boost::get<std::string>(flight_sql_conn->GetInfo(SQL_DBMS_VER));
+  return "Server Name: " + server_name + "\n" + "Server Version: " + server_version;
 }
 }  // namespace
 
@@ -60,7 +60,7 @@ DsnConfigurationWindow::DsnConfigurationWindow(Window* parent,
       height(375),
       config(config),
       accepted(false),
-      isInitialized(false) {
+      is_initialized(false) {
   // No-op.
 }
 
@@ -70,20 +70,20 @@ DsnConfigurationWindow::~DsnConfigurationWindow() {
 
 void DsnConfigurationWindow::Create() {
   // Finding out parent position.
-  RECT parentRect;
-  GetWindowRect(parent->GetHandle(), &parentRect);
+  RECT parent_rect;
+  GetWindowRect(parent->GetHandle(), &parent_rect);
 
   // Positioning window to the center of parent window.
-  const int posX = parentRect.left + (parentRect.right - parentRect.left - width) / 2;
-  const int posY = parentRect.top + (parentRect.bottom - parentRect.top - height) / 2;
+  const int pos_x = parent_rect.left + (parent_rect.right - parent_rect.left - width) / 2;
+  const int pos_y = parent_rect.top + (parent_rect.bottom - parent_rect.top - height) / 2;
 
-  RECT desiredRect = {posX, posY, posX + width, posY + height};
-  AdjustWindowRect(&desiredRect, WS_BORDER | WS_CAPTION | WS_SYSMENU | WS_THICKFRAME,
+  RECT desired_rect = {pos_x, pos_y, pos_x + width, pos_y + height};
+  AdjustWindowRect(&desired_rect, WS_BORDER | WS_CAPTION | WS_SYSMENU | WS_THICKFRAME,
                    FALSE);
 
-  Window::Create(WS_OVERLAPPED | WS_SYSMENU, desiredRect.left, desiredRect.top,
-                 desiredRect.right - desiredRect.left,
-                 desiredRect.bottom - desiredRect.top, 0);
+  Window::Create(WS_OVERLAPPED | WS_SYSMENU, desired_rect.left, desired_rect.top,
+                 desired_rect.right - desired_rect.left,
+                 desired_rect.bottom - desired_rect.top, 0);
 
   if (!handle) {
     std::stringstream buf;
@@ -93,362 +93,369 @@ void DsnConfigurationWindow::Create() {
 }
 
 void DsnConfigurationWindow::OnCreate() {
-  tabControl = CreateTabControl(ChildId::TAB_CONTROL);
-  tabControl->AddTab("Common", COMMON_TAB);
-  tabControl->AddTab("Advanced", ADVANCED_TAB);
+  tab_control = CreateTabControl(ChildId::TAB_CONTROL);
+  tab_control->AddTab("Common", COMMON_TAB);
+  tab_control->AddTab("Advanced", ADVANCED_TAB);
 
-  int groupPosY = 3 * MARGIN;
-  int groupSizeY = width - 2 * MARGIN;
+  int group_pos_y = 3 * MARGIN;
+  int group_size_y = width - 2 * MARGIN;
 
-  int commonGroupPosY = groupPosY;
-  commonGroupPosY +=
-      INTERVAL + CreateConnectionSettingsGroup(MARGIN, commonGroupPosY, groupSizeY);
-  commonGroupPosY +=
-      INTERVAL + CreateAuthSettingsGroup(MARGIN, commonGroupPosY, groupSizeY);
+  int common_group_pos_y = group_pos_y;
+  common_group_pos_y +=
+      INTERVAL + CreateConnectionSettingsGroup(MARGIN, common_group_pos_y, group_size_y);
+  common_group_pos_y +=
+      INTERVAL + CreateAuthSettingsGroup(MARGIN, common_group_pos_y, group_size_y);
 
-  int advancedGroupPosY = groupPosY;
-  advancedGroupPosY +=
-      INTERVAL + CreateEncryptionSettingsGroup(MARGIN, advancedGroupPosY, groupSizeY);
-  advancedGroupPosY +=
-      INTERVAL + CreatePropertiesGroup(MARGIN, advancedGroupPosY, groupSizeY);
+  int advanced_group_pos_y = group_pos_y;
+  advanced_group_pos_y += INTERVAL + CreateEncryptionSettingsGroup(
+                                         MARGIN, advanced_group_pos_y, group_size_y);
+  advanced_group_pos_y +=
+      INTERVAL + CreatePropertiesGroup(MARGIN, advanced_group_pos_y, group_size_y);
 
-  int testPosX = MARGIN;
-  int cancelPosX = width - MARGIN - BUTTON_WIDTH;
-  int okPosX = cancelPosX - INTERVAL - BUTTON_WIDTH;
+  int test_pos_x = MARGIN;
+  int cancel_pos_x = width - MARGIN - BUTTON_WIDTH;
+  int ok_pos_x = cancel_pos_x - INTERVAL - BUTTON_WIDTH;
 
-  int buttonPosY = std::max(commonGroupPosY, advancedGroupPosY);
-  testButton = CreateButton(testPosX, buttonPosY, BUTTON_WIDTH + 20, BUTTON_HEIGHT,
-                            "Test Connection", ChildId::TEST_CONNECTION_BUTTON);
-  okButton = CreateButton(okPosX, buttonPosY, BUTTON_WIDTH, BUTTON_HEIGHT, "Ok",
-                          ChildId::OK_BUTTON);
-  cancelButton = CreateButton(cancelPosX, buttonPosY, BUTTON_WIDTH, BUTTON_HEIGHT,
-                              "Cancel", ChildId::CANCEL_BUTTON);
-  isInitialized = true;
+  int button_pos_y = std::max(common_group_pos_y, advanced_group_pos_y);
+  test_button = CreateButton(test_pos_x, button_pos_y, BUTTON_WIDTH + 20, BUTTON_HEIGHT,
+                             "Test Connection", ChildId::TEST_CONNECTION_BUTTON);
+  ok_button = CreateButton(ok_pos_x, button_pos_y, BUTTON_WIDTH, BUTTON_HEIGHT, "Ok",
+                           ChildId::OK_BUTTON);
+  cancel_button = CreateButton(cancel_pos_x, button_pos_y, BUTTON_WIDTH, BUTTON_HEIGHT,
+                               "Cancel", ChildId::CANCEL_BUTTON);
+  is_initialized = true;
   CheckEnableOk();
   SelectTab(COMMON_TAB);
 }
 
-int DsnConfigurationWindow::CreateConnectionSettingsGroup(int posX, int posY, int sizeX) {
+int DsnConfigurationWindow::CreateConnectionSettingsGroup(int pos_x, int pos_y,
+                                                          int size_x) {
   enum { LABEL_WIDTH = 100 };
 
-  const int labelPosX = posX + INTERVAL;
+  const int label_pos_x = pos_x + INTERVAL;
 
-  const int editSizeX = sizeX - LABEL_WIDTH - 3 * INTERVAL;
-  const int editPosX = labelPosX + LABEL_WIDTH + INTERVAL;
+  const int edit_size_x = size_x - LABEL_WIDTH - 3 * INTERVAL;
+  const int edit_pos_x = label_pos_x + LABEL_WIDTH + INTERVAL;
 
-  int rowPos = posY + 2 * INTERVAL;
+  int row_pos = pos_y + 2 * INTERVAL;
 
   const char* val = config.Get(FlightSqlConnection::DSN).c_str();
-  labels.push_back(CreateLabel(labelPosX, rowPos, LABEL_WIDTH, ROW_HEIGHT,
+  labels.push_back(CreateLabel(label_pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT,
                                "Data Source Name:", ChildId::NAME_LABEL));
-  nameEdit = CreateEdit(editPosX, rowPos, editSizeX, ROW_HEIGHT, val, ChildId::NAME_EDIT);
+  name_edit =
+      CreateEdit(edit_pos_x, row_pos, edit_size_x, ROW_HEIGHT, val, ChildId::NAME_EDIT);
 
-  rowPos += INTERVAL + ROW_HEIGHT;
+  row_pos += INTERVAL + ROW_HEIGHT;
 
   val = config.Get(FlightSqlConnection::HOST).c_str();
-  labels.push_back(CreateLabel(labelPosX, rowPos, LABEL_WIDTH, ROW_HEIGHT,
+  labels.push_back(CreateLabel(label_pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT,
                                "Host Name:", ChildId::SERVER_LABEL));
-  serverEdit =
-      CreateEdit(editPosX, rowPos, editSizeX, ROW_HEIGHT, val, ChildId::SERVER_EDIT);
+  server_edit =
+      CreateEdit(edit_pos_x, row_pos, edit_size_x, ROW_HEIGHT, val, ChildId::SERVER_EDIT);
 
-  rowPos += INTERVAL + ROW_HEIGHT;
+  row_pos += INTERVAL + ROW_HEIGHT;
 
   val = config.Get(FlightSqlConnection::PORT).c_str();
-  labels.push_back(CreateLabel(labelPosX, rowPos, LABEL_WIDTH, ROW_HEIGHT,
+  labels.push_back(CreateLabel(label_pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT,
                                "Port:", ChildId::PORT_LABEL));
-  portEdit = CreateEdit(editPosX, rowPos, editSizeX, ROW_HEIGHT, val, ChildId::PORT_EDIT,
-                        ES_NUMBER);
+  port_edit = CreateEdit(edit_pos_x, row_pos, edit_size_x, ROW_HEIGHT, val,
+                         ChildId::PORT_EDIT, ES_NUMBER);
 
-  rowPos += INTERVAL + ROW_HEIGHT;
+  row_pos += INTERVAL + ROW_HEIGHT;
 
-  connectionSettingsGroupBox =
-      CreateGroupBox(posX, posY, sizeX, rowPos - posY, "Connection settings",
+  connection_settings_group_box =
+      CreateGroupBox(pos_x, pos_y, size_x, row_pos - pos_y, "Connection settings",
                      ChildId::CONNECTION_SETTINGS_GROUP_BOX);
 
-  return rowPos - posY;
+  return row_pos - pos_y;
 }
 
-int DsnConfigurationWindow::CreateAuthSettingsGroup(int posX, int posY, int sizeX) {
+int DsnConfigurationWindow::CreateAuthSettingsGroup(int pos_x, int pos_y, int size_x) {
   enum { LABEL_WIDTH = 120 };
 
-  const int labelPosX = posX + INTERVAL;
+  const int label_pos_x = pos_x + INTERVAL;
 
-  const int editSizeX = sizeX - LABEL_WIDTH - 3 * INTERVAL;
-  const int editPosX = labelPosX + LABEL_WIDTH + INTERVAL;
+  const int edit_size_x = size_x - LABEL_WIDTH - 3 * INTERVAL;
+  const int edit_pos_x = label_pos_x + LABEL_WIDTH + INTERVAL;
 
-  int rowPos = posY + 2 * INTERVAL;
+  int row_pos = pos_y + 2 * INTERVAL;
 
-  labels.push_back(CreateLabel(labelPosX, rowPos, LABEL_WIDTH, ROW_HEIGHT,
+  labels.push_back(CreateLabel(label_pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT,
                                "Authentication Type:", ChildId::AUTH_TYPE_LABEL));
-  authTypeComboBox = CreateComboBox(editPosX, rowPos, editSizeX, ROW_HEIGHT,
-                                    "Authentication Type:", ChildId::AUTH_TYPE_COMBOBOX);
-  authTypeComboBox->AddString("Basic Authentication");
-  authTypeComboBox->AddString("Token Authentication");
+  auth_type_combo_box =
+      CreateComboBox(edit_pos_x, row_pos, edit_size_x, ROW_HEIGHT,
+                     "Authentication Type:", ChildId::AUTH_TYPE_COMBOBOX);
+  auth_type_combo_box->AddString("Basic Authentication");
+  auth_type_combo_box->AddString("Token Authentication");
 
-  rowPos += INTERVAL + ROW_HEIGHT;
+  row_pos += INTERVAL + ROW_HEIGHT;
 
   const char* val = config.Get(FlightSqlConnection::UID).c_str();
 
-  labels.push_back(CreateLabel(labelPosX, rowPos, LABEL_WIDTH, ROW_HEIGHT,
+  labels.push_back(CreateLabel(label_pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT,
                                "User:", ChildId::USER_LABEL));
-  userEdit = CreateEdit(editPosX, rowPos, editSizeX, ROW_HEIGHT, val, ChildId::USER_EDIT);
+  user_edit =
+      CreateEdit(edit_pos_x, row_pos, edit_size_x, ROW_HEIGHT, val, ChildId::USER_EDIT);
 
-  rowPos += INTERVAL + ROW_HEIGHT;
+  row_pos += INTERVAL + ROW_HEIGHT;
 
   val = config.Get(FlightSqlConnection::PWD).c_str();
-  labels.push_back(CreateLabel(labelPosX, rowPos, LABEL_WIDTH, ROW_HEIGHT,
+  labels.push_back(CreateLabel(label_pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT,
                                "Password:", ChildId::PASSWORD_LABEL));
-  passwordEdit = CreateEdit(editPosX, rowPos, editSizeX, ROW_HEIGHT, val,
-                            ChildId::USER_EDIT, ES_PASSWORD);
+  password_edit = CreateEdit(edit_pos_x, row_pos, edit_size_x, ROW_HEIGHT, val,
+                             ChildId::USER_EDIT, ES_PASSWORD);
 
-  rowPos += INTERVAL + ROW_HEIGHT;
+  row_pos += INTERVAL + ROW_HEIGHT;
 
   const auto& token = config.Get(FlightSqlConnection::TOKEN);
   val = token.c_str();
-  labels.push_back(CreateLabel(labelPosX, rowPos, LABEL_WIDTH, ROW_HEIGHT,
+  labels.push_back(CreateLabel(label_pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT,
                                "Authentication Token:", ChildId::AUTH_TOKEN_LABEL));
-  authTokenEdit =
-      CreateEdit(editPosX, rowPos, editSizeX, ROW_HEIGHT, val, ChildId::AUTH_TOKEN_EDIT);
-  authTokenEdit->SetEnabled(false);
+  auth_token_edit = CreateEdit(edit_pos_x, row_pos, edit_size_x, ROW_HEIGHT, val,
+                               ChildId::AUTH_TOKEN_EDIT);
+  auth_token_edit->SetEnabled(false);
 
   // Ensure the right elements are selected.
-  authTypeComboBox->SetSelection(token.empty() ? 0 : 1);
+  auth_type_combo_box->SetSelection(token.empty() ? 0 : 1);
   CheckAuthType();
 
-  rowPos += INTERVAL + ROW_HEIGHT;
+  row_pos += INTERVAL + ROW_HEIGHT;
 
-  authSettingsGroupBox =
-      CreateGroupBox(posX, posY, sizeX, rowPos - posY, "Authentication settings",
+  auth_settings_group_box =
+      CreateGroupBox(pos_x, pos_y, size_x, row_pos - pos_y, "Authentication settings",
                      ChildId::AUTH_SETTINGS_GROUP_BOX);
 
-  return rowPos - posY;
+  return row_pos - pos_y;
 }
 
-int DsnConfigurationWindow::CreateEncryptionSettingsGroup(int posX, int posY, int sizeX) {
+int DsnConfigurationWindow::CreateEncryptionSettingsGroup(int pos_x, int pos_y,
+                                                          int size_x) {
   enum { LABEL_WIDTH = 120 };
 
-  const int labelPosX = posX + INTERVAL;
+  const int label_pos_x = pos_x + INTERVAL;
 
-  const int editSizeX = sizeX - LABEL_WIDTH - 3 * INTERVAL;
-  const int editPosX = labelPosX + LABEL_WIDTH + INTERVAL;
+  const int edit_size_x = size_x - LABEL_WIDTH - 3 * INTERVAL;
+  const int edit_pos_x = label_pos_x + LABEL_WIDTH + INTERVAL;
 
-  int rowPos = posY + 2 * INTERVAL;
+  int row_pos = pos_y + 2 * INTERVAL;
 
   const char* val = config.Get(FlightSqlConnection::USE_ENCRYPTION).c_str();
 
-  const bool enableEncryption = driver::odbcabstraction::AsBool(val).value_or(true);
-  labels.push_back(CreateLabel(labelPosX, rowPos, LABEL_WIDTH, ROW_HEIGHT,
+  const bool enable_encryption = driver::odbcabstraction::AsBool(val).value_or(true);
+  labels.push_back(CreateLabel(label_pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT,
                                "Use Encryption:", ChildId::ENABLE_ENCRYPTION_LABEL));
-  enableEncryptionCheckBox =
-      CreateCheckBox(editPosX, rowPos - 2, editSizeX, ROW_HEIGHT, "",
-                     ChildId::ENABLE_ENCRYPTION_CHECKBOX, enableEncryption);
+  enable_encryption_check_box =
+      CreateCheckBox(edit_pos_x, row_pos - 2, edit_size_x, ROW_HEIGHT, "",
+                     ChildId::ENABLE_ENCRYPTION_CHECKBOX, enable_encryption);
 
-  rowPos += INTERVAL + ROW_HEIGHT;
+  row_pos += INTERVAL + ROW_HEIGHT;
 
   val = config.Get(FlightSqlConnection::TRUSTED_CERTS).c_str();
 
-  labels.push_back(CreateLabel(labelPosX, rowPos, LABEL_WIDTH, ROW_HEIGHT,
+  labels.push_back(CreateLabel(label_pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT,
                                "Certificate:", ChildId::CERTIFICATE_LABEL));
-  certificateEdit = CreateEdit(editPosX, rowPos, editSizeX - MARGIN - BUTTON_WIDTH,
-                               ROW_HEIGHT, val, ChildId::CERTIFICATE_EDIT);
-  certificateBrowseButton =
-      CreateButton(editPosX + editSizeX - BUTTON_WIDTH, rowPos - 2, BUTTON_WIDTH,
+  certificate_edit = CreateEdit(edit_pos_x, row_pos, edit_size_x - MARGIN - BUTTON_WIDTH,
+                                ROW_HEIGHT, val, ChildId::CERTIFICATE_EDIT);
+  certificate_browse_button =
+      CreateButton(edit_pos_x + edit_size_x - BUTTON_WIDTH, row_pos - 2, BUTTON_WIDTH,
                    BUTTON_HEIGHT, "Browse", ChildId::CERTIFICATE_BROWSE_BUTTON);
 
-  rowPos += INTERVAL + ROW_HEIGHT;
+  row_pos += INTERVAL + ROW_HEIGHT;
 
   val = config.Get(FlightSqlConnection::USE_SYSTEM_TRUST_STORE).c_str();
 
-  const bool useSystemCertStore = driver::odbcabstraction::AsBool(val).value_or(true);
+  const bool use_system_cert_store = driver::odbcabstraction::AsBool(val).value_or(true);
   labels.push_back(
-      CreateLabel(labelPosX, rowPos, LABEL_WIDTH, 2 * ROW_HEIGHT,
+      CreateLabel(label_pos_x, row_pos, LABEL_WIDTH, 2 * ROW_HEIGHT,
                   "Use System Certificate Store:", ChildId::USE_SYSTEM_CERT_STORE_LABEL));
-  useSystemCertStoreCheckBox =
-      CreateCheckBox(editPosX, rowPos - 2, 20, 2 * ROW_HEIGHT, "",
-                     ChildId::USE_SYSTEM_CERT_STORE_CHECKBOX, useSystemCertStore);
+  use_system_cert_store_check_box =
+      CreateCheckBox(edit_pos_x, row_pos - 2, 20, 2 * ROW_HEIGHT, "",
+                     ChildId::USE_SYSTEM_CERT_STORE_CHECKBOX, use_system_cert_store);
 
   val = config.Get(FlightSqlConnection::DISABLE_CERTIFICATE_VERIFICATION).c_str();
 
-  const int rightPosX = labelPosX + (sizeX - (2 * INTERVAL)) / 2;
-  const int rightCheckPosX = rightPosX + (editPosX - labelPosX);
-  const bool disableCertVerification =
+  const int right_pos_x = label_pos_x + (size_x - (2 * INTERVAL)) / 2;
+  const int right_check_pos_x = right_pos_x + (edit_pos_x - label_pos_x);
+  const bool disable_cert_verification =
       driver::odbcabstraction::AsBool(val).value_or(false);
   labels.push_back(CreateLabel(
-      rightPosX, rowPos, LABEL_WIDTH, 2 * ROW_HEIGHT,
+      right_pos_x, row_pos, LABEL_WIDTH, 2 * ROW_HEIGHT,
       "Disable Certificate Verification:", ChildId::DISABLE_CERT_VERIFICATION_LABEL));
-  disableCertVerificationCheckBox = CreateCheckBox(
-      rightCheckPosX, rowPos - 2, 20, 2 * ROW_HEIGHT, "",
-      ChildId::DISABLE_CERT_VERIFICATION_CHECKBOX, disableCertVerification);
+  disable_cert_verification_check_box = CreateCheckBox(
+      right_check_pos_x, row_pos - 2, 20, 2 * ROW_HEIGHT, "",
+      ChildId::DISABLE_CERT_VERIFICATION_CHECKBOX, disable_cert_verification);
 
-  rowPos += INTERVAL + static_cast<int>(1.5 * static_cast<int>(ROW_HEIGHT));
+  row_pos += INTERVAL + static_cast<int>(1.5 * static_cast<int>(ROW_HEIGHT));
 
-  encryptionSettingsGroupBox =
-      CreateGroupBox(posX, posY, sizeX, rowPos - posY, "Encryption settings",
+  encryption_settings_group_box =
+      CreateGroupBox(pos_x, pos_y, size_x, row_pos - pos_y, "Encryption settings",
                      ChildId::AUTH_SETTINGS_GROUP_BOX);
 
-  return rowPos - posY;
+  return row_pos - pos_y;
 }
 
-int DsnConfigurationWindow::CreatePropertiesGroup(int posX, int posY, int sizeX) {
+int DsnConfigurationWindow::CreatePropertiesGroup(int pos_x, int pos_y, int size_x) {
   enum { LABEL_WIDTH = 120 };
 
-  const int labelPosX = posX + INTERVAL;
-  const int listSize = sizeX - 2 * INTERVAL;
-  const int columnSize = listSize / 2;
+  const int label_pos_x = pos_x + INTERVAL;
+  const int list_size = size_x - 2 * INTERVAL;
+  const int column_size = list_size / 2;
 
-  int rowPos = posY + 2 * INTERVAL;
-  const int listHeight = 5 * ROW_HEIGHT;
+  int row_pos = pos_y + 2 * INTERVAL;
+  const int list_height = 5 * ROW_HEIGHT;
 
-  propertyList =
-      CreateList(labelPosX, rowPos, listSize, listHeight, ChildId::PROPERTY_LIST);
-  propertyList->ListAddColumn("Key", 0, columnSize);
-  propertyList->ListAddColumn("Value", 1, columnSize);
+  property_list =
+      CreateList(label_pos_x, row_pos, list_size, list_height, ChildId::PROPERTY_LIST);
+  property_list->ListAddColumn("Key", 0, column_size);
+  property_list->ListAddColumn("Value", 1, column_size);
 
   const auto keys = config.GetCustomKeys();
   for (const auto& key : keys) {
-    propertyList->ListAddItem({std::string(key), config.Get(key)});
+    property_list->ListAddItem({std::string(key), config.Get(key)});
   }
 
-  SendMessage(propertyList->GetHandle(), LVM_SETEXTENDEDLISTVIEWSTYLE,
+  SendMessage(property_list->GetHandle(), LVM_SETEXTENDEDLISTVIEWSTYLE,
               LVS_EX_FULLROWSELECT, LVS_EX_FULLROWSELECT);
 
-  rowPos += INTERVAL + listHeight;
+  row_pos += INTERVAL + list_height;
 
-  int deletePosX = width - INTERVAL - MARGIN - BUTTON_WIDTH;
-  int addPosX = deletePosX - INTERVAL - BUTTON_WIDTH;
-  addButton = CreateButton(addPosX, rowPos, BUTTON_WIDTH, BUTTON_HEIGHT, "Add",
-                           ChildId::ADD_BUTTON);
-  deleteButton = CreateButton(deletePosX, rowPos, BUTTON_WIDTH, BUTTON_HEIGHT, "Delete",
-                              ChildId::DELETE_BUTTON);
+  int delete_pos_x = width - INTERVAL - MARGIN - BUTTON_WIDTH;
+  int add_pos_x = delete_pos_x - INTERVAL - BUTTON_WIDTH;
+  add_button = CreateButton(add_pos_x, row_pos, BUTTON_WIDTH, BUTTON_HEIGHT, "Add",
+                            ChildId::ADD_BUTTON);
+  delete_button = CreateButton(delete_pos_x, row_pos, BUTTON_WIDTH, BUTTON_HEIGHT,
+                               "Delete", ChildId::DELETE_BUTTON);
 
-  rowPos += INTERVAL + BUTTON_HEIGHT;
+  row_pos += INTERVAL + BUTTON_HEIGHT;
 
-  propertyGroupBox = CreateGroupBox(posX, posY, sizeX, rowPos - posY,
-                                    "Advanced properties", ChildId::PROPERTY_GROUP_BOX);
+  property_group_box = CreateGroupBox(pos_x, pos_y, size_x, row_pos - pos_y,
+                                      "Advanced properties", ChildId::PROPERTY_GROUP_BOX);
 
-  return rowPos - posY;
+  return row_pos - pos_y;
 }
 
-void DsnConfigurationWindow::SelectTab(int tabIndex) {
-  if (!isInitialized) {
+void DsnConfigurationWindow::SelectTab(int tab_index) {
+  if (!is_initialized) {
     return;
   }
 
-  connectionSettingsGroupBox->SetVisible(COMMON_TAB == tabIndex);
-  authSettingsGroupBox->SetVisible(COMMON_TAB == tabIndex);
-  nameEdit->SetVisible(COMMON_TAB == tabIndex);
-  serverEdit->SetVisible(COMMON_TAB == tabIndex);
-  portEdit->SetVisible(COMMON_TAB == tabIndex);
-  authTypeComboBox->SetVisible(COMMON_TAB == tabIndex);
-  userEdit->SetVisible(COMMON_TAB == tabIndex);
-  passwordEdit->SetVisible(COMMON_TAB == tabIndex);
-  authTokenEdit->SetVisible(COMMON_TAB == tabIndex);
+  connection_settings_group_box->SetVisible(COMMON_TAB == tab_index);
+  auth_settings_group_box->SetVisible(COMMON_TAB == tab_index);
+  name_edit->SetVisible(COMMON_TAB == tab_index);
+  server_edit->SetVisible(COMMON_TAB == tab_index);
+  port_edit->SetVisible(COMMON_TAB == tab_index);
+  auth_type_combo_box->SetVisible(COMMON_TAB == tab_index);
+  user_edit->SetVisible(COMMON_TAB == tab_index);
+  password_edit->SetVisible(COMMON_TAB == tab_index);
+  auth_token_edit->SetVisible(COMMON_TAB == tab_index);
   for (size_t i = 0; i < 7; ++i) {
-    labels[i]->SetVisible(COMMON_TAB == tabIndex);
+    labels[i]->SetVisible(COMMON_TAB == tab_index);
   }
 
-  encryptionSettingsGroupBox->SetVisible(ADVANCED_TAB == tabIndex);
-  enableEncryptionCheckBox->SetVisible(ADVANCED_TAB == tabIndex);
-  certificateEdit->SetVisible(ADVANCED_TAB == tabIndex);
-  certificateBrowseButton->SetVisible(ADVANCED_TAB == tabIndex);
-  useSystemCertStoreCheckBox->SetVisible(ADVANCED_TAB == tabIndex);
-  disableCertVerificationCheckBox->SetVisible(ADVANCED_TAB == tabIndex);
-  propertyGroupBox->SetVisible(ADVANCED_TAB == tabIndex);
-  propertyList->SetVisible(ADVANCED_TAB == tabIndex);
-  addButton->SetVisible(ADVANCED_TAB == tabIndex);
-  deleteButton->SetVisible(ADVANCED_TAB == tabIndex);
+  encryption_settings_group_box->SetVisible(ADVANCED_TAB == tab_index);
+  enable_encryption_check_box->SetVisible(ADVANCED_TAB == tab_index);
+  certificate_edit->SetVisible(ADVANCED_TAB == tab_index);
+  certificate_browse_button->SetVisible(ADVANCED_TAB == tab_index);
+  use_system_cert_store_check_box->SetVisible(ADVANCED_TAB == tab_index);
+  disable_cert_verification_check_box->SetVisible(ADVANCED_TAB == tab_index);
+  property_group_box->SetVisible(ADVANCED_TAB == tab_index);
+  property_list->SetVisible(ADVANCED_TAB == tab_index);
+  add_button->SetVisible(ADVANCED_TAB == tab_index);
+  delete_button->SetVisible(ADVANCED_TAB == tab_index);
   for (size_t i = 7; i < labels.size(); ++i) {
-    labels[i]->SetVisible(ADVANCED_TAB == tabIndex);
+    labels[i]->SetVisible(ADVANCED_TAB == tab_index);
   }
 }
 
 void DsnConfigurationWindow::CheckEnableOk() {
-  if (!isInitialized) {
+  if (!is_initialized) {
     return;
   }
 
-  bool enableOk = !nameEdit->IsTextEmpty();
-  enableOk = enableOk && !serverEdit->IsTextEmpty();
-  enableOk = enableOk && !portEdit->IsTextEmpty();
-  if (authTokenEdit->IsEnabled()) {
-    enableOk = enableOk && !authTokenEdit->IsTextEmpty();
+  bool enable_ok = !name_edit->IsTextEmpty();
+  enable_ok = enable_ok && !server_edit->IsTextEmpty();
+  enable_ok = enable_ok && !port_edit->IsTextEmpty();
+  if (auth_token_edit->IsEnabled()) {
+    enable_ok = enable_ok && !auth_token_edit->IsTextEmpty();
   } else {
-    enableOk = enableOk && !userEdit->IsTextEmpty();
-    enableOk = enableOk && !passwordEdit->IsTextEmpty();
+    enable_ok = enable_ok && !user_edit->IsTextEmpty();
+    enable_ok = enable_ok && !password_edit->IsTextEmpty();
   }
 
-  testButton->SetEnabled(enableOk);
-  okButton->SetEnabled(enableOk);
+  test_button->SetEnabled(enable_ok);
+  ok_button->SetEnabled(enable_ok);
 }
 
-void DsnConfigurationWindow::SaveParameters(Configuration& targetConfig) {
-  targetConfig.Clear();
+void DsnConfigurationWindow::SaveParameters(Configuration& target_config) {
+  target_config.Clear();
 
   std::string text;
-  nameEdit->GetText(text);
-  targetConfig.Set(FlightSqlConnection::DSN, text);
-  serverEdit->GetText(text);
-  targetConfig.Set(FlightSqlConnection::HOST, text);
-  portEdit->GetText(text);
+  name_edit->GetText(text);
+  target_config.Set(FlightSqlConnection::DSN, text);
+  server_edit->GetText(text);
+  target_config.Set(FlightSqlConnection::HOST, text);
+  port_edit->GetText(text);
   try {
-    const int portInt = std::stoi(text);
-    if (0 > portInt || USHRT_MAX < portInt) {
+    const int port_int = std::stoi(text);
+    if (0 > port_int || USHRT_MAX < port_int) {
       throw odbcabstraction::DriverException("Invalid port value.");
     }
-    targetConfig.Set(FlightSqlConnection::PORT, text);
+    target_config.Set(FlightSqlConnection::PORT, text);
   } catch (odbcabstraction::DriverException&) {
     throw;
   } catch (std::exception&) {
     throw odbcabstraction::DriverException("Invalid port value.");
   }
 
-  if (0 == authTypeComboBox->GetSelection()) {
-    userEdit->GetText(text);
-    targetConfig.Set(FlightSqlConnection::UID, text);
-    passwordEdit->GetText(text);
-    targetConfig.Set(FlightSqlConnection::PWD, text);
+  if (0 == auth_type_combo_box->GetSelection()) {
+    user_edit->GetText(text);
+    target_config.Set(FlightSqlConnection::UID, text);
+    password_edit->GetText(text);
+    target_config.Set(FlightSqlConnection::PWD, text);
   } else {
-    authTokenEdit->GetText(text);
-    targetConfig.Set(FlightSqlConnection::TOKEN, text);
+    auth_token_edit->GetText(text);
+    target_config.Set(FlightSqlConnection::TOKEN, text);
   }
 
-  if (enableEncryptionCheckBox->IsChecked()) {
-    targetConfig.Set(FlightSqlConnection::USE_ENCRYPTION, TRUE_STR);
-    certificateEdit->GetText(text);
-    targetConfig.Set(FlightSqlConnection::TRUSTED_CERTS, text);
-    targetConfig.Set(FlightSqlConnection::USE_SYSTEM_TRUST_STORE,
-                     useSystemCertStoreCheckBox->IsChecked() ? TRUE_STR : FALSE_STR);
-    targetConfig.Set(FlightSqlConnection::DISABLE_CERTIFICATE_VERIFICATION,
-                     disableCertVerificationCheckBox->IsChecked() ? TRUE_STR : FALSE_STR);
+  if (enable_encryption_check_box->IsChecked()) {
+    target_config.Set(FlightSqlConnection::USE_ENCRYPTION, TRUE_STR);
+    certificate_edit->GetText(text);
+    target_config.Set(FlightSqlConnection::TRUSTED_CERTS, text);
+    target_config.Set(
+        FlightSqlConnection::USE_SYSTEM_TRUST_STORE,
+        use_system_cert_store_check_box->IsChecked() ? TRUE_STR : FALSE_STR);
+    target_config.Set(
+        FlightSqlConnection::DISABLE_CERTIFICATE_VERIFICATION,
+        disable_cert_verification_check_box->IsChecked() ? TRUE_STR : FALSE_STR);
   } else {
-    targetConfig.Set(FlightSqlConnection::USE_ENCRYPTION, FALSE_STR);
+    target_config.Set(FlightSqlConnection::USE_ENCRYPTION, FALSE_STR);
   }
 
   // Get all the list properties.
-  const auto properties = propertyList->ListGetAll();
+  const auto properties = property_list->ListGetAll();
   for (const auto& property : properties) {
-    targetConfig.Set(property[0], property[1]);
+    target_config.Set(property[0], property[1]);
   }
 }
 
 void DsnConfigurationWindow::CheckAuthType() {
-  const bool isBasic = COMMON_TAB == authTypeComboBox->GetSelection();
-  userEdit->SetEnabled(isBasic);
-  passwordEdit->SetEnabled(isBasic);
-  authTokenEdit->SetEnabled(!isBasic);
+  const bool is_basic = COMMON_TAB == auth_type_combo_box->GetSelection();
+  user_edit->SetEnabled(is_basic);
+  password_edit->SetEnabled(is_basic);
+  auth_token_edit->SetEnabled(!is_basic);
 }
 
-bool DsnConfigurationWindow::OnMessage(UINT msg, WPARAM wParam, LPARAM lParam) {
+bool DsnConfigurationWindow::OnMessage(UINT msg, WPARAM wparam, LPARAM lparam) {
   switch (msg) {
     case WM_NOTIFY: {
-      switch (((LPNMHDR)lParam)->code) {
+      switch (((LPNMHDR)lparam)->code) {
         case TCN_SELCHANGING: {
           // Return FALSE to allow the selection to change.
           return FALSE;
         }
 
         case TCN_SELCHANGE: {
-          SelectTab(TabCtrl_GetCurSel(tabControl->GetHandle()));
+          SelectTab(TabCtrl_GetCurSel(tab_control->GetHandle()));
           break;
         }
       }
@@ -456,14 +463,14 @@ bool DsnConfigurationWindow::OnMessage(UINT msg, WPARAM wParam, LPARAM lParam) {
     }
 
     case WM_COMMAND: {
-      switch (LOWORD(wParam)) {
+      switch (LOWORD(wparam)) {
         case ChildId::TEST_CONNECTION_BUTTON: {
           try {
-            Configuration testConfig;
-            SaveParameters(testConfig);
-            std::string testMessage = TestConnection(testConfig);
+            Configuration test_config;
+            SaveParameters(test_config);
+            std::string test_message = TestConnection(test_config);
 
-            MessageBox(NULL, testMessage.c_str(), "Test Connection Success", MB_OK);
+            MessageBox(NULL, test_message.c_str(), "Test Connection Success", MB_OK);
           } catch (odbcabstraction::DriverException& err) {
             MessageBox(NULL, err.GetMessageText().c_str(), "Error!",
                        MB_ICONEXCLAMATION | MB_OK);
@@ -496,7 +503,7 @@ bool DsnConfigurationWindow::OnMessage(UINT msg, WPARAM wParam, LPARAM lParam) {
         case ChildId::PORT_EDIT:
         case ChildId::SERVER_EDIT:
         case ChildId::USER_EDIT: {
-          if (HIWORD(wParam) == EN_CHANGE) {
+          if (HIWORD(wparam) == EN_CHANGE) {
             CheckEnableOk();
           }
           break;
@@ -509,67 +516,67 @@ bool DsnConfigurationWindow::OnMessage(UINT msg, WPARAM wParam, LPARAM lParam) {
         }
 
         case ChildId::ENABLE_ENCRYPTION_CHECKBOX: {
-          const bool toggle = !enableEncryptionCheckBox->IsChecked();
-          enableEncryptionCheckBox->SetChecked(toggle);
-          certificateEdit->SetEnabled(toggle);
-          certificateBrowseButton->SetEnabled(toggle);
-          useSystemCertStoreCheckBox->SetEnabled(toggle);
-          disableCertVerificationCheckBox->SetEnabled(toggle);
+          const bool toggle = !enable_encryption_check_box->IsChecked();
+          enable_encryption_check_box->SetChecked(toggle);
+          certificate_edit->SetEnabled(toggle);
+          certificate_browse_button->SetEnabled(toggle);
+          use_system_cert_store_check_box->SetEnabled(toggle);
+          disable_cert_verification_check_box->SetEnabled(toggle);
           break;
         }
 
         case ChildId::CERTIFICATE_BROWSE_BUTTON: {
-          OPENFILENAME openFileName;
-          char fileName[FILENAME_MAX];
+          OPENFILENAME open_file_name;
+          char file_name[FILENAME_MAX];
 
-          ZeroMemory(&openFileName, sizeof(openFileName));
-          openFileName.lStructSize = sizeof(openFileName);
-          openFileName.hwndOwner = NULL;
-          openFileName.lpstrFile = fileName;
-          openFileName.lpstrFile[0] = '\0';
-          openFileName.nMaxFile = FILENAME_MAX;
+          ZeroMemory(&open_file_name, sizeof(open_file_name));
+          open_file_name.lStructSize = sizeof(open_file_name);
+          open_file_name.hwndOwner = NULL;
+          open_file_name.lpstrFile = file_name;
+          open_file_name.lpstrFile[0] = '\0';
+          open_file_name.nMaxFile = FILENAME_MAX;
           // TODO: What type should this be?
-          openFileName.lpstrFilter = "All\0*.*";
-          openFileName.nFilterIndex = 1;
-          openFileName.lpstrFileTitle = NULL;
-          openFileName.nMaxFileTitle = 0;
-          openFileName.lpstrInitialDir = NULL;
-          openFileName.Flags = OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST;
+          open_file_name.lpstrFilter = "All\0*.*";
+          open_file_name.nFilterIndex = 1;
+          open_file_name.lpstrFileTitle = NULL;
+          open_file_name.nMaxFileTitle = 0;
+          open_file_name.lpstrInitialDir = NULL;
+          open_file_name.Flags = OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST;
 
-          if (GetOpenFileName(&openFileName)) {
-            certificateEdit->SetText(fileName);
+          if (GetOpenFileName(&open_file_name)) {
+            certificate_edit->SetText(file_name);
           }
           break;
         }
 
         case ChildId::USE_SYSTEM_CERT_STORE_CHECKBOX: {
-          useSystemCertStoreCheckBox->SetChecked(
-              !useSystemCertStoreCheckBox->IsChecked());
+          use_system_cert_store_check_box->SetChecked(
+              !use_system_cert_store_check_box->IsChecked());
           break;
         }
 
         case ChildId::DISABLE_CERT_VERIFICATION_CHECKBOX: {
-          disableCertVerificationCheckBox->SetChecked(
-              !disableCertVerificationCheckBox->IsChecked());
+          disable_cert_verification_check_box->SetChecked(
+              !disable_cert_verification_check_box->IsChecked());
           break;
         }
 
         case ChildId::DELETE_BUTTON: {
-          propertyList->ListDeleteSelectedItem();
+          property_list->ListDeleteSelectedItem();
           break;
         }
 
         case ChildId::ADD_BUTTON: {
-          AddPropertyWindow addWindow(this);
-          addWindow.Create();
-          addWindow.Show();
-          addWindow.Update();
+          AddPropertyWindow add_window(this);
+          add_window.Create();
+          add_window.Show();
+          add_window.Update();
 
-          if (ProcessMessages(addWindow) == Result::OK) {
+          if (ProcessMessages(add_window) == Result::OK) {
             std::string key;
             std::string value;
-            addWindow.GetProperty(key, value);
-            propertyList->ListAddItem({key, value});
+            add_window.GetProperty(key, value);
+            property_list->ListAddItem({key, value});
           }
           break;
         }

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/ui/dsn_configuration_window.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/ui/dsn_configuration_window.cc
@@ -56,11 +56,11 @@ namespace config {
 DsnConfigurationWindow::DsnConfigurationWindow(Window* parent,
                                                config::Configuration& config)
     : CustomWindow(parent, "FlightConfigureDSN", "Configure Apache Arrow Flight SQL"),
-      width(480),
-      height(375),
-      config(config),
-      accepted(false),
-      is_initialized(false) {
+      width_(480),
+      height_(375),
+      config_(config),
+      accepted_(false),
+      is_initialized_(false) {
   // No-op.
 }
 
@@ -71,13 +71,15 @@ DsnConfigurationWindow::~DsnConfigurationWindow() {
 void DsnConfigurationWindow::Create() {
   // Finding out parent position.
   RECT parent_rect;
-  GetWindowRect(parent->GetHandle(), &parent_rect);
+  GetWindowRect(parent_->GetHandle(), &parent_rect);
 
   // Positioning window to the center of parent window.
-  const int pos_x = parent_rect.left + (parent_rect.right - parent_rect.left - width) / 2;
-  const int pos_y = parent_rect.top + (parent_rect.bottom - parent_rect.top - height) / 2;
+  const int pos_x =
+      parent_rect.left + (parent_rect.right - parent_rect.left - width_) / 2;
+  const int pos_y =
+      parent_rect.top + (parent_rect.bottom - parent_rect.top - height_) / 2;
 
-  RECT desired_rect = {pos_x, pos_y, pos_x + width, pos_y + height};
+  RECT desired_rect = {pos_x, pos_y, pos_x + width_, pos_y + height_};
   AdjustWindowRect(&desired_rect, WS_BORDER | WS_CAPTION | WS_SYSMENU | WS_THICKFRAME,
                    FALSE);
 
@@ -85,7 +87,7 @@ void DsnConfigurationWindow::Create() {
                  desired_rect.right - desired_rect.left,
                  desired_rect.bottom - desired_rect.top, 0);
 
-  if (!handle) {
+  if (!handle_) {
     std::stringstream buf;
     buf << "Can not create window, error code: " << GetLastError();
     throw odbcabstraction::DriverException(buf.str());
@@ -93,12 +95,12 @@ void DsnConfigurationWindow::Create() {
 }
 
 void DsnConfigurationWindow::OnCreate() {
-  tab_control = CreateTabControl(ChildId::TAB_CONTROL);
-  tab_control->AddTab("Common", COMMON_TAB);
-  tab_control->AddTab("Advanced", ADVANCED_TAB);
+  tab_control_ = CreateTabControl(ChildId::TAB_CONTROL);
+  tab_control_->AddTab("Common", COMMON_TAB);
+  tab_control_->AddTab("Advanced", ADVANCED_TAB);
 
   int group_pos_y = 3 * MARGIN;
-  int group_size_y = width - 2 * MARGIN;
+  int group_size_y = width_ - 2 * MARGIN;
 
   int common_group_pos_y = group_pos_y;
   common_group_pos_y +=
@@ -113,17 +115,17 @@ void DsnConfigurationWindow::OnCreate() {
       INTERVAL + CreatePropertiesGroup(MARGIN, advanced_group_pos_y, group_size_y);
 
   int test_pos_x = MARGIN;
-  int cancel_pos_x = width - MARGIN - BUTTON_WIDTH;
+  int cancel_pos_x = width_ - MARGIN - BUTTON_WIDTH;
   int ok_pos_x = cancel_pos_x - INTERVAL - BUTTON_WIDTH;
 
   int button_pos_y = std::max(common_group_pos_y, advanced_group_pos_y);
-  test_button = CreateButton(test_pos_x, button_pos_y, BUTTON_WIDTH + 20, BUTTON_HEIGHT,
-                             "Test Connection", ChildId::TEST_CONNECTION_BUTTON);
-  ok_button = CreateButton(ok_pos_x, button_pos_y, BUTTON_WIDTH, BUTTON_HEIGHT, "Ok",
-                           ChildId::OK_BUTTON);
-  cancel_button = CreateButton(cancel_pos_x, button_pos_y, BUTTON_WIDTH, BUTTON_HEIGHT,
-                               "Cancel", ChildId::CANCEL_BUTTON);
-  is_initialized = true;
+  test_button_ = CreateButton(test_pos_x, button_pos_y, BUTTON_WIDTH + 20, BUTTON_HEIGHT,
+                              "Test Connection", ChildId::TEST_CONNECTION_BUTTON);
+  ok_button_ = CreateButton(ok_pos_x, button_pos_y, BUTTON_WIDTH, BUTTON_HEIGHT, "Ok",
+                            ChildId::OK_BUTTON);
+  cancel_button_ = CreateButton(cancel_pos_x, button_pos_y, BUTTON_WIDTH, BUTTON_HEIGHT,
+                                "Cancel", ChildId::CANCEL_BUTTON);
+  is_initialized_ = true;
   CheckEnableOk();
   SelectTab(COMMON_TAB);
 }
@@ -139,31 +141,31 @@ int DsnConfigurationWindow::CreateConnectionSettingsGroup(int pos_x, int pos_y,
 
   int row_pos = pos_y + 2 * INTERVAL;
 
-  const char* val = config.Get(FlightSqlConnection::DSN).c_str();
-  labels.push_back(CreateLabel(label_pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT,
-                               "Data Source Name:", ChildId::NAME_LABEL));
-  name_edit =
+  const char* val = config_.Get(FlightSqlConnection::DSN).c_str();
+  labels_.push_back(CreateLabel(label_pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT,
+                                "Data Source Name:", ChildId::NAME_LABEL));
+  name_edit_ =
       CreateEdit(edit_pos_x, row_pos, edit_size_x, ROW_HEIGHT, val, ChildId::NAME_EDIT);
 
   row_pos += INTERVAL + ROW_HEIGHT;
 
-  val = config.Get(FlightSqlConnection::HOST).c_str();
-  labels.push_back(CreateLabel(label_pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT,
-                               "Host Name:", ChildId::SERVER_LABEL));
-  server_edit =
+  val = config_.Get(FlightSqlConnection::HOST).c_str();
+  labels_.push_back(CreateLabel(label_pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT,
+                                "Host Name:", ChildId::SERVER_LABEL));
+  server_edit_ =
       CreateEdit(edit_pos_x, row_pos, edit_size_x, ROW_HEIGHT, val, ChildId::SERVER_EDIT);
 
   row_pos += INTERVAL + ROW_HEIGHT;
 
-  val = config.Get(FlightSqlConnection::PORT).c_str();
-  labels.push_back(CreateLabel(label_pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT,
-                               "Port:", ChildId::PORT_LABEL));
-  port_edit = CreateEdit(edit_pos_x, row_pos, edit_size_x, ROW_HEIGHT, val,
-                         ChildId::PORT_EDIT, ES_NUMBER);
+  val = config_.Get(FlightSqlConnection::PORT).c_str();
+  labels_.push_back(CreateLabel(label_pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT,
+                                "Port:", ChildId::PORT_LABEL));
+  port_edit_ = CreateEdit(edit_pos_x, row_pos, edit_size_x, ROW_HEIGHT, val,
+                          ChildId::PORT_EDIT, ES_NUMBER);
 
   row_pos += INTERVAL + ROW_HEIGHT;
 
-  connection_settings_group_box =
+  connection_settings_group_box_ =
       CreateGroupBox(pos_x, pos_y, size_x, row_pos - pos_y, "Connection settings",
                      ChildId::CONNECTION_SETTINGS_GROUP_BOX);
 
@@ -180,48 +182,48 @@ int DsnConfigurationWindow::CreateAuthSettingsGroup(int pos_x, int pos_y, int si
 
   int row_pos = pos_y + 2 * INTERVAL;
 
-  labels.push_back(CreateLabel(label_pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT,
-                               "Authentication Type:", ChildId::AUTH_TYPE_LABEL));
-  auth_type_combo_box =
+  labels_.push_back(CreateLabel(label_pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT,
+                                "Authentication Type:", ChildId::AUTH_TYPE_LABEL));
+  auth_type_combo_box_ =
       CreateComboBox(edit_pos_x, row_pos, edit_size_x, ROW_HEIGHT,
                      "Authentication Type:", ChildId::AUTH_TYPE_COMBOBOX);
-  auth_type_combo_box->AddString("Basic Authentication");
-  auth_type_combo_box->AddString("Token Authentication");
+  auth_type_combo_box_->AddString("Basic Authentication");
+  auth_type_combo_box_->AddString("Token Authentication");
 
   row_pos += INTERVAL + ROW_HEIGHT;
 
-  const char* val = config.Get(FlightSqlConnection::UID).c_str();
+  const char* val = config_.Get(FlightSqlConnection::UID).c_str();
 
-  labels.push_back(CreateLabel(label_pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT,
-                               "User:", ChildId::USER_LABEL));
-  user_edit =
+  labels_.push_back(CreateLabel(label_pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT,
+                                "User:", ChildId::USER_LABEL));
+  user_edit_ =
       CreateEdit(edit_pos_x, row_pos, edit_size_x, ROW_HEIGHT, val, ChildId::USER_EDIT);
 
   row_pos += INTERVAL + ROW_HEIGHT;
 
-  val = config.Get(FlightSqlConnection::PWD).c_str();
-  labels.push_back(CreateLabel(label_pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT,
-                               "Password:", ChildId::PASSWORD_LABEL));
-  password_edit = CreateEdit(edit_pos_x, row_pos, edit_size_x, ROW_HEIGHT, val,
-                             ChildId::USER_EDIT, ES_PASSWORD);
+  val = config_.Get(FlightSqlConnection::PWD).c_str();
+  labels_.push_back(CreateLabel(label_pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT,
+                                "Password:", ChildId::PASSWORD_LABEL));
+  password_edit_ = CreateEdit(edit_pos_x, row_pos, edit_size_x, ROW_HEIGHT, val,
+                              ChildId::USER_EDIT, ES_PASSWORD);
 
   row_pos += INTERVAL + ROW_HEIGHT;
 
-  const auto& token = config.Get(FlightSqlConnection::TOKEN);
+  const auto& token = config_.Get(FlightSqlConnection::TOKEN);
   val = token.c_str();
-  labels.push_back(CreateLabel(label_pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT,
-                               "Authentication Token:", ChildId::AUTH_TOKEN_LABEL));
-  auth_token_edit = CreateEdit(edit_pos_x, row_pos, edit_size_x, ROW_HEIGHT, val,
-                               ChildId::AUTH_TOKEN_EDIT);
-  auth_token_edit->SetEnabled(false);
+  labels_.push_back(CreateLabel(label_pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT,
+                                "Authentication Token:", ChildId::AUTH_TOKEN_LABEL));
+  auth_token_edit_ = CreateEdit(edit_pos_x, row_pos, edit_size_x, ROW_HEIGHT, val,
+                                ChildId::AUTH_TOKEN_EDIT);
+  auth_token_edit_->SetEnabled(false);
 
   // Ensure the right elements are selected.
-  auth_type_combo_box->SetSelection(token.empty() ? 0 : 1);
+  auth_type_combo_box_->SetSelection(token.empty() ? 0 : 1);
   CheckAuthType();
 
   row_pos += INTERVAL + ROW_HEIGHT;
 
-  auth_settings_group_box =
+  auth_settings_group_box_ =
       CreateGroupBox(pos_x, pos_y, size_x, row_pos - pos_y, "Authentication settings",
                      ChildId::AUTH_SETTINGS_GROUP_BOX);
 
@@ -239,55 +241,55 @@ int DsnConfigurationWindow::CreateEncryptionSettingsGroup(int pos_x, int pos_y,
 
   int row_pos = pos_y + 2 * INTERVAL;
 
-  const char* val = config.Get(FlightSqlConnection::USE_ENCRYPTION).c_str();
+  const char* val = config_.Get(FlightSqlConnection::USE_ENCRYPTION).c_str();
 
   const bool enable_encryption = driver::odbcabstraction::AsBool(val).value_or(true);
-  labels.push_back(CreateLabel(label_pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT,
-                               "Use Encryption:", ChildId::ENABLE_ENCRYPTION_LABEL));
-  enable_encryption_check_box =
+  labels_.push_back(CreateLabel(label_pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT,
+                                "Use Encryption:", ChildId::ENABLE_ENCRYPTION_LABEL));
+  enable_encryption_check_box_ =
       CreateCheckBox(edit_pos_x, row_pos - 2, edit_size_x, ROW_HEIGHT, "",
                      ChildId::ENABLE_ENCRYPTION_CHECKBOX, enable_encryption);
 
   row_pos += INTERVAL + ROW_HEIGHT;
 
-  val = config.Get(FlightSqlConnection::TRUSTED_CERTS).c_str();
+  val = config_.Get(FlightSqlConnection::TRUSTED_CERTS).c_str();
 
-  labels.push_back(CreateLabel(label_pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT,
-                               "Certificate:", ChildId::CERTIFICATE_LABEL));
-  certificate_edit = CreateEdit(edit_pos_x, row_pos, edit_size_x - MARGIN - BUTTON_WIDTH,
-                                ROW_HEIGHT, val, ChildId::CERTIFICATE_EDIT);
-  certificate_browse_button =
+  labels_.push_back(CreateLabel(label_pos_x, row_pos, LABEL_WIDTH, ROW_HEIGHT,
+                                "Certificate:", ChildId::CERTIFICATE_LABEL));
+  certificate_edit_ = CreateEdit(edit_pos_x, row_pos, edit_size_x - MARGIN - BUTTON_WIDTH,
+                                 ROW_HEIGHT, val, ChildId::CERTIFICATE_EDIT);
+  certificate_browse_button_ =
       CreateButton(edit_pos_x + edit_size_x - BUTTON_WIDTH, row_pos - 2, BUTTON_WIDTH,
                    BUTTON_HEIGHT, "Browse", ChildId::CERTIFICATE_BROWSE_BUTTON);
 
   row_pos += INTERVAL + ROW_HEIGHT;
 
-  val = config.Get(FlightSqlConnection::USE_SYSTEM_TRUST_STORE).c_str();
+  val = config_.Get(FlightSqlConnection::USE_SYSTEM_TRUST_STORE).c_str();
 
   const bool use_system_cert_store = driver::odbcabstraction::AsBool(val).value_or(true);
-  labels.push_back(
+  labels_.push_back(
       CreateLabel(label_pos_x, row_pos, LABEL_WIDTH, 2 * ROW_HEIGHT,
                   "Use System Certificate Store:", ChildId::USE_SYSTEM_CERT_STORE_LABEL));
-  use_system_cert_store_check_box =
+  use_system_cert_store_check_box_ =
       CreateCheckBox(edit_pos_x, row_pos - 2, 20, 2 * ROW_HEIGHT, "",
                      ChildId::USE_SYSTEM_CERT_STORE_CHECKBOX, use_system_cert_store);
 
-  val = config.Get(FlightSqlConnection::DISABLE_CERTIFICATE_VERIFICATION).c_str();
+  val = config_.Get(FlightSqlConnection::DISABLE_CERTIFICATE_VERIFICATION).c_str();
 
   const int right_pos_x = label_pos_x + (size_x - (2 * INTERVAL)) / 2;
   const int right_check_pos_x = right_pos_x + (edit_pos_x - label_pos_x);
   const bool disable_cert_verification =
       driver::odbcabstraction::AsBool(val).value_or(false);
-  labels.push_back(CreateLabel(
+  labels_.push_back(CreateLabel(
       right_pos_x, row_pos, LABEL_WIDTH, 2 * ROW_HEIGHT,
       "Disable Certificate Verification:", ChildId::DISABLE_CERT_VERIFICATION_LABEL));
-  disable_cert_verification_check_box = CreateCheckBox(
+  disable_cert_verification_check_box_ = CreateCheckBox(
       right_check_pos_x, row_pos - 2, 20, 2 * ROW_HEIGHT, "",
       ChildId::DISABLE_CERT_VERIFICATION_CHECKBOX, disable_cert_verification);
 
   row_pos += INTERVAL + static_cast<int>(1.5 * static_cast<int>(ROW_HEIGHT));
 
-  encryption_settings_group_box =
+  encryption_settings_group_box_ =
       CreateGroupBox(pos_x, pos_y, size_x, row_pos - pos_y, "Encryption settings",
                      ChildId::AUTH_SETTINGS_GROUP_BOX);
 
@@ -304,97 +306,98 @@ int DsnConfigurationWindow::CreatePropertiesGroup(int pos_x, int pos_y, int size
   int row_pos = pos_y + 2 * INTERVAL;
   const int list_height = 5 * ROW_HEIGHT;
 
-  property_list =
+  property_list_ =
       CreateList(label_pos_x, row_pos, list_size, list_height, ChildId::PROPERTY_LIST);
-  property_list->ListAddColumn("Key", 0, column_size);
-  property_list->ListAddColumn("Value", 1, column_size);
+  property_list_->ListAddColumn("Key", 0, column_size);
+  property_list_->ListAddColumn("Value", 1, column_size);
 
-  const auto keys = config.GetCustomKeys();
+  const auto keys = config_.GetCustomKeys();
   for (const auto& key : keys) {
-    property_list->ListAddItem({std::string(key), config.Get(key)});
+    property_list_->ListAddItem({std::string(key), config.Get(key)});
   }
 
-  SendMessage(property_list->GetHandle(), LVM_SETEXTENDEDLISTVIEWSTYLE,
+  SendMessage(property_list_->GetHandle(), LVM_SETEXTENDEDLISTVIEWSTYLE,
               LVS_EX_FULLROWSELECT, LVS_EX_FULLROWSELECT);
 
   row_pos += INTERVAL + list_height;
 
-  int delete_pos_x = width - INTERVAL - MARGIN - BUTTON_WIDTH;
+  int delete_pos_x = width_ - INTERVAL - MARGIN - BUTTON_WIDTH;
   int add_pos_x = delete_pos_x - INTERVAL - BUTTON_WIDTH;
-  add_button = CreateButton(add_pos_x, row_pos, BUTTON_WIDTH, BUTTON_HEIGHT, "Add",
-                            ChildId::ADD_BUTTON);
-  delete_button = CreateButton(delete_pos_x, row_pos, BUTTON_WIDTH, BUTTON_HEIGHT,
-                               "Delete", ChildId::DELETE_BUTTON);
+  add_button_ = CreateButton(add_pos_x, row_pos, BUTTON_WIDTH, BUTTON_HEIGHT, "Add",
+                             ChildId::ADD_BUTTON);
+  delete_button_ = CreateButton(delete_pos_x, row_pos, BUTTON_WIDTH, BUTTON_HEIGHT,
+                                "Delete", ChildId::DELETE_BUTTON);
 
   row_pos += INTERVAL + BUTTON_HEIGHT;
 
-  property_group_box = CreateGroupBox(pos_x, pos_y, size_x, row_pos - pos_y,
-                                      "Advanced properties", ChildId::PROPERTY_GROUP_BOX);
+  property_group_box_ =
+      CreateGroupBox(pos_x, pos_y, size_x, row_pos - pos_y, "Advanced properties",
+                     ChildId::PROPERTY_GROUP_BOX);
 
   return row_pos - pos_y;
 }
 
 void DsnConfigurationWindow::SelectTab(int tab_index) {
-  if (!is_initialized) {
+  if (!is_initialized_) {
     return;
   }
 
-  connection_settings_group_box->SetVisible(COMMON_TAB == tab_index);
-  auth_settings_group_box->SetVisible(COMMON_TAB == tab_index);
-  name_edit->SetVisible(COMMON_TAB == tab_index);
-  server_edit->SetVisible(COMMON_TAB == tab_index);
-  port_edit->SetVisible(COMMON_TAB == tab_index);
-  auth_type_combo_box->SetVisible(COMMON_TAB == tab_index);
-  user_edit->SetVisible(COMMON_TAB == tab_index);
-  password_edit->SetVisible(COMMON_TAB == tab_index);
-  auth_token_edit->SetVisible(COMMON_TAB == tab_index);
+  connection_settings_group_box_->SetVisible(COMMON_TAB == tab_index);
+  auth_settings_group_box_->SetVisible(COMMON_TAB == tab_index);
+  name_edit_->SetVisible(COMMON_TAB == tab_index);
+  server_edit_->SetVisible(COMMON_TAB == tab_index);
+  port_edit_->SetVisible(COMMON_TAB == tab_index);
+  auth_type_combo_box_->SetVisible(COMMON_TAB == tab_index);
+  user_edit_->SetVisible(COMMON_TAB == tab_index);
+  password_edit_->SetVisible(COMMON_TAB == tab_index);
+  auth_token_edit_->SetVisible(COMMON_TAB == tab_index);
   for (size_t i = 0; i < 7; ++i) {
-    labels[i]->SetVisible(COMMON_TAB == tab_index);
+    labels_[i]->SetVisible(COMMON_TAB == tab_index);
   }
 
-  encryption_settings_group_box->SetVisible(ADVANCED_TAB == tab_index);
-  enable_encryption_check_box->SetVisible(ADVANCED_TAB == tab_index);
-  certificate_edit->SetVisible(ADVANCED_TAB == tab_index);
-  certificate_browse_button->SetVisible(ADVANCED_TAB == tab_index);
-  use_system_cert_store_check_box->SetVisible(ADVANCED_TAB == tab_index);
-  disable_cert_verification_check_box->SetVisible(ADVANCED_TAB == tab_index);
-  property_group_box->SetVisible(ADVANCED_TAB == tab_index);
-  property_list->SetVisible(ADVANCED_TAB == tab_index);
-  add_button->SetVisible(ADVANCED_TAB == tab_index);
-  delete_button->SetVisible(ADVANCED_TAB == tab_index);
-  for (size_t i = 7; i < labels.size(); ++i) {
-    labels[i]->SetVisible(ADVANCED_TAB == tab_index);
+  encryption_settings_group_box_->SetVisible(ADVANCED_TAB == tab_index);
+  enable_encryption_check_box_->SetVisible(ADVANCED_TAB == tab_index);
+  certificate_edit_->SetVisible(ADVANCED_TAB == tab_index);
+  certificate_browse_button_->SetVisible(ADVANCED_TAB == tab_index);
+  use_system_cert_store_check_box_->SetVisible(ADVANCED_TAB == tab_index);
+  disable_cert_verification_check_box_->SetVisible(ADVANCED_TAB == tab_index);
+  property_group_box_->SetVisible(ADVANCED_TAB == tab_index);
+  property_list_->SetVisible(ADVANCED_TAB == tab_index);
+  add_button_->SetVisible(ADVANCED_TAB == tab_index);
+  delete_button_->SetVisible(ADVANCED_TAB == tab_index);
+  for (size_t i = 7; i < labels_.size(); ++i) {
+    labels_[i]->SetVisible(ADVANCED_TAB == tab_index);
   }
 }
 
 void DsnConfigurationWindow::CheckEnableOk() {
-  if (!is_initialized) {
+  if (!is_initialized_) {
     return;
   }
 
-  bool enable_ok = !name_edit->IsTextEmpty();
-  enable_ok = enable_ok && !server_edit->IsTextEmpty();
-  enable_ok = enable_ok && !port_edit->IsTextEmpty();
-  if (auth_token_edit->IsEnabled()) {
-    enable_ok = enable_ok && !auth_token_edit->IsTextEmpty();
+  bool enable_ok = !name_edit_->IsTextEmpty();
+  enable_ok = enable_ok && !server_edit_->IsTextEmpty();
+  enable_ok = enable_ok && !port_edit_->IsTextEmpty();
+  if (auth_token_edit_->IsEnabled()) {
+    enable_ok = enable_ok && !auth_token_edit_->IsTextEmpty();
   } else {
-    enable_ok = enable_ok && !user_edit->IsTextEmpty();
-    enable_ok = enable_ok && !password_edit->IsTextEmpty();
+    enable_ok = enable_ok && !user_edit_->IsTextEmpty();
+    enable_ok = enable_ok && !password_edit_->IsTextEmpty();
   }
 
-  test_button->SetEnabled(enable_ok);
-  ok_button->SetEnabled(enable_ok);
+  test_button_->SetEnabled(enable_ok);
+  ok_button_->SetEnabled(enable_ok);
 }
 
 void DsnConfigurationWindow::SaveParameters(Configuration& target_config) {
   target_config.Clear();
 
   std::string text;
-  name_edit->GetText(text);
+  name_edit_->GetText(text);
   target_config.Set(FlightSqlConnection::DSN, text);
-  server_edit->GetText(text);
+  server_edit_->GetText(text);
   target_config.Set(FlightSqlConnection::HOST, text);
-  port_edit->GetText(text);
+  port_edit_->GetText(text);
   try {
     const int port_int = std::stoi(text);
     if (0 > port_int || USHRT_MAX < port_int) {
@@ -407,42 +410,42 @@ void DsnConfigurationWindow::SaveParameters(Configuration& target_config) {
     throw odbcabstraction::DriverException("Invalid port value.");
   }
 
-  if (0 == auth_type_combo_box->GetSelection()) {
-    user_edit->GetText(text);
+  if (0 == auth_type_combo_box_->GetSelection()) {
+    user_edit_->GetText(text);
     target_config.Set(FlightSqlConnection::UID, text);
-    password_edit->GetText(text);
+    password_edit_->GetText(text);
     target_config.Set(FlightSqlConnection::PWD, text);
   } else {
-    auth_token_edit->GetText(text);
+    auth_token_edit_->GetText(text);
     target_config.Set(FlightSqlConnection::TOKEN, text);
   }
 
-  if (enable_encryption_check_box->IsChecked()) {
+  if (enable_encryption_check_box_->IsChecked()) {
     target_config.Set(FlightSqlConnection::USE_ENCRYPTION, TRUE_STR);
-    certificate_edit->GetText(text);
+    certificate_edit_->GetText(text);
     target_config.Set(FlightSqlConnection::TRUSTED_CERTS, text);
     target_config.Set(
         FlightSqlConnection::USE_SYSTEM_TRUST_STORE,
-        use_system_cert_store_check_box->IsChecked() ? TRUE_STR : FALSE_STR);
+        use_system_cert_store_check_box_->IsChecked() ? TRUE_STR : FALSE_STR);
     target_config.Set(
         FlightSqlConnection::DISABLE_CERTIFICATE_VERIFICATION,
-        disable_cert_verification_check_box->IsChecked() ? TRUE_STR : FALSE_STR);
+        disable_cert_verification_check_box_->IsChecked() ? TRUE_STR : FALSE_STR);
   } else {
     target_config.Set(FlightSqlConnection::USE_ENCRYPTION, FALSE_STR);
   }
 
   // Get all the list properties.
-  const auto properties = property_list->ListGetAll();
+  const auto properties = property_list_->ListGetAll();
   for (const auto& property : properties) {
     target_config.Set(property[0], property[1]);
   }
 }
 
 void DsnConfigurationWindow::CheckAuthType() {
-  const bool is_basic = COMMON_TAB == auth_type_combo_box->GetSelection();
-  user_edit->SetEnabled(is_basic);
-  password_edit->SetEnabled(is_basic);
-  auth_token_edit->SetEnabled(!is_basic);
+  const bool is_basic = COMMON_TAB == auth_type_combo_box_->GetSelection();
+  user_edit_->SetEnabled(is_basic);
+  password_edit_->SetEnabled(is_basic);
+  auth_token_edit_->SetEnabled(!is_basic);
 }
 
 bool DsnConfigurationWindow::OnMessage(UINT msg, WPARAM wparam, LPARAM lparam) {
@@ -455,7 +458,7 @@ bool DsnConfigurationWindow::OnMessage(UINT msg, WPARAM wparam, LPARAM lparam) {
         }
 
         case TCN_SELCHANGE: {
-          SelectTab(TabCtrl_GetCurSel(tab_control->GetHandle()));
+          SelectTab(TabCtrl_GetCurSel(tab_control_->GetHandle()));
           break;
         }
       }
@@ -480,8 +483,8 @@ bool DsnConfigurationWindow::OnMessage(UINT msg, WPARAM wparam, LPARAM lparam) {
         }
         case ChildId::OK_BUTTON: {
           try {
-            SaveParameters(config);
-            accepted = true;
+            SaveParameters(config_);
+            accepted_ = true;
             PostMessage(GetHandle(), WM_CLOSE, 0, 0);
           } catch (odbcabstraction::DriverException& err) {
             MessageBox(NULL, err.GetMessageText().c_str(), "Error!",
@@ -516,12 +519,12 @@ bool DsnConfigurationWindow::OnMessage(UINT msg, WPARAM wparam, LPARAM lparam) {
         }
 
         case ChildId::ENABLE_ENCRYPTION_CHECKBOX: {
-          const bool toggle = !enable_encryption_check_box->IsChecked();
-          enable_encryption_check_box->SetChecked(toggle);
-          certificate_edit->SetEnabled(toggle);
-          certificate_browse_button->SetEnabled(toggle);
-          use_system_cert_store_check_box->SetEnabled(toggle);
-          disable_cert_verification_check_box->SetEnabled(toggle);
+          const bool toggle = !enable_encryption_check_box_->IsChecked();
+          enable_encryption_check_box_->SetChecked(toggle);
+          certificate_edit_->SetEnabled(toggle);
+          certificate_browse_button_->SetEnabled(toggle);
+          use_system_cert_store_check_box_->SetEnabled(toggle);
+          disable_cert_verification_check_box_->SetEnabled(toggle);
           break;
         }
 
@@ -544,25 +547,25 @@ bool DsnConfigurationWindow::OnMessage(UINT msg, WPARAM wparam, LPARAM lparam) {
           open_file_name.Flags = OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST;
 
           if (GetOpenFileName(&open_file_name)) {
-            certificate_edit->SetText(file_name);
+            certificate_edit_->SetText(file_name);
           }
           break;
         }
 
         case ChildId::USE_SYSTEM_CERT_STORE_CHECKBOX: {
-          use_system_cert_store_check_box->SetChecked(
-              !use_system_cert_store_check_box->IsChecked());
+          use_system_cert_store_check_box_->SetChecked(
+              !use_system_cert_store_check_box_->IsChecked());
           break;
         }
 
         case ChildId::DISABLE_CERT_VERIFICATION_CHECKBOX: {
-          disable_cert_verification_check_box->SetChecked(
-              !disable_cert_verification_check_box->IsChecked());
+          disable_cert_verification_check_box_->SetChecked(
+              !disable_cert_verification_check_box_->IsChecked());
           break;
         }
 
         case ChildId::DELETE_BUTTON: {
-          property_list->ListDeleteSelectedItem();
+          property_list_->ListDeleteSelectedItem();
           break;
         }
 
@@ -576,7 +579,7 @@ bool DsnConfigurationWindow::OnMessage(UINT msg, WPARAM wparam, LPARAM lparam) {
             std::string key;
             std::string value;
             add_window.GetProperty(key, value);
-            property_list->ListAddItem({key, value});
+            property_list_->ListAddItem({key, value});
           }
           break;
         }
@@ -589,7 +592,7 @@ bool DsnConfigurationWindow::OnMessage(UINT msg, WPARAM wparam, LPARAM lparam) {
     }
 
     case WM_DESTROY: {
-      PostQuitMessage(accepted ? Result::OK : Result::CANCEL);
+      PostQuitMessage(accepted_ ? Result::OK : Result::CANCEL);
 
       break;
     }

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/ui/window.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/ui/window.cc
@@ -34,28 +34,28 @@ namespace flight_sql {
 namespace config {
 
 HINSTANCE GetHInstance() {
-  TCHAR szFileName[MAX_PATH];
-  GetModuleFileName(NULL, szFileName, MAX_PATH);
+  TCHAR sz_file_name[MAX_PATH];
+  GetModuleFileName(NULL, sz_file_name, MAX_PATH);
 
   // TODO: This needs to be the module name.
-  HINSTANCE hInstance = GetModuleHandle(szFileName);
+  HINSTANCE h_instance = GetModuleHandle(sz_file_name);
 
-  if (hInstance == NULL) {
+  if (h_instance == NULL) {
     std::stringstream buf;
     buf << "Can not get hInstance for the module, error code: " << GetLastError();
     throw odbcabstraction::DriverException(buf.str());
   }
 
-  return hInstance;
+  return h_instance;
 }
 
-Window::Window(Window* parent, const char* className, const char* title)
-    : className(className), title(title), handle(NULL), parent(parent), created(false) {
+Window::Window(Window* parent, const char* class_name, const char* title)
+    : class_name(class_name), title(title), handle(NULL), parent(parent), created(false) {
   // No-op.
 }
 
 Window::Window(HWND handle)
-    : className(), title(), handle(handle), parent(0), created(false) {
+    : class_name(), title(), handle(handle), parent(0), created(false) {
   // No-op.
 }
 
@@ -63,14 +63,14 @@ Window::~Window() {
   if (created) Destroy();
 }
 
-void Window::Create(DWORD style, int posX, int posY, int width, int height, int id) {
+void Window::Create(DWORD style, int pos_x, int pos_y, int width, int height, int id) {
   if (handle) {
     std::stringstream buf;
     buf << "Window already created, error code: " << GetLastError();
     throw odbcabstraction::DriverException(buf.str());
   }
 
-  handle = CreateWindow(className.c_str(), title.c_str(), style, posX, posY, width,
+  handle = CreateWindow(class_name.c_str(), title.c_str(), style, pos_x, pos_y, width,
                         height, parent ? parent->GetHandle() : NULL,
                         reinterpret_cast<HMENU>(static_cast<ptrdiff_t>(id)),
                         GetHInstance(), this);
@@ -83,8 +83,8 @@ void Window::Create(DWORD style, int posX, int posY, int width, int height, int 
 
   created = true;
 
-  const HGDIOBJ hfDefault = GetStockObject(DEFAULT_GUI_FONT);
-  SendMessage(GetHandle(), WM_SETFONT, (WPARAM)hfDefault, MAKELPARAM(FALSE, 0));
+  const HGDIOBJ hf_default = GetStockObject(DEFAULT_GUI_FONT);
+  SendMessage(GetHandle(), WM_SETFONT, (WPARAM)hf_default, MAKELPARAM(FALSE, 0));
 }
 
 std::unique_ptr<Window> Window::CreateTabControl(int id) {
@@ -92,81 +92,83 @@ std::unique_ptr<Window> Window::CreateTabControl(int id) {
 
   // Get the dimensions of the parent window's client area, and
   // create a tab control child window of that size.
-  RECT rcClient;
-  GetClientRect(handle, &rcClient);
+  RECT rc_client;
+  GetClientRect(handle, &rc_client);
 
   child->Create(WS_CHILD | WS_CLIPSIBLINGS | WS_VISIBLE | WS_TABSTOP, 0, 0,
-                rcClient.right, 20, id);
+                rc_client.right, 20, id);
 
   return child;
 }
 
-std::unique_ptr<Window> Window::CreateList(int posX, int posY, int sizeX, int sizeY,
+std::unique_ptr<Window> Window::CreateList(int pos_x, int pos_y, int size_x, int size_y,
                                            int id) {
   std::unique_ptr<Window> child(new Window(this, WC_LISTVIEW, ""));
 
   child->Create(
-      WS_CHILD | WS_VISIBLE | WS_BORDER | LVS_REPORT | LVS_EDITLABELS | WS_TABSTOP, posX,
-      posY, sizeX, sizeY, id);
+      WS_CHILD | WS_VISIBLE | WS_BORDER | LVS_REPORT | LVS_EDITLABELS | WS_TABSTOP, pos_x,
+      pos_y, size_x, size_y, id);
 
   return child;
 }
 
-std::unique_ptr<Window> Window::CreateGroupBox(int posX, int posY, int sizeX, int sizeY,
-                                               const char* title, int id) {
+std::unique_ptr<Window> Window::CreateGroupBox(int pos_x, int pos_y, int size_x,
+                                               int size_y, const char* title, int id) {
   std::unique_ptr<Window> child(new Window(this, "Button", title));
 
-  child->Create(WS_CHILD | WS_VISIBLE | BS_GROUPBOX, posX, posY, sizeX, sizeY, id);
+  child->Create(WS_CHILD | WS_VISIBLE | BS_GROUPBOX, pos_x, pos_y, size_x, size_y, id);
 
   return child;
 }
 
-std::unique_ptr<Window> Window::CreateLabel(int posX, int posY, int sizeX, int sizeY,
+std::unique_ptr<Window> Window::CreateLabel(int pos_x, int pos_y, int size_x, int size_y,
                                             const char* title, int id) {
   std::unique_ptr<Window> child(new Window(this, "Static", title));
 
-  child->Create(WS_CHILD | WS_VISIBLE, posX, posY, sizeX, sizeY, id);
+  child->Create(WS_CHILD | WS_VISIBLE, pos_x, pos_y, size_x, size_y, id);
 
   return child;
 }
 
-std::unique_ptr<Window> Window::CreateEdit(int posX, int posY, int sizeX, int sizeY,
+std::unique_ptr<Window> Window::CreateEdit(int pos_x, int pos_y, int size_x, int size_y,
                                            const char* title, int id, int style) {
   std::unique_ptr<Window> child(new Window(this, "Edit", title));
 
   child->Create(WS_CHILD | WS_VISIBLE | WS_BORDER | ES_AUTOHSCROLL | WS_TABSTOP | style,
-                posX, posY, sizeX, sizeY, id);
+                pos_x, pos_y, size_x, size_y, id);
 
   return child;
 }
 
-std::unique_ptr<Window> Window::CreateButton(int posX, int posY, int sizeX, int sizeY,
+std::unique_ptr<Window> Window::CreateButton(int pos_x, int pos_y, int size_x, int size_y,
                                              const char* title, int id, int style) {
   std::unique_ptr<Window> child(new Window(this, "Button", title));
 
-  child->Create(WS_CHILD | WS_VISIBLE | WS_TABSTOP | style, posX, posY, sizeX, sizeY, id);
+  child->Create(WS_CHILD | WS_VISIBLE | WS_TABSTOP | style, pos_x, pos_y, size_x, size_y,
+                id);
 
   return child;
 }
 
-std::unique_ptr<Window> Window::CreateCheckBox(int posX, int posY, int sizeX, int sizeY,
-                                               const char* title, int id, bool state) {
+std::unique_ptr<Window> Window::CreateCheckBox(int pos_x, int pos_y, int size_x,
+                                               int size_y, const char* title, int id,
+                                               bool state) {
   std::unique_ptr<Window> child(new Window(this, "Button", title));
 
-  child->Create(WS_CHILD | WS_VISIBLE | BS_CHECKBOX | WS_TABSTOP, posX, posY, sizeX,
-                sizeY, id);
+  child->Create(WS_CHILD | WS_VISIBLE | BS_CHECKBOX | WS_TABSTOP, pos_x, pos_y, size_x,
+                size_y, id);
 
   child->SetChecked(state);
 
   return child;
 }
 
-std::unique_ptr<Window> Window::CreateComboBox(int posX, int posY, int sizeX, int sizeY,
-                                               const char* title, int id) {
+std::unique_ptr<Window> Window::CreateComboBox(int pos_x, int pos_y, int size_x,
+                                               int size_y, const char* title, int id) {
   std::unique_ptr<Window> child(new Window(this, "Combobox", title));
 
-  child->Create(WS_CHILD | WS_VISIBLE | CBS_DROPDOWNLIST | WS_TABSTOP, posX, posY, sizeX,
-                sizeY, id);
+  child->Create(WS_CHILD | WS_VISIBLE | CBS_DROPDOWNLIST | WS_TABSTOP, pos_x, pos_y,
+                size_x, size_y, id);
 
   return child;
 }
@@ -181,8 +183,8 @@ void Window::Destroy() {
   handle = NULL;
 }
 
-void Window::SetVisible(bool isVisible) {
-  ShowWindow(handle, isVisible ? SW_SHOW : SW_HIDE);
+void Window::SetVisible(bool is_visible) {
+  ShowWindow(handle, is_visible ? SW_SHOW : SW_HIDE);
 }
 
 bool Window::IsTextEmpty() const {
@@ -228,9 +230,9 @@ void Window::ListAddItem(const std::vector<std::string>& items) {
 }
 
 void Window::ListDeleteSelectedItem() {
-  const int rowIndex = ListView_GetSelectionMark(handle);
-  if (rowIndex >= 0) {
-    if (ListView_DeleteItem(handle, rowIndex) == -1) {
+  const int row_index = ListView_GetSelectionMark(handle);
+  if (row_index >= 0) {
+    if (ListView_DeleteItem(handle, row_index) == -1) {
       std::stringstream buf;
       buf << "Can not delete list item, error code: " << GetLastError();
       throw odbcabstraction::DriverException(buf.str());
@@ -243,11 +245,11 @@ std::vector<std::vector<std::string> > Window::ListGetAll() {
   char buf[BUF_LEN];
 
   std::vector<std::vector<std::string> > values;
-  const int numColumns = Header_GetItemCount(ListView_GetHeader(handle));
-  const int numItems = ListView_GetItemCount(handle);
-  for (int i = 0; i < numItems; ++i) {
+  const int num_columns = Header_GetItemCount(ListView_GetHeader(handle));
+  const int num_items = ListView_GetItemCount(handle);
+  for (int i = 0; i < num_items; ++i) {
     std::vector<std::string> row;
-    for (int j = 0; j < numColumns; ++j) {
+    for (int j = 0; j < num_columns; ++j) {
       ListView_GetItemText(handle, i, j, buf, BUF_LEN);
       row.emplace_back(buf);
     }
@@ -258,11 +260,11 @@ std::vector<std::vector<std::string> > Window::ListGetAll() {
 }
 
 void Window::AddTab(const std::string& name, int index) {
-  TCITEM tabControlItem;
-  tabControlItem.mask = TCIF_TEXT | TCIF_IMAGE;
-  tabControlItem.iImage = -1;
-  tabControlItem.pszText = const_cast<char*>(name.c_str());
-  if (TabCtrl_InsertItem(handle, index, &tabControlItem) == -1) {
+  TCITEM tab_control_item;
+  tab_control_item.mask = TCIF_TEXT | TCIF_IMAGE;
+  tab_control_item.iImage = -1;
+  tab_control_item.pszText = const_cast<char*>(name.c_str());
+  if (TabCtrl_InsertItem(handle, index, &tab_control_item) == -1) {
     std::stringstream buf;
     buf << "Can not add tab, error code: " << GetLastError();
     throw odbcabstraction::DriverException(buf.str());

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/utils.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/utils.cc
@@ -51,16 +51,17 @@ bool IsComplexType(arrow::Type::type type_id) {
   }
 }
 
-odbcabstraction::SqlDataType GetDefaultSqlCharType(bool useWideChar) {
-  return useWideChar ? odbcabstraction::SqlDataType_WCHAR
-                     : odbcabstraction::SqlDataType_CHAR;
+odbcabstraction::SqlDataType GetDefaultSqlCharType(bool use_wide_char) {
+  return use_wide_char ? odbcabstraction::SqlDataType_WCHAR
+                       : odbcabstraction::SqlDataType_CHAR;
 }
-odbcabstraction::SqlDataType GetDefaultSqlVarcharType(bool useWideChar) {
-  return useWideChar ? odbcabstraction::SqlDataType_WVARCHAR
-                     : odbcabstraction::SqlDataType_VARCHAR;
+odbcabstraction::SqlDataType GetDefaultSqlVarcharType(bool use_wide_char) {
+  return use_wide_char ? odbcabstraction::SqlDataType_WVARCHAR
+                       : odbcabstraction::SqlDataType_VARCHAR;
 }
-odbcabstraction::CDataType GetDefaultCCharType(bool useWideChar) {
-  return useWideChar ? odbcabstraction::CDataType_WCHAR : odbcabstraction::CDataType_CHAR;
+odbcabstraction::CDataType GetDefaultCCharType(bool use_wide_char) {
+  return use_wide_char ? odbcabstraction::CDataType_WCHAR
+                       : odbcabstraction::CDataType_CHAR;
 }
 
 }  // namespace
@@ -79,8 +80,8 @@ using std::nullopt;
 /// \note use GetNonConciseDataType on the output to get the verbose type
 /// \note the concise and verbose types are the same for all but types relating to times
 /// and intervals
-SqlDataType GetDataTypeFromArrowField_V3(const std::shared_ptr<arrow::Field>& field,
-                                         bool useWideChar) {
+SqlDataType GetDataTypeFromArrowFieldV3(const std::shared_ptr<arrow::Field>& field,
+                                        bool use_wide_char) {
   const std::shared_ptr<arrow::DataType>& type = field->type();
 
   switch (type->id()) {
@@ -109,7 +110,7 @@ SqlDataType GetDataTypeFromArrowField_V3(const std::shared_ptr<arrow::Field>& fi
       return odbcabstraction::SqlDataType_BINARY;
     case arrow::Type::STRING:
     case arrow::Type::LARGE_STRING:
-      return GetDefaultSqlVarcharType(useWideChar);
+      return GetDefaultSqlVarcharType(use_wide_char);
     case arrow::Type::DATE32:
     case arrow::Type::DATE64:
       return odbcabstraction::SqlDataType_TYPE_DATE;
@@ -144,17 +145,17 @@ SqlDataType GetDataTypeFromArrowField_V3(const std::shared_ptr<arrow::Field>& fi
       break;
   }
 
-  return GetDefaultSqlVarcharType(useWideChar);
+  return GetDefaultSqlVarcharType(use_wide_char);
 }
 
-SqlDataType EnsureRightSqlCharType(SqlDataType data_type, bool useWideChar) {
+SqlDataType EnsureRightSqlCharType(SqlDataType data_type, bool use_wide_char) {
   switch (data_type) {
     case odbcabstraction::SqlDataType_CHAR:
     case odbcabstraction::SqlDataType_WCHAR:
-      return GetDefaultSqlCharType(useWideChar);
+      return GetDefaultSqlCharType(use_wide_char);
     case odbcabstraction::SqlDataType_VARCHAR:
     case odbcabstraction::SqlDataType_WVARCHAR:
-      return GetDefaultSqlVarcharType(useWideChar);
+      return GetDefaultSqlVarcharType(use_wide_char);
     default:
       return data_type;
   }
@@ -857,10 +858,10 @@ arrow::Type::type ConvertCToArrowType(odbcabstraction::CDataType data_type) {
 }
 
 odbcabstraction::CDataType ConvertArrowTypeToC(arrow::Type::type type_id,
-                                               bool useWideChar) {
+                                               bool use_wide_char) {
   switch (type_id) {
     case arrow::Type::STRING:
-      return GetDefaultCCharType(useWideChar);
+      return GetDefaultCCharType(use_wide_char);
     case arrow::Type::INT16:
       return odbcabstraction::CDataType_SSHORT;
     case arrow::Type::UINT16:
@@ -1110,14 +1111,14 @@ std::string ConvertToDBMSVer(const std::string& str) {
   return result;
 }
 
-int32_t GetDecimalTypeScale(const std::shared_ptr<arrow::DataType>& decimalType) {
-  auto decimal128Type = std::dynamic_pointer_cast<arrow::Decimal128Type>(decimalType);
-  return decimal128Type->scale();
+int32_t GetDecimalTypeScale(const std::shared_ptr<arrow::DataType>& decimal_type) {
+  auto decimal128_type = std::dynamic_pointer_cast<arrow::Decimal128Type>(decimal_type);
+  return decimal128_type->scale();
 }
 
-int32_t GetDecimalTypePrecision(const std::shared_ptr<arrow::DataType>& decimalType) {
-  auto decimal128Type = std::dynamic_pointer_cast<arrow::Decimal128Type>(decimalType);
-  return decimal128Type->precision();
+int32_t GetDecimalTypePrecision(const std::shared_ptr<arrow::DataType>& decimal_type) {
+  auto decimal128_type = std::dynamic_pointer_cast<arrow::Decimal128Type>(decimal_type);
+  return decimal128_type->precision();
 }
 
 }  // namespace flight_sql

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/utils.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/utils.h
@@ -58,11 +58,11 @@ arrow::Status AppendToBuilder(BUILDER& builder, T value) {
   return builder.Append(value);
 }
 
-odbcabstraction::SqlDataType GetDataTypeFromArrowField_V3(
-    const std::shared_ptr<arrow::Field>& field, bool useWideChar);
+odbcabstraction::SqlDataType GetDataTypeFromArrowFieldV3(
+    const std::shared_ptr<arrow::Field>& field, bool use_wide_char);
 
 odbcabstraction::SqlDataType EnsureRightSqlCharType(
-    odbcabstraction::SqlDataType data_type, bool useWideChar);
+    odbcabstraction::SqlDataType data_type, bool use_wide_char);
 
 int16_t ConvertSqlDataTypeFromV3ToV2(int16_t data_type_v3);
 
@@ -107,7 +107,7 @@ std::shared_ptr<arrow::DataType> GetDefaultDataTypeForTypeId(arrow::Type::type t
 arrow::Type::type ConvertCToArrowType(odbcabstraction::CDataType data_type);
 
 odbcabstraction::CDataType ConvertArrowTypeToC(arrow::Type::type type_id,
-                                               bool useWideChar);
+                                               bool use_wide_char);
 
 std::shared_ptr<arrow::Array> CheckConversion(const arrow::Result<arrow::Datum>& result);
 
@@ -116,9 +116,9 @@ ArrayConvertTask GetConverter(arrow::Type::type original_type_id,
 
 std::string ConvertToDBMSVer(const std::string& str);
 
-int32_t GetDecimalTypeScale(const std::shared_ptr<arrow::DataType>& decimalType);
+int32_t GetDecimalTypeScale(const std::shared_ptr<arrow::DataType>& decimal_type);
 
-int32_t GetDecimalTypePrecision(const std::shared_ptr<arrow::DataType>& decimalType);
+int32_t GetDecimalTypePrecision(const std::shared_ptr<arrow::DataType>& decimal_type);
 
 }  // namespace flight_sql
 }  // namespace driver

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/diagnostics.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/diagnostics.cc
@@ -52,7 +52,7 @@ void driver::odbcabstraction::Diagnostics::AddError(
   auto record = std::unique_ptr<DiagnosticsRecord>(new DiagnosticsRecord{
       exception.GetMessageText(), exception.GetSqlState(), exception.GetNativeError()});
   if (version_ == OdbcVersion::V_2) {
-    RewriteSQLStateForODBC2(record->sql_state_);
+    RewriteSQLStateForODBC2(record->sql_state);
   }
   TrackRecord(*record);
   owned_records_.push_back(std::move(record));
@@ -64,7 +64,7 @@ void driver::odbcabstraction::Diagnostics::AddWarning(std::string message,
   auto record = std::unique_ptr<DiagnosticsRecord>(
       new DiagnosticsRecord{std::move(message), std::move(sql_state), native_error});
   if (version_ == OdbcVersion::V_2) {
-    RewriteSQLStateForODBC2(record->sql_state_);
+    RewriteSQLStateForODBC2(record->sql_state);
   }
   TrackRecord(*record);
   owned_records_.push_back(std::move(record));
@@ -78,7 +78,7 @@ std::string driver::odbcabstraction::Diagnostics::GetMessageText(
   }
   const DiagnosticsRecord* rec = GetRecordAtIndex(record_index);
   return message + "[" + data_source_component_ + "] (" +
-         std::to_string(rec->native_error_) + ") " + rec->msg_text_;
+         std::to_string(rec->native_error) + ") " + rec->msg_text;
 }
 
 OdbcVersion Diagnostics::GetOdbcVersion() const { return version_; }

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/diagnostics.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/diagnostics.h
@@ -29,9 +29,9 @@ namespace odbcabstraction {
 class Diagnostics {
  public:
   struct DiagnosticsRecord {
-    std::string msg_text_;
-    std::string sql_state_;
-    int32_t native_error_;
+    std::string msg_text;
+    std::string sql_state;
+    int32_t native_error;
   };
 
  private:
@@ -56,7 +56,7 @@ class Diagnostics {
   }
 
   inline void TrackRecord(const DiagnosticsRecord& record) {
-    if (record.sql_state_[0] == '0' && record.sql_state_[1] == '1') {
+    if (record.sql_state[0] == '0' && record.sql_state[1] == '1') {
       warning_records_.push_back(&record);
     } else {
       error_records_.push_back(&record);
@@ -76,11 +76,11 @@ class Diagnostics {
 
   std::string GetMessageText(uint32_t record_index) const;
   std::string GetSQLState(uint32_t record_index) const {
-    return GetRecordAtIndex(record_index)->sql_state_;
+    return GetRecordAtIndex(record_index)->sql_state;
   }
 
   int32_t GetNativeError(uint32_t record_index) const {
-    return GetRecordAtIndex(record_index)->native_error_;
+    return GetRecordAtIndex(record_index)->native_error;
   }
 
   inline size_t GetRecordCount() const {

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/attribute_utils.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/attribute_utils.h
@@ -32,43 +32,44 @@ namespace ODBC {
 using driver::odbcabstraction::WcsToUtf8;
 
 template <typename T, typename O>
-inline void GetAttribute(T attributeValue, SQLPOINTER output, O outputSize,
-                         O* outputLenPtr) {
+inline void GetAttribute(T attribute_value, SQLPOINTER output, O output_size,
+                         O* output_len_ptr) {
   if (output) {
-    T* typedOutput = reinterpret_cast<T*>(output);
-    *typedOutput = attributeValue;
+    T* typed_output = reinterpret_cast<T*>(output);
+    *typed_output = attribute_value;
   }
 
-  if (outputLenPtr) {
-    *outputLenPtr = sizeof(T);
+  if (output_len_ptr) {
+    *output_len_ptr = sizeof(T);
   }
 }
 
 template <typename O>
-inline SQLRETURN GetAttributeUTF8(const std::string& attributeValue, SQLPOINTER output,
-                                  O outputSize, O* outputLenPtr) {
+inline SQLRETURN GetAttributeUTF8(const std::string& attribute_value, SQLPOINTER output,
+                                  O output_size, O* output_len_ptr) {
   if (output) {
-    size_t outputLenBeforeNul =
-        std::min(static_cast<O>(attributeValue.size()), static_cast<O>(outputSize - 1));
-    memcpy(output, attributeValue.c_str(), outputLenBeforeNul);
-    reinterpret_cast<char*>(output)[outputLenBeforeNul] = '\0';
+    size_t output_len_before_null =
+        std::min(static_cast<O>(attribute_value.size()), static_cast<O>(output_size - 1));
+    memcpy(output, attribute_value.c_str(), output_len_before_null);
+    reinterpret_cast<char*>(output)[output_len_before_null] = '\0';
   }
 
-  if (outputLenPtr) {
-    *outputLenPtr = static_cast<O>(attributeValue.size());
+  if (output_len_ptr) {
+    *output_len_ptr = static_cast<O>(attribute_value.size());
   }
 
-  if (output && outputSize < static_cast<O>(attributeValue.size() + 1)) {
+  if (output && output_size < static_cast<O>(attribute_value.size() + 1)) {
     return SQL_SUCCESS_WITH_INFO;
   }
   return SQL_SUCCESS;
 }
 
 template <typename O>
-inline SQLRETURN GetAttributeUTF8(const std::string& attributeValue, SQLPOINTER output,
-                                  O outputSize, O* outputLenPtr,
+inline SQLRETURN GetAttributeUTF8(const std::string& attribute_value, SQLPOINTER output,
+                                  O output_size, O* output_len_ptr,
                                   driver::odbcabstraction::Diagnostics& diagnostics) {
-  SQLRETURN result = GetAttributeUTF8(attributeValue, output, outputSize, outputLenPtr);
+  SQLRETURN result =
+      GetAttributeUTF8(attribute_value, output, output_size, output_len_ptr);
   if (SQL_SUCCESS_WITH_INFO == result) {
     diagnostics.AddTruncationWarning();
   }
@@ -76,31 +77,33 @@ inline SQLRETURN GetAttributeUTF8(const std::string& attributeValue, SQLPOINTER 
 }
 
 template <typename O>
-inline SQLRETURN GetAttributeSQLWCHAR(const std::string& attributeValue,
-                                      bool isLengthInBytes, SQLPOINTER output,
-                                      O outputSize, O* outputLenPtr) {
-  size_t result =
-      ConvertToSqlWChar(attributeValue, reinterpret_cast<SQLWCHAR*>(output),
-                        isLengthInBytes ? outputSize : outputSize * GetSqlWCharSize());
+inline SQLRETURN GetAttributeSQLWCHAR(const std::string& attribute_value,
+                                      bool is_length_in_bytes, SQLPOINTER output,
+                                      O output_size, O* output_len_ptr) {
+  size_t result = ConvertToSqlWChar(
+      attribute_value, reinterpret_cast<SQLWCHAR*>(output),
+      is_length_in_bytes ? output_size : output_size * GetSqlWCharSize());
 
-  if (outputLenPtr) {
-    *outputLenPtr = static_cast<O>(isLengthInBytes ? result : result / GetSqlWCharSize());
+  if (output_len_ptr) {
+    *output_len_ptr =
+        static_cast<O>(is_length_in_bytes ? result : result / GetSqlWCharSize());
   }
 
   if (output &&
-      outputSize < static_cast<O>(result + (isLengthInBytes ? GetSqlWCharSize() : 1))) {
+      output_size <
+          static_cast<O>(result + (is_length_in_bytes ? GetSqlWCharSize() : 1))) {
     return SQL_SUCCESS_WITH_INFO;
   }
   return SQL_SUCCESS;
 }
 
 template <typename O>
-inline SQLRETURN GetAttributeSQLWCHAR(const std::string& attributeValue,
-                                      bool isLengthInBytes, SQLPOINTER output,
-                                      O outputSize, O* outputLenPtr,
+inline SQLRETURN GetAttributeSQLWCHAR(const std::string& attribute_value,
+                                      bool is_length_in_bytes, SQLPOINTER output,
+                                      O output_size, O* output_len_ptr,
                                       driver::odbcabstraction::Diagnostics& diagnostics) {
-  SQLRETURN result = GetAttributeSQLWCHAR(attributeValue, isLengthInBytes, output,
-                                          outputSize, outputLenPtr);
+  SQLRETURN result = GetAttributeSQLWCHAR(attribute_value, is_length_in_bytes, output,
+                                          output_size, output_len_ptr);
   if (SQL_SUCCESS_WITH_INFO == result) {
     diagnostics.AddTruncationWarning();
   }
@@ -108,16 +111,16 @@ inline SQLRETURN GetAttributeSQLWCHAR(const std::string& attributeValue,
 }
 
 template <typename O>
-inline SQLRETURN GetStringAttribute(bool isUnicode, const std::string& attributeValue,
-                                    bool isLengthInBytes, SQLPOINTER output, O outputSize,
-                                    O* outputLenPtr,
+inline SQLRETURN GetStringAttribute(bool is_unicode, const std::string& attribute_value,
+                                    bool is_length_in_bytes, SQLPOINTER output,
+                                    O output_size, O* output_len_ptr,
                                     driver::odbcabstraction::Diagnostics& diagnostics) {
   SQLRETURN result = SQL_SUCCESS;
-  if (isUnicode) {
-    result = GetAttributeSQLWCHAR(attributeValue, isLengthInBytes, output, outputSize,
-                                  outputLenPtr);
+  if (is_unicode) {
+    result = GetAttributeSQLWCHAR(attribute_value, is_length_in_bytes, output,
+                                  output_size, output_len_ptr);
   } else {
-    result = GetAttributeUTF8(attributeValue, output, outputSize, outputLenPtr);
+    result = GetAttributeUTF8(attribute_value, output, output_size, output_len_ptr);
   }
 
   if (SQL_SUCCESS_WITH_INFO == result) {
@@ -127,32 +130,33 @@ inline SQLRETURN GetStringAttribute(bool isUnicode, const std::string& attribute
 }
 
 template <typename T>
-inline void SetAttribute(SQLPOINTER newValue, T& attributeToWrite) {
-  SQLLEN valueAsLen = reinterpret_cast<SQLLEN>(newValue);
-  attributeToWrite = static_cast<T>(valueAsLen);
+inline void SetAttribute(SQLPOINTER new_value, T& attribute_to_write) {
+  SQLLEN valueAsLen = reinterpret_cast<SQLLEN>(new_value);
+  attribute_to_write = static_cast<T>(valueAsLen);
 }
 
 template <typename T>
-inline void SetPointerAttribute(SQLPOINTER newValue, T& attributeToWrite) {
-  attributeToWrite = static_cast<T>(newValue);
+inline void SetPointerAttribute(SQLPOINTER new_value, T& attribute_to_write) {
+  attribute_to_write = static_cast<T>(new_value);
 }
 
-inline void SetAttributeUTF8(SQLPOINTER newValue, SQLINTEGER inputLength,
-                             std::string& attributeToWrite) {
-  const char* newValueAsChar = static_cast<const char*>(newValue);
-  attributeToWrite.assign(newValueAsChar,
-                          inputLength == SQL_NTS ? strlen(newValueAsChar) : inputLength);
+inline void SetAttributeUTF8(SQLPOINTER new_value, SQLINTEGER input_length,
+                             std::string& attribute_to_write) {
+  const char* new_value_as_char = static_cast<const char*>(new_value);
+  attribute_to_write.assign(new_value_as_char, input_length == SQL_NTS
+                                                   ? strlen(new_value_as_char)
+                                                   : input_length);
 }
 
-inline void SetAttributeSQLWCHAR(SQLPOINTER newValue, SQLINTEGER inputLengthInBytes,
-                                 std::string& attributeToWrite) {
+inline void SetAttributeSQLWCHAR(SQLPOINTER new_value, SQLINTEGER input_length_in_bytes,
+                                 std::string& attribute_to_write) {
   thread_local std::vector<uint8_t> utf8_str;
-  if (inputLengthInBytes == SQL_NTS) {
-    WcsToUtf8(newValue, &utf8_str);
+  if (input_length_in_bytes == SQL_NTS) {
+    WcsToUtf8(new_value, &utf8_str);
   } else {
-    WcsToUtf8(newValue, inputLengthInBytes / GetSqlWCharSize(), &utf8_str);
+    WcsToUtf8(new_value, input_length_in_bytes / GetSqlWCharSize(), &utf8_str);
   }
-  attributeToWrite.assign((char*)utf8_str.data());
+  attribute_to_write.assign((char*)utf8_str.data());
 }
 
 template <typename T>

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/encoding_utils.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/encoding_utils.h
@@ -38,38 +38,39 @@ using driver::odbcabstraction::Utf8ToWcs;
 // Return the number of bytes required for the conversion.
 template <typename CHAR_TYPE>
 inline size_t ConvertToSqlWChar(const std::string& str, SQLWCHAR* buffer,
-                                SQLLEN bufferSizeInBytes) {
+                                SQLLEN buffer_size_in_bytes) {
   thread_local std::vector<uint8_t> wstr;
   Utf8ToWcs<CHAR_TYPE>(str.data(), str.size(), &wstr);
-  SQLLEN valueLengthInBytes = wstr.size();
+  SQLLEN value_length_in_bytes = wstr.size();
 
   if (buffer) {
     memcpy(buffer, wstr.data(),
-           std::min(static_cast<SQLLEN>(wstr.size()), bufferSizeInBytes));
+           std::min(static_cast<SQLLEN>(wstr.size()), buffer_size_in_bytes));
 
     // Write a NUL terminator
-    if (bufferSizeInBytes >=
-        valueLengthInBytes + static_cast<SQLLEN>(GetSqlWCharSize())) {
-      reinterpret_cast<CHAR_TYPE*>(buffer)[valueLengthInBytes / GetSqlWCharSize()] = '\0';
+    if (buffer_size_in_bytes >=
+        value_length_in_bytes + static_cast<SQLLEN>(GetSqlWCharSize())) {
+      reinterpret_cast<CHAR_TYPE*>(buffer)[value_length_in_bytes / GetSqlWCharSize()] =
+          '\0';
     } else {
-      SQLLEN numCharsWritten = bufferSizeInBytes / GetSqlWCharSize();
+      SQLLEN num_chars_written = buffer_size_in_bytes / GetSqlWCharSize();
       // If we failed to even write one char, the buffer is too small to hold a
       // NUL-terminator.
-      if (numCharsWritten > 0) {
-        reinterpret_cast<CHAR_TYPE*>(buffer)[numCharsWritten - 1] = '\0';
+      if (num_chars_written > 0) {
+        reinterpret_cast<CHAR_TYPE*>(buffer)[num_chars_written - 1] = '\0';
       }
     }
   }
-  return valueLengthInBytes;
+  return value_length_in_bytes;
 }
 
 inline size_t ConvertToSqlWChar(const std::string& str, SQLWCHAR* buffer,
-                                SQLLEN bufferSizeInBytes) {
+                                SQLLEN buffer_size_in_bytes) {
   switch (GetSqlWCharSize()) {
     case sizeof(char16_t):
-      return ConvertToSqlWChar<char16_t>(str, buffer, bufferSizeInBytes);
+      return ConvertToSqlWChar<char16_t>(str, buffer, buffer_size_in_bytes);
     case sizeof(char32_t):
-      return ConvertToSqlWChar<char32_t>(str, buffer, bufferSizeInBytes);
+      return ConvertToSqlWChar<char32_t>(str, buffer, buffer_size_in_bytes);
     default:
       assert(false);
       throw DriverException("Encoding is unsupported, SQLWCHAR size: " +

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/odbc_connection.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/odbc_connection.h
@@ -42,56 +42,56 @@ class ODBCConnection : public ODBCHandle<ODBCConnection> {
   ODBCConnection& operator=(const ODBCConnection&) = delete;
 
   ODBCConnection(ODBCEnvironment& environment,
-                 std::shared_ptr<driver::odbcabstraction::Connection> spiConnection);
+                 std::shared_ptr<driver::odbcabstraction::Connection> spi_connection);
 
-  driver::odbcabstraction::Diagnostics& GetDiagnostics_Impl();
+  driver::odbcabstraction::Diagnostics& GetDiagnosticsImpl();
 
   const std::string& GetDSN() const;
-  bool isConnected() const;
-  void connect(std::string dsn,
+  bool IsConnected() const;
+  void Connect(std::string dsn,
                const driver::odbcabstraction::Connection::ConnPropertyMap& properties,
                std::vector<std::string_view>& missing_properties);
 
-  void GetInfo(SQLUSMALLINT infoType, SQLPOINTER value, SQLSMALLINT bufferLength,
-               SQLSMALLINT* outputLength, bool isUnicode);
-  void SetConnectAttr(SQLINTEGER attribute, SQLPOINTER value, SQLINTEGER stringLength,
+  void GetInfo(SQLUSMALLINT info_type, SQLPOINTER value, SQLSMALLINT buffer_length,
+               SQLSMALLINT* output_length, bool is_unicode);
+  void SetConnectAttr(SQLINTEGER attribute, SQLPOINTER value, SQLINTEGER string_length,
                       bool isUnicode);
-  void GetConnectAttr(SQLINTEGER attribute, SQLPOINTER value, SQLINTEGER bufferLength,
-                      SQLINTEGER* outputLength, bool isUnicode);
+  void GetConnectAttr(SQLINTEGER attribute, SQLPOINTER value, SQLINTEGER buffer_length,
+                      SQLINTEGER* output_length, bool is_unicode);
 
   ~ODBCConnection() = default;
 
-  inline ODBCStatement& GetTrackingStatement() { return *m_attributeTrackingStatement; }
+  inline ODBCStatement& GetTrackingStatement() { return *m_attribute_tracking_statement; }
 
-  void disconnect();
+  void Disconnect();
 
-  void releaseConnection();
+  void ReleaseConnection();
 
-  std::shared_ptr<ODBCStatement> createStatement();
-  void dropStatement(ODBCStatement* statement);
+  std::shared_ptr<ODBCStatement> CreateStatement();
+  void DropStatement(ODBCStatement* statement);
 
-  std::shared_ptr<ODBCDescriptor> createDescriptor();
-  void dropDescriptor(ODBCDescriptor* descriptor);
+  std::shared_ptr<ODBCDescriptor> CreateDescriptor();
+  void DropDescriptor(ODBCDescriptor* descriptor);
 
-  inline bool IsOdbc2Connection() const { return m_is2xConnection; }
+  inline bool IsOdbc2Connection() const { return m_is_2x_connection; }
 
   /// @return the DSN or empty string if Driver was used.
-  static std::string getPropertiesFromConnString(
-      const std::string& connStr,
+  static std::string GetPropertiesFromConnString(
+      const std::string& conn_str,
       driver::odbcabstraction::Connection::ConnPropertyMap& properties);
 
  private:
   ODBCEnvironment& m_environment;
-  std::shared_ptr<driver::odbcabstraction::Connection> m_spiConnection;
+  std::shared_ptr<driver::odbcabstraction::Connection> m_spi_connection;
   // Extra ODBC statement that's used to track and validate when statement attributes are
   // set through the connection handle. These attributes get copied to new ODBC statements
   // when they are allocated.
-  std::shared_ptr<ODBCStatement> m_attributeTrackingStatement;
+  std::shared_ptr<ODBCStatement> m_attribute_tracking_statement;
   std::vector<std::shared_ptr<ODBCStatement> > m_statements;
   std::vector<std::shared_ptr<ODBCDescriptor> > m_descriptors;
   std::string m_dsn;
-  const bool m_is2xConnection;
-  bool m_isConnected;
+  const bool m_is_2x_connection;
+  bool m_is_connected;
 };
 
 }  // namespace ODBC

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/odbc_connection.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/odbc_connection.h
@@ -61,7 +61,7 @@ class ODBCConnection : public ODBCHandle<ODBCConnection> {
 
   ~ODBCConnection() = default;
 
-  inline ODBCStatement& GetTrackingStatement() { return *m_attribute_tracking_statement; }
+  inline ODBCStatement& GetTrackingStatement() { return *attribute_tracking_statement_; }
 
   void Disconnect();
 
@@ -73,7 +73,7 @@ class ODBCConnection : public ODBCHandle<ODBCConnection> {
   std::shared_ptr<ODBCDescriptor> CreateDescriptor();
   void DropDescriptor(ODBCDescriptor* descriptor);
 
-  inline bool IsOdbc2Connection() const { return m_is_2x_connection; }
+  inline bool IsOdbc2Connection() const { return is_2x_connection_; }
 
   /// @return the DSN or empty string if Driver was used.
   static std::string GetPropertiesFromConnString(
@@ -81,17 +81,17 @@ class ODBCConnection : public ODBCHandle<ODBCConnection> {
       driver::odbcabstraction::Connection::ConnPropertyMap& properties);
 
  private:
-  ODBCEnvironment& m_environment;
-  std::shared_ptr<driver::odbcabstraction::Connection> m_spi_connection;
+  ODBCEnvironment& environment_;
+  std::shared_ptr<driver::odbcabstraction::Connection> spi_connection_;
   // Extra ODBC statement that's used to track and validate when statement attributes are
   // set through the connection handle. These attributes get copied to new ODBC statements
   // when they are allocated.
-  std::shared_ptr<ODBCStatement> m_attribute_tracking_statement;
-  std::vector<std::shared_ptr<ODBCStatement> > m_statements;
-  std::vector<std::shared_ptr<ODBCDescriptor> > m_descriptors;
-  std::string m_dsn;
-  const bool m_is_2x_connection;
-  bool m_is_connected;
+  std::shared_ptr<ODBCStatement> attribute_tracking_statement_;
+  std::vector<std::shared_ptr<ODBCStatement> > statements_;
+  std::vector<std::shared_ptr<ODBCDescriptor> > descriptors_;
+  std::string dsn_;
+  const bool is_2x_connection_;
+  bool is_connected_;
 };
 
 }  // namespace ODBC

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/odbc_descriptor.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/odbc_descriptor.h
@@ -38,40 +38,40 @@ class ODBCStatement;
 
 namespace ODBC {
 struct DescriptorRecord {
-  std::string m_baseColumnName;
-  std::string m_baseTableName;
-  std::string m_catalogName;
+  std::string m_base_column_name;
+  std::string m_base_table_name;
+  std::string m_catalog_name;
   std::string m_label;
-  std::string m_literalPrefix;
-  std::string m_literalSuffix;
-  std::string m_localTypeName;
+  std::string m_literal_prefix;
+  std::string m_literal_suffix;
+  std::string m_local_type_name;
   std::string m_name;
-  std::string m_schemaName;
-  std::string m_tableName;
-  std::string m_typeName;
-  SQLPOINTER m_dataPtr = NULL;
-  SQLLEN* m_indicatorPtr = NULL;
-  SQLLEN m_displaySize = 0;
-  SQLLEN m_octetLength = 0;
+  std::string m_schema_name;
+  std::string m_table_name;
+  std::string m_type_name;
+  SQLPOINTER m_data_ptr = NULL;
+  SQLLEN* m_indicator_ptr = NULL;
+  SQLLEN m_display_size = 0;
+  SQLLEN m_octet_length = 0;
   SQLULEN m_length = 0;
-  SQLINTEGER m_autoUniqueValue;
-  SQLINTEGER m_caseSensitive = SQL_TRUE;
-  SQLINTEGER m_datetimeIntervalPrecision = 0;
-  SQLINTEGER m_numPrecRadix = 0;
-  SQLSMALLINT m_conciseType = SQL_C_DEFAULT;
-  SQLSMALLINT m_datetimeIntervalCode = 0;
-  SQLSMALLINT m_fixedPrecScale = 0;
+  SQLINTEGER m_auto_unique_value;
+  SQLINTEGER m_case_sensitive = SQL_TRUE;
+  SQLINTEGER m_datetime_interval_precision = 0;
+  SQLINTEGER m_num_prec_radix = 0;
+  SQLSMALLINT m_concise_type = SQL_C_DEFAULT;
+  SQLSMALLINT m_datetime_interval_code = 0;
+  SQLSMALLINT m_fixed_prec_scale = 0;
   SQLSMALLINT m_nullable = SQL_NULLABLE_UNKNOWN;
-  SQLSMALLINT m_paramType = SQL_PARAM_INPUT;
+  SQLSMALLINT m_param_type = SQL_PARAM_INPUT;
   SQLSMALLINT m_precision = 0;
-  SQLSMALLINT m_rowVer = 0;
+  SQLSMALLINT m_row_ver = 0;
   SQLSMALLINT m_scale = 0;
   SQLSMALLINT m_searchable = SQL_SEARCHABLE;
   SQLSMALLINT m_type = SQL_C_DEFAULT;
   SQLSMALLINT m_unnamed = SQL_TRUE;
   SQLSMALLINT m_unsigned = SQL_FALSE;
   SQLSMALLINT m_updatable = SQL_FALSE;
-  bool m_isBound = false;
+  bool m_is_bound = false;
 
   void CheckConsistency();
 };
@@ -81,29 +81,29 @@ class ODBCDescriptor : public ODBCHandle<ODBCDescriptor> {
   /// \brief Construct a new ODBCDescriptor object. Link the descriptor to a connection,
   /// if applicable. A nullptr should be supplied for conn if the descriptor should not be
   /// linked.
-  ODBCDescriptor(driver::odbcabstraction::Diagnostics& baseDiagnostics,
-                 ODBCConnection* conn, ODBCStatement* stmt, bool isAppDescriptor,
-                 bool isWritable, bool is2xConnection);
+  ODBCDescriptor(driver::odbcabstraction::Diagnostics& base_diagnostics,
+                 ODBCConnection* conn, ODBCStatement* stmt, bool is_app_descriptor,
+                 bool is_writable, bool is_2x_connection);
 
-  driver::odbcabstraction::Diagnostics& GetDiagnostics_Impl();
+  driver::odbcabstraction::Diagnostics& GetDiagnosticsImpl();
 
   ODBCConnection& GetConnection();
 
-  void SetHeaderField(SQLSMALLINT fieldIdentifier, SQLPOINTER value,
-                      SQLINTEGER bufferLength);
-  void SetField(SQLSMALLINT recordNumber, SQLSMALLINT fieldIdentifier, SQLPOINTER value,
-                SQLINTEGER bufferLength);
-  void GetHeaderField(SQLSMALLINT fieldIdentifier, SQLPOINTER value,
-                      SQLINTEGER bufferLength, SQLINTEGER* outputLength) const;
-  void GetField(SQLSMALLINT recordNumber, SQLSMALLINT fieldIdentifier, SQLPOINTER value,
-                SQLINTEGER bufferLength, SQLINTEGER* outputLength);
-  SQLSMALLINT getAllocType() const;
+  void SetHeaderField(SQLSMALLINT field_identifier, SQLPOINTER value,
+                      SQLINTEGER buffer_length);
+  void SetField(SQLSMALLINT record_number, SQLSMALLINT field_identifier, SQLPOINTER value,
+                SQLINTEGER buffer_length);
+  void GetHeaderField(SQLSMALLINT field_identifier, SQLPOINTER value,
+                      SQLINTEGER buffer_length, SQLINTEGER* output_length) const;
+  void GetField(SQLSMALLINT record_number, SQLSMALLINT field_identifier, SQLPOINTER value,
+                SQLINTEGER buffer_length, SQLINTEGER* output_length);
+  SQLSMALLINT GetAllocType() const;
   bool IsAppDescriptor() const;
 
-  inline bool HaveBindingsChanged() const { return m_hasBindingsChanged; }
+  inline bool HaveBindingsChanged() const { return m_has_bindings_changed; }
 
-  void RegisterToStatement(ODBCStatement* statement, bool isApd);
-  void DetachFromStatement(ODBCStatement* statement, bool isApd);
+  void RegisterToStatement(ODBCStatement* statement, bool is_apd);
+  void DetachFromStatement(ODBCStatement* statement, bool is_apd);
   void ReleaseDescriptor();
 
   void PopulateFromResultSetMetadata(driver::odbcabstraction::ResultSetMetadata* rsmd);
@@ -111,49 +111,49 @@ class ODBCDescriptor : public ODBCHandle<ODBCDescriptor> {
   const std::vector<DescriptorRecord>& GetRecords() const;
   std::vector<DescriptorRecord>& GetRecords();
 
-  void BindCol(SQLSMALLINT recordNumber, SQLSMALLINT cType, SQLPOINTER dataPtr,
-               SQLLEN bufferLength, SQLLEN* indicatorPtr);
-  void SetDataPtrOnRecord(SQLPOINTER dataPtr, SQLSMALLINT recNumber);
+  void BindCol(SQLSMALLINT record_number, SQLSMALLINT c_type, SQLPOINTER data_ptr,
+               SQLLEN buffer_length, SQLLEN* indicator_ptr);
+  void SetDataPtrOnRecord(SQLPOINTER data_ptr, SQLSMALLINT rec_number);
 
-  inline SQLULEN GetBindOffset() { return m_bindOffsetPtr ? *m_bindOffsetPtr : 0UL; }
+  inline SQLULEN GetBindOffset() { return m_bind_offset_ptr ? *m_bind_offset_ptr : 0UL; }
 
   inline SQLULEN GetBoundStructOffset() {
-    // If this is SQL_BIND_BY_COLUMN, m_bindType is zero which indicates no offset due to
+    // If this is SQL_BIND_BY_COLUMN, m_bind_type is zero which indicates no offset due to
     // use of a bound struct. If this is non-zero, row-wise binding is being used so the
     // app should set this to sizeof(their struct).
-    return m_bindType;
+    return m_bind_type;
   }
 
-  inline SQLULEN GetArraySize() { return m_arraySize; }
+  inline SQLULEN GetArraySize() { return m_array_size; }
 
-  inline SQLUSMALLINT* GetArrayStatusPtr() { return m_arrayStatusPtr; }
+  inline SQLUSMALLINT* GetArrayStatusPtr() { return m_array_status_ptr; }
 
   inline void SetRowsProcessed(SQLULEN rows) {
-    if (m_rowsProccessedPtr) {
-      *m_rowsProccessedPtr = rows;
+    if (m_rows_proccessed_ptr) {
+      *m_rows_proccessed_ptr = rows;
     }
   }
 
-  inline void NotifyBindingsHavePropagated() { m_hasBindingsChanged = false; }
+  inline void NotifyBindingsHavePropagated() { m_has_bindings_changed = false; }
 
-  inline void NotifyBindingsHaveChanged() { m_hasBindingsChanged = true; }
+  inline void NotifyBindingsHaveChanged() { m_has_bindings_changed = true; }
 
  private:
   driver::odbcabstraction::Diagnostics m_diagnostics;
-  std::vector<ODBCStatement*> m_registeredOnStatementsAsApd;
-  std::vector<ODBCStatement*> m_registeredOnStatementsAsArd;
+  std::vector<ODBCStatement*> m_registered_on_statements_as_apd;
+  std::vector<ODBCStatement*> m_registered_on_statements_as_ard;
   std::vector<DescriptorRecord> m_records;
-  ODBCConnection* m_owningConnection;
-  ODBCStatement* m_parentStatement;
-  SQLUSMALLINT* m_arrayStatusPtr;
-  SQLULEN* m_bindOffsetPtr;
-  SQLULEN* m_rowsProccessedPtr;
-  SQLULEN m_arraySize;
-  SQLINTEGER m_bindType;
-  SQLSMALLINT m_highestOneBasedBoundRecord;
-  const bool m_is2xConnection;
-  bool m_isAppDescriptor;
-  bool m_isWritable;
-  bool m_hasBindingsChanged;
+  ODBCConnection* m_owning_connection;
+  ODBCStatement* m_parent_statement;
+  SQLUSMALLINT* m_array_status_ptr;
+  SQLULEN* m_bind_offset_ptr;
+  SQLULEN* m_rows_proccessed_ptr;
+  SQLULEN m_array_size;
+  SQLINTEGER m_bind_type;
+  SQLSMALLINT m_highest_one_based_bound_record;
+  const bool m_is_2x_connection;
+  bool m_is_app_descriptor;
+  bool m_is_writable;
+  bool m_has_bindings_changed;
 };
 }  // namespace ODBC

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/odbc_descriptor.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/odbc_descriptor.h
@@ -38,40 +38,40 @@ class ODBCStatement;
 
 namespace ODBC {
 struct DescriptorRecord {
-  std::string m_base_column_name;
-  std::string m_base_table_name;
-  std::string m_catalog_name;
-  std::string m_label;
-  std::string m_literal_prefix;
-  std::string m_literal_suffix;
-  std::string m_local_type_name;
-  std::string m_name;
-  std::string m_schema_name;
-  std::string m_table_name;
-  std::string m_type_name;
-  SQLPOINTER m_data_ptr = NULL;
-  SQLLEN* m_indicator_ptr = NULL;
-  SQLLEN m_display_size = 0;
-  SQLLEN m_octet_length = 0;
-  SQLULEN m_length = 0;
-  SQLINTEGER m_auto_unique_value;
-  SQLINTEGER m_case_sensitive = SQL_TRUE;
-  SQLINTEGER m_datetime_interval_precision = 0;
-  SQLINTEGER m_num_prec_radix = 0;
-  SQLSMALLINT m_concise_type = SQL_C_DEFAULT;
-  SQLSMALLINT m_datetime_interval_code = 0;
-  SQLSMALLINT m_fixed_prec_scale = 0;
-  SQLSMALLINT m_nullable = SQL_NULLABLE_UNKNOWN;
-  SQLSMALLINT m_param_type = SQL_PARAM_INPUT;
-  SQLSMALLINT m_precision = 0;
-  SQLSMALLINT m_row_ver = 0;
-  SQLSMALLINT m_scale = 0;
-  SQLSMALLINT m_searchable = SQL_SEARCHABLE;
-  SQLSMALLINT m_type = SQL_C_DEFAULT;
-  SQLSMALLINT m_unnamed = SQL_TRUE;
-  SQLSMALLINT m_unsigned = SQL_FALSE;
-  SQLSMALLINT m_updatable = SQL_FALSE;
-  bool m_is_bound = false;
+  std::string base_column_name;
+  std::string base_table_name;
+  std::string catalog_name;
+  std::string label;
+  std::string literal_prefix;
+  std::string literal_suffix;
+  std::string local_type_name;
+  std::string name;
+  std::string schema_name;
+  std::string table_name;
+  std::string type_name;
+  SQLPOINTER data_ptr = NULL;
+  SQLLEN* indicator_ptr = NULL;
+  SQLLEN display_size = 0;
+  SQLLEN octet_length = 0;
+  SQLULEN length = 0;
+  SQLINTEGER auto_unique_value;
+  SQLINTEGER case_sensitive = SQL_TRUE;
+  SQLINTEGER datetime_interval_precision = 0;
+  SQLINTEGER num_prec_radix = 0;
+  SQLSMALLINT concise_type = SQL_C_DEFAULT;
+  SQLSMALLINT datetime_interval_code = 0;
+  SQLSMALLINT fixed_prec_scale = 0;
+  SQLSMALLINT nullable = SQL_NULLABLE_UNKNOWN;
+  SQLSMALLINT param_type = SQL_PARAM_INPUT;
+  SQLSMALLINT precision = 0;
+  SQLSMALLINT row_ver = 0;
+  SQLSMALLINT scale = 0;
+  SQLSMALLINT searchable = SQL_SEARCHABLE;
+  SQLSMALLINT type = SQL_C_DEFAULT;
+  SQLSMALLINT unnamed = SQL_TRUE;
+  SQLSMALLINT is_unsigned = SQL_FALSE;
+  SQLSMALLINT updatable = SQL_FALSE;
+  bool is_bound = false;
 
   void CheckConsistency();
 };
@@ -100,7 +100,7 @@ class ODBCDescriptor : public ODBCHandle<ODBCDescriptor> {
   SQLSMALLINT GetAllocType() const;
   bool IsAppDescriptor() const;
 
-  inline bool HaveBindingsChanged() const { return m_has_bindings_changed; }
+  inline bool HaveBindingsChanged() const { return has_bindings_changed_; }
 
   void RegisterToStatement(ODBCStatement* statement, bool is_apd);
   void DetachFromStatement(ODBCStatement* statement, bool is_apd);
@@ -115,45 +115,45 @@ class ODBCDescriptor : public ODBCHandle<ODBCDescriptor> {
                SQLLEN buffer_length, SQLLEN* indicator_ptr);
   void SetDataPtrOnRecord(SQLPOINTER data_ptr, SQLSMALLINT rec_number);
 
-  inline SQLULEN GetBindOffset() { return m_bind_offset_ptr ? *m_bind_offset_ptr : 0UL; }
+  inline SQLULEN GetBindOffset() { return bind_offset_ptr_ ? *bind_offset_ptr_ : 0UL; }
 
   inline SQLULEN GetBoundStructOffset() {
-    // If this is SQL_BIND_BY_COLUMN, m_bind_type is zero which indicates no offset due to
+    // If this is SQL_BIND_BY_COLUMN, bind_type_ is zero which indicates no offset due to
     // use of a bound struct. If this is non-zero, row-wise binding is being used so the
     // app should set this to sizeof(their struct).
-    return m_bind_type;
+    return bind_type_;
   }
 
-  inline SQLULEN GetArraySize() { return m_array_size; }
+  inline SQLULEN GetArraySize() { return array_size_; }
 
-  inline SQLUSMALLINT* GetArrayStatusPtr() { return m_array_status_ptr; }
+  inline SQLUSMALLINT* GetArrayStatusPtr() { return array_status_ptr_; }
 
   inline void SetRowsProcessed(SQLULEN rows) {
-    if (m_rows_proccessed_ptr) {
-      *m_rows_proccessed_ptr = rows;
+    if (rows_processed_ptr_) {
+      *rows_processed_ptr_ = rows;
     }
   }
 
-  inline void NotifyBindingsHavePropagated() { m_has_bindings_changed = false; }
+  inline void NotifyBindingsHavePropagated() { has_bindings_changed_ = false; }
 
-  inline void NotifyBindingsHaveChanged() { m_has_bindings_changed = true; }
+  inline void NotifyBindingsHaveChanged() { has_bindings_changed_ = true; }
 
  private:
-  driver::odbcabstraction::Diagnostics m_diagnostics;
-  std::vector<ODBCStatement*> m_registered_on_statements_as_apd;
-  std::vector<ODBCStatement*> m_registered_on_statements_as_ard;
-  std::vector<DescriptorRecord> m_records;
-  ODBCConnection* m_owning_connection;
-  ODBCStatement* m_parent_statement;
-  SQLUSMALLINT* m_array_status_ptr;
-  SQLULEN* m_bind_offset_ptr;
-  SQLULEN* m_rows_proccessed_ptr;
-  SQLULEN m_array_size;
-  SQLINTEGER m_bind_type;
-  SQLSMALLINT m_highest_one_based_bound_record;
-  const bool m_is_2x_connection;
-  bool m_is_app_descriptor;
-  bool m_is_writable;
-  bool m_has_bindings_changed;
+  driver::odbcabstraction::Diagnostics diagnostics_;
+  std::vector<ODBCStatement*> registered_on_statements_as_apd_;
+  std::vector<ODBCStatement*> registered_on_statements_as_ard_;
+  std::vector<DescriptorRecord> records_;
+  ODBCConnection* owning_connection_;
+  ODBCStatement* parent_statement_;
+  SQLUSMALLINT* array_status_ptr_;
+  SQLULEN* bind_offset_ptr_;
+  SQLULEN* rows_processed_ptr_;
+  SQLULEN array_size_;
+  SQLINTEGER bind_type_;
+  SQLSMALLINT highest_one_based_bound_record_;
+  const bool is_2x_connection_;
+  bool is_app_descriptor_;
+  bool is_writable_;
+  bool has_bindings_changed_;
 };
 }  // namespace ODBC

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/odbc_environment.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/odbc_environment.h
@@ -50,11 +50,11 @@ class ODBCEnvironment : public ODBCHandle<ODBCEnvironment> {
   ~ODBCEnvironment() = default;
 
  private:
-  std::vector<std::shared_ptr<ODBCConnection> > m_connections;
-  std::shared_ptr<driver::odbcabstraction::Driver> m_driver;
-  std::unique_ptr<driver::odbcabstraction::Diagnostics> m_diagnostics;
-  SQLINTEGER m_version;
-  SQLINTEGER m_connection_pooling;
+  std::vector<std::shared_ptr<ODBCConnection> > connections_;
+  std::shared_ptr<driver::odbcabstraction::Driver> driver_;
+  std::unique_ptr<driver::odbcabstraction::Diagnostics> diagnostics_;
+  SQLINTEGER version_;
+  SQLINTEGER connection_pooling_;
 };
 
 }  // namespace ODBC

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/odbc_environment.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/odbc_environment.h
@@ -40,11 +40,11 @@ namespace ODBC {
 class ODBCEnvironment : public ODBCHandle<ODBCEnvironment> {
  public:
   explicit ODBCEnvironment(std::shared_ptr<driver::odbcabstraction::Driver> driver);
-  driver::odbcabstraction::Diagnostics& GetDiagnostics_Impl();
-  SQLINTEGER getODBCVersion() const;
-  void setODBCVersion(SQLINTEGER version);
-  SQLINTEGER getConnectionPooling() const;
-  void setConnectionPooling(SQLINTEGER pooling);
+  driver::odbcabstraction::Diagnostics& GetDiagnosticsImpl();
+  SQLINTEGER GetODBCVersion() const;
+  void SetODBCVersion(SQLINTEGER version);
+  SQLINTEGER GetConnectionPooling() const;
+  void SetConnectionPooling(SQLINTEGER pooling);
   std::shared_ptr<ODBCConnection> CreateConnection();
   void DropConnection(ODBCConnection* conn);
   ~ODBCEnvironment() = default;
@@ -54,7 +54,7 @@ class ODBCEnvironment : public ODBCHandle<ODBCEnvironment> {
   std::shared_ptr<driver::odbcabstraction::Driver> m_driver;
   std::unique_ptr<driver::odbcabstraction::Diagnostics> m_diagnostics;
   SQLINTEGER m_version;
-  SQLINTEGER m_connectionPooling;
+  SQLINTEGER m_connection_pooling;
 };
 
 }  // namespace ODBC

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/odbc_handle.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/odbc_handle.h
@@ -33,15 +33,15 @@ template <typename Derived>
 class ODBCHandle {
  public:
   inline driver::odbcabstraction::Diagnostics& GetDiagnostics() {
-    return static_cast<Derived*>(this)->GetDiagnostics_Impl();
+    return static_cast<Derived*>(this)->GetDiagnosticsImpl();
   }
 
-  inline driver::odbcabstraction::Diagnostics& GetDiagnostics_Impl() {
+  inline driver::odbcabstraction::Diagnostics& GetDiagnosticsImpl() {
     throw std::runtime_error("Illegal state -- diagnostics requested on invalid handle");
   }
 
   template <typename Function>
-  inline SQLRETURN execute(SQLRETURN rc, Function function) {
+  inline SQLRETURN Execute(SQLRETURN rc, Function function) {
     try {
       GetDiagnostics().Clear();
       rc = function();
@@ -67,9 +67,9 @@ class ODBCHandle {
   }
 
   template <typename Function>
-  inline SQLRETURN executeWithLock(SQLRETURN rc, Function function) {
+  inline SQLRETURN ExecuteWithLock(SQLRETURN rc, Function function) {
     const std::lock_guard<std::mutex> lock(mtx_);
-    return execute(rc, function);
+    return Execute(rc, function);
   }
 
   template <typename Function, bool SHOULD_LOCK = true>
@@ -79,13 +79,13 @@ class ODBCHandle {
       return SQL_INVALID_HANDLE;
     }
     if (SHOULD_LOCK) {
-      return reinterpret_cast<Derived*>(handle)->executeWithLock(rc, func);
+      return reinterpret_cast<Derived*>(handle)->ExecuteWithLock(rc, func);
     } else {
-      return reinterpret_cast<Derived*>(handle)->execute(rc, func);
+      return reinterpret_cast<Derived*>(handle)->Execute(rc, func);
     }
   }
 
-  static Derived* of(SQLHANDLE handle) { return reinterpret_cast<Derived*>(handle); }
+  static Derived* Of(SQLHANDLE handle) { return reinterpret_cast<Derived*>(handle); }
 
  private:
   std::mutex mtx_;

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/odbc_statement.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/odbc_statement.h
@@ -52,7 +52,7 @@ class ODBCStatement : public ODBCHandle<ODBCStatement> {
   ~ODBCStatement() = default;
 
   inline driver::odbcabstraction::Diagnostics& GetDiagnosticsImpl() {
-    return *m_diagnostics;
+    return *diagnostics_;
   }
 
   ODBCConnection& GetConnection();
@@ -75,11 +75,11 @@ class ODBCStatement : public ODBCHandle<ODBCStatement> {
 
   void RevertAppDescriptor(bool is_apd);
 
-  inline ODBCDescriptor* GetIRD() { return m_ird.get(); }
+  inline ODBCDescriptor* GetIRD() { return ird_.get(); }
 
-  inline ODBCDescriptor* GetARD() { return m_current_ard; }
+  inline ODBCDescriptor* GetARD() { return current_ard_; }
 
-  inline SQLULEN GetRowsetSize() { return m_rowset_size; }
+  inline SQLULEN GetRowsetSize() { return rowset_size_; }
 
   bool GetData(SQLSMALLINT record_number, SQLSMALLINT c_type, SQLPOINTER data_ptr,
                SQLLEN buffer_length, SQLLEN* indicator_ptr);
@@ -103,21 +103,21 @@ class ODBCStatement : public ODBCHandle<ODBCStatement> {
   void Cancel();
 
  private:
-  ODBCConnection& m_connection;
-  std::shared_ptr<driver::odbcabstraction::Statement> m_spi_statement;
-  std::shared_ptr<driver::odbcabstraction::ResultSet> m_current_result;
-  driver::odbcabstraction::Diagnostics* m_diagnostics;
+  ODBCConnection& connection_;
+  std::shared_ptr<driver::odbcabstraction::Statement> spi_statement_;
+  std::shared_ptr<driver::odbcabstraction::ResultSet> current_result_;
+  driver::odbcabstraction::Diagnostics* diagnostics_;
 
-  std::shared_ptr<ODBCDescriptor> m_built_in_ard;
-  std::shared_ptr<ODBCDescriptor> m_built_in_apd;
-  std::shared_ptr<ODBCDescriptor> m_ipd;
-  std::shared_ptr<ODBCDescriptor> m_ird;
-  ODBCDescriptor* m_current_ard;
-  ODBCDescriptor* m_current_apd;
-  SQLULEN m_row_number;
-  SQLULEN m_max_rows;
-  SQLULEN m_rowset_size;  // Used by SQLExtendedFetch instead of the ARD array size.
-  bool m_is_prepared;
-  bool m_has_reached_end_of_result;
+  std::shared_ptr<ODBCDescriptor> built_in_ard_;
+  std::shared_ptr<ODBCDescriptor> built_in_apd_;
+  std::shared_ptr<ODBCDescriptor> ipd_;
+  std::shared_ptr<ODBCDescriptor> ird_;
+  ODBCDescriptor* current_ard_;
+  ODBCDescriptor* current_apd_;
+  SQLULEN row_number_;
+  SQLULEN max_rows_;
+  SQLULEN rowset_size_;  // Used by SQLExtendedFetch instead of the ARD array size.
+  bool is_prepared_;
+  bool has_reached_end_of_result_;
 };
 }  // namespace ODBC

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/odbc_statement.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/odbc_statement.h
@@ -47,11 +47,11 @@ class ODBCStatement : public ODBCHandle<ODBCStatement> {
   ODBCStatement& operator=(const ODBCStatement&) = delete;
 
   ODBCStatement(ODBCConnection& connection,
-                std::shared_ptr<driver::odbcabstraction::Statement> spiStatement);
+                std::shared_ptr<driver::odbcabstraction::Statement> spi_statement);
 
   ~ODBCStatement() = default;
 
-  inline driver::odbcabstraction::Diagnostics& GetDiagnostics_Impl() {
+  inline driver::odbcabstraction::Diagnostics& GetDiagnosticsImpl() {
     return *m_diagnostics;
   }
 
@@ -66,58 +66,58 @@ class ODBCStatement : public ODBCHandle<ODBCStatement> {
    * @brief Returns true if the number of rows fetch was greater than zero.
    */
   bool Fetch(size_t rows);
-  bool isPrepared() const;
+  bool IsPrepared() const;
 
-  void GetStmtAttr(SQLINTEGER statementAttribute, SQLPOINTER output,
-                   SQLINTEGER bufferSize, SQLINTEGER* strLenPtr, bool isUnicode);
-  void SetStmtAttr(SQLINTEGER statementAttribute, SQLPOINTER value, SQLINTEGER bufferSize,
-                   bool isUnicode);
+  void GetStmtAttr(SQLINTEGER statement_attribute, SQLPOINTER output,
+                   SQLINTEGER buffer_size, SQLINTEGER* str_len_ptr, bool is_unicode);
+  void SetStmtAttr(SQLINTEGER statement_attribute, SQLPOINTER value,
+                   SQLINTEGER buffer_size, bool is_unicode);
 
-  void RevertAppDescriptor(bool isApd);
+  void RevertAppDescriptor(bool is_apd);
 
   inline ODBCDescriptor* GetIRD() { return m_ird.get(); }
 
-  inline ODBCDescriptor* GetARD() { return m_currentArd; }
+  inline ODBCDescriptor* GetARD() { return m_current_ard; }
 
-  inline SQLULEN GetRowsetSize() { return m_rowsetSize; }
+  inline SQLULEN GetRowsetSize() { return m_rowset_size; }
 
-  bool GetData(SQLSMALLINT recordNumber, SQLSMALLINT cType, SQLPOINTER dataPtr,
-               SQLLEN bufferLength, SQLLEN* indicatorPtr);
+  bool GetData(SQLSMALLINT record_number, SQLSMALLINT c_type, SQLPOINTER data_ptr,
+               SQLLEN buffer_length, SQLLEN* indicator_ptr);
 
   /**
    * @brief Closes the cursor. This does _not_ un-prepare the statement or change
    * bindings.
    */
-  void closeCursor(bool suppressErrors);
+  void CloseCursor(bool suppress_errors);
 
   /**
    * @brief Releases this statement from memory.
    */
-  void releaseStatement();
+  void ReleaseStatement();
 
   void GetTables(const std::string* catalog, const std::string* schema,
-                 const std::string* table, const std::string* tableType);
+                 const std::string* table, const std::string* table_type);
   void GetColumns(const std::string* catalog, const std::string* schema,
                   const std::string* table, const std::string* column);
-  void GetTypeInfo(SQLSMALLINT dataType);
+  void GetTypeInfo(SQLSMALLINT data_type);
   void Cancel();
 
  private:
   ODBCConnection& m_connection;
-  std::shared_ptr<driver::odbcabstraction::Statement> m_spiStatement;
-  std::shared_ptr<driver::odbcabstraction::ResultSet> m_currenResult;
+  std::shared_ptr<driver::odbcabstraction::Statement> m_spi_statement;
+  std::shared_ptr<driver::odbcabstraction::ResultSet> m_current_result;
   driver::odbcabstraction::Diagnostics* m_diagnostics;
 
-  std::shared_ptr<ODBCDescriptor> m_builtInArd;
-  std::shared_ptr<ODBCDescriptor> m_builtInApd;
+  std::shared_ptr<ODBCDescriptor> m_built_in_ard;
+  std::shared_ptr<ODBCDescriptor> m_built_in_apd;
   std::shared_ptr<ODBCDescriptor> m_ipd;
   std::shared_ptr<ODBCDescriptor> m_ird;
-  ODBCDescriptor* m_currentArd;
-  ODBCDescriptor* m_currentApd;
-  SQLULEN m_rowNumber;
-  SQLULEN m_maxRows;
-  SQLULEN m_rowsetSize;  // Used by SQLExtendedFetch instead of the ARD array size.
-  bool m_isPrepared;
-  bool m_hasReachedEndOfResult;
+  ODBCDescriptor* m_current_ard;
+  ODBCDescriptor* m_current_apd;
+  SQLULEN m_row_number;
+  SQLULEN m_max_rows;
+  SQLULEN m_rowset_size;  // Used by SQLExtendedFetch instead of the ARD array size.
+  bool m_is_prepared;
+  bool m_has_reached_end_of_result;
 };
 }  // namespace ODBC

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/type_utilities.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/odbc_impl/type_utilities.h
@@ -21,19 +21,19 @@
 #include <sqlext.h>
 
 namespace ODBC {
-inline SQLSMALLINT GetSqlTypeForODBCVersion(SQLSMALLINT type, bool isOdbc2x) {
+inline SQLSMALLINT GetSqlTypeForODBCVersion(SQLSMALLINT type, bool is_odbc_2x) {
   switch (type) {
     case SQL_DATE:
     case SQL_TYPE_DATE:
-      return isOdbc2x ? SQL_DATE : SQL_TYPE_DATE;
+      return is_odbc_2x ? SQL_DATE : SQL_TYPE_DATE;
 
     case SQL_TIME:
     case SQL_TYPE_TIME:
-      return isOdbc2x ? SQL_TIME : SQL_TYPE_TIME;
+      return is_odbc_2x ? SQL_TIME : SQL_TYPE_TIME;
 
     case SQL_TIMESTAMP:
     case SQL_TYPE_TIMESTAMP:
-      return isOdbc2x ? SQL_TIMESTAMP : SQL_TYPE_TIMESTAMP;
+      return is_odbc_2x ? SQL_TIMESTAMP : SQL_TYPE_TIMESTAMP;
 
     default:
       return type;

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/types.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/types.h
@@ -172,9 +172,9 @@ enum RowStatus : uint16_t {
 };
 
 struct MetadataSettings {
-  boost::optional<int32_t> string_column_length_{boost::none};
-  size_t chunk_buffer_capacity_;
-  bool use_wide_char_;
+  boost::optional<int32_t> string_column_length{boost::none};
+  size_t chunk_buffer_capacity;
+  bool use_wide_char;
 };
 
 }  // namespace odbcabstraction

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/utils.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/utils.h
@@ -32,22 +32,22 @@ boost::optional<bool> AsBool(const std::string& value);
 
 /// Looks up for a value inside the ConnPropertyMap and then try to parse it.
 /// In case it does not find or it cannot parse, the default value will be returned.
-/// \param connPropertyMap    the map with the connection properties.
+/// \param conn_property_map    the map with the connection properties.
 /// \param property_name      the name of the property that will be looked up.
 /// \return                   the parsed valued.
-boost::optional<bool> AsBool(const Connection::ConnPropertyMap& connPropertyMap,
+boost::optional<bool> AsBool(const Connection::ConnPropertyMap& conn_property_map,
                              const std::string_view& property_name);
 
 /// Looks up for a value inside the ConnPropertyMap and then try to parse it.
 /// In case it does not find or it cannot parse, the default value will be returned.
 /// \param min_value                    the minimum value to be parsed, else the default
-/// value is returned. \param connPropertyMap              the map with the connection
+/// value is returned. \param conn_property_map              the map with the connection
 /// properties. \param property_name                the name of the property that will be
 /// looked up. \return                             the parsed valued. \exception
 /// std::invalid_argument    exception from std::stoi \exception
 /// std::out_of_range        exception from std::stoi
 boost::optional<int32_t> AsInt32(int32_t min_value,
-                                 const Connection::ConnPropertyMap& connPropertyMap,
+                                 const Connection::ConnPropertyMap& conn_property_map,
                                  const std::string_view& property_name);
 }  // namespace odbcabstraction
 }  // namespace driver

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/odbc_impl/odbc_connection.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/odbc_impl/odbc_connection.cc
@@ -103,179 +103,179 @@ void loadPropertiesFromDSN(const std::string& dsn,
 // Public
 // =========================================================================================
 ODBCConnection::ODBCConnection(ODBCEnvironment& environment,
-                               std::shared_ptr<Connection> spiConnection)
+                               std::shared_ptr<Connection> spi_connection)
     : m_environment(environment),
-      m_spiConnection(std::move(spiConnection)),
-      m_is2xConnection(environment.getODBCVersion() == SQL_OV_ODBC2),
-      m_isConnected(false) {}
+      m_spi_connection(std::move(spi_connection)),
+      m_is_2x_connection(environment.GetODBCVersion() == SQL_OV_ODBC2),
+      m_is_connected(false) {}
 
-Diagnostics& ODBCConnection::GetDiagnostics_Impl() {
-  return m_spiConnection->GetDiagnostics();
+Diagnostics& ODBCConnection::GetDiagnosticsImpl() {
+  return m_spi_connection->GetDiagnostics();
 }
 
-bool ODBCConnection::isConnected() const { return m_isConnected; }
+bool ODBCConnection::IsConnected() const { return m_is_connected; }
 
 const std::string& ODBCConnection::GetDSN() const { return m_dsn; }
 
-void ODBCConnection::connect(std::string dsn,
+void ODBCConnection::Connect(std::string dsn,
                              const Connection::ConnPropertyMap& properties,
                              std::vector<std::string_view>& missing_properties) {
-  if (m_isConnected) {
+  if (m_is_connected) {
     throw DriverException("Already connected.", "HY010");
   }
 
   m_dsn = std::move(dsn);
-  m_spiConnection->Connect(properties, missing_properties);
-  m_isConnected = true;
-  std::shared_ptr<Statement> spiStatement = m_spiConnection->CreateStatement();
-  m_attributeTrackingStatement = std::make_shared<ODBCStatement>(*this, spiStatement);
+  m_spi_connection->Connect(properties, missing_properties);
+  m_is_connected = true;
+  std::shared_ptr<Statement> spi_statement = m_spi_connection->CreateStatement();
+  m_attribute_tracking_statement = std::make_shared<ODBCStatement>(*this, spi_statement);
 }
 
-void ODBCConnection::GetInfo(SQLUSMALLINT infoType, SQLPOINTER value,
-                             SQLSMALLINT bufferLength, SQLSMALLINT* outputLength,
-                             bool isUnicode) {
-  switch (infoType) {
+void ODBCConnection::GetInfo(SQLUSMALLINT info_type, SQLPOINTER value,
+                             SQLSMALLINT buffer_length, SQLSMALLINT* output_length,
+                             bool is_unicode) {
+  switch (info_type) {
     case SQL_ACTIVE_ENVIRONMENTS:
-      GetAttribute(static_cast<SQLUSMALLINT>(0), value, bufferLength, outputLength);
+      GetAttribute(static_cast<SQLUSMALLINT>(0), value, buffer_length, output_length);
       break;
 #ifdef SQL_ASYNC_DBC_FUNCTIONS
     case SQL_ASYNC_DBC_FUNCTIONS:
       GetAttribute(static_cast<SQLUINTEGER>(SQL_ASYNC_DBC_NOT_CAPABLE), value,
-                   bufferLength, outputLength);
+                   buffer_length, output_length);
       break;
 #endif
     case SQL_ASYNC_MODE:
-      GetAttribute(static_cast<SQLUINTEGER>(SQL_AM_NONE), value, bufferLength,
-                   outputLength);
+      GetAttribute(static_cast<SQLUINTEGER>(SQL_AM_NONE), value, buffer_length,
+                   output_length);
       break;
 #ifdef SQL_ASYNC_NOTIFICATION
     case SQL_ASYNC_NOTIFICATION:
       GetAttribute(static_cast<SQLUINTEGER>(SQL_ASYNC_NOTIFICATION_NOT_CAPABLE), value,
-                   bufferLength, outputLength);
+                   buffer_length, output_length);
       break;
 #endif
     case SQL_BATCH_ROW_COUNT:
-      GetAttribute(static_cast<SQLUINTEGER>(0), value, bufferLength, outputLength);
+      GetAttribute(static_cast<SQLUINTEGER>(0), value, buffer_length, output_length);
       break;
     case SQL_BATCH_SUPPORT:
-      GetAttribute(static_cast<SQLUINTEGER>(0), value, bufferLength, outputLength);
+      GetAttribute(static_cast<SQLUINTEGER>(0), value, buffer_length, output_length);
       break;
     case SQL_DATA_SOURCE_NAME:
-      GetStringAttribute(isUnicode, m_dsn, true, value, bufferLength, outputLength,
+      GetStringAttribute(is_unicode, m_dsn, true, value, buffer_length, output_length,
                          GetDiagnostics());
       break;
     case SQL_DRIVER_ODBC_VER:
-      GetStringAttribute(isUnicode, "03.80", true, value, bufferLength, outputLength,
+      GetStringAttribute(is_unicode, "03.80", true, value, buffer_length, output_length,
                          GetDiagnostics());
       break;
     case SQL_DYNAMIC_CURSOR_ATTRIBUTES1:
-      GetAttribute(static_cast<SQLUINTEGER>(0), value, bufferLength, outputLength);
+      GetAttribute(static_cast<SQLUINTEGER>(0), value, buffer_length, output_length);
       break;
     case SQL_DYNAMIC_CURSOR_ATTRIBUTES2:
-      GetAttribute(static_cast<SQLUINTEGER>(0), value, bufferLength, outputLength);
+      GetAttribute(static_cast<SQLUINTEGER>(0), value, buffer_length, output_length);
       break;
     case SQL_FORWARD_ONLY_CURSOR_ATTRIBUTES1:
-      GetAttribute(static_cast<SQLUINTEGER>(SQL_CA1_NEXT), value, bufferLength,
-                   outputLength);
+      GetAttribute(static_cast<SQLUINTEGER>(SQL_CA1_NEXT), value, buffer_length,
+                   output_length);
       break;
     case SQL_FORWARD_ONLY_CURSOR_ATTRIBUTES2:
       GetAttribute(static_cast<SQLUINTEGER>(SQL_CA2_READ_ONLY_CONCURRENCY), value,
-                   bufferLength, outputLength);
+                   buffer_length, output_length);
       break;
     case SQL_FILE_USAGE:
-      GetAttribute(static_cast<SQLUSMALLINT>(SQL_FILE_NOT_SUPPORTED), value, bufferLength,
-                   outputLength);
+      GetAttribute(static_cast<SQLUSMALLINT>(SQL_FILE_NOT_SUPPORTED), value,
+                   buffer_length, output_length);
       break;
     case SQL_KEYSET_CURSOR_ATTRIBUTES1:
-      GetAttribute(static_cast<SQLUINTEGER>(0), value, bufferLength, outputLength);
+      GetAttribute(static_cast<SQLUINTEGER>(0), value, buffer_length, output_length);
       break;
     case SQL_KEYSET_CURSOR_ATTRIBUTES2:
-      GetAttribute(static_cast<SQLUINTEGER>(0), value, bufferLength, outputLength);
+      GetAttribute(static_cast<SQLUINTEGER>(0), value, buffer_length, output_length);
       break;
     case SQL_MAX_ASYNC_CONCURRENT_STATEMENTS:
-      GetAttribute(static_cast<SQLUINTEGER>(0), value, bufferLength, outputLength);
+      GetAttribute(static_cast<SQLUINTEGER>(0), value, buffer_length, output_length);
       break;
     case SQL_ODBC_INTERFACE_CONFORMANCE:
-      GetAttribute(static_cast<SQLUINTEGER>(SQL_OIC_CORE), value, bufferLength,
-                   outputLength);
+      GetAttribute(static_cast<SQLUINTEGER>(SQL_OIC_CORE), value, buffer_length,
+                   output_length);
       break;
     // case SQL_ODBC_STANDARD_CLI_CONFORMANCE: - mentioned in SQLGetInfo spec with no
     // description and there is no constant for this.
     case SQL_PARAM_ARRAY_ROW_COUNTS:
-      GetAttribute(static_cast<SQLUINTEGER>(SQL_PARC_NO_BATCH), value, bufferLength,
-                   outputLength);
+      GetAttribute(static_cast<SQLUINTEGER>(SQL_PARC_NO_BATCH), value, buffer_length,
+                   output_length);
       break;
     case SQL_PARAM_ARRAY_SELECTS:
-      GetAttribute(static_cast<SQLUINTEGER>(SQL_PAS_NO_SELECT), value, bufferLength,
-                   outputLength);
+      GetAttribute(static_cast<SQLUINTEGER>(SQL_PAS_NO_SELECT), value, buffer_length,
+                   output_length);
       break;
     case SQL_ROW_UPDATES:
-      GetStringAttribute(isUnicode, "N", true, value, bufferLength, outputLength,
+      GetStringAttribute(is_unicode, "N", true, value, buffer_length, output_length,
                          GetDiagnostics());
       break;
     case SQL_SCROLL_OPTIONS:
-      GetAttribute(static_cast<SQLUINTEGER>(SQL_SO_FORWARD_ONLY), value, bufferLength,
-                   outputLength);
+      GetAttribute(static_cast<SQLUINTEGER>(SQL_SO_FORWARD_ONLY), value, buffer_length,
+                   output_length);
       break;
     case SQL_STATIC_CURSOR_ATTRIBUTES1:
-      GetAttribute(static_cast<SQLUINTEGER>(0), value, bufferLength, outputLength);
+      GetAttribute(static_cast<SQLUINTEGER>(0), value, buffer_length, output_length);
       break;
     case SQL_STATIC_CURSOR_ATTRIBUTES2:
-      GetAttribute(static_cast<SQLUINTEGER>(0), value, bufferLength, outputLength);
+      GetAttribute(static_cast<SQLUINTEGER>(0), value, buffer_length, output_length);
       break;
     case SQL_BOOKMARK_PERSISTENCE:
-      GetAttribute(static_cast<SQLUINTEGER>(0), value, bufferLength, outputLength);
+      GetAttribute(static_cast<SQLUINTEGER>(0), value, buffer_length, output_length);
       break;
     case SQL_DESCRIBE_PARAMETER:
-      GetStringAttribute(isUnicode, "N", true, value, bufferLength, outputLength,
+      GetStringAttribute(is_unicode, "N", true, value, buffer_length, output_length,
                          GetDiagnostics());
       break;
     case SQL_MULT_RESULT_SETS:
-      GetStringAttribute(isUnicode, "N", true, value, bufferLength, outputLength,
+      GetStringAttribute(is_unicode, "N", true, value, buffer_length, output_length,
                          GetDiagnostics());
       break;
     case SQL_MULTIPLE_ACTIVE_TXN:
-      GetStringAttribute(isUnicode, "N", true, value, bufferLength, outputLength,
+      GetStringAttribute(is_unicode, "N", true, value, buffer_length, output_length,
                          GetDiagnostics());
       break;
     case SQL_NEED_LONG_DATA_LEN:
-      GetStringAttribute(isUnicode, "N", true, value, bufferLength, outputLength,
+      GetStringAttribute(is_unicode, "N", true, value, buffer_length, output_length,
                          GetDiagnostics());
       break;
     case SQL_TXN_CAPABLE:
-      GetAttribute(static_cast<SQLUSMALLINT>(SQL_TC_NONE), value, bufferLength,
-                   outputLength);
+      GetAttribute(static_cast<SQLUSMALLINT>(SQL_TC_NONE), value, buffer_length,
+                   output_length);
       break;
     case SQL_TXN_ISOLATION_OPTION:
-      GetAttribute(static_cast<SQLUINTEGER>(0), value, bufferLength, outputLength);
+      GetAttribute(static_cast<SQLUINTEGER>(0), value, buffer_length, output_length);
       break;
     case SQL_TABLE_TERM:
-      GetStringAttribute(isUnicode, "table", true, value, bufferLength, outputLength,
+      GetStringAttribute(is_unicode, "table", true, value, buffer_length, output_length,
                          GetDiagnostics());
       break;
     // Deprecated ODBC 2.x fields required for backwards compatibility.
     case SQL_ODBC_API_CONFORMANCE:
-      GetAttribute(static_cast<SQLUSMALLINT>(SQL_OAC_LEVEL1), value, bufferLength,
-                   outputLength);
+      GetAttribute(static_cast<SQLUSMALLINT>(SQL_OAC_LEVEL1), value, buffer_length,
+                   output_length);
       break;
     case SQL_FETCH_DIRECTION:
-      GetAttribute(static_cast<SQLINTEGER>(SQL_FETCH_NEXT), value, bufferLength,
-                   outputLength);
+      GetAttribute(static_cast<SQLINTEGER>(SQL_FETCH_NEXT), value, buffer_length,
+                   output_length);
       break;
     case SQL_LOCK_TYPES:
-      GetAttribute(static_cast<SQLINTEGER>(0), value, bufferLength, outputLength);
+      GetAttribute(static_cast<SQLINTEGER>(0), value, buffer_length, output_length);
       break;
     case SQL_POS_OPERATIONS:
-      GetAttribute(static_cast<SQLINTEGER>(0), value, bufferLength, outputLength);
+      GetAttribute(static_cast<SQLINTEGER>(0), value, buffer_length, output_length);
       break;
     case SQL_POSITIONED_STATEMENTS:
-      GetAttribute(static_cast<SQLINTEGER>(0), value, bufferLength, outputLength);
+      GetAttribute(static_cast<SQLINTEGER>(0), value, buffer_length, output_length);
       break;
     case SQL_SCROLL_CONCURRENCY:
-      GetAttribute(static_cast<SQLINTEGER>(0), value, bufferLength, outputLength);
+      GetAttribute(static_cast<SQLINTEGER>(0), value, buffer_length, output_length);
       break;
     case SQL_STATIC_SENSITIVITY:
-      GetAttribute(static_cast<SQLINTEGER>(0), value, bufferLength, outputLength);
+      GetAttribute(static_cast<SQLINTEGER>(0), value, buffer_length, output_length);
       break;
 
     // Driver-level string properties.
@@ -309,10 +309,10 @@ void ODBCConnection::GetInfo(SQLUSMALLINT infoType, SQLPOINTER value,
     case SQL_PROCEDURES:
     case SQL_SPECIAL_CHARACTERS:
     case SQL_XOPEN_CLI_YEAR: {
-      const auto& info = m_spiConnection->GetInfo(infoType);
-      const std::string& infoValue = boost::get<std::string>(info);
-      GetStringAttribute(isUnicode, infoValue, true, value, bufferLength, outputLength,
-                         GetDiagnostics());
+      const auto& info = m_spi_connection->GetInfo(info_type);
+      const std::string& info_value = boost::get<std::string>(info);
+      GetStringAttribute(is_unicode, info_value, true, value, buffer_length,
+                         output_length, GetDiagnostics());
       break;
     }
 
@@ -400,9 +400,9 @@ void ODBCConnection::GetInfo(SQLUSMALLINT infoType, SQLPOINTER value,
     case SQL_SQL92_STRING_FUNCTIONS:
     case SQL_SQL92_VALUE_EXPRESSIONS:
     case SQL_STANDARD_CLI_CONFORMANCE: {
-      const auto& info = m_spiConnection->GetInfo(infoType);
-      uint32_t infoValue = boost::get<uint32_t>(info);
-      GetAttribute(infoValue, value, bufferLength, outputLength);
+      const auto& info = m_spi_connection->GetInfo(info_type);
+      uint32_t info_value = boost::get<uint32_t>(info);
+      GetAttribute(info_value, value, buffer_length, output_length);
       break;
     }
 
@@ -435,31 +435,31 @@ void ODBCConnection::GetInfo(SQLUSMALLINT infoType, SQLPOINTER value,
     case SQL_MAX_USER_NAME_LEN:
     case SQL_ODBC_SQL_CONFORMANCE:
     case SQL_ODBC_SAG_CLI_CONFORMANCE: {
-      const auto& info = m_spiConnection->GetInfo(infoType);
-      uint16_t infoValue = boost::get<uint16_t>(info);
-      GetAttribute(infoValue, value, bufferLength, outputLength);
+      const auto& info = m_spi_connection->GetInfo(info_type);
+      uint16_t info_value = boost::get<uint16_t>(info);
+      GetAttribute(info_value, value, buffer_length, output_length);
       break;
     }
 
     // Special case - SQL_DATABASE_NAME is an alias for SQL_ATTR_CURRENT_CATALOG.
     case SQL_DATABASE_NAME: {
-      const auto& attr = m_spiConnection->GetAttribute(Connection::CURRENT_CATALOG);
+      const auto& attr = m_spi_connection->GetAttribute(Connection::CURRENT_CATALOG);
       if (!attr) {
         throw DriverException("Optional feature not supported.", "HYC00");
       }
-      const std::string& infoValue = boost::get<std::string>(*attr);
-      GetStringAttribute(isUnicode, infoValue, true, value, bufferLength, outputLength,
-                         GetDiagnostics());
+      const std::string& info_value = boost::get<std::string>(*attr);
+      GetStringAttribute(is_unicode, info_value, true, value, buffer_length,
+                         output_length, GetDiagnostics());
       break;
     }
     default:
-      throw DriverException("Unknown SQLGetInfo type: " + std::to_string(infoType));
+      throw DriverException("Unknown SQLGetInfo type: " + std::to_string(info_type));
   }
 }
 
 void ODBCConnection::SetConnectAttr(SQLINTEGER attribute, SQLPOINTER value,
-                                    SQLINTEGER stringLength, bool isUnicode) {
-  uint32_t attributeToWrite = 0;
+                                    SQLINTEGER string_length, bool is_unicode) {
+  uint32_t attribute_to_write = 0;
   bool successfully_written = false;
   switch (attribute) {
     // Internal connection attributes
@@ -511,12 +511,12 @@ void ODBCConnection::SetConnectAttr(SQLINTEGER attribute, SQLPOINTER value,
     // ODBCAbstraction-level attributes
     case SQL_ATTR_CURRENT_CATALOG: {
       std::string catalog;
-      if (isUnicode) {
-        SetAttributeUTF8(value, stringLength, catalog);
+      if (is_unicode) {
+        SetAttributeUTF8(value, string_length, catalog);
       } else {
-        SetAttributeSQLWCHAR(value, stringLength, catalog);
+        SetAttributeSQLWCHAR(value, string_length, catalog);
       }
-      if (!m_spiConnection->SetAttribute(Connection::CURRENT_CATALOG, catalog)) {
+      if (!m_spi_connection->SetAttribute(Connection::CURRENT_CATALOG, catalog)) {
         throw DriverException("Option value changed.", "01S02");
       }
       return;
@@ -539,29 +539,29 @@ void ODBCConnection::SetConnectAttr(SQLINTEGER attribute, SQLPOINTER value,
     case SQL_ATTR_ROW_BIND_TYPE:
     case SQL_ATTR_SIMULATE_CURSOR:
     case SQL_ATTR_USE_BOOKMARKS:
-      m_attributeTrackingStatement->SetStmtAttr(attribute, value, stringLength,
-                                                isUnicode);
+      m_attribute_tracking_statement->SetStmtAttr(attribute, value, string_length,
+                                                  is_unicode);
       return;
 
     case SQL_ATTR_ACCESS_MODE:
-      SetAttribute(value, attributeToWrite);
+      SetAttribute(value, attribute_to_write);
       successfully_written =
-          m_spiConnection->SetAttribute(Connection::ACCESS_MODE, attributeToWrite);
+          m_spi_connection->SetAttribute(Connection::ACCESS_MODE, attribute_to_write);
       break;
     case SQL_ATTR_CONNECTION_TIMEOUT:
-      SetAttribute(value, attributeToWrite);
-      successfully_written =
-          m_spiConnection->SetAttribute(Connection::CONNECTION_TIMEOUT, attributeToWrite);
+      SetAttribute(value, attribute_to_write);
+      successfully_written = m_spi_connection->SetAttribute(
+          Connection::CONNECTION_TIMEOUT, attribute_to_write);
       break;
     case SQL_ATTR_LOGIN_TIMEOUT:
-      SetAttribute(value, attributeToWrite);
+      SetAttribute(value, attribute_to_write);
       successfully_written =
-          m_spiConnection->SetAttribute(Connection::LOGIN_TIMEOUT, attributeToWrite);
+          m_spi_connection->SetAttribute(Connection::LOGIN_TIMEOUT, attribute_to_write);
       break;
     case SQL_ATTR_PACKET_SIZE:
-      SetAttribute(value, attributeToWrite);
+      SetAttribute(value, attribute_to_write);
       successfully_written =
-          m_spiConnection->SetAttribute(Connection::PACKET_SIZE, attributeToWrite);
+          m_spi_connection->SetAttribute(Connection::PACKET_SIZE, attribute_to_write);
       break;
     default:
       throw DriverException("Invalid attribute: " + std::to_string(attribute), "HY092");
@@ -574,57 +574,57 @@ void ODBCConnection::SetConnectAttr(SQLINTEGER attribute, SQLPOINTER value,
 }
 
 void ODBCConnection::GetConnectAttr(SQLINTEGER attribute, SQLPOINTER value,
-                                    SQLINTEGER bufferLength, SQLINTEGER* outputLength,
-                                    bool isUnicode) {
+                                    SQLINTEGER buffer_length, SQLINTEGER* output_length,
+                                    bool is_unicode) {
   using driver::odbcabstraction::Connection;
-  boost::optional<Connection::Attribute> spiAttribute;
+  boost::optional<Connection::Attribute> spi_attribute;
 
   switch (attribute) {
     // Internal connection attributes
 #ifdef SQL_ATR_ASYNC_DBC_EVENT
     case SQL_ATTR_ASYNC_DBC_EVENT:
-      GetAttribute(static_cast<SQLPOINTER>(NULL), value, bufferLength, outputLength);
+      GetAttribute(static_cast<SQLPOINTER>(NULL), value, buffer_length, output_length);
       return;
 #endif
 #ifdef SQL_ATTR_ASYNC_DBC_FUNCTIONS_ENABLE
     case SQL_ATTR_ASYNC_DBC_FUNCTIONS_ENABLE:
       GetAttribute(static_cast<SQLUINTEGER>(SQL_ASYNC_DBC_ENABLE_OFF), value,
-                   bufferLength, outputLength);
+                   buffer_length, output_length);
       return;
 #endif
 #ifdef SQL_ATTR_ASYNC_PCALLBACK
     case SQL_ATTR_ASYNC_DBC_PCALLBACK:
-      GetAttribute(static_cast<SQLPOINTER>(NULL), value, bufferLength, outputLength);
+      GetAttribute(static_cast<SQLPOINTER>(NULL), value, buffer_length, output_length);
       return;
 #endif
 #ifdef SQL_ATTR_ASYNC_DBC_PCONTEXT
     case SQL_ATTR_ASYNC_DBC_PCONTEXT:
-      GetAttribute(static_cast<SQLPOINTER>(NULL), value, bufferLength, outputLength);
+      GetAttribute(static_cast<SQLPOINTER>(NULL), value, buffer_length, output_length);
       return;
 #endif
     case SQL_ATTR_ASYNC_ENABLE:
-      GetAttribute(static_cast<SQLULEN>(SQL_ASYNC_ENABLE_OFF), value, bufferLength,
-                   outputLength);
+      GetAttribute(static_cast<SQLULEN>(SQL_ASYNC_ENABLE_OFF), value, buffer_length,
+                   output_length);
       return;
     case SQL_ATTR_AUTO_IPD:
-      GetAttribute(static_cast<SQLUINTEGER>(SQL_FALSE), value, bufferLength,
-                   outputLength);
+      GetAttribute(static_cast<SQLUINTEGER>(SQL_FALSE), value, buffer_length,
+                   output_length);
       return;
     case SQL_ATTR_AUTOCOMMIT:
-      GetAttribute(static_cast<SQLUINTEGER>(SQL_AUTOCOMMIT_ON), value, bufferLength,
-                   outputLength);
+      GetAttribute(static_cast<SQLUINTEGER>(SQL_AUTOCOMMIT_ON), value, buffer_length,
+                   output_length);
       return;
 #ifdef SQL_ATTR_DBC_INFO_TOKEN
     case SQL_ATTR_DBC_INFO_TOKEN:
       throw DriverException("Cannot read set-only attribute", "HY092");
 #endif
     case SQL_ATTR_ENLIST_IN_DTC:
-      GetAttribute(static_cast<SQLPOINTER>(NULL), value, bufferLength, outputLength);
+      GetAttribute(static_cast<SQLPOINTER>(NULL), value, buffer_length, output_length);
       return;
     case SQL_ATTR_ODBC_CURSORS:  // DM-only.
       throw DriverException("Invalid attribute", "HY092");
     case SQL_ATTR_QUIET_MODE:
-      GetAttribute(static_cast<SQLPOINTER>(NULL), value, bufferLength, outputLength);
+      GetAttribute(static_cast<SQLPOINTER>(NULL), value, buffer_length, output_length);
       return;
     case SQL_ATTR_TRACE:  // DM-only
       throw DriverException("Invalid attribute", "HY092");
@@ -639,70 +639,70 @@ void ODBCConnection::GetConnectAttr(SQLINTEGER attribute, SQLPOINTER value,
 
     // ODBCAbstraction-level connection attributes.
     case SQL_ATTR_CURRENT_CATALOG: {
-      const auto& catalog = m_spiConnection->GetAttribute(Connection::CURRENT_CATALOG);
+      const auto& catalog = m_spi_connection->GetAttribute(Connection::CURRENT_CATALOG);
       if (!catalog) {
         throw DriverException("Optional feature not supported.", "HYC00");
       }
-      const std::string& infoValue = boost::get<std::string>(*catalog);
-      GetStringAttribute(isUnicode, infoValue, true, value, bufferLength, outputLength,
-                         GetDiagnostics());
+      const std::string& info_value = boost::get<std::string>(*catalog);
+      GetStringAttribute(is_unicode, info_value, true, value, buffer_length,
+                         output_length, GetDiagnostics());
       return;
     }
 
     // These all are uint32_t attributes.
     case SQL_ATTR_ACCESS_MODE:
-      spiAttribute = m_spiConnection->GetAttribute(Connection::ACCESS_MODE);
+      spi_attribute = m_spi_connection->GetAttribute(Connection::ACCESS_MODE);
       break;
     case SQL_ATTR_CONNECTION_DEAD:
-      spiAttribute = m_spiConnection->GetAttribute(Connection::CONNECTION_DEAD);
+      spi_attribute = m_spi_connection->GetAttribute(Connection::CONNECTION_DEAD);
       break;
     case SQL_ATTR_CONNECTION_TIMEOUT:
-      spiAttribute = m_spiConnection->GetAttribute(Connection::CONNECTION_TIMEOUT);
+      spi_attribute = m_spi_connection->GetAttribute(Connection::CONNECTION_TIMEOUT);
       break;
     case SQL_ATTR_LOGIN_TIMEOUT:
-      spiAttribute = m_spiConnection->GetAttribute(Connection::LOGIN_TIMEOUT);
+      spi_attribute = m_spi_connection->GetAttribute(Connection::LOGIN_TIMEOUT);
       break;
     case SQL_ATTR_PACKET_SIZE:
-      spiAttribute = m_spiConnection->GetAttribute(Connection::PACKET_SIZE);
+      spi_attribute = m_spi_connection->GetAttribute(Connection::PACKET_SIZE);
       break;
     default:
       throw DriverException("Invalid attribute", "HY092");
   }
 
-  if (!spiAttribute) {
+  if (!spi_attribute) {
     throw DriverException("Invalid attribute", "HY092");
   }
 
-  GetAttribute(static_cast<SQLUINTEGER>(boost::get<uint32_t>(*spiAttribute)), value,
-               bufferLength, outputLength);
+  GetAttribute(static_cast<SQLUINTEGER>(boost::get<uint32_t>(*spi_attribute)), value,
+               buffer_length, output_length);
 }
 
-void ODBCConnection::disconnect() {
-  if (m_isConnected) {
+void ODBCConnection::Disconnect() {
+  if (m_is_connected) {
     // Ensure that all statements (and corresponding SPI statements) get cleaned
     // up before terminating the SPI connection in case they need to be de-allocated in
     // the reverse of the allocation order.
     m_statements.clear();
-    m_spiConnection->Close();
-    m_isConnected = false;
+    m_spi_connection->Close();
+    m_is_connected = false;
   }
 }
 
-void ODBCConnection::releaseConnection() {
-  disconnect();
+void ODBCConnection::ReleaseConnection() {
+  Disconnect();
   m_environment.DropConnection(this);
 }
 
-std::shared_ptr<ODBCStatement> ODBCConnection::createStatement() {
-  std::shared_ptr<Statement> spiStatement = m_spiConnection->CreateStatement();
+std::shared_ptr<ODBCStatement> ODBCConnection::CreateStatement() {
+  std::shared_ptr<Statement> spi_statement = m_spi_connection->CreateStatement();
   std::shared_ptr<ODBCStatement> statement =
-      std::make_shared<ODBCStatement>(*this, spiStatement);
+      std::make_shared<ODBCStatement>(*this, spi_statement);
   m_statements.push_back(statement);
   statement->CopyAttributesFromConnection(*this);
   return statement;
 }
 
-void ODBCConnection::dropStatement(ODBCStatement* stmt) {
+void ODBCConnection::DropStatement(ODBCStatement* stmt) {
   auto it = std::find_if(m_statements.begin(), m_statements.end(),
                          [&stmt](const std::shared_ptr<ODBCStatement>& statement) {
                            return statement.get() == stmt;
@@ -712,14 +712,14 @@ void ODBCConnection::dropStatement(ODBCStatement* stmt) {
   }
 }
 
-std::shared_ptr<ODBCDescriptor> ODBCConnection::createDescriptor() {
+std::shared_ptr<ODBCDescriptor> ODBCConnection::CreateDescriptor() {
   std::shared_ptr<ODBCDescriptor> desc = std::make_shared<ODBCDescriptor>(
-      m_spiConnection->GetDiagnostics(), this, nullptr, true, true, false);
+      m_spi_connection->GetDiagnostics(), this, nullptr, true, true, false);
   m_descriptors.push_back(desc);
   return desc;
 }
 
-void ODBCConnection::dropDescriptor(ODBCDescriptor* desc) {
+void ODBCConnection::DropDescriptor(ODBCDescriptor* desc) {
   auto it = std::find_if(m_descriptors.begin(), m_descriptors.end(),
                          [&desc](const std::shared_ptr<ODBCDescriptor>& descriptor) {
                            return descriptor.get() == desc;
@@ -731,35 +731,35 @@ void ODBCConnection::dropDescriptor(ODBCDescriptor* desc) {
 
 // Public Static
 // ===================================================================================
-std::string ODBCConnection::getPropertiesFromConnString(
-    const std::string& connStr, Connection::ConnPropertyMap& properties) {
+std::string ODBCConnection::GetPropertiesFromConnString(
+    const std::string& conn_str, Connection::ConnPropertyMap& properties) {
   const int groups[] = {1, 2};  // CONNECTION_STR_REGEX has two groups. key: 1, value: 2
-  boost::xpressive::sregex_token_iterator regexIter(connStr.begin(), connStr.end(),
-                                                    CONNECTION_STR_REGEX, groups),
+  boost::xpressive::sregex_token_iterator regex_iter(conn_str.begin(), conn_str.end(),
+                                                     CONNECTION_STR_REGEX, groups),
       end;
 
-  bool isDsnFirst = false;
-  bool isDriverFirst = false;
+  bool is_dsn_first = false;
+  bool is_driver_first = false;
   std::string dsn;
-  for (auto it = regexIter; end != regexIter; ++regexIter) {
-    std::string key = *regexIter;
-    std::string value = *++regexIter;
+  for (auto it = regex_iter; end != regex_iter; ++regex_iter) {
+    std::string key = *regex_iter;
+    std::string value = *++regex_iter;
 
     // If the DSN shows up before driver key, load settings from the DSN.
     // Only load values from the DSN once regardless of how many times the DSN
     // key shows up.
     if (boost::iequals(key, "DSN")) {
-      if (!isDriverFirst) {
-        if (!isDsnFirst) {
-          isDsnFirst = true;
+      if (!is_driver_first) {
+        if (!is_dsn_first) {
+          is_dsn_first = true;
           loadPropertiesFromDSN(value, properties);
           dsn.swap(value);
         }
       }
       continue;
     } else if (boost::iequals(key, "Driver")) {
-      if (!isDsnFirst) {
-        isDriverFirst = true;
+      if (!is_dsn_first) {
+        is_driver_first = true;
       }
       continue;
     }

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/odbc_impl/odbc_descriptor.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/odbc_impl/odbc_descriptor.cc
@@ -42,7 +42,7 @@ SQLSMALLINT CalculateHighestBoundRecord(const std::vector<DescriptorRecord>& rec
   // Most applications will bind every column, so optimistically assume that we'll
   // find the next bound record fastest by counting backwards.
   for (size_t i = records.size(); i > 0; --i) {
-    if (records[i - 1].m_isBound) {
+    if (records[i - 1].m_is_bound) {
       return i;
     }
   }
@@ -52,76 +52,77 @@ SQLSMALLINT CalculateHighestBoundRecord(const std::vector<DescriptorRecord>& rec
 
 // Public
 // =========================================================================================
-ODBCDescriptor::ODBCDescriptor(Diagnostics& baseDiagnostics, ODBCConnection* conn,
-                               ODBCStatement* stmt, bool isAppDescriptor, bool isWritable,
-                               bool is2xConnection)
-    : m_diagnostics(baseDiagnostics.GetVendor(), baseDiagnostics.GetDataSourceComponent(),
+ODBCDescriptor::ODBCDescriptor(Diagnostics& base_diagnostics, ODBCConnection* conn,
+                               ODBCStatement* stmt, bool is_app_descriptor,
+                               bool is_writable, bool is_2x_connection)
+    : m_diagnostics(base_diagnostics.GetVendor(),
+                    base_diagnostics.GetDataSourceComponent(),
                     driver::odbcabstraction::V_3),
-      m_owningConnection(conn),
-      m_parentStatement(stmt),
-      m_arrayStatusPtr(nullptr),
-      m_bindOffsetPtr(nullptr),
-      m_rowsProccessedPtr(nullptr),
-      m_arraySize(1),
-      m_bindType(SQL_BIND_BY_COLUMN),
-      m_highestOneBasedBoundRecord(0),
-      m_is2xConnection(is2xConnection),
-      m_isAppDescriptor(isAppDescriptor),
-      m_isWritable(isWritable),
-      m_hasBindingsChanged(true) {}
+      m_owning_connection(conn),
+      m_parent_statement(stmt),
+      m_array_status_ptr(nullptr),
+      m_bind_offset_ptr(nullptr),
+      m_rows_proccessed_ptr(nullptr),
+      m_array_size(1),
+      m_bind_type(SQL_BIND_BY_COLUMN),
+      m_highest_one_based_bound_record(0),
+      m_is_2x_connection(is_2x_connection),
+      m_is_app_descriptor(is_app_descriptor),
+      m_is_writable(is_writable),
+      m_has_bindings_changed(true) {}
 
-Diagnostics& ODBCDescriptor::GetDiagnostics_Impl() { return m_diagnostics; }
+Diagnostics& ODBCDescriptor::GetDiagnosticsImpl() { return m_diagnostics; }
 
 ODBCConnection& ODBCDescriptor::GetConnection() {
-  if (m_owningConnection) {
-    return *m_owningConnection;
+  if (m_owning_connection) {
+    return *m_owning_connection;
   }
-  assert(m_parentStatement);
-  return m_parentStatement->GetConnection();
+  assert(m_parent_statement);
+  return m_parent_statement->GetConnection();
 }
 
-void ODBCDescriptor::SetHeaderField(SQLSMALLINT fieldIdentifier, SQLPOINTER value,
-                                    SQLINTEGER bufferLength) {
+void ODBCDescriptor::SetHeaderField(SQLSMALLINT field_identifier, SQLPOINTER value,
+                                    SQLINTEGER buffer_length) {
   // Only these two fields can be set on the IRD.
-  if (!m_isWritable && fieldIdentifier != SQL_DESC_ARRAY_STATUS_PTR &&
-      fieldIdentifier != SQL_DESC_ROWS_PROCESSED_PTR) {
+  if (!m_is_writable && field_identifier != SQL_DESC_ARRAY_STATUS_PTR &&
+      field_identifier != SQL_DESC_ROWS_PROCESSED_PTR) {
     throw DriverException("Cannot modify read-only descriptor", "HY016");
   }
 
-  switch (fieldIdentifier) {
+  switch (field_identifier) {
     case SQL_DESC_ALLOC_TYPE:
       throw DriverException("Invalid descriptor field", "HY091");
     case SQL_DESC_ARRAY_SIZE:
-      SetAttribute(value, m_arraySize);
-      m_hasBindingsChanged = true;
+      SetAttribute(value, m_array_size);
+      m_has_bindings_changed = true;
       break;
     case SQL_DESC_ARRAY_STATUS_PTR:
-      SetPointerAttribute(value, m_arrayStatusPtr);
-      m_hasBindingsChanged = true;
+      SetPointerAttribute(value, m_array_status_ptr);
+      m_has_bindings_changed = true;
       break;
     case SQL_DESC_BIND_OFFSET_PTR:
-      SetPointerAttribute(value, m_bindOffsetPtr);
-      m_hasBindingsChanged = true;
+      SetPointerAttribute(value, m_bind_offset_ptr);
+      m_has_bindings_changed = true;
       break;
     case SQL_DESC_BIND_TYPE:
-      SetAttribute(value, m_bindType);
-      m_hasBindingsChanged = true;
+      SetAttribute(value, m_bind_type);
+      m_has_bindings_changed = true;
       break;
     case SQL_DESC_ROWS_PROCESSED_PTR:
-      SetPointerAttribute(value, m_rowsProccessedPtr);
-      m_hasBindingsChanged = true;
+      SetPointerAttribute(value, m_rows_proccessed_ptr);
+      m_has_bindings_changed = true;
       break;
     case SQL_DESC_COUNT: {
-      SQLSMALLINT newCount;
-      SetAttribute(value, newCount);
-      m_records.resize(newCount);
+      SQLSMALLINT new_count;
+      SetAttribute(value, new_count);
+      m_records.resize(new_count);
 
-      if (m_isAppDescriptor && newCount <= m_highestOneBasedBoundRecord) {
-        m_highestOneBasedBoundRecord = CalculateHighestBoundRecord(m_records);
+      if (m_is_app_descriptor && new_count <= m_highest_one_based_bound_record) {
+        m_highest_one_based_bound_record = CalculateHighestBoundRecord(m_records);
       } else {
-        m_highestOneBasedBoundRecord = newCount;
+        m_highest_one_based_bound_record = new_count;
       }
-      m_hasBindingsChanged = true;
+      m_has_bindings_changed = true;
       break;
     }
     default:
@@ -129,14 +130,14 @@ void ODBCDescriptor::SetHeaderField(SQLSMALLINT fieldIdentifier, SQLPOINTER valu
   }
 }
 
-void ODBCDescriptor::SetField(SQLSMALLINT recordNumber, SQLSMALLINT fieldIdentifier,
-                              SQLPOINTER value, SQLINTEGER bufferLength) {
-  if (!m_isWritable) {
+void ODBCDescriptor::SetField(SQLSMALLINT record_number, SQLSMALLINT field_identifier,
+                              SQLPOINTER value, SQLINTEGER buffer_length) {
+  if (!m_is_writable) {
     throw DriverException("Cannot modify read-only descriptor", "HY016");
   }
 
   // Handle header fields before validating the record number.
-  switch (fieldIdentifier) {
+  switch (field_identifier) {
     case SQL_DESC_ALLOC_TYPE:
     case SQL_DESC_ARRAY_SIZE:
     case SQL_DESC_ARRAY_STATUS_PTR:
@@ -144,23 +145,23 @@ void ODBCDescriptor::SetField(SQLSMALLINT recordNumber, SQLSMALLINT fieldIdentif
     case SQL_DESC_BIND_TYPE:
     case SQL_DESC_ROWS_PROCESSED_PTR:
     case SQL_DESC_COUNT:
-      SetHeaderField(fieldIdentifier, value, bufferLength);
+      SetHeaderField(field_identifier, value, buffer_length);
       return;
     default:
       break;
   }
 
-  if (recordNumber == 0) {
+  if (record_number == 0) {
     throw DriverException("Bookmarks are unsupported.", "07009");
   }
 
-  if (recordNumber > m_records.size()) {
+  if (record_number > m_records.size()) {
     throw DriverException("Invalid descriptor index", "HY009");
   }
 
-  SQLSMALLINT zeroBasedRecord = recordNumber - 1;
-  DescriptorRecord& record = m_records[zeroBasedRecord];
-  switch (fieldIdentifier) {
+  SQLSMALLINT zero_based_record = record_number - 1;
+  DescriptorRecord& record = m_records[zero_based_record];
+  switch (field_identifier) {
     case SQL_DESC_AUTO_UNIQUE_VALUE:
     case SQL_DESC_BASE_COLUMN_NAME:
     case SQL_DESC_BASE_TABLE_NAME:
@@ -184,98 +185,98 @@ void ODBCDescriptor::SetField(SQLSMALLINT recordNumber, SQLSMALLINT fieldIdentif
     case SQL_DESC_UPDATABLE:
       throw DriverException("Cannot modify read-only field.", "HY092");
     case SQL_DESC_CONCISE_TYPE:
-      SetAttribute(value, record.m_conciseType);
-      record.m_isBound = false;
-      m_hasBindingsChanged = true;
+      SetAttribute(value, record.m_concise_type);
+      record.m_is_bound = false;
+      m_has_bindings_changed = true;
       break;
     case SQL_DESC_DATA_PTR:
-      SetDataPtrOnRecord(value, recordNumber);
+      SetDataPtrOnRecord(value, record_number);
       break;
     case SQL_DESC_DATETIME_INTERVAL_CODE:
-      SetAttribute(value, record.m_datetimeIntervalCode);
-      record.m_isBound = false;
-      m_hasBindingsChanged = true;
+      SetAttribute(value, record.m_datetime_interval_code);
+      record.m_is_bound = false;
+      m_has_bindings_changed = true;
       break;
     case SQL_DESC_DATETIME_INTERVAL_PRECISION:
-      SetAttribute(value, record.m_datetimeIntervalPrecision);
-      record.m_isBound = false;
-      m_hasBindingsChanged = true;
+      SetAttribute(value, record.m_datetime_interval_precision);
+      record.m_is_bound = false;
+      m_has_bindings_changed = true;
       break;
     case SQL_DESC_INDICATOR_PTR:
     case SQL_DESC_OCTET_LENGTH_PTR:
-      SetPointerAttribute(value, record.m_indicatorPtr);
-      m_hasBindingsChanged = true;
+      SetPointerAttribute(value, record.m_indicator_ptr);
+      m_has_bindings_changed = true;
       break;
     case SQL_DESC_LENGTH:
       SetAttribute(value, record.m_length);
-      record.m_isBound = false;
-      m_hasBindingsChanged = true;
+      record.m_is_bound = false;
+      m_has_bindings_changed = true;
       break;
     case SQL_DESC_NAME:
-      SetAttributeUTF8(value, bufferLength, record.m_name);
-      m_hasBindingsChanged = true;
+      SetAttributeUTF8(value, buffer_length, record.m_name);
+      m_has_bindings_changed = true;
       break;
     case SQL_DESC_OCTET_LENGTH:
-      SetAttribute(value, record.m_octetLength);
-      record.m_isBound = false;
-      m_hasBindingsChanged = true;
+      SetAttribute(value, record.m_octet_length);
+      record.m_is_bound = false;
+      m_has_bindings_changed = true;
       break;
     case SQL_DESC_PARAMETER_TYPE:
-      SetAttribute(value, record.m_paramType);
-      record.m_isBound = false;
-      m_hasBindingsChanged = true;
+      SetAttribute(value, record.m_param_type);
+      record.m_is_bound = false;
+      m_has_bindings_changed = true;
       break;
     case SQL_DESC_PRECISION:
       SetAttribute(value, record.m_precision);
-      record.m_isBound = false;
-      m_hasBindingsChanged = true;
+      record.m_is_bound = false;
+      m_has_bindings_changed = true;
       break;
     case SQL_DESC_SCALE:
       SetAttribute(value, record.m_scale);
-      record.m_isBound = false;
-      m_hasBindingsChanged = true;
+      record.m_is_bound = false;
+      m_has_bindings_changed = true;
       break;
     case SQL_DESC_TYPE:
       SetAttribute(value, record.m_type);
-      record.m_isBound = false;
-      m_hasBindingsChanged = true;
+      record.m_is_bound = false;
+      m_has_bindings_changed = true;
       break;
     default:
       throw DriverException("Invalid descriptor field", "HY091");
   }
 }
 
-void ODBCDescriptor::GetHeaderField(SQLSMALLINT fieldIdentifier, SQLPOINTER value,
-                                    SQLINTEGER bufferLength,
-                                    SQLINTEGER* outputLength) const {
-  switch (fieldIdentifier) {
+void ODBCDescriptor::GetHeaderField(SQLSMALLINT field_identifier, SQLPOINTER value,
+                                    SQLINTEGER buffer_length,
+                                    SQLINTEGER* output_length) const {
+  switch (field_identifier) {
     case SQL_DESC_ALLOC_TYPE: {
       SQLSMALLINT result;
-      if (m_owningConnection) {
+      if (m_owning_connection) {
         result = SQL_DESC_ALLOC_USER;
       } else {
         result = SQL_DESC_ALLOC_AUTO;
       }
-      GetAttribute(result, value, bufferLength, outputLength);
+      GetAttribute(result, value, buffer_length, output_length);
       break;
     }
     case SQL_DESC_ARRAY_SIZE:
-      GetAttribute(m_arraySize, value, bufferLength, outputLength);
+      GetAttribute(m_array_size, value, buffer_length, output_length);
       break;
     case SQL_DESC_ARRAY_STATUS_PTR:
-      GetAttribute(m_arrayStatusPtr, value, bufferLength, outputLength);
+      GetAttribute(m_array_status_ptr, value, buffer_length, output_length);
       break;
     case SQL_DESC_BIND_OFFSET_PTR:
-      GetAttribute(m_bindOffsetPtr, value, bufferLength, outputLength);
+      GetAttribute(m_bind_offset_ptr, value, buffer_length, output_length);
       break;
     case SQL_DESC_BIND_TYPE:
-      GetAttribute(m_bindType, value, bufferLength, outputLength);
+      GetAttribute(m_bind_type, value, buffer_length, output_length);
       break;
     case SQL_DESC_ROWS_PROCESSED_PTR:
-      GetAttribute(m_rowsProccessedPtr, value, bufferLength, outputLength);
+      GetAttribute(m_rows_proccessed_ptr, value, buffer_length, output_length);
       break;
     case SQL_DESC_COUNT: {
-      GetAttribute(m_highestOneBasedBoundRecord, value, bufferLength, outputLength);
+      GetAttribute(m_highest_one_based_bound_record, value, buffer_length, output_length);
       break;
     }
     default:
@@ -283,11 +284,11 @@ void ODBCDescriptor::GetHeaderField(SQLSMALLINT fieldIdentifier, SQLPOINTER valu
   }
 }
 
-void ODBCDescriptor::GetField(SQLSMALLINT recordNumber, SQLSMALLINT fieldIdentifier,
-                              SQLPOINTER value, SQLINTEGER bufferLength,
-                              SQLINTEGER* outputLength) {
+void ODBCDescriptor::GetField(SQLSMALLINT record_number, SQLSMALLINT field_identifier,
+                              SQLPOINTER value, SQLINTEGER buffer_length,
+                              SQLINTEGER* output_length) {
   // Handle header fields before validating the record number.
-  switch (fieldIdentifier) {
+  switch (field_identifier) {
     case SQL_DESC_ALLOC_TYPE:
     case SQL_DESC_ARRAY_SIZE:
     case SQL_DESC_ARRAY_STATUS_PTR:
@@ -295,226 +296,227 @@ void ODBCDescriptor::GetField(SQLSMALLINT recordNumber, SQLSMALLINT fieldIdentif
     case SQL_DESC_BIND_TYPE:
     case SQL_DESC_ROWS_PROCESSED_PTR:
     case SQL_DESC_COUNT:
-      GetHeaderField(fieldIdentifier, value, bufferLength, outputLength);
+      GetHeaderField(field_identifier, value, buffer_length, output_length);
       return;
     default:
       break;
   }
 
-  if (recordNumber == 0) {
+  if (record_number == 0) {
     throw DriverException("Bookmarks are unsupported.", "07009");
   }
 
-  if (recordNumber > m_records.size()) {
+  if (record_number > m_records.size()) {
     throw DriverException("Invalid descriptor index", "07009");
   }
 
   // TODO: Restrict fields based on AppDescriptor IPD, and IRD.
 
-  SQLSMALLINT zeroBasedRecord = recordNumber - 1;
-  const DescriptorRecord& record = m_records[zeroBasedRecord];
-  switch (fieldIdentifier) {
+  SQLSMALLINT zero_based_record = record_number - 1;
+  const DescriptorRecord& record = m_records[zero_based_record];
+  switch (field_identifier) {
     case SQL_DESC_BASE_COLUMN_NAME:
-      GetAttributeUTF8(record.m_baseColumnName, value, bufferLength, outputLength,
+      GetAttributeUTF8(record.m_base_column_name, value, buffer_length, output_length,
                        GetDiagnostics());
       break;
     case SQL_DESC_BASE_TABLE_NAME:
-      GetAttributeUTF8(record.m_baseTableName, value, bufferLength, outputLength,
+      GetAttributeUTF8(record.m_base_table_name, value, buffer_length, output_length,
                        GetDiagnostics());
       break;
     case SQL_DESC_CATALOG_NAME:
-      GetAttributeUTF8(record.m_catalogName, value, bufferLength, outputLength,
+      GetAttributeUTF8(record.m_catalog_name, value, buffer_length, output_length,
                        GetDiagnostics());
       break;
     case SQL_DESC_LABEL:
-      GetAttributeUTF8(record.m_label, value, bufferLength, outputLength,
+      GetAttributeUTF8(record.m_label, value, buffer_length, output_length,
                        GetDiagnostics());
       break;
     case SQL_DESC_LITERAL_PREFIX:
-      GetAttributeUTF8(record.m_literalPrefix, value, bufferLength, outputLength,
+      GetAttributeUTF8(record.m_literal_prefix, value, buffer_length, output_length,
                        GetDiagnostics());
       break;
     case SQL_DESC_LITERAL_SUFFIX:
-      GetAttributeUTF8(record.m_literalSuffix, value, bufferLength, outputLength,
+      GetAttributeUTF8(record.m_literal_suffix, value, buffer_length, output_length,
                        GetDiagnostics());
       break;
     case SQL_DESC_LOCAL_TYPE_NAME:
-      GetAttributeUTF8(record.m_localTypeName, value, bufferLength, outputLength,
+      GetAttributeUTF8(record.m_local_type_name, value, buffer_length, output_length,
                        GetDiagnostics());
       break;
     case SQL_DESC_NAME:
-      GetAttributeUTF8(record.m_name, value, bufferLength, outputLength,
+      GetAttributeUTF8(record.m_name, value, buffer_length, output_length,
                        GetDiagnostics());
       break;
     case SQL_DESC_SCHEMA_NAME:
-      GetAttributeUTF8(record.m_schemaName, value, bufferLength, outputLength,
+      GetAttributeUTF8(record.m_schema_name, value, buffer_length, output_length,
                        GetDiagnostics());
       break;
     case SQL_DESC_TABLE_NAME:
-      GetAttributeUTF8(record.m_tableName, value, bufferLength, outputLength,
+      GetAttributeUTF8(record.m_table_name, value, buffer_length, output_length,
                        GetDiagnostics());
       break;
     case SQL_DESC_TYPE_NAME:
-      GetAttributeUTF8(record.m_typeName, value, bufferLength, outputLength,
+      GetAttributeUTF8(record.m_type_name, value, buffer_length, output_length,
                        GetDiagnostics());
       break;
 
     case SQL_DESC_DATA_PTR:
-      GetAttribute(record.m_dataPtr, value, bufferLength, outputLength);
+      GetAttribute(record.m_data_ptr, value, buffer_length, output_length);
       break;
     case SQL_DESC_INDICATOR_PTR:
     case SQL_DESC_OCTET_LENGTH_PTR:
-      GetAttribute(record.m_indicatorPtr, value, bufferLength, outputLength);
+      GetAttribute(record.m_indicator_ptr, value, buffer_length, output_length);
       break;
 
     case SQL_DESC_LENGTH:
-      GetAttribute(record.m_length, value, bufferLength, outputLength);
+      GetAttribute(record.m_length, value, buffer_length, output_length);
       break;
     case SQL_DESC_OCTET_LENGTH:
-      GetAttribute(record.m_octetLength, value, bufferLength, outputLength);
+      GetAttribute(record.m_octet_length, value, buffer_length, output_length);
       break;
 
     case SQL_DESC_AUTO_UNIQUE_VALUE:
-      GetAttribute(record.m_autoUniqueValue, value, bufferLength, outputLength);
+      GetAttribute(record.m_auto_unique_value, value, buffer_length, output_length);
       break;
     case SQL_DESC_CASE_SENSITIVE:
-      GetAttribute(record.m_caseSensitive, value, bufferLength, outputLength);
+      GetAttribute(record.m_case_sensitive, value, buffer_length, output_length);
       break;
     case SQL_DESC_DATETIME_INTERVAL_PRECISION:
-      GetAttribute(record.m_datetimeIntervalPrecision, value, bufferLength, outputLength);
+      GetAttribute(record.m_datetime_interval_precision, value, buffer_length,
+                   output_length);
       break;
     case SQL_DESC_NUM_PREC_RADIX:
-      GetAttribute(record.m_numPrecRadix, value, bufferLength, outputLength);
+      GetAttribute(record.m_num_prec_radix, value, buffer_length, output_length);
       break;
 
     case SQL_DESC_CONCISE_TYPE:
-      GetAttribute(record.m_conciseType, value, bufferLength, outputLength);
+      GetAttribute(record.m_concise_type, value, buffer_length, output_length);
       break;
     case SQL_DESC_DATETIME_INTERVAL_CODE:
-      GetAttribute(record.m_datetimeIntervalCode, value, bufferLength, outputLength);
+      GetAttribute(record.m_datetime_interval_code, value, buffer_length, output_length);
       break;
     case SQL_DESC_DISPLAY_SIZE:
-      GetAttribute(record.m_displaySize, value, bufferLength, outputLength);
+      GetAttribute(record.m_display_size, value, buffer_length, output_length);
       break;
     case SQL_DESC_FIXED_PREC_SCALE:
-      GetAttribute(record.m_fixedPrecScale, value, bufferLength, outputLength);
+      GetAttribute(record.m_fixed_prec_scale, value, buffer_length, output_length);
       break;
     case SQL_DESC_NULLABLE:
-      GetAttribute(record.m_nullable, value, bufferLength, outputLength);
+      GetAttribute(record.m_nullable, value, buffer_length, output_length);
       break;
     case SQL_DESC_PARAMETER_TYPE:
-      GetAttribute(record.m_paramType, value, bufferLength, outputLength);
+      GetAttribute(record.m_param_type, value, buffer_length, output_length);
       break;
     case SQL_DESC_PRECISION:
-      GetAttribute(record.m_precision, value, bufferLength, outputLength);
+      GetAttribute(record.m_precision, value, buffer_length, output_length);
       break;
     case SQL_DESC_ROWVER:
-      GetAttribute(record.m_rowVer, value, bufferLength, outputLength);
+      GetAttribute(record.m_row_ver, value, buffer_length, output_length);
       break;
     case SQL_DESC_SCALE:
-      GetAttribute(record.m_scale, value, bufferLength, outputLength);
+      GetAttribute(record.m_scale, value, buffer_length, output_length);
       break;
     case SQL_DESC_SEARCHABLE:
-      GetAttribute(record.m_searchable, value, bufferLength, outputLength);
+      GetAttribute(record.m_searchable, value, buffer_length, output_length);
       break;
     case SQL_DESC_TYPE:
-      GetAttribute(record.m_type, value, bufferLength, outputLength);
+      GetAttribute(record.m_type, value, buffer_length, output_length);
       break;
     case SQL_DESC_UNNAMED:
-      GetAttribute(record.m_unnamed, value, bufferLength, outputLength);
+      GetAttribute(record.m_unnamed, value, buffer_length, output_length);
       break;
     case SQL_DESC_UNSIGNED:
-      GetAttribute(record.m_unsigned, value, bufferLength, outputLength);
+      GetAttribute(record.m_unsigned, value, buffer_length, output_length);
       break;
     case SQL_DESC_UPDATABLE:
-      GetAttribute(record.m_updatable, value, bufferLength, outputLength);
+      GetAttribute(record.m_updatable, value, buffer_length, output_length);
       break;
     default:
       throw DriverException("Invalid descriptor field", "HY091");
   }
 }
 
-SQLSMALLINT ODBCDescriptor::getAllocType() const {
-  return m_owningConnection != nullptr ? SQL_DESC_ALLOC_USER : SQL_DESC_ALLOC_AUTO;
+SQLSMALLINT ODBCDescriptor::GetAllocType() const {
+  return m_owning_connection != nullptr ? SQL_DESC_ALLOC_USER : SQL_DESC_ALLOC_AUTO;
 }
 
-bool ODBCDescriptor::IsAppDescriptor() const { return m_isAppDescriptor; }
+bool ODBCDescriptor::IsAppDescriptor() const { return m_is_app_descriptor; }
 
-void ODBCDescriptor::RegisterToStatement(ODBCStatement* statement, bool isApd) {
-  if (isApd) {
-    m_registeredOnStatementsAsApd.push_back(statement);
+void ODBCDescriptor::RegisterToStatement(ODBCStatement* statement, bool is_apd) {
+  if (is_apd) {
+    m_registered_on_statements_as_apd.push_back(statement);
   } else {
-    m_registeredOnStatementsAsArd.push_back(statement);
+    m_registered_on_statements_as_ard.push_back(statement);
   }
 }
 
-void ODBCDescriptor::DetachFromStatement(ODBCStatement* statement, bool isApd) {
-  auto& vectorToUpdate =
-      isApd ? m_registeredOnStatementsAsApd : m_registeredOnStatementsAsArd;
-  auto it = std::find(vectorToUpdate.begin(), vectorToUpdate.end(), statement);
-  if (it != vectorToUpdate.end()) {
-    vectorToUpdate.erase(it);
+void ODBCDescriptor::DetachFromStatement(ODBCStatement* statement, bool is_apd) {
+  auto& vector_to_update =
+      is_apd ? m_registered_on_statements_as_apd : m_registered_on_statements_as_ard;
+  auto it = std::find(vector_to_update.begin(), vector_to_update.end(), statement);
+  if (it != vector_to_update.end()) {
+    vector_to_update.erase(it);
   }
 }
 
 void ODBCDescriptor::ReleaseDescriptor() {
-  for (ODBCStatement* stmt : m_registeredOnStatementsAsApd) {
+  for (ODBCStatement* stmt : m_registered_on_statements_as_apd) {
     stmt->RevertAppDescriptor(true);
   }
 
-  for (ODBCStatement* stmt : m_registeredOnStatementsAsArd) {
+  for (ODBCStatement* stmt : m_registered_on_statements_as_ard) {
     stmt->RevertAppDescriptor(false);
   }
 
-  if (m_owningConnection) {
-    m_owningConnection->dropDescriptor(this);
+  if (m_owning_connection) {
+    m_owning_connection->DropDescriptor(this);
   }
 }
 
 void ODBCDescriptor::PopulateFromResultSetMetadata(ResultSetMetadata* rsmd) {
   m_records.assign(rsmd->GetColumnCount(), DescriptorRecord());
-  m_highestOneBasedBoundRecord = m_records.size() + 1;
+  m_highest_one_based_bound_record = m_records.size() + 1;
 
   for (size_t i = 0; i < m_records.size(); ++i) {
-    size_t oneBasedIndex = i + 1;
-    m_records[i].m_baseColumnName = rsmd->GetBaseColumnName(oneBasedIndex);
-    m_records[i].m_baseTableName = rsmd->GetBaseTableName(oneBasedIndex);
-    m_records[i].m_catalogName = rsmd->GetCatalogName(oneBasedIndex);
-    m_records[i].m_label = rsmd->GetColumnLabel(oneBasedIndex);
-    m_records[i].m_literalPrefix = rsmd->GetLiteralPrefix(oneBasedIndex);
-    m_records[i].m_literalSuffix = rsmd->GetLiteralSuffix(oneBasedIndex);
-    m_records[i].m_localTypeName = rsmd->GetLocalTypeName(oneBasedIndex);
-    m_records[i].m_name = rsmd->GetName(oneBasedIndex);
-    m_records[i].m_schemaName = rsmd->GetSchemaName(oneBasedIndex);
-    m_records[i].m_tableName = rsmd->GetTableName(oneBasedIndex);
-    m_records[i].m_typeName = rsmd->GetTypeName(oneBasedIndex);
-    m_records[i].m_conciseType =
-        GetSqlTypeForODBCVersion(rsmd->GetConciseType(oneBasedIndex), m_is2xConnection);
-    m_records[i].m_dataPtr = nullptr;
-    m_records[i].m_indicatorPtr = nullptr;
-    m_records[i].m_displaySize = rsmd->GetColumnDisplaySize(oneBasedIndex);
-    m_records[i].m_octetLength = rsmd->GetOctetLength(oneBasedIndex);
-    m_records[i].m_length = rsmd->GetLength(oneBasedIndex);
-    m_records[i].m_autoUniqueValue =
-        rsmd->IsAutoUnique(oneBasedIndex) ? SQL_TRUE : SQL_FALSE;
-    m_records[i].m_caseSensitive =
-        rsmd->IsCaseSensitive(oneBasedIndex) ? SQL_TRUE : SQL_FALSE;
-    m_records[i].m_datetimeIntervalPrecision;  // TODO - update when rsmd adds this
-    m_records[i].m_numPrecRadix = rsmd->GetNumPrecRadix(oneBasedIndex);
-    m_records[i].m_datetimeIntervalCode;  // TODO
-    m_records[i].m_fixedPrecScale =
-        rsmd->IsFixedPrecScale(oneBasedIndex) ? SQL_TRUE : SQL_FALSE;
-    m_records[i].m_nullable = rsmd->IsNullable(oneBasedIndex);
-    m_records[i].m_paramType = SQL_PARAM_INPUT;
-    m_records[i].m_precision = rsmd->GetPrecision(oneBasedIndex);
-    m_records[i].m_rowVer = SQL_FALSE;
-    m_records[i].m_scale = rsmd->GetScale(oneBasedIndex);
-    m_records[i].m_searchable = rsmd->IsSearchable(oneBasedIndex);
+    size_t one_based_index = i + 1;
+    m_records[i].m_base_column_name = rsmd->GetBaseColumnName(one_based_index);
+    m_records[i].m_base_table_name = rsmd->GetBaseTableName(one_based_index);
+    m_records[i].m_catalog_name = rsmd->GetCatalogName(one_based_index);
+    m_records[i].m_label = rsmd->GetColumnLabel(one_based_index);
+    m_records[i].m_literal_prefix = rsmd->GetLiteralPrefix(one_based_index);
+    m_records[i].m_literal_suffix = rsmd->GetLiteralSuffix(one_based_index);
+    m_records[i].m_local_type_name = rsmd->GetLocalTypeName(one_based_index);
+    m_records[i].m_name = rsmd->GetName(one_based_index);
+    m_records[i].m_schema_name = rsmd->GetSchemaName(one_based_index);
+    m_records[i].m_table_name = rsmd->GetTableName(one_based_index);
+    m_records[i].m_type_name = rsmd->GetTypeName(one_based_index);
+    m_records[i].m_concise_type = GetSqlTypeForODBCVersion(
+        rsmd->GetConciseType(one_based_index), m_is_2x_connection);
+    m_records[i].m_data_ptr = nullptr;
+    m_records[i].m_indicator_ptr = nullptr;
+    m_records[i].m_display_size = rsmd->GetColumnDisplaySize(one_based_index);
+    m_records[i].m_octet_length = rsmd->GetOctetLength(one_based_index);
+    m_records[i].m_length = rsmd->GetLength(one_based_index);
+    m_records[i].m_auto_unique_value =
+        rsmd->IsAutoUnique(one_based_index) ? SQL_TRUE : SQL_FALSE;
+    m_records[i].m_case_sensitive =
+        rsmd->IsCaseSensitive(one_based_index) ? SQL_TRUE : SQL_FALSE;
+    m_records[i].m_datetime_interval_precision;  // TODO - update when rsmd adds this
+    m_records[i].m_num_prec_radix = rsmd->GetNumPrecRadix(one_based_index);
+    m_records[i].m_datetime_interval_code;  // TODO
+    m_records[i].m_fixed_prec_scale =
+        rsmd->IsFixedPrecScale(one_based_index) ? SQL_TRUE : SQL_FALSE;
+    m_records[i].m_nullable = rsmd->IsNullable(one_based_index);
+    m_records[i].m_param_type = SQL_PARAM_INPUT;
+    m_records[i].m_precision = rsmd->GetPrecision(one_based_index);
+    m_records[i].m_row_ver = SQL_FALSE;
+    m_records[i].m_scale = rsmd->GetScale(one_based_index);
+    m_records[i].m_searchable = rsmd->IsSearchable(one_based_index);
     m_records[i].m_type =
-        GetSqlTypeForODBCVersion(rsmd->GetDataType(oneBasedIndex), m_is2xConnection);
+        GetSqlTypeForODBCVersion(rsmd->GetDataType(one_based_index), m_is_2x_connection);
     m_records[i].m_unnamed = m_records[i].m_name.empty() ? SQL_TRUE : SQL_FALSE;
-    m_records[i].m_unsigned = rsmd->IsUnsigned(oneBasedIndex) ? SQL_TRUE : SQL_FALSE;
-    m_records[i].m_updatable = rsmd->GetUpdatable(oneBasedIndex);
+    m_records[i].m_unsigned = rsmd->IsUnsigned(one_based_index) ? SQL_TRUE : SQL_FALSE;
+    m_records[i].m_updatable = rsmd->GetUpdatable(one_based_index);
   }
 }
 
@@ -524,50 +526,50 @@ const std::vector<DescriptorRecord>& ODBCDescriptor::GetRecords() const {
 
 std::vector<DescriptorRecord>& ODBCDescriptor::GetRecords() { return m_records; }
 
-void ODBCDescriptor::BindCol(SQLSMALLINT recordNumber, SQLSMALLINT cType,
-                             SQLPOINTER dataPtr, SQLLEN bufferLength,
-                             SQLLEN* indicatorPtr) {
-  assert(m_isAppDescriptor);
-  assert(m_isWritable);
+void ODBCDescriptor::BindCol(SQLSMALLINT record_number, SQLSMALLINT c_type,
+                             SQLPOINTER data_ptr, SQLLEN buffer_length,
+                             SQLLEN* indicator_ptr) {
+  assert(m_is_app_descriptor);
+  assert(m_is_writable);
 
   // The set of records auto-expands to the supplied record number.
-  if (m_records.size() < recordNumber) {
-    m_records.resize(recordNumber);
+  if (m_records.size() < record_number) {
+    m_records.resize(record_number);
   }
 
-  SQLSMALLINT zeroBasedRecordIndex = recordNumber - 1;
-  DescriptorRecord& record = m_records[zeroBasedRecordIndex];
+  SQLSMALLINT zero_based_record_index = record_number - 1;
+  DescriptorRecord& record = m_records[zero_based_record_index];
 
-  record.m_type = cType;
-  record.m_indicatorPtr = indicatorPtr;
-  record.m_length = bufferLength;
+  record.m_type = c_type;
+  record.m_indicator_ptr = indicator_ptr;
+  record.m_length = buffer_length;
 
   // Initialize default precision and scale for SQL_C_NUMERIC.
   if (record.m_type == SQL_C_NUMERIC) {
     record.m_precision = 38;
     record.m_scale = 0;
   }
-  SetDataPtrOnRecord(dataPtr, recordNumber);
+  SetDataPtrOnRecord(data_ptr, record_number);
 }
 
-void ODBCDescriptor::SetDataPtrOnRecord(SQLPOINTER dataPtr, SQLSMALLINT recordNumber) {
-  assert(recordNumber <= m_records.size());
-  DescriptorRecord& record = m_records[recordNumber - 1];
-  if (dataPtr) {
+void ODBCDescriptor::SetDataPtrOnRecord(SQLPOINTER data_ptr, SQLSMALLINT record_number) {
+  assert(record_number <= m_records.size());
+  DescriptorRecord& record = m_records[record_number - 1];
+  if (data_ptr) {
     record.CheckConsistency();
-    record.m_isBound = true;
+    record.m_is_bound = true;
   } else {
-    record.m_isBound = false;
+    record.m_is_bound = false;
   }
-  record.m_dataPtr = dataPtr;
+  record.m_data_ptr = data_ptr;
 
   // Bookkeeping on the highest bound record (used for returning SQL_DESC_COUNT)
-  if (m_highestOneBasedBoundRecord < recordNumber && dataPtr) {
-    m_highestOneBasedBoundRecord = recordNumber;
-  } else if (m_highestOneBasedBoundRecord == recordNumber && !dataPtr) {
-    m_highestOneBasedBoundRecord = CalculateHighestBoundRecord(m_records);
+  if (m_highest_one_based_bound_record < record_number && data_ptr) {
+    m_highest_one_based_bound_record = record_number;
+  } else if (m_highest_one_based_bound_record == record_number && !data_ptr) {
+    m_highest_one_based_bound_record = CalculateHighestBoundRecord(m_records);
   }
-  m_hasBindingsChanged = true;
+  m_has_bindings_changed = true;
 }
 
 void DescriptorRecord::CheckConsistency() {

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/odbc_impl/odbc_environment.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/odbc_impl/odbc_environment.cc
@@ -40,13 +40,13 @@ ODBCEnvironment::ODBCEnvironment(std::shared_ptr<Driver> driver)
                                     m_driver->GetDiagnostics().GetDataSourceComponent(),
                                     driver::odbcabstraction::V_2)),
       m_version(SQL_OV_ODBC2),
-      m_connectionPooling(SQL_CP_OFF) {}
+      m_connection_pooling(SQL_CP_OFF) {}
 
-Diagnostics& ODBCEnvironment::GetDiagnostics_Impl() { return *m_diagnostics; }
+Diagnostics& ODBCEnvironment::GetDiagnosticsImpl() { return *m_diagnostics; }
 
-SQLINTEGER ODBCEnvironment::getODBCVersion() const { return m_version; }
+SQLINTEGER ODBCEnvironment::GetODBCVersion() const { return m_version; }
 
-void ODBCEnvironment::setODBCVersion(SQLINTEGER version) {
+void ODBCEnvironment::SetODBCVersion(SQLINTEGER version) {
   if (version != m_version) {
     m_version = version;
     m_diagnostics.reset(new Diagnostics(
@@ -56,20 +56,20 @@ void ODBCEnvironment::setODBCVersion(SQLINTEGER version) {
   }
 }
 
-SQLINTEGER ODBCEnvironment::getConnectionPooling() const { return m_connectionPooling; }
+SQLINTEGER ODBCEnvironment::GetConnectionPooling() const { return m_connection_pooling; }
 
-void ODBCEnvironment::setConnectionPooling(SQLINTEGER connectionPooling) {
-  m_connectionPooling = connectionPooling;
+void ODBCEnvironment::SetConnectionPooling(SQLINTEGER connection_pooling) {
+  m_connection_pooling = connection_pooling;
 }
 
 std::shared_ptr<ODBCConnection> ODBCEnvironment::CreateConnection() {
-  std::shared_ptr<Connection> spiConnection = m_driver->CreateConnection(
+  std::shared_ptr<Connection> spi_connection = m_driver->CreateConnection(
       m_version == SQL_OV_ODBC2 ? driver::odbcabstraction::V_2
                                 : driver::odbcabstraction::V_3);
-  std::shared_ptr<ODBCConnection> newConn =
-      std::make_shared<ODBCConnection>(*this, spiConnection);
-  m_connections.push_back(newConn);
-  return newConn;
+  std::shared_ptr<ODBCConnection> new_conn =
+      std::make_shared<ODBCConnection>(*this, spi_connection);
+  m_connections.push_back(new_conn);
+  return new_conn;
 }
 
 void ODBCEnvironment::DropConnection(ODBCConnection* conn) {

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/odbc_impl/odbc_environment.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/odbc_impl/odbc_environment.cc
@@ -35,49 +35,49 @@ using driver::odbcabstraction::Driver;
 // Public
 // =========================================================================================
 ODBCEnvironment::ODBCEnvironment(std::shared_ptr<Driver> driver)
-    : m_driver(std::move(driver)),
-      m_diagnostics(new Diagnostics(m_driver->GetDiagnostics().GetVendor(),
-                                    m_driver->GetDiagnostics().GetDataSourceComponent(),
-                                    driver::odbcabstraction::V_2)),
-      m_version(SQL_OV_ODBC2),
-      m_connection_pooling(SQL_CP_OFF) {}
+    : driver_(std::move(driver)),
+      diagnostics_(new Diagnostics(driver_->GetDiagnostics().GetVendor(),
+                                   driver_->GetDiagnostics().GetDataSourceComponent(),
+                                   driver::odbcabstraction::V_2)),
+      version_(SQL_OV_ODBC2),
+      connection_pooling_(SQL_CP_OFF) {}
 
-Diagnostics& ODBCEnvironment::GetDiagnosticsImpl() { return *m_diagnostics; }
+Diagnostics& ODBCEnvironment::GetDiagnosticsImpl() { return *diagnostics_; }
 
-SQLINTEGER ODBCEnvironment::GetODBCVersion() const { return m_version; }
+SQLINTEGER ODBCEnvironment::GetODBCVersion() const { return version_; }
 
 void ODBCEnvironment::SetODBCVersion(SQLINTEGER version) {
-  if (version != m_version) {
-    m_version = version;
-    m_diagnostics.reset(new Diagnostics(
-        m_diagnostics->GetVendor(), m_diagnostics->GetDataSourceComponent(),
-        version == SQL_OV_ODBC2 ? driver::odbcabstraction::V_2
-                                : driver::odbcabstraction::V_3));
+  if (version != version_) {
+    version_ = version;
+    diagnostics_.reset(
+        new Diagnostics(diagnostics_->GetVendor(), diagnostics_->GetDataSourceComponent(),
+                        version == SQL_OV_ODBC2 ? driver::odbcabstraction::V_2
+                                                : driver::odbcabstraction::V_3));
   }
 }
 
-SQLINTEGER ODBCEnvironment::GetConnectionPooling() const { return m_connection_pooling; }
+SQLINTEGER ODBCEnvironment::GetConnectionPooling() const { return connection_pooling_; }
 
 void ODBCEnvironment::SetConnectionPooling(SQLINTEGER connection_pooling) {
-  m_connection_pooling = connection_pooling;
+  connection_pooling_ = connection_pooling;
 }
 
 std::shared_ptr<ODBCConnection> ODBCEnvironment::CreateConnection() {
-  std::shared_ptr<Connection> spi_connection = m_driver->CreateConnection(
-      m_version == SQL_OV_ODBC2 ? driver::odbcabstraction::V_2
-                                : driver::odbcabstraction::V_3);
+  std::shared_ptr<Connection> spi_connection =
+      driver_->CreateConnection(version_ == SQL_OV_ODBC2 ? driver::odbcabstraction::V_2
+                                                         : driver::odbcabstraction::V_3);
   std::shared_ptr<ODBCConnection> new_conn =
       std::make_shared<ODBCConnection>(*this, spi_connection);
-  m_connections.push_back(new_conn);
+  connections_.push_back(new_conn);
   return new_conn;
 }
 
 void ODBCEnvironment::DropConnection(ODBCConnection* conn) {
-  auto it = std::find_if(m_connections.begin(), m_connections.end(),
+  auto it = std::find_if(connections_.begin(), connections_.end(),
                          [&conn](const std::shared_ptr<ODBCConnection>& connection) {
                            return connection.get() == conn;
                          });
-  if (m_connections.end() != it) {
-    m_connections.erase(it);
+  if (connections_.end() != it) {
+    connections_.erase(it);
   }
 }

--- a/cpp/src/arrow/flight/sql/odbc/odbcabstraction/utils.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbcabstraction/utils.cc
@@ -34,11 +34,11 @@ boost::optional<bool> AsBool(const std::string& value) {
   }
 }
 
-boost::optional<bool> AsBool(const Connection::ConnPropertyMap& connPropertyMap,
+boost::optional<bool> AsBool(const Connection::ConnPropertyMap& conn_property_map,
                              const std::string_view& property_name) {
-  auto extracted_property = connPropertyMap.find(property_name);
+  auto extracted_property = conn_property_map.find(std::string(property_name));
 
-  if (extracted_property != connPropertyMap.end()) {
+  if (extracted_property != conn_property_map.end()) {
     return AsBool(extracted_property->second);
   }
 
@@ -46,15 +46,15 @@ boost::optional<bool> AsBool(const Connection::ConnPropertyMap& connPropertyMap,
 }
 
 boost::optional<int32_t> AsInt32(int32_t min_value,
-                                 const Connection::ConnPropertyMap& connPropertyMap,
+                                 const Connection::ConnPropertyMap& conn_property_map,
                                  const std::string_view& property_name) {
-  auto extracted_property = connPropertyMap.find(property_name);
+  auto extracted_property = conn_property_map.find(std::string(property_name));
 
-  if (extracted_property != connPropertyMap.end()) {
-    const int32_t stringColumnLength = std::stoi(extracted_property->second);
+  if (extracted_property != conn_property_map.end()) {
+    const int32_t string_column_length = std::stoi(extracted_property->second);
 
-    if (stringColumnLength >= min_value && stringColumnLength <= INT32_MAX) {
-      return stringColumnLength;
+    if (string_column_length >= min_value && string_column_length <= INT32_MAX) {
+      return string_column_length;
     }
   }
   return boost::none;


### PR DESCRIPTION
### Rationale for this change

We want our code to adhere to Arrow's expected naming conventions.

### What changes are included in this PR?

Functions are renamed to be `PascalCase` and variables are renamed to be `snake_case`.
Private/protected member variables are named `member_var_`.
Public member variables are named `member_var`.

### Are these changes tested?

N/A

### Are there any user-facing changes?

No.

* GitHub Issue: #47646