### PR TITLE
GH-47664: [C++][Parquet] add num_rows_ before each call to RowGroupWriter::Close in FileSerializer

### DIFF
--- a/cpp/src/parquet/file_serialize_test.cc
+++ b/cpp/src/parquet/file_serialize_test.cc
@@ -76,6 +76,7 @@ class TestSerialize : public PrimitiveTypedTest<TestType> {
     for (int rg = 0; rg < num_rowgroups_ / 2; ++rg) {
       RowGroupWriter* row_group_writer;
       row_group_writer = file_writer->AppendRowGroup();
+      EXPECT_EQ(rows_per_rowgroup_ * rg, file_writer->num_rows());
       for (int col = 0; col < num_columns_; ++col) {
         auto column_writer =
             static_cast<TypedColumnWriter<TestType>*>(row_group_writer->NextColumn());
@@ -97,6 +98,7 @@ class TestSerialize : public PrimitiveTypedTest<TestType> {
     for (int rg = 0; rg < num_rowgroups_ / 2; ++rg) {
       RowGroupWriter* row_group_writer;
       row_group_writer = file_writer->AppendBufferedRowGroup();
+      EXPECT_EQ(rows_per_rowgroup_ * (rg + num_rowgroups_ / 2), file_writer->num_rows());
       for (int batch = 0; batch < (rows_per_rowgroup_ / rows_per_batch_); ++batch) {
         for (int col = 0; col < num_columns_; ++col) {
           auto column_writer =

--- a/cpp/src/parquet/file_writer.cc
+++ b/cpp/src/parquet/file_writer.cc
@@ -358,6 +358,7 @@ class FileSerializer : public ParquetFileWriter::Contents {
 
   RowGroupWriter* AppendRowGroup(bool buffered_row_group) {
     if (row_group_writer_) {
+      num_rows_ += row_group_writer_->num_rows();
       row_group_writer_->Close();
     }
     int16_t row_group_ordinal = -1;  // row group ordinal not set


### PR DESCRIPTION
### Rationale for this change

Fix wrong result of `num_rows()` method in `FileSerializer`.

### What changes are included in this PR?

1. add `num_rows_` before each call to `RowGroupWriter::Close` in `FileSerializer`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Now `num_rows_` will return the corrent result which is the number of rows in the yet started RowGroups.

* GitHub Issue: #47664