### PR TITLE
GH-47679: [C++] Register arrow compute calls in ODBC

### DIFF
--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/CMakeLists.txt
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/CMakeLists.txt
@@ -99,10 +99,12 @@ if(WIN32)
                          system_dsn.cc)
 endif()
 
-target_link_libraries(arrow_odbc_spi_impl PUBLIC odbcabstraction arrow_flight_sql_shared)
+target_link_libraries(arrow_odbc_spi_impl PUBLIC odbcabstraction arrow_flight_sql_shared
+                                                 arrow_compute_shared Boost::locale)
 
-if(MSVC)
-  target_link_libraries(arrow_odbc_spi_impl PUBLIC Boost::locale)
+# Link libraries on MINGW64 only
+if((MINGW AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU") OR APPLE)
+  target_link_libraries(arrow_odbc_spi_impl PUBLIC ${ODBCINST})
 endif()
 
 set_target_properties(arrow_odbc_spi_impl
@@ -121,7 +123,7 @@ set_target_properties(arrow_odbc_spi_impl_cli
 target_link_libraries(arrow_odbc_spi_impl_cli arrow_odbc_spi_impl)
 
 # Unit tests
-add_arrow_test(arrow_odbc_spi_impl_test
+add_arrow_test(odbc_spi_impl_test
                SOURCES
                accessors/boolean_array_accessor_test.cc
                accessors/binary_array_accessor_test.cc

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/CMakeLists.txt
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/CMakeLists.txt
@@ -102,8 +102,8 @@ endif()
 target_link_libraries(arrow_odbc_spi_impl PUBLIC odbcabstraction arrow_flight_sql_shared
                                                  arrow_compute_shared Boost::locale)
 
-# Link libraries on MINGW64 only
-if((MINGW AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU") OR APPLE)
+# Link libraries on MINGW64 and macOS
+if(MINGW OR APPLE)
   target_link_libraries(arrow_odbc_spi_impl PUBLIC ${ODBCINST})
 endif()
 

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_connection_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/flight_sql_connection_test.cc
@@ -204,8 +204,3 @@ TEST(PopulateCallOptionsTest, GenericOptionWithSpaces) {
 
 }  // namespace flight_sql
 }  // namespace driver
-
-int main(int argc, char** argv) {
-  ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
-}

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/include/flight_sql/flight_sql_driver.h
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/include/flight_sql/flight_sql_driver.h
@@ -39,6 +39,9 @@ class FlightSqlDriver : public odbcabstraction::Driver {
 
   void SetVersion(std::string version) override;
 
+  /// Register Arrow Compute kernels once.
+  void RegisterComputeKernels();
+
   void RegisterLog() override;
 };
 

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/utils_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/utils_test.cc
@@ -28,12 +28,15 @@
 namespace driver {
 namespace flight_sql {
 
-class UtilTestsWithCompute : public ::testing::Test {
+// A global test "environment", to ensure Arrow compute kernel functions are registered
+
+class ComputeKernelEnvironment : public ::testing::Environment {
  public:
-  // This must be done before using the compute kernels in order to
-  // register them to the FunctionRegistry.
   void SetUp() override { ASSERT_OK(arrow::compute::Initialize()); }
 };
+
+::testing::Environment* kernel_env =
+    ::testing::AddGlobalTestEnvironment(new ComputeKernelEnvironment);
 
 void AssertConvertedArray(const std::shared_ptr<arrow::Array>& expected_array,
                           const std::shared_ptr<arrow::Array>& converted_array,
@@ -88,7 +91,7 @@ void TestTime64ArrayConversion(const std::vector<int64_t>& input,
   AssertConvertedArray(expected_array, converted_array, input.size(), arrow_type);
 }
 
-TEST_F(UtilTestsWithCompute, Time32ToTimeStampArray) {
+TEST(Utils, Time32ToTimeStampArray) {
   std::vector<int32_t> input_data = {14896, 17820};
 
   const auto seconds_from_epoch = odbcabstraction::GetTodayTimeFromEpoch();
@@ -108,7 +111,7 @@ TEST_F(UtilTestsWithCompute, Time32ToTimeStampArray) {
                             arrow::Type::TIMESTAMP);
 }
 
-TEST_F(UtilTestsWithCompute, Time64ToTimeStampArray) {
+TEST(Utils, Time64ToTimeStampArray) {
   std::vector<int64_t> input_data = {1579489200000, 1646881200000};
 
   const auto seconds_from_epoch = odbcabstraction::GetTodayTimeFromEpoch();
@@ -128,7 +131,7 @@ TEST_F(UtilTestsWithCompute, Time64ToTimeStampArray) {
                             arrow::Type::TIMESTAMP);
 }
 
-TEST_F(UtilTestsWithCompute, StringToDateArray) {
+TEST(Utils, StringToDateArray) {
   std::shared_ptr<arrow::Array> expected;
   arrow::ArrayFromVector<arrow::Date64Type, int64_t>({1579489200000, 1646881200000},
                                                      &expected);
@@ -137,7 +140,7 @@ TEST_F(UtilTestsWithCompute, StringToDateArray) {
                       odbcabstraction::CDataType_DATE, arrow::Type::DATE64);
 }
 
-TEST_F(UtilTestsWithCompute, StringToTimeArray) {
+TEST(Utils, StringToTimeArray) {
   std::shared_ptr<arrow::Array> expected;
   arrow::ArrayFromVector<arrow::Time64Type, int64_t>(
       time64(arrow::TimeUnit::MICRO), {36000000000, 43200000000}, &expected);
@@ -146,7 +149,7 @@ TEST_F(UtilTestsWithCompute, StringToTimeArray) {
                       arrow::Type::TIME64);
 }
 
-TEST_F(UtilTestsWithCompute, ConvertSqlPatternToRegexString) {
+TEST(Utils, ConvertSqlPatternToRegexString) {
   ASSERT_EQ(std::string("XY"), ConvertSqlPatternToRegexString("XY"));
   ASSERT_EQ(std::string("X.Y"), ConvertSqlPatternToRegexString("X_Y"));
   ASSERT_EQ(std::string("X.*Y"), ConvertSqlPatternToRegexString("X%Y"));
@@ -154,7 +157,7 @@ TEST_F(UtilTestsWithCompute, ConvertSqlPatternToRegexString) {
   ASSERT_EQ(std::string("X_Y"), ConvertSqlPatternToRegexString("X\\_Y"));
 }
 
-TEST_F(UtilTestsWithCompute, ConvertToDBMSVer) {
+TEST(Utils, ConvertToDBMSVer) {
   ASSERT_EQ(std::string("01.02.0003"), ConvertToDBMSVer("1.2.3"));
   ASSERT_EQ(std::string("01.02.0003.0"), ConvertToDBMSVer("1.2.3.0"));
   ASSERT_EQ(std::string("01.02.0000"), ConvertToDBMSVer("1.2"));

--- a/cpp/src/arrow/flight/sql/odbc/flight_sql/utils_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/flight_sql/utils_test.cc
@@ -19,6 +19,7 @@
 
 #include "arrow/flight/sql/odbc/odbcabstraction/include/odbcabstraction/calendar_utils.h"
 
+#include "arrow/compute/initialize.h"
 #include "arrow/testing/builder.h"
 #include "arrow/testing/gtest_util.h"
 #include "arrow/testing/util.h"
@@ -26,6 +27,13 @@
 
 namespace driver {
 namespace flight_sql {
+
+class UtilTestsWithCompute : public ::testing::Test {
+ public:
+  // This must be done before using the compute kernels in order to
+  // register them to the FunctionRegistry.
+  void SetUp() override { ASSERT_OK(arrow::compute::Initialize()); }
+};
 
 void AssertConvertedArray(const std::shared_ptr<arrow::Array>& expected_array,
                           const std::shared_ptr<arrow::Array>& converted_array,
@@ -80,7 +88,7 @@ void TestTime64ArrayConversion(const std::vector<int64_t>& input,
   AssertConvertedArray(expected_array, converted_array, input.size(), arrow_type);
 }
 
-TEST(Utils, Time32ToTimeStampArray) {
+TEST_F(UtilTestsWithCompute, Time32ToTimeStampArray) {
   std::vector<int32_t> input_data = {14896, 17820};
 
   const auto seconds_from_epoch = odbcabstraction::GetTodayTimeFromEpoch();
@@ -100,7 +108,7 @@ TEST(Utils, Time32ToTimeStampArray) {
                             arrow::Type::TIMESTAMP);
 }
 
-TEST(Utils, Time64ToTimeStampArray) {
+TEST_F(UtilTestsWithCompute, Time64ToTimeStampArray) {
   std::vector<int64_t> input_data = {1579489200000, 1646881200000};
 
   const auto seconds_from_epoch = odbcabstraction::GetTodayTimeFromEpoch();
@@ -120,7 +128,7 @@ TEST(Utils, Time64ToTimeStampArray) {
                             arrow::Type::TIMESTAMP);
 }
 
-TEST(Utils, StringToDateArray) {
+TEST_F(UtilTestsWithCompute, StringToDateArray) {
   std::shared_ptr<arrow::Array> expected;
   arrow::ArrayFromVector<arrow::Date64Type, int64_t>({1579489200000, 1646881200000},
                                                      &expected);
@@ -129,7 +137,7 @@ TEST(Utils, StringToDateArray) {
                       odbcabstraction::CDataType_DATE, arrow::Type::DATE64);
 }
 
-TEST(Utils, StringToTimeArray) {
+TEST_F(UtilTestsWithCompute, StringToTimeArray) {
   std::shared_ptr<arrow::Array> expected;
   arrow::ArrayFromVector<arrow::Time64Type, int64_t>(
       time64(arrow::TimeUnit::MICRO), {36000000000, 43200000000}, &expected);
@@ -138,7 +146,7 @@ TEST(Utils, StringToTimeArray) {
                       arrow::Type::TIME64);
 }
 
-TEST(Utils, ConvertSqlPatternToRegexString) {
+TEST_F(UtilTestsWithCompute, ConvertSqlPatternToRegexString) {
   ASSERT_EQ(std::string("XY"), ConvertSqlPatternToRegexString("XY"));
   ASSERT_EQ(std::string("X.Y"), ConvertSqlPatternToRegexString("X_Y"));
   ASSERT_EQ(std::string("X.*Y"), ConvertSqlPatternToRegexString("X%Y"));
@@ -146,7 +154,7 @@ TEST(Utils, ConvertSqlPatternToRegexString) {
   ASSERT_EQ(std::string("X_Y"), ConvertSqlPatternToRegexString("X\\_Y"));
 }
 
-TEST(Utils, ConvertToDBMSVer) {
+TEST_F(UtilTestsWithCompute, ConvertToDBMSVer) {
   ASSERT_EQ(std::string("01.02.0003"), ConvertToDBMSVer("1.2.3"));
   ASSERT_EQ(std::string("01.02.0003.0"), ConvertToDBMSVer("1.2.3.0"));
   ASSERT_EQ(std::string("01.02.0000"), ConvertToDBMSVer("1.2"));


### PR DESCRIPTION
### Rationale for this change
Need to call function to register Arrow compute calls which is needed due to https://github.com/apache/arrow/issues/25025

### What changes are included in this PR?
- Add calls to `arrow::compute::Initialize`
- Remove `RUN_ALL_TESTS` that wasn't needed; it is no longer needed after fix of GH-47434.
### Are these changes tested?
- `arrow-odbc-spi-impl-test` pass locally.
### Are there any user-facing changes?
No

PR is extracted from PR https://github.com/apache/arrow/pull/46099
* GitHub Issue: #47679