### PR TITLE
GH-45644: [Python][Documentation] Timestamp with tz loses its time zone after to_numpy

### DIFF
--- a/docs/source/python/numpy.rst
+++ b/docs/source/python/numpy.rst
@@ -73,3 +73,24 @@ representation as Arrow, and assuming the Arrow data has no nulls.
 For more complex data types, you have to use the :meth:`~pyarrow.Array.to_pandas`
 method (which will construct a Numpy array with Pandas semantics for, e.g.,
 representation of null values).
+
+.. note::
+
+   Converting Arrow timestamp arrays that include a time zone (for example,
+   ``pa.timestamp('s', tz='UTC')``) to NumPy with ``to_numpy()`` will drop the
+   timezone information, because NumPy's ``datetime64`` dtype does **not**
+   carry timezone metadata. The result is a timezone-naive ``datetime64[...]``
+   array (typically representing UTC). To preserve timezone-aware semantics
+   when interoperating with pandas, use ``to_pandas()`` which preserves
+   timezones as pandas ``DatetimeTZDtype``.
+
+   Example:
+
+.. code-block:: python
+
+   import pyarrow as pa
+   x = pa.array([1735689600], type=pa.timestamp('s', tz='UTC'))
+   print(x.type)               # -> timestamp[s, tz=UTC]
+   print(x.to_numpy().dtype)   # -> datetime64[s]   (no tz)
+   print(x.to_pandas().dtype)  # -> datetime64[ns, UTC] or DatetimeTZDtype('ns','UTC')	
+	


### PR DESCRIPTION
DOC: clarify that Array.to_numpy() drops timezone for timestamp arrays (fixes #45644)

### Rationale for this change

NumPy's `datetime64` dtype does not preserve timezone metadata.  
Currently, when converting Arrow timestamp arrays with a timezone (e.g. `timestamp[s, tz=UTC]`) via `.to_numpy()`, the timezone information is silently dropped.  
This has caused user confusion (see issue #45644).  
This PR clarifies this behavior in the documentation and shows a minimal example. It also points users to `.to_pandas()` for preserving timezone-aware semantics.

### What changes are included in this PR?

- Added a note in `docs/source/python/numpy.rst` under the "Arrow → NumPy" section.  
- The note explicitly states that `.to_numpy()` returns a timezone-naive `datetime64` array.  
- Added a minimal code example comparing `.to_numpy()` vs `.to_pandas()`.

### Are these changes tested?

- Not applicable: this is a documentation-only change.  
- The included code snippet was run locally to confirm correctness.

### Are there any user-facing changes?

- Yes: clearer documentation of `.to_numpy()` limitations with timezone-aware Arrow timestamp arrays.  
- No API or functional changes.

**This PR includes breaking changes to public APIs.**  
N/A — documentation only.

**This PR contains a "Critical Fix".**  
N/A — documentation only.

* GitHub Issue: #45644