### PR TITLE
GH-47923: [CI] Use macos-15-intel instead of macos-13 for macOS x86 runner

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -186,7 +186,7 @@ jobs:
       matrix:
         include:
           - architecture: AMD64
-            macos-version: "13"
+            macos-version: "15-intel"
           - architecture: ARM64
             macos-version: "14"
     env:
@@ -257,7 +257,7 @@ jobs:
           restore-keys: cpp-ccache-macos-${{ matrix.macos-version }}-
       - name: Build
         run: |
-          if [ "${{ matrix.macos-version }}" = "13" ]; then
+          if [ "${{ matrix.macos-version }}" = "15-intel" ]; then
             # This is a workaround.
             #
             # Homebrew uses /usr/local as prefix. So packages

--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -94,7 +94,7 @@ jobs:
       matrix:
         include:
           - architecture: AMD64
-            macos-version: "13"
+            macos-version: "15-intel"
           - architecture: ARM64
             macos-version: "14"
     steps:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -148,7 +148,7 @@ jobs:
       matrix:
         include:
           - architecture: AMD64
-            macos-version: "13"
+            macos-version: "15-intel"
           - architecture: ARM64
             macos-version: "14"
     env:
@@ -219,7 +219,7 @@ jobs:
       - name: Build
         shell: bash
         run: |
-          if [ "${{ matrix.macos-version }}" = "13" ]; then
+          if [ "${{ matrix.macos-version }}" = "15-intel" ]; then
             # This is a workaround.
             #
             # Homebrew uses /usr/local as prefix. So packages

--- a/.github/workflows/verify_rc.yml
+++ b/.github/workflows/verify_rc.yml
@@ -195,7 +195,7 @@ jobs:
       fail-fast: false
       matrix:
         runs-on:
-          - macos-13
+          - macos-15-intel
           - macos-14
     env:
       RC: ${{ needs.target.outputs.rc }}

--- a/dev/tasks/matlab/github.yml
+++ b/dev/tasks/matlab/github.yml
@@ -64,7 +64,7 @@ jobs:
     strategy:
       matrix:
         platform:
-            - { architecture: "AMD64", macos-version: "13", architecture-suffix: "x64"}
+            - { architecture: "AMD64", macos-version: "15-intel", architecture-suffix: "x64"}
             - { architecture: "ARM64", macos-version: "14", architecture-suffix: "arm64"}
     steps:
       {{ macros.github_checkout_arrow()|indent }}

--- a/dev/tasks/python-wheels/github.osx.yml
+++ b/dev/tasks/python-wheels/github.osx.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Install System Dependencies
         run: |
-          brew install bash bison coreutils ninja
+          brew install bash bison coreutils ninja mono
           echo "$(brew --prefix bison)/bin" >> $GITHUB_PATH
 
       - name: Homebrew packages

--- a/dev/tasks/python-wheels/github.osx.yml
+++ b/dev/tasks/python-wheels/github.osx.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Install System Dependencies
         run: |
-          brew install bash bison coreutils ninja mono
+          brew install bash bison coreutils mono ninja
           echo "$(brew --prefix bison)/bin" >> $GITHUB_PATH
 
       - name: Homebrew packages

--- a/dev/tasks/r/github.packages.yml
+++ b/dev/tasks/r/github.packages.yml
@@ -64,7 +64,7 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - { runs_on: macos-13, arch: "x86_64" }
+          - { runs_on: macos-15-intel, arch: "x86_64" }
           - { runs_on: macos-14, arch: "arm64" }
         openssl: ['3.0', '1.1']
     env:
@@ -216,7 +216,7 @@ jobs:
       matrix:
         platform:
           - { runs_on: 'windows-latest', name: "Windows"}
-          - { runs_on: macos-13, name: "macOS x86_64"}
+          - { runs_on: macos-15-intel, name: "macOS x86_64"}
           - { runs_on: macos-14, name: "macOS arm64" }
         r_version: [oldrel, release]
     steps:
@@ -396,7 +396,7 @@ jobs:
       matrix:
         platform:
           - {runs_on: "ubuntu-latest", name: "Linux"}
-          - {runs_on: "macos-13" , name: "macOS"}
+          - {runs_on: "macos-15-intel" , name: "macOS"}
     steps:
       - name: Install R
         uses: r-lib/actions/setup-r@v2

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -219,7 +219,7 @@ tasks:
       python_version: "{{ python_version }}"
       python_abi_tag: "{{ abi_tag }}"
       macos_deployment_target: "12.0"
-      runs_on: "macos-13"
+      runs_on: "macos-15-intel"
       vcpkg_arch: "amd64"
     artifacts:
       - pyarrow-{no_rc_version}-{{ python_tag }}-{{ abi_tag }}-macosx_12_0_x86_64.whl
@@ -346,7 +346,7 @@ tasks:
     params:
       target: {{ target }}
       use_conda: True
-      github_runner: "macos-13"
+      github_runner: "macos-15-intel"
   {% endfor %}
 
   {% for target in ["cpp",
@@ -358,7 +358,7 @@ tasks:
     template: verify-rc/github.macos.yml
     params:
       target: {{ target }}
-      github_runner: "macos-13"
+      github_runner: "macos-15-intel"
   {% endfor %}
 
   {% for target in ["cpp",


### PR DESCRIPTION
### Rationale for this change

`macos-13` github runners are https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/

This PR replaces `macos-13` with `macos-15-intel` based on recommendations [here](https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories)

### What changes are included in this PR?
Change all references of `macos-13` to `macos-15-intel`

### Are these changes tested?
Yes, CI 

### Are there any user-facing changes?

No.

* GitHub Issue: #47923