### PR TITLE
GH-47682: [R] `install_pyarrow(nightly = TRUE)` installs old pyarrow

### DIFF
--- a/r/R/python.R
+++ b/r/R/python.R
@@ -326,10 +326,16 @@ as_record_batch_reader.pyarrow.lib.RecordBatchReader <- function(x, ...) {
 #' @export
 install_pyarrow <- function(envname = NULL, nightly = FALSE, ...) {
   if (nightly) {
-    reticulate::py_install("pyarrow",
-      envname = envname, ...,
+    reticulate::py_install(
+      "pyarrow",
+      envname = envname,
+      ...,
       # Nightly for pip
-      pip_options = "--extra-index-url https://repo.fury.io/arrow-nightlies/ --pre --upgrade",
+      pip_options = c(
+        "--extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple",
+        "--pre",
+        "--upgrade"
+      ),
       # Nightly for conda
       channel = "arrow-nightlies"
     )


### PR DESCRIPTION
### Rationale for this change

`install_pyarrow(nightly = TRUE)` installs pyarrow from `https://repo.fury.io/arrow-nightlies/`, but after #47470, new version of pyarrow is't released on fury.io.

### What changes are included in this PR?

Replace the index url to the new url `https://pypi.anaconda.org/scientific-python-nightly-wheels/simple`.

### Are these changes tested?

No.

### Are there any user-facing changes?

The URL used behind the scenes will change, but this will not affect functionality.


* GitHub Issue: #47682