### PR TITLE
GH-47695: [CI][Release] Link arrow-io hdfs_test to c++fs on compilers where std:::filesystem is not default present

### DIFF
--- a/cpp/src/arrow/io/CMakeLists.txt
+++ b/cpp/src/arrow/io/CMakeLists.txt
@@ -23,12 +23,22 @@ add_arrow_test(compressed_test PREFIX "arrow-io")
 add_arrow_test(file_test PREFIX "arrow-io")
 
 if(ARROW_HDFS)
+  set(HDFS_TEST_EXTRA_LINK_LIBS arrow::hadoop)
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "9")
+      list(APPEND HDFS_TEST_EXTRA_LINK_LIBS stdc++fs)
+    endif()
+  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS "8")
+      list(APPEND HDFS_TEST_EXTRA_LINK_LIBS c++fs)
+    endif()
+  endif()
   add_arrow_test(hdfs_test
                  NO_VALGRIND
                  PREFIX
                  "arrow-io"
                  EXTRA_LINK_LIBS
-                 arrow::hadoop)
+                 ${HDFS_TEST_EXTRA_LINK_LIBS})
 endif()
 
 add_arrow_test(memory_test PREFIX "arrow-io")


### PR DESCRIPTION
### Rationale for this change

Currently our verify-rc on almalinux 8 fails due to missing symbols for `std::filesystem`. If we use `std::filesystem`, we need `-lstdc++fs` with GCC 8 and `-lc++fs` for clang 7. 

### What changes are included in this PR?

Link the test to `-lc++fs` for the required compilers.

### Are these changes tested?

Yes, via archery

### Are there any user-facing changes?

No
* GitHub Issue: #47695