### PR TITLE
GH-47635: [CI][Integration] Add new gold files

### DIFF
--- a/ci/scripts/integration_arrow.sh
+++ b/ci/scripts/integration_arrow.sh
@@ -71,3 +71,4 @@ time archery integration \
     --gold-dirs="$gold_dir/1.0.0-littleendian" \
     --gold-dirs="$gold_dir/2.0.0-compression" \
     --gold-dirs="$gold_dir/4.0.0-shareddict" \
+    --gold-dirs="$gold_dir/cpp-21.0.0" \


### PR DESCRIPTION
### Rationale for this change

Update the `testing` submodule to the latest contents as of https://github.com/apache/arrow-testing/pull/114 .
This adds "gold" IPC files generated by Arrow C++ 21.0.0.

### Are these changes tested?

Yes, by existing Integration CI build.

### Are there any user-facing changes?

No.


* GitHub Issue: #47635