### PR TITLE
GH-47705: [R][CI] Migrate rhub debian-gcc-release to equivalent supported image

### DIFF
--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -733,12 +733,12 @@ tasks:
     ci: github
     template: r/github.linux.offline.build.yml
 
-  test-r-rhub-debian-gcc-release-custom-ccache:
+  test-r-rhub-ubuntu-gcc12-custom-ccache:
     ci: azure
     template: r/azure.linux.yml
     params:
       r_org: rhub
-      r_image: debian-gcc-release
+      r_image: ubuntu-gcc12
       r_tag: latest
       r_custom_ccache: true
 


### PR DESCRIPTION
### Rationale for this change

Old image fails due to debian update

### What changes are included in this PR?

Use newer image

### Are these changes tested?

Will submit crossbow run

### Are there any user-facing changes?

No
* GitHub Issue: #47705