### PR TITLE
GH-47742: [C++][CI] Silence Valgrind leak on protobuf initialization

### DIFF
--- a/cpp/valgrind.supp
+++ b/cpp/valgrind.supp
@@ -82,3 +82,15 @@
     fun:curl_share_init
     fun:*Azure*CurlConnection*
 }
+{
+    <protobuf>:leak on library initialization
+    Memcheck:Leak
+    ...
+    fun:*google*protobuf*AddDescriptors*
+}
+{
+    <protobuf>:leak on library initialization
+    Memcheck:Leak
+    ...
+    fun:*google*protobuf*RegisterGeneratedFile*
+}

--- a/cpp/valgrind.supp
+++ b/cpp/valgrind.supp
@@ -86,11 +86,11 @@
     <protobuf>:leak on library initialization
     Memcheck:Leak
     ...
-    fun:*google*protobuf*AddDescriptors*
+    fun:*google*protobuf*AddDescriptorsRunner*
 }
 {
     <protobuf>:leak on library initialization
     Memcheck:Leak
     ...
-    fun:*google*protobuf*RegisterGeneratedFile*
+    fun:*google*protobuf*InternalRegisterGeneratedFile*
 }


### PR DESCRIPTION
### Rationale for this change

Valgrind would report memory leaks induced by protobuf initialization on library load, for example:
```
==14628== 414 bytes in 16 blocks are possibly lost in loss record 22 of 26
==14628==    at 0x4914EFF: operator new(unsigned long) (vg_replace_malloc.c:487)
==14628==    by 0x8D0B6CA: void std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_construct<char*>(char*, char*, std::forward_iterator_tag) [clone .isra.0] (in /opt/conda/envs/arrow/lib/libprotobuf.so.25.3.0)
==14628==    by 0x8D33E62: google::protobuf::DescriptorPool::Tables::Tables() (in /opt/conda/envs/arrow/lib/libprotobuf.so.25.3.0)
==14628==    by 0x8D340E2: google::protobuf::DescriptorPool::DescriptorPool(google::protobuf::DescriptorDatabase*, google::protobuf::DescriptorPool::ErrorCollector*) (in /opt/conda/envs/arrow/lib/libprotobuf.so.25.3.0)
==14628==    by 0x8D341A2: google::protobuf::DescriptorPool::internal_generated_pool() (in /opt/conda/envs/arrow/lib/libprotobuf.so.25.3.0)
==14628==    by 0x8D34277: google::protobuf::DescriptorPool::InternalAddGeneratedFile(void const*, int) (in /opt/conda/envs/arrow/lib/libprotobuf.so.25.3.0)
==14628==    by 0x8D9C56F: google::protobuf::internal::AddDescriptorsRunner::AddDescriptorsRunner(google::protobuf::internal::DescriptorTable const*) (in /opt/conda/envs/arrow/lib/libprotobuf.so.25.3.0)
==14628==    by 0x40D147D: call_init.part.0 (dl-init.c:70)
==14628==    by 0x40D1567: call_init (dl-init.c:33)
==14628==    by 0x40D1567: _dl_init (dl-init.c:117)
==14628==    by 0x40EB2C9: ??? (in /usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2)
```

This was triggered by the `libprotobuf` upgrade on conda-forge from 3.21.12 to 4.25.3.

### What changes are included in this PR?

Add a Valgrind suppression for these leak reports, as there is probably not much we can do about them.

### Are these changes tested?

Yes, by existing CI test.

### Are there any user-facing changes?

No.

* GitHub Issue: #47742