### PR TITLE
GH-47632: [CI][C++] Add a CI job for JNI on Linux

### DIFF
--- a/.env
+++ b/.env
@@ -38,7 +38,7 @@ ARCH=amd64
 ARCH_ALIAS=x86_64
 ARCH_SHORT=amd64
 # For aarch64
-# ARCH=aarch64v8
+# ARCH=arm64v8
 # ARCH_ALIAS=aarch64
 # ARCH_SHORT=arm64
 

--- a/.env
+++ b/.env
@@ -37,6 +37,10 @@ DOCKER_BUILDKIT=1
 ARCH=amd64
 ARCH_ALIAS=x86_64
 ARCH_SHORT=amd64
+# For aarch64
+# ARCH=aarch64v8
+# ARCH_ALIAS=aarch64
+# ARCH_SHORT=arm64
 
 # Default repository to pull and push images from
 REPO=apache/arrow-dev

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -368,11 +368,12 @@ jobs:
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
           bash -c "ci/scripts/cpp_build.sh $(pwd) $(pwd)/build"
       - name: Test
-        shell: bash
+        shell: cmd
         run: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
           # For ORC
-          export TZDIR=/c/msys64/usr/share/zoneinfo
-          ci/scripts/cpp_test.sh $(pwd) $(pwd)/build
+          set TZDIR=C:\msys64\usr\share\zoneinfo
+          bash -c "ci/scripts/cpp_test.sh $(pwd) $(pwd)/build"
 
   windows-mingw:
     name: AMD64 Windows MinGW ${{ matrix.msystem_upper }} C++

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -321,7 +321,6 @@ jobs:
       BOOST_SOURCE: BUNDLED
       CMAKE_CXX_STANDARD: "17"
       CMAKE_GENERATOR: Ninja
-      CMAKE_INSTALL_LIBDIR: bin
       CMAKE_INSTALL_PREFIX: /usr
       CMAKE_UNITY_BUILD: ON
     steps:

--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -205,8 +205,10 @@ jobs:
         env:
           ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}
           ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
+          GITHUB_TOKEN: {{ '${{ secrets.GITHUB_TOKEN }}' }}
         run: |
           source ci/scripts/util_enable_core_dumps.sh
+          export VCPKG_BINARY_SOURCES="clear;nuget,GitHub,readwrite"
           archery docker run \
             -e ARROW_BUILD_TESTS=ON \
             -e ARROW_CMAKE_ARGS="-DARROW_BUILD_TESTS=ON" \

--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -76,7 +76,6 @@ concurrency:
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   check-labels:
@@ -174,6 +173,9 @@ jobs:
       contains(fromJSON(needs.check-labels.outputs.ci-extra-labels || '[]'), 'CI: Extra') ||
       contains(fromJSON(needs.check-labels.outputs.ci-extra-labels || '[]'), 'CI: Extra: C++')
     timeout-minutes: 240
+    permissions:
+      # This is for using GitHub Packages for vcpkg cache
+      packages: write
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -172,7 +172,7 @@ jobs:
       needs.check-labels.outputs.force == 'true' ||
       contains(fromJSON(needs.check-labels.outputs.ci-extra-labels || '[]'), 'CI: Extra') ||
       contains(fromJSON(needs.check-labels.outputs.ci-extra-labels || '[]'), 'CI: Extra: C++')
-    timeout-minutes: 120
+    timeout-minutes: 240
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -164,6 +164,56 @@ jobs:
         continue-on-error: true
         run: archery docker push ${{ matrix.image }}
 
+  jni-linux:
+    needs: check-labels
+    name: JNI ${{ matrix.platform.runs-on }} ${{ matrix.platform.arch }}
+    runs-on: ${{ matrix.platform.runs-on }}
+    if: needs.check-labels.outputs.ci-extra == 'true'
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - runs-on: ubuntu-latest
+            arch: "amd64"
+          - runs-on: ubuntu-24.04-arm
+            arch: "arm64v8"
+    env:
+      ARCH: ${{ matrix.platform.arch }}
+    steps:
+      - name: Checkout Arrow
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+          submodules: recursive
+      - name: Cache Docker Volumes
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: .docker
+          key: jni-${{ matrix.platform.runs-on }}-${{ hashFiles('cpp/**') }}
+          restore-keys: jni-${{ matrix.platform.runs-on }}-
+      - name: Setup Python
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+        with:
+          python-version: 3
+      - name: Setup Archery
+        run: python3 -m pip install -e dev/archery[docker]
+      - name: Execute Docker Build
+        env:
+          ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}
+          ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          source ci/scripts/util_enable_core_dumps.sh
+          archery docker run \
+            -e ARROW_BUILD_TESTS=ON \
+            -e ARROW_CMAKE_ARGS="-DARROW_BUILD_TESTS=ON" \
+            -e CMAKE_PRESET=ninja-release-jni-linux \
+            -e VCPKG_ROOT=/opt/vcpkg \
+            -e VCPKG_TARGET_TRIPLET=${ARCH}-linux-static-release \
+            python-wheel-manylinux-2-28 \
+              '/arrow/ci/scripts/cpp_build.sh /arrow /build && \
+               /arrow/ci/scripts/cpp_test.sh /arrow /build'
+
   jni-macos:
     needs: check-labels
     name: JNI macOS
@@ -177,7 +227,7 @@ jobs:
       MACOSX_DEPLOYMENT_TARGET: "14.0"
     steps:
       - name: Checkout Arrow
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
           submodules: recursive

--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -76,6 +76,7 @@ concurrency:
 
 permissions:
   contents: read
+  packages: write
 
 jobs:
   check-labels:
@@ -206,9 +207,9 @@ jobs:
           ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}
           ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VCPKG_BINARY_SOURCES: "clear;nuget,GitHub,readwrite"
         run: |
           source ci/scripts/util_enable_core_dumps.sh
-          export VCPKG_BINARY_SOURCES="clear;nuget,GitHub,readwrite"
           archery docker run \
             -e ARROW_BUILD_TESTS=ON \
             -e ARROW_CMAKE_ARGS="-DARROW_BUILD_TESTS=ON" \

--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -214,6 +214,16 @@ jobs:
         run: |
           source ci/scripts/util_enable_core_dumps.sh
           archery docker run cpp-jni
+      - name: Docker Push
+        if: >-
+          success() &&
+          github.event_name == 'push' &&
+          github.ref_name == 'main'
+        env:
+          ARCHERY_DOCKER_USER: ${{ github.actor }}
+          ARCHERY_DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
+        run: archery docker push cpp-jni
 
   jni-macos:
     needs: check-labels

--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -167,7 +167,7 @@ jobs:
 
   jni-linux:
     needs: check-labels
-    name: JNI ${{ matrix.platform.runs-on }} ${{ matrix.platform.arch }}
+    name: JNI ${{ matrix.platform.runs-on }} ${{ matrix.platform.archery-arch }}
     runs-on: ${{ matrix.platform.runs-on }}
     if: >-
       needs.check-labels.outputs.force == 'true' ||
@@ -178,15 +178,15 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - archery_arch: "amd64"
+          - archery-arch: "amd64"
             runs-on: ubuntu-latest
-            vcpkg_arch: "amd64"
-          - archery_arch: "arm64v8"
+            vcpkg-arch: "amd64"
+          - archery-arch: "arm64v8"
             runs-on: ubuntu-24.04-arm
-            vcpkg_arch: "arm64"
+            vcpkg-arch: "arm64"
     env:
-      ARCH: ${{ matrix.platform.archery_arch }}
-      VCPKG_ARCH: ${{ matrix.platform.vcpkg_arch }}
+      ARCH: ${{ matrix.platform.archery-arch }}
+      VCPKG_ARCH: ${{ matrix.platform.vcpkg-arch }}
     steps:
       - name: Checkout Arrow
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -168,7 +168,10 @@ jobs:
     needs: check-labels
     name: JNI ${{ matrix.platform.runs-on }} ${{ matrix.platform.arch }}
     runs-on: ${{ matrix.platform.runs-on }}
-    if: needs.check-labels.outputs.ci-extra == 'true'
+    if: >-
+      needs.check-labels.outputs.force == 'true' ||
+      contains(fromJSON(needs.check-labels.outputs.ci-extra-labels || '[]'), 'CI: Extra') ||
+      contains(fromJSON(needs.check-labels.outputs.ci-extra-labels || '[]'), 'CI: Extra: C++')
     timeout-minutes: 120
     strategy:
       fail-fast: false

--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -181,17 +181,11 @@ jobs:
       matrix:
         platform:
           - arch: "amd64"
-            arch-alias: "x86_64"
-            arch-short: "amd64"
             runs-on: ubuntu-latest
-          - arch: "aarch64v8"
-            arch-alias: "aarch64"
-            arch-short: "arm64"
+          - arch: "arm64v8"
             runs-on: ubuntu-24.04-arm
     env:
       ARCH: ${{ matrix.platform.arch }}
-      ARCH_ALIAS: ${{ matrix.platform.arch-alias }}
-      ARCH_SHORT: ${{ matrix.platform.arch-short }}
       REPO: ghcr.io/${{ github.repository }}-dev
     steps:
       - name: Checkout Arrow

--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -212,7 +212,7 @@ jobs:
           source ci/scripts/util_enable_core_dumps.sh
           archery docker run \
             -e ARROW_BUILD_TESTS=ON \
-            -e ARROW_CMAKE_ARGS="-DARROW_BUILD_TESTS=ON" \
+            -e ARROW_CMAKE_ARGS="-DARROW_BUILD_TESTS=ON -DCMAKE_FIND_DEBUG_MODE=ON" \
             -e CMAKE_PRESET=ninja-release-jni-linux \
             -e VCPKG_ROOT=/opt/vcpkg \
             -e VCPKG_TARGET_TRIPLET=${ARCH}-linux-static-release \

--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -205,7 +205,7 @@ jobs:
         env:
           ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}
           ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
-          GITHUB_TOKEN: {{ '${{ secrets.GITHUB_TOKEN }}' }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           source ci/scripts/util_enable_core_dumps.sh
           export VCPKG_BINARY_SOURCES="clear;nuget,GitHub,readwrite"

--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -178,12 +178,15 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - runs-on: ubuntu-latest
-            arch: "amd64"
-          - runs-on: ubuntu-24.04-arm
-            arch: "arm64v8"
+          - archery_arch: "amd64"
+            runs-on: ubuntu-latest
+            vcpkg_arch: "amd64"
+          - archery_arch: "arm64v8"
+            runs-on: ubuntu-24.04-arm
+            vcpkg_arch: "arm64"
     env:
-      ARCH: ${{ matrix.platform.arch }}
+      ARCH: ${{ matrix.platform.archery_arch }}
+      VCPKG_ARCH: ${{ matrix.platform.vcpkg_arch }}
     steps:
       - name: Checkout Arrow
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -215,7 +218,7 @@ jobs:
             -e ARROW_CMAKE_ARGS="-DARROW_BUILD_TESTS=ON -DCMAKE_FIND_DEBUG_MODE=ON" \
             -e CMAKE_PRESET=ninja-release-jni-linux \
             -e VCPKG_ROOT=/opt/vcpkg \
-            -e VCPKG_TARGET_TRIPLET=${ARCH}-linux-static-release \
+            -e VCPKG_TARGET_TRIPLET=${VCPKG_ARCH}-linux-static-release \
             python-wheel-manylinux-2-28 \
               '/arrow/ci/scripts/cpp_build.sh /arrow /build && \
                /arrow/ci/scripts/cpp_test.sh /arrow /build'

--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -215,7 +215,7 @@ jobs:
           source ci/scripts/util_enable_core_dumps.sh
           archery docker run \
             -e ARROW_BUILD_TESTS=ON \
-            -e ARROW_CMAKE_ARGS="-DARROW_BUILD_TESTS=ON -DCMAKE_FIND_DEBUG_MODE=ON" \
+            -e ARROW_CMAKE_ARGS="-DARROW_BUILD_TESTS=ON" \
             -e CMAKE_PRESET=ninja-release-jni-linux \
             -e VCPKG_ROOT=/opt/vcpkg \
             -e VCPKG_TARGET_TRIPLET=${VCPKG_ARCH}-linux-static-release \

--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -166,7 +166,7 @@ jobs:
 
   jni-linux:
     needs: check-labels
-    name: JNI ${{ matrix.platform.runs-on }} ${{ matrix.platform.archery-arch }}
+    name: JNI ${{ matrix.platform.runs-on }} ${{ matrix.platform.arch }}
     runs-on: ${{ matrix.platform.runs-on }}
     if: >-
       needs.check-labels.outputs.force == 'true' ||
@@ -180,15 +180,19 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - archery-arch: "amd64"
+          - arch: "amd64"
+            arch-alias: "x86_64"
+            arch-short: "amd64"
             runs-on: ubuntu-latest
-            vcpkg-arch: "amd64"
-          - archery-arch: "arm64v8"
+          - arch: "aarch64v8"
+            arch-alias: "aarch64"
+            arch-short: "arm64"
             runs-on: ubuntu-24.04-arm
-            vcpkg-arch: "arm64"
     env:
-      ARCH: ${{ matrix.platform.archery-arch }}
-      VCPKG_ARCH: ${{ matrix.platform.vcpkg-arch }}
+      ARCH: ${{ matrix.platform.arch }}
+      ARCH_ALIAS: ${{ matrix.platform.arch-alias }}
+      ARCH_SHORT: ${{ matrix.platform.arch-short }}
+      REPO: ghcr.io/${{ github.repository }}-dev
     steps:
       - name: Checkout Arrow
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -209,21 +213,13 @@ jobs:
         run: python3 -m pip install -e dev/archery[docker]
       - name: Execute Docker Build
         env:
-          ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}
-          ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
+          ARCHERY_DOCKER_USER: ${{ github.actor }}
+          ARCHERY_DOCKER_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VCPKG_BINARY_SOURCES: "clear;nuget,GitHub,readwrite"
         run: |
           source ci/scripts/util_enable_core_dumps.sh
-          archery docker run \
-            -e ARROW_BUILD_TESTS=ON \
-            -e ARROW_CMAKE_ARGS="-DARROW_BUILD_TESTS=ON" \
-            -e CMAKE_PRESET=ninja-release-jni-linux \
-            -e VCPKG_ROOT=/opt/vcpkg \
-            -e VCPKG_TARGET_TRIPLET=${VCPKG_ARCH}-linux-static-release \
-            python-wheel-manylinux-2-28 \
-              '/arrow/ci/scripts/cpp_build.sh /arrow /build && \
-               /arrow/ci/scripts/cpp_test.sh /arrow /build'
+          archery docker run cpp-jni
 
   jni-macos:
     needs: check-labels

--- a/ci/docker/python-wheel-manylinux.dockerfile
+++ b/ci/docker/python-wheel-manylinux.dockerfile
@@ -89,7 +89,9 @@ RUN --mount=type=secret,id=github_repository_owner \
         --x-install-root=${VCPKG_ROOT}/installed \
         --x-manifest-root=/arrow/ci/vcpkg \
         --x-feature=azure \
+        --x-feature=dev \
         --x-feature=flight \
+        --x-feature=gandiva \
         --x-feature=gcs \
         --x-feature=json \
         --x-feature=orc \

--- a/ci/scripts/cpp_build.sh
+++ b/ci/scripts/cpp_build.sh
@@ -174,6 +174,11 @@ elif [ "${ARROW_EMSCRIPTEN:-OFF}" = "ON" ]; then
     -DCMAKE_UNITY_BUILD=${CMAKE_UNITY_BUILD:-OFF} \
     ${ARROW_CMAKE_ARGS} \
     ${source_dir}
+elif [ -n "${CMAKE_PRESET}" ]; then
+  cmake \
+    --preset="${CMAKE_PRESET}" \
+    ${ARROW_CMAKE_ARGS} \
+    ${source_dir}
 else
   cmake \
     -Dabsl_SOURCE=${absl_SOURCE:-} \
@@ -308,10 +313,14 @@ fi
 popd
 
 if [ -x "$(command -v ldconfig)" ]; then
-  if [ -x "$(command -v sudo)" ]; then
-    SUDO=sudo
-  else
+  if [ "$(id --user)" -eq 0 ]; then
     SUDO=
+  else
+    if [ -x "$(command -v sudo)" ]; then
+      SUDO=sudo
+    else
+      SUDO=
+    fi
   fi
   ${SUDO} ldconfig ${ARROW_HOME}/${CMAKE_INSTALL_LIBDIR:-lib}
 fi

--- a/ci/scripts/cpp_test.sh
+++ b/ci/scripts/cpp_test.sh
@@ -140,7 +140,7 @@ if [ "${ARROW_USE_MESON:-OFF}" = "OFF" ] && \
     -S "${source_dir}/examples/minimal_build" \
     -B "${build_dir}/examples/minimal_build" \
     -DCMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH}"
-  cmake --build "${build_dir}/examples/minimal_build"
+  cmake --build "${build_dir}/examples/minimal_build" --verbose
   pushd "${source_dir}/examples/minimal_build"
   # PATH= is for Windows.
   PATH="${CMAKE_INSTALL_PREFIX:-${ARROW_HOME}}/bin:${PATH}" \

--- a/ci/scripts/cpp_test.sh
+++ b/ci/scripts/cpp_test.sh
@@ -47,6 +47,12 @@ ctest_options=()
 if ! type azurite >/dev/null 2>&1; then
   exclude_tests+=("arrow-azurefs-test")
 fi
+if ! type storage-testbench >/dev/null 2>&1; then
+  exclude_tests+=("arrow-gcsfs-test")
+fi
+if ! type minio >/dev/null 2>&1; then
+  exclude_tests+=("arrow-s3fs-test")
+fi
 case "$(uname)" in
   Linux)
     n_jobs=$(nproc)
@@ -112,6 +118,21 @@ else
     --timeout "${ARROW_CTEST_TIMEOUT:-300}" \
     "${ctest_options[@]}" \
     "$@"
+fi
+
+if [ "${ARROW_USE_MESON:-OFF}" = "OFF" ] && [ "${ARROW_EMSCRIPTEN:-OFF}" = "OFF" ]; then
+  CMAKE_PREFIX_PATH="${CMAKE_INSTALL_PREFIX:-${ARROW_HOME}}"
+  if [ -n "${VCPKG_ROOT}" ] && [ -n "${VCPKG_TARGET_TRIPLET}" ]; then
+    CMAKE_PREFIX_PATH+=";${VCPKG_ROOT}/installed/${VCPKG_TARGET_TRIPLET}"
+  fi
+  cmake \
+    -S ${source_dir}/examples/minimal_build \
+    -B ${build_dir}/examples/minimal_build \
+    -DCMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH}"
+  cmake --build ${build_dir}/examples/minimal_build
+  pushd ${source_dir}/examples/minimal_build
+  ${build_dir}/examples/minimal_build/arrow-example
+  popd
 fi
 
 if [ "${ARROW_BUILD_EXAMPLES}" == "ON" ]; then

--- a/ci/scripts/cpp_test.sh
+++ b/ci/scripts/cpp_test.sh
@@ -139,11 +139,12 @@ if [ "${ARROW_USE_MESON:-OFF}" = "OFF" ] && \
   cmake \
     -S "${source_dir}/examples/minimal_build" \
     -B "${build_dir}/examples/minimal_build" \
-    -DCMAKE_FIND_DEBUG_MODE=ON \
     -DCMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH}"
   cmake --build "${build_dir}/examples/minimal_build"
   pushd "${source_dir}/examples/minimal_build"
-  "${build_dir}/examples/minimal_build/arrow-example"
+  # PATH= is for Windows.
+  PATH="${CMAKE_INSTALL_PREFIX:-${ARROW_HOME}}/bin:${PATH}" \
+    "${build_dir}/examples/minimal_build/arrow-example"
   popd
 fi
 

--- a/ci/scripts/cpp_test.sh
+++ b/ci/scripts/cpp_test.sh
@@ -128,12 +128,12 @@ if [ "${ARROW_USE_MESON:-OFF}" != "OFF" ] && \
     CMAKE_PREFIX_PATH+=";${VCPKG_ROOT}/installed/${VCPKG_TARGET_TRIPLET}"
   fi
   cmake \
-    -S ${source_dir}/examples/minimal_build \
-    -B ${build_dir}/examples/minimal_build \
+    -S "${source_dir}/examples/minimal_build" \
+    -B "${build_dir}/examples/minimal_build" \
     -DCMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH}"
-  cmake --build ${build_dir}/examples/minimal_build
-  pushd ${source_dir}/examples/minimal_build
-  ${build_dir}/examples/minimal_build/arrow-example
+  cmake --build "${build_dir}/examples/minimal_build"
+  pushd "${source_dir}/examples/minimal_build"
+  "${build_dir}/examples/minimal_build/arrow-example"
   popd
 fi
 

--- a/ci/scripts/cpp_test.sh
+++ b/ci/scripts/cpp_test.sh
@@ -140,7 +140,7 @@ if [ "${ARROW_USE_MESON:-OFF}" = "OFF" ] && \
     -S "${source_dir}/examples/minimal_build" \
     -B "${build_dir}/examples/minimal_build" \
     -DCMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH}"
-  cmake --build "${build_dir}/examples/minimal_build" --verbose
+  cmake --build "${build_dir}/examples/minimal_build"
   pushd "${source_dir}/examples/minimal_build"
   # PATH= is for Windows.
   PATH="${CMAKE_INSTALL_PREFIX:-${ARROW_HOME}}/bin:${PATH}" \

--- a/ci/scripts/cpp_test.sh
+++ b/ci/scripts/cpp_test.sh
@@ -124,6 +124,15 @@ if [ "${ARROW_USE_MESON:-OFF}" = "OFF" ] && \
      [ "${ARROW_EMSCRIPTEN:-OFF}" = "OFF" ] && \
      [ "${ARROW_USE_ASAN:-OFF}" = "OFF" ]; then
   CMAKE_PREFIX_PATH="${CMAKE_INSTALL_PREFIX:-${ARROW_HOME}}"
+  case "$(uname)" in
+    MINGW*)
+      # <prefix>/lib/cmake/ isn't searched on Windows.
+      #
+      # See also:
+      # https://cmake.org/cmake/help/latest/command/find_package.html#config-mode-search-procedure
+      CMAKE_PREFIX_PATH+="/lib/cmake/"
+      ;;
+  esac
   if [ -n "${VCPKG_ROOT}" ] && [ -n "${VCPKG_TARGET_TRIPLET}" ]; then
     CMAKE_PREFIX_PATH+=";${VCPKG_ROOT}/installed/${VCPKG_TARGET_TRIPLET}"
   fi

--- a/ci/scripts/cpp_test.sh
+++ b/ci/scripts/cpp_test.sh
@@ -120,7 +120,7 @@ else
     "$@"
 fi
 
-if [ "${ARROW_USE_MESON:-OFF}" != "OFF" ] && \
+if [ "${ARROW_USE_MESON:-OFF}" = "OFF" ] && \
      [ "${ARROW_EMSCRIPTEN:-OFF}" = "OFF" ] && \
      [ "${ARROW_USE_ASAN:-OFF}" = "OFF" ]; then
   CMAKE_PREFIX_PATH="${CMAKE_INSTALL_PREFIX:-${ARROW_HOME}}"

--- a/ci/scripts/cpp_test.sh
+++ b/ci/scripts/cpp_test.sh
@@ -120,6 +120,13 @@ else
     "$@"
 fi
 
+# This is for testing find_package(Arrow).
+#
+# Note that this is not a perfect solution. We should improve this
+# later.
+#
+# * This is ad-hoc
+# * This doesn't test other CMake packages such as ArrowDataset
 if [ "${ARROW_USE_MESON:-OFF}" = "OFF" ] && \
      [ "${ARROW_EMSCRIPTEN:-OFF}" = "OFF" ] && \
      [ "${ARROW_USE_ASAN:-OFF}" = "OFF" ]; then
@@ -133,8 +140,8 @@ if [ "${ARROW_USE_MESON:-OFF}" = "OFF" ] && \
       CMAKE_PREFIX_PATH+="/lib/cmake/"
       ;;
   esac
-  if [ -n "${VCPKG_ROOT}" ] && [ -n "${VCPKG_TARGET_TRIPLET}" ]; then
-    CMAKE_PREFIX_PATH+=";${VCPKG_ROOT}/installed/${VCPKG_TARGET_TRIPLET}"
+  if [ -n "${VCPKG_ROOT}" ] && [ -n "${VCPKG_DEFAULT_TRIPLET}" ]; then
+    CMAKE_PREFIX_PATH+=";${VCPKG_ROOT}/installed/${VCPKG_DEFAULT_TRIPLET}"
   fi
   cmake \
     -S "${source_dir}/examples/minimal_build" \

--- a/ci/scripts/cpp_test.sh
+++ b/ci/scripts/cpp_test.sh
@@ -130,6 +130,7 @@ if [ "${ARROW_USE_MESON:-OFF}" != "OFF" ] && \
   cmake \
     -S "${source_dir}/examples/minimal_build" \
     -B "${build_dir}/examples/minimal_build" \
+    -DCMAKE_FIND_DEBUG_MODE=ON \
     -DCMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH}"
   cmake --build "${build_dir}/examples/minimal_build"
   pushd "${source_dir}/examples/minimal_build"

--- a/ci/scripts/cpp_test.sh
+++ b/ci/scripts/cpp_test.sh
@@ -120,7 +120,9 @@ else
     "$@"
 fi
 
-if [ "${ARROW_USE_MESON:-OFF}" = "OFF" ] && [ "${ARROW_EMSCRIPTEN:-OFF}" = "OFF" ]; then
+if [ "${ARROW_USE_MESON:-OFF}" != "OFF" ] && \
+     [ "${ARROW_EMSCRIPTEN:-OFF}" = "OFF" ] && \
+     [ "${ARROW_USE_ASAN:-OFF}" = "OFF" ]; then
   CMAKE_PREFIX_PATH="${CMAKE_INSTALL_PREFIX:-${ARROW_HOME}}"
   if [ -n "${VCPKG_ROOT}" ] && [ -n "${VCPKG_TARGET_TRIPLET}" ]; then
     CMAKE_PREFIX_PATH+=";${VCPKG_ROOT}/installed/${VCPKG_TARGET_TRIPLET}"

--- a/ci/vcpkg/vcpkg.json
+++ b/ci/vcpkg/vcpkg.json
@@ -19,6 +19,7 @@
     "re2",
     "snappy",
     "utf8proc",
+    "xsimd",
     "zlib",
     "zstd",
     {

--- a/ci/vcpkg/vcpkg.json
+++ b/ci/vcpkg/vcpkg.json
@@ -40,6 +40,10 @@
         "boost-crc",
         "boost-filesystem",
         "boost-process",
+        {
+          "name": "gdb",
+          "platform": "!windows"
+        },
         "gtest"
       ]
     },

--- a/ci/vcpkg/vcpkg.json
+++ b/ci/vcpkg/vcpkg.json
@@ -40,10 +40,6 @@
         "boost-crc",
         "boost-filesystem",
         "boost-process",
-        {
-          "name": "gdb",
-          "platform": "!windows"
-        },
         "gtest"
       ]
     },

--- a/cpp/CMakePresets.json
+++ b/cpp/CMakePresets.json
@@ -583,6 +583,37 @@
       "cacheVariables": {}
     },
     {
+      "name": "ninja-release-jni-linux",
+      "inherits": [
+        "base-release"
+      ],
+      "displayName": "Build for JNI on Linux",
+      "cacheVariables": {
+        "ARROW_ACERO": "ON",
+        "ARROW_BUILD_SHARED": "OFF",
+        "ARROW_BUILD_STATIC": "ON",
+        "ARROW_CSV": "ON",
+        "ARROW_DATASET": "ON",
+        "ARROW_DEPENDENCY_SOURCE": "VCPKG",
+        "ARROW_DEPENDENCY_USE_SHARED": "OFF",
+        "ARROW_GANDIVA": "ON",
+        "ARROW_GANDIVA_STATIC_LIBSTDCPP": "ON",
+        "ARROW_GCS": "ON",
+        "ARROW_JSON": "ON",
+        "ARROW_ORC": "ON",
+        "ARROW_PARQUET": "ON",
+        "ARROW_RPATH_ORIGIN": "ON",
+        "ARROW_S3": "ON",
+        "ARROW_SUBSTRAIT": "ON",
+        "PARQUET_BUILD_EXAMPLES": "OFF",
+        "PARQUET_BUILD_EXECUTABLES": "OFF",
+        "PARQUET_REQUIRE_ENCRYPTION": "OFF",
+        "VCPKG_MANIFEST_MODE": "OFF",
+        "VCPKG_ROOT": "$env{VCPKG_ROOT}",
+        "VCPKG_TARGET_TRIPLET": "$env{VCPKG_TARGET_TRIPLET}"
+      }
+    },
+    {
       "name": "ninja-release-jni-macos",
       "inherits": [
         "base-release"

--- a/cpp/src/arrow/testing/process.cc
+++ b/cpp/src/arrow/testing/process.cc
@@ -176,7 +176,7 @@ class Process::Impl {
       for (const auto& kv : process::environment::current()) {
         env[kv.key()] = process::environment::value(kv.value());
       }
-      env["PATH"] = process::environment::value(current_exe.parent_path());
+      env["PATH"] = process::environment::value(current_exe.parent_path().string());
       executable_ = process::environment::find_executable(name, env);
 #  else
       executable_ = process::search_path(name, {current_exe.parent_path()});

--- a/cpp/src/gandiva/tests/projector_test.cc
+++ b/cpp/src/gandiva/tests/projector_test.cc
@@ -389,6 +389,10 @@ TEST_F(TestProjector, TestAllIntTypes) {
 }
 
 TEST_F(TestProjector, TestExtendedMath) {
+#ifdef __aarch64__
+  GTEST_SKIP() << "Failed on aarch64 with 'JIT session error: Symbols not found: [ "
+                  "__multf3, __subtf3, __trunctfdf2, __extenddftf2, __divtf3 ]'";
+#endif
   // schema for input fields
   auto field0 = arrow::field("f0", arrow::float64());
   auto field1 = arrow::field("f1", arrow::float64());

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -774,7 +774,7 @@ services:
     # Usage:
     #   docker compose run --rm cpp-jni
     # Parameters:
-    #   ARCH: amd64, aarch64v8
+    #   ARCH: amd64, arm64v8
     #   ARCH_ALIAS: x86_64, aarch64
     #   ARCH_SHORT: amd64, arm64
     image: ${REPO}:${ARCH}-cpp-jni-${VCPKG}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -130,6 +130,7 @@ x-hierarchy:
         - conda-python-spark
   - conda-verify-rc
   - conan
+  - cpp-jni
   - debian-cpp:
     - debian-c-glib:
       - debian-ruby
@@ -187,6 +188,8 @@ volumes:
     name: ${ARCH}-alpine-linux-ccache
   conda-ccache:
     name: ${ARCH}-conda-ccache
+  cpp-jni-ccache:
+    name: ${ARCH}-cpp-jni-ccache
   debian-ccache:
     name: ${ARCH}-debian-${DEBIAN}-ccache
   fedora-ccache:
@@ -764,6 +767,37 @@ services:
         sudo /arrow/ci/scripts/install_sccache.sh unknown-linux-musl /usr/local/bin &&
         /arrow/ci/scripts/conan_setup.sh &&
         /arrow/ci/scripts/conan_build.sh /arrow /build"
+
+  cpp-jni:
+    # Test for the build configuration for JNI.
+    #
+    # Usage:
+    #   docker compose run --rm cpp-jni
+    # Parameters:
+    #   ARCH: amd64, aarch64v8
+    #   ARCH_ALIAS: x86_64, aarch64
+    #   ARCH_SHORT: amd64, arm64
+    image: ${REPO}:${ARCH}-cpp-jni-${VCPKG}
+    build:
+      args:
+        arch: ${ARCH}
+        arch_short: ${ARCH_SHORT}
+        # See available versions at:
+        #   https://quay.io/repository/pypa/manylinux_2_28_x86_64?tab=tags
+        #   https://quay.io/repository/pypa/manylinux_2_28_aarch64?tab=tags
+        base: quay.io/pypa/manylinux_2_28_${ARCH_ALIAS}:2025.10.09-1
+        vcpkg: ${VCPKG}
+      context: .
+      dockerfile: ci/docker/cpp-jni.dockerfile
+      cache_from:
+        - ${REPO}:${ARCH}-cpp-jni-${VCPKG}
+      secrets: *vcpkg-build-secrets
+    environment:
+      <<: [*common, *ccache]
+    volumes:
+      - .:/arrow:delegated
+      - ${DOCKER_VOLUME_PREFIX}cpp-jni-ccache:/ccache:delegated
+    command: *cpp-command
 
   ############################### C GLib ######################################
 


### PR DESCRIPTION
### Rationale for this change

This is for preventing to break Apache Arrow Java JNI use case on Linux.

### What changes are included in this PR?

* Add a CI job that uses build options for JNI use case
* Install more packages in manylinux image that is also used by JNI build 

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #47632