### PR TITLE
GH-47748: [C++][Dataset] Fix link error on macOS

### DIFF
--- a/cpp/src/arrow/ArrowConfig.cmake.in
+++ b/cpp/src/arrow/ArrowConfig.cmake.in
@@ -129,6 +129,8 @@ if(TARGET Arrow::arrow_static AND NOT TARGET Arrow::arrow_bundled_dependencies)
       find_library(CORE_FOUNDATION CoreFoundation)
       target_link_libraries(Arrow::arrow_bundled_dependencies
                             INTERFACE ${CORE_FOUNDATION})
+      find_library(NETWORK Network)
+      target_link_libraries(Arrow::arrow_bundled_dependencies INTERFACE ${NETWORK})
       find_library(SECURITY Security)
       target_link_libraries(Arrow::arrow_bundled_dependencies INTERFACE ${SECURITY})
     elseif(WIN32)

--- a/cpp/src/arrow/ArrowConfig.cmake.in
+++ b/cpp/src/arrow/ArrowConfig.cmake.in
@@ -124,7 +124,7 @@ if(TARGET Arrow::arrow_static AND NOT TARGET Arrow::arrow_bundled_dependencies)
   # https://cmake.org/cmake/help/latest/policy/CMP0057.html
   cmake_policy(PUSH)
   cmake_policy(SET CMP0057 NEW)
-  if("AWS::aws-c-common" IN_LIST ARROW_BUNDLED_STATIC_LIBS)
+  if("aws-c-common" IN_LIST ARROW_BUNDLED_STATIC_LIBS)
     if(APPLE)
       find_library(CORE_FOUNDATION CoreFoundation)
       target_link_libraries(Arrow::arrow_bundled_dependencies

--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -780,7 +780,6 @@ if(ARROW_COMPUTE)
        compute/kernels/scalar_temporal_binary.cc
        compute/kernels/scalar_temporal_unary.cc
        compute/kernels/scalar_validity.cc
-       compute/kernels/temporal_internal.cc
        compute/kernels/util_internal.cc
        compute/kernels/vector_array_sort.cc
        compute/kernels/vector_cumulative_ops.cc

--- a/cpp/src/arrow/compute/kernels/temporal_internal.h
+++ b/cpp/src/arrow/compute/kernels/temporal_internal.h
@@ -80,7 +80,7 @@ inline int64_t GetQuarter(const year_month_day& ymd) {
   return static_cast<int64_t>((static_cast<uint32_t>(ymd.month()) - 1) / 3);
 }
 
-Result<ArrowTimeZone> LocateZone(const std::string_view timezone);
+ARROW_EXPORT Result<ArrowTimeZone> LocateZone(const std::string_view timezone);
 
 static inline const std::string& GetInputTimezone(const DataType& type) {
   static const std::string no_timezone = "";

--- a/cpp/src/arrow/meson.build
+++ b/cpp/src/arrow/meson.build
@@ -525,7 +525,6 @@ if needs_compute
         'compute/kernels/scalar_temporal_binary.cc',
         'compute/kernels/scalar_temporal_unary.cc',
         'compute/kernels/scalar_validity.cc',
-        'compute/kernels/temporal_internal.cc',
         'compute/kernels/util_internal.cc',
         'compute/kernels/vector_array_sort.cc',
         'compute/kernels/vector_cumulative_ops.cc',


### PR DESCRIPTION
### Rationale for this change

There are link errors with build options for JNI on macOS.

### What changes are included in this PR?

`ARROW_BUNDLED_STATIC_LIBS` has CMake target names defined in Apache Arrow not `find_package()`-ed target names. So we should use `aws-c-common` not `AWS::aws-c-common`.

Recent aws-c-common or something use the Network framework. So add `Network` to `Arrow::arrow_bundled_dependencies` dependencies.

Don't use `compute/kernels/temporal_internal.cc` in `libarrow.dylib` and `libarrow_compute.dylib` to avoid duplicated symbols error.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #47748