### PR TITLE
GH-47751: [CI] Fix check for job to ignore on reporting

### DIFF
--- a/dev/archery/archery/ci/core.py
+++ b/dev/archery/archery/ci/core.py
@@ -70,7 +70,7 @@ class Workflow:
                 # from the reusable workflow this will be report-ci.
                 # The real job_data['name'] is the display name, like
                 # "report-extra-cpp / report-ci".
-                if self.ignore_job in job_data.get('name'):
+                if self.ignore_job not in job_data.get('name'):
                     job = Job(job_data)
                     jobs.append(job)
         return jobs


### PR DESCRIPTION
### Rationale for this change

It failed notifying on Zulip and the email, see:
https://lists.apache.org/thread/12glcwk1jb8lb5x6lw3t2vr6zn9kp66v

We basically were ignoring all jobs except the report-ci :disappointed: 

### What changes are included in this PR?

The check was wrong, I clearly did not test this properly after the latest change, sorry about that.

### Are these changes tested?

I validated locally, without the change:
```
$ archery ci report-chat --dry-run --ignore report-ci --repository apache/arrow 18329667061

*Extra CI GitHub report for <https://github.com/apache/arrow/actions/runs/18329667061|C++ Extra>*


:tada: *1 successful jobs*
```
It shows successful because it has now finished, this is not the case when is running on CI, but only a single job which is not expected, it should show 5!

with the change:
```
archery ci report-chat --dry-run --ignore report-ci --repository apache/arrow 18329667061

*Extra CI GitHub report for <https://github.com/apache/arrow/actions/runs/18329667061|C++ Extra>*


:tada: *5 successful jobs*
```


### Are there any user-facing changes?

No

* GitHub Issue: #47751