### PR TITLE
GH-47229: [C++][Arm] Force mimalloc to generate armv8.0 binary

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -2294,7 +2294,8 @@ if(ARROW_MIMALLOC)
       -DMI_LOCAL_DYNAMIC_TLS=ON
       -DMI_BUILD_OBJECT=OFF
       -DMI_BUILD_SHARED=OFF
-      -DMI_BUILD_TESTS=OFF)
+      -DMI_BUILD_TESTS=OFF
+      -DMI_NO_OPT_ARCH=ON)
 
   externalproject_add(mimalloc_ep
                       ${EP_COMMON_OPTIONS}

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -2295,6 +2295,7 @@ if(ARROW_MIMALLOC)
       -DMI_BUILD_OBJECT=OFF
       -DMI_BUILD_SHARED=OFF
       -DMI_BUILD_TESTS=OFF
+      # GH-47229: Force mimalloc to generate armv8.0 binary
       -DMI_NO_OPT_ARCH=ON)
 
   externalproject_add(mimalloc_ep


### PR DESCRIPTION
### Rationale for this change
Mimalloc default generates LSE atomic instructions only work on armv8.1. This causes illegal instruction on armv8.0 platforms like Raspberry4. This PR sets mimalloc build flag -DMI_NO_OPT_ARCH=ON to disable LSE instruction.
Please note even with flag set, compiler and libc will replace the atmoic call with an ifunc that matches hardware best at runtime. That means LSE is used only if the running platform supports it.

### What changes are included in this PR?
Force mimalloc build flag -DMI_NO_OPT_ARCH=ON.

### Are these changes tested?
Manually tested.

### Are there any user-facing changes?
No.

**This PR contains a "Critical Fix".**
Fixes crashes on Armv8.0 platform.
* GitHub Issue: #47229