### PR TITLE
GH-47710: [C++][FlightRPC] Statement attribute Support in ODBC

### DIFF
--- a/cpp/src/arrow/flight/sql/odbc/odbc_api.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_api.cc
@@ -923,8 +923,19 @@ SQLRETURN SQLGetStmtAttr(SQLHSTMT stmt, SQLINTEGER attribute, SQLPOINTER value_p
                    << ", attribute: " << attribute << ", value_ptr: " << value_ptr
                    << ", buffer_length: " << buffer_length << ", string_length_ptr: "
                    << static_cast<const void*>(string_length_ptr);
-  // GH-47710 TODO: Implement SQLGetStmtAttr
-  return SQL_INVALID_HANDLE;
+
+  using ODBC::ODBCStatement;
+
+  return ODBCStatement::ExecuteWithDiagnostics(stmt, SQL_ERROR, [=]() {
+    ODBCStatement* statement = reinterpret_cast<ODBCStatement*>(stmt);
+
+    bool is_unicode = true;
+
+    statement->GetStmtAttr(attribute, value_ptr, buffer_length, string_length_ptr,
+                           is_unicode);
+
+    return SQL_SUCCESS;
+  });
 }
 
 SQLRETURN SQLSetStmtAttr(SQLHSTMT stmt, SQLINTEGER attribute, SQLPOINTER value_ptr,
@@ -932,8 +943,18 @@ SQLRETURN SQLSetStmtAttr(SQLHSTMT stmt, SQLINTEGER attribute, SQLPOINTER value_p
   ARROW_LOG(DEBUG) << "SQLSetStmtAttrW called with stmt: " << stmt
                    << ", attribute: " << attribute << ", value_ptr: " << value_ptr
                    << ", string_length: " << string_length;
-  // GH-47710 TODO: Implement SQLSetStmtAttr
-  return SQL_INVALID_HANDLE;
+
+  using ODBC::ODBCStatement;
+
+  return ODBCStatement::ExecuteWithDiagnostics(stmt, SQL_ERROR, [=]() {
+    ODBCStatement* statement = reinterpret_cast<ODBCStatement*>(stmt);
+
+    bool is_unicode = true;
+
+    statement->SetStmtAttr(attribute, value_ptr, string_length, is_unicode);
+
+    return SQL_SUCCESS;
+  });
 }
 
 SQLRETURN SQLExecDirect(SQLHSTMT stmt, SQLWCHAR* query_text, SQLINTEGER text_length) {

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/odbc_statement.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/odbc_statement.cc
@@ -375,6 +375,14 @@ void ODBCStatement::GetStmtAttr(SQLINTEGER statement_attribute, SQLPOINTER outpu
       return;
     case SQL_ATTR_PARAM_BIND_TYPE:
       current_apd_->GetHeaderField(SQL_DESC_BIND_TYPE, output, buffer_size, str_len_ptr);
+      if (output) {
+        // Convert SQLINTEGER output to SQLULEN, since SQL_DESC_BIND_TYPE is SQLINTEGER
+        // and SQL_ATTR_PARAM_BIND_TYPE is SQLULEN
+        SQLINTEGER* output_int_ptr = reinterpret_cast<SQLINTEGER*>(output);
+        SQLINTEGER output_int = *output_int_ptr;
+        SQLULEN* typed_output = reinterpret_cast<SQLULEN*>(output);
+        *typed_output = static_cast<SQLULEN>(output_int);
+      }
       return;
     case SQL_ATTR_PARAM_OPERATION_PTR:
       current_apd_->GetHeaderField(SQL_DESC_ARRAY_STATUS_PTR, output, buffer_size,
@@ -398,6 +406,14 @@ void ODBCStatement::GetStmtAttr(SQLINTEGER statement_attribute, SQLPOINTER outpu
       return;
     case SQL_ATTR_ROW_BIND_TYPE:
       current_ard_->GetHeaderField(SQL_DESC_BIND_TYPE, output, buffer_size, str_len_ptr);
+      if (output) {
+        // Convert SQLINTEGER output to SQLULEN, since SQL_DESC_BIND_TYPE is SQLINTEGER
+        // and SQL_ATTR_ROW_BIND_TYPE is SQLULEN
+        SQLINTEGER* output_int_ptr = reinterpret_cast<SQLINTEGER*>(output);
+        SQLINTEGER output_int = *output_int_ptr;
+        SQLULEN* typed_output = reinterpret_cast<SQLULEN*>(output);
+        *typed_output = static_cast<SQLULEN>(output_int);
+      }
       return;
     case SQL_ATTR_ROW_OPERATION_PTR:
       current_ard_->GetHeaderField(SQL_DESC_ARRAY_STATUS_PTR, output, buffer_size,

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/odbc_statement.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/odbc_statement.cc
@@ -627,7 +627,7 @@ void ODBCStatement::SetStmtAttr(SQLINTEGER statement_attribute, SQLPOINTER value
       CheckIfAttributeIsSetToOnlyValidValue(value, static_cast<SQLULEN>(SQL_UB_OFF));
       return;
     case SQL_ATTR_RETRIEVE_DATA:
-      CheckIfAttributeIsSetToOnlyValidValue(value, static_cast<SQLULEN>(SQL_TRUE));
+      CheckIfAttributeIsSetToOnlyValidValue(value, static_cast<SQLULEN>(SQL_RD_ON));
       return;
     case SQL_ROWSET_SIZE:
       SetAttribute(value, rowset_size_);

--- a/cpp/src/arrow/flight/sql/odbc/tests/CMakeLists.txt
+++ b/cpp/src/arrow/flight/sql/odbc/tests/CMakeLists.txt
@@ -34,6 +34,7 @@ add_arrow_test(flight_sql_odbc_test
                SOURCES
                odbc_test_suite.cc
                odbc_test_suite.h
+               statement_attr_test.cc
                connection_test.cc
                # Enable Protobuf cleanup after test execution
                # GH-46889: move protobuf_test_util to a more common location

--- a/cpp/src/arrow/flight/sql/odbc/tests/odbc_test_suite.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/odbc_test_suite.cc
@@ -61,13 +61,11 @@ void ODBCRemoteTestBase::ConnectWithString(std::string connect_str) {
                              kOdbcBufferSize, &out_str_len, SQL_DRIVER_NOPROMPT))
       << GetOdbcErrorMessage(SQL_HANDLE_DBC, conn);
 
-  // GH-47710: TODO Allocate a statement using alloc handle
-  // ASSERT_EQ(SQL_SUCCESS, SQLAllocHandle(SQL_HANDLE_STMT, conn, &stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLAllocHandle(SQL_HANDLE_STMT, conn, &stmt));
 }
 
 void ODBCRemoteTestBase::Disconnect() {
-  // GH-47710: TODO Close statement
-  // EXPECT_EQ(SQL_SUCCESS, SQLFreeHandle(SQL_HANDLE_STMT, stmt));
+  EXPECT_EQ(SQL_SUCCESS, SQLFreeHandle(SQL_HANDLE_STMT, stmt));
 
   // Disconnect from ODBC
   EXPECT_EQ(SQL_SUCCESS, SQLDisconnect(conn))

--- a/cpp/src/arrow/flight/sql/odbc/tests/statement_attr_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/statement_attr_test.cc
@@ -39,52 +39,28 @@ TYPED_TEST_SUITE(StatementAttributeTest, TestTypes);
 namespace {
 // Helper Functions
 
-// Validate SQLULEN return value
-void ValidateGetStmtAttr(SQLHSTMT statement, SQLINTEGER attribute,
-                         SQLULEN expected_value) {
-  SQLULEN value = 0;
+// Get SQLULEN return value
+void GetStmtAttr(SQLHSTMT statement, SQLINTEGER attribute, SQLULEN* value) {
   SQLINTEGER string_length = 0;
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetStmtAttr(statement, attribute, &value, sizeof(value), &string_length));
-
-  EXPECT_EQ(expected_value, value);
+            SQLGetStmtAttr(statement, attribute, value, sizeof(*value), &string_length));
 }
 
-// Validate SQLLEN return value
-void ValidateGetStmtAttr(SQLHSTMT statement, SQLINTEGER attribute,
-                         SQLLEN expected_value) {
-  SQLLEN value = 0;
+// Get SQLLEN return value
+void GetStmtAttr(SQLHSTMT statement, SQLINTEGER attribute, SQLLEN* value) {
   SQLINTEGER string_length = 0;
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetStmtAttr(statement, attribute, &value, sizeof(value), &string_length));
-
-  EXPECT_EQ(expected_value, value);
+            SQLGetStmtAttr(statement, attribute, value, sizeof(*value), &string_length));
 }
 
-// Validate SQLPOINTER return value
-void ValidateGetStmtAttr(SQLHSTMT statement, SQLINTEGER attribute,
-                         SQLPOINTER expected_value) {
-  SQLPOINTER value = nullptr;
+// Get SQLPOINTER return value
+void GetStmtAttr(SQLHSTMT statement, SQLINTEGER attribute, SQLPOINTER* value) {
   SQLINTEGER string_length = 0;
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetStmtAttr(statement, attribute, &value, sizeof(value), &string_length));
-
-  EXPECT_EQ(expected_value, value);
-}
-
-// Validate unsigned length SQLULEN return value is greater than
-void ValidateGetStmtAttrGreaterThan(SQLHSTMT statement, SQLINTEGER attribute,
-                                    SQLULEN compared_value) {
-  SQLULEN value = 0;
-  SQLINTEGER string_length_ptr;
-
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetStmtAttr(statement, attribute, &value, 0, &string_length_ptr));
-
-  EXPECT_GT(value, compared_value);
+            SQLGetStmtAttr(statement, attribute, value, SQL_IS_POINTER, &string_length));
 }
 
 // Validate error return value and code
@@ -138,18 +114,24 @@ void ValidateSetStmtAttrErrorCode(SQLHSTMT statement, SQLINTEGER attribute,
 // Test Cases
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrAppParamDesc) {
-  ValidateGetStmtAttrGreaterThan(this->stmt, SQL_ATTR_APP_PARAM_DESC,
-                                 static_cast<SQLULEN>(0));
+  SQLULEN value;
+  GetStmtAttr(this->stmt, SQL_ATTR_APP_PARAM_DESC, &value);
+
+  EXPECT_GT(value, static_cast<SQLULEN>(0));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrAppRowDesc) {
-  ValidateGetStmtAttrGreaterThan(this->stmt, SQL_ATTR_APP_ROW_DESC,
-                                 static_cast<SQLULEN>(0));
+  SQLULEN value;
+  GetStmtAttr(this->stmt, SQL_ATTR_APP_ROW_DESC, &value);
+
+  EXPECT_GT(value, static_cast<SQLULEN>(0));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrAsyncEnable) {
-  ValidateGetStmtAttr(this->stmt, SQL_ATTR_ASYNC_ENABLE,
-                      static_cast<SQLULEN>(SQL_ASYNC_ENABLE_OFF));
+  SQLULEN value;
+  GetStmtAttr(this->stmt, SQL_ATTR_ASYNC_ENABLE, &value);
+
+  EXPECT_EQ(value, static_cast<SQLULEN>(SQL_ASYNC_ENABLE_OFF));
 }
 
 #ifdef SQL_ATTR_ASYNC_STMT_EVENT
@@ -176,113 +158,171 @@ TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrAsyncStmtPCContextUnsupport
 #endif
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrConcurrency) {
-  ValidateGetStmtAttr(this->stmt, SQL_ATTR_CONCURRENCY,
-                      static_cast<SQLULEN>(SQL_CONCUR_READ_ONLY));
+  SQLULEN value;
+  GetStmtAttr(this->stmt, SQL_ATTR_CONCURRENCY, &value);
+
+  EXPECT_EQ(value, static_cast<SQLULEN>(SQL_CONCUR_READ_ONLY));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrCursorScrollable) {
-  ValidateGetStmtAttr(this->stmt, SQL_ATTR_CURSOR_SCROLLABLE,
-                      static_cast<SQLULEN>(SQL_NONSCROLLABLE));
+  SQLULEN value;
+  GetStmtAttr(this->stmt, SQL_ATTR_CURSOR_SCROLLABLE, &value);
+
+  EXPECT_EQ(value, static_cast<SQLULEN>(SQL_NONSCROLLABLE));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrCursorSensitivity) {
-  ValidateGetStmtAttr(this->stmt, SQL_ATTR_CURSOR_SENSITIVITY,
-                      static_cast<SQLULEN>(SQL_UNSPECIFIED));
+  SQLULEN value;
+  GetStmtAttr(this->stmt, SQL_ATTR_CURSOR_SENSITIVITY, &value);
+
+  EXPECT_EQ(value, static_cast<SQLULEN>(SQL_UNSPECIFIED));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrCursorType) {
-  ValidateGetStmtAttr(this->stmt, SQL_ATTR_CURSOR_TYPE,
-                      static_cast<SQLULEN>(SQL_CURSOR_FORWARD_ONLY));
+  SQLULEN value;
+  GetStmtAttr(this->stmt, SQL_ATTR_CURSOR_TYPE, &value);
+
+  EXPECT_EQ(value, static_cast<SQLULEN>(SQL_CURSOR_FORWARD_ONLY));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrEnableAutoIPD) {
-  ValidateGetStmtAttr(this->stmt, SQL_ATTR_ENABLE_AUTO_IPD,
-                      static_cast<SQLULEN>(SQL_FALSE));
+  SQLULEN value;
+  GetStmtAttr(this->stmt, SQL_ATTR_ENABLE_AUTO_IPD, &value);
+
+  EXPECT_EQ(value, static_cast<SQLULEN>(SQL_FALSE));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrFetchBookmarkPointer) {
-  ValidateGetStmtAttr(this->stmt, SQL_ATTR_FETCH_BOOKMARK_PTR, static_cast<SQLLEN>(NULL));
+  SQLLEN value;
+  GetStmtAttr(this->stmt, SQL_ATTR_FETCH_BOOKMARK_PTR, &value);
+
+  EXPECT_EQ(value, static_cast<SQLLEN>(NULL));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrIMPParamDesc) {
-  ValidateGetStmtAttrGreaterThan(this->stmt, SQL_ATTR_IMP_PARAM_DESC,
-                                 static_cast<SQLULEN>(0));
+  SQLULEN value;
+  GetStmtAttr(this->stmt, SQL_ATTR_IMP_PARAM_DESC, &value);
+
+  EXPECT_GT(value, static_cast<SQLULEN>(0));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrIMPRowDesc) {
-  ValidateGetStmtAttrGreaterThan(this->stmt, SQL_ATTR_IMP_ROW_DESC,
-                                 static_cast<SQLULEN>(0));
+  SQLULEN value;
+  GetStmtAttr(this->stmt, SQL_ATTR_IMP_ROW_DESC, &value);
+
+  EXPECT_GT(value, static_cast<SQLULEN>(0));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrKeysetSize) {
-  ValidateGetStmtAttr(this->stmt, SQL_ATTR_KEYSET_SIZE, static_cast<SQLULEN>(0));
+  SQLULEN value;
+  GetStmtAttr(this->stmt, SQL_ATTR_KEYSET_SIZE, &value);
+
+  EXPECT_EQ(value, static_cast<SQLULEN>(0));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrMaxLength) {
-  ValidateGetStmtAttr(this->stmt, SQL_ATTR_MAX_LENGTH, static_cast<SQLULEN>(0));
+  SQLULEN value;
+  GetStmtAttr(this->stmt, SQL_ATTR_MAX_LENGTH, &value);
+
+  EXPECT_EQ(value, static_cast<SQLULEN>(0));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrMaxRows) {
-  ValidateGetStmtAttr(this->stmt, SQL_ATTR_MAX_ROWS, static_cast<SQLULEN>(0));
+  SQLULEN value;
+  GetStmtAttr(this->stmt, SQL_ATTR_MAX_ROWS, &value);
+
+  EXPECT_EQ(value, static_cast<SQLULEN>(0));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrMetadataID) {
-  ValidateGetStmtAttr(this->stmt, SQL_ATTR_METADATA_ID, static_cast<SQLULEN>(SQL_FALSE));
+  SQLULEN value;
+  GetStmtAttr(this->stmt, SQL_ATTR_METADATA_ID, &value);
+
+  EXPECT_EQ(value, static_cast<SQLULEN>(SQL_FALSE));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrNoscan) {
-  ValidateGetStmtAttr(this->stmt, SQL_ATTR_NOSCAN, static_cast<SQLULEN>(SQL_NOSCAN_OFF));
+  SQLULEN value;
+  GetStmtAttr(this->stmt, SQL_ATTR_NOSCAN, &value);
+
+  EXPECT_EQ(value, static_cast<SQLULEN>(SQL_NOSCAN_OFF));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrParamBindOffsetPtr) {
-  ValidateGetStmtAttr(this->stmt, SQL_ATTR_PARAM_BIND_OFFSET_PTR,
-                      static_cast<SQLPOINTER>(nullptr));
+  SQLPOINTER value = nullptr;
+  GetStmtAttr(this->stmt, SQL_ATTR_PARAM_BIND_OFFSET_PTR, &value);
+
+  EXPECT_EQ(value, static_cast<SQLPOINTER>(nullptr));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrParamBindType) {
-  ValidateGetStmtAttr(this->stmt, SQL_ATTR_PARAM_BIND_TYPE,
-                      static_cast<SQLULEN>(SQL_PARAM_BIND_BY_COLUMN));
+  SQLULEN value;
+  GetStmtAttr(this->stmt, SQL_ATTR_PARAM_BIND_TYPE, &value);
+
+  EXPECT_EQ(value, static_cast<SQLULEN>(SQL_PARAM_BIND_BY_COLUMN));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrParamOperationPtr) {
-  ValidateGetStmtAttr(this->stmt, SQL_ATTR_PARAM_OPERATION_PTR,
-                      static_cast<SQLPOINTER>(nullptr));
+  SQLPOINTER value = nullptr;
+  GetStmtAttr(this->stmt, SQL_ATTR_PARAM_OPERATION_PTR, &value);
+
+  EXPECT_EQ(value, static_cast<SQLPOINTER>(nullptr));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrParamStatusPtr) {
-  ValidateGetStmtAttr(this->stmt, SQL_ATTR_PARAM_STATUS_PTR,
-                      static_cast<SQLPOINTER>(nullptr));
+  SQLPOINTER value = nullptr;
+  GetStmtAttr(this->stmt, SQL_ATTR_PARAM_STATUS_PTR, &value);
+
+  EXPECT_EQ(value, static_cast<SQLPOINTER>(nullptr));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrParamsProcessedPtr) {
-  ValidateGetStmtAttr(this->stmt, SQL_ATTR_PARAMS_PROCESSED_PTR,
-                      static_cast<SQLPOINTER>(nullptr));
+  SQLPOINTER value = nullptr;
+  GetStmtAttr(this->stmt, SQL_ATTR_PARAMS_PROCESSED_PTR, &value);
+
+  EXPECT_EQ(value, static_cast<SQLPOINTER>(nullptr));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrParamsetSize) {
-  ValidateGetStmtAttr(this->stmt, SQL_ATTR_PARAMSET_SIZE, static_cast<SQLULEN>(1));
+  SQLULEN value;
+  GetStmtAttr(this->stmt, SQL_ATTR_PARAMSET_SIZE, &value);
+
+  EXPECT_EQ(value, static_cast<SQLULEN>(1));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrQueryTimeout) {
-  ValidateGetStmtAttr(this->stmt, SQL_ATTR_QUERY_TIMEOUT, static_cast<SQLULEN>(0));
+  SQLULEN value;
+  GetStmtAttr(this->stmt, SQL_ATTR_QUERY_TIMEOUT, &value);
+
+  EXPECT_EQ(value, static_cast<SQLULEN>(0));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrRetrieveData) {
-  ValidateGetStmtAttr(this->stmt, SQL_ATTR_RETRIEVE_DATA,
-                      static_cast<SQLULEN>(SQL_RD_ON));
+  SQLULEN value;
+  GetStmtAttr(this->stmt, SQL_ATTR_RETRIEVE_DATA, &value);
+
+  EXPECT_EQ(value, static_cast<SQLULEN>(SQL_RD_ON));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrRowArraySize) {
-  ValidateGetStmtAttr(this->stmt, SQL_ATTR_ROW_ARRAY_SIZE, static_cast<SQLULEN>(1));
+  SQLULEN value;
+  GetStmtAttr(this->stmt, SQL_ATTR_ROW_ARRAY_SIZE, &value);
+
+  EXPECT_EQ(value, static_cast<SQLULEN>(1));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrRowBindOffsetPtr) {
-  ValidateGetStmtAttr(this->stmt, SQL_ATTR_ROW_BIND_OFFSET_PTR,
-                      static_cast<SQLPOINTER>(nullptr));
+  SQLPOINTER value = nullptr;
+  GetStmtAttr(this->stmt, SQL_ATTR_ROW_BIND_OFFSET_PTR, &value);
+
+  EXPECT_EQ(value, static_cast<SQLPOINTER>(nullptr));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrRowBindType) {
-  ValidateGetStmtAttr(this->stmt, SQL_ATTR_ROW_BIND_TYPE, static_cast<SQLULEN>(0));
+  SQLULEN value;
+  GetStmtAttr(this->stmt, SQL_ATTR_ROW_BIND_TYPE, &value);
+
+  EXPECT_EQ(value, static_cast<SQLULEN>(0));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrRowNumber) {
@@ -294,37 +334,53 @@ TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrRowNumber) {
 
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
-  ValidateGetStmtAttr(this->stmt, SQL_ATTR_ROW_NUMBER, static_cast<SQLULEN>(1));
+  SQLULEN value;
+  GetStmtAttr(this->stmt, SQL_ATTR_ROW_NUMBER, &value);
+
+  EXPECT_EQ(value, static_cast<SQLULEN>(1));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrRowOperationPtr) {
-  ValidateGetStmtAttr(this->stmt, SQL_ATTR_ROW_OPERATION_PTR,
-                      static_cast<SQLPOINTER>(nullptr));
+  SQLPOINTER value = nullptr;
+  GetStmtAttr(this->stmt, SQL_ATTR_ROW_OPERATION_PTR, &value);
+
+  EXPECT_EQ(value, static_cast<SQLPOINTER>(nullptr));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrRowStatusPtr) {
-  ValidateGetStmtAttr(this->stmt, SQL_ATTR_ROW_STATUS_PTR,
-                      static_cast<SQLPOINTER>(nullptr));
+  SQLPOINTER value = nullptr;
+  GetStmtAttr(this->stmt, SQL_ATTR_ROW_STATUS_PTR, &value);
+
+  EXPECT_EQ(value, static_cast<SQLPOINTER>(nullptr));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrRowsFetchedPtr) {
-  ValidateGetStmtAttr(this->stmt, SQL_ATTR_ROWS_FETCHED_PTR,
-                      static_cast<SQLPOINTER>(nullptr));
+  SQLPOINTER value = nullptr;
+  GetStmtAttr(this->stmt, SQL_ATTR_ROWS_FETCHED_PTR, &value);
+
+  EXPECT_EQ(value, static_cast<SQLPOINTER>(nullptr));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrSimulateCursor) {
-  ValidateGetStmtAttr(this->stmt, SQL_ATTR_SIMULATE_CURSOR,
-                      static_cast<SQLULEN>(SQL_SC_UNIQUE));
+  SQLULEN value;
+  GetStmtAttr(this->stmt, SQL_ATTR_SIMULATE_CURSOR, &value);
+
+  EXPECT_EQ(value, static_cast<SQLULEN>(SQL_SC_UNIQUE));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrUseBookmarks) {
-  ValidateGetStmtAttr(this->stmt, SQL_ATTR_USE_BOOKMARKS,
-                      static_cast<SQLULEN>(SQL_UB_OFF));
+  SQLULEN value;
+  GetStmtAttr(this->stmt, SQL_ATTR_USE_BOOKMARKS, &value);
+
+  EXPECT_EQ(value, static_cast<SQLULEN>(SQL_UB_OFF));
 }
 
 // This is a pre ODBC 3 attribute
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrRowsetSize) {
-  ValidateGetStmtAttr(this->stmt, SQL_ROWSET_SIZE, static_cast<SQLULEN>(1));
+  SQLULEN value;
+  GetStmtAttr(this->stmt, SQL_ROWSET_SIZE, &value);
+
+  EXPECT_EQ(value, static_cast<SQLULEN>(1));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrAppParamDesc) {
@@ -453,8 +509,10 @@ TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrParamBindOffsetPtr) {
   ValidateSetStmtAttr(this->stmt, SQL_ATTR_PARAM_BIND_OFFSET_PTR,
                       static_cast<SQLPOINTER>(&offset));
 
-  ValidateGetStmtAttr(this->stmt, SQL_ATTR_PARAM_BIND_OFFSET_PTR,
-                      static_cast<SQLPOINTER>(&offset));
+  SQLPOINTER value = nullptr;
+  GetStmtAttr(this->stmt, SQL_ATTR_PARAM_BIND_OFFSET_PTR, &value);
+
+  EXPECT_EQ(value, static_cast<SQLPOINTER>(&offset));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrParamBindType) {
@@ -470,8 +528,10 @@ TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrParamOperationPtr) {
   ValidateSetStmtAttr(this->stmt, SQL_ATTR_PARAM_OPERATION_PTR,
                       static_cast<SQLPOINTER>(param_operations));
 
-  ValidateGetStmtAttr(this->stmt, SQL_ATTR_PARAM_OPERATION_PTR,
-                      static_cast<SQLPOINTER>(param_operations));
+  SQLPOINTER value = nullptr;
+  GetStmtAttr(this->stmt, SQL_ATTR_PARAM_OPERATION_PTR, &value);
+
+  EXPECT_EQ(value, static_cast<SQLPOINTER>(param_operations));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrParamStatusPtr) {
@@ -483,8 +543,10 @@ TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrParamStatusPtr) {
   ValidateSetStmtAttr(this->stmt, SQL_ATTR_PARAM_STATUS_PTR,
                       static_cast<SQLPOINTER>(param_status));
 
-  ValidateGetStmtAttr(this->stmt, SQL_ATTR_PARAM_STATUS_PTR,
-                      static_cast<SQLPOINTER>(param_status));
+  SQLPOINTER value = nullptr;
+  GetStmtAttr(this->stmt, SQL_ATTR_PARAM_STATUS_PTR, &value);
+
+  EXPECT_EQ(value, static_cast<SQLPOINTER>(param_status));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrParamsProcessedPtr) {
@@ -493,8 +555,10 @@ TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrParamsProcessedPtr) {
   ValidateSetStmtAttr(this->stmt, SQL_ATTR_PARAMS_PROCESSED_PTR,
                       static_cast<SQLPOINTER>(&processed_count));
 
-  ValidateGetStmtAttr(this->stmt, SQL_ATTR_PARAMS_PROCESSED_PTR,
-                      static_cast<SQLPOINTER>(&processed_count));
+  SQLPOINTER value = nullptr;
+  GetStmtAttr(this->stmt, SQL_ATTR_PARAMS_PROCESSED_PTR, &value);
+
+  EXPECT_EQ(value, static_cast<SQLPOINTER>(&processed_count));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrParamsetSize) {
@@ -520,8 +584,10 @@ TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrRowBindOffsetPtr) {
   ValidateSetStmtAttr(this->stmt, SQL_ATTR_ROW_BIND_OFFSET_PTR,
                       static_cast<SQLPOINTER>(&offset));
 
-  ValidateGetStmtAttr(this->stmt, SQL_ATTR_ROW_BIND_OFFSET_PTR,
-                      static_cast<SQLPOINTER>(&offset));
+  SQLPOINTER value = nullptr;
+  GetStmtAttr(this->stmt, SQL_ATTR_ROW_BIND_OFFSET_PTR, &value);
+
+  EXPECT_EQ(value, static_cast<SQLPOINTER>(&offset));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrRowBindType) {
@@ -542,8 +608,10 @@ TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrRowOperationPtr) {
   ValidateSetStmtAttr(this->stmt, SQL_ATTR_ROW_OPERATION_PTR,
                       static_cast<SQLPOINTER>(row_operations));
 
-  ValidateGetStmtAttr(this->stmt, SQL_ATTR_ROW_OPERATION_PTR,
-                      static_cast<SQLPOINTER>(row_operations));
+  SQLPOINTER value = nullptr;
+  GetStmtAttr(this->stmt, SQL_ATTR_ROW_OPERATION_PTR, &value);
+
+  EXPECT_EQ(value, static_cast<SQLPOINTER>(row_operations));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrRowStatusPtr) {
@@ -553,8 +621,10 @@ TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrRowStatusPtr) {
   ValidateSetStmtAttr(this->stmt, SQL_ATTR_ROW_STATUS_PTR,
                       static_cast<SQLPOINTER>(values));
 
-  ValidateGetStmtAttr(this->stmt, SQL_ATTR_ROW_STATUS_PTR,
-                      static_cast<SQLPOINTER>(values));
+  SQLPOINTER value = nullptr;
+  GetStmtAttr(this->stmt, SQL_ATTR_ROW_STATUS_PTR, &value);
+
+  EXPECT_EQ(value, static_cast<SQLPOINTER>(values));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrRowsFetchedPtr) {
@@ -563,8 +633,10 @@ TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrRowsFetchedPtr) {
   ValidateSetStmtAttr(this->stmt, SQL_ATTR_ROWS_FETCHED_PTR,
                       static_cast<SQLPOINTER>(&rows_fetched));
 
-  ValidateGetStmtAttr(this->stmt, SQL_ATTR_ROWS_FETCHED_PTR,
-                      static_cast<SQLPOINTER>(&rows_fetched));
+  SQLPOINTER value = nullptr;
+  GetStmtAttr(this->stmt, SQL_ATTR_ROWS_FETCHED_PTR, &value);
+
+  EXPECT_EQ(value, static_cast<SQLPOINTER>(&rows_fetched));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrSimulateCursor) {

--- a/cpp/src/arrow/flight/sql/odbc/tests/statement_attr_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/statement_attr_test.cc
@@ -1,0 +1,893 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+#include "arrow/flight/sql/odbc/tests/odbc_test_suite.h"
+
+#include "arrow/flight/sql/odbc/odbc_impl/odbc_statement.h"
+#include "arrow/flight/sql/odbc/odbc_impl/spi/statement.h"
+
+#ifdef _WIN32
+#  include <windows.h>
+#endif
+
+#include <sql.h>
+#include <sqltypes.h>
+#include <sqlucode.h>
+
+#include "gtest/gtest.h"
+
+namespace arrow::flight::sql::odbc {
+
+// Helper Functions
+
+// Validate SQLULEN return value
+void ValidateGetStmtAttr(SQLHSTMT statement, SQLINTEGER attribute,
+                         SQLULEN expected_value) {
+  SQLULEN value = 0;
+  SQLINTEGER string_length = 0;
+
+  SQLRETURN ret =
+      SQLGetStmtAttr(statement, attribute, &value, sizeof(value), &string_length);
+
+  EXPECT_EQ(SQL_SUCCESS, ret);
+
+  EXPECT_EQ(expected_value, value);
+}
+
+// Validate SQLLEN return value
+void ValidateGetStmtAttr(SQLHSTMT statement, SQLINTEGER attribute,
+                         SQLLEN expected_value) {
+  SQLLEN value = 0;
+  SQLINTEGER string_length = 0;
+
+  SQLRETURN ret =
+      SQLGetStmtAttr(statement, attribute, &value, sizeof(value), &string_length);
+
+  EXPECT_EQ(SQL_SUCCESS, ret);
+
+  EXPECT_EQ(expected_value, value);
+}
+
+// Validate SQLPOINTER return value
+void ValidateGetStmtAttr(SQLHSTMT statement, SQLINTEGER attribute,
+                         SQLPOINTER expected_value) {
+  SQLPOINTER value = nullptr;
+  SQLINTEGER string_length = 0;
+
+  SQLRETURN ret =
+      SQLGetStmtAttr(statement, attribute, &value, sizeof(value), &string_length);
+
+  EXPECT_EQ(SQL_SUCCESS, ret);
+
+  EXPECT_EQ(expected_value, value);
+}
+
+// Validate unsigned length SQLULEN return value is greater than
+void ValidateGetStmtAttrGreaterThan(SQLHSTMT statement, SQLINTEGER attribute,
+                                    SQLULEN compared_value) {
+  SQLULEN value = 0;
+  SQLINTEGER string_length_ptr;
+
+  SQLRETURN ret = SQLGetStmtAttr(statement, attribute, &value, 0, &string_length_ptr);
+
+  EXPECT_EQ(SQL_SUCCESS, ret);
+
+  EXPECT_GT(value, compared_value);
+}
+
+// Validate error return value and code
+void ValidateGetStmtAttrErrorCode(SQLHSTMT statement, SQLINTEGER attribute,
+                                  std::string_view error_code) {
+  SQLULEN value = 0;
+  SQLINTEGER string_length_ptr;
+
+  SQLRETURN ret = SQLGetStmtAttr(statement, attribute, &value, 0, &string_length_ptr);
+
+  EXPECT_EQ(SQL_ERROR, ret);
+
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, statement, error_code);
+}
+
+// Validate return value for call to SQLSetStmtAttr with SQLULEN
+void ValidateSetStmtAttr(SQLHSTMT statement, SQLINTEGER attribute, SQLULEN new_value) {
+  SQLINTEGER string_length_ptr = sizeof(SQLULEN);
+
+  SQLRETURN ret = SQLSetStmtAttr(
+      statement, attribute, reinterpret_cast<SQLPOINTER>(new_value), string_length_ptr);
+
+  EXPECT_EQ(SQL_SUCCESS, ret);
+}
+
+// Validate return value for call to SQLSetStmtAttr with SQLLEN
+void ValidateSetStmtAttr(SQLHSTMT statement, SQLINTEGER attribute, SQLLEN new_value) {
+  SQLINTEGER string_length_ptr = sizeof(SQLLEN);
+
+  SQLRETURN ret = SQLSetStmtAttr(
+      statement, attribute, reinterpret_cast<SQLPOINTER>(new_value), string_length_ptr);
+
+  EXPECT_EQ(SQL_SUCCESS, ret);
+}
+
+// Validate return value for call to SQLSetStmtAttr with SQLPOINTER
+void ValidateSetStmtAttr(SQLHSTMT statement, SQLINTEGER attribute, SQLPOINTER value) {
+  SQLRETURN ret = SQLSetStmtAttr(statement, attribute, value, 0);
+
+  EXPECT_EQ(SQL_SUCCESS, ret);
+}
+
+// Validate error return value and code
+void ValidateSetStmtAttrErrorCode(SQLHSTMT statement, SQLINTEGER attribute,
+                                  SQLULEN new_value, std::string_view error_code) {
+  SQLINTEGER string_length_ptr = sizeof(SQLULEN);
+
+  SQLRETURN ret = SQLSetStmtAttr(
+      statement, attribute, reinterpret_cast<SQLPOINTER>(new_value), string_length_ptr);
+
+  EXPECT_EQ(SQL_ERROR, ret);
+
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, statement, error_code);
+}
+
+// Test Cases
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrAppParamDesc) {
+  this->Connect();
+
+  ValidateGetStmtAttrGreaterThan(this->stmt, SQL_ATTR_APP_PARAM_DESC,
+                                 static_cast<SQLULEN>(0));
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrAppRowDesc) {
+  this->Connect();
+
+  ValidateGetStmtAttrGreaterThan(this->stmt, SQL_ATTR_APP_ROW_DESC,
+                                 static_cast<SQLULEN>(0));
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrAsyncEnable) {
+  this->Connect();
+
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_ASYNC_ENABLE,
+                      static_cast<SQLULEN>(SQL_ASYNC_ENABLE_OFF));
+
+  this->Disconnect();
+}
+
+#ifdef SQL_ATTR_ASYNC_STMT_EVENT
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrAsyncStmtEventUnsupported) {
+  this->Connect();
+
+  // Optional feature not implemented
+  ValidateGetStmtAttrErrorCode(this->stmt, SQL_ATTR_ASYNC_STMT_EVENT, error_state_HYC00);
+
+  this->Disconnect();
+}
+#endif
+
+#ifdef SQL_ATTR_ASYNC_STMT_PCALLBACK
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrAsyncStmtPCCallbackUnsupported) {
+  this->Connect();
+
+  // Optional feature not implemented
+  ValidateGetStmtAttrErrorCode(this->stmt, SQL_ATTR_ASYNC_STMT_PCALLBACK,
+                               error_state_HYC00);
+
+  this->Disconnect();
+}
+#endif
+
+#ifdef SQL_ATTR_ASYNC_STMT_PCONTEXT
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrAsyncStmtPCContextUnsupported) {
+  this->Connect();
+
+  // Optional feature not implemented
+  ValidateGetStmtAttrErrorCode(this->stmt, SQL_ATTR_ASYNC_STMT_PCONTEXT,
+                               error_state_HYC00);
+
+  this->Disconnect();
+}
+#endif
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrConcurrency) {
+  this->Connect();
+
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_CONCURRENCY,
+                      static_cast<SQLULEN>(SQL_CONCUR_READ_ONLY));
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrCursorScrollable) {
+  this->Connect();
+
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_CURSOR_SCROLLABLE,
+                      static_cast<SQLULEN>(SQL_NONSCROLLABLE));
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrCursorSensitivity) {
+  this->Connect();
+
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_CURSOR_SENSITIVITY,
+                      static_cast<SQLULEN>(SQL_UNSPECIFIED));
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrCursorType) {
+  this->Connect();
+
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_CURSOR_TYPE,
+                      static_cast<SQLULEN>(SQL_CURSOR_FORWARD_ONLY));
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrEnableAutoIPD) {
+  this->Connect();
+
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_ENABLE_AUTO_IPD,
+                      static_cast<SQLULEN>(SQL_FALSE));
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrFetchBookmarkPointer) {
+  this->Connect();
+
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_FETCH_BOOKMARK_PTR, static_cast<SQLLEN>(NULL));
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrIMPParamDesc) {
+  this->Connect();
+
+  ValidateGetStmtAttrGreaterThan(this->stmt, SQL_ATTR_IMP_PARAM_DESC,
+                                 static_cast<SQLULEN>(0));
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrIMPRowDesc) {
+  this->Connect();
+
+  ValidateGetStmtAttrGreaterThan(this->stmt, SQL_ATTR_IMP_ROW_DESC,
+                                 static_cast<SQLULEN>(0));
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrKeysetSize) {
+  this->Connect();
+
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_KEYSET_SIZE, static_cast<SQLULEN>(0));
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrMaxLength) {
+  this->Connect();
+
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_MAX_LENGTH, static_cast<SQLULEN>(0));
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrMaxRows) {
+  this->Connect();
+
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_MAX_ROWS, static_cast<SQLULEN>(0));
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrMetadataID) {
+  this->Connect();
+
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_METADATA_ID, static_cast<SQLULEN>(SQL_FALSE));
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrNoscan) {
+  this->Connect();
+
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_NOSCAN, static_cast<SQLULEN>(SQL_NOSCAN_OFF));
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrParamBindOffsetPtr) {
+  this->Connect();
+
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_PARAM_BIND_OFFSET_PTR,
+                      static_cast<SQLPOINTER>(nullptr));
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrParamBindType) {
+  this->Connect();
+
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_PARAM_BIND_TYPE,
+                      static_cast<SQLULEN>(SQL_PARAM_BIND_BY_COLUMN));
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrParamOperationPtr) {
+  this->Connect();
+
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_PARAM_OPERATION_PTR,
+                      static_cast<SQLPOINTER>(nullptr));
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrParamStatusPtr) {
+  this->Connect();
+
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_PARAM_STATUS_PTR,
+                      static_cast<SQLPOINTER>(nullptr));
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrParamsProcessedPtr) {
+  this->Connect();
+
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_PARAMS_PROCESSED_PTR,
+                      static_cast<SQLPOINTER>(nullptr));
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrParamsetSize) {
+  this->Connect();
+
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_PARAMSET_SIZE, static_cast<SQLULEN>(1));
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrQueryTimeout) {
+  this->Connect();
+
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_QUERY_TIMEOUT, static_cast<SQLULEN>(0));
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrRetrieveData) {
+  this->Connect();
+
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_RETRIEVE_DATA,
+                      static_cast<SQLULEN>(SQL_RD_ON));
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrRowArraySize) {
+  this->Connect();
+
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_ROW_ARRAY_SIZE, static_cast<SQLULEN>(1));
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrRowBindOffsetPtr) {
+  this->Connect();
+
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_ROW_BIND_OFFSET_PTR,
+                      static_cast<SQLPOINTER>(nullptr));
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrRowBindType) {
+  this->Connect();
+
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_ROW_BIND_TYPE, static_cast<SQLULEN>(0));
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrRowNumber) {
+  this->Connect();
+
+  std::wstring wsql = L"SELECT 1;";
+  std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
+
+  SQLRETURN ret =
+      SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size()));
+
+  EXPECT_EQ(SQL_SUCCESS, ret);
+
+  ret = SQLFetch(this->stmt);
+
+  EXPECT_EQ(SQL_SUCCESS, ret);
+
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_ROW_NUMBER, static_cast<SQLULEN>(1));
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrRowOperationPtr) {
+  this->Connect();
+
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_ROW_OPERATION_PTR,
+                      static_cast<SQLPOINTER>(nullptr));
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrRowStatusPtr) {
+  this->Connect();
+
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_ROW_STATUS_PTR,
+                      static_cast<SQLPOINTER>(nullptr));
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrRowsFetchedPtr) {
+  this->Connect();
+
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_ROWS_FETCHED_PTR,
+                      static_cast<SQLPOINTER>(nullptr));
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrSimulateCursor) {
+  this->Connect();
+
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_SIMULATE_CURSOR,
+                      static_cast<SQLULEN>(SQL_SC_UNIQUE));
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrUseBookmarks) {
+  this->Connect();
+
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_USE_BOOKMARKS,
+                      static_cast<SQLULEN>(SQL_UB_OFF));
+
+  this->Disconnect();
+}
+
+// This is a pre ODBC 3 attribute
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLGetStmtAttrRowsetSize) {
+  this->Connect();
+
+  ValidateGetStmtAttr(this->stmt, SQL_ROWSET_SIZE, static_cast<SQLULEN>(1));
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrAppParamDesc) {
+  SQLULEN app_param_desc = 0;
+  SQLINTEGER string_length_ptr;
+  this->Connect();
+
+  SQLRETURN ret = SQLGetStmtAttr(this->stmt, SQL_ATTR_APP_PARAM_DESC, &app_param_desc, 0,
+                                 &string_length_ptr);
+
+  EXPECT_EQ(SQL_SUCCESS, ret);
+
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_APP_PARAM_DESC, static_cast<SQLULEN>(0));
+
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_APP_PARAM_DESC,
+                      static_cast<SQLULEN>(app_param_desc));
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrAppRowDesc) {
+  SQLULEN app_row_desc = 0;
+  SQLINTEGER string_length_ptr;
+  this->Connect();
+
+  SQLRETURN ret = SQLGetStmtAttr(this->stmt, SQL_ATTR_APP_ROW_DESC, &app_row_desc, 0,
+                                 &string_length_ptr);
+
+  EXPECT_EQ(SQL_SUCCESS, ret);
+
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_APP_ROW_DESC, static_cast<SQLULEN>(0));
+
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_APP_ROW_DESC,
+                      static_cast<SQLULEN>(app_row_desc));
+
+  this->Disconnect();
+}
+
+#ifdef SQL_ATTR_ASYNC_ENABLE
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrAsyncEnableUnsupported) {
+  this->Connect();
+
+  // Optional feature not implemented
+  ValidateSetStmtAttrErrorCode(this->stmt, SQL_ATTR_ASYNC_ENABLE, SQL_ASYNC_ENABLE_OFF,
+                               error_state_HYC00);
+
+  this->Disconnect();
+}
+#endif
+
+#ifdef SQL_ATTR_ASYNC_STMT_EVENT
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrAsyncStmtEventUnsupported) {
+  this->Connect();
+
+  // Driver does not support asynchronous notification
+  ValidateSetStmtAttrErrorCode(this->stmt, SQL_ATTR_ASYNC_STMT_EVENT, 0,
+                               error_state_HY118);
+
+  this->Disconnect();
+}
+#endif
+
+#ifdef SQL_ATTR_ASYNC_STMT_PCALLBACK
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrAsyncStmtPCCallbackUnsupported) {
+  this->Connect();
+
+  ValidateSetStmtAttrErrorCode(this->stmt, SQL_ATTR_ASYNC_STMT_PCALLBACK, 0,
+                               error_state_HYC00);
+
+  this->Disconnect();
+}
+#endif
+
+#ifdef SQL_ATTR_ASYNC_STMT_PCONTEXT
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrAsyncStmtPCContextUnsupported) {
+  this->Connect();
+
+  // Optional feature not implemented
+  ValidateSetStmtAttrErrorCode(this->stmt, SQL_ATTR_ASYNC_STMT_PCONTEXT, 0,
+                               error_state_HYC00);
+
+  this->Disconnect();
+}
+#endif
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrConcurrency) {
+  this->Connect();
+
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_CONCURRENCY,
+                      static_cast<SQLULEN>(SQL_CONCUR_READ_ONLY));
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrCursorScrollable) {
+  this->Connect();
+
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_CURSOR_SCROLLABLE,
+                      static_cast<SQLULEN>(SQL_NONSCROLLABLE));
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrCursorSensitivity) {
+  this->Connect();
+
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_CURSOR_SENSITIVITY,
+                      static_cast<SQLULEN>(SQL_UNSPECIFIED));
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrCursorType) {
+  this->Connect();
+
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_CURSOR_TYPE,
+                      static_cast<SQLULEN>(SQL_CURSOR_FORWARD_ONLY));
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrEnableAutoIPD) {
+  this->Connect();
+
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_ENABLE_AUTO_IPD,
+                      static_cast<SQLULEN>(SQL_FALSE));
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrFetchBookmarkPointer) {
+  this->Connect();
+
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_FETCH_BOOKMARK_PTR, static_cast<SQLLEN>(NULL));
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrIMPParamDesc) {
+  this->Connect();
+
+  // Invalid use of an automatically allocated descriptor handle
+  ValidateSetStmtAttrErrorCode(this->stmt, SQL_ATTR_IMP_PARAM_DESC,
+                               static_cast<SQLULEN>(0), error_state_HY017);
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrIMPRowDesc) {
+  this->Connect();
+
+  // Invalid use of an automatically allocated descriptor handle
+  ValidateSetStmtAttrErrorCode(this->stmt, SQL_ATTR_IMP_ROW_DESC, static_cast<SQLULEN>(0),
+                               error_state_HY017);
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrKeysetSizeUnsupported) {
+  this->Connect();
+
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_KEYSET_SIZE, static_cast<SQLULEN>(0));
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrMaxLength) {
+  this->Connect();
+
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_MAX_LENGTH, static_cast<SQLULEN>(0));
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrMaxRows) {
+  this->Connect();
+
+  // Cannot set read-only attribute
+  ValidateSetStmtAttrErrorCode(this->stmt, SQL_ATTR_MAX_ROWS, static_cast<SQLULEN>(0),
+                               error_state_HY092);
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrMetadataID) {
+  this->Connect();
+
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_METADATA_ID, static_cast<SQLULEN>(SQL_FALSE));
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrNoscan) {
+  this->Connect();
+
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_NOSCAN, static_cast<SQLULEN>(SQL_NOSCAN_OFF));
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrParamBindOffsetPtr) {
+  this->Connect();
+
+  SQLULEN offset = 1000;
+
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_PARAM_BIND_OFFSET_PTR,
+                      static_cast<SQLPOINTER>(&offset));
+
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_PARAM_BIND_OFFSET_PTR,
+                      static_cast<SQLPOINTER>(&offset));
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrParamBindType) {
+  this->Connect();
+
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_PARAM_BIND_TYPE,
+                      static_cast<SQLULEN>(SQL_PARAM_BIND_BY_COLUMN));
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrParamOperationPtr) {
+  this->Connect();
+
+  constexpr SQLULEN param_set_size = 4;
+  SQLUSMALLINT param_operations[param_set_size] = {SQL_PARAM_PROCEED, SQL_PARAM_IGNORE,
+                                                   SQL_PARAM_PROCEED, SQL_PARAM_IGNORE};
+
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_PARAM_OPERATION_PTR,
+                      static_cast<SQLPOINTER>(param_operations));
+
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_PARAM_OPERATION_PTR,
+                      static_cast<SQLPOINTER>(param_operations));
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrParamStatusPtr) {
+  this->Connect();
+
+  // Driver does not support parameters, so just check array can be saved/retrieved
+  constexpr SQLULEN param_status_size = 4;
+  SQLUSMALLINT param_status[param_status_size] = {SQL_PARAM_PROCEED, SQL_PARAM_IGNORE,
+                                                  SQL_PARAM_PROCEED, SQL_PARAM_IGNORE};
+
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_PARAM_STATUS_PTR,
+                      static_cast<SQLPOINTER>(param_status));
+
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_PARAM_STATUS_PTR,
+                      static_cast<SQLPOINTER>(param_status));
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrParamsProcessedPtr) {
+  this->Connect();
+
+  SQLULEN processed_count = 0;
+
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_PARAMS_PROCESSED_PTR,
+                      static_cast<SQLPOINTER>(&processed_count));
+
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_PARAMS_PROCESSED_PTR,
+                      static_cast<SQLPOINTER>(&processed_count));
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrParamsetSize) {
+  this->Connect();
+
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_PARAMSET_SIZE, static_cast<SQLULEN>(1));
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrQueryTimeout) {
+  this->Connect();
+
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_QUERY_TIMEOUT, static_cast<SQLULEN>(1));
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrRetrieveData) {
+  this->Connect();
+
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_RETRIEVE_DATA,
+                      static_cast<SQLULEN>(SQL_RD_ON));
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrRowArraySize) {
+  this->Connect();
+
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_ROW_ARRAY_SIZE, static_cast<SQLULEN>(1));
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrRowBindOffsetPtr) {
+  this->Connect();
+
+  SQLULEN offset = 1000;
+
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_ROW_BIND_OFFSET_PTR,
+                      static_cast<SQLPOINTER>(&offset));
+
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_ROW_BIND_OFFSET_PTR,
+                      static_cast<SQLPOINTER>(&offset));
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrRowBindType) {
+  this->Connect();
+
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_ROW_BIND_TYPE, static_cast<SQLULEN>(0));
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrRowNumber) {
+  this->Connect();
+
+  // Cannot set read-only attribute
+  ValidateSetStmtAttrErrorCode(this->stmt, SQL_ATTR_ROW_NUMBER, static_cast<SQLULEN>(0),
+                               error_state_HY092);
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrRowOperationPtr) {
+  this->Connect();
+
+  constexpr SQLULEN param_set_size = 4;
+  SQLUSMALLINT row_operations[param_set_size] = {SQL_ROW_PROCEED, SQL_ROW_IGNORE,
+                                                 SQL_ROW_PROCEED, SQL_ROW_IGNORE};
+
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_ROW_OPERATION_PTR,
+                      static_cast<SQLPOINTER>(row_operations));
+
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_ROW_OPERATION_PTR,
+                      static_cast<SQLPOINTER>(row_operations));
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrRowStatusPtr) {
+  this->Connect();
+
+  constexpr SQLULEN row_status_size = 4;
+  SQLUSMALLINT values[4] = {0, 0, 0, 0};
+
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_ROW_STATUS_PTR,
+                      static_cast<SQLPOINTER>(values));
+
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_ROW_STATUS_PTR,
+                      static_cast<SQLPOINTER>(values));
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrRowsFetchedPtr) {
+  this->Connect();
+
+  SQLULEN rows_fetched = 1;
+
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_ROWS_FETCHED_PTR,
+                      static_cast<SQLPOINTER>(&rows_fetched));
+
+  ValidateGetStmtAttr(this->stmt, SQL_ATTR_ROWS_FETCHED_PTR,
+                      static_cast<SQLPOINTER>(&rows_fetched));
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrSimulateCursor) {
+  this->Connect();
+
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_SIMULATE_CURSOR,
+                      static_cast<SQLULEN>(SQL_SC_UNIQUE));
+
+  this->Disconnect();
+}
+
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrUseBookmarks) {
+  this->Connect();
+
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_USE_BOOKMARKS,
+                      static_cast<SQLULEN>(SQL_UB_OFF));
+
+  this->Disconnect();
+}
+
+// This is a pre ODBC 3 attribute
+TYPED_TEST(FlightSQLODBCTestBase, TestSQLSetStmtAttrRowsetSize) {
+  this->Connect();
+
+  ValidateSetStmtAttr(this->stmt, SQL_ROWSET_SIZE, static_cast<SQLULEN>(1));
+
+  this->Disconnect();
+}
+
+}  // namespace arrow::flight::sql::odbc

--- a/cpp/src/arrow/flight/sql/odbc/tests/statement_attr_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/statement_attr_test.cc
@@ -131,7 +131,7 @@ TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrAsyncEnable) {
   SQLULEN value;
   GetStmtAttr(this->stmt, SQL_ATTR_ASYNC_ENABLE, &value);
 
-  EXPECT_EQ(value, static_cast<SQLULEN>(SQL_ASYNC_ENABLE_OFF));
+  EXPECT_EQ(static_cast<SQLULEN>(SQL_ASYNC_ENABLE_OFF), value);
 }
 
 #ifdef SQL_ATTR_ASYNC_STMT_EVENT
@@ -161,42 +161,42 @@ TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrConcurrency) {
   SQLULEN value;
   GetStmtAttr(this->stmt, SQL_ATTR_CONCURRENCY, &value);
 
-  EXPECT_EQ(value, static_cast<SQLULEN>(SQL_CONCUR_READ_ONLY));
+  EXPECT_EQ(static_cast<SQLULEN>(SQL_CONCUR_READ_ONLY), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrCursorScrollable) {
   SQLULEN value;
   GetStmtAttr(this->stmt, SQL_ATTR_CURSOR_SCROLLABLE, &value);
 
-  EXPECT_EQ(value, static_cast<SQLULEN>(SQL_NONSCROLLABLE));
+  EXPECT_EQ(static_cast<SQLULEN>(SQL_NONSCROLLABLE), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrCursorSensitivity) {
   SQLULEN value;
   GetStmtAttr(this->stmt, SQL_ATTR_CURSOR_SENSITIVITY, &value);
 
-  EXPECT_EQ(value, static_cast<SQLULEN>(SQL_UNSPECIFIED));
+  EXPECT_EQ(static_cast<SQLULEN>(SQL_UNSPECIFIED), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrCursorType) {
   SQLULEN value;
   GetStmtAttr(this->stmt, SQL_ATTR_CURSOR_TYPE, &value);
 
-  EXPECT_EQ(value, static_cast<SQLULEN>(SQL_CURSOR_FORWARD_ONLY));
+  EXPECT_EQ(static_cast<SQLULEN>(SQL_CURSOR_FORWARD_ONLY), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrEnableAutoIPD) {
   SQLULEN value;
   GetStmtAttr(this->stmt, SQL_ATTR_ENABLE_AUTO_IPD, &value);
 
-  EXPECT_EQ(value, static_cast<SQLULEN>(SQL_FALSE));
+  EXPECT_EQ(static_cast<SQLULEN>(SQL_FALSE), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrFetchBookmarkPointer) {
   SQLLEN value;
   GetStmtAttr(this->stmt, SQL_ATTR_FETCH_BOOKMARK_PTR, &value);
 
-  EXPECT_EQ(value, static_cast<SQLLEN>(NULL));
+  EXPECT_EQ(static_cast<SQLLEN>(NULL), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrIMPParamDesc) {
@@ -217,112 +217,112 @@ TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrKeysetSize) {
   SQLULEN value;
   GetStmtAttr(this->stmt, SQL_ATTR_KEYSET_SIZE, &value);
 
-  EXPECT_EQ(value, static_cast<SQLULEN>(0));
+  EXPECT_EQ(static_cast<SQLULEN>(0), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrMaxLength) {
   SQLULEN value;
   GetStmtAttr(this->stmt, SQL_ATTR_MAX_LENGTH, &value);
 
-  EXPECT_EQ(value, static_cast<SQLULEN>(0));
+  EXPECT_EQ(static_cast<SQLULEN>(0), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrMaxRows) {
   SQLULEN value;
   GetStmtAttr(this->stmt, SQL_ATTR_MAX_ROWS, &value);
 
-  EXPECT_EQ(value, static_cast<SQLULEN>(0));
+  EXPECT_EQ(static_cast<SQLULEN>(0), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrMetadataID) {
   SQLULEN value;
   GetStmtAttr(this->stmt, SQL_ATTR_METADATA_ID, &value);
 
-  EXPECT_EQ(value, static_cast<SQLULEN>(SQL_FALSE));
+  EXPECT_EQ(static_cast<SQLULEN>(SQL_FALSE), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrNoscan) {
   SQLULEN value;
   GetStmtAttr(this->stmt, SQL_ATTR_NOSCAN, &value);
 
-  EXPECT_EQ(value, static_cast<SQLULEN>(SQL_NOSCAN_OFF));
+  EXPECT_EQ(static_cast<SQLULEN>(SQL_NOSCAN_OFF), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrParamBindOffsetPtr) {
   SQLPOINTER value = nullptr;
   GetStmtAttr(this->stmt, SQL_ATTR_PARAM_BIND_OFFSET_PTR, &value);
 
-  EXPECT_EQ(value, static_cast<SQLPOINTER>(nullptr));
+  EXPECT_EQ(static_cast<SQLPOINTER>(nullptr), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrParamBindType) {
   SQLULEN value;
   GetStmtAttr(this->stmt, SQL_ATTR_PARAM_BIND_TYPE, &value);
 
-  EXPECT_EQ(value, static_cast<SQLULEN>(SQL_PARAM_BIND_BY_COLUMN));
+  EXPECT_EQ(static_cast<SQLULEN>(SQL_PARAM_BIND_BY_COLUMN), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrParamOperationPtr) {
   SQLPOINTER value = nullptr;
   GetStmtAttr(this->stmt, SQL_ATTR_PARAM_OPERATION_PTR, &value);
 
-  EXPECT_EQ(value, static_cast<SQLPOINTER>(nullptr));
+  EXPECT_EQ(static_cast<SQLPOINTER>(nullptr), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrParamStatusPtr) {
   SQLPOINTER value = nullptr;
   GetStmtAttr(this->stmt, SQL_ATTR_PARAM_STATUS_PTR, &value);
 
-  EXPECT_EQ(value, static_cast<SQLPOINTER>(nullptr));
+  EXPECT_EQ(static_cast<SQLPOINTER>(nullptr), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrParamsProcessedPtr) {
   SQLPOINTER value = nullptr;
   GetStmtAttr(this->stmt, SQL_ATTR_PARAMS_PROCESSED_PTR, &value);
 
-  EXPECT_EQ(value, static_cast<SQLPOINTER>(nullptr));
+  EXPECT_EQ(static_cast<SQLPOINTER>(nullptr), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrParamsetSize) {
   SQLULEN value;
   GetStmtAttr(this->stmt, SQL_ATTR_PARAMSET_SIZE, &value);
 
-  EXPECT_EQ(value, static_cast<SQLULEN>(1));
+  EXPECT_EQ(static_cast<SQLULEN>(1), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrQueryTimeout) {
   SQLULEN value;
   GetStmtAttr(this->stmt, SQL_ATTR_QUERY_TIMEOUT, &value);
 
-  EXPECT_EQ(value, static_cast<SQLULEN>(0));
+  EXPECT_EQ(static_cast<SQLULEN>(0), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrRetrieveData) {
   SQLULEN value;
   GetStmtAttr(this->stmt, SQL_ATTR_RETRIEVE_DATA, &value);
 
-  EXPECT_EQ(value, static_cast<SQLULEN>(SQL_RD_ON));
+  EXPECT_EQ(static_cast<SQLULEN>(SQL_RD_ON), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrRowArraySize) {
   SQLULEN value;
   GetStmtAttr(this->stmt, SQL_ATTR_ROW_ARRAY_SIZE, &value);
 
-  EXPECT_EQ(value, static_cast<SQLULEN>(1));
+  EXPECT_EQ(static_cast<SQLULEN>(1), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrRowBindOffsetPtr) {
   SQLPOINTER value = nullptr;
   GetStmtAttr(this->stmt, SQL_ATTR_ROW_BIND_OFFSET_PTR, &value);
 
-  EXPECT_EQ(value, static_cast<SQLPOINTER>(nullptr));
+  EXPECT_EQ(static_cast<SQLPOINTER>(nullptr), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrRowBindType) {
   SQLULEN value;
   GetStmtAttr(this->stmt, SQL_ATTR_ROW_BIND_TYPE, &value);
 
-  EXPECT_EQ(value, static_cast<SQLULEN>(0));
+  EXPECT_EQ(static_cast<SQLULEN>(0), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrRowNumber) {
@@ -337,42 +337,42 @@ TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrRowNumber) {
   SQLULEN value;
   GetStmtAttr(this->stmt, SQL_ATTR_ROW_NUMBER, &value);
 
-  EXPECT_EQ(value, static_cast<SQLULEN>(1));
+  EXPECT_EQ(static_cast<SQLULEN>(1), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrRowOperationPtr) {
   SQLPOINTER value = nullptr;
   GetStmtAttr(this->stmt, SQL_ATTR_ROW_OPERATION_PTR, &value);
 
-  EXPECT_EQ(value, static_cast<SQLPOINTER>(nullptr));
+  EXPECT_EQ(static_cast<SQLPOINTER>(nullptr), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrRowStatusPtr) {
   SQLPOINTER value = nullptr;
   GetStmtAttr(this->stmt, SQL_ATTR_ROW_STATUS_PTR, &value);
 
-  EXPECT_EQ(value, static_cast<SQLPOINTER>(nullptr));
+  EXPECT_EQ(static_cast<SQLPOINTER>(nullptr), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrRowsFetchedPtr) {
   SQLPOINTER value = nullptr;
   GetStmtAttr(this->stmt, SQL_ATTR_ROWS_FETCHED_PTR, &value);
 
-  EXPECT_EQ(value, static_cast<SQLPOINTER>(nullptr));
+  EXPECT_EQ(static_cast<SQLPOINTER>(nullptr), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrSimulateCursor) {
   SQLULEN value;
   GetStmtAttr(this->stmt, SQL_ATTR_SIMULATE_CURSOR, &value);
 
-  EXPECT_EQ(value, static_cast<SQLULEN>(SQL_SC_UNIQUE));
+  EXPECT_EQ(static_cast<SQLULEN>(SQL_SC_UNIQUE), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrUseBookmarks) {
   SQLULEN value;
   GetStmtAttr(this->stmt, SQL_ATTR_USE_BOOKMARKS, &value);
 
-  EXPECT_EQ(value, static_cast<SQLULEN>(SQL_UB_OFF));
+  EXPECT_EQ(static_cast<SQLULEN>(SQL_UB_OFF), value);
 }
 
 // This is a pre ODBC 3 attribute
@@ -380,7 +380,7 @@ TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrRowsetSize) {
   SQLULEN value;
   GetStmtAttr(this->stmt, SQL_ROWSET_SIZE, &value);
 
-  EXPECT_EQ(value, static_cast<SQLULEN>(1));
+  EXPECT_EQ(static_cast<SQLULEN>(1), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrAppParamDesc) {
@@ -512,7 +512,7 @@ TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrParamBindOffsetPtr) {
   SQLPOINTER value = nullptr;
   GetStmtAttr(this->stmt, SQL_ATTR_PARAM_BIND_OFFSET_PTR, &value);
 
-  EXPECT_EQ(value, static_cast<SQLPOINTER>(&offset));
+  EXPECT_EQ(static_cast<SQLPOINTER>(&offset), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrParamBindType) {
@@ -531,7 +531,7 @@ TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrParamOperationPtr) {
   SQLPOINTER value = nullptr;
   GetStmtAttr(this->stmt, SQL_ATTR_PARAM_OPERATION_PTR, &value);
 
-  EXPECT_EQ(value, static_cast<SQLPOINTER>(param_operations));
+  EXPECT_EQ(static_cast<SQLPOINTER>(param_operations), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrParamStatusPtr) {
@@ -546,7 +546,7 @@ TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrParamStatusPtr) {
   SQLPOINTER value = nullptr;
   GetStmtAttr(this->stmt, SQL_ATTR_PARAM_STATUS_PTR, &value);
 
-  EXPECT_EQ(value, static_cast<SQLPOINTER>(param_status));
+  EXPECT_EQ(static_cast<SQLPOINTER>(param_status), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrParamsProcessedPtr) {
@@ -558,7 +558,7 @@ TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrParamsProcessedPtr) {
   SQLPOINTER value = nullptr;
   GetStmtAttr(this->stmt, SQL_ATTR_PARAMS_PROCESSED_PTR, &value);
 
-  EXPECT_EQ(value, static_cast<SQLPOINTER>(&processed_count));
+  EXPECT_EQ(static_cast<SQLPOINTER>(&processed_count), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrParamsetSize) {
@@ -587,7 +587,7 @@ TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrRowBindOffsetPtr) {
   SQLPOINTER value = nullptr;
   GetStmtAttr(this->stmt, SQL_ATTR_ROW_BIND_OFFSET_PTR, &value);
 
-  EXPECT_EQ(value, static_cast<SQLPOINTER>(&offset));
+  EXPECT_EQ(static_cast<SQLPOINTER>(&offset), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrRowBindType) {
@@ -611,7 +611,7 @@ TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrRowOperationPtr) {
   SQLPOINTER value = nullptr;
   GetStmtAttr(this->stmt, SQL_ATTR_ROW_OPERATION_PTR, &value);
 
-  EXPECT_EQ(value, static_cast<SQLPOINTER>(row_operations));
+  EXPECT_EQ(static_cast<SQLPOINTER>(row_operations), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrRowStatusPtr) {
@@ -624,7 +624,7 @@ TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrRowStatusPtr) {
   SQLPOINTER value = nullptr;
   GetStmtAttr(this->stmt, SQL_ATTR_ROW_STATUS_PTR, &value);
 
-  EXPECT_EQ(value, static_cast<SQLPOINTER>(values));
+  EXPECT_EQ(static_cast<SQLPOINTER>(values), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrRowsFetchedPtr) {
@@ -636,7 +636,7 @@ TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrRowsFetchedPtr) {
   SQLPOINTER value = nullptr;
   GetStmtAttr(this->stmt, SQL_ATTR_ROWS_FETCHED_PTR, &value);
 
-  EXPECT_EQ(value, static_cast<SQLPOINTER>(&rows_fetched));
+  EXPECT_EQ(static_cast<SQLPOINTER>(&rows_fetched), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrSimulateCursor) {

--- a/cpp/src/arrow/flight/sql/odbc/tests/statement_attr_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/statement_attr_test.cc
@@ -30,10 +30,7 @@
 namespace arrow::flight::sql::odbc {
 
 template <typename T>
-class StatementAttributeTest : public T {
- public:
-  using List = std::list<T>;
-};
+class StatementAttributeTest : public T {};
 
 using TestTypes =
     ::testing::Types<FlightSQLODBCMockTestBase, FlightSQLODBCRemoteTestBase>;
@@ -158,7 +155,7 @@ TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrAsyncEnable) {
 #ifdef SQL_ATTR_ASYNC_STMT_EVENT
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrAsyncStmtEventUnsupported) {
   // Optional feature not implemented
-  ValidateGetStmtAttrErrorCode(this->stmt, SQL_ATTR_ASYNC_STMT_EVENT, error_state_HYC00);
+  ValidateGetStmtAttrErrorCode(this->stmt, SQL_ATTR_ASYNC_STMT_EVENT, kErrorStateHYC00);
 }
 #endif
 
@@ -166,7 +163,7 @@ TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrAsyncStmtEventUnsupported) 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrAsyncStmtPCCallbackUnsupported) {
   // Optional feature not implemented
   ValidateGetStmtAttrErrorCode(this->stmt, SQL_ATTR_ASYNC_STMT_PCALLBACK,
-                               error_state_HYC00);
+                               kErrorStateHYC00);
 }
 #endif
 
@@ -174,7 +171,7 @@ TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrAsyncStmtPCCallbackUnsuppor
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrAsyncStmtPCContextUnsupported) {
   // Optional feature not implemented
   ValidateGetStmtAttrErrorCode(this->stmt, SQL_ATTR_ASYNC_STMT_PCONTEXT,
-                               error_state_HYC00);
+                               kErrorStateHYC00);
 }
 #endif
 
@@ -360,7 +357,7 @@ TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrAppRowDesc) {
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrAsyncEnableUnsupported) {
   // Optional feature not implemented
   ValidateSetStmtAttrErrorCode(this->stmt, SQL_ATTR_ASYNC_ENABLE, SQL_ASYNC_ENABLE_OFF,
-                               error_state_HYC00);
+                               kErrorStateHYC00);
 }
 #endif
 
@@ -368,14 +365,14 @@ TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrAsyncEnableUnsupported) {
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrAsyncStmtEventUnsupported) {
   // Driver does not support asynchronous notification
   ValidateSetStmtAttrErrorCode(this->stmt, SQL_ATTR_ASYNC_STMT_EVENT, 0,
-                               error_state_HY118);
+                               kErrorStateHY118);
 }
 #endif
 
 #ifdef SQL_ATTR_ASYNC_STMT_PCALLBACK
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrAsyncStmtPCCallbackUnsupported) {
   ValidateSetStmtAttrErrorCode(this->stmt, SQL_ATTR_ASYNC_STMT_PCALLBACK, 0,
-                               error_state_HYC00);
+                               kErrorStateHYC00);
 }
 #endif
 
@@ -383,7 +380,7 @@ TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrAsyncStmtPCCallbackUnsuppor
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrAsyncStmtPCContextUnsupported) {
   // Optional feature not implemented
   ValidateSetStmtAttrErrorCode(this->stmt, SQL_ATTR_ASYNC_STMT_PCONTEXT, 0,
-                               error_state_HYC00);
+                               kErrorStateHYC00);
 }
 #endif
 
@@ -419,13 +416,13 @@ TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrFetchBookmarkPointer) {
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrIMPParamDesc) {
   // Invalid use of an automatically allocated descriptor handle
   ValidateSetStmtAttrErrorCode(this->stmt, SQL_ATTR_IMP_PARAM_DESC,
-                               static_cast<SQLULEN>(0), error_state_HY017);
+                               static_cast<SQLULEN>(0), kErrorStateHY017);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrIMPRowDesc) {
   // Invalid use of an automatically allocated descriptor handle
   ValidateSetStmtAttrErrorCode(this->stmt, SQL_ATTR_IMP_ROW_DESC, static_cast<SQLULEN>(0),
-                               error_state_HY017);
+                               kErrorStateHY017);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrKeysetSizeUnsupported) {
@@ -439,7 +436,7 @@ TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrMaxLength) {
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrMaxRows) {
   // Cannot set read-only attribute
   ValidateSetStmtAttrErrorCode(this->stmt, SQL_ATTR_MAX_ROWS, static_cast<SQLULEN>(0),
-                               error_state_HY092);
+                               kErrorStateHY092);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrMetadataID) {
@@ -534,7 +531,7 @@ TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrRowBindType) {
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrRowNumber) {
   // Cannot set read-only attribute
   ValidateSetStmtAttrErrorCode(this->stmt, SQL_ATTR_ROW_NUMBER, static_cast<SQLULEN>(0),
-                               error_state_HY092);
+                               kErrorStateHY092);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrRowOperationPtr) {

--- a/cpp/src/arrow/flight/sql/odbc/tests/statement_attr_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/statement_attr_test.cc
@@ -325,7 +325,8 @@ TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrRowBindType) {
   EXPECT_EQ(static_cast<SQLULEN>(0), value);
 }
 
-TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrRowNumber) {
+TYPED_TEST(StatementAttributeTest, DISABLED_TestSQLGetStmtAttrRowNumber) {
+  // GH-47711 TODO: enable test after SQLExecDirect support
   std::wstring wsql = L"SELECT 1;";
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
@@ -616,7 +617,7 @@ TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrRowOperationPtr) {
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrRowStatusPtr) {
   constexpr SQLULEN row_status_size = 4;
-  SQLUSMALLINT values[4] = {0, 0, 0, 0};
+  SQLUSMALLINT values[row_status_size] = {0, 0, 0, 0};
 
   ValidateSetStmtAttr(this->stmt, SQL_ATTR_ROW_STATUS_PTR,
                       static_cast<SQLPOINTER>(values));


### PR DESCRIPTION
### Rationale for this change
Support for getting and setting statement attributes in ODBC is added. 

### What changes are included in this PR?
- Implementation of `SQLGetStmtAttr` and  `SQLSetStmtAttr` to get and set statement attributes. 
- Tests

### Are these changes tested?
Tested on local MSVC

### Are there any user-facing changes?
No
* GitHub Issue: #47710