### PR TITLE
GH-47767: [CI] Add date to extra CI report email subject

### DIFF
--- a/dev/archery/archery/ci/core.py
+++ b/dev/archery/archery/ci/core.py
@@ -15,6 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
+from datetime import datetime
 from functools import cached_property
 
 import requests
@@ -42,6 +43,12 @@ class Workflow:
             # TODO: We could send an error report instead
             raise Exception(
                 f'Failed to fetch workflow data: {workflow_resp.status_code}')
+
+    @property
+    def datetime(self):
+        return datetime.strptime(
+            self.workflow_data.get('created_at'), "%Y-%m-%dT%H:%M:%SZ"
+        )
 
     @property
     def conclusion(self):

--- a/dev/archery/archery/templates/email_workflow_report.txt.j2
+++ b/dev/archery/archery/templates/email_workflow_report.txt.j2
@@ -20,7 +20,7 @@
 {%- endif -%}
 From: {{ sender_name }} <{{ sender_email }}>
 To: {{ recipient_email }}
-Subject: [NIGHTLY] Arrow Build Report for {{ report.name }}: {{ report.failed_jobs() | length }} failed
+Subject: [{{ report.datetime.strftime('%d/%m/%Y') }}] Arrow Build Report for {{ report.name }}: {{ report.failed_jobs() | length }} failed
 
 Arrow Build Report for {{ report.name }}
 

--- a/dev/archery/archery/templates/email_workflow_report.txt.j2
+++ b/dev/archery/archery/templates/email_workflow_report.txt.j2
@@ -20,7 +20,7 @@
 {%- endif -%}
 From: {{ sender_name }} <{{ sender_email }}>
 To: {{ recipient_email }}
-Subject: [{{ report.datetime.strftime('%d/%m/%Y') }}] Arrow Build Report for {{ report.name }}: {{ report.failed_jobs() | length }} failed
+Subject: [{{ report.datetime.strftime('%Y-%m-%d') }}] Arrow Build Report for {{ report.name }}: {{ report.failed_jobs() | length }} failed
 
 Arrow Build Report for {{ report.name }}
 


### PR DESCRIPTION
### Rationale for this change

We always use "[NIGHTLY] Arrow Build Report for C++ Extra: N failed" like subject for extra CI report emails.

It seems that lists.apache.org puts the same subject emails (even if they don't have References:/In-Reply-To: headers) to the same thread: https://lists.apache.org/thread/rjby1r7n5pw8l96pl1hbqsk29btbtbz4

### What changes are included in this PR?

Add date of when the workflow started to subject email.

### Are these changes tested?

Yes, locally from an old workflow run:
```
$ archery ci report-email --dry-run ...  --ignore report-extra-cpp  --repository raulcd/arrow  17676897217
From: Arrow <arrow@commit-email.info>
To: builds@arrow.apache.org
Subject: [12/09/2025] Arrow Build Report for C++ Extra: 0 failed

Arrow Build Report for C++ Extra

Workflow URL: https://github.com/raulcd/arrow/actions/runs/17676897217

```

### Are there any user-facing changes?

No

* GitHub Issue: #47767