### PR TITLE
GH-47781: [C++] Cleaned up type-limit warning in sink_node.cc

### DIFF
--- a/cpp/src/arrow/acero/sink_node.cc
+++ b/cpp/src/arrow/acero/sink_node.cc
@@ -267,11 +267,6 @@ class SinkNode : public ExecNode,
       return Status::Invalid(
           "`backpressure::pause_if_above` must be >= `backpressure::resume_if_below");
     }
-    if (sink_options.backpressure.resume_if_below < 0) {
-      return Status::Invalid(
-          "`backpressure::pause_if_above and backpressure::resume_if_below must be >= 0. "
-          " Set to 0 to disable backpressure.");
-    }
     return Status::OK();
   }
 


### PR DESCRIPTION
### Rationale for this change

This cleans up a dead code branch the compiler warns about

### What changes are included in this PR?

Removes a code branch that will never be hit

### Are these changes tested?

Yes

### Are there any user-facing changes?

No
* GitHub Issue: #47781