### PR TITLE
MINOR: [Docs][Python] update `exclude_invalid_files` docstring to correct default behavior

### DIFF
--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -3241,7 +3241,7 @@ cdef class FileSystemFactoryOptions(_Weakrefable):
     partitioning : Partitioning/PartitioningFactory, optional
        Apply the Partitioning to every discovered Fragment. See Partitioning or
        PartitioningFactory documentation.
-    exclude_invalid_files : bool, optional (default True)
+    exclude_invalid_files : bool, optional (default False)
         If True, invalid files will be excluded (file format specific check).
         This will incur IO for each files in a serial and single threaded
         fashion. Disabling this feature will skip the IO, but unsupported

--- a/python/pyarrow/dataset.py
+++ b/python/pyarrow/dataset.py
@@ -644,7 +644,7 @@ RecordBatch or Table, iterable of RecordBatch, RecordBatchReader, or URI
         partition_base_dir prefix will be skipped for partitioning discovery.
         The ignored files will still be part of the Dataset, but will not
         have partition information.
-    exclude_invalid_files : bool, optional (default True)
+    exclude_invalid_files : bool, optional (default False)
         If True, invalid files will be excluded (file format specific check).
         This will incur IO for each files in a serial and single threaded
         fashion. Disabling this feature will skip the IO, but unsupported


### PR DESCRIPTION
### Rationale for this change

This PR simply updates the default quoted in the docstring to the correct value for `exclude_invalid_files` in `dataset` (see #47770).

### What changes are included in this PR?

The `exclude_invalid_files` default is now listed as `False` instead of `True`

### Are these changes tested?

No, these changes only affect docstrings and not testable code. There is a test that appears to assert this behavior, though, so this updates the docstring to be consistent with an existing test: https://github.com/apache/arrow/blob/5750e2932fc26c27be92fe9262f6b128a513abca/python/pyarrow/tests/test_dataset.py#L1149

### Are there any user-facing changes?

Updated documentation
