### PR TITLE
GH-47803: [C++][Parquet] Fix read out of bounds on invalid RLE data

### DIFF
--- a/cpp/src/arrow/util/rle_encoding_internal.h
+++ b/cpp/src/arrow/util/rle_encoding_internal.h
@@ -699,6 +699,11 @@ auto RleBitPackedParser::PeekImpl(Handler&& handler) const
   ARROW_DCHECK_LT(value_bytes, internal::max_size_for_v<rle_size_t>);
   const auto bytes_read = header_bytes + static_cast<rle_size_t>(value_bytes);
 
+  if (ARROW_PREDICT_FALSE(bytes_read > data_size_)) {
+    // RLE run would overflow data buffer
+    return {0, ControlFlow::Break};
+  }
+
   auto control =
       handler.OnRleRun(RleRun(data_ + header_bytes, values_count, value_bit_width_));
 


### PR DESCRIPTION
### Rationale for this change

Found by OSS-Fuzz, should fix https://issues.oss-fuzz.com/issues/451150486.

### What changes are included in this PR?

Ensure RLE run is within bounds before reading it.

### Are these changes tested?

Yes, by fuzz regression test in ASAN/UBSAN build.

### Are there any user-facing changes?

No.

**This PR contains a "Critical Fix".** (If the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld), please provide explanation. If not, you can remove this.)

* GitHub Issue: #47803