### PR TITLE
GH-47809: [CI][Release] Fix Windows verification job trying to install patch from conda

### DIFF
--- a/ci/conda_env_cpp.txt
+++ b/ci/conda_env_cpp.txt
@@ -41,7 +41,6 @@ meson
 ninja
 nodejs
 orc<2.1.0
-patch
 pkg-config
 python
 rapidjson

--- a/ci/conda_env_unix.txt
+++ b/ci/conda_env_unix.txt
@@ -20,4 +20,5 @@
 autoconf
 ccache
 orc
+patch
 pkg-config


### PR DESCRIPTION
### Rationale for this change

Our verify-rc-source Windows job is failing due to patch not being available for Windows.

### What changes are included in this PR?

Move patch requirement from `conda_env_cpp.txt` to `conda_env_unix.txt`

### Are these changes tested?

Yes via CI and archery.

### Are there any user-facing changes?

No

* GitHub Issue: #47809