### PR TITLE
GH-47196: [CI][C++] Add Windows ARM64 build

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -280,100 +280,13 @@ jobs:
           ci/scripts/cpp_test.sh $(pwd) $(pwd)/build
 
   windows:
-    name: ${{ matrix.title }}
-    runs-on: ${{ matrix.os }}
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
-    timeout-minutes: 60
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - windows-2022
-        include:
-          - os: windows-2022
-            simd-level: AVX2
-            title: AMD64 Windows 2022 AVX2
-    env:
-      ARROW_BOOST_USE_SHARED: OFF
-      ARROW_BUILD_BENCHMARKS: ON
-      ARROW_BUILD_SHARED: ON
-      ARROW_BUILD_STATIC: OFF
-      ARROW_BUILD_TESTS: ON
-      ARROW_DATASET: ON
-      ARROW_FLIGHT: OFF
-      ARROW_HDFS: ON
-      ARROW_HOME: /usr
-      ARROW_JEMALLOC: OFF
-      ARROW_MIMALLOC: ON
-      ARROW_ORC: ON
-      ARROW_PARQUET: ON
-      ARROW_SIMD_LEVEL: ${{ matrix.simd-level }}
-      ARROW_SUBSTRAIT: ON
-      ARROW_USE_GLOG: OFF
-      ARROW_VERBOSE_THIRDPARTY_BUILD: OFF
-      ARROW_WITH_BROTLI: OFF
-      ARROW_WITH_BZ2: OFF
-      ARROW_WITH_LZ4: OFF
-      ARROW_WITH_OPENTELEMETRY: OFF
-      ARROW_WITH_SNAPPY: ON
-      ARROW_WITH_ZLIB: ON
-      ARROW_WITH_ZSTD: ON
-      BOOST_SOURCE: BUNDLED
-      CMAKE_CXX_STANDARD: "17"
-      CMAKE_GENERATOR: Ninja
-      CMAKE_INSTALL_PREFIX: /usr
-      CMAKE_UNITY_BUILD: ON
-    steps:
-      - name: Disable Crash Dialogs
-        run: |
-          reg add `
-            "HKCU\SOFTWARE\Microsoft\Windows\Windows Error Reporting" `
-            /v DontShowUI `
-            /t REG_DWORD `
-            /d 1 `
-            /f
-      - name: Checkout Arrow
-        uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
-          submodules: recursive
-      - name: Download Timezone Database
-        shell: bash
-        run: ci/scripts/download_tz_database.sh
-      - name: Install ccache
-        shell: bash
-        run: |
-          ci/scripts/install_ccache.sh 4.6.3 /usr
-      - name: Setup ccache
-        shell: bash
-        run: |
-          ci/scripts/ccache_setup.sh
-      - name: ccache info
-        id: ccache-info
-        shell: bash
-        run: |
-          echo "cache-dir=$(ccache --get-config cache_dir)" >> $GITHUB_OUTPUT
-      - name: Cache ccache
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.ccache-info.outputs.cache-dir }}
-          key: cpp-ccache-windows-${{ env.CACHE_VERSION }}-${{ hashFiles('cpp/**') }}
-          restore-keys: cpp-ccache-windows-${{ env.CACHE_VERSION }}-
-        env:
-          # We can invalidate the current cache by updating this.
-          CACHE_VERSION: "2022-09-13"
-      - name: Build
-        shell: cmd
-        run: |
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
-          bash -c "ci/scripts/cpp_build.sh $(pwd) $(pwd)/build"
-      - name: Test
-        shell: cmd
-        run: |
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
-          # For ORC
-          set TZDIR=C:\msys64\usr\share\zoneinfo
-          bash -c "ci/scripts/cpp_test.sh $(pwd) $(pwd)/build"
+    name: AMD64 Windows 2022 AVX2 C++
+    uses: ./.github/workflows/cpp_windows.yml
+    with:
+      arch: x64
+      os: windows-2022
+      simd-level: AVX2
 
   windows-mingw:
     name: AMD64 Windows MinGW ${{ matrix.msystem_upper }} C++

--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -164,6 +164,19 @@ jobs:
         continue-on-error: true
         run: archery docker push ${{ matrix.image }}
 
+  msvc-arm64:
+    needs: check-labels
+    if: >-
+      needs.check-labels.outputs.force == 'true' ||
+      contains(fromJSON(needs.check-labels.outputs.ci-extra-labels || '[]'), 'CI: Extra') ||
+      contains(fromJSON(needs.check-labels.outputs.ci-extra-labels || '[]'), 'CI: Extra: C++')
+    name: ARM64 Windows 11 MSVC
+    uses: ./.github/workflows/cpp_windows.yml
+    with:
+      arch: arm64
+      os: windows-11-arm
+      simd-level: NONE
+
   jni-linux:
     needs: check-labels
     name: JNI ${{ matrix.platform.runs-on }} ${{ matrix.platform.arch }}

--- a/.github/workflows/cpp_windows.yml
+++ b/.github/workflows/cpp_windows.yml
@@ -1,0 +1,124 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+name: C++ Windows MSVC Reusable
+
+on:
+  workflow_call:
+    inputs:
+      arch:
+        description: "The architecture to build for"
+        required: true
+        type: string
+      os:
+        description: "The runner label to run the job on"
+        required: true
+        type: string
+      simd-level:
+        description: "The Arrow SIMD level to build with"
+        required: true
+        type: string
+
+jobs:
+  windows:
+    runs-on: ${{ inputs.os }}
+    timeout-minutes: 60
+    env:
+      ARROW_BOOST_USE_SHARED: OFF
+      ARROW_BUILD_BENCHMARKS: ON
+      ARROW_BUILD_SHARED: ON
+      ARROW_BUILD_STATIC: OFF
+      ARROW_BUILD_TESTS: ON
+      ARROW_DATASET: ON
+      ARROW_FLIGHT: OFF
+      ARROW_HDFS: ON
+      ARROW_HOME: /usr
+      ARROW_JEMALLOC: OFF
+      ARROW_MIMALLOC: ON
+      ARROW_ORC: ON
+      ARROW_PARQUET: ON
+      ARROW_SIMD_LEVEL: ${{ inputs.simd-level }}
+      ARROW_SUBSTRAIT: ON
+      ARROW_USE_GLOG: OFF
+      ARROW_VERBOSE_THIRDPARTY_BUILD: OFF
+      ARROW_WITH_BROTLI: OFF
+      ARROW_WITH_BZ2: OFF
+      ARROW_WITH_LZ4: OFF
+      ARROW_WITH_OPENTELEMETRY: OFF
+      ARROW_WITH_SNAPPY: ON
+      ARROW_WITH_ZLIB: ON
+      ARROW_WITH_ZSTD: ON
+      BOOST_SOURCE: BUNDLED
+      CMAKE_CXX_STANDARD: "17"
+      CMAKE_GENERATOR: Ninja
+      CMAKE_INSTALL_PREFIX: /usr
+      CMAKE_UNITY_BUILD: ON
+    steps:
+      - name: Disable Crash Dialogs
+        run: |
+          reg add `
+            "HKCU\SOFTWARE\Microsoft\Windows\Windows Error Reporting" `
+            /v DontShowUI `
+            /t REG_DWORD `
+            /d 1 `
+            /f
+      - name: Checkout Arrow
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          submodules: recursive
+      - name: Download Timezone Database
+        shell: bash
+        run: ci/scripts/download_tz_database.sh
+      - name: Install msys2 (for tzdata for ORC tests)
+        uses: msys2/setup-msys2@v2
+        id: setup-msys2
+      - name: Install cmake
+        shell: bash
+        run: |
+          ci/scripts/install_cmake.sh 4.1.2 /usr
+      - name: Install ccache
+        shell: bash
+        run: |
+          ci/scripts/install_ccache.sh 4.12.1 /usr
+      - name: Setup ccache
+        shell: bash
+        run: |
+          ci/scripts/ccache_setup.sh
+      - name: ccache info
+        id: ccache-info
+        shell: bash
+        run: |
+          echo "cache-dir=$(ccache --get-config cache_dir)" >> $GITHUB_OUTPUT
+      - name: Cache ccache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.ccache-info.outputs.cache-dir }}
+          key: cpp-ccache-windows-${{ inputs.arch }}-${{ hashFiles('cpp/**') }}
+          restore-keys: cpp-ccache-windows-${{ inputs.arch }}-
+      - name: Build
+        shell: cmd
+        run: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{ inputs.arch }}
+          bash -c "ci/scripts/cpp_build.sh $(pwd) $(pwd)/build"
+      - name: Test
+        shell: cmd
+        run: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{ inputs.arch }}
+          # For ORC
+          set TZDIR=${{ steps.setup-msys2.outputs.msys2-location }}\usr\share\zoneinfo
+          bash -c "ci/scripts/cpp_test.sh $(pwd) $(pwd)/build"

--- a/ci/scripts/install_ccache.sh
+++ b/ci/scripts/install_ccache.sh
@@ -30,10 +30,19 @@ prefix=$2
 mkdir -p /tmp/ccache
 case $(uname) in
   MINGW64*)
-    url="https://github.com/ccache/ccache/releases/download/v${version}/ccache-${version}-windows-x86_64.zip"
+    declare -A archs
+    archs=([64-bit]="x86_64"
+           [ARM 64-bit Processor]="aarch64")
+    arch=$(powershell -Command "(Get-CimInstance Win32_OperatingSystem).OSArchitecture")
+    if [ -z "${archs[$arch]}" ]; then
+      echo "Unsupported architecture on Windows: ${arch}"
+      exit 0
+    fi
+    arch=${archs[$arch]}
+    url="https://github.com/ccache/ccache/releases/download/v${version}/ccache-${version}-windows-${arch}.zip"
     pushd /tmp/ccache
     curl --fail --location --remote-name "${url}"
-    unzip -j "ccache-${version}-windows-x86_64.zip"
+    unzip -j "ccache-${version}-windows-${arch}.zip"
     chmod +x ccache.exe
     mv ccache.exe "${prefix}/bin/"
     popd

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -1118,6 +1118,11 @@ function(build_boost)
     # This is for https://github.com/boostorg/container/issues/305
     string(APPEND CMAKE_C_FLAGS " -Wno-strict-prototypes")
   endif()
+  if(MSVC AND "${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "ARM64")
+    set(BOOST_CONTEXT_IMPLEMENTATION
+        winfib
+        CACHE STRING "" FORCE)
+  endif()
   set(CMAKE_UNITY_BUILD OFF)
 
   fetchcontent_makeavailable(boost)


### PR DESCRIPTION
### Rationale for this change

This PR adds a CI job to test building the C++ library on Windows ARM64 with MSVC, which will help ensuring that downstream projects like [`vcpkg`](https://github.com/microsoft/vcpkg) can build Arrow C++ on that platform.

### What changes are included in this PR?

- The `windows` job from the `cpp.yml` workflow has been moved into a reusable workflow `cpp_windows.yml`
- Use GitHub hosted runner `windows-11-arm` to build with MSVC ARM64 in `cpp_extra.yml`
- `simd-level` is set `NONE` for now as xsimd does not yet support MSVC ARM64
- `msys2` is installed and used for the timezone data, as it is not guaranteed to exist on `windows-11-arm` images
- A recent version of `cmake` is installed as support for finding Windows OpenSSL ARM64 builds was only added in 4.1.0 (see https://github.com/Kitware/CMake/commit/bf52219e4c095fb0db7d0dc6cc0ebcbd5026c73e)
- The Boost context implementation is set to `winfib` when building with MSVC ARM64 as it's the only supported implementation for that platform (see https://github.com/boostorg/context/issues/296#issuecomment-3234098728 and https://github.com/boostorg/context/pull/315)

### Are these changes tested?

Yes, in the CI itself

### Are there any user-facing changes?

No
* GitHub Issue: #47196