### PR TITLE
GH-47812: [R][CI] Fix lint for new version of styler

### DIFF
--- a/r/tests/testthat/test-RecordBatch.R
+++ b/r/tests/testthat/test-RecordBatch.R
@@ -760,7 +760,6 @@ test_that("RecordBatch to C-interface", {
 })
 
 
-
 test_that("RecordBatchReader to C-interface to arrow_dplyr_query", {
   skip_if_not_available("dataset")
 


### PR DESCRIPTION
### Rationale for this change

Linter job is currently failing on main due to a new version of styler on CRAN.

### What changes are included in this PR?

Remove empty line to please the linter.

### Are these changes tested?

Yes, CI job is now successful

### Are there any user-facing changes?

No

* GitHub Issue: #47812