### PR TITLE
GH-47819: [CI][Packaging][Release] Avoid triggering Linux packages on release branch push

### DIFF
--- a/.github/workflows/package_linux.yml
+++ b/.github/workflows/package_linux.yml
@@ -22,6 +22,7 @@ on:
     branches:
       - '**'
       - '!dependabot/**'
+      - '!release-*'
     paths:
       - '.github/workflows/check_labels.yml'
       - '.github/workflows/package_linux.yml'


### PR DESCRIPTION
### Rationale for this change

We require the Linux package jobs to be triggered on RC tag creation. For example for 22.0.0, we currently push the tag `apache-arrow-22.0.0-rc0` and the release branch `release-22.0.0-rc0`. Those events are triggering builds over the same commit and the tag event gets cancelled due to a "high priority task" triggering the same jobs. This causes jobs to fail on the branch because the ARROW_VERSION is not generated. If we manually re-trigger the jobs on the tag they are successful.

### What changes are included in this PR?

Remove the `release-*` branches from triggering the event to allow only the tag to run the jobs so they don't get cancelled.

### Are these changes tested?

No

### Are there any user-facing changes?

No

* GitHub Issue: #47819