### PR TITLE
GH-47821: [CI][Release][R] Add backslash to repo folder for R binary testing and remove libarrow subfolder

### DIFF
--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -244,7 +244,7 @@ env:
     uses: actions/download-artifact@v4
     with:
       name: r-libarrow-windows-x86_64
-      path: repo/libarrow
+      path: repo
   {% endif %}
   {% if get_nix %}
     {% for openssl_version in ["1.0", "1.1", "3.0"] %}
@@ -252,7 +252,7 @@ env:
     uses: actions/download-artifact@v4
     with:
       name: r-libarrow-linux-x86_64-openssl-{{ openssl_version }}
-      path: repo/libarrow
+      path: repo
     {% endfor %}
   {% endif %}
   {% if get_mac %}
@@ -262,7 +262,7 @@ env:
     uses: actions/download-artifact@v4
     with:
       name: r-libarrow-darwin-{{ arch }}-openssl-{{ openssl_version }}
-      path: repo/libarrow
+      path: repo
       {% endfor %}
     {% endfor %}
   {% endif %}
@@ -285,7 +285,7 @@ env:
     shell: Rscript {0}
     run: |
       profile_path <- file.path(getwd(), ".Rprofile")
-      repo <- paste0("file://", getwd(), "/repo")
+      repo <- paste0("file://", getwd(), "/repo/")
       str <- paste0("options(arrow.repo = '", repo, "' )")
       print(str)
       write(str, file = profile_path, append = TRUE)

--- a/dev/tasks/r/github.packages.yml
+++ b/dev/tasks/r/github.packages.yml
@@ -257,7 +257,7 @@ jobs:
           LIBARROW_BINARY: "true" # has to be set as long as allowlist not updated
           LIBARROW_BUILD: "false"
           ARROW_R_ENFORCE_CHECKSUM: "true"
-          ARROW_R_CHECKSUM_PATH: "{{ '${{ github.workspace }}' }}/repo/libarrow"
+          ARROW_R_CHECKSUM_PATH: "{{ '${{ github.workspace }}' }}/repo"
         run: |
           on_windows <- tolower(Sys.info()[["sysname"]]) == "windows"
 
@@ -346,7 +346,7 @@ jobs:
           LIBARROW_BUILD: "FALSE"
           LIBARROW_BINARY: {{ '${{ matrix.config.libarrow_binary }}' }}
           ARROW_R_ENFORCE_CHECKSUM: "true"
-          ARROW_R_CHECKSUM_PATH: "{{ '${{ github.workspace }}' }}/repo/libarrow"
+          ARROW_R_CHECKSUM_PATH: "{{ '${{ github.workspace }}' }}/repo"
         shell: bash
         run: |
           Rscript -e '

--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -935,7 +935,7 @@ is_release <- is.na(dev_version) || dev_version < "100"
 
 on_macos <- tolower(Sys.info()[["sysname"]]) == "darwin"
 on_windows <- tolower(Sys.info()[["sysname"]]) == "windows"
-on_linux_dev <-  tolower(Sys.info()[["sysname"]]) == "linux" && grepl("devel", R.version.string)
+on_linux_dev <- tolower(Sys.info()[["sysname"]]) == "linux" && grepl("devel", R.version.string)
 
 # For local debugging, set ARROW_R_DEV=TRUE to make this script print more
 quietly <- !env_is("ARROW_R_DEV", "true")
@@ -976,7 +976,7 @@ if (is_release) {
   }
 } else {
   VERSION_22_OR_LATER <- TRUE
-  arrow_repo <- paste0(getOption("arrow.dev_repo", "https://nightlies.apache.org/arrow/r"), "/libarrow/")
+  arrow_repo <- getOption("arrow.dev_repo", "https://nightlies.apache.org/arrow/r/libarrow/")
 }
 
 # Check if we're authorized to download


### PR DESCRIPTION
### Rationale for this change

The r-binary-packages job was failing on the release candidate 0 for 22.0.0 due to local repository not being correct.

### What changes are included in this PR?

Minor fixes to the R packages repository

### Are these changes tested?

Yes, this commit was temporarily applied to the Release Candidate branch to generate the r-binary-packages. The r-binary-packages where generated successfully. See the corresponding issue for a more details description.

### Are there any user-facing changes?

No
* GitHub Issue: #47821