### PR TITLE
GH-47830: [Release] Run RC verification source testing step in a subshell

### DIFF
--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -1027,10 +1027,10 @@ TEST_SUCCESS=no
 
 setup_tempdir
 ensure_source_directory
-# Run source and binary tests in subshells so environment variables
+# Run source tests in a subshell so environment variables
 # set for source testing aren't exposed to the binary tests.
 (test_source_distribution)
-(test_binary_distribution)
+test_binary_distribution
 
 TEST_SUCCESS=yes
 

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -1027,8 +1027,10 @@ TEST_SUCCESS=no
 
 setup_tempdir
 ensure_source_directory
-test_source_distribution
-test_binary_distribution
+# Run source and binary tests in subshells so environment variables
+# set for source testing aren't exposed to the binary tests.
+(test_source_distribution)
+(test_binary_distribution)
 
 TEST_SUCCESS=yes
 


### PR DESCRIPTION
### Rationale for this change

Isolates environment variable changes made when verifying the source from the tests that verify the binaries, to prevent these causing errors like in #47830.

### What changes are included in this PR?

Changes `verify-release-candidate.sh` to run `test_source_distribution` in a subshell.

### Are these changes tested?

I've tested this manually, I'm not sure if there are any existing CI tests that run this script on PRs.

### Are there any user-facing changes?

No
* GitHub Issue: #47830