### PR TITLE
GH-47836: [C++] Fix Meson configuration after bpacking changes

### DIFF
--- a/ci/scripts/cpp_test.sh
+++ b/ci/scripts/cpp_test.sh
@@ -105,9 +105,11 @@ fi
 if [ "${ARROW_USE_MESON:-OFF}" = "ON" ]; then
   ARROW_BUILD_EXAMPLES=OFF # TODO: Remove this
   meson test \
+    --max-lines=0 \
     --no-rebuild \
     --print-errorlogs \
     --suite arrow \
+    --timeout-multiplier=10 \
     "$@"
 else
   ctest \

--- a/cpp/src/arrow/meson.build
+++ b/cpp/src/arrow/meson.build
@@ -175,6 +175,8 @@ arrow_util_srcs = [
     'util/bitmap_builders.cc',
     'util/bitmap_ops.cc',
     'util/bpacking.cc',
+    'util/bpacking_scalar.cc',
+    'util/bpacking_simd_default.cc',
     'util/byte_size.cc',
     'util/byte_stream_split_internal.cc',
     'util/cancel.cc',


### PR DESCRIPTION
### Rationale for this change

This fixes the Meson configuration

### What changes are included in this PR?

Added new bpacking modules to the Meson configuration

### Are these changes tested?

Yes

### Are there any user-facing changes?

No
* GitHub Issue: #47836