### PR TITLE
MINOR: [Docs] Add note to Windows docs about patch util

### DIFF
--- a/docs/source/developers/cpp/windows.rst
+++ b/docs/source/developers/cpp/windows.rst
@@ -327,6 +327,12 @@ The command line to build Arrow in Debug mode will look something like this:
          -DBOOST_LIBRARYDIR=C:/local/boost_1_63_0/lib64-msvc-14.0
    cmake --build . --config Debug
 
+Depending on the CMake variables or preset you use, you may need to have the
+``patch`` utility in your ``PATH``. There are a number of ways to do this. For
+example, if you're already using  `Git for Windows
+<https://git-scm.com/downloads/win>`_, you could add ``C:\Program
+Files\Git\usr\bin`` to your ``PATH``.
+
 Windows dependency resolution issues
 ====================================
 


### PR DESCRIPTION
### Rationale for this change

For certain C++ build configurations, we require `patch` to be in the user's `PATH`. This was introduced in https://github.com/apache/arrow/commit/e1f727cbb447d2385949a54d8f4be2fdc6cefe29 and a [Discussion pointed this out](https://github.com/apache/arrow/discussions/47829#discussioncomment-14702132). For Linux and macOS, it's pretty reasonable for us to assume `patch` is available but not on Windows.

### What changes are included in this PR?

Adds a note in the "Debug" section of the Windows docs.

### Are these changes tested?

Yes, I'll add a screenshot to make review easier.

### Are there any user-facing changes?

No.