### PR TITLE
GH-47840: [CI][C++] Check whether the CSV module/thread sanitizer is enabled or not before building example

### DIFF
--- a/ci/scripts/cpp_test.sh
+++ b/ci/scripts/cpp_test.sh
@@ -129,7 +129,9 @@ fi
 # * This doesn't test other CMake packages such as ArrowDataset
 if [ "${ARROW_USE_MESON:-OFF}" = "OFF" ] && \
      [ "${ARROW_EMSCRIPTEN:-OFF}" = "OFF" ] && \
-     [ "${ARROW_USE_ASAN:-OFF}" = "OFF" ]; then
+     [ "${ARROW_USE_ASAN:-OFF}" = "OFF" ] && \
+     [ "${ARROW_USE_TSAN:-OFF}" = "OFF" ] && \
+     [ "${ARROW_CSV:-ON}" = "ON" ]; then
   CMAKE_PREFIX_PATH="${CMAKE_INSTALL_PREFIX:-${ARROW_HOME}}"
   case "$(uname)" in
     MINGW*)


### PR DESCRIPTION
### Rationale for this change

`cpp/examples/minimal_build/` needs the CSV module.

We need additional flags for thread sanitizer.

### What changes are included in this PR?

* Check whether `ARROW_CSV` is enabled.
* Check whether thread sanitizer is enabled.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #47840