### PR TITLE
GH-47846: [Format] clarify the encoding of the fp16 substrait literal

### DIFF
--- a/format/substrait/extension_types.yaml
+++ b/format/substrait/extension_types.yaml
@@ -107,8 +107,11 @@ types:
   - name: u64
     structure: {}
   # fp16 literals are encoded as user defined literals with
-  # a google.protobuf.UInt32Value message where the lower 16 bits are
-  # the fp16 value.
+  # a google.protobuf.UInt32Value message where the least significant
+  # 16 bits are the fp16 value encoded with little-endian encoding.
+  #
+  # In other words, the least significant 8 bits of the u32 will contain
+  # the most significant 8 bits of the fp16 value.
   - name: fp16
     structure: {}
   # 64-bit integers are big.  Even though date64 stores ms and not days it


### PR DESCRIPTION
### Rationale for this change

Closes #47846 

### What changes are included in this PR?

This is only a format change.  The C++ Substrait library does not (tmk) support encoding fp16 literals via Substrait.  This is to support a proposed Datafusion change (https://github.com/apache/datafusion/pull/18086).

### Are these changes tested?

Only via the Datafusion change

### Are there any user-facing changes?

This is a clarification to the Substrait spec for Arrow types that are not standard Substrait types
* GitHub Issue: #47846