### PR TITLE
MINOR: [Docs] Add Python 3.14 to install documentation

### DIFF
--- a/docs/source/python/install.rst
+++ b/docs/source/python/install.rst
@@ -27,7 +27,7 @@ Linux distributions. We strongly recommend using a 64-bit system.
 Python Compatibility
 --------------------
 
-PyArrow is currently compatible with Python 3.10, 3.11, 3.12 and 3.13.
+PyArrow is currently compatible with Python 3.10, 3.11, 3.12, 3.13 and 3.14.
 
 Using Conda
 -----------


### PR DESCRIPTION
### Rationale for this change

I have noticed I forgot to add support for Python 3.14 to the install docs. The support for Python 3.14 has been added in this PR: https://github.com/apache/arrow/pull/47616.

### What changes are included in this PR?

Minor documentation change in Python Compatibility section.

### Are these changes tested?

No, no need.

### Are there any user-facing changes?

No.