### PR TITLE
GH-46197: [C++] Avoid using legacy timezone in tests

### DIFF
--- a/cpp/src/arrow/compute/kernels/scalar_temporal_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_temporal_test.cc
@@ -2175,10 +2175,10 @@ TEST_F(ScalarTemporalTest, StrftimeCLocale) {
                    string_milliseconds, &options);
   CheckScalarUnary("strftime", timestamp(TimeUnit::MICRO, "Asia/Kolkata"), microseconds,
                    utf8(), string_microseconds, &options);
-  CheckScalarUnary("strftime", timestamp(TimeUnit::NANO, "US/Hawaii"), nanoseconds,
+  CheckScalarUnary("strftime", timestamp(TimeUnit::NANO, "Pacific/Honolulu"), nanoseconds,
                    utf8(), string_nanoseconds, &options);
 
-  CheckScalarUnary("strftime", timestamp(TimeUnit::NANO, "US/Hawaii"), nanoseconds,
+  CheckScalarUnary("strftime", timestamp(TimeUnit::NANO, "Pacific/Honolulu"), nanoseconds,
                    utf8(), string_locale_specific, &options_locale_specific);
 }
 


### PR DESCRIPTION
### Rationale for this change

Most of these cases have been fixed by https://github.com/apache/arrow/pull/46201 already but it seems we missed a couple of them.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #46197