### PR TITLE
GH-47883: [CI] Add openssl gem explicitly to fix ceriticate validation error on test

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Install Dependencies
         shell: bash
         run: |
-          gem install test-unit
+          gem install test-unit openssl
           pip install "cython>=3.1" setuptools pytest requests setuptools-scm
       - name: Run Release Test
         shell: bash


### PR DESCRIPTION
### Rationale for this change

The Source Release and Merge Script on macos-latest is failing on PRs with
> Error: OpenSSL::SSL::SSLError: SSL_connect returned=1 errno=0 peeraddr=140.82.116.6:443 state=error: certificate verify failed (unable to get certificate CRL)


### What changes are included in this PR?

Include openssl gem on environment setup.

As suggested on rails issue: https://github.com/rails/rails/issues/55886

### Are these changes tested?

Yes via CI.

### Are there any user-facing changes?

No

* GitHub Issue: #47883