### PR TITLE
GH-47000: [R] concat_tables on a record_batch causes segfault

### DIFF
--- a/r/R/table.R
+++ b/r/R/table.R
@@ -184,6 +184,15 @@ concat_tables <- function(..., unify_schemas = TRUE) {
     abort("Must pass at least one Table.")
   }
 
+  # Convert any RecordBatch objects to Tables
+  tables <- lapply(tables, function(x) {
+    if (inherits(x, "RecordBatch")) {
+      arrow_table(x)
+    } else {
+      x
+    }
+  })
+
   if (!unify_schemas) {
     # assert they have same schema
     schema <- tables[[1]]$schema

--- a/r/R/table.R
+++ b/r/R/table.R
@@ -166,7 +166,8 @@ names.Table <- function(x) x$ColumnNames()
 #' does not copy array data, but instead creates new chunked arrays for each
 #' column that point at existing array data.
 #'
-#' @param ... A [Table]
+#' @param ... One or more [Table] or [RecordBatch] objects. RecordBatch objects
+#'   will be automatically converted to Tables.
 #' @param unify_schemas If TRUE, the schemas of the tables will be first unified
 #' with fields of the same name being merged, then each table will be promoted
 #' to the unified schema before being concatenated. Otherwise, all tables should
@@ -176,6 +177,10 @@ names.Table <- function(x) x$ColumnNames()
 #' prius <- arrow_table(name = "Prius", mpg = 58, cyl = 4, disp = 1.8)
 #' combined <- concat_tables(tbl, prius)
 #' tail(combined)$to_data_frame()
+#'
+#' # Can also pass RecordBatch objects
+#' batch <- record_batch(name = "Volt", mpg = 53, cyl = 4, disp = 1.5)
+#' combined2 <- concat_tables(tbl, batch)
 #' @export
 concat_tables <- function(..., unify_schemas = TRUE) {
   tables <- list2(...)

--- a/r/man/concat_tables.Rd
+++ b/r/man/concat_tables.Rd
@@ -7,7 +7,8 @@
 concat_tables(..., unify_schemas = TRUE)
 }
 \arguments{
-\item{...}{A \link{Table}}
+\item{...}{One or more \link{Table} or \link{RecordBatch} objects. RecordBatch objects
+will be automatically converted to Tables.}
 
 \item{unify_schemas}{If TRUE, the schemas of the tables will be first unified
 with fields of the same name being merged, then each table will be promoted
@@ -24,4 +25,8 @@ tbl <- arrow_table(name = rownames(mtcars), mtcars)
 prius <- arrow_table(name = "Prius", mpg = 58, cyl = 4, disp = 1.8)
 combined <- concat_tables(tbl, prius)
 tail(combined)$to_data_frame()
+
+# Can also pass RecordBatch objects
+batch <- record_batch(name = "Volt", mpg = 53, cyl = 4, disp = 1.5)
+combined2 <- concat_tables(tbl, batch)
 }

--- a/r/tests/testthat/test-Table.R
+++ b/r/tests/testthat/test-Table.R
@@ -478,6 +478,20 @@ test_that("Tables can be combined with concat_tables()", {
   expect_equal(expected, concat_tables(expected))
 })
 
+test_that("concat_tables() handles RecordBatch objects (GH-47000)", {
+  # concat_tables() should automatically convert RecordBatch to Table
+  tbl <- arrow_table(a = 1:5, b = letters[1:5])
+  rb <- record_batch(a = 6:10, b = letters[6:10])
+
+  # Concatenating a Table with a RecordBatch should work (not segfault)
+  result <- concat_tables(tbl, rb)
+  expect_s3_class(result, "Table")
+  expect_equal(
+    result,
+    arrow_table(a = 1:10, b = letters[1:10])
+  )
+})
+
 test_that("Table supports rbind", {
   expect_error(
     rbind(arrow_table(a = 1:10), arrow_table(a = c("a", "b"))),


### PR DESCRIPTION
### Rationale for this change

Segfault due to combining recordbatches in concat_tables

### What changes are included in this PR?

Convert to tables before combining

### Are these changes tested?

Yes

### Are there any user-facing changes?

No
* GitHub Issue: #47000