### PR TITLE
GH-47887: [C++][Integration] Enable extension types with C Data Interface tests

### DIFF
--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -679,8 +679,8 @@ set(ARROW_TESTING_SRCS
 #
 
 if(ARROW_BUILD_INTEGRATION OR ARROW_BUILD_TESTS)
-  arrow_add_object_library(ARROW_INTEGRATION integration/c_data_integration_internal.cc
-                           integration/json_integration.cc integration/json_internal.cc)
+  arrow_add_object_library(ARROW_INTEGRATION integration/json_integration.cc
+                           integration/json_internal.cc)
   foreach(ARROW_INTEGRATION_TARGET ${ARROW_INTEGRATION_TARGETS})
     target_link_libraries(${ARROW_INTEGRATION_TARGET} PRIVATE RapidJSON)
   endforeach()

--- a/cpp/src/arrow/integration/CMakeLists.txt
+++ b/cpp/src/arrow/integration/CMakeLists.txt
@@ -38,7 +38,7 @@ elseif(ARROW_BUILD_INTEGRATION)
                 SOURCES
                 c_data_integration_internal.cc
                 SHARED_LINK_LIBS
-                ${ARROW_TEST_SHARED_LINK_LIBS}
+                arrow_testing_shared
                 STATIC_LINK_LIBS
-                ${ARROW_TEST_STATIC_LINK_LIBS})
+                arrow_testing_static)
 endif()

--- a/cpp/src/arrow/integration/CMakeLists.txt
+++ b/cpp/src/arrow/integration/CMakeLists.txt
@@ -33,4 +33,12 @@ elseif(ARROW_BUILD_INTEGRATION)
 
   add_dependencies(arrow-json-integration-test arrow arrow_testing)
   add_dependencies(arrow-integration arrow-json-integration-test)
+
+  add_arrow_lib(arrow_c_data_integration
+                SOURCES
+                c_data_integration_internal.cc
+                SHARED_LINK_LIBS
+                ${ARROW_TEST_SHARED_LINK_LIBS}
+                STATIC_LINK_LIBS
+                ${ARROW_TEST_STATIC_LINK_LIBS})
 endif()

--- a/cpp/src/arrow/integration/c_data_integration_internal.cc
+++ b/cpp/src/arrow/integration/c_data_integration_internal.cc
@@ -28,12 +28,18 @@
 #include "arrow/record_batch.h"
 #include "arrow/result.h"
 #include "arrow/status.h"
+#include "arrow/testing/extension_type.h"
 #include "arrow/type.h"
 #include "arrow/type_fwd.h"
 #include "arrow/util/logging.h"
 
 namespace arrow::internal::integration {
 namespace {
+
+// Make sure the extension types referenced in test data are registered.
+[[nodiscard]] auto RequireExtensionTypes() {
+  return ExtensionTypeGuard({uuid(), dict_extension_type()});
+}
 
 template <typename Func>
 const char* StatusToErrorString(Func&& func) {
@@ -113,30 +119,39 @@ Status ImportBatchAndCompareToJson(std::string json_path, int num_batch,
 const char* ArrowCpp_CDataIntegration_ExportSchemaFromJson(const char* json_path,
                                                            ArrowSchema* out) {
   using namespace arrow::internal::integration;  // NOLINT(build/namespaces)
-  return StatusToErrorString([=]() { return ExportSchemaFromJson(json_path, out); });
+  return StatusToErrorString([=]() {
+    auto guard = RequireExtensionTypes();
+    return ExportSchemaFromJson(json_path, out);
+  });
 }
 
 const char* ArrowCpp_CDataIntegration_ImportSchemaAndCompareToJson(const char* json_path,
                                                                    ArrowSchema* schema) {
   using namespace arrow::internal::integration;  // NOLINT(build/namespaces)
-  return StatusToErrorString(
-      [=]() { return ImportSchemaAndCompareToJson(json_path, schema); });
+  return StatusToErrorString([=]() {
+    auto guard = RequireExtensionTypes();
+    return ImportSchemaAndCompareToJson(json_path, schema);
+  });
 }
 
 const char* ArrowCpp_CDataIntegration_ExportBatchFromJson(const char* json_path,
                                                           int num_batch,
                                                           ArrowArray* out) {
   using namespace arrow::internal::integration;  // NOLINT(build/namespaces)
-  return StatusToErrorString(
-      [=]() { return ExportBatchFromJson(json_path, num_batch, out); });
+  return StatusToErrorString([=]() {
+    auto guard = RequireExtensionTypes();
+    return ExportBatchFromJson(json_path, num_batch, out);
+  });
 }
 
 const char* ArrowCpp_CDataIntegration_ImportBatchAndCompareToJson(const char* json_path,
                                                                   int num_batch,
                                                                   ArrowArray* batch) {
   using namespace arrow::internal::integration;  // NOLINT(build/namespaces)
-  return StatusToErrorString(
-      [=]() { return ImportBatchAndCompareToJson(json_path, num_batch, batch); });
+  return StatusToErrorString([=]() {
+    auto guard = RequireExtensionTypes();
+    return ImportBatchAndCompareToJson(json_path, num_batch, batch);
+  });
 }
 
 int64_t ArrowCpp_BytesAllocated() {

--- a/dev/archery/archery/integration/datagen.py
+++ b/dev/archery/archery/integration/datagen.py
@@ -2017,9 +2017,6 @@ def get_generated_json_files(tempdir=None):
 
         generate_extension_case()
         .skip_tester('nanoarrow')
-        # TODO: ensure the extension is registered in the C++ entrypoint
-        .skip_format(SKIP_C_SCHEMA, 'C++')
-        .skip_format(SKIP_C_ARRAY, 'C++')
         # TODO(https://github.com/apache/arrow/issues/38045)
         .skip_format(SKIP_FLIGHT, '.NET'),
     ]

--- a/dev/archery/archery/integration/datagen.py
+++ b/dev/archery/archery/integration/datagen.py
@@ -28,7 +28,7 @@ import shutil
 import numpy as np
 
 from .util import frombytes, tobytes, random_bytes, random_utf8
-from .util import SKIP_C_SCHEMA, SKIP_C_ARRAY, SKIP_FLIGHT
+from .util import SKIP_C_SCHEMA, SKIP_FLIGHT
 
 
 def metadata_key_values(pairs):

--- a/dev/archery/archery/integration/tester_cpp.py
+++ b/dev/archery/archery/integration/tester_cpp.py
@@ -42,7 +42,7 @@ _FLIGHT_CLIENT_CMD = [
 ]
 
 _DLL_PATH = _EXE_PATH
-_ARROW_DLL = os.path.join(_DLL_PATH, "libarrow" + cdata.dll_suffix)
+_ARROW_DLL = os.path.join(_DLL_PATH, "libarrow_c_data_integration" + cdata.dll_suffix)
 
 
 class CppTester(Tester):


### PR DESCRIPTION
### Rationale for this change

Extension type tests were skipped in the C Data Interface tests.

### What changes are included in this PR?

* Move C Data Integration testing entrypoints into a dedicated DLL, and make them link to the `arrow_testing` library
* Register the required extension types in those entrypoints
* Remove the associated skip in the Archery integration testing harness

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #47887