### PR TITLE
GH-47895: [C++][Parquet] Add prolog and epilog in unpack

### DIFF
--- a/cpp/src/arrow/util/bit_run_reader.cc
+++ b/cpp/src/arrow/util/bit_run_reader.cc
@@ -45,7 +45,7 @@ BitRunReader::BitRunReader(const uint8_t* bitmap, int64_t start_offset, int64_t 
 
   // Prepare for inversion in NextRun.
   // Clear out any preceding bits.
-  word_ = word_ & ~bit_util::LeastSignificantBitMask(position_);
+  word_ = word_ & ~bit_util::LeastSignificantBitMask<uint64_t>(position_);
 }
 
 #endif

--- a/cpp/src/arrow/util/bit_run_reader.h
+++ b/cpp/src/arrow/util/bit_run_reader.h
@@ -106,7 +106,7 @@ class ARROW_EXPORT BitRunReader {
     int64_t start_bit_offset = start_position & 63;
     // Invert the word for proper use of CountTrailingZeros and
     // clear bits so CountTrailingZeros can do it magic.
-    word_ = ~word_ & ~bit_util::LeastSignificantBitMask(start_bit_offset);
+    word_ = ~word_ & ~bit_util::LeastSignificantBitMask<uint64_t>(start_bit_offset);
 
     // Go  forward until the next change from unset to set.
     int64_t new_bits = bit_util::CountTrailingZeros(word_) - start_bit_offset;
@@ -311,12 +311,12 @@ class BaseSetBitRunReader {
       memcpy(reinterpret_cast<char*>(&word) + 8 - num_bytes, bitmap_, num_bytes);
       // XXX MostSignificantBitmask
       return (bit_util::ToLittleEndian(word) << bit_offset) &
-             ~bit_util::LeastSignificantBitMask(64 - num_bits);
+             ~bit_util::LeastSignificantBitMask<uint64_t>(64 - num_bits);
     } else {
       memcpy(&word, bitmap_, num_bytes);
       bitmap_ += num_bytes;
       return (bit_util::ToLittleEndian(word) >> bit_offset) &
-             bit_util::LeastSignificantBitMask(num_bits);
+             bit_util::LeastSignificantBitMask<uint64_t>(num_bits);
     }
   }
 

--- a/cpp/src/arrow/util/bit_stream_utils_internal.h
+++ b/cpp/src/arrow/util/bit_stream_utils_internal.h
@@ -337,9 +337,8 @@ inline int BitReader::GetBatch(int num_bits, T* v, int batch_size) {
 
   using unpack_t = typename internal_bit_reader::unpack_detect<T>::type;
 
-  int num_unpacked = ::arrow::internal::unpack(
-      buffer + byte_offset, reinterpret_cast<unpack_t*>(v + i), batch_size - i, num_bits);
-  ARROW_DCHECK_EQ(batch_size - i, num_unpacked);
+  ::arrow::internal::unpack(buffer + byte_offset, reinterpret_cast<unpack_t*>(v + i),
+                            batch_size - i, num_bits);
 
   this->Advance(batch_size * num_bits);
 

--- a/cpp/src/arrow/util/bit_stream_utils_internal.h
+++ b/cpp/src/arrow/util/bit_stream_utils_internal.h
@@ -339,20 +339,9 @@ inline int BitReader::GetBatch(int num_bits, T* v, int batch_size) {
 
   int num_unpacked = ::arrow::internal::unpack(
       buffer + byte_offset, reinterpret_cast<unpack_t*>(v + i), batch_size - i, num_bits);
-  i += num_unpacked;
-  byte_offset += num_unpacked * num_bits / 8;
+  ARROW_DCHECK_EQ(batch_size - i, num_unpacked);
 
-  buffered_values =
-      detail::ReadLittleEndianWord(buffer + byte_offset, max_bytes - byte_offset);
-
-  for (; i < batch_size; ++i) {
-    detail::GetValue_(num_bits, &v[i], max_bytes, buffer, &bit_offset, &byte_offset,
-                      &buffered_values);
-  }
-
-  bit_offset_ = bit_offset;
-  byte_offset_ = byte_offset;
-  buffered_values_ = buffered_values;
+  this->Advance(batch_size * num_bits);
 
   return batch_size;
 }

--- a/cpp/src/arrow/util/bit_stream_utils_internal.h
+++ b/cpp/src/arrow/util/bit_stream_utils_internal.h
@@ -19,7 +19,6 @@
 
 #pragma once
 
-#include <algorithm>
 #include <cstdint>
 #include <cstring>
 #include <type_traits>
@@ -249,98 +248,36 @@ inline bool BitWriter::PutAligned(T val, int num_bytes) {
   return true;
 }
 
-namespace detail {
-
-template <typename T>
-inline void GetValue_(int num_bits, T* v, int max_bytes, const uint8_t* buffer,
-                      int* bit_offset, int* byte_offset, uint64_t* buffered_values) {
-#ifdef _MSC_VER
-#  pragma warning(push)
-#  pragma warning(disable : 4800)
-#endif
-  *v = static_cast<T>(bit_util::TrailingBits(*buffered_values, *bit_offset + num_bits) >>
-                      *bit_offset);
-#ifdef _MSC_VER
-#  pragma warning(pop)
-#endif
-  *bit_offset += num_bits;
-  if (*bit_offset >= 64) {
-    *byte_offset += 8;
-    *bit_offset -= 64;
-
-    *buffered_values =
-        detail::ReadLittleEndianWord(buffer + *byte_offset, max_bytes - *byte_offset);
-#ifdef _MSC_VER
-#  pragma warning(push)
-#  pragma warning(disable : 4800 4805)
-#endif
-    // Read bits of v that crossed into new buffered_values_
-    if (ARROW_PREDICT_TRUE(num_bits - *bit_offset < static_cast<int>(8 * sizeof(T)))) {
-      // if shift exponent(num_bits - *bit_offset) is not less than sizeof(T), *v will not
-      // change and the following code may cause a runtime error that the shift exponent
-      // is too large
-      *v = *v | static_cast<T>(bit_util::TrailingBits(*buffered_values, *bit_offset)
-                               << (num_bits - *bit_offset));
-    }
-#ifdef _MSC_VER
-#  pragma warning(pop)
-#endif
-    ARROW_DCHECK_LE(*bit_offset, 64);
-  }
-}
-
-}  // namespace detail
-
 template <typename T>
 inline bool BitReader::GetValue(int num_bits, T* v) {
   return GetBatch(num_bits, v, 1) == 1;
 }
 
-namespace internal_bit_reader {
-template <typename T>
-struct unpack_detect {
-  using type = std::make_unsigned_t<T>;
-};
-
-template <>
-struct unpack_detect<bool> {
-  using type = bool;
-};
-}  // namespace internal_bit_reader
-
 template <typename T>
 inline int BitReader::GetBatch(int num_bits, T* v, int batch_size) {
-  ARROW_DCHECK(buffer_ != NULL);
+  constexpr uint64_t kBitsPerByte = 8;
+
+  ARROW_DCHECK(buffer_ != NULLPTR);
   ARROW_DCHECK_LE(num_bits, static_cast<int>(sizeof(T) * 8)) << "num_bits: " << num_bits;
 
-  int bit_offset = bit_offset_;
-  int byte_offset = byte_offset_;
-  uint64_t buffered_values = buffered_values_;
-  int max_bytes = max_bytes_;
-  const uint8_t* buffer = buffer_;
-
   const int64_t needed_bits = num_bits * static_cast<int64_t>(batch_size);
-  constexpr uint64_t kBitsPerByte = 8;
   const int64_t remaining_bits =
-      static_cast<int64_t>(max_bytes - byte_offset) * kBitsPerByte - bit_offset;
+      static_cast<int64_t>(max_bytes_ - byte_offset_) * kBitsPerByte - bit_offset_;
   if (remaining_bits < needed_bits) {
     batch_size = static_cast<int>(remaining_bits / num_bits);
   }
 
-  int i = 0;
-  if (ARROW_PREDICT_FALSE(bit_offset != 0)) {
-    for (; i < batch_size && bit_offset != 0; ++i) {
-      detail::GetValue_(num_bits, &v[i], max_bytes, buffer, &bit_offset, &byte_offset,
-                        &buffered_values);
-    }
+  if constexpr (std::is_same_v<T, bool>) {
+    ::arrow::internal::unpack(buffer_ + byte_offset_, reinterpret_cast<bool*>(v),
+                              batch_size, num_bits, bit_offset_);
+
+  } else {
+    ::arrow::internal::unpack(buffer_ + byte_offset_,
+                              reinterpret_cast<std::make_unsigned_t<T>*>(v), batch_size,
+                              num_bits, bit_offset_);
   }
 
-  using unpack_t = typename internal_bit_reader::unpack_detect<T>::type;
-
-  ::arrow::internal::unpack(buffer + byte_offset, reinterpret_cast<unpack_t*>(v + i),
-                            batch_size - i, num_bits);
-
-  this->Advance(batch_size * num_bits);
+  Advance(batch_size * num_bits);
 
   return batch_size;
 }

--- a/cpp/src/arrow/util/bit_stream_utils_internal.h
+++ b/cpp/src/arrow/util/bit_stream_utils_internal.h
@@ -268,8 +268,8 @@ inline int BitReader::GetBatch(int num_bits, T* v, int batch_size) {
   }
 
   if constexpr (std::is_same_v<T, bool>) {
-    ::arrow::internal::unpack(buffer_ + byte_offset_, reinterpret_cast<bool*>(v),
-                              batch_size, num_bits, bit_offset_);
+    ::arrow::internal::unpack(buffer_ + byte_offset_, v, batch_size, num_bits,
+                              bit_offset_);
 
   } else {
     ::arrow::internal::unpack(buffer_ + byte_offset_,

--- a/cpp/src/arrow/util/bit_util.h
+++ b/cpp/src/arrow/util/bit_util.h
@@ -113,17 +113,14 @@ constexpr bool IsMultipleOf64(int64_t n) { return (n & 63) == 0; }
 constexpr bool IsMultipleOf8(int64_t n) { return (n & 7) == 0; }
 
 // Returns a mask for the bit_index lower order bits.
-// Only valid for bit_index in the range [0, 64).
-constexpr uint64_t LeastSignificantBitMask(int64_t bit_index) {
-  return (static_cast<uint64_t>(1) << bit_index) - 1;
-}
-
-// Returns a mask for the bit_index lower order bits.
-// Only valid for bit_index in the range [0, sizeof(Uint)].
-template <typename Uint>
-constexpr auto LeastSignificantBitMaskInc(Uint bit_index) {
-  if (bit_index == 8 * sizeof(Uint)) {
-    return ~Uint{0};
+// Valid in the range `[0, 8*sizof(Uint)]` if `kAllowUpperBound`
+// otherwise `[0, 8*sizof(Uint)[`
+template <typename Uint, bool kAllowUpperBound = false>
+constexpr auto LeastSignificantBitMask(Uint bit_index) {
+  if constexpr (kAllowUpperBound) {
+    if (bit_index == 8 * sizeof(Uint)) {
+      return ~Uint{0};
+    }
   }
   return (Uint{1} << bit_index) - Uint{1};
 }

--- a/cpp/src/arrow/util/bit_util.h
+++ b/cpp/src/arrow/util/bit_util.h
@@ -118,6 +118,16 @@ constexpr uint64_t LeastSignificantBitMask(int64_t bit_index) {
   return (static_cast<uint64_t>(1) << bit_index) - 1;
 }
 
+// Returns a mask for the bit_index lower order bits.
+// Only valid for bit_index in the range [0, sizeof(Uint)].
+template <typename Uint>
+constexpr auto LeastSignificantBitMaskInc(Uint bit_index) {
+  if (bit_index == 8 * sizeof(Uint)) {
+    return ~Uint{0};
+  }
+  return (Uint{1} << bit_index) - Uint{1};
+}
+
 // Returns 'value' rounded up to the nearest multiple of 'factor'
 constexpr int64_t RoundUp(int64_t value, int64_t factor) {
   return CeilDiv(value, factor) * factor;

--- a/cpp/src/arrow/util/bitmap_reader.h
+++ b/cpp/src/arrow/util/bitmap_reader.h
@@ -136,7 +136,7 @@ class BitmapUInt64Reader {
     memcpy(&word, bitmap_, num_bytes);
     bitmap_ += num_bytes;
     return (bit_util::ToLittleEndian(word) >> bit_offset) &
-           bit_util::LeastSignificantBitMask(num_bits);
+           bit_util::LeastSignificantBitMask<uint64_t>(num_bits);
   }
 
   const uint8_t* bitmap_;

--- a/cpp/src/arrow/util/bpacking.cc
+++ b/cpp/src/arrow/util/bpacking.cc
@@ -50,19 +50,19 @@ struct UnpackDynamicFunction {
 }  // namespace
 
 template <typename Uint>
-void unpack(const uint8_t* in, Uint* out, int batch_size, int num_bits) {
+void unpack(const uint8_t* in, Uint* out, int batch_size, int num_bits, int bit_offset) {
 #if defined(ARROW_HAVE_NEON)
-  return unpack_neon(in, out, batch_size, num_bits);
+  return unpack_neon(in, out, batch_size, num_bits, bit_offset);
 #else
   static DynamicDispatch<UnpackDynamicFunction<Uint> > dispatch;
-  return dispatch.func(in, out, batch_size, num_bits);
+  return dispatch.func(in, out, batch_size, num_bits, bit_offset);
 #endif
 }
 
-template void unpack<bool>(const uint8_t*, bool*, int, int);
-template void unpack<uint8_t>(const uint8_t*, uint8_t*, int, int);
-template void unpack<uint16_t>(const uint8_t*, uint16_t*, int, int);
-template void unpack<uint32_t>(const uint8_t*, uint32_t*, int, int);
-template void unpack<uint64_t>(const uint8_t*, uint64_t*, int, int);
+template void unpack<bool>(const uint8_t*, bool*, int, int, int);
+template void unpack<uint8_t>(const uint8_t*, uint8_t*, int, int, int);
+template void unpack<uint16_t>(const uint8_t*, uint16_t*, int, int, int);
+template void unpack<uint32_t>(const uint8_t*, uint32_t*, int, int, int);
+template void unpack<uint64_t>(const uint8_t*, uint64_t*, int, int, int);
 
 }  // namespace arrow::internal

--- a/cpp/src/arrow/util/bpacking.cc
+++ b/cpp/src/arrow/util/bpacking.cc
@@ -50,7 +50,7 @@ struct UnpackDynamicFunction {
 }  // namespace
 
 template <typename Uint>
-int unpack(const uint8_t* in, Uint* out, int batch_size, int num_bits) {
+void unpack(const uint8_t* in, Uint* out, int batch_size, int num_bits) {
 #if defined(ARROW_HAVE_NEON)
   return unpack_neon(in, out, batch_size, num_bits);
 #else
@@ -59,10 +59,10 @@ int unpack(const uint8_t* in, Uint* out, int batch_size, int num_bits) {
 #endif
 }
 
-template int unpack<bool>(const uint8_t*, bool*, int, int);
-template int unpack<uint8_t>(const uint8_t*, uint8_t*, int, int);
-template int unpack<uint16_t>(const uint8_t*, uint16_t*, int, int);
-template int unpack<uint32_t>(const uint8_t*, uint32_t*, int, int);
-template int unpack<uint64_t>(const uint8_t*, uint64_t*, int, int);
+template void unpack<bool>(const uint8_t*, bool*, int, int);
+template void unpack<uint8_t>(const uint8_t*, uint8_t*, int, int);
+template void unpack<uint16_t>(const uint8_t*, uint16_t*, int, int);
+template void unpack<uint32_t>(const uint8_t*, uint32_t*, int, int);
+template void unpack<uint64_t>(const uint8_t*, uint64_t*, int, int);
 
 }  // namespace arrow::internal

--- a/cpp/src/arrow/util/bpacking_benchmark.cc
+++ b/cpp/src/arrow/util/bpacking_benchmark.cc
@@ -33,7 +33,7 @@ namespace arrow::internal {
 namespace {
 
 template <typename Int>
-using UnpackFunc = int (*)(const uint8_t*, Int*, int, int);
+using UnpackFunc = void (*)(const uint8_t*, Int*, int, int);
 
 /// Get the number of bytes associate with a packing.
 constexpr int32_t GetNumBytes(int32_t num_values, int32_t bit_width) {

--- a/cpp/src/arrow/util/bpacking_benchmark.cc
+++ b/cpp/src/arrow/util/bpacking_benchmark.cc
@@ -33,7 +33,7 @@ namespace arrow::internal {
 namespace {
 
 template <typename Int>
-using UnpackFunc = void (*)(const uint8_t*, Int*, int, int);
+using UnpackFunc = void (*)(const uint8_t*, Int*, int, int, int);
 
 /// Get the number of bytes associate with a packing.
 constexpr int32_t GetNumBytes(int32_t num_values, int32_t bit_width) {
@@ -89,7 +89,7 @@ void BM_Unpack(benchmark::State& state, bool aligned, UnpackFunc<Int> unpack, bo
   std::vector<Int> unpacked(num_values, 0);
 
   for (auto _ : state) {
-    unpack(packed_ptr, unpacked.data(), num_values, bit_width);
+    unpack(packed_ptr, unpacked.data(), num_values, bit_width, /* bit_offset = */ 0);
     benchmark::ClobberMemory();
   }
   state.SetItemsProcessed(num_values * state.iterations());

--- a/cpp/src/arrow/util/bpacking_dispatch_internal.h
+++ b/cpp/src/arrow/util/bpacking_dispatch_internal.h
@@ -99,6 +99,7 @@ template <int kPackedBitWidth, bool kIsProlog, typename Uint>
 int unpack_exact(const uint8_t* in, Uint* out, int batch_size, int bit_offset) {
   // For the epilog we adapt the max spread since better alignment give shorter spreads
   ARROW_DCHECK(kIsProlog || bit_offset == 0);
+  ARROW_DCHECK(bit_offset >= 0 && bit_offset < 8);
   constexpr int kMaxSpreadBytes = kIsProlog ? PackedMaxSpreadBytes(kPackedBitWidth)
                                             : PackedMaxSpreadBytes(kPackedBitWidth, 0);
   using buffer_uint = SpreadBufferUint<kMaxSpreadBytes>;

--- a/cpp/src/arrow/util/bpacking_dispatch_internal.h
+++ b/cpp/src/arrow/util/bpacking_dispatch_internal.h
@@ -74,8 +74,11 @@ constexpr int PackedMaxSpreadBytes(int width) {
 
 // Integer type that tries to contain as much as the spread as possible.
 template <int kSpreadBytes>
-using SpreadBufferUint =
-    std::conditional_t<(kSpreadBytes <= sizeof(uint32_t)), uint_fast32_t, uint_fast64_t>;
+using SpreadBufferUint = std::conditional_t<
+    (kSpreadBytes <= sizeof(uint8_t)), uint_fast8_t,
+    std::conditional_t<(kSpreadBytes <= sizeof(uint16_t)), uint_fast16_t,
+                       std::conditional_t<(kSpreadBytes <= sizeof(uint32_t)),
+                                          uint_fast32_t, uint_fast64_t>>>;
 
 /// Unpack integers.
 /// This function works for all input batch sizes but is not the fastest.

--- a/cpp/src/arrow/util/bpacking_dispatch_internal.h
+++ b/cpp/src/arrow/util/bpacking_dispatch_internal.h
@@ -81,7 +81,7 @@ using SpreadBufferUint = std::conditional_t<
 /// Unpack integers.
 /// This function works for all input batch sizes but is not the fastest.
 template <int kPackedBitWidth, bool kBreakWhenAligned, typename Uint>
-int unpack_exact(const uint8_t* in, Uint* out, int batch_size, int bit_offset = 0) {
+int unpack_exact(const uint8_t* in, Uint* out, int batch_size, int bit_offset) {
   constexpr int kMaxSpreadBytes = PackedMaxSpreadBytes(kPackedBitWidth);
   using buffer_uint = SpreadBufferUint<kMaxSpreadBytes>;
   constexpr int kBufferSize = sizeof(buffer_uint);
@@ -166,7 +166,7 @@ void unpack_width(const uint8_t* in, UnpackedUInt* out, int batch_size) {
 
 template <template <typename, int> typename Unpacker, typename UnpackedUint>
 static void unpack_jump(const uint8_t* in, UnpackedUint* out, int batch_size,
-                        int num_bits) {
+                        int num_bits, int bit_offset) {
   if constexpr (std::is_same_v<UnpackedUint, bool>) {
     switch (num_bits) {
       case 0:

--- a/cpp/src/arrow/util/bpacking_dispatch_internal.h
+++ b/cpp/src/arrow/util/bpacking_dispatch_internal.h
@@ -109,7 +109,7 @@ int unpack_exact(const uint8_t* in, Uint* out, int batch_size, int bit_offset) {
   // aligned bytes.
   constexpr bool kOversized = kBufferSize < kMaxSpreadBytes;
   constexpr buffer_uint kLowMask =
-      bit_util::LeastSignificantBitMaskInc<buffer_uint>(kPackedBitWidth);
+      bit_util::LeastSignificantBitMask<buffer_uint, true>(kPackedBitWidth);
 
   ARROW_DCHECK_GE(bit_offset, 0);
   ARROW_DCHECK_LE(bit_offset, 8);

--- a/cpp/src/arrow/util/bpacking_internal.h
+++ b/cpp/src/arrow/util/bpacking_internal.h
@@ -24,25 +24,27 @@
 namespace arrow::internal {
 
 template <typename Uint>
-ARROW_EXPORT void unpack(const uint8_t* in, Uint* out, int batch_size, int num_bits);
+ARROW_EXPORT void unpack(const uint8_t* in, Uint* out, int batch_size, int num_bits,
+                         int bit_offset = 0);
 
 extern template ARROW_TEMPLATE_EXPORT void unpack<bool>(const uint8_t* in, bool* out,
-                                                        int batch_size, int num_bits);
+                                                        int batch_size, int num_bits,
+                                                        int bit_offset);
 
 extern template ARROW_TEMPLATE_EXPORT void unpack<uint8_t>(const uint8_t* in,
                                                            uint8_t* out, int batch_size,
-                                                           int num_bits);
+                                                           int num_bits, int bit_offset);
 
 extern template ARROW_TEMPLATE_EXPORT void unpack<uint16_t>(const uint8_t* in,
                                                             uint16_t* out, int batch_size,
-                                                            int num_bits);
+                                                            int num_bits, int bit_offset);
 
 extern template ARROW_TEMPLATE_EXPORT void unpack<uint32_t>(const uint8_t* in,
                                                             uint32_t* out, int batch_size,
-                                                            int num_bits);
+                                                            int num_bits, int bit_offset);
 
 extern template ARROW_TEMPLATE_EXPORT void unpack<uint64_t>(const uint8_t* in,
                                                             uint64_t* out, int batch_size,
-                                                            int num_bits);
+                                                            int num_bits, int bit_offset);
 
 }  // namespace arrow::internal

--- a/cpp/src/arrow/util/bpacking_internal.h
+++ b/cpp/src/arrow/util/bpacking_internal.h
@@ -24,24 +24,25 @@
 namespace arrow::internal {
 
 template <typename Uint>
-ARROW_EXPORT int unpack(const uint8_t* in, Uint* out, int batch_size, int num_bits);
+ARROW_EXPORT void unpack(const uint8_t* in, Uint* out, int batch_size, int num_bits);
 
-extern template ARROW_TEMPLATE_EXPORT int unpack<bool>(const uint8_t* in, bool* out,
-                                                       int batch_size, int num_bits);
+extern template ARROW_TEMPLATE_EXPORT void unpack<bool>(const uint8_t* in, bool* out,
+                                                        int batch_size, int num_bits);
 
-extern template ARROW_TEMPLATE_EXPORT int unpack<uint8_t>(const uint8_t* in, uint8_t* out,
-                                                          int batch_size, int num_bits);
-
-extern template ARROW_TEMPLATE_EXPORT int unpack<uint16_t>(const uint8_t* in,
-                                                           uint16_t* out, int batch_size,
+extern template ARROW_TEMPLATE_EXPORT void unpack<uint8_t>(const uint8_t* in,
+                                                           uint8_t* out, int batch_size,
                                                            int num_bits);
 
-extern template ARROW_TEMPLATE_EXPORT int unpack<uint32_t>(const uint8_t* in,
-                                                           uint32_t* out, int batch_size,
-                                                           int num_bits);
+extern template ARROW_TEMPLATE_EXPORT void unpack<uint16_t>(const uint8_t* in,
+                                                            uint16_t* out, int batch_size,
+                                                            int num_bits);
 
-extern template ARROW_TEMPLATE_EXPORT int unpack<uint64_t>(const uint8_t* in,
-                                                           uint64_t* out, int batch_size,
-                                                           int num_bits);
+extern template ARROW_TEMPLATE_EXPORT void unpack<uint32_t>(const uint8_t* in,
+                                                            uint32_t* out, int batch_size,
+                                                            int num_bits);
+
+extern template ARROW_TEMPLATE_EXPORT void unpack<uint64_t>(const uint8_t* in,
+                                                            uint64_t* out, int batch_size,
+                                                            int num_bits);
 
 }  // namespace arrow::internal

--- a/cpp/src/arrow/util/bpacking_scalar.cc
+++ b/cpp/src/arrow/util/bpacking_scalar.cc
@@ -22,14 +22,14 @@
 namespace arrow::internal {
 
 template <typename Uint>
-int unpack_scalar(const uint8_t* in, Uint* out, int batch_size, int num_bits) {
+void unpack_scalar(const uint8_t* in, Uint* out, int batch_size, int num_bits) {
   return unpack_jump<ScalarUnpackerForWidth>(in, out, batch_size, num_bits);
 }
 
-template int unpack_scalar<bool>(const uint8_t*, bool*, int, int);
-template int unpack_scalar<uint8_t>(const uint8_t*, uint8_t*, int, int);
-template int unpack_scalar<uint16_t>(const uint8_t*, uint16_t*, int, int);
-template int unpack_scalar<uint32_t>(const uint8_t*, uint32_t*, int, int);
-template int unpack_scalar<uint64_t>(const uint8_t*, uint64_t*, int, int);
+template void unpack_scalar<bool>(const uint8_t*, bool*, int, int);
+template void unpack_scalar<uint8_t>(const uint8_t*, uint8_t*, int, int);
+template void unpack_scalar<uint16_t>(const uint8_t*, uint16_t*, int, int);
+template void unpack_scalar<uint32_t>(const uint8_t*, uint32_t*, int, int);
+template void unpack_scalar<uint64_t>(const uint8_t*, uint64_t*, int, int);
 
 }  // namespace arrow::internal

--- a/cpp/src/arrow/util/bpacking_scalar.cc
+++ b/cpp/src/arrow/util/bpacking_scalar.cc
@@ -22,14 +22,15 @@
 namespace arrow::internal {
 
 template <typename Uint>
-void unpack_scalar(const uint8_t* in, Uint* out, int batch_size, int num_bits) {
-  return unpack_jump<ScalarUnpackerForWidth>(in, out, batch_size, num_bits);
+void unpack_scalar(const uint8_t* in, Uint* out, int batch_size, int num_bits,
+                   int bit_offset) {
+  return unpack_jump<ScalarUnpackerForWidth>(in, out, batch_size, num_bits, bit_offset);
 }
 
-template void unpack_scalar<bool>(const uint8_t*, bool*, int, int);
-template void unpack_scalar<uint8_t>(const uint8_t*, uint8_t*, int, int);
-template void unpack_scalar<uint16_t>(const uint8_t*, uint16_t*, int, int);
-template void unpack_scalar<uint32_t>(const uint8_t*, uint32_t*, int, int);
-template void unpack_scalar<uint64_t>(const uint8_t*, uint64_t*, int, int);
+template void unpack_scalar<bool>(const uint8_t*, bool*, int, int, int);
+template void unpack_scalar<uint8_t>(const uint8_t*, uint8_t*, int, int, int);
+template void unpack_scalar<uint16_t>(const uint8_t*, uint16_t*, int, int, int);
+template void unpack_scalar<uint32_t>(const uint8_t*, uint32_t*, int, int, int);
+template void unpack_scalar<uint64_t>(const uint8_t*, uint64_t*, int, int, int);
 
 }  // namespace arrow::internal

--- a/cpp/src/arrow/util/bpacking_scalar_internal.h
+++ b/cpp/src/arrow/util/bpacking_scalar_internal.h
@@ -25,30 +25,23 @@ namespace arrow::internal {
 
 template <typename Uint>
 ARROW_EXPORT void unpack_scalar(const uint8_t* in, Uint* out, int batch_size,
-                                int num_bits);
+                                int num_bits, int bit_offset);
 
 extern template ARROW_TEMPLATE_EXPORT void unpack_scalar<bool>(const uint8_t* in,
                                                                bool* out, int batch_size,
-                                                               int num_bits);
+                                                               int num_bits,
+                                                               int bit_offset);
 
-extern template ARROW_TEMPLATE_EXPORT void unpack_scalar<uint8_t>(const uint8_t* in,
-                                                                  uint8_t* out,
-                                                                  int batch_size,
-                                                                  int num_bits);
+extern template ARROW_TEMPLATE_EXPORT void unpack_scalar<uint8_t>(
+    const uint8_t* in, uint8_t* out, int batch_size, int num_bits, int bit_offset);
 
-extern template ARROW_TEMPLATE_EXPORT void unpack_scalar<uint16_t>(const uint8_t* in,
-                                                                   uint16_t* out,
-                                                                   int batch_size,
-                                                                   int num_bits);
+extern template ARROW_TEMPLATE_EXPORT void unpack_scalar<uint16_t>(
+    const uint8_t* in, uint16_t* out, int batch_size, int num_bits, int bit_offset);
 
-extern template ARROW_TEMPLATE_EXPORT void unpack_scalar<uint32_t>(const uint8_t* in,
-                                                                   uint32_t* out,
-                                                                   int batch_size,
-                                                                   int num_bits);
+extern template ARROW_TEMPLATE_EXPORT void unpack_scalar<uint32_t>(
+    const uint8_t* in, uint32_t* out, int batch_size, int num_bits, int bit_offset);
 
-extern template ARROW_TEMPLATE_EXPORT void unpack_scalar<uint64_t>(const uint8_t* in,
-                                                                   uint64_t* out,
-                                                                   int batch_size,
-                                                                   int num_bits);
+extern template ARROW_TEMPLATE_EXPORT void unpack_scalar<uint64_t>(
+    const uint8_t* in, uint64_t* out, int batch_size, int num_bits, int bit_offset);
 
 }  // namespace arrow::internal

--- a/cpp/src/arrow/util/bpacking_scalar_internal.h
+++ b/cpp/src/arrow/util/bpacking_scalar_internal.h
@@ -24,31 +24,31 @@
 namespace arrow::internal {
 
 template <typename Uint>
-ARROW_EXPORT int unpack_scalar(const uint8_t* in, Uint* out, int batch_size,
-                               int num_bits);
+ARROW_EXPORT void unpack_scalar(const uint8_t* in, Uint* out, int batch_size,
+                                int num_bits);
 
-extern template ARROW_TEMPLATE_EXPORT int unpack_scalar<bool>(const uint8_t* in,
-                                                              bool* out, int batch_size,
-                                                              int num_bits);
+extern template ARROW_TEMPLATE_EXPORT void unpack_scalar<bool>(const uint8_t* in,
+                                                               bool* out, int batch_size,
+                                                               int num_bits);
 
-extern template ARROW_TEMPLATE_EXPORT int unpack_scalar<uint8_t>(const uint8_t* in,
-                                                                 uint8_t* out,
-                                                                 int batch_size,
-                                                                 int num_bits);
-
-extern template ARROW_TEMPLATE_EXPORT int unpack_scalar<uint16_t>(const uint8_t* in,
-                                                                  uint16_t* out,
+extern template ARROW_TEMPLATE_EXPORT void unpack_scalar<uint8_t>(const uint8_t* in,
+                                                                  uint8_t* out,
                                                                   int batch_size,
                                                                   int num_bits);
 
-extern template ARROW_TEMPLATE_EXPORT int unpack_scalar<uint32_t>(const uint8_t* in,
-                                                                  uint32_t* out,
-                                                                  int batch_size,
-                                                                  int num_bits);
+extern template ARROW_TEMPLATE_EXPORT void unpack_scalar<uint16_t>(const uint8_t* in,
+                                                                   uint16_t* out,
+                                                                   int batch_size,
+                                                                   int num_bits);
 
-extern template ARROW_TEMPLATE_EXPORT int unpack_scalar<uint64_t>(const uint8_t* in,
-                                                                  uint64_t* out,
-                                                                  int batch_size,
-                                                                  int num_bits);
+extern template ARROW_TEMPLATE_EXPORT void unpack_scalar<uint32_t>(const uint8_t* in,
+                                                                   uint32_t* out,
+                                                                   int batch_size,
+                                                                   int num_bits);
+
+extern template ARROW_TEMPLATE_EXPORT void unpack_scalar<uint64_t>(const uint8_t* in,
+                                                                   uint64_t* out,
+                                                                   int batch_size,
+                                                                   int num_bits);
 
 }  // namespace arrow::internal

--- a/cpp/src/arrow/util/bpacking_simd_avx2.cc
+++ b/cpp/src/arrow/util/bpacking_simd_avx2.cc
@@ -22,14 +22,14 @@
 namespace arrow::internal {
 
 template <typename Uint>
-int unpack_avx2(const uint8_t* in, Uint* out, int batch_size, int num_bits) {
+void unpack_avx2(const uint8_t* in, Uint* out, int batch_size, int num_bits) {
   return unpack_jump<Simd256UnpackerForWidth>(in, out, batch_size, num_bits);
 }
 
-template int unpack_avx2<bool>(const uint8_t*, bool*, int, int);
-template int unpack_avx2<uint8_t>(const uint8_t*, uint8_t*, int, int);
-template int unpack_avx2<uint16_t>(const uint8_t*, uint16_t*, int, int);
-template int unpack_avx2<uint32_t>(const uint8_t*, uint32_t*, int, int);
-template int unpack_avx2<uint64_t>(const uint8_t*, uint64_t*, int, int);
+template void unpack_avx2<bool>(const uint8_t*, bool*, int, int);
+template void unpack_avx2<uint8_t>(const uint8_t*, uint8_t*, int, int);
+template void unpack_avx2<uint16_t>(const uint8_t*, uint16_t*, int, int);
+template void unpack_avx2<uint32_t>(const uint8_t*, uint32_t*, int, int);
+template void unpack_avx2<uint64_t>(const uint8_t*, uint64_t*, int, int);
 
 }  // namespace arrow::internal

--- a/cpp/src/arrow/util/bpacking_simd_avx2.cc
+++ b/cpp/src/arrow/util/bpacking_simd_avx2.cc
@@ -22,14 +22,15 @@
 namespace arrow::internal {
 
 template <typename Uint>
-void unpack_avx2(const uint8_t* in, Uint* out, int batch_size, int num_bits) {
-  return unpack_jump<Simd256UnpackerForWidth>(in, out, batch_size, num_bits);
+void unpack_avx2(const uint8_t* in, Uint* out, int batch_size, int num_bits,
+                 int bit_offset) {
+  return unpack_jump<Simd256UnpackerForWidth>(in, out, batch_size, num_bits, bit_offset);
 }
 
-template void unpack_avx2<bool>(const uint8_t*, bool*, int, int);
-template void unpack_avx2<uint8_t>(const uint8_t*, uint8_t*, int, int);
-template void unpack_avx2<uint16_t>(const uint8_t*, uint16_t*, int, int);
-template void unpack_avx2<uint32_t>(const uint8_t*, uint32_t*, int, int);
-template void unpack_avx2<uint64_t>(const uint8_t*, uint64_t*, int, int);
+template void unpack_avx2<bool>(const uint8_t*, bool*, int, int, int);
+template void unpack_avx2<uint8_t>(const uint8_t*, uint8_t*, int, int, int);
+template void unpack_avx2<uint16_t>(const uint8_t*, uint16_t*, int, int, int);
+template void unpack_avx2<uint32_t>(const uint8_t*, uint32_t*, int, int, int);
+template void unpack_avx2<uint64_t>(const uint8_t*, uint64_t*, int, int, int);
 
 }  // namespace arrow::internal

--- a/cpp/src/arrow/util/bpacking_simd_avx512.cc
+++ b/cpp/src/arrow/util/bpacking_simd_avx512.cc
@@ -22,14 +22,14 @@
 namespace arrow::internal {
 
 template <typename Uint>
-int unpack_avx512(const uint8_t* in, Uint* out, int batch_size, int num_bits) {
+void unpack_avx512(const uint8_t* in, Uint* out, int batch_size, int num_bits) {
   return unpack_jump<Simd512UnpackerForWidth>(in, out, batch_size, num_bits);
 }
 
-template int unpack_avx512<bool>(const uint8_t*, bool*, int, int);
-template int unpack_avx512<uint8_t>(const uint8_t*, uint8_t*, int, int);
-template int unpack_avx512<uint16_t>(const uint8_t*, uint16_t*, int, int);
-template int unpack_avx512<uint32_t>(const uint8_t*, uint32_t*, int, int);
-template int unpack_avx512<uint64_t>(const uint8_t*, uint64_t*, int, int);
+template void unpack_avx512<bool>(const uint8_t*, bool*, int, int);
+template void unpack_avx512<uint8_t>(const uint8_t*, uint8_t*, int, int);
+template void unpack_avx512<uint16_t>(const uint8_t*, uint16_t*, int, int);
+template void unpack_avx512<uint32_t>(const uint8_t*, uint32_t*, int, int);
+template void unpack_avx512<uint64_t>(const uint8_t*, uint64_t*, int, int);
 
 }  // namespace arrow::internal

--- a/cpp/src/arrow/util/bpacking_simd_avx512.cc
+++ b/cpp/src/arrow/util/bpacking_simd_avx512.cc
@@ -22,14 +22,15 @@
 namespace arrow::internal {
 
 template <typename Uint>
-void unpack_avx512(const uint8_t* in, Uint* out, int batch_size, int num_bits) {
-  return unpack_jump<Simd512UnpackerForWidth>(in, out, batch_size, num_bits);
+void unpack_avx512(const uint8_t* in, Uint* out, int batch_size, int num_bits,
+                   int bit_offset) {
+  return unpack_jump<Simd512UnpackerForWidth>(in, out, batch_size, num_bits, bit_offset);
 }
 
-template void unpack_avx512<bool>(const uint8_t*, bool*, int, int);
-template void unpack_avx512<uint8_t>(const uint8_t*, uint8_t*, int, int);
-template void unpack_avx512<uint16_t>(const uint8_t*, uint16_t*, int, int);
-template void unpack_avx512<uint32_t>(const uint8_t*, uint32_t*, int, int);
-template void unpack_avx512<uint64_t>(const uint8_t*, uint64_t*, int, int);
+template void unpack_avx512<bool>(const uint8_t*, bool*, int, int, int);
+template void unpack_avx512<uint8_t>(const uint8_t*, uint8_t*, int, int, int);
+template void unpack_avx512<uint16_t>(const uint8_t*, uint16_t*, int, int, int);
+template void unpack_avx512<uint32_t>(const uint8_t*, uint32_t*, int, int, int);
+template void unpack_avx512<uint64_t>(const uint8_t*, uint64_t*, int, int, int);
 
 }  // namespace arrow::internal

--- a/cpp/src/arrow/util/bpacking_simd_default.cc
+++ b/cpp/src/arrow/util/bpacking_simd_default.cc
@@ -26,15 +26,16 @@ namespace arrow::internal {
 #if defined(ARROW_HAVE_NEON)
 
 template <typename Uint>
-void unpack_neon(const uint8_t* in, Uint* out, int batch_size, int num_bits) {
-  return unpack_jump<Simd128UnpackerForWidth>(in, out, batch_size, num_bits);
+void unpack_neon(const uint8_t* in, Uint* out, int batch_size, int num_bits,
+                 int bit_offset) {
+  return unpack_jump<Simd128UnpackerForWidth>(in, out, batch_size, num_bits, bit_offset);
 }
 
-template void unpack_neon<bool>(const uint8_t*, bool*, int, int);
-template void unpack_neon<uint8_t>(const uint8_t*, uint8_t*, int, int);
-template void unpack_neon<uint16_t>(const uint8_t*, uint16_t*, int, int);
-template void unpack_neon<uint32_t>(const uint8_t*, uint32_t*, int, int);
-template void unpack_neon<uint64_t>(const uint8_t*, uint64_t*, int, int);
+template void unpack_neon<bool>(const uint8_t*, bool*, int, int, int);
+template void unpack_neon<uint8_t>(const uint8_t*, uint8_t*, int, int, int);
+template void unpack_neon<uint16_t>(const uint8_t*, uint16_t*, int, int, int);
+template void unpack_neon<uint32_t>(const uint8_t*, uint32_t*, int, int, int);
+template void unpack_neon<uint64_t>(const uint8_t*, uint64_t*, int, int, int);
 
 #endif
 

--- a/cpp/src/arrow/util/bpacking_simd_default.cc
+++ b/cpp/src/arrow/util/bpacking_simd_default.cc
@@ -26,15 +26,15 @@ namespace arrow::internal {
 #if defined(ARROW_HAVE_NEON)
 
 template <typename Uint>
-int unpack_neon(const uint8_t* in, Uint* out, int batch_size, int num_bits) {
+void unpack_neon(const uint8_t* in, Uint* out, int batch_size, int num_bits) {
   return unpack_jump<Simd128UnpackerForWidth>(in, out, batch_size, num_bits);
 }
 
-template int unpack_neon<bool>(const uint8_t*, bool*, int, int);
-template int unpack_neon<uint8_t>(const uint8_t*, uint8_t*, int, int);
-template int unpack_neon<uint16_t>(const uint8_t*, uint16_t*, int, int);
-template int unpack_neon<uint32_t>(const uint8_t*, uint32_t*, int, int);
-template int unpack_neon<uint64_t>(const uint8_t*, uint64_t*, int, int);
+template void unpack_neon<bool>(const uint8_t*, bool*, int, int);
+template void unpack_neon<uint8_t>(const uint8_t*, uint8_t*, int, int);
+template void unpack_neon<uint16_t>(const uint8_t*, uint16_t*, int, int);
+template void unpack_neon<uint32_t>(const uint8_t*, uint32_t*, int, int);
+template void unpack_neon<uint64_t>(const uint8_t*, uint64_t*, int, int);
 
 #endif
 

--- a/cpp/src/arrow/util/bpacking_simd_internal.h
+++ b/cpp/src/arrow/util/bpacking_simd_internal.h
@@ -26,62 +26,48 @@ namespace arrow::internal {
 #if defined(ARROW_HAVE_NEON)
 
 template <typename Uint>
-ARROW_EXPORT void unpack_neon(const uint8_t* in, Uint* out, int batch_size, int num_bits);
+ARROW_EXPORT void unpack_neon(const uint8_t* in, Uint* out, int batch_size, int num_bits,
+                              int bit_offset);
 
 extern template ARROW_TEMPLATE_EXPORT void unpack_neon<bool>(const uint8_t* in, bool* out,
-                                                             int batch_size,
-                                                             int num_bits);
+                                                             int batch_size, int num_bits,
+                                                             int bit_offset);
 
-extern template ARROW_TEMPLATE_EXPORT void unpack_neon<uint8_t>(const uint8_t* in,
-                                                                uint8_t* out,
-                                                                int batch_size,
-                                                                int num_bits);
+extern template ARROW_TEMPLATE_EXPORT void unpack_neon<uint8_t>(
+    const uint8_t* in, uint8_t* out, int batch_size, int num_bits, int bit_offset);
 
-extern template ARROW_TEMPLATE_EXPORT void unpack_neon<uint16_t>(const uint8_t* in,
-                                                                 uint16_t* out,
-                                                                 int batch_size,
-                                                                 int num_bits);
+extern template ARROW_TEMPLATE_EXPORT void unpack_neon<uint16_t>(
+    const uint8_t* in, uint16_t* out, int batch_size, int num_bits, int bit_offset);
 
-extern template ARROW_TEMPLATE_EXPORT void unpack_neon<uint32_t>(const uint8_t* in,
-                                                                 uint32_t* out,
-                                                                 int batch_size,
-                                                                 int num_bits);
+extern template ARROW_TEMPLATE_EXPORT void unpack_neon<uint32_t>(
+    const uint8_t* in, uint32_t* out, int batch_size, int num_bits, int bit_offset);
 
-extern template ARROW_TEMPLATE_EXPORT void unpack_neon<uint64_t>(const uint8_t* in,
-                                                                 uint64_t* out,
-                                                                 int batch_size,
-                                                                 int num_bits);
+extern template ARROW_TEMPLATE_EXPORT void unpack_neon<uint64_t>(
+    const uint8_t* in, uint64_t* out, int batch_size, int num_bits, int bit_offset);
 
 #endif
 
 #if defined(ARROW_HAVE_AVX2) || defined(ARROW_HAVE_RUNTIME_AVX2)
 
 template <typename Uint>
-ARROW_EXPORT void unpack_avx2(const uint8_t* in, Uint* out, int batch_size, int num_bits);
+ARROW_EXPORT void unpack_avx2(const uint8_t* in, Uint* out, int batch_size, int num_bits,
+                              int bit_offset);
 
 extern template ARROW_TEMPLATE_EXPORT void unpack_avx2<bool>(const uint8_t* in, bool* out,
-                                                             int batch_size,
-                                                             int num_bits);
+                                                             int batch_size, int num_bits,
+                                                             int bit_offset);
 
-extern template ARROW_TEMPLATE_EXPORT void unpack_avx2<uint8_t>(const uint8_t* in,
-                                                                uint8_t* out,
-                                                                int batch_size,
-                                                                int num_bits);
+extern template ARROW_TEMPLATE_EXPORT void unpack_avx2<uint8_t>(
+    const uint8_t* in, uint8_t* out, int batch_size, int num_bits, int bit_offset);
 
-extern template ARROW_TEMPLATE_EXPORT void unpack_avx2<uint16_t>(const uint8_t* in,
-                                                                 uint16_t* out,
-                                                                 int batch_size,
-                                                                 int num_bits);
+extern template ARROW_TEMPLATE_EXPORT void unpack_avx2<uint16_t>(
+    const uint8_t* in, uint16_t* out, int batch_size, int num_bits, int bit_offset);
 
-extern template ARROW_TEMPLATE_EXPORT void unpack_avx2<uint32_t>(const uint8_t* in,
-                                                                 uint32_t* out,
-                                                                 int batch_size,
-                                                                 int num_bits);
+extern template ARROW_TEMPLATE_EXPORT void unpack_avx2<uint32_t>(
+    const uint8_t* in, uint32_t* out, int batch_size, int num_bits, int bit_offset);
 
-extern template ARROW_TEMPLATE_EXPORT void unpack_avx2<uint64_t>(const uint8_t* in,
-                                                                 uint64_t* out,
-                                                                 int batch_size,
-                                                                 int num_bits);
+extern template ARROW_TEMPLATE_EXPORT void unpack_avx2<uint64_t>(
+    const uint8_t* in, uint64_t* out, int batch_size, int num_bits, int bit_offset);
 
 #endif
 
@@ -89,31 +75,24 @@ extern template ARROW_TEMPLATE_EXPORT void unpack_avx2<uint64_t>(const uint8_t* 
 
 template <typename Uint>
 ARROW_EXPORT void unpack_avx512(const uint8_t* in, Uint* out, int batch_size,
-                                int num_bits);
+                                int num_bits, int bit_offset);
 
 extern template ARROW_TEMPLATE_EXPORT void unpack_avx512<bool>(const uint8_t* in,
                                                                bool* out, int batch_size,
-                                                               int num_bits);
+                                                               int num_bits,
+                                                               int bit_offset);
 
-extern template ARROW_TEMPLATE_EXPORT void unpack_avx512<uint8_t>(const uint8_t* in,
-                                                                  uint8_t* out,
-                                                                  int batch_size,
-                                                                  int num_bits);
+extern template ARROW_TEMPLATE_EXPORT void unpack_avx512<uint8_t>(
+    const uint8_t* in, uint8_t* out, int batch_size, int num_bits, int bit_offset);
 
-extern template ARROW_TEMPLATE_EXPORT void unpack_avx512<uint16_t>(const uint8_t* in,
-                                                                   uint16_t* out,
-                                                                   int batch_size,
-                                                                   int num_bits);
+extern template ARROW_TEMPLATE_EXPORT void unpack_avx512<uint16_t>(
+    const uint8_t* in, uint16_t* out, int batch_size, int num_bits, int bit_offset);
 
-extern template ARROW_TEMPLATE_EXPORT void unpack_avx512<uint32_t>(const uint8_t* in,
-                                                                   uint32_t* out,
-                                                                   int batch_size,
-                                                                   int num_bits);
+extern template ARROW_TEMPLATE_EXPORT void unpack_avx512<uint32_t>(
+    const uint8_t* in, uint32_t* out, int batch_size, int num_bits, int bit_offset);
 
-extern template ARROW_TEMPLATE_EXPORT void unpack_avx512<uint64_t>(const uint8_t* in,
-                                                                   uint64_t* out,
-                                                                   int batch_size,
-                                                                   int num_bits);
+extern template ARROW_TEMPLATE_EXPORT void unpack_avx512<uint64_t>(
+    const uint8_t* in, uint64_t* out, int batch_size, int num_bits, int bit_offset);
 
 #endif
 

--- a/cpp/src/arrow/util/bpacking_simd_internal.h
+++ b/cpp/src/arrow/util/bpacking_simd_internal.h
@@ -26,92 +26,94 @@ namespace arrow::internal {
 #if defined(ARROW_HAVE_NEON)
 
 template <typename Uint>
-ARROW_EXPORT int unpack_neon(const uint8_t* in, Uint* out, int batch_size, int num_bits);
+ARROW_EXPORT void unpack_neon(const uint8_t* in, Uint* out, int batch_size, int num_bits);
 
-extern template ARROW_TEMPLATE_EXPORT int unpack_neon<bool>(const uint8_t* in, bool* out,
-                                                            int batch_size, int num_bits);
+extern template ARROW_TEMPLATE_EXPORT void unpack_neon<bool>(const uint8_t* in, bool* out,
+                                                             int batch_size,
+                                                             int num_bits);
 
-extern template ARROW_TEMPLATE_EXPORT int unpack_neon<uint8_t>(const uint8_t* in,
-                                                               uint8_t* out,
-                                                               int batch_size,
-                                                               int num_bits);
-
-extern template ARROW_TEMPLATE_EXPORT int unpack_neon<uint16_t>(const uint8_t* in,
-                                                                uint16_t* out,
+extern template ARROW_TEMPLATE_EXPORT void unpack_neon<uint8_t>(const uint8_t* in,
+                                                                uint8_t* out,
                                                                 int batch_size,
                                                                 int num_bits);
 
-extern template ARROW_TEMPLATE_EXPORT int unpack_neon<uint32_t>(const uint8_t* in,
-                                                                uint32_t* out,
-                                                                int batch_size,
-                                                                int num_bits);
+extern template ARROW_TEMPLATE_EXPORT void unpack_neon<uint16_t>(const uint8_t* in,
+                                                                 uint16_t* out,
+                                                                 int batch_size,
+                                                                 int num_bits);
 
-extern template ARROW_TEMPLATE_EXPORT int unpack_neon<uint64_t>(const uint8_t* in,
-                                                                uint64_t* out,
-                                                                int batch_size,
-                                                                int num_bits);
+extern template ARROW_TEMPLATE_EXPORT void unpack_neon<uint32_t>(const uint8_t* in,
+                                                                 uint32_t* out,
+                                                                 int batch_size,
+                                                                 int num_bits);
+
+extern template ARROW_TEMPLATE_EXPORT void unpack_neon<uint64_t>(const uint8_t* in,
+                                                                 uint64_t* out,
+                                                                 int batch_size,
+                                                                 int num_bits);
 
 #endif
 
 #if defined(ARROW_HAVE_AVX2) || defined(ARROW_HAVE_RUNTIME_AVX2)
 
 template <typename Uint>
-ARROW_EXPORT int unpack_avx2(const uint8_t* in, Uint* out, int batch_size, int num_bits);
+ARROW_EXPORT void unpack_avx2(const uint8_t* in, Uint* out, int batch_size, int num_bits);
 
-extern template ARROW_TEMPLATE_EXPORT int unpack_avx2<bool>(const uint8_t* in, bool* out,
-                                                            int batch_size, int num_bits);
+extern template ARROW_TEMPLATE_EXPORT void unpack_avx2<bool>(const uint8_t* in, bool* out,
+                                                             int batch_size,
+                                                             int num_bits);
 
-extern template ARROW_TEMPLATE_EXPORT int unpack_avx2<uint8_t>(const uint8_t* in,
-                                                               uint8_t* out,
-                                                               int batch_size,
-                                                               int num_bits);
-
-extern template ARROW_TEMPLATE_EXPORT int unpack_avx2<uint16_t>(const uint8_t* in,
-                                                                uint16_t* out,
+extern template ARROW_TEMPLATE_EXPORT void unpack_avx2<uint8_t>(const uint8_t* in,
+                                                                uint8_t* out,
                                                                 int batch_size,
                                                                 int num_bits);
 
-extern template ARROW_TEMPLATE_EXPORT int unpack_avx2<uint32_t>(const uint8_t* in,
-                                                                uint32_t* out,
-                                                                int batch_size,
-                                                                int num_bits);
+extern template ARROW_TEMPLATE_EXPORT void unpack_avx2<uint16_t>(const uint8_t* in,
+                                                                 uint16_t* out,
+                                                                 int batch_size,
+                                                                 int num_bits);
 
-extern template ARROW_TEMPLATE_EXPORT int unpack_avx2<uint64_t>(const uint8_t* in,
-                                                                uint64_t* out,
-                                                                int batch_size,
-                                                                int num_bits);
+extern template ARROW_TEMPLATE_EXPORT void unpack_avx2<uint32_t>(const uint8_t* in,
+                                                                 uint32_t* out,
+                                                                 int batch_size,
+                                                                 int num_bits);
+
+extern template ARROW_TEMPLATE_EXPORT void unpack_avx2<uint64_t>(const uint8_t* in,
+                                                                 uint64_t* out,
+                                                                 int batch_size,
+                                                                 int num_bits);
 
 #endif
 
 #if defined(ARROW_HAVE_AVX512) || defined(ARROW_HAVE_RUNTIME_AVX512)
 
 template <typename Uint>
-ARROW_EXPORT int unpack_avx512(const uint8_t* in, Uint* out, int batch_size,
-                               int num_bits);
+ARROW_EXPORT void unpack_avx512(const uint8_t* in, Uint* out, int batch_size,
+                                int num_bits);
 
-extern template ARROW_TEMPLATE_EXPORT int unpack_avx512<bool>(const uint8_t* in,
-                                                              bool* out, int batch_size,
-                                                              int num_bits);
+extern template ARROW_TEMPLATE_EXPORT void unpack_avx512<bool>(const uint8_t* in,
+                                                               bool* out, int batch_size,
+                                                               int num_bits);
 
-extern template ARROW_TEMPLATE_EXPORT int unpack_avx512<uint8_t>(const uint8_t* in,
-                                                                 uint8_t* out,
-                                                                 int batch_size,
-                                                                 int num_bits);
-
-extern template ARROW_TEMPLATE_EXPORT int unpack_avx512<uint16_t>(const uint8_t* in,
-                                                                  uint16_t* out,
+extern template ARROW_TEMPLATE_EXPORT void unpack_avx512<uint8_t>(const uint8_t* in,
+                                                                  uint8_t* out,
                                                                   int batch_size,
                                                                   int num_bits);
 
-extern template ARROW_TEMPLATE_EXPORT int unpack_avx512<uint32_t>(const uint8_t* in,
-                                                                  uint32_t* out,
-                                                                  int batch_size,
-                                                                  int num_bits);
+extern template ARROW_TEMPLATE_EXPORT void unpack_avx512<uint16_t>(const uint8_t* in,
+                                                                   uint16_t* out,
+                                                                   int batch_size,
+                                                                   int num_bits);
 
-extern template ARROW_TEMPLATE_EXPORT int unpack_avx512<uint64_t>(const uint8_t* in,
-                                                                  uint64_t* out,
-                                                                  int batch_size,
-                                                                  int num_bits);
+extern template ARROW_TEMPLATE_EXPORT void unpack_avx512<uint32_t>(const uint8_t* in,
+                                                                   uint32_t* out,
+                                                                   int batch_size,
+                                                                   int num_bits);
+
+extern template ARROW_TEMPLATE_EXPORT void unpack_avx512<uint64_t>(const uint8_t* in,
+                                                                   uint64_t* out,
+                                                                   int batch_size,
+                                                                   int num_bits);
 
 #endif
 

--- a/cpp/src/arrow/util/bpacking_test.cc
+++ b/cpp/src/arrow/util/bpacking_test.cc
@@ -25,7 +25,6 @@
 #include "arrow/util/bpacking_internal.h"
 #include "arrow/util/bpacking_scalar_internal.h"
 #include "arrow/util/bpacking_simd_internal.h"
-#include "arrow/util/logging.h"
 
 #if defined(ARROW_HAVE_RUNTIME_AVX2)
 #  include "arrow/util/cpu_info.h"
@@ -34,7 +33,7 @@
 namespace arrow::internal {
 
 template <typename Int>
-using UnpackFunc = int (*)(const uint8_t*, Int*, int, int);
+using UnpackFunc = void (*)(const uint8_t*, Int*, int, int);
 
 /// Get the number of bytes associate with a packing.
 int32_t GetNumBytes(int32_t num_values, int32_t bit_width) {
@@ -58,11 +57,9 @@ std::vector<Int> UnpackValues(const uint8_t* packed, int32_t num_values,
                               int32_t bit_width, UnpackFunc<Int> unpack) {
   // Using dynamic array to avoid std::vector<bool>
   auto buffer = std::make_unique<Int[]>(num_values);
-  int values_read = unpack(packed, buffer.get(), num_values, bit_width);
-  ARROW_DCHECK_GE(values_read, 0);
-  EXPECT_LE(values_read, num_values);
+  unpack(packed, buffer.get(), num_values, bit_width);
 
-  return std::vector<Int>(buffer.get(), buffer.get() + values_read);
+  return std::vector<Int>(buffer.get(), buffer.get() + num_values);
 }
 
 /// Use BitWriter to pack values into a vector.

--- a/cpp/src/arrow/util/bpacking_test.cc
+++ b/cpp/src/arrow/util/bpacking_test.cc
@@ -33,7 +33,7 @@
 namespace arrow::internal {
 
 template <typename Int>
-using UnpackFunc = void (*)(const uint8_t*, Int*, int, int);
+using UnpackFunc = void (*)(const uint8_t*, Int*, int, int, int);
 
 /// Get the number of bytes associate with a packing.
 int32_t GetNumBytes(int32_t num_values, int32_t bit_width) {
@@ -57,7 +57,7 @@ std::vector<Int> UnpackValues(const uint8_t* packed, int32_t num_values,
                               int32_t bit_width, UnpackFunc<Int> unpack) {
   // Using dynamic array to avoid std::vector<bool>
   auto buffer = std::make_unique<Int[]>(num_values);
-  unpack(packed, buffer.get(), num_values, bit_width);
+  unpack(packed, buffer.get(), num_values, bit_width, /* bit_offset = */ 0);
 
   return std::vector<Int>(buffer.get(), buffer.get() + num_values);
 }

--- a/cpp/src/arrow/util/bpacking_test.cc
+++ b/cpp/src/arrow/util/bpacking_test.cc
@@ -83,6 +83,10 @@ std::vector<Int> UnpackValues(const uint8_t* packed, int32_t num_values,
 template <typename Int>
 std::vector<uint8_t> PackValues(const std::vector<Int>& values, int num_values,
                                 int bit_width, int bit_offset) {
+  if (bit_width == 0) {
+    return {};
+  }
+
   const auto num_bytes = GetNumBytes(num_values, bit_width, bit_offset);
 
   std::vector<uint8_t> out(static_cast<std::size_t>(num_bytes));

--- a/cpp/src/arrow/util/decimal.cc
+++ b/cpp/src/arrow/util/decimal.cc
@@ -610,7 +610,8 @@ static void AppendLittleEndianArrayToString(const std::array<uint64_t, n>& array
       // *elem = dividend / 1e9;
       // remainder = dividend % 1e9.
       uint32_t hi = static_cast<uint32_t>(*elem >> 32);
-      uint32_t lo = static_cast<uint32_t>(*elem & bit_util::LeastSignificantBitMask(32));
+      uint32_t lo =
+          static_cast<uint32_t>(*elem & bit_util::LeastSignificantBitMask<uint64_t>(32));
       uint64_t dividend_hi = (static_cast<uint64_t>(remainder) << 32) | hi;
       uint64_t quotient_hi = dividend_hi / k1e9;
       remainder = static_cast<uint32_t>(dividend_hi % k1e9);

--- a/cpp/src/arrow/util/rle_encoding_test.cc
+++ b/cpp/src/arrow/util/rle_encoding_test.cc
@@ -290,7 +290,7 @@ void TestRleDecoder(std::vector<uint8_t> bytes, rle_size_t value_count,
   EXPECT_EQ(vals.at(0), expected_value);
   EXPECT_EQ(decoder.remaining(), value_count - read);
 
-  EXPECT_EQ(decoder.Advance(3, bit_width), 3);
+  EXPECT_EQ(decoder.Advance(3), 3);
   read += 3;
   EXPECT_EQ(decoder.remaining(), value_count - read);
 
@@ -302,9 +302,9 @@ void TestRleDecoder(std::vector<uint8_t> bytes, rle_size_t value_count,
   EXPECT_EQ(decoder.remaining(), value_count - read);
 
   // Exhaust iteration
-  EXPECT_EQ(decoder.Advance(value_count - read, bit_width), value_count - read);
+  EXPECT_EQ(decoder.Advance(value_count - read), value_count - read);
   EXPECT_EQ(decoder.remaining(), 0);
-  EXPECT_EQ(decoder.Advance(1, bit_width), 0);
+  EXPECT_EQ(decoder.Advance(1), 0);
   vals = {0, 0};
   EXPECT_EQ(decoder.Get(vals.data(), bit_width), 0);
   EXPECT_EQ(vals.at(0), 0);
@@ -350,7 +350,7 @@ void TestBitPackedDecoder(std::vector<uint8_t> bytes, rle_size_t value_count,
   read += 1;
   EXPECT_EQ(decoder.remaining(), value_count - read);
 
-  EXPECT_EQ(decoder.Advance(3, bit_width), 3);
+  EXPECT_EQ(decoder.Advance(3), 3);
   read += 3;
   EXPECT_EQ(decoder.remaining(), value_count - read);
 
@@ -362,9 +362,9 @@ void TestBitPackedDecoder(std::vector<uint8_t> bytes, rle_size_t value_count,
   EXPECT_EQ(decoder.remaining(), value_count - read);
 
   // Exhaust iteration
-  EXPECT_EQ(decoder.Advance(value_count - read, bit_width), value_count - read);
+  EXPECT_EQ(decoder.Advance(value_count - read), value_count - read);
   EXPECT_EQ(decoder.remaining(), 0);
-  EXPECT_EQ(decoder.Advance(1, bit_width), 0);
+  EXPECT_EQ(decoder.Advance(1), 0);
   vals = {0, 0};
   EXPECT_EQ(decoder.Get(vals.data(), bit_width), 0);
   EXPECT_EQ(vals.at(0), 0);


### PR DESCRIPTION
### Rationale for this change
- Simplify the use of `unpack`
- Reduce code spread for unpacking integers

### What changes are included in this PR?
- epilog: `unpack` extract exactly the required number of values -> change return type to `void`.
- prolog: `unpack` can handled non aligned data -> include `bit_offset` in input parameters. 
- Include prolog/epilog cases in `unpack` tests.
- Simplify a roundtrip test from packed -> unpacked -> packed to unpacked -> packed -> unpacked

Decoder benchmarks  should remain the same (tested linux x86-64).
I have not benchmark the `unpack` functions themselves but I don't believe it's relevant since they now do more work.

### Are these changes tested?
Yes

### Are there any user-facing changes?
No

* GitHub Issue: #47895