### PR TITLE
GH-46825: [R] Use smallest_decimal() from C++ instead of working out which decimal type to instantiate in R

### DIFF
--- a/r/R/arrowExports.R
+++ b/r/R/arrowExports.R
@@ -940,6 +940,10 @@ Decimal256Type__initialize <- function(precision, scale) {
   .Call(`_arrow_Decimal256Type__initialize`, precision, scale)
 }
 
+SmallestDecimal__initialize <- function(precision, scale) {
+  .Call(`_arrow_SmallestDecimal__initialize`, precision, scale)
+}
+
 DayTimeInterval__initialize <- function() {
   .Call(`_arrow_DayTimeInterval__initialize`)
 }

--- a/r/R/type.R
+++ b/r/R/type.R
@@ -604,16 +604,7 @@ timestamp <- function(unit = c("s", "ms", "us", "ns"), timezone = "") {
 #' @export
 decimal <- function(precision, scale) {
   args <- check_decimal_args(precision, scale)
-
-  if (args$precision > 38) {
-    decimal256(args$precision, args$scale)
-  } else if (args$precision > 18) {
-    decimal128(args$precision, args$scale)
-  } else if (args$precision > 9) {
-    decimal64(args$precision, args$scale)
-  } else {
-    decimal32(args$precision, args$scale)
-  }
+  SmallestDecimal__initialize(args$precision, args$scale)
 }
 
 #' @rdname data-type

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -2588,6 +2588,15 @@ BEGIN_CPP11
 END_CPP11
 }
 // datatype.cpp
+std::shared_ptr<arrow::DataType> SmallestDecimal__initialize(int32_t precision, int32_t scale);
+extern "C" SEXP _arrow_SmallestDecimal__initialize(SEXP precision_sexp, SEXP scale_sexp){
+BEGIN_CPP11
+	arrow::r::Input<int32_t>::type precision(precision_sexp);
+	arrow::r::Input<int32_t>::type scale(scale_sexp);
+	return cpp11::as_sexp(SmallestDecimal__initialize(precision, scale));
+END_CPP11
+}
+// datatype.cpp
 std::shared_ptr<arrow::DataType> DayTimeInterval__initialize();
 extern "C" SEXP _arrow_DayTimeInterval__initialize(){
 BEGIN_CPP11
@@ -5933,6 +5942,7 @@ static const R_CallMethodDef CallEntries[] = {
 		{ "_arrow_Decimal64Type__initialize", (DL_FUNC) &_arrow_Decimal64Type__initialize, 2}, 
 		{ "_arrow_Decimal128Type__initialize", (DL_FUNC) &_arrow_Decimal128Type__initialize, 2}, 
 		{ "_arrow_Decimal256Type__initialize", (DL_FUNC) &_arrow_Decimal256Type__initialize, 2}, 
+		{ "_arrow_SmallestDecimal__initialize", (DL_FUNC) &_arrow_SmallestDecimal__initialize, 2}, 
 		{ "_arrow_DayTimeInterval__initialize", (DL_FUNC) &_arrow_DayTimeInterval__initialize, 0}, 
 		{ "_arrow_FixedSizeBinary__initialize", (DL_FUNC) &_arrow_FixedSizeBinary__initialize, 1}, 
 		{ "_arrow_FixedSizeBinary__byte_width", (DL_FUNC) &_arrow_FixedSizeBinary__byte_width, 1}, 

--- a/r/src/datatype.cpp
+++ b/r/src/datatype.cpp
@@ -215,7 +215,7 @@ std::shared_ptr<arrow::DataType> Decimal256Type__initialize(int32_t precision,
 
 // [[arrow::export]]
 std::shared_ptr<arrow::DataType> SmallestDecimal__initialize(int32_t precision,
-                                                              int32_t scale) {
+                                                               int32_t scale) {
   return arrow::smallest_decimal(precision, scale);
 }
 

--- a/r/src/datatype.cpp
+++ b/r/src/datatype.cpp
@@ -215,7 +215,7 @@ std::shared_ptr<arrow::DataType> Decimal256Type__initialize(int32_t precision,
 
 // [[arrow::export]]
 std::shared_ptr<arrow::DataType> SmallestDecimal__initialize(int32_t precision,
-                                                               int32_t scale) {
+                                                             int32_t scale) {
   return arrow::smallest_decimal(precision, scale);
 }
 

--- a/r/src/datatype.cpp
+++ b/r/src/datatype.cpp
@@ -214,6 +214,12 @@ std::shared_ptr<arrow::DataType> Decimal256Type__initialize(int32_t precision,
 }
 
 // [[arrow::export]]
+std::shared_ptr<arrow::DataType> SmallestDecimal__initialize(int32_t precision,
+                                                              int32_t scale) {
+  return arrow::smallest_decimal(precision, scale);
+}
+
+// [[arrow::export]]
 std::shared_ptr<arrow::DataType> DayTimeInterval__initialize() {
   return arrow::day_time_interval();
 }


### PR DESCRIPTION
### Rationale for this change

R code duplicated code from C++

### What changes are included in this PR?

Remove duplication

### Are these changes tested?

There were existing tests

### Are there any user-facing changes?

Nah
* GitHub Issue: #46825