### PR TITLE
GH-47909: [C++] Fix MSVC ARM64 build

### DIFF
--- a/cpp/src/arrow/util/bpacking_simd_default.cc
+++ b/cpp/src/arrow/util/bpacking_simd_default.cc
@@ -16,7 +16,9 @@
 // under the License.
 
 #include "arrow/util/bpacking_dispatch_internal.h"
-#include "arrow/util/bpacking_simd128_generated_internal.h"
+#if defined(ARROW_HAVE_NEON)
+#  include "arrow/util/bpacking_simd128_generated_internal.h"
+#endif
 #include "arrow/util/bpacking_simd_internal.h"
 
 namespace arrow::internal {


### PR DESCRIPTION
### Rationale for this change

#47573 broke the Windows ARM64 MSVC build by trying to compile xsimd even when `ARROW_SIMD_LEVEL` is set to `NONE`.

### What changes are included in this PR?

Make sure that xsimd is only included when SIMD is requested.

### Are these changes tested?

Yes, in the Windows ARM64 MSVC build pipeline that I was developing on #47811 when I noticed the change.

### Are there any user-facing changes?

No.
* GitHub Issue: #47909