### PR TITLE
GH-47914: [C++] Fix system Apache ORC/Google logging used detection

### DIFF
--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -80,7 +80,7 @@ if(ARROW_WITH_ZSTD)
 endif()
 
 if(ARROW_ORC)
-  if(ORC_SOURCE STREQUAL "SYSTEM")
+  if(orc_SOURCE STREQUAL "SYSTEM")
     list(APPEND ARROW_STATIC_INSTALL_INTERFACE_LIBS orc::orc)
   endif()
 endif()

--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -86,7 +86,7 @@ if(ARROW_ORC)
 endif()
 
 if(ARROW_USE_GLOG)
-  if(GLOG_SOURCE STREQUAL "SYSTEM")
+  if(glog_SOURCE STREQUAL "SYSTEM")
     list(APPEND ARROW_STATIC_INSTALL_INTERFACE_LIBS glog::glog)
   endif()
 endif()


### PR DESCRIPTION
### Rationale for this change

We need to use `orc_SOURCE` not `ORC_SOURCE` for Apache ORC and `glog_SOURCE` not `GLOG_SOURCE` for Google logging.

### What changes are included in this PR?

Fix referred variable names.

### Are these changes tested?

Yes in https://github.com/apache/arrow-java/pull/865 .

### Are there any user-facing changes?

Yes.
* GitHub Issue: #47914