### PR TITLE
GH-47844: [CI] Fix unconditionally running extra workflows reporting when there are jobs failing

### DIFF
--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -327,7 +327,7 @@ jobs:
           ../minimal_build.build/arrow-example
 
   report-extra-cpp:
-    if: github.event_name == 'schedule' && always()
+    if: always()
     needs:
       - docker
       - jni-macos

--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -330,6 +330,8 @@ jobs:
     if: always()
     needs:
       - docker
+      - jni-linux
       - jni-macos
+      - msvc-arm64
     uses: ./.github/workflows/report_ci.yml
     secrets: inherit

--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -327,7 +327,7 @@ jobs:
           ../minimal_build.build/arrow-example
 
   report-extra-cpp:
-    if: always()
+    if: github.event_name == 'schedule' && always()
     needs:
       - docker
       - jni-linux

--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -327,6 +327,7 @@ jobs:
           ../minimal_build.build/arrow-example
 
   report-extra-cpp:
+    if: github.event_name == 'schedule' && always()
     needs:
       - docker
       - jni-macos

--- a/.github/workflows/package_linux.yml
+++ b/.github/workflows/package_linux.yml
@@ -314,6 +314,7 @@ jobs:
           popd
 
   report-package-linux:
+    if: github.event_name == 'schedule' && always()
     needs:
       - package
     uses: ./.github/workflows/report_ci.yml

--- a/.github/workflows/report_ci.yml
+++ b/.github/workflows/report_ci.yml
@@ -28,7 +28,6 @@ jobs:
     # We match github.job to the name so we can pass it via context in order to be ignored on the report.
     # The job is still running.
     name: ${{ github.job }}
-    if: github.event_name == 'schedule' && always()
     steps:
       - name: Checkout Arrow
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0


### PR DESCRIPTION
### Rationale for this change

If a job fails on the workflow the report step is currently being skipped.

### What changes are included in this PR?

The unconditional `always()` check should be done on the parent workflow using `.github/workflows/report_ci.yml`  not on the common one.
Added also missing needed jobs before generating the report on the cpp_extra.yml (msvc-arm64 and jni-linux)

### Are these changes tested?

Yes via CI I validated the job will be executed even if there are job failures.

### Are there any user-facing changes?

No
* GitHub Issue: #47844