### PR TITLE
GH-47919: [C++] Update Meson config for C Data Interface changes

### DIFF
--- a/cpp/src/arrow/integration/meson.build
+++ b/cpp/src/arrow/integration/meson.build
@@ -23,6 +23,12 @@ exc = executable(
     dependencies: [arrow_test_dep_no_main, rapidjson_dep, gflags_dep],
 )
 
+arrow_c_data_integration_lib = library(
+    'arrow_c_data_integration',
+    sources: ['c_data_integration_internal.cc'],
+    dependencies: [arrow_test_dep_no_main],
+)
+
 if needs_tests
     test('arrow-json-integration-test', exc)
 endif

--- a/cpp/src/arrow/meson.build
+++ b/cpp/src/arrow/meson.build
@@ -280,7 +280,6 @@ if needs_integration or needs_tests
     arrow_components += {
         'arrow_integration': {
             'sources': [
-                'integration/c_data_integration_internal.cc',
                 'integration/json_integration.cc',
                 'integration/json_internal.cc',
             ],

--- a/cpp/src/arrow/util/meson.build
+++ b/cpp/src/arrow/util/meson.build
@@ -253,7 +253,10 @@ util_tests = {
         'sources': [
             'bit_block_counter_test.cc',
             'bit_util_test.cc',
+            'bitmap_test.cc',
+            'bpacking_test.cc',
             'rle_encoding_test.cc',
+            'test_common.cc',
         ],
     },
     'arrow-threading-utility-test': {
@@ -283,6 +286,7 @@ util_benchmarks = [
     'bit_block_counter',
     'bit_util',
     'bitmap_reader',
+    'bpacking',
     'cache',
     'compression',
     'decimal',


### PR DESCRIPTION
### Rationale for this change

This retains parity with the CMake configuration

### What changes are included in this PR?

C Data Interface library is created as a standalone

### Are these changes tested?

No (not possible with current CI)

### Are there any user-facing changes?

No
* GitHub Issue: #47919