### PR TITLE
GH-46531: [C++] Add type_singleton utility function and tests.

### DIFF
--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -2645,4 +2645,17 @@ const std::vector<std::shared_ptr<DataType>>& PrimitiveTypes();
 ARROW_EXPORT
 const std::vector<Type::type>& DecimalTypeIds();
 
+/// \brief Create a data type instance from a type ID for parameter-free types
+///
+/// This function creates a data type instance for types that don't require
+/// additional parameters (where TypeTraits<T>::is_parameter_free is true).
+/// For types that require parameters (like TimestampType or ListType),
+/// this function will return an error.
+///
+/// \param[in] id The type ID to create a type instance for
+/// \return The type instance for the given type ID,
+///         or a TypeError if the type requires parameters
+ARROW_EXPORT
+Result<std::shared_ptr<DataType>> type_singleton(Type::type id);
+
 }  // namespace arrow

--- a/cpp/src/arrow/visit_type_inline.h
+++ b/cpp/src/arrow/visit_type_inline.h
@@ -71,10 +71,8 @@ inline Status VisitTypeInline(const DataType& type, VISITOR* visitor, ARGS&&... 
 /// \tparam ARGS Additional arguments, if any, will be passed to the Visit function after
 /// the `type` argument
 ///
-/// Unlike VisitTypeInline which calls `visitor.Visit`, here `visitor`
+/// Unlike VisitTypeInline which calls `visitor->Visit`, here `visitor`
 /// itself is called.
-/// `visitor` must support a `const DataType&` argument as a fallback,
-/// in addition to concrete type classes.
 ///
 /// The intent is for this to be called on a generic lambda
 /// that may internally use `if constexpr` or similar constructs.
@@ -104,6 +102,34 @@ inline auto VisitType(const DataType& type, VISITOR&& visitor, ARGS&&... args)
 /// \return Status
 template <typename VISITOR, typename... ARGS>
 inline Status VisitTypeIdInline(Type::type id, VISITOR* visitor, ARGS&&... args) {
+  switch (id) {
+    ARROW_GENERATE_FOR_ALL_TYPES(TYPE_ID_VISIT_INLINE);
+    default:
+      break;
+  }
+  return Status::NotImplemented("Type not implemented");
+}
+
+#undef TYPE_ID_VISIT_INLINE
+
+#define TYPE_ID_VISIT_INLINE(TYPE_CLASS)                                              \
+  case TYPE_CLASS##Type::type_id: {                                                   \
+    const TYPE_CLASS##Type* concrete_ptr = NULLPTR;                                   \
+    return std::forward<VISITOR>(visitor)(concrete_ptr, std::forward<ARGS>(args)...); \
+  }
+
+/// \brief Calls `visitor` with a nullptr of the corresponding concrete type class
+/// \tparam ARGS Additional arguments, if any, will be passed to the Visit function after
+/// the `type` argument
+///
+/// Unlike VisitTypeIdInline which calls `visitor->Visit`, here `visitor`
+/// itself is called.
+///
+/// The intent is for this to be called on a generic lambda
+/// that may internally use `if constexpr` or similar constructs.
+template <typename VISITOR, typename... ARGS>
+inline auto VisitTypeId(Type::type id, VISITOR&& visitor, ARGS&&... args)
+    -> decltype(std::forward<VISITOR>(visitor)(std::declval<DataType*>(), args...)) {
   switch (id) {
     ARROW_GENERATE_FOR_ALL_TYPES(TYPE_ID_VISIT_INLINE);
     default:


### PR DESCRIPTION
### Rationale for this change

Introduce a `type_singleton(Type::type id)` utility to create parameter-free DataType instances (such as int32, boolean, utf8, etc.). Returns an error for parameterized types.

### Are these changes tested?

Yes, by additional unit tests in `type_test.cc`.

### Are there any user-facing changes?

No.

* GitHub Issue: #46531