### PR TITLE
GH-47927: [Release] Fix APT repository metadata generation with new repository

### DIFF
--- a/dev/release/binary-task.rb
+++ b/dev/release/binary-task.rb
@@ -1579,10 +1579,15 @@ APT::FTPArchive::Release::Description "#{apt_repository_description}";
         base_dists_dir = "#{base_dir}/#{distribution}/dists/#{code_name}"
         merged_dists_dir = "#{merged_dir}/#{distribution}/dists/#{code_name}"
         rm_rf(merged_dists_dir)
-        merger = APTDistsMerge::Merger.new(base_dists_dir,
-                                           dists_dir,
-                                           merged_dists_dir)
-        merger.merge
+        if Dir.empty?(base_dists_dir)
+          mkdir_p(File.dirname(merged_dists_dir))
+          cp_r(dists_dir, File.dirname(merged_dists_dir))
+        else
+          merger = APTDistsMerge::Merger.new(base_dists_dir,
+                                             dists_dir,
+                                             merged_dists_dir)
+          merger.merge
+        end
 
         in_release_path = "#{merged_dists_dir}/InRelease"
         release_path = "#{merged_dists_dir}/Release"


### PR DESCRIPTION
### Rationale for this change

We added a new APT repository for Debian GNU/Linux trixie in 22.0.0 but our APT repository metadata update logic doesn't work for the case. The current logic requires existing metadata but new APT repository doesn't have metadata. So the current logic doesn't work.

### What changes are included in this PR?

If there is no existing metadata, we don't merge existing metadata and new metadata. We just use new metadata as-is.

### Are these changes tested?

Yes. I used this for 22.0.0 release.

### Are there any user-facing changes?

No.
* GitHub Issue: #47927