### PR TITLE
GH-47821: [CI][Release][R] Fix test repository path in release

### DIFF
--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -286,7 +286,7 @@ env:
     run: |
       profile_path <- file.path(getwd(), ".Rprofile")
       repo <- paste0("file://", getwd(), "/repo")
-      str <- paste0("options(arrow.repo = '", repo, "/' )")
+      str <- paste0("options(arrow.repo = '", repo, "/libarrow/' )")
       print(str)
       write(str, file = profile_path, append = TRUE)
       str <- paste0("options(arrow.dev_repo = '", repo, "' )")

--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -286,7 +286,7 @@ env:
     run: |
       profile_path <- file.path(getwd(), ".Rprofile")
       repo <- paste0("file://", getwd(), "/repo")
-      str <- paste0("options(arrow.repo = '", repo, "' )")
+      str <- paste0("options(arrow.repo = '", repo, "/' )")
       print(str)
       write(str, file = profile_path, append = TRUE)
       str <- paste0("options(arrow.dev_repo = '", repo, "' )")

--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: arrow
 Title: Integration to 'Apache' 'Arrow'
-Version: 22.0.0
+Version: 21.0.0.9000
 Authors@R: c(
     person("Neal", "Richardson", email = "neal.p.richardson@gmail.com", role = c("aut")),
     person("Ian", "Cook", email = "ianmcook@gmail.com", role = c("aut")),

--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: arrow
 Title: Integration to 'Apache' 'Arrow'
-Version: 21.0.0.9000
+Version: 22.0.0
 Authors@R: c(
     person("Neal", "Richardson", email = "neal.p.richardson@gmail.com", role = c("aut")),
     person("Ian", "Cook", email = "ianmcook@gmail.com", role = c("aut")),


### PR DESCRIPTION
### Rationale for this change

`r/tools/nixlibs.R` assumes that `arrow.repo` ends with `/` but `dev/tasks/macros.jinja` uses `arrow.repo` without the end `/`.

### What changes are included in this PR?

Add missing the end `/` and `/libarrow` sub directory.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #47821