### PR TITLE
MINOR: Update documentation for size_statistics_level

### DIFF
--- a/cpp/src/parquet/properties.h
+++ b/cpp/src/parquet/properties.h
@@ -733,7 +733,7 @@ class PARQUET_EXPORT WriterProperties {
       return this->disable_write_page_index(path->ToDotString());
     }
 
-    /// \brief Set the level to write size statistics for all columns. Default is None.
+    /// \brief Set the level to write size statistics for all columns. Default is PageAndColumnChunk.
     ///
     /// \param level The level to write size statistics. Note that if page index is not
     /// enabled, page level size statistics will not be written even if the level


### PR DESCRIPTION
The default of `size_statistics_level` is `PageAndColumnChunk` (updated in this [commit](https://github.com/apache/arrow/commit/1fcc89240db4fe0ad798498e7410668423846118#diff-562a81d45d101d71ec2673a6b981c63e8f5299df6f573b7841b67ede5d854936)) but the comment wasn't updated. 