### PR TITLE
GH-47936: [R] docgen.R requires installed package instead of current working code

### DIFF
--- a/r/data-raw/docgen.R
+++ b/r/data-raw/docgen.R
@@ -128,6 +128,16 @@ render_pkg <- function(df, pkg) {
   paste("#'", c(header, bullets), collapse = "\n")
 }
 
+# Load the current development version so we get the latest function mappings
+if (requireNamespace("devtools", quietly = TRUE)) {
+  devtools::load_all()
+} else {
+  warning(
+    "devtools is not installed. Using installed arrow package instead of current working code.\n",
+    "To generate accurate docs, install the current branch version of arrow first."
+  )
+}
+
 docs <- arrow:::.cache$docs
 
 # Add some functions

--- a/r/data-raw/docgen.R
+++ b/r/data-raw/docgen.R
@@ -134,7 +134,8 @@ if (requireNamespace("devtools", quietly = TRUE)) {
 } else {
   warning(
     "devtools is not installed. Using installed arrow package instead of current working code.\n",
-    "To generate accurate docs, install the current branch version of arrow first."
+    "To generate accurate docs, install the current branch version of arrow first via `R CMD INSTALL .` ",
+    "or install devtools before running this script again."
   )
 }
 


### PR DESCRIPTION
### Rationale for this change

R package doc generation uses installed version of package so creates wrong docs if older version installed.

### What changes are included in this PR?

Use devtools::load_all() to load the package first when running locally.

### Are these changes tested?

CI should be happy, but I did test locally. 

### Are there any user-facing changes?

Nah.
* GitHub Issue: #47936