### PR TITLE
GH-47942: [R] CRAN 22.0.0 R package release fails on Winbuilder due to "non-API call to R: 'Rf_lazy_duplicate'"

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -60,7 +60,9 @@ jobs:
       - name: Cache pre-commit
         uses: actions/cache@v4
         with:
-          path: ~/.cache/pre-commit
+          path: |
+            ~/.cache/pre-commit
+            ~/.local/share/renv/cache
           key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
       - name: Install Air
         uses: posit-dev/setup-air@63e80dedb6d275c94a3841e15e5ff8691e1ab237 # v1.0.0

--- a/r/.Rbuildignore
+++ b/r/.Rbuildignore
@@ -31,3 +31,4 @@ STYLE.md
 ^PACKAGING\.md$
 ^inst/__pycache__$
 ^bootstrap.R$
+air.toml

--- a/r/src/altrep.cpp
+++ b/r/src/altrep.cpp
@@ -572,7 +572,7 @@ struct AltrepFactor : public AltrepVectorBase<AltrepFactor> {
 
   static SEXP Duplicate(SEXP alt, Rboolean /* deep */) {
     // the representation integer vector
-    SEXP dup = PROTECT(Rf_lazy_duplicate(Materialize(alt)));
+    SEXP dup = PROTECT(Rf_shallow_duplicate(Materialize(alt)));
 
     // additional attributes from the altrep
     SEXP atts = PROTECT(Rf_duplicate(ATTRIB(alt)));


### PR DESCRIPTION
### Rationale for this change

CRAN 22.0.0 R package release fails on Winbuilder due to "non-API call to R: 'Rf_lazy_duplicate'" 

### What changes are included in this PR?

Change function used for altrep code to not use `Rf_lazy_duplicate`

### Are these changes tested?

No

### Are there any user-facing changes?

No
* GitHub Issue: #47942