### PR TITLE
GH-47939: [R] Update CRAN packaging checklist to update checksums and have make build call make clean

### DIFF
--- a/r/Makefile
+++ b/r/Makefile
@@ -48,7 +48,10 @@ sync-cpp:
 	cp -p ../LICENSE.txt tools/
 	sed -i"" -e "s/\.env/dotenv/g" tools/cpp/CMakeLists.txt
 
-build: clean doc sync-cpp
+build:
+	$(MAKE) clean
+	$(MAKE) doc
+	$(MAKE) sync-cpp
 	R CMD build ${args} .
 
 check: build

--- a/r/Makefile
+++ b/r/Makefile
@@ -63,11 +63,11 @@ release: build
 	rm -rf arrow.Rcheck/
 
 clean:
-	-rm src/*.o
-	-rm src/*.so
-	-rm src/*.dll
-	-rm src/Makevars
-	-rm src/Makevars.win
+	-rm -f src/*.o
+	-rm -f src/*.so
+	-rm -f src/*.dll
+	-rm -f src/Makevars
+	-rm -f src/Makevars.win
 	-rm -rf arrow.Rcheck/
 	-rm -rf libarrow/
 	-rm -rf tools/cpp/ tools/dotenv tools/NOTICE.txt tools/LICENSE.txt

--- a/r/Makefile
+++ b/r/Makefile
@@ -48,7 +48,7 @@ sync-cpp:
 	cp -p ../LICENSE.txt tools/
 	sed -i"" -e "s/\.env/dotenv/g" tools/cpp/CMakeLists.txt
 
-build: doc sync-cpp
+build: clean doc sync-cpp
 	R CMD build ${args} .
 
 check: build
@@ -67,5 +67,5 @@ clean:
 	-rm src/Makevars.win
 	-rm -rf arrow.Rcheck/
 	-rm -rf libarrow/
-	-rm -rf tools/cpp/ tools/dotenv tools/NOTICE.txt tools/LICENSE.txt tools/checksums
+	-rm -rf tools/cpp/ tools/dotenv tools/NOTICE.txt tools/LICENSE.txt
 	-find . -name "*.orig" -delete

--- a/r/PACKAGING.md
+++ b/r/PACKAGING.md
@@ -58,7 +58,8 @@ _Wait for the release candidate to be created._
 - [ ] Run `urlchecker::url_check()` on the R directory.
 - [ ] Create a PR entitled `WIP: [R] Verify CRAN release-X.Y.Z-rcX`. Add a comment `@github-actions crossbow submit --group r` to run all R crossbow jobs against the CRAN-specific release branch.
 - [ ] Run `Rscript tools/update-checksums.R <libarrow version>` to download the checksums for the pre-compiled binaries from the ASF artifactory into the tools directory.
-- [ ] Regenerate arrow_X.Y.Z.tar.gz (i.e., `make build`).
+- [ ] Commit the checksums: `git add -f tools/checksums/ && git commit -m "[CRAN] Add checksums"`
+- [ ] Regenerate arrow_X.Y.Z.tar.gz (i.e., `make build`). This will clean old artifacts, regenerate documentation, sync C++ files, and build the package.
 
 ## Check Binary Arrow C++ Distributions Specific to the R Package
 


### PR DESCRIPTION
### Rationale for this change

- checksum update not part of instructions
- non-obvious need to call make clean

### What changes are included in this PR?

- update instructions and makefile 

### Are these changes tested?

I will test locally before marking this as ready for review

### Are there any user-facing changes?

No
* GitHub Issue: #47939