### PR TITLE
GH-47945: [C++] Add support for Boost 1.89.0 and require Boost 1.69 or later

### DIFF
--- a/ci/conda_env_cpp.txt
+++ b/ci/conda_env_cpp.txt
@@ -22,7 +22,6 @@ azure-storage-blobs-cpp>=12.10.0
 azure-storage-common-cpp>=12.5.0
 azure-storage-files-datalake-cpp>=12.9.0
 benchmark>=1.6.0,!=1.8.4
-boost-cpp>=1.68.0
 brotli
 bzip2
 c-ares
@@ -32,6 +31,7 @@ glog
 gmock>=1.10.0
 google-cloud-cpp>=1.34.0
 gtest>=1.10.0
+libboost-devel
 libgrpc
 libprotobuf
 libutf8proc

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -1207,6 +1207,8 @@ endif()
 # https://cmake.org/cmake/help/latest/policy/CMP0167.html with CMake
 # 3.30.0 or later.
 set(Boost_ADDITIONAL_VERSIONS
+    "1.89.0"
+    "1.89"
     "1.88.0"
     "1.88"
     "1.87.0"

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -1191,10 +1191,9 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION
   # GH-34094 Older versions of Boost use the deprecated std::unary_function in
   # boost/container_hash/hash.hpp and support for that was removed in clang 16
   set(ARROW_BOOST_REQUIRED_VERSION "1.81")
-elseif(ARROW_BUILD_TESTS)
-  set(ARROW_BOOST_REQUIRED_VERSION "1.64")
 else()
-  set(ARROW_BOOST_REQUIRED_VERSION "1.58")
+  # CentOS 7 uses Boost 1.69.
+  set(ARROW_BOOST_REQUIRED_VERSION "1.69")
 endif()
 
 set(Boost_USE_MULTITHREADED ON)
@@ -1202,6 +1201,11 @@ if(MSVC AND ARROW_USE_STATIC_CRT)
   set(Boost_USE_STATIC_RUNTIME ON)
 endif()
 # CMake 3.25.0 has 1.80 and older versions.
+#
+# We can remove this once we require CMake 3.30.0 or later because we
+# enable CMP0167 "The FindBoost module is removed."
+# https://cmake.org/cmake/help/latest/policy/CMP0167.html with CMake
+# 3.30.0 or later.
 set(Boost_ADDITIONAL_VERSIONS
     "1.88.0"
     "1.88"
@@ -1273,7 +1277,7 @@ if(ARROW_USE_BOOST)
     set(Boost_USE_STATIC_LIBS ON)
   endif()
   if(ARROW_BOOST_REQUIRE_LIBRARY)
-    set(ARROW_BOOST_COMPONENTS filesystem system)
+    set(ARROW_BOOST_COMPONENTS filesystem)
     if(ARROW_FLIGHT_SQL_ODBC)
       list(APPEND ARROW_BOOST_COMPONENTS locale)
     endif()
@@ -1326,9 +1330,6 @@ if(ARROW_USE_BOOST)
       add_library(arrow::Boost::process INTERFACE IMPORTED)
       if(TARGET Boost::filesystem)
         target_link_libraries(arrow::Boost::process INTERFACE Boost::filesystem)
-      endif()
-      if(TARGET Boost::system)
-        target_link_libraries(arrow::Boost::process INTERFACE Boost::system)
       endif()
       if(TARGET Boost::headers)
         target_link_libraries(arrow::Boost::process INTERFACE Boost::headers)

--- a/cpp/src/arrow/filesystem/CMakeLists.txt
+++ b/cpp/src/arrow/filesystem/CMakeLists.txt
@@ -132,12 +132,11 @@ if(ARROW_S3)
                    DEFINITIONS
                    ARROW_S3_LIBPATH="$<TARGET_FILE:arrow_s3fs>"
                    EXTRA_LINK_LIBS
-                   Boost::filesystem
-                   Boost::system)
+                   Boost::filesystem)
     target_compile_definitions(arrow-filesystem-test
                                PUBLIC ARROW_S3_LIBPATH="$<TARGET_FILE:arrow_s3fs>")
     target_sources(arrow-filesystem-test PUBLIC s3fs_module_test.cc s3_test_util.cc)
-    target_link_libraries(arrow-filesystem-test PUBLIC Boost::filesystem Boost::system)
+    target_link_libraries(arrow-filesystem-test PUBLIC Boost::filesystem)
   endif()
 endif()
 


### PR DESCRIPTION
### Rationale for this change

Boost 1.89.0 removed backward compatibility CMake package for Boost.System. Boost.System is header-only since Boost 1.69. So CMake package for Boost.System isn't needed but it's provided for backward compatibility.

CentOS 7 uses Boost 1.69. So we can drop support for Boost 1.68 or older.

### What changes are included in this PR?

* Require Boost 1.69 or later.
* Remove `system` from `COMPONENTS` because Boost.System is header-only.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #47945