### PR TITLE
GH-47953: [C++] Remove Windows inclusion from `int_util_overflow.h`

### DIFF
--- a/cpp/src/arrow/util/int_util_overflow.h
+++ b/cpp/src/arrow/util/int_util_overflow.h
@@ -26,10 +26,8 @@
 #include "arrow/util/visibility.h"
 
 // "safe-math.h" includes <intsafe.h> from the Windows headers.
-#include "arrow/util/windows_compatibility.h"
 #include "arrow/vendored/portable-snippets/safe-math.h"
 // clang-format off (avoid include reordering)
-#include "arrow/util/windows_fixup.h"
 // clang-format on
 
 namespace arrow {


### PR DESCRIPTION
### Rationale for this change

In `int_util_overflow.h` we're currently including (indirectly) some Windows header through `windows_compatibility.h`:
https://github.com/apache/arrow/blob/f669b9fb6b71e74bb41496252709b494233de44d/cpp/src/arrow/util/int_util_overflow.h#L28-L33

This was probably necessary when this was initially committed, but can produce problems when expanding the use of this header in our codebase, due to unwanted macro definitions, here is an [example](https://github.com/apache/arrow/actions/runs/18754865884/job/53504089972?pr=47925):
```
D:/a/arrow/arrow/cpp/src/parquet/arrow/schema.cc:78:45: error: expected unqualified-id
   78 |   return is_nullable ? Repetition::OPTIONAL : Repetition::REQUIRED;
      |                                             ^
D:/a/arrow/arrow/cpp/src/parquet/arrow/schema.cc:331:45: error: expected unqualified-id
  331 |       if (repetition != Repetition::OPTIONAL) {
      |                                             ^
2 errors generated.
```

### What changes are included in this PR?

Simply remove the Windows inclusion. This seems to pass our current CI suite.

### Are these changes tested?

Yes, by existing CI tests.

### Are there any user-facing changes?

No.

* GitHub Issue: #47953