### PR TITLE
GH-47946: [C++][Parquet] Fix Simd inclusion paths

### DIFF
--- a/cpp/src/arrow/util/byte_stream_split_internal.h
+++ b/cpp/src/arrow/util/byte_stream_split_internal.h
@@ -29,7 +29,8 @@
 #include <cstdint>
 #include <cstring>
 
-#if defined(ARROW_HAVE_NEON) || defined(ARROW_HAVE_SSE4_2)
+#if defined(ARROW_HAVE_NEON) || defined(ARROW_HAVE_SSE4_2) || \
+    defined(ARROW_HAVE_RUNTIME_AVX2)
 #  include <xsimd/xsimd.hpp>
 #  define ARROW_HAVE_SIMD_SPLIT
 #endif

--- a/cpp/src/arrow/util/byte_stream_split_internal.h
+++ b/cpp/src/arrow/util/byte_stream_split_internal.h
@@ -29,8 +29,7 @@
 #include <cstdint>
 #include <cstring>
 
-// ARROW_HAVE_RUNTIME_SSE4_2 is used on x86-64 to include ARROW_HAVE_SSE4_2 and
-// ARROW_RUNTIME_SIMD_LEVEL != NONE.
+// ARROW_HAVE_RUNTIME_SSE4_2 is used on x86-64 to indicate ARROW_RUNTIME_SIMD_LEVEL != NONE.
 #if defined(ARROW_HAVE_NEON) || defined(ARROW_HAVE_RUNTIME_SSE4_2)
 #  include <xsimd/xsimd.hpp>
 #  define ARROW_HAVE_SIMD_SPLIT

--- a/cpp/src/arrow/util/byte_stream_split_internal.h
+++ b/cpp/src/arrow/util/byte_stream_split_internal.h
@@ -29,8 +29,9 @@
 #include <cstdint>
 #include <cstring>
 
-#if defined(ARROW_HAVE_NEON) || defined(ARROW_HAVE_SSE4_2) || \
-    defined(ARROW_HAVE_RUNTIME_AVX2)
+// ARROW_HAVE_RUNTIME_SSE4_2 is used on x86-64 to include ARROW_HAVE_SSE4_2 and
+// ARROW_RUNTIME_SIMD_LEVEL != NONE.
+#if defined(ARROW_HAVE_NEON) || defined(ARROW_HAVE_RUNTIME_SSE4_2)
 #  include <xsimd/xsimd.hpp>
 #  define ARROW_HAVE_SIMD_SPLIT
 #endif

--- a/cpp/src/arrow/util/byte_stream_split_internal.h
+++ b/cpp/src/arrow/util/byte_stream_split_internal.h
@@ -29,7 +29,8 @@
 #include <cstdint>
 #include <cstring>
 
-// ARROW_HAVE_RUNTIME_SSE4_2 is used on x86-64 to indicate ARROW_RUNTIME_SIMD_LEVEL != NONE.
+// ARROW_HAVE_RUNTIME_SSE4_2 is used on x86-64 to indicate
+// ARROW_RUNTIME_SIMD_LEVEL != NONE.
 #if defined(ARROW_HAVE_NEON) || defined(ARROW_HAVE_RUNTIME_SSE4_2)
 #  include <xsimd/xsimd.hpp>
 #  define ARROW_HAVE_SIMD_SPLIT


### PR DESCRIPTION
### Rationale for this change

Fix build with `ARROW_SIMD_LEVEL=NONE` and `ARROW_RUNTIME_SIMD_LEVEL` set to something else than `NONE`.

### Are these changes tested?

Locally. Adding a CI test case with `ARROW_SIMD_LEVEL=NONE` may prove useful in preventing further regressions.

### Are there any user-facing changes?

No

* GitHub Issue: #47946