### PR TITLE
GH-47734: [CI] Limit max and min values for timedelta hypothesis strategy for duration and interval

### DIFF
--- a/python/pyarrow/tests/strategies.py
+++ b/python/pyarrow/tests/strategies.py
@@ -323,9 +323,14 @@ def arrays(draw, type, size=None, nullable=True):
         value = st.datetimes(timezones=st.just(tz), min_value=min_datetime,
                              max_value=max_datetime)
     elif pa.types.is_duration(ty):
-        value = st.timedeltas()
+        # Max days to fit in 64 bits in case of nanosecond precision
+        max_days = 2**63 // (24 * 60 * 60 * 1_000_000_000)
+        value = st.timedeltas(min_value=datetime.timedelta(days=-max_days),
+                              max_value=datetime.timedelta(days=max_days))
     elif pa.types.is_interval(ty):
-        value = st.timedeltas()
+        max_days = 2**63 // (24 * 60 * 60 * 1_000_000_000)
+        value = st.timedeltas(min_value=datetime.timedelta(days=-max_days),
+                              max_value=datetime.timedelta(days=max_days))
     elif pa.types.is_binary(ty) or pa.types.is_large_binary(ty):
         value = st.binary()
     elif pa.types.is_string(ty) or pa.types.is_large_string(ty):

--- a/python/pyarrow/tests/strategies.py
+++ b/python/pyarrow/tests/strategies.py
@@ -324,11 +324,11 @@ def arrays(draw, type, size=None, nullable=True):
                              max_value=max_datetime)
     elif pa.types.is_duration(ty):
         # Max days to fit in 64 bits in case of nanosecond precision
-        max_days = 2**63 // (24 * 60 * 60 * 1_000_000_000)
+        max_days = 1000  # 2**63 // (24 * 60 * 60 * 1_000_000_000)
         value = st.timedeltas(min_value=datetime.timedelta(days=-max_days),
                               max_value=datetime.timedelta(days=max_days))
     elif pa.types.is_interval(ty):
-        max_days = 2**63 // (24 * 60 * 60 * 1_000_000_000)
+        max_days = 1000  # 2**63 // (24 * 60 * 60 * 1_000_000_000)
         value = st.timedeltas(min_value=datetime.timedelta(days=-max_days),
                               max_value=datetime.timedelta(days=max_days))
     elif pa.types.is_binary(ty) or pa.types.is_large_binary(ty):


### PR DESCRIPTION
### Rationale for this change

Hypothesys tests are failing due to generation of timedelta values that are larger than 64 bits:
`pyarrow.lib.ArrowInvalid: Timedelta too large to fit in 64-bit integer`

### What changes are included in this PR?

Limit min and max values for hypothesis strategy.

### Are these changes tested?

Via archery.

### Are there any user-facing changes?

No

* GitHub Issue: #47734