### PR TITLE
GH-47103: [Statistics][C++] Implement Statistics specification attribute ARROW:null_count:approximate 

### DIFF
--- a/c_glib/arrow-glib/basic-array.cpp
+++ b/c_glib/arrow-glib/basic-array.cpp
@@ -457,6 +457,22 @@ garrow_array_statistics_has_null_count(GArrowArrayStatistics *statistics)
 }
 
 /**
+ * garrow_array_statistics_is_null_count_exact:
+ * @statistics: A #GArrowArrayStatistics.
+ *
+ * Returns: %TRUE if the null count is available and exact, %FALSE otherwise.
+ *
+ * Since: 23.0.0
+ */
+gboolean
+garrow_array_statistics_is_null_count_exact(GArrowArrayStatistics *statistics)
+{
+  auto priv = GARROW_ARRAY_STATISTICS_GET_PRIVATE(statistics);
+  return priv->statistics.null_count.has_value() &&
+         std::holds_alternative<int64_t>(*priv->statistics.null_count);
+}
+
+/**
  * garrow_array_statistics_get_null_count:
  * @statistics: A #GArrowArrayStatistics.
  *
@@ -464,16 +480,56 @@ garrow_array_statistics_has_null_count(GArrowArrayStatistics *statistics)
  *   -1 otherwise.
  *
  * Since: 20.0.0
+ *
+ * Deprecated: 23.0.0. Use garrow_array_statistics_is_null_count_exact(),
+ *   garrow_array_statistics_get_null_count_exact() and
+ *   garrow_array_statistics_get_null_count_approximate() instead.
  */
 gint64
 garrow_array_statistics_get_null_count(GArrowArrayStatistics *statistics)
 {
+  return garrow_array_statistics_get_null_count_exact(statistics);
+}
+
+/**
+ * garrow_array_statistics_get_null_count_exact:
+ * @statistics: A #GArrowArrayStatistics.
+ *
+ * Returns: 0 or larger value if @statistics has a valid exact null
+ *   count value, -1 otherwise.
+ *
+ * Since: 23.0.0
+ */
+gint64
+garrow_array_statistics_get_null_count_exact(GArrowArrayStatistics *statistics)
+{
   auto priv = GARROW_ARRAY_STATISTICS_GET_PRIVATE(statistics);
   const auto &null_count = priv->statistics.null_count;
-  if (null_count) {
-    return null_count.value();
+  if (null_count && std::holds_alternative<int64_t>(*null_count)) {
+    return std::get<int64_t>(*null_count);
   } else {
     return -1;
+  }
+}
+
+/**
+ * garrow_array_statistics_get_null_count_approximate:
+ * @statistics: A #GArrowArrayStatistics.
+ *
+ * Returns: Non `NaN` value if @statistics has a valid approximate
+ *   null count value, `NaN` otherwise.
+ *
+ * Since: 23.0.0
+ */
+gdouble
+garrow_array_statistics_get_null_count_approximate(GArrowArrayStatistics *statistics)
+{
+  auto priv = GARROW_ARRAY_STATISTICS_GET_PRIVATE(statistics);
+  const auto &null_count = priv->statistics.null_count;
+  if (null_count && std::holds_alternative<double>(*null_count)) {
+    return std::get<double>(*null_count);
+  } else {
+    return std::nan("");
   }
 }
 

--- a/c_glib/arrow-glib/basic-array.h
+++ b/c_glib/arrow-glib/basic-array.h
@@ -54,9 +54,21 @@ struct _GArrowArrayStatisticsClass
 GARROW_AVAILABLE_IN_20_0
 gboolean
 garrow_array_statistics_has_null_count(GArrowArrayStatistics *statistics);
+GARROW_AVAILABLE_IN_23_0
+gboolean
+garrow_array_statistics_is_null_count_exact(GArrowArrayStatistics *statistics);
+#ifndef GARROW_DISABLE_DEPRECATED
 GARROW_AVAILABLE_IN_20_0
+GARROW_DEPRECATED_IN_23_0_FOR(garrow_array_statistics_get_null_count_exact)
 gint64
 garrow_array_statistics_get_null_count(GArrowArrayStatistics *statistics);
+#endif
+GARROW_AVAILABLE_IN_23_0
+gint64
+garrow_array_statistics_get_null_count_exact(GArrowArrayStatistics *statistics);
+GARROW_AVAILABLE_IN_23_0
+gdouble
+garrow_array_statistics_get_null_count_approximate(GArrowArrayStatistics *statistics);
 
 GARROW_AVAILABLE_IN_21_0
 gboolean

--- a/c_glib/test/test-array-statistics.rb
+++ b/c_glib/test/test-array-statistics.rb
@@ -45,8 +45,20 @@ class TestArrayStatistics < Test::Unit::TestCase
     end
   end
 
-  test("#null_count") do
-    assert_equal(1, @statistics.null_count)
+  test("#null_count_exact?") do
+    assert do
+      @statistics.null_count_exact?
+    end
+  end
+
+  test("#null_count_exact") do
+    assert_equal(1, @statistics.null_count_exact)
+  end
+
+  test("#null_count_approximate") do
+    assert do
+      @statistics.null_count_approximate.nan?
+    end
   end
 
   test("#has_distinct_count?") do

--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -3934,7 +3934,7 @@ class TestArrayDataStatistics : public ::testing::Test {
 
  protected:
   std::vector<uint8_t> valids_;
-  size_t null_count_;
+  int64_t null_count_;
   double distinct_count_;
   double max_byte_width_;
   double average_byte_width_;
@@ -3951,7 +3951,7 @@ TEST_F(TestArrayDataStatistics, MoveConstructor) {
   ArrayData moved_data(std::move(copied_data));
 
   ASSERT_TRUE(moved_data.statistics->null_count.has_value());
-  ASSERT_EQ(null_count_, moved_data.statistics->null_count.value());
+  ASSERT_EQ(null_count_, std::get<int64_t>(moved_data.statistics->null_count.value()));
 
   ASSERT_TRUE(moved_data.statistics->distinct_count.has_value());
   ASSERT_DOUBLE_EQ(distinct_count_,
@@ -3981,7 +3981,7 @@ TEST_F(TestArrayDataStatistics, CopyConstructor) {
   ArrayData copied_data(*data_);
 
   ASSERT_TRUE(copied_data.statistics->null_count.has_value());
-  ASSERT_EQ(null_count_, copied_data.statistics->null_count.value());
+  ASSERT_EQ(null_count_, std::get<int64_t>(copied_data.statistics->null_count.value()));
 
   ASSERT_TRUE(copied_data.statistics->distinct_count.has_value());
   ASSERT_DOUBLE_EQ(distinct_count_,
@@ -4013,7 +4013,7 @@ TEST_F(TestArrayDataStatistics, MoveAssignment) {
   moved_data = std::move(copied_data);
 
   ASSERT_TRUE(moved_data.statistics->null_count.has_value());
-  ASSERT_EQ(null_count_, moved_data.statistics->null_count.value());
+  ASSERT_EQ(null_count_, std::get<int64_t>(moved_data.statistics->null_count.value()));
 
   ASSERT_TRUE(moved_data.statistics->distinct_count.has_value());
   ASSERT_DOUBLE_EQ(distinct_count_,
@@ -4044,7 +4044,7 @@ TEST_F(TestArrayDataStatistics, CopyAssignment) {
   copied_data = *data_;
 
   ASSERT_TRUE(copied_data.statistics->null_count.has_value());
-  ASSERT_EQ(null_count_, copied_data.statistics->null_count.value());
+  ASSERT_EQ(null_count_, std::get<int64_t>(copied_data.statistics->null_count.value()));
 
   ASSERT_TRUE(copied_data.statistics->distinct_count.has_value());
   ASSERT_DOUBLE_EQ(distinct_count_,
@@ -4075,7 +4075,7 @@ TEST_F(TestArrayDataStatistics, CopyTo) {
                        data_->CopyTo(arrow::default_cpu_memory_manager()));
 
   ASSERT_TRUE(copied_data->statistics->null_count.has_value());
-  ASSERT_EQ(null_count_, copied_data->statistics->null_count.value());
+  ASSERT_EQ(null_count_, std::get<int64_t>(copied_data->statistics->null_count.value()));
 
   ASSERT_TRUE(copied_data->statistics->min.has_value());
   ASSERT_TRUE(std::holds_alternative<int64_t>(copied_data->statistics->min.value()));

--- a/cpp/src/arrow/array/statistics.h
+++ b/cpp/src/arrow/array/statistics.h
@@ -76,7 +76,9 @@ struct ARROW_EXPORT ArrayStatistics {
   }
 
   /// \brief The number of null values, may not be set
-  std::optional<int64_t> null_count = std::nullopt;
+  /// Note: when set to `int64_t`, it represents `exact_null_count`,
+  /// and when set to `double`, it represents `approximate_null_count`.
+  std::optional<CountType> null_count = std::nullopt;
 
   /// \brief The number of distinct values, may not be set
   /// Note: when set to `int64_t`, it represents `exact_distinct_count`,

--- a/cpp/src/arrow/array/statistics_test.cc
+++ b/cpp/src/arrow/array/statistics_test.cc
@@ -25,12 +25,20 @@
 
 namespace arrow {
 
-TEST(TestArrayStatistics, NullCount) {
+TEST(TestArrayStatistics, NullCountExact) {
   ArrayStatistics statistics;
   ASSERT_FALSE(statistics.null_count.has_value());
   statistics.null_count = 29;
   ASSERT_TRUE(statistics.null_count.has_value());
-  ASSERT_EQ(29, statistics.null_count.value());
+  ASSERT_EQ(29, std::get<int64_t>(statistics.null_count.value()));
+}
+
+TEST(TestArrayStatistics, NullCountAprroximate) {
+  ArrayStatistics statistics;
+  ASSERT_FALSE(statistics.null_count.has_value());
+  statistics.null_count = 29.0;
+  ASSERT_TRUE(statistics.null_count.has_value());
+  ASSERT_EQ(29.0, std::get<double>(statistics.null_count.value()));
 }
 
 TEST(TestArrayStatistics, DistinctCountExact) {
@@ -106,9 +114,16 @@ TEST(TestArrayStatistics, Equals) {
 
   ASSERT_EQ(statistics1, statistics2);
 
+  // Test NULL_COUNT_EXACT
   statistics1.null_count = 29;
   ASSERT_NE(statistics1, statistics2);
   statistics2.null_count = 29;
+  ASSERT_EQ(statistics1, statistics2);
+
+  // Test NULL_COUNT_APPROXIMATE
+  statistics1.null_count = 29.0;
+  ASSERT_NE(statistics1, statistics2);
+  statistics2.null_count = 29.0;
   ASSERT_EQ(statistics1, statistics2);
 
   // Test DISTINCT_COUNT_EXACT

--- a/cpp/src/arrow/array/statistics_test.cc
+++ b/cpp/src/arrow/array/statistics_test.cc
@@ -33,12 +33,12 @@ TEST(TestArrayStatistics, NullCountExact) {
   ASSERT_EQ(29, std::get<int64_t>(statistics.null_count.value()));
 }
 
-TEST(TestArrayStatistics, NullCountAprroximate) {
+TEST(TestArrayStatistics, NullCountApproximate) {
   ArrayStatistics statistics;
   ASSERT_FALSE(statistics.null_count.has_value());
   statistics.null_count = 29.0;
   ASSERT_TRUE(statistics.null_count.has_value());
-  ASSERT_EQ(29.0, std::get<double>(statistics.null_count.value()));
+  ASSERT_DOUBLE_EQ(29.0, std::get<double>(statistics.null_count.value()));
 }
 
 TEST(TestArrayStatistics, DistinctCountExact) {

--- a/cpp/src/arrow/compare.cc
+++ b/cpp/src/arrow/compare.cc
@@ -1563,7 +1563,8 @@ bool ArrayStatisticsOptionalValueEquals(const std::optional<Type>& left,
 
 bool ArrayStatisticsEqualsImpl(const ArrayStatistics& left, const ArrayStatistics& right,
                                const EqualOptions& equal_options) {
-  return left.null_count == right.null_count &&
+  return ArrayStatisticsOptionalValueEquals(left.null_count, right.null_count,
+                                            equal_options) &&
          ArrayStatisticsOptionalValueEquals(left.distinct_count, right.distinct_count,
                                             equal_options) &&
          ArrayStatisticsOptionalValueEquals(left.max_byte_width, right.max_byte_width,

--- a/cpp/src/arrow/record_batch.cc
+++ b/cpp/src/arrow/record_batch.cc
@@ -541,14 +541,13 @@ Status EnumerateStatistics(const RecordBatch& record_batch, OnStatistics on_stat
         statistics.type = int64();
         statistics.value = std::get<int64_t>(column_statistics->null_count.value());
         RETURN_NOT_OK(on_statistics(statistics));
-        statistics.start_new_column = false;
       } else {
         statistics.key = ARROW_STATISTICS_KEY_NULL_COUNT_APPROXIMATE;
         statistics.type = float64();
         statistics.value = std::get<double>(column_statistics->null_count.value());
         RETURN_NOT_OK(on_statistics(statistics));
-        statistics.start_new_column = false;
       }
+      statistics.start_new_column = false;
     }
 
     if (column_statistics->distinct_count.has_value()) {

--- a/cpp/src/arrow/record_batch.cc
+++ b/cpp/src/arrow/record_batch.cc
@@ -536,11 +536,19 @@ Status EnumerateStatistics(const RecordBatch& record_batch, OnStatistics on_stat
     statistics.nth_column = nth_column;
     if (column_statistics->null_count.has_value()) {
       statistics.nth_statistics++;
-      statistics.key = ARROW_STATISTICS_KEY_NULL_COUNT_EXACT;
-      statistics.type = int64();
-      statistics.value = column_statistics->null_count.value();
-      RETURN_NOT_OK(on_statistics(statistics));
-      statistics.start_new_column = false;
+      if (std::holds_alternative<int64_t>(column_statistics->null_count.value())) {
+        statistics.key = ARROW_STATISTICS_KEY_NULL_COUNT_EXACT;
+        statistics.type = int64();
+        statistics.value = std::get<int64_t>(column_statistics->null_count.value());
+        RETURN_NOT_OK(on_statistics(statistics));
+        statistics.start_new_column = false;
+      } else {
+        statistics.key = ARROW_STATISTICS_KEY_NULL_COUNT_APPROXIMATE;
+        statistics.type = float64();
+        statistics.value = std::get<double>(column_statistics->null_count.value());
+        RETURN_NOT_OK(on_statistics(statistics));
+        statistics.start_new_column = false;
+      }
     }
 
     if (column_statistics->distinct_count.has_value()) {

--- a/cpp/src/parquet/arrow/arrow_statistics_test.cc
+++ b/cpp/src/parquet/arrow/arrow_statistics_test.cc
@@ -22,7 +22,6 @@
 #include "arrow/array/builder_time.h"
 #include "arrow/table.h"
 #include "arrow/testing/gtest_util.h"
-#include "arrow/util/logger.h"
 
 #include "parquet/api/reader.h"
 #include "parquet/api/writer.h"

--- a/cpp/src/parquet/arrow/arrow_statistics_test.cc
+++ b/cpp/src/parquet/arrow/arrow_statistics_test.cc
@@ -22,6 +22,7 @@
 #include "arrow/array/builder_time.h"
 #include "arrow/table.h"
 #include "arrow/testing/gtest_util.h"
+#include "arrow/util/logger.h"
 
 #include "parquet/api/reader.h"
 #include "parquet/api/writer.h"
@@ -236,7 +237,8 @@ void TestStatisticsReadArray(std::shared_ptr<::arrow::DataType> arrow_type) {
   auto statistics = typed_read_array->statistics();
   ASSERT_NE(nullptr, statistics);
   ASSERT_EQ(true, statistics->null_count.has_value());
-  ASSERT_EQ(1, statistics->null_count.value());
+  ASSERT_EQ(true, std::holds_alternative<int64_t>(statistics->null_count.value()));
+  ASSERT_EQ(1, std::get<int64_t>(statistics->null_count.value()));
   ASSERT_EQ(false, statistics->distinct_count.has_value());
   ASSERT_EQ(true, statistics->min.has_value());
   ASSERT_EQ(true, std::holds_alternative<MinMaxType>(*statistics->min));
@@ -356,7 +358,8 @@ TEST(TestStatisticsRead, MultipleRowGroupsShouldLoadStatistics) {
   auto statistics = typed_read_array->statistics();
   ASSERT_NE(nullptr, statistics);
   ASSERT_EQ(true, statistics->null_count.has_value());
-  ASSERT_EQ(1, statistics->null_count.value());
+  ASSERT_EQ(true, std::holds_alternative<int64_t>(statistics->null_count.value()));
+  ASSERT_EQ(1, std::get<int64_t>(statistics->null_count.value()));
   ASSERT_EQ(false, statistics->distinct_count.has_value());
   ASSERT_EQ(true, statistics->min.has_value());
   // This is not -1 because this array has only the first 2 elements.

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -766,10 +766,24 @@ cdef class ArrayStatistics(_Weakrefable):
         null_count = self.sp_statistics.get().null_count
         # We'll be able to simplify this after
         # https://github.com/cython/cython/issues/6692 is solved.
-        if null_count.has_value():
-            return null_count.value()
-        else:
+        if not null_count.has_value():
             return None
+        value = null_count.value()
+        if holds_alternative[int64_t](value):
+            return get[int64_t](value)
+        else:
+            return get[double](value)
+
+    @property
+    def is_null_count_exact(self):
+        """
+        Whether the number of distinct values is a valid exact value or not.
+        """
+        null_count = self.sp_statistics.get().null_count
+        if not null_count.has_value():
+            return False
+        value = null_count.value()
+        return holds_alternative[int64_t](value)
 
     @property
     def distinct_count(self):

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -777,7 +777,7 @@ cdef class ArrayStatistics(_Weakrefable):
     @property
     def is_null_count_exact(self):
         """
-        Whether the number of distinct values is a valid exact value or not.
+        Whether the number of null values is a valid exact value or not.
         """
         null_count = self.sp_statistics.get().null_count
         if not null_count.has_value():

--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -206,7 +206,7 @@ cdef extern from "arrow/api.h" namespace "arrow" nogil:
     c_bool is_numeric(Type type)
 
     cdef cppclass CArrayStatistics" arrow::ArrayStatistics":
-        optional[int64_t] null_count
+        optional[CArrayStatisticsCountType] null_count
         optional[CArrayStatisticsCountType] distinct_count
         optional[CArrayStatisticsValueType] min
         c_bool is_min_exact

--- a/python/pyarrow/tests/parquet/test_parquet_file.py
+++ b/python/pyarrow/tests/parquet/test_parquet_file.py
@@ -346,6 +346,7 @@ def test_read_statistics():
     buf.seek(0)
 
     statistics = pq.ParquetFile(buf).read().columns[0].chunks[0].statistics
+    assert statistics.is_null_count_exact is True
     assert statistics.null_count == 1
     assert statistics.distinct_count is None
     # TODO: add tests for is_distinct_count_exact == None and True

--- a/ruby/red-arrow/lib/arrow/array-statistics.rb
+++ b/ruby/red-arrow/lib/arrow/array-statistics.rb
@@ -17,6 +17,18 @@
 
 module Arrow
   class ArrayStatistics
+    if method_defined?(:null_count_exact)
+      alias_method :null_count_raw, :null_count
+      def null_count
+        return nil unless has_null_count?
+        if null_count_exact?
+          null_count_exact
+        else
+          null_count_approximate
+        end
+      end
+    end
+
     if method_defined?(:distinct_count_exact)
       alias_method :distinct_count_raw, :distinct_count
       def distinct_count

--- a/ruby/red-parquet/test/test-array-statistics.rb
+++ b/ruby/red-parquet/test/test-array-statistics.rb
@@ -27,6 +27,16 @@ class TestArrayStatistics < Test::Unit::TestCase
     @statistics = loaded_table[:int64].data.chunks[0].statistics
   end
 
+  def test_null_count
+    assert do
+      @statistics.has_null_count?
+    end
+    assert do
+      @statistics.null_count_exact?
+    end
+    assert_equal(1, @statistics.null_count)
+  end
+
   def test_distinct_count
     assert do
       not @statistics.has_distinct_count?


### PR DESCRIPTION
### Rationale for this change

Enable `ARROW:null_count:approximate` support for `arrow::ArrayStatistics`, along with the corresponding GLib, Ruby and Python bindings.

### What changes are included in this PR?

Enable `ARROW:null_count:approximate` in C++ and bind it to `ArrayStatistics` in GLib, Ruby and Python.

### Are these changes tested?

Yes, I ran the relevant unit tests.

### Are there any user-facing changes?

Yes.

* The type of `arrow::ArrayStatistics::null_count` has been changed from `std::optional<int64_t>` to `std::optional<CountType>`
* New `garrow_array_statistics_is_null_count_exact()`/`garrow_array_statistics_get_null_count_{exact,approximate}()` functions in GLib.
* Add support for approximate value in `Arrow::ArrayStatistics#null_count` in Ruby.
* A new field `is_null_count_exact` has been added to `ArrayStatistics` in Python.


* GitHub Issue: #47103