### PR TITLE
GH-47970: [CI][C++] Fix a bug that JNI jobs runs nothing

### DIFF
--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -207,6 +207,9 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
+      - name: Free up disk space
+        run: |
+          ci/scripts/util_free_space.sh
       - name: Cache Docker Volumes
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:

--- a/ci/docker/cpp-jni.dockerfile
+++ b/ci/docker/cpp-jni.dockerfile
@@ -21,9 +21,6 @@ FROM ${base}
 ARG arch
 ARG arch_short
 
-SHELL ["/bin/bash", "-i", "-c"]
-ENTRYPOINT ["/bin/bash", "-i", "-c"]
-
 # Install basic dependencies
 RUN dnf install -y \
     autoconf \

--- a/ci/docker/cpp-jni.dockerfile
+++ b/ci/docker/cpp-jni.dockerfile
@@ -105,4 +105,5 @@ RUN --mount=type=secret,id=github_repository_owner \
 
 ENV ARROW_BUILD_TESTS=ON \
     ARROW_CMAKE_ARGS="-DARROW_BUILD_TESTS=ON" \
-    CMAKE_PRESET=ninja-${CMAKE_BUILD_TYPE}-jni-linux
+    CMAKE_PRESET=ninja-${CMAKE_BUILD_TYPE}-jni-linux \
+    VCPKG_TARGET_TRIPLET=${VCPKG_DEFAULT_TRIPLET}


### PR DESCRIPTION
### Rationale for this change

If we use `bash -i -c` as `ENTRYPOINT`, we need to pass command line as a string such as `archery docker run cpp-jni 'ls -la'` not `archery docker run cpp-jni ls -lah`.

Our `compose.yaml` assumes the latter style. So our command line in `compose.yaml` is ignored.

### What changes are included in this PR?

Remove needless `SHELL` and `ENTRYPOINT`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #47970