### PR TITLE
GH-47975: [Docs][Python] Remove experimental warning on PyCapsule documentation

### DIFF
--- a/docs/source/format/CDataInterface/PyCapsuleInterface.rst
+++ b/docs/source/format/CDataInterface/PyCapsuleInterface.rst
@@ -22,8 +22,6 @@
 The Arrow PyCapsule Interface
 =============================
 
-.. warning:: The Arrow PyCapsule Interface should be considered experimental
-
 Rationale
 =========
 


### PR DESCRIPTION
### Rationale for this change

Follow up from discussion on the mailing list thread:
https://lists.apache.org/thread/ncfmmd1429qjsr07j5f5ds177w4wb2s6

The documentation reads:
> Warning:
> The Arrow PyCapsule Interface should be considered experimental

There haven't been major updates to the PyCapsule Interface during the last 2 years, since it was created and has seen widespread usage as tracked on [this comment](https://github.com/apache/arrow/issues/39195#issuecomment-2245718008). The only big change was adding C Device.

### What changes are included in this PR?

Remove experimental note from the documentation.
I've validated there are no notes on the code / API about experimental around the PyCapsule Interface.

### Are these changes tested?

No

### Are there any user-facing changes?

Yes, PyCapsule won't be considered experimental anymore.

* GitHub Issue: #47975