### PR TITLE
GH-47966: [Python] PyArrow v22.0 assumes Pandas DataFrame attrs are serializable

### DIFF
--- a/python/pyarrow/pandas_compat.py
+++ b/python/pyarrow/pandas_compat.py
@@ -277,6 +277,15 @@ def construct_metadata(columns_to_convert, df, column_names, index_levels,
 
     attributes = df.attrs if hasattr(df, "attrs") else {}
 
+    try:
+        json.dumps(attributes)
+    except (TypeError, OverflowError):
+        attributes = {}
+        warnings.warn(
+            "Could not serialize pd.attrs, "
+            "defaulting to empty attributes",
+            UserWarning, stacklevel=4)
+
     return {
         b'pandas': json.dumps({
             'index_columns': index_descriptors,

--- a/python/pyarrow/pandas_compat.py
+++ b/python/pyarrow/pandas_compat.py
@@ -279,11 +279,11 @@ def construct_metadata(columns_to_convert, df, column_names, index_levels,
 
     try:
         json.dumps(attributes)
-    except (TypeError, OverflowError):
+    except Exception as e:
         attributes = {}
         warnings.warn(
-            "Could not serialize pd.attrs, "
-            "defaulting to empty attributes",
+            f"Could not serialize pd.DataFrame.attrs: {e},"
+            f" defaulting to empty attributes.",
             UserWarning, stacklevel=4)
 
     return {

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -5274,7 +5274,7 @@ def test_json_unserializable_pd_df_attrs():
 
     with pytest.warns(
         UserWarning,
-        match=r"Could not serialize pd.DataFrame.attrs: \w+",
+        match="Could not serialize pd.DataFrame.attrs:",
     ):
         df_table = pa.table(df)
 

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -5265,3 +5265,19 @@ def test_bytes_column_name_to_pandas():
 def test_is_data_frame_race_condition():
     # See https://github.com/apache/arrow/issues/39313
     test_util.invoke_script('arrow_39313.py')
+
+
+def test_json_unserializable_pd_attrs():
+    df = pd.DataFrame({"x": [1, 2, 3]})
+
+    df.attrs["timestamp"] = datetime.fromisoformat("2025-10-28T14:20:42")
+
+    with pytest.warns(
+        UserWarning,
+        match="Could not serialize pd.attrs, defaulting to empty attributes",
+    ):
+        df_table = pa.table(df)
+
+    pd_metadata = json.loads(df_table.schema.metadata[b"pandas"])
+
+    assert not pd_metadata["attributes"]

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -5267,14 +5267,14 @@ def test_is_data_frame_race_condition():
     test_util.invoke_script('arrow_39313.py')
 
 
-def test_json_unserializable_pd_attrs():
+def test_json_unserializable_pd_df_attrs():
     df = pd.DataFrame({"x": [1, 2, 3]})
 
     df.attrs["timestamp"] = datetime.fromisoformat("2025-10-28T14:20:42")
 
     with pytest.warns(
         UserWarning,
-        match="Could not serialize pd.attrs, defaulting to empty attributes",
+        match=r"Could not serialize pd.DataFrame.attrs: \w+",
     ):
         df_table = pa.table(df)
 


### PR DESCRIPTION
### Rationale for this change
Please see #47966, #47147 assumed that pandas attributes should be JSON serializable, whilst they shouldn't be

### What changes are included in this PR?
Checked if serializing the pandas attributes raises any errors (`TypeError` and `OverflowError`), default to emptying the attributes if that's the case and raise a warning that the attributes were emptied.

### Are these changes tested?
Yes 

### Are there any user-facing changes?
No, fixing a regression

* GitHub Issue: #47966