### PR TITLE
GH-47978: [C++][Parquet][CI] Add more compression codecs to fuzzing seed corpus

### DIFF
--- a/cpp/src/parquet/arrow/reader.cc
+++ b/cpp/src/parquet/arrow/reader.cc
@@ -1416,7 +1416,8 @@ Status FuzzReader(std::unique_ptr<FileReader> reader) {
 Status FuzzReader(const uint8_t* data, int64_t size) {
   auto buffer = std::make_shared<::arrow::Buffer>(data, size);
   Status st;
-  for (auto batch_size : std::vector<std::optional<int>>{std::nullopt, 1, 13, 300}) {
+  // Note that very small batch sizes probably make fuzzing slower
+  for (auto batch_size : std::vector<std::optional<int>>{std::nullopt, 13, 300}) {
     auto file = std::make_shared<::arrow::io::BufferReader>(buffer);
     FileReaderBuilder builder;
     ArrowReaderProperties properties;

--- a/cpp/src/parquet/properties.h
+++ b/cpp/src/parquet/properties.h
@@ -321,8 +321,6 @@ class PARQUET_EXPORT WriterProperties {
           content_defined_chunking_options_(
               properties.content_defined_chunking_options()) {}
 
-    virtual ~Builder() {}
-
     /// \brief EXPERIMENTAL: Use content-defined page chunking for all columns.
     ///
     /// Optimize parquet files for content addressable storage (CAS) systems by writing
@@ -1183,7 +1181,6 @@ class PARQUET_EXPORT ArrowWriterProperties {
           use_threads_(kArrowDefaultUseThreads),
           executor_(NULLPTR),
           write_time_adjusted_to_utc_(false) {}
-    virtual ~Builder() = default;
 
     /// \brief Disable writing legacy int96 timestamps (default disabled).
     Builder* disable_deprecated_int96_timestamps() {


### PR DESCRIPTION
### Rationale for this change

1. Add more compression codecs to seed corpus
2. Tweak fuzz target to make fuzzing slightly faster (around ~30% locally according to my measurements), which will allow testing more mutations per day

### Are these changes tested?

Not specifically by CI, but hopefully they will make fuzzing more efficient.

### Are there any user-facing changes?

No.
* GitHub Issue: #47978