### PR TITLE
GH-47933: [Release][R] Don't upload *.sha512.{asc,sha512}

### DIFF
--- a/dev/release/05-binary-upload.sh
+++ b/dev/release/05-binary-upload.sh
@@ -86,15 +86,18 @@ upload_to_github_release() {
     local base_name
     base_name="$(basename "${target}")"
     cp -a "${target}" "${dist_dir}/${base_name}"
-    gpg \
-      --armor \
-      --detach-sign \
-      --local-user "${GPG_KEY_ID}" \
-      --output "${dist_dir}/${base_name}.asc" \
-      "${target}"
-    pushd "${dist_dir}"
-    shasum -a 512 "${base_name}" >"${base_name}.sha512"
-    popd
+    # Skip signing/checksumming .sha512 files (e.g., R binaries already include checksums from CI)
+    if [[ "${base_name}" != *.sha512 ]]; then
+      gpg \
+        --armor \
+        --detach-sign \
+        --local-user "${GPG_KEY_ID}" \
+        --output "${dist_dir}/${base_name}.asc" \
+        "${target}"
+      pushd "${dist_dir}"
+      shasum -a 512 "${base_name}" >"${base_name}.sha512"
+      popd
+    fi
   done
   gh release upload \
     --repo apache/arrow \


### PR DESCRIPTION
### Rationale for this change

R binary CI jobs already create `.sha512` checksum files, but the upload script was signing and checksumming them again, creating redundant `.sha512.asc`  and `.sha512.sha512` files.

### What changes are included in this PR?

Skip signing and checksumming for files that already end in `.sha512`.

### Are these changes tested?

Reviewed manually. The bash pattern matching correctly identifies and skips `.sha512` files.

### Are there any user-facing changes?

No. This only reduces redundant files in release artifacts.


* GitHub Issue: #47933