### PR TITLE
GH-47983: [CI][R] R nightly upload workflow failing for a few weeks

### DIFF
--- a/.github/workflows/r_nightly.yml
+++ b/.github/workflows/r_nightly.yml
@@ -128,6 +128,7 @@ jobs:
             pattern = "r-lib",
             recursive = TRUE
           )
+          current_path <- c(current_pkg_path, current_lib_path)
           files <- c(
             sub("r-pkg", repo_root, current_pkg_path),
             sub("r-lib", paste0(repo_root, "__r-lib"), current_lib_path),

--- a/.github/workflows/r_nightly.yml
+++ b/.github/workflows/r_nightly.yml
@@ -131,7 +131,7 @@ jobs:
           current_path <- c(current_pkg_path, current_lib_path)
           files <- c(
             sub("r-pkg", repo_root, current_pkg_path),
-            sub("r-lib", paste0(repo_root, "__r-lib"), current_lib_path),
+            sub("r-lib", paste0(repo_root, "__r-lib"), current_lib_path)
           )
 
           # decode contrib.url from artifact name:


### PR DESCRIPTION
### Rationale for this change

PR #47727 refactored the R nightly upload workflow to handle r-pkg and r-lib files separately, but we needed to update the variable name used by `file.copy()`, causing the workflow to fail with "object 'current_path' not found" error.

### What changes are included in this PR?

Add `current_path <- c(current_pkg_path, current_lib_path)` to combine the two path vectors before the `file.copy()` call on line 145.

### Are these changes tested?

No

### Are there any user-facing changes?

No
* GitHub Issue: #47983