### PR TITLE
GH-47973: [C++][Parquet] Fix invalid Parquet files written when dictionary encoded pages are large

### DIFF
--- a/cpp/src/arrow/util/bit_stream_utils_internal.h
+++ b/cpp/src/arrow/util/bit_stream_utils_internal.h
@@ -198,7 +198,9 @@ inline bool BitWriter::PutValue(uint64_t v, int num_bits) {
     ARROW_DCHECK_EQ(v >> num_bits, 0) << "v = " << v << ", num_bits = " << num_bits;
   }
 
-  if (ARROW_PREDICT_FALSE(byte_offset_ * 8 + bit_offset_ + num_bits > max_bytes_ * 8))
+  if (ARROW_PREDICT_FALSE(static_cast<int64_t>(byte_offset_) * 8 + bit_offset_ +
+                              num_bits >
+                          static_cast<int64_t>(max_bytes_) * 8))
     return false;
 
   buffered_values_ |= v << bit_offset_;

--- a/cpp/src/arrow/util/bit_stream_utils_internal.h
+++ b/cpp/src/arrow/util/bit_stream_utils_internal.h
@@ -59,7 +59,7 @@ class BitWriter {
   int buffer_len() const { return max_bytes_; }
 
   /// Writes a value to buffered_values_, flushing to buffer_ if necessary.  This is bit
-  /// packed.  Returns false if there was not enough space. num_bits must be <= 32.
+  /// packed.  Returns false if there was not enough space. num_bits must be <= 64.
   bool PutValue(uint64_t v, int num_bits);
 
   /// Writes v to the next aligned byte using num_bytes. If T is larger than

--- a/cpp/src/arrow/util/rle_encoding_internal.h
+++ b/cpp/src/arrow/util/rle_encoding_internal.h
@@ -514,32 +514,30 @@ class RleBitPackedEncoder {
   /// Returns the minimum buffer size needed to use the encoder for 'bit_width'
   /// This is the maximum length of a single run for 'bit_width'.
   /// It is not valid to pass a buffer less than this length.
-  static int MinBufferSize(int bit_width) {
+  static int64_t MinBufferSize(int bit_width) {
     // 1 indicator byte and MAX_VALUES_PER_LITERAL_RUN 'bit_width' values.
-    int max_literal_run_size = 1 + static_cast<int>(::arrow::bit_util::BytesForBits(
-                                       MAX_VALUES_PER_LITERAL_RUN * bit_width));
+    int64_t max_literal_run_size =
+        1 + ::arrow::bit_util::BytesForBits(MAX_VALUES_PER_LITERAL_RUN * bit_width);
     // Up to kMaxVlqByteLength indicator and a single 'bit_width' value.
-    int max_repeated_run_size =
-        bit_util::kMaxLEB128ByteLenFor<int32_t> +
-        static_cast<int>(::arrow::bit_util::BytesForBits(bit_width));
+    int64_t max_repeated_run_size = bit_util::kMaxLEB128ByteLenFor<int32_t> +
+                                    ::arrow::bit_util::BytesForBits(bit_width);
     return std::max(max_literal_run_size, max_repeated_run_size);
   }
 
   /// Returns the maximum byte size it could take to encode 'num_values'.
-  static int MaxBufferSize(int bit_width, int num_values) {
+  static int64_t MaxBufferSize(int bit_width, int64_t num_values) {
     // For a bit_width > 1, the worst case is the repetition of "literal run of length 8
     // and then a repeated run of length 8".
     // 8 values per smallest run, 8 bits per byte
-    int bytes_per_run = bit_width;
-    int num_runs = static_cast<int>(::arrow::bit_util::CeilDiv(num_values, 8));
-    int literal_max_size = num_runs + num_runs * bytes_per_run;
+    int64_t bytes_per_run = bit_width;
+    int64_t num_runs = ::arrow::bit_util::CeilDiv(num_values, 8);
+    int64_t literal_max_size = num_runs + num_runs * bytes_per_run;
 
     // In the very worst case scenario, the data is a concatenation of repeated
     // runs of 8 values. Repeated run has a 1 byte varint followed by the
     // bit-packed repeated value
-    int min_repeated_run_size =
-        1 + static_cast<int>(::arrow::bit_util::BytesForBits(bit_width));
-    int repeated_max_size = num_runs * min_repeated_run_size;
+    int64_t min_repeated_run_size = 1 + ::arrow::bit_util::BytesForBits(bit_width);
+    int64_t repeated_max_size = num_runs * min_repeated_run_size;
 
     return std::max(literal_max_size, repeated_max_size);
   }

--- a/cpp/src/arrow/util/rle_encoding_internal.h
+++ b/cpp/src/arrow/util/rle_encoding_internal.h
@@ -1423,7 +1423,7 @@ inline int RleBitPackedEncoder::Flush() {
 }
 
 inline void RleBitPackedEncoder::CheckBufferFull() {
-  int bytes_written = bit_writer_.bytes_written();
+  int64_t bytes_written = bit_writer_.bytes_written();
   if (bytes_written + max_run_byte_size_ > bit_writer_.buffer_len()) {
     buffer_full_ = true;
   }

--- a/cpp/src/arrow/util/rle_encoding_internal.h
+++ b/cpp/src/arrow/util/rle_encoding_internal.h
@@ -506,7 +506,7 @@ class RleBitPackedEncoder {
       : bit_width_(bit_width), bit_writer_(buffer, buffer_len) {
     ARROW_DCHECK_GE(bit_width_, 0);
     ARROW_DCHECK_LE(bit_width_, 64);
-    max_run_byte_size_ = MinBufferSize(bit_width);
+    max_run_byte_size_ = static_cast<int>(MinBufferSize(bit_width));
     ARROW_DCHECK_GE(buffer_len, max_run_byte_size_) << "Input buffer not big enough.";
     Clear();
   }

--- a/cpp/src/arrow/util/rle_encoding_test.cc
+++ b/cpp/src/arrow/util/rle_encoding_test.cc
@@ -813,7 +813,7 @@ TEST(BitRle, RepeatedPattern) {
 
 TEST(BitRle, Overflow) {
   for (int bit_width = 1; bit_width < 32; bit_width += 3) {
-    int len = RleBitPackedEncoder::MinBufferSize(bit_width);
+    int len = static_cast<int>(RleBitPackedEncoder::MinBufferSize(bit_width));
     std::vector<uint8_t> buffer(len);
     int num_added = 0;
     bool parity = true;
@@ -861,7 +861,8 @@ void CheckRoundTrip(const Array& data, int bit_width, bool spaced, int32_t parts
   const int data_size = static_cast<int>(data.length());
   const int data_values_count =
       static_cast<int>(data.length() - spaced * data.null_count());
-  const int buffer_size = RleBitPackedEncoder::MaxBufferSize(bit_width, data_size);
+  const int buffer_size =
+      static_cast<int>(RleBitPackedEncoder::MaxBufferSize(bit_width, data_size));
   ASSERT_GE(parts, 1);
   ASSERT_LE(parts, data_size);
 

--- a/cpp/src/parquet/column_writer_test.cc
+++ b/cpp/src/parquet/column_writer_test.cc
@@ -1005,18 +1005,17 @@ TEST(TestColumnWriter, ReproInvalidDictIndex) {
   auto file_writer = ParquetFileWriter::Open(sink, schema, properties);
   auto rg_writer = file_writer->AppendRowGroup();
 
-  constexpr int32_t num_batches = 50'000'000;
-  constexpr int32_t batch_size = 3;
+  constexpr int32_t num_batches = 150;
+  constexpr int32_t batch_size = 1'000'000;
   constexpr int32_t unique_count = 200'000;
 
   std::vector<int32_t> values(batch_size, 0);
 
-  std::default_random_engine gen(1);
-  std::uniform_int_distribution<int32_t> val_dist(0, unique_count - 1);
-
   auto col_writer = static_cast<parquet::Int32Writer*>(rg_writer->NextColumn());
   for (int32_t i = 0; i < num_batches; i++) {
-    values[0] = val_dist(gen);
+    for (int32_t j = 0; j < batch_size; j++) {
+      values[j] = j % unique_count;
+    }
     col_writer->WriteBatch(batch_size, nullptr, nullptr, values.data());
   }
   file_writer->Close();

--- a/cpp/src/parquet/column_writer_test.cc
+++ b/cpp/src/parquet/column_writer_test.cc
@@ -993,6 +993,87 @@ TEST_F(TestValuesWriterInt32Type, PagesSplitWithListAlignedWrites) {
   ASSERT_EQ(values_out_, values_);
 }
 
+TEST(TestColumnWriter, ReproInvalidDictIndex) {
+  auto sink = CreateOutputStream();
+  auto schema = std::static_pointer_cast<GroupNode>(GroupNode::Make(
+      "schema", Repetition::REQUIRED,
+      {
+          GroupNode::Make(
+              "x", Repetition::OPTIONAL,
+              {GroupNode::Make(
+                  "list", Repetition::REPEATED,
+                  {PrimitiveNode::Make("item", Repetition::REQUIRED, Type::FLOAT)})},
+              LogicalType::List()),
+      }));
+  auto properties =
+      WriterProperties::Builder().data_pagesize(1024 * 1024 * 1024)->build();
+  auto file_writer = ParquetFileWriter::Open(sink, schema, properties);
+  auto rg_writer = file_writer->AppendRowGroup();
+
+  constexpr int32_t num_rows = 50'000'000;
+  constexpr float nan_proportion = 0.6f;
+  constexpr int32_t unique_count = 200'000;
+
+  std::vector<int16_t> def_levels(3, 2);
+  std::vector<int16_t> rep_levels(3, 1);
+  std::vector<float> values(3, 0.0f);
+  rep_levels[0] = 0;
+
+  std::default_random_engine gen(1);
+  std::uniform_int_distribution<int32_t> val_dist(0, unique_count - 1);
+  std::uniform_real_distribution<float_t> nan_dist(0.0f, 1.0f);
+
+  auto col_writer = static_cast<parquet::FloatWriter*>(rg_writer->NextColumn());
+  for (int32_t i = 0; i < num_rows; i++) {
+    if (nan_dist(gen) < nan_proportion) {
+      values[0] = std::numeric_limits<float>::quiet_NaN();
+    } else {
+      values[0] = static_cast<float>(val_dist(gen)) / 100.0f;
+    }
+    col_writer->WriteBatch(3, def_levels.data(), rep_levels.data(), values.data());
+  }
+  file_writer->Close();
+
+  ASSERT_OK_AND_ASSIGN(auto buffer, sink->Finish());
+
+  auto file_reader = ParquetFileReader::Open(
+      std::make_shared<::arrow::io::BufferReader>(buffer), default_reader_properties());
+  auto metadata = file_reader->metadata();
+  ASSERT_EQ(1, metadata->num_row_groups());
+  auto row_group_reader = file_reader->RowGroup(0);
+  auto col_reader = std::static_pointer_cast<FloatReader>(row_group_reader->Column(0));
+
+  auto page_reader = row_group_reader->GetColumnPageReader(0);
+  int64_t page_count = 0;
+  while (true) {
+    auto page = page_reader->NextPage();
+    if (page == nullptr) {
+      break;
+    }
+    if (page_count == 0) {
+      ASSERT_EQ(page->type(), PageType::DICTIONARY_PAGE);
+    } else {
+      ASSERT_EQ(page->type(), PageType::DATA_PAGE);
+    }
+    page_count++;
+  }
+  ASSERT_EQ(page_count, 2);
+
+  constexpr size_t buffer_size = 1024 * 1024;
+  def_levels.resize(buffer_size);
+  rep_levels.resize(buffer_size);
+  values.resize(buffer_size);
+
+  size_t levels_read = 0;
+  while (levels_read < num_rows * 3) {
+    int64_t batch_values;
+    int64_t batch_levels = col_reader->ReadBatch(
+        buffer_size, def_levels.data(), rep_levels.data(), values.data(), &batch_values);
+    levels_read += batch_levels;
+  }
+  std::cout << "Read " << levels_read << " levels" << std::endl;
+}
+
 TEST(TestPageWriter, ThrowsOnPagesTooLarge) {
   NodePtr item = schema::Int32("item");  // optional item
   NodePtr list(GroupNode::Make("b", Repetition::REPEATED, {item}, ConvertedType::LIST));


### PR DESCRIPTION
### Rationale for this change

Prevents silently writing invalid data when using dictionary encoding and the number of bits in the estimated max buffer size is greater than the max int32 value.

Also fixes an overflow resulting in a "Negative buffer resize" error if the buffer size in bytes is greater than max int32, and instead throw a more helpful exception.

### What changes are included in this PR?

* Fix overflow when computing the bit position in `BitWriter::PutValue`. This overflow would cause the method to return without writing data, and the return value is only checked in debug builds.
* Change buffer size calculations to use int64 and check for overflow before casting to int

### Are these changes tested?

Yes, I've added unit tests for both issues. These require enabling `ARROW_LARGE_MEMORY_TESTS` as they allocate a lot of memory.

### Are there any user-facing changes?

**This PR contains a "Critical Fix".**

This fixes a bug where invalid Parquet files can be silently written when the buffer size for dictionary indices is large.

* GitHub Issue: #47973