### PR TITLE
GH-47728: [Python] Check the source argument in parquet.read_table

### DIFF
--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -1887,10 +1887,23 @@ def read_table(source, *, columns=None, use_threads=True,
                 "the 'schema' argument is not supported when the "
                 "pyarrow.dataset module is not available"
             )
+        if isinstance(source, list):
+            raise ValueError(
+                "the 'source' argument cannot be a list of files "
+                "when the pyarrow.dataset is not available"
+            )
+
         filesystem, path = _resolve_filesystem_and_path(source, filesystem)
         if filesystem is not None:
-            source = filesystem.open_input_file(path)
-        # TODO test that source is not a directory or a list
+            try:
+                source = filesystem.open_input_file(path)
+            except (OSError, FileNotFoundError) as e:
+                raise ValueError(
+                    "the 'source' argument should be "
+                    "an existing .parquet file and not a directory, "
+                    "when the pyarrow.dataset is not available"
+                ) from e
+
         dataset = ParquetFile(
             source, read_dictionary=read_dictionary,
             binary_type=binary_type,

--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -1890,19 +1890,19 @@ def read_table(source, *, columns=None, use_threads=True,
         if isinstance(source, list):
             raise ValueError(
                 "the 'source' argument cannot be a list of files "
-                "when the pyarrow.dataset is not available"
+                "when the pyarrow.dataset module is not available"
             )
 
         filesystem, path = _resolve_filesystem_and_path(source, filesystem)
         if filesystem is not None:
-            try:
-                source = filesystem.open_input_file(path)
-            except (OSError, FileNotFoundError) as e:
+            if not filesystem.get_file_info(path).is_file:
                 raise ValueError(
                     "the 'source' argument should be "
                     "an existing .parquet file and not a directory, "
-                    "when the pyarrow.dataset is not available"
-                ) from e
+                    "when the pyarrow.dataset module is not available"
+                )
+
+            source = filesystem.open_input_file(path)
 
         dataset = ParquetFile(
             source, read_dictionary=read_dictionary,

--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -1898,7 +1898,7 @@ def read_table(source, *, columns=None, use_threads=True,
             if not filesystem.get_file_info(path).is_file:
                 raise ValueError(
                     "the 'source' argument should be "
-                    "an existing .parquet file and not a directory, "
+                    "an existing parquet file and not a directory "
                     "when the pyarrow.dataset module is not available"
                 )
 

--- a/python/pyarrow/tests/parquet/test_basic.py
+++ b/python/pyarrow/tests/parquet/test_basic.py
@@ -16,6 +16,7 @@
 # under the License.
 
 import os
+import sys
 from collections import OrderedDict
 import io
 import warnings
@@ -993,3 +994,14 @@ def test_checksum_write_to_dataset(tempdir):
     # checksum verification enabled raises an exception
     with pytest.raises(OSError, match="CRC checksum verification"):
         _ = pq.read_table(corrupted_file_path, page_checksum_verification=True)
+
+
+@pytest.mark.parametrize(
+    "source", ["/tmp/", ["/tmp/file1.parquet", "/tmp/file2.parquet"]])
+def test_read_table_raises_value_error_when_ds_is_unavailable(
+    monkeypatch, source):
+    # GH-47728
+    monkeypatch.setitem(sys.modules, "pyarrow.dataset", None)
+
+    with pytest.raises(ValueError):
+        pq.read_table(source=source)

--- a/python/pyarrow/tests/parquet/test_basic.py
+++ b/python/pyarrow/tests/parquet/test_basic.py
@@ -186,8 +186,7 @@ def test_read_table_without_dataset(tempdir):
             pq.read_table(path, partitioning=['week', 'color'])
         with pytest.raises(ValueError, match="the 'schema' argument"):
             pq.read_table(path, schema=table.schema)
-        # Error message varies depending on OS
-        with pytest.raises(OSError):
+        with pytest.raises(ValueError, match="the 'source' argument"):
             pq.read_table(tempdir)
         result = pq.read_table(path)
         assert result == table

--- a/python/pyarrow/tests/parquet/test_basic.py
+++ b/python/pyarrow/tests/parquet/test_basic.py
@@ -1003,5 +1003,5 @@ def test_read_table_raises_value_error_when_ds_is_unavailable(
     # GH-47728
     monkeypatch.setitem(sys.modules, "pyarrow.dataset", None)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="the 'source' argument"):
         pq.read_table(source=source)

--- a/python/pyarrow/tests/parquet/test_basic.py
+++ b/python/pyarrow/tests/parquet/test_basic.py
@@ -999,7 +999,7 @@ def test_checksum_write_to_dataset(tempdir):
 @pytest.mark.parametrize(
     "source", ["/tmp/", ["/tmp/file1.parquet", "/tmp/file2.parquet"]])
 def test_read_table_raises_value_error_when_ds_is_unavailable(
-    monkeypatch, source):
+        monkeypatch, source):
     # GH-47728
     monkeypatch.setitem(sys.modules, "pyarrow.dataset", None)
 

--- a/python/pyarrow/tests/parquet/test_basic.py
+++ b/python/pyarrow/tests/parquet/test_basic.py
@@ -997,8 +997,7 @@ def test_checksum_write_to_dataset(tempdir):
 
 @pytest.mark.parametrize(
     "source", ["/tmp/", ["/tmp/file1.parquet", "/tmp/file2.parquet"]])
-def test_read_table_raises_value_error_when_ds_is_unavailable(
-        monkeypatch, source):
+def test_read_table_raises_value_error_when_ds_is_unavailable(monkeypatch, source):
     # GH-47728
     monkeypatch.setitem(sys.modules, "pyarrow.dataset", None)
 


### PR DESCRIPTION
### Rationale for this change
See #47728. Check `source` argument in `pyarrow.parquet.read_table` if `pyarrow.dataset` is not available.

### What changes are included in this PR?
Check the `source` argument, raise `ValueError` if the `source` argument is either a list of `.parquet` files or a directory.

### Are these changes tested?
Yes

### Are there any user-facing changes?
No

In case if the `source` argument is a directory, I decided not to check it directly, but to catch the exceptions coming from the `fs.open_input_file`, since it already checks for it, and add extra exception on top of the stack that explains the actual reason.
* GitHub Issue: #47728