### PR TITLE
GH-31869: [Python][Parquet] Implement external key material features in Python

### DIFF
--- a/cpp/src/parquet/encryption/file_system_key_material_store.cc
+++ b/cpp/src/parquet/encryption/file_system_key_material_store.cc
@@ -25,7 +25,7 @@
 
 #include "parquet/encryption/file_system_key_material_store.h"
 #include "parquet/encryption/key_material.h"
-#include "parquet/exception.h"
+
 
 namespace parquet::encryption {
 

--- a/cpp/src/parquet/encryption/file_system_key_material_store.cc
+++ b/cpp/src/parquet/encryption/file_system_key_material_store.cc
@@ -26,7 +26,6 @@
 #include "parquet/encryption/file_system_key_material_store.h"
 #include "parquet/encryption/key_material.h"
 
-
 namespace parquet::encryption {
 
 constexpr const char FileSystemKeyMaterialStore::kKeyMaterialFilePrefix[];

--- a/cpp/src/parquet/encryption/file_system_key_material_store.h
+++ b/cpp/src/parquet/encryption/file_system_key_material_store.h
@@ -24,6 +24,7 @@
 #include "arrow/filesystem/filesystem.h"
 
 #include "parquet/encryption/file_key_material_store.h"
+#include "parquet/exception.h"
 
 namespace parquet::encryption {
 
@@ -59,6 +60,9 @@ class PARQUET_EXPORT FileSystemKeyMaterialStore : public FileKeyMaterialStore {
       LoadKeyMaterialMap();
     }
     auto found = key_material_map_.find(key_id_in_file);
+    if (found == key_material_map_.end()) {
+      throw ParquetException("Invalid key id");
+    } 
     return found->second;
   }
 

--- a/cpp/src/parquet/encryption/file_system_key_material_store.h
+++ b/cpp/src/parquet/encryption/file_system_key_material_store.h
@@ -62,7 +62,7 @@ class PARQUET_EXPORT FileSystemKeyMaterialStore : public FileKeyMaterialStore {
     auto found = key_material_map_.find(key_id_in_file);
     if (found == key_material_map_.end()) {
       throw ParquetException("Invalid key id");
-    } 
+    }
     return found->second;
   }
 

--- a/python/pyarrow/_parquet_encryption.pxd
+++ b/python/pyarrow/_parquet_encryption.pxd
@@ -49,6 +49,14 @@ cdef class KmsConnectionConfig(_Weakrefable):
     @staticmethod
     cdef wrap(const CKmsConnectionConfig& config)
 
+cdef class KeyMaterial(_Weakrefable):
+    cdef shared_ptr[CKeyMaterial] key_material
+
+    @staticmethod
+    cdef inline KeyMaterial wrap(shared_ptr[CKeyMaterial] key_material)
+
+cdef class FileSystemKeyMaterialStore(_Weakrefable):
+    cdef shared_ptr[CFileSystemKeyMaterialStore] store
 
 cdef shared_ptr[CCryptoFactory] pyarrow_unwrap_cryptofactory(object crypto_factory) except *
 cdef shared_ptr[CKmsConnectionConfig] pyarrow_unwrap_kmsconnectionconfig(object kmsconnectionconfig) except *

--- a/python/pyarrow/_parquet_encryption.pyx
+++ b/python/pyarrow/_parquet_encryption.pyx
@@ -433,7 +433,7 @@ cdef class CryptoFactory(_Weakrefable):
 
         filesystem : FileSystem, default None
             Used only when internal_key_material is set to False on 
-            EncryptionConfiguration. If nothinng passed, will be inferred
+            EncryptionConfiguration. If None, the file system will be inferred
             based on parquet_file_path. 
 
         Returns
@@ -489,7 +489,7 @@ cdef class CryptoFactory(_Weakrefable):
 
         filesystem : FileSystem, default None
             Used only when the parquet file uses external key material. If
-            nothinng passed, will be inferred based on parquet_file_path. 
+            None, the file system will be inferred based on parquet_file_path. 
 
         Returns
         -------
@@ -533,7 +533,7 @@ cdef class CryptoFactory(_Weakrefable):
             self,
             KmsConnectionConfig kms_connection_config,
             parquet_file_path, 
-            FileSystem filesystem,
+            FileSystem filesystem=None,
             double_wrapping = True,
             cache_lifetime_seconds = 600):
         """ Rotates master encryption keys for a Parquet file that uses
@@ -549,23 +549,17 @@ cdef class CryptoFactory(_Weakrefable):
 
         filesystem : FileSystem, default None
             Used only when the parquet file uses external key material. If
-            nothinng passed, will be inferred based on parquet_file_path. 
+            None, the file system will be inferred based on parquet_file_path. 
 
         double_wrapping : bool, default True
-            In the single wrapping mode, decrypts data keys with old master
-            keys, then encrypts them with new master keys. In the double
-            wrapping mode, decrypts KEKs (key encryption keys) with old 
-            master keys, generates new KEKs and encrypts them with new master
-            keys.
+            In the single wrapping mode, encrypts data encryption keys with
+            new master keys. In the double wrapping mode, generates new
+            KEKs (key encryption keys) and uses these to encrypt the data keys,
+            and encrypts the KEKs with the new master keys.
 
         cache_lifetime_seconds : int or float, default 600
             During key rotation, KMS Client and Key Encryption Keys will be
             cached for this duration.
-
-        Returns
-        -------
-        file_decryption_properties : FileDecryptionProperties
-            File decryption properties.
         """
         cdef:
             c_string c_parquet_file_path
@@ -585,7 +579,7 @@ cdef class CryptoFactory(_Weakrefable):
             double_wrapping,
             cache_lifetime_seconds);
 
-        return check_status(status)
+        check_status(status)
 
     cdef inline shared_ptr[CPyCryptoFactory] unwrap(self):
         return self.factory
@@ -667,7 +661,7 @@ cdef class FileSystemKeyMaterialStore(_Weakrefable):
             Path to a parquet file using external key material.
 
         filesystem : FileSystem, default None
-            FileSystem where the parquet file is located. If nothinng passed,
+            FileSystem where the parquet file is located. If None,
             will be inferred based on parquet_file_path. 
 
         Returns

--- a/python/pyarrow/_parquet_encryption.pyx
+++ b/python/pyarrow/_parquet_encryption.pyx
@@ -28,7 +28,7 @@ from pyarrow.includes.libarrow cimport *
 from pyarrow.lib cimport check_status
 from pyarrow.lib cimport _Weakrefable
 from pyarrow.lib import tobytes, frombytes
-from pyarrow._fs cimport FileSystem 
+from pyarrow._fs cimport FileSystem
 from pyarrow.fs import _resolve_filesystem_and_path
 
 cdef ParquetCipher cipher_from_name(name):
@@ -409,7 +409,6 @@ cdef class CryptoFactory(_Weakrefable):
             static_pointer_cast[CKmsClientFactory, CPyKmsClientFactory](
                 kms_client_factory))
 
-
     def file_encryption_properties(self,
                                    KmsConnectionConfig kms_connection_config,
                                    EncryptionConfiguration encryption_config,
@@ -470,7 +469,6 @@ cdef class CryptoFactory(_Weakrefable):
             DecryptionConfiguration decryption_config=None,
             parquet_file_path="",
             FileSystem filesystem=None):
-
         """Create file decryption properties.
 
         Parameters
@@ -532,10 +530,10 @@ cdef class CryptoFactory(_Weakrefable):
     def rotate_master_keys(
             self,
             KmsConnectionConfig kms_connection_config,
-            parquet_file_path, 
+            parquet_file_path,
             FileSystem filesystem=None,
-            double_wrapping = True,
-            cache_lifetime_seconds = 600):
+            double_wrapping=True,
+            cache_lifetime_seconds=600):
         """ Rotates master encryption keys for a Parquet file that uses
         external key material.
 
@@ -577,13 +575,13 @@ cdef class CryptoFactory(_Weakrefable):
             c_parquet_file_path,
             c_filesystem,
             double_wrapping,
-            cache_lifetime_seconds);
+            cache_lifetime_seconds)
 
         check_status(status)
 
     cdef inline shared_ptr[CPyCryptoFactory] unwrap(self):
         return self.factory
-    
+
 cdef class KeyMaterial(_Weakrefable):
 
     @property
@@ -626,7 +624,7 @@ cdef class KeyMaterial(_Weakrefable):
 
     @staticmethod
     def parse(
-        const c_string key_material_string):
+            const c_string key_material_string):
         cdef:
             shared_ptr[CKeyMaterial] c_key_material
         c_key_material = make_shared[CKeyMaterial](move(
@@ -650,8 +648,8 @@ cdef class FileSystemKeyMaterialStore(_Weakrefable):
         return self.store.get().GetKeyIDSet()
 
     @classmethod
-    def for_file(cls, parquet_file_path, 
-                          FileSystem filesystem = None):
+    def for_file(cls, parquet_file_path,
+                 FileSystem filesystem=None):
         """Creates a FileSystemKeyMaterialStore for a parquet file that
         was created with external key material.
 
@@ -681,9 +679,9 @@ cdef class FileSystemKeyMaterialStore(_Weakrefable):
         c_filesystem = _unwrap_fs(filesystem)
 
         c_store = CFileSystemKeyMaterialStore.Make(
-                c_parquet_file_path, c_filesystem, False)
+            c_parquet_file_path, c_filesystem, False)
         store.store = c_store
-        return store 
+        return store
 
 cdef shared_ptr[CCryptoFactory] pyarrow_unwrap_cryptofactory(object crypto_factory) except *:
     if isinstance(crypto_factory, CryptoFactory):

--- a/python/pyarrow/_parquet_encryption.pyx
+++ b/python/pyarrow/_parquet_encryption.pyx
@@ -30,7 +30,6 @@ from pyarrow.lib cimport _Weakrefable
 from pyarrow.lib import tobytes, frombytes
 from pyarrow._fs cimport FileSystem 
 from pyarrow.fs import _resolve_filesystem_and_path
-import json
 
 cdef ParquetCipher cipher_from_name(name):
     name = name.upper()
@@ -659,6 +658,23 @@ cdef class FileSystemKeyMaterialStore(_Weakrefable):
     @classmethod
     def for_file(cls, parquet_file_path, 
                           FileSystem filesystem = None):
+        """Creates a FileSystemKeyMaterialStore for a parquet file that
+        was created with external key material.
+
+        Parameters
+        ----------
+        parquet_file_path : str or pathlib.Path
+            Path to a parquet file using external key material.
+
+        filesystem : FileSystem, default None
+            FileSystem where the parquet file is located. If nothinng passed,
+            will be inferred based on parquet_file_path. 
+
+        Returns
+        -------
+        FileSystemKeyMaterialStore
+            A FileSystemKeyMaterialStore wrapping the external key material.
+        """
         cdef:
             c_string c_parquet_file_path
             shared_ptr[CFileSystem] c_filesystem

--- a/python/pyarrow/_parquet_encryption.pyx
+++ b/python/pyarrow/_parquet_encryption.pyx
@@ -412,7 +412,7 @@ cdef class CryptoFactory(_Weakrefable):
     def file_encryption_properties(self,
                                    KmsConnectionConfig kms_connection_config,
                                    EncryptionConfiguration encryption_config,
-                                   parquet_file_path="",
+                                   parquet_file_path=None,
                                    FileSystem filesystem=None):
         """Create file encryption properties.
 
@@ -424,7 +424,7 @@ cdef class CryptoFactory(_Weakrefable):
         encryption_config : EncryptionConfiguration
             Configuration of the encryption, such as which columns to encrypt
 
-        parquet_file_path : str or pathlib.Path, default ""
+        parquet_file_path : str, pathlib.Path or None, default None
             Path to the parquet file to be encrypted. Only required when the
             internal_key_material attribute of EncryptionConfiguration is set
             to False. Used to derive the path for storing key material 
@@ -446,11 +446,12 @@ cdef class CryptoFactory(_Weakrefable):
             c_string c_parquet_file_path
             shared_ptr[CFileSystem] c_filesystem
 
-        if parquet_file_path != "":
-            filesystem, parquet_file_path = _resolve_filesystem_and_path(
-                parquet_file_path, filesystem)
-
-        c_parquet_file_path = tobytes(parquet_file_path)
+        filesystem, parquet_file_path = _resolve_filesystem_and_path(
+            parquet_file_path, filesystem)
+        if parquet_file_path is not None:
+            c_parquet_file_path = tobytes(parquet_file_path)
+        else:
+            c_parquet_file_path = tobytes("")
         c_filesystem = _unwrap_fs(filesystem)
 
         with nogil:
@@ -467,7 +468,7 @@ cdef class CryptoFactory(_Weakrefable):
             self,
             KmsConnectionConfig kms_connection_config,
             DecryptionConfiguration decryption_config=None,
-            parquet_file_path="",
+            parquet_file_path=None,
             FileSystem filesystem=None):
         """Create file decryption properties.
 
@@ -480,7 +481,7 @@ cdef class CryptoFactory(_Weakrefable):
             Configuration of the decryption, such as cache timeout.
             Can be None.
 
-        parquet_file_path : str or pathlib.Path, default ""
+        parquet_file_path : str, pathlib.Path or None, default None
             Path to the parquet file to be decrypted. Only required when
             the parquet file uses external key material.  Used to derive
             the path to the external key material file.
@@ -501,11 +502,12 @@ cdef class CryptoFactory(_Weakrefable):
             c_string c_parquet_file_path
             shared_ptr[CFileSystem] c_filesystem
 
-        if parquet_file_path != "":
-            filesystem, parquet_file_path = _resolve_filesystem_and_path(
-                parquet_file_path, filesystem)
-
-        c_parquet_file_path = tobytes(parquet_file_path)
+        filesystem, parquet_file_path = _resolve_filesystem_and_path(
+            parquet_file_path, filesystem)
+        if parquet_file_path is not None:
+            c_parquet_file_path = tobytes(parquet_file_path)
+        else:
+            c_parquet_file_path = tobytes("")
         c_filesystem = _unwrap_fs(filesystem)
 
         if decryption_config is None:

--- a/python/pyarrow/_parquet_encryption.pyx
+++ b/python/pyarrow/_parquet_encryption.pyx
@@ -424,13 +424,13 @@ cdef class CryptoFactory(_Weakrefable):
         encryption_config : EncryptionConfiguration
             Configuration of the encryption, such as which columns to encrypt
 
-        parquet_file_path : str, pathlib.Path or None, default None
+        parquet_file_path : str, pathlib.Path, or None, default None
             Path to the parquet file to be encrypted. Only required when the
             internal_key_material attribute of EncryptionConfiguration is set
             to False. Used to derive the path for storing key material 
             specific to this parquet file.
 
-        filesystem : FileSystem, default None
+        filesystem : FileSystem or None, default None
             Used only when internal_key_material is set to False on 
             EncryptionConfiguration. If None, the file system will be inferred
             based on parquet_file_path. 
@@ -481,12 +481,12 @@ cdef class CryptoFactory(_Weakrefable):
             Configuration of the decryption, such as cache timeout.
             Can be None.
 
-        parquet_file_path : str, pathlib.Path or None, default None
+        parquet_file_path : str, pathlib.Path, or None, default None
             Path to the parquet file to be decrypted. Only required when
             the parquet file uses external key material.  Used to derive
             the path to the external key material file.
 
-        filesystem : FileSystem, default None
+        filesystem : FileSystem or None, default None
             Used only when the parquet file uses external key material. If
             None, the file system will be inferred based on parquet_file_path. 
 
@@ -547,7 +547,7 @@ cdef class CryptoFactory(_Weakrefable):
         parquet_file_path : str or pathlib.Path
             Path to a parquet file using external key material.
 
-        filesystem : FileSystem, default None
+        filesystem : FileSystem or None, default None
             Used only when the parquet file uses external key material. If
             None, the file system will be inferred based on parquet_file_path. 
 

--- a/python/pyarrow/includes/libparquet_encryption.pxd
+++ b/python/pyarrow/includes/libparquet_encryption.pxd
@@ -19,6 +19,7 @@
 
 from pyarrow.includes.common cimport *
 from pyarrow.includes.libarrow cimport CSecureString
+from pyarrow.includes.libarrow_fs cimport CFileSystem
 from pyarrow._parquet cimport (ParquetCipher,
                                CFileEncryptionProperties,
                                CFileDecryptionProperties,
@@ -91,12 +92,57 @@ cdef extern from "parquet/encryption/crypto_factory.h" \
             shared_ptr[CKmsClientFactory] kms_client_factory) except +
         shared_ptr[CFileEncryptionProperties] GetFileEncryptionProperties(
             const CKmsConnectionConfig& kms_connection_config,
-            const CEncryptionConfiguration& encryption_config) except +*
+            const CEncryptionConfiguration& encryption_config,
+            const c_string parquet_file_path,
+            const shared_ptr[CFileSystem] file_system) except +*
         shared_ptr[CFileDecryptionProperties] GetFileDecryptionProperties(
             const CKmsConnectionConfig& kms_connection_config,
-            const CDecryptionConfiguration& decryption_config) except +*
+            const CDecryptionConfiguration& decryption_config,
+            const c_string parquet_file_path,
+            const shared_ptr[CFileSystem] file_system) except +*
         void RemoveCacheEntriesForToken(const c_string& access_token) except +
         void RemoveCacheEntriesForAllTokens() except +
+        void RotateMasterKeys(const CKmsConnectionConfig& kms_connection_config,
+            const c_string parquet_file_path,
+            const shared_ptr[CFileSystem] file_system,
+            c_bool double_wrapping,
+            double cache_lifetime_seconds)
+
+cdef extern from "parquet/encryption/file_key_material_store.h" \
+        namespace "parquet::encryption" nogil:
+    cdef cppclass CFileKeyMaterialStore\
+            "parquet::encryption::FileKeyMaterialStore":
+        @staticmethod
+        c_string GetKeyMaterial(c_string key_id_in_file) except +
+        vector[c_string] GetKeyIDSet() except +
+
+cdef extern from "parquet/encryption/file_system_key_material_store.h" \
+        namespace "parquet::encryption" nogil:
+    cdef cppclass CFileSystemKeyMaterialStore\
+            "parquet::encryption::FileSystemKeyMaterialStore":
+
+        @staticmethod
+        shared_ptr[CFileSystemKeyMaterialStore] Make(c_string parquet_file_path, 
+                shared_ptr[CFileSystem] file_system,
+                c_bool use_tmp_prefix) except +
+
+        c_string GetKeyMaterial(c_string key_id_in_file) except +
+        
+        vector[c_string] GetKeyIDSet() except +
+
+cdef extern from "parquet/encryption/key_material.h" \
+        namespace "parquet::encryption" nogil:
+    cdef cppclass CKeyMaterial "parquet::encryption::KeyMaterial":
+        @staticmethod
+        CKeyMaterial Parse(const c_string& key_material_string);
+        c_bool is_footer_key()
+        c_bool is_double_wrapped()
+        const c_string& master_key_id()
+        const c_string& wrapped_dek()
+        const c_string& kek_id()
+        const c_string& wrapped_kek()
+        const c_string& kms_instance_id()
+        const c_string& kms_instance_url()
 
 cdef extern from "arrow/python/parquet_encryption.h" \
         namespace "arrow::py::parquet::encryption" nogil:
@@ -125,8 +171,17 @@ cdef extern from "arrow/python/parquet_encryption.h" \
         CResult[shared_ptr[CFileEncryptionProperties]] \
             SafeGetFileEncryptionProperties(
             const CKmsConnectionConfig& kms_connection_config,
-            const CEncryptionConfiguration& encryption_config)
+            const CEncryptionConfiguration& encryption_config,
+            const c_string parquet_file_path,
+            const shared_ptr[CFileSystem] filesystem)
         CResult[shared_ptr[CFileDecryptionProperties]] \
             SafeGetFileDecryptionProperties(
             const CKmsConnectionConfig& kms_connection_config,
-            const CDecryptionConfiguration& decryption_config)
+            const CDecryptionConfiguration& decryption_config,
+            const c_string parquet_file_path,
+            const shared_ptr[CFileSystem] filesystem)
+        CStatus SafeRotateMasterKeys(const CKmsConnectionConfig& kms_connection_config,
+            const c_string parquet_file_path,
+            const shared_ptr[CFileSystem] filesystem,
+            c_bool double_wrapping,
+            double cache_lifetime_seconds)

--- a/python/pyarrow/includes/libparquet_encryption.pxd
+++ b/python/pyarrow/includes/libparquet_encryption.pxd
@@ -103,10 +103,10 @@ cdef extern from "parquet/encryption/crypto_factory.h" \
         void RemoveCacheEntriesForToken(const c_string& access_token) except +
         void RemoveCacheEntriesForAllTokens() except +
         void RotateMasterKeys(const CKmsConnectionConfig& kms_connection_config,
-            const c_string parquet_file_path,
-            const shared_ptr[CFileSystem] file_system,
-            c_bool double_wrapping,
-            double cache_lifetime_seconds)
+                              const c_string parquet_file_path,
+                              const shared_ptr[CFileSystem] file_system,
+                              c_bool double_wrapping,
+                              double cache_lifetime_seconds)
 
 cdef extern from "parquet/encryption/file_key_material_store.h" \
         namespace "parquet::encryption" nogil:
@@ -122,19 +122,19 @@ cdef extern from "parquet/encryption/file_system_key_material_store.h" \
             "parquet::encryption::FileSystemKeyMaterialStore":
 
         @staticmethod
-        shared_ptr[CFileSystemKeyMaterialStore] Make(c_string parquet_file_path, 
-                shared_ptr[CFileSystem] file_system,
-                c_bool use_tmp_prefix) except +
+        shared_ptr[CFileSystemKeyMaterialStore] Make(c_string parquet_file_path,
+                                                     shared_ptr[CFileSystem] file_system,
+                                                     c_bool use_tmp_prefix) except +
 
         c_string GetKeyMaterial(c_string key_id_in_file) except +
-        
+
         vector[c_string] GetKeyIDSet() except +
 
 cdef extern from "parquet/encryption/key_material.h" \
         namespace "parquet::encryption" nogil:
     cdef cppclass CKeyMaterial "parquet::encryption::KeyMaterial":
         @staticmethod
-        CKeyMaterial Parse(const c_string& key_material_string);
+        CKeyMaterial Parse(const c_string& key_material_string)
         c_bool is_footer_key()
         c_bool is_double_wrapped()
         const c_string& master_key_id()
@@ -181,7 +181,7 @@ cdef extern from "arrow/python/parquet_encryption.h" \
             const c_string parquet_file_path,
             const shared_ptr[CFileSystem] filesystem)
         CStatus SafeRotateMasterKeys(const CKmsConnectionConfig& kms_connection_config,
-            const c_string parquet_file_path,
-            const shared_ptr[CFileSystem] filesystem,
-            c_bool double_wrapping,
-            double cache_lifetime_seconds)
+                                     const c_string parquet_file_path,
+                                     const shared_ptr[CFileSystem] filesystem,
+                                     c_bool double_wrapping,
+                                     double cache_lifetime_seconds)

--- a/python/pyarrow/src/arrow/python/parquet_encryption.cc
+++ b/python/pyarrow/src/arrow/python/parquet_encryption.cc
@@ -82,9 +82,8 @@ PyCryptoFactory::SafeGetFileEncryptionProperties(
     const ::parquet::encryption::EncryptionConfiguration& encryption_config,
     const std::string& parquet_file_path,
     const std::shared_ptr<::arrow::fs::FileSystem>& filesystem) {
-  PARQUET_CATCH_AND_RETURN(
-      this->GetFileEncryptionProperties(kms_connection_config, encryption_config,
-        parquet_file_path, filesystem));
+  PARQUET_CATCH_AND_RETURN(this->GetFileEncryptionProperties(
+      kms_connection_config, encryption_config, parquet_file_path, filesystem));
 }
 
 arrow::Result<std::shared_ptr<::parquet::FileDecryptionProperties>>
@@ -93,20 +92,18 @@ PyCryptoFactory::SafeGetFileDecryptionProperties(
     const ::parquet::encryption::DecryptionConfiguration& decryption_config,
     const std::string& parquet_file_path,
     const std::shared_ptr<::arrow::fs::FileSystem>& filesystem) {
-  PARQUET_CATCH_AND_RETURN(
-      this->GetFileDecryptionProperties(kms_connection_config,
-        decryption_config, parquet_file_path, filesystem));
+  PARQUET_CATCH_AND_RETURN(this->GetFileDecryptionProperties(
+      kms_connection_config, decryption_config, parquet_file_path, filesystem));
 }
 
 arrow::Status PyCryptoFactory::SafeRotateMasterKeys(
     const ::parquet::encryption::KmsConnectionConfig& kms_connection_config,
     const std::string& parquet_file_path,
-    const std::shared_ptr<::arrow::fs::FileSystem>& filesystem,
-    bool double_wrapping,
-    double cache_lifetime_seconds) {    
-  PARQUET_CATCH_NOT_OK(
-      this->RotateMasterKeys(kms_connection_config, parquet_file_path,
-         filesystem, double_wrapping, cache_lifetime_seconds));
+    const std::shared_ptr<::arrow::fs::FileSystem>& filesystem, bool double_wrapping,
+    double cache_lifetime_seconds) {
+  PARQUET_CATCH_NOT_OK(this->RotateMasterKeys(kms_connection_config, parquet_file_path,
+                                              filesystem, double_wrapping,
+                                              cache_lifetime_seconds));
   return arrow::Status::OK();
 }
 

--- a/python/pyarrow/src/arrow/python/parquet_encryption.cc
+++ b/python/pyarrow/src/arrow/python/parquet_encryption.cc
@@ -79,17 +79,35 @@ std::shared_ptr<::parquet::encryption::KmsClient> PyKmsClientFactory::CreateKmsC
 arrow::Result<std::shared_ptr<::parquet::FileEncryptionProperties>>
 PyCryptoFactory::SafeGetFileEncryptionProperties(
     const ::parquet::encryption::KmsConnectionConfig& kms_connection_config,
-    const ::parquet::encryption::EncryptionConfiguration& encryption_config) {
+    const ::parquet::encryption::EncryptionConfiguration& encryption_config,
+    const std::string& parquet_file_path,
+    const std::shared_ptr<::arrow::fs::FileSystem>& filesystem) {
   PARQUET_CATCH_AND_RETURN(
-      this->GetFileEncryptionProperties(kms_connection_config, encryption_config));
+      this->GetFileEncryptionProperties(kms_connection_config, encryption_config,
+        parquet_file_path, filesystem));
 }
 
 arrow::Result<std::shared_ptr<::parquet::FileDecryptionProperties>>
 PyCryptoFactory::SafeGetFileDecryptionProperties(
     const ::parquet::encryption::KmsConnectionConfig& kms_connection_config,
-    const ::parquet::encryption::DecryptionConfiguration& decryption_config) {
+    const ::parquet::encryption::DecryptionConfiguration& decryption_config,
+    const std::string& parquet_file_path,
+    const std::shared_ptr<::arrow::fs::FileSystem>& filesystem) {
   PARQUET_CATCH_AND_RETURN(
-      this->GetFileDecryptionProperties(kms_connection_config, decryption_config));
+      this->GetFileDecryptionProperties(kms_connection_config,
+        decryption_config, parquet_file_path, filesystem));
+}
+
+arrow::Status PyCryptoFactory::SafeRotateMasterKeys(
+    const ::parquet::encryption::KmsConnectionConfig& kms_connection_config,
+    const std::string& parquet_file_path,
+    const std::shared_ptr<::arrow::fs::FileSystem>& filesystem,
+    bool double_wrapping,
+    double cache_lifetime_seconds) {    
+  PARQUET_CATCH_NOT_OK(
+      this->RotateMasterKeys(kms_connection_config, parquet_file_path,
+         filesystem, double_wrapping, cache_lifetime_seconds));
+  return arrow::Status::OK();
 }
 
 }  // namespace encryption

--- a/python/pyarrow/src/arrow/python/parquet_encryption.h
+++ b/python/pyarrow/src/arrow/python/parquet_encryption.h
@@ -18,9 +18,9 @@
 #pragma once
 
 #include <string>
-#include "arrow/result.h"
 #include "arrow/python/common.h"
 #include "arrow/python/visibility.h"
+#include "arrow/result.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/secure_string.h"
 #include "parquet/encryption/crypto_factory.h"
@@ -136,8 +136,7 @@ class ARROW_PYTHON_PARQUET_ENCRYPTION_EXPORT PyCryptoFactory
   arrow::Status SafeRotateMasterKeys(
       const ::parquet::encryption::KmsConnectionConfig& kms_connection_config,
       const std::string& parquet_file_path,
-      const std::shared_ptr<::arrow::fs::FileSystem>& filesystem,
-      bool double_wrapping,
+      const std::shared_ptr<::arrow::fs::FileSystem>& filesystem, bool double_wrapping,
       double cache_lifetime_seconds);
 };
 

--- a/python/pyarrow/src/arrow/python/parquet_encryption.h
+++ b/python/pyarrow/src/arrow/python/parquet_encryption.h
@@ -18,12 +18,14 @@
 #pragma once
 
 #include <string>
-
+#include "arrow/result.h"
 #include "arrow/python/common.h"
 #include "arrow/python/visibility.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/secure_string.h"
 #include "parquet/encryption/crypto_factory.h"
+#include "parquet/encryption/file_system_key_material_store.h"
+#include "parquet/encryption/key_material.h"
 #include "parquet/encryption/kms_client.h"
 #include "parquet/encryption/kms_client_factory.h"
 
@@ -116,7 +118,9 @@ class ARROW_PYTHON_PARQUET_ENCRYPTION_EXPORT PyCryptoFactory
   arrow::Result<std::shared_ptr<::parquet::FileEncryptionProperties>>
   SafeGetFileEncryptionProperties(
       const ::parquet::encryption::KmsConnectionConfig& kms_connection_config,
-      const ::parquet::encryption::EncryptionConfiguration& encryption_config);
+      const ::parquet::encryption::EncryptionConfiguration& encryption_config,
+      const std::string& parquet_file_path,
+      const std::shared_ptr<::arrow::fs::FileSystem>& filesystem);
 
   /// The returned FileDecryptionProperties object will use the cache inside this
   /// CryptoFactory object, so please keep this
@@ -125,7 +129,16 @@ class ARROW_PYTHON_PARQUET_ENCRYPTION_EXPORT PyCryptoFactory
   arrow::Result<std::shared_ptr<::parquet::FileDecryptionProperties>>
   SafeGetFileDecryptionProperties(
       const ::parquet::encryption::KmsConnectionConfig& kms_connection_config,
-      const ::parquet::encryption::DecryptionConfiguration& decryption_config);
+      const ::parquet::encryption::DecryptionConfiguration& decryption_config,
+      const std::string& parquet_file_path,
+      const std::shared_ptr<::arrow::fs::FileSystem>& filesystem);
+
+  arrow::Status SafeRotateMasterKeys(
+      const ::parquet::encryption::KmsConnectionConfig& kms_connection_config,
+      const std::string& parquet_file_path,
+      const std::shared_ptr<::arrow::fs::FileSystem>& filesystem,
+      bool double_wrapping,
+      double cache_lifetime_seconds);
 };
 
 }  // namespace encryption

--- a/python/pyarrow/tests/parquet/conftest.py
+++ b/python/pyarrow/tests/parquet/conftest.py
@@ -103,3 +103,8 @@ def s3_example_fs(s3_server):
     fs.create_dir("mybucket")
 
     yield fs, uri, path
+
+
+@pytest.fixture(scope="class")
+def reusable_tempdir(tmp_path_factory):
+    return tmp_path_factory.mktemp('encryption')

--- a/python/pyarrow/tests/parquet/conftest.py
+++ b/python/pyarrow/tests/parquet/conftest.py
@@ -107,4 +107,4 @@ def s3_example_fs(s3_server):
 
 @pytest.fixture(scope="class")
 def reusable_tempdir(tmp_path_factory):
-    return tmp_path_factory.mktemp('encryption')
+    return tmp_path_factory.mktemp('pyarrow-parquet')

--- a/python/pyarrow/tests/parquet/encryption.py
+++ b/python/pyarrow/tests/parquet/encryption.py
@@ -103,9 +103,6 @@ class MockVersioningKmsClient(pe.KmsClient):
                              key_id, master_key_identifier)
         return key
 
-    def key_version(self, wrapped_key: bytes) -> int:
-        return int.from_bytes(base64.b64decode(wrapped_key)[:16])
-
 
 def verify_file_encrypted(path):
     """Verify that the file is encrypted by looking at its first 4 bytes.

--- a/python/pyarrow/tests/parquet/encryption.py
+++ b/python/pyarrow/tests/parquet/encryption.py
@@ -15,8 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 import base64
-
 import pyarrow.parquet.encryption as pe
+from pyarrow._parquet_encryption import FileSystemKeyMaterialStore
+import re
 
 
 class InMemoryKmsClient(pe.KmsClient):
@@ -51,6 +52,61 @@ class InMemoryKmsClient(pe.KmsClient):
                          master_key_bytes, decrypted_key)
 
 
+def parse_wrapped_key(wrapped_key: str) -> tuple[str, int, bytes]:
+    """Parses a wrapped key string into a tuple: (key id, version, key) given
+    input in the form: <key id>:v<version>:<bas64 encoded key>"""
+    ptn = re.compile("(.+?):v([0-9]+?):(.+)")
+    if m := ptn.fullmatch(wrapped_key):
+        id, version, b64key = m.groups()
+        version = int(version)
+        key = base64.b64decode(b64key)
+        return (id, version, key)
+    else:
+        raise ValueError("Cannot parse wrapped key", wrapped_key)
+
+
+MASTER_KEY_VERSION = "master_key_version"
+
+
+class MockVersioningKmsClient(pe.KmsClient):
+    """This is a mock class implementation of KmsClient, built for testing
+    only.
+
+    During tests that involve CryptoFactory.rotate_master_keys, separate
+    instances of this client will be created when writing, rotating keys, and
+    reading back parquet data. To help unit tests verify that external key
+    material was stored correctly at each step, this client wraps keys with a
+    master_key_identifier and a version number. To ensure each client wraps
+    with the correct version, the current version is persisted in the
+    key_access_token attribute of the KmsConnectionConfig shared by all clients
+    """
+
+    def __init__(self, connection_config) -> None:
+        pe.KmsClient.__init__(self)
+        self.connection_config = connection_config
+
+    @property
+    def master_key_version(self) -> int:
+        return int(self.connection_config.key_access_token)
+
+    def wrap_key(self, key_bytes: bytes, master_key_identifier: str) -> str:
+        b64key = base64.b64encode(key_bytes).decode('utf-8')
+        return f"{master_key_identifier}:v{self.master_key_version}:{b64key}"
+
+    def unwrap_key(
+            self,
+            wrapped_key: str,
+            master_key_identifier: str) -> bytes:
+        key_id, _, key = parse_wrapped_key(wrapped_key)
+        if key_id != master_key_identifier:
+            raise ValueError("Mismatched master key identifiers:",
+                             key_id, master_key_identifier)
+        return key
+
+    def key_version(self, wrapped_key: bytes) -> int:
+        return int.from_bytes(base64.b64decode(wrapped_key)[:16])
+
+
 def verify_file_encrypted(path):
     """Verify that the file is encrypted by looking at its first 4 bytes.
     If it's the magic string PARE
@@ -59,3 +115,14 @@ def verify_file_encrypted(path):
         magic_str = file.read(4)
         # Verify magic string for parquet with encrypted footer is PARE
         assert magic_str == b'PARE'
+
+
+def read_external_keys_to_dict(path):
+    """Reads an external key material store given a parquet file path and
+    returns a dict mapping master_key_id to KeyMaterial objects"""
+    store = FileSystemKeyMaterialStore.for_file(path)
+    keys = dict()
+    for id in store.get_key_id_set():
+        key_material = store.get_key_material(id)
+        keys[key_material.master_key_id] = key_material
+    return keys

--- a/python/pyarrow/tests/parquet/test_encryption.py
+++ b/python/pyarrow/tests/parquet/test_encryption.py
@@ -556,8 +556,8 @@ def test_encrypted_parquet_write_read_external(tempdir, data_table,
         assert len(key_ids := store.get_key_id_set()) == (
             len(external_encryption_config.column_keys[COL_KEY_NAME]) + 1 )
         assert all([store.get_key_material(k) is not None for k in key_ids ])
-    except:
-        pytest.fail("Unable to read external key material store.")
+    except Exception as e:
+        pytest.fail(f"Unable to read external key material store: {e}")
     
     assert data_table.equals(result_table)
 

--- a/python/pyarrow/tests/parquet/test_encryption.py
+++ b/python/pyarrow/tests/parquet/test_encryption.py
@@ -16,7 +16,6 @@
 # under the License.
 import pytest
 from datetime import timedelta
-from hypothesis import given, strategies as st
 import pyarrow as pa
 try:
     import pyarrow.parquet as pq
@@ -563,7 +562,12 @@ def test_encrypted_parquet_write_read_external(tempdir, data_table,
     assert data_table.equals(result_table)
 
 
-@given(double_wrap_initial=st.booleans(), double_wrap_rotated=st.booleans())
+@pytest.mark.parametrize(
+    ("double_wrap_initial", "double_wrap_rotated"), [
+        pytest.param(True, True, id="double wrapping"),
+        pytest.param(False, True, id="single to double wrapped"),
+        pytest.param(True, False, id="double to singe wrapped"),
+        pytest.param(False, False, id="single wrapping")])
 def test_external_key_material_rotation(
         reusable_tempdir,
         data_table,
@@ -576,11 +580,7 @@ def test_external_key_material_rotation(
     EncryptionConfig.double_wrapping was set to true (also the default) when
     the external key material store was written. This means double wrapping may
     be set one way initially and then applied or removed during rotation.
-    When run as a regular pytest test, this function tests the default
-    scenario - double_wrapping before and after rotation.
-
-    A separate wrapper test function below is driven by hypothesis strategies
-    to run through the permutations."""
+    """
     path = reusable_tempdir / PARQUET_NAME
     encryption_config = pe.EncryptionConfiguration(
         footer_key=FOOTER_KEY_NAME,

--- a/python/pyarrow/tests/parquet/test_encryption.py
+++ b/python/pyarrow/tests/parquet/test_encryption.py
@@ -588,8 +588,7 @@ def test_external_key_material_rotation(
         double_wrapping=double_wrap_initial)
 
     # initial master key version - see MockVersioningKmsClient docstring
-    kms_connection_config = pe.KmsConnectionConfig(
-        key_access_token="1", custom_kms_conf={"master_key_version": "1"})
+    kms_connection_config = pe.KmsConnectionConfig(key_access_token="1")
 
     def kms_factory(kms_connection_configuration):
         return MockVersioningKmsClient(kms_connection_configuration)

--- a/python/pyarrow/tests/parquet/test_encryption.py
+++ b/python/pyarrow/tests/parquet/test_encryption.py
@@ -563,11 +563,12 @@ def test_encrypted_parquet_write_read_external(tempdir, data_table,
     assert data_table.equals(result_table)
 
 
+@given(double_wrap_initial=st.booleans(), double_wrap_rotated=st.booleans())
 def test_external_key_material_rotation(
-        tempdir,
+        reusable_tempdir,
         data_table,
-        double_wrap_initial=True,
-        double_wrap_rotated=True):
+        double_wrap_initial,
+        double_wrap_rotated):
     """Tests CryptoFactory.rotate_master_keys
 
     Note: The CryptoFactory.rotate_master_keys() double_wrapping keword arg
@@ -580,7 +581,7 @@ def test_external_key_material_rotation(
 
     A separate wrapper test function below is driven by hypothesis strategies
     to run through the permutations."""
-    path = tempdir / PARQUET_NAME
+    path = reusable_tempdir / PARQUET_NAME
     encryption_config = pe.EncryptionConfiguration(
         footer_key=FOOTER_KEY_NAME,
         column_keys={COL_KEY_NAME: ["a", "b"]},
@@ -642,21 +643,6 @@ def test_external_key_material_rotation(
     check_rotated_external_keys(FOOTER_KEY_NAME)
     check_rotated_external_keys(COL_KEY_NAME)
     assert data_table.equals(table_read_after_rotation)
-
-
-@given(double_wrap_initial=st.booleans(), double_wrap_rotated=st.booleans())
-def test_key_rotation_double_wrap_scenarios(
-        reusable_tempdir,
-        data_table,
-        double_wrap_initial,
-        double_wrap_rotated):
-    """Hypothesis driven wrapper test for runing through permutations of key
-    wrapping before/after key rotation."""
-    test_external_key_material_rotation(
-        reusable_tempdir,
-        data_table,
-        double_wrap_initial,
-        double_wrap_rotated)
 
 
 def test_encrypted_parquet_loop(tempdir, data_table, basic_encryption_config):


### PR DESCRIPTION
### Rationale for this change
Enables external key material and rotation for individual parquet files in PyArrow.  This change does not address any parquet dataset encryption functionality.  

### What changes are included in this PR?
This PR enables external key material for parquet encryption from PyArrow:
Optional parquet_file_path and FileSystem paramters to CryptoFactory - mirroring the interface for CryptoFactory in C++

1. Exposes the rotate_master_keys method of CryptoFactory

2. Adds Cython classes for FileKeyMaterialStore, FileSystemKeyMaterialStore, and KeyMaterial - but does not expose these from PyArrow encryption.  I included these changes only so that a unit test may verify an external store without leaking the implementation details for the store into the test.

### Are these changes tested?
Yes - I've modified an existing test (previously marked pytest.xfail) to do a basic read write test and verify creation of the external key material store and added a test for CryptoFactory.rotate_master_keys.

### Are there any user-facing changes?

1. Users may optionally supply a parquet file path and FileSystem to CryptoFactory methods that provide en/decryption_properties.  Doing so in conjunction with setting EncryptionConfiguration.internal_key_material=False enables external key material from pyarrow.
2. PyArrow CryptoFactory now has a rotate_master_keys method exposing key rotation functionality from C++ CryptoFactory.


* GitHub Issue: #31869