### PR TITLE
GH-47957: [CI][C++] ARM64 macOS 14 C++ fails on Substrait.ArrowSpecificLiterals test

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -235,7 +235,7 @@ jobs:
         run: |
           echo "Current protobuf version:"
           brew list --versions protobuf
-          brew uninstall protobuf
+          brew uninstall --ignore-dependencies protobuf
           brew install protobuf@32
           brew link protobuf@32 --force
           echo "Pinned protobuf version:"

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -235,11 +235,10 @@ jobs:
         run: |
           echo "Current protobuf version:"
           brew list --versions protobuf
-          brew uninstall --ignore-dependencies protobuf
-          # Install protobuf 32.1 from Homebrew formula before the 33.0 update (Oct 15)
+          # Reinstall protobuf 32.1 from Homebrew formula before the 33.0 update (Oct 15)
           # Using commit fb3f8063367841cdc08d81362969ce2f530d1ae3 from Sep 14, 2025
-          brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/fb3f8063367841cdc08d81362969ce2f530d1ae3/Formula/p/protobuf.rb
-          echo "Pinned protobuf version:"
+          brew reinstall https://raw.githubusercontent.com/Homebrew/homebrew-core/fb3f8063367841cdc08d81362969ce2f530d1ae3/Formula/p/protobuf.rb
+          echo "Downgraded protobuf version:"
           brew list --versions protobuf
       - name: Install MinIO
         run: |

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -236,10 +236,11 @@ jobs:
           echo "Current protobuf version:"
           brew list --versions protobuf
           brew uninstall --ignore-dependencies protobuf
-          brew install protobuf@32
-          brew link protobuf@32 --force
+          # Install protobuf 32.1 from Homebrew formula before the 33.0 update (Oct 15)
+          # Using commit fb3f8063367841cdc08d81362969ce2f530d1ae3 from Sep 14, 2025
+          brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/fb3f8063367841cdc08d81362969ce2f530d1ae3/Formula/p/protobuf.rb
           echo "Pinned protobuf version:"
-          brew list --versions protobuf@32
+          brew list --versions protobuf
       - name: Install MinIO
         run: |
           $(brew --prefix bash)/bin/bash \

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -230,6 +230,16 @@ jobs:
           brew uninstall pkg-config || :
           brew uninstall pkg-config@0.29.2 || :
           brew bundle --file=cpp/Brewfile
+      - name: Pin Protobuf to 32.1 for testing (GH-47957)
+        if: matrix.architecture == 'ARM64'
+        run: |
+          echo "Current protobuf version:"
+          brew list --versions protobuf
+          brew uninstall protobuf
+          brew install protobuf@32
+          brew link protobuf@32 --force
+          echo "Pinned protobuf version:"
+          brew list --versions protobuf@32
       - name: Install MinIO
         run: |
           $(brew --prefix bash)/bin/bash \


### PR DESCRIPTION
### Rationale for this change

Diagnostic PR to test the hypothesis that the ARM64 macOS substrait test failures are caused by a regression in protobuf 33.0.

### What changes are included in this PR?

Pin to earlier version

### Are these changes tested?

CI will tell

### Are there any user-facing changes?

Nah
* GitHub Issue: #47957