### PR TITLE
GH-47823: [Python] Use PyWeakref_GetRef instead of PyWeakref_GET_OBJECT (Python 3.15)

### DIFF
--- a/python/pyarrow/src/arrow/python/extension_type.cc
+++ b/python/pyarrow/src/arrow/python/extension_type.cc
@@ -22,6 +22,7 @@
 #include "arrow/python/extension_type.h"
 #include "arrow/python/helpers.h"
 #include "arrow/python/pyarrow.h"
+#include "arrow/python/vendored/pythoncapi_compat.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/logging.h"
 
@@ -164,15 +165,18 @@ PyObject* PyExtensionType::GetInstance() const {
     return nullptr;
   }
   ARROW_DCHECK(PyWeakref_CheckRef(type_instance_.obj()));
-  PyObject* inst = PyWeakref_GET_OBJECT(type_instance_.obj());
-  if (inst != Py_None) {
-    // Cached instance still alive
-    Py_INCREF(inst);
+  PyObject* inst = NULL;
+  int result = PyWeakref_GetRef(type_instance_.obj(), &inst);
+  if (result == 1) {
+    // Alive: inst is a new strong reference
     return inst;
-  } else {
-    // Must reconstruct from serialized form
+  } else if (result == 0) {
+    // Weakref is dead, must reconstruct from serialized form
     // XXX cache again?
     return DeserializeExtInstance(type_class_.obj(), storage_type_, serialized_);
+  } else {
+    // -1 = exception
+    return nullptr;
   }
 }
 


### PR DESCRIPTION
### Rationale for this change

pyarrow builds fail on CPython 3.15 due to the 3.15's removal of PyWeakref_GetObject, used in extension_types.cc. This was deprecated in 3.13. A backport is available in the already-vendored [pythoncapi_compat](https://github.com/apache/arrow/blob/main/python/pyarrow/src/arrow/python/vendored/pythoncapi_compat.h). 

Fixes https://github.com/apache/arrow/issues/47823. To be clear: this fixes only the build issue reported in the issue, not "3.15 support". 

### What changes are included in this PR?

Replaces the sole use of PyWeakref_GET_OBJECT with the backported version of PyWeakref_GetRef. 

This follows the recommendation from [Pending removal in Python 3.15](https://docs.python.org/3/deprecations/c-api-pending-removal-in-3.15.html) 
> [PyWeakref_GetObject()](https://docs.python.org/3/c-api/weakref.html#c.PyWeakref_GetObject) and [PyWeakref_GET_OBJECT()](https://docs.python.org/3/c-api/weakref.html#c.PyWeakref_GET_OBJECT): Use [PyWeakref_GetRef()](https://docs.python.org/3/c-api/weakref.html#c.PyWeakref_GetRef) instead. The [pythoncapi-compat project](https://github.com/python/pythoncapi-compat/) can be used to get [PyWeakref_GetRef()](https://docs.python.org/3/c-api/weakref.html#c.PyWeakref_GetRef) on Python 3.12 and older.


### Are these changes tested?
Build and tested on a local Ubuntu 24.04 build. 

### Are there any user-facing changes?
No user-facing changes. 


* GitHub Issue: #47823