### PR TITLE
GH-48029: [R][CI] R nightly upload workflow failing in pruning step

### DIFF
--- a/.github/workflows/r_nightly.yml
+++ b/.github/workflows/r_nightly.yml
@@ -160,20 +160,15 @@ jobs:
             ls -t "$@" | tail -n +$((KEEP + 1)) | xargs --no-run-if-empty rm
           }
 
-          # find leaf sub dirs
-          repo_dirs=$(find repo -type d -links 2)
-
-          # Debug: print what we found
-          echo "DEBUG: repo_dirs variable contains:"
-          echo "$repo_dirs"
-          echo "DEBUG: end of repo_dirs"
+          # find leaf sub dirs and store in array
+          mapfile -t repo_dirs < <(find repo -type d -links 2)
 
           # Old packages: repo/libarrow/bin/${TARGET}/arrow-${VERSION}.zip
           #
           # We want to retain $keep (14) versions of each pkg/lib so we call
           # prune on each leaf dir and not on repo/.
           for dir in "${repo_dirs[@]}"; do
-            prune $dir/arrow* || :
+            prune "$dir"/arrow* || :
           done
 
           # New packages: repo/libarrow/${TARGET}-arrow-${VERSION}.zip

--- a/.github/workflows/r_nightly.yml
+++ b/.github/workflows/r_nightly.yml
@@ -36,11 +36,6 @@ on:
     #Crossbow packaging runs at 0 8 * * *
     - cron: '0 14 * * *'
 
-  # TEMPORARY: For testing debug logging on PR #48030
-  pull_request:
-    paths:
-      - '.github/workflows/r_nightly.yml'
-
 permissions:
   contents: read
 

--- a/.github/workflows/r_nightly.yml
+++ b/.github/workflows/r_nightly.yml
@@ -153,6 +153,8 @@ jobs:
         env:
           KEEP: ${{ github.event.inputs.keep || 14 }}
         run: |
+          set -x
+
           prune() {
             # list files  | retain $KEEP newest files | delete everything else
             ls -t "$@" | tail -n +$((KEEP + 1)) | xargs --no-run-if-empty rm
@@ -160,6 +162,11 @@ jobs:
 
           # find leaf sub dirs
           repo_dirs=$(find repo -type d -links 2)
+
+          # Debug: print what we found
+          echo "DEBUG: repo_dirs variable contains:"
+          echo "$repo_dirs"
+          echo "DEBUG: end of repo_dirs"
 
           # Old packages: repo/libarrow/bin/${TARGET}/arrow-${VERSION}.zip
           #

--- a/.github/workflows/r_nightly.yml
+++ b/.github/workflows/r_nightly.yml
@@ -36,6 +36,11 @@ on:
     #Crossbow packaging runs at 0 8 * * *
     - cron: '0 14 * * *'
 
+  # TEMPORARY: For testing debug logging on PR #48030
+  pull_request:
+    paths:
+      - '.github/workflows/r_nightly.yml'
+
 permissions:
   contents: read
 

--- a/.github/workflows/r_nightly.yml
+++ b/.github/workflows/r_nightly.yml
@@ -166,7 +166,7 @@ jobs:
           # We want to retain $keep (14) versions of each pkg/lib so we call
           # prune on each leaf dir and not on repo/.
           for dir in "${repo_dirs[@]}"; do
-            prune $dir/arrow*
+            prune $dir/arrow* || :
           done
 
           # New packages: repo/libarrow/${TARGET}-arrow-${VERSION}.zip


### PR DESCRIPTION
### Rationale for this change

Arrow nightlies failing due to error

### What changes are included in this PR?

Add `|| :` so we don't error on missing dirs

### Are these changes tested?

They will be after the night time the nightlies run!

### Are there any user-facing changes?

No
* GitHub Issue: #48029