### PR TITLE
GH-47713: [C++][FlightRPC] ODBC SQLMoreResults implementation

### DIFF
--- a/cpp/src/arrow/flight/sql/odbc/odbc_api.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_api.cc
@@ -1142,8 +1142,14 @@ SQLRETURN SQLGetData(SQLHSTMT stmt, SQLUSMALLINT record_number, SQLSMALLINT c_ty
 
 SQLRETURN SQLMoreResults(SQLHSTMT stmt) {
   ARROW_LOG(DEBUG) << "SQLMoreResults called with stmt: " << stmt;
-  // GH-47713 TODO: Implement SQLMoreResults
-  return SQL_INVALID_HANDLE;
+
+  using ODBC::ODBCStatement;
+  // Multiple result sets are not supported by Arrow protocol. Return SQL_NO_DATA by
+  // default to indicate no data is available.
+  return ODBCStatement::ExecuteWithDiagnostics(stmt, SQL_ERROR, [=]() {
+    ODBCStatement* statement = reinterpret_cast<ODBCStatement*>(stmt);
+    return statement->GetMoreResults();
+  });
 }
 
 SQLRETURN SQLNumResultCols(SQLHSTMT stmt, SQLSMALLINT* column_count_ptr) {

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/odbc_statement.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/odbc_statement.cc
@@ -761,6 +761,15 @@ SQLRETURN ODBCStatement::GetData(SQLSMALLINT record_number, SQLSMALLINT c_type,
                                   data_ptr, buffer_length, indicator_ptr);
 }
 
+SQLRETURN ODBCStatement::GetMoreResults() {
+  // Multiple result sets are not supported by Arrow protocol.
+  if (current_result_) {
+    return SQL_NO_DATA;
+  } else {
+    throw DriverException("Function sequence error", "HY010");
+  }
+}
+
 void ODBCStatement::GetColumnCount(SQLSMALLINT* column_count_ptr) {
   if (!column_count_ptr) {
     // column count pointer is not valid, do nothing as ODBC spec does not mention this as

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/odbc_statement.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/odbc_statement.h
@@ -81,6 +81,8 @@ class ODBCStatement : public ODBCHandle<ODBCStatement> {
   SQLRETURN GetData(SQLSMALLINT record_number, SQLSMALLINT c_type, SQLPOINTER data_ptr,
                     SQLLEN buffer_length, SQLLEN* indicator_ptr);
 
+  SQLRETURN GetMoreResults();
+
   /// \brief Return number of columns from data set
   void GetColumnCount(SQLSMALLINT* column_count_ptr);
 

--- a/cpp/src/arrow/flight/sql/odbc/tests/statement_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/statement_test.cc
@@ -1722,6 +1722,24 @@ TYPED_TEST(StatementTest, TestSQLBindColIndicatorOnlySQLUnbind) {
   // EXPECT_EQ(1, char_val_ind);
 }
 
+TYPED_TEST(StatementTest, TestSQLMoreResultsNoData) {
+  // Verify SQLMoreResults returns SQL_NO_DATA by default.
+  std::wstring wsql = L"SELECT 1;";
+  std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
+
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+
+  ASSERT_EQ(SQL_NO_DATA, SQLMoreResults(this->stmt));
+}
+
+TYPED_TEST(StatementTest, TestSQLMoreResultsInvalidFunctionSequence) {
+  // Verify function sequence error state is reported when SQLMoreResults is called
+  // without executing any queries
+  ASSERT_EQ(SQL_ERROR, SQLMoreResults(this->stmt));
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorStateHY010);
+}
+
 TYPED_TEST(StatementTest, TestSQLNativeSqlReturnsInputString) {
   SQLWCHAR buf[1024];
   SQLINTEGER buf_char_len = sizeof(buf) / GetSqlWCharSize();


### PR DESCRIPTION
### Rationale for this change
Implement SQLMoreResults for fetching more results. Arrow protocol doesn't support multiple result sets, so `no data` is returned by default in SQLMoreResults.


### What changes are included in this PR?
- SQLMoreResults  & tests

### Are these changes tested?
Tested on local MSVC

### Are there any user-facing changes?

N/A

* GitHub Issue: #47713