### PR TITLE
GH-48044: [Packaging][RPM][Parquet] Don't install `parquet-glib.pc` by `parquet-devel`

### DIFF
--- a/dev/tasks/linux-packages/apache-arrow/yum/arrow.spec.in
+++ b/dev/tasks/linux-packages/apache-arrow/yum/arrow.spec.in
@@ -596,7 +596,7 @@ Libraries and header files for Apache Parquet C++.
 %{_libdir}/cmake/Parquet/
 %{_libdir}/libparquet.a
 %{_libdir}/libparquet.so
-%{_libdir}/pkgconfig/parquet*.pc
+%{_libdir}/pkgconfig/parquet.pc
 
 %package -n %{name}%{so_version}-glib-libs
 Summary:	Runtime libraries for Apache Arrow GLib


### PR DESCRIPTION
### Rationale for this change

If `parquet-devel` installs `parquet-glib.pc`, `parquet-devel` depends on `parquet-glib-devel` automatically. It's not an expected behavior. `parquet-devel` should not depend on `parquet-glib-devel`.

### What changes are included in this PR?

Don't install `parquet-glib.pc` by `parquet-devel`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #48044