### PR TITLE
MINOR: Update null values documentation in `csv.rst`

### DIFF
--- a/cpp/src/arrow/csv/options.h
+++ b/cpp/src/arrow/csv/options.h
@@ -129,6 +129,10 @@ struct ARROW_EXPORT ConvertOptions {
 
   /// Create conversion options with default values, including conventional
   /// values for `null_values`, `true_values` and `false_values`
+  ///
+  /// Default null values: see http://crossbow.voltrondata.com/pr_docs/48048/cpp/csv.html#nulls
+  /// Default true values: `"1"`, `"True"`, `"TRUE"`, `"true"`,
+  /// Default false values: `"0"`, `"False"`, `"FALSE"`, `"false"`,
   static ConvertOptions Defaults();
 
   /// \brief Test that all set options are valid

--- a/docs/source/cpp/csv.rst
+++ b/docs/source/cpp/csv.rst
@@ -351,9 +351,8 @@ Nulls
 
 Null values are recognized from the spellings stored in
 :member:`ConvertOptions::null_values`.  The :func:`ConvertOptions::Defaults`
-factory method will initialize a number of conventional null spellings: `""`,
-`"#N/A"`, `"#N/A N/A"`, `"#NA"`,`"-1.#IND"`, `"-1.#QNAN"`, `"-NaN"`, `"-nan"`,
-`"1.#IND"`, `"1.#QNAN"`, `"N/A"`, `"NA"`, `"NULL"`, `"NaN"`, `"n/a"`, `"nan"`, `"null"`.
+factory method will initialize a number of conventional null spellings such
+as ``N/A``.
 
 Character encoding
 ------------------

--- a/docs/source/cpp/csv.rst
+++ b/docs/source/cpp/csv.rst
@@ -351,8 +351,9 @@ Nulls
 
 Null values are recognized from the spellings stored in
 :member:`ConvertOptions::null_values`.  The :func:`ConvertOptions::Defaults`
-factory method will initialize a number of conventional null spellings such
-as ``N/A``.
+factory method will initialize a number of conventional null spellings: `""`,
+`"#N/A"`, `"#N/A N/A"`, `"#NA"`,`"-1.#IND"`, `"-1.#QNAN"`, `"-NaN"`, `"-nan"`,
+`"1.#IND"`, `"1.#QNAN"`, `"N/A"`, `"NA"`, `"NULL"`, `"NaN"`, `"n/a"`, `"nan"`, `"null"`.
 
 Character encoding
 ------------------


### PR DESCRIPTION
### Rationale for this change
Explicitly showing the default null spellings in the document would be convenient.
Source: https://github.com/apache/arrow/blob/5eaf553bfc7aa639fd67bd622b6b808e71fbba39/cpp/src/arrow/csv/options.cc#L38-L47
### What changes are included in this PR?
Only the document.
### Are these changes tested?
No need to test.
### Are there any user-facing changes?
No.