### PR TITLE
GH-47724: [C++][FlightRPC] ODBC: implement SQLDescribeCol

### DIFF
--- a/cpp/src/arrow/flight/sql/odbc/tests/columns_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/columns_test.cc
@@ -2184,4 +2184,551 @@ TYPED_TEST(ColumnsOdbcV2Test, TestSQLColAttributesUpdatable) {
   ASSERT_EQ(SQL_ATTR_READWRITE_UNKNOWN, value);
 }
 
+TEST_F(ColumnsMockTest, SQLDescribeColValidateInput) {
+  this->CreateTestTables();
+
+  SQLWCHAR sql_query[] = L"SELECT * FROM TestTable LIMIT 1;";
+  SQLINTEGER query_length = static_cast<SQLINTEGER>(wcslen(sql_query));
+
+  SQLUSMALLINT bookmark_column = 0;
+  SQLUSMALLINT out_of_range_column = 4;
+  SQLUSMALLINT negative_column = -1;
+  SQLWCHAR column_name[1024];
+  SQLSMALLINT buf_char_len =
+      static_cast<SQLSMALLINT>(sizeof(column_name) / GetSqlWCharSize());
+  SQLSMALLINT name_length = 0;
+  SQLSMALLINT data_type = 0;
+  SQLULEN column_size = 0;
+  SQLSMALLINT decimal_digits = 0;
+  SQLSMALLINT nullable = 0;
+
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, sql_query, query_length));
+
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+
+  // Invalid descriptor index - Bookmarks are not supported
+  EXPECT_EQ(SQL_ERROR, SQLDescribeCol(this->stmt, bookmark_column, column_name,
+                                      buf_char_len, &name_length, &data_type,
+                                      &column_size, &decimal_digits, &nullable));
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorState07009);
+
+  // Invalid descriptor index - index out of range
+  EXPECT_EQ(SQL_ERROR, SQLDescribeCol(this->stmt, out_of_range_column, column_name,
+                                      buf_char_len, &name_length, &data_type,
+                                      &column_size, &decimal_digits, &nullable));
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorState07009);
+
+  // Invalid descriptor index - index out of range
+  EXPECT_EQ(SQL_ERROR, SQLDescribeCol(this->stmt, negative_column, column_name,
+                                      buf_char_len, &name_length, &data_type,
+                                      &column_size, &decimal_digits, &nullable));
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorState07009);
+}
+
+TEST_F(ColumnsMockTest, SQLDescribeColQueryAllDataTypesMetadata) {
+  // Mock server has a limitation where only SQL_WVARCHAR column type values are returned
+  // from SELECT AS queries
+
+  SQLWCHAR column_name[1024];
+  SQLSMALLINT buf_char_len =
+      static_cast<SQLSMALLINT>(sizeof(column_name) / GetSqlWCharSize());
+  SQLSMALLINT name_length = 0;
+  SQLSMALLINT column_data_type = 0;
+  SQLULEN column_size = 0;
+  SQLSMALLINT decimal_digits = 0;
+  SQLSMALLINT nullable = 0;
+  size_t column_index = 0;
+
+  std::wstring wsql = this->GetQueryAllDataTypes();
+  std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
+
+  const SQLWCHAR* column_names[] = {static_cast<const SQLWCHAR*>(L"stiny_int_min"),
+                                    static_cast<const SQLWCHAR*>(L"stiny_int_max"),
+                                    static_cast<const SQLWCHAR*>(L"utiny_int_min"),
+                                    static_cast<const SQLWCHAR*>(L"utiny_int_max"),
+                                    static_cast<const SQLWCHAR*>(L"ssmall_int_min"),
+                                    static_cast<const SQLWCHAR*>(L"ssmall_int_max"),
+                                    static_cast<const SQLWCHAR*>(L"usmall_int_min"),
+                                    static_cast<const SQLWCHAR*>(L"usmall_int_max"),
+                                    static_cast<const SQLWCHAR*>(L"sinteger_min"),
+                                    static_cast<const SQLWCHAR*>(L"sinteger_max"),
+                                    static_cast<const SQLWCHAR*>(L"uinteger_min"),
+                                    static_cast<const SQLWCHAR*>(L"uinteger_max"),
+                                    static_cast<const SQLWCHAR*>(L"sbigint_min"),
+                                    static_cast<const SQLWCHAR*>(L"sbigint_max"),
+                                    static_cast<const SQLWCHAR*>(L"ubigint_min"),
+                                    static_cast<const SQLWCHAR*>(L"ubigint_max"),
+                                    static_cast<const SQLWCHAR*>(L"decimal_negative"),
+                                    static_cast<const SQLWCHAR*>(L"decimal_positive"),
+                                    static_cast<const SQLWCHAR*>(L"float_min"),
+                                    static_cast<const SQLWCHAR*>(L"float_max"),
+                                    static_cast<const SQLWCHAR*>(L"double_min"),
+                                    static_cast<const SQLWCHAR*>(L"double_max"),
+                                    static_cast<const SQLWCHAR*>(L"bit_false"),
+                                    static_cast<const SQLWCHAR*>(L"bit_true"),
+                                    static_cast<const SQLWCHAR*>(L"c_char"),
+                                    static_cast<const SQLWCHAR*>(L"c_wchar"),
+                                    static_cast<const SQLWCHAR*>(L"c_wvarchar"),
+                                    static_cast<const SQLWCHAR*>(L"c_varchar"),
+                                    static_cast<const SQLWCHAR*>(L"date_min"),
+                                    static_cast<const SQLWCHAR*>(L"date_max"),
+                                    static_cast<const SQLWCHAR*>(L"timestamp_min"),
+                                    static_cast<const SQLWCHAR*>(L"timestamp_max")};
+  SQLSMALLINT column_data_types[] = {
+      SQL_WVARCHAR, SQL_WVARCHAR, SQL_WVARCHAR, SQL_WVARCHAR, SQL_WVARCHAR, SQL_WVARCHAR,
+      SQL_WVARCHAR, SQL_WVARCHAR, SQL_WVARCHAR, SQL_WVARCHAR, SQL_WVARCHAR, SQL_WVARCHAR,
+      SQL_WVARCHAR, SQL_WVARCHAR, SQL_WVARCHAR, SQL_WVARCHAR, SQL_WVARCHAR, SQL_WVARCHAR,
+      SQL_WVARCHAR, SQL_WVARCHAR, SQL_WVARCHAR, SQL_WVARCHAR, SQL_WVARCHAR, SQL_WVARCHAR,
+      SQL_WVARCHAR, SQL_WVARCHAR, SQL_WVARCHAR, SQL_WVARCHAR, SQL_WVARCHAR, SQL_WVARCHAR,
+      SQL_WVARCHAR, SQL_WVARCHAR};
+
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+
+  for (size_t i = 0; i < sizeof(column_names) / sizeof(*column_names); ++i) {
+    column_index = i + 1;
+
+    ASSERT_EQ(SQL_SUCCESS, SQLDescribeCol(this->stmt, column_index, column_name,
+                                          buf_char_len, &name_length, &column_data_type,
+                                          &column_size, &decimal_digits, &nullable));
+
+    EXPECT_EQ(wcslen(column_names[i]), name_length);
+
+    std::wstring returned(column_name, column_name + name_length);
+    EXPECT_EQ(column_names[i], returned);
+    EXPECT_EQ(column_data_types[i], column_data_type);
+    EXPECT_EQ(1024, column_size);
+    EXPECT_EQ(0, decimal_digits);
+    EXPECT_EQ(SQL_NULLABLE, nullable);
+
+    name_length = 0;
+    column_data_type = 0;
+    column_size = 0;
+    decimal_digits = 0;
+    nullable = 0;
+  }
+}
+
+TEST_F(ColumnsRemoteTest, SQLDescribeColQueryAllDataTypesMetadata) {
+  SQLWCHAR column_name[1024];
+  SQLSMALLINT buf_char_len =
+      static_cast<SQLSMALLINT>(sizeof(column_name) / GetSqlWCharSize());
+  SQLSMALLINT name_length = 0;
+  SQLSMALLINT column_data_type = 0;
+  SQLULEN column_size = 0;
+  SQLSMALLINT decimal_digits = 0;
+  SQLSMALLINT nullable = 0;
+  size_t column_index = 0;
+
+  std::wstring wsql = this->GetQueryAllDataTypes();
+  std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
+
+  const SQLWCHAR* column_names[] = {static_cast<const SQLWCHAR*>(L"stiny_int_min"),
+                                    static_cast<const SQLWCHAR*>(L"stiny_int_max"),
+                                    static_cast<const SQLWCHAR*>(L"utiny_int_min"),
+                                    static_cast<const SQLWCHAR*>(L"utiny_int_max"),
+                                    static_cast<const SQLWCHAR*>(L"ssmall_int_min"),
+                                    static_cast<const SQLWCHAR*>(L"ssmall_int_max"),
+                                    static_cast<const SQLWCHAR*>(L"usmall_int_min"),
+                                    static_cast<const SQLWCHAR*>(L"usmall_int_max"),
+                                    static_cast<const SQLWCHAR*>(L"sinteger_min"),
+                                    static_cast<const SQLWCHAR*>(L"sinteger_max"),
+                                    static_cast<const SQLWCHAR*>(L"uinteger_min"),
+                                    static_cast<const SQLWCHAR*>(L"uinteger_max"),
+                                    static_cast<const SQLWCHAR*>(L"sbigint_min"),
+                                    static_cast<const SQLWCHAR*>(L"sbigint_max"),
+                                    static_cast<const SQLWCHAR*>(L"ubigint_min"),
+                                    static_cast<const SQLWCHAR*>(L"ubigint_max"),
+                                    static_cast<const SQLWCHAR*>(L"decimal_negative"),
+                                    static_cast<const SQLWCHAR*>(L"decimal_positive"),
+                                    static_cast<const SQLWCHAR*>(L"float_min"),
+                                    static_cast<const SQLWCHAR*>(L"float_max"),
+                                    static_cast<const SQLWCHAR*>(L"double_min"),
+                                    static_cast<const SQLWCHAR*>(L"double_max"),
+                                    static_cast<const SQLWCHAR*>(L"bit_false"),
+                                    static_cast<const SQLWCHAR*>(L"bit_true"),
+                                    static_cast<const SQLWCHAR*>(L"c_char"),
+                                    static_cast<const SQLWCHAR*>(L"c_wchar"),
+                                    static_cast<const SQLWCHAR*>(L"c_wvarchar"),
+                                    static_cast<const SQLWCHAR*>(L"c_varchar"),
+                                    static_cast<const SQLWCHAR*>(L"date_min"),
+                                    static_cast<const SQLWCHAR*>(L"date_max"),
+                                    static_cast<const SQLWCHAR*>(L"timestamp_min"),
+                                    static_cast<const SQLWCHAR*>(L"timestamp_max")};
+  SQLSMALLINT column_data_types[] = {
+      SQL_INTEGER,        SQL_INTEGER,       SQL_INTEGER,  SQL_INTEGER,   SQL_INTEGER,
+      SQL_INTEGER,        SQL_INTEGER,       SQL_INTEGER,  SQL_INTEGER,   SQL_INTEGER,
+      SQL_BIGINT,         SQL_BIGINT,        SQL_BIGINT,   SQL_BIGINT,    SQL_BIGINT,
+      SQL_WVARCHAR,       SQL_DECIMAL,       SQL_DECIMAL,  SQL_FLOAT,     SQL_FLOAT,
+      SQL_DOUBLE,         SQL_DOUBLE,        SQL_BIT,      SQL_BIT,       SQL_WVARCHAR,
+      SQL_WVARCHAR,       SQL_WVARCHAR,      SQL_WVARCHAR, SQL_TYPE_DATE, SQL_TYPE_DATE,
+      SQL_TYPE_TIMESTAMP, SQL_TYPE_TIMESTAMP};
+  SQLULEN column_sizes[] = {4, 4, 4,     4,     4,     4,     4,  4,  4,  4, 8,
+                            8, 8, 8,     8,     65536, 19,    19, 8,  8,  8, 8,
+                            1, 1, 65536, 65536, 65536, 65536, 10, 10, 23, 23};
+  SQLULEN column_decimal_digits[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,  0,  0,  0,
+                                     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10, 23, 23};
+
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+
+  for (size_t i = 0; i < sizeof(column_names) / sizeof(*column_names); ++i) {
+    column_index = i + 1;
+
+    ASSERT_EQ(SQL_SUCCESS, SQLDescribeCol(this->stmt, column_index, column_name,
+                                          buf_char_len, &name_length, &column_data_type,
+                                          &column_size, &decimal_digits, &nullable));
+
+    EXPECT_EQ(wcslen(column_names[i]), name_length);
+
+    std::wstring returned(column_name, column_name + name_length);
+    EXPECT_EQ(column_names[i], returned);
+    EXPECT_EQ(column_data_types[i], column_data_type);
+    EXPECT_EQ(column_sizes[i], column_size);
+    EXPECT_EQ(column_decimal_digits[i], decimal_digits);
+    EXPECT_EQ(SQL_NULLABLE, nullable);
+
+    name_length = 0;
+    column_data_type = 0;
+    column_size = 0;
+    decimal_digits = 0;
+    nullable = 0;
+  }
+}
+
+TEST_F(ColumnsRemoteTest, SQLDescribeColODBCTestTableMetadata) {
+  // Test assumes there is a table $scratch.ODBCTest in remote server
+
+  SQLWCHAR column_name[1024];
+  SQLSMALLINT buf_char_len =
+      static_cast<SQLSMALLINT>(sizeof(column_name) / GetSqlWCharSize());
+  SQLSMALLINT name_length = 0;
+  SQLSMALLINT column_data_type = 0;
+  SQLULEN column_size = 0;
+  SQLSMALLINT decimal_digits = 0;
+  SQLSMALLINT nullable = 0;
+  size_t column_index = 0;
+
+  SQLWCHAR sql_query[] = L"SELECT * from $scratch.ODBCTest LIMIT 1;";
+  SQLINTEGER query_length = static_cast<SQLINTEGER>(wcslen(sql_query));
+
+  const SQLWCHAR* column_names[] = {static_cast<const SQLWCHAR*>(L"sinteger_max"),
+                                    static_cast<const SQLWCHAR*>(L"sbigint_max"),
+                                    static_cast<const SQLWCHAR*>(L"decimal_positive"),
+                                    static_cast<const SQLWCHAR*>(L"float_max"),
+                                    static_cast<const SQLWCHAR*>(L"double_max"),
+                                    static_cast<const SQLWCHAR*>(L"bit_true"),
+                                    static_cast<const SQLWCHAR*>(L"date_max"),
+                                    static_cast<const SQLWCHAR*>(L"time_max"),
+                                    static_cast<const SQLWCHAR*>(L"timestamp_max")};
+  SQLSMALLINT column_data_types[] = {SQL_INTEGER,   SQL_BIGINT,    SQL_DECIMAL,
+                                     SQL_FLOAT,     SQL_DOUBLE,    SQL_BIT,
+                                     SQL_TYPE_DATE, SQL_TYPE_TIME, SQL_TYPE_TIMESTAMP};
+  SQLULEN column_sizes[] = {4, 8, 19, 8, 8, 1, 10, 12, 23};
+  SQLULEN columndecimal_digits[] = {0, 0, 0, 0, 0, 0, 10, 12, 23};
+
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, sql_query, query_length));
+
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+
+  for (size_t i = 0; i < sizeof(column_names) / sizeof(*column_names); ++i) {
+    column_index = i + 1;
+
+    ASSERT_EQ(SQL_SUCCESS, SQLDescribeCol(this->stmt, column_index, column_name,
+                                          buf_char_len, &name_length, &column_data_type,
+                                          &column_size, &decimal_digits, &nullable));
+
+    EXPECT_EQ(wcslen(column_names[i]), name_length);
+
+    std::wstring returned(column_name, column_name + name_length);
+    EXPECT_EQ(column_names[i], returned);
+    EXPECT_EQ(column_data_types[i], column_data_type);
+    EXPECT_EQ(column_sizes[i], column_size);
+    EXPECT_EQ(columndecimal_digits[i], decimal_digits);
+    EXPECT_EQ(SQL_NULLABLE, nullable);
+
+    name_length = 0;
+    column_data_type = 0;
+    column_size = 0;
+    decimal_digits = 0;
+    nullable = 0;
+  }
+}
+
+TEST_F(ColumnsOdbcV2RemoteTest, SQLDescribeColODBCTestTableMetadataODBC2) {
+  // Test assumes there is a table $scratch.ODBCTest in remote server
+  SQLWCHAR column_name[1024];
+  SQLSMALLINT buf_char_len =
+      static_cast<SQLSMALLINT>(sizeof(column_name) / GetSqlWCharSize());
+  SQLSMALLINT name_length = 0;
+  SQLSMALLINT column_data_type = 0;
+  SQLULEN column_size = 0;
+  SQLSMALLINT decimal_digits = 0;
+  SQLSMALLINT nullable = 0;
+  size_t column_index = 0;
+
+  SQLWCHAR sql_query[] = L"SELECT * from $scratch.ODBCTest LIMIT 1;";
+  SQLINTEGER query_length = static_cast<SQLINTEGER>(wcslen(sql_query));
+
+  const SQLWCHAR* column_names[] = {static_cast<const SQLWCHAR*>(L"sinteger_max"),
+                                    static_cast<const SQLWCHAR*>(L"sbigint_max"),
+                                    static_cast<const SQLWCHAR*>(L"decimal_positive"),
+                                    static_cast<const SQLWCHAR*>(L"float_max"),
+                                    static_cast<const SQLWCHAR*>(L"double_max"),
+                                    static_cast<const SQLWCHAR*>(L"bit_true"),
+                                    static_cast<const SQLWCHAR*>(L"date_max"),
+                                    static_cast<const SQLWCHAR*>(L"time_max"),
+                                    static_cast<const SQLWCHAR*>(L"timestamp_max")};
+  SQLSMALLINT column_data_types[] = {SQL_INTEGER, SQL_BIGINT, SQL_DECIMAL,
+                                     SQL_FLOAT,   SQL_DOUBLE, SQL_BIT,
+                                     SQL_DATE,    SQL_TIME,   SQL_TIMESTAMP};
+  SQLULEN column_sizes[] = {4, 8, 19, 8, 8, 1, 10, 12, 23};
+  SQLULEN columndecimal_digits[] = {0, 0, 0, 0, 0, 0, 10, 12, 23};
+
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, sql_query, query_length));
+
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+
+  for (size_t i = 0; i < sizeof(column_names) / sizeof(*column_names); ++i) {
+    column_index = i + 1;
+
+    ASSERT_EQ(SQL_SUCCESS, SQLDescribeCol(this->stmt, column_index, column_name,
+                                          buf_char_len, &name_length, &column_data_type,
+                                          &column_size, &decimal_digits, &nullable));
+
+    EXPECT_EQ(wcslen(column_names[i]), name_length);
+
+    std::wstring returned(column_name, column_name + name_length);
+    EXPECT_EQ(column_names[i], returned);
+    EXPECT_EQ(column_data_types[i], column_data_type);
+    EXPECT_EQ(column_sizes[i], column_size);
+    EXPECT_EQ(columndecimal_digits[i], decimal_digits);
+    EXPECT_EQ(SQL_NULLABLE, nullable);
+
+    name_length = 0;
+    column_data_type = 0;
+    column_size = 0;
+    decimal_digits = 0;
+    nullable = 0;
+  }
+}
+
+TEST_F(ColumnsMockTest, SQLDescribeColAllTypesTableMetadata) {
+  this->CreateTableAllDataType();
+
+  SQLWCHAR column_name[1024];
+  SQLSMALLINT buf_char_len =
+      static_cast<SQLSMALLINT>(sizeof(column_name) / GetSqlWCharSize());
+  SQLSMALLINT name_length = 0;
+  SQLSMALLINT column_data_type = 0;
+  SQLULEN column_size = 0;
+  SQLSMALLINT decimal_digits = 0;
+  SQLSMALLINT nullable = 0;
+  size_t column_index = 0;
+
+  SQLWCHAR sql_query[] = L"SELECT * from AllTypesTable LIMIT 1;";
+  SQLINTEGER query_length = static_cast<SQLINTEGER>(wcslen(sql_query));
+
+  const SQLWCHAR* column_names[] = {static_cast<const SQLWCHAR*>(L"bigint_col"),
+                                    static_cast<const SQLWCHAR*>(L"char_col"),
+                                    static_cast<const SQLWCHAR*>(L"varbinary_col"),
+                                    static_cast<const SQLWCHAR*>(L"double_col")};
+  SQLSMALLINT column_data_types[] = {SQL_BIGINT, SQL_WVARCHAR, SQL_BINARY, SQL_DOUBLE};
+  SQLULEN column_sizes[] = {8, 0, 0, 8};
+
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, sql_query, query_length));
+
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+
+  for (size_t i = 0; i < sizeof(column_names) / sizeof(*column_names); ++i) {
+    column_index = i + 1;
+
+    ASSERT_EQ(SQL_SUCCESS, SQLDescribeCol(this->stmt, column_index, column_name,
+                                          buf_char_len, &name_length, &column_data_type,
+                                          &column_size, &decimal_digits, &nullable));
+
+    EXPECT_EQ(wcslen(column_names[i]), name_length);
+
+    std::wstring returned(column_name, column_name + name_length);
+    EXPECT_EQ(column_names[i], returned);
+    EXPECT_EQ(column_data_types[i], column_data_type);
+    EXPECT_EQ(column_sizes[i], column_size);
+    EXPECT_EQ(0, decimal_digits);
+    EXPECT_EQ(SQL_NULLABLE, nullable);
+
+    name_length = 0;
+    column_data_type = 0;
+    column_size = 0;
+    decimal_digits = 0;
+    nullable = 0;
+  }
+}
+
+TEST_F(ColumnsMockTest, SQLDescribeColUnicodeTableMetadata) {
+  this->CreateUnicodeTable();
+
+  SQLWCHAR column_name[1024];
+  SQLSMALLINT buf_char_len =
+      static_cast<SQLSMALLINT>(sizeof(column_name) / GetSqlWCharSize());
+  SQLSMALLINT name_length = 0;
+  SQLSMALLINT column_data_type = 0;
+  SQLULEN column_size = 0;
+  SQLSMALLINT decimal_digits = 0;
+  SQLSMALLINT nullable = 0;
+  size_t column_index = 1;
+
+  SQLWCHAR sql_query[] = L"SELECT * from 数据 LIMIT 1;";
+  SQLINTEGER query_length = static_cast<SQLINTEGER>(wcslen(sql_query));
+
+  SQLWCHAR expected_column_name[] = L"资料";
+  SQLSMALLINT expected_column_data_type = SQL_WVARCHAR;
+  SQLULEN expected_column_size = 0;
+
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, sql_query, query_length));
+
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+
+  ASSERT_EQ(SQL_SUCCESS, SQLDescribeCol(this->stmt, column_index, column_name,
+                                        buf_char_len, &name_length, &column_data_type,
+                                        &column_size, &decimal_digits, &nullable));
+
+  EXPECT_EQ(name_length, wcslen(expected_column_name));
+
+  std::wstring returned(column_name, column_name + name_length);
+  EXPECT_EQ(returned, expected_column_name);
+  EXPECT_EQ(column_data_type, expected_column_data_type);
+  EXPECT_EQ(column_size, expected_column_size);
+  EXPECT_EQ(0, decimal_digits);
+  EXPECT_EQ(SQL_NULLABLE, nullable);
+}
+
+TYPED_TEST(ColumnsTest, SQLColumnsGetMetadataBySQLDescribeCol) {
+  SQLWCHAR column_name[1024];
+  SQLSMALLINT buf_char_len =
+      static_cast<SQLSMALLINT>(sizeof(column_name) / GetSqlWCharSize());
+  SQLSMALLINT name_length = 0;
+  SQLSMALLINT column_data_type = 0;
+  SQLULEN column_size = 0;
+  SQLSMALLINT decimal_digits = 0;
+  SQLSMALLINT nullable = 0;
+  size_t column_index = 0;
+
+  const SQLWCHAR* column_names[] = {static_cast<const SQLWCHAR*>(L"TABLE_CAT"),
+                                    static_cast<const SQLWCHAR*>(L"TABLE_SCHEM"),
+                                    static_cast<const SQLWCHAR*>(L"TABLE_NAME"),
+                                    static_cast<const SQLWCHAR*>(L"COLUMN_NAME"),
+                                    static_cast<const SQLWCHAR*>(L"DATA_TYPE"),
+                                    static_cast<const SQLWCHAR*>(L"TYPE_NAME"),
+                                    static_cast<const SQLWCHAR*>(L"COLUMN_SIZE"),
+                                    static_cast<const SQLWCHAR*>(L"BUFFER_LENGTH"),
+                                    static_cast<const SQLWCHAR*>(L"DECIMAL_DIGITS"),
+                                    static_cast<const SQLWCHAR*>(L"NUM_PREC_RADIX"),
+                                    static_cast<const SQLWCHAR*>(L"NULLABLE"),
+                                    static_cast<const SQLWCHAR*>(L"REMARKS"),
+                                    static_cast<const SQLWCHAR*>(L"COLUMN_DEF"),
+                                    static_cast<const SQLWCHAR*>(L"SQL_DATA_TYPE"),
+                                    static_cast<const SQLWCHAR*>(L"SQL_DATETIME_SUB"),
+                                    static_cast<const SQLWCHAR*>(L"CHAR_OCTET_LENGTH"),
+                                    static_cast<const SQLWCHAR*>(L"ORDINAL_POSITION"),
+                                    static_cast<const SQLWCHAR*>(L"IS_NULLABLE")};
+  SQLSMALLINT column_data_types[] = {
+      SQL_WVARCHAR, SQL_WVARCHAR, SQL_WVARCHAR, SQL_WVARCHAR, SQL_SMALLINT, SQL_WVARCHAR,
+      SQL_INTEGER,  SQL_INTEGER,  SQL_SMALLINT, SQL_SMALLINT, SQL_SMALLINT, SQL_WVARCHAR,
+      SQL_WVARCHAR, SQL_SMALLINT, SQL_SMALLINT, SQL_INTEGER,  SQL_INTEGER,  SQL_WVARCHAR};
+  SQLULEN column_sizes[] = {1024, 1024, 1024, 1024, 2, 1024, 4, 4, 2,
+                            2,    2,    1024, 1024, 2, 2,    4, 4, 1024};
+
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLColumns(this->stmt, nullptr, 0, nullptr, 0, nullptr, 0, nullptr, 0));
+
+  for (size_t i = 0; i < sizeof(column_names) / sizeof(*column_names); ++i) {
+    column_index = i + 1;
+
+    ASSERT_EQ(SQL_SUCCESS, SQLDescribeCol(this->stmt, column_index, column_name,
+                                          buf_char_len, &name_length, &column_data_type,
+                                          &column_size, &decimal_digits, &nullable));
+
+    EXPECT_EQ(wcslen(column_names[i]), name_length);
+
+    std::wstring returned(column_name, column_name + name_length);
+    EXPECT_EQ(column_names[i], returned);
+    EXPECT_EQ(column_data_types[i], column_data_type);
+    EXPECT_EQ(column_sizes[i], column_size);
+    EXPECT_EQ(0, decimal_digits);
+    EXPECT_EQ(SQL_NULLABLE, nullable);
+
+    name_length = 0;
+    column_data_type = 0;
+    column_size = 0;
+    decimal_digits = 0;
+    nullable = 0;
+  }
+}
+
+TYPED_TEST(ColumnsOdbcV2Test, SQLColumnsGetMetadataBySQLDescribeColODBC2) {
+  SQLWCHAR column_name[1024];
+  SQLSMALLINT buf_char_len =
+      static_cast<SQLSMALLINT>(sizeof(column_name) / GetSqlWCharSize());
+  SQLSMALLINT name_length = 0;
+  SQLSMALLINT column_data_type = 0;
+  SQLULEN column_size = 0;
+  SQLSMALLINT decimal_digits = 0;
+  SQLSMALLINT nullable = 0;
+  size_t column_index = 0;
+
+  const SQLWCHAR* column_names[] = {static_cast<const SQLWCHAR*>(L"TABLE_QUALIFIER"),
+                                    static_cast<const SQLWCHAR*>(L"TABLE_OWNER"),
+                                    static_cast<const SQLWCHAR*>(L"TABLE_NAME"),
+                                    static_cast<const SQLWCHAR*>(L"COLUMN_NAME"),
+                                    static_cast<const SQLWCHAR*>(L"DATA_TYPE"),
+                                    static_cast<const SQLWCHAR*>(L"TYPE_NAME"),
+                                    static_cast<const SQLWCHAR*>(L"PRECISION"),
+                                    static_cast<const SQLWCHAR*>(L"LENGTH"),
+                                    static_cast<const SQLWCHAR*>(L"SCALE"),
+                                    static_cast<const SQLWCHAR*>(L"RADIX"),
+                                    static_cast<const SQLWCHAR*>(L"NULLABLE"),
+                                    static_cast<const SQLWCHAR*>(L"REMARKS"),
+                                    static_cast<const SQLWCHAR*>(L"COLUMN_DEF"),
+                                    static_cast<const SQLWCHAR*>(L"SQL_DATA_TYPE"),
+                                    static_cast<const SQLWCHAR*>(L"SQL_DATETIME_SUB"),
+                                    static_cast<const SQLWCHAR*>(L"CHAR_OCTET_LENGTH"),
+                                    static_cast<const SQLWCHAR*>(L"ORDINAL_POSITION"),
+                                    static_cast<const SQLWCHAR*>(L"IS_NULLABLE")};
+  SQLSMALLINT column_data_types[] = {
+      SQL_WVARCHAR, SQL_WVARCHAR, SQL_WVARCHAR, SQL_WVARCHAR, SQL_SMALLINT, SQL_WVARCHAR,
+      SQL_INTEGER,  SQL_INTEGER,  SQL_SMALLINT, SQL_SMALLINT, SQL_SMALLINT, SQL_WVARCHAR,
+      SQL_WVARCHAR, SQL_SMALLINT, SQL_SMALLINT, SQL_INTEGER,  SQL_INTEGER,  SQL_WVARCHAR};
+  SQLULEN column_sizes[] = {1024, 1024, 1024, 1024, 2, 1024, 4, 4, 2,
+                            2,    2,    1024, 1024, 2, 2,    4, 4, 1024};
+
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLColumns(this->stmt, nullptr, 0, nullptr, 0, nullptr, 0, nullptr, 0));
+
+  for (size_t i = 0; i < sizeof(column_names) / sizeof(*column_names); ++i) {
+    column_index = i + 1;
+
+    ASSERT_EQ(SQL_SUCCESS, SQLDescribeCol(this->stmt, column_index, column_name,
+                                          buf_char_len, &name_length, &column_data_type,
+                                          &column_size, &decimal_digits, &nullable));
+
+    EXPECT_EQ(wcslen(column_names[i]), name_length);
+
+    std::wstring returned(column_name, column_name + name_length);
+    EXPECT_EQ(column_names[i], returned);
+    EXPECT_EQ(column_data_types[i], column_data_type);
+    EXPECT_EQ(column_sizes[i], column_size);
+    EXPECT_EQ(0, decimal_digits);
+    EXPECT_EQ(SQL_NULLABLE, nullable);
+
+    name_length = 0;
+    column_data_type = 0;
+    column_size = 0;
+    decimal_digits = 0;
+    nullable = 0;
+  }
+}
+
 }  // namespace arrow::flight::sql::odbc

--- a/cpp/src/arrow/flight/sql/odbc/tests/columns_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/columns_test.cc
@@ -2458,7 +2458,7 @@ TEST_F(ColumnsRemoteTest, SQLDescribeColODBCTestTableMetadata) {
   }
 }
 
-TEST_F(ColumnsOdbcV2RemoteTest, SQLDescribeColODBCTestTableMetadataODBC2) {
+TEST_F(ColumnsOdbcV2RemoteTest, SQLDescribeColODBCTestTableMetadataODBCVer2) {
   // Test assumes there is a table $scratch.ODBCTest in remote server
   SQLWCHAR column_name[1024];
   SQLSMALLINT buf_char_len =
@@ -2668,7 +2668,7 @@ TYPED_TEST(ColumnsTest, SQLColumnsGetMetadataBySQLDescribeCol) {
   }
 }
 
-TYPED_TEST(ColumnsOdbcV2Test, SQLColumnsGetMetadataBySQLDescribeColODBC2) {
+TYPED_TEST(ColumnsOdbcV2Test, SQLColumnsGetMetadataBySQLDescribeColODBCVer2) {
   SQLWCHAR column_name[1024];
   SQLSMALLINT buf_char_len =
       static_cast<SQLSMALLINT>(sizeof(column_name) / GetSqlWCharSize());

--- a/cpp/src/arrow/flight/sql/odbc/tests/tables_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/tables_test.cc
@@ -487,4 +487,97 @@ TEST_F(TablesRemoteTest, SQLTablesGetSupportedTableTypes) {
   ValidateFetch(this->stmt, SQL_NO_DATA);
 }
 
+TYPED_TEST(TablesTest, SQLTablesGetMetadataBySQLDescribeCol) {
+  SQLWCHAR column_name[1024];
+  SQLSMALLINT buf_char_len =
+      static_cast<SQLSMALLINT>(sizeof(column_name) / GetSqlWCharSize());
+  SQLSMALLINT name_length = 0;
+  SQLSMALLINT column_data_type = 0;
+  SQLULEN column_size = 0;
+  SQLSMALLINT decimal_digits = 0;
+  SQLSMALLINT nullable = 0;
+  size_t column_index = 0;
+
+  const SQLWCHAR* column_names[] = {static_cast<const SQLWCHAR*>(L"TABLE_CAT"),
+                                    static_cast<const SQLWCHAR*>(L"TABLE_SCHEM"),
+                                    static_cast<const SQLWCHAR*>(L"TABLE_NAME"),
+                                    static_cast<const SQLWCHAR*>(L"TABLE_TYPE"),
+                                    static_cast<const SQLWCHAR*>(L"REMARKS")};
+  SQLSMALLINT column_data_types[] = {SQL_WVARCHAR, SQL_WVARCHAR, SQL_WVARCHAR,
+                                     SQL_WVARCHAR, SQL_WVARCHAR};
+  SQLULEN column_sizes[] = {1024, 1024, 1024, 1024, 1024};
+
+  ASSERT_EQ(SQL_SUCCESS, SQLTables(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
+                                   nullptr, SQL_NTS, nullptr, SQL_NTS));
+
+  for (size_t i = 0; i < sizeof(column_names) / sizeof(*column_names); ++i) {
+    column_index = i + 1;
+
+    ASSERT_EQ(SQL_SUCCESS, SQLDescribeCol(this->stmt, column_index, column_name,
+                                          buf_char_len, &name_length, &column_data_type,
+                                          &column_size, &decimal_digits, &nullable));
+
+    EXPECT_EQ(wcslen(column_names[i]), name_length);
+
+    std::wstring returned(column_name, column_name + name_length);
+    EXPECT_EQ(column_names[i], returned);
+    EXPECT_EQ(column_data_types[i], column_data_type);
+    EXPECT_EQ(column_sizes[i], column_size);
+    EXPECT_EQ(0, decimal_digits);
+    EXPECT_EQ(SQL_NULLABLE, nullable);
+
+    name_length = 0;
+    column_data_type = 0;
+    column_size = 0;
+    decimal_digits = 0;
+    nullable = 0;
+  }
+}
+
+TYPED_TEST(TablesOdbcV2Test, SQLTablesGetMetadataBySQLDescribeColODBC2) {
+  SQLWCHAR column_name[1024];
+  SQLSMALLINT buf_char_len =
+      static_cast<SQLSMALLINT>(sizeof(column_name) / GetSqlWCharSize());
+  SQLSMALLINT name_length = 0;
+  SQLSMALLINT column_data_type = 0;
+  SQLULEN column_size = 0;
+  SQLSMALLINT decimal_digits = 0;
+  SQLSMALLINT nullable = 0;
+  size_t column_index = 0;
+
+  const SQLWCHAR* column_names[] = {static_cast<const SQLWCHAR*>(L"TABLE_QUALIFIER"),
+                                    static_cast<const SQLWCHAR*>(L"TABLE_OWNER"),
+                                    static_cast<const SQLWCHAR*>(L"TABLE_NAME"),
+                                    static_cast<const SQLWCHAR*>(L"TABLE_TYPE"),
+                                    static_cast<const SQLWCHAR*>(L"REMARKS")};
+  SQLSMALLINT column_data_types[] = {SQL_WVARCHAR, SQL_WVARCHAR, SQL_WVARCHAR,
+                                     SQL_WVARCHAR, SQL_WVARCHAR};
+  SQLULEN column_sizes[] = {1024, 1024, 1024, 1024, 1024};
+
+  ASSERT_EQ(SQL_SUCCESS, SQLTables(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
+                                   nullptr, SQL_NTS, nullptr, SQL_NTS));
+
+  for (size_t i = 0; i < sizeof(column_names) / sizeof(*column_names); ++i) {
+    column_index = i + 1;
+
+    ASSERT_EQ(SQL_SUCCESS, SQLDescribeCol(this->stmt, column_index, column_name,
+                                          buf_char_len, &name_length, &column_data_type,
+                                          &column_size, &decimal_digits, &nullable));
+
+    EXPECT_EQ(wcslen(column_names[i]), name_length);
+
+    std::wstring returned(column_name, column_name + name_length);
+    EXPECT_EQ(column_names[i], returned);
+    EXPECT_EQ(column_data_types[i], column_data_type);
+    EXPECT_EQ(column_sizes[i], column_size);
+    EXPECT_EQ(0, decimal_digits);
+    EXPECT_EQ(SQL_NULLABLE, nullable);
+
+    name_length = 0;
+    column_data_type = 0;
+    column_size = 0;
+    decimal_digits = 0;
+    nullable = 0;
+  }
+}
 }  // namespace arrow::flight::sql::odbc

--- a/cpp/src/arrow/flight/sql/odbc/tests/tables_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/tables_test.cc
@@ -534,7 +534,7 @@ TYPED_TEST(TablesTest, SQLTablesGetMetadataBySQLDescribeCol) {
   }
 }
 
-TYPED_TEST(TablesOdbcV2Test, SQLTablesGetMetadataBySQLDescribeColODBC2) {
+TYPED_TEST(TablesOdbcV2Test, SQLTablesGetMetadataBySQLDescribeColODBCVer2) {
   SQLWCHAR column_name[1024];
   SQLSMALLINT buf_char_len =
       static_cast<SQLSMALLINT>(sizeof(column_name) / GetSqlWCharSize());

--- a/cpp/src/arrow/flight/sql/odbc/tests/type_info_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/type_info_test.cc
@@ -40,6 +40,119 @@ class TypeInfoOdbcV2MockTest : public FlightSQLOdbcV2MockTestBase {};
 namespace {
 // Helper Functions
 
+void CheckSQLDescribeCol(SQLHSTMT stmt, const SQLUSMALLINT column_index,
+                         const std::wstring& expected_name,
+                         const SQLSMALLINT& expected_data_type,
+                         const SQLULEN& expected_column_size,
+                         const SQLSMALLINT& expected_decimal_digits,
+                         const SQLSMALLINT& expected_nullable) {
+  SQLWCHAR column_name[1024];
+  SQLSMALLINT buf_char_len =
+      static_cast<SQLSMALLINT>(sizeof(column_name) / GetSqlWCharSize());
+  SQLSMALLINT name_length = 0;
+  SQLSMALLINT column_data_type = 0;
+  SQLULEN column_size = 0;
+  SQLSMALLINT decimal_digits = 0;
+  SQLSMALLINT nullable = 0;
+
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLDescribeCol(stmt, column_index, column_name, buf_char_len, &name_length,
+                           &column_data_type, &column_size, &decimal_digits, &nullable));
+
+  EXPECT_EQ(name_length, expected_name.size());
+
+  std::wstring returned(column_name, column_name + name_length);
+  EXPECT_EQ(expected_name, returned);
+  EXPECT_EQ(expected_data_type, column_data_type);
+  EXPECT_EQ(expected_column_size, column_size);
+  EXPECT_EQ(expected_decimal_digits, decimal_digits);
+  EXPECT_EQ(expected_nullable, nullable);
+}
+
+void CheckSQLDescribeColODBC2(SQLHSTMT stmt) {
+  const SQLWCHAR* column_names[] = {static_cast<const SQLWCHAR*>(L"TYPE_NAME"),
+                                    static_cast<const SQLWCHAR*>(L"DATA_TYPE"),
+                                    static_cast<const SQLWCHAR*>(L"PRECISION"),
+                                    static_cast<const SQLWCHAR*>(L"LITERAL_PREFIX"),
+                                    static_cast<const SQLWCHAR*>(L"LITERAL_SUFFIX"),
+                                    static_cast<const SQLWCHAR*>(L"CREATE_PARAMS"),
+                                    static_cast<const SQLWCHAR*>(L"NULLABLE"),
+                                    static_cast<const SQLWCHAR*>(L"CASE_SENSITIVE"),
+                                    static_cast<const SQLWCHAR*>(L"SEARCHABLE"),
+                                    static_cast<const SQLWCHAR*>(L"UNSIGNED_ATTRIBUTE"),
+                                    static_cast<const SQLWCHAR*>(L"MONEY"),
+                                    static_cast<const SQLWCHAR*>(L"AUTO_INCREMENT"),
+                                    static_cast<const SQLWCHAR*>(L"LOCAL_TYPE_NAME"),
+                                    static_cast<const SQLWCHAR*>(L"MINIMUM_SCALE"),
+                                    static_cast<const SQLWCHAR*>(L"MAXIMUM_SCALE"),
+                                    static_cast<const SQLWCHAR*>(L"SQL_DATA_TYPE"),
+                                    static_cast<const SQLWCHAR*>(L"SQL_DATETIME_SUB"),
+                                    static_cast<const SQLWCHAR*>(L"NUM_PREC_RADIX"),
+                                    static_cast<const SQLWCHAR*>(L"INTERVAL_PRECISION")};
+  SQLSMALLINT column_data_types[] = {
+      SQL_WVARCHAR, SQL_SMALLINT, SQL_INTEGER,  SQL_WVARCHAR, SQL_WVARCHAR,
+      SQL_WVARCHAR, SQL_SMALLINT, SQL_SMALLINT, SQL_SMALLINT, SQL_SMALLINT,
+      SQL_SMALLINT, SQL_SMALLINT, SQL_WVARCHAR, SQL_SMALLINT, SQL_SMALLINT,
+      SQL_SMALLINT, SQL_SMALLINT, SQL_INTEGER,  SQL_SMALLINT};
+  SQLULEN column_sizes[] = {1024, 2, 4,    1024, 1024, 1024, 2, 2, 2, 2,
+                            2,    2, 1024, 2,    2,    2,    2, 4, 2};
+  SQLSMALLINT column_decimal_digits[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                         0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  SQLSMALLINT column_nullable[] = {SQL_NO_NULLS, SQL_NO_NULLS, SQL_NULLABLE, SQL_NULLABLE,
+                                   SQL_NULLABLE, SQL_NULLABLE, SQL_NO_NULLS, SQL_NO_NULLS,
+                                   SQL_NO_NULLS, SQL_NULLABLE, SQL_NO_NULLS, SQL_NULLABLE,
+                                   SQL_NULLABLE, SQL_NULLABLE, SQL_NULLABLE, SQL_NO_NULLS,
+                                   SQL_NULLABLE, SQL_NULLABLE, SQL_NULLABLE};
+
+  for (size_t i = 0; i < sizeof(column_names) / sizeof(*column_names); ++i) {
+    SQLUSMALLINT column_index = i + 1;
+    CheckSQLDescribeCol(stmt, column_index, column_names[i], column_data_types[i],
+                        column_sizes[i], column_decimal_digits[i], column_nullable[i]);
+  }
+}
+
+void CheckSQLDescribeColODBC3(SQLHSTMT stmt) {
+  const SQLWCHAR* column_names[] = {static_cast<const SQLWCHAR*>(L"TYPE_NAME"),
+                                    static_cast<const SQLWCHAR*>(L"DATA_TYPE"),
+                                    static_cast<const SQLWCHAR*>(L"COLUMN_SIZE"),
+                                    static_cast<const SQLWCHAR*>(L"LITERAL_PREFIX"),
+                                    static_cast<const SQLWCHAR*>(L"LITERAL_SUFFIX"),
+                                    static_cast<const SQLWCHAR*>(L"CREATE_PARAMS"),
+                                    static_cast<const SQLWCHAR*>(L"NULLABLE"),
+                                    static_cast<const SQLWCHAR*>(L"CASE_SENSITIVE"),
+                                    static_cast<const SQLWCHAR*>(L"SEARCHABLE"),
+                                    static_cast<const SQLWCHAR*>(L"UNSIGNED_ATTRIBUTE"),
+                                    static_cast<const SQLWCHAR*>(L"FIXED_PREC_SCALE"),
+                                    static_cast<const SQLWCHAR*>(L"AUTO_UNIQUE_VALUE"),
+                                    static_cast<const SQLWCHAR*>(L"LOCAL_TYPE_NAME"),
+                                    static_cast<const SQLWCHAR*>(L"MINIMUM_SCALE"),
+                                    static_cast<const SQLWCHAR*>(L"MAXIMUM_SCALE"),
+                                    static_cast<const SQLWCHAR*>(L"SQL_DATA_TYPE"),
+                                    static_cast<const SQLWCHAR*>(L"SQL_DATETIME_SUB"),
+                                    static_cast<const SQLWCHAR*>(L"NUM_PREC_RADIX"),
+                                    static_cast<const SQLWCHAR*>(L"INTERVAL_PRECISION")};
+  SQLSMALLINT column_data_types[] = {
+      SQL_WVARCHAR, SQL_SMALLINT, SQL_INTEGER,  SQL_WVARCHAR, SQL_WVARCHAR,
+      SQL_WVARCHAR, SQL_SMALLINT, SQL_SMALLINT, SQL_SMALLINT, SQL_SMALLINT,
+      SQL_SMALLINT, SQL_SMALLINT, SQL_WVARCHAR, SQL_SMALLINT, SQL_SMALLINT,
+      SQL_SMALLINT, SQL_SMALLINT, SQL_INTEGER,  SQL_SMALLINT};
+  SQLULEN column_sizes[] = {1024, 2, 4,    1024, 1024, 1024, 2, 2, 2, 2,
+                            2,    2, 1024, 2,    2,    2,    2, 4, 2};
+  SQLSMALLINT column_decimal_digits[] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                         0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+  SQLSMALLINT column_nullable[] = {SQL_NO_NULLS, SQL_NO_NULLS, SQL_NULLABLE, SQL_NULLABLE,
+                                   SQL_NULLABLE, SQL_NULLABLE, SQL_NO_NULLS, SQL_NO_NULLS,
+                                   SQL_NO_NULLS, SQL_NULLABLE, SQL_NO_NULLS, SQL_NULLABLE,
+                                   SQL_NULLABLE, SQL_NULLABLE, SQL_NULLABLE, SQL_NO_NULLS,
+                                   SQL_NULLABLE, SQL_NULLABLE, SQL_NULLABLE};
+
+  for (size_t i = 0; i < sizeof(column_names) / sizeof(*column_names); ++i) {
+    SQLUSMALLINT column_index = i + 1;
+    CheckSQLDescribeCol(stmt, column_index, column_names[i], column_data_types[i],
+                        column_sizes[i], column_decimal_digits[i], column_nullable[i]);
+  }
+}
+
 void CheckSQLGetTypeInfo(
     SQLHSTMT stmt, const std::wstring& expected_type_name,
     const SQLSMALLINT& expected_data_type, const SQLINTEGER& expected_column_size,
@@ -119,6 +232,8 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       NULL,                  // expected_num_prec_radix
                       NULL);                 // expected_interval_prec
 
+  CheckSQLDescribeColODBC3(this->stmt);
+
   // Check tinyint data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
@@ -142,6 +257,8 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       NULL,                      // expected_sql_datetime_sub
                       NULL,                      // expected_num_prec_radix
                       NULL);                     // expected_interval_prec
+
+  CheckSQLDescribeColODBC3(this->stmt);
 
   // Check bigint data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
@@ -167,6 +284,8 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       NULL,                     // expected_num_prec_radix
                       NULL);                    // expected_interval_prec
 
+  CheckSQLDescribeColODBC3(this->stmt);
+
   // Check longvarbinary data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
@@ -191,6 +310,8 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       NULL,                            // expected_num_prec_radix
                       NULL);                           // expected_interval_prec
 
+  CheckSQLDescribeColODBC3(this->stmt);
+
   // Check varbinary data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
@@ -214,6 +335,8 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       NULL,                        // expected_sql_datetime_sub
                       NULL,                        // expected_num_prec_radix
                       NULL);                       // expected_interval_prec
+
+  CheckSQLDescribeColODBC3(this->stmt);
 
   // Check text data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
@@ -240,6 +363,8 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       NULL,                     // expected_num_prec_radix
                       NULL);                    // expected_interval_prec
 
+  CheckSQLDescribeColODBC3(this->stmt);
+
   // Check longvarchar data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
@@ -263,6 +388,8 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       NULL,                          // expected_sql_datetime_sub
                       NULL,                          // expected_num_prec_radix
                       NULL);                         // expected_interval_prec
+
+  CheckSQLDescribeColODBC3(this->stmt);
 
   // Check char data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
@@ -289,6 +416,8 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       NULL,                     // expected_num_prec_radix
                       NULL);                    // expected_interval_prec
 
+  CheckSQLDescribeColODBC3(this->stmt);
+
   // Check integer data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
@@ -312,6 +441,8 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       NULL,                      // expected_sql_datetime_sub
                       NULL,                      // expected_num_prec_radix
                       NULL);                     // expected_interval_prec
+
+  CheckSQLDescribeColODBC3(this->stmt);
 
   // Check smallint data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
@@ -337,6 +468,8 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       NULL,                       // expected_num_prec_radix
                       NULL);                      // expected_interval_prec
 
+  CheckSQLDescribeColODBC3(this->stmt);
+
   // Check float data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
@@ -361,6 +494,8 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       NULL,                    // expected_num_prec_radix
                       NULL);                   // expected_interval_prec
 
+  CheckSQLDescribeColODBC3(this->stmt);
+
   // Check double data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
@@ -384,6 +519,8 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       NULL,                     // expected_sql_datetime_sub
                       NULL,                     // expected_num_prec_radix
                       NULL);                    // expected_interval_prec
+
+  CheckSQLDescribeColODBC3(this->stmt);
 
   // Check numeric data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
@@ -410,6 +547,8 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       NULL,                      // expected_num_prec_radix
                       NULL);                     // expected_interval_prec
 
+  CheckSQLDescribeColODBC3(this->stmt);
+
   // Check varchar data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
@@ -435,6 +574,8 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       NULL,                      // expected_num_prec_radix
                       NULL);                     // expected_interval_prec
 
+  CheckSQLDescribeColODBC3(this->stmt);
+
   // Check date data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
@@ -458,6 +599,8 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       SQL_CODE_DATE,          // expected_sql_datetime_sub
                       NULL,                   // expected_num_prec_radix
                       NULL);                  // expected_interval_prec
+
+  CheckSQLDescribeColODBC3(this->stmt);
 
   // Check time data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
@@ -483,6 +626,8 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       NULL,                   // expected_num_prec_radix
                       NULL);                  // expected_interval_prec
 
+  CheckSQLDescribeColODBC3(this->stmt);
+
   // Check timestamp data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
@@ -506,6 +651,8 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       SQL_CODE_TIMESTAMP,          // expected_sql_datetime_sub
                       NULL,                        // expected_num_prec_radix
                       NULL);                       // expected_interval_prec
+
+  CheckSQLDescribeColODBC3(this->stmt);
 }
 
 TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
@@ -535,6 +682,8 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       NULL,                  // expected_num_prec_radix
                       NULL);                 // expected_interval_prec
 
+  CheckSQLDescribeColODBC2(this->stmt);
+
   // Check tinyint data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
@@ -558,6 +707,8 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       NULL,                      // expected_sql_datetime_sub
                       NULL,                      // expected_num_prec_radix
                       NULL);                     // expected_interval_prec
+
+  CheckSQLDescribeColODBC2(this->stmt);
 
   // Check bigint data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
@@ -583,6 +734,8 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       NULL,                     // expected_num_prec_radix
                       NULL);                    // expected_interval_prec
 
+  CheckSQLDescribeColODBC2(this->stmt);
+
   // Check longvarbinary data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
@@ -607,6 +760,8 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       NULL,                            // expected_num_prec_radix
                       NULL);                           // expected_interval_prec
 
+  CheckSQLDescribeColODBC2(this->stmt);
+
   // Check varbinary data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
@@ -630,6 +785,8 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       NULL,                        // expected_sql_datetime_sub
                       NULL,                        // expected_num_prec_radix
                       NULL);                       // expected_interval_prec
+
+  CheckSQLDescribeColODBC2(this->stmt);
 
   // Check text data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
@@ -656,6 +813,8 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       NULL,                     // expected_num_prec_radix
                       NULL);                    // expected_interval_prec
 
+  CheckSQLDescribeColODBC2(this->stmt);
+
   // Check longvarchar data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
@@ -679,6 +838,8 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       NULL,                          // expected_sql_datetime_sub
                       NULL,                          // expected_num_prec_radix
                       NULL);                         // expected_interval_prec
+
+  CheckSQLDescribeColODBC2(this->stmt);
 
   // Check char data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
@@ -705,6 +866,8 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       NULL,                     // expected_num_prec_radix
                       NULL);                    // expected_interval_prec
 
+  CheckSQLDescribeColODBC2(this->stmt);
+
   // Check integer data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
@@ -728,6 +891,8 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       NULL,                      // expected_sql_datetime_sub
                       NULL,                      // expected_num_prec_radix
                       NULL);                     // expected_interval_prec
+
+  CheckSQLDescribeColODBC2(this->stmt);
 
   // Check smallint data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
@@ -753,6 +918,8 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       NULL,                       // expected_num_prec_radix
                       NULL);                      // expected_interval_prec
 
+  CheckSQLDescribeColODBC2(this->stmt);
+
   // Check float data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
@@ -777,6 +944,8 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       NULL,                    // expected_num_prec_radix
                       NULL);                   // expected_interval_prec
 
+  CheckSQLDescribeColODBC2(this->stmt);
+
   // Check double data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
@@ -800,6 +969,8 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       NULL,                     // expected_sql_datetime_sub
                       NULL,                     // expected_num_prec_radix
                       NULL);                    // expected_interval_prec
+
+  CheckSQLDescribeColODBC2(this->stmt);
 
   // Check numeric data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
@@ -826,6 +997,8 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       NULL,                      // expected_num_prec_radix
                       NULL);                     // expected_interval_prec
 
+  CheckSQLDescribeColODBC2(this->stmt);
+
   // Check varchar data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
@@ -851,6 +1024,8 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       NULL,                      // expected_num_prec_radix
                       NULL);                     // expected_interval_prec
 
+  CheckSQLDescribeColODBC2(this->stmt);
+
   // Check date data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
@@ -874,6 +1049,8 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       NULL,   // expected_sql_datetime_sub, driver returns NULL for Ver2
                       NULL,   // expected_num_prec_radix
                       NULL);  // expected_interval_prec
+
+  CheckSQLDescribeColODBC2(this->stmt);
 
   // Check time data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
@@ -899,6 +1076,8 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       NULL,   // expected_num_prec_radix
                       NULL);  // expected_interval_prec
 
+  CheckSQLDescribeColODBC2(this->stmt);
+
   // Check timestamp data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
@@ -922,6 +1101,8 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       NULL,   // expected_sql_datetime_sub, driver returns NULL for Ver2
                       NULL,   // expected_num_prec_radix
                       NULL);  // expected_interval_prec
+
+  CheckSQLDescribeColODBC2(this->stmt);
 }
 
 TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoBit) {
@@ -950,6 +1131,8 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoBit) {
                       NULL,                  // expected_sql_datetime_sub
                       NULL,                  // expected_num_prec_radix
                       NULL);                 // expected_interval_prec
+
+  CheckSQLDescribeColODBC3(this->stmt);
 
   // No more data
   ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
@@ -982,6 +1165,8 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoTinyInt) {
                       NULL,                      // expected_num_prec_radix
                       NULL);                     // expected_interval_prec
 
+  CheckSQLDescribeColODBC3(this->stmt);
+
   // No more data
   ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
 }
@@ -1013,6 +1198,8 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoBigInt) {
                       NULL,                     // expected_num_prec_radix
                       NULL);                    // expected_interval_prec
 
+  CheckSQLDescribeColODBC3(this->stmt);
+
   // No more data
   ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
 }
@@ -1043,6 +1230,8 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoLongVarbinary) {
                       NULL,                            // expected_sql_datetime_sub
                       NULL,                            // expected_num_prec_radix
                       NULL);                           // expected_interval_prec
+
+  CheckSQLDescribeColODBC3(this->stmt);
 
   // No more data
   ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
@@ -1107,6 +1296,8 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoLongVarchar) {
                       NULL,                     // expected_num_prec_radix
                       NULL);                    // expected_interval_prec
 
+  CheckSQLDescribeColODBC3(this->stmt);
+
   // Check longvarchar data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
@@ -1130,6 +1321,8 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoLongVarchar) {
                       NULL,                          // expected_sql_datetime_sub
                       NULL,                          // expected_num_prec_radix
                       NULL);                         // expected_interval_prec
+
+  CheckSQLDescribeColODBC3(this->stmt);
 
   // No more data
   ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
@@ -1163,6 +1356,8 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoChar) {
                       NULL,                     // expected_num_prec_radix
                       NULL);                    // expected_interval_prec
 
+  CheckSQLDescribeColODBC3(this->stmt);
+
   // No more data
   ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
 }
@@ -1193,6 +1388,8 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoInteger) {
                       NULL,                      // expected_sql_datetime_sub
                       NULL,                      // expected_num_prec_radix
                       NULL);                     // expected_interval_prec
+
+  CheckSQLDescribeColODBC3(this->stmt);
 
   // No more data
   ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
@@ -1225,6 +1422,8 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoSmallInt) {
                       NULL,                       // expected_num_prec_radix
                       NULL);                      // expected_interval_prec
 
+  CheckSQLDescribeColODBC3(this->stmt);
+
   // No more data
   ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
 }
@@ -1255,6 +1454,8 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoFloat) {
                       NULL,                    // expected_sql_datetime_sub
                       NULL,                    // expected_num_prec_radix
                       NULL);                   // expected_interval_prec
+
+  CheckSQLDescribeColODBC3(this->stmt);
 
   // No more data
   ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
@@ -1287,6 +1488,8 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoDouble) {
                       NULL,                     // expected_num_prec_radix
                       NULL);                    // expected_interval_prec
 
+  CheckSQLDescribeColODBC3(this->stmt);
+
   // Check numeric data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
@@ -1311,6 +1514,8 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoDouble) {
                       NULL,                      // expected_sql_datetime_sub
                       NULL,                      // expected_num_prec_radix
                       NULL);                     // expected_interval_prec
+
+  CheckSQLDescribeColODBC3(this->stmt);
 
   // No more data
   ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
@@ -1344,6 +1549,8 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoVarchar) {
                       NULL,                      // expected_num_prec_radix
                       NULL);                     // expected_interval_prec
 
+  CheckSQLDescribeColODBC3(this->stmt);
+
   // No more data
   ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
 }
@@ -1374,6 +1581,8 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoSQLTypeDate) {
                       SQL_CODE_DATE,          // expected_sql_datetime_sub
                       NULL,                   // expected_num_prec_radix
                       NULL);                  // expected_interval_prec
+
+  CheckSQLDescribeColODBC3(this->stmt);
 
   // No more data
   ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
@@ -1407,6 +1616,8 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoSQLDate) {
                       NULL,                   // expected_num_prec_radix
                       NULL);                  // expected_interval_prec
 
+  CheckSQLDescribeColODBC3(this->stmt);
+
   // No more data
   ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
 }
@@ -1437,6 +1648,8 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoDateODBCVer2) {
                       NULL,   // expected_sql_datetime_sub, driver returns NULL for Ver2
                       NULL,   // expected_num_prec_radix
                       NULL);  // expected_interval_prec
+
+  CheckSQLDescribeColODBC2(this->stmt);
 
   // No more data
   ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
@@ -1477,6 +1690,8 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoSQLTypeTime) {
                       NULL,                   // expected_num_prec_radix
                       NULL);                  // expected_interval_prec
 
+  CheckSQLDescribeColODBC3(this->stmt);
+
   // No more data
   ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
 }
@@ -1509,6 +1724,8 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoSQLTime) {
                       NULL,                   // expected_num_prec_radix
                       NULL);                  // expected_interval_prec
 
+  CheckSQLDescribeColODBC3(this->stmt);
+
   // No more data
   ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
 }
@@ -1539,6 +1756,8 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoTimeODBCVer2) {
                       NULL,   // expected_sql_datetime_sub, driver returns NULL for Ver2
                       NULL,   // expected_num_prec_radix
                       NULL);  // expected_interval_prec
+
+  CheckSQLDescribeColODBC2(this->stmt);
 
   // No more data
   ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
@@ -1579,6 +1798,8 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoSQLTypeTimestamp) {
                       NULL,                        // expected_num_prec_radix
                       NULL);                       // expected_interval_prec
 
+  CheckSQLDescribeColODBC3(this->stmt);
+
   // No more data
   ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
 }
@@ -1611,6 +1832,8 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoSQLTimestamp) {
                       NULL,                        // expected_num_prec_radix
                       NULL);                       // expected_interval_prec
 
+  CheckSQLDescribeColODBC3(this->stmt);
+
   // No more data
   ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
 }
@@ -1641,6 +1864,8 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoSQLTimestampODBCVer2) {
                       NULL,   // expected_sql_datetime_sub, driver returns NULL for Ver2
                       NULL,   // expected_num_prec_radix
                       NULL);  // expected_interval_prec
+
+  CheckSQLDescribeColODBC2(this->stmt);
 
   // No more data
   ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));

--- a/cpp/src/arrow/flight/sql/odbc/tests/type_info_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/type_info_test.cc
@@ -69,7 +69,7 @@ void CheckSQLDescribeCol(SQLHSTMT stmt, const SQLUSMALLINT column_index,
   EXPECT_EQ(expected_nullable, nullable);
 }
 
-void CheckSQLDescribeColODBC2(SQLHSTMT stmt) {
+void CheckSQLDescribeColODBCVer2(SQLHSTMT stmt) {
   const SQLWCHAR* column_names[] = {static_cast<const SQLWCHAR*>(L"TYPE_NAME"),
                                     static_cast<const SQLWCHAR*>(L"DATA_TYPE"),
                                     static_cast<const SQLWCHAR*>(L"PRECISION"),
@@ -111,7 +111,7 @@ void CheckSQLDescribeColODBC2(SQLHSTMT stmt) {
   }
 }
 
-void CheckSQLDescribeColODBC3(SQLHSTMT stmt) {
+void CheckSQLDescribeColODBCVer3(SQLHSTMT stmt) {
   const SQLWCHAR* column_names[] = {static_cast<const SQLWCHAR*>(L"TYPE_NAME"),
                                     static_cast<const SQLWCHAR*>(L"DATA_TYPE"),
                                     static_cast<const SQLWCHAR*>(L"COLUMN_SIZE"),
@@ -232,7 +232,7 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       NULL,                  // expected_num_prec_radix
                       NULL);                 // expected_interval_prec
 
-  CheckSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBCVer3(this->stmt);
 
   // Check tinyint data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
@@ -258,7 +258,7 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       NULL,                      // expected_num_prec_radix
                       NULL);                     // expected_interval_prec
 
-  CheckSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBCVer3(this->stmt);
 
   // Check bigint data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
@@ -284,7 +284,7 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       NULL,                     // expected_num_prec_radix
                       NULL);                    // expected_interval_prec
 
-  CheckSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBCVer3(this->stmt);
 
   // Check longvarbinary data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
@@ -310,7 +310,7 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       NULL,                            // expected_num_prec_radix
                       NULL);                           // expected_interval_prec
 
-  CheckSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBCVer3(this->stmt);
 
   // Check varbinary data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
@@ -336,7 +336,7 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       NULL,                        // expected_num_prec_radix
                       NULL);                       // expected_interval_prec
 
-  CheckSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBCVer3(this->stmt);
 
   // Check text data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
@@ -363,7 +363,7 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       NULL,                     // expected_num_prec_radix
                       NULL);                    // expected_interval_prec
 
-  CheckSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBCVer3(this->stmt);
 
   // Check longvarchar data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
@@ -389,7 +389,7 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       NULL,                          // expected_num_prec_radix
                       NULL);                         // expected_interval_prec
 
-  CheckSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBCVer3(this->stmt);
 
   // Check char data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
@@ -416,7 +416,7 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       NULL,                     // expected_num_prec_radix
                       NULL);                    // expected_interval_prec
 
-  CheckSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBCVer3(this->stmt);
 
   // Check integer data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
@@ -442,7 +442,7 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       NULL,                      // expected_num_prec_radix
                       NULL);                     // expected_interval_prec
 
-  CheckSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBCVer3(this->stmt);
 
   // Check smallint data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
@@ -468,7 +468,7 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       NULL,                       // expected_num_prec_radix
                       NULL);                      // expected_interval_prec
 
-  CheckSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBCVer3(this->stmt);
 
   // Check float data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
@@ -494,7 +494,7 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       NULL,                    // expected_num_prec_radix
                       NULL);                   // expected_interval_prec
 
-  CheckSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBCVer3(this->stmt);
 
   // Check double data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
@@ -520,7 +520,7 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       NULL,                     // expected_num_prec_radix
                       NULL);                    // expected_interval_prec
 
-  CheckSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBCVer3(this->stmt);
 
   // Check numeric data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
@@ -547,7 +547,7 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       NULL,                      // expected_num_prec_radix
                       NULL);                     // expected_interval_prec
 
-  CheckSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBCVer3(this->stmt);
 
   // Check varchar data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
@@ -574,7 +574,7 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       NULL,                      // expected_num_prec_radix
                       NULL);                     // expected_interval_prec
 
-  CheckSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBCVer3(this->stmt);
 
   // Check date data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
@@ -600,7 +600,7 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       NULL,                   // expected_num_prec_radix
                       NULL);                  // expected_interval_prec
 
-  CheckSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBCVer3(this->stmt);
 
   // Check time data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
@@ -626,7 +626,7 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       NULL,                   // expected_num_prec_radix
                       NULL);                  // expected_interval_prec
 
-  CheckSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBCVer3(this->stmt);
 
   // Check timestamp data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
@@ -652,7 +652,7 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       NULL,                        // expected_num_prec_radix
                       NULL);                       // expected_interval_prec
 
-  CheckSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBCVer3(this->stmt);
 }
 
 TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
@@ -682,7 +682,7 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       NULL,                  // expected_num_prec_radix
                       NULL);                 // expected_interval_prec
 
-  CheckSQLDescribeColODBC2(this->stmt);
+  CheckSQLDescribeColODBCVer2(this->stmt);
 
   // Check tinyint data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
@@ -708,7 +708,7 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       NULL,                      // expected_num_prec_radix
                       NULL);                     // expected_interval_prec
 
-  CheckSQLDescribeColODBC2(this->stmt);
+  CheckSQLDescribeColODBCVer2(this->stmt);
 
   // Check bigint data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
@@ -734,7 +734,7 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       NULL,                     // expected_num_prec_radix
                       NULL);                    // expected_interval_prec
 
-  CheckSQLDescribeColODBC2(this->stmt);
+  CheckSQLDescribeColODBCVer2(this->stmt);
 
   // Check longvarbinary data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
@@ -760,7 +760,7 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       NULL,                            // expected_num_prec_radix
                       NULL);                           // expected_interval_prec
 
-  CheckSQLDescribeColODBC2(this->stmt);
+  CheckSQLDescribeColODBCVer2(this->stmt);
 
   // Check varbinary data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
@@ -786,7 +786,7 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       NULL,                        // expected_num_prec_radix
                       NULL);                       // expected_interval_prec
 
-  CheckSQLDescribeColODBC2(this->stmt);
+  CheckSQLDescribeColODBCVer2(this->stmt);
 
   // Check text data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
@@ -813,7 +813,7 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       NULL,                     // expected_num_prec_radix
                       NULL);                    // expected_interval_prec
 
-  CheckSQLDescribeColODBC2(this->stmt);
+  CheckSQLDescribeColODBCVer2(this->stmt);
 
   // Check longvarchar data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
@@ -839,7 +839,7 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       NULL,                          // expected_num_prec_radix
                       NULL);                         // expected_interval_prec
 
-  CheckSQLDescribeColODBC2(this->stmt);
+  CheckSQLDescribeColODBCVer2(this->stmt);
 
   // Check char data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
@@ -866,7 +866,7 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       NULL,                     // expected_num_prec_radix
                       NULL);                    // expected_interval_prec
 
-  CheckSQLDescribeColODBC2(this->stmt);
+  CheckSQLDescribeColODBCVer2(this->stmt);
 
   // Check integer data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
@@ -892,7 +892,7 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       NULL,                      // expected_num_prec_radix
                       NULL);                     // expected_interval_prec
 
-  CheckSQLDescribeColODBC2(this->stmt);
+  CheckSQLDescribeColODBCVer2(this->stmt);
 
   // Check smallint data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
@@ -918,7 +918,7 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       NULL,                       // expected_num_prec_radix
                       NULL);                      // expected_interval_prec
 
-  CheckSQLDescribeColODBC2(this->stmt);
+  CheckSQLDescribeColODBCVer2(this->stmt);
 
   // Check float data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
@@ -944,7 +944,7 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       NULL,                    // expected_num_prec_radix
                       NULL);                   // expected_interval_prec
 
-  CheckSQLDescribeColODBC2(this->stmt);
+  CheckSQLDescribeColODBCVer2(this->stmt);
 
   // Check double data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
@@ -970,7 +970,7 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       NULL,                     // expected_num_prec_radix
                       NULL);                    // expected_interval_prec
 
-  CheckSQLDescribeColODBC2(this->stmt);
+  CheckSQLDescribeColODBCVer2(this->stmt);
 
   // Check numeric data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
@@ -997,7 +997,7 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       NULL,                      // expected_num_prec_radix
                       NULL);                     // expected_interval_prec
 
-  CheckSQLDescribeColODBC2(this->stmt);
+  CheckSQLDescribeColODBCVer2(this->stmt);
 
   // Check varchar data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
@@ -1024,7 +1024,7 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       NULL,                      // expected_num_prec_radix
                       NULL);                     // expected_interval_prec
 
-  CheckSQLDescribeColODBC2(this->stmt);
+  CheckSQLDescribeColODBCVer2(this->stmt);
 
   // Check date data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
@@ -1050,7 +1050,7 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       NULL,   // expected_num_prec_radix
                       NULL);  // expected_interval_prec
 
-  CheckSQLDescribeColODBC2(this->stmt);
+  CheckSQLDescribeColODBCVer2(this->stmt);
 
   // Check time data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
@@ -1076,7 +1076,7 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       NULL,   // expected_num_prec_radix
                       NULL);  // expected_interval_prec
 
-  CheckSQLDescribeColODBC2(this->stmt);
+  CheckSQLDescribeColODBCVer2(this->stmt);
 
   // Check timestamp data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
@@ -1102,7 +1102,7 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       NULL,   // expected_num_prec_radix
                       NULL);  // expected_interval_prec
 
-  CheckSQLDescribeColODBC2(this->stmt);
+  CheckSQLDescribeColODBCVer2(this->stmt);
 }
 
 TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoBit) {
@@ -1132,7 +1132,7 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoBit) {
                       NULL,                  // expected_num_prec_radix
                       NULL);                 // expected_interval_prec
 
-  CheckSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBCVer3(this->stmt);
 
   // No more data
   ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
@@ -1165,7 +1165,7 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoTinyInt) {
                       NULL,                      // expected_num_prec_radix
                       NULL);                     // expected_interval_prec
 
-  CheckSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBCVer3(this->stmt);
 
   // No more data
   ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
@@ -1198,7 +1198,7 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoBigInt) {
                       NULL,                     // expected_num_prec_radix
                       NULL);                    // expected_interval_prec
 
-  CheckSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBCVer3(this->stmt);
 
   // No more data
   ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
@@ -1231,7 +1231,7 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoLongVarbinary) {
                       NULL,                            // expected_num_prec_radix
                       NULL);                           // expected_interval_prec
 
-  CheckSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBCVer3(this->stmt);
 
   // No more data
   ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
@@ -1296,7 +1296,7 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoLongVarchar) {
                       NULL,                     // expected_num_prec_radix
                       NULL);                    // expected_interval_prec
 
-  CheckSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBCVer3(this->stmt);
 
   // Check longvarchar data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
@@ -1322,7 +1322,7 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoLongVarchar) {
                       NULL,                          // expected_num_prec_radix
                       NULL);                         // expected_interval_prec
 
-  CheckSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBCVer3(this->stmt);
 
   // No more data
   ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
@@ -1356,7 +1356,7 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoChar) {
                       NULL,                     // expected_num_prec_radix
                       NULL);                    // expected_interval_prec
 
-  CheckSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBCVer3(this->stmt);
 
   // No more data
   ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
@@ -1389,7 +1389,7 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoInteger) {
                       NULL,                      // expected_num_prec_radix
                       NULL);                     // expected_interval_prec
 
-  CheckSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBCVer3(this->stmt);
 
   // No more data
   ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
@@ -1422,7 +1422,7 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoSmallInt) {
                       NULL,                       // expected_num_prec_radix
                       NULL);                      // expected_interval_prec
 
-  CheckSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBCVer3(this->stmt);
 
   // No more data
   ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
@@ -1455,7 +1455,7 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoFloat) {
                       NULL,                    // expected_num_prec_radix
                       NULL);                   // expected_interval_prec
 
-  CheckSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBCVer3(this->stmt);
 
   // No more data
   ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
@@ -1488,7 +1488,7 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoDouble) {
                       NULL,                     // expected_num_prec_radix
                       NULL);                    // expected_interval_prec
 
-  CheckSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBCVer3(this->stmt);
 
   // Check numeric data type
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
@@ -1515,7 +1515,7 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoDouble) {
                       NULL,                      // expected_num_prec_radix
                       NULL);                     // expected_interval_prec
 
-  CheckSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBCVer3(this->stmt);
 
   // No more data
   ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
@@ -1549,7 +1549,7 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoVarchar) {
                       NULL,                      // expected_num_prec_radix
                       NULL);                     // expected_interval_prec
 
-  CheckSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBCVer3(this->stmt);
 
   // No more data
   ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
@@ -1582,7 +1582,7 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoSQLTypeDate) {
                       NULL,                   // expected_num_prec_radix
                       NULL);                  // expected_interval_prec
 
-  CheckSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBCVer3(this->stmt);
 
   // No more data
   ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
@@ -1616,7 +1616,7 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoSQLDate) {
                       NULL,                   // expected_num_prec_radix
                       NULL);                  // expected_interval_prec
 
-  CheckSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBCVer3(this->stmt);
 
   // No more data
   ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
@@ -1649,7 +1649,7 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoDateODBCVer2) {
                       NULL,   // expected_num_prec_radix
                       NULL);  // expected_interval_prec
 
-  CheckSQLDescribeColODBC2(this->stmt);
+  CheckSQLDescribeColODBCVer2(this->stmt);
 
   // No more data
   ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
@@ -1690,7 +1690,7 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoSQLTypeTime) {
                       NULL,                   // expected_num_prec_radix
                       NULL);                  // expected_interval_prec
 
-  CheckSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBCVer3(this->stmt);
 
   // No more data
   ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
@@ -1724,7 +1724,7 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoSQLTime) {
                       NULL,                   // expected_num_prec_radix
                       NULL);                  // expected_interval_prec
 
-  CheckSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBCVer3(this->stmt);
 
   // No more data
   ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
@@ -1757,7 +1757,7 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoTimeODBCVer2) {
                       NULL,   // expected_num_prec_radix
                       NULL);  // expected_interval_prec
 
-  CheckSQLDescribeColODBC2(this->stmt);
+  CheckSQLDescribeColODBCVer2(this->stmt);
 
   // No more data
   ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
@@ -1798,7 +1798,7 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoSQLTypeTimestamp) {
                       NULL,                        // expected_num_prec_radix
                       NULL);                       // expected_interval_prec
 
-  CheckSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBCVer3(this->stmt);
 
   // No more data
   ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
@@ -1832,7 +1832,7 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoSQLTimestamp) {
                       NULL,                        // expected_num_prec_radix
                       NULL);                       // expected_interval_prec
 
-  CheckSQLDescribeColODBC3(this->stmt);
+  CheckSQLDescribeColODBCVer3(this->stmt);
 
   // No more data
   ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
@@ -1865,7 +1865,7 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoSQLTimestampODBCVer2) {
                       NULL,   // expected_num_prec_radix
                       NULL);  // expected_interval_prec
 
-  CheckSQLDescribeColODBC2(this->stmt);
+  CheckSQLDescribeColODBCVer2(this->stmt);
 
   // No more data
   ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));


### PR DESCRIPTION
### Rationale for this change
Implement SQLDescribeCol which "returns the result descriptor - column name,type, column size, decimal digits, and nullability - for one column in the result set. This information also is available in the fields of the IRD." ([Microsoft doc reference](https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqldescribecol-function?view=sql-server-ver17))

### What changes are included in this PR?
- SQLDescribeCol & Tests
### Are these changes tested?
Tested locally on MSVC Windows
### Are there any user-facing changes?
n/a
* GitHub Issue: #47724