### PR TITLE
GH-47957: [CI][C++] Try uninstalling protobuf from macOS 14

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -230,6 +230,11 @@ jobs:
           brew uninstall pkg-config || :
           brew uninstall pkg-config@0.29.2 || :
           brew bundle --file=cpp/Brewfile
+      - name: Uninstall protobuf on macOS 14
+        if: ${{ matrix.macos-version == '14' }}
+        run: |
+          # this should use bundled protobuf
+          brew uninstall re2 abseil grpc protobuf || :
       - name: Install MinIO
         run: |
           $(brew --prefix bash)/bin/bash \


### PR DESCRIPTION
## TBD

This is just a testing PR to validate whether the problem we see with substrait failures is because if brew's protobuf. This is not a solution.

### Rationale for this change

### What changes are included in this PR?

### Are these changes tested?

### Are there any user-facing changes?

**This PR includes breaking changes to public APIs.** (If there are any breaking changes to public APIs, please explain which changes are breaking. If not, you can remove this.)

**This PR contains a "Critical Fix".** (If the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld), please provide explanation. If not, you can remove this.)

* GitHub Issue: #47957