### PR TITLE
GH-48000: [CI][Release] Publish RC GitHub Release as draft to allow immutable releases

### DIFF
--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -112,6 +112,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh release create ${GITHUB_REF_NAME} \
+            --draft \
             --verify-tag \
             --prerelease \
             --title "${RELEASE_CANDIDATE_TITLE}" \

--- a/dev/release/08-publish-gh-release.sh
+++ b/dev/release/08-publish-gh-release.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -e
+set -u
+set -o pipefail
+
+SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [ "$#" -ne 2 ]; then
+  echo "Usage: $0 <version> <rc-num>"
+  exit
+fi
+
+. "${SOURCE_DIR}/utils-env.sh"
+
+version=$1
+rc=$2
+REPOSITORY="apache/arrow"
+
+rc_tag="apache-arrow-${version}-rc${rc}"
+gh release edit ${rc_tag} --repo ${REPOSITORY} --draft=false

--- a/docs/source/developers/release.rst
+++ b/docs/source/developers/release.rst
@@ -266,7 +266,7 @@ Build source and binaries and submit them
     # Start verifications for binaries and wheels
     dev/release/07-binary-verify.sh <version> <rc-number>
 
-    # Move the GitHub Release from draft to published state
+    # Move the Release Candidate GitHub Release from draft to published state
     dev/release/08-publish-gh-release.sh <version> <rc-number>
 
 Verify the Release

--- a/docs/source/developers/release.rst
+++ b/docs/source/developers/release.rst
@@ -266,6 +266,9 @@ Build source and binaries and submit them
     # Start verifications for binaries and wheels
     dev/release/07-binary-verify.sh <version> <rc-number>
 
+    # Move the GitHub Release from draft to published state
+    dev/release/08-publish-gh-release.sh <version> <rc-number>
+
 Verify the Release
 ------------------
 


### PR DESCRIPTION
### Rationale for this change

GitHub allows repositories to set up immutable GitHub releases. Immutable releases won't allow for artifacts to be published to the release once the release is published and out of draft-mode. The release immutability has to be set up per repository (or organization).

### What changes are included in this PR?

Create the Release Candidate GitHub release as draft in order to allow for immutable releases to be set up on the repository.

Addition of artifacts will be available to the RC release but won't be available to the official release as we upload all artifacts as part of the release creation.

Publish the RC release once no new artifacts have to be uploaded.

### Are these changes tested?

Not as part of a release but I've created a release on my fork and tested the workflow. See:
https://github.com/raulcd/arrow/releases/tag/raul-test-release-immutable

I've validated that when immutable releases are configured on the repository:
- artifacts can be uploaded when the release is in draft mode.
- Release can be edited on draft mode
- Once the draft mode is removed no new artifacts can be uploaded
- The release can be edited (add final release notes) when the release is not in draft mode, allowing for our workflow of the release to add the final release notes without problems.

### Are there any user-facing changes?

No but users will be able to validate the artifacts have not been updated/changed since the release was done due to immutability.

* GitHub Issue: #48000