### PR TITLE
GH-48062: [C++] Fix null pointer dereference in MakeExecBatch

### DIFF
--- a/cpp/src/arrow/compute/expression.cc
+++ b/cpp/src/arrow/compute/expression.cc
@@ -687,7 +687,8 @@ Result<ExecBatch> MakeExecBatch(const Schema& full_schema, const Datum& partial,
   }
 
   // wasteful but useful for testing:
-  if (partial.type()->id() == Type::STRUCT) {
+  const auto& partial_type = partial.type();
+  if (partial_type && partial_type->id() == Type::STRUCT) {
     if (partial.is_array()) {
       ARROW_ASSIGN_OR_RAISE(auto partial_batch,
                             RecordBatch::FromStructArray(partial.make_array()));

--- a/cpp/src/arrow/compute/expression_test.cc
+++ b/cpp/src/arrow/compute/expression_test.cc
@@ -224,6 +224,9 @@ TEST(ExpressionUtils, MakeExecBatch) {
   auto duplicated_names =
       RecordBatch::Make(schema({GetField("i32"), GetField("i32")}), kNumRows, {i32, i32});
   ASSERT_RAISES(Invalid, MakeExecBatch(*kBoringSchema, duplicated_names));
+
+  ASSERT_OK_AND_ASSIGN(auto boring_table, Table::MakeEmpty(kBoringSchema));
+  ASSERT_RAISES(NotImplemented, MakeExecBatch(*kBoringSchema, boring_table));
 }
 
 class WidgetifyOptions : public compute::FunctionOptions {


### PR DESCRIPTION
### Rationale for this change

The `arrow::compute::MakeExecBatch` function calls `DataType::id()` on `partial.type()` which could be a null pointer when `partial` is a datum representing a table. `MakeExecBatch` fails to check for this and thus null pointer dereference indeed happen. 

### What changes are included in this PR?

This patch adds a simple check in `MakeExecBatch` before calling `DataType::id()` to make sure it won't gets called on a null pointer.

### Are these changes tested?

Yes. This patch updates the unit test `ExpressionUtils.MakeExecBatch` and includes a case that calls `MakeExecBatch` with a table.

### Are there any user-facing changes?

No.

This PR indeed resolve a crash problem, but I'm not quite sure whether this should be classified as a "critical fix".

Resolve #48062 .
* GitHub Issue: #48062