### PR TITLE
GH-48064: [C++] Set ARROW_BUILD_STATIC=ON when features-flight are enabled on CMake presets

### DIFF
--- a/cpp/CMakePresets.json
+++ b/cpp/CMakePresets.json
@@ -111,6 +111,7 @@
       "inherits": "features-basic",
       "hidden": true,
       "cacheVariables": {
+        "ARROW_BUILD_STATIC": "ON",
         "ARROW_FLIGHT": "ON"
       }
     },


### PR DESCRIPTION
### Rationale for this change

We require static build when we are building flight. The current preset fails.

### What changes are included in this PR?

Set `"ARROW_BUILD_STATIC": "ON",` when using `features-flight`

### Are these changes tested?

I've tested locally, the build following our build guidelines does not fail anymore.

### Are there any user-facing changes?

No

* GitHub Issue: #48064