### PR TITLE
GH-48079: [CI] Fix a typo in util_free_space.sh

### DIFF
--- a/ci/scripts/util_free_space.sh
+++ b/ci/scripts/util_free_space.sh
@@ -25,7 +25,7 @@ du -hsc /usr/local/*
 echo "::endgroup::"
 # ~1GB
 sudo rm -rf \
-  /usr/local/aws-sam-cil \
+  /usr/local/aws-sam-cli \
   /usr/local/julia* || :
 echo "::group::/usr/local/bin/*"
 du -hsc /usr/local/bin/*


### PR DESCRIPTION
### Rationale for this change
Fixes a typo in util_free_space.sh. See #48079

### What changes are included in this PR?
Simple typo fix.

### Are these changes tested?
This is a CI script.

### Are there any user-facing changes?
No

* GitHub Issue: #48079