### PR TITLE
GH-48091: [C++] Use FetchContent for bundled c-ares

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -3019,6 +3019,9 @@ function(build_cares)
                                                    "${LIBRESOLV_LIBRARY}")
   endif()
 
+  set(ARROW_BUNDLED_STATIC_LIBS
+      ${ARROW_BUNDLED_STATIC_LIBS} c-ares::cares
+      PARENT_SCOPE)
   list(POP_BACK CMAKE_MESSAGE_INDENT)
 endfunction()
 

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -3171,7 +3171,9 @@ function(build_absl)
     # This is due to upstream absl::cctz issue
     # https://github.com/abseil/abseil-cpp/issues/283
     find_library(CoreFoundation CoreFoundation)
-    set_property(TARGET absl::time
+    # When ABSL_ENABLE_INSTALL is ON, the real target is "time" not "absl_time"
+    # Cannot use set_property on alias targets (absl::time is an alias)
+    set_property(TARGET time
                  APPEND
                  PROPERTY INTERFACE_LINK_LIBRARIES ${CoreFoundation})
   endif()


### PR DESCRIPTION
### Rationale for this change

As a follow up of requiring a minimum CMake version >= 3.25 we discussed moving our dependencies from ExternalProject to FetchContent. This can heavily simplify our third party dependency management. Moving c-ares is the next step before moving grpc.

### What changes are included in this PR?

The general change is moving from `ExternalProject` to `FetchContent`. 

It also add some required integration due to other dependencies, like grpc, using `ExternalProject`. We not only have to build but also install in order for those other dependencies to find c-ares. This causes some timing issues between config, build, install that requires us to create a custom target to depend on so the other dependencies find abseil.

### Are these changes tested?

Yes, the changes are tested locally and on CI.

### Are there any user-facing changes?

No
* GitHub Issue: #48091