### PR TITLE
GH-48098: [R] Fix nightly libarrow binary uploads

### DIFF
--- a/.github/workflows/r_nightly.yml
+++ b/.github/workflows/r_nightly.yml
@@ -125,13 +125,13 @@ jobs:
           )
           current_lib_path <- list.files(art_path,
             full.names = TRUE,
-            pattern = "r-lib",
+            pattern = "r-libarrow",
             recursive = TRUE
           )
           current_path <- c(current_pkg_path, current_lib_path)
           files <- c(
             sub("r-pkg", repo_root, current_pkg_path),
-            sub("r-lib", paste0(repo_root, "__r-lib"), current_lib_path)
+            sub("r-libarrow", paste0(repo_root, "__libarrow__r-libarrow"), current_lib_path)
           )
 
           # decode contrib.url from artifact name:


### PR DESCRIPTION
### Rationale for this change

R nightly libarrow C++ binary uploads have been failing 

### What changes are included in this PR?

Fix artifact pattern matching in the R nightly upload workflow to correctly find and copy libarrow C++ binaries.

### Are these changes tested?

Will verify once workflow runs successfully and files appear at https://nightlies.apache.org/arrow/r/libarrow/

### Are there any user-facing changes?

Yes - restores nightly libarrow C++ binary availability for R package source builds.
* GitHub Issue: #48098