### PR TITLE
GH-48096 [Python][Parquet] Expose new WriterProperties::max_rows_per_page to Python bindings

### DIFF
--- a/python/pyarrow/_dataset_parquet.pyx
+++ b/python/pyarrow/_dataset_parquet.pyx
@@ -696,6 +696,7 @@ cdef class ParquetFileWriteOptions(FileWriteOptions):
             version="2.6",
             write_statistics=None,
             data_page_size=None,
+            max_rows_per_page=None,
             compression_level=None,
             use_byte_stream_split=False,
             column_encoding=None,

--- a/python/pyarrow/_dataset_parquet.pyx
+++ b/python/pyarrow/_dataset_parquet.pyx
@@ -646,6 +646,7 @@ cdef class ParquetFileWriteOptions(FileWriteOptions):
             version=self._properties["version"],
             write_statistics=self._properties["write_statistics"],
             data_page_size=self._properties["data_page_size"],
+            max_rows_per_page=self._properties["max_rows_per_page"],
             compression_level=self._properties["compression_level"],
             use_byte_stream_split=(
                 self._properties["use_byte_stream_split"]

--- a/python/pyarrow/_parquet.pxd
+++ b/python/pyarrow/_parquet.pxd
@@ -44,6 +44,7 @@ cdef shared_ptr[WriterProperties] _create_writer_properties(
     version=*,
     write_statistics=*,
     data_page_size=*,
+    max_rows_per_page=*,
     compression_level=*,
     use_byte_stream_split=*,
     column_encoding=*,

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -1984,6 +1984,7 @@ cdef shared_ptr[WriterProperties] _create_writer_properties(
         version=None,
         write_statistics=None,
         data_page_size=None,
+        max_rows_per_page=None,
         compression_level=None,
         use_byte_stream_split=False,
         column_encoding=None,
@@ -2128,6 +2129,9 @@ cdef shared_ptr[WriterProperties] _create_writer_properties(
     # size limits
     if data_page_size is not None:
         props.data_pagesize(data_page_size)
+
+    if max_rows_per_page is not None:
+        props.max_rows_per_page(max_rows_per_page)
 
     if write_batch_size is not None:
         props.write_batch_size(write_batch_size)
@@ -2300,6 +2304,7 @@ cdef class ParquetWriter(_Weakrefable):
                   use_deprecated_int96_timestamps=False,
                   coerce_timestamps=None,
                   data_page_size=None,
+                  max_rows_per_page=None,
                   allow_truncated_timestamps=False,
                   compression_level=None,
                   use_byte_stream_split=False,
@@ -2340,6 +2345,7 @@ cdef class ParquetWriter(_Weakrefable):
             version=version,
             write_statistics=write_statistics,
             data_page_size=data_page_size,
+            max_rows_per_page=max_rows_per_page,
             compression_level=compression_level,
             use_byte_stream_split=use_byte_stream_split,
             column_encoding=column_encoding,

--- a/python/pyarrow/includes/libparquet.pxd
+++ b/python/pyarrow/includes/libparquet.pxd
@@ -492,6 +492,7 @@ cdef extern from "parquet/api/writer.h" namespace "parquet" nogil:
             Builder* enable_store_decimal_as_integer()
             Builder* disable_store_decimal_as_integer()
             Builder* data_pagesize(int64_t size)
+            Builder* max_rows_per_page(int64_t max_rows)
             Builder* encoding(ParquetEncoding encoding)
             Builder* encoding(const c_string& path,
                               ParquetEncoding encoding)

--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -797,7 +797,7 @@ data_page_size : int, default None
     size of 1MByte.
 max_rows_per_page : int, default None
     Maximum number of rows per page within a column chunk.
-    If no value is passed, then the default value of 20000 is set.
+    If None, use the default of 20000.
     Smaller values reduce memory usage during reads but increase metadata overhead.
 flavor : {'spark'}, default None
     Sanitize schema or set other compatibility options to work with

--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -795,6 +795,10 @@ data_page_size : int, default None
     Set a target threshold for the approximate encoded size of data
     pages within a column chunk (in bytes). If None, use the default data page
     size of 1MByte.
+max_rows_per_page : int, default None
+    Maximum number of rows per page within a column chunk.
+    If no value is passed, then the default value of 20000 is set.
+    Smaller values reduce memory usage during reads but increase metadata overhead.
 flavor : {'spark'}, default None
     Sanitize schema or set other compatibility options to work with
     various target systems.

--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -1042,6 +1042,7 @@ Examples
                  sorting_columns=None,
                  store_decimal_as_integer=False,
                  write_time_adjusted_to_utc=False,
+                 max_rows_per_page=None,
                  **options):
         if use_deprecated_int96_timestamps is None:
             # Use int96 timestamps for Spark
@@ -1096,6 +1097,7 @@ Examples
             sorting_columns=sorting_columns,
             store_decimal_as_integer=store_decimal_as_integer,
             write_time_adjusted_to_utc=write_time_adjusted_to_utc,
+            max_rows_per_page=max_rows_per_page,
             **options)
         self.is_open = True
 
@@ -1958,6 +1960,7 @@ def write_table(table, where, row_group_size=None, version='2.6',
                 sorting_columns=None,
                 store_decimal_as_integer=False,
                 write_time_adjusted_to_utc=False,
+                max_rows_per_page=None,
                 **kwargs):
     # Implementor's note: when adding keywords here / updating defaults, also
     # update it in write_to_dataset and _dataset_parquet.pyx ParquetFileWriteOptions
@@ -1990,6 +1993,7 @@ def write_table(table, where, row_group_size=None, version='2.6',
                 sorting_columns=sorting_columns,
                 store_decimal_as_integer=store_decimal_as_integer,
                 write_time_adjusted_to_utc=write_time_adjusted_to_utc,
+                max_rows_per_page=max_rows_per_page,
                 **kwargs) as writer:
             writer.write_table(table, row_group_size=row_group_size)
     except Exception:

--- a/python/pyarrow/tests/parquet/test_parquet_writer.py
+++ b/python/pyarrow/tests/parquet/test_parquet_writer.py
@@ -523,7 +523,10 @@ def test_writer_props_max_rows_per_page(tempdir, max_rows_per_page):
 
 def test_writer_props_max_rows_per_page_file_size(tempdir):
     # GH-48096
-    table = _test_table(100_000)
+    table = pa.table({
+        "x": pa.array(range(1_000_000))
+    })
+
     local = fs.LocalFileSystem()
     file_infos = []
 


### PR DESCRIPTION
### Rationale for this change
See #48096, exposes `parquet.WriterProperties max_rows_per_page` argument to Python's API.

### What changes are included in this PR?
Added the argument

### Are these changes tested?
Yes, since the metadata doesn't have any info about the number of pages, a naive end-to-end test was used to ensure the implementation correctness.

### Are there any user-facing changes?
The ability to set the `max_rows_per_page` directly from PyArrow.

* GitHub Issue: #48096