### PR TITLE
GH-48105: [C++][Parquet][IPC] Cap allocated memory when fuzzing

### DIFF
--- a/cpp/src/arrow/CMakeLists.txt
+++ b/cpp/src/arrow/CMakeLists.txt
@@ -511,6 +511,7 @@ set(ARROW_UTIL_SRCS
     util/float16.cc
     util/formatting.cc
     util/future.cc
+    util/fuzz_internal.cc
     util/hashing.cc
     util/int_util.cc
     util/io_util.cc

--- a/cpp/src/arrow/ipc/file_fuzz.cc
+++ b/cpp/src/arrow/ipc/file_fuzz.cc
@@ -19,10 +19,11 @@
 
 #include "arrow/ipc/reader.h"
 #include "arrow/status.h"
+#include "arrow/util/fuzz_internal.h"
 #include "arrow/util/macros.h"
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   auto status = arrow::ipc::internal::FuzzIpcFile(data, static_cast<int64_t>(size));
-  ARROW_UNUSED(status);
+  arrow::internal::NoteFuzzStatus(status, data, static_cast<int64_t>(size));
   return 0;
 }

--- a/cpp/src/arrow/ipc/file_fuzz.cc
+++ b/cpp/src/arrow/ipc/file_fuzz.cc
@@ -24,6 +24,6 @@
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   auto status = arrow::ipc::internal::FuzzIpcFile(data, static_cast<int64_t>(size));
-  arrow::internal::NoteFuzzStatus(status, data, static_cast<int64_t>(size));
+  arrow::internal::LogFuzzStatus(status, data, static_cast<int64_t>(size));
   return 0;
 }

--- a/cpp/src/arrow/ipc/stream_fuzz.cc
+++ b/cpp/src/arrow/ipc/stream_fuzz.cc
@@ -24,6 +24,6 @@
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   auto status = arrow::ipc::internal::FuzzIpcStream(data, static_cast<int64_t>(size));
-  arrow::internal::NoteFuzzStatus(status, data, static_cast<int64_t>(size));
+  arrow::internal::LogFuzzStatus(status, data, static_cast<int64_t>(size));
   return 0;
 }

--- a/cpp/src/arrow/memory_pool.h
+++ b/cpp/src/arrow/memory_pool.h
@@ -26,6 +26,7 @@
 #include "arrow/result.h"
 #include "arrow/status.h"
 #include "arrow/type_fwd.h"
+#include "arrow/util/macros.h"
 #include "arrow/util/visibility.h"
 
 namespace arrow {
@@ -243,6 +244,64 @@ class ARROW_EXPORT ProxyMemoryPool : public MemoryPool {
  private:
   class ProxyMemoryPoolImpl;
   std::unique_ptr<ProxyMemoryPoolImpl> impl_;
+};
+
+/// EXPERIMENTAL MemoryPool wrapper with an upper limit
+class ARROW_EXPORT CappedMemoryPool : public MemoryPool {
+ public:
+  CappedMemoryPool(MemoryPool* wrapped_pool, int64_t bytes_allocated_limit)
+      : wrapped_(wrapped_pool), bytes_allocated_limit_(bytes_allocated_limit) {}
+
+  using MemoryPool::Allocate;
+  using MemoryPool::Reallocate;
+
+  Status Allocate(int64_t size, int64_t alignment, uint8_t** out) override {
+    const auto attempted = size + wrapped_->bytes_allocated();
+    if (ARROW_PREDICT_FALSE(attempted > bytes_allocated_limit_)) {
+      return OutOfMemory(attempted);
+    }
+    return wrapped_->Allocate(size, alignment, out);
+  }
+
+  Status Reallocate(int64_t old_size, int64_t new_size, int64_t alignment,
+                    uint8_t** ptr) override {
+    const auto attempted = new_size - old_size + wrapped_->bytes_allocated();
+    if (ARROW_PREDICT_FALSE(attempted > bytes_allocated_limit_)) {
+      return OutOfMemory(attempted);
+    }
+    return wrapped_->Reallocate(old_size, new_size, alignment, ptr);
+  }
+
+  void Free(uint8_t* buffer, int64_t size, int64_t alignment) override {
+    return wrapped_->Free(buffer, size, alignment);
+  }
+
+  void ReleaseUnused() override { wrapped_->ReleaseUnused(); }
+
+  void PrintStats() override { wrapped_->PrintStats(); }
+
+  int64_t bytes_allocated() const override { return wrapped_->bytes_allocated(); }
+
+  int64_t max_memory() const override { return wrapped_->max_memory(); }
+
+  int64_t total_bytes_allocated() const override {
+    return wrapped_->total_bytes_allocated();
+  }
+
+  int64_t num_allocations() const override { return wrapped_->num_allocations(); }
+
+  std::string backend_name() const override { return wrapped_->backend_name(); }
+
+ private:
+  Status OutOfMemory(int64_t value) {
+    return Status::OutOfMemory(
+        "MemoryPool bytes_allocated cap exceeded: "
+        "limit=",
+        bytes_allocated_limit_, ", attempted=", value);
+  }
+
+  MemoryPool* wrapped_;
+  int64_t bytes_allocated_limit_;
 };
 
 /// \brief Return a process-wide memory pool based on the system allocator.

--- a/cpp/src/arrow/memory_pool.h
+++ b/cpp/src/arrow/memory_pool.h
@@ -310,7 +310,7 @@ class ARROW_EXPORT CappedMemoryPool : public MemoryPool {
   }
 
   MemoryPool* wrapped_;
-  int64_t bytes_allocated_limit_;
+  const int64_t bytes_allocated_limit_;
 };
 
 /// \brief Return a process-wide memory pool based on the system allocator.

--- a/cpp/src/arrow/util/fuzz_internal.cc
+++ b/cpp/src/arrow/util/fuzz_internal.cc
@@ -15,15 +15,25 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <memory>
-
-#include "arrow/ipc/reader.h"
-#include "arrow/status.h"
 #include "arrow/util/fuzz_internal.h"
-#include "arrow/util/macros.h"
 
-extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
-  auto status = arrow::ipc::internal::FuzzIpcStream(data, static_cast<int64_t>(size));
-  arrow::internal::NoteFuzzStatus(status, data, static_cast<int64_t>(size));
-  return 0;
+#include "arrow/memory_pool.h"
+#include "arrow/status.h"
+#include "arrow/util/logging_internal.h"
+
+namespace arrow::internal {
+
+MemoryPool* fuzzing_memory_pool() {
+  static auto pool = std::make_shared<::arrow::CappedMemoryPool>(
+      ::arrow::default_memory_pool(), /*bytes_allocated_limit=*/kFuzzingMemoryLimit);
+  return pool.get();
 }
+
+void NoteFuzzStatus(const Status& st, const uint8_t* data, int64_t size) {
+  if (st.IsOutOfMemory()) {
+    ARROW_LOG(WARNING) << "Fuzzing input with size=" << size
+                       << " hit allocation failure: " << st.ToString();
+  }
+}
+
+}  // namespace arrow::internal

--- a/cpp/src/arrow/util/fuzz_internal.cc
+++ b/cpp/src/arrow/util/fuzz_internal.cc
@@ -29,7 +29,8 @@ MemoryPool* fuzzing_memory_pool() {
   return pool.get();
 }
 
-void NoteFuzzStatus(const Status& st, const uint8_t* data, int64_t size) {
+void LogFuzzStatus(const Status& st, const uint8_t* data, int64_t size) {
+  // Most fuzz inputs will be invalid and generate errors, only log potential OOMs
   if (st.IsOutOfMemory()) {
     ARROW_LOG(WARNING) << "Fuzzing input with size=" << size
                        << " hit allocation failure: " << st.ToString();

--- a/cpp/src/arrow/util/fuzz_internal.h
+++ b/cpp/src/arrow/util/fuzz_internal.h
@@ -15,15 +15,23 @@
 // specific language governing permissions and limitations
 // under the License.
 
-#include <memory>
+#pragma once
 
-#include "arrow/ipc/reader.h"
-#include "arrow/status.h"
-#include "arrow/util/fuzz_internal.h"
+#include <cstdint>
+
+#include "arrow/type_fwd.h"
 #include "arrow/util/macros.h"
 
-extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
-  auto status = arrow::ipc::internal::FuzzIpcStream(data, static_cast<int64_t>(size));
-  arrow::internal::NoteFuzzStatus(status, data, static_cast<int64_t>(size));
-  return 0;
-}
+namespace arrow::internal {
+
+// The default rss_limit_mb on OSS-Fuzz is 2560 MB and we want to fail allocations
+// before that limit is reached, otherwise the fuzz target gets killed (GH-48105).
+constexpr int64_t kFuzzingMemoryLimit = 2200LL * 1000 * 1000;
+
+/// Return a memory pool that will not allocate more than kFuzzingMemoryLimit bytes.
+ARROW_EXPORT MemoryPool* fuzzing_memory_pool();
+
+// Optionally log the outcome of fuzzing an input
+ARROW_EXPORT void NoteFuzzStatus(const Status&, const uint8_t* data, int64_t size);
+
+}  // namespace arrow::internal

--- a/cpp/src/arrow/util/fuzz_internal.h
+++ b/cpp/src/arrow/util/fuzz_internal.h
@@ -32,6 +32,6 @@ constexpr int64_t kFuzzingMemoryLimit = 2200LL * 1000 * 1000;
 ARROW_EXPORT MemoryPool* fuzzing_memory_pool();
 
 // Optionally log the outcome of fuzzing an input
-ARROW_EXPORT void NoteFuzzStatus(const Status&, const uint8_t* data, int64_t size);
+ARROW_EXPORT void LogFuzzStatus(const Status&, const uint8_t* data, int64_t size);
 
 }  // namespace arrow::internal

--- a/cpp/src/parquet/arrow/fuzz.cc
+++ b/cpp/src/parquet/arrow/fuzz.cc
@@ -16,10 +16,11 @@
 // under the License.
 
 #include "arrow/status.h"
+#include "arrow/util/fuzz_internal.h"
 #include "parquet/arrow/reader.h"
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   auto status = parquet::arrow::internal::FuzzReader(data, static_cast<int64_t>(size));
-  ARROW_UNUSED(status);
+  arrow::internal::NoteFuzzStatus(status, data, static_cast<int64_t>(size));
   return 0;
 }

--- a/cpp/src/parquet/arrow/fuzz.cc
+++ b/cpp/src/parquet/arrow/fuzz.cc
@@ -21,6 +21,6 @@
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   auto status = parquet::arrow::internal::FuzzReader(data, static_cast<int64_t>(size));
-  arrow::internal::NoteFuzzStatus(status, data, static_cast<int64_t>(size));
+  arrow::internal::LogFuzzStatus(status, data, static_cast<int64_t>(size));
   return 0;
 }


### PR DESCRIPTION
### Rationale for this change

OSS-Fuzz will trigger an out-of-memory crash if the allocated memory goes beyond a predefined limit (usually 2560 MB, though that can be configured). For Parquet and IPC, it is legitimate to allocate a lot of memory when decompressing data, though, so that can happen on both valid and invalid input files.

Unfortunately, OSS-Fuzz checks for this memory limit not by instrumenting malloc and having it return NULL when the limit is reached, but by checking allocated memory periodically from a separate thread. This can be solved by implementing our custom allocator with an upper limit, exactly how the mupdf project did in https://github.com/google/oss-fuzz/issues/1830

### What changes are included in this PR?

1. Implement a `CappedMemoryPool`
2. Use the `CappedMemoryPool` with a hardcoded limit in the Parquet and IPC fuzz targets

### Are these changes tested?

Yes, by additional unit tests.

### Are there any user-facing changes?

No.

* GitHub Issue: #48105