### PR TITLE
GH-48125: [C++] Remove gnu11 standard from the Meson configuration

### DIFF
--- a/cpp/meson.build
+++ b/cpp/meson.build
@@ -22,7 +22,7 @@ project(
     version: '23.0.0-SNAPSHOT',
     license: 'Apache-2.0',
     meson_version: '>=1.3.0',
-    default_options: ['c_std=gnu11,c11', 'warning_level=2', 'cpp_std=c++17'],
+    default_options: ['c_std=c11', 'warning_level=2', 'cpp_std=c++17'],
 )
 
 project_args = [


### PR DESCRIPTION
### Rationale for this change

The gnu11 standard flag seems unnecesary

### What changes are included in this PR?

Removed the gnu11 standard flag from the top level Meson configuration

### Are these changes tested?

Yes

### Are there any user-facing changes?

No

* GitHub Issue: #48125