### PR TITLE
GH-48129: [CI] Stale issues bot only looks at 30 issues at a time

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -19,9 +19,6 @@ name: "Close stale PRs"
 on:
   schedule:
     - cron: "0 11 * * *" # Run daily at 11:00 AM UTC
-  pull_request:
-    paths:
-      - '.github/workflows/stale.yml'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,7 +18,7 @@
 name: "Close stale PRs"
 on:
   schedule:
-    - cron: "0 11 * * *" # Run daily at 11:00 AM UTC
+    - cron: "10 11 * * *" # Run daily at 11:10 AM UTC
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,7 +18,11 @@
 name: "Close stale PRs"
 on:
   schedule:
-    - cron: "0 11 * * 3" # Run once per week on Wednesday at 11:00 AM UTC
+    - cron: "0 11 * * *" # Run daily at 11:00 AM UTC
+  pull_request:
+    paths:
+      - '.github/workflows/stale.yml'
+  workflow_dispatch:
 
 jobs:
   close-stale-prs:
@@ -36,6 +40,7 @@ jobs:
           # exclude issues
           days-before-issue-stale: -1
           days-before-issue-close: -1
+          operations-per-run: 1000
           repo-token: ${{ secrets.GITHUB_TOKEN }}
   close-stale-issues-usage:
     runs-on: ubuntu-latest
@@ -53,6 +58,7 @@ jobs:
           stale-issue-label: "Status: stale-warning"
           days-before-issue-stale: 365
           days-before-issue-close: 14
+          operations-per-run: 1000
           repo-token: ${{ secrets.GITHUB_TOKEN }}
   close-stale-issues-enhancement:
     runs-on: ubuntu-latest
@@ -71,4 +77,5 @@ jobs:
           stale-issue-label: "Status: stale-warning"
           days-before-issue-stale: 365
           days-before-issue-close: 14
+          operations-per-run: 1000
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Rationale for this change

Stale issues bot only analyses 30 issues at a time due to defaults.

### What changes are included in this PR?

Increase them to 1000 and run daily to catch any beyond this value.

### Are these changes tested?

Yeah, I temporarily ran on this PR and looks like everything which is permitted on PRs did run.

### Are there any user-facing changes?

No
* GitHub Issue: #48129