### PR TITLE
GH-48139: [C++] Allow compilation for QNX versions up to 8

### DIFF
--- a/cpp/src/arrow/util/endian.h
+++ b/cpp/src/arrow/util/endian.h
@@ -24,7 +24,7 @@
 #    include <machine/endian.h>  // IWYU pragma: keep
 #  elif defined(sun) || defined(__sun)
 #    include <sys/byteorder.h>  // IWYU pragma: keep
-#  elif !defined(_AIX)
+#  elif !defined(_AIX) && !defined(__QNXNTO__) && !defined(__QNX__)
 #    include <endian.h>  // IWYU pragma: keep
 #  endif
 #


### PR DESCRIPTION
### Rationale for this change

The endianness header inclusion preprocessor selection logic in `cpp/src/arrow/util/endian.h` currently prevents compling Arrow C++ libraries for the QNX operating system. Modern QNX operating system toolchains are detectable via the preprocessor defines  `__QNXNTO__` (versions 5 - 7) and `__QNX__` (version 8), which are not currently considered, but the basis for the logic is already implemented for AIX.

### What changes are included in this PR?

Extend the current preprocessor `!defined()` check for AIX with the equivalent for QNX in `cpp/src/arrow/util/endian.h`.

### Are these changes tested?

The change is verified using the proprietary QNX SDP 7.1 GCC 8 based toolchain and tested on QNX 7. Applying the patch allows building for QNX.

### Are there any user-facing changes?

No; the changes purely relate to OS-specific toolchain detection.

* GitHub Issue: #48139