### PR TITLE
GH-48152: [CI][MATLAB] Bump MATLAB release to R2025b in the MATLAB GitHub Actions Workflow

### DIFF
--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Install MATLAB
         uses: matlab-actions/setup-matlab@v2
         with:
-          release: R2025a
+          release: R2025b
       - name: Install ccache
         run: sudo apt-get install ccache
       - name: Setup ccache
@@ -107,7 +107,7 @@ jobs:
       - name: Install MATLAB
         uses: matlab-actions/setup-matlab@v2
         with:
-          release: R2025a
+          release: R2025b
       - name: Install ccache
         run: brew install ccache
       - name: Setup ccache
@@ -146,7 +146,7 @@ jobs:
       - name: Install MATLAB
         uses: matlab-actions/setup-matlab@v2
         with:
-          release: R2025a
+          release: R2025b
       - name: Download Timezone Database
         shell: bash
         run: ci/scripts/download_tz_database.sh


### PR DESCRIPTION
Thanks for opening a pull request!

### Rationale for this change

MATLAB R2025b is the latest available version of MATLAB as of November 2025. 

We are currently building against MATLAB R2025a in CI, and would like to build and test the MATLAB Interface to Apache Arrow against the latest version of MATLAB.

### What changes are included in this PR?

Updated `.github/workfows/matlab.yml` to build/test the MATLAB Interface to Apache Arrow against MATLAB `R2025b`.

### Are these changes tested?

Yes. MATLAB CI workflow [successfully passed on all platforms in mathworks/arrow](https://github.com/apache/arrow/actions/runs/19440402671).

### Are there any user-facing changes?

Yes, the MATLAB Interface to Apache Arrow will now be built against `R2025b` in CI.


* GitHub Issue: #48152