### PR TITLE
GH-48154: [MATAB][Packaging] Update MATLAB crossbow workflow to build against MATLAB `R2025b`

### DIFF
--- a/dev/tasks/matlab/github.yml
+++ b/dev/tasks/matlab/github.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install MATLAB
         uses: matlab-actions/setup-matlab@v2
         with:
-          release: R2025a
+          release: R2025b
       - name: Build MATLAB Interface
         env:
         {{ macros.github_set_sccache_envvars()|indent(8) }}
@@ -73,7 +73,7 @@ jobs:
       - name: Install MATLAB
         uses: matlab-actions/setup-matlab@v2
         with:
-          release: R2025a
+          release: R2025b
       - name: Build MATLAB Interface
         env:
         {{ macros.github_set_sccache_envvars()|indent(8) }}
@@ -99,7 +99,7 @@ jobs:
       - name: Install MATLAB
         uses: matlab-actions/setup-matlab@v2
         with:
-          release: R2025a
+          release: R2025b
       - name: Install sccache
         shell: bash
         run: arrow/ci/scripts/install_sccache.sh pc-windows-msvc $(pwd)/sccache
@@ -146,7 +146,7 @@ jobs:
       - name: Install MATLAB
         uses: matlab-actions/setup-matlab@v2
         with:
-          release: R2025a
+          release: R2025b
       - name: Run commands
         env:
           MATLABPATH: arrow/matlab/tools


### PR DESCRIPTION
Thanks for opening a pull request!

### Rationale for this change

MATLAB [R2025b](https://www.mathworks.com/products/new_products/latest_features.html) is now available for use with the [matlab-actions/setup-matlab](https://github.com/matlab-actions/setup-matlab) GitHub Action.

We should update the [crossbow packaging workflows for the MATLAB MLTBX files](https://github.com/apache/arrow/blob/main/dev/tasks/matlab/github.yml) to build against R2025b.

### What changes are included in this PR?

1. Updated the `dev/tasks/matlab/github.yml` crossbow packaging workflow to build the MATLAB MLTBX files against MATLAB R2025b.

### Are these changes tested?

Yes. The MATLAB crossbow packaging workflow [passed on all three platforms](https://github.com/ursacomputing/crossbow/actions/runs/19440978027/job/55623923047). 

### Are there any user-facing changes?

Yes. The MATLAB MLTBX release artifacts will now be built against R2025b.


* GitHub Issue: #48154