### PR TITLE
GH-48163: [CI][Docs] Update preview docs task S3 secret to use

### DIFF
--- a/dev/archery/archery/crossbow/tests/fixtures/chat-report-extra-message-failure.txt
+++ b/dev/archery/archery/crossbow/tests/fixtures/chat-report-extra-message-failure.txt
@@ -1,5 +1,5 @@
 
-*<http://crossbow.voltrondata.com|Archery crossbow report> for <https://github.com/apache/crossbow/branches/all?query=ursabot-1|ursabot-1>*
+*<https://s3.amazonaws.com/arrow-data/index.html|Archery crossbow report> for <https://github.com/apache/crossbow/branches/all?query=ursabot-1|ursabot-1>*
 
 :x: *1 failed jobs*
 - <https://github.com/apache/crossbow/runs/2|wheel-osx-cp37m>

--- a/dev/archery/archery/crossbow/tests/fixtures/chat-report-extra-message-success.txt
+++ b/dev/archery/archery/crossbow/tests/fixtures/chat-report-extra-message-success.txt
@@ -1,5 +1,5 @@
 
-*<http://crossbow.voltrondata.com|Archery crossbow report> for <https://github.com/apache/crossbow/branches/all?query=ursabot-1|ursabot-1>*
+*<https://s3.amazonaws.com/arrow-data/index.html|Archery crossbow report> for <https://github.com/apache/crossbow/branches/all?query=ursabot-1|ursabot-1>*
 
 
 :tada: *4 successful jobs*

--- a/dev/archery/archery/crossbow/tests/fixtures/chat-report.txt
+++ b/dev/archery/archery/crossbow/tests/fixtures/chat-report.txt
@@ -1,5 +1,5 @@
 
-*<http://crossbow.voltrondata.com|Archery crossbow report> for <https://github.com/apache/crossbow/branches/all?query=ursabot-1|ursabot-1>*
+*<https://s3.amazonaws.com/arrow-data/index.html|Archery crossbow report> for <https://github.com/apache/crossbow/branches/all?query=ursabot-1|ursabot-1>*
 
 :x: *1 failed jobs*
 - <https://github.com/apache/crossbow/runs/2|wheel-osx-cp37m>

--- a/dev/archery/archery/crossbow/tests/fixtures/email-report.txt
+++ b/dev/archery/archery/crossbow/tests/fixtures/email-report.txt
@@ -4,7 +4,7 @@ Subject: [NIGHTLY] Arrow Build Report for Job ursabot-1: 2 failed, 1 pending
 
 Arrow Build Report for Job ursabot-1
 
-See http://crossbow.voltrondata.com/ for more information.
+See https://s3.amazonaws.com/arrow-data/index.html for more information.
 
 All tasks: https://github.com/apache/crossbow/branches/all?query=ursabot-1
 

--- a/dev/archery/archery/templates/chat_nightly_report.txt.j2
+++ b/dev/archery/archery/templates/chat_nightly_report.txt.j2
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #}
-*<http://crossbow.voltrondata.com|Archery crossbow report> for <{{ report.url(report.job.branch) }}|{{ report.job.branch }}>*
+*<https://s3.amazonaws.com/arrow-data/index.html|Archery crossbow report> for <{{ report.url(report.job.branch) }}|{{ report.job.branch }}>*
 {% if report.tasks_by_state["failure"] %}
 :x: *{{ report.tasks_by_state["failure"] | length }} failed jobs*
 {% for task_name, task in report.tasks_by_state["failure"] | dictsort -%}

--- a/dev/archery/archery/templates/email_nightly_report.txt.j2
+++ b/dev/archery/archery/templates/email_nightly_report.txt.j2
@@ -24,7 +24,7 @@ Subject: [NIGHTLY] Arrow Build Report for Job {{report.job.branch}}: {{ (report.
 
 Arrow Build Report for Job {{ report.job.branch }}
 
-See http://crossbow.voltrondata.com/ for more information.
+See https://s3.amazonaws.com/arrow-data/index.html for more information.
 
 All tasks: {{ report.url(report.job.branch) }}
 {% if report.tasks_by_state["failure"] %}

--- a/dev/tasks/docs/github.linux.yml
+++ b/dev/tasks/docs/github.linux.yml
@@ -57,14 +57,14 @@ jobs:
       - name: Upload preview to S3
         env:
           {%- raw %}
-          AWS_ACCESS_KEY_ID: ${{ secrets.CROSSBOW_DOCS_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.CROSSBOW_DOCS_AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: ${{ secrets.CROSSBOW_DOCS_S3_BUCKET_REGION }}
-          BUCKET: ${{ secrets.CROSSBOW_DOCS_S3_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.CROSSBOW_DOCS_ARROW_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.CROSSBOW_DOCS_ARROW_AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.CROSSBOW_DOCS_ARROW_S3_BUCKET_REGION }}
+          BUCKET: ${{ secrets.CROSSBOW_DOCS_ARROW_S3_BUCKET }}
           {% endraw %}
         run: |
           aws s3 cp build/docs/ $BUCKET/pr_docs/{{ pr_number }}/ --recursive
-          echo ":open_book: You can find the preview here: http://crossbow.voltrondata.com/pr_docs/{{ pr_number }}" >> $GITHUB_STEP_SUMMARY
+          echo ":open_book: You can find the preview here: https://s3.amazonaws.com/arrow-data/pr_docs/{{ pr_number }}" >> $GITHUB_STEP_SUMMARY
       {% endif %}
       - name: Prepare Docs artifacts
         run: |

--- a/dev/tasks/docs/github.linux.yml
+++ b/dev/tasks/docs/github.linux.yml
@@ -64,7 +64,8 @@ jobs:
           {% endraw %}
         run: |
           aws s3 cp build/docs/ $BUCKET/pr_docs/{{ pr_number }}/ --recursive
-          echo ":open_book: You can find the preview here: https://s3.amazonaws.com/arrow-data/pr_docs/{{ pr_number }}" >> $GITHUB_STEP_SUMMARY
+          echo ":open_book: You can find the preview here: https://s3.amazonaws.com/arrow-data/pr_docs/{{ pr_number }}/index.html" >> $GITHUB_STEP_SUMMARY
+
       {% endif %}
       - name: Prepare Docs artifacts
         run: |

--- a/r/PACKAGING.md
+++ b/r/PACKAGING.md
@@ -26,7 +26,7 @@ For a high-level overview of the Arrow release process see the [Apache Arrow Rel
 
 - [ ] [Create a GitHub issue](https://github.com/apache/arrow/issues/new/) entitled `[R] CRAN packaging checklist for version X.Y.Z` and copy this checklist to the issue.
 - [ ] Review deprecated functions to advance their deprecation status.
-- [ ] Evaluate the status of any failing [nightly tests and nightly packaging builds](http://crossbow.voltrondata.com). These checks replicate most of the checks that CRAN runs, so we need them all to be passing or to understand that the failures may (though won't necessarily) result in a rejection from CRAN.
+- [ ] Evaluate the status of any failing [nightly tests and nightly packaging builds](https://s3.amazonaws.com/arrow-data/index.html). These checks replicate most of the checks that CRAN runs, so we need them all to be passing or to understand that the failures may (though won't necessarily) result in a rejection from CRAN.
 - [ ] Check [current CRAN check results](https://cran.rstudio.org/web/checks/check_results_arrow.html).
 - [ ] Ensure the contents of the README are accurate and up to date.
 - [ ] Run `urlchecker::url_check()` on the R directory at the release candidate.


### PR DESCRIPTION
### Rationale for this change

The voltron data AWS account will be closed soon, we have to update to newly created bucket under the AWS account for Arrow.

### What changes are included in this PR?

Migrate credentials for newly created bucket and update URL where dashboard will be deployed.

### Are these changes tested?

Yes, via archery.

### Are there any user-facing changes?

No, only devs where the URL is different

* GitHub Issue: #48163