### PR TITLE
GH-48162: [CI] Stale issues bot hit secondary rate limit and did not complete 

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,9 +18,7 @@
 name: "Close stale PRs"
 on:
   schedule:
-    # TODO: Change back to daily (e.g., "10 11 * * *") once the backlog is processed
-    # Running hourly temporarily to process the backlog faster
-    - cron: "10 * * * *" # Run hourly at 10 minutes past the hour
+    - cron: "10 11 * * *" # Run daily at 11:10 UTC
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -54,7 +54,6 @@ jobs:
           stale-issue-label: "Status: stale-warning"
           days-before-issue-stale: 365
           days-before-issue-close: 14
-          operations-per-run: 30
           repo-token: ${{ secrets.GITHUB_TOKEN }}
   close-stale-issues-enhancement:
     runs-on: ubuntu-latest
@@ -73,5 +72,4 @@ jobs:
           stale-issue-label: "Status: stale-warning"
           days-before-issue-stale: 365
           days-before-issue-close: 14
-          operations-per-run: 30
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,7 +18,9 @@
 name: "Close stale PRs"
 on:
   schedule:
-    - cron: "10 11 * * *" # Run daily at 11:10 AM UTC
+    # TODO: Change back to daily (e.g., "10 11 * * *") once the backlog is processed
+    # Running hourly temporarily to process the backlog faster
+    - cron: "10 * * * *" # Run hourly at 10 minutes past the hour
   workflow_dispatch:
 
 jobs:
@@ -37,7 +39,6 @@ jobs:
           # exclude issues
           days-before-issue-stale: -1
           days-before-issue-close: -1
-          operations-per-run: 1000
           repo-token: ${{ secrets.GITHUB_TOKEN }}
   close-stale-issues-usage:
     runs-on: ubuntu-latest
@@ -55,7 +56,7 @@ jobs:
           stale-issue-label: "Status: stale-warning"
           days-before-issue-stale: 365
           days-before-issue-close: 14
-          operations-per-run: 1000
+          operations-per-run: 30
           repo-token: ${{ secrets.GITHUB_TOKEN }}
   close-stale-issues-enhancement:
     runs-on: ubuntu-latest
@@ -74,5 +75,5 @@ jobs:
           stale-issue-label: "Status: stale-warning"
           days-before-issue-stale: 365
           days-before-issue-close: 14
-          operations-per-run: 1000
+          operations-per-run: 30
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Rationale for this change

Stale issues bot hits rate limit on API and doesn't post comments

### What changes are included in this PR?

Reduce how many operations it can complete (I went and manually added comments myself to the issues/PRs with labels but no comments)

### Are these changes tested?

No

### Are there any user-facing changes?

No
* GitHub Issue: #48162