### PR TITLE
MINOR: [C++] Fix lint errors

### DIFF
--- a/cpp/examples/arrow/parquet_read_write.cc
+++ b/cpp/examples/arrow/parquet_read_write.cc
@@ -118,9 +118,9 @@ arrow::Status WriteFullFile(std::string path_to_file) {
   std::shared_ptr<arrow::io::FileOutputStream> outfile;
   ARROW_ASSIGN_OR_RAISE(outfile, arrow::io::FileOutputStream::Open(path_to_file));
 
-  ARROW_RETURN_NOT_OK(parquet::arrow::WriteTable(*table.get(),
-                                                 arrow::default_memory_pool(), outfile,
-                                                 /*chunk_size=*/64*1024, props, arrow_props));
+  ARROW_RETURN_NOT_OK(
+      parquet::arrow::WriteTable(*table.get(), arrow::default_memory_pool(), outfile,
+                                 /*chunk_size=*/64 * 1024, props, arrow_props));
   return arrow::Status::OK();
 }
 


### PR DESCRIPTION
### Rationale for this change

A C++ linting error was introduced with #40705.

### What changes are included in this PR?

Linter fixed issue in `cpp/examples/arrow/parquet_read_write.cc`