### PR TITLE
GH-48174: [CI][Dev] Fix shellcheck errors in ci/scripts/util_download_apache.sh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -341,6 +341,7 @@ repos:
           ?^ci/scripts/release_test\.sh$|
           ?^ci/scripts/ruby_test\.sh$|
           ?^ci/scripts/rust_build\.sh$|
+          ?^ci/scripts/util_download_apache\.sh$|
           ?^ci/scripts/util_enable_core_dumps\.sh$|
           ?^ci/scripts/util_free_space\.sh$|
           ?^ci/scripts/util_log\.sh$|

--- a/ci/scripts/util_download_apache.sh
+++ b/ci/scripts/util_download_apache.sh
@@ -44,10 +44,9 @@ APACHE_MIRRORS=(
 
 mkdir -p "${target_dir}"
 
-for mirror in ${APACHE_MIRRORS[*]}
+for mirror in "${APACHE_MIRRORS[@]}"
 do
-  curl -SL "${mirror}/${tarball_path}" | tar -xzf - -C "${target_dir}"
-  if [ $? == 0 ]; then
+  if curl -SL "${mirror}/${tarball_path}" | tar -xzf - -C "${target_dir}"; then
     exit 0
   fi
 done


### PR DESCRIPTION
### Rationale for this change

This is the sub issue #44748.

* SC2048: Use "$@" (with quotes) to prevent whitespace problems.
* SC2181: Check exit code directly with e.g. if mycmd;, not indirectly with $?.

```
In ci/scripts/util_download_apache.sh line 47:
for mirror in ${APACHE_MIRRORS[*]}
              ^------------------^ SC2048 (warning): Use "${array[@]}" (with quotes) to prevent whitespace problems.


In ci/scripts/util_download_apache.sh line 50:
  if [ $? == 0 ]; then
       ^-- SC2181 (style): Check exit code directly with e.g. 'if mycmd;', not indirectly with $?.

For more information:
  https://www.shellcheck.net/wiki/SC2048 -- Use "${array[@]}" (with quotes) t...
  https://www.shellcheck.net/wiki/SC2181 -- Check exit code directly with e.g...
```

### What changes are included in this PR?

* SC2048: Use `"${APACHE_MIRRORS[@]}"` instead of `${APACHE_MIRRORS[*]}`.
* Sc2181: Use `if cmd ; then` statement instead of `$?`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #48174