### PR TITLE
GH-48178: [C++] Use FetchContent for bundled RE2

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -2815,8 +2815,10 @@ function(build_re2)
   fetchcontent_declare(re2
                        URL ${RE2_SOURCE_URL}
                        URL_HASH "SHA256=${ARROW_RE2_BUILD_SHA256_CHECKSUM}")
-
   prepare_fetchcontent()
+
+  # Unity build causes some build errors
+  set(CMAKE_UNITY_BUILD OFF)
   fetchcontent_makeavailable(re2)
 
   # Install RE2 for gRPC to find via find_package()

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -2799,7 +2799,7 @@ if(ARROW_WITH_ZSTD)
 endif()
 
 # ----------------------------------------------------------------------
-# RE2 (required for Gandiva)
+# RE2 (required for Gandiva and gRPC)
 
 function(build_re2)
   list(APPEND CMAKE_MESSAGE_INDENT "RE2: ")
@@ -2818,13 +2818,6 @@ function(build_re2)
 
   prepare_fetchcontent()
   fetchcontent_makeavailable(re2)
-
-  # RE2 creates re2::re2 target automatically
-  # Just need to add to bundled libs list
-  list(APPEND ARROW_BUNDLED_STATIC_LIBS re2::re2)
-  set(ARROW_BUNDLED_STATIC_LIBS
-      "${ARROW_BUNDLED_STATIC_LIBS}"
-      PARENT_SCOPE)
 
   # Install RE2 for gRPC to find via find_package()
   # Save and disable RE2's install script
@@ -2857,6 +2850,9 @@ function(build_re2)
 
   add_custom_target(re2_fc DEPENDS "${RE2_PREFIX}/.re2_installed")
 
+  set(ARROW_BUNDLED_STATIC_LIBS
+      ${ARROW_BUNDLED_STATIC_LIBS} re2::re2
+      PARENT_SCOPE)
   list(POP_BACK CMAKE_MESSAGE_INDENT)
 endfunction()
 
@@ -3263,7 +3259,6 @@ macro(build_grpc)
   endif()
 
   if(RE2_VENDORED)
-    # RE2 is built via FetchContent and installed for gRPC to find
     add_dependencies(grpc_dependencies re2_fc)
   endif()
 

--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -2821,8 +2821,9 @@ function(build_re2)
   set(CMAKE_UNITY_BUILD OFF)
   fetchcontent_makeavailable(re2)
 
-  # Install RE2 for gRPC to find via find_package()
-  # Save and disable RE2's install script
+  # This custom target ensures re2 is built before we install
+  add_custom_target(re2_built DEPENDS re2::re2)
+
   add_custom_command(OUTPUT "${re2_BINARY_DIR}/cmake_install.cmake.saved"
                      COMMAND ${CMAKE_COMMAND} -E copy_if_different
                              "${re2_BINARY_DIR}/cmake_install.cmake"
@@ -2830,7 +2831,7 @@ function(build_re2)
                      COMMAND ${CMAKE_COMMAND} -E echo
                              "# RE2 install disabled to prevent double installation with Arrow"
                              > "${re2_BINARY_DIR}/cmake_install.cmake"
-                     DEPENDS re2::re2
+                     DEPENDS re2_built
                      COMMENT "Disabling RE2 install to prevent double installation"
                      VERBATIM)
 
@@ -2844,7 +2845,8 @@ function(build_re2)
                              "${re2_BINARY_DIR}/cmake_install.cmake.tmp"
                      COMMAND ${CMAKE_COMMAND} -DCMAKE_INSTALL_PREFIX=${RE2_PREFIX}
                              -DCMAKE_INSTALL_CONFIG_NAME=$<CONFIG> -P
-                             "${re2_BINARY_DIR}/cmake_install.cmake.tmp"
+                             "${re2_BINARY_DIR}/cmake_install.cmake.tmp" ||
+                             ${CMAKE_COMMAND} -E true
                      COMMAND ${CMAKE_COMMAND} -E touch "${RE2_PREFIX}/.re2_installed"
                      DEPENDS re2_install_disabled
                      COMMENT "Installing RE2 to ${RE2_PREFIX} for gRPC"


### PR DESCRIPTION
### Rationale for this change

As a follow up of requiring a minimum CMake version >= 3.25 we discussed moving our dependencies from ExternalProject to FetchContent. This can simplify our third party dependency management. Moving RE2 is the next step before moving Protobuf and gRPC.

### What changes are included in this PR?

The general change is moving from `ExternalProject` to `FetchContent`. 

It also add some required integration due to other dependencies, like gRPC, using `ExternalProject`. We not only have to build but also install in order for those other dependencies to find RE2. This causes some timing issues between config, build, install that requires us to create a custom target to depend on so the other dependencies find abseil.

### Are these changes tested?

Yes, the changes are tested locally and on CI.

### Are there any user-facing changes?

No
* GitHub Issue: #48178