### PR TITLE
GH-48199: [Python][Parquet] Expose existing Parquet C++ metadata about index_page and bloom_filter to Python

### DIFF
--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -474,8 +474,14 @@ cdef class ColumnChunkMetaData(_Weakrefable):
   has_dictionary_page: {self.has_dictionary_page}
   dictionary_page_offset: {self.dictionary_page_offset}
   data_page_offset: {self.data_page_offset}
+  has_index_page: {self.has_index_page}
+  index_page_offset: {self.index_page_offset}
+  has_bloom_filter: {self.has_bloom_filter}
+  bloom_filter_offset: {self.bloom_filter_offset}
   total_compressed_size: {self.total_compressed_size}
-  total_uncompressed_size: {self.total_uncompressed_size}"""
+  total_uncompressed_size: {self.total_uncompressed_size}
+  has_offset_index: {self.has_offset_index}
+  has_column_index: {self.has_column_index}"""
 
     def to_dict(self):
         """
@@ -506,8 +512,14 @@ cdef class ColumnChunkMetaData(_Weakrefable):
             has_dictionary_page=self.has_dictionary_page,
             dictionary_page_offset=self.dictionary_page_offset,
             data_page_offset=self.data_page_offset,
+            has_index_page=self.has_index_page,
+            index_page_offset=self.index_page_offset,
+            has_bloom_filter=self.has_bloom_filter,
+            bloom_filter_offset=self.bloom_filter_offset,
             total_compressed_size=self.total_compressed_size,
-            total_uncompressed_size=self.total_uncompressed_size
+            total_uncompressed_size=self.total_uncompressed_size,
+            has_offset_index=self.has_offset_index,
+            has_column_index=self.has_column_index
         )
         return d
 
@@ -627,13 +639,30 @@ cdef class ColumnChunkMetaData(_Weakrefable):
 
     @property
     def has_index_page(self):
-        """Not yet supported."""
-        raise NotImplementedError('not supported in parquet-cpp')
+        """Whether there is an index data present in the column chunk (bool)."""
+        return self.metadata.has_index_page()
 
     @property
     def index_page_offset(self):
-        """Not yet supported."""
-        raise NotImplementedError("parquet-cpp doesn't return valid values")
+        """Offset of index page relative to beginning of the file (int or None)."""
+        return self.metadata.index_page_offset() if self.has_index_page else None
+
+    @property
+    def has_bloom_filter(self):
+        """Whether there is a bloom filter present in the column chunk (bool)."""
+        return self.metadata.bloom_filter_offset().has_value()
+
+    @property
+    def bloom_filter_offset(self):
+        """Offset of bloom filter relative to beginning of the file (int or None)."""
+        offset = self.metadata.bloom_filter_offset()
+        return offset.value() if offset.has_value() else None
+
+    @property
+    def bloom_filter_length(self):
+        """Length of bloom filter (int or None)."""
+        length = self.metadata.bloom_filter_length()
+        return length.value() if length.has_value() else None
 
     @property
     def total_compressed_size(self):

--- a/python/pyarrow/includes/libparquet.pxd
+++ b/python/pyarrow/includes/libparquet.pxd
@@ -364,9 +364,12 @@ cdef extern from "parquet/api/reader.h" namespace "parquet" nogil:
         const vector[ParquetEncoding]& encodings() const
         c_bool Equals(const CColumnChunkMetaData&) const
 
+        optional[int64_t] bloom_filter_offset() const
+        optional[int64_t] bloom_filter_length() const
         int64_t has_dictionary_page() const
         int64_t dictionary_page_offset() const
         int64_t data_page_offset() const
+        c_bool has_index_page() const
         int64_t index_page_offset() const
         int64_t total_compressed_size() const
         int64_t total_uncompressed_size() const


### PR DESCRIPTION
### Rationale for this change

The Parquet C++ implementation contains information about some metadata that is not exposed to PyArrow. This PR is to expose those.

### What changes are included in this PR?

Expose present `parquet::ColumnChunkMetaData`:
- has_index_page
- index_page_offset
- bloom_filter_offset
- bloom_filter_length

### Are these changes tested?

Yes

### Are there any user-facing changes?

Yes, new API methods on pyarrow.parquet ColumnChunkMetadata.
* GitHub Issue: #48199