### PR TITLE
GH-48204: [C++][Parquet] Fix Column Reader & Writer logic to enable Parquet DB support on s390x

### DIFF
--- a/cpp/src/parquet/column_reader.cc
+++ b/cpp/src/parquet/column_reader.cc
@@ -41,6 +41,7 @@
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/compression.h"
 #include "arrow/util/crc32.h"
+#include "arrow/util/endian.h"
 #include "arrow/util/int_util_overflow.h"
 #include "arrow/util/logging.h"
 #include "arrow/util/rle_encoding_internal.h"
@@ -112,7 +113,8 @@ int LevelDecoder::SetData(Encoding::type encoding, int16_t max_level,
       if (data_size < 4) {
         throw ParquetException("Received invalid levels (corrupt data page?)");
       }
-      num_bytes = ::arrow::util::SafeLoadAs<int32_t>(data);
+      num_bytes =
+          ::arrow::bit_util::FromLittleEndian(::arrow::util::SafeLoadAs<int32_t>(data));
       if (num_bytes < 0 || num_bytes > data_size - 4) {
         throw ParquetException("Received invalid number of bytes (corrupt data page?)");
       }

--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -958,7 +958,8 @@ int64_t ColumnWriterImpl::RleEncodeLevels(const void* src_buffer,
   DCHECK_EQ(encoded, num_buffered_values_);
 
   if (include_length_prefix) {
-    reinterpret_cast<int32_t*>(dest_buffer->mutable_data())[0] = level_encoder_.len();
+    ::arrow::util::SafeStore(dest_buffer->mutable_data(),
+                             ::arrow::bit_util::ToLittleEndian(level_encoder_.len()));
   }
 
   return level_encoder_.len() + prefix_size;
@@ -2633,13 +2634,31 @@ struct SerializeFunctor<
       if constexpr (std::is_same_v<ArrowType, ::arrow::Decimal64Type>) {
         *p++ = ::arrow::bit_util::ToBigEndian(u64_in[0]);
       } else if constexpr (std::is_same_v<ArrowType, ::arrow::Decimal128Type>) {
+#if ARROW_LITTLE_ENDIAN
+        // On little-endian: u64_in[0] = low, u64_in[1] = high
+        // Write high first for big-endian output
         *p++ = ::arrow::bit_util::ToBigEndian(u64_in[1]);
         *p++ = ::arrow::bit_util::ToBigEndian(u64_in[0]);
+#else
+        // On big-endian: u64_in[0] = high, u64_in[1] = low
+        // Write high first for big-endian output
+        *p++ = ::arrow::bit_util::ToBigEndian(u64_in[0]);
+        *p++ = ::arrow::bit_util::ToBigEndian(u64_in[1]);
+#endif
       } else if constexpr (std::is_same_v<ArrowType, ::arrow::Decimal256Type>) {
+#if ARROW_LITTLE_ENDIAN
+        // On little-endian: write words in reverse order (high to low)
         *p++ = ::arrow::bit_util::ToBigEndian(u64_in[3]);
         *p++ = ::arrow::bit_util::ToBigEndian(u64_in[2]);
         *p++ = ::arrow::bit_util::ToBigEndian(u64_in[1]);
         *p++ = ::arrow::bit_util::ToBigEndian(u64_in[0]);
+#else
+        // On big-endian: write words in natural order (high to low)
+        *p++ = ::arrow::bit_util::ToBigEndian(u64_in[0]);
+        *p++ = ::arrow::bit_util::ToBigEndian(u64_in[1]);
+        *p++ = ::arrow::bit_util::ToBigEndian(u64_in[2]);
+        *p++ = ::arrow::bit_util::ToBigEndian(u64_in[3]);
+#endif
       }
       scratch = reinterpret_cast<uint8_t*>(p);
     }
@@ -2658,7 +2677,24 @@ struct SerializeFunctor<
 template <>
 struct SerializeFunctor<::parquet::FLBAType, ::arrow::HalfFloatType> {
   Status Serialize(const ::arrow::HalfFloatArray& array, ArrowWriteContext*, FLBA* out) {
+#if ARROW_LITTLE_ENDIAN
+    return SerializeLittleEndianValues(array, array.raw_values(), out);
+#else
     const uint16_t* values = array.raw_values();
+    const int64_t length = array.length();
+    converted_values_.resize(length);
+    for (int64_t i = 0; i < length; ++i) {
+      // We don't need IsValid() here. Non valid values are just ignored in
+      // SerializeLittleEndianValues().
+      converted_values_[i] = ::arrow::bit_util::ToLittleEndian(values[i]);
+    }
+    return SerializeLittleEndianValues(array, converted_values_.data(), out);
+#endif
+  }
+
+ private:
+  Status SerializeLittleEndianValues(const ::arrow::HalfFloatArray& array,
+                                     const uint16_t* values, FLBA* out) {
     if (array.null_count() == 0) {
       for (int64_t i = 0; i < array.length(); ++i) {
         out[i] = ToFLBA(&values[i]);
@@ -2671,10 +2707,13 @@ struct SerializeFunctor<::parquet::FLBAType, ::arrow::HalfFloatType> {
     return Status::OK();
   }
 
- private:
   FLBA ToFLBA(const uint16_t* value_ptr) const {
     return FLBA{reinterpret_cast<const uint8_t*>(value_ptr)};
   }
+
+#if !ARROW_LITTLE_ENDIAN
+  std::vector<uint16_t> converted_values_;
+#endif
 };
 
 template <>

--- a/cpp/src/parquet/column_writer.h
+++ b/cpp/src/parquet/column_writer.h
@@ -267,9 +267,14 @@ inline void ArrowTimestampToImpalaTimestamp(const int64_t time, Int96* impala_ti
   }
   impala_timestamp->value[2] = static_cast<uint32_t>(julian_days);
   uint64_t last_day_nanos = static_cast<uint64_t>(last_day_units) * NanosecondsPerUnit;
+#if ARROW_LITTLE_ENDIAN
   // impala_timestamp will be unaligned every other entry so do memcpy instead
   // of assign and reinterpret cast to avoid undefined behavior.
-  std::memcpy(impala_timestamp, &last_day_nanos, sizeof(uint64_t));
+  std::memcpy(impala_timestamp, &last_day_nanos, sizeof(int64_t));
+#else
+  (*impala_timestamp).value[0] = static_cast<uint32_t>(last_day_nanos);
+  (*impala_timestamp).value[1] = static_cast<uint32_t>(last_day_nanos >> 32);
+#endif
 }
 
 constexpr int64_t kSecondsInNanos = INT64_C(1000000000);

--- a/cpp/src/parquet/column_writer.h
+++ b/cpp/src/parquet/column_writer.h
@@ -277,9 +277,14 @@ inline void ArrowTimestampToImpalaTimestamp(const int64_t time, Int96* impala_ti
   }
   impala_timestamp->value[2] = static_cast<uint32_t>(julian_days);
   uint64_t last_day_nanos = static_cast<uint64_t>(last_day_units) * NanosecondsPerUnit;
+#if ARROW_LITTLE_ENDIAN
   // impala_timestamp will be unaligned every other entry so do memcpy instead
   // of assign and reinterpret cast to avoid undefined behavior.
-  std::memcpy(impala_timestamp, &last_day_nanos, sizeof(uint64_t));
+  std::memcpy(impala_timestamp, &last_day_nanos, sizeof(int64_t));
+#else
+  (*impala_timestamp).value[0] = static_cast<uint32_t>(last_day_nanos);
+  (*impala_timestamp).value[1] = static_cast<uint32_t>(last_day_nanos >> 32);
+#endif
 }
 
 constexpr int64_t kSecondsInNanos = INT64_C(1000000000);


### PR DESCRIPTION
### Rationale for this change

This PR is intended to enable Parquet DB support on Big-endian (s390x) systems. The fix in this PR fixes the column reader & writer logic. Column Reader & Writer are the main part of most of the parquet & arrow-parquet testcases.

### What changes are included in this PR?

The fix includes changes to following files:
cpp/src/parquet/column_reader.cc
cpp/src/parquet/column_writer.cc
cpp/src/parquet/column_writer.h

### Are these changes tested?

Yes. The changes are tested on s390x arch to make sure things are working fine. The fix is also tested on x86 arch, to make sure there is no new regression introduced.

### Are there any user-facing changes?

No

GitHub main Issue link: https://github.com/apache/arrow/issues/48151
* GitHub Issue: #48204