### PR TITLE
GH-48208: [C++][Parquet] Fix Types logic to enable Parquet DB support on s390x

### DIFF
--- a/cpp/src/parquet/types.h
+++ b/cpp/src/parquet/types.h
@@ -27,6 +27,7 @@
 #include <string>
 #include <string_view>
 
+#include "arrow/util/endian.h"
 #include "parquet/platform.h"
 #include "parquet/type_fwd.h"
 #include "parquet/windows_fixup.h"  // for OPTIONAL
@@ -708,7 +709,12 @@ static inline std::string ByteArrayToString(const ByteArray& a) {
 }
 
 static inline void Int96SetNanoSeconds(parquet::Int96& i96, int64_t nanoseconds) {
+#if ARROW_LITTLE_ENDIAN
   std::memcpy(&i96.value, &nanoseconds, sizeof(nanoseconds));
+#else
+  i96.value[0] = static_cast<uint32_t>(nanoseconds);
+  i96.value[1] = static_cast<uint32_t>(nanoseconds >> 32);
+#endif
 }
 
 struct DecodedInt96 {
@@ -723,7 +729,12 @@ static inline DecodedInt96 DecodeInt96Timestamp(const parquet::Int96& i96) {
   result.days_since_epoch = i96.value[2] - static_cast<uint64_t>(kJulianToUnixEpochDays);
   result.nanoseconds = 0;
 
+#if ARROW_LITTLE_ENDIAN
   memcpy(&result.nanoseconds, &i96.value, sizeof(uint64_t));
+#else
+  result.nanoseconds =
+      static_cast<uint64_t>(i96.value[0]) | (static_cast<uint64_t>(i96.value[1]) << 32);
+#endif
   return result;
 }
 


### PR DESCRIPTION

### Rationale for this change

This PR is intended to enable Parquet DB support on Big-endian (s390x) systems. The fix in this PR fixes the Types logic.

### What changes are included in this PR?

The fix includes changes to following files:
cpp/src/parquet/types.cc
cpp/src/parquet/types.h

### Are these changes tested?

Yes. The changes are tested on s390x arch to make sure things are working fine. The fix is also tested on x86 arch, to make sure there is no new regression introduced.

### Are there any user-facing changes?

No

GitHub main Issue link: https://github.com/apache/arrow/issues/48151
* GitHub Issue: #48208