### PR TITLE
GH-48210: [C++][Parquet] Fix Bloom Filter logic to enable Parquet DB support on s390x

### DIFF
--- a/cpp/src/parquet/bloom_filter.cc
+++ b/cpp/src/parquet/bloom_filter.cc
@@ -30,6 +30,7 @@
 
 #include "generated/parquet_types.h"
 
+#include "arrow/util/endian.h"
 #include "parquet/bloom_filter.h"
 #include "parquet/encryption/encryption_internal.h"
 #include "parquet/encryption/internal_file_decryptor.h"
@@ -433,13 +434,14 @@ void BlockSplitBloomFilter::Fold(uint32_t num_folds) {
 bool BlockSplitBloomFilter::FindHash(uint64_t hash) const {
   const uint32_t bucket_index = static_cast<uint32_t>(((hash >> 32) * NumBlocks()) >> 32);
   const uint32_t key = static_cast<uint32_t>(hash);
-  const uint32_t* bitset32 = reinterpret_cast<const uint32_t*>(data_->data());
+  const uint32_t* raw_bitset32 = reinterpret_cast<const uint32_t*>(data_->data());
 
   for (int i = 0; i < kBitsSetPerBlock; ++i) {
+    const uint32_t bitset_word = ::arrow::bit_util::FromLittleEndian(
+        raw_bitset32[kBitsSetPerBlock * bucket_index + i]);
     // Calculate mask for key in the given bitset.
     const uint32_t mask = UINT32_C(0x1) << ((key * SALT[i]) >> 27);
-    if (ARROW_PREDICT_FALSE(0 ==
-                            (bitset32[kBitsSetPerBlock * bucket_index + i] & mask))) {
+    if (ARROW_PREDICT_FALSE(0 == (bitset_word & mask))) {
       return false;
     }
   }
@@ -449,12 +451,16 @@ bool BlockSplitBloomFilter::FindHash(uint64_t hash) const {
 void BlockSplitBloomFilter::InsertHashImpl(uint64_t hash) {
   const uint32_t bucket_index = static_cast<uint32_t>(((hash >> 32) * NumBlocks()) >> 32);
   const uint32_t key = static_cast<uint32_t>(hash);
-  uint32_t* bitset32 = reinterpret_cast<uint32_t*>(data_->mutable_data());
+  uint32_t* raw_bitset32 = reinterpret_cast<uint32_t*>(data_->mutable_data());
 
   for (int i = 0; i < kBitsSetPerBlock; i++) {
+    const int word_index = bucket_index * kBitsSetPerBlock + i;
+    uint32_t bitset_word = ::arrow::bit_util::FromLittleEndian(raw_bitset32[word_index]);
+
     // Calculate mask for key in the given bitset.
     const uint32_t mask = UINT32_C(0x1) << ((key * SALT[i]) >> 27);
-    bitset32[bucket_index * kBitsSetPerBlock + i] |= mask;
+    bitset_word |= mask;
+    raw_bitset32[word_index] = ::arrow::bit_util::ToLittleEndian(bitset_word);
   }
 }
 


### PR DESCRIPTION

### Rationale for this change

This PR is intended to enable Parquet DB support on Big-endian (s390x) systems. The fix in this PR fixes the Bloom Filter logic.

### What changes are included in this PR?

The fix includes changes to following file:
cpp/src/parquet/bloom_filter.cc

### Are these changes tested?

Yes. The changes are tested on s390x arch to make sure things are working fine. The fix is also tested on x86 arch, to make sure there is no new regression introduced.

### Are there any user-facing changes?

No

GitHub main Issue link: https://github.com/apache/arrow/issues/48151
* GitHub Issue: #48210