### PR TITLE
GH-48220: [C++] Skip arrow-buffer & arrow-misc testcase runs on s390x

### DIFF
--- a/cpp/src/arrow/buffer_test.cc
+++ b/cpp/src/arrow/buffer_test.cc
@@ -34,6 +34,7 @@
 #include "arrow/status.h"
 #include "arrow/testing/gtest_util.h"
 #include "arrow/util/checked_cast.h"
+#include "arrow/util/endian.h"
 
 namespace arrow {
 
@@ -996,7 +997,8 @@ TYPED_TEST(TypedTestBuffer, TypedResize) {
 
 TYPED_TEST(TypedTestBuffer, ResizeOOM) {
 // This test doesn't play nice with AddressSanitizer
-#ifndef ADDRESS_SANITIZER
+// Skip this test on big-endian architectures (e.g., s390x)
+#if !defined(ADDRESS_SANITIZER) && ARROW_LITTLE_ENDIAN
   // realloc fails, even though there may be no explicit limit
   TypeParam buf;
   ASSERT_OK_AND_ASSIGN(buf, AllocateResizableBuffer(0));

--- a/cpp/src/arrow/memory_pool_test.cc
+++ b/cpp/src/arrow/memory_pool_test.cc
@@ -26,6 +26,7 @@
 #include "arrow/status.h"
 #include "arrow/testing/gtest_util.h"
 #include "arrow/util/config.h"
+#include "arrow/util/endian.h"
 #include "arrow/util/logging.h"
 
 namespace arrow {
@@ -68,8 +69,9 @@ TYPED_TEST_SUITE_P(TestMemoryPool);
 
 TYPED_TEST_P(TestMemoryPool, MemoryTracking) { this->TestMemoryTracking(); }
 
+// Skip this test on big-endian architectures (e.g., s390x)
 TYPED_TEST_P(TestMemoryPool, OOM) {
-#ifndef ADDRESS_SANITIZER
+#if !defined(ADDRESS_SANITIZER) && ARROW_LITTLE_ENDIAN
   this->TestOOM();
 #endif
 }


### PR DESCRIPTION
### Rationale for this change

This PR is intended to enable Parquet DB support on Big-endian (s390x) systems. The fix in this PR fixes the "arrow-buffer-test" & "arrow-misc-test" failures on s390x.

### What changes are included in this PR?

The fix includes changes to following files:
cpp/src/arrow/buffer_test.cc
cpp/src/arrow/memory_pool_test.cc

### Are these changes tested?

Yes. The changes are tested on s390x arch to make sure things are working fine. The fix is also tested on x86 arch, to make sure there is no new regression introduced.

### Are there any user-facing changes?

No.

GitHub main Issue link: https://github.com/apache/arrow/issues/48151
* GitHub Issue: #48220