### PR TITLE
GH-48222: [CI][Dev] Fix shellcheck errors in ci/scripts/cpp_build.sh

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -300,6 +300,7 @@ repos:
           ?^ci/scripts/ccache_setup\.sh$|
           ?^ci/scripts/conan_build\.sh$|
           ?^ci/scripts/conan_setup\.sh$|
+          ?^ci/scripts/cpp_build\.sh$|
           ?^ci/scripts/cpp_test\.sh$|
           ?^ci/scripts/download_tz_database\.sh$|
           ?^ci/scripts/install_azurite\.sh$|

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -295,6 +295,7 @@ repos:
           ?^ci/scripts/c_glib_build\.sh$|
           ?^ci/scripts/c_glib_test\.sh$|
           ?^ci/scripts/ccache_setup\.sh$|
+          ?^ci/scripts/cpp_build\.sh$|
           ?^ci/scripts/cpp_test\.sh$|
           ?^ci/scripts/download_tz_database\.sh$|
           ?^ci/scripts/install_azurite\.sh$|

--- a/ci/scripts/cpp_build.sh
+++ b/ci/scripts/cpp_build.sh
@@ -22,16 +22,16 @@ set -ex
 source_dir=${1}/cpp
 build_dir=${2}/cpp
 
-: ${ARROW_OFFLINE:=OFF}
-: ${ARROW_USE_CCACHE:=OFF}
-: ${BUILD_DOCS_CPP:=OFF}
+: "${ARROW_OFFLINE:=OFF}"
+: "${ARROW_USE_CCACHE:=OFF}"
+: "${BUILD_DOCS_CPP:=OFF}"
 
 if [ -x "$(command -v git)" ]; then
-  git config --global --add safe.directory ${1}
+  git config --global --add safe.directory "${1}"
 fi
 
 # TODO(kszucs): consider to move these to CMake
-if [ ! -z "${CONDA_PREFIX}" ] && [ "${ARROW_EMSCRIPTEN:-OFF}" = "OFF" ]; then
+if [ -n "${CONDA_PREFIX}" ] && [ "${ARROW_EMSCRIPTEN:-OFF}" = "OFF" ]; then
   echo -e "===\n=== Conda environment for build\n==="
   conda list
 
@@ -42,17 +42,19 @@ if [ ! -z "${CONDA_PREFIX}" ] && [ "${ARROW_EMSCRIPTEN:-OFF}" = "OFF" ]; then
     ARROW_CMAKE_ARGS+=" -DCMAKE_RANLIB=${RANLIB}"
   fi
   export ARROW_CMAKE_ARGS
-  export ARROW_GANDIVA_PC_CXX_FLAGS=$(echo | ${CXX} -E -Wp,-v -xc++ - 2>&1 | grep '^ ' | awk '{print "-isystem;" substr($1, 1)}' | tr '\n' ';')
+  ARROW_GANDIVA_PC_CXX_FLAGS=$(echo | ${CXX} -E -Wp,-v -xc++ - 2>&1 | grep '^ ' | awk '{print "-isystem;" substr($1, 1)}' | tr '\n' ';')
+  export ARROW_GANDIVA_PC_CXX_FLAGS
 elif [ -x "$(command -v xcrun)" ]; then
-  export ARROW_GANDIVA_PC_CXX_FLAGS="-isysroot;$(xcrun --show-sdk-path)"
+  ARROW_GANDIVA_PC_CXX_FLAGS="-isysroot;$(xcrun --show-sdk-path)"
+  export ARROW_GANDIVA_PC_CXX_FLAGS
 fi
 
 if [ "${GITHUB_ACTIONS:-false}" = "true" ]; then
   case "$(uname)" in
     Linux|Darwin|MINGW*)
       if [ "${ARROW_GDB:-OFF}" != "ON" ]; then
-        : ${ARROW_C_FLAGS_DEBUG:=-g1}
-        : ${ARROW_CXX_FLAGS_DEBUG:=-g1}
+        : "${ARROW_C_FLAGS_DEBUG:=-g1}"
+        : "${ARROW_CXX_FLAGS_DEBUG:=-g1}"
       fi
       ;;
     *)
@@ -97,12 +99,13 @@ case "$(uname)" in
     ;;
 esac
 
-mkdir -p ${build_dir}
-pushd ${build_dir}
+mkdir -p "${build_dir}"
+pushd "${build_dir}"
 
 if [ "${ARROW_OFFLINE}" = "ON" ]; then
-  ${source_dir}/thirdparty/download_dependencies.sh ${PWD}/thirdparty > \
+  "${source_dir}"/thirdparty/download_dependencies.sh "${PWD}"/thirdparty > \
     enable_offline_build.sh
+  # shellcheck source=/dev/null
   . enable_offline_build.sh
   # We can't use mv because we can't remove /etc/resolv.conf in Docker
   # container.
@@ -141,156 +144,158 @@ if [ "${ARROW_USE_MESON:-OFF}" = "ON" ]; then
     fi
   fi
   meson setup \
-    --prefix=${MESON_PREFIX:-${ARROW_HOME}} \
-    --buildtype=${ARROW_BUILD_TYPE:-debug} \
+    --prefix="${MESON_PREFIX:-${ARROW_HOME}}" \
+    --buildtype="${ARROW_BUILD_TYPE:-debug}" \
     --pkg-config-path="${CONDA_PREFIX}/lib/pkgconfig/" \
     -Dauto_features=enabled \
     -Dfuzzing=disabled \
     -Ds3=disabled \
     . \
-    ${source_dir}
+    "${source_dir}"
 
   CC="${ORIGINAL_CC}"
   CXX="${ORIGINAL_CXX}"
 elif [ "${ARROW_EMSCRIPTEN:-OFF}" = "ON" ]; then
   if [ "${UBUNTU}" = "20.04" ]; then
     echo "arrow emscripten build is not supported on Ubuntu 20.04, run with UBUNTU=22.04"
-    exit -1
+    exit 1
   fi
   n_jobs=2 # Emscripten build fails on docker unless this is set really low
+  # shellcheck source=/dev/null
   source ~/emsdk/emsdk_env.sh
-  export CMAKE_INSTALL_PREFIX=$(em-config CACHE)/sysroot
+  CMAKE_INSTALL_PREFIX=$(em-config CACHE)/sysroot
+  export CMAKE_INSTALL_PREFIX
   # conda sets LDFLAGS / CFLAGS etc. which break
   # emcmake so we unset them
   unset LDFLAGS CFLAGS CXXFLAGS CPPFLAGS
   emcmake cmake \
-    --preset=ninja-${ARROW_BUILD_TYPE:-debug}-emscripten \
-    -DCMAKE_VERBOSE_MAKEFILE=${CMAKE_VERBOSE_MAKEFILE:-OFF} \
+    --preset=ninja-"${ARROW_BUILD_TYPE:-debug}"-emscripten \
+    -DCMAKE_VERBOSE_MAKEFILE="${CMAKE_VERBOSE_MAKEFILE:-OFF}" \
     -DCMAKE_C_FLAGS="${CFLAGS:-}" \
     -DCMAKE_CXX_FLAGS="${CXXFLAGS:-}" \
     -DCMAKE_CXX_STANDARD="${CMAKE_CXX_STANDARD:-17}" \
-    -DCMAKE_INSTALL_LIBDIR=${CMAKE_INSTALL_LIBDIR:-lib} \
-    -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX:-${ARROW_HOME}} \
-    -DCMAKE_UNITY_BUILD=${CMAKE_UNITY_BUILD:-OFF} \
-    ${ARROW_CMAKE_ARGS} \
-    ${source_dir}
+    -DCMAKE_INSTALL_LIBDIR="${CMAKE_INSTALL_LIBDIR:-lib}" \
+    -DCMAKE_INSTALL_PREFIX="${CMAKE_INSTALL_PREFIX:-${ARROW_HOME}}" \
+    -DCMAKE_UNITY_BUILD="${CMAKE_UNITY_BUILD:-OFF}" \
+    "${ARROW_CMAKE_ARGS}" \
+    "${source_dir}"
 elif [ -n "${CMAKE_PRESET}" ]; then
   cmake \
     --preset="${CMAKE_PRESET}" \
-    ${ARROW_CMAKE_ARGS} \
-    ${source_dir}
+    "${ARROW_CMAKE_ARGS}" \
+    "${source_dir}"
 else
   cmake \
-    -Dabsl_SOURCE=${absl_SOURCE:-} \
-    -DARROW_ACERO=${ARROW_ACERO:-OFF} \
-    -DARROW_AZURE=${ARROW_AZURE:-OFF} \
-    -DARROW_BOOST_USE_SHARED=${ARROW_BOOST_USE_SHARED:-ON} \
-    -DARROW_BUILD_BENCHMARKS_REFERENCE=${ARROW_BUILD_BENCHMARKS:-OFF} \
-    -DARROW_BUILD_BENCHMARKS=${ARROW_BUILD_BENCHMARKS:-OFF} \
-    -DARROW_BUILD_EXAMPLES=${ARROW_BUILD_EXAMPLES:-OFF} \
-    -DARROW_BUILD_INTEGRATION=${ARROW_BUILD_INTEGRATION:-OFF} \
-    -DARROW_BUILD_SHARED=${ARROW_BUILD_SHARED:-ON} \
-    -DARROW_BUILD_STATIC=${ARROW_BUILD_STATIC:-ON} \
-    -DARROW_BUILD_TESTS=${ARROW_BUILD_TESTS:-OFF} \
-    -DARROW_BUILD_UTILITIES=${ARROW_BUILD_UTILITIES:-ON} \
-    -DARROW_COMPUTE=${ARROW_COMPUTE:-ON} \
-    -DARROW_CSV=${ARROW_CSV:-ON} \
-    -DARROW_CUDA=${ARROW_CUDA:-OFF} \
-    -DARROW_CXXFLAGS=${ARROW_CXXFLAGS:-} \
+    -Dabsl_SOURCE="${absl_SOURCE:-}" \
+    -DARROW_ACERO="${ARROW_ACERO:-OFF}" \
+    -DARROW_AZURE="${ARROW_AZURE:-OFF}" \
+    -DARROW_BOOST_USE_SHARED="${ARROW_BOOST_USE_SHARED:-ON}" \
+    -DARROW_BUILD_BENCHMARKS_REFERENCE="${ARROW_BUILD_BENCHMARKS:-OFF}" \
+    -DARROW_BUILD_BENCHMARKS="${ARROW_BUILD_BENCHMARKS:-OFF}" \
+    -DARROW_BUILD_EXAMPLES="${ARROW_BUILD_EXAMPLES:-OFF}" \
+    -DARROW_BUILD_INTEGRATION="${ARROW_BUILD_INTEGRATION:-OFF}" \
+    -DARROW_BUILD_SHARED="${ARROW_BUILD_SHARED:-ON}" \
+    -DARROW_BUILD_STATIC="${ARROW_BUILD_STATIC:-ON}" \
+    -DARROW_BUILD_TESTS="${ARROW_BUILD_TESTS:-OFF}" \
+    -DARROW_BUILD_UTILITIES="${ARROW_BUILD_UTILITIES:-ON}" \
+    -DARROW_COMPUTE="${ARROW_COMPUTE:-ON}" \
+    -DARROW_CSV="${ARROW_CSV:-ON}" \
+    -DARROW_CUDA="${ARROW_CUDA:-OFF}" \
+    -DARROW_CXXFLAGS="${ARROW_CXXFLAGS:-}" \
     -DARROW_CXX_FLAGS_DEBUG="${ARROW_CXX_FLAGS_DEBUG:-}" \
     -DARROW_CXX_FLAGS_RELEASE="${ARROW_CXX_FLAGS_RELEASE:-}" \
     -DARROW_CXX_FLAGS_RELWITHDEBINFO="${ARROW_CXX_FLAGS_RELWITHDEBINFO:-}" \
     -DARROW_C_FLAGS_DEBUG="${ARROW_C_FLAGS_DEBUG:-}" \
     -DARROW_C_FLAGS_RELEASE="${ARROW_C_FLAGS_RELEASE:-}" \
     -DARROW_C_FLAGS_RELWITHDEBINFO="${ARROW_C_FLAGS_RELWITHDEBINFO:-}" \
-    -DARROW_DATASET=${ARROW_DATASET:-OFF} \
-    -DARROW_DEPENDENCY_SOURCE=${ARROW_DEPENDENCY_SOURCE:-AUTO} \
-    -DARROW_DEPENDENCY_USE_SHARED=${ARROW_DEPENDENCY_USE_SHARED:-ON} \
-    -DARROW_ENABLE_THREADING=${ARROW_ENABLE_THREADING:-ON} \
-    -DARROW_ENABLE_TIMING_TESTS=${ARROW_ENABLE_TIMING_TESTS:-ON} \
-    -DARROW_EXTRA_ERROR_CONTEXT=${ARROW_EXTRA_ERROR_CONTEXT:-OFF} \
-    -DARROW_FILESYSTEM=${ARROW_FILESYSTEM:-ON} \
-    -DARROW_FLIGHT=${ARROW_FLIGHT:-OFF} \
-    -DARROW_FLIGHT_SQL=${ARROW_FLIGHT_SQL:-OFF} \
-    -DARROW_FLIGHT_SQL_ODBC=${ARROW_FLIGHT_SQL_ODBC:-OFF} \
-    -DARROW_FUZZING=${ARROW_FUZZING:-OFF} \
-    -DARROW_GANDIVA_PC_CXX_FLAGS=${ARROW_GANDIVA_PC_CXX_FLAGS:-} \
-    -DARROW_GANDIVA=${ARROW_GANDIVA:-OFF} \
-    -DARROW_GCS=${ARROW_GCS:-OFF} \
-    -DARROW_HDFS=${ARROW_HDFS:-ON} \
-    -DARROW_INSTALL_NAME_RPATH=${ARROW_INSTALL_NAME_RPATH:-ON} \
-    -DARROW_JEMALLOC=${ARROW_JEMALLOC:-OFF} \
-    -DARROW_JSON=${ARROW_JSON:-ON} \
-    -DARROW_LARGE_MEMORY_TESTS=${ARROW_LARGE_MEMORY_TESTS:-OFF} \
-    -DARROW_MIMALLOC=${ARROW_MIMALLOC:-ON} \
-    -DARROW_ORC=${ARROW_ORC:-OFF} \
-    -DARROW_PARQUET=${ARROW_PARQUET:-OFF} \
-    -DARROW_RUNTIME_SIMD_LEVEL=${ARROW_RUNTIME_SIMD_LEVEL:-MAX} \
-    -DARROW_S3=${ARROW_S3:-OFF} \
-    -DARROW_SIMD_LEVEL=${ARROW_SIMD_LEVEL:-DEFAULT} \
-    -DARROW_SUBSTRAIT=${ARROW_SUBSTRAIT:-OFF} \
-    -DARROW_TEST_LINKAGE=${ARROW_TEST_LINKAGE:-shared} \
-    -DARROW_TEST_MEMCHECK=${ARROW_TEST_MEMCHECK:-OFF} \
-    -DARROW_USE_ASAN=${ARROW_USE_ASAN:-OFF} \
-    -DARROW_USE_CCACHE=${ARROW_USE_CCACHE:-ON} \
-    -DARROW_USE_GLOG=${ARROW_USE_GLOG:-OFF} \
-    -DARROW_USE_LLD=${ARROW_USE_LLD:-OFF} \
-    -DARROW_USE_MOLD=${ARROW_USE_MOLD:-OFF} \
-    -DARROW_USE_STATIC_CRT=${ARROW_USE_STATIC_CRT:-OFF} \
-    -DARROW_USE_TSAN=${ARROW_USE_TSAN:-OFF} \
-    -DARROW_USE_UBSAN=${ARROW_USE_UBSAN:-OFF} \
-    -DARROW_VERBOSE_THIRDPARTY_BUILD=${ARROW_VERBOSE_THIRDPARTY_BUILD:-OFF} \
-    -DARROW_WITH_BROTLI=${ARROW_WITH_BROTLI:-OFF} \
-    -DARROW_WITH_BZ2=${ARROW_WITH_BZ2:-OFF} \
-    -DARROW_WITH_LZ4=${ARROW_WITH_LZ4:-OFF} \
-    -DARROW_WITH_OPENTELEMETRY=${ARROW_WITH_OPENTELEMETRY:-OFF} \
-    -DARROW_WITH_MUSL=${ARROW_WITH_MUSL:-OFF} \
-    -DARROW_WITH_SNAPPY=${ARROW_WITH_SNAPPY:-OFF} \
-    -DARROW_WITH_UTF8PROC=${ARROW_WITH_UTF8PROC:-ON} \
-    -DARROW_WITH_ZLIB=${ARROW_WITH_ZLIB:-OFF} \
-    -DARROW_WITH_ZSTD=${ARROW_WITH_ZSTD:-OFF} \
-    -DAWSSDK_SOURCE=${AWSSDK_SOURCE:-} \
-    -DAzure_SOURCE=${Azure_SOURCE:-} \
-    -Dbenchmark_SOURCE=${benchmark_SOURCE:-} \
-    -DBOOST_SOURCE=${BOOST_SOURCE:-} \
-    -DBrotli_SOURCE=${Brotli_SOURCE:-} \
-    -DBUILD_WARNING_LEVEL=${BUILD_WARNING_LEVEL:-CHECKIN} \
-    -Dc-ares_SOURCE=${cares_SOURCE:-} \
-    -DCMAKE_BUILD_TYPE=${ARROW_BUILD_TYPE:-debug} \
-    -DCMAKE_VERBOSE_MAKEFILE=${CMAKE_VERBOSE_MAKEFILE:-OFF} \
+    -DARROW_DATASET="${ARROW_DATASET:-OFF}" \
+    -DARROW_DEPENDENCY_SOURCE="${ARROW_DEPENDENCY_SOURCE:-AUTO}" \
+    -DARROW_DEPENDENCY_USE_SHARED="${ARROW_DEPENDENCY_USE_SHARED:-ON}" \
+    -DARROW_ENABLE_THREADING="${ARROW_ENABLE_THREADING:-ON}" \
+    -DARROW_ENABLE_TIMING_TESTS="${ARROW_ENABLE_TIMING_TESTS:-ON}" \
+    -DARROW_EXTRA_ERROR_CONTEXT="${ARROW_EXTRA_ERROR_CONTEXT:-OFF}" \
+    -DARROW_FILESYSTEM="${ARROW_FILESYSTEM:-ON}" \
+    -DARROW_FLIGHT="${ARROW_FLIGHT:-OFF}" \
+    -DARROW_FLIGHT_SQL="${ARROW_FLIGHT_SQL:-OFF}" \
+    -DARROW_FLIGHT_SQL_ODBC="${ARROW_FLIGHT_SQL_ODBC:-OFF}" \
+    -DARROW_FUZZING="${ARROW_FUZZING:-OFF}" \
+    -DARROW_GANDIVA_PC_CXX_FLAGS="${ARROW_GANDIVA_PC_CXX_FLAGS:-}" \
+    -DARROW_GANDIVA="${ARROW_GANDIVA:-OFF}" \
+    -DARROW_GCS="${ARROW_GCS:-OFF}" \
+    -DARROW_HDFS="${ARROW_HDFS:-ON}" \
+    -DARROW_INSTALL_NAME_RPATH="${ARROW_INSTALL_NAME_RPATH:-ON}" \
+    -DARROW_JEMALLOC="${ARROW_JEMALLOC:-OFF}" \
+    -DARROW_JSON="${ARROW_JSON:-ON}" \
+    -DARROW_LARGE_MEMORY_TESTS="${ARROW_LARGE_MEMORY_TESTS:-OFF}" \
+    -DARROW_MIMALLOC="${ARROW_MIMALLOC:-ON}" \
+    -DARROW_ORC="${ARROW_ORC:-OFF}" \
+    -DARROW_PARQUET="${ARROW_PARQUET:-OFF}" \
+    -DARROW_RUNTIME_SIMD_LEVEL="${ARROW_RUNTIME_SIMD_LEVEL:-MAX}" \
+    -DARROW_S3="${ARROW_S3:-OFF}" \
+    -DARROW_SIMD_LEVEL="${ARROW_SIMD_LEVEL:-DEFAULT}" \
+    -DARROW_SUBSTRAIT="${ARROW_SUBSTRAIT:-OFF}" \
+    -DARROW_TEST_LINKAGE="${ARROW_TEST_LINKAGE:-shared}" \
+    -DARROW_TEST_MEMCHECK="${ARROW_TEST_MEMCHECK:-OFF}" \
+    -DARROW_USE_ASAN="${ARROW_USE_ASAN:-OFF}" \
+    -DARROW_USE_CCACHE="${ARROW_USE_CCACHE:-ON}" \
+    -DARROW_USE_GLOG="${ARROW_USE_GLOG:-OFF}" \
+    -DARROW_USE_LLD="${ARROW_USE_LLD:-OFF}" \
+    -DARROW_USE_MOLD="${ARROW_USE_MOLD:-OFF}" \
+    -DARROW_USE_STATIC_CRT="${ARROW_USE_STATIC_CRT:-OFF}" \
+    -DARROW_USE_TSAN="${ARROW_USE_TSAN:-OFF}" \
+    -DARROW_USE_UBSAN="${ARROW_USE_UBSAN:-OFF}" \
+    -DARROW_VERBOSE_THIRDPARTY_BUILD="${ARROW_VERBOSE_THIRDPARTY_BUILD:-OFF}" \
+    -DARROW_WITH_BROTLI="${ARROW_WITH_BROTLI:-OFF}" \
+    -DARROW_WITH_BZ2="${ARROW_WITH_BZ2:-OFF}" \
+    -DARROW_WITH_LZ4="${ARROW_WITH_LZ4:-OFF}" \
+    -DARROW_WITH_OPENTELEMETRY="${ARROW_WITH_OPENTELEMETRY:-OFF}" \
+    -DARROW_WITH_MUSL="${ARROW_WITH_MUSL:-OFF}" \
+    -DARROW_WITH_SNAPPY="${ARROW_WITH_SNAPPY:-OFF}" \
+    -DARROW_WITH_UTF8PROC="${ARROW_WITH_UTF8PROC:-ON}" \
+    -DARROW_WITH_ZLIB="${ARROW_WITH_ZLIB:-OFF}" \
+    -DARROW_WITH_ZSTD="${ARROW_WITH_ZSTD:-OFF}" \
+    -DAWSSDK_SOURCE="${AWSSDK_SOURCE:-}" \
+    -DAzure_SOURCE="${Azure_SOURCE:-}" \
+    -Dbenchmark_SOURCE="${benchmark_SOURCE:-}" \
+    -DBOOST_SOURCE="${BOOST_SOURCE:-}" \
+    -DBrotli_SOURCE="${Brotli_SOURCE:-}" \
+    -DBUILD_WARNING_LEVEL="${BUILD_WARNING_LEVEL:-CHECKIN}" \
+    -Dc-ares_SOURCE="${cares_SOURCE:-}" \
+    -DCMAKE_BUILD_TYPE="${ARROW_BUILD_TYPE:-debug}" \
+    -DCMAKE_VERBOSE_MAKEFILE="${CMAKE_VERBOSE_MAKEFILE:-OFF}" \
     -DCMAKE_C_FLAGS="${CFLAGS:-}" \
     -DCMAKE_CXX_FLAGS="${CXXFLAGS:-}" \
     -DCMAKE_CXX_STANDARD="${CMAKE_CXX_STANDARD:-17}" \
-    -DCMAKE_INSTALL_LIBDIR=${CMAKE_INSTALL_LIBDIR:-lib} \
-    -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX:-${ARROW_HOME}} \
-    -DCMAKE_UNITY_BUILD=${CMAKE_UNITY_BUILD:-OFF} \
-    -DCUDAToolkit_ROOT=${CUDAToolkit_ROOT:-} \
-    -Dgflags_SOURCE=${gflags_SOURCE:-} \
-    -Dgoogle_cloud_cpp_storage_SOURCE=${google_cloud_cpp_storage_SOURCE:-} \
-    -DgRPC_SOURCE=${gRPC_SOURCE:-} \
-    -DGTest_SOURCE=${GTest_SOURCE:-} \
-    -Dlz4_SOURCE=${lz4_SOURCE:-} \
-    -Dopentelemetry-cpp_SOURCE=${opentelemetry_cpp_SOURCE:-} \
-    -DORC_SOURCE=${ORC_SOURCE:-} \
-    -DPARQUET_BUILD_EXAMPLES=${PARQUET_BUILD_EXAMPLES:-OFF} \
-    -DPARQUET_BUILD_EXECUTABLES=${PARQUET_BUILD_EXECUTABLES:-OFF} \
-    -DPARQUET_REQUIRE_ENCRYPTION=${PARQUET_REQUIRE_ENCRYPTION:-ON} \
-    -DProtobuf_SOURCE=${Protobuf_SOURCE:-} \
-    -DRapidJSON_SOURCE=${RapidJSON_SOURCE:-} \
-    -Dre2_SOURCE=${re2_SOURCE:-} \
-    -DSnappy_SOURCE=${Snappy_SOURCE:-} \
-    -DThrift_SOURCE=${Thrift_SOURCE:-} \
-    -Dutf8proc_SOURCE=${utf8proc_SOURCE:-} \
-    -Dzstd_SOURCE=${zstd_SOURCE:-} \
-    -Dxsimd_SOURCE=${xsimd_SOURCE:-} \
+    -DCMAKE_INSTALL_LIBDIR="${CMAKE_INSTALL_LIBDIR:-lib}" \
+    -DCMAKE_INSTALL_PREFIX="${CMAKE_INSTALL_PREFIX:-${ARROW_HOME}}" \
+    -DCMAKE_UNITY_BUILD="${CMAKE_UNITY_BUILD:-OFF}" \
+    -DCUDAToolkit_ROOT="${CUDAToolkit_ROOT:-}" \
+    -Dgflags_SOURCE="${gflags_SOURCE:-}" \
+    -Dgoogle_cloud_cpp_storage_SOURCE="${google_cloud_cpp_storage_SOURCE:-}" \
+    -DgRPC_SOURCE="${gRPC_SOURCE:-}" \
+    -DGTest_SOURCE="${GTest_SOURCE:-}" \
+    -Dlz4_SOURCE="${lz4_SOURCE:-}" \
+    -Dopentelemetry-cpp_SOURCE="${opentelemetry_cpp_SOURCE:-}" \
+    -DORC_SOURCE="${ORC_SOURCE:-}" \
+    -DPARQUET_BUILD_EXAMPLES="${PARQUET_BUILD_EXAMPLES:-OFF}" \
+    -DPARQUET_BUILD_EXECUTABLES="${PARQUET_BUILD_EXECUTABLES:-OFF}" \
+    -DPARQUET_REQUIRE_ENCRYPTION="${PARQUET_REQUIRE_ENCRYPTION:-ON}" \
+    -DProtobuf_SOURCE="${Protobuf_SOURCE:-}" \
+    -DRapidJSON_SOURCE="${RapidJSON_SOURCE:-}" \
+    -Dre2_SOURCE="${re2_SOURCE:-}" \
+    -DSnappy_SOURCE="${Snappy_SOURCE:-}" \
+    -DThrift_SOURCE="${Thrift_SOURCE:-}" \
+    -Dutf8proc_SOURCE="${utf8proc_SOURCE:-}" \
+    -Dzstd_SOURCE="${zstd_SOURCE:-}" \
+    -Dxsimd_SOURCE="${xsimd_SOURCE:-}" \
     -G "${CMAKE_GENERATOR:-Ninja}" \
-    ${ARROW_CMAKE_ARGS} \
-    ${source_dir}
+    "${ARROW_CMAKE_ARGS}" \
+    "${source_dir}"
 fi
 
-: ${ARROW_BUILD_PARALLEL:=$[${n_jobs} + 1]}
+: "${ARROW_BUILD_PARALLEL:=$(( n_jobs + 1))}"
 if [ "${ARROW_USE_MESON:-OFF}" = "ON" ]; then
-  time meson compile -j ${ARROW_BUILD_PARALLEL}
+  time meson compile -j "${ARROW_BUILD_PARALLEL}"
   meson install
   # Remove all added files in cpp/subprojects/ because they may have
   # unreadable permissions on Docker host.
@@ -298,7 +303,7 @@ if [ "${ARROW_USE_MESON:-OFF}" = "ON" ]; then
   meson subprojects purge --confirm --include-cache
   popd
 else
-  : ${CMAKE_BUILD_PARALLEL_LEVEL:=${ARROW_BUILD_PARALLEL}}
+  : "${CMAKE_BUILD_PARALLEL_LEVEL:=${ARROW_BUILD_PARALLEL}}"
   export CMAKE_BUILD_PARALLEL_LEVEL
   time cmake --build . --target install
 fi
@@ -322,7 +327,7 @@ if [ -x "$(command -v ldconfig)" ]; then
       SUDO=
     fi
   fi
-  ${SUDO} ldconfig ${ARROW_HOME}/${CMAKE_INSTALL_LIBDIR:-lib}
+  ${SUDO} ldconfig "${ARROW_HOME}"/"${CMAKE_INSTALL_LIBDIR:-lib}"
 fi
 
 if [ "${ARROW_USE_CCACHE}" == "ON" ]; then
@@ -336,7 +341,7 @@ if command -v sccache &> /dev/null; then
 fi
 
 if [ "${BUILD_DOCS_CPP}" == "ON" ]; then
-  pushd ${source_dir}/apidoc
+  pushd "${source_dir}/apidoc"
   OUTPUT_DIRECTORY=${build_dir}/apidoc doxygen
   popd
 fi

--- a/ci/scripts/cpp_build.sh
+++ b/ci/scripts/cpp_build.sh
@@ -327,7 +327,7 @@ if [ -x "$(command -v ldconfig)" ]; then
       SUDO=
     fi
   fi
-  ${SUDO} ldconfig "${ARROW_HOME}"/"${CMAKE_INSTALL_LIBDIR:-lib}"
+  ${SUDO} ldconfig "${ARROW_HOME}/${CMAKE_INSTALL_LIBDIR:-lib}"
 fi
 
 if [ "${ARROW_USE_CCACHE}" == "ON" ]; then

--- a/ci/scripts/cpp_build.sh
+++ b/ci/scripts/cpp_build.sh
@@ -293,7 +293,7 @@ else
     "${source_dir}"
 fi
 
-: "${ARROW_BUILD_PARALLEL:=$(( n_jobs + 1))}"
+: "${ARROW_BUILD_PARALLEL:=$((n_jobs + 1))}"
 if [ "${ARROW_USE_MESON:-OFF}" = "ON" ]; then
   time meson compile -j "${ARROW_BUILD_PARALLEL}"
   meson install

--- a/ci/scripts/cpp_build.sh
+++ b/ci/scripts/cpp_build.sh
@@ -31,7 +31,7 @@ if [ -x "$(command -v git)" ]; then
 fi
 
 # TODO(kszucs): consider to move these to CMake
-if [ ! -z "${CONDA_PREFIX}" ] && [ "${ARROW_EMSCRIPTEN:-OFF}" = "OFF" ]; then
+if [ -n "${CONDA_PREFIX}" ] && [ "${ARROW_EMSCRIPTEN:-OFF}" = "OFF" ]; then
   echo -e "===\n=== Conda environment for build\n==="
   conda list
 

--- a/ci/scripts/cpp_build.sh
+++ b/ci/scripts/cpp_build.sh
@@ -173,7 +173,7 @@ elif [ "${ARROW_EMSCRIPTEN:-OFF}" = "ON" ]; then
   # emcmake so we unset them
   unset LDFLAGS CFLAGS CXXFLAGS CPPFLAGS
   emcmake cmake \
-    --preset=ninja-"${ARROW_BUILD_TYPE:-debug}"-emscripten \
+    --preset="ninja-${ARROW_BUILD_TYPE:-debug}-emscripten" \
     -DCMAKE_VERBOSE_MAKEFILE="${CMAKE_VERBOSE_MAKEFILE:-OFF}" \
     -DCMAKE_C_FLAGS="${CFLAGS:-}" \
     -DCMAKE_CXX_FLAGS="${CXXFLAGS:-}" \
@@ -335,7 +335,7 @@ if [ -x "$(command -v ldconfig)" ]; then
       SUDO=
     fi
   fi
-  ${SUDO} ldconfig "${ARROW_HOME}"/"${CMAKE_INSTALL_LIBDIR:-lib}"
+  ${SUDO} ldconfig "${ARROW_HOME}/${CMAKE_INSTALL_LIBDIR:-lib}"
 fi
 
 if [ "${ARROW_USE_CCACHE}" == "ON" ]; then

--- a/ci/scripts/cpp_build.sh
+++ b/ci/scripts/cpp_build.sh
@@ -22,12 +22,12 @@ set -ex
 source_dir=${1}/cpp
 build_dir=${2}/cpp
 
-: ${ARROW_OFFLINE:=OFF}
-: ${ARROW_USE_CCACHE:=OFF}
-: ${BUILD_DOCS_CPP:=OFF}
+: "${ARROW_OFFLINE:=OFF}"
+: "${ARROW_USE_CCACHE:=OFF}"
+: "${BUILD_DOCS_CPP:=OFF}"
 
 if [ -x "$(command -v git)" ]; then
-  git config --global --add safe.directory ${1}
+  git config --global --add safe.directory "${1}"
 fi
 
 # TODO(kszucs): consider to move these to CMake
@@ -42,23 +42,29 @@ if [ ! -z "${CONDA_PREFIX}" ] && [ "${ARROW_EMSCRIPTEN:-OFF}" = "OFF" ]; then
     ARROW_CMAKE_ARGS+=" -DCMAKE_RANLIB=${RANLIB}"
   fi
   export ARROW_CMAKE_ARGS
-  export ARROW_GANDIVA_PC_CXX_FLAGS=$(echo | ${CXX} -E -Wp,-v -xc++ - 2>&1 | grep '^ ' | awk '{print "-isystem;" substr($1, 1)}' | tr '\n' ';')
+  ARROW_GANDIVA_PC_CXX_FLAGS=$(echo | ${CXX} -E -Wp,-v -xc++ - 2>&1 | grep '^ ' | awk '{print "-isystem;" substr($1, 1)}' | tr '\n' ';')
+  export ARROW_GANDIVA_PC_CXX_FLAGS
 elif [ -x "$(command -v xcrun)" ]; then
-  export ARROW_GANDIVA_PC_CXX_FLAGS="-isysroot;$(xcrun --show-sdk-path)"
+  ARROW_GANDIVA_PC_CXX_FLAGS="-isysroot;$(xcrun --show-sdk-path)"
+  export ARROW_GANDIVA_PC_CXX_FLAGS
 fi
 
 if [ "${GITHUB_ACTIONS:-false}" = "true" ]; then
   case "$(uname)" in
     Linux|Darwin|MINGW*)
       if [ "${ARROW_GDB:-OFF}" != "ON" ]; then
-        : ${ARROW_C_FLAGS_DEBUG:=-g1}
-        : ${ARROW_CXX_FLAGS_DEBUG:=-g1}
+        : "${ARROW_C_FLAGS_DEBUG:=-g1}"
+        : "${ARROW_CXX_FLAGS_DEBUG:=-g1}"
       fi
       ;;
     *)
       ;;
   esac
 fi
+
+# Convert the space-separated CMake options into a Bash array.
+# This avoids ShellCheck SC2086 and preserves argument boundaries.
+read -r -a ARROW_CMAKE_ARGS_ARRAY <<< "$ARROW_CMAKE_ARGS"
 
 if [ "${ARROW_ENABLE_THREADING:-ON}" = "OFF" ]; then
   ARROW_AZURE=OFF
@@ -101,12 +107,13 @@ case "$(uname)" in
     ;;
 esac
 
-mkdir -p ${build_dir}
-pushd ${build_dir}
+mkdir -p "${build_dir}"
+pushd "${build_dir}"
 
 if [ "${ARROW_OFFLINE}" = "ON" ]; then
-  ${source_dir}/thirdparty/download_dependencies.sh ${PWD}/thirdparty > \
+  "${source_dir}"/thirdparty/download_dependencies.sh "${PWD}"/thirdparty > \
     enable_offline_build.sh
+  # shellcheck source=/dev/null
   . enable_offline_build.sh
   # We can't use mv because we can't remove /etc/resolv.conf in Docker
   # container.
@@ -145,156 +152,158 @@ if [ "${ARROW_USE_MESON:-OFF}" = "ON" ]; then
     fi
   fi
   meson setup \
-    --prefix=${MESON_PREFIX:-${ARROW_HOME}} \
-    --buildtype=${ARROW_BUILD_TYPE:-debug} \
+    --prefix="${MESON_PREFIX:-${ARROW_HOME}}" \
+    --buildtype="${ARROW_BUILD_TYPE:-debug}" \
     --pkg-config-path="${CONDA_PREFIX}/lib/pkgconfig/" \
     -Dauto_features=enabled \
     -Dfuzzing=disabled \
     -Ds3=disabled \
     . \
-    ${source_dir}
+    "${source_dir}"
 
   CC="${ORIGINAL_CC}"
   CXX="${ORIGINAL_CXX}"
 elif [ "${ARROW_EMSCRIPTEN:-OFF}" = "ON" ]; then
   n_jobs=2 # Emscripten build fails on docker unless this is set really low
+  # shellcheck source=/dev/null
   source ~/emsdk/emsdk_env.sh
-  export CMAKE_INSTALL_PREFIX=$(em-config CACHE)/sysroot
+  CMAKE_INSTALL_PREFIX=$(em-config CACHE)/sysroot
+  export CMAKE_INSTALL_PREFIX
   # conda sets LDFLAGS / CFLAGS etc. which break
   # emcmake so we unset them
   unset LDFLAGS CFLAGS CXXFLAGS CPPFLAGS
   emcmake cmake \
-    --preset=ninja-${ARROW_BUILD_TYPE:-debug}-emscripten \
-    -DCMAKE_VERBOSE_MAKEFILE=${CMAKE_VERBOSE_MAKEFILE:-OFF} \
+    --preset=ninja-"${ARROW_BUILD_TYPE:-debug}"-emscripten \
+    -DCMAKE_VERBOSE_MAKEFILE="${CMAKE_VERBOSE_MAKEFILE:-OFF}" \
     -DCMAKE_C_FLAGS="${CFLAGS:-}" \
     -DCMAKE_CXX_FLAGS="${CXXFLAGS:-}" \
     -DCMAKE_CXX_STANDARD="${CMAKE_CXX_STANDARD:-20}" \
-    -DCMAKE_INSTALL_LIBDIR=${CMAKE_INSTALL_LIBDIR:-lib} \
-    -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX:-${ARROW_HOME}} \
-    -DCMAKE_UNITY_BUILD=${CMAKE_UNITY_BUILD:-OFF} \
-    ${ARROW_CMAKE_ARGS} \
-    ${source_dir}
+    -DCMAKE_INSTALL_LIBDIR="${CMAKE_INSTALL_LIBDIR:-lib}" \
+    -DCMAKE_INSTALL_PREFIX="${CMAKE_INSTALL_PREFIX:-${ARROW_HOME}}" \
+    -DCMAKE_UNITY_BUILD="${CMAKE_UNITY_BUILD:-OFF}" \
+    "${ARROW_CMAKE_ARGS_ARRAY[@]}" \
+    "${source_dir}"
 elif [ -n "${CMAKE_PRESET}" ]; then
   cmake \
     --preset="${CMAKE_PRESET}" \
-    ${ARROW_CMAKE_ARGS} \
-    ${source_dir}
+    "${ARROW_CMAKE_ARGS_ARRAY[@]}" \
+    "${source_dir}"
 else
   cmake \
-    -Dabsl_SOURCE=${absl_SOURCE:-} \
-    -DARROW_ACERO=${ARROW_ACERO:-OFF} \
-    -DARROW_AZURE=${ARROW_AZURE:-OFF} \
-    -DARROW_BOOST_USE_SHARED=${ARROW_BOOST_USE_SHARED:-ON} \
-    -DARROW_BUILD_BENCHMARKS_REFERENCE=${ARROW_BUILD_BENCHMARKS:-OFF} \
-    -DARROW_BUILD_BENCHMARKS=${ARROW_BUILD_BENCHMARKS:-OFF} \
-    -DARROW_BUILD_EXAMPLES=${ARROW_BUILD_EXAMPLES:-OFF} \
-    -DARROW_BUILD_INTEGRATION=${ARROW_BUILD_INTEGRATION:-OFF} \
-    -DARROW_BUILD_SHARED=${ARROW_BUILD_SHARED:-ON} \
-    -DARROW_BUILD_STATIC=${ARROW_BUILD_STATIC:-ON} \
-    -DARROW_BUILD_TESTS=${ARROW_BUILD_TESTS:-OFF} \
-    -DARROW_BUILD_UTILITIES=${ARROW_BUILD_UTILITIES:-ON} \
-    -DARROW_COMPUTE=${ARROW_COMPUTE:-ON} \
-    -DARROW_CSV=${ARROW_CSV:-ON} \
-    -DARROW_CUDA=${ARROW_CUDA:-OFF} \
-    -DARROW_CXXFLAGS=${ARROW_CXXFLAGS:-} \
+    -Dabsl_SOURCE="${absl_SOURCE:-}" \
+    -DARROW_ACERO="${ARROW_ACERO:-OFF}" \
+    -DARROW_AZURE="${ARROW_AZURE:-OFF}" \
+    -DARROW_BOOST_USE_SHARED="${ARROW_BOOST_USE_SHARED:-ON}" \
+    -DARROW_BUILD_BENCHMARKS_REFERENCE="${ARROW_BUILD_BENCHMARKS:-OFF}" \
+    -DARROW_BUILD_BENCHMARKS="${ARROW_BUILD_BENCHMARKS:-OFF}" \
+    -DARROW_BUILD_EXAMPLES="${ARROW_BUILD_EXAMPLES:-OFF}" \
+    -DARROW_BUILD_INTEGRATION="${ARROW_BUILD_INTEGRATION:-OFF}" \
+    -DARROW_BUILD_SHARED="${ARROW_BUILD_SHARED:-ON}" \
+    -DARROW_BUILD_STATIC="${ARROW_BUILD_STATIC:-ON}" \
+    -DARROW_BUILD_TESTS="${ARROW_BUILD_TESTS:-OFF}" \
+    -DARROW_BUILD_UTILITIES="${ARROW_BUILD_UTILITIES:-ON}" \
+    -DARROW_COMPUTE="${ARROW_COMPUTE:-ON}" \
+    -DARROW_CSV="${ARROW_CSV:-ON}" \
+    -DARROW_CUDA="${ARROW_CUDA:-OFF}" \
+    -DARROW_CXXFLAGS="${ARROW_CXXFLAGS:-}" \
     -DARROW_CXX_FLAGS_DEBUG="${ARROW_CXX_FLAGS_DEBUG:-}" \
     -DARROW_CXX_FLAGS_RELEASE="${ARROW_CXX_FLAGS_RELEASE:-}" \
     -DARROW_CXX_FLAGS_RELWITHDEBINFO="${ARROW_CXX_FLAGS_RELWITHDEBINFO:-}" \
     -DARROW_C_FLAGS_DEBUG="${ARROW_C_FLAGS_DEBUG:-}" \
     -DARROW_C_FLAGS_RELEASE="${ARROW_C_FLAGS_RELEASE:-}" \
     -DARROW_C_FLAGS_RELWITHDEBINFO="${ARROW_C_FLAGS_RELWITHDEBINFO:-}" \
-    -DARROW_DATASET=${ARROW_DATASET:-OFF} \
-    -DARROW_DEPENDENCY_SOURCE=${ARROW_DEPENDENCY_SOURCE:-AUTO} \
-    -DARROW_DEPENDENCY_USE_SHARED=${ARROW_DEPENDENCY_USE_SHARED:-ON} \
-    -DARROW_ENABLE_THREADING=${ARROW_ENABLE_THREADING:-ON} \
-    -DARROW_ENABLE_TIMING_TESTS=${ARROW_ENABLE_TIMING_TESTS:-ON} \
-    -DARROW_EXTRA_ERROR_CONTEXT=${ARROW_EXTRA_ERROR_CONTEXT:-OFF} \
-    -DARROW_FILESYSTEM=${ARROW_FILESYSTEM:-ON} \
-    -DARROW_FLIGHT=${ARROW_FLIGHT:-OFF} \
-    -DARROW_FLIGHT_SQL=${ARROW_FLIGHT_SQL:-OFF} \
-    -DARROW_FLIGHT_SQL_ODBC=${ARROW_FLIGHT_SQL_ODBC:-OFF} \
-    -DARROW_FLIGHT_SQL_ODBC_INSTALLER=${ARROW_FLIGHT_SQL_ODBC_INSTALLER:-OFF} \
-    -DARROW_FUZZING=${ARROW_FUZZING:-OFF} \
-    -DARROW_GANDIVA_PC_CXX_FLAGS=${ARROW_GANDIVA_PC_CXX_FLAGS:-} \
-    -DARROW_GANDIVA=${ARROW_GANDIVA:-OFF} \
-    -DARROW_GCS=${ARROW_GCS:-OFF} \
-    -DARROW_HDFS=${ARROW_HDFS:-ON} \
-    -DARROW_INSTALL_NAME_RPATH=${ARROW_INSTALL_NAME_RPATH:-ON} \
-    -DARROW_JEMALLOC=${ARROW_JEMALLOC:-OFF} \
-    -DARROW_JSON=${ARROW_JSON:-ON} \
-    -DARROW_LARGE_MEMORY_TESTS=${ARROW_LARGE_MEMORY_TESTS:-OFF} \
-    -DARROW_MIMALLOC=${ARROW_MIMALLOC:-ON} \
-    -DARROW_ORC=${ARROW_ORC:-OFF} \
-    -DARROW_PARQUET=${ARROW_PARQUET:-OFF} \
-    -DARROW_RUNTIME_SIMD_LEVEL=${ARROW_RUNTIME_SIMD_LEVEL:-MAX} \
-    -DARROW_S3=${ARROW_S3:-OFF} \
-    -DARROW_S3_MODULE=${ARROW_S3_MODULE:-OFF} \
-    -DARROW_SIMD_LEVEL=${ARROW_SIMD_LEVEL:-DEFAULT} \
-    -DARROW_SUBSTRAIT=${ARROW_SUBSTRAIT:-OFF} \
-    -DARROW_TEST_LINKAGE=${ARROW_TEST_LINKAGE:-shared} \
-    -DARROW_TEST_MEMCHECK=${ARROW_TEST_MEMCHECK:-OFF} \
-    -DARROW_USE_ASAN=${ARROW_USE_ASAN:-OFF} \
-    -DARROW_USE_CCACHE=${ARROW_USE_CCACHE:-ON} \
-    -DARROW_USE_GLOG=${ARROW_USE_GLOG:-OFF} \
-    -DARROW_USE_LLD=${ARROW_USE_LLD:-OFF} \
-    -DARROW_USE_MOLD=${ARROW_USE_MOLD:-OFF} \
-    -DARROW_USE_STATIC_CRT=${ARROW_USE_STATIC_CRT:-OFF} \
-    -DARROW_USE_TSAN=${ARROW_USE_TSAN:-OFF} \
-    -DARROW_USE_UBSAN=${ARROW_USE_UBSAN:-OFF} \
-    -DARROW_VERBOSE_THIRDPARTY_BUILD=${ARROW_VERBOSE_THIRDPARTY_BUILD:-OFF} \
-    -DARROW_WITH_BROTLI=${ARROW_WITH_BROTLI:-OFF} \
-    -DARROW_WITH_BZ2=${ARROW_WITH_BZ2:-OFF} \
-    -DARROW_WITH_LZ4=${ARROW_WITH_LZ4:-OFF} \
-    -DARROW_WITH_OPENTELEMETRY=${ARROW_WITH_OPENTELEMETRY:-OFF} \
-    -DARROW_WITH_MUSL=${ARROW_WITH_MUSL:-OFF} \
-    -DARROW_WITH_SNAPPY=${ARROW_WITH_SNAPPY:-OFF} \
-    -DARROW_WITH_UTF8PROC=${ARROW_WITH_UTF8PROC:-ON} \
-    -DARROW_WITH_ZLIB=${ARROW_WITH_ZLIB:-OFF} \
-    -DARROW_WITH_ZSTD=${ARROW_WITH_ZSTD:-OFF} \
-    -DAWSSDK_SOURCE=${AWSSDK_SOURCE:-} \
-    -DAzure_SOURCE=${Azure_SOURCE:-} \
-    -Dbenchmark_SOURCE=${benchmark_SOURCE:-} \
-    -DBOOST_SOURCE=${BOOST_SOURCE:-} \
-    -DBrotli_SOURCE=${Brotli_SOURCE:-} \
-    -DBUILD_WARNING_LEVEL=${BUILD_WARNING_LEVEL:-CHECKIN} \
-    -Dc-ares_SOURCE=${cares_SOURCE:-} \
-    -DCMAKE_BUILD_TYPE=${ARROW_BUILD_TYPE:-debug} \
-    -DCMAKE_VERBOSE_MAKEFILE=${CMAKE_VERBOSE_MAKEFILE:-OFF} \
+    -DARROW_DATASET="${ARROW_DATASET:-OFF}" \
+    -DARROW_DEPENDENCY_SOURCE="${ARROW_DEPENDENCY_SOURCE:-AUTO}" \
+    -DARROW_DEPENDENCY_USE_SHARED="${ARROW_DEPENDENCY_USE_SHARED:-ON}" \
+    -DARROW_ENABLE_THREADING="${ARROW_ENABLE_THREADING:-ON}" \
+    -DARROW_ENABLE_TIMING_TESTS="${ARROW_ENABLE_TIMING_TESTS:-ON}" \
+    -DARROW_EXTRA_ERROR_CONTEXT="${ARROW_EXTRA_ERROR_CONTEXT:-OFF}" \
+    -DARROW_FILESYSTEM="${ARROW_FILESYSTEM:-ON}" \
+    -DARROW_FLIGHT="${ARROW_FLIGHT:-OFF}" \
+    -DARROW_FLIGHT_SQL="${ARROW_FLIGHT_SQL:-OFF}" \
+    -DARROW_FLIGHT_SQL_ODBC="${ARROW_FLIGHT_SQL_ODBC:-OFF}" \
+    -DARROW_FLIGHT_SQL_ODBC_INSTALLER="${ARROW_FLIGHT_SQL_ODBC_INSTALLER:-OFF}" \
+    -DARROW_FUZZING="${ARROW_FUZZING:-OFF}" \
+    -DARROW_GANDIVA_PC_CXX_FLAGS="${ARROW_GANDIVA_PC_CXX_FLAGS:-}" \
+    -DARROW_GANDIVA="${ARROW_GANDIVA:-OFF}" \
+    -DARROW_GCS="${ARROW_GCS:-OFF}" \
+    -DARROW_HDFS="${ARROW_HDFS:-ON}" \
+    -DARROW_INSTALL_NAME_RPATH="${ARROW_INSTALL_NAME_RPATH:-ON}" \
+    -DARROW_JEMALLOC="${ARROW_JEMALLOC:-OFF}" \
+    -DARROW_JSON="${ARROW_JSON:-ON}" \
+    -DARROW_LARGE_MEMORY_TESTS="${ARROW_LARGE_MEMORY_TESTS:-OFF}" \
+    -DARROW_MIMALLOC="${ARROW_MIMALLOC:-ON}" \
+    -DARROW_ORC="${ARROW_ORC:-OFF}" \
+    -DARROW_PARQUET="${ARROW_PARQUET:-OFF}" \
+    -DARROW_RUNTIME_SIMD_LEVEL="${ARROW_RUNTIME_SIMD_LEVEL:-MAX}" \
+    -DARROW_S3="${ARROW_S3:-OFF}" \
+    -DARROW_S3_MODULE="${ARROW_S3_MODULE:-OFF}" \
+    -DARROW_SIMD_LEVEL="${ARROW_SIMD_LEVEL:-DEFAULT}" \
+    -DARROW_SUBSTRAIT="${ARROW_SUBSTRAIT:-OFF}" \
+    -DARROW_TEST_LINKAGE="${ARROW_TEST_LINKAGE:-shared}" \
+    -DARROW_TEST_MEMCHECK="${ARROW_TEST_MEMCHECK:-OFF}" \
+    -DARROW_USE_ASAN="${ARROW_USE_ASAN:-OFF}" \
+    -DARROW_USE_CCACHE="${ARROW_USE_CCACHE:-ON}" \
+    -DARROW_USE_GLOG="${ARROW_USE_GLOG:-OFF}" \
+    -DARROW_USE_LLD="${ARROW_USE_LLD:-OFF}" \
+    -DARROW_USE_MOLD="${ARROW_USE_MOLD:-OFF}" \
+    -DARROW_USE_STATIC_CRT="${ARROW_USE_STATIC_CRT:-OFF}" \
+    -DARROW_USE_TSAN="${ARROW_USE_TSAN:-OFF}" \
+    -DARROW_USE_UBSAN="${ARROW_USE_UBSAN:-OFF}" \
+    -DARROW_VERBOSE_THIRDPARTY_BUILD="${ARROW_VERBOSE_THIRDPARTY_BUILD:-OFF}" \
+    -DARROW_WITH_BROTLI="${ARROW_WITH_BROTLI:-OFF}" \
+    -DARROW_WITH_BZ2="${ARROW_WITH_BZ2:-OFF}" \
+    -DARROW_WITH_LZ4="${ARROW_WITH_LZ4:-OFF}" \
+    -DARROW_WITH_OPENTELEMETRY="${ARROW_WITH_OPENTELEMETRY:-OFF}" \
+    -DARROW_WITH_MUSL="${ARROW_WITH_MUSL:-OFF}" \
+    -DARROW_WITH_SNAPPY="${ARROW_WITH_SNAPPY:-OFF}" \
+    -DARROW_WITH_UTF8PROC="${ARROW_WITH_UTF8PROC:-ON}" \
+    -DARROW_WITH_ZLIB="${ARROW_WITH_ZLIB:-OFF}" \
+    -DARROW_WITH_ZSTD="${ARROW_WITH_ZSTD:-OFF}" \
+    -DAWSSDK_SOURCE="${AWSSDK_SOURCE:-}" \
+    -DAzure_SOURCE="${Azure_SOURCE:-}" \
+    -Dbenchmark_SOURCE="${benchmark_SOURCE:-}" \
+    -DBOOST_SOURCE="${BOOST_SOURCE:-}" \
+    -DBrotli_SOURCE="${Brotli_SOURCE:-}" \
+    -DBUILD_WARNING_LEVEL="${BUILD_WARNING_LEVEL:-CHECKIN}" \
+    -Dc-ares_SOURCE="${cares_SOURCE:-}" \
+    -DCMAKE_BUILD_TYPE="${ARROW_BUILD_TYPE:-debug}" \
+    -DCMAKE_VERBOSE_MAKEFILE="${CMAKE_VERBOSE_MAKEFILE:-OFF}" \
     -DCMAKE_C_FLAGS="${CFLAGS:-}" \
     -DCMAKE_CXX_FLAGS="${CXXFLAGS:-}" \
     -DCMAKE_CXX_STANDARD="${CMAKE_CXX_STANDARD:-20}" \
-    -DCMAKE_INSTALL_LIBDIR=${CMAKE_INSTALL_LIBDIR:-lib} \
-    -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX:-${ARROW_HOME}} \
-    -DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=${CMAKE_MSVC_DEBUG_INFORMATION_FORMAT:-} \
-    -DCMAKE_UNITY_BUILD=${CMAKE_UNITY_BUILD:-OFF} \
-    -DCUDAToolkit_ROOT=${CUDAToolkit_ROOT:-} \
-    -Dgflags_SOURCE=${gflags_SOURCE:-} \
-    -Dgoogle_cloud_cpp_storage_SOURCE=${google_cloud_cpp_storage_SOURCE:-} \
-    -DgRPC_SOURCE=${gRPC_SOURCE:-} \
-    -DGTest_SOURCE=${GTest_SOURCE:-} \
-    -Dlz4_SOURCE=${lz4_SOURCE:-} \
-    -Dnlohmann_json_SOURCE=${nlohmann_json_SOURCE:-} \
-    -Dopentelemetry-cpp_SOURCE=${opentelemetry_cpp_SOURCE:-} \
-    -DORC_SOURCE=${ORC_SOURCE:-} \
-    -DPARQUET_BUILD_EXAMPLES=${PARQUET_BUILD_EXAMPLES:-OFF} \
-    -DPARQUET_BUILD_EXECUTABLES=${PARQUET_BUILD_EXECUTABLES:-OFF} \
-    -DPARQUET_REQUIRE_ENCRYPTION=${PARQUET_REQUIRE_ENCRYPTION:-ON} \
-    -DProtobuf_SOURCE=${Protobuf_SOURCE:-} \
-    -DRapidJSON_SOURCE=${RapidJSON_SOURCE:-} \
-    -Dre2_SOURCE=${re2_SOURCE:-} \
-    -DSnappy_SOURCE=${Snappy_SOURCE:-} \
-    -DThrift_SOURCE=${Thrift_SOURCE:-} \
-    -Dutf8proc_SOURCE=${utf8proc_SOURCE:-} \
-    -Dzstd_SOURCE=${zstd_SOURCE:-} \
-    -Dxsimd_SOURCE=${xsimd_SOURCE:-} \
+    -DCMAKE_INSTALL_LIBDIR="${CMAKE_INSTALL_LIBDIR:-lib}" \
+    -DCMAKE_INSTALL_PREFIX="${CMAKE_INSTALL_PREFIX:-${ARROW_HOME}}" \
+    -DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT="${CMAKE_MSVC_DEBUG_INFORMATION_FORMAT:-}" \
+    -DCMAKE_UNITY_BUILD="${CMAKE_UNITY_BUILD:-OFF}" \
+    -DCUDAToolkit_ROOT="${CUDAToolkit_ROOT:-}" \
+    -Dgflags_SOURCE="${gflags_SOURCE:-}" \
+    -Dgoogle_cloud_cpp_storage_SOURCE="${google_cloud_cpp_storage_SOURCE:-}" \
+    -DgRPC_SOURCE="${gRPC_SOURCE:-}" \
+    -DGTest_SOURCE="${GTest_SOURCE:-}" \
+    -Dlz4_SOURCE="${lz4_SOURCE:-}" \
+    -Dnlohmann_json_SOURCE="${nlohmann_json_SOURCE:-}" \
+    -Dopentelemetry-cpp_SOURCE="${opentelemetry_cpp_SOURCE:-}" \
+    -DORC_SOURCE="${ORC_SOURCE:-}" \
+    -DPARQUET_BUILD_EXAMPLES="${PARQUET_BUILD_EXAMPLES:-OFF}" \
+    -DPARQUET_BUILD_EXECUTABLES="${PARQUET_BUILD_EXECUTABLES:-OFF}" \
+    -DPARQUET_REQUIRE_ENCRYPTION="${PARQUET_REQUIRE_ENCRYPTION:-ON}" \
+    -DProtobuf_SOURCE="${Protobuf_SOURCE:-}" \
+    -DRapidJSON_SOURCE="${RapidJSON_SOURCE:-}" \
+    -Dre2_SOURCE="${re2_SOURCE:-}" \
+    -DSnappy_SOURCE="${Snappy_SOURCE:-}" \
+    -DThrift_SOURCE="${Thrift_SOURCE:-}" \
+    -Dutf8proc_SOURCE="${utf8proc_SOURCE:-}" \
+    -Dzstd_SOURCE="${zstd_SOURCE:-}" \
+    -Dxsimd_SOURCE="${xsimd_SOURCE:-}" \
     -G "${CMAKE_GENERATOR:-Ninja}" \
-    ${ARROW_CMAKE_ARGS} \
-    ${source_dir}
+    "${ARROW_CMAKE_ARGS_ARRAY[@]}" \
+    "${source_dir}"
 fi
 
-: ${ARROW_BUILD_PARALLEL:=$[${n_jobs} + 1]}
+: "${ARROW_BUILD_PARALLEL:=$((n_jobs + 1))}"
 if [ "${ARROW_USE_MESON:-OFF}" = "ON" ]; then
-  time meson compile -j ${ARROW_BUILD_PARALLEL}
+  time meson compile -j "${ARROW_BUILD_PARALLEL}"
   meson install
   # Remove all added files in cpp/subprojects/ because they may have
   # unreadable permissions on Docker host.
@@ -302,7 +311,7 @@ if [ "${ARROW_USE_MESON:-OFF}" = "ON" ]; then
   meson subprojects purge --confirm --include-cache
   popd
 else
-  : ${CMAKE_BUILD_PARALLEL_LEVEL:=${ARROW_BUILD_PARALLEL}}
+  : "${CMAKE_BUILD_PARALLEL_LEVEL:=${ARROW_BUILD_PARALLEL}}"
   export CMAKE_BUILD_PARALLEL_LEVEL
   time cmake --build . --target install
 fi
@@ -326,7 +335,7 @@ if [ -x "$(command -v ldconfig)" ]; then
       SUDO=
     fi
   fi
-  ${SUDO} ldconfig ${ARROW_HOME}/${CMAKE_INSTALL_LIBDIR:-lib}
+  ${SUDO} ldconfig "${ARROW_HOME}"/"${CMAKE_INSTALL_LIBDIR:-lib}"
 fi
 
 if [ "${ARROW_USE_CCACHE}" == "ON" ]; then
@@ -340,7 +349,7 @@ if command -v sccache &> /dev/null; then
 fi
 
 if [ "${BUILD_DOCS_CPP}" == "ON" ]; then
-  pushd ${source_dir}/apidoc
+  pushd "${source_dir}/apidoc"
   OUTPUT_DIRECTORY=${build_dir}/apidoc doxygen
   popd
 fi


### PR DESCRIPTION
### Rationale for this change

This is the sub issue #44748.

* SC1090: Can't follow non-constant source. Use a directive to specify location
* SC1091: Not following: (error message here)
* SC2007: Use `$((..))` instead of deprecated `$[..]`
* SC2086: Double quote to prevent globbing and word splitting.
* SC2155: Declare and assign separately to avoid masking return values.
* SC2223: This default assignment may cause DoS due to globbing. Quote it.
* SC2236: Use `-n` instead of `! -z`.
* SC2242: Can only exit with status 0-255. Other data should be written to stdout/stderr.

```
In ci/scripts/cpp_build.sh line 25:
: ${ARROW_OFFLINE:=OFF}
  ^-------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/cpp_build.sh line 26:
: ${ARROW_USE_CCACHE:=OFF}
  ^----------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/cpp_build.sh line 27:
: ${BUILD_DOCS_CPP:=OFF}
  ^--------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/cpp_build.sh line 30:
  git config --global --add safe.directory ${1}
                                           ^--^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
  git config --global --add safe.directory "${1}"


In ci/scripts/cpp_build.sh line 34:
if [ ! -z "${CONDA_PREFIX}" ] && [ "${ARROW_EMSCRIPTEN:-OFF}" = "OFF" ]; then
     ^-- SC2236 (style): Use -n instead of ! -z.


In ci/scripts/cpp_build.sh line 45:
  export ARROW_GANDIVA_PC_CXX_FLAGS=$(echo | ${CXX} -E -Wp,-v -xc++ - 2>&1 | grep '^ ' | awk '{print "-isystem;" substr($1, 1)}' | tr '\n' ';')
         ^------------------------^ SC2155 (warning): Declare and assign separately to avoid masking return values.


In ci/scripts/cpp_build.sh line 47:
  export ARROW_GANDIVA_PC_CXX_FLAGS="-isysroot;$(xcrun --show-sdk-path)"
         ^------------------------^ SC2155 (warning): Declare and assign separately to avoid masking return values.


In ci/scripts/cpp_build.sh line 54:
        : ${ARROW_C_FLAGS_DEBUG:=-g1}
          ^-------------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/cpp_build.sh line 55:
        : ${ARROW_CXX_FLAGS_DEBUG:=-g1}
          ^---------------------------^ SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/cpp_build.sh line 100:
mkdir -p ${build_dir}
         ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
mkdir -p "${build_dir}"


In ci/scripts/cpp_build.sh line 101:
pushd ${build_dir}
      ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
pushd "${build_dir}"


In ci/scripts/cpp_build.sh line 104:
  ${source_dir}/thirdparty/download_dependencies.sh ${PWD}/thirdparty > \
  ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                                    ^----^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
  "${source_dir}"/thirdparty/download_dependencies.sh "${PWD}"/thirdparty > \


In ci/scripts/cpp_build.sh line 106:
  . enable_offline_build.sh
    ^---------------------^ SC1091 (info): Not following: enable_offline_build.sh: openBinaryFile: does not exist (No such file or directory)


In ci/scripts/cpp_build.sh line 144:
    --prefix=${MESON_PREFIX:-${ARROW_HOME}} \
             ^----------------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    --prefix="${MESON_PREFIX:-${ARROW_HOME}}" \


In ci/scripts/cpp_build.sh line 145:
    --buildtype=${ARROW_BUILD_TYPE:-debug} \
                ^------------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    --buildtype="${ARROW_BUILD_TYPE:-debug}" \


In ci/scripts/cpp_build.sh line 151:
    ${source_dir}
    ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    "${source_dir}"


In ci/scripts/cpp_build.sh line 158:
    exit -1
         ^-- SC2242 (error): Can only exit with status 0-255. Other data should be written to stdout/stderr.


In ci/scripts/cpp_build.sh line 161:
  source ~/emsdk/emsdk_env.sh
         ^------------------^ SC1090 (warning): ShellCheck can't follow non-constant source. Use a directive to specify location.


In ci/scripts/cpp_build.sh line 162:
  export CMAKE_INSTALL_PREFIX=$(em-config CACHE)/sysroot
         ^------------------^ SC2155 (warning): Declare and assign separately to avoid masking return values.


In ci/scripts/cpp_build.sh line 167:
    --preset=ninja-${ARROW_BUILD_TYPE:-debug}-emscripten \
                   ^------------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    --preset=ninja-"${ARROW_BUILD_TYPE:-debug}"-emscripten \


In ci/scripts/cpp_build.sh line 168:
    -DCMAKE_VERBOSE_MAKEFILE=${CMAKE_VERBOSE_MAKEFILE:-OFF} \
                             ^----------------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DCMAKE_VERBOSE_MAKEFILE="${CMAKE_VERBOSE_MAKEFILE:-OFF}" \


In ci/scripts/cpp_build.sh line 172:
    -DCMAKE_INSTALL_LIBDIR=${CMAKE_INSTALL_LIBDIR:-lib} \
                           ^--------------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DCMAKE_INSTALL_LIBDIR="${CMAKE_INSTALL_LIBDIR:-lib}" \


In ci/scripts/cpp_build.sh line 173:
    -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX:-${ARROW_HOME}} \
                           ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DCMAKE_INSTALL_PREFIX="${CMAKE_INSTALL_PREFIX:-${ARROW_HOME}}" \


In ci/scripts/cpp_build.sh line 174:
    -DCMAKE_UNITY_BUILD=${CMAKE_UNITY_BUILD:-OFF} \
                        ^-----------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DCMAKE_UNITY_BUILD="${CMAKE_UNITY_BUILD:-OFF}" \


In ci/scripts/cpp_build.sh line 175:
    ${ARROW_CMAKE_ARGS} \
    ^-----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    "${ARROW_CMAKE_ARGS}" \


In ci/scripts/cpp_build.sh line 176:
    ${source_dir}
    ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    "${source_dir}"


In ci/scripts/cpp_build.sh line 180:
    ${ARROW_CMAKE_ARGS} \
    ^-----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    "${ARROW_CMAKE_ARGS}" \


In ci/scripts/cpp_build.sh line 181:
    ${source_dir}
    ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    "${source_dir}"


In ci/scripts/cpp_build.sh line 184:
    -Dabsl_SOURCE=${absl_SOURCE:-} \
                  ^--------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -Dabsl_SOURCE="${absl_SOURCE:-}" \


In ci/scripts/cpp_build.sh line 185:
    -DARROW_ACERO=${ARROW_ACERO:-OFF} \
                  ^-----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_ACERO="${ARROW_ACERO:-OFF}" \


In ci/scripts/cpp_build.sh line 186:
    -DARROW_AZURE=${ARROW_AZURE:-OFF} \
                  ^-----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_AZURE="${ARROW_AZURE:-OFF}" \


In ci/scripts/cpp_build.sh line 187:
    -DARROW_BOOST_USE_SHARED=${ARROW_BOOST_USE_SHARED:-ON} \
                             ^---------------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_BOOST_USE_SHARED="${ARROW_BOOST_USE_SHARED:-ON}" \


In ci/scripts/cpp_build.sh line 188:
    -DARROW_BUILD_BENCHMARKS_REFERENCE=${ARROW_BUILD_BENCHMARKS:-OFF} \
                                       ^----------------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_BUILD_BENCHMARKS_REFERENCE="${ARROW_BUILD_BENCHMARKS:-OFF}" \


In ci/scripts/cpp_build.sh line 189:
    -DARROW_BUILD_BENCHMARKS=${ARROW_BUILD_BENCHMARKS:-OFF} \
                             ^----------------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_BUILD_BENCHMARKS="${ARROW_BUILD_BENCHMARKS:-OFF}" \


In ci/scripts/cpp_build.sh line 190:
    -DARROW_BUILD_EXAMPLES=${ARROW_BUILD_EXAMPLES:-OFF} \
                           ^--------------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_BUILD_EXAMPLES="${ARROW_BUILD_EXAMPLES:-OFF}" \


In ci/scripts/cpp_build.sh line 191:
    -DARROW_BUILD_INTEGRATION=${ARROW_BUILD_INTEGRATION:-OFF} \
                              ^-----------------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_BUILD_INTEGRATION="${ARROW_BUILD_INTEGRATION:-OFF}" \


In ci/scripts/cpp_build.sh line 192:
    -DARROW_BUILD_SHARED=${ARROW_BUILD_SHARED:-ON} \
                         ^-----------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_BUILD_SHARED="${ARROW_BUILD_SHARED:-ON}" \


In ci/scripts/cpp_build.sh line 193:
    -DARROW_BUILD_STATIC=${ARROW_BUILD_STATIC:-ON} \
                         ^-----------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_BUILD_STATIC="${ARROW_BUILD_STATIC:-ON}" \


In ci/scripts/cpp_build.sh line 194:
    -DARROW_BUILD_TESTS=${ARROW_BUILD_TESTS:-OFF} \
                        ^-----------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_BUILD_TESTS="${ARROW_BUILD_TESTS:-OFF}" \


In ci/scripts/cpp_build.sh line 195:
    -DARROW_BUILD_UTILITIES=${ARROW_BUILD_UTILITIES:-ON} \
                            ^--------------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_BUILD_UTILITIES="${ARROW_BUILD_UTILITIES:-ON}" \


In ci/scripts/cpp_build.sh line 196:
    -DARROW_COMPUTE=${ARROW_COMPUTE:-ON} \
                    ^------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_COMPUTE="${ARROW_COMPUTE:-ON}" \


In ci/scripts/cpp_build.sh line 197:
    -DARROW_CSV=${ARROW_CSV:-ON} \
                ^--------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_CSV="${ARROW_CSV:-ON}" \


In ci/scripts/cpp_build.sh line 198:
    -DARROW_CUDA=${ARROW_CUDA:-OFF} \
                 ^----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_CUDA="${ARROW_CUDA:-OFF}" \


In ci/scripts/cpp_build.sh line 199:
    -DARROW_CXXFLAGS=${ARROW_CXXFLAGS:-} \
                     ^-----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_CXXFLAGS="${ARROW_CXXFLAGS:-}" \


In ci/scripts/cpp_build.sh line 206:
    -DARROW_DATASET=${ARROW_DATASET:-OFF} \
                    ^-------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_DATASET="${ARROW_DATASET:-OFF}" \


In ci/scripts/cpp_build.sh line 207:
    -DARROW_DEPENDENCY_SOURCE=${ARROW_DEPENDENCY_SOURCE:-AUTO} \
                              ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_DEPENDENCY_SOURCE="${ARROW_DEPENDENCY_SOURCE:-AUTO}" \


In ci/scripts/cpp_build.sh line 208:
    -DARROW_DEPENDENCY_USE_SHARED=${ARROW_DEPENDENCY_USE_SHARED:-ON} \
                                  ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_DEPENDENCY_USE_SHARED="${ARROW_DEPENDENCY_USE_SHARED:-ON}" \


In ci/scripts/cpp_build.sh line 209:
    -DARROW_ENABLE_THREADING=${ARROW_ENABLE_THREADING:-ON} \
                             ^---------------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_ENABLE_THREADING="${ARROW_ENABLE_THREADING:-ON}" \


In ci/scripts/cpp_build.sh line 210:
    -DARROW_ENABLE_TIMING_TESTS=${ARROW_ENABLE_TIMING_TESTS:-ON} \
                                ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_ENABLE_TIMING_TESTS="${ARROW_ENABLE_TIMING_TESTS:-ON}" \


In ci/scripts/cpp_build.sh line 211:
    -DARROW_EXTRA_ERROR_CONTEXT=${ARROW_EXTRA_ERROR_CONTEXT:-OFF} \
                                ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_EXTRA_ERROR_CONTEXT="${ARROW_EXTRA_ERROR_CONTEXT:-OFF}" \


In ci/scripts/cpp_build.sh line 212:
    -DARROW_FILESYSTEM=${ARROW_FILESYSTEM:-ON} \
                       ^---------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_FILESYSTEM="${ARROW_FILESYSTEM:-ON}" \


In ci/scripts/cpp_build.sh line 213:
    -DARROW_FLIGHT=${ARROW_FLIGHT:-OFF} \
                   ^------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_FLIGHT="${ARROW_FLIGHT:-OFF}" \


In ci/scripts/cpp_build.sh line 214:
    -DARROW_FLIGHT_SQL=${ARROW_FLIGHT_SQL:-OFF} \
                       ^----------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_FLIGHT_SQL="${ARROW_FLIGHT_SQL:-OFF}" \


In ci/scripts/cpp_build.sh line 215:
    -DARROW_FLIGHT_SQL_ODBC=${ARROW_FLIGHT_SQL_ODBC:-OFF} \
                            ^---------------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_FLIGHT_SQL_ODBC="${ARROW_FLIGHT_SQL_ODBC:-OFF}" \


In ci/scripts/cpp_build.sh line 216:
    -DARROW_FUZZING=${ARROW_FUZZING:-OFF} \
                    ^-------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_FUZZING="${ARROW_FUZZING:-OFF}" \


In ci/scripts/cpp_build.sh line 217:
    -DARROW_GANDIVA_PC_CXX_FLAGS=${ARROW_GANDIVA_PC_CXX_FLAGS:-} \
                                 ^-----------------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_GANDIVA_PC_CXX_FLAGS="${ARROW_GANDIVA_PC_CXX_FLAGS:-}" \


In ci/scripts/cpp_build.sh line 218:
    -DARROW_GANDIVA=${ARROW_GANDIVA:-OFF} \
                    ^-------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_GANDIVA="${ARROW_GANDIVA:-OFF}" \


In ci/scripts/cpp_build.sh line 219:
    -DARROW_GCS=${ARROW_GCS:-OFF} \
                ^---------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_GCS="${ARROW_GCS:-OFF}" \


In ci/scripts/cpp_build.sh line 220:
    -DARROW_HDFS=${ARROW_HDFS:-ON} \
                 ^---------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_HDFS="${ARROW_HDFS:-ON}" \


In ci/scripts/cpp_build.sh line 221:
    -DARROW_INSTALL_NAME_RPATH=${ARROW_INSTALL_NAME_RPATH:-ON} \
                               ^-----------------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_INSTALL_NAME_RPATH="${ARROW_INSTALL_NAME_RPATH:-ON}" \


In ci/scripts/cpp_build.sh line 222:
    -DARROW_JEMALLOC=${ARROW_JEMALLOC:-OFF} \
                     ^--------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_JEMALLOC="${ARROW_JEMALLOC:-OFF}" \


In ci/scripts/cpp_build.sh line 223:
    -DARROW_JSON=${ARROW_JSON:-ON} \
                 ^---------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_JSON="${ARROW_JSON:-ON}" \


In ci/scripts/cpp_build.sh line 224:
    -DARROW_LARGE_MEMORY_TESTS=${ARROW_LARGE_MEMORY_TESTS:-OFF} \
                               ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_LARGE_MEMORY_TESTS="${ARROW_LARGE_MEMORY_TESTS:-OFF}" \


In ci/scripts/cpp_build.sh line 225:
    -DARROW_MIMALLOC=${ARROW_MIMALLOC:-ON} \
                     ^-------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_MIMALLOC="${ARROW_MIMALLOC:-ON}" \


In ci/scripts/cpp_build.sh line 226:
    -DARROW_ORC=${ARROW_ORC:-OFF} \
                ^---------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_ORC="${ARROW_ORC:-OFF}" \


In ci/scripts/cpp_build.sh line 227:
    -DARROW_PARQUET=${ARROW_PARQUET:-OFF} \
                    ^-------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_PARQUET="${ARROW_PARQUET:-OFF}" \


In ci/scripts/cpp_build.sh line 228:
    -DARROW_RUNTIME_SIMD_LEVEL=${ARROW_RUNTIME_SIMD_LEVEL:-MAX} \
                               ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_RUNTIME_SIMD_LEVEL="${ARROW_RUNTIME_SIMD_LEVEL:-MAX}" \


In ci/scripts/cpp_build.sh line 229:
    -DARROW_S3=${ARROW_S3:-OFF} \
               ^--------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_S3="${ARROW_S3:-OFF}" \


In ci/scripts/cpp_build.sh line 230:
    -DARROW_SIMD_LEVEL=${ARROW_SIMD_LEVEL:-DEFAULT} \
                       ^--------------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_SIMD_LEVEL="${ARROW_SIMD_LEVEL:-DEFAULT}" \


In ci/scripts/cpp_build.sh line 231:
    -DARROW_SUBSTRAIT=${ARROW_SUBSTRAIT:-OFF} \
                      ^---------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_SUBSTRAIT="${ARROW_SUBSTRAIT:-OFF}" \


In ci/scripts/cpp_build.sh line 232:
    -DARROW_TEST_LINKAGE=${ARROW_TEST_LINKAGE:-shared} \
                         ^---------------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_TEST_LINKAGE="${ARROW_TEST_LINKAGE:-shared}" \


In ci/scripts/cpp_build.sh line 233:
    -DARROW_TEST_MEMCHECK=${ARROW_TEST_MEMCHECK:-OFF} \
                          ^-------------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_TEST_MEMCHECK="${ARROW_TEST_MEMCHECK:-OFF}" \


In ci/scripts/cpp_build.sh line 234:
    -DARROW_USE_ASAN=${ARROW_USE_ASAN:-OFF} \
                     ^--------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_USE_ASAN="${ARROW_USE_ASAN:-OFF}" \


In ci/scripts/cpp_build.sh line 235:
    -DARROW_USE_CCACHE=${ARROW_USE_CCACHE:-ON} \
                       ^---------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_USE_CCACHE="${ARROW_USE_CCACHE:-ON}" \


In ci/scripts/cpp_build.sh line 236:
    -DARROW_USE_GLOG=${ARROW_USE_GLOG:-OFF} \
                     ^--------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_USE_GLOG="${ARROW_USE_GLOG:-OFF}" \


In ci/scripts/cpp_build.sh line 237:
    -DARROW_USE_LLD=${ARROW_USE_LLD:-OFF} \
                    ^-------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_USE_LLD="${ARROW_USE_LLD:-OFF}" \


In ci/scripts/cpp_build.sh line 238:
    -DARROW_USE_MOLD=${ARROW_USE_MOLD:-OFF} \
                     ^--------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_USE_MOLD="${ARROW_USE_MOLD:-OFF}" \


In ci/scripts/cpp_build.sh line 239:
    -DARROW_USE_STATIC_CRT=${ARROW_USE_STATIC_CRT:-OFF} \
                           ^--------------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_USE_STATIC_CRT="${ARROW_USE_STATIC_CRT:-OFF}" \


In ci/scripts/cpp_build.sh line 240:
    -DARROW_USE_TSAN=${ARROW_USE_TSAN:-OFF} \
                     ^--------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_USE_TSAN="${ARROW_USE_TSAN:-OFF}" \


In ci/scripts/cpp_build.sh line 241:
    -DARROW_USE_UBSAN=${ARROW_USE_UBSAN:-OFF} \
                      ^---------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_USE_UBSAN="${ARROW_USE_UBSAN:-OFF}" \


In ci/scripts/cpp_build.sh line 242:
    -DARROW_VERBOSE_THIRDPARTY_BUILD=${ARROW_VERBOSE_THIRDPARTY_BUILD:-OFF} \
                                     ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_VERBOSE_THIRDPARTY_BUILD="${ARROW_VERBOSE_THIRDPARTY_BUILD:-OFF}" \


In ci/scripts/cpp_build.sh line 243:
    -DARROW_WITH_BROTLI=${ARROW_WITH_BROTLI:-OFF} \
                        ^-----------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_WITH_BROTLI="${ARROW_WITH_BROTLI:-OFF}" \


In ci/scripts/cpp_build.sh line 244:
    -DARROW_WITH_BZ2=${ARROW_WITH_BZ2:-OFF} \
                     ^--------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_WITH_BZ2="${ARROW_WITH_BZ2:-OFF}" \


In ci/scripts/cpp_build.sh line 245:
    -DARROW_WITH_LZ4=${ARROW_WITH_LZ4:-OFF} \
                     ^--------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_WITH_LZ4="${ARROW_WITH_LZ4:-OFF}" \


In ci/scripts/cpp_build.sh line 246:
    -DARROW_WITH_OPENTELEMETRY=${ARROW_WITH_OPENTELEMETRY:-OFF} \
                               ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_WITH_OPENTELEMETRY="${ARROW_WITH_OPENTELEMETRY:-OFF}" \


In ci/scripts/cpp_build.sh line 247:
    -DARROW_WITH_MUSL=${ARROW_WITH_MUSL:-OFF} \
                      ^---------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_WITH_MUSL="${ARROW_WITH_MUSL:-OFF}" \


In ci/scripts/cpp_build.sh line 248:
    -DARROW_WITH_SNAPPY=${ARROW_WITH_SNAPPY:-OFF} \
                        ^-----------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_WITH_SNAPPY="${ARROW_WITH_SNAPPY:-OFF}" \


In ci/scripts/cpp_build.sh line 249:
    -DARROW_WITH_UTF8PROC=${ARROW_WITH_UTF8PROC:-ON} \
                          ^------------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_WITH_UTF8PROC="${ARROW_WITH_UTF8PROC:-ON}" \


In ci/scripts/cpp_build.sh line 250:
    -DARROW_WITH_ZLIB=${ARROW_WITH_ZLIB:-OFF} \
                      ^---------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_WITH_ZLIB="${ARROW_WITH_ZLIB:-OFF}" \


In ci/scripts/cpp_build.sh line 251:
    -DARROW_WITH_ZSTD=${ARROW_WITH_ZSTD:-OFF} \
                      ^---------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DARROW_WITH_ZSTD="${ARROW_WITH_ZSTD:-OFF}" \


In ci/scripts/cpp_build.sh line 252:
    -DAWSSDK_SOURCE=${AWSSDK_SOURCE:-} \
                    ^----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DAWSSDK_SOURCE="${AWSSDK_SOURCE:-}" \


In ci/scripts/cpp_build.sh line 253:
    -DAzure_SOURCE=${Azure_SOURCE:-} \
                   ^---------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DAzure_SOURCE="${Azure_SOURCE:-}" \


In ci/scripts/cpp_build.sh line 254:
    -Dbenchmark_SOURCE=${benchmark_SOURCE:-} \
                       ^-------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -Dbenchmark_SOURCE="${benchmark_SOURCE:-}" \


In ci/scripts/cpp_build.sh line 255:
    -DBOOST_SOURCE=${BOOST_SOURCE:-} \
                   ^---------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DBOOST_SOURCE="${BOOST_SOURCE:-}" \


In ci/scripts/cpp_build.sh line 256:
    -DBrotli_SOURCE=${Brotli_SOURCE:-} \
                    ^----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DBrotli_SOURCE="${Brotli_SOURCE:-}" \


In ci/scripts/cpp_build.sh line 257:
    -DBUILD_WARNING_LEVEL=${BUILD_WARNING_LEVEL:-CHECKIN} \
                          ^-----------------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DBUILD_WARNING_LEVEL="${BUILD_WARNING_LEVEL:-CHECKIN}" \


In ci/scripts/cpp_build.sh line 258:
    -Dc-ares_SOURCE=${cares_SOURCE:-} \
                    ^---------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -Dc-ares_SOURCE="${cares_SOURCE:-}" \


In ci/scripts/cpp_build.sh line 259:
    -DCMAKE_BUILD_TYPE=${ARROW_BUILD_TYPE:-debug} \
                       ^------------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DCMAKE_BUILD_TYPE="${ARROW_BUILD_TYPE:-debug}" \


In ci/scripts/cpp_build.sh line 260:
    -DCMAKE_VERBOSE_MAKEFILE=${CMAKE_VERBOSE_MAKEFILE:-OFF} \
                             ^----------------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DCMAKE_VERBOSE_MAKEFILE="${CMAKE_VERBOSE_MAKEFILE:-OFF}" \


In ci/scripts/cpp_build.sh line 264:
    -DCMAKE_INSTALL_LIBDIR=${CMAKE_INSTALL_LIBDIR:-lib} \
                           ^--------------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DCMAKE_INSTALL_LIBDIR="${CMAKE_INSTALL_LIBDIR:-lib}" \


In ci/scripts/cpp_build.sh line 265:
    -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX:-${ARROW_HOME}} \
                           ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DCMAKE_INSTALL_PREFIX="${CMAKE_INSTALL_PREFIX:-${ARROW_HOME}}" \


In ci/scripts/cpp_build.sh line 266:
    -DCMAKE_UNITY_BUILD=${CMAKE_UNITY_BUILD:-OFF} \
                        ^-----------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DCMAKE_UNITY_BUILD="${CMAKE_UNITY_BUILD:-OFF}" \


In ci/scripts/cpp_build.sh line 267:
    -DCUDAToolkit_ROOT=${CUDAToolkit_ROOT:-} \
                       ^-------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DCUDAToolkit_ROOT="${CUDAToolkit_ROOT:-}" \


In ci/scripts/cpp_build.sh line 268:
    -Dgflags_SOURCE=${gflags_SOURCE:-} \
                    ^----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -Dgflags_SOURCE="${gflags_SOURCE:-}" \


In ci/scripts/cpp_build.sh line 269:
    -Dgoogle_cloud_cpp_storage_SOURCE=${google_cloud_cpp_storage_SOURCE:-} \
                                      ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -Dgoogle_cloud_cpp_storage_SOURCE="${google_cloud_cpp_storage_SOURCE:-}" \


In ci/scripts/cpp_build.sh line 270:
    -DgRPC_SOURCE=${gRPC_SOURCE:-} \
                  ^--------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DgRPC_SOURCE="${gRPC_SOURCE:-}" \


In ci/scripts/cpp_build.sh line 271:
    -DGTest_SOURCE=${GTest_SOURCE:-} \
                   ^---------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DGTest_SOURCE="${GTest_SOURCE:-}" \


In ci/scripts/cpp_build.sh line 272:
    -Dlz4_SOURCE=${lz4_SOURCE:-} \
                 ^-------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -Dlz4_SOURCE="${lz4_SOURCE:-}" \


In ci/scripts/cpp_build.sh line 273:
    -Dopentelemetry-cpp_SOURCE=${opentelemetry_cpp_SOURCE:-} \
                               ^---------------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -Dopentelemetry-cpp_SOURCE="${opentelemetry_cpp_SOURCE:-}" \


In ci/scripts/cpp_build.sh line 274:
    -DORC_SOURCE=${ORC_SOURCE:-} \
                 ^-------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DORC_SOURCE="${ORC_SOURCE:-}" \


In ci/scripts/cpp_build.sh line 275:
    -DPARQUET_BUILD_EXAMPLES=${PARQUET_BUILD_EXAMPLES:-OFF} \
                             ^----------------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DPARQUET_BUILD_EXAMPLES="${PARQUET_BUILD_EXAMPLES:-OFF}" \


In ci/scripts/cpp_build.sh line 276:
    -DPARQUET_BUILD_EXECUTABLES=${PARQUET_BUILD_EXECUTABLES:-OFF} \
                                ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DPARQUET_BUILD_EXECUTABLES="${PARQUET_BUILD_EXECUTABLES:-OFF}" \


In ci/scripts/cpp_build.sh line 277:
    -DPARQUET_REQUIRE_ENCRYPTION=${PARQUET_REQUIRE_ENCRYPTION:-ON} \
                                 ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DPARQUET_REQUIRE_ENCRYPTION="${PARQUET_REQUIRE_ENCRYPTION:-ON}" \


In ci/scripts/cpp_build.sh line 278:
    -DProtobuf_SOURCE=${Protobuf_SOURCE:-} \
                      ^------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DProtobuf_SOURCE="${Protobuf_SOURCE:-}" \


In ci/scripts/cpp_build.sh line 279:
    -DRapidJSON_SOURCE=${RapidJSON_SOURCE:-} \
                       ^-------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DRapidJSON_SOURCE="${RapidJSON_SOURCE:-}" \


In ci/scripts/cpp_build.sh line 280:
    -Dre2_SOURCE=${re2_SOURCE:-} \
                 ^-------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -Dre2_SOURCE="${re2_SOURCE:-}" \


In ci/scripts/cpp_build.sh line 281:
    -DSnappy_SOURCE=${Snappy_SOURCE:-} \
                    ^----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DSnappy_SOURCE="${Snappy_SOURCE:-}" \


In ci/scripts/cpp_build.sh line 282:
    -DThrift_SOURCE=${Thrift_SOURCE:-} \
                    ^----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -DThrift_SOURCE="${Thrift_SOURCE:-}" \


In ci/scripts/cpp_build.sh line 283:
    -Dutf8proc_SOURCE=${utf8proc_SOURCE:-} \
                      ^------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -Dutf8proc_SOURCE="${utf8proc_SOURCE:-}" \


In ci/scripts/cpp_build.sh line 284:
    -Dzstd_SOURCE=${zstd_SOURCE:-} \
                  ^--------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -Dzstd_SOURCE="${zstd_SOURCE:-}" \


In ci/scripts/cpp_build.sh line 285:
    -Dxsimd_SOURCE=${xsimd_SOURCE:-} \
                   ^---------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    -Dxsimd_SOURCE="${xsimd_SOURCE:-}" \


In ci/scripts/cpp_build.sh line 287:
    ${ARROW_CMAKE_ARGS} \
    ^-----------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    "${ARROW_CMAKE_ARGS}" \


In ci/scripts/cpp_build.sh line 288:
    ${source_dir}
    ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    "${source_dir}"


In ci/scripts/cpp_build.sh line 291:
: ${ARROW_BUILD_PARALLEL:=$[${n_jobs} + 1]}
  ^-- SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.
                          ^--------------^ SC2007 (style): Use $((..)) instead of deprecated $[..]


In ci/scripts/cpp_build.sh line 293:
  time meson compile -j ${ARROW_BUILD_PARALLEL}
                        ^---------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
  time meson compile -j "${ARROW_BUILD_PARALLEL}"


In ci/scripts/cpp_build.sh line 301:
  : ${CMAKE_BUILD_PARALLEL_LEVEL:=${ARROW_BUILD_PARALLEL}}
    ^-- SC2223 (info): This default assignment may cause DoS due to globbing. Quote it.


In ci/scripts/cpp_build.sh line 325:
  ${SUDO} ldconfig ${ARROW_HOME}/${CMAKE_INSTALL_LIBDIR:-lib}
                   ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                                 ^--------------------------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
  ${SUDO} ldconfig "${ARROW_HOME}"/"${CMAKE_INSTALL_LIBDIR:-lib}"


In ci/scripts/cpp_build.sh line 339:
  pushd ${source_dir}/apidoc
        ^-----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
  pushd "${source_dir}"/apidoc

For more information:
  https://www.shellcheck.net/wiki/SC2242 -- Can only exit with status 0-255. ...
  https://www.shellcheck.net/wiki/SC1090 -- ShellCheck can't follow non-const...
  https://www.shellcheck.net/wiki/SC2155 -- Declare and assign separately to ...
```

### What changes are included in this PR?

* SC1090: Ignore shellcheck.
* SC1091: Ignore shellcheck.
* SC2007: Use `$((..))`.
* SC2086: Quote variables.
* SC2155: Declare and assign variables separately.
* SC2223: Quote variables.
* SC2236: Use `-n`
* SC2242: Use 1 as exit number

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #48222