### PR TITLE
GH-47989: [Python][Docs] Add filters_to_expression to Parquet API reference

### DIFF
--- a/docs/source/python/api/formats.rst
+++ b/docs/source/python/api/formats.rst
@@ -82,6 +82,7 @@ Parquet Files
    ParquetDataset
    ParquetFile
    ParquetWriter
+   filters_to_expression
    read_table
    read_metadata
    read_pandas


### PR DESCRIPTION
Fixes #47989

Adds `filters_to_expression` to the Parquet autosummary section in `formats.rst`.
Documentation-only change.

* GitHub Issue: #47989