### PR TITLE
GH-48234: [C++][Parquet] Fix overly strict check for BIT_PACKED levels byte size

### DIFF
--- a/cpp/src/parquet/column_reader.cc
+++ b/cpp/src/parquet/column_reader.cc
@@ -132,7 +132,7 @@ int LevelDecoder::SetData(Encoding::type encoding, int16_t max_level,
             "Number of buffered values too large (corrupt data page?)");
       }
       num_bytes = static_cast<int32_t>(bit_util::BytesForBits(num_bits));
-      if (num_bytes < 0 || num_bytes > data_size - 4) {
+      if (num_bytes < 0 || num_bytes > data_size) {
         throw ParquetException("Received invalid number of bytes (corrupt data page?)");
       }
       if (!bit_packed_decoder_) {


### PR DESCRIPTION
### Rationale for this change

The original change from `data_size` to `data_size - 4` was made by me in https://github.com/apache/arrow/pull/6848 and it was probably based on a misunderstanding, or just blindly copying the similar check for `Encoding::RLE` (which, unlike `Encoding::BIT_PACKED`, does have a 4-byte length header).

### Are these changes tested?

Yes, by existing CI tests.

### Are there any user-facing changes?

No, just a potential bugfix for an unlikely case.

* GitHub Issue: #48234