### PR TITLE
MINOR: [Python] Clean up unused link references in README

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -53,7 +53,7 @@ See [Python Development][2] in the documentation subproject.
 See [documentation build instructions][1] in the documentation subproject.
 
 [1]: https://github.com/apache/arrow/blob/main/docs/source/developers/documentation.rst
-[2]: https://arrow.apache.org/docs/developers/python.html
+[2]: https://arrow.apache.org/docs/developers/python/index.html
 [3]: https://github.com/pandas-dev/pandas
 [5]: https://arrow.apache.org/docs/latest/python/benchmarks.html
 [6]: https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170#latest-microsoft-visual-c-redistributable-version

--- a/python/README.md
+++ b/python/README.md
@@ -42,7 +42,7 @@ pip install pyarrow
 ```
 
 If you encounter any issues importing the pip wheels on Windows, you may need
-to install the latest [Visual C++ Redistributable for Visual Studio][6].
+to install the latest [Visual C++ Redistributable for Visual Studio][3].
 
 ## Development
 
@@ -54,6 +54,4 @@ See [documentation build instructions][1] in the documentation subproject.
 
 [1]: https://github.com/apache/arrow/blob/main/docs/source/developers/documentation.rst
 [2]: https://arrow.apache.org/docs/developers/python/index.html
-[3]: https://github.com/pandas-dev/pandas
-[5]: https://arrow.apache.org/docs/latest/python/benchmarks.html
-[6]: https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170#latest-microsoft-visual-c-redistributable-version
+[3]: https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170#latest-microsoft-visual-c-redistributable-version


### PR DESCRIPTION
### Rationale for this change
The link to the python development documentation in python/README.md  is broken:  https://arrow.apache.org/docs/developers/python.html

### What changes are included in this PR?
This PR fix the link to  point to the new location: https://arrow.apache.org/docs/developers/python/index.html
Also removes unused links

### Are these changes tested?
Yes, link is now functional

### Are there any user-facing changes?
No 
