### PR TITLE
GH-48256: [Packaging][Linux] Use `closer.lua?action=download` URL

### DIFF
--- a/dev/tasks/linux-packages/apache-arrow/Rakefile
+++ b/dev/tasks/linux-packages/apache-arrow/Rakefile
@@ -69,11 +69,8 @@ class ApacheArrowPackageTask < PackageTask
   def download_released_archive
     mirror_base_url = "https://www.apache.org/dyn/closer.lua/arrow"
     mirror_list_url = "#{mirror_base_url}/arrow-#{@version}/#{@archive_name}"
-    open(mirror_list_url) do |response|
-      if /href="(.+?\/#{Regexp.escape(@archive_name)})"/ =~ response.read
-        download($1, ".")
-      end
-    end
+    mirror_download_url = "#{mirror_list_url}?action=download"
+    download(mirror_download_url, @archive_name)
   end
 
   def build_archive


### PR DESCRIPTION
### Rationale for this change

If we use the `closer.lua?action=download` URL, we don't need to find a mirror download URL manually.

Note that this code isn't used in our release process. Because we use RC source archive not released source archive in our release process.

### What changes are included in this PR?

Use `closer.lua?action=download` URL instead of scraping manually.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #48256