### PR TITLE
GH 40849: [Python] Remove all Py_FatalError calls

### DIFF
--- a/python/pyarrow/src/arrow/python/datetime.cc
+++ b/python/pyarrow/src/arrow/python/datetime.cc
@@ -82,7 +82,7 @@ void InitDatetime() {
   datetime_api =
       reinterpret_cast<PyDateTime_CAPI*>(PyCapsule_Import(PyDateTime_CAPSULE_NAME, 0));
   if (datetime_api == nullptr) {
-    Py_FatalError("Could not import datetime C API");
+    PyErr_SetString(PyExc_ImportError, "Could not import datetime C API");
   }
 }
 #endif
@@ -276,7 +276,8 @@ static inline Status PyDate_convert_int(int64_t val, const DateUnit unit, int64_
 PyObject* NewMonthDayNanoTupleType() {
   if (MonthDayNanoTupleType.tp_name == nullptr) {
     if (PyStructSequence_InitType2(&MonthDayNanoTupleType, &MonthDayNanoTupleDesc) != 0) {
-      Py_FatalError("Could not initialize MonthDayNanoTuple");
+      PyErr_SetString(PyExc_ImportError, "Could not initialize MonthDayNanoTuple");
+      return NULL;
     }
   }
   Py_INCREF(&MonthDayNanoTupleType);
@@ -607,7 +608,7 @@ struct PyListAssigner {
 
   void operator=(PyObject* obj) {
     if (ARROW_PREDICT_FALSE(PyList_SetItem(list_, current_index_, obj) == -1)) {
-      Py_FatalError("list did not have the correct preallocated size.");
+      PyErr_SetString(PyExc_RuntimeError, "list did not have the correct preallocated size.");
     }
   }
 
@@ -633,6 +634,7 @@ Result<PyObject*> MonthDayNanoIntervalArrayToPyList(
   OwnedRef out_list(PyList_New(array.length()));
   RETURN_IF_PYERROR();
   PyListAssigner out_objects(out_list.obj());
+  RETURN_IF_PYERROR();
   auto& interval_array =
       arrow::internal::checked_cast<const MonthDayNanoIntervalArray&>(array);
   RETURN_NOT_OK(internal::WriteArrayObjects(

--- a/python/pyarrow/src/arrow/python/datetime.cc
+++ b/python/pyarrow/src/arrow/python/datetime.cc
@@ -608,7 +608,8 @@ struct PyListAssigner {
 
   void operator=(PyObject* obj) {
     if (ARROW_PREDICT_FALSE(PyList_SetItem(list_, current_index_, obj) == -1)) {
-      PyErr_SetString(PyExc_RuntimeError, "list did not have the correct preallocated size.");
+      PyErr_SetString(PyExc_RuntimeError,
+                      "list did not have the correct preallocated size.");
     }
   }
 

--- a/python/pyarrow/src/arrow/python/datetime.cc
+++ b/python/pyarrow/src/arrow/python/datetime.cc
@@ -77,13 +77,15 @@ static PyStructSequence_Desc MonthDayNanoTupleDesc = {
 #ifndef PYPY_VERSION
 PyDateTime_CAPI* datetime_api = nullptr;
 
-void InitDatetime() {
+int InitDatetime() {
   PyAcquireGIL lock;
   datetime_api =
       reinterpret_cast<PyDateTime_CAPI*>(PyCapsule_Import(PyDateTime_CAPSULE_NAME, 0));
   if (datetime_api == nullptr) {
     PyErr_SetString(PyExc_ImportError, "Could not import datetime C API");
+    return -1;
   }
+  return 0;
 }
 #endif
 

--- a/python/pyarrow/src/arrow/python/datetime.h
+++ b/python/pyarrow/src/arrow/python/datetime.h
@@ -50,7 +50,7 @@ namespace internal {
 extern PyDateTime_CAPI* datetime_api;
 
 ARROW_PYTHON_EXPORT
-void InitDatetime();
+int InitDatetime();
 #endif
 
 // Returns the MonthDayNano namedtuple type (increments the reference count).

--- a/python/pyarrow/src/arrow/python/pyarrow.cc
+++ b/python/pyarrow/src/arrow/python/pyarrow.cc
@@ -46,7 +46,7 @@ int import_pyarrow() {
 #else
   auto init = internal::InitDatetime();
   if (init == -1) {
-      return -1;
+    return -1;
   }
 #endif
   return ::import_pyarrow__lib();

--- a/python/pyarrow/src/arrow/python/pyarrow.cc
+++ b/python/pyarrow/src/arrow/python/pyarrow.cc
@@ -46,6 +46,9 @@ int import_pyarrow() {
 #else
   internal::InitDatetime();
 #endif
+  if (PyErr_Occurred()) {
+    return -1;
+  }
   return ::import_pyarrow__lib();
 }
 

--- a/python/pyarrow/src/arrow/python/pyarrow.cc
+++ b/python/pyarrow/src/arrow/python/pyarrow.cc
@@ -44,11 +44,11 @@ int import_pyarrow() {
 #ifdef PYPY_VERSION
   PyDateTime_IMPORT;
 #else
-  internal::InitDatetime();
-#endif
-  if (PyErr_Occurred()) {
-    return -1;
+  auto init = internal::InitDatetime();
+  if (init == -1) {
+      return -1;
   }
+#endif
   return ::import_pyarrow__lib();
 }
 


### PR DESCRIPTION
Closes: https://github.com/apache/arrow/issues/40849

Calling this function will crash the process if being run in an embedded interpreter. Instead, try to raise a normal exception for datetime API initialization failures.

### Rationale for this change

Prevent crashes in embedded contexts

### What changes are included in this PR?

### Are these changes tested?

Ran the full test suite successfully

### Are there any user-facing changes? No