### PR TITLE
GH-48127: [R] stringr argument deprecation - add binding for stringr::str_ilike() and remove ignore_case argument for stringr::str_like()

### DIFF
--- a/r/R/dplyr-funcs-doc.R
+++ b/r/R/dplyr-funcs-doc.R
@@ -21,7 +21,7 @@
 #'
 #' The `arrow` package contains methods for 37 `dplyr` table functions, many of
 #' which are "verbs" that do transformations to one or more tables.
-#' The package also has mappings of 223 R functions to the corresponding
+#' The package also has mappings of 224 R functions to the corresponding
 #' functions in the Arrow compute library. These allow you to write code inside
 #' of `dplyr` methods that call R functions, including many in packages like
 #' `stringr` and `lubridate`, and they will get translated to Arrow and run
@@ -334,6 +334,7 @@
 #' * [`str_detect()`][stringr::str_detect()]
 #' * [`str_dup()`][stringr::str_dup()]
 #' * [`str_ends()`][stringr::str_ends()]
+#' * [`str_ilike()`][stringr::str_ilike()]
 #' * [`str_length()`][stringr::str_length()]
 #' * [`str_like()`][stringr::str_like()]
 #' * [`str_pad()`][stringr::str_pad()]

--- a/r/R/dplyr-funcs-string.R
+++ b/r/R/dplyr-funcs-string.R
@@ -259,11 +259,31 @@ register_bindings_string_regex <- function() {
 
   register_binding(
     "stringr::str_like",
-    function(string, pattern, ignore_case = TRUE) {
+    function(string, pattern, ignore_case) {
+      # TODO: Remove ignore_case parameter after stringr removes it (stringr >= 2.0.0?)
+      if (!missing(ignore_case)) {
+        warning(
+          "The `ignore_case` argument of `str_like()` is deprecated as of stringr 1.6.0.\n",
+          "`str_like()` is always case sensitive.\n",
+          "Use `str_ilike()` for case insensitive string matching.",
+          call. = FALSE
+        )
+      }
       Expression$create(
         "match_like",
         string,
-        options = list(pattern = pattern, ignore_case = ignore_case)
+        options = list(pattern = pattern, ignore_case = FALSE)
+      )
+    }
+  )
+
+  register_binding(
+    "stringr::str_ilike",
+    function(string, pattern) {
+      Expression$create(
+        "match_like",
+        string,
+        options = list(pattern = pattern, ignore_case = TRUE)
       )
     }
   )

--- a/r/man/acero.Rd
+++ b/r/man/acero.Rd
@@ -9,7 +9,7 @@
 \description{
 The \code{arrow} package contains methods for 37 \code{dplyr} table functions, many of
 which are "verbs" that do transformations to one or more tables.
-The package also has mappings of 223 R functions to the corresponding
+The package also has mappings of 224 R functions to the corresponding
 functions in the Arrow compute library. These allow you to write code inside
 of \code{dplyr} methods that call R functions, including many in packages like
 \code{stringr} and \code{lubridate}, and they will get translated to Arrow and run
@@ -341,6 +341,7 @@ Pattern modifiers \code{coll()} and \code{boundary()} are not supported in any f
 \item \code{\link[stringr:str_detect]{str_detect()}}
 \item \code{\link[stringr:str_dup]{str_dup()}}
 \item \code{\link[stringr:str_starts]{str_ends()}}
+\item \code{\link[stringr:str_like]{str_ilike()}}
 \item \code{\link[stringr:str_length]{str_length()}}
 \item \code{\link[stringr:str_like]{str_like()}}
 \item \code{\link[stringr:str_pad]{str_pad()}}

--- a/r/tests/testthat/test-dplyr-funcs-string.R
+++ b/r/tests/testthat/test-dplyr-funcs-string.R
@@ -903,7 +903,8 @@ test_that("str_like and str_ilike", {
   # with namespacing
   compare_dplyr_binding(
     .input |>
-      mutate(x = stringr::str_like(x, "baz")) |>
+      mutate(x_like = stringr::str_like(x, "baz")) |>
+      mutate(x_ilike = stringr::str_ilike(x, "foo%")) |>
       collect(),
     df
   )
@@ -911,34 +912,19 @@ test_that("str_like and str_ilike", {
   # Match - entire string
   compare_dplyr_binding(
     .input |>
-      mutate(x = str_like(x, "Foo and bar")) |>
+      mutate(x_like = str_like(x, "foo and bar")) |>
+      mutate(x_ilike = str_ilike(x, "foo and bar")) |>
       collect(),
     df
   )
 
-  # Case sensitivity: str_like is case-sensitive, str_ilike is not
+  # Wildcard
   compare_dplyr_binding(
     .input |>
       mutate(like_lower = str_like(x, "f%")) |>
       mutate(like_upper = str_like(x, "F%")) |>
       mutate(ilike_lower = str_ilike(x, "f%")) |>
       mutate(ilike_upper = str_ilike(x, "F%")) |>
-      collect(),
-    df
-  )
-
-  # str_ilike with namespacing and different patterns
-  compare_dplyr_binding(
-    .input |>
-      mutate(ilike_ns = stringr::str_ilike(x, "foo%")) |>
-      mutate(ilike_full = str_ilike(x, "foo and bar")) |>
-      collect(),
-    df
-  )
-
-  # Wildcards: % and _
-  compare_dplyr_binding(
-    .input |>
       mutate(like_percent = str_like(x, "%baz%")) |>
       mutate(like_underscore = str_like(x, "_a%")) |>
       mutate(ilike_mixed = str_ilike(x, "%BAZ%")) |>

--- a/r/tests/testthat/test-dplyr-funcs-string.R
+++ b/r/tests/testthat/test-dplyr-funcs-string.R
@@ -952,7 +952,6 @@ test_that("str_like and str_ilike", {
     call_binding("str_like", x, pattern = "f%", ignore_case = TRUE),
     "The `ignore_case` argument of `str_like\\(\\)` is deprecated"
   )
-
 })
 
 test_that("str_pad", {

--- a/r/tests/testthat/test-dplyr-funcs-string.R
+++ b/r/tests/testthat/test-dplyr-funcs-string.R
@@ -889,7 +889,7 @@ test_that("stri_reverse and arrow_ascii_reverse functions", {
   )
 })
 
-test_that("str_like", {
+test_that("str_like and str_ilike", {
   df <- tibble(x = c("Foo and bar", "baz and qux and quux"))
 
   # No match - entire string
@@ -899,6 +899,7 @@ test_that("str_like", {
       collect(),
     df
   )
+
   # with namespacing
   compare_dplyr_binding(
     .input |>
@@ -915,36 +916,43 @@ test_that("str_like", {
     df
   )
 
-  # Wildcard
+  # Case sensitivity: str_like is case-sensitive, str_ilike is not
   compare_dplyr_binding(
     .input |>
-      mutate(x = str_like(x, "f%", ignore_case = TRUE)) |>
+      mutate(like_lower = str_like(x, "f%")) |>
+      mutate(like_upper = str_like(x, "F%")) |>
+      mutate(ilike_lower = str_ilike(x, "f%")) |>
+      mutate(ilike_upper = str_ilike(x, "F%")) |>
       collect(),
     df
   )
 
-  # Ignore case
+  # str_ilike with namespacing and different patterns
   compare_dplyr_binding(
     .input |>
-      mutate(x = str_like(x, "f%", ignore_case = FALSE)) |>
+      mutate(ilike_ns = stringr::str_ilike(x, "foo%")) |>
+      mutate(ilike_full = str_ilike(x, "foo and bar")) |>
       collect(),
     df
   )
 
-  # Single character
+  # Wildcards: % and _
   compare_dplyr_binding(
     .input |>
-      mutate(x = str_like(x, "_a%")) |>
+      mutate(like_percent = str_like(x, "%baz%")) |>
+      mutate(like_underscore = str_like(x, "_a%")) |>
+      mutate(ilike_mixed = str_ilike(x, "%BAZ%")) |>
+      mutate(ilike_underscore = str_ilike(x, "_a%")) |>
       collect(),
     df
   )
 
-  compare_dplyr_binding(
-    .input |>
-      mutate(x = str_like(x, "%baz%")) |>
-      collect(),
-    df
+  x <- Expression$field_ref("x")
+  expect_warning(
+    call_binding("str_like", x, pattern = "f%", ignore_case = TRUE),
+    "The `ignore_case` argument of `str_like\\(\\)` is deprecated"
   )
+
 })
 
 test_that("str_pad", {


### PR DESCRIPTION
### Rationale for this change

We have bindings to stringr but stringr updated

### What changes are included in this PR?

Add new binding and warn re deprecation

### Are these changes tested?

Yes

### Are there any user-facing changes?

No
* GitHub Issue: #48127