### PR TITLE
GH-48268: [C++][Acero] Enhance the type checking for hash join residual filter

### DIFF
--- a/cpp/src/arrow/acero/swiss_join_internal.h
+++ b/cpp/src/arrow/acero/swiss_join_internal.h
@@ -980,6 +980,8 @@ class JoinResidualFilter {
 
  private:
   Expression filter_;
+  bool is_trivial_ = false;
+  bool is_literal_true_ = false;
 
   QueryContext* ctx_;
   MemoryPool* pool_;


### PR DESCRIPTION
### Rationale for this change

Type checking for hash join filter isn't enforced for some corner cases (literal filter expression). Some invalid tests are introduced.

### What changes are included in this PR?

Enforce the type checking for all cases. Also fix the problematic test cases. Also refined the trivial residual filter handling in swiss join.

### Are these changes tested?

Test included.

### Are there any user-facing changes?

None.
* GitHub Issue: #48268