### PR TITLE
GH-48960: [Python] Adds DEFAULT option in simd_level of cli.py

### DIFF
--- a/dev/archery/archery/cli.py
+++ b/dev/archery/archery/cli.py
@@ -78,7 +78,7 @@ build_type = click.Choice(["debug", "relwithdebinfo", "release"],
 warn_level_type = click.Choice(["everything", "checkin", "production"],
                                case_sensitive=False)
 
-simd_level = click.Choice(["NONE", "SSE4_2", "AVX2", "AVX512"],
+simd_level = click.Choice(["NONE", "DEFAULT", "SSE4_2", "AVX2", "AVX512"],
                           case_sensitive=True)
 
 


### PR DESCRIPTION
### Rationale for this change

For aarch64 machines, except `NONE`, none of the existing options in `simd_level` of `/dev/archery/archery/cli.py` are valid. The error also occurs on x86_64, unless one of `SSE4_2`, `AVX2`, or `AVX512` is specified.

With the `DEFAULT` option in `simd_level`, `Neon` paths will be activated for aarch64 machines, and `SSE4_2` will be activated for x86_64.

### What changes are included in this PR?
Adding `DEFAULT` option in `simd_level` of `/dev/archery/archery/cli.py`.

### Are these changes tested?
Yes.

### Are there any user-facing changes?
No.
* GitHub Issue: #48960