### PR TITLE
GH-48275: [C++][Dev] Allow choosing verbosity when fuzzing

### DIFF
--- a/cpp/src/arrow/util/fuzz_internal.h
+++ b/cpp/src/arrow/util/fuzz_internal.h
@@ -31,7 +31,7 @@ constexpr int64_t kFuzzingMemoryLimit = 2200LL * 1000 * 1000;
 /// Return a memory pool that will not allocate more than kFuzzingMemoryLimit bytes.
 ARROW_EXPORT MemoryPool* fuzzing_memory_pool();
 
-// Optionally log the outcome of fuzzing an input
+/// Optionally log the outcome of fuzzing an input
 ARROW_EXPORT void LogFuzzStatus(const Status&, const uint8_t* data, int64_t size);
 
 }  // namespace arrow::internal

--- a/cpp/src/arrow/util/io_util.cc
+++ b/cpp/src/arrow/util/io_util.cc
@@ -1768,13 +1768,13 @@ Result<std::string> GetEnvVar(const char* name) {
   if (res >= bufsize) {
     return Status::CapacityError("environment variable value too long");
   } else if (res == 0) {
-    return Status::KeyError("environment variable undefined");
+    return Status::KeyError("environment variable '", name, "'undefined");
   }
   return std::string(c_str);
 #else
   char* c_str = getenv(name);
   if (c_str == nullptr) {
-    return Status::KeyError("environment variable undefined");
+    return Status::KeyError("environment variable '", name, "'undefined");
   }
   return std::string(c_str);
 #endif
@@ -1793,7 +1793,7 @@ Result<NativePathString> GetEnvVarNative(const std::string& name) {
   if (res >= bufsize) {
     return Status::CapacityError("environment variable value too long");
   } else if (res == 0) {
-    return Status::KeyError("environment variable undefined");
+    return Status::KeyError("environment variable '", name, "'undefined");
   }
   return NativePathString(w_str);
 }

--- a/cpp/src/arrow/util/io_util.cc
+++ b/cpp/src/arrow/util/io_util.cc
@@ -1758,13 +1758,13 @@ Status FileTruncate(int fd, const int64_t size) {
 // Environment variables
 //
 
-Result<std::string> GetEnvVar(const char* name) {
+Result<std::string> GetEnvVar(std::string_view name) {
 #ifdef _WIN32
   // On Windows, getenv() reads an early copy of the process' environment
   // which doesn't get updated when SetEnvironmentVariable() is called.
   constexpr int32_t bufsize = 2000;
   char c_str[bufsize];
-  auto res = GetEnvironmentVariableA(name, c_str, bufsize);
+  auto res = GetEnvironmentVariableA(name.data(), c_str, bufsize);
   if (res >= bufsize) {
     return Status::CapacityError("environment variable value too long");
   } else if (res == 0) {
@@ -1772,7 +1772,7 @@ Result<std::string> GetEnvVar(const char* name) {
   }
   return std::string(c_str);
 #else
-  char* c_str = getenv(name);
+  char* c_str = getenv(name.data());
   if (c_str == nullptr) {
     return Status::KeyError("environment variable '", name, "'undefined");
   }
@@ -1780,10 +1780,8 @@ Result<std::string> GetEnvVar(const char* name) {
 #endif
 }
 
-Result<std::string> GetEnvVar(const std::string& name) { return GetEnvVar(name.c_str()); }
-
 #ifdef _WIN32
-Result<NativePathString> GetEnvVarNative(const std::string& name) {
+Result<NativePathString> GetEnvVarNative(std::string_view name) {
   NativePathString w_name;
   constexpr int32_t bufsize = 2000;
   wchar_t w_str[bufsize];
@@ -1798,28 +1796,23 @@ Result<NativePathString> GetEnvVarNative(const std::string& name) {
   return NativePathString(w_str);
 }
 
-Result<NativePathString> GetEnvVarNative(const char* name) {
-  return GetEnvVarNative(std::string(name));
-}
-
 #else
 
-Result<NativePathString> GetEnvVarNative(const std::string& name) {
+Result<NativePathString> GetEnvVarNative(std::string_view name) {
   return GetEnvVar(name);
 }
 
-Result<NativePathString> GetEnvVarNative(const char* name) { return GetEnvVar(name); }
 #endif
 
-Status SetEnvVar(const char* name, const char* value) {
+Status SetEnvVar(std::string_view name, std::string_view value) {
 #ifdef _WIN32
-  if (SetEnvironmentVariableA(name, value)) {
+  if (SetEnvironmentVariableA(name.data(), value.data())) {
     return Status::OK();
   } else {
     return Status::Invalid("failed setting environment variable");
   }
 #else
-  if (setenv(name, value, 1) == 0) {
+  if (setenv(name.data(), value.data(), 1) == 0) {
     return Status::OK();
   } else {
     return Status::Invalid("failed setting environment variable");
@@ -1827,27 +1820,21 @@ Status SetEnvVar(const char* name, const char* value) {
 #endif
 }
 
-Status SetEnvVar(const std::string& name, const std::string& value) {
-  return SetEnvVar(name.c_str(), value.c_str());
-}
-
-Status DelEnvVar(const char* name) {
+Status DelEnvVar(std::string_view name) {
 #ifdef _WIN32
-  if (SetEnvironmentVariableA(name, nullptr)) {
+  if (SetEnvironmentVariableA(name.data(), nullptr)) {
     return Status::OK();
   } else {
     return Status::Invalid("failed deleting environment variable");
   }
 #else
-  if (unsetenv(name) == 0) {
+  if (unsetenv(name.data()) == 0) {
     return Status::OK();
   } else {
     return Status::Invalid("failed deleting environment variable");
   }
 #endif
 }
-
-Status DelEnvVar(const std::string& name) { return DelEnvVar(name.c_str()); }
 
 //
 // Temporary directories

--- a/cpp/src/arrow/util/io_util.h
+++ b/cpp/src/arrow/util/io_util.h
@@ -25,6 +25,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -238,23 +239,16 @@ Status MemoryMapRemap(void* addr, size_t old_size, size_t new_size, int fildes,
 ARROW_EXPORT
 Status MemoryAdviseWillNeed(const std::vector<MemoryRegion>& regions);
 
+// Returns KeyError if the environment variable doesn't exist
 ARROW_EXPORT
-Result<std::string> GetEnvVar(const char* name);
+Result<std::string> GetEnvVar(std::string_view name);
 ARROW_EXPORT
-Result<std::string> GetEnvVar(const std::string& name);
-ARROW_EXPORT
-Result<NativePathString> GetEnvVarNative(const char* name);
-ARROW_EXPORT
-Result<NativePathString> GetEnvVarNative(const std::string& name);
+Result<NativePathString> GetEnvVarNative(std::string_view name);
 
 ARROW_EXPORT
-Status SetEnvVar(const char* name, const char* value);
+Status SetEnvVar(std::string_view name, std::string_view value);
 ARROW_EXPORT
-Status SetEnvVar(const std::string& name, const std::string& value);
-ARROW_EXPORT
-Status DelEnvVar(const char* name);
-ARROW_EXPORT
-Status DelEnvVar(const std::string& name);
+Status DelEnvVar(std::string_view name);
 
 ARROW_EXPORT
 std::string ErrnoMessage(int errnum);


### PR DESCRIPTION
### What changes are included in this PR?

Introduce an environment variable `ARROW_FUZZING_VERBOSITY` that allows choosing whether fuzzing errors are logged or silenced.

Also slight internal API simplification using `std::string_view`.

### Are these changes tested?

Manually.

### Are there any user-facing changes?

No.

* GitHub Issue: #48275