### PR TITLE
GH-44810: [C++][Parquet] Add arrow::Result version of parquet::arrow::FileReader::Make()

### DIFF
--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -4183,10 +4183,11 @@ void TryReadDataFile(const std::string& path,
   auto pool = ::arrow::default_memory_pool();
 
   std::unique_ptr<FileReader> arrow_reader;
-  Status s =
-      FileReader::Make(pool, ParquetFileReader::OpenFile(path, false), &arrow_reader);
-  if (s.ok()) {
+  Status s;
+  Result result = FileReader::Make(pool, ParquetFileReader::OpenFile(path, false));
+  if (result.ok()) {
     std::shared_ptr<::arrow::Table> table;
+    auto arrow_reader = result->get();
     s = arrow_reader->ReadTable(&table);
   }
 

--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -5196,9 +5196,8 @@ TEST_F(TestArrowReadDeltaEncoding, IncrementalDecodeDeltaByteArray) {
   const int64_t batch_size = 100;
   ArrowReaderProperties properties = default_arrow_reader_properties();
   properties.set_batch_size(batch_size);
-  std::unique_ptr<FileReader> parquet_reader;
   ASSERT_OK_AND_ASSIGN(
-      parquet_reader,
+      auto parquet_reader,
       FileReader::Make(pool, ParquetFileReader::OpenFile(file, false), properties));
   ASSERT_OK_AND_ASSIGN(auto rb_reader, parquet_reader->GetRecordBatchReader());
 

--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -4539,8 +4539,8 @@ TEST(TestArrowFileReader, RecordBatchReaderEmptyRowGroups) {
                                              default_arrow_writer_properties(), &buffer));
 
   auto reader = ParquetFileReader::Open(std::make_shared<BufferReader>(buffer));
-  ASSERT_OK_AND_ASSIGN(
-      auto file_reader, FileReader::Make(::arrow::default_memory_pool(), std::move(reader)));
+  ASSERT_OK_AND_ASSIGN(auto file_reader, FileReader::Make(::arrow::default_memory_pool(),
+                                                          std::move(reader)));
   // This is the important part in this test.
   std::vector<int> row_group_indices = {};
   ASSERT_OK_AND_ASSIGN(auto record_batch_reader,
@@ -4566,8 +4566,8 @@ TEST(TestArrowFileReader, RecordBatchReaderEmptyInput) {
                                              default_arrow_writer_properties(), &buffer));
 
   auto reader = ParquetFileReader::Open(std::make_shared<BufferReader>(buffer));
-  ASSERT_OK_AND_ASSIGN(
-      auto file_reader, FileReader::Make(::arrow::default_memory_pool(), std::move(reader)));
+  ASSERT_OK_AND_ASSIGN(auto file_reader, FileReader::Make(::arrow::default_memory_pool(),
+                                                          std::move(reader)));
   ASSERT_OK_AND_ASSIGN(auto record_batch_reader, file_reader->GetRecordBatchReader());
   std::shared_ptr<::arrow::RecordBatch> record_batch;
   ASSERT_OK(record_batch_reader->ReadNext(&record_batch));
@@ -4589,8 +4589,8 @@ TEST(TestArrowColumnReader, NextBatchZeroBatchSize) {
                                              default_arrow_writer_properties(), &buffer));
 
   auto reader = ParquetFileReader::Open(std::make_shared<BufferReader>(buffer));
-  ASSERT_OK_AND_ASSIGN(
-      auto file_reader, FileReader::Make(::arrow::default_memory_pool(), std::move(reader)));
+  ASSERT_OK_AND_ASSIGN(auto file_reader, FileReader::Make(::arrow::default_memory_pool(),
+                                                          std::move(reader)));
   std::unique_ptr<arrow::ColumnReader> column_reader;
   ASSERT_OK(file_reader->GetColumn(0, &column_reader));
   std::shared_ptr<ChunkedArray> chunked_array;
@@ -4614,8 +4614,8 @@ TEST(TestArrowColumnReader, NextBatchEmptyInput) {
                                              default_arrow_writer_properties(), &buffer));
 
   auto reader = ParquetFileReader::Open(std::make_shared<BufferReader>(buffer));
-  ASSERT_OK_AND_ASSIGN(
-      auto file_reader, FileReader::Make(::arrow::default_memory_pool(), std::move(reader)));
+  ASSERT_OK_AND_ASSIGN(auto file_reader, FileReader::Make(::arrow::default_memory_pool(),
+                                                          std::move(reader)));
   std::unique_ptr<arrow::ColumnReader> column_reader;
   ASSERT_OK(file_reader->GetColumn(0, &column_reader));
   std::shared_ptr<ChunkedArray> chunked_array;
@@ -5138,7 +5138,8 @@ class TestArrowReadDeltaEncoding : public ::testing::Test {
     auto file = test::get_data_file(file_name);
     auto pool = ::arrow::default_memory_pool();
     ASSERT_OK_AND_ASSIGN(
-        auto parquet_reader, FileReader::Make(pool, ParquetFileReader::OpenFile(file, false)));
+        auto parquet_reader,
+        FileReader::Make(pool, ParquetFileReader::OpenFile(file, false)));
     ASSERT_OK(parquet_reader->ReadTable(out));
     ASSERT_OK((*out)->ValidateFull());
   }

--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -4183,8 +4183,8 @@ void TryReadDataFile(const std::string& path,
   auto pool = ::arrow::default_memory_pool();
 
   Status s;
-  Result result = FileReader::Make(pool, ParquetFileReader::OpenFile(path, false));
-  if (result.ok()) {
+  auto reader_result = FileReader::Make(pool, ParquetFileReader::OpenFile(path, false));
+  if (reader_result.ok()) {
     std::shared_ptr<::arrow::Table> table;
     auto arrow_reader = result->get();
     s = arrow_reader->ReadTable(&table);

--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -4182,7 +4182,6 @@ void TryReadDataFile(const std::string& path,
                      const std::string& expected_message = "") {
   auto pool = ::arrow::default_memory_pool();
 
-  std::unique_ptr<FileReader> arrow_reader;
   Status s;
   Result result = FileReader::Make(pool, ParquetFileReader::OpenFile(path, false));
   if (result.ok()) {

--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -4260,8 +4260,7 @@ TEST(TestArrowReaderAdHoc, LARGE_MEMORY_TEST(LargeStringColumn)) {
   array.reset();
 
   auto reader = ParquetFileReader::Open(std::make_shared<BufferReader>(tables_buffer));
-  std::unique_ptr<FileReader> arrow_reader;
-  ASSERT_OK_AND_ASSIGN(arrow_reader,
+  ASSERT_OK_AND_ASSIGN(auto arrow_reader,
                        FileReader::Make(default_memory_pool(), std::move(reader)));
   ASSERT_OK_NO_THROW(arrow_reader->ReadTable(&table));
   ASSERT_OK(table->ValidateFull());

--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -4187,6 +4187,8 @@ void TryReadDataFile(const std::string& path,
   if (reader_result.ok()) {
     std::shared_ptr<::arrow::Table> table;
     s = (*reader_result)->ReadTable(&table);
+  } else {
+    s = reader_result.status();
   }
 
   ASSERT_EQ(s.code(), expected_code)

--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -4365,8 +4365,7 @@ TEST(TestArrowReaderAdHoc, LegacyTwoLevelList) {
     ASSERT_EQ(kExpectedLegacyList, nodeStr.str());
 
     // Verify Arrow schema and data
-    std::unique_ptr<FileReader> reader;
-    ASSERT_OK_AND_ASSIGN(reader,
+    ASSERT_OK_AND_ASSIGN(auto reader,
                          FileReader::Make(default_memory_pool(), std::move(file_reader)));
     std::shared_ptr<Table> table;
     ASSERT_OK(reader->ReadTable(&table));
@@ -4430,8 +4429,7 @@ TEST_P(TestArrowReaderAdHocSparkAndHvr, ReadDecimals) {
 
   auto pool = ::arrow::default_memory_pool();
 
-  std::unique_ptr<FileReader> arrow_reader;
-  ASSERT_OK_AND_ASSIGN(arrow_reader,
+  ASSERT_OK_AND_ASSIGN(auto arrow_reader,
                        FileReader::Make(pool, ParquetFileReader::OpenFile(path, false)));
   std::shared_ptr<::arrow::Table> table;
   ASSERT_OK_NO_THROW(arrow_reader->ReadTable(&table));
@@ -4497,9 +4495,8 @@ TEST(TestArrowReaderAdHoc, ReadFloat16Files) {
     path += "/" + tc.filename + ".parquet";
     ARROW_SCOPED_TRACE("path = ", path);
 
-    std::unique_ptr<FileReader> reader;
     ASSERT_OK_AND_ASSIGN(
-        reader, FileReader::Make(pool, ParquetFileReader::OpenFile(path, false)));
+        auto reader, FileReader::Make(pool, ParquetFileReader::OpenFile(path, false)));
     std::shared_ptr<::arrow::Table> table;
     ASSERT_OK_NO_THROW(reader->ReadTable(&table));
 
@@ -4542,9 +4539,8 @@ TEST(TestArrowFileReader, RecordBatchReaderEmptyRowGroups) {
                                              default_arrow_writer_properties(), &buffer));
 
   auto reader = ParquetFileReader::Open(std::make_shared<BufferReader>(buffer));
-  std::unique_ptr<FileReader> file_reader;
   ASSERT_OK_AND_ASSIGN(
-      file_reader, FileReader::Make(::arrow::default_memory_pool(), std::move(reader)));
+      auto file_reader, FileReader::Make(::arrow::default_memory_pool(), std::move(reader)));
   // This is the important part in this test.
   std::vector<int> row_group_indices = {};
   ASSERT_OK_AND_ASSIGN(auto record_batch_reader,
@@ -4570,9 +4566,8 @@ TEST(TestArrowFileReader, RecordBatchReaderEmptyInput) {
                                              default_arrow_writer_properties(), &buffer));
 
   auto reader = ParquetFileReader::Open(std::make_shared<BufferReader>(buffer));
-  std::unique_ptr<FileReader> file_reader;
   ASSERT_OK_AND_ASSIGN(
-      file_reader, FileReader::Make(::arrow::default_memory_pool(), std::move(reader)));
+      auto file_reader, FileReader::Make(::arrow::default_memory_pool(), std::move(reader)));
   ASSERT_OK_AND_ASSIGN(auto record_batch_reader, file_reader->GetRecordBatchReader());
   std::shared_ptr<::arrow::RecordBatch> record_batch;
   ASSERT_OK(record_batch_reader->ReadNext(&record_batch));
@@ -4594,9 +4589,8 @@ TEST(TestArrowColumnReader, NextBatchZeroBatchSize) {
                                              default_arrow_writer_properties(), &buffer));
 
   auto reader = ParquetFileReader::Open(std::make_shared<BufferReader>(buffer));
-  std::unique_ptr<FileReader> file_reader;
   ASSERT_OK_AND_ASSIGN(
-      file_reader, FileReader::Make(::arrow::default_memory_pool(), std::move(reader)));
+      auto file_reader, FileReader::Make(::arrow::default_memory_pool(), std::move(reader)));
   std::unique_ptr<arrow::ColumnReader> column_reader;
   ASSERT_OK(file_reader->GetColumn(0, &column_reader));
   std::shared_ptr<ChunkedArray> chunked_array;
@@ -4620,9 +4614,8 @@ TEST(TestArrowColumnReader, NextBatchEmptyInput) {
                                              default_arrow_writer_properties(), &buffer));
 
   auto reader = ParquetFileReader::Open(std::make_shared<BufferReader>(buffer));
-  std::unique_ptr<FileReader> file_reader;
   ASSERT_OK_AND_ASSIGN(
-      file_reader, FileReader::Make(::arrow::default_memory_pool(), std::move(reader)));
+      auto file_reader, FileReader::Make(::arrow::default_memory_pool(), std::move(reader)));
   std::unique_ptr<arrow::ColumnReader> column_reader;
   ASSERT_OK(file_reader->GetColumn(0, &column_reader));
   std::shared_ptr<ChunkedArray> chunked_array;
@@ -5144,9 +5137,8 @@ class TestArrowReadDeltaEncoding : public ::testing::Test {
                                 std::shared_ptr<Table>* out) {
     auto file = test::get_data_file(file_name);
     auto pool = ::arrow::default_memory_pool();
-    std::unique_ptr<FileReader> parquet_reader;
     ASSERT_OK_AND_ASSIGN(
-        parquet_reader, FileReader::Make(pool, ParquetFileReader::OpenFile(file, false)));
+        auto parquet_reader, FileReader::Make(pool, ParquetFileReader::OpenFile(file, false)));
     ASSERT_OK(parquet_reader->ReadTable(out));
     ASSERT_OK((*out)->ValidateFull());
   }
@@ -5733,8 +5725,7 @@ TEST(TestArrowReadWrite, WriteAndReadRecordBatch) {
   auto read_properties = default_arrow_reader_properties();
   read_properties.set_batch_size(record_batch->num_rows());
   auto reader = ParquetFileReader::Open(std::make_shared<BufferReader>(buffer));
-  std::unique_ptr<FileReader> arrow_reader;
-  ASSERT_OK_AND_ASSIGN(arrow_reader,
+  ASSERT_OK_AND_ASSIGN(auto arrow_reader,
                        FileReader::Make(pool, std::move(reader), read_properties));
 
   // Verify the single record batch has been sliced into two row groups by

--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -4186,8 +4186,7 @@ void TryReadDataFile(const std::string& path,
   auto reader_result = FileReader::Make(pool, ParquetFileReader::OpenFile(path, false));
   if (reader_result.ok()) {
     std::shared_ptr<::arrow::Table> table;
-    auto arrow_reader = result->get();
-    s = arrow_reader->ReadTable(&table);
+    s = (*reader_result)->ReadTable(&table);
   }
 
   ASSERT_EQ(s.code(), expected_code)

--- a/cpp/src/parquet/arrow/arrow_statistics_test.cc
+++ b/cpp/src/parquet/arrow/arrow_statistics_test.cc
@@ -202,9 +202,9 @@ namespace {
 
   auto reader =
       ParquetFileReader::Open(std::make_shared<::arrow::io::BufferReader>(buffer));
-  std::unique_ptr<FileReader> file_reader;
-  ARROW_RETURN_NOT_OK(FileReader::Make(::arrow::default_memory_pool(), std::move(reader),
-                                       reader_properties, &file_reader));
+  ARROW_ASSIGN_OR_RAISE(auto file_reader,
+                        FileReader::Make(::arrow::default_memory_pool(),
+                                         std::move(reader), reader_properties));
   std::shared_ptr<::arrow::ChunkedArray> chunked_array;
   ARROW_RETURN_NOT_OK(file_reader->ReadColumn(0, &chunked_array));
   return chunked_array->chunk(0);

--- a/cpp/src/parquet/arrow/fuzz_internal.cc
+++ b/cpp/src/parquet/arrow/fuzz_internal.cc
@@ -281,8 +281,10 @@ Status FuzzReader(const uint8_t* data, int64_t size) {
     pq_file_reader = ParquetFileReader::Open(file, reader_properties, pq_md);
     END_PARQUET_CATCH_EXCEPTIONS
 
-    std::unique_ptr<FileReader> reader;
-    RETURN_NOT_OK(FileReader::Make(pool, std::move(pq_file_reader), properties, &reader));
+    auto arrow_reader_result =
+        FileReader::Make(pool, std::move(pq_file_reader), properties);
+    RETURN_NOT_OK(arrow_reader_result.status());
+    auto reader = std::move(*arrow_reader_result);
     st &= FuzzReadData(std::move(reader));
   }
   return st;

--- a/cpp/src/parquet/arrow/reader.cc
+++ b/cpp/src/parquet/arrow/reader.cc
@@ -1343,8 +1343,7 @@ Status FileReader::Make(::arrow::MemoryPool* pool,
                         std::unique_ptr<ParquetFileReader> reader,
                         const ArrowReaderProperties& properties,
                         std::unique_ptr<FileReader>* out) {
-  ARROW_ASSIGN_OR_RAISE(auto result, Make(pool, std::move(reader), properties));
-  *out = std::move(result);
+  ARROW_ASSIGN_OR_RAISE(*out, Make(pool, std::move(reader), properties));
   return Status::OK();
 }
 

--- a/cpp/src/parquet/arrow/reader.cc
+++ b/cpp/src/parquet/arrow/reader.cc
@@ -1350,9 +1350,8 @@ Status FileReader::Make(::arrow::MemoryPool* pool,
 Status FileReader::Make(::arrow::MemoryPool* pool,
                         std::unique_ptr<ParquetFileReader> reader,
                         std::unique_ptr<FileReader>* out) {
-  ARROW_ASSIGN_OR_RAISE(auto result,
+  ARROW_ASSIGN_OR_RAISE(*out,
                         Make(pool, std::move(reader), default_arrow_reader_properties()));
-  *out = std::move(result);
   return Status::OK();
 }
 

--- a/cpp/src/parquet/arrow/reader.cc
+++ b/cpp/src/parquet/arrow/reader.cc
@@ -1404,13 +1404,13 @@ FileReaderBuilder* FileReaderBuilder::properties(
 }
 
 Status FileReaderBuilder::Build(std::unique_ptr<FileReader>* out) {
-  return FileReader::Make(pool_, std::move(raw_reader_), properties_, out);
+  ARROW_ASSIGN_OR_RAISE(*out,
+                        FileReader::Make(pool_, std::move(raw_reader_), properties_));
+  return Status::OK();
 }
 
 Result<std::unique_ptr<FileReader>> FileReaderBuilder::Build() {
-  std::unique_ptr<FileReader> out;
-  RETURN_NOT_OK(FileReader::Make(pool_, std::move(raw_reader_), properties_, &out));
-  return out;
+  return FileReader::Make(pool_, std::move(raw_reader_), properties_);
 }
 
 Result<std::unique_ptr<FileReader>> OpenFile(

--- a/cpp/src/parquet/arrow/reader.cc
+++ b/cpp/src/parquet/arrow/reader.cc
@@ -1366,10 +1366,7 @@ Result<std::unique_ptr<FileReader>> FileReader::Make(
 
 Result<std::unique_ptr<FileReader>> FileReader::Make(
     ::arrow::MemoryPool* pool, std::unique_ptr<ParquetFileReader> parquet_reader) {
-  std::unique_ptr<FileReader> reader = std::make_unique<FileReaderImpl>(
-      pool, std::move(parquet_reader), default_arrow_reader_properties());
-  RETURN_NOT_OK(static_cast<FileReaderImpl*>(reader.get())->Init());
-  return reader;
+  return Make(pool, std::move(parquet_reader), default_arrow_reader_properties());
 }
 
 FileReaderBuilder::FileReaderBuilder()

--- a/cpp/src/parquet/arrow/reader.h
+++ b/cpp/src/parquet/arrow/reader.h
@@ -134,6 +134,7 @@ class PARQUET_EXPORT FileReader {
   /// Factory function to create a FileReader from a ParquetFileReader
   static ::arrow::Result<std::unique_ptr<FileReader>> Make(
       ::arrow::MemoryPool* pool, std::unique_ptr<ParquetFileReader> reader);
+
   // Since the distribution of columns amongst a Parquet file's row groups may
   // be uneven (the number of values in each column chunk can be different), we
   // provide a column-oriented read interface. The ColumnReader hides the

--- a/cpp/src/parquet/arrow/reader.h
+++ b/cpp/src/parquet/arrow/reader.h
@@ -126,6 +126,14 @@ class PARQUET_EXPORT FileReader {
                               std::unique_ptr<ParquetFileReader> reader,
                               std::unique_ptr<FileReader>* out);
 
+  /// Factory function to create a FileReader from a ParquetFileReader and properties
+  static ::arrow::Result<std::unique_ptr<FileReader>> Make(
+      ::arrow::MemoryPool* pool, std::unique_ptr<ParquetFileReader> reader,
+      const ArrowReaderProperties& properties);
+
+  /// Factory function to create a FileReader from a ParquetFileReader
+  static ::arrow::Result<std::unique_ptr<FileReader>> Make(
+      ::arrow::MemoryPool* pool, std::unique_ptr<ParquetFileReader> reader);
   // Since the distribution of columns amongst a Parquet file's row groups may
   // be uneven (the number of values in each column chunk can be different), we
   // provide a column-oriented read interface. The ColumnReader hides the

--- a/cpp/src/parquet/arrow/reader.h
+++ b/cpp/src/parquet/arrow/reader.h
@@ -116,12 +116,16 @@ class RowGroupReader;
 class PARQUET_EXPORT FileReader {
  public:
   /// Factory function to create a FileReader from a ParquetFileReader and properties
+  /// \deprecated Deprecated in 23.0.0. Use arrow::Result version instead.
+  ARROW_DEPRECATED("Deprecated in 23.0.0. Use arrow::Result version instead.")
   static ::arrow::Status Make(::arrow::MemoryPool* pool,
                               std::unique_ptr<ParquetFileReader> reader,
                               const ArrowReaderProperties& properties,
                               std::unique_ptr<FileReader>* out);
 
   /// Factory function to create a FileReader from a ParquetFileReader
+  /// \deprecated Deprecated in 23.0.0. Use arrow::Result version instead.
+  ARROW_DEPRECATED("Deprecated in 23.0.0. Use arrow::Result version instead.")
   static ::arrow::Status Make(::arrow::MemoryPool* pool,
                               std::unique_ptr<ParquetFileReader> reader,
                               std::unique_ptr<FileReader>* out);

--- a/cpp/src/parquet/arrow/reader_writer_benchmark.cc
+++ b/cpp/src/parquet/arrow/reader_writer_benchmark.cc
@@ -799,8 +799,8 @@ static void BM_ReadMultipleRowGroupsGenerator(::benchmark::State& state) {
     auto reader =
         ParquetFileReader::Open(std::make_shared<::arrow::io::BufferReader>(buffer));
     std::unique_ptr<FileReader> unique_reader;
-    EXIT_NOT_OK(FileReader::Make(::arrow::default_memory_pool(), std::move(reader),
-                                 &unique_reader));
+    ASSERT_OK_AND_ASSIGN(unique_reader, FileReader::Make(::arrow::default_memory_pool(),
+                                                         std::move(reader)));
     std::shared_ptr<FileReader> arrow_reader = std::move(unique_reader);
     ASSIGN_OR_ABORT(auto generator,
                     arrow_reader->GetRecordBatchGenerator(arrow_reader, rgs, {0}));

--- a/cpp/src/parquet/arrow/reader_writer_benchmark.cc
+++ b/cpp/src/parquet/arrow/reader_writer_benchmark.cc
@@ -799,8 +799,8 @@ static void BM_ReadMultipleRowGroupsGenerator(::benchmark::State& state) {
     auto reader =
         ParquetFileReader::Open(std::make_shared<::arrow::io::BufferReader>(buffer));
     std::unique_ptr<FileReader> unique_reader;
-    ASSIGN_OR_ABORT(unique_reader, FileReader::Make(::arrow::default_memory_pool(),
-                                                    std::move(reader)));
+    ASSIGN_OR_ABORT(unique_reader,
+                    FileReader::Make(::arrow::default_memory_pool(), std::move(reader)));
     std::shared_ptr<FileReader> arrow_reader = std::move(unique_reader);
     ASSIGN_OR_ABORT(auto generator,
                     arrow_reader->GetRecordBatchGenerator(arrow_reader, rgs, {0}));

--- a/cpp/src/parquet/arrow/reader_writer_benchmark.cc
+++ b/cpp/src/parquet/arrow/reader_writer_benchmark.cc
@@ -299,7 +299,7 @@ static void BenchmarkReadTable(::benchmark::State& state, const Table& table,
     std::unique_ptr<FileReader> arrow_reader;
     auto reader_result =
         FileReader::Make(::arrow::default_memory_pool(), std::move(reader));
-    EXIT_NOT_OK(result.status());
+    EXIT_NOT_OK(reader_result.status());
 
     std::shared_ptr<Table> table;
     EXIT_NOT_OK(arrow_reader->ReadTable(&table));

--- a/cpp/src/parquet/arrow/reader_writer_benchmark.cc
+++ b/cpp/src/parquet/arrow/reader_writer_benchmark.cc
@@ -299,7 +299,7 @@ static void BenchmarkReadTable(::benchmark::State& state, const Table& table,
     std::unique_ptr<FileReader> arrow_reader;
     auto reader_result =
         FileReader::Make(::arrow::default_memory_pool(), std::move(reader));
-    EXIT_NOT_OK(result.status);
+    EXIT_NOT_OK(result.status());
 
     std::shared_ptr<Table> table;
     EXIT_NOT_OK(arrow_reader->ReadTable(&table));

--- a/cpp/src/parquet/arrow/reader_writer_benchmark.cc
+++ b/cpp/src/parquet/arrow/reader_writer_benchmark.cc
@@ -296,10 +296,10 @@ static void BenchmarkReadTable(::benchmark::State& state, const Table& table,
   for (auto _ : state) {
     auto reader =
         ParquetFileReader::Open(std::make_shared<::arrow::io::BufferReader>(buffer));
-    std::unique_ptr<FileReader> arrow_reader;
-    auto reader_result =
+    auto arrow_reader_result =
         FileReader::Make(::arrow::default_memory_pool(), std::move(reader));
-    EXIT_NOT_OK(reader_result.status());
+    EXIT_NOT_OK(arrow_reader_result.status());
+    std::shared_ptr<FileReader> arrow_reader = std::move(*arrow_reader_result);
 
     std::shared_ptr<Table> table;
     EXIT_NOT_OK(arrow_reader->ReadTable(&table));
@@ -736,10 +736,10 @@ static void BM_ReadIndividualRowGroups(::benchmark::State& state) {
   while (state.KeepRunning()) {
     auto reader =
         ParquetFileReader::Open(std::make_shared<::arrow::io::BufferReader>(buffer));
-    std::unique_ptr<FileReader> arrow_reader;
-    auto reader_result =
+    auto arrow_reader_result =
         FileReader::Make(::arrow::default_memory_pool(), std::move(reader));
-    EXIT_NOT_OK(reader_result.status());
+    EXIT_NOT_OK(arrow_reader_result.status());
+    std::shared_ptr<FileReader> arrow_reader = std::move(*arrow_reader_result);
 
     std::vector<std::shared_ptr<Table>> tables;
     for (int i = 0; i < arrow_reader->num_row_groups(); i++) {
@@ -799,8 +799,8 @@ static void BM_ReadMultipleRowGroupsGenerator(::benchmark::State& state) {
     auto reader =
         ParquetFileReader::Open(std::make_shared<::arrow::io::BufferReader>(buffer));
     std::unique_ptr<FileReader> unique_reader;
-    ASSERT_OK_AND_ASSIGN(unique_reader, FileReader::Make(::arrow::default_memory_pool(),
-                                                         std::move(reader)));
+    ASSIGN_OR_ABORT(unique_reader, FileReader::Make(::arrow::default_memory_pool(),
+                                                    std::move(reader)));
     std::shared_ptr<FileReader> arrow_reader = std::move(unique_reader);
     ASSIGN_OR_ABORT(auto generator,
                     arrow_reader->GetRecordBatchGenerator(arrow_reader, rgs, {0}));

--- a/cpp/src/parquet/arrow/reader_writer_benchmark.cc
+++ b/cpp/src/parquet/arrow/reader_writer_benchmark.cc
@@ -297,8 +297,9 @@ static void BenchmarkReadTable(::benchmark::State& state, const Table& table,
     auto reader =
         ParquetFileReader::Open(std::make_shared<::arrow::io::BufferReader>(buffer));
     std::unique_ptr<FileReader> arrow_reader;
-    EXIT_NOT_OK(FileReader::Make(::arrow::default_memory_pool(), std::move(reader),
-                                 &arrow_reader));
+    auto reader_result =
+        FileReader::Make(::arrow::default_memory_pool(), std::move(reader));
+    EXIT_NOT_OK(result.status);
 
     std::shared_ptr<Table> table;
     EXIT_NOT_OK(arrow_reader->ReadTable(&table));
@@ -736,8 +737,9 @@ static void BM_ReadIndividualRowGroups(::benchmark::State& state) {
     auto reader =
         ParquetFileReader::Open(std::make_shared<::arrow::io::BufferReader>(buffer));
     std::unique_ptr<FileReader> arrow_reader;
-    EXIT_NOT_OK(FileReader::Make(::arrow::default_memory_pool(), std::move(reader),
-                                 &arrow_reader));
+    auto reader_result =
+        FileReader::Make(::arrow::default_memory_pool(), std::move(reader));
+    EXIT_NOT_OK(reader_result.status());
 
     std::vector<std::shared_ptr<Table>> tables;
     for (int i = 0; i < arrow_reader->num_row_groups(); i++) {
@@ -771,8 +773,10 @@ static void BM_ReadMultipleRowGroups(::benchmark::State& state) {
     auto reader =
         ParquetFileReader::Open(std::make_shared<::arrow::io::BufferReader>(buffer));
     std::unique_ptr<FileReader> arrow_reader;
-    EXIT_NOT_OK(FileReader::Make(::arrow::default_memory_pool(), std::move(reader),
-                                 &arrow_reader));
+    auto reader_result =
+        FileReader::Make(::arrow::default_memory_pool(), std::move(reader));
+    EXIT_NOT_OK(reader_result.status());
+
     std::shared_ptr<Table> table;
     EXIT_NOT_OK(arrow_reader->ReadRowGroups(rgs, &table));
   }

--- a/cpp/src/parquet/arrow/reader_writer_benchmark.cc
+++ b/cpp/src/parquet/arrow/reader_writer_benchmark.cc
@@ -798,10 +798,10 @@ static void BM_ReadMultipleRowGroupsGenerator(::benchmark::State& state) {
   while (state.KeepRunning()) {
     auto reader =
         ParquetFileReader::Open(std::make_shared<::arrow::io::BufferReader>(buffer));
-    std::unique_ptr<FileReader> unique_reader;
-    ASSIGN_OR_ABORT(unique_reader,
-                    FileReader::Make(::arrow::default_memory_pool(), std::move(reader)));
-    std::shared_ptr<FileReader> arrow_reader = std::move(unique_reader);
+    auto arrow_reader_result =
+        FileReader::Make(::arrow::default_memory_pool(), std::move(reader));
+    EXIT_NOT_OK(arrow_reader_result.status());
+    std::shared_ptr<FileReader> arrow_reader = std::move(*arrow_reader_result);
     ASSIGN_OR_ABORT(auto generator,
                     arrow_reader->GetRecordBatchGenerator(arrow_reader, rgs, {0}));
     auto fut = ::arrow::CollectAsyncGenerator(generator);

--- a/cpp/src/parquet/arrow/reader_writer_benchmark.cc
+++ b/cpp/src/parquet/arrow/reader_writer_benchmark.cc
@@ -299,7 +299,7 @@ static void BenchmarkReadTable(::benchmark::State& state, const Table& table,
     auto arrow_reader_result =
         FileReader::Make(::arrow::default_memory_pool(), std::move(reader));
     EXIT_NOT_OK(arrow_reader_result.status());
-    std::shared_ptr<FileReader> arrow_reader = std::move(*arrow_reader_result);
+    auto arrow_reader = std::move(*arrow_reader_result);
 
     std::shared_ptr<Table> table;
     EXIT_NOT_OK(arrow_reader->ReadTable(&table));
@@ -739,7 +739,7 @@ static void BM_ReadIndividualRowGroups(::benchmark::State& state) {
     auto arrow_reader_result =
         FileReader::Make(::arrow::default_memory_pool(), std::move(reader));
     EXIT_NOT_OK(arrow_reader_result.status());
-    std::shared_ptr<FileReader> arrow_reader = std::move(*arrow_reader_result);
+    auto arrow_reader = std::move(*arrow_reader_result);
 
     std::vector<std::shared_ptr<Table>> tables;
     for (int i = 0; i < arrow_reader->num_row_groups(); i++) {
@@ -775,7 +775,7 @@ static void BM_ReadMultipleRowGroups(::benchmark::State& state) {
     auto arrow_reader_result =
         FileReader::Make(::arrow::default_memory_pool(), std::move(reader));
     EXIT_NOT_OK(arrow_reader_result.status());
-    std::shared_ptr<FileReader> arrow_reader = std::move(*arrow_reader_result);
+    auto arrow_reader = std::move(*arrow_reader_result);
 
     std::shared_ptr<Table> table;
     EXIT_NOT_OK(arrow_reader->ReadRowGroups(rgs, &table));

--- a/cpp/src/parquet/arrow/reader_writer_benchmark.cc
+++ b/cpp/src/parquet/arrow/reader_writer_benchmark.cc
@@ -772,10 +772,10 @@ static void BM_ReadMultipleRowGroups(::benchmark::State& state) {
   while (state.KeepRunning()) {
     auto reader =
         ParquetFileReader::Open(std::make_shared<::arrow::io::BufferReader>(buffer));
-    std::unique_ptr<FileReader> arrow_reader;
-    auto reader_result =
+    auto arrow_reader_result =
         FileReader::Make(::arrow::default_memory_pool(), std::move(reader));
-    EXIT_NOT_OK(reader_result.status());
+    EXIT_NOT_OK(arrow_reader_result.status());
+    std::shared_ptr<FileReader> arrow_reader = std::move(*arrow_reader_result);
 
     std::shared_ptr<Table> table;
     EXIT_NOT_OK(arrow_reader->ReadRowGroups(rgs, &table));


### PR DESCRIPTION
### Rationale for this change

`FileReader::Make` previously returned `Status` and required callers to pass an `out` parameter.

### What changes are included in this PR?

Introduce a `Result<std::unique_ptr<FileReader>>` returning API to allow clearer error propagation 

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes. 

Status version `FileReader::Make` has been deprecated.

```cpp
  static ::arrow::Status Make(::arrow::MemoryPool* pool,
                              std::unique_ptr<ParquetFileReader> reader,
                              const ArrowReaderProperties& properties,
                              std::unique_ptr<FileReader>* out);

  static ::arrow::Status Make(::arrow::MemoryPool* pool,
                              std::unique_ptr<ParquetFileReader> reader,
                              std::unique_ptr<FileReader>* out);
```

* GitHub Issue: #44810