### PR TITLE
GH-36593: [Python] Add rename_columns method to pyarrow datasets

### DIFF
--- a/python/pyarrow/_dataset.pxd
+++ b/python/pyarrow/_dataset.pxd
@@ -47,6 +47,7 @@ cdef class Dataset(_Weakrefable):
         SharedPtrNoGIL[CDataset] wrapped
         CDataset* dataset
         public dict _scan_options
+        public dict _columns
 
     cdef void init(self, const shared_ptr[CDataset]& sp)
 

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -175,6 +175,7 @@ cdef class Dataset(_Weakrefable):
         self.wrapped = sp
         self.dataset = sp.get()
         self._scan_options = dict()
+        self._columns = dict()
 
     @staticmethod
     cdef wrap(const shared_ptr[CDataset]& sp):
@@ -413,8 +414,8 @@ cdef class Dataset(_Weakrefable):
         animal: [["Parrot","Dog","Horse","Centipede"]]
         """
         # Apply column projection from rename_columns() if present
-        if columns is None and 'columns' in self._scan_options:
-            columns = self._scan_options['columns']
+        if columns is None and self._columns:
+            columns = self._columns
 
         return Scanner.from_dataset(
             self,
@@ -1066,7 +1067,7 @@ cdef class Dataset(_Weakrefable):
         projection = {new_name: ds.field(old_name)
                       for old_name, new_name in name_mapping.items()}
 
-        self._scan_options['columns'] = projection
+        self._columns = projection
 
         return self
 

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -1012,6 +1012,24 @@ cdef class Dataset(_Weakrefable):
         -------
         Dataset
             The existing dataset with column projection applied.
+
+        Examples
+        --------
+        Rename all columns by position:
+
+        >>> import pyarrow as pa
+        >>> table = pa.table({'year': [2020, 2022, 2021, 2022, 2019, 2021],
+        ...                   'n_legs': [2, 2, 4, 4, 5, 100],
+        ...                   'animal': ["Flamingo", "Parrot", "Dog", "Horse",
+        ...                              "Brittle stars", "Centipede"]})
+
+        >>> import pyarrow.dataset as ds
+        >>> dataset = ds.InMemoryDataset([table])
+        >>> dataset.rename_columns(['time', 'number_of_legs', 'name']).to_table()
+
+        Rename specific columns:
+
+        >>> dataset.rename_columns({'n_legs': 'number_of_legs'}).to_table()
         """
         import pyarrow.dataset as ds
 

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -1026,10 +1026,26 @@ cdef class Dataset(_Weakrefable):
         >>> import pyarrow.dataset as ds
         >>> dataset = ds.InMemoryDataset([table])
         >>> dataset.rename_columns(['time', 'number_of_legs', 'name']).to_table()
+        pyarrow.Table
+        time: int64
+        number_of_legs: int64
+        name: string
+        ----
+        time: [[2020,2022,2021,2022,2019,2021]]
+        number_of_legs: [[2,2,4,4,5,100]]
+        name: [["Flamingo","Parrot","Dog","Horse","Brittle stars","Centipede"]]
 
         Rename specific columns:
 
         >>> dataset.rename_columns({'n_legs': 'number_of_legs'}).to_table()
+        pyarrow.Table
+        year: int64
+        number_of_legs: int64
+        animal: string
+        ----
+        year: [[2020,2022,2021,2022,2019,2021]]
+        number_of_legs: [[2,2,4,4,5,100]]
+        animal: [["Flamingo","Parrot","Dog","Horse","Brittle stars","Centipede"]]
         """
         import pyarrow.dataset as ds
 

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -1012,16 +1012,6 @@ cdef class Dataset(_Weakrefable):
         -------
         Dataset
             The existing dataset with column projection applied.
-
-        Examples
-        --------
-        Rename all columns by position:
-
-        >>> dataset.rename_columns(['name', 'age', 'city']).to_table()
-
-        Rename specific columns:
-
-        >>> dataset.rename_columns({'old_name': 'new_name'}).to_table()
         """
         import pyarrow.dataset as ds
 

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -1064,10 +1064,8 @@ cdef class Dataset(_Weakrefable):
         else:
             raise TypeError(f"names must be list, tuple, or dict, not {type(names)!r}")
 
-        projection = {new_name: ds.field(old_name)
-                      for old_name, new_name in name_mapping.items()}
-
-        self._columns = projection
+        self._columns = {new_name: ds.field(old_name)
+                         for old_name, new_name in name_mapping.items()}
 
         return self
 

--- a/python/pyarrow/_dataset.pyx
+++ b/python/pyarrow/_dataset.pyx
@@ -1058,7 +1058,8 @@ cdef class Dataset(_Weakrefable):
             name_mapping = {schema.field(i).name: names[i]
                             for i in range(len(names))}
         elif isinstance(names, dict):
-            name_mapping = names
+            name_mapping = {field.name: names.get(field.name, field.name)
+                            for field in schema}
         else:
             raise TypeError(f"names must be list, tuple, or dict, not {type(names)!r}")
 

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -5934,13 +5934,18 @@ def test_scanner_from_substrait(dataset):
     assert result.to_pydict() == {'str': ['4', '4']}
 
 
-@pytest.mark.parametrize("names", [
-    ["new-index", "new-color"],
-    ("new-index", "new-color"),
-    {"index": "new-index", "color": "new-color"}
+@pytest.mark.parametrize("names, expected_schema", [
+    (["new-index", "new-color"],
+     pa.schema([pa.field("new-index", pa.int64()), pa.field("new-color", pa.string())])),
+    (("new-index", "new-color"),
+     pa.schema([pa.field("new-index", pa.int64()), pa.field("new-color", pa.string())])),
+    ({"index": "new-index", "color": "new-color"},
+     pa.schema([pa.field("new-index", pa.int64()), pa.field("new-color", pa.string())])),
+    ({"index": "new-index"},
+     pa.schema([pa.field("new-index", pa.int64()), pa.field("color", pa.string())])),
 ]
 )
-def test_rename_columns(names):
+def test_rename_columns(names, expected_schema):
     original_schema = pa.schema([
         pa.field('index', pa.int64()),
         pa.field('color', pa.string()),
@@ -5954,10 +5959,5 @@ def test_rename_columns(names):
     )
 
     dataset.rename_columns(names)
-
-    expected_schema = pa.schema([
-        pa.field("new-index", pa.int64()),
-        pa.field("new-color", pa.string())
-    ])
 
     assert dataset.to_table().schema.equals(expected_schema)

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -5932,3 +5932,32 @@ def test_scanner_from_substrait(dataset):
         filter=ps.BoundExpressions.from_substrait(filtering)
     ).to_table()
     assert result.to_pydict() == {'str': ['4', '4']}
+
+
+@pytest.mark.parametrize("names", [
+    ["new-index", "new-color"],
+    ("new-index", "new-color"),
+    {"index": "new-index", "color": "new-color"}
+]
+)
+def test_rename_columns(names):
+    original_schema = pa.schema([
+        pa.field('index', pa.int64()),
+        pa.field('color', pa.string()),
+    ]
+    )
+
+    dataset = ds.InMemoryDataset(
+        pa.RecordBatch.from_pylist(
+            [{"index": 1, "color": "green"}, {"index": 2, "color": "blue"}]),
+        schema=original_schema
+    )
+
+    dataset.rename_columns(names)
+
+    expected_schema = pa.schema([
+        pa.field("new-index", pa.int64()),
+        pa.field("new-color", pa.string())
+    ])
+
+    assert dataset.to_table().schema.equals(expected_schema)

--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -5936,13 +5936,17 @@ def test_scanner_from_substrait(dataset):
 
 @pytest.mark.parametrize("names, expected_schema", [
     (["new-index", "new-color"],
-     pa.schema([pa.field("new-index", pa.int64()), pa.field("new-color", pa.string())])),
+     pa.schema([pa.field("new-index", pa.int64()),
+                pa.field("new-color", pa.string())])),
     (("new-index", "new-color"),
-     pa.schema([pa.field("new-index", pa.int64()), pa.field("new-color", pa.string())])),
+     pa.schema([pa.field("new-index", pa.int64()),
+                pa.field("new-color", pa.string())])),
     ({"index": "new-index", "color": "new-color"},
-     pa.schema([pa.field("new-index", pa.int64()), pa.field("new-color", pa.string())])),
+     pa.schema([pa.field("new-index", pa.int64()),
+                pa.field("new-color", pa.string())])),
     ({"index": "new-index"},
-     pa.schema([pa.field("new-index", pa.int64()), pa.field("color", pa.string())])),
+     pa.schema([pa.field("new-index", pa.int64()),
+                pa.field("color", pa.string())])),
 ]
 )
 def test_rename_columns(names, expected_schema):


### PR DESCRIPTION
### Rationale for this change

See https://github.com/apache/arrow/issues/36593
In particular this change is convenient when the column names stored in a file are different from the logical names associated with the columns (see deltalake column mapping feature as an example).

### What changes are included in this PR?

Adds the `rename_columns` method to datasets in pyarrow. 
This mehod allows a user to rename columns in the data returned from a scan before actually creating a scanner object.

### Are these changes tested?
This PR also add a test for the new `rename_columns` method using an InMemoryDataset. 

### Are there any user-facing changes?

Adds the `rename_columns` method to pyarrow datasets.
* GitHub Issue: #36593