### PR TITLE
GH-48292: [Ruby] Add `Arrow::Column#to_arrow{,_array,_chunked_array}`

### DIFF
--- a/ruby/red-arrow/lib/arrow/column.rb
+++ b/ruby/red-arrow/lib/arrow/column.rb
@@ -30,6 +30,18 @@ module Arrow
       @container.share_input(@data)
     end
 
+    def to_arrow
+      @data
+    end
+
+    def to_arrow_array
+      @data.to_arrow_array
+    end
+
+    def to_arrow_chunked_array
+      @data.to_arrow_chunked_array
+    end
+
     def name
       @field.name
     end

--- a/ruby/red-arrow/test/test-column.rb
+++ b/ruby/red-arrow/test/test-column.rb
@@ -21,6 +21,18 @@ class ColumnTest < Test::Unit::TestCase
     @column = table.visible
   end
 
+  test("#to_arrow") do
+    assert_equal(@column.data, @column.to_arrow)
+  end
+
+  test("#to_arrow_array") do
+    assert_equal(@column.data.chunks[0], @column.to_arrow_chunked_array)
+  end
+
+  test("#to_arrow_chunked_array") do
+    assert_equal(@column.data, @column.to_arrow_chunked_array)
+  end
+
   test("#name") do
     assert_equal("visible", @column.name)
   end


### PR DESCRIPTION
### Rationale for this change

If they exist, we can use `Arrow::Column` as `Arrow::Array`/`Arrow::ChunkedArray`. It's convenient.

### What changes are included in this PR?

* Add `Arrow::Column#to_arrow`
* Add `Arrow::Column#to_arrow_array`
* Add `Arrow::Column#to_arrow_chunked_array`

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #48292