### PR TITLE
GH-48295: [Ruby] Add support for reading Int8 array

### DIFF
--- a/ruby/red-arrow-format/lib/arrow-format/array.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/array.rb
@@ -15,17 +15,55 @@
 # under the License.
 
 module ArrowFormat
-  class UInt8Array
+  class Array
+    attr_reader :type
     attr_reader :size
-    def initialize(size, validity_buffer, values_buffer)
+    alias_method :length, :size
+    def initialize(type, size, validity_buffer, values_buffer)
+      @type = type
       @size = size
       @validity_buffer = validity_buffer
       @values_buffer = values_buffer
     end
 
+    def valid?(i)
+      return true if @validity_buffer.nil?
+      (@validity_buffer.get_value(:U8, i / 8) & (1 << (i % 8))) > 0
+    end
+
+    def null?(i)
+      not valid?(i)
+    end
+
+    private
+    def apply_validity(array)
+      return array if @validity_buffer.nil?
+      n_bytes = @size / 8
+      @validity_buffer.each(:U8, 0, n_bytes) do |offset, value|
+        7.times do |i|
+          array[offset * 8 + i] = nil if (value & (1 << (i % 8))).zero?
+        end
+      end
+      remained_bits = @size % 8
+      unless remained_bits.zero?
+        value = @validity_buffer.get_value(:U8, n_bytes)
+        remained_bits.times do |i|
+          array[n_bytes * 8 + i] = nil if (value & (1 << (i % 8))).zero?
+        end
+      end
+      array
+    end
+  end
+
+  class Int8Array < Array
     def to_a
-      # TODO: Check @validity_buffer
-      @values_buffer.values(:U8, 0, @size)
+      apply_validity(@values_buffer.values(:S8, 0, @size))
+    end
+  end
+
+  class UInt8Array < Array
+    def to_a
+      apply_validity(@values_buffer.values(:U8, 0, @size))
     end
   end
 end

--- a/ruby/red-arrow-format/lib/arrow-format/file-reader.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/file-reader.rb
@@ -132,9 +132,9 @@ module ArrowFormat
           case fb_type.bit_width
           when 8
             if fb_type.signed?
-              type = Int8Type.new
+              type = Int8Type.singleton
             else
-              type = UInt8Type.new
+              type = UInt8Type.singleton
             end
           end
         end
@@ -145,7 +145,8 @@ module ArrowFormat
 
     def read_column(field, n_rows, buffers, body)
       case field.type
-      when UInt8Type
+      when Int8Type,
+           UInt8Type
         validity_buffer = buffers.shift
         if validity_buffer.length.zero?
           validity = nil
@@ -155,7 +156,7 @@ module ArrowFormat
 
         values_buffer = buffers.shift
         values = body.slice(values_buffer.offset, values_buffer.length)
-        UInt8Array.new(n_rows, validity, values)
+        field.type.build_array(n_rows, validity, values)
       end
     end
   end

--- a/ruby/red-arrow-format/lib/arrow-format/type.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/type.rb
@@ -33,14 +33,34 @@ module ArrowFormat
   end
 
   class Int8Type < IntType
+    class << self
+      def singleton
+        @singleton ||= new
+      end
+    end
+
     def initialize
       super("Int8", 8, true)
+    end
+
+    def build_array(size, validity_buffer, values_buffer)
+      Int8Array.new(self, size, validity_buffer, values_buffer)
     end
   end
 
   class UInt8Type < IntType
+    class << self
+      def singleton
+        @singleton ||= new
+      end
+    end
+
     def initialize
       super("UInt8", 8, false)
+    end
+
+    def build_array(size, validity_buffer, values_buffer)
+      UInt8Array.new(self, size, validity_buffer, values_buffer)
     end
   end
 end

--- a/ruby/red-arrow-format/test/test-file-reader.rb
+++ b/ruby/red-arrow-format/test/test-file-reader.rb
@@ -18,7 +18,7 @@
 class TestFileReader < Test::Unit::TestCase
   def setup
     Dir.mktmpdir do |tmp_dir|
-      table = Arrow::Table.new(uint8: Arrow::UInt8Array.new([1, 2, 3]))
+      table = Arrow::Table.new(value: build_array)
       @path = File.join(tmp_dir, "data.arrow")
       table.save(@path)
       File.open(@path, "rb") do |input|
@@ -40,10 +40,25 @@ class TestFileReader < Test::Unit::TestCase
     end
   end
 
-  def test_uint8
-    assert_equal([
-                   {"uint8" => [1, 2, 3]},
-                 ],
-                 read)
+  sub_test_case("Int8") do
+    def build_array
+      Arrow::Int8Array.new([-128, nil, 127])
+    end
+
+    def test_read
+      assert_equal([{"value" => [-128, nil, 127]}],
+                   read)
+    end
+  end
+
+  sub_test_case("UInt8") do
+    def build_array
+      Arrow::UInt8Array.new([0, nil, 255])
+    end
+
+    def test_uint8
+      assert_equal([{"value" => [0, nil, 255]}],
+                   read)
+    end
   end
 end


### PR DESCRIPTION
### Rationale for this change

We already have UInt8 array support. So Int8 array support is easier than others.

### What changes are included in this PR?

* Add `ArrowFormat::UInt8Array`
* Add `ArrowFormat::Array`
  * Add support for parsing validity bitmap

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #48295