### PR TITLE
GH-45449: [R][CI] Remove OpenSSL 1.x builds

### DIFF
--- a/.github/workflows/r_nightly.yml
+++ b/.github/workflows/r_nightly.yml
@@ -172,13 +172,9 @@ jobs:
           done
 
           # New packages: repo/libarrow/${TARGET}-arrow-${VERSION}.zip
-          prune repo/libarrow/r-libarrow-darwin-arm64-openssl-1.1-* || :
-          prune repo/libarrow/r-libarrow-darwin-arm64-openssl-3.0-* || :
-          prune repo/libarrow/r-libarrow-darwin-x86_64-openssl-1.1-* || :
-          prune repo/libarrow/r-libarrow-darwin-x86_64-openssl-3.0-* || :
-          prune repo/libarrow/r-libarrow-linux-x86_64-openssl-1.0-* || :
-          prune repo/libarrow/r-libarrow-linux-x86_64-openssl-1.1-* || :
-          prune repo/libarrow/r-libarrow-linux-x86_64-openssl-3.0-* || :
+          prune repo/libarrow/r-libarrow-darwin-arm64-* || :
+          prune repo/libarrow/r-libarrow-darwin-x86_64-* || :
+          prune repo/libarrow/r-libarrow-linux-x86_64-* || :
           prune repo/libarrow/r-libarrow-windows-x86_64-* || :
       - name: Update Repository Index
         shell: Rscript {0}

--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -247,23 +247,19 @@ env:
       path: repo/libarrow
   {% endif %}
   {% if get_nix %}
-    {% for openssl_version in ["1.0", "1.1", "3.0"] %}
-  - name: Get Linux OpenSSL {{ openssl_version }} binary
+  - name: Get Linux OpenSSL 3.0 binary
     uses: actions/download-artifact@v4
     with:
-      name: r-libarrow-linux-x86_64-openssl-{{ openssl_version }}
+      name: r-libarrow-linux-x86_64-openssl-3.0
       path: repo/libarrow
-    {% endfor %}
   {% endif %}
   {% if get_mac %}
-    {% for openssl_version in ["1.1", "3.0"] %}
-      {% for arch in ["x86_64", "arm64"] %}
-  - name: Get macOS {{ arch }} OpenSSL {{ openssl_version }} binary
+    {% for arch in ["x86_64", "arm64"] %}
+  - name: Get macOS {{ arch }} OpenSSL 3.0 binary
     uses: actions/download-artifact@v4
     with:
-      name: r-libarrow-darwin-{{ arch }}-openssl-{{ openssl_version }}
+      name: r-libarrow-darwin-{{ arch }}-openssl-3.0
       path: repo/libarrow
-      {% endfor %}
     {% endfor %}
   {% endif %}
   - name: Get src pkg

--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -247,18 +247,18 @@ env:
       path: repo/libarrow
   {% endif %}
   {% if get_nix %}
-  - name: Get Linux OpenSSL 3.0 binary
+  - name: Get Linux binary
     uses: actions/download-artifact@v4
     with:
-      name: r-libarrow-linux-x86_64-openssl-3.0
+      name: r-libarrow-linux-x86_64
       path: repo/libarrow
   {% endif %}
   {% if get_mac %}
     {% for arch in ["x86_64", "arm64"] %}
-  - name: Get macOS {{ arch }} OpenSSL 3.0 binary
+  - name: Get macOS {{ arch }} binary
     uses: actions/download-artifact@v4
     with:
-      name: r-libarrow-darwin-{{ arch }}-openssl-3.0
+      name: r-libarrow-darwin-{{ arch }}
       path: repo/libarrow
     {% endfor %}
   {% endif %}

--- a/dev/tasks/r/github.packages.yml
+++ b/dev/tasks/r/github.packages.yml
@@ -66,17 +66,16 @@ jobs:
         platform:
           - { runs_on: macos-15-intel, arch: "x86_64" }
           - { runs_on: macos-14, arch: "arm64" }
-        openssl: ['3.0', '1.1']
     env:
-      PKG_ID: r-libarrow-darwin-{{ '${{ matrix.platform.arch }}' }}-openssl-{{ '${{ matrix.openssl }}' }}
-      PKG_FILE: r-libarrow-darwin-{{ '${{ matrix.platform.arch }}' }}-openssl-{{ '${{ matrix.openssl }}' }}-{{ '${{ needs.source.outputs.pkg_version }}' }}.zip
+      PKG_ID: r-libarrow-darwin-{{ '${{ matrix.platform.arch }}' }}-openssl-3.0
+      PKG_FILE: r-libarrow-darwin-{{ '${{ matrix.platform.arch }}' }}-openssl-3.0-{{ '${{ needs.source.outputs.pkg_version }}' }}.zip
     steps:
       {{ macros.github_checkout_arrow(action_v="3")|indent }}
       {{ macros.github_change_r_pkg_version(is_fork, '${{ needs.source.outputs.pkg_version }}')|indent }}
       - name: Install Deps
         run: |
           brew install sccache ninja
-          brew install openssl@{{ '${{ matrix.openssl }}' }}
+          brew install openssl@3.0
       - name: Build libarrow
         shell: bash
         env:
@@ -117,21 +116,9 @@ jobs:
     needs: source
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - openssl: "3.0"
-            os: ubuntu
-            ubuntu: "22.04"
-          - extra-cmake-flags: >-
-              -DCMAKE_INCLUDE_PATH=/usr/include/openssl11
-              -DCMAKE_LIBRARY_PATH=/usr/lib64/openssl11
-            openssl: "1.1"
-            os: centos
-          - openssl: "1.0"
-            os: centos
     env:
-      PKG_ID: r-libarrow-linux-x86_64-openssl-{{ '${{ matrix.openssl }}' }}
-      PKG_FILE: r-libarrow-linux-x86_64-openssl-{{ '${{ matrix.openssl }}' }}-{{ '${{ needs.source.outputs.pkg_version }}' }}.zip
+      PKG_ID: r-libarrow-linux-x86_64-openssl-3.0
+      PKG_FILE: r-libarrow-linux-x86_64-openssl-3.0-{{ '${{ needs.source.outputs.pkg_version }}' }}.zip
     steps:
       {{ macros.github_checkout_arrow()|indent }}
       {{ macros.github_change_r_pkg_version(is_fork, '${{ needs.source.outputs.pkg_version }}')|indent }}
@@ -139,13 +126,11 @@ jobs:
       - name: Build libarrow
         shell: bash
         env:
-          UBUNTU: {{ '"${{ matrix.ubuntu }}"' }}
+          UBUNTU: "22.04"
         {{ macros.github_set_sccache_envvars()|indent(8) }}
         run: |
           source arrow/ci/scripts/util_enable_core_dumps.sh
-          archery docker run \
-            -e EXTRA_CMAKE_FLAGS="{{ '${{ matrix.extra-cmake-flags }}' }}" \
-            {{ '${{ matrix.os }}' }}-cpp-static
+          archery docker run ubuntu-cpp-static
       - name: Bundle libarrow
         shell: bash
         run: |

--- a/dev/tasks/r/github.packages.yml
+++ b/dev/tasks/r/github.packages.yml
@@ -57,7 +57,7 @@ jobs:
           path: arrow/r/arrow_*.tar.gz
 
   macos-cpp:
-    name: C++ Binary macOS OpenSSL {{ '${{ matrix.openssl }}' }} {{ '${{ matrix.platform.arch }}' }}
+    name: C++ Binary macOS {{ '${{ matrix.platform.arch }}' }}
     runs-on: {{ '${{ matrix.platform.runs_on }}' }}
     needs: source
     strategy:
@@ -67,8 +67,8 @@ jobs:
           - { runs_on: macos-15-intel, arch: "x86_64" }
           - { runs_on: macos-14, arch: "arm64" }
     env:
-      PKG_ID: r-libarrow-darwin-{{ '${{ matrix.platform.arch }}' }}-openssl-3.0
-      PKG_FILE: r-libarrow-darwin-{{ '${{ matrix.platform.arch }}' }}-openssl-3.0-{{ '${{ needs.source.outputs.pkg_version }}' }}.zip
+      PKG_ID: r-libarrow-darwin-{{ '${{ matrix.platform.arch }}' }}
+      PKG_FILE: r-libarrow-darwin-{{ '${{ matrix.platform.arch }}' }}-{{ '${{ needs.source.outputs.pkg_version }}' }}.zip
     steps:
       {{ macros.github_checkout_arrow(action_v="3")|indent }}
       {{ macros.github_change_r_pkg_version(is_fork, '${{ needs.source.outputs.pkg_version }}')|indent }}
@@ -88,7 +88,7 @@ jobs:
           LIBARROW_MINIMAL: false
         run: |
           sccache --start-server
-          export EXTRA_CMAKE_FLAGS="-DOPENSSL_ROOT_DIR=$(brew --prefix openssl@{{ '${{ matrix.openssl }}' }})"
+          export EXTRA_CMAKE_FLAGS="-DOPENSSL_ROOT_DIR=$(brew --prefix openssl@3.0)"
           cd arrow
           r/inst/build_arrow_static.sh
       - name: Bundle libarrow
@@ -111,14 +111,14 @@ jobs:
             {{ '${{ env.PKG_FILE }}' }}.sha512
 
   linux-cpp:
-    name: C++ Binary Linux OpenSSL {{ '${{ matrix.openssl }}' }}
+    name: C++ Binary Linux
     runs-on: ubuntu-latest
     needs: source
     strategy:
       fail-fast: false
     env:
-      PKG_ID: r-libarrow-linux-x86_64-openssl-3.0
-      PKG_FILE: r-libarrow-linux-x86_64-openssl-3.0-{{ '${{ needs.source.outputs.pkg_version }}' }}.zip
+      PKG_ID: r-libarrow-linux-x86_64
+      PKG_FILE: r-libarrow-linux-x86_64-{{ '${{ needs.source.outputs.pkg_version }}' }}.zip
     steps:
       {{ macros.github_checkout_arrow()|indent }}
       {{ macros.github_change_r_pkg_version(is_fork, '${{ needs.source.outputs.pkg_version }}')|indent }}

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -283,9 +283,9 @@ tasks:
       custom_version: Unset
     artifacts:
       - r-libarrow-windows-x86_64-{no_rc_r_version}\.zip
-      - r-libarrow-linux-x86_64-openssl-3.0-{no_rc_r_version}\.zip
-      - r-libarrow-darwin-arm64-openssl-3.0-{no_rc_r_version}\.zip
-      - r-libarrow-darwin-x86_64-openssl-3.0-{no_rc_r_version}\.zip
+      - r-libarrow-linux-x86_64-{no_rc_r_version}\.zip
+      - r-libarrow-darwin-arm64-{no_rc_r_version}\.zip
+      - r-libarrow-darwin-x86_64-{no_rc_r_version}\.zip
       - r-pkg__bin__windows__contrib__4.5__arrow_{no_rc_r_version}\.zip
       - r-pkg__bin__windows__contrib__4.4__arrow_{no_rc_r_version}\.zip
       - r-pkg__bin__macosx__big-sur-x86_64__contrib__4.5__arrow_{no_rc_r_version}\.tgz

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -283,12 +283,8 @@ tasks:
       custom_version: Unset
     artifacts:
       - r-libarrow-windows-x86_64-{no_rc_r_version}\.zip
-      - r-libarrow-linux-x86_64-openssl-1.0-{no_rc_r_version}\.zip
-      - r-libarrow-linux-x86_64-openssl-1.1-{no_rc_r_version}\.zip
       - r-libarrow-linux-x86_64-openssl-3.0-{no_rc_r_version}\.zip
-      - r-libarrow-darwin-arm64-openssl-1.1-{no_rc_r_version}\.zip
       - r-libarrow-darwin-arm64-openssl-3.0-{no_rc_r_version}\.zip
-      - r-libarrow-darwin-x86_64-openssl-1.1-{no_rc_r_version}\.zip
       - r-libarrow-darwin-x86_64-openssl-3.0-{no_rc_r_version}\.zip
       - r-pkg__bin__windows__contrib__4.5__arrow_{no_rc_r_version}\.zip
       - r-pkg__bin__windows__contrib__4.4__arrow_{no_rc_r_version}\.zip

--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -223,6 +223,17 @@ identify_binary <- function(lib = Sys.getenv("LIBARROW_BINARY"), info = distro()
     # Env var provided an os-version to use, to override our logic.
     # We don't validate that this exists. If it doesn't, the download will fail
     # and the build will fall back to building from source
+    if (grepl("openssl-1", lib)) {
+      stop(
+        "OpenSSL 1.x binaries are no longer provided. Use LIBARROW_BINARY='",
+        sub("-openssl-1.*$", "", lib),
+        "'"
+      )
+    }
+    if (grepl("openssl-3", lib)) {
+      lib <- sub("-openssl-3.*$", "", lib)
+      lg("OpenSSL suffix deprecated in LIBARROW_BINARY, using '%s'", lib)
+    }
   } else {
     # See if we can find a suitable binary
     lib <- select_binary()

--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -340,11 +340,11 @@ has_binary_sysreqs <- function(errs) {
     lg("OpenSSL not found")
     return(FALSE)
   } else if (any(grepl("OpenSSL version must be 3.0 or greater", errs))) {
-    lg("OpenSSL found but version >= 3.0.0 is required")
+    lg("OpenSSL found but version >= 3.0 is required")
     return(FALSE)
   } else if (is.null(attr(errs, "status"))) {
     # Successful compile = OpenSSL >= 3.0 found
-    lg("Found libcurl and OpenSSL >= 3.0.0")
+    lg("Found libcurl and OpenSSL >= 3.0")
     return(TRUE)
   }
   FALSE

--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -256,7 +256,7 @@ select_binary <- function(
       # so globally handle the possibility that this could fail
       {
         errs <- compile_test_program(test_program)
-        if (has_curl_and_openssl(errs)) {
+        if (has_binary_sysreqs(errs)) {
           paste0(os, "-", arch)
         } else {
           NULL
@@ -327,8 +327,7 @@ get_macos_openssl_dir <- function() {
   openssl_root_dir
 }
 
-# (built with newer devtoolset but older glibc (2.17) for broader compatibility, like manylinux2014)
-has_curl_and_openssl <- function(errs) {
+has_binary_sysreqs <- function(errs) {
   # Check for dealbreakers:
   if (!on_macos && any(grepl("Using libc++", errs, fixed = TRUE))) {
     # Our linux binaries are all built with GNU stdlib so they fail with libc++

--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -292,9 +292,6 @@ test_for_curl_and_openssl <- "
 #if OPENSSL_VERSION_NUMBER < 0x30000000L
 #error OpenSSL version must be 3.0 or greater
 #endif
-#if OPENSSL_VERSION_NUMBER >= 0x30000000L
-#error Using OpenSSL version 3
-#endif
 "
 
 compile_test_program <- function(code) {
@@ -348,8 +345,8 @@ determine_binary_from_stderr <- function(errs) {
   } else if (any(grepl("OpenSSL version must be 3.0 or greater", errs))) {
     lg("OpenSSL found but version >= 3.0.0 is required")
     return(NULL)
-  } else if (any(grepl("Using OpenSSL version 3", errs)) || is.null(attr(errs, "status"))) {
-    # Either explicitly found OpenSSL 3, or no error (assumes OpenSSL 3+)
+  } else if (is.null(attr(errs, "status"))) {
+    # Successful compile = OpenSSL >= 3.0 found
     lg("Found libcurl and OpenSSL >= 3.0.0")
     return("openssl-3.0")
   }

--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -289,11 +289,8 @@ test_for_curl_and_openssl <- "
 
 #include <curl/curl.h>
 #include <openssl/opensslv.h>
-#if OPENSSL_VERSION_NUMBER < 0x10002000L
-#error OpenSSL version too old
-#endif
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-#error Using OpenSSL version 1.0
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
+#error OpenSSL version must be 3.0 or greater
 #endif
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
 #error Using OpenSSL version 3
@@ -348,10 +345,7 @@ determine_binary_from_stderr <- function(errs) {
   } else if (header_not_found("openssl/opensslv", errs)) {
     lg("OpenSSL not found")
     return(NULL)
-  } else if (
-    any(grepl("OpenSSL version too old", errs)) ||
-      any(grepl("Using OpenSSL version 1\\.", errs))
-  ) {
+  } else if (any(grepl("OpenSSL version must be 3.0 or greater", errs))) {
     lg("OpenSSL found but version >= 3.0.0 is required")
     return(NULL)
   } else if (any(grepl("Using OpenSSL version 3", errs)) || is.null(attr(errs, "status"))) {

--- a/r/tools/test-nixlibs.R
+++ b/r/tools/test-nixlibs.R
@@ -70,7 +70,7 @@ test_that("has_binary_sysreqs", {
     expect_true(
       has_binary_sysreqs(character(0)) # Successful compile = OpenSSL >= 3.0
     ),
-    "Found libcurl and OpenSSL >= 3.0.0"
+    "Found libcurl and OpenSSL >= 3.0"
   )
 })
 
@@ -81,20 +81,24 @@ test_that("select_binary() with test program", {
       select_binary("linux", "x86_64", "int a;"),
       "linux-x86_64"
     ),
-    "Found libcurl and OpenSSL >= 3.0.0"
+    "Found libcurl and OpenSSL >= 3.0"
   )
   expect_output(
     expect_null(
-      select_binary("linux", "x86_64", "#error OpenSSL version must be 3.0 or greater")
+      select_binary(
+        "linux",
+        "x86_64",
+        "#error OpenSSL version must be 3.0 or greater"
+      )
     ),
-    "OpenSSL found but version >= 3.0.0 is required"
+    "OpenSSL found but version >= 3.0 is required"
   )
   expect_output(
     expect_identical(
       select_binary("linux", "x86_64", character(0)), # Successful compile = OpenSSL >= 3.0
       "linux-x86_64"
     ),
-    "Found libcurl and OpenSSL >= 3.0.0"
+    "Found libcurl and OpenSSL >= 3.0"
   )
   nixlibs_env$on_macos <- TRUE
   expect_output(
@@ -102,34 +106,38 @@ test_that("select_binary() with test program", {
       select_binary("darwin", "x86_64", "int a;"),
       "darwin-x86_64"
     ),
-    "Found libcurl and OpenSSL >= 3.0.0"
+    "Found libcurl and OpenSSL >= 3.0"
   )
   expect_output(
     expect_identical(
       select_binary("darwin", "x86_64", character(0)), # Successful compile = OpenSSL >= 3.0
       "darwin-x86_64"
     ),
-    "Found libcurl and OpenSSL >= 3.0.0"
+    "Found libcurl and OpenSSL >= 3.0"
   )
   expect_output(
     expect_identical(
       select_binary("darwin", "arm64", "int a;"),
       "darwin-arm64"
     ),
-    "Found libcurl and OpenSSL >= 3.0.0"
+    "Found libcurl and OpenSSL >= 3.0"
   )
   expect_output(
     expect_identical(
       select_binary("darwin", "arm64", character(0)), # Successful compile = OpenSSL >= 3.0
       "darwin-arm64"
     ),
-    "Found libcurl and OpenSSL >= 3.0.0"
+    "Found libcurl and OpenSSL >= 3.0"
   )
   expect_output(
     expect_null(
-      select_binary("darwin", "x86_64", "#error OpenSSL version must be 3.0 or greater")
+      select_binary(
+        "darwin",
+        "x86_64",
+        "#error OpenSSL version must be 3.0 or greater"
+      )
     ),
-    "OpenSSL found but version >= 3.0.0 is required"
+    "OpenSSL found but version >= 3.0 is required"
   )
 })
 

--- a/r/tools/test-nixlibs.R
+++ b/r/tools/test-nixlibs.R
@@ -29,8 +29,8 @@ capture.output(source("nixlibs.R", local = nixlibs_env))
 test_that("identify_binary() based on LIBARROW_BINARY", {
   expect_null(identify_binary("FALSE"))
   expect_identical(
-    identify_binary("linux-x86_64-openssl-1.0"),
-    "linux-x86_64-openssl-1.0"
+    identify_binary("linux-x86_64-openssl-3.0"),
+    "linux-x86_64-openssl-3.0"
   )
   expect_null(identify_binary("", info = list(id = "debian")))
 })
@@ -53,25 +53,23 @@ test_that("determine_binary_from_stderr", {
   expect_output(
     expect_identical(
       determine_binary_from_stderr(compile_test_program("int a;")),
-      "openssl-1.1"
+      "openssl-3.0"
     ),
-    "Found libcurl and OpenSSL >= 1.1"
+    "Found libcurl and OpenSSL >= 3.0.0"
   )
 
   nixlibs_env$on_macos <- FALSE
   expect_output(
-    expect_identical(
-      determine_binary_from_stderr(compile_test_program("#error Using OpenSSL version 1.0")),
-      "openssl-1.0"
-    ),
-    "Found libcurl and OpenSSL < 1.1"
-  )
-  nixlibs_env$on_macos <- TRUE
-  expect_output(
     expect_null(
       determine_binary_from_stderr(compile_test_program("#error Using OpenSSL version 1.0"))
     ),
-    "OpenSSL 1.0 is not supported on macOS"
+    "OpenSSL found but version >= 3.0.0 is required"
+  )
+  expect_output(
+    expect_null(
+      determine_binary_from_stderr(compile_test_program("#error Using OpenSSL version 1.1"))
+    ),
+    "OpenSSL found but version >= 3.0.0 is required"
   )
   expect_output(
     expect_identical(
@@ -84,7 +82,7 @@ test_that("determine_binary_from_stderr", {
     expect_null(
       determine_binary_from_stderr(compile_test_program("#error OpenSSL version too old"))
     ),
-    "OpenSSL found but version >= 1.0.2 is required for some features"
+    "OpenSSL found but version >= 3.0.0 is required"
   )
 })
 
@@ -93,16 +91,15 @@ test_that("select_binary() with test program", {
   expect_output(
     expect_identical(
       select_binary("linux", "x86_64", "int a;"),
-      "linux-x86_64-openssl-1.1"
+      "linux-x86_64-openssl-3.0"
     ),
-    "Found libcurl and OpenSSL >= 1.1"
+    "Found libcurl and OpenSSL >= 3.0.0"
   )
   expect_output(
-    expect_identical(
-      select_binary("linux", "x86_64", "#error Using OpenSSL version 1.0"),
-      "linux-x86_64-openssl-1.0"
+    expect_null(
+      select_binary("linux", "x86_64", "#error Using OpenSSL version 1.0")
     ),
-    "Found libcurl and OpenSSL < 1.1"
+    "OpenSSL found but version >= 3.0.0 is required"
   )
   expect_output(
     expect_identical(
@@ -115,9 +112,9 @@ test_that("select_binary() with test program", {
   expect_output(
     expect_identical(
       select_binary("darwin", "x86_64", "int a;"),
-      "darwin-x86_64-openssl-1.1"
+      "darwin-x86_64-openssl-3.0"
     ),
-    "Found libcurl and OpenSSL >= 1.1"
+    "Found libcurl and OpenSSL >= 3.0.0"
   )
   expect_output(
     expect_identical(
@@ -129,9 +126,9 @@ test_that("select_binary() with test program", {
   expect_output(
     expect_identical(
       select_binary("darwin", "arm64", "int a;"),
-      "darwin-arm64-openssl-1.1"
+      "darwin-arm64-openssl-3.0"
     ),
-    "Found libcurl and OpenSSL >= 1.1"
+    "Found libcurl and OpenSSL >= 3.0.0"
   )
   expect_output(
     expect_identical(
@@ -144,7 +141,7 @@ test_that("select_binary() with test program", {
     expect_null(
       select_binary("darwin", "x86_64", "#error Using OpenSSL version 1.0")
     ),
-    "OpenSSL 1.0 is not supported on macOS"
+    "OpenSSL found but version >= 3.0.0 is required"
   )
 })
 

--- a/r/tools/test-nixlibs.R
+++ b/r/tools/test-nixlibs.R
@@ -73,7 +73,7 @@ test_that("determine_binary_from_stderr", {
   )
   expect_output(
     expect_identical(
-      determine_binary_from_stderr(compile_test_program("#error Using OpenSSL version 3")),
+      determine_binary_from_stderr(character(0)), # Successful compile = OpenSSL >= 3.0
       "openssl-3.0"
     ),
     "Found libcurl and OpenSSL >= 3.0.0"
@@ -103,8 +103,8 @@ test_that("select_binary() with test program", {
   )
   expect_output(
     expect_identical(
-      select_binary("linux", "x86_64", "#error Using OpenSSL version 3"),
-      "linux-x86_64-openssl-3.0"
+      select_binary("linux", "x86_64", character(0)), # Successful compile = OpenSSL >= 3.0
+      "linux-x86_64"
     ),
     "Found libcurl and OpenSSL >= 3.0.0"
   )
@@ -118,8 +118,8 @@ test_that("select_binary() with test program", {
   )
   expect_output(
     expect_identical(
-      select_binary("darwin", "x86_64", "#error Using OpenSSL version 3"),
-      "darwin-x86_64-openssl-3.0"
+      select_binary("darwin", "x86_64", character(0)), # Successful compile = OpenSSL >= 3.0
+      "darwin-x86_64"
     ),
     "Found libcurl and OpenSSL >= 3.0.0"
   )
@@ -132,8 +132,8 @@ test_that("select_binary() with test program", {
   )
   expect_output(
     expect_identical(
-      select_binary("darwin", "arm64", "#error Using OpenSSL version 3"),
-      "darwin-arm64-openssl-3.0"
+      select_binary("darwin", "arm64", character(0)), # Successful compile = OpenSSL >= 3.0
+      "darwin-arm64"
     ),
     "Found libcurl and OpenSSL >= 3.0.0"
   )

--- a/r/tools/test-nixlibs.R
+++ b/r/tools/test-nixlibs.R
@@ -69,7 +69,7 @@ test_that("has_binary_sysreqs", {
     expect_true(
       has_binary_sysreqs(compile_test_program("int a;"))
     ),
-    "Found libcurl and OpenSSL >= 3.0.0"
+    "Found libcurl and OpenSSL >= 3.0",
   )
 
   nixlibs_env$on_macos <- FALSE
@@ -79,7 +79,7 @@ test_that("has_binary_sysreqs", {
         "#error OpenSSL version must be 3.0 or greater"
       ))
     ),
-    "OpenSSL found but version >= 3.0.0 is required"
+    "OpenSSL found but version >= 3.0 is required"
   )
 })
 

--- a/r/tools/test-nixlibs.R
+++ b/r/tools/test-nixlibs.R
@@ -33,6 +33,21 @@ test_that("identify_binary() based on LIBARROW_BINARY", {
     "linux-x86_64"
   )
   expect_null(identify_binary("", info = list(id = "debian")))
+
+  expect_output(
+    expect_identical(
+      identify_binary("linux-x86_64-openssl-3.0"),
+      "linux-x86_64"
+    ),
+    "OpenSSL suffix deprecated in LIBARROW_BINARY, using 'linux-x86_64'",
+    fixed = TRUE
+  )
+
+  expect_error(
+    identify_binary("linux-x86_64-openssl-1.0"),
+    "OpenSSL 1.x binaries are no longer provided. Use LIBARROW_BINARY='linux-x86_64'",
+    fixed = TRUE
+  )
 })
 
 test_that("select_binary() based on system", {

--- a/r/tools/test-nixlibs.R
+++ b/r/tools/test-nixlibs.R
@@ -60,13 +60,7 @@ test_that("has_curl_and_openssl", {
   nixlibs_env$on_macos <- FALSE
   expect_output(
     expect_false(
-      has_curl_and_openssl(compile_test_program("#error Using OpenSSL version 1.0"))
-    ),
-    "OpenSSL found but version >= 3.0.0 is required"
-  )
-  expect_output(
-    expect_false(
-      has_curl_and_openssl(compile_test_program("#error Using OpenSSL version 1.1"))
+      has_curl_and_openssl(compile_test_program("#error OpenSSL version must be 3.0 or greater"))
     ),
     "OpenSSL found but version >= 3.0.0 is required"
   )
@@ -75,12 +69,6 @@ test_that("has_curl_and_openssl", {
       has_curl_and_openssl(character(0)) # Successful compile = OpenSSL >= 3.0
     ),
     "Found libcurl and OpenSSL >= 3.0.0"
-  )
-  expect_output(
-    expect_false(
-      has_curl_and_openssl(compile_test_program("#error OpenSSL version too old"))
-    ),
-    "OpenSSL found but version >= 3.0.0 is required"
   )
 })
 
@@ -95,7 +83,7 @@ test_that("select_binary() with test program", {
   )
   expect_output(
     expect_null(
-      select_binary("linux", "x86_64", "#error Using OpenSSL version 1.0")
+      select_binary("linux", "x86_64", "#error OpenSSL version must be 3.0 or greater")
     ),
     "OpenSSL found but version >= 3.0.0 is required"
   )
@@ -137,7 +125,7 @@ test_that("select_binary() with test program", {
   )
   expect_output(
     expect_null(
-      select_binary("darwin", "x86_64", "#error Using OpenSSL version 1.0")
+      select_binary("darwin", "x86_64", "#error OpenSSL version must be 3.0 or greater")
     ),
     "OpenSSL found but version >= 3.0.0 is required"
   )

--- a/r/tools/test-nixlibs.R
+++ b/r/tools/test-nixlibs.R
@@ -66,12 +66,6 @@ test_that("has_binary_sysreqs", {
     ),
     "OpenSSL found but version >= 3.0.0 is required"
   )
-  expect_output(
-    expect_true(
-      has_binary_sysreqs(character(0)) # Successful compile = OpenSSL >= 3.0
-    ),
-    "Found libcurl and OpenSSL >= 3.0"
-  )
 })
 
 test_that("select_binary() with test program", {

--- a/r/tools/test-nixlibs.R
+++ b/r/tools/test-nixlibs.R
@@ -49,10 +49,10 @@ test_that("compile_test_program()", {
   expect_true(header_not_found("wrong/NOTAHEADER", fail))
 })
 
-test_that("has_curl_and_openssl", {
+test_that("has_binary_sysreqs", {
   expect_output(
     expect_true(
-      has_curl_and_openssl(compile_test_program("int a;"))
+      has_binary_sysreqs(compile_test_program("int a;"))
     ),
     "Found libcurl and OpenSSL >= 3.0.0"
   )
@@ -60,13 +60,15 @@ test_that("has_curl_and_openssl", {
   nixlibs_env$on_macos <- FALSE
   expect_output(
     expect_false(
-      has_curl_and_openssl(compile_test_program("#error OpenSSL version must be 3.0 or greater"))
+      has_binary_sysreqs(compile_test_program(
+        "#error OpenSSL version must be 3.0 or greater"
+      ))
     ),
     "OpenSSL found but version >= 3.0.0 is required"
   )
   expect_output(
     expect_true(
-      has_curl_and_openssl(character(0)) # Successful compile = OpenSSL >= 3.0
+      has_binary_sysreqs(character(0)) # Successful compile = OpenSSL >= 3.0
     ),
     "Found libcurl and OpenSSL >= 3.0.0"
   )

--- a/r/tools/test-nixlibs.R
+++ b/r/tools/test-nixlibs.R
@@ -29,8 +29,8 @@ capture.output(source("nixlibs.R", local = nixlibs_env))
 test_that("identify_binary() based on LIBARROW_BINARY", {
   expect_null(identify_binary("FALSE"))
   expect_identical(
-    identify_binary("linux-x86_64-openssl-3.0"),
-    "linux-x86_64-openssl-3.0"
+    identify_binary("linux-x86_64"),
+    "linux-x86_64"
   )
   expect_null(identify_binary("", info = list(id = "debian")))
 })
@@ -49,38 +49,36 @@ test_that("compile_test_program()", {
   expect_true(header_not_found("wrong/NOTAHEADER", fail))
 })
 
-test_that("determine_binary_from_stderr", {
+test_that("has_curl_and_openssl", {
   expect_output(
-    expect_identical(
-      determine_binary_from_stderr(compile_test_program("int a;")),
-      "openssl-3.0"
+    expect_true(
+      has_curl_and_openssl(compile_test_program("int a;"))
     ),
     "Found libcurl and OpenSSL >= 3.0.0"
   )
 
   nixlibs_env$on_macos <- FALSE
   expect_output(
-    expect_null(
-      determine_binary_from_stderr(compile_test_program("#error Using OpenSSL version 1.0"))
+    expect_false(
+      has_curl_and_openssl(compile_test_program("#error Using OpenSSL version 1.0"))
     ),
     "OpenSSL found but version >= 3.0.0 is required"
   )
   expect_output(
-    expect_null(
-      determine_binary_from_stderr(compile_test_program("#error Using OpenSSL version 1.1"))
+    expect_false(
+      has_curl_and_openssl(compile_test_program("#error Using OpenSSL version 1.1"))
     ),
     "OpenSSL found but version >= 3.0.0 is required"
   )
   expect_output(
-    expect_identical(
-      determine_binary_from_stderr(character(0)), # Successful compile = OpenSSL >= 3.0
-      "openssl-3.0"
+    expect_true(
+      has_curl_and_openssl(character(0)) # Successful compile = OpenSSL >= 3.0
     ),
     "Found libcurl and OpenSSL >= 3.0.0"
   )
   expect_output(
-    expect_null(
-      determine_binary_from_stderr(compile_test_program("#error OpenSSL version too old"))
+    expect_false(
+      has_curl_and_openssl(compile_test_program("#error OpenSSL version too old"))
     ),
     "OpenSSL found but version >= 3.0.0 is required"
   )
@@ -91,7 +89,7 @@ test_that("select_binary() with test program", {
   expect_output(
     expect_identical(
       select_binary("linux", "x86_64", "int a;"),
-      "linux-x86_64-openssl-3.0"
+      "linux-x86_64"
     ),
     "Found libcurl and OpenSSL >= 3.0.0"
   )
@@ -112,7 +110,7 @@ test_that("select_binary() with test program", {
   expect_output(
     expect_identical(
       select_binary("darwin", "x86_64", "int a;"),
-      "darwin-x86_64-openssl-3.0"
+      "darwin-x86_64"
     ),
     "Found libcurl and OpenSSL >= 3.0.0"
   )
@@ -126,7 +124,7 @@ test_that("select_binary() with test program", {
   expect_output(
     expect_identical(
       select_binary("darwin", "arm64", "int a;"),
-      "darwin-arm64-openssl-3.0"
+      "darwin-arm64"
     ),
     "Found libcurl and OpenSSL >= 3.0.0"
   )


### PR DESCRIPTION
### Rationale for this change

We support old OpenSSL versions which are now deprecated.  It complicates our CI by having unnecessary things running too.

### What changes are included in this PR?

Stop supporting OpenSSL < 3.0

### Are these changes tested?

Will trigger CI

### Are there any user-facing changes?

Not unless they're using deprecated versions of OpenSSL, which isn't something we should support anyway

* GitHub Issue: #45449