### PR TITLE
MINOR: [C++][Parquet] Fix *_write_page_index and set_size_statistics_level comments

### DIFF
--- a/cpp/src/parquet/properties.h
+++ b/cpp/src/parquet/properties.h
@@ -700,7 +700,7 @@ class PARQUET_EXPORT WriterProperties {
       return this;
     }
 
-    /// Enable writing page index in general for all columns. Default disabled.
+    /// Enable writing page index in general for all columns. Default enabled.
     ///
     /// Writing statistics to the page index disables the old method of writing
     /// statistics to each data page header.
@@ -715,35 +715,35 @@ class PARQUET_EXPORT WriterProperties {
       return this;
     }
 
-    /// Disable writing page index in general for all columns. Default disabled.
+    /// Disable writing page index in general for all columns. Default enabled.
     Builder* disable_write_page_index() {
       default_column_properties_.set_page_index_enabled(false);
       return this;
     }
 
-    /// Enable writing page index for column specified by `path`. Default disabled.
+    /// Enable writing page index for column specified by `path`. Default enabled.
     Builder* enable_write_page_index(const std::string& path) {
       page_index_enabled_[path] = true;
       return this;
     }
 
-    /// Enable writing page index for column specified by `path`. Default disabled.
+    /// Enable writing page index for column specified by `path`. Default enabled.
     Builder* enable_write_page_index(const std::shared_ptr<schema::ColumnPath>& path) {
       return this->enable_write_page_index(path->ToDotString());
     }
 
-    /// Disable writing page index for column specified by `path`. Default disabled.
+    /// Disable writing page index for column specified by `path`. Default enabled.
     Builder* disable_write_page_index(const std::string& path) {
       page_index_enabled_[path] = false;
       return this;
     }
 
-    /// Disable writing page index for column specified by `path`. Default disabled.
+    /// Disable writing page index for column specified by `path`. Default enabled.
     Builder* disable_write_page_index(const std::shared_ptr<schema::ColumnPath>& path) {
       return this->disable_write_page_index(path->ToDotString());
     }
 
-    /// \brief Set the level to write size statistics for all columns. Default is None.
+    /// \brief Set the level to write size statistics for all columns. Default is PageAndColumnChunk.
     ///
     /// \param level The level to write size statistics. Note that if page index is not
     /// enabled, page level size statistics will not be written even if the level

--- a/cpp/src/parquet/properties.h
+++ b/cpp/src/parquet/properties.h
@@ -743,7 +743,8 @@ class PARQUET_EXPORT WriterProperties {
       return this->disable_write_page_index(path->ToDotString());
     }
 
-    /// \brief Set the level to write size statistics for all columns. Default is PageAndColumnChunk.
+    /// \brief Set the level to write size statistics for all columns. Default is
+    /// PageAndColumnChunk.
     ///
     /// \param level The level to write size statistics. Note that if page index is not
     /// enabled, page level size statistics will not be written even if the level


### PR DESCRIPTION
### Rationale for this change

Defaults were changed in this commit https://github.com/apache/arrow/commit/1fcc89240db4fe0ad798498e7410668423846118

### What changes are included in this PR?

Fixed comments about default values of some writer properties

### Are these changes tested?

No need to test

### Are there any user-facing changes?

No
