### PR TITLE
GH-48303: [CI] Remove needless `setup-dotnet` from `.github/workflows/dev.yml`

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -99,10 +99,6 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ruby
-      - name: Install .NET
-        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4.3.1
-        with:
-          dotnet-version: '8.0.x'
       - name: Install Dependencies
         shell: bash
         run: |


### PR DESCRIPTION
### Rationale for this change

It's no longer needed because we split `csharp/` to apache/arrow-dotnet.

### What changes are included in this PR?

Remove `setup-dotnet`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #48303