### PR TITLE
GH-48306: [Ruby] Add support for reading binary array

### DIFF
--- a/ruby/red-arrow-format/lib/arrow-format/type.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/type.rb
@@ -63,4 +63,21 @@ module ArrowFormat
       UInt8Array.new(self, size, validity_buffer, values_buffer)
     end
   end
+
+  class BinaryType < Type
+    class << self
+      def singleton
+        @singleton ||= new
+      end
+    end
+
+    attr_reader :name
+    def initialize
+      super("Binary")
+    end
+
+    def build_array(size, validity_buffer, offsets_buffer, values_buffer)
+      BinaryArray.new(self, size, validity_buffer, offsets_buffer, values_buffer)
+    end
+  end
 end

--- a/ruby/red-arrow-format/test/test-file-reader.rb
+++ b/ruby/red-arrow-format/test/test-file-reader.rb
@@ -56,8 +56,19 @@ class TestFileReader < Test::Unit::TestCase
       Arrow::UInt8Array.new([0, nil, 255])
     end
 
-    def test_uint8
+    def test_read
       assert_equal([{"value" => [0, nil, 255]}],
+                   read)
+    end
+  end
+
+  sub_test_case("Binary") do
+    def build_array
+      Arrow::BinaryArray.new(["Hello".b, nil, "World".b])
+    end
+
+    def test_read
+      assert_equal([{"value" => ["Hello".b, nil, "World".b]}],
                    read)
     end
   end


### PR DESCRIPTION
### Rationale for this change

We can use this as a base feature for UTF-8/large binary/large UTF-8 array.

### What changes are included in this PR?

* Add `ArrowFormat::BinaryType`
* Add `ArrowFormat::BinaryArray`
* Add support `Binary` FlatBuffers type

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #48306