### PR TITLE
GH-48308: [C++][Parquet] Fix potential crash when reading invalid Parquet data

### DIFF
--- a/cpp/src/parquet/decoder.cc
+++ b/cpp/src/parquet/decoder.cc
@@ -776,8 +776,8 @@ class PlainByteArrayDecoder : public PlainDecoder<ByteArrayType> {
             // This precondition follows from those two checks.
             DCHECK_GE(len_, 4);
             auto value_len = SafeLoadAs<int32_t>(data_);
-            // `value_len <= estimated_data_length` is stricter than `value_len <= len_ - 4`
-            // due to the way `estimated_data_length` is computed.
+            // This check also ensures that `value_len <= len_ - 4` due to the way
+            // `estimated_data_length` is computed.
             if (ARROW_PREDICT_FALSE(value_len < 0 || value_len > estimated_data_length)) {
               return Status::Invalid(
                   "Invalid or truncated PLAIN-encoded BYTE_ARRAY data");

--- a/cpp/src/parquet/decoder.cc
+++ b/cpp/src/parquet/decoder.cc
@@ -776,6 +776,8 @@ class PlainByteArrayDecoder : public PlainDecoder<ByteArrayType> {
             // This precondition follows from those two checks.
             DCHECK_GE(len_, 4);
             auto value_len = SafeLoadAs<int32_t>(data_);
+            // `value_len <= estimated_data_length` is stricter than `value_len <= len_ - 4`
+            // due to the way `estimated_data_length` is computed.
             if (ARROW_PREDICT_FALSE(value_len < 0 || value_len > estimated_data_length)) {
               return Status::Invalid(
                   "Invalid or truncated PLAIN-encoded BYTE_ARRAY data");
@@ -789,6 +791,7 @@ class PlainByteArrayDecoder : public PlainDecoder<ByteArrayType> {
             DCHECK_GE(estimated_data_length, 0);
           }
           values_decoded += static_cast<int>(run_length);
+          DCHECK_LE(values_decoded, num_values);
           return Status::OK();
         } else {
           return helper->AppendNulls(run_length);

--- a/cpp/src/parquet/decoder.cc
+++ b/cpp/src/parquet/decoder.cc
@@ -144,11 +144,7 @@ struct ArrowBinaryHelper<ByteArrayType, ::arrow::BinaryType> {
     if (estimated_remaining_data_length.has_value()) {
       int64_t required_capacity =
           std::min(*estimated_remaining_data_length, chunk_space_remaining_);
-      // Ensure we'll be allocating a non-zero-sized data buffer, to avoid encountering
-      // a null pointer
-      constexpr int64_t kMinReserveCapacity = 64;
-      RETURN_NOT_OK(
-          builder_->ReserveData(std::max(required_capacity, kMinReserveCapacity)));
+      RETURN_NOT_OK(builder_->ReserveData(required_capacity));
     }
     return Status::OK();
   }


### PR DESCRIPTION
### Rationale for this change

1. Make value length validation stricter in PLAIN decoding of BYTE_ARRAY columns.
2. Ensure BinaryBuilder always reserves a non-zero data length, to avoid encountering a null data pointer when unsafe-appending values.

This should fix https://oss-fuzz.com/testcase-detail/4570087119192064

### Are these changes tested?

Yes, by additional fuzz regression file.

### Are there any user-facing changes?

No.

**This PR contains a "Critical Fix".** (If the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld), please provide explanation. If not, you can remove this.)

* GitHub Issue: #48308