### PR TITLE
GH-48315: [C++] Use FetchContent for bundled CRC32C

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -3392,8 +3392,8 @@ endif()
 # GCS and dependencies
 
 function(build_crc32c_once)
-  list(APPEND CMAKE_MESSAGE_INDENT "crc32c: ")
-  message(STATUS "Building crc32c from source using FetchContent")
+  list(APPEND CMAKE_MESSAGE_INDENT "CRC32C: ")
+  message(STATUS "Building CRC32C from source using FetchContent")
   set(CRC32C_VENDORED
       TRUE
       PARENT_SCOPE)


### PR DESCRIPTION
### Rationale for this change

As a follow up of requiring a minimum CMake version >= 3.25 we discussed moving our dependencies from ExternalProject to FetchContent. This can simplify our third party dependency management.

### What changes are included in this PR?

The general change is moving CRC32C from `ExternalProject` to `FetchContent`. 

We will be able to clean up installation once google-cloud-cpp is also migated.

### Are these changes tested?

Yes, the changes are tested locally and on CI.

### Are there any user-facing changes?

No
* GitHub Issue: #48315