### PR TITLE
GH-48314: [Python] Compat with pandas 3.0 changed default datetime unit

### DIFF
--- a/python/pyarrow/pandas_compat.py
+++ b/python/pyarrow/pandas_compat.py
@@ -140,7 +140,7 @@ def get_extension_dtype_info(column):
         physical_dtype = str(cats.codes.dtype)
     elif hasattr(dtype, 'tz'):
         metadata = {'timezone': pa.lib.tzinfo_to_string(dtype.tz)}
-        physical_dtype = 'datetime64[ns]'
+        physical_dtype = f'datetime64[{dtype.unit}]'
     else:
         metadata = None
         physical_dtype = str(dtype)
@@ -1188,7 +1188,7 @@ def _reconstruct_columns_from_metadata(columns, column_indexes):
             if _pandas_api.is_ge_v3():
                 # with pandas 3+, to_datetime returns a unit depending on the string
                 # data, so we restore it to the original unit from the metadata
-                level = level.as_unit(np.datetime_data(dtype)[0])
+                level = level.as_unit(np.datetime_data(numpy_dtype)[0])
         # GH-41503: if the column index was decimal, restore to decimal
         elif pandas_dtype == "decimal":
             level = _pandas_api.pd.Index([decimal.Decimal(i) for i in level])

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -448,11 +448,12 @@ class TestConvertMetadata:
         assert len(md) == 1
         assert md['encoding'] == 'UTF-8'
 
-    def test_datetimetz_column_index(self):
+    @pytest.mark.parametrize('unit', ['us', 'ns'])
+    def test_datetimetz_column_index(self, unit):
         df = pd.DataFrame(
             [(1, 'a', 2.0), (2, 'b', 3.0), (3, 'c', 4.0)],
             columns=pd.date_range(
-                start='2017-01-01', periods=3, tz='America/New_York', unit='us'
+                start='2017-01-01', periods=3, tz='America/New_York', unit=unit
             )
         )
         t = pa.Table.from_pandas(df, preserve_index=True)
@@ -461,7 +462,7 @@ class TestConvertMetadata:
         column_indexes, = js['column_indexes']
         assert column_indexes['name'] is None
         assert column_indexes['pandas_type'] == 'datetimetz'
-        assert column_indexes['numpy_type'] == 'datetime64[us]'
+        assert column_indexes['numpy_type'] == f'datetime64[{unit}]'
 
         md = column_indexes['metadata']
         assert md['timezone'] == 'America/New_York'


### PR DESCRIPTION
### Rationale for this change

pandas 3.0 changes the default datetime/timedelta resolution from nanoseconds to microseconds. We already had mostly accounted for that in previous PRs, but pandas made this change the last days in a few additional places (eg `pd.date_range`), uncovering some more issues

### What changes are included in this PR?

- Don't hardcode the nanosecond unit in the metadata and when recreating a datetime-tz column's Index
- Update a few tests to account for those changes

### Are these changes tested?

Yes

### Are there any user-facing changes?

No

* GitHub Issue: #48314