### PR TITLE
GH-48084: [C++][FlightRPC] Replace boost::optional with std::optional

### DIFF
--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/blocking_queue.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/blocking_queue.h
@@ -18,9 +18,9 @@
 #pragma once
 
 #include <atomic>
-#include <boost/optional.hpp>
 #include <condition_variable>
 #include <mutex>
+#include <optional>
 #include <thread>
 #include <vector>
 
@@ -43,7 +43,7 @@ class BlockingQueue {
   std::atomic<bool> closed_{false};
 
  public:
-  typedef std::function<boost::optional<T>(void)> Supplier;
+  typedef std::function<std::optional<T>(void)> Supplier;
 
   explicit BlockingQueue(size_t capacity) : capacity_(capacity), buffer_(capacity) {}
 
@@ -58,7 +58,7 @@ class BlockingQueue {
 
         // Only one thread at a time be notified and call supplier
         auto item = supplier();
-        if (!item) break;
+        if (!item.has_value()) break;
 
         Push(*item);
       }

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/flight_sql_auth_method.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/flight_sql_auth_method.cc
@@ -24,6 +24,7 @@
 #include "arrow/result.h"
 #include "arrow/status.h"
 
+#include <optional>
 #include <utility>
 
 namespace arrow::flight::sql::odbc {
@@ -63,7 +64,7 @@ class UserPasswordAuthMethod : public FlightSqlAuthMethod {
   void Authenticate(FlightSqlConnection& connection,
                     FlightCallOptions& call_options) override {
     FlightCallOptions auth_call_options;
-    const boost::optional<Connection::Attribute>& login_timeout =
+    const std::optional<Connection::Attribute>& login_timeout =
         connection.GetAttribute(Connection::LOGIN_TIMEOUT);
     if (login_timeout && boost::get<uint32_t>(*login_timeout) > 0) {
       // ODBC's LOGIN_TIMEOUT attribute and FlightCallOptions.timeout use

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/flight_sql_connection.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/flight_sql_connection.cc
@@ -31,7 +31,6 @@
 #include <boost/algorithm/string/join.hpp>
 #include <boost/asio/ip/address.hpp>
 #include <boost/lexical_cast.hpp>
-#include <boost/optional.hpp>
 #include "arrow/flight/sql/odbc/odbc_impl/exceptions.h"
 
 #include <sql.h>
@@ -194,7 +193,7 @@ void FlightSqlConnection::PopulateMetadataSettings(
   metadata_settings_.chunk_buffer_capacity = GetChunkBufferCapacity(conn_property_map);
 }
 
-boost::optional<int32_t> FlightSqlConnection::GetStringColumnLength(
+std::optional<int32_t> FlightSqlConnection::GetStringColumnLength(
     const Connection::ConnPropertyMap& conn_property_map) {
   const int32_t min_string_column_length = 1;
 
@@ -209,7 +208,7 @@ boost::optional<int32_t> FlightSqlConnection::GetStringColumnLength(
         "01000", ODBCErrorCodes_GENERAL_WARNING);
   }
 
-  return boost::none;
+  return std::nullopt;
 }
 
 bool FlightSqlConnection::GetUseWideChar(const ConnPropertyMap& conn_property_map) {
@@ -245,7 +244,7 @@ const FlightCallOptions& FlightSqlConnection::PopulateCallOptions(
     const ConnPropertyMap& props) {
   // Set CONNECTION_TIMEOUT attribute or LOGIN_TIMEOUT depending on if this
   // is the first request.
-  const boost::optional<Connection::Attribute>& connection_timeout =
+  const std::optional<Connection::Attribute>& connection_timeout =
       closed_ ? GetAttribute(LOGIN_TIMEOUT) : GetAttribute(CONNECTION_TIMEOUT);
   if (connection_timeout && boost::get<uint32_t>(*connection_timeout) > 0) {
     call_options_.timeout =
@@ -383,17 +382,21 @@ bool FlightSqlConnection::SetAttribute(Connection::AttributeId attribute,
   }
 }
 
-boost::optional<Connection::Attribute> FlightSqlConnection::GetAttribute(
+std::optional<Connection::Attribute> FlightSqlConnection::GetAttribute(
     Connection::AttributeId attribute) {
   switch (attribute) {
     case ACCESS_MODE:
       // FlightSQL does not provide this metadata.
-      return boost::make_optional(Attribute(static_cast<uint32_t>(SQL_MODE_READ_WRITE)));
+      return std::make_optional(Attribute(static_cast<uint32_t>(SQL_MODE_READ_WRITE)));
     case PACKET_SIZE:
-      return boost::make_optional(Attribute(static_cast<uint32_t>(0)));
+      return std::make_optional(Attribute(static_cast<uint32_t>(0)));
     default:
       const auto& it = attribute_.find(attribute);
-      return boost::make_optional(it != attribute_.end(), it->second);
+      if (it != attribute_.end()) {
+        return std::make_optional(it->second);
+      } else {
+        return std::nullopt;
+      }
   }
 }
 

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/flight_sql_connection.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/flight_sql_connection.h
@@ -19,6 +19,7 @@
 
 #include "arrow/flight/sql/odbc/odbc_impl/spi/connection.h"
 
+#include <optional>
 #include <vector>
 #include "arrow/flight/api.h"
 #include "arrow/flight/sql/api.h"
@@ -84,7 +85,7 @@ class FlightSqlConnection : public Connection {
 
   bool SetAttribute(AttributeId attribute, const Attribute& value) override;
 
-  boost::optional<Connection::Attribute> GetAttribute(
+  std::optional<Connection::Attribute> GetAttribute(
       Connection::AttributeId attribute) override;
 
   Info GetInfo(uint16_t info_type) override;
@@ -111,8 +112,7 @@ class FlightSqlConnection : public Connection {
   /// \note Visible for testing
   void SetClosed(bool is_closed);
 
-  boost::optional<int32_t> GetStringColumnLength(
-      const ConnPropertyMap& conn_property_map);
+  std::optional<int32_t> GetStringColumnLength(const ConnPropertyMap& conn_property_map);
 
   bool GetUseWideChar(const ConnPropertyMap& conn_property_map);
 

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/flight_sql_connection_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/flight_sql_connection_test.cc
@@ -21,6 +21,8 @@
 #include "arrow/flight/types.h"
 #include "gtest/gtest.h"
 
+#include <optional>
+
 namespace arrow::flight::sql::odbc {
 
 TEST(AttributeTests, SetAndGetAttribute) {
@@ -28,7 +30,7 @@ TEST(AttributeTests, SetAndGetAttribute) {
   connection.SetClosed(false);
 
   connection.SetAttribute(Connection::CONNECTION_TIMEOUT, static_cast<uint32_t>(200));
-  const boost::optional<Connection::Attribute> first_value =
+  const std::optional<Connection::Attribute> first_value =
       connection.GetAttribute(Connection::CONNECTION_TIMEOUT);
 
   EXPECT_TRUE(first_value);
@@ -37,7 +39,7 @@ TEST(AttributeTests, SetAndGetAttribute) {
 
   connection.SetAttribute(Connection::CONNECTION_TIMEOUT, static_cast<uint32_t>(300));
 
-  const boost::optional<Connection::Attribute> change_value =
+  const std::optional<Connection::Attribute> change_value =
       connection.GetAttribute(Connection::CONNECTION_TIMEOUT);
 
   EXPECT_TRUE(change_value);
@@ -49,7 +51,7 @@ TEST(AttributeTests, SetAndGetAttribute) {
 TEST(AttributeTests, GetAttributeWithoutSetting) {
   FlightSqlConnection connection(OdbcVersion::V_3);
 
-  const boost::optional<Connection::Attribute> optional =
+  const std::optional<Connection::Attribute> optional =
       connection.GetAttribute(Connection::CONNECTION_TIMEOUT);
   connection.SetClosed(false);
 
@@ -72,7 +74,7 @@ TEST(MetadataSettingsTest, StringColumnLengthTest) {
        std::to_string(expected_string_column_length)},
   };
 
-  const boost::optional<int32_t> actual_string_column_length =
+  const std::optional<int32_t> actual_string_column_length =
       connection.GetStringColumnLength(properties);
 
   EXPECT_TRUE(actual_string_column_length);

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/flight_sql_statement.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/flight_sql_statement.cc
@@ -29,7 +29,7 @@
 #include "arrow/flight/sql/odbc/odbc_impl/util.h"
 #include "arrow/io/memory.h"
 
-#include <boost/optional.hpp>
+#include <optional>
 #include <utility>
 #include "arrow/flight/sql/odbc/odbc_impl/exceptions.h"
 
@@ -92,13 +92,17 @@ bool FlightSqlStatement::SetAttribute(StatementAttributeId attribute,
   }
 }
 
-boost::optional<Statement::Attribute> FlightSqlStatement::GetAttribute(
+std::optional<Statement::Attribute> FlightSqlStatement::GetAttribute(
     StatementAttributeId attribute) {
   const auto& it = attribute_.find(attribute);
-  return boost::make_optional(it != attribute_.end(), it->second);
+  if (it != attribute_.end()) {
+    return std::make_optional(it->second);
+  } else {
+    return std::nullopt;
+  }
 }
 
-boost::optional<std::shared_ptr<ResultSetMetadata>> FlightSqlStatement::Prepare(
+std::optional<std::shared_ptr<ResultSetMetadata>> FlightSqlStatement::Prepare(
     const std::string& query) {
   ClosePreparedStatementIfAny(prepared_statement_, call_options_);
 
@@ -110,7 +114,7 @@ boost::optional<std::shared_ptr<ResultSetMetadata>> FlightSqlStatement::Prepare(
 
   const auto& result_set_metadata = std::make_shared<FlightSqlResultSetMetadata>(
       prepared_statement_->dataset_schema(), metadata_settings_);
-  return boost::optional<std::shared_ptr<ResultSetMetadata>>(result_set_metadata);
+  return std::optional<std::shared_ptr<ResultSetMetadata>>(result_set_metadata);
 }
 
 bool FlightSqlStatement::ExecutePrepared() {

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/flight_sql_statement.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/flight_sql_statement.h
@@ -26,6 +26,8 @@
 #include "arrow/flight/sql/api.h"
 #include "arrow/flight/types.h"
 
+#include <optional>
+
 namespace arrow::flight::sql::odbc {
 
 class FlightSqlStatement : public Statement {
@@ -52,9 +54,9 @@ class FlightSqlStatement : public Statement {
 
   bool SetAttribute(StatementAttributeId attribute, const Attribute& value) override;
 
-  boost::optional<Attribute> GetAttribute(StatementAttributeId attribute) override;
+  std::optional<Attribute> GetAttribute(StatementAttributeId attribute) override;
 
-  boost::optional<std::shared_ptr<ResultSetMetadata>> Prepare(
+  std::optional<std::shared_ptr<ResultSetMetadata>> Prepare(
       const std::string& query) override;
 
   bool ExecutePrepared() override;

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/flight_sql_stream_chunk_buffer.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/flight_sql_stream_chunk_buffer.cc
@@ -68,11 +68,13 @@ FlightStreamChunkBuffer::FlightStreamChunkBuffer(
       // call. temp_flight_sql_client is intentionally null if the list of endpoint
       // Locations is empty.
       // After all data is fetched from reader, the temp client is closed.
-
-      // gh-48084 Replace boost::optional with std::optional
-      return boost::make_optional(
-          is_not_ok || is_not_empty,
-          std::make_pair(std::move(result), temp_flight_sql_client));
+      if (is_not_ok || is_not_empty) {
+        return std::make_optional(
+            std::make_pair(std::move(result), temp_flight_sql_client));
+      } else {
+        return std::optional<std::pair<arrow::Result<FlightStreamChunk>,
+                                       std::shared_ptr<FlightSqlClient>>>{};
+      }
     };
     queue_.AddProducer(std::move(supplier));
   }

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/flight_sql_stream_chunk_buffer.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/flight_sql_stream_chunk_buffer.cc
@@ -59,7 +59,9 @@ FlightStreamChunkBuffer::FlightStreamChunkBuffer(
     std::shared_ptr<FlightStreamReader> stream_reader_ptr(std::move(result.ValueOrDie()));
 
     BlockingQueue<std::pair<Result<FlightStreamChunk>,
-                            std::shared_ptr<FlightSqlClient>>>::Supplier supplier = [=] {
+                            std::shared_ptr<FlightSqlClient>>>::Supplier supplier = [=]()
+        -> std::optional<
+            std::pair<Result<FlightStreamChunk>, std::shared_ptr<FlightSqlClient>>> {
       auto result = stream_reader_ptr->Next();
       bool is_not_ok = !result.ok();
       bool is_not_empty = result.ok() && (result.ValueOrDie().data != nullptr);
@@ -72,8 +74,7 @@ FlightStreamChunkBuffer::FlightStreamChunkBuffer(
         return std::make_optional(
             std::make_pair(std::move(result), temp_flight_sql_client));
       } else {
-        return std::optional<std::pair<arrow::Result<FlightStreamChunk>,
-                                       std::shared_ptr<FlightSqlClient>>>{};
+        return std::nullopt;
       }
     };
     queue_.AddProducer(std::move(supplier));

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/odbc_connection.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/odbc_connection.cc
@@ -36,6 +36,7 @@
 #include <boost/xpressive/xpressive.hpp>
 #include <iterator>
 #include <memory>
+#include <optional>
 #include <utility>
 
 using ODBC::ODBCConnection;
@@ -531,7 +532,7 @@ void ODBCConnection::SetConnectAttr(SQLINTEGER attribute, SQLPOINTER value,
 SQLRETURN ODBCConnection::GetConnectAttr(SQLINTEGER attribute, SQLPOINTER value,
                                          SQLINTEGER buffer_length,
                                          SQLINTEGER* output_length, bool is_unicode) {
-  boost::optional<Connection::Attribute> spi_attribute;
+  std::optional<Connection::Attribute> spi_attribute;
 
   switch (attribute) {
     // Internal connection attributes

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/odbc_statement.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/odbc_statement.cc
@@ -29,8 +29,8 @@
 #include <sql.h>
 #include <sqlext.h>
 #include <sqltypes.h>
-#include <boost/optional.hpp>
 #include <boost/variant.hpp>
+#include <optional>
 #include <utility>
 
 using ODBC::DescriptorRecord;
@@ -273,7 +273,7 @@ void ODBCStatement::CopyAttributesFromConnection(ODBCConnection& connection) {
 bool ODBCStatement::IsPrepared() const { return is_prepared_; }
 
 void ODBCStatement::Prepare(const std::string& query) {
-  boost::optional<std::shared_ptr<ResultSetMetadata> > metadata =
+  std::optional<std::shared_ptr<ResultSetMetadata> > metadata =
       spi_statement_->Prepare(query);
 
   if (metadata) {
@@ -352,7 +352,7 @@ bool ODBCStatement::Fetch(size_t rows) {
 void ODBCStatement::GetStmtAttr(SQLINTEGER statement_attribute, SQLPOINTER output,
                                 SQLINTEGER buffer_size, SQLINTEGER* str_len_ptr,
                                 bool is_unicode) {
-  boost::optional<Statement::Attribute> spi_attribute;
+  std::optional<Statement::Attribute> spi_attribute;
   switch (statement_attribute) {
     // Descriptor accessor attributes
     case SQL_ATTR_APP_PARAM_DESC:

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/spi/connection.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/spi/connection.h
@@ -18,10 +18,10 @@
 #pragma once
 
 #include <boost/algorithm/string.hpp>
-#include <boost/optional.hpp>
 #include <boost/variant.hpp>
 #include <functional>
 #include <map>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -88,7 +88,7 @@ class Connection {
 
   /// \brief Retrieve a connection attribute
   /// \param attribute [in] Attribute to be retrieved.
-  virtual boost::optional<Connection::Attribute> GetAttribute(
+  virtual std::optional<Connection::Attribute> GetAttribute(
       Connection::AttributeId attribute) = 0;
 
   /// \brief Retrieves info from the database (see ODBC's SQLGetInfo).

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/spi/statement.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/spi/statement.h
@@ -17,9 +17,9 @@
 
 #pragma once
 
-#include <boost/optional.hpp>
 #include <boost/variant.hpp>
 #include <map>
+#include <optional>
 #include <vector>
 
 namespace arrow::flight::sql::odbc {
@@ -67,14 +67,14 @@ class Statement {
   ///
   /// \param attribute Attribute identifier to be retrieved.
   /// \return Value associated with the attribute.
-  virtual boost::optional<Statement::Attribute> GetAttribute(
+  virtual std::optional<Statement::Attribute> GetAttribute(
       Statement::StatementAttributeId attribute) = 0;
 
   /// \brief Prepares the statement.
   /// Returns ResultSetMetadata if query returns a result set,
-  /// otherwise it returns `boost::none`.
+  /// otherwise it returns `std::nullopt`.
   /// \param query The SQL query to prepare.
-  virtual boost::optional<std::shared_ptr<ResultSetMetadata>> Prepare(
+  virtual std::optional<std::shared_ptr<ResultSetMetadata>> Prepare(
       const std::string& query) = 0;
 
   /// \brief Execute the prepared statement.

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/types.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/types.h
@@ -17,9 +17,9 @@
 
 #pragma once
 
+#include <cstdint>
+#include <optional>
 #include "arrow/flight/sql/odbc/odbc_impl/platform.h"
-
-#include <boost/optional.hpp>
 
 namespace arrow::flight::sql::odbc {
 
@@ -172,7 +172,7 @@ enum RowStatus : uint16_t {
 };
 
 struct MetadataSettings {
-  boost::optional<int32_t> string_column_length{boost::none};
+  std::optional<int32_t> string_column_length{std::nullopt};
   size_t chunk_buffer_capacity;
   bool use_wide_char;
 };

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/types.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/types.h
@@ -172,7 +172,7 @@ enum RowStatus : uint16_t {
 };
 
 struct MetadataSettings {
-  std::optional<int32_t> string_column_length{std::nullopt};
+  std::optional<int32_t> string_column_length;
   size_t chunk_buffer_capacity;
   bool use_wide_char;
 };

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/util.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/util.cc
@@ -1098,30 +1098,30 @@ int32_t GetDecimalTypePrecision(const std::shared_ptr<DataType>& decimal_type) {
   return decimal128_type->precision();
 }
 
-boost::optional<bool> AsBool(const std::string& value) {
+std::optional<bool> AsBool(const std::string& value) {
   if (boost::iequals(value, "true") || boost::iequals(value, "1")) {
     return true;
   } else if (boost::iequals(value, "false") || boost::iequals(value, "0")) {
     return false;
   } else {
-    return boost::none;
+    return std::nullopt;
   }
 }
 
-boost::optional<bool> AsBool(const Connection::ConnPropertyMap& conn_property_map,
-                             std::string_view property_name) {
+std::optional<bool> AsBool(const Connection::ConnPropertyMap& conn_property_map,
+                           std::string_view property_name) {
   auto extracted_property = conn_property_map.find(property_name);
 
   if (extracted_property != conn_property_map.end()) {
     return AsBool(extracted_property->second);
   }
 
-  return boost::none;
+  return std::nullopt;
 }
 
-boost::optional<int32_t> AsInt32(int32_t min_value,
-                                 const Connection::ConnPropertyMap& conn_property_map,
-                                 std::string_view property_name) {
+std::optional<int32_t> AsInt32(int32_t min_value,
+                               const Connection::ConnPropertyMap& conn_property_map,
+                               std::string_view property_name) {
   auto extracted_property = conn_property_map.find(property_name);
 
   if (extracted_property != conn_property_map.end()) {
@@ -1131,7 +1131,7 @@ boost::optional<int32_t> AsInt32(int32_t min_value,
       return string_column_length;
     }
   }
-  return boost::none;
+  return std::nullopt;
 }
 
 }  // namespace util

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/util.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/util.h
@@ -135,15 +135,15 @@ int32_t GetDecimalTypePrecision(const std::shared_ptr<DataType>& decimal_type);
 /// Parse a string value to a boolean.
 /// \param value            the value to be parsed.
 /// \return                 the parsed valued.
-boost::optional<bool> AsBool(const std::string& value);
+std::optional<bool> AsBool(const std::string& value);
 
 /// Looks up for a value inside the ConnPropertyMap and then try to parse it.
 /// In case it does not find or it cannot parse, the default value will be returned.
 /// \param conn_property_map    the map with the connection properties.
 /// \param property_name      the name of the property that will be looked up.
 /// \return                   the parsed valued.
-boost::optional<bool> AsBool(const Connection::ConnPropertyMap& conn_property_map,
-                             std::string_view property_name);
+std::optional<bool> AsBool(const Connection::ConnPropertyMap& conn_property_map,
+                           std::string_view property_name);
 
 /// Looks up for a value inside the ConnPropertyMap and then try to parse it.
 /// In case it does not find or it cannot parse, the default value will be returned.
@@ -153,9 +153,9 @@ boost::optional<bool> AsBool(const Connection::ConnPropertyMap& conn_property_ma
 /// looked up. \return                             the parsed valued. \exception
 /// std::invalid_argument    exception from std::stoi \exception
 /// std::out_of_range        exception from std::stoi
-boost::optional<int32_t> AsInt32(int32_t min_value,
-                                 const Connection::ConnPropertyMap& conn_property_map,
-                                 std::string_view property_name);
+std::optional<int32_t> AsInt32(int32_t min_value,
+                               const Connection::ConnPropertyMap& conn_property_map,
+                               std::string_view property_name);
 
 }  // namespace util
 }  // namespace arrow::flight::sql::odbc


### PR DESCRIPTION

### Rationale for this change
Replace boost::optional with std::optional to resolve build failures on MSVC Windows CI. This PR is extracted from https://github.com/apache/arrow/pull/48313.

### What changes are included in this PR?
Replace boost::optional with std::optional in ODBC.
### Are these changes tested?
Yes, locally on MSVC
### Are there any user-facing changes?
N/A
* GitHub Issue: #48084