### PR TITLE
GH-48102: [Python] Remove deprecated Array.format method

### DIFF
--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1465,22 +1465,6 @@ cdef class Array(_PandasConvertible):
 
         return frombytes(result, safe=True)
 
-    def format(self, **kwargs):
-        """
-        DEPRECATED, use pyarrow.Array.to_string
-
-        Parameters
-        ----------
-        **kwargs : dict
-
-        Returns
-        -------
-        str
-        """
-        import warnings
-        warnings.warn('Array.format is deprecated, use Array.to_string')
-        return self.to_string(**kwargs)
-
     def __str__(self):
         return self.to_string()
 


### PR DESCRIPTION
### Rationale for this change

This PR removes the deprecated `Array.format` method as requested in issue #48102.

### What changes are included in this PR?

- Removed the deprecated `Array.format` method from the Python API
- The method will be automatically removed from the documentation (https://arrow.apache.org/docs/python/generated/pyarrow.Array.html) as it's auto-generated from the source code

### Are these changes tested?

Yes, existing tests continue to pass.

### Are there any user-facing changes?

**This PR includes breaking changes to public APIs.**

The deprecated `Array.format` method has been removed. Users who have not migrated from this deprecated method should use `Array.to_string()` instead. This change was announced in the deprecation warning since 2020.

**Migration:**
```python
# Old (deprecated)
array.format()

# New
array.to_string()
* GitHub Issue: #48102