### PR TITLE
GH-48328: [Ruby] Add support for reading UTF-8 array

### DIFF
--- a/ruby/red-arrow-format/lib/arrow-format/array.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/array.rb
@@ -73,7 +73,7 @@ module ArrowFormat
     end
   end
 
-  class BinaryArray < Array
+  class VariableSizeBinaryLayoutArray < Array
     def initialize(type, size, validity_buffer, offsets_buffer, values_buffer)
       super(type, size, validity_buffer)
       @offsets_buffer = offsets_buffer
@@ -86,9 +86,23 @@ module ArrowFormat
         each_cons(2).
         collect do |(_, offset), (_, next_offset)|
         length = next_offset - offset
-        @values_buffer.get_string(offset, length)
+        @values_buffer.get_string(offset, length, encoding)
       end
       apply_validity(values)
+    end
+  end
+
+  class BinaryArray < VariableSizeBinaryLayoutArray
+    private
+    def encoding
+      Encoding::ASCII_8BIT
+    end
+  end
+
+  class UTF8Array < VariableSizeBinaryLayoutArray
+    private
+    def encoding
+      Encoding::UTF_8
     end
   end
 end

--- a/ruby/red-arrow-format/lib/arrow-format/file-reader.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/file-reader.rb
@@ -139,6 +139,8 @@ module ArrowFormat
           end
         when Org::Apache::Arrow::Flatbuf::Binary
           type = BinaryType.singleton
+        when Org::Apache::Arrow::Flatbuf::Utf8
+          type = UTF8Type.singleton
         end
         Field.new(fb_field.name, type)
       end
@@ -159,7 +161,8 @@ module ArrowFormat
         values_buffer = buffers.shift
         values = body.slice(values_buffer.offset, values_buffer.length)
         field.type.build_array(n_rows, validity, values)
-      when BinaryType
+      when BinaryType,
+           UTF8Type
         offsets_buffer = buffers.shift
         values_buffer = buffers.shift
         offsets = body.slice(offsets_buffer.offset, offsets_buffer.length)

--- a/ruby/red-arrow-format/lib/arrow-format/type.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/type.rb
@@ -80,4 +80,21 @@ module ArrowFormat
       BinaryArray.new(self, size, validity_buffer, offsets_buffer, values_buffer)
     end
   end
+
+  class UTF8Type < Type
+    class << self
+      def singleton
+        @singleton ||= new
+      end
+    end
+
+    attr_reader :name
+    def initialize
+      super("UTF8")
+    end
+
+    def build_array(size, validity_buffer, offsets_buffer, values_buffer)
+      UTF8Array.new(self, size, validity_buffer, offsets_buffer, values_buffer)
+    end
+  end
 end

--- a/ruby/red-arrow-format/test/test-file-reader.rb
+++ b/ruby/red-arrow-format/test/test-file-reader.rb
@@ -72,4 +72,15 @@ class TestFileReader < Test::Unit::TestCase
                    read)
     end
   end
+
+  sub_test_case("UTF8") do
+    def build_array
+      Arrow::StringArray.new(["Hello", nil, "World"])
+    end
+
+    def test_read
+      assert_equal([{"value" => ["Hello", nil, "World"]}],
+                   read)
+    end
+  end
 end


### PR DESCRIPTION
### Rationale for this change

It's similar to already implemented binary array.

### What changes are included in this PR?

* Add `ArrowFormat::UTF8Type`
* Add `ArrowFormat::UTF8Array`

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #48328