### PR TITLE
GH-48330: [Ruby] Add support for reading null array

### DIFF
--- a/ruby/red-arrow-format/lib/arrow-format/array.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/array.rb
@@ -54,6 +54,16 @@ module ArrowFormat
     end
   end
 
+  class NullArray < Array
+    def initialize(type, size)
+      super(type, size, nil)
+    end
+
+    def to_a
+      [nil] * @size
+    end
+  end
+
   class IntArray < Array
     def initialize(type, size, validity_buffer, values_buffer)
       super(type, size, validity_buffer)

--- a/ruby/red-arrow-format/lib/arrow-format/file-reader.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/file-reader.rb
@@ -24,6 +24,10 @@ require_relative "type"
 
 require_relative "org/apache/arrow/flatbuf/footer"
 require_relative "org/apache/arrow/flatbuf/message"
+require_relative "org/apache/arrow/flatbuf/binary"
+require_relative "org/apache/arrow/flatbuf/int"
+require_relative "org/apache/arrow/flatbuf/null"
+require_relative "org/apache/arrow/flatbuf/utf8"
 require_relative "org/apache/arrow/flatbuf/schema"
 
 module ArrowFormat
@@ -128,6 +132,8 @@ module ArrowFormat
       fields = fb_schema.fields.collect do |fb_field|
         fb_type = fb_field.type
         case fb_type
+        when Org::Apache::Arrow::Flatbuf::Null
+          type = NullType.singleton
         when Org::Apache::Arrow::Flatbuf::Int
           case fb_type.bit_width
           when 8
@@ -146,6 +152,8 @@ module ArrowFormat
     end
 
     def read_column(field, n_rows, buffers, body)
+      return field.type.build_array(n_rows) if field.type.is_a?(NullType)
+
       validity_buffer = buffers.shift
       if validity_buffer.length.zero?
         validity = nil

--- a/ruby/red-arrow-format/lib/arrow-format/type.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/type.rb
@@ -22,6 +22,22 @@ module ArrowFormat
     end
   end
 
+  class NullType < Type
+    class << self
+      def singleton
+        @singleton ||= new
+      end
+    end
+
+    def initialize
+      super("Null")
+    end
+
+    def build_array(size)
+      NullArray.new(self, size)
+    end
+  end
+
   class IntType < Type
     attr_reader :bit_width
     attr_reader :signed

--- a/ruby/red-arrow-format/test/test-file-reader.rb
+++ b/ruby/red-arrow-format/test/test-file-reader.rb
@@ -40,6 +40,17 @@ class TestFileReader < Test::Unit::TestCase
     end
   end
 
+  sub_test_case("Null") do
+    def build_array
+      Arrow::NullArray.new(3)
+    end
+
+    def test_read
+      assert_equal([{"value" => [nil, nil, nil]}],
+                   read)
+    end
+  end
+
   sub_test_case("Int8") do
     def build_array
       Arrow::Int8Array.new([-128, nil, 127])


### PR DESCRIPTION
### Rationale for this change

It's the simplest array.

### What changes are included in this PR?

* Add `ArrowFormat::NullType`
* Add `ArrowFormat::NullArray`

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #48330