### PR TITLE
GH-48337: [C++][Parquet] Improve column encryption API

### DIFF
--- a/cpp/examples/parquet/low_level_api/encryption_reader_writer.cc
+++ b/cpp/examples/parquet/low_level_api/encryption_reader_writer.cc
@@ -68,13 +68,10 @@ int main(int argc, char** argv) {
     auto column_path1 = schema_desc.Column(5)->path()->ToDotString();
     auto column_path2 = schema_desc.Column(4)->path()->ToDotString();
 
-    parquet::ColumnEncryptionProperties::Builder encryption_col_builder0(column_path1);
-    parquet::ColumnEncryptionProperties::Builder encryption_col_builder1(column_path2);
-    encryption_col_builder0.key(kColumnEncryptionKey1)->key_id("kc1");
-    encryption_col_builder1.key(kColumnEncryptionKey2)->key_id("kc2");
-
-    encryption_cols[column_path1] = encryption_col_builder0.build();
-    encryption_cols[column_path2] = encryption_col_builder1.build();
+    encryption_cols[column_path1] =
+        parquet::ColumnEncryptionProperties::WithColumnKey(kColumnEncryptionKey1, "kc1");
+    encryption_cols[column_path2] =
+        parquet::ColumnEncryptionProperties::WithColumnKey(kColumnEncryptionKey2, "kc2");
 
     parquet::FileEncryptionProperties::Builder file_encryption_builder(
         kFooterEncryptionKey);

--- a/cpp/examples/parquet/low_level_api/encryption_reader_writer_all_crypto_options.cc
+++ b/cpp/examples/parquet/low_level_api/encryption_reader_writer_all_crypto_options.cc
@@ -173,13 +173,10 @@ void InteropTestWriteEncryptedParquetFiles(std::string root_path) {
       encryption_cols2;
   std::string path1 = "double_field";
   std::string path2 = "float_field";
-  parquet::ColumnEncryptionProperties::Builder encryption_col_builder_20(path1);
-  parquet::ColumnEncryptionProperties::Builder encryption_col_builder_21(path2);
-  encryption_col_builder_20.key(kColumnEncryptionKey1)->key_id("kc1");
-  encryption_col_builder_21.key(kColumnEncryptionKey2)->key_id("kc2");
-
-  encryption_cols2[path1] = encryption_col_builder_20.build();
-  encryption_cols2[path2] = encryption_col_builder_21.build();
+  encryption_cols2[path1] =
+      parquet::ColumnEncryptionProperties::WithColumnKey(kColumnEncryptionKey1, "kc1");
+  encryption_cols2[path2] =
+      parquet::ColumnEncryptionProperties::WithColumnKey(kColumnEncryptionKey1, "kc2");
 
   parquet::FileEncryptionProperties::Builder file_encryption_builder_2(
       kFooterEncryptionKey);
@@ -194,13 +191,11 @@ void InteropTestWriteEncryptedParquetFiles(std::string root_path) {
   // (plaintext footer mode, readable by legacy readers)
   std::map<std::string, std::shared_ptr<parquet::ColumnEncryptionProperties>>
       encryption_cols3;
-  parquet::ColumnEncryptionProperties::Builder encryption_col_builder_30(path1);
-  parquet::ColumnEncryptionProperties::Builder encryption_col_builder_31(path2);
-  encryption_col_builder_30.key(kColumnEncryptionKey1)->key_id("kc1");
-  encryption_col_builder_31.key(kColumnEncryptionKey2)->key_id("kc2");
+  encryption_cols3[path1] =
+      parquet::ColumnEncryptionProperties::WithColumnKey(kColumnEncryptionKey1, "kc1");
+  encryption_cols3[path2] =
+      parquet::ColumnEncryptionProperties::WithColumnKey(kColumnEncryptionKey1, "kc2");
 
-  encryption_cols3[path1] = encryption_col_builder_30.build();
-  encryption_cols3[path2] = encryption_col_builder_31.build();
   parquet::FileEncryptionProperties::Builder file_encryption_builder_3(
       kFooterEncryptionKey);
 
@@ -214,13 +209,11 @@ void InteropTestWriteEncryptedParquetFiles(std::string root_path) {
   // Use aad_prefix.
   std::map<std::string, std::shared_ptr<parquet::ColumnEncryptionProperties>>
       encryption_cols4;
-  parquet::ColumnEncryptionProperties::Builder encryption_col_builder_40(path1);
-  parquet::ColumnEncryptionProperties::Builder encryption_col_builder_41(path2);
-  encryption_col_builder_40.key(kColumnEncryptionKey1)->key_id("kc1");
-  encryption_col_builder_41.key(kColumnEncryptionKey2)->key_id("kc2");
+  encryption_cols4[path1] =
+      parquet::ColumnEncryptionProperties::WithColumnKey(kColumnEncryptionKey1, "kc1");
+  encryption_cols4[path2] =
+      parquet::ColumnEncryptionProperties::WithColumnKey(kColumnEncryptionKey1, "kc2");
 
-  encryption_cols4[path1] = encryption_col_builder_40.build();
-  encryption_cols4[path2] = encryption_col_builder_41.build();
   parquet::FileEncryptionProperties::Builder file_encryption_builder_4(
       kFooterEncryptionKey);
 
@@ -234,13 +227,11 @@ void InteropTestWriteEncryptedParquetFiles(std::string root_path) {
   // Use aad_prefix and disable_aad_prefix_storage.
   std::map<std::string, std::shared_ptr<parquet::ColumnEncryptionProperties>>
       encryption_cols5;
-  parquet::ColumnEncryptionProperties::Builder encryption_col_builder_50(path1);
-  parquet::ColumnEncryptionProperties::Builder encryption_col_builder_51(path2);
-  encryption_col_builder_50.key(kColumnEncryptionKey1)->key_id("kc1");
-  encryption_col_builder_51.key(kColumnEncryptionKey2)->key_id("kc2");
+  encryption_cols5[path1] =
+      parquet::ColumnEncryptionProperties::WithColumnKey(kColumnEncryptionKey1, "kc1");
+  encryption_cols5[path2] =
+      parquet::ColumnEncryptionProperties::WithColumnKey(kColumnEncryptionKey1, "kc2");
 
-  encryption_cols5[path1] = encryption_col_builder_50.build();
-  encryption_cols5[path2] = encryption_col_builder_51.build();
   parquet::FileEncryptionProperties::Builder file_encryption_builder_5(
       kFooterEncryptionKey);
 
@@ -255,13 +246,11 @@ void InteropTestWriteEncryptedParquetFiles(std::string root_path) {
   // Use AES_GCM_CTR_V1 algorithm.
   std::map<std::string, std::shared_ptr<parquet::ColumnEncryptionProperties>>
       encryption_cols6;
-  parquet::ColumnEncryptionProperties::Builder encryption_col_builder_60(path1);
-  parquet::ColumnEncryptionProperties::Builder encryption_col_builder_61(path2);
-  encryption_col_builder_60.key(kColumnEncryptionKey1)->key_id("kc1");
-  encryption_col_builder_61.key(kColumnEncryptionKey2)->key_id("kc2");
+  encryption_cols6[path1] =
+      parquet::ColumnEncryptionProperties::WithColumnKey(kColumnEncryptionKey1, "kc1");
+  encryption_cols6[path2] =
+      parquet::ColumnEncryptionProperties::WithColumnKey(kColumnEncryptionKey1, "kc2");
 
-  encryption_cols6[path1] = encryption_col_builder_60.build();
-  encryption_cols6[path2] = encryption_col_builder_61.build();
   parquet::FileEncryptionProperties::Builder file_encryption_builder_6(
       kFooterEncryptionKey);
 

--- a/cpp/src/parquet/encryption/crypto_factory.cc
+++ b/cpp/src/parquet/encryption/crypto_factory.cc
@@ -156,7 +156,7 @@ ColumnPathToEncryptionPropertiesMap CryptoFactory::GetColumnEncryptionProperties
           key_wrapper->GetEncryptionKeyMetadata(column_key, column_key_id, false);
 
       std::shared_ptr<ColumnEncryptionProperties> cmd =
-          ColumnEncryptionProperties::Builder(column_name)
+          ColumnEncryptionProperties::Builder()
               .key(column_key)
               ->key_metadata(column_key_key_metadata)
               ->build();

--- a/cpp/src/parquet/encryption/encryption.cc
+++ b/cpp/src/parquet/encryption/encryption.cc
@@ -179,16 +179,12 @@ FileEncryptionProperties::Builder::disable_aad_prefix_storage() {
   return this;
 }
 
-ColumnEncryptionProperties::ColumnEncryptionProperties(bool encrypted,
-                                                       std::string column_path,
-                                                       SecureString key,
+ColumnEncryptionProperties::ColumnEncryptionProperties(bool encrypted, SecureString key,
                                                        std::string key_metadata)
-    : column_path_(std::move(column_path)),
-      encrypted_(encrypted),
+    : encrypted_(encrypted),
       encrypted_with_footer_key_(encrypted && key.empty()),
       key_(std::move(key)),
       key_metadata_(std::move(key_metadata)) {
-  DCHECK(!column_path_.empty());
   if (!encrypted) {
     DCHECK(key_.empty() && key_metadata_.empty());
   }
@@ -198,6 +194,22 @@ ColumnEncryptionProperties::ColumnEncryptionProperties(bool encrypted,
   if (encrypted_with_footer_key_) {
     DCHECK(key_metadata_.empty());
   }
+}
+
+std::shared_ptr<ColumnEncryptionProperties> ColumnEncryptionProperties::Unencrypted() {
+  return std::shared_ptr<ColumnEncryptionProperties>(
+      new ColumnEncryptionProperties(/*encrypted=*/false, {}, {}));
+}
+
+std::shared_ptr<ColumnEncryptionProperties> ColumnEncryptionProperties::WithFooterKey() {
+  return std::shared_ptr<ColumnEncryptionProperties>(
+      new ColumnEncryptionProperties(/*encrypted=*/true, {}, {}));
+}
+
+std::shared_ptr<ColumnEncryptionProperties> ColumnEncryptionProperties::WithColumnKey(
+    ::arrow::util::SecureString key, std::string key_metadata) {
+  return std::shared_ptr<ColumnEncryptionProperties>(new ColumnEncryptionProperties(
+      /*encrypted=*/true, std::move(key), std::move(key_metadata)));
 }
 
 ColumnDecryptionProperties::ColumnDecryptionProperties(std::string column_path,

--- a/cpp/src/parquet/encryption/encryption.h
+++ b/cpp/src/parquet/encryption/encryption.h
@@ -114,12 +114,13 @@ class PARQUET_EXPORT ColumnEncryptionProperties {
  public:
   class PARQUET_EXPORT Builder {
    public:
-    /// Convenience builder for encrypted columns.
-    explicit Builder(std::string name) : Builder(std::move(name), true) {}
+    PARQUET_DEPRECATED("name argument is ignored, use default constructor instead")
+    explicit Builder(const std::string& name) : encrypted_(true) {}
 
-    /// Convenience builder for encrypted columns.
-    explicit Builder(const schema::ColumnPath& path)
-        : Builder(path.ToDotString(), true) {}
+    PARQUET_DEPRECATED("path argument is ignored, use default constructor instead")
+    explicit Builder(const schema::ColumnPath& path) : encrypted_(true) {}
+
+    Builder() = default;
 
     /// Set a column-specific key.
     /// If key is not set on an encrypted column, the column will
@@ -140,33 +141,31 @@ class PARQUET_EXPORT ColumnEncryptionProperties {
 
     std::shared_ptr<ColumnEncryptionProperties> build() {
       return std::shared_ptr<ColumnEncryptionProperties>(
-          new ColumnEncryptionProperties(encrypted_, column_path_, key_, key_metadata_));
+          new ColumnEncryptionProperties(encrypted_, key_, key_metadata_));
     }
 
    private:
-    std::string column_path_;
-    bool encrypted_;
+    bool encrypted_ = true;
     ::arrow::util::SecureString key_;
     std::string key_metadata_;
-
-    Builder(std::string path, bool encrypted)
-        : column_path_(std::move(path)), encrypted_(encrypted) {}
   };
 
-  const std::string& column_path() const { return column_path_; }
   bool is_encrypted() const { return encrypted_; }
   bool is_encrypted_with_footer_key() const { return encrypted_with_footer_key_; }
   const ::arrow::util::SecureString& key() const { return key_; }
   const std::string& key_metadata() const { return key_metadata_; }
 
+  static std::shared_ptr<ColumnEncryptionProperties> Unencrypted();
+  static std::shared_ptr<ColumnEncryptionProperties> WithFooterKey();
+  static std::shared_ptr<ColumnEncryptionProperties> WithColumnKey(
+      ::arrow::util::SecureString key, std::string key_metadata = "");
+
  private:
-  std::string column_path_;
   bool encrypted_;
   bool encrypted_with_footer_key_;
   ::arrow::util::SecureString key_;
   std::string key_metadata_;
-  explicit ColumnEncryptionProperties(bool encrypted, std::string column_path,
-                                      ::arrow::util::SecureString key,
+  explicit ColumnEncryptionProperties(bool encrypted, ::arrow::util::SecureString key,
                                       std::string key_metadata);
 };
 

--- a/cpp/src/parquet/encryption/write_configurations_test.cc
+++ b/cpp/src/parquet/encryption/write_configurations_test.cc
@@ -81,9 +81,8 @@ class TestEncryptionConfiguration : public ::testing::Test {
   SecureString kColumnEncryptionKey2_ = kColumnEncryptionKey2;
   std::string kFileName_ = std::string(kFileName);
 
-  void EncryptFile(
-      std::shared_ptr<parquet::FileEncryptionProperties> encryption_configurations,
-      std::string file_name) {
+  void EncryptFile(std::shared_ptr<FileEncryptionProperties> encryption_configurations,
+                   std::string file_name) {
     std::string file = temp_dir->path().ToString() + file_name;
     encryptor_.EncryptFile(file, encryption_configurations);
   }
@@ -92,8 +91,7 @@ class TestEncryptionConfiguration : public ::testing::Test {
 // Encryption configuration 1: Encrypt all columns and the footer with the same key.
 // (uniform encryption)
 TEST_F(TestEncryptionConfiguration, UniformEncryption) {
-  parquet::FileEncryptionProperties::Builder file_encryption_builder_1(
-      kFooterEncryptionKey_);
+  FileEncryptionProperties::Builder file_encryption_builder_1(kFooterEncryptionKey_);
 
   this->EncryptFile(file_encryption_builder_1.footer_key_metadata("kf")->build(),
                     "tmp_uniform_encryption.parquet.encrypted");
@@ -101,20 +99,13 @@ TEST_F(TestEncryptionConfiguration, UniformEncryption) {
 
 // Encryption configuration 2: Encrypt two columns and the footer, with different keys.
 TEST_F(TestEncryptionConfiguration, EncryptTwoColumnsAndTheFooter) {
-  std::map<std::string, std::shared_ptr<parquet::ColumnEncryptionProperties>>
-      encryption_cols2;
-  parquet::ColumnEncryptionProperties::Builder encryption_col_builder_20(
-      path_to_double_field_);
-  parquet::ColumnEncryptionProperties::Builder encryption_col_builder_21(
-      path_to_float_field_);
-  encryption_col_builder_20.key(kColumnEncryptionKey1_)->key_id("kc1");
-  encryption_col_builder_21.key(kColumnEncryptionKey2_)->key_id("kc2");
+  std::map<std::string, std::shared_ptr<ColumnEncryptionProperties>> encryption_cols2;
+  encryption_cols2[path_to_double_field_] =
+      ColumnEncryptionProperties::WithColumnKey(kColumnEncryptionKey1_, "kc1");
+  encryption_cols2[path_to_float_field_] =
+      ColumnEncryptionProperties::WithColumnKey(kColumnEncryptionKey2_, "kc2");
 
-  encryption_cols2[path_to_double_field_] = encryption_col_builder_20.build();
-  encryption_cols2[path_to_float_field_] = encryption_col_builder_21.build();
-
-  parquet::FileEncryptionProperties::Builder file_encryption_builder_2(
-      kFooterEncryptionKey_);
+  FileEncryptionProperties::Builder file_encryption_builder_2(kFooterEncryptionKey_);
 
   this->EncryptFile(file_encryption_builder_2.footer_key_metadata("kf")
                         ->encrypted_columns(std::move(encryption_cols2))
@@ -126,19 +117,13 @@ TEST_F(TestEncryptionConfiguration, EncryptTwoColumnsAndTheFooter) {
 // Don’t encrypt footer.
 // (plaintext footer mode, readable by legacy readers)
 TEST_F(TestEncryptionConfiguration, EncryptTwoColumnsWithPlaintextFooter) {
-  std::map<std::string, std::shared_ptr<parquet::ColumnEncryptionProperties>>
-      encryption_cols3;
-  parquet::ColumnEncryptionProperties::Builder encryption_col_builder_30(
-      path_to_double_field_);
-  parquet::ColumnEncryptionProperties::Builder encryption_col_builder_31(
-      path_to_float_field_);
-  encryption_col_builder_30.key(kColumnEncryptionKey1_)->key_id("kc1");
-  encryption_col_builder_31.key(kColumnEncryptionKey2_)->key_id("kc2");
+  std::map<std::string, std::shared_ptr<ColumnEncryptionProperties>> encryption_cols3;
+  encryption_cols3[path_to_double_field_] =
+      ColumnEncryptionProperties::WithColumnKey(kColumnEncryptionKey1_, "kc1");
+  encryption_cols3[path_to_float_field_] =
+      ColumnEncryptionProperties::WithColumnKey(kColumnEncryptionKey2_, "kc2");
 
-  encryption_cols3[path_to_double_field_] = encryption_col_builder_30.build();
-  encryption_cols3[path_to_float_field_] = encryption_col_builder_31.build();
-  parquet::FileEncryptionProperties::Builder file_encryption_builder_3(
-      kFooterEncryptionKey_);
+  FileEncryptionProperties::Builder file_encryption_builder_3(kFooterEncryptionKey_);
 
   this->EncryptFile(file_encryption_builder_3.footer_key_metadata("kf")
                         ->encrypted_columns(std::move(encryption_cols3))
@@ -150,19 +135,13 @@ TEST_F(TestEncryptionConfiguration, EncryptTwoColumnsWithPlaintextFooter) {
 // Encryption configuration 4: Encrypt two columns and the footer, with different keys.
 // Use aad_prefix.
 TEST_F(TestEncryptionConfiguration, EncryptTwoColumnsAndFooterWithAadPrefix) {
-  std::map<std::string, std::shared_ptr<parquet::ColumnEncryptionProperties>>
-      encryption_cols4;
-  parquet::ColumnEncryptionProperties::Builder encryption_col_builder_40(
-      path_to_double_field_);
-  parquet::ColumnEncryptionProperties::Builder encryption_col_builder_41(
-      path_to_float_field_);
-  encryption_col_builder_40.key(kColumnEncryptionKey1_)->key_id("kc1");
-  encryption_col_builder_41.key(kColumnEncryptionKey2_)->key_id("kc2");
+  std::map<std::string, std::shared_ptr<ColumnEncryptionProperties>> encryption_cols4;
+  encryption_cols4[path_to_double_field_] =
+      ColumnEncryptionProperties::WithColumnKey(kColumnEncryptionKey1_, "kc1");
+  encryption_cols4[path_to_float_field_] =
+      ColumnEncryptionProperties::WithColumnKey(kColumnEncryptionKey2_, "kc2");
 
-  encryption_cols4[path_to_double_field_] = encryption_col_builder_40.build();
-  encryption_cols4[path_to_float_field_] = encryption_col_builder_41.build();
-  parquet::FileEncryptionProperties::Builder file_encryption_builder_4(
-      kFooterEncryptionKey_);
+  FileEncryptionProperties::Builder file_encryption_builder_4(kFooterEncryptionKey_);
 
   this->EncryptFile(file_encryption_builder_4.footer_key_metadata("kf")
                         ->encrypted_columns(std::move(encryption_cols4))
@@ -175,19 +154,13 @@ TEST_F(TestEncryptionConfiguration, EncryptTwoColumnsAndFooterWithAadPrefix) {
 // Use aad_prefix and disable_aad_prefix_storage.
 TEST_F(TestEncryptionConfiguration,
        EncryptTwoColumnsAndFooterWithAadPrefixDisable_aad_prefix_storage) {
-  std::map<std::string, std::shared_ptr<parquet::ColumnEncryptionProperties>>
-      encryption_cols5;
-  parquet::ColumnEncryptionProperties::Builder encryption_col_builder_50(
-      path_to_double_field_);
-  parquet::ColumnEncryptionProperties::Builder encryption_col_builder_51(
-      path_to_float_field_);
-  encryption_col_builder_50.key(kColumnEncryptionKey1_)->key_id("kc1");
-  encryption_col_builder_51.key(kColumnEncryptionKey2_)->key_id("kc2");
+  std::map<std::string, std::shared_ptr<ColumnEncryptionProperties>> encryption_cols5;
+  encryption_cols5[path_to_double_field_] =
+      ColumnEncryptionProperties::WithColumnKey(kColumnEncryptionKey1_, "kc1");
+  encryption_cols5[path_to_float_field_] =
+      ColumnEncryptionProperties::WithColumnKey(kColumnEncryptionKey2_, "kc2");
 
-  encryption_cols5[path_to_double_field_] = encryption_col_builder_50.build();
-  encryption_cols5[path_to_float_field_] = encryption_col_builder_51.build();
-  parquet::FileEncryptionProperties::Builder file_encryption_builder_5(
-      kFooterEncryptionKey_);
+  FileEncryptionProperties::Builder file_encryption_builder_5(kFooterEncryptionKey_);
 
   this->EncryptFile(
       file_encryption_builder_5.encrypted_columns(std::move(encryption_cols5))
@@ -201,19 +174,13 @@ TEST_F(TestEncryptionConfiguration,
 // Encryption configuration 6: Encrypt two columns and the footer, with different keys.
 // Use AES_GCM_CTR_V1 algorithm.
 TEST_F(TestEncryptionConfiguration, EncryptTwoColumnsAndFooterUseAES_GCM_CTR) {
-  std::map<std::string, std::shared_ptr<parquet::ColumnEncryptionProperties>>
-      encryption_cols6;
-  parquet::ColumnEncryptionProperties::Builder encryption_col_builder_60(
-      path_to_double_field_);
-  parquet::ColumnEncryptionProperties::Builder encryption_col_builder_61(
-      path_to_float_field_);
-  encryption_col_builder_60.key(kColumnEncryptionKey1_)->key_id("kc1");
-  encryption_col_builder_61.key(kColumnEncryptionKey2_)->key_id("kc2");
+  std::map<std::string, std::shared_ptr<ColumnEncryptionProperties>> encryption_cols6;
+  encryption_cols6[path_to_double_field_] =
+      ColumnEncryptionProperties::WithColumnKey(kColumnEncryptionKey1_, "kc1");
+  encryption_cols6[path_to_float_field_] =
+      ColumnEncryptionProperties::WithColumnKey(kColumnEncryptionKey2_, "kc2");
 
-  encryption_cols6[path_to_double_field_] = encryption_col_builder_60.build();
-  encryption_cols6[path_to_float_field_] = encryption_col_builder_61.build();
-  parquet::FileEncryptionProperties::Builder file_encryption_builder_6(
-      kFooterEncryptionKey_);
+  FileEncryptionProperties::Builder file_encryption_builder_6(kFooterEncryptionKey_);
 
   EXPECT_NO_THROW(
       this->EncryptFile(file_encryption_builder_6.footer_key_metadata("kf")


### PR DESCRIPTION
### Rationale for this change

While working on PR #48336 I quickly got irritated by the clumsiness of the Parquet encryption configuration API. This issue attempts to reduce the verbosity of `ColumnEncryptionProperties` construction.

### What changes are included in this PR?

1. Remove unused `column_path` member in `ColumnEncryptionProperties`
2. Add convenience `ColumnEncryptionProperties` factory functions to avoid going through the clumsy `Builder` API

### Are these changes tested?

Yes

### Are there any user-facing changes?

Two deprecated constructors and a removed accessor for an useless property.

**This PR includes breaking changes to public APIs.** (If there are any breaking changes to public APIs, please explain which changes are breaking. If not, you can remove this.)

* GitHub Issue: #48337