### PR TITLE
GH-48346: [Ruby] Add support for reading boolean array

### DIFF
--- a/ruby/red-arrow-format/lib/arrow-format/bitmap.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/bitmap.rb
@@ -1,0 +1,44 @@
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+module ArrowFormat
+  class Bitmap
+    include Enumerable
+
+    def initialize(buffer, n_values)
+      @buffer = buffer
+      @n_values = n_values
+    end
+
+    def each
+      return to_enum(__method__) unless block_given?
+
+      n_bytes = @n_values / 8
+      @buffer.each(:U8, 0, n_bytes) do |offset, value|
+        7.times do |i|
+          yield(value & (1 << (i % 8)))
+        end
+      end
+      remained_bits = @n_values % 8
+      unless remained_bits.zero?
+        value = @buffer.get_value(:U8, n_bytes)
+        remained_bits.times do |i|
+          yield(value & (1 << (i % 8)))
+        end
+      end
+    end
+  end
+end

--- a/ruby/red-arrow-format/lib/arrow-format/file-reader.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/file-reader.rb
@@ -22,6 +22,7 @@ require_relative "record-batch"
 require_relative "schema"
 require_relative "type"
 
+require_relative "org/apache/arrow/flatbuf/bool"
 require_relative "org/apache/arrow/flatbuf/footer"
 require_relative "org/apache/arrow/flatbuf/message"
 require_relative "org/apache/arrow/flatbuf/binary"
@@ -134,6 +135,8 @@ module ArrowFormat
         case fb_type
         when Org::Apache::Arrow::Flatbuf::Null
           type = NullType.singleton
+        when Org::Apache::Arrow::Flatbuf::Bool
+          type = BooleanType.singleton
         when Org::Apache::Arrow::Flatbuf::Int
           case fb_type.bit_width
           when 8
@@ -164,7 +167,8 @@ module ArrowFormat
       end
 
       case field.type
-      when Int8Type,
+      when BooleanType,
+           Int8Type,
            UInt8Type
         values_buffer = buffers.shift
         values = body.slice(values_buffer.offset, values_buffer.length)

--- a/ruby/red-arrow-format/lib/arrow-format/type.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/type.rb
@@ -38,6 +38,22 @@ module ArrowFormat
     end
   end
 
+  class BooleanType < Type
+    class << self
+      def singleton
+        @singleton ||= new
+      end
+    end
+
+    def initialize
+      super("Boolean")
+    end
+
+    def build_array(size, validity_buffer, values_buffer)
+      BooleanArray.new(self, size, validity_buffer, values_buffer)
+    end
+  end
+
   class IntType < Type
     attr_reader :bit_width
     attr_reader :signed

--- a/ruby/red-arrow-format/test/test-file-reader.rb
+++ b/ruby/red-arrow-format/test/test-file-reader.rb
@@ -51,6 +51,17 @@ class TestFileReader < Test::Unit::TestCase
     end
   end
 
+  sub_test_case("Boolean") do
+    def build_array
+      Arrow::BooleanArray.new([true, nil, false])
+    end
+
+    def test_read
+      assert_equal([{"value" => [true, nil, false]}],
+                   read)
+    end
+  end
+
   sub_test_case("Int8") do
     def build_array
       Arrow::Int8Array.new([-128, nil, 127])


### PR DESCRIPTION
### Rationale for this change

This is a primitive type but we need to handle bitmap for boolean values.

### What changes are included in this PR?

* Add `ArrowFormat::BooleanType`
* Add `ArrowFormat::BooleanArray`

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #48346