### PR TITLE
MINOR: [Docs] Fix a typo in Flatbuffers and change http to https in License image at README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 # Apache Arrow
 
 [![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/arrow.svg)](https://bugs.chromium.org/p/oss-fuzz/issues/list?sort=-opened&can=1&q=proj:arrow)
-[![License](http://img.shields.io/:license-Apache%202-blue.svg)](https://github.com/apache/arrow/blob/main/LICENSE.txt)
+[![License](https://img.shields.io/:license-Apache%202-blue.svg)](https://github.com/apache/arrow/blob/main/LICENSE.txt)
 [![BlueSky Follow](https://img.shields.io/badge/bluesky-Follow-blue?logo=bluesky)](https://bsky.app/profile/arrow.apache.org)
 
 ## Powering In-Memory Analytics
@@ -68,7 +68,7 @@ The reference Arrow libraries contain many distinct software components:
 
 - Columnar vector and table-like containers (similar to data frames) supporting
   flat or nested types
-- Fast, language agnostic metadata messaging layer (using Google's Flatbuffers
+- Fast, language agnostic metadata messaging layer (using Google's FlatBuffers
   library)
 - Reference-counted off-heap buffer memory management, for zero-copy memory
   sharing and handling memory-mapped files


### PR DESCRIPTION
### Rationale for this change

- The official name is FlatBuffers
- Using safer way of getting the image (https)

### What changes are included in this PR?

Changing a typo, and license image link from http to https.

### Are these changes tested?

Yes, I tested via my browser.

### Are there any user-facing changes?

No, dev-only.
