### PR TITLE
MINOR: [Docs] Mention that linuxdoc should be installed via pip

### DIFF
--- a/docs/source/developers/documentation.rst
+++ b/docs/source/developers/documentation.rst
@@ -32,6 +32,10 @@ If you're using Conda, the required software can be installed in a single line:
 
    conda install -c conda-forge --file=arrow/ci/conda_env_sphinx.txt
 
+.. note::
+
+   ``linuxdoc`` cannot be installed by Conda. It has to be installed via pip separately.
+
 Otherwise, you'll first need to install `Doxygen <http://www.doxygen.nl/>`_
 yourself (for example from your distribution's official repositories, if
 using Linux).  Then you can install the Python-based requirements with the


### PR DESCRIPTION
### Rationale for this change

https://github.com/apache/arrow/blob/f0955f1b0019f4794bbc707eeefcb96eee856d1f/ci/conda_env_sphinx.txt#L24-L26

Documentation build requires `linuxdoc` but it cannot be installed via Conda. Therefore, has to be documented properly for dev.

### What changes are included in this PR?

This PR adds a note about `linuxdoc` that has to be installed via `pip` to successfully build documentation.

### Are these changes tested?

Yes

<img width="689" height="435" alt="Screenshot 2025-12-05 at 4 12 10 PM" src="https://github.com/user-attachments/assets/1595ea39-ade8-42ea-a6c1-b2fc662b583b" />


### Are there any user-facing changes?

No