### PR TITLE
MINOR: [Python] Remove obsolete is_map TODO comment

### DIFF
--- a/python/pyarrow/tests/test_types.py
+++ b/python/pyarrow/tests/test_types.py
@@ -260,9 +260,6 @@ def test_is_run_end_encoded():
     assert not types.is_run_end_encoded(pa.utf8())
 
 
-# TODO(wesm): is_map, once implemented
-
-
 def test_is_binary_string():
     assert types.is_binary(pa.binary())
     assert not types.is_binary(pa.string())


### PR DESCRIPTION
### Rationale for this change

This TODO was added in https://github.com/apache/arrow/commit/eaeb5d4820ce36484aaa78a15fe5bf957a53651e. However, now we have map support properly, and its test was added in https://github.com/apache/arrow/commit/e0c1ffe9c38d1759f1b5311f95864b0e2a406c51

### What changes are included in this PR?

This PR proposes to remove obsolete is_map TODO comment.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.