### PR TITLE
GH-48355: [Python] Remove obsolete snprintf workaround for Python 3.9

### DIFF
--- a/python/pyarrow/src/arrow/python/platform.h
+++ b/python/pyarrow/src/arrow/python/platform.h
@@ -32,10 +32,4 @@
 #  if _MSC_VER >= 1900
 #    undef timezone
 #  endif
-
-// https://bugs.python.org/issue36020
-// TODO(wjones127): Can remove once we drop support for CPython 3.9
-#  ifdef snprintf
-#    undef snprintf
-#  endif
 #endif


### PR DESCRIPTION
### Rationale for this change

https://github.com/apache/arrow/commit/e9b9042a058333b68849a640b510e94413a29d91 added the workaround for Python 3.9 on Windows. However, PyArrow dropped Python 3.9 at https://github.com/apache/arrow/commit/aedb752762174b7971fe13a42d2b925bd76da3be. Per https://github.com/python/cpython/commit/e822e37946f27c09953bb5733acf3b07c2db690f, this should be fine to be removed.

### What changes are included in this PR?

This PR proposes to remove obsolete snprintf workaround for Python 3.9 on Windows.

### Are these changes tested?

I tested locally but do not have Windows environment. I will rely on CI.

### Are there any user-facing changes?

No.

* GitHub Issue: #48355