### PR TITLE
GH-48356: [GLib][Ruby] Add missing options classes

### DIFF
--- a/c_glib/arrow-glib/array-builder.h
+++ b/c_glib/arrow-glib/array-builder.h
@@ -1635,6 +1635,32 @@ GARROW_AVAILABLE_IN_0_16
 GArrowArrayBuilder *
 garrow_large_list_array_builder_get_value_builder(GArrowLargeListArrayBuilder *builder);
 
+#define GARROW_TYPE_FIXED_SIZE_LIST_ARRAY_BUILDER                                        \
+  (garrow_fixed_size_list_array_builder_get_type())
+GARROW_AVAILABLE_IN_23_0
+G_DECLARE_DERIVABLE_TYPE(GArrowFixedSizeListArrayBuilder,
+                         garrow_fixed_size_list_array_builder,
+                         GARROW,
+                         FIXED_SIZE_LIST_ARRAY_BUILDER,
+                         GArrowArrayBuilder)
+struct _GArrowFixedSizeListArrayBuilderClass
+{
+  GArrowArrayBuilderClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_23_0
+GArrowFixedSizeListArrayBuilder *
+garrow_fixed_size_list_array_builder_new(GArrowFixedSizeListDataType *data_type,
+                                         GError **error);
+GARROW_AVAILABLE_IN_23_0
+gboolean
+garrow_fixed_size_list_array_builder_append_value(
+  GArrowFixedSizeListArrayBuilder *builder, GError **error);
+GARROW_AVAILABLE_IN_23_0
+GArrowArrayBuilder *
+garrow_fixed_size_list_array_builder_get_value_builder(
+  GArrowFixedSizeListArrayBuilder *builder);
+
 #define GARROW_TYPE_STRUCT_ARRAY_BUILDER (garrow_struct_array_builder_get_type())
 GARROW_AVAILABLE_IN_ALL
 G_DECLARE_DERIVABLE_TYPE(GArrowStructArrayBuilder,

--- a/c_glib/arrow-glib/basic-array.cpp
+++ b/c_glib/arrow-glib/basic-array.cpp
@@ -4005,6 +4005,9 @@ garrow_array_new_raw_valist(std::shared_ptr<arrow::Array> *arrow_array,
   case arrow::Type::type::LARGE_LIST:
     type = GARROW_TYPE_LARGE_LIST_ARRAY;
     break;
+  case arrow::Type::type::FIXED_SIZE_LIST:
+    type = GARROW_TYPE_FIXED_SIZE_LIST_ARRAY;
+    break;
   case arrow::Type::type::STRUCT:
     type = GARROW_TYPE_STRUCT_ARRAY;
     break;

--- a/c_glib/arrow-glib/composite-array.h
+++ b/c_glib/arrow-glib/composite-array.h
@@ -110,6 +110,50 @@ GARROW_AVAILABLE_IN_2_0
 const gint64 *
 garrow_large_list_array_get_value_offsets(GArrowLargeListArray *array, gint64 *n_offsets);
 
+#define GARROW_TYPE_FIXED_SIZE_LIST_ARRAY (garrow_fixed_size_list_array_get_type())
+GARROW_AVAILABLE_IN_23_0
+G_DECLARE_DERIVABLE_TYPE(GArrowFixedSizeListArray,
+                         garrow_fixed_size_list_array,
+                         GARROW,
+                         FIXED_SIZE_LIST_ARRAY,
+                         GArrowArray)
+struct _GArrowFixedSizeListArrayClass
+{
+  GArrowArrayClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_23_0
+GArrowFixedSizeListArray *
+garrow_fixed_size_list_array_new(GArrowDataType *data_type,
+                                 gint64 length,
+                                 GArrowArray *values,
+                                 GArrowBuffer *null_bitmap,
+                                 gint64 n_nulls);
+
+GARROW_AVAILABLE_IN_23_0
+GArrowDataType *
+garrow_fixed_size_list_array_get_value_type(GArrowFixedSizeListArray *array);
+
+GARROW_AVAILABLE_IN_23_0
+GArrowArray *
+garrow_fixed_size_list_array_get_value(GArrowFixedSizeListArray *array, gint64 i);
+
+GARROW_AVAILABLE_IN_23_0
+GArrowArray *
+garrow_fixed_size_list_array_get_values(GArrowFixedSizeListArray *array);
+
+GARROW_AVAILABLE_IN_23_0
+gint64
+garrow_fixed_size_list_array_get_value_offset(GArrowFixedSizeListArray *array, gint64 i);
+
+GARROW_AVAILABLE_IN_23_0
+gint32
+garrow_fixed_size_list_array_get_value_length(GArrowFixedSizeListArray *array, gint64 i);
+
+GARROW_AVAILABLE_IN_23_0
+gint32
+garrow_fixed_size_list_array_get_list_size(GArrowFixedSizeListArray *array);
+
 #define GARROW_TYPE_STRUCT_ARRAY (garrow_struct_array_get_type())
 GARROW_AVAILABLE_IN_ALL
 G_DECLARE_DERIVABLE_TYPE(

--- a/c_glib/arrow-glib/compute.cpp
+++ b/c_glib/arrow-glib/compute.cpp
@@ -272,6 +272,9 @@ G_BEGIN_DECLS
  * #GArrowExtractRegexSpanOptions is a class to customize the `extract_regex_span`
  * function.
  *
+ * #GArrowJoinOptions is a class to customize the `binary_join_element_wise`
+ * function.
+ *
  * There are many functions to compute data on an array.
  */
 
@@ -7190,6 +7193,125 @@ garrow_extract_regex_span_options_new(void)
   return GARROW_EXTRACT_REGEX_SPAN_OPTIONS(options);
 }
 
+enum {
+  PROP_JOIN_OPTIONS_NULL_HANDLING = 1,
+  PROP_JOIN_OPTIONS_NULL_REPLACEMENT,
+};
+
+G_DEFINE_TYPE(GArrowJoinOptions, garrow_join_options, GARROW_TYPE_FUNCTION_OPTIONS)
+
+static void
+garrow_join_options_set_property(GObject *object,
+                                 guint prop_id,
+                                 const GValue *value,
+                                 GParamSpec *pspec)
+{
+  auto options = garrow_join_options_get_raw(GARROW_JOIN_OPTIONS(object));
+
+  switch (prop_id) {
+  case PROP_JOIN_OPTIONS_NULL_HANDLING:
+    options->null_handling =
+      static_cast<arrow::compute::JoinOptions::NullHandlingBehavior>(
+        g_value_get_enum(value));
+    break;
+  case PROP_JOIN_OPTIONS_NULL_REPLACEMENT:
+    options->null_replacement = g_value_get_string(value);
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+garrow_join_options_get_property(GObject *object,
+                                 guint prop_id,
+                                 GValue *value,
+                                 GParamSpec *pspec)
+{
+  auto options = garrow_join_options_get_raw(GARROW_JOIN_OPTIONS(object));
+
+  switch (prop_id) {
+  case PROP_JOIN_OPTIONS_NULL_HANDLING:
+    g_value_set_enum(value,
+                     static_cast<GArrowJoinNullHandlingBehavior>(options->null_handling));
+    break;
+  case PROP_JOIN_OPTIONS_NULL_REPLACEMENT:
+    g_value_set_string(value, options->null_replacement.c_str());
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+garrow_join_options_init(GArrowJoinOptions *object)
+{
+  auto priv = GARROW_FUNCTION_OPTIONS_GET_PRIVATE(object);
+  priv->options =
+    static_cast<arrow::compute::FunctionOptions *>(new arrow::compute::JoinOptions());
+}
+
+static void
+garrow_join_options_class_init(GArrowJoinOptionsClass *klass)
+{
+  auto gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->set_property = garrow_join_options_set_property;
+  gobject_class->get_property = garrow_join_options_get_property;
+
+  arrow::compute::JoinOptions options;
+
+  GParamSpec *spec;
+  /**
+   * GArrowJoinOptions:null-handling:
+   *
+   * How to handle null values. (A null separator always results in a null output.)
+   *
+   * Since: 23.0.0
+   */
+  spec =
+    g_param_spec_enum("null-handling",
+                      "Null handling",
+                      "How to handle null values",
+                      GARROW_TYPE_JOIN_NULL_HANDLING_BEHAVIOR,
+                      static_cast<GArrowJoinNullHandlingBehavior>(options.null_handling),
+                      static_cast<GParamFlags>(G_PARAM_READWRITE));
+  g_object_class_install_property(gobject_class, PROP_JOIN_OPTIONS_NULL_HANDLING, spec);
+
+  /**
+   * GArrowJoinOptions:null-replacement:
+   *
+   * Replacement string for null values when null-handling is REPLACE.
+   *
+   * Since: 23.0.0
+   */
+  spec = g_param_spec_string(
+    "null-replacement",
+    "Null replacement",
+    "Replacement string for null values when null-handling is REPLACE",
+    options.null_replacement.c_str(),
+    static_cast<GParamFlags>(G_PARAM_READWRITE));
+  g_object_class_install_property(gobject_class,
+                                  PROP_JOIN_OPTIONS_NULL_REPLACEMENT,
+                                  spec);
+}
+
+/**
+ * garrow_join_options_new:
+ *
+ * Returns: A newly created #GArrowJoinOptions.
+ *
+ * Since: 23.0.0
+ */
+GArrowJoinOptions *
+garrow_join_options_new(void)
+{
+  auto options = g_object_new(GARROW_TYPE_JOIN_OPTIONS, NULL);
+  return GARROW_JOIN_OPTIONS(options);
+}
+
 G_END_DECLS
 
 arrow::Result<arrow::FieldRef>
@@ -7358,6 +7480,11 @@ garrow_function_options_new_raw(const arrow::compute::FunctionOptions *arrow_opt
       static_cast<const arrow::compute::ExtractRegexSpanOptions *>(arrow_options);
     auto options =
       garrow_extract_regex_span_options_new_raw(arrow_extract_regex_span_options);
+    return GARROW_FUNCTION_OPTIONS(options);
+  } else if (arrow_type_name == "JoinOptions") {
+    const auto arrow_join_options =
+      static_cast<const arrow::compute::JoinOptions *>(arrow_options);
+    auto options = garrow_join_options_new_raw(arrow_join_options);
     return GARROW_FUNCTION_OPTIONS(options);
   } else {
     auto options = g_object_new(GARROW_TYPE_FUNCTION_OPTIONS, NULL);
@@ -8014,5 +8141,24 @@ arrow::compute::ExtractRegexSpanOptions *
 garrow_extract_regex_span_options_get_raw(GArrowExtractRegexSpanOptions *options)
 {
   return static_cast<arrow::compute::ExtractRegexSpanOptions *>(
+    garrow_function_options_get_raw(GARROW_FUNCTION_OPTIONS(options)));
+}
+
+GArrowJoinOptions *
+garrow_join_options_new_raw(const arrow::compute::JoinOptions *arrow_options)
+{
+  return GARROW_JOIN_OPTIONS(g_object_new(
+    GARROW_TYPE_JOIN_OPTIONS,
+    "null-handling",
+    static_cast<GArrowJoinNullHandlingBehavior>(arrow_options->null_handling),
+    "null-replacement",
+    arrow_options->null_replacement.c_str(),
+    NULL));
+}
+
+arrow::compute::JoinOptions *
+garrow_join_options_get_raw(GArrowJoinOptions *options)
+{
+  return static_cast<arrow::compute::JoinOptions *>(
     garrow_function_options_get_raw(GARROW_FUNCTION_OPTIONS(options)));
 }

--- a/c_glib/arrow-glib/compute.cpp
+++ b/c_glib/arrow-glib/compute.cpp
@@ -295,6 +295,9 @@ G_BEGIN_DECLS
  * `utf8_lpad`, `utf8_rpad`, `utf8_center`, `ascii_lpad`, `ascii_rpad`, and
  * `ascii_center`.
  *
+ * #GArrowPairwiseOptions is a class to customize the pairwise functions such as
+ * `pairwise_diff` and `pairwise_diff_checked`.
+ *
  * There are many functions to compute data on an array.
  */
 
@@ -8279,6 +8282,100 @@ garrow_pad_options_new(void)
   return GARROW_PAD_OPTIONS(g_object_new(GARROW_TYPE_PAD_OPTIONS, NULL));
 }
 
+enum {
+  PROP_PAIRWISE_OPTIONS_PERIODS = 1,
+};
+
+G_DEFINE_TYPE(GArrowPairwiseOptions,
+              garrow_pairwise_options,
+              GARROW_TYPE_FUNCTION_OPTIONS)
+
+static void
+garrow_pairwise_options_set_property(GObject *object,
+                                     guint prop_id,
+                                     const GValue *value,
+                                     GParamSpec *pspec)
+{
+  auto options = garrow_pairwise_options_get_raw(GARROW_PAIRWISE_OPTIONS(object));
+
+  switch (prop_id) {
+  case PROP_PAIRWISE_OPTIONS_PERIODS:
+    options->periods = g_value_get_int64(value);
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+garrow_pairwise_options_get_property(GObject *object,
+                                     guint prop_id,
+                                     GValue *value,
+                                     GParamSpec *pspec)
+{
+  auto options = garrow_pairwise_options_get_raw(GARROW_PAIRWISE_OPTIONS(object));
+
+  switch (prop_id) {
+  case PROP_PAIRWISE_OPTIONS_PERIODS:
+    g_value_set_int64(value, options->periods);
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+garrow_pairwise_options_init(GArrowPairwiseOptions *object)
+{
+  auto priv = GARROW_FUNCTION_OPTIONS_GET_PRIVATE(object);
+  priv->options =
+    static_cast<arrow::compute::FunctionOptions *>(new arrow::compute::PairwiseOptions());
+}
+
+static void
+garrow_pairwise_options_class_init(GArrowPairwiseOptionsClass *klass)
+{
+  auto gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->set_property = garrow_pairwise_options_set_property;
+  gobject_class->get_property = garrow_pairwise_options_get_property;
+
+  arrow::compute::PairwiseOptions options;
+
+  GParamSpec *spec;
+  /**
+   * GArrowPairwiseOptions:periods:
+   *
+   * Periods to shift for applying the binary operation, accepts negative values.
+   *
+   * Since: 23.0.0
+   */
+  spec = g_param_spec_int64(
+    "periods",
+    "Periods",
+    "Periods to shift for applying the binary operation, accepts negative values",
+    G_MININT64,
+    G_MAXINT64,
+    options.periods,
+    static_cast<GParamFlags>(G_PARAM_READWRITE));
+  g_object_class_install_property(gobject_class, PROP_PAIRWISE_OPTIONS_PERIODS, spec);
+}
+
+/**
+ * garrow_pairwise_options_new:
+ *
+ * Returns: A newly created #GArrowPairwiseOptions.
+ *
+ * Since: 23.0.0
+ */
+GArrowPairwiseOptions *
+garrow_pairwise_options_new(void)
+{
+  return GARROW_PAIRWISE_OPTIONS(g_object_new(GARROW_TYPE_PAIRWISE_OPTIONS, NULL));
+}
+
 G_END_DECLS
 
 arrow::Result<arrow::FieldRef>
@@ -8482,6 +8579,11 @@ garrow_function_options_new_raw(const arrow::compute::FunctionOptions *arrow_opt
     const auto arrow_pad_options =
       static_cast<const arrow::compute::PadOptions *>(arrow_options);
     auto options = garrow_pad_options_new_raw(arrow_pad_options);
+    return GARROW_FUNCTION_OPTIONS(options);
+  } else if (arrow_type_name == "PairwiseOptions") {
+    const auto arrow_pairwise_options =
+      static_cast<const arrow::compute::PairwiseOptions *>(arrow_options);
+    auto options = garrow_pairwise_options_new_raw(arrow_pairwise_options);
     return GARROW_FUNCTION_OPTIONS(options);
   } else {
     auto options = g_object_new(GARROW_TYPE_FUNCTION_OPTIONS, NULL);
@@ -9309,5 +9411,19 @@ arrow::compute::PadOptions *
 garrow_pad_options_get_raw(GArrowPadOptions *options)
 {
   return static_cast<arrow::compute::PadOptions *>(
+    garrow_function_options_get_raw(GARROW_FUNCTION_OPTIONS(options)));
+}
+
+GArrowPairwiseOptions *
+garrow_pairwise_options_new_raw(const arrow::compute::PairwiseOptions *arrow_options)
+{
+  return GARROW_PAIRWISE_OPTIONS(
+    g_object_new(GARROW_TYPE_PAIRWISE_OPTIONS, "periods", arrow_options->periods, NULL));
+}
+
+arrow::compute::PairwiseOptions *
+garrow_pairwise_options_get_raw(GArrowPairwiseOptions *options)
+{
+  return static_cast<arrow::compute::PairwiseOptions *>(
     garrow_function_options_get_raw(GARROW_FUNCTION_OPTIONS(options)));
 }

--- a/c_glib/arrow-glib/compute.cpp
+++ b/c_glib/arrow-glib/compute.cpp
@@ -269,6 +269,9 @@ G_BEGIN_DECLS
  * #GArrowExtractRegexOptions is a class to customize the `extract_regex`
  * function.
  *
+ * #GArrowExtractRegexSpanOptions is a class to customize the `extract_regex_span`
+ * function.
+ *
  * There are many functions to compute data on an array.
  */
 
@@ -7091,6 +7094,102 @@ garrow_extract_regex_options_new(void)
   return GARROW_EXTRACT_REGEX_OPTIONS(options);
 }
 
+enum {
+  PROP_EXTRACT_REGEX_SPAN_OPTIONS_PATTERN = 1,
+};
+
+G_DEFINE_TYPE(GArrowExtractRegexSpanOptions,
+              garrow_extract_regex_span_options,
+              GARROW_TYPE_FUNCTION_OPTIONS)
+
+static void
+garrow_extract_regex_span_options_set_property(GObject *object,
+                                               guint prop_id,
+                                               const GValue *value,
+                                               GParamSpec *pspec)
+{
+  auto options =
+    garrow_extract_regex_span_options_get_raw(GARROW_EXTRACT_REGEX_SPAN_OPTIONS(object));
+
+  switch (prop_id) {
+  case PROP_EXTRACT_REGEX_SPAN_OPTIONS_PATTERN:
+    options->pattern = g_value_get_string(value);
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+garrow_extract_regex_span_options_get_property(GObject *object,
+                                               guint prop_id,
+                                               GValue *value,
+                                               GParamSpec *pspec)
+{
+  auto options =
+    garrow_extract_regex_span_options_get_raw(GARROW_EXTRACT_REGEX_SPAN_OPTIONS(object));
+
+  switch (prop_id) {
+  case PROP_EXTRACT_REGEX_SPAN_OPTIONS_PATTERN:
+    g_value_set_string(value, options->pattern.c_str());
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+garrow_extract_regex_span_options_init(GArrowExtractRegexSpanOptions *object)
+{
+  auto priv = GARROW_FUNCTION_OPTIONS_GET_PRIVATE(object);
+  priv->options = static_cast<arrow::compute::FunctionOptions *>(
+    new arrow::compute::ExtractRegexSpanOptions());
+}
+
+static void
+garrow_extract_regex_span_options_class_init(GArrowExtractRegexSpanOptionsClass *klass)
+{
+  auto gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->set_property = garrow_extract_regex_span_options_set_property;
+  gobject_class->get_property = garrow_extract_regex_span_options_get_property;
+
+  arrow::compute::ExtractRegexSpanOptions options;
+
+  GParamSpec *spec;
+  /**
+   * GArrowExtractRegexSpanOptions:pattern:
+   *
+   * Regular expression with named capture fields.
+   *
+   * Since: 23.0.0
+   */
+  spec = g_param_spec_string("pattern",
+                             "Pattern",
+                             "Regular expression with named capture fields",
+                             options.pattern.c_str(),
+                             static_cast<GParamFlags>(G_PARAM_READWRITE));
+  g_object_class_install_property(gobject_class,
+                                  PROP_EXTRACT_REGEX_SPAN_OPTIONS_PATTERN,
+                                  spec);
+}
+
+/**
+ * garrow_extract_regex_span_options_new:
+ *
+ * Returns: A newly created #GArrowExtractRegexSpanOptions.
+ *
+ * Since: 23.0.0
+ */
+GArrowExtractRegexSpanOptions *
+garrow_extract_regex_span_options_new(void)
+{
+  auto options = g_object_new(GARROW_TYPE_EXTRACT_REGEX_SPAN_OPTIONS, NULL);
+  return GARROW_EXTRACT_REGEX_SPAN_OPTIONS(options);
+}
+
 G_END_DECLS
 
 arrow::Result<arrow::FieldRef>
@@ -7253,6 +7352,12 @@ garrow_function_options_new_raw(const arrow::compute::FunctionOptions *arrow_opt
     const auto arrow_extract_regex_options =
       static_cast<const arrow::compute::ExtractRegexOptions *>(arrow_options);
     auto options = garrow_extract_regex_options_new_raw(arrow_extract_regex_options);
+    return GARROW_FUNCTION_OPTIONS(options);
+  } else if (arrow_type_name == "ExtractRegexSpanOptions") {
+    const auto arrow_extract_regex_span_options =
+      static_cast<const arrow::compute::ExtractRegexSpanOptions *>(arrow_options);
+    auto options =
+      garrow_extract_regex_span_options_new_raw(arrow_extract_regex_span_options);
     return GARROW_FUNCTION_OPTIONS(options);
   } else {
     auto options = g_object_new(GARROW_TYPE_FUNCTION_OPTIONS, NULL);
@@ -7891,5 +7996,23 @@ arrow::compute::ExtractRegexOptions *
 garrow_extract_regex_options_get_raw(GArrowExtractRegexOptions *options)
 {
   return static_cast<arrow::compute::ExtractRegexOptions *>(
+    garrow_function_options_get_raw(GARROW_FUNCTION_OPTIONS(options)));
+}
+
+GArrowExtractRegexSpanOptions *
+garrow_extract_regex_span_options_new_raw(
+  const arrow::compute::ExtractRegexSpanOptions *arrow_options)
+{
+  return GARROW_EXTRACT_REGEX_SPAN_OPTIONS(
+    g_object_new(GARROW_TYPE_EXTRACT_REGEX_SPAN_OPTIONS,
+                 "pattern",
+                 arrow_options->pattern.c_str(),
+                 NULL));
+}
+
+arrow::compute::ExtractRegexSpanOptions *
+garrow_extract_regex_span_options_get_raw(GArrowExtractRegexSpanOptions *options)
+{
+  return static_cast<arrow::compute::ExtractRegexSpanOptions *>(
     garrow_function_options_get_raw(GARROW_FUNCTION_OPTIONS(options)));
 }

--- a/c_glib/arrow-glib/compute.cpp
+++ b/c_glib/arrow-glib/compute.cpp
@@ -289,6 +289,8 @@ G_BEGIN_DECLS
  *
  * #GArrowModeOptions is a class to customize the `mode` function.
  *
+ * #GArrowNullOptions is a class to customize the `is_null` function.
+ *
  * There are many functions to compute data on an array.
  */
 
@@ -8043,6 +8045,95 @@ garrow_mode_options_new(void)
   return GARROW_MODE_OPTIONS(g_object_new(GARROW_TYPE_MODE_OPTIONS, NULL));
 }
 
+enum {
+  PROP_NULL_OPTIONS_NAN_IS_NULL = 1,
+};
+
+G_DEFINE_TYPE(GArrowNullOptions, garrow_null_options, GARROW_TYPE_FUNCTION_OPTIONS)
+
+static void
+garrow_null_options_set_property(GObject *object,
+                                 guint prop_id,
+                                 const GValue *value,
+                                 GParamSpec *pspec)
+{
+  auto options = garrow_null_options_get_raw(GARROW_NULL_OPTIONS(object));
+
+  switch (prop_id) {
+  case PROP_NULL_OPTIONS_NAN_IS_NULL:
+    options->nan_is_null = g_value_get_boolean(value);
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+garrow_null_options_get_property(GObject *object,
+                                 guint prop_id,
+                                 GValue *value,
+                                 GParamSpec *pspec)
+{
+  auto options = garrow_null_options_get_raw(GARROW_NULL_OPTIONS(object));
+
+  switch (prop_id) {
+  case PROP_NULL_OPTIONS_NAN_IS_NULL:
+    g_value_set_boolean(value, options->nan_is_null);
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+garrow_null_options_init(GArrowNullOptions *object)
+{
+  auto priv = GARROW_FUNCTION_OPTIONS_GET_PRIVATE(object);
+  priv->options =
+    static_cast<arrow::compute::FunctionOptions *>(new arrow::compute::NullOptions());
+}
+
+static void
+garrow_null_options_class_init(GArrowNullOptionsClass *klass)
+{
+  auto gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->set_property = garrow_null_options_set_property;
+  gobject_class->get_property = garrow_null_options_get_property;
+
+  arrow::compute::NullOptions options;
+
+  GParamSpec *spec;
+  /**
+   * GArrowNullOptions:nan-is-null:
+   *
+   * Whether floating-point NaN values are considered null.
+   *
+   * Since: 23.0.0
+   */
+  spec = g_param_spec_boolean("nan-is-null",
+                              "NaN is null",
+                              "Whether floating-point NaN values are considered null",
+                              options.nan_is_null,
+                              static_cast<GParamFlags>(G_PARAM_READWRITE));
+  g_object_class_install_property(gobject_class, PROP_NULL_OPTIONS_NAN_IS_NULL, spec);
+}
+
+/**
+ * garrow_null_options_new:
+ *
+ * Returns: A newly created #GArrowNullOptions.
+ *
+ * Since: 23.0.0
+ */
+GArrowNullOptions *
+garrow_null_options_new(void)
+{
+  return GARROW_NULL_OPTIONS(g_object_new(GARROW_TYPE_NULL_OPTIONS, NULL));
+}
+
 G_END_DECLS
 
 arrow::Result<arrow::FieldRef>
@@ -8236,6 +8327,11 @@ garrow_function_options_new_raw(const arrow::compute::FunctionOptions *arrow_opt
     const auto arrow_mode_options =
       static_cast<const arrow::compute::ModeOptions *>(arrow_options);
     auto options = garrow_mode_options_new_raw(arrow_mode_options);
+    return GARROW_FUNCTION_OPTIONS(options);
+  } else if (arrow_type_name == "NullOptions") {
+    const auto arrow_null_options =
+      static_cast<const arrow::compute::NullOptions *>(arrow_options);
+    auto options = garrow_null_options_new_raw(arrow_null_options);
     return GARROW_FUNCTION_OPTIONS(options);
   } else {
     auto options = g_object_new(GARROW_TYPE_FUNCTION_OPTIONS, NULL);
@@ -9027,5 +9123,21 @@ arrow::compute::ModeOptions *
 garrow_mode_options_get_raw(GArrowModeOptions *options)
 {
   return static_cast<arrow::compute::ModeOptions *>(
+    garrow_function_options_get_raw(GARROW_FUNCTION_OPTIONS(options)));
+}
+
+GArrowNullOptions *
+garrow_null_options_new_raw(const arrow::compute::NullOptions *arrow_options)
+{
+  return GARROW_NULL_OPTIONS(g_object_new(GARROW_TYPE_NULL_OPTIONS,
+                                          "nan-is-null",
+                                          arrow_options->nan_is_null,
+                                          NULL));
+}
+
+arrow::compute::NullOptions *
+garrow_null_options_get_raw(GArrowNullOptions *options)
+{
+  return static_cast<arrow::compute::NullOptions *>(
     garrow_function_options_get_raw(GARROW_FUNCTION_OPTIONS(options)));
 }

--- a/c_glib/arrow-glib/compute.cpp
+++ b/c_glib/arrow-glib/compute.cpp
@@ -336,6 +336,8 @@ G_BEGIN_DECLS
  *
  * #GArrowWeekOptions is a class to customize the `week` function.
  *
+ * #GArrowWinsorizeOptions is a class to customize the `winsorize` function.
+ *
  * There are many functions to compute data on an array.
  */
 
@@ -10504,6 +10506,136 @@ garrow_week_options_new(void)
   return GARROW_WEEK_OPTIONS(g_object_new(GARROW_TYPE_WEEK_OPTIONS, NULL));
 }
 
+enum {
+  PROP_WINSORIZE_OPTIONS_LOWER_LIMIT = 1,
+  PROP_WINSORIZE_OPTIONS_UPPER_LIMIT,
+};
+
+G_DEFINE_TYPE(GArrowWinsorizeOptions,
+              garrow_winsorize_options,
+              GARROW_TYPE_FUNCTION_OPTIONS)
+
+static void
+garrow_winsorize_options_set_property(GObject *object,
+                                      guint prop_id,
+                                      const GValue *value,
+                                      GParamSpec *pspec)
+{
+  auto options = garrow_winsorize_options_get_raw(GARROW_WINSORIZE_OPTIONS(object));
+
+  switch (prop_id) {
+  case PROP_WINSORIZE_OPTIONS_LOWER_LIMIT:
+    options->lower_limit = g_value_get_double(value);
+    break;
+  case PROP_WINSORIZE_OPTIONS_UPPER_LIMIT:
+    options->upper_limit = g_value_get_double(value);
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+garrow_winsorize_options_get_property(GObject *object,
+                                      guint prop_id,
+                                      GValue *value,
+                                      GParamSpec *pspec)
+{
+  auto options = garrow_winsorize_options_get_raw(GARROW_WINSORIZE_OPTIONS(object));
+
+  switch (prop_id) {
+  case PROP_WINSORIZE_OPTIONS_LOWER_LIMIT:
+    g_value_set_double(value, options->lower_limit);
+    break;
+  case PROP_WINSORIZE_OPTIONS_UPPER_LIMIT:
+    g_value_set_double(value, options->upper_limit);
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+garrow_winsorize_options_init(GArrowWinsorizeOptions *object)
+{
+  auto priv = GARROW_FUNCTION_OPTIONS_GET_PRIVATE(object);
+  priv->options = static_cast<arrow::compute::FunctionOptions *>(
+    new arrow::compute::WinsorizeOptions());
+}
+
+static void
+garrow_winsorize_options_class_init(GArrowWinsorizeOptionsClass *klass)
+{
+  auto gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->set_property = garrow_winsorize_options_set_property;
+  gobject_class->get_property = garrow_winsorize_options_get_property;
+
+  auto options = arrow::compute::WinsorizeOptions();
+
+  GParamSpec *spec;
+  /**
+   * GArrowWinsorizeOptions:lower-limit:
+   *
+   * The quantile below which all values are replaced with the quantile's value.
+   * For example, if lower_limit = 0.05, then all values in the lower 5% percentile
+   * will be replaced with the 5% percentile value.
+   *
+   * Since: 23.0.0
+   */
+  spec = g_param_spec_double(
+    "lower-limit",
+    "Lower limit",
+    "The quantile below which all values are replaced with the quantile's value. For "
+    "example, if lower_limit = 0.05, then all values in the lower 5% percentile will be "
+    "replaced with the 5% percentile value",
+    0.0,
+    1.0,
+    options.lower_limit,
+    static_cast<GParamFlags>(G_PARAM_READWRITE));
+  g_object_class_install_property(gobject_class,
+                                  PROP_WINSORIZE_OPTIONS_LOWER_LIMIT,
+                                  spec);
+
+  /**
+   * GArrowWinsorizeOptions:upper-limit:
+   *
+   * The quantile above which all values are replaced with the quantile's value.
+   * For example, if upper_limit = 0.95, then all values in the upper 95% percentile
+   * will be replaced with the 95% percentile value.
+   *
+   * Since: 23.0.0
+   */
+  spec = g_param_spec_double(
+    "upper-limit",
+    "Upper limit",
+    "The quantile above which all values are replaced with the quantile's value. For "
+    "example, if upper_limit = 0.95, then all values in the upper 95% percentile will be "
+    "replaced with the 95% percentile value",
+    0.0,
+    1.0,
+    options.upper_limit,
+    static_cast<GParamFlags>(G_PARAM_READWRITE));
+  g_object_class_install_property(gobject_class,
+                                  PROP_WINSORIZE_OPTIONS_UPPER_LIMIT,
+                                  spec);
+}
+
+/**
+ * garrow_winsorize_options_new:
+ *
+ * Returns: A newly created #GArrowWinsorizeOptions.
+ *
+ * Since: 23.0.0
+ */
+GArrowWinsorizeOptions *
+garrow_winsorize_options_new(void)
+{
+  return GARROW_WINSORIZE_OPTIONS(g_object_new(GARROW_TYPE_WINSORIZE_OPTIONS, NULL));
+}
+
 G_END_DECLS
 
 arrow::Result<arrow::FieldRef>
@@ -10783,6 +10915,11 @@ garrow_function_options_new_raw(const arrow::compute::FunctionOptions *arrow_opt
     const auto arrow_week_options =
       static_cast<const arrow::compute::WeekOptions *>(arrow_options);
     auto options = garrow_week_options_new_raw(arrow_week_options);
+    return GARROW_FUNCTION_OPTIONS(options);
+  } else if (arrow_type_name == "WinsorizeOptions") {
+    const auto arrow_winsorize_options =
+      static_cast<const arrow::compute::WinsorizeOptions *>(arrow_options);
+    auto options = garrow_winsorize_options_new_raw(arrow_winsorize_options);
     return GARROW_FUNCTION_OPTIONS(options);
   } else {
     auto options = g_object_new(GARROW_TYPE_FUNCTION_OPTIONS, NULL);
@@ -11917,5 +12054,24 @@ arrow::compute::WeekOptions *
 garrow_week_options_get_raw(GArrowWeekOptions *options)
 {
   return static_cast<arrow::compute::WeekOptions *>(
+    garrow_function_options_get_raw(GARROW_FUNCTION_OPTIONS(options)));
+}
+
+GArrowWinsorizeOptions *
+garrow_winsorize_options_new_raw(const arrow::compute::WinsorizeOptions *arrow_options)
+{
+  auto options = g_object_new(GARROW_TYPE_WINSORIZE_OPTIONS,
+                              "lower-limit",
+                              arrow_options->lower_limit,
+                              "upper-limit",
+                              arrow_options->upper_limit,
+                              NULL);
+  return GARROW_WINSORIZE_OPTIONS(options);
+}
+
+arrow::compute::WinsorizeOptions *
+garrow_winsorize_options_get_raw(GArrowWinsorizeOptions *options)
+{
+  return static_cast<arrow::compute::WinsorizeOptions *>(
     garrow_function_options_get_raw(GARROW_FUNCTION_OPTIONS(options)));
 }

--- a/c_glib/arrow-glib/compute.cpp
+++ b/c_glib/arrow-glib/compute.cpp
@@ -275,6 +275,9 @@ G_BEGIN_DECLS
  * #GArrowJoinOptions is a class to customize the `binary_join_element_wise`
  * function.
  *
+ * #GArrowListFlattenOptions is a class to customize the `list_flatten`
+ * function.
+ *
  * There are many functions to compute data on an array.
  */
 
@@ -7312,6 +7315,101 @@ garrow_join_options_new(void)
   return GARROW_JOIN_OPTIONS(options);
 }
 
+enum {
+  PROP_LIST_FLATTEN_OPTIONS_RECURSIVE = 1,
+};
+
+G_DEFINE_TYPE(GArrowListFlattenOptions,
+              garrow_list_flatten_options,
+              GARROW_TYPE_FUNCTION_OPTIONS)
+
+static void
+garrow_list_flatten_options_set_property(GObject *object,
+                                         guint prop_id,
+                                         const GValue *value,
+                                         GParamSpec *pspec)
+{
+  auto options = garrow_list_flatten_options_get_raw(GARROW_LIST_FLATTEN_OPTIONS(object));
+
+  switch (prop_id) {
+  case PROP_LIST_FLATTEN_OPTIONS_RECURSIVE:
+    options->recursive = g_value_get_boolean(value);
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+garrow_list_flatten_options_get_property(GObject *object,
+                                         guint prop_id,
+                                         GValue *value,
+                                         GParamSpec *pspec)
+{
+  auto options = garrow_list_flatten_options_get_raw(GARROW_LIST_FLATTEN_OPTIONS(object));
+
+  switch (prop_id) {
+  case PROP_LIST_FLATTEN_OPTIONS_RECURSIVE:
+    g_value_set_boolean(value, options->recursive);
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+garrow_list_flatten_options_init(GArrowListFlattenOptions *object)
+{
+  auto priv = GARROW_FUNCTION_OPTIONS_GET_PRIVATE(object);
+  priv->options = static_cast<arrow::compute::FunctionOptions *>(
+    new arrow::compute::ListFlattenOptions());
+}
+
+static void
+garrow_list_flatten_options_class_init(GArrowListFlattenOptionsClass *klass)
+{
+  auto gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->set_property = garrow_list_flatten_options_set_property;
+  gobject_class->get_property = garrow_list_flatten_options_get_property;
+
+  arrow::compute::ListFlattenOptions options;
+
+  GParamSpec *spec;
+  /**
+   * GArrowListFlattenOptions:recursive:
+   *
+   * If true, the list is flattened recursively until a non-list array is formed.
+   *
+   * Since: 23.0.0
+   */
+  spec = g_param_spec_boolean(
+    "recursive",
+    "Recursive",
+    "If true, the list is flattened recursively until a non-list array is formed",
+    options.recursive,
+    static_cast<GParamFlags>(G_PARAM_READWRITE));
+  g_object_class_install_property(gobject_class,
+                                  PROP_LIST_FLATTEN_OPTIONS_RECURSIVE,
+                                  spec);
+}
+
+/**
+ * garrow_list_flatten_options_new:
+ *
+ * Returns: A newly created #GArrowListFlattenOptions.
+ *
+ * Since: 23.0.0
+ */
+GArrowListFlattenOptions *
+garrow_list_flatten_options_new(void)
+{
+  auto options = g_object_new(GARROW_TYPE_LIST_FLATTEN_OPTIONS, NULL);
+  return GARROW_LIST_FLATTEN_OPTIONS(options);
+}
+
 G_END_DECLS
 
 arrow::Result<arrow::FieldRef>
@@ -7485,6 +7583,11 @@ garrow_function_options_new_raw(const arrow::compute::FunctionOptions *arrow_opt
     const auto arrow_join_options =
       static_cast<const arrow::compute::JoinOptions *>(arrow_options);
     auto options = garrow_join_options_new_raw(arrow_join_options);
+    return GARROW_FUNCTION_OPTIONS(options);
+  } else if (arrow_type_name == "ListFlattenOptions") {
+    const auto arrow_list_flatten_options =
+      static_cast<const arrow::compute::ListFlattenOptions *>(arrow_options);
+    auto options = garrow_list_flatten_options_new_raw(arrow_list_flatten_options);
     return GARROW_FUNCTION_OPTIONS(options);
   } else {
     auto options = g_object_new(GARROW_TYPE_FUNCTION_OPTIONS, NULL);
@@ -8160,5 +8263,22 @@ arrow::compute::JoinOptions *
 garrow_join_options_get_raw(GArrowJoinOptions *options)
 {
   return static_cast<arrow::compute::JoinOptions *>(
+    garrow_function_options_get_raw(GARROW_FUNCTION_OPTIONS(options)));
+}
+
+GArrowListFlattenOptions *
+garrow_list_flatten_options_new_raw(
+  const arrow::compute::ListFlattenOptions *arrow_options)
+{
+  return GARROW_LIST_FLATTEN_OPTIONS(g_object_new(GARROW_TYPE_LIST_FLATTEN_OPTIONS,
+                                                  "recursive",
+                                                  arrow_options->recursive,
+                                                  NULL));
+}
+
+arrow::compute::ListFlattenOptions *
+garrow_list_flatten_options_get_raw(GArrowListFlattenOptions *options)
+{
+  return static_cast<arrow::compute::ListFlattenOptions *>(
     garrow_function_options_get_raw(GARROW_FUNCTION_OPTIONS(options)));
 }

--- a/c_glib/arrow-glib/compute.cpp
+++ b/c_glib/arrow-glib/compute.cpp
@@ -260,6 +260,9 @@ G_BEGIN_DECLS
  *
  * #GArrowDayOfWeekOptions is a class to customize the `day_of_week` function.
  *
+ * #GArrowDictionaryEncodeOptions is a class to customize the `dictionary_encode`
+ * function.
+ *
  * There are many functions to compute data on an array.
  */
 
@@ -6785,6 +6788,108 @@ garrow_day_of_week_options_new(void)
   return GARROW_DAY_OF_WEEK_OPTIONS(options);
 }
 
+enum {
+  PROP_DICTIONARY_ENCODE_OPTIONS_NULL_ENCODING_BEHAVIOR = 1,
+};
+
+G_DEFINE_TYPE(GArrowDictionaryEncodeOptions,
+              garrow_dictionary_encode_options,
+              GARROW_TYPE_FUNCTION_OPTIONS)
+
+static void
+garrow_dictionary_encode_options_set_property(GObject *object,
+                                              guint prop_id,
+                                              const GValue *value,
+                                              GParamSpec *pspec)
+{
+  auto options =
+    garrow_dictionary_encode_options_get_raw(GARROW_DICTIONARY_ENCODE_OPTIONS(object));
+
+  switch (prop_id) {
+  case PROP_DICTIONARY_ENCODE_OPTIONS_NULL_ENCODING_BEHAVIOR:
+    options->null_encoding_behavior =
+      static_cast<arrow::compute::DictionaryEncodeOptions::NullEncodingBehavior>(
+        g_value_get_enum(value));
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+garrow_dictionary_encode_options_get_property(GObject *object,
+                                              guint prop_id,
+                                              GValue *value,
+                                              GParamSpec *pspec)
+{
+  auto options =
+    garrow_dictionary_encode_options_get_raw(GARROW_DICTIONARY_ENCODE_OPTIONS(object));
+
+  switch (prop_id) {
+  case PROP_DICTIONARY_ENCODE_OPTIONS_NULL_ENCODING_BEHAVIOR:
+    g_value_set_enum(value,
+                     static_cast<GArrowDictionaryEncodeNullEncodingBehavior>(
+                       options->null_encoding_behavior));
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+garrow_dictionary_encode_options_init(GArrowDictionaryEncodeOptions *object)
+{
+  auto priv = GARROW_FUNCTION_OPTIONS_GET_PRIVATE(object);
+  priv->options = static_cast<arrow::compute::FunctionOptions *>(
+    new arrow::compute::DictionaryEncodeOptions());
+}
+
+static void
+garrow_dictionary_encode_options_class_init(GArrowDictionaryEncodeOptionsClass *klass)
+{
+  auto gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->set_property = garrow_dictionary_encode_options_set_property;
+  gobject_class->get_property = garrow_dictionary_encode_options_get_property;
+
+  arrow::compute::DictionaryEncodeOptions options;
+
+  GParamSpec *spec;
+  /**
+   * GArrowDictionaryEncodeOptions:null-encoding-behavior:
+   *
+   * How null values will be encoded.
+   *
+   * Since: 23.0.0
+   */
+  spec = g_param_spec_enum("null-encoding-behavior",
+                           "Null encoding behavior",
+                           "How null values will be encoded",
+                           GARROW_TYPE_DICTIONARY_ENCODE_NULL_ENCODING_BEHAVIOR,
+                           static_cast<GArrowDictionaryEncodeNullEncodingBehavior>(
+                             options.null_encoding_behavior),
+                           static_cast<GParamFlags>(G_PARAM_READWRITE));
+  g_object_class_install_property(gobject_class,
+                                  PROP_DICTIONARY_ENCODE_OPTIONS_NULL_ENCODING_BEHAVIOR,
+                                  spec);
+}
+
+/**
+ * garrow_dictionary_encode_options_new:
+ *
+ * Returns: A newly created #GArrowDictionaryEncodeOptions.
+ *
+ * Since: 23.0.0
+ */
+GArrowDictionaryEncodeOptions *
+garrow_dictionary_encode_options_new(void)
+{
+  auto options = g_object_new(GARROW_TYPE_DICTIONARY_ENCODE_OPTIONS, NULL);
+  return GARROW_DICTIONARY_ENCODE_OPTIONS(options);
+}
+
 G_END_DECLS
 
 arrow::Result<arrow::FieldRef>
@@ -6930,6 +7035,12 @@ garrow_function_options_new_raw(const arrow::compute::FunctionOptions *arrow_opt
     const auto arrow_day_of_week_options =
       static_cast<const arrow::compute::DayOfWeekOptions *>(arrow_options);
     auto options = garrow_day_of_week_options_new_raw(arrow_day_of_week_options);
+    return GARROW_FUNCTION_OPTIONS(options);
+  } else if (arrow_type_name == "DictionaryEncodeOptions") {
+    const auto arrow_dictionary_encode_options =
+      static_cast<const arrow::compute::DictionaryEncodeOptions *>(arrow_options);
+    auto options =
+      garrow_dictionary_encode_options_new_raw(arrow_dictionary_encode_options);
     return GARROW_FUNCTION_OPTIONS(options);
   } else {
     auto options = g_object_new(GARROW_TYPE_FUNCTION_OPTIONS, NULL);
@@ -7514,5 +7625,24 @@ arrow::compute::DayOfWeekOptions *
 garrow_day_of_week_options_get_raw(GArrowDayOfWeekOptions *options)
 {
   return static_cast<arrow::compute::DayOfWeekOptions *>(
+    garrow_function_options_get_raw(GARROW_FUNCTION_OPTIONS(options)));
+}
+
+GArrowDictionaryEncodeOptions *
+garrow_dictionary_encode_options_new_raw(
+  const arrow::compute::DictionaryEncodeOptions *arrow_options)
+{
+  return GARROW_DICTIONARY_ENCODE_OPTIONS(
+    g_object_new(GARROW_TYPE_DICTIONARY_ENCODE_OPTIONS,
+                 "null-encoding-behavior",
+                 static_cast<GArrowDictionaryEncodeNullEncodingBehavior>(
+                   arrow_options->null_encoding_behavior),
+                 NULL));
+}
+
+arrow::compute::DictionaryEncodeOptions *
+garrow_dictionary_encode_options_get_raw(GArrowDictionaryEncodeOptions *options)
+{
+  return static_cast<arrow::compute::DictionaryEncodeOptions *>(
     garrow_function_options_get_raw(GARROW_FUNCTION_OPTIONS(options)));
 }

--- a/c_glib/arrow-glib/compute.cpp
+++ b/c_glib/arrow-glib/compute.cpp
@@ -301,6 +301,9 @@ G_BEGIN_DECLS
  * #GArrowPartitionNthOptions is a class to customize the `partition_nth_indices`
  * function.
  *
+ * #GArrowPivotWiderOptions is a class to customize the `pivot_wider` and
+ * `hash_pivot_wider` functions.
+ *
  * There are many functions to compute data on an array.
  */
 
@@ -8502,6 +8505,143 @@ garrow_partition_nth_options_new(void)
     g_object_new(GARROW_TYPE_PARTITION_NTH_OPTIONS, NULL));
 }
 
+enum {
+  PROP_PIVOT_WIDER_OPTIONS_KEY_NAMES = 1,
+  PROP_PIVOT_WIDER_OPTIONS_UNEXPECTED_KEY_BEHAVIOR,
+};
+
+G_DEFINE_TYPE(GArrowPivotWiderOptions,
+              garrow_pivot_wider_options,
+              GARROW_TYPE_FUNCTION_OPTIONS)
+
+static void
+garrow_pivot_wider_options_set_property(GObject *object,
+                                        guint prop_id,
+                                        const GValue *value,
+                                        GParamSpec *pspec)
+{
+  auto options = garrow_pivot_wider_options_get_raw(GARROW_PIVOT_WIDER_OPTIONS(object));
+
+  switch (prop_id) {
+  case PROP_PIVOT_WIDER_OPTIONS_KEY_NAMES:
+    {
+      auto strv = static_cast<gchar **>(g_value_get_boxed(value));
+      options->key_names.clear();
+      if (strv) {
+        for (gchar **p = strv; *p; ++p) {
+          options->key_names.emplace_back(*p);
+        }
+      }
+    }
+    break;
+  case PROP_PIVOT_WIDER_OPTIONS_UNEXPECTED_KEY_BEHAVIOR:
+    options->unexpected_key_behavior =
+      static_cast<arrow::compute::PivotWiderOptions::UnexpectedKeyBehavior>(
+        g_value_get_enum(value));
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+garrow_pivot_wider_options_get_property(GObject *object,
+                                        guint prop_id,
+                                        GValue *value,
+                                        GParamSpec *pspec)
+{
+  auto options = garrow_pivot_wider_options_get_raw(GARROW_PIVOT_WIDER_OPTIONS(object));
+
+  switch (prop_id) {
+  case PROP_PIVOT_WIDER_OPTIONS_KEY_NAMES:
+    {
+      const auto &names = options->key_names;
+      auto strv = static_cast<gchar **>(g_new0(gchar *, names.size() + 1));
+      for (gsize i = 0; i < names.size(); ++i) {
+        strv[i] = g_strdup(names[i].c_str());
+      }
+      g_value_take_boxed(value, strv);
+    }
+    break;
+  case PROP_PIVOT_WIDER_OPTIONS_UNEXPECTED_KEY_BEHAVIOR:
+    g_value_set_enum(value,
+                     static_cast<GArrowPivotWiderUnexpectedKeyBehavior>(
+                       options->unexpected_key_behavior));
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+garrow_pivot_wider_options_init(GArrowPivotWiderOptions *object)
+{
+  auto priv = GARROW_FUNCTION_OPTIONS_GET_PRIVATE(object);
+  priv->options = static_cast<arrow::compute::FunctionOptions *>(
+    new arrow::compute::PivotWiderOptions());
+}
+
+static void
+garrow_pivot_wider_options_class_init(GArrowPivotWiderOptionsClass *klass)
+{
+  auto gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->set_property = garrow_pivot_wider_options_set_property;
+  gobject_class->get_property = garrow_pivot_wider_options_get_property;
+
+  arrow::compute::PivotWiderOptions options;
+
+  GParamSpec *spec;
+  /**
+   * GArrowPivotWiderOptions:key-names:
+   *
+   * The values expected in the pivot key column.
+   *
+   * Since: 23.0.0
+   */
+  spec = g_param_spec_boxed("key-names",
+                            "Key names",
+                            "The values expected in the pivot key column",
+                            G_TYPE_STRV,
+                            static_cast<GParamFlags>(G_PARAM_READWRITE));
+  g_object_class_install_property(gobject_class,
+                                  PROP_PIVOT_WIDER_OPTIONS_KEY_NAMES,
+                                  spec);
+
+  /**
+   * GArrowPivotWiderOptions:unexpected-key-behavior:
+   *
+   * The behavior when pivot keys not in key_names are encountered.
+   *
+   * Since: 23.0.0
+   */
+  spec = g_param_spec_enum(
+    "unexpected-key-behavior",
+    "Unexpected key behavior",
+    "The behavior when pivot keys not in key_names are encountered",
+    GARROW_TYPE_PIVOT_WIDER_UNEXPECTED_KEY_BEHAVIOR,
+    static_cast<GArrowPivotWiderUnexpectedKeyBehavior>(options.unexpected_key_behavior),
+    static_cast<GParamFlags>(G_PARAM_READWRITE));
+  g_object_class_install_property(gobject_class,
+                                  PROP_PIVOT_WIDER_OPTIONS_UNEXPECTED_KEY_BEHAVIOR,
+                                  spec);
+}
+
+/**
+ * garrow_pivot_wider_options_new:
+ *
+ * Returns: A newly created #GArrowPivotWiderOptions.
+ *
+ * Since: 23.0.0
+ */
+GArrowPivotWiderOptions *
+garrow_pivot_wider_options_new(void)
+{
+  return GARROW_PIVOT_WIDER_OPTIONS(g_object_new(GARROW_TYPE_PIVOT_WIDER_OPTIONS, NULL));
+}
+
 G_END_DECLS
 
 arrow::Result<arrow::FieldRef>
@@ -8715,6 +8855,11 @@ garrow_function_options_new_raw(const arrow::compute::FunctionOptions *arrow_opt
     const auto arrow_partition_nth_options =
       static_cast<const arrow::compute::PartitionNthOptions *>(arrow_options);
     auto options = garrow_partition_nth_options_new_raw(arrow_partition_nth_options);
+    return GARROW_FUNCTION_OPTIONS(options);
+  } else if (arrow_type_name == "PivotWiderOptions") {
+    const auto arrow_pivot_wider_options =
+      static_cast<const arrow::compute::PivotWiderOptions *>(arrow_options);
+    auto options = garrow_pivot_wider_options_new_raw(arrow_pivot_wider_options);
     return GARROW_FUNCTION_OPTIONS(options);
   } else {
     auto options = g_object_new(GARROW_TYPE_FUNCTION_OPTIONS, NULL);
@@ -9576,5 +9721,29 @@ arrow::compute::PartitionNthOptions *
 garrow_partition_nth_options_get_raw(GArrowPartitionNthOptions *options)
 {
   return static_cast<arrow::compute::PartitionNthOptions *>(
+    garrow_function_options_get_raw(GARROW_FUNCTION_OPTIONS(options)));
+}
+
+GArrowPivotWiderOptions *
+garrow_pivot_wider_options_new_raw(const arrow::compute::PivotWiderOptions *arrow_options)
+{
+  auto strv = static_cast<gchar **>(g_new0(gchar *, arrow_options->key_names.size() + 1));
+  for (gsize i = 0; i < arrow_options->key_names.size(); ++i) {
+    strv[i] = g_strdup(arrow_options->key_names[i].c_str());
+  }
+  return GARROW_PIVOT_WIDER_OPTIONS(
+    g_object_new(GARROW_TYPE_PIVOT_WIDER_OPTIONS,
+                 "key-names",
+                 strv,
+                 "unexpected-key-behavior",
+                 static_cast<GArrowPivotWiderUnexpectedKeyBehavior>(
+                   arrow_options->unexpected_key_behavior),
+                 NULL));
+}
+
+arrow::compute::PivotWiderOptions *
+garrow_pivot_wider_options_get_raw(GArrowPivotWiderOptions *options)
+{
+  return static_cast<arrow::compute::PivotWiderOptions *>(
     garrow_function_options_get_raw(GARROW_FUNCTION_OPTIONS(options)));
 }

--- a/c_glib/arrow-glib/compute.cpp
+++ b/c_glib/arrow-glib/compute.cpp
@@ -322,6 +322,9 @@ G_BEGIN_DECLS
  *
  * #GArrowSkewOptions is a class to customize the `skew` and `kurtosis` functions.
  *
+ * #GArrowSliceOptions is a class to customize the `utf8_slice_codeunits` and
+ * `binary_slice` functions.
+ *
  * There are many functions to compute data on an array.
  */
 
@@ -9757,6 +9760,143 @@ garrow_skew_options_new(void)
   return GARROW_SKEW_OPTIONS(g_object_new(GARROW_TYPE_SKEW_OPTIONS, NULL));
 }
 
+enum {
+  PROP_SLICE_OPTIONS_START = 1,
+  PROP_SLICE_OPTIONS_STOP,
+  PROP_SLICE_OPTIONS_STEP,
+};
+
+G_DEFINE_TYPE(GArrowSliceOptions, garrow_slice_options, GARROW_TYPE_FUNCTION_OPTIONS)
+
+static void
+garrow_slice_options_set_property(GObject *object,
+                                  guint prop_id,
+                                  const GValue *value,
+                                  GParamSpec *pspec)
+{
+  auto options = garrow_slice_options_get_raw(GARROW_SLICE_OPTIONS(object));
+
+  switch (prop_id) {
+  case PROP_SLICE_OPTIONS_START:
+    options->start = g_value_get_int64(value);
+    break;
+  case PROP_SLICE_OPTIONS_STOP:
+    options->stop = g_value_get_int64(value);
+    break;
+  case PROP_SLICE_OPTIONS_STEP:
+    options->step = g_value_get_int64(value);
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+garrow_slice_options_get_property(GObject *object,
+                                  guint prop_id,
+                                  GValue *value,
+                                  GParamSpec *pspec)
+{
+  auto options = garrow_slice_options_get_raw(GARROW_SLICE_OPTIONS(object));
+
+  switch (prop_id) {
+  case PROP_SLICE_OPTIONS_START:
+    g_value_set_int64(value, options->start);
+    break;
+  case PROP_SLICE_OPTIONS_STOP:
+    g_value_set_int64(value, options->stop);
+    break;
+  case PROP_SLICE_OPTIONS_STEP:
+    g_value_set_int64(value, options->step);
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+garrow_slice_options_init(GArrowSliceOptions *object)
+{
+  auto arrow_priv = GARROW_FUNCTION_OPTIONS_GET_PRIVATE(object);
+  arrow_priv->options =
+    static_cast<arrow::compute::FunctionOptions *>(new arrow::compute::SliceOptions());
+}
+
+static void
+garrow_slice_options_class_init(GArrowSliceOptionsClass *klass)
+{
+  auto gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->set_property = garrow_slice_options_set_property;
+  gobject_class->get_property = garrow_slice_options_get_property;
+
+  arrow::compute::SliceOptions options;
+
+  GParamSpec *spec;
+  /**
+   * GArrowSliceOptions:start:
+   *
+   * Index to start slicing at (inclusive).
+   *
+   * Since: 23.0.0
+   */
+  spec = g_param_spec_int64("start",
+                            "Start",
+                            "Index to start slicing at (inclusive)",
+                            G_MININT64,
+                            G_MAXINT64,
+                            options.start,
+                            static_cast<GParamFlags>(G_PARAM_READWRITE));
+  g_object_class_install_property(gobject_class, PROP_SLICE_OPTIONS_START, spec);
+
+  /**
+   * GArrowSliceOptions:stop:
+   *
+   * Index to stop slicing at (exclusive).
+   *
+   * Since: 23.0.0
+   */
+  spec = g_param_spec_int64("stop",
+                            "Stop",
+                            "Index to stop slicing at (exclusive)",
+                            G_MININT64,
+                            G_MAXINT64,
+                            options.stop,
+                            static_cast<GParamFlags>(G_PARAM_READWRITE));
+  g_object_class_install_property(gobject_class, PROP_SLICE_OPTIONS_STOP, spec);
+
+  /**
+   * GArrowSliceOptions:step:
+   *
+   * Slice step.
+   *
+   * Since: 23.0.0
+   */
+  spec = g_param_spec_int64("step",
+                            "Step",
+                            "Slice step",
+                            G_MININT64,
+                            G_MAXINT64,
+                            options.step,
+                            static_cast<GParamFlags>(G_PARAM_READWRITE));
+  g_object_class_install_property(gobject_class, PROP_SLICE_OPTIONS_STEP, spec);
+}
+
+/**
+ * garrow_slice_options_new:
+ *
+ * Returns: A newly created #GArrowSliceOptions.
+ *
+ * Since: 23.0.0
+ */
+GArrowSliceOptions *
+garrow_slice_options_new(void)
+{
+  return GARROW_SLICE_OPTIONS(g_object_new(GARROW_TYPE_SLICE_OPTIONS, NULL));
+}
+
 G_END_DECLS
 
 arrow::Result<arrow::FieldRef>
@@ -10011,6 +10151,11 @@ garrow_function_options_new_raw(const arrow::compute::FunctionOptions *arrow_opt
     const auto arrow_skew_options =
       static_cast<const arrow::compute::SkewOptions *>(arrow_options);
     auto options = garrow_skew_options_new_raw(arrow_skew_options);
+    return GARROW_FUNCTION_OPTIONS(options);
+  } else if (arrow_type_name == "SliceOptions") {
+    const auto arrow_slice_options =
+      static_cast<const arrow::compute::SliceOptions *>(arrow_options);
+    auto options = garrow_slice_options_new_raw(arrow_slice_options);
     return GARROW_FUNCTION_OPTIONS(options);
   } else {
     auto options = g_object_new(GARROW_TYPE_FUNCTION_OPTIONS, NULL);
@@ -11042,5 +11187,26 @@ arrow::compute::SkewOptions *
 garrow_skew_options_get_raw(GArrowSkewOptions *options)
 {
   return static_cast<arrow::compute::SkewOptions *>(
+    garrow_function_options_get_raw(GARROW_FUNCTION_OPTIONS(options)));
+}
+
+GArrowSliceOptions *
+garrow_slice_options_new_raw(const arrow::compute::SliceOptions *arrow_options)
+{
+  auto options = g_object_new(GARROW_TYPE_SLICE_OPTIONS,
+                              "start",
+                              arrow_options->start,
+                              "stop",
+                              arrow_options->stop,
+                              "step",
+                              arrow_options->step,
+                              NULL);
+  return GARROW_SLICE_OPTIONS(options);
+}
+
+arrow::compute::SliceOptions *
+garrow_slice_options_get_raw(GArrowSliceOptions *options)
+{
+  return static_cast<arrow::compute::SliceOptions *>(
     garrow_function_options_get_raw(GARROW_FUNCTION_OPTIONS(options)));
 }

--- a/c_glib/arrow-glib/compute.cpp
+++ b/c_glib/arrow-glib/compute.cpp
@@ -298,6 +298,9 @@ G_BEGIN_DECLS
  * #GArrowPairwiseOptions is a class to customize the pairwise functions such as
  * `pairwise_diff` and `pairwise_diff_checked`.
  *
+ * #GArrowPartitionNthOptions is a class to customize the `partition_nth_indices`
+ * function.
+ *
  * There are many functions to compute data on an array.
  */
 
@@ -8376,6 +8379,129 @@ garrow_pairwise_options_new(void)
   return GARROW_PAIRWISE_OPTIONS(g_object_new(GARROW_TYPE_PAIRWISE_OPTIONS, NULL));
 }
 
+enum {
+  PROP_PARTITION_NTH_OPTIONS_PIVOT = 1,
+  PROP_PARTITION_NTH_OPTIONS_NULL_PLACEMENT,
+};
+
+G_DEFINE_TYPE(GArrowPartitionNthOptions,
+              garrow_partition_nth_options,
+              GARROW_TYPE_FUNCTION_OPTIONS)
+
+static void
+garrow_partition_nth_options_set_property(GObject *object,
+                                          guint prop_id,
+                                          const GValue *value,
+                                          GParamSpec *pspec)
+{
+  auto options =
+    garrow_partition_nth_options_get_raw(GARROW_PARTITION_NTH_OPTIONS(object));
+
+  switch (prop_id) {
+  case PROP_PARTITION_NTH_OPTIONS_PIVOT:
+    options->pivot = g_value_get_int64(value);
+    break;
+  case PROP_PARTITION_NTH_OPTIONS_NULL_PLACEMENT:
+    options->null_placement =
+      static_cast<arrow::compute::NullPlacement>(g_value_get_enum(value));
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+garrow_partition_nth_options_get_property(GObject *object,
+                                          guint prop_id,
+                                          GValue *value,
+                                          GParamSpec *pspec)
+{
+  auto options =
+    garrow_partition_nth_options_get_raw(GARROW_PARTITION_NTH_OPTIONS(object));
+
+  switch (prop_id) {
+  case PROP_PARTITION_NTH_OPTIONS_PIVOT:
+    g_value_set_int64(value, options->pivot);
+    break;
+  case PROP_PARTITION_NTH_OPTIONS_NULL_PLACEMENT:
+    g_value_set_enum(value, static_cast<GArrowNullPlacement>(options->null_placement));
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+garrow_partition_nth_options_init(GArrowPartitionNthOptions *object)
+{
+  auto priv = GARROW_FUNCTION_OPTIONS_GET_PRIVATE(object);
+  priv->options = static_cast<arrow::compute::FunctionOptions *>(
+    new arrow::compute::PartitionNthOptions());
+}
+
+static void
+garrow_partition_nth_options_class_init(GArrowPartitionNthOptionsClass *klass)
+{
+  auto gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->set_property = garrow_partition_nth_options_set_property;
+  gobject_class->get_property = garrow_partition_nth_options_get_property;
+
+  arrow::compute::PartitionNthOptions options;
+
+  GParamSpec *spec;
+  /**
+   * GArrowPartitionNthOptions:pivot:
+   *
+   * The index into the equivalent sorted array of the partition pivot element.
+   *
+   * Since: 23.0.0
+   */
+  spec = g_param_spec_int64(
+    "pivot",
+    "Pivot",
+    "The index into the equivalent sorted array of the partition pivot element",
+    0,
+    G_MAXINT64,
+    options.pivot,
+    static_cast<GParamFlags>(G_PARAM_READWRITE));
+  g_object_class_install_property(gobject_class, PROP_PARTITION_NTH_OPTIONS_PIVOT, spec);
+
+  /**
+   * GArrowPartitionNthOptions:null-placement:
+   *
+   * Whether nulls and NaNs are partitioned at the start or at the end.
+   *
+   * Since: 23.0.0
+   */
+  spec =
+    g_param_spec_enum("null-placement",
+                      "Null placement",
+                      "Whether nulls and NaNs are partitioned at the start or at the end",
+                      GARROW_TYPE_NULL_PLACEMENT,
+                      static_cast<GArrowNullPlacement>(options.null_placement),
+                      static_cast<GParamFlags>(G_PARAM_READWRITE));
+  g_object_class_install_property(gobject_class,
+                                  PROP_PARTITION_NTH_OPTIONS_NULL_PLACEMENT,
+                                  spec);
+}
+
+/**
+ * garrow_partition_nth_options_new:
+ *
+ * Returns: A newly created #GArrowPartitionNthOptions.
+ *
+ * Since: 23.0.0
+ */
+GArrowPartitionNthOptions *
+garrow_partition_nth_options_new(void)
+{
+  return GARROW_PARTITION_NTH_OPTIONS(
+    g_object_new(GARROW_TYPE_PARTITION_NTH_OPTIONS, NULL));
+}
+
 G_END_DECLS
 
 arrow::Result<arrow::FieldRef>
@@ -8584,6 +8710,11 @@ garrow_function_options_new_raw(const arrow::compute::FunctionOptions *arrow_opt
     const auto arrow_pairwise_options =
       static_cast<const arrow::compute::PairwiseOptions *>(arrow_options);
     auto options = garrow_pairwise_options_new_raw(arrow_pairwise_options);
+    return GARROW_FUNCTION_OPTIONS(options);
+  } else if (arrow_type_name == "PartitionNthOptions") {
+    const auto arrow_partition_nth_options =
+      static_cast<const arrow::compute::PartitionNthOptions *>(arrow_options);
+    auto options = garrow_partition_nth_options_new_raw(arrow_partition_nth_options);
     return GARROW_FUNCTION_OPTIONS(options);
   } else {
     auto options = g_object_new(GARROW_TYPE_FUNCTION_OPTIONS, NULL);
@@ -9425,5 +9556,25 @@ arrow::compute::PairwiseOptions *
 garrow_pairwise_options_get_raw(GArrowPairwiseOptions *options)
 {
   return static_cast<arrow::compute::PairwiseOptions *>(
+    garrow_function_options_get_raw(GARROW_FUNCTION_OPTIONS(options)));
+}
+
+GArrowPartitionNthOptions *
+garrow_partition_nth_options_new_raw(
+  const arrow::compute::PartitionNthOptions *arrow_options)
+{
+  return GARROW_PARTITION_NTH_OPTIONS(
+    g_object_new(GARROW_TYPE_PARTITION_NTH_OPTIONS,
+                 "pivot",
+                 arrow_options->pivot,
+                 "null-placement",
+                 static_cast<GArrowNullPlacement>(arrow_options->null_placement),
+                 NULL));
+}
+
+arrow::compute::PartitionNthOptions *
+garrow_partition_nth_options_get_raw(GArrowPartitionNthOptions *options)
+{
+  return static_cast<arrow::compute::PartitionNthOptions *>(
     garrow_function_options_get_raw(GARROW_FUNCTION_OPTIONS(options)));
 }

--- a/c_glib/arrow-glib/compute.cpp
+++ b/c_glib/arrow-glib/compute.cpp
@@ -318,6 +318,8 @@ G_BEGIN_DECLS
  * #GArrowRoundTemporalOptions is a class to customize the `round_temporal`,
  * `floor_temporal`, and `ceil_temporal` functions.
  *
+ * #GArrowSelectKOptions is a class to customize the `select_k_unstable` function.
+ *
  * There are many functions to compute data on an array.
  */
 
@@ -9476,6 +9478,146 @@ garrow_round_temporal_options_new(void)
     g_object_new(GARROW_TYPE_ROUND_TEMPORAL_OPTIONS, NULL));
 }
 
+enum {
+  PROP_SELECT_K_OPTIONS_K = 1,
+};
+
+G_DEFINE_TYPE(GArrowSelectKOptions, garrow_select_k_options, GARROW_TYPE_FUNCTION_OPTIONS)
+
+static void
+garrow_select_k_options_set_property(GObject *object,
+                                     guint prop_id,
+                                     const GValue *value,
+                                     GParamSpec *pspec)
+{
+  auto options = garrow_select_k_options_get_raw(GARROW_SELECT_K_OPTIONS(object));
+
+  switch (prop_id) {
+  case PROP_SELECT_K_OPTIONS_K:
+    options->k = g_value_get_int64(value);
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+garrow_select_k_options_get_property(GObject *object,
+                                     guint prop_id,
+                                     GValue *value,
+                                     GParamSpec *pspec)
+{
+  auto options = garrow_select_k_options_get_raw(GARROW_SELECT_K_OPTIONS(object));
+
+  switch (prop_id) {
+  case PROP_SELECT_K_OPTIONS_K:
+    g_value_set_int64(value, options->k);
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+garrow_select_k_options_init(GArrowSelectKOptions *object)
+{
+  auto arrow_priv = GARROW_FUNCTION_OPTIONS_GET_PRIVATE(object);
+  arrow_priv->options =
+    static_cast<arrow::compute::FunctionOptions *>(new arrow::compute::SelectKOptions());
+}
+
+static void
+garrow_select_k_options_class_init(GArrowSelectKOptionsClass *klass)
+{
+  auto gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->set_property = garrow_select_k_options_set_property;
+  gobject_class->get_property = garrow_select_k_options_get_property;
+
+  arrow::compute::SelectKOptions options;
+
+  GParamSpec *spec;
+  /**
+   * GArrowSelectKOptions:k:
+   *
+   * The number of k elements to keep.
+   *
+   * Since: 23.0.0
+   */
+  spec = g_param_spec_int64("k",
+                            "K",
+                            "The number of k elements to keep",
+                            G_MININT64,
+                            G_MAXINT64,
+                            options.k,
+                            static_cast<GParamFlags>(G_PARAM_READWRITE));
+  g_object_class_install_property(gobject_class, PROP_SELECT_K_OPTIONS_K, spec);
+}
+
+/**
+ * garrow_select_k_options_new:
+ *
+ * Returns: A newly created #GArrowSelectKOptions.
+ *
+ * Since: 23.0.0
+ */
+GArrowSelectKOptions *
+garrow_select_k_options_new(void)
+{
+  return GARROW_SELECT_K_OPTIONS(g_object_new(GARROW_TYPE_SELECT_K_OPTIONS, NULL));
+}
+
+/**
+ * garrow_select_k_options_get_sort_keys:
+ * @options: A #GArrowSelectKOptions.
+ *
+ * Returns: (transfer full) (element-type GArrowSortKey):
+ *   The sort keys to be used.
+ *
+ * Since: 23.0.0
+ */
+GList *
+garrow_select_k_options_get_sort_keys(GArrowSelectKOptions *options)
+{
+  auto arrow_options = garrow_select_k_options_get_raw(options);
+  return garrow_sort_keys_new_raw(arrow_options->sort_keys);
+}
+
+/**
+ * garrow_select_k_options_set_sort_keys:
+ * @options: A #GArrowSelectKOptions.
+ * @sort_keys: (element-type GArrowSortKey): The sort keys to be used.
+ *
+ * Set sort keys to be used.
+ *
+ * Since: 23.0.0
+ */
+void
+garrow_select_k_options_set_sort_keys(GArrowSelectKOptions *options, GList *sort_keys)
+{
+  auto arrow_options = garrow_select_k_options_get_raw(options);
+  garrow_raw_sort_keys_set(arrow_options->sort_keys, sort_keys);
+}
+
+/**
+ * garrow_select_k_options_add_sort_key:
+ * @options: A #GArrowSelectKOptions.
+ * @sort_key: The sort key to be added.
+ *
+ * Add a sort key to be used.
+ *
+ * Since: 23.0.0
+ */
+void
+garrow_select_k_options_add_sort_key(GArrowSelectKOptions *options,
+                                     GArrowSortKey *sort_key)
+{
+  auto arrow_options = garrow_select_k_options_get_raw(options);
+  garrow_raw_sort_keys_add(arrow_options->sort_keys, sort_key);
+}
+
 G_END_DECLS
 
 arrow::Result<arrow::FieldRef>
@@ -9720,6 +9862,11 @@ garrow_function_options_new_raw(const arrow::compute::FunctionOptions *arrow_opt
     const auto arrow_round_temporal_options =
       static_cast<const arrow::compute::RoundTemporalOptions *>(arrow_options);
     auto options = garrow_round_temporal_options_new_raw(arrow_round_temporal_options);
+    return GARROW_FUNCTION_OPTIONS(options);
+  } else if (arrow_type_name == "SelectKOptions") {
+    const auto arrow_select_k_options =
+      static_cast<const arrow::compute::SelectKOptions *>(arrow_options);
+    auto options = garrow_select_k_options_new_raw(arrow_select_k_options);
     return GARROW_FUNCTION_OPTIONS(options);
   } else {
     auto options = g_object_new(GARROW_TYPE_FUNCTION_OPTIONS, NULL);
@@ -10713,5 +10860,22 @@ arrow::compute::RoundTemporalOptions *
 garrow_round_temporal_options_get_raw(GArrowRoundTemporalOptions *options)
 {
   return static_cast<arrow::compute::RoundTemporalOptions *>(
+    garrow_function_options_get_raw(GARROW_FUNCTION_OPTIONS(options)));
+}
+
+GArrowSelectKOptions *
+garrow_select_k_options_new_raw(const arrow::compute::SelectKOptions *arrow_options)
+{
+  auto options = GARROW_SELECT_K_OPTIONS(
+    g_object_new(GARROW_TYPE_SELECT_K_OPTIONS, "k", arrow_options->k, NULL));
+  auto arrow_new_options = garrow_select_k_options_get_raw(options);
+  arrow_new_options->sort_keys = arrow_options->sort_keys;
+  return options;
+}
+
+arrow::compute::SelectKOptions *
+garrow_select_k_options_get_raw(GArrowSelectKOptions *options)
+{
+  return static_cast<arrow::compute::SelectKOptions *>(
     garrow_function_options_get_raw(GARROW_FUNCTION_OPTIONS(options)));
 }

--- a/c_glib/arrow-glib/compute.cpp
+++ b/c_glib/arrow-glib/compute.cpp
@@ -291,6 +291,10 @@ G_BEGIN_DECLS
  *
  * #GArrowNullOptions is a class to customize the `is_null` function.
  *
+ * #GArrowPadOptions is a class to customize the padding functions such as
+ * `utf8_lpad`, `utf8_rpad`, `utf8_center`, `ascii_lpad`, `ascii_rpad`, and
+ * `ascii_center`.
+ *
  * There are many functions to compute data on an array.
  */
 
@@ -8134,6 +8138,147 @@ garrow_null_options_new(void)
   return GARROW_NULL_OPTIONS(g_object_new(GARROW_TYPE_NULL_OPTIONS, NULL));
 }
 
+enum {
+  PROP_PAD_OPTIONS_WIDTH = 1,
+  PROP_PAD_OPTIONS_PADDING,
+  PROP_PAD_OPTIONS_LEAN_LEFT_ON_ODD_PADDING,
+};
+
+G_DEFINE_TYPE(GArrowPadOptions, garrow_pad_options, GARROW_TYPE_FUNCTION_OPTIONS)
+
+static void
+garrow_pad_options_set_property(GObject *object,
+                                guint prop_id,
+                                const GValue *value,
+                                GParamSpec *pspec)
+{
+  auto options = garrow_pad_options_get_raw(GARROW_PAD_OPTIONS(object));
+
+  switch (prop_id) {
+  case PROP_PAD_OPTIONS_WIDTH:
+    options->width = g_value_get_int64(value);
+    break;
+  case PROP_PAD_OPTIONS_PADDING:
+    options->padding = g_value_get_string(value);
+    break;
+  case PROP_PAD_OPTIONS_LEAN_LEFT_ON_ODD_PADDING:
+    options->lean_left_on_odd_padding = g_value_get_boolean(value);
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+garrow_pad_options_get_property(GObject *object,
+                                guint prop_id,
+                                GValue *value,
+                                GParamSpec *pspec)
+{
+  auto options = garrow_pad_options_get_raw(GARROW_PAD_OPTIONS(object));
+
+  switch (prop_id) {
+  case PROP_PAD_OPTIONS_WIDTH:
+    g_value_set_int64(value, options->width);
+    break;
+  case PROP_PAD_OPTIONS_PADDING:
+    g_value_set_string(value, options->padding.c_str());
+    break;
+  case PROP_PAD_OPTIONS_LEAN_LEFT_ON_ODD_PADDING:
+    g_value_set_boolean(value, options->lean_left_on_odd_padding);
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+garrow_pad_options_init(GArrowPadOptions *object)
+{
+  auto priv = GARROW_FUNCTION_OPTIONS_GET_PRIVATE(object);
+  priv->options =
+    static_cast<arrow::compute::FunctionOptions *>(new arrow::compute::PadOptions());
+}
+
+static void
+garrow_pad_options_class_init(GArrowPadOptionsClass *klass)
+{
+  auto gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->set_property = garrow_pad_options_set_property;
+  gobject_class->get_property = garrow_pad_options_get_property;
+
+  arrow::compute::PadOptions options;
+
+  GParamSpec *spec;
+  /**
+   * GArrowPadOptions:width:
+   *
+   * The desired string length.
+   *
+   * Since: 23.0.0
+   */
+  spec = g_param_spec_int64("width",
+                            "Width",
+                            "The desired string length",
+                            0,
+                            G_MAXINT64,
+                            options.width,
+                            static_cast<GParamFlags>(G_PARAM_READWRITE));
+  g_object_class_install_property(gobject_class, PROP_PAD_OPTIONS_WIDTH, spec);
+
+  /**
+   * GArrowPadOptions:padding:
+   *
+   * What to pad the string with. Should be one codepoint (Unicode)/byte (ASCII).
+   *
+   * Since: 23.0.0
+   */
+  spec = g_param_spec_string(
+    "padding",
+    "Padding",
+    "What to pad the string with. Should be one codepoint (Unicode)/byte (ASCII)",
+    options.padding.c_str(),
+    static_cast<GParamFlags>(G_PARAM_READWRITE));
+  g_object_class_install_property(gobject_class, PROP_PAD_OPTIONS_PADDING, spec);
+
+  /**
+   * GArrowPadOptions:lean-left-on-odd-padding:
+   *
+   * What to do if there is an odd number of padding characters (in case of centered
+   * padding). Defaults to aligning on the left (i.e. adding the extra padding character
+   * on the right).
+   *
+   * Since: 23.0.0
+   */
+  spec =
+    g_param_spec_boolean("lean-left-on-odd-padding",
+                         "Lean left on odd padding",
+                         "What to do if there is an odd number of padding characters (in "
+                         "case of centered padding). Defaults to aligning on the left "
+                         "(i.e. adding the extra padding character on the right)",
+                         options.lean_left_on_odd_padding,
+                         static_cast<GParamFlags>(G_PARAM_READWRITE));
+  g_object_class_install_property(gobject_class,
+                                  PROP_PAD_OPTIONS_LEAN_LEFT_ON_ODD_PADDING,
+                                  spec);
+}
+
+/**
+ * garrow_pad_options_new:
+ *
+ * Returns: A newly created #GArrowPadOptions.
+ *
+ * Since: 23.0.0
+ */
+GArrowPadOptions *
+garrow_pad_options_new(void)
+{
+  return GARROW_PAD_OPTIONS(g_object_new(GARROW_TYPE_PAD_OPTIONS, NULL));
+}
+
 G_END_DECLS
 
 arrow::Result<arrow::FieldRef>
@@ -8332,6 +8477,11 @@ garrow_function_options_new_raw(const arrow::compute::FunctionOptions *arrow_opt
     const auto arrow_null_options =
       static_cast<const arrow::compute::NullOptions *>(arrow_options);
     auto options = garrow_null_options_new_raw(arrow_null_options);
+    return GARROW_FUNCTION_OPTIONS(options);
+  } else if (arrow_type_name == "PadOptions") {
+    const auto arrow_pad_options =
+      static_cast<const arrow::compute::PadOptions *>(arrow_options);
+    auto options = garrow_pad_options_new_raw(arrow_pad_options);
     return GARROW_FUNCTION_OPTIONS(options);
   } else {
     auto options = g_object_new(GARROW_TYPE_FUNCTION_OPTIONS, NULL);
@@ -9139,5 +9289,25 @@ arrow::compute::NullOptions *
 garrow_null_options_get_raw(GArrowNullOptions *options)
 {
   return static_cast<arrow::compute::NullOptions *>(
+    garrow_function_options_get_raw(GARROW_FUNCTION_OPTIONS(options)));
+}
+
+GArrowPadOptions *
+garrow_pad_options_new_raw(const arrow::compute::PadOptions *arrow_options)
+{
+  return GARROW_PAD_OPTIONS(g_object_new(GARROW_TYPE_PAD_OPTIONS,
+                                         "width",
+                                         arrow_options->width,
+                                         "padding",
+                                         arrow_options->padding.c_str(),
+                                         "lean-left-on-odd-padding",
+                                         arrow_options->lean_left_on_odd_padding,
+                                         NULL));
+}
+
+arrow::compute::PadOptions *
+garrow_pad_options_get_raw(GArrowPadOptions *options)
+{
+  return static_cast<arrow::compute::PadOptions *>(
     garrow_function_options_get_raw(GARROW_FUNCTION_OPTIONS(options)));
 }

--- a/c_glib/arrow-glib/compute.cpp
+++ b/c_glib/arrow-glib/compute.cpp
@@ -266,6 +266,9 @@ G_BEGIN_DECLS
  * #GArrowElementWiseAggregateOptions is a class to customize element-wise
  * aggregate functions such as `min_element_wise` and `max_element_wise`.
  *
+ * #GArrowExtractRegexOptions is a class to customize the `extract_regex`
+ * function.
+ *
  * There are many functions to compute data on an array.
  */
 
@@ -6992,6 +6995,102 @@ garrow_element_wise_aggregate_options_new(void)
   return GARROW_ELEMENT_WISE_AGGREGATE_OPTIONS(options);
 }
 
+enum {
+  PROP_EXTRACT_REGEX_OPTIONS_PATTERN = 1,
+};
+
+G_DEFINE_TYPE(GArrowExtractRegexOptions,
+              garrow_extract_regex_options,
+              GARROW_TYPE_FUNCTION_OPTIONS)
+
+static void
+garrow_extract_regex_options_set_property(GObject *object,
+                                          guint prop_id,
+                                          const GValue *value,
+                                          GParamSpec *pspec)
+{
+  auto options =
+    garrow_extract_regex_options_get_raw(GARROW_EXTRACT_REGEX_OPTIONS(object));
+
+  switch (prop_id) {
+  case PROP_EXTRACT_REGEX_OPTIONS_PATTERN:
+    options->pattern = g_value_get_string(value);
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+garrow_extract_regex_options_get_property(GObject *object,
+                                          guint prop_id,
+                                          GValue *value,
+                                          GParamSpec *pspec)
+{
+  auto options =
+    garrow_extract_regex_options_get_raw(GARROW_EXTRACT_REGEX_OPTIONS(object));
+
+  switch (prop_id) {
+  case PROP_EXTRACT_REGEX_OPTIONS_PATTERN:
+    g_value_set_string(value, options->pattern.c_str());
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+garrow_extract_regex_options_init(GArrowExtractRegexOptions *object)
+{
+  auto priv = GARROW_FUNCTION_OPTIONS_GET_PRIVATE(object);
+  priv->options = static_cast<arrow::compute::FunctionOptions *>(
+    new arrow::compute::ExtractRegexOptions());
+}
+
+static void
+garrow_extract_regex_options_class_init(GArrowExtractRegexOptionsClass *klass)
+{
+  auto gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->set_property = garrow_extract_regex_options_set_property;
+  gobject_class->get_property = garrow_extract_regex_options_get_property;
+
+  arrow::compute::ExtractRegexOptions options;
+
+  GParamSpec *spec;
+  /**
+   * GArrowExtractRegexOptions:pattern:
+   *
+   * Regular expression with named capture fields.
+   *
+   * Since: 23.0.0
+   */
+  spec = g_param_spec_string("pattern",
+                             "Pattern",
+                             "Regular expression with named capture fields",
+                             options.pattern.c_str(),
+                             static_cast<GParamFlags>(G_PARAM_READWRITE));
+  g_object_class_install_property(gobject_class,
+                                  PROP_EXTRACT_REGEX_OPTIONS_PATTERN,
+                                  spec);
+}
+
+/**
+ * garrow_extract_regex_options_new:
+ *
+ * Returns: A newly created #GArrowExtractRegexOptions.
+ *
+ * Since: 23.0.0
+ */
+GArrowExtractRegexOptions *
+garrow_extract_regex_options_new(void)
+{
+  auto options = g_object_new(GARROW_TYPE_EXTRACT_REGEX_OPTIONS, NULL);
+  return GARROW_EXTRACT_REGEX_OPTIONS(options);
+}
+
 G_END_DECLS
 
 arrow::Result<arrow::FieldRef>
@@ -7149,6 +7248,11 @@ garrow_function_options_new_raw(const arrow::compute::FunctionOptions *arrow_opt
       static_cast<const arrow::compute::ElementWiseAggregateOptions *>(arrow_options);
     auto options =
       garrow_element_wise_aggregate_options_new_raw(arrow_element_wise_aggregate_options);
+    return GARROW_FUNCTION_OPTIONS(options);
+  } else if (arrow_type_name == "ExtractRegexOptions") {
+    const auto arrow_extract_regex_options =
+      static_cast<const arrow::compute::ExtractRegexOptions *>(arrow_options);
+    auto options = garrow_extract_regex_options_new_raw(arrow_extract_regex_options);
     return GARROW_FUNCTION_OPTIONS(options);
   } else {
     auto options = g_object_new(GARROW_TYPE_FUNCTION_OPTIONS, NULL);
@@ -7770,5 +7874,22 @@ arrow::compute::ElementWiseAggregateOptions *
 garrow_element_wise_aggregate_options_get_raw(GArrowElementWiseAggregateOptions *options)
 {
   return static_cast<arrow::compute::ElementWiseAggregateOptions *>(
+    garrow_function_options_get_raw(GARROW_FUNCTION_OPTIONS(options)));
+}
+
+GArrowExtractRegexOptions *
+garrow_extract_regex_options_new_raw(
+  const arrow::compute::ExtractRegexOptions *arrow_options)
+{
+  return GARROW_EXTRACT_REGEX_OPTIONS(g_object_new(GARROW_TYPE_EXTRACT_REGEX_OPTIONS,
+                                                   "pattern",
+                                                   arrow_options->pattern.c_str(),
+                                                   NULL));
+}
+
+arrow::compute::ExtractRegexOptions *
+garrow_extract_regex_options_get_raw(GArrowExtractRegexOptions *options)
+{
+  return static_cast<arrow::compute::ExtractRegexOptions *>(
     garrow_function_options_get_raw(GARROW_FUNCTION_OPTIONS(options)));
 }

--- a/c_glib/arrow-glib/compute.cpp
+++ b/c_glib/arrow-glib/compute.cpp
@@ -287,6 +287,8 @@ G_BEGIN_DECLS
  * #GArrowMapLookupOptions is a class to customize the `map_lookup`
  * function.
  *
+ * #GArrowModeOptions is a class to customize the `mode` function.
+ *
  * There are many functions to compute data on an array.
  */
 
@@ -7905,6 +7907,142 @@ garrow_map_lookup_options_new(GArrowScalar *query_key,
                                                 NULL));
 }
 
+enum {
+  PROP_MODE_OPTIONS_N = 1,
+  PROP_MODE_OPTIONS_SKIP_NULLS,
+  PROP_MODE_OPTIONS_MIN_COUNT,
+};
+
+G_DEFINE_TYPE(GArrowModeOptions, garrow_mode_options, GARROW_TYPE_FUNCTION_OPTIONS)
+
+static void
+garrow_mode_options_set_property(GObject *object,
+                                 guint prop_id,
+                                 const GValue *value,
+                                 GParamSpec *pspec)
+{
+  auto options = garrow_mode_options_get_raw(GARROW_MODE_OPTIONS(object));
+
+  switch (prop_id) {
+  case PROP_MODE_OPTIONS_N:
+    options->n = g_value_get_int64(value);
+    break;
+  case PROP_MODE_OPTIONS_SKIP_NULLS:
+    options->skip_nulls = g_value_get_boolean(value);
+    break;
+  case PROP_MODE_OPTIONS_MIN_COUNT:
+    options->min_count = g_value_get_uint(value);
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+garrow_mode_options_get_property(GObject *object,
+                                 guint prop_id,
+                                 GValue *value,
+                                 GParamSpec *pspec)
+{
+  auto options = garrow_mode_options_get_raw(GARROW_MODE_OPTIONS(object));
+
+  switch (prop_id) {
+  case PROP_MODE_OPTIONS_N:
+    g_value_set_int64(value, options->n);
+    break;
+  case PROP_MODE_OPTIONS_SKIP_NULLS:
+    g_value_set_boolean(value, options->skip_nulls);
+    break;
+  case PROP_MODE_OPTIONS_MIN_COUNT:
+    g_value_set_uint(value, options->min_count);
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+garrow_mode_options_init(GArrowModeOptions *object)
+{
+  auto priv = GARROW_FUNCTION_OPTIONS_GET_PRIVATE(object);
+  priv->options =
+    static_cast<arrow::compute::FunctionOptions *>(new arrow::compute::ModeOptions());
+}
+
+static void
+garrow_mode_options_class_init(GArrowModeOptionsClass *klass)
+{
+  auto gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->set_property = garrow_mode_options_set_property;
+  gobject_class->get_property = garrow_mode_options_get_property;
+
+  arrow::compute::ModeOptions options;
+
+  GParamSpec *spec;
+  /**
+   * GArrowModeOptions:n:
+   *
+   * Number of distinct most-common values to return.
+   *
+   * Since: 23.0.0
+   */
+  spec = g_param_spec_int64("n",
+                            "N",
+                            "Number of distinct most-common values to return",
+                            1,
+                            G_MAXINT64,
+                            options.n,
+                            static_cast<GParamFlags>(G_PARAM_READWRITE));
+  g_object_class_install_property(gobject_class, PROP_MODE_OPTIONS_N, spec);
+
+  /**
+   * GArrowModeOptions:skip-nulls:
+   *
+   * Whether NULLs are skipped or not.
+   *
+   * Since: 23.0.0
+   */
+  spec = g_param_spec_boolean("skip-nulls",
+                              "Skip NULLs",
+                              "Whether NULLs are skipped or not",
+                              options.skip_nulls,
+                              static_cast<GParamFlags>(G_PARAM_READWRITE));
+  g_object_class_install_property(gobject_class, PROP_MODE_OPTIONS_SKIP_NULLS, spec);
+
+  /**
+   * GArrowModeOptions:min-count:
+   *
+   * If less than this many non-null values are observed, emit null.
+   *
+   * Since: 23.0.0
+   */
+  spec =
+    g_param_spec_uint("min-count",
+                      "Min count",
+                      "If less than this many non-null values are observed, emit null",
+                      0,
+                      G_MAXUINT,
+                      options.min_count,
+                      static_cast<GParamFlags>(G_PARAM_READWRITE));
+  g_object_class_install_property(gobject_class, PROP_MODE_OPTIONS_MIN_COUNT, spec);
+}
+
+/**
+ * garrow_mode_options_new:
+ *
+ * Returns: A newly created #GArrowModeOptions.
+ *
+ * Since: 23.0.0
+ */
+GArrowModeOptions *
+garrow_mode_options_new(void)
+{
+  return GARROW_MODE_OPTIONS(g_object_new(GARROW_TYPE_MODE_OPTIONS, NULL));
+}
+
 G_END_DECLS
 
 arrow::Result<arrow::FieldRef>
@@ -8093,6 +8231,11 @@ garrow_function_options_new_raw(const arrow::compute::FunctionOptions *arrow_opt
     const auto arrow_map_lookup_options =
       static_cast<const arrow::compute::MapLookupOptions *>(arrow_options);
     auto options = garrow_map_lookup_options_new_raw(arrow_map_lookup_options);
+    return GARROW_FUNCTION_OPTIONS(options);
+  } else if (arrow_type_name == "ModeOptions") {
+    const auto arrow_mode_options =
+      static_cast<const arrow::compute::ModeOptions *>(arrow_options);
+    auto options = garrow_mode_options_new_raw(arrow_mode_options);
     return GARROW_FUNCTION_OPTIONS(options);
   } else {
     auto options = g_object_new(GARROW_TYPE_FUNCTION_OPTIONS, NULL);
@@ -8863,5 +9006,26 @@ arrow::compute::MapLookupOptions *
 garrow_map_lookup_options_get_raw(GArrowMapLookupOptions *options)
 {
   return static_cast<arrow::compute::MapLookupOptions *>(
+    garrow_function_options_get_raw(GARROW_FUNCTION_OPTIONS(options)));
+}
+
+GArrowModeOptions *
+garrow_mode_options_new_raw(const arrow::compute::ModeOptions *arrow_options)
+{
+  auto options = g_object_new(GARROW_TYPE_MODE_OPTIONS,
+                              "n",
+                              arrow_options->n,
+                              "skip-nulls",
+                              arrow_options->skip_nulls,
+                              "min-count",
+                              arrow_options->min_count,
+                              NULL);
+  return GARROW_MODE_OPTIONS(options);
+}
+
+arrow::compute::ModeOptions *
+garrow_mode_options_get_raw(GArrowModeOptions *options)
+{
+  return static_cast<arrow::compute::ModeOptions *>(
     garrow_function_options_get_raw(GARROW_FUNCTION_OPTIONS(options)));
 }

--- a/c_glib/arrow-glib/compute.cpp
+++ b/c_glib/arrow-glib/compute.cpp
@@ -338,6 +338,8 @@ G_BEGIN_DECLS
  *
  * #GArrowWinsorizeOptions is a class to customize the `winsorize` function.
  *
+ * #GArrowZeroFillOptions is a class to customize the `utf8_zero_fill` function.
+ *
  * There are many functions to compute data on an array.
  */
 
@@ -10636,6 +10638,157 @@ garrow_winsorize_options_new(void)
   return GARROW_WINSORIZE_OPTIONS(g_object_new(GARROW_TYPE_WINSORIZE_OPTIONS, NULL));
 }
 
+enum {
+  PROP_ZERO_FILL_OPTIONS_WIDTH = 1,
+  PROP_ZERO_FILL_OPTIONS_PADDING,
+};
+
+typedef struct _GArrowZeroFillOptionsPrivate GArrowZeroFillOptionsPrivate;
+struct _GArrowZeroFillOptionsPrivate
+{
+  gchar *padding;
+};
+
+G_DEFINE_TYPE_WITH_PRIVATE(GArrowZeroFillOptions,
+                           garrow_zero_fill_options,
+                           GARROW_TYPE_FUNCTION_OPTIONS)
+
+#define GARROW_ZERO_FILL_OPTIONS_GET_PRIVATE(object)                                     \
+  static_cast<GArrowZeroFillOptionsPrivate *>(                                           \
+    garrow_zero_fill_options_get_instance_private(GARROW_ZERO_FILL_OPTIONS(object)))
+
+static void
+garrow_zero_fill_options_dispose(GObject *object)
+{
+  auto priv = GARROW_ZERO_FILL_OPTIONS_GET_PRIVATE(object);
+  if (priv->padding) {
+    g_free(priv->padding);
+    priv->padding = nullptr;
+  }
+  G_OBJECT_CLASS(garrow_zero_fill_options_parent_class)->dispose(object);
+}
+
+static void
+garrow_zero_fill_options_set_property(GObject *object,
+                                      guint prop_id,
+                                      const GValue *value,
+                                      GParamSpec *pspec)
+{
+  auto options = garrow_zero_fill_options_get_raw(GARROW_ZERO_FILL_OPTIONS(object));
+  auto priv = GARROW_ZERO_FILL_OPTIONS_GET_PRIVATE(object);
+
+  switch (prop_id) {
+  case PROP_ZERO_FILL_OPTIONS_WIDTH:
+    options->width = g_value_get_int64(value);
+    break;
+  case PROP_ZERO_FILL_OPTIONS_PADDING:
+    {
+      const gchar *padding = g_value_get_string(value);
+      if (priv->padding) {
+        g_free(priv->padding);
+      }
+      priv->padding = g_strdup(padding);
+      options->padding = padding ? padding : "";
+    }
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+garrow_zero_fill_options_get_property(GObject *object,
+                                      guint prop_id,
+                                      GValue *value,
+                                      GParamSpec *pspec)
+{
+  auto options = garrow_zero_fill_options_get_raw(GARROW_ZERO_FILL_OPTIONS(object));
+  auto priv = GARROW_ZERO_FILL_OPTIONS_GET_PRIVATE(object);
+
+  switch (prop_id) {
+  case PROP_ZERO_FILL_OPTIONS_WIDTH:
+    g_value_set_int64(value, options->width);
+    break;
+  case PROP_ZERO_FILL_OPTIONS_PADDING:
+    g_value_set_string(value, priv->padding ? priv->padding : options->padding.c_str());
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+garrow_zero_fill_options_init(GArrowZeroFillOptions *object)
+{
+  auto priv = GARROW_ZERO_FILL_OPTIONS_GET_PRIVATE(object);
+  priv->padding = nullptr;
+  auto arrow_priv = GARROW_FUNCTION_OPTIONS_GET_PRIVATE(object);
+  arrow_priv->options =
+    static_cast<arrow::compute::FunctionOptions *>(new arrow::compute::ZeroFillOptions());
+  // Sync the private string with the C++ options
+  auto arrow_options = garrow_zero_fill_options_get_raw(GARROW_ZERO_FILL_OPTIONS(object));
+  priv->padding = g_strdup(arrow_options->padding.c_str());
+}
+
+static void
+garrow_zero_fill_options_class_init(GArrowZeroFillOptionsClass *klass)
+{
+  auto gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->dispose = garrow_zero_fill_options_dispose;
+  gobject_class->set_property = garrow_zero_fill_options_set_property;
+  gobject_class->get_property = garrow_zero_fill_options_get_property;
+
+  arrow::compute::ZeroFillOptions options;
+
+  GParamSpec *spec;
+  /**
+   * GArrowZeroFillOptions:width:
+   *
+   * The desired string length.
+   *
+   * Since: 23.0.0
+   */
+  spec = g_param_spec_int64("width",
+                            "Width",
+                            "The desired string length",
+                            G_MININT64,
+                            G_MAXINT64,
+                            options.width,
+                            static_cast<GParamFlags>(G_PARAM_READWRITE));
+  g_object_class_install_property(gobject_class, PROP_ZERO_FILL_OPTIONS_WIDTH, spec);
+
+  /**
+   * GArrowZeroFillOptions:padding:
+   *
+   * What to pad the string with. Should be one codepoint (Unicode).
+   *
+   * Since: 23.0.0
+   */
+  spec =
+    g_param_spec_string("padding",
+                        "Padding",
+                        "What to pad the string with. Should be one codepoint (Unicode)",
+                        options.padding.c_str(),
+                        static_cast<GParamFlags>(G_PARAM_READWRITE));
+  g_object_class_install_property(gobject_class, PROP_ZERO_FILL_OPTIONS_PADDING, spec);
+}
+
+/**
+ * garrow_zero_fill_options_new:
+ *
+ * Returns: A newly created #GArrowZeroFillOptions.
+ *
+ * Since: 23.0.0
+ */
+GArrowZeroFillOptions *
+garrow_zero_fill_options_new(void)
+{
+  return GARROW_ZERO_FILL_OPTIONS(g_object_new(GARROW_TYPE_ZERO_FILL_OPTIONS, NULL));
+}
+
 G_END_DECLS
 
 arrow::Result<arrow::FieldRef>
@@ -10920,6 +11073,11 @@ garrow_function_options_new_raw(const arrow::compute::FunctionOptions *arrow_opt
     const auto arrow_winsorize_options =
       static_cast<const arrow::compute::WinsorizeOptions *>(arrow_options);
     auto options = garrow_winsorize_options_new_raw(arrow_winsorize_options);
+    return GARROW_FUNCTION_OPTIONS(options);
+  } else if (arrow_type_name == "ZeroFillOptions") {
+    const auto arrow_zero_fill_options =
+      static_cast<const arrow::compute::ZeroFillOptions *>(arrow_options);
+    auto options = garrow_zero_fill_options_new_raw(arrow_zero_fill_options);
     return GARROW_FUNCTION_OPTIONS(options);
   } else {
     auto options = g_object_new(GARROW_TYPE_FUNCTION_OPTIONS, NULL);
@@ -12073,5 +12231,23 @@ arrow::compute::WinsorizeOptions *
 garrow_winsorize_options_get_raw(GArrowWinsorizeOptions *options)
 {
   return static_cast<arrow::compute::WinsorizeOptions *>(
+    garrow_function_options_get_raw(GARROW_FUNCTION_OPTIONS(options)));
+}
+
+GArrowZeroFillOptions *
+garrow_zero_fill_options_new_raw(const arrow::compute::ZeroFillOptions *arrow_options)
+{
+  return GARROW_ZERO_FILL_OPTIONS(g_object_new(GARROW_TYPE_ZERO_FILL_OPTIONS,
+                                               "width",
+                                               arrow_options->width,
+                                               "padding",
+                                               arrow_options->padding.c_str(),
+                                               NULL));
+}
+
+arrow::compute::ZeroFillOptions *
+garrow_zero_fill_options_get_raw(GArrowZeroFillOptions *options)
+{
+  return static_cast<arrow::compute::ZeroFillOptions *>(
     garrow_function_options_get_raw(GARROW_FUNCTION_OPTIONS(options)));
 }

--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -1588,4 +1588,20 @@ GARROW_AVAILABLE_IN_23_0
 GArrowReplaceSubstringOptions *
 garrow_replace_substring_options_new(void);
 
+#define GARROW_TYPE_ROUND_BINARY_OPTIONS (garrow_round_binary_options_get_type())
+GARROW_AVAILABLE_IN_23_0
+G_DECLARE_DERIVABLE_TYPE(GArrowRoundBinaryOptions,
+                         garrow_round_binary_options,
+                         GARROW,
+                         ROUND_BINARY_OPTIONS,
+                         GArrowFunctionOptions)
+struct _GArrowRoundBinaryOptionsClass
+{
+  GArrowFunctionOptionsClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_23_0
+GArrowRoundBinaryOptions *
+garrow_round_binary_options_new(void);
+
 G_END_DECLS

--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -1337,4 +1337,41 @@ GARROW_AVAILABLE_IN_23_0
 GArrowListFlattenOptions *
 garrow_list_flatten_options_new(void);
 
+/**
+ * GArrowListSliceReturnFixedSizeList:
+ * @GARROW_LIST_SLICE_RETURN_FIXED_SIZE_LIST_AUTO: Return the same type which was passed
+ * in (default).
+ * @GARROW_LIST_SLICE_RETURN_FIXED_SIZE_LIST_FALSE: Explicitly return the same type which
+ * was passed in.
+ * @GARROW_LIST_SLICE_RETURN_FIXED_SIZE_LIST_TRUE: Return a FixedSizeListArray. If stop is
+ * after a list element's length, nulls will be appended to create the requested slice
+ * size.
+ *
+ * They correspond to the values of
+ * `std::optional<bool>` for `arrow::compute::ListSliceOptions::return_fixed_size_list`.
+ *
+ * Since: 23.0.0
+ */
+typedef enum {
+  GARROW_LIST_SLICE_RETURN_FIXED_SIZE_LIST_AUTO,
+  GARROW_LIST_SLICE_RETURN_FIXED_SIZE_LIST_FALSE,
+  GARROW_LIST_SLICE_RETURN_FIXED_SIZE_LIST_TRUE,
+} GArrowListSliceReturnFixedSizeList;
+
+#define GARROW_TYPE_LIST_SLICE_OPTIONS (garrow_list_slice_options_get_type())
+GARROW_AVAILABLE_IN_23_0
+G_DECLARE_DERIVABLE_TYPE(GArrowListSliceOptions,
+                         garrow_list_slice_options,
+                         GARROW,
+                         LIST_SLICE_OPTIONS,
+                         GArrowFunctionOptions)
+struct _GArrowListSliceOptionsClass
+{
+  GArrowFunctionOptionsClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_23_0
+GArrowListSliceOptions *
+garrow_list_slice_options_new(void);
+
 G_END_DECLS

--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -1122,4 +1122,55 @@ GARROW_AVAILABLE_IN_16_0
 GArrowStructFieldOptions *
 garrow_struct_field_options_new(void);
 
+/**
+ * GArrowAssumeTimezoneAmbiguous:
+ * @GARROW_ASSUME_TIMEZONE_AMBIGUOUS_RAISE: Raise an error on ambiguous times.
+ * @GARROW_ASSUME_TIMEZONE_AMBIGUOUS_EARLIEST: Emit the earliest instant.
+ * @GARROW_ASSUME_TIMEZONE_AMBIGUOUS_LATEST: Emit the latest instant.
+ *
+ * They correspond to the values of
+ * `arrow::compute::AssumeTimezoneOptions::Ambiguous`.
+ *
+ * Since: 23.0.0
+ */
+typedef enum {
+  GARROW_ASSUME_TIMEZONE_AMBIGUOUS_RAISE,
+  GARROW_ASSUME_TIMEZONE_AMBIGUOUS_EARLIEST,
+  GARROW_ASSUME_TIMEZONE_AMBIGUOUS_LATEST,
+} GArrowAssumeTimezoneAmbiguous;
+
+/**
+ * GArrowAssumeTimezoneNonexistent:
+ * @GARROW_ASSUME_TIMEZONE_NONEXISTENT_RAISE: Raise an error on nonexistent times.
+ * @GARROW_ASSUME_TIMEZONE_NONEXISTENT_EARLIEST: Emit the instant just before the DST
+ * shift.
+ * @GARROW_ASSUME_TIMEZONE_NONEXISTENT_LATEST: Emit the DST shift instant.
+ *
+ * They correspond to the values of
+ * `arrow::compute::AssumeTimezoneOptions::Nonexistent`.
+ *
+ * Since: 23.0.0
+ */
+typedef enum {
+  GARROW_ASSUME_TIMEZONE_NONEXISTENT_RAISE,
+  GARROW_ASSUME_TIMEZONE_NONEXISTENT_EARLIEST,
+  GARROW_ASSUME_TIMEZONE_NONEXISTENT_LATEST,
+} GArrowAssumeTimezoneNonexistent;
+
+#define GARROW_TYPE_ASSUME_TIMEZONE_OPTIONS (garrow_assume_timezone_options_get_type())
+GARROW_AVAILABLE_IN_23_0
+G_DECLARE_DERIVABLE_TYPE(GArrowAssumeTimezoneOptions,
+                         garrow_assume_timezone_options,
+                         GARROW,
+                         ASSUME_TIMEZONE_OPTIONS,
+                         GArrowFunctionOptions)
+struct _GArrowAssumeTimezoneOptionsClass
+{
+  GArrowFunctionOptionsClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_23_0
+GArrowAssumeTimezoneOptions *
+garrow_assume_timezone_options_new(void);
+
 G_END_DECLS

--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -1272,4 +1272,21 @@ GARROW_AVAILABLE_IN_23_0
 GArrowExtractRegexOptions *
 garrow_extract_regex_options_new(void);
 
+#define GARROW_TYPE_EXTRACT_REGEX_SPAN_OPTIONS                                           \
+  (garrow_extract_regex_span_options_get_type())
+GARROW_AVAILABLE_IN_23_0
+G_DECLARE_DERIVABLE_TYPE(GArrowExtractRegexSpanOptions,
+                         garrow_extract_regex_span_options,
+                         GARROW,
+                         EXTRACT_REGEX_SPAN_OPTIONS,
+                         GArrowFunctionOptions)
+struct _GArrowExtractRegexSpanOptionsClass
+{
+  GArrowFunctionOptionsClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_23_0
+GArrowExtractRegexSpanOptions *
+garrow_extract_regex_span_options_new(void);
+
 G_END_DECLS

--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -1722,4 +1722,29 @@ GARROW_AVAILABLE_IN_23_0
 GArrowSplitOptions *
 garrow_split_options_new(void);
 
+#define GARROW_TYPE_TDIGEST_OPTIONS (garrow_tdigest_options_get_type())
+GARROW_AVAILABLE_IN_23_0
+G_DECLARE_DERIVABLE_TYPE(GArrowTDigestOptions,
+                         garrow_tdigest_options,
+                         GARROW,
+                         TDIGEST_OPTIONS,
+                         GArrowFunctionOptions)
+struct _GArrowTDigestOptionsClass
+{
+  GArrowFunctionOptionsClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_23_0
+GArrowTDigestOptions *
+garrow_tdigest_options_new(void);
+GARROW_AVAILABLE_IN_23_0
+const gdouble *
+garrow_tdigest_options_get_qs(GArrowTDigestOptions *options, gsize *n);
+GARROW_AVAILABLE_IN_23_0
+void
+garrow_tdigest_options_set_q(GArrowTDigestOptions *options, gdouble q);
+GARROW_AVAILABLE_IN_23_0
+void
+garrow_tdigest_options_set_qs(GArrowTDigestOptions *options, const gdouble *qs, gsize n);
+
 G_END_DECLS

--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -1424,4 +1424,17 @@ GArrowMapLookupOptions *
 garrow_map_lookup_options_new(GArrowScalar *query_key,
                               GArrowMapLookupOccurrence occurrence);
 
+#define GARROW_TYPE_MODE_OPTIONS (garrow_mode_options_get_type())
+GARROW_AVAILABLE_IN_23_0
+G_DECLARE_DERIVABLE_TYPE(
+  GArrowModeOptions, garrow_mode_options, GARROW, MODE_OPTIONS, GArrowFunctionOptions)
+struct _GArrowModeOptionsClass
+{
+  GArrowFunctionOptionsClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_23_0
+GArrowModeOptions *
+garrow_mode_options_new(void);
+
 G_END_DECLS

--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -1747,4 +1747,17 @@ GARROW_AVAILABLE_IN_23_0
 void
 garrow_tdigest_options_set_qs(GArrowTDigestOptions *options, const gdouble *qs, gsize n);
 
+#define GARROW_TYPE_TRIM_OPTIONS (garrow_trim_options_get_type())
+GARROW_AVAILABLE_IN_23_0
+G_DECLARE_DERIVABLE_TYPE(
+  GArrowTrimOptions, garrow_trim_options, GARROW, TRIM_OPTIONS, GArrowFunctionOptions)
+struct _GArrowTrimOptionsClass
+{
+  GArrowFunctionOptionsClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_23_0
+GArrowTrimOptions *
+garrow_trim_options_new(void);
+
 G_END_DECLS

--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -1239,4 +1239,21 @@ GARROW_AVAILABLE_IN_23_0
 GArrowDictionaryEncodeOptions *
 garrow_dictionary_encode_options_new(void);
 
+#define GARROW_TYPE_ELEMENT_WISE_AGGREGATE_OPTIONS                                       \
+  (garrow_element_wise_aggregate_options_get_type())
+GARROW_AVAILABLE_IN_23_0
+G_DECLARE_DERIVABLE_TYPE(GArrowElementWiseAggregateOptions,
+                         garrow_element_wise_aggregate_options,
+                         GARROW,
+                         ELEMENT_WISE_AGGREGATE_OPTIONS,
+                         GArrowFunctionOptions)
+struct _GArrowElementWiseAggregateOptionsClass
+{
+  GArrowFunctionOptionsClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_23_0
+GArrowElementWiseAggregateOptions *
+garrow_element_wise_aggregate_options_new(void);
+
 G_END_DECLS

--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -1683,4 +1683,17 @@ void
 garrow_select_k_options_add_sort_key(GArrowSelectKOptions *options,
                                      GArrowSortKey *sort_key);
 
+#define GARROW_TYPE_SKEW_OPTIONS (garrow_skew_options_get_type())
+GARROW_AVAILABLE_IN_23_0
+G_DECLARE_DERIVABLE_TYPE(
+  GArrowSkewOptions, garrow_skew_options, GARROW, SKEW_OPTIONS, GArrowFunctionOptions)
+struct _GArrowSkewOptionsClass
+{
+  GArrowFunctionOptionsClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_23_0
+GArrowSkewOptions *
+garrow_skew_options_new(void);
+
 G_END_DECLS

--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -1495,4 +1495,37 @@ GARROW_AVAILABLE_IN_23_0
 GArrowPartitionNthOptions *
 garrow_partition_nth_options_new(void);
 
+/**
+ * GArrowPivotWiderUnexpectedKeyBehavior:
+ * @GARROW_PIVOT_WIDER_UNEXPECTED_KEY_BEHAVIOR_IGNORE: Unexpected pivot keys are ignored
+ * silently.
+ * @GARROW_PIVOT_WIDER_UNEXPECTED_KEY_BEHAVIOR_RAISE: Unexpected pivot keys return a
+ * KeyError.
+ *
+ * They correspond to the values of
+ * `arrow::compute::PivotWiderOptions::UnexpectedKeyBehavior`.
+ *
+ * Since: 23.0.0
+ */
+typedef enum {
+  GARROW_PIVOT_WIDER_UNEXPECTED_KEY_BEHAVIOR_IGNORE,
+  GARROW_PIVOT_WIDER_UNEXPECTED_KEY_BEHAVIOR_RAISE,
+} GArrowPivotWiderUnexpectedKeyBehavior;
+
+#define GARROW_TYPE_PIVOT_WIDER_OPTIONS (garrow_pivot_wider_options_get_type())
+GARROW_AVAILABLE_IN_23_0
+G_DECLARE_DERIVABLE_TYPE(GArrowPivotWiderOptions,
+                         garrow_pivot_wider_options,
+                         GARROW,
+                         PIVOT_WIDER_OPTIONS,
+                         GArrowFunctionOptions)
+struct _GArrowPivotWiderOptionsClass
+{
+  GArrowFunctionOptionsClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_23_0
+GArrowPivotWiderOptions *
+garrow_pivot_wider_options_new(void);
+
 G_END_DECLS

--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -1374,4 +1374,20 @@ GARROW_AVAILABLE_IN_23_0
 GArrowListSliceOptions *
 garrow_list_slice_options_new(void);
 
+#define GARROW_TYPE_MAKE_STRUCT_OPTIONS (garrow_make_struct_options_get_type())
+GARROW_AVAILABLE_IN_23_0
+G_DECLARE_DERIVABLE_TYPE(GArrowMakeStructOptions,
+                         garrow_make_struct_options,
+                         GARROW,
+                         MAKE_STRUCT_OPTIONS,
+                         GArrowFunctionOptions)
+struct _GArrowMakeStructOptionsClass
+{
+  GArrowFunctionOptionsClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_23_0
+GArrowMakeStructOptions *
+garrow_make_struct_options_new(void);
+
 G_END_DECLS

--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -1289,4 +1289,36 @@ GARROW_AVAILABLE_IN_23_0
 GArrowExtractRegexSpanOptions *
 garrow_extract_regex_span_options_new(void);
 
+/**
+ * GArrowJoinNullHandlingBehavior:
+ * @GARROW_JOIN_NULL_HANDLING_EMIT_NULL: A null in any input results in a null in the
+ * output.
+ * @GARROW_JOIN_NULL_HANDLING_SKIP: Nulls in inputs are skipped.
+ * @GARROW_JOIN_NULL_HANDLING_REPLACE: Nulls in inputs are replaced with the replacement
+ * string.
+ *
+ * They correspond to the values of
+ * `arrow::compute::JoinOptions::NullHandlingBehavior`.
+ *
+ * Since: 23.0.0
+ */
+typedef enum {
+  GARROW_JOIN_NULL_HANDLING_EMIT_NULL,
+  GARROW_JOIN_NULL_HANDLING_SKIP,
+  GARROW_JOIN_NULL_HANDLING_REPLACE,
+} GArrowJoinNullHandlingBehavior;
+
+#define GARROW_TYPE_JOIN_OPTIONS (garrow_join_options_get_type())
+GARROW_AVAILABLE_IN_23_0
+G_DECLARE_DERIVABLE_TYPE(
+  GArrowJoinOptions, garrow_join_options, GARROW, JOIN_OPTIONS, GArrowFunctionOptions)
+struct _GArrowJoinOptionsClass
+{
+  GArrowFunctionOptionsClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_23_0
+GArrowJoinOptions *
+garrow_join_options_new(void);
+
 G_END_DECLS

--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -1555,4 +1555,20 @@ void
 garrow_rank_quantile_options_add_sort_key(GArrowRankQuantileOptions *options,
                                           GArrowSortKey *sort_key);
 
+#define GARROW_TYPE_REPLACE_SLICE_OPTIONS (garrow_replace_slice_options_get_type())
+GARROW_AVAILABLE_IN_23_0
+G_DECLARE_DERIVABLE_TYPE(GArrowReplaceSliceOptions,
+                         garrow_replace_slice_options,
+                         GARROW,
+                         REPLACE_SLICE_OPTIONS,
+                         GArrowFunctionOptions)
+struct _GArrowReplaceSliceOptionsClass
+{
+  GArrowFunctionOptionsClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_23_0
+GArrowReplaceSliceOptions *
+garrow_replace_slice_options_new(void);
+
 G_END_DECLS

--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -1696,4 +1696,17 @@ GARROW_AVAILABLE_IN_23_0
 GArrowSkewOptions *
 garrow_skew_options_new(void);
 
+#define GARROW_TYPE_SLICE_OPTIONS (garrow_slice_options_get_type())
+GARROW_AVAILABLE_IN_23_0
+G_DECLARE_DERIVABLE_TYPE(
+  GArrowSliceOptions, garrow_slice_options, GARROW, SLICE_OPTIONS, GArrowFunctionOptions)
+struct _GArrowSliceOptionsClass
+{
+  GArrowFunctionOptionsClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_23_0
+GArrowSliceOptions *
+garrow_slice_options_new(void);
+
 G_END_DECLS

--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -1709,4 +1709,17 @@ GARROW_AVAILABLE_IN_23_0
 GArrowSliceOptions *
 garrow_slice_options_new(void);
 
+#define GARROW_TYPE_SPLIT_OPTIONS (garrow_split_options_get_type())
+GARROW_AVAILABLE_IN_23_0
+G_DECLARE_DERIVABLE_TYPE(
+  GArrowSplitOptions, garrow_split_options, GARROW, SPLIT_OPTIONS, GArrowFunctionOptions)
+struct _GArrowSplitOptionsClass
+{
+  GArrowFunctionOptionsClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_23_0
+GArrowSplitOptions *
+garrow_split_options_new(void);
+
 G_END_DECLS

--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -1479,4 +1479,20 @@ GARROW_AVAILABLE_IN_23_0
 GArrowPairwiseOptions *
 garrow_pairwise_options_new(void);
 
+#define GARROW_TYPE_PARTITION_NTH_OPTIONS (garrow_partition_nth_options_get_type())
+GARROW_AVAILABLE_IN_23_0
+G_DECLARE_DERIVABLE_TYPE(GArrowPartitionNthOptions,
+                         garrow_partition_nth_options,
+                         GARROW,
+                         PARTITION_NTH_OPTIONS,
+                         GArrowFunctionOptions)
+struct _GArrowPartitionNthOptionsClass
+{
+  GArrowFunctionOptionsClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_23_0
+GArrowPartitionNthOptions *
+garrow_partition_nth_options_new(void);
+
 G_END_DECLS

--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -1450,4 +1450,17 @@ GARROW_AVAILABLE_IN_23_0
 GArrowNullOptions *
 garrow_null_options_new(void);
 
+#define GARROW_TYPE_PAD_OPTIONS (garrow_pad_options_get_type())
+GARROW_AVAILABLE_IN_23_0
+G_DECLARE_DERIVABLE_TYPE(
+  GArrowPadOptions, garrow_pad_options, GARROW, PAD_OPTIONS, GArrowFunctionOptions)
+struct _GArrowPadOptionsClass
+{
+  GArrowFunctionOptionsClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_23_0
+GArrowPadOptions *
+garrow_pad_options_new(void);
+
 G_END_DECLS

--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -1760,4 +1760,17 @@ GARROW_AVAILABLE_IN_23_0
 GArrowTrimOptions *
 garrow_trim_options_new(void);
 
+#define GARROW_TYPE_WEEK_OPTIONS (garrow_week_options_get_type())
+GARROW_AVAILABLE_IN_23_0
+G_DECLARE_DERIVABLE_TYPE(
+  GArrowWeekOptions, garrow_week_options, GARROW, WEEK_OPTIONS, GArrowFunctionOptions)
+struct _GArrowWeekOptionsClass
+{
+  GArrowFunctionOptionsClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_23_0
+GArrowWeekOptions *
+garrow_week_options_new(void);
+
 G_END_DECLS

--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -1437,4 +1437,17 @@ GARROW_AVAILABLE_IN_23_0
 GArrowModeOptions *
 garrow_mode_options_new(void);
 
+#define GARROW_TYPE_NULL_OPTIONS (garrow_null_options_get_type())
+GARROW_AVAILABLE_IN_23_0
+G_DECLARE_DERIVABLE_TYPE(
+  GArrowNullOptions, garrow_null_options, GARROW, NULL_OPTIONS, GArrowFunctionOptions)
+struct _GArrowNullOptionsClass
+{
+  GArrowFunctionOptionsClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_23_0
+GArrowNullOptions *
+garrow_null_options_new(void);
+
 G_END_DECLS

--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -1189,4 +1189,20 @@ GARROW_AVAILABLE_IN_23_0
 GArrowCumulativeOptions *
 garrow_cumulative_options_new(void);
 
+#define GARROW_TYPE_DAY_OF_WEEK_OPTIONS (garrow_day_of_week_options_get_type())
+GARROW_AVAILABLE_IN_23_0
+G_DECLARE_DERIVABLE_TYPE(GArrowDayOfWeekOptions,
+                         garrow_day_of_week_options,
+                         GARROW,
+                         DAY_OF_WEEK_OPTIONS,
+                         GArrowFunctionOptions)
+struct _GArrowDayOfWeekOptionsClass
+{
+  GArrowFunctionOptionsClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_23_0
+GArrowDayOfWeekOptions *
+garrow_day_of_week_options_new(void);
+
 G_END_DECLS

--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -1789,4 +1789,20 @@ GARROW_AVAILABLE_IN_23_0
 GArrowWinsorizeOptions *
 garrow_winsorize_options_new(void);
 
+#define GARROW_TYPE_ZERO_FILL_OPTIONS (garrow_zero_fill_options_get_type())
+GARROW_AVAILABLE_IN_23_0
+G_DECLARE_DERIVABLE_TYPE(GArrowZeroFillOptions,
+                         garrow_zero_fill_options,
+                         GARROW,
+                         ZERO_FILL_OPTIONS,
+                         GArrowFunctionOptions)
+struct _GArrowZeroFillOptionsClass
+{
+  GArrowFunctionOptionsClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_23_0
+GArrowZeroFillOptions *
+garrow_zero_fill_options_new(void);
+
 G_END_DECLS

--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -1173,4 +1173,20 @@ GARROW_AVAILABLE_IN_23_0
 GArrowAssumeTimezoneOptions *
 garrow_assume_timezone_options_new(void);
 
+#define GARROW_TYPE_CUMULATIVE_OPTIONS (garrow_cumulative_options_get_type())
+GARROW_AVAILABLE_IN_23_0
+G_DECLARE_DERIVABLE_TYPE(GArrowCumulativeOptions,
+                         garrow_cumulative_options,
+                         GARROW,
+                         CUMULATIVE_OPTIONS,
+                         GArrowFunctionOptions)
+struct _GArrowCumulativeOptionsClass
+{
+  GArrowFunctionOptionsClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_23_0
+GArrowCumulativeOptions *
+garrow_cumulative_options_new(void);
+
 G_END_DECLS

--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -1463,4 +1463,20 @@ GARROW_AVAILABLE_IN_23_0
 GArrowPadOptions *
 garrow_pad_options_new(void);
 
+#define GARROW_TYPE_PAIRWISE_OPTIONS (garrow_pairwise_options_get_type())
+GARROW_AVAILABLE_IN_23_0
+G_DECLARE_DERIVABLE_TYPE(GArrowPairwiseOptions,
+                         garrow_pairwise_options,
+                         GARROW,
+                         PAIRWISE_OPTIONS,
+                         GArrowFunctionOptions)
+struct _GArrowPairwiseOptionsClass
+{
+  GArrowFunctionOptionsClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_23_0
+GArrowPairwiseOptions *
+garrow_pairwise_options_new(void);
+
 G_END_DECLS

--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -1528,4 +1528,31 @@ GARROW_AVAILABLE_IN_23_0
 GArrowPivotWiderOptions *
 garrow_pivot_wider_options_new(void);
 
+#define GARROW_TYPE_RANK_QUANTILE_OPTIONS (garrow_rank_quantile_options_get_type())
+GARROW_AVAILABLE_IN_23_0
+G_DECLARE_DERIVABLE_TYPE(GArrowRankQuantileOptions,
+                         garrow_rank_quantile_options,
+                         GARROW,
+                         RANK_QUANTILE_OPTIONS,
+                         GArrowFunctionOptions)
+struct _GArrowRankQuantileOptionsClass
+{
+  GArrowFunctionOptionsClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_23_0
+GArrowRankQuantileOptions *
+garrow_rank_quantile_options_new(void);
+GARROW_AVAILABLE_IN_23_0
+GList *
+garrow_rank_quantile_options_get_sort_keys(GArrowRankQuantileOptions *options);
+GARROW_AVAILABLE_IN_23_0
+void
+garrow_rank_quantile_options_set_sort_keys(GArrowRankQuantileOptions *options,
+                                           GList *sort_keys);
+GARROW_AVAILABLE_IN_23_0
+void
+garrow_rank_quantile_options_add_sort_key(GArrowRankQuantileOptions *options,
+                                          GArrowSortKey *sort_key);
+
 G_END_DECLS

--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -1321,4 +1321,20 @@ GARROW_AVAILABLE_IN_23_0
 GArrowJoinOptions *
 garrow_join_options_new(void);
 
+#define GARROW_TYPE_LIST_FLATTEN_OPTIONS (garrow_list_flatten_options_get_type())
+GARROW_AVAILABLE_IN_23_0
+G_DECLARE_DERIVABLE_TYPE(GArrowListFlattenOptions,
+                         garrow_list_flatten_options,
+                         GARROW,
+                         LIST_FLATTEN_OPTIONS,
+                         GArrowFunctionOptions)
+struct _GArrowListFlattenOptionsClass
+{
+  GArrowFunctionOptionsClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_23_0
+GArrowListFlattenOptions *
+garrow_list_flatten_options_new(void);
+
 G_END_DECLS

--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -1604,4 +1604,54 @@ GARROW_AVAILABLE_IN_23_0
 GArrowRoundBinaryOptions *
 garrow_round_binary_options_new(void);
 
+/**
+ * GArrowCalendarUnit:
+ * @GARROW_CALENDAR_UNIT_NANOSECOND: Nanosecond
+ * @GARROW_CALENDAR_UNIT_MICROSECOND: Microsecond
+ * @GARROW_CALENDAR_UNIT_MILLISECOND: Millisecond
+ * @GARROW_CALENDAR_UNIT_SECOND: Second
+ * @GARROW_CALENDAR_UNIT_MINUTE: Minute
+ * @GARROW_CALENDAR_UNIT_HOUR: Hour
+ * @GARROW_CALENDAR_UNIT_DAY: Day
+ * @GARROW_CALENDAR_UNIT_WEEK: Week
+ * @GARROW_CALENDAR_UNIT_MONTH: Month
+ * @GARROW_CALENDAR_UNIT_QUARTER: Quarter
+ * @GARROW_CALENDAR_UNIT_YEAR: Year
+ *
+ * They correspond to the values of `arrow::compute::CalendarUnit`.
+ *
+ * Since: 23.0.0
+ */
+typedef enum {
+  GARROW_CALENDAR_UNIT_NANOSECOND,
+  GARROW_CALENDAR_UNIT_MICROSECOND,
+  GARROW_CALENDAR_UNIT_MILLISECOND,
+  GARROW_CALENDAR_UNIT_SECOND,
+  GARROW_CALENDAR_UNIT_MINUTE,
+  GARROW_CALENDAR_UNIT_HOUR,
+  GARROW_CALENDAR_UNIT_DAY,
+  GARROW_CALENDAR_UNIT_WEEK,
+  GARROW_CALENDAR_UNIT_MONTH,
+  GARROW_CALENDAR_UNIT_QUARTER,
+  GARROW_CALENDAR_UNIT_YEAR,
+} GArrowCalendarUnit;
+
+#define GARROW_TYPE_CALENDAR_UNIT          (garrow_calendar_unit_get_type())
+
+#define GARROW_TYPE_ROUND_TEMPORAL_OPTIONS (garrow_round_temporal_options_get_type())
+GARROW_AVAILABLE_IN_23_0
+G_DECLARE_DERIVABLE_TYPE(GArrowRoundTemporalOptions,
+                         garrow_round_temporal_options,
+                         GARROW,
+                         ROUND_TEMPORAL_OPTIONS,
+                         GArrowFunctionOptions)
+struct _GArrowRoundTemporalOptionsClass
+{
+  GArrowFunctionOptionsClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_23_0
+GArrowRoundTemporalOptions *
+garrow_round_temporal_options_new(void);
+
 G_END_DECLS

--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -1256,4 +1256,20 @@ GARROW_AVAILABLE_IN_23_0
 GArrowElementWiseAggregateOptions *
 garrow_element_wise_aggregate_options_new(void);
 
+#define GARROW_TYPE_EXTRACT_REGEX_OPTIONS (garrow_extract_regex_options_get_type())
+GARROW_AVAILABLE_IN_23_0
+G_DECLARE_DERIVABLE_TYPE(GArrowExtractRegexOptions,
+                         garrow_extract_regex_options,
+                         GARROW,
+                         EXTRACT_REGEX_OPTIONS,
+                         GArrowFunctionOptions)
+struct _GArrowExtractRegexOptionsClass
+{
+  GArrowFunctionOptionsClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_23_0
+GArrowExtractRegexOptions *
+garrow_extract_regex_options_new(void);
+
 G_END_DECLS

--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -1390,4 +1390,38 @@ GARROW_AVAILABLE_IN_23_0
 GArrowMakeStructOptions *
 garrow_make_struct_options_new(void);
 
+/**
+ * GArrowMapLookupOccurrence:
+ * @GARROW_MAP_LOOKUP_OCCURRENCE_FIRST: Return the first matching value.
+ * @GARROW_MAP_LOOKUP_OCCURRENCE_LAST: Return the last matching value.
+ * @GARROW_MAP_LOOKUP_OCCURRENCE_ALL: Return all matching values.
+ *
+ * They correspond to the values of
+ * `arrow::compute::MapLookupOptions::Occurrence`.
+ *
+ * Since: 23.0.0
+ */
+typedef enum {
+  GARROW_MAP_LOOKUP_OCCURRENCE_FIRST,
+  GARROW_MAP_LOOKUP_OCCURRENCE_LAST,
+  GARROW_MAP_LOOKUP_OCCURRENCE_ALL,
+} GArrowMapLookupOccurrence;
+
+#define GARROW_TYPE_MAP_LOOKUP_OPTIONS (garrow_map_lookup_options_get_type())
+GARROW_AVAILABLE_IN_23_0
+G_DECLARE_DERIVABLE_TYPE(GArrowMapLookupOptions,
+                         garrow_map_lookup_options,
+                         GARROW,
+                         MAP_LOOKUP_OPTIONS,
+                         GArrowFunctionOptions)
+struct _GArrowMapLookupOptionsClass
+{
+  GArrowFunctionOptionsClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_23_0
+GArrowMapLookupOptions *
+garrow_map_lookup_options_new(GArrowScalar *query_key,
+                              GArrowMapLookupOccurrence occurrence);
+
 G_END_DECLS

--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -1773,4 +1773,20 @@ GARROW_AVAILABLE_IN_23_0
 GArrowWeekOptions *
 garrow_week_options_new(void);
 
+#define GARROW_TYPE_WINSORIZE_OPTIONS (garrow_winsorize_options_get_type())
+GARROW_AVAILABLE_IN_23_0
+G_DECLARE_DERIVABLE_TYPE(GArrowWinsorizeOptions,
+                         garrow_winsorize_options,
+                         GARROW,
+                         WINSORIZE_OPTIONS,
+                         GArrowFunctionOptions)
+struct _GArrowWinsorizeOptionsClass
+{
+  GArrowFunctionOptionsClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_23_0
+GArrowWinsorizeOptions *
+garrow_winsorize_options_new(void);
+
 G_END_DECLS

--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -1205,4 +1205,38 @@ GARROW_AVAILABLE_IN_23_0
 GArrowDayOfWeekOptions *
 garrow_day_of_week_options_new(void);
 
+/**
+ * GArrowDictionaryEncodeNullEncodingBehavior:
+ * @GARROW_DICTIONARY_ENCODE_NULL_ENCODING_ENCODE: The null value will be added to the
+ * dictionary with a proper index.
+ * @GARROW_DICTIONARY_ENCODE_NULL_ENCODING_MASK: The null value will be masked in the
+ * indices array.
+ *
+ * They correspond to the values of
+ * `arrow::compute::DictionaryEncodeOptions::NullEncodingBehavior`.
+ *
+ * Since: 23.0.0
+ */
+typedef enum {
+  GARROW_DICTIONARY_ENCODE_NULL_ENCODING_ENCODE,
+  GARROW_DICTIONARY_ENCODE_NULL_ENCODING_MASK,
+} GArrowDictionaryEncodeNullEncodingBehavior;
+
+#define GARROW_TYPE_DICTIONARY_ENCODE_OPTIONS                                            \
+  (garrow_dictionary_encode_options_get_type())
+GARROW_AVAILABLE_IN_23_0
+G_DECLARE_DERIVABLE_TYPE(GArrowDictionaryEncodeOptions,
+                         garrow_dictionary_encode_options,
+                         GARROW,
+                         DICTIONARY_ENCODE_OPTIONS,
+                         GArrowFunctionOptions)
+struct _GArrowDictionaryEncodeOptionsClass
+{
+  GArrowFunctionOptionsClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_23_0
+GArrowDictionaryEncodeOptions *
+garrow_dictionary_encode_options_new(void);
+
 G_END_DECLS

--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -1654,4 +1654,33 @@ GARROW_AVAILABLE_IN_23_0
 GArrowRoundTemporalOptions *
 garrow_round_temporal_options_new(void);
 
+#define GARROW_TYPE_SELECT_K_OPTIONS (garrow_select_k_options_get_type())
+GARROW_AVAILABLE_IN_23_0
+G_DECLARE_DERIVABLE_TYPE(GArrowSelectKOptions,
+                         garrow_select_k_options,
+                         GARROW,
+                         SELECT_K_OPTIONS,
+                         GArrowFunctionOptions)
+struct _GArrowSelectKOptionsClass
+{
+  GArrowFunctionOptionsClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_23_0
+GArrowSelectKOptions *
+garrow_select_k_options_new(void);
+
+GARROW_AVAILABLE_IN_23_0
+GList *
+garrow_select_k_options_get_sort_keys(GArrowSelectKOptions *options);
+
+GARROW_AVAILABLE_IN_23_0
+void
+garrow_select_k_options_set_sort_keys(GArrowSelectKOptions *options, GList *sort_keys);
+
+GARROW_AVAILABLE_IN_23_0
+void
+garrow_select_k_options_add_sort_key(GArrowSelectKOptions *options,
+                                     GArrowSortKey *sort_key);
+
 G_END_DECLS

--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -1571,4 +1571,21 @@ GARROW_AVAILABLE_IN_23_0
 GArrowReplaceSliceOptions *
 garrow_replace_slice_options_new(void);
 
+#define GARROW_TYPE_REPLACE_SUBSTRING_OPTIONS                                            \
+  (garrow_replace_substring_options_get_type())
+GARROW_AVAILABLE_IN_23_0
+G_DECLARE_DERIVABLE_TYPE(GArrowReplaceSubstringOptions,
+                         garrow_replace_substring_options,
+                         GARROW,
+                         REPLACE_SUBSTRING_OPTIONS,
+                         GArrowFunctionOptions)
+struct _GArrowReplaceSubstringOptionsClass
+{
+  GArrowFunctionOptionsClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_23_0
+GArrowReplaceSubstringOptions *
+garrow_replace_substring_options_new(void);
+
 G_END_DECLS

--- a/c_glib/arrow-glib/compute.hpp
+++ b/c_glib/arrow-glib/compute.hpp
@@ -247,3 +247,8 @@ GArrowModeOptions *
 garrow_mode_options_new_raw(const arrow::compute::ModeOptions *arrow_options);
 arrow::compute::ModeOptions *
 garrow_mode_options_get_raw(GArrowModeOptions *options);
+
+GArrowNullOptions *
+garrow_null_options_new_raw(const arrow::compute::NullOptions *arrow_options);
+arrow::compute::NullOptions *
+garrow_null_options_get_raw(GArrowNullOptions *options);

--- a/c_glib/arrow-glib/compute.hpp
+++ b/c_glib/arrow-glib/compute.hpp
@@ -215,3 +215,8 @@ garrow_extract_regex_span_options_new_raw(
   const arrow::compute::ExtractRegexSpanOptions *arrow_options);
 arrow::compute::ExtractRegexSpanOptions *
 garrow_extract_regex_span_options_get_raw(GArrowExtractRegexSpanOptions *options);
+
+GArrowJoinOptions *
+garrow_join_options_new_raw(const arrow::compute::JoinOptions *arrow_options);
+arrow::compute::JoinOptions *
+garrow_join_options_get_raw(GArrowJoinOptions *options);

--- a/c_glib/arrow-glib/compute.hpp
+++ b/c_glib/arrow-glib/compute.hpp
@@ -324,3 +324,8 @@ GArrowSplitOptions *
 garrow_split_options_new_raw(const arrow::compute::SplitOptions *arrow_options);
 arrow::compute::SplitOptions *
 garrow_split_options_get_raw(GArrowSplitOptions *options);
+
+GArrowTDigestOptions *
+garrow_tdigest_options_new_raw(const arrow::compute::TDigestOptions *arrow_options);
+arrow::compute::TDigestOptions *
+garrow_tdigest_options_get_raw(GArrowTDigestOptions *options);

--- a/c_glib/arrow-glib/compute.hpp
+++ b/c_glib/arrow-glib/compute.hpp
@@ -237,3 +237,8 @@ garrow_make_struct_options_new_raw(
   const arrow::compute::MakeStructOptions *arrow_options);
 arrow::compute::MakeStructOptions *
 garrow_make_struct_options_get_raw(GArrowMakeStructOptions *options);
+
+GArrowMapLookupOptions *
+garrow_map_lookup_options_new_raw(const arrow::compute::MapLookupOptions *arrow_options);
+arrow::compute::MapLookupOptions *
+garrow_map_lookup_options_get_raw(GArrowMapLookupOptions *options);

--- a/c_glib/arrow-glib/compute.hpp
+++ b/c_glib/arrow-glib/compute.hpp
@@ -257,3 +257,8 @@ GArrowPadOptions *
 garrow_pad_options_new_raw(const arrow::compute::PadOptions *arrow_options);
 arrow::compute::PadOptions *
 garrow_pad_options_get_raw(GArrowPadOptions *options);
+
+GArrowPairwiseOptions *
+garrow_pairwise_options_new_raw(const arrow::compute::PairwiseOptions *arrow_options);
+arrow::compute::PairwiseOptions *
+garrow_pairwise_options_get_raw(GArrowPairwiseOptions *options);

--- a/c_glib/arrow-glib/compute.hpp
+++ b/c_glib/arrow-glib/compute.hpp
@@ -220,3 +220,9 @@ GArrowJoinOptions *
 garrow_join_options_new_raw(const arrow::compute::JoinOptions *arrow_options);
 arrow::compute::JoinOptions *
 garrow_join_options_get_raw(GArrowJoinOptions *options);
+
+GArrowListFlattenOptions *
+garrow_list_flatten_options_new_raw(
+  const arrow::compute::ListFlattenOptions *arrow_options);
+arrow::compute::ListFlattenOptions *
+garrow_list_flatten_options_get_raw(GArrowListFlattenOptions *options);

--- a/c_glib/arrow-glib/compute.hpp
+++ b/c_glib/arrow-glib/compute.hpp
@@ -334,3 +334,8 @@ GArrowTrimOptions *
 garrow_trim_options_new_raw(const arrow::compute::TrimOptions *arrow_options);
 arrow::compute::TrimOptions *
 garrow_trim_options_get_raw(GArrowTrimOptions *options);
+
+GArrowWeekOptions *
+garrow_week_options_new_raw(const arrow::compute::WeekOptions *arrow_options);
+arrow::compute::WeekOptions *
+garrow_week_options_get_raw(GArrowWeekOptions *options);

--- a/c_glib/arrow-glib/compute.hpp
+++ b/c_glib/arrow-glib/compute.hpp
@@ -314,3 +314,8 @@ GArrowSkewOptions *
 garrow_skew_options_new_raw(const arrow::compute::SkewOptions *arrow_options);
 arrow::compute::SkewOptions *
 garrow_skew_options_get_raw(GArrowSkewOptions *options);
+
+GArrowSliceOptions *
+garrow_slice_options_new_raw(const arrow::compute::SliceOptions *arrow_options);
+arrow::compute::SliceOptions *
+garrow_slice_options_get_raw(GArrowSliceOptions *options);

--- a/c_glib/arrow-glib/compute.hpp
+++ b/c_glib/arrow-glib/compute.hpp
@@ -292,3 +292,9 @@ garrow_replace_substring_options_new_raw(
   const arrow::compute::ReplaceSubstringOptions *arrow_options);
 arrow::compute::ReplaceSubstringOptions *
 garrow_replace_substring_options_get_raw(GArrowReplaceSubstringOptions *options);
+
+GArrowRoundBinaryOptions *
+garrow_round_binary_options_new_raw(
+  const arrow::compute::RoundBinaryOptions *arrow_options);
+arrow::compute::RoundBinaryOptions *
+garrow_round_binary_options_get_raw(GArrowRoundBinaryOptions *options);

--- a/c_glib/arrow-glib/compute.hpp
+++ b/c_glib/arrow-glib/compute.hpp
@@ -268,3 +268,9 @@ garrow_partition_nth_options_new_raw(
   const arrow::compute::PartitionNthOptions *arrow_options);
 arrow::compute::PartitionNthOptions *
 garrow_partition_nth_options_get_raw(GArrowPartitionNthOptions *options);
+
+GArrowPivotWiderOptions *
+garrow_pivot_wider_options_new_raw(
+  const arrow::compute::PivotWiderOptions *arrow_options);
+arrow::compute::PivotWiderOptions *
+garrow_pivot_wider_options_get_raw(GArrowPivotWiderOptions *options);

--- a/c_glib/arrow-glib/compute.hpp
+++ b/c_glib/arrow-glib/compute.hpp
@@ -280,3 +280,9 @@ garrow_rank_quantile_options_new_raw(
   const arrow::compute::RankQuantileOptions *arrow_options);
 arrow::compute::RankQuantileOptions *
 garrow_rank_quantile_options_get_raw(GArrowRankQuantileOptions *options);
+
+GArrowReplaceSliceOptions *
+garrow_replace_slice_options_new_raw(
+  const arrow::compute::ReplaceSliceOptions *arrow_options);
+arrow::compute::ReplaceSliceOptions *
+garrow_replace_slice_options_get_raw(GArrowReplaceSliceOptions *options);

--- a/c_glib/arrow-glib/compute.hpp
+++ b/c_glib/arrow-glib/compute.hpp
@@ -286,3 +286,9 @@ garrow_replace_slice_options_new_raw(
   const arrow::compute::ReplaceSliceOptions *arrow_options);
 arrow::compute::ReplaceSliceOptions *
 garrow_replace_slice_options_get_raw(GArrowReplaceSliceOptions *options);
+
+GArrowReplaceSubstringOptions *
+garrow_replace_substring_options_new_raw(
+  const arrow::compute::ReplaceSubstringOptions *arrow_options);
+arrow::compute::ReplaceSubstringOptions *
+garrow_replace_substring_options_get_raw(GArrowReplaceSubstringOptions *options);

--- a/c_glib/arrow-glib/compute.hpp
+++ b/c_glib/arrow-glib/compute.hpp
@@ -197,3 +197,9 @@ garrow_dictionary_encode_options_new_raw(
   const arrow::compute::DictionaryEncodeOptions *arrow_options);
 arrow::compute::DictionaryEncodeOptions *
 garrow_dictionary_encode_options_get_raw(GArrowDictionaryEncodeOptions *options);
+
+GArrowElementWiseAggregateOptions *
+garrow_element_wise_aggregate_options_new_raw(
+  const arrow::compute::ElementWiseAggregateOptions *arrow_options);
+arrow::compute::ElementWiseAggregateOptions *
+garrow_element_wise_aggregate_options_get_raw(GArrowElementWiseAggregateOptions *options);

--- a/c_glib/arrow-glib/compute.hpp
+++ b/c_glib/arrow-glib/compute.hpp
@@ -252,3 +252,8 @@ GArrowNullOptions *
 garrow_null_options_new_raw(const arrow::compute::NullOptions *arrow_options);
 arrow::compute::NullOptions *
 garrow_null_options_get_raw(GArrowNullOptions *options);
+
+GArrowPadOptions *
+garrow_pad_options_new_raw(const arrow::compute::PadOptions *arrow_options);
+arrow::compute::PadOptions *
+garrow_pad_options_get_raw(GArrowPadOptions *options);

--- a/c_glib/arrow-glib/compute.hpp
+++ b/c_glib/arrow-glib/compute.hpp
@@ -226,3 +226,8 @@ garrow_list_flatten_options_new_raw(
   const arrow::compute::ListFlattenOptions *arrow_options);
 arrow::compute::ListFlattenOptions *
 garrow_list_flatten_options_get_raw(GArrowListFlattenOptions *options);
+
+GArrowListSliceOptions *
+garrow_list_slice_options_new_raw(const arrow::compute::ListSliceOptions *arrow_options);
+arrow::compute::ListSliceOptions *
+garrow_list_slice_options_get_raw(GArrowListSliceOptions *options);

--- a/c_glib/arrow-glib/compute.hpp
+++ b/c_glib/arrow-glib/compute.hpp
@@ -339,3 +339,8 @@ GArrowWeekOptions *
 garrow_week_options_new_raw(const arrow::compute::WeekOptions *arrow_options);
 arrow::compute::WeekOptions *
 garrow_week_options_get_raw(GArrowWeekOptions *options);
+
+GArrowWinsorizeOptions *
+garrow_winsorize_options_new_raw(const arrow::compute::WinsorizeOptions *arrow_options);
+arrow::compute::WinsorizeOptions *
+garrow_winsorize_options_get_raw(GArrowWinsorizeOptions *options);

--- a/c_glib/arrow-glib/compute.hpp
+++ b/c_glib/arrow-glib/compute.hpp
@@ -344,3 +344,8 @@ GArrowWinsorizeOptions *
 garrow_winsorize_options_new_raw(const arrow::compute::WinsorizeOptions *arrow_options);
 arrow::compute::WinsorizeOptions *
 garrow_winsorize_options_get_raw(GArrowWinsorizeOptions *options);
+
+GArrowZeroFillOptions *
+garrow_zero_fill_options_new_raw(const arrow::compute::ZeroFillOptions *arrow_options);
+arrow::compute::ZeroFillOptions *
+garrow_zero_fill_options_get_raw(GArrowZeroFillOptions *options);

--- a/c_glib/arrow-glib/compute.hpp
+++ b/c_glib/arrow-glib/compute.hpp
@@ -175,3 +175,9 @@ garrow_struct_field_options_new_raw(
   const arrow::compute::StructFieldOptions *arrow_options);
 arrow::compute::StructFieldOptions *
 garrow_struct_field_options_get_raw(GArrowStructFieldOptions *options);
+
+GArrowAssumeTimezoneOptions *
+garrow_assume_timezone_options_new_raw(
+  const arrow::compute::AssumeTimezoneOptions *arrow_options);
+arrow::compute::AssumeTimezoneOptions *
+garrow_assume_timezone_options_get_raw(GArrowAssumeTimezoneOptions *options);

--- a/c_glib/arrow-glib/compute.hpp
+++ b/c_glib/arrow-glib/compute.hpp
@@ -181,3 +181,8 @@ garrow_assume_timezone_options_new_raw(
   const arrow::compute::AssumeTimezoneOptions *arrow_options);
 arrow::compute::AssumeTimezoneOptions *
 garrow_assume_timezone_options_get_raw(GArrowAssumeTimezoneOptions *options);
+
+GArrowCumulativeOptions *
+garrow_cumulative_options_new_raw(const arrow::compute::CumulativeOptions *arrow_options);
+arrow::compute::CumulativeOptions *
+garrow_cumulative_options_get_raw(GArrowCumulativeOptions *options);

--- a/c_glib/arrow-glib/compute.hpp
+++ b/c_glib/arrow-glib/compute.hpp
@@ -329,3 +329,8 @@ GArrowTDigestOptions *
 garrow_tdigest_options_new_raw(const arrow::compute::TDigestOptions *arrow_options);
 arrow::compute::TDigestOptions *
 garrow_tdigest_options_get_raw(GArrowTDigestOptions *options);
+
+GArrowTrimOptions *
+garrow_trim_options_new_raw(const arrow::compute::TrimOptions *arrow_options);
+arrow::compute::TrimOptions *
+garrow_trim_options_get_raw(GArrowTrimOptions *options);

--- a/c_glib/arrow-glib/compute.hpp
+++ b/c_glib/arrow-glib/compute.hpp
@@ -209,3 +209,9 @@ garrow_extract_regex_options_new_raw(
   const arrow::compute::ExtractRegexOptions *arrow_options);
 arrow::compute::ExtractRegexOptions *
 garrow_extract_regex_options_get_raw(GArrowExtractRegexOptions *options);
+
+GArrowExtractRegexSpanOptions *
+garrow_extract_regex_span_options_new_raw(
+  const arrow::compute::ExtractRegexSpanOptions *arrow_options);
+arrow::compute::ExtractRegexSpanOptions *
+garrow_extract_regex_span_options_get_raw(GArrowExtractRegexSpanOptions *options);

--- a/c_glib/arrow-glib/compute.hpp
+++ b/c_glib/arrow-glib/compute.hpp
@@ -262,3 +262,9 @@ GArrowPairwiseOptions *
 garrow_pairwise_options_new_raw(const arrow::compute::PairwiseOptions *arrow_options);
 arrow::compute::PairwiseOptions *
 garrow_pairwise_options_get_raw(GArrowPairwiseOptions *options);
+
+GArrowPartitionNthOptions *
+garrow_partition_nth_options_new_raw(
+  const arrow::compute::PartitionNthOptions *arrow_options);
+arrow::compute::PartitionNthOptions *
+garrow_partition_nth_options_get_raw(GArrowPartitionNthOptions *options);

--- a/c_glib/arrow-glib/compute.hpp
+++ b/c_glib/arrow-glib/compute.hpp
@@ -186,3 +186,8 @@ GArrowCumulativeOptions *
 garrow_cumulative_options_new_raw(const arrow::compute::CumulativeOptions *arrow_options);
 arrow::compute::CumulativeOptions *
 garrow_cumulative_options_get_raw(GArrowCumulativeOptions *options);
+
+GArrowDayOfWeekOptions *
+garrow_day_of_week_options_new_raw(const arrow::compute::DayOfWeekOptions *arrow_options);
+arrow::compute::DayOfWeekOptions *
+garrow_day_of_week_options_get_raw(GArrowDayOfWeekOptions *options);

--- a/c_glib/arrow-glib/compute.hpp
+++ b/c_glib/arrow-glib/compute.hpp
@@ -304,3 +304,8 @@ garrow_round_temporal_options_new_raw(
   const arrow::compute::RoundTemporalOptions *arrow_options);
 arrow::compute::RoundTemporalOptions *
 garrow_round_temporal_options_get_raw(GArrowRoundTemporalOptions *options);
+
+GArrowSelectKOptions *
+garrow_select_k_options_new_raw(const arrow::compute::SelectKOptions *arrow_options);
+arrow::compute::SelectKOptions *
+garrow_select_k_options_get_raw(GArrowSelectKOptions *options);

--- a/c_glib/arrow-glib/compute.hpp
+++ b/c_glib/arrow-glib/compute.hpp
@@ -298,3 +298,9 @@ garrow_round_binary_options_new_raw(
   const arrow::compute::RoundBinaryOptions *arrow_options);
 arrow::compute::RoundBinaryOptions *
 garrow_round_binary_options_get_raw(GArrowRoundBinaryOptions *options);
+
+GArrowRoundTemporalOptions *
+garrow_round_temporal_options_new_raw(
+  const arrow::compute::RoundTemporalOptions *arrow_options);
+arrow::compute::RoundTemporalOptions *
+garrow_round_temporal_options_get_raw(GArrowRoundTemporalOptions *options);

--- a/c_glib/arrow-glib/compute.hpp
+++ b/c_glib/arrow-glib/compute.hpp
@@ -309,3 +309,8 @@ GArrowSelectKOptions *
 garrow_select_k_options_new_raw(const arrow::compute::SelectKOptions *arrow_options);
 arrow::compute::SelectKOptions *
 garrow_select_k_options_get_raw(GArrowSelectKOptions *options);
+
+GArrowSkewOptions *
+garrow_skew_options_new_raw(const arrow::compute::SkewOptions *arrow_options);
+arrow::compute::SkewOptions *
+garrow_skew_options_get_raw(GArrowSkewOptions *options);

--- a/c_glib/arrow-glib/compute.hpp
+++ b/c_glib/arrow-glib/compute.hpp
@@ -274,3 +274,9 @@ garrow_pivot_wider_options_new_raw(
   const arrow::compute::PivotWiderOptions *arrow_options);
 arrow::compute::PivotWiderOptions *
 garrow_pivot_wider_options_get_raw(GArrowPivotWiderOptions *options);
+
+GArrowRankQuantileOptions *
+garrow_rank_quantile_options_new_raw(
+  const arrow::compute::RankQuantileOptions *arrow_options);
+arrow::compute::RankQuantileOptions *
+garrow_rank_quantile_options_get_raw(GArrowRankQuantileOptions *options);

--- a/c_glib/arrow-glib/compute.hpp
+++ b/c_glib/arrow-glib/compute.hpp
@@ -191,3 +191,9 @@ GArrowDayOfWeekOptions *
 garrow_day_of_week_options_new_raw(const arrow::compute::DayOfWeekOptions *arrow_options);
 arrow::compute::DayOfWeekOptions *
 garrow_day_of_week_options_get_raw(GArrowDayOfWeekOptions *options);
+
+GArrowDictionaryEncodeOptions *
+garrow_dictionary_encode_options_new_raw(
+  const arrow::compute::DictionaryEncodeOptions *arrow_options);
+arrow::compute::DictionaryEncodeOptions *
+garrow_dictionary_encode_options_get_raw(GArrowDictionaryEncodeOptions *options);

--- a/c_glib/arrow-glib/compute.hpp
+++ b/c_glib/arrow-glib/compute.hpp
@@ -203,3 +203,9 @@ garrow_element_wise_aggregate_options_new_raw(
   const arrow::compute::ElementWiseAggregateOptions *arrow_options);
 arrow::compute::ElementWiseAggregateOptions *
 garrow_element_wise_aggregate_options_get_raw(GArrowElementWiseAggregateOptions *options);
+
+GArrowExtractRegexOptions *
+garrow_extract_regex_options_new_raw(
+  const arrow::compute::ExtractRegexOptions *arrow_options);
+arrow::compute::ExtractRegexOptions *
+garrow_extract_regex_options_get_raw(GArrowExtractRegexOptions *options);

--- a/c_glib/arrow-glib/compute.hpp
+++ b/c_glib/arrow-glib/compute.hpp
@@ -242,3 +242,8 @@ GArrowMapLookupOptions *
 garrow_map_lookup_options_new_raw(const arrow::compute::MapLookupOptions *arrow_options);
 arrow::compute::MapLookupOptions *
 garrow_map_lookup_options_get_raw(GArrowMapLookupOptions *options);
+
+GArrowModeOptions *
+garrow_mode_options_new_raw(const arrow::compute::ModeOptions *arrow_options);
+arrow::compute::ModeOptions *
+garrow_mode_options_get_raw(GArrowModeOptions *options);

--- a/c_glib/arrow-glib/compute.hpp
+++ b/c_glib/arrow-glib/compute.hpp
@@ -319,3 +319,8 @@ GArrowSliceOptions *
 garrow_slice_options_new_raw(const arrow::compute::SliceOptions *arrow_options);
 arrow::compute::SliceOptions *
 garrow_slice_options_get_raw(GArrowSliceOptions *options);
+
+GArrowSplitOptions *
+garrow_split_options_new_raw(const arrow::compute::SplitOptions *arrow_options);
+arrow::compute::SplitOptions *
+garrow_split_options_get_raw(GArrowSplitOptions *options);

--- a/c_glib/arrow-glib/compute.hpp
+++ b/c_glib/arrow-glib/compute.hpp
@@ -231,3 +231,9 @@ GArrowListSliceOptions *
 garrow_list_slice_options_new_raw(const arrow::compute::ListSliceOptions *arrow_options);
 arrow::compute::ListSliceOptions *
 garrow_list_slice_options_get_raw(GArrowListSliceOptions *options);
+
+GArrowMakeStructOptions *
+garrow_make_struct_options_new_raw(
+  const arrow::compute::MakeStructOptions *arrow_options);
+arrow::compute::MakeStructOptions *
+garrow_make_struct_options_get_raw(GArrowMakeStructOptions *options);

--- a/c_glib/test/helper/buildable.rb
+++ b/c_glib/test/helper/buildable.rb
@@ -172,6 +172,16 @@ module Helper
       builder.finish
     end
 
+    def build_fixed_size_list_array(value_data_type, list_size, values_list, field_name: "value")
+      value_field = Arrow::Field.new(field_name, value_data_type)
+      data_type = Arrow::FixedSizeListDataType.new(value_field, list_size)
+      builder = Arrow::FixedSizeListArrayBuilder.new(data_type)
+      values_list.each do |values|
+        append_to_builder(builder, values)
+      end
+      builder.finish
+    end
+
     def build_map_array(key_data_type, item_data_type, maps)
       data_type = Arrow::MapDataType.new(key_data_type, item_data_type)
       builder = Arrow::MapArrayBuilder.new(data_type)
@@ -204,7 +214,7 @@ module Helper
             append_to_builder(key_builder, k)
             append_to_builder(item_builder, v)
           end
-        when Arrow::ListDataType, Arrow::LargeListDataType
+        when Arrow::ListDataType, Arrow::LargeListDataType, Arrow::FixedSizeListDataType
           builder.append_value
           value_builder = builder.value_builder
           value.each do |v|

--- a/c_glib/test/test-assume-timezone-options.rb
+++ b/c_glib/test/test-assume-timezone-options.rb
@@ -1,0 +1,61 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestAssumeTimezoneOptions < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def setup
+    @options = Arrow::AssumeTimezoneOptions.new
+  end
+
+  def test_timezone_property
+    assert_equal("UTC", @options.timezone)
+    @options.timezone = "America/New_York"
+    assert_equal("America/New_York", @options.timezone)
+  end
+
+  def test_ambiguous_property
+    assert_equal(Arrow::AssumeTimezoneAmbiguous::RAISE, @options.ambiguous)
+    @options.ambiguous = :earliest
+    assert_equal(Arrow::AssumeTimezoneAmbiguous::EARLIEST, @options.ambiguous)
+    @options.ambiguous = :latest
+    assert_equal(Arrow::AssumeTimezoneAmbiguous::LATEST, @options.ambiguous)
+  end
+
+  def test_nonexistent_property
+    assert_equal(Arrow::AssumeTimezoneNonexistent::RAISE, @options.nonexistent)
+    @options.nonexistent = :earliest
+    assert_equal(Arrow::AssumeTimezoneNonexistent::EARLIEST, @options.nonexistent)
+    @options.nonexistent = :latest
+    assert_equal(Arrow::AssumeTimezoneNonexistent::LATEST, @options.nonexistent)
+  end
+
+  def test_assume_timezone_function
+    omit("Missing tzdata on Windows") if Gem.win_platform?
+    args = [
+      Arrow::ArrayDatum.new(build_timestamp_array(:milli, [1504953190000])),
+    ]
+    @options.timezone = "America/New_York"
+    @options.ambiguous = :earliest
+    @options.nonexistent = :earliest
+    assume_timezone_function = Arrow::Function.find("assume_timezone")
+    result = assume_timezone_function.execute(args, @options).value
+    assert_equal(Arrow::TimestampDataType.new(:milli, "America/New_York"),
+                 result.value_data_type)
+  end
+end
+

--- a/c_glib/test/test-cumulative-options.rb
+++ b/c_glib/test/test-cumulative-options.rb
@@ -1,0 +1,64 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestCumulativeOptions < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def setup
+    @options = Arrow::CumulativeOptions.new
+  end
+
+  def test_start_property
+    assert_nil(@options.start)
+    start_scalar = Arrow::Int64Scalar.new(10)
+    @options.start = start_scalar
+    assert_equal(start_scalar, @options.start)
+    @options.start = nil
+    assert_nil(@options.start)
+  end
+
+  def test_skip_nulls_property
+    assert do
+      !@options.skip_nulls?
+    end
+    @options.skip_nulls = true
+    assert do
+      @options.skip_nulls?
+    end
+  end
+
+  def test_cumulative_sum_with_skip_nulls
+    args = [
+      Arrow::ArrayDatum.new(build_int64_array([1, 2, 3, nil, 4, 5])),
+    ]
+    @options.skip_nulls = true
+    cumulative_sum_function = Arrow::Function.find("cumulative_sum")
+    assert_equal(build_int64_array([1, 3, 6, nil, 10, 15]),
+                 cumulative_sum_function.execute(args, @options).value)
+  end
+
+  def test_cumulative_sum_with_start
+    args = [
+      Arrow::ArrayDatum.new(build_int64_array([1, 2, 3])),
+    ]
+    @options.start = Arrow::Int64Scalar.new(10)
+    cumulative_sum_function = Arrow::Function.find("cumulative_sum")
+    assert_equal(build_int64_array([11, 13, 16]),
+                 cumulative_sum_function.execute(args, @options).value)
+  end
+end
+

--- a/c_glib/test/test-day-of-week-options.rb
+++ b/c_glib/test/test-day-of-week-options.rb
@@ -1,0 +1,63 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestDayOfWeekOptions < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def setup
+    @options = Arrow::DayOfWeekOptions.new
+  end
+
+  def test_count_from_zero_property
+    assert do
+      @options.count_from_zero?
+    end
+    @options.count_from_zero = false
+    assert do
+      !@options.count_from_zero?
+    end
+  end
+
+  def test_week_start_property
+    assert_equal(1, @options.week_start)
+    @options.week_start = 7
+    assert_equal(7, @options.week_start)
+  end
+
+  def test_day_of_week_function_with_count_from_zero_false
+    omit("Missing tzdata on Windows") if Gem.win_platform?
+    args = [
+      Arrow::ArrayDatum.new(build_timestamp_array(:milli, [1504953190000])),
+    ]
+    @options.count_from_zero = false
+    day_of_week_function = Arrow::Function.find("day_of_week")
+    assert_equal(build_int64_array([6]),
+                 day_of_week_function.execute(args, @options).value)
+  end
+
+  def test_day_of_week_function_with_week_start
+    omit("Missing tzdata on Windows") if Gem.win_platform?
+    args = [
+      Arrow::ArrayDatum.new(build_timestamp_array(:milli, [1504953190000])),
+    ]
+    @options.week_start = 2
+    day_of_week_function = Arrow::Function.find("day_of_week")
+    assert_equal(build_int64_array([4]),
+                 day_of_week_function.execute(args, @options).value)
+  end
+end
+

--- a/c_glib/test/test-dictionary-encode-options.rb
+++ b/c_glib/test/test-dictionary-encode-options.rb
@@ -1,0 +1,46 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestDictionaryEncodeOptions < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def setup
+    @options = Arrow::DictionaryEncodeOptions.new
+  end
+
+  def test_null_encoding_behavior_property
+    assert_equal(Arrow::DictionaryEncodeNullEncodingBehavior::MASK, @options.null_encoding_behavior)
+    @options.null_encoding_behavior = :encode
+    assert_equal(Arrow::DictionaryEncodeNullEncodingBehavior::ENCODE, 
+                 @options.null_encoding_behavior)
+  end
+
+  def test_dictionary_encode_function_with_encode
+    args = [
+      Arrow::ArrayDatum.new(build_string_array(["a", "b", nil, "a", "b"])),
+    ]
+    @options.null_encoding_behavior = :encode
+    dictionary_encode_function = Arrow::Function.find("dictionary_encode")
+    result = dictionary_encode_function.execute(args, @options).value
+    assert_equal(Arrow::DictionaryDataType.new(Arrow::Int32DataType.new,
+                                               Arrow::StringDataType.new,
+                                               false),
+                 result.value_data_type)
+    assert_equal(build_int32_array([0, 1, 2, 0, 1]), result.indices)
+  end
+end
+

--- a/c_glib/test/test-element-wise-aggregate-options.rb
+++ b/c_glib/test/test-element-wise-aggregate-options.rb
@@ -1,0 +1,46 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestElementWiseAggregateOptions < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def setup
+    @options = Arrow::ElementWiseAggregateOptions.new
+  end
+
+  def test_skip_nulls_property
+    assert do
+      @options.skip_nulls?
+    end
+    @options.skip_nulls = false
+    assert do
+      !@options.skip_nulls?
+    end
+  end
+
+  def test_min_element_wise_function_with_skip_nulls_false
+    args = [
+      Arrow::ArrayDatum.new(build_int64_array([1, nil, 3])),
+      Arrow::ArrayDatum.new(build_int64_array([4, 1, 5])),
+    ]
+    @options.skip_nulls = false
+    min_element_wise_function = Arrow::Function.find("min_element_wise")
+    assert_equal(build_int64_array([1, nil, 3]),
+                 min_element_wise_function.execute(args, @options).value)
+  end
+end
+

--- a/c_glib/test/test-extract-regex-options.rb
+++ b/c_glib/test/test-extract-regex-options.rb
@@ -1,0 +1,53 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestExtractRegexOptions < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def setup
+    @options = Arrow::ExtractRegexOptions.new
+  end
+
+  def test_pattern_property
+    assert_equal("", @options.pattern)
+    @options.pattern = "(?P<year>\\d{4})-(?P<month>\\d{2})"
+    assert_equal("(?P<year>\\d{4})-(?P<month>\\d{2})", @options.pattern)
+  end
+
+  def test_extract_regex_function
+    omit("RE2 is not available") unless Arrow::Function.find("extract_regex")
+    args = [
+      Arrow::ArrayDatum.new(build_string_array(["2023-01-15", "2024-12-31"])),
+    ]
+    @options.pattern = "(?P<year>\\d{4})-(?P<month>\\d{2})-(?P<day>\\d{2})"
+    extract_regex_function = Arrow::Function.find("extract_regex")
+    result = extract_regex_function.execute(args, @options).value
+    fields = [
+               Arrow::Field.new("year", Arrow::StringDataType.new),
+               Arrow::Field.new("month", Arrow::StringDataType.new),
+               Arrow::Field.new("day", Arrow::StringDataType.new),
+             ]
+    assert_equal(Arrow::StructDataType.new(fields),
+                 result.value_data_type)
+    assert_equal(build_struct_array(fields, [
+                   {"year" => "2023", "month" => "01", "day" => "15"},
+                   {"year" => "2024", "month" => "12", "day" => "31"},
+                 ]),
+                 result)
+  end
+end
+

--- a/c_glib/test/test-extract-regex-span-options.rb
+++ b/c_glib/test/test-extract-regex-span-options.rb
@@ -1,0 +1,65 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestExtractRegexSpanOptions < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def setup
+    @options = Arrow::ExtractRegexSpanOptions.new
+  end
+
+  def test_pattern_property
+    assert_equal("", @options.pattern)
+    @options.pattern = "(?P<year>\\d{4})-(?P<month>\\d{2})"
+    assert_equal("(?P<year>\\d{4})-(?P<month>\\d{2})", @options.pattern)
+  end
+
+  def test_extract_regex_span_function
+    omit("RE2 is not available") unless Arrow::Function.find("extract_regex_span")
+    args = [
+      Arrow::ArrayDatum.new(build_string_array(["2023-01-15", "2024-12-31"])),
+    ]
+    @options.pattern = "(?P<year>\\d{4})-(?P<month>\\d{2})-(?P<day>\\d{2})"
+    extract_regex_span_function = Arrow::Function.find("extract_regex_span")
+    result = extract_regex_span_function.execute(args, @options).value
+    fields = [
+      Arrow::Field.new("year", Arrow::FixedSizeListDataType.new(Arrow::Int32DataType.new, 2)),
+      Arrow::Field.new("month", Arrow::FixedSizeListDataType.new(Arrow::Int32DataType.new, 2)),
+      Arrow::Field.new("day", Arrow::FixedSizeListDataType.new(Arrow::Int32DataType.new, 2)),
+    ]
+    assert_equal(Arrow::StructDataType.new(fields),
+                 result.value_data_type)
+    # The result contains [index, length] pairs for each capture group
+    # year: [0, 4] (starts at index 0, length 4)
+    # month: [5, 2] (starts at index 5, length 2)
+    # day: [8, 2] (starts at index 8, length 2)
+    assert_equal(build_struct_array(fields, [
+                   {
+                     "year" => [0, 4],
+                     "month" => [5, 2],
+                     "day" => [8, 2],
+                   },
+                   {
+                     "year" => [0, 4],
+                     "month" => [5, 2],
+                     "day" => [8, 2],
+                   },
+                 ]),
+                 result)
+  end
+end
+

--- a/c_glib/test/test-fixed-size-list-array-builder.rb
+++ b/c_glib/test/test-fixed-size-list-array-builder.rb
@@ -1,0 +1,93 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestFixedSizeListArrayBuilder < Test::Unit::TestCase
+  include Helper::Buildable
+  include Helper::Omittable
+
+  def setup
+    require_gi_bindings(3, 1, 9)
+  end
+
+  def test_new
+    field = Arrow::Field.new("value", Arrow::Int8DataType.new)
+    data_type = Arrow::FixedSizeListDataType.new(field, 2)
+    builder = Arrow::FixedSizeListArrayBuilder.new(data_type)
+    assert_equal(data_type, builder.value_data_type)
+  end
+
+  def test_append_value
+    field = Arrow::Field.new("value", Arrow::Int8DataType.new)
+    data_type = Arrow::FixedSizeListDataType.new(field, 2)
+    builder = Arrow::FixedSizeListArrayBuilder.new(data_type)
+    value_builder = builder.value_builder
+
+    # Append first list: [1, 2]
+    builder.append_value
+    value_builder.append_value(1)
+    value_builder.append_value(2)
+
+    # Append second list: [3, 4]
+    builder.append_value
+    value_builder.append_value(3)
+    value_builder.append_value(4)
+
+    array = builder.finish
+    assert_equal(2, array.length)
+    assert_equal([1, 2], array.get_value(0).length.times.collect {|i|
+ array.get_value(0).get_value(i)})
+    assert_equal([3, 4], array.get_value(1).length.times.collect {|i|
+ array.get_value(1).get_value(i)})
+  end
+
+  def test_append_null
+    field = Arrow::Field.new("value", Arrow::Int8DataType.new)
+    data_type = Arrow::FixedSizeListDataType.new(field, 2)
+    builder = Arrow::FixedSizeListArrayBuilder.new(data_type)
+    value_builder = builder.value_builder
+
+    # Append first list: [1, 2]
+    builder.append_value
+    value_builder.append_value(1)
+    value_builder.append_value(2)
+
+    # Append null list
+    builder.append_null
+
+    # Append third list: [5, 6]
+    builder.append_value
+    value_builder.append_value(5)
+    value_builder.append_value(6)
+
+    array = builder.finish
+    assert_equal(3, array.length)
+    assert_equal([1, 2], array.get_value(0).length.times.collect {|i|
+ array.get_value(0).get_value(i)})
+    assert_equal(true, array.null?(1))
+    assert_equal([5, 6], array.get_value(2).length.times.collect {|i|
+ array.get_value(2).get_value(i)})
+  end
+
+  def test_value_builder
+    field = Arrow::Field.new("value", Arrow::Int8DataType.new)
+    data_type = Arrow::FixedSizeListDataType.new(field, 2)
+    builder = Arrow::FixedSizeListArrayBuilder.new(data_type)
+    value_builder = builder.value_builder
+    assert_equal(Arrow::Int8DataType.new, value_builder.value_data_type)
+  end
+end
+

--- a/c_glib/test/test-fixed-size-list-array.rb
+++ b/c_glib/test/test-fixed-size-list-array.rb
@@ -1,0 +1,81 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestFixedSizeListArray < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def test_new
+    field = Arrow::Field.new("value", Arrow::Int8DataType.new)
+    data_type = Arrow::FixedSizeListDataType.new(field, 2)
+    data = Arrow::Buffer.new([1, 2, 3, 4].pack("c*"))
+    nulls = Arrow::Buffer.new([0b1111].pack("C*"))
+    values = Arrow::Int8Array.new(4, data, nulls, 0)
+    assert_equal(build_fixed_size_list_array(Arrow::Int8DataType.new, 2,
+                                             [[1, 2], [3, 4]]),
+                 Arrow::FixedSizeListArray.new(data_type,
+                                               2,
+                                               values,
+                                               Arrow::Buffer.new([0b11].pack("C*")),
+                                               -1))
+  end
+
+  def test_value
+    array = build_fixed_size_list_array(Arrow::Int8DataType.new, 2,
+                                        [[1, 2], [3, 4]])
+    value = array.get_value(1)
+    assert_equal([3, 4],
+                 value.length.times.collect {|i| value.get_value(i)})
+  end
+
+  def test_value_type
+    field = Arrow::Field.new("value", Arrow::Int8DataType.new)
+    data_type = Arrow::FixedSizeListDataType.new(field, 2)
+    builder = Arrow::FixedSizeListArrayBuilder.new(data_type)
+    array = builder.finish
+    assert_equal(Arrow::Int8DataType.new, array.value_type)
+  end
+
+  def test_values
+    array = build_fixed_size_list_array(Arrow::Int8DataType.new, 2,
+                                        [[1, 2], [3, 4]])
+    values = array.values
+    assert_equal([1, 2, 3, 4],
+                 values.length.times.collect {|i| values.get_value(i)})
+  end
+
+  def test_value_offset
+    array = build_fixed_size_list_array(Arrow::Int8DataType.new, 2,
+                                        [[1, 2], [3, 4]])
+    assert_equal([0, 2],
+                 array.length.times.collect {|i| array.get_value_offset(i)})
+  end
+
+  def test_value_length
+    array = build_fixed_size_list_array(Arrow::Int8DataType.new, 2,
+                                        [[1, 2], [3, 4]])
+    # All lists have the same fixed size
+    assert_equal([2, 2],
+                 array.length.times.collect {|i| array.get_value_length(i)})
+  end
+
+  def test_list_size
+    array = build_fixed_size_list_array(Arrow::Int8DataType.new, 2,
+                                        [[1, 2], [3, 4]])
+    assert_equal(2, array.list_size)
+  end
+end
+

--- a/c_glib/test/test-join-options.rb
+++ b/c_glib/test/test-join-options.rb
@@ -1,0 +1,64 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestJoinOptions < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def setup
+    @options = Arrow::JoinOptions.new
+  end
+
+  def test_null_handling_property
+    assert_equal(Arrow::JoinNullHandlingBehavior::EMIT_NULL, @options.null_handling)
+    @options.null_handling = Arrow::JoinNullHandlingBehavior::SKIP
+    assert_equal(Arrow::JoinNullHandlingBehavior::SKIP, @options.null_handling)
+    @options.null_handling = Arrow::JoinNullHandlingBehavior::REPLACE
+    assert_equal(Arrow::JoinNullHandlingBehavior::REPLACE, @options.null_handling)
+  end
+
+  def test_null_replacement_property
+    assert_equal("", @options.null_replacement)
+    @options.null_replacement = "NULL"
+    assert_equal("NULL", @options.null_replacement)
+  end
+
+  def test_binary_join_element_wise_function
+    args = [
+      Arrow::ArrayDatum.new(build_string_array(["a", "b", nil])),
+      Arrow::ArrayDatum.new(build_string_array(["x", "y", "z"])),
+      Arrow::ScalarDatum.new(Arrow::StringScalar.new(Arrow::Buffer.new("-"))),
+    ]
+    binary_join_element_wise_function = Arrow::Function.find("binary_join_element_wise")
+
+    @options.null_handling = Arrow::JoinNullHandlingBehavior::EMIT_NULL
+    result = binary_join_element_wise_function.execute(args, @options).value
+    assert_equal(build_string_array(["a-x", "b-y", nil]),
+                 result)
+
+    @options.null_handling = Arrow::JoinNullHandlingBehavior::SKIP
+    result = binary_join_element_wise_function.execute(args, @options).value
+    assert_equal(build_string_array(["a-x", "b-y", "z"]),
+                 result)
+
+    @options.null_handling = Arrow::JoinNullHandlingBehavior::REPLACE
+    @options.null_replacement = "NULL"
+    result = binary_join_element_wise_function.execute(args, @options).value
+    assert_equal(build_string_array(["a-x", "b-y", "NULL-z"]),
+                 result)
+  end
+end
+

--- a/c_glib/test/test-list-flatten-options.rb
+++ b/c_glib/test/test-list-flatten-options.rb
@@ -1,0 +1,58 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestListFlattenOptions < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def setup
+    @options = Arrow::ListFlattenOptions.new
+  end
+
+  def test_recursive_property
+    assert do
+      !@options.recursive?
+    end
+    @options.recursive = true
+    assert do
+      @options.recursive?
+    end
+  end
+
+  def test_list_flatten_function_recursive
+    list_data_type = Arrow::ListDataType.new(Arrow::Field.new("value", Arrow::Int8DataType.new))
+    nested_list = build_list_array(list_data_type, [[[1, 2], [3]], [[4, 5]]])
+
+    args = [
+      Arrow::ArrayDatum.new(nested_list),
+    ]
+    list_flatten_function = Arrow::Function.find("list_flatten")
+
+    @options.recursive = false
+    result = list_flatten_function.execute(args, @options).value
+    assert_equal(list_data_type,
+                 result.value_data_type)
+    assert_equal(build_list_array(Arrow::Int8DataType.new, [[1, 2], [3], [4, 5]]),
+                 result)
+
+    @options.recursive = true
+    result = list_flatten_function.execute(args, @options).value
+    assert_equal(Arrow::Int8DataType.new,
+                 result.value_data_type)
+    assert_equal(build_int8_array([1, 2, 3, 4, 5]),
+                 result)
+  end
+end

--- a/c_glib/test/test-list-slice-options.rb
+++ b/c_glib/test/test-list-slice-options.rb
@@ -1,0 +1,124 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestListSliceOptions < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def setup
+    @options = Arrow::ListSliceOptions.new
+  end
+
+  def test_start_property
+    assert_equal(0, @options.start)
+    @options.start = 2
+    assert_equal(2, @options.start)
+  end
+
+  def test_stop_property
+    # Default is -1 (not set)
+    assert_equal(-1, @options.stop)
+    @options.stop = 5
+    assert_equal(5, @options.stop)
+    # Setting to -1 means "not set"
+    @options.stop = -1
+    assert_equal(-1, @options.stop)
+  end
+
+  def test_step_property
+    assert_equal(1, @options.step)
+    @options.step = 2
+    assert_equal(2, @options.step)
+  end
+
+  def test_return_fixed_size_list_property
+    assert_equal(Arrow::ListSliceReturnFixedSizeList::AUTO,
+                 @options.return_fixed_size_list)
+    @options.return_fixed_size_list = :true
+    assert_equal(Arrow::ListSliceReturnFixedSizeList::TRUE,
+                 @options.return_fixed_size_list)
+    @options.return_fixed_size_list = :false
+    assert_equal(Arrow::ListSliceReturnFixedSizeList::FALSE,
+                 @options.return_fixed_size_list)
+    @options.return_fixed_size_list = :auto
+    assert_equal(Arrow::ListSliceReturnFixedSizeList::AUTO,
+                 @options.return_fixed_size_list)
+  end
+
+  def test_list_slice_function_with_step
+    args = [
+      Arrow::ArrayDatum.new(build_list_array(Arrow::Int8DataType.new,
+                                             [[1, 2, 3, 4, 5], [6, 7, 8, 9]])),
+    ]
+    @options.step = 2
+    list_slice_function = Arrow::Function.find("list_slice")
+    result = list_slice_function.execute(args, @options).value
+    assert_equal(build_list_array(Arrow::Int8DataType.new, [[1, 3, 5], [6, 8]]),
+                 result)
+  end
+
+  def test_list_slice_function_without_stop
+    args = [
+      Arrow::ArrayDatum.new(build_list_array(Arrow::Int8DataType.new,
+                                             [[1, 2, 3], [4, 5]])),
+    ]
+    @options.start = 1
+    @options.stop = -1
+    list_slice_function = Arrow::Function.find("list_slice")
+    result = list_slice_function.execute(args, @options).value
+    assert_equal(build_list_array(Arrow::Int8DataType.new, [[2, 3], [5]]),
+                 result)
+  end
+
+  def test_list_slice_function_with_return_fixed_size_list_auto
+    args = [
+      Arrow::ArrayDatum.new(build_fixed_size_list_array(Arrow::Int8DataType.new, 2,
+                                                        [[1, 2], [3, 4]])),
+    ]
+    @options.start = 1
+    list_slice_function = Arrow::Function.find("list_slice")
+    result = list_slice_function.execute(args, @options).value
+    assert_equal(build_fixed_size_list_array(Arrow::Int8DataType.new, 1, [[2], [4]]),
+                 result)
+  end
+
+  def test_list_slice_function_with_return_fixed_size_list_true
+    args = [
+      Arrow::ArrayDatum.new(build_list_array(Arrow::Int8DataType.new,
+                                             [[1, 2, 3], [4, 5]])),
+    ]
+    @options.start = 1
+    @options.stop = 3
+    @options.return_fixed_size_list = :true
+    list_slice_function = Arrow::Function.find("list_slice")
+    result = list_slice_function.execute(args, @options).value
+    assert_equal(build_fixed_size_list_array(Arrow::Int8DataType.new, 2, [[2, 3], [5, nil]]),
+                 result)
+  end
+
+  def test_list_slice_function_with_return_fixed_size_list_false
+    args = [
+      Arrow::ArrayDatum.new(build_fixed_size_list_array(Arrow::Int8DataType.new, 2,
+                                                        [[1, 2], [3, 4]])),
+    ]
+    @options.start = 1
+    @options.return_fixed_size_list = :false
+    list_slice_function = Arrow::Function.find("list_slice")
+    result = list_slice_function.execute(args, @options).value
+    assert_equal(build_list_array(Arrow::Int8DataType.new, [[2], [4]]),
+                 result)
+  end
+end

--- a/c_glib/test/test-make-struct-options.rb
+++ b/c_glib/test/test-make-struct-options.rb
@@ -1,0 +1,57 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestMakeStructOptions < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def setup
+    @options = Arrow::MakeStructOptions.new
+  end
+
+  def test_field_names_property
+    assert_equal([], @options.field_names)
+    @options.field_names = ["a", "b", "c"]
+    assert_equal(["a", "b", "c"], @options.field_names)
+  end
+
+  def test_make_struct_function
+    a = build_int8_array([1, 2, 3])
+    b = build_boolean_array([true, false, nil])
+    args = [
+      Arrow::ArrayDatum.new(a),
+      Arrow::ArrayDatum.new(b),
+    ]
+    @options.field_names = ["a", "b"]
+    make_struct_function = Arrow::Function.find("make_struct")
+    result = make_struct_function.execute(args, @options).value
+
+    expected = build_struct_array(
+      [
+        Arrow::Field.new("a", Arrow::Int8DataType.new),
+        Arrow::Field.new("b", Arrow::BooleanDataType.new),
+      ],
+      [
+        {"a" => 1, "b" => true},
+        {"a" => 2, "b" => false},
+        {"a" => 3, "b" => nil},
+      ]
+    )
+    assert_equal(expected, result)
+  end
+end
+
+

--- a/c_glib/test/test-map-lookup-options.rb
+++ b/c_glib/test/test-map-lookup-options.rb
@@ -1,0 +1,77 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestMapLookupOptions < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def setup
+    @query_key = Arrow::Int32Scalar.new(1)
+    @options = Arrow::MapLookupOptions.new(@query_key,
+                                           Arrow::MapLookupOccurrence::FIRST)
+  end
+
+  def test_query_key_property
+    assert_equal(@query_key, @options.query_key)
+    new_query_key = Arrow::Int32Scalar.new(2)
+    @options.query_key = new_query_key
+    assert_equal(new_query_key, @options.query_key)
+  end
+
+  def test_occurrence_property
+    assert_equal(Arrow::MapLookupOccurrence::FIRST, @options.occurrence)
+    @options.occurrence = :last
+    assert_equal(Arrow::MapLookupOccurrence::LAST, @options.occurrence)
+    @options.occurrence = :all
+    assert_equal(Arrow::MapLookupOccurrence::ALL, @options.occurrence)
+    @options.occurrence = :first
+    assert_equal(Arrow::MapLookupOccurrence::FIRST, @options.occurrence)
+  end
+
+  def build_map_with_duplicate_keys
+  end
+
+  def test_map_lookup_function
+    map_array = build_map_array(Arrow::Int32DataType.new,
+                                Arrow::StringDataType.new,
+                                [[
+                                  [1, "first_one"],
+                                  [2, "two"],
+                                  [1, nil],
+                                  [3, "three"],
+                                  [1, "second_one"],
+                                  [1, "last_one"],
+                                ]])
+    args = [Arrow::ArrayDatum.new(map_array)]
+    map_lookup_function = Arrow::Function.find("map_lookup")
+    @options.query_key = Arrow::Int32Scalar.new(1)
+
+    @options.occurrence = :first
+    result = map_lookup_function.execute(args, @options).value
+    assert_equal(build_string_array(["first_one"]), result)
+
+    @options.occurrence = :last
+    result = map_lookup_function.execute(args, @options).value
+    assert_equal(build_string_array(["last_one"]), result)
+
+    @options.occurrence = :all
+    result = map_lookup_function.execute(args, @options).value
+    assert_equal(build_list_array(Arrow::StringDataType.new,
+                                  [["first_one", nil, "second_one", "last_one"]]),
+                 result)
+  end
+end
+

--- a/c_glib/test/test-mode-options.rb
+++ b/c_glib/test/test-mode-options.rb
@@ -1,0 +1,69 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestModeOptions < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def setup
+    @options = Arrow::ModeOptions.new
+  end
+
+  def test_n
+    assert_equal(1, @options.n)
+    @options.n = 2
+    assert_equal(2, @options.n)
+  end
+
+  def test_skip_nulls
+    assert do
+      @options.skip_nulls?
+    end
+    @options.skip_nulls = false
+    assert do
+      not @options.skip_nulls?
+    end
+  end
+
+  def test_min_count
+    assert_equal(0, @options.min_count)
+    @options.min_count = 1
+    assert_equal(1, @options.min_count)
+  end
+
+  def test_mode_function_with_all_options
+    args = [
+      Arrow::ArrayDatum.new(build_int32_array([1, 2, 2, 3, 3, 3, 4])),
+    ]
+    @options.n = 2
+    @options.skip_nulls = false
+    @options.min_count = 2
+    mode_function = Arrow::Function.find("mode")
+    result = mode_function.execute(args, @options).value
+    expected = build_struct_array(
+      [
+        Arrow::Field.new("mode", Arrow::Int32DataType.new),
+        Arrow::Field.new("count", Arrow::Int64DataType.new),
+      ],
+      [
+        {"mode" => 3, "count" => 3},
+        {"mode" => 2, "count" => 2},
+      ]
+    )
+    assert_equal(expected, result)
+  end
+end
+

--- a/c_glib/test/test-null-options.rb
+++ b/c_glib/test/test-null-options.rb
@@ -1,0 +1,45 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestNullOptions < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def setup
+    @options = Arrow::NullOptions.new
+  end
+
+  def test_nan_is_null_property
+    assert do
+      !@options.nan_is_null?
+    end
+    @options.nan_is_null = true
+    assert do
+      @options.nan_is_null?
+    end
+  end
+
+  def test_is_null_function
+    args = [
+      Arrow::ArrayDatum.new(build_float_array([1.0, Float::NAN, 2.0, nil, 4.0])),
+    ]
+    is_null_function = Arrow::Function.find("is_null")
+    @options.nan_is_null = true
+    result = is_null_function.execute(args, @options).value
+    assert_equal(build_boolean_array([false, true, false, true, false]), result)
+  end
+end
+

--- a/c_glib/test/test-pad-options.rb
+++ b/c_glib/test/test-pad-options.rb
@@ -1,0 +1,63 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestPadOptions < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def setup
+    @options = Arrow::PadOptions.new
+  end
+
+  def test_width_property
+    assert_equal(0, @options.width)
+    @options.width = 5
+    assert_equal(5, @options.width)
+  end
+
+  def test_padding_property
+    assert_equal(" ", @options.padding)
+    @options.padding = "0"
+    assert_equal("0", @options.padding)
+  end
+
+  def test_lean_left_on_odd_padding_property
+    assert do
+      @options.lean_left_on_odd_padding?
+    end
+    @options.lean_left_on_odd_padding = false
+    assert do
+      not @options.lean_left_on_odd_padding?
+    end
+  end
+
+  def test_utf8_center_function
+    args = [
+      Arrow::ArrayDatum.new(build_string_array(["a", "ab", "abc"])),
+    ]
+    utf8_center_function = Arrow::Function.find("utf8_center")
+
+    @options.width = 5
+    @options.padding = " "
+    result = utf8_center_function.execute(args, @options).value
+    assert_equal(build_string_array(["  a  ", " ab  ", " abc "]), result)
+
+    @options.lean_left_on_odd_padding = false
+    result = utf8_center_function.execute(args, @options).value
+    assert_equal(build_string_array(["  a  ", "  ab ", " abc "]), result)
+  end
+end
+

--- a/c_glib/test/test-pairwise-options.rb
+++ b/c_glib/test/test-pairwise-options.rb
@@ -1,0 +1,43 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestPairwiseOptions < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def setup
+    @options = Arrow::PairwiseOptions.new
+  end
+
+  def test_periods_property
+    assert_equal(1, @options.periods)
+    @options.periods = 2
+    assert_equal(2, @options.periods)
+    @options.periods = -1
+    assert_equal(-1, @options.periods)
+  end
+
+  def test_pairwise_diff_function
+    args = [
+      Arrow::ArrayDatum.new(build_int32_array([1, 2, 4, 7, 11])),
+    ]
+    pairwise_diff_function = Arrow::Function.find("pairwise_diff")
+    @options.periods = 2
+    result = pairwise_diff_function.execute(args, @options).value
+    assert_equal(build_int32_array([nil, nil, 3, 5, 7]), result)
+  end
+end
+

--- a/c_glib/test/test-partition-nth-options.rb
+++ b/c_glib/test/test-partition-nth-options.rb
@@ -1,0 +1,52 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestPartitionNthOptions < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def setup
+    @options = Arrow::PartitionNthOptions.new
+  end
+
+  def test_pivot_property
+    assert_equal(0, @options.pivot)
+    @options.pivot = 2
+    assert_equal(2, @options.pivot)
+  end
+
+  def test_null_placement_property
+    assert_equal(Arrow::NullPlacement::AT_END, @options.null_placement)
+    @options.null_placement = :at_start
+    assert_equal(Arrow::NullPlacement::AT_START, @options.null_placement)
+    @options.null_placement = :at_end
+    assert_equal(Arrow::NullPlacement::AT_END, @options.null_placement)
+  end
+
+  def test_partition_nth_indices_function
+    args = [
+      Arrow::ArrayDatum.new(build_int32_array([5, 1, 4, 2, nil, 3])),
+    ]
+    @options.pivot = 2
+    partition_nth_indices_function = Arrow::Function.find("partition_nth_indices")
+    result = partition_nth_indices_function.execute(args, @options).value
+    assert_equal(5, result.get_value(2))
+    @options.null_placement = :at_start
+    result = partition_nth_indices_function.execute(args, @options).value
+    assert_equal(5, result.get_value(3))
+  end
+end
+

--- a/c_glib/test/test-pivot-wider-options.rb
+++ b/c_glib/test/test-pivot-wider-options.rb
@@ -1,0 +1,39 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestPivotWiderOptions < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def setup
+    @options = Arrow::PivotWiderOptions.new
+  end
+
+  def test_key_names_property
+    assert_equal([], @options.key_names)
+    @options.key_names = ["height", "width"]
+    assert_equal(["height", "width"], @options.key_names)
+  end
+
+  def test_unexpected_key_behavior_property
+    assert_equal(Arrow::PivotWiderUnexpectedKeyBehavior::IGNORE, @options.unexpected_key_behavior)
+    @options.unexpected_key_behavior = :raise
+    assert_equal(Arrow::PivotWiderUnexpectedKeyBehavior::RAISE, @options.unexpected_key_behavior)
+    @options.unexpected_key_behavior = :ignore
+    assert_equal(Arrow::PivotWiderUnexpectedKeyBehavior::IGNORE, @options.unexpected_key_behavior)
+  end
+end
+

--- a/c_glib/test/test-rank-quantile-options.rb
+++ b/c_glib/test/test-rank-quantile-options.rb
@@ -1,0 +1,61 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestRankQuantileOptions < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def setup
+    @options = Arrow::RankQuantileOptions.new
+  end
+
+  def test_sort_keys
+    sort_keys = [
+      Arrow::SortKey.new("column1", :ascending),
+      Arrow::SortKey.new("column2", :descending),
+    ]
+    @options.sort_keys = sort_keys
+    assert_equal(sort_keys, @options.sort_keys)
+  end
+
+  def test_add_sort_key
+    @options.add_sort_key(Arrow::SortKey.new("column1", :ascending))
+    @options.add_sort_key(Arrow::SortKey.new("column2", :descending))
+    assert_equal([
+                   Arrow::SortKey.new("column1", :ascending),
+                   Arrow::SortKey.new("column2", :descending),
+                 ],
+                 @options.sort_keys)
+  end
+
+  def test_null_placement
+    assert_equal(Arrow::NullPlacement::AT_END, @options.null_placement)
+    @options.null_placement = :at_start
+    assert_equal(Arrow::NullPlacement::AT_START, @options.null_placement)
+  end
+
+  def test_rank_quantile_function
+    args = [
+      Arrow::ArrayDatum.new(build_int32_array([nil, 1, nil, 2, nil])),
+    ]
+    @options.null_placement = :at_start
+    rank_quantile_function = Arrow::Function.find("rank_quantile")
+    result = rank_quantile_function.execute(args, @options).value
+    expected = build_double_array([0.3, 0.7, 0.3, 0.9, 0.3])
+    assert_equal(expected, result)
+  end
+end
+

--- a/c_glib/test/test-replace-slice-options.rb
+++ b/c_glib/test/test-replace-slice-options.rb
@@ -1,0 +1,59 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestReplaceSliceOptions < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def setup
+    @options = Arrow::ReplaceSliceOptions.new
+  end
+
+  def test_start_property
+    assert_equal(0, @options.start)
+    @options.start = 1
+    assert_equal(1, @options.start)
+  end
+
+  def test_stop_property
+    assert_equal(0, @options.stop)
+    @options.stop = 2
+    assert_equal(2, @options.stop)
+  end
+
+  def test_replacement_property
+    assert_equal("", @options.replacement)
+    @options.replacement = "XX"
+    assert_equal("XX", @options.replacement)
+  end
+
+  def test_utf8_replace_slice_function
+    args = [
+      Arrow::ArrayDatum.new(build_string_array(["hello", "world"])),
+    ]
+    @options.start = 1
+    @options.stop = 3
+    @options.replacement = "XX"
+    utf8_replace_slice_function = Arrow::Function.find("utf8_replace_slice")
+    result = utf8_replace_slice_function.execute(args, @options).value
+    # Replace slice from index 1 to 3 (exclusive) with "XX"
+    # "hello" -> "hXXlo" (replaces "el" with "XX")
+    # "world" -> "wXXld" (replaces "or" with "XX")
+    expected = build_string_array(["hXXlo", "wXXld"])
+    assert_equal(expected, result)
+  end
+end
+

--- a/c_glib/test/test-replace-substring-options.rb
+++ b/c_glib/test/test-replace-substring-options.rb
@@ -1,0 +1,68 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestReplaceSubstringOptions < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def setup
+    @options = Arrow::ReplaceSubstringOptions.new
+  end
+
+  def test_pattern_property
+    assert_equal("", @options.pattern)
+    @options.pattern = "foo"
+    assert_equal("foo", @options.pattern)
+  end
+
+  def test_replacement_property
+    assert_equal("", @options.replacement)
+    @options.replacement = "bar"
+    assert_equal("bar", @options.replacement)
+  end
+
+  def test_max_replacements_property
+    assert_equal(-1, @options.max_replacements)
+    @options.max_replacements = 1
+    assert_equal(1, @options.max_replacements)
+  end
+
+  def test_replace_substring_function
+    args = [
+      Arrow::ArrayDatum.new(build_string_array(["foo", "this foo that foo", "bar"])),
+    ]
+    @options.pattern = "foo"
+    @options.replacement = "baz"
+    replace_substring_function = Arrow::Function.find("replace_substring")
+    result = replace_substring_function.execute(args, @options).value
+    expected = build_string_array(["baz", "this baz that baz", "bar"])
+    assert_equal(expected, result)
+  end
+
+  def test_replace_substring_with_max_replacements
+    args = [
+      Arrow::ArrayDatum.new(build_string_array(["this foo that foo"])),
+    ]
+    @options.pattern = "foo"
+    @options.replacement = "baz"
+    @options.max_replacements = 1
+    replace_substring_function = Arrow::Function.find("replace_substring")
+    result = replace_substring_function.execute(args, @options).value
+    expected = build_string_array(["this baz that foo"])
+    assert_equal(expected, result)
+  end
+end
+

--- a/c_glib/test/test-round-binary-options.rb
+++ b/c_glib/test/test-round-binary-options.rb
@@ -1,0 +1,43 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestRoundBinaryOptions < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def setup
+    @options = Arrow::RoundBinaryOptions.new
+  end
+
+  def test_mode
+    assert_equal(Arrow::RoundMode::HALF_TO_EVEN, @options.mode)
+    @options.mode = :down
+    assert_equal(Arrow::RoundMode::DOWN, @options.mode)
+  end
+
+  def test_round_binary_function
+    args = [
+      Arrow::ArrayDatum.new(build_double_array([5.0])),
+      Arrow::ArrayDatum.new(build_int32_array([-1])),
+    ]
+    @options.mode = :half_towards_zero
+    round_binary_function = Arrow::Function.find("round_binary")
+    result = round_binary_function.execute(args, @options).value
+    expected = build_double_array([0.0])
+    assert_equal(expected, result)
+  end
+end
+

--- a/c_glib/test/test-round-temporal-options.rb
+++ b/c_glib/test/test-round-temporal-options.rb
@@ -1,0 +1,68 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestRoundTemporalOptions < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def setup
+    @options = Arrow::RoundTemporalOptions.new
+  end
+
+  def test_multiple
+    assert_equal(1, @options.multiple)
+    @options.multiple = 3
+    assert_equal(3, @options.multiple)
+  end
+
+  def test_unit
+    assert_equal(Arrow::CalendarUnit::DAY, @options.unit)
+    @options.unit = :hour
+    assert_equal(Arrow::CalendarUnit::HOUR, @options.unit)
+  end
+
+  def test_week_starts_monday
+    assert_equal(true, @options.week_starts_monday?)
+    @options.week_starts_monday = false
+    assert_equal(false, @options.week_starts_monday?)
+  end
+
+  def test_ceil_is_strictly_greater
+    assert_equal(false, @options.ceil_is_strictly_greater?)
+    @options.ceil_is_strictly_greater = true
+    assert_equal(true, @options.ceil_is_strictly_greater?)
+  end
+
+  def test_calendar_based_origin
+    assert_equal(false, @options.calendar_based_origin?)
+    @options.calendar_based_origin = true
+    assert_equal(true, @options.calendar_based_origin?)
+  end
+
+  def test_round_temporal_function
+    # 1504953190000 = 2017-09-09 10:33:10 UTC
+    args = [
+      Arrow::ArrayDatum.new(build_timestamp_array(:milli, [1504953190000])),
+    ]
+    @options.multiple = 5
+    @options.unit = :minute
+    round_temporal_function = Arrow::Function.find("round_temporal")
+    result = round_temporal_function.execute(args, @options).value
+    # 1504953300000 = 2017-09-09 10:35:00 UTC
+    expected = build_timestamp_array(:milli, [1504953300000])
+    assert_equal(expected, result)
+  end
+end

--- a/c_glib/test/test-select-k-options.rb
+++ b/c_glib/test/test-select-k-options.rb
@@ -1,0 +1,62 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestSelectKOptions < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def setup
+    @options = Arrow::SelectKOptions.new
+  end
+
+  def test_k
+    assert_equal(-1, @options.k)
+    @options.k = 3
+    assert_equal(3, @options.k)
+  end
+
+  def test_sort_keys
+    sort_keys = [
+      Arrow::SortKey.new("column1", :ascending),
+      Arrow::SortKey.new("column2", :descending),
+    ]
+    @options.sort_keys = sort_keys
+    assert_equal(sort_keys, @options.sort_keys)
+  end
+
+  def test_add_sort_key
+    @options.add_sort_key(Arrow::SortKey.new("column1", :ascending))
+    @options.add_sort_key(Arrow::SortKey.new("column2", :descending))
+    assert_equal([
+                   Arrow::SortKey.new("column1", :ascending),
+                   Arrow::SortKey.new("column2", :descending),
+                 ],
+                 @options.sort_keys)
+  end
+
+  def test_select_k_unstable_function
+    input_array = build_int32_array([5, 2, 8, 1, 9, 3])
+    args = [
+      Arrow::ArrayDatum.new(input_array),
+    ]
+    @options.k = 3
+    @options.add_sort_key(Arrow::SortKey.new("dummy", :descending))
+    select_k_unstable_function = Arrow::Function.find("select_k_unstable")
+    result = select_k_unstable_function.execute(args, @options).value
+    assert_equal(build_uint64_array([4, 2, 0]), result)
+  end
+end
+

--- a/c_glib/test/test-skew-options.rb
+++ b/c_glib/test/test-skew-options.rb
@@ -1,0 +1,61 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestSkewOptions < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def setup
+    @options = Arrow::SkewOptions.new
+  end
+
+  def test_skip_nulls
+    assert do
+      @options.skip_nulls?
+    end
+    @options.skip_nulls = false
+    assert do
+      not @options.skip_nulls?
+    end
+  end
+
+  def test_biased
+    assert do
+      @options.biased?
+    end
+    @options.biased = false
+    assert do
+      not @options.biased?
+    end
+  end
+
+  def test_min_count
+    assert_equal(0, @options.min_count)
+    @options.min_count = 1
+    assert_equal(1, @options.min_count)
+  end
+
+  def test_skew_function
+    args = [
+      Arrow::ArrayDatum.new(build_double_array([1.0, 1.0, 2.0])),
+    ]
+    @options.min_count = 4
+    skew_function = Arrow::Function.find("skew")
+    result = skew_function.execute(args, @options).value
+    assert_equal(0.0, result.value)
+  end
+end
+

--- a/c_glib/test/test-slice-options.rb
+++ b/c_glib/test/test-slice-options.rb
@@ -1,0 +1,55 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestSliceOptions < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def setup
+    @options = Arrow::SliceOptions.new
+  end
+
+  def test_start_property
+    assert_equal(0, @options.start)
+    @options.start = 1
+    assert_equal(1, @options.start)
+  end
+
+  def test_stop_property
+    assert_equal(0, @options.stop)
+    @options.stop = 5
+    assert_equal(5, @options.stop)
+  end
+
+  def test_step_property
+    assert_equal(1, @options.step)
+    @options.step = 2
+    assert_equal(2, @options.step)
+  end
+
+  def test_utf8_slice_codeunits_function
+    args = [
+      Arrow::ArrayDatum.new(build_string_array(["hello", "world", "test"])),
+    ]
+    @options.start = 1
+    @options.stop = 4
+    @options.step = 1
+    utf8_slice_codeunits_function = Arrow::Function.find("utf8_slice_codeunits")
+    result = utf8_slice_codeunits_function.execute(args, @options).value
+    expected = build_string_array(["ell", "orl", "est"])
+    assert_equal(expected, result)
+  end
+end

--- a/c_glib/test/test-split-options.rb
+++ b/c_glib/test/test-split-options.rb
@@ -1,0 +1,52 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestSplitOptions < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def setup
+    @options = Arrow::SplitOptions.new
+  end
+
+  def test_max_splits_property
+    assert_equal(-1, @options.max_splits)
+    @options.max_splits = 1
+    assert_equal(1, @options.max_splits)
+  end
+
+  def test_reverse_property
+    assert do
+      !@options.reverse?
+    end
+    @options.reverse = true
+    assert do
+      @options.reverse?
+    end
+  end
+
+  def test_utf8_split_whitespace_function
+    args = [
+      Arrow::ArrayDatum.new(build_string_array(["hello world test"])),
+    ]
+    @options.max_splits = 1
+    utf8_split_whitespace_function = Arrow::Function.find("utf8_split_whitespace")
+    result = utf8_split_whitespace_function.execute(args, @options).value
+    expected = build_list_array(Arrow::StringDataType.new, [["hello", "world test"]])
+    assert_equal(expected, result)
+  end
+end
+

--- a/c_glib/test/test-tdigest-options.rb
+++ b/c_glib/test/test-tdigest-options.rb
@@ -1,0 +1,72 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestTDigestOptions < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def setup
+    @options = Arrow::TDigestOptions.new
+  end
+
+  def test_delta
+    assert_equal(100, @options.delta)
+    @options.delta = 200
+    assert_equal(200, @options.delta)
+  end
+
+  def test_buffer_size
+    assert_equal(500, @options.buffer_size)
+    @options.buffer_size = 1000
+    assert_equal(1000, @options.buffer_size)
+  end
+
+  def test_skip_nulls
+    assert do
+      @options.skip_nulls?
+    end
+    @options.skip_nulls = false
+    assert do
+      not @options.skip_nulls?
+    end
+  end
+
+  def test_min_count
+    assert_equal(0, @options.min_count)
+    @options.min_count = 1
+    assert_equal(1, @options.min_count)
+  end
+
+  def test_q
+    assert_equal([0.5], @options.qs)
+    @options.qs = [0.1, 0.2, 0.9]
+    assert_equal([0.1, 0.2, 0.9], @options.qs)
+    @options.q = 0.7
+    assert_equal([0.7], @options.qs)
+  end
+
+  def test_tdigest_function
+    args = [
+      Arrow::ArrayDatum.new(build_double_array([1.0, 2.0, 3.0, 4.0, 5.0])),
+    ]
+    @options.q = 0.5
+    @options.delta = 200
+    tdigest_function = Arrow::Function.find("tdigest")
+    result = tdigest_function.execute(args, @options).value
+    assert_equal(build_double_array([3.0]), result)
+  end
+end
+

--- a/c_glib/test/test-trim-options.rb
+++ b/c_glib/test/test-trim-options.rb
@@ -1,0 +1,42 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestTrimOptions < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def setup
+    @options = Arrow::TrimOptions.new
+  end
+
+  def test_characters_property
+    assert_equal("", @options.characters)
+    @options.characters = " \t"
+    assert_equal(" \t", @options.characters)
+  end
+
+  def test_utf8_trim_function
+    args = [
+      Arrow::ArrayDatum.new(build_string_array(["  hello  ", "  world  "])),
+    ]
+    @options.characters = " "
+    utf8_trim_function = Arrow::Function.find("utf8_trim")
+    result = utf8_trim_function.execute(args, @options).value
+    expected = build_string_array(["hello", "world"])
+    assert_equal(expected, result)
+  end
+end
+

--- a/c_glib/test/test-week-options.rb
+++ b/c_glib/test/test-week-options.rb
@@ -1,0 +1,71 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestWeekOptions < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def setup
+    @options = Arrow::WeekOptions.new
+  end
+
+  def test_week_starts_monday_property
+    assert do
+      @options.week_starts_monday?
+    end
+    @options.week_starts_monday = false
+    assert do
+      !@options.week_starts_monday?
+    end
+  end
+
+  def test_count_from_zero_property
+    assert do
+      !@options.count_from_zero?
+    end
+    @options.count_from_zero = true
+    assert do
+      @options.count_from_zero?
+    end
+  end
+
+  def test_first_week_is_fully_in_year_property
+    assert do
+      !@options.first_week_is_fully_in_year?
+    end
+    @options.first_week_is_fully_in_year = true
+    assert do
+      @options.first_week_is_fully_in_year?
+    end
+  end
+
+  def test_week_function_with_week_starts_monday
+    omit("Missing tzdata on Windows") if Gem.win_platform?
+    # January 1, 2023 (Sunday)
+    args = [
+      Arrow::ArrayDatum.new(build_timestamp_array(:milli, [1672531200000])),
+    ]
+    @options.week_starts_monday = true
+    week_function = Arrow::Function.find("week")
+    result = week_function.execute(args, @options).value
+    assert_equal(build_int64_array([52]), result)
+
+    @options.week_starts_monday = false
+    result = week_function.execute(args, @options).value
+    assert_equal(build_int64_array([1]), result)
+  end
+end
+

--- a/c_glib/test/test-winsorize-options.rb
+++ b/c_glib/test/test-winsorize-options.rb
@@ -1,0 +1,50 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestWinsorizeOptions < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def setup
+    @options = Arrow::WinsorizeOptions.new
+  end
+
+  def test_lower_limit_property
+    assert_equal(0.0, @options.lower_limit)
+    @options.lower_limit = 0.05
+    assert_equal(0.05, @options.lower_limit)
+  end
+
+  def test_upper_limit_property
+    assert_equal(1.0, @options.upper_limit)
+    @options.upper_limit = 0.95
+    assert_equal(0.95, @options.upper_limit)
+  end
+
+  def test_winsorize_function
+    args = [
+      Arrow::ArrayDatum.new(build_double_array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 
+10.0])),
+    ]
+    @options.lower_limit = 0.1
+    @options.upper_limit = 0.9
+    winsorize_function = Arrow::Function.find("winsorize")
+    result = winsorize_function.execute(args, @options).value
+    expected = build_double_array([2.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 9.0])
+    assert_equal(expected, result)
+  end
+end
+

--- a/c_glib/test/test-zero-fill-options.rb
+++ b/c_glib/test/test-zero-fill-options.rb
@@ -1,0 +1,49 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestZeroFillOptions < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def setup
+    @options = Arrow::ZeroFillOptions.new
+  end
+
+  def test_width_property
+    assert_equal(0, @options.width)
+    @options.width = 4
+    assert_equal(4, @options.width)
+  end
+
+  def test_padding_property
+    assert_equal("0", @options.padding)
+    @options.padding = "x"
+    assert_equal("x", @options.padding)
+  end
+
+  def test_utf8_zero_fill_function
+    args = [
+      Arrow::ArrayDatum.new(build_string_array(["1", "-2", "+3"])),
+    ]
+    @options.width = 4
+    @options.padding = "0"
+    utf8_zero_fill_function = Arrow::Function.find("utf8_zero_fill")
+    result = utf8_zero_fill_function.execute(args, @options).value
+    expected = build_string_array(["0001", "-002", "+003"])
+    assert_equal(expected, result)
+  end
+end
+


### PR DESCRIPTION
### Rationale for this change

Many compute functions are missing their corresponding options class in the GLib bindings. Many functions can still be used in Ruby with reduced functionality, but some functions like `extract_regex` cannot be used at all.

### What changes are included in this PR?

The following options classes are added to the GLib bindings:

* GArrowAssumeTimezoneOptions
* GArrowCumulativeOptions
* GArrowDayOfWeekOptions
* GArrowDictionaryEncodeOptions
* GArrowElementWiseAggregateOptions
* GArrowExtractRegexOptions
* GArrowExtractRegexSpanOptions
* GArrowJoinOptions
* GArrowListFlattenOptions
* GArrowListSliceOptions
* GArrowMakeStructOptions
* GArrowMapLookupOptions
* GArrowModeOptions
* GArrowNullOptions
* GArrowPadOptions
* GArrowPairwiseOptions
* GArrowPartitionNthOptions
* GArrowPivotWiderOptions
* GArrowRankQuantileOptions
* GArrowReplaceSliceOptions
* GArrowReplaceSubstringOptions
* GArrowRoundBinaryOptions
* GArrowRoundTemporalOptions
* GArrowSelectKOptions
* GArrowSkewOptions
* GArrowSliceOptions
* GArrowSplitOptions
* GArrowTDigestOptions
* GArrowTrimOptions
* GArrowWeekOptions
* GArrowWinsorizeOptions

The following classes are added as well since they were needed in some tests:

* GArrowFixedSizeListArray
* GArrowFixedSizeListArrayBuilder

### Are these changes tested?

All classes are tested with Ruby unit tests.

### Are there any user-facing changes?

Yes, new classes.
* GitHub Issue: #48356