### PR TITLE
GH-48358: [Ruby] Add support for reading float32 array

### DIFF
--- a/ruby/red-arrow-format/lib/arrow-format/array.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/array.rb
@@ -91,6 +91,19 @@ module ArrowFormat
     end
   end
 
+  class FloatArray < Array
+    def initialize(type, size, validity_buffer, values_buffer)
+      super(type, size, validity_buffer)
+      @values_buffer = values_buffer
+    end
+  end
+
+  class Float32Array < FloatArray
+    def to_a
+      apply_validity(@values_buffer.values(:f32, 0, @size))
+    end
+  end
+
   class VariableSizeBinaryLayoutArray < Array
     def initialize(type, size, validity_buffer, offsets_buffer, values_buffer)
       super(type, size, validity_buffer)

--- a/ruby/red-arrow-format/lib/arrow-format/file-reader.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/file-reader.rb
@@ -24,11 +24,13 @@ require_relative "type"
 
 require_relative "org/apache/arrow/flatbuf/binary"
 require_relative "org/apache/arrow/flatbuf/bool"
+require_relative "org/apache/arrow/flatbuf/floating_point"
 require_relative "org/apache/arrow/flatbuf/footer"
 require_relative "org/apache/arrow/flatbuf/int"
 require_relative "org/apache/arrow/flatbuf/list"
 require_relative "org/apache/arrow/flatbuf/message"
 require_relative "org/apache/arrow/flatbuf/null"
+require_relative "org/apache/arrow/flatbuf/precision"
 require_relative "org/apache/arrow/flatbuf/schema"
 require_relative "org/apache/arrow/flatbuf/utf8"
 
@@ -147,6 +149,11 @@ module ArrowFormat
             type = UInt8Type.singleton
           end
         end
+      when Org::Apache::Arrow::Flatbuf::FloatingPoint
+        case fb_type.precision
+        when Org::Apache::Arrow::Flatbuf::Precision::SINGLE
+          type = Float32Type.singleton
+        end
       when Org::Apache::Arrow::Flatbuf::List
         type = ListType.new(read_field(fb_field.children[0]))
       when Org::Apache::Arrow::Flatbuf::Binary
@@ -179,8 +186,8 @@ module ArrowFormat
 
       case field.type
       when BooleanType,
-           Int8Type,
-           UInt8Type
+           IntType,
+           FloatType
         values_buffer = buffers.shift
         values = body.slice(values_buffer.offset, values_buffer.length)
         field.type.build_array(length, validity, values)

--- a/ruby/red-arrow-format/lib/arrow-format/type.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/type.rb
@@ -96,6 +96,30 @@ module ArrowFormat
     end
   end
 
+  class FloatType < Type
+    attr_reader :precision
+    def initialize(name, precision)
+      super(name)
+      @precision = precision
+    end
+  end
+
+  class Float32Type < FloatType
+    class << self
+      def singleton
+        @singleton ||= new
+      end
+    end
+
+    def initialize
+      super("Float32", 32)
+    end
+
+    def build_array(size, validity_buffer, values_buffer)
+      Float32Array.new(self, size, validity_buffer, values_buffer)
+    end
+  end
+
   class BinaryType < Type
     class << self
       def singleton

--- a/ruby/red-arrow-format/test/test-file-reader.rb
+++ b/ruby/red-arrow-format/test/test-file-reader.rb
@@ -84,6 +84,17 @@ class TestFileReader < Test::Unit::TestCase
     end
   end
 
+  sub_test_case("Float32") do
+    def build_array
+      Arrow::FloatArray.new([-0.5, nil, 0.5])
+    end
+
+    def test_read
+      assert_equal([{"value" => [-0.5, nil, 0.5]}],
+                   read)
+    end
+  end
+
   sub_test_case("Binary") do
     def build_array
       Arrow::BinaryArray.new(["Hello".b, nil, "World".b])


### PR DESCRIPTION
### Rationale for this change

It's the first float array.

### What changes are included in this PR?

* Add `ArrowFormat::Float32Type`
* Add `ArrowFormat::Float32Array`

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #48358