### PR TITLE
GH-48360: [Ruby] Add support for reading large binary array

### DIFF
--- a/ruby/red-arrow-format/lib/arrow-format/array.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/array.rb
@@ -113,7 +113,7 @@ module ArrowFormat
 
     def to_a
       values = @offsets_buffer.
-        each(:s32, 0, @size + 1). # TODO: big endian support
+        each(buffer_type, 0, @size + 1).
         each_cons(2).
         collect do |(_, offset), (_, next_offset)|
         length = next_offset - offset
@@ -125,6 +125,21 @@ module ArrowFormat
 
   class BinaryArray < VariableSizeBinaryLayoutArray
     private
+    def buffer_type
+      :s32 # TODO: big endian support
+    end
+
+    def encoding
+      Encoding::ASCII_8BIT
+    end
+  end
+
+  class LargeBinaryArray < VariableSizeBinaryLayoutArray
+    private
+    def buffer_type
+      :s64 # TODO: big endian support
+    end
+
     def encoding
       Encoding::ASCII_8BIT
     end
@@ -132,6 +147,10 @@ module ArrowFormat
 
   class UTF8Array < VariableSizeBinaryLayoutArray
     private
+    def buffer_type
+      :s32 # TODO: big endian support
+    end
+
     def encoding
       Encoding::UTF_8
     end

--- a/ruby/red-arrow-format/lib/arrow-format/file-reader.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/file-reader.rb
@@ -27,6 +27,7 @@ require_relative "org/apache/arrow/flatbuf/bool"
 require_relative "org/apache/arrow/flatbuf/floating_point"
 require_relative "org/apache/arrow/flatbuf/footer"
 require_relative "org/apache/arrow/flatbuf/int"
+require_relative "org/apache/arrow/flatbuf/large_binary"
 require_relative "org/apache/arrow/flatbuf/list"
 require_relative "org/apache/arrow/flatbuf/message"
 require_relative "org/apache/arrow/flatbuf/null"
@@ -158,6 +159,8 @@ module ArrowFormat
         type = ListType.new(read_field(fb_field.children[0]))
       when Org::Apache::Arrow::Flatbuf::Binary
         type = BinaryType.singleton
+      when Org::Apache::Arrow::Flatbuf::LargeBinary
+        type = LargeBinaryType.singleton
       when Org::Apache::Arrow::Flatbuf::Utf8
         type = UTF8Type.singleton
       end
@@ -196,8 +199,7 @@ module ArrowFormat
         offsets = body.slice(offsets_buffer.offset, offsets_buffer.length)
         child = read_column(field.type.child, nodes, buffers, body)
         field.type.build_array(length, validity, offsets, child)
-      when BinaryType,
-           UTF8Type
+      when VariableSizeBinaryType
         offsets_buffer = buffers.shift
         values_buffer = buffers.shift
         offsets = body.slice(offsets_buffer.offset, offsets_buffer.length)

--- a/ruby/red-arrow-format/lib/arrow-format/type.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/type.rb
@@ -120,7 +120,10 @@ module ArrowFormat
     end
   end
 
-  class BinaryType < Type
+  class VariableSizeBinaryType < Type
+  end
+
+  class BinaryType < VariableSizeBinaryType
     class << self
       def singleton
         @singleton ||= new
@@ -136,7 +139,27 @@ module ArrowFormat
     end
   end
 
-  class UTF8Type < Type
+  class LargeBinaryType < VariableSizeBinaryType
+    class << self
+      def singleton
+        @singleton ||= new
+      end
+    end
+
+    def initialize
+      super("LargeBinary")
+    end
+
+    def build_array(size, validity_buffer, offsets_buffer, values_buffer)
+      LargeBinaryArray.new(self,
+                           size,
+                           validity_buffer,
+                           offsets_buffer,
+                           values_buffer)
+    end
+  end
+
+  class UTF8Type < VariableSizeBinaryType
     class << self
       def singleton
         @singleton ||= new

--- a/ruby/red-arrow-format/test/test-file-reader.rb
+++ b/ruby/red-arrow-format/test/test-file-reader.rb
@@ -106,6 +106,17 @@ class TestFileReader < Test::Unit::TestCase
     end
   end
 
+  sub_test_case("LargeBinary") do
+    def build_array
+      Arrow::LargeBinaryArray.new(["Hello".b, nil, "World".b])
+    end
+
+    def test_read
+      assert_equal([{"value" => ["Hello".b, nil, "World".b]}],
+                   read)
+    end
+  end
+
   sub_test_case("UTF8") do
     def build_array
       Arrow::StringArray.new(["Hello", nil, "World"])


### PR DESCRIPTION
### Rationale for this change

It's the 64 bit offset version of binary array.

### What changes are included in this PR?

* Add `ArrowFormat::LargeBinaryType`
* Add `ArrowFormat::LargeBinaryArray`

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #48360