### PR TITLE
GH-48362: [GLib][Ruby] Add FixedSizeListArray

### DIFF
--- a/c_glib/arrow-glib/array-builder.h
+++ b/c_glib/arrow-glib/array-builder.h
@@ -1635,6 +1635,32 @@ GARROW_AVAILABLE_IN_0_16
 GArrowArrayBuilder *
 garrow_large_list_array_builder_get_value_builder(GArrowLargeListArrayBuilder *builder);
 
+#define GARROW_TYPE_FIXED_SIZE_LIST_ARRAY_BUILDER                                        \
+  (garrow_fixed_size_list_array_builder_get_type())
+GARROW_AVAILABLE_IN_23_0
+G_DECLARE_DERIVABLE_TYPE(GArrowFixedSizeListArrayBuilder,
+                         garrow_fixed_size_list_array_builder,
+                         GARROW,
+                         FIXED_SIZE_LIST_ARRAY_BUILDER,
+                         GArrowArrayBuilder)
+struct _GArrowFixedSizeListArrayBuilderClass
+{
+  GArrowArrayBuilderClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_23_0
+GArrowFixedSizeListArrayBuilder *
+garrow_fixed_size_list_array_builder_new(GArrowFixedSizeListDataType *data_type,
+                                         GError **error);
+GARROW_AVAILABLE_IN_23_0
+gboolean
+garrow_fixed_size_list_array_builder_append_value(
+  GArrowFixedSizeListArrayBuilder *builder, GError **error);
+GARROW_AVAILABLE_IN_23_0
+GArrowArrayBuilder *
+garrow_fixed_size_list_array_builder_get_value_builder(
+  GArrowFixedSizeListArrayBuilder *builder);
+
 #define GARROW_TYPE_STRUCT_ARRAY_BUILDER (garrow_struct_array_builder_get_type())
 GARROW_AVAILABLE_IN_ALL
 G_DECLARE_DERIVABLE_TYPE(GArrowStructArrayBuilder,

--- a/c_glib/arrow-glib/basic-array.cpp
+++ b/c_glib/arrow-glib/basic-array.cpp
@@ -4005,6 +4005,9 @@ garrow_array_new_raw_valist(std::shared_ptr<arrow::Array> *arrow_array,
   case arrow::Type::type::LARGE_LIST:
     type = GARROW_TYPE_LARGE_LIST_ARRAY;
     break;
+  case arrow::Type::type::FIXED_SIZE_LIST:
+    type = GARROW_TYPE_FIXED_SIZE_LIST_ARRAY;
+    break;
   case arrow::Type::type::STRUCT:
     type = GARROW_TYPE_STRUCT_ARRAY;
     break;

--- a/c_glib/arrow-glib/composite-array.h
+++ b/c_glib/arrow-glib/composite-array.h
@@ -110,6 +110,50 @@ GARROW_AVAILABLE_IN_2_0
 const gint64 *
 garrow_large_list_array_get_value_offsets(GArrowLargeListArray *array, gint64 *n_offsets);
 
+#define GARROW_TYPE_FIXED_SIZE_LIST_ARRAY (garrow_fixed_size_list_array_get_type())
+GARROW_AVAILABLE_IN_23_0
+G_DECLARE_DERIVABLE_TYPE(GArrowFixedSizeListArray,
+                         garrow_fixed_size_list_array,
+                         GARROW,
+                         FIXED_SIZE_LIST_ARRAY,
+                         GArrowArray)
+struct _GArrowFixedSizeListArrayClass
+{
+  GArrowArrayClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_23_0
+GArrowFixedSizeListArray *
+garrow_fixed_size_list_array_new(GArrowDataType *data_type,
+                                 gint64 length,
+                                 GArrowArray *values,
+                                 GArrowBuffer *null_bitmap,
+                                 gint64 n_nulls);
+
+GARROW_AVAILABLE_IN_23_0
+GArrowDataType *
+garrow_fixed_size_list_array_get_value_type(GArrowFixedSizeListArray *array);
+
+GARROW_AVAILABLE_IN_23_0
+GArrowArray *
+garrow_fixed_size_list_array_get_value(GArrowFixedSizeListArray *array, gint64 i);
+
+GARROW_AVAILABLE_IN_23_0
+GArrowArray *
+garrow_fixed_size_list_array_get_values(GArrowFixedSizeListArray *array);
+
+GARROW_AVAILABLE_IN_23_0
+gint64
+garrow_fixed_size_list_array_get_value_offset(GArrowFixedSizeListArray *array, gint64 i);
+
+GARROW_AVAILABLE_IN_23_0
+gint32
+garrow_fixed_size_list_array_get_value_length(GArrowFixedSizeListArray *array, gint64 i);
+
+GARROW_AVAILABLE_IN_23_0
+gint32
+garrow_fixed_size_list_array_get_list_size(GArrowFixedSizeListArray *array);
+
 #define GARROW_TYPE_STRUCT_ARRAY (garrow_struct_array_get_type())
 GARROW_AVAILABLE_IN_ALL
 G_DECLARE_DERIVABLE_TYPE(

--- a/c_glib/test/helper/buildable.rb
+++ b/c_glib/test/helper/buildable.rb
@@ -172,6 +172,16 @@ module Helper
       builder.finish
     end
 
+    def build_fixed_size_list_array(value_data_type, list_size, values_list, field_name: "value")
+      value_field = Arrow::Field.new(field_name, value_data_type)
+      data_type = Arrow::FixedSizeListDataType.new(value_field, list_size)
+      builder = Arrow::FixedSizeListArrayBuilder.new(data_type)
+      values_list.each do |values|
+        append_to_builder(builder, values)
+      end
+      builder.finish
+    end
+
     def build_map_array(key_data_type, item_data_type, maps)
       data_type = Arrow::MapDataType.new(key_data_type, item_data_type)
       builder = Arrow::MapArrayBuilder.new(data_type)
@@ -204,7 +214,7 @@ module Helper
             append_to_builder(key_builder, k)
             append_to_builder(item_builder, v)
           end
-        when Arrow::ListDataType, Arrow::LargeListDataType
+        when Arrow::ListDataType, Arrow::LargeListDataType, Arrow::FixedSizeListDataType
           builder.append_value
           value_builder = builder.value_builder
           value.each do |v|

--- a/c_glib/test/test-fixed-size-list-array-builder.rb
+++ b/c_glib/test/test-fixed-size-list-array-builder.rb
@@ -23,6 +23,13 @@ class TestFixedSizeListArrayBuilder < Test::Unit::TestCase
     require_gi_bindings(3, 1, 9)
   end
 
+  def get_value(array, i)
+    value = array.get_value(i)
+    value.length.times.collect do |j|
+      value.get_value(j)
+    end
+  end
+
   def test_new
     field = Arrow::Field.new("value", Arrow::Int8DataType.new)
     data_type = Arrow::FixedSizeListDataType.new(field, 2)
@@ -48,10 +55,8 @@ class TestFixedSizeListArrayBuilder < Test::Unit::TestCase
 
     array = builder.finish
     assert_equal(2, array.length)
-    assert_equal([1, 2], array.get_value(0).length.times.collect {|i|
- array.get_value(0).get_value(i)})
-    assert_equal([3, 4], array.get_value(1).length.times.collect {|i|
- array.get_value(1).get_value(i)})
+    assert_equal([1, 2], get_value(array, 0))
+    assert_equal([3, 4], get_value(array, 1))
   end
 
   def test_append_null
@@ -75,11 +80,11 @@ class TestFixedSizeListArrayBuilder < Test::Unit::TestCase
 
     array = builder.finish
     assert_equal(3, array.length)
-    assert_equal([1, 2], array.get_value(0).length.times.collect {|i|
- array.get_value(0).get_value(i)})
-    assert_equal(true, array.null?(1))
-    assert_equal([5, 6], array.get_value(2).length.times.collect {|i|
- array.get_value(2).get_value(i)})
+    assert_equal([1, 2], get_value(array, 0))
+    assert do
+      array.null?(1)
+    end
+    assert_equal([5, 6], get_value(array, 2))
   end
 
   def test_value_builder

--- a/c_glib/test/test-fixed-size-list-array-builder.rb
+++ b/c_glib/test/test-fixed-size-list-array-builder.rb
@@ -95,4 +95,3 @@ class TestFixedSizeListArrayBuilder < Test::Unit::TestCase
     assert_equal(Arrow::Int8DataType.new, value_builder.value_data_type)
   end
 end
-

--- a/c_glib/test/test-fixed-size-list-array-builder.rb
+++ b/c_glib/test/test-fixed-size-list-array-builder.rb
@@ -1,0 +1,93 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestFixedSizeListArrayBuilder < Test::Unit::TestCase
+  include Helper::Buildable
+  include Helper::Omittable
+
+  def setup
+    require_gi_bindings(3, 1, 9)
+  end
+
+  def test_new
+    field = Arrow::Field.new("value", Arrow::Int8DataType.new)
+    data_type = Arrow::FixedSizeListDataType.new(field, 2)
+    builder = Arrow::FixedSizeListArrayBuilder.new(data_type)
+    assert_equal(data_type, builder.value_data_type)
+  end
+
+  def test_append_value
+    field = Arrow::Field.new("value", Arrow::Int8DataType.new)
+    data_type = Arrow::FixedSizeListDataType.new(field, 2)
+    builder = Arrow::FixedSizeListArrayBuilder.new(data_type)
+    value_builder = builder.value_builder
+
+    # Append first list: [1, 2]
+    builder.append_value
+    value_builder.append_value(1)
+    value_builder.append_value(2)
+
+    # Append second list: [3, 4]
+    builder.append_value
+    value_builder.append_value(3)
+    value_builder.append_value(4)
+
+    array = builder.finish
+    assert_equal(2, array.length)
+    assert_equal([1, 2], array.get_value(0).length.times.collect {|i|
+ array.get_value(0).get_value(i)})
+    assert_equal([3, 4], array.get_value(1).length.times.collect {|i|
+ array.get_value(1).get_value(i)})
+  end
+
+  def test_append_null
+    field = Arrow::Field.new("value", Arrow::Int8DataType.new)
+    data_type = Arrow::FixedSizeListDataType.new(field, 2)
+    builder = Arrow::FixedSizeListArrayBuilder.new(data_type)
+    value_builder = builder.value_builder
+
+    # Append first list: [1, 2]
+    builder.append_value
+    value_builder.append_value(1)
+    value_builder.append_value(2)
+
+    # Append null list
+    builder.append_null
+
+    # Append third list: [5, 6]
+    builder.append_value
+    value_builder.append_value(5)
+    value_builder.append_value(6)
+
+    array = builder.finish
+    assert_equal(3, array.length)
+    assert_equal([1, 2], array.get_value(0).length.times.collect {|i|
+ array.get_value(0).get_value(i)})
+    assert_equal(true, array.null?(1))
+    assert_equal([5, 6], array.get_value(2).length.times.collect {|i|
+ array.get_value(2).get_value(i)})
+  end
+
+  def test_value_builder
+    field = Arrow::Field.new("value", Arrow::Int8DataType.new)
+    data_type = Arrow::FixedSizeListDataType.new(field, 2)
+    builder = Arrow::FixedSizeListArrayBuilder.new(data_type)
+    value_builder = builder.value_builder
+    assert_equal(Arrow::Int8DataType.new, value_builder.value_data_type)
+  end
+end
+

--- a/c_glib/test/test-fixed-size-list-array.rb
+++ b/c_glib/test/test-fixed-size-list-array.rb
@@ -78,4 +78,3 @@ class TestFixedSizeListArray < Test::Unit::TestCase
     assert_equal(2, array.list_size)
   end
 end
-

--- a/c_glib/test/test-fixed-size-list-array.rb
+++ b/c_glib/test/test-fixed-size-list-array.rb
@@ -1,0 +1,81 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestFixedSizeListArray < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def test_new
+    field = Arrow::Field.new("value", Arrow::Int8DataType.new)
+    data_type = Arrow::FixedSizeListDataType.new(field, 2)
+    data = Arrow::Buffer.new([1, 2, 3, 4].pack("c*"))
+    nulls = Arrow::Buffer.new([0b1111].pack("C*"))
+    values = Arrow::Int8Array.new(4, data, nulls, 0)
+    assert_equal(build_fixed_size_list_array(Arrow::Int8DataType.new, 2,
+                                             [[1, 2], [3, 4]]),
+                 Arrow::FixedSizeListArray.new(data_type,
+                                               2,
+                                               values,
+                                               Arrow::Buffer.new([0b11].pack("C*")),
+                                               -1))
+  end
+
+  def test_value
+    array = build_fixed_size_list_array(Arrow::Int8DataType.new, 2,
+                                        [[1, 2], [3, 4]])
+    value = array.get_value(1)
+    assert_equal([3, 4],
+                 value.length.times.collect {|i| value.get_value(i)})
+  end
+
+  def test_value_type
+    field = Arrow::Field.new("value", Arrow::Int8DataType.new)
+    data_type = Arrow::FixedSizeListDataType.new(field, 2)
+    builder = Arrow::FixedSizeListArrayBuilder.new(data_type)
+    array = builder.finish
+    assert_equal(Arrow::Int8DataType.new, array.value_type)
+  end
+
+  def test_values
+    array = build_fixed_size_list_array(Arrow::Int8DataType.new, 2,
+                                        [[1, 2], [3, 4]])
+    values = array.values
+    assert_equal([1, 2, 3, 4],
+                 values.length.times.collect {|i| values.get_value(i)})
+  end
+
+  def test_value_offset
+    array = build_fixed_size_list_array(Arrow::Int8DataType.new, 2,
+                                        [[1, 2], [3, 4]])
+    assert_equal([0, 2],
+                 array.length.times.collect {|i| array.get_value_offset(i)})
+  end
+
+  def test_value_length
+    array = build_fixed_size_list_array(Arrow::Int8DataType.new, 2,
+                                        [[1, 2], [3, 4]])
+    # All lists have the same fixed size
+    assert_equal([2, 2],
+                 array.length.times.collect {|i| array.get_value_length(i)})
+  end
+
+  def test_list_size
+    array = build_fixed_size_list_array(Arrow::Int8DataType.new, 2,
+                                        [[1, 2], [3, 4]])
+    assert_equal(2, array.list_size)
+  end
+end
+


### PR DESCRIPTION
### Rationale for this change

The `FixedSizeListArray` class is not available in GLib/Ruby, and it can be the result of e.g. the `extract_regex_span` and `list_slice` compute functions.

### What changes are included in this PR?

This adds the `GArrowFixedSizeListArray` and `GArrowFixedSizeListArrayBuilder` to GLib.

### Are these changes tested?

Yes, with Ruby unit tests.

### Are there any user-facing changes?

Yes, new classes.
* GitHub Issue: #48362