### PR TITLE
GH-48364: [GLib][Ruby] Add CumulativeOptions

### DIFF
--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -1173,4 +1173,20 @@ GARROW_AVAILABLE_IN_23_0
 GArrowAssumeTimezoneOptions *
 garrow_assume_timezone_options_new(void);
 
+#define GARROW_TYPE_CUMULATIVE_OPTIONS (garrow_cumulative_options_get_type())
+GARROW_AVAILABLE_IN_23_0
+G_DECLARE_DERIVABLE_TYPE(GArrowCumulativeOptions,
+                         garrow_cumulative_options,
+                         GARROW,
+                         CUMULATIVE_OPTIONS,
+                         GArrowFunctionOptions)
+struct _GArrowCumulativeOptionsClass
+{
+  GArrowFunctionOptionsClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_23_0
+GArrowCumulativeOptions *
+garrow_cumulative_options_new(void);
+
 G_END_DECLS

--- a/c_glib/arrow-glib/compute.hpp
+++ b/c_glib/arrow-glib/compute.hpp
@@ -181,3 +181,8 @@ garrow_assume_timezone_options_new_raw(
   const arrow::compute::AssumeTimezoneOptions *arrow_options);
 arrow::compute::AssumeTimezoneOptions *
 garrow_assume_timezone_options_get_raw(GArrowAssumeTimezoneOptions *options);
+
+GArrowCumulativeOptions *
+garrow_cumulative_options_new_raw(const arrow::compute::CumulativeOptions *arrow_options);
+arrow::compute::CumulativeOptions *
+garrow_cumulative_options_get_raw(GArrowCumulativeOptions *options);

--- a/c_glib/test/test-cumulative-options.rb
+++ b/c_glib/test/test-cumulative-options.rb
@@ -1,0 +1,64 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestCumulativeOptions < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def setup
+    @options = Arrow::CumulativeOptions.new
+  end
+
+  def test_start_property
+    assert_nil(@options.start)
+    start_scalar = Arrow::Int64Scalar.new(10)
+    @options.start = start_scalar
+    assert_equal(start_scalar, @options.start)
+    @options.start = nil
+    assert_nil(@options.start)
+  end
+
+  def test_skip_nulls_property
+    assert do
+      !@options.skip_nulls?
+    end
+    @options.skip_nulls = true
+    assert do
+      @options.skip_nulls?
+    end
+  end
+
+  def test_cumulative_sum_with_skip_nulls
+    args = [
+      Arrow::ArrayDatum.new(build_int64_array([1, 2, 3, nil, 4, 5])),
+    ]
+    @options.skip_nulls = true
+    cumulative_sum_function = Arrow::Function.find("cumulative_sum")
+    assert_equal(build_int64_array([1, 3, 6, nil, 10, 15]),
+                 cumulative_sum_function.execute(args, @options).value)
+  end
+
+  def test_cumulative_sum_with_start
+    args = [
+      Arrow::ArrayDatum.new(build_int64_array([1, 2, 3])),
+    ]
+    @options.start = Arrow::Int64Scalar.new(10)
+    cumulative_sum_function = Arrow::Function.find("cumulative_sum")
+    assert_equal(build_int64_array([11, 13, 16]),
+                 cumulative_sum_function.execute(args, @options).value)
+  end
+end
+


### PR DESCRIPTION
### Rationale for this change

The `CumulativeOptions` class is not available in GLib/Ruby, and it is used together with the `cumulative_sum`, `cumulative_prod`, etc compute functions.

### What changes are included in this PR?

This adds the `CumulativeOptions` to GLib.

### Are these changes tested?

Yes, with Ruby unit tests.

### Are there any user-facing changes?

Yes, a new class.
* GitHub Issue: #48364