### PR TITLE
GH-48367: [GLib][Ruby] Add ElementWiseAggregateOptions

### DIFF
--- a/c_glib/arrow-glib/compute.cpp
+++ b/c_glib/arrow-glib/compute.cpp
@@ -261,6 +261,9 @@ G_BEGIN_DECLS
  * #GArrowDictionaryEncodeOptions is a class to customize the `dictionary_encode`
  * function.
  *
+ * #GArrowElementWiseAggregateOptions is a class to customize element-wise
+ * aggregate functions such as `min_element_wise` and `max_element_wise`.
+ *
  * There are many functions to compute data on an array.
  */
 
@@ -6767,6 +6770,105 @@ garrow_dictionary_encode_options_new(void)
   return GARROW_DICTIONARY_ENCODE_OPTIONS(options);
 }
 
+enum {
+  PROP_ELEMENT_WISE_AGGREGATE_OPTIONS_SKIP_NULLS = 1,
+};
+
+G_DEFINE_TYPE(GArrowElementWiseAggregateOptions,
+              garrow_element_wise_aggregate_options,
+              GARROW_TYPE_FUNCTION_OPTIONS)
+
+static void
+garrow_element_wise_aggregate_options_set_property(GObject *object,
+                                                   guint prop_id,
+                                                   const GValue *value,
+                                                   GParamSpec *pspec)
+{
+  auto options = garrow_element_wise_aggregate_options_get_raw(
+    GARROW_ELEMENT_WISE_AGGREGATE_OPTIONS(object));
+
+  switch (prop_id) {
+  case PROP_ELEMENT_WISE_AGGREGATE_OPTIONS_SKIP_NULLS:
+    options->skip_nulls = g_value_get_boolean(value);
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+garrow_element_wise_aggregate_options_get_property(GObject *object,
+                                                   guint prop_id,
+                                                   GValue *value,
+                                                   GParamSpec *pspec)
+{
+  auto options = garrow_element_wise_aggregate_options_get_raw(
+    GARROW_ELEMENT_WISE_AGGREGATE_OPTIONS(object));
+
+  switch (prop_id) {
+  case PROP_ELEMENT_WISE_AGGREGATE_OPTIONS_SKIP_NULLS:
+    g_value_set_boolean(value, options->skip_nulls);
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+garrow_element_wise_aggregate_options_init(GArrowElementWiseAggregateOptions *object)
+{
+  auto priv = GARROW_FUNCTION_OPTIONS_GET_PRIVATE(object);
+  priv->options = static_cast<arrow::compute::FunctionOptions *>(
+    new arrow::compute::ElementWiseAggregateOptions());
+}
+
+static void
+garrow_element_wise_aggregate_options_class_init(
+  GArrowElementWiseAggregateOptionsClass *klass)
+{
+  auto gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->set_property = garrow_element_wise_aggregate_options_set_property;
+  gobject_class->get_property = garrow_element_wise_aggregate_options_get_property;
+
+  arrow::compute::ElementWiseAggregateOptions options;
+
+  GParamSpec *spec;
+  /**
+   * GArrowElementWiseAggregateOptions:skip-nulls:
+   *
+   * Whether to skip (ignore) nulls in the input.
+   * If false, any null in the input forces the output to null.
+   *
+   * Since: 23.0.0
+   */
+  spec = g_param_spec_boolean("skip-nulls",
+                              "Skip nulls",
+                              "Whether to skip (ignore) nulls in the input. If false, "
+                              "any null in the input forces the output to null",
+                              options.skip_nulls,
+                              static_cast<GParamFlags>(G_PARAM_READWRITE));
+  g_object_class_install_property(gobject_class,
+                                  PROP_ELEMENT_WISE_AGGREGATE_OPTIONS_SKIP_NULLS,
+                                  spec);
+}
+
+/**
+ * garrow_element_wise_aggregate_options_new:
+ *
+ * Returns: A newly created #GArrowElementWiseAggregateOptions.
+ *
+ * Since: 23.0.0
+ */
+GArrowElementWiseAggregateOptions *
+garrow_element_wise_aggregate_options_new(void)
+{
+  auto options = g_object_new(GARROW_TYPE_ELEMENT_WISE_AGGREGATE_OPTIONS, NULL);
+  return GARROW_ELEMENT_WISE_AGGREGATE_OPTIONS(options);
+}
+
 G_END_DECLS
 
 arrow::Result<arrow::FieldRef>
@@ -6913,6 +7015,12 @@ garrow_function_options_new_raw(const arrow::compute::FunctionOptions *arrow_opt
       static_cast<const arrow::compute::DictionaryEncodeOptions *>(arrow_options);
     auto options =
       garrow_dictionary_encode_options_new_raw(arrow_dictionary_encode_options);
+    return GARROW_FUNCTION_OPTIONS(options);
+  } else if (arrow_type_name == "ElementWiseAggregateOptions") {
+    const auto arrow_element_wise_aggregate_options =
+      static_cast<const arrow::compute::ElementWiseAggregateOptions *>(arrow_options);
+    auto options =
+      garrow_element_wise_aggregate_options_new_raw(arrow_element_wise_aggregate_options);
     return GARROW_FUNCTION_OPTIONS(options);
   } else {
     auto options = g_object_new(GARROW_TYPE_FUNCTION_OPTIONS, NULL);
@@ -7498,5 +7606,23 @@ arrow::compute::DictionaryEncodeOptions *
 garrow_dictionary_encode_options_get_raw(GArrowDictionaryEncodeOptions *options)
 {
   return static_cast<arrow::compute::DictionaryEncodeOptions *>(
+    garrow_function_options_get_raw(GARROW_FUNCTION_OPTIONS(options)));
+}
+
+GArrowElementWiseAggregateOptions *
+garrow_element_wise_aggregate_options_new_raw(
+  const arrow::compute::ElementWiseAggregateOptions *arrow_options)
+{
+  return GARROW_ELEMENT_WISE_AGGREGATE_OPTIONS(
+    g_object_new(GARROW_TYPE_ELEMENT_WISE_AGGREGATE_OPTIONS,
+                 "skip-nulls",
+                 arrow_options->skip_nulls,
+                 NULL));
+}
+
+arrow::compute::ElementWiseAggregateOptions *
+garrow_element_wise_aggregate_options_get_raw(GArrowElementWiseAggregateOptions *options)
+{
+  return static_cast<arrow::compute::ElementWiseAggregateOptions *>(
     garrow_function_options_get_raw(GARROW_FUNCTION_OPTIONS(options)));
 }

--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -1223,4 +1223,21 @@ GARROW_AVAILABLE_IN_23_0
 GArrowDictionaryEncodeOptions *
 garrow_dictionary_encode_options_new(void);
 
+#define GARROW_TYPE_ELEMENT_WISE_AGGREGATE_OPTIONS                                       \
+  (garrow_element_wise_aggregate_options_get_type())
+GARROW_AVAILABLE_IN_23_0
+G_DECLARE_DERIVABLE_TYPE(GArrowElementWiseAggregateOptions,
+                         garrow_element_wise_aggregate_options,
+                         GARROW,
+                         ELEMENT_WISE_AGGREGATE_OPTIONS,
+                         GArrowFunctionOptions)
+struct _GArrowElementWiseAggregateOptionsClass
+{
+  GArrowFunctionOptionsClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_23_0
+GArrowElementWiseAggregateOptions *
+garrow_element_wise_aggregate_options_new(void);
+
 G_END_DECLS

--- a/c_glib/arrow-glib/compute.hpp
+++ b/c_glib/arrow-glib/compute.hpp
@@ -192,3 +192,9 @@ garrow_dictionary_encode_options_new_raw(
   const arrow::compute::DictionaryEncodeOptions *arrow_options);
 arrow::compute::DictionaryEncodeOptions *
 garrow_dictionary_encode_options_get_raw(GArrowDictionaryEncodeOptions *options);
+
+GArrowElementWiseAggregateOptions *
+garrow_element_wise_aggregate_options_new_raw(
+  const arrow::compute::ElementWiseAggregateOptions *arrow_options);
+arrow::compute::ElementWiseAggregateOptions *
+garrow_element_wise_aggregate_options_get_raw(GArrowElementWiseAggregateOptions *options);

--- a/c_glib/test/test-element-wise-aggregate-options.rb
+++ b/c_glib/test/test-element-wise-aggregate-options.rb
@@ -1,0 +1,45 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestElementWiseAggregateOptions < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def setup
+    @options = Arrow::ElementWiseAggregateOptions.new
+  end
+
+  def test_skip_nulls_property
+    assert do
+      @options.skip_nulls?
+    end
+    @options.skip_nulls = false
+    assert do
+      !@options.skip_nulls?
+    end
+  end
+
+  def test_min_element_wise_function_with_skip_nulls_false
+    args = [
+      Arrow::ArrayDatum.new(build_int64_array([1, nil, 3])),
+      Arrow::ArrayDatum.new(build_int64_array([4, 1, 5])),
+    ]
+    @options.skip_nulls = false
+    min_element_wise_function = Arrow::Function.find("min_element_wise")
+    assert_equal(build_int64_array([1, nil, 3]),
+                 min_element_wise_function.execute(args, @options).value)
+  end
+end


### PR DESCRIPTION
### Rationale for this change

The `ElementWiseAggregateOptions` class is not available in GLib/Ruby, and it is used together with the `min_element_wise` and `max_element_wise` compute functions.

### What changes are included in this PR?

This adds the `ElementWiseAggregateOptions` class to GLib.

### Are these changes tested?

Yes, with Ruby unit tests.

### Are there any user-facing changes?

Yes, a new class.
* GitHub Issue: #48367