### PR TITLE
GH-48368: [GLib][Ruby] Add ExtractRegexOptions

### DIFF
--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -1256,4 +1256,20 @@ GARROW_AVAILABLE_IN_23_0
 GArrowDayOfWeekOptions *
 garrow_day_of_week_options_new(void);
 
+#define GARROW_TYPE_EXTRACT_REGEX_OPTIONS (garrow_extract_regex_options_get_type())
+GARROW_AVAILABLE_IN_23_0
+G_DECLARE_DERIVABLE_TYPE(GArrowExtractRegexOptions,
+                         garrow_extract_regex_options,
+                         GARROW,
+                         EXTRACT_REGEX_OPTIONS,
+                         GArrowFunctionOptions)
+struct _GArrowExtractRegexOptionsClass
+{
+  GArrowFunctionOptionsClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_23_0
+GArrowExtractRegexOptions *
+garrow_extract_regex_options_new(void);
+
 G_END_DECLS

--- a/c_glib/arrow-glib/compute.hpp
+++ b/c_glib/arrow-glib/compute.hpp
@@ -203,3 +203,9 @@ GArrowDayOfWeekOptions *
 garrow_day_of_week_options_new_raw(const arrow::compute::DayOfWeekOptions *arrow_options);
 arrow::compute::DayOfWeekOptions *
 garrow_day_of_week_options_get_raw(GArrowDayOfWeekOptions *options);
+
+GArrowExtractRegexOptions *
+garrow_extract_regex_options_new_raw(
+  const arrow::compute::ExtractRegexOptions *arrow_options);
+arrow::compute::ExtractRegexOptions *
+garrow_extract_regex_options_get_raw(GArrowExtractRegexOptions *options);

--- a/c_glib/test/test-extract-regex-options.rb
+++ b/c_glib/test/test-extract-regex-options.rb
@@ -40,8 +40,6 @@ class TestExtractRegexOptions < Test::Unit::TestCase
                Arrow::Field.new("month", Arrow::StringDataType.new),
                Arrow::Field.new("day", Arrow::StringDataType.new),
              ]
-    assert_equal(Arrow::StructDataType.new(fields),
-                 result.value_data_type)
     assert_equal(build_struct_array(fields, [
                    {"year" => "2023", "month" => "01", "day" => "15"},
                    {"year" => "2024", "month" => "12", "day" => "31"},

--- a/c_glib/test/test-extract-regex-options.rb
+++ b/c_glib/test/test-extract-regex-options.rb
@@ -1,0 +1,51 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestExtractRegexOptions < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def setup
+    @options = Arrow::ExtractRegexOptions.new
+  end
+
+  def test_pattern_property
+    assert_equal("", @options.pattern)
+    @options.pattern = "(?P<year>\\d{4})-(?P<month>\\d{2})"
+    assert_equal("(?P<year>\\d{4})-(?P<month>\\d{2})", @options.pattern)
+  end
+
+  def test_extract_regex_function
+    args = [
+      Arrow::ArrayDatum.new(build_string_array(["2023-01-15", "2024-12-31"])),
+    ]
+    @options.pattern = "(?P<year>\\d{4})-(?P<month>\\d{2})-(?P<day>\\d{2})"
+    extract_regex_function = Arrow::Function.find("extract_regex")
+    result = extract_regex_function.execute(args, @options).value
+    fields = [
+               Arrow::Field.new("year", Arrow::StringDataType.new),
+               Arrow::Field.new("month", Arrow::StringDataType.new),
+               Arrow::Field.new("day", Arrow::StringDataType.new),
+             ]
+    assert_equal(Arrow::StructDataType.new(fields),
+                 result.value_data_type)
+    assert_equal(build_struct_array(fields, [
+                   {"year" => "2023", "month" => "01", "day" => "15"},
+                   {"year" => "2024", "month" => "12", "day" => "31"},
+                 ]),
+                 result)
+  end
+end


### PR DESCRIPTION
### Rationale for this change

The `ExtractRegexOptions` class is not available in GLib/Ruby, and it is used together with the `extract_regex` compute function.

### What changes are included in this PR?

This adds the `ExtractRegexOptions` class to GLib.

### Are these changes tested?

Yes, with Ruby unit tests.

### Are there any user-facing changes?

Yes, a new class.
* GitHub Issue: #48368