### PR TITLE
GH-48380: [Ruby] Add support for reading float64 array

### DIFF
--- a/ruby/red-arrow-format/lib/arrow-format/array.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/array.rb
@@ -91,16 +91,22 @@ module ArrowFormat
     end
   end
 
-  class FloatArray < Array
+  class FloatingPointArray < Array
     def initialize(type, size, validity_buffer, values_buffer)
       super(type, size, validity_buffer)
       @values_buffer = values_buffer
     end
   end
 
-  class Float32Array < FloatArray
+  class Float32Array < FloatingPointArray
     def to_a
       apply_validity(@values_buffer.values(:f32, 0, @size))
+    end
+  end
+
+  class Float64Array < FloatingPointArray
+    def to_a
+      apply_validity(@values_buffer.values(:f64, 0, @size))
     end
   end
 

--- a/ruby/red-arrow-format/lib/arrow-format/file-reader.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/file-reader.rb
@@ -154,6 +154,8 @@ module ArrowFormat
         case fb_type.precision
         when Org::Apache::Arrow::Flatbuf::Precision::SINGLE
           type = Float32Type.singleton
+        when Org::Apache::Arrow::Flatbuf::Precision::DOUBLE
+          type = Float64Type.singleton
         end
       when Org::Apache::Arrow::Flatbuf::List
         type = ListType.new(read_field(fb_field.children[0]))
@@ -189,8 +191,7 @@ module ArrowFormat
 
       case field.type
       when BooleanType,
-           IntType,
-           FloatType
+           NumberType
         values_buffer = buffers.shift
         values = body.slice(values_buffer.offset, values_buffer.length)
         field.type.build_array(length, validity, values)

--- a/ruby/red-arrow-format/lib/arrow-format/type.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/type.rb
@@ -54,7 +54,10 @@ module ArrowFormat
     end
   end
 
-  class IntType < Type
+  class NumberType < Type
+  end
+
+  class IntType < NumberType
     attr_reader :bit_width
     attr_reader :signed
     def initialize(name, bit_width, signed)
@@ -96,7 +99,7 @@ module ArrowFormat
     end
   end
 
-  class FloatType < Type
+  class FloatingPointType < NumberType
     attr_reader :precision
     def initialize(name, precision)
       super(name)
@@ -104,7 +107,7 @@ module ArrowFormat
     end
   end
 
-  class Float32Type < FloatType
+  class Float32Type < FloatingPointType
     class << self
       def singleton
         @singleton ||= new
@@ -112,11 +115,27 @@ module ArrowFormat
     end
 
     def initialize
-      super("Float32", 32)
+      super("Float32", :single)
     end
 
     def build_array(size, validity_buffer, values_buffer)
       Float32Array.new(self, size, validity_buffer, values_buffer)
+    end
+  end
+
+  class Float64Type < FloatingPointType
+    class << self
+      def singleton
+        @singleton ||= new
+      end
+    end
+
+    def initialize
+      super("Float64", :double)
+    end
+
+    def build_array(size, validity_buffer, values_buffer)
+      Float64Array.new(self, size, validity_buffer, values_buffer)
     end
   end
 


### PR DESCRIPTION
### Rationale for this change

It's the second floating point array.

### What changes are included in this PR?

* Add `ArrowFromat::Float64Type`
* Add `ArrowFormat::Float64Array`

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #48380