### PR TITLE
GH-48382: [Ruby] Add support for reading struct array

### DIFF
--- a/ruby/red-arrow-format/lib/arrow-format/array.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/array.rb
@@ -174,4 +174,21 @@ module ArrowFormat
       apply_validity(values)
     end
   end
+
+  class StructArray < Array
+    def initialize(type, size, validity_buffer, children)
+      super(type, size, validity_buffer)
+      @children = children
+    end
+
+    def to_a
+      if @children.empty?
+        values = [[]] * @size
+      else
+        children_values = @children.collect(&:to_a)
+        values = children_values[0].zip(*children_values[1..-1])
+      end
+      apply_validity(values)
+    end
+  end
 end

--- a/ruby/red-arrow-format/lib/arrow-format/type.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/type.rb
@@ -187,4 +187,16 @@ module ArrowFormat
       ListArray.new(self, size, validity_buffer, offsets_buffer, child)
     end
   end
+
+  class StructType < Type
+    attr_reader :children
+    def initialize(children)
+      super("Struct")
+      @children = children
+    end
+
+    def build_array(size, validity_buffer, children)
+      StructArray.new(self, size, validity_buffer, children)
+    end
+  end
 end

--- a/ruby/red-arrow-format/test/test-file-reader.rb
+++ b/ruby/red-arrow-format/test/test-file-reader.rb
@@ -139,4 +139,25 @@ class TestFileReader < Test::Unit::TestCase
                    read)
     end
   end
+
+  sub_test_case("Struct") do
+    def build_array
+      data_type = Arrow::StructDataType.new(count: :int8,
+                                            visible: :boolean)
+      Arrow::StructArray.new(data_type, [[-128, nil], nil, [nil, true]])
+    end
+
+    def test_read
+      assert_equal([
+                     {
+                       "value" => [
+                         [-128, nil],
+                         nil,
+                         [nil, true],
+                       ],
+                     },
+                   ],
+                   read)
+    end
+  end
 end


### PR DESCRIPTION
### Rationale for this change

It's a nested array.

### What changes are included in this PR?

* Add `ArrowFormat::StructType`
* Add `ArrowFormat::StructArray`

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.

* GitHub Issue: #48382