### PR TITLE
GH-48384: [C++][Docs][Parquet] Fix broken link for parquet-format spec

### DIFF
--- a/cpp/src/parquet/encoder.cc
+++ b/cpp/src/parquet/encoder.cc
@@ -448,7 +448,7 @@ int64_t RlePreserveBufferSize(int64_t num_values, int bit_width) {
 }
 
 /// See the dictionary encoding section of
-/// https://github.com/Parquet/parquet-format.  The encoding supports
+/// https://github.com/apache/parquet-format/blob/master/Encodings.md.  The encoding supports
 /// streaming encoding. Values are encoded as they are added while the
 /// dictionary is being constructed. At any time, the buffered values
 /// can be written out with the current dictionary size. More values

--- a/cpp/src/parquet/encoder.cc
+++ b/cpp/src/parquet/encoder.cc
@@ -448,12 +448,11 @@ int64_t RlePreserveBufferSize(int64_t num_values, int bit_width) {
 }
 
 /// See the dictionary encoding section of
-/// https://github.com/apache/parquet-format/blob/master/Encodings.md.  The encoding supports
-/// streaming encoding. Values are encoded as they are added while the
-/// dictionary is being constructed. At any time, the buffered values
-/// can be written out with the current dictionary size. More values
-/// can then be added to the encoder, including new dictionary
-/// entries.
+/// https://github.com/apache/parquet-format/blob/master/Encodings.md.  The encoding
+/// supports streaming encoding. Values are encoded as they are added while the dictionary
+/// is being constructed. At any time, the buffered values can be written out with the
+/// current dictionary size. More values can then be added to the encoder, including new
+/// dictionary entries.
 template <typename DType>
 class DictEncoderImpl : public EncoderImpl, virtual public DictEncoder<DType> {
   using MemoTableType = typename DictEncoderTraits<DType>::MemoTableType;


### PR DESCRIPTION
### Rationale for this change:
 - Broken link for dictionary spec for parquet.
 - Fixes the same

### What changes are included in this PR?
 - Same as above

### Are these changes tested?
 - Yes, CI
 
### Are there any user-facing changes?
 - Yes, doc update
* GitHub Issue: #48384