### PR TITLE
GH-48388: [Ruby] Add support for reading map array

### DIFF
--- a/ruby/red-arrow-format/lib/arrow-format/array.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/array.rb
@@ -162,7 +162,7 @@ module ArrowFormat
     end
   end
 
-  class ListArray < Array
+  class VariableSizeListArray < Array
     def initialize(type, size, validity_buffer, offsets_buffer, child)
       super(type, size, validity_buffer)
       @offsets_buffer = offsets_buffer
@@ -181,6 +181,9 @@ module ArrowFormat
     end
   end
 
+  class ListArray < VariableSizeListArray
+  end
+
   class StructArray < Array
     def initialize(type, size, validity_buffer, children)
       super(type, size, validity_buffer)
@@ -195,6 +198,22 @@ module ArrowFormat
         values = children_values[0].zip(*children_values[1..-1])
       end
       apply_validity(values)
+    end
+  end
+
+  class MapArray < VariableSizeListArray
+    def to_a
+      super.collect do |entries|
+        if entries.nil?
+          entries
+        else
+          hash = {}
+          entries.each do |key, value|
+            hash[key] = value
+          end
+          hash
+        end
+      end
     end
   end
 end

--- a/ruby/red-arrow-format/lib/arrow-format/error.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/error.rb
@@ -18,11 +18,14 @@ module ArrowFormat
   class Error < StandardError
   end
 
-  class ReadError < StandardError
+  class ReadError < Error
     attr_reader :buffer
     def initialize(buffer, message)
       @buffer = buffer
       super("#{message}: #{@buffer}")
     end
+  end
+
+  class TypeError < Error
   end
 end

--- a/ruby/red-arrow-format/lib/arrow-format/field.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/field.rb
@@ -18,9 +18,14 @@ module ArrowFormat
   class Field
     attr_reader :name
     attr_reader :type
-    def initialize(name, type)
+    def initialize(name, type, nullable)
       @name = name
       @type = type
+      @nullable = nullable
+    end
+
+    def nullable?
+      @nullable
     end
   end
 end

--- a/ruby/red-arrow-format/test/test-file-reader.rb
+++ b/ruby/red-arrow-format/test/test-file-reader.rb
@@ -160,4 +160,29 @@ class TestFileReader < Test::Unit::TestCase
                    read)
     end
   end
+
+  sub_test_case("Map") do
+    def build_array
+      data_type = Arrow::MapDataType.new(:string, :int8)
+      Arrow::MapArray.new(data_type,
+                          [
+                            {"a" => -128, "b" => 127},
+                            nil,
+                            {"c" => nil},
+                          ])
+    end
+
+    def test_read
+      assert_equal([
+                     {
+                       "value" => [
+                         {"a" => -128, "b" => 127},
+                         nil,
+                         {"c" => nil},
+                       ],
+                     },
+                   ],
+                   read)
+    end
+  end
 end


### PR DESCRIPTION
### Rationale for this change

It's a list of struct array.

### What changes are included in this PR?

* Add `ArrowFormat::MapType`
* Add `ArrowFormat::MapArray`

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #48388