### PR TITLE
MINOR: [Docs] Change Conda PyArrow badge to Anaconda's official one

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -19,7 +19,7 @@
 
 ## Python library for Apache Arrow
 
-[![pypi](https://img.shields.io/pypi/v/pyarrow.svg)](https://pypi.org/project/pyarrow/) [![conda-forge](https://img.shields.io/conda/vn/conda-forge/pyarrow.svg)](https://anaconda.org/conda-forge/pyarrow)
+[![pypi](https://img.shields.io/pypi/v/pyarrow.svg)](https://pypi.org/project/pyarrow/) [![conda-forge](https://anaconda.org/conda-forge/pyarrow/badges/version.svg)](https://anaconda.org/conda-forge/pyarrow)
 
 This library provides a Python API for functionality provided by the Arrow C++
 libraries, along with tools for Arrow integration and interoperability with


### PR DESCRIPTION
### Rationale for this change

`shields.io` for pyarrow is broken for some reasons for last few days specifically for several packages with failing a request timeout:

<img width="425" height="116" alt="Screenshot 2025-12-08 at 7 09 02 AM" src="https://github.com/user-attachments/assets/cca495d5-e34f-491e-95d0-b8595c306e60" />

Instead of relying on the thirdparty project, we should better use the official ones provided by Anaconda in https://anaconda.org/conda-forge/pyarrow/badges

### What changes are included in this PR?

Changes the URI for Conda badge to use the official one provided in Anaconda (https://anaconda.org/conda-forge/pyarrow/badges).

### Are these changes tested?

Yes, manually tested via my browser.

### Are there any user-facing changes?

No.