### PR TITLE
GH-48386: [Ruby][Dev] Enable Layout/TrailingEmptyLines: final_newline cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,3 +31,6 @@ Layout/ArgumentAlignment:
 
 Layout/SpaceAfterComma:
   Enabled: true
+
+Layout/TrailingEmptyLines:
+  Enabled: true

--- a/c_glib/test/test-assume-timezone-options.rb
+++ b/c_glib/test/test-assume-timezone-options.rb
@@ -58,4 +58,3 @@ class TestAssumeTimezoneOptions < Test::Unit::TestCase
                  result.value_data_type)
   end
 end
-

--- a/c_glib/test/test-cumulative-options.rb
+++ b/c_glib/test/test-cumulative-options.rb
@@ -61,4 +61,3 @@ class TestCumulativeOptions < Test::Unit::TestCase
                  cumulative_sum_function.execute(args, @options).value)
   end
 end
-

--- a/c_glib/test/test-dictionary-encode-options.rb
+++ b/c_glib/test/test-dictionary-encode-options.rb
@@ -43,4 +43,3 @@ class TestDictionaryEncodeOptions < Test::Unit::TestCase
     assert_equal(build_int32_array([0, 1, 2, 0, 1]), result.indices)
   end
 end
-


### PR DESCRIPTION
### Rationale for this change

This fix introduces new Ruby formatting checks to streamline multi-person development.

### What changes are included in this PR?

Enable [`Layout/TrailingEmptyLines`](https://docs.rubocop.org/rubocop/cops_layout.html#layouttrailingemptylines) options

```ruby
# `final_newline` looks for one newline at the end of files.

# bad
class Foo; end

# EOF

# bad
class Foo; end # EOF

# good
class Foo; end
# EOF
```

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #48386