### PR TITLE
GH-48395: [C++][Dev] Update fuzzing CMake preset

### DIFF
--- a/cpp/CMakePresets.json
+++ b/cpp/CMakePresets.json
@@ -440,20 +440,20 @@
       ],
       "displayName": "Debug build with IPC and Parquet fuzzing targets",
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Debug",
-        "CMAKE_C_COMPILER": "clang",
-        "CMAKE_CXX_COMPILER": "clang++",
-        "ARROW_DEPENDENCY_SOURCE": "BUNDLED",
         "ARROW_CSV": "ON",
+        "ARROW_DEPENDENCY_SOURCE": "BUNDLED",
+        "ARROW_FUZZING": "ON",
         "ARROW_IPC": "ON",
         "ARROW_PARQUET": "ON",
-        "PARQUET_REQUIRE_ENCRYPTION": "ON",
-        "ARROW_FUZZING": "ON",
         "ARROW_WITH_BROTLI": "ON",
         "ARROW_WITH_LZ4": "ON",
         "ARROW_WITH_SNAPPY": "ON",
         "ARROW_WITH_ZLIB": "ON",
-        "ARROW_WITH_ZSTD": "ON"
+        "ARROW_WITH_ZSTD": "ON",
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_C_COMPILER": "clang",
+        "CMAKE_CXX_COMPILER": "clang++",
+        "PARQUET_REQUIRE_ENCRYPTION": "ON"
       }
     },
     {

--- a/cpp/CMakePresets.json
+++ b/cpp/CMakePresets.json
@@ -443,10 +443,17 @@
         "CMAKE_BUILD_TYPE": "Debug",
         "CMAKE_C_COMPILER": "clang",
         "CMAKE_CXX_COMPILER": "clang++",
+        "ARROW_DEPENDENCY_SOURCE": "BUNDLED",
+        "ARROW_CSV": "ON",
         "ARROW_IPC": "ON",
         "ARROW_PARQUET": "ON",
+        "PARQUET_REQUIRE_ENCRYPTION": "ON",
         "ARROW_FUZZING": "ON",
-        "ARROW_WITH_SNAPPY": "ON"
+        "ARROW_WITH_BROTLI": "ON",
+        "ARROW_WITH_LZ4": "ON",
+        "ARROW_WITH_SNAPPY": "ON",
+        "ARROW_WITH_ZLIB": "ON",
+        "ARROW_WITH_ZSTD": "ON"
       }
     },
     {


### PR DESCRIPTION
### Rationale for this change

We have more features enabled on our fuzzing setup but we haven't updated the corresponding CMake preset.

### Are these changes tested?

Manually.

### Are there any user-facing changes?

No.

* GitHub Issue: #48395