### PR TITLE
GH-48400: [Python] Convert an old todo to a proper ticket in `test_copy_files_directory`

### DIFF
--- a/python/pyarrow/tests/test_fs.py
+++ b/python/pyarrow/tests/test_fs.py
@@ -2044,7 +2044,6 @@ def test_copy_files_directory(tempdir):
 
     # Copy directory with local file paths
     destination_dir1 = tempdir / "destination1"
-    # TODO need to create?
     destination_dir1.mkdir()
     copy_files(str(source_dir), str(destination_dir1))
     check_copied_files(destination_dir1)


### PR DESCRIPTION
### Rationale for this change

There is a legacy TODO as below:

https://github.com/apache/arrow/blob/06148950fb895bb947b2d0e4cb98d5bc455396a0/python/pyarrow/tests/test_fs.py#L1626

The test fails with:

```
__________________________ test_copy_files_directory ___________________________

tempdir = PosixPath('/tmp/pytest-of-root/pytest-0/test_copy_files_directory0')

    def test_copy_files_directory(tempdir):
        localfs = LocalFileSystem()
    
        # create source directory with 2 files
        source_dir = tempdir / "source"
        source_dir.mkdir()
        with localfs.open_output_stream(str(source_dir / "file1")) as f:
            f.write(b'test1')
        with localfs.open_output_stream(str(source_dir / "file2")) as f:
            f.write(b'test2')
    
        def check_copied_files(destination_dir):
            with localfs.open_input_stream(str(destination_dir / "file1")) as f:
                assert f.read() == b"test1"
            with localfs.open_input_stream(str(destination_dir / "file2")) as f:
                assert f.read() == b"test2"
    
        # Copy directory with local file paths
        # copy_files automatically creates destination directories when copying directories
        destination_dir1 = tempdir / "destination1"
>       copy_files(str(source_dir), str(destination_dir1))

opt/conda/envs/arrow/lib/python3.10/site-packages/pyarrow/tests/test_fs.py:2048: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
opt/conda/envs/arrow/lib/python3.10/site-packages/pyarrow/fs.py:256: in copy_files
    _copy_files_selector(source_fs, source_sel,
pyarrow/_fs.pyx:1649: in pyarrow._fs._copy_files_selector
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

>   ???
E   FileNotFoundError: [Errno 2] Failed to open local file '/tmp/pytest-of-root/pytest-0/test_copy_files_directory0/destination1/file1'. Detail: [errno 2] No such file or directory
```

Should better have an explicit ticket for this instead of having a todo that could be easily misleading (just like what happened in this PR).

### What changes are included in this PR?

This PR converts the TODO to a ticket (https://github.com/apache/arrow/issues/48436) in `test_copy_files_directory`

### Are these changes tested?

Manually.

### Are there any user-facing changes?

No.
* GitHub Issue: #48400