### PR TITLE
GH-48402: [Python] Enable the relative path in test_write_dataset

### DIFF
--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -4225,12 +4225,12 @@ def test_write_dataset(tempdir):
     expected_files = [target / "part-0.arrow"]
     _check_dataset_roundtrip(dataset, target, expected_files, 'a', target)
 
-    # TODO
-    # # relative path
-    # target = tempdir / 'single-file-target3'
-    # expected_files = [target / "part-0.ipc"]
-    # _check_dataset_roundtrip(
-    #     dataset, './single-file-target3', expected_files, target)
+    # relative path
+    target = tempdir / 'single-file-target3'
+    expected_files = [target / "part-0.arrow"]
+    with change_cwd(tempdir):
+        _check_dataset_roundtrip(
+            dataset, './single-file-target3', expected_files, 'a', target)
 
     # Directory of files
     directory = tempdir / 'single-directory'


### PR DESCRIPTION
### Rationale for this change

Enable a test that is intended so.

### What changes are included in this PR?

This PR proposes to enable the relative path in `test_write_dataset` with `pyarrow.tests.util.change_cwd`.

### Are these changes tested?

Manually tested with `pytest -k "test_write_dataset"`

### Are there any user-facing changes?

No, test-only.

* GitHub Issue: #48402