### PR TITLE
GH-48404: [Python] Add tests to to_table(filter=...) to reject a boolean expr

### DIFF
--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -432,7 +432,14 @@ def test_dataset(dataset, dataset_reader):
     assert isinstance(dataset, ds.Dataset)
     assert isinstance(dataset.schema, pa.Schema)
 
-    # TODO(kszucs): test non-boolean Exprs for filter do raise
+    non_boolean_expr = ds.field('i64')
+    with pytest.raises(TypeError, match="must evaluate to bool"):
+        dataset.to_table(filter=non_boolean_expr)
+
+    non_boolean_expr2 = ds.field('i64') + 1
+    with pytest.raises(TypeError, match="must evaluate to bool"):
+        dataset.to_table(filter=non_boolean_expr2)
+
     expected_i64 = pa.array([0, 1, 2, 3, 4], type=pa.int64())
     expected_f64 = pa.array([0, 1, 2, 3, 4], type=pa.float64())
 


### PR DESCRIPTION
### Rationale for this change

- In order to remove the legacy TODO (from https://github.com/apache/arrow/commit/9cb49f3d34dde8d28ac2eb921c4540eada2b19a2)
- To test non-boolean expressions to be rejected in the filter

### What changes are included in this PR?

Added a couple of tests for non-boolean expressions at filter in to_table

### Are these changes tested?

Yes, locally via `pytest pyarrow/tests/test_dataset.py`.

### Are there any user-facing changes?

No, test-only.
* GitHub Issue: #48404