### PR TITLE
GH-48406: [Python] Negative test for struct_field no-argument (ARROW-14853)

### DIFF
--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -3419,8 +3419,8 @@ def test_struct_fields_options():
     with pytest.raises(pa.ArrowInvalid, match="No match for FieldRef"):
         pc.struct_field(arr, '.a.foo')
 
-    # TODO: https://issues.apache.org/jira/browse/ARROW-14853
-    # assert pc.struct_field(arr) == arr
+    with pytest.raises(pa.ArrowInvalid, match="cannot be called without options"):
+        pc.struct_field(arr)
 
 
 def test_case_when():


### PR DESCRIPTION
### Rationale for this change

Seems like it is decided to make the error message better explicitly in ARROW-14853 and https://github.com/apache/arrow/pull/11961

Therefore, this test can be converted to the negative test.
https://github.com/apache/arrow/blob/2a3c5db7900028fbdf54a4162ce6c5b3f6e9f8e4/python/pyarrow/tests/test_compute.py#L3423 

### What changes are included in this PR?

This PR proposes to add a negative test.

### Are these changes tested?

Yes, via `python -m pytest pyarrow/tests/test_compute.py::test_struct_fields_options -v`

### Are there any user-facing changes?

No, test-only.

* GitHub Issue: #48406