### PR TITLE
GH-48412: [Ruby] Add support for reading date32 array

### DIFF
--- a/ruby/red-arrow-format/lib/arrow-format/array.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/array.rb
@@ -110,6 +110,19 @@ module ArrowFormat
     end
   end
 
+  class DateArray < Array
+    def initialize(type, size, validity_buffer, values_buffer)
+      super(type, size, validity_buffer)
+      @values_buffer = values_buffer
+    end
+  end
+
+  class Date32Array < DateArray
+    def to_a
+      apply_validity(@values_buffer.values(:s32, 0, @size))
+    end
+  end
+
   class VariableSizeBinaryLayoutArray < Array
     def initialize(type, size, validity_buffer, offsets_buffer, values_buffer)
       super(type, size, validity_buffer)

--- a/ruby/red-arrow-format/lib/arrow-format/file-reader.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/file-reader.rb
@@ -24,6 +24,8 @@ require_relative "type"
 
 require_relative "org/apache/arrow/flatbuf/binary"
 require_relative "org/apache/arrow/flatbuf/bool"
+require_relative "org/apache/arrow/flatbuf/date"
+require_relative "org/apache/arrow/flatbuf/date_unit"
 require_relative "org/apache/arrow/flatbuf/floating_point"
 require_relative "org/apache/arrow/flatbuf/footer"
 require_relative "org/apache/arrow/flatbuf/int"
@@ -159,6 +161,11 @@ module ArrowFormat
         when Org::Apache::Arrow::Flatbuf::Precision::DOUBLE
           type = Float64Type.singleton
         end
+      when Org::Apache::Arrow::Flatbuf::Date
+        case fb_type.unit
+        when Org::Apache::Arrow::Flatbuf::DateUnit::DAY
+          type = Date32Type.singleton
+        end
       when Org::Apache::Arrow::Flatbuf::List
         type = ListType.new(read_field(fb_field.children[0]))
       when Org::Apache::Arrow::Flatbuf::Struct
@@ -198,7 +205,8 @@ module ArrowFormat
 
       case field.type
       when BooleanType,
-           NumberType
+           NumberType,
+           DateType
         values_buffer = buffers.shift
         values = body.slice(values_buffer.offset, values_buffer.length)
         field.type.build_array(length, validity, values)

--- a/ruby/red-arrow-format/lib/arrow-format/type.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/type.rb
@@ -139,6 +139,25 @@ module ArrowFormat
     end
   end
 
+  class DateType < Type
+  end
+
+  class Date32Type < DateType
+    class << self
+      def singleton
+        @singleton ||= new
+      end
+    end
+
+    def initialize
+      super("Date32")
+    end
+
+    def build_array(size, validity_buffer, values_buffer)
+      Date32Array.new(self, size, validity_buffer, values_buffer)
+    end
+  end
+
   class VariableSizeBinaryType < Type
   end
 

--- a/ruby/red-arrow-format/test/test-file-reader.rb
+++ b/ruby/red-arrow-format/test/test-file-reader.rb
@@ -95,6 +95,34 @@ class TestFileReader < Test::Unit::TestCase
     end
   end
 
+  sub_test_case("Float64") do
+    def build_array
+      Arrow::DoubleArray.new([-0.5, nil, 0.5])
+    end
+
+    def test_read
+      assert_equal([{"value" => [-0.5, nil, 0.5]}],
+                   read)
+    end
+  end
+
+  sub_test_case("Date32") do
+    def setup(&block)
+      @date_2017_08_28 = 17406
+      @date_2025_12_09 = 20431
+      super(&block)
+    end
+
+    def build_array
+      Arrow::Date32Array.new([@date_2017_08_28, nil, @date_2025_12_09])
+    end
+
+    def test_read
+      assert_equal([{"value" => [@date_2017_08_28, nil, @date_2025_12_09]}],
+                   read)
+    end
+  end
+
   sub_test_case("Binary") do
     def build_array
       Arrow::BinaryArray.new(["Hello".b, nil, "World".b])


### PR DESCRIPTION
### Rationale for this change

It's a day variant of date array.

### What changes are included in this PR?

* Add `ArrowFormat::Date32Type`
* Add `ArrowFormat::Date32Array`
* Add a missing test for float64 array (This is not related. Sorry.)

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #48412