### PR TITLE
GH-48433: [C++] Use NDEBUG to fix linkage to abseil libraries

### DIFF
--- a/cpp/examples/arrow/flight_grpc_example.cc
+++ b/cpp/examples/arrow/flight_grpc_example.cc
@@ -22,6 +22,27 @@
 #include <arrow/api.h>
 #include <arrow/flight/api.h>
 #include <gflags/gflags.h>
+
+// HACK: Workaround absl::Mutex ABI incompatibility by making sure the
+// non-debug version of Abseil is included
+// (https://github.com/conda-forge/abseil-cpp-feedstock/issues/104,
+//  https://github.com/abseil/abseil-cpp/issues/1624)
+
+#if __has_include(<absl/synchronization/mutex.h>)
+
+#  ifndef NDEBUG
+#    define ARROW_NO_NDEBUG
+#    define NDEBUG
+#  endif
+
+#  include <absl/synchronization/mutex.h>
+
+#  ifdef ARROW_NO_NDEBUG
+#    undef NDEBUG
+#  endif
+
+#endif
+
 #include <grpc++/grpc++.h>
 
 #include "examples/arrow/helloworld.grpc.pb.h"

--- a/cpp/src/arrow/flight/transport/grpc/customize_grpc.h
+++ b/cpp/src/arrow/flight/transport/grpc/customize_grpc.h
@@ -20,6 +20,26 @@
 #include <limits>
 #include <memory>
 
+// HACK: Workaround absl::Mutex ABI incompatibility by making sure the
+// non-debug version of Abseil is included
+// (https://github.com/conda-forge/abseil-cpp-feedstock/issues/104,
+//  https://github.com/abseil/abseil-cpp/issues/1624)
+
+#if __has_include(<absl/synchronization/mutex.h>)
+
+#  ifndef NDEBUG
+#    define ARROW_NO_NDEBUG
+#    define NDEBUG
+#  endif
+
+#  include <absl/synchronization/mutex.h>
+
+#  ifdef ARROW_NO_NDEBUG
+#    undef NDEBUG
+#  endif
+
+#endif
+
 #include "arrow/flight/platform.h"
 #include "arrow/flight/type_fwd.h"
 #include "arrow/flight/visibility.h"

--- a/cpp/src/arrow/flight/transport/grpc/grpc_client.cc
+++ b/cpp/src/arrow/flight/transport/grpc/grpc_client.cc
@@ -28,6 +28,8 @@
 #include <unordered_map>
 #include <utility>
 
+#include "arrow/flight/transport/grpc/customize_grpc.h"
+
 #include <grpcpp/grpcpp.h>
 #include <grpcpp/support/client_callback.h>
 #if defined(GRPC_NAMESPACE_FOR_TLS_CREDENTIALS_OPTIONS)

--- a/cpp/src/arrow/flight/transport/grpc/grpc_server.cc
+++ b/cpp/src/arrow/flight/transport/grpc/grpc_server.cc
@@ -25,6 +25,8 @@
 #include <unordered_map>
 #include <utility>
 
+#include "arrow/flight/transport/grpc/customize_grpc.h"
+
 #include <grpcpp/grpcpp.h>
 
 #include "arrow/buffer.h"


### PR DESCRIPTION
### Rationale for this change

When referencing production abseil libraries but using a debug build type, libarrow_flight ends up referencing private symbols from the libabsl_syncrhonization library. For a reproducer in CI of the issue, see https://github.com/apache/arrow/actions/runs/20072853100/job/57579472724?pr=48418

### What changes are included in this PR?

NDEBUG is defined for CI builds so that the abseil desctructor that only appears in debug builds is not present in Arrow libraries

### Are these changes tested?

Yes

### Are there any user-facing changes?

No - this update is strictly to the CI jobs
* GitHub Issue: #48433