### PR TITLE
GH-48419: [Python] Fix test_parquet_file_too_small to catch only ArrowInvalid

### DIFF
--- a/python/pyarrow/tests/parquet/test_basic.py
+++ b/python/pyarrow/tests/parquet/test_basic.py
@@ -713,15 +713,12 @@ def test_zlib_compression_bug():
 
 def test_parquet_file_too_small(tempdir):
     path = str(tempdir / "test.parquet")
-    # TODO(dataset) with datasets API it raises OSError instead
-    with pytest.raises((pa.ArrowInvalid, OSError),
-                       match='size is 0 bytes'):
+    with pytest.raises(pa.ArrowInvalid, match='size is 0 bytes'):
         with open(path, 'wb') as f:
             pass
         pq.read_table(path)
 
-    with pytest.raises((pa.ArrowInvalid, OSError),
-                       match='size is 4 bytes'):
+    with pytest.raises(pa.ArrowInvalid, match='size is 4 bytes'):
         with open(path, 'wb') as f:
             f.write(b'ffff')
         pq.read_table(path)


### PR DESCRIPTION
### Rationale for this change

The test does not throw `OSError` anymore.

### What changes are included in this PR?

This PR changes `test_parquet_file_too_small` test to only catch `ArrowInvalid`.

### Are these changes tested?

Yes, manually tested via

```
pytest pyarrow/tests/parquet/test_basic.py::test_parquet_file_too_small
```

### Are there any user-facing changes?

No, test-only.
* GitHub Issue: #48419