### PR TITLE
GH-48421: [Python] Enable test_orc_scan_options with batch_size

### DIFF
--- a/python/pyarrow/tests/test_dataset.py
+++ b/python/pyarrow/tests/test_dataset.py
@@ -3433,13 +3433,13 @@ def test_orc_scan_options(tempdir, dataset_reader):
     assert len(result) == 1
     assert result[0].num_rows == 3
     assert result[0].equals(table.to_batches()[0])
-    # TODO batch_size is not yet supported (ARROW-14153)
-    # result = list(dataset_reader.to_batches(dataset, batch_size=2))
-    # assert len(result) == 2
-    # assert result[0].num_rows == 2
-    # assert result[0].equals(table.slice(0, 2).to_batches()[0])
-    # assert result[1].num_rows == 1
-    # assert result[1].equals(table.slice(2, 1).to_batches()[0])
+
+    result = list(dataset_reader.to_batches(dataset, batch_size=2))
+    assert len(result) == 2
+    assert result[0].num_rows == 2
+    assert result[0].equals(table.slice(0, 2).to_batches()[0])
+    assert result[1].num_rows == 1
+    assert result[1].equals(table.slice(2, 1).to_batches()[0])
 
 
 def test_orc_format_not_supported():


### PR DESCRIPTION
### Rationale for this change

https://github.com/apache/arrow/blob/4a8194e5c5b65579e09439121328aa3a448a7bf0/python/pyarrow/tests/test_dataset.py#L3436-L3442

was disabled because of batch size implementation missing in ORC scanner (ARROW-14153).

This is resolved now so we can enable the tests.

### What changes are included in this PR?

Enable test_orc_scan_options with batch_size

### Are these changes tested?

Yes, via

```
python/pyarrow/tests/test_dataset.py::test_orc_dataset_reader
```

### Are there any user-facing changes?

No, test-only.
* GitHub Issue: #48421