### PR TITLE
GH-48423: [Ruby] Add support for reading date64 array

### DIFF
--- a/ruby/red-arrow-format/lib/arrow-format/array.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/array.rb
@@ -123,6 +123,12 @@ module ArrowFormat
     end
   end
 
+  class Date64Array < DateArray
+    def to_a
+      apply_validity(@values_buffer.values(:s64, 0, @size))
+    end
+  end
+
   class VariableSizeBinaryLayoutArray < Array
     def initialize(type, size, validity_buffer, offsets_buffer, values_buffer)
       super(type, size, validity_buffer)

--- a/ruby/red-arrow-format/lib/arrow-format/file-reader.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/file-reader.rb
@@ -166,6 +166,8 @@ module ArrowFormat
         case fb_type.unit
         when Org::Apache::Arrow::Flatbuf::DateUnit::DAY
           type = Date32Type.singleton
+        when Org::Apache::Arrow::Flatbuf::DateUnit::MILLISECOND
+          type = Date64Type.singleton
         end
       when Org::Apache::Arrow::Flatbuf::List
         type = ListType.new(read_field(fb_field.children[0]))

--- a/ruby/red-arrow-format/lib/arrow-format/type.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/type.rb
@@ -158,6 +158,22 @@ module ArrowFormat
     end
   end
 
+  class Date64Type < DateType
+    class << self
+      def singleton
+        @singleton ||= new
+      end
+    end
+
+    def initialize
+      super("Date64")
+    end
+
+    def build_array(size, validity_buffer, values_buffer)
+      Date64Array.new(self, size, validity_buffer, values_buffer)
+    end
+  end
+
   class VariableSizeBinaryType < Type
   end
 

--- a/ruby/red-arrow-format/test/test-file-reader.rb
+++ b/ruby/red-arrow-format/test/test-file-reader.rb
@@ -123,6 +123,35 @@ class TestFileReader < Test::Unit::TestCase
     end
   end
 
+  sub_test_case("Date64") do
+    def setup(&block)
+      @date_2017_08_28_00_00_00 = 1503878400000
+      @date_2025_12_09_00_00_00 = 1765324800000
+      super(&block)
+    end
+
+    def build_array
+      Arrow::Date64Array.new([
+                               @date_2017_08_28_00_00_00,
+                               nil,
+                               @date_2025_12_09_00_00_00,
+                             ])
+    end
+
+    def test_read
+      assert_equal([
+                     {
+                       "value" => [
+                         @date_2017_08_28_00_00_00,
+                         nil,
+                         @date_2025_12_09_00_00_00,
+                       ],
+                     },
+                   ],
+                   read)
+    end
+  end
+
   sub_test_case("Binary") do
     def build_array
       Arrow::BinaryArray.new(["Hello".b, nil, "World".b])


### PR DESCRIPTION
### Rationale for this change

It's a millisecond variant of date array.

### What changes are included in this PR?

* Add `ArrowFormat::Date64Type`
* Add `ArrowFormat::Date64Array`

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #48423