### PR TITLE
GH-48339: [C++] Enhance functions in util/ubsan.h to support types without a default constructor

### DIFF
--- a/cpp/src/arrow/util/ubsan.h
+++ b/cpp/src/arrow/util/ubsan.h
@@ -21,8 +21,10 @@
 
 #include <cstring>
 #include <memory>
+#include <new>
 #include <type_traits>
 
+#include "arrow/util/aligned_storage.h"
 #include "arrow/util/macros.h"
 
 namespace arrow {
@@ -55,16 +57,23 @@ inline T* MakeNonNull(T* maybe_null = NULLPTR) {
 template <typename T>
 inline std::enable_if_t<std::is_trivially_copyable_v<T>, T> SafeLoadAs(
     const uint8_t* unaligned) {
-  std::remove_const_t<T> ret;
-  std::memcpy(&ret, unaligned, sizeof(T));
-  return ret;
+  using Type = std::remove_const_t<T>;
+  arrow::internal::AlignedStorage<Type> raw_data;
+  std::memcpy(raw_data.get(), unaligned, sizeof(T));
+  auto data = *raw_data.get();
+  raw_data.destroy();
+  return data;
 }
 
 template <typename T>
 inline std::enable_if_t<std::is_trivially_copyable_v<T>, T> SafeLoad(const T* unaligned) {
-  std::remove_const_t<T> ret;
-  std::memcpy(&ret, static_cast<const void*>(unaligned), sizeof(T));
-  return ret;
+  using Type = std::remove_const_t<T>;
+  arrow::internal::AlignedStorage<Type> raw_data;
+  std::memcpy(raw_data.get(), std::launder(reinterpret_cast<const uint8_t*>(unaligned)),
+              sizeof(T));
+  auto data = *raw_data.get();
+  raw_data.destroy();
+  return data;
 }
 
 template <typename U, typename T>
@@ -72,9 +81,13 @@ inline std::enable_if_t<std::is_trivially_copyable_v<T> &&
                             std::is_trivially_copyable_v<U> && sizeof(T) == sizeof(U),
                         U>
 SafeCopy(T value) {
-  std::remove_const_t<U> ret;
-  std::memcpy(&ret, static_cast<const void*>(&value), sizeof(T));
-  return ret;
+  using TypeU = std::remove_const_t<U>;
+  arrow::internal::AlignedStorage<TypeU> raw_data;
+  std::memcpy(raw_data.get(), std::launder(reinterpret_cast<const uint8_t*>(&value)),
+              sizeof(T));
+  auto data = *raw_data.get();
+  raw_data.destroy();
+  return data;
 }
 
 template <typename T>

--- a/cpp/src/arrow/util/ubsan.h
+++ b/cpp/src/arrow/util/ubsan.h
@@ -21,7 +21,6 @@
 
 #include <cstring>
 #include <memory>
-#include <new>
 #include <type_traits>
 
 #include "arrow/util/aligned_storage.h"
@@ -69,8 +68,7 @@ template <typename T>
 inline std::enable_if_t<std::is_trivially_copyable_v<T>, T> SafeLoad(const T* unaligned) {
   using Type = std::remove_const_t<T>;
   arrow::internal::AlignedStorage<Type> raw_data;
-  std::memcpy(raw_data.get(), std::launder(reinterpret_cast<const uint8_t*>(unaligned)),
-              sizeof(T));
+  std::memcpy(raw_data.get(), static_cast<const void*>(unaligned), sizeof(T));
   auto data = *raw_data.get();
   raw_data.destroy();
   return data;
@@ -83,8 +81,7 @@ inline std::enable_if_t<std::is_trivially_copyable_v<T> &&
 SafeCopy(T value) {
   using TypeU = std::remove_const_t<U>;
   arrow::internal::AlignedStorage<TypeU> raw_data;
-  std::memcpy(raw_data.get(), std::launder(reinterpret_cast<const uint8_t*>(&value)),
-              sizeof(T));
+  std::memcpy(raw_data.get(), static_cast<const void*>(&value), sizeof(T));
   auto data = *raw_data.get();
   raw_data.destroy();
   return data;


### PR DESCRIPTION
### Rationale for this change

`arrow::util::SafeLoadAs`, `arrow::util::SafeLoad`, and `arrow::util::SafeCopy` do not work correctly for types that do not have a default constructor.

### What changes are included in this PR?

Changed the behavior of the above-mentioned functions to support types that do not have a default constructor.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.

* GitHub Issue: #48339