### PR TITLE
GH-48432: [CI][Ruby] Don't run Red Arrow Format tests with Ruby 3.1

### DIFF
--- a/ruby/Rakefile
+++ b/ruby/Rakefile
@@ -25,7 +25,7 @@ packages = []
 Dir.glob("#{base_dir}/*/*.gemspec") do |gemspec|
   package = File.basename(File.dirname(gemspec))
   if package == "red-arrow-format"
-    next if RUBY_VERSION < "3.1.0"
+    next if RUBY_VERSION < "3.2.0"
   else
     glib_package_name = package.gsub(/\Ared-/, "") + "-glib"
     next unless PKGConfig.exist?(glib_package_name)


### PR DESCRIPTION
### Rationale for this change

Ruby 3.1 has `IO::Buffer` but it doesn't provide some efficient methods such as `#each` and `#values`. So we don't support Ruby 3.1.

FYI: Ruby 3.1 reached EOL.

### What changes are included in this PR?

Don't run Red Arrow Format tests with Ruby 3.1.

We don't add `required_ruby_version` in `.gemspec`. Red Arrow Format provides `#to_a` for convenient and `#each`/`#values` are used in `#to_a`. But I don't want to use `#to_a` as much as possible because it's slow. Users should use another Apache Arrow implementation to process Apache Arrow data. Red Arrow Format is fast only for serialization/deserialization because of zero-copy. 

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #48432