### PR TITLE
GH-48435: [Ruby] Add support for reading sparse union array

### DIFF
--- a/ruby/red-arrow-format/lib/arrow-format/array.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/array.rb
@@ -232,19 +232,23 @@ module ArrowFormat
   end
 
   class UnionArray < Array
-    def initialize(type,
-                   size,
-                   types_buffer,
-                   offsets_buffer,
-                   children)
+    def initialize(type, size, types_buffer, children)
       super(type, size, nil)
       @types_buffer = types_buffer
-      @offsets_buffer = offsets_buffer
       @children = children
     end
   end
 
   class DenseUnionArray < UnionArray
+    def initialize(type,
+                   size,
+                   types_buffer,
+                   offsets_buffer,
+                   children)
+      super(type, size, types_buffer, children)
+      @offsets_buffer = offsets_buffer
+    end
+
     def to_a
       children_values = @children.collect(&:to_a)
       types = @types_buffer.each(:S8, 0, @size)
@@ -252,6 +256,16 @@ module ArrowFormat
       types.zip(offsets).collect do |(_, type), (_, offset)|
         index = @type.resolve_type_index(type)
         children_values[index][offset]
+      end
+    end
+  end
+
+  class SparseUnionArray < UnionArray
+    def to_a
+      children_values = @children.collect(&:to_a)
+      @types_buffer.each(:S8, 0, @size).with_index.collect do |(_, type), i|
+        index = @type.resolve_type_index(type)
+        children_values[index][i]
       end
     end
   end

--- a/ruby/red-arrow-format/lib/arrow-format/type.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/type.rb
@@ -321,4 +321,14 @@ module ArrowFormat
       DenseUnionArray.new(self, size, types_buffer, offsets_buffer, children)
     end
   end
+
+  class SparseUnionType < UnionType
+    def initialize(children, type_ids)
+      super("SparseUnion", children, type_ids)
+    end
+
+    def build_array(size, types_buffer, children)
+      SparseUnionArray.new(self, size, types_buffer, children)
+    end
+  end
 end

--- a/ruby/red-arrow-format/test/test-file-reader.rb
+++ b/ruby/red-arrow-format/test/test-file-reader.rb
@@ -256,6 +256,28 @@ class TestFileReader < Test::Unit::TestCase
     end
   end
 
+  sub_test_case("SparseUnion") do
+    def build_array
+      fields = [
+        Arrow::Field.new("number", :int8),
+        Arrow::Field.new("text", :string),
+      ]
+      type_ids = [11, 13]
+      data_type = Arrow::SparseUnionDataType.new(fields, type_ids)
+      types = Arrow::Int8Array.new([11, 13, 11, 13, 11])
+      children = [
+        Arrow::Int8Array.new([1, nil, nil, nil, 5]),
+        Arrow::StringArray.new([nil, "b", nil, "d", nil])
+      ]
+      Arrow::SparseUnionArray.new(data_type, types, children)
+    end
+
+    def test_read
+      assert_equal([{"value" => [1, "b", nil, "d", 5]}],
+                   read)
+    end
+  end
+
   sub_test_case("Map") do
     def build_array
       data_type = Arrow::MapDataType.new(:string, :int8)


### PR DESCRIPTION
### Rationale for this change

It's a sparse variant of union array.

### What changes are included in this PR?

* Add `ArrowFormat::SparseUnionType`
* Add `ArrowFormat::SparseUnionArray`

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #48435