### PR TITLE
GH-48440: [Ruby] Add support for reading time32 array

### DIFF
--- a/ruby/red-arrow-format/lib/arrow-format/array.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/array.rb
@@ -110,14 +110,14 @@ module ArrowFormat
     end
   end
 
-  class TemporaryArray < Array
+  class TemporalArray < Array
     def initialize(type, size, validity_buffer, values_buffer)
       super(type, size, validity_buffer)
       @values_buffer = values_buffer
     end
   end
 
-  class DateArray < TemporaryArray
+  class DateArray < TemporalArray
   end
 
   class Date32Array < DateArray
@@ -132,7 +132,7 @@ module ArrowFormat
     end
   end
 
-  class TimeArray < TemporaryArray
+  class TimeArray < TemporalArray
   end
 
   class Time32Array < TimeArray

--- a/ruby/red-arrow-format/lib/arrow-format/array.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/array.rb
@@ -110,11 +110,14 @@ module ArrowFormat
     end
   end
 
-  class DateArray < Array
+  class TemporaryArray < Array
     def initialize(type, size, validity_buffer, values_buffer)
       super(type, size, validity_buffer)
       @values_buffer = values_buffer
     end
+  end
+
+  class DateArray < TemporaryArray
   end
 
   class Date32Array < DateArray
@@ -126,6 +129,15 @@ module ArrowFormat
   class Date64Array < DateArray
     def to_a
       apply_validity(@values_buffer.values(:s64, 0, @size))
+    end
+  end
+
+  class TimeArray < TemporaryArray
+  end
+
+  class Time32Array < TimeArray
+    def to_a
+      apply_validity(@values_buffer.values(:s32, 0, @size))
     end
   end
 

--- a/ruby/red-arrow-format/lib/arrow-format/file-reader.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/file-reader.rb
@@ -38,6 +38,8 @@ require_relative "org/apache/arrow/flatbuf/null"
 require_relative "org/apache/arrow/flatbuf/precision"
 require_relative "org/apache/arrow/flatbuf/schema"
 require_relative "org/apache/arrow/flatbuf/struct_"
+require_relative "org/apache/arrow/flatbuf/time"
+require_relative "org/apache/arrow/flatbuf/time_unit"
 require_relative "org/apache/arrow/flatbuf/union"
 require_relative "org/apache/arrow/flatbuf/union_mode"
 require_relative "org/apache/arrow/flatbuf/utf8"
@@ -171,6 +173,16 @@ module ArrowFormat
         when Org::Apache::Arrow::Flatbuf::DateUnit::MILLISECOND
           type = Date64Type.singleton
         end
+      when Org::Apache::Arrow::Flatbuf::Time
+        case fb_type.bit_width
+        when 32
+          case fb_type.unit
+          when Org::Apache::Arrow::Flatbuf::TimeUnit::SECOND
+            type = Time32Type.new(:second)
+          when Org::Apache::Arrow::Flatbuf::TimeUnit::MILLISECOND
+            type = Time32Type.new(:millisecond)
+          end
+        end
       when Org::Apache::Arrow::Flatbuf::List
         type = ListType.new(read_field(fb_field.children[0]))
       when Org::Apache::Arrow::Flatbuf::LargeList
@@ -220,7 +232,7 @@ module ArrowFormat
       case field.type
       when BooleanType,
            NumberType,
-           DateType
+           TemporalType
         values_buffer = buffers.shift
         values = body.slice(values_buffer.offset, values_buffer.length)
         field.type.build_array(length, validity, values)

--- a/ruby/red-arrow-format/lib/arrow-format/type.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/type.rb
@@ -139,7 +139,10 @@ module ArrowFormat
     end
   end
 
-  class DateType < Type
+  class TemporalType < Type
+  end
+
+  class DateType < TemporalType
   end
 
   class Date32Type < DateType
@@ -171,6 +174,20 @@ module ArrowFormat
 
     def build_array(size, validity_buffer, values_buffer)
       Date64Array.new(self, size, validity_buffer, values_buffer)
+    end
+  end
+
+  class TimeType < TemporalType
+  end
+
+  class Time32Type < TimeType
+    def initialize(unit)
+      super("Time32")
+      @unit = unit
+    end
+
+    def build_array(size, validity_buffer, values_buffer)
+      Time32Array.new(self, size, validity_buffer, values_buffer)
     end
   end
 

--- a/ruby/red-arrow-format/test/test-file-reader.rb
+++ b/ruby/red-arrow-format/test/test-file-reader.rb
@@ -152,6 +152,41 @@ class TestFileReader < Test::Unit::TestCase
     end
   end
 
+  sub_test_case("Time32(:second)") do
+    def setup(&block)
+      @time_00_00_10 = 10
+      @time_00_01_10 = 60 + 10
+      super(&block)
+    end
+
+    def build_array
+      Arrow::Time32Array.new(:second, [@time_00_00_10, nil, @time_00_01_10])
+    end
+
+    def test_read
+      assert_equal([{"value" => [@time_00_00_10, nil, @time_00_01_10]}],
+                   read)
+    end
+  end
+
+  sub_test_case("Time32(:millisecond)") do
+    def setup(&block)
+      @time_00_00_10_000 = 10 * 1000
+      @time_00_01_10_000 = (60 + 10) * 1000
+      super(&block)
+    end
+
+    def build_array
+      Arrow::Time32Array.new(:milli,
+                             [@time_00_00_10_000, nil, @time_00_01_10_000])
+    end
+
+    def test_read
+      assert_equal([{"value" => [@time_00_00_10_000, nil, @time_00_01_10_000]}],
+                   read)
+    end
+  end
+
   sub_test_case("Binary") do
     def build_array
       Arrow::BinaryArray.new(["Hello".b, nil, "World".b])


### PR DESCRIPTION
### Rationale for this change

It's a 32 bits variant for time array.

### What changes are included in this PR?

* Add `ArrowFormat::Time32Type`
* Add `ArrowFormat::Time32Array`

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #48440