### PR TITLE
GH-48444: [Python] Remove todo of implementing requested_schema in test_roundtrip_reader_capsule

### DIFF
--- a/python/pyarrow/tests/test_cffi.py
+++ b/python/pyarrow/tests/test_cffi.py
@@ -645,7 +645,6 @@ def test_roundtrip_device_array_capsule(arr, schema_accessor, bad_type, good_typ
     assert schema_accessor(arr_out) == good_type
 
 
-# TODO: implement requested_schema for stream
 @pytest.mark.parametrize('constructor', [
     pa.RecordBatchReader.from_batches,
     # Use a lambda because we need to re-order the parameters


### PR DESCRIPTION
### Rationale for this change

https://github.com/apache/arrow/blob/6456944f5092dedb3f80d9bc80400e857d6571c7/python/pyarrow/tests/test_cffi.py#L648

can be removed now because `requested_schema` is implemented in https://github.com/apache/arrow/commit/d6b9051fa0 and its corresponding test was added as `test_roundtrip_batch_reader_capsule_requested_schema`.

### What changes are included in this PR?

This PR removes the todo of implementing requested_schema.

### Are these changes tested?

I removed a comment so did not test.

### Are there any user-facing changes?

No, test-only.
* GitHub Issue: #48444