### PR TITLE
GH-48446: [Python] Remove todo of schema=name mismatch in `record_batches`

### DIFF
--- a/python/pyarrow/tests/strategies.py
+++ b/python/pyarrow/tests/strategies.py
@@ -390,8 +390,6 @@ def record_batches(draw, type, rows=None, max_fields=None):
 
     schema = draw(schemas(type, max_fields=max_fields))
     children = [draw(arrays(field.type, size=rows)) for field in schema]
-    # TODO(kszucs): the names and schema arguments are not consistent with
-    #               Table.from_array's arguments
     return pa.RecordBatch.from_arrays(children, schema=schema)
 
 


### PR DESCRIPTION
### Rationale for this change

https://github.com/apache/arrow/blob/6456944f5092dedb3f80d9bc80400e857d6571c7/python/pyarrow/tests/strategies.py#L393-L394

https://github.com/apache/arrow/commit/2b36521e52 fixed the issue by:

```diff
-    return pa.RecordBatch.from_arrays(children, names=schema)
+    return pa.RecordBatch.from_arrays(children, schema=schema)
```

so this todo can be removed.

### What changes are included in this PR?

This PR removes an obsolete todo.

### Are these changes tested?

No, I removed a comment and did not test this.

### Are there any user-facing changes?

No, test-only.
* GitHub Issue: #48446