### PR TITLE
GH-48455: [Python] Handle nested field names when sanitizing table at ParquetWriter (flavor='spark')

### DIFF
--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -715,32 +715,77 @@ def _sanitized_spark_field_name(name):
     return _SPARK_DISALLOWED_CHARS.sub('_', name)
 
 
+def _sanitize_field_recursive(field):
+    """
+    Recursively sanitize field names in struct types for Spark compatibility.
+
+    Returns
+    -------
+    tuple
+        (sanitized_field, changed) where changed is True if any sanitization occurred
+    """
+    sanitized_name = _sanitized_spark_field_name(field.name)
+    sanitized_type = field.type
+    type_changed = False
+
+    if pa.types.is_struct(field.type):
+        sanitized_fields = [_sanitize_field_recursive(f) for f in field.type]
+        if any(changed for _, changed in sanitized_fields):
+            sanitized_type = pa.struct([f for f, _ in sanitized_fields])
+            type_changed = True
+    elif pa.types.is_list(field.type) or pa.types.is_large_list(field.type):
+        # Sanitize the value field of list types
+        value_field = field.type.value_field
+        sanitized_value_field, value_changed = _sanitize_field_recursive(value_field)
+        if value_changed:
+            if pa.types.is_list(field.type):
+                sanitized_type = pa.list_(sanitized_value_field)
+            else:  # large_list
+                sanitized_type = pa.large_list(sanitized_value_field)
+            type_changed = True
+    elif pa.types.is_fixed_size_list(field.type):
+        # Sanitize the value field of fixed_size_list types
+        value_field = field.type.value_field
+        list_size = field.type.list_size
+        sanitized_value_field, value_changed = _sanitize_field_recursive(value_field)
+        if value_changed:
+            sanitized_type = pa.list_(sanitized_value_field, list_size)
+            type_changed = True
+    elif pa.types.is_map(field.type):
+        # Sanitize both key and item fields of map types
+        key_field = field.type.key_field
+        item_field = field.type.item_field
+        sanitized_key_field, key_changed = _sanitize_field_recursive(key_field)
+        sanitized_item_field, item_changed = _sanitize_field_recursive(item_field)
+        if key_changed or item_changed:
+            sanitized_type = pa.map_(sanitized_key_field, sanitized_item_field,
+                                     keys_sorted=field.type.keys_sorted)
+            type_changed = True
+
+    name_changed = sanitized_name != field.name
+    if name_changed or type_changed:
+        return pa.field(sanitized_name, sanitized_type, field.nullable,
+                        field.metadata), True
+    return field, False
+
+
 def _sanitize_schema(schema, flavor):
-    if 'spark' in flavor:
-        sanitized_fields = []
-
-        schema_changed = False
-
-        for field in schema:
-            name = field.name
-            sanitized_name = _sanitized_spark_field_name(name)
-
-            if sanitized_name != name:
-                schema_changed = True
-                sanitized_field = pa.field(sanitized_name, field.type,
-                                           field.nullable, field.metadata)
-                sanitized_fields.append(sanitized_field)
-            else:
-                sanitized_fields.append(field)
-
-        new_schema = pa.schema(sanitized_fields, metadata=schema.metadata)
-        return new_schema, schema_changed
-    else:
+    if 'spark' not in flavor:
         return schema, False
+
+    sanitized_fields = []
+    schema_changed = False
+
+    for field in schema:
+        sanitized_field, changed = _sanitize_field_recursive(field)
+        sanitized_fields.append(sanitized_field)
+        schema_changed = schema_changed or changed
+
+    new_schema = pa.schema(sanitized_fields, metadata=schema.metadata)
+    return new_schema, schema_changed
 
 
 def _sanitize_table(table, new_schema, flavor):
-    # TODO: This will not handle prohibited characters in nested field names
     if 'spark' in flavor:
         column_data = [table[i] for i in range(table.num_columns)]
         return pa.Table.from_arrays(column_data, schema=new_schema)


### PR DESCRIPTION
### Rationale for this change

https://github.com/apache/arrow/blob/7a36fcc8b7456bea52911f9601b26be51d16265a/python/pyarrow/parquet/core.py#L743

This was first introduced in https://github.com/apache/arrow/commit/4a6a6cb47dcf832213f1fb31f2325ad10a3864bd but did not implement the logic to handle nested types.

### What changes are included in this PR?

This PR implements the nested handling for the sanitising the field names ParquetWriter (flavor='spark')

### Are these changes tested?

Unittests were added, and manually tested via:

```
pytest python/pyarrow/tests/parquet/test_basic.py -k 'sanitized_spark' -v
```

### Are there any user-facing changes?

Yes. It sanitizes the field names when `ParquetWriter` is used with `flavor` set to `'spark'`.

* GitHub Issue: #48455