### PR TITLE
GH-48457: [Python] Overflow check in datetime conversion in pa.array

### DIFF
--- a/python/pyarrow/src/arrow/python/numpy_to_arrow.cc
+++ b/python/pyarrow/src/arrow/python/numpy_to_arrow.cc
@@ -364,14 +364,14 @@ Status CastBuffer(const std::shared_ptr<DataType>& in_type,
   return Status::OK();
 }
 
-// Cast buffer from FromType to ToType with optional overflow checking.
+// Downcast buffer from FromType to ToType with optional overflow checking.
 // This function only supports narrowing casts (FromType wider than ToType).
 // Do not use this function for widening casts (ToType wider than FromType).
 template <typename FromType, typename ToType>
-Status StaticCastBuffer(const Buffer& input, int64_t length, MemoryPool* pool,
-                        const uint8_t* null_bitmap,
-                        const compute::CastOptions& cast_options,
-                        std::shared_ptr<Buffer>* out) {
+Status StaticDowncastBuffer(const Buffer& input, int64_t length, MemoryPool* pool,
+                            const uint8_t* null_bitmap,
+                            const compute::CastOptions& cast_options,
+                            std::shared_ptr<Buffer>* out) {
   ARROW_ASSIGN_OR_RAISE(auto result, AllocateBuffer(sizeof(ToType) * length, pool));
 
   auto in_values = reinterpret_cast<const FromType*>(input.data());
@@ -516,7 +516,7 @@ inline Status NumPyConverter::ConvertData<Date32Type>(std::shared_ptr<Buffer>* d
     if (date_dtype->meta.base == NPY_FR_D) {
       // Downcast from int64 to int32 with overflow checking
       const uint8_t* null_bitmap_ptr = null_bitmap_ ? null_bitmap_->data() : nullptr;
-      RETURN_NOT_OK((StaticCastBuffer<int64_t, int32_t>(
+      RETURN_NOT_OK((StaticDowncastBuffer<int64_t, int32_t>(
           **data, length_, pool_, null_bitmap_ptr, cast_options_, data)));
     } else {
       ARROW_ASSIGN_OR_RAISE(input_type, NumPyDtypeToArrow(dtype_));

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -2470,6 +2470,31 @@ def test_array_from_numpy_datetime_overflow():
     result = pa.array(valid_arr, type=pa.date32())
     assert len(result) == 5
 
+    # Test with different masks (null bitmaps)
+    # Null at overflow position should not trigger overflow error
+    arr_with_null = np.array([overflow_value], dtype='datetime64[D]')
+    mask = np.array([True])  # True means null in numpy masked arrays
+    result = pa.array(arr_with_null, type=pa.date32(), mask=mask)
+    assert result.null_count == 1
+    assert len(result) == 1
+
+    # Mix of null and overflow values - nulls skipped, overflows still caught
+    arr_mixed = np.array([overflow_value, 100, underflow_value],
+                         dtype='datetime64[D]')
+    mask_first_null = np.array([True, False, False])
+    # First value is null (skipped), third value overflows (error raised)
+    with pytest.raises(pa.ArrowInvalid, match='value .* out of bounds'):
+        pa.array(arr_mixed, type=pa.date32(), mask=mask_first_null)
+
+    # All overflow values but all masked (nulls) should succeed
+    arr_all_overflow = np.array([overflow_value, underflow_value,
+                                 overflow_value + 1000],
+                                dtype='datetime64[D]')
+    mask_all_null = np.array([True, True, True])
+    result = pa.array(arr_all_overflow, type=pa.date32(), mask=mask_all_null)
+    assert result.null_count == 3
+    assert len(result) == 3
+
 
 def test_array_from_naive_datetimes():
     arr = pa.array([


### PR DESCRIPTION
### Rationale for this change

https://github.com/apache/arrow/blob/7a36fcc8b7456bea52911f9601b26be51d16265a/python/pyarrow/src/arrow/python/numpy_to_arrow.cc#L499-L500

Should check and work together with `safe` paramter.

### What changes are included in this PR?

This PR proposes to implement overflow check in date and integer conversions

### Are these changes tested?

Yes, manually tested, and also added a unittest:

```
pytest pyarrow/tests/test_array.py -k "test_array_from_numpy_datetime_overflow" -v
```

### Are there any user-facing changes?

Yes. 

```python
import numpy as np
import pyarrow as pa
pa.array(np.array([np.int64(-3000000000)], dtype='datetime64[D]'), safe=True)
```

Before:

```
>>> pa.array(np.array([np.int64(-3000000000)], dtype='datetime64[D]'), safe=True)
<pyarrow.lib.Date32Array object at 0x1207f85e0>
[
  <value out of range: 1294967296>
]
```

After:

```
pyarrow.lib.ArrowInvalid: Integer value -3000000000 out of bounds for int32 conversion at index 0
```

* GitHub Issue: #48457