### PR TITLE
GH-46063: [C++][Compute] Fix the issue that MinMax kernel emits -inf/inf for all-NaN input

### DIFF
--- a/cpp/src/arrow/compute/kernels/aggregate_basic.inc.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_basic.inc.cc
@@ -694,8 +694,8 @@ struct MinMaxState<ArrowType, SimdLevel, enable_if_floating_point<ArrowType>> {
     this->max = std::fmax(this->max, value);
   }
 
-  T min = std::numeric_limits<T>::infinity();
-  T max = -std::numeric_limits<T>::infinity();
+  T min = std::numeric_limits<T>::quiet_NaN();
+  T max = std::numeric_limits<T>::quiet_NaN();
   bool has_nulls = false;
 };
 

--- a/cpp/src/arrow/compute/kernels/hash_aggregate.cc
+++ b/cpp/src/arrow/compute/kernels/hash_aggregate.cc
@@ -274,16 +274,15 @@ struct GroupedCountImpl : public GroupedAggregator {
 // XXX: Consider making these concepts complete and moving to public header.
 
 template <typename T>
-concept CBooleanConcept = std::is_same_v<T, bool>;
+concept CBooleanConcept = std::same_as<T, bool>;
 
 // XXX: Ideally we want to have std::floating_point<Float16> = true.
 template <typename T>
-concept CFloatingPointConcept =
-    std::floating_point<T> || std::is_same_v<T, util::Float16>;
+concept CFloatingPointConcept = std::floating_point<T> || std::same_as<T, util::Float16>;
 
 template <typename T>
-concept CDecimalConcept = std::is_same_v<T, Decimal32> || std::is_same_v<T, Decimal64> ||
-    std::is_same_v<T, Decimal128> || std::is_same_v<T, Decimal256>;
+concept CDecimalConcept = std::same_as<T, Decimal32> || std::same_as<T, Decimal64> ||
+    std::same_as<T, Decimal128> || std::same_as<T, Decimal256>;
 
 template <typename CType>
 struct AntiExtrema {

--- a/cpp/src/arrow/compute/kernels/hash_aggregate.cc
+++ b/cpp/src/arrow/compute/kernels/hash_aggregate.cc
@@ -16,6 +16,7 @@
 // under the License.
 
 #include <cmath>
+#include <concepts>
 #include <functional>
 #include <memory>
 #include <string>
@@ -269,6 +270,20 @@ struct GroupedCountImpl : public GroupedAggregator {
 
 // ----------------------------------------------------------------------
 // MinMax implementation
+
+// XXX: Consider making these concepts complete and moving to public header.
+
+template <typename T>
+concept CBooleanConcept = std::is_same_v<T, bool>;
+
+// XXX: Ideally we want to have std::floating_point<Float16> = true.
+template <typename T>
+concept CFloatingPointConcept =
+    std::floating_point<T> || std::is_same_v<T, util::Float16>;
+
+template <typename T>
+concept CDecimalConcept = std::is_same_v<T, Decimal32> || std::is_same_v<T, Decimal64> ||
+    std::is_same_v<T, Decimal128> || std::is_same_v<T, Decimal256>;
 
 template <typename CType>
 struct AntiExtrema {

--- a/cpp/src/arrow/type_traits.h
+++ b/cpp/src/arrow/type_traits.h
@@ -17,7 +17,6 @@
 
 #pragma once
 
-#include <concepts>
 #include <memory>
 #include <string>
 #include <type_traits>
@@ -1835,25 +1834,6 @@ constexpr bool is_nested(const DataType& type) { return is_nested(type.id()); }
 ///
 /// Convenience for checking using the type's id
 constexpr bool is_union(const DataType& type) { return is_union(type.id()); }
-
-/// @}
-
-/// \addtogroup c-type-concepts
-/// @{
-
-// XXX: To be completed with more concepts as needed.
-
-template <typename T>
-concept CBooleanConcept = std::is_same_v<T, bool>;
-
-// XXX: Ideally we want to have std::floating_point<Float16> = true.
-template <typename T>
-concept CFloatingPointConcept =
-    std::floating_point<T> || std::is_same_v<T, util::Float16>;
-
-template <typename T>
-concept CDecimalConcept = std::is_same_v<T, Decimal32> || std::is_same_v<T, Decimal64> ||
-    std::is_same_v<T, Decimal128> || std::is_same_v<T, Decimal256>;
 
 /// @}
 

--- a/cpp/src/arrow/type_traits.h
+++ b/cpp/src/arrow/type_traits.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <concepts>
 #include <memory>
 #include <string>
 #include <type_traits>
@@ -1834,6 +1835,25 @@ constexpr bool is_nested(const DataType& type) { return is_nested(type.id()); }
 ///
 /// Convenience for checking using the type's id
 constexpr bool is_union(const DataType& type) { return is_union(type.id()); }
+
+/// @}
+
+/// \addtogroup c-type-concepts
+/// @{
+
+// XXX: To be completed with more concepts as needed.
+
+template <typename T>
+concept CBooleanConcept = std::is_same_v<T, bool>;
+
+// XXX: Ideally we want to have std::floating_point<Float16> = true.
+template <typename T>
+concept CFloatingPointConcept =
+    std::floating_point<T> || std::is_same_v<T, util::Float16>;
+
+template <typename T>
+concept CDecimalConcept = std::is_same_v<T, Decimal32> || std::is_same_v<T, Decimal64> ||
+                          std::is_same_v<T, Decimal128> || std::is_same_v<T, Decimal256>;
 
 /// @}
 

--- a/cpp/src/arrow/type_traits.h
+++ b/cpp/src/arrow/type_traits.h
@@ -1853,7 +1853,7 @@ concept CFloatingPointConcept =
 
 template <typename T>
 concept CDecimalConcept = std::is_same_v<T, Decimal32> || std::is_same_v<T, Decimal64> ||
-                          std::is_same_v<T, Decimal128> || std::is_same_v<T, Decimal256>;
+    std::is_same_v<T, Decimal128> || std::is_same_v<T, Decimal256>;
 
 /// @}
 


### PR DESCRIPTION
### Rationale for this change

Our MinMax kernels emit -inf/inf for all-NaN input array, which doesn't make sense.

### What changes are included in this PR?

Initialize the running min/max value from -inf/inf to NaN, so we can leverage the nice property that:
`std::fmin/fmax(all-NaN) = NaN`
`std::fmin/fmax(NaN, non-NaN) = non-NaN`

### Are these changes tested?

Test included.

### Are there any user-facing changes?

None.
* GitHub Issue: #46063