### PR TITLE
GH-48463: [Python] Improve error message in CheckTypeExact arrow_to_pandas.cc

### DIFF
--- a/python/pyarrow/src/arrow/python/arrow_to_pandas.cc
+++ b/python/pyarrow/src/arrow/python/arrow_to_pandas.cc
@@ -1127,8 +1127,9 @@ class TypedPandasWriter : public PandasWriter {
 
   Status CheckTypeExact(const DataType& type, Type::type expected) {
     if (type.id() != expected) {
-      // TODO(wesm): stringify NumPy / pandas type
-      return Status::NotImplemented("Cannot write Arrow data of type ", type.ToString());
+      return Status::NotImplemented("Cannot write Arrow data of type ", type.ToString(),
+                                    " to pandas block with NumPy type ",
+                                    GetNumPyTypeName(NPY_TYPE));
     }
     return Status::OK();
   }

--- a/python/pyarrow/src/arrow/python/python_test.cc
+++ b/python/pyarrow/src/arrow/python/python_test.cc
@@ -32,6 +32,7 @@
 #include "arrow/python/decimal.h"
 #include "arrow/python/helpers.h"
 #include "arrow/python/numpy_convert.h"
+#include "arrow/python/numpy_internal.h"
 #include "arrow/python/numpy_interop.h"
 #include "arrow/python/python_test.h"
 #include "arrow/python/python_to_arrow.h"
@@ -847,6 +848,21 @@ Status TestUpdateWithNaN() {
   return Status::OK();
 }
 
+Status TestGetNumPyTypeName() {
+  ASSERT_EQ(GetNumPyTypeName(NPY_BOOL), "bool");
+  ASSERT_EQ(GetNumPyTypeName(NPY_INT8), "int8");
+  ASSERT_EQ(GetNumPyTypeName(NPY_INT16), "int16");
+  ASSERT_EQ(GetNumPyTypeName(NPY_INT32), "int32");
+  ASSERT_EQ(GetNumPyTypeName(NPY_INT64), "int64");
+  ASSERT_EQ(GetNumPyTypeName(NPY_UINT8), "uint8");
+  ASSERT_EQ(GetNumPyTypeName(NPY_UINT16), "uint16");
+  ASSERT_EQ(GetNumPyTypeName(NPY_UINT32), "uint32");
+  ASSERT_EQ(GetNumPyTypeName(NPY_UINT64), "uint64");
+  ASSERT_EQ(GetNumPyTypeName(NPY_FLOAT32), "float32");
+  ASSERT_EQ(GetNumPyTypeName(NPY_FLOAT64), "float64");
+  return Status::OK();
+}
+
 }  // namespace
 
 std::vector<TestCase> GetCppTestCases() {
@@ -886,6 +902,7 @@ std::vector<TestCase> GetCppTestCases() {
        TestMixedPrecisionAndScaleSequenceConvert},
       {"test_simple_inference", TestSimpleInference},
       {"test_update_with_nan", TestUpdateWithNaN},
+      {"test_get_numpy_type_name", TestGetNumPyTypeName},
   };
 }
 


### PR DESCRIPTION
### Rationale for this change

https://github.com/apache/arrow/commit/3b000b7062b5614a02134d1a90ae381b937aac07 first introduced this todo as below 

https://github.com/apache/arrow/blob/0bfbd19bce3e10163537b349f9205b635c87eea7/python/pyarrow/src/arrow/python/arrow_to_pandas.cc#L1130

Then, the error messages are actually handled at the higher level if I am not mistaken (e.g.,  05bc63c3b76a5fc865434f596c63ff0f26388f69 introduced `_sanitize_arrays` and casting at `asarray` ). So the end users would not reach this. This is more for a sanity check and developers to debug.

This is to improve the error message for the sanity check and developers.

### What changes are included in this PR?

This PR improves the error message in CheckTypeExact arrow_to_pandas.cc by adding the corresponding NumPy string type.

### Are these changes tested?

Unittest is added, and manually run as below:

```
pytest pyarrow/tests/test_cpp_internals.py::test_get_numpy_type_name -v
```

### Are there any user-facing changes?

No.
* GitHub Issue: #48463