### PR TITLE
GH-48467: [C++][Parquet] Add configure to limit the row group size in bytes

### DIFF
--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -5797,8 +5797,8 @@ TEST(TestArrowReadWrite, WriteRecordBatchNotProduceEmptyRowGroup) {
 TEST(TestArrowReadWrite, WriteRecordBatchFlushRowGroupByBufferedSize) {
   auto pool = ::arrow::default_memory_pool();
   auto sink = CreateOutputStream();
-  // Limit the max bytes in a row group to 10 so that each batch produces a new group.
-  auto writer_properties = WriterProperties::Builder().max_row_group_bytes(10)->build();
+  // Limit the max bytes in a row group to 100 so that each batch produces a new group.
+  auto writer_properties = WriterProperties::Builder().max_row_group_bytes(100)->build();
   auto arrow_writer_properties = default_arrow_writer_properties();
 
   // Prepare schema

--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -378,19 +378,19 @@ const double test_traits<::arrow::DoubleType>::value(4.2);
 template <>
 struct test_traits<::arrow::StringType> {
   static constexpr ParquetType::type parquet_enum = ParquetType::BYTE_ARRAY;
-  static std::string const value;
+  static const std::string value;
 };
 
 template <>
 struct test_traits<::arrow::BinaryType> {
   static constexpr ParquetType::type parquet_enum = ParquetType::BYTE_ARRAY;
-  static std::string const value;
+  static const std::string value;
 };
 
 template <>
 struct test_traits<::arrow::FixedSizeBinaryType> {
   static constexpr ParquetType::type parquet_enum = ParquetType::FIXED_LEN_BYTE_ARRAY;
-  static std::string const value;
+  static const std::string value;
 };
 
 const std::string test_traits<::arrow::StringType>::value("Test");            // NOLINT
@@ -5791,6 +5791,44 @@ TEST(TestArrowReadWrite, WriteRecordBatchNotProduceEmptyRowGroup) {
   EXPECT_EQ(20, file_metadata->num_row_groups());
   for (int i = 0; i < 20; ++i) {
     EXPECT_EQ(2, file_metadata->RowGroup(i)->num_rows());
+  }
+}
+
+TEST(TestArrowReadWrite, FlushRowGroupByBufferedSize) {
+  auto pool = ::arrow::default_memory_pool();
+  auto sink = CreateOutputStream();
+  // Limit the max bytes in a row group to 10 so that each batch produces a new group.
+  auto writer_properties = WriterProperties::Builder().max_row_group_bytes(10)->build();
+  auto arrow_writer_properties = default_arrow_writer_properties();
+
+  // Prepare schema
+  auto schema = ::arrow::schema({::arrow::field("a", ::arrow::int64())});
+  std::shared_ptr<SchemaDescriptor> parquet_schema;
+  ASSERT_OK_NO_THROW(ToParquetSchema(schema.get(), *writer_properties,
+                                     *arrow_writer_properties, &parquet_schema));
+  auto schema_node = std::static_pointer_cast<GroupNode>(parquet_schema->schema_root());
+
+  auto gen = ::arrow::random::RandomArrayGenerator(/*seed=*/42);
+
+  // Create writer to write data via RecordBatch.
+  auto writer = ParquetFileWriter::Open(sink, schema_node, writer_properties);
+  std::unique_ptr<FileWriter> arrow_writer;
+  ASSERT_OK(FileWriter::Make(pool, std::move(writer), schema, arrow_writer_properties,
+                             &arrow_writer));
+  // NewBufferedRowGroup() is not called explicitly and it will be called
+  // inside WriteRecordBatch().
+  for (int i = 0; i < 5; ++i) {
+    auto record_batch =
+        gen.BatchOf({::arrow::field("a", ::arrow::int64())}, /*length=*/1);
+    ASSERT_OK_NO_THROW(arrow_writer->WriteRecordBatch(*record_batch));
+  }
+  ASSERT_OK_NO_THROW(arrow_writer->Close());
+  ASSERT_OK_AND_ASSIGN(auto buffer, sink->Finish());
+
+  auto file_metadata = arrow_writer->metadata();
+  EXPECT_EQ(5, file_metadata->num_row_groups());
+  for (int i = 0; i < 5; ++i) {
+    EXPECT_EQ(1, file_metadata->RowGroup(i)->num_rows());
   }
 }
 

--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -378,19 +378,19 @@ const double test_traits<::arrow::DoubleType>::value(4.2);
 template <>
 struct test_traits<::arrow::StringType> {
   static constexpr ParquetType::type parquet_enum = ParquetType::BYTE_ARRAY;
-  static const std::string value;
+  static std::string const value;
 };
 
 template <>
 struct test_traits<::arrow::BinaryType> {
   static constexpr ParquetType::type parquet_enum = ParquetType::BYTE_ARRAY;
-  static const std::string value;
+  static std::string const value;
 };
 
 template <>
 struct test_traits<::arrow::FixedSizeBinaryType> {
   static constexpr ParquetType::type parquet_enum = ParquetType::FIXED_LEN_BYTE_ARRAY;
-  static const std::string value;
+  static std::string const value;
 };
 
 const std::string test_traits<::arrow::StringType>::value("Test");            // NOLINT
@@ -5825,10 +5825,9 @@ TEST(TestArrowReadWrite, WriteRecordBatchFlushRowGroupByBufferedSize) {
   ASSERT_OK_AND_ASSIGN(auto buffer, sink->Finish());
 
   auto file_metadata = arrow_writer->metadata();
-  EXPECT_EQ(5, file_metadata->num_row_groups());
-  for (int i = 0; i < 5; ++i) {
-    EXPECT_EQ(1, file_metadata->RowGroup(i)->num_rows());
-  }
+  EXPECT_EQ(2, file_metadata->num_row_groups());
+  EXPECT_EQ(3, file_metadata->RowGroup(0)->num_rows());
+  EXPECT_EQ(2, file_metadata->RowGroup(1)->num_rows());
 }
 
 TEST(TestArrowReadWrite, WriteTableFlushRowGroupByBufferedSize) {

--- a/cpp/src/parquet/arrow/writer.cc
+++ b/cpp/src/parquet/arrow/writer.cc
@@ -396,7 +396,7 @@ class FileWriterImpl : public FileWriter {
     RETURN_NOT_OK(table.Validate());
 
     if (chunk_size <= 0 && table.num_rows() > 0) {
-      return Status::Invalid("rows per row_group must be greater than 0");
+      return Status::Invalid("chunk size per row_group must be greater than 0");
     } else if (!table.schema()->Equals(*schema_, /*check_metadata=*/false)) {
       return Status::Invalid("table schema does not match this writer's. table:'",
                              table.schema()->ToString(), "' this:'", schema_->ToString(),

--- a/cpp/src/parquet/arrow/writer.cc
+++ b/cpp/src/parquet/arrow/writer.cc
@@ -395,14 +395,23 @@ class FileWriterImpl : public FileWriter {
     RETURN_NOT_OK(CheckClosed());
     RETURN_NOT_OK(table.Validate());
 
-    if (chunk_size <= 0 && table.num_rows() > 0) {
-      return Status::Invalid("chunk size per row_group must be greater than 0");
-    } else if (!table.schema()->Equals(*schema_, false)) {
+    if (!table.schema()->Equals(*schema_, false)) {
       return Status::Invalid("table schema does not match this writer's. table:'",
                              table.schema()->ToString(), "' this:'", schema_->ToString(),
                              "'");
     } else if (chunk_size > this->properties().max_row_group_length()) {
       chunk_size = this->properties().max_row_group_length();
+    }
+    // max_row_group_bytes is applied only after the row group has accumulated data.
+    if (row_group_writer_ != nullptr && row_group_writer_->num_rows() > 0) {
+      double avg_row_size = row_group_writer_->current_buffered_bytes() * 1.0 /
+                            row_group_writer_->num_rows();
+      chunk_size = std::min(
+          chunk_size,
+          static_cast<int64_t>(this->properties().max_row_group_bytes() / avg_row_size));
+    }
+    if (chunk_size <= 0 && table.num_rows() > 0) {
+      return Status::Invalid("rows per row_group must be greater than 0");
     }
 
     auto WriteRowGroup = [&](int64_t offset, int64_t size) {

--- a/cpp/src/parquet/arrow/writer.cc
+++ b/cpp/src/parquet/arrow/writer.cc
@@ -493,15 +493,13 @@ class FileWriterImpl : public FileWriter {
             batch_size,
             static_cast<int64_t>((max_row_group_bytes - buffered_bytes) / avg_row_bytes));
       }
-      if (batch_size <= 0) {
+      if (batch_size > 0) {
+        RETURN_NOT_OK(WriteBatch(offset, batch_size));
+        offset += batch_size;
+      } else if (offset < batch.num_rows()) {
         // Current row group is full, write remaining rows in a new group.
-        if (offset < batch.num_rows()) {
-          RETURN_NOT_OK(NewBufferedRowGroup());
-        }
-        continue;
+        RETURN_NOT_OK(NewBufferedRowGroup());
       }
-      RETURN_NOT_OK(WriteBatch(offset, batch_size));
-      offset += batch_size;
     }
 
     return Status::OK();

--- a/cpp/src/parquet/arrow/writer.cc
+++ b/cpp/src/parquet/arrow/writer.cc
@@ -404,8 +404,8 @@ class FileWriterImpl : public FileWriter {
     }
     // max_row_group_bytes is applied only after the row group has accumulated data.
     if (row_group_writer_ != nullptr && row_group_writer_->num_rows() > 0) {
-      double avg_row_size = row_group_writer_->current_buffered_bytes() * 1.0 /
-                            row_group_writer_->num_rows();
+      double avg_row_size =
+          row_group_writer_->total_buffered_bytes() * 1.0 / row_group_writer_->num_rows();
       chunk_size = std::min(
           chunk_size,
           static_cast<int64_t>(this->properties().max_row_group_bytes() / avg_row_size));
@@ -496,11 +496,11 @@ class FileWriterImpl : public FileWriter {
       int64_t batch_size =
           std::min(max_row_group_length - group_rows, batch.num_rows() - offset);
       if (group_rows > 0) {
-        int64_t buffered_bytes = row_group_writer_->current_buffered_bytes();
-        double avg_row_bytes = buffered_bytes * 1.0 / group_rows;
+        int64_t buffered_bytes = row_group_writer_->total_buffered_bytes();
+        double avg_row_size = buffered_bytes * 1.0 / group_rows;
         batch_size = std::min(
             batch_size,
-            static_cast<int64_t>((max_row_group_bytes - buffered_bytes) / avg_row_bytes));
+            static_cast<int64_t>((max_row_group_bytes - buffered_bytes) / avg_row_size));
       }
       if (batch_size > 0) {
         RETURN_NOT_OK(WriteBatch(offset, batch_size));

--- a/cpp/src/parquet/arrow/writer.h
+++ b/cpp/src/parquet/arrow/writer.h
@@ -111,9 +111,9 @@ class PARQUET_EXPORT FileWriter {
   /// Multiple RecordBatches can be written into the same row group
   /// through this method.
   ///
-  /// WriterProperties.max_row_group_length() is respected and a new
-  /// row group will be created if the current row group exceeds the
-  /// limit.
+  /// WriterProperties.max_row_group_length() and WriterProperties.max_row_group_bytes()
+  /// are respected and a new row group will be created if the current row group exceeds
+  /// the limits.
   ///
   /// Batches get flushed to the output stream once NewBufferedRowGroup()
   /// or Close() is called.

--- a/cpp/src/parquet/arrow/writer.h
+++ b/cpp/src/parquet/arrow/writer.h
@@ -139,8 +139,8 @@ class PARQUET_EXPORT FileWriter {
   /// `store_schema` being unusable during read.
   virtual ::arrow::Status AddKeyValueMetadata(
       const std::shared_ptr<const ::arrow::KeyValueMetadata>& key_value_metadata) = 0;
-  /// \brief Estimate compressed bytes per row from closed row groups or the active row
-  /// group.
+  /// \brief Estimate compressed bytes per row from data written so far.
+  /// \note std::nullopt will be returned if there is no row written.
   virtual std::optional<double> EstimateCompressedBytesPerRow() const = 0;
   /// \brief Return the file metadata, only available after calling Close().
   virtual const std::shared_ptr<FileMetaData> metadata() const = 0;

--- a/cpp/src/parquet/arrow/writer.h
+++ b/cpp/src/parquet/arrow/writer.h
@@ -139,6 +139,9 @@ class PARQUET_EXPORT FileWriter {
   /// `store_schema` being unusable during read.
   virtual ::arrow::Status AddKeyValueMetadata(
       const std::shared_ptr<const ::arrow::KeyValueMetadata>& key_value_metadata) = 0;
+  /// \brief Estimate compressed bytes per row from closed row groups or the active row
+  /// group.
+  virtual std::optional<double> EstimateCompressedBytesPerRow() const = 0;
   /// \brief Return the file metadata, only available after calling Close().
   virtual const std::shared_ptr<FileMetaData> metadata() const = 0;
 };

--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -1480,6 +1480,10 @@ class TypedColumnWriterImpl : public ColumnWriterImpl,
     return current_encoder_->EstimatedDataEncodedSize();
   }
 
+  int64_t EstimatedBufferedLevelsBytes() const override {
+    return definition_levels_sink_.length() + repetition_levels_sink_.length();
+  }
+
  protected:
   std::shared_ptr<Buffer> GetValuesBuffer() override {
     return current_encoder_->FlushValues();

--- a/cpp/src/parquet/column_writer.h
+++ b/cpp/src/parquet/column_writer.h
@@ -164,6 +164,9 @@ class PARQUET_EXPORT ColumnWriter {
   /// \brief Estimated size of the values that are not written to a page yet.
   virtual int64_t estimated_buffered_value_bytes() const = 0;
 
+  /// \brief Estimated size of the levels that are not written to a page yet.
+  virtual int64_t EstimatedBufferedLevelsBytes() const = 0;
+
   /// \brief The file-level writer properties
   virtual const WriterProperties* properties() = 0;
 

--- a/cpp/src/parquet/file_writer.cc
+++ b/cpp/src/parquet/file_writer.cc
@@ -68,6 +68,12 @@ int64_t RowGroupWriter::total_compressed_bytes_written() const {
   return contents_->total_compressed_bytes_written();
 }
 
+int64_t RowGroupWriter::current_buffered_bytes() const {
+  return contents_->total_compressed_bytes() +
+         contents_->total_compressed_bytes_written() +
+         contents_->estimated_buffered_value_bytes();
+}
+
 bool RowGroupWriter::buffered() const { return contents_->buffered(); }
 
 int RowGroupWriter::current_column() { return contents_->current_column(); }
@@ -193,6 +199,20 @@ class RowGroupSerializer : public RowGroupWriter::Contents {
       }
     }
     return total_compressed_bytes_written;
+  }
+
+  int64_t estimated_buffered_value_bytes() const override {
+    if (closed_) {
+      return 0;
+    }
+    int64_t estimated_buffered_value_bytes = 0;
+    for (size_t i = 0; i < column_writers_.size(); i++) {
+      if (column_writers_[i]) {
+        estimated_buffered_value_bytes +=
+            column_writers_[i]->estimated_buffered_value_bytes();
+      }
+    }
+    return estimated_buffered_value_bytes;
   }
 
   bool buffered() const override { return buffered_row_group_; }

--- a/cpp/src/parquet/file_writer.cc
+++ b/cpp/src/parquet/file_writer.cc
@@ -71,7 +71,7 @@ int64_t RowGroupWriter::total_compressed_bytes_written() const {
 int64_t RowGroupWriter::EstimatedTotalCompressedBytes() const {
   return contents_->total_compressed_bytes() +
          contents_->total_compressed_bytes_written() +
-         contents_->EstimatedBufferedValueBytes();
+         contents_->EstimatedBufferedBytes();
 }
 
 bool RowGroupWriter::buffered() const { return contents_->buffered(); }
@@ -201,7 +201,7 @@ class RowGroupSerializer : public RowGroupWriter::Contents {
     return total_compressed_bytes_written;
   }
 
-  int64_t EstimatedBufferedValueBytes() const override {
+  int64_t EstimatedBufferedBytes() const override {
     if (closed_) {
       return 0;
     }
@@ -209,7 +209,8 @@ class RowGroupSerializer : public RowGroupWriter::Contents {
     for (size_t i = 0; i < column_writers_.size(); i++) {
       if (column_writers_[i]) {
         estimated_buffered_value_bytes +=
-            column_writers_[i]->estimated_buffered_value_bytes();
+            column_writers_[i]->estimated_buffered_value_bytes() +
+            column_writers_[i]->EstimatedBufferedLevelsBytes();
       }
     }
     return estimated_buffered_value_bytes;

--- a/cpp/src/parquet/file_writer.cc
+++ b/cpp/src/parquet/file_writer.cc
@@ -68,10 +68,10 @@ int64_t RowGroupWriter::total_compressed_bytes_written() const {
   return contents_->total_compressed_bytes_written();
 }
 
-int64_t RowGroupWriter::current_buffered_bytes() const {
+int64_t RowGroupWriter::total_buffered_bytes() const {
   return contents_->total_compressed_bytes() +
          contents_->total_compressed_bytes_written() +
-         contents_->estimated_buffered_value_bytes();
+         contents_->EstimatedBufferedValueBytes();
 }
 
 bool RowGroupWriter::buffered() const { return contents_->buffered(); }
@@ -201,7 +201,7 @@ class RowGroupSerializer : public RowGroupWriter::Contents {
     return total_compressed_bytes_written;
   }
 
-  int64_t estimated_buffered_value_bytes() const override {
+  int64_t EstimatedBufferedValueBytes() const override {
     if (closed_) {
       return 0;
     }

--- a/cpp/src/parquet/file_writer.h
+++ b/cpp/src/parquet/file_writer.h
@@ -59,7 +59,7 @@ class PARQUET_EXPORT RowGroupWriter {
     /// \brief total compressed bytes written by the page writer
     virtual int64_t total_compressed_bytes_written() const = 0;
     /// \brief estimated size of the values that are not written to a page yet
-    virtual int64_t estimated_buffered_value_bytes() const = 0;
+    virtual int64_t EstimatedBufferedValueBytes() const = 0;
 
     virtual bool buffered() const = 0;
   };
@@ -103,7 +103,7 @@ class PARQUET_EXPORT RowGroupWriter {
   int64_t total_compressed_bytes_written() const;
   /// \brief including compressed bytes in page writer and uncompressed data
   /// value buffer.
-  int64_t current_buffered_bytes() const;
+  int64_t total_buffered_bytes() const;
 
   /// Returns whether the current RowGroupWriter is in the buffered mode and is created
   /// by calling ParquetFileWriter::AppendBufferedRowGroup.

--- a/cpp/src/parquet/file_writer.h
+++ b/cpp/src/parquet/file_writer.h
@@ -58,6 +58,8 @@ class PARQUET_EXPORT RowGroupWriter {
     virtual int64_t total_compressed_bytes() const = 0;
     /// \brief total compressed bytes written by the page writer
     virtual int64_t total_compressed_bytes_written() const = 0;
+    /// \brief estimated size of the values that are not written to a page yet
+    virtual int64_t estimated_buffered_value_bytes() const = 0;
 
     virtual bool buffered() const = 0;
   };
@@ -99,6 +101,9 @@ class PARQUET_EXPORT RowGroupWriter {
   int64_t total_compressed_bytes() const;
   /// \brief total compressed bytes written by the page writer
   int64_t total_compressed_bytes_written() const;
+  /// \brief including compressed bytes in page writer and uncompressed data
+  /// value buffer.
+  int64_t current_buffered_bytes() const;
 
   /// Returns whether the current RowGroupWriter is in the buffered mode and is created
   /// by calling ParquetFileWriter::AppendBufferedRowGroup.

--- a/cpp/src/parquet/file_writer.h
+++ b/cpp/src/parquet/file_writer.h
@@ -58,9 +58,9 @@ class PARQUET_EXPORT RowGroupWriter {
     virtual int64_t total_compressed_bytes() const = 0;
     /// \brief total compressed bytes written by the page writer
     virtual int64_t total_compressed_bytes_written() const = 0;
-    /// \brief estimated bytes of values that are buffered by the page writer
+    /// \brief Estimated bytes of values and levels that are buffered by the page writer
     /// but not written to a page yet
-    virtual int64_t EstimatedBufferedValueBytes() const = 0;
+    virtual int64_t EstimatedBufferedBytes() const = 0;
 
     virtual bool buffered() const = 0;
   };
@@ -155,8 +155,8 @@ class PARQUET_EXPORT ParquetFileWriter {
     virtual RowGroupWriter* AppendRowGroup() = 0;
     virtual RowGroupWriter* AppendBufferedRowGroup() = 0;
 
-    virtual int64_t num_rows() const = 0;
     virtual int64_t written_compressed_bytes() const = 0;
+    virtual int64_t num_rows() const = 0;
     virtual int num_columns() const = 0;
     virtual int num_row_groups() const = 0;
 

--- a/cpp/src/parquet/file_writer.h
+++ b/cpp/src/parquet/file_writer.h
@@ -58,7 +58,8 @@ class PARQUET_EXPORT RowGroupWriter {
     virtual int64_t total_compressed_bytes() const = 0;
     /// \brief total compressed bytes written by the page writer
     virtual int64_t total_compressed_bytes_written() const = 0;
-    /// \brief estimated size of the values that are not written to a page yet
+    /// \brief estimated bytes of values that are buffered by the page writer
+    /// but not written to a page yet
     virtual int64_t EstimatedBufferedValueBytes() const = 0;
 
     virtual bool buffered() const = 0;
@@ -101,9 +102,8 @@ class PARQUET_EXPORT RowGroupWriter {
   int64_t total_compressed_bytes() const;
   /// \brief total compressed bytes written by the page writer
   int64_t total_compressed_bytes_written() const;
-  /// \brief including compressed bytes in page writer and uncompressed data
-  /// value buffer.
-  int64_t total_buffered_bytes() const;
+  /// \brief Estimate total compressed bytes including written and buffered bytes.
+  int64_t EstimatedTotalCompressedBytes() const;
 
   /// Returns whether the current RowGroupWriter is in the buffered mode and is created
   /// by calling ParquetFileWriter::AppendBufferedRowGroup.
@@ -156,6 +156,7 @@ class PARQUET_EXPORT ParquetFileWriter {
     virtual RowGroupWriter* AppendBufferedRowGroup() = 0;
 
     virtual int64_t num_rows() const = 0;
+    virtual int64_t compressed_bytes() const = 0;
     virtual int num_columns() const = 0;
     virtual int num_row_groups() const = 0;
 
@@ -211,6 +212,9 @@ class PARQUET_EXPORT ParquetFileWriter {
   /// \throw ParquetException if Close() has been called.
   void AddKeyValueMetadata(
       const std::shared_ptr<const KeyValueMetadata>& key_value_metadata);
+
+  /// Estimate compressed bytes per row from closed row groups.
+  std::optional<double> EstimateCompressedBytesPerRow() const;
 
   /// Number of columns.
   ///

--- a/cpp/src/parquet/file_writer.h
+++ b/cpp/src/parquet/file_writer.h
@@ -156,7 +156,7 @@ class PARQUET_EXPORT ParquetFileWriter {
     virtual RowGroupWriter* AppendBufferedRowGroup() = 0;
 
     virtual int64_t num_rows() const = 0;
-    virtual int64_t compressed_bytes() const = 0;
+    virtual int64_t written_compressed_bytes() const = 0;
     virtual int num_columns() const = 0;
     virtual int num_row_groups() const = 0;
 
@@ -213,7 +213,8 @@ class PARQUET_EXPORT ParquetFileWriter {
   void AddKeyValueMetadata(
       const std::shared_ptr<const KeyValueMetadata>& key_value_metadata);
 
-  /// Estimate compressed bytes per row from closed row groups.
+  /// \brief Estimate compressed bytes per row from closed row groups.
+  /// \return Estimated bytes or std::nullopt when no written row group.
   std::optional<double> EstimateCompressedBytesPerRow() const;
 
   /// Number of columns.

--- a/cpp/src/parquet/properties.cc
+++ b/cpp/src/parquet/properties.cc
@@ -67,6 +67,20 @@ std::shared_ptr<ArrowWriterProperties> default_arrow_writer_properties() {
   return default_writer_properties;
 }
 
+WriterProperties::Builder* WriterProperties::Builder::max_row_group_length(
+    int64_t max_row_group_length) {
+  ARROW_CHECK_GT(max_row_group_length, 0) << "max_row_group_length must be positive";
+  max_row_group_length_ = max_row_group_length;
+  return this;
+}
+
+WriterProperties::Builder* WriterProperties::Builder::max_row_group_bytes(
+    int64_t max_row_group_bytes) {
+  ARROW_CHECK_GT(max_row_group_bytes, 0) << "max_row_group_bytes must be positive";
+  max_row_group_bytes_ = max_row_group_bytes;
+  return this;
+}
+
 void WriterProperties::Builder::CopyColumnSpecificProperties(
     const WriterProperties& properties) {
   for (const auto& [col_path, col_props] : properties.column_properties_) {

--- a/cpp/src/parquet/properties.h
+++ b/cpp/src/parquet/properties.h
@@ -160,6 +160,7 @@ static constexpr bool DEFAULT_IS_DICTIONARY_ENABLED = true;
 static constexpr int64_t DEFAULT_DICTIONARY_PAGE_SIZE_LIMIT = kDefaultDataPageSize;
 static constexpr int64_t DEFAULT_WRITE_BATCH_SIZE = 1024;
 static constexpr int64_t DEFAULT_MAX_ROW_GROUP_LENGTH = 1024 * 1024;
+static constexpr int64_t DEFAULT_MAX_ROW_GROUP_BYTES = 128 * 1024 * 1024;
 static constexpr bool DEFAULT_ARE_STATISTICS_ENABLED = true;
 static constexpr int64_t DEFAULT_MAX_STATISTICS_SIZE = 4096;
 static constexpr Encoding::type DEFAULT_ENCODING = Encoding::UNKNOWN;
@@ -293,6 +294,7 @@ class PARQUET_EXPORT WriterProperties {
           dictionary_pagesize_limit_(DEFAULT_DICTIONARY_PAGE_SIZE_LIMIT),
           write_batch_size_(DEFAULT_WRITE_BATCH_SIZE),
           max_row_group_length_(DEFAULT_MAX_ROW_GROUP_LENGTH),
+          max_row_group_bytes_(DEFAULT_MAX_ROW_GROUP_BYTES),
           pagesize_(kDefaultDataPageSize),
           max_rows_per_page_(kDefaultMaxRowsPerPage),
           version_(ParquetVersion::PARQUET_2_6),
@@ -309,6 +311,7 @@ class PARQUET_EXPORT WriterProperties {
           dictionary_pagesize_limit_(properties.dictionary_pagesize_limit()),
           write_batch_size_(properties.write_batch_size()),
           max_row_group_length_(properties.max_row_group_length()),
+          max_row_group_bytes_(properties.max_row_group_bytes()),
           pagesize_(properties.data_pagesize()),
           max_rows_per_page_(properties.max_rows_per_page()),
           version_(properties.version()),
@@ -415,6 +418,13 @@ class PARQUET_EXPORT WriterProperties {
     /// Default 1Mi rows.
     Builder* max_row_group_length(int64_t max_row_group_length) {
       max_row_group_length_ = max_row_group_length;
+      return this;
+    }
+
+    /// Specify the max number of bytes to put in a single row group.
+    /// Default 128MB.
+    Builder* max_row_group_bytes(int64_t max_row_group_bytes) {
+      max_row_group_bytes_ = max_row_group_bytes;
       return this;
     }
 
@@ -779,11 +789,12 @@ class PARQUET_EXPORT WriterProperties {
 
       return std::shared_ptr<WriterProperties>(new WriterProperties(
           pool_, dictionary_pagesize_limit_, write_batch_size_, max_row_group_length_,
-          pagesize_, max_rows_per_page_, version_, created_by_, page_checksum_enabled_,
-          size_statistics_level_, std::move(file_encryption_properties_),
-          default_column_properties_, column_properties, data_page_version_,
-          store_decimal_as_integer_, std::move(sorting_columns_),
-          content_defined_chunking_enabled_, content_defined_chunking_options_));
+          max_row_group_bytes_, pagesize_, max_rows_per_page_, version_, created_by_,
+          page_checksum_enabled_, size_statistics_level_,
+          std::move(file_encryption_properties_), default_column_properties_,
+          column_properties, data_page_version_, store_decimal_as_integer_,
+          std::move(sorting_columns_), content_defined_chunking_enabled_,
+          content_defined_chunking_options_));
     }
 
    private:
@@ -793,6 +804,7 @@ class PARQUET_EXPORT WriterProperties {
     int64_t dictionary_pagesize_limit_;
     int64_t write_batch_size_;
     int64_t max_row_group_length_;
+    int64_t max_row_group_bytes_;
     int64_t pagesize_;
     int64_t max_rows_per_page_;
     ParquetVersion::type version_;
@@ -827,6 +839,8 @@ class PARQUET_EXPORT WriterProperties {
   inline int64_t write_batch_size() const { return write_batch_size_; }
 
   inline int64_t max_row_group_length() const { return max_row_group_length_; }
+
+  inline int64_t max_row_group_bytes() const { return max_row_group_bytes_; }
 
   inline int64_t data_pagesize() const { return pagesize_; }
 
@@ -946,9 +960,10 @@ class PARQUET_EXPORT WriterProperties {
  private:
   explicit WriterProperties(
       MemoryPool* pool, int64_t dictionary_pagesize_limit, int64_t write_batch_size,
-      int64_t max_row_group_length, int64_t pagesize, int64_t max_rows_per_page,
-      ParquetVersion::type version, const std::string& created_by,
-      bool page_write_checksum_enabled, SizeStatisticsLevel size_statistics_level,
+      int64_t max_row_group_length, int64_t max_row_group_bytes, int64_t pagesize,
+      int64_t max_rows_per_page, ParquetVersion::type version,
+      const std::string& created_by, bool page_write_checksum_enabled,
+      SizeStatisticsLevel size_statistics_level,
       std::shared_ptr<FileEncryptionProperties> file_encryption_properties,
       const ColumnProperties& default_column_properties,
       const std::unordered_map<std::string, ColumnProperties>& column_properties,
@@ -959,6 +974,7 @@ class PARQUET_EXPORT WriterProperties {
         dictionary_pagesize_limit_(dictionary_pagesize_limit),
         write_batch_size_(write_batch_size),
         max_row_group_length_(max_row_group_length),
+        max_row_group_bytes_(max_row_group_bytes),
         pagesize_(pagesize),
         max_rows_per_page_(max_rows_per_page),
         parquet_data_page_version_(data_page_version),
@@ -978,6 +994,7 @@ class PARQUET_EXPORT WriterProperties {
   int64_t dictionary_pagesize_limit_;
   int64_t write_batch_size_;
   int64_t max_row_group_length_;
+  int64_t max_row_group_bytes_;
   int64_t pagesize_;
   int64_t max_rows_per_page_;
   ParquetDataPageVersion parquet_data_page_version_;

--- a/cpp/src/parquet/properties.h
+++ b/cpp/src/parquet/properties.h
@@ -26,7 +26,6 @@
 #include "arrow/io/caching.h"
 #include "arrow/type_fwd.h"
 #include "arrow/util/compression.h"
-#include "arrow/util/logging.h"
 #include "arrow/util/type_fwd.h"
 #include "parquet/encryption/encryption.h"
 #include "parquet/exception.h"
@@ -417,20 +416,12 @@ class PARQUET_EXPORT WriterProperties {
 
     /// Specify the max number of rows to put in a single row group.
     /// Default 1Mi rows.
-    Builder* max_row_group_length(int64_t max_row_group_length) {
-      ARROW_CHECK_GT(max_row_group_length, 0) << "max_row_group_length must be positive";
-      max_row_group_length_ = max_row_group_length;
-      return this;
-    }
+    Builder* max_row_group_length(int64_t max_row_group_length);
 
     /// Specify the max number of bytes to put in a single row group.
     /// The size is estimated based on encoded and compressed data.
     /// Default 128MB.
-    Builder* max_row_group_bytes(int64_t max_row_group_bytes) {
-      ARROW_CHECK_GT(max_row_group_bytes, 0) << "max_row_group_bytes must be positive";
-      max_row_group_bytes_ = max_row_group_bytes;
-      return this;
-    }
+    Builder* max_row_group_bytes(int64_t max_row_group_bytes);
 
     /// Specify the data page size.
     /// Default 1MB.

--- a/cpp/src/parquet/properties.h
+++ b/cpp/src/parquet/properties.h
@@ -26,6 +26,7 @@
 #include "arrow/io/caching.h"
 #include "arrow/type_fwd.h"
 #include "arrow/util/compression.h"
+#include "arrow/util/logging.h"
 #include "arrow/util/type_fwd.h"
 #include "parquet/encryption/encryption.h"
 #include "parquet/exception.h"
@@ -417,13 +418,16 @@ class PARQUET_EXPORT WriterProperties {
     /// Specify the max number of rows to put in a single row group.
     /// Default 1Mi rows.
     Builder* max_row_group_length(int64_t max_row_group_length) {
+      ARROW_CHECK_GT(max_row_group_length, 0) << "max_row_group_length must be positive";
       max_row_group_length_ = max_row_group_length;
       return this;
     }
 
     /// Specify the max number of bytes to put in a single row group.
+    /// The size is estimated based on encoded and compressed data.
     /// Default 128MB.
     Builder* max_row_group_bytes(int64_t max_row_group_bytes) {
+      ARROW_CHECK_GT(max_row_group_bytes, 0) << "max_row_group_bytes must be positive";
       max_row_group_bytes_ = max_row_group_bytes;
       return this;
     }


### PR DESCRIPTION
### Rationale for this change
Limit the row group size in bytes

### What changes are included in this PR?
Add a new config `parquet::WriterProperties::max_row_group_bytes`.

### Are these changes tested?
Yes, add unit test.

### Are there any user-facing changes?
Yes, user could use the new config to limit row group size.

* GitHub Issue: #48467