### PR TITLE
GH-48471: [Ruby] Add support for reading Int16 and UInt16 arrays

### DIFF
--- a/ruby/red-arrow-format/lib/arrow-format/array.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/array.rb
@@ -91,6 +91,18 @@ module ArrowFormat
     end
   end
 
+  class Int16Array < IntArray
+    def to_a
+      apply_validity(@values_buffer.values(:s16, 0, @size))
+    end
+  end
+
+  class UInt16Array < IntArray
+    def to_a
+      apply_validity(@values_buffer.values(:u16, 0, @size))
+    end
+  end
+
   class FloatingPointArray < Array
     def initialize(type, size, validity_buffer, values_buffer)
       super(type, size, validity_buffer)

--- a/ruby/red-arrow-format/lib/arrow-format/file-reader.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/file-reader.rb
@@ -156,6 +156,12 @@ module ArrowFormat
           else
             type = UInt8Type.singleton
           end
+        when 16
+          if fb_type.signed?
+            type = Int16Type.singleton
+          else
+            type = UInt16Type.singleton
+          end
         end
       when Org::Apache::Arrow::Flatbuf::FloatingPoint
         case fb_type.precision

--- a/ruby/red-arrow-format/lib/arrow-format/type.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/type.rb
@@ -99,6 +99,38 @@ module ArrowFormat
     end
   end
 
+  class Int16Type < IntType
+    class << self
+      def singleton
+        @singleton ||= new
+      end
+    end
+
+    def initialize
+      super("Int16", 16, true)
+    end
+
+    def build_array(size, validity_buffer, values_buffer)
+      Int16Array.new(self, size, validity_buffer, values_buffer)
+    end
+  end
+
+  class UInt16Type < IntType
+    class << self
+      def singleton
+        @singleton ||= new
+      end
+    end
+
+    def initialize
+      super("UInt16", 16, false)
+    end
+
+    def build_array(size, validity_buffer, values_buffer)
+      UInt16Array.new(self, size, validity_buffer, values_buffer)
+    end
+  end
+
   class FloatingPointType < NumberType
     attr_reader :precision
     def initialize(name, precision)

--- a/ruby/red-arrow-format/test/test-file-reader.rb
+++ b/ruby/red-arrow-format/test/test-file-reader.rb
@@ -84,6 +84,28 @@ class TestFileReader < Test::Unit::TestCase
     end
   end
 
+  sub_test_case("Int16") do
+    def build_array
+      Arrow::Int16Array.new([-32768, nil, 32767])
+    end
+
+    def test_read
+      assert_equal([{"value" => [-32768, nil, 32767]}],
+                   read)
+    end
+  end
+
+  sub_test_case("UInt16") do
+    def build_array
+      Arrow::UInt16Array.new([0, nil, 65535])
+    end
+
+    def test_read
+      assert_equal([{"value" => [0, nil, 65535]}],
+                   read)
+    end
+  end
+
   sub_test_case("Float32") do
     def build_array
       Arrow::FloatArray.new([-0.5, nil, 0.5])


### PR DESCRIPTION
### Rationale for this change

They are int16 and uint16 variants of an int array.


### What changes are included in this PR?

* Add `ArrowFromat::Int16Type`
* Add `ArrowFromat::UInt16Type`
* Add `ArrowFromat::Int16Array`
* Add `ArrowFromat::UInt16Array`

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #48471