### PR TITLE
GH-48475: [Ruby] Add support for reading Int32 and UInt32 arrays

### DIFF
--- a/ruby/red-arrow-format/lib/arrow-format/array.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/array.rb
@@ -103,6 +103,18 @@ module ArrowFormat
     end
   end
 
+  class Int32Array < IntArray
+    def to_a
+      apply_validity(@values_buffer.values(:s32, 0, @size))
+    end
+  end
+
+  class UInt32Array < IntArray
+    def to_a
+      apply_validity(@values_buffer.values(:u32, 0, @size))
+    end
+  end
+
   class FloatingPointArray < Array
     def initialize(type, size, validity_buffer, values_buffer)
       super(type, size, validity_buffer)

--- a/ruby/red-arrow-format/lib/arrow-format/file-reader.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/file-reader.rb
@@ -164,6 +164,12 @@ module ArrowFormat
           else
             type = UInt16Type.singleton
           end
+        when 32
+          if fb_type.signed?
+            type = Int32Type.singleton
+          else
+            type = UInt32Type.singleton
+          end
         end
       when Org::Apache::Arrow::Flatbuf::FloatingPoint
         case fb_type.precision

--- a/ruby/red-arrow-format/lib/arrow-format/type.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/type.rb
@@ -131,6 +131,38 @@ module ArrowFormat
     end
   end
 
+  class Int32Type < IntType
+    class << self
+      def singleton
+        @singleton ||= new
+      end
+    end
+
+    def initialize
+      super("Int32", 32, true)
+    end
+
+    def build_array(size, validity_buffer, values_buffer)
+      Int32Array.new(self, size, validity_buffer, values_buffer)
+    end
+  end
+
+  class UInt32Type < IntType
+    class << self
+      def singleton
+        @singleton ||= new
+      end
+    end
+
+    def initialize
+      super("UInt32", 32, false)
+    end
+
+    def build_array(size, validity_buffer, values_buffer)
+      UInt32Array.new(self, size, validity_buffer, values_buffer)
+    end
+  end
+
   class FloatingPointType < NumberType
     attr_reader :precision
     def initialize(name, precision)

--- a/ruby/red-arrow-format/test/test-file-reader.rb
+++ b/ruby/red-arrow-format/test/test-file-reader.rb
@@ -106,6 +106,28 @@ class TestFileReader < Test::Unit::TestCase
     end
   end
 
+  sub_test_case("Int32") do
+    def build_array
+      Arrow::Int32Array.new([-2147483648, nil, 2147483647])
+    end
+
+    def test_read
+      assert_equal([{"value" => [-2147483648, nil, 2147483647]}],
+                   read)
+    end
+  end
+
+  sub_test_case("UInt32") do
+    def build_array
+      Arrow::UInt32Array.new([0, nil, 4294967295])
+    end
+
+    def test_read
+      assert_equal([{"value" => [0, nil, 4294967295]}],
+                   read)
+    end
+  end
+
   sub_test_case("Float32") do
     def build_array
       Arrow::FloatArray.new([-0.5, nil, 0.5])


### PR DESCRIPTION
### Rationale for this change

They are int32 and uint32 variants of an int array.


### What changes are included in this PR?

* Add `ArrowFromat::Int32Type`
* Add `ArrowFromat::UInt32Type`
* Add `ArrowFromat::Int32Array`
* Add `ArrowFromat::UInt32Array`

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.

* GitHub Issue: #48475