### PR TITLE
GH-48479: [Ruby] Add support for reading Int64 and UInt64 arrays

### DIFF
--- a/ruby/red-arrow-format/lib/arrow-format/array.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/array.rb
@@ -115,6 +115,18 @@ module ArrowFormat
     end
   end
 
+  class Int64Array < IntArray
+    def to_a
+      apply_validity(@values_buffer.values(:s64, 0, @size))
+    end
+  end
+
+  class UInt64Array < IntArray
+    def to_a
+      apply_validity(@values_buffer.values(:u64, 0, @size))
+    end
+  end
+
   class FloatingPointArray < Array
     def initialize(type, size, validity_buffer, values_buffer)
       super(type, size, validity_buffer)

--- a/ruby/red-arrow-format/lib/arrow-format/file-reader.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/file-reader.rb
@@ -170,6 +170,12 @@ module ArrowFormat
           else
             type = UInt32Type.singleton
           end
+        when 64
+          if fb_type.signed?
+            type = Int64Type.singleton
+          else
+            type = UInt64Type.singleton
+          end
         end
       when Org::Apache::Arrow::Flatbuf::FloatingPoint
         case fb_type.precision

--- a/ruby/red-arrow-format/lib/arrow-format/type.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/type.rb
@@ -163,6 +163,38 @@ module ArrowFormat
     end
   end
 
+  class Int64Type < IntType
+    class << self
+      def singleton
+        @singleton ||= new
+      end
+    end
+
+    def initialize
+      super("Int64", 64, true)
+    end
+
+    def build_array(size, validity_buffer, values_buffer)
+      Int64Array.new(self, size, validity_buffer, values_buffer)
+    end
+  end
+
+  class UInt64Type < IntType
+    class << self
+      def singleton
+        @singleton ||= new
+      end
+    end
+
+    def initialize
+      super("UInt64", 64, false)
+    end
+
+    def build_array(size, validity_buffer, values_buffer)
+      UInt64Array.new(self, size, validity_buffer, values_buffer)
+    end
+  end
+
   class FloatingPointType < NumberType
     attr_reader :precision
     def initialize(name, precision)

--- a/ruby/red-arrow-format/test/test-file-reader.rb
+++ b/ruby/red-arrow-format/test/test-file-reader.rb
@@ -138,13 +138,14 @@ class TestFileReader < Test::Unit::TestCase
     end
 
     def test_read
-      assert_equal([{"value" => 
-                      [
-                        -9223372036854775808,
-                        nil,
-                        9223372036854775807
-                      ]
-                    }
+      assert_equal([
+                     {
+                       "value" => [
+                         -9223372036854775808,
+                         nil,
+                         9223372036854775807
+                       ]
+                     }
                    ],
                    read)
     end

--- a/ruby/red-arrow-format/test/test-file-reader.rb
+++ b/ruby/red-arrow-format/test/test-file-reader.rb
@@ -128,6 +128,39 @@ class TestFileReader < Test::Unit::TestCase
     end
   end
 
+  sub_test_case("Int64") do
+    def build_array
+      Arrow::Int64Array.new([
+                              -9223372036854775808,
+                              nil,
+                              9223372036854775807
+                            ])
+    end
+
+    def test_read
+      assert_equal([{"value" => 
+                      [
+                        -9223372036854775808,
+                        nil,
+                        9223372036854775807
+                      ]
+                    }
+                   ],
+                   read)
+    end
+  end
+
+  sub_test_case("UInt64") do
+    def build_array
+      Arrow::UInt64Array.new([0, nil, 18446744073709551615])
+    end
+
+    def test_read
+      assert_equal([{"value" => [0, nil, 18446744073709551615]}],
+                   read)
+    end
+  end
+
   sub_test_case("Float32") do
     def build_array
       Arrow::FloatArray.new([-0.5, nil, 0.5])


### PR DESCRIPTION
### Rationale for this change

They are int64 and uint64 variants of an int array.

### What changes are included in this PR?

* Add `ArrowFromat::Int64Type`
* Add `ArrowFromat::UInt64Type`
* Add `ArrowFromat::Int64Array`
* Add `ArrowFromat::UInt64Array`

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.

* GitHub Issue: #48479