### PR TITLE
GH-48484: [GLib][Ruby] Add GArrowJoinOptions

### DIFF
--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -1289,4 +1289,36 @@ GARROW_AVAILABLE_IN_23_0
 GArrowExtractRegexSpanOptions *
 garrow_extract_regex_span_options_new(void);
 
+/**
+ * GArrowJoinNullHandlingBehavior:
+ * @GARROW_JOIN_NULL_HANDLING_EMIT_NULL: A null in any input results in a null in the
+ * output.
+ * @GARROW_JOIN_NULL_HANDLING_SKIP: Nulls in inputs are skipped.
+ * @GARROW_JOIN_NULL_HANDLING_REPLACE: Nulls in inputs are replaced with the replacement
+ * string.
+ *
+ * They correspond to the values of
+ * `arrow::compute::JoinOptions::NullHandlingBehavior`.
+ *
+ * Since: 23.0.0
+ */
+typedef enum {
+  GARROW_JOIN_NULL_HANDLING_EMIT_NULL,
+  GARROW_JOIN_NULL_HANDLING_SKIP,
+  GARROW_JOIN_NULL_HANDLING_REPLACE,
+} GArrowJoinNullHandlingBehavior;
+
+#define GARROW_TYPE_JOIN_OPTIONS (garrow_join_options_get_type())
+GARROW_AVAILABLE_IN_23_0
+G_DECLARE_DERIVABLE_TYPE(
+  GArrowJoinOptions, garrow_join_options, GARROW, JOIN_OPTIONS, GArrowFunctionOptions)
+struct _GArrowJoinOptionsClass
+{
+  GArrowFunctionOptionsClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_23_0
+GArrowJoinOptions *
+garrow_join_options_new(void);
+
 G_END_DECLS

--- a/c_glib/arrow-glib/compute.hpp
+++ b/c_glib/arrow-glib/compute.hpp
@@ -215,3 +215,8 @@ garrow_extract_regex_span_options_new_raw(
   const arrow::compute::ExtractRegexSpanOptions *arrow_options);
 arrow::compute::ExtractRegexSpanOptions *
 garrow_extract_regex_span_options_get_raw(GArrowExtractRegexSpanOptions *options);
+
+GArrowJoinOptions *
+garrow_join_options_new_raw(const arrow::compute::JoinOptions *arrow_options);
+arrow::compute::JoinOptions *
+garrow_join_options_get_raw(GArrowJoinOptions *options);

--- a/c_glib/test/test-join-options.rb
+++ b/c_glib/test/test-join-options.rb
@@ -1,0 +1,63 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestJoinOptions < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def setup
+    @options = Arrow::JoinOptions.new
+  end
+
+  def test_null_handling_property
+    assert_equal(Arrow::JoinNullHandlingBehavior::EMIT_NULL, @options.null_handling)
+    @options.null_handling = :skip
+    assert_equal(Arrow::JoinNullHandlingBehavior::SKIP, @options.null_handling)
+    @options.null_handling = :replace
+    assert_equal(Arrow::JoinNullHandlingBehavior::REPLACE, @options.null_handling)
+  end
+
+  def test_null_replacement_property
+    assert_equal("", @options.null_replacement)
+    @options.null_replacement = "NULL"
+    assert_equal("NULL", @options.null_replacement)
+  end
+
+  def test_binary_join_element_wise_function
+    args = [
+      Arrow::ArrayDatum.new(build_string_array(["a", "b", nil])),
+      Arrow::ArrayDatum.new(build_string_array(["x", "y", "z"])),
+      Arrow::ScalarDatum.new(Arrow::StringScalar.new(Arrow::Buffer.new("-"))),
+    ]
+    binary_join_element_wise_function = Arrow::Function.find("binary_join_element_wise")
+
+    @options.null_handling = :emit_null
+    result = binary_join_element_wise_function.execute(args, @options).value
+    assert_equal(build_string_array(["a-x", "b-y", nil]),
+                 result)
+
+    @options.null_handling = :skip
+    result = binary_join_element_wise_function.execute(args, @options).value
+    assert_equal(build_string_array(["a-x", "b-y", "z"]),
+                 result)
+
+    @options.null_handling = :replace
+    @options.null_replacement = "NULL"
+    result = binary_join_element_wise_function.execute(args, @options).value
+    assert_equal(build_string_array(["a-x", "b-y", "NULL-z"]),
+                 result)
+  end
+end


### PR DESCRIPTION
### Rationale for this change

The `JoinOptions` class is not available in GLib/Ruby, and it is used together with the `binary_join_element_wise` compute function.

### What changes are included in this PR?

This adds the `JoinOptions` class to GLib.

### Are these changes tested?

Yes, with Ruby unit tests.

### Are there any user-facing changes?

Yes, a new class.
* GitHub Issue: #48484