### PR TITLE
GH-48493: [GLib][Ruby] Add ModeOptions

### DIFF
--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -1420,4 +1420,17 @@ GARROW_AVAILABLE_IN_23_0
 GArrowListSliceOptions *
 garrow_list_slice_options_new(void);
 
+#define GARROW_TYPE_MODE_OPTIONS (garrow_mode_options_get_type())
+GARROW_AVAILABLE_IN_23_0
+G_DECLARE_DERIVABLE_TYPE(
+  GArrowModeOptions, garrow_mode_options, GARROW, MODE_OPTIONS, GArrowFunctionOptions)
+struct _GArrowModeOptionsClass
+{
+  GArrowFunctionOptionsClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_23_0
+GArrowModeOptions *
+garrow_mode_options_new(void);
+
 G_END_DECLS

--- a/c_glib/arrow-glib/compute.hpp
+++ b/c_glib/arrow-glib/compute.hpp
@@ -236,3 +236,8 @@ GArrowListSliceOptions *
 garrow_list_slice_options_new_raw(const arrow::compute::ListSliceOptions *arrow_options);
 arrow::compute::ListSliceOptions *
 garrow_list_slice_options_get_raw(GArrowListSliceOptions *options);
+
+GArrowModeOptions *
+garrow_mode_options_new_raw(const arrow::compute::ModeOptions *arrow_options);
+arrow::compute::ModeOptions *
+garrow_mode_options_get_raw(GArrowModeOptions *options);

--- a/c_glib/test/test-mode-options.rb
+++ b/c_glib/test/test-mode-options.rb
@@ -1,0 +1,68 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestModeOptions < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def setup
+    @options = Arrow::ModeOptions.new
+  end
+
+  def test_n
+    assert_equal(1, @options.n)
+    @options.n = 2
+    assert_equal(2, @options.n)
+  end
+
+  def test_skip_nulls
+    assert do
+      @options.skip_nulls?
+    end
+    @options.skip_nulls = false
+    assert do
+      not @options.skip_nulls?
+    end
+  end
+
+  def test_min_count
+    assert_equal(0, @options.min_count)
+    @options.min_count = 1
+    assert_equal(1, @options.min_count)
+  end
+
+  def test_mode_function_with_all_options
+    args = [
+      Arrow::ArrayDatum.new(build_int32_array([1, 2, 2, 3, 3, 3, 4])),
+    ]
+    @options.n = 2
+    @options.skip_nulls = false
+    @options.min_count = 2
+    mode_function = Arrow::Function.find("mode")
+    result = mode_function.execute(args, @options).value
+    expected = build_struct_array(
+      [
+        Arrow::Field.new("mode", Arrow::Int32DataType.new),
+        Arrow::Field.new("count", Arrow::Int64DataType.new),
+      ],
+      [
+        {"mode" => 3, "count" => 3},
+        {"mode" => 2, "count" => 2},
+      ]
+    )
+    assert_equal(expected, result)
+  end
+end


### PR DESCRIPTION
### Rationale for this change

The `ModeOptions` class is not available in GLib/Ruby, and it is used together with the `mode` compute function.

### What changes are included in this PR?

This adds the `ModeOptions` class to GLib.

### Are these changes tested?

Yes, with Ruby unit tests.

### Are there any user-facing changes?

Yes, a new class.

* GitHub Issue: #48493