### PR TITLE
GH-48494: [GLib][Ruby] Add NullOptions

### DIFF
--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -1433,4 +1433,17 @@ GARROW_AVAILABLE_IN_23_0
 GArrowModeOptions *
 garrow_mode_options_new(void);
 
+#define GARROW_TYPE_NULL_OPTIONS (garrow_null_options_get_type())
+GARROW_AVAILABLE_IN_23_0
+G_DECLARE_DERIVABLE_TYPE(
+  GArrowNullOptions, garrow_null_options, GARROW, NULL_OPTIONS, GArrowFunctionOptions)
+struct _GArrowNullOptionsClass
+{
+  GArrowFunctionOptionsClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_23_0
+GArrowNullOptions *
+garrow_null_options_new(void);
+
 G_END_DECLS

--- a/c_glib/arrow-glib/compute.hpp
+++ b/c_glib/arrow-glib/compute.hpp
@@ -241,3 +241,8 @@ GArrowModeOptions *
 garrow_mode_options_new_raw(const arrow::compute::ModeOptions *arrow_options);
 arrow::compute::ModeOptions *
 garrow_mode_options_get_raw(GArrowModeOptions *options);
+
+GArrowNullOptions *
+garrow_null_options_new_raw(const arrow::compute::NullOptions *arrow_options);
+arrow::compute::NullOptions *
+garrow_null_options_get_raw(GArrowNullOptions *options);

--- a/c_glib/test/test-null-options.rb
+++ b/c_glib/test/test-null-options.rb
@@ -1,0 +1,44 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestNullOptions < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def setup
+    @options = Arrow::NullOptions.new
+  end
+
+  def test_nan_is_null_property
+    assert do
+      !@options.nan_is_null?
+    end
+    @options.nan_is_null = true
+    assert do
+      @options.nan_is_null?
+    end
+  end
+
+  def test_is_null_function
+    args = [
+      Arrow::ArrayDatum.new(build_float_array([1.0, Float::NAN, 2.0, nil, 4.0])),
+    ]
+    is_null_function = Arrow::Function.find("is_null")
+    @options.nan_is_null = true
+    result = is_null_function.execute(args, @options).value
+    assert_equal(build_boolean_array([false, true, false, true, false]), result)
+  end
+end


### PR DESCRIPTION
### Rationale for this change

The `NullOptions` class is not available in GLib/Ruby, and it is used together with the `is_null` compute function.

### What changes are included in this PR?

This adds the `NullOptions` class to GLib.

### Are these changes tested?

Yes, with Ruby unit tests.

### Are there any user-facing changes?

Yes, a new class.


* GitHub Issue: #48494