### PR TITLE
GH-48495: [GLib][Ruby] Add PadOptions

### DIFF
--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -1446,4 +1446,17 @@ GARROW_AVAILABLE_IN_23_0
 GArrowNullOptions *
 garrow_null_options_new(void);
 
+#define GARROW_TYPE_PAD_OPTIONS (garrow_pad_options_get_type())
+GARROW_AVAILABLE_IN_23_0
+G_DECLARE_DERIVABLE_TYPE(
+  GArrowPadOptions, garrow_pad_options, GARROW, PAD_OPTIONS, GArrowFunctionOptions)
+struct _GArrowPadOptionsClass
+{
+  GArrowFunctionOptionsClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_23_0
+GArrowPadOptions *
+garrow_pad_options_new(void);
+
 G_END_DECLS

--- a/c_glib/arrow-glib/compute.hpp
+++ b/c_glib/arrow-glib/compute.hpp
@@ -246,3 +246,8 @@ GArrowNullOptions *
 garrow_null_options_new_raw(const arrow::compute::NullOptions *arrow_options);
 arrow::compute::NullOptions *
 garrow_null_options_get_raw(GArrowNullOptions *options);
+
+GArrowPadOptions *
+garrow_pad_options_new_raw(const arrow::compute::PadOptions *arrow_options);
+arrow::compute::PadOptions *
+garrow_pad_options_get_raw(GArrowPadOptions *options);

--- a/c_glib/test/test-pad-options.rb
+++ b/c_glib/test/test-pad-options.rb
@@ -1,0 +1,62 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestPadOptions < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def setup
+    @options = Arrow::PadOptions.new
+  end
+
+  def test_width_property
+    assert_equal(0, @options.width)
+    @options.width = 5
+    assert_equal(5, @options.width)
+  end
+
+  def test_padding_property
+    assert_equal(" ", @options.padding)
+    @options.padding = "0"
+    assert_equal("0", @options.padding)
+  end
+
+  def test_lean_left_on_odd_padding_property
+    assert do
+      @options.lean_left_on_odd_padding?
+    end
+    @options.lean_left_on_odd_padding = false
+    assert do
+      not @options.lean_left_on_odd_padding?
+    end
+  end
+
+  def test_utf8_center_function
+    args = [
+      Arrow::ArrayDatum.new(build_string_array(["a", "ab", "abc"])),
+    ]
+    utf8_center_function = Arrow::Function.find("utf8_center")
+
+    @options.width = 5
+    @options.padding = " "
+    result = utf8_center_function.execute(args, @options).value
+    assert_equal(build_string_array(["  a  ", " ab  ", " abc "]), result)
+
+    @options.lean_left_on_odd_padding = false
+    result = utf8_center_function.execute(args, @options).value
+    assert_equal(build_string_array(["  a  ", "  ab ", " abc "]), result)
+  end
+end


### PR DESCRIPTION
### Rationale for this change

The `PadOptions` class is not available in GLib/Ruby, and it is used together with the `utf8_lpad` compute function.

### What changes are included in this PR?

This adds the `PadOptions` class to GLib.

### Are these changes tested?

Yes, with Ruby unit tests.

### Are there any user-facing changes?

Yes, a new class.


* GitHub Issue: #48495