### PR TITLE
GH-48496: [GLib][Ruby] Add PairwiseOptions

### DIFF
--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -1459,4 +1459,20 @@ GARROW_AVAILABLE_IN_23_0
 GArrowPadOptions *
 garrow_pad_options_new(void);
 
+#define GARROW_TYPE_PAIRWISE_OPTIONS (garrow_pairwise_options_get_type())
+GARROW_AVAILABLE_IN_23_0
+G_DECLARE_DERIVABLE_TYPE(GArrowPairwiseOptions,
+                         garrow_pairwise_options,
+                         GARROW,
+                         PAIRWISE_OPTIONS,
+                         GArrowFunctionOptions)
+struct _GArrowPairwiseOptionsClass
+{
+  GArrowFunctionOptionsClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_23_0
+GArrowPairwiseOptions *
+garrow_pairwise_options_new(void);
+
 G_END_DECLS

--- a/c_glib/arrow-glib/compute.hpp
+++ b/c_glib/arrow-glib/compute.hpp
@@ -251,3 +251,8 @@ GArrowPadOptions *
 garrow_pad_options_new_raw(const arrow::compute::PadOptions *arrow_options);
 arrow::compute::PadOptions *
 garrow_pad_options_get_raw(GArrowPadOptions *options);
+
+GArrowPairwiseOptions *
+garrow_pairwise_options_new_raw(const arrow::compute::PairwiseOptions *arrow_options);
+arrow::compute::PairwiseOptions *
+garrow_pairwise_options_get_raw(GArrowPairwiseOptions *options);

--- a/c_glib/test/test-pairwise-options.rb
+++ b/c_glib/test/test-pairwise-options.rb
@@ -1,0 +1,42 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestPairwiseOptions < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def setup
+    @options = Arrow::PairwiseOptions.new
+  end
+
+  def test_periods_property
+    assert_equal(1, @options.periods)
+    @options.periods = 2
+    assert_equal(2, @options.periods)
+    @options.periods = -1
+    assert_equal(-1, @options.periods)
+  end
+
+  def test_pairwise_diff_function
+    args = [
+      Arrow::ArrayDatum.new(build_int32_array([1, 2, 4, 7, 11])),
+    ]
+    pairwise_diff_function = Arrow::Function.find("pairwise_diff")
+    @options.periods = 2
+    result = pairwise_diff_function.execute(args, @options).value
+    assert_equal(build_int32_array([nil, nil, 3, 5, 7]), result)
+  end
+end


### PR DESCRIPTION
### Rationale for this change

The `PairwiseOptions` class is not available in GLib/Ruby, and it is used together with the `pairwise_diff` compute function.

### What changes are included in this PR?

This adds the `PairwiseOptions` class to GLib.

### Are these changes tested?

Yes, with Ruby unit tests.

### Are there any user-facing changes?

Yes, a new class.



* GitHub Issue: #48496