### PR TITLE
GH-48497: [GLib][Ruby] Add PartitionNthOptions

### DIFF
--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -1491,4 +1491,20 @@ GARROW_AVAILABLE_IN_23_0
 GArrowReplaceSliceOptions *
 garrow_replace_slice_options_new(void);
 
+#define GARROW_TYPE_PARTITION_NTH_OPTIONS (garrow_partition_nth_options_get_type())
+GARROW_AVAILABLE_IN_23_0
+G_DECLARE_DERIVABLE_TYPE(GArrowPartitionNthOptions,
+                         garrow_partition_nth_options,
+                         GARROW,
+                         PARTITION_NTH_OPTIONS,
+                         GArrowFunctionOptions)
+struct _GArrowPartitionNthOptionsClass
+{
+  GArrowFunctionOptionsClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_23_0
+GArrowPartitionNthOptions *
+garrow_partition_nth_options_new(void);
+
 G_END_DECLS

--- a/c_glib/arrow-glib/compute.hpp
+++ b/c_glib/arrow-glib/compute.hpp
@@ -262,3 +262,9 @@ garrow_replace_slice_options_new_raw(
   const arrow::compute::ReplaceSliceOptions *arrow_options);
 arrow::compute::ReplaceSliceOptions *
 garrow_replace_slice_options_get_raw(GArrowReplaceSliceOptions *options);
+
+GArrowPartitionNthOptions *
+garrow_partition_nth_options_new_raw(
+  const arrow::compute::PartitionNthOptions *arrow_options);
+arrow::compute::PartitionNthOptions *
+garrow_partition_nth_options_get_raw(GArrowPartitionNthOptions *options);

--- a/c_glib/test/test-partition-nth-options.rb
+++ b/c_glib/test/test-partition-nth-options.rb
@@ -1,0 +1,51 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestPartitionNthOptions < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def setup
+    @options = Arrow::PartitionNthOptions.new
+  end
+
+  def test_pivot_property
+    assert_equal(0, @options.pivot)
+    @options.pivot = 2
+    assert_equal(2, @options.pivot)
+  end
+
+  def test_null_placement_property
+    assert_equal(Arrow::NullPlacement::AT_END, @options.null_placement)
+    @options.null_placement = :at_start
+    assert_equal(Arrow::NullPlacement::AT_START, @options.null_placement)
+    @options.null_placement = :at_end
+    assert_equal(Arrow::NullPlacement::AT_END, @options.null_placement)
+  end
+
+  def test_partition_nth_indices_function
+    args = [
+      Arrow::ArrayDatum.new(build_int32_array([5, 1, 4, 2, nil, 3])),
+    ]
+    @options.pivot = 2
+    partition_nth_indices_function = Arrow::Function.find("partition_nth_indices")
+    result = partition_nth_indices_function.execute(args, @options).value
+    assert_equal(5, result.get_value(2))
+    @options.null_placement = :at_start
+    result = partition_nth_indices_function.execute(args, @options).value
+    assert_equal(5, result.get_value(3))
+  end
+end


### PR DESCRIPTION
### Rationale for this change

The `PartitionNthOptions` class is not available in GLib/Ruby, and it is used together with the `partition_nth_indices` compute function.

### What changes are included in this PR?

This adds the `PartitionNthOptions` class to GLib.

### Are these changes tested?

Yes, with Ruby unit tests.

### Are there any user-facing changes?

Yes, a new class.


* GitHub Issue: #48497