### PR TITLE
GH-48498: [GLib][Ruby] Add PivotWiderOptions

### DIFF
--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -1507,4 +1507,37 @@ GARROW_AVAILABLE_IN_23_0
 GArrowPartitionNthOptions *
 garrow_partition_nth_options_new(void);
 
+/**
+ * GArrowPivotWiderUnexpectedKeyBehavior:
+ * @GARROW_PIVOT_WIDER_UNEXPECTED_KEY_BEHAVIOR_IGNORE: Unexpected pivot keys are ignored
+ * silently.
+ * @GARROW_PIVOT_WIDER_UNEXPECTED_KEY_BEHAVIOR_RAISE: Unexpected pivot keys return a
+ * KeyError.
+ *
+ * They correspond to the values of
+ * `arrow::compute::PivotWiderOptions::UnexpectedKeyBehavior`.
+ *
+ * Since: 23.0.0
+ */
+typedef enum {
+  GARROW_PIVOT_WIDER_UNEXPECTED_KEY_BEHAVIOR_IGNORE,
+  GARROW_PIVOT_WIDER_UNEXPECTED_KEY_BEHAVIOR_RAISE,
+} GArrowPivotWiderUnexpectedKeyBehavior;
+
+#define GARROW_TYPE_PIVOT_WIDER_OPTIONS (garrow_pivot_wider_options_get_type())
+GARROW_AVAILABLE_IN_23_0
+G_DECLARE_DERIVABLE_TYPE(GArrowPivotWiderOptions,
+                         garrow_pivot_wider_options,
+                         GARROW,
+                         PIVOT_WIDER_OPTIONS,
+                         GArrowFunctionOptions)
+struct _GArrowPivotWiderOptionsClass
+{
+  GArrowFunctionOptionsClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_23_0
+GArrowPivotWiderOptions *
+garrow_pivot_wider_options_new(void);
+
 G_END_DECLS

--- a/c_glib/arrow-glib/compute.hpp
+++ b/c_glib/arrow-glib/compute.hpp
@@ -268,3 +268,9 @@ garrow_partition_nth_options_new_raw(
   const arrow::compute::PartitionNthOptions *arrow_options);
 arrow::compute::PartitionNthOptions *
 garrow_partition_nth_options_get_raw(GArrowPartitionNthOptions *options);
+
+GArrowPivotWiderOptions *
+garrow_pivot_wider_options_new_raw(
+  const arrow::compute::PivotWiderOptions *arrow_options);
+arrow::compute::PivotWiderOptions *
+garrow_pivot_wider_options_get_raw(GArrowPivotWiderOptions *options);

--- a/c_glib/test/test-pivot-wider-options.rb
+++ b/c_glib/test/test-pivot-wider-options.rb
@@ -1,0 +1,60 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestPivotWiderOptions < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def setup
+    @options = Arrow::PivotWiderOptions.new
+  end
+
+  def test_key_names_property
+    assert_equal([], @options.key_names)
+    @options.key_names = ["height", "width"]
+    assert_equal(["height", "width"], @options.key_names)
+  end
+
+  def test_unexpected_key_behavior_property
+    assert_equal(Arrow::PivotWiderUnexpectedKeyBehavior::IGNORE, @options.unexpected_key_behavior)
+    @options.unexpected_key_behavior = :raise
+    assert_equal(Arrow::PivotWiderUnexpectedKeyBehavior::RAISE, @options.unexpected_key_behavior)
+    @options.unexpected_key_behavior = :ignore
+    assert_equal(Arrow::PivotWiderUnexpectedKeyBehavior::IGNORE, @options.unexpected_key_behavior)
+  end
+
+  def test_pivot_wider_function
+    keys = build_string_array(["height", "width", "depth"])
+    values = build_int32_array([10, 20, 30])
+    args = [
+      Arrow::ArrayDatum.new(keys),
+      Arrow::ArrayDatum.new(values),
+    ]
+    @options.key_names = ["height", "width"]
+    pivot_wider_function = Arrow::Function.find("pivot_wider")
+    result = pivot_wider_function.execute(args, @options).value
+    fields = [
+      Arrow::Field.new("height", Arrow::Int32DataType.new),
+      Arrow::Field.new("width", Arrow::Int32DataType.new),
+    ]
+    data_type = Arrow::StructDataType.new(fields)
+    expected = Arrow::StructScalar.new(data_type, [
+      Arrow::Int32Scalar.new(10),
+      Arrow::Int32Scalar.new(20),
+    ])
+    assert_equal(expected, result)
+  end
+end


### PR DESCRIPTION
### Rationale for this change

The `PivotWiderOptions` class is not available in GLib/Ruby, and it is used together with the `pivot_wider` compute function.

### What changes are included in this PR?

This adds the `PivotWiderOptions` class to GLib.

### Are these changes tested?

Yes, with Ruby unit tests.

### Are there any user-facing changes?

Yes, a new class.


* GitHub Issue: #48498