### PR TITLE
GH-48499: [GLib][Ruby] Add RankQuantileOptions

### DIFF
--- a/c_glib/arrow-glib/compute.cpp
+++ b/c_glib/arrow-glib/compute.cpp
@@ -306,6 +306,9 @@ G_BEGIN_DECLS
  * #GArrowPivotWiderOptions is a class to customize the `pivot_wider` and
  * `hash_pivot_wider` functions.
  *
+ * #GArrowRankQuantileOptions is a class to customize the `rank_quantile` and
+ * `rank_normal` functions.
+ *
  * There are many functions to compute data on an array.
  */
 
@@ -8762,6 +8765,155 @@ garrow_pivot_wider_options_new(void)
     g_object_new(GARROW_TYPE_PIVOT_WIDER_OPTIONS, nullptr));
 }
 
+enum {
+  PROP_RANK_QUANTILE_OPTIONS_NULL_PLACEMENT = 1,
+};
+
+G_DEFINE_TYPE(GArrowRankQuantileOptions,
+              garrow_rank_quantile_options,
+              GARROW_TYPE_FUNCTION_OPTIONS)
+
+static void
+garrow_rank_quantile_options_set_property(GObject *object,
+                                          guint prop_id,
+                                          const GValue *value,
+                                          GParamSpec *pspec)
+{
+  auto options =
+    garrow_rank_quantile_options_get_raw(GARROW_RANK_QUANTILE_OPTIONS(object));
+
+  switch (prop_id) {
+  case PROP_RANK_QUANTILE_OPTIONS_NULL_PLACEMENT:
+    options->null_placement =
+      static_cast<arrow::compute::NullPlacement>(g_value_get_enum(value));
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+garrow_rank_quantile_options_get_property(GObject *object,
+                                          guint prop_id,
+                                          GValue *value,
+                                          GParamSpec *pspec)
+{
+  auto options =
+    garrow_rank_quantile_options_get_raw(GARROW_RANK_QUANTILE_OPTIONS(object));
+
+  switch (prop_id) {
+  case PROP_RANK_QUANTILE_OPTIONS_NULL_PLACEMENT:
+    g_value_set_enum(value, static_cast<GArrowNullPlacement>(options->null_placement));
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+garrow_rank_quantile_options_init(GArrowRankQuantileOptions *object)
+{
+  auto priv = GARROW_FUNCTION_OPTIONS_GET_PRIVATE(object);
+  priv->options = static_cast<arrow::compute::FunctionOptions *>(
+    new arrow::compute::RankQuantileOptions());
+}
+
+static void
+garrow_rank_quantile_options_class_init(GArrowRankQuantileOptionsClass *klass)
+{
+  auto gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->set_property = garrow_rank_quantile_options_set_property;
+  gobject_class->get_property = garrow_rank_quantile_options_get_property;
+
+  auto options = arrow::compute::RankQuantileOptions::Defaults();
+
+  GParamSpec *spec;
+  /**
+   * GArrowRankQuantileOptions:null-placement:
+   *
+   * Whether nulls and NaNs are placed at the start or at the end.
+   *
+   * Since: 23.0.0
+   */
+  spec = g_param_spec_enum("null-placement",
+                           "Null placement",
+                           "Whether nulls and NaNs are placed "
+                           "at the start or at the end.",
+                           GARROW_TYPE_NULL_PLACEMENT,
+                           static_cast<GArrowNullPlacement>(options.null_placement),
+                           static_cast<GParamFlags>(G_PARAM_READWRITE));
+  g_object_class_install_property(gobject_class,
+                                  PROP_RANK_QUANTILE_OPTIONS_NULL_PLACEMENT,
+                                  spec);
+}
+
+/**
+ * garrow_rank_quantile_options_new:
+ *
+ * Returns: A newly created #GArrowRankQuantileOptions.
+ *
+ * Since: 23.0.0
+ */
+GArrowRankQuantileOptions *
+garrow_rank_quantile_options_new(void)
+{
+  return GARROW_RANK_QUANTILE_OPTIONS(
+    g_object_new(GARROW_TYPE_RANK_QUANTILE_OPTIONS, nullptr));
+}
+
+/**
+ * garrow_rank_quantile_options_get_sort_keys:
+ * @options: A #GArrowRankQuantileOptions.
+ *
+ * Returns: (transfer full) (element-type GArrowSortKey):
+ *   The sort keys to be used.
+ *
+ * Since: 23.0.0
+ */
+GList *
+garrow_rank_quantile_options_get_sort_keys(GArrowRankQuantileOptions *options)
+{
+  auto arrow_options = garrow_rank_quantile_options_get_raw(options);
+  return garrow_sort_keys_new_raw(arrow_options->sort_keys);
+}
+
+/**
+ * garrow_rank_quantile_options_set_sort_keys:
+ * @options: A #GArrowRankQuantileOptions.
+ * @sort_keys: (element-type GArrowSortKey): The sort keys to be used.
+ *
+ * Set sort keys to be used.
+ *
+ * Since: 23.0.0
+ */
+void
+garrow_rank_quantile_options_set_sort_keys(GArrowRankQuantileOptions *options,
+                                           GList *sort_keys)
+{
+  auto arrow_options = garrow_rank_quantile_options_get_raw(options);
+  garrow_raw_sort_keys_set(arrow_options->sort_keys, sort_keys);
+}
+
+/**
+ * garrow_rank_quantile_options_add_sort_key:
+ * @options: A #GArrowRankQuantileOptions.
+ * @sort_key: The sort key to be added.
+ *
+ * Add a sort key to be used.
+ *
+ * Since: 23.0.0
+ */
+void
+garrow_rank_quantile_options_add_sort_key(GArrowRankQuantileOptions *options,
+                                          GArrowSortKey *sort_key)
+{
+  auto arrow_options = garrow_rank_quantile_options_get_raw(options);
+  garrow_raw_sort_keys_add(arrow_options->sort_keys, sort_key);
+}
+
 G_END_DECLS
 
 arrow::Result<arrow::FieldRef>
@@ -8980,6 +9132,11 @@ garrow_function_options_new_raw(const arrow::compute::FunctionOptions *arrow_opt
     const auto arrow_pivot_wider_options =
       static_cast<const arrow::compute::PivotWiderOptions *>(arrow_options);
     auto options = garrow_pivot_wider_options_new_raw(arrow_pivot_wider_options);
+    return GARROW_FUNCTION_OPTIONS(options);
+  } else if (arrow_type_name == "RankQuantileOptions") {
+    const auto arrow_rank_quantile_options =
+      static_cast<const arrow::compute::RankQuantileOptions *>(arrow_options);
+    auto options = garrow_rank_quantile_options_new_raw(arrow_rank_quantile_options);
     return GARROW_FUNCTION_OPTIONS(options);
   } else {
     auto options = g_object_new(GARROW_TYPE_FUNCTION_OPTIONS, NULL);
@@ -9868,5 +10025,26 @@ arrow::compute::PivotWiderOptions *
 garrow_pivot_wider_options_get_raw(GArrowPivotWiderOptions *options)
 {
   return static_cast<arrow::compute::PivotWiderOptions *>(
+    garrow_function_options_get_raw(GARROW_FUNCTION_OPTIONS(options)));
+}
+
+GArrowRankQuantileOptions *
+garrow_rank_quantile_options_new_raw(
+  const arrow::compute::RankQuantileOptions *arrow_options)
+{
+  auto options =
+    GARROW_RANK_QUANTILE_OPTIONS(g_object_new(GARROW_TYPE_RANK_QUANTILE_OPTIONS,
+                                              "null-placement",
+                                              arrow_options->null_placement,
+                                              nullptr));
+  auto arrow_new_options = garrow_rank_quantile_options_get_raw(options);
+  arrow_new_options->sort_keys = arrow_options->sort_keys;
+  return options;
+}
+
+arrow::compute::RankQuantileOptions *
+garrow_rank_quantile_options_get_raw(GArrowRankQuantileOptions *options)
+{
+  return static_cast<arrow::compute::RankQuantileOptions *>(
     garrow_function_options_get_raw(GARROW_FUNCTION_OPTIONS(options)));
 }

--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -1540,4 +1540,30 @@ GARROW_AVAILABLE_IN_23_0
 GArrowPivotWiderOptions *
 garrow_pivot_wider_options_new(void);
 
+#define GARROW_TYPE_RANK_QUANTILE_OPTIONS (garrow_rank_quantile_options_get_type())
+GARROW_AVAILABLE_IN_23_0
+G_DECLARE_DERIVABLE_TYPE(GArrowRankQuantileOptions,
+                         garrow_rank_quantile_options,
+                         GARROW,
+                         RANK_QUANTILE_OPTIONS,
+                         GArrowFunctionOptions)
+struct _GArrowRankQuantileOptionsClass
+{
+  GArrowFunctionOptionsClass parent_class;
+};
+
+GArrowRankQuantileOptions *
+garrow_rank_quantile_options_new(void);
+GARROW_AVAILABLE_IN_23_0
+GList *
+garrow_rank_quantile_options_get_sort_keys(GArrowRankQuantileOptions *options);
+GARROW_AVAILABLE_IN_23_0
+void
+garrow_rank_quantile_options_set_sort_keys(GArrowRankQuantileOptions *options,
+                                           GList *sort_keys);
+GARROW_AVAILABLE_IN_23_0
+void
+garrow_rank_quantile_options_add_sort_key(GArrowRankQuantileOptions *options,
+                                          GArrowSortKey *sort_key);
+
 G_END_DECLS

--- a/c_glib/arrow-glib/compute.hpp
+++ b/c_glib/arrow-glib/compute.hpp
@@ -274,3 +274,9 @@ garrow_pivot_wider_options_new_raw(
   const arrow::compute::PivotWiderOptions *arrow_options);
 arrow::compute::PivotWiderOptions *
 garrow_pivot_wider_options_get_raw(GArrowPivotWiderOptions *options);
+
+GArrowRankQuantileOptions *
+garrow_rank_quantile_options_new_raw(
+  const arrow::compute::RankQuantileOptions *arrow_options);
+arrow::compute::RankQuantileOptions *
+garrow_rank_quantile_options_get_raw(GArrowRankQuantileOptions *options);

--- a/c_glib/test/test-rank-quantile-options.rb
+++ b/c_glib/test/test-rank-quantile-options.rb
@@ -1,0 +1,60 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestRankQuantileOptions < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def setup
+    @options = Arrow::RankQuantileOptions.new
+  end
+
+  def test_sort_keys
+    sort_keys = [
+      Arrow::SortKey.new("column1", :ascending),
+      Arrow::SortKey.new("column2", :descending),
+    ]
+    @options.sort_keys = sort_keys
+    assert_equal(sort_keys, @options.sort_keys)
+  end
+
+  def test_add_sort_key
+    @options.add_sort_key(Arrow::SortKey.new("column1", :ascending))
+    @options.add_sort_key(Arrow::SortKey.new("column2", :descending))
+    assert_equal([
+                   Arrow::SortKey.new("column1", :ascending),
+                   Arrow::SortKey.new("column2", :descending),
+                 ],
+                 @options.sort_keys)
+  end
+
+  def test_null_placement
+    assert_equal(Arrow::NullPlacement::AT_END, @options.null_placement)
+    @options.null_placement = :at_start
+    assert_equal(Arrow::NullPlacement::AT_START, @options.null_placement)
+  end
+
+  def test_rank_quantile_function
+    args = [
+      Arrow::ArrayDatum.new(build_int32_array([nil, 1, nil, 2, nil])),
+    ]
+    @options.null_placement = :at_start
+    rank_quantile_function = Arrow::Function.find("rank_quantile")
+    result = rank_quantile_function.execute(args, @options).value
+    expected = build_double_array([0.3, 0.7, 0.3, 0.9, 0.3])
+    assert_equal(expected, result)
+  end
+end


### PR DESCRIPTION
### Rationale for this change

The `RankQuantileOptions` class is not available in GLib/Ruby, and it is used together with the `rank_quantile` compute function.

### What changes are included in this PR?

This adds the `RankQuantileOptions` class to GLib.

### Are these changes tested?

Yes, with Ruby unit tests.

### Are there any user-facing changes?

Yes, a new class.


* GitHub Issue: #48499