### PR TITLE
GH-48501: [GLib][Ruby] Add ReplaceSubstringOptions

### DIFF
--- a/c_glib/arrow-glib/compute.cpp
+++ b/c_glib/arrow-glib/compute.cpp
@@ -8923,36 +8923,9 @@ enum {
   PROP_REPLACE_SUBSTRING_OPTIONS_MAX_REPLACEMENTS,
 };
 
-typedef struct _GArrowReplaceSubstringOptionsPrivate GArrowReplaceSubstringOptionsPrivate;
-struct _GArrowReplaceSubstringOptionsPrivate
-{
-  gchar *pattern;
-  gchar *replacement;
-};
-
-G_DEFINE_TYPE_WITH_PRIVATE(GArrowReplaceSubstringOptions,
-                           garrow_replace_substring_options,
-                           GARROW_TYPE_FUNCTION_OPTIONS)
-
-#define GARROW_REPLACE_SUBSTRING_OPTIONS_GET_PRIVATE(object)                             \
-  static_cast<GArrowReplaceSubstringOptionsPrivate *>(                                   \
-    garrow_replace_substring_options_get_instance_private(                               \
-      GARROW_REPLACE_SUBSTRING_OPTIONS(object)))
-
-static void
-garrow_replace_substring_options_dispose(GObject *object)
-{
-  auto priv = GARROW_REPLACE_SUBSTRING_OPTIONS_GET_PRIVATE(object);
-  if (priv->pattern) {
-    g_free(priv->pattern);
-    priv->pattern = nullptr;
-  }
-  if (priv->replacement) {
-    g_free(priv->replacement);
-    priv->replacement = nullptr;
-  }
-  G_OBJECT_CLASS(garrow_replace_substring_options_parent_class)->dispose(object);
-}
+G_DEFINE_TYPE(GArrowReplaceSubstringOptions,
+              garrow_replace_substring_options,
+              GARROW_TYPE_FUNCTION_OPTIONS)
 
 static void
 garrow_replace_substring_options_set_property(GObject *object,
@@ -8962,28 +8935,13 @@ garrow_replace_substring_options_set_property(GObject *object,
 {
   auto options =
     garrow_replace_substring_options_get_raw(GARROW_REPLACE_SUBSTRING_OPTIONS(object));
-  auto priv = GARROW_REPLACE_SUBSTRING_OPTIONS_GET_PRIVATE(object);
 
   switch (prop_id) {
   case PROP_REPLACE_SUBSTRING_OPTIONS_PATTERN:
-    {
-      const gchar *pattern = g_value_get_string(value);
-      if (priv->pattern) {
-        g_free(priv->pattern);
-      }
-      priv->pattern = g_strdup(pattern);
-      options->pattern = pattern ? pattern : "";
-    }
+    options->pattern = g_value_get_string(value);
     break;
   case PROP_REPLACE_SUBSTRING_OPTIONS_REPLACEMENT:
-    {
-      const gchar *replacement = g_value_get_string(value);
-      if (priv->replacement) {
-        g_free(priv->replacement);
-      }
-      priv->replacement = g_strdup(replacement);
-      options->replacement = replacement ? replacement : "";
-    }
+    options->replacement = g_value_get_string(value);
     break;
   case PROP_REPLACE_SUBSTRING_OPTIONS_MAX_REPLACEMENTS:
     options->max_replacements = g_value_get_int64(value);
@@ -9002,16 +8960,13 @@ garrow_replace_substring_options_get_property(GObject *object,
 {
   auto options =
     garrow_replace_substring_options_get_raw(GARROW_REPLACE_SUBSTRING_OPTIONS(object));
-  auto priv = GARROW_REPLACE_SUBSTRING_OPTIONS_GET_PRIVATE(object);
 
   switch (prop_id) {
   case PROP_REPLACE_SUBSTRING_OPTIONS_PATTERN:
-    g_value_set_string(value, priv->pattern ? priv->pattern : options->pattern.c_str());
+    g_value_set_string(value, options->pattern.c_str());
     break;
   case PROP_REPLACE_SUBSTRING_OPTIONS_REPLACEMENT:
-    g_value_set_string(value,
-                       priv->replacement ? priv->replacement
-                                         : options->replacement.c_str());
+    g_value_set_string(value, options->replacement.c_str());
     break;
   case PROP_REPLACE_SUBSTRING_OPTIONS_MAX_REPLACEMENTS:
     g_value_set_int64(value, options->max_replacements);
@@ -9025,17 +8980,9 @@ garrow_replace_substring_options_get_property(GObject *object,
 static void
 garrow_replace_substring_options_init(GArrowReplaceSubstringOptions *object)
 {
-  auto priv = GARROW_REPLACE_SUBSTRING_OPTIONS_GET_PRIVATE(object);
-  priv->pattern = nullptr;
-  priv->replacement = nullptr;
   auto arrow_priv = GARROW_FUNCTION_OPTIONS_GET_PRIVATE(object);
   arrow_priv->options = static_cast<arrow::compute::FunctionOptions *>(
     new arrow::compute::ReplaceSubstringOptions());
-  // Sync the private strings with the C++ options
-  auto arrow_options =
-    garrow_replace_substring_options_get_raw(GARROW_REPLACE_SUBSTRING_OPTIONS(object));
-  priv->pattern = g_strdup(arrow_options->pattern.c_str());
-  priv->replacement = g_strdup(arrow_options->replacement.c_str());
 }
 
 static void
@@ -9043,7 +8990,6 @@ garrow_replace_substring_options_class_init(GArrowReplaceSubstringOptionsClass *
 {
   auto gobject_class = G_OBJECT_CLASS(klass);
 
-  gobject_class->dispose = garrow_replace_substring_options_dispose;
   gobject_class->set_property = garrow_replace_substring_options_set_property;
   gobject_class->get_property = garrow_replace_substring_options_get_property;
 

--- a/c_glib/arrow-glib/compute.cpp
+++ b/c_glib/arrow-glib/compute.cpp
@@ -9030,13 +9030,13 @@ garrow_replace_substring_options_class_init(GArrowReplaceSubstringOptionsClass *
                                   spec);
 
   /**
-   * GArrowReplaceSubstringOptions:max_replacements:
+   * GArrowReplaceSubstringOptions:max-replacements:
    *
    * Max number of substrings to replace (-1 means unbounded).
    *
    * Since: 23.0.0
    */
-  spec = g_param_spec_int64("max_replacements",
+  spec = g_param_spec_int64("max-replacements",
                             "Max Replacements",
                             "Max number of substrings to replace (-1 means unbounded)",
                             -1,
@@ -10213,7 +10213,7 @@ garrow_replace_substring_options_new_raw(
                  arrow_options->pattern.c_str(),
                  "replacement",
                  arrow_options->replacement.c_str(),
-                 "max_replacements",
+                 "max-replacements",
                  arrow_options->max_replacements,
                  nullptr));
 }

--- a/c_glib/arrow-glib/compute.cpp
+++ b/c_glib/arrow-glib/compute.cpp
@@ -309,6 +309,9 @@ G_BEGIN_DECLS
  * #GArrowRankQuantileOptions is a class to customize the `rank_quantile` and
  * `rank_normal` functions.
  *
+ * #GArrowReplaceSubstringOptions is a class to customize the
+ * `replace_substring` and `replace_substring_regex` functions.
+ *
  * There are many functions to compute data on an array.
  */
 
@@ -8914,6 +8917,205 @@ garrow_rank_quantile_options_add_sort_key(GArrowRankQuantileOptions *options,
   garrow_raw_sort_keys_add(arrow_options->sort_keys, sort_key);
 }
 
+enum {
+  PROP_REPLACE_SUBSTRING_OPTIONS_PATTERN = 1,
+  PROP_REPLACE_SUBSTRING_OPTIONS_REPLACEMENT,
+  PROP_REPLACE_SUBSTRING_OPTIONS_MAX_REPLACEMENTS,
+};
+
+typedef struct _GArrowReplaceSubstringOptionsPrivate GArrowReplaceSubstringOptionsPrivate;
+struct _GArrowReplaceSubstringOptionsPrivate
+{
+  gchar *pattern;
+  gchar *replacement;
+};
+
+G_DEFINE_TYPE_WITH_PRIVATE(GArrowReplaceSubstringOptions,
+                           garrow_replace_substring_options,
+                           GARROW_TYPE_FUNCTION_OPTIONS)
+
+#define GARROW_REPLACE_SUBSTRING_OPTIONS_GET_PRIVATE(object)                             \
+  static_cast<GArrowReplaceSubstringOptionsPrivate *>(                                   \
+    garrow_replace_substring_options_get_instance_private(                               \
+      GARROW_REPLACE_SUBSTRING_OPTIONS(object)))
+
+static void
+garrow_replace_substring_options_dispose(GObject *object)
+{
+  auto priv = GARROW_REPLACE_SUBSTRING_OPTIONS_GET_PRIVATE(object);
+  if (priv->pattern) {
+    g_free(priv->pattern);
+    priv->pattern = nullptr;
+  }
+  if (priv->replacement) {
+    g_free(priv->replacement);
+    priv->replacement = nullptr;
+  }
+  G_OBJECT_CLASS(garrow_replace_substring_options_parent_class)->dispose(object);
+}
+
+static void
+garrow_replace_substring_options_set_property(GObject *object,
+                                              guint prop_id,
+                                              const GValue *value,
+                                              GParamSpec *pspec)
+{
+  auto options =
+    garrow_replace_substring_options_get_raw(GARROW_REPLACE_SUBSTRING_OPTIONS(object));
+  auto priv = GARROW_REPLACE_SUBSTRING_OPTIONS_GET_PRIVATE(object);
+
+  switch (prop_id) {
+  case PROP_REPLACE_SUBSTRING_OPTIONS_PATTERN:
+    {
+      const gchar *pattern = g_value_get_string(value);
+      if (priv->pattern) {
+        g_free(priv->pattern);
+      }
+      priv->pattern = g_strdup(pattern);
+      options->pattern = pattern ? pattern : "";
+    }
+    break;
+  case PROP_REPLACE_SUBSTRING_OPTIONS_REPLACEMENT:
+    {
+      const gchar *replacement = g_value_get_string(value);
+      if (priv->replacement) {
+        g_free(priv->replacement);
+      }
+      priv->replacement = g_strdup(replacement);
+      options->replacement = replacement ? replacement : "";
+    }
+    break;
+  case PROP_REPLACE_SUBSTRING_OPTIONS_MAX_REPLACEMENTS:
+    options->max_replacements = g_value_get_int64(value);
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+garrow_replace_substring_options_get_property(GObject *object,
+                                              guint prop_id,
+                                              GValue *value,
+                                              GParamSpec *pspec)
+{
+  auto options =
+    garrow_replace_substring_options_get_raw(GARROW_REPLACE_SUBSTRING_OPTIONS(object));
+  auto priv = GARROW_REPLACE_SUBSTRING_OPTIONS_GET_PRIVATE(object);
+
+  switch (prop_id) {
+  case PROP_REPLACE_SUBSTRING_OPTIONS_PATTERN:
+    g_value_set_string(value, priv->pattern ? priv->pattern : options->pattern.c_str());
+    break;
+  case PROP_REPLACE_SUBSTRING_OPTIONS_REPLACEMENT:
+    g_value_set_string(value,
+                       priv->replacement ? priv->replacement
+                                         : options->replacement.c_str());
+    break;
+  case PROP_REPLACE_SUBSTRING_OPTIONS_MAX_REPLACEMENTS:
+    g_value_set_int64(value, options->max_replacements);
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+garrow_replace_substring_options_init(GArrowReplaceSubstringOptions *object)
+{
+  auto priv = GARROW_REPLACE_SUBSTRING_OPTIONS_GET_PRIVATE(object);
+  priv->pattern = nullptr;
+  priv->replacement = nullptr;
+  auto arrow_priv = GARROW_FUNCTION_OPTIONS_GET_PRIVATE(object);
+  arrow_priv->options = static_cast<arrow::compute::FunctionOptions *>(
+    new arrow::compute::ReplaceSubstringOptions());
+  // Sync the private strings with the C++ options
+  auto arrow_options =
+    garrow_replace_substring_options_get_raw(GARROW_REPLACE_SUBSTRING_OPTIONS(object));
+  priv->pattern = g_strdup(arrow_options->pattern.c_str());
+  priv->replacement = g_strdup(arrow_options->replacement.c_str());
+}
+
+static void
+garrow_replace_substring_options_class_init(GArrowReplaceSubstringOptionsClass *klass)
+{
+  auto gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->dispose = garrow_replace_substring_options_dispose;
+  gobject_class->set_property = garrow_replace_substring_options_set_property;
+  gobject_class->get_property = garrow_replace_substring_options_get_property;
+
+  arrow::compute::ReplaceSubstringOptions options;
+
+  GParamSpec *spec;
+  /**
+   * GArrowReplaceSubstringOptions:pattern:
+   *
+   * Pattern to match, literal, or regular expression depending on which kernel is used.
+   *
+   * Since: 23.0.0
+   */
+  spec = g_param_spec_string(
+    "pattern",
+    "Pattern",
+    "Pattern to match, literal, or regular expression depending on which kernel is used",
+    options.pattern.c_str(),
+    static_cast<GParamFlags>(G_PARAM_READWRITE));
+  g_object_class_install_property(gobject_class,
+                                  PROP_REPLACE_SUBSTRING_OPTIONS_PATTERN,
+                                  spec);
+
+  /**
+   * GArrowReplaceSubstringOptions:replacement:
+   *
+   * String to replace the pattern with.
+   *
+   * Since: 23.0.0
+   */
+  spec = g_param_spec_string("replacement",
+                             "Replacement",
+                             "String to replace the pattern with",
+                             options.replacement.c_str(),
+                             static_cast<GParamFlags>(G_PARAM_READWRITE));
+  g_object_class_install_property(gobject_class,
+                                  PROP_REPLACE_SUBSTRING_OPTIONS_REPLACEMENT,
+                                  spec);
+
+  /**
+   * GArrowReplaceSubstringOptions:max_replacements:
+   *
+   * Max number of substrings to replace (-1 means unbounded).
+   *
+   * Since: 23.0.0
+   */
+  spec = g_param_spec_int64("max_replacements",
+                            "Max Replacements",
+                            "Max number of substrings to replace (-1 means unbounded)",
+                            G_MININT64,
+                            G_MAXINT64,
+                            options.max_replacements,
+                            static_cast<GParamFlags>(G_PARAM_READWRITE));
+  g_object_class_install_property(gobject_class,
+                                  PROP_REPLACE_SUBSTRING_OPTIONS_MAX_REPLACEMENTS,
+                                  spec);
+}
+
+/**
+ * garrow_replace_substring_options_new:
+ *
+ * Returns: A newly created #GArrowReplaceSubstringOptions.
+ *
+ * Since: 23.0.0
+ */
+GArrowReplaceSubstringOptions *
+garrow_replace_substring_options_new(void)
+{
+  return GARROW_REPLACE_SUBSTRING_OPTIONS(
+    g_object_new(GARROW_TYPE_REPLACE_SUBSTRING_OPTIONS, NULL));
+}
+
 G_END_DECLS
 
 arrow::Result<arrow::FieldRef>
@@ -9137,6 +9339,12 @@ garrow_function_options_new_raw(const arrow::compute::FunctionOptions *arrow_opt
     const auto arrow_rank_quantile_options =
       static_cast<const arrow::compute::RankQuantileOptions *>(arrow_options);
     auto options = garrow_rank_quantile_options_new_raw(arrow_rank_quantile_options);
+    return GARROW_FUNCTION_OPTIONS(options);
+  } else if (arrow_type_name == "ReplaceSubstringOptions") {
+    const auto arrow_replace_substring_options =
+      static_cast<const arrow::compute::ReplaceSubstringOptions *>(arrow_options);
+    auto options =
+      garrow_replace_substring_options_new_raw(arrow_replace_substring_options);
     return GARROW_FUNCTION_OPTIONS(options);
   } else {
     auto options = g_object_new(GARROW_TYPE_FUNCTION_OPTIONS, NULL);
@@ -10046,5 +10254,27 @@ arrow::compute::RankQuantileOptions *
 garrow_rank_quantile_options_get_raw(GArrowRankQuantileOptions *options)
 {
   return static_cast<arrow::compute::RankQuantileOptions *>(
+    garrow_function_options_get_raw(GARROW_FUNCTION_OPTIONS(options)));
+}
+
+GArrowReplaceSubstringOptions *
+garrow_replace_substring_options_new_raw(
+  const arrow::compute::ReplaceSubstringOptions *arrow_options)
+{
+  return GARROW_REPLACE_SUBSTRING_OPTIONS(
+    g_object_new(GARROW_TYPE_REPLACE_SUBSTRING_OPTIONS,
+                 "pattern",
+                 arrow_options->pattern.c_str(),
+                 "replacement",
+                 arrow_options->replacement.c_str(),
+                 "max_replacements",
+                 arrow_options->max_replacements,
+                 NULL));
+}
+
+arrow::compute::ReplaceSubstringOptions *
+garrow_replace_substring_options_get_raw(GArrowReplaceSubstringOptions *options)
+{
+  return static_cast<arrow::compute::ReplaceSubstringOptions *>(
     garrow_function_options_get_raw(GARROW_FUNCTION_OPTIONS(options)));
 }

--- a/c_glib/arrow-glib/compute.cpp
+++ b/c_glib/arrow-glib/compute.cpp
@@ -9039,7 +9039,7 @@ garrow_replace_substring_options_class_init(GArrowReplaceSubstringOptionsClass *
   spec = g_param_spec_int64("max_replacements",
                             "Max Replacements",
                             "Max number of substrings to replace (-1 means unbounded)",
-                            G_MININT64,
+                            -1,
                             G_MAXINT64,
                             options.max_replacements,
                             static_cast<GParamFlags>(G_PARAM_READWRITE));

--- a/c_glib/arrow-glib/compute.cpp
+++ b/c_glib/arrow-glib/compute.cpp
@@ -9059,7 +9059,7 @@ GArrowReplaceSubstringOptions *
 garrow_replace_substring_options_new(void)
 {
   return GARROW_REPLACE_SUBSTRING_OPTIONS(
-    g_object_new(GARROW_TYPE_REPLACE_SUBSTRING_OPTIONS, NULL));
+    g_object_new(GARROW_TYPE_REPLACE_SUBSTRING_OPTIONS, nullptr));
 }
 
 G_END_DECLS
@@ -10215,7 +10215,7 @@ garrow_replace_substring_options_new_raw(
                  arrow_options->replacement.c_str(),
                  "max_replacements",
                  arrow_options->max_replacements,
-                 NULL));
+                 nullptr));
 }
 
 arrow::compute::ReplaceSubstringOptions *

--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -1566,4 +1566,21 @@ void
 garrow_rank_quantile_options_add_sort_key(GArrowRankQuantileOptions *options,
                                           GArrowSortKey *sort_key);
 
+#define GARROW_TYPE_REPLACE_SUBSTRING_OPTIONS                                            \
+  (garrow_replace_substring_options_get_type())
+GARROW_AVAILABLE_IN_23_0
+G_DECLARE_DERIVABLE_TYPE(GArrowReplaceSubstringOptions,
+                         garrow_replace_substring_options,
+                         GARROW,
+                         REPLACE_SUBSTRING_OPTIONS,
+                         GArrowFunctionOptions)
+struct _GArrowReplaceSubstringOptionsClass
+{
+  GArrowFunctionOptionsClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_23_0
+GArrowReplaceSubstringOptions *
+garrow_replace_substring_options_new(void);
+
 G_END_DECLS

--- a/c_glib/arrow-glib/compute.hpp
+++ b/c_glib/arrow-glib/compute.hpp
@@ -280,3 +280,9 @@ garrow_rank_quantile_options_new_raw(
   const arrow::compute::RankQuantileOptions *arrow_options);
 arrow::compute::RankQuantileOptions *
 garrow_rank_quantile_options_get_raw(GArrowRankQuantileOptions *options);
+
+GArrowReplaceSubstringOptions *
+garrow_replace_substring_options_new_raw(
+  const arrow::compute::ReplaceSubstringOptions *arrow_options);
+arrow::compute::ReplaceSubstringOptions *
+garrow_replace_substring_options_get_raw(GArrowReplaceSubstringOptions *options);

--- a/c_glib/test/test-replace-substring-options.rb
+++ b/c_glib/test/test-replace-substring-options.rb
@@ -1,0 +1,67 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestReplaceSubstringOptions < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def setup
+    @options = Arrow::ReplaceSubstringOptions.new
+  end
+
+  def test_pattern_property
+    assert_equal("", @options.pattern)
+    @options.pattern = "foo"
+    assert_equal("foo", @options.pattern)
+  end
+
+  def test_replacement_property
+    assert_equal("", @options.replacement)
+    @options.replacement = "bar"
+    assert_equal("bar", @options.replacement)
+  end
+
+  def test_max_replacements_property
+    assert_equal(-1, @options.max_replacements)
+    @options.max_replacements = 1
+    assert_equal(1, @options.max_replacements)
+  end
+
+  def test_replace_substring_function
+    args = [
+      Arrow::ArrayDatum.new(build_string_array(["foo", "this foo that foo", "bar"])),
+    ]
+    @options.pattern = "foo"
+    @options.replacement = "baz"
+    replace_substring_function = Arrow::Function.find("replace_substring")
+    result = replace_substring_function.execute(args, @options).value
+    expected = build_string_array(["baz", "this baz that baz", "bar"])
+    assert_equal(expected, result)
+  end
+
+  def test_replace_substring_with_max_replacements
+    args = [
+      Arrow::ArrayDatum.new(build_string_array(["this foo that foo"])),
+    ]
+    @options.pattern = "foo"
+    @options.replacement = "baz"
+    @options.max_replacements = 1
+    replace_substring_function = Arrow::Function.find("replace_substring")
+    result = replace_substring_function.execute(args, @options).value
+    expected = build_string_array(["this baz that foo"])
+    assert_equal(expected, result)
+  end
+end


### PR DESCRIPTION
### Rationale for this change

The `ReplaceSubstringOptions` class is not available in GLib/Ruby, and it is used together with the `replace_substring` compute function.

### What changes are included in this PR?

This adds the `ReplaceSubstringOptions` class to GLib.

### Are these changes tested?

Yes, with Ruby unit tests.

### Are there any user-facing changes?

Yes, a new class.


* GitHub Issue: #48501