### PR TITLE
GH-48502: [GLib][Ruby] Add RoundBinaryOptions

### DIFF
--- a/c_glib/arrow-glib/compute.cpp
+++ b/c_glib/arrow-glib/compute.cpp
@@ -270,8 +270,8 @@ G_BEGIN_DECLS
  * #GArrowExtractRegexOptions is a class to customize the `extract_regex`
  * function.
  *
- * #GArrowExtractRegexSpanOptions is a class to customize the `extract_regex_span`
- * function.
+ * #GArrowExtractRegexSpanOptions is a class to customize the
+ * `extract_regex_span` function.
  *
  * #GArrowJoinOptions is a class to customize the `binary_join_element_wise`
  * function.
@@ -311,6 +311,9 @@ G_BEGIN_DECLS
  *
  * #GArrowReplaceSubstringOptions is a class to customize the
  * `replace_substring` and `replace_substring_regex` functions.
+ *
+ * #GArrowRoundBinaryOptions is a class to customize the
+ * `round_binary` function.
  *
  * There are many functions to compute data on an array.
  */
@@ -9062,6 +9065,99 @@ garrow_replace_substring_options_new(void)
     g_object_new(GARROW_TYPE_REPLACE_SUBSTRING_OPTIONS, nullptr));
 }
 
+enum {
+  PROP_ROUND_BINARY_OPTIONS_MODE = 1,
+};
+
+G_DEFINE_TYPE(GArrowRoundBinaryOptions,
+              garrow_round_binary_options,
+              GARROW_TYPE_FUNCTION_OPTIONS)
+
+static void
+garrow_round_binary_options_set_property(GObject *object,
+                                         guint prop_id,
+                                         const GValue *value,
+                                         GParamSpec *pspec)
+{
+  auto options = garrow_round_binary_options_get_raw(GARROW_ROUND_BINARY_OPTIONS(object));
+
+  switch (prop_id) {
+  case PROP_ROUND_BINARY_OPTIONS_MODE:
+    options->round_mode = static_cast<arrow::compute::RoundMode>(g_value_get_enum(value));
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+garrow_round_binary_options_get_property(GObject *object,
+                                         guint prop_id,
+                                         GValue *value,
+                                         GParamSpec *pspec)
+{
+  auto options = garrow_round_binary_options_get_raw(GARROW_ROUND_BINARY_OPTIONS(object));
+
+  switch (prop_id) {
+  case PROP_ROUND_BINARY_OPTIONS_MODE:
+    g_value_set_enum(value, static_cast<GArrowRoundMode>(options->round_mode));
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+garrow_round_binary_options_init(GArrowRoundBinaryOptions *object)
+{
+  auto arrow_priv = GARROW_FUNCTION_OPTIONS_GET_PRIVATE(object);
+  arrow_priv->options = static_cast<arrow::compute::FunctionOptions *>(
+    new arrow::compute::RoundBinaryOptions());
+}
+
+static void
+garrow_round_binary_options_class_init(GArrowRoundBinaryOptionsClass *klass)
+{
+  auto gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->set_property = garrow_round_binary_options_set_property;
+  gobject_class->get_property = garrow_round_binary_options_get_property;
+
+  arrow::compute::RoundBinaryOptions options;
+
+  GParamSpec *spec;
+  /**
+   * GArrowRoundBinaryOptions:mode:
+   *
+   * The rounding and tie-breaking mode.
+   *
+   * Since: 23.0.0
+   */
+  spec = g_param_spec_enum("mode",
+                           "Mode",
+                           "The rounding and tie-breaking mode",
+                           GARROW_TYPE_ROUND_MODE,
+                           static_cast<GArrowRoundMode>(options.round_mode),
+                           static_cast<GParamFlags>(G_PARAM_READWRITE));
+  g_object_class_install_property(gobject_class, PROP_ROUND_BINARY_OPTIONS_MODE, spec);
+}
+
+/**
+ * garrow_round_binary_options_new:
+ *
+ * Returns: A newly created #GArrowRoundBinaryOptions.
+ *
+ * Since: 23.0.0
+ */
+GArrowRoundBinaryOptions *
+garrow_round_binary_options_new(void)
+{
+  return GARROW_ROUND_BINARY_OPTIONS(
+    g_object_new(GARROW_TYPE_ROUND_BINARY_OPTIONS, nullptr));
+}
+
 G_END_DECLS
 
 arrow::Result<arrow::FieldRef>
@@ -9291,6 +9387,11 @@ garrow_function_options_new_raw(const arrow::compute::FunctionOptions *arrow_opt
       static_cast<const arrow::compute::ReplaceSubstringOptions *>(arrow_options);
     auto options =
       garrow_replace_substring_options_new_raw(arrow_replace_substring_options);
+    return GARROW_FUNCTION_OPTIONS(options);
+  } else if (arrow_type_name == "RoundBinaryOptions") {
+    const auto arrow_round_binary_options =
+      static_cast<const arrow::compute::RoundBinaryOptions *>(arrow_options);
+    auto options = garrow_round_binary_options_new_raw(arrow_round_binary_options);
     return GARROW_FUNCTION_OPTIONS(options);
   } else {
     auto options = g_object_new(GARROW_TYPE_FUNCTION_OPTIONS, NULL);
@@ -10222,5 +10323,23 @@ arrow::compute::ReplaceSubstringOptions *
 garrow_replace_substring_options_get_raw(GArrowReplaceSubstringOptions *options)
 {
   return static_cast<arrow::compute::ReplaceSubstringOptions *>(
+    garrow_function_options_get_raw(GARROW_FUNCTION_OPTIONS(options)));
+}
+
+GArrowRoundBinaryOptions *
+garrow_round_binary_options_new_raw(
+  const arrow::compute::RoundBinaryOptions *arrow_options)
+{
+  return GARROW_ROUND_BINARY_OPTIONS(
+    g_object_new(GARROW_TYPE_ROUND_BINARY_OPTIONS,
+                 "mode",
+                 static_cast<GArrowRoundMode>(arrow_options->round_mode),
+                 nullptr));
+}
+
+arrow::compute::RoundBinaryOptions *
+garrow_round_binary_options_get_raw(GArrowRoundBinaryOptions *options)
+{
+  return static_cast<arrow::compute::RoundBinaryOptions *>(
     garrow_function_options_get_raw(GARROW_FUNCTION_OPTIONS(options)));
 }

--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -1583,4 +1583,20 @@ GARROW_AVAILABLE_IN_23_0
 GArrowReplaceSubstringOptions *
 garrow_replace_substring_options_new(void);
 
+#define GARROW_TYPE_ROUND_BINARY_OPTIONS (garrow_round_binary_options_get_type())
+GARROW_AVAILABLE_IN_23_0
+G_DECLARE_DERIVABLE_TYPE(GArrowRoundBinaryOptions,
+                         garrow_round_binary_options,
+                         GARROW,
+                         ROUND_BINARY_OPTIONS,
+                         GArrowFunctionOptions)
+struct _GArrowRoundBinaryOptionsClass
+{
+  GArrowFunctionOptionsClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_23_0
+GArrowRoundBinaryOptions *
+garrow_round_binary_options_new(void);
+
 G_END_DECLS

--- a/c_glib/arrow-glib/compute.hpp
+++ b/c_glib/arrow-glib/compute.hpp
@@ -286,3 +286,9 @@ garrow_replace_substring_options_new_raw(
   const arrow::compute::ReplaceSubstringOptions *arrow_options);
 arrow::compute::ReplaceSubstringOptions *
 garrow_replace_substring_options_get_raw(GArrowReplaceSubstringOptions *options);
+
+GArrowRoundBinaryOptions *
+garrow_round_binary_options_new_raw(
+  const arrow::compute::RoundBinaryOptions *arrow_options);
+arrow::compute::RoundBinaryOptions *
+garrow_round_binary_options_get_raw(GArrowRoundBinaryOptions *options);

--- a/c_glib/test/test-round-binary-options.rb
+++ b/c_glib/test/test-round-binary-options.rb
@@ -1,0 +1,42 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestRoundBinaryOptions < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def setup
+    @options = Arrow::RoundBinaryOptions.new
+  end
+
+  def test_mode
+    assert_equal(Arrow::RoundMode::HALF_TO_EVEN, @options.mode)
+    @options.mode = :down
+    assert_equal(Arrow::RoundMode::DOWN, @options.mode)
+  end
+
+  def test_round_binary_function
+    args = [
+      Arrow::ArrayDatum.new(build_double_array([5.0])),
+      Arrow::ArrayDatum.new(build_int32_array([-1])),
+    ]
+    @options.mode = :half_towards_zero
+    round_binary_function = Arrow::Function.find("round_binary")
+    result = round_binary_function.execute(args, @options).value
+    expected = build_double_array([0.0])
+    assert_equal(expected, result)
+  end
+end


### PR DESCRIPTION
### Rationale for this change

The `RoundBinaryOptions` class is not available in GLib/Ruby, and it is used together with the `round_binary` compute function.

### What changes are included in this PR?

This adds the `RoundBinaryOptions` class to GLib.

### Are these changes tested?

Yes, with Ruby unit tests.

### Are there any user-facing changes?

Yes, a new class.


* GitHub Issue: #48502