### PR TITLE
GH-48504: [GLib][Ruby] Add SelectKOptions

### DIFF
--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -1649,4 +1649,33 @@ GARROW_AVAILABLE_IN_23_0
 GArrowRoundTemporalOptions *
 garrow_round_temporal_options_new(void);
 
+#define GARROW_TYPE_SELECT_K_OPTIONS (garrow_select_k_options_get_type())
+GARROW_AVAILABLE_IN_23_0
+G_DECLARE_DERIVABLE_TYPE(GArrowSelectKOptions,
+                         garrow_select_k_options,
+                         GARROW,
+                         SELECT_K_OPTIONS,
+                         GArrowFunctionOptions)
+struct _GArrowSelectKOptionsClass
+{
+  GArrowFunctionOptionsClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_23_0
+GArrowSelectKOptions *
+garrow_select_k_options_new(void);
+
+GARROW_AVAILABLE_IN_23_0
+GList *
+garrow_select_k_options_get_sort_keys(GArrowSelectKOptions *options);
+
+GARROW_AVAILABLE_IN_23_0
+void
+garrow_select_k_options_set_sort_keys(GArrowSelectKOptions *options, GList *sort_keys);
+
+GARROW_AVAILABLE_IN_23_0
+void
+garrow_select_k_options_add_sort_key(GArrowSelectKOptions *options,
+                                     GArrowSortKey *sort_key);
+
 G_END_DECLS

--- a/c_glib/arrow-glib/compute.hpp
+++ b/c_glib/arrow-glib/compute.hpp
@@ -298,3 +298,8 @@ garrow_round_temporal_options_new_raw(
   const arrow::compute::RoundTemporalOptions *arrow_options);
 arrow::compute::RoundTemporalOptions *
 garrow_round_temporal_options_get_raw(GArrowRoundTemporalOptions *options);
+
+GArrowSelectKOptions *
+garrow_select_k_options_new_raw(const arrow::compute::SelectKOptions *arrow_options);
+arrow::compute::SelectKOptions *
+garrow_select_k_options_get_raw(GArrowSelectKOptions *options);

--- a/c_glib/test/test-select-k-options.rb
+++ b/c_glib/test/test-select-k-options.rb
@@ -1,0 +1,61 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestSelectKOptions < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def setup
+    @options = Arrow::SelectKOptions.new
+  end
+
+  def test_k
+    assert_equal(-1, @options.k)
+    @options.k = 3
+    assert_equal(3, @options.k)
+  end
+
+  def test_sort_keys
+    sort_keys = [
+      Arrow::SortKey.new("column1", :ascending),
+      Arrow::SortKey.new("column2", :descending),
+    ]
+    @options.sort_keys = sort_keys
+    assert_equal(sort_keys, @options.sort_keys)
+  end
+
+  def test_add_sort_key
+    @options.add_sort_key(Arrow::SortKey.new("column1", :ascending))
+    @options.add_sort_key(Arrow::SortKey.new("column2", :descending))
+    assert_equal([
+                   Arrow::SortKey.new("column1", :ascending),
+                   Arrow::SortKey.new("column2", :descending),
+                 ],
+                 @options.sort_keys)
+  end
+
+  def test_select_k_unstable_function
+    input_array = build_int32_array([5, 2, 8, 1, 9, 3])
+    args = [
+      Arrow::ArrayDatum.new(input_array),
+    ]
+    @options.k = 3
+    @options.add_sort_key(Arrow::SortKey.new("dummy", :descending))
+    select_k_unstable_function = Arrow::Function.find("select_k_unstable")
+    result = select_k_unstable_function.execute(args, @options).value
+    assert_equal(build_uint64_array([4, 2, 0]), result)
+  end
+end


### PR DESCRIPTION
### Rationale for this change

The `SelectKOptions` class is not available in GLib/Ruby, and it is used together with the `select_k_unstable` compute function.

### What changes are included in this PR?

This adds the `SelectKOptions` class to GLib.

### Are these changes tested?

Yes, with Ruby unit tests.

### Are there any user-facing changes?

Yes, a new class.

* GitHub Issue: #48504