### PR TITLE
GH-48507: [GLib][Ruby] Add SplitOptions

### DIFF
--- a/c_glib/arrow-glib/compute.cpp
+++ b/c_glib/arrow-glib/compute.cpp
@@ -10563,7 +10563,7 @@ garrow_split_options_class_init(GArrowSplitOptionsClass *klass)
   spec = g_param_spec_int64("max-splits",
                             "Max splits",
                             "Maximum number of splits allowed, or unlimited when -1",
-                            G_MININT64,
+                            -1,
                             G_MAXINT64,
                             options.max_splits,
                             static_cast<GParamFlags>(G_PARAM_READWRITE));

--- a/c_glib/arrow-glib/compute.cpp
+++ b/c_glib/arrow-glib/compute.cpp
@@ -339,6 +339,9 @@ G_BEGIN_DECLS
  * #GArrowZeroFillOptions is a class to customize the `utf8_zero_fill`
  * function.
  *
+ * #GArrowSplitOptions is a class to customize the `ascii_split_whitespace` and
+ * `utf8_split_whitespace` functions.
+ *
  * There are many functions to compute data on an array.
  */
 
@@ -10482,6 +10485,119 @@ garrow_zero_fill_options_new(void)
   return GARROW_ZERO_FILL_OPTIONS(g_object_new(GARROW_TYPE_ZERO_FILL_OPTIONS, nullptr));
 }
 
+enum {
+  PROP_SPLIT_OPTIONS_MAX_SPLITS = 1,
+  PROP_SPLIT_OPTIONS_REVERSE,
+};
+
+G_DEFINE_TYPE(GArrowSplitOptions, garrow_split_options, GARROW_TYPE_FUNCTION_OPTIONS)
+
+static void
+garrow_split_options_set_property(GObject *object,
+                                  guint prop_id,
+                                  const GValue *value,
+                                  GParamSpec *pspec)
+{
+  auto options = garrow_split_options_get_raw(GARROW_SPLIT_OPTIONS(object));
+
+  switch (prop_id) {
+  case PROP_SPLIT_OPTIONS_MAX_SPLITS:
+    options->max_splits = g_value_get_int64(value);
+    break;
+  case PROP_SPLIT_OPTIONS_REVERSE:
+    options->reverse = g_value_get_boolean(value);
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+garrow_split_options_get_property(GObject *object,
+                                  guint prop_id,
+                                  GValue *value,
+                                  GParamSpec *pspec)
+{
+  auto options = garrow_split_options_get_raw(GARROW_SPLIT_OPTIONS(object));
+
+  switch (prop_id) {
+  case PROP_SPLIT_OPTIONS_MAX_SPLITS:
+    g_value_set_int64(value, options->max_splits);
+    break;
+  case PROP_SPLIT_OPTIONS_REVERSE:
+    g_value_set_boolean(value, options->reverse);
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+garrow_split_options_init(GArrowSplitOptions *object)
+{
+  auto arrow_priv = GARROW_FUNCTION_OPTIONS_GET_PRIVATE(object);
+  arrow_priv->options =
+    static_cast<arrow::compute::FunctionOptions *>(new arrow::compute::SplitOptions());
+}
+
+static void
+garrow_split_options_class_init(GArrowSplitOptionsClass *klass)
+{
+  auto gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->set_property = garrow_split_options_set_property;
+  gobject_class->get_property = garrow_split_options_get_property;
+
+  arrow::compute::SplitOptions options;
+
+  GParamSpec *spec;
+  /**
+   * GArrowSplitOptions:max-splits:
+   *
+   * Maximum number of splits allowed, or unlimited when -1.
+   *
+   * Since: 23.0.0
+   */
+  spec = g_param_spec_int64("max-splits",
+                            "Max splits",
+                            "Maximum number of splits allowed, or unlimited when -1",
+                            G_MININT64,
+                            G_MAXINT64,
+                            options.max_splits,
+                            static_cast<GParamFlags>(G_PARAM_READWRITE));
+  g_object_class_install_property(gobject_class, PROP_SPLIT_OPTIONS_MAX_SPLITS, spec);
+
+  /**
+   * GArrowSplitOptions:reverse:
+   *
+   * Start splitting from the end of the string (only relevant when max_splits != -1).
+   *
+   * Since: 23.0.0
+   */
+  spec = g_param_spec_boolean(
+    "reverse",
+    "Reverse",
+    "Start splitting from the end of the string (only relevant when max_splits != -1)",
+    options.reverse,
+    static_cast<GParamFlags>(G_PARAM_READWRITE));
+  g_object_class_install_property(gobject_class, PROP_SPLIT_OPTIONS_REVERSE, spec);
+}
+
+/**
+ * garrow_split_options_new:
+ *
+ * Returns: A newly created #GArrowSplitOptions.
+ *
+ * Since: 23.0.0
+ */
+GArrowSplitOptions *
+garrow_split_options_new(void)
+{
+  return GARROW_SPLIT_OPTIONS(g_object_new(GARROW_TYPE_SPLIT_OPTIONS, nullptr));
+}
+
 G_END_DECLS
 
 arrow::Result<arrow::FieldRef>
@@ -10761,6 +10877,11 @@ garrow_function_options_new_raw(const arrow::compute::FunctionOptions *arrow_opt
     const auto arrow_zero_fill_options =
       static_cast<const arrow::compute::ZeroFillOptions *>(arrow_options);
     auto options = garrow_zero_fill_options_new_raw(arrow_zero_fill_options);
+    return GARROW_FUNCTION_OPTIONS(options);
+  } else if (arrow_type_name == "SplitOptions") {
+    const auto arrow_split_options =
+      static_cast<const arrow::compute::SplitOptions *>(arrow_options);
+    auto options = garrow_split_options_new_raw(arrow_split_options);
     return GARROW_FUNCTION_OPTIONS(options);
   } else {
     auto options = g_object_new(GARROW_TYPE_FUNCTION_OPTIONS, NULL);
@@ -11895,5 +12016,24 @@ arrow::compute::ZeroFillOptions *
 garrow_zero_fill_options_get_raw(GArrowZeroFillOptions *options)
 {
   return static_cast<arrow::compute::ZeroFillOptions *>(
+    garrow_function_options_get_raw(GARROW_FUNCTION_OPTIONS(options)));
+}
+
+GArrowSplitOptions *
+garrow_split_options_new_raw(const arrow::compute::SplitOptions *arrow_options)
+{
+  auto options = g_object_new(GARROW_TYPE_SPLIT_OPTIONS,
+                              "max-splits",
+                              arrow_options->max_splits,
+                              "reverse",
+                              arrow_options->reverse,
+                              nullptr);
+  return GARROW_SPLIT_OPTIONS(options);
+}
+
+arrow::compute::SplitOptions *
+garrow_split_options_get_raw(GArrowSplitOptions *options)
+{
+  return static_cast<arrow::compute::SplitOptions *>(
     garrow_function_options_get_raw(GARROW_FUNCTION_OPTIONS(options)));
 }

--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -1787,4 +1787,17 @@ GARROW_AVAILABLE_IN_23_0
 GArrowZeroFillOptions *
 garrow_zero_fill_options_new(void);
 
+#define GARROW_TYPE_SPLIT_OPTIONS (garrow_split_options_get_type())
+GARROW_AVAILABLE_IN_23_0
+G_DECLARE_DERIVABLE_TYPE(
+  GArrowSplitOptions, garrow_split_options, GARROW, SPLIT_OPTIONS, GArrowFunctionOptions)
+struct _GArrowSplitOptionsClass
+{
+  GArrowFunctionOptionsClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_23_0
+GArrowSplitOptions *
+garrow_split_options_new(void);
+
 G_END_DECLS

--- a/c_glib/arrow-glib/compute.hpp
+++ b/c_glib/arrow-glib/compute.hpp
@@ -338,3 +338,8 @@ GArrowZeroFillOptions *
 garrow_zero_fill_options_new_raw(const arrow::compute::ZeroFillOptions *arrow_options);
 arrow::compute::ZeroFillOptions *
 garrow_zero_fill_options_get_raw(GArrowZeroFillOptions *options);
+
+GArrowSplitOptions *
+garrow_split_options_new_raw(const arrow::compute::SplitOptions *arrow_options);
+arrow::compute::SplitOptions *
+garrow_split_options_get_raw(GArrowSplitOptions *options);

--- a/c_glib/test/test-split-options.rb
+++ b/c_glib/test/test-split-options.rb
@@ -1,0 +1,51 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestSplitOptions < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def setup
+    @options = Arrow::SplitOptions.new
+  end
+
+  def test_max_splits_property
+    assert_equal(-1, @options.max_splits)
+    @options.max_splits = 1
+    assert_equal(1, @options.max_splits)
+  end
+
+  def test_reverse_property
+    assert do
+      not @options.reverse?
+    end
+    @options.reverse = true
+    assert do
+      @options.reverse?
+    end
+  end
+
+  def test_utf8_split_whitespace_function
+    args = [
+      Arrow::ArrayDatum.new(build_string_array(["hello world test"])),
+    ]
+    @options.max_splits = 1
+    utf8_split_whitespace_function = Arrow::Function.find("utf8_split_whitespace")
+    result = utf8_split_whitespace_function.execute(args, @options).value
+    expected = build_list_array(Arrow::StringDataType.new, [["hello", "world test"]])
+    assert_equal(expected, result)
+  end
+end


### PR DESCRIPTION
### Rationale for this change

The `SplitOptions` class is not available in GLib/Ruby, and it is used together with the `ascii_split_whitespace` compute function.

### What changes are included in this PR?

This adds the `SplitOptions` class to GLib.

### Are these changes tested?

Yes, with Ruby unit tests.

### Are there any user-facing changes?

Yes, a new class.



* GitHub Issue: #48507