### PR TITLE
GH-48509: [GLib][Ruby] Add TrimOptions

### DIFF
--- a/c_glib/arrow-glib/compute.cpp
+++ b/c_glib/arrow-glib/compute.cpp
@@ -329,6 +329,9 @@ G_BEGIN_DECLS
  * #GArrowTDigestOptions is a class to customize the `tdigest` and
  * `hash_tdigest` functions.
  *
+ * #GArrowTrimOptions is a class to customize the `utf8_trim`, `utf8_ltrim`,
+ * `utf8_rtrim`, `ascii_trim`, `ascii_ltrim`, and `ascii_rtrim` functions.
+ *
  * There are many functions to compute data on an array.
  */
 
@@ -9996,6 +9999,134 @@ garrow_tdigest_options_set_qs(GArrowTDigestOptions *options, const gdouble *qs, 
   }
 }
 
+enum {
+  PROP_TRIM_OPTIONS_CHARACTERS = 1,
+};
+
+typedef struct _GArrowTrimOptionsPrivate GArrowTrimOptionsPrivate;
+struct _GArrowTrimOptionsPrivate
+{
+  gchar *characters;
+};
+
+G_DEFINE_TYPE_WITH_PRIVATE(GArrowTrimOptions,
+                           garrow_trim_options,
+                           GARROW_TYPE_FUNCTION_OPTIONS)
+
+#define GARROW_TRIM_OPTIONS_GET_PRIVATE(object)                                          \
+  static_cast<GArrowTrimOptionsPrivate *>(                                               \
+    garrow_trim_options_get_instance_private(GARROW_TRIM_OPTIONS(object)))
+
+static void
+garrow_trim_options_dispose(GObject *object)
+{
+  auto priv = GARROW_TRIM_OPTIONS_GET_PRIVATE(object);
+  if (priv->characters) {
+    g_free(priv->characters);
+    priv->characters = nullptr;
+  }
+  G_OBJECT_CLASS(garrow_trim_options_parent_class)->dispose(object);
+}
+
+static void
+garrow_trim_options_set_property(GObject *object,
+                                 guint prop_id,
+                                 const GValue *value,
+                                 GParamSpec *pspec)
+{
+  auto options = garrow_trim_options_get_raw(GARROW_TRIM_OPTIONS(object));
+  auto priv = GARROW_TRIM_OPTIONS_GET_PRIVATE(object);
+
+  switch (prop_id) {
+  case PROP_TRIM_OPTIONS_CHARACTERS:
+    {
+      const gchar *characters = g_value_get_string(value);
+      if (priv->characters) {
+        g_free(priv->characters);
+      }
+      priv->characters = g_strdup(characters);
+      options->characters = characters ? characters : "";
+    }
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+garrow_trim_options_get_property(GObject *object,
+                                 guint prop_id,
+                                 GValue *value,
+                                 GParamSpec *pspec)
+{
+  auto options = garrow_trim_options_get_raw(GARROW_TRIM_OPTIONS(object));
+  auto priv = GARROW_TRIM_OPTIONS_GET_PRIVATE(object);
+
+  switch (prop_id) {
+  case PROP_TRIM_OPTIONS_CHARACTERS:
+    g_value_set_string(value,
+                       priv->characters ? priv->characters : options->characters.c_str());
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+garrow_trim_options_init(GArrowTrimOptions *object)
+{
+  auto priv = GARROW_TRIM_OPTIONS_GET_PRIVATE(object);
+  priv->characters = nullptr;
+  auto arrow_priv = GARROW_FUNCTION_OPTIONS_GET_PRIVATE(object);
+  arrow_priv->options =
+    static_cast<arrow::compute::FunctionOptions *>(new arrow::compute::TrimOptions());
+  // Sync the private string with the C++ options
+  auto arrow_options = garrow_trim_options_get_raw(GARROW_TRIM_OPTIONS(object));
+  priv->characters = g_strdup(arrow_options->characters.c_str());
+}
+
+static void
+garrow_trim_options_class_init(GArrowTrimOptionsClass *klass)
+{
+  auto gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->dispose = garrow_trim_options_dispose;
+  gobject_class->set_property = garrow_trim_options_set_property;
+  gobject_class->get_property = garrow_trim_options_get_property;
+
+  arrow::compute::TrimOptions options;
+
+  GParamSpec *spec;
+  /**
+   * GArrowTrimOptions:characters:
+   *
+   * The individual characters to be trimmed from the string.
+   *
+   * Since: 23.0.0
+   */
+  spec = g_param_spec_string("characters",
+                             "Characters",
+                             "The individual characters to be trimmed from the string",
+                             options.characters.c_str(),
+                             static_cast<GParamFlags>(G_PARAM_READWRITE));
+  g_object_class_install_property(gobject_class, PROP_TRIM_OPTIONS_CHARACTERS, spec);
+}
+
+/**
+ * garrow_trim_options_new:
+ *
+ * Returns: A newly created #GArrowTrimOptions.
+ *
+ * Since: 23.0.0
+ */
+GArrowTrimOptions *
+garrow_trim_options_new(void)
+{
+  return GARROW_TRIM_OPTIONS(g_object_new(GARROW_TYPE_TRIM_OPTIONS, nullptr));
+}
+
 G_END_DECLS
 
 arrow::Result<arrow::FieldRef>
@@ -10255,6 +10386,11 @@ garrow_function_options_new_raw(const arrow::compute::FunctionOptions *arrow_opt
     const auto arrow_tdigest_options =
       static_cast<const arrow::compute::TDigestOptions *>(arrow_options);
     auto options = garrow_tdigest_options_new_raw(arrow_tdigest_options);
+    return GARROW_FUNCTION_OPTIONS(options);
+  } else if (arrow_type_name == "TrimOptions") {
+    const auto arrow_trim_options =
+      static_cast<const arrow::compute::TrimOptions *>(arrow_options);
+    auto options = garrow_trim_options_new_raw(arrow_trim_options);
     return GARROW_FUNCTION_OPTIONS(options);
   } else {
     auto options = g_object_new(GARROW_TYPE_FUNCTION_OPTIONS, NULL);
@@ -11315,5 +11451,21 @@ arrow::compute::TDigestOptions *
 garrow_tdigest_options_get_raw(GArrowTDigestOptions *options)
 {
   return static_cast<arrow::compute::TDigestOptions *>(
+    garrow_function_options_get_raw(GARROW_FUNCTION_OPTIONS(options)));
+}
+
+GArrowTrimOptions *
+garrow_trim_options_new_raw(const arrow::compute::TrimOptions *arrow_options)
+{
+  return GARROW_TRIM_OPTIONS(g_object_new(GARROW_TYPE_TRIM_OPTIONS,
+                                          "characters",
+                                          arrow_options->characters.c_str(),
+                                          nullptr));
+}
+
+arrow::compute::TrimOptions *
+garrow_trim_options_get_raw(GArrowTrimOptions *options)
+{
+  return static_cast<arrow::compute::TrimOptions *>(
     garrow_function_options_get_raw(GARROW_FUNCTION_OPTIONS(options)));
 }

--- a/c_glib/arrow-glib/compute.cpp
+++ b/c_glib/arrow-glib/compute.cpp
@@ -10003,30 +10003,7 @@ enum {
   PROP_TRIM_OPTIONS_CHARACTERS = 1,
 };
 
-typedef struct _GArrowTrimOptionsPrivate GArrowTrimOptionsPrivate;
-struct _GArrowTrimOptionsPrivate
-{
-  gchar *characters;
-};
-
-G_DEFINE_TYPE_WITH_PRIVATE(GArrowTrimOptions,
-                           garrow_trim_options,
-                           GARROW_TYPE_FUNCTION_OPTIONS)
-
-#define GARROW_TRIM_OPTIONS_GET_PRIVATE(object)                                          \
-  static_cast<GArrowTrimOptionsPrivate *>(                                               \
-    garrow_trim_options_get_instance_private(GARROW_TRIM_OPTIONS(object)))
-
-static void
-garrow_trim_options_dispose(GObject *object)
-{
-  auto priv = GARROW_TRIM_OPTIONS_GET_PRIVATE(object);
-  if (priv->characters) {
-    g_free(priv->characters);
-    priv->characters = nullptr;
-  }
-  G_OBJECT_CLASS(garrow_trim_options_parent_class)->dispose(object);
-}
+G_DEFINE_TYPE(GArrowTrimOptions, garrow_trim_options, GARROW_TYPE_FUNCTION_OPTIONS)
 
 static void
 garrow_trim_options_set_property(GObject *object,
@@ -10035,18 +10012,10 @@ garrow_trim_options_set_property(GObject *object,
                                  GParamSpec *pspec)
 {
   auto options = garrow_trim_options_get_raw(GARROW_TRIM_OPTIONS(object));
-  auto priv = GARROW_TRIM_OPTIONS_GET_PRIVATE(object);
 
   switch (prop_id) {
   case PROP_TRIM_OPTIONS_CHARACTERS:
-    {
-      const gchar *characters = g_value_get_string(value);
-      if (priv->characters) {
-        g_free(priv->characters);
-      }
-      priv->characters = g_strdup(characters);
-      options->characters = characters ? characters : "";
-    }
+    options->characters = g_value_get_string(value);
     break;
   default:
     G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
@@ -10061,12 +10030,10 @@ garrow_trim_options_get_property(GObject *object,
                                  GParamSpec *pspec)
 {
   auto options = garrow_trim_options_get_raw(GARROW_TRIM_OPTIONS(object));
-  auto priv = GARROW_TRIM_OPTIONS_GET_PRIVATE(object);
 
   switch (prop_id) {
   case PROP_TRIM_OPTIONS_CHARACTERS:
-    g_value_set_string(value,
-                       priv->characters ? priv->characters : options->characters.c_str());
+    g_value_set_string(value, options->characters.c_str());
     break;
   default:
     G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
@@ -10077,14 +10044,9 @@ garrow_trim_options_get_property(GObject *object,
 static void
 garrow_trim_options_init(GArrowTrimOptions *object)
 {
-  auto priv = GARROW_TRIM_OPTIONS_GET_PRIVATE(object);
-  priv->characters = nullptr;
   auto arrow_priv = GARROW_FUNCTION_OPTIONS_GET_PRIVATE(object);
   arrow_priv->options =
     static_cast<arrow::compute::FunctionOptions *>(new arrow::compute::TrimOptions());
-  // Sync the private string with the C++ options
-  auto arrow_options = garrow_trim_options_get_raw(GARROW_TRIM_OPTIONS(object));
-  priv->characters = g_strdup(arrow_options->characters.c_str());
 }
 
 static void
@@ -10092,7 +10054,6 @@ garrow_trim_options_class_init(GArrowTrimOptionsClass *klass)
 {
   auto gobject_class = G_OBJECT_CLASS(klass);
 
-  gobject_class->dispose = garrow_trim_options_dispose;
   gobject_class->set_property = garrow_trim_options_set_property;
   gobject_class->get_property = garrow_trim_options_get_property;
 

--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -1729,4 +1729,17 @@ GARROW_AVAILABLE_IN_23_0
 void
 garrow_tdigest_options_set_qs(GArrowTDigestOptions *options, const gdouble *qs, gsize n);
 
+#define GARROW_TYPE_TRIM_OPTIONS (garrow_trim_options_get_type())
+GARROW_AVAILABLE_IN_23_0
+G_DECLARE_DERIVABLE_TYPE(
+  GArrowTrimOptions, garrow_trim_options, GARROW, TRIM_OPTIONS, GArrowFunctionOptions)
+struct _GArrowTrimOptionsClass
+{
+  GArrowFunctionOptionsClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_23_0
+GArrowTrimOptions *
+garrow_trim_options_new(void);
+
 G_END_DECLS

--- a/c_glib/arrow-glib/compute.hpp
+++ b/c_glib/arrow-glib/compute.hpp
@@ -318,3 +318,8 @@ GArrowTDigestOptions *
 garrow_tdigest_options_new_raw(const arrow::compute::TDigestOptions *arrow_options);
 arrow::compute::TDigestOptions *
 garrow_tdigest_options_get_raw(GArrowTDigestOptions *options);
+
+GArrowTrimOptions *
+garrow_trim_options_new_raw(const arrow::compute::TrimOptions *arrow_options);
+arrow::compute::TrimOptions *
+garrow_trim_options_get_raw(GArrowTrimOptions *options);

--- a/c_glib/test/test-trim-options.rb
+++ b/c_glib/test/test-trim-options.rb
@@ -1,0 +1,41 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestTrimOptions < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def setup
+    @options = Arrow::TrimOptions.new
+  end
+
+  def test_characters_property
+    assert_equal("", @options.characters)
+    @options.characters = " \t"
+    assert_equal(" \t", @options.characters)
+  end
+
+  def test_utf8_trim_function
+    args = [
+      Arrow::ArrayDatum.new(build_string_array(["  hello  ", "  world  "])),
+    ]
+    @options.characters = " "
+    utf8_trim_function = Arrow::Function.find("utf8_trim")
+    result = utf8_trim_function.execute(args, @options).value
+    expected = build_string_array(["hello", "world"])
+    assert_equal(expected, result)
+  end
+end


### PR DESCRIPTION
### Rationale for this change

The `TrimOptions` class is not available in GLib/Ruby, and it is used together with the `utf8_trim` compute function.

### What changes are included in this PR?

This adds the `TrimOptions` class to GLib.

### Are these changes tested?

Yes, with Ruby unit tests.

### Are there any user-facing changes?

Yes, a new class.


* GitHub Issue: #48509