### PR TITLE
GH-48510: [GLib][Ruby] Add WeekOptions

### DIFF
--- a/c_glib/arrow-glib/compute.cpp
+++ b/c_glib/arrow-glib/compute.cpp
@@ -332,6 +332,8 @@ G_BEGIN_DECLS
  * #GArrowTrimOptions is a class to customize the `utf8_trim`, `utf8_ltrim`,
  * `utf8_rtrim`, `ascii_trim`, `ascii_ltrim`, and `ascii_rtrim` functions.
  *
+ * #GArrowWeekOptions is a class to customize the `week` function.
+ *
  * There are many functions to compute data on an array.
  */
 
@@ -9310,7 +9312,7 @@ garrow_round_temporal_options_class_init(GArrowRoundTemporalOptionsClass *klass)
    */
   spec =
     g_param_spec_boolean("week-starts-monday",
-                         "Week Starts Monday",
+                         "Week starts Monday",
                          "What day does the week start with (Monday=true, Sunday=false)",
                          options.week_starts_monday,
                          static_cast<GParamFlags>(G_PARAM_READWRITE));
@@ -10088,6 +10090,148 @@ garrow_trim_options_new(void)
   return GARROW_TRIM_OPTIONS(g_object_new(GARROW_TYPE_TRIM_OPTIONS, nullptr));
 }
 
+enum {
+  PROP_WEEK_OPTIONS_WEEK_STARTS_MONDAY = 1,
+  PROP_WEEK_OPTIONS_COUNT_FROM_ZERO,
+  PROP_WEEK_OPTIONS_FIRST_WEEK_IS_FULLY_IN_YEAR,
+};
+
+G_DEFINE_TYPE(GArrowWeekOptions, garrow_week_options, GARROW_TYPE_FUNCTION_OPTIONS)
+
+static void
+garrow_week_options_set_property(GObject *object,
+                                 guint prop_id,
+                                 const GValue *value,
+                                 GParamSpec *pspec)
+{
+  auto options = garrow_week_options_get_raw(GARROW_WEEK_OPTIONS(object));
+
+  switch (prop_id) {
+  case PROP_WEEK_OPTIONS_WEEK_STARTS_MONDAY:
+    options->week_starts_monday = g_value_get_boolean(value);
+    break;
+  case PROP_WEEK_OPTIONS_COUNT_FROM_ZERO:
+    options->count_from_zero = g_value_get_boolean(value);
+    break;
+  case PROP_WEEK_OPTIONS_FIRST_WEEK_IS_FULLY_IN_YEAR:
+    options->first_week_is_fully_in_year = g_value_get_boolean(value);
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+garrow_week_options_get_property(GObject *object,
+                                 guint prop_id,
+                                 GValue *value,
+                                 GParamSpec *pspec)
+{
+  auto options = garrow_week_options_get_raw(GARROW_WEEK_OPTIONS(object));
+
+  switch (prop_id) {
+  case PROP_WEEK_OPTIONS_WEEK_STARTS_MONDAY:
+    g_value_set_boolean(value, options->week_starts_monday);
+    break;
+  case PROP_WEEK_OPTIONS_COUNT_FROM_ZERO:
+    g_value_set_boolean(value, options->count_from_zero);
+    break;
+  case PROP_WEEK_OPTIONS_FIRST_WEEK_IS_FULLY_IN_YEAR:
+    g_value_set_boolean(value, options->first_week_is_fully_in_year);
+    break;
+  default:
+    G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
+    break;
+  }
+}
+
+static void
+garrow_week_options_init(GArrowWeekOptions *object)
+{
+  auto priv = GARROW_FUNCTION_OPTIONS_GET_PRIVATE(object);
+  priv->options =
+    static_cast<arrow::compute::FunctionOptions *>(new arrow::compute::WeekOptions());
+}
+
+static void
+garrow_week_options_class_init(GArrowWeekOptionsClass *klass)
+{
+  auto gobject_class = G_OBJECT_CLASS(klass);
+
+  gobject_class->set_property = garrow_week_options_set_property;
+  gobject_class->get_property = garrow_week_options_get_property;
+
+  auto options = arrow::compute::WeekOptions::Defaults();
+
+  GParamSpec *spec;
+  /**
+   * GArrowWeekOptions:week-starts-monday:
+   *
+   * What day does the week start with (Monday=true, Sunday=false).
+   *
+   * Since: 23.0.0
+   */
+  spec =
+    g_param_spec_boolean("week-starts-monday",
+                         "Week starts Monday",
+                         "What day does the week start with (Monday=true, Sunday=false)",
+                         options.week_starts_monday,
+                         static_cast<GParamFlags>(G_PARAM_READWRITE));
+  g_object_class_install_property(gobject_class,
+                                  PROP_WEEK_OPTIONS_WEEK_STARTS_MONDAY,
+                                  spec);
+
+  /**
+   * GArrowWeekOptions:count-from-zero:
+   *
+   * Dates from current year that fall into last ISO week of the previous year
+   * return 0 if true and 52 or 53 if false.
+   *
+   * Since: 23.0.0
+   */
+  spec = g_param_spec_boolean("count-from-zero",
+                              "Count from zero",
+                              "Dates from current year that fall into last ISO week of "
+                              "the previous year return 0 if true and 52 or 53 if false",
+                              options.count_from_zero,
+                              static_cast<GParamFlags>(G_PARAM_READWRITE));
+  g_object_class_install_property(gobject_class, PROP_WEEK_OPTIONS_COUNT_FROM_ZERO, spec);
+
+  /**
+   * GArrowWeekOptions:first-week-is-fully-in-year:
+   *
+   * Must the first week be fully in January (true), or is a week that begins
+   * on December 29, 30, or 31 considered to be the first week of the new
+   * year (false)?
+   *
+   * Since: 23.0.0
+   */
+  spec = g_param_spec_boolean(
+    "first-week-is-fully-in-year",
+    "First week is fully in year",
+    "Must the first week be fully in January (true), or is a week that begins on "
+    "December 29, 30, or 31 considered to be the first week of the new year (false)?",
+    options.first_week_is_fully_in_year,
+    static_cast<GParamFlags>(G_PARAM_READWRITE));
+  g_object_class_install_property(gobject_class,
+                                  PROP_WEEK_OPTIONS_FIRST_WEEK_IS_FULLY_IN_YEAR,
+                                  spec);
+}
+
+/**
+ * garrow_week_options_new:
+ *
+ * Returns: A newly created #GArrowWeekOptions.
+ *
+ * Since: 23.0.0
+ */
+GArrowWeekOptions *
+garrow_week_options_new(void)
+{
+  return GARROW_WEEK_OPTIONS(g_object_new(GARROW_TYPE_WEEK_OPTIONS, nullptr));
+}
+
 G_END_DECLS
 
 arrow::Result<arrow::FieldRef>
@@ -10352,6 +10496,11 @@ garrow_function_options_new_raw(const arrow::compute::FunctionOptions *arrow_opt
     const auto arrow_trim_options =
       static_cast<const arrow::compute::TrimOptions *>(arrow_options);
     auto options = garrow_trim_options_new_raw(arrow_trim_options);
+    return GARROW_FUNCTION_OPTIONS(options);
+  } else if (arrow_type_name == "WeekOptions") {
+    const auto arrow_week_options =
+      static_cast<const arrow::compute::WeekOptions *>(arrow_options);
+    auto options = garrow_week_options_new_raw(arrow_week_options);
     return GARROW_FUNCTION_OPTIONS(options);
   } else {
     auto options = g_object_new(GARROW_TYPE_FUNCTION_OPTIONS, NULL);
@@ -11428,5 +11577,26 @@ arrow::compute::TrimOptions *
 garrow_trim_options_get_raw(GArrowTrimOptions *options)
 {
   return static_cast<arrow::compute::TrimOptions *>(
+    garrow_function_options_get_raw(GARROW_FUNCTION_OPTIONS(options)));
+}
+
+GArrowWeekOptions *
+garrow_week_options_new_raw(const arrow::compute::WeekOptions *arrow_options)
+{
+  auto options = g_object_new(GARROW_TYPE_WEEK_OPTIONS,
+                              "week-starts-monday",
+                              arrow_options->week_starts_monday,
+                              "count-from-zero",
+                              arrow_options->count_from_zero,
+                              "first-week-is-fully-in-year",
+                              arrow_options->first_week_is_fully_in_year,
+                              nullptr);
+  return GARROW_WEEK_OPTIONS(options);
+}
+
+arrow::compute::WeekOptions *
+garrow_week_options_get_raw(GArrowWeekOptions *options)
+{
+  return static_cast<arrow::compute::WeekOptions *>(
     garrow_function_options_get_raw(GARROW_FUNCTION_OPTIONS(options)));
 }

--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -1742,4 +1742,17 @@ GARROW_AVAILABLE_IN_23_0
 GArrowTrimOptions *
 garrow_trim_options_new(void);
 
+#define GARROW_TYPE_WEEK_OPTIONS (garrow_week_options_get_type())
+GARROW_AVAILABLE_IN_23_0
+G_DECLARE_DERIVABLE_TYPE(
+  GArrowWeekOptions, garrow_week_options, GARROW, WEEK_OPTIONS, GArrowFunctionOptions)
+struct _GArrowWeekOptionsClass
+{
+  GArrowFunctionOptionsClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_23_0
+GArrowWeekOptions *
+garrow_week_options_new(void);
+
 G_END_DECLS

--- a/c_glib/arrow-glib/compute.hpp
+++ b/c_glib/arrow-glib/compute.hpp
@@ -323,3 +323,8 @@ GArrowTrimOptions *
 garrow_trim_options_new_raw(const arrow::compute::TrimOptions *arrow_options);
 arrow::compute::TrimOptions *
 garrow_trim_options_get_raw(GArrowTrimOptions *options);
+
+GArrowWeekOptions *
+garrow_week_options_new_raw(const arrow::compute::WeekOptions *arrow_options);
+arrow::compute::WeekOptions *
+garrow_week_options_get_raw(GArrowWeekOptions *options);

--- a/c_glib/test/test-week-options.rb
+++ b/c_glib/test/test-week-options.rb
@@ -1,0 +1,70 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestWeekOptions < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def setup
+    @options = Arrow::WeekOptions.new
+  end
+
+  def test_week_starts_monday_property
+    assert do
+      @options.week_starts_monday?
+    end
+    @options.week_starts_monday = false
+    assert do
+      !@options.week_starts_monday?
+    end
+  end
+
+  def test_count_from_zero_property
+    assert do
+      !@options.count_from_zero?
+    end
+    @options.count_from_zero = true
+    assert do
+      @options.count_from_zero?
+    end
+  end
+
+  def test_first_week_is_fully_in_year_property
+    assert do
+      !@options.first_week_is_fully_in_year?
+    end
+    @options.first_week_is_fully_in_year = true
+    assert do
+      @options.first_week_is_fully_in_year?
+    end
+  end
+
+  def test_week_function_with_week_starts_monday
+    omit("Missing tzdata on Windows") if Gem.win_platform?
+    # January 1, 2023 (Sunday)
+    args = [
+      Arrow::ArrayDatum.new(build_timestamp_array(:milli, [1672531200000])),
+    ]
+    @options.week_starts_monday = true
+    week_function = Arrow::Function.find("week")
+    result = week_function.execute(args, @options).value
+    assert_equal(build_int64_array([52]), result)
+
+    @options.week_starts_monday = false
+    result = week_function.execute(args, @options).value
+    assert_equal(build_int64_array([1]), result)
+  end
+end


### PR DESCRIPTION
### Rationale for this change

The `WeekOptions` class is not available in GLib/Ruby, and it is used together with the `week` compute function.

### What changes are included in this PR?

This adds the `WeekOptions` class to GLib.

### Are these changes tested?

Yes, with Ruby unit tests.

### Are there any user-facing changes?

Yes, a new class.


* GitHub Issue: #48510