### PR TITLE
GH-48511: [GLib][Ruby] Add WinsorizeOptions

### DIFF
--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -1755,4 +1755,20 @@ GARROW_AVAILABLE_IN_23_0
 GArrowWeekOptions *
 garrow_week_options_new(void);
 
+#define GARROW_TYPE_WINSORIZE_OPTIONS (garrow_winsorize_options_get_type())
+GARROW_AVAILABLE_IN_23_0
+G_DECLARE_DERIVABLE_TYPE(GArrowWinsorizeOptions,
+                         garrow_winsorize_options,
+                         GARROW,
+                         WINSORIZE_OPTIONS,
+                         GArrowFunctionOptions)
+struct _GArrowWinsorizeOptionsClass
+{
+  GArrowFunctionOptionsClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_23_0
+GArrowWinsorizeOptions *
+garrow_winsorize_options_new(void);
+
 G_END_DECLS

--- a/c_glib/arrow-glib/compute.hpp
+++ b/c_glib/arrow-glib/compute.hpp
@@ -328,3 +328,8 @@ GArrowWeekOptions *
 garrow_week_options_new_raw(const arrow::compute::WeekOptions *arrow_options);
 arrow::compute::WeekOptions *
 garrow_week_options_get_raw(GArrowWeekOptions *options);
+
+GArrowWinsorizeOptions *
+garrow_winsorize_options_new_raw(const arrow::compute::WinsorizeOptions *arrow_options);
+arrow::compute::WinsorizeOptions *
+garrow_winsorize_options_get_raw(GArrowWinsorizeOptions *options);

--- a/c_glib/test/test-winsorize-options.rb
+++ b/c_glib/test/test-winsorize-options.rb
@@ -1,0 +1,49 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestWinsorizeOptions < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def setup
+    @options = Arrow::WinsorizeOptions.new
+  end
+
+  def test_lower_limit_property
+    assert_equal(0.0, @options.lower_limit)
+    @options.lower_limit = 0.05
+    assert_equal(0.05, @options.lower_limit)
+  end
+
+  def test_upper_limit_property
+    assert_equal(1.0, @options.upper_limit)
+    @options.upper_limit = 0.95
+    assert_equal(0.95, @options.upper_limit)
+  end
+
+  def test_winsorize_function
+    args = [
+      Arrow::ArrayDatum.new(build_double_array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 
+10.0])),
+    ]
+    @options.lower_limit = 0.1
+    @options.upper_limit = 0.9
+    winsorize_function = Arrow::Function.find("winsorize")
+    result = winsorize_function.execute(args, @options).value
+    expected = build_double_array([2.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 9.0])
+    assert_equal(expected, result)
+  end
+end


### PR DESCRIPTION
### Rationale for this change

The `WinsorizeOptions` class is not available in GLib/Ruby, and it is used together with the `winsorize` compute function.

### What changes are included in this PR?

This adds the `WinsorizeOptions` class to GLib.

### Are these changes tested?

Yes, with Ruby unit tests.

### Are there any user-facing changes?

Yes, a new class.


* GitHub Issue: #48511