### PR TITLE
GH-48512: [GLib][Ruby] Add ZeroFillOptions

### DIFF
--- a/c_glib/arrow-glib/compute.cpp
+++ b/c_glib/arrow-glib/compute.cpp
@@ -10372,30 +10372,9 @@ enum {
   PROP_ZERO_FILL_OPTIONS_PADDING,
 };
 
-typedef struct _GArrowZeroFillOptionsPrivate GArrowZeroFillOptionsPrivate;
-struct _GArrowZeroFillOptionsPrivate
-{
-  gchar *padding;
-};
-
-G_DEFINE_TYPE_WITH_PRIVATE(GArrowZeroFillOptions,
-                           garrow_zero_fill_options,
-                           GARROW_TYPE_FUNCTION_OPTIONS)
-
-#define GARROW_ZERO_FILL_OPTIONS_GET_PRIVATE(object)                                     \
-  static_cast<GArrowZeroFillOptionsPrivate *>(                                           \
-    garrow_zero_fill_options_get_instance_private(GARROW_ZERO_FILL_OPTIONS(object)))
-
-static void
-garrow_zero_fill_options_dispose(GObject *object)
-{
-  auto priv = GARROW_ZERO_FILL_OPTIONS_GET_PRIVATE(object);
-  if (priv->padding) {
-    g_free(priv->padding);
-    priv->padding = nullptr;
-  }
-  G_OBJECT_CLASS(garrow_zero_fill_options_parent_class)->dispose(object);
-}
+G_DEFINE_TYPE(GArrowZeroFillOptions,
+              garrow_zero_fill_options,
+              GARROW_TYPE_FUNCTION_OPTIONS)
 
 static void
 garrow_zero_fill_options_set_property(GObject *object,
@@ -10404,21 +10383,13 @@ garrow_zero_fill_options_set_property(GObject *object,
                                       GParamSpec *pspec)
 {
   auto options = garrow_zero_fill_options_get_raw(GARROW_ZERO_FILL_OPTIONS(object));
-  auto priv = GARROW_ZERO_FILL_OPTIONS_GET_PRIVATE(object);
 
   switch (prop_id) {
   case PROP_ZERO_FILL_OPTIONS_WIDTH:
     options->width = g_value_get_int64(value);
     break;
   case PROP_ZERO_FILL_OPTIONS_PADDING:
-    {
-      const gchar *padding = g_value_get_string(value);
-      if (priv->padding) {
-        g_free(priv->padding);
-      }
-      priv->padding = g_strdup(padding);
-      options->padding = padding ? padding : "";
-    }
+    options->padding = g_value_get_string(value);
     break;
   default:
     G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
@@ -10433,14 +10404,13 @@ garrow_zero_fill_options_get_property(GObject *object,
                                       GParamSpec *pspec)
 {
   auto options = garrow_zero_fill_options_get_raw(GARROW_ZERO_FILL_OPTIONS(object));
-  auto priv = GARROW_ZERO_FILL_OPTIONS_GET_PRIVATE(object);
 
   switch (prop_id) {
   case PROP_ZERO_FILL_OPTIONS_WIDTH:
     g_value_set_int64(value, options->width);
     break;
   case PROP_ZERO_FILL_OPTIONS_PADDING:
-    g_value_set_string(value, priv->padding ? priv->padding : options->padding.c_str());
+    g_value_set_string(value, options->padding.c_str());
     break;
   default:
     G_OBJECT_WARN_INVALID_PROPERTY_ID(object, prop_id, pspec);
@@ -10451,14 +10421,9 @@ garrow_zero_fill_options_get_property(GObject *object,
 static void
 garrow_zero_fill_options_init(GArrowZeroFillOptions *object)
 {
-  auto priv = GARROW_ZERO_FILL_OPTIONS_GET_PRIVATE(object);
-  priv->padding = nullptr;
   auto arrow_priv = GARROW_FUNCTION_OPTIONS_GET_PRIVATE(object);
   arrow_priv->options =
     static_cast<arrow::compute::FunctionOptions *>(new arrow::compute::ZeroFillOptions());
-  // Sync the private string with the C++ options
-  auto arrow_options = garrow_zero_fill_options_get_raw(GARROW_ZERO_FILL_OPTIONS(object));
-  priv->padding = g_strdup(arrow_options->padding.c_str());
 }
 
 static void
@@ -10466,7 +10431,6 @@ garrow_zero_fill_options_class_init(GArrowZeroFillOptionsClass *klass)
 {
   auto gobject_class = G_OBJECT_CLASS(klass);
 
-  gobject_class->dispose = garrow_zero_fill_options_dispose;
   gobject_class->set_property = garrow_zero_fill_options_set_property;
   gobject_class->get_property = garrow_zero_fill_options_get_property;
 

--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -1771,4 +1771,20 @@ GARROW_AVAILABLE_IN_23_0
 GArrowWinsorizeOptions *
 garrow_winsorize_options_new(void);
 
+#define GARROW_TYPE_ZERO_FILL_OPTIONS (garrow_zero_fill_options_get_type())
+GARROW_AVAILABLE_IN_23_0
+G_DECLARE_DERIVABLE_TYPE(GArrowZeroFillOptions,
+                         garrow_zero_fill_options,
+                         GARROW,
+                         ZERO_FILL_OPTIONS,
+                         GArrowFunctionOptions)
+struct _GArrowZeroFillOptionsClass
+{
+  GArrowFunctionOptionsClass parent_class;
+};
+
+GARROW_AVAILABLE_IN_23_0
+GArrowZeroFillOptions *
+garrow_zero_fill_options_new(void);
+
 G_END_DECLS

--- a/c_glib/arrow-glib/compute.hpp
+++ b/c_glib/arrow-glib/compute.hpp
@@ -333,3 +333,8 @@ GArrowWinsorizeOptions *
 garrow_winsorize_options_new_raw(const arrow::compute::WinsorizeOptions *arrow_options);
 arrow::compute::WinsorizeOptions *
 garrow_winsorize_options_get_raw(GArrowWinsorizeOptions *options);
+
+GArrowZeroFillOptions *
+garrow_zero_fill_options_new_raw(const arrow::compute::ZeroFillOptions *arrow_options);
+arrow::compute::ZeroFillOptions *
+garrow_zero_fill_options_get_raw(GArrowZeroFillOptions *options);

--- a/c_glib/test/test-zero-fill-options.rb
+++ b/c_glib/test/test-zero-fill-options.rb
@@ -1,0 +1,48 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+class TestZeroFillOptions < Test::Unit::TestCase
+  include Helper::Buildable
+
+  def setup
+    @options = Arrow::ZeroFillOptions.new
+  end
+
+  def test_width_property
+    assert_equal(0, @options.width)
+    @options.width = 4
+    assert_equal(4, @options.width)
+  end
+
+  def test_padding_property
+    assert_equal("0", @options.padding)
+    @options.padding = "x"
+    assert_equal("x", @options.padding)
+  end
+
+  def test_utf8_zero_fill_function
+    args = [
+      Arrow::ArrayDatum.new(build_string_array(["1", "-2", "+3"])),
+    ]
+    @options.width = 4
+    @options.padding = "0"
+    utf8_zero_fill_function = Arrow::Function.find("utf8_zero_fill")
+    result = utf8_zero_fill_function.execute(args, @options).value
+    expected = build_string_array(["0001", "-002", "+003"])
+    assert_equal(expected, result)
+  end
+end


### PR DESCRIPTION
### Rationale for this change

The `ZeroFillOptions` class is not available in GLib/Ruby, and it is used together with the `utf8_zero_fill` compute function.

### What changes are included in this PR?

This adds the `ZeroFillOptions` class to GLib.

### Are these changes tested?

Yes, with Ruby unit tests.

### Are there any user-facing changes?

Yes, a new class.



* GitHub Issue: #48512