### PR TITLE
[Python][Docs] Document file path support for IPC reader source

### DIFF
--- a/python/pyarrow/ipc.py
+++ b/python/pyarrow/ipc.py
@@ -37,8 +37,9 @@ class RecordBatchStreamReader(lib._RecordBatchStreamReader):
 
     Parameters
     ----------
-    source : bytes/buffer-like, pyarrow.NativeFile, or file-like Python object
-        Either an in-memory buffer, or a readable file object.
+    source : str, pathlib.Path, bytes/buffer-like, pyarrow.NativeFile, or file-like Python object
+        Either a file path, an in-memory buffer, or a readable file object.
+        If a string or Path is provided, it will be interpreted as a file path.
         If you want to use memory map use MemoryMappedFile as source.
     options : pyarrow.ipc.IpcReadOptions
         Options for IPC deserialization.
@@ -96,8 +97,9 @@ class RecordBatchFileReader(lib._RecordBatchFileReader):
 
     Parameters
     ----------
-    source : bytes/buffer-like, pyarrow.NativeFile, or file-like Python object
-        Either an in-memory buffer, or a readable file object.
+    source : str, pathlib.Path, bytes/buffer-like, pyarrow.NativeFile, or file-like Python object
+        Either a file path, an in-memory buffer, or a readable file object.
+        If a string or Path is provided, it will be interpreted as a file path.
         If you want to use memory map use MemoryMappedFile as source.
     footer_offset : int, default None
         If the file is embedded in some larger file, this is the byte offset to
@@ -171,8 +173,9 @@ def open_stream(source, *, options=None, memory_pool=None):
 
     Parameters
     ----------
-    source : bytes/buffer-like, pyarrow.NativeFile, or file-like Python object
-        Either an in-memory buffer, or a readable file object.
+    source : str, pathlib.Path, bytes/buffer-like, pyarrow.NativeFile, or file-like Python object
+        Either a file path, an in-memory buffer, or a readable file object.
+        If a string or Path is provided, it will be interpreted as a file path.
     options : pyarrow.ipc.IpcReadOptions
         Options for IPC serialization.
         If None, default values will be used.
@@ -210,8 +213,9 @@ def open_file(source, footer_offset=None, *, options=None, memory_pool=None):
 
     Parameters
     ----------
-    source : bytes/buffer-like, pyarrow.NativeFile, or file-like Python object
-        Either an in-memory buffer, or a readable file object.
+    source : str, pathlib.Path, bytes/buffer-like, pyarrow.NativeFile, or file-like Python object
+        Either a file path, an in-memory buffer, or a readable file object.
+        If a string or Path is provided, it will be interpreted as a file path.
     footer_offset : int, default None
         If the file is embedded in some larger file, this is the byte offset to
         the very end of the file data.


### PR DESCRIPTION
## What changed

Document that IPC reader APIs accept a file path for the `source` parameter,
consistent with existing writer documentation.

## Affected APIs

- pyarrow.ipc.open_file
- pyarrow.ipc.open_stream
- pyarrow.ipc.RecordBatchFileReader
- pyarrow.ipc.RecordBatchStreamReader

## Why

These APIs already accept file paths, but this behavior was undocumented.
This PR aligns the reader documentation with actual behavior and with
the corresponding writer APIs.

Fixes #46927
