### PR TITLE
GH-48535: [Ruby] Add support for reading time64 array

### DIFF
--- a/ruby/red-arrow-format/lib/arrow-format/array.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/array.rb
@@ -177,6 +177,12 @@ module ArrowFormat
     end
   end
 
+  class Time64Array < TimeArray
+    def to_a
+      apply_validity(@values_buffer.values(:s64, 0, @size))
+    end
+  end
+
   class VariableSizeBinaryLayoutArray < Array
     def initialize(type, size, validity_buffer, offsets_buffer, values_buffer)
       super(type, size, validity_buffer)

--- a/ruby/red-arrow-format/lib/arrow-format/file-reader.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/file-reader.rb
@@ -200,6 +200,13 @@ module ArrowFormat
           when Org::Apache::Arrow::Flatbuf::TimeUnit::MILLISECOND
             type = Time32Type.new(:millisecond)
           end
+        when 64
+          case fb_type.unit
+          when Org::Apache::Arrow::Flatbuf::TimeUnit::MICROSECOND
+            type = Time64Type.new(:microsecond)
+          when Org::Apache::Arrow::Flatbuf::TimeUnit::NANOSECOND
+            type = Time64Type.new(:nanosecond)
+          end
         end
       when Org::Apache::Arrow::Flatbuf::List
         type = ListType.new(read_field(fb_field.children[0]))

--- a/ruby/red-arrow-format/lib/arrow-format/type.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/type.rb
@@ -287,6 +287,17 @@ module ArrowFormat
     end
   end
 
+  class Time64Type < TimeType
+    def initialize(unit)
+      super("Time64")
+      @unit = unit
+    end
+
+    def build_array(size, validity_buffer, values_buffer)
+      Time64Array.new(self, size, validity_buffer, values_buffer)
+    end
+  end
+
   class VariableSizeBinaryType < Type
   end
 

--- a/ruby/red-arrow-format/test/test-file-reader.rb
+++ b/ruby/red-arrow-format/test/test-file-reader.rb
@@ -265,6 +265,66 @@ class TestFileReader < Test::Unit::TestCase
     end
   end
 
+  sub_test_case("Time64(:microsecond)") do
+    def setup(&block)
+      @time_00_00_10_000_000 = 10 * 1_000_000
+      @time_00_01_10_000_000 = (60 + 10) * 1_000_000
+      super(&block)
+    end
+
+    def build_array
+      Arrow::Time64Array.new(:micro,
+                             [
+                               @time_00_00_10_000_000,
+                               nil,
+                               @time_00_01_10_000_000,
+                             ])
+    end
+
+    def test_read
+      assert_equal([
+                     {
+                       "value" => [
+                         @time_00_00_10_000_000,
+                         nil,
+                         @time_00_01_10_000_000,
+                       ],
+                     },
+                   ],
+                   read)
+    end
+  end
+
+  sub_test_case("Time64(:nanosecond)") do
+    def setup(&block)
+      @time_00_00_10_000_000_000 = 10 * 1_000_000_000
+      @time_00_01_10_000_000_000 = (60 + 10) * 1_000_000_000
+      super(&block)
+    end
+
+    def build_array
+      Arrow::Time64Array.new(:nano,
+                             [
+                               @time_00_00_10_000_000_000,
+                               nil,
+                               @time_00_01_10_000_000_000,
+                             ])
+    end
+
+    def test_read
+      assert_equal([
+                     {
+                       "value" => [
+                         @time_00_00_10_000_000_000,
+                         nil,
+                         @time_00_01_10_000_000_000,
+                       ],
+                     },
+                   ],
+                   read)
+    end
+  end
+
   sub_test_case("Binary") do
     def build_array
       Arrow::BinaryArray.new(["Hello".b, nil, "World".b])


### PR DESCRIPTION
### Rationale for this change

It's a 64 bits variant of time array.

### What changes are included in this PR?

* Add `ArrowFormat::Time64Type`
* Add `ArrowFormat::Time64Array`

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #48535