### PR TITLE
GH-48537: [Ruby] Add support for reading fixed size binary array

### DIFF
--- a/ruby/red-arrow-format/lib/arrow-format/array.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/array.rb
@@ -244,17 +244,6 @@ module ArrowFormat
     end
   end
 
-  class BinaryArray < VariableSizeBinaryLayoutArray
-    private
-    def buffer_type
-      :s32 # TODO: big endian support
-    end
-
-    def encoding
-      Encoding::ASCII_8BIT
-    end
-  end
-
   class VariableSizeListArray < Array
     def initialize(type, size, validity_buffer, offsets_buffer, child)
       super(type, size, validity_buffer)

--- a/ruby/red-arrow-format/lib/arrow-format/array.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/array.rb
@@ -229,6 +229,32 @@ module ArrowFormat
     end
   end
 
+  class FixedSizeBinaryArray < Array
+    def initialize(type, size, validity_buffer, values_buffer)
+      super(type, size, validity_buffer)
+      @values_buffer = values_buffer
+    end
+
+    def to_a
+      byte_width = @type.byte_width
+      values = 0.step(@size * byte_width - 1, byte_width).collect do |offset|
+        @values_buffer.get_string(offset, byte_width)
+      end
+      apply_validity(values)
+    end
+  end
+
+  class BinaryArray < VariableSizeBinaryLayoutArray
+    private
+    def buffer_type
+      :s32 # TODO: big endian support
+    end
+
+    def encoding
+      Encoding::ASCII_8BIT
+    end
+  end
+
   class VariableSizeListArray < Array
     def initialize(type, size, validity_buffer, offsets_buffer, child)
       super(type, size, validity_buffer)

--- a/ruby/red-arrow-format/lib/arrow-format/file-reader.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/file-reader.rb
@@ -225,6 +225,8 @@ module ArrowFormat
         type = LargeBinaryType.singleton
       when Org::Apache::Arrow::Flatbuf::Utf8
         type = UTF8Type.singleton
+      when Org::Apache::Arrow::Flatbuf::FixedSizeBinary
+        type = FixedSizeBinaryType.new(fb_type.byte_width)
       end
       Field.new(fb_field.name, type, fb_field.nullable?)
     end
@@ -256,6 +258,16 @@ module ArrowFormat
         values_buffer = buffers.shift
         values = body.slice(values_buffer.offset, values_buffer.length)
         field.type.build_array(length, validity, values)
+      when VariableSizeBinaryType
+        offsets_buffer = buffers.shift
+        values_buffer = buffers.shift
+        offsets = body.slice(offsets_buffer.offset, offsets_buffer.length)
+        values = body.slice(values_buffer.offset, values_buffer.length)
+        field.type.build_array(length, validity, offsets, values)
+      when FixedSizeBinaryType
+        values_buffer = buffers.shift
+        values = body.slice(values_buffer.offset, values_buffer.length)
+        field.type.build_array(length, validity, values)
       when VariableSizeListType
         offsets_buffer = buffers.shift
         offsets = body.slice(offsets_buffer.offset, offsets_buffer.length)
@@ -282,12 +294,6 @@ module ArrowFormat
           read_column(child, nodes, buffers, body)
         end
         field.type.build_array(length, types, children)
-      when VariableSizeBinaryType
-        offsets_buffer = buffers.shift
-        values_buffer = buffers.shift
-        offsets = body.slice(offsets_buffer.offset, offsets_buffer.length)
-        values = body.slice(values_buffer.offset, values_buffer.length)
-        field.type.build_array(length, validity, offsets, values)
       end
     end
   end

--- a/ruby/red-arrow-format/lib/arrow-format/type.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/type.rb
@@ -333,13 +333,24 @@ module ArrowFormat
       end
     end
 
-    attr_reader :name
     def initialize
       super("UTF8")
     end
 
     def build_array(size, validity_buffer, offsets_buffer, values_buffer)
       UTF8Array.new(self, size, validity_buffer, offsets_buffer, values_buffer)
+    end
+  end
+
+  class FixedSizeBinaryType < Type
+    attr_reader :byte_width
+    def initialize(byte_width)
+      super("FixedSizeBinary")
+      @byte_width = byte_width
+    end
+
+    def build_array(size, validity_buffer, values_buffer)
+      FixedSizeBinaryArray.new(self, size, validity_buffer, values_buffer)
     end
   end
 

--- a/ruby/red-arrow-format/test/test-file-reader.rb
+++ b/ruby/red-arrow-format/test/test-file-reader.rb
@@ -298,6 +298,18 @@ class TestFileReader < Test::Unit::TestCase
     end
   end
 
+  sub_test_case("FixedSizeBinary") do
+    def build_array
+      data_type = Arrow::FixedSizeBinaryDataType.new(4)
+      Arrow::FixedSizeBinaryArray.new(data_type, ["0124".b, nil, "abcd".b])
+    end
+
+    def test_read
+      assert_equal([{"value" => ["0124".b, nil, "abcd".b]}],
+                   read)
+    end
+  end
+
   sub_test_case("List") do
     def build_array
       data_type = Arrow::ListDataType.new(name: "count", type: :int8)


### PR DESCRIPTION
### Rationale for this change

It's a fixed size variant of binary array.

### What changes are included in this PR?

* Add `ArrowFormat::FixedSizeBinaryType`
* Add `ArrowFormat::FixedSizeBinaryArray`

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #48537