### PR TITLE
GH-47918: [Format] Clarify that empty compressed buffers can omit the length header

### DIFF
--- a/format/Message.fbs
+++ b/format/Message.fbs
@@ -42,7 +42,7 @@ struct FieldNode {
   null_count: long;
 }
 
-enum CompressionType:byte {
+enum CompressionType: byte {
   // LZ4 frame format, for portability, as provided by lz4frame.h or wrappers
   // thereof. Not to be confused with "raw" (also called "block") format
   // provided by lz4.h
@@ -55,7 +55,7 @@ enum CompressionType:byte {
 /// Provided for forward compatibility in case we need to support different
 /// strategies for compressing the IPC message body (like whole-body
 /// compression rather than buffer-level) in the future
-enum BodyCompressionMethod:byte {
+enum BodyCompressionMethod: byte {
   /// Each constituent buffer is first compressed with the indicated
   /// compressor, and then written with the uncompressed length in the first 8
   /// bytes as a 64-bit little-endian signed integer followed by the compressed
@@ -63,6 +63,8 @@ enum BodyCompressionMethod:byte {
   /// uncompressed length may be set to -1 to indicate that the data that
   /// follows is not compressed, which can be useful for cases where
   /// compression does not yield appreciable savings.
+  /// Also, empty buffers can optionally be written out as 0-byte compressed
+  /// buffers, thereby omitting the 8-bytes length header.
   BUFFER
 }
 


### PR DESCRIPTION
### Rationale for this change

The 8-byte length header is considered optional for empty compressed buffers in Arrow C++ and other implementations.

### Are these changes tested?

Not applicable.

### Are there any user-facing changes?

No.

* GitHub Issue: #47918