### PR TITLE
GH-48547: [C++][Flight RPC] Enable ODBC tests in MSVC CI

### DIFF
--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -175,6 +175,7 @@ jobs:
     uses: ./.github/workflows/cpp_windows.yml
     with:
       arch: arm64
+      flight-sql-odbc: true
       os: windows-11-arm
       simd-level: NONE
 

--- a/.github/workflows/cpp_windows.yml
+++ b/.github/workflows/cpp_windows.yml
@@ -24,6 +24,11 @@ on:
         description: "The architecture to build for"
         required: true
         type: string
+      flight-sql-odbc:
+        default: false
+        description: "Whether to enable Arrow Flight SQL ODBC"
+        required: false
+        type: boolean
       os:
         description: "The runner label to run the job on"
         required: true
@@ -45,6 +50,7 @@ jobs:
       ARROW_BUILD_TESTS: ON
       ARROW_DATASET: ON
       ARROW_FLIGHT: OFF
+      ARROW_FLIGHT_SQL_ODBC: ${{ inputs.flight-sql-odbc && 'ON' || 'OFF' }}
       ARROW_HDFS: ON
       ARROW_HOME: /usr
       ARROW_JEMALLOC: OFF

--- a/cpp/src/arrow/meson.build
+++ b/cpp/src/arrow/meson.build
@@ -191,6 +191,7 @@ arrow_util_srcs = [
     'util/fixed_width_internal.cc',
     'util/float16.cc',
     'util/formatting.cc',
+    'util/fuzz_internal.cc',
     'util/future.cc',
     'util/hashing.cc',
     'util/int_util.cc',


### PR DESCRIPTION
### Rationale for this change

This PR addresses [#48547](https://github.com/apache/arrow/issues/48547) to enable Arrow Flight SQL ODBC tests in MSVC CI.

### What changes are included in this PR?

1. Added a new optional `flight-sql-odbc` input parameter to the reusable `cpp_windows.yml` workflow
2. Added `ARROW_FLIGHT_SQL_ODBC` environment variable that conditionally enables ODBC based on the input
3. Updated `cpp_extra.yml` to pass `flight-sql-odbc: true` for the `msvc-arm64` job

### Are these changes tested?

This change enables existing ODBC tests to run in the MSVC CI pipeline.

### Are there any user-facing changes?

No.

### Notes

This PR depends on [#48269](https://github.com/apache/arrow/issues/48269) (enabling Flight/Flight SQL tests in MSVC CI) being resolved first. Once Flight and Flight SQL tests are enabled, the ODBC tests configured by this PR will execute properly.
* GitHub Issue: #48547