### PR TITLE
GH-45847: [C++] Optimize Parquet column reader by fusing decoding and counting

### DIFF
--- a/cpp/src/arrow/util/rle_encoding_internal.h
+++ b/cpp/src/arrow/util/rle_encoding_internal.h
@@ -395,10 +395,14 @@ class BitPackedRunDecoder {
   }
 
   /// Get a batch of values and count how many equal match_value
+  /// Note: For bit-packed runs, we use std::count after GetBatch since it's
+  /// highly optimized by the compiler. The fused approach is only beneficial
+  /// for RLE runs where counting is O(1).
   [[nodiscard]] rle_size_t GetBatchWithCount(value_type* out, rle_size_t batch_size,
                                              rle_size_t value_bit_width,
                                              value_type match_value, int64_t* out_count) {
-    auto steps = GetBatch(out, batch_size, value_bit_width);
+    const auto steps = GetBatch(out, batch_size, value_bit_width);
+    // std::count is highly optimized (SIMD) by modern compilers
     *out_count += std::count(out, out + steps, match_value);
     return steps;
   }

--- a/cpp/src/arrow/util/rle_encoding_internal.h
+++ b/cpp/src/arrow/util/rle_encoding_internal.h
@@ -308,20 +308,17 @@ class RleRunDecoder {
     return to_read;
   }
 
-  /// Get a batch of values and count how many equal match_value
+  /// Get a batch of values and count how many equal match_value.
+  /// For RLE runs, counting is O(1) because all values in the run are identical.
   [[nodiscard]] rle_size_t GetBatchWithCount(value_type* out, rle_size_t batch_size,
                                              rle_size_t value_bit_width,
                                              value_type match_value, int64_t* out_count) {
-    if (ARROW_PREDICT_FALSE(remaining_count_ == 0)) {
-      return 0;
-    }
-
-    const auto to_read = std::min(remaining_count_, batch_size);
-    std::fill(out, out + to_read, value_);
-    if (value_ == match_value) {
+    // Save value_ before GetBatch since it doesn't change during the call.
+    const auto current_value = value_;
+    const auto to_read = GetBatch(out, batch_size, value_bit_width);
+    if (current_value == match_value) {
       *out_count += to_read;
     }
-    remaining_count_ -= to_read;
     return to_read;
   }
 

--- a/cpp/src/arrow/util/rle_encoding_internal.h
+++ b/cpp/src/arrow/util/rle_encoding_internal.h
@@ -308,6 +308,23 @@ class RleRunDecoder {
     return to_read;
   }
 
+  /// Get a batch of values and count how many equal match_value
+  [[nodiscard]] rle_size_t GetBatchWithCount(value_type* out, rle_size_t batch_size,
+                                             rle_size_t value_bit_width,
+                                             value_type match_value, int64_t* out_count) {
+    if (ARROW_PREDICT_FALSE(remaining_count_ == 0)) {
+      return 0;
+    }
+
+    const auto to_read = std::min(remaining_count_, batch_size);
+    std::fill(out, out + to_read, value_);
+    if (value_ == match_value) {
+      *out_count += to_read;
+    }
+    remaining_count_ -= to_read;
+    return to_read;
+  }
+
  private:
   value_type value_ = {};
   rle_size_t remaining_count_ = 0;
@@ -377,6 +394,15 @@ class BitPackedRunDecoder {
     return steps;
   }
 
+  /// Get a batch of values and count how many equal match_value
+  [[nodiscard]] rle_size_t GetBatchWithCount(value_type* out, rle_size_t batch_size,
+                                             rle_size_t value_bit_width,
+                                             value_type match_value, int64_t* out_count) {
+    auto steps = GetBatch(out, batch_size, value_bit_width);
+    *out_count += std::count(out, out + steps, match_value);
+    return steps;
+  }
+
  private:
   /// The pointer to the beginning of the run
   const uint8_t* data_ = nullptr;
@@ -438,6 +464,10 @@ class RleBitPackedDecoder {
   /// left or if an error occurred.
   [[nodiscard]] rle_size_t GetBatch(value_type* out, rle_size_t batch_size);
 
+  /// Get a batch of values and count how many equal match_value
+  [[nodiscard]] rle_size_t GetBatchWithCount(value_type* out, rle_size_t batch_size,
+                                             value_type match_value, int64_t* out_count);
+
   /// Like GetBatch but add spacing for null entries.
   ///
   /// Null entries will be set to an arbistrary value to avoid leaking private data.
@@ -480,6 +510,18 @@ class RleBitPackedDecoder {
   [[nodiscard]] rle_size_t RunGetBatch(value_type* out, rle_size_t batch_size) {
     return std::visit(
         [&](auto& dec) { return dec.GetBatch(out, batch_size, value_bit_width_); },
+        decoder_);
+  }
+
+  /// Get a batch of values from the current run and return the number elements read.
+  [[nodiscard]] rle_size_t RunGetBatchWithCount(value_type* out, rle_size_t batch_size,
+                                                value_type match_value,
+                                                int64_t* out_count) {
+    return std::visit(
+        [&](auto& dec) {
+          return dec.GetBatchWithCount(out, batch_size, value_bit_width_, match_value,
+                                       out_count);
+        },
         decoder_);
   }
 
@@ -1472,6 +1514,51 @@ inline void RleBitPackedEncoder::Clear() {
   literal_count_ = 0;
   literal_indicator_byte_ = NULL;
   bit_writer_.Clear();
+}
+
+template <typename T>
+auto RleBitPackedDecoder<T>::GetBatchWithCount(value_type* out, rle_size_t batch_size,
+                                               value_type match_value, int64_t* out_count)
+    -> rle_size_t {
+  using ControlFlow = RleBitPackedParser::ControlFlow;
+
+  rle_size_t values_read = 0;
+
+  // Remaining from a previous call that would have left some unread data from a run.
+  if (ARROW_PREDICT_FALSE(run_remaining() > 0)) {
+    const auto read = RunGetBatchWithCount(out, batch_size, match_value, out_count);
+    values_read += read;
+    out += read;
+
+    // Either we fulfilled all the batch to be read or we finished remaining run.
+    if (ARROW_PREDICT_FALSE(values_read == batch_size)) {
+      return values_read;
+    }
+    ARROW_DCHECK(run_remaining() == 0);
+  }
+
+  ParseWithCallable([&](auto run) {
+    using RunDecoder = typename decltype(run)::template DecoderType<value_type>;
+
+    ARROW_DCHECK_LT(values_read, batch_size);
+    RunDecoder decoder(run, value_bit_width_);
+    const auto read =
+        decoder.GetBatchWithCount(out, batch_size - values_read, value_bit_width_,
+                                  match_value, out_count);
+    ARROW_DCHECK_LE(read, batch_size - values_read);
+    values_read += read;
+    out += read;
+
+    // Stop reading and store remaining decoder
+    if (ARROW_PREDICT_FALSE(values_read == batch_size || read == 0)) {
+      decoder_ = std::move(decoder);
+      return ControlFlow::Break;
+    }
+
+    return ControlFlow::Continue;
+  });
+
+  return values_read;
 }
 
 }  // namespace arrow::util

--- a/cpp/src/parquet/column_reader.h
+++ b/cpp/src/parquet/column_reader.h
@@ -92,6 +92,10 @@ class PARQUET_EXPORT LevelDecoder {
   // Decodes a batch of levels into an array and returns the number of levels decoded
   int Decode(int batch_size, int16_t* levels);
 
+  /// Decodes a batch of levels into an array and counts the number of levels equal to
+  /// max_level_
+  int DecodeAndCount(int batch_size, int16_t* levels, int64_t* count);
+
  private:
   int bit_width_;
   int num_values_remaining_;


### PR DESCRIPTION
### Rationale for this change

This PR implements the optimization to fuse definition level decoding with counting in the Parquet column reader, addressing the TODO in `cpp/src/parquet/column_reader.cc`.

### What changes are included in this PR?

1.  Added `GetBatchWithCount` to `RleBitPackedDecoder`, `RleRunDecoder`, and `BitPackedRunDecoder` in `cpp/src/arrow/util/rle_encoding_internal.h`.
2.  Added `DecodeAndCount` to `LevelDecoder` in `cpp/src/parquet/column_reader.h` and `cpp/src/parquet/column_reader.cc`.
3.  Updated `TypedColumnReaderImpl::ReadLevels` in `cpp/src/parquet/column_reader.cc` to use `DecodeAndCount`.

### Are these changes tested?

Yes.
1.  Added a new unit test `Rle.GetBatchWithCount` in `cpp/src/arrow/util/rle_encoding_test.cc`.
2.  Verified with `arrow-bit-utility-test`.

### Are there any user-facing changes?

No, this is an internal performance optimization.
* GitHub Issue: #45847