### PR TITLE
GH-48551: [Ruby] Add support for reading large UTF-8 array

### DIFF
--- a/ruby/red-arrow-format/lib/arrow-format/array.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/array.rb
@@ -235,6 +235,17 @@ module ArrowFormat
     end
   end
 
+  class LargeUTF8Array < VariableSizeBinaryLayoutArray
+    private
+    def buffer_type
+      :s64 # TODO: big endian support
+    end
+
+    def encoding
+      Encoding::UTF_8
+    end
+  end
+
   class FixedSizeBinaryArray < Array
     def initialize(type, size, validity_buffer, values_buffer)
       super(type, size, validity_buffer)

--- a/ruby/red-arrow-format/lib/arrow-format/file-reader.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/file-reader.rb
@@ -26,11 +26,13 @@ require_relative "org/apache/arrow/flatbuf/binary"
 require_relative "org/apache/arrow/flatbuf/bool"
 require_relative "org/apache/arrow/flatbuf/date"
 require_relative "org/apache/arrow/flatbuf/date_unit"
+require_relative "org/apache/arrow/flatbuf/fixed_size_binary"
 require_relative "org/apache/arrow/flatbuf/floating_point"
 require_relative "org/apache/arrow/flatbuf/footer"
 require_relative "org/apache/arrow/flatbuf/int"
 require_relative "org/apache/arrow/flatbuf/large_binary"
 require_relative "org/apache/arrow/flatbuf/large_list"
+require_relative "org/apache/arrow/flatbuf/large_utf8"
 require_relative "org/apache/arrow/flatbuf/list"
 require_relative "org/apache/arrow/flatbuf/map"
 require_relative "org/apache/arrow/flatbuf/message"
@@ -232,6 +234,8 @@ module ArrowFormat
         type = LargeBinaryType.singleton
       when Org::Apache::Arrow::Flatbuf::Utf8
         type = UTF8Type.singleton
+      when Org::Apache::Arrow::Flatbuf::LargeUtf8
+        type = LargeUTF8Type.singleton
       when Org::Apache::Arrow::Flatbuf::FixedSizeBinary
         type = FixedSizeBinaryType.new(fb_type.byte_width)
       end

--- a/ruby/red-arrow-format/lib/arrow-format/type.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/type.rb
@@ -353,6 +353,26 @@ module ArrowFormat
     end
   end
 
+  class LargeUTF8Type < VariableSizeBinaryType
+    class << self
+      def singleton
+        @singleton ||= new
+      end
+    end
+
+    def initialize
+      super("LargeUTF8")
+    end
+
+    def build_array(size, validity_buffer, offsets_buffer, values_buffer)
+      LargeUTF8Array.new(self,
+                         size,
+                         validity_buffer,
+                         offsets_buffer,
+                         values_buffer)
+    end
+  end
+
   class FixedSizeBinaryType < Type
     attr_reader :byte_width
     def initialize(byte_width)

--- a/ruby/red-arrow-format/test/test-file-reader.rb
+++ b/ruby/red-arrow-format/test/test-file-reader.rb
@@ -358,6 +358,17 @@ class TestFileReader < Test::Unit::TestCase
     end
   end
 
+  sub_test_case("LargeUTF8") do
+    def build_array
+      Arrow::LargeStringArray.new(["Hello", nil, "World"])
+    end
+
+    def test_read
+      assert_equal([{"value" => ["Hello", nil, "World"]}],
+                   read)
+    end
+  end
+
   sub_test_case("FixedSizeBinary") do
     def build_array
       data_type = Arrow::FixedSizeBinaryDataType.new(4)


### PR DESCRIPTION
### Rationale for this change

It's a large variant of UTF-8 array.

### What changes are included in this PR?

* Add `ArrowFormat::LargeUTF8Type`
* Add `ArrowFormat::LargeUTF8Array`

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #48551