### PR TITLE
GH-48557: [C++][Parquet][CI] Also encrypt nested columns in fuzz seed corpus

### DIFF
--- a/cpp/src/parquet/arrow/generate_fuzz_corpus.cc
+++ b/cpp/src/parquet/arrow/generate_fuzz_corpus.cc
@@ -168,11 +168,6 @@ std::vector<WriteConfig> GetEncryptedWriteConfigurations(const ::arrow::Schema& 
   {
     ColumnPathToEncryptionPropertiesMap column_map;
     for (const auto& field : schema.fields()) {
-      // Skip nested columns (they will not be encrypted) until GH-41246 makes
-      // their configuration easier.
-      if (field->type()->num_fields() > 0) {
-        continue;
-      }
       auto column_key = MakeEncryptionKey();
       column_map[field->name()] = ColumnEncryptionProperties::WithColumnKey(
           column_key.key, column_key.key_metadata);
@@ -184,11 +179,7 @@ std::vector<WriteConfig> GetEncryptedWriteConfigurations(const ::arrow::Schema& 
   // Unencrypted columns
   {
     ColumnPathToEncryptionPropertiesMap column_map;
-    // Only encrypt the first non-nested column, the rest will be written in plaintext
     for (const auto& field : schema.fields()) {
-      if (field->type()->num_fields() > 0) {
-        continue;
-      }
       column_map[field->name()] = ColumnEncryptionProperties::Unencrypted();
     }
     ARROW_DCHECK_NE(column_map.size(), 0);


### PR DESCRIPTION
### Rationale for this change

In https://github.com/apache/arrow/pull/48336 we skipped encrypted nested columns because it was too cumbersome to configure (each leaf column had to be configured independently).

Now that https://github.com/apache/arrow/pull/45462 has been merged we can configure nested columns the same way as non-nested ones.

### Are these changes tested?

Manually and later by OSS-Fuzz.

### Are there any user-facing changes?

No.
* GitHub Issue: #48557