### PR TITLE
MINOR: [C++] Fix typos in telemetry and compute comments

### DIFF
--- a/cpp/src/arrow/compute/exec.cc
+++ b/cpp/src/arrow/compute/exec.cc
@@ -410,7 +410,7 @@ bool ExecSpanIterator::Next(ExecSpan* span) {
     // The first time this is called, we populate the output span with any
     // Scalar or Array arguments in the ExecValue struct, and then just
     // increment array offsets below. If any arguments are ChunkedArray, then
-    // the internal ArraySpans will see their members updated during hte
+    // the internal ArraySpans will see their members updated during the
     // iteration
     span->values.resize(args_->size());
     for (size_t i = 0; i < args_->size(); ++i) {

--- a/cpp/src/arrow/telemetry/logging.h
+++ b/cpp/src/arrow/telemetry/logging.h
@@ -60,7 +60,7 @@ class ARROW_EXPORT OtelLogger : public util::Logger {
 class ARROW_EXPORT OtelLoggerProvider {
  public:
   /// \brief Attempt to flush the log record processor associated with the provider
-  /// \return `true` if the flush occured
+  /// \return `true` if the flush occurred
   static bool Flush(std::chrono::microseconds timeout = std::chrono::microseconds::max());
 
   static Result<std::shared_ptr<OtelLogger>> MakeLogger(


### PR DESCRIPTION
## Description

Fix two typos in C++ documentation comments:
- `cpp/src/arrow/telemetry/logging.h`: "occured" → "occurred"  
- `cpp/src/arrow/compute/exec.cc`: "hte" → "the"

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation / Minor (typo fix)

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly (N/A - comment only)
- [x] I have added tests to cover my changes (N/A - comment only)