### PR TITLE
GH-48566: [C++][CI] Fix compilation on Valgrind job

### DIFF
--- a/cpp/src/arrow/dataset/file_parquet_encryption_test.cc
+++ b/cpp/src/arrow/dataset/file_parquet_encryption_test.cc
@@ -38,6 +38,7 @@
 #include "arrow/util/thread_pool.h"
 #include "parquet/arrow/reader.h"
 #include "parquet/encryption/crypto_factory.h"
+#include "parquet/encryption/encryption_internal.h"  // for EnsureBackendInitialized
 #include "parquet/encryption/kms_client.h"
 #include "parquet/encryption/test_in_memory_kms.h"
 


### PR DESCRIPTION
### Rationale for this change

A `#include` required on Valgrind (due to conditional compilation) was removed in PR #45462.

### Are these changes tested?

Yes, by existing CI jobs.

### Are there any user-facing changes?

No.
* GitHub Issue: #48566