### PR TITLE
GH-48570: [C++] Add Missing Fuzz Sources to Meson configuration

### DIFF
--- a/cpp/src/arrow/meson.build
+++ b/cpp/src/arrow/meson.build
@@ -192,6 +192,7 @@ arrow_util_srcs = [
     'util/float16.cc',
     'util/formatting.cc',
     'util/future.cc',
+    'util/fuzz_internal.cc',
     'util/hashing.cc',
     'util/int_util.cc',
     'util/io_util.cc',

--- a/cpp/src/parquet/meson.build
+++ b/cpp/src/parquet/meson.build
@@ -17,6 +17,7 @@
 
 parquet_srcs = files(
     '../generated/parquet_types.cpp',
+    'arrow/fuzz_internal.cc',
     'arrow/path_internal.cc',
     'arrow/reader.cc',
     'arrow/reader_internal.cc',


### PR DESCRIPTION
### Rationale for this change

The meson configuration on main is broken - this fixes it

### What changes are included in this PR?

Missing fuzzing targets are added to the configuration

### Are these changes tested?

Yes

### Are there any user-facing changes?

No

* GitHub Issue: #48570