### PR TITLE
GH-22081: [Python] Support reading numpy arrays with ndims > 1 into pa arrays of Lists

### DIFF
--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -174,6 +174,12 @@ def array(object obj, type=None, mask=None, size=None, from_pandas=None,
 
     Notes
     -----
+    Multidimensional numpy arrays are supported and will be converted to
+    nested list arrays. For example, a 2D array of shape (2, 3) will be
+    converted to a list array of 2 lists, each containing 3 elements.
+    Note that mask and size parameters are not supported for multidimensional
+    arrays.
+
     Timezone will be preserved in the returned array for timezone-aware data,
     else no timezone will be returned for naive timestamps.
     Internally, UTC values are stored for timezone-aware data with the
@@ -229,6 +235,24 @@ def array(object obj, type=None, mask=None, size=None, from_pandas=None,
     >>> arr = pa.array(range(1024), type=pa.dictionary(pa.int8(), pa.int64()))
     >>> arr.type.index_type
     DataType(int16)
+
+    Multidimensional numpy arrays are supported:
+
+    >>> np_2d = np.arange(6).reshape(2, 3)
+    >>> pa.array(np_2d)
+    <pyarrow.lib.ListArray object at ...>
+    [
+      [
+        0,
+        1,
+        2
+      ],
+      [
+        3,
+        4,
+        5
+      ]
+    ]
     """
     cdef:
         CMemoryPool* pool = maybe_unbox_memory_pool(memory_pool)

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -334,7 +334,7 @@ def array(object obj, type=None, mask=None, size=None, from_pandas=None,
             if size is not None:
                 raise NotImplementedError(
                     "size is not supported for multidimensional arrays")
-            
+
             # For efficiency, use recursive FixedSizeListArray construction
             # for C-contiguous arrays (zero-copy), otherwise use .tolist()
             if values.flags['C_CONTIGUOUS']:
@@ -342,18 +342,18 @@ def array(object obj, type=None, mask=None, size=None, from_pandas=None,
                 # then wrap in nested FixedSizeListArray layers
                 shape = values.shape
                 flat = values.ravel()
-                
+
                 # Convert flattened 1D array to Arrow (zero-copy)
                 base_arr = _ndarray_to_array(flat, None, None, c_from_pandas,
-                                            safe, pool)
-                
+                                             safe, pool)
+
                 # Build nested FixedSizeListArray from innermost to outermost
                 # For shape (2, 3, 4), we create:
                 #   FixedSizeList[4] -> FixedSizeList[3] -> 2 elements
                 result = base_arr
                 for dim_size in reversed(shape[1:]):
                     result = FixedSizeListArray.from_arrays(result, int(dim_size))
-                
+
                 # Apply explicit type if provided
                 if type is not None:
                     result = result.cast(type, safe=safe, memory_pool=memory_pool)
@@ -362,7 +362,7 @@ def array(object obj, type=None, mask=None, size=None, from_pandas=None,
                 # This handles transposed, sliced, and F-contiguous arrays
                 result = _sequence_to_array(values.tolist(), None, None, type, pool,
                                             c_from_pandas)
-            
+
             if extension_type is not None:
                 result = ExtensionArray.from_storage(extension_type, result)
             return result

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -299,6 +299,21 @@ def array(object obj, type=None, mask=None, size=None, from_pandas=None,
                 mask = None if values.mask is np.ma.nomask else values.mask
                 values = values.data
 
+        # Handle multidimensional numpy arrays by converting to nested lists
+        if isinstance(values, np.ndarray) and values.ndim > 1:
+            if mask is not None:
+                raise NotImplementedError(
+                    "mask is not supported for multidimensional arrays")
+            if size is not None:
+                raise NotImplementedError(
+                    "size is not supported for multidimensional arrays")
+            # Convert to list and use sequence conversion path
+            result = _sequence_to_array(values.tolist(), None, None, type, pool, 
+                                       c_from_pandas)
+            if extension_type is not None:
+                result = ExtensionArray.from_storage(extension_type, result)
+            return result
+
         if mask is not None:
             if mask.dtype != np.bool_:
                 raise TypeError("Mask must be boolean dtype")

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -332,8 +332,8 @@ def array(object obj, type=None, mask=None, size=None, from_pandas=None,
                 raise NotImplementedError(
                     "size is not supported for multidimensional arrays")
             # Convert to list and use sequence conversion path
-            result = _sequence_to_array(values.tolist(), None, None, type, pool, 
-                                       c_from_pandas)
+            result = _sequence_to_array(values.tolist(), None, None, type, pool,
+                                        c_from_pandas)
             if extension_type is not None:
                 result = ExtensionArray.from_storage(extension_type, result)
             return result

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -2479,6 +2479,42 @@ def test_array_from_numpy_datetime(dtype, type):
 
 
 @pytest.mark.numpy
+def test_array_from_numpy_multidimensional():
+    # GH-XXXXX: support reading multidimensional numpy arrays
+    # Test 2D array
+    np_arr_2d = np.arange(6).reshape(2, 3)
+    pa_arr_2d = pa.array(np_arr_2d)
+    expected_2d = pa.array([[0, 1, 2], [3, 4, 5]])
+    assert pa_arr_2d.equals(expected_2d)
+    
+    # Test 3D array (example from the issue)
+    np_arr_3d = np.arange(24).reshape(2, 3, 4)
+    pa_arr_3d = pa.array(np_arr_3d)
+    expected_3d = pa.array(np_arr_3d.tolist())
+    assert pa_arr_3d.equals(expected_3d)
+    
+    # Test with different dtypes
+    np_arr_float = np.array([[1.5, 2.5], [3.5, 4.5]])
+    pa_arr_float = pa.array(np_arr_float)
+    expected_float = pa.array([[1.5, 2.5], [3.5, 4.5]])
+    assert pa_arr_float.equals(expected_float)
+    
+    # Test with explicit type
+    np_arr_typed = np.array([[1, 2], [3, 4]], dtype=np.int32)
+    pa_arr_typed = pa.array(np_arr_typed, type=pa.list_(pa.int32()))
+    expected_typed = pa.array([[1, 2], [3, 4]], type=pa.list_(pa.int32()))
+    assert pa_arr_typed.equals(expected_typed)
+    
+    # Test that mask is not supported for multidimensional arrays
+    with pytest.raises(NotImplementedError, match="mask is not supported"):
+        pa.array(np_arr_2d, mask=np.array([True, False]))
+    
+    # Test that size is not supported for multidimensional arrays
+    with pytest.raises(NotImplementedError, match="size is not supported"):
+        pa.array(np_arr_2d, size=2)
+
+
+@pytest.mark.numpy
 def test_array_from_different_numpy_datetime_units_raises():
     data = [
         None,

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -2484,7 +2484,7 @@ def test_array_from_numpy_multidimensional():
     # Test 2D array
     np_arr_2d = np.arange(6).reshape(2, 3)
     pa_arr_2d = pa.array(np_arr_2d)
-    expected_2d = pa.array([[0, 1, 2], [3, 4, 5]])
+    expected_2d = pa.array(np_arr_2d.tolist())
     assert pa_arr_2d.equals(expected_2d)
 
     # Test 3D array (example from the issue)
@@ -2496,13 +2496,13 @@ def test_array_from_numpy_multidimensional():
     # Test with different dtypes
     np_arr_float = np.array([[1.5, 2.5], [3.5, 4.5]])
     pa_arr_float = pa.array(np_arr_float)
-    expected_float = pa.array([[1.5, 2.5], [3.5, 4.5]])
+    expected_float = pa.array(np_arr_float.tolist())
     assert pa_arr_float.equals(expected_float)
 
     # Test with explicit type
     np_arr_typed = np.array([[1, 2], [3, 4]], dtype=np.int32)
     pa_arr_typed = pa.array(np_arr_typed, type=pa.list_(pa.int32()))
-    expected_typed = pa.array([[1, 2], [3, 4]], type=pa.list_(pa.int32()))
+    expected_typed = pa.array(np_arr_typed.tolist(), type=pa.list_(pa.int32()))
     assert pa_arr_typed.equals(expected_typed)
 
     # Test that mask is not supported for multidimensional arrays

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -2480,35 +2480,35 @@ def test_array_from_numpy_datetime(dtype, type):
 
 @pytest.mark.numpy
 def test_array_from_numpy_multidimensional():
-    # GH-XXXXX: support reading multidimensional numpy arrays
+    # Support reading multidimensional numpy arrays
     # Test 2D array
     np_arr_2d = np.arange(6).reshape(2, 3)
     pa_arr_2d = pa.array(np_arr_2d)
     expected_2d = pa.array([[0, 1, 2], [3, 4, 5]])
     assert pa_arr_2d.equals(expected_2d)
-    
+
     # Test 3D array (example from the issue)
     np_arr_3d = np.arange(24).reshape(2, 3, 4)
     pa_arr_3d = pa.array(np_arr_3d)
     expected_3d = pa.array(np_arr_3d.tolist())
     assert pa_arr_3d.equals(expected_3d)
-    
+
     # Test with different dtypes
     np_arr_float = np.array([[1.5, 2.5], [3.5, 4.5]])
     pa_arr_float = pa.array(np_arr_float)
     expected_float = pa.array([[1.5, 2.5], [3.5, 4.5]])
     assert pa_arr_float.equals(expected_float)
-    
+
     # Test with explicit type
     np_arr_typed = np.array([[1, 2], [3, 4]], dtype=np.int32)
     pa_arr_typed = pa.array(np_arr_typed, type=pa.list_(pa.int32()))
     expected_typed = pa.array([[1, 2], [3, 4]], type=pa.list_(pa.int32()))
     assert pa_arr_typed.equals(expected_typed)
-    
+
     # Test that mask is not supported for multidimensional arrays
     with pytest.raises(NotImplementedError, match="mask is not supported"):
         pa.array(np_arr_2d, mask=np.array([True, False]))
-    
+
     # Test that size is not supported for multidimensional arrays
     with pytest.raises(NotImplementedError, match="size is not supported"):
         pa.array(np_arr_2d, size=2)


### PR DESCRIPTION
### Rationale for this change

Fixes https://github.com/apache/arrow/issues/22081

Efficiently/correctly creating List arrays from numpy arrays with ndims > 1.

### What changes are included in this PR?

Before, `pa.array(np.arange(6).reshape(2,3))` would fail. Now it returns an array of length 2, where each element is a size-3 list.

I think this is the only intuitive behavior. But if you can think of an alternative behavior a user might want/expect from this, then please let's talk about it.

I am not super familiar with numpy/pyarrow memory layout internals to understand if there are other cases besides the C-continuous memory layout where we could use zero-copy. But even if there are other cases, I'm not sure if we need to bother with them, I bet the c-continuous covers 95% of usage.

I also am not sure if this is a good way to to do this, or if there is a more succinct way.

This was written entirely by GH copilot. You can see my dialog with copilot as I tweaked it's directions and chose an implementation in https://github.com/NickCrews/arrow/pull/3

Perhaps this logic should be pulled into its own `_from_n_dim_numpy(np_arr)` helper function to keep the larger control flow of the function more clear, let me know if you think so.

### Are these changes tested?

Yes, I think adequately. It doesn't actually verify that the zero-copy path is used, just that the results are correct. I didn't really want to deal with messing with monkeypatching/spying on things to detect the 0-copy, but can add this if we want to verify.

We also just compare the results to the result via the .tolist() path, but perhaps we should instead write out the actual expected value as boilerplate so that it is even more obvious what the expected behavior is.

### Are there any user-facing changes?

No breaking changes, only newly supported features!

* GitHub Issue: #22081