### PR TITLE
GH-48478: [Ruby] Fix Ruby list inference for nested non-negative integer arrays

### DIFF
--- a/ruby/red-arrow/lib/arrow/array-builder.rb
+++ b/ruby/red-arrow/lib/arrow/array-builder.rb
@@ -162,7 +162,7 @@ module Arrow
             field = Field.new("item", sub_value_data_type)
             {
               builder: ListArrayBuilder.new(ListDataType.new(field)),
-              detected: !!sub_builder_info[:detected],
+              detected: sub_builder_info[:detected],
             }
           else
             builder_info

--- a/ruby/red-arrow/lib/arrow/array-builder.rb
+++ b/ruby/red-arrow/lib/arrow/array-builder.rb
@@ -155,12 +155,14 @@ module Arrow
             sub_builder_info = detect_builder_info(sub_value, sub_builder_info)
             break if sub_builder_info and sub_builder_info[:detected]
           end
-          if sub_builder_info and sub_builder_info[:detected]
-            sub_value_data_type = sub_builder_info[:builder].value_data_type
+          if sub_builder_info
+            sub_builder = sub_builder_info[:builder]
+            return builder_info unless sub_builder
+            sub_value_data_type = sub_builder.value_data_type
             field = Field.new("item", sub_value_data_type)
             {
               builder: ListArrayBuilder.new(ListDataType.new(field)),
-              detected: true,
+              detected: !!sub_builder_info[:detected],
             }
           else
             builder_info

--- a/ruby/red-arrow/test/test-array-builder.rb
+++ b/ruby/red-arrow/test/test-array-builder.rb
@@ -148,13 +148,43 @@ class ArrayBuilderTest < Test::Unit::TestCase
       end
 
       test("list<uint>s") do
-        array = Arrow::ArrayBuilder.build([[0, 1, 2], [3, 4]])
-        assert_equal("list<item: uint8>", array.value_data_type.to_s)
+        values = [
+          [0, 1, 2],
+          [3, 4],
+        ]
+        array = Arrow::Array.new(values)
+        data_type = Arrow::ListDataType.new(Arrow::UInt8DataType.new)
+        assert_equal({
+                       data_type: data_type,
+                       values: [
+                         [0, 1, 2],
+                         [3, 4],
+                       ],
+                     },
+                     {
+                       data_type: array.value_data_type,
+                       values: array.to_a,
+                     })
       end
 
       test("list<int>s") do
-        array = Arrow::ArrayBuilder.build([[0, -1, 2], [3, 4]])
-        assert_equal("list<item: int8>", array.value_data_type.to_s)
+        values = [
+          [0, -1, 2],
+          [3, 4],
+        ]
+        array = Arrow::Array.new(values)
+        data_type = Arrow::ListDataType.new(Arrow::Int8DataType.new)
+        assert_equal({
+                       data_type: data_type,
+                       values: [
+                         [0, -1, 2],
+                         [3, 4],
+                       ],
+                     },
+                     {
+                       data_type: array.value_data_type,
+                       values: array.to_a,
+                     })
       end
     end
 

--- a/ruby/red-arrow/test/test-array-builder.rb
+++ b/ruby/red-arrow/test/test-array-builder.rb
@@ -146,6 +146,16 @@ class ArrayBuilderTest < Test::Unit::TestCase
                        ["Apache Arrow"],
                      ])
       end
+
+      test("list<uint>s") do
+        array = Arrow::ArrayBuilder.build([[0, 1, 2], [3, 4]])
+        assert_equal("list<item: uint8>", array.value_data_type.to_s)
+      end
+
+      test("list<int>s") do
+        array = Arrow::ArrayBuilder.build([[0, -1, 2], [3, 4]])
+        assert_equal("list<item: int8>", array.value_data_type.to_s)
+      end
     end
 
     sub_test_case("specific builder") do

--- a/ruby/red-arrow/test/test-table.rb
+++ b/ruby/red-arrow/test/test-table.rb
@@ -72,18 +72,6 @@ class TableTest < Test::Unit::TestCase
       assert_equal(Arrow::Table.new(schema, [Arrow::UInt8Array.new([1, 2, 3])]),
                    Arrow::Table.new(numbers: array_like))
     end
-
-    test("{Symbol: nested non-negative integer Array}") do
-      table = Arrow::Table.new(numbers: [[0, 1, 2], [3, 4]])
-      assert_equal("list<item: uint8>",
-                   table.schema["numbers"].data_type.to_s)
-    end
-
-    test("{Symbol: nested signed integer Array}") do
-      table = Arrow::Table.new(numbers: [[0, -1, 2], [3, 4]])
-      assert_equal("list<item: int8>",
-                   table.schema["numbers"].data_type.to_s)
-    end
   end
 
   test("#columns") do

--- a/ruby/red-arrow/test/test-table.rb
+++ b/ruby/red-arrow/test/test-table.rb
@@ -72,6 +72,18 @@ class TableTest < Test::Unit::TestCase
       assert_equal(Arrow::Table.new(schema, [Arrow::UInt8Array.new([1, 2, 3])]),
                    Arrow::Table.new(numbers: array_like))
     end
+
+    test("{Symbol: nested non-negative integer Array}") do
+      table = Arrow::Table.new(numbers: [[0, 1, 2], [3, 4]])
+      assert_equal("list<item: uint8>",
+                   table.schema["numbers"].data_type.to_s)
+    end
+
+    test("{Symbol: nested signed integer Array}") do
+      table = Arrow::Table.new(numbers: [[0, -1, 2], [3, 4]])
+      assert_equal("list<item: int8>",
+                   table.schema["numbers"].data_type.to_s)
+    end
   end
 
   test("#columns") do


### PR DESCRIPTION
### Rationale for this change 

When building an `Arrow::Table` from a Ruby Hash passed to `Arrow::Table.new`, nested `Integer` arrays are incorrectly inferred as `string` (utf8) if all values are non-negative. This behavior is unexpected; nested integer arrays should be consistently represented as a list type (e.g., `list<item: uint*>` or `list<item: int*>`) rather than falling back to UTF-8 strings. 

### What changes are included in this PR? 

This PR modifies the logic in `detect_builder_info()`, specifically the `when ::Array` block, to correctly identify nested non-negative integer arrays as list arrays. 

The change ensures that if `sub_builder_info` contains a valid `:builder`, it will be used even if `sub_builder_info` does not yet indicate that the type has been "detected."

### Are these changes tested?

Yes. (`ruby ruby/red-arrow/test/run-test.rb`)

### Are there any user-facing changes?

Yes.

GitHub Issue: Closes #48478 
* GitHub Issue: #48478