### PR TITLE
GH-48594: [C++][FlightRPC] Fix ODBC CI Long Build Time Issue

### DIFF
--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -343,6 +343,8 @@ jobs:
       contains(fromJSON(needs.check-labels.outputs.ci-extra-labels || '[]'), 'CI: Extra') ||
       contains(fromJSON(needs.check-labels.outputs.ci-extra-labels || '[]'), 'CI: Extra: C++')
     timeout-minutes: 240
+    permissions:
+      packages: write
     env:
       ARROW_BUILD_SHARED: ON
       ARROW_BUILD_STATIC: OFF
@@ -351,10 +353,10 @@ jobs:
       ARROW_DEPENDENCY_SOURCE: VCPKG
       ARROW_FLIGHT_SQL_ODBC: ON
       ARROW_FLIGHT_SQL_ODBC_INSTALLER: ON
-      ARROW_SIMD_LEVEL: AVX2
+      ARROW_HOME: /usr
       CMAKE_GENERATOR: Ninja
       CMAKE_INSTALL_PREFIX: /usr
-      VCPKG_BINARY_SOURCES: 'clear;nuget,GitHub,readwrite'
+      VCPKG_BINARY_SOURCES: 'clear;nugettimeout,600;nuget,GitHub,readwrite'
       VCPKG_DEFAULT_TRIPLET: x64-windows
     steps:
       - name: Disable Crash Dialogs
@@ -373,10 +375,6 @@ jobs:
       - name: Download Timezone Database
         shell: bash
         run: ci/scripts/download_tz_database.sh
-      - name: Install cmake
-        shell: bash
-        run: |
-          ci/scripts/install_cmake.sh 4.1.2 /usr
       - name: Install ccache
         shell: bash
         run: |

--- a/.github/workflows/dev_pr/labeler.yml
+++ b/.github/workflows/dev_pr/labeler.yml
@@ -73,3 +73,9 @@
   - any-glob-to-any-file:
     - docs/**/*
     - "**/*.{md, rst, Rmd, Rd}"
+
+"CI: Extra: C++":
+- changed-files:
+  - any-glob-to-any-file:
+    - .github/workflows/cpp_extra.yml
+    - cpp/src/arrow/flight/sql/odbc/**/*


### PR DESCRIPTION
### Rationale for this change
#48594 

### What changes are included in this PR?
- Resolve caching issue inside ODBC CI, so build time is generally less than 1hr
- Removed environment variables that are not necessary for ODBC building to keep workflow simple
- Changed ODBC workflow to be triggered when ODBC files are changed
- Add `CI: Extra: C++` label when ODBC files pr C++ Extra workflow is changed

### Are these changes tested?
- Tested in CI
### Are there any user-facing changes?
N/A
* GitHub Issue: #48594