### PR TITLE
GH-48119: [C++][ODBC] Move class definitions to type_fwd.h 

### DIFF
--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/CMakeLists.txt
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/CMakeLists.txt
@@ -107,6 +107,7 @@ add_library(arrow_odbc_spi_impl
             system_trust_store.cc
             system_trust_store.h
             types.h
+            type_fwd.h
             type_utilities.h
             util.cc
             util.h)

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/odbc_connection.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/odbc_connection.h
@@ -19,18 +19,13 @@
 
 #include <arrow/flight/sql/odbc/odbc_impl/spi/connection.h>
 #include "arrow/flight/sql/odbc/odbc_impl/odbc_handle.h"
+#include "arrow/flight/sql/odbc/odbc_impl/type_fwd.h"
 
 #include <sql.h>
 #include <map>
 #include <memory>
 #include <optional>
 #include <vector>
-
-namespace ODBC {
-class ODBCEnvironment;
-class ODBCDescriptor;
-class ODBCStatement;
-}  // namespace ODBC
 
 /**
  * @brief An abstraction over an ODBC connection handle. This also wraps an SPI

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/odbc_descriptor.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/odbc_descriptor.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "arrow/flight/sql/odbc/odbc_impl/odbc_handle.h"
+#include "arrow/flight/sql/odbc/odbc_impl/type_fwd.h"
 
 #include <sql.h>
 #include <sqlext.h>
@@ -26,13 +27,7 @@
 #include <string>
 #include <vector>
 
-namespace arrow::flight::sql::odbc {
-class ResultSetMetadata;
-}  // namespace arrow::flight::sql::odbc
-
 namespace ODBC {
-class ODBCConnection;
-class ODBCStatement;
 
 struct DescriptorRecord {
   std::string base_column_name;

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/odbc_environment.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/odbc_environment.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "arrow/flight/sql/odbc/odbc_impl/odbc_handle.h"
+#include "arrow/flight/sql/odbc/odbc_impl/type_fwd.h"
 
 #include <sql.h>
 #include <memory>
@@ -28,7 +29,6 @@ class Driver;
 }  // namespace arrow::flight::sql::odbc
 
 namespace ODBC {
-class ODBCConnection;
 
 /**
  * @brief An abstraction over an ODBC environment handle.

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/odbc_statement.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/odbc_statement.h
@@ -18,20 +18,14 @@
 #pragma once
 
 #include "arrow/flight/sql/odbc/odbc_impl/odbc_handle.h"
+#include "arrow/flight/sql/odbc/odbc_impl/type_fwd.h"
 
 #include <arrow/flight/sql/odbc/odbc_impl/platform.h>
 #include <sql.h>
 #include <memory>
 #include <string>
 
-namespace arrow::flight::sql::odbc {
-class Statement;
-class ResultSet;
-}  // namespace arrow::flight::sql::odbc
-
 namespace ODBC {
-class ODBCConnection;
-class ODBCDescriptor;
 
 /**
  * @brief An abstraction over an ODBC connection handle. This also wraps an SPI

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/spi/connection.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/spi/connection.h
@@ -27,6 +27,7 @@
 
 #include "arrow/flight/sql/odbc/odbc_impl/diagnostics.h"
 #include "arrow/flight/sql/odbc/odbc_impl/types.h"
+#include "arrow/flight/sql/odbc/odbc_impl/type_fwd.h"
 
 namespace arrow::flight::sql::odbc {
 
@@ -41,8 +42,6 @@ struct CaseInsensitiveComparator {
 
 // PropertyMap is case-insensitive for keys.
 typedef std::map<std::string, std::string, CaseInsensitiveComparator> PropertyMap;
-
-class Statement;
 
 /// \brief High-level representation of an ODBC connection.
 class Connection {

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/spi/connection.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/spi/connection.h
@@ -26,8 +26,8 @@
 #include <vector>
 
 #include "arrow/flight/sql/odbc/odbc_impl/diagnostics.h"
-#include "arrow/flight/sql/odbc/odbc_impl/types.h"
 #include "arrow/flight/sql/odbc/odbc_impl/type_fwd.h"
+#include "arrow/flight/sql/odbc/odbc_impl/types.h"
 
 namespace arrow::flight::sql::odbc {
 

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/spi/result_set.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/spi/result_set.h
@@ -23,12 +23,11 @@
 #include "arrow/flight/sql/odbc/odbc_impl/platform.h"
 
 #include "arrow/flight/sql/odbc/odbc_impl/types.h"
+#include "arrow/flight/sql/odbc/odbc_impl/type_fwd.h"
 
 #include <sqltypes.h>
 
 namespace arrow::flight::sql::odbc {
-
-class ResultSetMetadata;
 
 class ResultSet {
  protected:

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/spi/result_set.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/spi/result_set.h
@@ -22,8 +22,8 @@
 
 #include "arrow/flight/sql/odbc/odbc_impl/platform.h"
 
-#include "arrow/flight/sql/odbc/odbc_impl/types.h"
 #include "arrow/flight/sql/odbc/odbc_impl/type_fwd.h"
+#include "arrow/flight/sql/odbc/odbc_impl/types.h"
 
 #include <sqltypes.h>
 

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/spi/statement.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/spi/statement.h
@@ -22,11 +22,9 @@
 #include <optional>
 #include <vector>
 
+#include "arrow/flight/sql/odbc/odbc_impl/type_fwd.h"
+
 namespace arrow::flight::sql::odbc {
-
-class ResultSet;
-
-class ResultSetMetadata;
 
 /// \brief High-level representation of an ODBC statement.
 class Statement {

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/type_fwd.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/type_fwd.h
@@ -23,6 +23,7 @@ class ResultSet;
 class ResultSetMetadata;
 }
 
+// TODO: Replace ODBC namespace with namespace arrow::flight::sql::odbc #48083
 namespace ODBC {
 class ODBCEnvironment;
 class ODBCDescriptor;

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/type_fwd.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/type_fwd.h
@@ -1,0 +1,31 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+namespace arrow::flight::sql::odbc {
+class Statement;
+class ResultSet;
+class ResultSetMetadata;
+}
+
+namespace ODBC {
+class ODBCEnvironment;
+class ODBCDescriptor;
+class ODBCStatement;
+class ODBCConnection;
+}

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/type_fwd.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/type_fwd.h
@@ -21,12 +21,12 @@ namespace arrow::flight::sql::odbc {
 class Statement;
 class ResultSet;
 class ResultSetMetadata;
-}
+}  // namespace arrow::flight::sql::odbc
 
-// TODO: Replace ODBC namespace with namespace arrow::flight::sql::odbc #48083
+// GH-48083 TODO: Replace ODBC namespace with namespace arrow::flight::sql::odbc
 namespace ODBC {
 class ODBCEnvironment;
 class ODBCDescriptor;
 class ODBCStatement;
 class ODBCConnection;
-}
+}  // namespace ODBC


### PR DESCRIPTION
### Rationale for this change
This PR addresses the issue #48119 

### What changes are included in this PR?
Create type_fwd.h with forward declarations for ODBC classes to reduce compilation dependencies:
- Add new type_fwd.h with forward declarations for Statement, ResultSet, ResultSetMetadata, ODBCEnvironment, ODBCDescriptor, ODBCStatement, and ODBCConnection
- Replace full header includes with type_fwd.h
- Remove duplicate forward declarations from existing headers
- Update CMakeLists.txt to include new header

### Are these changes tested?
No

### Are there any user-facing changes?
No
* GitHub Issue: #48119