### PR TITLE
[WIP] GH-38792: [C++][Gandiva] Optimize cache

### DIFF
--- a/cpp/src/gandiva/annotator.h
+++ b/cpp/src/gandiva/annotator.h
@@ -60,6 +60,8 @@ class GANDIVA_EXPORT Annotator {
   EvalBatchPtr PrepareEvalBatch(const arrow::RecordBatch& record_batch,
                                 const ArrayDataVector& out_vector) const;
 
+  const Status CheckEvalBatchFieldType(const arrow::RecordBatch& record_batch) const;
+
   int buffer_count() const { return buffer_count_; }
 
  private:

--- a/cpp/src/gandiva/expr_validator.cc
+++ b/cpp/src/gandiva/expr_validator.cc
@@ -72,20 +72,6 @@ Status ExprValidator::Visit(const FieldNode& node) {
                   Status::ExpressionValidationError("Field ", node.field()->name(),
                                                     " has unsupported data type ",
                                                     node.return_type()->name()));
-
-  // Ensure that field is found in schema
-  auto field_in_schema_entry = field_map_.find(node.field()->name());
-  ARROW_RETURN_IF(field_in_schema_entry == field_map_.end(),
-                  Status::ExpressionValidationError("Field ", node.field()->name(),
-                                                    " not in schema."));
-
-  // Ensure that the found field matches.
-  FieldPtr field_in_schema = field_in_schema_entry->second;
-  ARROW_RETURN_IF(!field_in_schema->Equals(node.field()),
-                  Status::ExpressionValidationError(
-                      "Field definition in schema ", field_in_schema->ToString(),
-                      " different from field in expression ", node.field()->ToString()));
-
   return Status::OK();
 }
 

--- a/cpp/src/gandiva/expression.cc
+++ b/cpp/src/gandiva/expression.cc
@@ -22,4 +22,6 @@ namespace gandiva {
 
 std::string Expression::ToString() { return root()->ToString(); }
 
+std::string Expression::ToCacheKeyString() {return root()->ToCacheKeyString();}
+
 }  // namespace gandiva

--- a/cpp/src/gandiva/expression.cc
+++ b/cpp/src/gandiva/expression.cc
@@ -22,6 +22,6 @@ namespace gandiva {
 
 std::string Expression::ToString() { return root()->ToString(); }
 
-std::string Expression::ToCacheKeyString() {return root()->ToCacheKeyString();}
+std::string Expression::ToCacheKeyString() { return root()->ToCacheKeyString(); }
 
 }  // namespace gandiva

--- a/cpp/src/gandiva/expression.h
+++ b/cpp/src/gandiva/expression.h
@@ -38,6 +38,8 @@ class GANDIVA_EXPORT Expression {
 
   std::string ToString();
 
+  std::string ToCacheKeyString();
+
  private:
   const NodePtr root_;
   const FieldPtr result_;

--- a/cpp/src/gandiva/expression_cache_key.h
+++ b/cpp/src/gandiva/expression_cache_key.h
@@ -51,7 +51,7 @@ class ExpressionCacheKey {
 
   ExpressionCacheKey(SchemaPtr schema, std::shared_ptr<Configuration> configuration,
                      Expression& expression)
-      :mode_(SelectionVector::MODE_NONE), uniqifier_(0), configuration_(configuration) {
+      : mode_(SelectionVector::MODE_NONE), uniqifier_(0), configuration_(configuration) {
     static const int kSeedValue = 4;
     size_t result = kSeedValue;
     expressions_as_cache_key_strings_.push_back(expression.ToCacheKeyString());

--- a/cpp/src/gandiva/expression_cache_key.h
+++ b/cpp/src/gandiva/expression_cache_key.h
@@ -79,7 +79,6 @@ class ExpressionCacheKey {
       return false;
     }
 
-
     if (configuration_ != other.configuration_) {
       return false;
     }

--- a/cpp/src/gandiva/expression_cache_key.h
+++ b/cpp/src/gandiva/expression_cache_key.h
@@ -51,14 +51,12 @@ class ExpressionCacheKey {
 
   ExpressionCacheKey(SchemaPtr schema, std::shared_ptr<Configuration> configuration,
                      Expression& expression)
-      :mode_(SelectionVector::MODE_NONE),
-        uniqifier_(0),
-        configuration_(configuration) {
+      :mode_(SelectionVector::MODE_NONE), uniqifier_(0), configuration_(configuration) {
     static const int kSeedValue = 4;
     size_t result = kSeedValue;
     expressions_as_cache_key_strings_.push_back(expression.ToCacheKeyString());
     UpdateUniqifier(expression.ToCacheKeyString());
-    arrow::internal::hash_combine(result,expression.ToCacheKeyString());
+    arrow::internal::hash_combine(result, expression.ToCacheKeyString());
     arrow::internal::hash_combine(result, configuration->Hash());
     arrow::internal::hash_combine(result, uniqifier_);
     hash_code_ = result;

--- a/cpp/src/gandiva/filter.cc
+++ b/cpp/src/gandiva/filter.cc
@@ -91,8 +91,6 @@ Status Filter::Make(SchemaPtr schema, ConditionPtr condition,
 Status Filter::Evaluate(const arrow::RecordBatch& batch,
                         std::shared_ptr<SelectionVector> out_selection) {
   const auto num_rows = batch.num_rows();
-  ARROW_RETURN_IF(!batch.schema()->Equals(*schema_),
-                  Status::Invalid("RecordBatch schema must expected filter schema"));
   ARROW_RETURN_IF(num_rows == 0, Status::Invalid("RecordBatch must be non-empty."));
   ARROW_RETURN_IF(out_selection == nullptr,
                   Status::Invalid("out_selection must be non-null."));

--- a/cpp/src/gandiva/llvm_generator.cc
+++ b/cpp/src/gandiva/llvm_generator.cc
@@ -131,6 +131,10 @@ Status LLVMGenerator::Execute(const arrow::RecordBatch& record_batch,
                               const ArrayDataVector& output_vector) const {
   DCHECK_GT(record_batch.num_rows(), 0);
 
+  auto status = annotator_.CheckEvalBatchFieldType(record_batch);
+
+  ARROW_RETURN_IF(!status.ok(), status);
+
   auto eval_batch = annotator_.PrepareEvalBatch(record_batch, output_vector);
   DCHECK_GT(eval_batch->GetNumBuffers(), 0);
 

--- a/cpp/src/gandiva/projector.cc
+++ b/cpp/src/gandiva/projector.cc
@@ -230,8 +230,6 @@ Status Projector::AllocArrayData(const DataTypePtr& type, int64_t num_records,
 }
 
 Status Projector::ValidateEvaluateArgsCommon(const arrow::RecordBatch& batch) const {
-  ARROW_RETURN_IF(!batch.schema()->Equals(*schema_),
-                  Status::Invalid("Schema in RecordBatch must match schema in Make()"));
   ARROW_RETURN_IF(batch.num_rows() == 0,
                   Status::Invalid("RecordBatch must be non-empty."));
 

--- a/cpp/src/gandiva/tests/filter_test.cc
+++ b/cpp/src/gandiva/tests/filter_test.cc
@@ -42,16 +42,16 @@ class TestFilter : public ::testing::Test {
 
 TEST_F(TestFilter, TestFilterCache) {
   // schema for input fields
-  auto field0 = field("f0_filter_cache", int32());
-  auto field1 = field("f1_filter_cache", int32());
+  auto field0 = field("f0_filter_cache", int64());
+  auto field1 = field("f1_filter_cache", int64());
   auto schema = arrow::schema({field0, field1});
 
   // Build condition f0 + f1 < 10
   auto node_f0 = TreeExprBuilder::MakeField(field0);
   auto node_f1 = TreeExprBuilder::MakeField(field1);
   auto sum_func =
-      TreeExprBuilder::MakeFunction("add", {node_f0, node_f1}, arrow::int32());
-  auto literal_10 = TreeExprBuilder::MakeLiteral((int32_t)10);
+      TreeExprBuilder::MakeFunction("add", {node_f0, node_f1}, arrow::int64());
+  auto literal_10 = TreeExprBuilder::MakeLiteral((int64_t)10);
   auto less_than_10 = TreeExprBuilder::MakeFunction("less_than", {sum_func, literal_10},
                                                     arrow::boolean());
   auto condition = TreeExprBuilder::MakeCondition(less_than_10);
@@ -69,13 +69,13 @@ TEST_F(TestFilter, TestFilterCache) {
   EXPECT_TRUE(cached_filter->GetBuiltFromCache());
 
   // schema is different should return a new filter.
-  auto field2 = field("f2_filter_cache", int32());
+  auto field2 = field("f2_filter_cache", int64());
   auto different_schema = arrow::schema({field0, field1, field2});
   std::shared_ptr<Filter> should_be_new_filter;
   status =
       Filter::Make(different_schema, condition, configuration, &should_be_new_filter);
   EXPECT_TRUE(status.ok());
-  EXPECT_FALSE(should_be_new_filter->GetBuiltFromCache());
+  EXPECT_TRUE(should_be_new_filter->GetBuiltFromCache());
 
   // condition is different, should return a new filter.
   auto greater_than_10 = TreeExprBuilder::MakeFunction(
@@ -84,7 +84,7 @@ TEST_F(TestFilter, TestFilterCache) {
   std::shared_ptr<Filter> should_be_new_filter1;
   status = Filter::Make(schema, new_condition, configuration, &should_be_new_filter1);
   EXPECT_TRUE(status.ok());
-  EXPECT_FALSE(should_be_new_filter->GetBuiltFromCache());
+  EXPECT_FALSE(should_be_new_filter1->GetBuiltFromCache());
 }
 
 TEST_F(TestFilter, TestFilterCacheNullTreatment) {

--- a/cpp/src/gandiva/tests/projector_test.cc
+++ b/cpp/src/gandiva/tests/projector_test.cc
@@ -88,7 +88,7 @@ TEST_F(TestProjector, TestProjectCache) {
   status = Projector::Make(different_schema, {sum_expr, sub_expr}, configuration,
                            &should_be_new_projector);
   ASSERT_OK(status);
-  EXPECT_FALSE(should_be_new_projector->GetBuiltFromCache());
+  EXPECT_TRUE(should_be_new_projector->GetBuiltFromCache());
 
   // expression list is different should return a new projector.
   std::shared_ptr<Projector> should_be_new_projector1;
@@ -2350,10 +2350,19 @@ TEST_F(TestProjector, TestBigIntCastFunction) {
       MakeArrowArrayFloat32({6.6f, -6.6f, 9.999999f, 0}, {true, true, true, false});
   auto array1 =
       MakeArrowArrayFloat64({6.6, -6.6, 9.99999999999, 0}, {true, true, true, false});
-  auto array2 = MakeArrowArrayInt64({100, 25, -0, 0}, {true, true, true, false});
-  auto array3 = MakeArrowArrayInt32({25, -25, -0, 0}, {true, true, true, false});
-  auto in_batch =
-      arrow::RecordBatch::Make(schema, num_records, {array0, array1, array2, array3});
+
+  std::shared_ptr<arrow::Array> array_day_interval;
+  arrow::ArrayFromVector<arrow::DayTimeIntervalType,
+                         arrow::DayTimeIntervalType::DayMilliseconds>(
+      arrow::day_time_interval(), {true, true, true, false},
+      {{100, 0}, {25, 0}, {0, 0}, {0, 0}}, &array_day_interval);
+
+  std::shared_ptr<arrow::Array> array_month_interval;
+  arrow::ArrayFromVector<arrow::MonthIntervalType>(
+      arrow::month_interval(), {true, true, true, false}, {25, -25, -0, 0},
+      &array_month_interval);
+  auto in_batch = arrow::RecordBatch::Make(
+      schema, num_records, {array0, array1, array_day_interval, array_month_interval});
 
   auto out_float4 = MakeArrowArrayInt64({7, -7, 10, 0}, {true, true, true, false});
   auto out_float8 = MakeArrowArrayInt64({7, -7, 10, 0}, {true, true, true, false});
@@ -2407,8 +2416,14 @@ TEST_F(TestProjector, TestIntCastFunction) {
       MakeArrowArrayFloat32({6.6f, -6.6f, 9.999999f, 0}, {true, true, true, false});
   auto array1 =
       MakeArrowArrayFloat64({6.6, -6.6, 9.99999999999, 0}, {true, true, true, false});
-  auto array2 = MakeArrowArrayInt32({25, -25, -0, 0}, {true, true, true, false});
-  auto in_batch = arrow::RecordBatch::Make(schema, num_records, {array0, array1, array2});
+
+  std::shared_ptr<arrow::Array> array_month_interval;
+  arrow::ArrayFromVector<arrow::MonthIntervalType>(
+      arrow::month_interval(), {true, true, true, false}, {25, -25, -0, 0},
+      &array_month_interval);
+
+  auto in_batch = arrow::RecordBatch::Make(schema, num_records,
+                                           {array0, array1, array_month_interval});
 
   auto out_float4 = MakeArrowArrayInt32({7, -7, 10, 0}, {true, true, true, false});
   auto out_float8 = MakeArrowArrayInt32({7, -7, 10, 0}, {true, true, true, false});
@@ -2453,7 +2468,10 @@ TEST_F(TestProjector, TestCastNullableIntYearInterval) {
 
   // Last validity is false and the cast functions throw error when input is empty. Should
   // not be evaluated due to addition of NativeFunction::kCanReturnErrors
-  auto array0 = MakeArrowArrayInt32({12, -24, -0, 0}, {true, true, true, false});
+  std::shared_ptr<arrow::Array> array0;
+  arrow::ArrayFromVector<arrow::MonthIntervalType>(
+      arrow::month_interval(), {true, true, true, false}, {12, -24, -0, 0}, &array0);
+
   auto in_batch = arrow::RecordBatch::Make(schema, num_records, {array0});
 
   auto out_int32 = MakeArrowArrayInt32({1, -2, -0, 0}, {true, true, true, false});
@@ -3116,7 +3134,7 @@ TEST_F(TestProjector, TestCastBinaryBinary) {
   int num_records = 3;
 
   auto array0 =
-      MakeArrowArrayUtf8({"\\x41\\x42\\x43", "\\x41\\x42", ""}, {true, true, true});
+      MakeArrowArrayBinary({"\\x41\\x42\\x43", "\\x41\\x42", ""}, {true, true, true});
 
   auto in_batch = arrow::RecordBatch::Make(schema, num_records, {array0});
 
@@ -3577,7 +3595,6 @@ TEST_F(TestProjector, TestSqrtFloat64) {
 
   EXPECT_ARROW_ARRAY_EQUALS(out, outs.at(0));
 }
-
 TEST_F(TestProjector, TestExtendedFunctions) {
   auto in_field = field("in", arrow::int32());
   auto schema = arrow::schema({in_field});
@@ -3676,6 +3693,69 @@ TEST_F(TestProjector, TestExtendedCFunctionThatNeedsContext) {
   arrow::ArrayVector outs;
   ARROW_EXPECT_OK(projector->Evaluate(*in_batch, pool_, &outs));
   EXPECT_ARROW_ARRAY_EQUALS(out, outs.at(0));
+}
+TEST_F(TestProjector, TestCacheHitForDifferentSchema) {
+  auto field0 = field("f0", arrow::utf8());
+  auto field1 = field("f1", arrow::utf8());
+  auto field2 = field("f2", arrow::int32());
+  auto field3 = field("f3", arrow::int32());
+  auto field4 = field("f4", arrow::int32());
+  auto field5 = field("f5", arrow::int32());
+
+  auto schema_1 = arrow::schema({field0});
+
+  auto field0_lower = field("f0_lower", arrow::utf8());
+  auto field_add = field("field_add", arrow::int32());
+
+  auto lower_expr = TreeExprBuilder::MakeExpression("lower", {field0}, field0_lower);
+  auto add_expr = TreeExprBuilder::MakeExpression("add", {field2, field3}, field_add);
+  auto configuration = TestConfiguration();
+
+  std::shared_ptr<Projector> projector;
+  auto status =
+      Projector::Make(schema_1, {lower_expr, add_expr}, configuration, &projector);
+  ASSERT_OK(status);
+  EXPECT_FALSE(projector->GetBuiltFromCache());
+
+  auto lower_expr2 = TreeExprBuilder::MakeExpression("lower", {field1}, field0_lower);
+  auto add_expr2 = TreeExprBuilder::MakeExpression("add", {field4, field5}, field_add);
+
+  std::shared_ptr<Projector> projector_new;
+  status = Projector::Make(arrow::schema({field1}), {lower_expr2, add_expr2},
+                           configuration, &projector_new);
+  ASSERT_OK(status);
+  EXPECT_TRUE(projector_new->GetBuiltFromCache());
+
+  auto data_lower = MakeArrowArrayUtf8({"A", "B", "C", "D"}, {true, true, true, true});
+  auto array0 = MakeArrowArrayInt32({1, 2, 3, 4}, {true, true, true, true});
+  auto array1 = MakeArrowArrayInt32({1, 1, 1, 1}, {true, true, true, true});
+  int num_records = 4;
+  auto in_batch = arrow::RecordBatch::Make(arrow::schema({field1, field4, field5}),
+                                           num_records, {data_lower, array0, array1});
+
+  arrow::ArrayVector outputs_new;
+  status = projector_new->Evaluate(*in_batch, pool_, &outputs_new);
+  EXPECT_TRUE(status.ok());
+
+  auto data_lower_expect =
+      MakeArrowArrayUtf8({"a", "b", "c", "d"}, {true, true, true, true});
+  auto add_expect = MakeArrowArrayInt32({2, 3, 4, 5}, {true, true, true, true});
+
+  EXPECT_ARROW_ARRAY_EQUALS(data_lower_expect, outputs_new.at(0));
+  EXPECT_ARROW_ARRAY_EQUALS(add_expect, outputs_new.at(1));
+
+  // different type like add(int64,int64)
+
+  auto array0_int64 = MakeArrowArrayInt64({1, 2, 3, 4}, {true, true, true, true});
+  auto array1_int64 = MakeArrowArrayInt64({1, 1, 1, 1}, {true, true, true, true});
+  auto field4_int64 = arrow::field("f4", int64());
+  auto field5_int64 = arrow::field("f5", int64());
+
+  in_batch =
+      arrow::RecordBatch::Make(arrow::schema({field1, field4_int64, field5_int64}),
+                               num_records, {data_lower, array0_int64, array1_int64});
+  status = projector_new->Evaluate(*in_batch, pool_, &outputs_new);
+  EXPECT_FALSE(status.ok());
 }
 
 }  // namespace gandiva

--- a/cpp/src/gandiva/tests/utf8_test.cc
+++ b/cpp/src/gandiva/tests/utf8_test.cc
@@ -653,10 +653,10 @@ TEST_F(TestUtf8, TestConvertUtf8) {
 
   // Create a row-batch with some sample data
   int num_records = 3;
-  auto array_a = MakeArrowArrayUtf8({"ok-\xf8\x28"
-                                     "-a",
-                                     "all-valid", "ok-\xa0\xa1-valid"},
-                                    {true, true, true});
+  auto array_a = MakeArrowArrayBinary({"ok-\xf8\x28"
+                                       "-a",
+                                       "all-valid", "ok-\xa0\xa1-valid"},
+                                      {true, true, true});
 
   auto array_b =
       MakeArrowArrayUtf8({"ok-z(-a", "all-valid", "ok-zz-valid"}, {true, true, true});


### PR DESCRIPTION
This PR supersedes #38790 since that has been inactive for a few years.

The original author is @likun666661 

Rationale for this change
In Gandiva, it has been observed that the tool caches compiled expressions. However, when using the expression cache, Gandiva takes into account the schema, expr->ToString, and specific parameters. Nevertheless, in llvm_generator.cc, Gandiva still traverses the expressions to generate LLVM IR code and then produces specific JIT functions. Considering that llvm_generator traverses expressions and calculates the memory start positions of fields involved in the computation, we can further enhance Gandiva's caching mechanism.

Specifically, we can exclude the influence of the schema. Simultaneously, we can also exclude the field names' information involved in the expression computation. For example, for a schema {f0:int32, f1:int32} with an expression add(f0, f1), we can cache it initially. Then, for a schema {a0:int32, a1:int32, a2:int32} with an expression add(a1, a2), it should not require recompilation; it can directly reuse the JIT function generated by the expression {f0:int32, f1:int32}, add(f0, f1).

What changes are included in this PR?
This PR primarily alters the construction of the cache key and makes modifications to the schema validation in both the projector and filter. It also adjusts the validation of fields in expr_validator. Additionally, a ToCacheKeyString function has been added to each node. This PR mainly focuses on these areas.

Are these changes tested?
Yes,these changes are tested.

Are there any user-facing changes?
No.

* GitHub Issue: #38792