### PR TITLE
GH-28859: [Doc][Python] Use only code-block directive and set up doctest for the python user guide

### DIFF
--- a/.github/workflows/docs_light.yml
+++ b/.github/workflows/docs_light.yml
@@ -69,4 +69,5 @@ jobs:
         env:
           ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}
           ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
+          PYTEST_RST_ARGS: "--doctest-glob=*.rst"
         run: archery docker run conda-python-docs

--- a/.github/workflows/docs_light.yml
+++ b/.github/workflows/docs_light.yml
@@ -69,5 +69,4 @@ jobs:
         env:
           ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}
           ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
-          PYTEST_RST_ARGS: "--doctest-glob=*.rst"
         run: archery docker run conda-python-docs

--- a/.github/workflows/docs_light.yml
+++ b/.github/workflows/docs_light.yml
@@ -48,7 +48,6 @@ jobs:
     timeout-minutes: 60
     env:
       PYTHON: "3.12"
-      PYTEST_RST_ARGS: "--doctest-glob=*.rst"
     steps:
       - name: Checkout Arrow
         uses: actions/checkout@v6
@@ -70,4 +69,5 @@ jobs:
         env:
           ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}
           ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
+          PYTEST_RST_ARGS: "--doctest-glob=*.rst"
         run: archery docker run conda-python-docs

--- a/.github/workflows/docs_light.yml
+++ b/.github/workflows/docs_light.yml
@@ -48,6 +48,7 @@ jobs:
     timeout-minutes: 60
     env:
       PYTHON: "3.12"
+      PYTEST_RST_ARGS: "--doctest-glob=*.rst"
     steps:
       - name: Checkout Arrow
         uses: actions/checkout@v6
@@ -69,5 +70,4 @@ jobs:
         env:
           ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}
           ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
-          PYTEST_RST_ARGS: "--doctest-glob=*.rst"
         run: archery docker run conda-python-docs

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -69,10 +69,10 @@ jobs:
           - conda-python-3.12-no-numpy
         include:
           - name: conda-python-docs
-            cache: conda-python-3.10
+            cache: conda-python-3.12
             image: conda-python-docs
-            title: AMD64 Conda Python 3.10 Sphinx & Numpydoc
-            python: "3.10"
+            title: AMD64 Conda Python 3.12 Sphinx & Numpydoc
+            python: "3.12"
           - name: conda-python-3.11-nopandas
             cache: conda-python-3.11
             image: conda-python

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -69,10 +69,10 @@ jobs:
           - conda-python-3.12-no-numpy
         include:
           - name: conda-python-docs
-            cache: conda-python-3.12
+            cache: conda-python-3.10
             image: conda-python-docs
-            title: AMD64 Conda Python 3.12 Sphinx & Numpydoc
-            python: "3.12"
+            title: AMD64 Conda Python 3.10 Sphinx & Numpydoc
+            python: "3.10"
           - name: conda-python-3.11-nopandas
             cache: conda-python-3.11
             image: conda-python

--- a/ci/scripts/python_test.sh
+++ b/ci/scripts/python_test.sh
@@ -70,4 +70,4 @@ export PYARROW_TEST_S3
 
 # Testing PyArrow
 pytest -r s ${PYTEST_ARGS} --pyargs pyarrow
-pytest ${PYTEST_RST_ARGS}
+pytest ${PYTEST_RST_ARGS} ${arrow_dir}/docs/source/python

--- a/ci/scripts/python_test.sh
+++ b/ci/scripts/python_test.sh
@@ -70,4 +70,8 @@ export PYARROW_TEST_S3
 
 # Testing PyArrow
 pytest -r s ${PYTEST_ARGS} --pyargs pyarrow
-pytest ${PYTEST_RST_ARGS} ${arrow_dir}/docs/source/python
+
+# Testing RST documentation examples (if PYTEST_RST_ARGS is set)
+if [ -n "${PYTEST_RST_ARGS}" ]; then
+  pytest ${PYTEST_RST_ARGS} ${arrow_dir}/docs/source/python
+fi

--- a/ci/scripts/python_test.sh
+++ b/ci/scripts/python_test.sh
@@ -70,4 +70,4 @@ export PYARROW_TEST_S3
 
 # Testing PyArrow
 pytest -r s ${PYTEST_ARGS} --pyargs pyarrow
-pytest -r ${PYTEST_RST_ARGS}
+pytest ${PYTEST_RST_ARGS}

--- a/ci/scripts/python_test.sh
+++ b/ci/scripts/python_test.sh
@@ -70,3 +70,4 @@ export PYARROW_TEST_S3
 
 # Testing PyArrow
 pytest -r s ${PYTEST_ARGS} --pyargs pyarrow
+pytest -r ${PYTEST_RST_ARGS}

--- a/compose.yaml
+++ b/compose.yaml
@@ -1530,7 +1530,7 @@ services:
       BUILD_DOCS_CPP: "ON"
       BUILD_DOCS_PYTHON: "ON"
       PYTEST_ARGS: "--doctest-modules --doctest-cython"
-      PYTEST_RST_ARGS: "--doctest-glob='*.rst' docs/source/python"
+      PYTEST_RST_ARGS: "--doctest-glob='*.rst'"
     volumes: *conda-volumes
     command:
       ["/arrow/ci/scripts/cpp_build.sh /arrow /build &&

--- a/compose.yaml
+++ b/compose.yaml
@@ -1530,7 +1530,7 @@ services:
       BUILD_DOCS_CPP: "ON"
       BUILD_DOCS_PYTHON: "ON"
       PYTEST_ARGS: "--doctest-modules --doctest-cython"
-      PYTEST_RST_ARGS: "--doctest-glob='*.rst'"
+      PYTEST_RST_ARGS: "--doctest-glob=*.rst"
     volumes: *conda-volumes
     command:
       ["/arrow/ci/scripts/cpp_build.sh /arrow /build &&

--- a/compose.yaml
+++ b/compose.yaml
@@ -1530,6 +1530,7 @@ services:
       BUILD_DOCS_CPP: "ON"
       BUILD_DOCS_PYTHON: "ON"
       PYTEST_ARGS: "--doctest-modules --doctest-cython"
+      PYTEST_RST_ARGS: "--doctest-glob=*.rst"
     volumes: *conda-volumes
     command:
       ["/arrow/ci/scripts/cpp_build.sh /arrow /build &&

--- a/compose.yaml
+++ b/compose.yaml
@@ -1529,7 +1529,7 @@ services:
       LANG: "C.UTF-8"
       BUILD_DOCS_CPP: "ON"
       BUILD_DOCS_PYTHON: "ON"
-      PYTEST_ARGS: "--doctest-modules --doctest-cython"
+      PYTEST_ARGS: "--doctest-modules --doctest-cython --doctest-glob='*.rst' docs/source/python/*.rst"
     volumes: *conda-volumes
     command:
       ["/arrow/ci/scripts/cpp_build.sh /arrow /build &&

--- a/compose.yaml
+++ b/compose.yaml
@@ -1529,7 +1529,8 @@ services:
       LANG: "C.UTF-8"
       BUILD_DOCS_CPP: "ON"
       BUILD_DOCS_PYTHON: "ON"
-      PYTEST_ARGS: "--doctest-modules --doctest-cython --doctest-glob='*.rst' docs/source/python/*.rst"
+      PYTEST_ARGS: "--doctest-modules --doctest-cython"
+      PYTEST_RST_ARGS: "--doctest-glob='*.rst' docs/source/python"
     volumes: *conda-volumes
     command:
       ["/arrow/ci/scripts/cpp_build.sh /arrow /build &&

--- a/compose.yaml
+++ b/compose.yaml
@@ -1530,7 +1530,6 @@ services:
       BUILD_DOCS_CPP: "ON"
       BUILD_DOCS_PYTHON: "ON"
       PYTEST_ARGS: "--doctest-modules --doctest-cython"
-      PYTEST_RST_ARGS: "--doctest-glob=*.rst"
     volumes: *conda-volumes
     command:
       ["/arrow/ci/scripts/cpp_build.sh /arrow /build &&

--- a/docs/source/developers/python/development.rst
+++ b/docs/source/developers/python/development.rst
@@ -127,6 +127,24 @@ for ``.py`` files or
 for ``.pyx`` and ``.pxi`` files. In this case you will also need to
 install the `pytest-cython <https://github.com/lgpage/pytest-cython>`_ plugin.
 
+Testing Documentation Examples
+-------------------------------
+
+Documentation examples in ``.rst`` files under ``docs/source/python/`` use
+doctest syntax and can be tested locally using:
+
+.. code-block::
+
+   $ pushd arrow/python
+   $ pytest --doctest-glob="*.rst" docs/source/python/file.rst # checking single file
+   $ pytest --doctest-glob="*.rst" docs/source/python # checking entire directory
+   $ popd
+
+The examples use standard doctest syntax with ``>>>`` for Python prompts and
+``...`` for continuation lines. The ``conftest.py`` fixture automatically
+handles temporary directory setup for examples that create files.
+
+
 Debugging
 =========
 

--- a/docs/source/python/compute.rst
+++ b/docs/source/python/compute.rst
@@ -424,15 +424,18 @@ output type need to be defined. Using :func:`pyarrow.compute.register_scalar_fun
    ...    "y" : pa.int64()
    ... }
    >>> output_type = pa.int64()
+   >>>
    >>> def to_np(val):
    ...     if isinstance(val, pa.Scalar):
    ...        return val.as_py()
    ...     else:
    ...        return np.array(val)
+   >>>
    >>> def gcd_numpy(ctx, x, y):
    ...     np_x = to_np(x)
    ...     np_y = to_np(y)
    ...     return pa.array(np.gcd(np_x, np_y))
+   >>>
    >>> pc.register_scalar_function(gcd_numpy,
    ...                            function_name,
    ...                            function_docs,

--- a/docs/source/python/compute.rst
+++ b/docs/source/python/compute.rst
@@ -26,7 +26,9 @@ Arrow supports logical compute operations over inputs of possibly
 varying types.
 
 The standard compute operations are provided by the :mod:`pyarrow.compute`
-module and can be used directly::
+module and can be used directly:
+
+.. code-block:: python
 
    >>> import pyarrow as pa
    >>> import pyarrow.compute as pc
@@ -45,14 +47,14 @@ Many compute functions support both array (chunked or not)
 and scalar inputs, but some will mandate either.  For example,
 ``sort_indices`` requires its first and only input to be an array.
 
-Below are a few simple examples::
+Below are a few simple examples:
 
-   >>> import pyarrow as pa
-   >>> import pyarrow.compute as pc
+.. code-block:: python
+
    >>> a = pa.array([1, 1, 2, 3])
    >>> b = pa.array([4, 1, 2, 8])
    >>> pc.equal(a, b)
-   <pyarrow.lib.BooleanArray object at 0x7f686e4eef30>
+   <pyarrow.lib.BooleanArray object at ...>
    [
      false,
      true,
@@ -65,10 +67,10 @@ Below are a few simple examples::
 
 If you are using a compute function which returns more than one value, results
 will be returned as a ``StructScalar``.  You can extract the individual values by
-calling the :meth:`pyarrow.StructScalar.values` method::
+calling the :meth:`pyarrow.StructScalar.values` method:
 
-   >>> import pyarrow as pa
-   >>> import pyarrow.compute as pc
+.. code-block:: python
+
    >>> a = pa.array([1, 1, 2, 3])
    >>> pc.min_max(a)
    <pyarrow.StructScalar: [('min', 1), ('max', 3)]>
@@ -79,14 +81,14 @@ calling the :meth:`pyarrow.StructScalar.values` method::
    <pyarrow.Int64Scalar: 3>
 
 These functions can do more than just element-by-element operations.
-Here is an example of sorting a table::
+Here is an example of sorting a table:
 
-    >>> import pyarrow as pa
-    >>> import pyarrow.compute as pc
+.. code-block:: python
+
     >>> t = pa.table({'x':[1,2,3],'y':[3,2,1]})
     >>> i = pc.sort_indices(t, sort_keys=[('y', 'ascending')])
     >>> i
-    <pyarrow.lib.UInt64Array object at 0x7fcee5df75e8>
+    <pyarrow.lib.UInt64Array object at ...>
     [
       2,
       1,
@@ -108,28 +110,30 @@ Grouped Aggregations
 PyArrow supports grouped aggregations over :class:`pyarrow.Table` through the
 :meth:`pyarrow.Table.group_by` method.
 The method will return a grouping declaration
-to which the hash aggregation functions can be applied::
+to which the hash aggregation functions can be applied:
 
-   >>> import pyarrow as pa
+.. code-block:: python
+
    >>> t = pa.table([
    ...       pa.array(["a", "a", "b", "b", "c"]),
    ...       pa.array([1, 2, 3, 4, 5]),
    ... ], names=["keys", "values"])
    >>> t.group_by("keys").aggregate([("values", "sum")])
    pyarrow.Table
-   values_sum: int64
    keys: string
+   values_sum: int64
    ----
-   values_sum: [[3,7,5]]
    keys: [["a","b","c"]]
+   values_sum: [[3,7,5]]
 
 The ``"sum"`` aggregation passed to the ``aggregate`` method in the previous
 example is the ``hash_sum`` compute function.
 
 Multiple aggregations can be performed at the same time by providing them
-to the ``aggregate`` method::
+to the ``aggregate`` method:
 
-   >>> import pyarrow as pa
+.. code-block:: python
+
    >>> t = pa.table([
    ...       pa.array(["a", "a", "b", "b", "c"]),
    ...       pa.array([1, 2, 3, 4, 5]),
@@ -139,20 +143,20 @@ to the ``aggregate`` method::
    ...    ("keys", "count")
    ... ])
    pyarrow.Table
+   keys: string
    values_sum: int64
    keys_count: int64
-   keys: string
    ----
+   keys: [["a","b","c"]]
    values_sum: [[3,7,5]]
    keys_count: [[2,2,1]]
-   keys: [["a","b","c"]]
 
 Aggregation options can also be provided for each aggregation function,
 for example we can use :class:`CountOptions` to change how we count
-null values::
+null values:
 
-   >>> import pyarrow as pa
-   >>> import pyarrow.compute as pc
+.. code-block:: python
+
    >>> table_with_nulls = pa.table([
    ...    pa.array(["a", "a", "a"]),
    ...    pa.array([1, None, None])
@@ -161,20 +165,20 @@ null values::
    ...    ("values", "count", pc.CountOptions(mode="all"))
    ... ])
    pyarrow.Table
-   values_count: int64
    keys: string
+   values_count: int64
    ----
-   values_count: [[3]]
    keys: [["a"]]
+   values_count: [[3]]
    >>> table_with_nulls.group_by(["keys"]).aggregate([
    ...    ("values", "count", pc.CountOptions(mode="only_valid"))
    ... ])
    pyarrow.Table
-   values_count: int64
    keys: string
+   values_count: int64
    ----
-   values_count: [[1]]
    keys: [["a"]]
+   values_count: [[1]]
 
 Following is a list of all supported grouped aggregation functions.
 You can use them with or without the ``"hash_"`` prefix.
@@ -212,20 +216,19 @@ on which the join should be performed:
 
 .. code-block:: python
 
-   import pyarrow as pa
-
-   table1 = pa.table({'id': [1, 2, 3],
-                      'year': [2020, 2022, 2019]})
-
-   table2 = pa.table({'id': [3, 4],
-                      'n_legs': [5, 100],
-                      'animal': ["Brittle stars", "Centipede"]})
-
-   joined_table = table1.join(table2, keys="id")
+   >>> table1 = pa.table({'id': [1, 2, 3],
+   ...                    'year': [2020, 2022, 2019]})
+   >>> table2 = pa.table({'id': [3, 4],
+   ...                    'n_legs': [5, 100],
+   ...                    'animal': ["Brittle stars", "Centipede"]})
+   >>> joined_table = table1.join(table2, keys="id")
 
 The result will be a new table created by joining ``table1`` with
-``table2`` on the ``id`` key with a ``left outer join``::
+``table2`` on the ``id`` key with a ``left outer join``:
 
+.. code-block:: python
+
+   >>> joined_table
    pyarrow.Table
    id: int64
    year: int64
@@ -242,70 +245,57 @@ passing them to the ``join_type`` argument:
 
 .. code-block:: python
 
-   table1.join(table2, keys='id', join_type="full outer")
-
-In that case the result would be::
-
+   >>> table1.join(table2, keys='id', join_type="full outer")
    pyarrow.Table
    id: int64
    year: int64
    n_legs: int64
    animal: string
    ----
-   id: [[3,1,2,4]]
-   year: [[2019,2020,2022,null]]
-   n_legs: [[5,null,null,100]]
-   animal: [["Brittle stars",null,null,"Centipede"]]
+   id: [[3,1,2],[4]]
+   year: [[2019,2020,2022],[null]]
+   n_legs: [[5,null,null],[100]]
+   animal: [["Brittle stars",null,null],["Centipede"]]
 
 It's also possible to provide additional join keys, so that the
 join happens on two keys instead of one. For example we can add
 an ``year`` column to ``table2`` so that we can join on ``('id', 'year')``:
 
-.. code-block::
+.. code-block:: python
 
-   table2_withyear = table2.append_column("year", pa.array([2019, 2022]))
-   table1.join(table2_withyear, keys=["id", "year"])
-
-The result will be a table where only entries with ``id=3`` and ``year=2019``
-have data, the rest will be ``null``::
-
+   >>> table2_withyear = table2.append_column("year", pa.array([2019, 2022]))
+   >>> table1.join(table2_withyear, keys=["id", "year"])
    pyarrow.Table
    id: int64
    year: int64
-   animal: string
    n_legs: int64
+   animal: string
    ----
    id: [[3,1,2]]
    year: [[2019,2020,2022]]
-   animal: [["Brittle stars",null,null]]
    n_legs: [[5,null,null]]
+   animal: [["Brittle stars",null,null]]
 
 The same capabilities are available for :meth:`.Dataset.join` too, so you can
 take two datasets and join them:
 
-.. code-block::
+.. code-block:: python
 
-   import pyarrow.dataset as ds
-
-   ds1 = ds.dataset(table1)
-   ds2 = ds.dataset(table2)
-
-   joined_ds = ds1.join(ds2, keys="id")
-
-The resulting dataset will be an :class:`.InMemoryDataset` containing the joined data::
-
+   >>> import pyarrow.dataset as ds
+   >>> ds1 = ds.dataset(table1)
+   >>> ds2 = ds.dataset(table2)
+   >>> joined_ds = ds1.join(ds2, keys="id")
    >>> joined_ds.head(5)
-
    pyarrow.Table
    id: int64
    year: int64
-   animal: string
    n_legs: int64
+   animal: string
    ----
    id: [[3,1,2]]
    year: [[2019,2020,2022]]
-   animal: [["Brittle stars",null,null]]
    n_legs: [[5,null,null]]
+   animal: [["Brittle stars",null,null]]
 
 .. _py-filter-expr:
 
@@ -328,8 +318,7 @@ in column ``"nums"``
 
 .. code-block:: python
 
-   import pyarrow.compute as pc
-   even_filter = (pc.bit_wise_and(pc.field("nums"), pc.scalar(1)) == pc.scalar(0))
+   >>> even_filter = (pc.bit_wise_and(pc.field("nums"), pc.scalar(1)) == pc.scalar(0))
 
 .. note::
 
@@ -387,6 +376,8 @@ our ``even_filter`` with a ``pc.field("nums") > 5`` filter:
 The method will return an instance of :class:`.Dataset` which will lazily
 apply the filter as soon as actual data of the dataset is accessed:
 
+.. code-block:: python
+
    >>> dataset = ds.dataset(table)
    >>> filtered = dataset.filter(pc.field("nums") < 5).filter(pc.field("nums") > 2)
    >>> filtered.to_table()
@@ -420,42 +411,33 @@ output type need to be defined. Using :func:`pyarrow.compute.register_scalar_fun
 
 .. code-block:: python
 
-   import numpy as np
-
-   import pyarrow as pa
-   import pyarrow.compute as pc
-
-   function_name = "numpy_gcd"
-   function_docs = {
-         "summary": "Calculates the greatest common divisor",
-         "description":
-            "Given 'x' and 'y' find the greatest number that divides\n"
-            "evenly into both x and y."
-   }
-
-   input_types = {
-      "x" : pa.int64(),
-      "y" : pa.int64()
-   }
-
-   output_type = pa.int64()
-
-   def to_np(val):
-       if isinstance(val, pa.Scalar):
-          return val.as_py()
-       else:
-          return np.array(val)
-
-   def gcd_numpy(ctx, x, y):
-       np_x = to_np(x)
-       np_y = to_np(y)
-       return pa.array(np.gcd(np_x, np_y))
-
-   pc.register_scalar_function(gcd_numpy,
-                              function_name,
-                              function_docs,
-                              input_types,
-                              output_type)
+   >>> import numpy as np
+   >>> function_name = "numpy_gcd"
+   >>> function_docs = {
+   ...       "summary": "Calculates the greatest common divisor",
+   ...       "description":
+   ...          "Given 'x' and 'y' find the greatest number that divides\n"
+   ...          "evenly into both x and y."
+   ... }
+   >>> input_types = {
+   ...    "x" : pa.int64(),
+   ...    "y" : pa.int64()
+   ... }
+   >>> output_type = pa.int64()
+   >>> def to_np(val):
+   ...     if isinstance(val, pa.Scalar):
+   ...        return val.as_py()
+   ...     else:
+   ...        return np.array(val)
+   >>> def gcd_numpy(ctx, x, y):
+   ...     np_x = to_np(x)
+   ...     np_y = to_np(y)
+   ...     return pa.array(np.gcd(np_x, np_y))
+   >>> pc.register_scalar_function(gcd_numpy,
+   ...                            function_name,
+   ...                            function_docs,
+   ...                            input_types,
+   ...                            output_type)
 
 
 The implementation of a user-defined function always takes a first *context*
@@ -472,7 +454,7 @@ You can call a user-defined function directly using :func:`pyarrow.compute.call_
    >>> pc.call_function("numpy_gcd", [pa.scalar(27), pa.scalar(63)])
    <pyarrow.Int64Scalar: 9>
    >>> pc.call_function("numpy_gcd", [pa.scalar(27), pa.array([81, 12, 5])])
-   <pyarrow.lib.Int64Array object at 0x7fcfa0e7b100>
+   <pyarrow.lib.Int64Array object at ...>
    [
      27,
      3,
@@ -492,7 +474,6 @@ the GCD of one column with the scalar value 30.  We will be re-using the
 
 .. code-block:: python
 
-   >>> import pyarrow.dataset as ds
    >>> data_table = pa.table({'category': ['A', 'B', 'C', 'D'], 'value': [90, 630, 1827, 2709]})
    >>> dataset = ds.dataset(data_table)
    >>> func_args = [pc.scalar(30), ds.field("value")]

--- a/docs/source/python/compute.rst
+++ b/docs/source/python/compute.rst
@@ -245,17 +245,17 @@ passing them to the ``join_type`` argument:
 
 .. code-block:: python
 
-   >>> table1.join(table2, keys='id', join_type="full outer")
+   >>> table1.join(table2, keys='id', join_type="full outer").combine_chunks().sort_by('id')
    pyarrow.Table
    id: int64
    year: int64
    n_legs: int64
    animal: string
    ----
-   id: [[3,1,2],[4]]
-   year: [[2019,2020,2022],[null]]
-   n_legs: [[5,null,null],[100]]
-   animal: [["Brittle stars",null,null],["Centipede"]]
+   id: [[1,2,3,4]]
+   year: [[2020,2022,2019,null]]
+   n_legs: [[null,null,5,100]]
+   animal: [[null,null,"Brittle stars","Centipede"]]
 
 It's also possible to provide additional join keys, so that the
 join happens on two keys instead of one. For example we can add

--- a/docs/source/python/conftest.py
+++ b/docs/source/python/conftest.py
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import pytest
+
+
+# Save output files from doctest examples into temp dir
+@pytest.fixture(autouse=True)
+def _docdir(request):
+    # Trigger ONLY for the doctests
+    is_doctest = request.node.__class__.__name__ == 'DoctestItem'
+
+    if is_doctest:
+        # Get the fixture dynamically by its name.
+        tmpdir = request.getfixturevalue('tmpdir')
+
+        # Chdir only for the duration of the test.
+        with tmpdir.as_cwd():
+            yield
+    else:
+        yield

--- a/docs/source/python/conftest.py
+++ b/docs/source/python/conftest.py
@@ -22,7 +22,8 @@ import pytest
 @pytest.fixture(autouse=True)
 def _docdir(request):
     # Trigger ONLY for the doctests
-    is_doctest = request.node.__class__.__name__ == 'DoctestItem'
+    from _pytest.doctest import DoctestItem
+    is_doctest = isinstance(request.node, DoctestItem)
 
     if is_doctest:
         # Get the fixture dynamically by its name.

--- a/docs/source/python/csv.rst
+++ b/docs/source/python/csv.rst
@@ -41,12 +41,16 @@ Usage
 
 CSV reading and writing functionality is available through the
 :mod:`pyarrow.csv` module.  In many cases, you will simply call the
-:func:`read_csv` function with the file path you want to read from::
+:func:`read_csv` function with the file path you want to read from:
+
+.. code-block:: python
 
    >>> from pyarrow import csv
-   >>> fn = 'tips.csv.gz'
-   >>> table = csv.read_csv(fn)
-   >>> table
+   >>> import pyarrow as pa
+   >>> import pandas as pd
+   >>> fn = 'tips.csv.gz'  # doctest: +SKIP
+   >>> table = csv.read_csv(fn)  # doctest: +SKIP
+   >>> table  # doctest: +SKIP
    pyarrow.Table
    total_bill: double
    tip: double
@@ -55,10 +59,10 @@ CSV reading and writing functionality is available through the
    day: string
    time: string
    size: int64
-   >>> len(table)
+   >>> len(table)  # doctest: +SKIP
    244
-   >>> df = table.to_pandas()
-   >>> df.head()
+   >>> df = table.to_pandas()  # doctest: +SKIP
+   >>> df.head()  # doctest: +SKIP
       total_bill   tip     sex smoker  day    time  size
    0       16.99  1.01  Female     No  Sun  Dinner     2
    1       10.34  1.66    Male     No  Sun  Dinner     3
@@ -68,10 +72,11 @@ CSV reading and writing functionality is available through the
 
 To write CSV files, just call :func:`write_csv` with a
 :class:`pyarrow.RecordBatch` or :class:`pyarrow.Table` and a path or
-file-like object::
+file-like object:
 
-  >>> import pyarrow as pa
-  >>> import pyarrow.csv as csv
+.. code-block:: python
+
+  >>> table = pa.table({'col1': [1, 2, 3], 'col2': ['a', 'b', 'c']})
   >>> csv.write_csv(table, "tips.csv")
   >>> with pa.CompressedOutputStream("tips.csv.gz", "gzip") as out:
   ...     csv.write_csv(table, out)
@@ -83,15 +88,21 @@ Customized parsing
 
 To alter the default parsing settings in case of reading CSV files with an
 unusual structure, you should create a :class:`ParseOptions` instance
-and pass it to :func:`read_csv`::
+and pass it to :func:`read_csv`:
 
-    import pyarrow as pa
-    import pyarrow.csv as csv
+.. code-block:: python
 
-    table = csv.read_csv('tips.csv.gz', parse_options=csv.ParseOptions(
-       delimiter=";",
-       invalid_row_handler=skip_handler
-    ))
+    >>> def skip_handler(row):
+    ...     pass
+    >>> table = csv.read_csv('tips.csv.gz', parse_options=csv.ParseOptions(
+    ...    delimiter=";",
+    ...    invalid_row_handler=skip_handler
+    ... ))
+    >>> table
+    pyarrow.Table
+    col1,"col2": string
+    ----
+    col1,"col2": [["1,"a"","2,"b"","3,"c""]]
 
 Available parsing options are:
 
@@ -113,17 +124,23 @@ Customized conversion
 ---------------------
 
 To alter how CSV data is converted to Arrow types and data, you should create
-a :class:`ConvertOptions` instance and pass it to :func:`read_csv`::
+a :class:`ConvertOptions` instance and pass it to :func:`read_csv`:
 
-   import pyarrow as pa
-   import pyarrow.csv as csv
+.. code-block:: python
 
-   table = csv.read_csv('tips.csv.gz', convert_options=csv.ConvertOptions(
-       column_types={
-           'total_bill': pa.decimal128(precision=10, scale=2),
-           'tip': pa.decimal128(precision=10, scale=2),
-       }
-   ))
+   >>> table = csv.read_csv('tips.csv.gz', convert_options=csv.ConvertOptions(
+   ...     column_types={
+   ...         'total_bill': pa.decimal128(precision=10, scale=2),
+   ...         'tip': pa.decimal128(precision=10, scale=2),
+   ...     }
+   ... ))
+   >>> table
+   pyarrow.Table
+   col1: int64
+   col2: string
+   ----
+   col1: [[1,2,3]]
+   col2: [["a","b","c"]]
 
 .. note::
    To assign a column as ``duration``, the CSV values must be numeric strings
@@ -173,15 +190,21 @@ Character encoding
 
 By default, CSV files are expected to be encoded in UTF8.  Non-UTF8 data
 is accepted for ``binary`` columns.  The encoding can be changed using
-the :class:`ReadOptions` class::
+the :class:`ReadOptions` class:
 
-    import pyarrow as pa
-    import pyarrow.csv as csv
+.. code-block:: python
 
-    table = csv.read_csv('tips.csv.gz', read_options=csv.ReadOptions(
-       column_names=["animals", "n_legs", "entry"],
-       skip_rows=1
-    ))
+   >>> table = csv.read_csv('tips.csv.gz', read_options=csv.ReadOptions(
+   ...    column_names=["n_legs", "entry"],
+   ...    skip_rows=1
+   ... ))
+   >>> table
+   pyarrow.Table
+   n_legs: int64
+   entry: string
+   ----
+   n_legs: [[1,2,3]]
+   entry: [["a","b","c"]]
 
 Available read options are:
 
@@ -204,10 +227,10 @@ Customized writing
 
 To alter the default write settings in case of writing CSV files with
 different conventions, you can create a :class:`WriteOptions` instance and
-pass it to :func:`write_csv`::
+pass it to :func:`write_csv`:
 
-  >>> import pyarrow as pa
-  >>> import pyarrow.csv as csv
+.. code-block:: python
+
   >>> # Omit the header row (include_header=True is the default)
   >>> options = csv.WriteOptions(include_header=False)
   >>> csv.write_csv(table, "data.csv", options)
@@ -217,12 +240,12 @@ Incremental writing
 
 To write CSV files one batch at a time, create a :class:`CSVWriter`. This
 requires the output (a path or file-like object), the schema of the data to
-be written, and optionally write options as described above::
+be written, and optionally write options as described above:
 
-  >>> import pyarrow as pa
-  >>> import pyarrow.csv as csv
+.. code-block:: python
+
   >>> with csv.CSVWriter("data.csv", table.schema) as writer:
-  >>>     writer.write_table(table)
+  ...     writer.write_table(table)
 
 Performance
 -----------

--- a/docs/source/python/data.rst
+++ b/docs/source/python/data.rst
@@ -58,19 +58,22 @@ array data. These include:
 Each data type in Arrow has a corresponding factory function for creating
 an instance of that type object in Python:
 
-.. ipython:: python
+.. code-block:: python
 
-   import pyarrow as pa
-   t1 = pa.int32()
-   t2 = pa.string()
-   t3 = pa.binary()
-   t4 = pa.binary(10)
-   t5 = pa.timestamp('ms')
-
-   t1
-   print(t1)
-   print(t4)
-   print(t5)
+   >>> import pyarrow as pa
+   >>> t1 = pa.int32()
+   >>> t2 = pa.string()
+   >>> t3 = pa.binary()
+   >>> t4 = pa.binary(10)
+   >>> t5 = pa.timestamp('ms')
+   >>> t1
+   DataType(int32)
+   >>> print(t1)
+   int32
+   >>> print(t4)
+   fixed_size_binary[10]
+   >>> print(t5)
+   timestamp[ms]
 
 .. note::
    Different data types might use a given physical storage. For example,
@@ -83,44 +86,50 @@ input data (e.g. Python objects) may be coerced to more than one Arrow type.
 The :class:`~pyarrow.Field` type is a type plus a name and optional
 user-defined metadata:
 
-.. ipython:: python
+.. code-block:: python
 
-   f0 = pa.field('int32_field', t1)
-   f0
-   f0.name
-   f0.type
+   >>> f0 = pa.field('int32_field', t1)
+   >>> f0
+   pyarrow.Field<int32_field: int32>
+   >>> f0.name
+   'int32_field'
+   >>> f0.type
+   DataType(int32)
 
 Arrow supports **nested value types** like list, map, struct, and union. When
 creating these, you must pass types or fields to indicate the data types of the
 types' children. For example, we can define a list of int32 values with:
 
-.. ipython:: python
+.. code-block:: python
 
-   t6 = pa.list_(t1)
-   t6
+   >>> t6 = pa.list_(t1)
+   >>> t6
+   ListType(list<item: int32>)
 
 A ``struct`` is a collection of named fields:
 
-.. ipython:: python
+.. code-block:: python
 
-   fields = [
-       pa.field('s0', t1),
-       pa.field('s1', t2),
-       pa.field('s2', t4),
-       pa.field('s3', t6),
-   ]
-
-   t7 = pa.struct(fields)
-   print(t7)
+   >>> fields = [
+   ...     pa.field('s0', t1),
+   ...     pa.field('s1', t2),
+   ...     pa.field('s2', t4),
+   ...     pa.field('s3', t6),
+   ... ]
+   >>> t7 = pa.struct(fields)
+   >>> print(t7)
+   struct<s0: int32, s1: string, s2: fixed_size_binary[10], s3: list<item: int32>>
 
 For convenience, you can pass ``(name, type)`` tuples directly instead of
 :class:`~pyarrow.Field` instances:
 
-.. ipython:: python
+.. code-block:: python
 
-   t8 = pa.struct([('s0', t1), ('s1', t2), ('s2', t4), ('s3', t6)])
-   print(t8)
-   t8 == t7
+   >>> t8 = pa.struct([('s0', t1), ('s1', t2), ('s2', t4), ('s3', t6)])
+   >>> print(t8)
+   struct<s0: int32, s1: string, s2: fixed_size_binary[10], s3: list<item: int32>>
+   >>> t8 == t7
+   True
 
 
 See :ref:`Data Types API <api.types>` for a full listing of data type
@@ -136,13 +145,18 @@ defines the column names and types in a record batch or table data
 structure. The :func:`pyarrow.schema` factory function makes new Schema objects in
 Python:
 
-.. ipython:: python
+.. code-block:: python
 
-   my_schema = pa.schema([('field0', t1),
-                          ('field1', t2),
-                          ('field2', t4),
-                          ('field3', t6)])
-   my_schema
+   >>> my_schema = pa.schema([('field0', t1),
+   ...                        ('field1', t2),
+   ...                        ('field2', t4),
+   ...                        ('field3', t6)])
+   >>> my_schema
+   field0: int32
+   field1: string
+   field2: fixed_size_binary[10]
+   field3: list<item: int32>
+     child 0, item: int32
 
 In some applications, you may not create schemas directly, only using the ones
 that are embedded in :ref:`IPC messages <ipc>`.
@@ -150,11 +164,16 @@ that are embedded in :ref:`IPC messages <ipc>`.
 Schemas are immutable, which means you can't update an existing schema, but you
 can create a new one with updated values using :meth:`Schema.set`.
 
-.. ipython:: python
+.. code-block:: python
 
-   updated_field = pa.field('field0_new', pa.int64())
-   my_schema2 = my_schema.set(0, updated_field)
-   my_schema2
+   >>> updated_field = pa.field('field0_new', pa.int64())
+   >>> my_schema2 = my_schema.set(0, updated_field)
+   >>> my_schema2
+   field0_new: int64
+   field1: string
+   field2: fixed_size_binary[10]
+   field3: list<item: int32>
+     child 0, item: int32
 
 .. _data.array:
 
@@ -171,47 +190,69 @@ A simple way to create arrays is with ``pyarrow.array``, which is similar to
 the ``numpy.array`` function.  By default PyArrow will infer the data type
 for you:
 
-.. ipython:: python
+.. code-block:: python
 
-   arr = pa.array([1, 2, None, 3])
-   arr
+   >>> arr = pa.array([1, 2, None, 3])
+   >>> arr
+   <pyarrow.lib.Int64Array object at ...>
+   [
+     1,
+     2,
+     null,
+     3
+   ]
 
 But you may also pass a specific data type to override type inference:
 
-.. ipython:: python
+.. code-block:: python
 
-   pa.array([1, 2], type=pa.uint16())
+   >>> pa.array([1, 2], type=pa.uint16())
+   <pyarrow.lib.UInt16Array object at ...>
+   [
+     1,
+     2
+   ]
 
 The array's ``type`` attribute is the corresponding piece of type metadata:
 
-.. ipython:: python
+.. code-block:: python
 
-   arr.type
+   >>> arr.type
+   DataType(int64)
 
 Each in-memory array has a known length and null count (which will be 0 if
 there are no null values):
 
-.. ipython:: python
+.. code-block:: python
 
-   len(arr)
-   arr.null_count
+   >>> len(arr)
+   4
+   >>> arr.null_count
+   1
 
 Scalar values can be selected with normal indexing.  ``pyarrow.array`` converts
 ``None`` values to Arrow nulls; we return the special ``pyarrow.NA`` value for
 nulls:
 
-.. ipython:: python
+.. code-block:: python
 
-   arr[0]
-   arr[2]
+   >>> arr[0]
+   <pyarrow.Int64Scalar: 1>
+   >>> arr[2]
+   <pyarrow.Int64Scalar: None>
 
 Arrow data is immutable, so values can be selected but not assigned.
 
 Arrays can be sliced without copying:
 
-.. ipython:: python
+.. code-block:: python
 
-   arr[1:3]
+   >>> arr[1:3]
+   <pyarrow.lib.Int64Array object at ...>
+   [
+     2,
+     null
+   ]
 
 None values and NAN handling
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -234,32 +275,49 @@ List arrays
 ``pyarrow.array`` is able to infer the type of simple nested data structures
 like lists:
 
-.. ipython:: python
+.. code-block:: python
 
-   nested_arr = pa.array([[], None, [1, 2], [None, 1]])
-   print(nested_arr.type)
+   >>> nested_arr = pa.array([[], None, [1, 2], [None, 1]])
+   >>> print(nested_arr.type)
+   list<item: int64>
 
 ListView arrays
 ~~~~~~~~~~~~~~~
 
 ``pyarrow.array`` can create an alternate list type called ListView:
 
-.. ipython:: python
+.. code-block:: python
 
-   nested_arr = pa.array([[], None, [1, 2], [None, 1]], type=pa.list_view(pa.int64()))
-   print(nested_arr.type)
+   >>> nested_arr = pa.array([[], None, [1, 2], [None, 1]], type=pa.list_view(pa.int64()))
+   >>> print(nested_arr.type)
+   list_view<item: int64>
 
 ListView arrays have a different set of buffers than List arrays. The ListView array
 has both an offsets and sizes buffer, while a List array only has an offsets buffer.
 This allows for ListView arrays to specify out-of-order offsets:
 
-.. ipython:: python
+.. code-block:: python
 
-   values = [1, 2, 3, 4, 5, 6]
-   offsets = [4, 2, 0]
-   sizes = [2, 2, 2]
-   arr = pa.ListViewArray.from_arrays(offsets, sizes, values)
-   arr
+   >>> values = [1, 2, 3, 4, 5, 6]
+   >>> offsets = [4, 2, 0]
+   >>> sizes = [2, 2, 2]
+   >>> arr = pa.ListViewArray.from_arrays(offsets, sizes, values)
+   >>> arr
+   <pyarrow.lib.ListViewArray object at ...>
+   [
+     [
+       5,
+       6
+     ],
+     [
+       3,
+       4
+     ],
+     [
+       1,
+       2
+     ]
+   ]
 
 See the format specification for more details on :ref:`listview-layout`.
 
@@ -269,39 +327,114 @@ Struct arrays
 ``pyarrow.array`` is able to infer the schema of a struct type from arrays of
 dictionaries:
 
-.. ipython:: python
+.. code-block:: python
 
-   pa.array([{'x': 1, 'y': True}, {'z': 3.4, 'x': 4}])
+   >>> pa.array([{'x': 1, 'y': True}, {'z': 3.4, 'x': 4}])
+   <pyarrow.lib.StructArray object at ...>
+   -- is_valid: all not null
+   -- child 0 type: int64
+     [
+       1,
+       4
+     ]
+   -- child 1 type: bool
+     [
+       true,
+       null
+     ]
+   -- child 2 type: double
+     [
+       null,
+       3.4
+     ]
 
 Struct arrays can be initialized from a sequence of Python dicts or tuples. For tuples,
 you must explicitly pass the type:
 
-.. ipython:: python
+.. code-block:: python
 
-   ty = pa.struct([('x', pa.int8()),
-                   ('y', pa.bool_())])
-   pa.array([{'x': 1, 'y': True}, {'x': 2, 'y': False}], type=ty)
-   pa.array([(3, True), (4, False)], type=ty)
+   >>> ty = pa.struct([('x', pa.int8()),
+   ...                 ('y', pa.bool_())])
+   >>> pa.array([{'x': 1, 'y': True}, {'x': 2, 'y': False}], type=ty)
+   <pyarrow.lib.StructArray object at ...>
+   -- is_valid: all not null
+   -- child 0 type: int8
+     [
+       1,
+       2
+     ]
+   -- child 1 type: bool
+     [
+       true,
+       false
+     ]
+   >>> pa.array([(3, True), (4, False)], type=ty)
+   <pyarrow.lib.StructArray object at ...>
+   -- is_valid: all not null
+   -- child 0 type: int8
+     [
+       3,
+       4
+     ]
+   -- child 1 type: bool
+     [
+       true,
+       false
+     ]
 
 When initializing a struct array, nulls are allowed both at the struct
 level and at the individual field level.  If initializing from a sequence
 of Python dicts, a missing dict key is handled as a null value:
 
-.. ipython:: python
+.. code-block:: python
 
-   pa.array([{'x': 1}, None, {'y': None}], type=ty)
+   >>> pa.array([{'x': 1}, None, {'y': None}], type=ty)
+   <pyarrow.lib.StructArray object at ...>
+   -- is_valid:
+     [
+       true,
+       false,
+       true
+     ]
+   -- child 0 type: int8
+     [
+       1,
+       0,
+       null
+     ]
+   -- child 1 type: bool
+     [
+       null,
+       false,
+       null
+     ]
 
 You can also construct a struct array from existing arrays for each of the
 struct's components.  In this case, data storage will be shared with the
 individual arrays, and no copy is involved:
 
-.. ipython:: python
+.. code-block:: python
 
-   xs = pa.array([5, 6, 7], type=pa.int16())
-   ys = pa.array([False, True, True])
-   arr = pa.StructArray.from_arrays((xs, ys), names=('x', 'y'))
-   arr.type
-   arr
+   >>> xs = pa.array([5, 6, 7], type=pa.int16())
+   >>> ys = pa.array([False, True, True])
+   >>> arr = pa.StructArray.from_arrays((xs, ys), names=('x', 'y'))
+   >>> arr.type
+   StructType(struct<x: int16, y: bool>)
+   >>> arr
+   <pyarrow.lib.StructArray object at ...>
+   -- is_valid: all not null
+   -- child 0 type: int16
+     [
+       5,
+       6,
+       7
+     ]
+   -- child 1 type: bool
+     [
+       false,
+       true,
+       true
+     ]
 
 Map arrays
 ~~~~~~~~~~
@@ -309,11 +442,34 @@ Map arrays
 Map arrays can be constructed from lists of lists of tuples (key-item pairs), but only if
 the type is explicitly passed into :meth:`array`:
 
-.. ipython:: python
+.. code-block:: python
 
-   data = [[('x', 1), ('y', 0)], [('a', 2), ('b', 45)]]
-   ty = pa.map_(pa.string(), pa.int64())
-   pa.array(data, type=ty)
+   >>> data = [[('x', 1), ('y', 0)], [('a', 2), ('b', 45)]]
+   >>> ty = pa.map_(pa.string(), pa.int64())
+   >>> pa.array(data, type=ty)
+   <pyarrow.lib.MapArray object at ...>
+   [
+     keys:
+     [
+       "x",
+       "y"
+     ]
+     values:
+     [
+       1,
+       0
+     ],
+     keys:
+     [
+       "a",
+       "b"
+     ]
+     values:
+     [
+       2,
+       45
+     ]
+   ]
 
 MapArrays can also be constructed from offset, key, and item arrays. Offsets represent the
 starting position of each map. Note that the :attr:`MapArray.keys` and :attr:`MapArray.items`
@@ -321,13 +477,45 @@ properties give the *flattened* keys and items. To keep the keys and items assoc
 their row, use the :meth:`ListArray.from_arrays` constructor with the
 :attr:`MapArray.offsets` property.
 
-.. ipython:: python
+.. code-block:: python
 
-   arr = pa.MapArray.from_arrays([0, 2, 3], ['x', 'y', 'z'], [4, 5, 6])
-   arr.keys
-   arr.items
-   pa.ListArray.from_arrays(arr.offsets, arr.keys)
-   pa.ListArray.from_arrays(arr.offsets, arr.items)
+   >>> arr = pa.MapArray.from_arrays([0, 2, 3], ['x', 'y', 'z'], [4, 5, 6])
+   >>> arr.keys
+   <pyarrow.lib.StringArray object at ...>
+   [
+     "x",
+     "y",
+     "z"
+   ]
+   >>> arr.items
+   <pyarrow.lib.Int64Array object at ...>
+   [
+     4,
+     5,
+     6
+   ]
+   >>> pa.ListArray.from_arrays(arr.offsets, arr.keys)
+   <pyarrow.lib.ListArray object at ...>
+   [
+     [
+       "x",
+       "y"
+     ],
+     [
+       "z"
+     ]
+   ]
+   >>> pa.ListArray.from_arrays(arr.offsets, arr.items)
+   <pyarrow.lib.ListArray object at ...>
+   [
+     [
+       4,
+       5
+     ],
+     [
+       6
+     ]
+   ]
 
 Union arrays
 ~~~~~~~~~~~~
@@ -341,28 +529,76 @@ as the resulting union array.  They are adjuncted with a ``int8`` "types"
 array that tells, for each value, from which child array it must be
 selected:
 
-.. ipython:: python
+.. code-block:: python
 
-   xs = pa.array([5, 6, 7])
-   ys = pa.array([False, False, True])
-   types = pa.array([0, 1, 1], type=pa.int8())
-   union_arr = pa.UnionArray.from_sparse(types, [xs, ys])
-   union_arr.type
-   union_arr
+   >>> xs = pa.array([5, 6, 7])
+   >>> ys = pa.array([False, False, True])
+   >>> types = pa.array([0, 1, 1], type=pa.int8())
+   >>> union_arr = pa.UnionArray.from_sparse(types, [xs, ys])
+   >>> union_arr.type
+   SparseUnionType(sparse_union<0: int64=0, 1: bool=1>)
+   >>> union_arr
+   <pyarrow.lib.UnionArray object at ...>
+   -- is_valid: all not null
+   -- type_ids:   [
+       0,
+       1,
+       1
+     ]
+   -- child 0 type: int64
+     [
+       5,
+       6,
+       7
+     ]
+   -- child 1 type: bool
+     [
+       false,
+       false,
+       true
+     ]
 
 In a dense union array, you also pass, in addition to the ``int8`` "types"
 array, a ``int32`` "offsets" array that tells, for each value, at
 each offset in the selected child array it can be found:
 
-.. ipython:: python
+.. code-block:: python
 
-   xs = pa.array([5, 6, 7])
-   ys = pa.array([False, True])
-   types = pa.array([0, 1, 1, 0, 0], type=pa.int8())
-   offsets = pa.array([0, 0, 1, 1, 2], type=pa.int32())
-   union_arr = pa.UnionArray.from_dense(types, offsets, [xs, ys])
-   union_arr.type
-   union_arr
+   >>> xs = pa.array([5, 6, 7])
+   >>> ys = pa.array([False, True])
+   >>> types = pa.array([0, 1, 1, 0, 0], type=pa.int8())
+   >>> offsets = pa.array([0, 0, 1, 1, 2], type=pa.int32())
+   >>> union_arr = pa.UnionArray.from_dense(types, offsets, [xs, ys])
+   >>> union_arr.type
+   DenseUnionType(dense_union<0: int64=0, 1: bool=1>)
+   >>> union_arr
+   <pyarrow.lib.UnionArray object at ...>
+   -- is_valid: all not null
+   -- type_ids:   [
+       0,
+       1,
+       1,
+       0,
+       0
+     ]
+   -- value_offsets:   [
+       0,
+       0,
+       1,
+       1,
+       2
+     ]
+   -- child 0 type: int64
+     [
+       5,
+       6,
+       7
+     ]
+   -- child 1 type: bool
+     [
+       false,
+       true
+     ]
 
 .. _data.dictionary:
 
@@ -380,28 +616,75 @@ they appear in C++ and Python is slightly different. We define a special
 :class:`~.DictionaryArray` type with a corresponding dictionary type. Let's
 consider an example:
 
-.. ipython:: python
+.. code-block:: python
 
-   indices = pa.array([0, 1, 0, 1, 2, 0, None, 2])
-   dictionary = pa.array(['foo', 'bar', 'baz'])
-
-   dict_array = pa.DictionaryArray.from_arrays(indices, dictionary)
-   dict_array
+   >>> indices = pa.array([0, 1, 0, 1, 2, 0, None, 2])
+   >>> dictionary = pa.array(['foo', 'bar', 'baz'])
+   >>>
+   >>> dict_array = pa.DictionaryArray.from_arrays(indices, dictionary)
+   >>> dict_array
+   <pyarrow.lib.DictionaryArray object at ...>
+   ...
+   -- dictionary:
+     [
+       "foo",
+       "bar",
+       "baz"
+     ]
+   -- indices:
+     [
+       0,
+       1,
+       0,
+       1,
+       2,
+       0,
+       null,
+       2
+     ]
 
 Here we have:
 
-.. ipython:: python
+.. code-block:: python
 
-   print(dict_array.type)
-   dict_array.indices
-   dict_array.dictionary
+   >>> print(dict_array.type)
+   dictionary<values=string, indices=int64, ordered=0>
+   >>> dict_array.indices
+   <pyarrow.lib.Int64Array object at ...>
+   [
+     0,
+     1,
+     0,
+     1,
+     2,
+     0,
+     null,
+     2
+   ]
+   >>> dict_array.dictionary
+   <pyarrow.lib.StringArray object at ...>
+   [
+     "foo",
+     "bar",
+     "baz"
+   ]
 
 When using :class:`~.DictionaryArray` with pandas, the analogue is
 ``pandas.Categorical`` (more on this later):
 
-.. ipython:: python
+.. code-block:: python
 
-   dict_array.to_pandas()
+   >>> dict_array.to_pandas()
+   0    foo
+   1    bar
+   2    foo
+   3    bar
+   4    baz
+   5    foo
+   6    NaN
+   7    baz
+   dtype: category
+   Categories (3, object): ['foo', 'bar', 'baz']
 
 .. _data.record_batch:
 
@@ -411,32 +694,50 @@ Record Batches
 A **Record Batch** in Apache Arrow is a collection of equal-length array
 instances. Let's consider a collection of arrays:
 
-.. ipython:: python
+.. code-block:: python
 
-   data = [
-       pa.array([1, 2, 3, 4]),
-       pa.array(['foo', 'bar', 'baz', None]),
-       pa.array([True, None, False, True])
-   ]
+   >>> data = [
+   ...     pa.array([1, 2, 3, 4]),
+   ...     pa.array(['foo', 'bar', 'baz', None]),
+   ...     pa.array([True, None, False, True])
+   ... ]
 
 A record batch can be created from this list of arrays using
 ``RecordBatch.from_arrays``:
 
-.. ipython:: python
+.. code-block:: python
 
-   batch = pa.RecordBatch.from_arrays(data, ['f0', 'f1', 'f2'])
-   batch.num_columns
-   batch.num_rows
-   batch.schema
-
-   batch[1]
+   >>> batch = pa.RecordBatch.from_arrays(data, ['f0', 'f1', 'f2'])
+   >>> batch.num_columns
+   3
+   >>> batch.num_rows
+   4
+   >>> batch.schema
+   f0: int64
+   f1: string
+   f2: bool
+   >>>
+   >>> batch[1]
+   <pyarrow.lib.StringArray object at ...>
+   [
+     "foo",
+     "bar",
+     "baz",
+     null
+   ]
 
 A record batch can be sliced without copying memory like an array:
 
-.. ipython:: python
+.. code-block:: python
 
-   batch2 = batch.slice(1, 3)
-   batch2[1]
+   >>> batch2 = batch.slice(1, 3)
+   >>> batch2[1]
+   <pyarrow.lib.StringArray object at ...>
+   [
+     "bar",
+     "baz",
+     null
+   ]
 
 .. _data.table:
 
@@ -453,40 +754,96 @@ object makes this efficient without requiring additional memory copying.
 Considering the record batch we created above, we can create a Table containing
 one or more copies of the batch using ``Table.from_batches``:
 
-.. ipython:: python
+.. code-block:: python
 
-   batches = [batch] * 5
-   table = pa.Table.from_batches(batches)
-   table
-   table.num_rows
+   >>> batches = [batch] * 5
+   >>> table = pa.Table.from_batches(batches)
+   >>> table
+   pyarrow.Table
+   f0: int64
+   f1: string
+   f2: bool
+   ----
+   f0: [[1,2,3,4],[1,2,3,4],...,[1,2,3,4],[1,2,3,4]]
+   f1: [["foo","bar","baz",null],...,["foo","bar","baz",null]]
+   f2: [[true,null,false,true],...,[true,null,false,true]]
+   >>> table.num_rows
+   20
 
 The table's columns are instances of :class:`~.ChunkedArray`, which is a
 container for one or more arrays of the same type.
 
-.. ipython:: python
+.. code-block:: python
 
-   c = table[0]
-   c
-   c.num_chunks
-   c.chunk(0)
+   >>> c = table[0]
+   >>> c
+   <pyarrow.lib.ChunkedArray object at ...>
+   [
+     [
+       1,
+       2,
+       3,
+       4
+     ],
+     ...
+     [
+       1,
+       2,
+       3,
+       4
+     ]
+   ]
+   >>> c.num_chunks
+   5
+   >>> c.chunk(0)
+   <pyarrow.lib.Int64Array object at ...>
+   [
+     1,
+     2,
+     3,
+     4
+   ]
 
 As you'll see in the :ref:`pandas section <pandas_interop>`, we can convert
 these objects to contiguous NumPy arrays for use in pandas:
 
-.. ipython:: python
+.. code-block:: python
 
-   c.to_pandas()
+   >>> c.to_pandas()
+   0     1
+   1     2
+   2     3
+   3     4
+   4     1
+   5     2
+   6     3
+   7     4
+   8     1
+   9     2
+   10    3
+   11    4
+   12    1
+   13    2
+   14    3
+   15    4
+   16    1
+   17    2
+   18    3
+   19    4
+   Name: f0, dtype: int64
 
 Multiple tables can also be concatenated together to form a single table using
 ``pyarrow.concat_tables``, if the schemas are equal:
 
-.. ipython:: python
+.. code-block:: python
 
-   tables = [table] * 2
-   table_all = pa.concat_tables(tables)
-   table_all.num_rows
-   c = table_all[0]
-   c.num_chunks
+   >>> tables = [table] * 2
+   >>> table_all = pa.concat_tables(tables)
+   >>> table_all.num_rows
+   40
+   >>> c = table_all[0]
+   >>> c.num_chunks
+   10
 
 This is similar to ``Table.from_batches``, but uses tables as input instead of
 record batches. Record batches can be made into tables, but not the other way
@@ -508,21 +865,23 @@ Note that this metadata is preserved in :ref:`ipc` processes.
 To customize the schema metadata of an existing table you can use
 :meth:`Table.replace_schema_metadata`:
 
-.. ipython:: python
+.. code-block:: python
 
-   table.schema.metadata # empty
-   table = table.replace_schema_metadata({"f0": "First dose"})
-   table.schema.metadata
+   >>> table.schema.metadata
+   >>> table = table.replace_schema_metadata({"f0": "First dose"})
+   >>> table.schema.metadata
+   {b'f0': b'First dose'}
 
 To customize the metadata of the field from the table schema you can use
 :meth:`Field.with_metadata`:
 
-.. ipython:: python
+.. code-block:: python
 
-   field_f1 = table.schema.field("f1")
-   field_f1.metadata # empty
-   field_f1 = field_f1.with_metadata({"f1": "Second dose"})
-   field_f1.metadata
+   >>> field_f1 = table.schema.field("f1")
+   >>> field_f1.metadata
+   >>> field_f1 = field_f1.with_metadata({"f1": "Second dose"})
+   >>> field_f1.metadata
+   {b'f1': b'Second dose'}
 
 Both options create a shallow copy of the data and do not in fact change the
 Schema which is immutable. To change the metadata in the schema of the table
@@ -531,17 +890,20 @@ we created a new object when calling :meth:`Table.replace_schema_metadata`.
 To change the metadata of the field in the schema we would need to define
 a new schema and cast the data to this schema:
 
-.. ipython:: python
+.. code-block:: python
 
-   my_schema2 = pa.schema([
-      pa.field('f0', pa.int64(), metadata={"name": "First dose"}),
-      pa.field('f1', pa.string(), metadata={"name": "Second dose"}),
-      pa.field('f2', pa.bool_())],
-      metadata={"f2": "booster"})
-   t2 = table.cast(my_schema2)
-   t2.schema.field("f0").metadata
-   t2.schema.field("f1").metadata
-   t2.schema.metadata
+   >>> my_schema2 = pa.schema([
+   ...    pa.field('f0', pa.int64(), metadata={"name": "First dose"}),
+   ...    pa.field('f1', pa.string(), metadata={"name": "Second dose"}),
+   ...    pa.field('f2', pa.bool_())],
+   ...    metadata={"f2": "booster"})
+   >>> t2 = table.cast(my_schema2)
+   >>> t2.schema.field("f0").metadata
+   {b'name': b'First dose'}
+   >>> t2.schema.field("f1").metadata
+   {b'name': b'Second dose'}
+   >>> t2.schema.metadata
+   {b'f2': b'booster'}
 
 Metadata key and value pairs are ``std::string`` objects in the C++ implementation
 and so they are bytes objects (``b'...'``) in Python.
@@ -553,20 +915,25 @@ Many functions in PyArrow either return or take as an argument a :class:`RecordB
 It can be used like any iterable of record batches, but also provides their common
 schema without having to get any of the batches.::
 
+.. code-block:: python
+
    >>> schema = pa.schema([('x', pa.int64())])
    >>> def iter_record_batches():
    ...    for i in range(2):
    ...       yield pa.RecordBatch.from_arrays([pa.array([1, 2, 3])], schema=schema)
    >>> reader = pa.RecordBatchReader.from_batches(schema, iter_record_batches())
    >>> print(reader.schema)
-   pyarrow.Schema
    x: int64
    >>> for batch in reader:
    ...    print(batch)
    pyarrow.RecordBatch
    x: int64
+   ----
+   x: [1,2,3]
    pyarrow.RecordBatch
    x: int64
+   ----
+   x: [1,2,3]
 
 It can also be sent between languages using the :ref:`C stream interface <c-stream-interface>`.
 
@@ -584,31 +951,33 @@ to efficiently convert tabular columnar data into a tensor.
 Data types supported in this conversion are unsigned, signed integer and float
 types. Currently only column-major conversion is supported.
 
-   >>>  import pyarrow as pa
-   >>>  arr1 = [1, 2, 3, 4, 5]
-   >>>  arr2 = [10, 20, 30, 40, 50]
-   >>>  batch = pa.RecordBatch.from_arrays(
+.. code-block:: python
+
+   >>> arr1 = [1, 2, 3, 4, 5]
+   >>> arr2 = [10, 20, 30, 40, 50]
+   >>> batch = pa.RecordBatch.from_arrays(
    ...      [
    ...          pa.array(arr1, type=pa.uint16()),
    ...          pa.array(arr2, type=pa.int16()),
    ...      ], ["a", "b"]
    ...  )
-   >>>  batch.to_tensor()
+   >>> batch.to_tensor()
    <pyarrow.Tensor>
    type: int32
-   shape: (9, 2)
-   strides: (4, 36)
-   >>>  batch.to_tensor().to_numpy()
+   shape: (5, 2)
+   strides: (8, 4)
+   >>> batch.to_tensor().to_numpy()
    array([[ 1, 10],
-         [ 2, 20],
-         [ 3, 30],
-         [ 4, 40],
-         [ 5, 50]], dtype=int32)
+          [ 2, 20],
+          [ 3, 30],
+          [ 4, 40],
+          [ 5, 50]], dtype=int32)
 
 With ``null_to_nan`` set to ``True`` one can also convert data with
 nulls. They will be converted to ``NaN``:
 
-   >>> import pyarrow as pa
+.. code-block:: python
+
    >>> batch = pa.record_batch(
    ...     [
    ...         pa.array([1, 2, 3, 4, None], type=pa.int32()),
@@ -617,7 +986,7 @@ nulls. They will be converted to ``NaN``:
    ... )
    >>> batch.to_tensor(null_to_nan=True).to_numpy()
    array([[ 1., 10.],
-         [ 2., 20.],
-         [ 3., 30.],
-         [ 4., 40.],
-         [nan, nan]])
+          [ 2., 20.],
+          [ 3., 30.],
+          [ 4., 40.],
+          [nan, nan]])

--- a/docs/source/python/data.rst
+++ b/docs/source/python/data.rst
@@ -918,9 +918,11 @@ schema without having to get any of the batches.::
 .. code-block:: python
 
    >>> schema = pa.schema([('x', pa.int64())])
+   >>>
    >>> def iter_record_batches():
    ...    for i in range(2):
    ...       yield pa.RecordBatch.from_arrays([pa.array([1, 2, 3])], schema=schema)
+   >>>
    >>> reader = pa.RecordBatchReader.from_batches(schema, iter_record_batches())
    >>> print(reader.schema)
    x: int64

--- a/docs/source/python/data.rst
+++ b/docs/source/python/data.rst
@@ -913,7 +913,7 @@ Record Batch Readers
 
 Many functions in PyArrow either return or take as an argument a :class:`RecordBatchReader`.
 It can be used like any iterable of record batches, but also provides their common
-schema without having to get any of the batches.::
+schema without having to get any of the batches.
 
 .. code-block:: python
 

--- a/docs/source/python/dataset.rst
+++ b/docs/source/python/dataset.rst
@@ -811,18 +811,18 @@ to supply a visitor that will be called as each file is created:
     >>> ds.write_dataset(table, "dataset_visited", format="parquet", partitioning=part,
     ...                  file_visitor=file_visitor)
     path=dataset_visited/c=.../part-0.parquet
-    size=824 bytes
+    size=... bytes
     metadata=<pyarrow._parquet.FileMetaData object at ...>
-      created_by: parquet-cpp-arrow version 23.0.0-SNAPSHOT
+      created_by: parquet-cpp-arrow version ...
       num_columns: 2
       num_rows: 5
       num_row_groups: 1
       format_version: 2.6
       serialized_size: 0
     path=dataset_visited/c=.../part-0.parquet
-    size=826 bytes
+    size=... bytes
     metadata=<pyarrow._parquet.FileMetaData object at ...>
-      created_by: parquet-cpp-arrow version 23.0.0-SNAPSHOT
+      created_by: parquet-cpp-arrow version ...
       num_columns: 2
       num_rows: 5
       num_row_groups: 1

--- a/docs/source/python/dlpack.rst
+++ b/docs/source/python/dlpack.rst
@@ -68,36 +68,36 @@ Examples
 
 Convert a PyArrow CPU array into a NumPy array:
 
-.. code-block::
+.. code-block:: python
 
     >>> import pyarrow as pa
-    >>> array = pa.array([2, 0, 2, 4])
-    <pyarrow.lib.Int64Array object at 0x121fd4880>
-    [
-    2,
-    0,
-    2,
-    4
-    ]
-
     >>> import numpy as np
+    >>> array = pa.array([2, 0, 2, 4])
+    >>> array
+    <pyarrow.lib.Int64Array object at ...>
+    [
+      2,
+      0,
+      2,
+      4
+    ]
     >>> np.from_dlpack(array)
     array([2, 0, 2, 4])
 
 Convert a PyArrow CPU array into a PyTorch tensor:
 
-.. code-block::
+.. code-block:: python
 
-    >>> import torch
-    >>> torch.from_dlpack(array)
+    >>> import torch  # doctest: +SKIP
+    >>> torch.from_dlpack(array)  # doctest: +SKIP
     tensor([2, 0, 2, 4])
 
 Convert a PyArrow CPU array into a JAX array:
 
-.. code-block::
+.. code-block:: python
 
-    >>> import jax
-    >>> jax.numpy.from_dlpack(array)
+    >>> import jax  # doctest: +SKIP
+    >>> jax.numpy.from_dlpack(array)  # doctest: +SKIP
     Array([2, 0, 2, 4], dtype=int32)
-    >>> jax.dlpack.from_dlpack(array)
+    >>> jax.dlpack.from_dlpack(array)  # doctest: +SKIP
     Array([2, 0, 2, 4], dtype=int32)

--- a/docs/source/python/extending_types.rst
+++ b/docs/source/python/extending_types.rst
@@ -614,13 +614,13 @@ example
 
 .. code-block:: python
 
-    >>> tensor_type = pa.fixed_shape_tensor(pa.float64(), [2, 2, 3], permutation=[0, 2, 1])
+   >>> tensor_type = pa.fixed_shape_tensor(pa.float64(), [2, 2, 3], permutation=[0, 2, 1])
 
 or
 
 .. code-block:: python
 
-    >>> tensor_type = pa.fixed_shape_tensor(pa.bool_(), [2, 2, 3], dim_names=["C", "H", "W"])
+   >>> tensor_type = pa.fixed_shape_tensor(pa.bool_(), [2, 2, 3], dim_names=["C", "H", "W"])
 
 for ``NCHW`` format where:
 

--- a/docs/source/python/getstarted.rst
+++ b/docs/source/python/getstarted.rst
@@ -152,7 +152,7 @@ and will lazily load chunks of data only when iterating over them
 .. code-block:: python
 
    >>> import datetime
-   >>> current_year = datetime.datetime.now(datetime.UTC).year
+   >>> current_year = 2025
    >>> for table_chunk in birthdays_dataset.to_batches():
    ...     print("AGES", pc.subtract(current_year, table_chunk["years"]))
    AGES [

--- a/docs/source/python/getstarted.rst
+++ b/docs/source/python/getstarted.rst
@@ -151,7 +151,6 @@ and will lazily load chunks of data only when iterating over them
 
 .. code-block:: python
 
-   >>> import datetime
    >>> current_year = 2025
    >>> for table_chunk in birthdays_dataset.to_batches():
    ...     print("AGES", pc.subtract(current_year, table_chunk["years"]))

--- a/docs/source/python/getstarted.rst
+++ b/docs/source/python/getstarted.rst
@@ -15,17 +15,6 @@
 .. specific language governing permissions and limitations
 .. under the License.
 
-.. ipython:: python
-    :suppress:
-
-    # set custom tmp working directory for files that create data
-    import os
-    import tempfile
-
-    orig_working_dir = os.getcwd()
-    temp_working_dir = tempfile.mkdtemp(prefix="pyarrow-")
-    os.chdir(temp_working_dir)
-
 .. _getstarted:
 
 Getting Started
@@ -47,24 +36,29 @@ Arrow to use the best performing implementation to store the data and
 perform computations on it. So each array is meant to have data and
 a type
 
-.. ipython:: python
+.. code-block:: python
 
-    import pyarrow as pa
-
-    days = pa.array([1, 12, 17, 23, 28], type=pa.int8())
+   >>> import pyarrow as pa
+   >>> days = pa.array([1, 12, 17, 23, 28], type=pa.int8())
 
 Multiple arrays can be combined in tables to form the columns
 in tabular data when attached to a column name
 
-.. ipython:: python
+.. code-block:: python
 
-    months = pa.array([1, 3, 5, 7, 1], type=pa.int8())
-    years = pa.array([1990, 2000, 1995, 2000, 1995], type=pa.int16())
-
-    birthdays_table = pa.table([days, months, years],
-                               names=["days", "months", "years"])
-
-    birthdays_table
+   >>> months = pa.array([1, 3, 5, 7, 1], type=pa.int8())
+   >>> years = pa.array([1990, 2000, 1995, 2000, 1995], type=pa.int16())
+   >>> birthdays_table = pa.table([days, months, years],
+   ...                            names=["days", "months", "years"])
+   >>> birthdays_table
+   pyarrow.Table
+   days: int8
+   months: int8
+   years: int16
+   ----
+   days: [[1,12,17,23,28]]
+   months: [[1,3,5,7,1]]
+   years: [[1990,2000,1995,2000,1995]]
 
 See :ref:`data` for more details.
 
@@ -75,21 +69,27 @@ Once you have tabular data, Arrow provides out of the box
 the features to save and restore that data for common formats
 like Parquet:
 
-.. ipython:: python
+.. code-block:: python
 
-    import pyarrow.parquet as pq
-
-    pq.write_table(birthdays_table, 'birthdays.parquet')
+   >>> import pyarrow.parquet as pq
+   >>> pq.write_table(birthdays_table, 'birthdays.parquet')
 
 Once you have your data on disk, loading it back is a single function call,
 and Arrow is heavily optimized for memory and speed so loading
 data will be as quick as possible
 
-.. ipython:: python
+.. code-block:: python
 
-    reloaded_birthdays = pq.read_table('birthdays.parquet')
-
-    reloaded_birthdays
+   >>> reloaded_birthdays = pq.read_table('birthdays.parquet')
+   >>> reloaded_birthdays
+   pyarrow.Table
+   days: int8
+   months: int8
+   years: int16
+   ----
+   days: [[1,12,17,23,28]]
+   months: [[1,3,5,7,1]]
+   years: [[1990,2000,1995,2000,1995]]
 
 Saving and loading back data in arrow is usually done through
 :ref:`Parquet <parquet>`, :ref:`IPC format <ipc>` (:ref:`feather`),
@@ -102,11 +102,24 @@ Arrow ships with a bunch of compute functions that can be applied
 to its arrays and tables, so through the compute functions
 it's possible to apply transformations to the data
 
-.. ipython:: python
+.. code-block:: python
 
-    import pyarrow.compute as pc
-
-    pc.value_counts(birthdays_table["years"])
+   >>> import pyarrow.compute as pc
+   >>> pc.value_counts(birthdays_table["years"])
+   <pyarrow.lib.StructArray object at ...>
+   -- is_valid: all not null
+   -- child 0 type: int16
+     [
+       1990,
+       2000,
+       1995
+     ]
+   -- child 1 type: int64
+     [
+       1,
+       2,
+       2
+     ]
 
 See :ref:`compute` for a list of available compute functions and
 how to use them.
@@ -118,33 +131,41 @@ Arrow also provides the :class:`pyarrow.dataset` API to work with
 large data, which will handle for you partitioning of your data in
 smaller chunks
 
-.. ipython:: python
+.. code-block:: python
 
-    import pyarrow.dataset as ds
-
-    ds.write_dataset(birthdays_table, "savedir", format="parquet",
-                     partitioning=ds.partitioning(
-                        pa.schema([birthdays_table.schema.field("years")])
-                    ))
+   >>> import pyarrow.dataset as ds
+   >>> ds.write_dataset(birthdays_table, "savedir", format="parquet",
+   ...                  partitioning=ds.partitioning(
+   ...                     pa.schema([birthdays_table.schema.field("years")])
+   ...                 ))
 
 Loading back the partitioned dataset will detect the chunks
 
-.. ipython:: python
+.. code-block:: python
 
-    birthdays_dataset = ds.dataset("savedir", format="parquet", partitioning=["years"])
-
-    birthdays_dataset.files
+   >>> birthdays_dataset = ds.dataset("savedir", format="parquet", partitioning=["years"])
+   >>> birthdays_dataset.files
+   ['savedir/1990/part-0.parquet', 'savedir/1995/part-0.parquet', 'savedir/2000/part-0.parquet']
 
 and will lazily load chunks of data only when iterating over them
 
-.. ipython:: python
-    :okexcept:
+.. code-block:: python
 
-    import datetime
-
-    current_year = datetime.datetime.now(datetime.UTC).year
-    for table_chunk in birthdays_dataset.to_batches():
-        print("AGES", pc.subtract(current_year, table_chunk["years"]))
+   >>> import datetime
+   >>> current_year = datetime.datetime.now(datetime.UTC).year
+   >>> for table_chunk in birthdays_dataset.to_batches():
+   ...     print("AGES", pc.subtract(current_year, table_chunk["years"]))
+   AGES [
+     35
+   ]
+   AGES [
+     30,
+     30
+   ]
+   AGES [
+     25,
+     25
+   ]
 
 For further details on how to work with big datasets, how to filter them,
 how to project them, etc., refer to :ref:`dataset` documentation.
@@ -155,14 +176,3 @@ Continuing from here
 For digging further into Arrow, you might want to read the
 :doc:`PyArrow Documentation <./index>` itself or the
 `Arrow Python Cookbook <https://arrow.apache.org/cookbook/py/>`_
-
-
-.. ipython:: python
-    :suppress:
-
-    # clean-up custom working directory
-    import os
-    import shutil
-
-    os.chdir(orig_working_dir)
-    shutil.rmtree(temp_working_dir, ignore_errors=True)

--- a/docs/source/python/install.rst
+++ b/docs/source/python/install.rst
@@ -54,7 +54,7 @@ and macOS):
 
 .. code-block:: bash
 
-    pip install pyarrow
+   pip install pyarrow
 
 If you encounter any importing issues of the pip wheels on Windows, you may
 need to install the `latest Visual C++ Redistributable for Visual Studio
@@ -96,7 +96,7 @@ a custom path to the database from Python:
 .. code-block:: python
 
    >>> import pyarrow as pa
-   >>> pa.set_timezone_db_path("custom_path")
+   >>> pa.set_timezone_db_path("custom_path")  # doctest: +SKIP
 
 You may encounter problems writing datetime data to an ORC file if you install
 pyarrow with pip. One possible solution to fix this problem:
@@ -109,8 +109,8 @@ command:
 
 .. code-block:: python
 
-   >>> import tzdata
-   >>> print(tzdata.__file__)
+   >>> import tzdata  # doctest: +SKIP
+   >>> print(tzdata.__file__)  # doctest: +SKIP
    path\to\.venv\Lib\site-packages\tzdata\__init__.py
 
 

--- a/docs/source/python/integration/substrait.rst
+++ b/docs/source/python/integration/substrait.rst
@@ -35,36 +35,41 @@ Arrow schemas can be encoded and decoded using the :meth:`pyarrow.substrait.seri
 
 .. code-block:: python
 
-    import pyarrow as pa
-    import pyarrow.substrait as pa_substrait
-
-    arrow_schema = pa.schema([
-        pa.field("x", pa.int32()),
-        pa.field("y", pa.string())
-    ])
-    substrait_schema = pa_substrait.serialize_schema(arrow_schema)
+    >>> import pyarrow as pa
+    >>> import pyarrow.substrait as pa_substrait
+    >>> arrow_schema = pa.schema([
+    ...     pa.field("x", pa.int32()),
+    ...     pa.field("y", pa.string())
+    ... ])
+    >>> substrait_schema = pa_substrait.serialize_schema(arrow_schema)
 
 The schema marshalled as a Substrait ``NamedStruct`` is directly
-available as ``substrait_schema.schema``::
+available as ``substrait_schema.schema``:
 
-    >>> print(substrait_schema.schema)
+.. code-block:: python
+
+    >>> print(bytes(substrait_schema.schema))
     b'\n\x01x\n\x01y\x12\x0c\n\x04*\x02\x10\x01\n\x04b\x02\x10\x01'
 
 In case arrow custom types were used, the schema will require
 extensions for those types to be actually usable, for this reason
 the schema is also available as an `Extended Expression`_ including
-all the extensions types::
+all the extensions types:
 
-    >>> print(substrait_schema.expression)
-    b'"\x14\n\x01x\n\x01y\x12\x0c\n\x04*\x02\x10\x01\n\x04b\x02\x10\x01:\x19\x10,*\x15Acero 17.0.0'
+.. code-block:: python
+
+    >>> print(bytes(substrait_schema.expression))
+    b'"\x14\n\x01x\n\x01y\x12\x0c\n\x04*\x02\x10\x01\n\x04b\x02\x10\x01:\x19\x10,*\x15Acero ...'
 
 If ``Substrait Python`` is installed, the schema can also be converted to
-a ``substrait-python`` object::
+a ``substrait-python`` object:
 
-    >>> print(substrait_schema.to_pysubstrait())
+.. code-block:: python
+
+    >>> print(substrait_schema.to_pysubstrait())  # doctest: +SKIP
     version {
         minor_number: 44
-        producer: "Acero 17.0.0"
+        producer: "Acero ..."
     }
     base_schema {
         names: "x"
@@ -92,33 +97,33 @@ Arrow compute expressions can be encoded and decoded using the
 
 .. code-block:: python
 
-    import pyarrow as pa
-    import pyarrow.compute as pa
-    import pyarrow.substrait as pa_substrait
-
-    arrow_schema = pa.schema([
-        pa.field("x", pa.int32()),
-        pa.field("y", pa.int32())
-    ])
-
-    substrait_expr = pa_substrait.serialize_expressions(
-        exprs=[pc.field("x") + pc.field("y")],
-        names=["total"],
-        schema=arrow_schema
-    )
+    >>> import pyarrow.compute as pc
+    >>> arrow_schema = pa.schema([
+    ...     pa.field("x", pa.int32()),
+    ...     pa.field("y", pa.int32())
+    ... ])
+    >>> substrait_expr = pa_substrait.serialize_expressions(
+    ...     exprs=[pc.field("x") + pc.field("y")],
+    ...     names=["total"],
+    ...     schema=arrow_schema
+    ... )
 
 The result of encoding to substrait an expression will be the
-protobuf ``ExtendedExpression`` message data itself::
+protobuf ``ExtendedExpression`` message data itself:
+
+.. code-block:: python
 
     >>> print(bytes(substrait_expr))
-    b'\nZ\x12Xhttps://github.com/substrait-io/substrait/blob/main/extensions/functions_arithmetic.yaml\x12\x07\x1a\x05\x1a\x03add\x1a>\n5\x1a3\x1a\x04*\x02\x10\x01"\n\x1a\x08\x12\x06\n\x02\x12\x00"\x00"\x0c\x1a\n\x12\x08\n\x04\x12\x02\x08\x01"\x00*\x11\n\x08overflow\x12\x05ERROR\x1a\x05total"\x14\n\x01x\n\x01y\x12\x0c\n\x04*\x02\x10\x01\n\x04*\x02\x10\x01:\x19\x10,*\x15Acero 17.0.0'
+    b'\nZ\x12Xhttps://github.com/substrait-io/substrait/blob/main/extensions/functions_arithmetic.yaml\x12\x07\x1a\x05\x1a\x03add\x1a>\n5\x1a3\x1a\x04*\x02\x10\x01"\n\x1a\x08\x12\x06\n\x02\x12\x00"\x00"\x0c\x1a\n\x12\x08\n\x04\x12\x02\x08\x01"\x00*\x11\n\x08overflow\x12\x05ERROR\x1a\x05total"\x14\n\x01x\n\x01y\x12\x0c\n\x04*\x02\x10\x01\n\x04*\x02\x10\x01:\x19\x10,*\x15Acero ...'
 
 So in case a ``Substrait Python`` object is required, the expression
-has to be decoded from ``substrait-python`` itself::
+has to be decoded from ``substrait-python`` itself:
 
-    >>> import substrait
-    >>> pysubstrait_expr = substrait.proto.ExtendedExpression.FromString(substrait_expr)
-    >>> print(pysubstrait_expr)
+.. code-block:: python
+
+    >>> import substrait  # doctest: +SKIP
+    >>> pysubstrait_expr = substrait.proto.ExtendedExpression.FromString(substrait_expr)  # doctest: +SKIP
+    >>> print(pysubstrait_expr)  # doctest: +SKIP
     version {
       minor_number: 44
       producer: "Acero 17.0.0"
@@ -198,39 +203,33 @@ the expressions can be passed to the dataset scanner in the form of
 
 .. code-block:: python
 
-    import pyarrow.dataset as ds
-    import pyarrow.substrait as pa_substrait
-
-    # Use substrait-python to create the queries
-    from substrait import proto
-
-    dataset = ds.dataset("./data/index-0.parquet")
-    substrait_schema = pa_substrait.serialize_schema(dataset.schema).to_pysubstrait()
-
-    # SELECT project_name FROM dataset WHERE project_name = 'pyarrow'
-
-    projection = proto.ExtendedExpression(referred_expr=[
-        {"expression": {"selection": {"direct_reference": {"struct_field": {"field": 0}}}},
-        "output_names": ["project_name"]}
-    ])
-    projection.MergeFrom(substrait_schema)
-
-    filtering = proto.ExtendedExpression(
-            extension_uris=[{"extension_uri_anchor": 99, "uri": "/functions_comparison.yaml"}],
-            extensions=[{"extension_function": {"extension_uri_reference": 99, "function_anchor": 199, "name": "equal:any1_any1"}}],
-            referred_expr=[
-                {"expression": {"scalar_function": {"function_reference": 199, "arguments": [
-                    {"value": {"selection": {"direct_reference": {"struct_field": {"field": 0}}}}},
-                    {"value": {"literal": {"string": "pyarrow"}}}
-                ], "output_type": {"bool": {"nullability": False}}}}}
-            ]
-    )
-    filtering.MergeFrom(substrait_schema)
-
-    results = dataset.scanner(
-        columns=pa.substrait.BoundExpressions.from_substrait(projection),
-        filter=pa.substrait.BoundExpressions.from_substrait(filtering)
-    ).head(5)
+    >>> import pyarrow.dataset as ds  # doctest: +SKIP
+    >>> import pyarrow.substrait as pa_substrait  # doctest: +SKIP
+    >>> # Use substrait-python to create the queries
+    >>> from substrait import proto  # doctest: +SKIP
+    >>> dataset = ds.dataset("./data/index-0.parquet")  # doctest: +SKIP
+    >>> substrait_schema = pa_substrait.serialize_schema(dataset.schema).to_pysubstrait()  # doctest: +SKIP
+    >>> # SELECT project_name FROM dataset WHERE project_name = 'pyarrow'
+    >>> projection = proto.ExtendedExpression(referred_expr=[  # doctest: +SKIP
+    ...     {"expression": {"selection": {"direct_reference": {"struct_field": {"field": 0}}}},
+    ...     "output_names": ["project_name"]}
+    ... ])
+    >>> projection.MergeFrom(substrait_schema)  # doctest: +SKIP
+    >>> filtering = proto.ExtendedExpression(  # doctest: +SKIP
+    ...         extension_uris=[{"extension_uri_anchor": 99, "uri": "/functions_comparison.yaml"}],
+    ...         extensions=[{"extension_function": {"extension_uri_reference": 99, "function_anchor": 199, "name": "equal:any1_any1"}}],
+    ...         referred_expr=[
+    ...             {"expression": {"scalar_function": {"function_reference": 199, "arguments": [
+    ...                 {"value": {"selection": {"direct_reference": {"struct_field": {"field": 0}}}}},
+    ...                 {"value": {"literal": {"string": "pyarrow"}}}
+    ...             ], "output_type": {"bool": {"nullability": False}}}}}
+    ...         ]
+    ... )
+    >>> filtering.MergeFrom(substrait_schema)  # doctest: +SKIP
+    >>> results = dataset.scanner(  # doctest: +SKIP
+    ...     columns=pa.substrait.BoundExpressions.from_substrait(projection),
+    ...     filter=pa.substrait.BoundExpressions.from_substrait(filtering)
+    ... ).head(5)
 
 
 .. code-block:: text

--- a/docs/source/python/interchange_protocol.rst
+++ b/docs/source/python/interchange_protocol.rst
@@ -29,7 +29,6 @@ data type. The protocol also has missing data support and
 it supports chunking, meaning accessing the
 data in “batches” of rows.
 
-
 The Python dataframe interchange protocol is designed by the
 `Consortium for Python Data API Standards <https://data-apis.org/>`_
 in order to enable data interchange between dataframe
@@ -43,7 +42,7 @@ From PyArrow to other libraries: ``__dataframe__()`` method
 The ``__dataframe__()`` method creates a new exchange object that
 the consumer library can take and construct an object of it's own.
 
-.. code-block::
+.. code-block:: python
 
     >>> import pyarrow as pa
     >>> table = pa.table({"n_attendees": [100, 10, 1]})
@@ -65,7 +64,7 @@ protocol.
 We can for example take a pandas dataframe and construct a
 PyArrow table with the use of the interchange protocol:
 
-.. code-block::
+.. code-block:: python
 
     >>> import pyarrow
     >>> from pyarrow.interchange import from_dataframe
@@ -90,18 +89,18 @@ PyArrow table with the use of the interchange protocol:
 
 We can do the same with a polars dataframe:
 
-.. code-block::
+.. code-block:: python
 
-    >>> import polars as pl
-    >>> from datetime import datetime
-    >>> arr = [datetime(2023, 5, 20, 10, 0),
+    >>> import polars as pl  # doctest: +SKIP
+    >>> from datetime import datetime  # doctest: +SKIP
+    >>> arr = [datetime(2023, 5, 20, 10, 0),  # doctest: +SKIP
     ...        datetime(2023, 5, 20, 11, 0),
     ...        datetime(2023, 5, 20, 13, 30)]
-    >>> df = pl.DataFrame({
+    >>> df = pl.DataFrame({  # doctest: +SKIP
     ...          'Talk': ['About Polars','Intro into PyArrow','Coding in Rust'],
     ...          'Time': arr,
     ...      })
-    >>> df
+    >>> df  # doctest: +SKIP
     shape: (3, 2)
     ┌────────────────────┬─────────────────────┐
     │ Talk               ┆ Time                │
@@ -112,7 +111,7 @@ We can do the same with a polars dataframe:
     │ Intro into PyArrow ┆ 2023-05-20 11:00:00 │
     │ Coding in Rust     ┆ 2023-05-20 13:30:00 │
     └────────────────────┴─────────────────────┘
-    >>> from_dataframe(df)
+    >>> from_dataframe(df)  # doctest: +SKIP
     pyarrow.Table
     Talk: large_string
     Time: timestamp[us]

--- a/docs/source/python/json.rst
+++ b/docs/source/python/json.rst
@@ -47,18 +47,20 @@ Usage
 
 JSON reading functionality is available through the :mod:`pyarrow.json` module.
 In many cases, you will simply call the :func:`read_json` function
-with the file path you want to read from::
+with the file path you want to read from:
+
+.. code-block:: python
 
    >>> from pyarrow import json
-   >>> fn = 'my_data.json'
-   >>> table = json.read_json(fn)
-   >>> table
+   >>> fn = 'my_data.json'  # doctest: +SKIP
+   >>> table = json.read_json(fn)  # doctest: +SKIP
+   >>> table  # doctest: +SKIP
    pyarrow.Table
    a: int64
    b: double
    c: string
    d: bool
-   >>> table.to_pandas()
+   >>> table.to_pandas()  # doctest: +SKIP
       a    b     c      d
    0  1  2.0   foo  False
    1  4 -5.5  None   True
@@ -89,17 +91,19 @@ Thus, reading this JSON file:
    {"a": [1, 2], "b": {"c": true, "d": "1991-02-03"}}
    {"a": [3, 4, 5], "b": {"c": false, "d": "2019-04-01"}}
 
-returns the following data::
+returns the following data:
 
-   >>> table = json.read_json("my_data.json")
-   >>> table
+.. code-block:: python
+
+   >>> table = json.read_json("my_data.json")  # doctest: +SKIP
+   >>> table  # doctest: +SKIP
    pyarrow.Table
    a: list<item: int64>
      child 0, item: int64
    b: struct<c: bool, d: timestamp[s]>
      child 0, c: bool
      child 1, d: timestamp[s]
-   >>> table.to_pandas()
+   >>> table.to_pandas()  # doctest: +SKIP
               a                                       b
    0     [1, 2]   {'c': True, 'd': 1991-02-03 00:00:00}
    1  [3, 4, 5]  {'c': False, 'd': 2019-04-01 00:00:00}

--- a/docs/source/python/memory.rst
+++ b/docs/source/python/memory.rst
@@ -229,8 +229,8 @@ able to write to buffers or do on-the-fly compression.
    >>> with pa.output_stream('example1.dat') as stream:
    ...     stream.write(b'some data')
    9
-   >>> f = open('example1.dat', 'rb')
-   >>> f.read()
+   >>> with open('example1.dat', 'rb') as f:
+   ...     f.read()
    b'some data'
 
 

--- a/docs/source/python/numpy.rst
+++ b/docs/source/python/numpy.rst
@@ -29,14 +29,14 @@ NumPy to Arrow
 To convert a NumPy array to Arrow, one can simply call the :func:`pyarrow.array`
 factory function.
 
-.. code-block:: pycon
+.. code-block:: python
 
    >>> import numpy as np
    >>> import pyarrow as pa
    >>> data = np.arange(10, dtype='int16')
    >>> arr = pa.array(data)
    >>> arr
-   <pyarrow.lib.Int16Array object at 0x7fb1d1e6ae58>
+   <pyarrow.lib.Int16Array object at ...>
    [
      0,
      1,
@@ -61,7 +61,7 @@ for use with NumPy using the :meth:`~pyarrow.Array.to_numpy` method.
 This is limited to primitive types for which NumPy has the same physical
 representation as Arrow, and assuming the Arrow data has no nulls.
 
-.. code-block:: pycon
+.. code-block:: python
 
    >>> import numpy as np
    >>> import pyarrow as pa

--- a/docs/source/python/orc.rst
+++ b/docs/source/python/orc.rst
@@ -37,7 +37,9 @@ Obtaining pyarrow with ORC Support
 --------------------------------------
 
 If you installed ``pyarrow`` with pip or conda, it should be built with ORC
-support bundled::
+support bundled:
+
+.. code-block:: python
 
    >>> from pyarrow import orc
 
@@ -52,7 +54,9 @@ Reading and Writing Single Files
 The functions :func:`~.orc.read_table` and :func:`~.orc.write_table`
 read and write the :ref:`pyarrow.Table <data.table>` object, respectively.
 
-Let's look at a simple table::
+Let's look at a simple table:
+
+.. code-block:: python
 
    >>> import numpy as np
    >>> import pyarrow as pa
@@ -65,19 +69,25 @@ Let's look at a simple table::
    ...     }
    ... )
 
-We write this to ORC format with ``write_table``::
+We write this to ORC format with ``write_table``:
+
+.. code-block:: python
 
    >>> from pyarrow import orc
    >>> orc.write_table(table, 'example.orc')
 
 This creates a single ORC file. In practice, an ORC dataset may consist
 of many files in many directories. We can read a single file back with
-``read_table``::
+``read_table``:
+
+.. code-block:: python
 
    >>> table2 = orc.read_table('example.orc')
 
 You can pass a subset of columns to read, which can be much faster than reading
-the whole file (due to the columnar layout)::
+the whole file (due to the columnar layout):
+
+.. code-block:: python
 
    >>> orc.read_table('example.orc', columns=['one', 'three'])
    pyarrow.Table
@@ -120,11 +130,13 @@ See the :func:`~pyarrow.orc.write_table()` docstring for more details.
 Finer-grained Reading and Writing
 ---------------------------------
 
-``read_table`` uses the :class:`~.ORCFile` class, which has other features::
+``read_table`` uses the :class:`~.ORCFile` class, which has other features:
+
+.. code-block:: python
 
    >>> orc_file = orc.ORCFile('example.orc')
    >>> orc_file.metadata
-
+   <BLANKLINE>
    -- metadata --
    >>> orc_file.schema
    one: double
@@ -139,7 +151,9 @@ As you can learn more in the `Apache ORC format
 <https://orc.apache.org/specification/>`_, an ORC file consists of
 multiple stripes. ``read_table`` will read all of the stripes and
 concatenate them into a single table. You can read individual stripes with
-``read_stripe``::
+``read_stripe``:
+
+.. code-block:: python
 
    >>> orc_file.nstripes
    1
@@ -148,8 +162,14 @@ concatenate them into a single table. You can read individual stripes with
    one: double
    two: string
    three: bool
+   ----
+   one: [-1,nan,2.5]
+   two: ["foo","bar","baz"]
+   three: [true,false,true]
 
-We can write an ORC file using ``ORCWriter``::
+We can write an ORC file using ``ORCWriter``:
+
+.. code-block:: python
 
    >>> with orc.ORCWriter('example2.orc') as writer:
    ...     writer.write(table)
@@ -159,12 +179,14 @@ Compression
 
 The data pages within a column in a row group can be compressed after the
 encoding passes (dictionary, RLE encoding). In PyArrow we don't use compression
-by default, but Snappy, ZSTD, Zlib, and LZ4 are also supported::
+by default, but Snappy, ZSTD, Zlib, and LZ4 are also supported:
 
-   >>> orc.write_table(table, where, compression='uncompressed')
-   >>> orc.write_table(table, where, compression='zlib')
-   >>> orc.write_table(table, where, compression='zstd')
-   >>> orc.write_table(table, where, compression='snappy')
+.. code-block:: python
+
+   >>> orc.write_table(table, 'example.orc', compression='uncompressed')
+   >>> orc.write_table(table, 'example.orc', compression='zlib')
+   >>> orc.write_table(table, 'example.orc', compression='zstd')
+   >>> orc.write_table(table, 'example.orc', compression='snappy')
 
 Snappy generally results in better performance, while Zlib may yield smaller
 files.
@@ -173,12 +195,14 @@ Reading from cloud storage
 --------------------------
 
 In addition to local files, pyarrow supports other filesystems, such as cloud
-filesystems, through the ``filesystem`` keyword::
+filesystems, through the ``filesystem`` keyword:
+
+.. code-block:: python
 
    >>> from pyarrow import fs
 
-   >>> s3  = fs.S3FileSystem(region="us-east-2")
-   >>> table = orc.read_table("bucket/object/key/prefix", filesystem=s3)
+   >>> s3  = fs.S3FileSystem(region="us-east-2")  # doctest: +SKIP
+   >>> table = orc.read_table("bucket/object/key/prefix", filesystem=s3)  # doctest: +SKIP
 
 .. seealso::
    :ref:`Documentation for filesystems <filesystem>`.

--- a/docs/source/python/pandas.rst
+++ b/docs/source/python/pandas.rst
@@ -31,10 +31,10 @@ to them.
 
 To follow examples in this document, make sure to run:
 
-.. ipython:: python
+.. code-block:: python
 
-   import pandas as pd
-   import pyarrow as pa
+   >>> import pandas as pd
+   >>> import pyarrow as pa
 
 DataFrames
 ----------
@@ -50,17 +50,14 @@ Conversion from a Table to a DataFrame is done by calling
 
 .. code-block:: python
 
-    import pyarrow as pa
-    import pandas as pd
+    >>> df = pd.DataFrame({"a": [1, 2, 3]})
+    >>> # Convert from pandas to Arrow
+    >>> table = pa.Table.from_pandas(df)
+    >>> # Convert back to pandas
+    >>> df_new = table.to_pandas()
 
-    df = pd.DataFrame({"a": [1, 2, 3]})
-    # Convert from pandas to Arrow
-    table = pa.Table.from_pandas(df)
-    # Convert back to pandas
-    df_new = table.to_pandas()
-
-    # Infer Arrow schema from pandas
-    schema = pa.Schema.from_pandas(df)
+    >>> # Infer Arrow schema from pandas
+    >>> schema = pa.Schema.from_pandas(df)
 
 By default ``pyarrow`` tries to preserve and restore the ``.index``
 data as accurately as possible. See the section below for more about
@@ -169,24 +166,52 @@ columns are converted to :ref:`Arrow dictionary arrays <data.dictionary>`,
 a special array type optimized to handle repeated and limited
 number of possible values.
 
-.. ipython:: python
+.. code-block:: python
 
-   df = pd.DataFrame({"cat": pd.Categorical(["a", "b", "c", "a", "b", "c"])})
-   df.cat.dtype.categories
-   df
-
-   table = pa.Table.from_pandas(df)
-   table
+   >>> df = pd.DataFrame({"cat": pd.Categorical(["a", "b", "c", "a", "b", "c"])})
+   >>> df.cat.dtype.categories
+   Index(['a', 'b', 'c'], dtype='object')
+   >>> df
+     cat
+   0   a
+   1   b
+   2   c
+   3   a
+   4   b
+   5   c
+   >>> table = pa.Table.from_pandas(df)
+   >>> table
+   pyarrow.Table
+   cat: dictionary<values=string, indices=int8, ordered=0>
+   ----
+   cat: [  -- dictionary:
+   ["a","b","c"]  -- indices:
+   [0,1,2,0,1,2]]
 
 We can inspect the :class:`~.ChunkedArray` of the created table and see the
 same categories of the Pandas DataFrame.
 
-.. ipython:: python
+.. code-block:: python
 
-   column = table[0]
-   chunk = column.chunk(0)
-   chunk.dictionary
-   chunk.indices
+   >>> column = table[0]
+   >>> chunk = column.chunk(0)
+   >>> chunk.dictionary
+   <pyarrow.lib.StringArray object at ...>
+   [
+     "a",
+     "b",
+     "c"
+   ]
+   >>> chunk.indices
+   <pyarrow.lib.Int8Array object at ...>
+   [
+     0,
+     1,
+     2,
+     0,
+     1,
+     2
+   ]
 
 Datetime (Timestamp) types
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -195,14 +220,23 @@ Datetime (Timestamp) types
 use the ``datetime64[ns]`` type in Pandas and are converted to an Arrow
 :class:`~.TimestampArray`.
 
-.. ipython:: python
+.. code-block:: python
 
-   df = pd.DataFrame({"datetime": pd.date_range("2020-01-01T00:00:00Z", freq="h", periods=3)})
-   df.dtypes
-   df
-
-   table = pa.Table.from_pandas(df)
-   table
+   >>> df = pd.DataFrame({"datetime": pd.date_range("2020-01-01T00:00:00Z", freq="h", periods=3)})
+   >>> df.dtypes
+   datetime    datetime64[ns, UTC]
+   dtype: object
+   >>> df
+                      datetime
+   0 2020-01-01 00:00:00+00:00
+   1 2020-01-01 01:00:00+00:00
+   2 2020-01-01 02:00:00+00:00
+   >>> table = pa.Table.from_pandas(df)
+   >>> table
+   pyarrow.Table
+   datetime: timestamp[ns, tz=UTC]
+   ----
+   datetime: [[2020-01-01 00:00:00.000000000Z,...,2020-01-01 02:00:00.000000000Z]]
 
 In this example the Pandas Timestamp is time zone aware
 (``UTC`` on this case), and this information is used to create the Arrow
@@ -215,42 +249,54 @@ While dates can be handled using the ``datetime64[ns]`` type in
 pandas, some systems work with object arrays of Python's built-in
 ``datetime.date`` object:
 
-.. ipython:: python
+.. code-block:: python
 
-   from datetime import date
-   s = pd.Series([date(2018, 12, 31), None, date(2000, 1, 1)])
-   s
+   >>> from datetime import date
+   >>> s = pd.Series([date(2018, 12, 31), None, date(2000, 1, 1)])
+   >>> s
+   0    2018-12-31
+   1          None
+   2    2000-01-01
+   dtype: object
 
 When converting to an Arrow array, the ``date32`` type will be used by
 default:
 
-.. ipython:: python
+.. code-block:: python
 
-   arr = pa.array(s)
-   arr.type
-   arr[0]
+   >>> arr = pa.array(s)
+   >>> arr.type
+   DataType(date32[day])
+   >>> arr[0]
+   <pyarrow.Date32Scalar: datetime.date(2018, 12, 31)>
 
 To use the 64-bit ``date64``, specify this explicitly:
 
-.. ipython:: python
+.. code-block:: python
 
-   arr = pa.array(s, type='date64')
-   arr.type
+   >>> arr = pa.array(s, type='date64')
+   >>> arr.type
+   DataType(date64[ms])
 
 When converting back with ``to_pandas``, object arrays of
 ``datetime.date`` objects are returned:
 
-.. ipython:: python
+.. code-block:: python
 
-   arr.to_pandas()
+   >>> arr.to_pandas()
+   0    2018-12-31
+   1          None
+   2    2000-01-01
+   dtype: object
 
 If you want to use NumPy's ``datetime64`` dtype instead, pass
 ``date_as_object=False``:
 
-.. ipython:: python
+.. code-block:: python
 
-   s2 = pd.Series(arr.to_pandas(date_as_object=False))
-   s2.dtype
+   >>> s2 = pd.Series(arr.to_pandas(date_as_object=False))
+   >>> s2.dtype
+   dtype('<M8[ms]')
 
 .. warning::
 
@@ -264,21 +310,32 @@ Time types
 The builtin ``datetime.time`` objects inside Pandas data structures will be
 converted to an Arrow ``time64`` and :class:`~.Time64Array` respectively.
 
-.. ipython:: python
+.. code-block:: python
 
-   from datetime import time
-   s = pd.Series([time(1, 1, 1), time(2, 2, 2)])
-   s
-
-   arr = pa.array(s)
-   arr.type
-   arr
+   >>> from datetime import time
+   >>> s = pd.Series([time(1, 1, 1), time(2, 2, 2)])
+   >>> s
+   0    01:01:01
+   1    02:02:02
+   dtype: object
+   >>> arr = pa.array(s)
+   >>> arr.type
+   Time64Type(time64[us])
+   >>> arr
+   <pyarrow.lib.Time64Array object at ...>
+   [
+     01:01:01.000000,
+     02:02:02.000000
+   ]
 
 When converting to pandas, arrays of ``datetime.time`` objects are returned:
 
-.. ipython:: python
+.. code-block:: python
 
-   arr.to_pandas()
+   >>> arr.to_pandas()
+   0    01:01:01
+   1    02:02:02
+   dtype: object
 
 Nullable types
 --------------
@@ -294,7 +351,7 @@ missing values are present:
 
    >>> arr = pa.array([1, 2, None])
    >>> arr
-   <pyarrow.lib.Int64Array object at 0x7f07d467c640>
+   <pyarrow.lib.Int64Array object at ...>
    [
      1,
      2,
@@ -321,7 +378,6 @@ round trip conversion for those:
 
    >>> table = pa.table(df)
    >>> table
-   Out[32]:
    pyarrow.Table
    a: int64
    ----
@@ -371,22 +427,21 @@ dictionary becomes:
 
 .. code-block:: python
 
-   dtype_mapping = {
-       pa.int8(): pd.Int8Dtype(),
-       pa.int16(): pd.Int16Dtype(),
-       pa.int32(): pd.Int32Dtype(),
-       pa.int64(): pd.Int64Dtype(),
-       pa.uint8(): pd.UInt8Dtype(),
-       pa.uint16(): pd.UInt16Dtype(),
-       pa.uint32(): pd.UInt32Dtype(),
-       pa.uint64(): pd.UInt64Dtype(),
-       pa.bool_(): pd.BooleanDtype(),
-       pa.float32(): pd.Float32Dtype(),
-       pa.float64(): pd.Float64Dtype(),
-       pa.string(): pd.StringDtype(),
-   }
-
-   df = table.to_pandas(types_mapper=dtype_mapping.get)
+   >>> dtype_mapping = {
+   ...     pa.int8(): pd.Int8Dtype(),
+   ...     pa.int16(): pd.Int16Dtype(),
+   ...     pa.int32(): pd.Int32Dtype(),
+   ...     pa.int64(): pd.Int64Dtype(),
+   ...     pa.uint8(): pd.UInt8Dtype(),
+   ...     pa.uint16(): pd.UInt16Dtype(),
+   ...     pa.uint32(): pd.UInt32Dtype(),
+   ...     pa.uint64(): pd.UInt64Dtype(),
+   ...     pa.bool_(): pd.BooleanDtype(),
+   ...     pa.float32(): pd.Float32Dtype(),
+   ...     pa.float64(): pd.Float64Dtype(),
+   ...     pa.string(): pd.StringDtype(),
+   ... }
+   >>> df = table.to_pandas(types_mapper=dtype_mapping.get)
 
 
 When using the pandas API for reading Parquet files (``pd.read_parquet(..)``),
@@ -394,7 +449,7 @@ this can also be achieved by passing ``use_nullable_dtypes``:
 
 .. code-block:: python
 
-   df = pd.read_parquet(path, use_nullable_dtypes=True)
+   >>> df = pd.read_parquet(path, use_nullable_dtypes=True)  # doctest: +SKIP
 
 
 Memory Usage and Zero Copy
@@ -463,8 +518,8 @@ Used together, the call
 
 .. code-block:: python
 
-   df = table.to_pandas(split_blocks=True, self_destruct=True)
-   del table  # not necessary, but a good practice
+   >>> df = table.to_pandas(split_blocks=True, self_destruct=True)
+   >>> del table  # not necessary, but a good practice
 
 will yield significantly lower memory usage in some scenarios. Without these
 options, ``to_pandas`` will always double memory.

--- a/docs/source/python/parquet.rst
+++ b/docs/source/python/parquet.rst
@@ -214,7 +214,7 @@ Finer-grained Reading and Writing
      num_rows: 3
      num_row_groups: 1
      format_version: 2.6
-     serialized_size: 2733
+     serialized_size: ...
    >>> parquet_file.schema
    <pyarrow._parquet.ParquetSchema object at ...>
    required group field_id=-1 schema {

--- a/docs/source/python/parquet.rst
+++ b/docs/source/python/parquet.rst
@@ -307,7 +307,7 @@ such as the row groups and column chunk metadata and statistics:
    >>> metadata.row_group(0).column(0)
    <pyarrow._parquet.ColumnChunkMetaData object at ...>
      file_offset: 0
-     file_path: 
+     file_path:
      physical_type: DOUBLE
      num_values: 3
      path_in_schema: one
@@ -697,7 +697,6 @@ if specified as a URI:
 
 .. code-block:: python
 
-    
    >>> table = pq.read_table("s3://bucket/object/key/prefix")  # doctest: +SKIP
 
 Other filesystems can still be supported if there is an
@@ -772,12 +771,12 @@ defined by :class:`pyarrow.parquet.encryption.KmsClient` as following:
    ...       pe.KmsClient.__init__(self)
    ...       # Any KMS-specific initialization based on
    ...       # kms_connection_configuration comes here
-   ... 
+   ...
    ...    def wrap_key(self, key_bytes, master_key_identifier):
    ...       wrapped_key = ... # call KMS to wrap key_bytes with key specified by
    ...                         # master_key_identifier
    ...       return wrapped_key
-   ... 
+   ...
    ...    def unwrap_key(self, wrapped_key, master_key_identifier):
    ...       key_bytes = ... # call KMS to unwrap wrapped_key with key specified by
    ...                       # master_key_identifier

--- a/docs/source/python/parquet.rst
+++ b/docs/source/python/parquet.rst
@@ -276,7 +276,7 @@ The ``FileMetaData`` of a Parquet file can be accessed through
      num_rows: 3
      num_row_groups: 1
      format_version: 2.6
-     serialized_size: 2733
+     serialized_size: ...
 
 or can also be read directly using :func:`~parquet.read_metadata`:
 
@@ -290,7 +290,7 @@ or can also be read directly using :func:`~parquet.read_metadata`:
      num_rows: 3
      num_row_groups: 1
      format_version: 2.6
-     serialized_size: 2733
+     serialized_size: ...
 
 The returned ``FileMetaData`` object allows to inspect the
 `Parquet file metadata <https://github.com/apache/parquet-format#metadata>`__,
@@ -588,7 +588,7 @@ the same:
       num_rows: 3
       num_row_groups: 1
       format_version: 2.6
-      serialized_size: 2004
+      serialized_size: ...
 
 Reading from Partitioned Datasets
 ------------------------------------------------

--- a/docs/source/python/parquet.rst
+++ b/docs/source/python/parquet.rst
@@ -139,13 +139,13 @@ but won't help much with resident memory consumption.
 
 .. code-block:: python
 
-      >>> pq_array = pa.parquet.read_table(path, memory_map=True)  # doctest: +SKIP
-      >>> print("RSS: {}MB".format(pa.total_allocated_bytes() >> 20))  # doctest: +SKIP
-      RSS: 4299MB
+   >>> pq_array = pa.parquet.read_table(path, memory_map=True)  # doctest: +SKIP
+   >>> print("RSS: {}MB".format(pa.total_allocated_bytes() >> 20))  # doctest: +SKIP
+   RSS: 4299MB
 
-      >>> pq_array = pa.parquet.read_table(path, memory_map=False)  # doctest: +SKIP
-      >>> print("RSS: {}MB".format(pa.total_allocated_bytes() >> 20))  # doctest: +SKIP
-      RSS: 4299MB
+   >>> pq_array = pa.parquet.read_table(path, memory_map=False)  # doctest: +SKIP
+   >>> print("RSS: {}MB".format(pa.total_allocated_bytes() >> 20))  # doctest: +SKIP
+   RSS: 4299MB
 
 If you need to deal with Parquet data bigger than memory,
 the :ref:`dataset` and partitioning is probably what you are looking for.
@@ -581,14 +581,14 @@ the same:
    ...     metadata_collector=metadata_collector
    ... )
 
-    >>> pq.read_metadata("_metadata")
-    <pyarrow._parquet.FileMetaData object at ...>
-      created_by: parquet-cpp-arrow version ...
-      num_columns: 3
-      num_rows: 3
-      num_row_groups: 1
-      format_version: 2.6
-      serialized_size: ...
+   >>> pq.read_metadata("_metadata")
+   <pyarrow._parquet.FileMetaData object at ...>
+     created_by: parquet-cpp-arrow version ...
+     num_columns: 3
+     num_rows: 3
+     num_row_groups: 1
+     format_version: 2.6
+     serialized_size: ...
 
 Reading from Partitioned Datasets
 ------------------------------------------------

--- a/docs/source/python/parquet.rst
+++ b/docs/source/python/parquet.rst
@@ -499,7 +499,7 @@ individual table writes are wrapped using ``with`` statements so the
 .. code-block:: python
 
    >>> # Remote file-system example
-   >>> from pyarrow.fs import HadoopFileSystem
+   >>> from pyarrow.fs import HadoopFileSystem  # doctest: +SKIP
    >>> fs = HadoopFileSystem(host, port, user=user, kerb_ticket=ticket_cache_path)  # doctest: +SKIP
    >>> pq.write_to_dataset(table, root_path='dataset_name',  # doctest: +SKIP
    ...                     partition_cols=['one', 'two'], filesystem=fs)
@@ -686,7 +686,7 @@ filesystems, through the ``filesystem`` keyword:
 
    >>> from pyarrow import fs
 
-   >>> s3  = fs.S3FileSystem(region="us-east-2")
+   >>> s3  = fs.S3FileSystem(region="us-east-2")  # doctest: +SKIP
    >>> table = pq.read_table("bucket/object/key/prefix", filesystem=s3)  # doctest: +SKIP
 
 Currently, :class:`HDFS <pyarrow.fs.HadoopFileSystem>` and

--- a/docs/source/python/parquet.rst
+++ b/docs/source/python/parquet.rst
@@ -44,9 +44,9 @@ Obtaining pyarrow with Parquet Support
 If you installed ``pyarrow`` with pip or conda, it should be built with Parquet
 support bundled:
 
-.. ipython:: python
+.. code-block:: python
 
-   import pyarrow.parquet as pq
+   >>> import pyarrow.parquet as pq
 
 If you are building ``pyarrow`` from source, you must use ``-DARROW_PARQUET=ON``
 when compiling the C++ libraries and enable the Parquet extensions when
@@ -62,47 +62,60 @@ read and write the :ref:`pyarrow.Table <data.table>` object, respectively.
 
 Let's look at a simple table:
 
-.. ipython:: python
+.. code-block:: python
 
-   import numpy as np
-   import pandas as pd
-   import pyarrow as pa
-
-   df = pd.DataFrame({'one': [-1, np.nan, 2.5],
-                      'two': ['foo', 'bar', 'baz'],
-                      'three': [True, False, True]},
-                      index=list('abc'))
-   table = pa.Table.from_pandas(df)
+   >>> import numpy as np
+   >>> import pandas as pd
+   >>> import pyarrow as pa
+   >>> df = pd.DataFrame({'one': [-1, np.nan, 2.5],
+   ...                    'two': ['foo', 'bar', 'baz'],
+   ...                    'three': [True, False, True]},
+   ...                    index=list('abc'))
+   >>> table = pa.Table.from_pandas(df)
 
 We write this to Parquet format with ``write_table``:
 
-.. ipython:: python
+.. code-block:: python
 
-   import pyarrow.parquet as pq
-   pq.write_table(table, 'example.parquet')
+   >>> import pyarrow.parquet as pq
+   >>> pq.write_table(table, 'example.parquet')
 
 This creates a single Parquet file. In practice, a Parquet dataset may consist
 of many files in many directories. We can read a single file back with
 ``read_table``:
 
-.. ipython:: python
+.. code-block:: python
 
-   table2 = pq.read_table('example.parquet')
-   table2.to_pandas()
+   >>> table2 = pq.read_table('example.parquet')
+   >>> table2.to_pandas()
+      one  two  three
+   a -1.0  foo   True
+   b  NaN  bar  False
+   c  2.5  baz   True
 
 You can pass a subset of columns to read, which can be much faster than reading
 the whole file (due to the columnar layout):
 
-.. ipython:: python
+.. code-block:: python
 
-   pq.read_table('example.parquet', columns=['one', 'three'])
+   >>> pq.read_table('example.parquet', columns=['one', 'three'])
+   pyarrow.Table
+   one: double
+   three: bool
+   ----
+   one: [[-1,null,2.5]]
+   three: [[true,false,true]]
 
 When reading a subset of columns from a file that used a Pandas dataframe as the
 source, we use ``read_pandas`` to maintain any additional index column data:
 
-.. ipython:: python
+.. code-block:: python
 
-   pq.read_pandas('example.parquet', columns=['two']).to_pandas()
+   >>> pq.read_pandas('example.parquet', columns=['two']).to_pandas()
+      two
+   a  foo
+   b  bar
+   c  baz
 
 We do not need to use a string to specify the origin of the file. It can be any of:
 
@@ -126,12 +139,12 @@ but won't help much with resident memory consumption.
 
 .. code-block:: python
 
-      >>> pq_array = pa.parquet.read_table("area1.parquet", memory_map=True)
-      >>> print("RSS: {}MB".format(pa.total_allocated_bytes() >> 20))
+      >>> pq_array = pa.parquet.read_table(path, memory_map=True)  # doctest: +SKIP
+      >>> print("RSS: {}MB".format(pa.total_allocated_bytes() >> 20))  # doctest: +SKIP
       RSS: 4299MB
 
-      >>> pq_array = pa.parquet.read_table("area1.parquet", memory_map=False)
-      >>> print("RSS: {}MB".format(pa.total_allocated_bytes() >> 20))
+      >>> pq_array = pa.parquet.read_table(path, memory_map=False)  # doctest: +SKIP
+      >>> print("RSS: {}MB".format(pa.total_allocated_bytes() >> 20))  # doctest: +SKIP
       RSS: 4299MB
 
 If you need to deal with Parquet data bigger than memory,
@@ -164,22 +177,25 @@ one or more special columns are added to keep track of the index (row
 labels). Storing the index takes extra space, so if your index is not valuable,
 you may choose to omit it by passing ``preserve_index=False``
 
-.. ipython:: python
+.. code-block:: python
 
-   df = pd.DataFrame({'one': [-1, np.nan, 2.5],
-                      'two': ['foo', 'bar', 'baz'],
-                      'three': [True, False, True]},
-                      index=list('abc'))
-   df
-   table = pa.Table.from_pandas(df, preserve_index=False)
+   >>> df = pd.DataFrame({'one': [-1, np.nan, 2.5],
+   ...                    'two': ['foo', 'bar', 'baz'],
+   ...                    'three': [True, False, True]},
+   ...                    index=list('abc'))
+   >>> table = pa.Table.from_pandas(df, preserve_index=False)
 
 Then we have:
 
-.. ipython:: python
+.. code-block:: python
 
-   pq.write_table(table, 'example_noindex.parquet')
-   t = pq.read_table('example_noindex.parquet')
-   t.to_pandas()
+   >>> pq.write_table(table, 'example_noindex.parquet')
+   >>> t = pq.read_table('example_noindex.parquet')
+   >>> t.to_pandas()
+      one  two  three
+   0 -1.0  foo   True
+   1  NaN  bar  False
+   2  2.5  baz   True
 
 Here you see the index did not survive the round trip.
 
@@ -188,11 +204,26 @@ Finer-grained Reading and Writing
 
 ``read_table`` uses the :class:`~.ParquetFile` class, which has other features:
 
-.. ipython:: python
+.. code-block:: python
 
-   parquet_file = pq.ParquetFile('example.parquet')
-   parquet_file.metadata
-   parquet_file.schema
+   >>> parquet_file = pq.ParquetFile('example.parquet')
+   >>> parquet_file.metadata
+   <pyarrow._parquet.FileMetaData object at ...>
+     created_by: parquet-cpp-arrow version ...
+     num_columns: 4
+     num_rows: 3
+     num_row_groups: 1
+     format_version: 2.6
+     serialized_size: 2733
+   >>> parquet_file.schema
+   <pyarrow._parquet.ParquetSchema object at ...>
+   required group field_id=-1 schema {
+     optional double field_id=-1 one;
+     optional binary field_id=-1 two (String);
+     optional boolean field_id=-1 three;
+     optional binary field_id=-1 __index_level_0__ (String);
+   }
+   <BLANKLINE>
 
 As you can learn more in the `Apache Parquet format
 <https://github.com/apache/parquet-format>`_, a Parquet file consists of
@@ -200,22 +231,33 @@ multiple row groups. ``read_table`` will read all of the row groups and
 concatenate them into a single table. You can read individual row groups with
 ``read_row_group``:
 
-.. ipython:: python
+.. code-block:: python
 
-   parquet_file.num_row_groups
-   parquet_file.read_row_group(0)
+   >>> parquet_file.num_row_groups
+   1
+   >>> parquet_file.read_row_group(0)
+   pyarrow.Table
+   one: double
+   two: string
+   three: bool
+   __index_level_0__: string
+   ----
+   one: [[-1,null,2.5]]
+   two: [["foo","bar","baz"]]
+   three: [[true,false,true]]
+   __index_level_0__: [["a","b","c"]]
 
 We can similarly write a Parquet file with multiple row groups by using
 ``ParquetWriter``:
 
-.. ipython:: python
+.. code-block:: python
 
-   with pq.ParquetWriter('example2.parquet', table.schema) as writer:
-      for i in range(3):
-         writer.write_table(table)
-
-   pf2 = pq.ParquetFile('example2.parquet')
-   pf2.num_row_groups
+   >>> with pq.ParquetWriter('example2.parquet', table.schema) as writer:
+   ...     for i in range(3):
+   ...         writer.write_table(table)
+   >>> pf2 = pq.ParquetFile('example2.parquet')
+   >>> pf2.num_row_groups
+   3
 
 Inspecting the Parquet File Metadata
 ------------------------------------
@@ -223,34 +265,73 @@ Inspecting the Parquet File Metadata
 The ``FileMetaData`` of a Parquet file can be accessed through
 :class:`~.ParquetFile` as shown above:
 
-.. ipython:: python
+.. code-block:: python
 
-   parquet_file = pq.ParquetFile('example.parquet')
-   metadata = parquet_file.metadata
+   >>> parquet_file = pq.ParquetFile('example.parquet')
+   >>> metadata = parquet_file.metadata
+   >>> metadata
+   <pyarrow._parquet.FileMetaData object at ...>
+     created_by: parquet-cpp-arrow version ...
+     num_columns: 4
+     num_rows: 3
+     num_row_groups: 1
+     format_version: 2.6
+     serialized_size: 2733
 
 or can also be read directly using :func:`~parquet.read_metadata`:
 
-.. ipython:: python
+.. code-block:: python
 
-   metadata = pq.read_metadata('example.parquet')
-   metadata
+   >>> metadata = pq.read_metadata('example.parquet')
+   >>> metadata
+   <pyarrow._parquet.FileMetaData object at ...>
+     created_by: parquet-cpp-arrow version ...
+     num_columns: 4
+     num_rows: 3
+     num_row_groups: 1
+     format_version: 2.6
+     serialized_size: 2733
 
 The returned ``FileMetaData`` object allows to inspect the
 `Parquet file metadata <https://github.com/apache/parquet-format#metadata>`__,
 such as the row groups and column chunk metadata and statistics:
 
-.. ipython:: python
+.. code-block:: python
 
-   metadata.row_group(0)
-   metadata.row_group(0).column(0)
-
-.. ipython:: python
-   :suppress:
-
-   !rm example.parquet
-   !rm example_noindex.parquet
-   !rm example2.parquet
-   !rm example3.parquet
+   >>> metadata.row_group(0)
+   <pyarrow._parquet.RowGroupMetaData object at ...>
+     num_columns: 4
+     num_rows: 3
+     total_byte_size: 290
+     sorting_columns: ()
+   >>> metadata.row_group(0).column(0)
+   <pyarrow._parquet.ColumnChunkMetaData object at ...>
+     file_offset: 0
+     file_path: 
+     physical_type: DOUBLE
+     num_values: 3
+     path_in_schema: one
+     is_stats_set: True
+     statistics:
+       <pyarrow._parquet.Statistics object at ...>
+         has_min_max: True
+         min: -1.0
+         max: 2.5
+         null_count: 1
+         distinct_count: None
+         num_values: 2
+         physical_type: DOUBLE
+         logical_type: None
+         converted_type (legacy): NONE
+     geo_statistics:
+       None
+     compression: SNAPPY
+     encodings: ('PLAIN', 'RLE', 'RLE_DICTIONARY')
+     has_dictionary_page: True
+     dictionary_page_offset: 4
+     data_page_offset: 36
+     total_compressed_size: 106
+     total_uncompressed_size: 102
 
 Data Type Handling
 ------------------
@@ -266,7 +347,19 @@ and improved performance for columns with many repeated string values.
 
 .. code-block:: python
 
-   pq.read_table(table, where, read_dictionary=['binary_c0', 'stringb_c2'])
+   >>> pq.read_table('example.parquet', read_dictionary=['two'])
+   pyarrow.Table
+   one: double
+   two: dictionary<values=string, indices=int32, ordered=0>
+   three: bool
+   __index_level_0__: string
+   ----
+   one: [[-1,null,2.5]]
+   two: [  -- dictionary:
+   ["foo","bar","baz"]  -- indices:
+   [0,1,2]]
+   three: [[true,false,true]]
+   __index_level_0__: [["a","b","c"]]
 
 Storing timestamps
 ~~~~~~~~~~~~~~~~~~
@@ -282,7 +375,7 @@ the desired resolution:
 
 .. code-block:: python
 
-   pq.write_table(table, where, coerce_timestamps='ms')
+   >>> pq.write_table(table, 'example.parquet', coerce_timestamps='ms')
 
 If a cast to a lower resolution value may result in a loss of data, by default
 an exception will be raised. This can be suppressed by passing
@@ -290,15 +383,15 @@ an exception will be raised. This can be suppressed by passing
 
 .. code-block:: python
 
-   pq.write_table(table, where, coerce_timestamps='ms',
-                  allow_truncated_timestamps=True)
+   >>> pq.write_table(table, 'example.parquet', coerce_timestamps='ms',
+   ...                allow_truncated_timestamps=True)
 
 Timestamps with nanoseconds can be stored without casting when using the
 more recent Parquet format version 2.6:
 
 .. code-block:: python
 
-   pq.write_table(table, where, version='2.6')
+   >>> pq.write_table(table, 'example.parquet', version='2.6')
 
 However, many Parquet readers do not yet support this newer format version, and
 therefore the default is to write version 1.0 files. When compatibility across
@@ -313,7 +406,7 @@ this format, set the ``use_deprecated_int96_timestamps`` option to
 
 .. code-block:: python
 
-   pq.write_table(table, where, use_deprecated_int96_timestamps=True)
+   >>> pq.write_table(table, 'example.parquet', use_deprecated_int96_timestamps=True)
 
 Compression, Encoding, and File Compatibility
 ---------------------------------------------
@@ -325,7 +418,7 @@ plain encoding. Whether dictionary encoding is used can be toggled using the
 
 .. code-block:: python
 
-   pq.write_table(table, where, use_dictionary=False)
+   >>> pq.write_table(table, 'example.parquet', use_dictionary=False)
 
 The data pages within a column in a row group can be compressed after the
 encoding passes (dictionary, RLE encoding). In PyArrow we use Snappy
@@ -334,12 +427,12 @@ also supported:
 
 .. code-block:: python
 
-   pq.write_table(table, where, compression='snappy')
-   pq.write_table(table, where, compression='gzip')
-   pq.write_table(table, where, compression='brotli')
-   pq.write_table(table, where, compression='zstd')
-   pq.write_table(table, where, compression='lz4')
-   pq.write_table(table, where, compression='none')
+   >>> pq.write_table(table, 'example.parquet', compression='snappy')
+   >>> pq.write_table(table, 'example.parquet', compression='gzip')
+   >>> pq.write_table(table, 'example.parquet', compression='brotli')
+   >>> pq.write_table(table, 'example.parquet', compression='zstd')
+   >>> pq.write_table(table, 'example.parquet', compression='lz4')
+   >>> pq.write_table(table, 'example.parquet', compression='none')
 
 Snappy generally results in better performance, while Gzip may yield smaller
 files.
@@ -348,8 +441,8 @@ These settings can also be set on a per-column basis:
 
 .. code-block:: python
 
-   pq.write_table(table, where, compression={'foo': 'snappy', 'bar': 'gzip'},
-                  use_dictionary=['foo', 'bar'])
+   >>> pq.write_table(table, 'example.parquet', compression={'one': 'snappy', 'two': 'gzip'},
+   ...                use_dictionary=['one', 'two'])
 
 Partitioned Datasets (Multiple Files)
 ------------------------------------------------
@@ -390,9 +483,9 @@ added is to use the local filesystem.
 
 .. code-block:: python
 
-   # Local dataset write
-   pq.write_to_dataset(table, root_path='dataset_name',
-                       partition_cols=['one', 'two'])
+   >>> # Local dataset write
+   >>> pq.write_to_dataset(table, root_path='dataset_name',
+   ...                     partition_cols=['one', 'two'])
 
 The root path in this case specifies the parent directory to which data will be
 saved. The partition columns are the column names by which to partition the
@@ -405,11 +498,11 @@ individual table writes are wrapped using ``with`` statements so the
 
 .. code-block:: python
 
-   # Remote file-system example
-   from pyarrow.fs import HadoopFileSystem
-   fs = HadoopFileSystem(host, port, user=user, kerb_ticket=ticket_cache_path)
-   pq.write_to_dataset(table, root_path='dataset_name',
-                       partition_cols=['one', 'two'], filesystem=fs)
+   >>> # Remote file-system example
+   >>> from pyarrow.fs import HadoopFileSystem
+   >>> fs = HadoopFileSystem(host, port, user=user, kerb_ticket=ticket_cache_path)  # doctest: +SKIP
+   >>> pq.write_to_dataset(table, root_path='dataset_name',  # doctest: +SKIP
+   ...                     partition_cols=['one', 'two'], filesystem=fs)
 
 Compatibility Note: if using ``pq.write_to_dataset`` to create a table that
 will then be used by HIVE then partition column values must be compatible with
@@ -439,18 +532,19 @@ combine and write them manually:
 
 .. code-block:: python
 
-   # Write a dataset and collect metadata information of all written files
-   metadata_collector = []
-   pq.write_to_dataset(table, root_path, metadata_collector=metadata_collector)
+   >>> # Write a dataset and collect metadata information of all written files
+   >>> metadata_collector = []
+   >>> root_path = "dataset_name_1"
+   >>> pq.write_to_dataset(table, root_path, metadata_collector=metadata_collector)
 
-   # Write the ``_common_metadata`` parquet file without row groups statistics
-   pq.write_metadata(table.schema, root_path / '_common_metadata')
+   >>> # Write the ``_common_metadata`` parquet file without row groups statistics
+   >>> pq.write_metadata(table.schema, root_path + '/_common_metadata')
 
-   # Write the ``_metadata`` parquet file with row groups statistics of all files
-   pq.write_metadata(
-       table.schema, root_path / '_metadata',
-       metadata_collector=metadata_collector
-   )
+   >>> # Write the ``_metadata`` parquet file with row groups statistics of all files
+   >>> pq.write_metadata(
+   ...     table.schema, root_path + '/_metadata',
+   ...     metadata_collector=metadata_collector
+   ... )
 
 When not using the :func:`~pyarrow.parquet.write_to_dataset` function, but
 writing the individual files of the partitioned dataset using
@@ -463,26 +557,38 @@ the same:
 
 .. code-block:: python
 
-   metadata_collector = []
-   pq.write_table(
-       table1, root_path / "year=2017/data1.parquet",
-       metadata_collector=metadata_collector
-   )
+   >>> import os
+   >>> os.mkdir("year=2017")
 
-   # set the file path relative to the root of the partitioned dataset
-   metadata_collector[-1].set_file_path("year=2017/data1.parquet")
+   >>> metadata_collector = []
+   >>> pq.write_table(
+   ...     table, "year=2017/data1.parquet",
+   ...     metadata_collector=metadata_collector
+   ... )
 
-   # combine and write the metadata
-   metadata = metadata_collector[0]
-   for _meta in metadata_collector[1:]:
-       metadata.append_row_groups(_meta)
-   metadata.write_metadata_file(root_path / "_metadata")
+   >>> # set the file path relative to the root of the partitioned dataset
+   >>> metadata_collector[-1].set_file_path("year=2017/data1.parquet")
 
-   # or use pq.write_metadata to combine and write in a single step
-   pq.write_metadata(
-       table1.schema, root_path / "_metadata",
-       metadata_collector=metadata_collector
-   )
+   >>> # combine and write the metadata
+   >>> metadata = metadata_collector[0]
+   >>> for _meta in metadata_collector[1:]:
+   ...     metadata.append_row_groups(_meta)
+   >>> metadata.write_metadata_file("_metadata")
+
+   >>> # or use pq.write_metadata to combine and write in a single step
+   >>> pq.write_metadata(
+   ...     table.schema, "_metadata",
+   ...     metadata_collector=metadata_collector
+   ... )
+
+    >>> pq.read_metadata("_metadata")
+    <pyarrow._parquet.FileMetaData object at ...>
+      created_by: parquet-cpp-arrow version ...
+      num_columns: 3
+      num_rows: 3
+      num_row_groups: 1
+      format_version: 2.6
+      serialized_size: 2004
 
 Reading from Partitioned Datasets
 ------------------------------------------------
@@ -493,8 +599,29 @@ such as those produced by Hive:
 
 .. code-block:: python
 
-   dataset = pq.ParquetDataset('dataset_name/')
-   table = dataset.read()
+   >>> dataset = pq.ParquetDataset('dataset_name/')
+   >>> table = dataset.read()
+   >>> table
+   pyarrow.Table
+   three: bool
+   one: dictionary<values=string, indices=int32, ordered=0>
+   two: dictionary<values=string, indices=int32, ordered=0>
+   ----
+   three: [[true],[true],[false]]
+   one: [  -- dictionary:
+   ["-1","2.5"]  -- indices:
+   [0],  -- dictionary:
+   ["-1","2.5"]  -- indices:
+   [1],  -- dictionary:
+   [null]  -- indices:
+   [0]]
+   two: [  -- dictionary:
+   ["foo","baz","bar"]  -- indices:
+   [0],  -- dictionary:
+   ["foo","baz","bar"]  -- indices:
+   [1],  -- dictionary:
+   ["foo","baz","bar"]  -- indices:
+   [2]]
 
 You can also use the convenience function ``read_table`` exposed by
 ``pyarrow.parquet`` that avoids the need for an additional Dataset object
@@ -502,7 +629,7 @@ creation step.
 
 .. code-block:: python
 
-   table = pq.read_table('dataset_name')
+   >>> table = pq.read_table('dataset_name')
 
 Note: the partition columns in the original table will have their types
 converted to Arrow dictionary types (pandas categorical) on load. Ordering of
@@ -557,10 +684,10 @@ filesystems, through the ``filesystem`` keyword:
 
 .. code-block:: python
 
-    from pyarrow import fs
+   >>> from pyarrow import fs
 
-    s3  = fs.S3FileSystem(region="us-east-2")
-    table = pq.read_table("bucket/object/key/prefix", filesystem=s3)
+   >>> s3  = fs.S3FileSystem(region="us-east-2")
+   >>> table = pq.read_table("bucket/object/key/prefix", filesystem=s3)  # doctest: +SKIP
 
 Currently, :class:`HDFS <pyarrow.fs.HadoopFileSystem>` and
 :class:`Amazon S3-compatible storage <pyarrow.fs.S3FileSystem>` are
@@ -570,7 +697,8 @@ if specified as a URI:
 
 .. code-block:: python
 
-    table = pq.read_table("s3://bucket/object/key/prefix")
+    
+   >>> table = pq.read_table("s3://bucket/object/key/prefix")  # doctest: +SKIP
 
 Other filesystems can still be supported if there is an
 `fsspec <https://filesystem-spec.readthedocs.io/en/latest/>`__-compatible
@@ -580,10 +708,9 @@ One example is Azure Blob storage, which can be interfaced through the
 
 .. code-block:: python
 
-    from adlfs import AzureBlobFileSystem
-
-    abfs = AzureBlobFileSystem(account_name="XXXX", account_key="XXXX", container_name="XXXX")
-    table = pq.read_table("file.parquet", filesystem=abfs)
+   >>> from adlfs import AzureBlobFileSystem  # doctest: +SKIP
+   >>> abfs = AzureBlobFileSystem(account_name="XXXX", account_key="XXXX", container_name="XXXX")  # doctest: +SKIP
+   >>> table = pq.read_table("file.parquet", filesystem=abfs)  # doctest: +SKIP
 
 Parquet Modular Encryption (Columnar Encryption)
 ------------------------------------------------
@@ -605,20 +732,20 @@ Writing an encrypted Parquet file:
 
 .. code-block:: python
 
-   encryption_properties = crypto_factory.file_encryption_properties(
-                                    kms_connection_config, encryption_config)
-   with pq.ParquetWriter(filename, schema,
-                        encryption_properties=encryption_properties) as writer:
-      writer.write_table(table)
+   >>> encryption_properties = crypto_factory.file_encryption_properties(  # doctest: +SKIP
+   ...                                  kms_connection_config, encryption_config)
+   >>> with pq.ParquetWriter(filename, schema,  # doctest: +SKIP
+   ...                      encryption_properties=encryption_properties) as writer:
+   ...    writer.write_table(table)
 
 Reading an encrypted Parquet file:
 
 .. code-block:: python
 
-   decryption_properties = crypto_factory.file_decryption_properties(
-                                                    kms_connection_config)
-   parquet_file = pq.ParquetFile(filename,
-                                 decryption_properties=decryption_properties)
+   >>> decryption_properties = crypto_factory.file_decryption_properties(  # doctest: +SKIP
+   ...                                                  kms_connection_config)
+   >>> parquet_file = pq.ParquetFile(filename,  # doctest: +SKIP
+   ...                               decryption_properties=decryption_properties)
 
 
 In order to create the encryption and decryption properties, a
@@ -637,25 +764,24 @@ defined by :class:`pyarrow.parquet.encryption.KmsClient` as following:
 
 .. code-block:: python
 
-   import pyarrow.parquet.encryption as pe
-
-   class MyKmsClient(pe.KmsClient):
-
-      """An example KmsClient implementation skeleton"""
-      def __init__(self, kms_connection_configuration):
-         pe.KmsClient.__init__(self)
-         # Any KMS-specific initialization based on
-         # kms_connection_configuration comes here
-
-      def wrap_key(self, key_bytes, master_key_identifier):
-         wrapped_key = ... # call KMS to wrap key_bytes with key specified by
-                           # master_key_identifier
-         return wrapped_key
-
-      def unwrap_key(self, wrapped_key, master_key_identifier):
-         key_bytes = ... # call KMS to unwrap wrapped_key with key specified by
-                         # master_key_identifier
-         return key_bytes
+   >>> import pyarrow.parquet.encryption as pe
+   >>> class MyKmsClient(pe.KmsClient):
+   ...
+   ...    """An example KmsClient implementation skeleton"""
+   ...    def __init__(self, kms_connection_configuration):
+   ...       pe.KmsClient.__init__(self)
+   ...       # Any KMS-specific initialization based on
+   ...       # kms_connection_configuration comes here
+   ... 
+   ...    def wrap_key(self, key_bytes, master_key_identifier):
+   ...       wrapped_key = ... # call KMS to wrap key_bytes with key specified by
+   ...                         # master_key_identifier
+   ...       return wrapped_key
+   ... 
+   ...    def unwrap_key(self, wrapped_key, master_key_identifier):
+   ...       key_bytes = ... # call KMS to unwrap wrapped_key with key specified by
+   ...                       # master_key_identifier
+   ...       return key_bytes
 
 The concrete implementation will be loaded at runtime by a factory function
 provided by the user. This factory function will be used to initialize the
@@ -666,10 +792,10 @@ For example, in order to use the ``MyKmsClient`` defined above:
 
 .. code-block:: python
 
-   def kms_client_factory(kms_connection_configuration):
-      return MyKmsClient(kms_connection_configuration)
+   >>> def kms_client_factory(kms_connection_configuration):
+   ...    return MyKmsClient(kms_connection_configuration)
 
-   crypto_factory = CryptoFactory(kms_client_factory)
+   >>> crypto_factory = pe.CryptoFactory(kms_client_factory)
 
 An :download:`example <../../../python/examples/parquet_encryption/sample_vault_kms_client.py>`
 of such a class for an open source
@@ -732,12 +858,12 @@ An example encryption configuration:
 
 .. code-block:: python
 
-   encryption_config = pq.EncryptionConfiguration(
-      footer_key="footer_key_name",
-      column_keys={
-         "column_key_name": ["Column1", "Column2"],
-      },
-   )
+   >>> encryption_config = pe.EncryptionConfiguration(
+   ...    footer_key="footer_key_name",
+   ...    column_keys={
+   ...       "column_key_name": ["Column1", "Column2"],
+   ...    },
+   ... )
 
 .. note::
 
@@ -757,7 +883,7 @@ all columns are encrypted with the same key identified by ``column_key_id``:
 
 .. code-block:: python
 
-   import pyarrow.parquet.encryption as pe
+   >>> import pyarrow.parquet.encryption as pe
 
    schema = pa.schema([
      ("MapColumn", pa.map_(pa.string(), pa.int32())),
@@ -776,19 +902,19 @@ some inner fields are encrypted with the same key identified by ``column_key_id`
 
 .. code-block:: python
 
-   import pyarrow.parquet.encryption as pe
+   >>> import pyarrow.parquet.encryption as pe
 
-   schema = pa.schema([
-     ("MapColumn", pa.map_(pa.string(), pa.int32())),
-     ("StructColumn", pa.struct([("f1", pa.int32()), ("f2", pa.string())])),
-   ])
+   >>> schema = pa.schema([
+   ...   ("MapColumn", pa.map_(pa.string(), pa.int32())),
+   ...   ("StructColumn", pa.struct([("f1", pa.int32()), ("f2", pa.string())])),
+   ... ])
 
-   encryption_config = pe.EncryptionConfiguration(
-      footer_key="footer_key_name",
-      column_keys={
-         "column_key_id": [ "MapColumn.key_value.value", "StructColumn.f1" ],
-      },
-   )
+   >>> encryption_config = pe.EncryptionConfiguration(
+   ...    footer_key="footer_key_name",
+   ...    column_keys={
+   ...       "column_key_id": [ "MapColumn.key_value.value", "StructColumn.f1" ],
+   ...    },
+   ... )
 
 Decryption configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -842,20 +968,17 @@ compression used.
 
 .. code-block:: python
 
-   import pyarrow as pa
-   import pyarrow.parquet as p
+   >>> table = pa.Table.from_pandas(df)
 
-   table = pa.Table.from_pandas(df)
+   >>> # Enable content-defined chunking with default settings
+   >>> pq.write_table(table, 'example.parquet', use_content_defined_chunking=True)
 
-   # Enable content-defined chunking with default settings
-   pq.write_table(table, 'example.parquet', use_content_defined_chunking=True)
-
-   # Enable content-defined chunking with custom settings
-   pq.write_table(
-       table,
-       'example_custom.parquet',
-       use_content_defined_chunking={
-           'min_chunk_size': 128 * 1024,  # 128 KiB
-           'max_chunk_size': 512 * 1024,  # 512 KiB
-       }
-   )
+   >>> # Enable content-defined chunking with custom settings
+   >>> pq.write_table(
+   ...     table,
+   ...     'example_custom.parquet',
+   ...     use_content_defined_chunking={
+   ...         'min_chunk_size': 128 * 1024,  # 128 KiB
+   ...         'max_chunk_size': 512 * 1024,  # 512 KiB
+   ...     }
+   ... )

--- a/docs/source/python/parquet.rst
+++ b/docs/source/python/parquet.rst
@@ -307,7 +307,7 @@ such as the row groups and column chunk metadata and statistics:
    >>> metadata.row_group(0).column(0)
    <pyarrow._parquet.ColumnChunkMetaData object at ...>
      file_offset: 0
-     file_path:
+     file_path:...
      physical_type: DOUBLE
      num_values: 3
      path_in_schema: one

--- a/docs/source/python/timestamps.rst
+++ b/docs/source/python/timestamps.rst
@@ -133,7 +133,6 @@ session time zone is still PST:
    +-------------------+-------------------+
    |2019-01-01 00:00:00|2019-01-01 00:00:00|
    +-------------------+-------------------+
-   <BLANKLINE>
 
     >>> pst_df.toPandas()  # doctest: +SKIP
            naive      aware

--- a/docs/source/python/timestamps.rst
+++ b/docs/source/python/timestamps.rst
@@ -145,8 +145,8 @@ session time zone is still PST:
     <class 'pandas.core.frame.DataFrame'>
     RangeIndex: 1 entries, 0 to 0
     Data columns (total 2 columns):
-     #   Column  Non-Null Count  Dtype         
-    ---  ------  --------------  -----         
+     #   Column  Non-Null Count  Dtype
+    ---  ------  --------------  -----
      0   naive   1 non-null      datetime64[ns]
      1   aware   1 non-null      datetime64[ns]
     dtypes: datetime64[ns](2)

--- a/docs/source/python/timestamps.rst
+++ b/docs/source/python/timestamps.rst
@@ -80,9 +80,8 @@ The following cases assume the Spark configuration
     +-------------------+-------------------+
     |              naive|              aware|
     +-------------------+-------------------+
-    |2018-12-31 23:00:00|2019-01-01 08:00:00|
+    |2019-01-01 00:00:00|2019-01-01 08:00:00|
     +-------------------+-------------------+
-    <BLANKLINE>
 
 Note that conversion of the aware timestamp is shifted to reflect the time
 assuming UTC (it represents the same instant in time).  For naive
@@ -103,9 +102,8 @@ still represents the same instant in time):
     +-------------------+-------------------+
     |              naive|              aware|
     +-------------------+-------------------+
-    |2018-12-31 15:00:00|2019-01-01 00:00:00|
+    |2019-01-01 00:00:00|2019-01-01 00:00:00|
     +-------------------+-------------------+
-    <BLANKLINE>
 
 Looking again at utc_df.show() we see one of the impacts of the session time
 zone.  The naive timestamp was initially converted assuming UTC, the instant it
@@ -118,9 +116,8 @@ data frame:
     +-------------------+-------------------+
     |              naive|              aware|
     +-------------------+-------------------+
-    |2018-12-31 15:00:00|2019-01-01 00:00:00|
+    |2018-12-31 16:00:00|2019-01-01 00:00:00|
     +-------------------+-------------------+
-    <BLANKLINE>
 
 Spark to Pandas
 ~~~~~~~~~~~~~~~
@@ -134,13 +131,13 @@ session time zone is still PST:
    +-------------------+-------------------+
    |              naive|              aware|
    +-------------------+-------------------+
-   |2018-12-31 15:00:00|2019-01-01 00:00:00|
+   |2019-01-01 00:00:00|2019-01-01 00:00:00|
    +-------------------+-------------------+
    <BLANKLINE>
 
     >>> pst_df.toPandas()  # doctest: +SKIP
-                    naive      aware
-    0 2018-12-31 15:00:00 2019-01-01
+           naive      aware
+    0 2019-01-01 2019-01-01
     >>> pst_df.toPandas().info()  # doctest: +SKIP
     <class 'pandas.core.frame.DataFrame'>
     RangeIndex: 1 entries, 0 to 0
@@ -150,7 +147,7 @@ session time zone is still PST:
      0   naive   1 non-null      datetime64[ns]
      1   aware   1 non-null      datetime64[ns]
     dtypes: datetime64[ns](2)
-    memory usage: 148.0 bytes
+    memory usage: ... bytes
 
 Notice that, in addition to being a "time zone naive" timestamp, the 'aware'
 value will now differ when converting to an epoch offset.  Spark does the conversion
@@ -179,13 +176,12 @@ the change in session time zone between creating data frames):
   +-------------------+-------------------+
   |              naive|              aware|
   +-------------------+-------------------+
-  |2018-12-31 15:00:00|2019-01-01 00:00:00|
+  |2018-12-31 16:00:00|2019-01-01 00:00:00|
   +-------------------+-------------------+
-  <BLANKLINE>
 
   >>> utc_df.toPandas()  # doctest: +SKIP
-                  naive               aware
-  0 2018-12-31 23:00:00 2019-01-01 08:00:00
+                  naive      aware
+  0 2018-12-31 16:00:00 2019-01-01
 
 Note that the surprising shift for aware doesn't happen
 when the session time zone is UTC (but the timestamps
@@ -198,9 +194,8 @@ still become "time zone naive"):
   +-------------------+-------------------+
   |              naive|              aware|
   +-------------------+-------------------+
-  |2018-12-31 23:00:00|2019-01-01 08:00:00|
+  |2019-01-01 08:00:00|2019-01-01 08:00:00|
   +-------------------+-------------------+
-  <BLANKLINE>
 
   >>> pst_df.toPandas()['aware'][0]  # doctest: +SKIP
   Timestamp('2019-01-01 08:00:00')


### PR DESCRIPTION
### Rationale for this change

In many places in the Python User Guide the code exampels are written with IPython directive (elsewhere code-block is used). IPython directives are converted to IPython format (`In` and `Out` during the doc build). This can lead to slower builds.

### What changes are included in this PR?

IPython directives are converted to runnable code-block (with `>>>` and `...`) and pytest doctest support for `.rst` files is added to the `conda-python-docs` CI job. This means the code in the Python User Guide is tested separately to the building  of the documentation.

### Are these changes tested?

Yes, with the CI.

### Are there any user-facing changes?

Changes to the Python User Guide examples will have to be tested with `pytest --doctest-glob='*.rst' docs/source/python/file.rst`

* GitHub Issue: #28859