### PR TITLE
GH-48627: [Python] Add PyDecimal_Check(pythopn_decimal) as a ARROW_DCHECK

### DIFF
--- a/python/pyarrow/src/arrow/python/decimal.cc
+++ b/python/pyarrow/src/arrow/python/decimal.cc
@@ -51,9 +51,9 @@ static Status InferDecimalPrecisionAndScale(PyObject* python_decimal, int32_t* p
   ARROW_DCHECK_NE(python_decimal, NULLPTR);
   ARROW_DCHECK_NE(precision, NULLPTR);
   ARROW_DCHECK_NE(scale, NULLPTR);
+  ARROW_DCHECK(PyDecimal_Check(python_decimal))
+      << "python_decimal is not an instance of decimal.Decimal";
 
-  // TODO(phillipc): Make sure we perform PyDecimal_Check(python_decimal) as a
-  // ARROW_DCHECK
   OwnedRef as_tuple(PyObject_CallMethod(python_decimal, const_cast<char*>("as_tuple"),
                                         const_cast<char*>("")));
   RETURN_IF_PYERROR();


### PR DESCRIPTION
### Rationale for this change

A 7-year-old TODO suggested adding a type validation assertion in `InferDecimalPrecisionAndScale()`. This helps catch type errors during development in debug builds.

### What changes are included in this PR?

Added `ARROW_DCHECK(PyDecimal_Check(python_decimal))` assertion in `InferDecimalPrecisionAndScale()` to validate that the input is a `decimal.Decimal` instance.

This resolves the TODO added in commit 9515fe92d

### Are these changes tested?

Yes. Existing tests in `python_test.cc` already execute this code path through `DecimalMetadata::Update()`. The assertion is debug-only and doesn't change runtime behavior.

### Are there any user-facing changes?

No, dev-only.
* GitHub Issue: #48627