### PR TITLE
GH-48631: [R] Non-API calls: 'ATTRIB', 'SET_ATTRIB'

### DIFF
--- a/r/src/altrep.cpp
+++ b/r/src/altrep.cpp
@@ -1093,11 +1093,8 @@ SEXP MakeAltrepVector(const std::shared_ptr<ChunkedArray>& chunked_array) {
 
 bool is_arrow_altrep(SEXP x) {
   if (ALTREP(x)) {
-    return R_altrep_inherits(x, AltrepVectorPrimitive<REALSXP>::class_t) ||
-           R_altrep_inherits(x, AltrepVectorPrimitive<INTSXP>::class_t) ||
-           R_altrep_inherits(x, AltrepFactor::class_t) ||
-           R_altrep_inherits(x, AltrepVectorString<StringType>::class_t) ||
-           R_altrep_inherits(x, AltrepVectorString<LargeStringType>::class_t);
+    SEXP pkg = R_altrep_class_package(x);
+    if (pkg == symbols::arrow) return true;
   }
 
   return false;
@@ -1160,21 +1157,20 @@ sexp test_arrow_altrep_is_materialized(sexp x) {
     return Rf_ScalarLogical(NA_LOGICAL);
   }
 
+  SEXP class_sym = R_altrep_class_name(x);
+  std::string class_name(CHAR(PRINTNAME(class_sym)));
+
   int result = NA_LOGICAL;
-  if (R_altrep_inherits(x, arrow::r::altrep::AltrepVectorPrimitive<REALSXP>::class_t)) {
+  if (class_name == "arrow::array_dbl_vector") {
     result = arrow::r::altrep::AltrepVectorPrimitive<REALSXP>::IsMaterialized(x);
-  } else if (R_altrep_inherits(
-                 x, arrow::r::altrep::AltrepVectorPrimitive<INTSXP>::class_t)) {
+  } else if (class_name == "arrow::array_int_vector") {
     result = arrow::r::altrep::AltrepVectorPrimitive<INTSXP>::IsMaterialized(x);
-  } else if (R_altrep_inherits(
-                 x, arrow::r::altrep::AltrepVectorString<arrow::StringType>::class_t)) {
+  } else if (class_name == "arrow::array_string_vector") {
     result = arrow::r::altrep::AltrepVectorString<arrow::StringType>::IsMaterialized(x);
-  } else if (R_altrep_inherits(
-                 x,
-                 arrow::r::altrep::AltrepVectorString<arrow::LargeStringType>::class_t)) {
+  } else if (class_name == "arrow::array_large_string_vector") {
     result =
         arrow::r::altrep::AltrepVectorString<arrow::LargeStringType>::IsMaterialized(x);
-  } else if (R_altrep_inherits(x, arrow::r::altrep::AltrepFactor::class_t)) {
+  } else if (class_name == "arrow::array_factor") {
     result = arrow::r::altrep::AltrepFactor::IsMaterialized(x);
   }
 
@@ -1192,19 +1188,18 @@ bool test_arrow_altrep_force_materialize(sexp x) {
     stop("x is already materialized");
   }
 
-  if (R_altrep_inherits(x, arrow::r::altrep::AltrepVectorPrimitive<REALSXP>::class_t)) {
+  SEXP class_sym = R_altrep_class_name(x);
+  std::string class_name(CHAR(PRINTNAME(class_sym)));
+
+  if (class_name == "arrow::array_dbl_vector") {
     arrow::r::altrep::AltrepVectorPrimitive<REALSXP>::Materialize(x);
-  } else if (R_altrep_inherits(
-                 x, arrow::r::altrep::AltrepVectorPrimitive<INTSXP>::class_t)) {
+  } else if (class_name == "arrow::array_int_vector") {
     arrow::r::altrep::AltrepVectorPrimitive<INTSXP>::Materialize(x);
-  } else if (R_altrep_inherits(
-                 x, arrow::r::altrep::AltrepVectorString<arrow::StringType>::class_t)) {
+  } else if (class_name == "arrow::array_string_vector") {
     arrow::r::altrep::AltrepVectorString<arrow::StringType>::Materialize(x);
-  } else if (R_altrep_inherits(
-                 x,
-                 arrow::r::altrep::AltrepVectorString<arrow::LargeStringType>::class_t)) {
+  } else if (class_name == "arrow::array_large_string_vector") {
     arrow::r::altrep::AltrepVectorString<arrow::LargeStringType>::Materialize(x);
-  } else if (R_altrep_inherits(x, arrow::r::altrep::AltrepFactor::class_t)) {
+  } else if (class_name == "arrow::array_factor") {
     arrow::r::altrep::AltrepFactor::Materialize(x);
   } else {
     return false;

--- a/r/src/arrow_cpp11.h
+++ b/r/src/arrow_cpp11.h
@@ -50,10 +50,13 @@
 #define DATAPTR(x) (void*)STRING_PTR(x)
 #endif
 
-// R_altrep_class_name doesn't exist before R 4.6
+// R_altrep_class_name and R_altrep_class_package don't exist before R 4.6
 #if R_VERSION < R_Version(4, 6, 0)
 inline SEXP R_altrep_class_name(SEXP x) {
   return ALTREP(x) ? CAR(ATTRIB(ALTREP_CLASS(x))) : R_NilValue;
+}
+inline SEXP R_altrep_class_package(SEXP x) {
+  return ALTREP(x) ? CADR(ATTRIB(ALTREP_CLASS(x))) : R_NilValue;
 }
 #endif
 

--- a/r/src/arrow_cpp11.h
+++ b/r/src/arrow_cpp11.h
@@ -39,11 +39,6 @@
 #define ARROW_R_DCHECK(EXPR)
 #endif
 
-// For context, see:
-// https://github.com/r-devel/r-svn/blob/6418faeb6f5d87d3d9b92b8978773bc3856b4b6f/src/main/altrep.c#L37
-#define ALTREP_CLASS_SERIALIZED_CLASS(x) ATTRIB(x)
-#define ALTREP_SERIALIZED_CLASS_PKGSYM(x) CADR(x)
-
 #if (R_VERSION < R_Version(3, 5, 0))
 #define LOGICAL_RO(x) ((const int*)LOGICAL(x))
 #define INTEGER_RO(x) ((const int*)INTEGER(x))

--- a/r/src/arrow_cpp11.h
+++ b/r/src/arrow_cpp11.h
@@ -50,6 +50,13 @@
 #define DATAPTR(x) (void*)STRING_PTR(x)
 #endif
 
+// R_altrep_class_name doesn't exist before R 4.6
+#if R_VERSION < R_Version(4, 6, 0)
+inline SEXP R_altrep_class_name(SEXP x) {
+  return ALTREP(x) ? CAR(ATTRIB(ALTREP_CLASS(x))) : R_NilValue;
+}
+#endif
+
 namespace arrow {
 namespace r {
 


### PR DESCRIPTION
### Rationale for this change

CRAN complains about non-API calls

### What changes are included in this PR?

Update those items to use alternative approaches

### Are these changes tested?

Well, if the tests pass I think we're good?

### Are there any user-facing changes?

Nope

### Summary of AI changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Have added comments inline regarding assumptions behind changes, and where I questioned those to try to verify it.

Sources referenced in approach:
  - https://github.com/Rdatatable/data.table/pull/7487 - similar fixes
  - https://cran.r-project.org/doc/manuals/r-release/R-ints.html on `DUPLICATE_ATTRIB`



* GitHub Issue: #48631