### PR TITLE
GH-48606: [CI][GLib] Increase NuGet timeout for vcpkg cache

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -352,7 +352,7 @@ jobs:
       CMAKE_CXX_STANDARD: "20"
       CMAKE_GENERATOR: Ninja
       CMAKE_INSTALL_PREFIX: "${{ github.workspace }}/dist"
-      VCPKG_BINARY_SOURCES: 'clear;nuget,GitHub,readwrite'
+      VCPKG_BINARY_SOURCES: 'clear;nugettimeout,600;nuget,GitHub,readwrite'
       VCPKG_DEFAULT_TRIPLET: x64-windows
     permissions:
       packages: write


### PR DESCRIPTION
### Rationale for this change

There are timeout errors for NuGet push to cache vcpkg packages.

### What changes are included in this PR?

Increase push timeout to 600s from 300s.

See also: https://learn.microsoft.com/en-us/vcpkg/reference/binarycaching

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #48606