### PR TITLE
GH-35957: [C++][Compute] Graceful error for decimal binary arithmetic and comparison instead of firing confusing assertion

### DIFF
--- a/cpp/src/arrow/compute/kernels/codegen_internal_test.cc
+++ b/cpp/src/arrow/compute/kernels/codegen_internal_test.cc
@@ -51,6 +51,22 @@ TEST(TestDispatchBest, CastBinaryDecimalArgs) {
   EXPECT_RAISES_WITH_MESSAGE_THAT(
       NotImplemented, ::testing::HasSubstr("Decimals with negative scales not supported"),
       CastBinaryDecimalArgs(DecimalPromotion::kAdd, &args));
+
+  // Non-castable -> unchanged
+  for (const auto promotion :
+       {DecimalPromotion::kAdd, DecimalPromotion::kMultiply, DecimalPromotion::kDivide}) {
+    for (const auto& args : std::vector<std::vector<TypeHolder>>{
+             {decimal128(3, 2), boolean()},
+             {boolean(), decimal128(3, 2)},
+             {decimal128(3, 2), utf8()},
+             {utf8(), decimal128(3, 2)},
+         }) {
+      auto args_copy = args;
+      ASSERT_OK(CastBinaryDecimalArgs(promotion, &args_copy));
+      AssertTypeEqual(*args_copy[0], *args[0]);
+      AssertTypeEqual(*args_copy[1], *args[1]);
+    }
+  }
 }
 
 TEST(TestDispatchBest, CastDecimalArgs) {


### PR DESCRIPTION
### Rationale for this change

When dispatching binary arithmetic and comparison kernels, we do a special casting ahead for decimal arguments. If one argument is decimal and another is the type not castable (e.g., string) to decimal, an assertion fires. On the other hand, we have a graceful way to error on dispatch failure in the general kernel dispatching path after this special casting:
```
Function 'greater' has no kernel matching input types (string, double)
```
We want to unify the error path for decimal.

### What changes are included in this PR?

Bypass the decimal casting early and not error out if we see the other argument is not castable to decimal, and let the subsequent general kernel dispatching path to handle the error gracefully.

### Are these changes tested?

Test included.

### Are there any user-facing changes?

None.
* GitHub Issue: #35957