### PR TITLE
GH-48668: [Python][Docs] Add python examples for compute functions `min/max/min_max`

### DIFF
--- a/python/pyarrow/_compute_docstrings.py
+++ b/python/pyarrow/_compute_docstrings.py
@@ -54,3 +54,60 @@ function_doc_additions["mode"] = """
     >>> modes[1]
     <pyarrow.StructScalar: [('mode', 1), ('count', 2)]>
     """
+
+function_doc_additions["min"] = """
+    Examples
+    --------
+    >>> import pyarrow as pa
+    >>> import pyarrow.compute as pc
+    >>> arr1 = pa.array([1, 1, 2, 2, 3, 2, 2, 2])
+    >>> pc.min(arr1)
+    <pyarrow.Int64Scalar: 1>
+    >>> arr2 = pa.array([1.0, None, 2.0, 3.0])
+    >>> pc.min(arr2)
+    <pyarrow.DoubleScalar: 1.0>
+    >>> arr3 = pa.array([1.0, None, float("nan"), 3.0])
+    >>> pc.min(arr3)
+    <pyarrow.DoubleScalar: 1.0>
+    >>> arr4 = pa.array(["z", None, "y", "x"])
+    >>> pc.min(arr4)
+    <pyarrow.StringScalar: 'x'>
+    """
+
+function_doc_additions["max"] = """
+    Examples
+    --------
+    >>> import pyarrow as pa
+    >>> import pyarrow.compute as pc
+    >>> arr1 = pa.array([1, 1, 2, 2, 3, 2, 2, 2])
+    >>> pc.max(arr1)
+    <pyarrow.Int64Scalar: 3>
+    >>> arr2 = pa.array([1.0, None, 2.0, 3.0])
+    >>> pc.max(arr2)
+    <pyarrow.DoubleScalar: 3.0>
+    >>> arr3 = pa.array([1.0, None, float("nan"), 3.0])
+    >>> pc.max(arr3)
+    <pyarrow.DoubleScalar: 3.0>
+    >>> arr4 = pa.array(["z", None, "y", "x"])
+    >>> pc.max(arr4)
+    <pyarrow.StringScalar: 'z'>
+    """
+
+function_doc_additions["min_max"] = """
+    Examples
+    --------
+    >>> import pyarrow as pa
+    >>> import pyarrow.compute as pc
+    >>> arr1 = pa.array([1, 1, 2, 2, 3, 2, 2, 2])
+    >>> pc.min_max(arr1)
+    <pyarrow.StructScalar: [('min', 1), ('max', 3)]>
+    >>> arr2 = pa.array([1.0, None, 2.0, 3.0])
+    >>> pc.min_max(arr2)
+    <pyarrow.StructScalar: [('min', 1.0), ('max', 3.0)]>
+    >>> arr3 = pa.array([1.0, None, float("nan"), 3.0])
+    >>> pc.min_max(arr3)
+    <pyarrow.StructScalar: [('min', 1.0), ('max', 3.0)]>
+    >>> arr4 = pa.array(["z", None, "y", "x"])
+    >>> pc.min_max(arr4)
+    <pyarrow.StructScalar: [('min', 'x'), ('max', 'z')]>
+    """

--- a/python/pyarrow/_compute_docstrings.py
+++ b/python/pyarrow/_compute_docstrings.py
@@ -64,7 +64,7 @@ function_doc_additions["min"] = """
     >>> pc.min(arr1)
     <pyarrow.Int64Scalar: 1>
 
-    Using `skip_nulls` to handle null values.
+    Using ``skip_nulls`` to handle null values.
 
     >>> arr2 = pa.array([1.0, None, 2.0, 3.0])
     >>> pc.min(arr2)
@@ -72,7 +72,7 @@ function_doc_additions["min"] = """
     >>> pc.min(arr2, skip_nulls=False)
     <pyarrow.DoubleScalar: None>
 
-    Using `ScalarAggregateOptions` to control minimum number of non-null values.
+    Using ``ScalarAggregateOptions`` to control minimum number of non-null values.
 
     >>> arr3 = pa.array([1.0, None, float("nan"), 3.0])
     >>> pc.min(arr3)
@@ -98,7 +98,7 @@ function_doc_additions["max"] = """
     >>> pc.max(arr1)
     <pyarrow.Int64Scalar: 3>
 
-    Using `skip_nulls` to handle null values.
+    Using ``skip_nulls`` to handle null values.
 
     >>> arr2 = pa.array([1.0, None, 2.0, 3.0])
     >>> pc.max(arr2)
@@ -106,7 +106,7 @@ function_doc_additions["max"] = """
     >>> pc.max(arr2, skip_nulls=False)
     <pyarrow.DoubleScalar: None>
 
-    Using `ScalarAggregateOptions` to control minimum number of non-null values.
+    Using ``ScalarAggregateOptions`` to control minimum number of non-null values.
 
     >>> arr3 = pa.array([1.0, None, float("nan"), 3.0])
     >>> pc.max(arr3)
@@ -132,7 +132,7 @@ function_doc_additions["min_max"] = """
     >>> pc.min_max(arr1)
     <pyarrow.StructScalar: [('min', 1), ('max', 3)]>
 
-    Using `skip_nulls` to handle null values.
+    Using ``skip_nulls`` to handle null values.
 
     >>> arr2 = pa.array([1.0, None, 2.0, 3.0])
     >>> pc.min_max(arr2)
@@ -140,7 +140,7 @@ function_doc_additions["min_max"] = """
     >>> pc.min_max(arr2, skip_nulls=False)
     <pyarrow.StructScalar: [('min', None), ('max', None)]>
 
-    Using `ScalarAggregateOptions` to control minimum number of non-null values.
+    Using ``ScalarAggregateOptions`` to control minimum number of non-null values.
 
     >>> arr3 = pa.array([1.0, None, float("nan"), 3.0])
     >>> pc.min_max(arr3)

--- a/python/pyarrow/_compute_docstrings.py
+++ b/python/pyarrow/_compute_docstrings.py
@@ -63,12 +63,27 @@ function_doc_additions["min"] = """
     >>> arr1 = pa.array([1, 1, 2, 2, 3, 2, 2, 2])
     >>> pc.min(arr1)
     <pyarrow.Int64Scalar: 1>
+
+    Using `skip_nulls` to handle null values.
+
     >>> arr2 = pa.array([1.0, None, 2.0, 3.0])
     >>> pc.min(arr2)
     <pyarrow.DoubleScalar: 1.0>
+    >>> pc.min(arr2, skip_nulls=False)
+    <pyarrow.DoubleScalar: None>
+
+    Using `ScalarAggregateOptions` to control minimum number of non-null values.
+
     >>> arr3 = pa.array([1.0, None, float("nan"), 3.0])
     >>> pc.min(arr3)
     <pyarrow.DoubleScalar: 1.0>
+    >>> pc.min(arr3, options=pc.ScalarAggregateOptions(min_count=3))
+    <pyarrow.DoubleScalar: 1.0>
+    >>> pc.min(arr3, options=pc.ScalarAggregateOptions(min_count=4))
+    <pyarrow.DoubleScalar: None>
+
+    This function also works with string values.
+
     >>> arr4 = pa.array(["z", None, "y", "x"])
     >>> pc.min(arr4)
     <pyarrow.StringScalar: 'x'>
@@ -82,12 +97,27 @@ function_doc_additions["max"] = """
     >>> arr1 = pa.array([1, 1, 2, 2, 3, 2, 2, 2])
     >>> pc.max(arr1)
     <pyarrow.Int64Scalar: 3>
+
+    Using `skip_nulls` to handle null values.
+
     >>> arr2 = pa.array([1.0, None, 2.0, 3.0])
     >>> pc.max(arr2)
     <pyarrow.DoubleScalar: 3.0>
+    >>> pc.max(arr2, skip_nulls=False)
+    <pyarrow.DoubleScalar: None>
+
+    Using `ScalarAggregateOptions` to control minimum number of non-null values.
+
     >>> arr3 = pa.array([1.0, None, float("nan"), 3.0])
     >>> pc.max(arr3)
     <pyarrow.DoubleScalar: 3.0>
+    >>> pc.max(arr3, options=pc.ScalarAggregateOptions(min_count=3))
+    <pyarrow.DoubleScalar: 3.0>
+    >>> pc.max(arr3, options=pc.ScalarAggregateOptions(min_count=4))
+    <pyarrow.DoubleScalar: None>
+
+    This function also works with string values.
+
     >>> arr4 = pa.array(["z", None, "y", "x"])
     >>> pc.max(arr4)
     <pyarrow.StringScalar: 'z'>
@@ -100,13 +130,28 @@ function_doc_additions["min_max"] = """
     >>> import pyarrow.compute as pc
     >>> arr1 = pa.array([1, 1, 2, 2, 3, 2, 2, 2])
     >>> pc.min_max(arr1)
+
+    Using `skip_nulls` to handle null values.
+
     <pyarrow.StructScalar: [('min', 1), ('max', 3)]>
     >>> arr2 = pa.array([1.0, None, 2.0, 3.0])
     >>> pc.min_max(arr2)
     <pyarrow.StructScalar: [('min', 1.0), ('max', 3.0)]>
+    >>> pc.min_max(arr2, skip_nulls=False)
+    <pyarrow.StructScalar: [('min', None), ('max', None)]>
+
+    Using `ScalarAggregateOptions` to control minimum number of non-null values.
+
     >>> arr3 = pa.array([1.0, None, float("nan"), 3.0])
     >>> pc.min_max(arr3)
     <pyarrow.StructScalar: [('min', 1.0), ('max', 3.0)]>
+    >>> pc.min_max(arr3, options=pc.ScalarAggregateOptions(min_count=3))
+    <pyarrow.StructScalar: [('min', 1.0), ('max', 3.0)]>
+    >>> pc.min_max(arr3, options=pc.ScalarAggregateOptions(min_count=4))
+    <pyarrow.StructScalar: [('min', None), ('max', None)]>
+
+    This function also works with string values.
+
     >>> arr4 = pa.array(["z", None, "y", "x"])
     >>> pc.min_max(arr4)
     <pyarrow.StructScalar: [('min', 'x'), ('max', 'z')]>

--- a/python/pyarrow/_compute_docstrings.py
+++ b/python/pyarrow/_compute_docstrings.py
@@ -130,10 +130,10 @@ function_doc_additions["min_max"] = """
     >>> import pyarrow.compute as pc
     >>> arr1 = pa.array([1, 1, 2, 2, 3, 2, 2, 2])
     >>> pc.min_max(arr1)
+    <pyarrow.StructScalar: [('min', 1), ('max', 3)]>
 
     Using `skip_nulls` to handle null values.
 
-    <pyarrow.StructScalar: [('min', 1), ('max', 3)]>
     >>> arr2 = pa.array([1.0, None, 2.0, 3.0])
     >>> pc.min_max(arr2)
     <pyarrow.StructScalar: [('min', 1.0), ('max', 3.0)]>

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -883,6 +883,38 @@ def test_generated_docstrings():
             Alternative way of passing options.
         memory_pool : pyarrow.MemoryPool, optional
             If not passed, will allocate memory from the default memory pool.
+
+        Examples
+        --------
+        >>> import pyarrow as pa
+        >>> import pyarrow.compute as pc
+        >>> arr1 = pa.array([1, 1, 2, 2, 3, 2, 2, 2])
+        >>> pc.min_max(arr1)
+
+        Using `skip_nulls` to handle null values.
+
+        <pyarrow.StructScalar: [('min', 1), ('max', 3)]>
+        >>> arr2 = pa.array([1.0, None, 2.0, 3.0])
+        >>> pc.min_max(arr2)
+        <pyarrow.StructScalar: [('min', 1.0), ('max', 3.0)]>
+        >>> pc.min_max(arr2, skip_nulls=False)
+        <pyarrow.StructScalar: [('min', None), ('max', None)]>
+
+        Using `ScalarAggregateOptions` to control minimum number of non-null values.
+
+        >>> arr3 = pa.array([1.0, None, float("nan"), 3.0])
+        >>> pc.min_max(arr3)
+        <pyarrow.StructScalar: [('min', 1.0), ('max', 3.0)]>
+        >>> pc.min_max(arr3, options=pc.ScalarAggregateOptions(min_count=3))
+        <pyarrow.StructScalar: [('min', 1.0), ('max', 3.0)]>
+        >>> pc.min_max(arr3, options=pc.ScalarAggregateOptions(min_count=4))
+        <pyarrow.StructScalar: [('min', None), ('max', None)]>
+
+        This function also works with string values.
+
+        >>> arr4 = pa.array(["z", None, "y", "x"])
+        >>> pc.min_max(arr4)
+        <pyarrow.StructScalar: [('min', 'x'), ('max', 'z')]>
         """)
     # Without options
     assert pc.add.__doc__ == textwrap.dedent("""\

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -890,10 +890,10 @@ def test_generated_docstrings():
         >>> import pyarrow.compute as pc
         >>> arr1 = pa.array([1, 1, 2, 2, 3, 2, 2, 2])
         >>> pc.min_max(arr1)
+        <pyarrow.StructScalar: [('min', 1), ('max', 3)]>
 
         Using `skip_nulls` to handle null values.
 
-        <pyarrow.StructScalar: [('min', 1), ('max', 3)]>
         >>> arr2 = pa.array([1.0, None, 2.0, 3.0])
         >>> pc.min_max(arr2)
         <pyarrow.StructScalar: [('min', 1.0), ('max', 3.0)]>

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -892,7 +892,7 @@ def test_generated_docstrings():
         >>> pc.min_max(arr1)
         <pyarrow.StructScalar: [('min', 1), ('max', 3)]>
 
-        Using `skip_nulls` to handle null values.
+        Using ``skip_nulls`` to handle null values.
 
         >>> arr2 = pa.array([1.0, None, 2.0, 3.0])
         >>> pc.min_max(arr2)
@@ -900,7 +900,7 @@ def test_generated_docstrings():
         >>> pc.min_max(arr2, skip_nulls=False)
         <pyarrow.StructScalar: [('min', None), ('max', None)]>
 
-        Using `ScalarAggregateOptions` to control minimum number of non-null values.
+        Using ``ScalarAggregateOptions`` to control minimum number of non-null values.
 
         >>> arr3 = pa.array([1.0, None, float("nan"), 3.0])
         >>> pc.min_max(arr3)


### PR DESCRIPTION

### Rationale for this change
To improve python documentation

### What changes are included in this PR?
Add python examples for compute functions `min/max/min_max`

### Are these changes tested?
Yes, doc-test

### Are there any user-facing changes?
Doc-only changes

* GitHub Issue: #48668