### PR TITLE
MINOR: [R] Add the explicit mirror to install R dependencies

### DIFF
--- a/r/vignettes/developers/setup.Rmd
+++ b/r/vignettes/developers/setup.Rmd
@@ -189,7 +189,7 @@ checkout:
 ```{bash, save=run}
 popd # To go back to the root directory of the project, from cpp/build
 pushd r
-R -e "install.packages('remotes'); remotes::install_deps(dependencies = TRUE)"
+R -e 'install.packages("remotes", repos="https://cloud.r-project.org"); remotes::install_deps(dependencies = TRUE)'
 R CMD INSTALL --no-multiarch .
 ```
 

--- a/r/vignettes/developers/setup.Rmd
+++ b/r/vignettes/developers/setup.Rmd
@@ -182,14 +182,12 @@ cmake --build . --target install -j8
 
 ### Step 4 - Build the Arrow R package
 
-Once you've built libarrow, you can install the R package and its
-dependencies, along with additional dev dependencies, from the git
-checkout:
+Once you've built libarrow, you can install the R package and its dependencies, along with additional dev dependencies, from the git checkout like below. You might need to either pick and set a repository interactively or you could add a repository to the `install.packages()` command with `repos="https://cloud.r-project.org"`.
 
 ```{bash, save=run}
 popd # To go back to the root directory of the project, from cpp/build
 pushd r
-R -e 'install.packages("remotes", repos="https://cloud.r-project.org"); remotes::install_deps(dependencies = TRUE)'
+R -e 'install.packages("remotes"); remotes::install_deps(dependencies = TRUE)'
 R CMD INSTALL --no-multiarch .
 ```
 


### PR DESCRIPTION
### Rationale for this change

Otherwise, it complains that the mirror has to be manually set in, e.g., R profile.
Should be best to make it self-contained.

### What changes are included in this PR?

This PR fixes the R dev guides (https://arrow.apache.org/docs/4.0/r/articles/developing.html) to provide an explicit mirror when downloading related dependencies.

### Are these changes tested?

Manually tested when setting up the dev.

### Are there any user-facing changes?

No, dev-only.