### PR TITLE
MINOR: [R] Fix typos in arrow/r/README.md and build badge

### DIFF
--- a/r/README.md
+++ b/r/README.md
@@ -3,7 +3,7 @@
 <!-- badges: start -->
 
 [![cran](https://www.r-pkg.org/badges/version-last-release/arrow)](https://cran.r-project.org/package=arrow)
-[![CI](https://github.com/apache/arrow/workflows/R/badge.svg?event=push)](https://github.com/apache/arrow/actions?query=workflow%3AR+branch%3Amain+event%3Apush)
+[![CI](https://github.com/apache/arrow/actions/workflows/r.yml/badge.svg?branch=main&event=push)](https://github.com/apache/arrow/actions/workflows/r.yml?query=branch%3Amain+event%3Apush)
 [![R-universe status badge](https://apache.r-universe.dev/badges/arrow)](https://apache.r-universe.dev)
 [![conda-forge](https://img.shields.io/conda/vn/conda-forge/r-arrow.svg)](https://anaconda.org/conda-forge/r-arrow)
 
@@ -50,10 +50,10 @@ There are some special cases to note:
 
 ## What can the arrow package do?
 
-The Arrow C++ library is comprised of different parts, each of which serves a specific purpose. The arrow package provides binding to the C++ functionality for a wide range of data analysis
+The Arrow C++ library is comprised of different parts, each of which serves a specific purpose. The arrow package provides bindings to the C++ functionality for a wide range of data analysis
 tasks.
 
-It allows users to read and write data in a variety formats:
+It allows users to read and write data in a variety of formats:
 
 - Read and write Parquet files, an efficient and widely used columnar format
 - Read and write Arrow (formerly known as Feather) files, a format optimized for speed and


### PR DESCRIPTION
### Rationale for this change

Couple of typos to fix in README.md and build badge

### What changes are included in this PR?

From "provides binding to" to "provides bindings to"
From "in a variety formats" to "in a variety of formats"
From https://github.com/apache/arrow/workflows/R/badge.svg?event=push to https://github.com/apache/arrow/actions/workflows/r.yml/badge.svg?branch=main&event=push

### Are these changes tested?

Manually tested wit my GitHub browser.

### Are there any user-facing changes?

No, dev-only.