### PR TITLE
MINOR: [R] Document Message and MessageReader classes

### DIFF
--- a/r/R/message.R
+++ b/r/R/message.R
@@ -19,13 +19,25 @@
 
 #' @title Message class
 #'
+#' @description
+#' `Message` holds an Arrow IPC message, which includes metadata and
+#' an optional message body.
+#'
 #' @usage NULL
 #' @format NULL
 #' @docType class
 #'
-#' @section Methods:
+#' @section R6 Methods:
 #'
-#' TODO
+#' - `$Equals(other)`: Check if this `Message` is equal to another `Message`
+#' - `$body_length()`: Return the length of the message body in bytes
+#' - `$Verify()`: Check if the `Message` metadata is valid Flatbuffer format
+#'
+#' @section Active bindings:
+#'
+#' - `$type`: The message type
+#' - `$metadata`: The message metadata
+#' - `$body`: The message body as a [Buffer]
 #'
 #' @rdname Message
 #' @name Message
@@ -48,13 +60,23 @@ Message <- R6Class(
 
 #' @title MessageReader class
 #'
+#' @description
+#' `MessageReader` reads `Message` objects from an input stream.
+#'
 #' @usage NULL
 #' @format NULL
 #' @docType class
 #'
-#' @section Methods:
+#' @section R6 Methods:
 #'
-#' TODO
+#' - `$ReadNextMessage()`: Read the next `Message` from the stream. Returns `NULL` if
+#'   there are no more messages.
+#'
+#' @section Factory:
+#'
+#' `MessageReader$create()` takes the following argument:
+#'
+#' * `stream`: An [InputStream] or object coercible to one (e.g., a raw vector)
 #'
 #' @rdname MessageReader
 #' @name MessageReader

--- a/r/R/message.R
+++ b/r/R/message.R
@@ -76,7 +76,7 @@ Message <- R6Class(
 #'
 #' `MessageReader$create()` takes the following argument:
 #'
-#' * `stream`: An [InputStream] or object coercible to one (e.g., a raw vector)
+#' - `stream`: An [InputStream] or object coercible to one (e.g., a raw vector)
 #'
 #' @rdname MessageReader
 #' @name MessageReader


### PR DESCRIPTION
### Rationale for this change

There are TODOs for documentation which result in https://arrow.apache.org/docs/r/reference/Message.html and https://arrow.apache.org/docs/r/reference/MessageReader.html

### What changes are included in this PR?

This PR documents `Message` and `MessageReader` classes.

### Are these changes tested?

I did not test them as they are documentation changes.

### Are there any user-facing changes?

Yes, it fixes the user facing documentation.
