### PR TITLE
MINOR: [R] Document FixedWidthType class

### DIFF
--- a/r/R/type.R
+++ b/r/R/type.R
@@ -166,6 +166,7 @@ infer_type.Expression <- function(x, ...) x$type()
 #'
 #' @rdname FixedWidthType
 #' @name FixedWidthType
+#' @keywords internal
 FixedWidthType <- R6Class(
   "FixedWidthType",
   inherit = DataType,

--- a/r/R/type.R
+++ b/r/R/type.R
@@ -146,13 +146,23 @@ infer_type.Expression <- function(x, ...) x$type()
 
 #' @title FixedWidthType class
 #'
+#' @description
+#' `FixedWidthType` is a base class for data types with a fixed width in bits.
+#' This includes all integer types, floating-point types, `Boolean`,
+#' `FixedSizeBinary`, temporal types (dates, times, timestamps, durations),
+#' and decimal types.
+#'
 #' @usage NULL
 #' @format NULL
 #' @docType class
 #'
-#' @section Methods:
+#' @section R6 Methods:
 #'
-#' TODO
+#' `FixedWidthType` inherits from [DataType], so it has the same methods.
+#'
+#' @section Active bindings:
+#'
+#' - `$bit_width`: The width of the type in bits
 #'
 #' @rdname FixedWidthType
 #' @name FixedWidthType


### PR DESCRIPTION
### Rationale for this change

There are a TODO for documentation which result in https://arrow.apache.org/docs/r/reference/FixedWidthType.html

### What changes are included in this PR?

This PR documents `FixedWidthType` classes.

### Are these changes tested?

I did not test them as they are documentation changes.

### Are there any user-facing changes?

Yes, it fixes the user facing documentation.
