### PR TITLE
MINOR: [R] Remove outdated TODO for integer division by zero tests

### DIFF
--- a/r/tests/testthat/test-compute-arith.R
+++ b/r/tests/testthat/test-compute-arith.R
@@ -71,8 +71,6 @@ test_that("Division", {
   expect_equal(a / 2 / 2, Array$create(c(1:4 / 2 / 2, NA_real_)))
   expect_equal(a %/% 2L %/% 2L, Array$create(c(0L, 0L, 0L, 1L, NA_integer_)))
   expect_equal(a / 0, Array$create(c(Inf, Inf, Inf, Inf, NA_real_)))
-  # TODO add tests for integer division %/% by 0
-  # see https://issues.apache.org/jira/browse/ARROW-14297
 
   b <- a$cast(float64())
   expect_equal(b / 2, Array$create(c(1:4 / 2, NA_real_)))
@@ -81,8 +79,6 @@ test_that("Division", {
   expect_equal(b %/% 2, Array$create(c(0, 1, 1, 2, NA_real_)))
   expect_equal(b %/% 2L, Array$create(c(0, 1, 1, 2, NA_real_)))
   expect_equal(b / 0, Array$create(c(Inf, Inf, Inf, Inf, NA_real_)))
-  # TODO add tests for integer division %/% by 0
-  # see https://issues.apache.org/jira/browse/ARROW-14297
 
   # the behavior of %/% matches R's (i.e. the integer of the quotient, not
   # simply dividing two integers)


### PR DESCRIPTION
### Rationale for this change

63b8b7eb22: ARROW-13800 Added the TODOs
24689928da: ARROW-14297 Added the tests but forgot to remove TODOs.

https://github.com/apache/arrow/blob/24689928da8b122df89f29b63cffa75845058d4e/r/tests/testthat/test-compute-arith.R#L67

https://github.com/apache/arrow/blob/24689928da8b122df89f29b63cffa75845058d4e/r/tests/testthat/test-compute-arith.R#L70

https://github.com/apache/arrow/blob/24689928da8b122df89f29b63cffa75845058d4e/r/tests/testthat/test-compute-arith.R#L79-L80

### What changes are included in this PR?

This PR proposes to remove the obsolete todo about integer division by zero tests.

### Are these changes tested?

No, I did not test this.

### Are there any user-facing changes?

No, dev-only.