### PR TITLE
MINOR: [R] Document DictionaryType class

### DIFF
--- a/r/R/dictionary.R
+++ b/r/R/dictionary.R
@@ -17,15 +17,38 @@
 
 #' @include type.R
 
-#' @title class DictionaryType
+#' @title DictionaryType class
+#'
+#' @description
+#' `DictionaryType` is a [FixedWidthType] that represents dictionary-encoded data.
+#' Dictionary encoding stores unique values in a dictionary and uses integer-type
+#' indices to reference them, which can be more memory-efficient for data with many
+#' repeated values.
 #'
 #' @usage NULL
 #' @format NULL
 #' @docType class
 #'
-#' @section Methods:
+#' @section R6 Methods:
 #'
-#' TODO
+#' - `$ToString()`: Return a string representation of the dictionary type
+#' - `$code(namespace = FALSE)`: Return R code to create this dictionary type
+#'
+#' @section Active bindings:
+#'
+#' - `$index_type`: The [DataType] for the dictionary indices (must be an integer type,
+#'   signed or unsigned)
+#' - `$value_type`: The [DataType] for the dictionary values
+#' - `$name`: The name of the type.
+#' - `$ordered`: Whether the dictionary is ordered.
+#'
+#' @section Factory:
+#'
+#' `DictionaryType$create()` takes the following arguments:
+#'
+#' - `index_type`: A [DataType] for the indices (default [int32()])
+#' - `value_type`: A [DataType] for the values (default [utf8()])
+#' - `ordered`: Is this an ordered dictionary (default `FALSE`)?
 #'
 #' @rdname DictionaryType
 #' @name DictionaryType


### PR DESCRIPTION
### Rationale for this change

There are a TODO for documentation which result in https://arrow.apache.org/docs/r/reference/DictionaryType.html

### What changes are included in this PR?

This PR documents `DictionaryType` classes.

### Are these changes tested?

I did not test them as they are documentation changes.

### Are there any user-facing changes?

Yes, it fixes the user facing documentation.
