### PR TITLE
GH-48658: [R] Add test for slice_sample with prop = 1 edge case

### DIFF
--- a/r/tests/testthat/test-dplyr-slice.R
+++ b/r/tests/testthat/test-dplyr-slice.R
@@ -218,4 +218,12 @@ test_that("n <-> prop conversion when nrow is not known", {
   )
 })
 
-# TODO: handle edge case where prop = 1, do nothing?
+test_that("slice_sample with prop = 1 returns all data", {
+  # When prop = 1, no filtering should occur and all data should be returned
+  tab <- arrow_table(tbl)
+  result <- tab |>
+    slice_sample(prop = 1) |>
+    collect()
+  expect_equal(nrow(result), nrow(tbl))
+  expect_setequal(result$int, tbl$int)
+})


### PR DESCRIPTION
### Rationale for this change

The TODO comment in `test-dplyr-slice.R` asked whether the edge case where `prop = 1` should be explicitly handled. The current implementation already correctly handles this case: when `prop = 1`, the `if (prop < 1)`
condition is false, so no filtering occurs and all data is returned.

https://github.com/apache/arrow/blob/80e398623d956304acaeb3922e367d45ed96ddec/r/R/dplyr-slice.R#L116

The TODO was introduced in commit 80e398623d when implementing `slice_sample()`:

https://github.com/apache/arrow/blob/80e398623d956304acaeb3922e367d45ed96ddec/r/tests/testthat/test-dplyr-slice.R#L192

This commit added both the `if (prop < 1)` behavior and the TODO comment, questioning whether the implicit behavior (doing nothing when prop = 1) was correct.

### What changes are included in this PR?

This PR adds a test for edge case of prop=1, and removed the todo comment.

### Are these changes tested?

Yes, added unittest.

### Are there any user-facing changes?

No, test-only.

* GitHub Issue: #48658