### PR TITLE
GH-48660: [R] Add tests for filter() and arrange() with aggregation expressions

### DIFF
--- a/r/R/dplyr-arrange.R
+++ b/r/R/dplyr-arrange.R
@@ -46,10 +46,9 @@ arrange.arrow_dplyr_query <- function(.data, ..., .by_group = FALSE) {
         # dplyr lets you arrange on e.g. x < mean(x), but we haven't implemented it.
         # But we could, the same way it works in mutate() via join, if someone asks.
         # Until then, just error.
-        # TODO: add a test for this
         arrow_not_supported(
           .actual_msg = "Expression not supported in arrange() in Arrow",
-          call = expr
+          call = exprs[[i]]
         )
       }
       descs[i] <- x[["desc"]]

--- a/r/R/dplyr-filter.R
+++ b/r/R/dplyr-filter.R
@@ -42,7 +42,6 @@ filter.arrow_dplyr_query <- function(.data, ..., .by = NULL, .preserve = FALSE) 
         # dplyr lets you filter on e.g. x < mean(x), but we haven't implemented it.
         # But we could, the same way it works in mutate() via join, if someone asks.
         # Until then, just error.
-        # TODO: add a test for this
         arrow_not_supported(
           .actual_msg = "Expression not supported in filter() in Arrow",
           call = expr

--- a/r/tests/testthat/test-dplyr-arrange.R
+++ b/r/tests/testthat/test-dplyr-arrange.R
@@ -245,3 +245,11 @@ test_that("Can use across() within arrange()", {
     example_data
   )
 })
+
+test_that("arrange() with aggregation expressions errors", {
+  tab <- arrow_table(tbl)
+  expect_warning(
+    tab |> arrange(int < mean(int)),
+    "not supported in arrange"
+  )
+})

--- a/r/tests/testthat/test-dplyr-filter.R
+++ b/r/tests/testthat/test-dplyr-filter.R
@@ -490,3 +490,11 @@ test_that(".by argument", {
     "Can't supply `\\.by` when `\\.data` is grouped data"
   )
 })
+
+test_that("filter() with aggregation expressions errors", {
+  tab <- arrow_table(tbl)
+  expect_warning(
+    tab |> filter(int < mean(int)),
+    "not supported in filter"
+  )
+})


### PR DESCRIPTION
### Rationale for this change

03f8ae754e added a couple of TODOs for testing aggregation expressions

https://github.com/apache/arrow/blob/03f8ae754ede16f118ccdba0abb593b1461024aa/r/R/dplyr-filter.R#L49

https://github.com/apache/arrow/blob/03f8ae754ede16f118ccdba0abb593b1461024aa/r/R/dplyr-arrange.R#L54

Should test negative cases too as mentioned in the TODOs.

### What changes are included in this PR?

This PP adds a couple of tests for filter() and arrange() with aggregation expressions

### Are these changes tested?

Unittests added.

### Are there any user-facing changes?

No, test-only.
* GitHub Issue: #48660