### PR TITLE
GH-48662: [R] Remove trace$calls %||% trace$call once rlang > 0.4.11 is released

### DIFF
--- a/r/R/metadata.R
+++ b/r/R/metadata.R
@@ -188,8 +188,7 @@ apply_arrow_r_metadata <- function(x, r_metadata) {
         # we cannot apply this row-level metadata, since the order of the rows is
         # not guaranteed to be the same, so don't even try, but warn what's going on
         trace <- trace_back()
-        # TODO: remove `trace$calls %||% trace$call` once rlang > 0.4.11 is released
-        in_dplyr_collect <- any(map_lgl(trace$calls %||% trace$call, function(x) {
+        in_dplyr_collect <- any(map_lgl(trace$call, function(x) {
           grepl("collect\\.([aA]rrow|Dataset)", x)[[1]]
         }))
         if (in_dplyr_collect) {
@@ -296,8 +295,7 @@ arrow_attributes <- function(x, only_top_level = FALSE) {
     # we cannot apply this row-level metadata, since the order of the rows is
     # not guaranteed to be the same, so don't even try, but warn what's going on
     trace <- trace_back()
-    # TODO: remove `trace$calls %||% trace$call` once rlang > 0.4.11 is released
-    in_dataset_write <- any(map_lgl(trace$calls %||% trace$call, function(x) {
+    in_dataset_write <- any(map_lgl(trace$call, function(x) {
       grepl("write_dataset", x, fixed = TRUE)[[1]]
     }))
     if (in_dataset_write) {


### PR DESCRIPTION
### Rationale for this change

https://github.com/apache/arrow/blob/ff5572c845118c6228a896ef9223e81f660cda66/r/R/metadata.R#L75

https://github.com/apache/arrow/blob/ff5572c845118c6228a896ef9223e81f660cda66/r/R/metadata.R#L148

rlang changed its callstack API: older versions used trace$calls, newer versions (rlang 0.4.11+) use trace$call from https://github.com/r-lib/rlang/pull/1255

This was released 5 years ago so should be safe to remove this workaround.

### What changes are included in this PR?

This PR removes `trace$calls` workaround (per newer `trace$call`).

### Are these changes tested?

Existing CI should cover this.

### Are there any user-facing changes?

No, dev-only.
* GitHub Issue: #48662