### PR TITLE
MINOR: [C++] Fix typo in arrow/cpp/*

### DIFF
--- a/cpp/README.md
+++ b/cpp/README.md
@@ -24,7 +24,7 @@ as well as for the C++ libraries for Apache Parquet.
 
 ## Installation
 
-See https://arrow.apache.org/install/ for the latest instructions how
+See https://arrow.apache.org/install/ for the latest instructions on how
 to install pre-compiled binary versions of the library.
 
 ## Source Builds and Development

--- a/cpp/examples/parquet/parquet_arrow/README.md
+++ b/cpp/examples/parquet/parquet_arrow/README.md
@@ -17,4 +17,4 @@ Using parquet-cpp with the arrow interface
 
 This folder contains an example project that shows how to setup a CMake project
 that consumes `parquet-cpp` as a library as well as how you can use the
-`parquet/arrow` interface to reading and write Apache Parquet files.
+`parquet/arrow` interface to read and write Apache Parquet files.

--- a/cpp/src/arrow/flight/sql/odbc/tests/tables_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/tables_test.cc
@@ -340,9 +340,9 @@ TEST_F(TablesMockTest, SQLTablesTestGetMetadataForUnicodeTableByTableName) {
 TEST_F(TablesMockTest, SQLTablesTestGetMetadataForInvalidTableNameNoData) {
   this->CreateTestTables();
 
-  SQLWCHAR invalid_table_name[] = L"NonExistanttable_name";
+  SQLWCHAR invalid_table_name[] = L"NonExistenttable_name";
 
-  //  Try to get metadata for a non-existant table name
+  //  Try to get metadata for a non-existent table name
   ASSERT_EQ(SQL_SUCCESS, SQLTables(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
                                    invalid_table_name, SQL_NTS, nullptr, SQL_NTS));
 

--- a/cpp/subprojects/README.md
+++ b/cpp/subprojects/README.md
@@ -70,7 +70,7 @@ In the default case, Meson will use the wrap file as a fallback. If a dependency
 can be satisfied by the system, then it will not use the wrap file to download
 any sources. However, you can toggle the behavior of the wrap system via the
 `--wrap-mode=` configuration option. `--wrap-mode=forcefallback` will always
-download and use the source defined in a wrap file, even if the depdendency could
+download and use the source defined in a wrap file, even if the dependency could
 be satisfied by the system. By contrast, `--wrap-mode=nofallback` will require
 that the system satisfies dependencies. For more ways to handle wrap dependencies,
 see https://mesonbuild.com/Subprojects.html#commandline-options


### PR DESCRIPTION
### Rationale for this change

This PR fixes several typos in `arrow/cpp/*`

### What changes are included in this PR?

This PR proposes to fix a typo in `arrow/cpp/*`

### Are these changes tested?

Manually tested via my browser.

### Are there any user-facing changes?

No, dev-only.
