### PR TITLE
GH-48024: [C++][Python] Preserve schema metadata in RenameColumns

### DIFF
--- a/cpp/src/arrow/record_batch.cc
+++ b/cpp/src/arrow/record_batch.cc
@@ -414,8 +414,8 @@ Result<std::shared_ptr<RecordBatch>> RecordBatch::RenameColumns(
     fields[i] = schema()->field(i)->WithName(names[i]);
   }
 
-  return RecordBatch::Make(::arrow::schema(std::move(fields)), num_rows(),
-                           std::move(columns), GetSyncEvent());
+  return RecordBatch::Make(::arrow::schema(std::move(fields), schema()->metadata()),
+                           num_rows(), std::move(columns), GetSyncEvent());
 }
 
 Result<std::shared_ptr<RecordBatch>> RecordBatch::SelectColumns(

--- a/cpp/src/arrow/record_batch_test.cc
+++ b/cpp/src/arrow/record_batch_test.cc
@@ -521,6 +521,32 @@ TEST_F(TestRecordBatch, RenameColumns) {
   ASSERT_RAISES(Invalid, batch->RenameColumns({"hello", "world"}));
 }
 
+TEST_F(TestRecordBatch, RenameColumnsPreservesMetadata) {
+  const int length = 10;
+
+  auto field1 = field("f1", int32());
+  auto field2 = field("f2", uint8());
+  auto field3 = field("f3", int16());
+
+  auto metadata = key_value_metadata({"foo", "bar"}, {"fizz", "buzz"});
+  auto schema1 = ::arrow::schema({field1, field2, field3})->WithMetadata(metadata);
+
+  random::RandomArrayGenerator gen(42);
+
+  auto array1 = gen.ArrayOf(int32(), length);
+  auto array2 = gen.ArrayOf(uint8(), length);
+  auto array3 = gen.ArrayOf(int16(), length);
+
+  auto batch = RecordBatch::Make(schema1, length, {array1, array2, array3});
+
+  ASSERT_OK_AND_ASSIGN(auto renamed, batch->RenameColumns({"zero", "one", "two"}));
+  EXPECT_THAT(renamed->ColumnNames(), testing::ElementsAre("zero", "one", "two"));
+
+  // Verify metadata is preserved
+  ASSERT_NE(nullptr, renamed->schema()->metadata());
+  ASSERT_TRUE(renamed->schema()->metadata()->Equals(*metadata));
+}
+
 TEST_F(TestRecordBatch, SelectColumns) {
   const int length = 10;
 

--- a/cpp/src/arrow/table.cc
+++ b/cpp/src/arrow/table.cc
@@ -366,7 +366,8 @@ Result<std::shared_ptr<Table>> Table::RenameColumns(
     columns[i] = column(i);
     fields[i] = field(i)->WithName(names[i]);
   }
-  return Table::Make(::arrow::schema(std::move(fields)), std::move(columns), num_rows());
+  return Table::Make(::arrow::schema(std::move(fields), schema()->metadata()),
+                     std::move(columns), num_rows());
 }
 
 Result<std::shared_ptr<Table>> Table::SelectColumns(

--- a/cpp/src/arrow/table_test.cc
+++ b/cpp/src/arrow/table_test.cc
@@ -801,6 +801,20 @@ TEST_F(TestTable, RenameColumns) {
   ASSERT_RAISES(Invalid, table->RenameColumns({"hello", "world"}));
 }
 
+TEST_F(TestTable, RenameColumnsPreservesMetadata) {
+  MakeExample1(10);
+  auto metadata = key_value_metadata({"foo", "bar"}, {"fizz", "buzz"});
+  auto schema_with_metadata = schema_->WithMetadata(metadata);
+  auto table = Table::Make(schema_with_metadata, columns_);
+
+  ASSERT_OK_AND_ASSIGN(auto renamed, table->RenameColumns({"zero", "one", "two"}));
+  EXPECT_THAT(renamed->ColumnNames(), testing::ElementsAre("zero", "one", "two"));
+
+  // Verify metadata is preserved
+  ASSERT_NE(nullptr, renamed->schema()->metadata());
+  ASSERT_TRUE(renamed->schema()->metadata()->Equals(*metadata));
+}
+
 TEST_F(TestTable, SelectColumns) {
   MakeExample1(10);
   auto table = Table::Make(schema_, columns_);

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -2459,7 +2459,7 @@ Result<std::shared_ptr<Schema>> Schema::WithNames(
   for (const auto& field : impl_->fields_) {
     new_fields.push_back(field->WithName(*names_itr++));
   }
-  return schema(std::move(new_fields));
+  return schema(std::move(new_fields), metadata());
 }
 
 std::shared_ptr<Schema> Schema::WithMetadata(


### PR DESCRIPTION
### Rationale for this change

`Table.rename_columns()` was dropping schema metadata, which is unexpected behavior. When you rename columns, you'd expect everything else about the schema to stay the same - including any metadata attached to it.

I noticed `RecordBatch.rename_columns()` and `Schema.WithNames()` had the same problem, so I fixed those too.

### What changes are included in this PR?

The issue was that these methods were calling `::arrow::schema(fields)` without passing along the original metadata. The fix just adds `schema()->metadata()` as the second argument, same pattern that `SelectColumns()` and `Flatten()` already use.

Files changed:
- `cpp/src/arrow/table.cc` - fix for Table::RenameColumns
- `cpp/src/arrow/record_batch.cc` - fix for RecordBatch::RenameColumns  
- `cpp/src/arrow/type.cc` - fix for Schema::WithNames
- Added tests in the corresponding test files
- Added a Python test covering both Table and RecordBatch

### Are these changes tested?

Yes, added tests for each fix:
- C++ test for Table in `table_test.cc`
- C++ test for RecordBatch in `record_batch_test.cc`
- C++ test for Schema in `type_test.cc`
- Python test in `test_table.py` (covers both Table and RecordBatch)

### Are there any user-facing changes?

Yes, this is a bug fix. After this change, `rename_columns()` will preserve schema metadata instead of dropping it.

* GitHub Issue: #48024