### PR TITLE
GH-48673: [C++] Fix ToStringWithoutContextLines to check for :\d+ pattern before removing lines

### DIFF
--- a/cpp/src/arrow/status_test.cc
+++ b/cpp/src/arrow/status_test.cc
@@ -342,4 +342,21 @@ TEST(StatusTest, ReturnIfNotOk) {
   ASSERT_EQ(StripContext(st.message()), "StatusLike: 43");
 }
 
+#ifdef ARROW_EXTRA_ERROR_CONTEXT
+TEST(StatusTest, ToStringWithoutContextLines) {
+  Status status = Status::IOError("base error");
+  status.AddContextLine("file1.cc", 42, "expr");
+  status.AddContextLine("file2.cc", 100, "expr");
+
+  ASSERT_EQ(status.ToStringWithoutContextLines(), "IOError: base error");
+
+  Status status2(StatusCode::Invalid,
+                 "Error message\nThis line has: a colon but no digits");
+  status2.AddContextLine("file.cc", 20, "expr");
+
+  ASSERT_EQ(status2.ToStringWithoutContextLines(),
+            "Invalid: Error message\nThis line has: a colon but no digits");
+}
+#endif
+
 }  // namespace arrow


### PR DESCRIPTION
### Rationale for this change

This PR proposes to fix the todo https://github.com/apache/arrow/blob/7ebc88c8fae62ed97bc30865c845c8061132af7e/cpp/src/arrow/status.cc#L131-L134 which would allows a better parsing for line numbers.

I could not find the relevant example to demonstrate within this project but assume that we have a test such as:

(Generated by ChatGPT)

```cpp
TEST(BlockParser, ErrorMessageWithColonsPreserved) {
  Status st(StatusCode::Invalid,
            "CSV parse error: Row #2: Expected 2 columns, got 3: 12:34:56,key:value,data\n"
            "Error details: Time format: 12:34:56, Key: value\n"
            "parser_test.cc:940  Parse(parser, csv, &out_size)");

  std::string expected_msg =
      "Invalid: CSV parse error: Row #2: Expected 2 columns, got 3: 12:34:56,key:value,data\n"
      "Error details: Time format: 12:34:56, Key: value";

  ASSERT_RAISES_WITH_MESSAGE(Invalid, expected_msg, st);
}

// Test with URL-like data (another common case with colons)
TEST(BlockParser, ErrorMessageWithURLPreserved) {
  Status st(StatusCode::Invalid,
            "CSV parse error: Row #2: Expected 1 columns, got 2: http://arrow.apache.org:8080/api,data\n"
            "URL: http://arrow.apache.org:8080/api\n"
            "parser_test.cc:974  Parse(parser, csv, &out_size)");

  std::string expected_msg =
      "Invalid: CSV parse error: Row #2: Expected 1 columns, got 2: http://arrow.apache.org:8080/api,data\n"
      "URL: http://arrow.apache.org:8080/api";

  ASSERT_RAISES_WITH_MESSAGE(Invalid, expected_msg, st);
}
```

then it fails.

### What changes are included in this PR?

Fixed `Status::ToStringWithoutContextLines()` to only remove context lines matching the `filename:line` pattern (`:\d+`), preventing legitimate error messages containing colons from being incorrectly stripped.

### Are these changes tested?

Manually tested, and unittests were added, with `cmake .. --preset ninja-debug -DARROW_EXTRA_ERROR_CONTEXT=ON`.

### Are there any user-facing changes?

No, test-only.

* GitHub Issue: #48673