### PR TITLE
GH-48675: [C++][FlightRPC] Document StatementAttributeId enum values in ODBC SPI

### DIFF
--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/spi/statement.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/spi/statement.h
@@ -37,16 +37,19 @@ class Statement {
   virtual ~Statement() = default;
 
   /// \brief Statement attributes that can be called at anytime.
-  ////TODO: Document attributes
   enum StatementAttributeId {
-    MAX_LENGTH,   // size_t - The maximum length when retrieving variable length data. 0
-                  // means no limit.
-    METADATA_ID,  // size_t - Modifies catalog function arguments to be identifiers.
-                  // SQL_TRUE or SQL_FALSE.
-    NOSCAN,  // size_t - Indicates that the driver does not scan for escape sequences.
-             // Default to SQL_NOSCAN_OFF
-    QUERY_TIMEOUT,  // size_t - The time to wait in seconds for queries to execute. 0 to
-                    // have no timeout.
+    /// \brief Maximum length when retrieving variable length data.
+    /// Type: size_t. Value 0 means no limit.
+    MAX_LENGTH,
+    /// \brief Modifies catalog function arguments to be identifiers.
+    /// Type: size_t. Values: SQL_TRUE or SQL_FALSE.
+    METADATA_ID,
+    /// \brief Indicates that the driver does not scan for escape sequences.
+    /// Type: size_t. Default: SQL_NOSCAN_OFF.
+    NOSCAN,
+    /// \brief The time to wait in seconds for queries to execute.
+    /// Type: size_t. Value 0 means no timeout.
+    QUERY_TIMEOUT,
   };
 
   typedef boost::variant<size_t> Attribute;


### PR DESCRIPTION
### Rationale for this change

https://github.com/apache/arrow/commit/ed36107ad8#diff-cbd67e664d899cd38324e1b1a05b073722bd9c011a3449127c408efcf2f1592eR42-R52

There is a todo in https://github.com/apache/arrow/commit/ed36107ad8 which I presume that the author just forgot to do it.

### What changes are included in this PR?

This PR simply moves the comments to the docs to the attributes per Doxygen.

### Are these changes tested?

No, I did not test.

### Are there any user-facing changes?

No, I believe this is an internal API.

* GitHub Issue: #48675