### PR TITLE
GH-47721: [C++][FlightRPC] Followup to remove unncessary std::move to resolve compliation flakiness

### DIFF
--- a/cpp/src/arrow/flight/sql/column_metadata.cc
+++ b/cpp/src/arrow/flight/sql/column_metadata.cc
@@ -59,8 +59,8 @@ const char* ColumnMetadata::kRemarks = "ARROW:FLIGHT:SQL:REMARKS";
 
 ColumnMetadata::ColumnMetadata(
     std::shared_ptr<const arrow::KeyValueMetadata> metadata_map) {
-  metadata_map_ = std::move(metadata_map ? metadata_map
-                                         : std::make_shared<arrow::KeyValueMetadata>());
+  metadata_map_ =
+      metadata_map ? metadata_map : std::make_shared<arrow::KeyValueMetadata>();
 }
 
 arrow::Result<std::string> ColumnMetadata::GetCatalogName() const {


### PR DESCRIPTION
### Rationale for this change

Fixes compilation error on macOS: `-Wpessimizing-move` warning. `std::move()` on a ternary expression prevents copy elision. `shared_ptr` assignment already handles moves automatically, so `std::move` is unnecessary and hurts optimization.

### What changes are included in this PR?

Removed `std::move()` from ternary expression in `ColumnMetadata` constructor (`cpp/src/arrow/flight/sql/column_metadata.cc:62`). Behavior unchanged - still ensures `metadata_map_` is never null.

### Are these changes tested?

Yes. Existing tests cover `ColumnMetadata` functionality. No behavioral changes, so tests continue to pass.

### Are there any user-facing changes?

No. Compilation fix only. Behavior identical, may have slight performance improvement from better compiler optimizations.
* GitHub Issue: #47721