### PR TITLE
GH-48093: [C++][FlightRPC] Replace boost::algorithm with alternatives

### DIFF
--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/flight_sql_statement_get_type_info.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/flight_sql_statement_get_type_info.cc
@@ -17,11 +17,11 @@
 
 #include "arrow/flight/sql/odbc/odbc_impl/flight_sql_statement_get_type_info.h"
 
-#include <boost/algorithm/string/join.hpp>
 #include "arrow/flight/sql/odbc/odbc_impl/flight_sql_connection.h"
 #include "arrow/flight/sql/odbc/odbc_impl/flight_sql_get_type_info_reader.h"
 #include "arrow/flight/sql/odbc/odbc_impl/platform.h"
 #include "arrow/flight/sql/odbc/odbc_impl/util.h"
+#include "arrow/util/string.h"
 
 namespace arrow::flight::sql::odbc {
 
@@ -109,8 +109,7 @@ Result<std::shared_ptr<RecordBatch>> TransformInner(
 
     const auto& create_params = reader.GetCreateParams();
     if (create_params && !create_params->empty()) {
-      // GH-48093 TODO: replace boost-algorithm with alternatives
-      data.create_params = boost::algorithm::join(*create_params, ",");
+      data.create_params = arrow::internal::JoinStrings(*create_params, ",");
     } else {
       data.create_params = nullopt;
     }


### PR DESCRIPTION
### Rationale for this change

Replaces `boost::algorithm::join` with Arrow's internal `arrow::internal::JoinStrings` to remove the boost dependency. Both functions have equivalent behavior: they join a vector of strings with a delimiter.

### What changes are included in this PR?

Replaced `boost::algorithm::join(*create_params, ",")` with `arrow::internal::JoinStrings(*create_params, ",")` (line 112) at `cpp/src/arrow/flight/sql/odbc/odbc_impl/flight_sql_statement_get_type_info.cc`.

From `boost/algorithm/string/join.hpp`:

```cpp
template< typename SequenceSequenceT, typename Range1T>
inline typename range_value<SequenceSequenceT>::type 
join(const SequenceSequenceT& Input, const Range1T& Separator)
{
    // Define working types
    typedef typename range_value<SequenceSequenceT>::type ResultT;
    typedef typename range_const_iterator<SequenceSequenceT>::type InputIteratorT;

    // Parse input
    InputIteratorT itBegin=::boost::begin(Input);
    InputIteratorT itEnd=::boost::end(Input);

    // Construct container to hold the result
    ResultT Result;
    
    // Append first element
    if(itBegin!=itEnd)
    {
        detail::insert(Result, ::boost::end(Result), *itBegin);
        ++itBegin;
    }

    for(;itBegin!=itEnd; ++itBegin)
    {
        // Add separator
        detail::insert(Result, ::boost::end(Result), ::boost::as_literal(Separator));
        // Add element
        detail::insert(Result, ::boost::end(Result), *itBegin);
    }

    return Result;
}
```

From `cpp/src/arrow/util/string.cc:126-148`:

```cpp
template <typename StringLike>
static std::string JoinStringLikes(const std::vector<StringLike>& strings,
                                   std::string_view delimiter) {
  if (strings.size() == 0) {
    return "";
  }
  std::string out = std::string(strings.front());
  for (size_t i = 1; i < strings.size(); ++i) {
    out.append(delimiter.begin(), delimiter.end());
    out.append(strings[i].begin(), strings[i].end());
  }
  return out;
}

std::string JoinStrings(const std::vector<std::string>& strings,
                        std::string_view delimiter) {
  return JoinStringLikes(strings, delimiter);
}
```


### Are these changes tested?

Yes. Existing test cases should verify the change.

### Are there any user-facing changes?

No.


* GitHub Issue: #48093