### PR TITLE
MINOR: [C++][FlightRPC] Clarify IsAutoUnique equivalence between ODBC 2.0 and 3.0+

### DIFF
--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/flight_sql_result_set_metadata.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/flight_sql_result_set_metadata.cc
@@ -222,7 +222,9 @@ Updatability FlightSqlResultSetMetadata::GetUpdatable(int column_position) {
 bool FlightSqlResultSetMetadata::IsAutoUnique(int column_position) {
   ColumnMetadata metadata = GetMetadata(schema_->field(column_position - 1));
 
-  // TODO: Is AutoUnique equivalent to AutoIncrement?
+  // AUTO_UNIQUE_VALUE (ODBC 3.0+) is equivalent to
+  // AUTO_INCREMENT (ODBC 2.0). Both indicate columns
+  // that automatically generate unique values.
   return metadata.GetIsAutoIncrement().ValueOrElse([] { return false; });
 }
 


### PR DESCRIPTION
### Rationale for this change

Clarify that `IsAutoUnique()` correctly maps to both ODBC 2.0 (`AUTO_INCREMENT`) and ODBC 3.0+ (`AUTO_UNIQUE_VALUE`) concepts, resolving a TODO comment.

Reference: https://learn.microsoft.com/en-us/sql/odbc/reference/syntax/sqlgettypeinfo-function?view=sql-server-ver17

### What changes are included in this PR?

Replace the todo to the explanation of the equivalence.

### Are these changes tested?

No, I did not test.

### Are there any user-facing changes?

No, dev-only.