### PR TITLE
GH-48690: [R] Make "Can read Parquet files from a URL" less flaky

### DIFF
--- a/r/tests/testthat/test-parquet.R
+++ b/r/tests/testthat/test-parquet.R
@@ -477,7 +477,8 @@ test_that("Can read Parquet files from a URL", {
   skip_if_offline()
   skip_on_cran()
   skip_if_not_available("snappy")
-  parquet_url <- "https://github.com/apache/arrow/blob/64f2cc7986ce672dd1a8cb268d193617a80a1653/r/inst/v0.7.1.parquet?raw=true" # nolint
+  # Use /raw/ path format (same as test-io.R line 74) instead of blob/...?raw=true.
+  parquet_url <- "https://github.com/apache/arrow/raw/64f2cc7986ce672dd1a8cb268d193617a80a1653/r/inst/v0.7.1.parquet" # nolint
   pu <- read_parquet(parquet_url)
   expect_true(tibble::is_tibble(pu))
   expect_identical(dim(pu), c(10L, 11L))

--- a/r/tests/testthat/test-parquet.R
+++ b/r/tests/testthat/test-parquet.R
@@ -477,7 +477,6 @@ test_that("Can read Parquet files from a URL", {
   skip_if_offline()
   skip_on_cran()
   skip_if_not_available("snappy")
-  # Use /raw/ path format (same as test-io.R line 74) instead of blob/...?raw=true.
   parquet_url <- "https://github.com/apache/arrow/raw/64f2cc7986ce672dd1a8cb268d193617a80a1653/r/inst/v0.7.1.parquet" # nolint
   pu <- read_parquet(parquet_url)
   expect_true(tibble::is_tibble(pu))


### PR DESCRIPTION
### Rationale for this change

The /raw/ path redirects to raw.githubusercontent.com and is arguably reliable (or rather recommended by GitHub itself) than blob/...?raw=true

Reference: https://developer.github.com/changes/24/

All other URL tests in this codebase already use /raw/ format (test-io.R, test-csv.R, etc.)

Disclaimer: I found this flakiness specifically in this test (with the non-raw link) that happens few times while other tests did not face this with raw links. I could not find the official claim related to it so it's based on my observation.

### What changes are included in this PR?

This PR fixes the link of downloading the parquet file being used in the test, from `arrow/blob` to `arrow/raw`.

### Are these changes tested?

No, I did not test.

### Are there any user-facing changes?

No, test-only.
* GitHub Issue: #48690