### PR TITLE
MINOR: [C++] Remove obsolete todo about NaN handling at compare.cc

### DIFF
--- a/cpp/src/arrow/compare.cc
+++ b/cpp/src/arrow/compare.cc
@@ -71,8 +71,6 @@ using util::Float16;
 
 namespace {
 
-// TODO also handle HALF_FLOAT NaNs
-
 template <bool Approximate, bool NansEqual, bool SignedZerosEqual>
 struct FloatingEqualityFlags {
   static constexpr bool approximate = Approximate;


### PR DESCRIPTION
### Rationale for this change

52d615dc2c added this todo.

https://github.com/apache/arrow/blob/52d615dc2cd64fbdbc10f2aeeb3b43ad5e879f3b/cpp/src/arrow/compare.cc#L64

After 4 years later, 72d20ad7190 implemented the logic

https://github.com/apache/arrow/blob/37c40fb789cdc87baab7faef217f02144e36d491/cpp/src/arrow/compare.cc#L92

https://github.com/apache/arrow/blob/37c40fb789cdc87baab7faef217f02144e36d491/cpp/src/arrow/compare.cc#L116

This is being tested in

https://github.com/apache/arrow/blob/37c40fb789cdc87baab7faef217f02144e36d491/cpp/src/arrow/array/array_test.cc#L2314-L2316

### What changes are included in this PR?

This PR removes the obsolete todo about NaN handling at compare.cc.

### Are these changes tested?

No, I did not test.

### Are there any user-facing changes?

No.
