### PR TITLE
MINOR: [Format] Fix incorrect bitmask examples and typos in Flight SQL and format

### DIFF
--- a/format/File.fbs
+++ b/format/File.fbs
@@ -38,7 +38,7 @@ table Footer {
 
 struct Block {
 
-  /// Index to the start of the RecordBlock (note this is past the Message header)
+  /// Index to the start of the RecordBatch (note this is past the Message header)
   offset: long;
 
   /// Length of the metadata

--- a/format/Flight.proto
+++ b/format/Flight.proto
@@ -649,7 +649,7 @@ message GetSessionOptionsResult {
 /*
  * Request message for the "Close Session" action.
  *
- * The exiting session is referenced via a cookie header.
+ * The existing session is referenced via a cookie header.
  */
 message CloseSessionRequest {
 }

--- a/format/Flight.proto
+++ b/format/Flight.proto
@@ -293,7 +293,7 @@ message FlightInfo {
    * represent partitioned data.
    *
    * If the returned data has an ordering, an application can use
-   * "FlightInfo.ordered = true" or should return the all data in a
+   * "FlightInfo.ordered = true" or should return all data in a
    * single endpoint. Otherwise, there is no ordering defined on
    * endpoints or the data within.
    *
@@ -306,7 +306,7 @@ message FlightInfo {
    *
    * * An application requires that all clients must read data in
    *   returned endpoints order.
-   * * An application must return the all data in a single endpoint.
+   * * An application must return all data in a single endpoint.
    */
   repeated FlightEndpoint endpoint = 3;
 

--- a/format/FlightSql.proto
+++ b/format/FlightSql.proto
@@ -195,7 +195,7 @@ enum SqlInfo {
   SQL_DDL_TABLE = 502;
 
   /*
-   * Retrieves a int32 ordinal representing the case sensitivity of catalog, table, schema and table names.
+   * Retrieves an int32 ordinal representing the case sensitivity of catalog, table, schema and table names.
    *
    * The possible values are listed in `arrow.flight.protocol.sql.SqlSupportedCaseSensitivity`.
    */
@@ -205,7 +205,7 @@ enum SqlInfo {
   SQL_IDENTIFIER_QUOTE_CHAR = 504;
 
   /*
-   * Retrieves a int32 describing the case sensitivity of quoted identifiers.
+   * Retrieves an int32 describing the case sensitivity of quoted identifiers.
    *
    * The possible values are listed in `arrow.flight.protocol.sql.SqlSupportedCaseSensitivity`.
    */
@@ -223,7 +223,7 @@ enum SqlInfo {
   /*
    * Retrieves the null ordering.
    *
-   * Returns a int32 ordinal for the null ordering being used, as described in
+   * Returns an int32 ordinal for the null ordering being used, as described in
    * `arrow.flight.protocol.sql.SqlNullOrdering`.
    */
   SQL_NULL_ORDERING = 507;
@@ -273,7 +273,7 @@ enum SqlInfo {
    * Retrieves a boolean value indicating whether concatenations between null and non-null values being
    * null are supported.
    *
-   * - Returns:
+   * Returns:
    * - false: if concatenations between null and non-null values being null are unsupported;
    * - true: if concatenations between null and non-null values being null are supported.
    */
@@ -401,7 +401,7 @@ enum SqlInfo {
    * Retrieves a boolean value indicating whether the SQL Integrity Enhancement Facility is supported.
    *
    * Returns:
-   * - false: if the SQL Integrity Enhancement Facility is supported;
+   * - false: if the SQL Integrity Enhancement Facility is unsupported;
    * - true: if the SQL Integrity Enhancement Facility is supported.
    */
   SQL_SUPPORTS_INTEGRITY_ENHANCEMENT_FACILITY = 527;
@@ -409,7 +409,7 @@ enum SqlInfo {
   /*
    * Retrieves the support level for SQL OUTER JOINs.
    *
-   * Returns a int32 ordinal for the SQL ordering being used, as described in
+   * Returns an int32 ordinal for the SQL ordering being used, as described in
    * `arrow.flight.protocol.sql.SqlOuterJoinsSupportLevel`.
    */
   SQL_OUTER_JOINS_SUPPORT_LEVEL = 528;
@@ -422,7 +422,7 @@ enum SqlInfo {
 
   /*
    * Retrieves a UTF-8 string with the preferred term for "catalog".
-   * If a empty string is returned its assumed that the server does NOT supports catalogs.
+   * If an empty string is returned it is assumed that the server does NOT support catalogs.
    */
   SQL_CATALOG_TERM = 531;
 
@@ -449,12 +449,12 @@ enum SqlInfo {
    * - return 5 (\b101) => [SQL_ELEMENT_IN_PROCEDURE_CALLS, SQL_ELEMENT_IN_PRIVILEGE_DEFINITIONS];
    * - return 6 (\b110) => [SQL_ELEMENT_IN_INDEX_DEFINITIONS, SQL_ELEMENT_IN_PRIVILEGE_DEFINITIONS];
    * - return 7 (\b111) => [SQL_ELEMENT_IN_PROCEDURE_CALLS, SQL_ELEMENT_IN_INDEX_DEFINITIONS, SQL_ELEMENT_IN_PRIVILEGE_DEFINITIONS].
-   * Valid actions for a SQL schema described under `arrow.flight.protocol.sql.SqlSupportedElementActions`.
+   * Valid actions for a SQL schema are described under `arrow.flight.protocol.sql.SqlSupportedElementActions`.
    */
   SQL_SCHEMAS_SUPPORTED_ACTIONS = 533;
 
   /*
-   * Retrieves the supported actions for a SQL schema.
+   * Retrieves the supported actions for a SQL catalog.
    *
    * Returns an int32 bitmask value representing the supported actions for a SQL catalog.
    * The returned bitmask should be parsed in order to retrieve the supported actions for a SQL catalog.
@@ -550,60 +550,60 @@ enum SqlInfo {
    * The returned bitmask should be parsed in order to retrieve the supported SQL UNIONs.
    *
    * For instance:
-   * - return 0 (\b0)   => [] (no supported SQL positioned commands);
+   * - return 0 (\b0)   => [] (no supported SQL UNIONs);
    * - return 1 (\b1)   => [SQL_UNION];
    * - return 2 (\b10)  => [SQL_UNION_ALL];
    * - return 3 (\b11)  => [SQL_UNION, SQL_UNION_ALL].
-   * Valid SQL positioned commands are described under `arrow.flight.protocol.sql.SqlSupportedUnions`.
+   * Valid SQL UNIONs are described under `arrow.flight.protocol.sql.SqlSupportedUnions`.
    */
   SQL_SUPPORTED_UNIONS = 540;
 
-  // Retrieves a int64 value representing the maximum number of hex characters allowed in an inline binary literal.
+  // Retrieves an int64 value representing the maximum number of hex characters allowed in an inline binary literal.
   SQL_MAX_BINARY_LITERAL_LENGTH = 541;
 
-  // Retrieves a int64 value representing the maximum number of characters allowed for a character literal.
+  // Retrieves an int64 value representing the maximum number of characters allowed for a character literal.
   SQL_MAX_CHAR_LITERAL_LENGTH = 542;
 
-  // Retrieves a int64 value representing the maximum number of characters allowed for a column name.
+  // Retrieves an int64 value representing the maximum number of characters allowed for a column name.
   SQL_MAX_COLUMN_NAME_LENGTH = 543;
 
-  // Retrieves a int64 value representing the maximum number of columns allowed in a GROUP BY clause.
+  // Retrieves an int64 value representing the maximum number of columns allowed in a GROUP BY clause.
   SQL_MAX_COLUMNS_IN_GROUP_BY = 544;
 
-  // Retrieves a int64 value representing the maximum number of columns allowed in an index.
+  // Retrieves an int64 value representing the maximum number of columns allowed in an index.
   SQL_MAX_COLUMNS_IN_INDEX = 545;
 
-  // Retrieves a int64 value representing the maximum number of columns allowed in an ORDER BY clause.
+  // Retrieves an int64 value representing the maximum number of columns allowed in an ORDER BY clause.
   SQL_MAX_COLUMNS_IN_ORDER_BY = 546;
 
-  // Retrieves a int64 value representing the maximum number of columns allowed in a SELECT list.
+  // Retrieves an int64 value representing the maximum number of columns allowed in a SELECT list.
   SQL_MAX_COLUMNS_IN_SELECT = 547;
 
-  // Retrieves a int64 value representing the maximum number of columns allowed in a table.
+  // Retrieves an int64 value representing the maximum number of columns allowed in a table.
   SQL_MAX_COLUMNS_IN_TABLE = 548;
 
-  // Retrieves a int64 value representing the maximum number of concurrent connections possible.
+  // Retrieves an int64 value representing the maximum number of concurrent connections possible.
   SQL_MAX_CONNECTIONS = 549;
 
-  // Retrieves a int64 value the maximum number of characters allowed in a cursor name.
+  // Retrieves an int64 value representing the maximum number of characters allowed in a cursor name.
   SQL_MAX_CURSOR_NAME_LENGTH = 550;
 
   /*
-   * Retrieves a int64 value representing the maximum number of bytes allowed for an index,
+   * Retrieves an int64 value representing the maximum number of bytes allowed for an index,
    * including all of the parts of the index.
    */
   SQL_MAX_INDEX_LENGTH = 551;
 
-  // Retrieves a int64 value representing the maximum number of characters allowed in a schema name.
+  // Retrieves an int64 value representing the maximum number of characters allowed in a schema name.
   SQL_DB_SCHEMA_NAME_LENGTH = 552;
 
-  // Retrieves a int64 value representing the maximum number of characters allowed in a procedure name.
+  // Retrieves an int64 value representing the maximum number of characters allowed in a procedure name.
   SQL_MAX_PROCEDURE_NAME_LENGTH = 553;
 
-  // Retrieves a int64 value representing the maximum number of characters allowed in a catalog name.
+  // Retrieves an int64 value representing the maximum number of characters allowed in a catalog name.
   SQL_MAX_CATALOG_NAME_LENGTH = 554;
 
-  // Retrieves a int64 value representing the maximum number of bytes allowed in a single row.
+  // Retrieves an int64 value representing the maximum number of bytes allowed in a single row.
   SQL_MAX_ROW_SIZE = 555;
 
   /*
@@ -619,28 +619,28 @@ enum SqlInfo {
   SQL_MAX_ROW_SIZE_INCLUDES_BLOBS = 556;
 
   /*
-   * Retrieves a int64 value representing the maximum number of characters allowed for an SQL statement;
+   * Retrieves an int64 value representing the maximum number of characters allowed for an SQL statement;
    * a result of 0 (zero) means that there is no limit or the limit is not known.
    */
   SQL_MAX_STATEMENT_LENGTH = 557;
 
-  // Retrieves a int64 value representing the maximum number of active statements that can be open at the same time.
+  // Retrieves an int64 value representing the maximum number of active statements that can be open at the same time.
   SQL_MAX_STATEMENTS = 558;
 
-  // Retrieves a int64 value representing the maximum number of characters allowed in a table name.
+  // Retrieves an int64 value representing the maximum number of characters allowed in a table name.
   SQL_MAX_TABLE_NAME_LENGTH = 559;
 
-  // Retrieves a int64 value representing the maximum number of tables allowed in a SELECT statement.
+  // Retrieves an int64 value representing the maximum number of tables allowed in a SELECT statement.
   SQL_MAX_TABLES_IN_SELECT = 560;
 
-  // Retrieves a int64 value representing the maximum number of characters allowed in a user name.
+  // Retrieves an int64 value representing the maximum number of characters allowed in a user name.
   SQL_MAX_USERNAME_LENGTH = 561;
 
   /*
    * Retrieves this database's default transaction isolation level as described in
    * `arrow.flight.protocol.sql.SqlTransactionIsolationLevel`.
    *
-   * Returns a int32 ordinal for the SQL transaction isolation level.
+   * Returns an int32 ordinal for the SQL transaction isolation level.
    */
   SQL_DEFAULT_TRANSACTION_ISOLATION = 562;
 
@@ -665,21 +665,21 @@ enum SqlInfo {
    * - return 1   (\b1)     => [SQL_TRANSACTION_NONE];
    * - return 2   (\b10)    => [SQL_TRANSACTION_READ_UNCOMMITTED];
    * - return 3   (\b11)    => [SQL_TRANSACTION_NONE, SQL_TRANSACTION_READ_UNCOMMITTED];
-   * - return 4   (\b100)   => [SQL_TRANSACTION_REPEATABLE_READ];
-   * - return 5   (\b101)   => [SQL_TRANSACTION_NONE, SQL_TRANSACTION_REPEATABLE_READ];
-   * - return 6   (\b110)   => [SQL_TRANSACTION_READ_UNCOMMITTED, SQL_TRANSACTION_REPEATABLE_READ];
-   * - return 7   (\b111)   => [SQL_TRANSACTION_NONE, SQL_TRANSACTION_READ_UNCOMMITTED, SQL_TRANSACTION_REPEATABLE_READ];
+   * - return 4   (\b100)   => [SQL_TRANSACTION_READ_COMMITTED];
+   * - return 5   (\b101)   => [SQL_TRANSACTION_NONE, SQL_TRANSACTION_READ_COMMITTED];
+   * - return 6   (\b110)   => [SQL_TRANSACTION_READ_UNCOMMITTED, SQL_TRANSACTION_READ_COMMITTED];
+   * - return 7   (\b111)   => [SQL_TRANSACTION_NONE, SQL_TRANSACTION_READ_UNCOMMITTED, SQL_TRANSACTION_READ_COMMITTED];
    * - return 8   (\b1000)  => [SQL_TRANSACTION_REPEATABLE_READ];
    * - return 9   (\b1001)  => [SQL_TRANSACTION_NONE, SQL_TRANSACTION_REPEATABLE_READ];
    * - return 10  (\b1010)  => [SQL_TRANSACTION_READ_UNCOMMITTED, SQL_TRANSACTION_REPEATABLE_READ];
    * - return 11  (\b1011)  => [SQL_TRANSACTION_NONE, SQL_TRANSACTION_READ_UNCOMMITTED, SQL_TRANSACTION_REPEATABLE_READ];
-   * - return 12  (\b1100)  => [SQL_TRANSACTION_REPEATABLE_READ, SQL_TRANSACTION_REPEATABLE_READ];
-   * - return 13  (\b1101)  => [SQL_TRANSACTION_NONE, SQL_TRANSACTION_REPEATABLE_READ, SQL_TRANSACTION_REPEATABLE_READ];
-   * - return 14  (\b1110)  => [SQL_TRANSACTION_READ_UNCOMMITTED, SQL_TRANSACTION_REPEATABLE_READ, SQL_TRANSACTION_REPEATABLE_READ];
-   * - return 15  (\b1111)  => [SQL_TRANSACTION_NONE, SQL_TRANSACTION_READ_UNCOMMITTED, SQL_TRANSACTION_REPEATABLE_READ, SQL_TRANSACTION_REPEATABLE_READ];
+   * - return 12  (\b1100)  => [SQL_TRANSACTION_READ_COMMITTED, SQL_TRANSACTION_REPEATABLE_READ];
+   * - return 13  (\b1101)  => [SQL_TRANSACTION_NONE, SQL_TRANSACTION_READ_COMMITTED, SQL_TRANSACTION_REPEATABLE_READ];
+   * - return 14  (\b1110)  => [SQL_TRANSACTION_READ_UNCOMMITTED, SQL_TRANSACTION_READ_COMMITTED, SQL_TRANSACTION_REPEATABLE_READ];
+   * - return 15  (\b1111)  => [SQL_TRANSACTION_NONE, SQL_TRANSACTION_READ_UNCOMMITTED, SQL_TRANSACTION_READ_COMMITTED, SQL_TRANSACTION_REPEATABLE_READ];
    * - return 16  (\b10000) => [SQL_TRANSACTION_SERIALIZABLE];
    * - ...
-   * Valid SQL positioned commands are described under `arrow.flight.protocol.sql.SqlTransactionIsolationLevel`.
+   * Valid SQL transaction isolation levels are described under `arrow.flight.protocol.sql.SqlTransactionIsolationLevel`.
    */
   SQL_SUPPORTED_TRANSACTIONS_ISOLATION_LEVELS = 564;
 
@@ -722,7 +722,7 @@ enum SqlInfo {
   SQL_SUPPORTED_RESULT_SET_TYPES = 567;
 
   /*
-   * Returns an int32 bitmask value concurrency types supported for
+   * Returns an int32 bitmask value representing the concurrency types supported for
    * `arrow.flight.protocol.sql.SqlSupportedResultSetType.SQL_RESULT_SET_TYPE_UNSPECIFIED`.
    *
    * For instance:
@@ -734,12 +734,12 @@ enum SqlInfo {
    * - return 5 (\b101) => [SQL_RESULT_SET_CONCURRENCY_UNSPECIFIED, SQL_RESULT_SET_CONCURRENCY_UPDATABLE]
    * - return 6 (\b110)  => [SQL_RESULT_SET_CONCURRENCY_READ_ONLY, SQL_RESULT_SET_CONCURRENCY_UPDATABLE]
    * - return 7 (\b111)  => [SQL_RESULT_SET_CONCURRENCY_UNSPECIFIED, SQL_RESULT_SET_CONCURRENCY_READ_ONLY, SQL_RESULT_SET_CONCURRENCY_UPDATABLE]
-   * Valid result set types are described under `arrow.flight.protocol.sql.SqlSupportedResultSetConcurrency`.
+   * Valid result set concurrency types are described under `arrow.flight.protocol.sql.SqlSupportedResultSetConcurrency`.
    */
   SQL_SUPPORTED_CONCURRENCIES_FOR_RESULT_SET_UNSPECIFIED = 568;
 
   /*
-   * Returns an int32 bitmask value concurrency types supported for
+   * Returns an int32 bitmask value representing the concurrency types supported for
    * `arrow.flight.protocol.sql.SqlSupportedResultSetType.SQL_RESULT_SET_TYPE_FORWARD_ONLY`.
    *
    * For instance:
@@ -751,12 +751,12 @@ enum SqlInfo {
    * - return 5 (\b101) => [SQL_RESULT_SET_CONCURRENCY_UNSPECIFIED, SQL_RESULT_SET_CONCURRENCY_UPDATABLE]
    * - return 6 (\b110)  => [SQL_RESULT_SET_CONCURRENCY_READ_ONLY, SQL_RESULT_SET_CONCURRENCY_UPDATABLE]
    * - return 7 (\b111)  => [SQL_RESULT_SET_CONCURRENCY_UNSPECIFIED, SQL_RESULT_SET_CONCURRENCY_READ_ONLY, SQL_RESULT_SET_CONCURRENCY_UPDATABLE]
-   * Valid result set types are described under `arrow.flight.protocol.sql.SqlSupportedResultSetConcurrency`.
+   * Valid result set concurrency types are described under `arrow.flight.protocol.sql.SqlSupportedResultSetConcurrency`.
    */
   SQL_SUPPORTED_CONCURRENCIES_FOR_RESULT_SET_FORWARD_ONLY = 569;
 
   /*
-   * Returns an int32 bitmask value concurrency types supported for
+   * Returns an int32 bitmask value representing the concurrency types supported for
    * `arrow.flight.protocol.sql.SqlSupportedResultSetType.SQL_RESULT_SET_TYPE_SCROLL_SENSITIVE`.
    *
    * For instance:
@@ -768,12 +768,12 @@ enum SqlInfo {
    * - return 5 (\b101) => [SQL_RESULT_SET_CONCURRENCY_UNSPECIFIED, SQL_RESULT_SET_CONCURRENCY_UPDATABLE]
    * - return 6 (\b110)  => [SQL_RESULT_SET_CONCURRENCY_READ_ONLY, SQL_RESULT_SET_CONCURRENCY_UPDATABLE]
    * - return 7 (\b111)  => [SQL_RESULT_SET_CONCURRENCY_UNSPECIFIED, SQL_RESULT_SET_CONCURRENCY_READ_ONLY, SQL_RESULT_SET_CONCURRENCY_UPDATABLE]
-   * Valid result set types are described under `arrow.flight.protocol.sql.SqlSupportedResultSetConcurrency`.
+   * Valid result set concurrency types are described under `arrow.flight.protocol.sql.SqlSupportedResultSetConcurrency`.
    */
   SQL_SUPPORTED_CONCURRENCIES_FOR_RESULT_SET_SCROLL_SENSITIVE = 570;
 
   /*
-   * Returns an int32 bitmask value concurrency types supported for
+   * Returns an int32 bitmask value representing the concurrency types supported for
    * `arrow.flight.protocol.sql.SqlSupportedResultSetType.SQL_RESULT_SET_TYPE_SCROLL_INSENSITIVE`.
    *
    * For instance:
@@ -785,7 +785,7 @@ enum SqlInfo {
    * - return 5 (\b101) => [SQL_RESULT_SET_CONCURRENCY_UNSPECIFIED, SQL_RESULT_SET_CONCURRENCY_UPDATABLE]
    * - return 6 (\b110)  => [SQL_RESULT_SET_CONCURRENCY_READ_ONLY, SQL_RESULT_SET_CONCURRENCY_UPDATABLE]
    * - return 7 (\b111)  => [SQL_RESULT_SET_CONCURRENCY_UNSPECIFIED, SQL_RESULT_SET_CONCURRENCY_READ_ONLY, SQL_RESULT_SET_CONCURRENCY_UPDATABLE]
-   * Valid result set types are described under `arrow.flight.protocol.sql.SqlSupportedResultSetConcurrency`.
+   * Valid result set concurrency types are described under `arrow.flight.protocol.sql.SqlSupportedResultSetConcurrency`.
    */
   SQL_SUPPORTED_CONCURRENCIES_FOR_RESULT_SET_SCROLL_INSENSITIVE = 571;
 
@@ -1029,7 +1029,7 @@ enum XdbcDatetimeSubcode {
 
 enum Nullable {
   /**
-   * Indicates that the fields does not allow the use of null values.
+   * Indicates that the field does not allow the use of null values.
    */
   NULLABILITY_NO_NULLS = 0;
 
@@ -1573,8 +1573,8 @@ message ActionBeginTransactionRequest {
  * Request message for the "BeginSavepoint" action.
  * Creates a savepoint within a transaction.
  *
- * Only supported if FLIGHT_SQL_TRANSACTION is
- * FLIGHT_SQL_TRANSACTION_SUPPORT_SAVEPOINT.
+ * Only supported if FLIGHT_SQL_SERVER_TRANSACTION returns
+ * SQL_SUPPORTED_TRANSACTION_SAVEPOINT.
  */
 message ActionBeginSavepointRequest {
 
@@ -1780,7 +1780,7 @@ message CommandPreparedStatementUpdate {
 
 /*
  * Represents a bulk ingestion request. Used in the command member of FlightDescriptor
- * for the the RPC call DoPut to cause the server load the contents of the stream's
+ * for the RPC call DoPut to cause the server load the contents of the stream's
  * FlightData into the target destination.
  */
 message CommandStatementIngest {
@@ -1863,7 +1863,7 @@ message DoPutPreparedStatementResult {
   // The updated handle allows implementing query parameters with stateless services.
   //
   // When an updated handle is not provided by the server, clients should continue
-  // using the previous handle provided by `ActionCreatePreparedStatementResonse`.
+  // using the previous handle provided by `ActionCreatePreparedStatementResult`.
   optional bytes prepared_statement_handle = 1;
 }
 

--- a/format/Message.fbs
+++ b/format/Message.fbs
@@ -104,7 +104,7 @@ table RecordBatch {
 
   /// Some types such as Utf8View are represented using a variable number of buffers.
   /// For each such Field in the pre-ordered flattened logical schema, there will be
-  /// an entry in variadicBufferCounts to indicate the number of number of variadic
+  /// an entry in variadicBufferCounts to indicate the number of variadic
   /// buffers which belong to that Field in the current RecordBatch.
   ///
   /// For example, the schema

--- a/format/Schema.fbs
+++ b/format/Schema.fbs
@@ -125,7 +125,7 @@ table FixedSizeList {
 /// may be set in the metadata for this field.
 ///
 /// In a field with Map type, the field has a child Struct field, which then
-/// has two children: key type and the second the value type. The names of the
+/// has two children: the key type and the value type. The names of the
 /// child fields may be respectively "entries", "key", and "value", but this is
 /// not enforced.
 ///
@@ -424,7 +424,7 @@ table Interval {
 // ("t1") naively (i.e. simply summing the two numbers) is acceptable even
 // though in some cases the resulting Timestamp (t2) would not account for
 // leap-seconds during the elapsed time between "t1" and "t2".  Similarly,
-// representing the difference between two Unix timestamp is acceptable, but
+// representing the difference between two Unix timestamps is acceptable, but
 // would yield a value that is possibly a few seconds off from the true elapsed
 // time.
 //
@@ -497,7 +497,7 @@ table DictionaryEncoding {
   indexType: Int;
 
   /// By default, dictionaries are not ordered, or the order does not have
-  /// semantic meaning. In some statistical, applications, dictionary-encoding
+  /// semantic meaning. In some statistical applications, dictionary-encoding
   /// is used to represent ordered categorical data, and we provide a way to
   /// preserve that metadata here
   isOrdered: bool;

--- a/format/SparseTensor.fbs
+++ b/format/SparseTensor.fbs
@@ -27,11 +27,11 @@ namespace org.apache.arrow.flatbuf;
 
 /// Coordinate (COO) format of sparse tensor index.
 ///
-/// COO's index list are represented as a NxM matrix,
+/// COO's index list is represented as an NxM matrix,
 /// where N is the number of non-zero values,
 /// and M is the number of dimensions of a sparse tensor.
 ///
-/// indicesBuffer stores the location and size of the data of this indices
+/// indicesBuffer stores the location and size of the data of these indices
 /// matrix.  The value type and the stride of the indices matrix is
 /// specified in indicesType and indicesStrides fields.
 ///
@@ -52,7 +52,7 @@ namespace org.apache.arrow.flatbuf;
 ///    [2, 2, 3, 1, 2, 0],
 ///    [0, 1, 0, 0, 3, 4]]
 /// ```
-/// When isCanonical is true, the indices is sorted in lexicographical order
+/// When isCanonical is true, the indices are sorted in lexicographical order
 /// (row-major order), and it does not have duplicated entries.  Otherwise,
 /// the indices may not be sorted, or may have duplicated entries.
 table SparseTensorIndexCOO {
@@ -116,7 +116,7 @@ table SparseMatrixIndexCSX {
   /// contains the column indices of the corresponding non-zero values.
   /// The type of index value is long.
   ///
-  /// For example, the indices of the above X is:
+  /// For example, the indices of the above X are:
   /// ```text
   ///   indices(X) = [1, 2, 2, 1, 3, 0, 2, 3, 1].
   /// ```
@@ -132,7 +132,7 @@ table SparseTensorIndexCSF {
   /// CSF index recursively compresses each dimension of a tensor into a set
   /// of prefix trees. Each path from a root to leaf forms one tensor
   /// non-zero index. CSF is implemented with two arrays of buffers and one
-  /// arrays of integers.
+  /// array of integers.
   ///
   /// For example, let X be a 2x3x4x5 tensor and let it have the following
   /// 8 non-zero values:
@@ -165,7 +165,7 @@ table SparseTensorIndexCSF {
   /// and `indptrBuffers[dim][i + 1]` signify a range of nodes in
   /// `indicesBuffers[dim + 1]` who are children of `indicesBuffers[dim][i]` node.
   ///
-  /// For example, the indptrBuffers for the above X is:
+  /// For example, the indptrBuffers for the above X are:
   /// ```text
   ///   indptrBuffer(X) = [
   ///                       [0, 2, 3],
@@ -180,7 +180,7 @@ table SparseTensorIndexCSF {
 
   /// indicesBuffers stores values of nodes.
   /// Each tensor dimension corresponds to a buffer in indicesBuffers.
-  /// For example, the indicesBuffers for the above X is:
+  /// For example, the indicesBuffers for the above X are:
   /// ```text
   ///   indicesBuffer(X) = [
   ///                        [0, 1],


### PR DESCRIPTION
### Rationale for this change

968e6ea488c added incorrect bitmask examples for `SQL_SUPPORTED_TRANSACTIONS_ISOLATION_LEVELS`.

https://github.com/apache/arrow/blob/968e6ea488c939c0e1f2bfe339a5a9ed1aed603e/format/FlightSql.proto#L588-L590

The bitmask incorrectly mapped bit 2 (value 4 = `\b100`) to `SQL_TRANSACTION_REPEATABLE_READ` instead of `SQL_TRANSACTION_READ_COMMITTED`, and omitted `SQL_TRANSACTION_READ_COMMITTED` entirely. According to the enum definition:

https://github.com/apache/arrow/blob/968e6ea488c939c0e1f2bfe339a5a9ed1aed603e/format/FlightSql.proto#L820-L826

The correct bit-to-enum mapping should be:
- Bit 0 (value 1) = `SQL_TRANSACTION_NONE` (enum value 0)
- Bit 1 (value 2) = `SQL_TRANSACTION_READ_UNCOMMITTED` (enum value 1)
- Bit 2 (value 4) = `SQL_TRANSACTION_READ_COMMITTED` (enum value 2)
- Bit 3 (value 8) = `SQL_TRANSACTION_REPEATABLE_READ` (enum value 3)
- Bit 4 (value 16) = `SQL_TRANSACTION_SERIALIZABLE` (enum value 4)


### What changes are included in this PR?

- Added `SQL_TRANSACTION_READ_COMMITTED` properly in the comments.
- `SQL positioned commands` (presumably copied and pasted from other places) -> `SQL transaction isolation levels` for `SQL_SUPPORTED_TRANSACTIONS_ISOLATION_LEVELS`
- `SQL positioned commands` (presumably copied and pasted from other places) -> `SQL UNIONs` for `SQL_SUPPORTED_UNIONS`
- ... and a lot of other similar typo fixes.

### Are these changes tested?

No, I did not test as they are comment-only.

### Are there any user-facing changes?

No, dev-only.