### PR TITLE
GH-48481: [Ruby] Correctly infer types for nested integer arrays

### DIFF
--- a/ruby/red-arrow/lib/arrow/array-builder.rb
+++ b/ruby/red-arrow/lib/arrow/array-builder.rb
@@ -76,12 +76,12 @@ module Arrow
         when Integer
           if value < 0
             {
-              builder: IntArrayBuilder.new,
+              builder_type: :int,
               detected: true,
             }
           else
             {
-              builder: UIntArrayBuilder.new,
+              builder_type: :uint,
             }
           end
         when Time
@@ -156,7 +156,7 @@ module Arrow
             break if sub_builder_info and sub_builder_info[:detected]
           end
           if sub_builder_info
-            sub_builder = sub_builder_info[:builder]
+            sub_builder = sub_builder_info[:builder] || create_builder(sub_builder_info)
             return builder_info unless sub_builder
             sub_value_data_type = sub_builder.value_data_type
             field = Field.new("item", sub_value_data_type)
@@ -186,6 +186,10 @@ module Arrow
           data_type = Decimal256DataType.new(builder_info[:precision],
                                              builder_info[:scale])
           Decimal256ArrayBuilder.new(data_type)
+        when :int
+          Int8ArrayBuilder.new
+        when :uint
+          UInt8ArrayBuilder.new
         else
           nil
         end

--- a/ruby/red-arrow/lib/arrow/array-builder.rb
+++ b/ruby/red-arrow/lib/arrow/array-builder.rb
@@ -79,21 +79,18 @@ module Arrow
           max = builder_info[:max] || value
           min = value if value < min
           max = value if value > max
-          bit_length = value.bit_length
 
           if builder_info[:builder_type] == :int || value < 0
             {
               builder_type: :int,
               min: min,
               max: max,
-              bit_length: [builder_info[:bit_length] || 0, bit_length].max
             }
           else
             {
               builder_type: :uint,
               min: min,
               max: max,
-              bit_length: [builder_info[:bit_length] || 0, bit_length].max
             }
           end
         when Time
@@ -200,29 +197,30 @@ module Arrow
                                              builder_info[:scale])
           Decimal256ArrayBuilder.new(data_type)
         when :int
-          required_bit_length = builder_info[:bit_length] + 1
+          min = builder_info[:min]
+          max = builder_info[:max]
 
-          if required_bit_length <= 8
+          if GLib::MININT8 <= min && max <= GLib::MAXINT8
             Int8ArrayBuilder.new
-          elsif required_bit_length <= 16
+          elsif GLib::MININT16 <= min && max <= GLib::MAXINT16
             Int16ArrayBuilder.new
-          elsif required_bit_length <= 32
+          elsif GLib::MININT32 <= min && max <= GLib::MAXINT32
             Int32ArrayBuilder.new
-          elsif required_bit_length <= 64
+          elsif GLib::MININT64 <= min && max <= GLib::MAXINT64
             Int64ArrayBuilder.new
           else
             StringArrayBuilder.new
           end
         when :uint
-          required_bit_length = builder_info[:bit_length]
+          max = builder_info[:max]
 
-          if required_bit_length <= 8
+          if max <= GLib::MAXUINT8
             UInt8ArrayBuilder.new
-          elsif required_bit_length <= 16
+          elsif max <= GLib::MAXUINT16
             UInt16ArrayBuilder.new
-          elsif required_bit_length <= 32
+          elsif max <= GLib::MAXUINT32
             UInt32ArrayBuilder.new
-          elsif required_bit_length <= 64
+          elsif max <= GLib::MAXUINT64
             UInt64ArrayBuilder.new
           else
             StringArrayBuilder.new

--- a/ruby/red-arrow/test/test-array-builder.rb
+++ b/ruby/red-arrow/test/test-array-builder.rb
@@ -169,10 +169,9 @@ class ArrayBuilderTest < Test::Unit::TestCase
         end
 
         test("list<int8>s boundary") do
-          # Int8 can hold values from -128 to 127.
           values = [
-            [0, -2**7],
-            [2**7 - 1],
+            [0, GLib::MININT8],
+            [GLib::MAXINT8],
           ]
           array = Arrow::Array.new(values)
           data_type = Arrow::ListDataType.new(:int8)
@@ -180,8 +179,8 @@ class ArrayBuilderTest < Test::Unit::TestCase
           assert_equal({
                          data_type: data_type,
                          values: [
-                           [0, -128],
-                           [127],
+                           [0, GLib::MININT8],
+                           [GLib::MAXINT8],
                          ],
                        },
                        {
@@ -192,18 +191,17 @@ class ArrayBuilderTest < Test::Unit::TestCase
 
         test("list<int16>s inferred from int8 underflow") do
           values = [
-            [0, -2**7 - 1],
-            [2**7 - 1],
+            [0, GLib::MININT8 - 1],
+            [GLib::MAXINT8],
           ]
           array = Arrow::Array.new(values)
           data_type = Arrow::ListDataType.new(:int16)
 
-          # Int8 lower bound is -128
           assert_equal({
                          data_type: data_type,
                          values: [
-                           [0, -129],
-                           [127],
+                           [0, GLib::MININT8 - 1],
+                           [GLib::MAXINT8],
                          ],
                        },
                        {
@@ -214,18 +212,17 @@ class ArrayBuilderTest < Test::Unit::TestCase
 
         test("list<int16>s inferred from int8 overflow") do
           values = [
-            [0, 2**7],
-            [-2**7],
+            [0, GLib::MAXINT8 + 1],
+            [GLib::MININT8],
           ]
           array = Arrow::Array.new(values)
           data_type = Arrow::ListDataType.new(:int16)
 
-          # Int8 upper bound is 127
           assert_equal({
                          data_type: data_type,
                          values: [
-                           [0, 128],
-                           [-128],
+                           [0, GLib::MAXINT8 + 1],
+                           [GLib::MININT8],
                          ],
                        },
                        {
@@ -236,8 +233,8 @@ class ArrayBuilderTest < Test::Unit::TestCase
 
         test("list<int16>s boundary") do
           values = [
-            [0, -2**15],
-            [2**15 - 1],
+            [0, GLib::MININT16],
+            [GLib::MAXINT16],
           ]
           array = Arrow::Array.new(values)
           data_type = Arrow::ListDataType.new(:int16)
@@ -245,8 +242,8 @@ class ArrayBuilderTest < Test::Unit::TestCase
           assert_equal({
                          data_type: data_type,
                          values: [
-                           [0, -32768],
-                           [32767],
+                           [0, GLib::MININT16],
+                           [GLib::MAXINT16],
                          ],
                        },
                        {
@@ -257,18 +254,17 @@ class ArrayBuilderTest < Test::Unit::TestCase
 
         test("list<int32>s inferred from int16 underflow") do
           values = [
-            [0, -2**15 - 1],
-            [2**15 - 1],
+            [0, GLib::MININT16 - 1],
+            [GLib::MAXINT16],
           ]
           array = Arrow::Array.new(values)
           data_type = Arrow::ListDataType.new(:int32)
 
-          # Int16 lower bound is -32768
           assert_equal({
                          data_type: data_type,
                          values: [
-                           [0, -32769],
-                           [32767],
+                           [0, GLib::MININT16 - 1],
+                           [GLib::MAXINT16],
                          ],
                        },
                        {
@@ -279,18 +275,17 @@ class ArrayBuilderTest < Test::Unit::TestCase
 
         test("list<int32>s inferred from int16 overflow") do
           values = [
-            [0, 2**15],
-            [-2**15],
+            [0, GLib::MAXINT16 + 1],
+            [GLib::MININT16],
           ]
           array = Arrow::Array.new(values)
           data_type = Arrow::ListDataType.new(:int32)
 
-          # Int16 upper bound is 32767
           assert_equal({
                          data_type: data_type,
                          values: [
-                           [0, 32768],
-                           [-32768],
+                           [0, GLib::MAXINT16 + 1],
+                           [GLib::MININT16],
                          ],
                        },
                        {
@@ -301,8 +296,8 @@ class ArrayBuilderTest < Test::Unit::TestCase
 
         test("list<int32>s boundary") do
           values = [
-            [0, -2**31],
-            [2**31 - 1],
+            [0, GLib::MININT32],
+            [GLib::MAXINT32],
           ]
           array = Arrow::Array.new(values)
           data_type = Arrow::ListDataType.new(:int32)
@@ -310,8 +305,8 @@ class ArrayBuilderTest < Test::Unit::TestCase
           assert_equal({
                          data_type: data_type,
                          values: [
-                           [0, -2147483648],
-                           [2147483647],
+                           [0, GLib::MININT32],
+                           [GLib::MAXINT32],
                          ],
                        },
                        {
@@ -322,18 +317,17 @@ class ArrayBuilderTest < Test::Unit::TestCase
 
         test("list<int64>s inferred from int32 underflow") do
           values = [
-            [0, -2**31 - 1],
-            [2**31 - 1],
+            [0, GLib::MININT32 - 1],
+            [GLib::MAXINT32],
           ]
           array = Arrow::Array.new(values)
           data_type = Arrow::ListDataType.new(:int64)
 
-          # Int32 lower bound is -2147483648
           assert_equal({
                          data_type: data_type,
                          values: [
-                           [0, -2147483649],
-                           [2147483647],
+                           [0, GLib::MININT32 - 1],
+                           [GLib::MAXINT32],
                          ],
                        },
                        {
@@ -344,18 +338,17 @@ class ArrayBuilderTest < Test::Unit::TestCase
 
         test("list<int64>s inferred from int32 overflow") do
           values = [
-            [0, 2**31],
-            [-2**31],
+            [0, GLib::MAXINT32 + 1],
+            [GLib::MININT32],
           ]
           array = Arrow::Array.new(values)
           data_type = Arrow::ListDataType.new(:int64)
 
-          # Int32 upper bound is 2147483647
           assert_equal({
                          data_type: data_type,
                          values: [
-                           [0, 2147483648],
-                           [-2147483648],
+                           [0, GLib::MAXINT32 + 1],
+                           [GLib::MININT32],
                          ],
                        },
                        {
@@ -366,8 +359,8 @@ class ArrayBuilderTest < Test::Unit::TestCase
 
         test("string fallback from nested int64 array overflow") do
           values = [
-            [0, 2**63],
-            [-2**63],
+            [0, GLib::MAXINT64 + 1],
+            [GLib::MININT64],
           ]
           array = Arrow::Array.new(values)
           data_type = Arrow::ListDataType.new(:string)
@@ -375,8 +368,8 @@ class ArrayBuilderTest < Test::Unit::TestCase
           assert_equal({
                          data_type: data_type,
                          values: [
-                           ["0", "9223372036854775808"],
-                           ["-9223372036854775808"],
+                           ["0", "#{GLib::MAXINT64 + 1}"],
+                           ["#{GLib::MININT64}"],
                          ],
                        },
                        {
@@ -387,8 +380,8 @@ class ArrayBuilderTest < Test::Unit::TestCase
 
         test("string fallback from nested int64 array underflow") do
           values = [
-            [0, -2**63 - 1],
-            [2**63 - 1],
+            [0, GLib::MININT64 - 1],
+            [GLib::MAXINT64],
           ]
           array = Arrow::Array.new(values)
           data_type = Arrow::ListDataType.new(:string)
@@ -396,8 +389,8 @@ class ArrayBuilderTest < Test::Unit::TestCase
           assert_equal({
                          data_type: data_type,
                          values: [
-                           ["0", "-9223372036854775809"],
-                           ["9223372036854775807"],
+                           ["0", "#{GLib::MININT64 - 1}"],
+                           ["#{GLib::MAXINT64}"],
                          ],
                        },
                        {
@@ -407,10 +400,9 @@ class ArrayBuilderTest < Test::Unit::TestCase
         end
 
         test("list<uint8>s boundary") do
-          # UInt8 can hold values up to 255,
           values = [
-            [0, 2**8 - 1],
-            [2**8 - 1],
+            [0, GLib::MAXUINT8],
+            [GLib::MAXUINT8],
           ]
           array = Arrow::Array.new(values)
           data_type = Arrow::ListDataType.new(:uint8)
@@ -418,8 +410,8 @@ class ArrayBuilderTest < Test::Unit::TestCase
           assert_equal({
                          data_type: data_type,
                          values: [
-                           [0, 255],
-                           [255],
+                           [0, GLib::MAXUINT8],
+                           [GLib::MAXUINT8],
                          ],
                        },
                        {
@@ -430,18 +422,17 @@ class ArrayBuilderTest < Test::Unit::TestCase
 
         test("list<uint16>s") do
           values = [
-            [0, 2**8],
-            [2**8 - 1],
+            [0, GLib::MAXUINT8 + 1],
+            [GLib::MAXUINT8],
           ]
           array = Arrow::Array.new(values)
           data_type = Arrow::ListDataType.new(:uint16)
 
-          # UInt8 can hold values up to 255
           assert_equal({
                          data_type: data_type,
                          values: [
-                           [0, 256],
-                           [255],
+                           [0, GLib::MAXUINT8 + 1],
+                           [GLib::MAXUINT8],
                          ],
                        },
                        {
@@ -452,8 +443,8 @@ class ArrayBuilderTest < Test::Unit::TestCase
 
         test("list<uint16>s boundary") do
           values = [
-            [0, 2**16 - 1],
-            [2**16 - 1],
+            [0, GLib::MAXUINT16],
+            [GLib::MAXUINT16],
           ]
           array = Arrow::Array.new(values)
           data_type = Arrow::ListDataType.new(:uint16)
@@ -461,8 +452,8 @@ class ArrayBuilderTest < Test::Unit::TestCase
           assert_equal({
                          data_type: data_type,
                          values: [
-                           [0, 65535],
-                           [65535],
+                           [0, GLib::MAXUINT16],
+                           [GLib::MAXUINT16],
                          ],
                        },
                        {
@@ -473,18 +464,17 @@ class ArrayBuilderTest < Test::Unit::TestCase
 
         test("list<uint32>s") do
           values = [
-            [0, 2**16],
-            [2**16 - 1],
+            [0, GLib::MAXUINT16 + 1],
+            [GLib::MAXUINT16],
           ]
           array = Arrow::Array.new(values)
           data_type = Arrow::ListDataType.new(:uint32)
 
-          # UInt16 can hold values up to 65535
           assert_equal({
                          data_type: data_type,
                          values: [
-                           [0, 65536],
-                           [65535],
+                           [0, GLib::MAXUINT16 + 1],
+                           [GLib::MAXUINT16],
                          ],
                        },
                        {
@@ -495,8 +485,8 @@ class ArrayBuilderTest < Test::Unit::TestCase
 
         test("list<uint32>s boundary") do
           values = [
-            [0, 2**32 - 1],
-            [2**32 - 1],
+            [0, GLib::MAXUINT32],
+            [GLib::MAXUINT32],
           ]
           array = Arrow::Array.new(values)
           data_type = Arrow::ListDataType.new(:uint32)
@@ -504,8 +494,8 @@ class ArrayBuilderTest < Test::Unit::TestCase
           assert_equal({
                          data_type: data_type,
                          values: [
-                           [0, 4294967295],
-                           [4294967295],
+                           [0, GLib::MAXUINT32],
+                           [GLib::MAXUINT32],
                          ],
                        },
                        {
@@ -516,18 +506,17 @@ class ArrayBuilderTest < Test::Unit::TestCase
 
         test("list<uint64>s") do
           values = [
-            [0, 2**32],
-            [2**32 - 1],
+            [0, GLib::MAXUINT32 + 1],
+            [GLib::MAXUINT32],
           ]
           array = Arrow::Array.new(values)
           data_type = Arrow::ListDataType.new(:uint64)
 
-          # UInt32 can hold values up to 4294967295
           assert_equal({
                          data_type: data_type,
                          values: [
-                           [0, 4294967296],
-                           [4294967295],
+                           [0, GLib::MAXUINT32 + 1],
+                           [GLib::MAXUINT32],
                          ],
                        },
                        {
@@ -538,8 +527,8 @@ class ArrayBuilderTest < Test::Unit::TestCase
 
         test("string fallback from nested uint64 array overflow") do
           values = [
-            [0, 2**64],
-            [2**64 - 1],
+            [0, GLib::MAXUINT64 + 1],
+            [GLib::MAXUINT64],
           ]
           array = Arrow::Array.new(values)
           data_type = Arrow::ListDataType.new(:string)
@@ -547,8 +536,8 @@ class ArrayBuilderTest < Test::Unit::TestCase
           assert_equal({
                          data_type: data_type,
                          values: [
-                           ["0", "18446744073709551616"],
-                           ["18446744073709551615"],
+                           ["0", "#{GLib::MAXUINT64 + 1}"],
+                           ["#{GLib::MAXUINT64}"],
                          ],
                        },
                        {

--- a/ruby/red-arrow/test/test-array-builder.rb
+++ b/ruby/red-arrow/test/test-array-builder.rb
@@ -154,7 +154,7 @@ class ArrayBuilderTest < Test::Unit::TestCase
             [3, 4],
           ]
           array = Arrow::Array.new(values)
-          data_type = Arrow::ListDataType.new(Arrow::UInt8DataType.new)
+          data_type = Arrow::ListDataType.new(:uint8)
           assert_equal({
                          data_type: data_type,
                          values: [
@@ -175,7 +175,7 @@ class ArrayBuilderTest < Test::Unit::TestCase
             [2**7 - 1],
           ]
           array = Arrow::Array.new(values)
-          data_type = Arrow::ListDataType.new(Arrow::Int8DataType.new)
+          data_type = Arrow::ListDataType.new(:int8)
 
           assert_equal({
                          data_type: data_type,
@@ -196,7 +196,7 @@ class ArrayBuilderTest < Test::Unit::TestCase
             [2**7 - 1],
           ]
           array = Arrow::Array.new(values)
-          data_type = Arrow::ListDataType.new(Arrow::Int16DataType.new)
+          data_type = Arrow::ListDataType.new(:int16)
 
           # Int8 lower bound is -128
           assert_equal({
@@ -218,7 +218,7 @@ class ArrayBuilderTest < Test::Unit::TestCase
             [-2**7],
           ]
           array = Arrow::Array.new(values)
-          data_type = Arrow::ListDataType.new(Arrow::Int16DataType.new)
+          data_type = Arrow::ListDataType.new(:int16)
 
           # Int8 upper bound is 127
           assert_equal({
@@ -240,7 +240,7 @@ class ArrayBuilderTest < Test::Unit::TestCase
             [2**15 - 1],
           ]
           array = Arrow::Array.new(values)
-          data_type = Arrow::ListDataType.new(Arrow::Int16DataType.new)
+          data_type = Arrow::ListDataType.new(:int16)
 
           assert_equal({
                          data_type: data_type,
@@ -261,7 +261,7 @@ class ArrayBuilderTest < Test::Unit::TestCase
             [2**15 - 1],
           ]
           array = Arrow::Array.new(values)
-          data_type = Arrow::ListDataType.new(Arrow::Int32DataType.new)
+          data_type = Arrow::ListDataType.new(:int32)
 
           # Int16 lower bound is -32768
           assert_equal({
@@ -283,7 +283,7 @@ class ArrayBuilderTest < Test::Unit::TestCase
             [-2**15],
           ]
           array = Arrow::Array.new(values)
-          data_type = Arrow::ListDataType.new(Arrow::Int32DataType.new)
+          data_type = Arrow::ListDataType.new(:int32)
 
           # Int16 upper bound is 32767
           assert_equal({
@@ -305,7 +305,7 @@ class ArrayBuilderTest < Test::Unit::TestCase
             [2**31 - 1],
           ]
           array = Arrow::Array.new(values)
-          data_type = Arrow::ListDataType.new(Arrow::Int32DataType.new)
+          data_type = Arrow::ListDataType.new(:int32)
 
           assert_equal({
                          data_type: data_type,
@@ -326,7 +326,7 @@ class ArrayBuilderTest < Test::Unit::TestCase
             [2**31 - 1],
           ]
           array = Arrow::Array.new(values)
-          data_type = Arrow::ListDataType.new(Arrow::Int64DataType.new)
+          data_type = Arrow::ListDataType.new(:int64)
 
           # Int32 lower bound is -2147483648
           assert_equal({
@@ -348,7 +348,7 @@ class ArrayBuilderTest < Test::Unit::TestCase
             [-2**31],
           ]
           array = Arrow::Array.new(values)
-          data_type = Arrow::ListDataType.new(Arrow::Int64DataType.new)
+          data_type = Arrow::ListDataType.new(:int64)
 
           # Int32 upper bound is 2147483647
           assert_equal({
@@ -370,7 +370,7 @@ class ArrayBuilderTest < Test::Unit::TestCase
             [-2**63],
           ]
           array = Arrow::Array.new(values)
-          data_type = Arrow::ListDataType.new(Arrow::StringDataType.new)
+          data_type = Arrow::ListDataType.new(:string)
 
           assert_equal({
                          data_type: data_type,
@@ -391,7 +391,7 @@ class ArrayBuilderTest < Test::Unit::TestCase
             [2**63 - 1],
           ]
           array = Arrow::Array.new(values)
-          data_type = Arrow::ListDataType.new(Arrow::StringDataType.new)
+          data_type = Arrow::ListDataType.new(:string)
 
           assert_equal({
                          data_type: data_type,
@@ -413,7 +413,7 @@ class ArrayBuilderTest < Test::Unit::TestCase
             [2**8 - 1],
           ]
           array = Arrow::Array.new(values)
-          data_type = Arrow::ListDataType.new(Arrow::UInt8DataType.new)
+          data_type = Arrow::ListDataType.new(:uint8)
 
           assert_equal({
                          data_type: data_type,
@@ -434,7 +434,7 @@ class ArrayBuilderTest < Test::Unit::TestCase
             [2**8 - 1],
           ]
           array = Arrow::Array.new(values)
-          data_type = Arrow::ListDataType.new(Arrow::UInt16DataType.new)
+          data_type = Arrow::ListDataType.new(:uint16)
 
           # UInt8 can hold values up to 255
           assert_equal({
@@ -456,7 +456,7 @@ class ArrayBuilderTest < Test::Unit::TestCase
             [2**16 - 1],
           ]
           array = Arrow::Array.new(values)
-          data_type = Arrow::ListDataType.new(Arrow::UInt16DataType.new)
+          data_type = Arrow::ListDataType.new(:uint16)
 
           assert_equal({
                          data_type: data_type,
@@ -477,7 +477,7 @@ class ArrayBuilderTest < Test::Unit::TestCase
             [2**16 - 1],
           ]
           array = Arrow::Array.new(values)
-          data_type = Arrow::ListDataType.new(Arrow::UInt32DataType.new)
+          data_type = Arrow::ListDataType.new(:uint32)
 
           # UInt16 can hold values up to 65535
           assert_equal({
@@ -499,7 +499,7 @@ class ArrayBuilderTest < Test::Unit::TestCase
             [2**32 - 1],
           ]
           array = Arrow::Array.new(values)
-          data_type = Arrow::ListDataType.new(Arrow::UInt32DataType.new)
+          data_type = Arrow::ListDataType.new(:uint32)
 
           assert_equal({
                          data_type: data_type,
@@ -520,7 +520,7 @@ class ArrayBuilderTest < Test::Unit::TestCase
             [2**32 - 1],
           ]
           array = Arrow::Array.new(values)
-          data_type = Arrow::ListDataType.new(Arrow::UInt64DataType.new)
+          data_type = Arrow::ListDataType.new(:uint64)
 
           # UInt32 can hold values up to 4294967295
           assert_equal({
@@ -542,7 +542,7 @@ class ArrayBuilderTest < Test::Unit::TestCase
             [2**64 - 1],
           ]
           array = Arrow::Array.new(values)
-          data_type = Arrow::ListDataType.new(Arrow::StringDataType.new)
+          data_type = Arrow::ListDataType.new(:string)
 
           assert_equal({
                          data_type: data_type,

--- a/ruby/red-arrow/test/test-array-builder.rb
+++ b/ruby/red-arrow/test/test-array-builder.rb
@@ -168,26 +168,6 @@ class ArrayBuilderTest < Test::Unit::TestCase
                        })
         end
 
-        test("list<int8>s") do
-          values = [
-            [0, -1, 2],
-            [3, 4],
-          ]
-          array = Arrow::Array.new(values)
-          data_type = Arrow::ListDataType.new(Arrow::Int8DataType.new)
-          assert_equal({
-                         data_type: data_type,
-                         values: [
-                           [0, -1, 2],
-                           [3, 4],
-                         ],
-                       },
-                       {
-                         data_type: array.value_data_type,
-                         values: array.to_a,
-                       })
-        end
-
         test("list<int8>s boundary") do
           # Int8 can hold values from -128 to 127.
           values = [

--- a/ruby/red-arrow/test/test-array-builder.rb
+++ b/ruby/red-arrow/test/test-array-builder.rb
@@ -147,44 +147,435 @@ class ArrayBuilderTest < Test::Unit::TestCase
                      ])
       end
 
-      test("list<uint>s") do
-        values = [
-          [0, 1, 2],
-          [3, 4],
-        ]
-        array = Arrow::Array.new(values)
-        data_type = Arrow::ListDataType.new(Arrow::UInt8DataType.new)
-        assert_equal({
-                       data_type: data_type,
-                       values: [
-                         [0, 1, 2],
-                         [3, 4],
-                       ],
-                     },
-                     {
-                       data_type: array.value_data_type,
-                       values: array.to_a,
-                     })
-      end
+      sub_test_case("nested integer list") do
+        test("list<uint8>s") do
+          values = [
+            [0, 1, 2],
+            [3, 4],
+          ]
+          array = Arrow::Array.new(values)
+          data_type = Arrow::ListDataType.new(Arrow::UInt8DataType.new)
+          assert_equal({
+                         data_type: data_type,
+                         values: [
+                           [0, 1, 2],
+                           [3, 4],
+                         ],
+                       },
+                       {
+                         data_type: array.value_data_type,
+                         values: array.to_a,
+                       })
+        end
 
-      test("list<int>s") do
-        values = [
-          [0, -1, 2],
-          [3, 4],
-        ]
-        array = Arrow::Array.new(values)
-        data_type = Arrow::ListDataType.new(Arrow::Int8DataType.new)
-        assert_equal({
-                       data_type: data_type,
-                       values: [
-                         [0, -1, 2],
-                         [3, 4],
-                       ],
-                     },
-                     {
-                       data_type: array.value_data_type,
-                       values: array.to_a,
-                     })
+        test("list<int8>s") do
+          values = [
+            [0, -1, 2],
+            [3, 4],
+          ]
+          array = Arrow::Array.new(values)
+          data_type = Arrow::ListDataType.new(Arrow::Int8DataType.new)
+          assert_equal({
+                         data_type: data_type,
+                         values: [
+                           [0, -1, 2],
+                           [3, 4],
+                         ],
+                       },
+                       {
+                         data_type: array.value_data_type,
+                         values: array.to_a,
+                       })
+        end
+
+        test("list<int8>s boundary") do
+          # Int8 can hold values from -128 to 127.
+          values = [
+            [0, -2**7],
+            [2**7 - 1],
+          ]
+          array = Arrow::Array.new(values)
+          data_type = Arrow::ListDataType.new(Arrow::Int8DataType.new)
+
+          assert_equal({
+                         data_type: data_type,
+                         values: [
+                           [0, -128],
+                           [127],
+                         ],
+                       },
+                       {
+                         data_type: array.value_data_type,
+                         values: array.to_a,
+                       })
+        end
+
+        test("list<int16>s inferred from int8 underflow") do
+          values = [
+            [0, -2**7 - 1],
+            [2**7 - 1],
+          ]
+          array = Arrow::Array.new(values)
+          data_type = Arrow::ListDataType.new(Arrow::Int16DataType.new)
+
+          # Int8 lower bound is -128
+          assert_equal({
+                         data_type: data_type,
+                         values: [
+                           [0, -129],
+                           [127],
+                         ],
+                       },
+                       {
+                         data_type: array.value_data_type,
+                         values: array.to_a,
+                       })
+        end
+
+        test("list<int16>s inferred from int8 overflow") do
+          values = [
+            [0, 2**7],
+            [-2**7],
+          ]
+          array = Arrow::Array.new(values)
+          data_type = Arrow::ListDataType.new(Arrow::Int16DataType.new)
+
+          # Int8 upper bound is 127
+          assert_equal({
+                         data_type: data_type,
+                         values: [
+                           [0, 128],
+                           [-128],
+                         ],
+                       },
+                       {
+                         data_type: array.value_data_type,
+                         values: array.to_a,
+                       })
+        end
+
+        test("list<int16>s boundary") do
+          values = [
+            [0, -2**15],
+            [2**15 - 1],
+          ]
+          array = Arrow::Array.new(values)
+          data_type = Arrow::ListDataType.new(Arrow::Int16DataType.new)
+
+          assert_equal({
+                         data_type: data_type,
+                         values: [
+                           [0, -32768],
+                           [32767],
+                         ],
+                       },
+                       {
+                         data_type: array.value_data_type,
+                         values: array.to_a,
+                       })
+        end
+
+        test("list<int32>s inferred from int16 underflow") do
+          values = [
+            [0, -2**15 - 1],
+            [2**15 - 1],
+          ]
+          array = Arrow::Array.new(values)
+          data_type = Arrow::ListDataType.new(Arrow::Int32DataType.new)
+
+          # Int16 lower bound is -32768
+          assert_equal({
+                         data_type: data_type,
+                         values: [
+                           [0, -32769],
+                           [32767],
+                         ],
+                       },
+                       {
+                         data_type: array.value_data_type,
+                         values: array.to_a,
+                       })
+        end
+
+        test("list<int32>s inferred from int16 overflow") do
+          values = [
+            [0, 2**15],
+            [-2**15],
+          ]
+          array = Arrow::Array.new(values)
+          data_type = Arrow::ListDataType.new(Arrow::Int32DataType.new)
+
+          # Int16 upper bound is 32767
+          assert_equal({
+                         data_type: data_type,
+                         values: [
+                           [0, 32768],
+                           [-32768],
+                         ],
+                       },
+                       {
+                         data_type: array.value_data_type,
+                         values: array.to_a,
+                       })
+        end
+
+        test("list<int32>s boundary") do
+          values = [
+            [0, -2**31],
+            [2**31 - 1],
+          ]
+          array = Arrow::Array.new(values)
+          data_type = Arrow::ListDataType.new(Arrow::Int32DataType.new)
+
+          assert_equal({
+                         data_type: data_type,
+                         values: [
+                           [0, -2147483648],
+                           [2147483647],
+                         ],
+                       },
+                       {
+                         data_type: array.value_data_type,
+                         values: array.to_a,
+                       })
+        end
+
+        test("list<int64>s inferred from int32 underflow") do
+          values = [
+            [0, -2**31 - 1],
+            [2**31 - 1],
+          ]
+          array = Arrow::Array.new(values)
+          data_type = Arrow::ListDataType.new(Arrow::Int64DataType.new)
+
+          # Int32 lower bound is -2147483648
+          assert_equal({
+                         data_type: data_type,
+                         values: [
+                           [0, -2147483649],
+                           [2147483647],
+                         ],
+                       },
+                       {
+                         data_type: array.value_data_type,
+                         values: array.to_a,
+                       })
+        end
+
+        test("list<int64>s inferred from int32 overflow") do
+          values = [
+            [0, 2**31],
+            [-2**31],
+          ]
+          array = Arrow::Array.new(values)
+          data_type = Arrow::ListDataType.new(Arrow::Int64DataType.new)
+
+          # Int32 upper bound is 2147483647
+          assert_equal({
+                         data_type: data_type,
+                         values: [
+                           [0, 2147483648],
+                           [-2147483648],
+                         ],
+                       },
+                       {
+                         data_type: array.value_data_type,
+                         values: array.to_a,
+                       })
+        end
+
+        test("string fallback from nested int64 array overflow") do
+          values = [
+            [0, 2**63],
+            [-2**63],
+          ]
+          array = Arrow::Array.new(values)
+          data_type = Arrow::ListDataType.new(Arrow::StringDataType.new)
+
+          assert_equal({
+                         data_type: data_type,
+                         values: [
+                           ["0", "9223372036854775808"],
+                           ["-9223372036854775808"],
+                         ],
+                       },
+                       {
+                         data_type: array.value_data_type,
+                         values: array.to_a,
+                       })
+        end
+
+        test("string fallback from nested int64 array underflow") do
+          values = [
+            [0, -2**63 - 1],
+            [2**63 - 1],
+          ]
+          array = Arrow::Array.new(values)
+          data_type = Arrow::ListDataType.new(Arrow::StringDataType.new)
+
+          assert_equal({
+                         data_type: data_type,
+                         values: [
+                           ["0", "-9223372036854775809"],
+                           ["9223372036854775807"],
+                         ],
+                       },
+                       {
+                         data_type: array.value_data_type,
+                         values: array.to_a,
+                       })
+        end
+
+        test("list<uint8>s boundary") do
+          # UInt8 can hold values up to 255,
+          values = [
+            [0, 2**8 - 1],
+            [2**8 - 1],
+          ]
+          array = Arrow::Array.new(values)
+          data_type = Arrow::ListDataType.new(Arrow::UInt8DataType.new)
+
+          assert_equal({
+                         data_type: data_type,
+                         values: [
+                           [0, 255],
+                           [255],
+                         ],
+                       },
+                       {
+                         data_type: array.value_data_type,
+                         values: array.to_a,
+                       })
+        end
+
+        test("list<uint16>s") do
+          values = [
+            [0, 2**8],
+            [2**8 - 1],
+          ]
+          array = Arrow::Array.new(values)
+          data_type = Arrow::ListDataType.new(Arrow::UInt16DataType.new)
+
+          # UInt8 can hold values up to 255
+          assert_equal({
+                         data_type: data_type,
+                         values: [
+                           [0, 256],
+                           [255],
+                         ],
+                       },
+                       {
+                         data_type: array.value_data_type,
+                         values: array.to_a,
+                       })
+        end
+
+        test("list<uint16>s boundary") do
+          values = [
+            [0, 2**16 - 1],
+            [2**16 - 1],
+          ]
+          array = Arrow::Array.new(values)
+          data_type = Arrow::ListDataType.new(Arrow::UInt16DataType.new)
+
+          assert_equal({
+                         data_type: data_type,
+                         values: [
+                           [0, 65535],
+                           [65535],
+                         ],
+                       },
+                       {
+                         data_type: array.value_data_type,
+                         values: array.to_a,
+                       })
+        end
+
+        test("list<uint32>s") do
+          values = [
+            [0, 2**16],
+            [2**16 - 1],
+          ]
+          array = Arrow::Array.new(values)
+          data_type = Arrow::ListDataType.new(Arrow::UInt32DataType.new)
+
+          # UInt16 can hold values up to 65535
+          assert_equal({
+                         data_type: data_type,
+                         values: [
+                           [0, 65536],
+                           [65535],
+                         ],
+                       },
+                       {
+                         data_type: array.value_data_type,
+                         values: array.to_a,
+                       })
+        end
+
+        test("list<uint32>s boundary") do
+          values = [
+            [0, 2**32 - 1],
+            [2**32 - 1],
+          ]
+          array = Arrow::Array.new(values)
+          data_type = Arrow::ListDataType.new(Arrow::UInt32DataType.new)
+
+          assert_equal({
+                         data_type: data_type,
+                         values: [
+                           [0, 4294967295],
+                           [4294967295],
+                         ],
+                       },
+                       {
+                         data_type: array.value_data_type,
+                         values: array.to_a,
+                       })
+        end
+
+        test("list<uint64>s") do
+          values = [
+            [0, 2**32],
+            [2**32 - 1],
+          ]
+          array = Arrow::Array.new(values)
+          data_type = Arrow::ListDataType.new(Arrow::UInt64DataType.new)
+
+          # UInt32 can hold values up to 4294967295
+          assert_equal({
+                         data_type: data_type,
+                         values: [
+                           [0, 4294967296],
+                           [4294967295],
+                         ],
+                       },
+                       {
+                         data_type: array.value_data_type,
+                         values: array.to_a,
+                       })
+        end
+
+        test("string fallback from nested uint64 array overflow") do
+          values = [
+            [0, 2**64],
+            [2**64 - 1],
+          ]
+          array = Arrow::Array.new(values)
+          data_type = Arrow::ListDataType.new(Arrow::StringDataType.new)
+
+          assert_equal({
+                         data_type: data_type,
+                         values: [
+                           ["0", "18446744073709551616"],
+                           ["18446744073709551615"],
+                         ],
+                       },
+                       {
+                         data_type: array.value_data_type,
+                         values: array.to_a,
+                       })
+        end
       end
     end
 


### PR DESCRIPTION
### Rationale for this change

When building an `Arrow::Table` from a Ruby Hash passed to `Arrow::Table.new`, nested Integer arrays are incorrectly inferred as `list<uint8>` or `list<int8>` regardless of the actual values contained. Nested integer arrays should be correctly inferred as the appropriate list type (e.g., `list<int64>`, `list<uint64>`) based on their values, similar to how flat arrays are handled, unless they contain values out of range for any integer type.

### What changes are included in this PR?

This PR modifies the logic in `detect_builder_info()` to fix the inference issue. Specifically:

- **Persist `sub_builder_info` across sub-array elements**: Previously, `sub_builder_info` was recreated for each sub-array element in the Array. The logic has been updated to accumulate and carry over the builder information across elements to ensure correct type inference for the entire list.
- **Refactor Integer builder logic**: Following the pattern used for `BigDecimal`, the logic for determining the Integer builder has been moved to `create_builder()`. `detect_builder_info()` now calls this function.

**Note:**   

- As a side effect of this refactoring, nested lists of `BigDecimal` (which were previously inferred as `string`) may now have their types inferred. However, comprehensive testing and verification for nested `BigDecimal` support will be addressed in a separate issue to keep this PR focused.
- We stopped using `IntArrayBuilder` for inference logic to ensure correctness. This results in a performance overhead (array building is approximately 2x slower) as we can no longer rely on the specialized builder's detection.

```text
                                           user     system      total        real
    array_builder int32 100000         0.085867   0.000194   0.086061 (  0.086369)
int_array_builder int32 100000         0.042163   0.001033   0.043196 (  0.043268)
    array_builder int64 100000         0.086799   0.000015   0.086814 (  0.086828)
int_array_builder int64 100000         0.044493   0.000973   0.045466 (  0.045469)
    array_builder uint32 100000        0.085748   0.000009   0.085757 (  0.085768)
int_array_builder uint32 100000        0.044463   0.001034   0.045497 (  0.045498)
    array_builder uint64 100000        0.084548   0.000987   0.085535 (  0.085537)
int_array_builder uint64 100000        0.044206   0.000017   0.044223 (  0.044225)
```

### Are these changes tested?

Yes. `ruby ruby/red-arrow/test/run-test.rb`

### Are there any user-facing changes?

Yes.

* GitHub Issue: #48481