### PR TITLE
MINOR: [C++] Fix a typo in the doc of  `pyarrow.compute.ascii_upper`

### DIFF
--- a/cpp/src/arrow/compute/kernels/scalar_string_ascii.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_string_ascii.cc
@@ -804,7 +804,7 @@ using AsciiTitle = StringTransformExec<Type, AsciiTitleTransform>;
 const FunctionDoc ascii_upper_doc(
     "Transform ASCII input to uppercase",
     ("For each string in `strings`, return an uppercase version.\n\n"
-     "This function assumes the input is fully ASCII.  It it may contain\n"
+     "This function assumes the input is fully ASCII.  If it may contain\n"
      "non-ASCII characters, use \"utf8_upper\" instead."),
     {"strings"});
 


### PR DESCRIPTION
### Rationale for this change
in existing https://arrow.apache.org/docs/dev/python/generated/pyarrow.compute.ascii_upper.html

> This function assumes the input is fully ASCII. It it may contain non-ASCII characters, use “utf8_upper” instead.



### What changes are included in this PR?
Fix a typo in the docstring of  `pyarrow.compute.ascii_upper`


### Are these changes tested?
CI

### Are there any user-facing changes?
yes, doc-only change
