### PR TITLE
GH-24157: [C++] Add tests for DayTimeIntervalBuilder

### DIFF
--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -4305,7 +4305,7 @@ TEST_F(TestDayTimeIntervalBuilder, TestConstructors) {
   DayTimeIntervalBuilder builder1;
   ASSERT_EQ(builder1.type()->id(), Type::INTERVAL_DAY_TIME);
 
-  MemoryPool* pool = default_memory_pool();
+  auto pool = default_memory_pool();
   DayTimeIntervalBuilder builder2(pool);
   ASSERT_EQ(builder2.type()->id(), Type::INTERVAL_DAY_TIME);
 

--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -4255,6 +4255,7 @@ TEST_F(TestDayTimeIntervalBuilder, TestAppend) {
   ASSERT_OK(builder.Append(value1));
   ASSERT_OK(builder.Append(value2));
   ASSERT_OK(builder.AppendNull());
+  ASSERT_EQ(1, builder.null_count());  // Verify null count in builder
   ASSERT_OK(builder.Reserve(3));
   builder.UnsafeAppend(value3);
 
@@ -4263,7 +4264,19 @@ TEST_F(TestDayTimeIntervalBuilder, TestAppend) {
   VerifyValue(builder, 3, value3);
 
   ASSERT_OK_AND_ASSIGN(auto array, builder.Finish());
-  ASSERT_TRUE(array->IsNull(2));
+  const auto& day_time_array = checked_cast<const DayTimeIntervalArray&>(*array);
+
+  // Verify null value
+  ASSERT_TRUE(day_time_array.IsNull(2));
+  ASSERT_EQ(1, day_time_array.null_count());
+
+  // Verify non-null values in the array
+  ASSERT_FALSE(day_time_array.IsNull(0));
+  ASSERT_EQ(day_time_array.GetValue(0), value1);
+  ASSERT_FALSE(day_time_array.IsNull(1));
+  ASSERT_EQ(day_time_array.GetValue(1), value2);
+  ASSERT_FALSE(day_time_array.IsNull(3));
+  ASSERT_EQ(day_time_array.GetValue(3), value3);
 }
 
 TEST_F(TestDayTimeIntervalBuilder, TestBulkAppend) {

--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -4237,4 +4237,69 @@ TEST_F(TestHalfFloatBuilder, TestBulkAppend) {
   }
 }
 
+class TestDayTimeIntervalBuilder : public ::testing::Test {
+ public:
+  void VerifyValue(const DayTimeIntervalBuilder& builder, int64_t index,
+                   DayTimeIntervalType::DayMilliseconds expected) {
+    ASSERT_EQ(builder.GetValue(index), expected);
+    ASSERT_EQ(builder[index], expected);
+  }
+};
+
+TEST_F(TestDayTimeIntervalBuilder, TestAppend) {
+  DayTimeIntervalBuilder builder;
+  DayTimeIntervalType::DayMilliseconds value1{1, 100};
+  DayTimeIntervalType::DayMilliseconds value2{3, 200};
+  DayTimeIntervalType::DayMilliseconds value3{5, 300};
+
+  ASSERT_OK(builder.Append(value1));
+  ASSERT_OK(builder.Append(value2));
+  ASSERT_OK(builder.AppendNull());
+  ASSERT_OK(builder.Reserve(3));
+  builder.UnsafeAppend(value3);
+
+  VerifyValue(builder, 0, value1);
+  VerifyValue(builder, 1, value2);
+  VerifyValue(builder, 3, value3);
+
+  ASSERT_OK_AND_ASSIGN(auto array, builder.Finish());
+  ASSERT_TRUE(array->IsNull(2));
+}
+
+TEST_F(TestDayTimeIntervalBuilder, TestBulkAppend) {
+  DayTimeIntervalBuilder builder;
+  std::vector<DayTimeIntervalType::DayMilliseconds> values{{1, 100}, {3, 200}, {5, 300}};
+  std::vector<bool> is_valid{true, false, true};
+  std::vector<uint8_t> is_valid_bytes{1, 0, 1};
+
+  ASSERT_OK(builder.AppendValues(values));
+  ASSERT_OK(builder.AppendValues(values, is_valid));
+  ASSERT_OK(builder.AppendValues(values.data(), values.size(), is_valid_bytes.data()));
+
+  ASSERT_OK_AND_ASSIGN(auto array, builder.Finish());
+  ASSERT_OK(array->ValidateFull());
+  ASSERT_EQ(array->null_count(), 2);
+  ASSERT_EQ(array->length(), 9);
+
+  const auto& day_time_array = checked_cast<const DayTimeIntervalArray&>(*array);
+  ASSERT_EQ(day_time_array.GetValue(0), values[0]);
+  ASSERT_TRUE(day_time_array.IsNull(4));
+  ASSERT_TRUE(day_time_array.IsNull(7));
+  ASSERT_EQ(day_time_array.GetValue(2), values[2]);
+}
+
+TEST_F(TestDayTimeIntervalBuilder, TestConstructors) {
+  DayTimeIntervalBuilder builder1;
+  ASSERT_EQ(builder1.type()->id(), Type::INTERVAL_DAY_TIME);
+
+  MemoryPool* pool = default_memory_pool();
+  DayTimeIntervalBuilder builder2(pool);
+  ASSERT_EQ(builder2.type()->id(), Type::INTERVAL_DAY_TIME);
+
+  auto type = day_time_interval();
+  DayTimeIntervalBuilder builder3(type, pool);
+  ASSERT_EQ(builder3.type()->id(), Type::INTERVAL_DAY_TIME);
+  ASSERT_TRUE(builder3.type()->Equals(type));
+}
+
 }  // namespace arrow

--- a/cpp/src/arrow/array/builder_time.h
+++ b/cpp/src/arrow/array/builder_time.h
@@ -30,8 +30,6 @@ namespace arrow {
 ///
 /// @{
 
-// TODO(ARROW-7938): this class is untested
-
 class ARROW_EXPORT DayTimeIntervalBuilder : public NumericBuilder<DayTimeIntervalType> {
  public:
   using DayMilliseconds = DayTimeIntervalType::DayMilliseconds;


### PR DESCRIPTION
### Rationale for this change

The `DayTimeIntervalBuilder` class was marked as untested (ARROW-7938). This PR adds dedicated tests to verify the builder's functionality, similar to how `TestHalfFloatBuilder` tests `HalfFloatBuilder`.

### What changes are included in this PR?

- Added `TestDayTimeIntervalBuilder` test class with three test cases:
  - `TestAppend`: Tests basic append operations including nulls and unsafe append
  - `TestBulkAppend`: Tests bulk append operations with various signatures
  - `TestConstructors`: Tests all constructor variations (default, with pool, with explicit type)
- Removed the TODO comment from `builder_time.h` since the class is now tested

### Are these changes tested?

Yes, the tests I mentioned are added.

### Are there any user-facing changes?

No, test-only.
* GitHub Issue: #24157