### PR TITLE
GH-36889: [C++][Python] Fix duplicate CSV header when first batch is empty

### DIFF
--- a/cpp/src/arrow/csv/writer.cc
+++ b/cpp/src/arrow/csv/writer.cc
@@ -541,7 +541,7 @@ class CSVWriterImpl : public ipc::RecordBatchWriter {
     for (auto maybe_slice : iterator) {
       ARROW_ASSIGN_OR_RAISE(std::shared_ptr<RecordBatch> slice, maybe_slice);
       RETURN_NOT_OK(TranslateMinimalBatch(*slice));
-      RETURN_NOT_OK(WriteAndClearBuffer());
+      RETURN_NOT_OK(FlushToSink());
       stats_.num_record_batches++;
     }
     return Status::OK();
@@ -554,7 +554,7 @@ class CSVWriterImpl : public ipc::RecordBatchWriter {
     RETURN_NOT_OK(reader.ReadNext(&batch));
     while (batch != nullptr) {
       RETURN_NOT_OK(TranslateMinimalBatch(*batch));
-      RETURN_NOT_OK(WriteAndClearBuffer());
+      RETURN_NOT_OK(FlushToSink());
       RETURN_NOT_OK(reader.ReadNext(&batch));
       stats_.num_record_batches++;
     }
@@ -590,9 +590,9 @@ class CSVWriterImpl : public ipc::RecordBatchWriter {
     return Status::OK();
   }
 
-  // GH-36889: Write buffer to sink and clear it to avoid stale content
+  // GH-36889: Flush buffer to sink and clear it to avoid stale content
   // being written again if the next batch is empty.
-  Status WriteAndClearBuffer() {
+  Status FlushToSink() {
     RETURN_NOT_OK(sink_->Write(data_buffer_));
     return data_buffer_->Resize(0, /*shrink_to_fit=*/false);
   }
@@ -661,7 +661,7 @@ class CSVWriterImpl : public ipc::RecordBatchWriter {
     next += options_.eol.size();
     DCHECK_EQ(reinterpret_cast<uint8_t*>(next),
               data_buffer_->data() + data_buffer_->size());
-    return WriteAndClearBuffer();
+    return FlushToSink();
   }
 
   Status TranslateMinimalBatch(const RecordBatch& batch) {

--- a/cpp/src/arrow/csv/writer.cc
+++ b/cpp/src/arrow/csv/writer.cc
@@ -659,6 +659,8 @@ class CSVWriterImpl : public ipc::RecordBatchWriter {
 
   Status TranslateMinimalBatch(const RecordBatch& batch) {
     if (batch.num_rows() == 0) {
+      // GH-36889: Clear buffer to avoid writing stale content (e.g., header)
+      RETURN_NOT_OK(data_buffer_->Resize(0, /*shrink_to_fit=*/false));
       return Status::OK();
     }
     offsets_.resize(batch.num_rows());

--- a/cpp/src/arrow/csv/writer_test.cc
+++ b/cpp/src/arrow/csv/writer_test.cc
@@ -415,8 +415,7 @@ TEST(TestWriteCSV, EmptyBatchAtStart) {
   // Concatenate empty table with data table
   ASSERT_OK_AND_ASSIGN(auto empty_table, Table::FromRecordBatches(schema, {empty_batch}));
   ASSERT_OK_AND_ASSIGN(auto data_table, Table::FromRecordBatches(schema, {data_batch}));
-  ASSERT_OK_AND_ASSIGN(auto combined_table,
-                       ConcatenateTables({empty_table, data_table}));
+  ASSERT_OK_AND_ASSIGN(auto combined_table, ConcatenateTables({empty_table, data_table}));
 
   ASSERT_OK_AND_ASSIGN(auto out, io::BufferOutputStream::Create());
   ASSERT_OK(WriteCSV(*combined_table, WriteOptions::Defaults(), out.get()));
@@ -435,8 +434,7 @@ TEST(TestWriteCSV, EmptyBatchInMiddle) {
   auto batch2 = RecordBatchFromJSON(schema, R"([{"col1": "b"}])");
 
   ASSERT_OK_AND_ASSIGN(auto table1, Table::FromRecordBatches(schema, {batch1}));
-  ASSERT_OK_AND_ASSIGN(auto empty_table,
-                       Table::FromRecordBatches(schema, {empty_batch}));
+  ASSERT_OK_AND_ASSIGN(auto empty_table, Table::FromRecordBatches(schema, {empty_batch}));
   ASSERT_OK_AND_ASSIGN(auto table2, Table::FromRecordBatches(schema, {batch2}));
   ASSERT_OK_AND_ASSIGN(auto combined_table,
                        ConcatenateTables({table1, empty_table, table2}));

--- a/python/pyarrow/tests/test_csv.py
+++ b/python/pyarrow/tests/test_csv.py
@@ -2065,3 +2065,36 @@ def test_read_csv_gil_deadlock():
     for i in range(20):
         with pytest.raises(pa.ArrowInvalid):
             read_csv(MyBytesIO(data))
+
+
+def test_write_csv_empty_batch_no_duplicate_header():
+    # GH-36889: Empty batches at the start should not cause duplicate headers
+    table = pa.table({"col1": ["a", "b", "c"]})
+
+    # Concatenate empty table with data table
+    empty_table = table.schema.empty_table()
+    combined = pa.concat_tables([empty_table, table])
+
+    buf = io.BytesIO()
+    write_csv(combined, buf)
+    buf.seek(0)
+    result = buf.read()
+
+    # Should have exactly one header, not two
+    assert result == b'"col1"\n"a"\n"b"\n"c"\n'
+
+
+def test_write_csv_empty_batch_in_middle():
+    # GH-36889: Empty batches in the middle should not cause issues
+    table1 = pa.table({"col1": ["a"]})
+    table2 = pa.table({"col1": ["b"]})
+    empty_table = table1.schema.empty_table()
+
+    combined = pa.concat_tables([table1, empty_table, table2])
+
+    buf = io.BytesIO()
+    write_csv(combined, buf)
+    buf.seek(0)
+    result = buf.read()
+
+    assert result == b'"col1"\n"a"\n"b"\n'


### PR DESCRIPTION
### Rationale for this change

Fixes https://github.com/apache/arrow/issues/36889

When writing CSV from a table where the first batch is empty, the header gets written twice:

```python
table = pa.table({"col1": ["a", "b", "c"]})
combined = pa.concat_tables([table.schema.empty_table(), table])
write_csv(combined, buf)
# Result: "col1"\n"col1"\n"a"\n"b"\n"c"\n  <-- header appears twice
```

### What changes are included in this PR?

The bug happens because:
1. Header is written to `data_buffer_` and flushed during `CSVWriterImpl` initialization
2. The buffer is not cleared after flush
3. When the next batch is empty, `TranslateMinimalBatch` returns early without modifying `data_buffer_`
4. The write loop then writes `data_buffer_` which still contains stale content

The fix introduces a `WriteAndClearBuffer()` helper that writes the buffer to sink and clears it. This helper is used in all write paths:
- `WriteHeader()`
- `WriteRecordBatch()`
- `WriteTable()`

This ensures the buffer is always clean after any flush, making it impossible for stale content to be written again.

### Are these changes tested?

Yes. Added C++ tests in `writer_test.cc` and Python tests in `test_csv.py`:
- Empty batch at start of table
- Empty batch in middle of table

### Are there any user-facing changes?

No API changes. This is a bug fix that prevents duplicate headers when writing CSV from tables with empty batches.

* GitHub Issue: #36889