### PR TITLE
GH-48721: [C++] Add test for file creation with UTF-8 filenames

### DIFF
--- a/cpp/src/arrow/io/file_test.cc
+++ b/cpp/src/arrow/io/file_test.cc
@@ -115,7 +115,25 @@ TEST_F(TestFileOutputStream, FileNameWideCharConversionRangeException) {
   ASSERT_RAISES(Invalid, ReadableFile::Open(file_name));
 }
 
-// TODO add a test with a valid utf-8 filename
+TEST_F(TestFileOutputStream, FileNameValidUtf8) {
+  // Test that file operations work with valid UTF-8 filenames.
+  // On Windows, PlatformFilename::FromString() converts UTF-8 strings to wide strings.
+  // On Unix, filenames are treated as opaque byte strings.
+  std::string utf8_file_name = "test_file_한국어_😀.txt";
+  std::string utf8_path = TempFile(utf8_file_name);
+
+  ASSERT_OK_AND_ASSIGN(auto file, FileOutputStream::Open(utf8_path));
+  const char* data = "UTF-8 test data";
+  ASSERT_OK(file->Write(data, strlen(data)));
+  ASSERT_OK(file->Close());
+
+  // Verify we can read it back
+  ASSERT_OK_AND_ASSIGN(auto readable_file, ReadableFile::Open(utf8_path));
+  ASSERT_OK_AND_ASSIGN(auto buffer, readable_file->ReadAt(0, strlen(data)));
+  ASSERT_EQ(std::string(reinterpret_cast<const char*>(buffer->data()), buffer->size()),
+            std::string(data));
+  ASSERT_OK(readable_file->Close());
+}
 #endif
 
 TEST_F(TestFileOutputStream, DestructorClosesFile) {

--- a/cpp/src/arrow/io/file_test.cc
+++ b/cpp/src/arrow/io/file_test.cc
@@ -114,6 +114,7 @@ TEST_F(TestFileOutputStream, FileNameWideCharConversionRangeException) {
   ASSERT_RAISES(Invalid, FileOutputStream::Open(file_name));
   ASSERT_RAISES(Invalid, ReadableFile::Open(file_name));
 }
+#endif
 
 TEST_F(TestFileOutputStream, FileNameValidUtf8) {
   // Test that file operations work with UTF-8 filenames (Korean + emoji).
@@ -134,7 +135,6 @@ TEST_F(TestFileOutputStream, FileNameValidUtf8) {
             std::string(data));
   ASSERT_OK(readable_file->Close());
 }
-#endif
 
 TEST_F(TestFileOutputStream, DestructorClosesFile) {
   int fd_file;

--- a/cpp/src/arrow/io/file_test.cc
+++ b/cpp/src/arrow/io/file_test.cc
@@ -116,14 +116,14 @@ TEST_F(TestFileOutputStream, FileNameWideCharConversionRangeException) {
 }
 
 TEST_F(TestFileOutputStream, FileNameValidUtf8) {
-  // Test that file operations work with valid UTF-8 filenames.
+  // Test that file operations work with UTF-8 filenames (Korean + emoji).
   // On Windows, PlatformFilename::FromString() converts UTF-8 strings to wide strings.
   // On Unix, filenames are treated as opaque byte strings.
   std::string utf8_file_name = "test_file_한국어_😀.txt";
   std::string utf8_path = TempFile(utf8_file_name);
 
   ASSERT_OK_AND_ASSIGN(auto file, FileOutputStream::Open(utf8_path));
-  const char* data = "UTF-8 test data";
+  const char* data = "test content";
   ASSERT_OK(file->Write(data, strlen(data)));
   ASSERT_OK(file->Close());
 


### PR DESCRIPTION
### Rationale for this change

https://github.com/apache/arrow/commit/4937d9fd2033a80a8f5ad81d25cde30195dfe620 (ARROW-5102) added the TODO comment requesting a test with valid UTF-8 filenames. Later, the UTF-8 to UTF-16 conversion logic on Windows was introduced in commit https://github.com/apache/arrow/commit/eb23ea952441cdc0e1046467d688445288db9742 (ARROW-5648) which should fix the issue.

Essentially we should add a test for:
https://github.com/apache/arrow/blob/727106f7ff65065298e1e79071fed2a408b4b4d6/cpp/src/arrow/util/io_util.cc#L143-L149 (`StringToNative()`). This test complements existing `FileNameWideCharConversionRangeException` test (invalid UTF-8).

### What changes are included in this PR?

This PR adds the test described above.

### Are these changes tested?

Unittest was added.

### Are there any user-facing changes?

No, test-only.
* GitHub Issue: #48721