### PR TITLE
GH-48725: [C++] Fix bundled Protobuf doesn't exist in libarrow_bundled_dependencies

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -1974,7 +1974,9 @@ function(build_protobuf)
 
   # Make protobuf_fc depend on the install completion marker
   add_custom_target(protobuf_fc DEPENDS "${PROTOBUF_PREFIX}/.protobuf_installed")
-  list(APPEND ARROW_BUNDLED_STATIC_LIBS protobuf::libprotobuf)
+  set(ARROW_BUNDLED_STATIC_LIBS
+      ${ARROW_BUNDLED_STATIC_LIBS} protobuf::libprotobuf
+      PARENT_SCOPE)
 
   if(CMAKE_CROSSCOMPILING)
     # If we are cross compiling, we need to build protoc for the host


### PR DESCRIPTION
### Rationale for this change

We need to update `ARROW_BUNDLED_STATIC_LIBS` in the parent scope because GH-48183 changed to `function(build_protobuf)` from `macro(build_protobuf)`.

### What changes are included in this PR?

Update `ARROW_BUNDLED_STATIC_LIBS` in the parent scope.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #48725