### PR TITLE
GH-48241: [Python] Scalar inferencing doesn't infer UUID

### DIFF
--- a/docs/source/python/extending_types.rst
+++ b/docs/source/python/extending_types.rst
@@ -649,7 +649,7 @@ so you can pass them directly to :func:`pyarrow.scalar` and :func:`pyarrow.array
    >>> import pyarrow as pa
 
    >>> pa.scalar(uuid.uuid4())
-   <pyarrow.UuidScalar: UUID('59c67eec-f171-4f6f-898b-7b4cdbd2821d')>
+   <pyarrow.UuidScalar: UUID('...')>
 
    >>> uuids = [uuid.uuid4() for _ in range(3)]
    >>> arr = pa.array(uuids)

--- a/docs/source/python/extending_types.rst
+++ b/docs/source/python/extending_types.rst
@@ -476,8 +476,8 @@ You can find the official list of canonical extension types in the
 :ref:`format_canonical_extensions` section. Here we add examples on how to
 use them in PyArrow.
 
-Fixed size tensor
-"""""""""""""""""
+Fixed shape tensor
+""""""""""""""""""
 
 To create an array of tensors with equal shape (fixed shape tensor array) we
 first need to define a fixed shape tensor extension type with value type
@@ -487,7 +487,7 @@ and shape:
 
    >>> tensor_type = pa.fixed_shape_tensor(pa.int32(), (2, 2))
 
-Then we need the storage array with :func:`pyarrow.list_` type where ``value_type```
+Then we need the storage array with :func:`pyarrow.list_` type where ``value_type``
 is the fixed shape tensor value type and list size is a product of ``tensor_type``
 shape elements. Then we can create an array of tensors with
 ``pa.ExtensionArray.from_storage()`` method:
@@ -629,3 +629,41 @@ for ``NCHW`` format where:
 * C: number of channels of the image
 * H: height of the image
 * W: width of the image
+
+UUID
+""""
+
+The UUID extension type (``arrow.uuid``) represents universally unique
+identifiers as 16-byte fixed-size binary values. PyArrow provides integration
+with Python's built-in :mod:`uuid` module, including automatic type inference.
+
+Creating UUID scalars and arrays
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+PyArrow infers the UUID type from Python's ``uuid.UUID`` objects,
+so you can pass them directly to :func:`pyarrow.scalar` and :func:`pyarrow.array`:
+
+.. code-block:: python
+
+   >>> import uuid
+   >>> import pyarrow as pa
+
+   >>> pa.scalar(uuid.uuid4())
+   <pyarrow.UuidScalar: UUID('59c67eec-f171-4f6f-898b-7b4cdbd2821d')>
+
+   >>> uuids = [uuid.uuid4() for _ in range(3)]
+   >>> arr = pa.array(uuids)
+   >>> arr.type
+   UuidType(extension<arrow.uuid>)
+
+You can also explicitly specify the UUID type using :func:`pyarrow.uuid`:
+
+.. code-block:: python
+
+   >>> pa.array([uuid.uuid4(), uuid.uuid4()], type=pa.uuid())
+   <pyarrow.lib.UuidArray object at ...>
+   [
+     77C17B9296554636A54C6A7EF37A70E4,
+     B71D2BF764374A60A1DEECB102A77B16
+   ]
+

--- a/docs/source/python/extending_types.rst
+++ b/docs/source/python/extending_types.rst
@@ -663,7 +663,7 @@ You can also explicitly specify the UUID type using :func:`pyarrow.uuid`:
    >>> pa.array([uuid.uuid4(), uuid.uuid4()], type=pa.uuid())
    <pyarrow.lib.UuidArray object at ...>
    [
-     77C17B9296554636A54C6A7EF37A70E4,
-     B71D2BF764374A60A1DEECB102A77B16
+     ...,
+     ...
    ]
 

--- a/python/pyarrow/src/arrow/python/common.h
+++ b/python/pyarrow/src/arrow/python/common.h
@@ -419,6 +419,16 @@ struct PyBytesView {
     return Status::OK();
   }
 
+  // Parse bytes from a uuid.UUID object (stores reference to keep bytes alive)
+  Status ParseUuid(PyObject* obj) {
+    ref.reset(PyObject_GetAttrString(obj, "bytes"));
+    RETURN_IF_PYERROR();
+    bytes = PyBytes_AS_STRING(ref.obj());
+    size = PyBytes_GET_SIZE(ref.obj());
+    is_utf8 = false;
+    return Status::OK();
+  }
+
  protected:
   OwnedRef ref;
 };

--- a/python/pyarrow/src/arrow/python/common.h
+++ b/python/pyarrow/src/arrow/python/common.h
@@ -423,6 +423,10 @@ struct PyBytesView {
   Status ParseUuid(PyObject* obj) {
     ref.reset(PyObject_GetAttrString(obj, "bytes"));
     RETURN_IF_PYERROR();
+    if (!PyBytes_Check(ref.obj())) {
+      return Status::TypeError("Expected uuid.UUID.bytes to return bytes, got '",
+                               Py_TYPE(ref.obj())->tp_name, "' object");
+    }
     bytes = PyBytes_AS_STRING(ref.obj());
     size = PyBytes_GET_SIZE(ref.obj());
     is_utf8 = false;

--- a/python/pyarrow/src/arrow/python/helpers.cc
+++ b/python/pyarrow/src/arrow/python/helpers.cc
@@ -317,6 +317,8 @@ void GetUuidStaticSymbols() {
   }
 
 #ifndef Py_GIL_DISABLED
+  // Since ImportModule can release the GIL, another thread could have
+  // already initialized the static data.
   if (uuid_static_initialized) {
     return;
   }
@@ -334,6 +336,8 @@ void InitUuidStaticData() {
 }
 #else
 void InitUuidStaticData() {
+  // NOTE: This is called with the GIL held.  We needn't (and shouldn't,
+  // to avoid deadlocks) use an additional C++ lock (ARROW-10519).
   if (uuid_static_initialized) {
     return;
   }

--- a/python/pyarrow/src/arrow/python/helpers.cc
+++ b/python/pyarrow/src/arrow/python/helpers.cc
@@ -356,7 +356,7 @@ bool IsPyUuid(PyObject* obj) {
     PyErr_Clear();
     return false;
   }
-  return result == 1;
+  return result != 0;
 }
 
 namespace {

--- a/python/pyarrow/src/arrow/python/helpers.cc
+++ b/python/pyarrow/src/arrow/python/helpers.cc
@@ -346,10 +346,14 @@ void InitUuidStaticData() {
 
 bool IsPyUuid(PyObject* obj) {
   InitUuidStaticData();
-  return uuid_UUID && PyObject_IsInstance(obj, uuid_UUID);
+  if (!uuid_UUID) return false;
+  int result = PyObject_IsInstance(obj, uuid_UUID);
+  if (result < 0) {
+    PyErr_Clear();
+    return false;
+  }
+  return result == 1;
 }
-
-PyObject* GetUuidBytes(PyObject* obj) { return PyObject_GetAttrString(obj, "bytes"); }
 
 namespace {
 

--- a/python/pyarrow/src/arrow/python/helpers.cc
+++ b/python/pyarrow/src/arrow/python/helpers.cc
@@ -309,8 +309,7 @@ class ModuleOnceRunner {
 #endif
 
  public:
-  explicit ModuleOnceRunner(const std::string& module_name)
-      : module_name_(module_name) {}
+  explicit ModuleOnceRunner(const std::string& module_name) : module_name_(module_name) {}
 
   template <typename Func>
   void RunOnce(Func&& func) {

--- a/python/pyarrow/src/arrow/python/helpers.cc
+++ b/python/pyarrow/src/arrow/python/helpers.cc
@@ -296,60 +296,60 @@ bool PyFloat_IsNaN(PyObject* obj) {
 
 namespace {
 
-// UUID module static data - lazily initialized on first use
-// Uses a conditional initialization strategy: std::once_flag when the GIL is
-// disabled, or a simple boolean flag when the GIL is enabled.
-// See the Pandas static data section below and ARROW-10519 for more details.
+// Thread-safe one-time Python module import + attribute lookup. For Pandas and UUID.
+// Uses std::call_once when the GIL is disabled, or a simple boolean flag when
+// the GIL is enabled to avoid deadlocks. See ARROW-10519 for more details and
+// https://github.com/apache/arrow/commit/f69061935e92e36e25bb891177ca8bc4f463b272
+class ModuleOnceRunner {
+  std::string module_name_;
 #ifdef Py_GIL_DISABLED
-static std::once_flag uuid_static_initialized;
+  std::once_flag initialized_;
 #else
-static bool uuid_static_initialized = false;
+  bool initialized_ = false;
 #endif
-static PyObject* uuid_UUID = nullptr;
 
-void GetUuidStaticSymbols() {
-  OwnedRef uuid_module;
+ public:
+  explicit ModuleOnceRunner(const std::string& module_name)
+      : module_name_(module_name) {}
 
-  // Import uuid module
-  Status s = ImportModule("uuid", &uuid_module);
-  if (!s.ok()) {
-    return;
-  }
-
+  template <typename Func>
+  void RunOnce(Func&& func) {
+    auto do_init = [&]() {
+      OwnedRef module;
+      if (ImportModule(module_name_, &module).ok()) {
 #ifndef Py_GIL_DISABLED
-  // Since ImportModule can release the GIL, another thread could have
-  // already initialized the static data.
-  if (uuid_static_initialized) {
-    return;
-  }
+        // Since ImportModule can release the GIL, another thread could have
+        // already initialized the static data.
+        if (initialized_) {
+          return;
+        }
 #endif
-
-  OwnedRef ref;
-  if (ImportFromModule(uuid_module.obj(), "UUID", &ref).ok()) {
-    uuid_UUID = ref.obj();
-  }
-}
-
+        func(module);
+      }
+    };
 #ifdef Py_GIL_DISABLED
-void InitUuidStaticData() {
-  std::call_once(uuid_static_initialized, GetUuidStaticSymbols);
-}
+    std::call_once(initialized_, do_init);
 #else
-void InitUuidStaticData() {
-  // NOTE: This is called with the GIL held.  We needn't (and shouldn't,
-  // to avoid deadlocks) use an additional C++ lock (ARROW-10519).
-  if (uuid_static_initialized) {
-    return;
-  }
-  GetUuidStaticSymbols();
-  uuid_static_initialized = true;
-}
+    if (!initialized_) {
+      do_init();
+      initialized_ = true;
+    }
 #endif
+  }
+};
+
+static PyObject* uuid_UUID = nullptr;
+static ModuleOnceRunner uuid_runner("uuid");
 
 }  // namespace
 
 bool IsPyUuid(PyObject* obj) {
-  InitUuidStaticData();
+  uuid_runner.RunOnce([](OwnedRef& module) {
+    OwnedRef ref;
+    if (ImportFromModule(module.obj(), "UUID", &ref).ok()) {
+      uuid_UUID = ref.obj();
+    }
+  });
   if (!uuid_UUID) return false;
   int result = PyObject_IsInstance(obj, uuid_UUID);
   if (result < 0) {
@@ -361,16 +361,6 @@ bool IsPyUuid(PyObject* obj) {
 
 namespace {
 
-// This needs a conditional, because using std::once_flag could introduce
-// a deadlock when the GIL is enabled. See
-// https://github.com/apache/arrow/commit/f69061935e92e36e25bb891177ca8bc4f463b272 for
-// more info.
-#ifdef Py_GIL_DISABLED
-static std::once_flag pandas_static_initialized;
-#else
-static bool pandas_static_initialized = false;
-#endif
-
 // Once initialized, these variables hold borrowed references to Pandas static data.
 // We should not use OwnedRef here because Python destructors would be
 // called on a finalized interpreter.
@@ -380,72 +370,43 @@ static PyObject* pandas_Timedelta = nullptr;
 static PyObject* pandas_Timestamp = nullptr;
 static PyTypeObject* pandas_NaTType = nullptr;
 static PyObject* pandas_DateOffset = nullptr;
-
-void GetPandasStaticSymbols() {
-  OwnedRef pandas;
-
-  // Import pandas
-  Status s = ImportModule("pandas", &pandas);
-  if (!s.ok()) {
-    return;
-  }
-
-#ifndef Py_GIL_DISABLED
-  // Since ImportModule can release the GIL, another thread could have
-  // already initialized the static data.
-  if (pandas_static_initialized) {
-    return;
-  }
-#endif
-
-  OwnedRef ref;
-
-  // set NaT sentinel and its type
-  if (ImportFromModule(pandas.obj(), "NaT", &ref).ok()) {
-    pandas_NaT = ref.obj();
-    // PyObject_Type returns a new reference but we trust that pandas.NaT will
-    // outlive our use of this PyObject*
-    pandas_NaTType = Py_TYPE(ref.obj());
-  }
-
-  // retain a reference to Timedelta
-  if (ImportFromModule(pandas.obj(), "Timedelta", &ref).ok()) {
-    pandas_Timedelta = ref.obj();
-  }
-
-  // retain a reference to Timestamp
-  if (ImportFromModule(pandas.obj(), "Timestamp", &ref).ok()) {
-    pandas_Timestamp = ref.obj();
-  }
-
-  // if pandas.NA exists, retain a reference to it
-  if (ImportFromModule(pandas.obj(), "NA", &ref).ok()) {
-    pandas_NA = ref.obj();
-  }
-
-  // Import DateOffset type
-  if (ImportFromModule(pandas.obj(), "DateOffset", &ref).ok()) {
-    pandas_DateOffset = ref.obj();
-  }
-}
+static ModuleOnceRunner pandas_runner("pandas");
 
 }  // namespace
 
-#ifdef Py_GIL_DISABLED
 void InitPandasStaticData() {
-  std::call_once(pandas_static_initialized, GetPandasStaticSymbols);
+  pandas_runner.RunOnce([](OwnedRef& module) {
+    OwnedRef ref;
+
+    // set NaT sentinel and its type
+    if (ImportFromModule(module.obj(), "NaT", &ref).ok()) {
+      pandas_NaT = ref.obj();
+      // PyObject_Type returns a new reference but we trust that pandas.NaT will
+      // outlive our use of this PyObject*
+      pandas_NaTType = Py_TYPE(ref.obj());
+    }
+
+    // retain a reference to Timedelta
+    if (ImportFromModule(module.obj(), "Timedelta", &ref).ok()) {
+      pandas_Timedelta = ref.obj();
+    }
+
+    // retain a reference to Timestamp
+    if (ImportFromModule(module.obj(), "Timestamp", &ref).ok()) {
+      pandas_Timestamp = ref.obj();
+    }
+
+    // if pandas.NA exists, retain a reference to it
+    if (ImportFromModule(module.obj(), "NA", &ref).ok()) {
+      pandas_NA = ref.obj();
+    }
+
+    // Import DateOffset type
+    if (ImportFromModule(module.obj(), "DateOffset", &ref).ok()) {
+      pandas_DateOffset = ref.obj();
+    }
+  });
 }
-#else
-void InitPandasStaticData() {
-  // NOTE: This is called with the GIL held.  We needn't (and shouldn't,
-  // to avoid deadlocks) use an additional C++ lock (ARROW-10519).
-  if (pandas_static_initialized) {
-    return;
-  }
-  GetPandasStaticSymbols();
-  pandas_static_initialized = true;
-}
-#endif
 
 bool PandasObjectIsNull(PyObject* obj) {
   if (!MayHaveNaN(obj)) {

--- a/python/pyarrow/src/arrow/python/helpers.h
+++ b/python/pyarrow/src/arrow/python/helpers.h
@@ -96,11 +96,6 @@ bool PyFloat_IsNaN(PyObject* obj);
 ARROW_PYTHON_EXPORT
 bool IsPyUuid(PyObject* obj);
 
-// \brief Get bytes from a uuid.UUID instance
-// Returns a borrowed reference to a 16-byte bytes object
-ARROW_PYTHON_EXPORT
-PyObject* GetUuidBytes(PyObject* obj);
-
 inline bool IsPyBinary(PyObject* obj) {
   return PyBytes_Check(obj) || PyByteArray_Check(obj) || PyMemoryView_Check(obj);
 }

--- a/python/pyarrow/src/arrow/python/helpers.h
+++ b/python/pyarrow/src/arrow/python/helpers.h
@@ -92,6 +92,15 @@ PyObject* BorrowPandasDataOffsetType();
 ARROW_PYTHON_EXPORT
 bool PyFloat_IsNaN(PyObject* obj);
 
+// \brief Check whether obj is a uuid.UUID instance
+ARROW_PYTHON_EXPORT
+bool IsPyUuid(PyObject* obj);
+
+// \brief Get bytes from a uuid.UUID instance
+// Returns a borrowed reference to a 16-byte bytes object
+ARROW_PYTHON_EXPORT
+PyObject* GetUuidBytes(PyObject* obj);
+
 inline bool IsPyBinary(PyObject* obj) {
   return PyBytes_Check(obj) || PyByteArray_Check(obj) || PyMemoryView_Check(obj);
 }

--- a/python/pyarrow/src/arrow/python/inference.cc
+++ b/python/pyarrow/src/arrow/python/inference.cc
@@ -27,6 +27,7 @@
 #include <utility>
 #include <vector>
 
+#include "arrow/extension/uuid.h"
 #include "arrow/scalar.h"
 #include "arrow/status.h"
 #include "arrow/util/decimal.h"
@@ -407,6 +408,7 @@ class TypeInferrer {
         arrow_scalar_count_(0),
         numpy_dtype_count_(0),
         interval_count_(0),
+        uuid_count_(0),
         max_decimal_metadata_(std::numeric_limits<int32_t>::min(),
                               std::numeric_limits<int32_t>::min()),
         decimal_type_() {
@@ -475,6 +477,9 @@ class TypeInferrer {
       ++decimal_count_;
     } else if (PyObject_IsInstance(obj, interval_types_.obj())) {
       ++interval_count_;
+    } else if (internal::IsPyUuid(obj)) {
+      ++uuid_count_;
+      *keep_going = make_unions_;
     } else {
       return internal::InvalidValue(obj,
                                     "did not recognize Python value type when inferring "
@@ -604,6 +609,8 @@ class TypeInferrer {
       *out = utf8();
     } else if (interval_count_) {
       *out = month_day_nano_interval();
+    } else if (uuid_count_) {
+      *out = extension::uuid();
     } else if (arrow_scalar_count_) {
       *out = scalar_type_;
     } else {
@@ -766,6 +773,7 @@ class TypeInferrer {
   int64_t arrow_scalar_count_;
   int64_t numpy_dtype_count_;
   int64_t interval_count_;
+  int64_t uuid_count_;
   std::unique_ptr<TypeInferrer> list_inferrer_;
   std::vector<std::pair<std::string, TypeInferrer>> struct_inferrers_;
   std::unordered_map<std::string, size_t> struct_field_index_;

--- a/python/pyarrow/src/arrow/python/python_to_arrow.cc
+++ b/python/pyarrow/src/arrow/python/python_to_arrow.cc
@@ -514,7 +514,7 @@ class PyValue {
   static Status Convert(const FixedSizeBinaryType* type, const O&, I obj,
                         PyBytesView& view) {
     // Check if obj is a uuid.UUID instance
-    if (type->byte_width() == 16 && internal::IsPyUuid(obj)) {
+    if (internal::IsPyUuid(obj)) {
       ARROW_RETURN_NOT_OK(view.ParseUuid(obj));
     } else {
       ARROW_RETURN_NOT_OK(view.ParseString(obj));

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -1439,10 +1439,7 @@ def test_uuid_array_from_python():
     assert len(arr) == 4
     assert arr.null_count == 1
     for i, u in enumerate(uuids):
-        if u is None:
-            assert arr[i].as_py() is None
-        else:
-            assert arr[i].as_py() == u
+        assert arr[i].as_py() == u
 
     # Test type inference for arrays
     arr = pa.array(uuids)

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -1469,6 +1469,10 @@ def test_uuid_bytes_property_not_bytes(bytes_value, exc_type, match):
         pa.array([bad], type=pa.uuid())
     with pytest.raises(exc_type, match=match):
         pa.scalar(bad, type=pa.uuid())
+    with pytest.raises(exc_type, match=match):
+        pa.array([bad])
+    with pytest.raises(exc_type, match=match):
+        pa.scalar(bad)
 
 
 def test_uuid_bytes_property_raises():
@@ -1482,6 +1486,12 @@ def test_uuid_bytes_property_raises():
     bad = BadUuid(uuid.uuid4().hex)
     with pytest.raises(RuntimeError, match="broken"):
         pa.array([bad], type=pa.uuid())
+    with pytest.raises(RuntimeError, match="broken"):
+        pa.scalar(bad, type=pa.uuid())
+    with pytest.raises(RuntimeError, match="broken"):
+        pa.array([bad])
+    with pytest.raises(RuntimeError, match="broken"):
+        pa.scalar(bad)
 
 
 def test_tensor_type():

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -1400,10 +1400,8 @@ def test_uuid_extension():
 
 
 def test_uuid_scalar_from_python():
-    import uuid
-
     # Test with explicit type
-    py_uuid = uuid.uuid4()
+    py_uuid = uuid4()
     scalar = pa.scalar(py_uuid, type=pa.uuid())
     assert isinstance(scalar, pa.UuidScalar)
     assert scalar.type == pa.uuid()
@@ -1420,7 +1418,7 @@ def test_uuid_scalar_from_python():
     assert scalar.as_py() is None
 
     # Test type inference from uuid.UUID
-    py_uuid = uuid.uuid4()
+    py_uuid = uuid4()
     scalar = pa.scalar(py_uuid)
     assert isinstance(scalar, pa.UuidScalar)
     assert scalar.type == pa.uuid()
@@ -1428,10 +1426,8 @@ def test_uuid_scalar_from_python():
 
 
 def test_uuid_array_from_python():
-    import uuid
-
     # Test array with explicit type
-    uuids = [uuid.uuid4() for _ in range(3)]
+    uuids = [uuid4() for _ in range(3)]
     uuids.append(None)
 
     arr = pa.array(uuids, type=pa.uuid())
@@ -1457,14 +1453,12 @@ def test_uuid_array_from_python():
     (None, TypeError, "Expected uuid.UUID.bytes to return bytes, got 'NoneType'"),
 ])
 def test_uuid_bytes_property_not_bytes(bytes_value, exc_type, match):
-    import uuid
-
-    class BadUuid(uuid.UUID):
+    class BadUuid(UUID):
         @property
         def bytes(self):
             return bytes_value
 
-    bad = BadUuid(uuid.uuid4().hex)
+    bad = BadUuid(uuid4().hex)
     with pytest.raises(exc_type, match=match):
         pa.array([bad], type=pa.uuid())
     with pytest.raises(exc_type, match=match):
@@ -1476,14 +1470,12 @@ def test_uuid_bytes_property_not_bytes(bytes_value, exc_type, match):
 
 
 def test_uuid_bytes_property_raises():
-    import uuid
-
-    class BadUuid(uuid.UUID):
+    class BadUuid(UUID):
         @property
         def bytes(self):
             raise RuntimeError("broken")
 
-    bad = BadUuid(uuid.uuid4().hex)
+    bad = BadUuid(uuid4().hex)
     with pytest.raises(RuntimeError, match="broken"):
         pa.array([bad], type=pa.uuid())
     with pytest.raises(RuntimeError, match="broken"):


### PR DESCRIPTION
### Rationale for this change
This closes #48241, #44224 and #43855.
Currently uuid.UUID objects are not inferred/converted automatically in PyArrow, requiring users to explicitly specify the type.

### What changes are included in this PR?
Adding support for Python's uuid.UUID objects in PyArrow's type inference and conversion.

### Are these changes tested?
Yes, added test_uuid_scalar_from_python() and test_uuid_array_from_python() in `test_extension.py`.

### Are there any user-facing changes?
Users can now pass Python uuid.UUID objects directly to PyArrow functions like pa.scalar() and pa.array() without specifying the type;
```python
import uuid
import pyarrow as pa

pa.scalar(uuid.uuid4())
``` 
<pyarrow.UuidScalar: UUID('958174b9-3a5c-4cdd-8fc5-d51a2fc55784')>
```python
pa.array([uuid.uuid4()])
```
 <pyarrow.lib.UuidArray object at 0x1217725f0>
[
  73611FD81F764A209C8B9CDBADDA1F53
]
* GitHub Issue: #48241