### PR TITLE
Remove old `add =` tests

### DIFF
--- a/r/R/dplyr-group-by.R
+++ b/r/R/dplyr-group-by.R
@@ -21,19 +21,8 @@ group_by.arrow_dplyr_query <- function(
   .data,
   ...,
   .add = FALSE,
-  add = NULL,
   .drop = dplyr::group_by_drop_default(.data)
 ) {
-  if (!missing(add)) {
-    .Deprecated(
-      msg = paste(
-        "The `add` argument of `group_by()` is deprecated.",
-        "Please use the `.add` argument instead."
-      )
-    )
-    .add <- add
-  }
-
   .data <- as_adq(.data)
   expression_list <- expand_across(.data, quos(...))
   named_expression_list <- ensure_named_exprs(expression_list)

--- a/r/tests/testthat/test-dplyr-group-by.R
+++ b/r/tests/testthat/test-dplyr-group-by.R
@@ -271,38 +271,6 @@ test_that("group_by() with .add", {
     tbl |>
       group_by(dbl2)
   )
-  suppressWarnings(compare_dplyr_binding(
-    .input |>
-      group_by(dbl2) |>
-      group_by(add = FALSE) |>
-      collect(),
-    tbl,
-    warning = "deprecated"
-  ))
-  suppressWarnings(compare_dplyr_binding(
-    .input |>
-      group_by(dbl2) |>
-      group_by(add = TRUE) |>
-      collect(),
-    tbl,
-    warning = "deprecated"
-  ))
-  expect_warning(
-    tbl |>
-      arrow_table() |>
-      group_by(add = TRUE) |>
-      collect(),
-    "The `add` argument of `group_by\\(\\)` is deprecated"
-  )
-  expect_error(
-    suppressWarnings(
-      tbl |>
-        arrow_table() |>
-        group_by(add = dbl2) |>
-        collect()
-    ),
-    "object 'dbl2' not found"
-  )
 })
 
 test_that("Can use across() within group_by()", {


### PR DESCRIPTION
Hi there, we are working on dplyr 1.2.0 and your package was flagged in our reverse dependency checks.

The `add` argument to `group_by()` is now defunct. You should use `.add` instead.

It looks like arrow was already doing this, it just had some outdated tests that relied on the old way.

You'll need to update your package to stay on CRAN.

We are still working on dplyr 1.2.0, but you can consider this an (at minimum) 2 week notice!