### PR TITLE
GH-48735: [Python] Fix pyproject.toml license format for PEP 621 compliance

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -32,7 +32,7 @@ dynamic = ["version"]
 requires-python = ">=3.10"
 description = "Python library for Apache Arrow"
 readme = {file = "README.md", content-type = "text/markdown"}
-license = "Apache-2.0"
+license = {text = "Apache-2.0"}
 license-files = [
     "LICENSE.txt",
     "NOTICE.txt",


### PR DESCRIPTION
### Rationale for this change

Python wheel builds are failing with:
```
ValueError: invalid pyproject.toml config: `project.license`.
configuration error: `project.license` must be valid exactly by one definition (2 matches found)
```

This was introduced in commit [866502e](https://github.com/apache/arrow/commit/866502e6d64e1e2422bbe7978c7bc3a5617431df) which changed the license to:
```toml
license = "Apache-2.0"
```

However, [PEP 621](https://peps.python.org/pep-0621/#license) requires the license field to be a table with either `text` or `file` key, not a plain string.

### What changes are included in this PR?

Changed line 35 from:
```toml
license = "Apache-2.0"
```
to:
```toml
license = {text = "Apache-2.0"}
```

(I believe this can also be `license = {file = "LICENSE.txt"}` but kept the original intention from the commit).

This maintains SPDX compliance while fixing PEP 621 compliance.

### Are these changes tested?

Should trigger the build to make sure it passes all fine with CI

### Are there any user-facing changes?

No, dev-only.

* GitHub Issue: #48735