### PR TITLE
GH-48735: [CI][Python] Fix macOS wheel builds by forcing setuptools upgrade in venv

### DIFF
--- a/ci/scripts/install_python.sh
+++ b/ci/scripts/install_python.sh
@@ -87,7 +87,7 @@ EOF
 
     echo "Installing Pip..."
     $python -m ensurepip
-    $python -m pip install -U pip setuptools
+    $python -m pip install -U pip "setuptools>=77"
 else
     echo "Unsupported platform: $platform"
     exit 1

--- a/ci/scripts/install_python.sh
+++ b/ci/scripts/install_python.sh
@@ -87,7 +87,7 @@ EOF
 
     echo "Installing Pip..."
     $python -m ensurepip
-    $python -m pip install -U pip "setuptools>=77"
+    $python -m pip install -U pip setuptools
 else
     echo "Unsupported platform: $platform"
     exit 1

--- a/ci/scripts/python_wheel_macos_build.sh
+++ b/ci/scripts/python_wheel_macos_build.sh
@@ -56,9 +56,10 @@ if [[ $FREE_THREADED_BUILD == "True"  ]]; then
 fi
 
 pip install \
+  --force-reinstall \
   --only-binary=:all: \
   --target $PIP_SITE_PACKAGES \
-  --upgrade --force-reinstall \
+  --upgrade \
   -r ${source_dir}/python/requirements-wheel-build.txt
 pip install "delocate>=0.10.3"
 

--- a/ci/scripts/python_wheel_macos_build.sh
+++ b/ci/scripts/python_wheel_macos_build.sh
@@ -58,6 +58,7 @@ fi
 pip install \
   --only-binary=:all: \
   --target $PIP_SITE_PACKAGES \
+  --upgrade --force-reinstall \
   -r ${source_dir}/python/requirements-wheel-build.txt
 pip install "delocate>=0.10.3"
 

--- a/python/requirements-wheel-build.txt
+++ b/python/requirements-wheel-build.txt
@@ -1,5 +1,5 @@
 cython>=3.1
 numpy>=2.0.0
 setuptools_scm
-setuptools>=58
+setuptools>=77
 wheel


### PR DESCRIPTION
### Rationale for this change

Commit 866502e updated `pyproject.toml` to use the license format `license = "Apache-2.0"` and required `setuptools>=77` in `[build-system]`.

However, macOS wheel builds for Python 3.10 were failing with:
```
configuration error: `project.license` must be valid exactly by one definition (2 matches found)
```

While Python 3.12 builds passed with identical code.

When `python -m venv build-env` creates the virtual environment, Python 3.10's venv inherits an older setuptools from the system Python installation. The build script uses `pip install --target` which seems not upgrading existing packages, leaving the old setuptools active for some reasons.

Evidence from Python 3.10 logs:
```
WARNING: Target directory .../build-env/lib/python3.10/site-packages/setuptools already exists. Specify --upgrade to force replacement.
```

Python 3.12 had no such warnings and used the fresh setuptools-80.9.0.

### What changes are included in this PR?

In `ci/scripts/python_wheel_macos_build.sh`, added `--upgrade --force-reinstall` flags to pip install command to force replacement of any old setuptools inherited from system Python

In addition, also added `setuptools>=77` at `python/requirements-wheel-build.txt` to match with the original PR.

### Are these changes tested?

Tested in CI: https://github.com/apache/arrow/pull/48739#issuecomment-3716765469

### Are there any user-facing changes?

No, test/dev-only.

* GitHub Issue: #48735