### PR TITLE
GH-48741: [C++] Fix deadlock in CSV AsyncThreadedTableReader destructor

### DIFF
--- a/cpp/src/arrow/csv/column_builder.cc
+++ b/cpp/src/arrow/csv/column_builder.cc
@@ -47,7 +47,8 @@ namespace csv {
 
 class BlockParser;
 
-class ConcreteColumnBuilder : public ColumnBuilder {
+class ConcreteColumnBuilder : public ColumnBuilder,
+                              public std::enable_shared_from_this<ConcreteColumnBuilder> {
  public:
   explicit ConcreteColumnBuilder(MemoryPool* pool, std::shared_ptr<TaskGroup> task_group,
                                  int32_t col_index = -1)
@@ -133,8 +134,8 @@ class ConcreteColumnBuilder : public ColumnBuilder {
 class NullColumnBuilder : public ConcreteColumnBuilder {
  public:
   explicit NullColumnBuilder(const std::shared_ptr<DataType>& type, MemoryPool* pool,
-                             const std::shared_ptr<TaskGroup>& task_group)
-      : ConcreteColumnBuilder(pool, task_group), type_(type) {}
+                             std::shared_ptr<TaskGroup> task_group)
+      : ConcreteColumnBuilder(pool, std::move(task_group)), type_(type) {}
 
   void Insert(int64_t block_index, const std::shared_ptr<BlockParser>& parser) override;
 
@@ -152,15 +153,17 @@ void NullColumnBuilder::Insert(int64_t block_index,
   const int32_t num_rows = parser->num_rows();
   DCHECK_GE(num_rows, 0);
 
-  task_group_->Append([this, block_index, num_rows]() -> Status {
-    std::unique_ptr<ArrayBuilder> builder;
-    RETURN_NOT_OK(MakeBuilder(pool_, type_, &builder));
-    std::shared_ptr<Array> res;
-    RETURN_NOT_OK(builder->AppendNulls(num_rows));
-    RETURN_NOT_OK(builder->Finish(&res));
+  // `self` keeps us alive, `this` allows easy access to derived / protected member vars
+  task_group_->Append(
+      [self = shared_from_this(), this, block_index, num_rows]() -> Status {
+        std::unique_ptr<ArrayBuilder> builder;
+        RETURN_NOT_OK(MakeBuilder(pool_, type_, &builder));
+        std::shared_ptr<Array> res;
+        RETURN_NOT_OK(builder->AppendNulls(num_rows));
+        RETURN_NOT_OK(builder->Finish(&res));
 
-    return SetChunk(block_index, res);
-  });
+        return SetChunk(block_index, res);
+      });
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -169,11 +172,11 @@ void NullColumnBuilder::Insert(int64_t block_index,
 class TypedColumnBuilder : public ConcreteColumnBuilder {
  public:
   TypedColumnBuilder(const std::shared_ptr<DataType>& type, int32_t col_index,
-                     const ConvertOptions& options, MemoryPool* pool,
-                     const std::shared_ptr<TaskGroup>& task_group)
-      : ConcreteColumnBuilder(pool, task_group, col_index),
+                     std::shared_ptr<ConvertOptions> options, MemoryPool* pool,
+                     std::shared_ptr<TaskGroup> task_group)
+      : ConcreteColumnBuilder(pool, std::move(task_group), col_index),
         type_(type),
-        options_(options) {}
+        options_(std::move(options)) {}
 
   Status Init();
 
@@ -185,13 +188,13 @@ class TypedColumnBuilder : public ConcreteColumnBuilder {
   std::shared_ptr<DataType> type_;
   // CAUTION: ConvertOptions can grow large (if it customizes hundreds or
   // thousands of columns), so avoid copying it in each TypedColumnBuilder.
-  const ConvertOptions& options_;
+  std::shared_ptr<ConvertOptions> options_;
 
   std::shared_ptr<Converter> converter_;
 };
 
 Status TypedColumnBuilder::Init() {
-  ARROW_ASSIGN_OR_RAISE(converter_, Converter::Make(type_, options_, pool_));
+  ARROW_ASSIGN_OR_RAISE(converter_, Converter::Make(type_, *options_, pool_));
   return Status::OK();
 }
 
@@ -202,7 +205,7 @@ void TypedColumnBuilder::Insert(int64_t block_index,
   ReserveChunks(block_index);
 
   // We're careful that all references in the closure outlive the Append() call
-  task_group_->Append([this, parser, block_index]() -> Status {
+  task_group_->Append([self = shared_from_this(), this, parser, block_index]() -> Status {
     return SetChunk(block_index, converter_->Convert(*parser, col_index_));
   });
 }
@@ -212,11 +215,11 @@ void TypedColumnBuilder::Insert(int64_t block_index,
 
 class InferringColumnBuilder : public ConcreteColumnBuilder {
  public:
-  InferringColumnBuilder(int32_t col_index, const ConvertOptions& options,
-                         MemoryPool* pool, const std::shared_ptr<TaskGroup>& task_group)
-      : ConcreteColumnBuilder(pool, task_group, col_index),
-        options_(options),
-        infer_status_(options) {}
+  InferringColumnBuilder(int32_t col_index, std::shared_ptr<ConvertOptions> options,
+                         MemoryPool* pool, std::shared_ptr<TaskGroup> task_group)
+      : ConcreteColumnBuilder(pool, std::move(task_group), col_index),
+        options_(std::move(options)),
+        infer_status_(*options_) {}
 
   Status Init();
 
@@ -237,7 +240,8 @@ class InferringColumnBuilder : public ConcreteColumnBuilder {
 
   // CAUTION: ConvertOptions can grow large (if it customizes hundreds or
   // thousands of columns), so avoid copying it in each InferringColumnBuilder.
-  const ConvertOptions& options_;
+  // However, it needs to be owned because of async task execution, hence shared_ptr.
+  std::shared_ptr<ConvertOptions> options_;
 
   // Current inference status
   InferStatus infer_status_;
@@ -257,7 +261,9 @@ Status InferringColumnBuilder::UpdateType() {
 }
 
 void InferringColumnBuilder::ScheduleConvertChunk(int64_t chunk_index) {
-  task_group_->Append([this, chunk_index]() { return TryConvertChunk(chunk_index); });
+  task_group_->Append([self = shared_from_this(), this, chunk_index]() {
+    return TryConvertChunk(chunk_index);
+  });
 }
 
 Status InferringColumnBuilder::TryConvertChunk(int64_t chunk_index) {
@@ -361,26 +367,26 @@ Result<std::shared_ptr<ChunkedArray>> InferringColumnBuilder::Finish() {
 
 Result<std::shared_ptr<ColumnBuilder>> ColumnBuilder::Make(
     MemoryPool* pool, const std::shared_ptr<DataType>& type, int32_t col_index,
-    const ConvertOptions& options, const std::shared_ptr<TaskGroup>& task_group) {
-  auto ptr =
-      std::make_shared<TypedColumnBuilder>(type, col_index, options, pool, task_group);
+    std::shared_ptr<ConvertOptions> options, std::shared_ptr<TaskGroup> task_group) {
+  auto ptr = std::make_shared<TypedColumnBuilder>(type, col_index, std::move(options),
+                                                  pool, std::move(task_group));
   RETURN_NOT_OK(ptr->Init());
   return ptr;
 }
 
 Result<std::shared_ptr<ColumnBuilder>> ColumnBuilder::Make(
-    MemoryPool* pool, int32_t col_index, const ConvertOptions& options,
-    const std::shared_ptr<TaskGroup>& task_group) {
-  auto ptr =
-      std::make_shared<InferringColumnBuilder>(col_index, options, pool, task_group);
+    MemoryPool* pool, int32_t col_index, std::shared_ptr<ConvertOptions> options,
+    std::shared_ptr<TaskGroup> task_group) {
+  auto ptr = std::make_shared<InferringColumnBuilder>(col_index, std::move(options), pool,
+                                                      std::move(task_group));
   RETURN_NOT_OK(ptr->Init());
   return ptr;
 }
 
 Result<std::shared_ptr<ColumnBuilder>> ColumnBuilder::MakeNull(
     MemoryPool* pool, const std::shared_ptr<DataType>& type,
-    const std::shared_ptr<TaskGroup>& task_group) {
-  return std::make_shared<NullColumnBuilder>(type, pool, task_group);
+    std::shared_ptr<TaskGroup> task_group) {
+  return std::make_shared<NullColumnBuilder>(type, pool, std::move(task_group));
 }
 
 }  // namespace csv

--- a/cpp/src/arrow/csv/column_builder.h
+++ b/cpp/src/arrow/csv/column_builder.h
@@ -53,19 +53,19 @@ class ARROW_EXPORT ColumnBuilder {
   /// Construct a strictly-typed ColumnBuilder.
   static Result<std::shared_ptr<ColumnBuilder>> Make(
       MemoryPool* pool, const std::shared_ptr<DataType>& type, int32_t col_index,
-      const ConvertOptions& options,
-      const std::shared_ptr<arrow::internal::TaskGroup>& task_group);
+      std::shared_ptr<ConvertOptions> options,
+      std::shared_ptr<arrow::internal::TaskGroup> task_group);
 
   /// Construct a type-inferring ColumnBuilder.
   static Result<std::shared_ptr<ColumnBuilder>> Make(
-      MemoryPool* pool, int32_t col_index, const ConvertOptions& options,
-      const std::shared_ptr<arrow::internal::TaskGroup>& task_group);
+      MemoryPool* pool, int32_t col_index, std::shared_ptr<ConvertOptions> options,
+      std::shared_ptr<arrow::internal::TaskGroup> task_group);
 
   /// Construct a ColumnBuilder for a column of nulls
   /// (i.e. not present in the CSV file).
   static Result<std::shared_ptr<ColumnBuilder>> MakeNull(
       MemoryPool* pool, const std::shared_ptr<DataType>& type,
-      const std::shared_ptr<arrow::internal::TaskGroup>& task_group);
+      std::shared_ptr<arrow::internal::TaskGroup> task_group);
 
  protected:
   explicit ColumnBuilder(std::shared_ptr<arrow::internal::TaskGroup> task_group)

--- a/cpp/src/arrow/csv/column_builder_test.cc
+++ b/cpp/src/arrow/csv/column_builder_test.cc
@@ -49,6 +49,10 @@ using ChunkData = std::vector<std::vector<std::string>>;
 
 class ColumnBuilderTest : public ::testing::Test {
  public:
+  std::shared_ptr<ConvertOptions> MakeOptions(ConvertOptions options) {
+    return std::make_shared<ConvertOptions>(std::move(options));
+  }
+
   void AssertBuilding(const std::shared_ptr<ColumnBuilder>& builder,
                       const ChunkData& chunks, bool validate_full,
                       std::shared_ptr<ChunkedArray>* out) {
@@ -76,8 +80,8 @@ class ColumnBuilderTest : public ::testing::Test {
                      std::shared_ptr<ChunkedArray> expected, bool validate_full = true) {
     std::shared_ptr<ColumnBuilder> builder;
     std::shared_ptr<ChunkedArray> actual;
-    ASSERT_OK_AND_ASSIGN(builder,
-                         ColumnBuilder::Make(default_memory_pool(), 0, options, tg));
+    ASSERT_OK_AND_ASSIGN(
+        builder, ColumnBuilder::Make(default_memory_pool(), 0, MakeOptions(options), tg));
     AssertBuilding(builder, csv_data, validate_full, &actual);
     AssertChunkedEqual(*actual, *expected);
   }
@@ -96,8 +100,8 @@ class ColumnBuilderTest : public ::testing::Test {
                       std::shared_ptr<ChunkedArray> expected) {
     std::shared_ptr<ColumnBuilder> builder;
     std::shared_ptr<ChunkedArray> actual;
-    ASSERT_OK_AND_ASSIGN(
-        builder, ColumnBuilder::Make(default_memory_pool(), type, 0, options, tg));
+    ASSERT_OK_AND_ASSIGN(builder, ColumnBuilder::Make(default_memory_pool(), type, 0,
+                                                      MakeOptions(options), tg));
     AssertBuilding(builder, csv_data, &actual);
     AssertChunkedEqual(*actual, *expected);
   }
@@ -219,8 +223,8 @@ TEST_F(TypedColumnBuilderTest, Empty) {
   auto options = ConvertOptions::Defaults();
   auto tg = TaskGroup::MakeSerial();
   std::shared_ptr<ColumnBuilder> builder;
-  ASSERT_OK_AND_ASSIGN(
-      builder, ColumnBuilder::Make(default_memory_pool(), int32(), 0, options, tg));
+  ASSERT_OK_AND_ASSIGN(builder, ColumnBuilder::Make(default_memory_pool(), int32(), 0,
+                                                    MakeOptions(options), tg));
 
   std::shared_ptr<ChunkedArray> actual;
   AssertBuilding(builder, {}, &actual);
@@ -242,8 +246,8 @@ TEST_F(TypedColumnBuilderTest, Insert) {
   auto options = ConvertOptions::Defaults();
   auto tg = TaskGroup::MakeSerial();
   std::shared_ptr<ColumnBuilder> builder;
-  ASSERT_OK_AND_ASSIGN(
-      builder, ColumnBuilder::Make(default_memory_pool(), int32(), 0, options, tg));
+  ASSERT_OK_AND_ASSIGN(builder, ColumnBuilder::Make(default_memory_pool(), int32(), 0,
+                                                    MakeOptions(options), tg));
 
   std::shared_ptr<BlockParser> parser;
   std::shared_ptr<ChunkedArray> actual, expected;
@@ -298,8 +302,8 @@ class InferringColumnBuilderTest : public ColumnBuilderTest {
                             bool validate_full = true) {
     std::shared_ptr<ColumnBuilder> builder;
     std::shared_ptr<ChunkedArray> actual;
-    ASSERT_OK_AND_ASSIGN(builder,
-                         ColumnBuilder::Make(default_memory_pool(), 0, options, tg));
+    ASSERT_OK_AND_ASSIGN(
+        builder, ColumnBuilder::Make(default_memory_pool(), 0, MakeOptions(options), tg));
     AssertBuilding(builder, csv_data, validate_full, &actual);
     ASSERT_EQ(actual->num_chunks(), static_cast<int>(csv_data.size()));
     for (int i = 0; i < actual->num_chunks(); ++i) {


### PR DESCRIPTION
### Rationale for this change

When reading a CSV file encounters an early error, and the `AsyncThreadedTableReader` is only kept alive through the chain of futures and their callbacks, the `~AsyncThreadedTableReader` destructor will be executed at the end of a `TaskGroup` task and try to wait for the `TaskGroup` itself for finish. This will obviously deadlock.

This issue was discovered by OSS-Fuzz in https://issues.oss-fuzz.com/issues/467451924

### What changes are included in this PR?

Instead of waiting for the `TaskGroup` to finish in the `AsyncThreadedTableReader`, make sure that all async callbacks involved in CSV reading own their captured variables, to avoid use-after-free problems.

This has the side effect of keeping the `AsyncThreadedTableReader` alive until all relevant async callbacks have executed.

### Are these changes tested?

Yes, by existing tests and a new fuzz regression test.

### Are there any user-facing changes?

No.
* GitHub Issue: #48741