### PR TITLE
GH-48744: [C++][Parquet] Fix undefined behavior in memcpy with nullptr

### DIFF
--- a/cpp/src/parquet/bloom_filter.cc
+++ b/cpp/src/parquet/bloom_filter.cc
@@ -70,7 +70,7 @@ void BlockSplitBloomFilter::Init(const uint8_t* bitset, uint32_t num_bytes) {
 
   num_bytes_ = num_bytes;
   PARQUET_ASSIGN_OR_THROW(data_, ::arrow::AllocateBuffer(num_bytes_, pool_));
-  memcpy(data_->mutable_data(), bitset, num_bytes_);
+  std::memcpy(data_->mutable_data(), bitset, num_bytes_);
 
   this->hasher_ = std::make_unique<XxHasher>();
 }
@@ -157,10 +157,8 @@ BlockSplitBloomFilter BlockSplitBloomFilter::Deserialize(
   auto buffer = AllocateBuffer(properties.memory_pool(), bloom_filter_size);
 
   const auto bloom_filter_bytes_in_header = header_buf->size() - header_size;
-  if (bloom_filter_bytes_in_header > 0) {
-    std::memcpy(buffer->mutable_data(), header_buf->data() + header_size,
-                static_cast<size_t>(bloom_filter_bytes_in_header));
-  }
+  SafeMemcpy(buffer->mutable_data(), header_buf->data() + header_size,
+             static_cast<size_t>(bloom_filter_bytes_in_header));
 
   const auto required_read_size = bloom_filter_size - bloom_filter_bytes_in_header;
   PARQUET_ASSIGN_OR_THROW(

--- a/cpp/src/parquet/column_reader.cc
+++ b/cpp/src/parquet/column_reader.cc
@@ -559,11 +559,9 @@ std::shared_ptr<Buffer> SerializedPageReader::DecompressIfNeeded(
   PARQUET_THROW_NOT_OK(
       decompression_buffer_->Resize(uncompressed_len, /*shrink_to_fit=*/false));
 
-  if (levels_byte_len > 0) {
-    // First copy the levels as-is
-    uint8_t* decompressed = decompression_buffer_->mutable_data();
-    memcpy(decompressed, page_buffer->data(), levels_byte_len);
-  }
+  // First copy the levels as-is
+  uint8_t* decompressed = decompression_buffer_->mutable_data();
+  SafeMemcpy(decompressed, page_buffer->data(), levels_byte_len);
 
   // GH-31992: DataPageV2 may store only levels and no values when all
   // values are null. In this case, Parquet java is known to produce a

--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -919,13 +919,13 @@ class ColumnWriterImpl {
   void ConcatenateBuffers(int64_t definition_levels_rle_size,
                           int64_t repetition_levels_rle_size,
                           const std::shared_ptr<Buffer>& values, uint8_t* combined) {
-    memcpy(combined, repetition_levels_rle_->data(),
-           static_cast<size_t>(repetition_levels_rle_size));
+    SafeMemcpy(combined, repetition_levels_rle_->data(),
+               static_cast<size_t>(repetition_levels_rle_size));
     combined += repetition_levels_rle_size;
-    memcpy(combined, definition_levels_rle_->data(),
-           static_cast<size_t>(definition_levels_rle_size));
+    SafeMemcpy(combined, definition_levels_rle_->data(),
+               static_cast<size_t>(definition_levels_rle_size));
     combined += definition_levels_rle_size;
-    memcpy(combined, values->data(), static_cast<size_t>(values->size()));
+    SafeMemcpy(combined, values->data(), static_cast<size_t>(values->size()));
   }
 };
 

--- a/cpp/src/parquet/column_writer_test.cc
+++ b/cpp/src/parquet/column_writer_test.cc
@@ -536,10 +536,7 @@ void TestPrimitiveWriter<ByteArrayType>::ReadColumnFully(Compression::type compr
     uint8_t* data_ptr = data.data();
     for (int64_t i = 0; i < values_read_recently; i++) {
       const ByteArray& value = this->values_out_ptr_[i + values_read_];
-      // Avoid calling memcpy with nullptr which is undefined behavior
-      if (value.len > 0) {
-        memcpy(data_ptr, value.ptr, value.len);
-      }
+      SafeMemcpy(data_ptr, value.ptr, value.len);
       this->values_out_[i + values_read_].ptr = data_ptr;
       data_ptr += value.len;
     }

--- a/cpp/src/parquet/column_writer_test.cc
+++ b/cpp/src/parquet/column_writer_test.cc
@@ -536,7 +536,10 @@ void TestPrimitiveWriter<ByteArrayType>::ReadColumnFully(Compression::type compr
     uint8_t* data_ptr = data.data();
     for (int64_t i = 0; i < values_read_recently; i++) {
       const ByteArray& value = this->values_out_ptr_[i + values_read_];
-      memcpy(data_ptr, value.ptr, value.len);
+      // Avoid calling memcpy with nullptr which is undefined behavior
+      if (value.len > 0) {
+        memcpy(data_ptr, value.ptr, value.len);
+      }
       this->values_out_[i + values_read_].ptr = data_ptr;
       data_ptr += value.len;
     }

--- a/cpp/src/parquet/decoder.cc
+++ b/cpp/src/parquet/decoder.cc
@@ -1058,7 +1058,10 @@ void DictDecoderImpl<ByteArrayType>::SetDict(TypedDecoder<ByteArrayType>* dictio
   uint8_t* bytes_data = byte_array_data_->mutable_data();
   int32_t* bytes_offsets = byte_array_offsets_->mutable_data_as<int32_t>();
   for (int i = 0; i < dictionary_length_; ++i) {
-    memcpy(bytes_data + offset, dict_values[i].ptr, dict_values[i].len);
+    // Avoid calling memcpy with nullptr which is undefined behavior
+    if (dict_values[i].len > 0) {
+      memcpy(bytes_data + offset, dict_values[i].ptr, dict_values[i].len);
+    }
     bytes_offsets[i] = offset;
     dict_values[i].ptr = bytes_data + offset;
     offset += dict_values[i].len;

--- a/cpp/src/parquet/encoder.cc
+++ b/cpp/src/parquet/encoder.cc
@@ -658,9 +658,9 @@ template <>
 void DictEncoderImpl<ByteArrayType>::WriteDict(uint8_t* buffer) const {
   memo_table_.VisitValues(0, [&buffer](::std::string_view v) {
     uint32_t len = static_cast<uint32_t>(v.length());
-    memcpy(buffer, &len, sizeof(len));
+    std::memcpy(buffer, &len, sizeof(len));
     buffer += sizeof(len);
-    memcpy(buffer, v.data(), len);
+    SafeMemcpy(buffer, v.data(), len);
     buffer += len;
   });
 }
@@ -669,7 +669,7 @@ template <>
 void DictEncoderImpl<FLBAType>::WriteDict(uint8_t* buffer) const {
   memo_table_.VisitValues(0, [&](::std::string_view v) {
     DCHECK_EQ(v.length(), static_cast<size_t>(type_length_));
-    memcpy(buffer, v.data(), type_length_);
+    std::memcpy(buffer, v.data(), type_length_);
     buffer += type_length_;
   });
 }
@@ -1216,8 +1216,8 @@ std::shared_ptr<Buffer> DeltaBitPackEncoder<DType>::FlushValues() {
   // and data was written immediately after. We now write the header data immediately
   // before the end of reserved space.
   const size_t offset_bytes = kMaxPageHeaderWriterSize - header_writer.bytes_written();
-  std::memcpy(buffer->mutable_data() + offset_bytes, header_buffer_,
-              header_writer.bytes_written());
+  SafeMemcpy(buffer->mutable_data() + offset_bytes, header_buffer_,
+             header_writer.bytes_written());
 
   // Reset counter of cached values
   total_value_count_ = 0;

--- a/cpp/src/parquet/statistics.cc
+++ b/cpp/src/parquet/statistics.cc
@@ -890,7 +890,10 @@ inline void TypedStatisticsImpl<ByteArrayType>::Copy(const ByteArray& src, ByteA
                                                      ResizableBuffer* buffer) {
   if (dst->ptr == src.ptr) return;
   PARQUET_THROW_NOT_OK(buffer->Resize(src.len, false));
-  std::memcpy(buffer->mutable_data(), src.ptr, src.len);
+  // Avoid calling memcpy with nullptr which is undefined behavior
+  if (src.len > 0) {
+    std::memcpy(buffer->mutable_data(), src.ptr, src.len);
+  }
   *dst = ByteArray(src.len, buffer->data());
 }
 

--- a/cpp/src/parquet/statistics.cc
+++ b/cpp/src/parquet/statistics.cc
@@ -890,9 +890,7 @@ inline void TypedStatisticsImpl<ByteArrayType>::Copy(const ByteArray& src, ByteA
                                                      ResizableBuffer* buffer) {
   if (dst->ptr == src.ptr) return;
   PARQUET_THROW_NOT_OK(buffer->Resize(src.len, false));
-  if (src.len > 0) {
-    memcpy(buffer->mutable_data(), src.ptr, src.len);
-  }
+  SafeMemcpy(buffer->mutable_data(), src.ptr, src.len);
   *dst = ByteArray(src.len, buffer->data());
 }
 

--- a/cpp/src/parquet/statistics.cc
+++ b/cpp/src/parquet/statistics.cc
@@ -890,9 +890,8 @@ inline void TypedStatisticsImpl<ByteArrayType>::Copy(const ByteArray& src, ByteA
                                                      ResizableBuffer* buffer) {
   if (dst->ptr == src.ptr) return;
   PARQUET_THROW_NOT_OK(buffer->Resize(src.len, false));
-  // Avoid calling memcpy with nullptr which is undefined behavior
   if (src.len > 0) {
-    std::memcpy(buffer->mutable_data(), src.ptr, src.len);
+    memcpy(buffer->mutable_data(), src.ptr, src.len);
   }
   *dst = ByteArray(src.len, buffer->data());
 }

--- a/cpp/src/parquet/statistics_test.cc
+++ b/cpp/src/parquet/statistics_test.cc
@@ -523,10 +523,7 @@ std::vector<ByteArray> TestStatistics<ByteArrayType>::GetDeepCopy(
   for (const ByteArray& ba : values) {
     uint8_t* ptr;
     PARQUET_THROW_NOT_OK(pool->Allocate(ba.len, &ptr));
-    // Avoid calling memcpy with nullptr which is undefined behavior
-    if (ba.len > 0) {
-      memcpy(ptr, ba.ptr, ba.len);
-    }
+    SafeMemcpy(ptr, ba.ptr, ba.len);
     copy.emplace_back(ba.len, ptr);
   }
   return copy;

--- a/cpp/src/parquet/statistics_test.cc
+++ b/cpp/src/parquet/statistics_test.cc
@@ -523,7 +523,10 @@ std::vector<ByteArray> TestStatistics<ByteArrayType>::GetDeepCopy(
   for (const ByteArray& ba : values) {
     uint8_t* ptr;
     PARQUET_THROW_NOT_OK(pool->Allocate(ba.len, &ptr));
-    memcpy(ptr, ba.ptr, ba.len);
+    // Avoid calling memcpy with nullptr which is undefined behavior
+    if (ba.len > 0) {
+      memcpy(ptr, ba.ptr, ba.len);
+    }
     copy.emplace_back(ba.len, ptr);
   }
   return copy;

--- a/cpp/src/parquet/types.h
+++ b/cpp/src/parquet/types.h
@@ -704,6 +704,16 @@ static inline std::string ByteArrayToString(const ByteArray& a) {
   return std::string(reinterpret_cast<const char*>(a.ptr), a.len);
 }
 
+/// \brief Safe memcpy that avoids undefined behavior when src is nullptr.
+///
+/// According to the C++ standard, calling std::memcpy with a nullptr is undefined
+/// behavior even when size is 0. This function guards against that case.
+static inline void SafeMemcpy(void* dest, const void* src, size_t size) {
+  if (size > 0) {
+    std::memcpy(dest, src, size);
+  }
+}
+
 static inline void Int96SetNanoSeconds(parquet::Int96& i96, int64_t nanoseconds) {
   std::memcpy(&i96.value, &nanoseconds, sizeof(nanoseconds));
 }


### PR DESCRIPTION
### Rationale for this change

As noted by @wgtmac in https://github.com/apache/arrow/pull/48717#discussion_r2665550214, calling `std::memcpy` with a nullptr source is undefined behavior according to the C++ standard, even when the size is 0.

When `ByteArray` has `len=0` and `ptr=nullptr` (the default-constructed state per `types.h:649`), the current code invokes UB.

### What changes are included in this PR?

Added guards to check `len > 0` before calling `memcpy` in:
- `TypedStatisticsImpl<ByteArrayType>::Copy` in `statistics.cc`
- `DictDecoderImpl<ByteArrayType>::SetDict` in `decoder.cc`
- Test utilities in `statistics_test.cc` and `column_writer_test.cc`

### Are these changes tested?

Existing tests pass. The fix prevents potential UB that sanitizers or optimizing compilers could exploit.

### Are there any user-facing changes?

No.
* GitHub Issue: #48744