### PR TITLE
GH-48470: [Python] Construct UuidArray from list of UuidScalars

### DIFF
--- a/python/pyarrow/src/arrow/python/python_to_arrow.cc
+++ b/python/pyarrow/src/arrow/python/python_to_arrow.cc
@@ -585,13 +585,13 @@ class PyConverter : public Converter<PyObject*, PyConversionOptions> {
 };
 
 // Helper function to unwrap extension scalar to its storage scalar
-const Scalar& GetStorageScalar(const Scalar& scalar) {
-  if (scalar.type->id() == Type::EXTENSION) {
-    return *checked_cast<const ExtensionScalar&>(scalar).value;
+Result<const Scalar*> GetStorageScalar(const Scalar& scalar) {
+  if (scalar.type->id() != Type::EXTENSION) {
+    return &scalar;
   }
-  return scalar;
+  const auto& extension_scalar = checked_cast<const ExtensionScalar&>(scalar);
+  return extension_scalar.value.get();
 }
-
 template <typename T, typename Enable = void>
 class PyPrimitiveConverter;
 
@@ -671,8 +671,9 @@ class PyPrimitiveConverter<
     } else if (arrow::py::is_scalar(value)) {
       ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Scalar> scalar,
                             arrow::py::unwrap_scalar(value));
+      ARROW_ASSIGN_OR_RAISE(const Scalar* storage_scalar, GetStorageScalar(*scalar));
       ARROW_RETURN_NOT_OK(
-          this->primitive_builder_->AppendScalar(GetStorageScalar(*scalar)));
+          this->primitive_builder_->AppendScalar(*storage_scalar));
     } else {
       ARROW_ASSIGN_OR_RAISE(
           auto converted, PyValue::Convert(this->primitive_type_, this->options_, value));

--- a/python/pyarrow/src/arrow/python/python_to_arrow.cc
+++ b/python/pyarrow/src/arrow/python/python_to_arrow.cc
@@ -584,6 +584,14 @@ class PyConverter : public Converter<PyObject*, PyConversionOptions> {
   }
 };
 
+// Helper function to unwrap extension scalar to its storage scalar
+inline const Scalar& GetStorageScalar(const Scalar& scalar) {
+  if (scalar.type->id() == Type::EXTENSION) {
+    return *checked_cast<const ExtensionScalar&>(scalar).value;
+  }
+  return scalar;
+}
+
 template <typename T, typename Enable = void>
 class PyPrimitiveConverter;
 
@@ -663,7 +671,8 @@ class PyPrimitiveConverter<
     } else if (arrow::py::is_scalar(value)) {
       ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Scalar> scalar,
                             arrow::py::unwrap_scalar(value));
-      ARROW_RETURN_NOT_OK(this->primitive_builder_->AppendScalar(*scalar));
+      ARROW_RETURN_NOT_OK(
+          this->primitive_builder_->AppendScalar(GetStorageScalar(*scalar)));
     } else {
       ARROW_ASSIGN_OR_RAISE(
           auto converted, PyValue::Convert(this->primitive_type_, this->options_, value));
@@ -684,7 +693,8 @@ class PyPrimitiveConverter<
     } else if (arrow::py::is_scalar(value)) {
       ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Scalar> scalar,
                             arrow::py::unwrap_scalar(value));
-      ARROW_RETURN_NOT_OK(this->primitive_builder_->AppendScalar(*scalar));
+      ARROW_RETURN_NOT_OK(
+          this->primitive_builder_->AppendScalar(GetStorageScalar(*scalar)));
     } else {
       ARROW_ASSIGN_OR_RAISE(
           auto converted, PyValue::Convert(this->primitive_type_, this->options_, value));
@@ -710,7 +720,8 @@ class PyPrimitiveConverter<T, enable_if_t<std::is_same<T, FixedSizeBinaryType>::
     } else if (arrow::py::is_scalar(value)) {
       ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Scalar> scalar,
                             arrow::py::unwrap_scalar(value));
-      ARROW_RETURN_NOT_OK(this->primitive_builder_->AppendScalar(*scalar));
+      ARROW_RETURN_NOT_OK(
+          this->primitive_builder_->AppendScalar(GetStorageScalar(*scalar)));
     } else {
       ARROW_RETURN_NOT_OK(
           PyValue::Convert(this->primitive_type_, this->options_, value, view_));
@@ -747,7 +758,8 @@ class PyPrimitiveConverter<
     } else if (arrow::py::is_scalar(value)) {
       ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Scalar> scalar,
                             arrow::py::unwrap_scalar(value));
-      ARROW_RETURN_NOT_OK(this->primitive_builder_->AppendScalar(*scalar));
+      ARROW_RETURN_NOT_OK(
+          this->primitive_builder_->AppendScalar(GetStorageScalar(*scalar)));
     } else {
       ARROW_RETURN_NOT_OK(
           PyValue::Convert(this->primitive_type_, this->options_, value, view_));
@@ -791,7 +803,7 @@ class PyDictionaryConverter<U, enable_if_has_c_type<U>>
     } else if (arrow::py::is_scalar(value)) {
       ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Scalar> scalar,
                             arrow::py::unwrap_scalar(value));
-      return this->value_builder_->AppendScalar(*scalar, 1);
+      return this->value_builder_->AppendScalar(GetStorageScalar(*scalar), 1);
     } else {
       ARROW_ASSIGN_OR_RAISE(auto converted,
                             PyValue::Convert(this->value_type_, this->options_, value));
@@ -810,7 +822,7 @@ class PyDictionaryConverter<U, enable_if_has_string_view<U>>
     } else if (arrow::py::is_scalar(value)) {
       ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Scalar> scalar,
                             arrow::py::unwrap_scalar(value));
-      return this->value_builder_->AppendScalar(*scalar, 1);
+      return this->value_builder_->AppendScalar(GetStorageScalar(*scalar), 1);
     } else {
       ARROW_RETURN_NOT_OK(
           PyValue::Convert(this->value_type_, this->options_, value, view_));
@@ -983,7 +995,7 @@ class PyStructConverter : public StructConverter<PyConverter, PyConverterTrait> 
     } else if (arrow::py::is_scalar(value)) {
       ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Scalar> scalar,
                             arrow::py::unwrap_scalar(value));
-      return this->struct_builder_->AppendScalar(*scalar);
+      return this->struct_builder_->AppendScalar(GetStorageScalar(*scalar));
     }
     switch (input_kind_) {
       case InputKind::DICT:

--- a/python/pyarrow/src/arrow/python/python_to_arrow.cc
+++ b/python/pyarrow/src/arrow/python/python_to_arrow.cc
@@ -585,12 +585,11 @@ class PyConverter : public Converter<PyObject*, PyConversionOptions> {
 };
 
 // Helper function to unwrap extension scalar to its storage scalar
-Result<const Scalar*> GetStorageScalar(const Scalar& scalar) {
-  if (scalar.type->id() != Type::EXTENSION) {
-    return &scalar;
+const Scalar& GetStorageScalar(const Scalar& scalar) {
+  if (scalar.type->id() == Type::EXTENSION) {
+    return *checked_cast<const ExtensionScalar&>(scalar).value;
   }
-  const auto& extension_scalar = checked_cast<const ExtensionScalar&>(scalar);
-  return extension_scalar.value.get();
+  return scalar;
 }
 
 template <typename T, typename Enable = void>
@@ -672,8 +671,8 @@ class PyPrimitiveConverter<
     } else if (arrow::py::is_scalar(value)) {
       ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Scalar> scalar,
                             arrow::py::unwrap_scalar(value));
-      ARROW_ASSIGN_OR_RAISE(const Scalar* storage_scalar, GetStorageScalar(*scalar));
-      ARROW_RETURN_NOT_OK(this->primitive_builder_->AppendScalar(*storage_scalar));
+      ARROW_RETURN_NOT_OK(
+          this->primitive_builder_->AppendScalar(GetStorageScalar(*scalar)));
     } else {
       ARROW_ASSIGN_OR_RAISE(
           auto converted, PyValue::Convert(this->primitive_type_, this->options_, value));
@@ -694,8 +693,8 @@ class PyPrimitiveConverter<
     } else if (arrow::py::is_scalar(value)) {
       ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Scalar> scalar,
                             arrow::py::unwrap_scalar(value));
-      ARROW_ASSIGN_OR_RAISE(const Scalar* storage_scalar, GetStorageScalar(*scalar));
-      ARROW_RETURN_NOT_OK(this->primitive_builder_->AppendScalar(*storage_scalar));
+      ARROW_RETURN_NOT_OK(
+          this->primitive_builder_->AppendScalar(GetStorageScalar(*scalar)));
     } else {
       ARROW_ASSIGN_OR_RAISE(
           auto converted, PyValue::Convert(this->primitive_type_, this->options_, value));
@@ -721,8 +720,8 @@ class PyPrimitiveConverter<T, enable_if_t<std::is_same<T, FixedSizeBinaryType>::
     } else if (arrow::py::is_scalar(value)) {
       ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Scalar> scalar,
                             arrow::py::unwrap_scalar(value));
-      ARROW_ASSIGN_OR_RAISE(const Scalar* storage_scalar, GetStorageScalar(*scalar));
-      ARROW_RETURN_NOT_OK(this->primitive_builder_->AppendScalar(*storage_scalar));
+      ARROW_RETURN_NOT_OK(
+          this->primitive_builder_->AppendScalar(GetStorageScalar(*scalar)));
     } else {
       ARROW_RETURN_NOT_OK(
           PyValue::Convert(this->primitive_type_, this->options_, value, view_));
@@ -759,8 +758,8 @@ class PyPrimitiveConverter<
     } else if (arrow::py::is_scalar(value)) {
       ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Scalar> scalar,
                             arrow::py::unwrap_scalar(value));
-      ARROW_ASSIGN_OR_RAISE(const Scalar* storage_scalar, GetStorageScalar(*scalar));
-      ARROW_RETURN_NOT_OK(this->primitive_builder_->AppendScalar(*storage_scalar));
+      ARROW_RETURN_NOT_OK(
+          this->primitive_builder_->AppendScalar(GetStorageScalar(*scalar)));
     } else {
       ARROW_RETURN_NOT_OK(
           PyValue::Convert(this->primitive_type_, this->options_, value, view_));
@@ -804,8 +803,7 @@ class PyDictionaryConverter<U, enable_if_has_c_type<U>>
     } else if (arrow::py::is_scalar(value)) {
       ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Scalar> scalar,
                             arrow::py::unwrap_scalar(value));
-      ARROW_ASSIGN_OR_RAISE(const Scalar* storage_scalar, GetStorageScalar(*scalar));
-      return this->value_builder_->AppendScalar(*storage_scalar, 1);
+      return this->value_builder_->AppendScalar(GetStorageScalar(*scalar), 1);
     } else {
       ARROW_ASSIGN_OR_RAISE(auto converted,
                             PyValue::Convert(this->value_type_, this->options_, value));
@@ -824,8 +822,7 @@ class PyDictionaryConverter<U, enable_if_has_string_view<U>>
     } else if (arrow::py::is_scalar(value)) {
       ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Scalar> scalar,
                             arrow::py::unwrap_scalar(value));
-      ARROW_ASSIGN_OR_RAISE(const Scalar* storage_scalar, GetStorageScalar(*scalar));
-      return this->value_builder_->AppendScalar(*storage_scalar, 1);
+      return this->value_builder_->AppendScalar(GetStorageScalar(*scalar), 1);
     } else {
       ARROW_RETURN_NOT_OK(
           PyValue::Convert(this->value_type_, this->options_, value, view_));
@@ -998,8 +995,7 @@ class PyStructConverter : public StructConverter<PyConverter, PyConverterTrait> 
     } else if (arrow::py::is_scalar(value)) {
       ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Scalar> scalar,
                             arrow::py::unwrap_scalar(value));
-      ARROW_ASSIGN_OR_RAISE(const Scalar* storage_scalar, GetStorageScalar(*scalar));
-      return this->struct_builder_->AppendScalar(*storage_scalar);
+      return this->struct_builder_->AppendScalar(GetStorageScalar(*scalar));
     }
     switch (input_kind_) {
       case InputKind::DICT:

--- a/python/pyarrow/src/arrow/python/python_to_arrow.cc
+++ b/python/pyarrow/src/arrow/python/python_to_arrow.cc
@@ -585,7 +585,7 @@ class PyConverter : public Converter<PyObject*, PyConversionOptions> {
 };
 
 // Helper function to unwrap extension scalar to its storage scalar
-inline const Scalar& GetStorageScalar(const Scalar& scalar) {
+const Scalar& GetStorageScalar(const Scalar& scalar) {
   if (scalar.type->id() == Type::EXTENSION) {
     return *checked_cast<const ExtensionScalar&>(scalar).value;
   }

--- a/python/pyarrow/src/arrow/python/python_to_arrow.cc
+++ b/python/pyarrow/src/arrow/python/python_to_arrow.cc
@@ -592,6 +592,7 @@ Result<const Scalar*> GetStorageScalar(const Scalar& scalar) {
   const auto& extension_scalar = checked_cast<const ExtensionScalar&>(scalar);
   return extension_scalar.value.get();
 }
+
 template <typename T, typename Enable = void>
 class PyPrimitiveConverter;
 

--- a/python/pyarrow/src/arrow/python/python_to_arrow.cc
+++ b/python/pyarrow/src/arrow/python/python_to_arrow.cc
@@ -672,8 +672,7 @@ class PyPrimitiveConverter<
       ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Scalar> scalar,
                             arrow::py::unwrap_scalar(value));
       ARROW_ASSIGN_OR_RAISE(const Scalar* storage_scalar, GetStorageScalar(*scalar));
-      ARROW_RETURN_NOT_OK(
-          this->primitive_builder_->AppendScalar(*storage_scalar));
+      ARROW_RETURN_NOT_OK(this->primitive_builder_->AppendScalar(*storage_scalar));
     } else {
       ARROW_ASSIGN_OR_RAISE(
           auto converted, PyValue::Convert(this->primitive_type_, this->options_, value));
@@ -694,8 +693,8 @@ class PyPrimitiveConverter<
     } else if (arrow::py::is_scalar(value)) {
       ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Scalar> scalar,
                             arrow::py::unwrap_scalar(value));
-      ARROW_RETURN_NOT_OK(
-          this->primitive_builder_->AppendScalar(GetStorageScalar(*scalar)));
+      ARROW_ASSIGN_OR_RAISE(const Scalar* storage_scalar, GetStorageScalar(*scalar));
+      ARROW_RETURN_NOT_OK(this->primitive_builder_->AppendScalar(*storage_scalar));
     } else {
       ARROW_ASSIGN_OR_RAISE(
           auto converted, PyValue::Convert(this->primitive_type_, this->options_, value));
@@ -721,8 +720,8 @@ class PyPrimitiveConverter<T, enable_if_t<std::is_same<T, FixedSizeBinaryType>::
     } else if (arrow::py::is_scalar(value)) {
       ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Scalar> scalar,
                             arrow::py::unwrap_scalar(value));
-      ARROW_RETURN_NOT_OK(
-          this->primitive_builder_->AppendScalar(GetStorageScalar(*scalar)));
+      ARROW_ASSIGN_OR_RAISE(const Scalar* storage_scalar, GetStorageScalar(*scalar));
+      ARROW_RETURN_NOT_OK(this->primitive_builder_->AppendScalar(*storage_scalar));
     } else {
       ARROW_RETURN_NOT_OK(
           PyValue::Convert(this->primitive_type_, this->options_, value, view_));
@@ -759,8 +758,8 @@ class PyPrimitiveConverter<
     } else if (arrow::py::is_scalar(value)) {
       ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Scalar> scalar,
                             arrow::py::unwrap_scalar(value));
-      ARROW_RETURN_NOT_OK(
-          this->primitive_builder_->AppendScalar(GetStorageScalar(*scalar)));
+      ARROW_ASSIGN_OR_RAISE(const Scalar* storage_scalar, GetStorageScalar(*scalar));
+      ARROW_RETURN_NOT_OK(this->primitive_builder_->AppendScalar(*storage_scalar));
     } else {
       ARROW_RETURN_NOT_OK(
           PyValue::Convert(this->primitive_type_, this->options_, value, view_));
@@ -804,7 +803,8 @@ class PyDictionaryConverter<U, enable_if_has_c_type<U>>
     } else if (arrow::py::is_scalar(value)) {
       ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Scalar> scalar,
                             arrow::py::unwrap_scalar(value));
-      return this->value_builder_->AppendScalar(GetStorageScalar(*scalar), 1);
+      ARROW_ASSIGN_OR_RAISE(const Scalar* storage_scalar, GetStorageScalar(*scalar));
+      return this->value_builder_->AppendScalar(*storage_scalar, 1);
     } else {
       ARROW_ASSIGN_OR_RAISE(auto converted,
                             PyValue::Convert(this->value_type_, this->options_, value));
@@ -823,7 +823,8 @@ class PyDictionaryConverter<U, enable_if_has_string_view<U>>
     } else if (arrow::py::is_scalar(value)) {
       ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Scalar> scalar,
                             arrow::py::unwrap_scalar(value));
-      return this->value_builder_->AppendScalar(GetStorageScalar(*scalar), 1);
+      ARROW_ASSIGN_OR_RAISE(const Scalar* storage_scalar, GetStorageScalar(*scalar));
+      return this->value_builder_->AppendScalar(*storage_scalar, 1);
     } else {
       ARROW_RETURN_NOT_OK(
           PyValue::Convert(this->value_type_, this->options_, value, view_));
@@ -996,7 +997,8 @@ class PyStructConverter : public StructConverter<PyConverter, PyConverterTrait> 
     } else if (arrow::py::is_scalar(value)) {
       ARROW_ASSIGN_OR_RAISE(std::shared_ptr<Scalar> scalar,
                             arrow::py::unwrap_scalar(value));
-      return this->struct_builder_->AppendScalar(GetStorageScalar(*scalar));
+      ARROW_ASSIGN_OR_RAISE(const Scalar* storage_scalar, GetStorageScalar(*scalar));
+      return this->struct_builder_->AppendScalar(*storage_scalar);
     }
     switch (input_kind_) {
       case InputKind::DICT:

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -1488,46 +1488,29 @@ def test_uuid_bytes_property_raises():
 
 def test_array_from_extension_scalars():
     import datetime
-    from decimal import Decimal
 
+    # One case per C++ converter: FixedSizeBinary, Binary/String
     builtin_cases = [
         (pa.uuid(), [b"0123456789abcdef"]),
-        (pa.bool8(), [0, 1]),
-        (pa.json_(pa.string()), ['{"a":1}', '{"b":2}']),
         (pa.opaque(pa.binary(), "t", "v"), [b"x", b"y"]),
     ]
     for ext_type, values in builtin_cases:
         scalars = [pa.scalar(v, type=ext_type) for v in values]
         result = pa.array(scalars, type=ext_type)
-        expected = pa.array(values, type=ext_type)
-        assert result.equals(expected)
+        assert result.equals(pa.array(values, type=ext_type))
 
-    # Custom extension types requiring registration
+    # One case per C++ converter: Numeric, Timestamp/Duration, Struct
     custom_cases = [
-        (TinyIntType(), [1, 2]),
         (IntegerType(), [100, 200]),
-        (LabelType(), ["a", "b"]),
-        (MyStructType(), [{"left": 1, "right": 2}]),
         (AnnotatedType(pa.timestamp("us"), "ts"),
          [datetime.datetime(2023, 1, 1)]),
-        (AnnotatedType(pa.duration("s"), "dur"),
-         [datetime.timedelta(seconds=100)]),
-        (AnnotatedType(pa.date32(), "date"),
-         [datetime.date(2023, 1, 1)]),
-        (AnnotatedType(pa.float64(), "f"), [1.5, 2.5]),
-        (AnnotatedType(pa.bool_(), "b"), [True, False]),
-        (AnnotatedType(pa.binary(), "bin"), [b"x", b"y"]),
-        (AnnotatedType(pa.decimal128(10, 2), "dec"),
-         [Decimal("1.50"), Decimal("2.75")]),
-        (AnnotatedType(pa.large_string(), "lstr"), ["hello", "world"]),
-        (AnnotatedType(pa.large_binary(), "lbin"), [b"ab", b"cd"]),
+        (MyStructType(), [{"left": 1, "right": 2}]),
     ]
     for ext_type, values in custom_cases:
         with registered_extension_type(ext_type):
             scalars = [pa.scalar(v, type=ext_type) for v in values]
             result = pa.array(scalars, type=ext_type)
-            expected = pa.array(values, type=ext_type)
-            assert result.equals(expected)
+            assert result.equals(pa.array(values, type=ext_type))
 
     # Null handling
     uuid_type = pa.uuid()
@@ -1536,6 +1519,7 @@ def test_array_from_extension_scalars():
     result = pa.array(scalars, type=uuid_type)
     assert result[0].is_valid and not result[1].is_valid
 
+    # ExtensionScalar.from_storage path
     scalars = [
         pa.ExtensionScalar.from_storage(uuid_type, b"0123456789abcdef"),
         pa.ExtensionScalar.from_storage(uuid_type, None),
@@ -1555,8 +1539,7 @@ def test_array_from_extension_scalars():
     # Mixed extension scalars and raw Python objects
     u1, u2 = uuid4(), uuid4()
     result = pa.array([pa.scalar(u1, type=pa.uuid()), u2], type=pa.uuid())
-    expected = pa.array([u1, u2], type=pa.uuid())
-    assert result.equals(expected)
+    assert result.equals(pa.array([u1, u2], type=pa.uuid()))
 
 
 def test_tensor_type():

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -1487,66 +1487,68 @@ def test_uuid_bytes_property_raises():
 
 
 def test_array_from_extension_scalars():
-    # Test unwrap to various storage types and different converters
     import datetime
+    from decimal import Decimal
 
     builtin_cases = [
-        # fixed_size_binary[16] storage
-        (pa.uuid(), [b"0123456789abcdef"], [
-         UUID('30313233-3435-3637-3839-616263646566')]),
-        # int8 storage
-        (pa.bool8(), [0, 1], [0, 1]),
-        # string storage
-        (pa.json_(pa.string()), ['{"a":1}', '{"b":2}'], ['{"a":1}', '{"b":2}']),
-        # binary storage
-        (pa.opaque(pa.binary(), "t", "v"), [b"x", b"y"], [b"x", b"y"]),
+        (pa.uuid(), [b"0123456789abcdef"]),
+        (pa.bool8(), [0, 1]),
+        (pa.json_(pa.string()), ['{"a":1}', '{"b":2}']),
+        (pa.opaque(pa.binary(), "t", "v"), [b"x", b"y"]),
     ]
-    for ext_type, values, expected in builtin_cases:
+    for ext_type, values in builtin_cases:
         scalars = [pa.scalar(v, type=ext_type) for v in values]
         result = pa.array(scalars, type=ext_type)
-        assert result.type == ext_type
-        # TODO: make `expected` pyarrow array so `to_pylist` isn't used, check GH-48241
-        assert result.to_pylist() == expected
+        expected = pa.array(values, type=ext_type)
+        assert result.equals(expected)
 
     # Custom extension types requiring registration
     custom_cases = [
-        # int8 storage
-        (TinyIntType(), [1, 2], [1, 2]),
-        # int64 storage
-        (IntegerType(), [100, 200], [100, 200]),
-        # string storage
-        (LabelType(), ["a", "b"], ["a", "b"]),
-        # struct storage
-        (MyStructType(), [{"left": 1, "right": 2}], [{"left": 1, "right": 2}]),
-        # timestamp storage
+        (TinyIntType(), [1, 2]),
+        (IntegerType(), [100, 200]),
+        (LabelType(), ["a", "b"]),
+        (MyStructType(), [{"left": 1, "right": 2}]),
         (AnnotatedType(pa.timestamp("us"), "ts"),
-         [datetime.datetime(2023, 1, 1)], [datetime.datetime(2023, 1, 1)]),
-        # duration storage
+         [datetime.datetime(2023, 1, 1)]),
         (AnnotatedType(pa.duration("s"), "dur"),
-         [datetime.timedelta(seconds=100)], [datetime.timedelta(seconds=100)]),
-        # date storage
+         [datetime.timedelta(seconds=100)]),
         (AnnotatedType(pa.date32(), "date"),
-         [datetime.date(2023, 1, 1)], [datetime.date(2023, 1, 1)]),
-        # float64 storage
-        (AnnotatedType(pa.float64(), "f"), [1.5, 2.5], [1.5, 2.5]),
-        # boolean storage
-        (AnnotatedType(pa.bool_(), "b"), [True, False], [True, False]),
-        # binary storage
-        (AnnotatedType(pa.binary(), "bin"), [b"x", b"y"], [b"x", b"y"]),
+         [datetime.date(2023, 1, 1)]),
+        (AnnotatedType(pa.float64(), "f"), [1.5, 2.5]),
+        (AnnotatedType(pa.bool_(), "b"), [True, False]),
+        (AnnotatedType(pa.binary(), "bin"), [b"x", b"y"]),
+        (AnnotatedType(pa.decimal128(10, 2), "dec"),
+         [Decimal("1.50"), Decimal("2.75")]),
+        (AnnotatedType(pa.large_string(), "lstr"), ["hello", "world"]),
+        (AnnotatedType(pa.large_binary(), "lbin"), [b"ab", b"cd"]),
     ]
-    for ext_type, values, expected in custom_cases:
+    for ext_type, values in custom_cases:
         with registered_extension_type(ext_type):
             scalars = [pa.scalar(v, type=ext_type) for v in values]
             result = pa.array(scalars, type=ext_type)
-            assert result.type == ext_type
-            # TODO: make `expected` pyarrow array so `to_pylist` isn't used
-            assert result.to_pylist() == expected
+            expected = pa.array(values, type=ext_type)
+            assert result.equals(expected)
 
+    # Null handling
     uuid_type = pa.uuid()
     scalars = [pa.scalar(b"0123456789abcdef", type=uuid_type),
                pa.scalar(None, type=uuid_type)]
     result = pa.array(scalars, type=uuid_type)
     assert result[0].is_valid and not result[1].is_valid
+
+    # Type inference without explicit type
+    u = uuid4()
+    scalars = [pa.scalar(u, type=pa.uuid()), None]
+    result = pa.array(scalars)
+    assert result.type == pa.uuid()
+    assert result[0].as_py() == u
+    assert not result[1].is_valid
+
+    # Mixed extension scalars and raw Python objects
+    u1, u2 = uuid4(), uuid4()
+    result = pa.array([pa.scalar(u1, type=pa.uuid()), u2], type=pa.uuid())
+    expected = pa.array([u1, u2], type=pa.uuid())
+    assert result.equals(expected)
 
 
 def test_tensor_type():

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -1535,12 +1535,15 @@ def test_array_from_extension_scalars():
                pa.scalar(None, type=uuid_type)]
     result = pa.array(scalars, type=uuid_type)
     assert result[0].is_valid and not result[1].is_valid
+
     scalars = [
         pa.ExtensionScalar.from_storage(uuid_type, b"0123456789abcdef"),
         pa.ExtensionScalar.from_storage(uuid_type, None),
     ]
     result = pa.array(scalars, type=uuid_type)
-    assert result.to_pylist() == [UUID(bytes=b"0123456789abcdef"), None]
+    expected = pa.array([b"0123456789abcdef", None], type=uuid_type)
+    assert result.equals(expected)
+
     # Type inference without explicit type
     u = uuid4()
     scalars = [pa.scalar(u, type=pa.uuid()), None]

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -16,6 +16,7 @@
 # under the License.
 
 import contextlib
+import datetime
 import os
 import shutil
 import subprocess
@@ -1487,8 +1488,6 @@ def test_uuid_bytes_property_raises():
 
 
 def test_array_from_extension_scalars():
-    import datetime
-
     # One case per C++ converter: FixedSizeBinary, Binary/String
     builtin_cases = [
         (pa.uuid(), [b"0123456789abcdef"]),

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -1486,6 +1486,69 @@ def test_uuid_bytes_property_raises():
         pa.scalar(bad)
 
 
+def test_array_from_extension_scalars():
+    # Test unwrap to various storage types and different converters
+    import datetime
+
+    builtin_cases = [
+        # fixed_size_binary[16] storage
+        (pa.uuid(), [b"0123456789abcdef"], [
+         UUID('30313233-3435-3637-3839-616263646566')]),
+        # int8 storage
+        (pa.bool8(), [0, 1], [0, 1]),
+        # string storage
+        (pa.json_(pa.string()), ['{"a":1}', '{"b":2}'], ['{"a":1}', '{"b":2}']),
+        # binary storage
+        (pa.opaque(pa.binary(), "t", "v"), [b"x", b"y"], [b"x", b"y"]),
+    ]
+    for ext_type, values, expected in builtin_cases:
+        scalars = [pa.scalar(v, type=ext_type) for v in values]
+        result = pa.array(scalars, type=ext_type)
+        assert result.type == ext_type
+        # TODO: make `expected` pyarrow array so `to_pylist` isn't used, check GH-48241
+        assert result.to_pylist() == expected
+
+    # Custom extension types requiring registration
+    custom_cases = [
+        # int8 storage
+        (TinyIntType(), [1, 2], [1, 2]),
+        # int64 storage
+        (IntegerType(), [100, 200], [100, 200]),
+        # string storage
+        (LabelType(), ["a", "b"], ["a", "b"]),
+        # struct storage
+        (MyStructType(), [{"left": 1, "right": 2}], [{"left": 1, "right": 2}]),
+        # timestamp storage
+        (AnnotatedType(pa.timestamp("us"), "ts"),
+         [datetime.datetime(2023, 1, 1)], [datetime.datetime(2023, 1, 1)]),
+        # duration storage
+        (AnnotatedType(pa.duration("s"), "dur"),
+         [datetime.timedelta(seconds=100)], [datetime.timedelta(seconds=100)]),
+        # date storage
+        (AnnotatedType(pa.date32(), "date"),
+         [datetime.date(2023, 1, 1)], [datetime.date(2023, 1, 1)]),
+        # float64 storage
+        (AnnotatedType(pa.float64(), "f"), [1.5, 2.5], [1.5, 2.5]),
+        # boolean storage
+        (AnnotatedType(pa.bool_(), "b"), [True, False], [True, False]),
+        # binary storage
+        (AnnotatedType(pa.binary(), "bin"), [b"x", b"y"], [b"x", b"y"]),
+    ]
+    for ext_type, values, expected in custom_cases:
+        with registered_extension_type(ext_type):
+            scalars = [pa.scalar(v, type=ext_type) for v in values]
+            result = pa.array(scalars, type=ext_type)
+            assert result.type == ext_type
+            # TODO: make `expected` pyarrow array so `to_pylist` isn't used
+            assert result.to_pylist() == expected
+
+    uuid_type = pa.uuid()
+    scalars = [pa.scalar(b"0123456789abcdef", type=uuid_type),
+               pa.scalar(None, type=uuid_type)]
+    result = pa.array(scalars, type=uuid_type)
+    assert result[0].is_valid and not result[1].is_valid
+
+
 def test_tensor_type():
     tensor_type = pa.fixed_shape_tensor(pa.int8(), [2, 3])
     assert tensor_type.extension_name == "arrow.fixed_shape_tensor"

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -1485,10 +1485,7 @@ def test_uuid_bytes_property_raises():
     with pytest.raises(RuntimeError, match="broken"):
         pa.scalar(bad)
 
-def test_array_from_mismatched_extension_scalar_type():
-    scalar = pa.scalar(b"1" * 16, type=ExampleUuidType())
-    with pytest.raises(TypeError):
-        pa.array([scalar], type=ExampleUuidType2())
+
 def test_array_from_extension_scalars():
     import datetime
     from decimal import Decimal

--- a/python/pyarrow/tests/test_extension_type.py
+++ b/python/pyarrow/tests/test_extension_type.py
@@ -1485,7 +1485,10 @@ def test_uuid_bytes_property_raises():
     with pytest.raises(RuntimeError, match="broken"):
         pa.scalar(bad)
 
-
+def test_array_from_mismatched_extension_scalar_type():
+    scalar = pa.scalar(b"1" * 16, type=ExampleUuidType())
+    with pytest.raises(TypeError):
+        pa.array([scalar], type=ExampleUuidType2())
 def test_array_from_extension_scalars():
     import datetime
     from decimal import Decimal
@@ -1535,7 +1538,12 @@ def test_array_from_extension_scalars():
                pa.scalar(None, type=uuid_type)]
     result = pa.array(scalars, type=uuid_type)
     assert result[0].is_valid and not result[1].is_valid
-
+    scalars = [
+        pa.ExtensionScalar.from_storage(uuid_type, b"0123456789abcdef"),
+        pa.ExtensionScalar.from_storage(uuid_type, None),
+    ]
+    result = pa.array(scalars, type=uuid_type)
+    assert result.to_pylist() == [UUID(bytes=b"0123456789abcdef"), None]
     # Type inference without explicit type
     u = uuid4()
     scalars = [pa.scalar(u, type=pa.uuid()), None]


### PR DESCRIPTION
### Rationale for this change
Fixes #48470. Also fixes all extension types, not just UUID.

### What changes are included in this PR?
An extension scalar is unwrapped to its storage type when building arrays.

### Are these changes tested?
Yes, new `test_array_from_extension_scalars` covers builtin (uuid, bool8, json_, opaque) and custom types across all storage types (int, float, bool, string, binary, large string/binary, decimal, fixed-size binary, struct, timestamp, duration, date).

### Are there any user-facing changes?
Now user can run such an example to get the output below instead of `ArrowInvalid` message.
This now works for any extension type, not just UUID.
```python
import pyarrow as pa
pa.array([pa.scalar(b'1'*16, type=pa.uuid())], type=pa.uuid())
``` 

```
<pyarrow.lib.UuidArray object at 0x128186970>
[
  31313131313131313131313131313131
]
```
* GitHub Issue: #48470