### PR TITLE
GH-48637: [C++][FlightRPC] ODBC: Disable `absl` deadlock detection

### DIFF
--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/flight_sql_driver.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/flight_sql_driver.cc
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <absl/synchronization/mutex.h>
+
 #include "arrow/flight/sql/odbc/odbc_impl/flight_sql_driver.h"
 
 #include "arrow/compute/api.h"
@@ -37,6 +39,8 @@ FlightSqlDriver::FlightSqlDriver()
   RegisterComputeKernels();
   // Register log after compute kernels check to avoid segfaults
   RegisterLog();
+  // GH-48637: Disable Absl Deadlock detection from upstream projects
+  absl::SetMutexDeadlockDetectionMode(absl::OnDeadlockCycle::kIgnore);
 }
 
 FlightSqlDriver::~FlightSqlDriver() {


### PR DESCRIPTION
### Rationale for this change
https://github.com/apache/arrow/issues/48637

Arrow Flight SQL ODBC gets `potential deadlock` error during tests because this error is happening at Arrow Flight SQL (see https://github.com/apache/arrow/issues/48714). Arrow doesn't use `absl::Mutex` directly, and `absl::Mutex` is used by upstream projects gRPC/Protobuf, so Arrow itself likely did not cause the potential deadlock. We can disable the deadlock detection for now.

### What changes are included in this PR?
- Disable `absl` deadlock detection inside ODBC, so potential deadlock detection from upstream projects don't get picked up in the tests.

### Are these changes tested?
- Tested locally on MSVC Windows
### Are there any user-facing changes?
N/A
* GitHub Issue: #48637