### PR TITLE
GH-48736: [CI][Python] Restore AlmaLinux 8 support of `dev/release/setup-rhel-rebuilds.sh` for wheel verification

### DIFF
--- a/dev/release/setup-rhel-rebuilds.sh
+++ b/dev/release/setup-rhel-rebuilds.sh
@@ -22,6 +22,7 @@
 
 set -exu
 
+# shellcheck source=/dev/null
 distribution_version=$(. /etc/os-release && echo "${VERSION_ID}" | grep -o "^[0-9]*")
 
 if [ "${distribution_version}" -eq 8 ]; then

--- a/dev/release/setup-rhel-rebuilds.sh
+++ b/dev/release/setup-rhel-rebuilds.sh
@@ -16,13 +16,21 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# A script to install dependencies required for release
-# verification on Red Hat Enterprise Linux 10 clones in particular
-# on AlmaLinux 10
+# A script to install dependencies required for release verification
+# on Red Hat Enterprise Linux 8 or later clones in particular on
+# AlmaLinux 8 or later.
 
 set -exu
 
-dnf -y install 'dnf-command(config-manager)'
+distribution_version=$(. /etc/os-release && echo "${VERSION_ID}" | grep -o "^[0-9]*")
+
+if [ "${distribution_version}" -eq 8 ]; then
+  dnf -y install 'dnf-command(config-manager)'
+  dnf config-manager --set-enabled powertools
+  python_devel=python3.12-devel
+else
+  python_devel=python3-devel
+fi
 dnf -y update
 dnf -y groupinstall "Development Tools"
 dnf -y install \
@@ -35,7 +43,7 @@ dnf -y install \
   ncurses-devel \
   ninja-build \
   openssl-devel \
-  python3-devel \
+  ${python_devel} \
   ruby-devel \
   sqlite-devel \
   vala-devel \


### PR DESCRIPTION
### Rationale for this change

GH-48414 removed AlmaLinux 8 support from `dev/release/setup-rhel-rebuilds.sh`. But we need to restore it for wheel verification. 

### What changes are included in this PR?

* Enable `powertools` repository for some development packages
* Use Python 3.12 explicitly

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #48736