### PR TITLE
GH-48755: [MATLAB] Rename getArrayProxyIDs to getProxyIDs

### DIFF
--- a/matlab/src/matlab/+arrow/+array/+internal/getProxyIDs.m
+++ b/matlab/src/matlab/+arrow/+array/+internal/getProxyIDs.m
@@ -1,5 +1,5 @@
-%GETARRAYPROXYIDS Extract the Proxy IDs underlying a cell array of 
-% arrow.array.Array instances.
+%GETPROXYIDS Extract the Proxy IDs underlying a cell array of 
+% arrow.array.Array or arrow.tabular.RecordBatch instances.
 
 % Licensed to the Apache Software Foundation (ASF) under one or more
 % contributor license agreements.  See the NOTICE file distributed with
@@ -15,12 +15,12 @@
 % WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
 % implied.  See the License for the specific language governing
 % permissions and limitations under the License.
-function proxyIDs = getArrayProxyIDs(arrowArrays)
-    proxyIDs = zeros(1, numel(arrowArrays), "uint64");
+function proxyIDs = getProxyIDs(objects)
+    proxyIDs = zeros(1, numel(objects), "uint64");
 
-    % Convert each MATLAB array into a corresponding
-    % arrow.array.Array.
-    for ii = 1:numel(arrowArrays)
-        proxyIDs(ii) = arrowArrays{ii}.Proxy.ID;
+    % Extract the Proxy.ID from each object
+    for ii = 1:numel(objects)
+        proxyIDs(ii) = objects{ii}.Proxy.ID;
     end
 end
+

--- a/matlab/src/matlab/+arrow/+array/ChunkedArray.m
+++ b/matlab/src/matlab/+arrow/+array/ChunkedArray.m
@@ -121,7 +121,7 @@ classdef ChunkedArray < matlab.mixin.CustomDisplay & ...
                 type = arrays{1}.Type;
             end
 
-            proxyIDs = arrow.array.internal.getArrayProxyIDs(arrays);
+            proxyIDs = arrow.array.internal.getProxyIDs(arrays);
             args = struct(ArrayProxyIDs=proxyIDs, TypeProxyID=type.Proxy.ID);
             proxyName = "arrow.array.proxy.ChunkedArray";
             proxy = arrow.internal.proxy.create(proxyName, args);

--- a/matlab/src/matlab/+arrow/+array/StructArray.m
+++ b/matlab/src/matlab/+arrow/+array/StructArray.m
@@ -123,7 +123,7 @@ classdef StructArray < arrow.array.Array
 
             import arrow.tabular.internal.validateArrayLengths
             import arrow.tabular.internal.validateColumnNames
-            import arrow.array.internal.getArrayProxyIDs
+            import arrow.array.internal.getProxyIDs
             import arrow.internal.validate.parseValid
 
             if numel(arrowArrays) == 0
@@ -135,7 +135,7 @@ classdef StructArray < arrow.array.Array
             validateColumnNames(opts.FieldNames, numel(arrowArrays));
             validElements = parseValid(opts, arrowArrays{1}.NumElements);
 
-            arrayProxyIDs = getArrayProxyIDs(arrowArrays);
+            arrayProxyIDs = getProxyIDs(arrowArrays);
             args = struct(ArrayProxyIDs=arrayProxyIDs, ...
                 FieldNames=opts.FieldNames, Valid=validElements);
             proxyName = "arrow.array.proxy.StructArray";
@@ -152,7 +152,7 @@ classdef StructArray < arrow.array.Array
 
             import arrow.tabular.internal.decompose
             import arrow.tabular.internal.validateColumnNames
-            import arrow.array.internal.getArrayProxyIDs
+            import arrow.array.internal.getProxyIDs
             import arrow.internal.validate.parseValid
 
             if width(T) == 0
@@ -166,7 +166,7 @@ classdef StructArray < arrow.array.Array
             validateColumnNames(opts.FieldNames, width(T));
 
             arrowArrays = decompose(T);
-            arrayProxyIDs = getArrayProxyIDs(arrowArrays);
+            arrayProxyIDs = getProxyIDs(arrowArrays);
             validElements = parseValid(opts, height(T));
 
             args = struct(ArrayProxyIDs=arrayProxyIDs, ...

--- a/matlab/src/matlab/+arrow/+tabular/RecordBatch.m
+++ b/matlab/src/matlab/+arrow/+tabular/RecordBatch.m
@@ -65,13 +65,13 @@ classdef RecordBatch < arrow.tabular.Tabular
 
             import arrow.tabular.internal.validateArrayLengths
             import arrow.tabular.internal.validateColumnNames
-            import arrow.array.internal.getArrayProxyIDs
+            import arrow.array.internal.getProxyIDs
             
             numColumns = numel(arrowArrays);
             validateArrayLengths(arrowArrays);
             validateColumnNames(opts.ColumnNames, numColumns);
 
-            arrayProxyIDs = getArrayProxyIDs(arrowArrays);
+            arrayProxyIDs = getProxyIDs(arrowArrays);
             args = struct(ArrayProxyIDs=arrayProxyIDs, ColumnNames=opts.ColumnNames);
             proxyName = "arrow.tabular.proxy.RecordBatch";
             proxy = arrow.internal.proxy.create(proxyName, args);

--- a/matlab/src/matlab/+arrow/+tabular/Table.m
+++ b/matlab/src/matlab/+arrow/+tabular/Table.m
@@ -47,13 +47,13 @@ classdef Table < arrow.tabular.Tabular
 
             import arrow.tabular.internal.validateArrayLengths
             import arrow.tabular.internal.validateColumnNames
-            import arrow.array.internal.getArrayProxyIDs
+            import arrow.array.internal.getProxyIDs
 
             numColumns = numel(arrowArrays);
             validateArrayLengths(arrowArrays);
             validateColumnNames(opts.ColumnNames, numColumns);
 
-            arrayProxyIDs = getArrayProxyIDs(arrowArrays);
+            arrayProxyIDs = getProxyIDs(arrowArrays);
             args = struct(Method="from_arrays", ArrayProxyIDs=arrayProxyIDs, ColumnNames=opts.ColumnNames);
             proxyName = "arrow.tabular.proxy.Table";
             proxy = arrow.internal.proxy.create(proxyName, args);
@@ -83,8 +83,7 @@ classdef Table < arrow.tabular.Tabular
                 end
             end
 
-            % TODO: Rename getArrayProxyIDs to getProxyIDs
-            proxyIDs = arrow.array.internal.getArrayProxyIDs(batches);
+            proxyIDs = arrow.array.internal.getProxyIDs(batches);
             args = struct(Method="from_record_batches", RecordBatchProxyIDs=proxyIDs);
             proxyName = "arrow.tabular.proxy.Table";
             proxy = arrow.internal.proxy.create(proxyName, args);

--- a/matlab/src/matlab/+arrow/recordBatch.m
+++ b/matlab/src/matlab/+arrow/recordBatch.m
@@ -20,7 +20,7 @@ function rb = recordBatch(T)
     end
 
     arrowArrays = arrow.tabular.internal.decompose(T);
-    arrayProxyIDs = arrow.array.internal.getArrayProxyIDs(arrowArrays);
+    arrayProxyIDs = arrow.array.internal.getProxyIDs(arrowArrays);
 
     columnNames = string(T.Properties.VariableNames);
     args = struct(ArrayProxyIDs=arrayProxyIDs, ColumnNames=columnNames);


### PR DESCRIPTION
### Rationale for this change

The internal helper function `getArrayProxyIDs` was misleadingly named since it works with both Arrays and RecordBatches, not just arrays.

### What changes are included in this PR?

- Renamed `getArrayProxyIDs.m` to `getProxyIDs.m`
- Updated all call sites
- Removed TODO comment requesting this change

### Are these changes tested?

Existing tests cover functionality.

### Are there any user-facing changes?

No, dev-only.
* GitHub Issue: #48755