### PR TITLE
GH-48757: [CI] Update arrow/.github /CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -51,8 +51,6 @@
 /.github/ @assignUser @jonkeane @kou @raulcd
 .asf.yaml @assignUser @kou @raulcd
 .pre-commit-config.yaml @raulcd
-.travis.yml @assignUser @kou @raulcd
-appveyor.yml @assignUser @kou @raulcd
 # .git*
 
 # release scripts, archery etc.
@@ -67,4 +65,4 @@ compose.yaml @assignUser @jonkeane @kou @raulcd
 /r/Makefile @assignUser
 /r/PACKAGING.md @assignUser
 /r/tools/ @assignUser
-.Rbuildignore @assignUser
+/r/.Rbuildignore @assignUser


### PR DESCRIPTION
### Rationale for this change

The CODEOWNERS file contained references to CI configuration files that no longer exist in the repository. Travis CI and AppVeyor have been replaced by GitHub Actions by 2c51a07ab181b4e678c6fbe09fcf832d248e289a and e1c6fd53048553deb61e69e53581fcf9d59e4f55.

### What changes are included in this PR?

- Removed `.travis.yml` and `appveyor.yml` from CODEOWNERS
- Move `.Rbuildignore` to `/r/.Rbuildignore` to be explicit.

### Are these changes tested?

I did not test.

### Are there any user-facing changes?

No, dev-only.
* GitHub Issue: #48757