### PR TITLE
GH-48759: [Python] Remove skip condition for pandas/issues/50127

### DIFF
--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -525,7 +525,7 @@ class TestConvertMetadata:
                                         preserve_index=True)
 
     def test_binary_column_name(self):
-        if Version("2.0.0") <= Version(pd.__version__) < Version("3.0.0"):
+        if Version(pd.__version__) >= Version("2.0.0"):
             # TODO: regression in pandas, hopefully fixed in next version
             # https://issues.apache.org/jira/browse/ARROW-18394
             # https://github.com/pandas-dev/pandas/issues/50127
@@ -3309,7 +3309,7 @@ def _fully_loaded_dataframe_example():
 
 @pytest.mark.parametrize('columns', ([b'foo'], ['foo']))
 def test_roundtrip_with_bytes_unicode(columns):
-    if Version("2.0.0") <= Version(pd.__version__) < Version("3.0.0"):
+    if Version(pd.__version__) >= Version("2.0.0"):
         # TODO: regression in pandas, hopefully fixed in next version
         # https://issues.apache.org/jira/browse/ARROW-18394
         # https://github.com/pandas-dev/pandas/issues/50127

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -525,11 +525,6 @@ class TestConvertMetadata:
                                         preserve_index=True)
 
     def test_binary_column_name(self):
-        if Version(pd.__version__) >= Version("2.0.0"):
-            # TODO: regression in pandas, hopefully fixed in next version
-            # https://issues.apache.org/jira/browse/ARROW-18394
-            # https://github.com/pandas-dev/pandas/issues/50127
-            pytest.skip("Regression in pandas 2.0.0")
         column_data = ['い']
         key = 'あ'.encode()
         data = {key: column_data}
@@ -3309,12 +3304,6 @@ def _fully_loaded_dataframe_example():
 
 @pytest.mark.parametrize('columns', ([b'foo'], ['foo']))
 def test_roundtrip_with_bytes_unicode(columns):
-    if Version(pd.__version__) >= Version("2.0.0"):
-        # TODO: regression in pandas, hopefully fixed in next version
-        # https://issues.apache.org/jira/browse/ARROW-18394
-        # https://github.com/pandas-dev/pandas/issues/50127
-        pytest.skip("Regression in pandas 2.0.0")
-
     df = pd.DataFrame(columns=columns)
     table1 = pa.Table.from_pandas(df)
     table2 = pa.Table.from_pandas(table1.to_pandas())


### PR DESCRIPTION
### Rationale for this change

Tests `test_binary_column_name` and `test_roundtrip_with_bytes_unicode` were being skipped on pandas 2.0+ due to a pandas regression (https://github.com/pandas-dev/pandas/issues/50127) that caused `NotImplementedError: |S3` when roundtripping DataFrames with bytes column names.

This issue was already fixed in commit e2ac52d661d (GH-44171) by changing an `if` statement to `elif` in `_reconstruct_columns_from_metadata()`. The fix prevents bytes-typed columns from falling through to the `level.astype(dtype)` call that triggered the pandas error.

### What changes are included in this PR?

Remove the skip conditions from two test cases.

### Are these changes tested?

Yes all related tests pass.

### Are there any user-facing changes?

No.

* GitHub Issue: #48759