### PR TITLE
MINOR: [Docs] Add missing external note for dotnet repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Major components of the project include:
    Arrow data with application-defined semantics (for example a storage server or a database)
  - [C++ libraries](https://github.com/apache/arrow/tree/main/cpp)
  - [C bindings using GLib](https://github.com/apache/arrow/tree/main/c_glib)
- - [.NET libraries](https://github.com/apache/arrow-dotnet)
+ - [.NET libraries](https://github.com/apache/arrow-dotnet) `↗`
  - [Gandiva](https://github.com/apache/arrow/tree/main/cpp/src/gandiva):
    an [LLVM](https://llvm.org)-based Arrow expression compiler, part of the C++ codebase
  - [Go libraries](https://github.com/apache/arrow-go) `↗`


### PR DESCRIPTION
### Rationale for this change

We use `↗` to indicate that a component / language implementation is in a different repository. The .NET one was missing the symbol.

### What changes are included in this PR?

Add missing `↗` to the readme.

### Are these changes tested?

No

### Are there any user-facing changes?

No
