### PR TITLE
GH-48772: [CI] Pass GITHUB_TOKEN via environment variable instead of writing to disk

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -106,8 +106,11 @@ jobs:
           pip install "cython>=3.1" setuptools pytest requests setuptools-scm
       - name: Run Release Test
         shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "GH_TOKEN=${{ secrets.GITHUB_TOKEN }}" > dev/release/.env
+          # Create empty .env file for scripts that source it
+          touch dev/release/.env
           ci/scripts/release_test.sh $(pwd)
       - name: Run Merge Script Test
         shell: bash

--- a/dev/release/02-source-test.rb
+++ b/dev/release/02-source-test.rb
@@ -72,7 +72,12 @@ class SourceTest < Test::Unit::TestCase
   end
 
   def test_vote
-    github_token = File.read(@env)[/^GH_TOKEN=(.*)$/, 1]
+    # Read token from ENV in CI, .env file for local dev
+    if ENV["GITHUB_ACTIONS"]
+      github_token = ENV["GH_TOKEN"]
+    else
+      github_token = File.read(@env)[/^GH_TOKEN=(.*)$/, 1]
+    end
     uri = URI.parse("https://api.github.com/graphql")
     n_issues_query = {
       "query" => <<-QUERY,


### PR DESCRIPTION
### Rationale for this change

The dev workflow was writing `GITHUB_TOKEN` to disk (`dev/release/.env` file), which is a security risk. Even though GitHub Actions redacts secrets in logs, writing them to disk can expose them if the runner is compromised or debug artifacts are uploaded.

Following [GitHub's official security guidance](https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#good-practices-for-using-secrets), secrets should be passed via environment variables instead of being written to files or command-line arguments.

```
steps:
  - name: Hello world action
    with: # Set the secret as an input
      super_secret: ${{ secrets.SuperSecret }}
    env: # Or as an environment variable
      super_secret: ${{ secrets.SuperSecret }}
```

### What changes are included in this PR?

- Pass `GH_TOKEN` via `env:` instead of writing to disk with `echo ... > .env`
- Check `ENV["GITHUB_ACTIONS"]` to determine environment
  - In CI: read token from `ENV["GH_TOKEN"]`
  - Local dev: read from `.env` file (preserves original behavior for developers)

### Are these changes tested?

Will be tested in CI at this PR.

### Are there any user-facing changes?

No, dev-only.
* GitHub Issue: #48772