### PR TITLE
GH-48774: [CI] Only cancel in-progress builds for pull requests, not main branch

### DIFF
--- a/.github/workflows/archery.yml
+++ b/.github/workflows/archery.yml
@@ -44,7 +44,7 @@ env:
 
 concurrency:
   group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -60,7 +60,7 @@ on:
 
 concurrency:
   group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -72,7 +72,7 @@ on:
 
 concurrency:
   group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -29,7 +29,7 @@ on:
 
 concurrency:
   group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -46,7 +46,7 @@ on:
 
 concurrency:
   group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -38,7 +38,7 @@ on:
 
 concurrency:
   group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/package_linux.yml
+++ b/.github/workflows/package_linux.yml
@@ -58,7 +58,7 @@ on:
 
 concurrency:
   group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   # Upload to GitHub Release

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -42,7 +42,7 @@ on:
 
 concurrency:
   group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -52,7 +52,7 @@ on:
 
 concurrency:
   group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -56,7 +56,7 @@ on:
 
 concurrency:
   group: ${{ github.repository }}-${{ github.head_ref || github.sha }}-${{ github.workflow }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read


### PR DESCRIPTION
### Rationale for this change

Currently, workflows use `cancel-in-progress: true` unconditionally, which cancels builds even on the main branch when multiple commits are pushed in quick succession. This prevents proper validation of main branch commits and can cause incomplete CI runs for scheduled builds.

TBD

### What changes are included in this PR?

Changed `cancel-in-progress` from `true` to `${{ github.event_name == 'pull_request' }}` in workflows.

Now only pull request builds are cancelled when new commits are pushed. Main branch pushes, scheduled runs, and manual runs will always complete.

### Are these changes tested?

Will be tested in CI.

### Are there any user-facing changes?

No, dev-only.
* GitHub Issue: #48774