### PR TITLE
GH-48776: [CI][Ruby][Windows] Ensure removing temporary files

### DIFF
--- a/c_glib/parquet-glib/arrow-file-reader.cpp
+++ b/c_glib/parquet-glib/arrow-file-reader.cpp
@@ -182,6 +182,24 @@ gparquet_arrow_file_reader_new_path(const gchar *path, GError **error)
 }
 
 /**
+ * gparquet_arrow_file_reader_close:
+ * @reader: A #GParquetArrowFileReader.
+ *
+ * Close the reader.
+ *
+ * Since: 23.0.0
+ */
+void
+gparquet_arrow_file_reader_close(GParquetArrowFileReader *reader)
+{
+  auto parquet_arrow_file_reader = gparquet_arrow_file_reader_get_raw(reader);
+  auto parquet_reader = parquet_arrow_file_reader->parquet_reader();
+  if (parquet_reader) {
+    parquet_reader->Close();
+  }
+}
+
+/**
  * gparquet_arrow_file_reader_read_table:
  * @reader: A #GParquetArrowFileReader.
  * @error: (nullable): Return location for a #GError or %NULL.

--- a/c_glib/parquet-glib/arrow-file-reader.h
+++ b/c_glib/parquet-glib/arrow-file-reader.h
@@ -43,6 +43,10 @@ GPARQUET_AVAILABLE_IN_0_11
 GParquetArrowFileReader *
 gparquet_arrow_file_reader_new_path(const gchar *path, GError **error);
 
+GPARQUET_AVAILABLE_IN_23_0
+void
+gparquet_arrow_file_reader_close(GParquetArrowFileReader *reader);
+
 GPARQUET_AVAILABLE_IN_0_11
 GArrowTable *
 gparquet_arrow_file_reader_read_table(GParquetArrowFileReader *reader, GError **error);

--- a/ruby/red-arrow/test/test-feather.rb
+++ b/ruby/red-arrow/test/test-feather.rb
@@ -29,6 +29,7 @@ class FeatherTest < Test::Unit::TestCase
     begin
       yield(@output)
     ensure
+      GC.start # Ensure freeing Arrow::Table that refers @output.path.
       @output.close!
     end
   end

--- a/ruby/red-arrow/test/test-record-batch-stream-reader.rb
+++ b/ruby/red-arrow/test/test-record-batch-stream-reader.rb
@@ -16,6 +16,10 @@
 # under the License.
 
 class RecordBatchStreamReaderTest < Test::Unit::TestCase
+  def teardown
+    GC.start # Ensure freeing Arrow::RecordBatch that refers tempfile.path.
+  end
+
   test("write/read") do
     fields = [
       Arrow::Field.new("uint8",  :uint8),

--- a/ruby/red-arrow/test/test-table.rb
+++ b/ruby/red-arrow/test/test-table.rb
@@ -747,6 +747,10 @@ class TableTest < Test::Unit::TestCase
           @file.path
         end
 
+        def teardown
+          GC.start # Ensure freeing Arrow::Table that refers @file.path.
+        end
+
         sub_test_case("save: auto detect") do
           test("arrow") do
             output = create_output(".arrow")

--- a/ruby/red-parquet/lib/parquet/arrow-file-reader.rb
+++ b/ruby/red-parquet/lib/parquet/arrow-file-reader.rb
@@ -17,6 +17,8 @@
 
 module Parquet
   class ArrowFileReader
+    include Arrow::BlockClosable
+
     def each_row_group
       return to_enum(__method__) {n_row_groups} unless block_given?
 

--- a/ruby/red-parquet/lib/parquet/arrow-file-writer.rb
+++ b/ruby/red-parquet/lib/parquet/arrow-file-writer.rb
@@ -17,6 +17,8 @@
 
 module Parquet
   class ArrowFileWriter
+    include Arrow::BlockClosable
+
     # Write data to Apache Parquet.
     #
     # @return [void]

--- a/ruby/red-parquet/test/test-arrow-table.rb
+++ b/ruby/red-parquet/test/test-arrow-table.rb
@@ -50,6 +50,7 @@ class TestArrowTable < Test::Unit::TestCase
     begin
       yield(@output)
     ensure
+      GC.start # Ensure freeing Arrow::Table that refers @output.path.
       @output.close!
     end
   end

--- a/ruby/red-parquet/test/test-boolean-statistics.rb
+++ b/ruby/red-parquet/test/test-boolean-statistics.rb
@@ -17,15 +17,22 @@
 
 class TestBooleanStatistics < Test::Unit::TestCase
   def setup
-    file = Tempfile.open(["data", ".parquet"])
-    array = Arrow::BooleanArray.new([nil, false, true])
-    table = Arrow::Table.new("boolean" => array)
-    writer = Parquet::ArrowFileWriter.new(table.schema, file.path)
-    chunk_size = 1024
-    writer.write_table(table, chunk_size)
-    writer.close
-    reader = Parquet::ArrowFileReader.new(file.path)
-    @statistics = reader.metadata.get_row_group(0).get_column_chunk(0).statistics
+    Tempfile.create(["data", ".parquet"]) do |file|
+      array = Arrow::BooleanArray.new([nil, false, true])
+      table = Arrow::Table.new("boolean" => array)
+      Parquet::ArrowFileWriter.open(table.schema, file.path) do |writer|
+        chunk_size = 1024
+        writer.write_table(table, chunk_size)
+        writer.close
+      end
+      Parquet::ArrowFileReader.open(file.path) do |reader|
+        @statistics =
+          reader.metadata.get_row_group(0).get_column_chunk(0).statistics
+        yield
+        @statistics = nil
+      end
+      GC.start # Ensure freeing @statistics that refers file.path.
+    end
   end
 
   def test_min


### PR DESCRIPTION
### Rationale for this change

We can't remove a file if someone is still opening the file on Windows.

We use `Tempfile` for tests. It removes associated file when it's GC-ed. If we still open the associated file, the GC process reports the following warning:

```text
warning: Exception in finalizer #<Tempfile::FinalizerManager:0x000001fb3c15ac00 @open_files={}, @path="D:/a/_temp/batch20260107-2120-ddy0e0.arrow", @pid=2120, @unlinked=false>
``` 

### What changes are included in this PR?

Ensure removing temporary files. 

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes. Only for `gparquet_arrow_file_reader_close()`.
* GitHub Issue: #48776