### PR TITLE
GH-48780: [CI] Add missing permissions for reusable workflow calls

### DIFF
--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -77,7 +77,9 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
+  actions: read
   contents: read
+  pull-requests: read
 
 jobs:
   check-labels:

--- a/.github/workflows/package_linux.yml
+++ b/.github/workflows/package_linux.yml
@@ -61,8 +61,10 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
+  actions: read
   # Upload to GitHub Release
   contents: write
+  pull-requests: read
 
 jobs:
   check-labels:

--- a/.github/workflows/r_extra.yml
+++ b/.github/workflows/r_extra.yml
@@ -67,7 +67,9 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
+  actions: read
   contents: read
+  pull-requests: read
 
 jobs:
   check-labels:


### PR DESCRIPTION
### Rationale for this change

Workflows `cpp_extra.yml`, `r_extra.yml` and `package_linux.yml` call reusable workflows (`check_labels.yml` and `report_ci.yml`) that require specific permissions. When #48771 added explicit permissions to these reusable workflows, the calling workflows were not updated to give those permissions.

This caused `startup_failure` errors when these workflows were triggered on pull requests. Here are example failures: https://github.com/apache/arrow/actions/runs/20809257825 and https://github.com/apache/arrow/actions/runs/20803198596

### What changes are included in this PR?

Added missing permissions to the workflows


### Are these changes tested?

Yes, I tested them within this PR.

### Are there any user-facing changes?

No, dev-only.

* GitHub Issue: #48780