### PR TITLE
GH-48752: [Ruby] Skip ChunkedArray test on Windows due to flakiness

### DIFF
--- a/ruby/red-arrow/test/test-ractor.rb
+++ b/ruby/red-arrow/test/test-ractor.rb
@@ -20,6 +20,10 @@ class RactorTest < Test::Unit::TestCase
 
   ractor
   test("ChunkedArray") do
+    if Gem.win_platform?
+      omit("Ractor is unstable on Windows: " +
+           "https://github.com/apache/arrow/issues/48752")
+    end
     require_ruby(3, 1, 0)
     array = Arrow::Array.new([1, 2, 3])
     chunked_array = Arrow::ChunkedArray.new([array])


### PR DESCRIPTION
### Rationale for this change

This is quite flaky on Windows, and seems like there is a bug in Ruby. It takes some time to investigate so skip it for now.

### What changes are included in this PR?

Skip `ChunkedArray` on Windows.

### Are these changes tested?

Will be tested in this PR/CI

### Are there any user-facing changes?

No, test-only.

* GitHub Issue: #48752