### PR TITLE
GH-48784: [GLib] Make (system) Parquet C++ is optional

### DIFF
--- a/c_glib/meson.build
+++ b/c_glib/meson.build
@@ -191,6 +191,7 @@ if arrow_cpp_build_lib_dir == ''
         'Parquet',
         kwargs: common_args,
         modules: ['Parquet::parquet_shared'],
+        required: false,
     )
 else
     base_include_directories += [


### PR DESCRIPTION
### Rationale for this change

`c_glib/parquet-glib/` is optional by design:
https://github.com/apache/arrow/blob/fe5e0e5eec6ff644879e4371d83ce130e475b8f1/c_glib/meson.build#L299-L301
https://github.com/apache/arrow/blob/fe5e0e5eec6ff644879e4371d83ce130e475b8f1/c_glib/meson.build#L252-L256

But system Parquet C++ detection is required (no explicit `required: false`):
https://github.com/apache/arrow/blob/fe5e0e5eec6ff644879e4371d83ce130e475b8f1/c_glib/meson.build#L189-L194

### What changes are included in this PR?

Add missing `required: false`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #48784