### PR TITLE
GH-48782: [Docs][CI] Skip Markdown files with doxygen and trigger Docs job on PR when files are modified

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,6 +18,11 @@
 name: Docs
 
 on:
+  pull_request:
+    paths:
+      - '.github/workflows/docs.yml'
+      - 'cpp/apidoc/**'
+      - 'docs/**'
   push:
 
 permissions:

--- a/.github/workflows/docs_light.yml
+++ b/.github/workflows/docs_light.yml
@@ -21,7 +21,6 @@ on:
   pull_request:
     paths:
       - '.dockerignore'
-      - 'docs/**'
       - '.github/workflows/docs_light.yml'
       - 'ci/docker/conda.dockerfile'
       - 'ci/docker/conda-cpp.dockerfile'
@@ -29,6 +28,8 @@ on:
       - 'ci/scripts/cpp_build.sh'
       - 'ci/scripts/python_build.sh'
       - 'compose.yaml'
+      - 'cpp/apidoc/**'
+      - 'docs/**'
 
 permissions:
   contents: read

--- a/cpp/apidoc/Doxyfile
+++ b/cpp/apidoc/Doxyfile
@@ -1096,7 +1096,8 @@ EXCLUDE_PATTERNS       = *-test.cc \
                          *_generated.h \
                          *-benchmark.cc \
                          *_codegen.py \
-                         *internal*
+                         *internal* \
+                         *.md
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
 # (namespaces, classes, functions, etc.) that should be excluded from the

--- a/cpp/src/arrow/flight/sql/odbc/README.md
+++ b/cpp/src/arrow/flight/sql/odbc/README.md
@@ -26,7 +26,7 @@ After the build succeeds, the ODBC DLL will be located in
 
 2. Register your ODBC DLL:
 
-   Need to replace <path\to\repo> with actual path to repository in the commands.
+   Need to replace `<path\to\repo>` with actual path to repository in the commands.
    1. `cd to repo.`
    2. `cd <path\to\repo>`
    3. Run script to register your ODBC DLL as Apache Arrow Flight SQL ODBC Driver


### PR DESCRIPTION
### Rationale for this change

Docs jobs are currently failing with Doxygen failure due to parsing the `cpp/src/arrow/flight/sql/odbc/README.md` file.

### What changes are included in this PR?

Minor fix to escape path and add Skip markdown files when running doxygen on doxygen config.
Add trigger for Complete docs workflow on Pull requests when documentation is modified.

### Are these changes tested?

Yes locally.

### Are there any user-facing changes?

No

* GitHub Issue: #48782