### PR TITLE
MINOR: [Docs][C++] Clarify ARROW_TEST_DATA requirement for tests

### DIFF
--- a/docs/source/developers/cpp/building.rst
+++ b/docs/source/developers/cpp/building.rst
@@ -314,15 +314,6 @@ The unit tests are not built by default. After building, one can also invoke
 the unit tests using the ``ctest`` tool provided by CMake (note that ``test``
 depends on ``python`` being available).
 
-On some Linux distributions, running the test suite might require setting an
-explicit locale. If you see any locale-related errors, try setting the
-environment variable (which requires the ``locales`` package or equivalent):
-
-.. code-block::
-
-   $ export LC_ALL="en_US.UTF-8"
-
-
 .. note::
    If you are building with tests (``-DARROW_BUILD_TESTS=ON``), you must ensure
    the test data submodules are initialized and the environment variables
@@ -341,7 +332,15 @@ environment variable (which requires the ``locales`` package or equivalent):
 
       $ export ARROW_TEST_DATA="<absolute_path_to_arrow>/testing/data"
       $ export PARQUET_TEST_DATA="<absolute_path_to_arrow>/cpp/submodules/parquet-testing/data"
-      
+  
+On some Linux distributions, running the test suite might require setting an
+explicit locale. If you see any locale-related errors, try setting the
+environment variable (which requires the ``locales`` package or equivalent):
+
+.. code-block::
+
+   $ export LC_ALL="en_US.UTF-8"
+    
 Faster builds with Ninja
 ~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/developers/cpp/building.rst
+++ b/docs/source/developers/cpp/building.rst
@@ -322,6 +322,26 @@ environment variable (which requires the ``locales`` package or equivalent):
 
    $ export LC_ALL="en_US.UTF-8"
 
+
+.. note::
+   If you are building with tests (``-DARROW_BUILD_TESTS=ON``), you must ensure
+   the test data submodules are initialized and the environment variables
+   ``ARROW_TEST_DATA`` and ``PARQUET_TEST_DATA`` are set. Without these, several
+   tests (especially IPC and Parquet tests) will fail with an ``IOError``.
+
+   To initialize submodules, run:
+
+   .. code-block:: shell
+
+      $ git submodule update --init --recursive
+
+   Then set the variables to the absolute paths of your testing data folders:
+
+   .. code-block:: shell
+
+      $ export ARROW_TEST_DATA="<absolute_path_to_arrow>/testing/data"
+      $ export PARQUET_TEST_DATA="<absolute_path_to_arrow>/cpp/submodules/parquet-testing/data"
+      
 Faster builds with Ninja
 ~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/developers/cpp/building.rst
+++ b/docs/source/developers/cpp/building.rst
@@ -332,7 +332,7 @@ depends on ``python`` being available).
 
       $ export ARROW_TEST_DATA="<absolute_path_to_arrow>/testing/data"
       $ export PARQUET_TEST_DATA="<absolute_path_to_arrow>/cpp/submodules/parquet-testing/data"
-  
+
 On some Linux distributions, running the test suite might require setting an
 explicit locale. If you see any locale-related errors, try setting the
 environment variable (which requires the ``locales`` package or equivalent):
@@ -340,7 +340,7 @@ environment variable (which requires the ``locales`` package or equivalent):
 .. code-block::
 
    $ export LC_ALL="en_US.UTF-8"
-    
+
 Faster builds with Ninja
 ~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION

### Rationale for this change

While setting up the C++ build on macOS, I encountered an IOError during testing because ARROW_TEST_DATA and PARQUET_TEST_DATA were not set. The current documentation lacks a clear warning that these exports are mandatory for a successful test pass.

### What changes are included in this PR?

I added a .. note:: block to building.rst clarifying the need to initialize submodules and export absolute paths for test data folders.

### Are these changes tested?

Yes, I built the documentation locally using Sphinx (make html) to verify the formatting renders correctly.

### Are there any user-facing changes?

Yes, this updates the developer-facing documentation for C++ building.
