### PR TITLE
GH-48807: [CI] Clean up space on GitHub runner to fix manylinux wheel failure

### DIFF
--- a/dev/tasks/python-wheels/github.linux.yml
+++ b/dev/tasks/python-wheels/github.linux.yml
@@ -46,6 +46,7 @@ jobs:
 
     steps:
       {{ macros.github_checkout_arrow()|indent }}
+      {{ macros.github_free_space()|indent }}
       {{ macros.github_install_archery()|indent }}
       {{ macros.github_login_dockerhub()|indent }}
 

--- a/dev/tasks/python-wheels/github.linux.yml
+++ b/dev/tasks/python-wheels/github.linux.yml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
       {{ macros.github_checkout_arrow()|indent }}
-      # remove entirely
+      {{ macros.github_free_space()|indent }}
       {{ macros.github_install_archery()|indent }}
       {{ macros.github_login_dockerhub()|indent }}
 

--- a/dev/tasks/python-wheels/github.linux.yml
+++ b/dev/tasks/python-wheels/github.linux.yml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
       {{ macros.github_checkout_arrow()|indent }}
-      {{ macros.github_free_space()|indent }}
+      # remove entirely
       {{ macros.github_install_archery()|indent }}
       {{ macros.github_login_dockerhub()|indent }}
 


### PR DESCRIPTION
### Rationale for this change

The `wheel-manylinux-2-28-cp312-cp312-amd64` performs the `almalinux-8` wheels verification and it fails with out of space: `At least 746MB more space needed on the / filesystem.`

### What changes are included in this PR?

Use our existing `github_free_space` macro to clean space on the runner.

### Are these changes tested?

Yes, via archery. I've validated the failure happened on the PR without the change and was solved with the clean up.

### Are there any user-facing changes?

No

* GitHub Issue: #48807