### PR TITLE
MINOR: [Python] Remove impossible TODO in server middleware

### DIFF
--- a/python/pyarrow/_flight.pyx
+++ b/python/pyarrow/_flight.pyx
@@ -2836,7 +2836,6 @@ cdef class _ServerMiddlewareFactoryWrapper(ServerMiddlewareFactory):
         for key, factory in self.factories.items():
             instance = factory.start_call(info, headers)
             if instance:
-                # TODO: prevent duplicate keys
                 instances[key] = instance
         if instances:
             wrapper = _ServerMiddlewareWrapper(instances)


### PR DESCRIPTION
### Rationale for this change

Remove a TODO comment that has been impossible to implement. The TODO asked to "prevent duplicate keys" in `_ServerMiddlewareFactoryWrapper.start_call()`, but this is already guaranteed by Python dict semantics. The TODO was added in commit d1848c85864.

### What changes are included in this PR?

Remove the TODO comment from `python/pyarrow/_flight.pyx`. The `factories` attribute has always been typed as `dict` (both in Cython `cdef` and the `__init__` type hint), which inherently prevents duplicate keys.

### Are these changes tested?

I did not test.

### Are there any user-facing changes?

No.