### PR TITLE
GH-48782: [C++][Docs] Fix Doxygen error in Flight SQL ODBC README

### DIFF
--- a/cpp/src/arrow/flight/sql/odbc/README.md
+++ b/cpp/src/arrow/flight/sql/odbc/README.md
@@ -26,7 +26,7 @@ After the build succeeds, the ODBC DLL will be located in
 
 2. Register your ODBC DLL:
 
-   Need to replace <path\to\repo> with actual path to repository in the commands.
+   Need to replace `<path\to\repo>` with actual path to repository in the commands.
    1. `cd to repo.`
    2. `cd <path\to\repo>`
    3. Run script to register your ODBC DLL as Apache Arrow Flight SQL ODBC Driver


### PR DESCRIPTION
### Rationale for this change

Fix Doxygen build failure caused by backslash sequences in Windows path [placeholders being interpreted as Doxygen commands](https://www.doxygen.nl/manual/commands.html).

### What changes are included in this PR?

Changed path placeholder format in `cpp/src/arrow/flight/sql/odbc/README.md` from `<path\to\repo>` to `` `<path\to\repo>` ``. This prevents Doxygen from interpreting `\to` as a command in inline code contexts.

### Are these changes tested?

Should be verified with a CI.

### Are there any user-facing changes?

No, dev-only.
* GitHub Issue: #48782