### PR TITLE
GH-35830: [C++] Fix fixed-size list scalar hashing with non-zero offsets

### DIFF
--- a/cpp/src/arrow/scalar_test.cc
+++ b/cpp/src/arrow/scalar_test.cc
@@ -1419,6 +1419,18 @@ TEST(TestFixedSizeListScalar, Cast) {
   ASSERT_EQ(casted_str->ToString(), scalar.ToString());
 }
 
+TEST(TestFixedSizeListScalar, Hashing) {
+  auto inner_type = fixed_size_list(int32(), 2);
+  auto outer_type = fixed_size_list(inner_type, 3);
+  auto g = ArrayFromJSON(outer_type,
+                         "[[[1, 2], [3, 4], [5, 6]], [[7, 8], [9, 10], [11, 12]]]");
+  auto h = ArrayFromJSON(outer_type, "[[[7, 8], [9, 10], [11, 12]]]");
+  ASSERT_OK_AND_ASSIGN(auto g1, g->GetScalar(1));
+  ASSERT_OK_AND_ASSIGN(auto h0, h->GetScalar(0));
+  ASSERT_EQ(*g1, *h0);
+  ASSERT_EQ(g1->hash(), h0->hash());
+}
+
 TEST(TestMapScalar, Basics) {
   auto value =
       ArrayFromJSON(struct_({field("key", utf8(), false), field("value", int8())}),

--- a/python/pyarrow/tests/test_scalars.py
+++ b/python/pyarrow/tests/test_scalars.py
@@ -193,6 +193,15 @@ def test_hashing_struct_scalar():
     assert hash1 == hash2
 
 
+def test_hashing_fixed_size_list_scalar():
+    # GH-35830
+    inner = pa.list_(pa.int32(), 2)
+    outer = pa.list_(inner, 3)
+    g = pa.array([[[1, 2], [3, 4], [5, 6]], [[7, 8], [9, 10], [11, 12]]], type=outer)
+    h = pa.array([[[7, 8], [9, 10], [11, 12]]], type=outer)
+    assert hash(g[1]) == hash(h[0])
+
+
 @pytest.mark.timezone_data
 def test_timestamp_scalar():
     a = repr(pa.scalar("0000-01-01").cast(pa.timestamp("s")))


### PR DESCRIPTION
### Rationale for this change

Fixed-size list scalars with equal values but different offsets were hashing to different values.

### What changes are included in this PR?

- Added `FIXED_SIZE_LIST` case in `ArrayHash` to scale child offsets by `list_size`
- Added C++ test in `scalar_test.cc` for nested fixed-size lists
- Added Python test in `test_scalars.py`

### Are these changes tested?

Unit tests were added, and also manually tested.

### Are there any user-facing changes?

Yes.

```python
import pyarrow as pa

inner = pa.list_(pa.int32(), 2)
outer = pa.list_(inner, 3)
g = pa.array([[[1, 2], [3, 4], [5, 6]], [[7, 8], [9, 10], [11, 12]]], type=outer)
h = pa.array([[[7, 8], [9, 10], [11, 12]]], type=outer)
# Comparing `[[7, 8], [9, 10], [11, 12]]`
print(g[1] == h[0])
print(hash(g[1]) == hash(h[0]))
```

Before:

```
True
False
```

After:

```
True
True
```
* GitHub Issue: #35830