### PR TITLE
GH-48802: [C++] Replace redundant nullptr assignment to DCHECK_EQ in FixedSizeBinary to String/Binary cast

### DIFF
--- a/cpp/src/arrow/compute/kernels/scalar_cast_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_string.cc
@@ -632,9 +632,8 @@ BinaryToBinaryCastExec(KernelContext* ctx, const ExecSpan& batch, ExecResult* ou
     ARROW_ASSIGN_OR_RAISE(output->buffers[2], input_data->CopySlice(0, input_data->size(),
                                                                     ctx->memory_pool()));
   } else {
-    // TODO(wesm): it should already be nullptr, so we may be able to remove
-    // this
-    output->buffers[2] = nullptr;
+    // Verify output->buffers[2] is already nullptr from PrepareOutput's resize() call
+    DCHECK_EQ(output->buffers[2], nullptr);
   }
 
   return Status::OK();


### PR DESCRIPTION
### Rationale for this change

The TODO comment saying explicitly setting `output->buffers[2] = nullptr` in the else branch was redundant.

The output `ArrayData` is allocated by `PrepareOutput()` before the kernel executes:

https://github.com/apache/arrow/blob/7be5a89ef083f38317fd94330127be5b5df648d8/cpp/src/arrow/compute/exec.cc#L907-L908

`PrepareOutput()` resizes the buffers vector to the required size for the output type (3 for String/Binary: validity, offsets, data):

https://github.com/apache/arrow/blob/7be5a89ef083f38317fd94330127be5b5df648d8/cpp/src/arrow/compute/exec.cc#L729-L731

For String/Binary output types, `ComputeDataPreallocate()` only preallocates the offsets buffer (not the data buffer):

https://github.com/apache/arrow/blob/7be5a89ef083f38317fd94330127be5b5df648d8/cpp/src/arrow/compute/exec.cc#L294-L298

`PrepareOutput()` only allocates buffers that are in the `data_preallocated_` vector. For String/Binary, this means only `buffers[1]` (offsets) is allocated:

https://github.com/apache/arrow/blob/7be5a89ef083f38317fd94330127be5b5df648d8/cpp/src/arrow/compute/exec.cc#L739-L747

Since `std::vector::resize()`constructs all elements, `buffers[2]` is already `nullptr` from the resize call. Therefore, explicitly assigning `nullptr` in the else branch is redundant.


### What changes are included in this PR?

Converted the redundant else clause to `DCHECK_EQ`.

### Are these changes tested?

Yes, I locally ran`Cast.FixedSizeBinaryToBinaryOrString` and `Cast.FixedSizeBinaryToBinaryOrStringWithSlice`.

### Are there any user-facing changes?

No.
* GitHub Issue: #48802