### PR TITLE
MINOR: [Dev] Remove non active collaborators and add new ones

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -32,12 +32,10 @@ github:
     main: {}
 
   collaborators:
-    - anjakefala
+    - alinaliBQ
+    - EnricoMi
     - hiroyuki-sato
-    - jbonofre
-    - js8544
-    - vibhatha
-    - ZhangHuiGui
+    - HyukjinKwon
 
 notifications:
   commits:      commits@arrow.apache.org


### PR DESCRIPTION
### Rationale for this change

The collaborator list defining triage role is currently outdated.

### What changes are included in this PR?

Remove outdated collaborators and add to the list some collaborators that could benefit from triage role.

### Are these changes tested?

No

### Are there any user-facing changes?

No
