### PR TITLE
GH-48811: [C++][FlightRPC] ODBC: Add missing `arrow::` to fix build

### DIFF
--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/odbc_statement.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/odbc_statement.cc
@@ -747,8 +747,8 @@ SQLRETURN ODBCStatement::GetData(SQLSMALLINT record_number, SQLSMALLINT c_type,
   // Get precision and scale from IRD (implementation row descriptor) as defaults.
   // These can be overridden by ARD (application row descriptor) if specified.
   const DescriptorRecord& ird_record = ird_->GetRecords()[record_number - 1];
-  int precision =
-      ird_record.precision > 0 ? ird_record.precision : Decimal128Type::kMaxPrecision;
+  int precision = ird_record.precision > 0 ? ird_record.precision
+                                           : arrow::Decimal128Type::kMaxPrecision;
   int scale = ird_record.scale;
 
   if (c_type == SQL_ARD_TYPE) {


### PR DESCRIPTION
### Rationale for this change
Add `arrow::` to  `Decimal128Type::kMaxPrecision` to fix the build
### What changes are included in this PR?
- Add `arrow::` as prefix to  `Decimal128Type::kMaxPrecision`
### Are these changes tested?
- Yes, on local MSVC and CI
### Are there any user-facing changes?
N/A

* GitHub Issue: #48811