### PR TITLE
GH-48805: [CI][R] test-r-alpine-linux-cran fails with segmentation fault

### DIFF
--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -565,7 +565,7 @@ build_libarrow <- function(src_dir, dst_dir) {
     # is found, it will be used by the libarrow build, and this does
     # not affect how R compiles the arrow bindings.
     CC = sub("^.*ccache", "", R_CMD_config("CC")),
-    CXX = paste(sub("^.*ccache", "", R_CMD_config("CXX17")), R_CMD_config("CXX17STD")),
+    CXX = sub("^.*ccache", "", R_CMD_config("CXX17")),
     # CXXFLAGS = R_CMD_config("CXX17FLAGS"), # We don't want the same debug symbols
     LDFLAGS = R_CMD_config("LDFLAGS"),
     N_JOBS = ncores


### PR DESCRIPTION
It looks like there's a mismatch on our Alpine builds. I'm a little bit surprised that _only_ that build is seeing it.

I don't think this will totally solve the problem though, and we will actually need to do #48817

Resolves: #48805

### Rationale for this change
Stop the build failures

### What changes are included in this PR?
Remove a flag

### Are these changes tested?
They are basically in the tests

### Are there any user-facing changes?


* GitHub Issue: #48805