### PR TITLE
GH-48817 [R][C++] Bump C++20 in R build infrastructure

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -1718,9 +1718,9 @@ services:
       cache_from:
         - ${REPO}:amd64-ubuntu-r-valgrind
       args:
-        base: wch1/r-debug:latest
+        base: rhub/valgrind:latest
         cmake: ${CMAKE}
-        r_bin: RDvalgrind
+        r_bin: R
         tz: ${TZ}
     environment:
       <<: [*common, *ccache, *sccache]

--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -28,7 +28,7 @@ URL: https://github.com/apache/arrow/, https://arrow.apache.org/docs/r/
 BugReports: https://github.com/apache/arrow/issues
 Encoding: UTF-8
 Language: en-US
-SystemRequirements: C++17; for AWS S3 support on Linux, libcurl and openssl (optional);
+SystemRequirements: C++20; for AWS S3 support on Linux, libcurl and openssl (optional);
     cmake >= 3.26 (build-time only, and only for full source build)
 Biarch: true
 Imports:

--- a/r/README.md
+++ b/r/README.md
@@ -44,7 +44,7 @@ There are some special cases to note:
 
 - On Linux the installation process can sometimes be more involved because CRAN does not host binaries for Linux. For more information please see the [installation guide](https://arrow.apache.org/docs/r/articles/install.html).
 
-- If you are compiling arrow from source, please note that as of version 10.0.0, arrow requires C++17 to build. This has implications on Windows and CentOS 7. For Windows users it means you need to be running an R version of 4.0 or later. On CentOS 7, it means you need to install a newer compiler than the default system compiler gcc. See the [installation details article](https://arrow.apache.org/docs/r/articles/developers/install_details.html) for guidance.
+- If you are compiling arrow from source, please note that as of version 22.0.0, arrow requires C++20 to build. This has implications on Windows and CentOS 7. For Windows users it means you need to be running an R version of 4.1 or later. See the [installation details article](https://arrow.apache.org/docs/r/articles/developers/install_details.html) for guidance.
 
 - Development versions of arrow are released nightly. For information on how to install nightly builds please see the [installing nightly builds](https://arrow.apache.org/docs/r/articles/install_nightly.html) article.
 

--- a/r/README.md
+++ b/r/README.md
@@ -44,7 +44,7 @@ There are some special cases to note:
 
 - On Linux the installation process can sometimes be more involved because CRAN does not host binaries for Linux. For more information please see the [installation guide](https://arrow.apache.org/docs/r/articles/install.html).
 
-- If you are compiling arrow from source, please note that as of version 22.0.0, arrow requires C++20 to build. This has implications on Windows and CentOS 7. For Windows users it means you need to be running an R version of 4.1 or later. See the [installation details article](https://arrow.apache.org/docs/r/articles/developers/install_details.html) for guidance.
+- If you are compiling arrow from source, please note that as of version 23.0.0, arrow requires C++20 to build. This has implications on Windows and CentOS 7. For Windows users it means you need to be running an R version of 4.3 or later (though R 4.2 has incomplete support and might work with special configuration). See the [installation details article](https://arrow.apache.org/docs/r/articles/developers/install_details.html) for guidance.
 
 - Development versions of arrow are released nightly. For information on how to install nightly builds please see the [installing nightly builds](https://arrow.apache.org/docs/r/articles/install_nightly.html) article.
 

--- a/r/configure
+++ b/r/configure
@@ -86,10 +86,10 @@ if [ "$ARROW_R_DEV" = "true" ] && [ -f "data-raw/codegen.R" ]; then
   ${R_HOME}/bin/Rscript data-raw/codegen.R
 fi
 
-# Arrow requires C++17, so check for it
-if [ ! "`${R_HOME}/bin/R CMD config CXX17`" ]; then
+# Arrow requires C++20, so check for it
+if [ ! "`${R_HOME}/bin/R CMD config CXX20`" ]; then
   echo "------------------------- NOTE ---------------------------"
-  echo "Cannot install arrow: a C++17 compiler is required."
+  echo "Cannot install arrow: a C++20 compiler is required."
   echo "See https://arrow.apache.org/docs/r/articles/install.html"
   echo "---------------------------------------------------------"
   exit 1
@@ -265,7 +265,7 @@ set_pkg_vars () {
   # match the substring. However, expr always outputs the number of matched characters
   # to stdout, to avoid noise in the log we redirect the output to /dev/null
   if [ "$UNAME" = "Darwin" ] && expr $(sw_vers -productVersion) : '10\.13' >/dev/null 2>&1; then
-    # avoid C++17 availability warnings on macOS < 11
+    # avoid C++20 availability warnings on macOS < 11
     PKG_CFLAGS="$PKG_CFLAGS -D_LIBCPP_DISABLE_AVAILABILITY"
   fi
 }
@@ -408,11 +408,11 @@ else
 fi
 
 # Test that we can compile something with those flags
-CXX17="`${R_HOME}/bin/R CMD config CXX17` -E"
-CXX17FLAGS=`"${R_HOME}"/bin/R CMD config CXX17FLAGS`
-CXX17STD=`"${R_HOME}"/bin/R CMD config CXX17STD`
+CXX20="`${R_HOME}/bin/R CMD config CXX20` -E"
+CXX20FLAGS=`"${R_HOME}"/bin/R CMD config CXX20FLAGS`
+CXX20STD=`"${R_HOME}"/bin/R CMD config CXX20STD`
 CPPFLAGS=`"${R_HOME}"/bin/R CMD config CPPFLAGS`
-TEST_CMD="${CXX17} ${CPPFLAGS} ${PKG_CFLAGS} ${CXX17FLAGS} ${CXX17STD} -xc++ -"
+TEST_CMD="${CXX20} ${CPPFLAGS} ${PKG_CFLAGS} ${CXX20FLAGS} ${CXX20STD} -xc++ -"
 TEST_ERROR=$(echo "#include $PKG_TEST_HEADER" | ${TEST_CMD} -o /dev/null 2>&1)
 
 if [ $? -eq 0 ]; then

--- a/r/configure
+++ b/r/configure
@@ -260,14 +260,6 @@ set_pkg_vars () {
   if [ "$ARROW_R_CXXFLAGS" ]; then
     PKG_CFLAGS="$PKG_CFLAGS $ARROW_R_CXXFLAGS"
   fi
-
-  # We use expr because the product version returns more than just 10.13 and we want to
-  # match the substring. However, expr always outputs the number of matched characters
-  # to stdout, to avoid noise in the log we redirect the output to /dev/null
-  if [ "$UNAME" = "Darwin" ] && expr $(sw_vers -productVersion) : '10\.13' >/dev/null 2>&1; then
-    # avoid C++20 availability warnings on macOS < 11
-    PKG_CFLAGS="$PKG_CFLAGS -D_LIBCPP_DISABLE_AVAILABILITY"
-  fi
 }
 
 # If we have pkg-config, it will tell us what libarrow needs

--- a/r/configure.win
+++ b/r/configure.win
@@ -320,11 +320,6 @@ if [ "$ARROW_R_CXXFLAGS" ]; then
   PKG_CFLAGS="$PKG_CFLAGS $ARROW_R_CXXFLAGS"
 fi
 
-# GCC 14+ with C++20 raises false positive -Wmaybe-uninitialized warnings
-# due to std::variant move operations in arrow::FieldRef.
-# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80635
-PKG_CFLAGS="$PKG_CFLAGS -Wno-maybe-uninitialized"
-
 echo "*** Writing $(pwd)/src/Makevars.win"
 sed -e "s|@cflags@|$PKG_CFLAGS|" -e "s|@libs@|$PKG_LIBS|" src/Makevars.in > src/Makevars.win
 

--- a/r/configure.win
+++ b/r/configure.win
@@ -117,14 +117,6 @@ set_pkg_vars () {
   if [ "$ARROW_R_CXXFLAGS" ]; then
     PKG_CFLAGS="$PKG_CFLAGS $ARROW_R_CXXFLAGS"
   fi
-
-  # We use expr because the product version returns more than just 10.13 and we want to
-  # match the substring. However, expr always outputs the number of matched characters
-  # to stdout, to avoid noise in the log we redirect the output to /dev/null
-  if [ "$UNAME" = "Darwin" ] && expr $(sw_vers -productVersion) : '10\.13' >/dev/null 2>&1; then
-    # avoid C++20 availability warnings on macOS < 11
-    PKG_CFLAGS="$PKG_CFLAGS -D_LIBCPP_DISABLE_AVAILABILITY"
-  fi
 }
 
 # If we have pkg-config, it will tell us what libarrow needs
@@ -327,6 +319,11 @@ fi
 if [ "$ARROW_R_CXXFLAGS" ]; then
   PKG_CFLAGS="$PKG_CFLAGS $ARROW_R_CXXFLAGS"
 fi
+
+# GCC 14+ with C++20 raises false positive -Wmaybe-uninitialized warnings
+# due to std::variant move operations in arrow::FieldRef.
+# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80635
+PKG_CFLAGS="$PKG_CFLAGS -Wno-maybe-uninitialized"
 
 echo "*** Writing $(pwd)/src/Makevars.win"
 sed -e "s|@cflags@|$PKG_CFLAGS|" -e "s|@libs@|$PKG_LIBS|" src/Makevars.in > src/Makevars.win

--- a/r/configure.win
+++ b/r/configure.win
@@ -122,7 +122,7 @@ set_pkg_vars () {
   # match the substring. However, expr always outputs the number of matched characters
   # to stdout, to avoid noise in the log we redirect the output to /dev/null
   if [ "$UNAME" = "Darwin" ] && expr $(sw_vers -productVersion) : '10\.13' >/dev/null 2>&1; then
-    # avoid C++17 availability warnings on macOS < 11
+    # avoid C++20 availability warnings on macOS < 11
     PKG_CFLAGS="$PKG_CFLAGS -D_LIBCPP_DISABLE_AVAILABILITY"
   fi
 }

--- a/r/src/Makevars.in
+++ b/r/src/Makevars.in
@@ -25,6 +25,11 @@ PKG_CPPFLAGS=@cflags@
 # https://bugs.llvm.org/show_bug.cgi?id=39191
 # https://www.mail-archive.com/gcc-bugs@gcc.gnu.org/msg534862.html
 # PKG_CXXFLAGS=$(CXX_VISIBILITY)
+
+# GCC 14+ with C++20 raises false positive -Wmaybe-uninitialized warnings
+# due to std::variant move operations in arrow::FieldRef.
+# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80635
+PKG_CXXFLAGS=-Wno-maybe-uninitialized
 CXX_STD=CXX20
 PKG_LIBS=@libs@
 

--- a/r/src/Makevars.in
+++ b/r/src/Makevars.in
@@ -25,11 +25,6 @@ PKG_CPPFLAGS=@cflags@
 # https://bugs.llvm.org/show_bug.cgi?id=39191
 # https://www.mail-archive.com/gcc-bugs@gcc.gnu.org/msg534862.html
 # PKG_CXXFLAGS=$(CXX_VISIBILITY)
-
-# GCC 14+ with C++20 raises false positive -Wmaybe-uninitialized warnings
-# due to std::variant move operations in arrow::FieldRef.
-# https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80635
-PKG_CXXFLAGS=-Wno-maybe-uninitialized
 CXX_STD=CXX20
 PKG_LIBS=@libs@
 

--- a/r/src/Makevars.in
+++ b/r/src/Makevars.in
@@ -25,7 +25,7 @@ PKG_CPPFLAGS=@cflags@
 # https://bugs.llvm.org/show_bug.cgi?id=39191
 # https://www.mail-archive.com/gcc-bugs@gcc.gnu.org/msg534862.html
 # PKG_CXXFLAGS=$(CXX_VISIBILITY)
-CXX_STD=CXX17
+CXX_STD=CXX20
 PKG_LIBS=@libs@
 
 all: $(SHLIB) purify

--- a/r/src/Makevars.ucrt
+++ b/r/src/Makevars.ucrt
@@ -19,4 +19,4 @@ CRT=-ucrt
 include Makevars.win
 
 # XXX for some reason, this variable doesn't seem propagated from Makevars.win
-CXX_STD=CXX17
+CXX_STD=CXX20

--- a/r/src/compute.cpp
+++ b/r/src/compute.cpp
@@ -163,9 +163,10 @@ std::shared_ptr<arrow::compute::FunctionOptions> make_compute_options(
     // cpp11 does not support bool here so use int
     auto orders = cpp11::as_cpp<std::vector<int>>(options["orders"]);
     std::vector<Key> keys;
+    keys.reserve(names.size());
     for (size_t i = 0; i < names.size(); i++) {
-      keys.push_back(
-          Key(names[i], (orders[i] > 0) ? Order::Descending : Order::Ascending));
+      Order order = (orders[i] > 0) ? Order::Descending : Order::Ascending;
+      keys.emplace_back(names[i], order);
     }
     auto out = std::make_shared<Options>(Options(keys));
     return out;

--- a/r/src/compute.cpp
+++ b/r/src/compute.cpp
@@ -163,10 +163,20 @@ std::shared_ptr<arrow::compute::FunctionOptions> make_compute_options(
     // cpp11 does not support bool here so use int
     auto orders = cpp11::as_cpp<std::vector<int>>(options["orders"]);
     std::vector<Key> keys;
+// GCC 14+ with C++20 raises a false positive -Wmaybe-uninitialized warning
+// due to std::variant move operations in arrow::FieldRef. This is a known
+// GCC issue with variant's move constructor analysis.
+#if defined(__GNUC__) && __GNUC__ >= 14
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
     for (size_t i = 0; i < names.size(); i++) {
       keys.push_back(
           Key(names[i], (orders[i] > 0) ? Order::Descending : Order::Ascending));
     }
+#if defined(__GNUC__) && __GNUC__ >= 14
+#pragma GCC diagnostic pop
+#endif
     auto out = std::make_shared<Options>(Options(keys));
     return out;
   }

--- a/r/src/compute.cpp
+++ b/r/src/compute.cpp
@@ -155,20 +155,18 @@ std::shared_ptr<arrow::compute::FunctionOptions> make_compute_options(
   }
 
   if (func_name == "sort_indices") {
-    using Key = arrow::compute::SortKey;
     using Order = arrow::compute::SortOrder;
     using Options = arrow::compute::SortOptions;
     auto names = cpp11::as_cpp<std::vector<std::string>>(options["names"]);
     // false means descending, true means ascending
     // cpp11 does not support bool here so use int
     auto orders = cpp11::as_cpp<std::vector<int>>(options["orders"]);
-    std::vector<Key> keys;
-    keys.reserve(names.size());
+    auto out = std::make_shared<Options>();
+    out->sort_keys.reserve(names.size());
     for (size_t i = 0; i < names.size(); i++) {
-      Order order = (orders[i] > 0) ? Order::Descending : Order::Ascending;
-      keys.emplace_back(names[i], order);
+      out->sort_keys.emplace_back(names[i],
+                                  (orders[i] > 0) ? Order::Descending : Order::Ascending);
     }
-    auto out = std::make_shared<Options>(Options(keys));
     return out;
   }
 

--- a/r/src/compute.cpp
+++ b/r/src/compute.cpp
@@ -163,20 +163,10 @@ std::shared_ptr<arrow::compute::FunctionOptions> make_compute_options(
     // cpp11 does not support bool here so use int
     auto orders = cpp11::as_cpp<std::vector<int>>(options["orders"]);
     std::vector<Key> keys;
-// GCC 14+ with C++20 raises a false positive -Wmaybe-uninitialized warning
-// due to std::variant move operations in arrow::FieldRef. This is a known
-// GCC issue with variant's move constructor analysis.
-#if defined(__GNUC__) && __GNUC__ >= 14
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
     for (size_t i = 0; i < names.size(); i++) {
       keys.push_back(
           Key(names[i], (orders[i] > 0) ? Order::Descending : Order::Ascending));
     }
-#if defined(__GNUC__) && __GNUC__ >= 14
-#pragma GCC diagnostic pop
-#endif
     auto out = std::make_shared<Options>(Options(keys));
     return out;
   }

--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -310,11 +310,11 @@ compile_test_program <- function(code) {
     openssl_dir <- paste0("-I", openssl_root_dir, "/include")
   }
   runner <- paste(
-    R_CMD_config("CXX17"),
+    R_CMD_config("CXX20"),
     openssl_dir,
     R_CMD_config("CPPFLAGS"),
-    R_CMD_config("CXX17FLAGS"),
-    R_CMD_config("CXX17STD"),
+    R_CMD_config("CXX20FLAGS"),
+    R_CMD_config("CXX20STD"),
     "-E",
     "-xc++"
   )
@@ -565,8 +565,11 @@ build_libarrow <- function(src_dir, dst_dir) {
     # is found, it will be used by the libarrow build, and this does
     # not affect how R compiles the arrow bindings.
     CC = sub("^.*ccache", "", R_CMD_config("CC")),
-    CXX = paste(sub("^.*ccache", "", R_CMD_config("CXX17")), R_CMD_config("CXX17STD")),
-    # CXXFLAGS = R_CMD_config("CXX17FLAGS"), # We don't want the same debug symbols
+    CXX = paste(
+      sub("^.*ccache", "", R_CMD_config("CXX20")),
+      R_CMD_config("CXX20STD")
+    ),
+    # CXXFLAGS = R_CMD_config("CXX20FLAGS"), # We don't want the same debug symbols
     LDFLAGS = R_CMD_config("LDFLAGS"),
     N_JOBS = ncores
   )

--- a/r/vignettes/install.Rmd
+++ b/r/vignettes/install.Rmd
@@ -23,8 +23,8 @@ but there are a few things to note.
 
 ### Compilers
 
-As of version 10.0.0, arrow requires a C++17 compiler to build.
-For `gcc`, this generally means version 7 or newer. Most contemporary Linux
+As of version 22.0.0, arrow requires a C++20 compiler to build.
+For `gcc`, this generally means version 10 or newer. Most contemporary Linux
 distributions have a new enough compiler; however, CentOS 7 is a notable
 exception, as it ships with gcc 4.8.
 


### PR DESCRIPTION
Resolves: #48817

### Rationale for this change
Keep R build infrastructure inline with our C++ version

### What changes are included in this PR?
Mostly `s/CXX17/CXX20/g`

### Are these changes tested?
Yes, lots of CI

### Are there any user-facing changes?

**This PR includes breaking changes to public APIs.** (If there are any breaking changes to public APIs, please explain which changes are breaking. If not, you can remove this.)

**This PR contains a "Critical Fix".** (If the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld), please provide explanation. If not, you can remove this.)

* GitHub Issue: #48817