### PR TITLE
MINOR: [C++] Remove TODO asking why null count set unknown

### DIFF
--- a/cpp/src/arrow/compute/kernels/vector_replace.cc
+++ b/cpp/src/arrow/compute/kernels/vector_replace.cc
@@ -252,12 +252,13 @@ struct ReplaceMaskImpl<Type, enable_if_base_binary<Type>> {
             MakeArrayFromScalar(*replacements.scalar, array.length, ctx->memory_pool()));
         out->value = std::move(replacement_array->data());
       } else {
-        // Set to be a slice of replacements
+        // Set to be a slice of replacements. We manually adjust offset/length instead of
+        // calling ArrayData::Slice() to avoid creating an extra copy.
         std::shared_ptr<ArrayData> result = replacements.array.ToArrayData();
         result->offset += replacements_offset;
         result->length = array.length;
-
-        // TODO(wesm): why is the replacements null count not sufficient?
+        // The null count from the original replacements array is not sufficient because
+        // it applies to the entire array, not this specific slice. Must mark as unknown.
         result->null_count = kUnknownNullCount;
         out->value = result;
       }


### PR DESCRIPTION
### Rationale for this change

Removed a TODO from `replace_with_mask` implementation that asking why the replacements null count wasn't sufficient for a slice operation. When slicing an array, the null count from the original full array doesn't apply to the slice.

The null count must be marked as `kUnknownNullCount` and computed lazily when needed.

### What changes are included in this PR?

Replaced the TODO with some comments clarifying:
- Why manual slicing is used (avoids extra allocation from `ArrayData::Slice()`)
- Why `kUnknownNullCount` is necessary (original null count doesn't apply to slice)

### Are these changes tested?

No, I did not test.

### Are there any user-facing changes?

No.