### PR TITLE
GH-48809: [CI] Fix homebrew-cpp with Mac by using formula-based dependency resolution

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -520,6 +520,8 @@ endif()
 set(PARQUET_PC_REQUIRES "")
 set(PARQUET_PC_REQUIRES_PRIVATE "")
 
+include(ThirdpartyToolchain)
+
 # Add common flags
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX_COMMON_FLAGS}")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${ARROW_CXXFLAGS}")
@@ -533,8 +535,6 @@ string(REPLACE "-std=c++20" "" CMAKE_C_FLAGS ${CMAKE_C_FLAGS})
 
 # Add C++-only flags, like -std=c++20
 set(CMAKE_CXX_FLAGS "${CXX_ONLY_FLAGS} ${CMAKE_CXX_FLAGS}")
-
-include(ThirdpartyToolchain)
 
 # ASAN / TSAN / UBSAN
 if(ARROW_FUZZING)

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -520,8 +520,6 @@ endif()
 set(PARQUET_PC_REQUIRES "")
 set(PARQUET_PC_REQUIRES_PRIVATE "")
 
-include(ThirdpartyToolchain)
-
 # Add common flags
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CXX_COMMON_FLAGS}")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${ARROW_CXXFLAGS}")
@@ -535,6 +533,8 @@ string(REPLACE "-std=c++20" "" CMAKE_C_FLAGS ${CMAKE_C_FLAGS})
 
 # Add C++-only flags, like -std=c++20
 set(CMAKE_CXX_FLAGS "${CXX_ONLY_FLAGS} ${CMAKE_CXX_FLAGS}")
+
+include(ThirdpartyToolchain)
 
 # ASAN / TSAN / UBSAN
 if(ARROW_FUZZING)

--- a/dev/tasks/homebrew-formulae/github.macos.yml
+++ b/dev/tasks/homebrew-formulae/github.macos.yml
@@ -29,6 +29,8 @@ jobs:
       {{ macros.configure_homebrew_arrow(formula)|indent }}
       - name: Test formula
         run: |
+          rm -rf ~/Library/Caches/Homebrew/downloads/
+          
           brew install -v --HEAD apache-arrow
           brew test apache-arrow
           brew audit --strict apache-arrow

--- a/dev/tasks/homebrew-formulae/github.macos.yml
+++ b/dev/tasks/homebrew-formulae/github.macos.yml
@@ -22,13 +22,14 @@
 jobs:
   homebrew:
     name: "Homebrew"
-    runs-on: macos-14
+    runs-on: macos-latest
     steps:
       {{ macros.github_checkout_arrow()|indent }}
 
       {{ macros.configure_homebrew_arrow(formula)|indent }}
       - name: Test formula
         run: |
+          brew fetch --force --deps --HEAD apache-arrow
           brew install -v --HEAD apache-arrow
           brew test apache-arrow
           brew audit --strict apache-arrow

--- a/dev/tasks/homebrew-formulae/github.macos.yml
+++ b/dev/tasks/homebrew-formulae/github.macos.yml
@@ -28,6 +28,9 @@ jobs:
 
       {{ macros.configure_homebrew_arrow(formula)|indent }}
       - name: Test formula
+        env:
+          # Workaround for bottle download failures on GitHub Actions runners
+          HOMEBREW_NO_INSTALL_FROM_API: 1
         run: |
           brew install -v --HEAD apache-arrow
           brew test apache-arrow

--- a/dev/tasks/homebrew-formulae/github.macos.yml
+++ b/dev/tasks/homebrew-formulae/github.macos.yml
@@ -22,15 +22,13 @@
 jobs:
   homebrew:
     name: "Homebrew"
-    runs-on: macos-latest
+    runs-on: macos-14
     steps:
       {{ macros.github_checkout_arrow()|indent }}
 
       {{ macros.configure_homebrew_arrow(formula)|indent }}
       - name: Test formula
         run: |
-          rm -rf ~/Library/Caches/Homebrew/downloads/
-          
           brew install -v --HEAD apache-arrow
           brew test apache-arrow
           brew audit --strict apache-arrow

--- a/dev/tasks/homebrew-formulae/github.macos.yml
+++ b/dev/tasks/homebrew-formulae/github.macos.yml
@@ -28,8 +28,6 @@ jobs:
 
       {{ macros.configure_homebrew_arrow(formula)|indent }}
       - name: Test formula
-        env:
-          HOMEBREW_NO_INSTALL_FROM_API: 1
         run: |
           brew install -v --HEAD apache-arrow
           brew test apache-arrow

--- a/dev/tasks/homebrew-formulae/github.macos.yml
+++ b/dev/tasks/homebrew-formulae/github.macos.yml
@@ -28,8 +28,9 @@ jobs:
 
       {{ macros.configure_homebrew_arrow(formula)|indent }}
       - name: Test formula
+        env:
+          HOMEBREW_NO_INSTALL_FROM_API: 1
         run: |
-          brew fetch --force --deps --HEAD apache-arrow
           brew install -v --HEAD apache-arrow
           brew test apache-arrow
           brew audit --strict apache-arrow


### PR DESCRIPTION
### Rationale for this change

homebrew-cpp with MacOS was failing with `No such file or directory @ rb_sysopen` errors when downloading bottles for dependencies (icu4c, boost, etc.).

This appears to be caused by Homebrew's JSON API (`ghcr.io`) returning stale or corrupted metadata on GitHub Actions runners.

Disclaimer: I can't tell what is the actual cause. Seems to be a bug in Homebrew introduced from the latest MacOS runner image but I don't have any evidence for it. What I can see was that there was an recent update in MacOS images with Homebrew upgraded together:
- https://github.com/actions/runner-images/releases/tag/macos-14%2F20260105.0099
- https://github.com/actions/runner-images/releases/tag/macos-15-arm64%2F20260105.0094
- https://github.com/Homebrew/brew/releases/tag/5.0.8

which I believe are related.

### What changes are included in this PR?

Add `HOMEBREW_NO_INSTALL_FROM_API=1` to the Homebrew test workflow to use traditional formula-based dependency resolution instead of the JSON API.

### Are these changes tested?

Tested in https://github.com/ursacomputing/crossbow/actions/runs/20907195327/job/60062808357

### Are there any user-facing changes?

No, CI-only.

* GitHub Issue: #48809