### PR TITLE
GH-48827: [CI][Python] Add required xz dependency to emscripten dockerfile

### DIFF
--- a/ci/docker/conda-python-emscripten.dockerfile
+++ b/ci/docker/conda-python-emscripten.dockerfile
@@ -39,16 +39,17 @@ RUN python -m pip install --no-cache-dir selenium==${selenium_version} && \
 RUN pyodide_dist_url="https://github.com/pyodide/pyodide/releases/download/${pyodide_version}/pyodide-${pyodide_version}.tar.bz2" && \
     wget -q "${pyodide_dist_url}" -O- | tar -xj -C /
 
+# install node 20 (needed for async call support)
+# and pthread-stubs for build, and unzip needed for chrome build to work
+# xz is needed by emsdk to extract node tarballs
+RUN conda install nodejs=20 unzip pthread-stubs make xz -c conda-forge
+
 # install correct version of emscripten for this pyodide
 COPY ci/scripts/install_emscripten.sh /arrow/ci/scripts/
 RUN bash /arrow/ci/scripts/install_emscripten.sh ~ /pyodide
 
 # make sure zlib is cached in the EMSDK folder
 RUN source ~/emsdk/emsdk_env.sh && embuilder --pic build zlib
-
-# install node 20 (needed for async call support)
-# and pthread-stubs for build, and unzip needed for chrome build to work
-RUN conda install nodejs=20  unzip pthread-stubs make -c conda-forge
 
 # install chrome for testing browser based runner
 COPY ci/scripts/install_chromedriver.sh /arrow/ci/scripts/


### PR DESCRIPTION
### Rationale for this change

The emscripten job has been failing on the nightlies jobs

### What changes are included in this PR?

Install dependencies slightly earlier on the Dockerfile and add xz which is required on `install_emscripten.sh` now.

### Are these changes tested?

Yes via archery.

### Are there any user-facing changes?

No

* GitHub Issue: #48827