### PR TITLE
GH-48837: [C++] Remove invalid DCHECK when allow_delayed_open is true

### DIFF
--- a/cpp/src/arrow/filesystem/s3fs.cc
+++ b/cpp/src/arrow/filesystem/s3fs.cc
@@ -1649,8 +1649,6 @@ class ObjectOutputStream final : public io::OutputStream {
   }
 
   Status CreateMultipartUpload() {
-    DCHECK(ShouldBeMultipartUpload());
-
     ARROW_ASSIGN_OR_RAISE(auto client_lock, holder_->Lock());
 
     // Initiate the multi-part upload


### PR DESCRIPTION
Thanks for opening a pull request!

If this is your first pull request you can find detailed information on how to contribute here:

  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)

Please remove this line and the above text before creating your pull request.

### Rationale for this change

C++ build with DEBUG mode.

``` C++
std::string test_data(11 * 1024 * 1024, 'A'); // 11MB which bigger than kMultiPartUploadThresholdSize(10 MB)
ARROW_ASSIGN_OR_RAISE(auto arrowfs, S3FileSystem::Make(...)); // with allow_delayed_open=true

auto write_status = output_stream->Write(test_data.data()); // <--- got core here
```

Core 

```

    ... 
    frame #7: 0x0000000119029565 arrow::util::ArrowLog::~ArrowLog(this=0x00007ff7bfefb410) at logging.cc:253:23
    frame #8: 0x0000000112fd0591 arrow::fs::ObjectOutputStream::CreateMultipartUpload(this=0x000061300000f018) at s3fs.cc:1652:5
    frame #9: 0x000000011301ceb7 arrow::fs::ObjectOutputStream::UploadPart(this=0x000061300000f018, data=0x0000000108001800, nbytes=10485760, owned_buffer=nullptr) at s3fs.cc:2057:7
    frame #10: 0x000000011301bff4 arrow::fs::ObjectOutputStream::DoWrite(this=0x000061300000f018, data=0x0000000108001800, nbytes=11534336, owned_buffer=nullptr) at s3fs.cc:1864:7
    frame #11: 0x00000001130194aa arrow::fs::ObjectOutputStream::Write(this=0x000061300000f018, data=0x0000000108001800, nbytes=11534336) at s3fs.cc:1828:75
    frame #12: 0x0000000118e862c6 arrow::io::Writable::Write(this=0x000061300000f018, data="AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"...) at interfaces.cc:199:10
    ... 

```

In `ShouldBeMultipartUpload()`. The `pos_` is 0, because nothing written, `allow_delayed_open_` is true, DCHECK won't be success in this case.


### What changes are included in this PR?

Remove invalid DCHECK when allow_delayed_open is true


### Are these changes tested?
Yes

### Are there any user-facing changes?
Nope

**This PR includes breaking changes to public APIs.** (If there are any breaking changes to public APIs, please explain which changes are breaking. If not, you can remove this.)

**This PR contains a "Critical Fix".** (If the changes fix either (a) a security vulnerability, (b) a bug that caused incorrect or invalid data to be produced, or (c) a bug that causes a crash (even when the API contract is upheld), please provide explanation. If not, you can remove this.)

* GitHub Issue: #48837