### PR TITLE
GH-48841: [Release][Package] Add GH_TOKEN to rake build step on Linux Packaging jobs

### DIFF
--- a/.github/workflows/package_linux.yml
+++ b/.github/workflows/package_linux.yml
@@ -232,6 +232,8 @@ jobs:
             ${GITHUB_REF_NAME} \
             release_candidate.yml
       - name: Build
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           pushd dev/tasks/linux-packages
           rake docker:pull || :


### PR DESCRIPTION
### Rationale for this change

With:
- https://github.com/apache/arrow/pull/48839

We use `gh release download`. This requires the GH_TOKEN available.

### What changes are included in this PR?

Add env with `GH_TOKEN`. I've validate the Rake's `sh` should inherit the environment variables that are defined on your shell.

### Are these changes tested?

No

### Are there any user-facing changes?
No

* GitHub Issue: #48841