### PR TITLE
GH-48844: [C++] Check IPC Message body length consistency in IPC file

### DIFF
--- a/cpp/src/arrow/ipc/message.cc
+++ b/cpp/src/arrow/ipc/message.cc
@@ -375,6 +375,8 @@ Result<std::unique_ptr<Message>> ReadMessage(int64_t offset, int32_t metadata_le
                            decoder.next_required_size());
   }
 
+  // TODO(GH-48846): we should take a body_length just like ReadMessageAsync
+  // and read metadata + body in one go.
   ARROW_ASSIGN_OR_RAISE(auto metadata, file->ReadAt(offset, metadata_length));
   if (metadata->size() < metadata_length) {
     return Status::Invalid("Expected to read ", metadata_length,


### PR DESCRIPTION
### Rationale for this change

The IPC file exposes [redundant information](https://github.com/apache/arrow/blob/d54a2051cf9020a0fdf50836420c38ad14787abb/format/File.fbs#L39-L50) about Message sizes so as to allow for random access from the file footer.

We tried adding [consistency checks](https://github.com/apache/arrow/issues/19596) in the past but this hit a bug in the JavaScript IPC writer at the time, so the checks were left disabled.

The JavaScript implementation was fixed soon after (7 years ago), so this PR re-enables those checks so as to more easily detect potentially invalid IPC files.

### Are these changes tested?

By existing tests.

### Are there any user-facing changes?

No, unless they try reading invalid IPC files.

* GitHub Issue: #48844