### PR TITLE
GH-48848: [Dev] Remove obsolete Java, Go, and Swift entries from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,27 +82,11 @@ cpp/Brewfile.lock.json
 # docker volumes used for caching
 .docker
 
-# generated native binaries created by java JNI build
-java-dist/
-java-native-c/
-java-native-cpp/
-
 # archery files
 dev/archery/build
 
-swift/Arrow/.build
-
-# Go dependencies
-go/vendor
-# go debug binaries
-__debug_bin
-
 # direnv
 .envrc
-
-# Develocity
-java/.mvn/.gradle-enterprise/
-java/.mvn/.develocity/
 
 # rat
 filtered_rat.txt


### PR DESCRIPTION
### Rationale for this change

The Java, Go, and Swift implementations have been moved to separate repositories, but their .gitignore entries were not cleaned up:
- Java removed in GH-44945 3a46cc2fd8a
- Go removed in GH-43879  e62fbaafd12
- Swift removed in GH-46803 a77bfec0b30

### What changes are included in this PR?

Remove obsolete Java, Go, and Swift entries from .gitignore.

### Are these changes tested?

No I did not test.

### Are there any user-facing changes?

No, dev-only.
* GitHub Issue: #48848