### PR TITLE
GH-37169: [C++] Zstd compression uses context

### DIFF
--- a/cpp/src/arrow/util/compression.cc
+++ b/cpp/src/arrow/util/compression.cc
@@ -200,11 +200,15 @@ Result<std::unique_ptr<Codec>> Codec::Create(Compression::type codec_type,
       codec = internal::MakeLz4HadoopRawCodec();
 #endif
       break;
-    case Compression::ZSTD:
+    case Compression::ZSTD: {
 #ifdef ARROW_WITH_ZSTD
-      codec = internal::MakeZSTDCodec(compression_level);
+      auto opt = dynamic_cast<const ZstdCodecOptions*>(&codec_options);
+      codec = internal::MakeZSTDCodec(compression_level,
+                                      opt ? opt->compression_context : false,
+                                      opt ? opt->decompression_context : false);
 #endif
       break;
+    }
     case Compression::BZ2:
 #ifdef ARROW_WITH_BZ2
       codec = internal::MakeBZ2Codec(compression_level);

--- a/cpp/src/arrow/util/compression.h
+++ b/cpp/src/arrow/util/compression.h
@@ -142,6 +142,15 @@ class ARROW_EXPORT BrotliCodecOptions : public CodecOptions {
   std::optional<int> window_bits;
 };
 
+// ----------------------------------------------------------------------
+// Zstd codec options implementation
+
+class ARROW_EXPORT ZstdCodecOptions : public CodecOptions {
+ public:
+  bool compression_context = false;
+  bool decompression_context = false;
+};
+
 /// \brief Compression codec
 class ARROW_EXPORT Codec {
  public:

--- a/cpp/src/arrow/util/compression_internal.h
+++ b/cpp/src/arrow/util/compression_internal.h
@@ -73,8 +73,9 @@ std::unique_ptr<Codec> MakeLz4HadoopRawCodec();
 // XXX level = 1 probably doesn't compress very much
 constexpr int kZSTDDefaultCompressionLevel = 1;
 
-std::unique_ptr<Codec> MakeZSTDCodec(
-    int compression_level = kZSTDDefaultCompressionLevel);
+std::unique_ptr<Codec> MakeZSTDCodec(int compression_level = kZSTDDefaultCompressionLevel,
+                                     bool compression_context = false,
+                                     bool decompression_context = false);
 
 }  // namespace internal
 }  // namespace util


### PR DESCRIPTION
### Rationale for this change

Reduce zstd compression/decompression resource consumption by reusing context.

### What changes are included in this PR?

`ZSTDCodec` will create a context lazily.

### Are these changes tested?

Yes. I improved the benchmark to test different compression level. And I test in my private environment. The above is the benchmark of this PR, and the following is the original one.

![img_v3_02tu_6f9779ff-c53b-4ccc-b707-f43354e553cg](https://github.com/user-attachments/assets/d7e05681-d840-49e6-a52b-637b9da9624a)


### Are there any user-facing changes?

No.

* GitHub Issue: #37169