### PR TITLE
GH-48856: [Release] Update copyright NOTICE year to 2026

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,5 +1,5 @@
 Apache Arrow
-Copyright 2016-2024 The Apache Software Foundation
+Copyright 2016-2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/ruby/red-arrow-format/NOTICE.txt
+++ b/ruby/red-arrow-format/NOTICE.txt
@@ -1,2 +1,2 @@
 Apache Arrow
-Copyright 2025 The Apache Software Foundation
+Copyright 2025-2026 The Apache Software Foundation


### PR DESCRIPTION
### Rationale for this change

Date is currently wrong

### What changes are included in this PR?

Update Copyright Notice to cover year 2026

### Are these changes tested?

No

### Are there any user-facing changes?

No breaking change but Yes in terms of copyright date updated.

* GitHub Issue: #48856