### PR TITLE
GH-34785: [Doc][Parquet] Update doc for bloom filter support

### DIFF
--- a/docs/source/cpp/parquet.rst
+++ b/docs/source/cpp/parquet.rst
@@ -651,13 +651,10 @@ Miscellaneous
 +--------------------------+----------+----------+---------+
 | Offset Index             | ✓        | ✓        | \(1)    |
 +--------------------------+----------+----------+---------+
-| Bloom Filter             | ✓        | ✓        | \(2)    |
+| Bloom Filter             | ✓        | ✓        | \(1)    |
 +--------------------------+----------+----------+---------+
 | CRC checksums            | ✓        | ✓        |         |
 +--------------------------+----------+----------+---------+
 
-* \(1) Access to the Column and Offset Index structures is provided, but
-  data read APIs do not currently make any use of them.
-
-* \(2) APIs are provided for creating, serializing and deserializing Bloom
-  Filters, but they are not integrated into data read APIs.
+* \(1) Access to the Column Index, Offset Index and Bloom Filter structures
+  is provided, but data read APIs do not currently make any use of them.


### PR DESCRIPTION
### Rationale for this change

Writing support for Parquet bloom filter has been added so the doc is out of date.

### What changes are included in this PR?

Update the doc to reflect the status that bloom filter is fully supported but not integrated with data read api.

### Are these changes tested?

N/A

### Are there any user-facing changes?

No
* GitHub Issue: #34785