### PR TITLE
GH-48864: [C++] Support customizing more Zstd parameters

### DIFF
--- a/cpp/src/arrow/util/compression.cc
+++ b/cpp/src/arrow/util/compression.cc
@@ -20,6 +20,7 @@
 #include <memory>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "arrow/result.h"
 #include "arrow/status.h"
@@ -200,11 +201,16 @@ Result<std::unique_ptr<Codec>> Codec::Create(Compression::type codec_type,
       codec = internal::MakeLz4HadoopRawCodec();
 #endif
       break;
-    case Compression::ZSTD:
+    case Compression::ZSTD: {
 #ifdef ARROW_WITH_ZSTD
-      codec = internal::MakeZSTDCodec(compression_level);
+      auto opt = dynamic_cast<const ZstdCodecOptions*>(&codec_options);
+      codec = internal::MakeZSTDCodec(
+          compression_level,
+          opt ? opt->compression_context_params : std::vector<std::pair<int, int>>{},
+          opt ? opt->decompression_context_params : std::vector<std::pair<int, int>>{});
 #endif
       break;
+    }
     case Compression::BZ2:
 #ifdef ARROW_WITH_BZ2
       codec = internal::MakeBZ2Codec(compression_level);

--- a/cpp/src/arrow/util/compression.h
+++ b/cpp/src/arrow/util/compression.h
@@ -22,6 +22,8 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <utility>
+#include <vector>
 
 #include "arrow/result.h"
 #include "arrow/status.h"
@@ -140,6 +142,16 @@ class ARROW_EXPORT GZipCodecOptions : public CodecOptions {
 class ARROW_EXPORT BrotliCodecOptions : public CodecOptions {
  public:
   std::optional<int> window_bits;
+};
+
+// ----------------------------------------------------------------------
+// Zstd codec options implementation
+
+class ARROW_EXPORT ZstdCodecOptions : public CodecOptions {
+ public:
+  // Valid keys can be found at https://facebook.github.io/zstd/zstd_manual.html.
+  std::vector<std::pair<int, int>> compression_context_params;
+  std::vector<std::pair<int, int>> decompression_context_params;
 };
 
 /// \brief Compression codec

--- a/cpp/src/arrow/util/compression_internal.h
+++ b/cpp/src/arrow/util/compression_internal.h
@@ -18,6 +18,8 @@
 #pragma once
 
 #include <memory>
+#include <utility>
+#include <vector>
 
 #include "arrow/util/compression.h"  // IWYU pragma: export
 
@@ -74,7 +76,9 @@ std::unique_ptr<Codec> MakeLz4HadoopRawCodec();
 constexpr int kZSTDDefaultCompressionLevel = 1;
 
 std::unique_ptr<Codec> MakeZSTDCodec(
-    int compression_level = kZSTDDefaultCompressionLevel);
+    int compression_level = kZSTDDefaultCompressionLevel,
+    std::vector<std::pair<int, int>> compression_context_params = {},
+    std::vector<std::pair<int, int>> decompression_context_params = {});
 
 }  // namespace internal
 }  // namespace util

--- a/cpp/src/arrow/util/compression_test.cc
+++ b/cpp/src/arrow/util/compression_test.cc
@@ -452,11 +452,12 @@ TEST(TestCodecMisc, SpecifyCompressionLevel) {
 template <std::derived_from<arrow::util::CodecOptions> T>
 void CheckSpecifyCodecOptions(Compression::type compression,
                               std::span<const std::pair<T, bool>> options) {
+  if (!Codec::IsAvailable(compression)) {
+    GTEST_SKIP() << "Support for this codec hasn't been built";
+  }
+
   std::vector<uint8_t> data = MakeRandomData(2000);
   for (const auto& [codec_option, expect_success] : options) {
-    if (!Codec::IsAvailable(compression)) {
-      GTEST_SKIP() << "Support for this codec hasn't been built";
-    }
     auto result1 = Codec::Create(compression, codec_option);
     auto result2 = Codec::Create(compression, codec_option);
     ASSERT_EQ(expect_success, result1.ok());
@@ -523,6 +524,10 @@ TEST(TestCodecMisc, SpecifyCodecOptionsZstd) {
 }
 
 TEST(TestCodecMisc, ZstdLargerWindowLog) {
+#ifndef ARROW_WITH_ZSTD
+  GTEST_SKIP() << "Test requires Zstd compression";
+#endif
+
   constexpr int ZSTD_c_windowLog = 101;
 
   arrow::util::ZstdCodecOptions option1;
@@ -552,6 +557,10 @@ TEST(TestCodecMisc, ZstdLargerWindowLog) {
 }
 
 TEST(TestCodecMisc, ZstdStreamLargerWindowLog) {
+#ifndef ARROW_WITH_ZSTD
+  GTEST_SKIP() << "Test requires Zstd compression";
+#endif
+
   constexpr int ZSTD_c_windowLog = 101;
   constexpr int ZSTD_d_windowLogMax = 100;
 

--- a/cpp/src/arrow/util/compression_zstd.cc
+++ b/cpp/src/arrow/util/compression_zstd.cc
@@ -229,7 +229,7 @@ class ZSTDCodec : public Codec {
   Result<CCtxPtr> CreateCCtx() const {
     CCtxPtr cctx{ZSTD_createCCtx(), ZSTD_freeCCtx};
     if (cctx == nullptr) {
-      return Status::IOError("ZSTD_CCtx create failed: Unknown error");
+      return Status::OutOfMemory("ZSTD_CCtx create failed");
     }
     auto ret =
         ZSTD_CCtx_setParameter(cctx.get(), ZSTD_c_compressionLevel, compression_level_);
@@ -248,7 +248,7 @@ class ZSTDCodec : public Codec {
   Result<DCtxPtr> CreateDCtx() const {
     DCtxPtr dctx{ZSTD_createDCtx(), ZSTD_freeDCtx};
     if (dctx == nullptr) {
-      return Status::IOError("ZSTD_DCtx create failed: Unknown error");
+      return Status::OutOfMemory("ZSTD_DCtx create failed");
     }
     for (auto& [key, value] : decompression_context_params_) {
       auto ret =

--- a/cpp/src/parquet/column_writer_test.cc
+++ b/cpp/src/parquet/column_writer_test.cc
@@ -703,6 +703,13 @@ TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithStatsAndZstdCompression) {
   this->TestRequiredWithSettings(Encoding::PLAIN, Compression::ZSTD, false, true,
                                  LARGE_SIZE);
 }
+TYPED_TEST(TestPrimitiveWriter, RequiredPlainWithZstdCodecOptions) {
+  constexpr int ZSTD_c_windowLog = 101;
+  auto codec_options = std::make_shared<::arrow::util::ZstdCodecOptions>();
+  codec_options->compression_context_params = {{ZSTD_c_windowLog, 23}};
+  this->TestRequiredWithCodecOptions(Encoding::PLAIN, Compression::ZSTD, false, false,
+                                     LARGE_SIZE, codec_options);
+}
 #endif
 
 TYPED_TEST(TestPrimitiveWriter, Optional) {

--- a/cpp/src/parquet/properties_test.cc
+++ b/cpp/src/parquet/properties_test.cc
@@ -81,9 +81,13 @@ TEST(TestWriterProperties, AdvancedHandling) {
 }
 
 TEST(TestWriterProperties, SetCodecOptions) {
+  constexpr int ZSTD_c_windowLog = 101;
+
   WriterProperties::Builder builder;
   builder.compression("gzip", Compression::GZIP);
-  builder.compression("zstd", Compression::ZSTD);
+  auto zstd_codec_options = std::make_shared<::arrow::util::ZstdCodecOptions>();
+  zstd_codec_options->compression_context_params = {{ZSTD_c_windowLog, 23}};
+  builder.codec_options("zstd", zstd_codec_options);
   builder.compression("brotli", Compression::BROTLI);
   auto gzip_codec_options = std::make_shared<::arrow::util::GZipCodecOptions>();
   gzip_codec_options->compression_level = 5;


### PR DESCRIPTION
### Rationale for this change

Support customizing more Zstd parameters to allow users to optimize the performance of parquet page compression/decompression.

### What changes are included in this PR?

1. Add a new class `ZstdCodecOptions` inherited from `CodecOptions`.
2. Create `ZSTD_CCtx`/`ZSTD_DCtx` explicitly in `ZSTDCodec`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes. The new class `ZstdCodecOptions` is added.

* GitHub Issue: #48864