### PR TITLE
MINOR: [CI][Release] Fix incorrect path in release_candidate.yml

### DIFF
--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -25,12 +25,12 @@ on:
     tags:
       - "apache-arrow-*-rc*"
     paths:
-      - ".github/workflows/release_candidate.sh"
+      - ".github/workflows/release_candidate.yml"
       - "dev/release/utils-create-release-tarball.sh"
       - "dev/release/utils-generate-checksum.sh"
   pull_request:
     paths:
-      - ".github/workflows/release_candidate.sh"
+      - ".github/workflows/release_candidate.yml"
       - "dev/release/utils-create-release-tarball.sh"
       - "dev/release/utils-generate-checksum.sh"
 


### PR DESCRIPTION
### Rationale for this change

I noticed a reference to a `release_candidate.sh` in the `paths` field in `release_candidate.yml` which is a file that doesn't exist. I think this was just a typo made during refactoring.

### What changes are included in this PR?

Corrected `paths` list entry.

### Are these changes tested?

No.

### Are there any user-facing changes?

No.