### PR TITLE
GH-48861: [CI] Fix wrong `smtplib.SMTP.send_message` usage

### DIFF
--- a/dev/archery/archery/crossbow/reports.py
+++ b/dev/archery/archery/crossbow/reports.py
@@ -264,7 +264,7 @@ class ReportUtils:
                 smtp.starttls()
             smtp.login(smtp_user, smtp_password)
             message = report.render()
-            smtp.send_message(smtp_user, report.recipient_email, message)
+            smtp.send_message(message)
 
     @classmethod
     def write_csv(cls, report, add_headers=True):


### PR DESCRIPTION
### Rationale for this change

https://docs.python.org/3/library/smtplib.html#smtplib.SMTP.sendmail uses the third argument as e-mail content but https://docs.python.org/3/library/smtplib.html#smtplib.SMTP.send_message uses the first argument as e-mail.

### What changes are included in this PR?

* Pass e-mail as the first argument
* Remove redundant from and to addresses
  * They are extracted from the given e-mail automatically
  
### Are these changes tested?

Yes. I sent a test e-mail manually.

### Are there any user-facing changes?

No.
* GitHub Issue: #48861