### PR TITLE
GH-48877: [C++][Parquet] Fix writer not to throw for bloom filter on disabled bool column

### DIFF
--- a/cpp/src/parquet/bloom_filter_writer.cc
+++ b/cpp/src/parquet/bloom_filter_writer.cc
@@ -199,12 +199,12 @@ void BloomFilterBuilderImpl::AppendRowGroup() {
 }
 
 BloomFilter* BloomFilterBuilderImpl::CreateBloomFilter(int32_t column_ordinal) {
-  CheckState(column_ordinal);
-
   auto opts = properties_->bloom_filter_options(schema_->Column(column_ordinal)->path());
   if (!opts.has_value()) {
     return nullptr;
   }
+
+  CheckState(column_ordinal);
 
   auto& curr_rg_bfs = *bloom_filters_.rbegin();
   if (curr_rg_bfs.find(column_ordinal) != curr_rg_bfs.cend()) {


### PR DESCRIPTION
### Rationale for this change

Now that https://github.com/apache/arrow/pull/37400 is merged. After a quick integration, I found that the Parquet writer throws if bloom filter is enabled and there is at least one boolean column (even when it is not enabled).

### What changes are included in this PR?

Move the bloom filter type check after bloom filter enablement check.

### Are these changes tested?

Yes, added test to verify this does not throw.

### Are there any user-facing changes?

No.
* GitHub Issue: #48877