### PR TITLE
GH-48850: [Doc][Dev] Clarify versions of clang-format/pre-commit/Ubuntu

### DIFF
--- a/docs/source/developers/cpp/development.rst
+++ b/docs/source/developers/cpp/development.rst
@@ -74,6 +74,24 @@ corresponding executable from the command line, e.g.::
 Code Style, Linting, and CI
 ===========================
 
+Development Tool Requirements
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following tools and versions are required for C++ development:
+
+* **clang-format** version 14.0.6 or later for code formatting
+* **pre-commit** version 2.17.0 or later (Ubuntu 22.04 ships with this version)
+* **Ubuntu** 22.04 LTS or later for Linux development (Ubuntu 22.04 is supported until June 2027)
+
+These tools are used in our continuous integration pipeline to ensure code quality
+and consistency. To set up pre-commit hooks locally, install the ``pre-commit``
+Python package and run::
+
+   $ pip install pre-commit
+   $ pre-commit install
+
+This will automatically run formatting and linting checks before each commit.
+
 This project follows `Google's C++ Style Guide
 <https://google.github.io/styleguide/cppguide.html>`_ with these exceptions:
 


### PR DESCRIPTION
### Rationale for this change
As discussed in #47168, we are now requiring C++20 capable toolchains and the clang-format has been updated in our CI. This PR clarifies the required toolchain versions in the developer documentation.

### What changes are included in this PR?
Added a new "Development Tool Requirements" section to the C++ development documentation ([docs/source/developers/cpp/development.rst](cci:7://file:///c:/Users/ishwet/arrow/docs/source/developers/cpp/development.rst:0:0-0:0)) that clearly specifies:
- clang-format version 14.0.6 or later
- pre-commit version 2.17.0 or later  
- Ubuntu 22.04 LTS or later

### Are these changes tested?
This is documentation only.

### Are there any user-facing changes?
No, this only updates developer documentation.

Closes #48850

* GitHub Issue: #48850