### PR TITLE
GH-48869: [Doc] Add runs-on and AWS to Continuous Integration Sponsors on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ on git main.
 
 ## How to Contribute
 
-Please read our latest [project contribution guide][5].
+Please read our latest [project contribution guide][4].
 
 ## Getting involved
 
@@ -103,8 +103,12 @@ integrations in other projects, we'd be happy to have you involved:
 - [Learn the format][2]
 - Contribute code to one of the reference implementations
 
+## Continuous Integration Sponsors
+
+We use [runs-on][5] for managing the project self-hosted runners.
+
 [1]: mailto:dev-subscribe@arrow.apache.org
 [2]: https://github.com/apache/arrow/tree/main/format
 [3]: https://github.com/apache/arrow/issues
-[4]: https://github.com/apache/arrow
-[5]: https://arrow.apache.org/docs/dev/developers/index.html
+[4]: https://arrow.apache.org/docs/dev/developers/index.html
+[5]: https://runs-on.com/

--- a/README.md
+++ b/README.md
@@ -106,9 +106,11 @@ integrations in other projects, we'd be happy to have you involved:
 ## Continuous Integration Sponsors
 
 We use [runs-on][5] for managing the project self-hosted runners.
+We use [AWS][6] for some of the required infrastructure for the project.
 
 [1]: mailto:dev-subscribe@arrow.apache.org
 [2]: https://github.com/apache/arrow/tree/main/format
 [3]: https://github.com/apache/arrow/issues
 [4]: https://arrow.apache.org/docs/dev/developers/index.html
 [5]: https://runs-on.com/
+[6]: https://aws.amazon.com/


### PR DESCRIPTION
### Rationale for this change

We have added runs-on as a solution for our cuda runners. As part of their [nonprofit license](https://runs-on.com/legal/nonprofit-license/), which we are using, we should add a working hyperlink and a shout-out to our documentation or our README.

### What changes are included in this PR?

- Add section for `Continuous Integration Sponsors` on README with link to runs-on and AWS.
- Remove unused link

### Are these changes tested?

No

### Are there any user-facing changes?

No
* GitHub Issue: #48869