### PR TITLE
GH-48884: [Dev][Release] Remove non-published draft release candidates when publishing official release to GitHub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,3 +73,14 @@ jobs:
             --title "${RELEASE_TITLE}" \
             --verify-tag \
             release_candidate_artifacts/*
+      - name: Remove Draft GitHub Releases
+        run: |
+          gh release list \
+            --jq '.[] | select(.isDraft).tagName' \
+            --json isDraft,tagName \
+            --repo ${GITHUB_REPOSITORY} |
+              while read tag; do \
+                gh release delete ${tag} \
+                  --repo ${GITHUB_REPOSITORY} \
+                  --yes; \
+              done


### PR DESCRIPTION
### Rationale for this change

Draft releases appear on top of the releases page on GitHub, cluttering the releases page.

### What changes are included in this PR?

Once we publish the official release we can delete draft release candidates. This can be done automatically on the `release.yml` workflow.

### Are these changes tested?

Not on the workflow but I've deleted the draft releases for 23.0.0 (RC0 and RC1) executing the same command:
```
$ gh release list --jq '.[] | select(.isDraft).tagName' --json isDraft,tagName --repo apache/arrow
apache-arrow-23.0.0-rc1
apache-arrow-23.0.0-rc0
$ gh release list --jq '.[] | select(.isDraft).tagName' --json isDraft,tagName --repo apache/arrow | while read tag; do gh release delete ${tag} --repo apache/arrow; done
✓ Deleted release apache-arrow-23.0.0-rc1
✓ Deleted release apache-arrow-23.0.0-rc0
```

### Are there any user-facing changes?

No

* GitHub Issue: #48884