### PR TITLE
GH-48888: [Ruby] Add support for writing boolean array

### DIFF
--- a/ruby/red-arrow-format/lib/arrow-format/buffer-alignable.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/buffer-alignable.rb
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+require_relative "flat-buffers"
+
+module ArrowFormat
+  module BufferAlignable
+    include FlatBuffers::Alignable
+
+    BUFFER_ALIGNMENT_SIZE = 64
+
+    private
+    def buffer_padding_size(buffer)
+      compute_padding_size(buffer.size, BUFFER_ALIGNMENT_SIZE)
+    end
+
+    def aligned_buffer_size(buffer)
+      buffer.size + buffer_padding_size(buffer)
+    end
+  end
+end

--- a/ruby/red-arrow-format/lib/arrow-format/record-batch.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/record-batch.rb
@@ -14,8 +14,12 @@
 # specific language governing permissions and limitations
 # under the License.
 
+require_relative "buffer-alignable"
+
 module ArrowFormat
   class RecordBatch
+    include BufferAlignable
+
     attr_reader :schema
     attr_reader :n_rows
     attr_reader :columns
@@ -44,15 +48,16 @@ module ArrowFormat
       end
       offset = 0
       fb_record_batch.buffers = all_buffers_enumerator.collect do |buffer|
-        buffer_flat_buffesr = FB::Buffer::Data.new
-        buffer_flat_buffesr.offset = offset
+        fb_buffer = FB::Buffer::Data.new
+        fb_buffer.offset = offset
         if buffer
-          offset += buffer.size
-          buffer_flat_buffesr.length = buffer.size
+          aligned_size = aligned_buffer_size(buffer)
+          offset += aligned_size
+          fb_buffer.length = aligned_size
         else
-          buffer_flat_buffesr.length = 0
+          fb_buffer.length = 0
         end
-        buffer_flat_buffesr
+        fb_buffer
       end
       # body_compression = FB::BodyCompression::Data.new
       # body_compression.codec = ...

--- a/ruby/red-arrow-format/lib/arrow-format/type.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/type.rb
@@ -52,6 +52,10 @@ module ArrowFormat
     def build_array(size, validity_buffer, values_buffer)
       BooleanArray.new(self, size, validity_buffer, values_buffer)
     end
+
+    def to_flat_buffers
+      FB::Bool::Data.new
+    end
   end
 
   class NumberType < Type

--- a/ruby/red-arrow-format/red-arrow-format.gemspec
+++ b/ruby/red-arrow-format/red-arrow-format.gemspec
@@ -46,7 +46,7 @@ Gem::Specification.new do |spec|
   spec.files += Dir.glob("lib/**/*.rb")
   spec.files += Dir.glob("doc/text/*")
 
-  spec.add_runtime_dependency("red-flatbuffers", ">=0.0.4")
+  spec.add_runtime_dependency("red-flatbuffers", ">=0.0.5")
 
   github_url = "https://github.com/apache/arrow"
   spec.metadata = {

--- a/ruby/red-arrow-format/test/test-writer.rb
+++ b/ruby/red-arrow-format/test/test-writer.rb
@@ -20,7 +20,14 @@ module WriterTests
     case red_arrow_type
     when Arrow::NullDataType
       ArrowFormat::NullType.singleton
+    when Arrow::BooleanDataType
+      ArrowFormat::BooleanType.singleton
     end
+  end
+
+  def convert_buffer(buffer)
+    return nil if buffer.nil?
+    IO::Buffer.for(buffer.data.to_s)
   end
 
   def convert_array(red_arrow_array)
@@ -28,6 +35,10 @@ module WriterTests
     case type
     when ArrowFormat::NullType
       type.build_array(red_arrow_array.size)
+    when ArrowFormat::BooleanType
+      type.build_array(red_arrow_array.size,
+                       convert_buffer(red_arrow_array.null_bitmap),
+                       convert_buffer(red_arrow_array.data_buffer))
     end
   end
 
@@ -41,6 +52,17 @@ module WriterTests
 
           def test_write
             assert_equal([nil, nil, nil],
+                         @values)
+          end
+        end
+
+        sub_test_case("Boolean") do
+          def build_array
+            Arrow::BooleanArray.new([true, nil, false])
+          end
+
+          def test_write
+            assert_equal([true, nil, false],
                          @values)
           end
         end


### PR DESCRIPTION
### Rationale for this change

It's a primitive array.

### What changes are included in this PR?

* Add support for 64-bit buffer alignment.
* Add `ArrowFormat::BooleanType#to_flat_buffers`

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #48888