### PR TITLE
GH-48885: [C++] Add missing curl dependency of `Arrow::arrow_static` CMake target

### DIFF
--- a/cpp/cmake_modules/ThirdpartyToolchain.cmake
+++ b/cpp/cmake_modules/ThirdpartyToolchain.cmake
@@ -3366,10 +3366,6 @@ function(build_google_cloud_cpp_storage)
   # List of dependencies taken from https://github.com/googleapis/google-cloud-cpp/blob/main/doc/packaging.md
   build_crc32c_once()
 
-  # Curl is required on all platforms, but building it internally might also trip over S3's copy.
-  # For now, force its inclusion from the underlying system or fail.
-  find_curl()
-
   fetchcontent_declare(google_cloud_cpp
                        ${FC_DECLARE_COMMON_OPTIONS}
                        URL ${google_cloud_cpp_storage_SOURCE_URL}
@@ -3453,6 +3449,9 @@ if(ARROW_WITH_GOOGLE_CLOUD_CPP)
     )
   endif()
 
+  # curl is required on all platforms. We always use system curl to
+  # avoid conflict.
+  find_curl()
   resolve_dependency(google_cloud_cpp_storage PC_PACKAGE_NAMES google_cloud_cpp_storage)
   get_target_property(google_cloud_cpp_storage_INCLUDE_DIR google-cloud-cpp::storage
                       INTERFACE_INCLUDE_DIRECTORIES)

--- a/dev/release/verify-apt.sh
+++ b/dev/release/verify-apt.sh
@@ -162,11 +162,19 @@ if [ "${cmake_version_major}" -gt "3" ] || \
    [ "${cmake_version_major}" -eq "3" -a "${cmake_version_minor}" -ge "25" ]; then
   cp -a "${TOP_SOURCE_DIR}/cpp/examples/minimal_build" build/
   pushd build/minimal_build
-  cmake .
-  make -j$(nproc)
-  ./arrow-example
-  c++ -o arrow-example example.cc $(pkg-config --cflags --libs arrow) -std=c++20
-  ./arrow-example
+  cmake -S . -B build_shared
+  make -C build_shared -j$(nproc)
+  build_shared/arrow-example
+  cmake -S . -B build_static -DARROW_LINK_SHARED=OFF
+  make -C build_static -j$(nproc)
+  build_static/arrow-example
+  mkdir -p build_pkg_config
+  c++ \
+    example.cc \
+    -o build_pkg_config/arrow-example \
+    $(pkg-config --cflags --libs arrow) \
+    -std=c++20
+  build_pkg_config/arrow-example
   popd
 fi
 echo "::endgroup::"


### PR DESCRIPTION
### Rationale for this change

We changed `macro(build_google_cloud_cpp_storage)` to `function(...)` in GH-48333 . So `find_curl()` doesn't change `ARROW_SYSTEM_DEPENDENCIES` in parent scope. (`function()` creates a new scope.)

### What changes are included in this PR?

Move `find_curl()` to the top-level from in `function(build_google_cloud_cpp_storage)`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #48885