### PR TITLE
GH-48853: [Release] Fix bytes to string comparison in download_rc_binaries.py

### DIFF
--- a/dev/release/download_rc_binaries.py
+++ b/dev/release/download_rc_binaries.py
@@ -136,7 +136,7 @@ class Downloader:
                     os.remove(dest_path)
                 except IOError:
                     pass
-                if "OpenSSL" not in stderr:
+                if b"OpenSSL" not in stderr:
                     # We assume curl has already retried on other errors.
                     break
             else:


### PR DESCRIPTION
### Rationale for this change
The download_rc_binaries.py script fails with a `TypeError` when a download fails and it tries to check if the error is related to OpenSSL.

### What changes are included in this PR?
`subprocess.Popen().communicate()` returns bytes objects, but the code was comparing `stderr` (bytes) with a string `"OpenSSL"`. Changed to use bytes literal `b"OpenSSL"` for proper comparison.

### Are these changes tested?
The fix is straightforward - using bytes literal instead of string literal for comparison with bytes object.

### Are there any user-facing changes?
No.

Closes #48853
* GitHub Issue: #48853