### PR TITLE
GH-44926: [R] Remove usage of cpp11's cpp11/altrep.hpp and HAS_ALTREP

### DIFF
--- a/r/data-raw/codegen.R
+++ b/r/data-raw/codegen.R
@@ -211,9 +211,7 @@ static const R_CallMethodDef CallEntries[] = {
   R_registerRoutines(dll, NULL, CallEntries, NULL, NULL);
   R_useDynamicSymbols(dll, FALSE);
 
-  #if defined(HAS_ALTREP)
   arrow::r::altrep::Init_Altrep_classes(dll);
-  #endif
 
   _arrow_compute__Initialize();
 }

--- a/r/src/altrep.cpp
+++ b/r/src/altrep.cpp
@@ -26,26 +26,7 @@
 
 #include <cpp11/declarations.hpp>
 
-#if R_VERSION < R_Version(3, 6, 0)
-
-// workaround because R's <R_ext/Altrep.h> not so conveniently uses `class`
-// as a variable name, and C++ is not happy about that
-//
-// SEXP R_new_altrep(R_altrep_class_t class, SEXP data1, SEXP data2);
-//
-#define class klass
-
-// Because functions declared in <R_ext/Altrep.h> have C linkage
-extern "C" {
 #include <R_ext/Altrep.h>
-}
-
-// undo the workaround
-#undef class
-
-#else
-#include <R_ext/Altrep.h>
-#endif
 
 #include "./r_task_group.h"
 

--- a/r/src/altrep.cpp
+++ b/r/src/altrep.cpp
@@ -24,9 +24,7 @@
 #include <arrow/util/bitmap_reader.h>
 #include <arrow/visit_data_inline.h>
 
-#include <cpp11/altrep.hpp>
 #include <cpp11/declarations.hpp>
-#if defined(HAS_ALTREP)
 
 #if R_VERSION < R_Version(3, 6, 0)
 
@@ -1115,29 +1113,6 @@ std::shared_ptr<ChunkedArray> vec_to_arrow_altrep_bypass(SEXP x) {
 }  // namespace altrep
 }  // namespace r
 }  // namespace arrow
-
-#else  // HAS_ALTREP
-
-namespace arrow {
-namespace r {
-namespace altrep {
-
-// return an altrep R vector that shadows the array if possible
-SEXP MakeAltrepVector(const std::shared_ptr<ChunkedArray>& chunked_array) {
-  return R_NilValue;
-}
-
-bool is_arrow_altrep(SEXP) { return false; }
-
-std::shared_ptr<ChunkedArray> vec_to_arrow_altrep_bypass(SEXP x) { return nullptr; }
-
-bool is_unmaterialized_arrow_altrep(SEXP) { return false; }
-
-}  // namespace altrep
-}  // namespace r
-}  // namespace arrow
-
-#endif
 
 // [[arrow::export]]
 bool is_arrow_altrep(cpp11::sexp x) { return arrow::r::altrep::is_arrow_altrep(x); }

--- a/r/src/array_to_vector.cpp
+++ b/r/src/array_to_vector.cpp
@@ -25,7 +25,6 @@
 #include <arrow/util/bitmap_writer.h>
 #include <arrow/util/int_util.h>
 
-#include <cpp11/altrep.hpp>
 #include <type_traits>
 
 #include "./extension.h"

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -6259,9 +6259,7 @@ extern "C" void R_init_arrow(DllInfo* dll){
   R_registerRoutines(dll, NULL, CallEntries, NULL, NULL);
   R_useDynamicSymbols(dll, FALSE);
 
-  #if defined(HAS_ALTREP)
   arrow::r::altrep::Init_Altrep_classes(dll);
-  #endif
 
   _arrow_compute__Initialize();
 }

--- a/r/src/arrow_cpp11.h
+++ b/r/src/arrow_cpp11.h
@@ -23,7 +23,6 @@
 #undef Free
 
 #include <cpp11.hpp>
-#include <cpp11/altrep.hpp>
 
 #include "./nameof.h"
 

--- a/r/src/arrow_types.h
+++ b/r/src/arrow_types.h
@@ -246,9 +246,7 @@ arrow::Status AddMetadataFromDots(SEXP lst, int num_fields,
 
 namespace altrep {
 
-#if defined(HAS_ALTREP)
 void Init_Altrep_classes(DllInfo* dll);
-#endif
 
 SEXP MakeAltrepVector(const std::shared_ptr<ChunkedArray>& chunked_array);
 bool is_arrow_altrep(SEXP x);


### PR DESCRIPTION
### Rationale for this change

Don't need to check for altrep as it's in R >= 4.0

### What changes are included in this PR?

Remove altrep checking

### Are these changes tested?

All good if CI passes

### Are there any user-facing changes?

Nah
* GitHub Issue: #44926