### PR TITLE
GH-18652: [C++] Enhance arrow::internal::call_traits to support function pointers

### DIFF
--- a/cpp/src/arrow/array/array_dict.cc
+++ b/cpp/src/arrow/array/array_dict.cc
@@ -540,8 +540,7 @@ Result<std::shared_ptr<ChunkedArray>> DictionaryUnifier::UnifyChunkedArray(
     return array;
   }
   ArrayVector chunks(array->num_chunks());
-  std::transform(data_chunks.begin(), data_chunks.end(), chunks.begin(),
-                 [](const std::shared_ptr<ArrayData>& data) { return MakeArray(data); });
+  std::transform(data_chunks.begin(), data_chunks.end(), chunks.begin(), MakeArray);
   return std::make_shared<ChunkedArray>(std::move(chunks), array->type());
 }
 

--- a/cpp/src/arrow/type_test.cc
+++ b/cpp/src/arrow/type_test.cc
@@ -1950,22 +1950,24 @@ void CheckListListTypeMetadata(ListListTypeFactory list_type_factory) {
 }
 
 TEST(TestListType, Metadata) {
-  CheckListListTypeMetadata([](std::shared_ptr<Field> field) { return list(field); });
+  CheckListListTypeMetadata(
+      static_cast<std::shared_ptr<DataType> (*)(std::shared_ptr<Field>)>(&list));
 }
 
 TEST(TestLargeListType, Metadata) {
   CheckListListTypeMetadata(
-      [](std::shared_ptr<Field> field) { return large_list(field); });
+      static_cast<std::shared_ptr<DataType> (*)(std::shared_ptr<Field>)>(&large_list));
 }
 
 TEST(TestListViewType, Metadata) {
   CheckListListTypeMetadata(
-      [](std::shared_ptr<Field> field) { return list_view(field); });
+      static_cast<std::shared_ptr<DataType> (*)(std::shared_ptr<Field>)>(&list_view));
 }
 
 TEST(TestLargeListViewType, Metadata) {
   CheckListListTypeMetadata(
-      [](std::shared_ptr<Field> field) { return large_list_view(field); });
+      static_cast<std::shared_ptr<DataType> (*)(std::shared_ptr<Field>)>(
+          &large_list_view));
 }
 
 TEST(TestNestedType, Equals) {

--- a/cpp/src/arrow/util/async_generator.h
+++ b/cpp/src/arrow/util/async_generator.h
@@ -1490,9 +1490,8 @@ Result<AsyncGenerator<T>> MakeSequencedMergedGenerator(
   if (max_subscriptions == 1) {
     return Status::Invalid("Use MakeConcatenatedGenerator if max_subscriptions is 1");
   }
-  AsyncGenerator<AsyncGenerator<T>> autostarting_source = MakeMappedGenerator(
-      std::move(source),
-      [](const AsyncGenerator<T>& sub) { return MakeAutoStartingGenerator(sub); });
+  AsyncGenerator<AsyncGenerator<T>> autostarting_source =
+      MakeMappedGenerator(std::move(source), MakeAutoStartingGenerator<T>);
   AsyncGenerator<AsyncGenerator<T>> sub_readahead =
       MakeSerialReadaheadGenerator(std::move(autostarting_source), max_subscriptions - 1);
   return MakeConcatenatedGenerator(std::move(sub_readahead));


### PR DESCRIPTION
### Rationale for this change

The `call_traits` utility only supported lambdas and functors, but not function pointers. This prevented simplifying code like `fut.Then([](T x) { return Func(x); })` to `fut.Then(Func)`, as described in GH-18652.

### What changes are included in this PR?

- Added function pointer support to `arrow::internal::call_traits` in `cpp/src/arrow/util/functional.h`
- Applied the simplifications.

### Are these changes tested?

Yes, I ran all existing tests locally.

### Are there any user-facing changes?

No.
* GitHub Issue: #18652