### PR TITLE
GH-48916: [Ruby] Add support for writing binary array

### DIFF
--- a/ruby/red-arrow-format/lib/arrow-format/type.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/type.rb
@@ -482,7 +482,15 @@ module ArrowFormat
     end
 
     def build_array(size, validity_buffer, offsets_buffer, values_buffer)
-      BinaryArray.new(self, size, validity_buffer, offsets_buffer, values_buffer)
+      BinaryArray.new(self,
+                      size,
+                      validity_buffer,
+                      offsets_buffer,
+                      values_buffer)
+    end
+
+    def to_flatbuffers
+      FB::Binary::Data.new
     end
   end
 

--- a/ruby/red-arrow-format/test/test-writer.rb
+++ b/ruby/red-arrow-format/test/test-writer.rb
@@ -26,6 +26,8 @@ module WriterTests
       ArrowFormat::Int8Type.singleton
     when Arrow::UInt8DataType
       ArrowFormat::UInt8Type.singleton
+    when Arrow::BinaryDataType
+      ArrowFormat::BinaryType.singleton
     else
       raise "Unsupported type: #{red_arrow_type.inspect}"
     end
@@ -44,6 +46,11 @@ module WriterTests
     when ArrowFormat::PrimitiveType
       type.build_array(red_arrow_array.size,
                        convert_buffer(red_arrow_array.null_bitmap),
+                       convert_buffer(red_arrow_array.data_buffer))
+    when ArrowFormat::VariableSizeBinaryType
+      type.build_array(red_arrow_array.size,
+                       convert_buffer(red_arrow_array.null_bitmap),
+                       convert_buffer(red_arrow_array.offsets_buffer),
                        convert_buffer(red_arrow_array.data_buffer))
     else
       raise "Unsupported array #{red_arrow_array.inspect}"
@@ -93,6 +100,17 @@ module WriterTests
 
           def test_write
             assert_equal([0, nil, 255],
+                         @values)
+          end
+        end
+
+        sub_test_case("Binary") do
+          def build_array
+            Arrow::BinaryArray.new(["Hello".b, nil, "World".b])
+          end
+
+          def test_write
+            assert_equal(["Hello".b, nil, "World".b],
                          @values)
           end
         end


### PR DESCRIPTION
### Rationale for this change

It's a variable size binary layout array.

### What changes are included in this PR?

* Add `ArrowFormat::BinaryType#to_flatbuffers`

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #48916