### PR TITLE
GH-48880: [Ruby] Fix a bug that Arrow::ExecutePlan nodes may be GC-ed

### DIFF
--- a/ruby/red-arrow/ext/arrow/arrow.cpp
+++ b/ruby/red-arrow/ext/arrow/arrow.cpp
@@ -59,7 +59,7 @@ namespace red_arrow {
   {
     auto plan = GARROW_EXECUTE_PLAN(object);
     auto nodes = garrow_execute_plan_get_nodes(plan);
-    for (auto node = nodes; nodes; nodes = g_list_next(nodes)) {
+    for (auto node = nodes; node; node = g_list_next(node)) {
       rbgobj_gc_mark_instance(node->data);
     }
   }


### PR DESCRIPTION
### Rationale for this change

We must mark all nodes in `Arrow::ExecutePlan` but only the first node is marked. 

### What changes are included in this PR?

Fix typos in variable name.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #48880