### PR TITLE
GH-48935: [Ruby] Add support for writing int16/32/64 and uint16/32/64 arrays

### DIFF
--- a/ruby/red-arrow-format/lib/arrow-format/type.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/type.rb
@@ -75,6 +75,13 @@ module ArrowFormat
     def signed?
       @signed
     end
+
+    def to_flatbuffers
+      fb_type = FB::Int::Data.new
+      fb_type.bit_width = @bit_width
+      fb_type.signed = @signed
+      fb_type
+    end
   end
 
   class Int8Type < IntType
@@ -99,13 +106,6 @@ module ArrowFormat
     def build_array(size, validity_buffer, values_buffer)
       Int8Array.new(self, size, validity_buffer, values_buffer)
     end
-
-    def to_flatbuffers
-      fb_type = FB::Int::Data.new
-      fb_type.bit_width = 8
-      fb_type.signed = true
-      fb_type
-    end
   end
 
   class UInt8Type < IntType
@@ -129,13 +129,6 @@ module ArrowFormat
 
     def build_array(size, validity_buffer, values_buffer)
       UInt8Array.new(self, size, validity_buffer, values_buffer)
-    end
-
-    def to_flatbuffers
-      fb_type = FB::Int::Data.new
-      fb_type.bit_width = 8
-      fb_type.signed = false
-      fb_type
     end
   end
 

--- a/ruby/red-arrow-format/test/test-writer.rb
+++ b/ruby/red-arrow-format/test/test-writer.rb
@@ -26,6 +26,18 @@ module WriterTests
       ArrowFormat::Int8Type.singleton
     when Arrow::UInt8DataType
       ArrowFormat::UInt8Type.singleton
+    when Arrow::Int16DataType
+      ArrowFormat::Int16Type.singleton
+    when Arrow::UInt16DataType
+      ArrowFormat::UInt16Type.singleton
+    when Arrow::Int32DataType
+      ArrowFormat::Int32Type.singleton
+    when Arrow::UInt32DataType
+      ArrowFormat::UInt32Type.singleton
+    when Arrow::Int64DataType
+      ArrowFormat::Int64Type.singleton
+    when Arrow::UInt64DataType
+      ArrowFormat::UInt64Type.singleton
     when Arrow::BinaryDataType
       ArrowFormat::BinaryType.singleton
     else
@@ -100,6 +112,80 @@ module WriterTests
 
           def test_write
             assert_equal([0, nil, 255],
+                         @values)
+          end
+        end
+
+        sub_test_case("Int16") do
+          def build_array
+            Arrow::Int16Array.new([-32768, nil, 32767])
+          end
+
+          def test_write
+            assert_equal([-32768, nil, 32767],
+                         @values)
+          end
+        end
+
+        sub_test_case("UInt16") do
+          def build_array
+            Arrow::UInt16Array.new([0, nil, 65535])
+          end
+
+          def test_write
+            assert_equal([0, nil, 65535],
+                         @values)
+          end
+        end
+
+        sub_test_case("Int32") do
+          def build_array
+            Arrow::Int32Array.new([-2147483648, nil, 2147483647])
+          end
+
+          def test_write
+            assert_equal([-2147483648, nil, 2147483647],
+                         @values)
+          end
+        end
+
+        sub_test_case("UInt32") do
+          def build_array
+            Arrow::UInt32Array.new([0, nil, 4294967295])
+          end
+
+          def test_write
+            assert_equal([0, nil, 4294967295],
+                         @values)
+          end
+        end
+
+        sub_test_case("Int64") do
+          def build_array
+            Arrow::Int64Array.new([
+                                    -9223372036854775808,
+                                    nil,
+                                    9223372036854775807
+                                  ])
+          end
+
+          def test_write
+            assert_equal([
+                           -9223372036854775808,
+                           nil,
+                           9223372036854775807
+                         ],
+                         @values)
+          end
+        end
+
+        sub_test_case("UInt64") do
+          def build_array
+            Arrow::UInt64Array.new([0, nil, 18446744073709551615])
+          end
+
+          def test_write
+            assert_equal([0, nil, 18446744073709551615],
                          @values)
           end
         end


### PR DESCRIPTION
### Rationale for this change

They are similar to int8/uint8 arrays.

### What changes are included in this PR?

Move `ArrowFormat::{,U}Int8Type#to_flatbuffers` to `ArrowFormat::IntType#to_flatbuffers`

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.

* GitHub Issue: #48935