### PR TITLE
GH-48937: [Ruby] Add support for writing UTF-8 array

### DIFF
--- a/ruby/red-arrow-format/lib/arrow-format/type.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/type.rb
@@ -528,6 +528,10 @@ module ArrowFormat
     def build_array(size, validity_buffer, offsets_buffer, values_buffer)
       UTF8Array.new(self, size, validity_buffer, offsets_buffer, values_buffer)
     end
+
+    def to_flatbuffers
+      FB::Utf8::Data.new
+    end
   end
 
   class LargeUTF8Type < VariableSizeBinaryType

--- a/ruby/red-arrow-format/test/test-writer.rb
+++ b/ruby/red-arrow-format/test/test-writer.rb
@@ -28,6 +28,8 @@ module WriterTests
       ArrowFormat::UInt8Type.singleton
     when Arrow::BinaryDataType
       ArrowFormat::BinaryType.singleton
+    when Arrow::StringDataType
+      ArrowFormat::UTF8Type.singleton
     else
       raise "Unsupported type: #{red_arrow_type.inspect}"
     end
@@ -111,6 +113,17 @@ module WriterTests
 
           def test_write
             assert_equal(["Hello".b, nil, "World".b],
+                         @values)
+          end
+        end
+
+        sub_test_case("String") do
+          def build_array
+            Arrow::StringArray.new(["Hello", nil, "World"])
+          end
+
+          def test_write
+            assert_equal(["Hello", nil, "World"],
                          @values)
           end
         end


### PR DESCRIPTION
### Rationale for this change

It's similar to binary array.

### What changes are included in this PR?

Add `ArrowFormat::UTF8Type#to_flatbuffers`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #48937