### PR TITLE
GH-48394: [C++][Parquet] Add arrow::Result version of parquet::arrow::FileReader::ReadTable()

### DIFF
--- a/c_glib/parquet-glib/arrow-file-reader.cpp
+++ b/c_glib/parquet-glib/arrow-file-reader.cpp
@@ -212,10 +212,11 @@ GArrowTable *
 gparquet_arrow_file_reader_read_table(GParquetArrowFileReader *reader, GError **error)
 {
   auto parquet_arrow_file_reader = gparquet_arrow_file_reader_get_raw(reader);
-  std::shared_ptr<arrow::Table> arrow_table;
-  auto status = parquet_arrow_file_reader->ReadTable(&arrow_table);
-  if (garrow_error_check(error, status, "[parquet][arrow][file-reader][read-table]")) {
-    return garrow_table_new_raw(&arrow_table);
+  auto arrow_table_result = parquet_arrow_file_reader->ReadTable();
+  if (garrow::check(error,
+                    arrow_table_result,
+                    "[parquet][arrow][file-reader][read-table]")) {
+    return garrow_table_new_raw(&(*arrow_table_result));
   } else {
     return NULL;
   }

--- a/cpp/examples/arrow/parquet_read_write.cc
+++ b/cpp/examples/arrow/parquet_read_write.cc
@@ -37,8 +37,7 @@ arrow::Status ReadFullFile(std::string path_to_file) {
   ARROW_ASSIGN_OR_RAISE(arrow_reader, parquet::arrow::OpenFile(input, pool));
 
   // Read entire file as a single Arrow table
-  std::shared_ptr<arrow::Table> table;
-  ARROW_RETURN_NOT_OK(arrow_reader->ReadTable(&table));
+  ARROW_RETURN_NOT_OK(arrow_reader->ReadTable().status());
   return arrow::Status::OK();
 }
 

--- a/cpp/examples/arrow/parquet_read_write.cc
+++ b/cpp/examples/arrow/parquet_read_write.cc
@@ -37,7 +37,8 @@ arrow::Status ReadFullFile(std::string path_to_file) {
   ARROW_ASSIGN_OR_RAISE(arrow_reader, parquet::arrow::OpenFile(input, pool));
 
   // Read entire file as a single Arrow table
-  ARROW_RETURN_NOT_OK(arrow_reader->ReadTable().status());
+  std::shared_ptr<arrow::Table> table;
+  ARROW_ASSIGN_OR_RAISE(table, arrow_reader->ReadTable());
   return arrow::Status::OK();
 }
 

--- a/cpp/examples/parquet/parquet_arrow/reader_writer.cc
+++ b/cpp/examples/parquet/parquet_arrow/reader_writer.cc
@@ -70,8 +70,7 @@ void read_whole_file() {
   std::unique_ptr<parquet::arrow::FileReader> reader;
   PARQUET_ASSIGN_OR_THROW(reader,
                           parquet::arrow::OpenFile(infile, arrow::default_memory_pool()));
-  std::shared_ptr<arrow::Table> table;
-  PARQUET_THROW_NOT_OK(reader->ReadTable(&table));
+  PARQUET_ASSIGN_OR_THROW(auto table, reader->ReadTable());
   std::cout << "Loaded " << table->num_rows() << " rows in " << table->num_columns()
             << " columns." << std::endl;
 }

--- a/cpp/examples/parquet/parquet_arrow/reader_writer.cc
+++ b/cpp/examples/parquet/parquet_arrow/reader_writer.cc
@@ -70,7 +70,8 @@ void read_whole_file() {
   std::unique_ptr<parquet::arrow::FileReader> reader;
   PARQUET_ASSIGN_OR_THROW(reader,
                           parquet::arrow::OpenFile(infile, arrow::default_memory_pool()));
-  PARQUET_ASSIGN_OR_THROW(auto table, reader->ReadTable());
+  std::shared_ptr<arrow::Table> table;
+  PARQUET_ASSIGN_OR_THROW(table, reader->ReadTable());
   std::cout << "Loaded " << table->num_rows() << " rows in " << table->num_columns()
             << " columns." << std::endl;
 }

--- a/cpp/examples/tutorial_examples/file_access_example.cc
+++ b/cpp/examples/tutorial_examples/file_access_example.cc
@@ -185,9 +185,8 @@ arrow::Status RunMain() {
   // (Doc section: Parquet OpenFile)
 
   // (Doc section: Parquet Read)
-  std::shared_ptr<arrow::Table> parquet_table;
   // Read the table.
-  PARQUET_THROW_NOT_OK(reader->ReadTable(&parquet_table));
+  PARQUET_ASSIGN_OR_THROW(auto parquet_table, reader->ReadTable());
   // (Doc section: Parquet Read)
 
   // (Doc section: Parquet Write)

--- a/cpp/examples/tutorial_examples/file_access_example.cc
+++ b/cpp/examples/tutorial_examples/file_access_example.cc
@@ -186,7 +186,8 @@ arrow::Status RunMain() {
 
   // (Doc section: Parquet Read)
   // Read the table.
-  PARQUET_ASSIGN_OR_THROW(auto parquet_table, reader->ReadTable());
+  std::shared_ptr<arrow::Table> parquet_table;
+  PARQUET_ASSIGN_OR_THROW(parquet_table, reader->ReadTable());
   // (Doc section: Parquet Read)
 
   // (Doc section: Parquet Write)

--- a/cpp/src/arrow/dataset/file_parquet_encryption_test.cc
+++ b/cpp/src/arrow/dataset/file_parquet_encryption_test.cc
@@ -397,8 +397,7 @@ TEST_P(DatasetEncryptionTest, ReadSingleFile) {
   parquet::arrow::FileReaderBuilder reader_builder;
   ASSERT_OK(reader_builder.Open(input, reader_properties));
   ASSERT_OK_AND_ASSIGN(auto arrow_reader, reader_builder.Build());
-  std::shared_ptr<Table> table;
-  ASSERT_OK(arrow_reader->ReadTable(&table));
+  ASSERT_OK_AND_ASSIGN(auto table, arrow_reader->ReadTable());
 
   // Check the contents of the table
   ASSERT_EQ(table->num_rows(), 2);

--- a/cpp/src/arrow/filesystem/s3fs_benchmark.cc
+++ b/cpp/src/arrow/filesystem/s3fs_benchmark.cc
@@ -315,8 +315,8 @@ static void ParquetRead(benchmark::State& st, S3FileSystem* fs, const std::strin
     ASSERT_OK(builder.properties(properties)->Build(&reader));
 
     if (read_strategy == "ReadTable") {
-      std::shared_ptr<Table> table;
-      ASSERT_OK(reader->ReadTable(column_indices, &table));
+      auto table_result = reader->ReadTable(column_indices);
+      ASSERT_OK(table_result.status());
     } else {
       ASSERT_OK_AND_ASSIGN(auto rb_reader, reader->GetRecordBatchReader(
                                                std::vector<int>{0}, column_indices));

--- a/cpp/src/arrow/filesystem/s3fs_benchmark.cc
+++ b/cpp/src/arrow/filesystem/s3fs_benchmark.cc
@@ -315,8 +315,7 @@ static void ParquetRead(benchmark::State& st, S3FileSystem* fs, const std::strin
     ASSERT_OK(builder.properties(properties)->Build(&reader));
 
     if (read_strategy == "ReadTable") {
-      auto table_result = reader->ReadTable(column_indices);
-      ASSERT_OK(table_result.status());
+      ASSERT_OK_AND_ASSIGN(auto table, reader->ReadTable(column_indices));
     } else {
       ASSERT_OK_AND_ASSIGN(auto rb_reader, reader->GetRecordBatchReader(
                                                std::vector<int>{0}, column_indices));

--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -2801,8 +2801,7 @@ TEST(TestArrowReadWrite, ReadCoalescedColumnSubset) {
       {0, 4, 8, 10}, {0, 1, 2, 3}, {5, 17, 18, 19}};
 
   for (std::vector<int>& column_subset : column_subsets) {
-    std::shared_ptr<Table> result;
-    ASSERT_OK_AND_ASSIGN(result, reader->ReadTable(column_subset));
+    ASSERT_OK_AND_ASSIGN(auto result, reader->ReadTable(column_subset));
 
     std::vector<std::shared_ptr<::arrow::ChunkedArray>> ex_columns;
     std::vector<std::shared_ptr<::arrow::Field>> ex_fields;
@@ -2839,8 +2838,7 @@ TEST(TestArrowReadWrite, ListLargeRecords) {
                                              ::arrow::default_memory_pool()));
 
   // Read everything
-  std::shared_ptr<Table> result;
-  ASSERT_OK_AND_ASSIGN(result, reader->ReadTable());
+  ASSERT_OK_AND_ASSIGN(auto result, reader->ReadTable());
   ASSERT_NO_FATAL_FAILURE(::arrow::AssertTablesEqual(*table, *result));
 
   // Read 1 record at a time
@@ -3579,8 +3577,7 @@ void DoNestedValidate(const std::shared_ptr<::arrow::DataType>& inner_type,
   ASSERT_OK(reader_builder.Build(&reader));
   ARROW_SCOPED_TRACE("Parquet schema: ",
                      reader->parquet_reader()->metadata()->schema()->ToString());
-  std::shared_ptr<Table> result;
-  ASSERT_OK_AND_ASSIGN(result, reader->ReadTable());
+  ASSERT_OK_AND_ASSIGN(auto result, reader->ReadTable());
 
   if (inner_type->id() == ::arrow::Type::DATE64 ||
       inner_type->id() == ::arrow::Type::TIMESTAMP ||
@@ -4036,8 +4033,7 @@ class TestNestedSchemaRead : public ::testing::TestWithParam<Repetition::type> {
 TEST_F(TestNestedSchemaRead, ReadIntoTableFull) {
   ASSERT_NO_FATAL_FAILURE(CreateSimpleNestedParquet(Repetition::OPTIONAL));
 
-  std::shared_ptr<Table> table;
-  ASSERT_OK_AND_ASSIGN(table, reader_->ReadTable());
+  ASSERT_OK_AND_ASSIGN(auto table, reader_->ReadTable());
   ASSERT_EQ(table->num_rows(), NUM_SIMPLE_TEST_ROWS);
   ASSERT_EQ(table->num_columns(), 2);
   ASSERT_EQ(table->schema()->field(0)->type()->num_fields(), 2);
@@ -4135,8 +4131,7 @@ TEST_P(TestNestedSchemaRead, DeepNestedSchemaRead) {
   int num_rows = SMALL_SIZE * (depth + 2);
   ASSERT_NO_FATAL_FAILURE(CreateMultiLevelNestedParquet(num_trees, depth, num_children,
                                                         num_rows, GetParam()));
-  std::shared_ptr<Table> table;
-  ASSERT_OK_AND_ASSIGN(table, reader_->ReadTable());
+  ASSERT_OK_AND_ASSIGN(auto table, reader_->ReadTable());
   ASSERT_EQ(table->num_columns(), num_trees);
   ASSERT_EQ(table->num_rows(), num_rows);
 
@@ -4365,8 +4360,7 @@ TEST(TestArrowReaderAdHoc, LegacyTwoLevelList) {
     // Verify Arrow schema and data
     ASSERT_OK_AND_ASSIGN(auto reader,
                          FileReader::Make(default_memory_pool(), std::move(file_reader)));
-    std::shared_ptr<Table> table;
-    ASSERT_OK_AND_ASSIGN(table, reader->ReadTable());
+    ASSERT_OK_AND_ASSIGN(auto table, reader->ReadTable());
     ASSERT_OK(table->ValidateFull());
     AssertTablesEqual(*expected_table, *table);
   };
@@ -4429,8 +4423,7 @@ TEST_P(TestArrowReaderAdHocSparkAndHvr, ReadDecimals) {
 
   ASSERT_OK_AND_ASSIGN(auto arrow_reader,
                        FileReader::Make(pool, ParquetFileReader::OpenFile(path, false)));
-  std::shared_ptr<::arrow::Table> table;
-  ASSERT_OK_AND_ASSIGN(table, arrow_reader->ReadTable());
+  ASSERT_OK_AND_ASSIGN(auto table, arrow_reader->ReadTable());
 
   std::shared_ptr<::arrow::Schema> schema;
   ASSERT_OK_NO_THROW(arrow_reader->GetSchema(&schema));
@@ -4495,8 +4488,7 @@ TEST(TestArrowReaderAdHoc, ReadFloat16Files) {
 
     ASSERT_OK_AND_ASSIGN(
         auto reader, FileReader::Make(pool, ParquetFileReader::OpenFile(path, false)));
-    std::shared_ptr<::arrow::Table> table;
-    ASSERT_OK_AND_ASSIGN(table, reader->ReadTable());
+    ASSERT_OK_AND_ASSIGN(auto table, reader->ReadTable());
 
     std::shared_ptr<::arrow::Schema> schema;
     ASSERT_OK_NO_THROW(reader->GetSchema(&schema));
@@ -4907,8 +4899,7 @@ class TestArrowReadDictionary : public ::testing::TestWithParam<double> {
   void CheckReadWholeFile(const Table& expected) {
     ASSERT_OK_AND_ASSIGN(auto reader, GetReader());
 
-    std::shared_ptr<Table> actual;
-    ASSERT_OK_AND_ASSIGN(actual, reader->ReadTable());
+    ASSERT_OK_AND_ASSIGN(auto actual, reader->ReadTable());
     ::arrow::AssertTablesEqual(expected, *actual, /*same_chunk_layout=*/false);
   }
 
@@ -5005,8 +4996,7 @@ TEST_P(TestArrowReadDictionary, IncrementalReads) {
 
   // Read in one shot
   ASSERT_OK_AND_ASSIGN(std::unique_ptr<FileReader> reader, GetReader());
-  std::shared_ptr<Table> expected;
-  ASSERT_OK_AND_ASSIGN(expected, reader->ReadTable());
+  ASSERT_OK_AND_ASSIGN(auto expected, reader->ReadTable());
 
   ASSERT_OK_AND_ASSIGN(reader, GetReader());
   std::unique_ptr<ColumnReader> col;
@@ -5340,8 +5330,7 @@ TEST_P(TestNestedSchemaFilteredReader, ReadWrite) {
   FileReaderBuilder builder;
   ASSERT_OK_NO_THROW(builder.Open(std::make_shared<BufferReader>(buffer)));
   ASSERT_OK(builder.properties(default_arrow_reader_properties())->Build(&reader));
-  std::shared_ptr<::arrow::Table> read_table;
-  ASSERT_OK_AND_ASSIGN(read_table, reader->ReadTable(GetParam().indices_to_read));
+  ASSERT_OK_AND_ASSIGN(auto read_table, reader->ReadTable(GetParam().indices_to_read));
 
   std::shared_ptr<::arrow::Array> expected =
       ArrayFromJSON(GetParam().expected_schema, GetParam().read_data);
@@ -5817,10 +5806,9 @@ TEST(TestArrowReadWrite, MultithreadedWrite) {
   ASSERT_OK_AND_ASSIGN(auto buffer, sink->Finish());
 
   // Read to verify the data.
-  std::shared_ptr<Table> result;
   ASSERT_OK_AND_ASSIGN(auto reader,
                        OpenFile(std::make_shared<BufferReader>(buffer), pool));
-  ASSERT_OK_AND_ASSIGN(result, reader->ReadTable());
+  ASSERT_OK_AND_ASSIGN(auto result, reader->ReadTable());
   ASSERT_NO_FATAL_FAILURE(::arrow::AssertTablesEqual(*table, *result));
 }
 

--- a/cpp/src/parquet/arrow/reader.h
+++ b/cpp/src/parquet/arrow/reader.h
@@ -235,7 +235,11 @@ class PARQUET_EXPORT FileReader {
                           int64_t rows_to_readahead = 0) = 0;
 
   /// Read all columns into a Table
-  virtual ::arrow::Status ReadTable(std::shared_ptr<::arrow::Table>* out) = 0;
+  virtual ::arrow::Result<std::shared_ptr<::arrow::Table>> ReadTable() = 0;
+
+  /// \deprecated Deprecated in 24.0.0. Use arrow::Result version instead.
+  ARROW_DEPRECATED("Deprecated in 24.0.0. Use arrow::Result version instead.")
+  ::arrow::Status ReadTable(std::shared_ptr<::arrow::Table>* out);
 
   /// \brief Read the given columns into a Table
   ///
@@ -254,8 +258,13 @@ class PARQUET_EXPORT FileReader {
   /// manifest().schema_fields to get the top level fields, and then walk the
   /// tree to identify the relevant leaf fields and access its column_index.
   /// To get the total number of leaf fields, use FileMetadata.num_columns().
-  virtual ::arrow::Status ReadTable(const std::vector<int>& column_indices,
-                                    std::shared_ptr<::arrow::Table>* out) = 0;
+  virtual ::arrow::Result<std::shared_ptr<::arrow::Table>> ReadTable(
+      const std::vector<int>& column_indices) = 0;
+
+  /// \deprecated Deprecated in 24.0.0. Use arrow::Result version instead.
+  ARROW_DEPRECATED("Deprecated in 24.0.0. Use arrow::Result version instead.")
+  ::arrow::Status ReadTable(const std::vector<int>& column_indices,
+                            std::shared_ptr<::arrow::Table>* out);
 
   virtual ::arrow::Status ReadRowGroup(int i, const std::vector<int>& column_indices,
                                        std::shared_ptr<::arrow::Table>* out) = 0;

--- a/cpp/src/parquet/arrow/reader_writer_benchmark.cc
+++ b/cpp/src/parquet/arrow/reader_writer_benchmark.cc
@@ -301,8 +301,8 @@ static void BenchmarkReadTable(::benchmark::State& state, const Table& table,
     EXIT_NOT_OK(arrow_reader_result.status());
     auto arrow_reader = std::move(*arrow_reader_result);
 
-    std::shared_ptr<Table> table;
-    EXIT_NOT_OK(arrow_reader->ReadTable(&table));
+    auto table_result = arrow_reader->ReadTable();
+    EXIT_NOT_OK(table_result.status());
   }
 
   if (num_values == -1) {

--- a/cpp/src/parquet/chunker_internal_test.cc
+++ b/cpp/src/parquet/chunker_internal_test.cc
@@ -319,7 +319,6 @@ Result<std::shared_ptr<Table>> ConcatAndCombine(
 }
 
 Result<std::shared_ptr<Table>> ReadTableFromBuffer(const std::shared_ptr<Buffer>& data) {
-  std::shared_ptr<Table> result;
   FileReaderBuilder builder;
   std::unique_ptr<FileReader> reader;
   auto props = default_arrow_reader_properties();
@@ -329,7 +328,7 @@ Result<std::shared_ptr<Table>> ReadTableFromBuffer(const std::shared_ptr<Buffer>
   RETURN_NOT_OK(builder.memory_pool(::arrow::default_memory_pool())
                     ->properties(props)
                     ->Build(&reader));
-  RETURN_NOT_OK(reader->ReadTable(&result));
+  ARROW_ASSIGN_OR_RAISE(auto result, reader->ReadTable());
   return result;
 }
 

--- a/python/pyarrow/_parquet.pyx
+++ b/python/pyarrow/_parquet.pyx
@@ -1847,7 +1847,7 @@ cdef class ParquetReader(_Weakrefable):
         table : pyarrow.Table
         """
         cdef:
-            shared_ptr[CTable] ctable
+            CResult[shared_ptr[CTable]] table_result
             vector[int] c_column_indices
 
         self.set_use_threads(use_threads)
@@ -1857,14 +1857,12 @@ cdef class ParquetReader(_Weakrefable):
                 c_column_indices.push_back(index)
 
             with nogil:
-                check_status(self.reader.get()
-                             .ReadTable(c_column_indices, &ctable))
+                table_result = self.reader.get().ReadTable(c_column_indices)
         else:
             # Read all columns
             with nogil:
-                check_status(self.reader.get()
-                             .ReadTable(&ctable))
-        return pyarrow_wrap_table(ctable)
+                table_result = self.reader.get().ReadTable()
+        return pyarrow_wrap_table(GetResultValue(table_result))
 
     def scan_contents(self, column_indices=None, batch_size=65536):
         """

--- a/python/pyarrow/includes/libparquet.pxd
+++ b/python/pyarrow/includes/libparquet.pxd
@@ -548,9 +548,8 @@ cdef extern from "parquet/arrow/reader.h" namespace "parquet::arrow" nogil:
                                                                      const vector[int]& column_indices)
         CResult[unique_ptr[CRecordBatchReader]] GetRecordBatchReader(const vector[int]& row_group_indices)
 
-        CStatus ReadTable(shared_ptr[CTable]* out)
-        CStatus ReadTable(const vector[int]& column_indices,
-                          shared_ptr[CTable]* out)
+        CResult[shared_ptr[CTable]] ReadTable()
+        CResult[shared_ptr[CTable]] ReadTable(const vector[int]& column_indices)
 
         CStatus ScanContents(vector[int] columns, int32_t column_batch_size,
                              int64_t* num_rows)

--- a/r/src/parquet.cpp
+++ b/r/src/parquet.cpp
@@ -130,24 +130,18 @@ std::shared_ptr<parquet::arrow::FileReader> parquet___arrow___FileReader__OpenFi
 // [[parquet::export]]
 std::shared_ptr<arrow::Table> parquet___arrow___FileReader__ReadTable1(
     const std::shared_ptr<parquet::arrow::FileReader>& reader) {
-  std::shared_ptr<arrow::Table> table;
-  auto result =
-      RunWithCapturedRIfPossibleVoid([&]() { return reader->ReadTable(&table); });
-
-  StopIfNotOk(result);
-  return table;
+  auto result = RunWithCapturedRIfPossible<std::shared_ptr<arrow::Table>>(
+      [&]() { return reader->ReadTable(); });
+  return ValueOrStop(result);
 }
 
 // [[parquet::export]]
 std::shared_ptr<arrow::Table> parquet___arrow___FileReader__ReadTable2(
     const std::shared_ptr<parquet::arrow::FileReader>& reader,
     const std::vector<int>& column_indices) {
-  std::shared_ptr<arrow::Table> table;
-  auto result = RunWithCapturedRIfPossibleVoid(
-      [&]() { return reader->ReadTable(column_indices, &table); });
-
-  StopIfNotOk(result);
-  return table;
+  auto result = RunWithCapturedRIfPossible<std::shared_ptr<arrow::Table>>(
+      [&]() { return reader->ReadTable(column_indices); });
+  return ValueOrStop(result);
 }
 
 // [[parquet::export]]


### PR DESCRIPTION
### Rationale for this change
`FileReader::ReadTable` previously returned `Status` and required callers to pass an `out` parameter.
### What changes are included in this PR?
Introduce `Result<std::shared_ptr<Table>>` returning API to allow clearer error propagation:
  - Add new Result-returning `ReadTable()` methods
  - Deprecate the old Status versions
  - Migrate all callers to use the new API
### Are these changes tested?
Yes.
### Are there any user-facing changes?
Yes.

Status version FileReader::ReadTable has been deprecated.
```cpp
virtual ::arrow::Status ReadTable(std::shared_ptr<::arrow::Table>* out);

virtual ::arrow::Status ReadTable(const std::vector<int>& column_indices,
                                  std::shared_ptr<::arrow::Table>* out);
```
* GitHub Issue: #48394