### PR TITLE
GH-48942: [Ruby] Add support for writing float32/64 arrays

### DIFF
--- a/ruby/red-arrow-format/lib/arrow-format/type.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/type.rb
@@ -282,6 +282,12 @@ module ArrowFormat
       super()
       @precision = precision
     end
+
+    def to_flatbuffers
+      fb_type = FB::FloatingPoint::Data.new
+      fb_type.precision = FB::Precision.try_convert(@precision.to_s.upcase)
+      fb_type
+    end
   end
 
   class Float32Type < FloatingPointType

--- a/ruby/red-arrow-format/test/test-writer.rb
+++ b/ruby/red-arrow-format/test/test-writer.rb
@@ -38,6 +38,10 @@ module WriterTests
       ArrowFormat::Int64Type.singleton
     when Arrow::UInt64DataType
       ArrowFormat::UInt64Type.singleton
+    when Arrow::FloatDataType
+      ArrowFormat::Float32Type.singleton
+    when Arrow::DoubleDataType
+      ArrowFormat::Float64Type.singleton
     when Arrow::BinaryDataType
       ArrowFormat::BinaryType.singleton
     when Arrow::StringDataType
@@ -188,6 +192,28 @@ module WriterTests
 
           def test_write
             assert_equal([0, nil, 18446744073709551615],
+                         @values)
+          end
+        end
+
+        sub_test_case("Float32") do
+          def build_array
+            Arrow::FloatArray.new([-0.5, nil, 0.5])
+          end
+
+          def test_write
+            assert_equal([-0.5, nil, 0.5],
+                         @values)
+          end
+        end
+
+        sub_test_case("Float64") do
+          def build_array
+            Arrow::DoubleArray.new([-0.5, nil, 0.5])
+          end
+
+          def test_write
+            assert_equal([-0.5, nil, 0.5],
                          @values)
           end
         end


### PR DESCRIPTION
### Rationale for this change

They are floating point array variants.

### What changes are included in this PR?

Add `ArrowFormat::FloatingPointType#to_flatbuffers`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #48942