### PR TITLE
GH-48947 [CI][Python] Install pymanager.msi instead of pymanager.msix to fix docker rebuild on Windows wheels

### DIFF
--- a/.env
+++ b/.env
@@ -102,8 +102,8 @@ VCPKG="4334d8b4c8916018600212ab4dd4bbdc343065d1"    # 2025.09.17 Release
 # ci/docker/python-*-windows-*.dockerfile or the vcpkg config.
 # This is a workaround for our CI problem that "archery docker build" doesn't
 # use pulled built images in dev/tasks/python-wheels/github.windows.yml.
-PYTHON_WHEEL_WINDOWS_IMAGE_REVISION=2025-10-13
-PYTHON_WHEEL_WINDOWS_TEST_IMAGE_REVISION=2025-10-13
+PYTHON_WHEEL_WINDOWS_IMAGE_REVISION=2026-01-22
+PYTHON_WHEEL_WINDOWS_TEST_IMAGE_REVISION=2026-01-22
 
 # Use conanio/${CONAN_BASE}:{CONAN_VERSION} for "docker compose run --rm conan".
 # See https://github.com/conan-io/conan-docker-tools#readme and

--- a/ci/docker/python-wheel-windows-vs2022-base.dockerfile
+++ b/ci/docker/python-wheel-windows-vs2022-base.dockerfile
@@ -84,21 +84,13 @@ RUN `
   [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; `
   iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
 
-# Install the Python install manager
-#
-# See https://docs.python.org/dev/using/windows.html#python-install-manager and
-# https://www.python.org/ftp/python/pymanager/
-RUN `
-  $pymanager_url = 'https://www.python.org/ftp/python/pymanager/python-manager-25.0.msix'; `
-  Invoke-WebRequest -Uri $pymanager_url -OutFile 'C:\Windows\pymanager.msix'; `
-  Add-AppxPackage C:\Windows\pymanager.msix
-
 SHELL ["cmd", "/S", "/C"]
 
 # Install CMake and other tools
 ARG cmake=3.31.2
 RUN choco install --no-progress -r -y cmake --version=%cmake% --installargs 'ADD_CMAKE_TO_PATH=System'
 RUN choco install --no-progress -r -y git gzip ninja wget
+RUN choco install --no-progress -r -y pymanager
 
 # Add UNIX tools to PATH
 RUN setx path "%path%;C:\Program Files\Git\usr\bin"

--- a/ci/docker/python-wheel-windows-vs2022-base.dockerfile
+++ b/ci/docker/python-wheel-windows-vs2022-base.dockerfile
@@ -87,7 +87,7 @@ RUN `
 SHELL ["cmd", "/S", "/C"]
 
 # Install CMake and other tools
-ARG cmake=3.31.2
+ARG cmake=3.31.9
 RUN choco install --no-progress -r -y cmake --version=%cmake% --installargs 'ADD_CMAKE_TO_PATH=System'
 RUN choco install --no-progress -r -y git gzip ninja wget
 RUN choco install --no-progress -r -y pymanager

--- a/ci/docker/python-wheel-windows-vs2022-base.dockerfile
+++ b/ci/docker/python-wheel-windows-vs2022-base.dockerfile
@@ -84,13 +84,22 @@ RUN `
   [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; `
   iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
 
+# Install the Python install manager
+#
+# See https://docs.python.org/dev/using/windows.html#python-install-manager and
+# https://www.python.org/ftp/python/pymanager/
+RUN `
+  $pymanager_url = 'https://www.python.org/ftp/python/pymanager/python-manager-25.0.msi'; `
+  Invoke-WebRequest -Uri $pymanager_url -OutFile 'C:\Windows\pymanager.msi'; `
+  Start-Process msiexec.exe -Wait -ArgumentList '/i C:\Windows\pymanager.msi /quiet /norestart'; `
+  Remove-Item C:\Windows\pymanager.msi
+
 SHELL ["cmd", "/S", "/C"]
 
 # Install CMake and other tools
 ARG cmake=3.31.9
 RUN choco install --no-progress -r -y cmake --version=%cmake% --installargs 'ADD_CMAKE_TO_PATH=System'
 RUN choco install --no-progress -r -y git gzip ninja wget
-RUN choco install --no-progress -r -y pymanager
 
 # Add UNIX tools to PATH
 RUN setx path "%path%;C:\Program Files\Git\usr\bin"

--- a/ci/docker/python-wheel-windows-vs2022.dockerfile
+++ b/ci/docker/python-wheel-windows-vs2022.dockerfile
@@ -34,6 +34,6 @@ RUN py -%PYTHON_VERSION% -m pip install -U pip setuptools
 COPY python/requirements-wheel-build.txt C:/arrow/python/
 RUN py -%PYTHON_VERSION% -m pip install -r C:/arrow/python/requirements-wheel-build.txt
 
-ENV PYTHON_CMD="py -${python}"
+ENV PYTHON_CMD="py -${python}${python_variant_suffix}"
 
 ENV PYTHON=${python}

--- a/ci/docker/python-wheel-windows-vs2022.dockerfile
+++ b/ci/docker/python-wheel-windows-vs2022.dockerfile
@@ -27,7 +27,8 @@ ARG python=3.10
 ARG python_variant=default
 ENV PYTHON_VERSION=${python}
 ENV PYTHON_VARIANT=${python_variant}
-RUN pymanager install --version %PYTHON_VERSION% --variant %PYTHON_VARIANT%
+# TODO: Fix pymanager to support freethread variants
+RUN pymanager install %PYTHON_VERSION%
 
 RUN py -%PYTHON_VERSION% -m pip install -U pip setuptools
 

--- a/ci/docker/python-wheel-windows-vs2022.dockerfile
+++ b/ci/docker/python-wheel-windows-vs2022.dockerfile
@@ -35,4 +35,6 @@ RUN py -%PYTHON_VERSION% -m pip install -U pip setuptools
 COPY python/requirements-wheel-build.txt C:/arrow/python/
 RUN py -%PYTHON_VERSION% -m pip install -r C:/arrow/python/requirements-wheel-build.txt
 
+ENV PYTHON_CMD="py -${python}"
+
 ENV PYTHON=${python}

--- a/ci/docker/python-wheel-windows-vs2022.dockerfile
+++ b/ci/docker/python-wheel-windows-vs2022.dockerfile
@@ -24,10 +24,9 @@ FROM ${base}
 # Define the full version number otherwise choco falls back to patch number 0 (3.10 => 3.10.0)
 ARG python=3.10
 
-ARG python_variant=default
-ENV PYTHON_VERSION=${python}
-ENV PYTHON_VARIANT=${python_variant}
-# TODO: Fix pymanager to support freethread variants
+ARG python_variant_suffix=""
+ENV PYTHON_VERSION=${python}${python_variant_suffix}
+
 RUN pymanager install %PYTHON_VERSION%
 
 RUN py -%PYTHON_VERSION% -m pip install -U pip setuptools

--- a/compose.yaml
+++ b/compose.yaml
@@ -1388,7 +1388,6 @@ services:
       args:
         base: ${REPO}:python-wheel-windows-vs2022-base-vcpkg-${VCPKG}-${PYTHON_WHEEL_WINDOWS_IMAGE_REVISION}
         python: ${PYTHON}
-        python_variant: default
       context: .
       dockerfile: ci/docker/python-wheel-windows-vs2022.dockerfile
       # This should make the pushed images reusable, but the image gets rebuilt.
@@ -1405,7 +1404,7 @@ services:
       args:
         base: ${REPO}:python-wheel-windows-vs2022-base-vcpkg-${VCPKG}-${PYTHON_WHEEL_WINDOWS_IMAGE_REVISION}
         python: ${PYTHON}
-        python_variant: freethreaded
+        python_variant_suffix: t
       context: .
       dockerfile: ci/docker/python-wheel-windows-vs2022.dockerfile
       # This should make the pushed images reusable, but the image gets rebuilt.


### PR DESCRIPTION
### Rationale for this change

As soon as we have to rebuild our Windows docker images they will fail installing python-manager-25.0.msix

### What changes are included in this PR?

- Use `pymanager.msi` to install python version instead of `pymanager.msix` which has problems on Docker.
- Update `pymanager install` command to use newer API (old command fails with missing flags)
- Update default python command to use the free-threaded required suffix if free-threaded wheels

### Are these changes tested?

Yes via archery

### Are there any user-facing changes?

No
* GitHub Issue: #48947