### PR TITLE
GH-48954: [C++] Add test for null-type dictionary sorting and clarify XXX comment

### DIFF
--- a/cpp/src/arrow/compute/kernels/vector_array_sort.cc
+++ b/cpp/src/arrow/compute/kernels/vector_array_sort.cc
@@ -237,7 +237,6 @@ class ArrayCompareSorter<DictionaryType> {
     RankOptions rank_options(SortOrder::Ascending, NullPlacement::AtEnd,
                              RankOptions::Dense);
 
-    // XXX Should this support Type::NA?
     auto data = array->data();
     std::shared_ptr<Buffer> null_bitmap;
     if (array->null_count() > 0) {

--- a/cpp/src/arrow/compute/kernels/vector_sort_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort_test.cc
@@ -444,7 +444,7 @@ TEST(ArraySortIndicesFunction, NullTypeDictionaryArray) {
   for (const auto& index_type : all_dictionary_index_types()) {
     ARROW_SCOPED_TRACE("index_type = ", index_type->ToString());
     auto dict_type = dictionary(index_type, null());
-    auto dict_arr = DictArrayFromJSON(dict_type, "[null, null, null, null]", "[]");
+    auto dict_arr = DictArrayFromJSON(dict_type, "[null, 0, 0, null]", "[null]");
 
     for (auto null_placement : AllNullPlacements()) {
       ArraySortOptions options{SortOrder::Ascending, null_placement};

--- a/cpp/src/arrow/compute/kernels/vector_sort_test.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort_test.cc
@@ -437,6 +437,27 @@ TEST(ArraySortIndicesFunction, AllNullDictionaryArray) {
   }
 }
 
+TEST(ArraySortIndicesFunction, NullTypeDictionaryArray) {
+  // Test that dictionaries with Type::NA (null type) values can be sorted.
+  // All values in a null-type dictionary are logically null, so sorting
+  // should just arrange indices based on null placement, preserving order.
+  for (const auto& index_type : all_dictionary_index_types()) {
+    ARROW_SCOPED_TRACE("index_type = ", index_type->ToString());
+    auto dict_type = dictionary(index_type, null());
+    auto dict_arr = DictArrayFromJSON(dict_type, "[null, null, null, null]", "[]");
+
+    for (auto null_placement : AllNullPlacements()) {
+      ArraySortOptions options{SortOrder::Ascending, null_placement};
+      // All nulls, so output should be identity permutation
+      auto expected = ArrayFromJSON(uint64(), "[0, 1, 2, 3]");
+      ASSERT_OK_AND_ASSIGN(auto actual,
+                           CallFunction("array_sort_indices", {dict_arr}, &options));
+      ValidateOutput(actual);
+      AssertDatumsEqual(expected, actual, /*verbose=*/true);
+    }
+  }
+}
+
 Result<std::shared_ptr<Array>> DecodeDictionary(const Array& array) {
   const auto& dict_array = checked_cast<const DictionaryArray&>(array);
   ARROW_ASSIGN_OR_RAISE(auto decoded_datum,


### PR DESCRIPTION
### Rationale for this change

Null-type dictionaries (e.g., `dictionary(int8(), null())`) are valid Arrow constructs supported from day one, but the sorting code had an uncertain `XXX Should this support Type::NA?` comment. We should explicitly support and test this because other functions already support this:

```python
import pyarrow as pa
import pyarrow.compute as pc

pc.array_sort_indices(pa.array([None, None, None, None], type=pa.int32()))
# [0, 1, 2, 3]
pc.array_sort_indices(pa.DictionaryArray.from_arrays(
    indices=pa.array([None, None, None, None], type=pa.int8()),
    dictionary=pa.array([], type=pa.null())
))
# [0, 1, 2, 3]
```

I believe it does not make sense to specifically disallow this in dictionaries at this point.

### What changes are included in this PR?

Added a unittest for null sorting behaviour.

### Are these changes tested?

Yes, the unittest was added.

### Are there any user-facing changes?

No.
* GitHub Issue: #48954