### PR TITLE
GH-48957: [Benchmarking] Add temporal type support to benchmarks

### DIFF
--- a/python/benchmarks/array_ops.py
+++ b/python/benchmarks/array_ops.py
@@ -17,18 +17,27 @@
 
 import pyarrow as pa
 
+from . import common
+
 
 class ScalarAccess(object):
     n = 10 ** 5
+    types = ('int64', 'float64', 'bool', 'decimal', 'binary', 'ascii',
+             'unicode', 'date32', 'timestamp', 'time64', 'duration')
 
-    def setUp(self):
-        self._array = pa.array(list(range(self.n)), type=pa.int64())
+    param_names = ['type']
+    params = [types]
+
+    def setup(self, type_name):
+        gen = common.BuiltinsGenerator()
+        ty, data = gen.get_type_and_builtins(self.n, type_name)
+        self._array = pa.array(data, type=ty)
         self._array_items = list(self._array)
 
-    def time_getitem(self):
+    def time_getitem(self, *args):
         for i in range(self.n):
             self._array[i]
 
-    def time_as_py(self):
+    def time_as_py(self, *args):
         for item in self._array_items:
             item.as_py()

--- a/python/benchmarks/convert_builtins.py
+++ b/python/benchmarks/convert_builtins.py
@@ -20,10 +20,6 @@ import pyarrow as pa
 from . import common
 
 
-# TODO:
-# - test dates and times
-
-
 class ConvertPyListToArray(object):
     """
     Benchmark pa.array(list of values, type=...)
@@ -32,7 +28,8 @@ class ConvertPyListToArray(object):
     types = ('int32', 'uint32', 'int64', 'uint64',
              'float32', 'float64', 'bool', 'decimal',
              'binary', 'binary10', 'ascii', 'unicode',
-             'int64 list', 'struct', 'struct from tuples')
+             'int64 list', 'struct', 'struct from tuples',
+             'date32', 'timestamp', 'time64', 'duration')
 
     param_names = ['type']
     params = [types]
@@ -51,7 +48,8 @@ class InferPyListToArray(object):
     """
     size = 10 ** 5
     types = ('int64', 'float64', 'bool', 'decimal', 'binary', 'ascii',
-             'unicode', 'int64 list', 'struct')
+             'unicode', 'int64 list', 'struct',
+             'date32', 'timestamp', 'time64', 'duration')
 
     param_names = ['type']
     params = [types]
@@ -73,7 +71,8 @@ class ConvertArrayToPyList(object):
     types = ('int32', 'uint32', 'int64', 'uint64',
              'float32', 'float64', 'bool', 'decimal',
              'binary', 'binary10', 'ascii', 'unicode',
-             'int64 list', 'struct')
+             'int64 list', 'struct',
+             'date32', 'timestamp', 'time64', 'duration')
 
     param_names = ['type']
     params = [types]

--- a/python/benchmarks/microbenchmarks.py
+++ b/python/benchmarks/microbenchmarks.py
@@ -22,7 +22,8 @@ from . import common
 
 class PandasObjectIsNull(object):
     size = 10 ** 5
-    types = ('int', 'float', 'object', 'decimal')
+    types = ('int', 'float', 'object', 'decimal',
+             'date32', 'timestamp', 'time64', 'duration')
 
     param_names = ['type']
     params = [types]
@@ -37,6 +38,14 @@ class PandasObjectIsNull(object):
             lst = gen.generate_object_list(self.size)
         elif type_name == 'decimal':
             lst = gen.generate_decimal_list(self.size)
+        elif type_name == 'date32':
+            lst = gen.generate_date_list(self.size)
+        elif type_name == 'timestamp':
+            lst = gen.generate_timestamp_list(self.size)
+        elif type_name == 'time64':
+            lst = gen.generate_time_list(self.size)
+        elif type_name == 'duration':
+            lst = gen.generate_duration_list(self.size)
         else:
             assert 0
         self.lst = lst


### PR DESCRIPTION
### Rationale for this change

The Python benchmark suite was missing coverage for temporal types (date, timestamp, time, duration), making it difficult to check performance of temporal type conversions over time. There was a TODO comment in `convert_builtins.py` for this.

### What changes are included in this PR?

- Added temporal type generators to `benchmarks/common.py` for date, timestamp, time, and duration
- Extended `convert_builtins.py`, `microbenchmarks.py`, and `array_ops.py` benchmarks to include temporal types

### Are these changes tested?

Tested as follows:

```bash
cd /.../arrow/python
pip install -e . --no-build-isolation
asv run --show-stderr --bench "convert_builtins" -E existing
asv run --show-stderr --bench "microbenchmarks" -E existing
asv run --show-stderr --bench "array_ops" -E existing
```

### Are there any user-facing changes?

No.
* GitHub Issue: #48957