### PR TITLE
GH-48966: [C++] Fix cookie duplication in the Flight SQL ODBC driver and the Flight Client

### DIFF
--- a/cpp/src/arrow/flight/cookie_internal.cc
+++ b/cpp/src/arrow/flight/cookie_internal.cc
@@ -64,6 +64,11 @@ size_t CaseInsensitiveHash::operator()(const std::string& key) const {
   return std::hash<std::string>{}(upper_string);
 }
 
+bool CaseInsensitiveEqual::operator()(const std::string& lhs,
+                                      const std::string& rhs) const {
+  return strcasecmp(lhs.c_str(), rhs.c_str()) == 0;
+}
+
 Cookie Cookie::Parse(std::string_view cookie_header_value) {
   // Parse the cookie string. If the cookie has an expiration, record it.
   // If the cookie has a max-age, calculate the current time + max_age and set that as

--- a/cpp/src/arrow/flight/cookie_internal.h
+++ b/cpp/src/arrow/flight/cookie_internal.h
@@ -41,6 +41,12 @@ class ARROW_FLIGHT_EXPORT CaseInsensitiveComparator {
   bool operator()(const std::string& t1, const std::string& t2) const;
 };
 
+/// \brief Case insensitive equality comparator for use by unordered cookie map.
+class ARROW_FLIGHT_EXPORT CaseInsensitiveEqual {
+ public:
+  bool operator()(const std::string& lhs, const std::string& rhs) const;
+};
+
 /// \brief Case insensitive hasher for use by cookie caching map. Cookies are not
 /// case-sensitive.
 class ARROW_FLIGHT_EXPORT CaseInsensitiveHash {
@@ -117,7 +123,7 @@ class ARROW_FLIGHT_EXPORT CookieCache {
 
   // Mutex must be used to protect cookie cache.
   std::mutex mutex_;
-  std::unordered_map<std::string, Cookie, CaseInsensitiveHash, CaseInsensitiveComparator>
+  std::unordered_map<std::string, Cookie, CaseInsensitiveHash, CaseInsensitiveEqual>
       cookies;
 };
 

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/flight_sql_connection.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/flight_sql_connection.cc
@@ -157,9 +157,6 @@ void FlightSqlConnection::Connect(const ConnPropertyMap& properties,
     client_options_ =
         BuildFlightClientOptions(properties, missing_attr, flight_ssl_configs);
 
-    const std::shared_ptr<ClientMiddlewareFactory>& cookie_factory = GetCookieFactory();
-    client_options_.middleware.push_back(cookie_factory);
-
     std::unique_ptr<FlightClient> flight_client;
     ThrowIfNotOK(FlightClient::Connect(location, client_options_).Value(&flight_client));
     PopulateMetadataSettings(properties);


### PR DESCRIPTION

### Rationale for this change

The bug breaks a Flight SQL server that refreshens the auth token when cookie authentication is enabled

### What changes are included in this PR?

1. In the ODBC layer, removed the code that adds a 2nd ClientCookieMiddlewareFactory in the client options (the 1st one is registered in `BuildFlightClientOptions`). This fixes the issue of the duplicate header cookie fields.
2. In the flight client layer, uses the case-insensitive equality comparator instead of the case-insensitive less-than comparator for the cookies cache which is an unordered map. This fixes the issue of duplicate cookie keys.

### Are these changes tested?
Manually on Windows, and CI

### Are there any user-facing changes?

No
* GitHub Issue: #48966