### PR TITLE
GH-48965: [Python][C++] Compare unique_ptr for CFlightResult or CFlightInfo to nullptr instead of NULL

### DIFF
--- a/python/pyarrow/_flight.pyx
+++ b/python/pyarrow/_flight.pyx
@@ -1666,7 +1666,7 @@ cdef class FlightClient(_Weakrefable):
                 result = Result.__new__(Result)
                 with nogil:
                     check_flight_status(results.get().Next().Value(&result.result))
-                    if result.result == NULL:
+                    if result.result == nullptr:
                         break
                 yield result
         return _do_action_response()
@@ -1695,7 +1695,7 @@ cdef class FlightClient(_Weakrefable):
                 result = FlightInfo.__new__(FlightInfo)
                 with nogil:
                     check_flight_status(listing.get().Next().Value(&result.info))
-                    if result.info == NULL:
+                    if result.info == nullptr:
                         break
                 yield result
 


### PR DESCRIPTION
### Rationale for this change

Cython built code is currently failing to compile on free threaded wheels due to:
```
/arrow/python/build/temp.linux-x86_64-cpython-313t/_flight.cpp: In function ‘PyObject* __pyx_gb_7pyarrow_7_flight_12FlightClient_9do_action_2generator2(__pyx_CoroutineObject*, PyThreadState*, PyObject*)’:
/arrow/python/build/temp.linux-x86_64-cpython-313t/_flight.cpp:43068:110: error: call of overloaded ‘unique_ptr(NULL)’ is ambiguous
43068 |           __pyx_t_3 = (__pyx_cur_scope->__pyx_v_result->result == ((std::unique_ptr< arrow::flight::Result> )NULL));
      |                            
```

### What changes are included in this PR?

Update comparing `unique_ptr[CFlightResult]` and `unique_ptr[CFlightInfo]` from `NULL` to `nullptr`.

### Are these changes tested?

Yes via archery.

### Are there any user-facing changes?

No

* GitHub Issue: #48965