### PR TITLE
GH-48912: [R] Configure C++20 in conda R on continuous benchmarking

### DIFF
--- a/dev/conbench_envs/hooks.sh
+++ b/dev/conbench_envs/hooks.sh
@@ -59,6 +59,25 @@ build_arrow_python() {
 
 build_arrow_r() {
   cat ci/etc/rprofile >> $(R RHOME)/etc/Rprofile.site
+
+  # Ensure CXX20 is configured in R's Makeconf.
+  # conda-forge's R may not have CXX20 set even though the compiler supports it.
+  # Arrow requires C++20, so we need to add these settings if missing.
+  MAKECONF="$(R RHOME)/etc/Makeconf"
+  if ! grep -q "^CXX20 " "$MAKECONF"; then
+    echo "*** CXX20 not configured in R, adding it to Makeconf"
+    cat >> "$MAKECONF" << 'EOF'
+
+# Added for Arrow C++20 support
+CXX20 = g++
+CXX20FLAGS = -g -O2 $(LTO)
+CXX20PICFLAGS = -fpic
+CXX20STD = -std=gnu++20
+SHLIB_CXX20LD = $(CXX20) $(CXX20STD)
+SHLIB_CXX20LDFLAGS = -shared
+EOF
+  fi
+
   ci/scripts/r_deps.sh $(pwd) $(pwd)
   (cd r; R CMD INSTALL .;)
 }

--- a/dev/conbench_envs/hooks.sh
+++ b/dev/conbench_envs/hooks.sh
@@ -61,10 +61,10 @@ build_arrow_r() {
   cat ci/etc/rprofile >> $(R RHOME)/etc/Rprofile.site
 
   # Ensure CXX20 is configured in R's Makeconf.
-  # conda-forge's R may not have CXX20 set even though the compiler supports it.
+  # conda-forge's R may have empty CXX20 entries even though the compiler supports it.
   # Arrow requires C++20, so we need to add these settings if missing.
   MAKECONF="$(R RHOME)/etc/Makeconf"
-  if ! grep -q "^CXX20 " "$MAKECONF"; then
+  if [ -z "$(R CMD config CXX20)" ]; then
     echo "*** CXX20 not configured in R, adding it to Makeconf"
     cat >> "$MAKECONF" << 'EOF'
 


### PR DESCRIPTION
### Rationale for this change

Benchmark failing since C++20 upgrade due to lack of C++20 configuration

### What changes are included in this PR?

Changes entirely from :robot: (Claude) with discussion from me regarding optimal approach.  

Description as follows:

> conda-forge's R package doesn't have CXX20 configured in Makeconf, even though the compiler (gcc 14.3.0) supports C++20. This causes Arrow R package installation to fail with "a C++20 compiler is required" because `R CMD config CXX20` returns empty. 
>
> This PR adds CXX20 configuration to R's Makeconf before building the Arrow R package in the benchmark hooks, if not already present.                                                               

### Are these changes tested?

I got :robot:  to try it locally in a container but I'm not convinced we'll know for sure til we try it out properly.

>  Tested in Docker container with Amazon Linux 2023 + conda-forge R - confirmed `R CMD config CXX20` returns empty before patch and `g++` after patch.
>
> The only thing we didn't test end-to-end was actually building Arrow R, but that would have taken much longer and the configure check (R CMD config CXX20 returning non-empty) is exactly what Arrow's configure script tests before proceeding.                                       


### Are there any user-facing changes?

Nope
* GitHub Issue: #48912