### PR TITLE
GH-48978: [Python] test failures on pandas 3.0 for fastparquet and for zoneinfo w/o pytz

### DIFF
--- a/ci/scripts/install_pandas.sh
+++ b/ci/scripts/install_pandas.sh
@@ -40,7 +40,7 @@ if [ "${pandas}" = "upstream_devel" ]; then
 elif [ "${pandas}" = "nightly" ]; then
   pip install --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --pre pandas
 elif [ "${pandas}" = "latest" ]; then
-  pip install --upgrade pandas
+  pip install pandas
 else
   pip install pandas=="${pandas}"
 fi

--- a/ci/scripts/install_pandas.sh
+++ b/ci/scripts/install_pandas.sh
@@ -40,7 +40,7 @@ if [ "${pandas}" = "upstream_devel" ]; then
 elif [ "${pandas}" = "nightly" ]; then
   pip install --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --pre pandas
 elif [ "${pandas}" = "latest" ]; then
-  pip install pandas
+  pip install --upgrade pandas
 else
   pip install pandas=="${pandas}"
 fi

--- a/ci/scripts/install_pandas.sh
+++ b/ci/scripts/install_pandas.sh
@@ -40,8 +40,7 @@ if [ "${pandas}" = "upstream_devel" ]; then
 elif [ "${pandas}" = "nightly" ]; then
   pip install --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --pre pandas
 elif [ "${pandas}" = "latest" ]; then
-  pip install --upgrade pandas fastparquet
-  pip uninstall -q -y pytz
+  pip install --upgrade pandas
 else
   pip install pandas=="${pandas}"
 fi

--- a/ci/scripts/install_pandas.sh
+++ b/ci/scripts/install_pandas.sh
@@ -40,7 +40,8 @@ if [ "${pandas}" = "upstream_devel" ]; then
 elif [ "${pandas}" = "nightly" ]; then
   pip install --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --pre pandas
 elif [ "${pandas}" = "latest" ]; then
-  pip install --upgrade pandas
+  pip install --upgrade pandas fastparquet
+  pip uninstall pytz
 else
   pip install pandas=="${pandas}"
 fi

--- a/ci/scripts/install_pandas.sh
+++ b/ci/scripts/install_pandas.sh
@@ -41,7 +41,7 @@ elif [ "${pandas}" = "nightly" ]; then
   pip install --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --pre pandas
 elif [ "${pandas}" = "latest" ]; then
   pip install --upgrade pandas fastparquet
-  pip uninstall pytz
+  pip uninstall -q -y pytz
 else
   pip install pandas=="${pandas}"
 fi

--- a/python/pyarrow/tests/parquet/test_basic.py
+++ b/python/pyarrow/tests/parquet/test_basic.py
@@ -747,7 +747,7 @@ def test_fastparquet_cross_compatibility(tempdir):
             "c": np.arange(4.0, 7.0, dtype="float64"),
             "d": [True, False, True],
             "e": pd.date_range("20130101", periods=3),
-            "f": pd.Categorical(["a", "b", "c"]),
+            "f": pd.Categorical(["a", "b", "a"]),
             # fastparquet writes list as BYTE_ARRAY JSON, so no roundtrip
             # "g": [[1, 2], None, [1, 2, 3]],
         }

--- a/python/pyarrow/tests/parquet/test_basic.py
+++ b/python/pyarrow/tests/parquet/test_basic.py
@@ -760,8 +760,9 @@ def test_fastparquet_cross_compatibility(tempdir):
 
     fp_file = fp.ParquetFile(file_arrow)
     df_fp = fp_file.to_pandas()
-    # TODO: once fastparquet supports pandas 3.0 dtypes revert string/categorical test
-    # check_dtype=False: string/categorical dtype handling differs between libraries
+    # TODO: once fastparquet supports pandas 3 dtypes revert string and categorical
+    # tests by removing `check_dtype=False` and `check_categorical=False` so type
+    # equality is asserted again
     tm.assert_frame_equal(df, df_fp, check_dtype=False, check_categorical=False)
 
     # Fastparquet -> arrow

--- a/python/pyarrow/tests/parquet/test_basic.py
+++ b/python/pyarrow/tests/parquet/test_basic.py
@@ -736,6 +736,7 @@ def test_parquet_file_too_small(tempdir):
 @pytest.mark.fastparquet
 @pytest.mark.filterwarnings("ignore:RangeIndex:FutureWarning")
 @pytest.mark.filterwarnings("ignore:tostring:DeprecationWarning:fastparquet")
+@pytest.mark.filterwarnings("ignore:unclosed file:ResourceWarning")
 def test_fastparquet_cross_compatibility(tempdir):
     fp = pytest.importorskip('fastparquet')
 

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -4956,7 +4956,7 @@ def test_timestamp_as_object_non_nanosecond(resolution, tz, dt):
         assert isinstance(result[0], datetime)
         if tz:
             assert result[0].tzinfo is not None
-            expected = dt.replace(tzinfo=timezone.utc).astimezone(result[0].tzinfo)
+            expected = dt.replace(tzinfo=timezone.utc).astimezone(ZoneInfo(tz))
         else:
             assert result[0].tzinfo is None
             expected = dt

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -24,6 +24,7 @@ import warnings
 
 from collections import OrderedDict
 from datetime import date, datetime, time, timedelta, timezone
+from zoneinfo import ZoneInfo
 
 import hypothesis as h
 import hypothesis.strategies as st

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -4956,7 +4956,7 @@ def test_timestamp_as_object_non_nanosecond(resolution, tz, dt):
         assert isinstance(result[0], datetime)
         if tz:
             assert result[0].tzinfo is not None
-            expected = result[0].tzinfo.fromutc(dt)
+            expected = dt.replace(tzinfo=timezone.utc).astimezone(result[0].tzinfo)
         else:
             assert result[0].tzinfo is None
             expected = dt


### PR DESCRIPTION
### Rationale for this change
Closes #48978 

### What changes are included in this PR?
Update to `parquet/test_basic.py test_fastparquet_cross_compatibility` for fastparquet string and categorical dtype differences causing failure `Attribute "dtype" are different`
Update to `test_pandas.py‎ test_timestamp_as_object_non_nanosecond` for failure `ValueError: fromutc: dt.tzinfo is not self`.

### Are these changes tested?
Yes. Initially tested locally with pandas upgraded to 3.0 as CI was still running with pandas 2.3.3 cached.

### Are there any user-facing changes?
No.
* GitHub Issue: #48978