### PR TITLE
GH-48983: [Packaging][Python] Build wheel from sdist using build and add check to validate LICENSE.txt and NOTICE.txt are part of the wheel contents

### DIFF
--- a/.env
+++ b/.env
@@ -102,8 +102,8 @@ VCPKG="4334d8b4c8916018600212ab4dd4bbdc343065d1"    # 2025.09.17 Release
 # ci/docker/python-*-windows-*.dockerfile or the vcpkg config.
 # This is a workaround for our CI problem that "archery docker build" doesn't
 # use pulled built images in dev/tasks/python-wheels/github.windows.yml.
-PYTHON_WHEEL_WINDOWS_IMAGE_REVISION=2026-01-22
-PYTHON_WHEEL_WINDOWS_TEST_IMAGE_REVISION=2026-01-22
+PYTHON_WHEEL_WINDOWS_IMAGE_REVISION=2026-01-27
+PYTHON_WHEEL_WINDOWS_TEST_IMAGE_REVISION=2026-01-27
 
 # Use conanio/${CONAN_BASE}:{CONAN_VERSION} for "docker compose run --rm conan".
 # See https://github.com/conan-io/conan-docker-tools#readme and

--- a/ci/scripts/python_wheel_macos_build.sh
+++ b/ci/scripts/python_wheel_macos_build.sh
@@ -177,6 +177,10 @@ export CMAKE_PREFIX_PATH=${build_dir}/install
 export SETUPTOOLS_SCM_PRETEND_VERSION=${PYARROW_VERSION}
 
 pushd ${source_dir}/python
+# Setuptools is really opinionated about where Licenses/Notices go in the source tree.
+# Copy them to the python/ directory so they end up in the wheel root.
+cp ${source_dir}/LICENSE.txt .
+cp ${source_dir}/NOTICE.txt .
 python setup.py bdist_wheel
 popd
 

--- a/ci/scripts/python_wheel_macos_build.sh
+++ b/ci/scripts/python_wheel_macos_build.sh
@@ -177,11 +177,7 @@ export CMAKE_PREFIX_PATH=${build_dir}/install
 export SETUPTOOLS_SCM_PRETEND_VERSION=${PYARROW_VERSION}
 
 pushd ${source_dir}/python
-# Setuptools is really opinionated about where Licenses/Notices go in the source tree.
-# Copy them to the python/ directory so they end up in the wheel root.
-cp ${source_dir}/LICENSE.txt .
-cp ${source_dir}/NOTICE.txt .
-python setup.py bdist_wheel
+python -m build --wheel .
 popd
 
 echo "=== (${PYTHON_VERSION}) Show dynamic libraries the wheel depend on ==="

--- a/ci/scripts/python_wheel_macos_build.sh
+++ b/ci/scripts/python_wheel_macos_build.sh
@@ -177,7 +177,7 @@ export CMAKE_PREFIX_PATH=${build_dir}/install
 export SETUPTOOLS_SCM_PRETEND_VERSION=${PYARROW_VERSION}
 
 pushd ${source_dir}/python
-python -m build --wheel . --no-isolation
+python -m build --sdist --wheel . --no-isolation
 popd
 
 echo "=== (${PYTHON_VERSION}) Show dynamic libraries the wheel depend on ==="

--- a/ci/scripts/python_wheel_macos_build.sh
+++ b/ci/scripts/python_wheel_macos_build.sh
@@ -177,7 +177,7 @@ export CMAKE_PREFIX_PATH=${build_dir}/install
 export SETUPTOOLS_SCM_PRETEND_VERSION=${PYARROW_VERSION}
 
 pushd ${source_dir}/python
-python -m build --wheel .
+python -m build --wheel . --no-isolation
 popd
 
 echo "=== (${PYTHON_VERSION}) Show dynamic libraries the wheel depend on ==="

--- a/ci/scripts/python_wheel_validate_contents.py
+++ b/ci/scripts/python_wheel_validate_contents.py
@@ -33,9 +33,9 @@ def validate_wheel(path):
         )
     ]
     assert not outliers, f"Unexpected contents in wheel: {sorted(outliers)}"
-  for filename in ('LICENSE.txt', 'NOTICE.txt'):
-      assert any(info.filename.endswith(filename) for info in f.filelist), \
-          f"{filename} is missing from the wheel."
+    for filename in ('LICENSE.txt', 'NOTICE.txt'):
+        assert any(info.filename.endswith(filename) for info in f.filelist), \
+            f"{filename} is missing from the wheel."
     print(f"The wheel: {wheels[0]} seems valid.")
 
 

--- a/ci/scripts/python_wheel_validate_contents.py
+++ b/ci/scripts/python_wheel_validate_contents.py
@@ -33,18 +33,9 @@ def validate_wheel(path):
         )
     ]
     assert not outliers, f"Unexpected contents in wheel: {sorted(outliers)}"
-    license = [
-        info.filename for info in f.filelist if re.search(
-            r'LICENSE.txt$', info.filename
-        )
-    ]
-    assert license, "LICENSE.txt is missing from the wheel."
-    notice = [
-        info.filename for info in f.filelist if re.search(
-            r'NOTICE.txt$', info.filename
-        )
-    ]
-    assert notice, "NOTICE.txt is missing from the wheel."
+  for filename in ('LICENSE.txt', 'NOTICE.txt'):
+      assert any(info.filename.endswith(filename) for info in f.filelist), \
+          f"{filename} is missing from the wheel."
     print(f"The wheel: {wheels[0]} seems valid.")
 
 

--- a/ci/scripts/python_wheel_validate_contents.py
+++ b/ci/scripts/python_wheel_validate_contents.py
@@ -33,6 +33,18 @@ def validate_wheel(path):
         )
     ]
     assert not outliers, f"Unexpected contents in wheel: {sorted(outliers)}"
+    license = [
+        info.filename for info in f.filelist if re.search(
+            r'LICENSE.txt$', info.filename
+        )
+    ]
+    assert license, "LICENSE.txt is missing from the wheel."
+    notice = [
+        info.filename for info in f.filelist if re.search(
+            r'NOTICE.txt$', info.filename
+        )
+    ]
+    assert notice, "NOTICE.txt is missing from the wheel."
     print(f"The wheel: {wheels[0]} seems valid.")
 
 

--- a/ci/scripts/python_wheel_validate_contents.py
+++ b/ci/scripts/python_wheel_validate_contents.py
@@ -34,7 +34,8 @@ def validate_wheel(path):
     ]
     assert not outliers, f"Unexpected contents in wheel: {sorted(outliers)}"
     for filename in ('LICENSE.txt', 'NOTICE.txt'):
-        assert any(info.filename.endswith(filename) for info in f.filelist), \
+        assert any(info.filename.split("/")[-1] == filename
+                   for info in f.filelist), \
             f"{filename} is missing from the wheel."
     print(f"The wheel: {wheels[0]} seems valid.")
 

--- a/ci/scripts/python_wheel_windows_build.bat
+++ b/ci/scripts/python_wheel_windows_build.bat
@@ -133,7 +133,7 @@ set CMAKE_PREFIX_PATH=C:\arrow-dist
 pushd C:\arrow\python
 
 @REM Build wheel
-%PYTHON_CMD% -m build --wheel . --no-isolation || exit /B 1
+%PYTHON_CMD% -m build --sdist --wheel . --no-isolation || exit /B 1
 
 @REM Repair the wheel with delvewheel
 @REM

--- a/ci/scripts/python_wheel_windows_build.bat
+++ b/ci/scripts/python_wheel_windows_build.bat
@@ -131,6 +131,10 @@ set ARROW_HOME=C:\arrow-dist
 set CMAKE_PREFIX_PATH=C:\arrow-dist
 
 pushd C:\arrow\python
+@REM Setuptools is really opinionated about where Licenses/Notices go in the source tree.
+@REM Copy them to the python/ directory so they end up in the wheel root.
+copy C:\arrow\LICENSE.txt .
+copy C:\arrow\NOTICE.txt .
 
 @REM Build wheel
 %PYTHON_CMD% setup.py bdist_wheel || exit /B 1

--- a/ci/scripts/python_wheel_windows_build.bat
+++ b/ci/scripts/python_wheel_windows_build.bat
@@ -133,7 +133,7 @@ set CMAKE_PREFIX_PATH=C:\arrow-dist
 pushd C:\arrow\python
 
 @REM Build wheel
-%PYTHON_CMD% -m build --wheel . || exit /B 1
+%PYTHON_CMD% -m build --wheel . --no-isolation || exit /B 1
 
 @REM Repair the wheel with delvewheel
 @REM

--- a/ci/scripts/python_wheel_windows_build.bat
+++ b/ci/scripts/python_wheel_windows_build.bat
@@ -131,13 +131,9 @@ set ARROW_HOME=C:\arrow-dist
 set CMAKE_PREFIX_PATH=C:\arrow-dist
 
 pushd C:\arrow\python
-@REM Setuptools is really opinionated about where Licenses/Notices go in the source tree.
-@REM Copy them to the python/ directory so they end up in the wheel root.
-copy C:\arrow\LICENSE.txt .
-copy C:\arrow\NOTICE.txt .
 
 @REM Build wheel
-%PYTHON_CMD% setup.py bdist_wheel || exit /B 1
+%PYTHON_CMD% -m build --wheel . || exit /B 1
 
 @REM Repair the wheel with delvewheel
 @REM

--- a/ci/scripts/python_wheel_xlinux_build.sh
+++ b/ci/scripts/python_wheel_xlinux_build.sh
@@ -167,6 +167,11 @@ export ARROW_HOME=/tmp/arrow-dist
 export CMAKE_PREFIX_PATH=/tmp/arrow-dist
 
 pushd /arrow/python
+# Setuptools is really opinionated about where Licenses/Notices go in the source tree.
+# Copy them to the python/ directory so they end up in the wheel root.
+cp /arrow/LICENSE.txt .
+cp /arrow/NOTICE.txt .
+
 python setup.py bdist_wheel
 
 echo "=== Strip symbols from wheel ==="

--- a/ci/scripts/python_wheel_xlinux_build.sh
+++ b/ci/scripts/python_wheel_xlinux_build.sh
@@ -167,8 +167,7 @@ export ARROW_HOME=/tmp/arrow-dist
 export CMAKE_PREFIX_PATH=/tmp/arrow-dist
 
 pushd /arrow/python
-python -m build --sdist . --no-isolation
-python -m build --wheel . --no-isolation
+python -m build --sdist --wheel . --no-isolation
 
 echo "=== Strip symbols from wheel ==="
 mkdir -p dist/temp-fix-wheel

--- a/ci/scripts/python_wheel_xlinux_build.sh
+++ b/ci/scripts/python_wheel_xlinux_build.sh
@@ -167,6 +167,7 @@ export ARROW_HOME=/tmp/arrow-dist
 export CMAKE_PREFIX_PATH=/tmp/arrow-dist
 
 pushd /arrow/python
+python -m build --sdist . --no-isolation
 python -m build --wheel . --no-isolation
 
 echo "=== Strip symbols from wheel ==="

--- a/ci/scripts/python_wheel_xlinux_build.sh
+++ b/ci/scripts/python_wheel_xlinux_build.sh
@@ -167,7 +167,7 @@ export ARROW_HOME=/tmp/arrow-dist
 export CMAKE_PREFIX_PATH=/tmp/arrow-dist
 
 pushd /arrow/python
-python -m build --wheel .
+python -m build --wheel . --no-isolation
 
 echo "=== Strip symbols from wheel ==="
 mkdir -p dist/temp-fix-wheel

--- a/ci/scripts/python_wheel_xlinux_build.sh
+++ b/ci/scripts/python_wheel_xlinux_build.sh
@@ -167,12 +167,7 @@ export ARROW_HOME=/tmp/arrow-dist
 export CMAKE_PREFIX_PATH=/tmp/arrow-dist
 
 pushd /arrow/python
-# Setuptools is really opinionated about where Licenses/Notices go in the source tree.
-# Copy them to the python/ directory so they end up in the wheel root.
-cp /arrow/LICENSE.txt .
-cp /arrow/NOTICE.txt .
-
-python setup.py bdist_wheel
+python -m build --wheel .
 
 echo "=== Strip symbols from wheel ==="
 mkdir -p dist/temp-fix-wheel

--- a/python/requirements-wheel-build.txt
+++ b/python/requirements-wheel-build.txt
@@ -1,3 +1,4 @@
+build
 cython>=3.1
 numpy>=2.0.0
 setuptools_scm

--- a/python/setup.py
+++ b/python/setup.py
@@ -35,6 +35,7 @@ else:
 
 from setuptools import setup, Extension, Distribution
 from setuptools.command.sdist import sdist
+from setuptools.command.bdist_wheel import bdist_wheel
 
 from Cython.Distutils import build_ext as _build_ext
 import Cython
@@ -397,33 +398,40 @@ class BinaryDistribution(Distribution):
         return True
 
 
+def copy_license_files(dest_dir):
+    license_files = [
+        ("LICENSE.txt", "../LICENSE.txt"),
+        ("NOTICE.txt", "../NOTICE.txt"),
+    ]
+
+    for dest_name, src_path in license_files:
+        src_full = os.path.join(os.path.dirname(__file__), src_path)
+        dest_full = os.path.join(dest_dir, dest_name)
+
+        if not os.path.exists(src_full):
+            msg = f"Required license file not found: {src_full}"
+            raise FileNotFoundError(msg)
+
+        shutil.copy2(src_full, dest_full)
+        print(f"Copied {src_path} to {dest_full}")
+
+
+class CopyLicenseBdistWheel(bdist_wheel):
+    """Custom bdist_wheel command that copies license files from parent directory."""
+
+    def run(self):
+        copy_license_files(os.path.dirname(__file__))
+        # Call parent to do the normal wheel building
+        super().run()
+
+
 class CopyLicenseSdist(sdist):
     """Custom sdist command that copies license files from parent directory."""
 
     def make_release_tree(self, base_dir, files):
         # Call parent to do the normal work
         super().make_release_tree(base_dir, files)
-
-        # Define source (parent dir) and destination (sdist root) for license files
-        license_files = [
-            ("LICENSE.txt", "../LICENSE.txt"),
-            ("NOTICE.txt", "../NOTICE.txt"),
-        ]
-
-        for dest_name, src_path in license_files:
-            src_full = os.path.join(os.path.dirname(__file__), src_path)
-            dest_full = os.path.join(base_dir, dest_name)
-
-            # Remove any existing file/symlink at destination
-            if os.path.exists(dest_full) or os.path.islink(dest_full):
-                os.unlink(dest_full)
-
-            if not os.path.exists(src_full):
-                msg = f"Required license file not found: {src_full}"
-                raise FileNotFoundError(msg)
-
-            shutil.copy2(src_full, dest_full)
-            print(f"Copied {src_path} to {dest_name} in sdist")
+        copy_license_files(base_dir)
 
 
 setup(
@@ -433,5 +441,6 @@ setup(
     cmdclass={
         'build_ext': build_ext,
         'sdist': CopyLicenseSdist,
+        'bdist_wheel': CopyLicenseBdistWheel,
     },
 )


### PR DESCRIPTION
### Rationale for this change

Currently the files are missing from the published wheels.

### What changes are included in this PR?

- Ensure the license and notice files are part of the wheels
- Use build frontend to build wheels
- Build wheel from sdist

### Are these changes tested?

Yes, via archery.
I've validated all wheels will fail with the new check if LICENSE.txt or NOTICE.txt are missing:
```
 AssertionError: LICENSE.txt is missing from the wheel.
```

### Are there any user-facing changes?

No

* GitHub Issue: #48983