### PR TITLE
GH-48985: [GLib][Ruby] Fix GC problems in node options and expressions

### DIFF
--- a/c_glib/arrow-glib/compute.h
+++ b/c_glib/arrow-glib/compute.h
@@ -183,6 +183,10 @@ GARROW_AVAILABLE_IN_11_0
 GArrowProjectNodeOptions *
 garrow_project_node_options_new(GList *expressions, gchar **names, gsize n_names);
 
+GARROW_AVAILABLE_IN_24_0
+GList *
+garrow_project_node_options_get_expressions(GArrowProjectNodeOptions *options);
+
 #define GARROW_TYPE_AGGREGATION (garrow_aggregation_get_type())
 GARROW_AVAILABLE_IN_6_0
 G_DECLARE_DERIVABLE_TYPE(
@@ -217,6 +221,10 @@ garrow_aggregate_node_options_new(GList *aggregations,
                                   const gchar **keys,
                                   gsize n_keys,
                                   GError **error);
+
+GARROW_AVAILABLE_IN_24_0
+GList *
+garrow_aggregate_node_options_get_aggregations(GArrowAggregateNodeOptions *options);
 
 #define GARROW_TYPE_SINK_NODE_OPTIONS (garrow_sink_node_options_get_type())
 GARROW_AVAILABLE_IN_6_0

--- a/c_glib/arrow-glib/expression.h
+++ b/c_glib/arrow-glib/expression.h
@@ -76,5 +76,8 @@ GArrowCallExpression *
 garrow_call_expression_new(const gchar *function,
                            GList *arguments,
                            GArrowFunctionOptions *options);
+GARROW_AVAILABLE_IN_24_0
+GList *
+garrow_call_expression_get_arguments(GArrowCallExpression *expression);
 
 G_END_DECLS

--- a/c_glib/arrow-glib/expression.hpp
+++ b/c_glib/arrow-glib/expression.hpp
@@ -28,5 +28,17 @@ GArrowExpression *
 garrow_expression_new_raw(const arrow::compute::Expression &arrow_expression);
 
 GARROW_EXTERN
+GArrowExpression *
+garrow_expression_new_raw(const arrow::compute::Expression &arrow_expression,
+                          const gchar *first_property_name,
+                          ...);
+
+GARROW_EXTERN
+GArrowExpression *
+garrow_expression_new_raw_valist(const arrow::compute::Expression &arrow_expression,
+                                 const gchar *first_property_name,
+                                 va_list args);
+
+GARROW_EXTERN
 arrow::compute::Expression *
 garrow_expression_get_raw(GArrowExpression *expression);

--- a/ruby/red-arrow/ext/arrow/arrow.cpp
+++ b/ruby/red-arrow/ext/arrow/arrow.cpp
@@ -63,6 +63,36 @@ namespace red_arrow {
       rbgobj_gc_mark_instance(node->data);
     }
   }
+
+  void
+  call_expression_mark(gpointer object)
+  {
+    auto expression = GARROW_CALL_EXPRESSION(object);
+    auto arguments = garrow_call_expression_get_arguments(expression);
+    for (auto argument = arguments; argument; argument = g_list_next(argument)) {
+      rbgobj_gc_mark_instance(argument->data);
+    }
+  }
+
+  void
+  aggregate_node_options_mark(gpointer object)
+  {
+    auto options = GARROW_AGGREGATE_NODE_OPTIONS(object);
+    auto aggregations = garrow_aggregate_node_options_get_aggregations(options);
+    for (auto aggregation = aggregations; aggregation; aggregation = g_list_next(aggregation)) {
+      rbgobj_gc_mark_instance(aggregation->data);
+    }
+  }
+
+  void
+  project_node_options_mark(gpointer object)
+  {
+    auto options = GARROW_PROJECT_NODE_OPTIONS(object);
+    auto expressions = garrow_project_node_options_get_expressions(options);
+    for (auto expression = expressions; expression; expression = g_list_next(expression)) {
+      rbgobj_gc_mark_instance(expression->data);
+    }
+  }
 }
 
 extern "C" void Init_arrow() {
@@ -124,4 +154,10 @@ extern "C" void Init_arrow() {
                             red_arrow::record_batch_reader_mark);
   rbgobj_register_mark_func(GARROW_TYPE_EXECUTE_PLAN,
                             red_arrow::execute_plan_mark);
+  rbgobj_register_mark_func(GARROW_TYPE_CALL_EXPRESSION,
+                            red_arrow::call_expression_mark);
+  rbgobj_register_mark_func(GARROW_TYPE_AGGREGATE_NODE_OPTIONS,
+                            red_arrow::aggregate_node_options_mark);
+  rbgobj_register_mark_func(GARROW_TYPE_PROJECT_NODE_OPTIONS,
+                            red_arrow::project_node_options_mark);
 }


### PR DESCRIPTION
### Rationale for this change

Some node options and expressions miss arguments reference. If they miss, arguments may be freed by GC.

### What changes are included in this PR?

* Refer arguments of `garrow_filter_node_options_new()`
* Refer arguments of `garrow_project_node_options_new()`
* Refer arguments of `garrow_aggregate_node_options_new()`
* Refer arguments of `garrow_literal_expression_new()`
* Refer arguments of `garrow_call_expression_new()`
 
### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #48985