### PR TITLE
GH-48990: [Ruby] Add support for writing date arrays

### DIFF
--- a/ruby/red-arrow-format/lib/arrow-format/type.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/type.rb
@@ -330,10 +330,21 @@ module ArrowFormat
     end
   end
 
-  class TemporalType < Type
+  class TemporalType < PrimitiveType
   end
 
   class DateType < TemporalType
+    attr_reader :unit
+    def initialize(unit)
+      super()
+      @unit = unit
+    end
+
+    def to_flatbuffers
+      fb_type = FB::Date::Data.new
+      fb_type.unit = FB::DateUnit.try_convert(@unit.to_s.upcase)
+      fb_type
+    end
   end
 
   class Date32Type < DateType
@@ -341,6 +352,10 @@ module ArrowFormat
       def singleton
         @singleton ||= new
       end
+    end
+
+    def initialize
+      super(:day)
     end
 
     def name
@@ -357,6 +372,10 @@ module ArrowFormat
       def singleton
         @singleton ||= new
       end
+    end
+
+    def initialize
+      super(:millisecond)
     end
 
     def name

--- a/ruby/red-arrow-format/test/test-reader.rb
+++ b/ruby/red-arrow-format/test/test-reader.rb
@@ -191,7 +191,7 @@ module ReaderTests
         sub_test_case("Date64") do
           def setup(&block)
             @date_2017_08_28_00_00_00 = 1503878400000
-            @date_2025_12_09_00_00_00 = 1765324800000
+            @date_2025_12_10_00_00_00 = 1765324800000
             super(&block)
           end
 
@@ -199,7 +199,7 @@ module ReaderTests
             Arrow::Date64Array.new([
                                      @date_2017_08_28_00_00_00,
                                      nil,
-                                     @date_2025_12_09_00_00_00,
+                                     @date_2025_12_10_00_00_00,
                                    ])
           end
 
@@ -209,7 +209,7 @@ module ReaderTests
                              "value" => [
                                @date_2017_08_28_00_00_00,
                                nil,
-                               @date_2025_12_09_00_00_00,
+                               @date_2025_12_10_00_00_00,
                              ],
                            },
                          ],

--- a/ruby/red-arrow-format/test/test-writer.rb
+++ b/ruby/red-arrow-format/test/test-writer.rb
@@ -42,6 +42,10 @@ module WriterTests
       ArrowFormat::Float32Type.singleton
     when Arrow::DoubleDataType
       ArrowFormat::Float64Type.singleton
+    when Arrow::Date32DataType
+      ArrowFormat::Date32Type.singleton
+    when Arrow::Date64DataType
+      ArrowFormat::Date64Type.singleton
     when Arrow::BinaryDataType
       ArrowFormat::BinaryType.singleton
     when Arrow::LargeBinaryDataType
@@ -216,6 +220,48 @@ module WriterTests
 
           def test_write
             assert_equal([-0.5, nil, 0.5],
+                         @values)
+          end
+        end
+
+        sub_test_case("Date32") do
+          def setup(&block)
+            @date_2017_08_28 = 17406
+            @date_2025_12_09 = 20431
+            super(&block)
+          end
+
+          def build_array
+            Arrow::Date32Array.new([@date_2017_08_28, nil, @date_2025_12_09])
+          end
+
+          def test_write
+            assert_equal([Date.new(2017, 8, 28), nil, Date.new(2025, 12, 9)],
+                         @values)
+          end
+        end
+
+        sub_test_case("Date64") do
+          def setup(&block)
+            @date_2017_08_28_00_00_00 = 1503878400000
+            @date_2025_12_10_00_00_00 = 1765324800000
+            super(&block)
+          end
+
+          def build_array
+            Arrow::Date64Array.new([
+                                     @date_2017_08_28_00_00_00,
+                                     nil,
+                                     @date_2025_12_10_00_00_00,
+                                   ])
+          end
+
+          def test_write
+            assert_equal([
+                           DateTime.new(2017, 8, 28, 0, 0, 0),
+                           nil,
+                           DateTime.new(2025, 12, 10, 0, 0, 0),
+                         ],
                          @values)
           end
         end


### PR DESCRIPTION
### Rationale for this change

There are date32 and date64 variants for date arrays.

### What changes are included in this PR?

* Add `ArrowFormat::DateType#to_flatbuffers`

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #48990