### PR TITLE
GH-48397: [R] Update docs on how to get our libarrow builds

### DIFF
--- a/r/README.md
+++ b/r/README.md
@@ -64,7 +64,7 @@ It allows users to read and write data in a variety of formats:
 
 It provides access to remote filesystems and servers:
 
-- Read and write files in Amazon S3 and Google Cloud Storage buckets
+- Read and write files in Amazon S3 and Google Cloud Storage buckets (note: CRAN builds include S3 support but not GCS which require an alternative installation method; see the [cloud storage article](https://arrow.apache.org/docs/r/articles/fs.html) for details)
 - Connect to Arrow Flight servers to transport large datasets over networks
 
 Additional features include:

--- a/r/vignettes/fs.Rmd
+++ b/r/vignettes/fs.Rmd
@@ -12,9 +12,9 @@ To make this work, the Arrow C++ library contains a general-purpose interface fo
 
 This article provides an overview of working with both S3 and GCS data using the Arrow toolkit. 
 
-## S3 and GCS support on Linux
+## S3 and GCS support
 
-Before you start, make sure that your arrow install has support for S3 and/or GCS enabled. For most users this will be true by default, because the Windows and macOS binary packages hosted on CRAN include S3 and GCS support. You can check whether support is enabled via helper functions:
+Before you start, make sure that your arrow installation has support for S3 and/or GCS enabled. You can check whether support is enabled via helper functions:
 
 ```r
 arrow_with_s3()
@@ -23,7 +23,20 @@ arrow_with_gcs()
 
 If these return `TRUE` then the relevant support is enabled.
 
-In some cases you may find that your system does not have support enabled. The most common case for this occurs on Linux when installing arrow from source. In this situation S3 and GCS support is not always enabled by default, and there are additional system requirements involved. See the [installation article](./install.html) for details on how to resolve this.
+CRAN builds of arrow include S3 support but not GCS support. If you need GCS support, you can install arrow with full features using one of the following methods:
+
+```r
+# Option 1: Install from R-universe
+install.packages("arrow", repos = "https://apache.r-universe.dev")
+```
+
+```r
+# Option 2: Reinstall from source with full features
+Sys.setenv("NOT_CRAN" = "true")
+install.packages("arrow", type = "source")
+```
+
+On Linux, S3 and GCS support is not always enabled by default when installing from source, and there are additional system requirements involved. See the [installation article](./install.html) for details.
 
 ## Connecting to cloud storage
 

--- a/r/vignettes/install.Rmd
+++ b/r/vignettes/install.Rmd
@@ -8,6 +8,8 @@ output: rmarkdown::html_vignette
 
 In most cases, `install.packages("arrow")` should just work. There are things you can do to make the installation faster, documented in this article. If for some reason installation does not work, set the environment variable `ARROW_R_DEV=true`, retry, and share the logs with us.
 
+Note that CRAN builds of arrow have some optional features disabled, including Google Cloud Storage (GCS) support. If you need these features, see the information below on [building with a libarrow binary](#r-source-package-with-libarrow-binary), or the [cloud storage article](./fs.html#s3-and-gcs-support) for alternative installation options.
+
 ## Background
 
 The Apache Arrow project is implemented in multiple languages, and the R package depends on the Arrow C++ library (referred to from here on as libarrow). This means that when you install arrow, you need both the R and C++ versions.  If you install arrow from CRAN on a machine running Windows or macOS, when you call `install.packages("arrow")`, a precompiled binary containing both the R package and libarrow will be downloaded.  However, CRAN does not host R package binaries for Linux, and so you must choose from one of the alternative approaches.


### PR DESCRIPTION
### Rationale for this change

Turning off GCS on CRAN to prevent excessive build times, need to tell people who wanna work with GCS how to do that.

### What changes are included in this PR?

Update docs.

### Are these changes tested?

Will preview docs build.

### Are there any user-facing changes?

Just docs.
* GitHub Issue: #48397