### PR TITLE
GH-49004: [C++][FlightRPC] Run ODBC tests in workflow using `cpp_test.sh`

### DIFF
--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -352,10 +352,10 @@ jobs:
       ARROW_BUILD_STATIC: OFF
       ARROW_BUILD_TESTS: ON
       ARROW_BUILD_TYPE: release
-      ARROW_DEPENDENCY_SOURCE: VCPKG
       # Turn Arrow CSV off to disable `find_package(Arrow)` check on MSVC CI. 
       # GH-49050 TODO: enable `find_package(Arrow)` check on MSVC CI.
       ARROW_CSV: OFF
+      ARROW_DEPENDENCY_SOURCE: VCPKG
       ARROW_FLIGHT_SQL_ODBC: ON
       ARROW_FLIGHT_SQL_ODBC_INSTALLER: ON
       ARROW_HOME: /usr

--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -437,16 +437,6 @@ jobs:
         shell: cmd
         run: |
           call "cpp\src\arrow\flight\sql\odbc\tests\install_odbc.cmd" ${{ github.workspace }}\build\cpp\%ARROW_BUILD_TYPE%\arrow_flight_sql_odbc.dll
-      # GH-48269 TODO: Enable Flight & Flight SQL testing in MSVC CI and run tests with `ci/scripts/cpp_test.sh` instead
-      # GH-48547 TODO: enable ODBC tests after GH-48270 and GH-48269 are resolved.
-      - name: Run ODBC Unit Tests
-        shell: cmd
-        run: |
-          build\cpp\%ARROW_BUILD_TYPE%\arrow-odbc-spi-impl-test.exe
-      - name: Run ODBC Driver Tests
-        shell: cmd
-        run: |
-          build\cpp\%ARROW_BUILD_TYPE%\arrow-flight-sql-odbc-test.exe
       - name: Test
         shell: cmd
         run: |

--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -434,7 +434,6 @@ jobs:
         shell: cmd
         run: |
           call "cpp\src\arrow\flight\sql\odbc\tests\install_odbc.cmd" ${{ github.workspace }}\build\cpp\%ARROW_BUILD_TYPE%\arrow_flight_sql_odbc.dll
-      # GH-48270 TODO: Resolve segementation fault during Arrow library unload, segementation fault is caught with `ci/scripts/cpp_test.sh`
       # GH-48269 TODO: Enable Flight & Flight SQL testing in MSVC CI and run tests with `ci/scripts/cpp_test.sh` instead
       # GH-48547 TODO: enable ODBC tests after GH-48270 and GH-48269 are resolved.
       - name: Run ODBC Unit Tests
@@ -445,6 +444,15 @@ jobs:
         shell: cmd
         run: |
           build\cpp\%ARROW_BUILD_TYPE%\arrow-flight-sql-odbc-test.exe
+      - name: Test
+        shell: cmd
+        run: |
+          set VCPKG_ROOT_KEEP=%VCPKG_ROOT%
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
+          set VCPKG_ROOT=%VCPKG_ROOT_KEEP%
+          # Convert VCPKG Windows path to MSYS path
+          for /f "usebackq delims=" %%I in (`bash -c "cygpath -u \"$VCPKG_ROOT_KEEP\""` ) do set VCPKG_ROOT=%%I
+          bash -c "ci/scripts/cpp_test.sh $(pwd) $(pwd)/build"
       - name: Install WiX Toolset
         shell: pwsh
         run: |

--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -353,6 +353,9 @@ jobs:
       ARROW_BUILD_TESTS: ON
       ARROW_BUILD_TYPE: release
       ARROW_DEPENDENCY_SOURCE: VCPKG
+      # Turn Arrow CSV off to disable `find_package(Arrow)` check on MSVC CI. 
+      # GH-49050 TODO: enable `find_package(Arrow)` check on MSVC CI.
+      ARROW_CSV: OFF
       ARROW_FLIGHT_SQL_ODBC: ON
       ARROW_FLIGHT_SQL_ODBC_INSTALLER: ON
       ARROW_HOME: /usr

--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -434,10 +434,17 @@ jobs:
         shell: cmd
         run: |
           call "cpp\src\arrow\flight\sql\odbc\tests\install_odbc.cmd" ${{ github.workspace }}\build\cpp\%ARROW_BUILD_TYPE%\arrow_flight_sql_odbc.dll
-      # GH-48270 TODO: Resolve segementation fault during Arrow library unload
-      # GH-48269 TODO: Enable Flight & Flight SQL testing in MSVC CI
+      # GH-48270 TODO: Resolve segementation fault during Arrow library unload, segementation fault is caught with `ci/scripts/cpp_test.sh`
+      # GH-48269 TODO: Enable Flight & Flight SQL testing in MSVC CI and run tests with `ci/scripts/cpp_test.sh` instead
       # GH-48547 TODO: enable ODBC tests after GH-48270 and GH-48269 are resolved.
-
+      - name: Run ODBC Unit Tests
+        shell: cmd
+        run: |
+          build\cpp\%ARROW_BUILD_TYPE%\arrow-odbc-spi-impl-test.exe
+      - name: Run ODBC Driver Tests
+        shell: cmd
+        run: |
+          build\cpp\%ARROW_BUILD_TYPE%\arrow-flight-sql-odbc-test.exe
       - name: Install WiX Toolset
         shell: pwsh
         run: |


### PR DESCRIPTION
### Rationale for this change
#49004 

### What changes are included in this PR?
- Run tests using `cpp_test.sh` in the ODBC job of C++ Extra CI.
Note:  `find_package(Arrow)` check in `cpp_test.sh` is disabled due to blocker GH-49050

### Are these changes tested?
Yes, in CI
### Are there any user-facing changes?
N/A
* GitHub Issue: #49004