### PR TITLE
GH-47692: [CI][Python] Do not fallback to return 404 if wheel is found on emscripten jobs

### DIFF
--- a/python/scripts/run_emscripten_tests.py
+++ b/python/scripts/run_emscripten_tests.py
@@ -45,7 +45,7 @@ class TemplateOverrider(http.server.SimpleHTTPRequestHandler):
             self.end_headers()
             with PYARROW_WHEEL_PATH.open(mode="rb") as wheel:
                 self.copyfile(wheel, self.wfile)
-        if self.path.endswith("/test.html"):
+        elif self.path.endswith("/test.html"):
             body = b"""
                 <!doctype html>
                 <html>


### PR DESCRIPTION
### Rationale for this change

When looking for the wheel the script was falling back to returning a 404 even when the wheel was found:
```
 + python scripts/run_emscripten_tests.py dist/pyarrow-24.0.0.dev31-cp312-cp312-pyodide_2024_0_wasm32.whl --dist-dir=/pyodide --runtime=chrome
127.0.0.1 - - [27/Jan/2026 01:14:50] code 404, message File not found
```
Timing out the job and failing.

### What changes are included in this PR?

Correct logic and only return 404 if the file requested wasn't found.

### Are these changes tested?

Yes via archery

### Are there any user-facing changes?

No
* GitHub Issue: #47692