### PR TITLE
GH-48586: [Python][CI] Upload artifact to python-sdist job

### DIFF
--- a/dev/tasks/python-sdist/github.yml
+++ b/dev/tasks/python-sdist/github.yml
@@ -42,4 +42,9 @@ jobs:
           UBUNTU: 22.04
           PYARROW_VERSION: {{ arrow.no_rc_version }}
 
+      - uses: actions/upload-artifact@v6
+        with:
+          name: sdist
+          path: arrow/python/dist/*.tar.gz
+
       {{ macros.github_upload_releases("arrow/python/dist/*.tar.gz")|indent }}


### PR DESCRIPTION
### Rationale for this change

When running the python-sdist job we are currently not uploading the build artifact to the job.

### What changes are included in this PR?

Upload artifact as part of building the job so it's easier to test and validate contents if necessary.

### Are these changes tested?

Yes via archery.


### Are there any user-facing changes?

No

* GitHub Issue: #48586