### PR TITLE
GH-48986: [C++][Dataset] Integrate ORC stripe filtering with dataset scanner (5/14)

### DIFF
--- a/cpp/src/arrow/dataset/file_orc.h
+++ b/cpp/src/arrow/dataset/file_orc.h
@@ -56,6 +56,10 @@ class ARROW_DS_EXPORT OrcFileFormat : public FileFormat {
   /// \brief Return the schema of the file if possible.
   Result<std::shared_ptr<Schema>> Inspect(const FileSource& source) const override;
 
+  Result<std::shared_ptr<FileFragment>> MakeFragment(
+      FileSource source, compute::Expression partition_expression,
+      std::shared_ptr<Schema> physical_schema) override;
+
   Result<RecordBatchGenerator> ScanBatchesAsync(
       const std::shared_ptr<ScanOptions>& options,
       const std::shared_ptr<FileFragment>& file) const override;


### PR DESCRIPTION
## Summary

Part 5/14 of ORC predicate pushdown implementation.

⚠️ **Depends on PRs 1-4 being merged first**

Integrates stripe filtering with Dataset API scanner:
- Wire `FilterStripes()` into `OrcScanTask`
- Log stripe skipping for observability
- Feature flag: `ARROW_ORC_DISABLE_PREDICATE_PUSHDOWN`
- Infrastructure ready for reader integration

## Feature Flag
```bash
# Disable predicate pushdown if needed
export ARROW_ORC_DISABLE_PREDICATE_PUSHDOWN=1
```

**Part of stacked PR series. Review after PR 4.**
* GitHub Issue: #48986
