### PR TITLE
GH-48986: [Python] Add placeholder for ORC predicate pushdown Python bindings (6/15)

### DIFF
--- a/cpp/src/arrow/dataset/file_orc.h
+++ b/cpp/src/arrow/dataset/file_orc.h
@@ -56,6 +56,10 @@ class ARROW_DS_EXPORT OrcFileFormat : public FileFormat {
   /// \brief Return the schema of the file if possible.
   Result<std::shared_ptr<Schema>> Inspect(const FileSource& source) const override;
 
+  Result<std::shared_ptr<FileFragment>> MakeFragment(
+      FileSource source, compute::Expression partition_expression,
+      std::shared_ptr<Schema> physical_schema) override;
+
   Result<RecordBatchGenerator> ScanBatchesAsync(
       const std::shared_ptr<ScanOptions>& options,
       const std::shared_ptr<FileFragment>& file) const override;


### PR DESCRIPTION
## Summary

Part 6/15 of ORC predicate pushdown implementation.

⚠️ **Depends on PRs 1-5 being merged first**

Adds Python binding placeholders for future ORC predicate pushdown features.

**Part of stacked PR series. Review after PR 5.**
* GitHub Issue: #48986