### PR TITLE
GH-49029: [Doc] Run sphinx-build in parallel

### DIFF
--- a/ci/scripts/python_build.sh
+++ b/ci/scripts/python_build.sh
@@ -115,6 +115,7 @@ if [ "${BUILD_DOCS_PYTHON}" == "ON" ]; then
   export ARROW_CPP_DOXYGEN_XML=${build_dir}/cpp/apidoc/xml
   pushd "${build_dir}"
   sphinx-build \
+    -j auto \
     -b html \
     "${python_build_dir}/docs/source" \
     "${build_dir}/docs"


### PR DESCRIPTION
### Rationale for this change

`sphinx-build` allows for parallel operation, but it builds serially by default and that can be very slow on our docs given the amount of documents (many of them auto-generated from API docs).

### Are these changes tested?

By existing CI jobs.

### Are there any user-facing changes?

No.
* GitHub Issue: #49029