### PR TITLE
GH-49030: [Ruby] Add support for writing fixed size binary array

### DIFF
--- a/ruby/red-arrow-format/lib/arrow-format/array.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/array.rb
@@ -301,6 +301,13 @@ module ArrowFormat
       @values_buffer = values_buffer
     end
 
+    def each_buffer
+      return to_enum(__method__) unless block_given?
+
+      yield(@validity_buffer)
+      yield(@values_buffer)
+    end
+
     def to_a
       byte_width = @type.byte_width
       values = 0.step(@size * byte_width - 1, byte_width).collect do |offset|

--- a/ruby/red-arrow-format/lib/arrow-format/type.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/type.rb
@@ -594,6 +594,12 @@ module ArrowFormat
     def build_array(size, validity_buffer, values_buffer)
       FixedSizeBinaryArray.new(self, size, validity_buffer, values_buffer)
     end
+
+    def to_flatbuffers
+      fb_type = FB::FixedSizeBinary::Data.new
+      fb_type.byte_width = @byte_width
+      fb_type
+    end
   end
 
   class DecimalType < FixedSizeBinaryType

--- a/ruby/red-arrow-format/test/test-writer.rb
+++ b/ruby/red-arrow-format/test/test-writer.rb
@@ -54,6 +54,8 @@ module WriterTests
       ArrowFormat::UTF8Type.singleton
     when Arrow::LargeStringDataType
       ArrowFormat::LargeUTF8Type.singleton
+    when Arrow::FixedSizeBinaryDataType
+      ArrowFormat::FixedSizeBinaryType.new(red_arrow_type.byte_width)
     else
       raise "Unsupported type: #{red_arrow_type.inspect}"
     end
@@ -77,6 +79,10 @@ module WriterTests
       type.build_array(red_arrow_array.size,
                        convert_buffer(red_arrow_array.null_bitmap),
                        convert_buffer(red_arrow_array.offsets_buffer),
+                       convert_buffer(red_arrow_array.data_buffer))
+    when ArrowFormat::FixedSizeBinaryType
+      type.build_array(red_arrow_array.size,
+                       convert_buffer(red_arrow_array.null_bitmap),
                        convert_buffer(red_arrow_array.data_buffer))
     else
       raise "Unsupported array #{red_arrow_array.inspect}"
@@ -308,6 +314,19 @@ module WriterTests
 
           def test_write
             assert_equal(["Hello", nil, "World"],
+                         @values)
+          end
+        end
+
+        sub_test_case("FixedSizeBinary") do
+          def build_array
+            data_type = Arrow::FixedSizeBinaryDataType.new(4)
+            Arrow::FixedSizeBinaryArray.new(data_type,
+                                            ["0124".b, nil, "abcd".b])
+          end
+
+          def test_write
+            assert_equal(["0124".b, nil, "abcd".b],
                          @values)
           end
         end


### PR DESCRIPTION
### Rationale for this change

It's a fixed size variant of binary array.

### What changes are included in this PR?

* Add `ArrowFormat::FixedSizeBinaryType#to_flatbuffers`
* Add `ArrowFormat::FixedSizeBinaryArray#each_buffer`

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #49030