### PR TITLE
GH-33450: [C++] Remove GlobalForkSafeMutex

### DIFF
--- a/cpp/src/arrow/util/mutex.cc
+++ b/cpp/src/arrow/util/mutex.cc
@@ -59,31 +59,5 @@ Mutex::Guard Mutex::Lock() {
 
 Mutex::Mutex() : impl_(new Impl, [](Impl* impl) { delete impl; }) {}
 
-#ifndef _WIN32
-namespace {
-
-struct AfterForkState {
-  // A global instance that will also register the atfork handler when
-  // constructed.
-  static AfterForkState instance;
-
-  // The mutex may be used at shutdown, so make it eternal.
-  // The leak (only in child processes) is a small price to pay for robustness.
-  Mutex* mutex = nullptr;
-
- private:
-  AfterForkState() {
-    pthread_atfork(/*prepare=*/nullptr, /*parent=*/nullptr, /*child=*/&AfterFork);
-  }
-
-  static void AfterFork() { instance.mutex = new Mutex; }
-};
-
-AfterForkState AfterForkState::instance;
-}  // namespace
-
-Mutex* GlobalForkSafeMutex() { return AfterForkState::instance.mutex; }
-#endif  // _WIN32
-
 }  // namespace util
 }  // namespace arrow

--- a/cpp/src/arrow/util/mutex.h
+++ b/cpp/src/arrow/util/mutex.h
@@ -60,26 +60,5 @@ class ARROW_EXPORT Mutex {
   std::unique_ptr<Impl, void (*)(Impl*)> impl_;
 };
 
-#ifndef _WIN32
-/// Return a pointer to a process-wide, process-specific Mutex that can be used
-/// at any point in a child process.  NULL is returned when called in the parent.
-///
-/// The rule is to first check that getpid() corresponds to the parent process pid
-/// and, if not, call this function to lock any after-fork reinitialization code.
-/// Like this:
-///
-///   std::atomic<pid_t> pid{getpid()};
-///   ...
-///   if (pid.load() != getpid()) {
-///     // In child process
-///     auto lock = GlobalForkSafeMutex()->Lock();
-///     if (pid.load() != getpid()) {
-///       // Reinitialize internal structures after fork
-///       ...
-///       pid.store(getpid());
-ARROW_EXPORT
-Mutex* GlobalForkSafeMutex();
-#endif
-
 }  // namespace util
 }  // namespace arrow


### PR DESCRIPTION
### Rationale for this change

This functionality is unused now that we have a proper atfork facility.

### Are these changes tested?

By existing CI tests.

### Are there any user-facing changes?

Removing an API that was always meant for internal use (though we didn't flag it explicitly as internal).

* GitHub Issue: #33450