### PR TITLE
GH-49034 [C++][Gandiva] Fix binary_string to not trigger error for null strings

### DIFF
--- a/cpp/src/gandiva/function_registry_string.cc
+++ b/cpp/src/gandiva/function_registry_string.cc
@@ -432,7 +432,8 @@ std::vector<NativeFunction> GetStringFunctionRegistry() {
                      NativeFunction::kNeedsContext | NativeFunction::kCanReturnErrors),
 
       NativeFunction("binary_string", {}, DataTypeVector{utf8()}, binary(),
-                     kResultNullIfNull, "binary_string", NativeFunction::kNeedsContext | NativeFunction::kCanReturnErrors),
+                     kResultNullIfNull, "binary_string",
+                     NativeFunction::kNeedsContext | NativeFunction::kCanReturnErrors),
 
       NativeFunction("left", {}, DataTypeVector{utf8(), int32()}, utf8(),
                      kResultNullIfNull, "left_utf8_int32", NativeFunction::kNeedsContext),

--- a/cpp/src/gandiva/function_registry_string.cc
+++ b/cpp/src/gandiva/function_registry_string.cc
@@ -432,7 +432,7 @@ std::vector<NativeFunction> GetStringFunctionRegistry() {
                      NativeFunction::kNeedsContext | NativeFunction::kCanReturnErrors),
 
       NativeFunction("binary_string", {}, DataTypeVector{utf8()}, binary(),
-                     kResultNullIfNull, "binary_string", NativeFunction::kNeedsContext),
+                     kResultNullIfNull, "binary_string", NativeFunction::kNeedsContext | NativeFunction::kCanReturnErrors),
 
       NativeFunction("left", {}, DataTypeVector{utf8(), int32()}, utf8(),
                      kResultNullIfNull, "left_utf8_int32", NativeFunction::kNeedsContext),

--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -2252,16 +2252,16 @@ const char* right_utf8_int32(gdv_int64 context, const char* text, gdv_int32 text
 FORCE_INLINE
 const char* binary_string(gdv_int64 context, const char* text, gdv_int32 text_len,
                           gdv_int32* out_len) {
+  if (text_len == 0) {
+    *out_len = 0;
+    return "";
+  }
+
   gdv_binary ret =
       reinterpret_cast<gdv_binary>(gdv_fn_context_arena_malloc(context, text_len));
 
   if (ret == nullptr) {
     gdv_fn_context_set_error_msg(context, "Could not allocate memory for output string");
-    *out_len = 0;
-    return "";
-  }
-
-  if (text_len == 0) {
     *out_len = 0;
     return "";
   }

--- a/cpp/src/gandiva/precompiled/string_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/string_ops_test.cc
@@ -1909,7 +1909,8 @@ TEST(TestStringOps, TestBinaryString) {
 }
 
 TEST(TestStringOps, TestBinaryStringNull) {
-  //This test is only valid if it is the first to trigger a memory allocation in the context.
+  // This test is only valid if it is the first to trigger a memory allocation in the
+  // context.
   gandiva::ExecutionContext ctx;
   uint64_t ctx_ptr = reinterpret_cast<gdv_int64>(&ctx);
   gdv_int32 out_len = 0;

--- a/cpp/src/gandiva/precompiled/string_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/string_ops_test.cc
@@ -1883,10 +1883,6 @@ TEST(TestStringOps, TestBinaryString) {
   std::string output = std::string(out_str, out_len);
   EXPECT_EQ(output, "TestString");
 
-  out_str = binary_string(ctx_ptr, "", 0, &out_len);
-  output = std::string(out_str, out_len);
-  EXPECT_EQ(output, "");
-
   out_str = binary_string(ctx_ptr, "T", 1, &out_len);
   output = std::string(out_str, out_len);
   EXPECT_EQ(output, "T");
@@ -1910,6 +1906,21 @@ TEST(TestStringOps, TestBinaryString) {
   out_str = binary_string(ctx_ptr, "\\x4f\\x4D", 8, &out_len);
   output = std::string(out_str, out_len);
   EXPECT_EQ(output, "OM");
+}
+
+TEST(TestStringOps, TestBinaryStringNull) {
+  //This test is only valid if it is the first to trigger a memory allocation in the context.
+  gandiva::ExecutionContext ctx;
+  uint64_t ctx_ptr = reinterpret_cast<gdv_int64>(&ctx);
+  gdv_int32 out_len = 0;
+  const char* out_str;
+
+  std::string output;
+
+  out_str = binary_string(ctx_ptr, "", 0, &out_len);
+  ASSERT_FALSE(ctx.has_error());
+  output = std::string(out_str, out_len);
+  EXPECT_EQ(output, "");
 }
 
 TEST(TestStringOps, TestSplitPart) {


### PR DESCRIPTION
### Rationale for this change

The binary_string function will attempt to allocate 0 bytes of memory, which results in a null ptr being returned and the function interprets that as an error.

### What changes are included in this PR?
Add kCanReturnErrors to the function definition to match other string functions. 
Move the check for 0 byte length input earlier in the binary_string function to prevent the 0 allocation.
Add a unit test.

### Are these changes tested?
Yes, unit and integration testing.

### Are there any user-facing changes?
No.

* GitHub Issue: #49034