### PR TITLE
MINOR: [R] Add 22.0.0.1 to compatiblity matrix

### DIFF
--- a/dev/tasks/r/github.linux.arrow.version.back.compat.yml
+++ b/dev/tasks/r/github.linux.arrow.version.back.compat.yml
@@ -73,7 +73,7 @@ jobs:
         config:
         # We use the R version that was released at the time of the arrow release in order
         # to make sure we can download binaries from RSPM.
-        - { old_arrow_version: '22.0.0', r: '4.5' }
+        - { old_arrow_version: '22.0.0.1', r: '4.5' }
         - { old_arrow_version: '21.0.0.1', r: '4.5' }
         - { old_arrow_version: '20.0.0.2', r: '4.5' }
         - { old_arrow_version: '20.0.0', r: '4.5' }


### PR DESCRIPTION
### Rationale for this change

CI needs updating to test old R package versions

### What changes are included in this PR?

Add 22.0.0.1

### Are these changes tested?

Nah, it's CI stuff

### Are there any user-facing changes?

No