### PR TITLE
GH-49043: [C++][FS][Azure] Avoid bugs caused by empty first page(s) followed by non-empty subsequent page(s)

### DIFF
--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -967,6 +967,10 @@ Status StageBlock(Blobs::BlockBlobClient* block_blob_client, const std::string& 
   return Status::OK();
 }
 
+// Usually if the first page is empty it means there are no results. This was assumed in
+// several places in AzureFilesystem. The Azure docs do not guarantee this and we have
+// evidence (GH-49043) that there can be subsequent non-empty pages.
+// Applying `SkipStartingEmptyPages` on a paged response corrects this assumption.
 void SkipStartingEmptyPages(Blobs::ListBlobContainersPagedResponse& paged_response) {
   while (paged_response.HasPage() && paged_response.BlobContainers.empty()) {
     paged_response.MoveToNextPage();

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -1811,6 +1811,15 @@ class AzureFileSystem::Impl {
       // prefix or a blob.
       // This strategy allows us to implement GetFileInfo with just 1 blob storage
       // operation in almost every case.
+
+      // Its unusual but possible that the first page contains no results, while
+      // subsequent pages do. Keep fetching pages until we find something or run out of
+      // pages.
+      while (list_response.BlobPrefixes.empty() && list_response.Blobs.empty() &&
+             list_response.HasPage()) {
+        list_response.MoveToNextPage();
+      }
+
       if (!list_response.BlobPrefixes.empty()) {
         // Ensure the returned BlobPrefixes[0] string doesn't contain more characters than
         // the requested Prefix. For instance, if we request with Prefix="dir/abra" and

--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -1813,8 +1813,7 @@ class AzureFileSystem::Impl {
       // operation in almost every case.
 
       // Its unusual but possible that the first page contains no results, while
-      // subsequent pages do. Keep fetching pages until we find something or run out of
-      // pages.
+      // subsequent pages do. We need to find the first result or lack of results.
       while (list_response.BlobPrefixes.empty() && list_response.Blobs.empty() &&
              list_response.HasPage()) {
         list_response.MoveToNextPage();


### PR DESCRIPTION
### Rationale for this change
Prevent bugs similar to https://github.com/apache/arrow/issues/49043

### What changes are included in this PR?
- Implement `SkipStartingEmptyPages` for various types of PagedResponses used in the `AzureFileSystem`.
- Apply `SkipStartingEmptyPages` on the response from every list operation that returns a paged response.
 
### Are these changes tested?
Ran the tests in the codebase including the ones that need to connect to real blob storage. This makes me fairly confident that I haven't introduced a regression.

The only reproduce I've found involves reading a production Azure blob storage account. With this I've tested that this PR solves https://github.com/apache/arrow/issues/49043, but I haven't been able to reproduce it in any checked in tests. I tried copying a chunk of data around our prod reproduce into azurite, but still can't reproduce.

### Are there any user-facing changes?
Some low probability bugs will be gone. No interface changes. 
* GitHub Issue: #49043