### PR TITLE
GH-49055: [Ruby] Add support for writing decimal128/256 arrays

### DIFF
--- a/ruby/red-arrow-format/lib/arrow-format/type.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/type.rb
@@ -627,6 +627,14 @@ module ArrowFormat
       @precision = precision
       @scale = scale
     end
+
+    def to_flatbuffers
+      fb_type = FB::Decimal::Data.new
+      fb_type.bit_width = @byte_width * 8
+      fb_type.precision = @precision
+      fb_type.scale = @scale
+      fb_type
+    end
   end
 
   class Decimal128Type < DecimalType

--- a/ruby/red-arrow-format/test/test-writer.rb
+++ b/ruby/red-arrow-format/test/test-writer.rb
@@ -68,6 +68,12 @@ module WriterTests
       ArrowFormat::UTF8Type.singleton
     when Arrow::LargeStringDataType
       ArrowFormat::LargeUTF8Type.singleton
+    when Arrow::Decimal128DataType
+      ArrowFormat::Decimal128Type.new(red_arrow_type.precision,
+                                      red_arrow_type.scale)
+    when Arrow::Decimal256DataType
+      ArrowFormat::Decimal256Type.new(red_arrow_type.precision,
+                                      red_arrow_type.scale)
     when Arrow::FixedSizeBinaryDataType
       ArrowFormat::FixedSizeBinaryType.new(red_arrow_type.byte_width)
     else
@@ -441,6 +447,62 @@ module WriterTests
 
           def test_write
             assert_equal(["0124".b, nil, "abcd".b],
+                         @values)
+          end
+        end
+
+        sub_test_case("Decimal128") do
+          def build_array
+            @positive_small = "1.200"
+            @positive_large = ("1234567890" * 3) + "12345.678"
+            @negative_small = "-1.200"
+            @negative_large = "-" + ("1234567890" * 3) + "12345.678"
+            Arrow::Decimal128Array.new({precision: 38, scale: 3},
+                                       [
+                                         @positive_large,
+                                         @positive_small,
+                                         nil,
+                                         @negative_small,
+                                         @negative_large,
+                                       ])
+          end
+
+          def test_write
+            assert_equal([
+                           BigDecimal(@positive_large),
+                           BigDecimal(@positive_small),
+                           nil,
+                           BigDecimal(@negative_small),
+                           BigDecimal(@negative_large),
+                         ],
+                         @values)
+          end
+        end
+
+        sub_test_case("Decimal256") do
+          def build_array
+            @positive_small = "1.200"
+            @positive_large = ("1234567890" * 7) + "123.456"
+            @negative_small = "-1.200"
+            @negative_large = "-" + ("1234567890" * 7) + "123.456"
+            Arrow::Decimal256Array.new({precision: 76, scale: 3},
+                                       [
+                                         @positive_large,
+                                         @positive_small,
+                                         nil,
+                                         @negative_small,
+                                         @negative_large,
+                                       ])
+          end
+
+          def test_write
+            assert_equal([
+                           BigDecimal(@positive_large),
+                           BigDecimal(@positive_small),
+                           nil,
+                           BigDecimal(@negative_small),
+                           BigDecimal(@negative_large),
+                         ],
                          @values)
           end
         end


### PR DESCRIPTION
### Rationale for this change

Decimal128/256 arrays are only supported.

### What changes are included in this PR?

Add `ArrowFormat::DecimalType#to_flatbuffers`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #49055