### PR TITLE
GH-49069: [C++] Share Trie instances across CSV value decoders

### DIFF
--- a/cpp/src/arrow/csv/converter.cc
+++ b/cpp/src/arrow/csv/converter.cc
@@ -128,7 +128,7 @@ struct TrieCache {
 struct ValueDecoder {
   explicit ValueDecoder(const std::shared_ptr<DataType>& type,
                         const ConvertOptions& options, const TrieCache* trie_cache)
-      : type_(type), options_(options), trie_cache_(*trie_cache) {}
+      : type_(type), options_(options), trie_cache_(trie_cache) {}
 
   Status Initialize() { return Status::OK(); }
 
@@ -136,14 +136,14 @@ struct ValueDecoder {
     if (quoted && !options_.quoted_strings_can_be_null) {
       return false;
     }
-    return trie_cache_.null_trie.Find(
+    return trie_cache_->null_trie.Find(
                std::string_view(reinterpret_cast<const char*>(data), size)) >= 0;
   }
 
  protected:
   const std::shared_ptr<DataType> type_;
   const ConvertOptions& options_;
-  const TrieCache& trie_cache_;
+  const TrieCache* trie_cache_;
 };
 
 //
@@ -253,12 +253,12 @@ struct BooleanValueDecoder : public ValueDecoder {
 
   Status Decode(const uint8_t* data, uint32_t size, bool quoted, value_type* out) {
     // XXX should quoted values be allowed at all?
-    if (trie_cache_.false_trie.Find(
+    if (trie_cache_->false_trie.Find(
             std::string_view(reinterpret_cast<const char*>(data), size)) >= 0) {
       *out = false;
       return Status::OK();
     }
-    if (ARROW_PREDICT_TRUE(trie_cache_.true_trie.Find(std::string_view(
+    if (ARROW_PREDICT_TRUE(trie_cache_->true_trie.Find(std::string_view(
                                reinterpret_cast<const char*>(data), size)) >= 0)) {
       *out = true;
       return Status::OK();

--- a/cpp/src/arrow/csv/converter.h
+++ b/cpp/src/arrow/csv/converter.h
@@ -57,7 +57,9 @@ class ARROW_EXPORT Converter {
   const ConvertOptions& options_;
   MemoryPool* pool_;
   std::shared_ptr<DataType> type_;
-  std::shared_ptr<void> trie_cache_;  // Opaque pointer to TrieCache
+  // Opaque TrieCache pointer. TrieCache destructor is called via control block.
+  // https://en.cppreference.com/w/cpp/memory/shared_ptr
+  std::shared_ptr<void> trie_cache_;
 };
 
 class ARROW_EXPORT DictionaryConverter : public Converter {

--- a/cpp/src/arrow/csv/converter.h
+++ b/cpp/src/arrow/csv/converter.h
@@ -57,6 +57,7 @@ class ARROW_EXPORT Converter {
   const ConvertOptions& options_;
   MemoryPool* pool_;
   std::shared_ptr<DataType> type_;
+  std::shared_ptr<void> trie_cache_;  // Opaque pointer to TrieCache
 };
 
 class ARROW_EXPORT DictionaryConverter : public Converter {


### PR DESCRIPTION
### Rationale for this change

The CSV converter was building identical Trie data structures (for null/true/false values) in every decoder instance, causing duplicate memory allocation and initialization overhead.

### What changes are included in this PR?

- Introduced `TrieCache` struct to hold shared Trie instances (null_trie, true_trie, false_trie)
- Updated `ValueDecoder` and all decoder subclasses to accept and reference a shared `TrieCache` instead of building their own Tries
- Updated `Converter` base class to create one `TrieCache` per converter and pass it to all decoders

### Are these changes tested?

Yes, all existing tests. I ran a simple benchmark showing roughly 2-4% faster converter creation, and obviously less memory usage.

### Are there any user-facing changes?

No.
* GitHub Issue: #49069