### PR TITLE
GH-49071: [Ruby] Add support for writing list and large list arrays

### DIFF
--- a/c_glib/arrow-glib/basic-array.cpp
+++ b/c_glib/arrow-glib/basic-array.cpp
@@ -1114,7 +1114,11 @@ garrow_array_get_null_bitmap(GArrowArray *array)
 
   auto arrow_array = garrow_array_get_raw(array);
   auto arrow_null_bitmap = arrow_array->null_bitmap();
-  return garrow_buffer_new_raw(&arrow_null_bitmap);
+  if (arrow_null_bitmap) {
+    return garrow_buffer_new_raw(&arrow_null_bitmap);
+  } else {
+    return nullptr;
+  }
 }
 
 /**

--- a/c_glib/arrow-glib/composite-array.cpp
+++ b/c_glib/arrow-glib/composite-array.cpp
@@ -188,6 +188,22 @@ garrow_base_list_array_get_value_offsets(GArrowArray *array, gint64 *n_offsets)
   return arrow_list_array->raw_value_offsets();
 };
 
+template <typename LIST_ARRAY_CLASS>
+GArrowBuffer *
+garrow_base_list_array_get_value_offsets_buffer(GArrowArray *array)
+{
+  GArrowBuffer *buffer = nullptr;
+  g_object_get(array, "buffer1", &buffer, nullptr);
+  if (buffer) {
+    return buffer;
+  }
+
+  auto arrow_array = garrow_array_get_raw(array);
+  auto arrow_list_array = std::static_pointer_cast<LIST_ARRAY_CLASS>(arrow_array);
+  auto arrow_buffer = arrow_list_array->value_offsets();
+  return garrow_buffer_new_raw(&arrow_buffer);
+};
+
 G_BEGIN_DECLS
 
 static void
@@ -383,6 +399,21 @@ garrow_list_array_get_value_offsets(GArrowListArray *array, gint64 *n_offsets)
 {
   return garrow_base_list_array_get_value_offsets<arrow::ListArray>(GARROW_ARRAY(array),
                                                                     n_offsets);
+}
+
+/**
+ * garrow_list_array_get_value_offsets_buffer:
+ * @array: A #GArrowListArray.
+ *
+ * Returns: (transfer full) (nullable): The value offsets buffer.
+ *
+ * Since: 24.0.0
+ */
+GArrowBuffer *
+garrow_list_array_get_value_offsets_buffer(GArrowListArray *array)
+{
+  return garrow_base_list_array_get_value_offsets_buffer<arrow::ListArray>(
+    GARROW_ARRAY(array));
 }
 
 typedef struct GArrowLargeListArrayPrivate_
@@ -600,6 +631,21 @@ garrow_large_list_array_get_value_offsets(GArrowLargeListArray *array, gint64 *n
     garrow_base_list_array_get_value_offsets<arrow::LargeListArray>(GARROW_ARRAY(array),
                                                                     n_offsets);
   return reinterpret_cast<const gint64 *>(value_offsets);
+}
+
+/**
+ * garrow_large_list_array_get_value_offsets_buffer:
+ * @array: A #GArrowLargeListArray.
+ *
+ * Returns: (transfer full) (nullable): The value offsets buffer.
+ *
+ * Since: 24.0.0
+ */
+GArrowBuffer *
+garrow_large_list_array_get_value_offsets_buffer(GArrowLargeListArray *array)
+{
+  return garrow_base_list_array_get_value_offsets_buffer<arrow::LargeListArray>(
+    GARROW_ARRAY(array));
 }
 
 typedef struct GArrowFixedSizeListArrayPrivate_

--- a/c_glib/arrow-glib/composite-array.h
+++ b/c_glib/arrow-glib/composite-array.h
@@ -68,6 +68,10 @@ GARROW_AVAILABLE_IN_2_0
 const gint32 *
 garrow_list_array_get_value_offsets(GArrowListArray *array, gint64 *n_offsets);
 
+GARROW_AVAILABLE_IN_24_0
+GArrowBuffer *
+garrow_list_array_get_value_offsets_buffer(GArrowListArray *array);
+
 #define GARROW_TYPE_LARGE_LIST_ARRAY (garrow_large_list_array_get_type())
 GARROW_AVAILABLE_IN_0_16
 G_DECLARE_DERIVABLE_TYPE(
@@ -109,6 +113,10 @@ garrow_large_list_array_get_value_length(GArrowLargeListArray *array, gint64 i);
 GARROW_AVAILABLE_IN_2_0
 const gint64 *
 garrow_large_list_array_get_value_offsets(GArrowLargeListArray *array, gint64 *n_offsets);
+
+GARROW_AVAILABLE_IN_24_0
+GArrowBuffer *
+garrow_large_list_array_get_value_offsets_buffer(GArrowLargeListArray *array);
 
 #define GARROW_TYPE_FIXED_SIZE_LIST_ARRAY (garrow_fixed_size_list_array_get_type())
 GARROW_AVAILABLE_IN_23_0

--- a/ruby/red-arrow-format/lib/arrow-format/array.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/array.rb
@@ -370,10 +370,18 @@ module ArrowFormat
   end
 
   class VariableSizeListArray < Array
+    attr_reader :child
     def initialize(type, size, validity_buffer, offsets_buffer, child)
       super(type, size, validity_buffer)
       @offsets_buffer = offsets_buffer
       @child = child
+    end
+
+    def each_buffer(&block)
+      return to_enum(__method__) unless block_given?
+
+      yield(@validity_buffer)
+      yield(@offsets_buffer)
     end
 
     def to_a

--- a/ruby/red-arrow-format/lib/arrow-format/field.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/field.rb
@@ -49,7 +49,9 @@ module ArrowFormat
       else
         fb_field.type = @type.to_flatbuffers
       end
-      if @type.respond_to?(:children)
+      if @type.respond_to?(:child)
+        fb_field.children = [@type.child.to_flatbuffers]
+      elsif @type.respond_to?(:children)
         fb_field.children = @type.children.collect(&:to_flatbuffers)
       end
       # fb_field.custom_metadata = @custom_metadata

--- a/ruby/red-arrow-format/lib/arrow-format/record-batch.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/record-batch.rb
@@ -70,7 +70,9 @@ module ArrowFormat
       Enumerator.new do |yielder|
         traverse = lambda do |array|
           yielder << array
-          if array.respond_to?(:children)
+          if array.respond_to?(:child)
+            traverse.call(array.child)
+          elsif array.respond_to?(:children)
             array.children.each do |child_array|
               traverse.call(child_array)
             end

--- a/ruby/red-arrow-format/lib/arrow-format/type.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/type.rb
@@ -678,7 +678,6 @@ module ArrowFormat
       super()
       @child = child
     end
-
   end
 
   class ListType < VariableSizeListType
@@ -689,6 +688,10 @@ module ArrowFormat
     def build_array(size, validity_buffer, offsets_buffer, child)
       ListArray.new(self, size, validity_buffer, offsets_buffer, child)
     end
+
+    def to_flatbuffers
+      FB::List::Data.new
+    end
   end
 
   class LargeListType < VariableSizeListType
@@ -698,6 +701,10 @@ module ArrowFormat
 
     def build_array(size, validity_buffer, offsets_buffer, child)
       LargeListArray.new(self, size, validity_buffer, offsets_buffer, child)
+    end
+
+    def to_flatbuffers
+      FB::LargeList::Data.new
     end
   end
 


### PR DESCRIPTION
### Rationale for this change

They use different offset size.

### What changes are included in this PR?

* Add `ArrowFormat::ListType#to_flatbuffers`
* Add `ArrowFormat::LargeListType#to_flatbuffers`
* Add `ArrowFormat::VariableSizeListArray#child`
* Add `ArrowFormat::VariableSizeListArray#each_buffer`
* `garrow_array_get_null_bitmap()` returns `NULL` when null bitmap doesn't exist
* Add `garrow_list_array_get_value_offsets_buffer()`
* Add `garrow_large_list_array_get_value_offsets_buffer()`

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #49071