### PR TITLE
GH-49064: [C++] Fix thread safety in DictionaryArray::dictionary()

### DIFF
--- a/cpp/src/arrow/array/array_dict.cc
+++ b/cpp/src/arrow/array/array_dict.cc
@@ -108,10 +108,9 @@ DictionaryArray::DictionaryArray(const std::shared_ptr<DataType>& type,
 }
 
 const std::shared_ptr<Array>& DictionaryArray::dictionary() const {
-  if (!dictionary_) {
-    // TODO(GH-36503) this isn't thread safe
-    dictionary_ = MakeArray(data_->dictionary);
-  }
+  std::call_once(dict_init_flag_, [this]() {
+    const_cast<DictionaryArray*>(this)->dictionary_ = MakeArray(data_->dictionary);
+  });
   return dictionary_;
 }
 

--- a/cpp/src/arrow/array/array_dict.h
+++ b/cpp/src/arrow/array/array_dict.h
@@ -19,6 +19,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <mutex>
 
 #include "arrow/array/array_base.h"
 #include "arrow/array/data.h"
@@ -120,6 +121,7 @@ class ARROW_EXPORT DictionaryArray : public Array {
 
   // Lazily initialized when invoking dictionary()
   mutable std::shared_ptr<Array> dictionary_;
+  mutable std::once_flag dict_init_flag_;
 };
 
 /// \brief Helper class for incremental dictionary unification


### PR DESCRIPTION
## Rationale for this change
`DictionaryArray::dictionary()` does lazy initialization without thread synchronization, causing race conditions when multiple threads access the same instance concurrently.

## Chages 
- Use `std::call_once` with `std::once_flag` for thread-safe lazy initialization
- Added `#include <mutex>` 
- Removed TODO comment at line 112
* GitHub Issue: #49064