### PR TITLE
GH-49084: [CI][Dev] Wait for odbc-nightly before executing CPP extra report job

### DIFF
--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -656,5 +656,6 @@ jobs:
       - msvc-arm64
       - odbc-macos
       - odbc-msvc
+      - odbc-nightly
     uses: ./.github/workflows/report_ci.yml
     secrets: inherit


### PR DESCRIPTION
### Rationale for this change

The report is currently shown as failed because we are not waiting for the nightly job to finish.

### What changes are included in this PR?

Add `odbc-nightly` to the list of needed jobs before running report.

### Are these changes tested?

No, but really minor

### Are there any user-facing changes?

No

* GitHub Issue: #49084