### PR TITLE
GH-49087 [CI][Packaging][Gandiva] Add support for LLVM 15 or earlier again

### DIFF
--- a/cpp/src/gandiva/engine.cc
+++ b/cpp/src/gandiva/engine.cc
@@ -230,7 +230,11 @@ Result<std::unique_ptr<llvm::orc::LLJIT>> BuildJIT(
 #endif
 
   jit_builder.setJITTargetMachineBuilder(std::move(jtmb));
+#if LLVM_VERSION_MAJOR >= 16
   jit_builder.setDataLayout(std::make_optional(data_layout));
+#else
+  jit_builder.setDataLayout(llvm::Optional<llvm::DataLayout>(data_layout));
+#endif
 
   if (object_cache.has_value()) {
     jit_builder.setCompileFunctionCreator(


### PR DESCRIPTION
### Rationale for this change

LLVM 15 or earlier uses `llvm::Optional` not `std::optional`.

### What changes are included in this PR?

Use `llvm::Optional` with LLVM 15 or earlier.

### Are these changes tested?

Yes, compiling.

### Are there any user-facing changes?

No

* GitHub Issue: #49087