### PR TITLE
GH-49096: [Ruby] Add support for writing struct array

### DIFF
--- a/ruby/red-arrow-format/lib/arrow-format/bitmap.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/bitmap.rb
@@ -33,14 +33,14 @@ module ArrowFormat
       n_bytes = @n_values / 8
       @buffer.each(:U8, 0, n_bytes) do |offset, value|
         7.times do |i|
-          yield(value & (1 << (i % 8)))
+          yield((value & (1 << (i % 8))) > 0)
         end
       end
       remained_bits = @n_values % 8
       unless remained_bits.zero?
         value = @buffer.get_value(:U8, n_bytes)
         remained_bits.times do |i|
-          yield(value & (1 << (i % 8)))
+          yield((value & (1 << (i % 8))) > 0)
         end
       end
     end

--- a/ruby/red-arrow-format/lib/arrow-format/type.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/type.rb
@@ -751,6 +751,10 @@ module ArrowFormat
     def build_array(size, validity_buffer, children)
       StructArray.new(self, size, validity_buffer, children)
     end
+
+    def to_flatbuffers
+      FB::Struct::Data.new
+    end
   end
 
   class MapType < VariableSizeListType


### PR DESCRIPTION
### Rationale for this change

It's a nested array.

### What changes are included in this PR?

* Add `ArrowFormat::StructType#to_flatbuffers`
* Add `ArrowFormat::StructArray#each_buffer`
* Add `ArrowFormat::StructArray#children`
* Fix `ArrowFormat::Array#n_nulls`

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #49096