### PR TITLE
GH-49098: [Packaging][deb] Add missing libarrow-cuda-glib-doc

### DIFF
--- a/dev/tasks/linux-packages/apache-arrow/debian/control.in
+++ b/dev/tasks/linux-packages/apache-arrow/debian/control.in
@@ -381,6 +381,17 @@ Description: Apache Arrow is a data processing library for analysis
  .
  This package provides GLib based library files for CUDA support.
 
+Package: libarrow-cuda-glib-doc
+Section: doc
+Architecture: @CUDA_ARCHITECTURE@
+Multi-Arch: foreign
+Depends:
+  ${misc:Depends}
+Recommends: libarrow-glib-doc
+Description: Apache Arrow is a data processing library for analysis
+ .
+ This package provides documentations for CUDA support.
+
 Package: gir1.2-arrow-cuda-24.0
 Section: introspection
 Architecture: @CUDA_ARCHITECTURE@

--- a/dev/tasks/linux-packages/apache-arrow/debian/libarrow-cuda-glib-doc.doc-base
+++ b/dev/tasks/linux-packages/apache-arrow/debian/libarrow-cuda-glib-doc.doc-base
@@ -1,0 +1,9 @@
+Document: arrow-cuda-glib
+Title: Apache Arrow CUDA GLib Reference Manual
+Author: The Apache Software Foundation
+Abstract: Apache Arrow CUDA GLib provides an API for CUDA integration.
+Section: Programming
+
+Format: HTML
+Index: /usr/share/doc/libarrow-cuda-glib-doc/arrow-cuda-glib/index.html
+Files: /usr/share/doc/libarrow-cuda-glib-doc/arrow-cuda-glib/*.html

--- a/dev/tasks/linux-packages/apache-arrow/debian/libarrow-cuda-glib-doc.install
+++ b/dev/tasks/linux-packages/apache-arrow/debian/libarrow-cuda-glib-doc.install
@@ -1,0 +1,1 @@
+usr/share/doc/arrow-cuda-glib usr/share/doc/libarrow-cuda-glib-doc/

--- a/dev/tasks/linux-packages/apache-arrow/debian/libarrow-cuda-glib-doc.links
+++ b/dev/tasks/linux-packages/apache-arrow/debian/libarrow-cuda-glib-doc.links
@@ -1,0 +1,5 @@
+usr/share/doc/libarrow-cuda-glib-doc/arrow-cuda-glib usr/share/devhelp/books/arrow-cuda-glib
+usr/share/doc/libarrow-glib-doc/arrow-glib usr/share/doc/libarrow-cuda-glib-doc/arrow-glib
+usr/share/doc/libglib2.0-doc/gio usr/share/doc/libarrow-cuda-glib-doc/gio
+usr/share/doc/libglib2.0-doc/glib usr/share/doc/libarrow-cuda-glib-doc/glib
+usr/share/doc/libglib2.0-doc/gobject usr/share/doc/libarrow-cuda-glib-doc/gobject

--- a/dev/tasks/linux-packages/apache-arrow/debian/rules
+++ b/dev/tasks/linux-packages/apache-arrow/debian/rules
@@ -86,12 +86,12 @@ override_dh_auto_build:
 
 override_dh_auto_install:
 	dh_auto_install				\
+	  --sourcedirectory=cpp			\
+	  --builddirectory=cpp_build
+	dh_auto_install				\
 	  --sourcedirectory=c_glib		\
 	  --builddirectory=c_glib_build		\
 	  --buildsystem=meson+ninja
-	dh_auto_install				\
-	  --sourcedirectory=cpp			\
-	  --builddirectory=cpp_build
 
 override_dh_auto_test:
 	# TODO: We need Boost 1.64 or later to build tests for


### PR DESCRIPTION
### Rationale for this change

Documents for libarrow-cuda-glib are generated but they aren't packaged.

### What changes are included in this PR?

Package documents for libarrow-cuda-glib.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #49098