### PR TITLE
GH-49100: [Docs] Broken link to Swift page in implementations.rst

### DIFF
--- a/docs/source/implementations.rst
+++ b/docs/source/implementations.rst
@@ -121,6 +121,6 @@ The source files for the Cookbook are maintained in the
    R <https://arrow.apache.org/docs/r>
    Ruby <https://github.com/apache/arrow/blob/main/ruby/README.md>
    Rust <https://docs.rs/crate/arrow/>
-   Swift <https://github.com/apache/arrow-swift/blob/main/Arrow/README.md>
+   Swift <https://swiftpackageindex.com/apache/arrow-swift/main/documentation/arrow>
    nanoarrow <https://arrow.apache.org/nanoarrow/>
    Implementation Status <status>

--- a/docs/source/implementations.rst
+++ b/docs/source/implementations.rst
@@ -121,6 +121,6 @@ The source files for the Cookbook are maintained in the
    R <https://arrow.apache.org/docs/r>
    Ruby <https://github.com/apache/arrow/blob/main/ruby/README.md>
    Rust <https://docs.rs/crate/arrow/>
-   Swift <https://swiftpackageindex.com/apache/arrow-swift/main/documentation/arrow>
+   Swift <https://arrow.apache.org/swift/>
    nanoarrow <https://arrow.apache.org/nanoarrow/>
    Implementation Status <status>


### PR DESCRIPTION
### Rationale for this change

The Swift documentation link in the implementations.rst file was broken and returned a 404 error.

### What changes are included in this PR?

Updated the Swift documentation link in https://github.com/apache/arrow/blob/235841d644d5454f7067c44f580f301446ba1cc0/docs/source/implementations.rst?plain=1#L124 from the [broken GitHub README link](https://github.com/apache/arrow-swift/blob/main/Arrow/README.md) to the [Swift Package documentation](https://swiftpackageindex.com/apache/arrow-swift/main/documentation/arrow)

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.

* GitHub Issue: #49100