### PR TITLE
GH-49104: [C++] Fix Segfault in SparseCSFIndex::Equals with mismatched dimensions

### DIFF
--- a/cpp/src/arrow/sparse_tensor.cc
+++ b/cpp/src/arrow/sparse_tensor.cc
@@ -416,14 +416,10 @@ bool SparseCSFIndex::Equals(const SparseCSFIndex& other) const {
   }
 
   for (int64_t i = 0; i < static_cast<int64_t>(indices().size()); ++i) {
-    if (!indices()[i]->Equals(*other.indices()[i])) {
-      return false;
-    }
+    if (!indices()[i]->Equals(*other.indices()[i])) return false;
   }
   for (int64_t i = 0; i < static_cast<int64_t>(indptr().size()); ++i) {
-    if (!indptr()[i]->Equals(*other.indptr()[i])) {
-      return false;
-    }
+    if (!indptr()[i]->Equals(*other.indptr()[i])) return false;
   }
   return axis_order() == other.axis_order();
 }

--- a/cpp/src/arrow/sparse_tensor.cc
+++ b/cpp/src/arrow/sparse_tensor.cc
@@ -405,21 +405,6 @@ SparseCSFIndex::SparseCSFIndex(const std::vector<std::shared_ptr<Tensor>>& indpt
 std::string SparseCSFIndex::ToString() const { return std::string("SparseCSFIndex"); }
 
 bool SparseCSFIndex::Equals(const SparseCSFIndex& other) const {
-  if (indices().size() != other.indices().size()) {
-    return false;
-  }
-  if (indptr().size() != other.indptr().size()) {
-    return false;
-  }
-
-  for (int64_t i = 0; i < static_cast<int64_t>(indices().size()); ++i) {
-    if (!indices()[i]->Equals(*other.indices()[i])) return false;
-  }
-  for (int64_t i = 0; i < static_cast<int64_t>(indptr().size()); ++i) {
-    if (!indptr()[i]->Equals(*other.indptr()[i])) return false;
-  }
-  return axis_order() == other.axis_order();
-bool SparseCSFIndex::Equals(const SparseCSFIndex& other) const {
   auto eq = [](const auto& a, const auto& b) { return a->Equals(*b); };
   return axis_order() == other.axis_order()
       && std::ranges::equal(indices(), other.indices(), eq)

--- a/cpp/src/arrow/sparse_tensor.cc
+++ b/cpp/src/arrow/sparse_tensor.cc
@@ -419,6 +419,11 @@ bool SparseCSFIndex::Equals(const SparseCSFIndex& other) const {
     if (!indptr()[i]->Equals(*other.indptr()[i])) return false;
   }
   return axis_order() == other.axis_order();
+bool SparseCSFIndex::Equals(const SparseCSFIndex& other) const {
+  auto eq = [](const auto& a, const auto& b) { return a->Equals(*b); };
+  return axis_order() == other.axis_order()
+      && std::ranges::equal(indices(), other.indices(), eq)
+      && std::ranges::equal(indptr(), other.indptr(), eq);
 }
 
 // ----------------------------------------------------------------------

--- a/cpp/src/arrow/sparse_tensor.cc
+++ b/cpp/src/arrow/sparse_tensor.cc
@@ -405,14 +405,25 @@ SparseCSFIndex::SparseCSFIndex(const std::vector<std::shared_ptr<Tensor>>& indpt
 std::string SparseCSFIndex::ToString() const { return std::string("SparseCSFIndex"); }
 
 bool SparseCSFIndex::Equals(const SparseCSFIndex& other) const {
-  if (indices().size() != other.indices().size()) return false;
-  if (indptr().size() != other.indptr().size()) return false;
-  if (axis_order().size() != other.axis_order().size()) return false;
+  if (indices().size() != other.indices().size()) {
+    return false;
+  }
+  if (indptr().size() != other.indptr().size()) {
+    return false;
+  }
+  if (axis_order().size() != other.axis_order().size()) {
+    return false;
+  }
+
   for (int64_t i = 0; i < static_cast<int64_t>(indices().size()); ++i) {
-    if (!indices()[i]->Equals(*other.indices()[i])) return false;
+    if (!indices()[i]->Equals(*other.indices()[i])) {
+      return false;
+    }
   }
   for (int64_t i = 0; i < static_cast<int64_t>(indptr().size()); ++i) {
-    if (!indptr()[i]->Equals(*other.indptr()[i])) return false;
+    if (!indptr()[i]->Equals(*other.indptr()[i])) {
+      return false;
+    }
   }
   return axis_order() == other.axis_order();
 }

--- a/cpp/src/arrow/sparse_tensor.cc
+++ b/cpp/src/arrow/sparse_tensor.cc
@@ -407,8 +407,8 @@ std::string SparseCSFIndex::ToString() const { return std::string("SparseCSFInde
 bool SparseCSFIndex::Equals(const SparseCSFIndex& other) const {
   auto eq = [](const auto& a, const auto& b) { return a->Equals(*b); };
   return axis_order() == other.axis_order() &&
-      std::ranges::equal(indices(), other.indices(), eq) &&
-      std::ranges::equal(indptr(), other.indptr(), eq);
+         std::ranges::equal(indices(), other.indices(), eq) &&
+         std::ranges::equal(indptr(), other.indptr(), eq);
 }
 
 // ----------------------------------------------------------------------

--- a/cpp/src/arrow/sparse_tensor.cc
+++ b/cpp/src/arrow/sparse_tensor.cc
@@ -405,9 +405,9 @@ SparseCSFIndex::SparseCSFIndex(const std::vector<std::shared_ptr<Tensor>>& indpt
 std::string SparseCSFIndex::ToString() const { return std::string("SparseCSFIndex"); }
 
 bool SparseCSFIndex::Equals(const SparseCSFIndex& other) const {
-  if (indices().size() != other.indices().size() || indptr().size() != other.indptr().size()) {
-    return false;
-  }
+  if (indices().size() != other.indices().size()) return false;
+  if (indptr().size() != other.indptr().size()) return false;
+  if (axis_order().size() != other.axis_order().size()) return false;
   for (int64_t i = 0; i < static_cast<int64_t>(indices().size()); ++i) {
     if (!indices()[i]->Equals(*other.indices()[i])) return false;
   }

--- a/cpp/src/arrow/sparse_tensor.cc
+++ b/cpp/src/arrow/sparse_tensor.cc
@@ -411,9 +411,6 @@ bool SparseCSFIndex::Equals(const SparseCSFIndex& other) const {
   if (indptr().size() != other.indptr().size()) {
     return false;
   }
-  if (axis_order().size() != other.axis_order().size()) {
-    return false;
-  }
 
   for (int64_t i = 0; i < static_cast<int64_t>(indices().size()); ++i) {
     if (!indices()[i]->Equals(*other.indices()[i])) return false;

--- a/cpp/src/arrow/sparse_tensor.cc
+++ b/cpp/src/arrow/sparse_tensor.cc
@@ -406,9 +406,9 @@ std::string SparseCSFIndex::ToString() const { return std::string("SparseCSFInde
 
 bool SparseCSFIndex::Equals(const SparseCSFIndex& other) const {
   auto eq = [](const auto& a, const auto& b) { return a->Equals(*b); };
-  return axis_order() == other.axis_order()
-      && std::ranges::equal(indices(), other.indices(), eq)
-      && std::ranges::equal(indptr(), other.indptr(), eq);
+  return axis_order() == other.axis_order() &&
+      std::ranges::equal(indices(), other.indices(), eq) &&
+      std::ranges::equal(indptr(), other.indptr(), eq);
 }
 
 // ----------------------------------------------------------------------

--- a/cpp/src/arrow/sparse_tensor.cc
+++ b/cpp/src/arrow/sparse_tensor.cc
@@ -405,6 +405,9 @@ SparseCSFIndex::SparseCSFIndex(const std::vector<std::shared_ptr<Tensor>>& indpt
 std::string SparseCSFIndex::ToString() const { return std::string("SparseCSFIndex"); }
 
 bool SparseCSFIndex::Equals(const SparseCSFIndex& other) const {
+  if (indices().size() != other.indices().size() || indptr().size() != other.indptr().size()) {
+    return false;
+  }
   for (int64_t i = 0; i < static_cast<int64_t>(indices().size()); ++i) {
     if (!indices()[i]->Equals(*other.indices()[i])) return false;
   }

--- a/cpp/src/arrow/sparse_tensor_test.cc
+++ b/cpp/src/arrow/sparse_tensor_test.cc
@@ -1645,19 +1645,21 @@ TYPED_TEST_P(TestSparseCSFTensorForIndexValueType, TestEqualityMismatchedDimensi
   using IndexValueType = TypeParam;
   using c_index_value_type = typename IndexValueType::c_type;
 
-  // 1D (trivial) vs 2D
-  std::vector<int64_t> axis_order_1D = {0};
-  std::vector<std::vector<c_index_value_type>> indptr_1D = {{0, 1}};
-  std::vector<std::vector<c_index_value_type>> indices_1D = {{0}};
-  auto si_1D = this->MakeSparseCSFIndex(axis_order_1D, indptr_1D, indices_1D);
-
+  // 2D vs 3D - comparing indices with different dimensionality
+  // 2D CSF: ndim=2, so indptr.size()=1, indices.size()=2
   std::vector<int64_t> axis_order_2D = {0, 1};
   std::vector<std::vector<c_index_value_type>> indptr_2D = {{0, 1}};
   std::vector<std::vector<c_index_value_type>> indices_2D = {{0}, {0}};
   auto si_2D = this->MakeSparseCSFIndex(axis_order_2D, indptr_2D, indices_2D);
 
-  ASSERT_FALSE(si_1D->Equals(*si_2D));
-  ASSERT_FALSE(si_2D->Equals(*si_1D));
+  // 3D CSF: ndim=3, so indptr.size()=2, indices.size()=3
+  std::vector<int64_t> axis_order_3D = {0, 1, 2};
+  std::vector<std::vector<c_index_value_type>> indptr_3D = {{0, 1}, {0, 1}};
+  std::vector<std::vector<c_index_value_type>> indices_3D = {{0}, {0}, {0}};
+  auto si_3D = this->MakeSparseCSFIndex(axis_order_3D, indptr_3D, indices_3D);
+
+  ASSERT_FALSE(si_2D->Equals(*si_3D));
+  ASSERT_FALSE(si_3D->Equals(*si_2D));
 }
 
 REGISTER_TYPED_TEST_SUITE_P(TestSparseCSFTensorForIndexValueType, TestCreateSparseTensor,

--- a/cpp/src/arrow/sparse_tensor_test.cc
+++ b/cpp/src/arrow/sparse_tensor_test.cc
@@ -1697,29 +1697,4 @@ TEST(TestSparseCSFMatrixForUInt64Index, Make) {
   ASSERT_RAISES(Invalid, SparseCSFTensor::Make(dense_tensor, uint64()));
 }
 
-TEST(TestSparseCSFIndex, EqualsMismatchedDimensions) {
-  std::vector<int64_t> axis_order_4d = {0, 1, 2, 3};
-  std::vector<int64_t> axis_order_2d = {0, 1};
-
-  // Create empty tensors for indptr/indices
-  auto empty_buffer = std::make_shared<Buffer>(nullptr, 0);
-  auto tensor_4d = std::make_shared<Tensor>(int32(), empty_buffer, std::vector<int64_t>{0});
-  auto tensor_2d = std::make_shared<Tensor>(int32(), empty_buffer, std::vector<int64_t>{0});
-
-  // Create a 4D index
-  std::vector<std::shared_ptr<Tensor>> indptr_4d = {tensor_4d, tensor_4d, tensor_4d};
-  std::vector<std::shared_ptr<Tensor>> indices_4d = {tensor_4d, tensor_4d, tensor_4d, tensor_4d};
-  auto si_4d = std::make_shared<SparseCSFIndex>(indptr_4d, indices_4d, axis_order_4d);
-
-  // Create a 2D index
-  std::vector<std::shared_ptr<Tensor>> indptr_2d = {tensor_2d};
-  std::vector<std::shared_ptr<Tensor>> indices_2d = {tensor_2d, tensor_2d};
-  auto si_2d = std::make_shared<SparseCSFIndex>(indptr_2d, indices_2d, axis_order_2d);
-
-  // Before fix: This would segfault.
-  // After fix: Returns false safely.
-  ASSERT_FALSE(si_4d->Equals(*si_2d));
-  ASSERT_FALSE(si_2d->Equals(*si_4d));
-}
-
 }  // namespace arrow

--- a/cpp/src/arrow/sparse_tensor_test.cc
+++ b/cpp/src/arrow/sparse_tensor_test.cc
@@ -1676,4 +1676,29 @@ TEST(TestSparseCSFMatrixForUInt64Index, Make) {
   ASSERT_RAISES(Invalid, SparseCSFTensor::Make(dense_tensor, uint64()));
 }
 
+TEST(TestSparseCSFIndex, EqualsMismatchedDimensions) {
+  std::vector<int64_t> axis_order_4d = {0, 1, 2, 3};
+  std::vector<int64_t> axis_order_2d = {0, 1};
+
+  // Create empty tensors for indptr/indices
+  auto empty_buffer = std::make_shared<Buffer>(nullptr, 0);
+  auto tensor_4d = std::make_shared<Tensor>(int32(), empty_buffer, std::vector<int64_t>{0});
+  auto tensor_2d = std::make_shared<Tensor>(int32(), empty_buffer, std::vector<int64_t>{0});
+
+  // Create a 4D index
+  std::vector<std::shared_ptr<Tensor>> indptr_4d = {tensor_4d, tensor_4d, tensor_4d};
+  std::vector<std::shared_ptr<Tensor>> indices_4d = {tensor_4d, tensor_4d, tensor_4d, tensor_4d};
+  auto si_4d = std::make_shared<SparseCSFIndex>(indptr_4d, indices_4d, axis_order_4d);
+
+  // Create a 2D index
+  std::vector<std::shared_ptr<Tensor>> indptr_2d = {tensor_2d};
+  std::vector<std::shared_ptr<Tensor>> indices_2d = {tensor_2d, tensor_2d};
+  auto si_2d = std::make_shared<SparseCSFIndex>(indptr_2d, indices_2d, axis_order_2d);
+
+  // Before fix: This would segfault.
+  // After fix: Returns false safely.
+  ASSERT_FALSE(si_4d->Equals(*si_2d));
+  ASSERT_FALSE(si_2d->Equals(*si_4d));
+}
+
 }  // namespace arrow

--- a/cpp/src/arrow/sparse_tensor_test.cc
+++ b/cpp/src/arrow/sparse_tensor_test.cc
@@ -1660,6 +1660,7 @@ TYPED_TEST_P(TestSparseCSFTensorForIndexValueType, TestEqualityMismatchedDimensi
 
   ASSERT_FALSE(si_2D->Equals(*si_3D));
   ASSERT_FALSE(si_3D->Equals(*si_2D));
+  ASSERT_TRUE(si_2D->Equals(*si_2D));
 }
 
 REGISTER_TYPED_TEST_SUITE_P(TestSparseCSFTensorForIndexValueType, TestCreateSparseTensor,

--- a/cpp/src/arrow/sparse_tensor_test.cc
+++ b/cpp/src/arrow/sparse_tensor_test.cc
@@ -1641,10 +1641,29 @@ TYPED_TEST_P(TestSparseCSFTensorForIndexValueType, TestNonAscendingShape) {
   ASSERT_TRUE(st->Equals(*sparse_tensor));
 }
 
+TYPED_TEST_P(TestSparseCSFTensorForIndexValueType, TestEqualityMismatchedDimensions) {
+  using IndexValueType = TypeParam;
+  using c_index_value_type = typename IndexValueType::c_type;
+
+  // 1D (trivial) vs 2D
+  std::vector<int64_t> axis_order_1D = {0};
+  std::vector<std::vector<c_index_value_type>> indptr_1D = {{0, 1}};
+  std::vector<std::vector<c_index_value_type>> indices_1D = {{0}};
+  auto si_1D = this->MakeSparseCSFIndex(axis_order_1D, indptr_1D, indices_1D);
+
+  std::vector<int64_t> axis_order_2D = {0, 1};
+  std::vector<std::vector<c_index_value_type>> indptr_2D = {{0, 1}};
+  std::vector<std::vector<c_index_value_type>> indices_2D = {{0}, {0}};
+  auto si_2D = this->MakeSparseCSFIndex(axis_order_2D, indptr_2D, indices_2D);
+
+  ASSERT_FALSE(si_1D->Equals(*si_2D));
+  ASSERT_FALSE(si_2D->Equals(*si_1D));
+}
+
 REGISTER_TYPED_TEST_SUITE_P(TestSparseCSFTensorForIndexValueType, TestCreateSparseTensor,
                             TestTensorToSparseTensor, TestSparseTensorToTensor,
                             TestAlternativeAxisOrder, TestNonAscendingShape,
-                            TestRoundTrip);
+                            TestRoundTrip, TestEqualityMismatchedDimensions);
 
 INSTANTIATE_TYPED_TEST_SUITE_P(TestInt8, TestSparseCSFTensorForIndexValueType, Int8Type);
 INSTANTIATE_TYPED_TEST_SUITE_P(TestUInt8, TestSparseCSFTensorForIndexValueType,


### PR DESCRIPTION
### Rationale for This Change

The `SparseCSFIndex::Equals` method can crash when comparing two sparse indices that have a different number of dimensions. The method iterates over the `indices()` and `indptr()` vectors of the current object and accesses the corresponding elements in the `other` object without first verifying that both objects have matching vector sizes. This can lead to out-of-bounds access and a segmentation fault when the dimension counts differ.

### What Changes Are Included in This PR?

This change adds explicit size equality checks for the `indices()` and `indptr()` vectors at the beginning of the `SparseCSFIndex::Equals` method. If the dimensions do not match, the method now safely returns `false` instead of attempting invalid memory access.

### Are These Changes Tested?

Yes. The fix has been validated through targeted reproduction of the crash scenario using mismatched dimension counts, ensuring the method behaves safely and deterministically.

### Are There Any User-Facing Changes?

No. This change improves internal safety and robustness without altering public APIs or observable user behavior.


* GitHub Issue: #49104