### PR TITLE
GH-49107: [C++] Doc update in aggregate_basic for first-last

### DIFF
--- a/cpp/src/arrow/compute/kernels/aggregate_basic.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_basic.cc
@@ -971,15 +971,15 @@ const FunctionDoc first_last_doc{
 const FunctionDoc first_doc{
     "Compute the first value in each group",
     ("Null values are ignored by default.\n"
-     "If skip_nulls = false, then this will return the first and last values\n"
+     "If skip_nulls = false, then this will return the first value\n"
      "regardless if it is null"),
     {"array"},
     "ScalarAggregateOptions"};
 
 const FunctionDoc last_doc{
-    "Compute the first value in each group",
+    "Compute the last value in each group",
     ("Null values are ignored by default.\n"
-     "If skip_nulls = false, then this will return the first and last values\n"
+     "If skip_nulls = false, then this will return the last value\n"
      "regardless if it is null"),
     {"array"},
     "ScalarAggregateOptions"};


### PR DESCRIPTION
fix consistency issues in doc between the first - last - first/last functions

### Rationale for this change

small change in docs
there seems to be some copy-paste residuals from the 3 version of the function

### What changes are included in this PR? 
Doc change

### Are these changes tested? 
No

### Are there any user-facing changes? 
Just doc

* GitHub Issue: #49107