### PR TITLE
GH-49108: [Python] SparseCOOTensor.__repr__ missing f-string prefix

### DIFF
--- a/python/pyarrow/tensor.pxi
+++ b/python/pyarrow/tensor.pxi
@@ -359,7 +359,7 @@ cdef class SparseCOOTensor(_Weakrefable):
         self.type = pyarrow_wrap_data_type(self.stp.type())
 
     def __repr__(self):
-        return """<pyarrow.SparseCOOTensor>
+        return f"""<pyarrow.SparseCOOTensor>
 type: {self.type}
 shape: {self.shape}"""
 


### PR DESCRIPTION
### Rationale for this change

`SparseCOOTensor.__repr__` outputs literal `{self.type}` and `{self.shape}` instead of actual values due to missing f-string prefix.

### What changes are included in this PR?

Add f prefix to the string in `SparseCOOTensor.__repr__`.

### Are these changes tested?

Yes, work after adding. f-string prefix:
```python3
>>> import pyarrow as pa
>>> import numpy as np
>>> dense_tensor = np.array([[0, 1, 0], [2, 0, 3]], dtype=np.float32)
>>> sparse_coo = pa.SparseCOOTensor.from_dense_numpy(dense_tensor)
>>> sparse_coo
<pyarrow.SparseCOOTensor>
type: float
shape: (2, 3)
```

### Are there any user-facing changes?

a bug that caused incorrect or invalid data to be produced:

```python3
>>> import pyarrow as pa
>>> import numpy as np
>>> dense_tensor = np.array([[0, 1, 0], [2, 0, 3]], dtype=np.float32)
>>> sparse_coo = pa.SparseCOOTensor.from_dense_numpy(dense_tensor)
>>> sparse_coo
<pyarrow.SparseCOOTensor>
type: {self.type}
shape: {self.shape}
```

* GitHub Issue: #49108