### PR TITLE
GH-49110: [C++] Add bounds checking to DataType::field() to return nullptr for out-of-bounds access

### DIFF
--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -150,7 +150,12 @@ class ARROW_EXPORT DataType : public std::enable_shared_from_this<DataType>,
   bool Equals(const std::shared_ptr<DataType>& other, bool check_metadata = false) const;
 
   /// \brief Return the child field at index i.
-  const std::shared_ptr<Field>& field(int i) const { return children_[i]; }
+  ///
+  /// Returns a null shared_ptr if index is out of bounds [0, num_fields()).
+  const std::shared_ptr<Field>& field(int i) const {
+    static const std::shared_ptr<Field> kNullField;
+    return (i < 0 || i >= num_fields()) ? kNullField : children_[i];
+  }
 
   /// \brief Return the children fields associated with this type.
   const FieldVector& fields() const { return children_; }

--- a/cpp/src/arrow/type_test.cc
+++ b/cpp/src/arrow/type_test.cc
@@ -2029,8 +2029,27 @@ TEST(TestStructType, Basics) {
   auto t3 = struct_({field("c", int8()), field("b", utf8())});
   ASSERT_TRUE(t1->Equals(t2));
   ASSERT_TRUE(!t1->Equals(t3));
+}
 
-  // TODO(wesm): out of bounds for field(...)
+// Test that out-of-bounds field access returns null
+TEST(TestStructType, FieldAccessOutOfBounds) {
+  auto f0 = field("f0", int32());
+  auto f1 = field("f1", utf8());
+  auto f2 = field("f2", uint8());
+  StructType struct_type({f0, f1, f2});
+
+  ASSERT_EQ(struct_type.num_fields(), 3);
+
+  // Out-of-bounds indices return nullptr
+  ASSERT_EQ(struct_type.field(3), nullptr);
+  ASSERT_EQ(struct_type.field(4), nullptr);
+  ASSERT_EQ(struct_type.field(100), nullptr);
+  ASSERT_EQ(struct_type.field(-1), nullptr);
+
+  // All out-of-bounds accesses return the same static null
+  const auto& null1 = struct_type.field(3);
+  const auto& null2 = struct_type.field(100);
+  EXPECT_EQ(&null1, &null2);
 }
 
 TEST(TestStructType, GetFieldByName) {


### PR DESCRIPTION
### Rationale for this change

Previously, `DataType::field(int i)` directly accessed `children_[i]` without bounds checking, resulting in undefined behavior for out-of-bounds indices. This could crash or return garbage.

### What changes are included in this PR?

Added bounds checking to `DataType::field()` to return `nullptr` for out-of-bounds access, matching the behavior of `GetFieldByName()`.

### Are these changes tested?

Yes, added `TestStructType.FieldAccessOutOfBounds` to verify that out-of-bounds indices return `nullptr`.

### Are there any user-facing changes?

Yes. `DataType::field(i)` now safely returns `nullptr` for invalid indices instead of undefined behavior.
* GitHub Issue: #49110