### PR TITLE
GH-49115: [CI][Packaging][Python] Update vcpkg baseline for our wheels

### DIFF
--- a/.env
+++ b/.env
@@ -93,14 +93,14 @@ TZ=UTC
 # Used through compose.yaml and serves as the default version for the
 # ci/scripts/install_vcpkg.sh script. Prefer to use short SHAs to keep the
 # docker tags more readable.
-VCPKG="4334d8b4c8916018600212ab4dd4bbdc343065d1"    # 2025.09.17 Release
+VCPKG="66c0373dc7fca549e5803087b9487edfe3aca0a1"    # 2026.01.16 Release
 
 # This must be updated when we update
 # ci/docker/python-*-windows-*.dockerfile or the vcpkg config.
 # This is a workaround for our CI problem that "archery docker build" doesn't
 # use pulled built images in dev/tasks/python-wheels/github.windows.yml.
-PYTHON_WHEEL_WINDOWS_IMAGE_REVISION=2026-01-27
-PYTHON_WHEEL_WINDOWS_TEST_IMAGE_REVISION=2026-01-27
+PYTHON_WHEEL_WINDOWS_IMAGE_REVISION=2026-02-02
+PYTHON_WHEEL_WINDOWS_TEST_IMAGE_REVISION=2026-02-02
 
 # Use conanio/${CONAN_BASE}:{CONAN_VERSION} for "docker compose run --rm conan".
 # See https://github.com/conan-io/conan-docker-tools#readme and

--- a/ci/docker/cpp-jni.dockerfile
+++ b/ci/docker/cpp-jni.dockerfile
@@ -29,6 +29,7 @@ RUN dnf install -y \
     gdb \
     git \
     perl-IPC-Cmd \
+    perl-Time-Piece \
     wget \
     zip
 

--- a/ci/docker/python-wheel-manylinux.dockerfile
+++ b/ci/docker/python-wheel-manylinux.dockerfile
@@ -26,7 +26,7 @@ ENV LINUX_WHEEL_KIND='manylinux'
 ENV LINUX_WHEEL_VERSION=${manylinux}
 
 # Install basic dependencies
-RUN dnf install -y git flex curl autoconf zip perl-IPC-Cmd wget
+RUN dnf install -y git flex curl autoconf zip perl-IPC-Cmd perl-Time-Piece wget
 
 # A system Python is required for Ninja and vcpkg in this Dockerfile.
 # On manylinux_2_28 base images, no system Python is installed.

--- a/ci/scripts/python_wheel_macos_build.sh
+++ b/ci/scripts/python_wheel_macos_build.sh
@@ -46,9 +46,6 @@ else
   exit 1
 fi
 
-echo "=== (${PYTHON_VERSION}) Install Python build dependencies ==="
-export PIP_SITE_PACKAGES=$(python -c 'import site; print(site.getsitepackages()[0])')
-
 # Remove once there are released Cython wheels for 3.13 free-threaded available
 FREE_THREADED_BUILD="$(python -c"import sysconfig; print(bool(sysconfig.get_config_var('Py_GIL_DISABLED')))")"
 if [[ $FREE_THREADED_BUILD == "True"  ]]; then
@@ -58,7 +55,6 @@ fi
 pip install \
   --force-reinstall \
   --only-binary=:all: \
-  --target $PIP_SITE_PACKAGES \
   --upgrade \
   -r ${source_dir}/python/requirements-wheel-build.txt
 pip install "delocate>=0.10.3"

--- a/ci/vcpkg/ports.patch
+++ b/ci/vcpkg/ports.patch
@@ -66,15 +66,14 @@ index 0000000000..25568e70cd
 +     }
 + 
 diff --git a/ports/orc/portfile.cmake b/ports/orc/portfile.cmake
-index 77ebf41ec3..4d065594a7 100644
+index 278bc17a1c..d47d859360 100644
 --- a/ports/orc/portfile.cmake
 +++ b/ports/orc/portfile.cmake
-@@ -6,6 +6,8 @@ vcpkg_from_github(
-   REF "v${VERSION}"
-   SHA512 eabee16a6e984452a8cb715d0524041b20dd1bd88d78bb32534db93e5dbdd786aa4df8c05975406cb0728241eb3025a506c4fefb8c334ef0d8a27e6cb920d44c
-   HEAD_REF master
-+  PATCHES
-+    orc-fix-exception-propagation.diff
+@@ -9,6 +9,7 @@ vcpkg_from_github(
+     PATCHES
+         external-project.diff
+         tools-build.diff
++        orc-fix-exception-propagation.diff
  )
- 
- file(REMOVE "${SOURCE_PATH}/cmake_modules/FindGTest.cmake")
+ file(GLOB modules "${SOURCE_PATH}/cmake_modules/Find*.cmake")
+ file(REMOVE ${modules} "${SOURCE_PATH}/c++/libs/libhdfspp/libhdfspp.tar.gz")


### PR DESCRIPTION
### Rationale for this change

Current wheels are failing to be built due to old version of vcpkg failing with our latest main.

### What changes are included in this PR?

- Update vcpkg version.
- Update patches
- Add `perl-Time-Piece` to some images as required to build newer OpenSSL.

### Are these changes tested?

Yes on CI

### Are there any user-facing changes?

No

* GitHub Issue: #49115