### PR TITLE
GH-49119: [Ruby] Add support for writing map array

### DIFF
--- a/ruby/red-arrow-format/lib/arrow-format/type.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/type.rb
@@ -791,6 +791,10 @@ module ArrowFormat
     def build_array(size, validity_buffer, offsets_buffer, child)
       MapArray.new(self, size, validity_buffer, offsets_buffer, child)
     end
+
+    def to_flatbuffers
+      FB::Map::Data.new
+    end
   end
 
   class UnionType < Type

--- a/ruby/red-arrow-format/test/test-writer.rb
+++ b/ruby/red-arrow-format/test/test-writer.rb
@@ -85,6 +85,8 @@ module WriterTests
                                       red_arrow_type.scale)
     when Arrow::FixedSizeBinaryDataType
       ArrowFormat::FixedSizeBinaryType.new(red_arrow_type.byte_width)
+    when Arrow::MapDataType
+      ArrowFormat::MapType.new(convert_field(red_arrow_type.field))
     when Arrow::ListDataType
       ArrowFormat::ListType.new(convert_field(red_arrow_type.field))
     when Arrow::LargeListDataType
@@ -819,6 +821,27 @@ module WriterTests
 
           def test_write
             assert_equal([[-128, 127], nil, [-1, 0, 1]],
+                         @values)
+          end
+        end
+
+        sub_test_case("Map") do
+          def build_array
+            data_type = Arrow::MapDataType.new(:string, :int8)
+            Arrow::MapArray.new(data_type,
+                                [
+                                  {"a" => -128, "b" => 127},
+                                  nil,
+                                  {"c" => nil},
+                                ])
+          end
+
+          def test_write
+            assert_equal([
+                           {"a" => -128, "b" => 127},
+                           nil,
+                           {"c" => nil},
+                         ],
                          @values)
           end
         end


### PR DESCRIPTION
### Rationale for this change

It's a list based array.

### What changes are included in this PR?

* Add `ArrowFormat::MapType#to_flatbuffers`

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #49119