### PR TITLE
MINOR: [C++] Remove obsolete TODO comment from mode kernel registration

### DIFF
--- a/cpp/src/arrow/compute/kernels/aggregate_mode.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_mode.cc
@@ -495,7 +495,6 @@ void RegisterScalarAggregateMode(FunctionRegistry* registry) {
       NewModeKernel(boolean(), ModeExecutor<StructType, BooleanType>::Exec,
                     ModeExecutorChunked<StructType, BooleanType>::Exec)));
   for (const auto& type : NumericTypes()) {
-    // TODO(wesm):
     DCHECK_OK(func->AddKernel(
         NewModeKernel(type, GenerateNumeric<ModeExecutor, StructType>(*type),
                       GenerateNumeric<ModeExecutorChunked, StructType>(*type))));


### PR DESCRIPTION
### Rationale for this change

The TODO comment was added in commit 53752adc6b8 during the ExecSpan refactoring. It was, presumably, a reminder to migrate the mode kernel from the old `GenerateNumericOld` API to the new `GenerateNumeric` API. This migration was completed in commit 4d931ff1c0f, but the TODO comment was accidentally left behind.

### What changes are included in this PR?

Removed the orphaned `// TODO(wesm):` comment from `aggregate_mode.cc`. The work it referenced was completed.

### Are these changes tested?

No, I did not test.

### Are there any user-facing changes?

No.