### PR TITLE
GH-49083: [CI][Python] Remove dask-contrib/dask-expr from the nightly dask test builds

### DIFF
--- a/ci/scripts/install_dask.sh
+++ b/ci/scripts/install_dask.sh
@@ -28,7 +28,6 @@ dask=$1
 
 if [ "${dask}" = "upstream_devel" ]; then
   pip install "dask[dataframe] @ git+https://github.com/dask/dask.git"
-  pip install -U git+https://github.com/dask-contrib/dask-expr.git
 elif [ "${dask}" = "latest" ]; then
   pip install "dask[dataframe]"
 else


### PR DESCRIPTION
### Rationale for this change
Failing nightly job for dask (test-conda-python-3.11-dask-upstream_devel).

### What changes are included in this PR?
Removal of dask-contrib/dask-expr package as it is included in the dask dataframe module since January 2025.

### Are these changes tested?
Yes, with extendeed dask build.

### Are there any user-facing changes?
No.
* GitHub Issue: #49083