### PR TITLE
GH-48922: [C++] Support Status-returning callables in Result::Map

### DIFF
--- a/cpp/src/arrow/result.h
+++ b/cpp/src/arrow/result.h
@@ -518,4 +518,9 @@ struct EnsureResult<Result<T>> {
   using type = Result<T>;
 };
 
+template <>
+struct EnsureResult<Status> {
+  using type = Status;
+};
+
 }  // namespace arrow


### PR DESCRIPTION
### Rationale for this change
Currently, Result::Map fails to compile when the mapping function returns a Status because it tries to instantiate Result, which is prohibited. This change allows Map to return Status directly in such cases.

### What changes are included in this PR?
- Added EnsureResult specialization to allow Map to return Status directly.
- Added unit tests to verify success/error propagation and return type resolution.

### Are these changes tested?
Yes.

### Are there any user-facing changes?
No
* GitHub Issue: #48922