### PR TITLE
GH-49129: [R][Parquet] Guard Parquet dataset code with ARROW_R_WITH_PARQUET

### DIFF
--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -717,9 +717,7 @@ tasks:
     ci: github
     template: docker-tests/github.linux.yml
     params:
-      env:
-        ARROW_DATASET: ON
-        ARROW_PARQUET: OFF
+      flags: '-e ARROW_DATASET=ON -e ARROW_PARQUET=OFF'
       image: ubuntu-r-only-r
 
   test-r-offline-maximal:

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -713,6 +713,15 @@ tasks:
         R_DUCKDB_DEV: TRUE
       image: ubuntu-r-only-r
 
+  test-r-dataset-without-parquet:
+    ci: github
+    template: docker-tests/github.linux.yml
+    params:
+      env:
+        ARROW_DATASET: ON
+        ARROW_PARQUET: OFF
+      image: ubuntu-r-only-r
+
   test-r-offline-maximal:
     ci: github
     template: r/github.linux.offline.build.yml

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -1836,6 +1836,7 @@ extern "C" SEXP _arrow_dataset___FileFormat__DefaultWriteOptions(SEXP fmt_sexp){
 #endif
 
 // dataset.cpp
+#if defined(ARROW_R_WITH_PARQUET)
 #if defined(ARROW_R_WITH_DATASET)
 std::shared_ptr<ds::ParquetFileFormat> dataset___ParquetFileFormat__Make(const std::shared_ptr<ds::ParquetFragmentScanOptions>& options, cpp11::strings dict_columns);
 extern "C" SEXP _arrow_dataset___ParquetFileFormat__Make(SEXP options_sexp, SEXP dict_columns_sexp){
@@ -1849,6 +1850,7 @@ END_CPP11
 extern "C" SEXP _arrow_dataset___ParquetFileFormat__Make(SEXP options_sexp, SEXP dict_columns_sexp){
 	Rf_error("Cannot call dataset___ParquetFileFormat__Make(). See https://arrow.apache.org/docs/r/articles/install.html for help installing Arrow C++ libraries. ");
 }
+#endif
 #endif
 
 // dataset.cpp
@@ -2033,6 +2035,7 @@ extern "C" SEXP _arrow_dataset___JsonFragmentScanOptions__Make(SEXP parse_option
 #endif
 
 // dataset.cpp
+#if defined(ARROW_R_WITH_PARQUET)
 #if defined(ARROW_R_WITH_DATASET)
 std::shared_ptr<ds::ParquetFragmentScanOptions> dataset___ParquetFragmentScanOptions__Make(bool use_buffered_stream, int64_t buffer_size, bool pre_buffer, int32_t thrift_string_size_limit, int32_t thrift_container_size_limit);
 extern "C" SEXP _arrow_dataset___ParquetFragmentScanOptions__Make(SEXP use_buffered_stream_sexp, SEXP buffer_size_sexp, SEXP pre_buffer_sexp, SEXP thrift_string_size_limit_sexp, SEXP thrift_container_size_limit_sexp){
@@ -2049,6 +2052,7 @@ END_CPP11
 extern "C" SEXP _arrow_dataset___ParquetFragmentScanOptions__Make(SEXP use_buffered_stream_sexp, SEXP buffer_size_sexp, SEXP pre_buffer_sexp, SEXP thrift_string_size_limit_sexp, SEXP thrift_container_size_limit_sexp){
 	Rf_error("Cannot call dataset___ParquetFragmentScanOptions__Make(). See https://arrow.apache.org/docs/r/articles/install.html for help installing Arrow C++ libraries. ");
 }
+#endif
 #endif
 
 // dataset.cpp

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -1867,7 +1867,7 @@ extern "C" SEXP _arrow_dataset___FileWriteOptions__type_name(SEXP options_sexp){
 #endif
 
 // dataset.cpp
-#if defined(ARROW_R_WITH_DATASET)
+#if defined(ARROW_R_WITH_DATASET) && defined(ARROW_R_WITH_PARQUET)
 void dataset___ParquetFileWriteOptions__update(const std::shared_ptr<ds::ParquetFileWriteOptions>& options, const std::shared_ptr<parquet::WriterProperties>& writer_props, const std::shared_ptr<parquet::ArrowWriterProperties>& arrow_writer_props);
 extern "C" SEXP _arrow_dataset___ParquetFileWriteOptions__update(SEXP options_sexp, SEXP writer_props_sexp, SEXP arrow_writer_props_sexp){
 BEGIN_CPP11

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -1836,8 +1836,7 @@ extern "C" SEXP _arrow_dataset___FileFormat__DefaultWriteOptions(SEXP fmt_sexp){
 #endif
 
 // dataset.cpp
-#if defined(ARROW_R_WITH_PARQUET)
-#if defined(ARROW_R_WITH_DATASET)
+#if defined(ARROW_R_WITH_DATASET) && defined(ARROW_R_WITH_PARQUET)
 std::shared_ptr<ds::ParquetFileFormat> dataset___ParquetFileFormat__Make(const std::shared_ptr<ds::ParquetFragmentScanOptions>& options, cpp11::strings dict_columns);
 extern "C" SEXP _arrow_dataset___ParquetFileFormat__Make(SEXP options_sexp, SEXP dict_columns_sexp){
 BEGIN_CPP11
@@ -1850,7 +1849,6 @@ END_CPP11
 extern "C" SEXP _arrow_dataset___ParquetFileFormat__Make(SEXP options_sexp, SEXP dict_columns_sexp){
 	Rf_error("Cannot call dataset___ParquetFileFormat__Make(). See https://arrow.apache.org/docs/r/articles/install.html for help installing Arrow C++ libraries. ");
 }
-#endif
 #endif
 
 // dataset.cpp
@@ -2035,8 +2033,7 @@ extern "C" SEXP _arrow_dataset___JsonFragmentScanOptions__Make(SEXP parse_option
 #endif
 
 // dataset.cpp
-#if defined(ARROW_R_WITH_PARQUET)
-#if defined(ARROW_R_WITH_DATASET)
+#if defined(ARROW_R_WITH_DATASET) && defined(ARROW_R_WITH_PARQUET)
 std::shared_ptr<ds::ParquetFragmentScanOptions> dataset___ParquetFragmentScanOptions__Make(bool use_buffered_stream, int64_t buffer_size, bool pre_buffer, int32_t thrift_string_size_limit, int32_t thrift_container_size_limit);
 extern "C" SEXP _arrow_dataset___ParquetFragmentScanOptions__Make(SEXP use_buffered_stream_sexp, SEXP buffer_size_sexp, SEXP pre_buffer_sexp, SEXP thrift_string_size_limit_sexp, SEXP thrift_container_size_limit_sexp){
 BEGIN_CPP11
@@ -2052,7 +2049,6 @@ END_CPP11
 extern "C" SEXP _arrow_dataset___ParquetFragmentScanOptions__Make(SEXP use_buffered_stream_sexp, SEXP buffer_size_sexp, SEXP pre_buffer_sexp, SEXP thrift_string_size_limit_sexp, SEXP thrift_container_size_limit_sexp){
 	Rf_error("Cannot call dataset___ParquetFragmentScanOptions__Make(). See https://arrow.apache.org/docs/r/articles/install.html for help installing Arrow C++ libraries. ");
 }
-#endif
 #endif
 
 // dataset.cpp

--- a/r/src/dataset.cpp
+++ b/r/src/dataset.cpp
@@ -27,7 +27,10 @@
 #include <arrow/table.h>
 #include <arrow/util/checked_cast.h>
 #include <arrow/util/iterator.h>
+
+#if defined(ARROW_R_WITH_PARQUET)
 #include <parquet/properties.h>
+#endif
 
 namespace ds = ::arrow::dataset;
 namespace fs = ::arrow::fs;
@@ -223,6 +226,7 @@ std::shared_ptr<ds::FileWriteOptions> dataset___FileFormat__DefaultWriteOptions(
   return fmt->DefaultWriteOptions();
 }
 
+#if defined(ARROW_R_WITH_PARQUET)
 // [[dataset::export]]
 std::shared_ptr<ds::ParquetFileFormat> dataset___ParquetFileFormat__Make(
     const std::shared_ptr<ds::ParquetFragmentScanOptions>& options,
@@ -237,6 +241,7 @@ std::shared_ptr<ds::ParquetFileFormat> dataset___ParquetFileFormat__Make(
 
   return fmt;
 }
+#endif
 
 // [[dataset::export]]
 std::string dataset___FileWriteOptions__type_name(
@@ -339,6 +344,7 @@ std::shared_ptr<ds::JsonFragmentScanOptions> dataset___JsonFragmentScanOptions__
   return options;
 }
 
+#if defined(ARROW_R_WITH_PARQUET)
 // [[dataset::export]]
 std::shared_ptr<ds::ParquetFragmentScanOptions>
 dataset___ParquetFragmentScanOptions__Make(bool use_buffered_stream, int64_t buffer_size,
@@ -362,6 +368,7 @@ dataset___ParquetFragmentScanOptions__Make(bool use_buffered_stream, int64_t buf
       thrift_container_size_limit);
   return options;
 }
+#endif
 
 // DirectoryPartitioning, HivePartitioning
 


### PR DESCRIPTION
### Rationale for this change

This ensures the code compiles correctly when Parquet support is disabled.

### What changes are included in this PR?

Add preprocessor guards around Parquet-related code in dataset.cpp and update the condition in arrowExports.cpp to check for both ARROW_R_WITH_DATASET and ARROW_R_WITH_PARQUET.

### Are these changes tested?

Yes. Please see the patch applied here https://github.com/emscripten-forge/recipes/pull/4397

### Are there any user-facing changes?

No.


Fixes #49129

* GitHub Issue: #49129