### PR TITLE
GH-49133: [C++] Remove todo asking to use assign_by_moving

### DIFF
--- a/cpp/src/arrow/util/small_vector.h
+++ b/cpp/src/arrow/util/small_vector.h
@@ -238,7 +238,6 @@ class StaticVectorImpl {
 
   StaticVectorImpl& operator=(StaticVectorImpl&& other) noexcept {
     if (ARROW_PREDICT_TRUE(&other != this)) {
-      // TODO move_assign?
       storage_.destroy();
       storage_.move_construct(std::move(other.storage_));
     }


### PR DESCRIPTION
### Rationale for this change

The TODO comment in `SmallVector`'s move assignment operator asks whether to use `assign_by_moving()` instead of `destroy() + move_construct()`.  However, using `destroy() + move_construct()` is faster in most of the cases by `memcpy` according to the benchmark I ran:

| Type | Elements | destroy + move_construct | assign_by_moving |
|------|----------|-----------------------------------|----------------------|
| `uint8_t*` | 16 | 3.54 ns | 8.71 ns |
| `const uint8_t*` | 16 | 3.54 ns | 8.71 ns |
| `const void*` | 3 | 1.49 ns | 5.00 ns |
| `int` | 2 | 1.38 ns | 5.52 ns | 4.00x slower |
| `std::string_view` | 2 | 8.42 ns | 3.78 ns |
| `std::pair<int64_t, int64_t>` | 1 | 1.40 ns | 2.16 ns |
| `FakeArrowStruct` | 4 | 3.54 ns | 6.32 ns |

(I did not include the benchmark code I ran to make the pr description shorter. Can be provided upon request)

We could sophisticatedly benchmark, design and consider other cases but I believe this is not worthwhile.

### What changes are included in this PR?

Removed the TODO comment.

### Are these changes tested?

No I did not test.

### Are there any user-facing changes?

No.
* GitHub Issue: #49133