### PR TITLE
GH-49146: [C++] Add option to disable atfork handlers

### DIFF
--- a/cpp/src/arrow/filesystem/s3fs.cc
+++ b/cpp/src/arrow/filesystem/s3fs.cc
@@ -119,7 +119,6 @@
 #include "arrow/util/string.h"
 #include "arrow/util/task_group.h"
 #include "arrow/util/thread_pool.h"
-#include "arrow/util/value_parsing.h"
 
 namespace arrow::fs {
 
@@ -3579,9 +3578,10 @@ S3GlobalOptions S3GlobalOptions::Defaults() {
     log_level = S3LogLevel::Off;
   }
 
-  value = arrow::internal::GetEnvVar("ARROW_S3_THREADS").ValueOr("1");
-  if (uint32_t u; ::arrow::internal::ParseUnsigned(value.data(), value.size(), &u)) {
-    num_event_loop_threads = u;
+  auto maybe_num_threads =
+      arrow::internal::GetEnvVarInteger("ARROW_S3_THREADS", /*min_value=*/1);
+  if (maybe_num_threads.ok()) {
+    num_event_loop_threads = static_cast<int>(*maybe_num_threads);
   }
   return S3GlobalOptions{log_level, num_event_loop_threads};
 }

--- a/cpp/src/arrow/io/interfaces.cc
+++ b/cpp/src/arrow/io/interfaces.cc
@@ -390,23 +390,15 @@ namespace {
 constexpr int kDefaultNumIoThreads = 8;
 
 std::shared_ptr<ThreadPool> MakeIOThreadPool() {
-  int threads = 0;
-  auto maybe_env_var = ::arrow::internal::GetEnvVar("ARROW_IO_THREADS");
-  if (maybe_env_var.ok()) {
-    auto str = *std::move(maybe_env_var);
-    if (!str.empty()) {
-      try {
-        threads = std::stoi(str);
-      } catch (...) {
-      }
-      if (threads <= 0) {
-        ARROW_LOG(WARNING)
-            << "ARROW_IO_THREADS does not contain a valid number of threads "
-               "(should be an integer > 0)";
-      }
-    }
+  int threads = kDefaultNumIoThreads;
+  auto maybe_num_threads = ::arrow::internal::GetEnvVarInteger(
+      "ARROW_IO_THREADS", /*min_value=*/1, /*max_value=*/std::numeric_limits<int>::max());
+  if (maybe_num_threads.ok()) {
+    threads = static_cast<int>(*maybe_num_threads);
+  } else if (!maybe_num_threads.status().IsKeyError()) {
+    maybe_num_threads.status().Warn();
   }
-  auto maybe_pool = ThreadPool::MakeEternal(threads > 0 ? threads : kDefaultNumIoThreads);
+  auto maybe_pool = ThreadPool::MakeEternal(threads);
   if (!maybe_pool.ok()) {
     maybe_pool.status().Abort("Failed to create global IO thread pool");
   }

--- a/cpp/src/arrow/testing/gtest_util.h
+++ b/cpp/src/arrow/testing/gtest_util.h
@@ -418,9 +418,11 @@ ARROW_TESTING_EXPORT
 void AssertChildExit(int child_pid, int expected_exit_status = 0);
 #endif
 
-// A RAII-style object that switches to a new locale, and switches back
-// to the old locale when going out of scope.  Doesn't do anything if the
-// new locale doesn't exist on the local machine.
+// A RAII-style object that temporarily switches to a new locale
+//
+// The guard switches back to the old locale when going out of scope.
+// It doesn't do anything if the new locale doesn't exist on the local machine.
+//
 // ATTENTION: may crash with an assertion failure on Windows debug builds.
 // See ARROW-6108, also https://gerrit.libreoffice.org/#/c/54110/
 class ARROW_TESTING_EXPORT LocaleGuard {
@@ -433,15 +435,20 @@ class ARROW_TESTING_EXPORT LocaleGuard {
   std::unique_ptr<Impl> impl_;
 };
 
+// A RAII-style object that temporarily sets an environment variable
+//
+// The guard restores the variable's previous value when going out of scope,
+// or deletes the variable if it was not initially set.
+// The environment variable can also be temporarily deleted if std::nullopt
+// is passed instead of a string value.
 class ARROW_TESTING_EXPORT EnvVarGuard {
  public:
-  EnvVarGuard(const std::string& name, const std::string& value);
+  EnvVarGuard(std::string name, std::optional<std::string> value);
   ~EnvVarGuard();
 
  protected:
-  const std::string name_;
-  std::string old_value_;
-  bool was_set_;
+  std::string name_;
+  std::optional<std::string> old_value_;
 };
 
 namespace internal {

--- a/cpp/src/arrow/util/atfork_test.cc
+++ b/cpp/src/arrow/util/atfork_test.cc
@@ -190,6 +190,9 @@ TEST_F(TestAtFork, SingleThread) {
   ASSERT_THAT(child_after_, ElementsAre());
 }
 
+// XXX we would like to test the ARROW_REGISTER_ATFORK environment variable,
+// but that would require spawning a test subprocess
+
 #  if !(defined(ARROW_VALGRIND) || defined(ADDRESS_SANITIZER) || \
         defined(THREAD_SANITIZER))
 

--- a/cpp/src/arrow/util/io_util.h
+++ b/cpp/src/arrow/util/io_util.h
@@ -244,6 +244,12 @@ ARROW_EXPORT
 Result<std::string> GetEnvVar(std::string_view name);
 ARROW_EXPORT
 Result<NativePathString> GetEnvVarNative(std::string_view name);
+// Returns KeyError if the environment variable doesn't exist,
+// Invalid if it's not a valid integer in the given range.
+ARROW_EXPORT
+Result<int64_t> GetEnvVarInteger(std::string_view name,
+                                 std::optional<int64_t> min_value = {},
+                                 std::optional<int64_t> max_value = {});
 
 ARROW_EXPORT
 Status SetEnvVar(std::string_view name, std::string_view value);

--- a/docs/source/cpp/env_vars.rst
+++ b/docs/source/cpp/env_vars.rst
@@ -87,6 +87,18 @@ that changing their value later will have an effect.
    ``libhdfs.dylib`` on macOS, ``libhdfs.so`` on other platforms).
    Alternatively, one can set :envvar:`HADOOP_HOME`.
 
+.. envvar:: ARROW_REGISTER_ATFORK
+
+   **Experimental**. An integer value to enable or disable the registration
+   of at-fork handlers. These are enabled by default or explicitly using the
+   value "1"; use "0" to disable.
+
+   If enabled, at-fork handlers make Arrow C++ compatible with the use of the
+   ``fork()`` system call, such as by Python's :python:mod:`multiprocessing`,
+   but at the expense of executing
+   `potentially unsafe code <https://pubs.opengroup.org/onlinepubs/9699919799/functions/pthread_atfork.html>`__
+   in a forked child process if the parent process is multi-threaded.
+
 .. envvar:: ARROW_S3_LOG_LEVEL
 
    Controls the verbosity of logging produced by S3 calls. Defaults to ``FATAL``

--- a/python/pyarrow/tests/test_misc.py
+++ b/python/pyarrow/tests/test_misc.py
@@ -80,8 +80,7 @@ def test_env_var_io_thread_count():
     for v in ('-1', 'z'):
         out, err = run_with_env_var(v)
         assert out.strip() == '8'  # default value
-        assert ("ARROW_IO_THREADS does not contain a valid number of threads"
-                in err.strip())
+        assert "Invalid value for ARROW_IO_THREADS" in err.strip()
 
 
 def test_build_info():


### PR DESCRIPTION
### Rationale for this change

The atfork handlers we register in Arrow C++ are generally useful if the Arrow APIs are meant to be used from the child process, but they also have the unfortunate effect of executing non-async-signal-safe code in the child process even if Arrow is not be used there. That is [not allowed by POSIX](https://pubs.opengroup.org/onlinepubs/9699919799/functions/pthread_atfork.html) if the parent process is multi-threaded.

There are situations where fork() is only called just before exec(), and therefore it is not necessary to run any atfork handler.

### What changes are included in this PR?

1. Add a `GetEnvVarInteger` utility function to automate parsing of a numeric environment variable
2. Remove hard-coded size limitations for environment variable values on Windows
3. Add basic unit tests for our APIs for getting and setting environment variables
4. Add an environment variable `ARROW_REGISTER_ATFORK` to disable the registration of atfork handlers at runtime

### Are these changes tested?

The new environment variable cannot be easily tested automatically, so I've checked it manually.

### Are there any user-facing changes?

No, only a new feature.

* GitHub Issue: #49146