### PR TITLE
GH-49092: [C++][FlightRPC][CI] Nightly Packaging: Add `dev-yyyy-mm-dd` to ODBC MSI name

### DIFF
--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -462,7 +462,7 @@ jobs:
     needs: odbc
     name: ODBC nightly
     runs-on: ubuntu-latest
-    if: github.event_name == 'schedule' && github.repository == 'apache/arrow'
+    # if: github.event_name == 'schedule' && github.repository == 'apache/arrow'
     steps:
       - name: Download the artifacts
         uses: actions/download-artifact@v7

--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -462,7 +462,7 @@ jobs:
     needs: odbc
     name: ODBC nightly
     runs-on: ubuntu-latest
-    # if: github.event_name == 'schedule' && github.repository == 'apache/arrow'
+    if: github.event_name == 'schedule' && github.repository == 'apache/arrow'
     steps:
       - name: Download the artifacts
         uses: actions/download-artifact@v7
@@ -473,7 +473,7 @@ jobs:
           mkdir odbc-installer
           mv *.msi odbc-installer/
 
-          # Add date to ODBC MSI
+          # Add `dev-yyyy-mm-dd` to ODBC MSI before `win64.msi`
           cd odbc-installer
           msi_name=$(ls *.msi)
           echo $msi_name

--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -476,13 +476,7 @@ jobs:
           # Add `dev-yyyy-mm-dd` to ODBC MSI before `win64.msi`
           cd odbc-installer
           msi_name=$(ls *.msi)
-          echo $msi_name
-          SUFFIX=dev-$(date +%Y-%m-%d)-
-          echo $SUFFIX
-          INDEX=${#msi_name}-9
-          dev_msi_name="${msi_name:0:$INDEX}${SUFFIX}${msi_name:$INDEX}"
-          echo $msi_name
-          echo $dev_msi_name
+          dev_msi_name=$(echo ${msi_name} | sed -e "s/win64\.msi$/dev-$(date +%Y-%m-%d)-win64.msi/")
           mv "${msi_name}" "${dev_msi_name}"
           cd ..
           

--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -473,7 +473,9 @@ jobs:
           mkdir odbc-installer
           mv *.msi odbc-installer/
 
-          # Add `dev-yyyy-mm-dd` to ODBC MSI before `win64.msi`
+          # Add `dev-yyyy-mm-dd` to ODBC MSI before `win64.msi`:
+          #   Apache Arrow Flight SQL ODBC-24.0.0-win64.msi ->
+          #   Apache Arrow Flight SQL ODBC-24.0.0-dev-2026-02-06-win64.msi
           cd odbc-installer
           msi_name=$(ls *.msi)
           dev_msi_name=$(echo ${msi_name} | sed -e "s/win64\.msi$/dev-$(date +%Y-%m-%d)-win64.msi/")

--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -472,6 +472,20 @@ jobs:
         run: |
           mkdir odbc-installer
           mv *.msi odbc-installer/
+
+          # Add date to ODBC MSI
+          cd odbc-installer
+          msi_name=$(ls *.msi)
+          echo $msi_name
+          SUFFIX=dev-$(date +%Y-%m-%d)-
+          echo $SUFFIX
+          INDEX=${#msi_name}-9
+          dev_msi_name="${msi_name:0:$INDEX}${SUFFIX}${msi_name:$INDEX}"
+          echo $msi_name
+          echo $dev_msi_name
+          mv "${msi_name}" "${dev_msi_name}"
+          cd ..
+          
           tree odbc-installer
       - name: Checkout Arrow
         uses: actions/checkout@v6


### PR DESCRIPTION
### Rationale for this change
#49092

### What changes are included in this PR?

-  Add `dev-yyyy-mm-dd` to ODBC MSI name. This is a similar approach to R nightly.

Before: `Apache Arrow Flight SQL ODBC-1.0.0-win64.msi`. After: `Apache Arrow Flight SQL ODBC-1.0.0-dev-2026-02-04-win64.msi`.

### Are these changes tested?

Tested in CI. Successfully renamed file: https://github.com/apache/arrow/actions/runs/21686252848/job/62534629714?pr=49151#step:3:26

### Are there any user-facing changes?

Yes, the nightly ODBC file names will be changed as described above. 

* GitHub Issue: #49092