### PR TITLE
GH-49159: [C++][Gandiva] Detect overflow in repeat()

### DIFF
--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -843,7 +843,7 @@ const char* repeat_utf8_int32(gdv_int64 context, const char* in, gdv_int32 in_le
   }
   if (ARROW_PREDICT_FALSE(
           arrow::internal::MultiplyWithOverflow(repeat_number, in_len, out_len))) {
-    gdv_fn_context_set_error_msg(context, "Too large output size");
+    gdv_fn_context_set_error_msg(context, "Would overflow maximum output size");
     *out_len = 0;
     return "";
   }

--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -841,7 +841,12 @@ const char* repeat_utf8_int32(gdv_int64 context, const char* in, gdv_int32 in_le
     *out_len = 0;
     return "";
   }
-  *out_len = repeat_number * in_len;
+  if (ARROW_PREDICT_FALSE(
+          arrow::internal::MultiplyWithOverflow(repeat_number, in_len, out_len))) {
+    gdv_fn_context_set_error_msg(context, "Too large output size");
+    *out_len = 0;
+    return "";
+  }
   char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, *out_len));
   if (ret == nullptr) {
     gdv_fn_context_set_error_msg(context, "Could not allocate memory for output string");

--- a/cpp/src/gandiva/precompiled/string_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/string_ops_test.cc
@@ -391,7 +391,8 @@ TEST(TestStringOps, TestRepeat) {
   out_str = repeat_utf8_int32(ctx_ptr, "aa", 2,
                               std::numeric_limits<int32_t>::max() / 2 + 1, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
-  EXPECT_THAT(ctx.get_error(), ::testing::HasSubstr("Would overflow maximum output size"));
+  EXPECT_THAT(ctx.get_error(),
+              ::testing::HasSubstr("Would overflow maximum output size"));
   ctx.Reset();
 }
 

--- a/cpp/src/gandiva/precompiled/string_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/string_ops_test.cc
@@ -391,7 +391,7 @@ TEST(TestStringOps, TestRepeat) {
   out_str = repeat_utf8_int32(ctx_ptr, "aa", 2,
                               std::numeric_limits<int32_t>::max() / 2 + 1, &out_len);
   EXPECT_EQ(std::string(out_str, out_len), "");
-  EXPECT_THAT(ctx.get_error(), ::testing::HasSubstr("Too large output size"));
+  EXPECT_THAT(ctx.get_error(), ::testing::HasSubstr("Would overflow maximum output size"));
   ctx.Reset();
 }
 

--- a/cpp/src/gandiva/precompiled/string_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/string_ops_test.cc
@@ -387,6 +387,12 @@ TEST(TestStringOps, TestRepeat) {
   EXPECT_EQ(std::string(out_str, out_len), "");
   EXPECT_THAT(ctx.get_error(), ::testing::HasSubstr("Repeat number can't be negative"));
   ctx.Reset();
+
+  out_str = repeat_utf8_int32(ctx_ptr, "aa", 2,
+                              std::numeric_limits<int32_t>::max() / 2 + 1, &out_len);
+  EXPECT_EQ(std::string(out_str, out_len), "");
+  EXPECT_THAT(ctx.get_error(), ::testing::HasSubstr("Too large output size"));
+  ctx.Reset();
 }
 
 TEST(TestStringOps, TestCastBoolToVarchar) {


### PR DESCRIPTION
### Rationale for this change

`repeat()` can only generate `< 2147483647` size output. So output larger than `2147483647` must be rejected.

### What changes are included in this PR?

Add overflow check in `repeat()`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #49159