### PR TITLE
GH-49156: [Python] Require GIL for string comparison

### DIFF
--- a/python/pyarrow/table.pxi
+++ b/python/pyarrow/table.pxi
@@ -6286,8 +6286,8 @@ def concat_tables(tables, MemoryPool memory_pool=None, str promote_options="none
         "default" if promote_options == "none" else promote_options
     )
 
+    options.unify_schemas = promote_options != "none"
     with nogil:
-        options.unify_schemas = promote_options != "none"
         c_result_table = GetResultValue(
             ConcatenateTables(c_tables, options, pool))
 


### PR DESCRIPTION
### Rationale for this change

With Cython 3.3.0.a0 this failed. After some discussion it seems that this should have always had to require the GIL.

### What changes are included in this PR?

Moving statement out of the `with nogil` context manager.

### Are these changes tested?

Existing CI builds pyarrow.

### Are there any user-facing changes?

No
* GitHub Issue: #49156