### PR TITLE
MINOR: [Python] `Array.from_buffers` accepts `None` buffers

### DIFF
--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1304,7 +1304,7 @@ cdef class Array(_PandasConvertible):
             The value type of the array.
         length : int
             The number of values in the array.
-        buffers : List[Buffer]
+        buffers : List[Buffer | None]
             The buffers backing this array.
         null_count : int, default -1
             The number of null entries in the array. Negative value means that

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -4013,7 +4013,7 @@ cdef class DictionaryArray(Array):
         type : pyarrow.DataType
         length : int
             The number of values in the array.
-        buffers : List[Buffer]
+        buffers : List[Buffer | None]
             The buffers backing the indices array.
         dictionary : pyarrow.Array, ndarray or pandas.Series
             The array of values referenced by the indices.


### PR DESCRIPTION
<!--
Thanks for opening a pull request!

If this is your first pull request you can find detailed information on how to contribute here:

  * [New Contributor's Guide](https://arrow.apache.org/docs/dev/developers/guide/step_by_step/pr_lifecycle.html#reviews-and-merge-of-the-pull-request)
  * [Contributing Overview](https://arrow.apache.org/docs/dev/developers/overview.html)
  * [AI-generated Code Guidance](https://arrow.apache.org/docs/dev/developers/overview.html#ai-generated-code)

Please remove this line and the above text before creating your pull request.
-->
### Rationale for this change
Fix the docs. It seems this is a feature and not just happens to work as the code a little below even has an explicit comment:

https://github.com/apache/arrow/blob/0dfae701ef98aa4a26b9abbaaf3bf01130df3702/python/pyarrow/array.pxi#L1347

### What changes are included in this PR?
Document that `Array.from_buffers` takes a `list[Buffer | None]` instead of strictly `list[Buffer]`.

### Are these changes tested?
*not applicable*

### Are there any user-facing changes?
Yes, but not in an API sense :)