### PR TITLE
GH-49164: [C++] Avoid invalid if() args in cmake when arrow is a subproject

### DIFF
--- a/cpp/src/arrow/io/CMakeLists.txt
+++ b/cpp/src/arrow/io/CMakeLists.txt
@@ -45,8 +45,9 @@ add_arrow_test(memory_test PREFIX "arrow-io")
 
 add_arrow_benchmark(file_benchmark PREFIX "arrow-io")
 
-if(NOT (${ARROW_SIMD_LEVEL} STREQUAL "NONE") AND NOT (${ARROW_SIMD_LEVEL} STREQUAL "NEON"
-                                                     ))
+if(DEFINED ARROW_SIMD_LEVEL
+   AND NOT (ARROW_SIMD_LEVEL STREQUAL "NONE")
+   AND NOT (ARROW_SIMD_LEVEL STREQUAL "NEON"))
   # This benchmark either requires SSE4.2 or ARMV8 SIMD to be enabled
   add_arrow_benchmark(memory_benchmark PREFIX "arrow-io")
 endif()


### PR DESCRIPTION
### Rationale for this change

Ref #49164: In subproject builds, `DefineOptions.cmake` sets `ARROW_DEFINE_OPTIONS_DEFAULT` to OFF, so `ARROW_SIMD_LEVEL` is never defined. The `if()` at `cpp/src/arrow/io/CMakeLists.txt:48` uses `${ARROW_SIMD_LEVEL}` and expands to empty, leading to invalid `if()` arguments.

### What changes are included in this PR?

Use the variable name directly (no `${}`).

### Are these changes tested?

Yes.

### Are there any user-facing changes?

None.
* GitHub Issue: #49164