### PR TITLE
GH-49356: [C++] Remove deprecated APIs from v13.0.0 and v18.0.0

### DIFF
--- a/cpp/src/arrow/gpu/cuda_memory.cc
+++ b/cpp/src/arrow/gpu/cuda_memory.cc
@@ -486,23 +486,6 @@ Result<uint8_t*> GetHostAddress(uintptr_t device_ptr) {
   return static_cast<uint8_t*>(ptr);
 }
 
-Result<std::shared_ptr<MemoryManager>> DefaultMemoryMapper(ArrowDeviceType device_type,
-                                                           int64_t device_id) {
-  switch (device_type) {
-    case ARROW_DEVICE_CPU:
-      return default_cpu_memory_manager();
-    case ARROW_DEVICE_CUDA:
-    case ARROW_DEVICE_CUDA_HOST:
-    case ARROW_DEVICE_CUDA_MANAGED: {
-      ARROW_ASSIGN_OR_RAISE(auto device,
-                            arrow::cuda::CudaDevice::Make(static_cast<int>(device_id)));
-      return device->default_memory_manager();
-    }
-    default:
-      return Status::NotImplemented("memory manager not implemented for device");
-  }
-}
-
 namespace {
 
 Result<std::shared_ptr<MemoryManager>> DefaultCUDADeviceMapper(int64_t device_id) {

--- a/cpp/src/arrow/gpu/cuda_memory.h
+++ b/cpp/src/arrow/gpu/cuda_memory.h
@@ -261,11 +261,5 @@ Result<uintptr_t> GetDeviceAddress(const uint8_t* cpu_data,
 ARROW_CUDA_EXPORT
 Result<uint8_t*> GetHostAddress(uintptr_t device_ptr);
 
-ARROW_DEPRECATED(
-    "Deprecated in 16.0.0. The CUDA device is registered by default, and you can use "
-    "arrow::DefaultDeviceMapper instead.")
-Result<std::shared_ptr<MemoryManager>> DefaultMemoryMapper(ArrowDeviceType device_type,
-                                                           int64_t device_id);
-
 }  // namespace cuda
 }  // namespace arrow

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -3345,11 +3345,6 @@ std::shared_ptr<Field> field(std::string name, std::shared_ptr<DataType> type,
                                  std::move(metadata));
 }
 
-std::shared_ptr<DataType> decimal(int32_t precision, int32_t scale) {
-  return precision <= Decimal128Type::kMaxPrecision ? decimal128(precision, scale)
-                                                    : decimal256(precision, scale);
-}
-
 std::shared_ptr<DataType> smallest_decimal(int32_t precision, int32_t scale) {
   return precision <= Decimal32Type::kMaxPrecision    ? decimal32(precision, scale)
          : precision <= Decimal64Type::kMaxPrecision  ? decimal64(precision, scale)

--- a/cpp/src/arrow/type.h
+++ b/cpp/src/arrow/type.h
@@ -2585,9 +2585,6 @@ constexpr bool has_variadic_buffers(Type::type id) {
   }
 }
 
-ARROW_DEPRECATED("Deprecated in 17.0.0. Use may_have_validity_bitmap() instead.")
-constexpr bool HasValidityBitmap(Type::type id) { return may_have_validity_bitmap(id); }
-
 ARROW_EXPORT
 std::string ToString(Type::type id);
 

--- a/cpp/src/arrow/type_fwd.h
+++ b/cpp/src/arrow/type_fwd.h
@@ -532,16 +532,6 @@ ARROW_EXPORT const std::shared_ptr<DataType>& date64();
 ARROW_EXPORT
 std::shared_ptr<DataType> fixed_size_binary(int32_t byte_width);
 
-/// \brief Create a DecimalType instance depending on the precision
-///
-/// If the precision is greater than 38, a Decimal256Type is returned,
-/// otherwise a Decimal128Type.
-///
-/// Deprecated: prefer `smallest_decimal` instead.
-ARROW_DEPRECATED("Deprecated in 18.0. Use `smallest_decimal` instead")
-ARROW_EXPORT
-std::shared_ptr<DataType> decimal(int32_t precision, int32_t scale);
-
 /// \brief Create a the smallest DecimalType instance depending on precision
 ///
 /// Given the requested precision and scale, the smallest DecimalType which


### PR DESCRIPTION
### Rationale for This Change

This PR removes C++ APIs that have been deprecated for more than one year, in line with Arrow's deprecation and cleanup policy. All removed APIs were deprecated before January 1, 2025.

---

### What Changes Are Included in This PR?

This PR removes **3 deprecated C++ APIs**:

**1. `decimal(precision, scale)` function**
- Deprecated in v18.0.0 (September 30, 2024, PR #43957)
- Replacement: `smallest_decimal(precision, scale)`
- Removed from: `cpp/src/arrow/type_fwd.h`, `cpp/src/arrow/type.cc`

**2. `cuda::DefaultMemoryMapper(device_type, device_id)` function**
- Deprecated in v16.0.0 (April 16, 2024, PR #40699)
- Replacement: `arrow::DefaultDeviceMapper`
- Removed from: `cpp/src/arrow/gpu/cuda_memory.h`, `cpp/src/arrow/gpu/cuda_memory.cc`

**3. `HasValidityBitmap(Type::type id)` global function**
- Deprecated in v17.0.0 (July 11, 2024, PR #41115)
- Replacement: `may_have_validity_bitmap(Type::type id)`
- Removed from: `cpp/src/arrow/type.h`
- Note: Member functions like `ArrayData::HasValidityBitmap()` remain unchanged

---

### Are These Changes Tested?

Yes. Verified via full codebase search that all removed symbols have zero remaining usages in the C++ codebase.

---

### Are There Any User-Facing Changes?

Yes. Downstream C++ consumers using these deprecated APIs will need to migrate to the replacement APIs listed above.

---

* GitHub Issue: #49356
