### PR TITLE
GH-49174: [Ruby] Add support for writing dictionary array

### DIFF
--- a/ruby/red-arrow-format/lib/arrow-format/array.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/array.rb
@@ -508,10 +508,19 @@ module ArrowFormat
   end
 
   class DictionaryArray < Array
+    attr_reader :indices_buffer
+    attr_reader :dictionary
     def initialize(type, size, validity_buffer, indices_buffer, dictionary)
       super(type, size, validity_buffer)
       @indices_buffer = indices_buffer
       @dictionary = dictionary
+    end
+
+    def each_buffer
+      return to_enum(__method__) unless block_given?
+
+      yield(@validity_buffer)
+      yield(@indices_buffer)
     end
 
     def to_a

--- a/ruby/red-arrow-format/lib/arrow-format/bitmap.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/bitmap.rb
@@ -24,7 +24,7 @@ module ArrowFormat
     end
 
     def [](i)
-      (@validity_buffer.get_value(:U8, i / 8) & (1 << (i % 8))) > 0
+      (@buffer.get_value(:U8, i / 8) & (1 << (i % 8))) > 0
     end
 
     def each

--- a/ruby/red-arrow-format/lib/arrow-format/field.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/field.rb
@@ -34,18 +34,8 @@ module ArrowFormat
       fb_field = FB::Field::Data.new
       fb_field.name = @name
       fb_field.nullable = @nullable
-      if @type.is_a?(DictionaryType)
-        fb_field.type = @type.value_type.to_flatbuffers
-        dictionary_encoding = FB::DictionaryEncoding::Data.new
-        dictionary_encoding.id = @dictionary_id
-        int = FB::Int::Data.new
-        int.bit_width = @type.index_type.bit_width
-        int.signed = @type.index_type.signed?
-        dictionary_encoding.index_type = int
-        dictionary_encoding.ordered = @type.ordered?
-        dictionary_encoding.dictionary_kind =
-          FB::DictionaryKind::DENSE_ARRAY
-        fb_field.dictionary = dictionary
+      if @type.respond_to?(:build_fb_field)
+        @type.build_fb_field(fb_field, self)
       else
         fb_field.type = @type.to_flatbuffers
       end

--- a/ruby/red-arrow-format/lib/arrow-format/file-writer.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/file-writer.rb
@@ -41,7 +41,7 @@ module ArrowFormat
       fb_footer = FB::Footer::Data.new
       fb_footer.version = FB::MetadataVersion::V5
       fb_footer.schema = @fb_schema
-      # fb_footer.dictionaries = ... # TODO
+      fb_footer.dictionaries = @fb_dictionary_blocks
       fb_footer.record_batches = @fb_record_batch_blocks
       # fb_footer.custom_metadata = ... # TODO
       FB::Footer.serialize(fb_footer)

--- a/ruby/red-arrow-format/lib/arrow-format/type.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/type.rb
@@ -873,5 +873,19 @@ module ArrowFormat
                           indices_buffer,
                           dictionary)
     end
+
+    def build_fb_field(fb_field, field)
+      fb_dictionary_encoding = FB::DictionaryEncoding::Data.new
+      fb_dictionary_encoding.id = field.dictionary_id
+      fb_int = FB::Int::Data.new
+      fb_int.bit_width = @index_type.bit_width
+      fb_int.signed = @index_type.signed?
+      fb_dictionary_encoding.index_type = fb_int
+      fb_dictionary_encoding.ordered = @ordered
+      fb_dictionary_encoding.dictionary_kind =
+        FB::DictionaryKind::DENSE_ARRAY
+      fb_field.type = @value_type.to_flatbuffers
+      fb_field.dictionary = fb_dictionary_encoding
+    end
   end
 end


### PR DESCRIPTION
### Rationale for this change

Delta dictionary message support is out of scope.

### What changes are included in this PR?

* Add `ArrowFormat::DictionaryArray#each_buffer`
* Add `ArrowFormat::DictionaryType#build_fb_type`
* Add support for dictionary message in `ArrowFormat::StreamingWriter`
* Add support for writing dictionary message blocks in footer in `ArrowFormat::FileWriter`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.


* GitHub Issue: #49174