### PR TITLE
GH-49184: [CI] AMD64 macOS 15-intel Python 3 consistently times out

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -57,7 +57,7 @@ jobs:
     name: ${{ matrix.title }}
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
-    timeout-minutes: 75
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -142,7 +142,7 @@ jobs:
     name: ${{ matrix.architecture }} macOS ${{ matrix.macos-version }} Python 3
     runs-on: macos-${{ matrix.macos-version }}
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
-    timeout-minutes: 60
+    timeout-minutes: 75
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -57,7 +57,7 @@ jobs:
     name: ${{ matrix.title }}
     runs-on: ubuntu-latest
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
-    timeout-minutes: 60
+    timeout-minutes: 75
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -176,7 +176,7 @@ jobs:
       ARROW_WITH_BROTLI: ON
       ARROW_BUILD_TESTS: OFF
       PYARROW_TEST_LARGE_MEMORY: ${{ matrix.large-memory-tests }}
-      PYTEST_ARGS: "--durations=40"
+      PYTEST_ARGS: "-n auto --durations=40"
       # Current oldest supported version according to https://endoflife.date/macos
       MACOSX_DEPLOYMENT_TARGET: 12.0
     steps:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -142,7 +142,7 @@ jobs:
     name: ${{ matrix.architecture }} macOS ${{ matrix.macos-version }} Python 3
     runs-on: macos-${{ matrix.macos-version }}
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
-    timeout-minutes: 90
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -176,9 +176,9 @@ jobs:
       ARROW_WITH_BROTLI: ON
       ARROW_BUILD_TESTS: OFF
       PYARROW_TEST_LARGE_MEMORY: ${{ matrix.large-memory-tests }}
-      PYTEST_ARGS: "--durations=40 -v"
+      PYTEST_ARGS: "--durations=40"
       # Current oldest supported version according to https://endoflife.date/macos
-      MACOSX_DEPLOYMENT_TARGET: 12.0
+      MACOSX_DEPLOYMENT_TARGET: 14.0
     steps:
       - name: Checkout Arrow
         uses: actions/checkout@v6

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -149,7 +149,7 @@ jobs:
         include:
           - architecture: AMD64
             macos-version: "15-intel"
-            large-memory-tests: "ON"
+            large-memory-tests: "OFF"
           - architecture: ARM64
             macos-version: "14"
             large-memory-tests: "ON"

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -149,7 +149,7 @@ jobs:
         include:
           - architecture: AMD64
             macos-version: "15-intel"
-            large-memory-tests: "OFF"
+            large-memory-tests: "ON"
           - architecture: ARM64
             macos-version: "14"
             large-memory-tests: "ON"

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -142,7 +142,7 @@ jobs:
     name: ${{ matrix.architecture }} macOS ${{ matrix.macos-version }} Python 3
     runs-on: macos-${{ matrix.macos-version }}
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
-    timeout-minutes: 75
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
@@ -174,7 +174,7 @@ jobs:
       ARROW_WITH_BROTLI: ON
       ARROW_BUILD_TESTS: OFF
       PYARROW_TEST_LARGE_MEMORY: ON
-      PYTEST_ARGS: "--durations=20 -v"
+      PYTEST_ARGS: "--durations=40 -v"
       # Current oldest supported version according to https://endoflife.date/macos
       MACOSX_DEPLOYMENT_TARGET: 12.0
     steps:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -206,8 +206,19 @@ jobs:
         run: |
           $(brew --prefix bash)/bin/bash \
             ci/scripts/install_minio.sh latest /usr/local
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.9
+      - name: Setup ccache
+        shell: bash
+        run: ci/scripts/ccache_setup.sh
+      - name: ccache info
+        id: ccache-info
+        shell: bash
+        run: echo "cache-dir=$(ccache --get-config cache_dir)" >> $GITHUB_OUTPUT
+      - name: Cache ccache
+        uses: actions/cache@v5
+        with:
+          path: ${{ steps.ccache-info.outputs.cache-dir }}
+          key: python-ccache-macos-${{ matrix.macos-version }}-${{ hashFiles('cpp/**', 'python/**') }}
+          restore-keys: python-ccache-macos-${{ matrix.macos-version }}-
       - name: Build
         shell: bash
         run: |

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -178,7 +178,7 @@ jobs:
       PYARROW_TEST_LARGE_MEMORY: ${{ matrix.large-memory-tests }}
       PYTEST_ARGS: "--durations=40"
       # Current oldest supported version according to https://endoflife.date/macos
-      MACOSX_DEPLOYMENT_TARGET: 14.0
+      MACOSX_DEPLOYMENT_TARGET: 12.0
     steps:
       - name: Checkout Arrow
         uses: actions/checkout@v6

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -174,6 +174,7 @@ jobs:
       ARROW_WITH_BROTLI: ON
       ARROW_BUILD_TESTS: OFF
       PYARROW_TEST_LARGE_MEMORY: ON
+      PYTEST_ARGS: "--durations=20 -v"
       # Current oldest supported version according to https://endoflife.date/macos
       MACOSX_DEPLOYMENT_TARGET: 12.0
     steps:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -149,8 +149,10 @@ jobs:
         include:
           - architecture: AMD64
             macos-version: "15-intel"
+            large-memory-tests: "OFF"
           - architecture: ARM64
             macos-version: "14"
+            large-memory-tests: "ON"
     env:
       ARROW_HOME: /tmp/local
       ARROW_AZURE: ON
@@ -173,7 +175,7 @@ jobs:
       ARROW_WITH_SNAPPY: ON
       ARROW_WITH_BROTLI: ON
       ARROW_BUILD_TESTS: OFF
-      PYARROW_TEST_LARGE_MEMORY: ON
+      PYARROW_TEST_LARGE_MEMORY: ${{ matrix.large-memory-tests }}
       PYTEST_ARGS: "--durations=40 -v"
       # Current oldest supported version according to https://endoflife.date/macos
       MACOSX_DEPLOYMENT_TARGET: 12.0
@@ -204,19 +206,8 @@ jobs:
         run: |
           $(brew --prefix bash)/bin/bash \
             ci/scripts/install_minio.sh latest /usr/local
-      - name: Setup ccache
-        shell: bash
-        run: ci/scripts/ccache_setup.sh
-      - name: ccache info
-        id: ccache-info
-        shell: bash
-        run: echo "cache-dir=$(ccache --get-config cache_dir)" >> $GITHUB_OUTPUT
-      - name: Cache ccache
-        uses: actions/cache@v5
-        with:
-          path: ${{ steps.ccache-info.outputs.cache-dir }}
-          key: python-ccache-macos-${{ matrix.macos-version }}-${{ hashFiles('cpp/**', 'python/**') }}
-          restore-keys: python-ccache-macos-${{ matrix.macos-version }}-
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.9
       - name: Build
         shell: bash
         run: |

--- a/python/requirements-test.txt
+++ b/python/requirements-test.txt
@@ -3,5 +3,6 @@ hypothesis
 packaging
 pandas
 pytest
+pytest-xdist
 pytz
 pyuwsgi; sys.platform != 'win32' and python_version < '3.13'


### PR DESCRIPTION
### Rationale for this change
Recent CI checks failing with the job `AMD64 macOS 15-intel Python 3` being cancelled at 60 minutes.
```The job has exceeded the maximum execution time of 1h0m0s```

### What changes are included in this PR?
Disabling large memory tests for macOS 15-intel only.
For both macOS 14 and 15 adding PYTEST_ARGS: "-n auto --durations=40" to run tests across multiple CPUs (workers) and also output slowest 40 durations.

### Are these changes tested?
Tested on CI.

### Are there any user-facing changes?
No.
* GitHub Issue: #49184