### PR TITLE
GH-49196: [Python][Annotations] Filesystems

### DIFF
--- a/python/pyarrow-stubs/pyarrow/_azurefs.pyi
+++ b/python/pyarrow-stubs/pyarrow/_azurefs.pyi
@@ -1,0 +1,36 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from typing import Literal
+
+from ._fs import FileSystem
+
+
+class AzureFileSystem(FileSystem):
+    def __init__(
+        self,
+        account_name: str | None = None,
+        account_key: str | None = None,
+        blob_storage_authority: str | None = None,
+        dfs_storage_authority: str | None = None,
+        blob_storage_scheme: Literal["http", "https"] = "https",
+        dfs_storage_scheme: Literal["http", "https"] = "https",
+        sas_token: str | None = None,
+        tenant_id: str | None = None,
+        client_id: str | None = None,
+        client_secret: str | None = None,
+    ) -> None: ...

--- a/python/pyarrow-stubs/pyarrow/_fs.pyi
+++ b/python/pyarrow-stubs/pyarrow/_fs.pyi
@@ -1,0 +1,234 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import datetime as dt
+import enum
+import sys
+
+from abc import ABC, abstractmethod
+from _typeshed import StrPath
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
+if sys.version_info >= (3, 10):
+    from typing import TypeAlias
+else:
+    from typing_extensions import TypeAlias
+
+from fsspec import AbstractFileSystem  # type: ignore
+
+from .lib import NativeFile, _Weakrefable
+
+
+class FileType(enum.IntFlag):
+    NotFound = enum.auto()
+    Unknown = enum.auto()
+    File = enum.auto()
+    Directory = enum.auto()
+
+
+class FileInfo(_Weakrefable):
+    def __init__(
+        self,
+        path: str,
+        type: FileType = FileType.Unknown,
+        *,
+        mtime: dt.datetime | float | None = None,
+        mtime_ns: int | None = None,
+        size: int | None = None,
+    ): ...
+
+    def __getitem__(self, int) -> FileInfo: ...
+
+    @property
+    def type(self) -> FileType: ...
+
+    @property
+    def is_file(self) -> bool: ...
+    @property
+    def path(self) -> str: ...
+
+    @property
+    def base_name(self) -> str: ...
+
+    @property
+    def size(self) -> int: ...
+
+    @property
+    def extension(self) -> str: ...
+
+    @property
+    def mtime(self) -> dt.datetime | None: ...
+
+    @property
+    def mtime_ns(self) -> int | None: ...
+
+
+class FileSelector(_Weakrefable):
+    base_dir: str
+    allow_not_found: bool
+    recursive: bool
+    def __init__(self, base_dir: str, allow_not_found: bool = False,
+                 recursive: bool = False): ...
+
+
+class FileSystem(_Weakrefable):
+    @classmethod
+    def from_uri(cls, uri: str | StrPath) -> tuple[Self, str]: ...
+
+    def equals(self, other: FileSystem | object) -> bool: ...
+
+    @property
+    def type_name(self) -> str: ...
+
+    def get_file_info(
+        self, paths_or_selector: str | list[str] | FileSelector
+    ) -> list[FileInfo] | FileInfo: ...
+
+    def create_dir(self, path: str, *, recursive: bool = True) -> None: ...
+
+    def delete_dir(self, path: str) -> None: ...
+
+    def delete_dir_contents(
+        self, path: str, *, accept_root_dir: bool = False, missing_dir_ok: bool = False
+    ) -> None: ...
+
+    def move(self, src: str, dest: str) -> None: ...
+
+    def copy_file(self, src: str, dest: str) -> None: ...
+
+    def delete_file(self, path: str) -> None: ...
+
+    def open_input_file(self, path: str) -> NativeFile: ...
+
+    def open_input_stream(
+        self,
+        path: str,
+        compression: str | None = "detect",
+        buffer_size: int | None = None) -> NativeFile: ...
+
+    def open_output_stream(
+        self,
+        path: str,
+        compression: str | None = "detect",
+        buffer_size: int | None = None,
+        metadata: dict[str, str] | None = None,
+    ) -> NativeFile: ...
+
+    def open_append_stream(
+        self,
+        path: str,
+        compression: str | None = "detect",
+        buffer_size: int | None = None,
+        metadata: dict[str, str] | None = None,
+    ): ...
+
+    def normalize_path(self, path: str) -> str: ...
+
+
+class LocalFileSystem(FileSystem):
+    def __init__(self, *, use_mmap: bool = False) -> None: ...
+
+
+class SubTreeFileSystem(FileSystem):
+    def __init__(self, base_path: str, base_fs: FileSystem): ...
+    @property
+    def base_path(self) -> str: ...
+    @property
+    def base_fs(self) -> FileSystem: ...
+
+
+class _MockFileSystem(FileSystem):
+    def __init__(self, current_time: dt.datetime | None = None) -> None: ...
+
+
+class PyFileSystem(FileSystem):
+    def __init__(self, handler: FileSystemHandler | None) -> None: ...
+    @property
+    def handler(self) -> FileSystemHandler: ...
+
+
+class FileSystemHandler(ABC):
+    @abstractmethod
+    def get_type_name(self) -> str: ...
+
+    @abstractmethod
+    def get_file_info(self, paths: str | list[str]) -> FileInfo | list[FileInfo]: ...
+
+    @abstractmethod
+    def get_file_info_selector(self, selector: FileSelector) -> list[FileInfo]: ...
+
+    @abstractmethod
+    def create_dir(self, path: str, recursive: bool) -> None: ...
+
+    @abstractmethod
+    def delete_dir(self, path: str) -> None: ...
+
+    @abstractmethod
+    def delete_dir_contents(self, path: str, missing_dir_ok: bool = False) -> None: ...
+
+    @abstractmethod
+    def delete_root_dir_contents(self) -> None: ...
+
+    @abstractmethod
+    def delete_file(self, path: str) -> None: ...
+
+    @abstractmethod
+    def move(self, src: str, dest: str) -> None: ...
+
+    @abstractmethod
+    def copy_file(self, src: str, dest: str) -> None: ...
+
+    @abstractmethod
+    def open_input_stream(self, path: str) -> NativeFile: ...
+
+    @abstractmethod
+    def open_input_file(self, path: str) -> NativeFile: ...
+
+    @abstractmethod
+    def open_output_stream(self, path: str, metadata: dict[str, str]) -> NativeFile: ...
+
+    @abstractmethod
+    def open_append_stream(self, path: str, metadata: dict[str, str]) -> NativeFile: ...
+
+    @abstractmethod
+    def normalize_path(self, path: str) -> str: ...
+
+
+SupportedFileSystem: TypeAlias = AbstractFileSystem | FileSystem
+
+
+def _copy_files(
+    source_fs: FileSystem,
+    source_path: str,
+    destination_fs: SupportedFileSystem | None,
+    destination_path: str,
+    chunk_size: int = 1048576,
+    use_threads: bool = True,
+) -> None: ...
+
+
+def _copy_files_selector(
+    source_fs: FileSystem,
+    source_sel: FileSelector,
+    destination_fs: SupportedFileSystem | None,
+    destination_base_dir: str,
+    chunk_size: int = 1048576,
+    use_threads: bool = True,
+) -> None: ...

--- a/python/pyarrow-stubs/pyarrow/_gcsfs.pyi
+++ b/python/pyarrow-stubs/pyarrow/_gcsfs.pyi
@@ -1,0 +1,43 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import datetime as dt
+
+from ._fs import FileSystem
+from .lib import KeyValueMetadata
+
+
+class GcsFileSystem(FileSystem):
+    def __init__(
+        self,
+        *,
+        anonymous: bool = False,
+        access_token: str | None = None,
+        target_service_account: str | None = None,
+        credential_token_expiration: dt.datetime | None = None,
+        default_bucket_location: str = "US",
+        scheme: str = "https",
+        endpoint_override: str | None = None,
+        default_metadata: dict | KeyValueMetadata | None = None,
+        retry_time_limit: dt.timedelta | None = None,
+        project_id: str | None = None,
+    ): ...
+    @property
+    def default_bucket_location(self) -> str: ...
+
+    @property
+    def project_id(self) -> str: ...

--- a/python/pyarrow-stubs/pyarrow/_hdfs.pyi
+++ b/python/pyarrow-stubs/pyarrow/_hdfs.pyi
@@ -1,0 +1,37 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from _typeshed import StrPath
+
+from ._fs import FileSystem
+
+
+class HadoopFileSystem(FileSystem):
+    def __init__(
+        self,
+        host: str | None = None,
+        port: int = 8020,
+        *,
+        user: str | None = None,
+        replication: int = 3,
+        buffer_size: int = 0,
+        default_block_size: int | None = None,
+        kerb_ticket: StrPath | None = None,
+        extra_conf: dict | None = None,
+    ): ...
+    @staticmethod
+    def from_uri(uri: str | int) -> HadoopFileSystem: ...  # type: ignore[override]

--- a/python/pyarrow-stubs/pyarrow/_s3fs.pyi
+++ b/python/pyarrow-stubs/pyarrow/_s3fs.pyi
@@ -1,0 +1,106 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import enum
+
+from typing import Literal, TypedDict
+from typing_extensions import Required, NotRequired
+
+from ._fs import FileSystem
+from .lib import KeyValueMetadata
+
+
+class _ProxyOptions(TypedDict):
+    scheme: Required[Literal["http", "https"]]
+    host: Required[str]
+    port: Required[int]
+    username: NotRequired[str]
+    password: NotRequired[str]
+
+
+class S3LogLevel(enum.IntEnum):
+    Off = enum.auto()
+    Fatal = enum.auto()
+    Error = enum.auto()
+    Warn = enum.auto()
+    Info = enum.auto()
+    Debug = enum.auto()
+    Trace = enum.auto()
+
+
+Off = S3LogLevel.Off
+Fatal = S3LogLevel.Fatal
+Error = S3LogLevel.Error
+Warn = S3LogLevel.Warn
+Info = S3LogLevel.Info
+Debug = S3LogLevel.Debug
+Trace = S3LogLevel.Trace
+
+
+def initialize_s3(
+    log_level: S3LogLevel = S3LogLevel.Fatal, num_event_loop_threads: int = 1
+) -> None: ...
+def ensure_s3_initialized() -> None: ...
+def finalize_s3() -> None: ...
+def ensure_s3_finalized() -> None: ...
+def resolve_s3_region(bucket: str) -> str: ...
+
+
+class S3RetryStrategy:
+    max_attempts: int
+    def __init__(self, max_attempts=3) -> None: ...
+
+
+class AwsStandardS3RetryStrategy(S3RetryStrategy):
+    ...
+
+
+class AwsDefaultS3RetryStrategy(S3RetryStrategy):
+    ...
+
+
+class S3FileSystem(FileSystem):
+    def __init__(
+        self,
+        *,
+        access_key: str | None = None,
+        secret_key: str | None = None,
+        session_token: str | None = None,
+        anonymous: bool = False,
+        region: str | None = None,
+        request_timeout: float | None = None,
+        connect_timeout: float | None = None,
+        scheme: Literal["http", "https"] = "https",
+        endpoint_override: str | None = None,
+        background_writes: bool = True,
+        default_metadata: dict | list | KeyValueMetadata | None = None,
+        role_arn: str | None = None,
+        session_name: str | None = None,
+        external_id: str | None = None,
+        load_frequency: int = 900,
+        proxy_options: _ProxyOptions | dict | tuple | str | None = None,
+        allow_bucket_creation: bool = False,
+        allow_bucket_deletion: bool = False,
+        allow_delayed_open: bool = False,
+        check_directory_existence_before_creation: bool = False,
+        tls_ca_file_path: str | None = None,
+        retry_strategy: S3RetryStrategy =
+        AwsStandardS3RetryStrategy(max_attempts=3),  # noqa: Y011
+        force_virtual_addressing: bool = False,
+    ): ...
+    @property
+    def region(self) -> str: ...

--- a/python/pyarrow-stubs/pyarrow/fs.pyi
+++ b/python/pyarrow-stubs/pyarrow/fs.pyi
@@ -1,0 +1,112 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from pyarrow._fs import (
+    FileSelector,
+    FileType,
+    FileInfo,
+    FileSystem,
+    LocalFileSystem,
+    SubTreeFileSystem,
+    _MockFileSystem,
+    FileSystemHandler,
+    PyFileSystem,
+    SupportedFileSystem,
+)
+from pyarrow._azurefs import AzureFileSystem
+from pyarrow._hdfs import HadoopFileSystem
+from pyarrow._gcsfs import GcsFileSystem
+from pyarrow._s3fs import (
+    AwsDefaultS3RetryStrategy,
+    AwsStandardS3RetryStrategy,
+    S3FileSystem,
+    S3LogLevel,
+    S3RetryStrategy,
+    ensure_s3_initialized,
+    finalize_s3,
+    ensure_s3_finalized,
+    initialize_s3,
+    resolve_s3_region,
+)
+
+FileStats = FileInfo
+
+
+def copy_files(
+    source: str,
+    destination: str,
+    source_filesystem: SupportedFileSystem | None = None,
+    destination_filesystem: SupportedFileSystem | None = None,
+    *,
+    chunk_size: int = 1024 * 1024,  # noqa: Y011
+    use_threads: bool = True,
+) -> None: ...
+
+
+def _ensure_filesystem(
+    filesystem: FileSystem | str | object,
+    *,
+    use_mmap: bool = False
+) -> FileSystem: ...
+
+
+def _resolve_filesystem_and_path(
+    path: str | object,
+    filesystem: FileSystem | str | object | None = None,
+    *,
+    memory_map: bool = False
+) -> tuple[FileSystem, str]: ...
+
+
+class FSSpecHandler(FileSystemHandler):  # type: ignore[misc]  # All abstract methods implemented via fsspec delegation # noqa: E501
+    fs: SupportedFileSystem
+    def __init__(self, fs: SupportedFileSystem) -> None: ...
+
+
+__all__ = [
+    # _fs
+    "FileSelector",
+    "FileType",
+    "FileInfo",
+    "FileSystem",
+    "LocalFileSystem",
+    "SubTreeFileSystem",
+    "_MockFileSystem",
+    "FileSystemHandler",
+    "PyFileSystem",
+    # _azurefs
+    "AzureFileSystem",
+    # _hdfs
+    "HadoopFileSystem",
+    # _gcsfs
+    "GcsFileSystem",
+    # _s3fs
+    "AwsDefaultS3RetryStrategy",
+    "AwsStandardS3RetryStrategy",
+    "S3FileSystem",
+    "S3LogLevel",
+    "S3RetryStrategy",
+    "ensure_s3_initialized",
+    "finalize_s3",
+    "ensure_s3_finalized",
+    "initialize_s3",
+    "resolve_s3_region",
+    # fs
+    "FileStats",
+    "copy_files",
+    "FSSpecHandler",
+]

--- a/python/pyarrow/fs.py
+++ b/python/pyarrow/fs.py
@@ -40,7 +40,7 @@ FileStats = FileInfo
 
 _not_imported = []
 try:
-    from pyarrow._azurefs import AzureFileSystem  # noqa
+    from pyarrow._azurefs import AzureFileSystem  # noqa  # type: ignore[reportMissingModuleSource]
 except ImportError:
     _not_imported.append("AzureFileSystem")
 
@@ -50,12 +50,12 @@ except ImportError:
     _not_imported.append("HadoopFileSystem")
 
 try:
-    from pyarrow._gcsfs import GcsFileSystem  # noqa
+    from pyarrow._gcsfs import GcsFileSystem  # noqa  # type: ignore[reportMissingModuleSource]
 except ImportError:
     _not_imported.append("GcsFileSystem")
 
 try:
-    from pyarrow._s3fs import (  # noqa
+    from pyarrow._s3fs import (  # noqa  # type: ignore[reportMissingModuleSource]
         AwsDefaultS3RetryStrategy, AwsStandardS3RetryStrategy,
         S3FileSystem, S3LogLevel, S3RetryStrategy, ensure_s3_initialized,
         finalize_s3, ensure_s3_finalized, initialize_s3, resolve_s3_region)
@@ -111,7 +111,7 @@ def _ensure_filesystem(filesystem, *, use_mmap=False):
     else:
         # handle fsspec-compatible filesystems
         try:
-            import fsspec
+            import fsspec  # type: ignore[import-untyped]
         except ImportError:
             pass
         else:
@@ -165,6 +165,7 @@ def _resolve_filesystem_and_path(path, filesystem=None, *, memory_map=False):
         file_info = None
         exists_locally = False
     else:
+        assert isinstance(file_info, FileInfo)
         exists_locally = (file_info.type != FileType.NotFound)
 
     # if the file or directory doesn't exists locally, then assume that
@@ -250,7 +251,9 @@ def copy_files(source, destination,
         destination, destination_filesystem
     )
 
+    assert isinstance(source_fs, FileSystem)
     file_info = source_fs.get_file_info(source_path)
+    assert isinstance(file_info, FileInfo)
     if file_info.type == FileType.Directory:
         source_sel = FileSelector(source_path, recursive=True)
         _copy_files_selector(source_fs, source_sel,


### PR DESCRIPTION
### Rationale for this change

Closes: #49196

### What changes are included in this PR?

Adds type annotation stubs for fs, _fs, _s3fs, _azurefs, _gcsfs, and _hdfs modules. Includes source fixes in fs.py and type-ignore annotations in test_fs.py.

### Are these changes tested?

Yes, by CI.

### Are there any user-facing changes?

Filesystems will be type annotated.
* GitHub Issue: #49196