### PR TITLE
GH-49197: [Python][Annotations] Parquet and Dataset

### DIFF
--- a/python/pyarrow-stubs/pyarrow/_dataset.pyi
+++ b/python/pyarrow-stubs/pyarrow/_dataset.pyi
@@ -1,0 +1,682 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import sys
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
+from collections.abc import Collection, Callable, Iterator, Iterable
+from typing import (
+    IO,
+    Any,
+    Generic,
+    Literal,
+    NamedTuple,
+    TypeVar,
+)
+
+from _typeshed import StrPath
+
+from . import csv, _json, _parquet, lib
+from ._fs import FileSelector, FileSystem, SupportedFileSystem
+from ._stubs_typing import Indices, JoinType, Order
+from .acero import ExecNodeOptions
+from .compute import Expression
+from .ipc import IpcWriteOptions, RecordBatchReader
+
+
+class Dataset(lib._Weakrefable):
+    @property
+    def partition_expression(self) -> Expression: ...
+
+    def replace_schema(self, schema: lib.Schema) -> Self: ...
+
+    def get_fragments(self, filter: Expression | None = None): ...
+
+    def scanner(
+        self,
+        columns: list[str] | dict[str, Expression] | None = None,
+        filter: Expression | None = None,
+        batch_size: int = ...,
+        batch_readahead: int = 16,
+        fragment_readahead: int = 4,
+        fragment_scan_options: FragmentScanOptions | None = None,
+        use_threads: bool = True,
+        cache_metadata: bool = True,
+        memory_pool: lib.MemoryPool | None = None,
+    ) -> Scanner: ...
+
+    def to_batches(
+        self,
+        columns: list[str] | None = None,
+        filter: Expression | None = None,
+        batch_size: int = ...,
+        batch_readahead: int = 16,
+        fragment_readahead: int = 4,
+        fragment_scan_options: FragmentScanOptions | None = None,
+        use_threads: bool = True,
+        cache_metadata: bool = True,
+        memory_pool: lib.MemoryPool | None = None,
+    ) -> Iterator[lib.RecordBatch]: ...
+
+    def to_table(
+        self,
+        columns: list[str] | dict[str, Expression] | None = None,
+        filter: Expression | None = None,
+        batch_size: int = ...,
+        batch_readahead: int = 16,
+        fragment_readahead: int = 4,
+        fragment_scan_options: FragmentScanOptions | None = None,
+        use_threads: bool = True,
+        cache_metadata: bool = True,
+        memory_pool: lib.MemoryPool | None = None,
+    ) -> lib.Table: ...
+
+    def take(
+        self,
+        indices: Indices,
+        columns: list[str] | None = None,
+        filter: Expression | None = None,
+        batch_size: int = ...,
+        batch_readahead: int = 16,
+        fragment_readahead: int = 4,
+        fragment_scan_options: FragmentScanOptions | None = None,
+        use_threads: bool = True,
+        cache_metadata: bool = True,
+        memory_pool: lib.MemoryPool | None = None,
+    ) -> lib.Table: ...
+
+    def head(
+        self,
+        num_rows: int,
+        columns: list[str] | None = None,
+        filter: Expression | None = None,
+        batch_size: int = ...,
+        batch_readahead: int = 16,
+        fragment_readahead: int = 4,
+        fragment_scan_options: FragmentScanOptions | None = None,
+        use_threads: bool = True,
+        cache_metadata: bool = True,
+        memory_pool: lib.MemoryPool | None = None,
+    ) -> lib.Table: ...
+
+    def count_rows(
+        self,
+        filter: Expression | None = None,
+        batch_size: int = ...,
+        batch_readahead: int = 16,
+        fragment_readahead: int = 4,
+        fragment_scan_options: FragmentScanOptions | None = None,
+        use_threads: bool = True,
+        cache_metadata: bool = True,
+        memory_pool: lib.MemoryPool | None = None,
+    ) -> int: ...
+
+    @property
+    def schema(self) -> lib.Schema: ...
+
+    def filter(self, expression: Expression | None) -> Self: ...
+
+    def sort_by(self, sorting: str |
+                list[tuple[str, Order]], **kwargs) -> InMemoryDataset: ...
+
+    def join(
+        self,
+        right_dataset: Dataset,
+        keys: str | list[str],
+        right_keys: str | list[str] | None = None,
+        join_type: JoinType = "left outer",
+        left_suffix: str | None = None,
+        right_suffix: str | None = None,
+        coalesce_keys: bool = True,
+        use_threads: bool = True,
+    ) -> InMemoryDataset: ...
+
+    def join_asof(
+        self,
+        right_dataset: Dataset,
+        on: str,
+        by: str | list[str],
+        tolerance: int,
+        right_on: str | list[str] | None = None,
+        right_by: str | list[str] | None = None,
+    ) -> InMemoryDataset: ...
+
+    @property
+    def format(self) -> FileFormat: ...
+
+
+class InMemoryDataset(Dataset):
+    def __init__(
+        self,
+        source: lib.Table
+        | lib.RecordBatch
+        | lib.RecordBatchReader
+        | Iterable[lib.RecordBatch]
+        | list[Any],
+        schema: lib.Schema | None = None,
+    ) -> None: ...
+
+
+class UnionDataset(Dataset):
+    def __init__(
+        self,
+        schema: lib.Schema | None = None,
+        children: list[Dataset] | None = None,
+    ) -> None: ...
+
+    @property
+    def children(self) -> list[Dataset]: ...
+
+
+class FileSystemDataset(Dataset):
+    def __init__(
+        self,
+        fragments: list[Fragment],
+        schema: lib.Schema,
+        format: FileFormat,
+        filesystem: SupportedFileSystem | None = None,
+        root_partition: Expression | None = None,
+    ) -> None: ...
+
+    @classmethod
+    def from_paths(
+        cls,
+        paths: list[str],
+        schema: lib.Schema | None = None,
+        format: FileFormat | None = None,
+        filesystem: SupportedFileSystem | None = None,
+        partitions: list[Expression] | None = None,
+        root_partition: Expression | None = None,
+    ) -> FileSystemDataset: ...
+
+    @property
+    def filesystem(self) -> FileSystem: ...
+    @property
+    def partitioning(self) -> Partitioning | None: ...
+
+    @property
+    def files(self) -> list[str]: ...
+
+
+class FileWriteOptions(lib._Weakrefable):
+    @property
+    def format(self) -> FileFormat: ...
+
+
+class FileFormat(lib._Weakrefable):
+    def inspect(
+        self, file: StrPath | IO, filesystem: SupportedFileSystem | None = None
+    ) -> lib.Schema: ...
+
+    def make_fragment(
+        self,
+        file: StrPath | IO | lib.Buffer | lib.BufferReader,
+        filesystem: SupportedFileSystem | None = None,
+        partition_expression: Expression | None = None,
+        *,
+        file_size: int | None = None,
+    ) -> Fragment: ...
+
+    def make_write_options(self) -> FileWriteOptions: ...
+    @property
+    def default_extname(self) -> str: ...
+    @property
+    def default_fragment_scan_options(self) -> FragmentScanOptions: ...
+    @default_fragment_scan_options.setter
+    def default_fragment_scan_options(self, options: FragmentScanOptions) -> None: ...
+
+
+class Fragment(lib._Weakrefable):
+    def open(self) -> lib.NativeFile | lib.BufferReader: ...
+    @property
+    def path(self) -> str: ...
+    @property
+    def row_groups(self) -> list[int]: ...
+
+    @property
+    def filesystem(self) -> SupportedFileSystem: ...
+
+    @property
+    def physical_schema(self) -> lib.Schema: ...
+
+    @property
+    def partition_expression(self) -> Expression: ...
+
+    def scanner(
+        self,
+        schema: lib.Schema | None = None,
+        columns: list[str] | None = None,
+        filter: Expression | None = None,
+        batch_size: int = ...,
+        batch_readahead: int = 16,
+        fragment_readahead: int = 4,
+        fragment_scan_options: FragmentScanOptions | None = None,
+        use_threads: bool = True,
+        cache_metadata: bool = True,
+        memory_pool: lib.MemoryPool | None = None,
+    ) -> Scanner: ...
+
+    def to_batches(
+        self,
+        schema: lib.Schema | None = None,
+        columns: list[str] | None = None,
+        filter: Expression | None = None,
+        batch_size: int = ...,
+        batch_readahead: int = 16,
+        fragment_readahead: int = 4,
+        fragment_scan_options: FragmentScanOptions | None = None,
+        use_threads: bool = True,
+        cache_metadata: bool = True,
+        memory_pool: lib.MemoryPool | None = None,
+    ) -> Iterator[lib.RecordBatch]: ...
+
+    def to_table(
+        self,
+        schema: lib.Schema | None = None,
+        columns: list[str] | None = None,
+        filter: Expression | None = None,
+        batch_size: int = ...,
+        batch_readahead: int = 16,
+        fragment_readahead: int = 4,
+        fragment_scan_options: FragmentScanOptions | None = None,
+        use_threads: bool = True,
+        cache_metadata: bool = True,
+        memory_pool: lib.MemoryPool | None = None,
+    ) -> lib.Table: ...
+
+    def take(
+        self,
+        indices: Indices,
+        columns: list[str] | None = None,
+        filter: Expression | None = None,
+        batch_size: int = ...,
+        batch_readahead: int = 16,
+        fragment_readahead: int = 4,
+        fragment_scan_options: FragmentScanOptions | None = None,
+        use_threads: bool = True,
+        cache_metadata: bool = True,
+        memory_pool: lib.MemoryPool | None = None,
+    ) -> lib.Table: ...
+
+    def head(
+        self,
+        num_rows: int,
+        columns: list[str] | None = None,
+        filter: Expression | None = None,
+        batch_size: int = ...,
+        batch_readahead: int = 16,
+        fragment_readahead: int = 4,
+        fragment_scan_options: FragmentScanOptions | None = None,
+        use_threads: bool = True,
+        cache_metadata: bool = True,
+        memory_pool: lib.MemoryPool | None = None,
+    ) -> lib.Table: ...
+
+    def count_rows(
+        self,
+        columns: list[str] | None = None,
+        filter: Expression | None = None,
+        batch_size: int = ...,
+        batch_readahead: int = 16,
+        fragment_readahead: int = 4,
+        fragment_scan_options: FragmentScanOptions | None = None,
+        use_threads: bool = True,
+        cache_metadata: bool = True,
+        memory_pool: lib.MemoryPool | None = None,
+    ) -> int: ...
+
+
+class FileFragment(Fragment):
+    def open(self) -> lib.NativeFile: ...
+
+    @property
+    def path(self) -> str: ...
+
+    @property
+    def filesystem(self) -> FileSystem: ...
+
+    @property
+    def buffer(self) -> lib.Buffer: ...
+
+    @property
+    def format(self) -> FileFormat: ...
+
+
+class FragmentScanOptions(lib._Weakrefable):
+    @property
+    def type_name(self) -> str: ...
+
+
+class IpcFileWriteOptions(FileWriteOptions):
+    @property
+    def write_options(self) -> IpcWriteOptions: ...
+    @write_options.setter
+    def write_options(self, write_options: IpcWriteOptions) -> None: ...
+
+
+class IpcFileFormat(FileFormat):
+    def equals(self, other: IpcFileFormat) -> bool: ...
+    def make_write_options(self, **kwargs) -> IpcFileWriteOptions: ...
+    @property
+    def default_extname(self) -> str: ...
+
+
+class FeatherFileFormat(IpcFileFormat):
+    ...
+
+
+class CsvFileFormat(FileFormat):
+    def __init__(
+        self,
+        parse_options: csv.ParseOptions | None = None,
+        default_fragment_scan_options: CsvFragmentScanOptions | None = None,
+        convert_options: csv.ConvertOptions | None = None,
+        read_options: csv.ReadOptions | None = None,
+    ) -> None: ...
+    def make_write_options(
+        self, **kwargs) -> CsvFileWriteOptions: ...  # type: ignore[override]
+
+    @property
+    def parse_options(self) -> csv.ParseOptions: ...
+    @parse_options.setter
+    def parse_options(self, parse_options: csv.ParseOptions) -> None: ...
+    def equals(self, other: CsvFileFormat) -> bool: ...
+
+
+class CsvFragmentScanOptions(FragmentScanOptions):
+    convert_options: csv.ConvertOptions
+    read_options: csv.ReadOptions
+
+    def __init__(
+        self,
+        convert_options: csv.ConvertOptions | None = None,
+        read_options: csv.ReadOptions | None = None,
+    ) -> None: ...
+    def equals(self, other: CsvFragmentScanOptions) -> bool: ...
+
+
+class CsvFileWriteOptions(FileWriteOptions):
+    write_options: csv.WriteOptions
+
+
+class JsonFileFormat(FileFormat):
+    def __init__(
+        self,
+        default_fragment_scan_options: JsonFragmentScanOptions | None = None,
+        parse_options: _json.ParseOptions | None = None,
+        read_options: _json.ReadOptions | None = None,
+    ) -> None: ...
+    def equals(self, other: JsonFileFormat) -> bool: ...
+
+
+class JsonFragmentScanOptions(FragmentScanOptions):
+    parse_options: _json.ParseOptions
+    read_options: _json.ReadOptions
+
+    def __init__(
+        self,
+        parse_options: _json.ParseOptions | None = None,
+        read_options: _json.ReadOptions | None = None,
+    ) -> None: ...
+    def equals(self, other: JsonFragmentScanOptions) -> bool: ...
+
+
+class Partitioning(lib._Weakrefable):
+    def parse(self, path: str) -> Expression: ...
+
+    def format(self, expr: Expression) -> tuple[str, str]: ...
+
+    @property
+    def schema(self) -> lib.Schema: ...
+
+    @property
+    def dictionaries(self) -> list[Any]: ...
+
+
+class PartitioningFactory(lib._Weakrefable):
+    @property
+    def type_name(self) -> str: ...
+
+
+class KeyValuePartitioning(Partitioning):
+    @property
+    def dictionaries(self) -> list[Any]: ...
+
+
+class DirectoryPartitioning(KeyValuePartitioning):
+    @staticmethod
+    def discover(
+        field_names: list[str] | None = None,
+        infer_dictionary: bool = False,
+        max_partition_dictionary_size: int = 0,
+        schema: lib.Schema | None = None,
+        segment_encoding: Literal["uri", "none"] = "uri",
+    ) -> PartitioningFactory: ...
+
+    def __init__(
+        self,
+        schema: lib.Schema,
+        dictionaries: dict[str, lib.Array] | None = None,
+        segment_encoding: Literal["uri", "none"] = "uri",
+    ) -> None: ...
+
+
+class HivePartitioning(KeyValuePartitioning):
+    def __init__(
+        self,
+        schema: lib.Schema,
+        dictionaries: dict[str, lib.Array] | None = None,
+        null_fallback: str = "__HIVE_DEFAULT_PARTITION__",
+        segment_encoding: Literal["uri", "none"] = "uri",
+    ) -> None: ...
+
+    @staticmethod
+    def discover(
+        infer_dictionary: bool = False,
+        max_partition_dictionary_size: int = 0,
+        null_fallback="__HIVE_DEFAULT_PARTITION__",
+        schema: lib.Schema | None = None,
+        segment_encoding: Literal["uri", "none"] = "uri",
+    ) -> PartitioningFactory: ...
+
+
+class FilenamePartitioning(KeyValuePartitioning):
+    def __init__(
+        self,
+        schema: lib.Schema,
+        dictionaries: dict[str, lib.Array] | None = None,
+        segment_encoding: Literal["uri", "none"] = "uri",
+    ) -> None: ...
+
+    @staticmethod
+    def discover(
+        field_names: list[str] | None = None,
+        infer_dictionary: bool = False,
+        schema: lib.Schema | None = None,
+        segment_encoding: Literal["uri", "none"] = "uri",
+    ) -> PartitioningFactory: ...
+
+
+class DatasetFactory(lib._Weakrefable):
+    root_partition: Expression
+    def finish(self, schema: lib.Schema | None = None) -> Dataset: ...
+
+    def inspect(
+        self,
+        *,
+        promote_options: str = "default",
+        fragments: list[Fragment] | int | str | None = None,
+    ) -> lib.Schema: ...
+
+    def inspect_schemas(self) -> list[lib.Schema]: ...
+
+
+class FileSystemFactoryOptions(lib._Weakrefable):
+    partitioning: Partitioning
+    partitioning_factory: PartitioningFactory
+    partition_base_dir: str
+    exclude_invalid_files: bool
+    selector_ignore_prefixes: list[str]
+
+    def __init__(
+        self,
+        partition_base_dir: str | None = None,
+        partitioning: Partitioning | PartitioningFactory | None = None,
+        exclude_invalid_files: bool | None = True,
+        selector_ignore_prefixes: list[str] | None = None,
+    ) -> None: ...
+
+
+class FileSystemDatasetFactory(DatasetFactory):
+    def __init__(
+        self,
+        filesystem: SupportedFileSystem,
+        paths_or_selector: Collection[str] | FileSelector,
+        format: FileFormat,
+        options: FileSystemFactoryOptions | None = None,
+    ) -> None: ...
+
+
+class UnionDatasetFactory(DatasetFactory):
+    def __init__(self, factories: list[DatasetFactory]) -> None: ...
+
+
+_RecordBatchT = TypeVar("_RecordBatchT", bound=lib.RecordBatch)
+
+
+class RecordBatchIterator(lib._Weakrefable, Generic[_RecordBatchT]):
+    def __iter__(self) -> Self: ...
+    def __next__(self) -> _RecordBatchT: ...
+
+
+class TaggedRecordBatch(NamedTuple):
+    record_batch: lib.RecordBatch
+    fragment: Fragment
+
+
+class TaggedRecordBatchIterator(lib._Weakrefable):
+    def __iter__(self) -> Self: ...
+    def __next__(self) -> TaggedRecordBatch: ...
+
+
+class Scanner(lib._Weakrefable):
+    @staticmethod
+    def from_dataset(
+        dataset: Dataset,
+        *,
+        columns: list[str] | dict[str, Expression] | None = None,
+        filter: Expression | None = None,
+        batch_size: int = ...,
+        batch_readahead: int = 16,
+        fragment_readahead: int = 4,
+        fragment_scan_options: FragmentScanOptions | None = None,
+        use_threads: bool = True,
+        cache_metadata: bool = True,
+        memory_pool: lib.MemoryPool | None = None,
+    ) -> Scanner: ...
+
+    @staticmethod
+    def from_fragment(
+        fragment: Fragment,
+        *,
+        schema: lib.Schema | None = None,
+        columns: list[str] | dict[str, Expression] | None = None,
+        filter: Expression | None = None,
+        batch_size: int = ...,
+        batch_readahead: int = 16,
+        fragment_readahead: int = 4,
+        fragment_scan_options: FragmentScanOptions | None = None,
+        use_threads: bool = True,
+        cache_metadata: bool = True,
+        memory_pool: lib.MemoryPool | None = None,
+    ) -> Scanner: ...
+
+    @staticmethod
+    def from_batches(
+        source: Iterator[lib.RecordBatch] | RecordBatchReader | Any,
+        *,
+        schema: lib.Schema | None = None,
+        columns: list[str] | dict[str, Expression] | None = None,
+        filter: Expression | None = None,
+        batch_size: int = ...,
+        batch_readahead: int = 16,
+        fragment_readahead: int = 4,
+        fragment_scan_options: FragmentScanOptions | None = None,
+        use_threads: bool = True,
+        cache_metadata: bool = True,
+        memory_pool: lib.MemoryPool | None = None,
+    ) -> Scanner: ...
+
+    @property
+    def dataset_schema(self) -> lib.Schema: ...
+
+    @property
+    def projected_schema(self) -> lib.Schema: ...
+
+    def to_batches(self) -> Iterator[lib.RecordBatch]: ...
+
+    def scan_batches(self) -> TaggedRecordBatchIterator: ...
+
+    def to_table(self) -> lib.Table: ...
+
+    def take(self, indices: Indices) -> lib.Table: ...
+
+    def head(self, num_rows: int) -> lib.Table: ...
+
+    def count_rows(self) -> int: ...
+
+    def to_reader(self) -> RecordBatchReader: ...
+
+
+def get_partition_keys(partition_expression: Expression) -> dict[str, Any]: ...
+
+
+class WrittenFile(lib._Weakrefable):
+    def __init__(self, path: str, metadata: _parquet.FileMetaData |
+                 None, size: int) -> None: ...
+
+
+def _filesystemdataset_write(
+    data: Scanner,
+    base_dir: StrPath,
+    basename_template: str,
+    filesystem: SupportedFileSystem,
+    partitioning: Partitioning,
+    preserve_order: bool,
+    file_options: FileWriteOptions,
+    max_partitions: int,
+    file_visitor: Callable[[str], None] | None,
+    existing_data_behavior: Literal["error", "overwrite_or_ignore", "delete_matching"],
+    max_open_files: int,
+    max_rows_per_file: int,
+    min_rows_per_group: int,
+    max_rows_per_group: int,
+    create_dir: bool,
+): ...
+
+
+class _ScanNodeOptions(ExecNodeOptions):
+    def _set_options(self, dataset: Dataset, scan_options: dict) -> None: ...
+
+
+class ScanNodeOptions(_ScanNodeOptions):
+    def __init__(
+        self, dataset: Dataset, require_sequenced_output: bool = False, **kwargs
+    ) -> None: ...

--- a/python/pyarrow-stubs/pyarrow/_dataset_orc.pyi
+++ b/python/pyarrow-stubs/pyarrow/_dataset_orc.pyi
@@ -1,5 +1,3 @@
-# pylint: disable=unused-wildcard-import, unused-import
-
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -16,9 +14,11 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from pyarrow._parquet_encryption import (CryptoFactory,   # noqa
-                                         EncryptionConfiguration,
-                                         DecryptionConfiguration,
-                                         KmsConnectionConfig,
-                                         KmsClient,
-                                         FileSystemKeyMaterialStore)
+
+from ._dataset import FileFormat
+
+
+class OrcFileFormat(FileFormat):
+    def equals(self, other: OrcFileFormat) -> bool: ...
+    @property
+    def default_extname(self): ...

--- a/python/pyarrow-stubs/pyarrow/_dataset_parquet.pyi
+++ b/python/pyarrow-stubs/pyarrow/_dataset_parquet.pyi
@@ -1,0 +1,200 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import IO, Any, TypedDict
+
+from _typeshed import StrPath
+
+from ._compute import Expression
+from ._dataset import (
+    DatasetFactory,
+    FileFormat,
+    FileFragment,
+    FileWriteOptions,
+    Fragment,
+    FragmentScanOptions,
+    Partitioning,
+    PartitioningFactory,
+)
+from ._dataset_parquet_encryption import ParquetDecryptionConfig
+from ._fs import SupportedFileSystem
+from ._parquet import FileDecryptionProperties, FileMetaData
+from ._types import DataType, LargeListType, ListType
+from .lib import CacheOptions, Schema, _Weakrefable, NativeFile, Buffer, BufferReader
+
+parquet_encryption_enabled: bool
+
+
+class ParquetFileFormat(FileFormat):
+    def __init__(
+        self,
+        read_options: ParquetReadOptions | None = None,
+        default_fragment_scan_options: ParquetFragmentScanOptions | None = None,
+        *,
+        pre_buffer: bool = True,
+        coerce_int96_timestamp_unit: str | None = None,
+        thrift_string_size_limit: int | None = None,
+        thrift_container_size_limit: int | None = None,
+        page_checksum_verification: bool = False,
+        arrow_extensions_enabled: bool = True,
+        binary_type: DataType | None = None,
+        list_type: type[ListType | LargeListType] | None = None,
+        use_buffered_stream: bool = False,
+        buffer_size: int = 8192,
+        dictionary_columns: list[str] | set[str] | None = None,
+        decryption_properties: FileDecryptionProperties | None = None,
+    ) -> None: ...
+    @property
+    def read_options(self) -> ParquetReadOptions: ...
+    def make_write_options(
+        self, **kwargs) -> ParquetFileWriteOptions: ...  # type: ignore[override]
+
+    def equals(self, other: ParquetFileFormat) -> bool: ...
+    @property
+    def default_extname(self) -> str: ...
+
+    def make_fragment(
+        self,
+        file: StrPath | IO | Buffer | BufferReader,
+        filesystem: SupportedFileSystem | None = None,
+        partition_expression: Expression | None = None,
+        row_groups: Iterable[int] | None = None,
+        *,
+        file_size: int | None = None,
+    ) -> Fragment: ...
+
+
+class _NameStats(TypedDict):
+    min: Any
+    max: Any
+
+
+class RowGroupInfo:
+    id: int
+    metadata: FileMetaData
+    schema: Schema
+
+    def __init__(self, id: int, metadata: FileMetaData, schema: Schema) -> None: ...
+    @property
+    def num_rows(self) -> int: ...
+    @property
+    def total_byte_size(self) -> int: ...
+    @property
+    def statistics(self) -> dict[str, _NameStats]: ...
+
+
+class ParquetFileFragment(FileFragment):
+    def ensure_complete_metadata(self) -> None: ...
+    @property
+    def path(self) -> str: ...
+    @property
+    def filesystem(self) -> SupportedFileSystem: ...
+    def open(self) -> NativeFile: ...
+
+    @property
+    def row_groups(self) -> list[int]: ...
+    @property
+    def metadata(self) -> FileMetaData: ...
+    @property
+    def num_row_groups(self) -> int: ...
+
+    def split_by_row_group(
+        self, filter: Expression | None = None, schema: Schema | None = None
+    ) -> list[Fragment]: ...
+
+    def subset(
+        self,
+        filter: Expression | None = None,
+        schema: Schema | None = None,
+        row_group_ids: list[int] | None = None,
+    ) -> ParquetFileFormat: ...
+
+
+class ParquetReadOptions(_Weakrefable):
+    def __init__(
+        self,
+        dictionary_columns: list[str] | set[str] | None = None,
+        coerce_int96_timestamp_unit: str | None = None,
+        binary_type: DataType | None = None,
+        list_type: type[ListType | LargeListType] | None = None,
+    ) -> None: ...
+
+    @property
+    def dictionary_columns(self) -> set[str]: ...
+    @dictionary_columns.setter
+    def dictionary_columns(self, columns: list[str] | set[str]) -> None: ...
+
+    @property
+    def coerce_int96_timestamp_unit(self) -> str: ...
+    @coerce_int96_timestamp_unit.setter
+    def coerce_int96_timestamp_unit(self, unit: str) -> None: ...
+
+    @property
+    def binary_type(self) -> DataType: ...
+    @binary_type.setter
+    def binary_type(self, type: DataType | None) -> None: ...
+
+    @property
+    def list_type(self) -> type[ListType | LargeListType]: ...
+    @list_type.setter
+    def list_type(self, type: type[ListType | LargeListType] | None) -> None: ...
+
+    def equals(self, other: ParquetReadOptions) -> bool: ...
+
+
+class ParquetFileWriteOptions(FileWriteOptions):
+    def update(self, **kwargs) -> None: ...
+    def _set_properties(self) -> None: ...
+    def _set_arrow_properties(self) -> None: ...
+    def _set_encryption_config(self) -> None: ...
+    # accept passthrough options used in tests
+    def __init__(self, **kwargs) -> None: ...
+
+
+@dataclass(kw_only=True)
+class ParquetFragmentScanOptions(FragmentScanOptions):
+    use_buffered_stream: bool = False
+    buffer_size: int = 8192
+    pre_buffer: bool = True
+    cache_options: CacheOptions | None = None
+    thrift_string_size_limit: int | None = None
+    thrift_container_size_limit: int | None = None
+    decryption_config: ParquetDecryptionConfig | None = None
+    decryption_properties: FileDecryptionProperties | None = None
+    page_checksum_verification: bool = False
+
+    def equals(self, other: ParquetFragmentScanOptions) -> bool: ...
+
+
+@dataclass
+class ParquetFactoryOptions(_Weakrefable):
+
+    partition_base_dir: str | None = None
+    partitioning: Partitioning | PartitioningFactory | None = None
+    validate_column_chunk_paths: bool = False
+
+
+class ParquetDatasetFactory(DatasetFactory):
+    def __init__(
+        self,
+        metadata_path: str,
+        filesystem: SupportedFileSystem,
+        format: FileFormat,
+        options: ParquetFactoryOptions | None = None,
+    ) -> None: ...

--- a/python/pyarrow-stubs/pyarrow/_dataset_parquet_encryption.pyi
+++ b/python/pyarrow-stubs/pyarrow/_dataset_parquet_encryption.pyi
@@ -1,0 +1,58 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from ._dataset_parquet import ParquetFileWriteOptions, ParquetFragmentScanOptions
+from ._parquet import FileDecryptionProperties
+from ._parquet_encryption import (CryptoFactory, EncryptionConfiguration,
+                                  DecryptionConfiguration, KmsConnectionConfig)
+from .lib import _Weakrefable
+
+
+class ParquetEncryptionConfig(_Weakrefable):
+    def __init__(
+        self,
+        crypto_factory: CryptoFactory,
+        kms_connection_config: KmsConnectionConfig,
+        encryption_config: EncryptionConfiguration,
+    ) -> None: ...
+
+
+class ParquetDecryptionConfig(_Weakrefable):
+    def __init__(
+        self,
+        crypto_factory: CryptoFactory,
+        kms_connection_config: KmsConnectionConfig,
+        decryption_config: DecryptionConfiguration,
+    ) -> None: ...
+
+
+def set_encryption_config(
+    opts: ParquetFileWriteOptions,
+    config: ParquetEncryptionConfig,
+) -> None: ...
+
+
+def set_decryption_properties(
+    opts: ParquetFragmentScanOptions,
+    config: FileDecryptionProperties,
+): ...
+
+
+def set_decryption_config(
+    opts: ParquetFragmentScanOptions,
+    config: ParquetDecryptionConfig,
+): ...

--- a/python/pyarrow-stubs/pyarrow/_parquet.pyi
+++ b/python/pyarrow-stubs/pyarrow/_parquet.pyi
@@ -1,0 +1,524 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from collections.abc import Iterable, Iterator, Sequence
+from typing import IO, Any, Literal, TypeAlias, TypedDict
+
+from _typeshed import StrPath
+
+from ._stubs_typing import Order
+from .lib import (
+    Buffer,
+    ChunkedArray,
+    KeyValueMetadata,
+    MemoryPool,
+    NativeFile,
+    RecordBatch,
+    Schema,
+    Table,
+    _Weakrefable,
+    DataType,
+    ListType,
+    LargeListType
+)
+
+_PhysicalType: TypeAlias = Literal[
+    "BOOLEAN",
+    "INT32",
+    "INT64",
+    "INT96",
+    "FLOAT",
+    "DOUBLE",
+    "BYTE_ARRAY",
+    "FIXED_LEN_BYTE_ARRAY",
+    "UNKNOWN",
+]
+_LogicTypeName: TypeAlias = Literal[
+    "UNDEFINED",
+    "STRING",
+    "MAP",
+    "LIST",
+    "ENUM",
+    "DECIMAL",
+    "DATE",
+    "TIME",
+    "TIMESTAMP",
+    "INT",
+    "FLOAT16",
+    "JSON",
+    "BSON",
+    "UUID",
+    "NONE",
+    "UNKNOWN",
+]
+_ConvertedType: TypeAlias = Literal[
+    "NONE",
+    "UTF8",
+    "MAP",
+    "MAP_KEY_VALUE",
+    "LIST",
+    "ENUM",
+    "DECIMAL",
+    "DATE",
+    "TIME_MILLIS",
+    "TIME_MICROS",
+    "TIMESTAMP_MILLIS",
+    "TIMESTAMP_MICROS",
+    "UINT_8",
+    "UINT_16",
+    "UINT_32",
+    "UINT_64",
+    "INT_8",
+    "INT_16",
+    "INT_32",
+    "INT_64",
+    "JSON",
+    "BSON",
+    "INTERVAL",
+    "UNKNOWN",
+]
+_Encoding: TypeAlias = Literal[
+    "PLAIN",
+    "PLAIN_DICTIONARY",
+    "RLE",
+    "BIT_PACKED",
+    "DELTA_BINARY_PACKED",
+    "DELTA_LENGTH_BYTE_ARRAY",
+    "DELTA_BYTE_ARRAY",
+    "RLE_DICTIONARY",
+    "BYTE_STREAM_SPLIT",
+    "UNKNOWN",
+]
+_Compression: TypeAlias = Literal[
+    "UNCOMPRESSED",
+    "SNAPPY",
+    "GZIP",
+    "LZO",
+    "BROTLI",
+    "LZ4",
+    "ZSTD",
+    "UNKNOWN",
+]
+
+
+class _Statistics(TypedDict):
+    has_min_max: bool
+    min: Any | None
+    max: Any | None
+    null_count: int | None
+    distinct_count: int | None
+    num_values: int
+    physical_type: _PhysicalType
+
+
+class Statistics(_Weakrefable):
+    def to_dict(self) -> _Statistics: ...
+    def equals(self, other: Statistics) -> bool: ...
+    @property
+    def has_min_max(self) -> bool: ...
+    @property
+    def has_null_count(self) -> bool: ...
+    @property
+    def has_distinct_count(self) -> bool: ...
+    @property
+    def min_raw(self) -> Any | None: ...
+    @property
+    def max_raw(self) -> Any | None: ...
+    @property
+    def min(self) -> Any | None: ...
+    @property
+    def max(self) -> Any | None: ...
+    @property
+    def null_count(self) -> int | None: ...
+    @property
+    def distinct_count(self) -> int | None: ...
+    @property
+    def num_values(self) -> int: ...
+    @property
+    def physical_type(self) -> _PhysicalType: ...
+    @property
+    def logical_type(self) -> ParquetLogicalType: ...
+    @property
+    def converted_type(self) -> _ConvertedType | None: ...
+    @property
+    def is_min_exact(self) -> bool: ...
+    @property
+    def is_max_exact(self) -> bool: ...
+
+
+class ParquetLogicalType(_Weakrefable):
+    def to_json(self) -> str: ...
+    @property
+    def type(self) -> _LogicTypeName: ...
+
+
+class _ColumnChunkMetaData(TypedDict):
+    file_offset: int
+    file_path: str | None
+    physical_type: _PhysicalType
+    num_values: int
+    path_in_schema: str
+    is_stats_set: bool
+    statistics: Statistics | None
+    compression: _Compression
+    encodings: tuple[_Encoding, ...]
+    has_dictionary_page: bool
+    dictionary_page_offset: int | None
+    data_page_offset: int
+    total_compressed_size: int
+    total_uncompressed_size: int
+
+
+class ColumnChunkMetaData(_Weakrefable):
+    def to_dict(self) -> _ColumnChunkMetaData: ...
+    def equals(self, other: ColumnChunkMetaData) -> bool: ...
+    @property
+    def file_offset(self) -> int: ...
+    @property
+    def file_path(self) -> str | None: ...
+    @property
+    def physical_type(self) -> _PhysicalType: ...
+    @property
+    def num_values(self) -> int: ...
+    @property
+    def path_in_schema(self) -> str: ...
+    @property
+    def is_stats_set(self) -> bool: ...
+    @property
+    def statistics(self) -> Statistics | None: ...
+    @property
+    def compression(self) -> _Compression: ...
+    @property
+    def encodings(self) -> tuple[_Encoding, ...]: ...
+    @property
+    def has_dictionary_page(self) -> bool: ...
+    @property
+    def dictionary_page_offset(self) -> int | None: ...
+    @property
+    def data_page_offset(self) -> int: ...
+    @property
+    def has_index_page(self) -> bool: ...
+    @property
+    def index_page_offset(self) -> int: ...
+    @property
+    def total_compressed_size(self) -> int: ...
+    @property
+    def total_uncompressed_size(self) -> int: ...
+    @property
+    def has_offset_index(self) -> bool: ...
+    @property
+    def has_column_index(self) -> bool: ...
+    @property
+    def metadata(self) -> dict[bytes, bytes] | None: ...
+    @property
+    def name(self) -> str: ...
+    @property
+    def max_definition_level(self) -> int: ...
+    @property
+    def max_repetition_level(self) -> int: ...
+    @property
+    def converted_type(self) -> _ConvertedType: ...
+    @property
+    def logical_type(self) -> ParquetLogicalType: ...
+
+
+class _SortingColumn(TypedDict):
+    column_index: int
+    descending: bool
+    nulls_first: bool
+
+
+class SortingColumn:
+    def __init__(
+        self, column_index: int, descending: bool = False, nulls_first: bool = False
+    ) -> None: ...
+
+    @classmethod
+    def from_ordering(
+        cls,
+        schema: Schema,
+        sort_keys: Sequence[str]
+        | Sequence[tuple[str, Order]]
+        | Sequence[str | tuple[str, Order]],
+        null_placement: Literal["at_start", "at_end"] = "at_end",
+    ) -> tuple[SortingColumn, ...]: ...
+
+    @staticmethod
+    def to_ordering(
+        schema: Schema, sorting_columns: tuple[SortingColumn, ...] | list[SortingColumn]
+    ) -> tuple[Sequence[tuple[str, Order]], Literal["at_start", "at_end"]]: ...
+    def __hash__(self) -> int: ...
+    @property
+    def column_index(self) -> int: ...
+    @property
+    def descending(self) -> bool: ...
+    @property
+    def nulls_first(self) -> bool: ...
+    def to_dict(self) -> _SortingColumn: ...
+
+
+class _RowGroupMetaData(TypedDict):
+    num_columns: int
+    num_rows: int
+    total_byte_size: int
+    columns: list[ColumnChunkMetaData]
+    sorting_columns: list[SortingColumn]
+
+
+class RowGroupMetaData(_Weakrefable):
+    def __init__(self, parent: FileMetaData, index: int) -> None: ...
+    def equals(self, other: RowGroupMetaData) -> bool: ...
+    def column(self, i: int) -> ColumnChunkMetaData: ...
+    def to_dict(self) -> _RowGroupMetaData: ...
+    @property
+    def num_columns(self) -> int: ...
+    @property
+    def num_rows(self) -> int: ...
+    @property
+    def total_byte_size(self) -> int: ...
+    @property
+    def sorting_columns(self) -> list[SortingColumn]: ...
+
+
+class _FileMetaData(TypedDict):
+    created_by: str
+    num_columns: int
+    num_rows: int
+    num_row_groups: int
+    format_version: str
+    serialized_size: int
+    row_groups: list[Any]  # List of row group metadata dictionaries
+
+
+class FileMetaData(_Weakrefable):
+    def __hash__(self) -> int: ...
+    def to_dict(self) -> _FileMetaData: ...
+    def equals(self, other: FileMetaData) -> bool: ...
+    @property
+    def schema(self) -> ParquetSchema: ...
+    @property
+    def serialized_size(self) -> int: ...
+    @property
+    def num_columns(self) -> int: ...
+    @property
+    def num_rows(self) -> int: ...
+    @property
+    def num_row_groups(self) -> int: ...
+    @property
+    def format_version(self) -> str: ...
+    @property
+    def created_by(self) -> str: ...
+    @property
+    def metadata(self) -> dict[bytes, bytes] | None: ...
+    def row_group(self, i: int) -> RowGroupMetaData: ...
+    def set_file_path(self, path: str) -> None: ...
+    def append_row_groups(self, other: FileMetaData) -> None: ...
+    def write_metadata_file(self, where: StrPath | Buffer |
+                            NativeFile | IO) -> None: ...
+
+
+class ParquetSchema(_Weakrefable):
+    def __init__(self, container: FileMetaData) -> None: ...
+    def __getitem__(self, i: int) -> ColumnSchema: ...
+    def __hash__(self) -> int: ...
+    def __len__(self) -> int: ...
+    @property
+    def names(self) -> list[str]: ...
+    def to_arrow_schema(self) -> Schema: ...
+    def equals(self, other: ParquetSchema) -> bool: ...
+    def column(self, i: int) -> ColumnSchema: ...
+
+
+class ColumnSchema(_Weakrefable):
+    def __init__(self, schema: ParquetSchema, index: int) -> None: ...
+    def equals(self, other: ColumnSchema) -> bool: ...
+    @property
+    def name(self) -> str: ...
+    @property
+    def path(self) -> str: ...
+    @property
+    def max_definition_level(self) -> int: ...
+    @property
+    def max_repetition_level(self) -> int: ...
+    @property
+    def physical_type(self) -> _PhysicalType: ...
+    @property
+    def logical_type(self) -> ParquetLogicalType: ...
+    @property
+    def converted_type(self) -> _ConvertedType | None: ...
+    @property
+    def length(self) -> int | None: ...
+    @property
+    def precision(self) -> int | None: ...
+    @property
+    def scale(self) -> int | None: ...
+
+
+class ParquetReader(_Weakrefable):
+    def __init__(self, memory_pool: MemoryPool | None = None) -> None: ...
+
+    def open(
+        self,
+        source: StrPath | Buffer | NativeFile | IO,
+        *,
+        use_memory_map: bool = False,
+        read_dictionary: Iterable[int] | Iterable[str] | None = None,
+        metadata: FileMetaData | None = None,
+        binary_type: DataType | None = None,
+        list_type: ListType | LargeListType | None = None,
+        buffer_size: int = 0,
+        pre_buffer: bool = False,
+        coerce_int96_timestamp_unit: str | None = None,
+        decryption_properties: FileDecryptionProperties | None = None,
+        thrift_string_size_limit: int | None = None,
+        thrift_container_size_limit: int | None = None,
+        page_checksum_verification: bool = False,
+        arrow_extensions_enabled: bool | None = None,
+    ) -> None: ...
+
+    @property
+    def column_paths(self) -> list[str]: ...
+    @property
+    def metadata(self) -> FileMetaData: ...
+    @property
+    def schema_arrow(self) -> Schema: ...
+    @property
+    def num_row_groups(self) -> int: ...
+    def set_use_threads(self, use_threads: bool) -> None: ...
+    def set_batch_size(self, batch_size: int) -> None: ...
+
+    def iter_batches(
+        self,
+        batch_size: int = 65536,
+        row_groups: list[int] | range | None = None,
+        column_indices: list[str] | list[int] | None = None,
+        use_threads: bool = True,
+        use_pandas_metadata: bool = False,
+    ) -> Iterator[RecordBatch]: ...
+
+    def read_row_group(
+        self, i: int, column_indices: list[int] | None = None, use_threads: bool = True
+    ) -> Table: ...
+
+    def read_row_groups(
+        self,
+        row_groups: Sequence[int] | range,
+        column_indices: list[str] | list[int] | None = None,
+        use_threads: bool = True,
+        use_pandas_metadata: bool = False,
+    ) -> Table: ...
+
+    def read_all(
+        self, column_indices: list[int] | None = None, use_threads: bool = True
+    ) -> Table: ...
+
+    def scan_contents(
+        self, columns: Sequence[str] | Sequence[int] | None = None,
+        batch_size: int = 65536
+    ) -> int: ...
+
+    def column_name_idx(self, column_name: str) -> int: ...
+    def read_column(self, column_index: int) -> ChunkedArray: ...
+    def close(self) -> None: ...
+    @property
+    def closed(self) -> bool: ...
+
+
+class ParquetWriter(_Weakrefable):
+    def __init__(
+        self,
+        where: StrPath | NativeFile | IO,
+        schema: Schema,
+        use_dictionary: bool | list[str] | None = None,
+        compression: _Compression | dict[str, _Compression] | str | None = None,
+        version: str | None = None,
+        write_statistics: bool | list[str] | None = None,
+        memory_pool: MemoryPool | None = None,
+        use_deprecated_int96_timestamps: bool = False,
+        coerce_timestamps: Literal["ms", "us"] | None = None,
+        data_page_size: int | None = None,
+        allow_truncated_timestamps: bool = False,
+        compression_level: int | dict[str, int] | None = None,
+        use_byte_stream_split: bool | list[str] = False,
+        column_encoding: _Encoding | dict[str, _Encoding] | None = None,
+        writer_engine_version: str | None = None,
+        data_page_version: str | None = None,
+        use_compliant_nested_type: bool = True,
+        encryption_properties: FileDecryptionProperties | None = None,
+        write_batch_size: int | None = None,
+        dictionary_pagesize_limit: int | None = None,
+        store_schema: bool = True,
+        write_page_index: bool = False,
+        write_page_checksum: bool = False,
+        sorting_columns: tuple[SortingColumn, ...] | None = None,
+        store_decimal_as_integer: bool = False,
+        write_time_adjusted_to_utc: bool = False,
+        max_rows_per_page: int | None = None,
+    ): ...
+    def close(self) -> None: ...
+    def write_table(self, table: Table, row_group_size: int | None = None) -> None: ...
+    def add_key_value_metadata(self, key_value_metadata: KeyValueMetadata) -> None: ...
+    @property
+    def metadata(self) -> FileMetaData: ...
+    @property
+    def use_dictionary(self) -> bool | list[str] | None: ...
+    @property
+    def use_deprecated_int96_timestamps(self) -> bool: ...
+    @property
+    def use_byte_stream_split(self) -> bool | list[str]: ...
+    @property
+    def column_encoding(self) -> _Encoding | dict[str, _Encoding] | None: ...
+    @property
+    def coerce_timestamps(self) -> Literal["ms", "us"] | None: ...
+    @property
+    def allow_truncated_timestamps(self) -> bool: ...
+    @property
+    def compression(self) -> _Compression | dict[str, _Compression] | None: ...
+    @property
+    def compression_level(self) -> int | dict[str, int] | None: ...
+    @property
+    def data_page_version(self) -> str | None: ...
+    @property
+    def use_compliant_nested_type(self) -> bool: ...
+    @property
+    def version(self) -> str | None: ...
+    @property
+    def write_statistics(self) -> bool | list[str] | None: ...
+    @property
+    def writer_engine_version(self) -> str: ...
+    @property
+    def row_group_size(self) -> int: ...
+    @property
+    def data_page_size(self) -> int: ...
+    @property
+    def encryption_properties(self) -> FileDecryptionProperties: ...
+    @property
+    def write_batch_size(self) -> int: ...
+    @property
+    def dictionary_pagesize_limit(self) -> int: ...
+    @property
+    def store_schema(self) -> bool: ...
+    @property
+    def store_decimal_as_integer(self) -> bool: ...
+
+
+class FileEncryptionProperties:
+    ...
+
+
+class FileDecryptionProperties:
+    ...

--- a/python/pyarrow-stubs/pyarrow/_parquet_encryption.pyi
+++ b/python/pyarrow-stubs/pyarrow/_parquet_encryption.pyi
@@ -1,0 +1,141 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import datetime as dt
+import pathlib
+
+from collections.abc import Callable
+
+from pyarrow._fs import FileSystem
+from ._parquet import FileDecryptionProperties, FileEncryptionProperties
+from .lib import _Weakrefable
+
+
+class EncryptionConfiguration(_Weakrefable):
+    footer_key: str
+    column_keys: dict[str, list[str]]
+    encryption_algorithm: str
+    plaintext_footer: bool
+    double_wrapping: bool
+    cache_lifetime: dt.timedelta
+    internal_key_material: bool
+    data_key_length_bits: int
+    uniform_encryption: bool
+
+    def __init__(
+        self,
+        footer_key: str,
+        *,
+        column_keys: dict[str, str | list[str]] | None = None,
+        encryption_algorithm: str | None = None,
+        plaintext_footer: bool | None = None,
+        double_wrapping: bool | None = None,
+        cache_lifetime: dt.timedelta | None = None,
+        internal_key_material: bool | None = None,
+        data_key_length_bits: int | None = None,
+        uniform_encryption: bool | None = None,
+    ) -> None: ...
+
+
+class DecryptionConfiguration(_Weakrefable):
+    cache_lifetime: dt.timedelta
+    def __init__(self, *, cache_lifetime: dt.timedelta | None = None): ...
+
+
+class KmsConnectionConfig(_Weakrefable):
+    kms_instance_id: str
+    kms_instance_url: str
+    key_access_token: str
+    custom_kms_conf: dict[str, str]
+
+    def __init__(
+        self,
+        *,
+        kms_instance_id: str | None = None,
+        kms_instance_url: str | None = None,
+        key_access_token: str | None = None,
+        custom_kms_conf: dict[str, str] | None = None,
+    ) -> None: ...
+    def refresh_key_access_token(self, value: str) -> None: ...
+
+
+class KmsClient(_Weakrefable):
+    def wrap_key(self, key_bytes: bytes, master_key_identifier: str) -> str: ...
+    def unwrap_key(self, wrapped_key: str, master_key_identifier: str) -> bytes: ...
+
+
+class CryptoFactory(_Weakrefable):
+    def __init__(self, kms_client_factory: Callable[[
+                 KmsConnectionConfig], KmsClient]): ...
+
+    def file_encryption_properties(
+        self,
+        kms_connection_config: KmsConnectionConfig,
+        encryption_config: EncryptionConfiguration,
+    ) -> FileEncryptionProperties: ...
+
+    def file_decryption_properties(
+        self,
+        kms_connection_config: KmsConnectionConfig,
+        decryption_config: DecryptionConfiguration | None = None,
+    ) -> FileDecryptionProperties: ...
+    def remove_cache_entries_for_token(self, access_token: str) -> None: ...
+    def remove_cache_entries_for_all_tokens(self) -> None: ...
+    def rotate_master_keys(
+        self,
+        kms_connection_config: KmsConnectionConfig,
+        parquet_file_path: str | pathlib.Path,
+        filesystem: FileSystem | None = None,
+        double_wrapping: bool = True,
+        cache_lifetime_seconds: int | float = 600,
+    ) -> None: ...
+
+
+class KeyMaterial(_Weakrefable):
+    @property
+    def is_footer_key(self) -> bool: ...
+    @property
+    def is_double_wrapped(self) -> bool: ...
+    @property
+    def master_key_id(self) -> str: ...
+    @property
+    def wrapped_dek(self) -> str: ...
+    @property
+    def kek_id(self) -> str: ...
+    @property
+    def wrapped_kek(self) -> str: ...
+    @property
+    def kms_instance_id(self) -> str: ...
+    @property
+    def kms_instance_url(self) -> str: ...
+    @staticmethod
+    def wrap(key_material: KeyMaterial) -> KeyMaterial: ...
+    @staticmethod
+    def parse(key_material_string: str) -> KeyMaterial: ...
+
+
+
+class FileSystemKeyMaterialStore(_Weakrefable):
+    def get_key_material(self, key_id: str) -> KeyMaterial: ...
+    def get_key_id_set(self) -> list[str]: ...
+    @classmethod
+    def for_file(
+            cls,
+            parquet_file_path: str | pathlib.Path, /,
+            filesystem: FileSystem | None = None
+    ) -> FileSystemKeyMaterialStore:
+        ...

--- a/python/pyarrow-stubs/pyarrow/dataset.pyi
+++ b/python/pyarrow-stubs/pyarrow/dataset.pyi
@@ -1,0 +1,199 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from collections.abc import Callable, Iterable, Sequence
+from typing import Literal, TypeAlias, Any
+
+from _typeshed import StrPath
+from pyarrow._dataset import (
+    CsvFileFormat,
+    CsvFragmentScanOptions,
+    Dataset,
+    DatasetFactory,
+    DirectoryPartitioning,
+    FeatherFileFormat,
+    FileFormat,
+    FileFragment,
+    FilenamePartitioning,
+    FileSystemDataset,
+    FileSystemDatasetFactory,
+    FileSystemFactoryOptions,
+    FileWriteOptions,
+    Fragment,
+    FragmentScanOptions,
+    HivePartitioning,
+    InMemoryDataset,
+    IpcFileFormat,
+    IpcFileWriteOptions,
+    JsonFileFormat,
+    JsonFragmentScanOptions,
+    Partitioning,
+    PartitioningFactory,
+    Scanner,
+    TaggedRecordBatch,
+    UnionDataset,
+    UnionDatasetFactory,
+    WrittenFile,
+    get_partition_keys,
+)
+from pyarrow._dataset_orc import OrcFileFormat
+from pyarrow._dataset_parquet import (
+    ParquetDatasetFactory,
+    ParquetFactoryOptions,
+    ParquetFileFormat,
+    ParquetFileFragment,
+    ParquetFileWriteOptions,
+    ParquetFragmentScanOptions,
+    ParquetReadOptions,
+    RowGroupInfo,
+)
+from pyarrow._dataset_parquet_encryption import (
+    ParquetDecryptionConfig,
+    ParquetEncryptionConfig,
+)
+from pyarrow.compute import Expression, field, scalar
+from pyarrow.lib import Array, RecordBatch, RecordBatchReader, Schema, Table
+
+from ._fs import SupportedFileSystem
+
+_orc_available: bool
+_parquet_available: bool
+
+__all__ = [
+    "CsvFileFormat",
+    "CsvFragmentScanOptions",
+    "Dataset",
+    "DatasetFactory",
+    "DirectoryPartitioning",
+    "FeatherFileFormat",
+    "FileFormat",
+    "FileFragment",
+    "FilenamePartitioning",
+    "FileSystemDataset",
+    "FileSystemDatasetFactory",
+    "FileSystemFactoryOptions",
+    "FileWriteOptions",
+    "Fragment",
+    "FragmentScanOptions",
+    "HivePartitioning",
+    "InMemoryDataset",
+    "IpcFileFormat",
+    "IpcFileWriteOptions",
+    "JsonFileFormat",
+    "JsonFragmentScanOptions",
+    "Partitioning",
+    "PartitioningFactory",
+    "Scanner",
+    "TaggedRecordBatch",
+    "UnionDataset",
+    "UnionDatasetFactory",
+    "WrittenFile",
+    "get_partition_keys",
+    # Orc
+    "OrcFileFormat",
+    # Parquet
+    "ParquetDatasetFactory",
+    "ParquetFactoryOptions",
+    "ParquetFileFormat",
+    "ParquetFileFragment",
+    "ParquetFileWriteOptions",
+    "ParquetFragmentScanOptions",
+    "ParquetReadOptions",
+    "RowGroupInfo",
+    # Parquet Encryption
+    "ParquetDecryptionConfig",
+    "ParquetEncryptionConfig",
+    # Compute
+    "Expression",
+    "field",
+    "scalar",
+    # Dataset
+    "partitioning",
+    "parquet_dataset",
+    "write_dataset",
+]
+
+_DatasetFormat: TypeAlias = (
+    Literal["parquet", "ipc", "arrow", "feather", "csv", "json", "orc", str]
+)
+
+
+def partitioning(
+    schema: Schema = None,
+    *,
+    field_names: list[str] = None,
+    flavor: Literal["hive"] = None,
+    dictionaries: dict[str, Array] | Literal["infer"] | None = None,
+) -> Partitioning | PartitioningFactory: ...
+
+
+def parquet_dataset(
+    metadata_path: StrPath,
+    schema: Schema | None = None,
+    filesystem: SupportedFileSystem | None = None,
+    format: ParquetFileFormat | None = None,
+    partitioning: Partitioning | PartitioningFactory | str | None = None,
+    partition_base_dir: str | None = None,
+) -> FileSystemDataset: ...
+
+
+def dataset(
+    source: StrPath
+    | Sequence[Dataset]
+    | Sequence[StrPath]
+    | Iterable[RecordBatch]
+    | Iterable[Table]
+    | RecordBatchReader
+    | RecordBatch
+    | Table,
+    schema: Schema | None = None,
+    format: FileFormat | _DatasetFormat | None = None,
+    filesystem: SupportedFileSystem | str | None = None,
+    partitioning: Partitioning | PartitioningFactory | str | list[str] | None = None,
+    partition_base_dir: str | None = None,
+    exclude_invalid_files: bool | None = None,
+    ignore_prefixes: list[str] | None = None,
+) -> FileSystemDataset | UnionDataset | InMemoryDataset | Dataset: ...
+
+
+def write_dataset(
+    data: Any | Dataset | Table | RecordBatch | RecordBatchReader | list[Table]
+    | Iterable[RecordBatch] | Scanner,
+    base_dir: StrPath,
+    *,
+    basename_template: str | None = None,
+    format: FileFormat | _DatasetFormat | None = None,
+    partitioning: Partitioning | PartitioningFactory | list[str] | None = None,
+    partitioning_flavor: str | None = None,
+    schema: Schema | None = None,
+    filesystem: SupportedFileSystem | str | None = None,
+    file_options: FileWriteOptions | None = None,
+    use_threads: bool | None = True,
+    max_partitions: int = 1024,
+    max_open_files: int = 1024,
+    max_rows_per_file: int = 0,
+    min_rows_per_group: int = 0,
+    max_rows_per_group: int = 1024 * 1024,  # noqa: Y011
+    file_visitor: Callable[[str], None] | None = None,
+    existing_data_behavior:
+    Literal["error", "overwrite_or_ignore", "delete_matching"] = "error",
+    create_dir: bool = True,
+    preserve_order: bool | None = None,
+): ...
+
+
+def _get_partition_keys(partition_expression: Expression) -> dict[str, Any]: ...

--- a/python/pyarrow-stubs/pyarrow/parquet/__init__.pyi
+++ b/python/pyarrow-stubs/pyarrow/parquet/__init__.pyi
@@ -1,5 +1,3 @@
-# pylint: disable=unused-wildcard-import, unused-import
-
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -16,9 +14,5 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from pyarrow._parquet_encryption import (CryptoFactory,   # noqa
-                                         EncryptionConfiguration,
-                                         DecryptionConfiguration,
-                                         KmsConnectionConfig,
-                                         KmsClient,
-                                         FileSystemKeyMaterialStore)
+
+from .core import *  # noqa: F401, F403

--- a/python/pyarrow-stubs/pyarrow/parquet/core.pyi
+++ b/python/pyarrow-stubs/pyarrow/parquet/core.pyi
@@ -1,0 +1,372 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import sys
+
+from pathlib import Path
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self
+from collections.abc import Callable, Iterator, Iterable, Sequence
+from typing import IO, Literal
+
+if sys.version_info >= (3, 10):
+    from typing import TypeAlias
+else:
+    from typing_extensions import TypeAlias
+
+from pyarrow import _parquet
+from pyarrow._compute import Expression
+from pyarrow._fs import FileSystem, SupportedFileSystem
+from pyarrow._parquet import (
+    ColumnChunkMetaData,
+    ColumnSchema,
+    FileDecryptionProperties,
+    FileEncryptionProperties,
+    FileMetaData,
+    ParquetLogicalType,
+    ParquetReader,
+    ParquetSchema,
+    RowGroupMetaData,
+    SortingColumn,
+    Statistics,
+)
+from pyarrow._stubs_typing import FilterTuple, SingleOrList
+from pyarrow.dataset import ParquetFileFragment, Partitioning, PartitioningFactory
+from pyarrow.lib import Buffer, NativeFile, RecordBatch, Schema, Table, ChunkedArray
+from typing_extensions import deprecated
+
+__all__ = (
+    "ColumnChunkMetaData",
+    "ColumnSchema",
+    "FileDecryptionProperties",
+    "FileEncryptionProperties",
+    "FileMetaData",
+    "ParquetDataset",
+    "ParquetFile",
+    "ParquetLogicalType",
+    "ParquetReader",
+    "ParquetSchema",
+    "ParquetWriter",
+    "RowGroupMetaData",
+    "SortingColumn",
+    "Statistics",
+    "read_metadata",
+    "read_pandas",
+    "read_schema",
+    "read_table",
+    "write_metadata",
+    "write_table",
+    "write_to_dataset",
+    "_filters_to_expression",
+    "filters_to_expression",
+)
+
+
+def filters_to_expression(
+    filters: list[FilterTuple | list[FilterTuple]]) -> Expression: ...
+
+
+@deprecated("use filters_to_expression")
+def _filters_to_expression(
+    filters: list[FilterTuple | list[FilterTuple]]) -> Expression: ...
+
+
+_Compression: TypeAlias = Literal["gzip", "bz2",
+                                  "brotli", "lz4", "zstd", "snappy", "none"]
+
+
+class ParquetFile:
+    reader: ParquetReader
+    common_metadata: FileMetaData
+
+    def __init__(
+        self,
+        source: str | Path | Buffer | NativeFile | IO,
+        *,
+        metadata: FileMetaData | None = None,
+        common_metadata: FileMetaData | None = None,
+        read_dictionary: list[str] | None = None,
+        memory_map: bool = False,
+        buffer_size: int = 0,
+        pre_buffer: bool = False,
+        coerce_int96_timestamp_unit: str | None = None,
+        decryption_properties: FileDecryptionProperties | None = None,
+        thrift_string_size_limit: int | None = None,
+        thrift_container_size_limit: int | None = None,
+        filesystem: SupportedFileSystem | None = None,
+        page_checksum_verification: bool = False,
+    ): ...
+    def __enter__(self) -> Self: ...
+    def __exit__(self, *args, **kwargs) -> None: ...
+    @property
+    def metadata(self) -> FileMetaData: ...
+    @property
+    def schema(self) -> ParquetSchema: ...
+    @property
+    def schema_arrow(self) -> Schema: ...
+    @property
+    def num_row_groups(self) -> int: ...
+    def close(self, force: bool = False) -> None: ...
+    @property
+    def closed(self) -> bool: ...
+
+    def read_row_group(
+        self,
+        i: int,
+        columns: Sequence[str | int] | None = None,
+        use_threads: bool = True,
+        use_pandas_metadata: bool = False,
+    ) -> Table: ...
+
+    def read_row_groups(
+        self,
+        row_groups: Sequence[int],
+        columns: Iterable[str | int] | None = None,
+        use_threads: bool = True,
+        use_pandas_metadata: bool = False,
+    ) -> Table: ...
+
+    def iter_batches(
+        self,
+        batch_size: int = 65536,
+        row_groups: Sequence[int] | None = None,
+        columns: Iterable[str | int] | None = None,
+        use_threads: bool = True,
+        use_pandas_metadata: bool = False,
+    ) -> Iterator[RecordBatch]: ...
+
+    def read(
+        self,
+        columns: Sequence[str | int] | None = None,
+        use_threads: bool = True,
+        use_pandas_metadata: bool = False,
+    ) -> Table: ...
+
+    def scan_contents(
+        self, columns: Iterable[str | int] | None = None, batch_size: int = 65536
+    ) -> int: ...
+
+
+class ParquetWriter:
+    flavor: str
+    schema_changed: bool
+    schema: ParquetSchema
+    where: str | Path | IO
+    file_handler: NativeFile | None
+    writer: _parquet.ParquetWriter
+    is_open: bool
+
+    def __init__(
+        self,
+        where: str | Path | IO | NativeFile,
+        schema: Schema,
+        filesystem: SupportedFileSystem | None = None,
+        flavor: str | None = None,
+        version: Literal["1.0", "2.4", "2.6"] = ...,
+        use_dictionary: bool = True,
+        compression: _Compression | dict[str, _Compression] = "snappy",
+        write_statistics: bool | list = True,
+        use_deprecated_int96_timestamps: bool | None = None,
+        compression_level: int | dict | None = None,
+        use_byte_stream_split: bool | list = False,
+        column_encoding: str | dict | None = None,
+        writer_engine_version=None,
+        data_page_version: Literal["1.0", "2.0"] = ...,
+        use_compliant_nested_type: bool = True,
+        encryption_properties: FileEncryptionProperties | None = None,
+        write_batch_size: int | None = None,
+        dictionary_pagesize_limit: int | None = None,
+        store_schema: bool = True,
+        write_page_index: bool = False,
+        write_page_checksum: bool = False,
+        sorting_columns: Sequence[SortingColumn] | None = None,
+        store_decimal_as_integer: bool = False,
+        max_rows_per_page: int | None = None,
+        **options,
+    ) -> None: ...
+    def __enter__(self) -> Self: ...
+    def __exit__(self, *args, **kwargs) -> Literal[False]: ...
+
+    def write(
+        self, table_or_batch: RecordBatch | Table, row_group_size: int | None = None
+    ) -> None: ...
+    def write_batch(self, batch: RecordBatch,
+                    row_group_size: int | None = None) -> None: ...
+
+    def write_table(self, table: Table, row_group_size: int | None = None) -> None: ...
+    def close(self) -> None: ...
+    def add_key_value_metadata(self, key_value_metadata: dict[str, str]) -> None: ...
+
+
+class ParquetDataset:
+    def __init__(
+        self,
+        path_or_paths: SingleOrList[str]
+        | SingleOrList[Path]
+        | SingleOrList[NativeFile]
+        | SingleOrList[IO],
+        filesystem: SupportedFileSystem | None = None,
+        schema: Schema | None = None,
+        *,
+        filters: Expression
+        | FilterTuple
+        | list[FilterTuple]
+        | list[list[FilterTuple]]
+        | None = None,
+        read_dictionary: list[str] | None = None,
+        memory_map: bool = False,
+        buffer_size: int = 0,
+        partitioning: str
+        | list[str]
+        | Partitioning
+        | PartitioningFactory
+        | None = "hive",
+        ignore_prefixes: list[str] | None = None,
+        pre_buffer: bool = True,
+        coerce_int96_timestamp_unit: str | None = None,
+        decryption_properties: FileDecryptionProperties | None = None,
+        thrift_string_size_limit: int | None = None,
+        thrift_container_size_limit: int | None = None,
+        page_checksum_verification: bool = False,
+    ): ...
+    def equals(self, other: ParquetDataset) -> bool: ...
+    @property
+    def schema(self) -> Schema: ...
+
+    def read(
+        self,
+        columns: list[str] | None = None,
+        use_threads: bool = True,
+        use_pandas_metadata: bool = False,
+    ) -> Table: ...
+    def read_pandas(self, **kwargs) -> Table: ...
+    @property
+    def fragments(self) -> list[ParquetFileFragment]: ...
+    @property
+    def files(self) -> list[str]: ...
+    @property
+    def filesystem(self) -> FileSystem: ...
+    @property
+    def partitioning(self) -> Partitioning: ...
+
+
+def read_table(
+    source: SingleOrList[str]
+    | SingleOrList[Path] | SingleOrList[NativeFile] | SingleOrList[IO] | Buffer,
+    *,
+    columns: list | None = None,
+    use_threads: bool = True,
+    schema: Schema | None = None,
+    use_pandas_metadata: bool = False,
+    read_dictionary: list[str] | None = None,
+    memory_map: bool = False,
+    buffer_size: int = 0,
+    partitioning: str | list[str] | Partitioning | PartitioningFactory | None = "hive",
+    filesystem: SupportedFileSystem | str | None = None,
+    filters: Expression
+    | FilterTuple
+    | list[FilterTuple]
+    | Sequence[Sequence[tuple]]
+    | None = None,
+    ignore_prefixes: list[str] | None = None,
+    pre_buffer: bool = True,
+    coerce_int96_timestamp_unit: str | None = None,
+    decryption_properties: FileDecryptionProperties | None = None,
+    thrift_string_size_limit: int | None = None,
+    thrift_container_size_limit: int | None = None,
+    page_checksum_verification: bool = False,
+) -> Table: ...
+
+
+def read_pandas(
+    source: str | Path | NativeFile | IO | Buffer, columns: list | None = None, **kwargs
+) -> Table: ...
+
+
+def write_table(
+    table: Table,
+    where: str | Path | NativeFile | IO,
+    row_group_size: int | None = None,
+    version: Literal["1.0", "2.4", "2.6"] = "2.6",
+    use_dictionary: bool = True,
+    compression: _Compression | dict[str, _Compression] = "snappy",
+    write_statistics: bool | list = True,
+    use_deprecated_int96_timestamps: bool | None = None,
+    coerce_timestamps: str | None = None,
+    allow_truncated_timestamps: bool = False,
+    data_page_size: int | None = None,
+    flavor: str | None = None,
+    filesystem: SupportedFileSystem | str | None = None,
+    compression_level: int | dict | None = None,
+    use_byte_stream_split: bool = False,
+    column_encoding: str | dict | None = None,
+    data_page_version: Literal["1.0", "2.0"] = ...,
+    use_compliant_nested_type: bool = True,
+    encryption_properties: FileEncryptionProperties | None = None,
+    write_batch_size: int | None = None,
+    dictionary_pagesize_limit: int | None = None,
+    store_schema: bool = True,
+    write_page_index: bool = False,
+    write_page_checksum: bool = False,
+    sorting_columns: Sequence[SortingColumn] | None = None,
+    store_decimal_as_integer: bool = False,
+    **kwargs,
+) -> None: ...
+
+
+def write_to_dataset(
+    table: Table | ChunkedArray,
+    root_path: str | Path,
+    partition_cols: list[str] | None = None,
+    filesystem: SupportedFileSystem | None = None,
+    schema: Schema | None = None,
+    partitioning: Partitioning | list[str] | None = None,
+    basename_template: str | None = None,
+    use_threads: bool | None = None,
+    file_visitor: Callable[[str], None] | None = None,
+    existing_data_behavior: Literal["overwrite_or_ignore", "error", "delete_matching"]
+    | None = None,
+    **kwargs,
+) -> None: ...
+
+
+def write_metadata(
+    schema: Schema,
+    where: str | NativeFile,
+    metadata_collector: list[FileMetaData] | None = None,
+    filesystem: SupportedFileSystem | None = None,
+    **kwargs,
+) -> None: ...
+
+
+def read_metadata(
+    where: str | Path | IO | NativeFile,
+    memory_map: bool = False,
+    decryption_properties: FileDecryptionProperties | None = None,
+    filesystem: SupportedFileSystem | str | None = None,
+) -> FileMetaData: ...
+
+
+def read_schema(
+    where: str | Path | IO | NativeFile,
+    memory_map: bool = False,
+    decryption_properties: FileDecryptionProperties | None = None,
+    filesystem: SupportedFileSystem | str | None = None,
+) -> Schema: ...

--- a/python/pyarrow-stubs/pyarrow/parquet/encryption.pyi
+++ b/python/pyarrow-stubs/pyarrow/parquet/encryption.pyi
@@ -1,5 +1,3 @@
-# pylint: disable=unused-wildcard-import, unused-import
-
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
 # distributed with this work for additional information
@@ -16,9 +14,21 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from pyarrow._parquet_encryption import (CryptoFactory,   # noqa
-                                         EncryptionConfiguration,
-                                         DecryptionConfiguration,
-                                         KmsConnectionConfig,
-                                         KmsClient,
-                                         FileSystemKeyMaterialStore)
+
+from pyarrow._parquet_encryption import (
+    CryptoFactory,
+    DecryptionConfiguration,
+    EncryptionConfiguration,
+    FileSystemKeyMaterialStore,
+    KmsClient,
+    KmsConnectionConfig,
+)
+
+__all__ = [
+    "CryptoFactory",
+    "DecryptionConfiguration",
+    "EncryptionConfiguration",
+    "FileSystemKeyMaterialStore",
+    "KmsClient",
+    "KmsConnectionConfig",
+]

--- a/python/pyarrow/dataset.py
+++ b/python/pyarrow/dataset.py
@@ -54,6 +54,9 @@ try:
         get_partition_keys as _get_partition_keys,  # keep for backwards compatibility
         _filesystemdataset_write,
     )
+    from pyarrow.fs import FileInfo
+
+
 except ImportError as exc:
     raise ImportError(
         f"The pyarrow installation is not built with support for 'dataset' ({str(exc)})"
@@ -70,7 +73,8 @@ _orc_msg = (
 )
 
 try:
-    from pyarrow._dataset_orc import OrcFileFormat
+    from pyarrow._dataset_orc import (  # type: ignore[import-not-found]
+        OrcFileFormat)
     _orc_available = True
 except ImportError:
     pass
@@ -371,6 +375,7 @@ def _ensure_multiple_sources(paths, filesystem=None):
     # possible improvement is to group the file_infos by type and raise for
     # multiple paths per error category
     if is_local:
+        # type: ignore[reportGeneralTypeIssues]
         for info in filesystem.get_file_info(paths):
             file_type = info.type
             if file_type == FileType.File:
@@ -422,16 +427,18 @@ def _ensure_single_source(path, filesystem=None):
     filesystem, path = _resolve_filesystem_and_path(path, filesystem)
 
     # ensure that the path is normalized before passing to dataset discovery
+    assert isinstance(path, str)
     path = filesystem.normalize_path(path)
 
     # retrieve the file descriptor
     file_info = filesystem.get_file_info(path)
+    assert isinstance(file_info, FileInfo)
 
     # depending on the path type either return with a recursive
     # directory selector or as a list containing a single file
-    if file_info.type == FileType.Directory:
+    if file_info.type == FileType.Directory:  # type: ignore[reportAttributeAccessIssue]
         paths_or_selector = FileSelector(path, recursive=True)
-    elif file_info.type == FileType.File:
+    elif file_info.type == FileType.File:  # type: ignore[reportAttributeAccessIssue]
         paths_or_selector = [path]
     else:
         raise FileNotFoundError(path)
@@ -1035,6 +1042,7 @@ Table/RecordBatch, or iterable of RecordBatch
     _filesystemdataset_write(
         scanner, base_dir, basename_template, filesystem, partitioning,
         preserve_order, file_options, max_partitions, file_visitor,
-        existing_data_behavior, max_open_files, max_rows_per_file,
-        min_rows_per_group, max_rows_per_group, create_dir
+        existing_data_behavior,  # type: ignore[reportArgumentType]
+        max_open_files, max_rows_per_file, min_rows_per_group,
+        max_rows_per_group, create_dir
     )

--- a/python/pyarrow/tests/parquet/common.py
+++ b/python/pyarrow/tests/parquet/common.py
@@ -16,11 +16,12 @@
 # under the License.
 
 import io
+from typing import cast
 
 try:
     import numpy as np
 except ImportError:
-    np = None
+    pass
 
 import pyarrow as pa
 from pyarrow.tests import util
@@ -137,7 +138,7 @@ def make_sample_file(table_or_df):
     else:
         a_table = pa.Table.from_pandas(table_or_df)
 
-    buf = io.BytesIO()
+    buf = io.BytesIO()  # type: ignore[attr-defined]
     _write_table(a_table, buf, compression='SNAPPY', version='2.6')
 
     buf.seek(0)
@@ -161,12 +162,9 @@ def alltypes_sample(size=10000, seed=0, categorical=False):
         'float32': np.arange(size, dtype=np.float32),
         'float64': np.arange(size, dtype=np.float64),
         'bool': np.random.randn(size) > 0,
-        'datetime_ms': np.arange("2016-01-01T00:00:00.001", size,
-                                 dtype='datetime64[ms]'),
-        'datetime_us': np.arange("2016-01-01T00:00:00.000001", size,
-                                 dtype='datetime64[us]'),
-        'datetime_ns': np.arange("2016-01-01T00:00:00.000000001", size,
-                                 dtype='datetime64[ns]'),
+        'datetime_ms': pd.date_range("2016-01-01T00:00:00.001", periods=size, freq='ms').values,
+        'datetime_us': pd.date_range("2016-01-01T00:00:00.000001", periods=size, freq='us').values,
+        'datetime_ns': pd.date_range("2016-01-01T00:00:00.000000001", periods=size, freq='ns').values,
         'timedelta': np.arange(0, size, dtype="timedelta64[s]"),
         'str': pd.Series([str(x) for x in range(size)]),
         'empty_str': [''] * size,
@@ -175,5 +173,6 @@ def alltypes_sample(size=10000, seed=0, categorical=False):
         'null_list': [None] * 2 + [[None] * (x % 4) for x in range(size - 2)],
     }
     if categorical:
-        arrays['str_category'] = arrays['str'].astype('category')
+        import pandas as pd
+        arrays['str_category'] = cast(pd.Series, arrays['str']).astype('category')
     return pd.DataFrame(arrays)

--- a/python/pyarrow/tests/parquet/encryption.py
+++ b/python/pyarrow/tests/parquet/encryption.py
@@ -30,7 +30,7 @@ class InMemoryKmsClient(pe.KmsClient):
         pe.KmsClient.__init__(self)
         self.master_keys_map = config.custom_kms_conf
 
-    def wrap_key(self, key_bytes, master_key_identifier):
+    def wrap_key(self, key_bytes, master_key_identifier):  # type: ignore[override]
         """Not a secure cipher - the wrapped key
         is just the master key concatenated with key bytes"""
         master_key_bytes = self.master_keys_map[master_key_identifier].encode(
@@ -39,7 +39,7 @@ class InMemoryKmsClient(pe.KmsClient):
         result = base64.b64encode(wrapped_key)
         return result
 
-    def unwrap_key(self, wrapped_key, master_key_identifier):
+    def unwrap_key(self, wrapped_key, master_key_identifier):  # type: ignore[override]
         """Not a secure cipher - just extract the key from
         the wrapped key"""
         if master_key_identifier not in self.master_keys_map:

--- a/python/pyarrow/tests/parquet/test_basic.py
+++ b/python/pyarrow/tests/parquet/test_basic.py
@@ -35,7 +35,7 @@ try:
     import pyarrow.parquet as pq
     from pyarrow.tests.parquet.common import _read_table, _write_table
 except ImportError:
-    pq = None
+    pass
 
 
 try:
@@ -45,12 +45,12 @@ try:
     from pyarrow.tests.pandas_examples import dataframe_with_lists
     from pyarrow.tests.parquet.common import alltypes_sample
 except ImportError:
-    pd = tm = None
+    pass
 
 try:
     import numpy as np
 except ImportError:
-    np = None
+    pass
 
 # Marks all of the tests in this module
 # Ignore these with pytest ... -m 'not parquet'
@@ -162,10 +162,10 @@ def test_invalid_source():
     # Test that we provide an helpful error message pointing out
     # that None wasn't expected when trying to open a Parquet None file.
     with pytest.raises(TypeError, match="None"):
-        pq.read_table(None)
+        pq.read_table(None)  # type: ignore[arg-type]
 
     with pytest.raises(TypeError, match="None"):
-        pq.ParquetFile(None)
+        pq.ParquetFile(None)  # type: ignore[arg-type]
 
 
 def test_read_table_without_dataset(tempdir):
@@ -755,7 +755,7 @@ def test_fastparquet_cross_compatibility(tempdir):
 
     # Arrow -> fastparquet
     file_arrow = str(tempdir / "cross_compat_arrow.parquet")
-    pq.write_table(table, file_arrow, compression=None)
+    pq.write_table(table, file_arrow, compression=None)  # type: ignore[arg-type]
 
     fp_file = fp.ParquetFile(file_arrow)
     df_fp = fp_file.to_pandas()
@@ -796,7 +796,7 @@ def test_buffer_contents(
     for col in table.columns:
         [chunk] = col.chunks
         buf = chunk.buffers()[1]
-        assert buf.to_pybytes() == buf.size * b"\0"
+        assert buf.to_pybytes() == buf.size * b"\0"  # type: ignore[union-attr]
 
 
 def test_parquet_compression_roundtrip(tempdir):
@@ -806,7 +806,7 @@ def test_parquet_compression_roundtrip(tempdir):
     # the stream due to auto-detecting the extension in the filename
     table = pa.table([pa.array(range(4))], names=["ints"])
     path = tempdir / "arrow-10480.pyarrow.gz"
-    pq.write_table(table, path, compression="GZIP")
+    pq.write_table(table, path, compression="GZIP")  # type: ignore[arg-type]
     result = pq.read_table(path)
     assert result.equals(table)
 
@@ -831,7 +831,7 @@ def test_empty_row_groups(tempdir):
 
 def test_reads_over_batch(tempdir):
     data = [None] * (1 << 20)
-    data.append([1])
+    data.append([1])  # type: ignore[reportArgumentType]
     # Large list<int64> with mostly nones and one final
     # value.  This should force batched reads when
     # reading back.

--- a/python/pyarrow/tests/parquet/test_compliant_nested_type.py
+++ b/python/pyarrow/tests/parquet/test_compliant_nested_type.py
@@ -24,15 +24,14 @@ try:
     from pyarrow.tests.parquet.common import (_read_table,
                                               _check_roundtrip)
 except ImportError:
-    pq = None
+    pass
 
 try:
     import pandas as pd
-    import pandas.testing as tm
 
     from pyarrow.tests.parquet.common import _roundtrip_pandas_dataframe
 except ImportError:
-    pd = tm = None
+    pass
 
 
 # Marks all of the tests in this module

--- a/python/pyarrow/tests/parquet/test_data_types.py
+++ b/python/pyarrow/tests/parquet/test_data_types.py
@@ -22,7 +22,7 @@ import random
 try:
     import numpy as np
 except ImportError:
-    np = None
+    pass
 import pytest
 
 import pyarrow as pa
@@ -33,7 +33,7 @@ try:
     import pyarrow.parquet as pq
     from pyarrow.tests.parquet.common import _read_table, _write_table
 except ImportError:
-    pq = None
+    pass
 
 
 try:
@@ -44,7 +44,7 @@ try:
                                                dataframe_with_lists)
     from pyarrow.tests.parquet.common import alltypes_sample
 except ImportError:
-    pd = tm = None
+    pass
 
 
 # Marks all of the tests in this module
@@ -142,7 +142,7 @@ def test_direct_read_dictionary():
                            read_dictionary=['f0'])
 
     # Compute dictionary-encoded subfield
-    expected = pa.table([table[0].dictionary_encode()], names=['f0'])
+    expected = pa.table([table.column(0).dictionary_encode()], names=['f0'])
     assert result.equals(expected)
 
 
@@ -174,7 +174,7 @@ def test_direct_read_dictionary_subfield():
     expected = pa.table([expected_arr], names=['f0'])
 
     assert result.equals(expected)
-    assert result[0].num_chunks == 1
+    assert result.column(0).num_chunks == 1
 
 
 @pytest.mark.numpy
@@ -260,8 +260,8 @@ def test_single_pylist_column_roundtrip(tempdir, dtype,):
     _write_table(table, filename)
     table_read = _read_table(filename)
     for i in range(table.num_columns):
-        col_written = table[i]
-        col_read = table_read[i]
+        col_written = table.column(i)
+        col_read = table_read.column(i)
         assert table.field(i).name == table_read.field(i).name
         assert col_read.num_chunks == 1
         data_written = col_written.chunk(0)

--- a/python/pyarrow/tests/parquet/test_encryption.py
+++ b/python/pyarrow/tests/parquet/test_encryption.py
@@ -21,8 +21,7 @@ try:
     import pyarrow.parquet as pq
     import pyarrow.parquet.encryption as pe
 except ImportError:
-    pq = None
-    pe = None
+    pass
 else:
     from pyarrow.tests.parquet.encryption import (InMemoryKmsClient,
                                                   MockVersioningKmsClient,
@@ -131,7 +130,7 @@ def test_encrypted_parquet_write_read(tempdir, data_table):
         encryption_algorithm="AES_GCM_V1",
         cache_lifetime=timedelta(minutes=5.0),
         data_key_length_bits=256)
-    assert encryption_config.uniform_encryption is False
+    assert encryption_config.uniform_encryption is False  # type: ignore[attr-defined]
 
     kms_connection_config, crypto_factory = write_encrypted_file(
         path, data_table, FOOTER_KEY_NAME, COL_KEY_NAME, FOOTER_KEY, COL_KEY,
@@ -154,11 +153,11 @@ def test_uniform_encrypted_parquet_write_read(tempdir, data_table):
     # Encrypt the footer and all columns with the footer key,
     encryption_config = pe.EncryptionConfiguration(
         footer_key=FOOTER_KEY_NAME,
-        uniform_encryption=True,
+        uniform_encryption=True,  # type: ignore[call-arg]
         encryption_algorithm="AES_GCM_V1",
         cache_lifetime=timedelta(minutes=5.0),
         data_key_length_bits=256)
-    assert encryption_config.uniform_encryption is True
+    assert encryption_config.uniform_encryption is True  # type: ignore[attr-defined]
 
     kms_connection_config, crypto_factory = write_encrypted_file(
         path, data_table, FOOTER_KEY_NAME, COL_KEY_NAME, FOOTER_KEY, b"",
@@ -303,7 +302,7 @@ def test_encrypted_parquet_write_col_key_and_uniform_encryption(tempdir, data_ta
         column_keys={
             COL_KEY_NAME: ["a", "b"],
         },
-        uniform_encryption=True)
+        uniform_encryption=True)  # type: ignore[call-arg]
 
     with pytest.raises(OSError,
                        match=r"Cannot set both column_keys and uniform_encryption"):
@@ -415,7 +414,7 @@ def test_encrypted_parquet_write_kms_factory_type_error(
     def kms_factory(kms_connection_configuration):
         return WrongTypeKmsClient(kms_connection_configuration)
 
-    crypto_factory = pe.CryptoFactory(kms_factory)
+    crypto_factory = pe.CryptoFactory(kms_factory)  # type: ignore[arg-type]
     with pytest.raises(TypeError):
         # Write with encryption properties
         write_encrypted_parquet(path, data_table, encryption_config,
@@ -554,7 +553,7 @@ def test_encrypted_parquet_write_read_external(tempdir, data_table,
     result_table = read_encrypted_parquet(
         path, decryption_config, kms_connection_config, crypto_factory,
         internal_key_material=False)
-    store = pa._parquet_encryption.FileSystemKeyMaterialStore.for_file(path)
+    store = pe.FileSystemKeyMaterialStore.for_file(path)
 
     assert len(key_ids := store.get_key_id_set()) == (
         len(external_encryption_config.column_keys[COL_KEY_NAME]) + 1)

--- a/python/pyarrow/tests/parquet/test_metadata.py
+++ b/python/pyarrow/tests/parquet/test_metadata.py
@@ -19,11 +19,7 @@ import datetime
 import decimal
 from collections import OrderedDict
 import io
-
-try:
-    import numpy as np
-except ImportError:
-    np = None
+from typing import TYPE_CHECKING
 import pytest
 
 import pyarrow as pa
@@ -31,20 +27,25 @@ from pyarrow.tests.parquet.common import _check_roundtrip, make_sample_file
 from pyarrow.fs import LocalFileSystem
 from pyarrow.tests import util
 
-try:
-    import pyarrow.parquet as pq
-    from pyarrow.tests.parquet.common import _write_table
-except ImportError:
-    pq = None
-
-
-try:
+if TYPE_CHECKING:
+    import numpy as np
     import pandas as pd
-    import pandas.testing as tm
-
-    from pyarrow.tests.parquet.common import alltypes_sample
-except ImportError:
-    pd = tm = None
+    import pyarrow.parquet as pq
+    from pyarrow.tests.parquet.common import alltypes_sample, _write_table
+else:
+    try:
+        import pyarrow.parquet as pq
+        from pyarrow.tests.parquet.common import _write_table, alltypes_sample
+    except ImportError:
+        pass
+    try:
+        import pandas as pd
+    except ImportError:
+        pass
+    try:
+        import numpy as np
+    except ImportError:
+        pass
 
 
 # Marks all of the tests in this module
@@ -56,7 +57,7 @@ pytestmark = pytest.mark.parquet
 def test_parquet_metadata_api():
     df = alltypes_sample(size=10000)
     df = df.reindex(columns=sorted(df.columns))
-    df.index = np.random.randint(0, 1000000, size=len(df))
+    df.index = np.random.randint(0, 1000000, size=len(df))  # type: ignore[assignment]
 
     fileh = make_sample_file(df)
     ncols = len(df.columns)
@@ -80,15 +81,15 @@ def test_parquet_metadata_api():
 
     col = schema[0]
     repr(col)
-    assert col.name == df.columns[0]
-    assert col.max_definition_level == 1
-    assert col.max_repetition_level == 0
-    assert col.max_repetition_level == 0
-    assert col.physical_type == 'BOOLEAN'
-    assert col.converted_type == 'NONE'
+    assert col.name == df.columns[0]  # type: ignore[attr-defined]
+    assert col.max_definition_level == 1  # type: ignore[attr-defined]
+    assert col.max_repetition_level == 0  # type: ignore[attr-defined]
+    assert col.max_repetition_level == 0  # type: ignore[attr-defined]
+    assert col.physical_type == 'BOOLEAN'  # type: ignore[attr-defined]
+    assert col.converted_type == 'NONE'  # type: ignore[attr-defined]
 
     col_float16 = schema[5]
-    assert col_float16.logical_type.type == 'FLOAT16'
+    assert col_float16.logical_type.type == 'FLOAT16'  # type: ignore[attr-defined]
 
     with pytest.raises(IndexError):
         schema[ncols + 1]  # +1 for index
@@ -210,15 +211,16 @@ def test_parquet_column_statistics_api(data, type, physical_type, min_value,
     col_meta = rg_meta.column(0)
 
     stat = col_meta.statistics
-    assert stat.has_min_max
-    assert _close(type, stat.min, min_value)
-    assert _close(type, stat.max, max_value)
-    assert stat.null_count == null_count
-    assert stat.num_values == num_values
+    assert stat is not None
+    assert stat.has_min_max  # type: ignore[attr-defined]
+    assert _close(type, stat.min, min_value)  # type: ignore[attr-defined]
+    assert _close(type, stat.max, max_value)  # type: ignore[attr-defined]
+    assert stat.null_count == null_count  # type: ignore[attr-defined]
+    assert stat.num_values == num_values  # type: ignore[attr-defined]
     # TODO(kszucs) until parquet-cpp API doesn't expose HasDistinctCount
     # method, missing distinct_count is represented as zero instead of None
-    assert stat.distinct_count == distinct_count
-    assert stat.physical_type == physical_type
+    assert stat.distinct_count == distinct_count  # type: ignore[attr-defined]
+    assert stat.physical_type == physical_type  # type: ignore[attr-defined]
 
 
 def _close(type, left, right):
@@ -236,8 +238,10 @@ def test_parquet_raise_on_unset_statistics():
     df = pd.DataFrame({"t": pd.Series([pd.NaT], dtype="datetime64[ns]")})
     meta = make_sample_file(pa.Table.from_pandas(df)).metadata
 
-    assert not meta.row_group(0).column(0).statistics.has_min_max
-    assert meta.row_group(0).column(0).statistics.max is None
+    stat = meta.row_group(0).column(0).statistics
+    assert stat is not None
+    assert not stat.has_min_max
+    assert stat.max is None
 
 
 def test_statistics_convert_logical_types(tempdir):
@@ -271,8 +275,9 @@ def test_statistics_convert_logical_types(tempdir):
         pq.write_table(t, path, version='2.6')
         pf = pq.ParquetFile(path)
         stats = pf.metadata.row_group(0).column(0).statistics
-        assert stats.min == min_val
-        assert stats.max == max_val
+        assert stats is not None
+        assert stats.min == min_val  # type: ignore[attr-defined]
+        assert stats.max == max_val  # type: ignore[attr-defined]
 
 
 def test_parquet_write_disable_statistics(tempdir):
@@ -429,29 +434,36 @@ def test_field_id_metadata():
     pf = pq.ParquetFile(pa.BufferReader(contents))
     schema = pf.schema_arrow
 
-    assert schema[0].metadata[field_id] == b'1'
-    assert schema[0].metadata[b'other'] == b'abc'
+    assert schema[0].metadata is not None
+    assert schema[0].metadata[field_id] == b'1'  # type: ignore[index]
+    assert schema[0].metadata[b'other'] == b'abc'  # type: ignore[index]
 
     list_field = schema[1]
-    assert list_field.metadata[field_id] == b'11'
+    assert list_field.metadata is not None
+    assert list_field.metadata[field_id] == b'11'  # type: ignore[index]
 
     list_item_field = list_field.type.value_field
-    assert list_item_field.metadata[field_id] == b'10'
+    assert list_item_field.metadata is not None
+    assert list_item_field.metadata[field_id] == b'10'  # type: ignore[index]
 
     struct_field = schema[2]
-    assert struct_field.metadata[field_id] == b'102'
+    assert struct_field.metadata is not None
+    assert struct_field.metadata[field_id] == b'102'  # type: ignore[index]
 
     struct_middle_field = struct_field.type[0]
-    assert struct_middle_field.metadata[field_id] == b'101'
+    assert struct_middle_field.metadata is not None
+    assert struct_middle_field.metadata[field_id] == b'101'  # type: ignore[index]
 
     struct_inner_field = struct_middle_field.type[0]
-    assert struct_inner_field.metadata[field_id] == b'100'
+    assert struct_inner_field.metadata is not None
+    assert struct_inner_field.metadata[field_id] == b'100'  # type: ignore[index]
 
     assert schema[3].metadata is None
     # Invalid input is passed through (ok) but does not
     # have field_id in parquet (not tested)
-    assert schema[4].metadata[field_id] == b'xyz'
-    assert schema[5].metadata[field_id] == b'-1000'
+    assert schema[4].metadata is not None
+    assert schema[4].metadata[field_id] == b'xyz'  # type: ignore[index]
+    assert schema[5].metadata[field_id] == b'-1000'  # type: ignore[index]
 
 
 def test_parquet_file_page_index():
@@ -495,13 +507,14 @@ def test_multi_dataset_metadata(tempdir):
             _meta.append_row_groups(meta[0])
 
     # Write merged metadata-only file
+    assert _meta is not None
     with open(metapath, "wb") as f:
-        _meta.write_metadata_file(f)
+        _meta.write_metadata_file(f)  # type: ignore[union-attr]
 
     # Read back the metadata
     meta = pq.read_metadata(metapath)
     md = meta.to_dict()
-    _md = _meta.to_dict()
+    _md = _meta.to_dict()  # type: ignore[union-attr]
     for key in _md:
         if key != 'serialized_size':
             assert _md[key] == md[key]
@@ -695,13 +708,14 @@ def test_metadata_schema_filesystem(tempdir):
     assert pq.read_metadata(
         file_path, filesystem=LocalFileSystem()).equals(metadata)
     assert pq.read_metadata(
+        # type: ignore[arg-type]
         fname, filesystem=f'file:///{tempdir}').equals(metadata)
 
     assert pq.read_schema(file_uri).equals(schema)
     assert pq.read_schema(
         file_path, filesystem=LocalFileSystem()).equals(schema)
     assert pq.read_schema(
-        fname, filesystem=f'file:///{tempdir}').equals(schema)
+        fname, filesystem=f'file:///{tempdir}').equals(schema)  # type: ignore[arg-type]
 
     with util.change_cwd(tempdir):
         # Pass `filesystem` arg
@@ -721,7 +735,7 @@ def test_metadata_equals():
     original_metadata = pq.read_metadata(pa.BufferReader(buf))
     match = "Argument 'other' has incorrect type"
     with pytest.raises(TypeError, match=match):
-        original_metadata.equals(None)
+        original_metadata.equals(None)  # type: ignore[arg-type]
 
 
 @pytest.mark.parametrize("t1,t2,expected_error", (
@@ -810,7 +824,7 @@ def test_internal_class_instantiation():
         pq.ColumnChunkMetaData()
 
     with pytest.raises(TypeError, match=msg("RowGroupMetaData")):
-        pq.RowGroupMetaData()
+        pq.RowGroupMetaData()  # type: ignore[call-arg]
 
     with pytest.raises(TypeError, match=msg("FileMetaData")):
-        pq.FileMetaData()
+        pq.FileMetaData()  # type: ignore[call-arg]

--- a/python/pyarrow/tests/parquet/test_pandas.py
+++ b/python/pyarrow/tests/parquet/test_pandas.py
@@ -17,11 +17,12 @@
 
 import io
 import json
+from typing import TYPE_CHECKING, cast
 
 try:
     import numpy as np
 except ImportError:
-    np = None
+    pass
 import pytest
 
 import pyarrow as pa
@@ -29,22 +30,29 @@ from pyarrow.fs import LocalFileSystem, SubTreeFileSystem
 from pyarrow.util import guid
 from pyarrow.vendored.version import Version
 
-try:
-    import pyarrow.parquet as pq
-    from pyarrow.tests.parquet.common import (_read_table, _test_dataframe,
-                                              _write_table)
-except ImportError:
-    pq = None
-
-
-try:
+if TYPE_CHECKING:
     import pandas as pd
     import pandas.testing as tm
+    import pyarrow.parquet as pq
+    from pyarrow.tests.parquet.common import (
+        _read_table, _roundtrip_pandas_dataframe, _test_dataframe,
+        _write_table, alltypes_sample
+    )
+else:
+    try:
+        import pyarrow.parquet as pq
+        from pyarrow.tests.parquet.common import (
+            _read_table, _test_dataframe, _write_table, alltypes_sample,
+            _roundtrip_pandas_dataframe
+        )
 
-    from pyarrow.tests.parquet.common import (_roundtrip_pandas_dataframe,
-                                              alltypes_sample)
-except ImportError:
-    pd = tm = None
+    except ImportError:
+        pass
+    try:
+        import pandas as pd
+        import pandas.testing as tm
+    except ImportError:
+        pass
 
 
 # Marks all of the tests in this module
@@ -58,11 +66,14 @@ def test_pandas_parquet_custom_metadata(tempdir):
 
     filename = tempdir / 'pandas_roundtrip.parquet'
     arrow_table = pa.Table.from_pandas(df)
+    assert arrow_table.schema.metadata is not None
     assert b'pandas' in arrow_table.schema.metadata
 
     _write_table(arrow_table, filename)
 
-    metadata = pq.read_metadata(filename).metadata
+    file_metadata = pq.read_metadata(filename)
+    metadata = file_metadata.metadata
+    assert metadata is not None
     assert b'pandas' in metadata
 
     js = json.loads(metadata[b'pandas'].decode('utf8'))
@@ -117,10 +128,13 @@ def test_attributes_metadata_persistence(tempdir):
     }
 
     table = pa.Table.from_pandas(df)
+    assert table.schema.metadata is not None
     assert b'attributes' in table.schema.metadata[b'pandas']
 
     _write_table(table, filename)
-    metadata = pq.read_metadata(filename).metadata
+    file_metadata = pq.read_metadata(filename)
+    metadata = file_metadata.metadata
+    assert metadata is not None
     js = json.loads(metadata[b'pandas'].decode('utf8'))
     assert 'attributes' in js
     assert js['attributes'] == df.attrs
@@ -297,8 +311,8 @@ def test_pandas_parquet_configuration_options(tempdir):
 @pytest.mark.pandas
 def test_spark_flavor_preserves_pandas_metadata():
     df = _test_dataframe(size=100)
-    df.index = np.arange(0, 10 * len(df), 10)
-    df.index.name = 'foo'
+    df.index = np.arange(0, 10 * len(df), 10)  # type: ignore[assignment]
+    df.index.name = 'foo'  # type: ignore[attr-defined]
 
     result = _roundtrip_pandas_dataframe(df, {'flavor': 'spark'})
     tm.assert_frame_equal(result, df)
@@ -450,7 +464,9 @@ def test_backwards_compatible_column_metadata_handling(datadir):
     table = _read_table(
         path, columns=['a'])
     result = table.to_pandas()
-    tm.assert_frame_equal(result, expected[['a']].reset_index(drop=True))
+    expected_df = expected[['a']].reset_index(drop=True)
+    assert isinstance(expected_df, pd.DataFrame)
+    tm.assert_frame_equal(result, expected_df)
 
 
 @pytest.mark.pandas
@@ -510,7 +526,7 @@ def test_pandas_categorical_roundtrip():
     codes = np.array([2, 0, 0, 2, 0, -1, 2], dtype='int32')
     categories = ['foo', 'bar', 'baz']
     df = pd.DataFrame({'x': pd.Categorical.from_codes(
-        codes, categories=categories)})
+        codes, categories=categories)})  # type: ignore[arg-type]
 
     buf = pa.BufferOutputStream()
     pq.write_table(pa.table(df), buf)
@@ -555,15 +571,18 @@ def test_write_to_dataset_pandas_preserve_extensiondtypes(tempdir):
         table, str(tempdir / "case1"), partition_cols=['part'],
     )
     result = pq.read_table(str(tempdir / "case1")).to_pandas()
-    tm.assert_frame_equal(result[["col"]], df[["col"]])
+    tm.assert_frame_equal(
+        result[["col"]], df[["col"]])
 
     pq.write_to_dataset(table, str(tempdir / "case2"))
     result = pq.read_table(str(tempdir / "case2")).to_pandas()
-    tm.assert_frame_equal(result[["col"]], df[["col"]])
+    tm.assert_frame_equal(
+        result[["col"]], df[["col"]])
 
     pq.write_table(table, str(tempdir / "data.parquet"))
     result = pq.read_table(str(tempdir / "data.parquet")).to_pandas()
-    tm.assert_frame_equal(result[["col"]], df[["col"]])
+    tm.assert_frame_equal(
+        result[["col"]], df[["col"]])
 
 
 @pytest.mark.pandas

--- a/python/pyarrow/tests/parquet/test_parquet_writer.py
+++ b/python/pyarrow/tests/parquet/test_parquet_writer.py
@@ -23,9 +23,10 @@ from pyarrow import fs
 try:
     import pyarrow.parquet as pq
     from pyarrow.tests.parquet.common import (_read_table, _test_dataframe,
+                                              # type: ignore[attr-defined]
                                               _test_table, _range_integers)
 except ImportError:
-    pq = None
+    pass
 
 
 try:
@@ -33,7 +34,7 @@ try:
     import pandas.testing as tm
 
 except ImportError:
-    pd = tm = None
+    pass
 
 
 # Marks all of the tests in this module
@@ -94,10 +95,10 @@ def test_parquet_invalid_writer(tempdir):
     # avoid segfaults with invalid construction
     with pytest.raises(TypeError):
         some_schema = pa.schema([pa.field("x", pa.int32())])
-        pq.ParquetWriter(None, some_schema)
+        pq.ParquetWriter(None, some_schema)  # type: ignore[arg-type]
 
     with pytest.raises(TypeError):
-        pq.ParquetWriter(tempdir / "some_path", None)
+        pq.ParquetWriter(tempdir / "some_path", None)  # type: ignore[arg-type]
 
 
 @pytest.mark.pandas
@@ -335,6 +336,7 @@ def test_parquet_writer_store_schema(tempdir):
         writer.write_table(table)
 
     meta = pq.read_metadata(path1)
+    assert meta.metadata is not None
     assert b'ARROW:schema' in meta.metadata
     assert meta.metadata[b'ARROW:schema']
 
@@ -357,6 +359,7 @@ def test_parquet_writer_append_key_value_metadata(tempdir):
         writer.add_key_value_metadata({'key2': '2', 'key3': '3'})
     reader = pq.ParquetFile(path)
     metadata = reader.metadata.metadata
+    assert metadata is not None
     assert metadata[b'key1'] == b'1'
     assert metadata[b'key2'] == b'2'
     assert metadata[b'key3'] == b'3'


### PR DESCRIPTION
### Rationale for this change

Closes: #49197

### What changes are included in this PR?

Add type annotation stubs for parquet (core, encryption) and dataset modules, including internal variants (_parquet, _dataset, _dataset_orc, _dataset_parquet, _dataset_parquet_encryption). Includes source fixes and type-ignore annotations in related tests.

### Are these changes tested?

Yes, by CI.

### Are there any user-facing changes?

Parquet and dataset modules will now be annotated.
* GitHub Issue: #49197