### PR TITLE
GH-49208: [Ruby] Add support for writing dictionary delta message

### DIFF
--- a/ruby/red-arrow-format/lib/arrow-format/bitmap.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/bitmap.rb
@@ -18,15 +18,18 @@ module ArrowFormat
   class Bitmap
     include Enumerable
 
-    def initialize(buffer, n_values)
+    def initialize(buffer, offset, n_values)
       @buffer = buffer
+      @offset = offset
       @n_values = n_values
     end
 
     def [](i)
+      i += @offset
       (@buffer.get_value(:U8, i / 8) & (1 << (i % 8))) > 0
     end
 
+    # TODO: offset support
     def each
       return to_enum(__method__) unless block_given?
 
@@ -42,6 +45,13 @@ module ArrowFormat
         remained_bits.times do |i|
           yield((value & (1 << (i % 8))) > 0)
         end
+      end
+    end
+
+    def popcount
+      # TODO: Optimize
+      count do |flaged|
+        flaged
       end
     end
   end

--- a/ruby/red-arrow-format/lib/arrow-format/streaming-writer.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/streaming-writer.rb
@@ -118,8 +118,7 @@ module ArrowFormat
         is_delta = false
       else
         is_delta = true
-        raise NotImplementedError,
-              "Delta dictionary message isn't implemented yet"
+        dictionary = dictionary.slice(offset)
       end
 
       schema = Schema.new([Field.new("dummy", value_type, true, nil)])

--- a/ruby/red-arrow-format/lib/arrow-format/type.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/type.rb
@@ -305,6 +305,10 @@ module ArrowFormat
       "Float32"
     end
 
+    def buffer_type
+      :f32
+    end
+
     def build_array(size, validity_buffer, values_buffer)
       Float32Array.new(self, size, validity_buffer, values_buffer)
     end
@@ -323,6 +327,10 @@ module ArrowFormat
 
     def name
       "Float64"
+    end
+
+    def buffer_type
+      :f64
     end
 
     def build_array(size, validity_buffer, values_buffer)
@@ -362,6 +370,10 @@ module ArrowFormat
       "Date32"
     end
 
+    def buffer_type
+      :s32
+    end
+
     def build_array(size, validity_buffer, values_buffer)
       Date32Array.new(self, size, validity_buffer, values_buffer)
     end
@@ -380,6 +392,10 @@ module ArrowFormat
 
     def name
       "Date64"
+    end
+
+    def buffer_type
+      :s64
     end
 
     def build_array(size, validity_buffer, values_buffer)
@@ -413,6 +429,10 @@ module ArrowFormat
       "Time32"
     end
 
+    def buffer_type
+      :s32
+    end
+
     def build_array(size, validity_buffer, values_buffer)
       Time32Array.new(self, size, validity_buffer, values_buffer)
     end
@@ -425,6 +445,10 @@ module ArrowFormat
 
     def name
       "Time64"
+    end
+
+    def buffer_type
+      :s64
     end
 
     def build_array(size, validity_buffer, values_buffer)
@@ -443,6 +467,10 @@ module ArrowFormat
 
     def name
       "Timestamp"
+    end
+
+    def buffer_type
+      :s64
     end
 
     def build_array(size, validity_buffer, values_buffer)
@@ -486,6 +514,10 @@ module ArrowFormat
       "YearMonthInterval"
     end
 
+    def buffer_type
+      :s32
+    end
+
     def build_array(size, validity_buffer, values_buffer)
       YearMonthIntervalArray.new(self, size, validity_buffer, values_buffer)
     end
@@ -500,6 +532,10 @@ module ArrowFormat
       "DayTimeInterval"
     end
 
+    def buffer_type
+      :s32
+    end
+
     def build_array(size, validity_buffer, values_buffer)
       DayTimeIntervalArray.new(self, size, validity_buffer, values_buffer)
     end
@@ -512,6 +548,10 @@ module ArrowFormat
 
     def name
       "MonthDayNanoInterval"
+    end
+
+    def buffer_types
+      @buffer_types ||= [:s32, :s32, :s64]
     end
 
     def build_array(size, validity_buffer, values_buffer)
@@ -531,6 +571,10 @@ module ArrowFormat
 
     def name
       "Duration"
+    end
+
+    def buffer_type
+      :s64
     end
 
     def build_array(size, validity_buffer, values_buffer)
@@ -558,6 +602,14 @@ module ArrowFormat
       "Binary"
     end
 
+    def offset_buffer_type
+      :s32 # TODO: big endian support
+    end
+
+    def encoding
+      Encoding::ASCII_8BIT
+    end
+
     def build_array(size, validity_buffer, offsets_buffer, values_buffer)
       BinaryArray.new(self,
                       size,
@@ -580,6 +632,14 @@ module ArrowFormat
 
     def name
       "LargeBinary"
+    end
+
+    def offset_buffer_type
+      :s64 # TODO: big endian support
+    end
+
+    def encoding
+      Encoding::ASCII_8BIT
     end
 
     def build_array(size, validity_buffer, offsets_buffer, values_buffer)
@@ -606,6 +666,14 @@ module ArrowFormat
       "UTF8"
     end
 
+    def offset_buffer_type
+      :s32 # TODO: big endian support
+    end
+
+    def encoding
+      Encoding::UTF_8
+    end
+
     def build_array(size, validity_buffer, offsets_buffer, values_buffer)
       UTF8Array.new(self, size, validity_buffer, offsets_buffer, values_buffer)
     end
@@ -624,6 +692,14 @@ module ArrowFormat
 
     def name
       "LargeUTF8"
+    end
+
+    def offset_buffer_type
+      :s64 # TODO: big endian support
+    end
+
+    def encoding
+      Encoding::UTF_8
     end
 
     def build_array(size, validity_buffer, offsets_buffer, values_buffer)
@@ -720,6 +796,10 @@ module ArrowFormat
       "List"
     end
 
+    def offset_buffer_type
+      :s32 # TODO: big endian support
+    end
+
     def build_array(size, validity_buffer, offsets_buffer, child)
       ListArray.new(self, size, validity_buffer, offsets_buffer, child)
     end
@@ -732,6 +812,10 @@ module ArrowFormat
   class LargeListType < VariableSizeListType
     def name
       "LargeList"
+    end
+
+    def offset_buffer_type
+      :s64 # TODO: big endian support
     end
 
     def build_array(size, validity_buffer, offsets_buffer, child)
@@ -786,6 +870,10 @@ module ArrowFormat
 
     def name
       "Map"
+    end
+
+    def offset_buffer_type
+      :s32 # TODO: big endian support
     end
 
     def build_array(size, validity_buffer, offsets_buffer, child)


### PR DESCRIPTION
### Rationale for this change

This focuses on implementing base dictionary delta message support mechanism. So this adds support for only UTF-8 array as dictionary. Other arrays will be supported in follow-up tasks.

### What changes are included in this PR?

* Add support for `ArrowFromat#slice` (But it's not completed. It just works partially.)
* If the second record batch includes an updated dictionary (new entries are appended), these appended entries are sliced and they are only written as delta.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #49208