### PR TITLE
GH-49168: [Python] map date32/date64 to datetime64[s] in to_pandas_dtype

### DIFF
--- a/python/pyarrow/tests/test_schema.py
+++ b/python/pyarrow/tests/test_schema.py
@@ -55,6 +55,7 @@ def test_type_integers():
 @pytest.mark.pandas
 def test_type_to_pandas_dtype():
     M8 = np.dtype('datetime64[ms]')
+    M8s = np.dtype('datetime64[s]')
     if Version(pd.__version__) < Version("2.0.0"):
         M8 = np.dtype('datetime64[ns]')
     cases = [
@@ -71,8 +72,8 @@ def test_type_to_pandas_dtype():
         (pa.float16(), np.float16),
         (pa.float32(), np.float32),
         (pa.float64(), np.float64),
-        (pa.date32(), M8),
-        (pa.date64(), M8),
+        (pa.date32(), M8s),
+        (pa.date64(), M8s),
         (pa.timestamp('ms'), M8),
         (pa.binary(), np.object_),
         (pa.large_binary(), np.object_),

--- a/python/pyarrow/tests/test_schema.py
+++ b/python/pyarrow/tests/test_schema.py
@@ -58,6 +58,7 @@ def test_type_to_pandas_dtype():
     M8s = np.dtype('datetime64[s]')
     if Version(pd.__version__) < Version("2.0.0"):
         M8 = np.dtype('datetime64[ns]')
+        M8s = np.dtype('datetime64[ns]')
     cases = [
         (pa.null(), np.object_),
         (pa.bool_(), np.bool_),

--- a/python/pyarrow/types.pxi
+++ b/python/pyarrow/types.pxi
@@ -54,8 +54,8 @@ def _get_pandas_type_map():
             _Type_FLOAT: np.float32,
             _Type_DOUBLE: np.float64,
             # Pandas does not support [D]ay, so default to [ms] for date32
-            _Type_DATE32: np.dtype('datetime64[ms]'),
-            _Type_DATE64: np.dtype('datetime64[ms]'),
+            _Type_DATE32: np.dtype('datetime64[s]'),
+            _Type_DATE64: np.dtype('datetime64[s]'),
             _Type_TIMESTAMP: {
                 's': np.dtype('datetime64[s]'),
                 'ms': np.dtype('datetime64[ms]'),


### PR DESCRIPTION
### Rationale for this change

Fixes #49168

### What changes are included in this PR?

As per the issue raised in [[Python] Consider pa.date32/64.to_pandas_dtype() returning datetime64[s] instead of datetime64[ms]](https://github.com/apache/arrow/issues/49168), it was observed that no `ms` timestamp was supported in [parquet](https://parquet.apache.org/docs/file-format/types/logicaltypes/). To rectify that, the `pa.Date32/64.to_pandas_dtype` will return `datetime64[s]`.

python/pyarrow/types.pxi
python/pyarrow/tests/test_schema.py

### Are these changes tested?
Yes, the schema test file `python/pyarrow/tests/test_schema.py` has been updated to include this change.

### Are there any user-facing changes?
Yes, the return types `pa.date64/32().to_pandas_dtype()` should return `datetime64[s]`.

**This PR includes breaking changes to public APIs.** (If there are any breaking changes to public APIs, please explain which changes are breaking. If not, you can remove this.)

* GitHub Issue: #49168