### PR TITLE
GH-49081: [C++][Parquet][FOLLOWUP] Correct variant's extension name

### DIFF
--- a/cpp/src/arrow/extension/meson.build
+++ b/cpp/src/arrow/extension/meson.build
@@ -32,5 +32,12 @@ exc = executable(
 test('arrow-canonical-extensions-test', exc)
 
 install_headers(
-    ['bool8.h', 'fixed_shape_tensor.h', 'json.h', 'opaque.h', 'uuid.h'],
+    [
+        'bool8.h',
+        'fixed_shape_tensor.h',
+        'json.h',
+        'opaque.h',
+        'parquet_variant.h',
+        'uuid.h',
+    ],
 )

--- a/cpp/src/arrow/meson.build
+++ b/cpp/src/arrow/meson.build
@@ -141,6 +141,7 @@ arrow_components = {
             'extension_type.cc',
             'extension/bool8.cc',
             'extension/json.cc',
+            'extension/parquet_variant.cc',
             'extension/uuid.cc',
             'pretty_print.cc',
             'record_batch.cc',

--- a/cpp/src/parquet/meson.build
+++ b/cpp/src/parquet/meson.build
@@ -23,7 +23,6 @@ parquet_srcs = files(
     'arrow/reader_internal.cc',
     'arrow/schema.cc',
     'arrow/schema_internal.cc',
-    'arrow/variant_internal.cc',
     'arrow/writer.cc',
     'bloom_filter.cc',
     'bloom_filter_reader.cc',


### PR DESCRIPTION
### Rationale for this change

Previous PR moved one file, modified the CMakeLists but didn't modify the meson file. Fix meson build failure.

### What changes are included in this PR?

Modified the meson configuration files.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.

* GitHub Issue: #49081