### PR TITLE
GH-49187: [Doc] Fix versions.json for Arrow 1.0

### DIFF
--- a/docs/source/_static/versions.json
+++ b/docs/source/_static/versions.json
@@ -128,6 +128,6 @@
     {
         "name": "1.0",
         "version": "1.0/",
-        "url": "https://arrow.apache.org/docs/dev/"
+        "url": "https://arrow.apache.org/docs/1.0/"
     }
 ]


### PR DESCRIPTION
### Rationale for this change

"1.0" in the version switcher has a wrong link.

### What changes are included in this PR?

Update the link to point to correct https://arrow.apache.org/docs/1.0/ docs

### Are these changes tested?

No. They will be tested with the new release (probably patch release) when the versions.json file will be copied to the [arrow-site](https://github.com/apache/arrow-site) repo.

### Are there any user-facing changes?

No.

* GitHub Issue: #49187