### PR TITLE
GH-49234: [CI][Python] Nightly sdist job fails due to missing update_stub_docstrings.py file

### DIFF
--- a/python/MANIFEST.in
+++ b/python/MANIFEST.in
@@ -5,6 +5,7 @@ include ../NOTICE.txt
 global-include CMakeLists.txt
 graft pyarrow
 graft pyarrow-stubs
+include scripts/update_stub_docstrings.py
 graft cmake_modules
 
 global-exclude *.so


### PR DESCRIPTION
### Rationale for this change

Nightly sdist job fails due to missing update_stub_docstrings.py file

### What changes are included in this PR?

Add update_stub_docstrings.py to MANIFEST.in

### Are these changes tested?

We should test with crossbow

### Are there any user-facing changes?

No.
* GitHub Issue: #49234