### PR TITLE
GH-48862: [C++][Integration] Build arrow_c_data_integration library regardless of ARROW_TEST value

### DIFF
--- a/cpp/src/arrow/integration/CMakeLists.txt
+++ b/cpp/src/arrow/integration/CMakeLists.txt
@@ -33,7 +33,9 @@ elseif(ARROW_BUILD_INTEGRATION)
 
   add_dependencies(arrow-json-integration-test arrow arrow_testing)
   add_dependencies(arrow-integration arrow-json-integration-test)
+endif()
 
+if(ARROW_BUILD_INTEGRATION)
   add_arrow_lib(arrow_c_data_integration
                 SOURCES
                 c_data_integration_internal.cc


### PR DESCRIPTION
### Rationale for this change

Currently if `ARROW_TEST=ON` the arrow_c_data_integration library is not built. This has been seen on Release verification for 23.0.0 and 23.0.1.

### What changes are included in this PR?

Build `arrow_c_data_integration` library if `ARROW_BUILD_INTEGRATION=ON` regardless of `ARROW_TEST` value.

### Are these changes tested?

Yes, I've temporarily modified the crossbow job to run both tests and integration and validated the commit fixes the problem and it failed without the fix.

### Are there any user-facing changes?

No

* GitHub Issue: #48862