### PR TITLE
GH-49248: [Release] Include checksum in vote email

### DIFF
--- a/dev/release/02-source-test.rb
+++ b/dev/release/02-source-test.rb
@@ -109,8 +109,7 @@ class SourceTest < Test::Unit::TestCase
       verify_pr_url = (JSON.parse(response.read)[0] || {})["html_url"]
     end
     output = source("VOTE")
-    # Extract the tarball hash from the output
-    tarball_hash = output[/\[11\]: ([a-f0-9]+)/, 1]
+    tarball_hash = Digest::SHA512.file(@archive_name).to_s
     assert_equal(<<-VOTE.strip, output[/^-+$(.+?)^-+$/m, 1].strip)
 To: dev@arrow.apache.org
 Subject: [VOTE] Release Apache Arrow #{@release_version} - RC0

--- a/dev/release/02-source-test.rb
+++ b/dev/release/02-source-test.rb
@@ -15,6 +15,8 @@
 # specific language governing permissions and limitations
 # under the License.
 
+require 'digest'
+
 class SourceTest < Test::Unit::TestCase
   include GitRunnable
   include VersionDetectable

--- a/dev/release/02-source-test.rb
+++ b/dev/release/02-source-test.rb
@@ -113,7 +113,7 @@ class SourceTest < Test::Unit::TestCase
       verify_pr_url = (JSON.parse(response.read)[0] || {})["html_url"]
     end
     output = source("VOTE")
-    tarball_hash = Digest::SHA512.file(@archive_name).to_s
+    tarball_hash = Digest::SHA512.file("artifacts/#{@archive_name}).to_s
     assert_equal(<<-VOTE.strip, output[/^-+$(.+?)^-+$/m, 1].strip)
 To: dev@arrow.apache.org
 Subject: [VOTE] Release Apache Arrow #{@release_version} - RC0

--- a/dev/release/02-source-test.rb
+++ b/dev/release/02-source-test.rb
@@ -46,7 +46,7 @@ class SourceTest < Test::Unit::TestCase
       env["SOURCE_#{target}"] = "1"
     end
     sh(env, @tarball_script, @release_version, "0")
-    Dir.mkdir("artifacts") unless Dir.exist?("artifacts")
+    FileUtils.mkdir_p("artifacts")
     sh("mv", @archive_name, "artifacts/")
     File.open("artifacts/#{@archive_name}.sha512", "w") do |sha512|
       sha512.puts(sh(env, "shasum", "-a", "512", "artifacts/#{@archive_name}"))

--- a/dev/release/02-source-test.rb
+++ b/dev/release/02-source-test.rb
@@ -44,6 +44,9 @@ class SourceTest < Test::Unit::TestCase
       env["SOURCE_#{target}"] = "1"
     end
     sh(env, @tarball_script, @release_version, "0")
+    File.open("#{@archive_name}.sha512", "w") do |sha512|
+      sha512.puts(sh(env, "shasum", "-a", "512", @archive_name))
+    end
     output = sh(env, @script, @release_version, "0")
     sh("tar", "xf", @archive_name)
     output

--- a/dev/release/02-source-test.rb
+++ b/dev/release/02-source-test.rb
@@ -106,6 +106,8 @@ class SourceTest < Test::Unit::TestCase
       verify_pr_url = (JSON.parse(response.read)[0] || {})["html_url"]
     end
     output = source("VOTE")
+    # Extract the tarball hash from the output
+    tarball_hash = output[/\[11\]: ([a-f0-9]+)/, 1]
     assert_equal(<<-VOTE.strip, output[/^-+$(.+?)^-+$/m, 1].strip)
 To: dev@arrow.apache.org
 Subject: [VOTE] Release Apache Arrow #{@release_version} - RC0
@@ -124,9 +126,10 @@ The binary artifacts are hosted at [4][5][6][7][8][9].
 The changelog is located at [10].
 
 Please download, verify checksums and signatures, run the unit tests,
-and vote on the release. See [11] for how to validate a release candidate.
+and vote on the release. See [11] for the SHA-512 checksum for this RC and [12]
+for how to validate a release candidate.
 
-See also a verification result on GitHub pull request [12].
+See also a verification result on GitHub pull request [13].
 
 The vote will be open for at least 72 hours.
 
@@ -144,8 +147,9 @@ The vote will be open for at least 72 hours.
 [8]: https://packages.apache.org/artifactory/arrow/ubuntu-rc/
 [9]: https://github.com/apache/arrow/releases/tag/apache-arrow-#{@release_version}-rc0
 [10]: https://github.com/apache/arrow/blob/#{@current_commit}/CHANGELOG.md
-[11]: https://arrow.apache.org/docs/developers/release_verification.html
-[12]: #{verify_pr_url || "null"}
+[11]: #{tarball_hash}
+[12]: https://arrow.apache.org/docs/developers/release_verification.html
+[13]: #{verify_pr_url || "null"}
     VOTE
   end
 end

--- a/dev/release/02-source-test.rb
+++ b/dev/release/02-source-test.rb
@@ -113,7 +113,7 @@ class SourceTest < Test::Unit::TestCase
       verify_pr_url = (JSON.parse(response.read)[0] || {})["html_url"]
     end
     output = source("VOTE")
-    tarball_hash = Digest::SHA512.file("artifacts/#{@archive_name}).to_s
+    tarball_hash = Digest::SHA512.file("artifacts/#{@archive_name}").to_s
     assert_equal(<<-VOTE.strip, output[/^-+$(.+?)^-+$/m, 1].strip)
 To: dev@arrow.apache.org
 Subject: [VOTE] Release Apache Arrow #{@release_version} - RC0

--- a/dev/release/02-source-test.rb
+++ b/dev/release/02-source-test.rb
@@ -15,8 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-require 'digest'
-
 class SourceTest < Test::Unit::TestCase
   include GitRunnable
   include VersionDetectable

--- a/dev/release/02-source-test.rb
+++ b/dev/release/02-source-test.rb
@@ -46,11 +46,13 @@ class SourceTest < Test::Unit::TestCase
       env["SOURCE_#{target}"] = "1"
     end
     sh(env, @tarball_script, @release_version, "0")
-    File.open("#{@archive_name}.sha512", "w") do |sha512|
-      sha512.puts(sh(env, "shasum", "-a", "512", @archive_name))
+    Dir.mkdir("artifacts") unless Dir.exist?("artifacts")
+    sh("mv", @archive_name, "artifacts/")
+    File.open("artifacts/#{@archive_name}.sha512", "w") do |sha512|
+      sha512.puts(sh(env, "shasum", "-a", "512", "artifacts/#{@archive_name}"))
     end
     output = sh(env, @script, @release_version, "0")
-    sh("tar", "xf", @archive_name)
+    sh("tar", "xf", "artifacts/#{@archive_name}")
     output
   end
 

--- a/dev/release/02-source-test.rb
+++ b/dev/release/02-source-test.rb
@@ -48,9 +48,8 @@ class SourceTest < Test::Unit::TestCase
     sh(env, @tarball_script, @release_version, "0")
     FileUtils.mkdir_p("artifacts")
     sh("mv", @archive_name, "artifacts/")
-    File.open("artifacts/#{@archive_name}.sha512", "w") do |sha512|
-      sha512.puts(sh(env, "shasum", "-a", "512", "artifacts/#{@archive_name}"))
-    end
+    File.write("artifacts/#{@archive_name}.sha512",
+               sh(env, "shasum", "-a", "512", "artifacts/#{@archive_name}"))
     output = sh(env, @script, @release_version, "0")
     sh("tar", "xf", "artifacts/#{@archive_name}")
     output

--- a/dev/release/02-source.sh
+++ b/dev/release/02-source.sh
@@ -131,6 +131,7 @@ if [ ${SOURCE_VOTE} -gt 0 ]; then
   curl_options+=(https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls)
   verify_pr_url=$(curl "${curl_options[@]}" | jq -r ".[0].html_url")
   # Read the checksum so we can include it in the vote thread email.
+  [[ -f "artifacts/${tarball}.sha512" ]] || { echo "Error: artifacts/${tarball}.sha512 must exist"; exit 1; }
   tarball_hash=$(cat "artifacts/${tarball}.sha512" | awk '{print $1}')
 
   echo "The following draft email has been created to send to the"

--- a/dev/release/02-source.sh
+++ b/dev/release/02-source.sh
@@ -130,15 +130,8 @@ if [ ${SOURCE_VOTE} -gt 0 ]; then
   curl_options+=(--data "head=apache:${rc_branch}")
   curl_options+=(https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls)
   verify_pr_url=$(curl "${curl_options[@]}" | jq -r ".[0].html_url")
-  # Read the checksum so we can include it in the vote thread email
-  # We check if $tarball exists to detect when this script is being run by
-  # 02-source-test.rb and we fill in the hash from the test tarball in that
-  # case.
-  if [ -f "${tarball}" ]; then
-    tarball_hash=$(shasum -a 512 "${tarball}" | awk '{print $1}')
-  else
-    tarball_hash=$(curl -s "https://dist.apache.org/repos/dist/dev/arrow/apache-arrow-${version}-rc${rc}/${tarball}.sha512" | awk '{print $1}')
-  fi
+  # Read the checksum so we can include it in the vote thread email.
+  tarball_hash=$(cat "artifacts/${tarball}.sha512" | awk '{print $1}')
 
   echo "The following draft email has been created to send to the"
   echo "dev@arrow.apache.org mailing list"

--- a/dev/release/02-source.sh
+++ b/dev/release/02-source.sh
@@ -130,6 +130,8 @@ if [ ${SOURCE_VOTE} -gt 0 ]; then
   curl_options+=(--data "head=apache:${rc_branch}")
   curl_options+=(https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls)
   verify_pr_url=$(curl "${curl_options[@]}" | jq -r ".[0].html_url")
+  # read the checksum so we can include it in the vote thread email
+  tarball_hash=$(curl -s "https://dist.apache.org/repos/dist/dev/arrow/apache-arrow-${version}-rc${rc}/${tarball}.sha512" | awk '{print $1}')
 
   echo "The following draft email has been created to send to the"
   echo "dev@arrow.apache.org mailing list"
@@ -153,9 +155,10 @@ The binary artifacts are hosted at [4][5][6][7][8][9].
 The changelog is located at [10].
 
 Please download, verify checksums and signatures, run the unit tests,
-and vote on the release. See [11] for how to validate a release candidate.
+and vote on the release. See [11] for the SHA-512 checksum for this RC and [12]
+for how to validate a release candidate.
 
-See also a verification result on GitHub pull request [12].
+See also a verification result on GitHub pull request [13].
 
 The vote will be open for at least 72 hours.
 
@@ -173,8 +176,9 @@ The vote will be open for at least 72 hours.
 [8]: https://packages.apache.org/artifactory/arrow/ubuntu-rc/
 [9]: https://github.com/apache/arrow/releases/tag/apache-arrow-${version}-rc${rc}
 [10]: https://github.com/apache/arrow/blob/${release_hash}/CHANGELOG.md
-[11]: https://arrow.apache.org/docs/developers/release_verification.html
-[12]: ${verify_pr_url}
+[11]: ${tarball_hash}
+[12]: https://arrow.apache.org/docs/developers/release_verification.html
+[13]: ${verify_pr_url}
 MAIL
   echo "---------------------------------------------------------"
 fi

--- a/dev/release/02-source.sh
+++ b/dev/release/02-source.sh
@@ -131,8 +131,9 @@ if [ ${SOURCE_VOTE} -gt 0 ]; then
   curl_options+=(https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls)
   verify_pr_url=$(curl "${curl_options[@]}" | jq -r ".[0].html_url")
   # Read the checksum so we can include it in the vote thread email.
-  [[ -f "artifacts/${tarball}.sha512" ]] || { echo "Error: artifacts/${tarball}.sha512 must exist"; exit 1; }
-  tarball_hash=$(cat "artifacts/${tarball}.sha512" | awk '{print $1}')
+  sha512_path="artifacts/${tarball}.sha512}
+  [[ -f "${sha512_path}" ]] || { echo "Error: ${sha512_path} must exist"; exit 1; }
+  tarball_hash=$(cat "${sha512_path}" | awk '{print $1}')
 
   echo "The following draft email has been created to send to the"
   echo "dev@arrow.apache.org mailing list"

--- a/dev/release/02-source.sh
+++ b/dev/release/02-source.sh
@@ -131,7 +131,7 @@ if [ ${SOURCE_VOTE} -gt 0 ]; then
   curl_options+=(https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls)
   verify_pr_url=$(curl "${curl_options[@]}" | jq -r ".[0].html_url")
   # Read the checksum so we can include it in the vote thread email.
-  sha512_path="artifacts/${tarball}.sha512}
+  sha512_path="artifacts/${tarball}.sha512"
   [[ -f "${sha512_path}" ]] || { echo "Error: ${sha512_path} must exist"; exit 1; }
   tarball_hash=$(cat "${sha512_path}" | awk '{print $1}')
 

--- a/dev/release/02-source.sh
+++ b/dev/release/02-source.sh
@@ -130,8 +130,15 @@ if [ ${SOURCE_VOTE} -gt 0 ]; then
   curl_options+=(--data "head=apache:${rc_branch}")
   curl_options+=(https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls)
   verify_pr_url=$(curl "${curl_options[@]}" | jq -r ".[0].html_url")
-  # read the checksum so we can include it in the vote thread email
-  tarball_hash=$(curl -s "https://dist.apache.org/repos/dist/dev/arrow/apache-arrow-${version}-rc${rc}/${tarball}.sha512" | awk '{print $1}')
+  # Read the checksum so we can include it in the vote thread email
+  # We check if $tarball exists to detect when this script is being run by
+  # 02-source-test.rb and we fill in the hash from the test tarball in that
+  # case.
+  if [ -f "${tarball}" ]; then
+    tarball_hash=$(shasum -a 512 "${tarball}" | awk '{print $1}')
+  else
+    tarball_hash=$(curl -s "https://dist.apache.org/repos/dist/dev/arrow/apache-arrow-${version}-rc${rc}/${tarball}.sha512" | awk '{print $1}')
+  fi
 
   echo "The following draft email has been created to send to the"
   echo "dev@arrow.apache.org mailing list"

--- a/dev/release/02-source.sh
+++ b/dev/release/02-source.sh
@@ -60,7 +60,6 @@ fi
 echo "Using commit $release_hash"
 
 tarball=apache-arrow-${version}.tar.gz
-tarball_hash=""
 
 if [ ${SOURCE_DOWNLOAD} -gt 0 ]; then
   # Wait for the release candidate workflow to finish before attempting
@@ -89,9 +88,6 @@ if [ ${SOURCE_UPLOAD} -gt 0 ]; then
   # commit to svn
   svn add tmp/${tag}
   svn ci -m "Apache Arrow ${version} RC${rc}" tmp/${tag}
-
-  # save hash for SOURCE_VOTE step
-  tarball_hash=$(awk '{print $1}' "artifacts/${tarball}.sha512")
 
   # clean up
   rm -rf artifacts
@@ -134,12 +130,8 @@ if [ ${SOURCE_VOTE} -gt 0 ]; then
   curl_options+=(--data "head=apache:${rc_branch}")
   curl_options+=(https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls)
   verify_pr_url=$(curl "${curl_options[@]}" | jq -r ".[0].html_url")
-
-  # get the hash if it wasn't already set (like when this is run with
-  # SOURCE_DEFAULT=0 SOURCE_VOTE=1).
-  if [ -z "${tarball_hash}" ]; then
-    tarball_hash=$(curl -s "https://dist.apache.org/repos/dist/dev/arrow/apache-arrow-${version}-rc${rc}/${tarball}.sha512" | awk '{print $1}')
-  fi
+  # read the checksum so we can include it in the vote thread email
+  tarball_hash=$(curl -s "https://dist.apache.org/repos/dist/dev/arrow/apache-arrow-${version}-rc${rc}/${tarball}.sha512" | awk '{print $1}')
 
   echo "The following draft email has been created to send to the"
   echo "dev@arrow.apache.org mailing list"

--- a/dev/release/test-helper.rb
+++ b/dev/release/test-helper.rb
@@ -17,6 +17,7 @@
 
 require "English"
 require "cgi/util"
+require 'digest'
 require "fileutils"
 require "find"
 require 'net/http'


### PR DESCRIPTION
### Rationale for this change

Resolves #49248 

### What changes are included in this PR?

Adds a step to the `SOURCE_VOTE` step in `02-source.sh` to grab the checksum we just pushed to svn from dist.apache.org and include that checksum as a footnote in the vote thread email. I did it this way because the person running this script may run this script like,

```sh
SOURCE_DEFAULT=0 SOURCE_VOTE=1 dev/release/02-source.sh 23.0.1 0
```

So the only way to get the checksum at this point is with another SVN command or by downloading the file from dist.apache.org.

### Are these changes tested?

Yes, using currently active RC and with the above command.

### Are there any user-facing changes?

No.
* GitHub Issue: #49248