### PR TITLE
MINOR: [Docs] Document tzdata behaviour on non-FHS systems

### DIFF
--- a/docs/source/python/install.rst
+++ b/docs/source/python/install.rst
@@ -126,7 +126,7 @@ produce errors such as:
 
 .. code-block:: text
 
-   ArrowInvalid: Cannot locate or parse timezone 'CET'
+   ArrowInvalid: Cannot locate or parse timezone '<timezone>'
    discover_tz_dir failed to find zoneinfo
 
 Arrow expects tzdata to be available in standard system locations (

--- a/docs/source/python/install.rst
+++ b/docs/source/python/install.rst
@@ -116,6 +116,27 @@ command:
 
 .. _python-conda-differences:
 
+tzdata on non-FHS-compliant systems
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+On environments without standard filesystem layouts (for example,
+non-FHS-compliant systems such as NixOS, minimal containers, or hermetic
+build environments), Arrow may fail to locate the timezone database and
+produce errors such as:
+
+.. code-block:: text
+
+   ArrowInvalid: Cannot locate or parse timezone 'CET'
+   discover_tz_dir failed to find zoneinfo
+
+Arrow expects tzdata to be available in standard system locations (
+``/usr/share/zoneinfo`` on typical Linux distributions). If tzdata
+is installed in a non-standard path, it may not be discovered automatically.
+
+If you encounter this issue, ensure that a timezone database is installed
+and accessible in a standard system location, or configure your environment
+appropriately.
+
 Differences between conda-forge packages
 ----------------------------------------
 


### PR DESCRIPTION
### Rationale for this change
Timezone-related failures can occur on non-FHS-compliant systems when the
system timezone database is not discoverable. This behavior is currently
not documented, which may lead contributors to interpret such failures as
Arrow bugs. 

### What changes are included in this PR?
Add a section on the install.rst titled 'tzdata on non FHS-compliant systems' and explaining what goes wrong.

### Are these changes tested?
No. 
### Are there any user-facing changes?
No. Changed docs.

*Github Issue: apache#49172 (Closes this)