### PR TITLE
GH-49186: [R] Support dplyr::filter_out() in Arrow dplyr backend

### DIFF
--- a/r/R/arrow-package.R
+++ b/r/R/arrow-package.R
@@ -38,6 +38,7 @@
 supported_dplyr_methods <- list(
   select = NULL,
   filter = NULL,
+  filter_out = NULL,
   collect = NULL,
   summarise = c(
     "window functions not currently supported;",

--- a/r/R/dplyr-filter.R
+++ b/r/R/dplyr-filter.R
@@ -47,7 +47,7 @@ filter.arrow_dplyr_query <- function(.data, ..., .by = NULL, .preserve = FALSE) 
           call = expr
         )
       }
-      out <- set_filters(out, filt)
+      out <- set_filters(out, filt, exclude = FALSE)
     }
 
     if (by$from_by) {
@@ -59,7 +59,58 @@ filter.arrow_dplyr_query <- function(.data, ..., .by = NULL, .preserve = FALSE) 
 }
 filter.Dataset <- filter.ArrowTabular <- filter.RecordBatchReader <- filter.arrow_dplyr_query
 
-set_filters <- function(.data, expressions) {
+filter_out.arrow_dplyr_query <- function(.data, ..., .by = NULL, .preserve = FALSE) {
+  try_arrow_dplyr({
+    # TODO something with the .preserve argument
+    out <- as_adq(.data)
+
+    by <- compute_by({{ .by }}, out, by_arg = ".by", data_arg = ".data")
+
+    if (by$from_by) {
+      out$group_by_vars <- by$names
+    }
+
+    expanded_filters <- expand_across(out, quos(...))
+    if (length(expanded_filters) == 0) {
+      # Nothing to do
+      return(as_adq(.data))
+    }
+
+    # tidy-eval the filter expressions inside an Arrow data_mask
+    mask <- arrow_mask(out)
+
+    combined <- NULL
+
+    for (expr in expanded_filters) {
+      filt <- arrow_eval(expr, mask)
+
+      if (length(mask$.aggregations)) {
+        arrow_not_supported(
+          .actual_msg = "Expression not supported in filter_out() in Arrow",
+          call = expr
+        )
+      }
+
+      # arrow_eval() may return either an Expression or a list_of<Expression>
+      if (is_list_of(filt, "Expression")) {
+        filt <- Reduce("&", filt)
+      }
+
+      combined <- if (is.null(combined)) filt else (combined & filt)
+    }
+
+    out <- set_filters(out, combined, exclude = TRUE)
+
+    if (by$from_by) {
+      out$group_by_vars <- character()
+    }
+
+    out
+  })
+}
+filter_out.Dataset <- filter_out.ArrowTabular <- filter_out.RecordBatchReader <- filter_out.arrow_dplyr_query
+
+set_filters <- function(.data, expressions, exclude = FALSE) {
   if (length(expressions)) {
     if (is_list_of(expressions, "Expression")) {
       # expressions is a list of Expressions. AND them together and set them on .data
@@ -68,6 +119,12 @@ set_filters <- function(.data, expressions) {
       new_filter <- expressions
     } else {
       stop("filter expressions must be either an expression or a list of expressions", call. = FALSE)
+    }
+
+    if (isTRUE(exclude)) {
+      # dplyr::filter_out() semantics: drop rows where predicate is TRUE;
+      # keep rows where predicate is FALSE or NA.
+      new_filter <- (!new_filter) | is.na(new_filter)
     }
 
     if (isTRUE(.data$filtered_rows)) {

--- a/r/R/dplyr-filter.R
+++ b/r/R/dplyr-filter.R
@@ -17,8 +17,14 @@
 
 # The following S3 methods are registered on load if dplyr is present
 
-apply_filter_impl <- function(.data, ..., .by = NULL, .preserve = FALSE,
-                              exclude = FALSE, verb = c("filter", "filter_out")) {
+apply_filter_impl <- function(
+  .data,
+  ...,
+  .by = NULL,
+  .preserve = FALSE,
+  exclude = FALSE,
+  verb = c("filter", "filter_out")
+) {
   verb <- match.arg(verb)
 
   # TODO something with the .preserve argument

--- a/r/R/dplyr-filter.R
+++ b/r/R/dplyr-filter.R
@@ -17,68 +17,30 @@
 
 # The following S3 methods are registered on load if dplyr is present
 
-filter.arrow_dplyr_query <- function(.data, ..., .by = NULL, .preserve = FALSE) {
-  try_arrow_dplyr({
-    # TODO something with the .preserve argument
-    out <- as_adq(.data)
+apply_filter_impl <- function(.data, ..., .by = NULL, .preserve = FALSE,
+                              exclude = FALSE, verb = c("filter", "filter_out")) {
+  verb <- match.arg(verb)
 
-    by <- compute_by({{ .by }}, out, by_arg = ".by", data_arg = ".data")
+  # TODO something with the .preserve argument
+  out <- as_adq(.data)
 
-    if (by$from_by) {
-      out$group_by_vars <- by$names
-    }
+  by <- compute_by({{ .by }}, out, by_arg = ".by", data_arg = ".data")
 
-    expanded_filters <- expand_across(out, quos(...))
-    if (length(expanded_filters) == 0) {
-      # Nothing to do
-      return(as_adq(.data))
-    }
+  if (by$from_by) {
+    out$group_by_vars <- by$names
+  }
 
-    # tidy-eval the filter expressions inside an Arrow data_mask
-    mask <- arrow_mask(out)
-    for (expr in expanded_filters) {
-      filt <- arrow_eval(expr, mask)
-      if (length(mask$.aggregations)) {
-        # dplyr lets you filter on e.g. x < mean(x), but we haven't implemented it.
-        # But we could, the same way it works in mutate() via join, if someone asks.
-        # Until then, just error.
-        arrow_not_supported(
-          .actual_msg = "Expression not supported in filter() in Arrow",
-          call = expr
-        )
-      }
-      out <- set_filters(out, filt, exclude = FALSE)
-    }
+  expanded_filters <- expand_across(out, quos(...))
+  if (length(expanded_filters) == 0) {
+    # Nothing to do
+    return(as_adq(.data))
+  }
 
-    if (by$from_by) {
-      out$group_by_vars <- character()
-    }
+  # tidy-eval the filter expressions inside an Arrow data_mask
+  mask <- arrow_mask(out)
 
-    out
-  })
-}
-filter.Dataset <- filter.ArrowTabular <- filter.RecordBatchReader <- filter.arrow_dplyr_query
-
-filter_out.arrow_dplyr_query <- function(.data, ..., .by = NULL, .preserve = FALSE) {
-  try_arrow_dplyr({
-    # TODO something with the .preserve argument
-    out <- as_adq(.data)
-
-    by <- compute_by({{ .by }}, out, by_arg = ".by", data_arg = ".data")
-
-    if (by$from_by) {
-      out$group_by_vars <- by$names
-    }
-
-    expanded_filters <- expand_across(out, quos(...))
-    if (length(expanded_filters) == 0) {
-      # Nothing to do
-      return(as_adq(.data))
-    }
-
-    # tidy-eval the filter expressions inside an Arrow data_mask
-    mask <- arrow_mask(out)
-
+  if (isTRUE(exclude)) {
+    # filter_out(): combine all predicates with &, then exclude
     combined <- NULL
 
     for (expr in expanded_filters) {
@@ -86,12 +48,11 @@ filter_out.arrow_dplyr_query <- function(.data, ..., .by = NULL, .preserve = FAL
 
       if (length(mask$.aggregations)) {
         arrow_not_supported(
-          .actual_msg = "Expression not supported in filter_out() in Arrow",
+          .actual_msg = sprintf("Expression not supported in %s() in Arrow", verb),
           call = expr
         )
       }
 
-      # arrow_eval() may return either an Expression or a list_of<Expression>
       if (is_list_of(filt, "Expression")) {
         filt <- Reduce("&", filt)
       }
@@ -100,12 +61,53 @@ filter_out.arrow_dplyr_query <- function(.data, ..., .by = NULL, .preserve = FAL
     }
 
     out <- set_filters(out, combined, exclude = TRUE)
+  } else {
+    # filter(): apply each predicate sequentially
+    for (expr in expanded_filters) {
+      filt <- arrow_eval(expr, mask)
 
-    if (by$from_by) {
-      out$group_by_vars <- character()
+      if (length(mask$.aggregations)) {
+        arrow_not_supported(
+          .actual_msg = sprintf("Expression not supported in %s() in Arrow", verb),
+          call = expr
+        )
+      }
+
+      out <- set_filters(out, filt, exclude = FALSE)
     }
+  }
 
-    out
+  if (by$from_by) {
+    out$group_by_vars <- character()
+  }
+
+  out
+}
+
+filter.arrow_dplyr_query <- function(.data, ..., .by = NULL, .preserve = FALSE) {
+  try_arrow_dplyr({
+    apply_filter_impl(
+      .data,
+      ...,
+      .by = {{ .by }},
+      .preserve = .preserve,
+      exclude = FALSE,
+      verb = "filter"
+    )
+  })
+}
+filter.Dataset <- filter.ArrowTabular <- filter.RecordBatchReader <- filter.arrow_dplyr_query
+
+filter_out.arrow_dplyr_query <- function(.data, ..., .by = NULL, .preserve = FALSE) {
+  try_arrow_dplyr({
+    apply_filter_impl(
+      .data,
+      ...,
+      .by = {{ .by }},
+      .preserve = .preserve,
+      exclude = TRUE,
+      verb = "filter_out"
+    )
   })
 }
 filter_out.Dataset <- filter_out.ArrowTabular <- filter_out.RecordBatchReader <- filter_out.arrow_dplyr_query

--- a/r/R/dplyr-funcs-doc.R
+++ b/r/R/dplyr-funcs-doc.R
@@ -19,7 +19,7 @@
 
 #' Functions available in Arrow dplyr queries
 #'
-#' The `arrow` package contains methods for 37 `dplyr` table functions, many of
+#' The `arrow` package contains methods for 38 `dplyr` table functions, many of
 #' which are "verbs" that do transformations to one or more tables.
 #' The package also has mappings of 224 R functions to the corresponding
 #' functions in the Arrow compute library. These allow you to write code inside
@@ -45,6 +45,7 @@
 #' * [`distinct()`][dplyr::distinct()]: `.keep_all = TRUE` returns a non-missing value if present, only returning missing values if all are missing.
 #' * [`explain()`][dplyr::explain()]
 #' * [`filter()`][dplyr::filter()]
+#' * [`filter_out()`][dplyr::filter_out()]
 #' * [`full_join()`][dplyr::full_join()]: the `copy` argument is ignored
 #' * [`glimpse()`][dplyr::glimpse()]
 #' * [`group_by()`][dplyr::group_by()]

--- a/r/man/acero.Rd
+++ b/r/man/acero.Rd
@@ -7,7 +7,7 @@
 \alias{arrow-dplyr}
 \title{Functions available in Arrow dplyr queries}
 \description{
-The \code{arrow} package contains methods for 37 \code{dplyr} table functions, many of
+The \code{arrow} package contains methods for 38 \code{dplyr} table functions, many of
 which are "verbs" that do transformations to one or more tables.
 The package also has mappings of 224 R functions to the corresponding
 functions in the Arrow compute library. These allow you to write code inside
@@ -32,6 +32,7 @@ Table into an R \code{tibble}.
 \item \code{\link[dplyr:distinct]{distinct()}}: \code{.keep_all = TRUE} returns a non-missing value if present, only returning missing values if all are missing.
 \item \code{\link[dplyr:explain]{explain()}}
 \item \code{\link[dplyr:filter]{filter()}}
+\item \code{\link[dplyr:filter]{filter_out()}}
 \item \code{\link[dplyr:mutate-joins]{full_join()}}: the \code{copy} argument is ignored
 \item \code{\link[dplyr:glimpse]{glimpse()}}
 \item \code{\link[dplyr:group_by]{group_by()}}
@@ -198,7 +199,7 @@ Valid values are "s", "ms" (default), "us", "ns".
 \itemize{
 \item \code{\link[dplyr:across]{across()}}
 \item \code{\link[dplyr:between]{between()}}
-\item \code{\link[dplyr:case_when]{case_when()}}: \code{.ptype} and \code{.size} arguments not supported
+\item \code{\link[dplyr:case-and-replace-when]{case_when()}}: \code{.ptype} and \code{.size} arguments not supported
 \item \code{\link[dplyr:coalesce]{coalesce()}}
 \item \code{\link[dplyr:desc]{desc()}}
 \item \code{\link[dplyr:across]{if_all()}}

--- a/r/tests/testthat/test-dplyr-filter.R
+++ b/r/tests/testthat/test-dplyr-filter.R
@@ -538,4 +538,11 @@ test_that("More complex select/filter_out", {
       collect(),
     tbl
   )
+
+  compare_dplyr_binding(
+    .input |>
+      filter_out(!is.na(int)) |>
+      collect(),
+    tbl
+  )
 })

--- a/r/tests/testthat/test-dplyr-filter.R
+++ b/r/tests/testthat/test-dplyr-filter.R
@@ -498,3 +498,44 @@ test_that("filter() with aggregation expressions errors", {
     "not supported in filter"
   )
 })
+
+test_that("filter_out() basic", {
+  compare_dplyr_binding(
+    .input |>
+      filter_out(chr == "b") |>
+      select(chr, int, lgl) |>
+      collect(),
+    tbl
+  )
+})
+
+test_that("filter_out() keeps NA values in predicate result", {
+  compare_dplyr_binding(
+    .input |>
+      filter_out(lgl) |>
+      select(chr, int, lgl) |>
+      collect(),
+    tbl
+  )
+})
+
+test_that("filter_out() with multiple conditions", {
+  compare_dplyr_binding(
+    .input |>
+      filter_out(dbl > 2, chr %in% c("d", "f")) |>
+      collect(),
+    tbl
+  )
+})
+
+test_that("More complex select/filter_out", {
+  compare_dplyr_binding(
+    .input |>
+      filter_out(dbl > 2, chr == "d" | chr == "f") |>
+      select(chr, int, lgl) |>
+      filter(int < 5) |>
+      select(int, chr) |>
+      collect(),
+    tbl
+  )
+})


### PR DESCRIPTION
### Rationale for this change

New function in dplyr not yet implemented in Arrow

### What changes are included in this PR?

This PR adds support for dplyr::filter_out() in the Arrow R dplyr backend.

The implementation reuses the existing filter() machinery and extends
set_filters() with an `exclude` flag. When exclude = TRUE, the predicate
is transformed to match dplyr semantics (drop rows where predicate is TRUE,
keep rows where predicate is FALSE or NA).

Multiple filter_out() predicates are combined before exclusion so that
filter_out(a, b) matches dplyr semantics (i.e. drop rows where a & b is TRUE).

This works for arrow_table(), RecordBatchReader, and open_dataset(), and
preserves lazy evaluation for larger-than-memory datasets.

Tests are added to verify basic behavior, NA handling, and multiple predicates.

Note: local test run hits a with_language() locale issue ('.cache' not found),
which appears environment-specific and unrelated to these changes.

### Are these changes tested?

Yes

### Are there any user-facing changes?

Just the new function



* GitHub Issue: #49257
* GitHub Issue: #49186