### PR TITLE
GH-49233: [CI][Python] Update anaconda-client to 1.14.1 to support latest setuptools release

### DIFF
--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -134,7 +134,7 @@ env:
           echo "No wheel files found!"
           exit 1
       fi
-      python3 -m pip install git+https://github.com/Anaconda-Platform/anaconda-client.git@1.12.3
+      python3 -m pip install git+https://github.com/Anaconda-Platform/anaconda-client.git@1.14.1
       anaconda -t ${CROSSBOW_SCIENTIFIC_PYTHON_UPLOAD_TOKEN} upload --force -u scientific-python-nightly-wheels --label main {{ pattern }}
     env:
       CROSSBOW_SCIENTIFIC_PYTHON_UPLOAD_TOKEN: {{ '${{ secrets.CROSSBOW_SCIENTIFIC_PYTHON_UPLOAD_TOKEN }}' }}


### PR DESCRIPTION
### Rationale for this change

This PR aims to address #49233. Setuptools dropped support for `pkg_resources` in 82.0.0 this week which broke the nightly builds. The failing code is part of anaconda-client which is pinned to an older version (1.12.3). Newer releases (1.14.0+) have this issue fixed, so we'll bring the macro up to date with the latest release.

### What changes are included in this PR?

The anaconda-client git tag for installation is moved from 1.12.3 to 1.14.1.

### Are these changes tested?

I'm not sure what the best way to test this is. Presumably this can be tested with the Crossbow builds? I'm not sure if I can trigger those but let me know if there's anything on my side to help.

### Are there any user-facing changes?

No, this only affects build CI.
* GitHub Issue: #49233