### PR TITLE
GH-49263: [Python][CI] Install rust compiler for libcst only on Debian 32 bits

### DIFF
--- a/ci/docker/debian-13-cpp.dockerfile
+++ b/ci/docker/debian-13-cpp.dockerfile
@@ -87,7 +87,7 @@ RUN apt-get update -y -q && \
         python3-venv \
         rapidjson-dev \
         rsync \
-        rust \
+        rustc \
         tzdata \
         tzdata-legacy \
         zlib1g-dev && \

--- a/ci/docker/debian-13-cpp.dockerfile
+++ b/ci/docker/debian-13-cpp.dockerfile
@@ -89,6 +89,9 @@ RUN apt-get update -y -q && \
         tzdata \
         tzdata-legacy \
         zlib1g-dev && \
+    if [ ${arch} = "i386" ]; then \
+        apt-get install -y -q --no-install-recommends rustc cargo \
+    fi && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/ci/docker/debian-13-cpp.dockerfile
+++ b/ci/docker/debian-13-cpp.dockerfile
@@ -42,6 +42,7 @@ RUN apt-get update -y -q && \
     apt-get update -y -q && \
     apt-get install -y -q --no-install-recommends \
         autoconf \
+        cargo \
         ccache \
         clang-${llvm} \
         cmake \
@@ -85,13 +86,11 @@ RUN apt-get update -y -q && \
         python3-pip \
         python3-venv \
         rapidjson-dev \
+        rust \
         rsync \
         tzdata \
         tzdata-legacy \
         zlib1g-dev && \
-    if [ ${arch} = "i386" ]; then \
-        apt-get install -y -q --no-install-recommends rustc cargo; \
-    fi && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/ci/docker/debian-13-cpp.dockerfile
+++ b/ci/docker/debian-13-cpp.dockerfile
@@ -86,8 +86,8 @@ RUN apt-get update -y -q && \
         python3-pip \
         python3-venv \
         rapidjson-dev \
-        rust \
         rsync \
+        rust \
         tzdata \
         tzdata-legacy \
         zlib1g-dev && \

--- a/ci/docker/debian-13-cpp.dockerfile
+++ b/ci/docker/debian-13-cpp.dockerfile
@@ -90,7 +90,7 @@ RUN apt-get update -y -q && \
         tzdata-legacy \
         zlib1g-dev && \
     if [ ${arch} = "i386" ]; then \
-        apt-get install -y -q --no-install-recommends rustc cargo \
+        apt-get install -y -q --no-install-recommends rustc cargo; \
     fi && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
### Rationale for this change

In order to automate docstrings and build type hints we require libcst. libcst does not provide wheels for Debian 32 and we have to build from source distribution. In order to build from sdist we require a rust compiler available.

### What changes are included in this PR?

Install rust on Debian i386.

### Are these changes tested?

Yes via archery

### Are there any user-facing changes?
No

* GitHub Issue: #49263