### PR TITLE
GH-49268: [C++][FlightRPC] Fix ODBC tests for MacOS

### DIFF
--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -442,6 +442,9 @@ jobs:
           sudo sysctl -w kern.coredump=1
           sudo sysctl -w kern.corefile=/tmp/core.%N.%P
           ulimit -c unlimited  # must enable within the same shell
+          # Give CI write access for system DSN
+          sudo mkdir -p /Library/ODBC
+          sudo chown -R $USER /Library/ODBC
           ci/scripts/cpp_test.sh $(pwd) $(pwd)/build
 
   odbc-msvc:

--- a/ci/scripts/cpp_test.sh
+++ b/ci/scripts/cpp_test.sh
@@ -59,7 +59,6 @@ case "$(uname)" in
     ;;
   Darwin)
     n_jobs=$(sysctl -n hw.ncpu)
-    exclude_tests+=("arrow-flight-sql-odbc-test")
     # TODO: https://github.com/apache/arrow/issues/40410
     exclude_tests+=("arrow-s3fs-test")
     ;;

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/CMakeLists.txt
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/CMakeLists.txt
@@ -104,6 +104,8 @@ add_library(arrow_odbc_spi_impl STATIC
             spi/result_set.h
             spi/result_set_metadata.h
             spi/statement.h
+            system_dsn.cc
+            system_dsn.h
             system_trust_store.cc
             system_trust_store.h
             types.h
@@ -125,9 +127,7 @@ if(WIN32)
                          ui/dsn_configuration_window.h
                          ui/window.cc
                          ui/window.h
-                         win_system_dsn.cc
-                         system_dsn.cc
-                         system_dsn.h)
+                         win_system_dsn.cc)
 endif()
 
 if(APPLE)

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/odbc_statement.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/odbc_statement.cc
@@ -554,7 +554,7 @@ void ODBCStatement::SetStmtAttr(SQLINTEGER statement_attribute, SQLPOINTER value
   switch (statement_attribute) {
     case SQL_ATTR_APP_PARAM_DESC: {
       ODBCDescriptor* desc = static_cast<ODBCDescriptor*>(value);
-      if (current_apd_ != desc) {
+      if (desc && current_apd_ != desc) {
         if (current_apd_ != built_in_apd_.get()) {
           current_apd_->DetachFromStatement(this, true);
         }
@@ -567,7 +567,7 @@ void ODBCStatement::SetStmtAttr(SQLINTEGER statement_attribute, SQLPOINTER value
     }
     case SQL_ATTR_APP_ROW_DESC: {
       ODBCDescriptor* desc = static_cast<ODBCDescriptor*>(value);
-      if (current_ard_ != desc) {
+      if (desc && current_ard_ != desc) {
         if (current_ard_ != built_in_ard_.get()) {
           current_ard_->DetachFromStatement(this, false);
         }

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/system_dsn.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/system_dsn.cc
@@ -17,23 +17,19 @@
 
 #include "arrow/flight/sql/odbc/odbc_impl/system_dsn.h"
 
-#include "arrow/flight/sql/odbc/odbc_impl/config/configuration.h"
-#include "arrow/flight/sql/odbc/odbc_impl/flight_sql_connection.h"
-#include "arrow/flight/sql/odbc/odbc_impl/ui/dsn_configuration_window.h"
-#include "arrow/flight/sql/odbc/odbc_impl/ui/window.h"
-#include "arrow/flight/sql/odbc/odbc_impl/util.h"
 #include "arrow/result.h"
 #include "arrow/util/utf8.h"
 
-#include <odbcinst.h>
 #include <sstream>
 
 namespace arrow::flight::sql::odbc {
 
 using config::Configuration;
 
-void PostError(DWORD error_code, LPCWSTR error_msg) {
+void PostError(DWORD error_code, LPWSTR error_msg) {
+#if defined _WIN32
   MessageBox(NULL, error_msg, L"Error!", MB_ICONEXCLAMATION | MB_OK);
+#endif  // _WIN32
   SQLPostInstallerError(error_code, error_msg);
 }
 
@@ -42,7 +38,7 @@ void PostArrowUtilError(arrow::Status error_status) {
   std::wstring werror_msg = arrow::util::UTF8ToWideString(error_msg).ValueOr(
       L"Error during utf8 to wide string conversion");
 
-  PostError(ODBC_ERROR_GENERAL_ERR, werror_msg.c_str());
+  PostError(ODBC_ERROR_GENERAL_ERR, (LPWSTR)werror_msg.c_str());
 }
 
 void PostLastInstallerError() {
@@ -55,7 +51,7 @@ void PostLastInstallerError() {
   buf << L"Message: \"" << msg << L"\", Code: " << code;
   std::wstring error_msg = buf.str();
 
-  PostError(code, error_msg.c_str());
+  PostError(code, (LPWSTR)error_msg.c_str());
 }
 
 /**

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/system_dsn.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/system_dsn.cc
@@ -20,6 +20,7 @@
 #include "arrow/result.h"
 #include "arrow/util/utf8.h"
 
+#include <boost/algorithm/string/predicate.hpp>
 #include <sstream>
 
 namespace arrow::flight::sql::odbc {
@@ -38,7 +39,7 @@ void PostArrowUtilError(arrow::Status error_status) {
   std::wstring werror_msg = arrow::util::UTF8ToWideString(error_msg).ValueOr(
       L"Error during utf8 to wide string conversion");
 
-  PostError(ODBC_ERROR_GENERAL_ERR, (LPWSTR)werror_msg.c_str());
+  PostError(ODBC_ERROR_GENERAL_ERR, const_cast<LPWSTR>(werror_msg.c_str()));
 }
 
 void PostLastInstallerError() {
@@ -51,7 +52,7 @@ void PostLastInstallerError() {
   buf << L"Message: \"" << msg << L"\", Code: " << code;
   std::wstring error_msg = buf.str();
 
-  PostError(code, (LPWSTR)error_msg.c_str());
+  PostError(code, const_cast<LPWSTR>(error_msg.c_str()));
 }
 
 /**

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/system_dsn.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/system_dsn.h
@@ -19,7 +19,10 @@
 #include "arrow/flight/sql/odbc/odbc_impl/platform.h"
 
 #include "arrow/flight/sql/odbc/odbc_impl/config/configuration.h"
+#include "arrow/flight/sql/odbc/odbc_impl/flight_sql_connection.h"
 #include "arrow/status.h"
+
+#include <odbcinst.h>
 
 namespace arrow::flight::sql::odbc {
 
@@ -64,7 +67,7 @@ bool RegisterDsn(const config::Configuration& config, LPCWSTR driver);
  */
 bool UnregisterDsn(const std::wstring& dsn);
 
-void PostError(DWORD error_code, LPCWSTR error_msg);
+void PostError(DWORD error_code, LPWSTR error_msg);
 
 void PostArrowUtilError(arrow::Status error_status);
 }  // namespace arrow::flight::sql::odbc

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/win_system_dsn.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/win_system_dsn.cc
@@ -144,7 +144,7 @@ BOOL INSTAPI ConfigDSNW(HWND hwnd_parent, WORD req, LPCWSTR wdriver,
         std::wstring werror_msg =
             arrow::util::UTF8ToWideString(error_msg).ValueOr(L"Error during DSN load");
 
-        PostError(err.GetNativeError(), werror_msg.c_str());
+        PostError(err.GetNativeError(), (LPWSTR)werror_msg.c_str());
         return FALSE;
       }
 

--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/win_system_dsn.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/win_system_dsn.cc
@@ -144,7 +144,7 @@ BOOL INSTAPI ConfigDSNW(HWND hwnd_parent, WORD req, LPCWSTR wdriver,
         std::wstring werror_msg =
             arrow::util::UTF8ToWideString(error_msg).ValueOr(L"Error during DSN load");
 
-        PostError(err.GetNativeError(), (LPWSTR)werror_msg.c_str());
+        PostError(err.GetNativeError(), const_cast<LPWSTR>(werror_msg.c_str()));
         return FALSE;
       }
 

--- a/cpp/src/arrow/flight/sql/odbc/tests/CMakeLists.txt
+++ b/cpp/src/arrow/flight/sql/odbc/tests/CMakeLists.txt
@@ -50,7 +50,8 @@ else()
                                            ${ARROW_TEST_SHARED_LINK_LIBS})
 endif()
 
-set(ARROW_FLIGHT_SQL_ODBC_TEST_LIBS ${ODBC_LIBRARIES} ${ODBCINST} ${SQLite3_LIBRARIES})
+# On macOS, link `ODBCINST` first to ensure iodbc take precedence over unixodbc
+set(ARROW_FLIGHT_SQL_ODBC_TEST_LIBS ${ODBCINST} ${ODBC_LIBRARIES} ${SQLite3_LIBRARIES})
 
 # On Windows, dynamic linking ODBC is supported, tests link libraries dynamically.
 # On unix systems, static linking ODBC is supported, thus tests link libraries statically.

--- a/cpp/src/arrow/flight/sql/odbc/tests/columns_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/columns_test.cc
@@ -24,6 +24,8 @@
 
 #include <gtest/gtest.h>
 
+// Many tests are disabled for MacOS due to iODBC limitations.
+
 namespace arrow::flight::sql::odbc {
 
 template <typename T>
@@ -237,6 +239,7 @@ void CheckSQLColAttribute(SQLHSTMT stmt, SQLUSMALLINT idx,
   EXPECT_EQ(expected_unsigned_column, unsigned_col);
 }
 
+#ifndef __APPLE__
 void CheckSQLColAttributes(SQLHSTMT stmt, SQLUSMALLINT idx,
                            const std::wstring& expected_column_name,
                            SQLLEN expected_data_type, SQLLEN expected_display_size,
@@ -306,6 +309,7 @@ void CheckSQLColAttributes(SQLHSTMT stmt, SQLUSMALLINT idx,
   EXPECT_EQ(expected_searchable, searchable);
   EXPECT_EQ(expected_unsigned_column, unsigned_col);
 }
+#endif  // __APPLE__
 
 void GetSQLColAttributeString(SQLHSTMT stmt, const std::wstring& wsql, SQLUSMALLINT idx,
                               SQLUSMALLINT field_identifier, std::wstring& value) {
@@ -364,6 +368,7 @@ void GetSQLColAttributeNumeric(SQLHSTMT stmt, const std::wstring& wsql, SQLUSMAL
             SQLColAttribute(stmt, idx, field_identifier, 0, 0, nullptr, value));
 }
 
+#ifndef __APPLE__
 void GetSQLColAttributesNumeric(SQLHSTMT stmt, const std::wstring& wsql, SQLUSMALLINT idx,
                                 SQLUSMALLINT field_identifier, SQLLEN* value) {
   // Execute query and check SQLColAttribute numeric attribute
@@ -377,7 +382,7 @@ void GetSQLColAttributesNumeric(SQLHSTMT stmt, const std::wstring& wsql, SQLUSMA
   ASSERT_EQ(SQL_SUCCESS,
             SQLColAttributes(stmt, idx, field_identifier, 0, 0, nullptr, value));
 }
-
+#endif  // __APPLE__
 }  // namespace
 
 TYPED_TEST(ColumnsTest, SQLColumnsTestInputData) {
@@ -387,29 +392,28 @@ TYPED_TEST(ColumnsTest, SQLColumnsTestInputData) {
   SQLWCHAR column_name[] = L"";
 
   // All values populated
-  EXPECT_EQ(SQL_SUCCESS,
-            SQLColumns(this->stmt, catalog_name, sizeof(catalog_name), schema_name,
-                       sizeof(schema_name), table_name, sizeof(table_name), column_name,
-                       sizeof(column_name)));
-  ValidateFetch(this->stmt, SQL_NO_DATA);
+  EXPECT_EQ(SQL_SUCCESS, SQLColumns(stmt, catalog_name, sizeof(catalog_name), schema_name,
+                                    sizeof(schema_name), table_name, sizeof(table_name),
+                                    column_name, sizeof(column_name)));
+  ValidateFetch(stmt, SQL_NO_DATA);
 
   // Sizes are zeros
-  EXPECT_EQ(SQL_SUCCESS, SQLColumns(this->stmt, catalog_name, 0, schema_name, 0,
-                                    table_name, 0, column_name, 0));
-  ValidateFetch(this->stmt, SQL_NO_DATA);
+  EXPECT_EQ(SQL_SUCCESS, SQLColumns(stmt, catalog_name, 0, schema_name, 0, table_name, 0,
+                                    column_name, 0));
+  ValidateFetch(stmt, SQL_NO_DATA);
 
   // Names are nulls
-  EXPECT_EQ(SQL_SUCCESS, SQLColumns(this->stmt, nullptr, sizeof(catalog_name), nullptr,
-                                    sizeof(schema_name), nullptr, sizeof(table_name),
-                                    nullptr, sizeof(column_name)));
-  ValidateFetch(this->stmt, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS,
+            SQLColumns(stmt, nullptr, sizeof(catalog_name), nullptr, sizeof(schema_name),
+                       nullptr, sizeof(table_name), nullptr, sizeof(column_name)));
+  ValidateFetch(stmt, SQL_SUCCESS);
   // Close statement cursor to avoid leaving in an invalid state
-  SQLFreeStmt(this->stmt, SQL_CLOSE);
+  SQLFreeStmt(stmt, SQL_CLOSE);
 
   // Names are nulls and sizes are zeros
   EXPECT_EQ(SQL_SUCCESS,
-            SQLColumns(this->stmt, nullptr, 0, nullptr, 0, nullptr, 0, nullptr, 0));
-  ValidateFetch(this->stmt, SQL_SUCCESS);
+            SQLColumns(stmt, nullptr, 0, nullptr, 0, nullptr, 0, nullptr, 0));
+  ValidateFetch(stmt, SQL_SUCCESS);
 }
 
 TEST_F(ColumnsMockTest, TestSQLColumnsAllColumns) {
@@ -419,17 +423,17 @@ TEST_F(ColumnsMockTest, TestSQLColumnsAllColumns) {
   SQLWCHAR table_pattern[] = L"%";
   SQLWCHAR column_pattern[] = L"%";
 
-  ASSERT_EQ(SQL_SUCCESS, SQLColumns(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
+  ASSERT_EQ(SQL_SUCCESS, SQLColumns(stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
                                     table_pattern, SQL_NTS, column_pattern, SQL_NTS));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   // mock limitation: SQLite mock server returns 10 for bigint size when spec indicates
   // should be 19
   // DECIMAL_DIGITS should be 0 for bigint type since it is exact
   // mock limitation: SQLite mock server returns 10 for bigint decimal digits when spec
   // indicates should be 0
-  CheckMockSQLColumns(this->stmt,
+  CheckMockSQLColumns(stmt,
                       std::wstring(L"main"),          // expected_catalog
                       std::wstring(L"foreignTable"),  // expected_table
                       std::wstring(L"id"),            // expected_column
@@ -447,9 +451,9 @@ TEST_F(ColumnsMockTest, TestSQLColumnsAllColumns) {
                       std::wstring(L"YES"));  // expected_is_nullable
 
   // Check 2nd Column
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckMockSQLColumns(this->stmt,
+  CheckMockSQLColumns(stmt,
                       std::wstring(L"main"),          // expected_catalog
                       std::wstring(L"foreignTable"),  // expected_table
                       std::wstring(L"foreignName"),   // expected_column
@@ -468,9 +472,9 @@ TEST_F(ColumnsMockTest, TestSQLColumnsAllColumns) {
                       std::wstring(L"YES"));  // expected_is_nullable
 
   // Check 3rd Column
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckMockSQLColumns(this->stmt,
+  CheckMockSQLColumns(stmt,
                       std::wstring(L"main"),          // expected_catalog
                       std::wstring(L"foreignTable"),  // expected_table
                       std::wstring(L"value"),         // expected_column
@@ -488,9 +492,9 @@ TEST_F(ColumnsMockTest, TestSQLColumnsAllColumns) {
                       std::wstring(L"YES"));  // expected_is_nullable
 
   // Check 4th Column
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckMockSQLColumns(this->stmt,
+  CheckMockSQLColumns(stmt,
                       std::wstring(L"main"),      // expected_catalog
                       std::wstring(L"intTable"),  // expected_table
                       std::wstring(L"id"),        // expected_column
@@ -508,9 +512,9 @@ TEST_F(ColumnsMockTest, TestSQLColumnsAllColumns) {
                       std::wstring(L"YES"));  // expected_is_nullable
 
   // Check 5th Column
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckMockSQLColumns(this->stmt,
+  CheckMockSQLColumns(stmt,
                       std::wstring(L"main"),      // expected_catalog
                       std::wstring(L"intTable"),  // expected_table
                       std::wstring(L"keyName"),   // expected_column
@@ -529,9 +533,9 @@ TEST_F(ColumnsMockTest, TestSQLColumnsAllColumns) {
                       std::wstring(L"YES"));  // expected_is_nullable
 
   // Check 6th Column
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckMockSQLColumns(this->stmt,
+  CheckMockSQLColumns(stmt,
                       std::wstring(L"main"),      // expected_catalog
                       std::wstring(L"intTable"),  // expected_table
                       std::wstring(L"value"),     // expected_column
@@ -549,9 +553,9 @@ TEST_F(ColumnsMockTest, TestSQLColumnsAllColumns) {
                       std::wstring(L"YES"));  // expected_is_nullable
 
   // Check 7th Column
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckMockSQLColumns(this->stmt,
+  CheckMockSQLColumns(stmt,
                       std::wstring(L"main"),       // expected_catalog
                       std::wstring(L"intTable"),   // expected_table
                       std::wstring(L"foreignId"),  // expected_column
@@ -575,19 +579,19 @@ TEST_F(ColumnsMockTest, TestSQLColumnsAllTypes) {
   // octet length from column size.
 
   // Checks filtering table with table name pattern
-  this->CreateTableAllDataType();
+  CreateAllDataTypeTable();
 
   // Attempt to get all columns from AllTypesTable
   SQLWCHAR table_pattern[] = L"AllTypesTable";
   SQLWCHAR column_pattern[] = L"%";
 
-  ASSERT_EQ(SQL_SUCCESS, SQLColumns(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
+  ASSERT_EQ(SQL_SUCCESS, SQLColumns(stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
                                     table_pattern, SQL_NTS, column_pattern, SQL_NTS));
 
   // Fetch SQLColumn data for 1st column in AllTypesTable
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckMockSQLColumns(this->stmt,
+  CheckMockSQLColumns(stmt,
                       std::wstring(L"main"),           // expected_catalog
                       std::wstring(L"AllTypesTable"),  // expected_table
                       std::wstring(L"bigint_col"),     // expected_column
@@ -607,9 +611,9 @@ TEST_F(ColumnsMockTest, TestSQLColumnsAllTypes) {
                       std::wstring(L"YES"));  // expected_is_nullable
 
   // Check SQLColumn data for 2nd column in AllTypesTable
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckMockSQLColumns(this->stmt,
+  CheckMockSQLColumns(stmt,
                       std::wstring(L"main"),           // expected_catalog
                       std::wstring(L"AllTypesTable"),  // expected_table
                       std::wstring(L"char_col"),       // expected_column
@@ -628,9 +632,9 @@ TEST_F(ColumnsMockTest, TestSQLColumnsAllTypes) {
                       std::wstring(L"YES"));  // expected_is_nullable
 
   // Check SQLColumn data for 3rd column in AllTypesTable
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckMockSQLColumns(this->stmt,
+  CheckMockSQLColumns(stmt,
                       std::wstring(L"main"),           // expected_catalog
                       std::wstring(L"AllTypesTable"),  // expected_table
                       std::wstring(L"varbinary_col"),  // expected_column
@@ -649,9 +653,9 @@ TEST_F(ColumnsMockTest, TestSQLColumnsAllTypes) {
                       std::wstring(L"YES"));  // expected_is_nullable
 
   // Check SQLColumn data for 4th column in AllTypesTable
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckMockSQLColumns(this->stmt,
+  CheckMockSQLColumns(stmt,
                       std::wstring(L"main"),           // expected_catalog
                       std::wstring(L"AllTypesTable"),  // expected_table
                       std::wstring(L"double_col"),     // expected_column
@@ -669,26 +673,28 @@ TEST_F(ColumnsMockTest, TestSQLColumnsAllTypes) {
                       std::wstring(L"YES"));           // expected_is_nullable
 
   // There should be no more column data
-  ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_NO_DATA, SQLFetch(stmt));
+
+  DropAllDataTypeTable();
 }
 
 TEST_F(ColumnsMockTest, TestSQLColumnsUnicode) {
   // Limitation: Mock server returns incorrect values for column size for some columns.
   // For character and binary type columns, the driver calculates buffer length and char
   // octet length from column size.
-  this->CreateUnicodeTable();
+  CreateUnicodeTable();
 
   // Attempt to get all columns
   SQLWCHAR table_pattern[] = L"数据";
   SQLWCHAR column_pattern[] = L"%";
 
-  ASSERT_EQ(SQL_SUCCESS, SQLColumns(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
+  ASSERT_EQ(SQL_SUCCESS, SQLColumns(stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
                                     table_pattern, SQL_NTS, column_pattern, SQL_NTS));
 
   // Check SQLColumn data for 1st column
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckMockSQLColumns(this->stmt,
+  CheckMockSQLColumns(stmt,
                       std::wstring(L"main"),      // expected_catalog
                       std::wstring(L"数据"),      // expected_table
                       std::wstring(L"资料"),      // expected_column
@@ -707,7 +713,9 @@ TEST_F(ColumnsMockTest, TestSQLColumnsUnicode) {
                       std::wstring(L"YES"));  // expected_is_nullable
 
   // There should be no more column data
-  EXPECT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
+  EXPECT_EQ(SQL_NO_DATA, SQLFetch(stmt));
+
+  DropUnicodeTable();
 }
 
 TEST_F(ColumnsRemoteTest, TestSQLColumnsAllTypes) {
@@ -717,14 +725,14 @@ TEST_F(ColumnsRemoteTest, TestSQLColumnsAllTypes) {
   SQLWCHAR table_pattern[] = L"ODBCTest";
   SQLWCHAR column_pattern[] = L"%";
 
-  ASSERT_EQ(SQL_SUCCESS, SQLColumns(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
+  ASSERT_EQ(SQL_SUCCESS, SQLColumns(stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
                                     table_pattern, SQL_NTS, column_pattern, SQL_NTS));
 
   // Check 1st Column
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   CheckRemoteSQLColumns(
-      this->stmt,
+      stmt,
       std::wstring(L"$scratch"),      // expected_schema
       std::wstring(L"ODBCTest"),      // expected_table
       std::wstring(L"sinteger_max"),  // expected_column
@@ -742,10 +750,10 @@ TEST_F(ColumnsRemoteTest, TestSQLColumnsAllTypes) {
       std::wstring(L"YES"));  // expected_is_nullable
 
   // Check 2nd Column
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   CheckRemoteSQLColumns(
-      this->stmt,
+      stmt,
       std::wstring(L"$scratch"),     // expected_schema
       std::wstring(L"ODBCTest"),     // expected_table
       std::wstring(L"sbigint_max"),  // expected_column
@@ -763,9 +771,9 @@ TEST_F(ColumnsRemoteTest, TestSQLColumnsAllTypes) {
       std::wstring(L"YES"));  // expected_is_nullable
 
   // Check 3rd Column
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckRemoteSQLColumns(this->stmt,
+  CheckRemoteSQLColumns(stmt,
                         std::wstring(L"$scratch"),          // expected_schema
                         std::wstring(L"ODBCTest"),          // expected_table
                         std::wstring(L"decimal_positive"),  // expected_column
@@ -783,9 +791,9 @@ TEST_F(ColumnsRemoteTest, TestSQLColumnsAllTypes) {
                         std::wstring(L"YES"));              // expected_is_nullable
 
   // Check 4th Column
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckRemoteSQLColumns(this->stmt,
+  CheckRemoteSQLColumns(stmt,
                         std::wstring(L"$scratch"),   // expected_schema
                         std::wstring(L"ODBCTest"),   // expected_table
                         std::wstring(L"float_max"),  // expected_column
@@ -803,9 +811,9 @@ TEST_F(ColumnsRemoteTest, TestSQLColumnsAllTypes) {
                         std::wstring(L"YES"));  // expected_is_nullable
 
   // Check 5th Column
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckRemoteSQLColumns(this->stmt,
+  CheckRemoteSQLColumns(stmt,
                         std::wstring(L"$scratch"),    // expected_schema
                         std::wstring(L"ODBCTest"),    // expected_table
                         std::wstring(L"double_max"),  // expected_column
@@ -823,9 +831,9 @@ TEST_F(ColumnsRemoteTest, TestSQLColumnsAllTypes) {
                         std::wstring(L"YES"));  // expected_is_nullable
 
   // Check 6th Column
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckRemoteSQLColumns(this->stmt,
+  CheckRemoteSQLColumns(stmt,
                         std::wstring(L"$scratch"),  // expected_schema
                         std::wstring(L"ODBCTest"),  // expected_table
                         std::wstring(L"bit_true"),  // expected_column
@@ -847,10 +855,10 @@ TEST_F(ColumnsRemoteTest, TestSQLColumnsAllTypes) {
   // DATA_TYPE field
 
   // Check 7th Column
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   CheckRemoteSQLColumns(
-      this->stmt,
+      stmt,
       std::wstring(L"$scratch"),  // expected_schema
       std::wstring(L"ODBCTest"),  // expected_table
       std::wstring(L"date_max"),  // expected_column
@@ -868,10 +876,10 @@ TEST_F(ColumnsRemoteTest, TestSQLColumnsAllTypes) {
       std::wstring(L"YES"));  // expected_is_nullable
 
   // Check 8th Column
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   CheckRemoteSQLColumns(
-      this->stmt,
+      stmt,
       std::wstring(L"$scratch"),  // expected_schema
       std::wstring(L"ODBCTest"),  // expected_table
       std::wstring(L"time_max"),  // expected_column
@@ -889,10 +897,10 @@ TEST_F(ColumnsRemoteTest, TestSQLColumnsAllTypes) {
       std::wstring(L"YES"));  // expected_is_nullable
 
   // Check 9th Column
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   CheckRemoteSQLColumns(
-      this->stmt,
+      stmt,
       std::wstring(L"$scratch"),       // expected_schema
       std::wstring(L"ODBCTest"),       // expected_table
       std::wstring(L"timestamp_max"),  // expected_column
@@ -910,7 +918,7 @@ TEST_F(ColumnsRemoteTest, TestSQLColumnsAllTypes) {
       std::wstring(L"YES"));  // expected_is_nullable
 
   // There is no more column
-  EXPECT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
+  EXPECT_EQ(SQL_NO_DATA, SQLFetch(stmt));
 }
 
 TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColumnsAllTypesODBCVer2) {
@@ -920,14 +928,14 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColumnsAllTypesODBCVer2) {
   SQLWCHAR table_pattern[] = L"ODBCTest";
   SQLWCHAR column_pattern[] = L"%";
 
-  ASSERT_EQ(SQL_SUCCESS, SQLColumns(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
+  ASSERT_EQ(SQL_SUCCESS, SQLColumns(stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
                                     table_pattern, SQL_NTS, column_pattern, SQL_NTS));
 
   // Check 1st Column
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   CheckRemoteSQLColumns(
-      this->stmt,
+      stmt,
       std::wstring(L"$scratch"),      // expected_schema
       std::wstring(L"ODBCTest"),      // expected_table
       std::wstring(L"sinteger_max"),  // expected_column
@@ -945,10 +953,10 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColumnsAllTypesODBCVer2) {
       std::wstring(L"YES"));  // expected_is_nullable
 
   // Check 2nd Column
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   CheckRemoteSQLColumns(
-      this->stmt,
+      stmt,
       std::wstring(L"$scratch"),     // expected_schema
       std::wstring(L"ODBCTest"),     // expected_table
       std::wstring(L"sbigint_max"),  // expected_column
@@ -966,9 +974,9 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColumnsAllTypesODBCVer2) {
       std::wstring(L"YES"));  // expected_is_nullable
 
   // Check 3rd Column
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckRemoteSQLColumns(this->stmt,
+  CheckRemoteSQLColumns(stmt,
                         std::wstring(L"$scratch"),          // expected_schema
                         std::wstring(L"ODBCTest"),          // expected_table
                         std::wstring(L"decimal_positive"),  // expected_column
@@ -986,9 +994,9 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColumnsAllTypesODBCVer2) {
                         std::wstring(L"YES"));              // expected_is_nullable
 
   // Check 4th Column
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckRemoteSQLColumns(this->stmt,
+  CheckRemoteSQLColumns(stmt,
                         std::wstring(L"$scratch"),   // expected_schema
                         std::wstring(L"ODBCTest"),   // expected_table
                         std::wstring(L"float_max"),  // expected_column
@@ -1006,9 +1014,9 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColumnsAllTypesODBCVer2) {
                         std::wstring(L"YES"));  // expected_is_nullable
 
   // Check 5th Column
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckRemoteSQLColumns(this->stmt,
+  CheckRemoteSQLColumns(stmt,
                         std::wstring(L"$scratch"),    // expected_schema
                         std::wstring(L"ODBCTest"),    // expected_table
                         std::wstring(L"double_max"),  // expected_column
@@ -1026,9 +1034,9 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColumnsAllTypesODBCVer2) {
                         std::wstring(L"YES"));  // expected_is_nullable
 
   // Check 6th Column
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckRemoteSQLColumns(this->stmt,
+  CheckRemoteSQLColumns(stmt,
                         std::wstring(L"$scratch"),  // expected_schema
                         std::wstring(L"ODBCTest"),  // expected_table
                         std::wstring(L"bit_true"),  // expected_column
@@ -1049,10 +1057,10 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColumnsAllTypesODBCVer2) {
   // ODBC ver 2 returns SQL_DATE, SQL_TIME, and SQL_TIMESTAMP in the DATA_TYPE field
 
   // Check 7th Column
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   CheckRemoteSQLColumns(
-      this->stmt,
+      stmt,
       std::wstring(L"$scratch"),  // expected_schema
       std::wstring(L"ODBCTest"),  // expected_table
       std::wstring(L"date_max"),  // expected_column
@@ -1070,10 +1078,10 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColumnsAllTypesODBCVer2) {
       std::wstring(L"YES"));  // expected_is_nullable
 
   // Check 8th Column
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   CheckRemoteSQLColumns(
-      this->stmt,
+      stmt,
       std::wstring(L"$scratch"),  // expected_schema
       std::wstring(L"ODBCTest"),  // expected_table
       std::wstring(L"time_max"),  // expected_column
@@ -1091,10 +1099,10 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColumnsAllTypesODBCVer2) {
       std::wstring(L"YES"));  // expected_is_nullable
 
   // Check 9th Column
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   CheckRemoteSQLColumns(
-      this->stmt,
+      stmt,
       std::wstring(L"$scratch"),       // expected_schema
       std::wstring(L"ODBCTest"),       // expected_table
       std::wstring(L"timestamp_max"),  // expected_column
@@ -1112,7 +1120,7 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColumnsAllTypesODBCVer2) {
       std::wstring(L"YES"));  // expected_is_nullable
 
   // There is no more column
-  EXPECT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
+  EXPECT_EQ(SQL_NO_DATA, SQLFetch(stmt));
 }
 
 TEST_F(ColumnsMockTest, TestSQLColumnsColumnPattern) {
@@ -1122,13 +1130,13 @@ TEST_F(ColumnsMockTest, TestSQLColumnsColumnPattern) {
   SQLWCHAR table_pattern[] = L"%";
   SQLWCHAR column_pattern[] = L"id";
 
-  EXPECT_EQ(SQL_SUCCESS, SQLColumns(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
+  EXPECT_EQ(SQL_SUCCESS, SQLColumns(stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
                                     table_pattern, SQL_NTS, column_pattern, SQL_NTS));
 
   // Check 1st Column
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckMockSQLColumns(this->stmt,
+  CheckMockSQLColumns(stmt,
                       std::wstring(L"main"),          // expected_catalog
                       std::wstring(L"foreignTable"),  // expected_table
                       std::wstring(L"id"),            // expected_column
@@ -1146,9 +1154,9 @@ TEST_F(ColumnsMockTest, TestSQLColumnsColumnPattern) {
                       std::wstring(L"YES"));  // expected_is_nullable
 
   // Check 2nd Column
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckMockSQLColumns(this->stmt,
+  CheckMockSQLColumns(stmt,
                       std::wstring(L"main"),      // expected_catalog
                       std::wstring(L"intTable"),  // expected_table
                       std::wstring(L"id"),        // expected_column
@@ -1166,7 +1174,7 @@ TEST_F(ColumnsMockTest, TestSQLColumnsColumnPattern) {
                       std::wstring(L"YES"));  // expected_is_nullable
 
   // There is no more column
-  EXPECT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
+  EXPECT_EQ(SQL_NO_DATA, SQLFetch(stmt));
 }
 
 TEST_F(ColumnsMockTest, TestSQLColumnsTableColumnPattern) {
@@ -1176,13 +1184,13 @@ TEST_F(ColumnsMockTest, TestSQLColumnsTableColumnPattern) {
   SQLWCHAR table_pattern[] = L"foreignTable";
   SQLWCHAR column_pattern[] = L"id";
 
-  ASSERT_EQ(SQL_SUCCESS, SQLColumns(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
+  ASSERT_EQ(SQL_SUCCESS, SQLColumns(stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
                                     table_pattern, SQL_NTS, column_pattern, SQL_NTS));
 
   // Check 1st Column
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckMockSQLColumns(this->stmt,
+  CheckMockSQLColumns(stmt,
                       std::wstring(L"main"),          // expected_catalog
                       std::wstring(L"foreignTable"),  // expected_table
                       std::wstring(L"id"),            // expected_column
@@ -1200,18 +1208,18 @@ TEST_F(ColumnsMockTest, TestSQLColumnsTableColumnPattern) {
                       std::wstring(L"YES"));  // expected_is_nullable
 
   // There is no more column
-  EXPECT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
+  EXPECT_EQ(SQL_NO_DATA, SQLFetch(stmt));
 }
 
 TEST_F(ColumnsMockTest, TestSQLColumnsInvalidTablePattern) {
   SQLWCHAR table_pattern[] = L"non-existent-table";
   SQLWCHAR column_pattern[] = L"%";
 
-  ASSERT_EQ(SQL_SUCCESS, SQLColumns(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
+  ASSERT_EQ(SQL_SUCCESS, SQLColumns(stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
                                     table_pattern, SQL_NTS, column_pattern, SQL_NTS));
 
   // There is no column from filter
-  EXPECT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
+  EXPECT_EQ(SQL_NO_DATA, SQLFetch(stmt));
 }
 
 TYPED_TEST(ColumnsTest, SQLColAttributeTestInputData) {
@@ -1219,9 +1227,10 @@ TYPED_TEST(ColumnsTest, SQLColAttributeTestInputData) {
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())))
+      << GetOdbcErrorMessage(SQL_HANDLE_DBC, conn);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   SQLUSMALLINT idx = 1;
   std::vector<SQLWCHAR> character_attr(kOdbcBufferSize);
@@ -1229,21 +1238,20 @@ TYPED_TEST(ColumnsTest, SQLColAttributeTestInputData) {
   SQLLEN numeric_attr = 0;
 
   // All character values populated
-  EXPECT_EQ(
-      SQL_SUCCESS,
-      SQLColAttribute(this->stmt, idx, SQL_DESC_NAME, &character_attr[0],
-                      (SQLSMALLINT)character_attr.size(), &character_attr_len, nullptr));
+  EXPECT_EQ(SQL_SUCCESS, SQLColAttribute(stmt, idx, SQL_DESC_NAME, &character_attr[0],
+                                         (SQLSMALLINT)character_attr.size(),
+                                         &character_attr_len, nullptr));
 
   // All numeric values populated
-  EXPECT_EQ(SQL_SUCCESS, SQLColAttribute(this->stmt, idx, SQL_DESC_COUNT, 0, 0, nullptr,
-                                         &numeric_attr));
+  EXPECT_EQ(SQL_SUCCESS,
+            SQLColAttribute(stmt, idx, SQL_DESC_COUNT, 0, 0, nullptr, &numeric_attr));
 
   // Pass null values, driver should not throw error
-  EXPECT_EQ(SQL_SUCCESS, SQLColAttribute(this->stmt, idx, SQL_COLUMN_TABLE_NAME, 0, 0,
-                                         nullptr, nullptr));
+  EXPECT_EQ(SQL_SUCCESS,
+            SQLColAttribute(stmt, idx, SQL_COLUMN_TABLE_NAME, 0, 0, nullptr, nullptr));
 
   EXPECT_EQ(SQL_SUCCESS,
-            SQLColAttribute(this->stmt, idx, SQL_DESC_COUNT, 0, 0, nullptr, nullptr));
+            SQLColAttribute(stmt, idx, SQL_DESC_COUNT, 0, 0, nullptr, nullptr));
 }
 
 TYPED_TEST(ColumnsTest, SQLColAttributeGetCharacterLen) {
@@ -1251,14 +1259,14 @@ TYPED_TEST(ColumnsTest, SQLColAttributeGetCharacterLen) {
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   SQLSMALLINT character_attr_len = 0;
 
   // Check length of character attribute
-  ASSERT_EQ(SQL_SUCCESS, SQLColAttribute(this->stmt, 1, SQL_DESC_BASE_COLUMN_NAME, 0, 0,
+  ASSERT_EQ(SQL_SUCCESS, SQLColAttribute(stmt, 1, SQL_DESC_BASE_COLUMN_NAME, 0, 0,
                                          &character_attr_len, nullptr));
   EXPECT_EQ(4 * GetSqlWCharSize(), character_attr_len);
 }
@@ -1268,9 +1276,9 @@ TYPED_TEST(ColumnsTest, SQLColAttributeInvalidFieldId) {
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   SQLUSMALLINT invalid_field_id = -100;
   SQLUSMALLINT idx = 1;
@@ -1278,12 +1286,11 @@ TYPED_TEST(ColumnsTest, SQLColAttributeInvalidFieldId) {
   SQLSMALLINT character_attr_len = 0;
   SQLLEN numeric_attr = 0;
 
-  ASSERT_EQ(
-      SQL_ERROR,
-      SQLColAttribute(this->stmt, idx, invalid_field_id, &character_attr[0],
-                      (SQLSMALLINT)character_attr.size(), &character_attr_len, nullptr));
+  ASSERT_EQ(SQL_ERROR, SQLColAttribute(stmt, idx, invalid_field_id, &character_attr[0],
+                                       (SQLSMALLINT)character_attr.size(),
+                                       &character_attr_len, nullptr));
   // Verify invalid descriptor field identifier error state is returned
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorStateHY091);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorStateHY091);
 }
 
 TYPED_TEST(ColumnsTest, SQLColAttributeInvalidColId) {
@@ -1291,34 +1298,34 @@ TYPED_TEST(ColumnsTest, SQLColAttributeInvalidColId) {
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   SQLUSMALLINT invalid_col_id = 2;
   std::vector<SQLWCHAR> character_attr(kOdbcBufferSize);
   SQLSMALLINT character_attr_len = 0;
 
-  ASSERT_EQ(SQL_ERROR,
-            SQLColAttribute(this->stmt, invalid_col_id, SQL_DESC_BASE_COLUMN_NAME,
-                            &character_attr[0], (SQLSMALLINT)character_attr.size(),
-                            &character_attr_len, nullptr));
+  ASSERT_EQ(
+      SQL_ERROR,
+      SQLColAttribute(stmt, invalid_col_id, SQL_DESC_BASE_COLUMN_NAME, &character_attr[0],
+                      (SQLSMALLINT)character_attr.size(), &character_attr_len, nullptr));
   // Verify invalid descriptor index error state is returned
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorState07009);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorState07009);
 }
 
 TEST_F(ColumnsMockTest, TestSQLColAttributeAllTypes) {
-  this->CreateTableAllDataType();
+  CreateAllDataTypeTable();
 
   std::wstring wsql = L"SELECT * from AllTypesTable;";
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckSQLColAttribute(this->stmt, 1,
+  CheckSQLColAttribute(stmt, 1,
                        std::wstring(L"bigint_col"),  // expected_column_name
                        SQL_BIGINT,                   // expected_data_type
                        SQL_BIGINT,                   // expected_concise_type
@@ -1335,7 +1342,7 @@ TEST_F(ColumnsMockTest, TestSQLColAttributeAllTypes) {
                        SQL_PRED_NONE,                // expected_searchable
                        SQL_FALSE);                   // expected_unsigned_column
 
-  CheckSQLColAttribute(this->stmt, 2,
+  CheckSQLColAttribute(stmt, 2,
                        std::wstring(L"char_col"),  // expected_column_name
                        SQL_WVARCHAR,               // expected_data_type
                        SQL_WVARCHAR,               // expected_concise_type
@@ -1352,7 +1359,7 @@ TEST_F(ColumnsMockTest, TestSQLColAttributeAllTypes) {
                        SQL_PRED_NONE,              // expected_searchable
                        SQL_TRUE);                  // expected_unsigned_column
 
-  CheckSQLColAttribute(this->stmt, 3,
+  CheckSQLColAttribute(stmt, 3,
                        std::wstring(L"varbinary_col"),  // expected_column_name
                        SQL_BINARY,                      // expected_data_type
                        SQL_BINARY,                      // expected_concise_type
@@ -1369,7 +1376,7 @@ TEST_F(ColumnsMockTest, TestSQLColAttributeAllTypes) {
                        SQL_PRED_NONE,                   // expected_searchable
                        SQL_TRUE);                       // expected_unsigned_column
 
-  CheckSQLColAttribute(this->stmt, 4,
+  CheckSQLColAttribute(stmt, 4,
                        std::wstring(L"double_col"),  // expected_column_name
                        SQL_DOUBLE,                   // expected_data_type
                        SQL_DOUBLE,                   // expected_concise_type
@@ -1385,20 +1392,24 @@ TEST_F(ColumnsMockTest, TestSQLColAttributeAllTypes) {
                        8,                            // expected_octet_length
                        SQL_PRED_NONE,                // expected_searchable
                        SQL_FALSE);                   // expected_unsigned_column
+
+  DropAllDataTypeTable();
 }
 
-TEST_F(ColumnsOdbcV2MockTest, TestSQLColAttributesAllTypesODBCVer2) {
+// iODBC does not support SQLColAttributes for ODBC 3.0 attributes.
+#ifndef __APPLE__
+TEST_F(ColumnsOdbcV2MockTest, TestSQLColAttributesAllTypes) {
   // Tests ODBC 2.0 API SQLColAttributes
-  this->CreateTableAllDataType();
+  CreateAllDataTypeTable();
 
   std::wstring wsql = L"SELECT * from AllTypesTable;";
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
-  CheckSQLColAttributes(this->stmt, 1,
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  CheckSQLColAttributes(stmt, 1,
                         std::wstring(L"bigint_col"),  // expected_column_name
                         SQL_BIGINT,                   // expected_data_type
                         20,                           // expected_display_size
@@ -1410,7 +1421,7 @@ TEST_F(ColumnsOdbcV2MockTest, TestSQLColAttributesAllTypesODBCVer2) {
                         SQL_PRED_NONE,                // expected_searchable
                         SQL_FALSE);                   // expected_unsigned_column
 
-  CheckSQLColAttributes(this->stmt, 2,
+  CheckSQLColAttributes(stmt, 2,
                         std::wstring(L"char_col"),  // expected_column_name
                         SQL_WVARCHAR,               // expected_data_type
                         0,                          // expected_display_size
@@ -1422,7 +1433,7 @@ TEST_F(ColumnsOdbcV2MockTest, TestSQLColAttributesAllTypesODBCVer2) {
                         SQL_PRED_NONE,              // expected_searchable
                         SQL_TRUE);                  // expected_unsigned_column
 
-  CheckSQLColAttributes(this->stmt, 3,
+  CheckSQLColAttributes(stmt, 3,
                         std::wstring(L"varbinary_col"),  // expected_column_name
                         SQL_BINARY,                      // expected_data_type
                         0,                               // expected_display_size
@@ -1434,7 +1445,7 @@ TEST_F(ColumnsOdbcV2MockTest, TestSQLColAttributesAllTypesODBCVer2) {
                         SQL_PRED_NONE,                   // expected_searchable
                         SQL_TRUE);                       // expected_unsigned_column
 
-  CheckSQLColAttributes(this->stmt, 4,
+  CheckSQLColAttributes(stmt, 4,
                         std::wstring(L"double_col"),  // expected_column_name
                         SQL_DOUBLE,                   // expected_data_type
                         24,                           // expected_display_size
@@ -1445,7 +1456,10 @@ TEST_F(ColumnsOdbcV2MockTest, TestSQLColAttributesAllTypesODBCVer2) {
                         SQL_NULLABLE,                 // expected_column_nullability
                         SQL_PRED_NONE,                // expected_searchable
                         SQL_FALSE);                   // expected_unsigned_column
+
+  DropAllDataTypeTable();
 }
+#endif  // __APPLE__
 
 TEST_F(ColumnsRemoteTest, TestSQLColAttributeAllTypes) {
   // Test assumes there is a table $scratch.ODBCTest in remote server
@@ -1454,11 +1468,11 @@ TEST_F(ColumnsRemoteTest, TestSQLColAttributeAllTypes) {
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckSQLColAttribute(this->stmt, 1,
+  CheckSQLColAttribute(stmt, 1,
                        std::wstring(L"sinteger_max"),  // expected_column_name
                        SQL_INTEGER,                    // expected_data_type
                        SQL_INTEGER,                    // expected_concise_type
@@ -1475,7 +1489,7 @@ TEST_F(ColumnsRemoteTest, TestSQLColAttributeAllTypes) {
                        SQL_SEARCHABLE,                 // expected_searchable
                        SQL_FALSE);                     // expected_unsigned_column
 
-  CheckSQLColAttribute(this->stmt, 2,
+  CheckSQLColAttribute(stmt, 2,
                        std::wstring(L"sbigint_max"),  // expected_column_name
                        SQL_BIGINT,                    // expected_data_type
                        SQL_BIGINT,                    // expected_concise_type
@@ -1492,7 +1506,7 @@ TEST_F(ColumnsRemoteTest, TestSQLColAttributeAllTypes) {
                        SQL_SEARCHABLE,                // expected_searchable
                        SQL_FALSE);                    // expected_unsigned_column
 
-  CheckSQLColAttribute(this->stmt, 3,
+  CheckSQLColAttribute(stmt, 3,
                        std::wstring(L"decimal_positive"),  // expected_column_name
                        SQL_DECIMAL,                        // expected_data_type
                        SQL_DECIMAL,                        // expected_concise_type
@@ -1509,7 +1523,7 @@ TEST_F(ColumnsRemoteTest, TestSQLColAttributeAllTypes) {
                        SQL_SEARCHABLE,                     // expected_searchable
                        SQL_FALSE);                         // expected_unsigned_column
 
-  CheckSQLColAttribute(this->stmt, 4,
+  CheckSQLColAttribute(stmt, 4,
                        std::wstring(L"float_max"),  // expected_column_name
                        SQL_FLOAT,                   // expected_data_type
                        SQL_FLOAT,                   // expected_concise_type
@@ -1526,7 +1540,7 @@ TEST_F(ColumnsRemoteTest, TestSQLColAttributeAllTypes) {
                        SQL_SEARCHABLE,              // expected_searchable
                        SQL_FALSE);                  // expected_unsigned_column
 
-  CheckSQLColAttribute(this->stmt, 5,
+  CheckSQLColAttribute(stmt, 5,
                        std::wstring(L"double_max"),  // expected_column_name
                        SQL_DOUBLE,                   // expected_data_type
                        SQL_DOUBLE,                   // expected_concise_type
@@ -1543,7 +1557,7 @@ TEST_F(ColumnsRemoteTest, TestSQLColAttributeAllTypes) {
                        SQL_SEARCHABLE,               // expected_searchable
                        SQL_FALSE);                   // expected_unsigned_column
 
-  CheckSQLColAttribute(this->stmt, 6,
+  CheckSQLColAttribute(stmt, 6,
                        std::wstring(L"bit_true"),  // expected_column_name
                        SQL_BIT,                    // expected_data_type
                        SQL_BIT,                    // expected_concise_type
@@ -1560,7 +1574,7 @@ TEST_F(ColumnsRemoteTest, TestSQLColAttributeAllTypes) {
                        SQL_SEARCHABLE,             // expected_searchable
                        SQL_TRUE);                  // expected_unsigned_column
 
-  CheckSQLColAttribute(this->stmt, 7,
+  CheckSQLColAttribute(stmt, 7,
                        std::wstring(L"date_max"),  // expected_column_name
                        SQL_DATETIME,               // expected_data_type
                        SQL_TYPE_DATE,              // expected_concise_type
@@ -1577,7 +1591,7 @@ TEST_F(ColumnsRemoteTest, TestSQLColAttributeAllTypes) {
                        SQL_SEARCHABLE,             // expected_searchable
                        SQL_TRUE);                  // expected_unsigned_column
 
-  CheckSQLColAttribute(this->stmt, 8,
+  CheckSQLColAttribute(stmt, 8,
                        std::wstring(L"time_max"),  // expected_column_name
                        SQL_DATETIME,               // expected_data_type
                        SQL_TYPE_TIME,              // expected_concise_type
@@ -1594,7 +1608,7 @@ TEST_F(ColumnsRemoteTest, TestSQLColAttributeAllTypes) {
                        SQL_SEARCHABLE,             // expected_searchable
                        SQL_TRUE);                  // expected_unsigned_column
 
-  CheckSQLColAttribute(this->stmt, 9,
+  CheckSQLColAttribute(stmt, 9,
                        std::wstring(L"timestamp_max"),  // expected_column_name
                        SQL_DATETIME,                    // expected_data_type
                        SQL_TYPE_TIMESTAMP,              // expected_concise_type
@@ -1612,17 +1626,19 @@ TEST_F(ColumnsRemoteTest, TestSQLColAttributeAllTypes) {
                        SQL_TRUE);                       // expected_unsigned_column
 }
 
-TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColAttributeAllTypesODBCVer2) {
+// iODBC does not support SQLColAttribute in ODBC 2.0 mode.
+#ifndef __APPLE__
+TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColAttributeAllTypes) {
   // Test assumes there is a table $scratch.ODBCTest in remote server
   std::wstring wsql = L"SELECT * from $scratch.ODBCTest;";
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckSQLColAttribute(this->stmt, 1,
+  CheckSQLColAttribute(stmt, 1,
                        std::wstring(L"sinteger_max"),  // expected_column_name
                        SQL_INTEGER,                    // expected_data_type
                        SQL_INTEGER,                    // expected_concise_type
@@ -1639,7 +1655,7 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColAttributeAllTypesODBCVer2) {
                        SQL_SEARCHABLE,                 // expected_searchable
                        SQL_FALSE);                     // expected_unsigned_column
 
-  CheckSQLColAttribute(this->stmt, 2,
+  CheckSQLColAttribute(stmt, 2,
                        std::wstring(L"sbigint_max"),  // expected_column_name
                        SQL_BIGINT,                    // expected_data_type
                        SQL_BIGINT,                    // expected_concise_type
@@ -1656,7 +1672,7 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColAttributeAllTypesODBCVer2) {
                        SQL_SEARCHABLE,                // expected_searchable
                        SQL_FALSE);                    // expected_unsigned_column
 
-  CheckSQLColAttribute(this->stmt, 3,
+  CheckSQLColAttribute(stmt, 3,
                        std::wstring(L"decimal_positive"),  // expected_column_name
                        SQL_DECIMAL,                        // expected_data_type
                        SQL_DECIMAL,                        // expected_concise_type
@@ -1673,7 +1689,7 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColAttributeAllTypesODBCVer2) {
                        SQL_SEARCHABLE,                     // expected_searchable
                        SQL_FALSE);                         // expected_unsigned_column
 
-  CheckSQLColAttribute(this->stmt, 4,
+  CheckSQLColAttribute(stmt, 4,
                        std::wstring(L"float_max"),  // expected_column_name
                        SQL_FLOAT,                   // expected_data_type
                        SQL_FLOAT,                   // expected_concise_type
@@ -1690,7 +1706,7 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColAttributeAllTypesODBCVer2) {
                        SQL_SEARCHABLE,              // expected_searchable
                        SQL_FALSE);                  // expected_unsigned_column
 
-  CheckSQLColAttribute(this->stmt, 5,
+  CheckSQLColAttribute(stmt, 5,
                        std::wstring(L"double_max"),  // expected_column_name
                        SQL_DOUBLE,                   // expected_data_type
                        SQL_DOUBLE,                   // expected_concise_type
@@ -1707,7 +1723,7 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColAttributeAllTypesODBCVer2) {
                        SQL_SEARCHABLE,               // expected_searchable
                        SQL_FALSE);                   // expected_unsigned_column
 
-  CheckSQLColAttribute(this->stmt, 6,
+  CheckSQLColAttribute(stmt, 6,
                        std::wstring(L"bit_true"),  // expected_column_name
                        SQL_BIT,                    // expected_data_type
                        SQL_BIT,                    // expected_concise_type
@@ -1724,7 +1740,7 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColAttributeAllTypesODBCVer2) {
                        SQL_SEARCHABLE,             // expected_searchable
                        SQL_TRUE);                  // expected_unsigned_column
 
-  CheckSQLColAttribute(this->stmt, 7,
+  CheckSQLColAttribute(stmt, 7,
                        std::wstring(L"date_max"),  // expected_column_name
                        SQL_DATETIME,               // expected_data_type
                        SQL_DATE,                   // expected_concise_type
@@ -1741,7 +1757,7 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColAttributeAllTypesODBCVer2) {
                        SQL_SEARCHABLE,             // expected_searchable
                        SQL_TRUE);                  // expected_unsigned_column
 
-  CheckSQLColAttribute(this->stmt, 8,
+  CheckSQLColAttribute(stmt, 8,
                        std::wstring(L"time_max"),  // expected_column_name
                        SQL_DATETIME,               // expected_data_type
                        SQL_TIME,                   // expected_concise_type
@@ -1758,7 +1774,7 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColAttributeAllTypesODBCVer2) {
                        SQL_SEARCHABLE,             // expected_searchable
                        SQL_TRUE);                  // expected_unsigned_column
 
-  CheckSQLColAttribute(this->stmt, 9,
+  CheckSQLColAttribute(stmt, 9,
                        std::wstring(L"timestamp_max"),  // expected_column_name
                        SQL_DATETIME,                    // expected_data_type
                        SQL_TIMESTAMP,                   // expected_concise_type
@@ -1776,18 +1792,19 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColAttributeAllTypesODBCVer2) {
                        SQL_TRUE);                       // expected_unsigned_column
 }
 
-TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColAttributesAllTypesODBCVer2) {
+// iODBC does not support SQLColAttributes for ODBC 3.0 attributes.
+TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColAttributesAllTypes) {
   // Tests ODBC 2.0 API SQLColAttributes
   // Test assumes there is a table $scratch.ODBCTest in remote server
   std::wstring wsql = L"SELECT * from $scratch.ODBCTest;";
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckSQLColAttributes(this->stmt, 1,
+  CheckSQLColAttributes(stmt, 1,
                         std::wstring(L"sinteger_max"),  // expected_column_name
                         SQL_INTEGER,                    // expected_data_type
                         11,                             // expected_display_size
@@ -1799,7 +1816,7 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColAttributesAllTypesODBCVer2) {
                         SQL_SEARCHABLE,                 // expected_searchable
                         SQL_FALSE);                     // expected_unsigned_column
 
-  CheckSQLColAttributes(this->stmt, 2,
+  CheckSQLColAttributes(stmt, 2,
                         std::wstring(L"sbigint_max"),  // expected_column_name
                         SQL_BIGINT,                    // expected_data_type
                         20,                            // expected_display_size
@@ -1811,7 +1828,7 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColAttributesAllTypesODBCVer2) {
                         SQL_SEARCHABLE,                // expected_searchable
                         SQL_FALSE);                    // expected_unsigned_column
 
-  CheckSQLColAttributes(this->stmt, 3,
+  CheckSQLColAttributes(stmt, 3,
                         std::wstring(L"decimal_positive"),  // expected_column_name
                         SQL_DECIMAL,                        // expected_data_type
                         40,                                 // expected_display_size
@@ -1823,7 +1840,7 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColAttributesAllTypesODBCVer2) {
                         SQL_SEARCHABLE,                     // expected_searchable
                         SQL_FALSE);                         // expected_unsigned_column
 
-  CheckSQLColAttributes(this->stmt, 4,
+  CheckSQLColAttributes(stmt, 4,
                         std::wstring(L"float_max"),  // expected_column_name
                         SQL_FLOAT,                   // expected_data_type
                         24,                          // expected_display_size
@@ -1835,7 +1852,7 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColAttributesAllTypesODBCVer2) {
                         SQL_SEARCHABLE,              // expected_searchable
                         SQL_FALSE);                  // expected_unsigned_column
 
-  CheckSQLColAttributes(this->stmt, 5,
+  CheckSQLColAttributes(stmt, 5,
                         std::wstring(L"double_max"),  // expected_column_name
                         SQL_DOUBLE,                   // expected_data_type
                         24,                           // expected_display_size
@@ -1847,7 +1864,7 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColAttributesAllTypesODBCVer2) {
                         SQL_SEARCHABLE,               // expected_searchable
                         SQL_FALSE);                   // expected_unsigned_column
 
-  CheckSQLColAttributes(this->stmt, 6,
+  CheckSQLColAttributes(stmt, 6,
                         std::wstring(L"bit_true"),  // expected_column_name
                         SQL_BIT,                    // expected_data_type
                         1,                          // expected_display_size
@@ -1859,7 +1876,7 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColAttributesAllTypesODBCVer2) {
                         SQL_SEARCHABLE,             // expected_searchable
                         SQL_TRUE);                  // expected_unsigned_column
 
-  CheckSQLColAttributes(this->stmt, 7,
+  CheckSQLColAttributes(stmt, 7,
                         std::wstring(L"date_max"),  // expected_column_name
                         SQL_DATE,                   // expected_data_type
                         10,                         // expected_display_size
@@ -1871,7 +1888,7 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColAttributesAllTypesODBCVer2) {
                         SQL_SEARCHABLE,             // expected_searchable
                         SQL_TRUE);                  // expected_unsigned_column
 
-  CheckSQLColAttributes(this->stmt, 8,
+  CheckSQLColAttributes(stmt, 8,
                         std::wstring(L"time_max"),  // expected_column_name
                         SQL_TIME,                   // expected_data_type
                         12,                         // expected_display_size
@@ -1883,7 +1900,7 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColAttributesAllTypesODBCVer2) {
                         SQL_SEARCHABLE,             // expected_searchable
                         SQL_TRUE);                  // expected_unsigned_column
 
-  CheckSQLColAttributes(this->stmt, 9,
+  CheckSQLColAttributes(stmt, 9,
                         std::wstring(L"timestamp_max"),  // expected_column_name
                         SQL_TIMESTAMP,                   // expected_data_type
                         23,                              // expected_display_size
@@ -1895,6 +1912,7 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColAttributesAllTypesODBCVer2) {
                         SQL_SEARCHABLE,                  // expected_searchable
                         SQL_TRUE);                       // expected_unsigned_column
 }
+#endif  // __APPLE__
 
 TYPED_TEST(ColumnsTest, TestSQLColAttributeCaseSensitive) {
   // Arrow limitation: returns SQL_FALSE for case sensitive column
@@ -1902,14 +1920,16 @@ TYPED_TEST(ColumnsTest, TestSQLColAttributeCaseSensitive) {
   std::wstring wsql = this->GetQueryAllDataTypes();
   // Int column
   SQLLEN value;
-  GetSQLColAttributeNumeric(this->stmt, wsql, 1, SQL_DESC_CASE_SENSITIVE, &value);
+  GetSQLColAttributeNumeric(stmt, wsql, 1, SQL_DESC_CASE_SENSITIVE, &value);
   ASSERT_EQ(SQL_FALSE, value);
-  SQLFreeStmt(this->stmt, SQL_CLOSE);
+  SQLFreeStmt(stmt, SQL_CLOSE);
   // Varchar column
-  GetSQLColAttributeNumeric(this->stmt, wsql, 28, SQL_DESC_CASE_SENSITIVE, &value);
+  GetSQLColAttributeNumeric(stmt, wsql, 28, SQL_DESC_CASE_SENSITIVE, &value);
   ASSERT_EQ(SQL_FALSE, value);
 }
 
+// iODBC does not support SQLColAttributes for ODBC 3.0 attributes.
+#ifndef __APPLE__
 TYPED_TEST(ColumnsOdbcV2Test, TestSQLColAttributesCaseSensitive) {
   // Arrow limitation: returns SQL_FALSE for case sensitive column
   // Tests ODBC 2.0 API SQLColAttributes
@@ -1917,63 +1937,80 @@ TYPED_TEST(ColumnsOdbcV2Test, TestSQLColAttributesCaseSensitive) {
   std::wstring wsql = this->GetQueryAllDataTypes();
   // Int column
   SQLLEN value;
-  GetSQLColAttributesNumeric(this->stmt, wsql, 1, SQL_COLUMN_CASE_SENSITIVE, &value);
+  GetSQLColAttributesNumeric(stmt, wsql, 1, SQL_COLUMN_CASE_SENSITIVE, &value);
   ASSERT_EQ(SQL_FALSE, value);
-  SQLFreeStmt(this->stmt, SQL_CLOSE);
+  SQLFreeStmt(stmt, SQL_CLOSE);
   // Varchar column
-  GetSQLColAttributesNumeric(this->stmt, wsql, 28, SQL_COLUMN_CASE_SENSITIVE, &value);
+  GetSQLColAttributesNumeric(stmt, wsql, 28, SQL_COLUMN_CASE_SENSITIVE, &value);
   ASSERT_EQ(SQL_FALSE, value);
 }
+#endif  // __APPLE__
 
 TEST_F(ColumnsMockTest, TestSQLColAttributeUniqueValue) {
   // Mock server limitation: returns false for auto-increment column
-  this->CreateTableAllDataType();
+  CreateAllDataTypeTable();
 
   std::wstring wsql = L"SELECT * from AllTypesTable;";
   SQLLEN value;
-  GetSQLColAttributeNumeric(this->stmt, wsql, 1, SQL_DESC_AUTO_UNIQUE_VALUE, &value);
+  GetSQLColAttributeNumeric(stmt, wsql, 1, SQL_DESC_AUTO_UNIQUE_VALUE, &value);
   ASSERT_EQ(SQL_FALSE, value);
+
+  DropAllDataTypeTable();
 }
 
+// iODBC does not support SQLColAttributes for ODBC 3.0 attributes.
+#ifndef __APPLE__
 TEST_F(ColumnsOdbcV2MockTest, TestSQLColAttributesAutoIncrement) {
   // Tests ODBC 2.0 API SQLColAttributes
   // Mock server limitation: returns false for auto-increment column
-  this->CreateTableAllDataType();
+  CreateAllDataTypeTable();
 
   std::wstring wsql = L"SELECT * from AllTypesTable;";
   SQLLEN value;
-  GetSQLColAttributeNumeric(this->stmt, wsql, 1, SQL_COLUMN_AUTO_INCREMENT, &value);
+  GetSQLColAttributeNumeric(stmt, wsql, 1, SQL_COLUMN_AUTO_INCREMENT, &value);
   ASSERT_EQ(SQL_FALSE, value);
+
+  DropAllDataTypeTable();
 }
+#endif  // __APPLE__
 
 TEST_F(ColumnsMockTest, TestSQLColAttributeBaseTableName) {
-  this->CreateTableAllDataType();
+  CreateAllDataTypeTable();
 
   std::wstring wsql = L"SELECT * from AllTypesTable;";
   std::wstring value;
-  GetSQLColAttributeString(this->stmt, wsql, 1, SQL_DESC_BASE_TABLE_NAME, value);
+  GetSQLColAttributeString(stmt, wsql, 1, SQL_DESC_BASE_TABLE_NAME, value);
   ASSERT_EQ(std::wstring(L"AllTypesTable"), value);
+
+  DropAllDataTypeTable();
 }
 
+// iODBC does not support SQLColAttributes for ODBC 3.0 attributes.
+#ifndef __APPLE__
 TEST_F(ColumnsOdbcV2MockTest, TestSQLColAttributesTableName) {
   // Tests ODBC 2.0 API SQLColAttributes
-  this->CreateTableAllDataType();
+  CreateAllDataTypeTable();
 
   std::wstring wsql = L"SELECT * from AllTypesTable;";
   std::wstring value;
-  GetSQLColAttributesString(this->stmt, wsql, 1, SQL_COLUMN_TABLE_NAME, value);
+  GetSQLColAttributesString(stmt, wsql, 1, SQL_COLUMN_TABLE_NAME, value);
   ASSERT_EQ(std::wstring(L"AllTypesTable"), value);
+
+  DropAllDataTypeTable();
 }
+#endif  // __APPLE__
 
 TEST_F(ColumnsMockTest, TestSQLColAttributeCatalogName) {
   // Mock server limitattion: mock doesn't return catalog for result metadata,
   // and the defautl catalog should be 'main'
-  this->CreateTableAllDataType();
+  CreateAllDataTypeTable();
 
   std::wstring wsql = L"SELECT * from AllTypesTable;";
   std::wstring value;
-  GetSQLColAttributeString(this->stmt, wsql, 1, SQL_DESC_CATALOG_NAME, value);
+  GetSQLColAttributeString(stmt, wsql, 1, SQL_DESC_CATALOG_NAME, value);
   ASSERT_EQ(std::wstring(L""), value);
+
+  DropAllDataTypeTable();
 }
 
 TEST_F(ColumnsRemoteTest, TestSQLColAttributeCatalogName) {
@@ -1981,20 +2018,24 @@ TEST_F(ColumnsRemoteTest, TestSQLColAttributeCatalogName) {
 
   std::wstring wsql = L"SELECT * from $scratch.ODBCTest;";
   std::wstring value;
-  GetSQLColAttributeString(this->stmt, wsql, 1, SQL_DESC_CATALOG_NAME, value);
+  GetSQLColAttributeString(stmt, wsql, 1, SQL_DESC_CATALOG_NAME, value);
   ASSERT_EQ(std::wstring(L""), value);
 }
 
+// iODBC does not support SQLColAttribute in ODBC 2.0 mode.
+#ifndef __APPLE__
 TEST_F(ColumnsOdbcV2MockTest, TestSQLColAttributesQualifierName) {
   // Mock server limitattion: mock doesn't return catalog for result metadata,
   // and the defautl catalog should be 'main'
   // Tests ODBC 2.0 API SQLColAttributes
-  this->CreateTableAllDataType();
+  CreateAllDataTypeTable();
 
   std::wstring wsql = L"SELECT * from AllTypesTable;";
   std::wstring value;
-  GetSQLColAttributeString(this->stmt, wsql, 1, SQL_COLUMN_QUALIFIER_NAME, value);
+  GetSQLColAttributeString(stmt, wsql, 1, SQL_COLUMN_QUALIFIER_NAME, value);
   ASSERT_EQ(std::wstring(L""), value);
+
+  DropAllDataTypeTable();
 }
 
 TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColAttributesQualifierName) {
@@ -2002,15 +2043,16 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColAttributesQualifierName) {
   // Tests ODBC 2.0 API SQLColAttributes
   std::wstring wsql = L"SELECT * from $scratch.ODBCTest;";
   std::wstring value;
-  GetSQLColAttributeString(this->stmt, wsql, 1, SQL_COLUMN_QUALIFIER_NAME, value);
+  GetSQLColAttributeString(stmt, wsql, 1, SQL_COLUMN_QUALIFIER_NAME, value);
   ASSERT_EQ(std::wstring(L""), value);
 }
+#endif  // __APPLE__
 
 TYPED_TEST(ColumnsTest, TestSQLColAttributeCount) {
   std::wstring wsql = this->GetQueryAllDataTypes();
   // Pass 0 as column number, driver should ignore it
   SQLLEN value;
-  GetSQLColAttributeNumeric(this->stmt, wsql, 0, SQL_DESC_COUNT, &value);
+  GetSQLColAttributeNumeric(stmt, wsql, 0, SQL_DESC_COUNT, &value);
   ASSERT_EQ(32, value);
 }
 
@@ -2018,25 +2060,27 @@ TEST_F(ColumnsMockTest, TestSQLColAttributeLocalTypeName) {
   std::wstring wsql = this->GetQueryAllDataTypes();
   // Mock server doesn't have local type name
   std::wstring value;
-  GetSQLColAttributeString(this->stmt, wsql, 1, SQL_DESC_LOCAL_TYPE_NAME, value);
+  GetSQLColAttributeString(stmt, wsql, 1, SQL_DESC_LOCAL_TYPE_NAME, value);
   ASSERT_EQ(std::wstring(L""), value);
 }
 
 TEST_F(ColumnsRemoteTest, TestSQLColAttributeLocalTypeName) {
   std::wstring wsql = this->GetQueryAllDataTypes();
   std::wstring value;
-  GetSQLColAttributesString(this->stmt, wsql, 1, SQL_DESC_LOCAL_TYPE_NAME, value);
+  GetSQLColAttributesString(stmt, wsql, 1, SQL_DESC_LOCAL_TYPE_NAME, value);
   ASSERT_EQ(std::wstring(L"INTEGER"), value);
 }
 
 TEST_F(ColumnsMockTest, TestSQLColAttributeSchemaName) {
-  this->CreateTableAllDataType();
+  CreateAllDataTypeTable();
 
   std::wstring wsql = L"SELECT * from AllTypesTable;";
   // Mock server doesn't have schemas
   std::wstring value;
-  GetSQLColAttributeString(this->stmt, wsql, 1, SQL_DESC_SCHEMA_NAME, value);
+  GetSQLColAttributeString(stmt, wsql, 1, SQL_DESC_SCHEMA_NAME, value);
   ASSERT_EQ(std::wstring(L""), value);
+
+  DropAllDataTypeTable();
 }
 
 TEST_F(ColumnsRemoteTest, TestSQLColAttributeSchemaName) {
@@ -2046,19 +2090,23 @@ TEST_F(ColumnsRemoteTest, TestSQLColAttributeSchemaName) {
   // Remote server limitation: doesn't return schema name, expected schema name is
   // $scratch
   std::wstring value;
-  GetSQLColAttributeString(this->stmt, wsql, 1, SQL_DESC_SCHEMA_NAME, value);
+  GetSQLColAttributeString(stmt, wsql, 1, SQL_DESC_SCHEMA_NAME, value);
   ASSERT_EQ(std::wstring(L""), value);
 }
 
+// iODBC does not support SQLColAttributes for ODBC 3.0 attributes.
+#ifndef __APPLE__
 TEST_F(ColumnsOdbcV2MockTest, TestSQLColAttributesOwnerName) {
   // Tests ODBC 2.0 API SQLColAttributes
-  this->CreateTableAllDataType();
+  CreateAllDataTypeTable();
 
   std::wstring wsql = L"SELECT * from AllTypesTable;";
   // Mock server doesn't have schemas
   std::wstring value;
-  GetSQLColAttributesString(this->stmt, wsql, 1, SQL_COLUMN_OWNER_NAME, value);
+  GetSQLColAttributesString(stmt, wsql, 1, SQL_COLUMN_OWNER_NAME, value);
   ASSERT_EQ(std::wstring(L""), value);
+
+  DropAllDataTypeTable();
 }
 
 TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColAttributesOwnerName) {
@@ -2068,102 +2116,112 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColAttributesOwnerName) {
   // Remote server limitation: doesn't return schema name, expected schema name is
   // $scratch
   std::wstring value;
-  GetSQLColAttributesString(this->stmt, wsql, 1, SQL_COLUMN_OWNER_NAME, value);
+  GetSQLColAttributesString(stmt, wsql, 1, SQL_COLUMN_OWNER_NAME, value);
   ASSERT_EQ(std::wstring(L""), value);
 }
+#endif  // __APPLE__
 
 TEST_F(ColumnsMockTest, TestSQLColAttributeTableName) {
-  this->CreateTableAllDataType();
+  CreateAllDataTypeTable();
 
   std::wstring wsql = L"SELECT * from AllTypesTable;";
   std::wstring value;
-  GetSQLColAttributeString(this->stmt, wsql, 1, SQL_DESC_TABLE_NAME, value);
+  GetSQLColAttributeString(stmt, wsql, 1, SQL_DESC_TABLE_NAME, value);
   ASSERT_EQ(std::wstring(L"AllTypesTable"), value);
+
+  DropAllDataTypeTable();
 }
 
 TEST_F(ColumnsMockTest, TestSQLColAttributeTypeName) {
-  this->CreateTableAllDataType();
+  CreateAllDataTypeTable();
 
   std::wstring wsql = L"SELECT * from AllTypesTable;";
   std::wstring value;
-  GetSQLColAttributeString(this->stmt, wsql, 1, SQL_DESC_TYPE_NAME, value);
+  GetSQLColAttributeString(stmt, wsql, 1, SQL_DESC_TYPE_NAME, value);
   ASSERT_EQ(std::wstring(L"BIGINT"), value);
-  GetSQLColAttributeString(this->stmt, L"", 2, SQL_DESC_TYPE_NAME, value);
+  GetSQLColAttributeString(stmt, L"", 2, SQL_DESC_TYPE_NAME, value);
   ASSERT_EQ(std::wstring(L"WVARCHAR"), value);
-  GetSQLColAttributeString(this->stmt, L"", 3, SQL_DESC_TYPE_NAME, value);
+  GetSQLColAttributeString(stmt, L"", 3, SQL_DESC_TYPE_NAME, value);
   ASSERT_EQ(std::wstring(L"BINARY"), value);
-  GetSQLColAttributeString(this->stmt, L"", 4, SQL_DESC_TYPE_NAME, value);
+  GetSQLColAttributeString(stmt, L"", 4, SQL_DESC_TYPE_NAME, value);
   ASSERT_EQ(std::wstring(L"DOUBLE"), value);
+
+  DropAllDataTypeTable();
 }
 
 TEST_F(ColumnsRemoteTest, TestSQLColAttributeTypeName) {
   std::wstring wsql = L"SELECT * from $scratch.ODBCTest;";
   std::wstring value;
-  GetSQLColAttributeString(this->stmt, wsql, 1, SQL_DESC_TYPE_NAME, value);
+  GetSQLColAttributeString(stmt, wsql, 1, SQL_DESC_TYPE_NAME, value);
   ASSERT_EQ(std::wstring(L"INTEGER"), value);
-  GetSQLColAttributeString(this->stmt, L"", 2, SQL_DESC_TYPE_NAME, value);
+  GetSQLColAttributeString(stmt, L"", 2, SQL_DESC_TYPE_NAME, value);
   ASSERT_EQ(std::wstring(L"BIGINT"), value);
-  GetSQLColAttributeString(this->stmt, L"", 3, SQL_DESC_TYPE_NAME, value);
+  GetSQLColAttributeString(stmt, L"", 3, SQL_DESC_TYPE_NAME, value);
   ASSERT_EQ(std::wstring(L"DECIMAL"), value);
-  GetSQLColAttributeString(this->stmt, L"", 4, SQL_DESC_TYPE_NAME, value);
+  GetSQLColAttributeString(stmt, L"", 4, SQL_DESC_TYPE_NAME, value);
   ASSERT_EQ(std::wstring(L"FLOAT"), value);
-  GetSQLColAttributeString(this->stmt, L"", 5, SQL_DESC_TYPE_NAME, value);
+  GetSQLColAttributeString(stmt, L"", 5, SQL_DESC_TYPE_NAME, value);
   ASSERT_EQ(std::wstring(L"DOUBLE"), value);
-  GetSQLColAttributeString(this->stmt, L"", 6, SQL_DESC_TYPE_NAME, value);
+  GetSQLColAttributeString(stmt, L"", 6, SQL_DESC_TYPE_NAME, value);
   ASSERT_EQ(std::wstring(L"BOOLEAN"), value);
-  GetSQLColAttributeString(this->stmt, L"", 7, SQL_DESC_TYPE_NAME, value);
+  GetSQLColAttributeString(stmt, L"", 7, SQL_DESC_TYPE_NAME, value);
   ASSERT_EQ(std::wstring(L"DATE"), value);
-  GetSQLColAttributeString(this->stmt, L"", 8, SQL_DESC_TYPE_NAME, value);
+  GetSQLColAttributeString(stmt, L"", 8, SQL_DESC_TYPE_NAME, value);
   ASSERT_EQ(std::wstring(L"TIME"), value);
-  GetSQLColAttributeString(this->stmt, L"", 9, SQL_DESC_TYPE_NAME, value);
+  GetSQLColAttributeString(stmt, L"", 9, SQL_DESC_TYPE_NAME, value);
   ASSERT_EQ(std::wstring(L"TIMESTAMP"), value);
 }
 
+// iODBC does not support SQLColAttributes for ODBC 3.0 attributes.
+#ifndef __APPLE__
 TEST_F(ColumnsOdbcV2MockTest, TestSQLColAttributesTypeName) {
   // Tests ODBC 2.0 API SQLColAttributes
-  this->CreateTableAllDataType();
+  CreateAllDataTypeTable();
 
   std::wstring wsql = L"SELECT * from AllTypesTable;";
   // Mock server doesn't return data source-dependent data type name
   std::wstring value;
-  GetSQLColAttributesString(this->stmt, wsql, 1, SQL_COLUMN_TYPE_NAME, value);
+  GetSQLColAttributesString(stmt, wsql, 1, SQL_COLUMN_TYPE_NAME, value);
   ASSERT_EQ(std::wstring(L"BIGINT"), value);
-  GetSQLColAttributesString(this->stmt, L"", 2, SQL_COLUMN_TYPE_NAME, value);
+  GetSQLColAttributesString(stmt, L"", 2, SQL_COLUMN_TYPE_NAME, value);
   ASSERT_EQ(std::wstring(L"WVARCHAR"), value);
-  GetSQLColAttributesString(this->stmt, L"", 3, SQL_COLUMN_TYPE_NAME, value);
+  GetSQLColAttributesString(stmt, L"", 3, SQL_COLUMN_TYPE_NAME, value);
   ASSERT_EQ(std::wstring(L"BINARY"), value);
-  GetSQLColAttributesString(this->stmt, L"", 4, SQL_COLUMN_TYPE_NAME, value);
+  GetSQLColAttributesString(stmt, L"", 4, SQL_COLUMN_TYPE_NAME, value);
   ASSERT_EQ(std::wstring(L"DOUBLE"), value);
+
+  DropAllDataTypeTable();
 }
 
 TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColAttributesTypeName) {
   // Tests ODBC 2.0 API SQLColAttributes
   std::wstring wsql = L"SELECT * from $scratch.ODBCTest;";
   std::wstring value;
-  GetSQLColAttributesString(this->stmt, wsql, 1, SQL_COLUMN_TYPE_NAME, value);
+  GetSQLColAttributesString(stmt, wsql, 1, SQL_COLUMN_TYPE_NAME, value);
   ASSERT_EQ(std::wstring(L"INTEGER"), value);
-  GetSQLColAttributesString(this->stmt, L"", 2, SQL_COLUMN_TYPE_NAME, value);
+  GetSQLColAttributesString(stmt, L"", 2, SQL_COLUMN_TYPE_NAME, value);
   ASSERT_EQ(std::wstring(L"BIGINT"), value);
-  GetSQLColAttributesString(this->stmt, L"", 3, SQL_COLUMN_TYPE_NAME, value);
+  GetSQLColAttributesString(stmt, L"", 3, SQL_COLUMN_TYPE_NAME, value);
   ASSERT_EQ(std::wstring(L"DECIMAL"), value);
-  GetSQLColAttributesString(this->stmt, L"", 4, SQL_COLUMN_TYPE_NAME, value);
+  GetSQLColAttributesString(stmt, L"", 4, SQL_COLUMN_TYPE_NAME, value);
   ASSERT_EQ(std::wstring(L"FLOAT"), value);
-  GetSQLColAttributesString(this->stmt, L"", 5, SQL_COLUMN_TYPE_NAME, value);
+  GetSQLColAttributesString(stmt, L"", 5, SQL_COLUMN_TYPE_NAME, value);
   ASSERT_EQ(std::wstring(L"DOUBLE"), value);
-  GetSQLColAttributesString(this->stmt, L"", 6, SQL_COLUMN_TYPE_NAME, value);
+  GetSQLColAttributesString(stmt, L"", 6, SQL_COLUMN_TYPE_NAME, value);
   ASSERT_EQ(std::wstring(L"BOOLEAN"), value);
-  GetSQLColAttributesString(this->stmt, L"", 7, SQL_COLUMN_TYPE_NAME, value);
+  GetSQLColAttributesString(stmt, L"", 7, SQL_COLUMN_TYPE_NAME, value);
   ASSERT_EQ(std::wstring(L"DATE"), value);
-  GetSQLColAttributesString(this->stmt, L"", 8, SQL_COLUMN_TYPE_NAME, value);
+  GetSQLColAttributesString(stmt, L"", 8, SQL_COLUMN_TYPE_NAME, value);
   ASSERT_EQ(std::wstring(L"TIME"), value);
-  GetSQLColAttributesString(this->stmt, L"", 9, SQL_COLUMN_TYPE_NAME, value);
+  GetSQLColAttributesString(stmt, L"", 9, SQL_COLUMN_TYPE_NAME, value);
   ASSERT_EQ(std::wstring(L"TIMESTAMP"), value);
 }
+#endif  // __APPLE__
 
 TYPED_TEST(ColumnsTest, TestSQLColAttributeUnnamed) {
   std::wstring wsql = this->GetQueryAllDataTypes();
   SQLLEN value;
-  GetSQLColAttributeNumeric(this->stmt, wsql, 1, SQL_DESC_UNNAMED, &value);
+  GetSQLColAttributeNumeric(stmt, wsql, 1, SQL_DESC_UNNAMED, &value);
   ASSERT_EQ(SQL_NAMED, value);
 }
 
@@ -2171,21 +2229,24 @@ TYPED_TEST(ColumnsTest, TestSQLColAttributeUpdatable) {
   std::wstring wsql = this->GetQueryAllDataTypes();
   // Mock server and remote server do not return updatable information
   SQLLEN value;
-  GetSQLColAttributeNumeric(this->stmt, wsql, 1, SQL_DESC_UPDATABLE, &value);
+  GetSQLColAttributeNumeric(stmt, wsql, 1, SQL_DESC_UPDATABLE, &value);
   ASSERT_EQ(SQL_ATTR_READWRITE_UNKNOWN, value);
 }
 
+// iODBC does not support SQLColAttributes for ODBC 3.0 attributes.
+#ifndef __APPLE__
 TYPED_TEST(ColumnsOdbcV2Test, TestSQLColAttributesUpdatable) {
   // Tests ODBC 2.0 API SQLColAttributes
   std::wstring wsql = this->GetQueryAllDataTypes();
   // Mock server and remote server do not return updatable information
   SQLLEN value;
-  GetSQLColAttributesNumeric(this->stmt, wsql, 1, SQL_COLUMN_UPDATABLE, &value);
+  GetSQLColAttributesNumeric(stmt, wsql, 1, SQL_COLUMN_UPDATABLE, &value);
   ASSERT_EQ(SQL_ATTR_READWRITE_UNKNOWN, value);
 }
+#endif  // __APPLE__
 
 TEST_F(ColumnsMockTest, SQLDescribeColValidateInput) {
-  this->CreateTestTables();
+  CreateTestTable();
 
   SQLWCHAR sql_query[] = L"SELECT * FROM TestTable LIMIT 1;";
   SQLINTEGER query_length = static_cast<SQLINTEGER>(wcslen(sql_query));
@@ -2202,27 +2263,34 @@ TEST_F(ColumnsMockTest, SQLDescribeColValidateInput) {
   SQLSMALLINT decimal_digits = 0;
   SQLSMALLINT nullable = 0;
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, sql_query, query_length));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, sql_query, query_length));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   // Invalid descriptor index - Bookmarks are not supported
-  EXPECT_EQ(SQL_ERROR, SQLDescribeCol(this->stmt, bookmark_column, column_name,
-                                      buf_char_len, &name_length, &data_type,
-                                      &column_size, &decimal_digits, &nullable));
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorState07009);
+  EXPECT_EQ(SQL_ERROR,
+            SQLDescribeCol(stmt, bookmark_column, column_name, buf_char_len, &name_length,
+                           &data_type, &column_size, &decimal_digits, &nullable));
+#ifdef __APPLE__
+  // non-standard odbc error code for invalid column index
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorStateS1002);
+#else
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorState07009);
+#endif  // __APPLE__
 
   // Invalid descriptor index - index out of range
-  EXPECT_EQ(SQL_ERROR, SQLDescribeCol(this->stmt, out_of_range_column, column_name,
+  EXPECT_EQ(SQL_ERROR, SQLDescribeCol(stmt, out_of_range_column, column_name,
                                       buf_char_len, &name_length, &data_type,
                                       &column_size, &decimal_digits, &nullable));
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorState07009);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorState07009);
 
   // Invalid descriptor index - index out of range
-  EXPECT_EQ(SQL_ERROR, SQLDescribeCol(this->stmt, negative_column, column_name,
-                                      buf_char_len, &name_length, &data_type,
-                                      &column_size, &decimal_digits, &nullable));
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorState07009);
+  EXPECT_EQ(SQL_ERROR,
+            SQLDescribeCol(stmt, negative_column, column_name, buf_char_len, &name_length,
+                           &data_type, &column_size, &decimal_digits, &nullable));
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorState07009);
+
+  DropTestTable();
 }
 
 TEST_F(ColumnsMockTest, SQLDescribeColQueryAllDataTypesMetadata) {
@@ -2283,15 +2351,15 @@ TEST_F(ColumnsMockTest, SQLDescribeColQueryAllDataTypesMetadata) {
       SQL_WVARCHAR, SQL_WVARCHAR};
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   for (size_t i = 0; i < sizeof(column_names) / sizeof(*column_names); ++i) {
     column_index = i + 1;
 
-    ASSERT_EQ(SQL_SUCCESS, SQLDescribeCol(this->stmt, column_index, column_name,
-                                          buf_char_len, &name_length, &column_data_type,
-                                          &column_size, &decimal_digits, &nullable));
+    ASSERT_EQ(SQL_SUCCESS, SQLDescribeCol(stmt, column_index, column_name, buf_char_len,
+                                          &name_length, &column_data_type, &column_size,
+                                          &decimal_digits, &nullable));
 
     EXPECT_EQ(wcslen(column_names[i]), name_length);
 
@@ -2371,16 +2439,16 @@ TEST_F(ColumnsRemoteTest, SQLDescribeColQueryAllDataTypesMetadata) {
                                      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10, 23, 23};
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   for (size_t i = 0; i < sizeof(column_names) / sizeof(*column_names); ++i) {
     column_index = i + 1;
 
-    ASSERT_EQ(SQL_SUCCESS, SQLDescribeCol(this->stmt, column_index, column_name,
-                                          buf_char_len, &name_length, &column_data_type,
-                                          &column_size, &decimal_digits, &nullable));
+    ASSERT_EQ(SQL_SUCCESS, SQLDescribeCol(stmt, column_index, column_name, buf_char_len,
+                                          &name_length, &column_data_type, &column_size,
+                                          &decimal_digits, &nullable));
 
     EXPECT_EQ(wcslen(column_names[i]), name_length);
 
@@ -2430,16 +2498,16 @@ TEST_F(ColumnsRemoteTest, SQLDescribeColODBCTestTableMetadata) {
   SQLULEN column_sizes[] = {4, 8, 19, 8, 8, 1, 10, 12, 23};
   SQLULEN columndecimal_digits[] = {0, 0, 0, 0, 0, 0, 10, 12, 23};
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, sql_query, query_length));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, sql_query, query_length));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   for (size_t i = 0; i < sizeof(column_names) / sizeof(*column_names); ++i) {
     column_index = i + 1;
 
-    ASSERT_EQ(SQL_SUCCESS, SQLDescribeCol(this->stmt, column_index, column_name,
-                                          buf_char_len, &name_length, &column_data_type,
-                                          &column_size, &decimal_digits, &nullable));
+    ASSERT_EQ(SQL_SUCCESS, SQLDescribeCol(stmt, column_index, column_name, buf_char_len,
+                                          &name_length, &column_data_type, &column_size,
+                                          &decimal_digits, &nullable));
 
     EXPECT_EQ(wcslen(column_names[i]), name_length);
 
@@ -2488,16 +2556,16 @@ TEST_F(ColumnsOdbcV2RemoteTest, SQLDescribeColODBCTestTableMetadataODBCVer2) {
   SQLULEN column_sizes[] = {4, 8, 19, 8, 8, 1, 10, 12, 23};
   SQLULEN columndecimal_digits[] = {0, 0, 0, 0, 0, 0, 10, 12, 23};
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, sql_query, query_length));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, sql_query, query_length));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   for (size_t i = 0; i < sizeof(column_names) / sizeof(*column_names); ++i) {
     column_index = i + 1;
 
-    ASSERT_EQ(SQL_SUCCESS, SQLDescribeCol(this->stmt, column_index, column_name,
-                                          buf_char_len, &name_length, &column_data_type,
-                                          &column_size, &decimal_digits, &nullable));
+    ASSERT_EQ(SQL_SUCCESS, SQLDescribeCol(stmt, column_index, column_name, buf_char_len,
+                                          &name_length, &column_data_type, &column_size,
+                                          &decimal_digits, &nullable));
 
     EXPECT_EQ(wcslen(column_names[i]), name_length);
 
@@ -2517,7 +2585,7 @@ TEST_F(ColumnsOdbcV2RemoteTest, SQLDescribeColODBCTestTableMetadataODBCVer2) {
 }
 
 TEST_F(ColumnsMockTest, SQLDescribeColAllTypesTableMetadata) {
-  this->CreateTableAllDataType();
+  CreateAllDataTypeTable();
 
   SQLWCHAR column_name[1024];
   SQLSMALLINT buf_char_len =
@@ -2539,16 +2607,16 @@ TEST_F(ColumnsMockTest, SQLDescribeColAllTypesTableMetadata) {
   SQLSMALLINT column_data_types[] = {SQL_BIGINT, SQL_WVARCHAR, SQL_BINARY, SQL_DOUBLE};
   SQLULEN column_sizes[] = {8, 0, 0, 8};
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, sql_query, query_length));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, sql_query, query_length));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   for (size_t i = 0; i < sizeof(column_names) / sizeof(*column_names); ++i) {
     column_index = i + 1;
 
-    ASSERT_EQ(SQL_SUCCESS, SQLDescribeCol(this->stmt, column_index, column_name,
-                                          buf_char_len, &name_length, &column_data_type,
-                                          &column_size, &decimal_digits, &nullable));
+    ASSERT_EQ(SQL_SUCCESS, SQLDescribeCol(stmt, column_index, column_name, buf_char_len,
+                                          &name_length, &column_data_type, &column_size,
+                                          &decimal_digits, &nullable));
 
     EXPECT_EQ(wcslen(column_names[i]), name_length);
 
@@ -2565,10 +2633,12 @@ TEST_F(ColumnsMockTest, SQLDescribeColAllTypesTableMetadata) {
     decimal_digits = 0;
     nullable = 0;
   }
+
+  DropAllDataTypeTable();
 }
 
 TEST_F(ColumnsMockTest, SQLDescribeColUnicodeTableMetadata) {
-  this->CreateUnicodeTable();
+  CreateUnicodeTable();
 
   SQLWCHAR column_name[1024];
   SQLSMALLINT buf_char_len =
@@ -2587,13 +2657,13 @@ TEST_F(ColumnsMockTest, SQLDescribeColUnicodeTableMetadata) {
   SQLSMALLINT expected_column_data_type = SQL_WVARCHAR;
   SQLULEN expected_column_size = 0;
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, sql_query, query_length));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, sql_query, query_length));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLDescribeCol(this->stmt, column_index, column_name,
-                                        buf_char_len, &name_length, &column_data_type,
-                                        &column_size, &decimal_digits, &nullable));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLDescribeCol(stmt, column_index, column_name, buf_char_len, &name_length,
+                           &column_data_type, &column_size, &decimal_digits, &nullable));
 
   EXPECT_EQ(name_length, wcslen(expected_column_name));
 
@@ -2603,6 +2673,8 @@ TEST_F(ColumnsMockTest, SQLDescribeColUnicodeTableMetadata) {
   EXPECT_EQ(column_size, expected_column_size);
   EXPECT_EQ(0, decimal_digits);
   EXPECT_EQ(SQL_NULLABLE, nullable);
+
+  DropUnicodeTable();
 }
 
 TYPED_TEST(ColumnsTest, SQLColumnsGetMetadataBySQLDescribeCol) {
@@ -2642,14 +2714,14 @@ TYPED_TEST(ColumnsTest, SQLColumnsGetMetadataBySQLDescribeCol) {
                             2,    2,    1024, 1024, 2, 2,    4, 4, 1024};
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLColumns(this->stmt, nullptr, 0, nullptr, 0, nullptr, 0, nullptr, 0));
+            SQLColumns(stmt, nullptr, 0, nullptr, 0, nullptr, 0, nullptr, 0));
 
   for (size_t i = 0; i < sizeof(column_names) / sizeof(*column_names); ++i) {
     column_index = i + 1;
 
-    ASSERT_EQ(SQL_SUCCESS, SQLDescribeCol(this->stmt, column_index, column_name,
-                                          buf_char_len, &name_length, &column_data_type,
-                                          &column_size, &decimal_digits, &nullable));
+    ASSERT_EQ(SQL_SUCCESS, SQLDescribeCol(stmt, column_index, column_name, buf_char_len,
+                                          &name_length, &column_data_type, &column_size,
+                                          &decimal_digits, &nullable));
 
     EXPECT_EQ(wcslen(column_names[i]), name_length);
 
@@ -2705,14 +2777,14 @@ TYPED_TEST(ColumnsOdbcV2Test, SQLColumnsGetMetadataBySQLDescribeColODBCVer2) {
                             2,    2,    1024, 1024, 2, 2,    4, 4, 1024};
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLColumns(this->stmt, nullptr, 0, nullptr, 0, nullptr, 0, nullptr, 0));
+            SQLColumns(stmt, nullptr, 0, nullptr, 0, nullptr, 0, nullptr, 0));
 
   for (size_t i = 0; i < sizeof(column_names) / sizeof(*column_names); ++i) {
     column_index = i + 1;
 
-    ASSERT_EQ(SQL_SUCCESS, SQLDescribeCol(this->stmt, column_index, column_name,
-                                          buf_char_len, &name_length, &column_data_type,
-                                          &column_size, &decimal_digits, &nullable));
+    ASSERT_EQ(SQL_SUCCESS, SQLDescribeCol(stmt, column_index, column_name, buf_char_len,
+                                          &name_length, &column_data_type, &column_size,
+                                          &decimal_digits, &nullable));
 
     EXPECT_EQ(wcslen(column_names[i]), name_length);
 

--- a/cpp/src/arrow/flight/sql/odbc/tests/connection_attr_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/connection_attr_test.cc
@@ -35,55 +35,55 @@ TYPED_TEST_SUITE(ConnectionAttributeTest, TestTypes);
 
 #ifdef SQL_ATTR_ASYNC_DBC_EVENT
 TYPED_TEST(ConnectionAttributeTest, TestSQLSetConnectAttrAsyncDbcEventUnsupported) {
-  ASSERT_EQ(SQL_ERROR, SQLSetConnectAttr(this->conn, SQL_ATTR_ASYNC_DBC_EVENT, 0, 0));
+  ASSERT_EQ(SQL_ERROR, SQLSetConnectAttr(conn, SQL_ATTR_ASYNC_DBC_EVENT, 0, 0));
   // Driver Manager on Windows returns error code HY118
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorStateHY118);
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorStateHY118);
 }
 #endif
 
 #ifdef SQL_ATTR_ASYNC_ENABLE
 TYPED_TEST(ConnectionAttributeTest, TestSQLSetConnectAttrAyncEnableUnsupported) {
-  ASSERT_EQ(SQL_ERROR, SQLSetConnectAttr(this->conn, SQL_ATTR_ASYNC_ENABLE, 0, 0));
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorStateHYC00);
+  ASSERT_EQ(SQL_ERROR, SQLSetConnectAttr(conn, SQL_ATTR_ASYNC_ENABLE, 0, 0));
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorStateHYC00);
 }
 #endif
 
 #ifdef SQL_ATTR_ASYNC_DBC_PCALLBACK
 TYPED_TEST(ConnectionAttributeTest, TestSQLSetConnectAttrAyncDbcPcCallbackUnsupported) {
-  ASSERT_EQ(SQL_ERROR, SQLSetConnectAttr(this->conn, SQL_ATTR_ASYNC_DBC_PCALLBACK, 0, 0));
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorStateHYC00);
+  ASSERT_EQ(SQL_ERROR, SQLSetConnectAttr(conn, SQL_ATTR_ASYNC_DBC_PCALLBACK, 0, 0));
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorStateHYC00);
 }
 #endif
 
 #ifdef SQL_ATTR_ASYNC_DBC_PCONTEXT
 TYPED_TEST(ConnectionAttributeTest, TestSQLSetConnectAttrAyncDbcPcContextUnsupported) {
-  ASSERT_EQ(SQL_ERROR, SQLSetConnectAttr(this->conn, SQL_ATTR_ASYNC_DBC_PCONTEXT, 0, 0));
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorStateHYC00);
+  ASSERT_EQ(SQL_ERROR, SQLSetConnectAttr(conn, SQL_ATTR_ASYNC_DBC_PCONTEXT, 0, 0));
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorStateHYC00);
 }
 #endif
 
 TYPED_TEST(ConnectionAttributeTest, TestSQLSetConnectAttrAutoIpdReadOnly) {
   // Verify read-only attribute cannot be set
-  ASSERT_EQ(SQL_ERROR, SQLSetConnectAttr(this->conn, SQL_ATTR_AUTO_IPD, 0, 0));
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorStateHY092);
+  ASSERT_EQ(SQL_ERROR, SQLSetConnectAttr(conn, SQL_ATTR_AUTO_IPD, 0, 0));
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorStateHY092);
 }
 
 TYPED_TEST(ConnectionAttributeTest, TestSQLSetConnectAttrConnectionDeadReadOnly) {
   // Verify read-only attribute cannot be set
-  ASSERT_EQ(SQL_ERROR, SQLSetConnectAttr(this->conn, SQL_ATTR_CONNECTION_DEAD, 0, 0));
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorStateHY092);
+  ASSERT_EQ(SQL_ERROR, SQLSetConnectAttr(conn, SQL_ATTR_CONNECTION_DEAD, 0, 0));
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorStateHY092);
 }
 
 #ifdef SQL_ATTR_DBC_INFO_TOKEN
 TYPED_TEST(ConnectionAttributeTest, TestSQLSetConnectAttrDbcInfoTokenUnsupported) {
-  ASSERT_EQ(SQL_ERROR, SQLSetConnectAttr(this->conn, SQL_ATTR_DBC_INFO_TOKEN, 0, 0));
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorStateHYC00);
+  ASSERT_EQ(SQL_ERROR, SQLSetConnectAttr(conn, SQL_ATTR_DBC_INFO_TOKEN, 0, 0));
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorStateHYC00);
 }
 #endif
 
 TYPED_TEST(ConnectionAttributeTest, TestSQLSetConnectAttrEnlistInDtcUnsupported) {
-  ASSERT_EQ(SQL_ERROR, SQLSetConnectAttr(this->conn, SQL_ATTR_ENLIST_IN_DTC, 0, 0));
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorStateHYC00);
+  ASSERT_EQ(SQL_ERROR, SQLSetConnectAttr(conn, SQL_ATTR_ENLIST_IN_DTC, 0, 0));
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorStateHYC00);
 }
 
 TYPED_TEST(ConnectionAttributeTest, TestSQLSetConnectAttrOdbcCursorsDMOnly) {
@@ -91,7 +91,7 @@ TYPED_TEST(ConnectionAttributeTest, TestSQLSetConnectAttrOdbcCursorsDMOnly) {
 
   // Verify DM-only attribute is settable via Driver Manager
   ASSERT_EQ(SQL_SUCCESS,
-            SQLSetConnectAttr(this->conn, SQL_ATTR_ODBC_CURSORS,
+            SQLSetConnectAttr(conn, SQL_ATTR_ODBC_CURSORS,
                               reinterpret_cast<SQLPOINTER>(SQL_CUR_USE_DRIVER), 0));
 
   std::string connect_str = this->GetConnectionString();
@@ -100,16 +100,19 @@ TYPED_TEST(ConnectionAttributeTest, TestSQLSetConnectAttrOdbcCursorsDMOnly) {
 
 TYPED_TEST(ConnectionAttributeTest, TestSQLSetConnectAttrQuietModeReadOnly) {
   // Verify read-only attribute cannot be set
-  ASSERT_EQ(SQL_ERROR, SQLSetConnectAttr(this->conn, SQL_ATTR_QUIET_MODE, 0, 0));
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorStateHY092);
+  ASSERT_EQ(SQL_ERROR, SQLSetConnectAttr(conn, SQL_ATTR_QUIET_MODE, 0, 0));
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorStateHY092);
 }
 
+// iODBC needs to be compiled with tracing enabled to handle SQL_ATTR_TRACE
+#ifndef __APPLE__
 TYPED_TEST(ConnectionAttributeTest, TestSQLSetConnectAttrTraceDMOnly) {
   // Verify DM-only attribute is settable via Driver Manager
   ASSERT_EQ(SQL_SUCCESS,
-            SQLSetConnectAttr(this->conn, SQL_ATTR_TRACE,
+            SQLSetConnectAttr(conn, SQL_ATTR_TRACE,
                               reinterpret_cast<SQLPOINTER>(SQL_OPT_TRACE_OFF), 0));
 }
+#endif  // __APPLE__
 
 TYPED_TEST(ConnectionAttributeTest, TestSQLSetConnectAttrTracefileDMOnly) {
   // Verify DM-only attribute is handled by Driver Manager
@@ -118,90 +121,101 @@ TYPED_TEST(ConnectionAttributeTest, TestSQLSetConnectAttrTracefileDMOnly) {
   // the driver manager will produce a trace file.
   std::wstring trace_file = L"invalid/file/path";
   std::vector<SQLWCHAR> trace_file0(trace_file.begin(), trace_file.end());
-  ASSERT_EQ(SQL_ERROR, SQLSetConnectAttr(this->conn, SQL_ATTR_TRACEFILE, &trace_file0[0],
+  ASSERT_EQ(SQL_ERROR, SQLSetConnectAttr(conn, SQL_ATTR_TRACEFILE, &trace_file0[0],
                                          static_cast<SQLINTEGER>(trace_file0.size())));
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorStateHY000);
+#ifdef __APPLE__
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorStateHYC00);
+#else
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorStateHY000);
+#endif  // __APPLE__
 }
 
 TYPED_TEST(ConnectionAttributeTest, TestSQLSetConnectAttrTranslateLabDMOnly) {
   // Verify DM-only attribute is handled by Driver Manager
-  ASSERT_EQ(SQL_ERROR, SQLSetConnectAttr(this->conn, SQL_ATTR_TRANSLATE_LIB, 0, 0));
+  ASSERT_EQ(SQL_ERROR, SQLSetConnectAttr(conn, SQL_ATTR_TRANSLATE_LIB, 0, 0));
   // Checks for invalid argument return error
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorStateHY024);
+#ifdef __APPLE__
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorStateHYC00);
+#else
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorStateHY024);
+#endif  // __APPLE__
 }
 
 TYPED_TEST(ConnectionAttributeTest, TestSQLSetConnectAttrTranslateOptionUnsupported) {
-  ASSERT_EQ(SQL_ERROR, SQLSetConnectAttr(this->conn, SQL_ATTR_TRANSLATE_OPTION, 0, 0));
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorStateHYC00);
+  ASSERT_EQ(SQL_ERROR, SQLSetConnectAttr(conn, SQL_ATTR_TRANSLATE_OPTION, 0, 0));
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorStateHYC00);
 }
 
 TYPED_TEST(ConnectionAttributeTest, TestSQLSetConnectAttrTxnIsolationUnsupported) {
   ASSERT_EQ(SQL_ERROR,
-            SQLSetConnectAttr(this->conn, SQL_ATTR_TXN_ISOLATION,
+            SQLSetConnectAttr(conn, SQL_ATTR_TXN_ISOLATION,
                               reinterpret_cast<SQLPOINTER>(SQL_TXN_READ_UNCOMMITTED), 0));
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorStateHYC00);
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorStateHYC00);
 }
 
 #ifdef SQL_ATTR_DBC_INFO_TOKEN
 TYPED_TEST(ConnectionAttributeTest, TestSQLGetConnectAttrDbcInfoTokenSetOnly) {
   // Verify that set-only attribute cannot be read
   SQLPOINTER ptr = NULL;
-  ASSERT_EQ(SQL_ERROR,
-            SQLGetConnectAttr(this->conn, SQL_ATTR_DBC_INFO_TOKEN, ptr, 0, nullptr));
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorStateHY092);
+  ASSERT_EQ(SQL_ERROR, SQLGetConnectAttr(conn, SQL_ATTR_DBC_INFO_TOKEN, ptr, 0, nullptr));
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorStateHY092);
 }
 #endif
 
+// iODBC does not treat SQL_ATTR_ODBC_CURSORS as DM-only
+#ifndef __APPLE__
 TYPED_TEST(ConnectionAttributeTest, TestSQLGetConnectAttrOdbcCursorsDMOnly) {
   // Verify that DM-only attribute is handled by driver manager
   SQLULEN cursor_attr;
-  ASSERT_EQ(SQL_SUCCESS, SQLGetConnectAttr(this->conn, SQL_ATTR_ODBC_CURSORS,
-                                           &cursor_attr, 0, nullptr));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetConnectAttr(conn, SQL_ATTR_ODBC_CURSORS, &cursor_attr, 0, nullptr));
   EXPECT_EQ(SQL_CUR_USE_DRIVER, cursor_attr);
 }
 
+// iODBC needs to be compiled with tracing enabled to handle SQL_ATTR_TRACE
 TYPED_TEST(ConnectionAttributeTest, TestSQLGetConnectAttrTraceDMOnly) {
   // Verify that DM-only attribute is handled by driver manager
   SQLUINTEGER trace;
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetConnectAttr(this->conn, SQL_ATTR_TRACE, &trace, 0, nullptr));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetConnectAttr(conn, SQL_ATTR_TRACE, &trace, 0, nullptr));
   EXPECT_EQ(SQL_OPT_TRACE_OFF, trace);
 }
 
+// iODBC needs to be compiled with tracing enabled to handle SQL_ATTR_TRACEFILE
 TYPED_TEST(ConnectionAttributeTest, TestSQLGetConnectAttrTraceFileDMOnly) {
   // Verify that DM-only attribute is handled by driver manager
   SQLWCHAR out_str[kOdbcBufferSize];
   SQLINTEGER out_str_len;
-  ASSERT_EQ(SQL_SUCCESS, SQLGetConnectAttr(this->conn, SQL_ATTR_TRACEFILE, out_str,
+  ASSERT_EQ(SQL_SUCCESS, SQLGetConnectAttr(conn, SQL_ATTR_TRACEFILE, out_str,
                                            kOdbcBufferSize, &out_str_len));
   // Length is returned in bytes for SQLGetConnectAttr,
   // we want the number of characters
-  out_str_len /= arrow::flight::sql::odbc::GetSqlWCharSize();
+  out_str_len /= GetSqlWCharSize();
   std::string out_connection_string =
       ODBC::SqlWcharToString(out_str, static_cast<SQLSMALLINT>(out_str_len));
   EXPECT_FALSE(out_connection_string.empty());
 }
+#endif  // __APPLE__
 
 TYPED_TEST(ConnectionAttributeTest, TestSQLGetConnectAttrTranslateLibUnsupported) {
   SQLWCHAR out_str[kOdbcBufferSize];
   SQLINTEGER out_str_len;
-  ASSERT_EQ(SQL_ERROR, SQLGetConnectAttr(this->conn, SQL_ATTR_TRANSLATE_LIB, out_str,
+  ASSERT_EQ(SQL_ERROR, SQLGetConnectAttr(conn, SQL_ATTR_TRANSLATE_LIB, out_str,
                                          kOdbcBufferSize, &out_str_len));
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorStateHYC00);
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorStateHYC00);
 }
 
 TYPED_TEST(ConnectionAttributeTest, TestSQLGetConnectAttrTranslateOptionUnsupported) {
   SQLINTEGER option;
-  ASSERT_EQ(SQL_ERROR, SQLGetConnectAttr(this->conn, SQL_ATTR_TRANSLATE_OPTION, &option,
-                                         0, nullptr));
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorStateHYC00);
+  ASSERT_EQ(SQL_ERROR,
+            SQLGetConnectAttr(conn, SQL_ATTR_TRANSLATE_OPTION, &option, 0, nullptr));
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorStateHYC00);
 }
 
 TYPED_TEST(ConnectionAttributeTest, TestSQLGetConnectAttrTxnIsolationUnsupported) {
   SQLINTEGER isolation;
-  ASSERT_EQ(SQL_ERROR, SQLGetConnectAttr(this->conn, SQL_ATTR_TXN_ISOLATION, &isolation,
-                                         0, nullptr));
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorStateHYC00);
+  ASSERT_EQ(SQL_ERROR,
+            SQLGetConnectAttr(conn, SQL_ATTR_TXN_ISOLATION, &isolation, 0, nullptr));
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorStateHYC00);
 }
 
 #ifdef SQL_ATTR_ASYNC_DBC_FUNCTIONS_ENABLE
@@ -209,9 +223,9 @@ TYPED_TEST(ConnectionAttributeTest,
            TestSQLGetConnectAttrAsyncDbcFunctionsEnableUnsupported) {
   // Verifies that the Windows driver manager returns HY114 for unsupported functionality
   SQLUINTEGER enable;
-  ASSERT_EQ(SQL_ERROR, SQLGetConnectAttr(this->conn, SQL_ATTR_ASYNC_DBC_FUNCTIONS_ENABLE,
-                                         &enable, 0, 0));
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorStateHY114);
+  ASSERT_EQ(SQL_ERROR,
+            SQLGetConnectAttr(conn, SQL_ATTR_ASYNC_DBC_FUNCTIONS_ENABLE, &enable, 0, 0));
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorStateHY114);
 }
 #endif
 
@@ -221,7 +235,7 @@ TYPED_TEST(ConnectionAttributeTest,
 TYPED_TEST(ConnectionAttributeTest, TestSQLGetConnectAttrAsyncDbcEventDefault) {
   SQLPOINTER ptr = NULL;
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetConnectAttr(this->conn, SQL_ATTR_ASYNC_DBC_EVENT, ptr, 0, nullptr));
+            SQLGetConnectAttr(conn, SQL_ATTR_ASYNC_DBC_EVENT, ptr, 0, nullptr));
   EXPECT_EQ(reinterpret_cast<SQLPOINTER>(NULL), ptr);
 }
 #endif
@@ -230,7 +244,7 @@ TYPED_TEST(ConnectionAttributeTest, TestSQLGetConnectAttrAsyncDbcEventDefault) {
 TYPED_TEST(ConnectionAttributeTest, TestSQLGetConnectAttrAsyncDbcPcallbackDefault) {
   SQLPOINTER ptr = NULL;
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetConnectAttr(this->conn, SQL_ATTR_ASYNC_DBC_PCALLBACK, ptr, 0, nullptr));
+            SQLGetConnectAttr(conn, SQL_ATTR_ASYNC_DBC_PCALLBACK, ptr, 0, nullptr));
   EXPECT_EQ(reinterpret_cast<SQLPOINTER>(NULL), ptr);
 }
 #endif
@@ -239,7 +253,7 @@ TYPED_TEST(ConnectionAttributeTest, TestSQLGetConnectAttrAsyncDbcPcallbackDefaul
 TYPED_TEST(ConnectionAttributeTest, TestSQLGetConnectAttrAsyncDbcPcontextDefault) {
   SQLPOINTER ptr = NULL;
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetConnectAttr(this->conn, SQL_ATTR_ASYNC_DBC_PCONTEXT, ptr, 0, nullptr));
+            SQLGetConnectAttr(conn, SQL_ATTR_ASYNC_DBC_PCONTEXT, ptr, 0, nullptr));
   EXPECT_EQ(reinterpret_cast<SQLPOINTER>(NULL), ptr);
 }
 #endif
@@ -247,35 +261,33 @@ TYPED_TEST(ConnectionAttributeTest, TestSQLGetConnectAttrAsyncDbcPcontextDefault
 TYPED_TEST(ConnectionAttributeTest, TestSQLGetConnectAttrAsyncEnableDefault) {
   SQLULEN enable;
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetConnectAttr(this->conn, SQL_ATTR_ASYNC_ENABLE, &enable, 0, nullptr));
+            SQLGetConnectAttr(conn, SQL_ATTR_ASYNC_ENABLE, &enable, 0, nullptr));
   EXPECT_EQ(SQL_ASYNC_ENABLE_OFF, enable);
 }
 
 TYPED_TEST(ConnectionAttributeTest, TestSQLGetConnectAttrAutoIpdDefault) {
   SQLUINTEGER ipd;
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetConnectAttr(this->conn, SQL_ATTR_AUTO_IPD, &ipd, 0, nullptr));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetConnectAttr(conn, SQL_ATTR_AUTO_IPD, &ipd, 0, nullptr));
   EXPECT_EQ(static_cast<SQLUINTEGER>(SQL_FALSE), ipd);
 }
 
 TYPED_TEST(ConnectionAttributeTest, TestSQLGetConnectAttrAutocommitDefault) {
   SQLUINTEGER auto_commit;
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetConnectAttr(this->conn, SQL_ATTR_AUTOCOMMIT, &auto_commit, 0, nullptr));
+            SQLGetConnectAttr(conn, SQL_ATTR_AUTOCOMMIT, &auto_commit, 0, nullptr));
   EXPECT_EQ(SQL_AUTOCOMMIT_ON, auto_commit);
 }
 
 TYPED_TEST(ConnectionAttributeTest, TestSQLGetConnectAttrEnlistInDtcDefault) {
   SQLPOINTER ptr = NULL;
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetConnectAttr(this->conn, SQL_ATTR_ENLIST_IN_DTC, ptr, 0, nullptr));
+            SQLGetConnectAttr(conn, SQL_ATTR_ENLIST_IN_DTC, ptr, 0, nullptr));
   EXPECT_EQ(reinterpret_cast<SQLPOINTER>(NULL), ptr);
 }
 
 TYPED_TEST(ConnectionAttributeTest, TestSQLGetConnectAttrQuietModeDefault) {
   HWND ptr = NULL;
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetConnectAttr(this->conn, SQL_ATTR_QUIET_MODE, ptr, 0, nullptr));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetConnectAttr(conn, SQL_ATTR_QUIET_MODE, ptr, 0, nullptr));
   EXPECT_EQ(reinterpret_cast<SQLPOINTER>(NULL), ptr);
 }
 
@@ -285,40 +297,40 @@ TYPED_TEST(ConnectionAttributeTest, TestSQLSetConnectAttrAccessModeValid) {
   // Check default value first
   SQLUINTEGER mode = -1;
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetConnectAttr(this->conn, SQL_ATTR_ACCESS_MODE, &mode, 0, nullptr));
+            SQLGetConnectAttr(conn, SQL_ATTR_ACCESS_MODE, &mode, 0, nullptr));
   EXPECT_EQ(SQL_MODE_READ_WRITE, mode);
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLSetConnectAttr(this->conn, SQL_ATTR_ACCESS_MODE,
+            SQLSetConnectAttr(conn, SQL_ATTR_ACCESS_MODE,
                               reinterpret_cast<SQLPOINTER>(SQL_MODE_READ_WRITE), 0));
 
   mode = -1;
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetConnectAttr(this->conn, SQL_ATTR_ACCESS_MODE, &mode, 0, nullptr));
+            SQLGetConnectAttr(conn, SQL_ATTR_ACCESS_MODE, &mode, 0, nullptr));
   EXPECT_EQ(SQL_MODE_READ_WRITE, mode);
 
   // Attempt to set to SQL_MODE_READ_ONLY, driver should return warning and not error
   EXPECT_EQ(SQL_SUCCESS_WITH_INFO,
-            SQLSetConnectAttr(this->conn, SQL_ATTR_ACCESS_MODE,
+            SQLSetConnectAttr(conn, SQL_ATTR_ACCESS_MODE,
                               reinterpret_cast<SQLPOINTER>(SQL_MODE_READ_ONLY), 0));
 
   // Verify warning status
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorState01S02);
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorState01S02);
 }
 
 TYPED_TEST(ConnectionAttributeTest, TestSQLSetConnectAttrConnectionTimeoutValid) {
   // Check default value first
   SQLUINTEGER timeout = -1;
-  ASSERT_EQ(SQL_SUCCESS, SQLGetConnectAttr(this->conn, SQL_ATTR_CONNECTION_TIMEOUT,
-                                           &timeout, 0, nullptr));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetConnectAttr(conn, SQL_ATTR_CONNECTION_TIMEOUT, &timeout, 0, nullptr));
   EXPECT_EQ(0, timeout);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLSetConnectAttr(this->conn, SQL_ATTR_CONNECTION_TIMEOUT,
+  ASSERT_EQ(SQL_SUCCESS, SQLSetConnectAttr(conn, SQL_ATTR_CONNECTION_TIMEOUT,
                                            reinterpret_cast<SQLPOINTER>(42), 0));
 
   timeout = -1;
-  ASSERT_EQ(SQL_SUCCESS, SQLGetConnectAttr(this->conn, SQL_ATTR_CONNECTION_TIMEOUT,
-                                           &timeout, 0, nullptr));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetConnectAttr(conn, SQL_ATTR_CONNECTION_TIMEOUT, &timeout, 0, nullptr));
   EXPECT_EQ(42, timeout);
 }
 
@@ -326,15 +338,15 @@ TYPED_TEST(ConnectionAttributeTest, TestSQLSetConnectAttrLoginTimeoutValid) {
   // Check default value first
   SQLUINTEGER timeout = -1;
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetConnectAttr(this->conn, SQL_ATTR_LOGIN_TIMEOUT, &timeout, 0, nullptr));
+            SQLGetConnectAttr(conn, SQL_ATTR_LOGIN_TIMEOUT, &timeout, 0, nullptr));
   EXPECT_EQ(0, timeout);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLSetConnectAttr(this->conn, SQL_ATTR_LOGIN_TIMEOUT,
+  ASSERT_EQ(SQL_SUCCESS, SQLSetConnectAttr(conn, SQL_ATTR_LOGIN_TIMEOUT,
                                            reinterpret_cast<SQLPOINTER>(42), 0));
 
   timeout = -1;
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetConnectAttr(this->conn, SQL_ATTR_LOGIN_TIMEOUT, &timeout, 0, nullptr));
+            SQLGetConnectAttr(conn, SQL_ATTR_LOGIN_TIMEOUT, &timeout, 0, nullptr));
   EXPECT_EQ(42, timeout);
 }
 
@@ -344,23 +356,23 @@ TYPED_TEST(ConnectionAttributeTest, TestSQLSetConnectAttrPacketSizeValid) {
   // Check default value first
   SQLUINTEGER size = -1;
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetConnectAttr(this->conn, SQL_ATTR_PACKET_SIZE, &size, 0, nullptr));
+            SQLGetConnectAttr(conn, SQL_ATTR_PACKET_SIZE, &size, 0, nullptr));
   EXPECT_EQ(0, size);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLSetConnectAttr(this->conn, SQL_ATTR_PACKET_SIZE,
+  ASSERT_EQ(SQL_SUCCESS, SQLSetConnectAttr(conn, SQL_ATTR_PACKET_SIZE,
                                            reinterpret_cast<SQLPOINTER>(0), 0));
 
   size = -1;
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetConnectAttr(this->conn, SQL_ATTR_PACKET_SIZE, &size, 0, nullptr));
+            SQLGetConnectAttr(conn, SQL_ATTR_PACKET_SIZE, &size, 0, nullptr));
   EXPECT_EQ(0, size);
 
   // Attempt to set to non-zero value, driver should return warning and not error
-  EXPECT_EQ(SQL_SUCCESS_WITH_INFO, SQLSetConnectAttr(this->conn, SQL_ATTR_PACKET_SIZE,
+  EXPECT_EQ(SQL_SUCCESS_WITH_INFO, SQLSetConnectAttr(conn, SQL_ATTR_PACKET_SIZE,
                                                      reinterpret_cast<SQLPOINTER>(2), 0));
 
   // Verify warning status
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorState01S02);
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorState01S02);
 }
 
 }  // namespace arrow::flight::sql::odbc

--- a/cpp/src/arrow/flight/sql/odbc/tests/connection_info_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/connection_info_test.cc
@@ -73,10 +73,10 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoTruncation) {
   SQLSMALLINT message_length;
 
   ASSERT_EQ(SQL_SUCCESS_WITH_INFO,
-            SQLGetInfo(this->conn, SQL_KEYWORDS, value, info_len, &message_length));
+            SQLGetInfo(conn, SQL_INTEGRITY, value, info_len, &message_length));
 
   // Verify string truncation is reported
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorState01004);
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorState01004);
   EXPECT_GT(message_length, 0);
 }
 
@@ -84,7 +84,7 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoTruncation) {
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoActiveEnvironments) {
   SQLUSMALLINT value;
-  GetInfo(this->conn, SQL_ACTIVE_ENVIRONMENTS, &value);
+  GetInfo(conn, SQL_ACTIVE_ENVIRONMENTS, &value);
 
   EXPECT_EQ(static_cast<SQLUSMALLINT>(0), value);
 }
@@ -92,7 +92,7 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoActiveEnvironments) {
 #ifdef SQL_ASYNC_DBC_FUNCTIONS
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoAsyncDbcFunctions) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_ASYNC_DBC_FUNCTIONS, &value);
+  GetInfo(conn, SQL_ASYNC_DBC_FUNCTIONS, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(SQL_ASYNC_DBC_NOT_CAPABLE), value);
 }
@@ -100,7 +100,7 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoAsyncDbcFunctions) {
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoAsyncMode) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_ASYNC_MODE, &value);
+  GetInfo(conn, SQL_ASYNC_MODE, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(SQL_AM_NONE), value);
 }
@@ -108,7 +108,7 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoAsyncMode) {
 #ifdef SQL_ASYNC_NOTIFICATION
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoAsyncNotification) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_ASYNC_NOTIFICATION, &value);
+  GetInfo(conn, SQL_ASYNC_NOTIFICATION, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(SQL_ASYNC_NOTIFICATION_NOT_CAPABLE), value);
 }
@@ -116,21 +116,21 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoAsyncNotification) {
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoBatchRowCount) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_BATCH_ROW_COUNT, &value);
+  GetInfo(conn, SQL_BATCH_ROW_COUNT, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoBatchSupport) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_BATCH_SUPPORT, &value);
+  GetInfo(conn, SQL_BATCH_SUPPORT, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDataSourceName) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_DATA_SOURCE_NAME, value);
+  GetInfo(conn, SQL_DATA_SOURCE_NAME, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L""), value);
 }
@@ -142,7 +142,7 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDriverAwarePoolingSupported) {
   // driver's return value for it.
 
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_DRIVER_AWARE_POOLING_SUPPORTED, &value);
+  GetInfo(conn, SQL_DRIVER_AWARE_POOLING_SUPPORTED, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(SQL_DRIVER_AWARE_POOLING_NOT_CAPABLE), value);
 }
@@ -152,7 +152,7 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDriverAwarePoolingSupported) {
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDriverHdbc) {
   // Value returned from driver manager is the connection address
   SQLULEN value;
-  GetInfo(this->conn, SQL_DRIVER_HDBC, &value);
+  GetInfo(conn, SQL_DRIVER_HDBC, &value);
 
   EXPECT_GT(value, static_cast<SQLULEN>(0));
 }
@@ -162,12 +162,11 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDriverHdesc) {
   SQLHDESC descriptor;
 
   // Allocate a descriptor using alloc handle
-  ASSERT_EQ(SQL_SUCCESS, SQLAllocHandle(SQL_HANDLE_DESC, this->conn, &descriptor));
+  ASSERT_EQ(SQL_SUCCESS, SQLAllocHandle(SQL_HANDLE_DESC, conn, &descriptor));
 
   // Value returned from driver manager is the desc address
   SQLHDESC local_desc = descriptor;
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetInfo(this->conn, SQL_HANDLE_DESC, &local_desc, 0, nullptr));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetInfo(conn, SQL_HANDLE_DESC, &local_desc, 0, nullptr));
   EXPECT_GT(local_desc, static_cast<SQLHSTMT>(0));
 
   // Free descriptor handle
@@ -178,7 +177,7 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDriverHdesc) {
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDriverHenv) {
   // Value returned from driver manager is the env address
   SQLULEN value;
-  GetInfo(this->conn, SQL_DRIVER_HENV, &value);
+  GetInfo(conn, SQL_DRIVER_HENV, &value);
 
   EXPECT_GT(value, static_cast<SQLULEN>(0));
 }
@@ -186,7 +185,7 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDriverHenv) {
 // These information types are implemented by the Driver Manager alone.
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDriverHlib) {
   SQLULEN value;
-  GetInfo(this->conn, SQL_DRIVER_HLIB, &value);
+  GetInfo(conn, SQL_DRIVER_HLIB, &value);
 
   EXPECT_GT(value, static_cast<SQLULEN>(0));
 }
@@ -194,78 +193,77 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDriverHlib) {
 // These information types are implemented by the Driver Manager alone.
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDriverHstmt) {
   // Value returned from driver manager is the stmt address
-  SQLHSTMT local_stmt = this->stmt;
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetInfo(this->conn, SQL_DRIVER_HSTMT, &local_stmt, 0, nullptr));
+  SQLHSTMT local_stmt = stmt;
+  ASSERT_EQ(SQL_SUCCESS, SQLGetInfo(conn, SQL_DRIVER_HSTMT, &local_stmt, 0, nullptr));
   EXPECT_GT(local_stmt, static_cast<SQLHSTMT>(0));
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDriverName) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_DRIVER_NAME, value);
+  GetInfo(conn, SQL_DRIVER_NAME, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"Arrow Flight ODBC Driver"), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDriverOdbcVer) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_DRIVER_ODBC_VER, value);
+  GetInfo(conn, SQL_DRIVER_ODBC_VER, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"03.80"), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDriverVer) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_DRIVER_VER, value);
+  GetInfo(conn, SQL_DRIVER_VER, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"00.09.0000.0"), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDynamicCursorAttributes1) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_DYNAMIC_CURSOR_ATTRIBUTES1, &value);
+  GetInfo(conn, SQL_DYNAMIC_CURSOR_ATTRIBUTES1, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDynamicCursorAttributes2) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_DYNAMIC_CURSOR_ATTRIBUTES2, &value);
+  GetInfo(conn, SQL_DYNAMIC_CURSOR_ATTRIBUTES2, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoForwardOnlyCursorAttributes1) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_FORWARD_ONLY_CURSOR_ATTRIBUTES1, &value);
+  GetInfo(conn, SQL_FORWARD_ONLY_CURSOR_ATTRIBUTES1, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(SQL_CA1_NEXT), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoForwardOnlyCursorAttributes2) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_FORWARD_ONLY_CURSOR_ATTRIBUTES2, &value);
+  GetInfo(conn, SQL_FORWARD_ONLY_CURSOR_ATTRIBUTES2, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(SQL_CA2_READ_ONLY_CONCURRENCY), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoFileUsage) {
   SQLUSMALLINT value;
-  GetInfo(this->conn, SQL_FILE_USAGE, &value);
+  GetInfo(conn, SQL_FILE_USAGE, &value);
 
   EXPECT_EQ(static_cast<SQLUSMALLINT>(SQL_FILE_NOT_SUPPORTED), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoGetDataExtensions) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_GETDATA_EXTENSIONS, &value);
+  GetInfo(conn, SQL_GETDATA_EXTENSIONS, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(SQL_GD_ANY_COLUMN | SQL_GD_ANY_ORDER), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoSchemaViews) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_INFO_SCHEMA_VIEWS, &value);
+  GetInfo(conn, SQL_INFO_SCHEMA_VIEWS, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(SQL_ISV_TABLES | SQL_ISV_COLUMNS | SQL_ISV_VIEWS),
             value);
@@ -273,42 +271,42 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoSchemaViews) {
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoKeysetCursorAttributes1) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_KEYSET_CURSOR_ATTRIBUTES1, &value);
+  GetInfo(conn, SQL_KEYSET_CURSOR_ATTRIBUTES1, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoKeysetCursorAttributes2) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_KEYSET_CURSOR_ATTRIBUTES2, &value);
+  GetInfo(conn, SQL_KEYSET_CURSOR_ATTRIBUTES2, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoMaxAsyncConcurrentStatements) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_MAX_ASYNC_CONCURRENT_STATEMENTS, &value);
+  GetInfo(conn, SQL_MAX_ASYNC_CONCURRENT_STATEMENTS, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoMaxConcurrentActivities) {
   SQLUSMALLINT value;
-  GetInfo(this->conn, SQL_MAX_CONCURRENT_ACTIVITIES, &value);
+  GetInfo(conn, SQL_MAX_CONCURRENT_ACTIVITIES, &value);
 
   EXPECT_EQ(static_cast<SQLUSMALLINT>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoMaxDriverConnections) {
   SQLUSMALLINT value;
-  GetInfo(this->conn, SQL_MAX_DRIVER_CONNECTIONS, &value);
+  GetInfo(conn, SQL_MAX_DRIVER_CONNECTIONS, &value);
 
   EXPECT_EQ(static_cast<SQLUSMALLINT>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoOdbcInterfaceConformance) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_ODBC_INTERFACE_CONFORMANCE, &value);
+  GetInfo(conn, SQL_ODBC_INTERFACE_CONFORMANCE, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(SQL_OIC_CORE), value);
 }
@@ -317,56 +315,60 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoOdbcVer) {
   // This is implemented only in the Driver Manager.
 
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_ODBC_VER, value);
+  GetInfo(conn, SQL_ODBC_VER, value);
 
+#ifdef __APPLE__
+  EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"03.52.0000"), value);
+#else
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"03.80.0000"), value);
+#endif  // __APPLE__
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoParamArrayRowCounts) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_PARAM_ARRAY_ROW_COUNTS, &value);
+  GetInfo(conn, SQL_PARAM_ARRAY_ROW_COUNTS, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(SQL_PARC_NO_BATCH), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoParamArraySelects) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_PARAM_ARRAY_SELECTS, &value);
+  GetInfo(conn, SQL_PARAM_ARRAY_SELECTS, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(SQL_PAS_NO_SELECT), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoRowUpdates) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_ROW_UPDATES, value);
+  GetInfo(conn, SQL_ROW_UPDATES, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"N"), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoSearchPatternEscape) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_SEARCH_PATTERN_ESCAPE, value);
+  GetInfo(conn, SQL_SEARCH_PATTERN_ESCAPE, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"\\"), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoServerName) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_SERVER_NAME, value);
+  GetInfo(conn, SQL_SERVER_NAME, value);
 
   EXPECT_GT(wcslen(value), 0);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoStaticCursorAttributes1) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_STATIC_CURSOR_ATTRIBUTES1, &value);
+  GetInfo(conn, SQL_STATIC_CURSOR_ATTRIBUTES1, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoStaticCursorAttributes2) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_STATIC_CURSOR_ATTRIBUTES2, &value);
+  GetInfo(conn, SQL_STATIC_CURSOR_ATTRIBUTES2, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
@@ -375,21 +377,21 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoStaticCursorAttributes2) {
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDatabaseName) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_DATABASE_NAME, value);
+  GetInfo(conn, SQL_DATABASE_NAME, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L""), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDbmsName) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_DBMS_NAME, value);
+  GetInfo(conn, SQL_DBMS_NAME, value);
 
   EXPECT_GT(wcslen(value), 0);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDbmsVer) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_DBMS_VER, value);
+  GetInfo(conn, SQL_DBMS_VER, value);
 
   EXPECT_GT(wcslen(value), 0);
 }
@@ -398,160 +400,160 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDbmsVer) {
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoAccessibleProcedures) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_ACCESSIBLE_PROCEDURES, value);
+  GetInfo(conn, SQL_ACCESSIBLE_PROCEDURES, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"N"), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoAccessibleTables) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_ACCESSIBLE_TABLES, value);
+  GetInfo(conn, SQL_ACCESSIBLE_TABLES, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"Y"), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoBookmarkPersistence) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_BOOKMARK_PERSISTENCE, &value);
+  GetInfo(conn, SQL_BOOKMARK_PERSISTENCE, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoCatalogTerm) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_CATALOG_TERM, value);
+  GetInfo(conn, SQL_CATALOG_TERM, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L""), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoCollationSeq) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_COLLATION_SEQ, value);
+  GetInfo(conn, SQL_COLLATION_SEQ, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L""), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoConcatNullBehavior) {
   SQLUSMALLINT value;
-  GetInfo(this->conn, SQL_CONCAT_NULL_BEHAVIOR, &value);
+  GetInfo(conn, SQL_CONCAT_NULL_BEHAVIOR, &value);
 
   EXPECT_EQ(static_cast<SQLUSMALLINT>(SQL_CB_NULL), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoCursorCommitBehavior) {
   SQLUSMALLINT value;
-  GetInfo(this->conn, SQL_CURSOR_COMMIT_BEHAVIOR, &value);
+  GetInfo(conn, SQL_CURSOR_COMMIT_BEHAVIOR, &value);
 
   EXPECT_EQ(static_cast<SQLUSMALLINT>(SQL_CB_CLOSE), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoCursorRollbackBehavior) {
   SQLUSMALLINT value;
-  GetInfo(this->conn, SQL_CURSOR_ROLLBACK_BEHAVIOR, &value);
+  GetInfo(conn, SQL_CURSOR_ROLLBACK_BEHAVIOR, &value);
 
   EXPECT_EQ(static_cast<SQLUSMALLINT>(SQL_CB_CLOSE), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoCursorSensitivity) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_CURSOR_SENSITIVITY, &value);
+  GetInfo(conn, SQL_CURSOR_SENSITIVITY, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(SQL_UNSPECIFIED), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDataSourceReadOnly) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_DATA_SOURCE_READ_ONLY, value);
+  GetInfo(conn, SQL_DATA_SOURCE_READ_ONLY, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"N"), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDefaultTxnIsolation) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_DEFAULT_TXN_ISOLATION, &value);
+  GetInfo(conn, SQL_DEFAULT_TXN_ISOLATION, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDescribeParameter) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_DESCRIBE_PARAMETER, value);
+  GetInfo(conn, SQL_DESCRIBE_PARAMETER, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"N"), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoMultResultSets) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_MULT_RESULT_SETS, value);
+  GetInfo(conn, SQL_MULT_RESULT_SETS, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"N"), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoMultipleActiveTxn) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_MULTIPLE_ACTIVE_TXN, value);
+  GetInfo(conn, SQL_MULTIPLE_ACTIVE_TXN, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"N"), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoNeedLongDataLen) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_NEED_LONG_DATA_LEN, value);
+  GetInfo(conn, SQL_NEED_LONG_DATA_LEN, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"N"), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoNullCollation) {
   SQLUSMALLINT value;
-  GetInfo(this->conn, SQL_NULL_COLLATION, &value);
+  GetInfo(conn, SQL_NULL_COLLATION, &value);
   EXPECT_EQ(static_cast<SQLUSMALLINT>(SQL_NC_START), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoProcedureTerm) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_PROCEDURE_TERM, value);
+  GetInfo(conn, SQL_PROCEDURE_TERM, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L""), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoSchemaTerm) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_SCHEMA_TERM, value);
+  GetInfo(conn, SQL_SCHEMA_TERM, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"schema"), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoScrollOptions) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_SCROLL_OPTIONS, &value);
+  GetInfo(conn, SQL_SCROLL_OPTIONS, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(SQL_SO_FORWARD_ONLY), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoTableTerm) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_TABLE_TERM, value);
+  GetInfo(conn, SQL_TABLE_TERM, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"table"), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoTxnCapable) {
   SQLUSMALLINT value;
-  GetInfo(this->conn, SQL_TXN_CAPABLE, &value);
+  GetInfo(conn, SQL_TXN_CAPABLE, &value);
 
   EXPECT_EQ(static_cast<SQLUSMALLINT>(SQL_TC_NONE), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoTxnIsolationOption) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_TXN_ISOLATION_OPTION, &value);
+  GetInfo(conn, SQL_TXN_ISOLATION_OPTION, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoUserName) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_USER_NAME, value);
+  GetInfo(conn, SQL_USER_NAME, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L""), value);
 }
@@ -560,7 +562,7 @@ TEST_F(ConnectionInfoMockTest, TestSQLGetInfoUserName) {
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoAggregateFunctions) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_AGGREGATE_FUNCTIONS, &value);
+  GetInfo(conn, SQL_AGGREGATE_FUNCTIONS, &value);
 
   EXPECT_EQ(value, static_cast<SQLUINTEGER>(SQL_AF_ALL | SQL_AF_AVG | SQL_AF_COUNT |
                                             SQL_AF_DISTINCT | SQL_AF_MAX | SQL_AF_MIN |
@@ -569,210 +571,214 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoAggregateFunctions) {
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoAlterDomain) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_ALTER_DOMAIN, &value);
+  GetInfo(conn, SQL_ALTER_DOMAIN, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoAlterTable) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_ALTER_TABLE, &value);
+  GetInfo(conn, SQL_ALTER_TABLE, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
+#ifdef DISABLE_TEST
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoCatalogLocation) {
   SQLUSMALLINT value;
-  GetInfo(this->conn, SQL_CATALOG_LOCATION, &value);
+  GetInfo(conn, SQL_CATALOG_LOCATION, &value);
 
   EXPECT_EQ(static_cast<SQLUSMALLINT>(0), value);
 }
+#endif
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoCatalogName) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_CATALOG_NAME, value);
+  GetInfo(conn, SQL_CATALOG_NAME, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"N"), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoCatalogNameSeparator) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_CATALOG_NAME_SEPARATOR, value);
+  GetInfo(conn, SQL_CATALOG_NAME_SEPARATOR, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L""), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoCatalogUsage) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_CATALOG_USAGE, &value);
+  GetInfo(conn, SQL_CATALOG_USAGE, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoColumnAlias) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_COLUMN_ALIAS, value);
+  GetInfo(conn, SQL_COLUMN_ALIAS, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"Y"), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoCorrelationName) {
   SQLUSMALLINT value;
-  GetInfo(this->conn, SQL_CORRELATION_NAME, &value);
+  GetInfo(conn, SQL_CORRELATION_NAME, &value);
 
   EXPECT_EQ(static_cast<SQLUSMALLINT>(SQL_CN_NONE), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoCreateAssertion) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_CREATE_ASSERTION, &value);
+  GetInfo(conn, SQL_CREATE_ASSERTION, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoCreateCharacterSet) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_CREATE_CHARACTER_SET, &value);
+  GetInfo(conn, SQL_CREATE_CHARACTER_SET, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoCreateCollation) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_CREATE_COLLATION, &value);
+  GetInfo(conn, SQL_CREATE_COLLATION, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoCreateDomain) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_CREATE_DOMAIN, &value);
+  GetInfo(conn, SQL_CREATE_DOMAIN, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoCreateSchema) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_CREATE_SCHEMA, &value);
+  GetInfo(conn, SQL_CREATE_SCHEMA, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(1), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoCreateTable) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_CREATE_TABLE, &value);
+  GetInfo(conn, SQL_CREATE_TABLE, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(1), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoCreateTranslation) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_CREATE_TRANSLATION, &value);
+  GetInfo(conn, SQL_CREATE_TRANSLATION, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDdlIndex) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_DDL_INDEX, &value);
+  GetInfo(conn, SQL_DDL_INDEX, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDropAssertion) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_DROP_ASSERTION, &value);
+  GetInfo(conn, SQL_DROP_ASSERTION, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDropCharacterSet) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_DROP_CHARACTER_SET, &value);
+  GetInfo(conn, SQL_DROP_CHARACTER_SET, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDropCollation) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_DROP_COLLATION, &value);
+  GetInfo(conn, SQL_DROP_COLLATION, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDropDomain) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_DROP_DOMAIN, &value);
+  GetInfo(conn, SQL_DROP_DOMAIN, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
+#ifdef DISABLE_TEST
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDropSchema) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_DROP_SCHEMA, &value);
+  GetInfo(conn, SQL_DROP_SCHEMA, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDropTable) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_DROP_TABLE, &value);
+  GetInfo(conn, SQL_DROP_TABLE, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
+#endif
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDropTranslation) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_DROP_TRANSLATION, &value);
+  GetInfo(conn, SQL_DROP_TRANSLATION, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDropView) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_DROP_VIEW, &value);
+  GetInfo(conn, SQL_DROP_VIEW, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoExpressionsInOrderby) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_EXPRESSIONS_IN_ORDERBY, value);
+  GetInfo(conn, SQL_EXPRESSIONS_IN_ORDERBY, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"N"), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoGroupBy) {
   SQLUSMALLINT value;
-  GetInfo(this->conn, SQL_GROUP_BY, &value);
+  GetInfo(conn, SQL_GROUP_BY, &value);
 
   EXPECT_EQ(static_cast<SQLUSMALLINT>(SQL_GB_GROUP_BY_CONTAINS_SELECT), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoIdentifierCase) {
   SQLUSMALLINT value;
-  GetInfo(this->conn, SQL_IDENTIFIER_CASE, &value);
+  GetInfo(conn, SQL_IDENTIFIER_CASE, &value);
 
   EXPECT_EQ(static_cast<SQLUSMALLINT>(SQL_IC_MIXED), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoIdentifierQuoteChar) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_IDENTIFIER_QUOTE_CHAR, value);
+  GetInfo(conn, SQL_IDENTIFIER_QUOTE_CHAR, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"\""), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoIndexKeywords) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_INDEX_KEYWORDS, &value);
+  GetInfo(conn, SQL_INDEX_KEYWORDS, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(SQL_IK_NONE), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoInsertStatement) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_INSERT_STATEMENT, &value);
+  GetInfo(conn, SQL_INSERT_STATEMENT, &value);
 
   EXPECT_EQ(value, static_cast<SQLUINTEGER>(SQL_IS_INSERT_LITERALS |
                                             SQL_IS_INSERT_SEARCHED | SQL_IS_SELECT_INTO));
@@ -780,93 +786,93 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoInsertStatement) {
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoIntegrity) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_INTEGRITY, value);
+  GetInfo(conn, SQL_INTEGRITY, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"N"), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoKeywords) {
-  // Keyword strings can require 5000 buffer length
-  static constexpr int info_len = kOdbcBufferSize * 5;
+  // Keyword strings can require 10000 buffer length
+  static constexpr int info_len = kOdbcBufferSize * 10;
   SQLWCHAR value[info_len] = L"";
-  GetInfo(this->conn, SQL_KEYWORDS, value, info_len);
+  GetInfo(conn, SQL_KEYWORDS, value, info_len);
 
   EXPECT_GT(wcslen(value), 0);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoLikeEscapeClause) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_LIKE_ESCAPE_CLAUSE, value);
+  GetInfo(conn, SQL_LIKE_ESCAPE_CLAUSE, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"Y"), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoNonNullableColumns) {
   SQLUSMALLINT value;
-  GetInfo(this->conn, SQL_NON_NULLABLE_COLUMNS, &value);
+  GetInfo(conn, SQL_NON_NULLABLE_COLUMNS, &value);
 
   EXPECT_EQ(static_cast<SQLUSMALLINT>(SQL_NNC_NULL), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoOjCapabilities) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_OJ_CAPABILITIES, &value);
+  GetInfo(conn, SQL_OJ_CAPABILITIES, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(SQL_OJ_LEFT | SQL_OJ_RIGHT | SQL_OJ_FULL), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoOrderByColumnsInSelect) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_ORDER_BY_COLUMNS_IN_SELECT, value);
+  GetInfo(conn, SQL_ORDER_BY_COLUMNS_IN_SELECT, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"Y"), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoOuterJoins) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_OUTER_JOINS, value);
+  GetInfo(conn, SQL_OUTER_JOINS, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"N"), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoProcedures) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_PROCEDURES, value);
+  GetInfo(conn, SQL_PROCEDURES, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"N"), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoQuotedIdentifierCase) {
   SQLUSMALLINT value;
-  GetInfo(this->conn, SQL_QUOTED_IDENTIFIER_CASE, &value);
+  GetInfo(conn, SQL_QUOTED_IDENTIFIER_CASE, &value);
 
   EXPECT_EQ(static_cast<SQLUSMALLINT>(SQL_IC_MIXED), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoSchemaUsage) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_SCHEMA_USAGE, &value);
+  GetInfo(conn, SQL_SCHEMA_USAGE, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(SQL_SU_DML_STATEMENTS), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoSpecialCharacters) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_SPECIAL_CHARACTERS, value);
+  GetInfo(conn, SQL_SPECIAL_CHARACTERS, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L""), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoSqlConformance) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_SQL_CONFORMANCE, &value);
+  GetInfo(conn, SQL_SQL_CONFORMANCE, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(SQL_SC_SQL92_ENTRY), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoSubqueries) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_SUBQUERIES, &value);
+  GetInfo(conn, SQL_SUBQUERIES, &value);
 
   EXPECT_EQ(value,
             static_cast<SQLUINTEGER>(SQL_SQ_CORRELATED_SUBQUERIES | SQL_SQ_COMPARISON |
@@ -875,7 +881,7 @@ TEST_F(ConnectionInfoMockTest, TestSQLGetInfoSubqueries) {
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoUnion) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_UNION, &value);
+  GetInfo(conn, SQL_UNION, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(SQL_U_UNION | SQL_U_UNION_ALL), value);
 }
@@ -884,140 +890,140 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoUnion) {
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoMaxBinaryLiteralLen) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_MAX_BINARY_LITERAL_LEN, &value);
+  GetInfo(conn, SQL_MAX_BINARY_LITERAL_LEN, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoMaxCatalogNameLen) {
   SQLUSMALLINT value;
-  GetInfo(this->conn, SQL_MAX_CATALOG_NAME_LEN, &value);
+  GetInfo(conn, SQL_MAX_CATALOG_NAME_LEN, &value);
 
   EXPECT_EQ(static_cast<SQLUSMALLINT>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoMaxCharLiteralLen) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_MAX_CHAR_LITERAL_LEN, &value);
+  GetInfo(conn, SQL_MAX_CHAR_LITERAL_LEN, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoMaxColumnNameLen) {
   SQLUSMALLINT value;
-  GetInfo(this->conn, SQL_MAX_COLUMN_NAME_LEN, &value);
+  GetInfo(conn, SQL_MAX_COLUMN_NAME_LEN, &value);
 
   EXPECT_EQ(static_cast<SQLUSMALLINT>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoMaxColumnsInGroupBy) {
   SQLUSMALLINT value;
-  GetInfo(this->conn, SQL_MAX_COLUMNS_IN_GROUP_BY, &value);
+  GetInfo(conn, SQL_MAX_COLUMNS_IN_GROUP_BY, &value);
 
   EXPECT_EQ(static_cast<SQLUSMALLINT>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoMaxColumnsInIndex) {
   SQLUSMALLINT value;
-  GetInfo(this->conn, SQL_MAX_COLUMNS_IN_INDEX, &value);
+  GetInfo(conn, SQL_MAX_COLUMNS_IN_INDEX, &value);
 
   EXPECT_EQ(static_cast<SQLUSMALLINT>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoMaxColumnsInOrderBy) {
   SQLUSMALLINT value;
-  GetInfo(this->conn, SQL_MAX_COLUMNS_IN_ORDER_BY, &value);
+  GetInfo(conn, SQL_MAX_COLUMNS_IN_ORDER_BY, &value);
 
   EXPECT_EQ(static_cast<SQLUSMALLINT>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoMaxColumnsInSelect) {
   SQLUSMALLINT value;
-  GetInfo(this->conn, SQL_MAX_COLUMNS_IN_SELECT, &value);
+  GetInfo(conn, SQL_MAX_COLUMNS_IN_SELECT, &value);
 
   EXPECT_EQ(static_cast<SQLUSMALLINT>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoMaxColumnsInTable) {
   SQLUSMALLINT value;
-  GetInfo(this->conn, SQL_MAX_COLUMNS_IN_TABLE, &value);
+  GetInfo(conn, SQL_MAX_COLUMNS_IN_TABLE, &value);
 
   EXPECT_EQ(static_cast<SQLUSMALLINT>(0), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoMaxCursorNameLen) {
   SQLUSMALLINT value;
-  GetInfo(this->conn, SQL_MAX_CURSOR_NAME_LEN, &value);
+  GetInfo(conn, SQL_MAX_CURSOR_NAME_LEN, &value);
 
   EXPECT_EQ(static_cast<SQLUSMALLINT>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoMaxIdentifierLen) {
   SQLUSMALLINT value;
-  GetInfo(this->conn, SQL_MAX_IDENTIFIER_LEN, &value);
+  GetInfo(conn, SQL_MAX_IDENTIFIER_LEN, &value);
 
   EXPECT_EQ(static_cast<SQLUSMALLINT>(65535), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoMaxIndexSize) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_MAX_INDEX_SIZE, &value);
+  GetInfo(conn, SQL_MAX_INDEX_SIZE, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoMaxProcedureNameLen) {
   SQLUSMALLINT value;
-  GetInfo(this->conn, SQL_MAX_PROCEDURE_NAME_LEN, &value);
+  GetInfo(conn, SQL_MAX_PROCEDURE_NAME_LEN, &value);
 
   EXPECT_EQ(static_cast<SQLUSMALLINT>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoMaxRowSize) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_MAX_ROW_SIZE, value);
+  GetInfo(conn, SQL_MAX_ROW_SIZE, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L""), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoMaxRowSizeIncludesLong) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_MAX_ROW_SIZE_INCLUDES_LONG, value);
+  GetInfo(conn, SQL_MAX_ROW_SIZE_INCLUDES_LONG, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"N"), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoMaxSchemaNameLen) {
   SQLUSMALLINT value;
-  GetInfo(this->conn, SQL_MAX_SCHEMA_NAME_LEN, &value);
+  GetInfo(conn, SQL_MAX_SCHEMA_NAME_LEN, &value);
 
   EXPECT_EQ(static_cast<SQLUSMALLINT>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoMaxStatementLen) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_MAX_STATEMENT_LEN, &value);
+  GetInfo(conn, SQL_MAX_STATEMENT_LEN, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoMaxTableNameLen) {
   SQLUSMALLINT value;
-  GetInfo(this->conn, SQL_MAX_TABLE_NAME_LEN, &value);
+  GetInfo(conn, SQL_MAX_TABLE_NAME_LEN, &value);
 
   EXPECT_EQ(static_cast<SQLUSMALLINT>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoMaxTablesInSelect) {
   SQLUSMALLINT value;
-  GetInfo(this->conn, SQL_MAX_TABLES_IN_SELECT, &value);
+  GetInfo(conn, SQL_MAX_TABLES_IN_SELECT, &value);
 
   EXPECT_EQ(static_cast<SQLUSMALLINT>(0), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoMaxUserNameLen) {
   SQLUSMALLINT value;
-  GetInfo(this->conn, SQL_MAX_USER_NAME_LEN, &value);
+  GetInfo(conn, SQL_MAX_USER_NAME_LEN, &value);
 
   EXPECT_EQ(static_cast<SQLUSMALLINT>(0), value);
 }
@@ -1026,21 +1032,21 @@ TEST_F(ConnectionInfoMockTest, TestSQLGetInfoMaxUserNameLen) {
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoConvertFunctions) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_CONVERT_FUNCTIONS, &value);
+  GetInfo(conn, SQL_CONVERT_FUNCTIONS, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoNumericFunctions) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_NUMERIC_FUNCTIONS, &value);
+  GetInfo(conn, SQL_NUMERIC_FUNCTIONS, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(4058942), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoStringFunctions) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_STRING_FUNCTIONS, &value);
+  GetInfo(conn, SQL_STRING_FUNCTIONS, &value);
 
   EXPECT_EQ(value, static_cast<SQLUINTEGER>(SQL_FN_STR_LTRIM | SQL_FN_STR_LENGTH |
                                             SQL_FN_STR_REPLACE | SQL_FN_STR_RTRIM));
@@ -1048,14 +1054,14 @@ TEST_F(ConnectionInfoMockTest, TestSQLGetInfoStringFunctions) {
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoSystemFunctions) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_SYSTEM_FUNCTIONS, &value);
+  GetInfo(conn, SQL_SYSTEM_FUNCTIONS, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(SQL_FN_SYS_IFNULL | SQL_FN_SYS_USERNAME), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoTimedateAddIntervals) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_TIMEDATE_ADD_INTERVALS, &value);
+  GetInfo(conn, SQL_TIMEDATE_ADD_INTERVALS, &value);
 
   EXPECT_EQ(value, static_cast<SQLUINTEGER>(
                        SQL_FN_TSI_FRAC_SECOND | SQL_FN_TSI_SECOND | SQL_FN_TSI_MINUTE |
@@ -1065,7 +1071,7 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoTimedateAddIntervals) {
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoTimedateDiffIntervals) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_TIMEDATE_DIFF_INTERVALS, &value);
+  GetInfo(conn, SQL_TIMEDATE_DIFF_INTERVALS, &value);
 
   EXPECT_EQ(value, static_cast<SQLUINTEGER>(
                        SQL_FN_TSI_FRAC_SECOND | SQL_FN_TSI_SECOND | SQL_FN_TSI_MINUTE |
@@ -1075,7 +1081,7 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoTimedateDiffIntervals) {
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoTimedateFunctions) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_TIMEDATE_FUNCTIONS, &value);
+  GetInfo(conn, SQL_TIMEDATE_FUNCTIONS, &value);
 
   EXPECT_EQ(value,
             static_cast<SQLUINTEGER>(
@@ -1092,147 +1098,147 @@ TEST_F(ConnectionInfoMockTest, TestSQLGetInfoTimedateFunctions) {
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoConvertBigint) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_CONVERT_BIGINT, &value);
+  GetInfo(conn, SQL_CONVERT_BIGINT, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(8), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoConvertBinary) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_CONVERT_BINARY, &value);
+  GetInfo(conn, SQL_CONVERT_BINARY, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoConvertBit) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_CONVERT_BIT, &value);
+  GetInfo(conn, SQL_CONVERT_BIT, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoConvertChar) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_CONVERT_CHAR, &value);
+  GetInfo(conn, SQL_CONVERT_CHAR, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoConvertDate) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_CONVERT_DATE, &value);
+  GetInfo(conn, SQL_CONVERT_DATE, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoConvertDecimal) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_CONVERT_DECIMAL, &value);
+  GetInfo(conn, SQL_CONVERT_DECIMAL, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoConvertDouble) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_CONVERT_DOUBLE, &value);
+  GetInfo(conn, SQL_CONVERT_DOUBLE, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoConvertFloat) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_CONVERT_FLOAT, &value);
+  GetInfo(conn, SQL_CONVERT_FLOAT, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoConvertInteger) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_CONVERT_INTEGER, &value);
+  GetInfo(conn, SQL_CONVERT_INTEGER, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoConvertIntervalDayTime) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_CONVERT_INTERVAL_DAY_TIME, &value);
+  GetInfo(conn, SQL_CONVERT_INTERVAL_DAY_TIME, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoConvertIntervalYearMonth) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_CONVERT_INTERVAL_YEAR_MONTH, &value);
+  GetInfo(conn, SQL_CONVERT_INTERVAL_YEAR_MONTH, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoConvertLongvarbinary) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_CONVERT_LONGVARBINARY, &value);
+  GetInfo(conn, SQL_CONVERT_LONGVARBINARY, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoConvertLongvarchar) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_CONVERT_LONGVARCHAR, &value);
+  GetInfo(conn, SQL_CONVERT_LONGVARCHAR, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoConvertNumeric) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_CONVERT_NUMERIC, &value);
+  GetInfo(conn, SQL_CONVERT_NUMERIC, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoConvertReal) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_CONVERT_REAL, &value);
+  GetInfo(conn, SQL_CONVERT_REAL, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoConvertSmallint) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_CONVERT_SMALLINT, &value);
+  GetInfo(conn, SQL_CONVERT_SMALLINT, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoConvertTime) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_CONVERT_TIME, &value);
+  GetInfo(conn, SQL_CONVERT_TIME, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoConvertTimestamp) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_CONVERT_TIMESTAMP, &value);
+  GetInfo(conn, SQL_CONVERT_TIMESTAMP, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoConvertTinyint) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_CONVERT_TINYINT, &value);
+  GetInfo(conn, SQL_CONVERT_TINYINT, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoConvertVarbinary) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_CONVERT_VARBINARY, &value);
+  GetInfo(conn, SQL_CONVERT_VARBINARY, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoConvertVarchar) {
   SQLUINTEGER value;
-  GetInfo(this->conn, SQL_CONVERT_VARCHAR, &value);
+  GetInfo(conn, SQL_CONVERT_VARCHAR, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }

--- a/cpp/src/arrow/flight/sql/odbc/tests/connection_info_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/connection_info_test.cc
@@ -33,6 +33,12 @@ class ConnectionInfoMockTest : public FlightSQLODBCMockTestBase {};
 using TestTypes = ::testing::Types<ConnectionInfoMockTest, FlightSQLODBCRemoteTestBase>;
 TYPED_TEST_SUITE(ConnectionInfoTest, TestTypes);
 
+template <typename T>
+class ConnectionInfoHandleTest : public T {};
+using TestTypesHandle = ::testing::Types<FlightSQLOdbcEnvConnHandleMockTestBase,
+                                         FlightSQLOdbcEnvConnHandleRemoteTestBase>;
+TYPED_TEST_SUITE(ConnectionInfoHandleTest, TestTypesHandle);
+
 namespace {
 // Helper Functions
 
@@ -583,14 +589,19 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoAlterTable) {
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
-#ifdef DISABLE_TEST
-TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoCatalogLocation) {
+TYPED_TEST(ConnectionInfoHandleTest, TestSQLGetInfoCatalogLocation) {
+  // GH-49482 TODO: resolve inconsitent return value for SQL_CATALOG_LOCATION and change
+  // test type to `ConnectionInfoTest`
+  this->ConnectWithString(this->GetConnectionString());
+
   SQLUSMALLINT value;
   GetInfo(conn, SQL_CATALOG_LOCATION, &value);
 
   EXPECT_EQ(static_cast<SQLUSMALLINT>(0), value);
+
+  EXPECT_EQ(SQL_SUCCESS, SQLDisconnect(conn))
+      << GetOdbcErrorMessage(SQL_HANDLE_DBC, conn);
 }
-#endif
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoCatalogName) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
@@ -711,21 +722,33 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDropDomain) {
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
-#ifdef DISABLE_TEST
-TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDropSchema) {
+TYPED_TEST(ConnectionInfoHandleTest, TestSQLGetInfoDropSchema) {
+  // GH-49482 TODO: resolve inconsitent return value for SQL_DROP_SCHEMA and change test
+  // type to `ConnectionInfoTest`
+  this->ConnectWithString(this->GetConnectionString());
+
   SQLUINTEGER value;
   GetInfo(conn, SQL_DROP_SCHEMA, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
+
+  EXPECT_EQ(SQL_SUCCESS, SQLDisconnect(conn))
+      << GetOdbcErrorMessage(SQL_HANDLE_DBC, conn);
 }
 
-TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDropTable) {
+TYPED_TEST(ConnectionInfoHandleTest, TestSQLGetInfoDropTable) {
+  // GH-49482 TODO: resolve inconsitent return value for SQL_DROP_TABLE and change test
+  // type to `ConnectionInfoTest`
+  this->ConnectWithString(this->GetConnectionString());
+
   SQLUINTEGER value;
   GetInfo(conn, SQL_DROP_TABLE, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
+
+  EXPECT_EQ(SQL_SUCCESS, SQLDisconnect(conn))
+      << GetOdbcErrorMessage(SQL_HANDLE_DBC, conn);
 }
-#endif
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDropTranslation) {
   SQLUINTEGER value;

--- a/cpp/src/arrow/flight/sql/odbc/tests/connection_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/connection_test.cc
@@ -155,7 +155,7 @@ TYPED_TEST(ConnectionTest, TestSQLGetEnvAttrOutputNTS) {
   SQLINTEGER output_nts;
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetEnvAttr(this->env, SQL_ATTR_OUTPUT_NTS, &output_nts, 0, nullptr));
+            SQLGetEnvAttr(env, SQL_ATTR_OUTPUT_NTS, &output_nts, 0, nullptr));
 
   ASSERT_EQ(SQL_TRUE, output_nts);
 }
@@ -165,8 +165,7 @@ TYPED_TEST(ConnectionTest, DISABLED_TestSQLGetEnvAttrGetLength) {
   // Windows. Windows driver manager ignores the length pointer.
   // This test case can be potentially used on macOS/Linux
   SQLINTEGER length;
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetEnvAttr(this->env, SQL_ATTR_ODBC_VERSION, nullptr, 0, &length));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetEnvAttr(env, SQL_ATTR_ODBC_VERSION, nullptr, 0, &length));
 
   EXPECT_EQ(sizeof(SQLINTEGER), length);
 }
@@ -175,8 +174,7 @@ TYPED_TEST(ConnectionTest, DISABLED_TestSQLGetEnvAttrNullValuePointer) {
   // Test is disabled because call to SQLGetEnvAttr is handled by the driver manager on
   // Windows. The Windows driver manager doesn't error out when null pointer is passed.
   // This test case can be potentially used on macOS/Linux
-  ASSERT_EQ(SQL_ERROR,
-            SQLGetEnvAttr(this->env, SQL_ATTR_ODBC_VERSION, nullptr, 0, nullptr));
+  ASSERT_EQ(SQL_ERROR, SQLGetEnvAttr(env, SQL_ATTR_ODBC_VERSION, nullptr, 0, nullptr));
 }
 
 TEST(SQLSetEnvAttr, TestSQLSetEnvAttrOutputNTSValid) {
@@ -229,10 +227,10 @@ TYPED_TEST(ConnectionHandleTest, TestSQLDriverConnect) {
 
   // Connecting to ODBC server.
   ASSERT_EQ(SQL_SUCCESS,
-            SQLDriverConnect(this->conn, NULL, &connect_str0[0],
+            SQLDriverConnect(conn, NULL, &connect_str0[0],
                              static_cast<SQLSMALLINT>(connect_str0.size()), out_str,
                              kOdbcBufferSize, &out_str_len, SQL_DRIVER_NOPROMPT))
-      << GetOdbcErrorMessage(SQL_HANDLE_DBC, this->conn);
+      << GetOdbcErrorMessage(SQL_HANDLE_DBC, conn);
 
   // Check that out_str has same content as connect_str
   std::string out_connection_string = ODBC::SqlWcharToString(out_str, out_str_len);
@@ -244,11 +242,10 @@ TYPED_TEST(ConnectionHandleTest, TestSQLDriverConnect) {
   ASSERT_TRUE(CompareConnPropertyMap(out_properties, in_properties));
 
   // Disconnect from ODBC
-  ASSERT_EQ(SQL_SUCCESS, SQLDisconnect(this->conn))
-      << GetOdbcErrorMessage(SQL_HANDLE_DBC, this->conn);
+  ASSERT_EQ(SQL_SUCCESS, SQLDisconnect(conn))
+      << GetOdbcErrorMessage(SQL_HANDLE_DBC, conn);
 }
 
-#if defined _WIN32
 TYPED_TEST(ConnectionHandleTest, TestSQLDriverConnectDsn) {
   // Connect string
   std::string connect_str = this->GetConnectionString();
@@ -272,17 +269,17 @@ TYPED_TEST(ConnectionHandleTest, TestSQLDriverConnectDsn) {
 
   // Connecting to ODBC server.
   ASSERT_EQ(SQL_SUCCESS,
-            SQLDriverConnect(this->conn, NULL, &connect_str0[0],
+            SQLDriverConnect(conn, NULL, &connect_str0[0],
                              static_cast<SQLSMALLINT>(connect_str0.size()), out_str,
                              kOdbcBufferSize, &out_str_len, SQL_DRIVER_NOPROMPT))
-      << GetOdbcErrorMessage(SQL_HANDLE_DBC, this->conn);
+      << GetOdbcErrorMessage(SQL_HANDLE_DBC, conn);
 
   // Remove DSN
   ASSERT_TRUE(UnregisterDsn(wdsn));
 
   // Disconnect from ODBC
-  ASSERT_EQ(SQL_SUCCESS, SQLDisconnect(this->conn))
-      << GetOdbcErrorMessage(SQL_HANDLE_DBC, this->conn);
+  ASSERT_EQ(SQL_SUCCESS, SQLDisconnect(conn))
+      << GetOdbcErrorMessage(SQL_HANDLE_DBC, conn);
 }
 
 TYPED_TEST(ConnectionHandleTest, TestSQLConnect) {
@@ -304,17 +301,17 @@ TYPED_TEST(ConnectionHandleTest, TestSQLConnect) {
 
   // Connecting to ODBC server. Empty uid and pwd should be ignored.
   ASSERT_EQ(SQL_SUCCESS,
-            SQLConnect(this->conn, dsn0.data(), static_cast<SQLSMALLINT>(dsn0.size()),
+            SQLConnect(conn, dsn0.data(), static_cast<SQLSMALLINT>(dsn0.size()),
                        uid0.data(), static_cast<SQLSMALLINT>(uid0.size()), pwd0.data(),
                        static_cast<SQLSMALLINT>(pwd0.size())))
-      << GetOdbcErrorMessage(SQL_HANDLE_DBC, this->conn);
+      << GetOdbcErrorMessage(SQL_HANDLE_DBC, conn);
 
   // Remove DSN
   ASSERT_TRUE(UnregisterDsn(wdsn));
 
   // Disconnect from ODBC
-  ASSERT_EQ(SQL_SUCCESS, SQLDisconnect(this->conn))
-      << GetOdbcErrorMessage(SQL_HANDLE_DBC, this->conn);
+  ASSERT_EQ(SQL_SUCCESS, SQLDisconnect(conn))
+      << GetOdbcErrorMessage(SQL_HANDLE_DBC, conn);
 }
 
 TEST_F(ConnectionRemoteTest, TestSQLConnectInputUidPwd) {
@@ -345,7 +342,7 @@ TEST_F(ConnectionRemoteTest, TestSQLConnectInputUidPwd) {
 
   // Connecting to ODBC server.
   ASSERT_EQ(SQL_SUCCESS,
-            SQLConnect(this->conn, dsn0.data(), static_cast<SQLSMALLINT>(dsn0.size()),
+            SQLConnect(conn, dsn0.data(), static_cast<SQLSMALLINT>(dsn0.size()),
                        uid0.data(), static_cast<SQLSMALLINT>(uid0.size()), pwd0.data(),
                        static_cast<SQLSMALLINT>(pwd0.size())))
       << GetOdbcErrorMessage(SQL_HANDLE_DBC, conn);
@@ -354,7 +351,7 @@ TEST_F(ConnectionRemoteTest, TestSQLConnectInputUidPwd) {
   ASSERT_TRUE(UnregisterDsn(wdsn));
 
   // Disconnect from ODBC
-  ASSERT_EQ(SQL_SUCCESS, SQLDisconnect(this->conn))
+  ASSERT_EQ(SQL_SUCCESS, SQLDisconnect(conn))
       << GetOdbcErrorMessage(SQL_HANDLE_DBC, conn);
 }
 
@@ -387,11 +384,11 @@ TEST_F(ConnectionRemoteTest, TestSQLConnectInvalidUid) {
   // UID specified in DSN will take precedence,
   // so connection still fails despite passing valid uid in SQLConnect call
   ASSERT_EQ(SQL_ERROR,
-            SQLConnect(this->conn, dsn0.data(), static_cast<SQLSMALLINT>(dsn0.size()),
+            SQLConnect(conn, dsn0.data(), static_cast<SQLSMALLINT>(dsn0.size()),
                        uid0.data(), static_cast<SQLSMALLINT>(uid0.size()), pwd0.data(),
                        static_cast<SQLSMALLINT>(pwd0.size())));
 
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorState28000);
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorState28000);
 
   // Remove DSN
   ASSERT_TRUE(UnregisterDsn(wdsn));
@@ -419,7 +416,7 @@ TEST_F(ConnectionRemoteTest, TestSQLConnectDSNPrecedence) {
 
   // Connecting to ODBC server.
   ASSERT_EQ(SQL_SUCCESS,
-            SQLConnect(this->conn, dsn0.data(), static_cast<SQLSMALLINT>(dsn0.size()),
+            SQLConnect(conn, dsn0.data(), static_cast<SQLSMALLINT>(dsn0.size()),
                        uid0.data(), static_cast<SQLSMALLINT>(uid0.size()), pwd0.data(),
                        static_cast<SQLSMALLINT>(pwd0.size())))
       << GetOdbcErrorMessage(SQL_HANDLE_DBC, conn);
@@ -428,11 +425,9 @@ TEST_F(ConnectionRemoteTest, TestSQLConnectDSNPrecedence) {
   ASSERT_TRUE(UnregisterDsn(wdsn));
 
   // Disconnect from ODBC
-  ASSERT_EQ(SQL_SUCCESS, SQLDisconnect(this->conn))
+  ASSERT_EQ(SQL_SUCCESS, SQLDisconnect(conn))
       << GetOdbcErrorMessage(SQL_HANDLE_DBC, conn);
 }
-
-#endif  // _WIN32
 
 TEST_F(ConnectionRemoteTest, TestSQLDriverConnectInvalidUid) {
   // Invalid connect string
@@ -447,11 +442,11 @@ TEST_F(ConnectionRemoteTest, TestSQLDriverConnectInvalidUid) {
 
   // Connecting to ODBC server.
   ASSERT_EQ(SQL_ERROR,
-            SQLDriverConnect(this->conn, NULL, &connect_str0[0],
+            SQLDriverConnect(conn, NULL, &connect_str0[0],
                              static_cast<SQLSMALLINT>(connect_str0.size()), out_str,
                              kOdbcBufferSize, &out_str_len, SQL_DRIVER_NOPROMPT));
 
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorState28000);
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorState28000);
 
   std::string out_connection_string = ODBC::SqlWcharToString(out_str, out_str_len);
   ASSERT_TRUE(out_connection_string.empty());
@@ -459,21 +454,17 @@ TEST_F(ConnectionRemoteTest, TestSQLDriverConnectInvalidUid) {
 
 TYPED_TEST(ConnectionHandleTest, TestSQLDisconnectWithoutConnection) {
   // Attempt to disconnect without a connection, expect to fail
-  ASSERT_EQ(SQL_ERROR, SQLDisconnect(this->conn));
+  ASSERT_EQ(SQL_ERROR, SQLDisconnect(conn));
 
   // Expect ODBC driver manager to return error state
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorState08003);
-}
-
-TYPED_TEST(ConnectionTest, TestConnect) {
-  // Verifies connect and disconnect works on its own
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorState08003);
 }
 
 TYPED_TEST(ConnectionTest, TestSQLAllocFreeStmt) {
   SQLHSTMT statement;
 
   // Allocate a statement using alloc statement
-  ASSERT_EQ(SQL_SUCCESS, SQLAllocStmt(this->conn, &statement));
+  ASSERT_EQ(SQL_SUCCESS, SQLAllocStmt(conn, &statement));
 
   // Close statement handle
   ASSERT_EQ(SQL_SUCCESS, SQLFreeStmt(statement, SQL_CLOSE));
@@ -496,23 +487,23 @@ TYPED_TEST(ConnectionHandleTest, TestCloseConnectionWithOpenStatement) {
 
   // Connecting to ODBC server.
   ASSERT_EQ(SQL_SUCCESS,
-            SQLDriverConnect(this->conn, NULL, &connect_str0[0],
+            SQLDriverConnect(conn, NULL, &connect_str0[0],
                              static_cast<SQLSMALLINT>(connect_str0.size()), out_str,
                              kOdbcBufferSize, &out_str_len, SQL_DRIVER_NOPROMPT))
-      << GetOdbcErrorMessage(SQL_HANDLE_DBC, this->conn);
+      << GetOdbcErrorMessage(SQL_HANDLE_DBC, conn);
 
   // Allocate a statement using alloc statement
-  ASSERT_EQ(SQL_SUCCESS, SQLAllocStmt(this->conn, &statement));
+  ASSERT_EQ(SQL_SUCCESS, SQLAllocStmt(conn, &statement));
 
   // Disconnect from ODBC without closing the statement first
-  ASSERT_EQ(SQL_SUCCESS, SQLDisconnect(this->conn));
+  ASSERT_EQ(SQL_SUCCESS, SQLDisconnect(conn));
 }
 
 TYPED_TEST(ConnectionTest, TestSQLAllocFreeDesc) {
   SQLHDESC descriptor;
 
   // Allocate a descriptor using alloc handle
-  ASSERT_EQ(SQL_SUCCESS, SQLAllocHandle(SQL_HANDLE_DESC, this->conn, &descriptor));
+  ASSERT_EQ(SQL_SUCCESS, SQLAllocHandle(SQL_HANDLE_DESC, conn, &descriptor));
 
   // Free descriptor handle
   ASSERT_EQ(SQL_SUCCESS, SQLFreeHandle(SQL_HANDLE_DESC, descriptor));
@@ -522,37 +513,37 @@ TYPED_TEST(ConnectionTest, TestSQLSetStmtAttrDescriptor) {
   SQLHDESC apd_descriptor, ard_descriptor;
 
   // Allocate an APD descriptor using alloc handle
-  ASSERT_EQ(SQL_SUCCESS, SQLAllocHandle(SQL_HANDLE_DESC, this->conn, &apd_descriptor));
+  ASSERT_EQ(SQL_SUCCESS, SQLAllocHandle(SQL_HANDLE_DESC, conn, &apd_descriptor));
 
   // Allocate an ARD descriptor using alloc handle
-  ASSERT_EQ(SQL_SUCCESS, SQLAllocHandle(SQL_HANDLE_DESC, this->conn, &ard_descriptor));
+  ASSERT_EQ(SQL_SUCCESS, SQLAllocHandle(SQL_HANDLE_DESC, conn, &ard_descriptor));
 
   // Save implicitly allocated internal APD and ARD descriptor pointers
   SQLPOINTER internal_apd, internal_ard = nullptr;
 
-  EXPECT_EQ(SQL_SUCCESS, SQLGetStmtAttr(this->stmt, SQL_ATTR_APP_PARAM_DESC,
-                                        &internal_apd, sizeof(internal_apd), 0));
+  EXPECT_EQ(SQL_SUCCESS, SQLGetStmtAttr(stmt, SQL_ATTR_APP_PARAM_DESC, &internal_apd,
+                                        sizeof(internal_apd), 0));
 
-  EXPECT_EQ(SQL_SUCCESS, SQLGetStmtAttr(this->stmt, SQL_ATTR_APP_ROW_DESC, &internal_ard,
+  EXPECT_EQ(SQL_SUCCESS, SQLGetStmtAttr(stmt, SQL_ATTR_APP_ROW_DESC, &internal_ard,
                                         sizeof(internal_ard), 0));
 
   // Set APD descriptor to explicitly allocated handle
-  EXPECT_EQ(SQL_SUCCESS, SQLSetStmtAttr(this->stmt, SQL_ATTR_APP_PARAM_DESC,
+  EXPECT_EQ(SQL_SUCCESS, SQLSetStmtAttr(stmt, SQL_ATTR_APP_PARAM_DESC,
                                         reinterpret_cast<SQLPOINTER>(apd_descriptor), 0));
 
   // Set ARD descriptor to explicitly allocated handle
-  EXPECT_EQ(SQL_SUCCESS, SQLSetStmtAttr(this->stmt, SQL_ATTR_APP_ROW_DESC,
+  EXPECT_EQ(SQL_SUCCESS, SQLSetStmtAttr(stmt, SQL_ATTR_APP_ROW_DESC,
                                         reinterpret_cast<SQLPOINTER>(ard_descriptor), 0));
 
   // Verify APD and ARD descriptors are set to explicitly allocated pointers
   SQLPOINTER value = nullptr;
-  EXPECT_EQ(SQL_SUCCESS, SQLGetStmtAttr(this->stmt, SQL_ATTR_APP_PARAM_DESC, &value,
-                                        sizeof(value), 0));
+  EXPECT_EQ(SQL_SUCCESS,
+            SQLGetStmtAttr(stmt, SQL_ATTR_APP_PARAM_DESC, &value, sizeof(value), 0));
 
   EXPECT_EQ(apd_descriptor, value);
 
   EXPECT_EQ(SQL_SUCCESS,
-            SQLGetStmtAttr(this->stmt, SQL_ATTR_APP_ROW_DESC, &value, sizeof(value), 0));
+            SQLGetStmtAttr(stmt, SQL_ATTR_APP_ROW_DESC, &value, sizeof(value), 0));
 
   EXPECT_EQ(ard_descriptor, value);
 
@@ -564,13 +555,13 @@ TYPED_TEST(ConnectionTest, TestSQLSetStmtAttrDescriptor) {
   // Verify APD and ARD descriptors has been reverted to implicit descriptors
   value = nullptr;
 
-  EXPECT_EQ(SQL_SUCCESS, SQLGetStmtAttr(this->stmt, SQL_ATTR_APP_PARAM_DESC, &value,
-                                        sizeof(value), 0));
+  EXPECT_EQ(SQL_SUCCESS,
+            SQLGetStmtAttr(stmt, SQL_ATTR_APP_PARAM_DESC, &value, sizeof(value), 0));
 
   EXPECT_EQ(internal_apd, value);
 
   EXPECT_EQ(SQL_SUCCESS,
-            SQLGetStmtAttr(this->stmt, SQL_ATTR_APP_ROW_DESC, &value, sizeof(value), 0));
+            SQLGetStmtAttr(stmt, SQL_ATTR_APP_ROW_DESC, &value, sizeof(value), 0));
 
   EXPECT_EQ(internal_ard, value);
 }

--- a/cpp/src/arrow/flight/sql/odbc/tests/errors_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/errors_test.cc
@@ -62,7 +62,7 @@ TYPED_TEST(ErrorsHandleTest, TestSQLGetDiagFieldWForConnectFailure) {
 
   // Connecting to ODBC server.
   ASSERT_EQ(SQL_ERROR,
-            SQLDriverConnect(this->conn, NULL, &connect_str0[0],
+            SQLDriverConnect(conn, NULL, &connect_str0[0],
                              static_cast<SQLSMALLINT>(connect_str0.size()), out_str,
                              kOdbcBufferSize, &out_str_len, SQL_DRIVER_NOPROMPT));
 
@@ -75,7 +75,7 @@ TYPED_TEST(ErrorsHandleTest, TestSQLGetDiagFieldWForConnectFailure) {
   SQLSMALLINT diag_number_length;
 
   EXPECT_EQ(SQL_SUCCESS,
-            SQLGetDiagField(SQL_HANDLE_DBC, this->conn, HEADER_LEVEL, SQL_DIAG_NUMBER,
+            SQLGetDiagField(SQL_HANDLE_DBC, conn, HEADER_LEVEL, SQL_DIAG_NUMBER,
                             &diag_number, sizeof(SQLINTEGER), &diag_number_length));
 
   EXPECT_EQ(1, diag_number);
@@ -85,16 +85,15 @@ TYPED_TEST(ErrorsHandleTest, TestSQLGetDiagFieldWForConnectFailure) {
   SQLSMALLINT server_name_length;
 
   EXPECT_EQ(SQL_SUCCESS,
-            SQLGetDiagField(SQL_HANDLE_DBC, this->conn, RECORD_1, SQL_DIAG_SERVER_NAME,
+            SQLGetDiagField(SQL_HANDLE_DBC, conn, RECORD_1, SQL_DIAG_SERVER_NAME,
                             server_name, kOdbcBufferSize, &server_name_length));
 
   // SQL_DIAG_MESSAGE_TEXT
   SQLWCHAR message_text[kOdbcBufferSize];
   SQLSMALLINT message_text_length;
 
-  SQLRETURN ret =
-      SQLGetDiagField(SQL_HANDLE_DBC, this->conn, RECORD_1, SQL_DIAG_MESSAGE_TEXT,
-                      message_text, kOdbcBufferSize, &message_text_length);
+  SQLRETURN ret = SQLGetDiagField(SQL_HANDLE_DBC, conn, RECORD_1, SQL_DIAG_MESSAGE_TEXT,
+                                  message_text, kOdbcBufferSize, &message_text_length);
 
   // dependent on the size of the message it could output SQL_SUCCESS_WITH_INFO
   EXPECT_TRUE(ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO);
@@ -106,8 +105,8 @@ TYPED_TEST(ErrorsHandleTest, TestSQLGetDiagFieldWForConnectFailure) {
   SQLSMALLINT diag_native_length;
 
   EXPECT_EQ(SQL_SUCCESS,
-            SQLGetDiagField(SQL_HANDLE_DBC, this->conn, RECORD_1, SQL_DIAG_NATIVE,
-                            &diag_native, sizeof(diag_native), &diag_native_length));
+            SQLGetDiagField(SQL_HANDLE_DBC, conn, RECORD_1, SQL_DIAG_NATIVE, &diag_native,
+                            sizeof(diag_native), &diag_native_length));
 
   EXPECT_EQ(200, diag_native);
 
@@ -116,10 +115,9 @@ TYPED_TEST(ErrorsHandleTest, TestSQLGetDiagFieldWForConnectFailure) {
   SQLWCHAR sql_state[sql_state_size];
   SQLSMALLINT sql_state_length;
 
-  EXPECT_EQ(
-      SQL_SUCCESS,
-      SQLGetDiagField(SQL_HANDLE_DBC, this->conn, RECORD_1, SQL_DIAG_SQLSTATE, sql_state,
-                      sql_state_size * GetSqlWCharSize(), &sql_state_length));
+  EXPECT_EQ(SQL_SUCCESS,
+            SQLGetDiagField(SQL_HANDLE_DBC, conn, RECORD_1, SQL_DIAG_SQLSTATE, sql_state,
+                            sql_state_size * GetSqlWCharSize(), &sql_state_length));
 
   EXPECT_EQ(kErrorState28000, SqlWcharToString(sql_state));
 }
@@ -140,7 +138,7 @@ TYPED_TEST(ErrorsHandleTest, DISABLED_TestSQLGetDiagFieldWForConnectFailureNTS) 
 
   // Connecting to ODBC server.
   ASSERT_EQ(SQL_ERROR,
-            SQLDriverConnect(this->conn, NULL, &connect_str0[0],
+            SQLDriverConnect(conn, NULL, &connect_str0[0],
                              static_cast<SQLSMALLINT>(connect_str0.size()), out_str,
                              kOdbcBufferSize, &out_str_len, SQL_DRIVER_NOPROMPT));
 
@@ -154,7 +152,7 @@ TYPED_TEST(ErrorsHandleTest, DISABLED_TestSQLGetDiagFieldWForConnectFailureNTS) 
   message_text[kOdbcBufferSize - 1] = '\0';
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetDiagField(SQL_HANDLE_DBC, this->conn, RECORD_1, SQL_DIAG_MESSAGE_TEXT,
+            SQLGetDiagField(SQL_HANDLE_DBC, conn, RECORD_1, SQL_DIAG_MESSAGE_TEXT,
                             message_text, SQL_NTS, &message_text_length));
 
   EXPECT_GT(message_text_length, 100);
@@ -166,7 +164,7 @@ TYPED_TEST(ErrorsTest, TestSQLGetDiagFieldWForDescriptorFailureFromDriverManager
   SQLHDESC descriptor;
 
   // Allocate a descriptor using alloc handle
-  ASSERT_EQ(SQL_SUCCESS, SQLAllocHandle(SQL_HANDLE_DESC, this->conn, &descriptor));
+  ASSERT_EQ(SQL_SUCCESS, SQLAllocHandle(SQL_HANDLE_DESC, conn, &descriptor));
 
   EXPECT_EQ(SQL_ERROR, SQLGetDescField(descriptor, 1, SQL_DESC_DATETIME_INTERVAL_CODE, 0,
                                        0, nullptr));
@@ -232,7 +230,7 @@ TYPED_TEST(ErrorsTest, TestSQLGetDiagRecForDescriptorFailureFromDriverManager) {
   SQLHDESC descriptor;
 
   // Allocate a descriptor using alloc handle
-  ASSERT_EQ(SQL_SUCCESS, SQLAllocHandle(SQL_HANDLE_DESC, this->conn, &descriptor));
+  ASSERT_EQ(SQL_SUCCESS, SQLAllocHandle(SQL_HANDLE_DESC, conn, &descriptor));
 
   EXPECT_EQ(SQL_ERROR, SQLGetDescField(descriptor, 1, SQL_DESC_DATETIME_INTERVAL_CODE, 0,
                                        0, nullptr));
@@ -273,7 +271,7 @@ TYPED_TEST(ErrorsHandleTest, TestSQLGetDiagRecForConnectFailure) {
 
   // Connecting to ODBC server.
   ASSERT_EQ(SQL_ERROR,
-            SQLDriverConnect(this->conn, NULL, &connect_str0[0],
+            SQLDriverConnect(conn, NULL, &connect_str0[0],
                              static_cast<SQLSMALLINT>(connect_str0.size()), out_str,
                              kOdbcBufferSize, &out_str_len, SQL_DRIVER_NOPROMPT));
 
@@ -281,9 +279,8 @@ TYPED_TEST(ErrorsHandleTest, TestSQLGetDiagRecForConnectFailure) {
   SQLINTEGER native_error;
   SQLWCHAR message[kOdbcBufferSize];
   SQLSMALLINT message_length;
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetDiagRec(SQL_HANDLE_DBC, this->conn, 1, sql_state, &native_error,
-                          message, kOdbcBufferSize, &message_length));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetDiagRec(SQL_HANDLE_DBC, conn, 1, sql_state, &native_error,
+                                       message, kOdbcBufferSize, &message_length));
 
   EXPECT_GT(message_length, 120);
 
@@ -303,19 +300,18 @@ TYPED_TEST(ErrorsTest, TestSQLGetDiagRecInputData) {
   SQLSMALLINT message_length;
 
   // Pass invalid record number
-  EXPECT_EQ(SQL_ERROR,
-            SQLGetDiagRec(SQL_HANDLE_DBC, this->conn, 0, sql_state, &native_error,
-                          message, kOdbcBufferSize, &message_length));
+  EXPECT_EQ(SQL_ERROR, SQLGetDiagRec(SQL_HANDLE_DBC, conn, 0, sql_state, &native_error,
+                                     message, kOdbcBufferSize, &message_length));
 
   // Pass valid record number with null inputs
-  EXPECT_EQ(SQL_NO_DATA, SQLGetDiagRec(SQL_HANDLE_DBC, this->conn, 1, nullptr, nullptr,
-                                       nullptr, 0, nullptr));
+  EXPECT_EQ(SQL_NO_DATA, SQLGetDiagRec(SQL_HANDLE_DBC, conn, 1, nullptr, nullptr, nullptr,
+                                       0, nullptr));
 
   // Invalid handle
 #ifdef __APPLE__
   // MacOS ODBC driver manager requires connection handle
   EXPECT_EQ(SQL_INVALID_HANDLE,
-            SQLGetDiagRec(0, this->conn, 1, nullptr, nullptr, nullptr, 0, nullptr));
+            SQLGetDiagRec(0, conn, 1, nullptr, nullptr, nullptr, 0, nullptr));
 #else
   EXPECT_EQ(SQL_INVALID_HANDLE,
             SQLGetDiagRec(0, nullptr, 0, nullptr, nullptr, nullptr, 0, nullptr));
@@ -328,17 +324,17 @@ TYPED_TEST(ErrorsOdbcV2Test, TestSQLErrorInputData) {
 
   // Pass valid handles with null inputs
   EXPECT_EQ(SQL_NO_DATA,
-            SQLError(this->env, nullptr, nullptr, nullptr, nullptr, nullptr, 0, nullptr));
+            SQLError(env, nullptr, nullptr, nullptr, nullptr, nullptr, 0, nullptr));
 
-  EXPECT_EQ(SQL_NO_DATA, SQLError(nullptr, this->conn, nullptr, nullptr, nullptr, nullptr,
-                                  0, nullptr));
+  EXPECT_EQ(SQL_NO_DATA,
+            SQLError(nullptr, conn, nullptr, nullptr, nullptr, nullptr, 0, nullptr));
 
 #ifdef __APPLE__
-  EXPECT_EQ(SQL_NO_DATA, SQLError(SQL_NULL_HENV, this->conn, this->stmt, nullptr, nullptr,
-                                  nullptr, 0, nullptr));
+  EXPECT_EQ(SQL_NO_DATA,
+            SQLError(SQL_NULL_HENV, conn, stmt, nullptr, nullptr, nullptr, 0, nullptr));
 #else
-  EXPECT_EQ(SQL_NO_DATA, SQLError(nullptr, nullptr, this->stmt, nullptr, nullptr, nullptr,
-                                  0, nullptr));
+  EXPECT_EQ(SQL_NO_DATA,
+            SQLError(nullptr, nullptr, stmt, nullptr, nullptr, nullptr, 0, nullptr));
 #endif  // __APPLE__
 
   // Invalid handle
@@ -353,14 +349,14 @@ TYPED_TEST(ErrorsTest, TestSQLErrorEnvErrorFromDriverManager) {
   // DM passes 512 as buffer length to SQLError.
 
   // Attempt to set environment attribute after connection handle allocation
-  ASSERT_EQ(SQL_ERROR, SQLSetEnvAttr(this->env, SQL_ATTR_ODBC_VERSION,
+  ASSERT_EQ(SQL_ERROR, SQLSetEnvAttr(env, SQL_ATTR_ODBC_VERSION,
                                      reinterpret_cast<void*>(SQL_OV_ODBC2), 0));
 
   SQLWCHAR sql_state[6] = {0};
   SQLINTEGER native_error = 0;
   SQLWCHAR message[SQL_MAX_MESSAGE_LENGTH] = {0};
   SQLSMALLINT message_length = 0;
-  ASSERT_EQ(SQL_SUCCESS, SQLError(this->env, nullptr, nullptr, sql_state, &native_error,
+  ASSERT_EQ(SQL_SUCCESS, SQLError(env, nullptr, nullptr, sql_state, &native_error,
                                   message, SQL_MAX_MESSAGE_LENGTH, &message_length));
 
   EXPECT_GT(message_length, 40);
@@ -380,14 +376,13 @@ TYPED_TEST(ErrorsTest, TestSQLErrorConnError) {
   // DM passes 512 as buffer length to SQLError.
 
   // Attempt to set unsupported attribute
-  ASSERT_EQ(SQL_ERROR,
-            SQLGetConnectAttr(this->conn, SQL_ATTR_TXN_ISOLATION, 0, 0, nullptr));
+  ASSERT_EQ(SQL_ERROR, SQLGetConnectAttr(conn, SQL_ATTR_TXN_ISOLATION, 0, 0, nullptr));
 
   SQLWCHAR sql_state[6] = {0};
   SQLINTEGER native_error = 0;
   SQLWCHAR message[SQL_MAX_MESSAGE_LENGTH] = {0};
   SQLSMALLINT message_length = 0;
-  ASSERT_EQ(SQL_SUCCESS, SQLError(nullptr, this->conn, nullptr, sql_state, &native_error,
+  ASSERT_EQ(SQL_SUCCESS, SQLError(nullptr, conn, nullptr, sql_state, &native_error,
                                   message, SQL_MAX_MESSAGE_LENGTH, &message_length));
 
   EXPECT_GT(message_length, 60);
@@ -410,14 +405,14 @@ TYPED_TEST(ErrorsTest, TestSQLErrorStmtError) {
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ASSERT_EQ(SQL_ERROR,
-            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
 
   SQLWCHAR sql_state[6] = {0};
   SQLINTEGER native_error = 0;
   SQLWCHAR message[SQL_MAX_MESSAGE_LENGTH] = {0};
   SQLSMALLINT message_length = 0;
-  SQLRETURN ret = SQLError(nullptr, this->conn, this->stmt, sql_state, &native_error,
-                           message, SQL_MAX_MESSAGE_LENGTH, &message_length);
+  SQLRETURN ret = SQLError(nullptr, conn, stmt, sql_state, &native_error, message,
+                           SQL_MAX_MESSAGE_LENGTH, &message_length);
 
   EXPECT_TRUE(ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO);
 
@@ -437,9 +432,9 @@ TYPED_TEST(ErrorsTest, TestSQLErrorStmtWarning) {
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   const int len = 17;
   SQLCHAR char_val[len];
@@ -447,15 +442,14 @@ TYPED_TEST(ErrorsTest, TestSQLErrorStmtWarning) {
   SQLLEN ind;
 
   EXPECT_EQ(SQL_SUCCESS_WITH_INFO,
-            SQLGetData(this->stmt, 1, SQL_C_CHAR, &char_val, buf_len, &ind));
+            SQLGetData(stmt, 1, SQL_C_CHAR, &char_val, buf_len, &ind));
 
   SQLWCHAR sql_state[6] = {0};
   SQLINTEGER native_error = 0;
   SQLWCHAR message[SQL_MAX_MESSAGE_LENGTH] = {0};
   SQLSMALLINT message_length = 0;
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLError(SQL_NULL_HENV, this->conn, this->stmt, sql_state, &native_error,
-                     message, SQL_MAX_MESSAGE_LENGTH, &message_length));
+  ASSERT_EQ(SQL_SUCCESS, SQLError(SQL_NULL_HENV, conn, stmt, sql_state, &native_error,
+                                  message, SQL_MAX_MESSAGE_LENGTH, &message_length));
 
   EXPECT_GT(message_length, 50);
 
@@ -474,14 +468,14 @@ TYPED_TEST(ErrorsOdbcV2Test, TestSQLErrorEnvErrorFromDriverManager) {
   // DM passes 512 as buffer length to SQLError.
 
   // Attempt to set environment attribute after connection handle allocation
-  ASSERT_EQ(SQL_ERROR, SQLSetEnvAttr(this->env, SQL_ATTR_ODBC_VERSION,
+  ASSERT_EQ(SQL_ERROR, SQLSetEnvAttr(env, SQL_ATTR_ODBC_VERSION,
                                      reinterpret_cast<void*>(SQL_OV_ODBC2), 0));
 
   SQLWCHAR sql_state[6] = {0};
   SQLINTEGER native_error = 0;
   SQLWCHAR message[SQL_MAX_MESSAGE_LENGTH] = {0};
   SQLSMALLINT message_length = 0;
-  ASSERT_EQ(SQL_SUCCESS, SQLError(this->env, nullptr, nullptr, sql_state, &native_error,
+  ASSERT_EQ(SQL_SUCCESS, SQLError(env, nullptr, nullptr, sql_state, &native_error,
                                   message, SQL_MAX_MESSAGE_LENGTH, &message_length));
 
   EXPECT_GT(message_length, 40);
@@ -500,6 +494,7 @@ TYPED_TEST(ErrorsOdbcV2Test, TestSQLErrorEnvErrorFromDriverManager) {
   EXPECT_FALSE(std::wstring(message).empty());
 }
 
+// TODO: verify that `SQLGetConnectOption` is not required by Excel.
 #ifndef __APPLE__
 TYPED_TEST(ErrorsOdbcV2Test, TestSQLErrorConnError) {
   // Test ODBC 2.0 API SQLError with ODBC ver 2.
@@ -513,14 +508,13 @@ TYPED_TEST(ErrorsOdbcV2Test, TestSQLErrorConnError) {
   // macOS Excel.
 
   // Attempt to set unsupported attribute
-  ASSERT_EQ(SQL_ERROR,
-            SQLGetConnectAttr(this->conn, SQL_ATTR_TXN_ISOLATION, 0, 0, nullptr));
+  ASSERT_EQ(SQL_ERROR, SQLGetConnectAttr(conn, SQL_ATTR_TXN_ISOLATION, 0, 0, nullptr));
 
   SQLWCHAR sql_state[6] = {0};
   SQLINTEGER native_error = 0;
   SQLWCHAR message[SQL_MAX_MESSAGE_LENGTH] = {0};
   SQLSMALLINT message_length = 0;
-  ASSERT_EQ(SQL_SUCCESS, SQLError(nullptr, this->conn, nullptr, sql_state, &native_error,
+  ASSERT_EQ(SQL_SUCCESS, SQLError(nullptr, conn, nullptr, sql_state, &native_error,
                                   message, SQL_MAX_MESSAGE_LENGTH, &message_length));
 
   EXPECT_GT(message_length, 60);
@@ -544,15 +538,14 @@ TYPED_TEST(ErrorsOdbcV2Test, TestSQLErrorStmtError) {
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ASSERT_EQ(SQL_ERROR,
-            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
 
   SQLWCHAR sql_state[6] = {0};
   SQLINTEGER native_error = 0;
   SQLSMALLINT message_length = 0;
   SQLWCHAR message[SQL_MAX_MESSAGE_LENGTH] = {0};
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLError(SQL_NULL_HENV, this->conn, this->stmt, sql_state, &native_error,
-                     message, SQL_MAX_MESSAGE_LENGTH, &message_length));
+  ASSERT_EQ(SQL_SUCCESS, SQLError(SQL_NULL_HENV, conn, stmt, sql_state, &native_error,
+                                  message, SQL_MAX_MESSAGE_LENGTH, &message_length));
   EXPECT_GT(message_length, 70);
 
   EXPECT_EQ(100, native_error);
@@ -570,9 +563,9 @@ TYPED_TEST(ErrorsOdbcV2Test, TestSQLErrorStmtWarning) {
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   const int len = 17;
   SQLCHAR char_val[len];
@@ -580,15 +573,14 @@ TYPED_TEST(ErrorsOdbcV2Test, TestSQLErrorStmtWarning) {
   SQLLEN ind;
 
   EXPECT_EQ(SQL_SUCCESS_WITH_INFO,
-            SQLGetData(this->stmt, 1, SQL_C_CHAR, &char_val, buf_len, &ind));
+            SQLGetData(stmt, 1, SQL_C_CHAR, &char_val, buf_len, &ind));
 
   SQLWCHAR sql_state[6] = {0};
   SQLINTEGER native_error = 0;
   SQLWCHAR message[SQL_MAX_MESSAGE_LENGTH] = {0};
   SQLSMALLINT message_length = 0;
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLError(SQL_NULL_HENV, this->conn, this->stmt, sql_state, &native_error,
-                     message, SQL_MAX_MESSAGE_LENGTH, &message_length));
+  ASSERT_EQ(SQL_SUCCESS, SQLError(SQL_NULL_HENV, conn, stmt, sql_state, &native_error,
+                                  message, SQL_MAX_MESSAGE_LENGTH, &message_length));
 
   EXPECT_GT(message_length, 50);
 

--- a/cpp/src/arrow/flight/sql/odbc/tests/get_functions_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/get_functions_test.cc
@@ -40,6 +40,8 @@ using TestTypesOdbcV2 =
     ::testing::Types<FlightSQLOdbcV2MockTestBase, FlightSQLOdbcV2RemoteTestBase>;
 TYPED_TEST_SUITE(GetFunctionsOdbcV2Test, TestTypesOdbcV2);
 
+// MacOS driver manager iODBC does not support SQLGetFunctions for ODBC 3.x or 2.x driver
+#ifndef __APPLE__
 TYPED_TEST(GetFunctionsTest, TestSQLGetFunctionsAllFunctions) {
   // Verify driver manager return values for SQLGetFunctions
 
@@ -75,8 +77,7 @@ TYPED_TEST(GetFunctionsTest, TestSQLGetFunctionsAllFunctions) {
       SQL_API_SQLDESCRIBEPARAM,  SQL_API_SQLPROCEDURES,       SQL_API_SQLSETPOS,
       SQL_API_SQLTABLEPRIVILEGES};
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetFunctions(this->conn, SQL_API_ODBC3_ALL_FUNCTIONS, api_exists));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetFunctions(conn, SQL_API_ODBC3_ALL_FUNCTIONS, api_exists));
 
   for (int api : supported_functions) {
     EXPECT_EQ(SQL_TRUE, SQL_FUNC_EXISTS(api_exists, api));
@@ -87,7 +88,7 @@ TYPED_TEST(GetFunctionsTest, TestSQLGetFunctionsAllFunctions) {
   }
 }
 
-TYPED_TEST(GetFunctionsOdbcV2Test, TestSQLGetFunctionsAllFunctionsODBCVer2) {
+TYPED_TEST(GetFunctionsOdbcV2Test, TestSQLGetFunctionsAllFunctions) {
   // Verify driver manager return values for SQLGetFunctions
 
   // ODBC 2.0 SQLGetFunctions returns 100 elements according to spec
@@ -112,7 +113,7 @@ TYPED_TEST(GetFunctionsOdbcV2Test, TestSQLGetFunctionsAllFunctionsODBCVer2) {
       SQL_API_SQLBULKOPERATIONS, SQL_API_SQLCOLUMNPRIVILEGES, SQL_API_SQLPROCEDURECOLUMNS,
       SQL_API_SQLDESCRIBEPARAM,  SQL_API_SQLPROCEDURES,       SQL_API_SQLSETPOS,
       SQL_API_SQLTABLEPRIVILEGES};
-  ASSERT_EQ(SQL_SUCCESS, SQLGetFunctions(this->conn, SQL_API_ALL_FUNCTIONS, api_exists));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetFunctions(conn, SQL_API_ALL_FUNCTIONS, api_exists));
 
   for (int api : supported_functions) {
     EXPECT_EQ(SQL_TRUE, api_exists[api]);
@@ -147,7 +148,7 @@ TYPED_TEST(GetFunctionsTest, TestSQLGetFunctionsSupportedSingleAPI) {
       SQL_API_SQLGETFUNCTIONS, SQL_API_SQLDRIVERS, SQL_API_SQLDATASOURCES};
   SQLUSMALLINT api_exists;
   for (SQLUSMALLINT api : supported_functions) {
-    ASSERT_EQ(SQL_SUCCESS, SQLGetFunctions(this->conn, api, &api_exists));
+    ASSERT_EQ(SQL_SUCCESS, SQLGetFunctions(conn, api, &api_exists));
 
     EXPECT_EQ(SQL_TRUE, api_exists);
 
@@ -167,7 +168,7 @@ TYPED_TEST(GetFunctionsTest, TestSQLGetFunctionsUnsupportedSingleAPI) {
       SQL_API_SQLTABLEPRIVILEGES};
   SQLUSMALLINT api_exists;
   for (SQLUSMALLINT api : unsupported_functions) {
-    ASSERT_EQ(SQL_SUCCESS, SQLGetFunctions(this->conn, api, &api_exists));
+    ASSERT_EQ(SQL_SUCCESS, SQLGetFunctions(conn, api, &api_exists));
 
     EXPECT_EQ(SQL_FALSE, api_exists);
 
@@ -175,7 +176,7 @@ TYPED_TEST(GetFunctionsTest, TestSQLGetFunctionsUnsupportedSingleAPI) {
   }
 }
 
-TYPED_TEST(GetFunctionsOdbcV2Test, TestSQLGetFunctionsSupportedSingleAPIODBCVer2) {
+TYPED_TEST(GetFunctionsOdbcV2Test, TestSQLGetFunctionsSupportedSingleAPI) {
   const std::vector<SQLUSMALLINT> supported_functions = {
       SQL_API_SQLCONNECT, SQL_API_SQLGETINFO, SQL_API_SQLDESCRIBECOL,
       SQL_API_SQLGETTYPEINFO, SQL_API_SQLDISCONNECT, SQL_API_SQLNUMRESULTCOLS,
@@ -191,7 +192,7 @@ TYPED_TEST(GetFunctionsOdbcV2Test, TestSQLGetFunctionsSupportedSingleAPIODBCVer2
       SQL_API_SQLGETFUNCTIONS, SQL_API_SQLDRIVERS, SQL_API_SQLDATASOURCES};
   SQLUSMALLINT api_exists;
   for (SQLUSMALLINT api : supported_functions) {
-    ASSERT_EQ(SQL_SUCCESS, SQLGetFunctions(this->conn, api, &api_exists));
+    ASSERT_EQ(SQL_SUCCESS, SQLGetFunctions(conn, api, &api_exists));
 
     EXPECT_EQ(SQL_TRUE, api_exists);
 
@@ -199,7 +200,7 @@ TYPED_TEST(GetFunctionsOdbcV2Test, TestSQLGetFunctionsSupportedSingleAPIODBCVer2
   }
 }
 
-TYPED_TEST(GetFunctionsOdbcV2Test, TestSQLGetFunctionsUnsupportedSingleAPIODBCVer2) {
+TYPED_TEST(GetFunctionsOdbcV2Test, TestSQLGetFunctionsUnsupportedSingleAPI) {
   const std::vector<SQLUSMALLINT> unsupported_functions = {
       SQL_API_SQLPUTDATA,        SQL_API_SQLPARAMDATA,        SQL_API_SQLSETCURSORNAME,
       SQL_API_SQLGETCURSORNAME,  SQL_API_SQLSTATISTICS,       SQL_API_SQLSPECIALCOLUMNS,
@@ -209,12 +210,13 @@ TYPED_TEST(GetFunctionsOdbcV2Test, TestSQLGetFunctionsUnsupportedSingleAPIODBCVe
       SQL_API_SQLTABLEPRIVILEGES};
   SQLUSMALLINT api_exists;
   for (SQLUSMALLINT api : unsupported_functions) {
-    ASSERT_EQ(SQL_SUCCESS, SQLGetFunctions(this->conn, api, &api_exists));
+    ASSERT_EQ(SQL_SUCCESS, SQLGetFunctions(conn, api, &api_exists));
 
     EXPECT_EQ(SQL_FALSE, api_exists);
 
     api_exists = -1;
   }
 }
+#endif  // __APPLE__
 
 }  // namespace arrow::flight::sql::odbc

--- a/cpp/src/arrow/flight/sql/odbc/tests/odbc_test_suite.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/odbc_test_suite.cc
@@ -28,7 +28,33 @@
 
 namespace arrow::flight::sql::odbc {
 
-void ODBCRemoteTestBase::AllocEnvConnHandles(SQLINTEGER odbc_ver) {
+class MockServerEnvironment : public ::testing::Environment {
+ public:
+  void SetUp() override {
+    ASSERT_OK_AND_ASSIGN(auto location, Location::ForGrpcTcp("0.0.0.0", 0));
+    arrow::flight::FlightServerOptions options(location);
+    options.auth_handler = std::make_unique<NoOpAuthHandler>();
+    options.middleware.push_back(
+        {"bearer-auth-server", std::make_shared<MockServerMiddlewareFactory>()});
+    ASSERT_OK_AND_ASSIGN(mock_server,
+                         arrow::flight::sql::example::SQLiteFlightSqlServer::Create());
+    ASSERT_OK(mock_server->Init(options));
+
+    mock_server_port = mock_server->port();
+    ASSERT_OK_AND_ASSIGN(location, Location::ForGrpcTcp("localhost", mock_server_port));
+    ASSERT_OK_AND_ASSIGN(auto client, arrow::flight::FlightClient::Connect(location));
+  }
+
+  void TearDown() override {
+    ASSERT_OK(mock_server->Shutdown());
+    ASSERT_OK(mock_server->Wait());
+  }
+};
+
+::testing::Environment* mock_env =
+    ::testing::AddGlobalTestEnvironment(new MockServerEnvironment);
+
+void ODBCTestBase::AllocEnvConnHandles(SQLINTEGER odbc_ver) {
   // Allocate an environment handle
   ASSERT_EQ(SQL_SUCCESS, SQLAllocEnv(&env));
 
@@ -41,13 +67,12 @@ void ODBCRemoteTestBase::AllocEnvConnHandles(SQLINTEGER odbc_ver) {
   ASSERT_EQ(SQL_SUCCESS, SQLAllocHandle(SQL_HANDLE_DBC, env, &conn));
 }
 
-void ODBCRemoteTestBase::Connect(SQLINTEGER odbc_ver) {
+void ODBCTestBase::Connect(std::string connect_str, SQLINTEGER odbc_ver) {
   ASSERT_NO_FATAL_FAILURE(AllocEnvConnHandles(odbc_ver));
-  std::string connect_str = GetConnectionString();
   ASSERT_NO_FATAL_FAILURE(ConnectWithString(connect_str));
 }
 
-void ODBCRemoteTestBase::ConnectWithString(std::string connect_str) {
+void ODBCTestBase::ConnectWithString(std::string connect_str) {
   // Connect string
   std::vector<SQLWCHAR> connect_str0(connect_str.begin(), connect_str.end());
 
@@ -60,13 +85,9 @@ void ODBCRemoteTestBase::ConnectWithString(std::string connect_str) {
                              static_cast<SQLSMALLINT>(connect_str0.size()), out_str,
                              kOdbcBufferSize, &out_str_len, SQL_DRIVER_NOPROMPT))
       << GetOdbcErrorMessage(SQL_HANDLE_DBC, conn);
-
-  ASSERT_EQ(SQL_SUCCESS, SQLAllocHandle(SQL_HANDLE_STMT, conn, &stmt));
 }
 
-void ODBCRemoteTestBase::Disconnect() {
-  EXPECT_EQ(SQL_SUCCESS, SQLFreeHandle(SQL_HANDLE_STMT, stmt));
-
+void ODBCTestBase::Disconnect() {
   // Disconnect from ODBC
   EXPECT_EQ(SQL_SUCCESS, SQLDisconnect(conn))
       << GetOdbcErrorMessage(SQL_HANDLE_DBC, conn);
@@ -74,7 +95,7 @@ void ODBCRemoteTestBase::Disconnect() {
   FreeEnvConnHandles();
 }
 
-void ODBCRemoteTestBase::FreeEnvConnHandles() {
+void ODBCTestBase::FreeEnvConnHandles() {
   // Free connection handle
   EXPECT_EQ(SQL_SUCCESS, SQLFreeHandle(SQL_HANDLE_DBC, conn));
 
@@ -82,20 +103,20 @@ void ODBCRemoteTestBase::FreeEnvConnHandles() {
   EXPECT_EQ(SQL_SUCCESS, SQLFreeHandle(SQL_HANDLE_ENV, env));
 }
 
-std::string ODBCRemoteTestBase::GetConnectionString() {
+std::string ODBCTestBase::GetConnectionString() {
   std::string connect_str =
       arrow::internal::GetEnvVar(kTestConnectStr.data()).ValueOrDie();
   return connect_str;
 }
 
-std::string ODBCRemoteTestBase::GetInvalidConnectionString() {
+std::string ODBCTestBase::GetInvalidConnectionString() {
   std::string connect_str = GetConnectionString();
   // Append invalid uid to connection string
   connect_str += std::string("uid=non_existent_id;");
   return connect_str;
 }
 
-std::wstring ODBCRemoteTestBase::GetQueryAllDataTypes() {
+std::wstring ODBCTestBase::GetQueryAllDataTypes() {
   std::wstring wsql =
       LR"( SELECT
            -- Numeric types
@@ -146,59 +167,69 @@ std::wstring ODBCRemoteTestBase::GetQueryAllDataTypes() {
   return wsql;
 }
 
-void ODBCRemoteTestBase::SetUp() {
+void ODBCTestBase::SetUp() {
+  if (connected) {
+    ASSERT_EQ(SQL_SUCCESS, SQLAllocHandle(SQL_HANDLE_STMT, conn, &stmt));
+  }
+}
+
+void ODBCTestBase::TearDown() {
+  if (connected) {
+    ASSERT_EQ(SQL_SUCCESS, SQLFreeHandle(SQL_HANDLE_STMT, stmt));
+  }
+}
+
+void ODBCTestBase::TearDownTestSuite() {
+  if (connected) {
+    Disconnect();
+    connected = false;
+  }
+}
+
+void FlightSQLODBCRemoteTestBase::CheckForRemoteTest() {
   if (arrow::internal::GetEnvVar(kTestConnectStr.data()).ValueOr("").empty()) {
-    skipping_test_ = true;
+    skipping_test = true;
     GTEST_SKIP() << "Skipping test: kTestConnectStr not set";
   }
 }
 
-void FlightSQLODBCRemoteTestBase::SetUp() {
-  ODBCRemoteTestBase::SetUp();
-  if (skipping_test_) {
+void FlightSQLODBCRemoteTestBase::SetUpTestSuite() {
+  CheckForRemoteTest();
+  if (skipping_test) {
     return;
   }
 
-  this->Connect();
-  connected_ = true;
+  std::string connect_str = GetConnectionString();
+  Connect(connect_str, SQL_OV_ODBC3);
+  connected = true;
 }
 
-void FlightSQLODBCRemoteTestBase::TearDown() {
-  if (connected_) {
-    this->Disconnect();
-    connected_ = false;
-  }
-}
-
-void FlightSQLOdbcV2RemoteTestBase::SetUp() {
-  ODBCRemoteTestBase::SetUp();
-  if (skipping_test_) {
+void FlightSQLOdbcV2RemoteTestBase::SetUpTestSuite() {
+  CheckForRemoteTest();
+  if (skipping_test) {
     return;
   }
 
-  this->Connect(SQL_OV_ODBC2);
-  connected_ = true;
+  std::string connect_str = GetConnectionString();
+  Connect(connect_str, SQL_OV_ODBC2);
+  connected = true;
 }
 
-void FlightSQLOdbcEnvConnHandleRemoteTestBase::SetUp() {
-  ODBCRemoteTestBase::SetUp();
-  if (skipping_test_) {
+void FlightSQLOdbcEnvConnHandleRemoteTestBase::SetUpTestSuite() {
+  CheckForRemoteTest();
+  if (skipping_test) {
     return;
   }
 
   AllocEnvConnHandles();
 }
 
-void FlightSQLOdbcEnvConnHandleRemoteTestBase::TearDown() {
-  if (skipping_test_) {
+void FlightSQLOdbcEnvConnHandleRemoteTestBase::TearDownTestSuite() {
+  if (skipping_test) {
     return;
   }
 
-  // Free connection handle
-  EXPECT_EQ(SQL_SUCCESS, SQLFreeHandle(SQL_HANDLE_DBC, conn));
-
-  // Free environment handle
-  EXPECT_EQ(SQL_SUCCESS, SQLFreeHandle(SQL_HANDLE_ENV, env));
+  FreeEnvConnHandles();
 }
 
 std::string FindTokenInCallHeaders(const CallHeaders& incoming_headers) {
@@ -244,7 +275,7 @@ Status MockServerMiddlewareFactory::StartCall(
 std::string ODBCMockTestBase::GetConnectionString() {
   std::string connect_str(
       "driver={Apache Arrow Flight SQL ODBC Driver};HOST=localhost;port=" +
-      std::to_string(port) + ";token=" + std::string(kTestToken) +
+      std::to_string(mock_server_port) + ";token=" + std::string(kTestToken) +
       ";useEncryption=false;UseWideChar=true;");
   return connect_str;
 }
@@ -305,8 +336,8 @@ std::wstring ODBCMockTestBase::GetQueryAllDataTypes() {
   return wsql;
 }
 
-void ODBCMockTestBase::CreateTestTables() {
-  ASSERT_OK(server_->ExecuteSql(R"(
+void ODBCMockTestBase::CreateTestTable() {
+  ASSERT_OK(mock_server->ExecuteSql(R"(
     CREATE TABLE TestTable (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     keyName varchar(100),
@@ -318,11 +349,15 @@ void ODBCMockTestBase::CreateTestTables() {
   )"));
 }
 
-void ODBCMockTestBase::CreateTableAllDataType() {
+void ODBCMockTestBase::DropTestTable() {
+  ASSERT_OK(mock_server->ExecuteSql("DROP TABLE TestTable;"));
+}
+
+void ODBCMockTestBase::CreateAllDataTypeTable() {
   // Limitation on mock SQLite server:
   // Only int64, float64, binary, and utf8 Arrow Types are supported by
   // SQLiteFlightSqlServer::Impl::DoGetTables
-  ASSERT_OK(server_->ExecuteSql(R"(
+  ASSERT_OK(mock_server->ExecuteSql(R"(
     CREATE TABLE AllTypesTable(
     bigint_col INTEGER PRIMARY KEY AUTOINCREMENT,
     char_col varchar(100),
@@ -340,6 +375,10 @@ void ODBCMockTestBase::CreateTableAllDataType() {
   )"));
 }
 
+void ODBCMockTestBase::DropAllDataTypeTable() {
+  ASSERT_OK(mock_server->ExecuteSql("DROP TABLE AllTypesTable;"));
+}
+
 void ODBCMockTestBase::CreateUnicodeTable() {
   std::string unicode_sql = arrow::util::WideStringToUTF8(
                                 LR"(
@@ -351,63 +390,30 @@ void ODBCMockTestBase::CreateUnicodeTable() {
     INSERT INTO 数据 (资料) VALUES ('3rd Row');
   )")
                                 .ValueOr("");
-  ASSERT_OK(server_->ExecuteSql(unicode_sql));
+  ASSERT_OK(mock_server->ExecuteSql(unicode_sql));
 }
 
-void ODBCMockTestBase::SetUp() {
-  ASSERT_OK_AND_ASSIGN(auto location, Location::ForGrpcTcp("0.0.0.0", 0));
-  arrow::flight::FlightServerOptions options(location);
-  options.auth_handler = std::make_unique<NoOpAuthHandler>();
-  options.middleware.push_back(
-      {"bearer-auth-server", std::make_shared<MockServerMiddlewareFactory>()});
-  ASSERT_OK_AND_ASSIGN(server_,
-                       arrow::flight::sql::example::SQLiteFlightSqlServer::Create());
-  ASSERT_OK(server_->Init(options));
-
-  port = server_->port();
-  ASSERT_OK_AND_ASSIGN(location, Location::ForGrpcTcp("localhost", port));
-  ASSERT_OK_AND_ASSIGN(auto client, arrow::flight::FlightClient::Connect(location));
+void ODBCMockTestBase::DropUnicodeTable() {
+  std::string unicode_sql =
+      arrow::util::WideStringToUTF8(L"DROP TABLE 数据;").ValueOr("");
+  ASSERT_OK(mock_server->ExecuteSql(unicode_sql));
 }
 
-void FlightSQLODBCMockTestBase::SetUp() {
-  ODBCMockTestBase::SetUp();
-  this->Connect();
-  connected_ = true;
+void FlightSQLODBCMockTestBase::SetUpTestSuite() {
+  std::string connect_str = GetConnectionString();
+  Connect(connect_str, SQL_OV_ODBC3);
+  connected = true;
 }
 
-void ODBCMockTestBase::TearDown() {
-  ASSERT_OK(server_->Shutdown());
-  ASSERT_OK(server_->Wait());
+void FlightSQLOdbcV2MockTestBase::SetUpTestSuite() {
+  std::string connect_str = GetConnectionString();
+  Connect(connect_str, SQL_OV_ODBC2);
+  connected = true;
 }
 
-void FlightSQLODBCMockTestBase::TearDown() {
-  if (connected_) {
-    this->Disconnect();
-    connected_ = false;
-  }
-  ODBCMockTestBase::TearDown();
-}
+void FlightSQLOdbcEnvConnHandleMockTestBase::SetUpTestSuite() { AllocEnvConnHandles(); }
 
-void FlightSQLOdbcV2MockTestBase::SetUp() {
-  ODBCMockTestBase::SetUp();
-  this->Connect(SQL_OV_ODBC2);
-  connected_ = true;
-}
-
-void FlightSQLOdbcEnvConnHandleMockTestBase::SetUp() {
-  ODBCMockTestBase::SetUp();
-  AllocEnvConnHandles();
-}
-
-void FlightSQLOdbcEnvConnHandleMockTestBase::TearDown() {
-  // Free connection handle
-  EXPECT_EQ(SQL_SUCCESS, SQLFreeHandle(SQL_HANDLE_DBC, conn));
-
-  // Free environment handle
-  EXPECT_EQ(SQL_SUCCESS, SQLFreeHandle(SQL_HANDLE_ENV, env));
-
-  ASSERT_OK(server_->Shutdown());
-}
+void FlightSQLOdbcEnvConnHandleMockTestBase::TearDownTestSuite() { FreeEnvConnHandles(); }
 
 bool CompareConnPropertyMap(Connection::ConnPropertyMap map1,
                             Connection::ConnPropertyMap map2) {
@@ -463,9 +469,6 @@ std::string GetOdbcErrorMessage(SQLSMALLINT handle_type, SQLHANDLE handle) {
   return res;
 }
 
-// GH-47822 TODO: once RegisterDsn is implemented in Mac and Linux, the following can be
-// re-enabled.
-#if defined _WIN32
 bool WriteDSN(std::string connection_str) {
   Connection::ConnPropertyMap properties;
 
@@ -490,7 +493,6 @@ bool WriteDSN(Connection::ConnPropertyMap properties) {
   std::wstring w_driver = arrow::util::UTF8ToWideString(driver).ValueOr(L"");
   return RegisterDsn(config, w_driver.c_str());
 }
-#endif
 
 std::wstring GetStringColumnW(SQLHSTMT stmt, int col_id) {
   SQLWCHAR buf[1024];

--- a/cpp/src/arrow/flight/sql/odbc/tests/odbc_test_suite.h
+++ b/cpp/src/arrow/flight/sql/odbc/tests/odbc_test_suite.h
@@ -41,6 +41,16 @@
 static constexpr std::string_view kTestConnectStr = "ARROW_FLIGHT_SQL_ODBC_CONN";
 static constexpr std::string_view kTestDsn = "Apache Arrow Flight SQL Test DSN";
 
+inline SQLHENV env = 0;
+inline SQLHDBC conn = 0;
+inline SQLHSTMT stmt = 0;
+
+inline bool skipping_test = false;
+inline bool connected = false;
+
+inline std::shared_ptr<arrow::flight::sql::example::SQLiteFlightSqlServer> mock_server;
+inline int mock_server_port = 0;
+
 namespace arrow::flight::sql::odbc {
 
 /// \brief Base test fixture for running tests against a remote server.
@@ -48,41 +58,32 @@ namespace arrow::flight::sql::odbc {
 /// in the ARROW_FLIGHT_SQL_ODBC_CONN environment variable.
 /// Note that this fixture does not handle the driver's connection/disconnection
 /// during SetUp/Teardown.
-class ODBCRemoteTestBase : public ::testing::Test {
+class ODBCTestBase : public ::testing::Test {
  public:
   /// \brief Allocate environment and connection handles
-  void AllocEnvConnHandles(SQLINTEGER odbc_ver = SQL_OV_ODBC3);
+  static void AllocEnvConnHandles(SQLINTEGER odbc_ver = SQL_OV_ODBC3);
   /// \brief Free environment and connection handles
-  void FreeEnvConnHandles();
+  static void FreeEnvConnHandles();
   /// \brief Connect to Arrow Flight SQL server using connection string defined in
   /// environment variable "ARROW_FLIGHT_SQL_ODBC_CONN", allocate statement handle.
   /// Connects using ODBC Ver 3 by default
-  void Connect(SQLINTEGER odbc_ver = SQL_OV_ODBC3);
+  static void Connect(std::string connect_str, SQLINTEGER odbc_ver = SQL_OV_ODBC3);
   /// \brief Connect to Arrow Flight SQL server using connection string
-  void ConnectWithString(std::string connection_str);
+  static void ConnectWithString(std::string connection_str);
   /// \brief Disconnect from server
-  void Disconnect();
+  static void Disconnect();
   /// \brief Get connection string from environment variable "ARROW_FLIGHT_SQL_ODBC_CONN"
-  std::string virtual GetConnectionString();
+  static std::string GetConnectionString();
   /// \brief Get invalid connection string based on connection string defined in
   /// environment variable "ARROW_FLIGHT_SQL_ODBC_CONN"
-  std::string virtual GetInvalidConnectionString();
+  static std::string GetInvalidConnectionString();
   /// \brief Return a SQL query that selects all data types
-  std::wstring virtual GetQueryAllDataTypes();
-
-  /** ODBC Environment. */
-  SQLHENV env = 0;
-
-  /** ODBC Connect. */
-  SQLHDBC conn = 0;
-
-  /** ODBC Statement. */
-  SQLHSTMT stmt = 0;
+  static std::wstring GetQueryAllDataTypes();
 
  protected:
   void SetUp() override;
-
-  bool skipping_test_ = false;
+  void TearDown() override;
+  static void TearDownTestSuite();
 };
 
 /// \brief Base test fixture for running tests against a remote server.
@@ -90,13 +91,12 @@ class ODBCRemoteTestBase : public ::testing::Test {
 /// fixture inheriting from this base fixture.
 /// The connection string for connecting to this server is defined
 /// in the ARROW_FLIGHT_SQL_ODBC_CONN environment variable.
-class FlightSQLODBCRemoteTestBase : public ODBCRemoteTestBase {
+class FlightSQLODBCRemoteTestBase : public ODBCTestBase {
+ public:
+  static void CheckForRemoteTest();
+
  protected:
-  void SetUp() override;
-
-  void TearDown() override;
-
-  bool connected_ = false;
+  static void SetUpTestSuite();
 };
 
 /// \brief Base test fixture for running ODBC V2 tests against a remote server.
@@ -104,15 +104,13 @@ class FlightSQLODBCRemoteTestBase : public ODBCRemoteTestBase {
 /// fixture inheriting from this base fixture.
 class FlightSQLOdbcV2RemoteTestBase : public FlightSQLODBCRemoteTestBase {
  protected:
-  void SetUp() override;
+  static void SetUpTestSuite();
 };
 
 class FlightSQLOdbcEnvConnHandleRemoteTestBase : public FlightSQLODBCRemoteTestBase {
  protected:
-  void SetUp() override;
-  void TearDown() override;
-
-  bool allocated_ = false;
+  static void SetUpTestSuite();
+  static void TearDownTestSuite();
 };
 
 static constexpr std::string_view kAuthorizationHeader = "authorization";
@@ -153,32 +151,33 @@ class MockServerMiddlewareFactory : public ServerMiddlewareFactory {
 };
 
 /// \brief Base test fixture for running tests against a mock server.
-class ODBCMockTestBase : public FlightSQLODBCRemoteTestBase {
+class ODBCMockTestBase : public ODBCTestBase {
   // Sets up a mock server for each test case
  public:
   /// \brief Get connection string for mock server
-  std::string GetConnectionString() override;
+  static std::string GetConnectionString();
   /// \brief Get invalid connection string for mock server
-  std::string GetInvalidConnectionString() override;
+  static std::string GetInvalidConnectionString();
   /// \brief Return a SQL query that selects all data types
-  std::wstring GetQueryAllDataTypes() override;
+  static std::wstring GetQueryAllDataTypes();
 
   /// \brief Run a SQL query to create default table for table test cases
-  void CreateTestTables();
+  static void CreateTestTable();
+  /// \brief Run a SQL query to drop default table for table test cases
+  static void DropTestTable();
 
   /// \brief run a SQL query to create a table with all data types
-  void CreateTableAllDataType();
-  /// \brief run a SQL query to create a table with unicode name
-  void CreateUnicodeTable();
+  static void CreateAllDataTypeTable();
+  /// \brief run a SQL query to drop a table with all data types
+  static void DropAllDataTypeTable();
 
-  int port;
+  /// \brief run a SQL query to create a table with unicode name
+  static void CreateUnicodeTable();
+  /// \brief run a SQL query to drop a table with unicode name
+  static void DropUnicodeTable();
 
  protected:
-  void SetUp() override;
-
-  void TearDown() override;
-
-  std::shared_ptr<arrow::flight::sql::example::SQLiteFlightSqlServer> server_;
+  static void SetUpTestSuite();
 };
 
 /// \brief Base test fixture for running tests against a mock server.
@@ -186,9 +185,7 @@ class ODBCMockTestBase : public FlightSQLODBCRemoteTestBase {
 /// fixture inheriting from this base fixture.
 class FlightSQLODBCMockTestBase : public ODBCMockTestBase {
  protected:
-  void SetUp() override;
-
-  void TearDown() override;
+  static void SetUpTestSuite();
 };
 
 /// \brief Base test fixture for running ODBC V2 tests against a mock server.
@@ -196,17 +193,23 @@ class FlightSQLODBCMockTestBase : public ODBCMockTestBase {
 /// fixture inheriting from this base fixture.
 class FlightSQLOdbcV2MockTestBase : public FlightSQLODBCMockTestBase {
  protected:
-  void SetUp() override;
+  static void SetUpTestSuite();
 };
 
 class FlightSQLOdbcEnvConnHandleMockTestBase : public FlightSQLODBCMockTestBase {
  protected:
-  void SetUp() override;
-  void TearDown() override;
+  static void SetUpTestSuite();
+  static void TearDownTestSuite();
 };
 
 /** ODBC read buffer size. */
+#ifdef __APPLE__
+// iODBC driver manager may crash with smaller buffer sizes
+// so we use a larger buffer on MacOS
+static constexpr int kOdbcBufferSize = 2048;
+#else
 static constexpr int kOdbcBufferSize = 1024;
+#endif  // __APPLE__
 
 /// Compare ConnPropertyMap, key value is case-insensitive
 bool CompareConnPropertyMap(Connection::ConnPropertyMap map1,

--- a/cpp/src/arrow/flight/sql/odbc/tests/statement_attr_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/statement_attr_test.cc
@@ -104,14 +104,18 @@ void ValidateSetStmtAttr(SQLHSTMT statement, SQLINTEGER attribute, SQLPOINTER va
 
 // Validate error return value and code
 void ValidateSetStmtAttrErrorCode(SQLHSTMT statement, SQLINTEGER attribute,
-                                  SQLULEN new_value, std::string_view error_code) {
+                                  SQLULEN new_value, SQLRETURN expected_rc,
+                                  std::string_view error_code) {
   SQLINTEGER string_length_ptr = sizeof(SQLULEN);
 
-  ASSERT_EQ(SQL_ERROR,
+  ASSERT_EQ(expected_rc,
             SQLSetStmtAttr(statement, attribute, reinterpret_cast<SQLPOINTER>(new_value),
-                           string_length_ptr));
+                           string_length_ptr))
+      << GetOdbcErrorMessage(SQL_HANDLE_STMT, statement);
 
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, statement, error_code);
+  if (expected_rc == SQL_ERROR) {
+    VerifyOdbcErrorState(SQL_HANDLE_STMT, statement, error_code);
+  }
 }
 }  // namespace
 
@@ -119,21 +123,21 @@ void ValidateSetStmtAttrErrorCode(SQLHSTMT statement, SQLINTEGER attribute,
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrAppParamDesc) {
   SQLULEN value;
-  GetStmtAttr(this->stmt, SQL_ATTR_APP_PARAM_DESC, &value);
+  GetStmtAttr(stmt, SQL_ATTR_APP_PARAM_DESC, &value);
 
   EXPECT_GT(value, static_cast<SQLULEN>(0));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrAppRowDesc) {
   SQLULEN value;
-  GetStmtAttr(this->stmt, SQL_ATTR_APP_ROW_DESC, &value);
+  GetStmtAttr(stmt, SQL_ATTR_APP_ROW_DESC, &value);
 
   EXPECT_GT(value, static_cast<SQLULEN>(0));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrAsyncEnable) {
   SQLULEN value;
-  GetStmtAttr(this->stmt, SQL_ATTR_ASYNC_ENABLE, &value);
+  GetStmtAttr(stmt, SQL_ATTR_ASYNC_ENABLE, &value);
 
   EXPECT_EQ(static_cast<SQLULEN>(SQL_ASYNC_ENABLE_OFF), value);
 }
@@ -141,241 +145,238 @@ TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrAsyncEnable) {
 #ifdef SQL_ATTR_ASYNC_STMT_EVENT
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrAsyncStmtEventUnsupported) {
   // Optional feature not implemented
-  ValidateGetStmtAttrErrorCode(this->stmt, SQL_ATTR_ASYNC_STMT_EVENT, kErrorStateHYC00);
+  ValidateGetStmtAttrErrorCode(stmt, SQL_ATTR_ASYNC_STMT_EVENT, kErrorStateHYC00);
 }
 #endif
 
 #ifdef SQL_ATTR_ASYNC_STMT_PCALLBACK
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrAsyncStmtPCCallbackUnsupported) {
   // Optional feature not implemented
-  ValidateGetStmtAttrErrorCode(this->stmt, SQL_ATTR_ASYNC_STMT_PCALLBACK,
-                               kErrorStateHYC00);
+  ValidateGetStmtAttrErrorCode(stmt, SQL_ATTR_ASYNC_STMT_PCALLBACK, kErrorStateHYC00);
 }
 #endif
 
 #ifdef SQL_ATTR_ASYNC_STMT_PCONTEXT
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrAsyncStmtPCContextUnsupported) {
   // Optional feature not implemented
-  ValidateGetStmtAttrErrorCode(this->stmt, SQL_ATTR_ASYNC_STMT_PCONTEXT,
-                               kErrorStateHYC00);
+  ValidateGetStmtAttrErrorCode(stmt, SQL_ATTR_ASYNC_STMT_PCONTEXT, kErrorStateHYC00);
 }
 #endif
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrConcurrency) {
   SQLULEN value;
-  GetStmtAttr(this->stmt, SQL_ATTR_CONCURRENCY, &value);
+  GetStmtAttr(stmt, SQL_ATTR_CONCURRENCY, &value);
 
   EXPECT_EQ(static_cast<SQLULEN>(SQL_CONCUR_READ_ONLY), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrCursorScrollable) {
   SQLULEN value;
-  GetStmtAttr(this->stmt, SQL_ATTR_CURSOR_SCROLLABLE, &value);
+  GetStmtAttr(stmt, SQL_ATTR_CURSOR_SCROLLABLE, &value);
 
   EXPECT_EQ(static_cast<SQLULEN>(SQL_NONSCROLLABLE), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrCursorSensitivity) {
   SQLULEN value;
-  GetStmtAttr(this->stmt, SQL_ATTR_CURSOR_SENSITIVITY, &value);
+  GetStmtAttr(stmt, SQL_ATTR_CURSOR_SENSITIVITY, &value);
 
   EXPECT_EQ(static_cast<SQLULEN>(SQL_UNSPECIFIED), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrCursorType) {
   SQLULEN value;
-  GetStmtAttr(this->stmt, SQL_ATTR_CURSOR_TYPE, &value);
+  GetStmtAttr(stmt, SQL_ATTR_CURSOR_TYPE, &value);
 
   EXPECT_EQ(static_cast<SQLULEN>(SQL_CURSOR_FORWARD_ONLY), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrEnableAutoIPD) {
   SQLULEN value;
-  GetStmtAttr(this->stmt, SQL_ATTR_ENABLE_AUTO_IPD, &value);
+  GetStmtAttr(stmt, SQL_ATTR_ENABLE_AUTO_IPD, &value);
 
   EXPECT_EQ(static_cast<SQLULEN>(SQL_FALSE), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrFetchBookmarkPointer) {
   SQLLEN value;
-  GetStmtAttr(this->stmt, SQL_ATTR_FETCH_BOOKMARK_PTR, &value);
+  GetStmtAttr(stmt, SQL_ATTR_FETCH_BOOKMARK_PTR, &value);
 
   EXPECT_EQ(static_cast<SQLLEN>(NULL), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrIMPParamDesc) {
   SQLULEN value;
-  GetStmtAttr(this->stmt, SQL_ATTR_IMP_PARAM_DESC, &value);
+  GetStmtAttr(stmt, SQL_ATTR_IMP_PARAM_DESC, &value);
 
   EXPECT_GT(value, static_cast<SQLULEN>(0));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrIMPRowDesc) {
   SQLULEN value;
-  GetStmtAttr(this->stmt, SQL_ATTR_IMP_ROW_DESC, &value);
+  GetStmtAttr(stmt, SQL_ATTR_IMP_ROW_DESC, &value);
 
   EXPECT_GT(value, static_cast<SQLULEN>(0));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrKeysetSize) {
   SQLULEN value;
-  GetStmtAttr(this->stmt, SQL_ATTR_KEYSET_SIZE, &value);
+  GetStmtAttr(stmt, SQL_ATTR_KEYSET_SIZE, &value);
 
   EXPECT_EQ(static_cast<SQLULEN>(0), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrMaxLength) {
   SQLULEN value;
-  GetStmtAttr(this->stmt, SQL_ATTR_MAX_LENGTH, &value);
+  GetStmtAttr(stmt, SQL_ATTR_MAX_LENGTH, &value);
 
   EXPECT_EQ(static_cast<SQLULEN>(0), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrMaxRows) {
   SQLULEN value;
-  GetStmtAttr(this->stmt, SQL_ATTR_MAX_ROWS, &value);
+  GetStmtAttr(stmt, SQL_ATTR_MAX_ROWS, &value);
 
   EXPECT_EQ(static_cast<SQLULEN>(0), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrMetadataID) {
   SQLULEN value;
-  GetStmtAttr(this->stmt, SQL_ATTR_METADATA_ID, &value);
+  GetStmtAttr(stmt, SQL_ATTR_METADATA_ID, &value);
 
   EXPECT_EQ(static_cast<SQLULEN>(SQL_FALSE), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrNoscan) {
   SQLULEN value;
-  GetStmtAttr(this->stmt, SQL_ATTR_NOSCAN, &value);
+  GetStmtAttr(stmt, SQL_ATTR_NOSCAN, &value);
 
   EXPECT_EQ(static_cast<SQLULEN>(SQL_NOSCAN_OFF), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrParamBindOffsetPtr) {
   SQLPOINTER value = nullptr;
-  GetStmtAttr(this->stmt, SQL_ATTR_PARAM_BIND_OFFSET_PTR, &value);
+  GetStmtAttr(stmt, SQL_ATTR_PARAM_BIND_OFFSET_PTR, &value);
 
   EXPECT_EQ(static_cast<SQLPOINTER>(nullptr), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrParamBindType) {
   SQLULEN value;
-  GetStmtAttr(this->stmt, SQL_ATTR_PARAM_BIND_TYPE, &value);
+  GetStmtAttr(stmt, SQL_ATTR_PARAM_BIND_TYPE, &value);
 
   EXPECT_EQ(static_cast<SQLULEN>(SQL_PARAM_BIND_BY_COLUMN), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrParamOperationPtr) {
   SQLPOINTER value = nullptr;
-  GetStmtAttr(this->stmt, SQL_ATTR_PARAM_OPERATION_PTR, &value);
+  GetStmtAttr(stmt, SQL_ATTR_PARAM_OPERATION_PTR, &value);
 
   EXPECT_EQ(static_cast<SQLPOINTER>(nullptr), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrParamStatusPtr) {
   SQLPOINTER value = nullptr;
-  GetStmtAttr(this->stmt, SQL_ATTR_PARAM_STATUS_PTR, &value);
+  GetStmtAttr(stmt, SQL_ATTR_PARAM_STATUS_PTR, &value);
 
   EXPECT_EQ(static_cast<SQLPOINTER>(nullptr), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrParamsProcessedPtr) {
   SQLPOINTER value = nullptr;
-  GetStmtAttr(this->stmt, SQL_ATTR_PARAMS_PROCESSED_PTR, &value);
+  GetStmtAttr(stmt, SQL_ATTR_PARAMS_PROCESSED_PTR, &value);
 
   EXPECT_EQ(static_cast<SQLPOINTER>(nullptr), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrParamsetSize) {
   SQLULEN value;
-  GetStmtAttr(this->stmt, SQL_ATTR_PARAMSET_SIZE, &value);
+  GetStmtAttr(stmt, SQL_ATTR_PARAMSET_SIZE, &value);
 
   EXPECT_EQ(static_cast<SQLULEN>(1), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrQueryTimeout) {
   SQLULEN value;
-  GetStmtAttr(this->stmt, SQL_ATTR_QUERY_TIMEOUT, &value);
+  GetStmtAttr(stmt, SQL_ATTR_QUERY_TIMEOUT, &value);
 
   EXPECT_EQ(static_cast<SQLULEN>(0), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrRetrieveData) {
   SQLULEN value;
-  GetStmtAttr(this->stmt, SQL_ATTR_RETRIEVE_DATA, &value);
+  GetStmtAttr(stmt, SQL_ATTR_RETRIEVE_DATA, &value);
 
   EXPECT_EQ(static_cast<SQLULEN>(SQL_RD_ON), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrRowArraySize) {
   SQLULEN value;
-  GetStmtAttr(this->stmt, SQL_ATTR_ROW_ARRAY_SIZE, &value);
+  GetStmtAttr(stmt, SQL_ATTR_ROW_ARRAY_SIZE, &value);
 
   EXPECT_EQ(static_cast<SQLULEN>(1), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrRowBindOffsetPtr) {
   SQLPOINTER value = nullptr;
-  GetStmtAttr(this->stmt, SQL_ATTR_ROW_BIND_OFFSET_PTR, &value);
+  GetStmtAttr(stmt, SQL_ATTR_ROW_BIND_OFFSET_PTR, &value);
 
   EXPECT_EQ(static_cast<SQLPOINTER>(nullptr), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrRowBindType) {
   SQLULEN value;
-  GetStmtAttr(this->stmt, SQL_ATTR_ROW_BIND_TYPE, &value);
+  GetStmtAttr(stmt, SQL_ATTR_ROW_BIND_TYPE, &value);
 
   EXPECT_EQ(static_cast<SQLULEN>(0), value);
 }
 
-TYPED_TEST(StatementAttributeTest, DISABLED_TestSQLGetStmtAttrRowNumber) {
-  // GH-47711 TODO: enable test after SQLExecDirect support
+TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrRowNumber) {
   std::wstring wsql = L"SELECT 1;";
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   SQLULEN value;
-  GetStmtAttr(this->stmt, SQL_ATTR_ROW_NUMBER, &value);
+  GetStmtAttr(stmt, SQL_ATTR_ROW_NUMBER, &value);
 
   EXPECT_EQ(static_cast<SQLULEN>(1), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrRowOperationPtr) {
   SQLPOINTER value = nullptr;
-  GetStmtAttr(this->stmt, SQL_ATTR_ROW_OPERATION_PTR, &value);
+  GetStmtAttr(stmt, SQL_ATTR_ROW_OPERATION_PTR, &value);
 
   EXPECT_EQ(static_cast<SQLPOINTER>(nullptr), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrRowStatusPtr) {
   SQLPOINTER value = nullptr;
-  GetStmtAttr(this->stmt, SQL_ATTR_ROW_STATUS_PTR, &value);
+  GetStmtAttr(stmt, SQL_ATTR_ROW_STATUS_PTR, &value);
 
   EXPECT_EQ(static_cast<SQLPOINTER>(nullptr), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrRowsFetchedPtr) {
   SQLPOINTER value = nullptr;
-  GetStmtAttr(this->stmt, SQL_ATTR_ROWS_FETCHED_PTR, &value);
+  GetStmtAttr(stmt, SQL_ATTR_ROWS_FETCHED_PTR, &value);
 
   EXPECT_EQ(static_cast<SQLPOINTER>(nullptr), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrSimulateCursor) {
   SQLULEN value;
-  GetStmtAttr(this->stmt, SQL_ATTR_SIMULATE_CURSOR, &value);
+  GetStmtAttr(stmt, SQL_ATTR_SIMULATE_CURSOR, &value);
 
   EXPECT_EQ(static_cast<SQLULEN>(SQL_SC_UNIQUE), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrUseBookmarks) {
   SQLULEN value;
-  GetStmtAttr(this->stmt, SQL_ATTR_USE_BOOKMARKS, &value);
+  GetStmtAttr(stmt, SQL_ATTR_USE_BOOKMARKS, &value);
 
   EXPECT_EQ(static_cast<SQLULEN>(SQL_UB_OFF), value);
 }
@@ -383,7 +384,7 @@ TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrUseBookmarks) {
 // This is a pre ODBC 3 attribute
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrRowsetSize) {
   SQLULEN value;
-  GetStmtAttr(this->stmt, SQL_ROWSET_SIZE, &value);
+  GetStmtAttr(stmt, SQL_ROWSET_SIZE, &value);
 
   EXPECT_EQ(static_cast<SQLULEN>(1), value);
 }
@@ -392,12 +393,12 @@ TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrAppParamDesc) {
   SQLULEN app_param_desc = 0;
   SQLINTEGER string_length_ptr;
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetStmtAttr(this->stmt, SQL_ATTR_APP_PARAM_DESC,
-                                        &app_param_desc, 0, &string_length_ptr));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetStmtAttr(stmt, SQL_ATTR_APP_PARAM_DESC, &app_param_desc, 0,
+                                        &string_length_ptr));
 
-  ValidateSetStmtAttr(this->stmt, SQL_ATTR_APP_PARAM_DESC, static_cast<SQLULEN>(0));
+  ValidateSetStmtAttr(stmt, SQL_ATTR_APP_PARAM_DESC, static_cast<SQLULEN>(0));
 
-  ValidateSetStmtAttr(this->stmt, SQL_ATTR_APP_PARAM_DESC,
+  ValidateSetStmtAttr(stmt, SQL_ATTR_APP_PARAM_DESC,
                       static_cast<SQLULEN>(app_param_desc));
 }
 
@@ -405,34 +406,33 @@ TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrAppRowDesc) {
   SQLULEN app_row_desc = 0;
   SQLINTEGER string_length_ptr;
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetStmtAttr(this->stmt, SQL_ATTR_APP_ROW_DESC, &app_row_desc,
-                                        0, &string_length_ptr));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetStmtAttr(stmt, SQL_ATTR_APP_ROW_DESC, &app_row_desc, 0,
+                                        &string_length_ptr));
 
-  ValidateSetStmtAttr(this->stmt, SQL_ATTR_APP_ROW_DESC, static_cast<SQLULEN>(0));
+  ValidateSetStmtAttr(stmt, SQL_ATTR_APP_ROW_DESC, static_cast<SQLULEN>(0));
 
-  ValidateSetStmtAttr(this->stmt, SQL_ATTR_APP_ROW_DESC,
-                      static_cast<SQLULEN>(app_row_desc));
+  ValidateSetStmtAttr(stmt, SQL_ATTR_APP_ROW_DESC, static_cast<SQLULEN>(app_row_desc));
 }
 
 #ifdef SQL_ATTR_ASYNC_ENABLE
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrAsyncEnableUnsupported) {
   // Optional feature not implemented
-  ValidateSetStmtAttrErrorCode(this->stmt, SQL_ATTR_ASYNC_ENABLE, SQL_ASYNC_ENABLE_OFF,
-                               kErrorStateHYC00);
+  ValidateSetStmtAttrErrorCode(stmt, SQL_ATTR_ASYNC_ENABLE, SQL_ASYNC_ENABLE_OFF,
+                               SQL_ERROR, kErrorStateHYC00);
 }
 #endif
 
 #ifdef SQL_ATTR_ASYNC_STMT_EVENT
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrAsyncStmtEventUnsupported) {
   // Driver does not support asynchronous notification
-  ValidateSetStmtAttrErrorCode(this->stmt, SQL_ATTR_ASYNC_STMT_EVENT, 0,
+  ValidateSetStmtAttrErrorCode(stmt, SQL_ATTR_ASYNC_STMT_EVENT, 0, SQL_ERROR,
                                kErrorStateHY118);
 }
 #endif
 
 #ifdef SQL_ATTR_ASYNC_STMT_PCALLBACK
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrAsyncStmtPCCallbackUnsupported) {
-  ValidateSetStmtAttrErrorCode(this->stmt, SQL_ATTR_ASYNC_STMT_PCALLBACK, 0,
+  ValidateSetStmtAttrErrorCode(stmt, SQL_ATTR_ASYNC_STMT_PCALLBACK, 0, SQL_ERROR,
                                kErrorStateHYC00);
 }
 #endif
@@ -440,44 +440,43 @@ TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrAsyncStmtPCCallbackUnsuppor
 #ifdef SQL_ATTR_ASYNC_STMT_PCONTEXT
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrAsyncStmtPCContextUnsupported) {
   // Optional feature not implemented
-  ValidateSetStmtAttrErrorCode(this->stmt, SQL_ATTR_ASYNC_STMT_PCONTEXT, 0,
+  ValidateSetStmtAttrErrorCode(stmt, SQL_ATTR_ASYNC_STMT_PCONTEXT, 0, SQL_ERROR,
                                kErrorStateHYC00);
 }
 #endif
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrConcurrency) {
-  ValidateSetStmtAttr(this->stmt, SQL_ATTR_CONCURRENCY,
+  ValidateSetStmtAttr(stmt, SQL_ATTR_CONCURRENCY,
                       static_cast<SQLULEN>(SQL_CONCUR_READ_ONLY));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrCursorScrollable) {
-  ValidateSetStmtAttr(this->stmt, SQL_ATTR_CURSOR_SCROLLABLE,
+  ValidateSetStmtAttr(stmt, SQL_ATTR_CURSOR_SCROLLABLE,
                       static_cast<SQLULEN>(SQL_NONSCROLLABLE));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrCursorSensitivity) {
-  ValidateSetStmtAttr(this->stmt, SQL_ATTR_CURSOR_SENSITIVITY,
+  ValidateSetStmtAttr(stmt, SQL_ATTR_CURSOR_SENSITIVITY,
                       static_cast<SQLULEN>(SQL_UNSPECIFIED));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrCursorType) {
-  ValidateSetStmtAttr(this->stmt, SQL_ATTR_CURSOR_TYPE,
+  ValidateSetStmtAttr(stmt, SQL_ATTR_CURSOR_TYPE,
                       static_cast<SQLULEN>(SQL_CURSOR_FORWARD_ONLY));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrEnableAutoIPD) {
-  ValidateSetStmtAttr(this->stmt, SQL_ATTR_ENABLE_AUTO_IPD,
-                      static_cast<SQLULEN>(SQL_FALSE));
+  ValidateSetStmtAttr(stmt, SQL_ATTR_ENABLE_AUTO_IPD, static_cast<SQLULEN>(SQL_FALSE));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrFetchBookmarkPointer) {
-  ValidateSetStmtAttr(this->stmt, SQL_ATTR_FETCH_BOOKMARK_PTR, static_cast<SQLLEN>(NULL));
+  ValidateSetStmtAttr(stmt, SQL_ATTR_FETCH_BOOKMARK_PTR, static_cast<SQLLEN>(NULL));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrIMPParamDesc) {
   // Invalid use of an automatically allocated descriptor handle
-  ValidateSetStmtAttrErrorCode(this->stmt, SQL_ATTR_IMP_PARAM_DESC,
-                               static_cast<SQLULEN>(0),
+  ValidateSetStmtAttrErrorCode(stmt, SQL_ATTR_IMP_PARAM_DESC, static_cast<SQLULEN>(0),
+                               SQL_ERROR,
 #ifdef __APPLE__
                                // static iODBC on MacOS returns IM001 for this case
                                kErrorStateIM001);
@@ -488,7 +487,8 @@ TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrIMPParamDesc) {
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrIMPRowDesc) {
   // Invalid use of an automatically allocated descriptor handle
-  ValidateSetStmtAttrErrorCode(this->stmt, SQL_ATTR_IMP_ROW_DESC, static_cast<SQLULEN>(0),
+  ValidateSetStmtAttrErrorCode(stmt, SQL_ATTR_IMP_ROW_DESC, static_cast<SQLULEN>(0),
+                               SQL_ERROR,
 #ifdef __APPLE__
                                // static iODBC on MacOS returns IM001 for this case
                                kErrorStateIM001);
@@ -496,42 +496,43 @@ TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrIMPRowDesc) {
                                kErrorStateHY017);
 #endif  // __APPLE__
 }
+
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrKeysetSizeUnsupported) {
-  ValidateSetStmtAttr(this->stmt, SQL_ATTR_KEYSET_SIZE, static_cast<SQLULEN>(0));
+  ValidateSetStmtAttr(stmt, SQL_ATTR_KEYSET_SIZE, static_cast<SQLULEN>(0));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrMaxLength) {
-  ValidateSetStmtAttr(this->stmt, SQL_ATTR_MAX_LENGTH, static_cast<SQLULEN>(0));
+  ValidateSetStmtAttr(stmt, SQL_ATTR_MAX_LENGTH, static_cast<SQLULEN>(0));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrMaxRows) {
   // Cannot set read-only attribute
-  ValidateSetStmtAttrErrorCode(this->stmt, SQL_ATTR_MAX_ROWS, static_cast<SQLULEN>(0),
-                               kErrorStateHY092);
+  ValidateSetStmtAttrErrorCode(stmt, SQL_ATTR_MAX_ROWS, static_cast<SQLULEN>(0),
+                               SQL_ERROR, kErrorStateHY092);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrMetadataID) {
-  ValidateSetStmtAttr(this->stmt, SQL_ATTR_METADATA_ID, static_cast<SQLULEN>(SQL_FALSE));
+  ValidateSetStmtAttr(stmt, SQL_ATTR_METADATA_ID, static_cast<SQLULEN>(SQL_FALSE));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrNoscan) {
-  ValidateSetStmtAttr(this->stmt, SQL_ATTR_NOSCAN, static_cast<SQLULEN>(SQL_NOSCAN_OFF));
+  ValidateSetStmtAttr(stmt, SQL_ATTR_NOSCAN, static_cast<SQLULEN>(SQL_NOSCAN_OFF));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrParamBindOffsetPtr) {
   SQLULEN offset = 1000;
 
-  ValidateSetStmtAttr(this->stmt, SQL_ATTR_PARAM_BIND_OFFSET_PTR,
+  ValidateSetStmtAttr(stmt, SQL_ATTR_PARAM_BIND_OFFSET_PTR,
                       static_cast<SQLPOINTER>(&offset));
 
   SQLPOINTER value = nullptr;
-  GetStmtAttr(this->stmt, SQL_ATTR_PARAM_BIND_OFFSET_PTR, &value);
+  GetStmtAttr(stmt, SQL_ATTR_PARAM_BIND_OFFSET_PTR, &value);
 
   EXPECT_EQ(static_cast<SQLPOINTER>(&offset), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrParamBindType) {
-  ValidateSetStmtAttr(this->stmt, SQL_ATTR_PARAM_BIND_TYPE,
+  ValidateSetStmtAttr(stmt, SQL_ATTR_PARAM_BIND_TYPE,
                       static_cast<SQLULEN>(SQL_PARAM_BIND_BY_COLUMN));
 }
 
@@ -540,11 +541,11 @@ TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrParamOperationPtr) {
   SQLUSMALLINT param_operations[param_set_size] = {SQL_PARAM_PROCEED, SQL_PARAM_IGNORE,
                                                    SQL_PARAM_PROCEED, SQL_PARAM_IGNORE};
 
-  ValidateSetStmtAttr(this->stmt, SQL_ATTR_PARAM_OPERATION_PTR,
+  ValidateSetStmtAttr(stmt, SQL_ATTR_PARAM_OPERATION_PTR,
                       static_cast<SQLPOINTER>(param_operations));
 
   SQLPOINTER value = nullptr;
-  GetStmtAttr(this->stmt, SQL_ATTR_PARAM_OPERATION_PTR, &value);
+  GetStmtAttr(stmt, SQL_ATTR_PARAM_OPERATION_PTR, &value);
 
   EXPECT_EQ(static_cast<SQLPOINTER>(param_operations), value);
 }
@@ -555,11 +556,11 @@ TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrParamStatusPtr) {
   SQLUSMALLINT param_status[param_status_size] = {SQL_PARAM_PROCEED, SQL_PARAM_IGNORE,
                                                   SQL_PARAM_PROCEED, SQL_PARAM_IGNORE};
 
-  ValidateSetStmtAttr(this->stmt, SQL_ATTR_PARAM_STATUS_PTR,
+  ValidateSetStmtAttr(stmt, SQL_ATTR_PARAM_STATUS_PTR,
                       static_cast<SQLPOINTER>(param_status));
 
   SQLPOINTER value = nullptr;
-  GetStmtAttr(this->stmt, SQL_ATTR_PARAM_STATUS_PTR, &value);
+  GetStmtAttr(stmt, SQL_ATTR_PARAM_STATUS_PTR, &value);
 
   EXPECT_EQ(static_cast<SQLPOINTER>(param_status), value);
 }
@@ -567,52 +568,51 @@ TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrParamStatusPtr) {
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrParamsProcessedPtr) {
   SQLULEN processed_count = 0;
 
-  ValidateSetStmtAttr(this->stmt, SQL_ATTR_PARAMS_PROCESSED_PTR,
+  ValidateSetStmtAttr(stmt, SQL_ATTR_PARAMS_PROCESSED_PTR,
                       static_cast<SQLPOINTER>(&processed_count));
 
   SQLPOINTER value = nullptr;
-  GetStmtAttr(this->stmt, SQL_ATTR_PARAMS_PROCESSED_PTR, &value);
+  GetStmtAttr(stmt, SQL_ATTR_PARAMS_PROCESSED_PTR, &value);
 
   EXPECT_EQ(static_cast<SQLPOINTER>(&processed_count), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrParamsetSize) {
-  ValidateSetStmtAttr(this->stmt, SQL_ATTR_PARAMSET_SIZE, static_cast<SQLULEN>(1));
+  ValidateSetStmtAttr(stmt, SQL_ATTR_PARAMSET_SIZE, static_cast<SQLULEN>(1));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrQueryTimeout) {
-  ValidateSetStmtAttr(this->stmt, SQL_ATTR_QUERY_TIMEOUT, static_cast<SQLULEN>(1));
+  ValidateSetStmtAttr(stmt, SQL_ATTR_QUERY_TIMEOUT, static_cast<SQLULEN>(1));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrRetrieveData) {
-  ValidateSetStmtAttr(this->stmt, SQL_ATTR_RETRIEVE_DATA,
-                      static_cast<SQLULEN>(SQL_RD_ON));
+  ValidateSetStmtAttr(stmt, SQL_ATTR_RETRIEVE_DATA, static_cast<SQLULEN>(SQL_RD_ON));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrRowArraySize) {
-  ValidateSetStmtAttr(this->stmt, SQL_ATTR_ROW_ARRAY_SIZE, static_cast<SQLULEN>(1));
+  ValidateSetStmtAttr(stmt, SQL_ATTR_ROW_ARRAY_SIZE, static_cast<SQLULEN>(1));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrRowBindOffsetPtr) {
   SQLULEN offset = 1000;
 
-  ValidateSetStmtAttr(this->stmt, SQL_ATTR_ROW_BIND_OFFSET_PTR,
+  ValidateSetStmtAttr(stmt, SQL_ATTR_ROW_BIND_OFFSET_PTR,
                       static_cast<SQLPOINTER>(&offset));
 
   SQLPOINTER value = nullptr;
-  GetStmtAttr(this->stmt, SQL_ATTR_ROW_BIND_OFFSET_PTR, &value);
+  GetStmtAttr(stmt, SQL_ATTR_ROW_BIND_OFFSET_PTR, &value);
 
   EXPECT_EQ(static_cast<SQLPOINTER>(&offset), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrRowBindType) {
-  ValidateSetStmtAttr(this->stmt, SQL_ATTR_ROW_BIND_TYPE, static_cast<SQLULEN>(0));
+  ValidateSetStmtAttr(stmt, SQL_ATTR_ROW_BIND_TYPE, static_cast<SQLULEN>(0));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrRowNumber) {
   // Cannot set read-only attribute
-  ValidateSetStmtAttrErrorCode(this->stmt, SQL_ATTR_ROW_NUMBER, static_cast<SQLULEN>(0),
-                               kErrorStateHY092);
+  ValidateSetStmtAttrErrorCode(stmt, SQL_ATTR_ROW_NUMBER, static_cast<SQLULEN>(0),
+                               SQL_ERROR, kErrorStateHY092);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrRowOperationPtr) {
@@ -620,11 +620,11 @@ TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrRowOperationPtr) {
   SQLUSMALLINT row_operations[param_set_size] = {SQL_ROW_PROCEED, SQL_ROW_IGNORE,
                                                  SQL_ROW_PROCEED, SQL_ROW_IGNORE};
 
-  ValidateSetStmtAttr(this->stmt, SQL_ATTR_ROW_OPERATION_PTR,
+  ValidateSetStmtAttr(stmt, SQL_ATTR_ROW_OPERATION_PTR,
                       static_cast<SQLPOINTER>(row_operations));
 
   SQLPOINTER value = nullptr;
-  GetStmtAttr(this->stmt, SQL_ATTR_ROW_OPERATION_PTR, &value);
+  GetStmtAttr(stmt, SQL_ATTR_ROW_OPERATION_PTR, &value);
 
   EXPECT_EQ(static_cast<SQLPOINTER>(row_operations), value);
 }
@@ -633,11 +633,10 @@ TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrRowStatusPtr) {
   constexpr SQLULEN row_status_size = 4;
   SQLUSMALLINT values[row_status_size] = {0, 0, 0, 0};
 
-  ValidateSetStmtAttr(this->stmt, SQL_ATTR_ROW_STATUS_PTR,
-                      static_cast<SQLPOINTER>(values));
+  ValidateSetStmtAttr(stmt, SQL_ATTR_ROW_STATUS_PTR, static_cast<SQLPOINTER>(values));
 
   SQLPOINTER value = nullptr;
-  GetStmtAttr(this->stmt, SQL_ATTR_ROW_STATUS_PTR, &value);
+  GetStmtAttr(stmt, SQL_ATTR_ROW_STATUS_PTR, &value);
 
   EXPECT_EQ(static_cast<SQLPOINTER>(values), value);
 }
@@ -645,28 +644,27 @@ TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrRowStatusPtr) {
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrRowsFetchedPtr) {
   SQLULEN rows_fetched = 1;
 
-  ValidateSetStmtAttr(this->stmt, SQL_ATTR_ROWS_FETCHED_PTR,
+  ValidateSetStmtAttr(stmt, SQL_ATTR_ROWS_FETCHED_PTR,
                       static_cast<SQLPOINTER>(&rows_fetched));
 
   SQLPOINTER value = nullptr;
-  GetStmtAttr(this->stmt, SQL_ATTR_ROWS_FETCHED_PTR, &value);
+  GetStmtAttr(stmt, SQL_ATTR_ROWS_FETCHED_PTR, &value);
 
   EXPECT_EQ(static_cast<SQLPOINTER>(&rows_fetched), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrSimulateCursor) {
-  ValidateSetStmtAttr(this->stmt, SQL_ATTR_SIMULATE_CURSOR,
+  ValidateSetStmtAttr(stmt, SQL_ATTR_SIMULATE_CURSOR,
                       static_cast<SQLULEN>(SQL_SC_UNIQUE));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrUseBookmarks) {
-  ValidateSetStmtAttr(this->stmt, SQL_ATTR_USE_BOOKMARKS,
-                      static_cast<SQLULEN>(SQL_UB_OFF));
+  ValidateSetStmtAttr(stmt, SQL_ATTR_USE_BOOKMARKS, static_cast<SQLULEN>(SQL_UB_OFF));
 }
 
 // This is a pre ODBC 3 attribute
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrRowsetSize) {
-  ValidateSetStmtAttr(this->stmt, SQL_ROWSET_SIZE, static_cast<SQLULEN>(1));
+  ValidateSetStmtAttr(stmt, SQL_ROWSET_SIZE, static_cast<SQLULEN>(1));
 }
 
 }  // namespace arrow::flight::sql::odbc

--- a/cpp/src/arrow/flight/sql/odbc/tests/statement_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/statement_test.cc
@@ -42,21 +42,27 @@ TYPED_TEST(StatementTest, TestSQLExecDirectSimpleQuery) {
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   SQLINTEGER val;
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 1, SQL_C_LONG, &val, 0, nullptr));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 1, SQL_C_LONG, &val, 0, nullptr));
   // Verify 1 is returned
   EXPECT_EQ(1, val);
 
-  ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_NO_DATA, SQLFetch(stmt));
 
-  ASSERT_EQ(SQL_ERROR, SQLGetData(this->stmt, 1, SQL_C_LONG, &val, 0, nullptr));
+#ifdef __APPLE__
+  // With iODBC we expect SQL_SUCCESS and the buffer unchanged in this situation.
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 1, SQL_C_LONG, &val, 0, nullptr));
+  EXPECT_EQ(1, val);
+#else
+  ASSERT_EQ(SQL_ERROR, SQLGetData(stmt, 1, SQL_C_LONG, &val, 0, nullptr));
   // Invalid cursor state
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorState24000);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorState24000);
+#endif
 }
 
 TYPED_TEST(StatementTest, TestSQLExecDirectInvalidQuery) {
@@ -64,9 +70,9 @@ TYPED_TEST(StatementTest, TestSQLExecDirectInvalidQuery) {
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ASSERT_EQ(SQL_ERROR,
-            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
   // ODBC provides generic error code HY000 to all statement errors
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorStateHY000);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorStateHY000);
 }
 
 TYPED_TEST(StatementTest, TestSQLExecuteSimpleQuery) {
@@ -74,38 +80,47 @@ TYPED_TEST(StatementTest, TestSQLExecuteSimpleQuery) {
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLPrepare(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+            SQLPrepare(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecute(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecute(stmt));
 
   // Fetch data
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   SQLINTEGER val;
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 1, SQL_C_LONG, &val, 0, nullptr));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 1, SQL_C_LONG, &val, 0, nullptr));
 
   // Verify 1 is returned
   EXPECT_EQ(1, val);
 
-  ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_NO_DATA, SQLFetch(stmt));
 
-  ASSERT_EQ(SQL_ERROR, SQLGetData(this->stmt, 1, SQL_C_LONG, &val, 0, nullptr));
+#ifdef __APPLE__
+  // With iODBC we expect SQL_SUCCESS and the buffer unchanged in this situation.
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 1, SQL_C_LONG, &val, 0, nullptr));
+  EXPECT_EQ(1, val);
+#else
+  ASSERT_EQ(SQL_ERROR, SQLGetData(stmt, 1, SQL_C_LONG, &val, 0, nullptr));
   // Invalid cursor state
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorState24000);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorState24000);
+#endif
 }
 
 TYPED_TEST(StatementTest, TestSQLPrepareInvalidQuery) {
   std::wstring wsql = L"SELECT;";
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
-  ASSERT_EQ(SQL_ERROR,
-            SQLPrepare(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+  ASSERT_EQ(SQL_ERROR, SQLPrepare(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
   // ODBC provides generic error code HY000 to all statement errors
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorStateHY000);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorStateHY000);
 
-  ASSERT_EQ(SQL_ERROR, SQLExecute(this->stmt));
+  ASSERT_EQ(SQL_ERROR, SQLExecute(stmt));
   // Verify function sequence error state is returned
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorStateHY010);
+#ifdef __APPLE__
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorStateS1010);
+#else
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorStateHY010);
+#endif  // __APPLE__
 }
 
 TYPED_TEST(StatementTest, TestSQLExecDirectDataQuery) {
@@ -113,9 +128,9 @@ TYPED_TEST(StatementTest, TestSQLExecDirectDataQuery) {
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   // Numeric Types
 
@@ -125,88 +140,84 @@ TYPED_TEST(StatementTest, TestSQLExecDirectDataQuery) {
   SQLLEN ind;
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 1, SQL_C_STINYINT, &stiny_int_val, buf_len, &ind));
+            SQLGetData(stmt, 1, SQL_C_STINYINT, &stiny_int_val, buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<int8_t>::min(), stiny_int_val);
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 2, SQL_C_STINYINT, &stiny_int_val, buf_len, &ind));
+            SQLGetData(stmt, 2, SQL_C_STINYINT, &stiny_int_val, buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<int8_t>::max(), stiny_int_val);
 
   // Unsigned Tiny Int
   uint8_t utiny_int_val;
   buf_len = sizeof(utiny_int_val);
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 3, SQL_C_UTINYINT, &utiny_int_val, buf_len, &ind));
+            SQLGetData(stmt, 3, SQL_C_UTINYINT, &utiny_int_val, buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<uint8_t>::min(), utiny_int_val);
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 4, SQL_C_UTINYINT, &utiny_int_val, buf_len, &ind));
+            SQLGetData(stmt, 4, SQL_C_UTINYINT, &utiny_int_val, buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<uint8_t>::max(), utiny_int_val);
 
   // Signed Small Int
   int16_t ssmall_int_val;
   buf_len = sizeof(ssmall_int_val);
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 5, SQL_C_SSHORT, &ssmall_int_val, buf_len, &ind));
+            SQLGetData(stmt, 5, SQL_C_SSHORT, &ssmall_int_val, buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<int16_t>::min(), ssmall_int_val);
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 6, SQL_C_SSHORT, &ssmall_int_val, buf_len, &ind));
+            SQLGetData(stmt, 6, SQL_C_SSHORT, &ssmall_int_val, buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<int16_t>::max(), ssmall_int_val);
 
   // Unsigned Small Int
   uint16_t usmall_int_val;
   buf_len = sizeof(usmall_int_val);
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 7, SQL_C_USHORT, &usmall_int_val, buf_len, &ind));
+            SQLGetData(stmt, 7, SQL_C_USHORT, &usmall_int_val, buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<uint16_t>::min(), usmall_int_val);
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 8, SQL_C_USHORT, &usmall_int_val, buf_len, &ind));
+            SQLGetData(stmt, 8, SQL_C_USHORT, &usmall_int_val, buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<uint16_t>::max(), usmall_int_val);
 
   // Signed Integer
   SQLINTEGER slong_val;
   buf_len = sizeof(slong_val);
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 9, SQL_C_SLONG, &slong_val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 9, SQL_C_SLONG, &slong_val, buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<SQLINTEGER>::min(), slong_val);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 10, SQL_C_SLONG, &slong_val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 10, SQL_C_SLONG, &slong_val, buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<SQLINTEGER>::max(), slong_val);
 
   // Unsigned Integer
   SQLUINTEGER ulong_val;
   buf_len = sizeof(ulong_val);
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 11, SQL_C_ULONG, &ulong_val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 11, SQL_C_ULONG, &ulong_val, buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<SQLUINTEGER>::min(), ulong_val);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 12, SQL_C_ULONG, &ulong_val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 12, SQL_C_ULONG, &ulong_val, buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<SQLUINTEGER>::max(), ulong_val);
 
   // Signed Big Int
   SQLBIGINT sbig_int_val;
   buf_len = sizeof(sbig_int_val);
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 13, SQL_C_SBIGINT, &sbig_int_val, buf_len, &ind));
+            SQLGetData(stmt, 13, SQL_C_SBIGINT, &sbig_int_val, buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<SQLBIGINT>::min(), sbig_int_val);
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 14, SQL_C_SBIGINT, &sbig_int_val, buf_len, &ind));
+            SQLGetData(stmt, 14, SQL_C_SBIGINT, &sbig_int_val, buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<SQLBIGINT>::max(), sbig_int_val);
 
   // Unsigned Big Int
   SQLUBIGINT ubig_int_val;
   buf_len = sizeof(ubig_int_val);
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 15, SQL_C_UBIGINT, &ubig_int_val, buf_len, &ind));
+            SQLGetData(stmt, 15, SQL_C_UBIGINT, &ubig_int_val, buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<SQLUBIGINT>::min(), ubig_int_val);
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 16, SQL_C_UBIGINT, &ubig_int_val, buf_len, &ind));
+            SQLGetData(stmt, 16, SQL_C_UBIGINT, &ubig_int_val, buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<SQLUBIGINT>::max(), ubig_int_val);
 
   // Decimal
@@ -214,7 +225,7 @@ TYPED_TEST(StatementTest, TestSQLExecDirectDataQuery) {
   memset(&decimal_val, 0, sizeof(decimal_val));
   buf_len = sizeof(SQL_NUMERIC_STRUCT);
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 17, SQL_C_NUMERIC, &decimal_val, buf_len, &ind));
+            SQLGetData(stmt, 17, SQL_C_NUMERIC, &decimal_val, buf_len, &ind));
   // Check for negative decimal_val value
   EXPECT_EQ(0, decimal_val.sign);
   EXPECT_EQ(0, decimal_val.scale);
@@ -224,7 +235,7 @@ TYPED_TEST(StatementTest, TestSQLExecDirectDataQuery) {
 
   memset(&decimal_val, 0, sizeof(decimal_val));
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 18, SQL_C_NUMERIC, &decimal_val, buf_len, &ind));
+            SQLGetData(stmt, 18, SQL_C_NUMERIC, &decimal_val, buf_len, &ind));
   // Check for positive decimal_val value
   EXPECT_EQ(1, decimal_val.sign);
   EXPECT_EQ(0, decimal_val.scale);
@@ -235,34 +246,30 @@ TYPED_TEST(StatementTest, TestSQLExecDirectDataQuery) {
   // Float
   float float_val;
   buf_len = sizeof(float_val);
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 19, SQL_C_FLOAT, &float_val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 19, SQL_C_FLOAT, &float_val, buf_len, &ind));
   // Get minimum negative float value
   EXPECT_EQ(-std::numeric_limits<float>::max(), float_val);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 20, SQL_C_FLOAT, &float_val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 20, SQL_C_FLOAT, &float_val, buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<float>::max(), float_val);
 
   // Double
   SQLDOUBLE double_val;
   buf_len = sizeof(double_val);
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 21, SQL_C_DOUBLE, &double_val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 21, SQL_C_DOUBLE, &double_val, buf_len, &ind));
   // Get minimum negative double value
   EXPECT_EQ(-std::numeric_limits<SQLDOUBLE>::max(), double_val);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 22, SQL_C_DOUBLE, &double_val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 22, SQL_C_DOUBLE, &double_val, buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<SQLDOUBLE>::max(), double_val);
 
   // Bit
   bool bit_val;
   buf_len = sizeof(bit_val);
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 23, SQL_C_BIT, &bit_val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 23, SQL_C_BIT, &bit_val, buf_len, &ind));
   EXPECT_EQ(false, bit_val);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 24, SQL_C_BIT, &bit_val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 24, SQL_C_BIT, &bit_val, buf_len, &ind));
   EXPECT_EQ(true, bit_val);
 
   // Characters
@@ -270,31 +277,27 @@ TYPED_TEST(StatementTest, TestSQLExecDirectDataQuery) {
   // Char
   SQLCHAR char_val[2];
   buf_len = sizeof(SQLCHAR) * 2;
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 25, SQL_C_CHAR, &char_val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 25, SQL_C_CHAR, &char_val, buf_len, &ind));
   EXPECT_EQ('Z', char_val[0]);
 
   // WChar
   SQLWCHAR wchar_val[2];
   size_t wchar_size = GetSqlWCharSize();
   buf_len = wchar_size * 2;
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 26, SQL_C_WCHAR, &wchar_val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 26, SQL_C_WCHAR, &wchar_val, buf_len, &ind));
   EXPECT_EQ(L'你', wchar_val[0]);
 
   // WVarchar
   SQLWCHAR wvarchar_val[3];
   buf_len = wchar_size * 3;
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 27, SQL_C_WCHAR, &wvarchar_val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 27, SQL_C_WCHAR, &wvarchar_val, buf_len, &ind));
   EXPECT_EQ(L'你', wvarchar_val[0]);
   EXPECT_EQ(L'好', wvarchar_val[1]);
 
   // varchar
   SQLCHAR varchar_val[4];
   buf_len = sizeof(SQLCHAR) * 4;
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 28, SQL_C_CHAR, &varchar_val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 28, SQL_C_CHAR, &varchar_val, buf_len, &ind));
   EXPECT_EQ('X', varchar_val[0]);
   EXPECT_EQ('Y', varchar_val[1]);
   EXPECT_EQ('Z', varchar_val[2]);
@@ -304,15 +307,13 @@ TYPED_TEST(StatementTest, TestSQLExecDirectDataQuery) {
   // Date
   SQL_DATE_STRUCT date_var{};
   buf_len = sizeof(date_var);
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 29, SQL_C_TYPE_DATE, &date_var, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 29, SQL_C_TYPE_DATE, &date_var, buf_len, &ind));
   // Check min values for date. Min valid year is 1400.
   EXPECT_EQ(1, date_var.day);
   EXPECT_EQ(1, date_var.month);
   EXPECT_EQ(1400, date_var.year);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 30, SQL_C_TYPE_DATE, &date_var, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 30, SQL_C_TYPE_DATE, &date_var, buf_len, &ind));
   // Check max values for date. Max valid year is 9999.
   EXPECT_EQ(31, date_var.day);
   EXPECT_EQ(12, date_var.month);
@@ -321,8 +322,8 @@ TYPED_TEST(StatementTest, TestSQLExecDirectDataQuery) {
   // Timestamp
   SQL_TIMESTAMP_STRUCT timestamp_var{};
   buf_len = sizeof(timestamp_var);
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 31, SQL_C_TYPE_TIMESTAMP, &timestamp_var,
-                                    buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetData(stmt, 31, SQL_C_TYPE_TIMESTAMP, &timestamp_var, buf_len, &ind));
   // Check min values for date. Min valid year is 1400.
   EXPECT_EQ(1, timestamp_var.day);
   EXPECT_EQ(1, timestamp_var.month);
@@ -332,8 +333,8 @@ TYPED_TEST(StatementTest, TestSQLExecDirectDataQuery) {
   EXPECT_EQ(0, timestamp_var.second);
   EXPECT_EQ(0, timestamp_var.fraction);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 32, SQL_C_TYPE_TIMESTAMP, &timestamp_var,
-                                    buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetData(stmt, 32, SQL_C_TYPE_TIMESTAMP, &timestamp_var, buf_len, &ind));
   // Check max values for date. Max valid year is 9999.
   EXPECT_EQ(31, timestamp_var.day);
   EXPECT_EQ(12, timestamp_var.month);
@@ -356,23 +357,21 @@ TEST_F(StatementRemoteTest, TestSQLExecDirectTimeQuery) {
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   SQL_TIME_STRUCT time_var{};
   SQLLEN buf_len = sizeof(time_var);
   SQLLEN ind;
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 1, SQL_C_TYPE_TIME, &time_var, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 1, SQL_C_TYPE_TIME, &time_var, buf_len, &ind));
   // Check min values for time.
   EXPECT_EQ(0, time_var.hour);
   EXPECT_EQ(0, time_var.minute);
   EXPECT_EQ(0, time_var.second);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 2, SQL_C_TYPE_TIME, &time_var, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 2, SQL_C_TYPE_TIME, &time_var, buf_len, &ind));
   // Check max values for time.
   EXPECT_EQ(23, time_var.hour);
   EXPECT_EQ(59, time_var.minute);
@@ -387,16 +386,16 @@ TEST_F(StatementMockTest, TestSQLExecDirectVarbinaryQuery) {
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   // varbinary
   std::vector<int8_t> varbinary_val(3);
   SQLLEN buf_len = varbinary_val.size();
   SQLLEN ind;
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 1, SQL_C_BINARY, &varbinary_val[0], buf_len, &ind));
+            SQLGetData(stmt, 1, SQL_C_BINARY, &varbinary_val[0], buf_len, &ind));
   EXPECT_EQ('\xAB', varbinary_val[0]);
   EXPECT_EQ('\xCD', varbinary_val[1]);
   EXPECT_EQ('\xEF', varbinary_val[2]);
@@ -411,9 +410,9 @@ TEST_F(StatementRemoteTest, TestSQLExecDirectDataQueryDefaultType) {
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   // Numeric Types
   // Signed Integer
@@ -421,12 +420,10 @@ TEST_F(StatementRemoteTest, TestSQLExecDirectDataQueryDefaultType) {
   SQLLEN buf_len = sizeof(slong_val);
   SQLLEN ind;
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 9, SQL_C_DEFAULT, &slong_val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 9, SQL_C_DEFAULT, &slong_val, buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<SQLINTEGER>::min(), slong_val);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 10, SQL_C_DEFAULT, &slong_val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 10, SQL_C_DEFAULT, &slong_val, buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<SQLINTEGER>::max(), slong_val);
 
   // Signed Big Int
@@ -434,11 +431,11 @@ TEST_F(StatementRemoteTest, TestSQLExecDirectDataQueryDefaultType) {
   buf_len = sizeof(sbig_int_val);
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 13, SQL_C_DEFAULT, &sbig_int_val, buf_len, &ind));
+            SQLGetData(stmt, 13, SQL_C_DEFAULT, &sbig_int_val, buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<SQLBIGINT>::min(), sbig_int_val);
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 14, SQL_C_DEFAULT, &sbig_int_val, buf_len, &ind));
+            SQLGetData(stmt, 14, SQL_C_DEFAULT, &sbig_int_val, buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<SQLBIGINT>::max(), sbig_int_val);
 
   // Decimal
@@ -447,7 +444,7 @@ TEST_F(StatementRemoteTest, TestSQLExecDirectDataQueryDefaultType) {
   buf_len = sizeof(SQL_NUMERIC_STRUCT);
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 17, SQL_C_DEFAULT, &decimal_val, buf_len, &ind));
+            SQLGetData(stmt, 17, SQL_C_DEFAULT, &decimal_val, buf_len, &ind));
   // Check for negative decimal_val value
   EXPECT_EQ(0, decimal_val.sign);
   EXPECT_EQ(0, decimal_val.scale);
@@ -457,7 +454,7 @@ TEST_F(StatementRemoteTest, TestSQLExecDirectDataQueryDefaultType) {
 
   memset(&decimal_val, 0, sizeof(decimal_val));
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 18, SQL_C_DEFAULT, &decimal_val, buf_len, &ind));
+            SQLGetData(stmt, 18, SQL_C_DEFAULT, &decimal_val, buf_len, &ind));
   // Check for positive decimal_val value
   EXPECT_EQ(1, decimal_val.sign);
   EXPECT_EQ(0, decimal_val.scale);
@@ -469,38 +466,32 @@ TEST_F(StatementRemoteTest, TestSQLExecDirectDataQueryDefaultType) {
   float float_val;
   buf_len = sizeof(float_val);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 19, SQL_C_DEFAULT, &float_val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 19, SQL_C_DEFAULT, &float_val, buf_len, &ind));
   // Get minimum negative float value
   EXPECT_EQ(-std::numeric_limits<float>::max(), float_val);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 20, SQL_C_DEFAULT, &float_val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 20, SQL_C_DEFAULT, &float_val, buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<float>::max(), float_val);
 
   // Double
   SQLDOUBLE double_val;
   buf_len = sizeof(double_val);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 21, SQL_C_DEFAULT, &double_val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 21, SQL_C_DEFAULT, &double_val, buf_len, &ind));
   // Get minimum negative double value
   EXPECT_EQ(-std::numeric_limits<SQLDOUBLE>::max(), double_val);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 22, SQL_C_DEFAULT, &double_val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 22, SQL_C_DEFAULT, &double_val, buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<SQLDOUBLE>::max(), double_val);
 
   // Bit
   bool bit_val;
   buf_len = sizeof(bit_val);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 23, SQL_C_DEFAULT, &bit_val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 23, SQL_C_DEFAULT, &bit_val, buf_len, &ind));
   EXPECT_EQ(false, bit_val);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 24, SQL_C_DEFAULT, &bit_val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 24, SQL_C_DEFAULT, &bit_val, buf_len, &ind));
   EXPECT_EQ(true, bit_val);
 
   // Characters
@@ -510,15 +501,13 @@ TEST_F(StatementRemoteTest, TestSQLExecDirectDataQueryDefaultType) {
   size_t wchar_size = GetSqlWCharSize();
   buf_len = wchar_size * 2;
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 25, SQL_C_DEFAULT, &wchar_val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 25, SQL_C_DEFAULT, &wchar_val, buf_len, &ind));
   EXPECT_EQ(L'Z', wchar_val[0]);
 
   // WChar
   SQLWCHAR wchar_val2[2];
   buf_len = wchar_size * 2;
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 26, SQL_C_DEFAULT, &wchar_val2, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 26, SQL_C_DEFAULT, &wchar_val2, buf_len, &ind));
   EXPECT_EQ(L'你', wchar_val2[0]);
 
   // WVarchar
@@ -526,7 +515,7 @@ TEST_F(StatementRemoteTest, TestSQLExecDirectDataQueryDefaultType) {
   buf_len = wchar_size * 3;
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 27, SQL_C_DEFAULT, &wvarchar_val, buf_len, &ind));
+            SQLGetData(stmt, 27, SQL_C_DEFAULT, &wvarchar_val, buf_len, &ind));
   EXPECT_EQ(L'你', wvarchar_val[0]);
   EXPECT_EQ(L'好', wvarchar_val[1]);
 
@@ -535,7 +524,7 @@ TEST_F(StatementRemoteTest, TestSQLExecDirectDataQueryDefaultType) {
   buf_len = wchar_size * 4;
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 28, SQL_C_DEFAULT, &wvarchar_val2, buf_len, &ind));
+            SQLGetData(stmt, 28, SQL_C_DEFAULT, &wvarchar_val2, buf_len, &ind));
   EXPECT_EQ(L'X', wvarchar_val2[0]);
   EXPECT_EQ(L'Y', wvarchar_val2[1]);
   EXPECT_EQ(L'Z', wvarchar_val2[2]);
@@ -546,15 +535,13 @@ TEST_F(StatementRemoteTest, TestSQLExecDirectDataQueryDefaultType) {
   SQL_DATE_STRUCT date_var{};
   buf_len = sizeof(date_var);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 29, SQL_C_DEFAULT, &date_var, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 29, SQL_C_DEFAULT, &date_var, buf_len, &ind));
   // Check min values for date. Min valid year is 1400.
   EXPECT_EQ(1, date_var.day);
   EXPECT_EQ(1, date_var.month);
   EXPECT_EQ(1400, date_var.year);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 30, SQL_C_DEFAULT, &date_var, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 30, SQL_C_DEFAULT, &date_var, buf_len, &ind));
   // Check max values for date. Max valid year is 9999.
   EXPECT_EQ(31, date_var.day);
   EXPECT_EQ(12, date_var.month);
@@ -565,7 +552,7 @@ TEST_F(StatementRemoteTest, TestSQLExecDirectDataQueryDefaultType) {
   buf_len = sizeof(timestamp_var);
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 31, SQL_C_DEFAULT, &timestamp_var, buf_len, &ind));
+            SQLGetData(stmt, 31, SQL_C_DEFAULT, &timestamp_var, buf_len, &ind));
   // Check min values for date. Min valid year is 1400.
   EXPECT_EQ(1, timestamp_var.day);
   EXPECT_EQ(1, timestamp_var.month);
@@ -576,7 +563,7 @@ TEST_F(StatementRemoteTest, TestSQLExecDirectDataQueryDefaultType) {
   EXPECT_EQ(0, timestamp_var.fraction);
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 32, SQL_C_DEFAULT, &timestamp_var, buf_len, &ind));
+            SQLGetData(stmt, 32, SQL_C_DEFAULT, &timestamp_var, buf_len, &ind));
   // Check max values for date. Max valid year is 9999.
   EXPECT_EQ(31, timestamp_var.day);
   EXPECT_EQ(12, timestamp_var.month);
@@ -599,23 +586,21 @@ TEST_F(StatementRemoteTest, TestSQLExecDirectTimeQueryDefaultType) {
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   SQL_TIME_STRUCT time_var{};
   SQLLEN buf_len = sizeof(time_var);
   SQLLEN ind;
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 1, SQL_C_DEFAULT, &time_var, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 1, SQL_C_DEFAULT, &time_var, buf_len, &ind));
   // Check min values for time.
   EXPECT_EQ(0, time_var.hour);
   EXPECT_EQ(0, time_var.minute);
   EXPECT_EQ(0, time_var.second);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 2, SQL_C_DEFAULT, &time_var, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 2, SQL_C_DEFAULT, &time_var, buf_len, &ind));
   // Check max values for time.
   EXPECT_EQ(23, time_var.hour);
   EXPECT_EQ(59, time_var.minute);
@@ -631,16 +616,16 @@ TEST_F(StatementRemoteTest, TestSQLExecDirectVarbinaryQueryDefaultType) {
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   // varbinary
   std::vector<int8_t> varbinary_val(3);
   SQLLEN buf_len = varbinary_val.size();
   SQLLEN ind;
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 1, SQL_C_DEFAULT, &varbinary_val[0], buf_len, &ind));
+            SQLGetData(stmt, 1, SQL_C_DEFAULT, &varbinary_val[0], buf_len, &ind));
   EXPECT_EQ('\xAB', varbinary_val[0]);
   EXPECT_EQ('\xCD', varbinary_val[1]);
   EXPECT_EQ('\xEF', varbinary_val[2]);
@@ -653,16 +638,15 @@ TYPED_TEST(StatementTest, DISABLED_TestGetDataPrecisionScaleUsesIRDAsDefault) {
   std::vector<SQLWCHAR> sql(wsql.begin(), wsql.end());
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(this->stmt, &sql[0], static_cast<SQLINTEGER>(sql.size())));
+            SQLExecDirect(stmt, &sql[0], static_cast<SQLINTEGER>(sql.size())));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   // Get precision and scale from IRD
   SQLLEN ird_precision = 0;
   SQLLEN ird_scale = 0;
   SQLHDESC ird = nullptr;
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetStmtAttr(this->stmt, SQL_ATTR_IMP_ROW_DESC, &ird, 0, nullptr));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetStmtAttr(stmt, SQL_ATTR_IMP_ROW_DESC, &ird, 0, nullptr));
   ASSERT_EQ(SQL_SUCCESS,
             SQLGetDescField(ird, 1, SQL_DESC_PRECISION, &ird_precision, 0, nullptr));
   ASSERT_EQ(SQL_SUCCESS, SQLGetDescField(ird, 1, SQL_DESC_SCALE, &ird_scale, 0, nullptr));
@@ -671,7 +655,7 @@ TYPED_TEST(StatementTest, DISABLED_TestGetDataPrecisionScaleUsesIRDAsDefault) {
   SQL_NUMERIC_STRUCT numeric_val;
   memset(&numeric_val, 0, sizeof(numeric_val));
   SQLLEN indicator;
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 1, SQL_C_NUMERIC, &numeric_val,
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 1, SQL_C_NUMERIC, &numeric_val,
                                     sizeof(SQL_NUMERIC_STRUCT), &indicator));
   EXPECT_EQ(static_cast<SQLSMALLINT>(ird_precision), numeric_val.precision);
   EXPECT_EQ(static_cast<SQLSMALLINT>(ird_scale), numeric_val.scale);
@@ -679,15 +663,14 @@ TYPED_TEST(StatementTest, DISABLED_TestGetDataPrecisionScaleUsesIRDAsDefault) {
   // Test with SQL_C_DEFAULT when ARD is unset (0) - should fall back to IRD
   // precision/scale
   SQLHDESC ard = nullptr;
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetStmtAttr(this->stmt, SQL_ATTR_APP_ROW_DESC, &ard, 0, nullptr));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetStmtAttr(stmt, SQL_ATTR_APP_ROW_DESC, &ard, 0, nullptr));
   ASSERT_EQ(SQL_SUCCESS, SQLSetDescField(ard, 1, SQL_DESC_PRECISION,
                                          reinterpret_cast<SQLPOINTER>(0), 0));
   ASSERT_EQ(SQL_SUCCESS,
             SQLSetDescField(ard, 1, SQL_DESC_SCALE, reinterpret_cast<SQLPOINTER>(0), 0));
 
   memset(&numeric_val, 0, sizeof(numeric_val));
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 1, SQL_C_DEFAULT, &numeric_val,
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 1, SQL_C_DEFAULT, &numeric_val,
                                     sizeof(SQL_NUMERIC_STRUCT), &indicator));
   EXPECT_EQ(static_cast<SQLSMALLINT>(ird_precision), numeric_val.precision);
   EXPECT_EQ(static_cast<SQLSMALLINT>(ird_scale), numeric_val.scale);
@@ -701,13 +684,12 @@ TYPED_TEST(StatementTest, DISABLED_TestGetDataPrecisionScaleUsesARDWhenSet) {
   std::vector<SQLWCHAR> sql(wsql.begin(), wsql.end());
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(this->stmt, &sql[0], static_cast<SQLINTEGER>(sql.size())));
+            SQLExecDirect(stmt, &sql[0], static_cast<SQLINTEGER>(sql.size())));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   SQLHDESC ard = nullptr;
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetStmtAttr(this->stmt, SQL_ATTR_APP_ROW_DESC, &ard, 0, nullptr));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetStmtAttr(stmt, SQL_ATTR_APP_ROW_DESC, &ard, 0, nullptr));
 
   // Test with SQL_ARD_TYPE
   SQLSMALLINT ard_precision = 15;
@@ -722,7 +704,7 @@ TYPED_TEST(StatementTest, DISABLED_TestGetDataPrecisionScaleUsesARDWhenSet) {
   SQL_NUMERIC_STRUCT numeric_val;
   memset(&numeric_val, 0, sizeof(numeric_val));
   SQLLEN indicator;
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 1, SQL_ARD_TYPE, &numeric_val,
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 1, SQL_ARD_TYPE, &numeric_val,
                                     sizeof(SQL_NUMERIC_STRUCT), &indicator));
   EXPECT_EQ(ard_precision, numeric_val.precision);
   EXPECT_EQ(ard_scale, numeric_val.scale);
@@ -736,7 +718,7 @@ TYPED_TEST(StatementTest, DISABLED_TestGetDataPrecisionScaleUsesARDWhenSet) {
                                          reinterpret_cast<SQLPOINTER>(ard_scale), 0));
 
   memset(&numeric_val, 0, sizeof(numeric_val));
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 1, SQL_C_DEFAULT, &numeric_val,
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 1, SQL_C_DEFAULT, &numeric_val,
                                     sizeof(SQL_NUMERIC_STRUCT), &indicator));
   EXPECT_EQ(ard_precision, numeric_val.precision);
   EXPECT_EQ(ard_scale, numeric_val.scale);
@@ -748,16 +730,16 @@ TYPED_TEST(StatementTest, TestSQLExecDirectGuidQueryUnsupported) {
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   SQLGUID guid_var;
   SQLLEN buf_len = sizeof(guid_var);
   SQLLEN ind;
-  ASSERT_EQ(SQL_ERROR, SQLGetData(this->stmt, 1, SQL_C_GUID, &guid_var, buf_len, &ind));
+  ASSERT_EQ(SQL_ERROR, SQLGetData(stmt, 1, SQL_C_GUID, &guid_var, buf_len, &ind));
   // GUID is not supported by ODBC
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorStateHY000);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorStateHY000);
 }
 
 TYPED_TEST(StatementTest, TestSQLExecDirectRowFetching) {
@@ -772,48 +754,53 @@ TYPED_TEST(StatementTest, TestSQLExecDirectRowFetching) {
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
 
   // Fetch row 1
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   SQLINTEGER val;
   SQLLEN buf_len = sizeof(val);
   SQLLEN ind;
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 1, SQL_C_LONG, &val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 1, SQL_C_LONG, &val, buf_len, &ind));
 
   // Verify 1 is returned
   EXPECT_EQ(1, val);
 
   // Fetch row 2
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 1, SQL_C_LONG, &val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 1, SQL_C_LONG, &val, buf_len, &ind));
 
   // Verify 2 is returned
   EXPECT_EQ(2, val);
 
   // Fetch row 3
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 1, SQL_C_LONG, &val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 1, SQL_C_LONG, &val, buf_len, &ind));
 
   // Verify 3 is returned
   EXPECT_EQ(3, val);
 
   // Verify result set has no more data beyond row 3
-  ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_NO_DATA, SQLFetch(stmt));
 
-  ASSERT_EQ(SQL_ERROR, SQLGetData(this->stmt, 1, SQL_C_LONG, &val, 0, &ind));
-
+#ifdef __APPLE__
+  // With iODBC we expect SQL_SUCCESS and the buffer unchanged in this situation.
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 1, SQL_C_LONG, &val, 0, nullptr));
+  EXPECT_EQ(3, val);
+#else
+  ASSERT_EQ(SQL_ERROR, SQLGetData(stmt, 1, SQL_C_LONG, &val, 0, &ind));
   // Invalid cursor state
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorState24000);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorState24000);
+#endif
 }
 
 TYPED_TEST(StatementTest, TestSQLFetchScrollRowFetching) {
   SQLLEN rows_fetched;
-  SQLSetStmtAttr(this->stmt, SQL_ATTR_ROWS_FETCHED_PTR, &rows_fetched, 0);
+  SQLSetStmtAttr(stmt, SQL_ATTR_ROWS_FETCHED_PTR, &rows_fetched, 0);
 
   std::wstring wsql =
       LR"(
@@ -826,25 +813,25 @@ TYPED_TEST(StatementTest, TestSQLFetchScrollRowFetching) {
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
 
   // Fetch row 1
-  ASSERT_EQ(SQL_SUCCESS, SQLFetchScroll(this->stmt, SQL_FETCH_NEXT, 0));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetchScroll(stmt, SQL_FETCH_NEXT, 0));
 
   SQLINTEGER val;
   SQLLEN buf_len = sizeof(val);
   SQLLEN ind;
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 1, SQL_C_LONG, &val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 1, SQL_C_LONG, &val, buf_len, &ind));
   // Verify 1 is returned
   EXPECT_EQ(1, val);
   // Verify 1 row is fetched
   EXPECT_EQ(1, rows_fetched);
 
   // Fetch row 2
-  ASSERT_EQ(SQL_SUCCESS, SQLFetchScroll(this->stmt, SQL_FETCH_NEXT, 0));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetchScroll(stmt, SQL_FETCH_NEXT, 0));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 1, SQL_C_LONG, &val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 1, SQL_C_LONG, &val, buf_len, &ind));
 
   // Verify 2 is returned
   EXPECT_EQ(2, val);
@@ -852,9 +839,9 @@ TYPED_TEST(StatementTest, TestSQLFetchScrollRowFetching) {
   EXPECT_EQ(1, rows_fetched);
 
   // Fetch row 3
-  ASSERT_EQ(SQL_SUCCESS, SQLFetchScroll(this->stmt, SQL_FETCH_NEXT, 0));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetchScroll(stmt, SQL_FETCH_NEXT, 0));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 1, SQL_C_LONG, &val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 1, SQL_C_LONG, &val, buf_len, &ind));
 
   // Verify 3 is returned
   EXPECT_EQ(3, val);
@@ -862,11 +849,17 @@ TYPED_TEST(StatementTest, TestSQLFetchScrollRowFetching) {
   EXPECT_EQ(1, rows_fetched);
 
   // Verify result set has no more data beyond row 3
-  ASSERT_EQ(SQL_NO_DATA, SQLFetchScroll(this->stmt, SQL_FETCH_NEXT, 0));
+  ASSERT_EQ(SQL_NO_DATA, SQLFetchScroll(stmt, SQL_FETCH_NEXT, 0));
 
-  ASSERT_EQ(SQL_ERROR, SQLGetData(this->stmt, 1, SQL_C_LONG, &val, 0, &ind));
+#ifdef __APPLE__
+  // With iODBC we expect SQL_SUCCESS and the buffer unchanged in this situation.
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 1, SQL_C_LONG, &val, 0, nullptr));
+  EXPECT_EQ(3, val);
+#else
+  ASSERT_EQ(SQL_ERROR, SQLGetData(stmt, 1, SQL_C_LONG, &val, 0, &ind));
   // Invalid cursor state
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorState24000);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorState24000);
+#endif
 }
 
 TYPED_TEST(StatementTest, TestSQLFetchScrollUnsupportedOrientation) {
@@ -876,33 +869,37 @@ TYPED_TEST(StatementTest, TestSQLFetchScrollUnsupportedOrientation) {
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
 
-  ASSERT_EQ(SQL_ERROR, SQLFetchScroll(this->stmt, SQL_FETCH_PRIOR, 0));
+  ASSERT_EQ(SQL_ERROR, SQLFetchScroll(stmt, SQL_FETCH_PRIOR, 0));
 
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorStateHYC00);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorStateHYC00);
 
   SQLLEN fetch_offset = 1;
-  ASSERT_EQ(SQL_ERROR, SQLFetchScroll(this->stmt, SQL_FETCH_RELATIVE, fetch_offset));
+  ASSERT_EQ(SQL_ERROR, SQLFetchScroll(stmt, SQL_FETCH_RELATIVE, fetch_offset));
 
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorStateHYC00);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorStateHYC00);
 
-  ASSERT_EQ(SQL_ERROR, SQLFetchScroll(this->stmt, SQL_FETCH_ABSOLUTE, fetch_offset));
+  ASSERT_EQ(SQL_ERROR, SQLFetchScroll(stmt, SQL_FETCH_ABSOLUTE, fetch_offset));
 
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorStateHYC00);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorStateHYC00);
 
-  ASSERT_EQ(SQL_ERROR, SQLFetchScroll(this->stmt, SQL_FETCH_FIRST, 0));
+  ASSERT_EQ(SQL_ERROR, SQLFetchScroll(stmt, SQL_FETCH_FIRST, 0));
 
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorStateHYC00);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorStateHYC00);
 
-  ASSERT_EQ(SQL_ERROR, SQLFetchScroll(this->stmt, SQL_FETCH_LAST, 0));
+  ASSERT_EQ(SQL_ERROR, SQLFetchScroll(stmt, SQL_FETCH_LAST, 0));
 
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorStateHYC00);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorStateHYC00);
 
-  ASSERT_EQ(SQL_ERROR, SQLFetchScroll(this->stmt, SQL_FETCH_BOOKMARK, fetch_offset));
+  ASSERT_EQ(SQL_ERROR, SQLFetchScroll(stmt, SQL_FETCH_BOOKMARK, fetch_offset));
 
-  // DM returns state HY106 for SQL_FETCH_BOOKMARK
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorStateHY106);
+#ifdef __APPLE__
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorStateHYC00);
+#else
+  // Windows DM returns state HY106 for SQL_FETCH_BOOKMARK
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorStateHY106);
+#endif  // __APPLE__
 }
 
 TYPED_TEST(StatementTest, TestSQLExecDirectVarcharTruncation) {
@@ -910,18 +907,18 @@ TYPED_TEST(StatementTest, TestSQLExecDirectVarcharTruncation) {
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   const int len = 17;
   SQLCHAR char_val[len];
   SQLLEN buf_len = sizeof(SQLCHAR) * len;
   SQLLEN ind;
   ASSERT_EQ(SQL_SUCCESS_WITH_INFO,
-            SQLGetData(this->stmt, 1, SQL_C_CHAR, &char_val, buf_len, &ind));
+            SQLGetData(stmt, 1, SQL_C_CHAR, &char_val, buf_len, &ind));
   // Verify string truncation is reported
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorState01004);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorState01004);
 
   EXPECT_EQ(std::string("VERY LONG STRING"), ODBC::SqlStringToString(char_val));
   EXPECT_EQ(21, ind);
@@ -931,9 +928,9 @@ TYPED_TEST(StatementTest, TestSQLExecDirectVarcharTruncation) {
   SQLCHAR char_val2[len2];
   buf_len = sizeof(SQLCHAR) * len2;
   ASSERT_EQ(SQL_SUCCESS_WITH_INFO,
-            SQLGetData(this->stmt, 1, SQL_C_CHAR, &char_val2, buf_len, &ind));
+            SQLGetData(stmt, 1, SQL_C_CHAR, &char_val2, buf_len, &ind));
   // Verify string truncation is reported
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorState01004);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorState01004);
 
   EXPECT_EQ(std::string(" "), ODBC::SqlStringToString(char_val2));
   EXPECT_EQ(5, ind);
@@ -944,8 +941,7 @@ TYPED_TEST(StatementTest, TestSQLExecDirectVarcharTruncation) {
   buf_len = sizeof(SQLCHAR) * len3;
 
   // Verify that there is no more truncation reports. The full string has been fetched.
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 1, SQL_C_CHAR, &char_val3, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 1, SQL_C_CHAR, &char_val3, buf_len, &ind));
 
   EXPECT_EQ(std::string("here"), ODBC::SqlStringToString(char_val3));
   EXPECT_EQ(4, ind);
@@ -953,7 +949,7 @@ TYPED_TEST(StatementTest, TestSQLExecDirectVarcharTruncation) {
   // Attempt to fetch data 4th time
   SQLCHAR char_val4[len];
   // Verify SQL_NO_DATA is returned
-  ASSERT_EQ(SQL_NO_DATA, SQLGetData(this->stmt, 1, SQL_C_CHAR, &char_val4, 0, &ind));
+  ASSERT_EQ(SQL_NO_DATA, SQLGetData(stmt, 1, SQL_C_CHAR, &char_val4, 0, &ind));
 }
 
 TYPED_TEST(StatementTest, TestSQLExecDirectWVarcharTruncation) {
@@ -961,9 +957,9 @@ TYPED_TEST(StatementTest, TestSQLExecDirectWVarcharTruncation) {
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   const int len = 28;
   SQLWCHAR wchar_val[len];
@@ -971,9 +967,9 @@ TYPED_TEST(StatementTest, TestSQLExecDirectWVarcharTruncation) {
   SQLLEN buf_len = wchar_size * len;
   SQLLEN ind;
   ASSERT_EQ(SQL_SUCCESS_WITH_INFO,
-            SQLGetData(this->stmt, 1, SQL_C_WCHAR, &wchar_val, buf_len, &ind));
+            SQLGetData(stmt, 1, SQL_C_WCHAR, &wchar_val, buf_len, &ind));
   // Verify string truncation is reported
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorState01004);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorState01004);
 
   EXPECT_EQ(std::wstring(L"VERY LONG Unicode STRING 句子"), std::wstring(wchar_val));
   EXPECT_EQ(32 * wchar_size, ind);
@@ -983,9 +979,9 @@ TYPED_TEST(StatementTest, TestSQLExecDirectWVarcharTruncation) {
   SQLWCHAR wchar_val2[len2];
   buf_len = wchar_size * len2;
   ASSERT_EQ(SQL_SUCCESS_WITH_INFO,
-            SQLGetData(this->stmt, 1, SQL_C_WCHAR, &wchar_val2, buf_len, &ind));
+            SQLGetData(stmt, 1, SQL_C_WCHAR, &wchar_val2, buf_len, &ind));
   // Verify string truncation is reported
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorState01004);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorState01004);
 
   EXPECT_EQ(std::wstring(L" "), std::wstring(wchar_val2));
   EXPECT_EQ(5 * wchar_size, ind);
@@ -996,8 +992,7 @@ TYPED_TEST(StatementTest, TestSQLExecDirectWVarcharTruncation) {
   buf_len = wchar_size * len3;
 
   // Verify that there is no more truncation reports. The full string has been fetched.
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 1, SQL_C_WCHAR, &wchar_val3, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 1, SQL_C_WCHAR, &wchar_val3, buf_len, &ind));
 
   EXPECT_EQ(std::wstring(L"here"), std::wstring(wchar_val3));
   EXPECT_EQ(4 * wchar_size, ind);
@@ -1005,7 +1000,7 @@ TYPED_TEST(StatementTest, TestSQLExecDirectWVarcharTruncation) {
   // Attempt to fetch data 4th time
   SQLWCHAR wchar_val4[len];
   // Verify SQL_NO_DATA is returned
-  ASSERT_EQ(SQL_NO_DATA, SQLGetData(this->stmt, 1, SQL_C_WCHAR, &wchar_val4, 0, &ind));
+  ASSERT_EQ(SQL_NO_DATA, SQLGetData(stmt, 1, SQL_C_WCHAR, &wchar_val4, 0, &ind));
 }
 
 TEST_F(StatementMockTest, TestSQLExecDirectVarbinaryTruncation) {
@@ -1016,18 +1011,18 @@ TEST_F(StatementMockTest, TestSQLExecDirectVarbinaryTruncation) {
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   // varbinary
   std::vector<int8_t> varbinary_val(3);
   SQLLEN buf_len = varbinary_val.size();
   SQLLEN ind;
   ASSERT_EQ(SQL_SUCCESS_WITH_INFO,
-            SQLGetData(this->stmt, 1, SQL_C_BINARY, &varbinary_val[0], buf_len, &ind));
+            SQLGetData(stmt, 1, SQL_C_BINARY, &varbinary_val[0], buf_len, &ind));
   // Verify binary truncation is reported
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorState01004);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorState01004);
   EXPECT_EQ('\xAB', varbinary_val[0]);
   EXPECT_EQ('\xCD', varbinary_val[1]);
   EXPECT_EQ('\xEF', varbinary_val[2]);
@@ -1039,7 +1034,7 @@ TEST_F(StatementMockTest, TestSQLExecDirectVarbinaryTruncation) {
 
   // Verify that there is no more truncation reports. The full binary has been fetched.
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 1, SQL_C_BINARY, &varbinary_val2[0], buf_len, &ind));
+            SQLGetData(stmt, 1, SQL_C_BINARY, &varbinary_val2[0], buf_len, &ind));
 
   EXPECT_EQ('\xAB', varbinary_val[0]);
   EXPECT_EQ(1, ind);
@@ -1049,7 +1044,7 @@ TEST_F(StatementMockTest, TestSQLExecDirectVarbinaryTruncation) {
   buf_len = varbinary_val3.size();
   // Verify SQL_NO_DATA is returned
   ASSERT_EQ(SQL_NO_DATA,
-            SQLGetData(this->stmt, 1, SQL_C_BINARY, &varbinary_val3[0], buf_len, &ind));
+            SQLGetData(stmt, 1, SQL_C_BINARY, &varbinary_val3[0], buf_len, &ind));
 }
 
 TYPED_TEST(StatementTest, DISABLED_TestSQLExecDirectFloatTruncation) {
@@ -1064,16 +1059,16 @@ TYPED_TEST(StatementTest, DISABLED_TestSQLExecDirectFloatTruncation) {
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   int16_t ssmall_int_val;
 
   ASSERT_EQ(SQL_SUCCESS_WITH_INFO,
-            SQLGetData(this->stmt, 1, SQL_C_SSHORT, &ssmall_int_val, 0, nullptr));
+            SQLGetData(stmt, 1, SQL_C_SSHORT, &ssmall_int_val, 0, nullptr));
   // Verify float truncation is reported
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorState01S07);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorState01S07);
 
   EXPECT_EQ(1, ssmall_int_val);
 }
@@ -1086,14 +1081,14 @@ TEST_F(StatementRemoteTest, TestSQLExecDirectNullQuery) {
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   SQLINTEGER val;
   SQLLEN ind;
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 1, SQL_C_LONG, &val, 0, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 1, SQL_C_LONG, &val, 0, &ind));
 
   // Verify SQL_NULL_DATA is returned for indicator
   EXPECT_EQ(SQL_NULL_DATA, ind);
@@ -1114,12 +1109,12 @@ TEST_F(StatementMockTest, TestSQLExecDirectTruncationQueryNullIndicator) {
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   SQLINTEGER val;
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 1, SQL_C_LONG, &val, 0, nullptr));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 1, SQL_C_LONG, &val, 0, nullptr));
   // Verify 1 is returned for non-truncation case.
   EXPECT_EQ(1, val);
 
@@ -1128,9 +1123,9 @@ TEST_F(StatementMockTest, TestSQLExecDirectTruncationQueryNullIndicator) {
   SQLCHAR char_val[len];
   SQLLEN buf_len = sizeof(SQLCHAR) * len;
   ASSERT_EQ(SQL_SUCCESS_WITH_INFO,
-            SQLGetData(this->stmt, 2, SQL_C_CHAR, &char_val, buf_len, nullptr));
+            SQLGetData(stmt, 2, SQL_C_CHAR, &char_val, buf_len, nullptr));
   // Verify string truncation is reported
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorState01004);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorState01004);
 
   // WChar
   const int len2 = 28;
@@ -1138,17 +1133,17 @@ TEST_F(StatementMockTest, TestSQLExecDirectTruncationQueryNullIndicator) {
   size_t wchar_size = GetSqlWCharSize();
   buf_len = wchar_size * len2;
   ASSERT_EQ(SQL_SUCCESS_WITH_INFO,
-            SQLGetData(this->stmt, 3, SQL_C_WCHAR, &wchar_val, buf_len, nullptr));
+            SQLGetData(stmt, 3, SQL_C_WCHAR, &wchar_val, buf_len, nullptr));
   // Verify string truncation is reported
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorState01004);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorState01004);
 
   // varbinary
   std::vector<int8_t> varbinary_val(3);
   buf_len = varbinary_val.size();
   ASSERT_EQ(SQL_SUCCESS_WITH_INFO,
-            SQLGetData(this->stmt, 4, SQL_C_BINARY, &varbinary_val[0], buf_len, nullptr));
+            SQLGetData(stmt, 4, SQL_C_BINARY, &varbinary_val[0], buf_len, nullptr));
   // Verify binary truncation is reported
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorState01004);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorState01004);
 }
 
 TEST_F(StatementRemoteTest, TestSQLExecDirectNullQueryNullIndicator) {
@@ -1159,17 +1154,20 @@ TEST_F(StatementRemoteTest, TestSQLExecDirectNullQueryNullIndicator) {
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   SQLINTEGER val;
 
-  ASSERT_EQ(SQL_ERROR, SQLGetData(this->stmt, 1, SQL_C_LONG, &val, 0, nullptr));
+  ASSERT_EQ(SQL_ERROR, SQLGetData(stmt, 1, SQL_C_LONG, &val, 0, nullptr));
   // Verify invalid null indicator is reported, as it is required
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorState22002);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorState22002);
 }
 
+// MacOS Driver Manager iODBC returns SQL_ERROR when invalid buffer length is provided to
+// SQLGetData
+#ifndef __APPLE__
 TYPED_TEST(StatementTest, TestSQLExecDirectIgnoreInvalidBufLen) {
   // Verify the driver ignores invalid buffer length for fixed data types
 
@@ -1177,9 +1175,9 @@ TYPED_TEST(StatementTest, TestSQLExecDirectIgnoreInvalidBufLen) {
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   // Numeric Types
 
@@ -1188,91 +1186,91 @@ TYPED_TEST(StatementTest, TestSQLExecDirectIgnoreInvalidBufLen) {
   SQLLEN invalid_buf_len = -1;
   SQLLEN ind;
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 1, SQL_C_STINYINT, &stiny_int_val,
-                                    invalid_buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetData(stmt, 1, SQL_C_STINYINT, &stiny_int_val, invalid_buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<int8_t>::min(), stiny_int_val);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 2, SQL_C_STINYINT, &stiny_int_val,
-                                    invalid_buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetData(stmt, 2, SQL_C_STINYINT, &stiny_int_val, invalid_buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<int8_t>::max(), stiny_int_val);
 
   // Unsigned Tiny Int
   uint8_t utiny_int_val;
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 3, SQL_C_UTINYINT, &utiny_int_val,
-                                    invalid_buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetData(stmt, 3, SQL_C_UTINYINT, &utiny_int_val, invalid_buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<uint8_t>::min(), utiny_int_val);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 4, SQL_C_UTINYINT, &utiny_int_val,
-                                    invalid_buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetData(stmt, 4, SQL_C_UTINYINT, &utiny_int_val, invalid_buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<uint8_t>::max(), utiny_int_val);
 
   // Signed Small Int
   int16_t ssmall_int_val;
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 5, SQL_C_SSHORT, &ssmall_int_val,
-                                    invalid_buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetData(stmt, 5, SQL_C_SSHORT, &ssmall_int_val, invalid_buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<int16_t>::min(), ssmall_int_val);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 6, SQL_C_SSHORT, &ssmall_int_val,
-                                    invalid_buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetData(stmt, 6, SQL_C_SSHORT, &ssmall_int_val, invalid_buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<int16_t>::max(), ssmall_int_val);
 
   // Unsigned Small Int
   uint16_t usmall_int_val;
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 7, SQL_C_USHORT, &usmall_int_val,
-                                    invalid_buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetData(stmt, 7, SQL_C_USHORT, &usmall_int_val, invalid_buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<uint16_t>::min(), usmall_int_val);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 8, SQL_C_USHORT, &usmall_int_val,
-                                    invalid_buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetData(stmt, 8, SQL_C_USHORT, &usmall_int_val, invalid_buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<uint16_t>::max(), usmall_int_val);
 
   // Signed Integer
   SQLINTEGER slong_val;
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 9, SQL_C_SLONG, &slong_val, invalid_buf_len, &ind));
+            SQLGetData(stmt, 9, SQL_C_SLONG, &slong_val, invalid_buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<SQLINTEGER>::min(), slong_val);
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 10, SQL_C_SLONG, &slong_val, invalid_buf_len, &ind));
+            SQLGetData(stmt, 10, SQL_C_SLONG, &slong_val, invalid_buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<SQLINTEGER>::max(), slong_val);
 
   // Unsigned Integer
   SQLUINTEGER ulong_val;
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 11, SQL_C_ULONG, &ulong_val, invalid_buf_len, &ind));
+            SQLGetData(stmt, 11, SQL_C_ULONG, &ulong_val, invalid_buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<SQLUINTEGER>::min(), ulong_val);
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 12, SQL_C_ULONG, &ulong_val, invalid_buf_len, &ind));
+            SQLGetData(stmt, 12, SQL_C_ULONG, &ulong_val, invalid_buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<SQLUINTEGER>::max(), ulong_val);
 
   // Signed Big Int
   SQLBIGINT sbig_int_val;
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 13, SQL_C_SBIGINT, &sbig_int_val,
-                                    invalid_buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetData(stmt, 13, SQL_C_SBIGINT, &sbig_int_val, invalid_buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<SQLBIGINT>::min(), sbig_int_val);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 14, SQL_C_SBIGINT, &sbig_int_val,
-                                    invalid_buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetData(stmt, 14, SQL_C_SBIGINT, &sbig_int_val, invalid_buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<SQLBIGINT>::max(), sbig_int_val);
 
   // Unsigned Big Int
   SQLUBIGINT ubig_int_val;
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 15, SQL_C_UBIGINT, &ubig_int_val,
-                                    invalid_buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetData(stmt, 15, SQL_C_UBIGINT, &ubig_int_val, invalid_buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<SQLUBIGINT>::min(), ubig_int_val);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 16, SQL_C_UBIGINT, &ubig_int_val,
-                                    invalid_buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetData(stmt, 16, SQL_C_UBIGINT, &ubig_int_val, invalid_buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<SQLUBIGINT>::max(), ubig_int_val);
 
   // Decimal
   SQL_NUMERIC_STRUCT decimal_val;
   memset(&decimal_val, 0, sizeof(decimal_val));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 17, SQL_C_NUMERIC, &decimal_val,
-                                    invalid_buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetData(stmt, 17, SQL_C_NUMERIC, &decimal_val, invalid_buf_len, &ind));
   // Check for negative decimal_val value
   EXPECT_EQ(0, decimal_val.sign);
   EXPECT_EQ(0, decimal_val.scale);
@@ -1282,8 +1280,8 @@ TYPED_TEST(StatementTest, TestSQLExecDirectIgnoreInvalidBufLen) {
 
   memset(&decimal_val, 0, sizeof(decimal_val));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 18, SQL_C_NUMERIC, &decimal_val,
-                                    invalid_buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetData(stmt, 18, SQL_C_NUMERIC, &decimal_val, invalid_buf_len, &ind));
   // Check for positive decimal_val value
   EXPECT_EQ(1, decimal_val.sign);
   EXPECT_EQ(0, decimal_val.scale);
@@ -1295,48 +1293,48 @@ TYPED_TEST(StatementTest, TestSQLExecDirectIgnoreInvalidBufLen) {
   float float_val;
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 19, SQL_C_FLOAT, &float_val, invalid_buf_len, &ind));
+            SQLGetData(stmt, 19, SQL_C_FLOAT, &float_val, invalid_buf_len, &ind));
   // Get minimum negative float value
   EXPECT_EQ(-std::numeric_limits<float>::max(), float_val);
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 20, SQL_C_FLOAT, &float_val, invalid_buf_len, &ind));
+            SQLGetData(stmt, 20, SQL_C_FLOAT, &float_val, invalid_buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<float>::max(), float_val);
 
   // Double
   SQLDOUBLE double_val;
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 21, SQL_C_DOUBLE, &double_val, invalid_buf_len, &ind));
+            SQLGetData(stmt, 21, SQL_C_DOUBLE, &double_val, invalid_buf_len, &ind));
   // Get minimum negative double value
   EXPECT_EQ(-std::numeric_limits<SQLDOUBLE>::max(), double_val);
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 22, SQL_C_DOUBLE, &double_val, invalid_buf_len, &ind));
+            SQLGetData(stmt, 22, SQL_C_DOUBLE, &double_val, invalid_buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<SQLDOUBLE>::max(), double_val);
 
   // Bit
   bool bit_val;
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 23, SQL_C_BIT, &bit_val, invalid_buf_len, &ind));
+            SQLGetData(stmt, 23, SQL_C_BIT, &bit_val, invalid_buf_len, &ind));
   EXPECT_EQ(false, bit_val);
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(this->stmt, 24, SQL_C_BIT, &bit_val, invalid_buf_len, &ind));
+            SQLGetData(stmt, 24, SQL_C_BIT, &bit_val, invalid_buf_len, &ind));
   EXPECT_EQ(true, bit_val);
 
   // Date and Timestamp
 
   // Date
   SQL_DATE_STRUCT date_var{};
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 29, SQL_C_TYPE_DATE, &date_var,
-                                    invalid_buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetData(stmt, 29, SQL_C_TYPE_DATE, &date_var, invalid_buf_len, &ind));
   // Check min values for date. Min valid year is 1400.
   EXPECT_EQ(1, date_var.day);
   EXPECT_EQ(1, date_var.month);
   EXPECT_EQ(1400, date_var.year);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 30, SQL_C_TYPE_DATE, &date_var,
-                                    invalid_buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetData(stmt, 30, SQL_C_TYPE_DATE, &date_var, invalid_buf_len, &ind));
   // Check max values for date. Max valid year is 9999.
   EXPECT_EQ(31, date_var.day);
   EXPECT_EQ(12, date_var.month);
@@ -1345,7 +1343,7 @@ TYPED_TEST(StatementTest, TestSQLExecDirectIgnoreInvalidBufLen) {
   // Timestamp
   SQL_TIMESTAMP_STRUCT timestamp_var{};
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 31, SQL_C_TYPE_TIMESTAMP, &timestamp_var,
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 31, SQL_C_TYPE_TIMESTAMP, &timestamp_var,
                                     invalid_buf_len, &ind));
   // Check min values for date. Min valid year is 1400.
   EXPECT_EQ(1, timestamp_var.day);
@@ -1356,7 +1354,7 @@ TYPED_TEST(StatementTest, TestSQLExecDirectIgnoreInvalidBufLen) {
   EXPECT_EQ(0, timestamp_var.second);
   EXPECT_EQ(0, timestamp_var.fraction);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 32, SQL_C_TYPE_TIMESTAMP, &timestamp_var,
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 32, SQL_C_TYPE_TIMESTAMP, &timestamp_var,
                                     invalid_buf_len, &ind));
   // Check max values for date. Max valid year is 9999.
   EXPECT_EQ(31, timestamp_var.day);
@@ -1367,6 +1365,7 @@ TYPED_TEST(StatementTest, TestSQLExecDirectIgnoreInvalidBufLen) {
   EXPECT_EQ(59, timestamp_var.second);
   EXPECT_EQ(0, timestamp_var.fraction);
 }
+#endif  // __APPLE__
 
 TYPED_TEST(StatementTest, TestSQLBindColDataQuery) {
   // Numeric Types
@@ -1378,80 +1377,79 @@ TYPED_TEST(StatementTest, TestSQLBindColDataQuery) {
   SQLLEN ind;
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(this->stmt, 1, SQL_C_STINYINT, &stiny_int_val_min, buf_len, &ind));
+            SQLBindCol(stmt, 1, SQL_C_STINYINT, &stiny_int_val_min, buf_len, &ind));
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(this->stmt, 2, SQL_C_STINYINT, &stiny_int_val_max, buf_len, &ind));
+            SQLBindCol(stmt, 2, SQL_C_STINYINT, &stiny_int_val_max, buf_len, &ind));
 
   // Unsigned Tiny Int
   uint8_t utiny_int_val_min;
   uint8_t utiny_int_val_max;
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(this->stmt, 3, SQL_C_UTINYINT, &utiny_int_val_min, buf_len, &ind));
+            SQLBindCol(stmt, 3, SQL_C_UTINYINT, &utiny_int_val_min, buf_len, &ind));
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(this->stmt, 4, SQL_C_UTINYINT, &utiny_int_val_max, buf_len, &ind));
+            SQLBindCol(stmt, 4, SQL_C_UTINYINT, &utiny_int_val_max, buf_len, &ind));
 
   // Signed Small Int
   int16_t ssmall_int_val_min;
   int16_t ssmall_int_val_max;
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(this->stmt, 5, SQL_C_SSHORT, &ssmall_int_val_min, buf_len, &ind));
+            SQLBindCol(stmt, 5, SQL_C_SSHORT, &ssmall_int_val_min, buf_len, &ind));
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(this->stmt, 6, SQL_C_SSHORT, &ssmall_int_val_max, buf_len, &ind));
+            SQLBindCol(stmt, 6, SQL_C_SSHORT, &ssmall_int_val_max, buf_len, &ind));
 
   // Unsigned Small Int
   uint16_t usmall_int_val_min;
   uint16_t usmall_int_val_max;
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(this->stmt, 7, SQL_C_USHORT, &usmall_int_val_min, buf_len, &ind));
+            SQLBindCol(stmt, 7, SQL_C_USHORT, &usmall_int_val_min, buf_len, &ind));
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(this->stmt, 8, SQL_C_USHORT, &usmall_int_val_max, buf_len, &ind));
+            SQLBindCol(stmt, 8, SQL_C_USHORT, &usmall_int_val_max, buf_len, &ind));
 
   // Signed Integer
   SQLINTEGER slong_val_min;
   SQLINTEGER slong_val_max;
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(this->stmt, 9, SQL_C_SLONG, &slong_val_min, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLBindCol(stmt, 9, SQL_C_SLONG, &slong_val_min, buf_len, &ind));
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(this->stmt, 10, SQL_C_SLONG, &slong_val_max, buf_len, &ind));
+            SQLBindCol(stmt, 10, SQL_C_SLONG, &slong_val_max, buf_len, &ind));
 
   // Unsigned Integer
   SQLUINTEGER ulong_val_min;
   SQLUINTEGER ulong_val_max;
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(this->stmt, 11, SQL_C_ULONG, &ulong_val_min, buf_len, &ind));
+            SQLBindCol(stmt, 11, SQL_C_ULONG, &ulong_val_min, buf_len, &ind));
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(this->stmt, 12, SQL_C_ULONG, &ulong_val_max, buf_len, &ind));
+            SQLBindCol(stmt, 12, SQL_C_ULONG, &ulong_val_max, buf_len, &ind));
 
   // Signed Big Int
   SQLBIGINT sbig_int_val_min;
   SQLBIGINT sbig_int_val_max;
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(this->stmt, 13, SQL_C_SBIGINT, &sbig_int_val_min, buf_len, &ind));
+            SQLBindCol(stmt, 13, SQL_C_SBIGINT, &sbig_int_val_min, buf_len, &ind));
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(this->stmt, 14, SQL_C_SBIGINT, &sbig_int_val_max, buf_len, &ind));
+            SQLBindCol(stmt, 14, SQL_C_SBIGINT, &sbig_int_val_max, buf_len, &ind));
 
   // Unsigned Big Int
   SQLUBIGINT ubig_int_val_min;
   SQLUBIGINT ubig_int_val_max;
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(this->stmt, 15, SQL_C_UBIGINT, &ubig_int_val_min, buf_len, &ind));
+            SQLBindCol(stmt, 15, SQL_C_UBIGINT, &ubig_int_val_min, buf_len, &ind));
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(this->stmt, 16, SQL_C_UBIGINT, &ubig_int_val_max, buf_len, &ind));
+            SQLBindCol(stmt, 16, SQL_C_UBIGINT, &ubig_int_val_max, buf_len, &ind));
 
   // Decimal
   SQL_NUMERIC_STRUCT decimal_val_neg;
@@ -1460,93 +1458,87 @@ TYPED_TEST(StatementTest, TestSQLBindColDataQuery) {
   memset(&decimal_val_pos, 0, sizeof(decimal_val_pos));
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(this->stmt, 17, SQL_C_NUMERIC, &decimal_val_neg, buf_len, &ind));
+            SQLBindCol(stmt, 17, SQL_C_NUMERIC, &decimal_val_neg, buf_len, &ind));
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(this->stmt, 18, SQL_C_NUMERIC, &decimal_val_pos, buf_len, &ind));
+            SQLBindCol(stmt, 18, SQL_C_NUMERIC, &decimal_val_pos, buf_len, &ind));
 
   // Float
   float float_val_min;
   float float_val_max;
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(this->stmt, 19, SQL_C_FLOAT, &float_val_min, buf_len, &ind));
+            SQLBindCol(stmt, 19, SQL_C_FLOAT, &float_val_min, buf_len, &ind));
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(this->stmt, 20, SQL_C_FLOAT, &float_val_max, buf_len, &ind));
+            SQLBindCol(stmt, 20, SQL_C_FLOAT, &float_val_max, buf_len, &ind));
 
   // Double
   SQLDOUBLE double_val_min;
   SQLDOUBLE double_val_max;
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(this->stmt, 21, SQL_C_DOUBLE, &double_val_min, buf_len, &ind));
+            SQLBindCol(stmt, 21, SQL_C_DOUBLE, &double_val_min, buf_len, &ind));
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(this->stmt, 22, SQL_C_DOUBLE, &double_val_max, buf_len, &ind));
+            SQLBindCol(stmt, 22, SQL_C_DOUBLE, &double_val_max, buf_len, &ind));
 
   // Bit
   bool bit_val_false;
   bool bit_val_true;
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(this->stmt, 23, SQL_C_BIT, &bit_val_false, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLBindCol(stmt, 23, SQL_C_BIT, &bit_val_false, buf_len, &ind));
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(this->stmt, 24, SQL_C_BIT, &bit_val_true, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLBindCol(stmt, 24, SQL_C_BIT, &bit_val_true, buf_len, &ind));
 
   // Characters
   SQLCHAR char_val[2];
   buf_len = sizeof(SQLCHAR) * 2;
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(this->stmt, 25, SQL_C_CHAR, &char_val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLBindCol(stmt, 25, SQL_C_CHAR, &char_val, buf_len, &ind));
 
   SQLWCHAR wchar_val[2];
-  size_t wchar_size = arrow::flight::sql::odbc::GetSqlWCharSize();
+  size_t wchar_size = GetSqlWCharSize();
   buf_len = wchar_size * 2;
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(this->stmt, 26, SQL_C_WCHAR, &wchar_val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLBindCol(stmt, 26, SQL_C_WCHAR, &wchar_val, buf_len, &ind));
 
   SQLWCHAR wvarchar_val[3];
   buf_len = wchar_size * 3;
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(this->stmt, 27, SQL_C_WCHAR, &wvarchar_val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLBindCol(stmt, 27, SQL_C_WCHAR, &wvarchar_val, buf_len, &ind));
 
   SQLCHAR varchar_val[4];
   buf_len = sizeof(SQLCHAR) * 4;
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(this->stmt, 28, SQL_C_CHAR, &varchar_val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLBindCol(stmt, 28, SQL_C_CHAR, &varchar_val, buf_len, &ind));
 
   // Date and Timestamp
   SQL_DATE_STRUCT date_val_min{}, date_val_max{};
   buf_len = 0;
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(this->stmt, 29, SQL_C_TYPE_DATE, &date_val_min, buf_len, &ind));
+            SQLBindCol(stmt, 29, SQL_C_TYPE_DATE, &date_val_min, buf_len, &ind));
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(this->stmt, 30, SQL_C_TYPE_DATE, &date_val_max, buf_len, &ind));
+            SQLBindCol(stmt, 30, SQL_C_TYPE_DATE, &date_val_max, buf_len, &ind));
 
   SQL_TIMESTAMP_STRUCT timestamp_val_min{}, timestamp_val_max{};
 
-  EXPECT_EQ(SQL_SUCCESS, SQLBindCol(this->stmt, 31, SQL_C_TYPE_TIMESTAMP,
-                                    &timestamp_val_min, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLBindCol(stmt, 31, SQL_C_TYPE_TIMESTAMP, &timestamp_val_min,
+                                    buf_len, &ind));
 
-  EXPECT_EQ(SQL_SUCCESS, SQLBindCol(this->stmt, 32, SQL_C_TYPE_TIMESTAMP,
-                                    &timestamp_val_max, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLBindCol(stmt, 32, SQL_C_TYPE_TIMESTAMP, &timestamp_val_max,
+                                    buf_len, &ind));
 
   // Execute query and fetch data once since there is only 1 row.
   std::wstring wsql = this->GetQueryAllDataTypes();
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   // Data verification
 
@@ -1654,10 +1646,10 @@ TEST_F(StatementRemoteTest, TestSQLBindColTimeQuery) {
   SQLLEN ind;
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(this->stmt, 1, SQL_C_TYPE_TIME, &time_var_min, buf_len, &ind));
+            SQLBindCol(stmt, 1, SQL_C_TYPE_TIME, &time_var_min, buf_len, &ind));
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(this->stmt, 2, SQL_C_TYPE_TIME, &time_var_max, buf_len, &ind));
+            SQLBindCol(stmt, 2, SQL_C_TYPE_TIME, &time_var_max, buf_len, &ind));
 
   std::wstring wsql =
       LR"(
@@ -1667,9 +1659,9 @@ TEST_F(StatementRemoteTest, TestSQLBindColTimeQuery) {
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   // Check min values for time.
   EXPECT_EQ(0, time_var_min.hour);
@@ -1691,15 +1683,15 @@ TEST_F(StatementMockTest, TestSQLBindColVarbinaryQuery) {
   SQLLEN buf_len = varbinary_val.size();
   SQLLEN ind;
   ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(this->stmt, 1, SQL_C_BINARY, &varbinary_val[0], buf_len, &ind));
+            SQLBindCol(stmt, 1, SQL_C_BINARY, &varbinary_val[0], buf_len, &ind));
 
   std::wstring wsql = L"SELECT X'ABCDEF' AS c_varbinary;";
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   // Check varbinary values
   EXPECT_EQ('\xAB', varbinary_val[0]);
@@ -1714,15 +1706,15 @@ TEST_F(StatementRemoteTest, TestSQLBindColNullQuery) {
   SQLINTEGER val;
   SQLLEN ind;
 
-  ASSERT_EQ(SQL_SUCCESS, SQLBindCol(this->stmt, 1, SQL_C_LONG, &val, 0, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLBindCol(stmt, 1, SQL_C_LONG, &val, 0, &ind));
 
   std::wstring wsql = L"SELECT null as null_col;";
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   // Verify SQL_NULL_DATA is returned for indicator
   EXPECT_EQ(SQL_NULL_DATA, ind);
@@ -1734,17 +1726,17 @@ TEST_F(StatementRemoteTest, TestSQLBindColNullQueryNullIndicator) {
 
   SQLINTEGER val;
 
-  ASSERT_EQ(SQL_SUCCESS, SQLBindCol(this->stmt, 1, SQL_C_LONG, &val, 0, 0));
+  ASSERT_EQ(SQL_SUCCESS, SQLBindCol(stmt, 1, SQL_C_LONG, &val, 0, 0));
 
   std::wstring wsql = L"SELECT null as null_col;";
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
 
-  ASSERT_EQ(SQL_ERROR, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_ERROR, SQLFetch(stmt));
   // Verify invalid null indicator is reported, as it is required
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorState22002);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorState22002);
 }
 
 TYPED_TEST(StatementTest, TestSQLBindColRowFetching) {
@@ -1754,7 +1746,7 @@ TYPED_TEST(StatementTest, TestSQLBindColRowFetching) {
 
   // Same variable will be used for column 1, the value of `val`
   // should be updated after every SQLFetch call.
-  ASSERT_EQ(SQL_SUCCESS, SQLBindCol(this->stmt, 1, SQL_C_LONG, &val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLBindCol(stmt, 1, SQL_C_LONG, &val, buf_len, &ind));
 
   std::wstring wsql =
       LR"(
@@ -1767,28 +1759,28 @@ TYPED_TEST(StatementTest, TestSQLBindColRowFetching) {
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
 
   // Fetch row 1
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   // Verify 1 is returned
   EXPECT_EQ(1, val);
 
   // Fetch row 2
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   // Verify 2 is returned
   EXPECT_EQ(2, val);
 
   // Fetch row 3
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   // Verify 3 is returned
   EXPECT_EQ(3, val);
 
   // Verify result set has no more data beyond row 3
-  ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_NO_DATA, SQLFetch(stmt));
 }
 
 TYPED_TEST(StatementTest, TestSQLBindColRowArraySize) {
@@ -1801,11 +1793,11 @@ TYPED_TEST(StatementTest, TestSQLBindColRowArraySize) {
 
   // Same variable will be used for column 1, the value of `val`
   // should be updated after every SQLFetch call.
-  ASSERT_EQ(SQL_SUCCESS, SQLBindCol(this->stmt, 1, SQL_C_LONG, val, buf_len, ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLBindCol(stmt, 1, SQL_C_LONG, val, buf_len, ind));
 
   SQLLEN rows_fetched;
   ASSERT_EQ(SQL_SUCCESS,
-            SQLSetStmtAttr(this->stmt, SQL_ATTR_ROWS_FETCHED_PTR, &rows_fetched, 0));
+            SQLSetStmtAttr(stmt, SQL_ATTR_ROWS_FETCHED_PTR, &rows_fetched, 0));
 
   std::wstring wsql =
       LR"(
@@ -1818,13 +1810,13 @@ TYPED_TEST(StatementTest, TestSQLBindColRowArraySize) {
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLSetStmtAttr(this->stmt, SQL_ATTR_ROW_ARRAY_SIZE,
+  ASSERT_EQ(SQL_SUCCESS, SQLSetStmtAttr(stmt, SQL_ATTR_ROW_ARRAY_SIZE,
                                         reinterpret_cast<SQLPOINTER>(rows), 0));
 
   // Fetch 3 rows at once
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   // Verify 3 rows are fetched
   EXPECT_EQ(3, rows_fetched);
@@ -1837,7 +1829,7 @@ TYPED_TEST(StatementTest, TestSQLBindColRowArraySize) {
   EXPECT_EQ(3, val[2]);
 
   // Verify result set has no more data beyond row 3
-  ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_NO_DATA, SQLFetch(stmt));
 }
 
 TYPED_TEST(StatementTest, DISABLED_TestSQLBindColIndicatorOnly) {
@@ -1849,22 +1841,21 @@ TYPED_TEST(StatementTest, DISABLED_TestSQLBindColIndicatorOnly) {
 
   // Signed Tiny Int
   SQLLEN stiny_int_ind;
-  EXPECT_EQ(SQL_SUCCESS, SQLBindCol(this->stmt, 1, SQL_C_STINYINT, 0, 0, &stiny_int_ind));
+  EXPECT_EQ(SQL_SUCCESS, SQLBindCol(stmt, 1, SQL_C_STINYINT, 0, 0, &stiny_int_ind));
 
   // Characters
   SQLLEN buf_len = sizeof(SQLCHAR) * 2;
   SQLLEN char_val_ind;
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(this->stmt, 25, SQL_C_CHAR, 0, buf_len, &char_val_ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLBindCol(stmt, 25, SQL_C_CHAR, 0, buf_len, &char_val_ind));
 
   // Execute query and fetch data once since there is only 1 row.
   std::wstring wsql = this->GetQueryAllDataTypes();
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   // Verify values for indicator pointer
   // Signed Tiny Int
@@ -1883,26 +1874,26 @@ TYPED_TEST(StatementTest, TestSQLBindColIndicatorOnlySQLUnbind) {
   int8_t stiny_int_val;
   SQLLEN stiny_int_ind;
   ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(this->stmt, 1, SQL_C_STINYINT, &stiny_int_val, 0, &stiny_int_ind));
+            SQLBindCol(stmt, 1, SQL_C_STINYINT, &stiny_int_val, 0, &stiny_int_ind));
 
   // Characters
   SQLCHAR char_val[2];
   SQLLEN buf_len = sizeof(SQLCHAR) * 2;
   SQLLEN char_val_ind;
   ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(this->stmt, 25, SQL_C_CHAR, &char_val, buf_len, &char_val_ind));
+            SQLBindCol(stmt, 25, SQL_C_CHAR, &char_val, buf_len, &char_val_ind));
 
   // Driver should still be able to execute queries after unbinding columns
-  EXPECT_EQ(SQL_SUCCESS, SQLFreeStmt(this->stmt, SQL_UNBIND));
+  EXPECT_EQ(SQL_SUCCESS, SQLFreeStmt(stmt, SQL_UNBIND));
 
   // Execute query and fetch data once since there is only 1 row.
   std::wstring wsql = this->GetQueryAllDataTypes();
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   // GH-47021 TODO: implement driver to return indicator value when data pointer is null
   // and uncomment the checks Verify values for indicator pointer Signed Tiny Int
@@ -1922,10 +1913,10 @@ TYPED_TEST(StatementTest, TestSQLExtendedFetchRowFetching) {
 
   // Same variable will be used for column 1, the value of `val`
   // should be updated after every SQLFetch call.
-  ASSERT_EQ(SQL_SUCCESS, SQLBindCol(this->stmt, 1, SQL_C_LONG, val, buf_len, ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLBindCol(stmt, 1, SQL_C_LONG, val, buf_len, ind));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLSetStmtAttr(this->stmt, SQL_ROWSET_SIZE,
-                                        reinterpret_cast<SQLPOINTER>(rows), 0));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLSetStmtAttr(stmt, SQL_ROWSET_SIZE, reinterpret_cast<SQLPOINTER>(rows), 0));
 
   std::wstring wsql =
       LR"(
@@ -1938,14 +1929,14 @@ TYPED_TEST(StatementTest, TestSQLExtendedFetchRowFetching) {
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
 
   // Fetch row 1-3.
   SQLULEN row_count;
   SQLUSMALLINT row_status[rows];
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLExtendedFetch(this->stmt, SQL_FETCH_NEXT, 0, &row_count, row_status));
+            SQLExtendedFetch(stmt, SQL_FETCH_NEXT, 0, &row_count, row_status));
   EXPECT_EQ(3, row_count);
 
   for (int i = 0; i < rows; i++) {
@@ -1963,7 +1954,7 @@ TYPED_TEST(StatementTest, TestSQLExtendedFetchRowFetching) {
   SQLULEN row_count2;
   SQLUSMALLINT row_status2[rows];
   EXPECT_EQ(SQL_NO_DATA,
-            SQLExtendedFetch(this->stmt, SQL_FETCH_NEXT, 0, &row_count2, row_status2));
+            SQLExtendedFetch(stmt, SQL_FETCH_NEXT, 0, &row_count2, row_status2));
 }
 
 TEST_F(StatementRemoteTest, DISABLED_TestSQLExtendedFetchQueryNullIndicator) {
@@ -1972,21 +1963,21 @@ TEST_F(StatementRemoteTest, DISABLED_TestSQLExtendedFetchQueryNullIndicator) {
   // server instead. Mock server has type `DENSE_UNION` for null column data.
   SQLINTEGER val;
 
-  ASSERT_EQ(SQL_SUCCESS, SQLBindCol(this->stmt, 1, SQL_C_LONG, &val, 0, nullptr));
+  ASSERT_EQ(SQL_SUCCESS, SQLBindCol(stmt, 1, SQL_C_LONG, &val, 0, nullptr));
 
   std::wstring wsql = L"SELECT null as null_col;";
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
 
   SQLULEN row_count1;
   SQLUSMALLINT row_status1[1];
 
   // SQLExtendedFetch should return SQL_SUCCESS_WITH_INFO for 22002 state
   ASSERT_EQ(SQL_SUCCESS_WITH_INFO,
-            SQLExtendedFetch(this->stmt, SQL_FETCH_NEXT, 0, &row_count1, row_status1));
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorState22002);
+            SQLExtendedFetch(stmt, SQL_FETCH_NEXT, 0, &row_count1, row_status1));
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorState22002);
 }
 
 TYPED_TEST(StatementTest, TestSQLMoreResultsNoData) {
@@ -1995,16 +1986,16 @@ TYPED_TEST(StatementTest, TestSQLMoreResultsNoData) {
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
 
-  ASSERT_EQ(SQL_NO_DATA, SQLMoreResults(this->stmt));
+  ASSERT_EQ(SQL_NO_DATA, SQLMoreResults(stmt));
 }
 
 TYPED_TEST(StatementTest, TestSQLMoreResultsInvalidFunctionSequence) {
   // Verify function sequence error state is reported when SQLMoreResults is called
   // without executing any queries
-  ASSERT_EQ(SQL_ERROR, SQLMoreResults(this->stmt));
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorStateHY010);
+  ASSERT_EQ(SQL_ERROR, SQLMoreResults(stmt));
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorStateHY010);
 }
 
 TYPED_TEST(StatementTest, TestSQLNativeSqlReturnsInputString) {
@@ -2015,8 +2006,8 @@ TYPED_TEST(StatementTest, TestSQLNativeSqlReturnsInputString) {
   SQLINTEGER output_char_len = 0;
   std::wstring expected_string = std::wstring(input_str);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLNativeSql(this->conn, input_str, input_char_len, buf,
-                                      buf_char_len, &output_char_len));
+  ASSERT_EQ(SQL_SUCCESS, SQLNativeSql(conn, input_str, input_char_len, buf, buf_char_len,
+                                      &output_char_len));
 
   EXPECT_EQ(input_char_len, output_char_len);
 
@@ -2034,8 +2025,8 @@ TYPED_TEST(StatementTest, TestSQLNativeSqlReturnsNTSInputString) {
   SQLINTEGER output_char_len = 0;
   std::wstring expected_string = std::wstring(input_str);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLNativeSql(this->conn, input_str, SQL_NTS, buf, buf_char_len,
-                                      &output_char_len));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLNativeSql(conn, input_str, SQL_NTS, buf, buf_char_len, &output_char_len));
 
   EXPECT_EQ(input_char_len, output_char_len);
 
@@ -2051,13 +2042,13 @@ TYPED_TEST(StatementTest, TestSQLNativeSqlReturnsInputStringLength) {
   SQLINTEGER output_char_len = 0;
   std::wstring expected_string = std::wstring(input_str);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLNativeSql(this->conn, input_str, input_char_len, nullptr, 0,
-                                      &output_char_len));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLNativeSql(conn, input_str, input_char_len, nullptr, 0, &output_char_len));
 
   EXPECT_EQ(input_char_len, output_char_len);
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLNativeSql(this->conn, input_str, SQL_NTS, nullptr, 0, &output_char_len));
+            SQLNativeSql(conn, input_str, SQL_NTS, nullptr, 0, &output_char_len));
 
   EXPECT_EQ(input_char_len, output_char_len);
 }
@@ -2078,9 +2069,9 @@ TYPED_TEST(StatementTest, TestSQLNativeSqlReturnsTruncatedString) {
                                expected_string_buf + small_buf_size_in_char);
 
   ASSERT_EQ(SQL_SUCCESS_WITH_INFO,
-            SQLNativeSql(this->conn, input_str, input_char_len, small_buf,
-                         small_buf_char_len, &output_char_len));
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorState01004);
+            SQLNativeSql(conn, input_str, input_char_len, small_buf, small_buf_char_len,
+                         &output_char_len));
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorState01004);
 
   // Returned text length represents full string char length regardless of truncation
   EXPECT_EQ(input_char_len, output_char_len);
@@ -2097,17 +2088,21 @@ TYPED_TEST(StatementTest, TestSQLNativeSqlReturnsErrorOnBadInputs) {
   SQLINTEGER input_char_len = static_cast<SQLINTEGER>(wcslen(input_str));
   SQLINTEGER output_char_len = 0;
 
-  ASSERT_EQ(SQL_ERROR, SQLNativeSql(this->conn, nullptr, input_char_len, buf,
-                                    buf_char_len, &output_char_len));
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorStateHY009);
-
-  ASSERT_EQ(SQL_ERROR, SQLNativeSql(this->conn, nullptr, SQL_NTS, buf, buf_char_len,
+  ASSERT_EQ(SQL_ERROR, SQLNativeSql(conn, nullptr, input_char_len, buf, buf_char_len,
                                     &output_char_len));
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorStateHY009);
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorStateHY009);
 
-  ASSERT_EQ(SQL_ERROR, SQLNativeSql(this->conn, input_str, -100, buf, buf_char_len,
-                                    &output_char_len));
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorStateHY090);
+  ASSERT_EQ(SQL_ERROR,
+            SQLNativeSql(conn, nullptr, SQL_NTS, buf, buf_char_len, &output_char_len));
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorStateHY009);
+
+  ASSERT_EQ(SQL_ERROR,
+            SQLNativeSql(conn, input_str, -100, buf, buf_char_len, &output_char_len));
+#ifdef __APPLE__
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorStateS1090);
+#else
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorStateHY090);
+#endif  // __APPLE__
 }
 
 TYPED_TEST(StatementTest, SQLNumResultColsReturnsColumnsOnSelect) {
@@ -2116,15 +2111,15 @@ TYPED_TEST(StatementTest, SQLNumResultColsReturnsColumnsOnSelect) {
   SQLWCHAR sql_query[] = L"SELECT 1 AS col1, 'One' AS col2, 3 AS col3";
   SQLINTEGER query_length = static_cast<SQLINTEGER>(wcslen(sql_query));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, sql_query, query_length));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, sql_query, query_length));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckIntColumn(this->stmt, 1, 1);
-  CheckStringColumnW(this->stmt, 2, L"One");
-  CheckIntColumn(this->stmt, 3, 3);
+  CheckIntColumn(stmt, 1, 1);
+  CheckStringColumnW(stmt, 2, L"One");
+  CheckIntColumn(stmt, 3, 3);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLNumResultCols(this->stmt, &column_count));
+  ASSERT_EQ(SQL_SUCCESS, SQLNumResultCols(stmt, &column_count));
 
   EXPECT_EQ(expected_value, column_count);
 }
@@ -2133,25 +2128,36 @@ TYPED_TEST(StatementTest, SQLNumResultColsReturnsSuccessOnNullptr) {
   SQLWCHAR sql_query[] = L"SELECT 1 AS col1, 'One' AS col2, 3 AS col3";
   SQLINTEGER query_length = static_cast<SQLINTEGER>(wcslen(sql_query));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, sql_query, query_length));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, sql_query, query_length));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckIntColumn(this->stmt, 1, 1);
-  CheckStringColumnW(this->stmt, 2, L"One");
-  CheckIntColumn(this->stmt, 3, 3);
+  CheckIntColumn(stmt, 1, 1);
+  CheckStringColumnW(stmt, 2, L"One");
+  CheckIntColumn(stmt, 3, 3);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLNumResultCols(this->stmt, nullptr));
+  ASSERT_EQ(SQL_SUCCESS, SQLNumResultCols(stmt, nullptr));
 }
 
 TYPED_TEST(StatementTest, SQLNumResultColsFunctionSequenceErrorOnNoQuery) {
   SQLSMALLINT column_count = 0;
   SQLSMALLINT expected_value = 0;
 
-  ASSERT_EQ(SQL_ERROR, SQLNumResultCols(this->stmt, &column_count));
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorStateHY010);
+  ASSERT_EQ(SQL_ERROR, SQLNumResultCols(stmt, &column_count));
+#ifdef __APPLE__
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorStateS1010);
+#else
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorStateHY010);
+#endif  // __APPLE__
 
-  EXPECT_EQ(expected_value, column_count);
+  ASSERT_EQ(SQL_ERROR, SQLNumResultCols(stmt, &column_count));
+#ifdef __APPLE__
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorStateS1010);
+#else
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorStateHY010);
+#endif  // __APPLE__
+
+  ASSERT_EQ(expected_value, column_count);
 }
 
 TYPED_TEST(StatementTest, SQLRowCountReturnsNegativeOneOnSelect) {
@@ -2160,15 +2166,15 @@ TYPED_TEST(StatementTest, SQLRowCountReturnsNegativeOneOnSelect) {
   SQLWCHAR sql_query[] = L"SELECT 1 AS col1, 'One' AS col2, 3 AS col3";
   SQLINTEGER query_length = static_cast<SQLINTEGER>(wcslen(sql_query));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, sql_query, query_length));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, sql_query, query_length));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckIntColumn(this->stmt, 1, 1);
-  CheckStringColumnW(this->stmt, 2, L"One");
-  CheckIntColumn(this->stmt, 3, 3);
+  CheckIntColumn(stmt, 1, 1);
+  CheckStringColumnW(stmt, 2, L"One");
+  CheckIntColumn(stmt, 3, 3);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLRowCount(this->stmt, &row_count));
+  ASSERT_EQ(SQL_SUCCESS, SQLRowCount(stmt, &row_count));
 
   EXPECT_EQ(expected_value, row_count);
 }
@@ -2177,25 +2183,39 @@ TYPED_TEST(StatementTest, SQLRowCountReturnsSuccessOnNullptr) {
   SQLWCHAR sql_query[] = L"SELECT 1 AS col1, 'One' AS col2, 3 AS col3";
   SQLINTEGER query_length = static_cast<SQLINTEGER>(wcslen(sql_query));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, sql_query, query_length));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, sql_query, query_length));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckIntColumn(this->stmt, 1, 1);
-  CheckStringColumnW(this->stmt, 2, L"One");
-  CheckIntColumn(this->stmt, 3, 3);
+  CheckIntColumn(stmt, 1, 1);
+  CheckStringColumnW(stmt, 2, L"One");
+  CheckIntColumn(stmt, 3, 3);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLRowCount(this->stmt, nullptr));
+  ASSERT_EQ(SQL_SUCCESS, SQLRowCount(stmt, nullptr));
 }
 
 TYPED_TEST(StatementTest, SQLRowCountFunctionSequenceErrorOnNoQuery) {
   SQLLEN row_count = 0;
   SQLLEN expected_value = 0;
 
-  ASSERT_EQ(SQL_ERROR, SQLRowCount(this->stmt, &row_count));
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorStateHY010);
+  ASSERT_EQ(SQL_ERROR, SQLRowCount(stmt, &row_count));
+#ifdef __APPLE__
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorStateS1010);
+#else
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorStateHY010);
+#endif  // __APPLE__
 
   EXPECT_EQ(expected_value, row_count);
+}
+
+TYPED_TEST(StatementTest, TestSQLFreeStmtSQLClose) {
+  std::wstring wsql = L"SELECT 1;";
+  std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
+
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+
+  ASSERT_EQ(SQL_SUCCESS, SQLFreeStmt(stmt, SQL_CLOSE));
 }
 
 TYPED_TEST(StatementTest, TestSQLCloseCursor) {
@@ -2203,22 +2223,22 @@ TYPED_TEST(StatementTest, TestSQLCloseCursor) {
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLCloseCursor(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLCloseCursor(stmt));
 }
 
 TYPED_TEST(StatementTest, TestSQLFreeStmtSQLCloseWithoutCursor) {
   // Verify SQLFreeStmt(SQL_CLOSE) does not throw error with invalid cursor
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFreeStmt(this->stmt, SQL_CLOSE));
+  ASSERT_EQ(SQL_SUCCESS, SQLFreeStmt(stmt, SQL_CLOSE));
 }
 
 TYPED_TEST(StatementTest, TestSQLCloseCursorWithoutCursor) {
-  ASSERT_EQ(SQL_ERROR, SQLCloseCursor(this->stmt));
+  ASSERT_EQ(SQL_ERROR, SQLCloseCursor(stmt));
 
   // Verify invalid cursor error state is returned
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorState24000);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorState24000);
 }
 
 }  // namespace arrow::flight::sql::odbc

--- a/cpp/src/arrow/flight/sql/odbc/tests/type_info_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/type_info_test.cc
@@ -1769,7 +1769,7 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoTimeODBCVer2) {
 
 TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoSQLTypeTime) {
 #ifdef __APPLE__
-  ASSERT_EQ(SQL_SUCCESS, SQLGetTypeInfo(stmt, SQL_TYPE_DATE));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetTypeInfo(stmt, SQL_TYPE_TIME));
 #else
   // Pass ODBC Ver 3 data type
   ASSERT_EQ(SQL_ERROR, SQLGetTypeInfo(stmt, SQL_TYPE_TIME));

--- a/cpp/src/arrow/flight/sql/odbc/tests/type_info_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/type_info_test.cc
@@ -206,12 +206,12 @@ void CheckSQLGetTypeInfo(
 }  // namespace
 
 TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
-  ASSERT_EQ(SQL_SUCCESS, SQLGetTypeInfo(this->stmt, SQL_ALL_TYPES));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetTypeInfo(stmt, SQL_ALL_TYPES));
 
   // Check bit data type
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckSQLGetTypeInfo(this->stmt,
+  CheckSQLGetTypeInfo(stmt,
                       std::wstring(L"bit"),  // expected_type_name
                       SQL_BIT,               // expected_data_type
                       1,                     // expected_column_size
@@ -232,12 +232,12 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       NULL,                  // expected_num_prec_radix
                       NULL);                 // expected_interval_prec
 
-  CheckSQLDescribeColODBCVer3(this->stmt);
+  CheckSQLDescribeColODBCVer3(stmt);
 
   // Check tinyint data type
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckSQLGetTypeInfo(this->stmt,
+  CheckSQLGetTypeInfo(stmt,
                       std::wstring(L"tinyint"),  // expected_type_name
                       SQL_TINYINT,               // expected_data_type
                       3,                         // expected_column_size
@@ -258,12 +258,12 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       NULL,                      // expected_num_prec_radix
                       NULL);                     // expected_interval_prec
 
-  CheckSQLDescribeColODBCVer3(this->stmt);
+  CheckSQLDescribeColODBCVer3(stmt);
 
   // Check bigint data type
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckSQLGetTypeInfo(this->stmt,
+  CheckSQLGetTypeInfo(stmt,
                       std::wstring(L"bigint"),  // expected_type_name
                       SQL_BIGINT,               // expected_data_type
                       19,                       // expected_column_size
@@ -284,12 +284,12 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       NULL,                     // expected_num_prec_radix
                       NULL);                    // expected_interval_prec
 
-  CheckSQLDescribeColODBCVer3(this->stmt);
+  CheckSQLDescribeColODBCVer3(stmt);
 
   // Check longvarbinary data type
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckSQLGetTypeInfo(this->stmt,
+  CheckSQLGetTypeInfo(stmt,
                       std::wstring(L"longvarbinary"),  // expected_type_name
                       SQL_LONGVARBINARY,               // expected_data_type
                       65536,                           // expected_column_size
@@ -310,12 +310,12 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       NULL,                            // expected_num_prec_radix
                       NULL);                           // expected_interval_prec
 
-  CheckSQLDescribeColODBCVer3(this->stmt);
+  CheckSQLDescribeColODBCVer3(stmt);
 
   // Check varbinary data type
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckSQLGetTypeInfo(this->stmt,
+  CheckSQLGetTypeInfo(stmt,
                       std::wstring(L"varbinary"),  // expected_type_name
                       SQL_VARBINARY,               // expected_data_type
                       255,                         // expected_column_size
@@ -336,13 +336,13 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       NULL,                        // expected_num_prec_radix
                       NULL);                       // expected_interval_prec
 
-  CheckSQLDescribeColODBCVer3(this->stmt);
+  CheckSQLDescribeColODBCVer3(stmt);
 
   // Check text data type
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   // Driver returns SQL_WLONGVARCHAR since unicode is enabled
-  CheckSQLGetTypeInfo(this->stmt,
+  CheckSQLGetTypeInfo(stmt,
                       std::wstring(L"text"),    // expected_type_name
                       SQL_WLONGVARCHAR,         // expected_data_type
                       65536,                    // expected_column_size
@@ -363,12 +363,12 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       NULL,                     // expected_num_prec_radix
                       NULL);                    // expected_interval_prec
 
-  CheckSQLDescribeColODBCVer3(this->stmt);
+  CheckSQLDescribeColODBCVer3(stmt);
 
   // Check longvarchar data type
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckSQLGetTypeInfo(this->stmt,
+  CheckSQLGetTypeInfo(stmt,
                       std::wstring(L"longvarchar"),  // expected_type_name
                       SQL_WLONGVARCHAR,              // expected_data_type
                       65536,                         // expected_column_size
@@ -389,13 +389,13 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       NULL,                          // expected_num_prec_radix
                       NULL);                         // expected_interval_prec
 
-  CheckSQLDescribeColODBCVer3(this->stmt);
+  CheckSQLDescribeColODBCVer3(stmt);
 
   // Check char data type
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   // Driver returns SQL_WCHAR since unicode is enabled
-  CheckSQLGetTypeInfo(this->stmt,
+  CheckSQLGetTypeInfo(stmt,
                       std::wstring(L"char"),    // expected_type_name
                       SQL_WCHAR,                // expected_data_type
                       255,                      // expected_column_size
@@ -416,12 +416,12 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       NULL,                     // expected_num_prec_radix
                       NULL);                    // expected_interval_prec
 
-  CheckSQLDescribeColODBCVer3(this->stmt);
+  CheckSQLDescribeColODBCVer3(stmt);
 
   // Check integer data type
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckSQLGetTypeInfo(this->stmt,
+  CheckSQLGetTypeInfo(stmt,
                       std::wstring(L"integer"),  // expected_type_name
                       SQL_INTEGER,               // expected_data_type
                       9,                         // expected_column_size
@@ -442,12 +442,12 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       NULL,                      // expected_num_prec_radix
                       NULL);                     // expected_interval_prec
 
-  CheckSQLDescribeColODBCVer3(this->stmt);
+  CheckSQLDescribeColODBCVer3(stmt);
 
   // Check smallint data type
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckSQLGetTypeInfo(this->stmt,
+  CheckSQLGetTypeInfo(stmt,
                       std::wstring(L"smallint"),  // expected_type_name
                       SQL_SMALLINT,               // expected_data_type
                       5,                          // expected_column_size
@@ -468,12 +468,12 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       NULL,                       // expected_num_prec_radix
                       NULL);                      // expected_interval_prec
 
-  CheckSQLDescribeColODBCVer3(this->stmt);
+  CheckSQLDescribeColODBCVer3(stmt);
 
   // Check float data type
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckSQLGetTypeInfo(this->stmt,
+  CheckSQLGetTypeInfo(stmt,
                       std::wstring(L"float"),  // expected_type_name
                       SQL_FLOAT,               // expected_data_type
                       7,                       // expected_column_size
@@ -494,12 +494,12 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       NULL,                    // expected_num_prec_radix
                       NULL);                   // expected_interval_prec
 
-  CheckSQLDescribeColODBCVer3(this->stmt);
+  CheckSQLDescribeColODBCVer3(stmt);
 
   // Check double data type
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckSQLGetTypeInfo(this->stmt,
+  CheckSQLGetTypeInfo(stmt,
                       std::wstring(L"double"),  // expected_type_name
                       SQL_DOUBLE,               // expected_data_type
                       15,                       // expected_column_size
@@ -520,13 +520,13 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       NULL,                     // expected_num_prec_radix
                       NULL);                    // expected_interval_prec
 
-  CheckSQLDescribeColODBCVer3(this->stmt);
+  CheckSQLDescribeColODBCVer3(stmt);
 
   // Check numeric data type
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   // Mock server treats numeric data type as a double type
-  CheckSQLGetTypeInfo(this->stmt,
+  CheckSQLGetTypeInfo(stmt,
                       std::wstring(L"numeric"),  // expected_type_name
                       SQL_DOUBLE,                // expected_data_type
                       15,                        // expected_column_size
@@ -547,13 +547,13 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       NULL,                      // expected_num_prec_radix
                       NULL);                     // expected_interval_prec
 
-  CheckSQLDescribeColODBCVer3(this->stmt);
+  CheckSQLDescribeColODBCVer3(stmt);
 
   // Check varchar data type
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   // Driver returns SQL_WVARCHAR since unicode is enabled
-  CheckSQLGetTypeInfo(this->stmt,
+  CheckSQLGetTypeInfo(stmt,
                       std::wstring(L"varchar"),  // expected_type_name
                       SQL_WVARCHAR,              // expected_data_type
                       255,                       // expected_column_size
@@ -574,12 +574,12 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       NULL,                      // expected_num_prec_radix
                       NULL);                     // expected_interval_prec
 
-  CheckSQLDescribeColODBCVer3(this->stmt);
+  CheckSQLDescribeColODBCVer3(stmt);
 
   // Check date data type
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckSQLGetTypeInfo(this->stmt,
+  CheckSQLGetTypeInfo(stmt,
                       std::wstring(L"date"),  // expected_type_name
                       SQL_TYPE_DATE,          // expected_data_type
                       10,                     // expected_column_size
@@ -600,12 +600,12 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       NULL,                   // expected_num_prec_radix
                       NULL);                  // expected_interval_prec
 
-  CheckSQLDescribeColODBCVer3(this->stmt);
+  CheckSQLDescribeColODBCVer3(stmt);
 
   // Check time data type
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckSQLGetTypeInfo(this->stmt,
+  CheckSQLGetTypeInfo(stmt,
                       std::wstring(L"time"),  // expected_type_name
                       SQL_TYPE_TIME,          // expected_data_type
                       8,                      // expected_column_size
@@ -626,12 +626,12 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       NULL,                   // expected_num_prec_radix
                       NULL);                  // expected_interval_prec
 
-  CheckSQLDescribeColODBCVer3(this->stmt);
+  CheckSQLDescribeColODBCVer3(stmt);
 
   // Check timestamp data type
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckSQLGetTypeInfo(this->stmt,
+  CheckSQLGetTypeInfo(stmt,
                       std::wstring(L"timestamp"),  // expected_type_name
                       SQL_TYPE_TIMESTAMP,          // expected_data_type
                       32,                          // expected_column_size
@@ -652,16 +652,16 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       NULL,                        // expected_num_prec_radix
                       NULL);                       // expected_interval_prec
 
-  CheckSQLDescribeColODBCVer3(this->stmt);
+  CheckSQLDescribeColODBCVer3(stmt);
 }
 
 TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
-  ASSERT_EQ(SQL_SUCCESS, SQLGetTypeInfo(this->stmt, SQL_ALL_TYPES));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetTypeInfo(stmt, SQL_ALL_TYPES));
 
   // Check bit data type
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckSQLGetTypeInfo(this->stmt,
+  CheckSQLGetTypeInfo(stmt,
                       std::wstring(L"bit"),  // expected_type_name
                       SQL_BIT,               // expected_data_type
                       1,                     // expected_column_size
@@ -682,12 +682,12 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       NULL,                  // expected_num_prec_radix
                       NULL);                 // expected_interval_prec
 
-  CheckSQLDescribeColODBCVer2(this->stmt);
+  CheckSQLDescribeColODBCVer2(stmt);
 
   // Check tinyint data type
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckSQLGetTypeInfo(this->stmt,
+  CheckSQLGetTypeInfo(stmt,
                       std::wstring(L"tinyint"),  // expected_type_name
                       SQL_TINYINT,               // expected_data_type
                       3,                         // expected_column_size
@@ -708,12 +708,12 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       NULL,                      // expected_num_prec_radix
                       NULL);                     // expected_interval_prec
 
-  CheckSQLDescribeColODBCVer2(this->stmt);
+  CheckSQLDescribeColODBCVer2(stmt);
 
   // Check bigint data type
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckSQLGetTypeInfo(this->stmt,
+  CheckSQLGetTypeInfo(stmt,
                       std::wstring(L"bigint"),  // expected_type_name
                       SQL_BIGINT,               // expected_data_type
                       19,                       // expected_column_size
@@ -734,12 +734,12 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       NULL,                     // expected_num_prec_radix
                       NULL);                    // expected_interval_prec
 
-  CheckSQLDescribeColODBCVer2(this->stmt);
+  CheckSQLDescribeColODBCVer2(stmt);
 
   // Check longvarbinary data type
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckSQLGetTypeInfo(this->stmt,
+  CheckSQLGetTypeInfo(stmt,
                       std::wstring(L"longvarbinary"),  // expected_type_name
                       SQL_LONGVARBINARY,               // expected_data_type
                       65536,                           // expected_column_size
@@ -760,12 +760,12 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       NULL,                            // expected_num_prec_radix
                       NULL);                           // expected_interval_prec
 
-  CheckSQLDescribeColODBCVer2(this->stmt);
+  CheckSQLDescribeColODBCVer2(stmt);
 
   // Check varbinary data type
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckSQLGetTypeInfo(this->stmt,
+  CheckSQLGetTypeInfo(stmt,
                       std::wstring(L"varbinary"),  // expected_type_name
                       SQL_VARBINARY,               // expected_data_type
                       255,                         // expected_column_size
@@ -786,13 +786,13 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       NULL,                        // expected_num_prec_radix
                       NULL);                       // expected_interval_prec
 
-  CheckSQLDescribeColODBCVer2(this->stmt);
+  CheckSQLDescribeColODBCVer2(stmt);
 
   // Check text data type
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   // Driver returns SQL_WLONGVARCHAR since unicode is enabled
-  CheckSQLGetTypeInfo(this->stmt,
+  CheckSQLGetTypeInfo(stmt,
                       std::wstring(L"text"),    // expected_type_name
                       SQL_WLONGVARCHAR,         // expected_data_type
                       65536,                    // expected_column_size
@@ -813,12 +813,12 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       NULL,                     // expected_num_prec_radix
                       NULL);                    // expected_interval_prec
 
-  CheckSQLDescribeColODBCVer2(this->stmt);
+  CheckSQLDescribeColODBCVer2(stmt);
 
   // Check longvarchar data type
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckSQLGetTypeInfo(this->stmt,
+  CheckSQLGetTypeInfo(stmt,
                       std::wstring(L"longvarchar"),  // expected_type_name
                       SQL_WLONGVARCHAR,              // expected_data_type
                       65536,                         // expected_column_size
@@ -839,13 +839,13 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       NULL,                          // expected_num_prec_radix
                       NULL);                         // expected_interval_prec
 
-  CheckSQLDescribeColODBCVer2(this->stmt);
+  CheckSQLDescribeColODBCVer2(stmt);
 
   // Check char data type
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   // Driver returns SQL_WCHAR since unicode is enabled
-  CheckSQLGetTypeInfo(this->stmt,
+  CheckSQLGetTypeInfo(stmt,
                       std::wstring(L"char"),    // expected_type_name
                       SQL_WCHAR,                // expected_data_type
                       255,                      // expected_column_size
@@ -866,12 +866,12 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       NULL,                     // expected_num_prec_radix
                       NULL);                    // expected_interval_prec
 
-  CheckSQLDescribeColODBCVer2(this->stmt);
+  CheckSQLDescribeColODBCVer2(stmt);
 
   // Check integer data type
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckSQLGetTypeInfo(this->stmt,
+  CheckSQLGetTypeInfo(stmt,
                       std::wstring(L"integer"),  // expected_type_name
                       SQL_INTEGER,               // expected_data_type
                       9,                         // expected_column_size
@@ -892,12 +892,12 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       NULL,                      // expected_num_prec_radix
                       NULL);                     // expected_interval_prec
 
-  CheckSQLDescribeColODBCVer2(this->stmt);
+  CheckSQLDescribeColODBCVer2(stmt);
 
   // Check smallint data type
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckSQLGetTypeInfo(this->stmt,
+  CheckSQLGetTypeInfo(stmt,
                       std::wstring(L"smallint"),  // expected_type_name
                       SQL_SMALLINT,               // expected_data_type
                       5,                          // expected_column_size
@@ -918,12 +918,12 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       NULL,                       // expected_num_prec_radix
                       NULL);                      // expected_interval_prec
 
-  CheckSQLDescribeColODBCVer2(this->stmt);
+  CheckSQLDescribeColODBCVer2(stmt);
 
   // Check float data type
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckSQLGetTypeInfo(this->stmt,
+  CheckSQLGetTypeInfo(stmt,
                       std::wstring(L"float"),  // expected_type_name
                       SQL_FLOAT,               // expected_data_type
                       7,                       // expected_column_size
@@ -944,12 +944,12 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       NULL,                    // expected_num_prec_radix
                       NULL);                   // expected_interval_prec
 
-  CheckSQLDescribeColODBCVer2(this->stmt);
+  CheckSQLDescribeColODBCVer2(stmt);
 
   // Check double data type
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckSQLGetTypeInfo(this->stmt,
+  CheckSQLGetTypeInfo(stmt,
                       std::wstring(L"double"),  // expected_type_name
                       SQL_DOUBLE,               // expected_data_type
                       15,                       // expected_column_size
@@ -970,13 +970,13 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       NULL,                     // expected_num_prec_radix
                       NULL);                    // expected_interval_prec
 
-  CheckSQLDescribeColODBCVer2(this->stmt);
+  CheckSQLDescribeColODBCVer2(stmt);
 
   // Check numeric data type
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   // Mock server treats numeric data type as a double type
-  CheckSQLGetTypeInfo(this->stmt,
+  CheckSQLGetTypeInfo(stmt,
                       std::wstring(L"numeric"),  // expected_type_name
                       SQL_DOUBLE,                // expected_data_type
                       15,                        // expected_column_size
@@ -997,13 +997,13 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       NULL,                      // expected_num_prec_radix
                       NULL);                     // expected_interval_prec
 
-  CheckSQLDescribeColODBCVer2(this->stmt);
+  CheckSQLDescribeColODBCVer2(stmt);
 
   // Check varchar data type
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   // Driver returns SQL_WVARCHAR since unicode is enabled
-  CheckSQLGetTypeInfo(this->stmt,
+  CheckSQLGetTypeInfo(stmt,
                       std::wstring(L"varchar"),  // expected_type_name
                       SQL_WVARCHAR,              // expected_data_type
                       255,                       // expected_column_size
@@ -1024,12 +1024,12 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       NULL,                      // expected_num_prec_radix
                       NULL);                     // expected_interval_prec
 
-  CheckSQLDescribeColODBCVer2(this->stmt);
+  CheckSQLDescribeColODBCVer2(stmt);
 
   // Check date data type
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckSQLGetTypeInfo(this->stmt,
+  CheckSQLGetTypeInfo(stmt,
                       std::wstring(L"date"),  // expected_type_name
                       SQL_DATE,               // expected_data_type
                       10,                     // expected_column_size
@@ -1050,12 +1050,12 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       NULL,   // expected_num_prec_radix
                       NULL);  // expected_interval_prec
 
-  CheckSQLDescribeColODBCVer2(this->stmt);
+  CheckSQLDescribeColODBCVer2(stmt);
 
   // Check time data type
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckSQLGetTypeInfo(this->stmt,
+  CheckSQLGetTypeInfo(stmt,
                       std::wstring(L"time"),  // expected_type_name
                       SQL_TIME,               // expected_data_type
                       8,                      // expected_column_size
@@ -1076,12 +1076,12 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       NULL,   // expected_num_prec_radix
                       NULL);  // expected_interval_prec
 
-  CheckSQLDescribeColODBCVer2(this->stmt);
+  CheckSQLDescribeColODBCVer2(stmt);
 
   // Check timestamp data type
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckSQLGetTypeInfo(this->stmt,
+  CheckSQLGetTypeInfo(stmt,
                       std::wstring(L"timestamp"),  // expected_type_name
                       SQL_TIMESTAMP,               // expected_data_type
                       32,                          // expected_column_size
@@ -1102,16 +1102,16 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       NULL,   // expected_num_prec_radix
                       NULL);  // expected_interval_prec
 
-  CheckSQLDescribeColODBCVer2(this->stmt);
+  CheckSQLDescribeColODBCVer2(stmt);
 }
 
 TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoBit) {
-  ASSERT_EQ(SQL_SUCCESS, SQLGetTypeInfo(this->stmt, SQL_BIT));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetTypeInfo(stmt, SQL_BIT));
 
   // Check bit data type
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckSQLGetTypeInfo(this->stmt,
+  CheckSQLGetTypeInfo(stmt,
                       std::wstring(L"bit"),  // expected_type_name
                       SQL_BIT,               // expected_data_type
                       1,                     // expected_column_size
@@ -1132,19 +1132,19 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoBit) {
                       NULL,                  // expected_num_prec_radix
                       NULL);                 // expected_interval_prec
 
-  CheckSQLDescribeColODBCVer3(this->stmt);
+  CheckSQLDescribeColODBCVer3(stmt);
 
   // No more data
-  ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_NO_DATA, SQLFetch(stmt));
 }
 
 TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoTinyInt) {
-  ASSERT_EQ(SQL_SUCCESS, SQLGetTypeInfo(this->stmt, SQL_TINYINT));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetTypeInfo(stmt, SQL_TINYINT));
 
   // Check tinyint data type
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckSQLGetTypeInfo(this->stmt,
+  CheckSQLGetTypeInfo(stmt,
                       std::wstring(L"tinyint"),  // expected_type_name
                       SQL_TINYINT,               // expected_data_type
                       3,                         // expected_column_size
@@ -1165,19 +1165,19 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoTinyInt) {
                       NULL,                      // expected_num_prec_radix
                       NULL);                     // expected_interval_prec
 
-  CheckSQLDescribeColODBCVer3(this->stmt);
+  CheckSQLDescribeColODBCVer3(stmt);
 
   // No more data
-  ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_NO_DATA, SQLFetch(stmt));
 }
 
 TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoBigInt) {
-  ASSERT_EQ(SQL_SUCCESS, SQLGetTypeInfo(this->stmt, SQL_BIGINT));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetTypeInfo(stmt, SQL_BIGINT));
 
   // Check bigint data type
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckSQLGetTypeInfo(this->stmt,
+  CheckSQLGetTypeInfo(stmt,
                       std::wstring(L"bigint"),  // expected_type_name
                       SQL_BIGINT,               // expected_data_type
                       19,                       // expected_column_size
@@ -1198,19 +1198,19 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoBigInt) {
                       NULL,                     // expected_num_prec_radix
                       NULL);                    // expected_interval_prec
 
-  CheckSQLDescribeColODBCVer3(this->stmt);
+  CheckSQLDescribeColODBCVer3(stmt);
 
   // No more data
-  ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_NO_DATA, SQLFetch(stmt));
 }
 
 TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoLongVarbinary) {
-  ASSERT_EQ(SQL_SUCCESS, SQLGetTypeInfo(this->stmt, SQL_LONGVARBINARY));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetTypeInfo(stmt, SQL_LONGVARBINARY));
 
   // Check longvarbinary data type
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckSQLGetTypeInfo(this->stmt,
+  CheckSQLGetTypeInfo(stmt,
                       std::wstring(L"longvarbinary"),  // expected_type_name
                       SQL_LONGVARBINARY,               // expected_data_type
                       65536,                           // expected_column_size
@@ -1231,19 +1231,19 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoLongVarbinary) {
                       NULL,                            // expected_num_prec_radix
                       NULL);                           // expected_interval_prec
 
-  CheckSQLDescribeColODBCVer3(this->stmt);
+  CheckSQLDescribeColODBCVer3(stmt);
 
   // No more data
-  ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_NO_DATA, SQLFetch(stmt));
 }
 
 TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoVarbinary) {
-  ASSERT_EQ(SQL_SUCCESS, SQLGetTypeInfo(this->stmt, SQL_VARBINARY));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetTypeInfo(stmt, SQL_VARBINARY));
 
   // Check varbinary data type
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckSQLGetTypeInfo(this->stmt,
+  CheckSQLGetTypeInfo(stmt,
                       std::wstring(L"varbinary"),  // expected_type_name
                       SQL_VARBINARY,               // expected_data_type
                       255,                         // expected_column_size
@@ -1265,17 +1265,17 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoVarbinary) {
                       NULL);                       // expected_interval_prec
 
   // No more data
-  ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_NO_DATA, SQLFetch(stmt));
 }
 
 TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoLongVarchar) {
-  ASSERT_EQ(SQL_SUCCESS, SQLGetTypeInfo(this->stmt, SQL_WLONGVARCHAR));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetTypeInfo(stmt, SQL_WLONGVARCHAR));
 
   // Check text data type
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   // Driver returns SQL_WLONGVARCHAR since unicode is enabled
-  CheckSQLGetTypeInfo(this->stmt,
+  CheckSQLGetTypeInfo(stmt,
                       std::wstring(L"text"),    // expected_type_name
                       SQL_WLONGVARCHAR,         // expected_data_type
                       65536,                    // expected_column_size
@@ -1296,12 +1296,12 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoLongVarchar) {
                       NULL,                     // expected_num_prec_radix
                       NULL);                    // expected_interval_prec
 
-  CheckSQLDescribeColODBCVer3(this->stmt);
+  CheckSQLDescribeColODBCVer3(stmt);
 
   // Check longvarchar data type
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckSQLGetTypeInfo(this->stmt,
+  CheckSQLGetTypeInfo(stmt,
                       std::wstring(L"longvarchar"),  // expected_type_name
                       SQL_WLONGVARCHAR,              // expected_data_type
                       65536,                         // expected_column_size
@@ -1322,20 +1322,20 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoLongVarchar) {
                       NULL,                          // expected_num_prec_radix
                       NULL);                         // expected_interval_prec
 
-  CheckSQLDescribeColODBCVer3(this->stmt);
+  CheckSQLDescribeColODBCVer3(stmt);
 
   // No more data
-  ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_NO_DATA, SQLFetch(stmt));
 }
 
 TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoChar) {
-  ASSERT_EQ(SQL_SUCCESS, SQLGetTypeInfo(this->stmt, SQL_WCHAR));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetTypeInfo(stmt, SQL_WCHAR));
 
   // Check char data type
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   // Driver returns SQL_WCHAR since unicode is enabled
-  CheckSQLGetTypeInfo(this->stmt,
+  CheckSQLGetTypeInfo(stmt,
                       std::wstring(L"char"),    // expected_type_name
                       SQL_WCHAR,                // expected_data_type
                       255,                      // expected_column_size
@@ -1356,19 +1356,19 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoChar) {
                       NULL,                     // expected_num_prec_radix
                       NULL);                    // expected_interval_prec
 
-  CheckSQLDescribeColODBCVer3(this->stmt);
+  CheckSQLDescribeColODBCVer3(stmt);
 
   // No more data
-  ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_NO_DATA, SQLFetch(stmt));
 }
 
 TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoInteger) {
-  ASSERT_EQ(SQL_SUCCESS, SQLGetTypeInfo(this->stmt, SQL_INTEGER));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetTypeInfo(stmt, SQL_INTEGER));
 
   // Check integer data type
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckSQLGetTypeInfo(this->stmt,
+  CheckSQLGetTypeInfo(stmt,
                       std::wstring(L"integer"),  // expected_type_name
                       SQL_INTEGER,               // expected_data_type
                       9,                         // expected_column_size
@@ -1389,19 +1389,19 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoInteger) {
                       NULL,                      // expected_num_prec_radix
                       NULL);                     // expected_interval_prec
 
-  CheckSQLDescribeColODBCVer3(this->stmt);
+  CheckSQLDescribeColODBCVer3(stmt);
 
   // No more data
-  ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_NO_DATA, SQLFetch(stmt));
 }
 
 TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoSmallInt) {
-  ASSERT_EQ(SQL_SUCCESS, SQLGetTypeInfo(this->stmt, SQL_SMALLINT));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetTypeInfo(stmt, SQL_SMALLINT));
 
   // Check smallint data type
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckSQLGetTypeInfo(this->stmt,
+  CheckSQLGetTypeInfo(stmt,
                       std::wstring(L"smallint"),  // expected_type_name
                       SQL_SMALLINT,               // expected_data_type
                       5,                          // expected_column_size
@@ -1422,19 +1422,19 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoSmallInt) {
                       NULL,                       // expected_num_prec_radix
                       NULL);                      // expected_interval_prec
 
-  CheckSQLDescribeColODBCVer3(this->stmt);
+  CheckSQLDescribeColODBCVer3(stmt);
 
   // No more data
-  ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_NO_DATA, SQLFetch(stmt));
 }
 
 TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoFloat) {
-  ASSERT_EQ(SQL_SUCCESS, SQLGetTypeInfo(this->stmt, SQL_FLOAT));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetTypeInfo(stmt, SQL_FLOAT));
 
   // Check float data type
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckSQLGetTypeInfo(this->stmt,
+  CheckSQLGetTypeInfo(stmt,
                       std::wstring(L"float"),  // expected_type_name
                       SQL_FLOAT,               // expected_data_type
                       7,                       // expected_column_size
@@ -1455,19 +1455,19 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoFloat) {
                       NULL,                    // expected_num_prec_radix
                       NULL);                   // expected_interval_prec
 
-  CheckSQLDescribeColODBCVer3(this->stmt);
+  CheckSQLDescribeColODBCVer3(stmt);
 
   // No more data
-  ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_NO_DATA, SQLFetch(stmt));
 }
 
 TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoDouble) {
-  ASSERT_EQ(SQL_SUCCESS, SQLGetTypeInfo(this->stmt, SQL_DOUBLE));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetTypeInfo(stmt, SQL_DOUBLE));
 
   // Check double data type
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckSQLGetTypeInfo(this->stmt,
+  CheckSQLGetTypeInfo(stmt,
                       std::wstring(L"double"),  // expected_type_name
                       SQL_DOUBLE,               // expected_data_type
                       15,                       // expected_column_size
@@ -1488,13 +1488,13 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoDouble) {
                       NULL,                     // expected_num_prec_radix
                       NULL);                    // expected_interval_prec
 
-  CheckSQLDescribeColODBCVer3(this->stmt);
+  CheckSQLDescribeColODBCVer3(stmt);
 
   // Check numeric data type
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   // Mock server treats numeric data type as a double type
-  CheckSQLGetTypeInfo(this->stmt,
+  CheckSQLGetTypeInfo(stmt,
                       std::wstring(L"numeric"),  // expected_type_name
                       SQL_DOUBLE,                // expected_data_type
                       15,                        // expected_column_size
@@ -1515,20 +1515,20 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoDouble) {
                       NULL,                      // expected_num_prec_radix
                       NULL);                     // expected_interval_prec
 
-  CheckSQLDescribeColODBCVer3(this->stmt);
+  CheckSQLDescribeColODBCVer3(stmt);
 
   // No more data
-  ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_NO_DATA, SQLFetch(stmt));
 }
 
 TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoVarchar) {
-  ASSERT_EQ(SQL_SUCCESS, SQLGetTypeInfo(this->stmt, SQL_WVARCHAR));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetTypeInfo(stmt, SQL_WVARCHAR));
 
   // Check varchar data type
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   // Driver returns SQL_WVARCHAR since unicode is enabled
-  CheckSQLGetTypeInfo(this->stmt,
+  CheckSQLGetTypeInfo(stmt,
                       std::wstring(L"varchar"),  // expected_type_name
                       SQL_WVARCHAR,              // expected_data_type
                       255,                       // expected_column_size
@@ -1549,19 +1549,19 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoVarchar) {
                       NULL,                      // expected_num_prec_radix
                       NULL);                     // expected_interval_prec
 
-  CheckSQLDescribeColODBCVer3(this->stmt);
+  CheckSQLDescribeColODBCVer3(stmt);
 
   // No more data
-  ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_NO_DATA, SQLFetch(stmt));
 }
 
 TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoSQLTypeDate) {
-  ASSERT_EQ(SQL_SUCCESS, SQLGetTypeInfo(this->stmt, SQL_TYPE_DATE));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetTypeInfo(stmt, SQL_TYPE_DATE));
 
   // Check date data type
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckSQLGetTypeInfo(this->stmt,
+  CheckSQLGetTypeInfo(stmt,
                       std::wstring(L"date"),  // expected_type_name
                       SQL_TYPE_DATE,          // expected_data_type
                       10,                     // expected_column_size
@@ -1582,20 +1582,20 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoSQLTypeDate) {
                       NULL,                   // expected_num_prec_radix
                       NULL);                  // expected_interval_prec
 
-  CheckSQLDescribeColODBCVer3(this->stmt);
+  CheckSQLDescribeColODBCVer3(stmt);
 
   // No more data
-  ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_NO_DATA, SQLFetch(stmt));
 }
 
 TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoSQLDate) {
   // Pass ODBC Ver 2 data type
-  ASSERT_EQ(SQL_SUCCESS, SQLGetTypeInfo(this->stmt, SQL_DATE));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetTypeInfo(stmt, SQL_DATE));
 
   // Check date data type
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckSQLGetTypeInfo(this->stmt,
+  CheckSQLGetTypeInfo(stmt,
                       std::wstring(L"date"),  // expected_type_name
                       SQL_TYPE_DATE,          // expected_data_type
                       10,                     // expected_column_size
@@ -1616,19 +1616,19 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoSQLDate) {
                       NULL,                   // expected_num_prec_radix
                       NULL);                  // expected_interval_prec
 
-  CheckSQLDescribeColODBCVer3(this->stmt);
+  CheckSQLDescribeColODBCVer3(stmt);
 
   // No more data
-  ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_NO_DATA, SQLFetch(stmt));
 }
 
 TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoDateODBCVer2) {
-  ASSERT_EQ(SQL_SUCCESS, SQLGetTypeInfo(this->stmt, SQL_DATE));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetTypeInfo(stmt, SQL_DATE));
 
   // Check date data type
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckSQLGetTypeInfo(this->stmt,
+  CheckSQLGetTypeInfo(stmt,
                       std::wstring(L"date"),  // expected_type_name
                       SQL_DATE,               // expected_data_type
                       10,                     // expected_column_size
@@ -1649,27 +1649,31 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoDateODBCVer2) {
                       NULL,   // expected_num_prec_radix
                       NULL);  // expected_interval_prec
 
-  CheckSQLDescribeColODBCVer2(this->stmt);
+  CheckSQLDescribeColODBCVer2(stmt);
 
   // No more data
-  ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_NO_DATA, SQLFetch(stmt));
 }
 
-TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoSQLTypeDateODBCVer2) {
+TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoSQLTypeDate) {
+#ifdef __APPLE__
+  ASSERT_EQ(SQL_SUCCESS, SQLGetTypeInfo(stmt, SQL_TYPE_DATE));
+#else
   // Pass ODBC Ver 3 data type
-  ASSERT_EQ(SQL_ERROR, SQLGetTypeInfo(this->stmt, SQL_TYPE_DATE));
+  ASSERT_EQ(SQL_ERROR, SQLGetTypeInfo(stmt, SQL_TYPE_DATE));
 
   // Driver manager returns SQL data type out of range error state
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorStateS1004);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorStateS1004);
+#endif  // __APPLE__
 }
 
 TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoSQLTypeTime) {
-  ASSERT_EQ(SQL_SUCCESS, SQLGetTypeInfo(this->stmt, SQL_TYPE_TIME));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetTypeInfo(stmt, SQL_TYPE_TIME));
 
   // Check time data type
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckSQLGetTypeInfo(this->stmt,
+  CheckSQLGetTypeInfo(stmt,
                       std::wstring(L"time"),  // expected_type_name
                       SQL_TYPE_TIME,          // expected_data_type
                       8,                      // expected_column_size
@@ -1690,20 +1694,20 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoSQLTypeTime) {
                       NULL,                   // expected_num_prec_radix
                       NULL);                  // expected_interval_prec
 
-  CheckSQLDescribeColODBCVer3(this->stmt);
+  CheckSQLDescribeColODBCVer3(stmt);
 
   // No more data
-  ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_NO_DATA, SQLFetch(stmt));
 }
 
 TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoSQLTime) {
   // Pass ODBC Ver 2 data type
-  ASSERT_EQ(SQL_SUCCESS, SQLGetTypeInfo(this->stmt, SQL_TIME));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetTypeInfo(stmt, SQL_TIME));
 
   // Check time data type
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckSQLGetTypeInfo(this->stmt,
+  CheckSQLGetTypeInfo(stmt,
                       std::wstring(L"time"),  // expected_type_name
                       SQL_TYPE_TIME,          // expected_data_type
                       8,                      // expected_column_size
@@ -1724,19 +1728,19 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoSQLTime) {
                       NULL,                   // expected_num_prec_radix
                       NULL);                  // expected_interval_prec
 
-  CheckSQLDescribeColODBCVer3(this->stmt);
+  CheckSQLDescribeColODBCVer3(stmt);
 
   // No more data
-  ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_NO_DATA, SQLFetch(stmt));
 }
 
 TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoTimeODBCVer2) {
-  ASSERT_EQ(SQL_SUCCESS, SQLGetTypeInfo(this->stmt, SQL_TIME));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetTypeInfo(stmt, SQL_TIME));
 
   // Check time data type
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckSQLGetTypeInfo(this->stmt,
+  CheckSQLGetTypeInfo(stmt,
                       std::wstring(L"time"),  // expected_type_name
                       SQL_TIME,               // expected_data_type
                       8,                      // expected_column_size
@@ -1757,27 +1761,31 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoTimeODBCVer2) {
                       NULL,   // expected_num_prec_radix
                       NULL);  // expected_interval_prec
 
-  CheckSQLDescribeColODBCVer2(this->stmt);
+  CheckSQLDescribeColODBCVer2(stmt);
 
   // No more data
-  ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_NO_DATA, SQLFetch(stmt));
 }
 
-TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoSQLTypeTimeODBCVer2) {
+TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoSQLTypeTime) {
+#ifdef __APPLE__
+  ASSERT_EQ(SQL_SUCCESS, SQLGetTypeInfo(stmt, SQL_TYPE_DATE));
+#else
   // Pass ODBC Ver 3 data type
-  ASSERT_EQ(SQL_ERROR, SQLGetTypeInfo(this->stmt, SQL_TYPE_TIME));
+  ASSERT_EQ(SQL_ERROR, SQLGetTypeInfo(stmt, SQL_TYPE_TIME));
 
   // Driver manager returns SQL data type out of range error state
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorStateS1004);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorStateS1004);
+#endif  // __APPLE__
 }
 
 TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoSQLTypeTimestamp) {
-  ASSERT_EQ(SQL_SUCCESS, SQLGetTypeInfo(this->stmt, SQL_TYPE_TIMESTAMP));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetTypeInfo(stmt, SQL_TYPE_TIMESTAMP));
 
   // Check timestamp data type
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckSQLGetTypeInfo(this->stmt,
+  CheckSQLGetTypeInfo(stmt,
                       std::wstring(L"timestamp"),  // expected_type_name
                       SQL_TYPE_TIMESTAMP,          // expected_data_type
                       32,                          // expected_column_size
@@ -1798,20 +1806,20 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoSQLTypeTimestamp) {
                       NULL,                        // expected_num_prec_radix
                       NULL);                       // expected_interval_prec
 
-  CheckSQLDescribeColODBCVer3(this->stmt);
+  CheckSQLDescribeColODBCVer3(stmt);
 
   // No more data
-  ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_NO_DATA, SQLFetch(stmt));
 }
 
 TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoSQLTimestamp) {
   // Pass ODBC Ver 2 data type
-  ASSERT_EQ(SQL_SUCCESS, SQLGetTypeInfo(this->stmt, SQL_TIMESTAMP));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetTypeInfo(stmt, SQL_TIMESTAMP));
 
   // Check timestamp data type
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckSQLGetTypeInfo(this->stmt,
+  CheckSQLGetTypeInfo(stmt,
                       std::wstring(L"timestamp"),  // expected_type_name
                       SQL_TYPE_TIMESTAMP,          // expected_data_type
                       32,                          // expected_column_size
@@ -1832,19 +1840,19 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoSQLTimestamp) {
                       NULL,                        // expected_num_prec_radix
                       NULL);                       // expected_interval_prec
 
-  CheckSQLDescribeColODBCVer3(this->stmt);
+  CheckSQLDescribeColODBCVer3(stmt);
 
   // No more data
-  ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_NO_DATA, SQLFetch(stmt));
 }
 
 TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoSQLTimestampODBCVer2) {
-  ASSERT_EQ(SQL_SUCCESS, SQLGetTypeInfo(this->stmt, SQL_TIMESTAMP));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetTypeInfo(stmt, SQL_TIMESTAMP));
 
   // Check timestamp data type
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  CheckSQLGetTypeInfo(this->stmt,
+  CheckSQLGetTypeInfo(stmt,
                       std::wstring(L"timestamp"),  // expected_type_name
                       SQL_TIMESTAMP,               // expected_data_type
                       32,                          // expected_column_size
@@ -1865,33 +1873,37 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoSQLTimestampODBCVer2) {
                       NULL,   // expected_num_prec_radix
                       NULL);  // expected_interval_prec
 
-  CheckSQLDescribeColODBCVer2(this->stmt);
+  CheckSQLDescribeColODBCVer2(stmt);
 
   // No more data
-  ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_NO_DATA, SQLFetch(stmt));
 }
 
-TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoSQLTypeTimestampODBCVer2) {
+TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoSQLTypeTimestamp) {
+#ifdef __APPLE__
+  ASSERT_EQ(SQL_SUCCESS, SQLGetTypeInfo(stmt, SQL_TYPE_TIMESTAMP));
+#else
   // Pass ODBC Ver 3 data type
-  ASSERT_EQ(SQL_ERROR, SQLGetTypeInfo(this->stmt, SQL_TYPE_TIMESTAMP));
+  ASSERT_EQ(SQL_ERROR, SQLGetTypeInfo(stmt, SQL_TYPE_TIMESTAMP));
 
   // Driver manager returns SQL data type out of range error state
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorStateS1004);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorStateS1004);
+#endif  // __APPLE__
 }
 
 TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoInvalidDataType) {
   SQLSMALLINT invalid_data_type = -114;
-  ASSERT_EQ(SQL_ERROR, SQLGetTypeInfo(this->stmt, invalid_data_type));
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorStateHY004);
+  ASSERT_EQ(SQL_ERROR, SQLGetTypeInfo(stmt, invalid_data_type));
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorStateHY004);
 }
 
 TYPED_TEST(TypeInfoTest, TestSQLGetTypeInfoUnsupportedDataType) {
   // Assumes mock and remote server don't support GUID data type
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetTypeInfo(this->stmt, SQL_GUID));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetTypeInfo(stmt, SQL_GUID));
 
   // Result set is empty with valid data type that is unsupported by the server
-  ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
+  ASSERT_EQ(SQL_NO_DATA, SQLFetch(stmt));
 }
 
 }  // namespace arrow::flight::sql::odbc


### PR DESCRIPTION
### Rationale for this change
Addresses https://github.com/apache/arrow/issues/49268

### What changes are included in this PR?
- Fixed Mock Server setup to work on both Windows and MacOS.
- Changed Mocker Server setup logic to happen once at the Test Environment level.
- Changed test connect/disconnect logic to happen once per test fixture instead of once per test.
- Disabled tests that are not appliable to MacOS (usually because iODBC doesn't support the relevant functionality).
- Adjusted expected SQL States where different on Mac.
- Fixed any tests failing on MacOS.

### Are these changes tested?
Yes.

### Are there any user-facing changes?
No.
* GitHub Issue: #49268