### PR TITLE
GH-49255: Fix pandas deprecation warnings in Categorical tests

### DIFF
--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -3069,15 +3069,19 @@ class TestConvertMisc:
         v2 = [4, 5, 6, 7, 8]
         v3 = [b'foo', None, b'bar', b'qux', np.nan]
 
+        cat_strings = pd.Categorical(v1 * repeats)
+        cat_strings_with_na = cat_strings.set_categories(['foo', 'bar'])
+
+        cat_strings_ordered = pd.Categorical(
+            v1 * repeats, categories=['bar', 'qux', 'foo'], ordered=True
+        )
+
         arrays = {
-            'cat_strings': pd.Categorical(v1 * repeats),
-            'cat_strings_with_na': pd.Categorical(v1 * repeats,
-                                                  categories=['foo', 'bar']),
+            'cat_strings': cat_strings,
+            'cat_strings_with_na': cat_strings_with_na,
             'cat_ints': pd.Categorical(v2 * repeats),
             'cat_binary': pd.Categorical(v3 * repeats),
-            'cat_strings_ordered': pd.Categorical(
-                v1 * repeats, categories=['bar', 'qux', 'foo'],
-                ordered=True),
+            'cat_strings_ordered': cat_strings_ordered,
             'ints': v2 * repeats,
             'ints2': v2 * repeats,
             'strings': v1 * repeats,
@@ -3096,10 +3100,10 @@ class TestConvertMisc:
             result = arr.to_pandas()
             tm.assert_series_equal(pd.Series(result), pd.Series(v))
 
+        base = pd.Categorical(['a', 'b', 'c'])
         arrays = [
-            pd.Categorical(['a', 'b', 'c'], categories=['a', 'b']),
-            pd.Categorical(['a', 'b', 'c'], categories=['a', 'b'],
-                           ordered=True)
+            base.set_categories(['a', 'b']),
+            base.set_categories(['a', 'b']).as_ordered(),
         ]
         for arr in arrays:
             _check(arr)


### PR DESCRIPTION
Fixes the pandas deprecation warnings we're seeing in the test suite.

## What was happening
Pandas started warning when you create a `Categorical` with values that aren't in the categories list. We had a few places in the tests doing this:

- `test_category`: Creating `cat_strings_with_na` with categories `['foo', 'bar']` but the data includes `'qux'`
- `test_category_implicit_from_pandas`: Two places creating Categoricals with `['a', 'b', 'c']` but only allowing `['a', 'b']` in categories

## What I changed
Instead of passing `categories` directly to `pd.Categorical()`, I:
1. Create the Categorical first with all the values
2. Then use `.set_categories()` to restrict it to what we want

This is the recommended way to do it and avoids the warnings.

## Testing
- Tests still pass (functionality unchanged)
- No more deprecation warnings
- No linter errors

Fixes #49255

* GitHub Issue: #49255