### PR TITLE
GH-49275: [Doc] Update docs to specify disclosure of AI on mailing list messages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,11 @@ publicly on the [arrow-dev mailing-list](https://mail-archives.apache.org/mod_mb
 
 You can also ask on the mailing-list, see above.
 
+## Are you using AI coding tools?
+
+Please review our [AI-generated code guidance](https://arrow.apache.org/docs/dev/developers/overview.html#ai-generated-code)
+before submitting AI-assisted contributions.
+
 ## Further information
 
 Please read our [development documentation](https://arrow.apache.org/docs/developers/index.html)

--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ on git main.
 
 Please read our latest [project contribution guide][4].
 
+If you are using AI coding tools, please review our
+[AI-generated code guidance][7].
+
 ## Getting involved
 
 Even if you do not plan to contribute to Apache Arrow itself or Arrow
@@ -114,3 +117,4 @@ We use [AWS][6] for some of the required infrastructure for the project.
 [4]: https://arrow.apache.org/docs/dev/developers/index.html
 [5]: https://runs-on.com/
 [6]: https://aws.amazon.com/
+[7]: https://arrow.apache.org/docs/dev/developers/overview.html#ai-generated-code

--- a/docs/source/developers/guide/communication.rst
+++ b/docs/source/developers/guide/communication.rst
@@ -120,10 +120,9 @@ It is announced on the development mailing list together with the link to join.
   More information and links for subscribing to the mailing lists `can be found here <https://arrow.apache.org/community/>`_.
 
 .. note::
-   Using AI tools to help with phrasing or grammar is fine and doesn't need to be
-   disclosed. However, if AI is more involved in your workflow (e.g. generating
-   questions or diagnosing errors), please let us know so we can tailor our
-   responses appropriately.
+   Using AI tools to help with phrasing or grammar is fine. However, please don't
+   use AI to generate questions on your behalf - we want to help you, not your
+   AI assistant.
 
 Recommended learning resources
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/developers/guide/communication.rst
+++ b/docs/source/developers/guide/communication.rst
@@ -119,6 +119,12 @@ It is announced on the development mailing list together with the link to join.
 .. seealso::
   More information and links for subscribing to the mailing lists `can be found here <https://arrow.apache.org/community/>`_.
 
+.. note::
+   Using AI tools to help with phrasing or grammar is fine and doesn't need to be
+   disclosed. However, if AI is more involved in your workflow (e.g. generating
+   questions or diagnosing errors), please let us know so we can tailor our
+   responses appropriately.
+
 Recommended learning resources
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/developers/guide/communication.rst
+++ b/docs/source/developers/guide/communication.rst
@@ -120,9 +120,9 @@ It is announced on the development mailing list together with the link to join.
   More information and links for subscribing to the mailing lists `can be found here <https://arrow.apache.org/community/>`_.
 
 .. note::
-   Using AI tools to help with phrasing or grammar is fine. However, please don't
-   use AI to generate questions on your behalf - we want to help you, not your
-   AI assistant.
+   Using AI tools to help with phrasing or grammar is absolutely fine. However,
+   we'd love to hear from *you* rather than your AI assistant - please don't
+   use AI to generate questions or comments on your behalf.
 
 Recommended learning resources
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/developers/overview.rst
+++ b/docs/source/developers/overview.rst
@@ -179,6 +179,9 @@ the following:
 * Watch for AI's tendency to generate overly verbose comments, unnecessary
   test cases, and incorrect fixes
 * Break down large PRs into smaller ones to make review easier
+* Avoid pinging maintainers to request reviews; most maintainers have
+  limited time, and we will review PRs as bandwidth allows. AI agents
+  should never tag or ping maintainers.
 
 PR authors are also responsible for disclosing any copyrighted materials in
 submitted contributions. See the `ASF's guidance on AI-generated code

--- a/docs/source/developers/overview.rst
+++ b/docs/source/developers/overview.rst
@@ -179,9 +179,7 @@ the following:
 * Watch for AI's tendency to generate overly verbose comments, unnecessary
   test cases, and incorrect fixes
 * Break down large PRs into smaller ones to make review easier
-* Avoid pinging maintainers to request reviews; most maintainers have
-  limited time, and we will review PRs as bandwidth allows. AI agents
-  should never tag or ping maintainers.
+* AI agents should never tag or ping maintainers
 
 PR authors are also responsible for disclosing any copyrighted materials in
 submitted contributions. See the `ASF's guidance on AI-generated code


### PR DESCRIPTION
### Rationale for this change

Replying to AI on the mailing list is annoying

### What changes are included in this PR?

Specify people should disclose

### Are these changes tested?

Nah

### Are there any user-facing changes?

Just docs
* GitHub Issue: #49275