### PR TITLE
GH-49283: [C++][FlightRPC] Add separate release & debug workflows for MacOS ODBC

### DIFF
--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -338,7 +338,7 @@ jobs:
 
   odbc-macos:
     needs: check-labels
-    name: ODBC ${{ matrix.architecture }} macOS ${{ matrix.macos-version }}
+    name: ODBC ${{ matrix.build-type }} ${{ matrix.architecture }} macOS ${{ matrix.macos-version }}
     runs-on: macos-${{ matrix.macos-version }}
     if: >-
       needs.check-labels.outputs.force == 'true' ||
@@ -349,12 +349,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - architecture: AMD64
-            macos-version: "15-intel"
-          - architecture: ARM64
-            macos-version: "14"
+          - { architecture: AMD64, macos-version: "15-intel", build-type : debug }
+          - { architecture: AMD64, macos-version: "15-intel", build-type : release }
+          - { architecture: ARM64, macos-version: "14", build-type : debug }
+          - { architecture: ARM64, macos-version: "14", build-type : release }
     env:
       ARROW_BUILD_TESTS: ON
+      ARROW_BUILD_TYPE: ${{ matrix.build-type }}
       ARROW_DEPENDENCY_SOURCE: BUNDLED
       ARROW_DEPENDENCY_USE_SHARED: OFF
       ARROW_FLIGHT_SQL_ODBC: ON
@@ -396,8 +397,8 @@ jobs:
         uses: actions/cache@v5.0.2
         with:
           path: ${{ steps.ccache-info.outputs.cache-dir }}
-          key: cpp-odbc-ccache-macos-${{ matrix.macos-version }}-${{ hashFiles('cpp/**') }}
-          restore-keys: cpp-odbc-ccache-macos-${{ matrix.macos-version }}-
+          key: cpp-odbc-ccache-macos-${{ matrix.macos-version }}-${{ matrix.build-type }}-${{ hashFiles('cpp/**') }}
+          restore-keys: cpp-odbc-ccache-macos-${{ matrix.macos-version }}-${{ matrix.build-type }}-
       - name: Build
         run: |
           # Homebrew uses /usr/local as prefix. So packages
@@ -431,10 +432,10 @@ jobs:
             --allow libiconv \
             --allow libresolv \
             --allow libz \
-            "$(pwd)/build/cpp/debug/libarrow_flight_sql_odbc.dylib"
+            "$(pwd)/build/cpp/${{ matrix.build-type }}/libarrow_flight_sql_odbc.dylib"
       - name: Register Flight SQL ODBC Driver
         run: |
-          sudo cpp/src/arrow/flight/sql/odbc/install/mac/install_odbc.sh $(pwd)/build/cpp/debug/libarrow_flight_sql_odbc.dylib
+          sudo cpp/src/arrow/flight/sql/odbc/install/mac/install_odbc.sh $(pwd)/build/cpp/${{ matrix.build-type }}/libarrow_flight_sql_odbc.dylib
       - name: Test
         shell: bash
         run: |


### PR DESCRIPTION
### Rationale for this change
Addresses https://github.com/apache/arrow/issues/49283

### What changes are included in this PR
The ODBC MacOS workflows now have release and debug workflows.

### Are these changes tested?
Yes.

### Are there any user-facing changes?
No.
* GitHub Issue: #49283