### PR TITLE
GH-49285: [Python] Add `buffer` parameter to `RecordBatch.serialize()`

### DIFF
--- a/python/pyarrow/includes/libarrow.pxd
+++ b/python/pyarrow/includes/libarrow.pxd
@@ -2007,6 +2007,8 @@ cdef extern from "arrow/ipc/api.h" namespace "arrow::ipc" nogil:
                                               CMemoryPool* pool)
 
     CStatus GetRecordBatchSize(const CRecordBatch& batch, int64_t* size)
+    CStatus GetRecordBatchSize(const CRecordBatch& batch,
+                               const CIpcWriteOptions& options, int64_t* size)
     CStatus GetTensorSize(const CTensor& tensor, int64_t* size)
 
     CStatus WriteTensor(const CTensor& tensor, COutputStream* dst,
@@ -2025,6 +2027,10 @@ cdef extern from "arrow/ipc/api.h" namespace "arrow::ipc" nogil:
 
     CResult[shared_ptr[CBuffer]] SerializeRecordBatch(
         const CRecordBatch& schema, const CIpcWriteOptions& options)
+
+    CStatus SerializeRecordBatch(const CRecordBatch& batch,
+                                 const CIpcWriteOptions& options,
+                                 COutputStream* out)
 
     CResult[shared_ptr[CSchema]] ReadSchema(const CMessage& message,
                                             CDictionaryMemo* dictionary_memo)


### PR DESCRIPTION
When serializing many `RecordBatch` objects in a hot loop (e.g. streaming IPC to a socket, writing to shared memory), `RecordBatch.serialize()` allocates a new buffer on every call. This creates unnecessary allocation pressure when the caller already knows the required size and could reuse a single buffer across calls.

### What changes are included in this PR?

Add an optional `buffer` parameter to `RecordBatch.serialize()`. When provided, the method serializes directly into the pre-allocated buffer instead of allocating a new one, and returns a zero-copy slice with the exact serialized size.

Changes:
- **`pyarrow/includes/libarrow.pxd`** — Add Cython declarations for `GetRecordBatchSize(batch, options, &size)` and `SerializeRecordBatch(batch, options, out)` overloads
- **`pyarrow/table.pxi`** — Add `buffer` parameter to `RecordBatch.serialize()` with size validation and mutability checks
- **`pyarrow/tests/test_ipc.py`** — Add tests for round-trip correctness, oversized buffers, exact-size buffers, too-small buffers, and immutable buffers

### Are these changes tested?

Yes. New test `test_serialize_record_batch_to_buffer` covers all cases.

### Are there any user-facing changes?

Yes. `RecordBatch.serialize()` now accepts an optional `buffer` keyword argument.

**AI Use Disclosure: I did use Claude to make this PR but I reviewed the code and stand behind its changes and tests.**

* GitHub Issue: #49285