### PR TITLE
GH-49272: [C++][CI] Fix intermittent segfault in arrow-json-test on M…

### DIFF
--- a/cpp/src/arrow/json/reader_test.cc
+++ b/cpp/src/arrow/json/reader_test.cc
@@ -290,6 +290,32 @@ TEST(ReaderTest, MultipleChunksParallel) {
   AssertTablesEqual(*serial, *threaded);
 }
 
+// Stress test for intermittent threading crashes on MinGW.
+// See https://github.com/apache/arrow/issues/49272
+TEST(ReaderTest, MultipleChunksParallelStress) {
+  constexpr int kTrials = 20;
+  for (int trial = 0; trial < kTrials; ++trial) {
+    int64_t count = 1 << 10;
+    ParseOptions parse_options;
+    parse_options.unexpected_field_behavior = UnexpectedFieldBehavior::InferType;
+    ReadOptions read_options;
+    read_options.block_size = static_cast<int>(count / 2);
+    read_options.use_threads = true;
+
+    std::string json;
+    for (int i = 0; i < count; ++i) {
+      json += "{\"a\":" + std::to_string(i) + "}\n";
+    }
+
+    std::shared_ptr<io::InputStream> input;
+    ASSERT_OK(MakeStream(json, &input));
+    ASSERT_OK_AND_ASSIGN(auto reader, TableReader::Make(default_memory_pool(), input,
+                                                        read_options, parse_options));
+    ASSERT_OK_AND_ASSIGN(auto table, reader->Read());
+    ASSERT_EQ(table->num_rows(), count);
+  }
+}
+
 TEST(ReaderTest, ListArrayWithFewValues) {
   // ARROW-7647
   ParseOptions parse_options;

--- a/cpp/src/arrow/util/thread_pool.cc
+++ b/cpp/src/arrow/util/thread_pool.cc
@@ -26,6 +26,10 @@
 #include <thread>
 #include <vector>
 
+#if defined(__MINGW32__) || defined(__MINGW64__)
+#  include "arrow/util/windows_compatibility.h"
+#endif
+
 #include "arrow/util/atfork_internal.h"
 #include "arrow/util/config.h"
 #include "arrow/util/io_util.h"
@@ -630,9 +634,39 @@ void ThreadPool::CollectFinishedWorkersUnlocked() {
   state_->finished_workers_.clear();
 }
 
+// MinGW's __emutls implementation for C++ thread_local has known race conditions
+// during thread creation that can cause segfaults. Use native Win32 TLS instead.
+// See https://github.com/apache/arrow/issues/49272
+#  if defined(__MINGW32__) || defined(__MINGW64__)
+
+namespace {
+DWORD GetPoolTlsIndex() {
+  static DWORD index = [] {
+    DWORD i = TlsAlloc();
+    if (i == TLS_OUT_OF_INDEXES) {
+      ARROW_LOG(FATAL) << "TlsAlloc failed for thread pool TLS";
+    }
+    return i;
+  }();
+  return index;
+}
+}  // namespace
+
+static ThreadPool* GetCurrentThreadPool() {
+  return static_cast<ThreadPool*>(TlsGetValue(GetPoolTlsIndex()));
+}
+
+static void SetCurrentThreadPool(ThreadPool* pool) {
+  TlsSetValue(GetPoolTlsIndex(), pool);
+}
+#  else
 thread_local ThreadPool* current_thread_pool_ = nullptr;
 
-bool ThreadPool::OwnsThisThread() { return current_thread_pool_ == this; }
+static ThreadPool* GetCurrentThreadPool() { return current_thread_pool_; }
+static void SetCurrentThreadPool(ThreadPool* pool) { current_thread_pool_ = pool; }
+#  endif
+
+bool ThreadPool::OwnsThisThread() { return GetCurrentThreadPool() == this; }
 
 void ThreadPool::LaunchWorkersUnlocked(int threads) {
   std::shared_ptr<State> state = sp_state_;
@@ -641,7 +675,7 @@ void ThreadPool::LaunchWorkersUnlocked(int threads) {
     state_->workers_.emplace_back();
     auto it = --(state_->workers_.end());
     *it = std::thread([this, state, it] {
-      current_thread_pool_ = this;
+      SetCurrentThreadPool(this);
       WorkerLoop(state, it);
     });
   }


### PR DESCRIPTION
### Rationale for this change

The `arrow-json-test` intermittently segfaults on AMD64 Windows MinGW CI (both CLANG64 and MINGW64 environments), causing false CI failures. The crash occurs at 0.03-0.07 seconds into test execution during the first parallel test (`ReaderTest.MultipleChunksParallel`). See #49272.

The root cause is MinGW's `__emutls` implementation for C++ `thread_local`, which has known race conditions during thread creation. When `ThreadPool::LaunchWorkersUnlocked` creates a new worker thread, the thread immediately writes to the `thread_local ThreadPool* current_thread_pool_` variable. If `__emutls` hasn't finished initializing TLS for the new thread, this dereferences an invalid pointer, causing a segfault.

### What changes are included in this PR?

1. **Replace `thread_local` with native Win32 TLS API on MinGW** (`thread_pool.cc`): Uses `TlsAlloc`/`TlsGetValue`/`TlsSetValue` instead of `thread_local` on MinGW to bypass the buggy `__emutls` emulation. Non-MinGW platforms are unchanged.

2. **Strengthen atomic memory ordering in `ThreadedTaskGroup`** (`task_group.cc`): Changed `nremaining_` operations from `memory_order_acquire`/`memory_order_release` to `memory_order_acq_rel` as defensive hardening. This is zero-cost on x86.

3. **Add SEH crash handler for MinGW test builds** (`reader_test.cc`): Logs the exception code and address on crash, providing better debugging info if segfaults recur.

4. **Add `MultipleChunksParallelStress` test** (`reader_test.cc`): Runs parallel JSON reading 20 times to help expose intermittent threading races.

### Are these changes tested?

Yes. A new stress test (`ReaderTest.MultipleChunksParallelStress`) is added that repeatedly exercises the parallel JSON reading path. The existing `ReaderTest.MultipleChunksParallel` and `AsyncStreamingReaderTest.AsyncReentrancy` tests also cover the affected code paths.

### Are there any user-facing changes?

No.

**This PR contains a "Critical Fix".** The changes fix a bug that causes a crash (segfault) in `arrow-json-test` on MinGW Windows CI due to a race condition in MinGW's `__emutls` thread-local storage emulation during thread pool worker creation.

* GitHub Issue: #49272