### PR TITLE
GH-49169: [C++] Add ApplicationId to AzureFileSystem for SDK calls

### DIFF
--- a/cpp/src/arrow/filesystem/azurefs.cc
+++ b/cpp/src/arrow/filesystem/azurefs.cc
@@ -304,6 +304,10 @@ Status ExceptionToStatus(const Azure::Core::RequestFailedException& exception,
   return Status::IOError(std::forward<PrefixArgs>(prefix_args)..., " Azure Error: [",
                          exception.ErrorCode, "] ", exception.what());
 }
+
+std::string BuildApplicationId() {
+  return "azpartner-arrow/" + GetBuildInfo().version_string;
+}
 }  // namespace
 
 std::string AzureOptions::AccountBlobUrl(const std::string& account_name) const {
@@ -388,8 +392,7 @@ Result<std::unique_ptr<Blobs::BlobServiceClient>> AzureOptions::MakeBlobServiceC
                            blob_storage_scheme);
   }
   Blobs::BlobClientOptions client_options;
-  client_options.Telemetry.ApplicationId =
-      "azpartner-arrow/" + GetBuildInfo().version_string;
+  client_options.Telemetry.ApplicationId = BuildApplicationId();
   switch (credential_kind_) {
     case CredentialKind::kAnonymous:
       return std::make_unique<Blobs::BlobServiceClient>(AccountBlobUrl(account_name),
@@ -426,8 +429,7 @@ AzureOptions::MakeDataLakeServiceClient() const {
                            dfs_storage_scheme);
   }
   DataLake::DataLakeClientOptions client_options;
-  client_options.Telemetry.ApplicationId =
-      "azpartner-arrow/" + GetBuildInfo().version_string;
+  client_options.Telemetry.ApplicationId = BuildApplicationId();
   switch (credential_kind_) {
     case CredentialKind::kAnonymous:
       return std::make_unique<DataLake::DataLakeServiceClient>(


### PR DESCRIPTION
### Rationale for this change
After discussion in #49169, this PR will add a unique identifier to the AzureFileSystem implementation to distinguish calls from the base Azure C++ SDK.

### What changes are included in this PR?
This PR adds `azpartner-arrow/{verion}` as the ApplicationId used by AzureFileSystem.

### Are these changes tested?
The change has been manually validated. I'm happy to add a test for its persistence, but I wasn't sure what level you'd like to see in Arrow. This is effectively just plumbing a string to the SDK. The ApplicationId functionality is validated in the SDK test suite.

### Are there any user-facing changes?
This shouldn't be user facing. Only a user-agent update for the underlying SDK.
* GitHub Issue: #49169