### PR TITLE
GH-49302: [Python][Doc] Incorrect parameter descriptions in SparseCSCMatrix.from_numpy

### DIFF
--- a/python/pyarrow/tensor.pxi
+++ b/python/pyarrow/tensor.pxi
@@ -984,10 +984,10 @@ shape: {self.shape}"""
         data : numpy.ndarray
             Data used to populate the sparse matrix.
         indptr : numpy.ndarray
-            Range of the rows,
-            The i-th row spans from `indptr[i]` to `indptr[i+1]` in the data.
+            Range of the columns,
+            The i-th column spans from `indptr[i]` to `indptr[i+1]` in the data.
         indices : numpy.ndarray
-            Column indices of the corresponding non-zero values.
+            Row indices of the corresponding non-zero values.
         shape : tuple
             Shape of the matrix.
         dim_names : list, optional


### PR DESCRIPTION
### Rationale for this change

The docstring for `SparseCSCMatrix.from_numpy` in `python/pyarrow/tensor.pxi` has incorrect parameter descriptions:

https://github.com/apache/arrow/blob/111495870686ef269254232b876de3aee2f919b6/python/pyarrow/tensor.pxi#L978-L995

- `indptr` is described as "Range of the rows" but should be "Range of the columns"
- `indices` is described as "Column indices" but should be "Row indices"

### What changes are included in this PR?

Fix parameter descriptions in SparseCSCMatrix.from_numpy in python/pyarrow/tensor.pxi:

* indptr: "Range of the rows" → "Range of the columns"
* indices: "Column indices" → "Row indices"

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.

* GitHub Issue: #49302