### PR TITLE
GH-49316: [Ruby] Add support for auto dependency install for red-arrow on macOS

### DIFF
--- a/ruby/red-arrow/red-arrow.gemspec
+++ b/ruby/red-arrow/red-arrow.gemspec
@@ -98,6 +98,8 @@ Gem::Specification.new do |spec|
 
       ["fedora", "libarrow-glib-devel"],
 
+      ["homebrew", "apache-arrow-glib"],
+
       # Try without additional repository
       ["rhel", "arrow-glib-devel"],
       # Retry with additional repository


### PR DESCRIPTION
### Rationale for this change

If `gem install red-arrow` installs Apache Arrow GLib automatically, it's convenient for users.

### What changes are included in this PR?

Add a rubygems-requirements-system configuration for Homebrew.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #49316