### PR TITLE
GH-49318: [Ruby] Ensure using extpp 0.1.2 or later

### DIFF
--- a/ruby/red-arrow/red-arrow.gemspec
+++ b/ruby/red-arrow/red-arrow.gemspec
@@ -58,7 +58,7 @@ Gem::Specification.new do |spec|
     spec.requirements << "jar org.apache.arrow, arrow-vector, #{spec.version}"
     spec.requirements << "jar org.apache.arrow, arrow-memory-netty, #{spec.version}"
   else
-    spec.add_runtime_dependency("extpp", ">= 0.1.1")
+    spec.add_runtime_dependency("extpp", ">= 0.1.2")
     spec.add_runtime_dependency("gio2", ">= 4.2.3")
     spec.add_runtime_dependency("pkg-config")
 


### PR DESCRIPTION
### Rationale for this change

extpp 0.1.2 includes C++20 support.

### What changes are included in this PR?

Update required version information of extpp dependency.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #49318