### PR TITLE
GH-39600: [R] Add trademark attribution to pkgdown site footer

### DIFF
--- a/r/_pkgdown.yml
+++ b/r/_pkgdown.yml
@@ -363,7 +363,7 @@ repo:
 footer:
   structure:
     left: older_versions
-    right: built_with
+    right: [built_with, legal]
   components:
     older_versions: |
       [Older versions of these docs](https://arrow.apache.org/docs/r/versions.html)

--- a/r/_pkgdown.yml
+++ b/r/_pkgdown.yml
@@ -365,4 +365,6 @@ footer:
     left: older_versions
     right: built_with
   components:
-    older_versions: "[Older versions of these docs](https://arrow.apache.org/docs/r/versions.html)"
+    older_versions: |
+      [Older versions of these docs](https://arrow.apache.org/docs/r/versions.html)
+      <br><small>Apache Arrow, Arrow, Apache, the Apache logo, and the Apache Arrow project logo are either registered trademarks or trademarks of The Apache Software Foundation in the United States and other countries.</small>

--- a/r/_pkgdown.yml
+++ b/r/_pkgdown.yml
@@ -365,6 +365,6 @@ footer:
     left: older_versions
     right: [built_with, legal]
   components:
-    older_versions: |
-      [Older versions of these docs](https://arrow.apache.org/docs/r/versions.html)
-      <br><small>Apache Arrow, Arrow, Apache, the Apache logo, and the Apache Arrow project logo are either registered trademarks or trademarks of The Apache Software Foundation in the United States and other countries.</small>
+    older_versions: "[Older versions of these docs](https://arrow.apache.org/docs/r/versions.html)"
+    legal: |
+      <small>Apache Arrow, Arrow, Apache, the Apache logo, and the Apache Arrow project logo are either registered trademarks or trademarks of The Apache Software Foundation in the United States and other countries.</small>

--- a/r/pkgdown/extra.css
+++ b/r/pkgdown/extra.css
@@ -14,3 +14,8 @@
 #search-input::placeholder {
   color: #d9d9d9;
 }
+
+/* Add bottom padding to footer to prevent Kapa AI widget from overlaying content */
+footer {
+  padding-bottom: 80px;
+}


### PR DESCRIPTION
### Rationale for this change

Per ASF policy, documentation pages should include trademark attribution in the footer. See #39461 for the broader effort.

### What changes are included in this PR?

Add Apache trademark attribution text to the R pkgdown site footer.

### Are these changes tested?

Documentation only. Can verify by building pkgdown site locally.

### Are there any user-facing changes?

Footer now includes trademark text matching the main Arrow website.

---

This PR was generated by Claude. All outputs were reviewed and confirmed before pushing.

* GitHub Issue: #39600