### PR TITLE
GH-48145: [R] Update to testthat 3.3.0 and use its expect_r6_class()

### DIFF
--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -68,7 +68,7 @@ Suggests:
     stringi,
     stringr,
     sys,
-    testthat (>= 3.1.0),
+    testthat (>= 3.3.0),
     tibble,
     tzdb,
     withr

--- a/r/tests/testthat/helper-expectation.R
+++ b/r/tests/testthat/helper-expectation.R
@@ -24,11 +24,6 @@ expect_equal_data_frame <- function(x, y, ...) {
   expect_equal(as.data.frame(x), as.data.frame(y), ...)
 }
 
-expect_r6_class <- function(object, class) {
-  expect_s3_class(object, class)
-  expect_s3_class(object, "R6")
-}
-
 #' Mask `testthat::expect_equal()` in order to compare ArrowObjects using their
 #' `Equals` methods from the C++ library.
 expect_equal <- function(object, expected, ignore_attr = FALSE, ..., info = NULL, label = NULL) {

--- a/r/tests/testthat/test-Array.R
+++ b/r/tests/testthat/test-Array.R
@@ -332,7 +332,7 @@ test_that("Timezone handling in Arrow roundtrip (ARROW-3543)", {
   )
   if (!identical(Sys.timezone(), "Pacific/Marquesas")) {
     # Confirming that the columns are in fact different
-    expect_false(any(df$no_tz == df$yes_tz))
+    expect_all_false(df$no_tz == df$yes_tz)
   }
   feather_file <- tempfile()
   on.exit(unlink(feather_file))

--- a/r/tests/testthat/test-RecordBatch.R
+++ b/r/tests/testthat/test-RecordBatch.R
@@ -204,7 +204,7 @@ test_that("[[<- assignment", {
   # can use $
   batch$new <- NULL
   expect_null(as.vector(batch$new))
-  expect_shape(batch, nrow = 10L, ncol = 4L)
+  expect_shape(batch, dim = c(10L, 4L))
 
   batch$int <- 1:10
   expect_as_vector(batch$int, 1:10)
@@ -328,7 +328,7 @@ test_that("record_batch(schema=) does some basic consistency checking of the sch
 
 test_that("RecordBatch dim() and nrow() (ARROW-3816)", {
   batch <- record_batch(x = 1:10, y = 1:10)
-  expect_shape(batch, nrow = 10L, ncol = 2L)
+  expect_shape(batch, dim = c(10L, 2L))
 })
 
 test_that("record_batch() handles Array", {

--- a/r/tests/testthat/test-RecordBatch.R
+++ b/r/tests/testthat/test-RecordBatch.R
@@ -204,7 +204,7 @@ test_that("[[<- assignment", {
   # can use $
   batch$new <- NULL
   expect_null(as.vector(batch$new))
-  expect_identical(dim(batch), c(10L, 4L))
+  expect_shape(batch, nrow = 10L, ncol = 4L)
 
   batch$int <- 1:10
   expect_as_vector(batch$int, 1:10)
@@ -328,8 +328,7 @@ test_that("record_batch(schema=) does some basic consistency checking of the sch
 
 test_that("RecordBatch dim() and nrow() (ARROW-3816)", {
   batch <- record_batch(x = 1:10, y = 1:10)
-  expect_equal(dim(batch), c(10L, 2L))
-  expect_equal(nrow(batch), 10L)
+  expect_shape(batch, nrow = 10L, ncol = 2L)
 })
 
 test_that("record_batch() handles Array", {

--- a/r/tests/testthat/test-Table.R
+++ b/r/tests/testthat/test-Table.R
@@ -144,7 +144,7 @@ test_that("[[<- assignment", {
   # can use $
   tab$new <- NULL
   expect_null(as.vector(tab$new))
-  expect_shape(tab, nrow = 10L, ncol = 4L)
+  expect_shape(tab, dim = c(10L, 4L))
 
   tab$int <- 1:10
   expect_as_vector(tab$int, 1:10)

--- a/r/tests/testthat/test-Table.R
+++ b/r/tests/testthat/test-Table.R
@@ -144,7 +144,7 @@ test_that("[[<- assignment", {
   # can use $
   tab$new <- NULL
   expect_null(as.vector(tab$new))
-  expect_identical(dim(tab), c(10L, 4L))
+  expect_shape(tab, nrow = 10L, ncol = 4L)
 
   tab$int <- 1:10
   expect_as_vector(tab$int, 1:10)

--- a/r/tests/testthat/test-chunked-array.R
+++ b/r/tests/testthat/test-chunked-array.R
@@ -391,9 +391,7 @@ test_that("ChunkedArray$View() (ARROW-6542)", {
   b <- a$View(float32())
   expect_equal(b$type, float32())
   expect_equal(length(b), 7L)
-  expect_true(all(
-    sapply(b$chunks, function(.x) .x$type == float32())
-  ))
+  expect_all_true(sapply(b$chunks, function(.x) .x$type == float32()))
   # Input validation
   expect_error(a$View("not a type"), "type must be a DataType, not character")
 })

--- a/r/tests/testthat/test-compute-aggregate.R
+++ b/r/tests/testthat/test-compute-aggregate.R
@@ -20,7 +20,7 @@ test_that("list_compute_functions", {
   expect_false(all(grepl("min", allfuncs)))
   justmins <- list_compute_functions("^min")
   expect_true(length(justmins) > 0)
-  expect_true(all(grepl("min", justmins)))
+  expect_all_true(grepl("min", justmins))
   no_hash_funcs <- list_compute_functions("^hash")
   expect_true(length(no_hash_funcs) == 0)
 })

--- a/r/tests/testthat/test-compute-no-bindings.R
+++ b/r/tests/testthat/test-compute-no-bindings.R
@@ -127,8 +127,8 @@ test_that("non-bound compute kernels using PartitionNthOptions", {
   )
   # Order of indices on either side of the pivot is not deterministic
   # (depends on C++ standard library implementation)
-  expect_true(all(as.vector(result[1:3]) < 3))
-  expect_true(all(as.vector(result[4:10]) >= 3))
+  expect_all_true(as.vector(result[1:3]) < 3)
+  expect_all_true(as.vector(result[4:10]) >= 3)
 })
 
 

--- a/r/tests/testthat/test-dataset.R
+++ b/r/tests/testthat/test-dataset.R
@@ -51,7 +51,7 @@ test_that("IPC/Feather format data", {
   expect_r6_class(ds$format, "IpcFileFormat")
   expect_r6_class(ds$filesystem, "LocalFileSystem")
   expect_named(ds, c(names(df1), "part"))
-  expect_identical(dim(ds), c(20L, 7L))
+  expect_shape(ds, nrow = 20L, ncol = 7L)
 
   expect_equal(
     ds |>
@@ -370,12 +370,12 @@ test_that("Can set schema on dataset", {
 
 test_that("as.data.frame.Dataset", {
   ds <- open_dataset(dataset_dir, partitioning = schema(part = uint8()))
-  expect_identical(dim(as.data.frame(ds)), c(20L, 7L))
+  expect_shape(as.data.frame(ds), nrow = 20L, ncol = 7L)
 })
 
 test_that("dim method returns the correct number of rows and columns", {
   ds <- open_dataset(dataset_dir, partitioning = schema(part = uint8()))
-  expect_identical(dim(ds), c(20L, 7L))
+  expect_shape(ds, nrow = 20L, ncol = 7L)
 })
 
 test_that("dimnames, colnames on Dataset objects", {

--- a/r/tests/testthat/test-dataset.R
+++ b/r/tests/testthat/test-dataset.R
@@ -51,7 +51,7 @@ test_that("IPC/Feather format data", {
   expect_r6_class(ds$format, "IpcFileFormat")
   expect_r6_class(ds$filesystem, "LocalFileSystem")
   expect_named(ds, c(names(df1), "part"))
-  expect_shape(ds, nrow = 20L, ncol = 7L)
+  expect_shape(ds, dim = c(20L, 7L))
 
   expect_equal(
     ds |>
@@ -370,12 +370,12 @@ test_that("Can set schema on dataset", {
 
 test_that("as.data.frame.Dataset", {
   ds <- open_dataset(dataset_dir, partitioning = schema(part = uint8()))
-  expect_shape(as.data.frame(ds), nrow = 20L, ncol = 7L)
+  expect_shape(as.data.frame(ds), dim = c(20L, 7L))
 })
 
 test_that("dim method returns the correct number of rows and columns", {
   ds <- open_dataset(dataset_dir, partitioning = schema(part = uint8()))
-  expect_shape(ds, nrow = 20L, ncol = 7L)
+  expect_shape(ds, dim = c(20L, 7L))
 })
 
 test_that("dimnames, colnames on Dataset objects", {

--- a/r/tests/testthat/test-duckdb.R
+++ b/r/tests/testthat/test-duckdb.R
@@ -223,10 +223,10 @@ test_that("Joining, auto-cleanup enabled", {
   expect_identical(dim(res), c(9L, 14L))
 
   # clean up cleans up the tables
-  expect_true(all(c(table_one_name, table_two_name) %in% duckdb::duckdb_list_arrow(con)))
+  expect_all_true(c(table_one_name, table_two_name) %in% duckdb::duckdb_list_arrow(con))
   rm(table_one, table_two)
   gc()
-  expect_false(any(c(table_one_name, table_two_name) %in% duckdb::duckdb_list_arrow(con)))
+  expect_all_false(c(table_one_name, table_two_name) %in% duckdb::duckdb_list_arrow(con))
 })
 
 test_that("Joining, auto-cleanup disabled", {

--- a/r/tests/testthat/test-memory-pool.R
+++ b/r/tests/testthat/test-memory-pool.R
@@ -22,5 +22,5 @@ test_that("default_memory_pool and its attributes", {
   expect_type(pool$max_memory, "double")
   expect_true(pool$backend_name %in% c("system", "jemalloc", "mimalloc"))
 
-  expect_true(all(supported_memory_backends() %in% c("system", "jemalloc", "mimalloc")))
+  expect_all_true(supported_memory_backends() %in% c("system", "jemalloc", "mimalloc"))
 })

--- a/r/tests/testthat/test-udf.R
+++ b/r/tests/testthat/test-udf.R
@@ -17,7 +17,7 @@
 
 test_that("list_compute_functions() works", {
   expect_type(list_compute_functions(), "character")
-  expect_true(all(!grepl("^hash_", list_compute_functions())))
+  expect_all_false(grepl("^hash_", list_compute_functions()))
 })
 
 test_that("arrow_scalar_function() works", {


### PR DESCRIPTION
### Rationale for this change

testthat 3.3.0 added several new expectation functions that we can use instead of our custom implementations or verbose patterns.

### What changes are included in this PR?

- Bump testthat requirement from >= 3.1.0 to >= 3.3.0
- Remove custom `expect_r6_class()` from helper-expectation.R in favor of testthat's version
- Replace `expect_true(all(...))` with `expect_all_true()`
- Replace `expect_false(any(...))` / `expect_true(all(!...))` with `expect_all_false()`
- Replace `expect_identical(dim(...), c(...))` with `expect_shape(..., dim = c(...))`

### Are these changes tested?

Existing tests pass with the new expectations.

### Are there any user-facing changes?

No.

---

This PR was generated by Claude. All outputs were reviewed and confirmed before pushing.

* GitHub Issue: #48145