### PR TITLE
GH-48334: [C++][Parquet] Support reading encrypted bloom filters

### DIFF
--- a/cpp/src/parquet/CMakeLists.txt
+++ b/cpp/src/parquet/CMakeLists.txt
@@ -416,6 +416,7 @@ add_parquet_test(arrow-metadata-test SOURCES arrow/arrow_metadata_test.cc
 if(PARQUET_REQUIRE_ENCRYPTION)
   add_parquet_test(encryption-test
                    SOURCES
+                   encryption/bloom_filter_encryption_test.cc
                    encryption/encryption_internal_test.cc
                    encryption/write_configurations_test.cc
                    encryption/read_configurations_test.cc

--- a/cpp/src/parquet/arrow/fuzz_internal.cc
+++ b/cpp/src/parquet/arrow/fuzz_internal.cc
@@ -155,6 +155,23 @@ Status FuzzReadPageIndex(RowGroupPageIndexReader* reader, const SchemaDescriptor
   return st;
 }
 
+Status FuzzReadBloomFilter(RowGroupBloomFilterReader* reader, int column,
+                           std::uniform_int_distribution<uint64_t>& hash_dist,
+                           std::default_random_engine& rng) {
+  Status st;
+  BEGIN_PARQUET_CATCH_EXCEPTIONS
+  std::unique_ptr<BloomFilter> bloom;
+  bloom = reader->GetColumnBloomFilter(column);
+  // If the column has a bloom filter, find a bunch of random hashes
+  if (bloom != nullptr) {
+    for (int k = 0; k < 100; ++k) {
+      bloom->FindHash(hash_dist(rng));
+    }
+  }
+  END_PARQUET_CATCH_EXCEPTIONS
+  return st;
+}
+
 ReaderProperties MakeFuzzReaderProperties(MemoryPool* pool) {
   FileDecryptionProperties::Builder builder;
   builder.key_retriever(MakeKeyRetriever());
@@ -207,31 +224,12 @@ Status FuzzReader(const uint8_t* data, int64_t size) {
     }
     {
       // Read and decode bloom filters
-      try {
-        auto& bloom_reader = pq_file_reader->GetBloomFilterReader();
-        std::uniform_int_distribution<uint64_t> hash_dist;
-        for (int i = 0; i < num_row_groups; ++i) {
-          auto bloom_rg = bloom_reader.RowGroup(i);
-          for (int j = 0; j < num_columns; ++j) {
-            std::unique_ptr<BloomFilter> bloom;
-            bloom = bloom_rg->GetColumnBloomFilter(j);
-            // If the column has a bloom filter, find a bunch of random hashes
-            if (bloom != nullptr) {
-              for (int k = 0; k < 100; ++k) {
-                bloom->FindHash(hash_dist(rng));
-              }
-            }
-          }
-        }
-      } catch (const ParquetException& exc) {
-        // XXX we just want to ignore encrypted bloom filters and validate the
-        // rest of the file; there is no better way of doing this until GH-46597
-        // is done.
-        // (also see GH-48334 for reading encrypted bloom filters)
-        if (std::string_view(exc.what())
-                .find("BloomFilter decryption is not yet supported") ==
-            std::string_view::npos) {
-          throw;
+      auto& bloom_reader = pq_file_reader->GetBloomFilterReader();
+      std::uniform_int_distribution<uint64_t> hash_dist;
+      for (int i = 0; i < num_row_groups; ++i) {
+        auto bloom_rg = bloom_reader.RowGroup(i);
+        for (int j = 0; j < num_columns; ++j) {
+          st &= FuzzReadBloomFilter(bloom_rg.get(), j, hash_dist, rng);
         }
       }
     }

--- a/cpp/src/parquet/bloom_filter.cc
+++ b/cpp/src/parquet/bloom_filter.cc
@@ -37,7 +37,9 @@ namespace {
 
 constexpr int32_t kCiphertextLengthSize = 4;
 
-int64_t ParseTotalCiphertextSize(const uint8_t* data, int64_t length) {
+// Parse the little-endian length prefix and return the total ciphertext size
+// including the 4-byte length field itself.
+int64_t ParseCiphertextTotalLength(const uint8_t* data, int64_t length) {
   if (length < kCiphertextLengthSize) {
     throw ParquetException("Ciphertext length buffer is too small");
   }
@@ -142,7 +144,7 @@ BlockSplitBloomFilter BlockSplitBloomFilter::Deserialize(
     }
 
     const int64_t header_cipher_total_len =
-        ParseTotalCiphertextSize(length_buf->data(), length_buf->size());
+        ParseCiphertextTotalLength(length_buf->data(), length_buf->size());
     if (ARROW_PREDICT_FALSE(header_cipher_total_len >
                             std::numeric_limits<int32_t>::max())) {
       throw ParquetException("Bloom filter header ciphertext length overflows int32");
@@ -168,9 +170,8 @@ BlockSplitBloomFilter BlockSplitBloomFilter::Deserialize(
 
     uint32_t header_cipher_len = static_cast<uint32_t>(header_cipher_total_len);
     try {
-      deserializer.DeserializeMessage(
-          reinterpret_cast<const uint8_t*>(header_cipher_buf->data()), &header_cipher_len,
-          &header, header_decryptor);
+      deserializer.DeserializeMessage(header_cipher_buf->data(), &header_cipher_len,
+                                      &header, header_decryptor);
       DCHECK_EQ(header_cipher_len, header_cipher_total_len);
     } catch (std::exception& e) {
       std::stringstream ss;
@@ -195,7 +196,7 @@ BlockSplitBloomFilter BlockSplitBloomFilter::Deserialize(
     // Read and decrypt the bitset bytes.
     PARQUET_ASSIGN_OR_THROW(auto bitset_cipher_buf, input->Read(bitset_cipher_len));
     if (ARROW_PREDICT_FALSE(bitset_cipher_buf->size() < bitset_cipher_len)) {
-      throw ParquetException("Bloom Filter read failed: not enough data");
+      throw ParquetException("Bloom filter read failed: not enough data");
     }
 
     const int32_t bitset_plain_len =
@@ -217,6 +218,7 @@ BlockSplitBloomFilter BlockSplitBloomFilter::Deserialize(
     bloom_filter.Init(bitset_plain_buf->data(), bloom_filter_size);
     return bloom_filter;
   }
+
   ThriftDeserializer deserializer(properties);
   format::BloomFilterHeader header;
   int64_t bloom_filter_header_read_size = 0;
@@ -236,8 +238,7 @@ BlockSplitBloomFilter BlockSplitBloomFilter::Deserialize(
   // This gets used, then set by DeserializeThriftMsg
   uint32_t header_size = static_cast<uint32_t>(header_buf->size());
   try {
-    deserializer.DeserializeMessage(reinterpret_cast<const uint8_t*>(header_buf->data()),
-                                    &header_size, &header);
+    deserializer.DeserializeMessage(header_buf->data(), &header_size, &header);
     DCHECK_LE(header_size, header_buf->size());
   } catch (std::exception& e) {
     std::stringstream ss;

--- a/cpp/src/parquet/bloom_filter.cc
+++ b/cpp/src/parquet/bloom_filter.cc
@@ -20,6 +20,7 @@
 #include <limits>
 #include <memory>
 
+#include "arrow/io/memory.h"
 #include "arrow/result.h"
 #include "arrow/util/logging_internal.h"
 #include "arrow/util/macros.h"
@@ -48,6 +49,16 @@ int64_t ParseCiphertextTotalLength(const uint8_t* data, int64_t length) {
       (static_cast<uint32_t>(data[3]) << 24) | (static_cast<uint32_t>(data[2]) << 16) |
       (static_cast<uint32_t>(data[1]) << 8) | (static_cast<uint32_t>(data[0]));
   return static_cast<int64_t>(buffer_size) + kCiphertextLengthSize;
+}
+
+void CheckBloomFilterShortRead(int64_t expected, int64_t actual,
+                               std::string_view context) {
+  if (ARROW_PREDICT_FALSE(actual < expected)) {
+    std::stringstream ss;
+    ss << context << " read failed: expected ";
+    ss << expected << " bytes, got " << actual;
+    throw ParquetException(ss.str());
+  }
 }
 
 }  // namespace
@@ -126,27 +137,17 @@ constexpr uint32_t kBloomFilterHeaderSizeGuess = 256;
   return ::arrow::Status::OK();
 }
 
-}  // namespace
-
-BlockSplitBloomFilter BlockSplitBloomFilter::DeserializeEncrypted(
+BlockSplitBloomFilter DeserializeEncryptedFromStream(
     const ReaderProperties& properties, ArrowInputStream* input,
     std::optional<int64_t> bloom_filter_length, Decryptor* decryptor,
     int16_t row_group_ordinal, int16_t column_ordinal) {
-  if (decryptor == nullptr) {
-    throw ParquetException("Bloom filter decryptor must be provided");
-  }
-
   ThriftDeserializer deserializer(properties);
   format::BloomFilterHeader header;
 
   // Read the length-prefixed ciphertext for the header.
   PARQUET_ASSIGN_OR_THROW(auto length_buf, input->Read(kCiphertextLengthSize));
-  if (ARROW_PREDICT_FALSE(length_buf->size() < kCiphertextLengthSize)) {
-    std::stringstream ss;
-    ss << "Bloom filter header read failed: expected " << kCiphertextLengthSize
-       << " bytes, got " << length_buf->size();
-    throw ParquetException(ss.str());
-  }
+  CheckBloomFilterShortRead(kCiphertextLengthSize, length_buf->size(),
+                            "Bloom filter header length");
 
   const int64_t header_cipher_total_len =
       ParseCiphertextTotalLength(length_buf->data(), length_buf->size());
@@ -158,6 +159,7 @@ BlockSplitBloomFilter BlockSplitBloomFilter::DeserializeEncrypted(
     throw ParquetException(
         "Bloom filter length less than encrypted bloom filter header length");
   }
+
   // Read the full header ciphertext and decrypt the Thrift header.
   auto header_cipher_buf =
       AllocateBuffer(properties.memory_pool(), header_cipher_total_len);
@@ -167,24 +169,24 @@ BlockSplitBloomFilter BlockSplitBloomFilter::DeserializeEncrypted(
   PARQUET_ASSIGN_OR_THROW(auto read_size, input->Read(header_cipher_remaining,
                                                       header_cipher_buf->mutable_data() +
                                                           kCiphertextLengthSize));
-  if (ARROW_PREDICT_FALSE(read_size < header_cipher_remaining)) {
-    std::stringstream ss;
-    ss << "Bloom filter header read failed: expected " << header_cipher_remaining
-       << " bytes, got " << read_size;
-    throw ParquetException(ss.str());
-  }
+  CheckBloomFilterShortRead(header_cipher_remaining, read_size, "Bloom filter header");
 
   // Bloom filter header and bitset are separate encrypted modules with different AADs.
   UpdateDecryptor(decryptor, row_group_ordinal, column_ordinal,
                   encryption::kBloomFilterHeader);
-  uint32_t header_cipher_len = static_cast<uint32_t>(header_cipher_total_len);
+  auto header_cipher_len = static_cast<uint32_t>(header_cipher_total_len);
   try {
     deserializer.DeserializeMessage(header_cipher_buf->data(), &header_cipher_len,
                                     &header, decryptor);
-    DCHECK_EQ(header_cipher_len, header_cipher_total_len);
   } catch (std::exception& e) {
     std::stringstream ss;
     ss << "Deserializing bloom filter header failed.\n" << e.what();
+    throw ParquetException(ss.str());
+  }
+  if (ARROW_PREDICT_FALSE(header_cipher_len != header_cipher_total_len)) {
+    std::stringstream ss;
+    ss << "Encrypted bloom filter header length mismatch: expected "
+       << header_cipher_total_len << " bytes, got " << header_cipher_len;
     throw ParquetException(ss.str());
   }
   PARQUET_THROW_NOT_OK(ValidateBloomFilterHeader(header));
@@ -204,12 +206,8 @@ BlockSplitBloomFilter BlockSplitBloomFilter::DeserializeEncrypted(
 
   // Read and decrypt the bitset bytes.
   PARQUET_ASSIGN_OR_THROW(auto bitset_cipher_buf, input->Read(bitset_cipher_len));
-  if (ARROW_PREDICT_FALSE(bitset_cipher_buf->size() < bitset_cipher_len)) {
-    std::stringstream ss;
-    ss << "Bloom filter bitset read failed: expected " << bitset_cipher_len
-       << " bytes, got " << bitset_cipher_buf->size();
-    throw ParquetException(ss.str());
-  }
+  CheckBloomFilterShortRead(bitset_cipher_len, bitset_cipher_buf->size(),
+                            "Bloom filter bitset");
 
   const int32_t bitset_plain_len =
       decryptor->PlaintextLength(static_cast<int32_t>(bitset_cipher_len));
@@ -229,6 +227,30 @@ BlockSplitBloomFilter BlockSplitBloomFilter::DeserializeEncrypted(
   BlockSplitBloomFilter bloom_filter(properties.memory_pool());
   bloom_filter.Init(bitset_plain_buf->data(), bloom_filter_size);
   return bloom_filter;
+}
+
+}  // namespace
+
+BlockSplitBloomFilter BlockSplitBloomFilter::DeserializeEncrypted(
+    const ReaderProperties& properties, ArrowInputStream* input,
+    std::optional<int64_t> bloom_filter_length, Decryptor* decryptor,
+    int16_t row_group_ordinal, int16_t column_ordinal) {
+  if (decryptor == nullptr) {
+    throw ParquetException("Bloom filter decryptor must be provided");
+  }
+
+  // Read the full Bloom filter payload up front when the total length is known.
+  if (bloom_filter_length.has_value()) {
+    PARQUET_ASSIGN_OR_THROW(auto bloom_filter_buf, input->Read(*bloom_filter_length));
+    CheckBloomFilterShortRead(*bloom_filter_length, bloom_filter_buf->size(),
+                              "Bloom filter");
+    ::arrow::io::BufferReader reader(bloom_filter_buf);
+    return DeserializeEncryptedFromStream(properties, &reader, bloom_filter_length,
+                                          decryptor, row_group_ordinal, column_ordinal);
+  }
+
+  return DeserializeEncryptedFromStream(properties, input, bloom_filter_length, decryptor,
+                                        row_group_ordinal, column_ordinal);
 }
 
 BlockSplitBloomFilter BlockSplitBloomFilter::Deserialize(
@@ -292,9 +314,7 @@ BlockSplitBloomFilter BlockSplitBloomFilter::Deserialize(
   PARQUET_ASSIGN_OR_THROW(
       auto read_size, input->Read(required_read_size,
                                   buffer->mutable_data() + bloom_filter_bytes_in_header));
-  if (ARROW_PREDICT_FALSE(read_size < required_read_size)) {
-    throw ParquetException("Bloom Filter read failed: not enough data");
-  }
+  CheckBloomFilterShortRead(required_read_size, read_size, "Bloom filter");
   BlockSplitBloomFilter bloom_filter(properties.memory_pool());
   bloom_filter.Init(buffer->data(), bloom_filter_size);
   return bloom_filter;

--- a/cpp/src/parquet/bloom_filter.cc
+++ b/cpp/src/parquet/bloom_filter.cc
@@ -37,8 +37,8 @@ namespace {
 
 constexpr int32_t kCiphertextLengthSize = 4;
 
-// Parse the little-endian length prefix and return the total ciphertext size
-// including the 4-byte length field itself.
+/// Parse the 4-byte little-endian length prefix and return the total ciphertext size,
+/// including the 4-byte length field itself.
 int64_t ParseCiphertextTotalLength(const uint8_t* data, int64_t length) {
   if (length < kCiphertextLengthSize) {
     throw ParquetException("Ciphertext length buffer is too small");
@@ -130,7 +130,8 @@ BlockSplitBloomFilter BlockSplitBloomFilter::Deserialize(
     Decryptor* bitset_decryptor) {
   if (header_decryptor != nullptr || bitset_decryptor != nullptr) {
     if (header_decryptor == nullptr || bitset_decryptor == nullptr) {
-      throw ParquetException("Bloom filter decryptors must be both provided");
+      throw ParquetException(
+          "Bloom filter decryptors must be both provided or both null");
     }
 
     // Encrypted path: header and bitset are encrypted separately.

--- a/cpp/src/parquet/bloom_filter.cc
+++ b/cpp/src/parquet/bloom_filter.cc
@@ -95,10 +95,11 @@ void BlockSplitBloomFilter::Init(const uint8_t* bitset, uint32_t num_bytes) {
   this->hasher_ = std::make_unique<XxHasher>();
 }
 
-static constexpr uint32_t kBloomFilterHeaderSizeGuess = 256;
+namespace {
 
-static ::arrow::Status ValidateBloomFilterHeader(
-    const format::BloomFilterHeader& header) {
+constexpr uint32_t kBloomFilterHeaderSizeGuess = 256;
+
+::arrow::Status ValidateBloomFilterHeader(const format::BloomFilterHeader& header) {
   if (!header.algorithm.__isset.BLOCK) {
     return ::arrow::Status::Invalid(
         "Unsupported Bloom filter algorithm: ", header.algorithm, ".");
@@ -124,6 +125,104 @@ static ::arrow::Status ValidateBloomFilterHeader(
   return ::arrow::Status::OK();
 }
 
+BlockSplitBloomFilter DeserializeEncrypted(const ReaderProperties& properties,
+                                           ArrowInputStream* input,
+                                           std::optional<int64_t> bloom_filter_length,
+                                           Decryptor* header_decryptor,
+                                           Decryptor* bitset_decryptor) {
+  // Encrypted path: header and bitset are encrypted separately.
+  ThriftDeserializer deserializer(properties);
+  format::BloomFilterHeader header;
+
+  // Read the length-prefixed ciphertext for the header.
+  PARQUET_ASSIGN_OR_THROW(auto length_buf, input->Read(kCiphertextLengthSize));
+  if (ARROW_PREDICT_FALSE(length_buf->size() < kCiphertextLengthSize)) {
+    std::stringstream ss;
+    ss << "Bloom filter header read failed: expected " << kCiphertextLengthSize
+       << " bytes, got " << length_buf->size();
+    throw ParquetException(ss.str());
+  }
+
+  const int64_t header_cipher_total_len =
+      ParseCiphertextTotalLength(length_buf->data(), length_buf->size());
+  if (ARROW_PREDICT_FALSE(header_cipher_total_len >
+                          std::numeric_limits<int32_t>::max())) {
+    throw ParquetException("Bloom filter header ciphertext length overflows int32");
+  }
+  if (bloom_filter_length && header_cipher_total_len > *bloom_filter_length) {
+    throw ParquetException(
+        "Bloom filter length less than encrypted bloom filter header length");
+  }
+  // Read the full header ciphertext and decrypt the Thrift header.
+  auto header_cipher_buf =
+      AllocateBuffer(properties.memory_pool(), header_cipher_total_len);
+  std::memcpy(header_cipher_buf->mutable_data(), length_buf->data(),
+              kCiphertextLengthSize);
+  const int64_t header_cipher_remaining = header_cipher_total_len - kCiphertextLengthSize;
+  PARQUET_ASSIGN_OR_THROW(auto read_size, input->Read(header_cipher_remaining,
+                                                      header_cipher_buf->mutable_data() +
+                                                          kCiphertextLengthSize));
+  if (ARROW_PREDICT_FALSE(read_size < header_cipher_remaining)) {
+    std::stringstream ss;
+    ss << "Bloom filter header read failed: expected " << header_cipher_remaining
+       << " bytes, got " << read_size;
+    throw ParquetException(ss.str());
+  }
+
+  uint32_t header_cipher_len = static_cast<uint32_t>(header_cipher_total_len);
+  try {
+    deserializer.DeserializeMessage(header_cipher_buf->data(), &header_cipher_len,
+                                    &header, header_decryptor);
+    DCHECK_EQ(header_cipher_len, header_cipher_total_len);
+  } catch (std::exception& e) {
+    std::stringstream ss;
+    ss << "Deserializing bloom filter header failed.\n" << e.what();
+    throw ParquetException(ss.str());
+  }
+  PARQUET_THROW_NOT_OK(ValidateBloomFilterHeader(header));
+
+  const int32_t bloom_filter_size = header.numBytes;
+  const int32_t bitset_cipher_len = bitset_decryptor->CiphertextLength(bloom_filter_size);
+  const int64_t total_cipher_len =
+      header_cipher_total_len + static_cast<int64_t>(bitset_cipher_len);
+  if (bloom_filter_length && *bloom_filter_length != total_cipher_len) {
+    std::stringstream ss;
+    ss << "Bloom filter length (" << bloom_filter_length.value()
+       << ") does not match the actual bloom filter (size: " << total_cipher_len << ").";
+    throw ParquetException(ss.str());
+  }
+
+  // Read and decrypt the bitset bytes.
+  PARQUET_ASSIGN_OR_THROW(auto bitset_cipher_buf, input->Read(bitset_cipher_len));
+  if (ARROW_PREDICT_FALSE(bitset_cipher_buf->size() < bitset_cipher_len)) {
+    std::stringstream ss;
+    ss << "Bloom filter bitset read failed: expected " << bitset_cipher_len
+       << " bytes, got " << bitset_cipher_buf->size();
+    throw ParquetException(ss.str());
+  }
+
+  const int32_t bitset_plain_len =
+      bitset_decryptor->PlaintextLength(static_cast<int32_t>(bitset_cipher_len));
+  if (ARROW_PREDICT_FALSE(bitset_plain_len != bloom_filter_size)) {
+    throw ParquetException("Bloom filter bitset size does not match header");
+  }
+
+  auto bitset_plain_buf = AllocateBuffer(properties.memory_pool(), bitset_plain_len);
+  int32_t decrypted_len =
+      bitset_decryptor->Decrypt(bitset_cipher_buf->span_as<const uint8_t>(),
+                                bitset_plain_buf->mutable_span_as<uint8_t>());
+  if (ARROW_PREDICT_FALSE(decrypted_len != bitset_plain_len)) {
+    throw ParquetException("Bloom filter bitset decryption failed");
+  }
+
+  // Initialize the bloom filter from the decrypted bitset.
+  BlockSplitBloomFilter bloom_filter(properties.memory_pool());
+  bloom_filter.Init(bitset_plain_buf->data(), bloom_filter_size);
+  return bloom_filter;
+}
+
+}  // namespace
+
 BlockSplitBloomFilter BlockSplitBloomFilter::Deserialize(
     const ReaderProperties& properties, ArrowInputStream* input,
     std::optional<int64_t> bloom_filter_length, Decryptor* header_decryptor,
@@ -133,91 +232,8 @@ BlockSplitBloomFilter BlockSplitBloomFilter::Deserialize(
       throw ParquetException(
           "Bloom filter decryptors must be both provided or both null");
     }
-
-    // Encrypted path: header and bitset are encrypted separately.
-    ThriftDeserializer deserializer(properties);
-    format::BloomFilterHeader header;
-
-    // Read the length-prefixed ciphertext for the header.
-    PARQUET_ASSIGN_OR_THROW(auto length_buf, input->Read(kCiphertextLengthSize));
-    if (ARROW_PREDICT_FALSE(length_buf->size() < kCiphertextLengthSize)) {
-      throw ParquetException("Bloom filter header read failed: not enough data");
-    }
-
-    const int64_t header_cipher_total_len =
-        ParseCiphertextTotalLength(length_buf->data(), length_buf->size());
-    if (ARROW_PREDICT_FALSE(header_cipher_total_len >
-                            std::numeric_limits<int32_t>::max())) {
-      throw ParquetException("Bloom filter header ciphertext length overflows int32");
-    }
-    if (bloom_filter_length && header_cipher_total_len > *bloom_filter_length) {
-      throw ParquetException(
-          "Bloom filter length less than encrypted bloom filter header length");
-    }
-    // Read the full header ciphertext and decrypt the Thrift header.
-    auto header_cipher_buf =
-        AllocateBuffer(properties.memory_pool(), header_cipher_total_len);
-    std::memcpy(header_cipher_buf->mutable_data(), length_buf->data(),
-                kCiphertextLengthSize);
-    const int64_t header_cipher_remaining =
-        header_cipher_total_len - kCiphertextLengthSize;
-    PARQUET_ASSIGN_OR_THROW(
-        auto read_size,
-        input->Read(header_cipher_remaining,
-                    header_cipher_buf->mutable_data() + kCiphertextLengthSize));
-    if (ARROW_PREDICT_FALSE(read_size < header_cipher_remaining)) {
-      throw ParquetException("Bloom filter header read failed: not enough data");
-    }
-
-    uint32_t header_cipher_len = static_cast<uint32_t>(header_cipher_total_len);
-    try {
-      deserializer.DeserializeMessage(header_cipher_buf->data(), &header_cipher_len,
-                                      &header, header_decryptor);
-      DCHECK_EQ(header_cipher_len, header_cipher_total_len);
-    } catch (std::exception& e) {
-      std::stringstream ss;
-      ss << "Deserializing bloom filter header failed.\n" << e.what();
-      throw ParquetException(ss.str());
-    }
-    PARQUET_THROW_NOT_OK(ValidateBloomFilterHeader(header));
-
-    const int32_t bloom_filter_size = header.numBytes;
-    const int32_t bitset_cipher_len =
-        bitset_decryptor->CiphertextLength(bloom_filter_size);
-    const int64_t total_cipher_len =
-        header_cipher_total_len + static_cast<int64_t>(bitset_cipher_len);
-    if (bloom_filter_length && *bloom_filter_length != total_cipher_len) {
-      std::stringstream ss;
-      ss << "Bloom filter length (" << bloom_filter_length.value()
-         << ") does not match the actual bloom filter (size: " << total_cipher_len
-         << ").";
-      throw ParquetException(ss.str());
-    }
-
-    // Read and decrypt the bitset bytes.
-    PARQUET_ASSIGN_OR_THROW(auto bitset_cipher_buf, input->Read(bitset_cipher_len));
-    if (ARROW_PREDICT_FALSE(bitset_cipher_buf->size() < bitset_cipher_len)) {
-      throw ParquetException("Bloom filter read failed: not enough data");
-    }
-
-    const int32_t bitset_plain_len =
-        bitset_decryptor->PlaintextLength(static_cast<int32_t>(bitset_cipher_len));
-    if (ARROW_PREDICT_FALSE(bitset_plain_len != bloom_filter_size)) {
-      throw ParquetException("Bloom filter bitset size does not match header");
-    }
-
-    auto bitset_plain_buf = AllocateBuffer(properties.memory_pool(), bitset_plain_len);
-    int32_t decrypted_len =
-        bitset_decryptor->Decrypt(bitset_cipher_buf->span_as<const uint8_t>(),
-                                  bitset_plain_buf->mutable_span_as<uint8_t>());
-    if (ARROW_PREDICT_FALSE(decrypted_len != bitset_plain_len)) {
-      throw ParquetException("Bloom filter bitset decryption failed");
-    }
-
-    // Initialize the bloom filter from the decrypted bitset.
-    BlockSplitBloomFilter bloom_filter(properties.memory_pool());
-    bloom_filter.Init(bitset_plain_buf->data(), bloom_filter_size);
-    return bloom_filter;
+    return DeserializeEncrypted(properties, input, bloom_filter_length, header_decryptor,
+                                bitset_decryptor);
   }
 
   ThriftDeserializer deserializer(properties);

--- a/cpp/src/parquet/bloom_filter.cc
+++ b/cpp/src/parquet/bloom_filter.cc
@@ -27,6 +27,7 @@
 #include "generated/parquet_types.h"
 
 #include "parquet/bloom_filter.h"
+#include "parquet/encryption/encryption_internal.h"
 #include "parquet/encryption/internal_file_decryptor.h"
 #include "parquet/exception.h"
 #include "parquet/thrift_internal.h"
@@ -125,12 +126,16 @@ constexpr uint32_t kBloomFilterHeaderSizeGuess = 256;
   return ::arrow::Status::OK();
 }
 
-BlockSplitBloomFilter DeserializeEncrypted(const ReaderProperties& properties,
-                                           ArrowInputStream* input,
-                                           std::optional<int64_t> bloom_filter_length,
-                                           Decryptor* header_decryptor,
-                                           Decryptor* bitset_decryptor) {
-  // Encrypted path: header and bitset are encrypted separately.
+}  // namespace
+
+BlockSplitBloomFilter BlockSplitBloomFilter::DeserializeEncrypted(
+    const ReaderProperties& properties, ArrowInputStream* input,
+    std::optional<int64_t> bloom_filter_length, Decryptor* decryptor,
+    int16_t row_group_ordinal, int16_t column_ordinal) {
+  if (decryptor == nullptr) {
+    throw ParquetException("Bloom filter decryptor must be provided");
+  }
+
   ThriftDeserializer deserializer(properties);
   format::BloomFilterHeader header;
 
@@ -169,10 +174,13 @@ BlockSplitBloomFilter DeserializeEncrypted(const ReaderProperties& properties,
     throw ParquetException(ss.str());
   }
 
+  // Bloom filter header and bitset are separate encrypted modules with different AADs.
+  UpdateDecryptor(decryptor, row_group_ordinal, column_ordinal,
+                  encryption::kBloomFilterHeader);
   uint32_t header_cipher_len = static_cast<uint32_t>(header_cipher_total_len);
   try {
     deserializer.DeserializeMessage(header_cipher_buf->data(), &header_cipher_len,
-                                    &header, header_decryptor);
+                                    &header, decryptor);
     DCHECK_EQ(header_cipher_len, header_cipher_total_len);
   } catch (std::exception& e) {
     std::stringstream ss;
@@ -182,7 +190,9 @@ BlockSplitBloomFilter DeserializeEncrypted(const ReaderProperties& properties,
   PARQUET_THROW_NOT_OK(ValidateBloomFilterHeader(header));
 
   const int32_t bloom_filter_size = header.numBytes;
-  const int32_t bitset_cipher_len = bitset_decryptor->CiphertextLength(bloom_filter_size);
+  UpdateDecryptor(decryptor, row_group_ordinal, column_ordinal,
+                  encryption::kBloomFilterBitset);
+  const int32_t bitset_cipher_len = decryptor->CiphertextLength(bloom_filter_size);
   const int64_t total_cipher_len =
       header_cipher_total_len + static_cast<int64_t>(bitset_cipher_len);
   if (bloom_filter_length && *bloom_filter_length != total_cipher_len) {
@@ -202,15 +212,15 @@ BlockSplitBloomFilter DeserializeEncrypted(const ReaderProperties& properties,
   }
 
   const int32_t bitset_plain_len =
-      bitset_decryptor->PlaintextLength(static_cast<int32_t>(bitset_cipher_len));
+      decryptor->PlaintextLength(static_cast<int32_t>(bitset_cipher_len));
   if (ARROW_PREDICT_FALSE(bitset_plain_len != bloom_filter_size)) {
     throw ParquetException("Bloom filter bitset size does not match header");
   }
 
   auto bitset_plain_buf = AllocateBuffer(properties.memory_pool(), bitset_plain_len);
   int32_t decrypted_len =
-      bitset_decryptor->Decrypt(bitset_cipher_buf->span_as<const uint8_t>(),
-                                bitset_plain_buf->mutable_span_as<uint8_t>());
+      decryptor->Decrypt(bitset_cipher_buf->span_as<const uint8_t>(),
+                         bitset_plain_buf->mutable_span_as<uint8_t>());
   if (ARROW_PREDICT_FALSE(decrypted_len != bitset_plain_len)) {
     throw ParquetException("Bloom filter bitset decryption failed");
   }
@@ -221,21 +231,9 @@ BlockSplitBloomFilter DeserializeEncrypted(const ReaderProperties& properties,
   return bloom_filter;
 }
 
-}  // namespace
-
 BlockSplitBloomFilter BlockSplitBloomFilter::Deserialize(
     const ReaderProperties& properties, ArrowInputStream* input,
-    std::optional<int64_t> bloom_filter_length, Decryptor* header_decryptor,
-    Decryptor* bitset_decryptor) {
-  if (header_decryptor != nullptr || bitset_decryptor != nullptr) {
-    if (header_decryptor == nullptr || bitset_decryptor == nullptr) {
-      throw ParquetException(
-          "Bloom filter decryptors must be both provided or both null");
-    }
-    return DeserializeEncrypted(properties, input, bloom_filter_length, header_decryptor,
-                                bitset_decryptor);
-  }
-
+    std::optional<int64_t> bloom_filter_length) {
   ThriftDeserializer deserializer(properties);
   format::BloomFilterHeader header;
   int64_t bloom_filter_header_read_size = 0;

--- a/cpp/src/parquet/bloom_filter.h
+++ b/cpp/src/parquet/bloom_filter.h
@@ -29,6 +29,8 @@
 
 namespace parquet {
 
+class Decryptor;
+
 // A Bloom filter is a compact structure to indicate whether an item is not in a set or
 // probably in a set. The Bloom filter usually consists of a bit set that represents a
 // set of elements, a hash strategy and a Bloom filter algorithm.
@@ -323,10 +325,15 @@ class PARQUET_EXPORT BlockSplitBloomFilter : public BloomFilter {
   /// @param input_stream The input stream from which to construct the bloom filter.
   /// @param bloom_filter_length The length of the serialized bloom filter including
   /// header.
+  /// @param header_decryptor Optional decryptor for the serialized header.
+  /// @param bitset_decryptor Optional decryptor for the bitset bytes.
+  /// Both decryptors must be provided for encrypted bloom filters, or both be null
+  /// for unencrypted. Providing only one will throw ParquetException.
   /// @return The BlockSplitBloomFilter.
   static BlockSplitBloomFilter Deserialize(
       const ReaderProperties& properties, ArrowInputStream* input_stream,
-      std::optional<int64_t> bloom_filter_length = std::nullopt);
+      std::optional<int64_t> bloom_filter_length = std::nullopt,
+      Decryptor* header_decryptor = NULLPTR, Decryptor* bitset_decryptor = NULLPTR);
 
  private:
   inline void InsertHashImpl(uint64_t hash);

--- a/cpp/src/parquet/bloom_filter.h
+++ b/cpp/src/parquet/bloom_filter.h
@@ -324,15 +324,28 @@ class PARQUET_EXPORT BlockSplitBloomFilter : public BloomFilter {
   /// @param input_stream The input stream from which to construct the bloom filter.
   /// @param bloom_filter_length The length of the serialized bloom filter including
   /// header.
-  /// @param header_decryptor Optional decryptor for the serialized header.
-  /// @param bitset_decryptor Optional decryptor for the bitset bytes.
-  /// Both decryptors must be provided for encrypted bloom filters, or both be null
-  /// for unencrypted. Providing only one will throw ParquetException.
   /// @return The BlockSplitBloomFilter.
   static BlockSplitBloomFilter Deserialize(
       const ReaderProperties& properties, ArrowInputStream* input_stream,
-      std::optional<int64_t> bloom_filter_length = std::nullopt,
-      Decryptor* header_decryptor = NULLPTR, Decryptor* bitset_decryptor = NULLPTR);
+      std::optional<int64_t> bloom_filter_length = std::nullopt);
+
+  /// Deserialize an encrypted Bloom filter from an input stream.
+  ///
+  /// The same metadata decryptor is used for both the serialized header and bitset,
+  /// while switching module AADs between the two encrypted modules.
+  ///
+  /// @param properties The parquet reader properties.
+  /// @param input_stream The input stream from which to construct the bloom filter.
+  /// @param bloom_filter_length The length of the serialized bloom filter including
+  /// header.
+  /// @param decryptor Decryptor for encrypted Bloom filter modules.
+  /// @param row_group_ordinal Ordinal of the row group containing this Bloom filter.
+  /// @param column_ordinal Ordinal of the column containing this Bloom filter.
+  /// @return The BlockSplitBloomFilter.
+  static BlockSplitBloomFilter DeserializeEncrypted(
+      const ReaderProperties& properties, ArrowInputStream* input_stream,
+      std::optional<int64_t> bloom_filter_length, Decryptor* decryptor,
+      int16_t row_group_ordinal, int16_t column_ordinal);
 
  private:
   inline void InsertHashImpl(uint64_t hash);

--- a/cpp/src/parquet/bloom_filter.h
+++ b/cpp/src/parquet/bloom_filter.h
@@ -23,13 +23,12 @@
 
 #include "arrow/util/bit_util.h"
 #include "arrow/util/logging.h"
+#include "parquet/encryption/type_fwd.h"
 #include "parquet/hasher.h"
 #include "parquet/platform.h"
 #include "parquet/types.h"
 
 namespace parquet {
-
-class Decryptor;
 
 // A Bloom filter is a compact structure to indicate whether an item is not in a set or
 // probably in a set. The Bloom filter usually consists of a bit set that represents a

--- a/cpp/src/parquet/bloom_filter_reader.cc
+++ b/cpp/src/parquet/bloom_filter_reader.cc
@@ -88,7 +88,7 @@ std::unique_ptr<BloomFilter> RowGroupBloomFilterReaderImpl::GetColumnBloomFilter
       InternalFileDecryptor::GetColumnMetaDecryptorFactory(file_decryptor_.get(),
                                                            crypto_metadata.get())();
   std::unique_ptr<Decryptor> bitset_decryptor =
-      InternalFileDecryptor::GetColumnDataDecryptorFactory(file_decryptor_.get(),
+      InternalFileDecryptor::GetColumnMetaDecryptorFactory(file_decryptor_.get(),
                                                            crypto_metadata.get())();
   if (header_decryptor != nullptr || bitset_decryptor != nullptr) {
     constexpr auto kEncryptedOrdinalLimit = 32767;

--- a/cpp/src/parquet/bloom_filter_reader.cc
+++ b/cpp/src/parquet/bloom_filter_reader.cc
@@ -90,6 +90,16 @@ std::unique_ptr<BloomFilter> RowGroupBloomFilterReaderImpl::GetColumnBloomFilter
   std::unique_ptr<Decryptor> bitset_decryptor =
       InternalFileDecryptor::GetColumnDataDecryptorFactory(file_decryptor_.get(),
                                                            crypto_metadata.get())();
+  if (header_decryptor != nullptr || bitset_decryptor != nullptr) {
+    constexpr auto kEncryptedOrdinalLimit = 32767;
+    if (ARROW_PREDICT_FALSE(row_group_ordinal_ > kEncryptedOrdinalLimit)) {
+      throw ParquetException("Encrypted files cannot contain more than 32767 row groups");
+    }
+    if (ARROW_PREDICT_FALSE(i > kEncryptedOrdinalLimit)) {
+      throw ParquetException("Encrypted files cannot contain more than 32767 columns");
+    }
+  }
+
   if (header_decryptor != nullptr) {
     UpdateDecryptor(header_decryptor.get(), row_group_ordinal_, static_cast<int16_t>(i),
                     encryption::kBloomFilterHeader);
@@ -98,6 +108,7 @@ std::unique_ptr<BloomFilter> RowGroupBloomFilterReaderImpl::GetColumnBloomFilter
     UpdateDecryptor(bitset_decryptor.get(), row_group_ordinal_, static_cast<int16_t>(i),
                     encryption::kBloomFilterBitset);
   }
+
   const int64_t stream_length =
       bloom_filter_length ? *bloom_filter_length : file_size - *bloom_filter_offset;
   auto stream = ::arrow::io::RandomAccessFile::GetStream(input_, *bloom_filter_offset,

--- a/cpp/src/parquet/bloom_filter_reader.cc
+++ b/cpp/src/parquet/bloom_filter_reader.cc
@@ -17,7 +17,6 @@
 
 #include "parquet/bloom_filter_reader.h"
 #include "parquet/bloom_filter.h"
-#include "parquet/encryption/encryption_internal.h"
 #include "parquet/encryption/internal_file_decryptor.h"
 #include "parquet/exception.h"
 #include "parquet/metadata.h"
@@ -83,12 +82,12 @@ std::unique_ptr<BloomFilter> RowGroupBloomFilterReaderImpl::GetColumnBloomFilter
           "bloom filter length + bloom filter offset greater than file size");
     }
   }
+
   std::unique_ptr<ColumnCryptoMetaData> crypto_metadata = col_chunk->crypto_metadata();
-  auto meta_decryptor_factory = InternalFileDecryptor::GetColumnMetaDecryptorFactory(
-      file_decryptor_.get(), crypto_metadata.get());
-  std::unique_ptr<Decryptor> header_decryptor = meta_decryptor_factory();
-  std::unique_ptr<Decryptor> bitset_decryptor = meta_decryptor_factory();
-  if (header_decryptor != nullptr || bitset_decryptor != nullptr) {
+  std::unique_ptr<Decryptor> decryptor =
+      InternalFileDecryptor::GetColumnMetaDecryptorFactory(file_decryptor_.get(),
+                                                           crypto_metadata.get())();
+  if (decryptor != nullptr) {
     constexpr auto kEncryptedOrdinalLimit = 32767;
     if (ARROW_PREDICT_FALSE(row_group_ordinal_ > kEncryptedOrdinalLimit)) {
       throw ParquetException("Encrypted files cannot contain more than 32767 row groups");
@@ -98,22 +97,17 @@ std::unique_ptr<BloomFilter> RowGroupBloomFilterReaderImpl::GetColumnBloomFilter
     }
   }
 
-  if (header_decryptor != nullptr) {
-    UpdateDecryptor(header_decryptor.get(), row_group_ordinal_, static_cast<int16_t>(i),
-                    encryption::kBloomFilterHeader);
-  }
-  if (bitset_decryptor != nullptr) {
-    UpdateDecryptor(bitset_decryptor.get(), row_group_ordinal_, static_cast<int16_t>(i),
-                    encryption::kBloomFilterBitset);
-  }
-
   const int64_t stream_length =
       bloom_filter_length ? *bloom_filter_length : file_size - *bloom_filter_offset;
   auto stream = ::arrow::io::RandomAccessFile::GetStream(input_, *bloom_filter_offset,
                                                          stream_length);
   auto bloom_filter =
-      BlockSplitBloomFilter::Deserialize(properties_, stream->get(), bloom_filter_length,
-                                         header_decryptor.get(), bitset_decryptor.get());
+      decryptor != nullptr
+          ? BlockSplitBloomFilter::DeserializeEncrypted(
+                properties_, stream->get(), bloom_filter_length, decryptor.get(),
+                static_cast<int16_t>(row_group_ordinal_), static_cast<int16_t>(i))
+          : BlockSplitBloomFilter::Deserialize(properties_, stream->get(),
+                                               bloom_filter_length);
   return std::make_unique<BlockSplitBloomFilter>(std::move(bloom_filter));
 }
 

--- a/cpp/src/parquet/bloom_filter_reader.cc
+++ b/cpp/src/parquet/bloom_filter_reader.cc
@@ -84,12 +84,10 @@ std::unique_ptr<BloomFilter> RowGroupBloomFilterReaderImpl::GetColumnBloomFilter
     }
   }
   std::unique_ptr<ColumnCryptoMetaData> crypto_metadata = col_chunk->crypto_metadata();
-  std::unique_ptr<Decryptor> header_decryptor =
-      InternalFileDecryptor::GetColumnMetaDecryptorFactory(file_decryptor_.get(),
-                                                           crypto_metadata.get())();
-  std::unique_ptr<Decryptor> bitset_decryptor =
-      InternalFileDecryptor::GetColumnMetaDecryptorFactory(file_decryptor_.get(),
-                                                           crypto_metadata.get())();
+  auto meta_decryptor_factory = InternalFileDecryptor::GetColumnMetaDecryptorFactory(
+      file_decryptor_.get(), crypto_metadata.get());
+  std::unique_ptr<Decryptor> header_decryptor = meta_decryptor_factory();
+  std::unique_ptr<Decryptor> bitset_decryptor = meta_decryptor_factory();
   if (header_decryptor != nullptr || bitset_decryptor != nullptr) {
     constexpr auto kEncryptedOrdinalLimit = 32767;
     if (ARROW_PREDICT_FALSE(row_group_ordinal_ > kEncryptedOrdinalLimit)) {

--- a/cpp/src/parquet/encryption/bloom_filter_encryption_test.cc
+++ b/cpp/src/parquet/encryption/bloom_filter_encryption_test.cc
@@ -1,0 +1,236 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "arrow/buffer.h"
+#include "arrow/io/file.h"
+#include "arrow/util/secure_string.h"
+#include "arrow/util/span.h"
+
+#include "parquet/bloom_filter.h"
+#include "parquet/encryption/encryption_internal.h"
+#include "parquet/encryption/internal_file_decryptor.h"
+#include "parquet/exception.h"
+#include "parquet/platform.h"
+#include "parquet/test_util.h"
+#include "parquet/thrift_internal.h"
+#include "parquet/types.h"
+
+namespace parquet::encryption::test {
+namespace {
+
+using ::parquet::BlockSplitBloomFilter;
+using ::parquet::CreateOutputStream;
+using ::parquet::Decryptor;
+using ::parquet::ReaderProperties;
+
+struct EncryptedBloomFilterPayload {
+  std::shared_ptr<Buffer> buffer;
+  std::unique_ptr<Decryptor> header_decryptor;
+  std::unique_ptr<Decryptor> bitset_decryptor;
+  std::vector<uint8_t> bitset;
+  int64_t total_cipher_len = 0;
+};
+
+EncryptedBloomFilterPayload BuildEncryptedBloomFilterPayload(int32_t bitset_size) {
+  // Build an encrypted payload in memory to exercise the reader path without relying
+  // on writer-side encryption support.
+  EncryptedBloomFilterPayload payload;
+  payload.bitset.resize(bitset_size);
+  for (int32_t i = 0; i < bitset_size; ++i) {
+    payload.bitset[static_cast<size_t>(i)] = static_cast<uint8_t>(i);
+  }
+
+  // Prepare a valid Bloom filter header for the given bitset size.
+  format::BloomFilterHeader header;
+  header.algorithm.__set_BLOCK(format::SplitBlockAlgorithm());
+  header.hash.__set_XXHASH(format::XxHash());
+  header.compression.__set_UNCOMPRESSED(format::Uncompressed());
+  header.__set_numBytes(bitset_size);
+
+  auto header_sink = CreateOutputStream();
+  ThriftSerializer serializer;
+  serializer.Serialize(&header, header_sink.get());
+  PARQUET_ASSIGN_OR_THROW(auto header_buf, header_sink->Finish());
+
+  const std::string file_aad = "file_aad";
+  const int16_t row_group_ordinal = 0;
+  const int16_t column_ordinal = 0;
+  // AAD must match the module type, row group, and column ordinals.
+  const std::string header_aad =
+      encryption::CreateModuleAad(file_aad, encryption::kBloomFilterHeader,
+                                  row_group_ordinal, column_ordinal, kNonPageOrdinal);
+  const std::string bitset_aad =
+      encryption::CreateModuleAad(file_aad, encryption::kBloomFilterBitset,
+                                  row_group_ordinal, column_ordinal, kNonPageOrdinal);
+
+  // Use fixed keys for deterministic test data.
+  const ::arrow::util::SecureString header_key("0123456789abcdef");
+  const ::arrow::util::SecureString bitset_key("abcdef0123456789");
+  auto header_encryptor = encryption::AesEncryptor::Make(
+      ParquetCipher::AES_GCM_V1, static_cast<int32_t>(header_key.size()), true);
+  auto bitset_encryptor = encryption::AesEncryptor::Make(
+      ParquetCipher::AES_GCM_V1, static_cast<int32_t>(bitset_key.size()), false);
+
+  // Encrypt header with the metadata cipher (AES-GCM).
+  const int32_t header_cipher_len =
+      header_encryptor->CiphertextLength(static_cast<int64_t>(header_buf->size()));
+  std::shared_ptr<Buffer> header_cipher_buf =
+      AllocateBuffer(::arrow::default_memory_pool(), header_cipher_len);
+  const int32_t header_written = header_encryptor->Encrypt(
+      header_buf->span_as<const uint8_t>(), header_key.as_span(), str2span(header_aad),
+      header_cipher_buf->mutable_span_as<uint8_t>());
+  if (header_written != header_cipher_len) {
+    throw ParquetException("Header encryption length mismatch");
+  }
+
+  // Encrypt bitset with the data cipher (AES-GCM).
+  const int32_t bitset_cipher_len =
+      bitset_encryptor->CiphertextLength(static_cast<int64_t>(payload.bitset.size()));
+  std::shared_ptr<Buffer> bitset_cipher_buf =
+      AllocateBuffer(::arrow::default_memory_pool(), bitset_cipher_len);
+  const int32_t bitset_written = bitset_encryptor->Encrypt(
+      ::arrow::util::span<const uint8_t>(payload.bitset.data(), payload.bitset.size()),
+      bitset_key.as_span(), str2span(bitset_aad),
+      bitset_cipher_buf->mutable_span_as<uint8_t>());
+  if (bitset_written != bitset_cipher_len) {
+    throw ParquetException("Bitset encryption length mismatch");
+  }
+
+  // Concatenate encrypted header and encrypted bitset.
+  payload.total_cipher_len = static_cast<int64_t>(header_cipher_len) + bitset_cipher_len;
+  std::shared_ptr<Buffer> total_cipher_buf =
+      AllocateBuffer(::arrow::default_memory_pool(), payload.total_cipher_len);
+  std::memcpy(total_cipher_buf->mutable_data(), header_cipher_buf->data(),
+              header_cipher_len);
+  std::memcpy(total_cipher_buf->mutable_data() + header_cipher_len,
+              bitset_cipher_buf->data(), bitset_cipher_len);
+  payload.buffer = std::move(total_cipher_buf);
+
+  payload.header_decryptor = std::make_unique<Decryptor>(
+      encryption::AesDecryptor::Make(ParquetCipher::AES_GCM_V1,
+                                     static_cast<int32_t>(header_key.size()), true),
+      header_key, file_aad, header_aad, ::arrow::default_memory_pool());
+  payload.bitset_decryptor = std::make_unique<Decryptor>(
+      encryption::AesDecryptor::Make(ParquetCipher::AES_GCM_V1,
+                                     static_cast<int32_t>(bitset_key.size()), false),
+      bitset_key, file_aad, bitset_aad, ::arrow::default_memory_pool());
+
+  return payload;
+}
+
+}  // namespace
+
+TEST(EncryptedDeserializeTest, TestBloomFilter) {
+  // It decrypts the header and bitset and validates Bloom filter behavior.
+  const int32_t bitset_size = 128;
+  auto payload = BuildEncryptedBloomFilterPayload(bitset_size);
+  ReaderProperties reader_properties;
+  ::arrow::io::BufferReader source(payload.buffer);
+  BlockSplitBloomFilter decrypted = BlockSplitBloomFilter::Deserialize(
+      reader_properties, &source, payload.total_cipher_len,
+      payload.header_decryptor.get(), payload.bitset_decryptor.get());
+
+  BlockSplitBloomFilter expected;
+  expected.Init(payload.bitset.data(), bitset_size);
+  for (int value : {1, 2, 3, 4, 5, 42, 99}) {
+    EXPECT_EQ(expected.FindHash(expected.Hash(value)),
+              decrypted.FindHash(decrypted.Hash(value)));
+  }
+}
+
+TEST(EncryptedDeserializeTest, TestBloomFilterInvalidLength) {
+  // It throws when the reported total length does not match the payload.
+  const int32_t bitset_size = 128;
+  auto payload = BuildEncryptedBloomFilterPayload(bitset_size);
+
+  ReaderProperties reader_properties;
+  ::arrow::io::BufferReader source(payload.buffer);
+  EXPECT_THROW_THAT(
+      [&]() {
+        BlockSplitBloomFilter::Deserialize(
+            reader_properties, &source, payload.total_cipher_len + 1,
+            payload.header_decryptor.get(), payload.bitset_decryptor.get());
+      },
+      ParquetException,
+      ::testing::Property(&ParquetException::what,
+                          ::testing::HasSubstr("Bloom filter length")));
+}
+
+TEST(EncryptedDeserializeTest, TestBloomFilterMissingDecryptor) {
+  // It throws when only one decryptor is provided.
+  const int32_t bitset_size = 128;
+  auto payload = BuildEncryptedBloomFilterPayload(bitset_size);
+  ReaderProperties reader_properties;
+
+  {
+    ::arrow::io::BufferReader source(payload.buffer);
+    EXPECT_THROW_THAT(
+        [&]() {
+          BlockSplitBloomFilter::Deserialize(reader_properties, &source,
+                                             payload.total_cipher_len,
+                                             payload.header_decryptor.get(), nullptr);
+        },
+        ParquetException,
+        ::testing::Property(
+            &ParquetException::what,
+            ::testing::HasSubstr("Bloom filter decryptors must be both provided")));
+  }
+  {
+    ::arrow::io::BufferReader source(payload.buffer);
+    EXPECT_THROW_THAT(
+        [&]() {
+          BlockSplitBloomFilter::Deserialize(reader_properties, &source,
+                                             payload.total_cipher_len, nullptr,
+                                             payload.bitset_decryptor.get());
+        },
+        ParquetException,
+        ::testing::Property(
+            &ParquetException::what,
+            ::testing::HasSubstr("Bloom filter decryptors must be both provided")));
+  }
+}
+
+TEST(EncryptedDeserializeTest, TestBloomFilterWithoutLength) {
+  // It decrypts the payload when bloom_filter_length is not provided.
+  const int32_t bitset_size = 128;
+  auto payload = BuildEncryptedBloomFilterPayload(bitset_size);
+  ReaderProperties reader_properties;
+  ::arrow::io::BufferReader source(payload.buffer);
+  BlockSplitBloomFilter decrypted = BlockSplitBloomFilter::Deserialize(
+      reader_properties, &source, std::nullopt, payload.header_decryptor.get(),
+      payload.bitset_decryptor.get());
+
+  BlockSplitBloomFilter expected;
+  expected.Init(payload.bitset.data(), bitset_size);
+  for (int value : {1, 2, 3, 4, 5, 42, 99}) {
+    EXPECT_EQ(expected.FindHash(expected.Hash(value)),
+              decrypted.FindHash(decrypted.Hash(value)));
+  }
+}
+
+}  // namespace parquet::encryption::test


### PR DESCRIPTION
### Rationale for this change
Reading bloom filters from encrypted Parquet files previously raised an exception. This change implements encrypted bloom filter deserialization by decrypting the Thrift header (module id 8) and bitset (module id 9) separately, and adds the necessary validation and tests.

### What changes are included in this PR?
- Wire metadata decryptor creation into the bloom filter reader
- Add BlockSplitBloomFilter::DeserializeEncrypted(...) for encrypted bloom filters
- Remove the fuzzer workaround that swallowed encrypted bloom filter exceptions

### Are these changes tested?
Yes.
### Are there any user-facing changes?
Yes.


* GitHub Issue: #48334