### PR TITLE
GH-49335: [CI] Don't run C++ extra jobs with the `CI: Extra: R` label

### DIFF
--- a/.github/workflows/check_labels.yml
+++ b/.github/workflows/check_labels.yml
@@ -59,6 +59,10 @@ jobs:
               echo "force=true" >> "${GITHUB_OUTPUT}"
               ;;
             pull_request)
+              gh pr view ${{ github.event.number }} \
+                --jq '[.labels[].name | select(startswith("CI: Extra"))]' \
+                --json labels \
+                --repo ${GITHUB_REPOSITORY}
               {
                 echo "ci-extra-labels<<LABELS"
                 gh pr view ${{ github.event.number }} \

--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -422,7 +422,7 @@ jobs:
       ARROW_BUILD_STATIC: OFF
       ARROW_BUILD_TESTS: ON
       ARROW_BUILD_TYPE: release
-      # Turn Arrow CSV off to disable `find_package(Arrow)` check on MSVC CI. 
+      # Turn Arrow CSV off to disable `find_package(Arrow)` check on MSVC CI.
       # GH-49050 TODO: enable `find_package(Arrow)` check on MSVC CI.
       ARROW_CSV: OFF
       ARROW_DEPENDENCY_SOURCE: VCPKG
@@ -594,7 +594,7 @@ jobs:
           dev_msi_name=$(echo ${msi_name} | sed -e "s/win64\.msi$/dev-$(date +%Y-%m-%d)-win64.msi/")
           mv "${msi_name}" "${dev_msi_name}"
           cd ..
-          
+
           tree odbc-installer
       - name: Checkout Arrow
         uses: actions/checkout@v6


### PR DESCRIPTION
### Rationale for this change

TODO

### What changes are included in this PR?

TODO

### Are these changes tested?

TODO

### Are there any user-facing changes?

No.
* GitHub Issue: #49335