### PR TITLE
GH-35806: [R] Improve error message for null type inference with sparse CSV data

### DIFF
--- a/r/R/util.R
+++ b/r/R/util.R
@@ -196,7 +196,6 @@ repeat_value_as_array <- function(object, n) {
 }
 
 handle_csv_read_error <- function(msg, call, schema) {
-  # Handle null type inference issue with sparse data
   if (grepl("conversion error to null", msg)) {
     msg <- c(
       msg,

--- a/r/R/util.R
+++ b/r/R/util.R
@@ -202,9 +202,8 @@ handle_csv_read_error <- function(msg, call, schema) {
       msg,
       i = paste(
         "Column type was inferred as null because the first block of data",
-        "(default 1MB, set via `block_size` in read options) contained only",
-        "missing values. Try specifying the column types explicitly using the",
-        "`col_types` or `schema` argument."
+        "contained only missing values. See `?csv_read_options` for how to",
+        "set a smaller value."
       )
     )
     abort(msg, call = call)

--- a/r/R/util.R
+++ b/r/R/util.R
@@ -196,6 +196,21 @@ repeat_value_as_array <- function(object, n) {
 }
 
 handle_csv_read_error <- function(msg, call, schema) {
+  # Handle null type inference issue with sparse data
+  if (grepl("conversion error to null", msg)) {
+    msg <- c(
+      msg,
+      i = paste(
+        "Column type was inferred as null because the first block of data",
+        "(default 1MB, set via `block_size` in read options) contained only",
+        "missing values. Try specifying the column types explicitly using the",
+        "`col_types` or `schema` argument."
+      )
+    )
+    abort(msg, call = call)
+  }
+
+  # Handle schema + header row issue
   if (grepl("conversion error", msg) && inherits(schema, "Schema")) {
     msg <- c(
       msg,

--- a/r/R/util.R
+++ b/r/R/util.R
@@ -208,7 +208,6 @@ handle_csv_read_error <- function(msg, call, schema) {
     abort(msg, call = call)
   }
 
-  # Handle schema + header row issue
   if (grepl("conversion error", msg) && inherits(schema, "Schema")) {
     msg <- c(
       msg,

--- a/r/R/util.R
+++ b/r/R/util.R
@@ -202,7 +202,7 @@ handle_csv_read_error <- function(msg, call, schema) {
       i = paste(
         "If you have not specified the schema, this error may be due to the column type being",
         "inferred as `null` because the first block of data contained only missing values.",
-        "See `?csv_read_options` for how to set a smaller value."
+        "See `?csv_read_options` for how to set a smaller value or specify a schema if you know the correct types."
       )
     )
     abort(msg, call = call)

--- a/r/R/util.R
+++ b/r/R/util.R
@@ -202,7 +202,7 @@ handle_csv_read_error <- function(msg, call, schema) {
       i = paste(
         "If you have not specified the schema, this error may be due to the column type being",
         "inferred as `null` because the first block of data contained only missing values.",
-        "See `?csv_read_options` for how to set a smaller value or specify a schema if you know the correct types."
+        "See `?csv_read_options` for how to set a larger value or specify a schema if you know the correct types."
       )
     )
     abort(msg, call = call)

--- a/r/R/util.R
+++ b/r/R/util.R
@@ -200,9 +200,9 @@ handle_csv_read_error <- function(msg, call, schema) {
     msg <- c(
       msg,
       i = paste(
-        "Column type was inferred as null because the first block of data",
-        "contained only missing values. See `?csv_read_options` for how to",
-        "set a smaller value."
+        "If you have not specified the schema, this error may be due to the column type being",
+        "inferred as `null` because the first block of data contained only missing values.",
+        "See `?csv_read_options` for how to set a smaller value."
       )
     )
     abort(msg, call = call)

--- a/r/R/util.R
+++ b/r/R/util.R
@@ -196,7 +196,9 @@ repeat_value_as_array <- function(object, n) {
 }
 
 handle_csv_read_error <- function(msg, call, schema) {
-  if (grepl("conversion error to null", msg)) {
+  # Dataset collection passes empty schema() when no explicit
+  # CSV schema from the original call is available in this error path.
+  if (grepl("conversion error to null", msg) && is_empty_schema(schema)) {
     msg <- c(
       msg,
       i = paste(
@@ -301,4 +303,8 @@ col_type_from_compact <- function(x, y) {
     "?" = NULL,
     abort(paste0("Unsupported compact specification: '", x, "' for column '", y, "'"))
   )
+}
+
+is_empty_schema <- function(x) {
+  x == schema()
 }

--- a/r/tests/testthat/test-dataset-csv.R
+++ b/r/tests/testthat/test-dataset-csv.R
@@ -711,3 +711,21 @@ test_that("open_dataset() with `decimal_point` argument", {
     tibble(x = 1.2, y = "c")
   )
 })
+
+
+test_that("more informative error when column inferred as null due to sparse data (GH-35806)", {
+  tf <- tempfile()
+  on.exit(unlink(tf))
+
+  # Create a CSV where the second column has NAs in the first rows
+  # but a value later - this causes Arrow to infer null type
+  writeLines(c("x,y", paste0(1:100, ",")), tf)
+  write("101,foo", tf, append = TRUE)
+
+  # Use small block_size to force type inference from only the first rows
+  expect_error(
+    open_dataset(tf, format = "csv", read_options = csv_read_options(block_size = 100L)) |>
+      collect(),
+    "inferred as null"
+  )
+})

--- a/r/tests/testthat/test-dataset-csv.R
+++ b/r/tests/testthat/test-dataset-csv.R
@@ -712,19 +712,19 @@ test_that("open_dataset() with `decimal_point` argument", {
   )
 })
 
-
 test_that("more informative error when column inferred as null due to sparse data (GH-35806)", {
   tf <- tempfile()
   on.exit(unlink(tf))
 
-  # Create a CSV where the second column has NAs in the first rows
-  # but a value later - this causes Arrow to infer null type
   writeLines(c("x,y", paste0(1:100, ",")), tf)
   write("101,foo", tf, append = TRUE)
 
-  # Use small block_size to force type inference from only the first rows
   expect_error(
-    open_dataset(tf, format = "csv", read_options = csv_read_options(block_size = 100L)) |>
+    open_dataset(
+      tf,
+      format = "csv",
+      read_options = csv_read_options(block_size = 100L)
+    ) |>
       collect(),
     "inferred as null"
   )

--- a/r/tests/testthat/test-dataset-csv.R
+++ b/r/tests/testthat/test-dataset-csv.R
@@ -726,6 +726,6 @@ test_that("more informative error when column inferred as null due to sparse dat
       read_options = csv_read_options(block_size = 100L)
     ) |>
       collect(),
-    "column type inferred as"
+    "column type being inferred as"
   )
 })

--- a/r/tests/testthat/test-dataset-csv.R
+++ b/r/tests/testthat/test-dataset-csv.R
@@ -726,6 +726,6 @@ test_that("more informative error when column inferred as null due to sparse dat
       read_options = csv_read_options(block_size = 100L)
     ) |>
       collect(),
-    "inferred as null"
+    "column type inferred as"
   )
 })


### PR DESCRIPTION
### Rationale for this change

When reading a CSV with sparse data (many missing values followed by actual values), Arrow can infer a column type as `null` based on the first block of data. When non-null values appear later, the error message incorrectly suggests using `skip = 1` for header rows, which is misleading.

### What changes are included in this PR?

Adds a specific check for "conversion error to null" that provides a helpful message explaining the cause (type inference from sparse data) and the solution (change the block size to use for inference).

### Are these changes tested?

Yes, added a test in `test-dataset-csv.R`.

### Are there any user-facing changes?

Yes, improved error message when CSV type inference fails due to sparse data.

---

This PR was authored by Claude (Opus 4.5) and reviewed by @thisisnic.

🤖 Generated with [Claude Code](https://claude.ai/code)
* GitHub Issue: #35806