### PR TITLE
MINOR: [C++] use std::move to avoid unnecessary copies

### DIFF
--- a/cpp/src/parquet/arrow/reader.cc
+++ b/cpp/src/parquet/arrow/reader.cc
@@ -976,7 +976,7 @@ Status GetReader(const SchemaField& field, const std::shared_ptr<Field>& arrow_f
       if (!schema_child_type.Equals(reader_child_type)) {
         child_field = child_field->WithType(child_reader->field()->type());
       }
-      child_fields.push_back(child_field);
+      child_fields.push_back(std::move(child_field));
       child_readers.emplace_back(std::move(child_reader));
     }
     if (child_fields.empty()) {

--- a/cpp/src/parquet/metadata.cc
+++ b/cpp/src/parquet/metadata.cc
@@ -177,9 +177,9 @@ std::shared_ptr<KeyValueMetadata> FromThriftKeyValueMetadata(const Metadata& sou
     std::vector<std::string> values;
     keys.reserve(source.key_value_metadata.size());
     values.reserve(source.key_value_metadata.size());
-    for (const auto& it : source.key_value_metadata) {
-      keys.push_back(it.key);
-      values.push_back(it.value);
+    for (auto& it : source.key_value_metadata) {
+      keys.push_back(std::move(it.key));
+      values.push_back(std::move(it.value));
     }
     metadata = std::make_shared<KeyValueMetadata>(std::move(keys), std::move(values));
   }

--- a/cpp/src/parquet/metadata.cc
+++ b/cpp/src/parquet/metadata.cc
@@ -177,9 +177,9 @@ std::shared_ptr<KeyValueMetadata> FromThriftKeyValueMetadata(const Metadata& sou
     std::vector<std::string> values;
     keys.reserve(source.key_value_metadata.size());
     values.reserve(source.key_value_metadata.size());
-    for (auto& it : source.key_value_metadata) {
-      keys.push_back(std::move(it.key));
-      values.push_back(std::move(it.value));
+    for (const auto& it : source.key_value_metadata) {
+      keys.push_back(it.key);
+      values.push_back(it.value);
     }
     metadata = std::make_shared<KeyValueMetadata>(std::move(keys), std::move(values));
   }


### PR DESCRIPTION
### Rationale for this change
avoid unnecessary copies

### What changes are included in this PR?
use std::move to avoid unnecessary copies

### Are these changes tested?
yes

### Are there any user-facing changes?
no
