### PR TITLE
GH-49341: [Packaging] Add support for Ubuntu 26.04

### DIFF
--- a/.github/workflows/dev_pr/labeler.yml
+++ b/.github/workflows/dev_pr/labeler.yml
@@ -79,3 +79,12 @@
   - any-glob-to-any-file:
     - .github/workflows/cpp_extra.yml
     - cpp/src/arrow/flight/sql/odbc/**/*
+
+"CI: Extra: Package: Linux":
+- changed-files:
+  - any-glob-to-any-file:
+    - .github/workflows/package_linux.yml
+    - dev/release/binary-task.rb
+    - dev/release/verify-apt.sh
+    - dev/release/verify-yum.sh
+    - dev/tasks/linux-packages/**/*

--- a/.github/workflows/package_linux.yml
+++ b/.github/workflows/package_linux.yml
@@ -109,6 +109,8 @@ jobs:
           - ubuntu-jammy-arm64
           - ubuntu-noble-amd64
           - ubuntu-noble-arm64
+          - ubuntu-resolute-amd64
+          - ubuntu-resolute-arm64
     env:
       DOCKER_VOLUME_PREFIX: ".docker/"
     steps:

--- a/dev/release/binary-task.rb
+++ b/dev/release/binary-task.rb
@@ -1433,6 +1433,7 @@ class BinaryTask
       ["debian", "forky", "main"],
       ["ubuntu", "jammy", "main"],
       ["ubuntu", "noble", "main"],
+      ["ubuntu", "resolute", "main"],
     ]
   end
 

--- a/dev/release/binary-task.rb
+++ b/dev/release/binary-task.rb
@@ -2333,6 +2333,8 @@ class LocalBinaryTask < BinaryTask
       # "ubuntu-jammy-arm64",
       "ubuntu-noble",
       # "ubuntu-noble-arm64",
+      "ubuntu-resolute",
+      # "ubuntu-resolute-arm64",
     ]
   end
 

--- a/dev/release/verify-release-candidate.sh
+++ b/dev/release/verify-release-candidate.sh
@@ -218,7 +218,8 @@ test_apt() {
                     "debian:trixie" \
                     "debian:forky" \
                     "ubuntu:jammy" \
-                    "ubuntu:noble"; do \
+                    "ubuntu:noble" \
+                    "ubuntu:resolute"; do \
         if ! docker run \
                --platform=linux/x86_64 \
                --rm \
@@ -238,7 +239,8 @@ test_apt() {
                     "arm64v8/debian:trixie" \
                     "arm64v8/debian:forky" \
                     "arm64v8/ubuntu:jammy" \
-                    "arm64v8/ubuntu:noble"; do \
+                    "arm64v8/ubuntu:noble" \
+                    "arm64v8/ubuntu:resolute"; do \
         if ! docker run \
                --platform=linux/arm64 \
                --rm \

--- a/dev/tasks/linux-packages/apache-arrow-apt-source/apt/ubuntu-resolute/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow-apt-source/apt/ubuntu-resolute/Dockerfile
@@ -1,0 +1,41 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+FROM ubuntu:resolute
+
+RUN \
+  echo "debconf debconf/frontend select Noninteractive" | \
+    debconf-set-selections
+
+RUN \
+  echo 'APT::Install-Recommends "false";' > \
+    /etc/apt/apt.conf.d/disable-install-recommends
+
+ARG DEBUG
+
+RUN \
+  quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
+  apt update ${quiet} && \
+  apt install -y -V ${quiet} \
+    build-essential \
+    debhelper \
+    devscripts \
+    fakeroot \
+    gnupg \
+    lsb-release && \
+  apt clean && \
+  rm -rf /var/lib/apt/lists/*

--- a/dev/tasks/linux-packages/apache-arrow/apt/ubuntu-resolute-arm64/from
+++ b/dev/tasks/linux-packages/apache-arrow/apt/ubuntu-resolute-arm64/from
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+arm64v8/ubuntu:resolute

--- a/dev/tasks/linux-packages/apache-arrow/apt/ubuntu-resolute/Dockerfile
+++ b/dev/tasks/linux-packages/apache-arrow/apt/ubuntu-resolute/Dockerfile
@@ -1,0 +1,85 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+ARG FROM=ubuntu:resolute
+FROM ${FROM}
+
+RUN \
+  echo "debconf debconf/frontend select Noninteractive" | \
+    debconf-set-selections
+
+RUN \
+  echo 'APT::Install-Recommends "false";' > \
+    /etc/apt/apt.conf.d/disable-install-recommends
+
+ARG DEBUG
+RUN \
+  quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
+  apt update ${quiet} && \
+  apt install -y -V ${quiet} \
+    build-essential \
+    clang \
+    clang-tools \
+    cmake \
+    debhelper \
+    devscripts \
+    gi-docgen \
+    git \
+    libboost-filesystem-dev \
+    libboost-system-dev \
+    libbrotli-dev \
+    libbz2-dev \
+    libc-ares-dev \
+    libcurl4-openssl-dev \
+    libgirepository1.0-dev \
+    libglib2.0-doc \
+    libgmock-dev \
+    libgoogle-glog-dev \
+    libgrpc++-dev \
+    libgtest-dev \
+    liblz4-dev \
+    libprotobuf-dev \
+    libprotoc-dev \
+    libre2-dev \
+    libsnappy-dev \
+    libssl-dev \
+    libthrift-dev \
+    libutf8proc-dev \
+    libxxhash-dev \
+    libzstd-dev \
+    llvm-dev \
+    lsb-release \
+    meson \
+    mold \
+    ninja-build \
+    nlohmann-json3-dev \
+    pkg-config \
+    protobuf-compiler-grpc \
+    python3-dev \
+    python3-pip \
+    python3-setuptools \
+    rapidjson-dev \
+    tzdata \
+    valac \
+    zlib1g-dev && \
+  if apt list | grep -q '^libcuda'; then \
+    apt install -y -V ${quiet} nvidia-cuda-toolkit; \
+  else \
+    :; \
+  fi && \
+  apt clean && \
+  rm -rf /var/lib/apt/lists/*

--- a/dev/tasks/linux-packages/apache-arrow/debian/rules
+++ b/dev/tasks/linux-packages/apache-arrow/debian/rules
@@ -6,7 +6,8 @@
 # This has to be exported to make some magic below work.
 export DH_OPTIONS
 
-export DEB_BUILD_MAINT_OPTIONS=reproducible=-timeless
+# lto1 (GCC 15) on Ubuntu 26.04 crashes with LTO.
+export DEB_BUILD_MAINT_OPTIONS=optimize=-lto,reproducible=-timeless
 
 BUILD_TYPE=relwithdebinfo
 
@@ -25,6 +26,12 @@ override_dh_auto_configure:
 	  ARROW_CUDA=ON;					\
 	else							\
 	  ARROW_CUDA=OFF;					\
+	fi;							\
+	if [ "$${code_name}" = "resolute" ]; then		\
+	  : "RE2 is not built for C++17 or later";		\
+	  re2_SOURCE=BUNDLED;					\
+	else							\
+	  re2_SOURCE=SYSTEM;					\
 	fi;							\
 	dh_auto_configure					\
 	  --sourcedirectory=cpp					\
@@ -61,7 +68,8 @@ override_dh_auto_configure:
 	  -DCUDAToolkit_ROOT=/usr				\
 	  -DFETCHCONTENT_FULLY_DISCONNECTED=OFF			\
 	  -DPARQUET_BUILD_EXECUTABLES=ON			\
-	  -DPARQUET_REQUIRE_ENCRYPTION=ON
+	  -DPARQUET_REQUIRE_ENCRYPTION=ON			\
+	  -Dre2_SOURCE=$${re2_SOURCE}
 
 override_dh_auto_build:
 	dh_auto_build				\

--- a/dev/tasks/linux-packages/apache-arrow/debian/rules
+++ b/dev/tasks/linux-packages/apache-arrow/debian/rules
@@ -7,7 +7,12 @@
 export DH_OPTIONS
 
 # lto1 (GCC 15) on Ubuntu 26.04 crashes with LTO.
+include /etc/os-release
+ifeq ($(VERSION_CODENAME),resolute)
 export DEB_BUILD_MAINT_OPTIONS=optimize=-lto,reproducible=-timeless
+else
+export DEB_BUILD_MAINT_OPTIONS=reproducible=-timeless
+endif
 
 BUILD_TYPE=relwithdebinfo
 
@@ -15,9 +20,7 @@ BUILD_TYPE=relwithdebinfo
 	dh $@ --with gir
 
 override_dh_auto_configure:
-	code_name="$$(. /etc/os-release &&			\
-                        echo $${VERSION_CODENAME})";		\
-	if [ "$${code_name}" = "focal" ]; then			\
+	if [ "$(VERSION_CODENAME)" = "focal" ]; then		\
 	  ARROW_AZURE=OFF;					\
 	else							\
 	  ARROW_AZURE=ON;					\
@@ -27,7 +30,7 @@ override_dh_auto_configure:
 	else							\
 	  ARROW_CUDA=OFF;					\
 	fi;							\
-	if [ "$${code_name}" = "resolute" ]; then		\
+	if [ "$(VERSION_CODENAME)" = "resolute" ]; then		\
 	  : "RE2 is not built for C++17 or later";		\
 	  re2_SOURCE=BUNDLED;					\
 	else							\

--- a/dev/tasks/linux-packages/package-task.rb
+++ b/dev/tasks/linux-packages/package-task.rb
@@ -278,6 +278,8 @@ class PackageTask
       # "ubuntu-jammy-arm64",
       "ubuntu-noble",
       # "ubuntu-noble-arm64",
+      "ubuntu-resolute",
+      # "ubuntu-resolute-arm64",
     ]
   end
 


### PR DESCRIPTION
### Rationale for this change

Ubuntu 26.04 will be the next LTS for Ubuntu. It'll be released on 2026-04.

### What changes are included in this PR?

* Add `Dockerfile`s for Ubuntu 26.04
* Add Ubuntu 26.04 entries 
* Add a labeler configuration for Linux packages

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #49341