### PR TITLE
GH-49351: [C++] Check TZDIR environment variable in vendored date library

### DIFF
--- a/cpp/src/arrow/public_api_test.cc
+++ b/cpp/src/arrow/public_api_test.cc
@@ -128,11 +128,9 @@ TEST(Misc, TZDIREnvironmentVariable) {
   // Find a valid zoneinfo directory
   std::string tz_dir;
   const char* env_tzdir = std::getenv("TZDIR");
-  if (env_tzdir != nullptr &&
-      std::filesystem::is_directory(env_tzdir)) {
+  if (env_tzdir != nullptr && std::filesystem::is_directory(env_tzdir)) {
     tz_dir = env_tzdir;
-  } else if (std::filesystem::is_directory(
-                 "/usr/share/zoneinfo")) {
+  } else if (std::filesystem::is_directory("/usr/share/zoneinfo")) {
     tz_dir = "/usr/share/zoneinfo";
   } else {
     GTEST_SKIP() << "No system zoneinfo directory found";
@@ -140,13 +138,9 @@ TEST(Misc, TZDIREnvironmentVariable) {
 
   // Set TZDIR and verify timezone resolution works
   EnvVarGuard guard("TZDIR", tz_dir);
-  auto arr = ArrayFromJSON(
-      timestamp(TimeUnit::SECOND, "UTC"), "[0]");
+  auto arr = ArrayFromJSON(timestamp(TimeUnit::SECOND, "UTC"), "[0]");
   ASSERT_OK_AND_ASSIGN(
-      auto result,
-      compute::Cast(
-          arr,
-          timestamp(TimeUnit::SECOND, "America/New_York")));
+      auto result, compute::Cast(arr, timestamp(TimeUnit::SECOND, "America/New_York")));
   ASSERT_NE(result.make_array(), nullptr);
 }
 #endif

--- a/cpp/src/arrow/vendored/datetime/README.md
+++ b/cpp/src/arrow/vendored/datetime/README.md
@@ -25,7 +25,10 @@ The following changes are made:
 - enclose the `date` namespace inside the `arrow_vendored` namespace
 - fix 4 declarations like `CONSTCD11 date::day  operator "" _d(unsigned long long d) NOEXCEPT;`
   to not have offending whitespace for modern clang:
-  `CONSTCD11 date::day  operator ""_d(unsigned long long d) NOEXCEPT;` 
+  `CONSTCD11 date::day  operator ""_d(unsigned long long d) NOEXCEPT;`
+- check the TZDIR environment variable in `discover_tz_dir()` (tz.cpp) before
+  falling back to hardcoded paths, for compatibility with non-FHS Linux
+  distributions (e.g. NixOS)
 
 ## How to update
 

--- a/cpp/src/arrow/vendored/datetime/tz.cpp
+++ b/cpp/src/arrow/vendored/datetime/tz.cpp
@@ -486,6 +486,12 @@ discover_tz_dir()
 {
     struct stat sb;
     using namespace std;
+    // Check TZDIR environment variable first (POSIX standard)
+    const char* tz_dir_env = std::getenv("TZDIR");
+    if (tz_dir_env != nullptr
+        && stat(tz_dir_env, &sb) == 0
+        && S_ISDIR(sb.st_mode))
+        return tz_dir_env;
 #  if defined(ANDROID) || defined(__ANDROID__)
     CONSTDATA auto tz_dir_default = "/apex/com.android.tzdata/etc/tz";
     CONSTDATA auto tz_dir_fallback = "/system/usr/share/zoneinfo";

--- a/python/pyarrow/conftest.py
+++ b/python/pyarrow/conftest.py
@@ -111,7 +111,8 @@ if sys.platform == "emscripten":
 if sys.platform == "win32":
     defaults['timezone_data'] = windows_has_tzdata()
 elif sys.platform == "emscripten":
-    defaults['timezone_data'] = os.path.exists("/usr/share/zoneinfo")
+    tz_dir = os.environ.get("TZDIR", "/usr/share/zoneinfo")
+    defaults['timezone_data'] = os.path.exists(tz_dir)
 
 try:
     import cython  # noqa


### PR DESCRIPTION
### Rationale for This Change

The vendored Howard Hinnant date library hardcodes `/usr/share/zoneinfo` as the timezone database path in `discover_tz_dir()`. It does not check the `TZDIR` environment variable, which is the POSIX standard mechanism for overriding this path.

This causes timezone operations to fail on non FHS Linux distributions such as NixOS, where `zoneinfo` resides under a non standard path like `/nix/store/.../share/zoneinfo`.

The upstream library also lacks `TZDIR` support.

---

### What Changes Are Included in This PR?

* `cpp/src/arrow/vendored/datetime/tz.cpp`: Check the `TZDIR` environment variable in `discover_tz_dir()` before falling back to platform specific hardcoded paths. Uses `stat()` and `S_ISDIR()` for validation, matching the existing pattern in the function.
* `cpp/src/arrow/vendored/datetime/README.md`: Document the patch.
* `cpp/src/arrow/public_api_test.cc`: Add a non Windows test that sets `TZDIR` and verifies timezone resolution succeeds through Arrow's compute API.
* `python/pyarrow/conftest.py`: Respect `TZDIR` in the emscripten `timezone_data` test marker.

---

### Are These Changes Tested?

Yes. A new `Misc.TZDIREnvironmentVariable` test sets `TZDIR` to a valid `zoneinfo` directory and casts a UTC timestamp to `America/New_York`, verifying the code path works end to end.

---

### Are There Any User Facing Changes?

Arrow now respects the `TZDIR` environment variable on non Windows platforms, enabling timezone operations on systems without `/usr/share/zoneinfo`.

Fixes #49351 
* GitHub Issue: #49351