### PR TITLE
GH-49358: [Python][Doc] Add import statement to filters_to_expression docstring example

### DIFF
--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -147,7 +147,7 @@ def filters_to_expression(filters):
     --------
 
     >>> import pyarrow.parquet as pq
-    >>> filters_to_expression([('foo', '==', 'bar')])
+    >>> pq.filters_to_expression([('foo', '==', 'bar')])
     <pyarrow.compute.Expression (foo == "bar")>
 
     Returns

--- a/python/pyarrow/parquet/core.py
+++ b/python/pyarrow/parquet/core.py
@@ -146,6 +146,7 @@ def filters_to_expression(filters):
     Examples
     --------
 
+    >>> import pyarrow.parquet as pq
     >>> filters_to_expression([('foo', '==', 'bar')])
     <pyarrow.compute.Expression (foo == "bar")>
 


### PR DESCRIPTION
### Rationale for this change

The docstring example for `filters_to_expression` calls the function without any import statement:

https://github.com/apache/arrow/blob/8c27898d36f45ece9b0d114b3d6c6a42d20bde7f/python/pyarrow/parquet/core.py#L149

### What changes are included in this PR?

Updated the `filters_to_expression` docstring example to add `import pyarrow.parquet as pq` and call the function as `pq.filters_to_expression(...)`, making the example self-contained and consistent with the rest of the file.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.

* GitHub Issue: #49358