### PR TITLE
GH-49366: [CI][C++] Use system LLVM to use libstdc++ in gcc-toolset

### DIFF
--- a/ci/docker/cpp-jni.dockerfile
+++ b/ci/docker/cpp-jni.dockerfile
@@ -22,16 +22,19 @@ ARG arch
 ARG arch_short
 
 # Install basic dependencies
-RUN dnf install -y \
-    autoconf \
-    curl \
-    flex \
-    gdb \
-    git \
-    perl-IPC-Cmd \
-    perl-Time-Piece \
-    wget \
-    zip
+RUN dnf module enable -y llvm-toolset && \
+    dnf install -y \
+      autoconf \
+      curl \
+      flex \
+      gdb \
+      git \
+      llvm-devel \
+      llvm-toolset \
+      perl-IPC-Cmd \
+      perl-Time-Piece \
+      wget \
+      zip
 
 # A system Python is required for Ninja and vcpkg in this Dockerfile.
 # On manylinux_2_28 base images, no system Python is installed.
@@ -96,7 +99,9 @@ RUN --mount=type=secret,id=github_repository_owner \
         --x-feature=azure \
         --x-feature=dev \
         --x-feature=flight \
-        --x-feature=gandiva \
+        # We can't use LLVM installed by vcpkg with gcc-toolset because
+        # LLVM installed by vcpkg doesn't use libc++ installed by gcc-toolset.
+        # --x-feature=gandiva \
         --x-feature=gcs \
         --x-feature=json \
         --x-feature=orc \

--- a/ci/vcpkg/vcpkg.json
+++ b/ci/vcpkg/vcpkg.json
@@ -39,6 +39,7 @@
         "benchmark",
         "boost-crc",
         "boost-filesystem",
+        "boost-multiprecision",
         "boost-process",
         "gtest"
       ]
@@ -67,7 +68,6 @@
         "boost-date-time",
         "boost-format",
         "boost-locale",
-        "boost-multiprecision",
         "boost-predef",
         "boost-regex",
         "boost-system",


### PR DESCRIPTION
### Rationale for this change

LLVM (clang) installed by vcpkg doesn't use libstdc++ installed by gcc-toolset. We need to use libstdc++ installed by gcc-toolset not system libstdc++ for C++20 support.

### What changes are included in this PR?

* Use LLVM installed by llvm-toolset module that can use use libstdc++ installed by gcc-toolset
* Move `boost-multiprecision` to `dev` feature because it's also used in `cpp/src/arrow/util/decimal_test.cc`

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #49366