### PR TITLE
GH-49369: [C++][R] Deal with validating libtool again

### DIFF
--- a/cpp/cmake_modules/BuildUtils.cmake
+++ b/cpp/cmake_modules/BuildUtils.cmake
@@ -100,13 +100,13 @@ function(arrow_create_merged_static_lib output_target)
                       OUTPUT_VARIABLE libtool_version
                       OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
       if("${libtool_version}" MATCHES ".*cctools.+([0-9.]+).*")
-        set(${result_var} 
-            TRUE 
+        set(${result_var}
+            TRUE
             PARENT_SCOPE)
       else()
-        set(${result_var} 
-              FALSE 
-              PARENT_SCOPE)
+        set(${result_var}
+            FALSE
+            PARENT_SCOPE)
       endif()
     endfunction()
 
@@ -123,7 +123,7 @@ function(arrow_create_merged_static_lib output_target)
       # HINTS is used before system paths and before PATHS, so we use that
       # even though hard coded paths should go in PATHS
       find_program(LIBTOOL_MACOS libtool
-                   HINTS /usr/bin /Library/Developer/CommandLineTools/usr/bin VALIDATOR 
+                   HINTS /usr/bin /Library/Developer/CommandLineTools/usr/bin VALIDATOR
                          validate_apple_libtool)
       if(NOT LIBTOOL_MACOS)
         message(FATAL_ERROR "Could not find Apple's libtool. GNU libtool is not compatible."

--- a/cpp/cmake_modules/BuildUtils.cmake
+++ b/cpp/cmake_modules/BuildUtils.cmake
@@ -91,28 +91,41 @@ function(arrow_create_merged_static_lib output_target)
   endforeach()
 
   if(APPLE)
+    # Validator function to confirm that the libtool is Apple's libtool.
+    # The apple-distributed libtool is what we want for bundling, but there is
+    # a GNU libtool that has a name collision (and happens to be bundled with R, too).
+    # We are not compatible with GNU libtool, so we need to avoid it.
+    function(validate_apple_libtool result_var item)
+      execute_process(COMMAND "${item}" -V
+                      OUTPUT_VARIABLE libtool_version
+                      OUTPUT_STRIP_TRAILING_WHITESPACE
+                      ERROR_QUIET)
+      if("${libtool_version}" MATCHES ".*cctools-([0-9.]+).*")
+        set(${result_var} TRUE PARENT_SCOPE)
+      else()
+        set(${result_var} FALSE PARENT_SCOPE)
+      endif()
+    endfunction()
+
     if(CMAKE_LIBTOOL)
       set(LIBTOOL_MACOS ${CMAKE_LIBTOOL})
+      # Validate that CMAKE_LIBTOOL is Apple's libtool
+      validate_apple_libtool(is_apple_libtool "${LIBTOOL_MACOS}")
+      if(NOT is_apple_libtool)
+        message(FATAL_ERROR "CMAKE_LIBTOOL does not appear to be Apple's libtool: ${LIBTOOL_MACOS}"
+        )
+      endif()
     else()
-      # The apple-distributed libtool is what we want for bundling, but there is
-      # a GNU libtool that has a namecollision (and happens to be bundled with R, too).
-      # We are not compatible with GNU libtool, so we need to avoid it.
-
-      # check in the obvious places first to find Apple's libtool
+      # Check in the obvious places first to find Apple's libtool
       # HINTS is used before system paths and before PATHS, so we use that
       # even though hard coded paths should go in PATHS
-      # TODO: use a VALIDATOR when we require cmake >= 3.25
       find_program(LIBTOOL_MACOS libtool
-                   HINTS /usr/bin /Library/Developer/CommandLineTools/usr/bin)
-    endif()
-
-    # confirm that the libtool we found is Apple's libtool
-    execute_process(COMMAND ${LIBTOOL_MACOS} -V
-                    OUTPUT_VARIABLE LIBTOOL_V_OUTPUT
-                    OUTPUT_STRIP_TRAILING_WHITESPACE)
-    if(NOT "${LIBTOOL_V_OUTPUT}" MATCHES ".*cctools-([0-9.]+).*")
-      message(FATAL_ERROR "libtool found appears not to be Apple's libtool: ${LIBTOOL_MACOS}"
-      )
+                   HINTS /usr/bin /Library/Developer/CommandLineTools/usr/bin
+                   VALIDATOR validate_apple_libtool)
+      if(NOT LIBTOOL_MACOS)
+        message(FATAL_ERROR "Could not find Apple's libtool. GNU libtool is not compatible."
+        )
+      endif()
     endif()
 
     set(BUNDLE_COMMAND ${LIBTOOL_MACOS} "-no_warning_for_no_symbols" "-static" "-o"

--- a/cpp/cmake_modules/BuildUtils.cmake
+++ b/cpp/cmake_modules/BuildUtils.cmake
@@ -98,12 +98,15 @@ function(arrow_create_merged_static_lib output_target)
     function(validate_apple_libtool result_var item)
       execute_process(COMMAND "${item}" -V
                       OUTPUT_VARIABLE libtool_version
-                      OUTPUT_STRIP_TRAILING_WHITESPACE
-                      ERROR_QUIET)
-      if("${libtool_version}" MATCHES ".*ccFAKEtools-([0-9.]+).*")
-        set(${result_var} TRUE PARENT_SCOPE)
+                      OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
+      if("${libtool_version}" MATCHES ".*cctools.+([0-9.]+).*")
+        set(${result_var} 
+            TRUE 
+            PARENT_SCOPE)
       else()
-        set(${result_var} FALSE PARENT_SCOPE)
+        set(${result_var} 
+              FALSE 
+              PARENT_SCOPE)
       endif()
     endfunction()
 
@@ -120,8 +123,8 @@ function(arrow_create_merged_static_lib output_target)
       # HINTS is used before system paths and before PATHS, so we use that
       # even though hard coded paths should go in PATHS
       find_program(LIBTOOL_MACOS libtool
-                   HINTS /usr/bin /Library/Developer/CommandLineTools/usr/bin
-                   VALIDATOR validate_apple_libtool)
+                   HINTS /usr/bin /Library/Developer/CommandLineTools/usr/bin VALIDATOR 
+                         validate_apple_libtool)
       if(NOT LIBTOOL_MACOS)
         message(FATAL_ERROR "Could not find Apple's libtool. GNU libtool is not compatible."
         )

--- a/cpp/cmake_modules/BuildUtils.cmake
+++ b/cpp/cmake_modules/BuildUtils.cmake
@@ -107,11 +107,7 @@ function(arrow_create_merged_static_lib output_target)
     # We are not compatible with GNU libtool, so we need to avoid it.
     function(validate_apple_libtool result_var item)
       get_libtool_version("${item}" libtool_version)
-      if("${libtool_version}" MATCHES ".*cctools.+([0-9.]+).*")
-        set(${result_var}
-            TRUE
-            PARENT_SCOPE)
-      else()
+      if(NOT "${libtool_version}" MATCHES ".*cctools.+([0-9.]+).*")
         set(${result_var}
             FALSE
             PARENT_SCOPE)

--- a/cpp/cmake_modules/BuildUtils.cmake
+++ b/cpp/cmake_modules/BuildUtils.cmake
@@ -100,7 +100,7 @@ function(arrow_create_merged_static_lib output_target)
                       OUTPUT_VARIABLE libtool_version
                       OUTPUT_STRIP_TRAILING_WHITESPACE
                       ERROR_QUIET)
-      if("${libtool_version}" MATCHES ".*cctools-([0-9.]+).*")
+      if("${libtool_version}" MATCHES ".*ccFAKEtools-([0-9.]+).*")
         set(${result_var} TRUE PARENT_SCOPE)
       else()
         set(${result_var} FALSE PARENT_SCOPE)


### PR DESCRIPTION
### Rationale for this change

Deal with bespoke frameworks on CRAN machines, ensure we can detect Apple-provided `libtool` as opposed to GNU `libtool`. Modernize cmake.

### What changes are included in this PR?

Use `VALIDATOR` to validate `libtool`, a slightly more flexible regex

### Are these changes tested?

Yes

### Are there any user-facing changes?

No, well just one.
* GitHub Issue: #49369