### PR TITLE
GH-49329: [C++][Parquet][CI] Add fuzz target for encoder/decoder roundtrip

### DIFF
--- a/ci/docker/ubuntu-22.04-cpp.dockerfile
+++ b/ci/docker/ubuntu-22.04-cpp.dockerfile
@@ -120,6 +120,7 @@ RUN apt-get update -y -q && \
         rsync \
         tzdata \
         uuid-runtime \
+        unzip \
         wget \
         xz-utils && \
     apt-get clean && \

--- a/ci/docker/ubuntu-24.04-cpp.dockerfile
+++ b/ci/docker/ubuntu-24.04-cpp.dockerfile
@@ -122,6 +122,7 @@ RUN apt-get update -y -q && \
         tzdata \
         tzdata-legacy \
         uuid-runtime \
+        unzip \
         wget && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists*

--- a/ci/scripts/cpp_test.sh
+++ b/ci/scripts/cpp_test.sh
@@ -180,10 +180,38 @@ fi
 
 if [ "${ARROW_FUZZING}" == "ON" ]; then
     # Fuzzing regression tests
+
+    # This will display any errors generated during fuzzing. These errors are
+    # usually not bugs (most fuzz files are invalid and hence generate errors
+    # when trying to read them), which is why they are hidden by default when
+    # fuzzing.
+    export ARROW_FUZZING_VERBOSITY=1
     # Some fuzz regression files may trigger huge memory allocations,
     # let the allocator return null instead of aborting.
     export ASAN_OPTIONS="$ASAN_OPTIONS allocator_may_return_null=1"
-    export ARROW_FUZZING_VERBOSITY=1
+
+    # 1. Generate seed corpuses
+    "${source_dir}/build-support/fuzzing/generate_corpuses.sh" "${binary_output_dir}"
+
+    # 2. Run fuzz targets on seed corpus entries
+    function run_fuzz_target_on_seed_corpus() {
+      fuzz_target_basename=$1
+      corpus_dir=${binary_output_dir}/${fuzz_target_basename}_seed_corpus
+      mkdir -p "${corpus_dir}"
+      rm -f "${corpus_dir}"/*
+      unzip "${binary_output_dir}"/"${fuzz_target_basename}"_seed_corpus.zip -d "${corpus_dir}"
+      "${binary_output_dir}"/"${fuzz_target_basename}" -rss_limit_mb=4000 "${corpus_dir}"/*
+    }
+    run_fuzz_target_on_seed_corpus arrow-csv-fuzz
+    run_fuzz_target_on_seed_corpus arrow-ipc-file-fuzz
+    run_fuzz_target_on_seed_corpus arrow-ipc-stream-fuzz
+    run_fuzz_target_on_seed_corpus arrow-ipc-tensor-stream-fuzz
+    if [ "${ARROW_PARQUET}" == "ON" ]; then
+      run_fuzz_target_on_seed_corpus parquet-arrow-fuzz
+      run_fuzz_target_on_seed_corpus parquet-encoding-fuzz
+    fi
+
+    # 3. Run fuzz targets on regression files from arrow-testing
     # Run golden IPC integration files: these should ideally load without errors,
     # though some very old ones carry invalid data (such as decimal values
     # larger than their advertised precision).

--- a/cpp/build-support/fuzzing/generate_corpuses.sh
+++ b/cpp/build-support/fuzzing/generate_corpuses.sh
@@ -56,7 +56,7 @@ rm -rf ${CORPUS_DIR}
 ${OUT}/arrow-ipc-generate-tensor-fuzz-corpus -stream ${CORPUS_DIR}
 ${ARROW_CPP}/build-support/fuzzing/pack_corpus.py ${CORPUS_DIR} ${OUT}/arrow-ipc-tensor-stream-fuzz_seed_corpus.zip
 
-# Parquet
+# Parquet file-level fuzzer
 
 rm -rf ${CORPUS_DIR}
 ${OUT}/parquet-arrow-generate-fuzz-corpus ${CORPUS_DIR}
@@ -64,6 +64,12 @@ ${OUT}/parquet-arrow-generate-fuzz-corpus ${CORPUS_DIR}
 cp ${ARROW_CPP}/submodules/parquet-testing/data/*.parquet ${CORPUS_DIR}
 cp ${ARROW_CPP}/submodules/parquet-testing/bad_data/*.parquet ${CORPUS_DIR}
 ${ARROW_CPP}/build-support/fuzzing/pack_corpus.py ${CORPUS_DIR} ${OUT}/parquet-arrow-fuzz_seed_corpus.zip
+
+# Parquet encoding fuzzer
+
+rm -rf ${CORPUS_DIR}
+${OUT}/parquet-generate-encoding-fuzz-corpus ${CORPUS_DIR}
+${ARROW_CPP}/build-support/fuzzing/pack_corpus.py ${CORPUS_DIR} ${OUT}/parquet-encoding-fuzz_seed_corpus.zip
 
 # CSV
 

--- a/cpp/src/arrow/util/macros.h
+++ b/cpp/src/arrow/util/macros.h
@@ -183,28 +183,18 @@
 #endif
 
 // ----------------------------------------------------------------------
+// Macros to enforce struct member packing
 
-// macros to disable padding
-// these macros are portable across different compilers and platforms
-//[https://github.com/google/flatbuffers/blob/master/include/flatbuffers/flatbuffers.h#L1355]
-#if !defined(MANUALLY_ALIGNED_STRUCT)
-#  if defined(_MSC_VER)
-#    define MANUALLY_ALIGNED_STRUCT(alignment) \
-      __pragma(pack(1));                       \
-      struct __declspec(align(alignment))
-#    define STRUCT_END(name, size) \
-      __pragma(pack());            \
-      static_assert(sizeof(name) == size, "compiler breaks packing rules")
-#  elif defined(__GNUC__) || defined(__clang__)
-#    define MANUALLY_ALIGNED_STRUCT(alignment) \
-      _Pragma("pack(1)") struct __attribute__((aligned(alignment)))
-#    define STRUCT_END(name, size)                          \
-      _Pragma("pack()") static_assert(sizeof(name) == size, \
-                                      "compiler breaks packing rules")
-#  else
-#    error Unknown compiler, please define structure alignment macros
-#  endif
-#endif  // !defined(MANUALLY_ALIGNED_STRUCT)
+#if defined(__GNUC__)
+#  define ARROW_PACKED_START(KEYWORD, ...) KEYWORD [[gnu::packed]] __VA_ARGS__
+#  define ARROW_PACKED_END
+#elif defined(_MSC_VER)
+#  define ARROW_PACKED_START(KEYWORD, ...) _Pragma("pack(push, 1)") KEYWORD __VA_ARGS__
+#  define ARROW_PACKED_END _Pragma("pack(pop)")
+#else
+#  define ARROW_PACKED_START(KEYWORD, ...) KEYWORD __VA_ARGS__
+#  define ARROW_PACKED_END
+#endif
 
 // ----------------------------------------------------------------------
 // Convenience macro disabling a particular UBSan check in a function

--- a/cpp/src/parquet/CMakeLists.txt
+++ b/cpp/src/parquet/CMakeLists.txt
@@ -151,6 +151,7 @@ endif()
 # Library config
 
 set(PARQUET_SRCS
+    arrow/fuzz_encoding_internal.cc
     arrow/fuzz_internal.cc
     arrow/path_internal.cc
     arrow/reader.cc

--- a/cpp/src/parquet/arrow/CMakeLists.txt
+++ b/cpp/src/parquet/arrow/CMakeLists.txt
@@ -19,13 +19,19 @@ arrow_install_all_headers("parquet/arrow")
 
 if(ARROW_BUILD_FUZZING_UTILITIES)
   add_executable(parquet-arrow-generate-fuzz-corpus generate_fuzz_corpus.cc)
+  add_executable(parquet-generate-encoding-fuzz-corpus generate_encoding_fuzz_corpus.cc)
   if(ARROW_BUILD_STATIC)
     target_link_libraries(parquet-arrow-generate-fuzz-corpus parquet_static
                           arrow_testing_static)
+    target_link_libraries(parquet-generate-encoding-fuzz-corpus parquet_static
+                          arrow_testing_static)
   else()
     target_link_libraries(parquet-arrow-generate-fuzz-corpus parquet_shared
+                          arrow_testing_shared)
+    target_link_libraries(parquet-generate-encoding-fuzz-corpus parquet_shared
                           arrow_testing_shared)
   endif()
 endif()
 
 add_parquet_fuzz_target(fuzz PREFIX "parquet-arrow")
+add_parquet_fuzz_target(encoding_fuzz PREFIX "parquet")

--- a/cpp/src/parquet/arrow/encoding_fuzz.cc
+++ b/cpp/src/parquet/arrow/encoding_fuzz.cc
@@ -1,0 +1,27 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "arrow/status.h"
+#include "arrow/util/fuzz_internal.h"
+#include "parquet/arrow/fuzz_encoding_internal.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+  auto status =
+      parquet::fuzzing::internal::FuzzEncoding(data, static_cast<int64_t>(size));
+  arrow::internal::LogFuzzStatus(status, data, static_cast<int64_t>(size));
+  return 0;
+}

--- a/cpp/src/parquet/arrow/fuzz_encoding_internal.cc
+++ b/cpp/src/parquet/arrow/fuzz_encoding_internal.cc
@@ -1,0 +1,491 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#include "parquet/arrow/fuzz_encoding_internal.h"
+
+#include <string.h>
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <limits>
+#include <sstream>
+#include <string_view>
+
+#include "arrow/array.h"
+#include "arrow/array/builder_binary.h"
+#include "arrow/array/builder_primitive.h"
+#include "arrow/buffer_builder.h"
+#include "arrow/compare.h"
+#include "arrow/io/memory.h"
+#include "arrow/pretty_print.h"
+#include "arrow/type.h"
+#include "arrow/util/fuzz_internal.h"
+#include "arrow/util/logging.h"
+#include "arrow/util/string.h"
+#include "parquet/encoding.h"
+#include "parquet/schema.h"
+#include "parquet/visit_type_inline.h"
+
+namespace parquet::fuzzing::internal {
+
+using ::arrow::Array;
+using ::arrow::ArrayData;
+using ::arrow::BufferBuilder;
+using ::arrow::DataType;
+using ::arrow::MemoryPool;
+using ::arrow::Result;
+using ::arrow::Status;
+using ::arrow::TypedBufferBuilder;
+using ::parquet::arrow::FileReader;
+
+ColumnDescriptor MakeColumnDescriptor(Type::type type, int type_length) {
+  // Repetition and max def/rep levels can take dummy values as they are not directly
+  // used by encoders and decoders.
+  auto node = schema::PrimitiveNode::Make("", Repetition::OPTIONAL, type,
+                                          ConvertedType::NONE, type_length);
+  return ColumnDescriptor(node, /*max_definition_level=*/1, /*max_repetition_level=*/0);
+}
+
+namespace {
+
+constexpr auto kPackedEncodingHeaderSize = 64;
+
+ARROW_PACKED_START(struct, PackedEncodingHeader) {
+  ARROW_PACKED_START(struct, Header) {
+    uint8_t source_encoding_id;
+    uint8_t roundtrip_encoding_id;
+    uint8_t type_id;
+    int32_t type_length;
+    int32_t num_values;
+  };
+  ARROW_PACKED_END
+
+  static_assert(sizeof(Header) == 3 * 1 + 2 * 4);
+  using Reserved = std::array<uint8_t, kPackedEncodingHeaderSize - sizeof(Header)>;
+
+  Header header;
+  Reserved reserved;
+};
+ARROW_PACKED_END
+
+static_assert(sizeof(PackedEncodingHeader) == kPackedEncodingHeaderSize);
+
+}  // namespace
+
+FuzzEncodingHeader::FuzzEncodingHeader(Encoding::type source_encoding,
+                                       Encoding::type roundtrip_encoding, Type::type type,
+                                       int type_length, int num_values)
+    : source_encoding(source_encoding),
+      roundtrip_encoding(roundtrip_encoding),
+      type(type),
+      type_length(type_length),
+      num_values(num_values) {}
+
+FuzzEncodingHeader::FuzzEncodingHeader(Encoding::type source_encoding,
+                                       Encoding::type roundtrip_encoding,
+                                       const ColumnDescriptor* descr, int num_values)
+    : FuzzEncodingHeader(source_encoding, roundtrip_encoding, descr->physical_type(),
+                         descr->type_length(), num_values) {}
+
+std::string FuzzEncodingHeader::Serialize() const {
+  PackedEncodingHeader packed{};
+  packed.header.source_encoding_id = static_cast<uint8_t>(source_encoding);
+  packed.header.roundtrip_encoding_id = static_cast<uint8_t>(roundtrip_encoding);
+  packed.header.type_id = static_cast<uint8_t>(type);
+  packed.header.type_length = type_length;
+  packed.header.num_values = num_values;
+  return std::string(reinterpret_cast<const char*>(&packed), kPackedEncodingHeaderSize);
+}
+
+::arrow::Result<FuzzEncodingHeader::ParseResult> FuzzEncodingHeader::Parse(
+    std::span<const uint8_t> payload) {
+  auto invalid_payload = []() {
+    return Status::Invalid("Invalid fuzz encoding payload");
+  };
+
+  if (payload.size() < kPackedEncodingHeaderSize) {
+    return invalid_payload();
+  }
+  PackedEncodingHeader packed;
+  std::memcpy(&packed, payload.data(), kPackedEncodingHeaderSize);
+  // We are strict in what we accept because we don't want the fuzzer to go
+  // explore pointless variations.
+  if (packed.reserved !=
+      PackedEncodingHeader::Reserved{}) {  // reserved bytes should be zero
+    return invalid_payload();
+  }
+  const auto& ph = packed.header;
+  if (ph.source_encoding_id >= static_cast<uint8_t>(Encoding::UNDEFINED) ||
+      ph.roundtrip_encoding_id >= static_cast<uint8_t>(Encoding::UNDEFINED) ||
+      ph.type_id >= static_cast<uint8_t>(Type::UNDEFINED)) {
+    return invalid_payload();
+  }
+  FuzzEncodingHeader header(static_cast<Encoding::type>(ph.source_encoding_id),
+                            static_cast<Encoding::type>(ph.roundtrip_encoding_id),
+                            static_cast<Type::type>(ph.type_id), ph.type_length,
+                            ph.num_values);
+  if ((header.type == Type::FIXED_LEN_BYTE_ARRAY) ? (header.type_length <= 0)
+                                                  : (header.type_length != -1)) {
+    return invalid_payload();
+  }
+  if (header.num_values < 0) {
+    return invalid_payload();
+  }
+  return ParseResult{header, payload.subspan(kPackedEncodingHeaderSize)};
+}
+
+namespace {
+
+// Just to use std::vector<T> while avoiding std::vector<bool>
+using BooleanSlot = std::array<uint8_t, sizeof(bool)>;
+
+template <typename DType>
+struct TypedFuzzEncoding {
+  static constexpr Type::type kType = DType::type_num;
+
+  using c_type =
+      std::conditional_t<kType == Type::BOOLEAN, BooleanSlot, typename DType::c_type>;
+  using EncoderType = typename EncodingTraits<DType>::Encoder;
+  using DecoderType = typename EncodingTraits<DType>::Decoder;
+  using Accumulator = EncodingTraits<DType>::Accumulator;
+
+  TypedFuzzEncoding(Encoding::type source_encoding, Encoding::type roundtrip_encoding,
+                    const ColumnDescriptor* descr, int num_values,
+                    std::span<const uint8_t> encoded_data)
+      : source_encoding_(source_encoding),
+        roundtrip_encoding_(roundtrip_encoding),
+        descr_(descr),
+        num_values_(num_values),
+        encoded_data_(encoded_data) {}
+
+  // Decoders of string-like types return pointers into the
+  // decoder's internal scratch space, which get invalidated on the
+  // following decoder call. We circumvent the issue by executing a
+  // functor on each decoded chunk before moving to the next one.
+  Status RunOnDecodedChunks(Encoding::type encoding,
+                            std::span<const uint8_t> encoded_data, int chunk_size,
+                            std::function<Status(int offset, std::vector<c_type>)> func) {
+    BEGIN_PARQUET_CATCH_EXCEPTIONS
+    int total_values = 0;
+    auto decoder = MakeDecoder(encoding);
+    // NOTE: In real API usage, the `num_values` given to SetData() is read from
+    // the data page header and can include a number of nulls, so it's merely an
+    // upper bound for the number of physical values.
+    // However, Decode() calls are not supposed to ask more than the actual number
+    // of physical values.
+    decoder->SetData(num_values_, encoded_data.data(),
+                     static_cast<int>(encoded_data.size()));
+    while (total_values < num_values_) {
+      const int read_size = std::min(num_values_ - total_values, chunk_size);
+      // ARROW_ASSIGN_OR_RAISE(auto chunk_values, DecodeChunk(read_size));
+      std::vector<c_type> chunk_values(read_size);
+      int values_read;
+      if constexpr (kType == Type::BOOLEAN) {
+        values_read =
+            decoder->Decode(reinterpret_cast<bool*>(chunk_values.data()), read_size);
+      } else {
+        values_read = decoder->Decode(chunk_values.data(), read_size);
+      }
+      ARROW_CHECK_LE(values_read, read_size);
+      chunk_values.resize(values_read);
+      RETURN_NOT_OK(func(total_values, std::move(chunk_values)));
+      total_values += values_read;
+      if (values_read < chunk_size) {
+        break;
+      }
+    }
+    if (total_values < num_values_) {
+      return Status::Invalid("Read less values than expected");
+    }
+    END_PARQUET_CATCH_EXCEPTIONS
+    return Status::OK();
+  }
+
+  Result<std::vector<c_type>> Decode(Encoding::type encoding,
+                                     std::span<const uint8_t> encoded_data,
+                                     int chunk_size) {
+    // Decoded chunk values shouldn't embed pointers to decoder scratch space.
+    static_assert(decoded_values_can_be_persisted());
+    std::vector<c_type> values;
+    auto accumulate_chunk = [&](int offset, std::vector<c_type> chunk_values) {
+      values.insert(values.end(), chunk_values.begin(), chunk_values.end());
+      return Status::OK();
+    };
+    RETURN_NOT_OK(
+        RunOnDecodedChunks(encoding, encoded_data, chunk_size, accumulate_chunk));
+    return values;
+  }
+
+  Result<std::shared_ptr<Array>> DecodeArrow(Encoding::type encoding,
+                                             std::span<const uint8_t> encoded_data) {
+    ARROW_ASSIGN_OR_RAISE(auto arrow_type, ArrowType());
+    auto decoder = MakeDecoder(encoding);
+    decoder->SetData(num_values_, encoded_data.data(),
+                     static_cast<int>(encoded_data.size()));
+
+    if constexpr (kType == Type::BYTE_ARRAY) {
+      Accumulator acc;
+      acc.builder = std::make_unique<::arrow::BinaryBuilder>(pool());
+      BEGIN_PARQUET_CATCH_EXCEPTIONS
+      decoder->DecodeArrowNonNull(num_values_, &acc);
+      END_PARQUET_CATCH_EXCEPTIONS
+      ARROW_CHECK_EQ(acc.chunks.size(), 0);
+      return acc.builder->Finish();
+    } else {
+      Accumulator builder(arrow_type, pool());
+      BEGIN_PARQUET_CATCH_EXCEPTIONS
+      decoder->DecodeArrowNonNull(num_values_, &builder);
+      END_PARQUET_CATCH_EXCEPTIONS
+      return builder.Finish();
+    }
+  }
+
+  Status Fuzz() {
+    // Decode using source encoding
+    if constexpr (arrow_supported()) {
+      // Read as Arrow directly and use that as reference
+      ARROW_ASSIGN_OR_RAISE(reference_array_,
+                            DecodeArrow(source_encoding_, encoded_data_));
+      ARROW_CHECK_OK(reference_array_->ValidateFull());
+    } else {
+      ARROW_ASSIGN_OR_RAISE(reference_values_,
+                            Decode(source_encoding_, encoded_data_, num_values_));
+    }
+
+    // Re-encode and re-decode using roundtrip encoding
+    {
+      auto compare_chunk = [&](int offset, std::vector<c_type> chunk_values) {
+        return CompareChunkAgainstReference(offset, chunk_values);
+      };
+      auto encoder = MakeEncoder(roundtrip_encoding_);
+      BEGIN_PARQUET_CATCH_EXCEPTIONS
+      if constexpr (arrow_supported()) {
+        encoder->Put(*reference_array_);
+        auto reencoded_buffer = encoder->FlushValues();
+        auto reencoded_data = reencoded_buffer->template span_as<uint8_t>();
+        auto array = DecodeArrow(roundtrip_encoding_, reencoded_data).ValueOrDie();
+        ARROW_CHECK_OK(array->ValidateFull());
+        ARROW_CHECK_OK(CompareAgainstReference(array));
+        // Compare with reading raw values
+        for (const int chunk_size : chunk_sizes()) {
+          ARROW_CHECK_OK(RunOnDecodedChunks(roundtrip_encoding_, reencoded_data,
+                                            chunk_size, compare_chunk));
+        }
+      } else {
+        encoder->Put(reference_values_);
+        auto reencoded_buffer = encoder->FlushValues();
+        auto reencoded_data = reencoded_buffer->template span_as<uint8_t>();
+        // Vary chunk sizes
+        for (const int chunk_size : chunk_sizes()) {
+          ARROW_CHECK_OK(RunOnDecodedChunks(roundtrip_encoding_, reencoded_data,
+                                            chunk_size, compare_chunk));
+        }
+      }
+      END_PARQUET_CATCH_EXCEPTIONS
+    }
+
+    return Status::OK();
+  }
+
+ protected:
+  Result<std::shared_ptr<Array>> MakeArrow(std::span<const c_type> values) {
+    ARROW_ASSIGN_OR_RAISE(auto arrow_type, ArrowType());
+    const int64_t length = static_cast<int64_t>(values.size());
+
+    if constexpr (kType == Type::FIXED_LEN_BYTE_ARRAY) {
+      // Use a buffer builder instead of FixedSizeBinaryBuilder to avoid the cost
+      // of generating a trivial validity bitmap bit by bit.
+      const int32_t byte_width = descr_->type_length();
+      BufferBuilder data_builder(pool());
+      RETURN_NOT_OK(data_builder.Reserve(length * byte_width));
+      for (const FLBA item : values) {
+        data_builder.UnsafeAppend(item.ptr, byte_width);
+      }
+      ARROW_ASSIGN_OR_RAISE(auto data_buffer, data_builder.Finish());
+      auto data = ArrayData::Make(arrow_type, length, {nullptr, data_buffer},
+                                  /*null_count=*/0);
+      return ::arrow::MakeArray(data);
+    } else if constexpr (kType == Type::BYTE_ARRAY) {
+      TypedBufferBuilder<int32_t> offsets_builder(pool());
+      BufferBuilder data_builder(pool());
+      int64_t total_data_size = 0;
+      for (const ByteArray item : values) {
+        total_data_size += item.len;
+      }
+      RETURN_NOT_OK(offsets_builder.Reserve(length + 1));
+      RETURN_NOT_OK(data_builder.Reserve(total_data_size));
+      int32_t offset = 0;
+      for (const ByteArray item : values) {
+        offsets_builder.UnsafeAppend(offset);
+        data_builder.UnsafeAppend(item.ptr, static_cast<int32_t>(item.len));
+        offset += static_cast<int32_t>(item.len);
+      }
+      offsets_builder.UnsafeAppend(offset);
+      ARROW_CHECK_EQ(offset, total_data_size);
+      ARROW_ASSIGN_OR_RAISE(auto offsets_buffer, offsets_builder.Finish());
+      ARROW_ASSIGN_OR_RAISE(auto data_buffer, data_builder.Finish());
+      auto data =
+          ArrayData::Make(arrow_type, length, {nullptr, offsets_buffer, data_buffer},
+                          /*null_count=*/0);
+      return ::arrow::MakeArray(data);
+    } else if constexpr (kType == Type::BOOLEAN) {
+      // Convert C++ bools into bitmap
+      ::arrow::BooleanBuilder builder(pool());
+      auto bool_data = reinterpret_cast<const bool*>(values.data());
+      RETURN_NOT_OK(builder.AppendValues(bool_data, bool_data + values.size()));
+      return builder.Finish();
+    } else {
+      auto data_buffer = std::make_shared<Buffer>(
+          reinterpret_cast<const uint8_t*>(values.data()), length * sizeof(c_type));
+      auto data = ArrayData::Make(arrow_type, length, {nullptr, data_buffer},
+                                  /*null_count=*/0);
+      return ::arrow::MakeArray(data);
+    }
+  }
+
+  Status CompareChunkAgainstReference(int chunk_offset,
+                                      const std::shared_ptr<Array>& array) {
+    auto options = ::arrow::EqualOptions{}.nans_equal(true);
+    ARROW_ASSIGN_OR_RAISE(auto expected,
+                          reference_array_->SliceSafe(chunk_offset, array->length()));
+    if (expected->length() != array->length()) {
+      return Status::Invalid("Array lengths unequal: expected ", expected->length(),
+                             ", got ", array->length());
+    }
+    if (!expected->Equals(array, options)) {
+      std::stringstream ss;
+      ::arrow::PrettyPrintOptions options(/*indent=*/2);
+      options.window = 50;
+      ss << "Arrays unequal, expected:\n";
+      ARROW_UNUSED(PrettyPrint(*expected, options, &ss));
+      ss << "Got:\n";
+      ARROW_UNUSED(PrettyPrint(*array, options, &ss));
+      return Status::Invalid("Arrays unequal: ", ss.str());
+    }
+    return Status::OK();
+  }
+
+  Status CompareAgainstReference(const std::shared_ptr<Array>& array) {
+    return CompareChunkAgainstReference(/*chunk_offset=*/0, array);
+  }
+
+  Status CompareChunkAgainstReference(int chunk_offset, std::span<const c_type> values) {
+    if constexpr (arrow_supported()) {
+      ARROW_ASSIGN_OR_RAISE(auto array, MakeArrow(values));
+      RETURN_NOT_OK(CompareChunkAgainstReference(chunk_offset, array));
+    } else {
+      static_assert(kType == Type::INT96);
+      if (reference_values_.size() - static_cast<size_t>(chunk_offset) < values.size() ||
+          memcmp(reference_values_.data() + chunk_offset, values.data(),
+                 values.size_bytes()) != 0) {
+        return Status::Invalid("Values unequal");
+      }
+    }
+    return Status::OK();
+  }
+
+  Status CompareAgainstReference(std::span<const c_type> values) {
+    return CompareChunkAgainstReference(/*chunk_offset=*/0, values);
+  }
+
+  Result<std::shared_ptr<DataType>> ArrowType() const {
+    switch (kType) {
+      case Type::BOOLEAN:
+        return ::arrow::boolean();
+      case Type::INT32:
+        return ::arrow::int32();
+      case Type::INT64:
+        return ::arrow::int64();
+      case Type::FLOAT:
+        return ::arrow::float32();
+      case Type::DOUBLE:
+        return ::arrow::float64();
+      case Type::BYTE_ARRAY:
+        return ::arrow::binary();
+      case Type::FIXED_LEN_BYTE_ARRAY:
+        return ::arrow::fixed_size_binary(descr_->type_length());
+      default:
+        return Status::NotImplemented("Physical type does not have Arrow equivalent");
+    }
+  }
+
+  std::shared_ptr<DecoderType> MakeDecoder(Encoding::type encoding) {
+    auto decoder = std::dynamic_pointer_cast<DecoderType>(
+        std::shared_ptr(::parquet::MakeDecoder(kType, encoding, descr_, pool())));
+    ARROW_CHECK_NE(decoder, nullptr);
+    return decoder;
+  }
+
+  std::shared_ptr<EncoderType> MakeEncoder(Encoding::type encoding) {
+    auto encoder =
+        std::dynamic_pointer_cast<EncoderType>(std::shared_ptr(::parquet::MakeEncoder(
+            kType, encoding, /*use_dictionary=*/false, descr_, pool())));
+    ARROW_CHECK_NE(encoder, nullptr);
+    return encoder;
+  }
+
+  MemoryPool* pool() { return ::arrow::internal::fuzzing_memory_pool(); }
+
+  static constexpr bool arrow_supported() { return kType != Type::INT96; }
+
+  static constexpr bool decoded_values_can_be_persisted() {
+    // Decoding string-like types returns pointers into the decoder's scratch space,
+    // which can not assume to remain valid after another decoder call.
+    return kType != Type::FIXED_LEN_BYTE_ARRAY && kType != Type::BYTE_ARRAY;
+  }
+
+  std::vector<int> chunk_sizes() const { return {(num_values_ + 1), 1 << 8, 1 << 12}; }
+
+  const Encoding::type source_encoding_, roundtrip_encoding_;
+  const ColumnDescriptor* descr_;
+  const int num_values_;
+  const std::span<const uint8_t> encoded_data_;
+
+  std::shared_ptr<Array> reference_array_;
+  // Only for INT96 as there is no strictly equivalent Arrow type
+  std::vector<c_type> reference_values_;
+};
+
+}  // namespace
+
+Status FuzzEncoding(const uint8_t* data, int64_t size) {
+  constexpr auto kInt32Max = std::numeric_limits<int32_t>::max();
+
+  ARROW_ASSIGN_OR_RAISE(const auto parse_result,
+                        FuzzEncodingHeader::Parse(std::span(data, size)));
+  auto& [header, encoded_data] = parse_result;
+  if (encoded_data.size() > static_cast<size_t>(kInt32Max)) {
+    // Unlikely but who knows?
+    return Status::Invalid("Fuzz payload too large");
+  }
+  const auto descr = MakeColumnDescriptor(header.type, header.type_length);
+
+  BEGIN_PARQUET_CATCH_EXCEPTIONS
+
+  auto typed_fuzz = [&](auto* dtype) {
+    using DType = std::decay_t<decltype(*dtype)>;
+    TypedFuzzEncoding<DType> typed_fuzz{header.source_encoding, header.roundtrip_encoding,
+                                        &descr, header.num_values, encoded_data};
+    return typed_fuzz.Fuzz();
+  };
+  RETURN_NOT_OK(VisitType(header.type, typed_fuzz));
+
+  END_PARQUET_CATCH_EXCEPTIONS
+  return Status::OK();
+}
+
+}  // namespace parquet::fuzzing::internal

--- a/cpp/src/parquet/arrow/fuzz_encoding_internal.h
+++ b/cpp/src/parquet/arrow/fuzz_encoding_internal.h
@@ -1,0 +1,84 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <span>
+#include <string>
+#include <utility>
+
+#include "arrow/result.h"
+#include "arrow/status.h"
+#include "arrow/type_fwd.h"
+#include "arrow/util/macros.h"
+#include "parquet/platform.h"
+#include "parquet/types.h"
+
+namespace parquet::fuzzing::internal {
+
+//
+// Helper APIs for Parquet encoding roundtrip fuzzing
+//
+
+/// Custom header to workaround the lack of parametric fuzzing on OSS-Fuzz
+///
+/// (see https://github.com/google/oss-fuzz/issues/14437)
+///
+/// The idea is to prefix the fuzzer payload with a fixed-size header encoding
+/// the fuzzer parameters. We also ensure that the seed corpus encompasses all
+/// parameter variations.
+///
+/// In the fuzzer payload, the fixed-size header is followed by the actual fuzz
+/// data. That fuzz data is supposed to represent `num_values` of type `type`
+/// encoded with the `source_encoding` (of course this may be wrong if the fuzzer
+/// mutated the payload).
+struct FuzzEncodingHeader {
+  /// The encoding the fuzz payload body is encoded with
+  Encoding::type source_encoding;
+  /// The encoding to roundtrip the decoded values with
+  Encoding::type roundtrip_encoding;
+  /// The type and type length (byte width) - the latter only for FIXED_LEN_BYTE_ARRAY
+  Type::type type;
+  int32_t type_length;
+  /// The number of encoded values
+  int32_t num_values;
+
+  FuzzEncodingHeader(Encoding::type source_encoding, Encoding::type roundtrip_encoding,
+                     Type::type type, int type_length, int num_values);
+  FuzzEncodingHeader(Encoding::type source_encoding, Encoding::type roundtrip_encoding,
+                     const ColumnDescriptor* descr, int num_values);
+
+  /// Serialize as a fixed size header for fuzz corpus generation
+  std::string Serialize() const;
+
+  using ParseResult = std::pair<FuzzEncodingHeader, std::span<const uint8_t>>;
+
+  /// Parse header from a fuzzer payload.
+  /// Returns a pair of (decoded header, fuzzer body).
+  static ::arrow::Result<ParseResult> Parse(std::span<const uint8_t> payload);
+};
+
+/// Fuzz a payload encoded as explained in FuzzEncodingHeader
+PARQUET_EXPORT ::arrow::Status FuzzEncoding(const uint8_t* data, int64_t size);
+
+PARQUET_EXPORT ColumnDescriptor MakeColumnDescriptor(Type::type type,
+                                                     int type_length = -1);
+
+}  // namespace parquet::fuzzing::internal

--- a/cpp/src/parquet/arrow/fuzz_internal.h
+++ b/cpp/src/parquet/arrow/fuzz_internal.h
@@ -30,6 +30,10 @@
 
 namespace parquet::fuzzing::internal {
 
+//
+// Helper APIs for full file Parquet fuzzing
+//
+
 struct EncryptionKey {
   ::arrow::util::SecureString key;
   std::string key_metadata;

--- a/cpp/src/parquet/arrow/generate_encoding_fuzz_corpus.cc
+++ b/cpp/src/parquet/arrow/generate_encoding_fuzz_corpus.cc
@@ -1,0 +1,255 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// A command line executable that generates a bunch of seed corpus files
+// for the Parquet encoding fuzzer.
+// More details about the format in fuzz_encoding_internal.h.
+
+#include <cstdlib>
+#include <iostream>
+#include <limits>
+#include <memory>
+#include <set>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "arrow/array.h"
+#include "arrow/io/file.h"
+#include "arrow/result.h"
+#include "arrow/testing/random.h"
+#include "arrow/util/checked_cast.h"
+#include "arrow/util/io_util.h"
+#include "arrow/util/logging_internal.h"
+#include "parquet/arrow/fuzz_encoding_internal.h"
+#include "parquet/encoding.h"
+#include "parquet/schema.h"
+
+namespace arrow {
+
+using internal::checked_cast;
+
+using Encoding = ::parquet::Encoding;
+using ParquetType = ::parquet::Type;
+using ::parquet::Int96;
+using ::parquet::fuzzing::internal::FuzzEncodingHeader;
+
+using EncodingVector = std::vector<Encoding::type>;
+
+struct FullParquetType {
+  ParquetType::type type;
+  int type_length = -1;
+
+  static FullParquetType FromArrow(const DataType& type) {
+    switch (type.id()) {
+      case Type::BOOL:
+        return {ParquetType::BOOLEAN};
+      case Type::INT32:
+        return {ParquetType::INT32};
+      case Type::INT64:
+        return {ParquetType::INT64};
+      case Type::FLOAT:
+        return {ParquetType::FLOAT};
+      case Type::DOUBLE:
+        return {ParquetType::DOUBLE};
+      case Type::BINARY:
+      case Type::STRING:
+        return {ParquetType::BYTE_ARRAY};
+      case Type::FIXED_SIZE_BINARY:
+        return {ParquetType::FIXED_LEN_BYTE_ARRAY,
+                checked_cast<const FixedSizeBinaryType&>(type).byte_width()};
+      default:
+        Status::TypeError("Unsupported Arrow type").Abort();
+    }
+  }
+
+  std::string ToString() const { return ::parquet::TypeToString(type, type_length); }
+};
+
+struct DataWithEncodings {
+  FullParquetType pq_type;
+  std::shared_ptr<Array> values;
+  EncodingVector encodings;
+};
+
+Result<std::vector<DataWithEncodings>> SampleData() {
+  auto rag = random::RandomArrayGenerator(/*seed=*/42);
+  std::vector<DataWithEncodings> all_data;
+
+  auto push_array = [&](std::shared_ptr<Array> arr, EncodingVector encodings = {}) {
+    auto pq_type = FullParquetType::FromArrow(*arr->type());
+    if (encodings.empty()) {
+      encodings = ::parquet::SupportedEncodings(pq_type.type);
+    }
+    all_data.emplace_back(pq_type, arr, std::move(encodings));
+  };
+
+  for (const auto size : {100, 10000}) {
+    push_array(rag.Int32(size, /*min=*/0, /*max=*/10));
+    push_array(rag.Int32(size, /*min=*/std::numeric_limits<int32_t>::min(),
+                         /*max=*/std::numeric_limits<int32_t>::max()));
+    push_array(rag.Int64(size, /*min=*/0, /*max=*/0));
+    push_array(rag.Int64(size, /*min=*/0, /*max=*/10'000));
+    push_array(rag.Int64(size, /*min=*/std::numeric_limits<int64_t>::min(),
+                         /*max=*/std::numeric_limits<int64_t>::max()));
+    for (const double true_probability : {0.01, 0.5, 0.9}) {
+      push_array(rag.Boolean(size, true_probability));
+    }
+    push_array(rag.Float32(size, /*min=*/-1.0f, /*max=*/1.0f));
+    push_array(rag.Float32(size, /*min=*/std::numeric_limits<float>::lowest(),
+                           /*max=*/std::numeric_limits<float>::max(),
+                           /*null_probability=*/0.0, /*nan_probability=*/1e-2));
+    push_array(rag.Float64(size, /*min=*/-1.0, /*max=*/1.0));
+    push_array(rag.Float64(size, /*min=*/std::numeric_limits<double>::lowest(),
+                           /*max=*/std::numeric_limits<double>::max(),
+                           /*null_probability=*/0.0, /*nan_probability=*/1e-2));
+    for (const int32_t byte_width : {1, 3, 16}) {
+      const auto fsb_size = size / byte_width;
+      push_array(rag.FixedSizeBinary(fsb_size, byte_width));
+    }
+    for (const int32_t max_binary_length : {1, 30}) {
+      const auto binary_size = size / max_binary_length;
+      push_array(rag.BinaryWithRepeats(binary_size, /*unique=*/binary_size / 2,
+                                       /*min_length=*/0,
+                                       /*max_length=*/max_binary_length));
+    }
+  }
+
+  return all_data;
+}
+
+using Int96Vector = std::vector<Int96>;
+
+Result<std::vector<Int96Vector>> SampleInt96() {
+  auto rag = random::RandomArrayGenerator(/*seed=*/42);
+  std::vector<Int96Vector> all_data;
+
+  for (const auto size : {50, 5000}) {
+    // The max value is chosen so that the nanoseconds component remains
+    // smaller than kNanosecondsPerDay.
+    auto ints = rag.Int32(size * 3, /*min=*/0, /*max=*/20000);
+    const Int96* int96_data = reinterpret_cast<const Int96*>(
+        checked_cast<const Int32Array&>(*ints).raw_values());
+    all_data.push_back(Int96Vector(int96_data, int96_data + size));
+  }
+  return all_data;
+}
+
+Status DoMain(const std::string& out_dir) {
+  ARROW_ASSIGN_OR_RAISE(auto dir_fn, internal::PlatformFilename::FromString(out_dir));
+  RETURN_NOT_OK(internal::CreateDir(dir_fn));
+
+  int sample_num = 1;
+  auto sample_file_name = [&](const std::string& name = "") -> std::string {
+    std::stringstream ss;
+    if (!name.empty()) {
+      ss << name << "-";
+    }
+    ss << sample_num++ << ".pq";
+    return std::move(ss).str();
+  };
+
+  auto write_sample = [&](Encoding::type source_encoding,
+                          Encoding::type roundtrip_encoding, FullParquetType type,
+                          const BufferVector& buffers) -> Status {
+    std::stringstream ss;
+    ss << type.ToString() << "-" << ::parquet::EncodingToString(source_encoding) << "-"
+       << ::parquet::EncodingToString(roundtrip_encoding);
+    ARROW_ASSIGN_OR_RAISE(auto sample_fn, dir_fn.Join(sample_file_name(ss.str())));
+    std::cerr << sample_fn.ToString() << std::endl;
+    ARROW_ASSIGN_OR_RAISE(auto file, io::FileOutputStream::Open(sample_fn.ToString()));
+    for (const auto& buf : buffers) {
+      RETURN_NOT_OK(file->Write(buf));
+    }
+    return file->Close();
+  };
+
+  ARROW_ASSIGN_OR_RAISE(auto all_data, SampleData());
+  for (const auto& data : all_data) {
+    const auto descr = parquet::fuzzing::internal::MakeColumnDescriptor(
+        data.pq_type.type, data.pq_type.type_length);
+    for (const auto roundtrip_encoding : data.encodings) {
+      // We always add PLAIN as a source encoding because the fuzzer might be able
+      // to explore more search space using this encoding.
+      for (const auto source_encoding : std::set{Encoding::PLAIN, roundtrip_encoding}) {
+        BufferVector buffers;
+        FuzzEncodingHeader header(
+            source_encoding, roundtrip_encoding, &descr, /*num_values=*/
+            static_cast<int>(data.values->length() - data.values->null_count()));
+
+        buffers.push_back(Buffer::FromString(header.Serialize()));
+        BEGIN_PARQUET_CATCH_EXCEPTIONS
+        auto encoder = ::parquet::MakeEncoder(data.pq_type.type, source_encoding,
+                                              /*use_dictionary=*/false, &descr);
+        encoder->Put(*data.values);
+        buffers.push_back(encoder->FlushValues());
+        END_PARQUET_CATCH_EXCEPTIONS
+        RETURN_NOT_OK(
+            write_sample(source_encoding, roundtrip_encoding, data.pq_type, buffers));
+      }
+    }
+  }
+
+  // Special-case INT96 as there is no direct Arrow equivalent to encode.
+  ARROW_ASSIGN_OR_RAISE(auto int96_data, SampleInt96());
+  for (const auto& data : int96_data) {
+    const auto pq_type = FullParquetType{ParquetType::INT96};
+    const auto descr = parquet::fuzzing::internal::MakeColumnDescriptor(
+        pq_type.type, pq_type.type_length);
+    const auto source_encoding = Encoding::PLAIN;
+    const auto roundtrip_encoding = Encoding::PLAIN;
+
+    BufferVector buffers;
+    FuzzEncodingHeader header(source_encoding, roundtrip_encoding, &descr, /*num_values=*/
+                              static_cast<int>(data.size()));
+    buffers.push_back(Buffer::FromString(header.Serialize()));
+    BEGIN_PARQUET_CATCH_EXCEPTIONS
+    auto encoder = ::parquet::MakeEncoder(pq_type.type, source_encoding,
+                                          /*use_dictionary=*/false, &descr);
+    dynamic_cast<::parquet::Int96Encoder*>(encoder.get())->Put(data);
+    buffers.push_back(encoder->FlushValues());
+    END_PARQUET_CATCH_EXCEPTIONS
+    RETURN_NOT_OK(write_sample(source_encoding, roundtrip_encoding, pq_type, buffers));
+  }
+
+  return Status::OK();
+}
+
+ARROW_NORETURN void Usage() {
+  std::cerr << "Usage: parquet-generate-encoding-fuzz-corpus "
+            << "<output directory>" << std::endl;
+  std::exit(2);
+}
+
+int Main(int argc, char** argv) {
+  if (argc != 2) {
+    Usage();
+  }
+  auto out_dir = std::string(argv[1]);
+
+  Status st = DoMain(out_dir);
+  if (!st.ok()) {
+    std::cerr << st.ToString() << std::endl;
+    return 1;
+  }
+  return 0;
+}
+
+}  // namespace arrow
+
+int main(int argc, char** argv) { return ::arrow::Main(argc, argv); }

--- a/cpp/src/parquet/arrow/reader.cc
+++ b/cpp/src/parquet/arrow/reader.cc
@@ -37,7 +37,6 @@
 #include "arrow/util/async_generator.h"
 #include "arrow/util/bit_util.h"
 #include "arrow/util/future.h"
-#include "arrow/util/fuzz_internal.h"
 #include "arrow/util/iterator.h"
 #include "arrow/util/logging_internal.h"
 #include "arrow/util/parallel.h"

--- a/cpp/src/parquet/decoder.cc
+++ b/cpp/src/parquet/decoder.cc
@@ -2447,4 +2447,28 @@ std::unique_ptr<Decoder> MakeDictDecoder(Type::type type_num,
 }
 
 }  // namespace detail
+
+std::vector<Encoding::type> SupportedEncodings(Type::type physical_type) {
+  switch (physical_type) {
+    case Type::BOOLEAN:
+      return {Encoding::PLAIN, Encoding::RLE};
+    case Type::INT32:
+    case Type::INT64:
+      return {Encoding::PLAIN, Encoding::DELTA_BINARY_PACKED,
+              Encoding::BYTE_STREAM_SPLIT};
+    case Type::INT96:
+      return {Encoding::PLAIN};
+    case Type::FLOAT:
+    case Type::DOUBLE:
+      return {Encoding::PLAIN, Encoding::BYTE_STREAM_SPLIT};
+    case Type::FIXED_LEN_BYTE_ARRAY:
+      return {Encoding::PLAIN, Encoding::BYTE_STREAM_SPLIT, Encoding::DELTA_BYTE_ARRAY};
+    case Type::BYTE_ARRAY:
+      return {Encoding::PLAIN, Encoding::DELTA_LENGTH_BYTE_ARRAY,
+              Encoding::DELTA_BYTE_ARRAY};
+    default:
+      throw ParquetException("Invalid physical type");
+  }
+}
+
 }  // namespace parquet

--- a/cpp/src/parquet/encoder.cc
+++ b/cpp/src/parquet/encoder.cc
@@ -116,9 +116,9 @@ class EncoderImpl : virtual public Encoder {
   const Encoding::type encoding_;
   MemoryPool* pool_;
 
-  /// Type length from descr
+  // Type length from descr
   const int type_length_;
-  /// Number of unencoded bytes written to the encoder. Used for ByteArray type only.
+  // Number of unencoded bytes written to the encoder. Used for ByteArray type only.
   int64_t unencoded_byte_array_data_bytes_ = 0;
 };
 

--- a/cpp/src/parquet/encoding.h
+++ b/cpp/src/parquet/encoding.h
@@ -455,4 +455,10 @@ std::unique_ptr<typename EncodingTraits<DType>::Decoder> MakeTypedDecoder(
   return std::unique_ptr<OutType>(dynamic_cast<OutType*>(base.release()));
 }
 
+/// Return the list of supported encodings for the given physical type
+///
+/// Only non-dictionary encodings are returned.
+PARQUET_EXPORT
+std::vector<Encoding::type> SupportedEncodings(Type::type physical_type);
+
 }  // namespace parquet

--- a/cpp/src/parquet/types.h
+++ b/cpp/src/parquet/types.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <algorithm>
+#include <array>
 #include <cstdint>
 #include <cstring>
 #include <iterator>
@@ -691,11 +692,13 @@ constexpr int64_t kMillisecondsPerDay = kSecondsPerDay * INT64_C(1000);
 constexpr int64_t kMicrosecondsPerDay = kMillisecondsPerDay * INT64_C(1000);
 constexpr int64_t kNanosecondsPerDay = kMicrosecondsPerDay * INT64_C(1000);
 
-MANUALLY_ALIGNED_STRUCT(1) Int96 { uint32_t value[3]; };
-STRUCT_END(Int96, 12);
+ARROW_PACKED_START(struct, Int96) { std::array<uint32_t, 3> value; };
+ARROW_PACKED_END
+static_assert(sizeof(Int96) == 12, "Int96 not packed to 12 bytes");
+static_assert(alignof(Int96) <= 4, "Int96 alignment too large");
 
 inline bool operator==(const Int96& left, const Int96& right) {
-  return std::equal(left.value, left.value + 3, right.value);
+  return left.value == right.value;
 }
 
 inline bool operator!=(const Int96& left, const Int96& right) { return !(left == right); }
@@ -752,7 +755,7 @@ static inline int64_t Int96GetSeconds(const parquet::Int96& i96) {
 
 static inline std::string Int96ToString(const Int96& a) {
   std::ostringstream result;
-  std::copy(a.value, a.value + 3, std::ostream_iterator<uint32_t>(result, " "));
+  std::copy(a.value.begin(), a.value.end(), std::ostream_iterator<uint32_t>(result, " "));
   return result.str();
 }
 

--- a/cpp/src/parquet/visit_type_inline.h
+++ b/cpp/src/parquet/visit_type_inline.h
@@ -1,0 +1,62 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+#pragma once
+
+#include <cstdint>
+#include <type_traits>
+#include <utility>
+
+#include "arrow/util/macros.h"
+#include "parquet/exception.h"
+#include "parquet/types.h"
+
+namespace parquet {
+
+#define TYPE_VISIT_INLINE(TYPE_VALUE)                                                 \
+  case Type::TYPE_VALUE: {                                                            \
+    const PhysicalType<Type::TYPE_VALUE>* concrete_ptr = NULLPTR;                     \
+    return std::forward<VISITOR>(visitor)(concrete_ptr, std::forward<ARGS>(args)...); \
+  }
+
+/// \brief Call `visitor` with a nullptr of the corresponding concrete type class
+/// \tparam ARGS Additional arguments, if any, will be passed to the visitor after
+/// the type argument
+///
+/// The intent is for this to be called on a generic lambda
+/// that may internally use `if constexpr` or similar constructs.
+template <typename VISITOR, typename... ARGS>
+auto VisitType(Type::type type, VISITOR&& visitor, ARGS&&... args)
+    -> decltype(std::forward<VISITOR>(visitor)(std::declval<PhysicalType<Type::INT32>*>(),
+                                               args...)) {
+  switch (type) {
+    TYPE_VISIT_INLINE(INT32)
+    TYPE_VISIT_INLINE(INT64)
+    TYPE_VISIT_INLINE(INT96)
+    TYPE_VISIT_INLINE(FLOAT)
+    TYPE_VISIT_INLINE(DOUBLE)
+    TYPE_VISIT_INLINE(FIXED_LEN_BYTE_ARRAY)
+    TYPE_VISIT_INLINE(BYTE_ARRAY)
+    TYPE_VISIT_INLINE(BOOLEAN)
+    default:
+      throw ParquetException("Invalid Type::type");
+  }
+}
+
+#undef TYPE_VISIT_INLINE
+
+}  // namespace parquet

--- a/cpp/src/parquet/xxhasher.cc
+++ b/cpp/src/parquet/xxhasher.cc
@@ -58,8 +58,7 @@ uint64_t XxHasher::Hash(const FLBA* value, uint32_t len) const {
 }
 
 uint64_t XxHasher::Hash(const Int96* value) const {
-  return XXH64(reinterpret_cast<const void*>(value->value), sizeof(value->value),
-               kParquetBloomXxHashSeed);
+  return XXH64(value->value.data(), sizeof(value->value), kParquetBloomXxHashSeed);
 }
 
 uint64_t XxHasher::Hash(std::string_view value) const {
@@ -89,8 +88,8 @@ void XxHasher::Hashes(const double* values, int num_values, uint64_t* hashes) co
 
 void XxHasher::Hashes(const Int96* values, int num_values, uint64_t* hashes) const {
   for (int i = 0; i < num_values; ++i) {
-    hashes[i] = XXH64(reinterpret_cast<const void*>(values[i].value),
-                      sizeof(values[i].value), kParquetBloomXxHashSeed);
+    hashes[i] =
+        XXH64(values[i].value.data(), sizeof(values[i].value), kParquetBloomXxHashSeed);
   }
 }
 

--- a/docs/source/developers/cpp/fuzzing.rst
+++ b/docs/source/developers/cpp/fuzzing.rst
@@ -29,6 +29,7 @@ fuzz testing on several parts of the Arrow C++ feature set, currently:
 * the IPC stream reader
 * the IPC file reader
 * the Parquet file reader
+* the Parquet encoders and decoders
 * the CSV file reader
 
 We welcome any contribution to expand the scope of fuzz testing and cover


### PR DESCRIPTION
### Rationale for this change

Add a fuzz target that does a 3-way encoding roundtrip:
1. decodes its payload using a source encoding
2. re-encodes the values using a roundtrip encoding
3. re-decodes using the same roundtrip encoding, and checks that the values read are identical

The motivation is to ensure that encoding and decoding can roundtrip for any valid data, while the full-file Parquet fuzzer only tests _reading_ the data. Furthermore, we postulate that a smaller workload that runs on a smaller search space like this might lead to a faster exploration of the search space (but we don't know for sure).

The reason for the two encodings (source and roundtrip) is that not all encodings imply the same input structure (grammar, etc.) and using another source encoding (especially PLAIN, which has very little structure) might allow the fuzzer to explore the logical search space (i.e. values) in different ways.

#### Parametrization

Since we want to fuzz all supported (type, encoding) combinations and OSS-Fuzz does not support fuzzer parametrization, we have to use a trick: we prefix the fuzz payload with a fixed-size header that encodes those parameters.

(while this may seem like we are reinventing the Parquet file format, it is a massively simpler format to decode, and the payload otherwise consists of a single range of encoded values: no Thrift metadata, no row groups, no columns, no multiple pages, no def/rep levels, no statistics, etc.)

### What changes are included in this PR?

1. Add a new fuzz target
2. Add a new fuzzing utility to generate the corresponding seed corpus
3. Add a test step on ASAN/ UBSAN CI job to run the fuzz targets on their respective seed corpuses
4. Add a Parquet API function to get the supported encodings for a given type
5. Add a Parquet helper API to dispatch a Parquet type to a generic callable (usually a lambda with an auto parameter)
6. Add a macro to pack a structure (and replace the previously existing macro from Flatbuffers)

### Are these changes tested?

Yes, partly by CI and partly manually.

### Are there any user-facing changes?

No.

* GitHub Issue: #49329 