### PR TITLE
GH-49310: [C++][Compute] Fix segmentation fault in pyarrow.compute.if_else

### DIFF
--- a/cpp/src/arrow/compute/kernels/scalar_if_else.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else.cc
@@ -762,7 +762,6 @@ struct IfElseFunctor<Type, enable_if_base_binary<Type>> {
 
       int64_t right_data_length = static_cast<int64_t>(right_offsets[right.length]) -
                                   static_cast<int64_t>(right_offsets[0]);
-      ARROW_RETURN_NOT_OK(ValidateCapacityForOffsetType(right_data_length));
       ARROW_ASSIGN_OR_RAISE(out_data->buffers[2], ctx->Allocate(right_data_length));
       std::memcpy(out_data->buffers[2]->mutable_data(), right_data, right_data_length);
       return Status::OK();

--- a/cpp/src/arrow/compute/kernels/scalar_if_else.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else.cc
@@ -760,20 +760,18 @@ struct IfElseFunctor<Type, enable_if_base_binary<Type>> {
       ARROW_ASSIGN_OR_RAISE(out_data->buffers[1], ctx->Allocate(offset_length));
       std::memcpy(out_data->buffers[1]->mutable_data(), right_offsets, offset_length);
 
-      int64_t right_data_length = static_cast<int64_t>(right_offsets[right.length]) -
-                                  static_cast<int64_t>(right_offsets[0]);
+      auto right_data_length = right_offsets[right.length] - right_offsets[0];
       ARROW_ASSIGN_OR_RAISE(out_data->buffers[2], ctx->Allocate(right_data_length));
       std::memcpy(out_data->buffers[2]->mutable_data(), right_data, right_data_length);
       return Status::OK();
     }
 
     std::string_view left_data = internal::UnboxScalar<Type>::Unbox(left);
+    auto left_size = static_cast<OffsetType>(left_data.size());
 
     // allocate data buffer conservatively
-    int64_t data_buff_alloc = static_cast<int64_t>(left_data.size()) * cond.length +
-                              (static_cast<int64_t>(right_offsets[right.length]) -
-                               static_cast<int64_t>(right_offsets[0]));
-    auto left_size = static_cast<OffsetType>(left_data.size());
+    int64_t data_buff_alloc =
+        left_size * cond.length + right_offsets[right.length] - right_offsets[0];
 
     BuilderType builder(ctx->memory_pool());
     ARROW_RETURN_NOT_OK(builder.Reserve(cond.length + 1));
@@ -802,20 +800,18 @@ struct IfElseFunctor<Type, enable_if_base_binary<Type>> {
       ARROW_ASSIGN_OR_RAISE(out_data->buffers[1], ctx->Allocate(offset_length));
       std::memcpy(out_data->buffers[1]->mutable_data(), left_offsets, offset_length);
 
-      int64_t left_data_length = static_cast<int64_t>(left_offsets[left.length]) -
-                                 static_cast<int64_t>(left_offsets[0]);
+      auto left_data_length = left_offsets[left.length] - left_offsets[0];
       ARROW_ASSIGN_OR_RAISE(out_data->buffers[2], ctx->Allocate(left_data_length));
       std::memcpy(out_data->buffers[2]->mutable_data(), left_data, left_data_length);
       return Status::OK();
     }
 
     std::string_view right_data = internal::UnboxScalar<Type>::Unbox(right);
+    auto right_size = static_cast<OffsetType>(right_data.size());
 
     // allocate data buffer conservatively
-    int64_t data_buff_alloc = static_cast<int64_t>(right_data.size()) * cond.length +
-                              (static_cast<int64_t>(left_offsets[left.length]) -
-                               static_cast<int64_t>(left_offsets[0]));
-    auto right_size = static_cast<OffsetType>(right_data.size());
+    int64_t data_buff_alloc =
+        right_size * cond.length + left_offsets[left.length] - left_offsets[0];
 
     BuilderType builder(ctx->memory_pool());
     ARROW_RETURN_NOT_OK(builder.Reserve(cond.length + 1));
@@ -836,14 +832,13 @@ struct IfElseFunctor<Type, enable_if_base_binary<Type>> {
   static Status Call(KernelContext* ctx, const ArraySpan& cond, const Scalar& left,
                      const Scalar& right, ExecResult* out) {
     std::string_view left_data = internal::UnboxScalar<Type>::Unbox(left);
+    auto left_size = static_cast<OffsetType>(left_data.size());
 
     std::string_view right_data = internal::UnboxScalar<Type>::Unbox(right);
+    auto right_size = static_cast<OffsetType>(right_data.size());
 
     // allocate data buffer conservatively
-    int64_t data_buff_alloc =
-        static_cast<int64_t>(std::max(left_data.size(), right_data.size())) * cond.length;
-    auto left_size = static_cast<OffsetType>(left_data.size());
-    auto right_size = static_cast<OffsetType>(right_data.size());
+    int64_t data_buff_alloc = std::max(right_size, left_size) * cond.length;
     BuilderType builder(ctx->memory_pool());
     ARROW_RETURN_NOT_OK(builder.Reserve(cond.length + 1));
     ARROW_RETURN_NOT_OK(builder.ReserveData(data_buff_alloc));

--- a/cpp/src/arrow/compute/kernels/scalar_if_else.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else.cc
@@ -695,7 +695,7 @@ struct IfElseFunctor<Type, enable_if_base_binary<Type>> {
       return Status::CapacityError("Result may exceed offset capacity for this type: ",
                                    data_bytes, " > ", max_offset,
                                    ". Convert inputs to a type that uses an int64 based "
-                                   "index such as a large_string");
+                                   "offset such as a large_string");
     }
     return Status::OK();
   }
@@ -773,7 +773,6 @@ struct IfElseFunctor<Type, enable_if_base_binary<Type>> {
     int64_t data_buff_alloc = static_cast<int64_t>(left_data.size()) * cond.length +
                               (static_cast<int64_t>(right_offsets[right.length]) -
                                static_cast<int64_t>(right_offsets[0]));
-    ARROW_RETURN_NOT_OK(ValidateCapacityForOffsetType(data_buff_alloc));
     auto left_size = static_cast<OffsetType>(left_data.size());
 
     BuilderType builder(ctx->memory_pool());
@@ -805,7 +804,6 @@ struct IfElseFunctor<Type, enable_if_base_binary<Type>> {
 
       int64_t left_data_length = static_cast<int64_t>(left_offsets[left.length]) -
                                  static_cast<int64_t>(left_offsets[0]);
-      ARROW_RETURN_NOT_OK(ValidateCapacityForOffsetType(left_data_length));
       ARROW_ASSIGN_OR_RAISE(out_data->buffers[2], ctx->Allocate(left_data_length));
       std::memcpy(out_data->buffers[2]->mutable_data(), left_data, left_data_length);
       return Status::OK();
@@ -817,7 +815,6 @@ struct IfElseFunctor<Type, enable_if_base_binary<Type>> {
     int64_t data_buff_alloc = static_cast<int64_t>(right_data.size()) * cond.length +
                               (static_cast<int64_t>(left_offsets[left.length]) -
                                static_cast<int64_t>(left_offsets[0]));
-    ARROW_RETURN_NOT_OK(ValidateCapacityForOffsetType(data_buff_alloc));
     auto right_size = static_cast<OffsetType>(right_data.size());
 
     BuilderType builder(ctx->memory_pool());
@@ -845,7 +842,6 @@ struct IfElseFunctor<Type, enable_if_base_binary<Type>> {
     // allocate data buffer conservatively
     int64_t data_buff_alloc =
         static_cast<int64_t>(std::max(left_data.size(), right_data.size())) * cond.length;
-    ARROW_RETURN_NOT_OK(ValidateCapacityForOffsetType(data_buff_alloc));
     auto left_size = static_cast<OffsetType>(left_data.size());
     auto right_size = static_cast<OffsetType>(right_data.size());
     BuilderType builder(ctx->memory_pool());

--- a/cpp/src/arrow/compute/kernels/scalar_if_else.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else.cc
@@ -729,6 +729,7 @@ struct IfElseFunctor<Type, enable_if_base_binary<Type>> {
                               (static_cast<int64_t>(right_offsets[right.length]) -
                                static_cast<int64_t>(right_offsets[0]));
 
+    // output a nicer error message if the heuristic overflows max capacity
     ARROW_RETURN_NOT_OK(ValidateCapacityForOffsetType(data_buff_alloc));
     BuilderType builder(ctx->memory_pool());
     ARROW_RETURN_NOT_OK(builder.Reserve(cond.length + 1));
@@ -773,6 +774,8 @@ struct IfElseFunctor<Type, enable_if_base_binary<Type>> {
     int64_t data_buff_alloc =
         left_size * cond.length + right_offsets[right.length] - right_offsets[0];
 
+    // output a nicer error message if the heuristic overflows max capacity
+    ARROW_RETURN_NOT_OK(ValidateCapacityForOffsetType(data_buff_alloc));
     BuilderType builder(ctx->memory_pool());
     ARROW_RETURN_NOT_OK(builder.Reserve(cond.length + 1));
     ARROW_RETURN_NOT_OK(builder.ReserveData(data_buff_alloc));
@@ -813,6 +816,8 @@ struct IfElseFunctor<Type, enable_if_base_binary<Type>> {
     int64_t data_buff_alloc =
         right_size * cond.length + left_offsets[left.length] - left_offsets[0];
 
+    // output a nicer error message if the heuristic overflows max capacity
+    ARROW_RETURN_NOT_OK(ValidateCapacityForOffsetType(data_buff_alloc));
     BuilderType builder(ctx->memory_pool());
     ARROW_RETURN_NOT_OK(builder.Reserve(cond.length + 1));
     ARROW_RETURN_NOT_OK(builder.ReserveData(data_buff_alloc));

--- a/cpp/src/arrow/compute/kernels/scalar_if_else_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else_test.cc
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <limits>
 #include <numeric>
 
 #include <gtest/gtest.h>
@@ -606,6 +607,115 @@ TYPED_TEST(TestIfElseBaseBinary, IfElseBaseBinaryRand) {
   ASSERT_OK_AND_ASSIGN(auto expected_data, builder.Finish());
 
   CheckIfElseOutput(cond, left, right, expected_data);
+}
+
+std::shared_ptr<Array> MakeOversizedBuffer(int32_t data_length) {
+  auto offsets = Buffer::FromVector(std::vector<int32_t>{0, data_length});
+  auto values = Buffer::FromString("x");
+  return MakeArray(
+      ArrayData::Make(binary(), 1, {nullptr, std::move(offsets), std::move(values)}));
+}
+
+Result<std::shared_ptr<Array>> MakeAllocatedVarBinaryArray(
+    const std::shared_ptr<DataType>& type, int64_t data_length) {
+  ARROW_ASSIGN_OR_RAISE(auto values, AllocateBuffer(data_length));
+  if (type->id() == Type::STRING || type->id() == Type::BINARY) {
+    if (data_length > std::numeric_limits<int32_t>::max()) {
+      return Status::Invalid("data_length exceeds int32 offset range");
+    }
+    auto offsets =
+        Buffer::FromVector(std::vector<int32_t>{0, static_cast<int32_t>(data_length)});
+    return MakeArray(
+        ArrayData::Make(type, 1, {nullptr, std::move(offsets), std::move(values)}));
+  }
+  if (type->id() != Type::LARGE_STRING && type->id() != Type::LARGE_BINARY) {
+    return Status::TypeError("unsupported var-binary type for helper: ", *type);
+  }
+  auto offsets = Buffer::FromVector(std::vector<int64_t>{0, data_length});
+  return MakeArray(
+      ArrayData::Make(type, 1, {nullptr, std::move(offsets), std::move(values)}));
+}
+
+TEST_F(TestIfElseKernel, IfElseStringAAAAllocatedDataCapacityError) {
+  constexpr int64_t kPerSide =
+      static_cast<int64_t>(std::numeric_limits<int32_t>::max() / 2) + 4096;
+
+  auto string_type = TypeTraits<StringType>::type_singleton();
+  auto cond = ArrayFromJSON(boolean(), "[true]");
+  ASSERT_OK_AND_ASSIGN(auto left, MakeAllocatedVarBinaryArray(string_type, kPerSide));
+  ASSERT_OK_AND_ASSIGN(auto right, MakeAllocatedVarBinaryArray(string_type, kPerSide));
+
+  EXPECT_RAISES_WITH_MESSAGE_THAT(
+      CapacityError,
+      ::testing::HasSubstr("Result may exceed offset capacity for this type"),
+      CallFunction("if_else", {cond, left, right}));
+}
+
+TEST_F(TestIfElseKernel, IfElseLargeStringAAADoesNotCapacityOverflow) {
+  constexpr int64_t kPerSide =
+      static_cast<int64_t>(std::numeric_limits<int32_t>::max() / 2) + 4096;
+
+  auto large_string_type = TypeTraits<LargeStringType>::type_singleton();
+  auto cond = ArrayFromJSON(boolean(), "[true]");
+  ASSERT_OK_AND_ASSIGN(auto left,
+                       MakeAllocatedVarBinaryArray(large_string_type, kPerSide));
+  ASSERT_OK_AND_ASSIGN(auto right,
+                       MakeAllocatedVarBinaryArray(large_string_type, kPerSide));
+
+  auto maybe_out = CallFunction("if_else", {cond, left, right});
+  ASSERT_FALSE(maybe_out.status().IsCapacityError()) << maybe_out.status();
+}
+
+TEST_F(TestIfElseKernel, IfElseBinaryCapacityErrorAAA) {
+  constexpr int32_t capacity_limit = std::numeric_limits<int32_t>::max();
+
+  auto cond = ArrayFromJSON(boolean(), "[true]");
+  auto left = MakeOversizedBuffer(capacity_limit);
+  auto right = MakeOversizedBuffer(capacity_limit);
+
+  EXPECT_RAISES_WITH_MESSAGE_THAT(
+      CapacityError,
+      ::testing::HasSubstr("Result may exceed offset capacity for this type"),
+      CallFunction("if_else", {cond, left, right}));
+}
+
+TEST_F(TestIfElseKernel, IfElseBinaryCapacityErrorASA) {
+  constexpr int32_t capacity_limit = std::numeric_limits<int32_t>::max();
+
+  auto cond = ArrayFromJSON(boolean(), "[true]");
+  auto left = Datum(std::make_shared<BinaryScalar>("x"));
+  auto right = MakeOversizedBuffer(capacity_limit);
+
+  EXPECT_RAISES_WITH_MESSAGE_THAT(
+      CapacityError,
+      ::testing::HasSubstr("Result may exceed offset capacity for this type"),
+      CallFunction("if_else", {cond, left, right}));
+}
+
+TEST_F(TestIfElseKernel, IfElseBinaryCapacityErrorAAS) {
+  constexpr int32_t capacity_limit = std::numeric_limits<int32_t>::max();
+
+  auto cond = ArrayFromJSON(boolean(), "[false]");
+  auto left = MakeOversizedBuffer(capacity_limit);
+  auto right = Datum(std::make_shared<BinaryScalar>("x"));
+
+  EXPECT_RAISES_WITH_MESSAGE_THAT(
+      CapacityError,
+      ::testing::HasSubstr("Result may exceed offset capacity for this type"),
+      CallFunction("if_else", {cond, left, right}));
+}
+
+TEST_F(TestIfElseKernel, IfElseBinaryCapacityErrorASS) {
+  constexpr int64_t kLength = 3000;
+  std::string payload(1 << 20, 'x');
+  ASSERT_OK_AND_ASSIGN(auto cond, MakeArrayFromScalar(BooleanScalar(true), kLength));
+  auto left = Datum(std::make_shared<BinaryScalar>(payload));
+  auto right = Datum(std::make_shared<BinaryScalar>("x"));
+
+  EXPECT_RAISES_WITH_MESSAGE_THAT(
+      CapacityError,
+      ::testing::HasSubstr("Result may exceed offset capacity for this type"),
+      CallFunction("if_else", {cond, left, right}));
 }
 
 TEST_F(TestIfElseKernel, IfElseFSBinary) {

--- a/cpp/src/arrow/compute/kernels/scalar_if_else_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else_test.cc
@@ -609,9 +609,10 @@ TYPED_TEST(TestIfElseBaseBinary, IfElseBaseBinaryRand) {
   CheckIfElseOutput(cond, left, right, expected_data);
 }
 
-Result<std::shared_ptr<Array>> MakeAllocatedVarBinaryArray(
-    const std::shared_ptr<DataType>& type, int64_t data_length) {
-  ARROW_ASSIGN_OR_RAISE(auto values, AllocateBuffer(data_length));
+Result<std::shared_ptr<Array>> MakeBinaryArrayWithData(
+    const std::shared_ptr<DataType>& type, const std::shared_ptr<Buffer>& data_buffer) {
+  // Make a (large-)binary array with a single item backed by the given data
+  const auto data_length = data_buffer->size();
   if (type->id() == Type::STRING || type->id() == Type::BINARY) {
     if (data_length > std::numeric_limits<int32_t>::max()) {
       return Status::Invalid("data_length exceeds int32 offset range");
@@ -619,56 +620,77 @@ Result<std::shared_ptr<Array>> MakeAllocatedVarBinaryArray(
     auto offsets =
         Buffer::FromVector(std::vector<int32_t>{0, static_cast<int32_t>(data_length)});
     return MakeArray(
-        ArrayData::Make(type, 1, {nullptr, std::move(offsets), std::move(values)}));
+        ArrayData::Make(type, 1, {nullptr, std::move(offsets), std::move(data_buffer)}));
   }
   if (type->id() != Type::LARGE_STRING && type->id() != Type::LARGE_BINARY) {
     return Status::TypeError("unsupported var-binary type for helper: ", *type);
   }
   auto offsets = Buffer::FromVector(std::vector<int64_t>{0, data_length});
   return MakeArray(
-      ArrayData::Make(type, 1, {nullptr, std::move(offsets), std::move(values)}));
+      ArrayData::Make(type, 1, {nullptr, std::move(offsets), std::move(data_buffer)}));
 }
 
 void CheckIfElseCapacityBehavior(const Datum& cond, const Datum& left, const Datum& right,
                                  bool expect_capacity_error) {
   auto maybe_out = CallFunction("if_else", {cond, left, right});
   if (expect_capacity_error) {
-    ASSERT_TRUE(maybe_out.status().IsCapacityError()) << maybe_out.status();
-    ASSERT_THAT(maybe_out.status().message(),
-                ::testing::HasSubstr("Result may exceed offset capacity for this type"));
+    EXPECT_RAISES_WITH_MESSAGE_THAT(
+        CapacityError,
+        ::testing::HasSubstr("Result may exceed offset capacity for this type"),
+        maybe_out);
   } else {
-    ASSERT_OK(maybe_out.status()) << maybe_out.status();
+    ASSERT_OK(maybe_out);
   }
 }
 
-TEST_F(TestIfElseKernel, IfElseStringAndLargeStringAAAOverflowBehavior) {
+TEST_F(TestIfElseKernel, LARGE_MEMORY_TEST(IfElseBinaryAAANear2GB)) {
+  // See GH-49310.
+  // `kPerSide` is below the capacity limit for a single binary array,
+  // but trying to allocate twice `kPerSide` would overflow the capacity limit.
   constexpr int64_t kPerSide =
       static_cast<int64_t>(std::numeric_limits<int32_t>::max() / 2) + 4096;
   auto cond = ArrayFromJSON(boolean(), "[true]");
 
-  ASSERT_OK_AND_ASSIGN(auto string_left, MakeAllocatedVarBinaryArray(utf8(), kPerSide));
-  ASSERT_OK_AND_ASSIGN(auto string_right, MakeAllocatedVarBinaryArray(utf8(), kPerSide));
-  CheckIfElseCapacityBehavior(cond, string_left, string_right, true);
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<Buffer> large_buffer, AllocateBuffer(kPerSide));
 
-  ASSERT_OK_AND_ASSIGN(auto large_string_left,
-                       MakeAllocatedVarBinaryArray(large_utf8(), kPerSide));
-  ASSERT_OK_AND_ASSIGN(auto large_string_right,
-                       MakeAllocatedVarBinaryArray(large_utf8(), kPerSide));
-  CheckIfElseCapacityBehavior(cond, large_string_left, large_string_right, false);
+  ASSERT_OK_AND_ASSIGN(auto binary_left, MakeBinaryArrayWithData(binary(), large_buffer));
+  ASSERT_OK_AND_ASSIGN(auto binary_right,
+                       MakeBinaryArrayWithData(binary(), large_buffer));
+  // The if_else heuristic for preallocation is too crude and fails with
+  // a capacity error as it would like to pre-allocate more than 2GiB
+  // of binary data.
+  CheckIfElseCapacityBehavior(cond, binary_left, binary_right,
+                              /*expect_capacity_error=*/true);
+  ASSERT_OK_AND_ASSIGN(auto large_binary_left,
+                       MakeBinaryArrayWithData(large_binary(), large_buffer));
+  ASSERT_OK_AND_ASSIGN(auto large_binary_right,
+                       MakeBinaryArrayWithData(large_binary(), large_buffer));
+  CheckIfElseCapacityBehavior(cond, large_binary_left, large_binary_right,
+                              /*expect_capacity_error=*/false);
 }
 
-TEST_F(TestIfElseKernel, IfElseBinaryASAHandlesStringAndLargeString) {
-  constexpr int32_t capacity_limit = std::numeric_limits<int32_t>::max();
-
+TEST_F(TestIfElseKernel, LARGE_MEMORY_TEST(IfElseBinaryASANear2GB)) {
+  constexpr int64_t kPerSide =
+      static_cast<int64_t>(std::numeric_limits<int32_t>::max() / 2) + 4096;
   auto cond = ArrayFromJSON(boolean(), "[true]");
-  auto left = Datum(MakeNullScalar(utf8()));
-  ASSERT_OK_AND_ASSIGN(auto right, MakeAllocatedVarBinaryArray(utf8(), capacity_limit));
-  CheckIfElseCapacityBehavior(cond, left, right, false);
 
-  ASSERT_OK_AND_ASSIGN(auto large_right,
-                       MakeAllocatedVarBinaryArray(large_utf8(), capacity_limit));
-  auto large_left = Datum(MakeNullScalar(large_utf8()));
-  CheckIfElseCapacityBehavior(cond, large_left, large_right, false);
+  ASSERT_OK_AND_ASSIGN(std::shared_ptr<Buffer> large_buffer, AllocateBuffer(kPerSide));
+  ASSERT_OK_AND_ASSIGN(auto binary_array,
+                       MakeBinaryArrayWithData(binary(), large_buffer));
+  ASSERT_OK_AND_ASSIGN(auto binary_scalar, MakeScalar(binary(), large_buffer));
+  CheckIfElseCapacityBehavior(cond, binary_scalar, binary_array,
+                              /*expect_capacity_error=*/true);
+  CheckIfElseCapacityBehavior(cond, binary_array, binary_scalar,
+                              /*expect_capacity_error=*/true);
+
+  ASSERT_OK_AND_ASSIGN(auto large_binary_array,
+                       MakeBinaryArrayWithData(large_binary(), large_buffer));
+  ASSERT_OK_AND_ASSIGN(auto large_binary_scalar,
+                       MakeScalar(large_binary(), large_buffer));
+  CheckIfElseCapacityBehavior(cond, large_binary_scalar, large_binary_array,
+                              /*expect_capacity_error=*/false);
+  CheckIfElseCapacityBehavior(cond, large_binary_array, large_binary_scalar,
+                              /*expect_capacity_error=*/false);
 }
 
 TEST_F(TestIfElseKernel, IfElseFSBinary) {

--- a/cpp/src/arrow/compute/kernels/scalar_if_else_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else_test.cc
@@ -629,71 +629,46 @@ Result<std::shared_ptr<Array>> MakeAllocatedVarBinaryArray(
       ArrayData::Make(type, 1, {nullptr, std::move(offsets), std::move(values)}));
 }
 
+void CheckIfElseCapacityBehavior(const Datum& cond, const Datum& left, const Datum& right,
+                                 bool expect_capacity_error) {
+  auto maybe_out = CallFunction("if_else", {cond, left, right});
+  if (expect_capacity_error) {
+    ASSERT_TRUE(maybe_out.status().IsCapacityError()) << maybe_out.status();
+    ASSERT_THAT(maybe_out.status().message(),
+                ::testing::HasSubstr("Result may exceed offset capacity for this type"));
+  } else {
+    ASSERT_OK(maybe_out.status()) << maybe_out.status();
+  }
+}
+
 TEST_F(TestIfElseKernel, IfElseStringAndLargeStringAAAOverflowBehavior) {
   constexpr int64_t kPerSide =
       static_cast<int64_t>(std::numeric_limits<int32_t>::max() / 2) + 4096;
   auto cond = ArrayFromJSON(boolean(), "[true]");
 
-  auto check = [&](const std::shared_ptr<DataType>& type, bool expect_capacity_error) {
-    ASSERT_OK_AND_ASSIGN(auto left, MakeAllocatedVarBinaryArray(type, kPerSide));
-    ASSERT_OK_AND_ASSIGN(auto right, MakeAllocatedVarBinaryArray(type, kPerSide));
+  ASSERT_OK_AND_ASSIGN(auto string_left, MakeAllocatedVarBinaryArray(utf8(), kPerSide));
+  ASSERT_OK_AND_ASSIGN(auto string_right, MakeAllocatedVarBinaryArray(utf8(), kPerSide));
+  CheckIfElseCapacityBehavior(cond, string_left, string_right, true);
 
-    auto maybe_out = CallFunction("if_else", {cond, left, right});
-    if (expect_capacity_error) {
-      ASSERT_TRUE(maybe_out.status().IsCapacityError()) << maybe_out.status();
-      ASSERT_THAT(
-          maybe_out.status().message(),
-          ::testing::HasSubstr("Result may exceed offset capacity for this type"));
-    } else {
-      ASSERT_OK(maybe_out.status()) << maybe_out.status();
-    }
-  };
-
-  check(TypeTraits<StringType>::type_singleton(), true);
-  check(TypeTraits<LargeStringType>::type_singleton(), false);
+  ASSERT_OK_AND_ASSIGN(auto large_string_left,
+                       MakeAllocatedVarBinaryArray(large_utf8(), kPerSide));
+  ASSERT_OK_AND_ASSIGN(auto large_string_right,
+                       MakeAllocatedVarBinaryArray(large_utf8(), kPerSide));
+  CheckIfElseCapacityBehavior(cond, large_string_left, large_string_right, false);
 }
 
-TEST_F(TestIfElseKernel, IfElseBinaryCapacityErrorASA) {
+TEST_F(TestIfElseKernel, IfElseBinaryASAHandlesStringAndLargeString) {
   constexpr int32_t capacity_limit = std::numeric_limits<int32_t>::max();
 
   auto cond = ArrayFromJSON(boolean(), "[true]");
-  auto left = Datum(std::make_shared<BinaryScalar>("x"));
-  ASSERT_OK_AND_ASSIGN(
-      auto right, MakeAllocatedVarBinaryArray(TypeTraits<StringType>::type_singleton(),
-                                              capacity_limit));
+  auto left = Datum(MakeNullScalar(utf8()));
+  ASSERT_OK_AND_ASSIGN(auto right, MakeAllocatedVarBinaryArray(utf8(), capacity_limit));
+  CheckIfElseCapacityBehavior(cond, left, right, false);
 
-  EXPECT_RAISES_WITH_MESSAGE_THAT(
-      CapacityError,
-      ::testing::HasSubstr("Result may exceed offset capacity for this type"),
-      CallFunction("if_else", {cond, left, right}));
-}
-
-TEST_F(TestIfElseKernel, IfElseBinaryCapacityErrorAAS) {
-  constexpr int32_t capacity_limit = std::numeric_limits<int32_t>::max();
-
-  auto cond = ArrayFromJSON(boolean(), "[false]");
-  ASSERT_OK_AND_ASSIGN(
-      auto left, MakeAllocatedVarBinaryArray(TypeTraits<StringType>::type_singleton(),
-                                             capacity_limit));
-  auto right = Datum(std::make_shared<BinaryScalar>("x"));
-
-  EXPECT_RAISES_WITH_MESSAGE_THAT(
-      CapacityError,
-      ::testing::HasSubstr("Result may exceed offset capacity for this type"),
-      CallFunction("if_else", {cond, left, right}));
-}
-
-TEST_F(TestIfElseKernel, IfElseBinaryCapacityErrorASS) {
-  constexpr int64_t kLength = 3000;
-  std::string payload(1 << 20, 'x');
-  ASSERT_OK_AND_ASSIGN(auto cond, MakeArrayFromScalar(BooleanScalar(true), kLength));
-  auto left = Datum(std::make_shared<BinaryScalar>(payload));
-  auto right = Datum(std::make_shared<BinaryScalar>("x"));
-
-  EXPECT_RAISES_WITH_MESSAGE_THAT(
-      CapacityError,
-      ::testing::HasSubstr("Result may exceed offset capacity for this type"),
-      CallFunction("if_else", {cond, left, right}));
+  ASSERT_OK_AND_ASSIGN(auto large_right,
+                       MakeAllocatedVarBinaryArray(large_utf8(), capacity_limit));
+  auto large_left = Datum(MakeNullScalar(large_utf8()));
+  CheckIfElseCapacityBehavior(cond, large_left, large_right, false);
 }
 
 TEST_F(TestIfElseKernel, IfElseFSBinary) {


### PR DESCRIPTION
### Rationale for this change
Fixing #49310 

### What changes are included in this PR?
I added a check for the if else compute kernels that verify that the result will fit in the offset of the result. The check asserts that no matter which values are chosen from either the left or right arrays/scalars there will be no overflow in order to use the UnsafeAppend which skips almost all safety checks.

### Are these changes tested?
Yes, There are tests for each of the kernels that include an array that the values that would overflow the 32 bit index trigger the check. These tests don't actually allocate the data to save on time and compute. There are also two tests that verify an overflow for a 32 bit offset type and trigger an error and the second one that ensures that for a data type with a 64 bit offset there is no overflow error. 

### Are there any user-facing changes?
Yes, if the result may not fit in a type that relies on 32 bit offsets the user will receive a helpful error message instead of a segfault.
* GitHub Issue: #49310