### PR TITLE
GH-49360: [C++][ORC] Add stripe statistics API to ORCFileReader

### DIFF
--- a/cpp/src/arrow/adapters/orc/adapter.cc
+++ b/cpp/src/arrow/adapters/orc/adapter.cc
@@ -126,7 +126,6 @@ Result<OrcColumnStatistics> ConvertColumnStatistics(
   stats.max = nullptr;
 
   // Try to extract min/max based on the ORC column statistics type.
-  // Use single dynamic_cast per branch to avoid unnecessary casts.
   if (const auto* int_stats =
           dynamic_cast<const liborc::IntegerColumnStatistics*>(orc_stats)) {
     if (int_stats->hasMinimum() && int_stats->hasMaximum()) {

--- a/cpp/src/arrow/adapters/orc/adapter.h
+++ b/cpp/src/arrow/adapters/orc/adapter.h
@@ -35,6 +35,23 @@ namespace arrow {
 namespace adapters {
 namespace orc {
 
+// Forward declarations
+struct OrcSchemaManifest;
+
+/// \brief Column statistics from an ORC file
+struct OrcColumnStatistics {
+  /// \brief Whether the column contains null values
+  bool has_null;
+  /// \brief Total number of values in the column
+  int64_t num_values;
+  /// \brief Whether min/max statistics are available
+  bool has_min_max;
+  /// \brief Minimum value (nullptr if not available)
+  std::shared_ptr<Scalar> min;
+  /// \brief Maximum value (nullptr if not available)
+  std::shared_ptr<Scalar> max;
+};
+
 /// \brief Information about an ORC stripe
 struct StripeInformation {
   /// \brief Offset of the stripe from the start of the file, in bytes
@@ -128,6 +145,27 @@ class ARROW_EXPORT ORCFileReader {
   /// \return the returned RecordBatch
   Result<std::shared_ptr<RecordBatch>> ReadStripe(
       int64_t stripe, const std::vector<std::string>& include_names);
+
+  /// \brief Read multiple selected stripes as a Table
+  ///
+  /// Reads only the specified stripes and concatenates them into a single table.
+  /// This is useful for stripe-selective reading based on predicate pushdown.
+  ///
+  /// \param[in] stripe_indices the indices of stripes to read
+  /// \return the returned Table containing data from the selected stripes
+  Result<std::shared_ptr<Table>> ReadStripes(
+      const std::vector<int64_t>& stripe_indices);
+
+  /// \brief Read multiple selected stripes with column selection as a Table
+  ///
+  /// Reads only the specified stripes and selected columns, concatenating them
+  /// into a single table.
+  ///
+  /// \param[in] stripe_indices the indices of stripes to read
+  /// \param[in] include_indices the selected field indices to read
+  /// \return the returned Table containing data from the selected stripes and columns
+  Result<std::shared_ptr<Table>> ReadStripes(const std::vector<int64_t>& stripe_indices,
+                                              const std::vector<int>& include_indices);
 
   /// \brief Seek to designated row. Invoke NextStripeReader() after seek
   ///        will return stripe reader starting from designated row.
@@ -266,6 +304,43 @@ class ARROW_EXPORT ORCFileReader {
   ///
   /// \return A KeyValueMetadata object containing the ORC metadata
   Result<std::shared_ptr<const KeyValueMetadata>> ReadMetadata();
+
+  /// \brief Get file-level statistics for a column.
+  ///
+  /// \param[in] column_index the column index (0-based)
+  /// \return the column statistics
+  Result<OrcColumnStatistics> GetColumnStatistics(int column_index);
+
+  /// \brief Get stripe-level statistics for a column.
+  ///
+  /// \param[in] stripe_index the stripe index (0-based)
+  /// \param[in] column_index the column index (0-based)
+  /// \return the column statistics for the specified stripe
+  Result<OrcColumnStatistics> GetStripeColumnStatistics(int64_t stripe_index,
+                                                        int column_index);
+
+  /// \brief Get stripe-level statistics for multiple columns at once.
+  ///
+  /// More efficient than calling GetStripeColumnStatistics() in a loop
+  /// because it parses the stripe's statistics object only once.
+  ///
+  /// \param[in] stripe_index the stripe index (0-based)
+  /// \param[in] column_indices the column indices to retrieve statistics for
+  /// \return vector of column statistics, one per requested column index
+  Result<std::vector<OrcColumnStatistics>> GetStripeStatistics(
+      int64_t stripe_index, const std::vector<int>& column_indices);
+
+  /// \brief Build a schema manifest mapping Arrow fields to ORC column IDs.
+  ///
+  /// Walks the ORC type tree paired with the Arrow schema to build a mapping
+  /// from Arrow field paths to ORC physical column indices, which are needed
+  /// for statistics lookup. ORC uses depth-first pre-order numbering where
+  /// column 0 is the root struct.
+  ///
+  /// \param[in] arrow_schema the Arrow schema (from ReadSchema())
+  /// \return the built manifest or an error
+  Result<std::shared_ptr<OrcSchemaManifest>> BuildSchemaManifest(
+      const std::shared_ptr<Schema>& arrow_schema) const;
 
  private:
   class Impl;

--- a/cpp/src/arrow/adapters/orc/adapter.h
+++ b/cpp/src/arrow/adapters/orc/adapter.h
@@ -150,6 +150,7 @@ class ARROW_EXPORT ORCFileReader {
   ///
   /// Reads only the specified stripes and concatenates them into a single table.
   /// This is useful for stripe-selective reading based on predicate pushdown.
+  /// If stripe_indices is empty, returns an empty table with the file's schema.
   ///
   /// \param[in] stripe_indices the indices of stripes to read
   /// \return the returned Table containing data from the selected stripes
@@ -160,6 +161,7 @@ class ARROW_EXPORT ORCFileReader {
   ///
   /// Reads only the specified stripes and selected columns, concatenating them
   /// into a single table.
+  /// If stripe_indices is empty, returns an empty table with the selected schema.
   ///
   /// \param[in] stripe_indices the indices of stripes to read
   /// \param[in] include_indices the selected field indices to read

--- a/cpp/src/arrow/adapters/orc/adapter_test.cc
+++ b/cpp/src/arrow/adapters/orc/adapter_test.cc
@@ -18,6 +18,7 @@
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 
+#include <cmath>
 #include <orc/OrcFile.hh>
 #include <string>
 
@@ -1179,4 +1180,720 @@ TEST_F(TestORCWriterMultipleWrite, MultipleWritesIntFieldRecordBatch) {
   AssertBatchWriteReadEqual(input_batches, expected_output_table,
                             kDefaultSmallMemStreamSize * 100);
 }
+
+TEST(TestAdapterRead, GetColumnStatisticsInteger) {
+  MemoryOutputStream mem_stream(kDefaultMemStreamSize);
+  std::unique_ptr<liborc::Type> type(
+      liborc::Type::buildTypeFromString("struct<col1:int,col2:bigint>"));
+
+  constexpr uint64_t stripe_size = 1024;
+  constexpr uint64_t row_count = 1000;
+
+  auto writer = CreateWriter(stripe_size, *type, &mem_stream);
+  auto batch = writer->createRowBatch(row_count);
+  auto struct_batch = internal::checked_cast<liborc::StructVectorBatch*>(batch.get());
+  auto int_batch =
+      internal::checked_cast<liborc::LongVectorBatch*>(struct_batch->fields[0]);
+  auto bigint_batch =
+      internal::checked_cast<liborc::LongVectorBatch*>(struct_batch->fields[1]);
+
+  for (uint64_t i = 0; i < row_count; ++i) {
+    int_batch->data[i] = static_cast<int64_t>(i);
+    bigint_batch->data[i] = static_cast<int64_t>(i + 1000);
+  }
+  struct_batch->numElements = row_count;
+  int_batch->numElements = row_count;
+  bigint_batch->numElements = row_count;
+  writer->add(*batch);
+  writer->close();
+
+  std::shared_ptr<io::RandomAccessFile> in_stream(new io::BufferReader(
+      std::make_shared<Buffer>(reinterpret_cast<const uint8_t*>(mem_stream.getData()),
+                               static_cast<int64_t>(mem_stream.getLength()))));
+
+  ASSERT_OK_AND_ASSIGN(auto reader,
+                       adapters::orc::ORCFileReader::Open(in_stream, default_memory_pool()));
+
+  ASSERT_OK_AND_ASSIGN(auto col1_stats, reader->GetColumnStatistics(1));
+  EXPECT_EQ(col1_stats.num_values, row_count);
+  EXPECT_TRUE(col1_stats.has_min_max);
+  ASSERT_NE(col1_stats.min, nullptr);
+  ASSERT_NE(col1_stats.max, nullptr);
+  EXPECT_EQ(checked_pointer_cast<Int64Scalar>(col1_stats.min)->value, 0);
+  EXPECT_EQ(checked_pointer_cast<Int64Scalar>(col1_stats.max)->value, 999);
+
+  ASSERT_OK_AND_ASSIGN(auto col2_stats, reader->GetColumnStatistics(2));
+  EXPECT_EQ(col2_stats.num_values, row_count);
+  EXPECT_TRUE(col2_stats.has_min_max);
+  ASSERT_NE(col2_stats.min, nullptr);
+  ASSERT_NE(col2_stats.max, nullptr);
+  EXPECT_EQ(checked_pointer_cast<Int64Scalar>(col2_stats.min)->value, 1000);
+  EXPECT_EQ(checked_pointer_cast<Int64Scalar>(col2_stats.max)->value, 1999);
+}
+
+TEST(TestAdapterRead, GetStripeColumnStatistics) {
+  MemoryOutputStream mem_stream(kDefaultMemStreamSize);
+  std::unique_ptr<liborc::Type> type(
+      liborc::Type::buildTypeFromString("struct<col1:int>"));
+
+  constexpr uint64_t stripe_size = 1024;
+  constexpr uint64_t row_count = 500;
+
+  auto writer = CreateWriter(stripe_size, *type, &mem_stream);
+  auto batch = writer->createRowBatch(row_count);
+  auto struct_batch = internal::checked_cast<liborc::StructVectorBatch*>(batch.get());
+  auto int_batch =
+      internal::checked_cast<liborc::LongVectorBatch*>(struct_batch->fields[0]);
+
+  for (uint64_t i = 0; i < row_count; ++i) {
+    int_batch->data[i] = static_cast<int64_t>(i + 100);
+  }
+  struct_batch->numElements = row_count;
+  int_batch->numElements = row_count;
+  writer->add(*batch);
+  writer->close();
+
+  std::shared_ptr<io::RandomAccessFile> in_stream(new io::BufferReader(
+      std::make_shared<Buffer>(reinterpret_cast<const uint8_t*>(mem_stream.getData()),
+                               static_cast<int64_t>(mem_stream.getLength()))));
+
+  ASSERT_OK_AND_ASSIGN(auto reader,
+                       adapters::orc::ORCFileReader::Open(in_stream, default_memory_pool()));
+
+  ASSERT_OK_AND_ASSIGN(auto stripe0_stats, reader->GetStripeColumnStatistics(0, 1));
+  EXPECT_TRUE(stripe0_stats.has_min_max);
+  EXPECT_EQ(checked_pointer_cast<Int64Scalar>(stripe0_stats.min)->value, 100);
+  EXPECT_EQ(checked_pointer_cast<Int64Scalar>(stripe0_stats.max)->value, 599);
+}
+
+TEST(TestAdapterRead, GetColumnStatisticsString) {
+  MemoryOutputStream mem_stream(kDefaultMemStreamSize);
+  std::unique_ptr<liborc::Type> type(
+      liborc::Type::buildTypeFromString("struct<col1:string>"));
+
+  constexpr uint64_t stripe_size = 1024;
+  constexpr uint64_t row_count = 5;
+
+  auto writer = CreateWriter(stripe_size, *type, &mem_stream);
+  auto batch = writer->createRowBatch(row_count);
+  auto struct_batch = internal::checked_cast<liborc::StructVectorBatch*>(batch.get());
+  auto str_batch =
+      internal::checked_cast<liborc::StringVectorBatch*>(struct_batch->fields[0]);
+
+  std::vector<std::string> strings = {"apple", "banana", "cherry", "date", "elderberry"};
+  std::string data_buffer;
+  for (const auto& s : strings) {
+    data_buffer += s;
+  }
+
+  size_t offset = 0;
+  for (size_t i = 0; i < strings.size(); ++i) {
+    str_batch->data[i] = const_cast<char*>(&data_buffer[offset]);
+    str_batch->length[i] = static_cast<int64_t>(strings[i].size());
+    offset += strings[i].size();
+  }
+  struct_batch->numElements = row_count;
+  str_batch->numElements = row_count;
+  writer->add(*batch);
+  writer->close();
+
+  std::shared_ptr<io::RandomAccessFile> in_stream(new io::BufferReader(
+      std::make_shared<Buffer>(reinterpret_cast<const uint8_t*>(mem_stream.getData()),
+                               static_cast<int64_t>(mem_stream.getLength()))));
+
+  ASSERT_OK_AND_ASSIGN(auto reader,
+                       adapters::orc::ORCFileReader::Open(in_stream, default_memory_pool()));
+
+  ASSERT_OK_AND_ASSIGN(auto col_stats, reader->GetColumnStatistics(1));
+  EXPECT_EQ(col_stats.num_values, row_count);
+  EXPECT_TRUE(col_stats.has_min_max);
+  ASSERT_NE(col_stats.min, nullptr);
+  ASSERT_NE(col_stats.max, nullptr);
+  EXPECT_EQ(checked_pointer_cast<StringScalar>(col_stats.min)->ToString(), "apple");
+  EXPECT_EQ(checked_pointer_cast<StringScalar>(col_stats.max)->ToString(), "elderberry");
+}
+
+TEST(TestAdapterRead, GetColumnStatisticsOutOfRange) {
+  MemoryOutputStream mem_stream(kDefaultMemStreamSize);
+  std::unique_ptr<liborc::Type> type(
+      liborc::Type::buildTypeFromString("struct<col1:int>"));
+
+  constexpr uint64_t stripe_size = 1024;
+  constexpr uint64_t row_count = 10;
+
+  auto writer = CreateWriter(stripe_size, *type, &mem_stream);
+  auto batch = writer->createRowBatch(row_count);
+  auto struct_batch = internal::checked_cast<liborc::StructVectorBatch*>(batch.get());
+  auto int_batch =
+      internal::checked_cast<liborc::LongVectorBatch*>(struct_batch->fields[0]);
+
+  for (uint64_t i = 0; i < row_count; ++i) {
+    int_batch->data[i] = static_cast<int64_t>(i);
+  }
+  struct_batch->numElements = row_count;
+  int_batch->numElements = row_count;
+  writer->add(*batch);
+  writer->close();
+
+  std::shared_ptr<io::RandomAccessFile> in_stream(new io::BufferReader(
+      std::make_shared<Buffer>(reinterpret_cast<const uint8_t*>(mem_stream.getData()),
+                               static_cast<int64_t>(mem_stream.getLength()))));
+
+  ASSERT_OK_AND_ASSIGN(auto reader,
+                       adapters::orc::ORCFileReader::Open(in_stream, default_memory_pool()));
+
+  EXPECT_THAT(reader->GetColumnStatistics(999),
+              Raises(StatusCode::Invalid, testing::HasSubstr("out of range")));
+
+  EXPECT_THAT(reader->GetStripeColumnStatistics(999, 1),
+              Raises(StatusCode::Invalid, testing::HasSubstr("out of range")));
+}
+
+TEST(TestAdapterRead, GetColumnStatisticsWithNulls) {
+  MemoryOutputStream mem_stream(kDefaultMemStreamSize);
+  std::unique_ptr<liborc::Type> type(
+      liborc::Type::buildTypeFromString("struct<col1:int>"));
+
+  constexpr uint64_t stripe_size = 1024;
+  constexpr uint64_t row_count = 10;
+
+  auto writer = CreateWriter(stripe_size, *type, &mem_stream);
+  auto batch = writer->createRowBatch(row_count);
+  auto struct_batch = internal::checked_cast<liborc::StructVectorBatch*>(batch.get());
+  auto int_batch =
+      internal::checked_cast<liborc::LongVectorBatch*>(struct_batch->fields[0]);
+
+  for (uint64_t i = 0; i < row_count; ++i) {
+    int_batch->data[i] = static_cast<int64_t>(i);
+    int_batch->notNull[i] = (i % 2 == 0) ? 1 : 0;
+  }
+  int_batch->hasNulls = true;
+  struct_batch->numElements = row_count;
+  int_batch->numElements = row_count;
+  writer->add(*batch);
+  writer->close();
+
+  std::shared_ptr<io::RandomAccessFile> in_stream(new io::BufferReader(
+      std::make_shared<Buffer>(reinterpret_cast<const uint8_t*>(mem_stream.getData()),
+                               static_cast<int64_t>(mem_stream.getLength()))));
+
+  ASSERT_OK_AND_ASSIGN(auto reader,
+                       adapters::orc::ORCFileReader::Open(in_stream, default_memory_pool()));
+
+  ASSERT_OK_AND_ASSIGN(auto col_stats, reader->GetColumnStatistics(1));
+  EXPECT_TRUE(col_stats.has_null);
+  EXPECT_TRUE(col_stats.has_min_max);
+}
+
+TEST(TestAdapterRead, GetColumnStatisticsBoolean) {
+  MemoryOutputStream mem_stream(kDefaultMemStreamSize);
+  std::unique_ptr<liborc::Type> type(
+      liborc::Type::buildTypeFromString("struct<col1:boolean>"));
+
+  constexpr uint64_t stripe_size = 1024;
+  constexpr uint64_t row_count = 100;
+
+  auto writer = CreateWriter(stripe_size, *type, &mem_stream);
+  auto batch = writer->createRowBatch(row_count);
+  auto struct_batch = internal::checked_cast<liborc::StructVectorBatch*>(batch.get());
+  auto bool_batch =
+      internal::checked_cast<liborc::LongVectorBatch*>(struct_batch->fields[0]);
+
+  // Write 60 true values and 40 false values
+  for (uint64_t i = 0; i < row_count; ++i) {
+    bool_batch->data[i] = (i < 60) ? 1 : 0;
+  }
+  struct_batch->numElements = row_count;
+  bool_batch->numElements = row_count;
+  writer->add(*batch);
+  writer->close();
+
+  std::shared_ptr<io::RandomAccessFile> in_stream(new io::BufferReader(
+      std::make_shared<Buffer>(reinterpret_cast<const uint8_t*>(mem_stream.getData()),
+                               static_cast<int64_t>(mem_stream.getLength()))));
+
+  ASSERT_OK_AND_ASSIGN(auto reader,
+                       adapters::orc::ORCFileReader::Open(in_stream, default_memory_pool()));
+
+  ASSERT_OK_AND_ASSIGN(auto col_stats, reader->GetColumnStatistics(1));
+  EXPECT_EQ(col_stats.num_values, row_count);
+  EXPECT_FALSE(col_stats.has_min_max);  // Boolean types don't have min/max
+  EXPECT_EQ(col_stats.min, nullptr);
+  EXPECT_EQ(col_stats.max, nullptr);
+}
+
+TEST(TestAdapterRead, GetColumnStatisticsDate) {
+  MemoryOutputStream mem_stream(kDefaultMemStreamSize);
+  std::unique_ptr<liborc::Type> type(
+      liborc::Type::buildTypeFromString("struct<col1:date>"));
+
+  constexpr uint64_t stripe_size = 1024;
+  constexpr uint64_t row_count = 10;
+
+  auto writer = CreateWriter(stripe_size, *type, &mem_stream);
+  auto batch = writer->createRowBatch(row_count);
+  auto struct_batch = internal::checked_cast<liborc::StructVectorBatch*>(batch.get());
+  auto date_batch =
+      internal::checked_cast<liborc::LongVectorBatch*>(struct_batch->fields[0]);
+
+  // Write dates: 0 (1970-01-01) through 9 (1970-01-10)
+  for (uint64_t i = 0; i < row_count; ++i) {
+    date_batch->data[i] = static_cast<int64_t>(i);
+  }
+  struct_batch->numElements = row_count;
+  date_batch->numElements = row_count;
+  writer->add(*batch);
+  writer->close();
+
+  std::shared_ptr<io::RandomAccessFile> in_stream(new io::BufferReader(
+      std::make_shared<Buffer>(reinterpret_cast<const uint8_t*>(mem_stream.getData()),
+                               static_cast<int64_t>(mem_stream.getLength()))));
+
+  ASSERT_OK_AND_ASSIGN(auto reader,
+                       adapters::orc::ORCFileReader::Open(in_stream, default_memory_pool()));
+
+  ASSERT_OK_AND_ASSIGN(auto col_stats, reader->GetColumnStatistics(1));
+  EXPECT_EQ(col_stats.num_values, row_count);
+  EXPECT_TRUE(col_stats.has_min_max);
+  ASSERT_NE(col_stats.min, nullptr);
+  ASSERT_NE(col_stats.max, nullptr);
+  EXPECT_EQ(checked_pointer_cast<Date32Scalar>(col_stats.min)->value, 0);
+  EXPECT_EQ(checked_pointer_cast<Date32Scalar>(col_stats.max)->value, 9);
+}
+
+TEST(TestAdapterRead, GetColumnStatisticsTimestamp) {
+  MemoryOutputStream mem_stream(kDefaultMemStreamSize);
+  std::unique_ptr<liborc::Type> type(
+      liborc::Type::buildTypeFromString("struct<col1:timestamp>"));
+
+  constexpr uint64_t stripe_size = 1024;
+  constexpr uint64_t row_count = 10;
+
+  auto writer = CreateWriter(stripe_size, *type, &mem_stream);
+  auto batch = writer->createRowBatch(row_count);
+  auto struct_batch = internal::checked_cast<liborc::StructVectorBatch*>(batch.get());
+  auto ts_batch =
+      internal::checked_cast<liborc::TimestampVectorBatch*>(struct_batch->fields[0]);
+
+  // Write timestamps with both seconds and nanoseconds
+  for (uint64_t i = 0; i < row_count; ++i) {
+    ts_batch->data[i] = static_cast<int64_t>(i * 1000);  // seconds
+    ts_batch->nanoseconds[i] = static_cast<int64_t>(i * 100);  // nanoseconds
+  }
+  struct_batch->numElements = row_count;
+  ts_batch->numElements = row_count;
+  writer->add(*batch);
+  writer->close();
+
+  std::shared_ptr<io::RandomAccessFile> in_stream(new io::BufferReader(
+      std::make_shared<Buffer>(reinterpret_cast<const uint8_t*>(mem_stream.getData()),
+                               static_cast<int64_t>(mem_stream.getLength()))));
+
+  ASSERT_OK_AND_ASSIGN(auto reader,
+                       adapters::orc::ORCFileReader::Open(in_stream, default_memory_pool()));
+
+  ASSERT_OK_AND_ASSIGN(auto col_stats, reader->GetColumnStatistics(1));
+  EXPECT_EQ(col_stats.num_values, row_count);
+  EXPECT_TRUE(col_stats.has_min_max);
+  ASSERT_NE(col_stats.min, nullptr);
+  ASSERT_NE(col_stats.max, nullptr);
+
+  // Verify the timestamps are TimestampScalar
+  auto min_ts = checked_pointer_cast<TimestampScalar>(col_stats.min);
+  auto max_ts = checked_pointer_cast<TimestampScalar>(col_stats.max);
+  EXPECT_TRUE(min_ts->is_valid);
+  EXPECT_TRUE(max_ts->is_valid);
+  // The actual values will be in nanoseconds
+  EXPECT_GT(max_ts->value, min_ts->value);
+}
+
+TEST(TestAdapterRead, ReadStripesMultiple) {
+  // Create a test file and read all stripes using ReadStripes
+  MemoryOutputStream mem_stream(kDefaultMemStreamSize);
+  std::unique_ptr<liborc::Type> type(
+      liborc::Type::buildTypeFromString("struct<col1:int,col2:bigint>"));
+
+  constexpr uint64_t stripe_size = 1024;
+  constexpr uint64_t row_count = 100;
+
+  auto writer = CreateWriter(stripe_size, *type, &mem_stream);
+  auto batch = writer->createRowBatch(row_count);
+  auto struct_batch = internal::checked_cast<liborc::StructVectorBatch*>(batch.get());
+  auto int_batch =
+      internal::checked_cast<liborc::LongVectorBatch*>(struct_batch->fields[0]);
+  auto bigint_batch =
+      internal::checked_cast<liborc::LongVectorBatch*>(struct_batch->fields[1]);
+
+  for (uint64_t i = 0; i < row_count; ++i) {
+    int_batch->data[i] = static_cast<int64_t>(i);
+    bigint_batch->data[i] = static_cast<int64_t>(i + 1000);
+  }
+  struct_batch->numElements = row_count;
+  int_batch->numElements = row_count;
+  bigint_batch->numElements = row_count;
+  writer->add(*batch);
+  writer->close();
+
+  std::shared_ptr<io::RandomAccessFile> in_stream(new io::BufferReader(
+      std::make_shared<Buffer>(reinterpret_cast<const uint8_t*>(mem_stream.getData()),
+                               static_cast<int64_t>(mem_stream.getLength()))));
+
+  ASSERT_OK_AND_ASSIGN(auto reader,
+                       adapters::orc::ORCFileReader::Open(in_stream, default_memory_pool()));
+
+  int64_t num_stripes = reader->NumberOfStripes();
+  ASSERT_GT(num_stripes, 0);
+
+  // Build vector of all stripe indices
+  std::vector<int64_t> stripe_indices;
+  for (int64_t i = 0; i < num_stripes; ++i) {
+    stripe_indices.push_back(i);
+  }
+
+  // Read all stripes using ReadStripes
+  ASSERT_OK_AND_ASSIGN(auto table, reader->ReadStripes(stripe_indices));
+
+  // Should have all rows and correct schema
+  EXPECT_EQ(table->num_rows(), row_count);
+  EXPECT_EQ(table->num_columns(), 2);
+  EXPECT_EQ(table->schema()->field(0)->name(), "col1");
+  EXPECT_EQ(table->schema()->field(1)->name(), "col2");
+}
+
+TEST(TestAdapterRead, ReadStripesWithColumnSelection) {
+  // Create a test file with multiple columns
+  MemoryOutputStream mem_stream(kDefaultMemStreamSize);
+  std::unique_ptr<liborc::Type> type(liborc::Type::buildTypeFromString(
+      "struct<col1:int,col2:bigint,col3:double>"));
+
+  constexpr uint64_t stripe_size = 1024;
+  constexpr uint64_t row_count = 100;
+
+  auto writer = CreateWriter(stripe_size, *type, &mem_stream);
+  auto batch = writer->createRowBatch(row_count);
+  auto struct_batch = internal::checked_cast<liborc::StructVectorBatch*>(batch.get());
+  auto int_batch =
+      internal::checked_cast<liborc::LongVectorBatch*>(struct_batch->fields[0]);
+  auto bigint_batch =
+      internal::checked_cast<liborc::LongVectorBatch*>(struct_batch->fields[1]);
+  auto double_batch =
+      internal::checked_cast<liborc::DoubleVectorBatch*>(struct_batch->fields[2]);
+
+  for (uint64_t i = 0; i < row_count; ++i) {
+    int_batch->data[i] = static_cast<int64_t>(i);
+    bigint_batch->data[i] = static_cast<int64_t>(i + 100);
+    double_batch->data[i] = static_cast<double>(i) + 0.5;
+  }
+  struct_batch->numElements = row_count;
+  int_batch->numElements = row_count;
+  bigint_batch->numElements = row_count;
+  double_batch->numElements = row_count;
+  writer->add(*batch);
+  writer->close();
+
+  std::shared_ptr<io::RandomAccessFile> in_stream(new io::BufferReader(
+      std::make_shared<Buffer>(reinterpret_cast<const uint8_t*>(mem_stream.getData()),
+                               static_cast<int64_t>(mem_stream.getLength()))));
+
+  ASSERT_OK_AND_ASSIGN(auto reader,
+                       adapters::orc::ORCFileReader::Open(in_stream, default_memory_pool()));
+
+  int64_t num_stripes = reader->NumberOfStripes();
+  ASSERT_GT(num_stripes, 0);
+
+  // Build vector of all stripe indices
+  std::vector<int64_t> stripe_indices;
+  for (int64_t i = 0; i < num_stripes; ++i) {
+    stripe_indices.push_back(i);
+  }
+
+  // Read all stripes but only columns 0 and 2 (col1 and col3)
+  std::vector<int> include_indices = {0, 2};
+  ASSERT_OK_AND_ASSIGN(auto table, reader->ReadStripes(stripe_indices, include_indices));
+
+  // Should have all rows and 2 columns
+  EXPECT_EQ(table->num_rows(), row_count);
+  EXPECT_EQ(table->num_columns(), 2);
+
+  // Verify we got the right columns (col2 was skipped)
+  EXPECT_EQ(table->schema()->field(0)->name(), "col1");
+  EXPECT_EQ(table->schema()->field(1)->name(), "col3");
+}
+
+TEST(TestAdapterRead, ReadStripesOutOfRange) {
+  MemoryOutputStream mem_stream(kDefaultMemStreamSize);
+  std::unique_ptr<liborc::Type> type(
+      liborc::Type::buildTypeFromString("struct<col1:int>"));
+
+  constexpr uint64_t stripe_size = 512;
+  constexpr uint64_t row_count = 100;
+
+  auto writer = CreateWriter(stripe_size, *type, &mem_stream);
+  auto batch = writer->createRowBatch(row_count);
+  auto struct_batch = internal::checked_cast<liborc::StructVectorBatch*>(batch.get());
+  auto int_batch =
+      internal::checked_cast<liborc::LongVectorBatch*>(struct_batch->fields[0]);
+
+  for (uint64_t i = 0; i < row_count; ++i) {
+    int_batch->data[i] = static_cast<int64_t>(i);
+  }
+  struct_batch->numElements = row_count;
+  int_batch->numElements = row_count;
+  writer->add(*batch);
+  writer->close();
+
+  std::shared_ptr<io::RandomAccessFile> in_stream(new io::BufferReader(
+      std::make_shared<Buffer>(reinterpret_cast<const uint8_t*>(mem_stream.getData()),
+                               static_cast<int64_t>(mem_stream.getLength()))));
+
+  ASSERT_OK_AND_ASSIGN(auto reader,
+                       adapters::orc::ORCFileReader::Open(in_stream, default_memory_pool()));
+
+  int64_t num_stripes = reader->NumberOfStripes();
+  ASSERT_GT(num_stripes, 0);
+
+  // Try to read a stripe index that's out of range
+  std::vector<int64_t> stripe_indices = {0, num_stripes};  // num_stripes is out of range
+  EXPECT_THAT(reader->ReadStripes(stripe_indices),
+              Raises(StatusCode::Invalid, testing::HasSubstr("Out of bounds stripe")));
+}
+
+TEST(TestAdapterRead, ReadStripesEmptyVector) {
+  MemoryOutputStream mem_stream(kDefaultMemStreamSize);
+  std::unique_ptr<liborc::Type> type(
+      liborc::Type::buildTypeFromString("struct<col1:int>"));
+
+  constexpr uint64_t stripe_size = 512;
+  constexpr uint64_t row_count = 100;
+
+  auto writer = CreateWriter(stripe_size, *type, &mem_stream);
+  auto batch = writer->createRowBatch(row_count);
+  auto struct_batch = internal::checked_cast<liborc::StructVectorBatch*>(batch.get());
+  auto int_batch =
+      internal::checked_cast<liborc::LongVectorBatch*>(struct_batch->fields[0]);
+
+  for (uint64_t i = 0; i < row_count; ++i) {
+    int_batch->data[i] = static_cast<int64_t>(i);
+  }
+  struct_batch->numElements = row_count;
+  int_batch->numElements = row_count;
+  writer->add(*batch);
+  writer->close();
+
+  std::shared_ptr<io::RandomAccessFile> in_stream(new io::BufferReader(
+      std::make_shared<Buffer>(reinterpret_cast<const uint8_t*>(mem_stream.getData()),
+                               static_cast<int64_t>(mem_stream.getLength()))));
+
+  ASSERT_OK_AND_ASSIGN(auto reader,
+                       adapters::orc::ORCFileReader::Open(in_stream, default_memory_pool()));
+
+  // Try to read with an empty stripe indices vector
+  std::vector<int64_t> stripe_indices;
+  EXPECT_THAT(reader->ReadStripes(stripe_indices),
+              Raises(StatusCode::Invalid, testing::HasSubstr("cannot be empty")));
+}
+
+TEST(TestAdapterRead, BuildSchemaManifest) {
+  MemoryOutputStream mem_stream(kDefaultMemStreamSize);
+  std::unique_ptr<liborc::Type> type(liborc::Type::buildTypeFromString(
+      "struct<col1:int,col2:bigint,col3:string>"));
+
+  constexpr uint64_t stripe_size = 1024;
+  constexpr uint64_t row_count = 10;
+
+  auto writer = CreateWriter(stripe_size, *type, &mem_stream);
+  auto batch = writer->createRowBatch(row_count);
+  auto struct_batch = internal::checked_cast<liborc::StructVectorBatch*>(batch.get());
+
+  struct_batch->numElements = row_count;
+  for (size_t i = 0; i < struct_batch->fields.size(); ++i) {
+    struct_batch->fields[i]->numElements = row_count;
+  }
+  writer->add(*batch);
+  writer->close();
+
+  std::shared_ptr<io::RandomAccessFile> in_stream(new io::BufferReader(
+      std::make_shared<Buffer>(reinterpret_cast<const uint8_t*>(mem_stream.getData()),
+                               static_cast<int64_t>(mem_stream.getLength()))));
+
+  ASSERT_OK_AND_ASSIGN(auto reader,
+                       adapters::orc::ORCFileReader::Open(in_stream, default_memory_pool()));
+  ASSERT_OK_AND_ASSIGN(auto arrow_schema, reader->ReadSchema());
+
+  // Build the manifest
+  ASSERT_OK_AND_ASSIGN(auto manifest, reader->BuildSchemaManifest(arrow_schema));
+
+  // Verify manifest field count matches Arrow schema field count
+  EXPECT_EQ(manifest->schema_fields.size(), arrow_schema->num_fields());
+  EXPECT_EQ(manifest->schema_fields.size(), 3);
+
+  // Field 0 ("col1") should map to ORC column 1
+  EXPECT_EQ(manifest->schema_fields[0].field->name(), "col1");
+  EXPECT_EQ(manifest->schema_fields[0].orc_column_id, 1);
+  EXPECT_TRUE(manifest->schema_fields[0].is_leaf());
+
+  // Field 1 ("col2") should map to ORC column 2
+  EXPECT_EQ(manifest->schema_fields[1].field->name(), "col2");
+  EXPECT_EQ(manifest->schema_fields[1].orc_column_id, 2);
+  EXPECT_TRUE(manifest->schema_fields[1].is_leaf());
+
+  // Field 2 ("col3") should map to ORC column 3
+  EXPECT_EQ(manifest->schema_fields[2].field->name(), "col3");
+  EXPECT_EQ(manifest->schema_fields[2].orc_column_id, 3);
+  EXPECT_TRUE(manifest->schema_fields[2].is_leaf());
+}
+
+TEST(TestAdapterRead, GetColumnStatisticsDoubleNaN) {
+  MemoryOutputStream mem_stream(kDefaultMemStreamSize);
+  std::unique_ptr<liborc::Type> type(
+      liborc::Type::buildTypeFromString("struct<col1:double>"));
+
+  constexpr uint64_t stripe_size = 1024;
+  constexpr uint64_t row_count = 10;
+
+  auto writer = CreateWriter(stripe_size, *type, &mem_stream);
+  auto batch = writer->createRowBatch(row_count);
+  auto struct_batch = internal::checked_cast<liborc::StructVectorBatch*>(batch.get());
+  auto double_batch =
+      internal::checked_cast<liborc::DoubleVectorBatch*>(struct_batch->fields[0]);
+
+  // Write some normal values and some NaN values
+  for (uint64_t i = 0; i < row_count; ++i) {
+    if (i % 3 == 0) {
+      double_batch->data[i] = std::numeric_limits<double>::quiet_NaN();
+    } else {
+      double_batch->data[i] = static_cast<double>(i);
+    }
+  }
+  struct_batch->numElements = row_count;
+  double_batch->numElements = row_count;
+  writer->add(*batch);
+  writer->close();
+
+  std::shared_ptr<io::RandomAccessFile> in_stream(new io::BufferReader(
+      std::make_shared<Buffer>(reinterpret_cast<const uint8_t*>(mem_stream.getData()),
+                               static_cast<int64_t>(mem_stream.getLength()))));
+
+  ASSERT_OK_AND_ASSIGN(auto reader,
+                       adapters::orc::ORCFileReader::Open(in_stream, default_memory_pool()));
+
+  ASSERT_OK_AND_ASSIGN(auto col_stats, reader->GetColumnStatistics(1));
+  // When NaN values are present, ORC may report NaN as min or max.
+  // Our guard should detect this and set has_min_max = false.
+  if (col_stats.has_min_max) {
+    // If ORC writer filtered NaN from statistics, min/max should be valid (non-NaN)
+    auto min_val = checked_pointer_cast<DoubleScalar>(col_stats.min);
+    auto max_val = checked_pointer_cast<DoubleScalar>(col_stats.max);
+    EXPECT_FALSE(std::isnan(min_val->value));
+    EXPECT_FALSE(std::isnan(max_val->value));
+  }
+  // Either has_min_max is false (NaN guard triggered), or min/max are non-NaN.
+  // Both outcomes are correct.
+}
+
+TEST(TestAdapterRead, GetColumnStatisticsNegativeIndex) {
+  MemoryOutputStream mem_stream(kDefaultMemStreamSize);
+  std::unique_ptr<liborc::Type> type(
+      liborc::Type::buildTypeFromString("struct<col1:int>"));
+
+  constexpr uint64_t stripe_size = 1024;
+  constexpr uint64_t row_count = 10;
+
+  auto writer = CreateWriter(stripe_size, *type, &mem_stream);
+  auto batch = writer->createRowBatch(row_count);
+  auto struct_batch = internal::checked_cast<liborc::StructVectorBatch*>(batch.get());
+  auto int_batch =
+      internal::checked_cast<liborc::LongVectorBatch*>(struct_batch->fields[0]);
+
+  for (uint64_t i = 0; i < row_count; ++i) {
+    int_batch->data[i] = static_cast<int64_t>(i);
+  }
+  struct_batch->numElements = row_count;
+  int_batch->numElements = row_count;
+  writer->add(*batch);
+  writer->close();
+
+  std::shared_ptr<io::RandomAccessFile> in_stream(new io::BufferReader(
+      std::make_shared<Buffer>(reinterpret_cast<const uint8_t*>(mem_stream.getData()),
+                               static_cast<int64_t>(mem_stream.getLength()))));
+
+  ASSERT_OK_AND_ASSIGN(auto reader,
+                       adapters::orc::ORCFileReader::Open(in_stream, default_memory_pool()));
+
+  // Negative column index should return Invalid
+  EXPECT_THAT(reader->GetColumnStatistics(-1),
+              Raises(StatusCode::Invalid, testing::HasSubstr("out of range")));
+
+  // Negative column index in stripe stats should also return Invalid
+  EXPECT_THAT(reader->GetStripeColumnStatistics(0, -1),
+              Raises(StatusCode::Invalid, testing::HasSubstr("out of range")));
+}
+
+TEST(TestAdapterRead, GetStripeStatisticsBulk) {
+  MemoryOutputStream mem_stream(kDefaultMemStreamSize);
+  std::unique_ptr<liborc::Type> type(liborc::Type::buildTypeFromString(
+      "struct<col1:int,col2:bigint,col3:double>"));
+
+  constexpr uint64_t stripe_size = 1024;
+  constexpr uint64_t row_count = 100;
+
+  auto writer = CreateWriter(stripe_size, *type, &mem_stream);
+  auto batch = writer->createRowBatch(row_count);
+  auto struct_batch = internal::checked_cast<liborc::StructVectorBatch*>(batch.get());
+  auto int_batch =
+      internal::checked_cast<liborc::LongVectorBatch*>(struct_batch->fields[0]);
+  auto bigint_batch =
+      internal::checked_cast<liborc::LongVectorBatch*>(struct_batch->fields[1]);
+  auto double_batch =
+      internal::checked_cast<liborc::DoubleVectorBatch*>(struct_batch->fields[2]);
+
+  for (uint64_t i = 0; i < row_count; ++i) {
+    int_batch->data[i] = static_cast<int64_t>(i);
+    bigint_batch->data[i] = static_cast<int64_t>(i + 1000);
+    double_batch->data[i] = static_cast<double>(i) + 0.5;
+  }
+  struct_batch->numElements = row_count;
+  int_batch->numElements = row_count;
+  bigint_batch->numElements = row_count;
+  double_batch->numElements = row_count;
+  writer->add(*batch);
+  writer->close();
+
+  std::shared_ptr<io::RandomAccessFile> in_stream(new io::BufferReader(
+      std::make_shared<Buffer>(reinterpret_cast<const uint8_t*>(mem_stream.getData()),
+                               static_cast<int64_t>(mem_stream.getLength()))));
+
+  ASSERT_OK_AND_ASSIGN(auto reader,
+                       adapters::orc::ORCFileReader::Open(in_stream, default_memory_pool()));
+
+  // ORC column indices: 0=root struct, 1=col1, 2=col2, 3=col3
+  std::vector<int> column_indices = {1, 2, 3};
+
+  // Get bulk stats for stripe 0
+  ASSERT_OK_AND_ASSIGN(auto bulk_stats, reader->GetStripeStatistics(0, column_indices));
+  ASSERT_EQ(bulk_stats.size(), 3);
+
+  // Verify bulk results match individual GetStripeColumnStatistics calls
+  for (size_t i = 0; i < column_indices.size(); ++i) {
+    ASSERT_OK_AND_ASSIGN(auto individual_stats,
+                         reader->GetStripeColumnStatistics(0, column_indices[i]));
+    EXPECT_EQ(bulk_stats[i].has_null, individual_stats.has_null);
+    EXPECT_EQ(bulk_stats[i].num_values, individual_stats.num_values);
+    EXPECT_EQ(bulk_stats[i].has_min_max, individual_stats.has_min_max);
+    if (bulk_stats[i].has_min_max && individual_stats.has_min_max) {
+      EXPECT_TRUE(bulk_stats[i].min->Equals(*individual_stats.min));
+      EXPECT_TRUE(bulk_stats[i].max->Equals(*individual_stats.max));
+    }
+  }
+
+  // Verify out-of-range column index in bulk API
+  std::vector<int> bad_indices = {1, 999};
+  EXPECT_THAT(reader->GetStripeStatistics(0, bad_indices),
+              Raises(StatusCode::Invalid, testing::HasSubstr("out of range")));
+
+  // Verify out-of-range stripe index in bulk API
+  EXPECT_THAT(reader->GetStripeStatistics(999, column_indices),
+              Raises(StatusCode::Invalid, testing::HasSubstr("out of range")));
+}
+
 }  // namespace arrow

--- a/cpp/src/arrow/adapters/orc/util.cc
+++ b/cpp/src/arrow/adapters/orc/util.cc
@@ -1229,6 +1229,30 @@ int GetOrcMajorVersion() {
   return std::stoi(major_version);
 }
 
+const OrcSchemaField* OrcSchemaManifest::GetField(const std::vector<int>& path) const {
+  if (path.empty()) {
+    return nullptr;
+  }
+
+  // Start with top-level field
+  if (path[0] < 0 || static_cast<size_t>(path[0]) >= schema_fields.size()) {
+    return nullptr;
+  }
+
+  const OrcSchemaField* current = &schema_fields[path[0]];
+
+  // Traverse nested path
+  for (size_t i = 1; i < path.size(); ++i) {
+    int child_index = path[i];
+    if (child_index < 0 || static_cast<size_t>(child_index) >= current->children.size()) {
+      return nullptr;
+    }
+    current = &current->children[child_index];
+  }
+
+  return current;
+}
+
 }  // namespace orc
 }  // namespace adapters
 }  // namespace arrow

--- a/cpp/src/arrow/adapters/orc/util.h
+++ b/cpp/src/arrow/adapters/orc/util.h
@@ -32,6 +32,39 @@ namespace arrow {
 namespace adapters {
 namespace orc {
 
+/// \brief Bridge between an Arrow Field and an ORC column index.
+///
+/// Represents a field in the Arrow schema mapped to its corresponding ORC column ID
+/// for statistics lookup. ORC uses depth-first pre-order numbering where column 0
+/// is the root struct.
+struct ARROW_EXPORT OrcSchemaField {
+  /// Arrow field definition
+  std::shared_ptr<Field> field;
+  /// ORC physical column ID (for GetColumnStatistics lookup)
+  int orc_column_id;
+  /// Child fields for nested types (struct, list, map)
+  std::vector<OrcSchemaField> children;
+  /// Returns true if this is a leaf field (no children)
+  bool is_leaf() const { return children.empty(); }
+};
+
+/// \brief Bridge between Arrow schema and ORC schema.
+///
+/// Maps Arrow field paths to ORC physical column indices for statistics lookup.
+struct ARROW_EXPORT OrcSchemaManifest {
+  /// Top-level fields (parallel to Arrow schema fields)
+  std::vector<OrcSchemaField> schema_fields;
+
+  /// \brief Find the OrcSchemaField for a given Arrow field path.
+  ///
+  /// Path is a sequence of child indices starting from the root.
+  /// For example, path {1, 0} means schema_fields[1].children[0].
+  ///
+  /// \param[in] path sequence of child indices from root to target field
+  /// \return pointer to the field if found, nullptr otherwise
+  const OrcSchemaField* GetField(const std::vector<int>& path) const;
+};
+
 Result<std::shared_ptr<DataType>> GetArrowType(const liborc::Type* type);
 
 Result<std::unique_ptr<liborc::Type>> GetOrcType(const Schema& schema);


### PR DESCRIPTION
### Rationale

Implement Part 1 of ORC predicate pushdown (#48986).

Add public APIs to `ORCFileReader` for accessing stripe-level and file-level column statistics as Arrow types and selective stripe reading. This is the foundation that the dataset layer will consume for predicate evaluation. Heavy inspiration drawn from the Parquet predicate pushdown implementation.

### What changes are included in this PR?

New structs in `adapter.h`:
```cpp
/// Column statistics from an ORC file, with min/max as Arrow scalars.
struct OrcColumnStatistics {
    bool has_null;
    int64_t num_values;
    bool has_min_max;
    std::shared_ptr<Scalar> min;  // Arrow scalar (nullptr if not available)
    std::shared_ptr<Scalar> max;  // Arrow scalar (nullptr if not available)
};
```
The struct exists because liborc's statistics API returns type-erased `ColumnStatistics*` pointers with different C++ return types per subclass (`int64_t`, `double`, `std::string`, `Decimal`), and the dataset layer needs a single uniform type it can pass around without knowing the ORC column type — `std::shared_ptr<Scalar>` provides that.

New structs in `util.h`:
```cpp
/// Maps an Arrow field to its ORC physical column ID.
/// ORC uses depth-first pre-order numbering (column 0 = root struct).
struct OrcSchemaField {
    std::shared_ptr<Field> field;
    int orc_column_id;
    std::vector<OrcSchemaField> children;  // for struct, list, map
    bool is_leaf() const;
};

/// Maps an entire Arrow schema to ORC column IDs.
struct OrcSchemaManifest {
    std::vector<OrcSchemaField> schema_fields;  // parallel to Arrow schema fields
    const OrcSchemaField* GetField(const std::vector<int>& path) const;
};
```
The dataset layer needs to translate Arrow field references from filter expressions into ORC column indices for statistics lookup. `BuildSchemaManifest()` walks the paired ORC and Arrow type trees to build this mapping, handling nested types (struct, list, map) recursively.

New methods on `ORCFileReader`:
```cpp
class ORCFileReader {
 public:
  // --- existing API (unchanged) ---
  Result<std::shared_ptr<Table>> Read();
  Result<std::shared_ptr<RecordBatch>> ReadStripe(int64_t stripe);
  Result<std::shared_ptr<RecordBatch>> ReadStripe(int64_t stripe,
                                                   const std::vector<int>& include_indices);
  int64_t NumberOfStripes();
  StripeInformation GetStripeInformation(int64_t stripe);

  // --- NEW: stripe-selective reading ---
  // Read only selected stripes, concatenated into a single Table.
  // Used by the dataset layer after predicate pushdown eliminates stripes.
  Result<std::shared_ptr<Table>> ReadStripes(
      const std::vector<int64_t>& stripe_indices);                              // NEW
  Result<std::shared_ptr<Table>> ReadStripes(
      const std::vector<int64_t>& stripe_indices,
      const std::vector<int>& include_indices);                                 // NEW

  // --- NEW: column statistics ---
  Result<OrcColumnStatistics> GetColumnStatistics(int column_index);            // NEW (file-level)
  Result<OrcColumnStatistics> GetStripeColumnStatistics(int64_t stripe_index,
                                                        int column_index);      // NEW (stripe-level)
  // Bulk variant — parses stripe statistics once instead of per-column.
  Result<std::vector<OrcColumnStatistics>> GetStripeStatistics(
      int64_t stripe_index, const std::vector<int>& column_indices);            // NEW

  // --- NEW: schema manifest ---
  // Builds a mapping from Arrow field paths to ORC column IDs by walking
  // the paired ORC/Arrow type trees. Needed for statistics lookup.
  Result<std::shared_ptr<OrcSchemaManifest>> BuildSchemaManifest(
      const std::shared_ptr<Schema>& arrow_schema) const;                       // NEW
};
```

For reference, the Parquet equivalent of ORCFileReader is `parquet::arrow::FileReader` at `cpp/src/parquet/arrow/reader.h:116`.

ORC (ORCFileReader) | Parquet (parquet::arrow::FileReader)
-- | --
ReadStripe(i) | ReadRowGroup(i)
ReadStripes(indices) | ReadRowGroups(row_groups)
ReadStripes(indices, cols) | ReadRowGroups(row_groups, column_indices)
NumberOfStripes() | num_row_groups()
GetRecordBatchReader(batch_size, names) | GetRecordBatchReader(row_groups, columns)
Read() | ReadTable()
BuildSchemaManifest(schema) | (parquet uses SchemaManifest in parquet/arrow/schema.h)

New Internal Helper:
`ConvertColumnStatistics()` downcasts liborc `ColumnStatistics` to typed subclasses and produces the appropriate Arrow scalar.
```java
Result<OrcColumnStatistics> ConvertColumnStatistics(const liborc::ColumnStatistics* s) {
    OrcColumnStatistics out{s->hasNull(), static_cast<int64_t>(s->getNumberOfValues()),
                            /*has_min_max=*/false, nullptr, nullptr};

    if (auto* p = dynamic_cast<const liborc::IntegerColumnStatistics*>(s)) {
      // BYTE, SHORT, INT, LONG → Int64Scalar

    } else if (auto* p = dynamic_cast<const liborc::DoubleColumnStatistics*>(s)) {
      // FLOAT, DOUBLE → DoubleScalar (skip if NaN)

    } else if (auto* p = dynamic_cast<const liborc::StringColumnStatistics*>(s)) {
      // STRING, VARCHAR, CHAR → StringScalar

    } else if (auto* p = dynamic_cast<const liborc::DateColumnStatistics*>(s)) {
      // DATE → Date32Scalar

    } else if (auto* p = dynamic_cast<const liborc::TimestampColumnStatistics*>(s)) {
      // millis * 1_000_000 + sub-millis nanos → TimestampScalar(NANO)

    } else if (auto* p = dynamic_cast<const liborc::DecimalColumnStatistics*>(s)) {
      // ORC Int128 → Arrow Decimal128Scalar(precision=38, scale from ORC)
      // Skip if min.scale != max.scale (corrupted stats)
    }
    // Boolean, Binary, Collection, etc. → no min/max (has_min_max stays false)

    return out;
}
```
The pattern is the same for every branch: `dynamic_cast` to typed subclass, check `hasMinimum() && hasMaximum()`, wrap in the corresponding Arrow scalar. The interesting branches are double (NaN guard), timestamp (two-part millis+nanos conversion), and decimal (scale consistency check + Int128 bit extraction).

### Are these changes tested?

Unit tests in `adapter_test.cc`:

*Statistics tests:*
- Integer column statistics (file-level and stripe-level)
- String column statistics
- Boolean column statistics (verifies no min/max via fallthrough)
- Date column statistics
- Timestamp column statistics
- Double with NaN values (NaN guard)
- Out-of-range column/stripe index → error
- Negative column index → error
- Columns with nulls
- Bulk stripe statistics (multiple columns at once, verified against individual calls)

*Stripe-selective reading tests:*
- ReadStripes with multiple stripes
- ReadStripes with column selection
- ReadStripes with out-of-range stripe index → error
- ReadStripes with empty stripe indices → error

*Schema manifest tests:*
- BuildSchemaManifest maps Arrow field names to correct ORC column IDs (column 0 = root struct, column 1 = first field, etc.)
- Verifies field count matches, leaf detection works

### Are there any user-facing changes?

No. These are new C++ APIs on `ORCFileReader` that are not yet exposed in Python bindings.

### Reference
![Image](https://github.com/user-attachments/assets/f58cb1c1-fc79-45e9-87fa-5566b7675c6a)

### Component(s)

C++
* GitHub Issue: #49360