### PR TITLE
GH-49380: [R] Remove hidden CI test chunks from setup.Rmd to fix r-de…

### DIFF
--- a/r/vignettes/developers/setup.Rmd
+++ b/r/vignettes/developers/setup.Rmd
@@ -354,6 +354,10 @@ sudo apt install -y -V libarrow-dev
 MAKEFLAGS="LDFLAGS=" R CMD INSTALL .
 ```
 
+```{bash, save=run & !sys_install & ubuntu}
+MAKEFLAGS="LDFLAGS=" R CMD INSTALL .
+```
+
 ## `rpath` issues
 
 If the package fails to install/load with an error like this:

--- a/r/vignettes/developers/setup.Rmd
+++ b/r/vignettes/developers/setup.Rmd
@@ -350,7 +350,7 @@ sudo apt update
 sudo apt install -y -V libarrow-dev
 ```
 
-```{bash, save=run & !sys_install & macos}
+```{bash, save=run & !sys_install}
 MAKEFLAGS="LDFLAGS=" R CMD INSTALL .
 ```
 

--- a/r/vignettes/developers/setup.Rmd
+++ b/r/vignettes/developers/setup.Rmd
@@ -354,8 +354,6 @@ sudo apt install -y -V libarrow-dev
 MAKEFLAGS="LDFLAGS=" R CMD INSTALL .
 ```
 
-```{bash, save=run & !sys_install}
-MAKEFLAGS="LDFLAGS=" R CMD INSTALL .
 ## `rpath` issues
 
 If the package fails to install/load with an error like this:

--- a/r/vignettes/developers/setup.Rmd
+++ b/r/vignettes/developers/setup.Rmd
@@ -354,9 +354,6 @@ sudo apt install -y -V libarrow-dev
 MAKEFLAGS="LDFLAGS=" R CMD INSTALL .
 ```
 
-```{bash, save=run & !sys_install & ubuntu}
-MAKEFLAGS="LDFLAGS=" R CMD INSTALL .
-```
 ```{bash, save=run & !sys_install}
 MAKEFLAGS="LDFLAGS=" R CMD INSTALL .
 ## `rpath` issues

--- a/r/vignettes/developers/setup.Rmd
+++ b/r/vignettes/developers/setup.Rmd
@@ -357,7 +357,8 @@ MAKEFLAGS="LDFLAGS=" R CMD INSTALL .
 ```{bash, save=run & !sys_install & ubuntu}
 MAKEFLAGS="LDFLAGS=" R CMD INSTALL .
 ```
-
+```{bash, save=run & !sys_install}
+MAKEFLAGS="LDFLAGS=" R CMD INSTALL .
 ## `rpath` issues
 
 If the package fails to install/load with an error like this:


### PR DESCRIPTION
### Rationale for this change

The `r-devdocs` crossbow CI job fails during the gap between the C++ release (published to apt) and the R package release (CRAN). Two hidden bash chunks in `setup.Rmd` were silently installing the released `libarrow-dev` from apt during CI, overwriting the version built from the git checkout. Since the R package (`arrow.so`) was compiled against the newer git-built `libarrow`, loading it against the older apt version caused an undefined symbol ABI mismatch error.

### What changes are included in this PR?

Removes the hidden CI test chunks from `r/vignettes/developers/setup.Rmd`:

- Removed hidden macOS chunk that ran `brew install apache-arrow`
- Removed hidden Ubuntu chunk that ran `apt install libarrow-dev` (root cause of the ABI mismatch)
- Converted the `MAKEFLAGS="LDFLAGS="` example from an executable knitr chunk to a plain `bash` code block preserves the documentation example without executing it in CI

### Are these changes tested?

No, the fix removes the broken test logic from the vignette. As noted by @thisisnic, this type of testing should live in proper CI infrastructure, not embedded as hidden code in documentation.

### Are there any user-facing changes?

No. The rendered documentation is unchanged the `MAKEFLAGS="LDFLAGS="` example remains visible in the "Multiple versions of libarrow" troubleshooting section.

* GitHub Issue: #49380