### PR TITLE
GH-49385: [C++][Parquet] Clarify empty schema contract on stream_reader

### DIFF
--- a/cpp/src/parquet/stream_reader.cc
+++ b/cpp/src/parquet/stream_reader.cc
@@ -50,6 +50,9 @@ StreamReader::StreamReader(std::unique_ptr<ParquetFileReader> reader)
   auto schema = file_metadata_->schema();
   auto group_node = schema->group_node();
 
+  if (schema->num_columns() == 0) {
+    throw ParquetException("StreamReader does not support empty schemas.");
+  }
   nodes_.resize(schema->num_columns());
 
   for (auto i = 0; i < schema->num_columns(); ++i) {

--- a/cpp/src/parquet/stream_reader.h
+++ b/cpp/src/parquet/stream_reader.h
@@ -65,7 +65,6 @@ class PARQUET_EXPORT StreamReader {
   //      assigned afterwards.
   StreamReader() = default;
 
-
   /// Reader must have at least one field defined in its schema.
   explicit StreamReader(std::unique_ptr<ParquetFileReader> reader);
 

--- a/cpp/src/parquet/stream_reader.h
+++ b/cpp/src/parquet/stream_reader.h
@@ -65,6 +65,8 @@ class PARQUET_EXPORT StreamReader {
   //      assigned afterwards.
   StreamReader() = default;
 
+
+  /// Reader must have at least one field defined in its schema.
   explicit StreamReader(std::unique_ptr<ParquetFileReader> reader);
 
   ~StreamReader() = default;


### PR DESCRIPTION
### Rationale for this change

StreamReader inherently does not support empty schemas. Guard this case with an exception.

### What changes are included in this PR?

Added validation around the parquet reader passed in.

### Are these changes tested?

Yes added unit tests.

### Are there any user-facing changes?

A change that might be debatable is the constructor for this class can now throw, but it was never marked noexcept.

**This PR contains a "Critical Fix".** 

* GitHub Issue: #49385