### PR TITLE
GH-49389: [Ruby] Add support for custom metadata in field and schema

### DIFF
--- a/ruby/red-arrow-format/lib/arrow-format/field.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/field.rb
@@ -19,11 +19,17 @@ module ArrowFormat
     attr_reader :name
     attr_reader :type
     attr_reader :dictionary_id
-    def initialize(name, type, nullable, dictionary_id)
+    attr_reader :metadata
+    def initialize(name,
+                   type,
+                   nullable: true,
+                   dictionary_id: nil,
+                   metadata: nil)
       @name = name
       @type = type
       @nullable = nullable
       @dictionary_id = dictionary_id
+      @metadata = metadata
     end
 
     def nullable?
@@ -44,7 +50,14 @@ module ArrowFormat
       elsif @type.respond_to?(:children)
         fb_field.children = @type.children.collect(&:to_flatbuffers)
       end
-      # fb_field.custom_metadata = @custom_metadata
+      if @metadata
+        fb_field.custom_metadata = @metadata.collect do |key, value|
+          fb_key_value = FB::KeyValue::Data.new
+          fb_key_value.key = key
+          fb_key_value.value = value
+          fb_key_value
+        end
+      end
       fb_field
     end
   end

--- a/ruby/red-arrow-format/lib/arrow-format/file-reader.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/file-reader.rb
@@ -47,7 +47,7 @@ module ArrowFormat
 
       validate
       @footer = read_footer
-      @record_batch_blocks = @footer.record_batches
+      @record_batch_blocks = @footer.record_batches || []
       @schema = read_schema(@footer.schema)
       @dictionaries = read_dictionaries
     end
@@ -193,7 +193,7 @@ module ArrowFormat
         end
 
         value_type = dictionary_fields[id].type.value_type
-        schema = Schema.new([Field.new("dummy", value_type, true, nil)])
+        schema = Schema.new([Field.new("dummy", value_type)])
         record_batch = read_record_batch(fb_header.data, schema, body)
         if fb_header.delta?
           dictionaries[id] << record_batch.columns[0]

--- a/ruby/red-arrow-format/lib/arrow-format/readable.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/readable.rb
@@ -25,11 +25,21 @@ require_relative "type"
 module ArrowFormat
   module Readable
     private
+    def read_custom_metadata(fb_custom_metadata)
+      return nil if fb_custom_metadata.nil?
+      metadata = {}
+      fb_custom_metadata.each do |key_value|
+        metadata[key_value.key] = key_value.value
+      end
+      metadata
+    end
+
     def read_schema(fb_schema)
       fields = fb_schema.fields.collect do |fb_field|
         read_field(fb_field)
       end
-      Schema.new(fields)
+      Schema.new(fields,
+                 metadata: read_custom_metadata(fb_schema.custom_metadata))
     end
 
     def read_field(fb_field)
@@ -132,7 +142,11 @@ module ArrowFormat
       else
         dictionary_id = nil
       end
-      Field.new(fb_field.name, type, fb_field.nullable?, dictionary_id)
+      Field.new(fb_field.name,
+                type,
+                nullable: fb_field.nullable?,
+                dictionary_id: dictionary_id,
+                metadata: read_custom_metadata(fb_field.custom_metadata))
     end
 
     def read_type_int(fb_type)

--- a/ruby/red-arrow-format/lib/arrow-format/schema.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/schema.rb
@@ -17,15 +17,24 @@
 module ArrowFormat
   class Schema
     attr_reader :fields
-    def initialize(fields)
+    attr_reader :metadata
+    def initialize(fields, metadata: nil)
       @fields = fields
+      @metadata = metadata
     end
 
     def to_flatbuffers
       fb_schema = FB::Schema::Data.new
       fb_schema.endianness = FB::Endianness::LITTLE
       fb_schema.fields = fields.collect(&:to_flatbuffers)
-      # fb_schema.custom_metadata = @custom_metadata
+      if @metadata
+        fb_schema.custom_metadata = @metadata.collect do |key, value|
+          fb_key_value = FB::KeyValue::Data.new
+          fb_key_value.key = key
+          fb_key_value.value = value
+          fb_key_value
+        end
+      end
       # fb_schema.features = @features
       fb_schema
     end

--- a/ruby/red-arrow-format/lib/arrow-format/streaming-pull-reader.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/streaming-pull-reader.rb
@@ -222,7 +222,7 @@ module ArrowFormat
       end
       field = @dictionary_fields[header.id]
       value_type = field.type.value_type
-      schema = Schema.new([Field.new("dummy", value_type, true, nil)])
+      schema = Schema.new([Field.new("dummy", value_type)])
       record_batch = read_record_batch(header.data, schema, body)
       if header.delta?
         @dictionaries[header.id] << record_batch.columns[0]

--- a/ruby/red-arrow-format/lib/arrow-format/streaming-writer.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/streaming-writer.rb
@@ -125,7 +125,7 @@ module ArrowFormat
           dictionary = dictionary.slice(written_offset - current_base_offset)
         end
 
-        schema = Schema.new([Field.new("dummy", value_type, true, nil)])
+        schema = Schema.new([Field.new("dummy", value_type)])
         size = dictionary.size
         record_batch = RecordBatch.new(schema, size, [dictionary])
         fb_dictionary_batch = FB::DictionaryBatch::Data.new

--- a/ruby/red-arrow-format/red-arrow-format.gemspec
+++ b/ruby/red-arrow-format/red-arrow-format.gemspec
@@ -46,7 +46,7 @@ Gem::Specification.new do |spec|
   spec.files += Dir.glob("lib/**/*.rb")
   spec.files += Dir.glob("doc/text/*")
 
-  spec.add_runtime_dependency("red-flatbuffers", ">=0.0.5")
+  spec.add_runtime_dependency("red-flatbuffers", ">=0.0.6")
 
   github_url = "https://github.com/apache/arrow"
   spec.metadata = {


### PR DESCRIPTION
### Rationale for this change

We can add custom metadata to `Field` and `Schema`.

### What changes are included in this PR?

* Add `ArrowFormat::Field#metadata`
* Add `ArrowFormat::Schema#metadata`
* Add support for reading and writing custom metadata in `Field` and `Schema`

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #49389