### PR TITLE
GH-49371: [CI][R] Fix C++ 20 build error on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
   under the License.
 -->
 
+
 # Apache Arrow
 
 [![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/arrow.svg)](https://bugs.chromium.org/p/oss-fuzz/issues/list?sort=-opened&can=1&q=proj:arrow)


### PR DESCRIPTION

### Rationale for this change
When the [PR](https://github.com/apache/arrow/pull/49298)  that migrates to C++ 20 stdlib bit utilities was merged the cran build came clean as seen [here](https://github.com/apache/arrow/pull/49298#issuecomment-3914762965) while afterwards the build started failing on macOS. This suggests that there was some change/regression in cran.

### What changes are included in this PR?
I added a one line change in the Readme to enable making the pr, this will be removed later, this pr is the work area for fixing the cran build.

### Are these changes tested?
No

### Are there any user-facing changes?
No
* GitHub Issue: #49371