### PR TITLE
GH-49444: [C++][FlightRPC][ODBC] Disable DSN default values on MacOS

### DIFF
--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/config/configuration.cc
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/config/configuration.cc
@@ -129,16 +129,29 @@ void Configuration::LoadDsn(const std::string& dsn) {
   Set(FlightSqlConnection::TOKEN, ReadDsnString(dsn, FlightSqlConnection::TOKEN));
   Set(FlightSqlConnection::UID, ReadDsnString(dsn, FlightSqlConnection::UID));
   Set(FlightSqlConnection::PWD, ReadDsnString(dsn, FlightSqlConnection::PWD));
-  Set(FlightSqlConnection::USE_ENCRYPTION,
-      ReadDsnString(dsn, FlightSqlConnection::USE_ENCRYPTION, DEFAULT_ENABLE_ENCRYPTION));
   Set(FlightSqlConnection::TRUSTED_CERTS,
       ReadDsnString(dsn, FlightSqlConnection::TRUSTED_CERTS));
+#ifdef __APPLE__
+  // macOS iODBC treats non-empty defaults as the real values when reading from system
+  // DSN, so we don't pass defaults on macOS.
+  // GH-49387 TODO: enable default values on macOS
+  Set(FlightSqlConnection::USE_ENCRYPTION,
+      ReadDsnString(dsn, FlightSqlConnection::USE_ENCRYPTION));
+  Set(FlightSqlConnection::USE_SYSTEM_TRUST_STORE,
+      ReadDsnString(dsn, FlightSqlConnection::USE_SYSTEM_TRUST_STORE));
+  Set(FlightSqlConnection::DISABLE_CERTIFICATE_VERIFICATION,
+      ReadDsnString(dsn, FlightSqlConnection::DISABLE_CERTIFICATE_VERIFICATION));
+#else
+  // Windows and Linux
+  Set(FlightSqlConnection::USE_ENCRYPTION,
+      ReadDsnString(dsn, FlightSqlConnection::USE_ENCRYPTION, DEFAULT_ENABLE_ENCRYPTION));
   Set(FlightSqlConnection::USE_SYSTEM_TRUST_STORE,
       ReadDsnString(dsn, FlightSqlConnection::USE_SYSTEM_TRUST_STORE,
                     DEFAULT_USE_CERT_STORE));
   Set(FlightSqlConnection::DISABLE_CERTIFICATE_VERIFICATION,
       ReadDsnString(dsn, FlightSqlConnection::DISABLE_CERTIFICATE_VERIFICATION,
                     DEFAULT_DISABLE_CERT_VERIFICATION));
+#endif
 
   auto customKeys = ReadAllKeys(dsn);
   RemoveAllKnownKeys(customKeys);


### PR DESCRIPTION
### Rationale for this change
iodbc driver manager on macOS treats default values as real values when reading from system DSN, and the driver manager ignores the actual values.

* GitHub Issue: #49444