### PR TITLE
GH-49408: [C++][Parquet] Add public virtual destructor to `parquet::Page`

### DIFF
--- a/cpp/src/parquet/column_page.h
+++ b/cpp/src/parquet/column_page.h
@@ -44,6 +44,8 @@ class Page {
   Page(const std::shared_ptr<Buffer>& buffer, PageType::type type)
       : buffer_(buffer), type_(type) {}
 
+  virtual ~Page() = default;
+
   PageType::type type() const { return type_; }
 
   std::shared_ptr<Buffer> buffer() const { return buffer_; }


### PR DESCRIPTION
### Rationale for this change

Clarify the destructor implementation of `parquet::Page` to expose the design intent.

### What changes are included in this PR?

Add public virtual destructor to `parquet::Page`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.

* GitHub Issue: #49408