### PR TITLE
GH-49415: [C++] Don't change map type key/item/value field names

### DIFF
--- a/cpp/src/arrow/ipc/metadata_internal.cc
+++ b/cpp/src/arrow/ipc/metadata_internal.cc
@@ -390,9 +390,7 @@ Status ConcreteTypeFromFlatbuffer(flatbuf::Type type, const void* type_data,
         return Status::Invalid("Map's keys must be non-nullable");
       } else {
         auto map = static_cast<const flatbuf::Map*>(type_data);
-        *out = std::make_shared<MapType>(children[0]->type()->field(0)->WithName("key"),
-                                         children[0]->type()->field(1)->WithName("value"),
-                                         map->keysSorted());
+        *out = std::make_shared<MapType>(children[0], map->keysSorted());
       }
       return Status::OK();
     case flatbuf::Type::Type_FixedSizeList:


### PR DESCRIPTION
### Rationale for this change

The current implementation forces using `key`/`value`/`entries` as key/item/value field names and ignores field names in FlatBuffers.

### What changes are included in this PR?

Use field names in FlatBuffers.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.

**This PR includes breaking changes to public APIs.** If an application depends on `key`/`value`/entries` as map type's field names, an application may not work when incoming Apache Arrow data doesn't use `key`/`value`/`entries` as map type's field names.

* GitHub Issue: #49415