### PR TITLE
GH-49417: [GLib] Add `garrow_map_data_type_is_keys_sorted()`

### DIFF
--- a/c_glib/arrow-glib/composite-data-type.cpp
+++ b/c_glib/arrow-glib/composite-data-type.cpp
@@ -422,6 +422,23 @@ garrow_map_data_type_get_item_type(GArrowMapDataType *map_data_type)
   return garrow_data_type_new_raw(&arrow_item_type);
 }
 
+/**
+ * garrow_map_data_type_is_keys_sorted:
+ * @map_data_type: A #GArrowMapDataType.
+ *
+ * Returns: Whether the keys in the map is sorted or not.
+ *
+ * Since: 24.0.0
+ */
+gboolean
+garrow_map_data_type_is_keys_sorted(GArrowMapDataType *map_data_type)
+{
+  auto data_type = GARROW_DATA_TYPE(map_data_type);
+  auto arrow_data_type = garrow_data_type_get_raw(data_type);
+  auto arrow_map_data_type = std::static_pointer_cast<arrow::MapType>(arrow_data_type);
+  return arrow_map_data_type->keys_sorted();
+}
+
 G_DEFINE_ABSTRACT_TYPE(GArrowUnionDataType, garrow_union_data_type, GARROW_TYPE_DATA_TYPE)
 
 static void

--- a/c_glib/arrow-glib/composite-data-type.h
+++ b/c_glib/arrow-glib/composite-data-type.h
@@ -142,6 +142,9 @@ garrow_map_data_type_get_key_type(GArrowMapDataType *map_data_type);
 GARROW_AVAILABLE_IN_0_17
 GArrowDataType *
 garrow_map_data_type_get_item_type(GArrowMapDataType *map_data_type);
+GARROW_AVAILABLE_IN_24_0
+gboolean
+garrow_map_data_type_is_keys_sorted(GArrowMapDataType *map_data_type);
 
 #define GARROW_TYPE_UNION_DATA_TYPE (garrow_union_data_type_get_type())
 GARROW_AVAILABLE_IN_ALL

--- a/c_glib/test/test-map-data-type.rb
+++ b/c_glib/test/test-map-data-type.rb
@@ -41,4 +41,10 @@ class TestMapDataType < Test::Unit::TestCase
   def test_item
     assert_equal(@item_type, @data_type.item_type)
   end
+
+  def test_keys_sorted?
+    assert do
+      not @data_type.keys_sorted?
+    end
+  end
 end


### PR DESCRIPTION
### Rationale for this change

It's the bindings of `arrow::MapType::keys_sorted()`.

### What changes are included in this PR?

Add `garrow_map_data_type_is_keys_sorted()`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #49417