### PR TITLE
GH-49424: [C++] Use std::bit_width instead of missing std::log2p1 on emscripten clang

### DIFF
--- a/cpp/src/arrow/util/align_util.h
+++ b/cpp/src/arrow/util/align_util.h
@@ -46,7 +46,7 @@ inline BitmapWordAlignParams BitmapWordAlign(const uint8_t* data, int64_t bit_of
                                              int64_t length) {
   // TODO: We can remove this condition once CRAN upgrades its macOS
   // SDK from 11.3.
-#if defined(__clang__) && !defined(__cpp_lib_bitops)
+#if defined(__clang__) && !defined(__cpp_lib_bitops) && !defined(__EMSCRIPTEN__)
   static_assert((ALIGN_IN_BYTES != 0) && ((ALIGN_IN_BYTES & (ALIGN_IN_BYTES - 1)) == 0),
                 "ALIGN_IN_BYTES should be a positive power of two");
 #else

--- a/cpp/src/arrow/util/bit_util.h
+++ b/cpp/src/arrow/util/bit_util.h
@@ -141,7 +141,7 @@ static inline int Log2(uint64_t x) {
 
   // TODO: We can remove this condition once CRAN upgrades its macOS
   // SDK from 11.3.
-#if defined(__clang__) && !defined(__cpp_lib_bitops)
+#if defined(__clang__) && !defined(__cpp_lib_bitops) && !defined(__EMSCRIPTEN__)
   return std::log2p1(x - 1);
 #else
   return std::bit_width(x - 1);

--- a/cpp/src/arrow/util/rle_encoding_test.cc
+++ b/cpp/src/arrow/util/rle_encoding_test.cc
@@ -918,7 +918,7 @@ TEST(BitRle, Random) {
     }
     // TODO: We can remove this condition once CRAN upgrades its macOS
     // SDK from 11.3.
-#if defined(__clang__) && !defined(__cpp_lib_bitops)
+#if defined(__clang__) && !defined(__cpp_lib_bitops) && !defined(__EMSCRIPTEN__)
     if (!CheckRoundTrip(values, std::log2p1(values.size()))) {
 #else
     if (!CheckRoundTrip(values, std::bit_width(values.size()))) {

--- a/cpp/src/parquet/chunker_internal.cc
+++ b/cpp/src/parquet/chunker_internal.cc
@@ -88,7 +88,7 @@ uint64_t CalculateMask(int64_t min_chunk_size, int64_t max_chunk_size, int norm_
   // by taking the floor(log2(target_size))
   // TODO: We can remove this condition once CRAN upgrades its macOS
   // SDK from 11.3.
-#if defined(__clang__) && !defined(__cpp_lib_bitops)
+#if defined(__clang__) && !defined(__cpp_lib_bitops) && !defined(__EMSCRIPTEN__)
   auto target_bits = std::log2p1(static_cast<uint64_t>(target_size));
 #else
   auto target_bits = std::bit_width(static_cast<uint64_t>(target_size));

--- a/cpp/src/parquet/encoder.cc
+++ b/cpp/src/parquet/encoder.cc
@@ -1169,7 +1169,7 @@ void DeltaBitPackEncoder<DType>::FlushBlock() {
     // See overflow comment above.
     // TODO: We can remove this condition once CRAN upgrades its macOS
     // SDK from 11.3.
-#if defined(__clang__) && !defined(__cpp_lib_bitops)
+#if defined(__clang__) && !defined(__cpp_lib_bitops) && !defined(__EMSCRIPTEN__)
     const auto bit_width = bit_width_data[i] =
         std::log2p1(static_cast<UT>(max_delta) - static_cast<UT>(min_delta));
 #else


### PR DESCRIPTION
### Rationale for this change

The current Emscripten job fails due to macro check targeting CRAN macOS being used for emscripten.

### What changes are included in this PR?

Avoid using workaround for Emscripten.

### Are these changes tested?

Yes via CI

### Are there any user-facing changes?
No

* GitHub Issue: #49424