### PR TITLE
GH-49426: [Python] Do not build pyarrow-stubs on emscripten builds

### DIFF
--- a/python/scripts/run_emscripten_tests.py
+++ b/python/scripts/run_emscripten_tests.py
@@ -280,6 +280,7 @@ import micropip
 if "pyarrow" not in sys.modules:
     await micropip.install("hypothesis")
     import pyodide_js as pjs
+    await pjs.loadPackage("tzdata")
     await pjs.loadPackage("numpy")
     await pjs.loadPackage("pandas")
     import pytest

--- a/python/scripts/run_emscripten_tests.py
+++ b/python/scripts/run_emscripten_tests.py
@@ -116,7 +116,7 @@ class TemplateOverrider(http.server.SimpleHTTPRequestHandler):
 def run_server_thread(dist_dir, q):
     global _SERVER_ADDRESS
     os.chdir(dist_dir)
-    server = http.server.HTTPServer(("", 0), TemplateOverrider)
+    server = http.server.HTTPServer(("127.0.0.1", 0), TemplateOverrider)
     q.put(server.server_address)
     print(f"Starting server for {dist_dir} at: {server.server_address}")
     server.serve_forever()

--- a/python/setup.py
+++ b/python/setup.py
@@ -126,6 +126,9 @@ class build_ext(_build_ext):
 
     def _update_stubs(self):
         """Copy stubs to build directory, then inject docstrings into the copies."""
+        if is_emscripten:
+            # stubs are not supported in Emscripten build
+            return
         stubs_dir = pjoin(setup_dir, 'pyarrow-stubs')
         if not os.path.exists(stubs_dir):
             return


### PR DESCRIPTION
### Rationale for this change

The emscripten job is currently failing due to pyarrow-stubs building.

### What changes are included in this PR?

- Do not build doc stubs for emscripten build as it tries to install pyarrow which is unavailable.
- Minor fix for chrome as it was timing out without being able to download wasm wheel.
- Fix loading tzdata as some tests were failing without it.

### Are these changes tested?

Yes via archery.

### Are there any user-facing changes?
No

* GitHub Issue: #49426