### PR TITLE
GH-49428: [C++][Gandiva] Add support for LLVM 22.1.0

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -177,6 +177,7 @@ set(ARROW_DOC_DIR "share/doc/${PROJECT_NAME}")
 set(BUILD_SUPPORT_DIR "${CMAKE_SOURCE_DIR}/build-support")
 
 set(ARROW_LLVM_VERSIONS
+    "22.1"
     "21.1"
     "20.1"
     "19.1"

--- a/cpp/src/gandiva/engine.cc
+++ b/cpp/src/gandiva/engine.cc
@@ -73,7 +73,7 @@
 #  include <llvm/IR/PassManager.h>
 #  include <llvm/MC/TargetRegistry.h>
 #  if LLVM_VERSION_MAJOR >= 22
-#    include "llvm/Plugins/PassPlugin.h"
+#    include <llvm/Plugins/PassPlugin.h>
 #  else
 #    include <llvm/Passes/PassPlugin.h>
 #  endif

--- a/cpp/src/gandiva/engine.cc
+++ b/cpp/src/gandiva/engine.cc
@@ -72,7 +72,11 @@
 #if LLVM_VERSION_MAJOR >= 14
 #  include <llvm/IR/PassManager.h>
 #  include <llvm/MC/TargetRegistry.h>
-#  include <llvm/Passes/PassPlugin.h>
+#  if LLVM_VERSION_MAJOR >= 22
+#    include "llvm/Plugins/PassPlugin.h"
+#  else
+#    include <llvm/Passes/PassPlugin.h>
+#  endif
 #  include <llvm/Transforms/IPO/GlobalOpt.h>
 #  include <llvm/Transforms/Scalar/NewGVN.h>
 #  include <llvm/Transforms/Scalar/SimplifyCFG.h>


### PR DESCRIPTION
### Rationale for this change

Some of our CI jobs fail because conda jobs are pulling LLVM 22.1.0 and we are not compatible.

### What changes are included in this PR?

Add 22.1.0 as compatible LLVM and minor fix to update the location of PassPlugin.h due to:
- https://github.com/llvm/llvm-project/pull/173279

### Are these changes tested?

Yes via CI

### Are there any user-facing changes?

No, the only change is that LLVM 22.1.0 will be supported.

* GitHub Issue: #49428