### PR TITLE
Fixed usage of libarrow built from the git checkout not the released version from apt

### DIFF
--- a/r/vignettes/developers/setup.Rmd
+++ b/r/vignettes/developers/setup.Rmd
@@ -348,6 +348,8 @@ wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr '
 sudo apt install -y -V ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
 sudo apt update
 sudo apt install -y -V libarrow-dev
+# Unset LD_LIBRARY_PATH to prevent loading mismatched system libarrow
+unset LD_LIBRARY_PATH
 ```
 
 ```{bash, save=run & !sys_install & macos}


### PR DESCRIPTION
### What changes are included in this PR?
The key change is adding unset LD_LIBRARY_PATH before the macOS troubleshooting section. This ensures that when R loads the package, it uses the libarrow built from the git checkout (which matches the R package build), not the released version from apt.

This approach:
Still tests the troubleshooting documentation as intended
Prevents the ABI mismatch by ensuring the R package uses the libarrow it was built against
Works during the release gap when git checkout and released versions differ

### Are these changes tested?
No


#49380 
