### PR TITLE
GH-49437: [Python][GPU] Fix numba-cuda interop after ctypes removal in numba-cuda 0.28

### DIFF
--- a/python/pyarrow/_cuda.pyx
+++ b/python/pyarrow/_cuda.pyx
@@ -81,7 +81,7 @@ cdef class Context(_Weakrefable):
             import numba.cuda
             context = numba.cuda.current_context()
         return Context(device_number=context.device.id,
-                       handle=context.handle.value)
+                       handle=int(context.handle))
 
     def to_numba(self):
         """

--- a/python/pyarrow/tests/test_cuda_numba_interop.py
+++ b/python/pyarrow/tests/test_cuda_numba_interop.py
@@ -50,8 +50,8 @@ def teardown_module(module):
                          ids=context_choice_ids)
 def test_context(c):
     ctx, nb_ctx = context_choices[c]
-    assert ctx.handle == nb_ctx.handle.value
-    assert ctx.handle == ctx.to_numba().handle.value
+    assert ctx.handle == int(nb_ctx.handle)
+    assert ctx.handle == int(ctx.to_numba().handle)
     ctx2 = cuda.Context.from_numba(nb_ctx)
     assert ctx.handle == ctx2.handle
     size = 10
@@ -203,7 +203,7 @@ def test_numba_context(c, dtype):
     with nb_cuda.gpus[0]:
         arr, cbuf = make_random_buffer(size, target='device',
                                        dtype=dtype, ctx=ctx)
-        assert cbuf.context.handle == nb_ctx.handle.value
+        assert cbuf.context.handle == int(nb_ctx.handle)
         mem = cbuf.to_numba()
         darr = DeviceNDArray(arr.shape, arr.strides, arr.dtype, gpu_data=mem)
         np.testing.assert_equal(darr.copy_to_host(), arr)


### PR DESCRIPTION
### Rationale for this change

Python cuda jobs are currently failing with `'cuda.bindings.driver.CUcontext' object has no attribute 'value'`

### What changes are included in this PR?

Cast to int instead of using `.value` accessor.
This is related to this PR:
- https://github.com/NVIDIA/numba-cuda/pull/784

### Are these changes tested?

Yes via archery

### Are there any user-facing changes?

No

* GitHub Issue: #49437