### PR TITLE
GH-49458: [CI][C++] Fix Meson build referencing non-existent fixed_shape_tensor_test.cc

### DIFF
--- a/cpp/src/arrow/extension/meson.build
+++ b/cpp/src/arrow/extension/meson.build
@@ -19,7 +19,7 @@ canonical_extension_tests = ['bool8_test.cc', 'json_test.cc', 'uuid_test.cc']
 
 if needs_json
     canonical_extension_tests += [
-        'fixed_shape_tensor_test.cc',
+        'tensor_extension_array_test.cc',
         'opaque_test.cc',
     ]
 endif


### PR DESCRIPTION
## Summary
- Fix `meson.build` in `cpp/src/arrow/extension/` referencing `fixed_shape_tensor_test.cc` which does not exist
- The test file was renamed to `tensor_extension_array_test.cc` but the Meson build was not updated to match `CMakeLists.txt`


🤖 Generated with [Claude Code](https://claude.com/claude-code)

* GitHub Issue: #49458