### PR TITLE
GH-49473: [Python] Fix get_include and get_library_dirs to work with both editable and non-editable builds

### DIFF
--- a/python/pyarrow/__init__.py
+++ b/python/pyarrow/__init__.py
@@ -305,7 +305,11 @@ def get_include():
     Return absolute path to directory containing Arrow C++ include
     headers. Similar to numpy.get_include
     """
-    return _os.path.join(_os.path.dirname(__file__), 'include')
+    # Use pyarrow.lib location instead of just __file__. That works
+    # for both editable and non-editable builds as it points
+    # to the actual location of the compiled C++ extension.
+    from pyarrow import lib as _lib
+    return _os.path.join(_os.path.dirname(_lib.__file__), 'include')
 
 
 def _get_pkg_config_executable():
@@ -388,7 +392,11 @@ def get_library_dirs():
     Return lists of directories likely to contain Arrow C++ libraries for
     linking C or Cython extensions using pyarrow
     """
-    package_cwd = _os.path.dirname(__file__)
+    # Use pyarrow.lib location instead of just __file__. That works
+    # for both editable and non-editable builds as it points
+    # to the actual location of the compiled C++ extension.
+    from pyarrow import lib as _lib
+    package_cwd = _os.path.dirname(_lib.__file__)
     library_dirs = [package_cwd]
 
     def append_library_dir(library_dir):


### PR DESCRIPTION
### Rationale for this change

With `scikit-build-core` our Cython tests fail to find PyArrow C++ headers due to get_include returning a non-existent directory.

### What changes are included in this PR?

Editable builds location of libraries and headers are located at ``

Previous to this change:
```
$ python -c "import pyarrow as pa; print(pa.get_include())"
/home/raulcd/code/arrow/python/pyarrow/include
$ ls /home/raulcd/code/arrow/python/pyarrow/include
ls: cannot access '/home/raulcd/code/arrow/python/pyarrow/include': No such file or directory
```
with this change:
```
$ python -c "import pyarrow as pa; print(pa.get_include())"
/home/raulcd/code/pyarrow-dev/lib/python3.13/site-packages/pyarrow/include
$ ls /home/raulcd/code/pyarrow-dev/lib/python3.13/site-packages/pyarrow/include
arrow
```
### Are these changes tested?

Yes, locally for editable installs and on CI for non-editable.

### Are there any user-facing changes?

The only change is that headers, generated Cython cpp files and built shared libraries are installed on the virtualenv.

* GitHub Issue: #49473