### PR TITLE
GH-49477: [C++][Parquet] Fix multiplication overflow in PLAIN BYTE_ARRAY decoder

### DIFF
--- a/ci/scripts/cpp_test.sh
+++ b/ci/scripts/cpp_test.sh
@@ -222,7 +222,7 @@ if [ "${ARROW_FUZZING}" == "ON" ]; then
     "${binary_output_dir}/arrow-ipc-tensor-stream-fuzz" arrow-ipc-tensor-stream/*-testcase-*
     if [ "${ARROW_PARQUET}" == "ON" ]; then
       "${binary_output_dir}/parquet-arrow-fuzz" parquet/fuzzing/*-testcase-*
-      # TODO replay encoding regression files when we have some
+      "${binary_output_dir}/parquet-encoding-fuzz" parquet/encoding-fuzzing/*-testcase-*
     fi
     "${binary_output_dir}/arrow-csv-fuzz" csv/fuzzing/*-testcase-*
     popd

--- a/cpp/src/parquet/decoder.cc
+++ b/cpp/src/parquet/decoder.cc
@@ -759,7 +759,8 @@ class PlainByteArrayDecoder : public PlainDecoder<ByteArrayType> {
     // We're going to decode `num_values - null_count` PLAIN values,
     // and each value has a 4-byte length header that doesn't count for the
     // Arrow binary data length.
-    int64_t estimated_data_length = len_ - 4 * (num_values - null_count);
+    int64_t estimated_data_length =
+        len_ - 4 * static_cast<int64_t>(num_values - null_count);
     if (ARROW_PREDICT_FALSE(estimated_data_length < 0)) {
       return Status::Invalid("Invalid or truncated PLAIN-encoded BYTE_ARRAY data");
     }


### PR DESCRIPTION
### Rationale for this change

Issue found by OSS-Fuzz: https://issues.oss-fuzz.com/issues/489948953

### Are these changes tested?

By added regression file.

### Are there any user-facing changes?

No.

**This PR contains a "Critical Fix".** Signed integer overflow is undefined behavior, so this could result in any kind of misbehavior.
* GitHub Issue: #49477