### PR TITLE
GH-49486: [CI][C++] Fix Meson build missing tensor extension sources

### DIFF
--- a/cpp/src/arrow/extension/meson.build
+++ b/cpp/src/arrow/extension/meson.build
@@ -39,5 +39,6 @@ install_headers(
         'opaque.h',
         'parquet_variant.h',
         'uuid.h',
+        'variable_shape_tensor.h',
     ],
 )

--- a/cpp/src/arrow/meson.build
+++ b/cpp/src/arrow/meson.build
@@ -507,6 +507,8 @@ if needs_json
             'sources': [
                 'extension/fixed_shape_tensor.cc',
                 'extension/opaque.cc',
+                'extension/tensor_internal.cc',
+                'extension/variable_shape_tensor.cc',
                 'json/options.cc',
                 'json/chunked_builder.cc',
                 'json/chunker.cc',


### PR DESCRIPTION
## Summary
- Add `extension/tensor_internal.cc` and `extension/variable_shape_tensor.cc` to the `arrow_json` sources in `meson.build`
- Add `variable_shape_tensor.h` to installed headers in `extension/meson.build`
- These files were present in `CMakeLists.txt` but missing from the Meson build, causing undefined reference linker errors for `variable_shape_tensor()`, `IsPermutationTrivial()`, `IsPermutationValid()`, `ComputeStrides()`, and `SliceTensorBuffer()`

## Test plan
- [ ] Verify the Meson CI build passes without linker errors

* GitHub Issue: #49486

🤖 Generated with [Claude Code](https://claude.com/claude-code)