### PR TITLE
GH-49526: [CI] Update Maven version from 3.8.7 to 3.9.9

### DIFF
--- a/.env
+++ b/.env
@@ -66,7 +66,7 @@ HDFS=3.2.1
 JDK=11
 # LLVM 12 and GCC 11 reports -Wmismatched-new-delete.
 LLVM=18
-MAVEN=3.8.7
+MAVEN=3.9.9
 NODE=20
 NUMBA=latest
 NUMBA_CUDA=latest

--- a/ci/docker/conda-integration.dockerfile
+++ b/ci/docker/conda-integration.dockerfile
@@ -22,7 +22,7 @@ FROM ${repo}:${arch}-conda-cpp
 ARG arch=amd64
 # We need to synchronize the following values with the values in .env
 # and services.conda-integration in compose.yaml.
-ARG maven=3.8.7
+ARG maven=3.9.9
 ARG node=20
 ARG yarn=1.22
 ARG jdk=17

--- a/ci/docker/conda-python-hdfs.dockerfile
+++ b/ci/docker/conda-python-hdfs.dockerfile
@@ -21,7 +21,7 @@ ARG python=3.10
 FROM ${repo}:${arch}-conda-python-${python}
 
 ARG jdk=11
-ARG maven=3.8.7
+ARG maven=3.9.9
 RUN mamba install -q -y \
         maven=${maven} \
         openjdk=${jdk} \

--- a/ci/docker/conda-python-jpype.dockerfile
+++ b/ci/docker/conda-python-jpype.dockerfile
@@ -21,7 +21,7 @@ ARG python=3.10
 FROM ${repo}:${arch}-conda-python-${python}
 
 ARG jdk=11
-ARG maven=3.8.7
+ARG maven=3.9.9
 RUN mamba install -q -y \
         maven=${maven} \
         openjdk=${jdk} \

--- a/ci/docker/conda-python-spark.dockerfile
+++ b/ci/docker/conda-python-spark.dockerfile
@@ -21,7 +21,7 @@ ARG python=3.10
 FROM ${repo}:${arch}-conda-python-${python}
 
 ARG jdk=11
-ARG maven=3.8.7
+ARG maven=3.9.9
 
 ARG numpy=latest
 COPY ci/scripts/install_numpy.sh /arrow/ci/scripts/


### PR DESCRIPTION
### Rationale for this change

This is related to https://github.com/apache/arrow-java/pull/1030. Upgrading to Apache POM 37 on Arrow Java requires Maven 3.9.x as some Maven plugins require this API version.

### What changes are included in this PR?

Bumps Maven from 3.8.7 to 3.9.9 in `.env` and all CI Dockerfiles that reference the Maven version:
- `.env`
- `ci/docker/conda-integration.dockerfile`
- `ci/docker/conda-python-hdfs.dockerfile`
- `ci/docker/conda-python-jpype.dockerfile`
- `ci/docker/conda-python-spark.dockerfile`

### Are these changes tested?

Crossbow CI jobs were submitted for the affected configurations (HDFS, Spark).

### Are there any user-facing changes?

No.
* GitHub Issue: #49526