### PR TITLE
GH-46600: [C++][CI] Add job with ARROW_LARGE_MEMORY_TESTS enabled

### DIFF
--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -110,7 +110,7 @@ jobs:
           - image: ubuntu-cpp
             run-options: >-
               -e ARROW_LARGE_MEMORY_TESTS=ON
-            runs-on: "runs-on=${{ github.run_id }}/family=x8i.xlarge/spot=capacity-optimized"
+            runs-on: "runs-on=${{ github.run_id }}/family=x8i.xlarge"
             title: AMD64 Ubuntu Large Memory Tests
           - image: conda-cpp
             run-options: >-

--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -109,7 +109,7 @@ jobs:
             title: AMD64 Alpine Linux
           - image: ubuntu-cpp
             run-options: >-
-              -e ARROW_CTEST_TIMEOUT=900
+              -e ARROW_CTEST_TIMEOUT=2400
               -e ARROW_C_FLAGS_DEBUG="-O1"
               -e ARROW_CXX_FLAGS_DEBUG="-O1"
               -e ARROW_LARGE_MEMORY_TESTS=ON

--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -107,6 +107,11 @@ jobs:
           - image: alpine-linux-cpp
             runs-on: ubuntu-latest
             title: AMD64 Alpine Linux
+          - image: ubuntu-cpp
+            run-options: >-
+              -e ARROW_LARGE_MEMORY_TESTS=ON
+            runs-on: "runs-on=${{ github.run_id }}/family=x8i.xlarge/spot=capacity-optimized"
+            title: AMD64 Ubuntu Large Memory Tests
           - image: conda-cpp
             run-options: >-
               -e ARROW_USE_MESON=ON

--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -109,7 +109,9 @@ jobs:
             title: AMD64 Alpine Linux
           - image: ubuntu-cpp
             run-options: >-
-              -e ARROW_BUILD_TYPE=Release -e ARROW_CTEST_TIMEOUT=900 -e ARROW_LARGE_MEMORY_TESTS=ON
+              -e ARROW_BUILD_TYPE=Release
+              -e ARROW_CTEST_TIMEOUT=900
+              -e ARROW_LARGE_MEMORY_TESTS=ON
             runs-on: "runs-on=${{ github.run_id }}/family=x8i.2xlarge/spot=capacity-optimized"
             title: AMD64 Ubuntu Large Memory Tests
           - image: conda-cpp

--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -110,7 +110,7 @@ jobs:
           - image: ubuntu-cpp
             run-options: >-
               -e ARROW_LARGE_MEMORY_TESTS=ON
-            runs-on: "runs-on=${{ github.run_id }}/family=x8i.xlarge/spot=false"
+            runs-on: "runs-on=${{ github.run_id }}/family=x8i.2xlarge/spot=capacity-optimized"
             title: AMD64 Ubuntu Large Memory Tests
           - image: conda-cpp
             run-options: >-

--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -109,6 +109,8 @@ jobs:
             title: AMD64 Alpine Linux
           - image: ubuntu-cpp
             run-options: >-
+              -e ARROW_BUILD_TYPE=Release \
+              -e ARROW_CTEST_TIMEOUT=900 \
               -e ARROW_LARGE_MEMORY_TESTS=ON
             runs-on: "runs-on=${{ github.run_id }}/family=x8i.2xlarge/spot=capacity-optimized"
             title: AMD64 Ubuntu Large Memory Tests

--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -114,7 +114,7 @@ jobs:
               -e ARROW_CXX_FLAGS_DEBUG="-O1"
               -e ARROW_LARGE_MEMORY_TESTS=ON
               -e BUILD_WARNING_LEVEL=PRODUCTION
-            runs-on: "runs-on=${{ github.run_id }}/family=x8i.2xlarge/spot=capacity-optimized"
+            runs-on: "runs-on=${{ github.run_id }}/family=x8i.2xlarge/volume=80gb/spot=capacity-optimized"
             title: AMD64 Ubuntu Large Memory Tests
           - image: conda-cpp
             run-options: >-

--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -110,7 +110,7 @@ jobs:
           - image: ubuntu-cpp
             run-options: >-
               -e ARROW_LARGE_MEMORY_TESTS=ON
-            runs-on: "runs-on=${{ github.run_id }}/family=x8i.xlarge"
+            runs-on: "runs-on=${{ github.run_id }}/family=x8i.xlarge/spot=false"
             title: AMD64 Ubuntu Large Memory Tests
           - image: conda-cpp
             run-options: >-

--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -108,12 +108,12 @@ jobs:
             runs-on: ubuntu-latest
             title: AMD64 Alpine Linux
           - image: ubuntu-cpp
-            # Use Release to speed up large memory tests that take a long time and
-            # increase timeout because some tests take more than 20 minutes.
             run-options: >-
-              -e ARROW_BUILD_TYPE=Release
-              -e ARROW_CTEST_TIMEOUT=2400
+              -e ARROW_CTEST_TIMEOUT=900
+              -e ARROW_C_FLAGS_DEBUG="-O1"
+              -e ARROW_CXX_FLAGS_DEBUG="-O1"
               -e ARROW_LARGE_MEMORY_TESTS=ON
+              -e BUILD_WARNING_LEVEL=PRODUCTION
             runs-on: "runs-on=${{ github.run_id }}/family=x8i.2xlarge/spot=capacity-optimized"
             title: AMD64 Ubuntu Large Memory Tests
           - image: conda-cpp

--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -110,7 +110,7 @@ jobs:
           - image: ubuntu-cpp
             run-options: >-
               -e ARROW_BUILD_TYPE=Release
-              -e ARROW_CTEST_TIMEOUT=900
+              -e ARROW_CTEST_TIMEOUT=1200
               -e ARROW_LARGE_MEMORY_TESTS=ON
             runs-on: "runs-on=${{ github.run_id }}/family=x8i.2xlarge/spot=capacity-optimized"
             title: AMD64 Ubuntu Large Memory Tests

--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -109,7 +109,7 @@ jobs:
             title: AMD64 Alpine Linux
           - image: ubuntu-cpp
             run-options: >-
-              -e ARROW_CTEST_TIMEOUT=1800
+              -e ARROW_CTEST_TIMEOUT=2000
               -e ARROW_C_FLAGS_DEBUG="-O1"
               -e ARROW_CXX_FLAGS_DEBUG="-O1"
               -e ARROW_GANDIVA=OFF

--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -108,9 +108,11 @@ jobs:
             runs-on: ubuntu-latest
             title: AMD64 Alpine Linux
           - image: ubuntu-cpp
+            # Use Release to speed up large memory tests that take a long time and
+            # increase timeout because some tests take more than 20 minutes.
             run-options: >-
               -e ARROW_BUILD_TYPE=Release
-              -e ARROW_CTEST_TIMEOUT=1200
+              -e ARROW_CTEST_TIMEOUT=2400
               -e ARROW_LARGE_MEMORY_TESTS=ON
             runs-on: "runs-on=${{ github.run_id }}/family=x8i.2xlarge/spot=capacity-optimized"
             title: AMD64 Ubuntu Large Memory Tests

--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -109,9 +109,7 @@ jobs:
             title: AMD64 Alpine Linux
           - image: ubuntu-cpp
             run-options: >-
-              -e ARROW_BUILD_TYPE=Release \
-              -e ARROW_CTEST_TIMEOUT=900 \
-              -e ARROW_LARGE_MEMORY_TESTS=ON
+              -e ARROW_BUILD_TYPE=Release -e ARROW_CTEST_TIMEOUT=900 -e ARROW_LARGE_MEMORY_TESTS=ON
             runs-on: "runs-on=${{ github.run_id }}/family=x8i.2xlarge/spot=capacity-optimized"
             title: AMD64 Ubuntu Large Memory Tests
           - image: conda-cpp

--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -109,9 +109,10 @@ jobs:
             title: AMD64 Alpine Linux
           - image: ubuntu-cpp
             run-options: >-
-              -e ARROW_CTEST_TIMEOUT=2400
+              -e ARROW_CTEST_TIMEOUT=1800
               -e ARROW_C_FLAGS_DEBUG="-O1"
               -e ARROW_CXX_FLAGS_DEBUG="-O1"
+              -e ARROW_GANDIVA=OFF
               -e ARROW_LARGE_MEMORY_TESTS=ON
               -e BUILD_WARNING_LEVEL=PRODUCTION
             runs-on: "runs-on=${{ github.run_id }}/family=x8i.2xlarge/volume=80gb/spot=capacity-optimized"

--- a/cpp/src/parquet/column_writer_test.cc
+++ b/cpp/src/parquet/column_writer_test.cc
@@ -1053,8 +1053,10 @@ TEST(TestColumnWriter, LARGE_MEMORY_TEST(WriteLargeDictEncodedPage)) {
                       {
                           PrimitiveNode::Make("item", Repetition::REQUIRED, Type::INT32),
                       }));
-  auto properties =
-      WriterProperties::Builder().data_pagesize(1024 * 1024 * 1024)->build();
+  auto properties = WriterProperties::Builder()
+                        .data_pagesize(1024 * 1024 * 1024)
+                        ->max_rows_per_page(std::numeric_limits<int64_t>::max())
+                        ->build();
   auto file_writer = ParquetFileWriter::Open(sink, schema, properties);
   auto rg_writer = file_writer->AppendRowGroup();
 
@@ -1124,8 +1126,10 @@ TEST(TestColumnWriter, LARGE_MEMORY_TEST(ThrowsOnDictIndicesTooLarge)) {
                       {
                           PrimitiveNode::Make("item", Repetition::REQUIRED, Type::INT32),
                       }));
-  auto properties =
-      WriterProperties::Builder().data_pagesize(4 * 1024LL * 1024 * 1024)->build();
+  auto properties = WriterProperties::Builder()
+                        .data_pagesize(4 * 1024LL * 1024 * 1024)
+                        ->max_rows_per_page(std::numeric_limits<int64_t>::max())
+                        ->build();
   auto file_writer = ParquetFileWriter::Open(sink, schema, properties);
   auto rg_writer = file_writer->AppendRowGroup();
 


### PR DESCRIPTION
### Rationale for this change

Now that we have self-hosted runners with AWS we should test the `ARROW_LARGE_MEMORY_TESTS` on CI.

### What changes are included in this PR?

Added new runner for ARROW_LARGE_MEMORY_TESTS.
Fix `parquet-writer-test` to generate huge expected page using huge `max_rows_per_page` instead of default.

### Are these changes tested?

Yes via CI

### Are there any user-facing changes?

No

* GitHub Issue: #46600