### PR TITLE
GH-49493: [C++][Python] Add OpenTelemetry to our CMakePresets when bulding python-maximal

### DIFF
--- a/cpp/CMakePresets.json
+++ b/cpp/CMakePresets.json
@@ -132,6 +132,14 @@
       }
     },
     {
+      "name": "features-opentelemetry",
+      "inherits": "features-basic",
+      "hidden": true,
+      "cacheVariables": {
+        "ARROW_WITH_OPENTELEMETRY": "ON"
+      }
+    },
+    {
       "name": "features-python-minimal",
       "inherits": [
         "features-minimal"
@@ -162,6 +170,7 @@
         "features-filesystems",
         "features-flight-sql",
         "features-gandiva",
+        "features-opentelemetry",
         "features-python"
       ],
       "hidden": true,


### PR DESCRIPTION
### Rationale for this change

OpenTelemetry can be enabled when building Python. It is currently missing from the `CMakePresets.json`

### What changes are included in this PR?

Add a `features-opentelemetry` which is added as part of `features-python-maximal`. This one is used for `ninja-debug-maximal` or other maximal features.

### Are these changes tested?

I tested locally with `ninja-debug-maximal` and validated that OpenTelemetry was enabled. I don't think we test our presets on CI (at least I haven't been able to find any `--preset ` presence)

### Are there any user-facing changes?

If a user is building using presets, now OpenTelemetry will be built, as expected.

* GitHub Issue: #49493