### PR TITLE
GH-49495: [C++][CI] Resolve ubuntu clang failure with parquet fuzzing

### DIFF
--- a/cpp/src/parquet/arrow/fuzz_encoding_internal.cc
+++ b/cpp/src/parquet/arrow/fuzz_encoding_internal.cc
@@ -161,7 +161,7 @@ struct TypedFuzzEncoding {
       std::conditional_t<kType == Type::BOOLEAN, BooleanSlot, typename DType::c_type>;
   using EncoderType = typename EncodingTraits<DType>::Encoder;
   using DecoderType = typename EncodingTraits<DType>::Decoder;
-  using Accumulator = EncodingTraits<DType>::Accumulator;
+  using Accumulator = typename EncodingTraits<DType>::Accumulator;
 
   TypedFuzzEncoding(Encoding::type source_encoding, Encoding::type roundtrip_encoding,
                     const ColumnDescriptor* descr, int num_values,


### PR DESCRIPTION
### Rationale for this change

Fix CRAN's clang setup failing

### What changes are included in this PR?

Added `typename`

### Are these changes tested?

Yes

### Are there any user-facing changes?

No
* GitHub Issue: #49495