### PR TITLE
GH-49497: [FlightRPC] Add is_update field to ActionCreatePreparedStatementResult

### DIFF
--- a/format/FlightSql.proto
+++ b/format/FlightSql.proto
@@ -1550,6 +1550,11 @@ message ActionCreatePreparedStatementResult {
   // If the query provided contained parameters, parameter_schema contains the
   // schema of the expected parameters.  It should be an IPC-encapsulated Schema, as described in Schema.fbs.
   bytes parameter_schema = 3;
+
+  // When set to true, the query should be executed with CommandPreparedStatementUpdate,
+  // when set to false, the query should be executed with CommandPreparedStatementQuery.
+  // If not set, the client can choose how to execute the query.
+  optional bool is_update = 4;
 }
 
 /*


### PR DESCRIPTION
### Rationale for this change
Multiple database driver APIs have functions that allow for executing prepared statements that can be either result set generating queries or update commands. Before this PR, there was no way for servers to indicate whether the query should be executed with `CommandPreparedStatementUpdate` or `CommandPreparedStatementQuery`.

### What changes are included in this PR?
The change in this PR introduces a new field set by the server after creation of the prepared statement to indicate the proper network flow. 

### Are these changes tested?
No, because these changes are best tested using a database driver but this PR includes only changes to the proto definition.

### Are there any user-facing changes?
No.

* GitHub Issue: #49497