### PR TITLE
GH-49506: [CI][Python] Doctest fails when pyarrow._cuda absent

### DIFF
--- a/python/pyarrow/conftest.py
+++ b/python/pyarrow/conftest.py
@@ -246,8 +246,7 @@ def pytest_ignore_collect(collection_path, config):
                 return True
 
         if 'pyarrow/cuda' in str(collection_path):
-            if not _cuda_is_available():
-                return True
+            return not _cuda_is_available()
 
         if 'pyarrow/fs' in str(collection_path):
             try:

--- a/python/pyarrow/conftest.py
+++ b/python/pyarrow/conftest.py
@@ -215,6 +215,13 @@ except ImportError:
 
 # Doctest should ignore files for the modules that are not built
 def pytest_ignore_collect(collection_path, config):
+    def _cuda_is_available():
+        try:
+            import pyarrow.cuda  # noqa
+            return True
+        except ImportError:
+            return False
+
     if config.option.doctestmodules:
         # don't try to run doctests on the /tests directory
         if "/pyarrow/tests/" in str(collection_path):
@@ -239,10 +246,7 @@ def pytest_ignore_collect(collection_path, config):
                 return True
 
         if 'pyarrow/cuda' in str(collection_path):
-            try:
-                import pyarrow.cuda  # noqa
-                return False
-            except ImportError:
+            if not _cuda_is_available():
                 return True
 
         if 'pyarrow/fs' in str(collection_path):
@@ -257,6 +261,9 @@ def pytest_ignore_collect(collection_path, config):
             return True
         if "/pyarrow/_parquet_encryption" in str(collection_path):
             return True
+        if "/pyarrow/_cuda" in str(collection_path):
+            if not _cuda_is_available():
+                return True
 
     return False
 

--- a/python/pyarrow/conftest.py
+++ b/python/pyarrow/conftest.py
@@ -261,8 +261,7 @@ def pytest_ignore_collect(collection_path, config):
         if "/pyarrow/_parquet_encryption" in str(collection_path):
             return True
         if "/pyarrow/_cuda" in str(collection_path):
-            if not _cuda_is_available():
-                return True
+            return not _cuda_is_available()
 
     return False
 


### PR DESCRIPTION
### Rationale for this change

See https://github.com/apache/arrow/issues/49506.

### What changes are included in this PR?

We skip cuda docstests in CI, since we don't build for CUDA.

### Are these changes tested?

We currently see failing CI. That should go away.

### Are there any user-facing changes?

Only to CI users.
* GitHub Issue: #49506