### PR TITLE
GH-49502: [Parquet][C++] Fix missing overflow check for dictionary encoder indices count

### DIFF
--- a/cpp/src/parquet/encoder.cc
+++ b/cpp/src/parquet/encoder.cc
@@ -541,6 +541,12 @@ class DictEncoderImpl : public EncoderImpl, virtual public DictEncoder<DType> {
     size_t buffer_position = buffered_indices_.size();
     buffered_indices_.resize(buffer_position +
                              static_cast<size_t>(data.length() - data.null_count()));
+    if (buffered_indices_.size() >
+        static_cast<size_t>(std::numeric_limits<int32_t>::max())) {
+      throw ParquetException("Total dictionary indices count (",
+                             buffered_indices_.size(),
+                             ") exceeds maximum int value");
+    }
     ::arrow::internal::VisitSetBitRunsVoid(
         data.null_bitmap_data(), data.offset(), data.length(),
         [&](int64_t position, int64_t length) {


### PR DESCRIPTION
Closes #49502
Rationale for this change

When writing large dictionary-encoded Parquet data with 
`ARROW_LARGE_MEMORY_TESTS=ON`, two tests were failing:

- `TestColumnWriter.WriteLargeDictEncodedPage` — expected 2 pages, got 7501
- `TestColumnWriter.ThrowsOnDictIndicesTooLarge` — expected ParquetException, 
  got nothing thrown

The root cause is that `PutIndicesTyped()` in `DictEncoderImpl` had no check 
for when the total number of buffered dictionary indices exceeds `INT32_MAX`. 
The existing overflow check in `FlushValues()` only checks the buffer size in 
bytes, not the index count, so it never triggered for this case.

What changes are included in this PR?

Added an overflow check in `DictEncoderImpl::PutIndicesTyped()` immediately 
after `buffered_indices_.resize()`:

if (buffered_indices_.size() >
    static_cast<size_t>(std::numeric_limits<int32_t>::max())) {
  throw ParquetException("Total dictionary indices count (",
                         buffered_indices_.size(),
                         ") exceeds maximum int value");
}

This makes the encoder throw a `ParquetException` with a message containing 
"exceeds maximum int value" when the index count overflows, which is exactly 
what `ThrowsOnDictIndicesTooLarge` expects.

### Are these changes tested?

Yes — the existing tests in `column_writer_test.cc` cover this fix:
- `TestColumnWriter.ThrowsOnDictIndicesTooLarge`
- `TestColumnWriter.WriteLargeDictEncodedPage`

Both tests were failing before this fix and should pass after.
Tests require building with `ARROW_LARGE_MEMORY_TESTS=ON`.


This PR contains a "Critical Fix"— previously, writing dictionary-encoded 
data with more than INT32_MAX indices would silently produce incorrect output 
(wrong page count) instead of raising an error. This fix makes the encoder 
correctly throw a `ParquetException` in that scenario.
* GitHub Issue: #49502