### PR TITLE
GH-49503: [Docs][Python] Documenting .pxi doctests are tested via lib.pyx

### DIFF
--- a/docs/source/developers/python/development.rst
+++ b/docs/source/developers/python/development.rst
@@ -201,7 +201,7 @@ install the `pytest-cython <https://github.com/lgpage/pytest-cython>`_ plugin.
    In PyArrow, all ``.pxi`` files are included into ``lib.pyx``, so run
    doctests on that file::
 
-      $ python -m pytest --doctest-cython pyarrow/lib.pyx
+      $ python -m pytest --doctest-cython path/to/lib.pyx
 
    Any doctest errors originating from ``.pxi`` files will appear under
    ``lib.pyx``, not the original ``.pxi`` filename.

--- a/docs/source/developers/python/development.rst
+++ b/docs/source/developers/python/development.rst
@@ -198,13 +198,13 @@ install the `pytest-cython <https://github.com/lgpage/pytest-cython>`_ plugin.
 .. note::
    Cython ``.pxi`` files are included in ``.pyx`` files at compile time,
    so ``--doctest-cython`` cannot be run directly on ``.pxi`` files.
-   Instead, run doctests on the ``.pyx`` file they are included in, for
-   example ``lib.pyx``::
+   In PyArrow, all ``.pxi`` files are included into ``lib.pyx``, so run
+   doctests on that file::
 
       $ python -m pytest --doctest-cython pyarrow/lib.pyx
 
    Any doctest errors originating from ``.pxi`` files will appear under
-   the corresponding ``.pyx`` file, not the original ``.pxi`` filename.
+   ``lib.pyx``, not the original ``.pxi`` filename.
 
 Testing Documentation Examples
 -------------------------------

--- a/docs/source/developers/python/development.rst
+++ b/docs/source/developers/python/development.rst
@@ -195,6 +195,17 @@ for ``.py`` files or
 for ``.pyx`` and ``.pxi`` files. In this case you will also need to
 install the `pytest-cython <https://github.com/lgpage/pytest-cython>`_ plugin.
 
+.. note::
+   Cython ``.pxi`` files are included in ``.pyx`` files at compile time,
+   so ``--doctest-cython`` cannot be run directly on ``.pxi`` files.
+   Instead, run doctests on the ``.pyx`` file they are included in, for
+   example ``lib.pyx``::
+
+      $ python -m pytest --doctest-cython pyarrow/lib.pyx
+
+   Any doctest errors originating from ``.pxi`` files will appear under
+   the corresponding ``.pyx`` file, not the original ``.pxi`` filename.
+
 Testing Documentation Examples
 -------------------------------
 


### PR DESCRIPTION
### Rationale for this change

Running `python -m pytest --doctest-cython` directly on `.pxi` files doesn't work because Cython `.pxi` files are included in `.pyx` files at compile time. This isn't documented, which could _potentially_ confuse contributors.

Please see discussion in #49279 (comment) by @AlenkaF for additional context.

### What changes are included in this PR?

Added a `note` to the Doctest section of the Developing PyArrow documentation explaining that:
- `.pxi` files cannot be tested directly with `--doctest-cython`
- Doctests should be run on the `.pyx` file they are included in (e.g., `lib.pyx`)
- Errors will appear under the `.pyx` file, not the original `.pxi` filename

### Are these changes tested?

Documentation-only change. No code changes.

### Are there any user-facing changes?

No.

* GitHub Issue: #49503