### PR TITLE
GH-49503: [Docs][Python] Document .pxi doctests

### DIFF
--- a/docs/source/developers/python/development.rst
+++ b/docs/source/developers/python/development.rst
@@ -195,6 +195,16 @@ for ``.py`` files or
 for ``.pyx`` and ``.pxi`` files. In this case you will also need to
 install the `pytest-cython <https://github.com/lgpage/pytest-cython>`_ plugin.
 
+.. note::
+
+   When running doctests for ``.pxi`` files, they are actually tested via
+   ``lib.pyx``. Use the following command pattern::
+
+      $ python -m pytest --doctest-cython path/to/lib.pyx
+
+   Any doctest errors in ``.pxi`` files will surface under ``lib.pyx`` in
+   the test output, not under the original ``.pxi`` filename.
+
 Testing Documentation Examples
 -------------------------------
 


### PR DESCRIPTION
## Description

This PR adds documentation explaining how to test doctests in `.pxi` files.

The documentation now clarifies that:
- `.pxi` file doctests are actually tested via `lib.pyx`
- The command pattern is: `python -m pytest --doctest-cython path/to/lib.pyx`
- Any doctest errors in `.pxi` files will surface under `lib.pyx` in the test output, not under the original `.pxi` filename

## Related Issue

Closes apache/arrow#49503

## Changes

- Added a `.. note::` block in `docs/source/developers/python/development.rst` under the Doctest section
* GitHub Issue: #49503