### PR TITLE
GH-49518: [CI] Do not override HOME to empty on build_conda.sh for minimal_build

### DIFF
--- a/python/examples/minimal_build/build_conda.sh
+++ b/python/examples/minimal_build/build_conda.sh
@@ -21,10 +21,10 @@ set -e
 #----------------------------------------------------------------------
 # Change this to whatever makes sense for your system
 
-HOME=
-MINICONDA=$HOME/miniconda-for-arrow
-LIBRARY_INSTALL_DIR=$HOME/local-libs
-CPP_BUILD_DIR=$HOME/arrow-cpp-build
+WORKDIR=${WORKDIR:-$HOME}
+MINICONDA=$WORKDIR/miniconda-for-arrow
+LIBRARY_INSTALL_DIR=$WORKDIR/local-libs
+CPP_BUILD_DIR=$WORKDIR/arrow-cpp-build
 ARROW_ROOT=/arrow
 PYTHON=3.10
 


### PR DESCRIPTION
### Rationale for this change

The CI job is currently failing

### What changes are included in this PR?

Do not set HOME to empty on `build_conda.sh` otherwise ccache fails creating cache folders. Just use default HOME and use WORKDIR

### Are these changes tested?

Yes via the failing job on archery.

### Are there any user-facing changes?

No

* GitHub Issue: #49518