### PR TITLE
GH-49503: [Docs][Python] Document that .pxi doctests are tested via lib.pyx

### DIFF
--- a/docs/source/developers/python/development.rst
+++ b/docs/source/developers/python/development.rst
@@ -195,6 +195,19 @@ for ``.py`` files or
 for ``.pyx`` and ``.pxi`` files. In this case you will also need to
 install the `pytest-cython <https://github.com/lgpage/pytest-cython>`_ plugin.
 
+Note that ``.pxi`` files are included in ``lib.pyx`` at compile time, so you
+cannot run doctests on them directly. Instead, run doctests on ``lib.pyx``
+where the ``.pxi`` code is compiled into:
+
+.. code-block::
+
+   $ pushd arrow/python
+   $ python -m pytest --doctest-cython pyarrow/lib.pyx
+   $ popd
+
+Any doctest failures in ``.pxi`` files will be reported under ``lib.pyx``
+rather than the original ``.pxi`` filename.
+
 Testing Documentation Examples
 -------------------------------
 


### PR DESCRIPTION
### Rationale for this change

The documentation did not explain how to run doctests on Cython .pxi files. Running pytest --doctest-cython directly on .pxi files does not work because these files are included in lib.pyx at compile time.

### What changes are included in this PR?

Added documentation explaining:
- That .pxi files cannot be tested directly and must be tested via lib.pyx
- The correct command to run doctests on .pxi files: python -m pytest --doctest-cython pyarrow/lib.pyx
- That doctest failures in .pxi files will be reported under lib.pyx, not the original .pxi filename

### Are these changes tested?

Documentation change only - verified the RST syntax is valid.

### Are there any user-facing changes?

Yes - improved documentation for developers running doctests on Cython files.

---

**AI Disclosure:** This PR was prepared with the assistance of an AI agent (ClawOSS).
* GitHub Issue: #49503