### PR TITLE
GH-49521: [CI][Packaging] Try removing KEY that seems bad from downloaded KEYS file

### DIFF
--- a/dev/tasks/linux-packages/apache-arrow-release/Rakefile
+++ b/dev/tasks/linux-packages/apache-arrow-release/Rakefile
@@ -50,8 +50,8 @@ class ApacheArrowReleasePackageTask < PackageTask
           # "rpmkeys --import" reports error for these keys.
           # It seems that a subkey of this key may be related. (Is SHA1 bad?)
           "8CAAD602",
-          # Another SHA1 that seems bad: https://github.com/apache/arrow/issues/49521
-          "C8282E76",
+          # Another KEY that seems bad: https://github.com/apache/arrow/issues/49521
+          "1AA8CF92D409A73393D0B736BFF2EE42C8282E76",
           # https://github.com/apache/arrow/issues/15007
           # It seems that a subkey of this key may be related.
           "B90EB64A3AF15545EC8A7B8803F0D5EA3790810C",

--- a/dev/tasks/linux-packages/apache-arrow-release/Rakefile
+++ b/dev/tasks/linux-packages/apache-arrow-release/Rakefile
@@ -50,6 +50,8 @@ class ApacheArrowReleasePackageTask < PackageTask
           # "rpmkeys --import" reports error for these keys.
           # It seems that a subkey of this key may be related. (Is SHA1 bad?)
           "8CAAD602",
+          # Another SHA1 that seems bad: https://github.com/apache/arrow/issues/49521
+          "C8282E76",
           # https://github.com/apache/arrow/issues/15007
           # It seems that a subkey of this key may be related.
           "B90EB64A3AF15545EC8A7B8803F0D5EA3790810C",


### PR DESCRIPTION
### Rationale for this change

Some CI jobs fail validating a newly added GPG key.

### What changes are included in this PR?

Remove this key from the processed ones on the packaging jobs as we do with others similar.

### Are these changes tested?

Yes on CI

### Are there any user-facing changes?

No

* GitHub Issue: #49521