### PR TITLE
GH-48467: [C++][Parquet] Add BufferedStats API to RowGroupWriter

### DIFF
--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -1489,6 +1489,10 @@ class TypedColumnWriterImpl : public ColumnWriterImpl,
     return current_encoder_->EstimatedDataEncodedSize();
   }
 
+  int64_t EstimatedBufferedLevelsBytes() const override {
+    return definition_levels_sink_.length() + repetition_levels_sink_.length();
+  }
+
  protected:
   std::shared_ptr<Buffer> GetValuesBuffer() override {
     return current_encoder_->FlushValues();

--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -1489,8 +1489,19 @@ class TypedColumnWriterImpl : public ColumnWriterImpl,
     return current_encoder_->EstimatedDataEncodedSize();
   }
 
-  int64_t EstimatedBufferedLevelsBytes() const override {
-    return definition_levels_sink_.length() + repetition_levels_sink_.length();
+  int64_t estimated_buffered_def_level_bytes() const override {
+    return definition_levels_sink_.length();
+  }
+
+  int64_t estimated_buffered_rep_level_bytes() const override {
+    return repetition_levels_sink_.length();
+  }
+
+  int64_t estimated_buffered_dict_bytes() const override {
+    if (current_dict_encoder_) {
+      return current_dict_encoder_->dict_encoded_size();
+    }
+    return 0;
   }
 
  protected:

--- a/cpp/src/parquet/column_writer.h
+++ b/cpp/src/parquet/column_writer.h
@@ -165,6 +165,9 @@ class PARQUET_EXPORT ColumnWriter {
   /// \brief Estimated size of the values that are not written to a page yet.
   virtual int64_t estimated_buffered_value_bytes() const = 0;
 
+  /// \brief Estimated size of the levels that are not written to a page yet.
+  virtual int64_t EstimatedBufferedLevelsBytes() const = 0;
+
   /// \brief The file-level writer properties
   virtual const WriterProperties* properties() = 0;
 

--- a/cpp/src/parquet/column_writer.h
+++ b/cpp/src/parquet/column_writer.h
@@ -165,8 +165,14 @@ class PARQUET_EXPORT ColumnWriter {
   /// \brief Estimated size of the values that are not written to a page yet.
   virtual int64_t estimated_buffered_value_bytes() const = 0;
 
-  /// \brief Estimated size of the levels that are not written to a page yet.
-  virtual int64_t EstimatedBufferedLevelsBytes() const = 0;
+  /// \brief Estimated size of the definition levels that are not written to a page yet.
+  virtual int64_t estimated_buffered_def_level_bytes() const = 0;
+
+  /// \brief Estimated size of the repetition levels that are not written to a page yet.
+  virtual int64_t estimated_buffered_rep_level_bytes() const = 0;
+
+  /// \brief Estimated size of the dictionary that are not written to a page yet.
+  virtual int64_t estimated_buffered_dict_bytes() const = 0;
 
   /// \brief The file-level writer properties
   virtual const WriterProperties* properties() = 0;

--- a/cpp/src/parquet/file_writer.cc
+++ b/cpp/src/parquet/file_writer.cc
@@ -69,7 +69,7 @@ int64_t RowGroupWriter::total_compressed_bytes_written() const {
   return contents_->total_compressed_bytes_written();
 }
 
-BufferedStats RowGroupWriter::estimated_buffered_stats() const {
+RowGroupWriter::BufferedStats RowGroupWriter::estimated_buffered_stats() const {
   return contents_->EstimatedBufferedStats();
 }
 
@@ -202,8 +202,8 @@ class RowGroupSerializer : public RowGroupWriter::Contents {
     return total_compressed_bytes_written;
   }
 
-  BufferedStats EstimatedBufferedStats() const override {
-    BufferedStats stats;
+  RowGroupWriter::BufferedStats EstimatedBufferedStats() const override {
+    RowGroupWriter::BufferedStats stats;
     if (closed_) {
       return stats;
     }

--- a/cpp/src/parquet/file_writer.cc
+++ b/cpp/src/parquet/file_writer.cc
@@ -207,12 +207,12 @@ class RowGroupSerializer : public RowGroupWriter::Contents {
     if (closed_) {
       return stats;
     }
-    for (size_t i = 0; i < column_writers_.size(); i++) {
-      if (column_writers_[i]) {
-        stats.def_level_bytes += column_writers_[i]->estimated_buffered_def_level_bytes();
-        stats.rep_level_bytes += column_writers_[i]->estimated_buffered_rep_level_bytes();
-        stats.value_bytes += column_writers_[i]->estimated_buffered_value_bytes();
-        stats.dict_bytes += column_writers_[i]->estimated_buffered_dict_bytes();
+    for (const auto& column_writer : column_writers_) {
+      if (column_writer) {
+        stats.def_level_bytes += column_writer->estimated_buffered_def_level_bytes();
+        stats.rep_level_bytes += column_writer->estimated_buffered_rep_level_bytes();
+        stats.value_bytes += column_writer->estimated_buffered_value_bytes();
+        stats.dict_bytes += column_writer->estimated_buffered_dict_bytes();
       }
     }
     return stats;

--- a/cpp/src/parquet/file_writer.cc
+++ b/cpp/src/parquet/file_writer.cc
@@ -69,8 +69,8 @@ int64_t RowGroupWriter::total_compressed_bytes_written() const {
   return contents_->total_compressed_bytes_written();
 }
 
-int64_t RowGroupWriter::total_buffered_bytes() const {
-  return contents_->EstimatedBufferedBytes();
+BufferedStats RowGroupWriter::estimated_buffered_stats() const {
+  return contents_->EstimatedBufferedStats();
 }
 
 bool RowGroupWriter::buffered() const { return contents_->buffered(); }
@@ -202,19 +202,20 @@ class RowGroupSerializer : public RowGroupWriter::Contents {
     return total_compressed_bytes_written;
   }
 
-  int64_t EstimatedBufferedBytes() const override {
+  BufferedStats EstimatedBufferedStats() const override {
+    BufferedStats stats;
     if (closed_) {
-      return 0;
+      return stats;
     }
-    int64_t estimated_buffered_value_bytes = 0;
     for (size_t i = 0; i < column_writers_.size(); i++) {
       if (column_writers_[i]) {
-        estimated_buffered_value_bytes +=
-            column_writers_[i]->estimated_buffered_value_bytes() +
-            column_writers_[i]->EstimatedBufferedLevelsBytes();
+        stats.def_level_bytes += column_writers_[i]->estimated_buffered_def_level_bytes();
+        stats.rep_level_bytes += column_writers_[i]->estimated_buffered_rep_level_bytes();
+        stats.value_bytes += column_writers_[i]->estimated_buffered_value_bytes();
+        stats.dict_bytes += column_writers_[i]->estimated_buffered_dict_bytes();
       }
     }
-    return estimated_buffered_value_bytes;
+    return stats;
   }
 
   bool buffered() const override { return buffered_row_group_; }

--- a/cpp/src/parquet/file_writer.cc
+++ b/cpp/src/parquet/file_writer.cc
@@ -69,6 +69,10 @@ int64_t RowGroupWriter::total_compressed_bytes_written() const {
   return contents_->total_compressed_bytes_written();
 }
 
+int64_t RowGroupWriter::total_buffered_bytes() const {
+  return contents_->EstimatedBufferedBytes();
+}
+
 bool RowGroupWriter::buffered() const { return contents_->buffered(); }
 
 int RowGroupWriter::current_column() { return contents_->current_column(); }
@@ -196,6 +200,21 @@ class RowGroupSerializer : public RowGroupWriter::Contents {
       }
     }
     return total_compressed_bytes_written;
+  }
+
+  int64_t EstimatedBufferedBytes() const override {
+    if (closed_) {
+      return 0;
+    }
+    int64_t estimated_buffered_value_bytes = 0;
+    for (size_t i = 0; i < column_writers_.size(); i++) {
+      if (column_writers_[i]) {
+        estimated_buffered_value_bytes +=
+            column_writers_[i]->estimated_buffered_value_bytes() +
+            column_writers_[i]->EstimatedBufferedLevelsBytes();
+      }
+    }
+    return estimated_buffered_value_bytes;
   }
 
   bool buffered() const override { return buffered_row_group_; }

--- a/cpp/src/parquet/file_writer.h
+++ b/cpp/src/parquet/file_writer.h
@@ -68,7 +68,7 @@ class PARQUET_EXPORT RowGroupWriter {
     /// \brief total compressed bytes written by the page writer
     virtual int64_t total_compressed_bytes_written() const = 0;
     /// \brief Estimated sizes of buffered data (levels, values, dict) not yet
-    /// written to a page.
+    /// written to pages.
     virtual BufferedStats EstimatedBufferedStats() const = 0;
 
     virtual bool buffered() const = 0;

--- a/cpp/src/parquet/file_writer.h
+++ b/cpp/src/parquet/file_writer.h
@@ -34,6 +34,13 @@ class ColumnWriter;
 static constexpr uint8_t kParquetMagic[4] = {'P', 'A', 'R', '1'};
 static constexpr uint8_t kParquetEMagic[4] = {'P', 'A', 'R', 'E'};
 
+struct PARQUET_EXPORT BufferedStats {
+  int64_t def_level_bytes = 0;
+  int64_t rep_level_bytes = 0;
+  int64_t value_bytes = 0;
+  int64_t dict_bytes = 0;
+};
+
 class PARQUET_EXPORT RowGroupWriter {
  public:
   // Forward declare a virtual class 'Contents' to aid dependency injection and more
@@ -58,9 +65,9 @@ class PARQUET_EXPORT RowGroupWriter {
     virtual int64_t total_compressed_bytes() const = 0;
     /// \brief total compressed bytes written by the page writer
     virtual int64_t total_compressed_bytes_written() const = 0;
-    /// \brief Estimated bytes of values and levels that are buffered by the page writer
-    /// but not written to a page yet
-    virtual int64_t EstimatedBufferedBytes() const = 0;
+    /// \brief Estimated sizes of buffered data (levels, values, dict) not yet
+    /// written to a page.
+    virtual BufferedStats EstimatedBufferedStats() const = 0;
 
     virtual bool buffered() const = 0;
   };
@@ -102,8 +109,9 @@ class PARQUET_EXPORT RowGroupWriter {
   int64_t total_compressed_bytes() const;
   /// \brief total compressed bytes written by the page writer
   int64_t total_compressed_bytes_written() const;
-  /// \brief total bytes of values and levels that are buffered by the page writer
-  int64_t total_buffered_bytes() const;
+  /// \brief Estimated sizes of buffered data (levels, values, dict) not yet
+  /// written to a page.
+  BufferedStats estimated_buffered_stats() const;
 
   /// Returns whether the current RowGroupWriter is in the buffered mode and is created
   /// by calling ParquetFileWriter::AppendBufferedRowGroup.

--- a/cpp/src/parquet/file_writer.h
+++ b/cpp/src/parquet/file_writer.h
@@ -34,15 +34,17 @@ class ColumnWriter;
 static constexpr uint8_t kParquetMagic[4] = {'P', 'A', 'R', '1'};
 static constexpr uint8_t kParquetEMagic[4] = {'P', 'A', 'R', 'E'};
 
-struct PARQUET_EXPORT BufferedStats {
-  int64_t def_level_bytes = 0;
-  int64_t rep_level_bytes = 0;
-  int64_t value_bytes = 0;
-  int64_t dict_bytes = 0;
-};
-
 class PARQUET_EXPORT RowGroupWriter {
  public:
+  // Estimated uncompressed byte sizes of data buffered by column writers
+  // that have not yet been serialized into data pages.
+  struct BufferedStats {
+    int64_t def_level_bytes = 0;
+    int64_t rep_level_bytes = 0;
+    int64_t value_bytes = 0;
+    int64_t dict_bytes = 0;
+  };
+
   // Forward declare a virtual class 'Contents' to aid dependency injection and more
   // easily create test fixtures
   // An implementation of the Contents class is defined in the .cc file

--- a/cpp/src/parquet/file_writer.h
+++ b/cpp/src/parquet/file_writer.h
@@ -37,7 +37,7 @@ static constexpr uint8_t kParquetEMagic[4] = {'P', 'A', 'R', 'E'};
 class PARQUET_EXPORT RowGroupWriter {
  public:
   // Estimated uncompressed byte sizes of data buffered by column writers
-  // that have not yet been serialized into data pages.
+  // that have not yet been serialized into pages.
   struct BufferedStats {
     int64_t def_level_bytes = 0;
     int64_t rep_level_bytes = 0;

--- a/cpp/src/parquet/file_writer.h
+++ b/cpp/src/parquet/file_writer.h
@@ -112,7 +112,7 @@ class PARQUET_EXPORT RowGroupWriter {
   /// \brief total compressed bytes written by the page writer
   int64_t total_compressed_bytes_written() const;
   /// \brief Estimated sizes of buffered data (levels, values, dict) not yet
-  /// written to a page.
+  /// written to pages.
   BufferedStats estimated_buffered_stats() const;
 
   /// Returns whether the current RowGroupWriter is in the buffered mode and is created

--- a/cpp/src/parquet/file_writer.h
+++ b/cpp/src/parquet/file_writer.h
@@ -58,6 +58,9 @@ class PARQUET_EXPORT RowGroupWriter {
     virtual int64_t total_compressed_bytes() const = 0;
     /// \brief total compressed bytes written by the page writer
     virtual int64_t total_compressed_bytes_written() const = 0;
+    /// \brief Estimated bytes of values and levels that are buffered by the page writer
+    /// but not written to a page yet
+    virtual int64_t EstimatedBufferedBytes() const = 0;
 
     virtual bool buffered() const = 0;
   };
@@ -99,6 +102,8 @@ class PARQUET_EXPORT RowGroupWriter {
   int64_t total_compressed_bytes() const;
   /// \brief total compressed bytes written by the page writer
   int64_t total_compressed_bytes_written() const;
+  /// \brief total bytes of values and levels that are buffered by the page writer
+  int64_t total_buffered_bytes() const;
 
   /// Returns whether the current RowGroupWriter is in the buffered mode and is created
   /// by calling ParquetFileWriter::AppendBufferedRowGroup.


### PR DESCRIPTION
### Rationale for this change
Expose an API for buffered bytes of values and levels in RowGroupWriter, it's useful in deciding whether a new row group is needed.
Discussion in https://github.com/apache/arrow/pull/48468#issuecomment-4047682751

### What changes are included in this PR?
Add a new API to return `BufferedStats` from `RowGroupWriter`.

### Are these changes tested?
Test locally.

### Are there any user-facing changes?
Yes, user could use the new API to implement their customized row group strategy.
* GitHub Issue: #48467