### PR TITLE
GH-49531: [CI][Packaging][Python] Ignore cleanup errors trying to remove loaded DLLs from temp dir

### DIFF
--- a/python/scripts/update_stub_docstrings.py
+++ b/python/scripts/update_stub_docstrings.py
@@ -264,7 +264,7 @@ if __name__ == "__main__":
         print("No .pyi files found in install tree, skipping docstring injection")
         sys.exit(0)
 
-    with tempfile.TemporaryDirectory() as tmpdir:
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
         pyarrow_pkg = Path(tmpdir) / "pyarrow"
         pyarrow_pkg.mkdir()
         _create_importable_pyarrow(pyarrow_pkg, source_dir, install_pyarrow_dir)


### PR DESCRIPTION
### Rationale for this change

Updating docstrings is failing on Windows trying to remove arrow.dll from tempdir because its still loaded in memory.

### What changes are included in this PR?

Added `ignore_cleanup_errors=True`

### Are these changes tested?

Yes via archery

### Are there any user-facing changes?

No

* GitHub Issue: #49531