### PR TITLE
GH-49539: [C++][Parquet] Fix argument count check in parquet_scan

### DIFF
--- a/cpp/tools/parquet/parquet_scan.cc
+++ b/cpp/tools/parquet/parquet_scan.cc
@@ -23,7 +23,7 @@
 #include "parquet/api/reader.h"
 
 int main(int argc, char** argv) {
-  if (argc > 4 || argc < 1) {
+  if (argc > 4 || argc < 2) {
     std::cerr << "Usage: parquet-scan [--batch-size=] [--columns=...] <file>"
               << std::endl;
     return -1;


### PR DESCRIPTION
### Rationale for this change
Running parquet-scan without arguments currently triggers a confusing IOError instead of showing how to use the tool.

### What changes are included in this PR?
Updated the argument validation from argc < 1 (always false) to argc < 2.

### Are these changes tested?
Yes. 

### Are there any user-facing changes?
Yes.

Old behavior:
$ parquet-scan
Parquet error: IOError: Failed to open local file ''. Detail: [errno 2] No such file or directory

New behavior:
$ parquet-scan
Usage: parquet-scan [--batch-size=] [--columns=...]

* GitHub Issue: #49539