### PR TITLE
GH-49499: [C++] Improve arrow vcpkg port integration

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -115,6 +115,8 @@ list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules")
 # vcpkg (ab)uses CMAKE_TOOLCHAIN_FILE to inject its logic into CMake
 if(ARROW_DEPENDENCY_SOURCE STREQUAL "VCPKG")
   include(Usevcpkg)
+elseif(ARROW_PACKAGE_KIND STREQUAL "vcpkg")
+  set(ARROW_VCPKG ON)
 endif()
 
 project(arrow VERSION "${ARROW_BASE_VERSION}")

--- a/cpp/cmake_modules/FindSnappyAlt.cmake
+++ b/cpp/cmake_modules/FindSnappyAlt.cmake
@@ -52,9 +52,12 @@ if(Snappy_FOUND)
       set(SnappyAlt_FOUND TRUE)
       return()
     else()
-      # The Conan's Snappy package always uses Snappy::snappy and it's
-      # an INTERFACE_LIBRARY.
-      get_target_property(Snappy Snappy::snappy TYPE)
+      # The Snappy packages in Conan and vcpkg always use
+      # Snappy::snappy.
+      #
+      # The Snappy package in Conan use an INTERFACE_LIBRARY for
+      # Snappy::snappy.
+      get_target_property(Snappy_TYPE Snappy::snappy TYPE)
       if(Snappy_TYPE STREQUAL "STATIC_LIBRARY" OR Snappy_TYPE STREQUAL
                                                   "INTERFACE_LIBRARY")
         set(Snappy_TARGET Snappy::snappy)


### PR DESCRIPTION
### Rationale for this change

We already have CMake configurations only for vcpkg but it's not used when our CMake packages is installed by vcpkg.

### What changes are included in this PR?

We're using `ARROW_DEPENDENCY_SOURCE=VCPKG` to detect that Apache Arrow is building with dependencies installed by vcpkg but we can't use it in our CMake packages installed by arrow vcpkg port. Because arrow vcpkg port doesn't use `ARROW_DEPENDENCY_SOURCE=VCPKG`.

We can use `ARROW_PACKAGE_KIND=vcpkg` to detect whether our CMake packages are installed by arrow vcpkg port. Because arrow vcpkg port uses `ARROW_PACKAGE_KIND=vcpkg`.

This also fixes a variable name typo in `FindSnappyAlt`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #49499