### PR TITLE
GH-49546: [Docs][Python] Fix documented editable build commands where verbose flags order was wrong

### DIFF
--- a/docs/source/developers/guide/step_by_step/building.rst
+++ b/docs/source/developers/guide/step_by_step/building.rst
@@ -155,7 +155,7 @@ Building other Arrow libraries
 
       .. code:: console
 
-         $ pip install --no-build-isolation --editable -vv .
+         $ pip install --no-build-isolation --editable . -vv
 
       **Recompiling C++**
 

--- a/docs/source/developers/python/building.rst
+++ b/docs/source/developers/python/building.rst
@@ -391,7 +391,7 @@ To build PyArrow run:
       .. code-block::
 
          $ pushd arrow/python
-         $ pip install --no-build-isolation --editable -vv .
+         $ pip install --no-build-isolation --editable . -vv
          $ popd
 
    .. tab-item:: Windows
@@ -400,7 +400,7 @@ To build PyArrow run:
       .. code-block::
 
          $ pushd arrow\python
-         $ pip install --no-build-isolation --editable -vv .
+         $ pip install --no-build-isolation --editable . -vv
          $ popd
 
       .. note::
@@ -429,7 +429,7 @@ To build PyArrow run:
          .. code-block::
 
             $ set PYARROW_BUNDLE_ARROW_CPP=ON
-            $ pip install --no-build-isolation --editable -vv .
+            $ pip install --no-build-isolation --editable . -vv
 
          Note that bundled Arrow C++ libraries will not be automatically
          updated when rebuilding Arrow C++.


### PR DESCRIPTION
### Rationale for this change

The current documented command was wrong as `--editable -vv .` fails it should be `--editable . -vv` or `-vv --editable .`

### What changes are included in this PR?

Update documentation for all `--editable` commands.

### Are these changes tested?

Tested the new command is correct.

### Are there any user-facing changes?

No

* GitHub Issue: #49546