### PR TITLE
GH-47696: [Docs] PyCapsule protocol implementation status

### DIFF
--- a/docs/source/python/extending_types.rst
+++ b/docs/source/python/extending_types.rst
@@ -88,47 +88,47 @@ for the latest updates):
 
    * - Library
      - Status
-   * - `pandas <https://pandas.pydata.org/>`__
+   * - `arro3 <https://github.com/kylebarron/arro3>`__
      - Implemented
-   * - `Polars <https://pola.rs/>`__
-     - Implemented
-   * - `PyArrow <https://arrow.apache.org/docs/python/>`__
-     - Implemented
-   * - `nanoarrow <https://arrow.apache.org/nanoarrow/>`__
-     - Implemented
-   * - `DuckDB <https://duckdb.org/>`__
-     - Implemented
-   * - `PySpark <https://spark.apache.org/docs/latest/api/python/>`__
+   * - `cuDF <https://docs.rapids.ai/api/cudf/stable/>`__
      - Implemented
    * - `DataFusion <https://datafusion.apache.org/python/>`__
      - Implemented
-   * - `ibis <https://ibis-project.org/>`__
+   * - `DuckDB <https://duckdb.org/>`__
+     - Implemented
+   * - `fastexcel <https://github.com/ToucanToco/fastexcel>`__
      - Implemented
    * - `GDAL/OGR <https://gdal.org/>`__
      - Implemented
    * - `GeoPandas <https://geopandas.org/>`__
      - Implemented
-   * - `pyogrio <https://pyogrio.readthedocs.io/>`__
-     - Implemented
-   * - `narwhals <https://narwhals-dev.github.io/narwhals/>`__
-     - Implemented
-   * - `cuDF <https://docs.rapids.ai/api/cudf/stable/>`__
-     - Implemented
-   * - `arro3 <https://github.com/kylebarron/arro3>`__
-     - Implemented
-   * - `Pillow <https://python-pillow.org/>`__
-     - Implemented
-   * - `VegaFusion <https://vegafusion.io/>`__
-     - Implemented
-   * - `fastexcel <https://github.com/ToucanToco/fastexcel>`__
-     - Implemented
-   * - `pantab <https://github.com/innobi/pantab>`__
-     - Implemented
    * - `h3ronpy <https://github.com/nmandery/h3ronpy>`__
+     - Implemented
+   * - `ibis <https://ibis-project.org/>`__
      - Implemented
    * - `lonboard <https://github.com/developmentseed/lonboard>`__
      - Implemented
+   * - `nanoarrow <https://arrow.apache.org/nanoarrow/>`__
+     - Implemented
+   * - `narwhals <https://narwhals-dev.github.io/narwhals/>`__
+     - Implemented
+   * - `pandas <https://pandas.pydata.org/>`__
+     - Implemented
+   * - `pantab <https://github.com/innobi/pantab>`__
+     - Implemented
+   * - `Pillow <https://python-pillow.org/>`__
+     - Implemented
+   * - `Polars <https://pola.rs/>`__
+     - Implemented
+   * - `PyArrow <https://arrow.apache.org/docs/python/>`__
+     - Implemented
+   * - `pyogrio <https://pyogrio.readthedocs.io/>`__
+     - Implemented
+   * - `PySpark <https://spark.apache.org/docs/latest/api/python/>`__
+     - Implemented
    * - `quak <https://github.com/manzt/quak>`__
+     - Implemented
+   * - `VegaFusion <https://vegafusion.io/>`__
      - Implemented
 
 .. _arrow_array_protocol:

--- a/docs/source/python/extending_types.rst
+++ b/docs/source/python/extending_types.rst
@@ -88,48 +88,62 @@ for the latest updates):
 
    * - Library
      - Status
+   * - `altair <https://github.com/vega/altair/issues/3568>`__
+     - Not yet implemented
    * - `arro3 <https://github.com/kylebarron/arro3>`__
      - Implemented
-   * - `cuDF <https://docs.rapids.ai/api/cudf/stable/>`__
+   * - `cuDF <https://github.com/rapidsai/cudf/pull/18402>`__
      - Implemented
-   * - `DataFusion <https://datafusion.apache.org/python/>`__
+   * - `daft <https://github.com/Eventual-Inc/Daft/issues/2504>`__
+     - Not yet implemented
+   * - `DataFusion <https://github.com/apache/datafusion-python/pull/825>`__
      - Implemented
-   * - `DuckDB <https://duckdb.org/>`__
+   * - `DuckDB <https://github.com/duckdb/duckdb/pull/13386>`__
      - Implemented
-   * - `fastexcel <https://github.com/ToucanToco/fastexcel>`__
+   * - `fastexcel <https://github.com/ToucanToco/fastexcel/pull/361>`__
      - Implemented
-   * - `GDAL/OGR <https://gdal.org/>`__
+   * - `GDAL/OGR <https://github.com/OSGeo/gdal/pull/9133>`__
      - Implemented
-   * - `GeoPandas <https://geopandas.org/>`__
+   * - `GeoPandas <https://github.com/geopandas/geopandas/pull/3219>`__
      - Implemented
-   * - `h3ronpy <https://github.com/nmandery/h3ronpy>`__
+   * - `h3ronpy <https://github.com/nmandery/h3ronpy/pull/64>`__
      - Implemented
-   * - `ibis <https://ibis-project.org/>`__
+   * - `ibis <https://github.com/ibis-project/ibis/pull/9143>`__
      - Implemented
+   * - `iceberg-python <https://github.com/apache/iceberg-python/issues/1655>`__
+     - Not yet implemented
+   * - `lance <https://github.com/lancedb/lance/issues/2630>`__
+     - Not yet implemented
+   * - `LightGBM <https://github.com/microsoft/LightGBM/issues/6204#issuecomment-2256015538>`__
+     - Not yet implemented
    * - `lonboard <https://github.com/developmentseed/lonboard>`__
      - Implemented
    * - `nanoarrow <https://arrow.apache.org/nanoarrow/>`__
      - Implemented
-   * - `narwhals <https://narwhals-dev.github.io/narwhals/>`__
+   * - `narwhals <https://github.com/narwhals-dev/narwhals/pull/786>`__
      - Implemented
-   * - `pandas <https://pandas.pydata.org/>`__
+   * - `pandas <https://github.com/pandas-dev/pandas/pull/56587>`__
      - Implemented
    * - `pantab <https://github.com/innobi/pantab>`__
      - Implemented
-   * - `Pillow <https://python-pillow.org/>`__
+   * - `Pillow <https://github.com/python-pillow/Pillow/pull/8330>`__
      - Implemented
-   * - `Polars <https://pola.rs/>`__
+   * - `Polars <https://github.com/pola-rs/polars/pull/17676>`__
      - Implemented
-   * - `PyArrow <https://arrow.apache.org/docs/python/>`__
+   * - `PyArrow <https://github.com/apache/arrow/pull/37797>`__
      - Implemented
    * - `pyogrio <https://pyogrio.readthedocs.io/>`__
      - Implemented
-   * - `PySpark <https://spark.apache.org/docs/latest/api/python/>`__
+   * - `PySpark <https://github.com/apache/spark/pull/53391>`__
      - Implemented
-   * - `quak <https://github.com/manzt/quak>`__
+   * - `quak <https://github.com/manzt/quak/pull/23>`__
      - Implemented
-   * - `VegaFusion <https://vegafusion.io/>`__
+   * - `seaborn <https://github.com/mwaskom/seaborn/issues/3756>`__
+     - Not yet implemented
+   * - `VegaFusion <https://github.com/vega/vegafusion/pull/517>`__
      - Implemented
+   * - `vortex <https://github.com/vortex-data/vortex/pull/4161>`__
+     - Not yet implemented
 
 .. _arrow_array_protocol:
 

--- a/docs/source/python/extending_types.rst
+++ b/docs/source/python/extending_types.rst
@@ -78,6 +78,59 @@ A :class:`DataType` can be created by consuming the schema-compatible object
 using :func:`pyarrow.field` and then accessing the ``.type`` of the resulting
 Field.
 
+The PyCapsule Interface has been adopted by a number of libraries in the Python
+ecosystem. The following table provides an overview of the current implementation
+status (see `the tracking issue <https://github.com/apache/arrow/issues/39195>`__
+for the latest updates):
+
+.. list-table:: PyCapsule Interface Implementation Status
+   :header-rows: 1
+
+   * - Library
+     - Status
+   * - `pandas <https://pandas.pydata.org/>`__
+     - Implemented
+   * - `Polars <https://pola.rs/>`__
+     - Implemented
+   * - `PyArrow <https://arrow.apache.org/docs/python/>`__
+     - Implemented
+   * - `nanoarrow <https://arrow.apache.org/nanoarrow/>`__
+     - Implemented
+   * - `DuckDB <https://duckdb.org/>`__
+     - Implemented
+   * - `PySpark <https://spark.apache.org/docs/latest/api/python/>`__
+     - Implemented
+   * - `DataFusion <https://datafusion.apache.org/python/>`__
+     - Implemented
+   * - `ibis <https://ibis-project.org/>`__
+     - Implemented
+   * - `GDAL/OGR <https://gdal.org/>`__
+     - Implemented
+   * - `GeoPandas <https://geopandas.org/>`__
+     - Implemented
+   * - `pyogrio <https://pyogrio.readthedocs.io/>`__
+     - Implemented
+   * - `narwhals <https://narwhals-dev.github.io/narwhals/>`__
+     - Implemented
+   * - `cuDF <https://docs.rapids.ai/api/cudf/stable/>`__
+     - Implemented
+   * - `arro3 <https://github.com/kylebarron/arro3>`__
+     - Implemented
+   * - `Pillow <https://python-pillow.org/>`__
+     - Implemented
+   * - `VegaFusion <https://vegafusion.io/>`__
+     - Implemented
+   * - `fastexcel <https://github.com/ToucanToco/fastexcel>`__
+     - Implemented
+   * - `pantab <https://github.com/innobi/pantab>`__
+     - Implemented
+   * - `h3ronpy <https://github.com/nmandery/h3ronpy>`__
+     - Implemented
+   * - `lonboard <https://github.com/developmentseed/lonboard>`__
+     - Implemented
+   * - `quak <https://github.com/manzt/quak>`__
+     - Implemented
+
 .. _arrow_array_protocol:
 
 Controlling conversion to ``pyarrow.Array`` with the ``__arrow_array__`` protocol

--- a/docs/source/python/extending_types.rst
+++ b/docs/source/python/extending_types.rst
@@ -81,7 +81,8 @@ Field.
 The PyCapsule Interface has been adopted by a number of libraries in the Python
 ecosystem. The following table provides an overview of the current implementation
 status (see `the tracking issue <https://github.com/apache/arrow/issues/39195>`__
-for the latest updates):
+for the latest updates). In the status column, ✓ means implemented and ✗ means
+not yet implemented.
 
 .. list-table:: PyCapsule Interface Implementation Status
    :header-rows: 1
@@ -89,61 +90,63 @@ for the latest updates):
    * - Library
      - Status
    * - `altair <https://github.com/vega/altair/issues/3568>`__
-     - Not yet implemented
-   * - `arro3 <https://github.com/kylebarron/arro3>`__
-     - Implemented
+     - ✗
+   * - `arro3 <https://github.com/apache/arrow/issues/39195#issuecomment-2245718008>`__
+     - ✓
    * - `cuDF <https://github.com/rapidsai/cudf/pull/18402>`__
-     - Implemented
+     - ✓
    * - `daft <https://github.com/Eventual-Inc/Daft/issues/2504>`__
-     - Not yet implemented
+     - ✗
    * - `DataFusion <https://github.com/apache/datafusion-python/pull/825>`__
-     - Implemented
+     - ✓
    * - `DuckDB <https://github.com/duckdb/duckdb/pull/13386>`__
-     - Implemented
+     - ✓
    * - `fastexcel <https://github.com/ToucanToco/fastexcel/pull/361>`__
-     - Implemented
+     - ✓
    * - `GDAL/OGR <https://github.com/OSGeo/gdal/pull/9133>`__
-     - Implemented
+     - ✓
    * - `GeoPandas <https://github.com/geopandas/geopandas/pull/3219>`__
-     - Implemented
+     - ✓
    * - `h3ronpy <https://github.com/nmandery/h3ronpy/pull/64>`__
-     - Implemented
+     - ✓
    * - `ibis <https://github.com/ibis-project/ibis/pull/9143>`__
-     - Implemented
+     - ✓
    * - `iceberg-python <https://github.com/apache/iceberg-python/issues/1655>`__
-     - Not yet implemented
+     - ✗
    * - `lance <https://github.com/lancedb/lance/issues/2630>`__
-     - Not yet implemented
+     - ✗
    * - `LightGBM <https://github.com/microsoft/LightGBM/issues/6204#issuecomment-2256015538>`__
-     - Not yet implemented
+     - ✗
    * - `lonboard <https://github.com/developmentseed/lonboard>`__
-     - Implemented
+     - ✓
    * - `nanoarrow <https://arrow.apache.org/nanoarrow/>`__
-     - Implemented
+     - ✓
    * - `narwhals <https://github.com/narwhals-dev/narwhals/pull/786>`__
-     - Implemented
+     - ✓
    * - `pandas <https://github.com/pandas-dev/pandas/pull/56587>`__
-     - Implemented
+     - ✓
    * - `pantab <https://github.com/innobi/pantab>`__
-     - Implemented
+     - ✓
    * - `Pillow <https://github.com/python-pillow/Pillow/pull/8330>`__
-     - Implemented
+     - ✓
    * - `Polars <https://github.com/pola-rs/polars/pull/17676>`__
-     - Implemented
+     - ✓
    * - `PyArrow <https://github.com/apache/arrow/pull/37797>`__
-     - Implemented
+     - ✓
    * - `pyogrio <https://pyogrio.readthedocs.io/>`__
-     - Implemented
+     - ✓
    * - `PySpark <https://github.com/apache/spark/pull/53391>`__
-     - Implemented
+     - ✓
    * - `quak <https://github.com/manzt/quak/pull/23>`__
-     - Implemented
+     - ✓
    * - `seaborn <https://github.com/mwaskom/seaborn/issues/3756>`__
-     - Not yet implemented
+     - ✗
+   * - `streamlit <https://github.com/streamlit/streamlit/issues/9436>`__
+     - ✗
    * - `VegaFusion <https://github.com/vega/vegafusion/pull/517>`__
-     - Implemented
+     - ✓
    * - `vortex <https://github.com/vortex-data/vortex/pull/4161>`__
-     - Not yet implemented
+     - ✗
 
 .. _arrow_array_protocol:
 


### PR DESCRIPTION
### Rationale for this change

The Python docs explain the PyCapsule Interface but don't show which libraries in the ecosystem have adopted it. Issue #47696 requested adding an implementation status table based on the tracking in #39195.

### What changes are included in this PR?

Added a table to `docs/source/python/extending_types.rst` listing 21 Python libraries that have implemented the PyCapsule Interface, with a link to the tracking issue for latest updates.

### Are these changes tested?

Documentation-only change. Verified the Sphinx build succeeds with `make python`.

### Are there any user-facing changes?

A new "PyCapsule Interface Implementation Status" table is now visible in the Python docs under the "Extending PyArrow" page.

---
Fixes #47696
* GitHub Issue: #47696