### PR TITLE
GH-49555: [Python][Packaging] Add riscv64 manylinux wheel builds to release pipeline

### DIFF
--- a/ci/vcpkg/riscv64-linux-static-debug.cmake
+++ b/ci/vcpkg/riscv64-linux-static-debug.cmake
@@ -1,0 +1,28 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set(VCPKG_TARGET_ARCHITECTURE riscv64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE static)
+set(VCPKG_CMAKE_SYSTEM_NAME Linux)
+set(VCPKG_BUILD_TYPE debug)
+
+if(NOT CMAKE_HOST_SYSTEM_PROCESSOR)
+  execute_process(COMMAND "uname" "-m"
+                  OUTPUT_VARIABLE CMAKE_HOST_SYSTEM_PROCESSOR
+                  OUTPUT_STRIP_TRAILING_WHITESPACE)
+endif()

--- a/ci/vcpkg/riscv64-linux-static-release.cmake
+++ b/ci/vcpkg/riscv64-linux-static-release.cmake
@@ -1,0 +1,28 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set(VCPKG_TARGET_ARCHITECTURE riscv64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE static)
+set(VCPKG_CMAKE_SYSTEM_NAME Linux)
+set(VCPKG_BUILD_TYPE release)
+
+if(NOT CMAKE_HOST_SYSTEM_PROCESSOR)
+  execute_process(COMMAND "uname" "-m"
+                  OUTPUT_VARIABLE CMAKE_HOST_SYSTEM_PROCESSOR
+                  OUTPUT_STRIP_TRAILING_WHITESPACE)
+endif()

--- a/compose.yaml
+++ b/compose.yaml
@@ -199,6 +199,8 @@ volumes:
     name: maven-cache
   python-wheel-manylinux-2-28-ccache:
     name: python-wheel-manylinux-2-28-ccache
+  python-wheel-manylinux-2-39-ccache:
+    name: python-wheel-manylinux-2-39-ccache
   python-wheel-musllinux-1-2-ccache:
     name: python-wheel-musllinux-1-2-ccache
   ubuntu-ccache:
@@ -1180,6 +1182,31 @@ services:
     volumes:
       - .:/arrow:delegated
       - ${DOCKER_VOLUME_PREFIX}python-wheel-manylinux-2-28-ccache:/ccache:delegated
+    command: /arrow/ci/scripts/python_wheel_xlinux_build.sh
+
+  # See available versions at:
+  #    https://quay.io/repository/pypa/manylinux_2_39_riscv64?tab=tags
+  python-wheel-manylinux-2-39:
+    image: ${REPO}:${ARCH}-python-${PYTHON}-wheel-manylinux-2-39-vcpkg-${VCPKG}
+    build:
+      args:
+        arch: ${ARCH}
+        arch_short: ${ARCH_SHORT}
+        base: quay.io/pypa/manylinux_2_39_riscv64:2026.03.01-1
+        manylinux: 2_39
+        python: ${PYTHON}
+        python_abi_tag: ${PYTHON_ABI_TAG}
+        vcpkg: ${VCPKG}
+      context: .
+      dockerfile: ci/docker/python-wheel-manylinux.dockerfile
+      cache_from:
+        - ${REPO}:${ARCH}-python-${PYTHON}-wheel-manylinux-2-39-vcpkg-${VCPKG}
+      secrets: *vcpkg-build-secrets
+    environment:
+      <<: [*common, *ccache]
+    volumes:
+      - .:/arrow:delegated
+      - ${DOCKER_VOLUME_PREFIX}python-wheel-manylinux-2-39-ccache:/ccache:delegated
     command: /arrow/ci/scripts/python_wheel_xlinux_build.sh
 
   # See available versions at:

--- a/dev/tasks/python-wheels/github.linux.yml
+++ b/dev/tasks/python-wheels/github.linux.yml
@@ -27,6 +27,8 @@ jobs:
     name: "Build wheel for {{ linux_wheel_kind }} {{ linux_wheel_version }}"
     {% if arch == "amd64" %}
     runs-on: ubuntu-latest
+    {% elif arch == "riscv64" %}
+    runs-on: ubuntu-24.04-riscv
     {% else %}
     runs-on: ubuntu-24.04-arm
     {% endif %}
@@ -37,6 +39,8 @@ jobs:
       # archery uses these environment variables
       {% if arch == "amd64" %}
       ARCH: amd64
+      {% elif arch == "riscv64" %}
+      ARCH: riscv64
       {% else %}
       ARCH: arm64v8
       {% endif %}

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -183,6 +183,7 @@ tasks:
 
 {% for wheel_kind, arch, version, platform_tag in [("manylinux", "amd64", "2-28", "manylinux_2_28_x86_64"),
                                                    ("manylinux", "arm64", "2-28", "manylinux_2_28_aarch64"),
+                                                   ("manylinux", "riscv64", "2-39", "manylinux_2_39_riscv64"),
                                                    ("musllinux", "amd64", "1-2", "musllinux_1_2_x86_64"),
                                                    ("musllinux", "arm64", "1-2", "musllinux_1_2_aarch64")] %}
   wheel-{{ wheel_kind }}-{{ version }}-{{ python_tag }}-{{ abi_tag }}-{{ arch }}:


### PR DESCRIPTION
### Describe the enhancement requested

Add riscv64 to the PyArrow wheel build pipeline using `manylinux_2_39` and native RISE riscv64 runners.

### Changes

- **`dev/tasks/tasks.yml`**: Add `("manylinux", "riscv64", "2-39", "manylinux_2_39_riscv64")` to the Linux wheel matrix
- **`dev/tasks/python-wheels/github.linux.yml`**: Add `ubuntu-24.04-riscv` runner selection and `riscv64` ARCH mapping

### What's still needed

- [ ] Docker image for riscv64 wheel builds (`apache/arrow-dev:riscv64-python-*-wheel-manylinux-2_39-vcpkg-*`)
- [ ] vcpkg dependency verification for riscv64
- [ ] Testing via Crossbow

This draft PR enables the CI pipeline. The Docker image creation is a separate effort — happy to work on that as well, or coordinate with the team.

### Evidence

- Arrow C++ native build on BananaPi F3 (SpacemiT K1, rv64gc, GCC 14.2.0): **SUCCESS** (1h13m)
- PyArrow install from source (Parquet, CSV, JSON, Compute, Filesystem): **SUCCESS**
- `import pyarrow; print(pyarrow.__version__)` → `24.0.0a1.dev1`

### CI Runners

Native riscv64 runners are available for free via [RISE RISC-V runners](https://github.com/apps/rise-risc-v-runners). numpy, llama.cpp, and pytorch already use them.

Fixes #49555

Note: this work is part of the [RISE Project](https://riseproject.dev/) effort to improve Python ecosystem support on riscv64 platforms.
* GitHub Issue: #49555