### PR TITLE
GH-47685: [Docs][Python] Add nested grouping to Python docs TOC

### DIFF
--- a/docs/source/python/data_and_compute.rst
+++ b/docs/source/python/data_and_compute.rst
@@ -1,0 +1,27 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+.. or more contributor license agreements.  See the NOTICE file
+.. distributed with this work for additional information
+.. regarding copyright ownership.  The ASF licenses this file
+.. to you under the Apache License, Version 2.0 (the
+.. "License"); you may not use this file except in compliance
+.. with the License.  You may obtain a copy of the License at
+
+..   http://www.apache.org/licenses/LICENSE-2.0
+
+.. Unless required by applicable law or agreed to in writing,
+.. software distributed under the License is distributed on an
+.. "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+.. KIND, either express or implied.  See the License for the
+.. specific language governing permissions and limitations
+.. under the License.
+
+Data and Compute
+================
+
+.. toctree::
+   :maxdepth: 2
+
+   data
+   compute
+   memory
+   timestamps

--- a/docs/source/python/data_interchange.rst
+++ b/docs/source/python/data_interchange.rst
@@ -1,0 +1,28 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+.. or more contributor license agreements.  See the NOTICE file
+.. distributed with this work for additional information
+.. regarding copyright ownership.  The ASF licenses this file
+.. to you under the Apache License, Version 2.0 (the
+.. "License"); you may not use this file except in compliance
+.. with the License.  You may obtain a copy of the License at
+
+..   http://www.apache.org/licenses/LICENSE-2.0
+
+.. Unless required by applicable law or agreed to in writing,
+.. software distributed under the License is distributed on an
+.. "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+.. KIND, either express or implied.  See the License for the
+.. specific language governing permissions and limitations
+.. under the License.
+
+Data Interchange
+================
+
+.. toctree::
+   :maxdepth: 2
+
+   numpy
+   pandas
+   interchange_protocol
+   dlpack
+   extending_types

--- a/docs/source/python/file_formats.rst
+++ b/docs/source/python/file_formats.rst
@@ -1,0 +1,32 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+.. or more contributor license agreements.  See the NOTICE file
+.. distributed with this work for additional information
+.. regarding copyright ownership.  The ASF licenses this file
+.. to you under the Apache License, Version 2.0 (the
+.. "License"); you may not use this file except in compliance
+.. with the License.  You may obtain a copy of the License at
+
+..   http://www.apache.org/licenses/LICENSE-2.0
+
+.. Unless required by applicable law or agreed to in writing,
+.. software distributed under the License is distributed on an
+.. "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+.. KIND, either express or implied.  See the License for the
+.. specific language governing permissions and limitations
+.. under the License.
+
+File Formats and I/O
+=====================
+
+.. toctree::
+   :maxdepth: 2
+
+   ipc
+   filesystems
+   csv
+   feather
+   json
+   orc
+   parquet
+   dataset
+   flight

--- a/docs/source/python/getting_started_guide.rst
+++ b/docs/source/python/getting_started_guide.rst
@@ -1,0 +1,25 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+.. or more contributor license agreements.  See the NOTICE file
+.. distributed with this work for additional information
+.. regarding copyright ownership.  The ASF licenses this file
+.. to you under the Apache License, Version 2.0 (the
+.. "License"); you may not use this file except in compliance
+.. with the License.  You may obtain a copy of the License at
+
+..   http://www.apache.org/licenses/LICENSE-2.0
+
+.. Unless required by applicable law or agreed to in writing,
+.. software distributed under the License is distributed on an
+.. "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+.. KIND, either express or implied.  See the License for the
+.. specific language governing permissions and limitations
+.. under the License.
+
+Getting Started
+===============
+
+.. toctree::
+   :maxdepth: 2
+
+   install
+   getstarted

--- a/docs/source/python/index.rst
+++ b/docs/source/python/index.rst
@@ -41,30 +41,13 @@ libraries that add additional functionality such as reading Apache Parquet
 files into Arrow structures.
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 3
 
-   install
-   getstarted
-   data
-   compute
-   memory
-   ipc
-   filesystems
-   numpy
-   pandas
-   interchange_protocol
-   dlpack
-   timestamps
-   orc
-   csv
-   feather
-   json
-   parquet
-   dataset
-   flight
-   extending_types
+   getting_started_guide
+   data_and_compute
+   file_formats
+   data_interchange
    integration
-   env_vars
-   api
+   reference
    getting_involved
    Python cookbook <https://arrow.apache.org/cookbook/py/>

--- a/docs/source/python/reference.rst
+++ b/docs/source/python/reference.rst
@@ -1,0 +1,25 @@
+.. Licensed to the Apache Software Foundation (ASF) under one
+.. or more contributor license agreements.  See the NOTICE file
+.. distributed with this work for additional information
+.. regarding copyright ownership.  The ASF licenses this file
+.. to you under the Apache License, Version 2.0 (the
+.. "License"); you may not use this file except in compliance
+.. with the License.  You may obtain a copy of the License at
+
+..   http://www.apache.org/licenses/LICENSE-2.0
+
+.. Unless required by applicable law or agreed to in writing,
+.. software distributed under the License is distributed on an
+.. "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+.. KIND, either express or implied.  See the License for the
+.. specific language governing permissions and limitations
+.. under the License.
+
+Reference
+=========
+
+.. toctree::
+   :maxdepth: 2
+
+   env_vars
+   api


### PR DESCRIPTION
### Rationale for this change

The left-hand sidebar menu for the Python docs lists 22+ entries in a flat structure, making it hard to skim and navigate. The C++ docs already use nested toctree groupings (Getting Started, User Guide, etc.) which makes the sidebar much more scannable. This was requested in #47685.

Closes #47685

### What changes are included in this PR?

- Created 5 new intermediate grouping pages that organize the flat toctree into logical sections:
  - **Getting Started**: install, getstarted
  - **Data and Compute**: data, compute, memory, timestamps
  - **File Formats and I/O**: ipc, filesystems, csv, feather, json, orc, parquet, dataset, flight
  - **Data Interchange**: numpy, pandas, interchange_protocol, dlpack, extending_types
  - **Reference**: env_vars, api
- Updated `index.rst` to reference the grouping pages and set `maxdepth: 3` so the sidebar shows the nested structure
- The existing `integration.rst` and `getting_involved` entries are reused as-is

### Are these changes tested?

Documentation-only change. Can be verified by building the docs with Sphinx.

### Are there any user-facing changes?

Yes — the Python docs sidebar navigation will show grouped sections instead of a flat list, improving discoverability.
* GitHub Issue: #47685