### PR TITLE
GH-49561: [C++][FlightRPC][ODBC] Use SQLWCHAR array for wide string literals in test suite

### DIFF
--- a/cpp/src/arrow/flight/sql/odbc/odbc_impl/encoding_utils.h
+++ b/cpp/src/arrow/flight/sql/odbc/odbc_impl/encoding_utils.h
@@ -31,6 +31,7 @@
 #define _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING
 
 namespace ODBC {
+using arrow::flight::sql::odbc::WcsToUtf8;
 
 // Return the number of bytes required for the conversion.
 template <typename CHAR_TYPE>
@@ -95,6 +96,24 @@ inline std::string SqlWcharToString(SQLWCHAR* wchar_msg, SQLINTEGER msg_len = SQ
   } else {
     arrow::flight::sql::odbc::WcsToUtf8((void*)wchar_msg, msg_len, &utf8_str);
   }
+
+  return std::string(utf8_str.begin(), utf8_str.end());
+}
+
+/// \brief Convert vector of SqlWchar to standard string
+/// \param[in] wchar_vec SqlWchar vector to convert
+/// \return wchar_vec in std::string format
+inline std::string SqlWcharToString(const std::vector<SQLWCHAR>& wchar_vec) {
+  if (wchar_vec.empty() || wchar_vec[0] == 0) {
+    return {};
+  }
+
+  auto end = std::find(wchar_vec.begin(), wchar_vec.end(), 0);
+  size_t actual_len = std::distance(wchar_vec.begin(), end);
+
+  thread_local std::vector<uint8_t> utf8_str;
+
+  WcsToUtf8((void*)wchar_vec.data(), static_cast<SQLINTEGER>(actual_len), &utf8_str);
 
   return std::string(utf8_str.begin(), utf8_str.end());
 }

--- a/cpp/src/arrow/flight/sql/odbc/tests/columns_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/columns_test.cc
@@ -127,12 +127,12 @@ void CheckRemoteSQLColumns(
 }
 
 void CheckSQLColAttribute(SQLHSTMT stmt, SQLUSMALLINT idx,
-                          const std::wstring& expected_column_name,
+                          const std::string& expected_column_name,
                           SQLLEN expected_data_type, SQLLEN expected_concise_type,
                           SQLLEN expected_display_size, SQLLEN expected_prec_scale,
                           SQLLEN expected_length,
-                          const std::wstring& expected_literal_prefix,
-                          const std::wstring& expected_literal_suffix,
+                          const std::string& expected_literal_prefix,
+                          const std::string& expected_literal_suffix,
                           SQLLEN expected_column_size, SQLLEN expected_column_scale,
                           SQLLEN expected_column_nullability,
                           SQLLEN expected_num_prec_radix, SQLLEN expected_octet_length,
@@ -215,10 +215,10 @@ void CheckSQLColAttribute(SQLHSTMT stmt, SQLUSMALLINT idx,
   EXPECT_EQ(SQL_SUCCESS,
             SQLColAttribute(stmt, idx, SQL_DESC_UNSIGNED, 0, 0, nullptr, &unsigned_col));
 
-  std::wstring name_str = ConvertToWString(name, name_len);
-  std::wstring base_column_name_str = ConvertToWString(base_column_name, column_name_len);
-  std::wstring label_str = ConvertToWString(label, label_len);
-  std::wstring prefixStr = ConvertToWString(prefix, prefix_len);
+  std::string name_str = ODBC::SqlWcharToString(name);
+  std::string base_column_name_str = ODBC::SqlWcharToString(base_column_name);
+  std::string label_str = ODBC::SqlWcharToString(label);
+  std::string prefix_str = ODBC::SqlWcharToString(prefix);
 
   // Assume column name, base column name, and label are equivalent in the result set
   EXPECT_EQ(expected_column_name, name_str);
@@ -229,7 +229,7 @@ void CheckSQLColAttribute(SQLHSTMT stmt, SQLUSMALLINT idx,
   EXPECT_EQ(expected_display_size, display_size);
   EXPECT_EQ(expected_prec_scale, prec_scale);
   EXPECT_EQ(expected_length, length);
-  EXPECT_EQ(expected_literal_prefix, prefixStr);
+  EXPECT_EQ(expected_literal_prefix, prefix_str);
   EXPECT_EQ(expected_column_size, size);
   EXPECT_EQ(expected_column_scale, scale);
   EXPECT_EQ(expected_column_nullability, nullability);
@@ -241,7 +241,7 @@ void CheckSQLColAttribute(SQLHSTMT stmt, SQLUSMALLINT idx,
 
 #ifndef __APPLE__
 void CheckSQLColAttributes(SQLHSTMT stmt, SQLUSMALLINT idx,
-                           const std::wstring& expected_column_name,
+                           const std::string& expected_column_name,
                            SQLLEN expected_data_type, SQLLEN expected_display_size,
                            SQLLEN expected_prec_scale, SQLLEN expected_length,
                            SQLLEN expected_column_size, SQLLEN expected_column_scale,
@@ -295,8 +295,8 @@ void CheckSQLColAttributes(SQLHSTMT stmt, SQLUSMALLINT idx,
   EXPECT_EQ(SQL_SUCCESS, SQLColAttributes(stmt, idx, SQL_COLUMN_UNSIGNED, 0, 0, nullptr,
                                           &unsigned_col));
 
-  std::wstring name_str = ConvertToWString(name, name_len);
-  std::wstring label_str = ConvertToWString(label, label_len);
+  std::string name_str = ODBC::SqlWcharToString(name);
+  std::string label_str = ODBC::SqlWcharToString(label);
 
   EXPECT_EQ(expected_column_name, name_str);
   EXPECT_EQ(expected_column_name, label_str);
@@ -326,8 +326,9 @@ void GetSQLColAttributeString(SQLHSTMT stmt, const std::wstring& wsql, SQLUSMALL
   std::vector<SQLWCHAR> str_val(kOdbcBufferSize);
   SQLSMALLINT str_len = 0;
 
-  ASSERT_EQ(SQL_SUCCESS, SQLColAttribute(stmt, idx, field_identifier, &str_val[0],
-                                         (SQLSMALLINT)str_val.size(), &str_len, nullptr));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLColAttribute(stmt, idx, field_identifier, &str_val[0],
+                            static_cast<SQLSMALLINT>(str_val.size()), &str_len, nullptr));
 
   value = ConvertToWString(str_val, str_len);
 }
@@ -347,9 +348,9 @@ void GetSQLColAttributesString(SQLHSTMT stmt, const std::wstring& wsql, SQLUSMAL
   std::vector<SQLWCHAR> str_val(kOdbcBufferSize);
   SQLSMALLINT str_len = 0;
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLColAttributes(stmt, idx, field_identifier, &str_val[0],
-                             (SQLSMALLINT)str_val.size(), &str_len, nullptr));
+  ASSERT_EQ(SQL_SUCCESS, SQLColAttributes(stmt, idx, field_identifier, &str_val[0],
+                                          static_cast<SQLSMALLINT>(str_val.size()),
+                                          &str_len, nullptr));
 
   value = ConvertToWString(str_val, str_len);
 }
@@ -1223,24 +1224,23 @@ TEST_F(ColumnsMockTest, TestSQLColumnsInvalidTablePattern) {
 }
 
 TYPED_TEST(ColumnsTest, SQLColAttributeTestInputData) {
-  std::wstring wsql = L"SELECT 1 as col1;";
-  std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
+  SQLWCHAR wsql[] = L"SELECT 1 as col1;";
+  SQLSMALLINT wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())))
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len))
       << GetOdbcErrorMessage(SQL_HANDLE_DBC, conn);
 
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   SQLUSMALLINT idx = 1;
-  std::vector<SQLWCHAR> character_attr(kOdbcBufferSize);
+  SQLWCHAR character_attr[kOdbcBufferSize];
   SQLSMALLINT character_attr_len = 0;
   SQLLEN numeric_attr = 0;
 
   // All character values populated
-  EXPECT_EQ(SQL_SUCCESS, SQLColAttribute(stmt, idx, SQL_DESC_NAME, &character_attr[0],
-                                         (SQLSMALLINT)character_attr.size(),
-                                         &character_attr_len, nullptr));
+  EXPECT_EQ(SQL_SUCCESS,
+            SQLColAttribute(stmt, idx, SQL_DESC_NAME, character_attr,
+                            std::wcslen(character_attr), &character_attr_len, nullptr));
 
   // All numeric values populated
   EXPECT_EQ(SQL_SUCCESS,
@@ -1255,11 +1255,10 @@ TYPED_TEST(ColumnsTest, SQLColAttributeTestInputData) {
 }
 
 TYPED_TEST(ColumnsTest, SQLColAttributeGetCharacterLen) {
-  std::wstring wsql = L"SELECT 1 as col1;";
-  std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
+  SQLWCHAR wsql[] = L"SELECT 1 as col1;";
+  SQLSMALLINT wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
 
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
@@ -1272,44 +1271,41 @@ TYPED_TEST(ColumnsTest, SQLColAttributeGetCharacterLen) {
 }
 
 TYPED_TEST(ColumnsTest, SQLColAttributeInvalidFieldId) {
-  std::wstring wsql = L"SELECT 1 as col1;";
-  std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
+  SQLWCHAR wsql[] = L"SELECT 1 as col1;";
+  SQLSMALLINT wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
 
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   SQLUSMALLINT invalid_field_id = -100;
   SQLUSMALLINT idx = 1;
-  std::vector<SQLWCHAR> character_attr(kOdbcBufferSize);
+  SQLWCHAR character_attr[kOdbcBufferSize];
   SQLSMALLINT character_attr_len = 0;
   SQLLEN numeric_attr = 0;
 
-  ASSERT_EQ(SQL_ERROR, SQLColAttribute(stmt, idx, invalid_field_id, &character_attr[0],
-                                       (SQLSMALLINT)character_attr.size(),
-                                       &character_attr_len, nullptr));
+  ASSERT_EQ(SQL_ERROR,
+            SQLColAttribute(stmt, idx, invalid_field_id, character_attr,
+                            std::wcslen(character_attr), &character_attr_len, nullptr));
   // Verify invalid descriptor field identifier error state is returned
   VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorStateHY091);
 }
 
 TYPED_TEST(ColumnsTest, SQLColAttributeInvalidColId) {
-  std::wstring wsql = L"SELECT 1 as col1;";
-  std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
+  SQLWCHAR wsql[] = L"SELECT 1 as col1;";
+  SQLSMALLINT wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
 
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   SQLUSMALLINT invalid_col_id = 2;
-  std::vector<SQLWCHAR> character_attr(kOdbcBufferSize);
+  SQLWCHAR character_attr[kOdbcBufferSize];
   SQLSMALLINT character_attr_len = 0;
 
-  ASSERT_EQ(
-      SQL_ERROR,
-      SQLColAttribute(stmt, invalid_col_id, SQL_DESC_BASE_COLUMN_NAME, &character_attr[0],
-                      (SQLSMALLINT)character_attr.size(), &character_attr_len, nullptr));
+  ASSERT_EQ(SQL_ERROR, SQLColAttribute(stmt, invalid_col_id, SQL_DESC_BASE_COLUMN_NAME,
+                                       character_attr, std::wcslen(character_attr),
+                                       &character_attr_len, nullptr));
   // Verify invalid descriptor index error state is returned
   VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorState07009);
 }
@@ -1317,81 +1313,80 @@ TYPED_TEST(ColumnsTest, SQLColAttributeInvalidColId) {
 TEST_F(ColumnsMockTest, TestSQLColAttributeAllTypes) {
   CreateAllDataTypeTable();
 
-  std::wstring wsql = L"SELECT * from AllTypesTable;";
-  std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
+  SQLWCHAR wsql[] = L"SELECT * from AllTypesTable;";
+  SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
 
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   CheckSQLColAttribute(stmt, 1,
-                       std::wstring(L"bigint_col"),  // expected_column_name
-                       SQL_BIGINT,                   // expected_data_type
-                       SQL_BIGINT,                   // expected_concise_type
-                       20,                           // expected_display_size
-                       SQL_FALSE,                    // expected_prec_scale
-                       8,                            // expected_length
-                       std::wstring(L""),            // expected_literal_prefix
-                       std::wstring(L""),            // expected_literal_suffix
-                       8,                            // expected_column_size
-                       0,                            // expected_column_scale
-                       SQL_NULLABLE,                 // expected_column_nullability
-                       10,                           // expected_num_prec_radix
-                       8,                            // expected_octet_length
-                       SQL_PRED_NONE,                // expected_searchable
-                       SQL_FALSE);                   // expected_unsigned_column
+                       "bigint_col",   // expected_column_name
+                       SQL_BIGINT,     // expected_data_type
+                       SQL_BIGINT,     // expected_concise_type
+                       20,             // expected_display_size
+                       SQL_FALSE,      // expected_prec_scale
+                       8,              // expected_length
+                       "",             // expected_literal_prefix
+                       "",             // expected_literal_suffix
+                       8,              // expected_column_size
+                       0,              // expected_column_scale
+                       SQL_NULLABLE,   // expected_column_nullability
+                       10,             // expected_num_prec_radix
+                       8,              // expected_octet_length
+                       SQL_PRED_NONE,  // expected_searchable
+                       SQL_FALSE);     // expected_unsigned_column
 
   CheckSQLColAttribute(stmt, 2,
-                       std::wstring(L"char_col"),  // expected_column_name
-                       SQL_WVARCHAR,               // expected_data_type
-                       SQL_WVARCHAR,               // expected_concise_type
-                       0,                          // expected_display_size
-                       SQL_FALSE,                  // expected_prec_scale
-                       0,                          // expected_length
-                       std::wstring(L""),          // expected_literal_prefix
-                       std::wstring(L""),          // expected_literal_suffix
-                       0,                          // expected_column_size
-                       0,                          // expected_column_scale
-                       SQL_NULLABLE,               // expected_column_nullability
-                       0,                          // expected_num_prec_radix
-                       0,                          // expected_octet_length
-                       SQL_PRED_NONE,              // expected_searchable
-                       SQL_TRUE);                  // expected_unsigned_column
+                       "char_col",     // expected_column_name
+                       SQL_WVARCHAR,   // expected_data_type
+                       SQL_WVARCHAR,   // expected_concise_type
+                       0,              // expected_display_size
+                       SQL_FALSE,      // expected_prec_scale
+                       0,              // expected_length
+                       "",             // expected_literal_prefix
+                       "",             // expected_literal_suffix
+                       0,              // expected_column_size
+                       0,              // expected_column_scale
+                       SQL_NULLABLE,   // expected_column_nullability
+                       0,              // expected_num_prec_radix
+                       0,              // expected_octet_length
+                       SQL_PRED_NONE,  // expected_searchable
+                       SQL_TRUE);      // expected_unsigned_column
 
   CheckSQLColAttribute(stmt, 3,
-                       std::wstring(L"varbinary_col"),  // expected_column_name
-                       SQL_BINARY,                      // expected_data_type
-                       SQL_BINARY,                      // expected_concise_type
-                       0,                               // expected_display_size
-                       SQL_FALSE,                       // expected_prec_scale
-                       0,                               // expected_length
-                       std::wstring(L""),               // expected_literal_prefix
-                       std::wstring(L""),               // expected_literal_suffix
-                       0,                               // expected_column_size
-                       0,                               // expected_column_scale
-                       SQL_NULLABLE,                    // expected_column_nullability
-                       0,                               // expected_num_prec_radix
-                       0,                               // expected_octet_length
-                       SQL_PRED_NONE,                   // expected_searchable
-                       SQL_TRUE);                       // expected_unsigned_column
+                       "varbinary_col",  // expected_column_name
+                       SQL_BINARY,       // expected_data_type
+                       SQL_BINARY,       // expected_concise_type
+                       0,                // expected_display_size
+                       SQL_FALSE,        // expected_prec_scale
+                       0,                // expected_length
+                       "",               // expected_literal_prefix
+                       "",               // expected_literal_suffix
+                       0,                // expected_column_size
+                       0,                // expected_column_scale
+                       SQL_NULLABLE,     // expected_column_nullability
+                       0,                // expected_num_prec_radix
+                       0,                // expected_octet_length
+                       SQL_PRED_NONE,    // expected_searchable
+                       SQL_TRUE);        // expected_unsigned_column
 
   CheckSQLColAttribute(stmt, 4,
-                       std::wstring(L"double_col"),  // expected_column_name
-                       SQL_DOUBLE,                   // expected_data_type
-                       SQL_DOUBLE,                   // expected_concise_type
-                       24,                           // expected_display_size
-                       SQL_FALSE,                    // expected_prec_scale
-                       8,                            // expected_length
-                       std::wstring(L""),            // expected_literal_prefix
-                       std::wstring(L""),            // expected_literal_suffix
-                       8,                            // expected_column_size
-                       0,                            // expected_column_scale
-                       SQL_NULLABLE,                 // expected_column_nullability
-                       2,                            // expected_num_prec_radix
-                       8,                            // expected_octet_length
-                       SQL_PRED_NONE,                // expected_searchable
-                       SQL_FALSE);                   // expected_unsigned_column
+                       "double_col",   // expected_column_name
+                       SQL_DOUBLE,     // expected_data_type
+                       SQL_DOUBLE,     // expected_concise_type
+                       24,             // expected_display_size
+                       SQL_FALSE,      // expected_prec_scale
+                       8,              // expected_length
+                       "",             // expected_literal_prefix
+                       "",             // expected_literal_suffix
+                       8,              // expected_column_size
+                       0,              // expected_column_scale
+                       SQL_NULLABLE,   // expected_column_nullability
+                       2,              // expected_num_prec_radix
+                       8,              // expected_octet_length
+                       SQL_PRED_NONE,  // expected_searchable
+                       SQL_FALSE);     // expected_unsigned_column
 
   DropAllDataTypeTable();
 }
@@ -1402,60 +1397,59 @@ TEST_F(ColumnsOdbcV2MockTest, TestSQLColAttributesAllTypes) {
   // Tests ODBC 2.0 API SQLColAttributes
   CreateAllDataTypeTable();
 
-  std::wstring wsql = L"SELECT * from AllTypesTable;";
-  std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
+  SQLWCHAR wsql[] = L"SELECT * from AllTypesTable;";
+  SQLSMALLINT wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
 
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
   CheckSQLColAttributes(stmt, 1,
-                        std::wstring(L"bigint_col"),  // expected_column_name
-                        SQL_BIGINT,                   // expected_data_type
-                        20,                           // expected_display_size
-                        SQL_FALSE,                    // expected_prec_scale
-                        8,                            // expected_length
-                        8,                            // expected_column_size
-                        0,                            // expected_column_scale
-                        SQL_NULLABLE,                 // expected_column_nullability
-                        SQL_PRED_NONE,                // expected_searchable
-                        SQL_FALSE);                   // expected_unsigned_column
+                        "bigint_col",   // expected_column_name
+                        SQL_BIGINT,     // expected_data_type
+                        20,             // expected_display_size
+                        SQL_FALSE,      // expected_prec_scale
+                        8,              // expected_length
+                        8,              // expected_column_size
+                        0,              // expected_column_scale
+                        SQL_NULLABLE,   // expected_column_nullability
+                        SQL_PRED_NONE,  // expected_searchable
+                        SQL_FALSE);     // expected_unsigned_column
 
   CheckSQLColAttributes(stmt, 2,
-                        std::wstring(L"char_col"),  // expected_column_name
-                        SQL_WVARCHAR,               // expected_data_type
-                        0,                          // expected_display_size
-                        SQL_FALSE,                  // expected_prec_scale
-                        0,                          // expected_length
-                        0,                          // expected_column_size
-                        0,                          // expected_column_scale
-                        SQL_NULLABLE,               // expected_column_nullability
-                        SQL_PRED_NONE,              // expected_searchable
-                        SQL_TRUE);                  // expected_unsigned_column
+                        "char_col",     // expected_column_name
+                        SQL_WVARCHAR,   // expected_data_type
+                        0,              // expected_display_size
+                        SQL_FALSE,      // expected_prec_scale
+                        0,              // expected_length
+                        0,              // expected_column_size
+                        0,              // expected_column_scale
+                        SQL_NULLABLE,   // expected_column_nullability
+                        SQL_PRED_NONE,  // expected_searchable
+                        SQL_TRUE);      // expected_unsigned_column
 
   CheckSQLColAttributes(stmt, 3,
-                        std::wstring(L"varbinary_col"),  // expected_column_name
-                        SQL_BINARY,                      // expected_data_type
-                        0,                               // expected_display_size
-                        SQL_FALSE,                       // expected_prec_scale
-                        0,                               // expected_length
-                        0,                               // expected_column_size
-                        0,                               // expected_column_scale
-                        SQL_NULLABLE,                    // expected_column_nullability
-                        SQL_PRED_NONE,                   // expected_searchable
-                        SQL_TRUE);                       // expected_unsigned_column
+                        "varbinary_col",  // expected_column_name
+                        SQL_BINARY,       // expected_data_type
+                        0,                // expected_display_size
+                        SQL_FALSE,        // expected_prec_scale
+                        0,                // expected_length
+                        0,                // expected_column_size
+                        0,                // expected_column_scale
+                        SQL_NULLABLE,     // expected_column_nullability
+                        SQL_PRED_NONE,    // expected_searchable
+                        SQL_TRUE);        // expected_unsigned_column
 
   CheckSQLColAttributes(stmt, 4,
-                        std::wstring(L"double_col"),  // expected_column_name
-                        SQL_DOUBLE,                   // expected_data_type
-                        24,                           // expected_display_size
-                        SQL_FALSE,                    // expected_prec_scale
-                        8,                            // expected_length
-                        8,                            // expected_column_size
-                        0,                            // expected_column_scale
-                        SQL_NULLABLE,                 // expected_column_nullability
-                        SQL_PRED_NONE,                // expected_searchable
-                        SQL_FALSE);                   // expected_unsigned_column
+                        "double_col",   // expected_column_name
+                        SQL_DOUBLE,     // expected_data_type
+                        24,             // expected_display_size
+                        SQL_FALSE,      // expected_prec_scale
+                        8,              // expected_length
+                        8,              // expected_column_size
+                        0,              // expected_column_scale
+                        SQL_NULLABLE,   // expected_column_nullability
+                        SQL_PRED_NONE,  // expected_searchable
+                        SQL_FALSE);     // expected_unsigned_column
 
   DropAllDataTypeTable();
 }
@@ -1464,453 +1458,450 @@ TEST_F(ColumnsOdbcV2MockTest, TestSQLColAttributesAllTypes) {
 TEST_F(ColumnsRemoteTest, TestSQLColAttributeAllTypes) {
   // Test assumes there is a table $scratch.ODBCTest in remote server
 
-  std::wstring wsql = L"SELECT * from $scratch.ODBCTest;";
-  std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
+  SQLWCHAR wsql[] = L"SELECT * from $scratch.ODBCTest;";
+  SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
 
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   CheckSQLColAttribute(stmt, 1,
-                       std::wstring(L"sinteger_max"),  // expected_column_name
-                       SQL_INTEGER,                    // expected_data_type
-                       SQL_INTEGER,                    // expected_concise_type
-                       11,                             // expected_display_size
-                       SQL_FALSE,                      // expected_prec_scale
-                       4,                              // expected_length
-                       std::wstring(L""),              // expected_literal_prefix
-                       std::wstring(L""),              // expected_literal_suffix
-                       4,                              // expected_column_size
-                       0,                              // expected_column_scale
-                       SQL_NULLABLE,                   // expected_column_nullability
-                       10,                             // expected_num_prec_radix
-                       4,                              // expected_octet_length
-                       SQL_SEARCHABLE,                 // expected_searchable
-                       SQL_FALSE);                     // expected_unsigned_column
+                       "sinteger_max",  // expected_column_name
+                       SQL_INTEGER,     // expected_data_type
+                       SQL_INTEGER,     // expected_concise_type
+                       11,              // expected_display_size
+                       SQL_FALSE,       // expected_prec_scale
+                       4,               // expected_length
+                       "",              // expected_literal_prefix
+                       "",              // expected_literal_suffix
+                       4,               // expected_column_size
+                       0,               // expected_column_scale
+                       SQL_NULLABLE,    // expected_column_nullability
+                       10,              // expected_num_prec_radix
+                       4,               // expected_octet_length
+                       SQL_SEARCHABLE,  // expected_searchable
+                       SQL_FALSE);      // expected_unsigned_column
 
   CheckSQLColAttribute(stmt, 2,
-                       std::wstring(L"sbigint_max"),  // expected_column_name
-                       SQL_BIGINT,                    // expected_data_type
-                       SQL_BIGINT,                    // expected_concise_type
-                       20,                            // expected_display_size
-                       SQL_FALSE,                     // expected_prec_scale
-                       8,                             // expected_length
-                       std::wstring(L""),             // expected_literal_prefix
-                       std::wstring(L""),             // expected_literal_suffix
-                       8,                             // expected_column_size
-                       0,                             // expected_column_scale
-                       SQL_NULLABLE,                  // expected_column_nullability
-                       10,                            // expected_num_prec_radix
-                       8,                             // expected_octet_length
-                       SQL_SEARCHABLE,                // expected_searchable
-                       SQL_FALSE);                    // expected_unsigned_column
+                       "sbigint_max",   // expected_column_name
+                       SQL_BIGINT,      // expected_data_type
+                       SQL_BIGINT,      // expected_concise_type
+                       20,              // expected_display_size
+                       SQL_FALSE,       // expected_prec_scale
+                       8,               // expected_length
+                       "",              // expected_literal_prefix
+                       "",              // expected_literal_suffix
+                       8,               // expected_column_size
+                       0,               // expected_column_scale
+                       SQL_NULLABLE,    // expected_column_nullability
+                       10,              // expected_num_prec_radix
+                       8,               // expected_octet_length
+                       SQL_SEARCHABLE,  // expected_searchable
+                       SQL_FALSE);      // expected_unsigned_column
 
   CheckSQLColAttribute(stmt, 3,
-                       std::wstring(L"decimal_positive"),  // expected_column_name
-                       SQL_DECIMAL,                        // expected_data_type
-                       SQL_DECIMAL,                        // expected_concise_type
-                       40,                                 // expected_display_size
-                       SQL_FALSE,                          // expected_prec_scale
-                       19,                                 // expected_length
-                       std::wstring(L""),                  // expected_literal_prefix
-                       std::wstring(L""),                  // expected_literal_suffix
-                       19,                                 // expected_column_size
-                       0,                                  // expected_column_scale
-                       SQL_NULLABLE,                       // expected_column_nullability
-                       10,                                 // expected_num_prec_radix
-                       40,                                 // expected_octet_length
-                       SQL_SEARCHABLE,                     // expected_searchable
-                       SQL_FALSE);                         // expected_unsigned_column
+                       "decimal_positive",  // expected_column_name
+                       SQL_DECIMAL,         // expected_data_type
+                       SQL_DECIMAL,         // expected_concise_type
+                       40,                  // expected_display_size
+                       SQL_FALSE,           // expected_prec_scale
+                       19,                  // expected_length
+                       "",                  // expected_literal_prefix
+                       "",                  // expected_literal_suffix
+                       19,                  // expected_column_size
+                       0,                   // expected_column_scale
+                       SQL_NULLABLE,        // expected_column_nullability
+                       10,                  // expected_num_prec_radix
+                       40,                  // expected_octet_length
+                       SQL_SEARCHABLE,      // expected_searchable
+                       SQL_FALSE);          // expected_unsigned_column
 
   CheckSQLColAttribute(stmt, 4,
-                       std::wstring(L"float_max"),  // expected_column_name
-                       SQL_FLOAT,                   // expected_data_type
-                       SQL_FLOAT,                   // expected_concise_type
-                       24,                          // expected_display_size
-                       SQL_FALSE,                   // expected_prec_scale
-                       8,                           // expected_length
-                       std::wstring(L""),           // expected_literal_prefix
-                       std::wstring(L""),           // expected_literal_suffix
-                       8,                           // expected_column_size
-                       0,                           // expected_column_scale
-                       SQL_NULLABLE,                // expected_column_nullability
-                       2,                           // expected_num_prec_radix
-                       8,                           // expected_octet_length
-                       SQL_SEARCHABLE,              // expected_searchable
-                       SQL_FALSE);                  // expected_unsigned_column
+                       "float_max",     // expected_column_name
+                       SQL_FLOAT,       // expected_data_type
+                       SQL_FLOAT,       // expected_concise_type
+                       24,              // expected_display_size
+                       SQL_FALSE,       // expected_prec_scale
+                       8,               // expected_length
+                       "",              // expected_literal_prefix
+                       "",              // expected_literal_suffix
+                       8,               // expected_column_size
+                       0,               // expected_column_scale
+                       SQL_NULLABLE,    // expected_column_nullability
+                       2,               // expected_num_prec_radix
+                       8,               // expected_octet_length
+                       SQL_SEARCHABLE,  // expected_searchable
+                       SQL_FALSE);      // expected_unsigned_column
 
   CheckSQLColAttribute(stmt, 5,
-                       std::wstring(L"double_max"),  // expected_column_name
-                       SQL_DOUBLE,                   // expected_data_type
-                       SQL_DOUBLE,                   // expected_concise_type
-                       24,                           // expected_display_size
-                       SQL_FALSE,                    // expected_prec_scale
-                       8,                            // expected_length
-                       std::wstring(L""),            // expected_literal_prefix
-                       std::wstring(L""),            // expected_literal_suffix
-                       8,                            // expected_column_size
-                       0,                            // expected_column_scale
-                       SQL_NULLABLE,                 // expected_column_nullability
-                       2,                            // expected_num_prec_radix
-                       8,                            // expected_octet_length
-                       SQL_SEARCHABLE,               // expected_searchable
-                       SQL_FALSE);                   // expected_unsigned_column
+                       "double_max",    // expected_column_name
+                       SQL_DOUBLE,      // expected_data_type
+                       SQL_DOUBLE,      // expected_concise_type
+                       24,              // expected_display_size
+                       SQL_FALSE,       // expected_prec_scale
+                       8,               // expected_length
+                       "",              // expected_literal_prefix
+                       "",              // expected_literal_suffix
+                       8,               // expected_column_size
+                       0,               // expected_column_scale
+                       SQL_NULLABLE,    // expected_column_nullability
+                       2,               // expected_num_prec_radix
+                       8,               // expected_octet_length
+                       SQL_SEARCHABLE,  // expected_searchable
+                       SQL_FALSE);      // expected_unsigned_column
 
   CheckSQLColAttribute(stmt, 6,
-                       std::wstring(L"bit_true"),  // expected_column_name
-                       SQL_BIT,                    // expected_data_type
-                       SQL_BIT,                    // expected_concise_type
-                       1,                          // expected_display_size
-                       SQL_FALSE,                  // expected_prec_scale
-                       1,                          // expected_length
-                       std::wstring(L""),          // expected_literal_prefix
-                       std::wstring(L""),          // expected_literal_suffix
-                       1,                          // expected_column_size
-                       0,                          // expected_column_scale
-                       SQL_NULLABLE,               // expected_column_nullability
-                       0,                          // expected_num_prec_radix
-                       1,                          // expected_octet_length
-                       SQL_SEARCHABLE,             // expected_searchable
-                       SQL_TRUE);                  // expected_unsigned_column
+                       "bit_true",      // expected_column_name
+                       SQL_BIT,         // expected_data_type
+                       SQL_BIT,         // expected_concise_type
+                       1,               // expected_display_size
+                       SQL_FALSE,       // expected_prec_scale
+                       1,               // expected_length
+                       "",              // expected_literal_prefix
+                       "",              // expected_literal_suffix
+                       1,               // expected_column_size
+                       0,               // expected_column_scale
+                       SQL_NULLABLE,    // expected_column_nullability
+                       0,               // expected_num_prec_radix
+                       1,               // expected_octet_length
+                       SQL_SEARCHABLE,  // expected_searchable
+                       SQL_TRUE);       // expected_unsigned_column
 
   CheckSQLColAttribute(stmt, 7,
-                       std::wstring(L"date_max"),  // expected_column_name
-                       SQL_DATETIME,               // expected_data_type
-                       SQL_TYPE_DATE,              // expected_concise_type
-                       10,                         // expected_display_size
-                       SQL_FALSE,                  // expected_prec_scale
-                       10,                         // expected_length
-                       std::wstring(L""),          // expected_literal_prefix
-                       std::wstring(L""),          // expected_literal_suffix
-                       10,                         // expected_column_size
-                       0,                          // expected_column_scale
-                       SQL_NULLABLE,               // expected_column_nullability
-                       0,                          // expected_num_prec_radix
-                       6,                          // expected_octet_length
-                       SQL_SEARCHABLE,             // expected_searchable
-                       SQL_TRUE);                  // expected_unsigned_column
+                       "date_max",      // expected_column_name
+                       SQL_DATETIME,    // expected_data_type
+                       SQL_TYPE_DATE,   // expected_concise_type
+                       10,              // expected_display_size
+                       SQL_FALSE,       // expected_prec_scale
+                       10,              // expected_length
+                       "",              // expected_literal_prefix
+                       "",              // expected_literal_suffix
+                       10,              // expected_column_size
+                       0,               // expected_column_scale
+                       SQL_NULLABLE,    // expected_column_nullability
+                       0,               // expected_num_prec_radix
+                       6,               // expected_octet_length
+                       SQL_SEARCHABLE,  // expected_searchable
+                       SQL_TRUE);       // expected_unsigned_column
 
   CheckSQLColAttribute(stmt, 8,
-                       std::wstring(L"time_max"),  // expected_column_name
-                       SQL_DATETIME,               // expected_data_type
-                       SQL_TYPE_TIME,              // expected_concise_type
-                       12,                         // expected_display_size
-                       SQL_FALSE,                  // expected_prec_scale
-                       12,                         // expected_length
-                       std::wstring(L""),          // expected_literal_prefix
-                       std::wstring(L""),          // expected_literal_suffix
-                       12,                         // expected_column_size
-                       3,                          // expected_column_scale
-                       SQL_NULLABLE,               // expected_column_nullability
-                       0,                          // expected_num_prec_radix
-                       6,                          // expected_octet_length
-                       SQL_SEARCHABLE,             // expected_searchable
-                       SQL_TRUE);                  // expected_unsigned_column
+                       "time_max",      // expected_column_name
+                       SQL_DATETIME,    // expected_data_type
+                       SQL_TYPE_TIME,   // expected_concise_type
+                       12,              // expected_display_size
+                       SQL_FALSE,       // expected_prec_scale
+                       12,              // expected_length
+                       "",              // expected_literal_prefix
+                       "",              // expected_literal_suffix
+                       12,              // expected_column_size
+                       3,               // expected_column_scale
+                       SQL_NULLABLE,    // expected_column_nullability
+                       0,               // expected_num_prec_radix
+                       6,               // expected_octet_length
+                       SQL_SEARCHABLE,  // expected_searchable
+                       SQL_TRUE);       // expected_unsigned_column
 
   CheckSQLColAttribute(stmt, 9,
-                       std::wstring(L"timestamp_max"),  // expected_column_name
-                       SQL_DATETIME,                    // expected_data_type
-                       SQL_TYPE_TIMESTAMP,              // expected_concise_type
-                       23,                              // expected_display_size
-                       SQL_FALSE,                       // expected_prec_scale
-                       23,                              // expected_length
-                       std::wstring(L""),               // expected_literal_prefix
-                       std::wstring(L""),               // expected_literal_suffix
-                       23,                              // expected_column_size
-                       3,                               // expected_column_scale
-                       SQL_NULLABLE,                    // expected_column_nullability
-                       0,                               // expected_num_prec_radix
-                       16,                              // expected_octet_length
-                       SQL_SEARCHABLE,                  // expected_searchable
-                       SQL_TRUE);                       // expected_unsigned_column
+                       "timestamp_max",     // expected_column_name
+                       SQL_DATETIME,        // expected_data_type
+                       SQL_TYPE_TIMESTAMP,  // expected_concise_type
+                       23,                  // expected_display_size
+                       SQL_FALSE,           // expected_prec_scale
+                       23,                  // expected_length
+                       "",                  // expected_literal_prefix
+                       "",                  // expected_literal_suffix
+                       23,                  // expected_column_size
+                       3,                   // expected_column_scale
+                       SQL_NULLABLE,        // expected_column_nullability
+                       0,                   // expected_num_prec_radix
+                       16,                  // expected_octet_length
+                       SQL_SEARCHABLE,      // expected_searchable
+                       SQL_TRUE);           // expected_unsigned_column
 }
 
 // iODBC does not support SQLColAttribute in ODBC 2.0 mode.
 #ifndef __APPLE__
 TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColAttributeAllTypes) {
   // Test assumes there is a table $scratch.ODBCTest in remote server
-  std::wstring wsql = L"SELECT * from $scratch.ODBCTest;";
-  std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
+  SQLWCHAR wsql[] = L"SELECT * from $scratch.ODBCTest;";
+  SQLSMALLINT wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
 
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   CheckSQLColAttribute(stmt, 1,
-                       std::wstring(L"sinteger_max"),  // expected_column_name
-                       SQL_INTEGER,                    // expected_data_type
-                       SQL_INTEGER,                    // expected_concise_type
-                       11,                             // expected_display_size
-                       SQL_FALSE,                      // expected_prec_scale
-                       4,                              // expected_length
-                       std::wstring(L""),              // expected_literal_prefix
-                       std::wstring(L""),              // expected_literal_suffix
-                       4,                              // expected_column_size
-                       0,                              // expected_column_scale
-                       SQL_NULLABLE,                   // expected_column_nullability
-                       10,                             // expected_num_prec_radix
-                       4,                              // expected_octet_length
-                       SQL_SEARCHABLE,                 // expected_searchable
-                       SQL_FALSE);                     // expected_unsigned_column
+                       "sinteger_max",  // expected_column_name
+                       SQL_INTEGER,     // expected_data_type
+                       SQL_INTEGER,     // expected_concise_type
+                       11,              // expected_display_size
+                       SQL_FALSE,       // expected_prec_scale
+                       4,               // expected_length
+                       "",              // expected_literal_prefix
+                       "",              // expected_literal_suffix
+                       4,               // expected_column_size
+                       0,               // expected_column_scale
+                       SQL_NULLABLE,    // expected_column_nullability
+                       10,              // expected_num_prec_radix
+                       4,               // expected_octet_length
+                       SQL_SEARCHABLE,  // expected_searchable
+                       SQL_FALSE);      // expected_unsigned_column
 
   CheckSQLColAttribute(stmt, 2,
-                       std::wstring(L"sbigint_max"),  // expected_column_name
-                       SQL_BIGINT,                    // expected_data_type
-                       SQL_BIGINT,                    // expected_concise_type
-                       20,                            // expected_display_size
-                       SQL_FALSE,                     // expected_prec_scale
-                       8,                             // expected_length
-                       std::wstring(L""),             // expected_literal_prefix
-                       std::wstring(L""),             // expected_literal_suffix
-                       8,                             // expected_column_size
-                       0,                             // expected_column_scale
-                       SQL_NULLABLE,                  // expected_column_nullability
-                       10,                            // expected_num_prec_radix
-                       8,                             // expected_octet_length
-                       SQL_SEARCHABLE,                // expected_searchable
-                       SQL_FALSE);                    // expected_unsigned_column
+                       "sbigint_max",   // expected_column_name
+                       SQL_BIGINT,      // expected_data_type
+                       SQL_BIGINT,      // expected_concise_type
+                       20,              // expected_display_size
+                       SQL_FALSE,       // expected_prec_scale
+                       8,               // expected_length
+                       "",              // expected_literal_prefix
+                       "",              // expected_literal_suffix
+                       8,               // expected_column_size
+                       0,               // expected_column_scale
+                       SQL_NULLABLE,    // expected_column_nullability
+                       10,              // expected_num_prec_radix
+                       8,               // expected_octet_length
+                       SQL_SEARCHABLE,  // expected_searchable
+                       SQL_FALSE);      // expected_unsigned_column
 
   CheckSQLColAttribute(stmt, 3,
-                       std::wstring(L"decimal_positive"),  // expected_column_name
-                       SQL_DECIMAL,                        // expected_data_type
-                       SQL_DECIMAL,                        // expected_concise_type
-                       40,                                 // expected_display_size
-                       SQL_FALSE,                          // expected_prec_scale
-                       19,                                 // expected_length
-                       std::wstring(L""),                  // expected_literal_prefix
-                       std::wstring(L""),                  // expected_literal_suffix
-                       19,                                 // expected_column_size
-                       0,                                  // expected_column_scale
-                       SQL_NULLABLE,                       // expected_column_nullability
-                       10,                                 // expected_num_prec_radix
-                       40,                                 // expected_octet_length
-                       SQL_SEARCHABLE,                     // expected_searchable
-                       SQL_FALSE);                         // expected_unsigned_column
+                       "decimal_positive",  // expected_column_name
+                       SQL_DECIMAL,         // expected_data_type
+                       SQL_DECIMAL,         // expected_concise_type
+                       40,                  // expected_display_size
+                       SQL_FALSE,           // expected_prec_scale
+                       19,                  // expected_length
+                       "",                  // expected_literal_prefix
+                       "",                  // expected_literal_suffix
+                       19,                  // expected_column_size
+                       0,                   // expected_column_scale
+                       SQL_NULLABLE,        // expected_column_nullability
+                       10,                  // expected_num_prec_radix
+                       40,                  // expected_octet_length
+                       SQL_SEARCHABLE,      // expected_searchable
+                       SQL_FALSE);          // expected_unsigned_column
 
   CheckSQLColAttribute(stmt, 4,
-                       std::wstring(L"float_max"),  // expected_column_name
-                       SQL_FLOAT,                   // expected_data_type
-                       SQL_FLOAT,                   // expected_concise_type
-                       24,                          // expected_display_size
-                       SQL_FALSE,                   // expected_prec_scale
-                       8,                           // expected_length
-                       std::wstring(L""),           // expected_literal_prefix
-                       std::wstring(L""),           // expected_literal_suffix
-                       8,                           // expected_column_size
-                       0,                           // expected_column_scale
-                       SQL_NULLABLE,                // expected_column_nullability
-                       2,                           // expected_num_prec_radix
-                       8,                           // expected_octet_length
-                       SQL_SEARCHABLE,              // expected_searchable
-                       SQL_FALSE);                  // expected_unsigned_column
+                       "float_max",     // expected_column_name
+                       SQL_FLOAT,       // expected_data_type
+                       SQL_FLOAT,       // expected_concise_type
+                       24,              // expected_display_size
+                       SQL_FALSE,       // expected_prec_scale
+                       8,               // expected_length
+                       "",              // expected_literal_prefix
+                       "",              // expected_literal_suffix
+                       8,               // expected_column_size
+                       0,               // expected_column_scale
+                       SQL_NULLABLE,    // expected_column_nullability
+                       2,               // expected_num_prec_radix
+                       8,               // expected_octet_length
+                       SQL_SEARCHABLE,  // expected_searchable
+                       SQL_FALSE);      // expected_unsigned_column
 
   CheckSQLColAttribute(stmt, 5,
-                       std::wstring(L"double_max"),  // expected_column_name
-                       SQL_DOUBLE,                   // expected_data_type
-                       SQL_DOUBLE,                   // expected_concise_type
-                       24,                           // expected_display_size
-                       SQL_FALSE,                    // expected_prec_scale
-                       8,                            // expected_length
-                       std::wstring(L""),            // expected_literal_prefix
-                       std::wstring(L""),            // expected_literal_suffix
-                       8,                            // expected_column_size
-                       0,                            // expected_column_scale
-                       SQL_NULLABLE,                 // expected_column_nullability
-                       2,                            // expected_num_prec_radix
-                       8,                            // expected_octet_length
-                       SQL_SEARCHABLE,               // expected_searchable
-                       SQL_FALSE);                   // expected_unsigned_column
+                       "double_max",    // expected_column_name
+                       SQL_DOUBLE,      // expected_data_type
+                       SQL_DOUBLE,      // expected_concise_type
+                       24,              // expected_display_size
+                       SQL_FALSE,       // expected_prec_scale
+                       8,               // expected_length
+                       "",              // expected_literal_prefix
+                       "",              // expected_literal_suffix
+                       8,               // expected_column_size
+                       0,               // expected_column_scale
+                       SQL_NULLABLE,    // expected_column_nullability
+                       2,               // expected_num_prec_radix
+                       8,               // expected_octet_length
+                       SQL_SEARCHABLE,  // expected_searchable
+                       SQL_FALSE);      // expected_unsigned_column
 
   CheckSQLColAttribute(stmt, 6,
-                       std::wstring(L"bit_true"),  // expected_column_name
-                       SQL_BIT,                    // expected_data_type
-                       SQL_BIT,                    // expected_concise_type
-                       1,                          // expected_display_size
-                       SQL_FALSE,                  // expected_prec_scale
-                       1,                          // expected_length
-                       std::wstring(L""),          // expected_literal_prefix
-                       std::wstring(L""),          // expected_literal_suffix
-                       1,                          // expected_column_size
-                       0,                          // expected_column_scale
-                       SQL_NULLABLE,               // expected_column_nullability
-                       0,                          // expected_num_prec_radix
-                       1,                          // expected_octet_length
-                       SQL_SEARCHABLE,             // expected_searchable
-                       SQL_TRUE);                  // expected_unsigned_column
+                       "bit_true",      // expected_column_name
+                       SQL_BIT,         // expected_data_type
+                       SQL_BIT,         // expected_concise_type
+                       1,               // expected_display_size
+                       SQL_FALSE,       // expected_prec_scale
+                       1,               // expected_length
+                       "",              // expected_literal_prefix
+                       "",              // expected_literal_suffix
+                       1,               // expected_column_size
+                       0,               // expected_column_scale
+                       SQL_NULLABLE,    // expected_column_nullability
+                       0,               // expected_num_prec_radix
+                       1,               // expected_octet_length
+                       SQL_SEARCHABLE,  // expected_searchable
+                       SQL_TRUE);       // expected_unsigned_column
 
   CheckSQLColAttribute(stmt, 7,
-                       std::wstring(L"date_max"),  // expected_column_name
-                       SQL_DATETIME,               // expected_data_type
-                       SQL_DATE,                   // expected_concise_type
-                       10,                         // expected_display_size
-                       SQL_FALSE,                  // expected_prec_scale
-                       10,                         // expected_length
-                       std::wstring(L""),          // expected_literal_prefix
-                       std::wstring(L""),          // expected_literal_suffix
-                       10,                         // expected_column_size
-                       0,                          // expected_column_scale
-                       SQL_NULLABLE,               // expected_column_nullability
-                       0,                          // expected_num_prec_radix
-                       6,                          // expected_octet_length
-                       SQL_SEARCHABLE,             // expected_searchable
-                       SQL_TRUE);                  // expected_unsigned_column
+                       "date_max",      // expected_column_name
+                       SQL_DATETIME,    // expected_data_type
+                       SQL_DATE,        // expected_concise_type
+                       10,              // expected_display_size
+                       SQL_FALSE,       // expected_prec_scale
+                       10,              // expected_length
+                       "",              // expected_literal_prefix
+                       "",              // expected_literal_suffix
+                       10,              // expected_column_size
+                       0,               // expected_column_scale
+                       SQL_NULLABLE,    // expected_column_nullability
+                       0,               // expected_num_prec_radix
+                       6,               // expected_octet_length
+                       SQL_SEARCHABLE,  // expected_searchable
+                       SQL_TRUE);       // expected_unsigned_column
 
   CheckSQLColAttribute(stmt, 8,
-                       std::wstring(L"time_max"),  // expected_column_name
-                       SQL_DATETIME,               // expected_data_type
-                       SQL_TIME,                   // expected_concise_type
-                       12,                         // expected_display_size
-                       SQL_FALSE,                  // expected_prec_scale
-                       12,                         // expected_length
-                       std::wstring(L""),          // expected_literal_prefix
-                       std::wstring(L""),          // expected_literal_suffix
-                       12,                         // expected_column_size
-                       3,                          // expected_column_scale
-                       SQL_NULLABLE,               // expected_column_nullability
-                       0,                          // expected_num_prec_radix
-                       6,                          // expected_octet_length
-                       SQL_SEARCHABLE,             // expected_searchable
-                       SQL_TRUE);                  // expected_unsigned_column
+                       "time_max",      // expected_column_name
+                       SQL_DATETIME,    // expected_data_type
+                       SQL_TIME,        // expected_concise_type
+                       12,              // expected_display_size
+                       SQL_FALSE,       // expected_prec_scale
+                       12,              // expected_length
+                       "",              // expected_literal_prefix
+                       "",              // expected_literal_suffix
+                       12,              // expected_column_size
+                       3,               // expected_column_scale
+                       SQL_NULLABLE,    // expected_column_nullability
+                       0,               // expected_num_prec_radix
+                       6,               // expected_octet_length
+                       SQL_SEARCHABLE,  // expected_searchable
+                       SQL_TRUE);       // expected_unsigned_column
 
   CheckSQLColAttribute(stmt, 9,
-                       std::wstring(L"timestamp_max"),  // expected_column_name
-                       SQL_DATETIME,                    // expected_data_type
-                       SQL_TIMESTAMP,                   // expected_concise_type
-                       23,                              // expected_display_size
-                       SQL_FALSE,                       // expected_prec_scale
-                       23,                              // expected_length
-                       std::wstring(L""),               // expected_literal_prefix
-                       std::wstring(L""),               // expected_literal_suffix
-                       23,                              // expected_column_size
-                       3,                               // expected_column_scale
-                       SQL_NULLABLE,                    // expected_column_nullability
-                       0,                               // expected_num_prec_radix
-                       16,                              // expected_octet_length
-                       SQL_SEARCHABLE,                  // expected_searchable
-                       SQL_TRUE);                       // expected_unsigned_column
+                       "timestamp_max",  // expected_column_name
+                       SQL_DATETIME,     // expected_data_type
+                       SQL_TIMESTAMP,    // expected_concise_type
+                       23,               // expected_display_size
+                       SQL_FALSE,        // expected_prec_scale
+                       23,               // expected_length
+                       "",               // expected_literal_prefix
+                       "",               // expected_literal_suffix
+                       23,               // expected_column_size
+                       3,                // expected_column_scale
+                       SQL_NULLABLE,     // expected_column_nullability
+                       0,                // expected_num_prec_radix
+                       16,               // expected_octet_length
+                       SQL_SEARCHABLE,   // expected_searchable
+                       SQL_TRUE);        // expected_unsigned_column
 }
 
 // iODBC does not support SQLColAttributes for ODBC 3.0 attributes.
 TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColAttributesAllTypes) {
   // Tests ODBC 2.0 API SQLColAttributes
   // Test assumes there is a table $scratch.ODBCTest in remote server
-  std::wstring wsql = L"SELECT * from $scratch.ODBCTest;";
-  std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
+  SQLWCHAR wsql[] = L"SELECT * from $scratch.ODBCTest;";
+  SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
 
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
   CheckSQLColAttributes(stmt, 1,
-                        std::wstring(L"sinteger_max"),  // expected_column_name
-                        SQL_INTEGER,                    // expected_data_type
-                        11,                             // expected_display_size
-                        SQL_FALSE,                      // expected_prec_scale
-                        4,                              // expected_length
-                        4,                              // expected_column_size
-                        0,                              // expected_column_scale
-                        SQL_NULLABLE,                   // expected_column_nullability
-                        SQL_SEARCHABLE,                 // expected_searchable
-                        SQL_FALSE);                     // expected_unsigned_column
+                        "sinteger_max",  // expected_column_name
+                        SQL_INTEGER,     // expected_data_type
+                        11,              // expected_display_size
+                        SQL_FALSE,       // expected_prec_scale
+                        4,               // expected_length
+                        4,               // expected_column_size
+                        0,               // expected_column_scale
+                        SQL_NULLABLE,    // expected_column_nullability
+                        SQL_SEARCHABLE,  // expected_searchable
+                        SQL_FALSE);      // expected_unsigned_column
 
   CheckSQLColAttributes(stmt, 2,
-                        std::wstring(L"sbigint_max"),  // expected_column_name
-                        SQL_BIGINT,                    // expected_data_type
-                        20,                            // expected_display_size
-                        SQL_FALSE,                     // expected_prec_scale
-                        8,                             // expected_length
-                        8,                             // expected_column_size
-                        0,                             // expected_column_scale
-                        SQL_NULLABLE,                  // expected_column_nullability
-                        SQL_SEARCHABLE,                // expected_searchable
-                        SQL_FALSE);                    // expected_unsigned_column
+                        "sbigint_max",   // expected_column_name
+                        SQL_BIGINT,      // expected_data_type
+                        20,              // expected_display_size
+                        SQL_FALSE,       // expected_prec_scale
+                        8,               // expected_length
+                        8,               // expected_column_size
+                        0,               // expected_column_scale
+                        SQL_NULLABLE,    // expected_column_nullability
+                        SQL_SEARCHABLE,  // expected_searchable
+                        SQL_FALSE);      // expected_unsigned_column
 
   CheckSQLColAttributes(stmt, 3,
-                        std::wstring(L"decimal_positive"),  // expected_column_name
-                        SQL_DECIMAL,                        // expected_data_type
-                        40,                                 // expected_display_size
-                        SQL_FALSE,                          // expected_prec_scale
-                        19,                                 // expected_length
-                        19,                                 // expected_column_size
-                        0,                                  // expected_column_scale
-                        SQL_NULLABLE,                       // expected_column_nullability
-                        SQL_SEARCHABLE,                     // expected_searchable
-                        SQL_FALSE);                         // expected_unsigned_column
+                        "decimal_positive",  // expected_column_name
+                        SQL_DECIMAL,         // expected_data_type
+                        40,                  // expected_display_size
+                        SQL_FALSE,           // expected_prec_scale
+                        19,                  // expected_length
+                        19,                  // expected_column_size
+                        0,                   // expected_column_scale
+                        SQL_NULLABLE,        // expected_column_nullability
+                        SQL_SEARCHABLE,      // expected_searchable
+                        SQL_FALSE);          // expected_unsigned_column
 
   CheckSQLColAttributes(stmt, 4,
-                        std::wstring(L"float_max"),  // expected_column_name
-                        SQL_FLOAT,                   // expected_data_type
-                        24,                          // expected_display_size
-                        SQL_FALSE,                   // expected_prec_scale
-                        8,                           // expected_length
-                        8,                           // expected_column_size
-                        0,                           // expected_column_scale
-                        SQL_NULLABLE,                // expected_column_nullability
-                        SQL_SEARCHABLE,              // expected_searchable
-                        SQL_FALSE);                  // expected_unsigned_column
+                        "float_max",     // expected_column_name
+                        SQL_FLOAT,       // expected_data_type
+                        24,              // expected_display_size
+                        SQL_FALSE,       // expected_prec_scale
+                        8,               // expected_length
+                        8,               // expected_column_size
+                        0,               // expected_column_scale
+                        SQL_NULLABLE,    // expected_column_nullability
+                        SQL_SEARCHABLE,  // expected_searchable
+                        SQL_FALSE);      // expected_unsigned_column
 
   CheckSQLColAttributes(stmt, 5,
-                        std::wstring(L"double_max"),  // expected_column_name
-                        SQL_DOUBLE,                   // expected_data_type
-                        24,                           // expected_display_size
-                        SQL_FALSE,                    // expected_prec_scale
-                        8,                            // expected_length
-                        8,                            // expected_column_size
-                        0,                            // expected_column_scale
-                        SQL_NULLABLE,                 // expected_column_nullability
-                        SQL_SEARCHABLE,               // expected_searchable
-                        SQL_FALSE);                   // expected_unsigned_column
+                        "double_max",    // expected_column_name
+                        SQL_DOUBLE,      // expected_data_type
+                        24,              // expected_display_size
+                        SQL_FALSE,       // expected_prec_scale
+                        8,               // expected_length
+                        8,               // expected_column_size
+                        0,               // expected_column_scale
+                        SQL_NULLABLE,    // expected_column_nullability
+                        SQL_SEARCHABLE,  // expected_searchable
+                        SQL_FALSE);      // expected_unsigned_column
 
   CheckSQLColAttributes(stmt, 6,
-                        std::wstring(L"bit_true"),  // expected_column_name
-                        SQL_BIT,                    // expected_data_type
-                        1,                          // expected_display_size
-                        SQL_FALSE,                  // expected_prec_scale
-                        1,                          // expected_length
-                        1,                          // expected_column_size
-                        0,                          // expected_column_scale
-                        SQL_NULLABLE,               // expected_column_nullability
-                        SQL_SEARCHABLE,             // expected_searchable
-                        SQL_TRUE);                  // expected_unsigned_column
+                        "bit_true",      // expected_column_name
+                        SQL_BIT,         // expected_data_type
+                        1,               // expected_display_size
+                        SQL_FALSE,       // expected_prec_scale
+                        1,               // expected_length
+                        1,               // expected_column_size
+                        0,               // expected_column_scale
+                        SQL_NULLABLE,    // expected_column_nullability
+                        SQL_SEARCHABLE,  // expected_searchable
+                        SQL_TRUE);       // expected_unsigned_column
 
   CheckSQLColAttributes(stmt, 7,
-                        std::wstring(L"date_max"),  // expected_column_name
-                        SQL_DATE,                   // expected_data_type
-                        10,                         // expected_display_size
-                        SQL_FALSE,                  // expected_prec_scale
-                        10,                         // expected_length
-                        10,                         // expected_column_size
-                        0,                          // expected_column_scale
-                        SQL_NULLABLE,               // expected_column_nullability
-                        SQL_SEARCHABLE,             // expected_searchable
-                        SQL_TRUE);                  // expected_unsigned_column
+                        "date_max",      // expected_column_name
+                        SQL_DATE,        // expected_data_type
+                        10,              // expected_display_size
+                        SQL_FALSE,       // expected_prec_scale
+                        10,              // expected_length
+                        10,              // expected_column_size
+                        0,               // expected_column_scale
+                        SQL_NULLABLE,    // expected_column_nullability
+                        SQL_SEARCHABLE,  // expected_searchable
+                        SQL_TRUE);       // expected_unsigned_column
 
   CheckSQLColAttributes(stmt, 8,
-                        std::wstring(L"time_max"),  // expected_column_name
-                        SQL_TIME,                   // expected_data_type
-                        12,                         // expected_display_size
-                        SQL_FALSE,                  // expected_prec_scale
-                        12,                         // expected_length
-                        12,                         // expected_column_size
-                        3,                          // expected_column_scale
-                        SQL_NULLABLE,               // expected_column_nullability
-                        SQL_SEARCHABLE,             // expected_searchable
-                        SQL_TRUE);                  // expected_unsigned_column
+                        "time_max",      // expected_column_name
+                        SQL_TIME,        // expected_data_type
+                        12,              // expected_display_size
+                        SQL_FALSE,       // expected_prec_scale
+                        12,              // expected_length
+                        12,              // expected_column_size
+                        3,               // expected_column_scale
+                        SQL_NULLABLE,    // expected_column_nullability
+                        SQL_SEARCHABLE,  // expected_searchable
+                        SQL_TRUE);       // expected_unsigned_column
 
   CheckSQLColAttributes(stmt, 9,
-                        std::wstring(L"timestamp_max"),  // expected_column_name
-                        SQL_TIMESTAMP,                   // expected_data_type
-                        23,                              // expected_display_size
-                        SQL_FALSE,                       // expected_prec_scale
-                        23,                              // expected_length
-                        23,                              // expected_column_size
-                        3,                               // expected_column_scale
-                        SQL_NULLABLE,                    // expected_column_nullability
-                        SQL_SEARCHABLE,                  // expected_searchable
-                        SQL_TRUE);                       // expected_unsigned_column
+                        "timestamp_max",  // expected_column_name
+                        SQL_TIMESTAMP,    // expected_data_type
+                        23,               // expected_display_size
+                        SQL_FALSE,        // expected_prec_scale
+                        23,               // expected_length
+                        23,               // expected_column_size
+                        3,                // expected_column_scale
+                        SQL_NULLABLE,     // expected_column_nullability
+                        SQL_SEARCHABLE,   // expected_searchable
+                        SQL_TRUE);        // expected_unsigned_column
 }
 #endif  // __APPLE__
 
@@ -2254,7 +2245,7 @@ TEST_F(ColumnsMockTest, SQLDescribeColValidateInput) {
   SQLUSMALLINT bookmark_column = 0;
   SQLUSMALLINT out_of_range_column = 4;
   SQLUSMALLINT negative_column = -1;
-  SQLWCHAR column_name[1024];
+  SQLWCHAR column_name[1024] = {0};
   SQLSMALLINT buf_char_len =
       static_cast<SQLSMALLINT>(sizeof(column_name) / GetSqlWCharSize());
   SQLSMALLINT name_length = 0;

--- a/cpp/src/arrow/flight/sql/odbc/tests/errors_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/errors_test.cc
@@ -401,11 +401,10 @@ TYPED_TEST(ErrorsTest, TestSQLErrorStmtError) {
   // When application passes buffer length greater than SQL_MAX_MESSAGE_LENGTH (512),
   // DM passes 512 as buffer length to SQLError.
 
-  std::wstring wsql = L"1";
-  std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
+  SQLWCHAR wsql[] = L"1";
+  SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_ERROR,
-            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+  ASSERT_EQ(SQL_ERROR, SQLExecDirect(stmt, wsql, wsql_len));
 
   SQLWCHAR sql_state[6] = {0};
   SQLINTEGER native_error = 0;
@@ -428,11 +427,10 @@ TYPED_TEST(ErrorsTest, TestSQLErrorStmtError) {
 TYPED_TEST(ErrorsTest, TestSQLErrorStmtWarning) {
   // Test ODBC 2.0 API SQLError.
 
-  std::wstring wsql = L"SELECT 'VERY LONG STRING here' AS string_col;";
-  std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
+  SQLWCHAR wsql[] = L"SELECT 'VERY LONG STRING here' AS string_col;";
+  SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
 
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
@@ -534,11 +532,10 @@ TYPED_TEST(ErrorsOdbcV2Test, TestSQLErrorStmtError) {
   // When application passes buffer length greater than SQL_MAX_MESSAGE_LENGTH (512),
   // DM passes 512 as buffer length to SQLError.
 
-  std::wstring wsql = L"SELECT * from non_existent_table;";
-  std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
+  SQLWCHAR wsql[] = L"SELECT * from non_existent_table;";
+  SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_ERROR,
-            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+  ASSERT_EQ(SQL_ERROR, SQLExecDirect(stmt, wsql, wsql_len));
 
   SQLWCHAR sql_state[6] = {0};
   SQLINTEGER native_error = 0;
@@ -559,11 +556,10 @@ TYPED_TEST(ErrorsOdbcV2Test, TestSQLErrorStmtError) {
 TYPED_TEST(ErrorsOdbcV2Test, TestSQLErrorStmtWarning) {
   // Test ODBC 2.0 API SQLError.
 
-  std::wstring wsql = L"SELECT 'VERY LONG STRING here' AS string_col;";
-  std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
+  SQLWCHAR wsql[] = L"SELECT 'VERY LONG STRING here' AS string_col;";
+  SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
 
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 

--- a/cpp/src/arrow/flight/sql/odbc/tests/statement_attr_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/statement_attr_test.cc
@@ -332,11 +332,10 @@ TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrRowBindType) {
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrRowNumber) {
-  std::wstring wsql = L"SELECT 1;";
-  std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
+  SQLWCHAR wsql[] = L"SELECT 1;";
+  SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
 
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 

--- a/cpp/src/arrow/flight/sql/odbc/tests/statement_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/statement_test.cc
@@ -38,11 +38,10 @@ using TestTypes = ::testing::Types<StatementMockTest, StatementRemoteTest>;
 TYPED_TEST_SUITE(StatementTest, TestTypes);
 
 TYPED_TEST(StatementTest, TestSQLExecDirectSimpleQuery) {
-  std::wstring wsql = L"SELECT 1;";
-  std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
+  SQLWCHAR wsql[] = L"SELECT 1;";
+  SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
 
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
@@ -66,21 +65,19 @@ TYPED_TEST(StatementTest, TestSQLExecDirectSimpleQuery) {
 }
 
 TYPED_TEST(StatementTest, TestSQLExecDirectInvalidQuery) {
-  std::wstring wsql = L"SELECT;";
-  std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
+  SQLWCHAR wsql[] = L"SELECT;";
+  SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_ERROR,
-            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+  ASSERT_EQ(SQL_ERROR, SQLExecDirect(stmt, wsql, wsql_len));
   // ODBC provides generic error code HY000 to all statement errors
   VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorStateHY000);
 }
 
 TYPED_TEST(StatementTest, TestSQLExecuteSimpleQuery) {
-  std::wstring wsql = L"SELECT 1;";
-  std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
+  SQLWCHAR wsql[] = L"SELECT 1;";
+  SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLPrepare(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+  ASSERT_EQ(SQL_SUCCESS, SQLPrepare(stmt, wsql, wsql_len));
 
   ASSERT_EQ(SQL_SUCCESS, SQLExecute(stmt));
 
@@ -107,10 +104,10 @@ TYPED_TEST(StatementTest, TestSQLExecuteSimpleQuery) {
 }
 
 TYPED_TEST(StatementTest, TestSQLPrepareInvalidQuery) {
-  std::wstring wsql = L"SELECT;";
-  std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
+  SQLWCHAR wsql[] = L"SELECT;";
+  SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_ERROR, SQLPrepare(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+  ASSERT_EQ(SQL_ERROR, SQLPrepare(stmt, wsql, wsql_len));
   // ODBC provides generic error code HY000 to all statement errors
   VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorStateHY000);
 
@@ -349,15 +346,14 @@ TEST_F(StatementRemoteTest, TestSQLExecDirectTimeQuery) {
   // Mock server test is skipped due to limitation on the mock server.
   // Time type from mock server does not include the fraction
 
-  std::wstring wsql =
+  SQLWCHAR wsql[] =
       LR"(
     SELECT CAST(TIME '00:00:00' AS TIME) AS time_min,
            CAST(TIME '23:59:59' AS TIME) AS time_max;
     )";
-  std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
+  SQLSMALLINT wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
 
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
@@ -382,11 +378,10 @@ TEST_F(StatementMockTest, TestSQLExecDirectVarbinaryQuery) {
   // Have binary test on mock test base as remote test servers tend to have different
   // formats for binary data
 
-  std::wstring wsql = L"SELECT X'ABCDEF' AS c_varbinary;";
-  std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
+  SQLWCHAR wsql[] = L"SELECT X'ABCDEF' AS c_varbinary;";
+  SQLSMALLINT wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
 
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
@@ -578,15 +573,14 @@ TEST_F(StatementRemoteTest, TestSQLExecDirectTimeQueryDefaultType) {
   // Mock server test is skipped due to limitation on the mock server.
   // Time type from mock server does not include the fraction
 
-  std::wstring wsql =
+  SQLWCHAR wsql[] =
       LR"(
    SELECT CAST(TIME '00:00:00' AS TIME) AS time_min,
           CAST(TIME '23:59:59' AS TIME) AS time_max;
    )";
-  std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
+  SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
 
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
@@ -612,11 +606,10 @@ TEST_F(StatementRemoteTest, TestSQLExecDirectVarbinaryQueryDefaultType) {
   // Mock server has type `DENSE_UNION` for varbinary.
   // Note that not all remote servers support "from_hex" function
 
-  std::wstring wsql = L"SELECT from_hex('ABCDEF') AS c_varbinary;";
-  std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
+  SQLWCHAR wsql[] = L"SELECT from_hex('ABCDEF') AS c_varbinary;";
+  SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
 
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
@@ -634,11 +627,10 @@ TEST_F(StatementRemoteTest, TestSQLExecDirectVarbinaryQueryDefaultType) {
 // TODO(GH-48730): Enable this test when ARD/IRD descriptor support is fully implemented
 TYPED_TEST(StatementTest, DISABLED_TestGetDataPrecisionScaleUsesIRDAsDefault) {
   // Verify that SQLGetData uses IRD precision/scale as defaults when ARD values are unset
-  std::wstring wsql = L"SELECT CAST('123.45' AS NUMERIC) as decimal_col;";
-  std::vector<SQLWCHAR> sql(wsql.begin(), wsql.end());
+  SQLWCHAR wsql[] = L"SELECT CAST('123.45' AS NUMERIC) as decimal_col;";
+  SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(stmt, &sql[0], static_cast<SQLINTEGER>(sql.size())));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
 
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
@@ -680,11 +672,10 @@ TYPED_TEST(StatementTest, DISABLED_TestGetDataPrecisionScaleUsesIRDAsDefault) {
 TYPED_TEST(StatementTest, DISABLED_TestGetDataPrecisionScaleUsesARDWhenSet) {
   // Verify that SQLGetData uses ARD precision/scale when set, for both SQL_ARD_TYPE and
   // SQL_C_DEFAULT
-  std::wstring wsql = L"SELECT CAST('123.45' AS NUMERIC) as decimal_col;";
-  std::vector<SQLWCHAR> sql(wsql.begin(), wsql.end());
+  SQLWCHAR wsql[] = L"SELECT CAST('123.45' AS NUMERIC) as decimal_col;";
+  SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(stmt, &sql[0], static_cast<SQLINTEGER>(sql.size())));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
 
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
@@ -726,11 +717,10 @@ TYPED_TEST(StatementTest, DISABLED_TestGetDataPrecisionScaleUsesARDWhenSet) {
 
 TYPED_TEST(StatementTest, TestSQLExecDirectGuidQueryUnsupported) {
   // Query GUID as string as SQLite does not support GUID
-  std::wstring wsql = L"SELECT 'C77313CF-4E08-47CE-B6DF-94DD2FCF3541' AS guid;";
-  std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
+  SQLWCHAR wsql[] = L"SELECT 'C77313CF-4E08-47CE-B6DF-94DD2FCF3541' AS guid;";
+  SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
 
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
@@ -743,7 +733,7 @@ TYPED_TEST(StatementTest, TestSQLExecDirectGuidQueryUnsupported) {
 }
 
 TYPED_TEST(StatementTest, TestSQLExecDirectRowFetching) {
-  std::wstring wsql =
+  SQLWCHAR wsql[] =
       LR"(
    SELECT 1 AS small_table
    UNION ALL
@@ -751,10 +741,9 @@ TYPED_TEST(StatementTest, TestSQLExecDirectRowFetching) {
    UNION ALL
    SELECT 3;
  )";
-  std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
+  SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
 
   // Fetch row 1
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
@@ -802,7 +791,7 @@ TYPED_TEST(StatementTest, TestSQLFetchScrollRowFetching) {
   SQLLEN rows_fetched;
   SQLSetStmtAttr(stmt, SQL_ATTR_ROWS_FETCHED_PTR, &rows_fetched, 0);
 
-  std::wstring wsql =
+  SQLWCHAR wsql[] =
       LR"(
    SELECT 1 AS small_table
    UNION ALL
@@ -810,10 +799,9 @@ TYPED_TEST(StatementTest, TestSQLFetchScrollRowFetching) {
    UNION ALL
    SELECT 3;
  )";
-  std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
+  SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
 
   // Fetch row 1
   ASSERT_EQ(SQL_SUCCESS, SQLFetchScroll(stmt, SQL_FETCH_NEXT, 0));
@@ -865,11 +853,10 @@ TYPED_TEST(StatementTest, TestSQLFetchScrollRowFetching) {
 TYPED_TEST(StatementTest, TestSQLFetchScrollUnsupportedOrientation) {
   // SQL_FETCH_NEXT is the only supported fetch orientation.
 
-  std::wstring wsql = L"SELECT 1;";
-  std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
+  SQLWCHAR wsql[] = L"SELECT 1;";
+  SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
 
   ASSERT_EQ(SQL_ERROR, SQLFetchScroll(stmt, SQL_FETCH_PRIOR, 0));
 
@@ -903,11 +890,10 @@ TYPED_TEST(StatementTest, TestSQLFetchScrollUnsupportedOrientation) {
 }
 
 TYPED_TEST(StatementTest, TestSQLExecDirectVarcharTruncation) {
-  std::wstring wsql = L"SELECT 'VERY LONG STRING here' AS string_col;";
-  std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
+  SQLWCHAR wsql[] = L"SELECT 'VERY LONG STRING here' AS string_col;";
+  SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
 
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
@@ -953,11 +939,10 @@ TYPED_TEST(StatementTest, TestSQLExecDirectVarcharTruncation) {
 }
 
 TYPED_TEST(StatementTest, TestSQLExecDirectWVarcharTruncation) {
-  std::wstring wsql = L"SELECT 'VERY LONG Unicode STRING 句子 here' AS wstring_col;";
-  std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
+  SQLWCHAR wsql[] = L"SELECT 'VERY LONG Unicode STRING 句子 here' AS wstring_col;";
+  SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
 
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
@@ -1007,11 +992,10 @@ TEST_F(StatementMockTest, TestSQLExecDirectVarbinaryTruncation) {
   // Have binary test on mock test base as remote test servers tend to have different
   // formats for binary data
 
-  std::wstring wsql = L"SELECT X'ABCDEFAB' AS c_varbinary;";
-  std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
+  SQLWCHAR wsql[] = L"SELECT X'ABCDEFAB' AS c_varbinary;";
+  SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
 
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
@@ -1052,9 +1036,9 @@ TYPED_TEST(StatementTest, DISABLED_TestSQLExecDirectFloatTruncation) {
   // GH-46985: return warning message instead of error on float truncation case
   std::wstring wsql;
   if constexpr (std::is_same_v<TypeParam, StatementMockTest>) {
-    wsql = std::wstring(L"SELECT CAST(1.234 AS REAL) AS float_val");
+    wsql = L"SELECT CAST(1.234 AS REAL) AS float_val";
   } else if constexpr (std::is_same_v<TypeParam, StatementRemoteTest>) {
-    wsql = std::wstring(L"SELECT CAST(1.234 AS FLOAT) AS float_val");
+    wsql = L"SELECT CAST(1.234 AS FLOAT) AS float_val";
   }
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
@@ -1077,11 +1061,10 @@ TEST_F(StatementRemoteTest, TestSQLExecDirectNullQuery) {
   // Limitation on mock test server prevents null from working properly, so use remote
   // server instead. Mock server has type `DENSE_UNION` for null column data.
 
-  std::wstring wsql = L"SELECT null as null_col;";
-  std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
+  SQLWCHAR wsql[] = L"SELECT null as null_col;";
+  SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
 
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
@@ -1099,17 +1082,16 @@ TEST_F(StatementMockTest, TestSQLExecDirectTruncationQueryNullIndicator) {
   // Have binary test on mock test base as remote test servers tend to have different
   // formats for binary data
 
-  std::wstring wsql =
+  SQLWCHAR wsql[] =
       LR"(
        SELECT 1,
        'VERY LONG STRING here' AS string_col,
        'VERY LONG Unicode STRING 句子 here' AS wstring_col,
        X'ABCDEFAB' AS c_varbinary;
  )";
-  std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
+  SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
 
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
@@ -1150,11 +1132,10 @@ TEST_F(StatementRemoteTest, TestSQLExecDirectNullQueryNullIndicator) {
   // Limitation on mock test server prevents null from working properly, so use remote
   // server instead. Mock server has type `DENSE_UNION` for null column data.
 
-  std::wstring wsql = L"SELECT null as null_col;";
-  std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
+  SQLWCHAR wsql[] = L"SELECT null as null_col;";
+  SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
 
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
@@ -1651,15 +1632,14 @@ TEST_F(StatementRemoteTest, TestSQLBindColTimeQuery) {
   ASSERT_EQ(SQL_SUCCESS,
             SQLBindCol(stmt, 2, SQL_C_TYPE_TIME, &time_var_max, buf_len, &ind));
 
-  std::wstring wsql =
+  SQLWCHAR wsql[] =
       LR"(
    SELECT CAST(TIME '00:00:00' AS TIME) AS time_min,
           CAST(TIME '23:59:59' AS TIME) AS time_max;
    )";
-  std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
+  SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
 
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
@@ -1685,11 +1665,10 @@ TEST_F(StatementMockTest, TestSQLBindColVarbinaryQuery) {
   ASSERT_EQ(SQL_SUCCESS,
             SQLBindCol(stmt, 1, SQL_C_BINARY, &varbinary_val[0], buf_len, &ind));
 
-  std::wstring wsql = L"SELECT X'ABCDEF' AS c_varbinary;";
-  std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
+  SQLWCHAR wsql[] = L"SELECT X'ABCDEF' AS c_varbinary;";
+  SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
 
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
@@ -1708,11 +1687,10 @@ TEST_F(StatementRemoteTest, TestSQLBindColNullQuery) {
 
   ASSERT_EQ(SQL_SUCCESS, SQLBindCol(stmt, 1, SQL_C_LONG, &val, 0, &ind));
 
-  std::wstring wsql = L"SELECT null as null_col;";
-  std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
+  SQLWCHAR wsql[] = L"SELECT null as null_col;";
+  SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
 
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
@@ -1728,11 +1706,10 @@ TEST_F(StatementRemoteTest, TestSQLBindColNullQueryNullIndicator) {
 
   ASSERT_EQ(SQL_SUCCESS, SQLBindCol(stmt, 1, SQL_C_LONG, &val, 0, 0));
 
-  std::wstring wsql = L"SELECT null as null_col;";
-  std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
+  SQLWCHAR wsql[] = L"SELECT null as null_col;";
+  SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
 
   ASSERT_EQ(SQL_ERROR, SQLFetch(stmt));
   // Verify invalid null indicator is reported, as it is required
@@ -1748,7 +1725,7 @@ TYPED_TEST(StatementTest, TestSQLBindColRowFetching) {
   // should be updated after every SQLFetch call.
   ASSERT_EQ(SQL_SUCCESS, SQLBindCol(stmt, 1, SQL_C_LONG, &val, buf_len, &ind));
 
-  std::wstring wsql =
+  SQLWCHAR wsql[] =
       LR"(
    SELECT 1 AS small_table
    UNION ALL
@@ -1756,10 +1733,9 @@ TYPED_TEST(StatementTest, TestSQLBindColRowFetching) {
    UNION ALL
    SELECT 3;
  )";
-  std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
+  SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
 
   // Fetch row 1
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
@@ -1799,7 +1775,7 @@ TYPED_TEST(StatementTest, TestSQLBindColRowArraySize) {
   ASSERT_EQ(SQL_SUCCESS,
             SQLSetStmtAttr(stmt, SQL_ATTR_ROWS_FETCHED_PTR, &rows_fetched, 0));
 
-  std::wstring wsql =
+  SQLWCHAR wsql[] =
       LR"(
    SELECT 1 AS small_table
    UNION ALL
@@ -1807,10 +1783,9 @@ TYPED_TEST(StatementTest, TestSQLBindColRowArraySize) {
    UNION ALL
    SELECT 3;
  )";
-  std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
+  SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
 
   ASSERT_EQ(SQL_SUCCESS, SQLSetStmtAttr(stmt, SQL_ATTR_ROW_ARRAY_SIZE,
                                         reinterpret_cast<SQLPOINTER>(rows), 0));
@@ -1918,7 +1893,7 @@ TYPED_TEST(StatementTest, TestSQLExtendedFetchRowFetching) {
   ASSERT_EQ(SQL_SUCCESS,
             SQLSetStmtAttr(stmt, SQL_ROWSET_SIZE, reinterpret_cast<SQLPOINTER>(rows), 0));
 
-  std::wstring wsql =
+  SQLWCHAR wsql[] =
       LR"(
    SELECT 1 AS small_table
    UNION ALL
@@ -1926,10 +1901,9 @@ TYPED_TEST(StatementTest, TestSQLExtendedFetchRowFetching) {
    UNION ALL
    SELECT 3;
  )";
-  std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
+  SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
 
   // Fetch row 1-3.
   SQLULEN row_count;
@@ -1965,11 +1939,10 @@ TEST_F(StatementRemoteTest, DISABLED_TestSQLExtendedFetchQueryNullIndicator) {
 
   ASSERT_EQ(SQL_SUCCESS, SQLBindCol(stmt, 1, SQL_C_LONG, &val, 0, nullptr));
 
-  std::wstring wsql = L"SELECT null as null_col;";
-  std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
+  SQLWCHAR wsql[] = L"SELECT null as null_col;";
+  SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
 
   SQLULEN row_count1;
   SQLUSMALLINT row_status1[1];
@@ -1982,11 +1955,11 @@ TEST_F(StatementRemoteTest, DISABLED_TestSQLExtendedFetchQueryNullIndicator) {
 
 TYPED_TEST(StatementTest, TestSQLMoreResultsNoData) {
   // Verify SQLMoreResults returns SQL_NO_DATA by default.
-  std::wstring wsql = L"SELECT 1;";
-  std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+  SQLWCHAR wsql[] = L"SELECT 1;";
+  SQLINTEGER wsql_len = std::wcslen(wsql);
+
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
 
   ASSERT_EQ(SQL_NO_DATA, SQLMoreResults(stmt));
 }
@@ -2209,21 +2182,19 @@ TYPED_TEST(StatementTest, SQLRowCountFunctionSequenceErrorOnNoQuery) {
 }
 
 TYPED_TEST(StatementTest, TestSQLFreeStmtSQLClose) {
-  std::wstring wsql = L"SELECT 1;";
-  std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
+  SQLWCHAR wsql[] = L"SELECT 1;";
+  SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
 
   ASSERT_EQ(SQL_SUCCESS, SQLFreeStmt(stmt, SQL_CLOSE));
 }
 
 TYPED_TEST(StatementTest, TestSQLCloseCursor) {
-  std::wstring wsql = L"SELECT 1;";
-  std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
+  SQLWCHAR wsql[] = L"SELECT 1;";
+  SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
 
   ASSERT_EQ(SQL_SUCCESS, SQLCloseCursor(stmt));
 }


### PR DESCRIPTION
### Rationale for this change
We want to use a SQLWCHAR array for wide string literal inside our test suite instead of a SQLWCHAR vector.

### What changes are included in this PR?
SQLWCHAR vector used for wide string literals are replaced with a SQLWCHAR array instead.
Columns tests were refactored to perform assertions over std::string equality rather than wide string equality.

### Are these changes tested?
Yes

### Are there any user-facing changes?
No
* GitHub Issue: #49561