### PR TITLE
GH-49565: [Python] Copy CKmsConnectionConfig instead of trying to move the const received one

### DIFF
--- a/python/pyarrow/_parquet_encryption.pyx
+++ b/python/pyarrow/_parquet_encryption.pyx
@@ -297,7 +297,10 @@ cdef class KmsConnectionConfig(_Weakrefable):
     @staticmethod
     cdef wrap(const CKmsConnectionConfig& config):
         result = KmsConnectionConfig()
-        result.configuration = make_shared[CKmsConnectionConfig](move(config))
+        # We require a copy of the config because the input is
+        # a const reference owned by C++.
+        cdef CKmsConnectionConfig config_copy = config
+        result.configuration = make_shared[CKmsConnectionConfig](move(config_copy))
         return result
 
 


### PR DESCRIPTION
### Rationale for this change

The [test-ubuntu-22.04-python-313-freethreading](https://github.com/ursacomputing/crossbow/actions/runs/23324175137/job/67841753438) job is currently failing with:
```
   [104/119] Building CXX object CMakeFiles/_parquet_encryption.dir/_parquet_encryption.cpp.o
  FAILED: CMakeFiles/_parquet_encryption.dir/_parquet_encryption.cpp.o
  /usr/bin/ccache /usr/lib/ccache/x86_64-linux-gnu-g++ -DARROW_HAVE_RUNTIME_AVX2 -DARROW_HAVE_RUNTIME_AVX512 -DARROW_HAVE_RUNTIME_BMI2 -DARROW_HAVE_RUNTIME_SSE4_2 -DARROW_HAVE_SSE4_2 -D_parquet_encryption_EXPORTS -I/usr/include/python3.13t -I/build/python/pyarrow/src -I/tmp/tmp2y9fbxsg/build/pyarrow/src -I/arrow-dev/lib/python3.13t/site-packages/numpy/_core/include -Wno-noexcept-type  -Wall -fno-semantic-interposition -msse4.2  -fdiagnostics-color=always  -fno-omit-frame-pointer -Wno-unused-variable -Wno-maybe-uninitialized -g -O0  -std=c++20 -fPIC -Wno-unused-function -MD -MT CMakeFiles/_parquet_encryption.dir/_parquet_encryption.cpp.o -MF CMakeFiles/_parquet_encryption.dir/_parquet_encryption.cpp.o.d -o CMakeFiles/_parquet_encryption.dir/_parquet_encryption.cpp.o -c /tmp/tmp2y9fbxsg/build/_parquet_encryption.cpp
  /tmp/tmp2y9fbxsg/build/_parquet_encryption.cpp: In function ‘PyObject* __pyx_f_7pyarrow_19_parquet_encryption_19KmsConnectionConfig_wrap(const parquet::encryption::KmsConnectionConfig&)’:
  /tmp/tmp2y9fbxsg/build/_parquet_encryption.cpp:16576:137: error: binding reference of type ‘parquet::encryption::KmsConnectionConfig&’ to ‘const parquet::encryption::KmsConnectionConfig’ discards qualifiers
  16576 |     __pyx_t_4 = std::make_shared< parquet::encryption::KmsConnectionConfig>(cython_std::move< parquet::encryption::KmsConnectionConfig>(__pyx_v_config));
        |                                                                                                                                         ^~~~~~~~~~~~~~
  /tmp/tmp2y9fbxsg/build/_parquet_encryption.cpp:1171:77: note:   initializing argument 1 of ‘typename std::remove_reference<_Tp>::type&& cython_std::move(T&) [with T = parquet::encryption::KmsConnectionConfig; typename std::remove_reference<_Tp>::type = parquet::encryption::KmsConnectionConfig]’
   1171 |     template <typename T> typename std::remove_reference<T>::type&& move(T& t) noexcept { return std::move(t); }
        |   
```

### What changes are included in this PR?

Copy CKmsConnectionConfig instead of trying to move the const one owned by C++.

### Are these changes tested?

Yes via archery

### Are there any user-facing changes?

No

* GitHub Issue: #49565