### PR TITLE
GH-49569: [CI][Python][C++] Add check targetting Apple clang on deciding whether to use std::bit_width or std::log2p1

### DIFF
--- a/cpp/src/arrow/util/align_util.h
+++ b/cpp/src/arrow/util/align_util.h
@@ -46,7 +46,8 @@ inline BitmapWordAlignParams BitmapWordAlign(const uint8_t* data, int64_t bit_of
                                              int64_t length) {
   // TODO: We can remove this condition once CRAN upgrades its macOS
   // SDK from 11.3.
-#if defined(__clang__) && !defined(__cpp_lib_bitops) && !defined(__EMSCRIPTEN__)
+  // __apple_build_version__ should be defined only on Apple clang
+#if defined(__apple_build_version__) && !defined(__cpp_lib_bitops)
   static_assert((ALIGN_IN_BYTES != 0) && ((ALIGN_IN_BYTES & (ALIGN_IN_BYTES - 1)) == 0),
                 "ALIGN_IN_BYTES should be a positive power of two");
 #else

--- a/cpp/src/arrow/util/bit_util.h
+++ b/cpp/src/arrow/util/bit_util.h
@@ -141,15 +141,8 @@ static inline int Log2(uint64_t x) {
 
 // TODO: We can remove this condition once CRAN upgrades its macOS
 // SDK from 11.3.
-// On Clang 15.0.7 newer libc++ removed log2p1 but __cpp_lib_bitops isn't defined
-// We check the libcpp version to validate whether it's there or not.
-// Commit reference landed on 12.0.0:
-// https://github.com/llvm/llvm-project/commit/1a036e9cc82a7f6d6f4675d631fa5eecd8748784
-// _LIBCPP_VERSION might not be defined in some environments that's why we keep the
-// check for __cpp_lib_bitops as well.
-#if defined(_LIBCPP_VERSION) && _LIBCPP_VERSION >= 12000
-  return std::bit_width(x - 1);
-#elif defined(__clang__) && !defined(__cpp_lib_bitops) && !defined(__EMSCRIPTEN__)
+// __apple_build_version__ should be defined only on Apple clang
+#if defined(__apple_build_version__) && !defined(__cpp_lib_bitops)
   return std::log2p1(x - 1);
 #else
   return std::bit_width(x - 1);

--- a/cpp/src/arrow/util/bit_util.h
+++ b/cpp/src/arrow/util/bit_util.h
@@ -139,9 +139,17 @@ static inline uint64_t TrailingBits(uint64_t v, int num_bits) {
 static inline int Log2(uint64_t x) {
   // DCHECK_GT(x, 0);
 
-  // TODO: We can remove this condition once CRAN upgrades its macOS
-  // SDK from 11.3.
-#if defined(__clang__) && !defined(__cpp_lib_bitops) && !defined(__EMSCRIPTEN__)
+// TODO: We can remove this condition once CRAN upgrades its macOS
+// SDK from 11.3.
+// On Clang 15.0.7 newer libc++ removed log2p1 but __cpp_lib_bitops isn't defined
+// We check the libcpp version to validate whether it's there or not.
+// Commit reference landed on 12.0.0:
+// https://github.com/llvm/llvm-project/commit/1a036e9cc82a7f6d6f4675d631fa5eecd8748784
+// _LIBCPP_VERSION might not be defined in some environments that's why we keep the
+// check for __cpp_lib_bitops as well.
+#if defined(_LIBCPP_VERSION) && _LIBCPP_VERSION >= 12000
+  return std::bit_width(x - 1);
+#elif defined(__clang__) && !defined(__cpp_lib_bitops) && !defined(__EMSCRIPTEN__)
   return std::log2p1(x - 1);
 #else
   return std::bit_width(x - 1);

--- a/cpp/src/arrow/util/rle_encoding_test.cc
+++ b/cpp/src/arrow/util/rle_encoding_test.cc
@@ -918,7 +918,8 @@ TEST(BitRle, Random) {
     }
     // TODO: We can remove this condition once CRAN upgrades its macOS
     // SDK from 11.3.
-#if defined(__clang__) && !defined(__cpp_lib_bitops) && !defined(__EMSCRIPTEN__)
+    // __apple_build_version__ should be defined only on Apple clang
+#if defined(__apple_build_version__) && !defined(__cpp_lib_bitops)
     if (!CheckRoundTrip(values, std::log2p1(values.size()))) {
 #else
     if (!CheckRoundTrip(values, std::bit_width(values.size()))) {

--- a/cpp/src/parquet/chunker_internal.cc
+++ b/cpp/src/parquet/chunker_internal.cc
@@ -88,7 +88,8 @@ uint64_t CalculateMask(int64_t min_chunk_size, int64_t max_chunk_size, int norm_
   // by taking the floor(log2(target_size))
   // TODO: We can remove this condition once CRAN upgrades its macOS
   // SDK from 11.3.
-#if defined(__clang__) && !defined(__cpp_lib_bitops) && !defined(__EMSCRIPTEN__)
+  // __apple_build_version__ should be defined only on Apple clang
+#if defined(__apple_build_version__) && !defined(__cpp_lib_bitops)
   auto target_bits = std::log2p1(static_cast<uint64_t>(target_size));
 #else
   auto target_bits = std::bit_width(static_cast<uint64_t>(target_size));

--- a/cpp/src/parquet/encoder.cc
+++ b/cpp/src/parquet/encoder.cc
@@ -1169,7 +1169,8 @@ void DeltaBitPackEncoder<DType>::FlushBlock() {
     // See overflow comment above.
     // TODO: We can remove this condition once CRAN upgrades its macOS
     // SDK from 11.3.
-#if defined(__clang__) && !defined(__cpp_lib_bitops) && !defined(__EMSCRIPTEN__)
+    // __apple_build_version__ should be defined only on Apple clang
+#if defined(__apple_build_version__) && !defined(__cpp_lib_bitops)
     const auto bit_width = bit_width_data[i] =
         std::log2p1(static_cast<UT>(max_delta) - static_cast<UT>(min_delta));
 #else


### PR DESCRIPTION
### Rationale for this change

Clang 15.0.7 (/opt/homebrew/bin/clang++) - Homebrew LLVM fails compiling with:
```
   FAILED: [code=1] CMakeFiles/arrow_python.dir/pyarrow/src/arrow/python/arrow_to_pandas.cc.o
  /opt/homebrew/bin/ccache /opt/homebrew/bin/clang++ -DARROW_HAVE_NEON -DARROW_PYTHON_EXPORTING -Darrow_python_EXPORTS -I/Users/runner/work/arrow/arrow/build/python/pyarrow/src -I/var/folders/gj/d1t24fg93wbdl854js_qwvb00000gn/T/tmpj20nqu3c/build/pyarrow/src -I/Library/Frameworks/Python.framework/Versions/3.11/include/python3.11 -I/tmp/local/include -I/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/numpy/_core/include -fno-aligned-new  -Wall -Wno-unknown-warning-option -Wno-pass-failed -march=armv8-a  -Qunused-arguments -fcolor-diagnostics  -fno-omit-frame-pointer -Wno-unused-variable -Wno-maybe-uninitialized -Wno-parentheses-equality -Wno-constant-logical-operand -Wno-missing-declarations -Wno-sometimes-uninitialized -Wno-return-type-c-linkage -g -O0  -std=c++20 -arch arm64 -mmacosx-version-min=12 -fPIC -Wno-parentheses-equality -MD -MT CMakeFiles/arrow_python.dir/pyarrow/src/arrow/python/arrow_to_pandas.cc.o -MF CMakeFiles/arrow_python.dir/pyarrow/src/arrow/python/arrow_to_pandas.cc.o.d -o CMakeFiles/arrow_python.dir/pyarrow/src/arrow/python/arrow_to_pandas.cc.o -c /Users/runner/work/arrow/arrow/build/python/pyarrow/src/arrow/python/arrow_to_pandas.cc
  In file included from /Users/runner/work/arrow/arrow/build/python/pyarrow/src/arrow/python/arrow_to_pandas.cc:34:
  In file included from /tmp/local/include/arrow/array.h:41:
  In file included from /tmp/local/include/arrow/array/array_base.h:26:
  In file included from /tmp/local/include/arrow/array/data.h:32:
  /tmp/local/include/arrow/util/bit_util.h:145:15: error: no member named 'log2p1' in namespace 'std'
    return std::log2p1(x - 1);
           ~~~~~^
  1 error generated.
```

This seems to be the case of clang not having `__cpp_lib_bitops` defined but `std::log2p1` having been removed.

### What changes are included in this PR?

Check for `__apple_build_version__` instead of `__clang__` so non Apple Clang just uses `std::bit_width`

### Are these changes tested?

Via CI

### Are there any user-facing changes?

No
* GitHub Issue: #49569