### PR TITLE
GH-49591: [R][CI] r-binary-packages crossbow job fails for CRAN patch releases

### DIFF
--- a/dev/tasks/r/github.packages.yml
+++ b/dev/tasks/r/github.packages.yml
@@ -36,8 +36,7 @@ jobs:
         id: save-version
         shell: bash
         run: |
-          # Truncate to 3 components (e.g., 23.0.1.1 -> 23.0.1) for CRAN patch releases
-          echo "pkg_version=$(grep ^Version arrow/r/DESCRIPTION | sed 's/Version: //' | cut -d. -f1-3)" >> $GITHUB_OUTPUT
+          echo "pkg_version=$(grep ^Version arrow/r/DESCRIPTION | sed 's/Version: //')" >> $GITHUB_OUTPUT
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/dev/tasks/r/github.packages.yml
+++ b/dev/tasks/r/github.packages.yml
@@ -36,7 +36,8 @@ jobs:
         id: save-version
         shell: bash
         run: |
-          echo "pkg_version=$(grep ^Version arrow/r/DESCRIPTION | sed s/Version:\ //)" >> $GITHUB_OUTPUT
+          # Truncate to 3 components (e.g., 23.0.1.1 -> 23.0.1) for CRAN patch releases
+          echo "pkg_version=$(grep ^Version arrow/r/DESCRIPTION | sed 's/Version: //' | cut -d. -f1-3)" >> $GITHUB_OUTPUT
 
       - uses: r-lib/actions/setup-r@v2
         with:


### PR DESCRIPTION
### Rationale for this change

CI fails on CRAN patch releases

### What changes are included in this PR?

Go for 3 component version not 4

### Are these changes tested?

Will submit CI job

### Are there any user-facing changes?

No

* GitHub Issue: #49591