### PR TITLE
GH-49593: [R][CI] Add libuv-dev to CI jobs due to update to fs package

### DIFF
--- a/.env
+++ b/.env
@@ -84,7 +84,6 @@ R_ORG=rhub
 R_TAG=latest
 
 # Env vars for R builds
-R_UPDATE_CLANG=false
 R_CUSTOM_CCACHE=false
 ARROW_R_DEV=TRUE
 R_PRUNE_DEPS=FALSE

--- a/ci/docker/linux-r.dockerfile
+++ b/ci/docker/linux-r.dockerfile
@@ -33,9 +33,6 @@ ENV R_PRUNE_DEPS=${r_prune_deps}
 ARG r_custom_ccache=false
 ENV R_CUSTOM_CCACHE=${r_custom_ccache}
 
-ARG r_update_clang=false
-ENV R_UPDATE_CLANG=${r_update_clang}
-
 ARG tz="UTC"
 ENV TZ=${tz}
 

--- a/ci/scripts/r_docker_configure.sh
+++ b/ci/scripts/r_docker_configure.sh
@@ -85,17 +85,6 @@ else
   $PACKAGE_MANAGER install -y rsync cmake curl
 fi
 
-# Update clang version to latest available.
-# This is only for rhub/clang20. If we change the base image from rhub/clang20,
-# we need to update this part too.
-if [ "$R_UPDATE_CLANG" = true ]; then
-  apt update -y --allow-releaseinfo-change # flag needed for when debian version changes
-  apt install -y gnupg
-  curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /etc/apt/trusted.gpg.d/llvm.gpg
-  echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-20 main" > /etc/apt/sources.list.d/llvm20.list
-  apt update -y --allow-releaseinfo-change # flag needed for when debian version changes
-  apt install -y clang-20 lld-20
-fi
 
 # Workaround for html help install failure; see https://github.com/r-lib/devtools/issues/2084#issuecomment-530912786
 Rscript -e 'x <- file.path(R.home("doc"), "html"); if (!file.exists(x)) {dir.create(x, recursive=TRUE); file.copy(system.file("html/R.css", package="stats"), x)}'

--- a/ci/scripts/r_install_system_dependencies.sh
+++ b/ci/scripts/r_install_system_dependencies.sh
@@ -35,17 +35,19 @@ else
   apt-get update
 fi
 
-# Install curl and OpenSSL (technically, only needed for S3/GCS support, but
-# installing the R curl package fails without it)
+# Install curl, OpenSSL, and libuv
+# - curl/OpenSSL: technically only needed for S3/GCS support, but
+#   installing the R curl package fails without it
+# - libuv: required by the fs R package (no longer bundles libuv by default)
 case "$PACKAGE_MANAGER" in
   apt-get)
-    apt-get install -y libcurl4-openssl-dev libssl-dev
+    apt-get install -y libcurl4-openssl-dev libssl-dev libuv1-dev
     ;;
   apk)
-    $PACKAGE_MANAGER add curl-dev openssl-dev
+    $PACKAGE_MANAGER add curl-dev openssl-dev libuv-dev
     ;;
   *)
-    $PACKAGE_MANAGER install -y libcurl-devel openssl-devel
+    $PACKAGE_MANAGER install -y libcurl-devel openssl-devel libuv-devel
     ;;
 esac
 

--- a/ci/scripts/r_revdepcheck.sh
+++ b/ci/scripts/r_revdepcheck.sh
@@ -36,6 +36,7 @@ apt install -y \
   libbz2-dev \
   libc-ares-dev \
   libcurl4-openssl-dev \
+  libuv1-dev \
   libgflags-dev \
   libgoogle-glog-dev \
   liblz4-dev \

--- a/compose.yaml
+++ b/compose.yaml
@@ -1667,7 +1667,6 @@ services:
         tz: ${TZ}
         r_prune_deps: ${R_PRUNE_DEPS}
         r_custom_ccache: ${R_CUSTOM_CCACHE}
-        r_update_clang: ${R_UPDATE_CLANG}
     shm_size: *shm-size
     environment:
       <<: [*common, *sccache]

--- a/dev/tasks/r/github.linux.cran.yml
+++ b/dev/tasks/r/github.linux.cran.yml
@@ -33,13 +33,12 @@ jobs:
           - { r_image: "ubuntu-clang" }  # ~ r-devel-linux-x86_64-debian-clang
           - { r_image: "ubuntu-next" }  # ~ r-patched-linux-x86_64
           - { r_image: "ubuntu-release" }  # ~ r-release-linux-x86_64
-          - { r_image: "clang20", skip_vignettes: true, r_update_clang: true }  # ~ r-devel-linux-x86_64-fedora-clang
+          - { r_image: "clang22", skip_vignettes: true }  # ~ r-devel-linux-x86_64-fedora-clang
     env:
       R_ORG: "rhub"
       R_IMAGE: {{ '${{ matrix.config.r_image }}' }}
       R_TAG: "latest"
       ARROW_R_DEV: "FALSE"
-      R_UPDATE_CLANG: {{ '${{ matrix.config.r_update_clang }}' }}
     steps:
       {{ macros.github_checkout_arrow()|indent }}
       {{ macros.github_install_archery()|indent }}

--- a/dev/tasks/r/github.packages.yml
+++ b/dev/tasks/r/github.packages.yml
@@ -374,10 +374,10 @@ jobs:
           arrow/ci/scripts/install_sccache.sh unknown-linux-musl /usr/local/bin
       - name: Install R package system dependencies (Linux)
         if: matrix.platform.name == 'Linux'
-        run: sudo apt-get install -y libcurl4-openssl-dev libssl-dev
+        run: sudo apt-get install -y libcurl4-openssl-dev libssl-dev libuv1-dev
       - name: Install R package system dependencies (macOS)
         if: matrix.platform.name == 'macOS'
-        run: brew install sccache openssl curl
+        run: brew install sccache openssl curl libuv
       - name: Remove arrow/
         run: |
           rm -rf arrow/


### PR DESCRIPTION
### Rationale for this change

fs package release no longer installs bundled libuv so we need to add it to our CI

### What changes are included in this PR?

Add libuv to R install scripts on CI

### Are these changes tested?

I'll run CI

### Are there any user-facing changes?

No
* GitHub Issue: #49593