### PR TITLE
GH-49596: [CI][Dev] Pin PyGithub to < 2.9 to fix broken archery

### DIFF
--- a/dev/archery/setup.py
+++ b/dev/archery/setup.py
@@ -37,9 +37,9 @@ extras = {
     'integration': ['cffi', 'numpy'],
     'integration-java': ['jpype1'],
     'numpydoc': ['numpydoc==1.1.0'],
-    'release': ['pygithub', jinja_req, 'semver', 'gitpython'],
+    'release': ['pygithub<2.9.0', jinja_req, 'semver', 'gitpython'],
 }
-extras['bot'] = extras['crossbow'] + ['pygithub']
+extras['bot'] = extras['crossbow'] + ['pygithub<2.9.0']
 extras['all'] = list(set(functools.reduce(operator.add, extras.values())))
 
 setup(


### PR DESCRIPTION
### Rationale for this change

A new PyGithub release has broken archery:
https://github.com/PyGithub/PyGithub/releases/tag/v2.9.0

I tried some quick test error fixes but those are going to require more investigation.

### What changes are included in this PR?

Pin PyGithub to < 2.9 so archery doesn't fail.

### Are these changes tested?

Yes via CI

### Are there any user-facing changes?
No

* GitHub Issue: #49596