### PR TITLE
GH-48590: [C++] Migrate SFINAE enable_if patterns to C++20 concepts

### DIFF
--- a/cpp/src/arrow/acero/asof_join_node.cc
+++ b/cpp/src/arrow/acero/asof_join_node.cc
@@ -130,7 +130,8 @@ typedef uint64_t row_index_t;
 typedef int col_index_t;
 
 // indicates normalization of a key value
-template <typename T, enable_if_t<std::is_integral<T>::value, bool> = true>
+template <typename T>
+  requires std::is_integral_v<T>
 static inline uint64_t key_value(T t) {
   return static_cast<uint64_t>(t);
 }

--- a/cpp/src/arrow/acero/time_series_util.cc
+++ b/cpp/src/arrow/acero/time_series_util.cc
@@ -22,7 +22,8 @@
 
 namespace arrow::acero {
 
-template <typename T, enable_if_t<std::is_integral<T>::value, bool>>
+template <typename T>
+  requires std::is_integral_v<T>
 inline uint64_t NormalizeTime(T t) {
   uint64_t bias =
       std::is_signed<T>::value ? static_cast<uint64_t>(1) << (8 * sizeof(T) - 1) : 0;

--- a/cpp/src/arrow/acero/time_series_util.h
+++ b/cpp/src/arrow/acero/time_series_util.h
@@ -23,7 +23,8 @@
 namespace arrow::acero {
 
 // normalize the value to unsigned 64-bits while preserving ordering of values
-template <typename T, enable_if_t<std::is_integral<T>::value, bool> = true>
+template <typename T>
+  requires std::is_integral_v<T>
 uint64_t NormalizeTime(T t);
 
 uint64_t GetTime(const RecordBatch* batch, Type::type time_type, int col, uint64_t row);

--- a/cpp/src/arrow/acero/unmaterialized_table_internal.h
+++ b/cpp/src/arrow/acero/unmaterialized_table_internal.h
@@ -166,8 +166,9 @@ class UnmaterializedCompositeTable {
   }
 
   template <class Type, class Builder = typename TypeTraits<Type>::BuilderType>
-  enable_if_boolean<Type, Status> static BuilderAppend(
-      Builder& builder, const std::shared_ptr<ArrayData>& source, uint64_t row) {
+    requires arrow_boolean<Type>
+  static Status BuilderAppend(Builder& builder, const std::shared_ptr<ArrayData>& source,
+                              uint64_t row) {
     if (source->IsNull(row)) {
       builder.UnsafeAppendNull();
       return Status::OK();
@@ -177,10 +178,9 @@ class UnmaterializedCompositeTable {
   }
 
   template <class Type, class Builder = typename TypeTraits<Type>::BuilderType>
-  enable_if_t<is_fixed_width_type<Type>::value && !is_boolean_type<Type>::value,
-              Status> static BuilderAppend(Builder& builder,
-                                           const std::shared_ptr<ArrayData>& source,
-                                           uint64_t row) {
+    requires(arrow_fixed_width<Type> && !arrow_boolean<Type>)
+  static Status BuilderAppend(Builder& builder, const std::shared_ptr<ArrayData>& source,
+                              uint64_t row) {
     if (source->IsNull(row)) {
       builder.UnsafeAppendNull();
       return Status::OK();
@@ -191,8 +191,9 @@ class UnmaterializedCompositeTable {
   }
 
   template <class Type, class Builder = typename TypeTraits<Type>::BuilderType>
-  enable_if_base_binary<Type, Status> static BuilderAppend(
-      Builder& builder, const std::shared_ptr<ArrayData>& source, uint64_t row) {
+    requires arrow_base_binary<Type>
+  static Status BuilderAppend(Builder& builder, const std::shared_ptr<ArrayData>& source,
+                              uint64_t row) {
     if (source->IsNull(row)) {
       return builder.AppendNull();
     }

--- a/cpp/src/arrow/adapters/orc/util.cc
+++ b/cpp/src/arrow/adapters/orc/util.cc
@@ -488,21 +488,17 @@ Result<std::shared_ptr<Array>> NormalizeArray(const std::shared_ptr<Array>& arra
   }
 }
 
-template <class DataType, class BatchType, typename Enable = void>
+template <class DataType, class BatchType>
 struct Appender {};
 
 // Types for long/double-like Appender, that is, numeric, boolean or date32
 template <typename T>
-using is_generic_type =
-    std::integral_constant<bool, is_number_type<T>::value ||
-                                     std::is_same<Date32Type, T>::value ||
-                                     is_boolean_type<T>::value>;
-template <typename T, typename R = void>
-using enable_if_generic = enable_if_t<is_generic_type<T>::value, R>;
+concept generic_type = arrow_number<T> || std::same_as<Date32Type, T> || arrow_boolean<T>;
 
 // Number-like
 template <class DataType, class BatchType>
-struct Appender<DataType, BatchType, enable_if_generic<DataType>> {
+  requires generic_type<DataType>
+struct Appender<DataType, BatchType> {
   using ArrayType = typename TypeTraits<DataType>::ArrayType;
   using ValueType = typename TypeTraits<DataType>::CType;
   Status VisitNull() {

--- a/cpp/src/arrow/array/array_dict.cc
+++ b/cpp/src/arrow/array/array_dict.cc
@@ -289,7 +289,8 @@ struct CompactTransposeMapVisitor {
   }
 
   template <typename Type>
-  enable_if_integer<Type, Status> Visit(const Type&) {
+    requires arrow_integer<Type>
+  Status Visit(const Type&) {
     return CompactTransposeMapImpl<Type>();
   }
 
@@ -435,14 +436,16 @@ struct MakeUnifier {
       : pool(pool), value_type(std::move(value_type)) {}
 
   template <typename T>
-  enable_if_no_memoize<T, Status> Visit(const T&) {
+    requires dictionary_has_no_memo_table<T>
+  Status Visit(const T&) {
     // Default implementation for non-dictionary-supported datatypes
     return Status::NotImplemented("Unification of ", *value_type,
                                   " dictionaries is not implemented");
   }
 
   template <typename T>
-  enable_if_memoize<T, Status> Visit(const T&) {
+    requires dictionary_has_memo_table<T>
+  Status Visit(const T&) {
     result.reset(new DictionaryUnifierImpl<T>(pool, value_type));
     return Status::OK();
   }

--- a/cpp/src/arrow/array/array_list_test.cc
+++ b/cpp/src/arrow/array/array_list_test.cc
@@ -330,7 +330,8 @@ class TestListArray : public ::testing::Test {
   }
 
   template <bool IsList = !kTypeClassIsListView>
-  std::enable_if_t<IsList, void> TestFromArraysWithSlicedOffsets() {
+    requires IsList
+  void TestFromArraysWithSlicedOffsets() {
     std::vector<offset_type> offsets = {-1, -1, 0, 1, 2, 4};
 
     std::shared_ptr<Array> offsets_wo_nulls;
@@ -356,7 +357,8 @@ class TestListArray : public ::testing::Test {
   }
 
   template <bool IsList = !kTypeClassIsListView>
-  std::enable_if_t<IsList, void> TestFromArraysWithSlicedNullOffsets() {
+    requires IsList
+  void TestFromArraysWithSlicedNullOffsets() {
     std::vector<offset_type> offsets = {-1, -1, 0, 1, 1, 3};
     std::vector<bool> offsets_w_nulls_is_valid = {true, true, true, false, true, true};
 
@@ -479,7 +481,8 @@ class TestListArray : public ::testing::Test {
   }
 
   template <bool IsListView = kTypeClassIsListView>
-  std::enable_if_t<IsListView, void> DoTestListViewFromArrays() {
+    requires IsListView
+  void DoTestListViewFromArrays() {
     std::shared_ptr<Array> offsets1, offsets2;
     std::shared_ptr<Array> sizes1, sizes2, sizes3, sizes4, sizes5;
     std::shared_ptr<Array> values;

--- a/cpp/src/arrow/array/array_primitive.h
+++ b/cpp/src/arrow/array/array_primitive.h
@@ -97,8 +97,8 @@ class NumericArray : public PrimitiveArray {
   // Only enable this constructor without a type argument for types without additional
   // metadata
   template <typename T1 = TYPE>
-  NumericArray(enable_if_parameter_free<T1, int64_t> length,
-               const std::shared_ptr<Buffer>& data,
+    requires arrow_parameter_free<T1>
+  NumericArray(int64_t length, const std::shared_ptr<Buffer>& data,
                const std::shared_ptr<Buffer>& null_bitmap = NULLPTR,
                int64_t null_count = kUnknownNullCount, int64_t offset = 0) {
     NumericArray::SetData(ArrayData::Make(TypeTraits<T1>::type_singleton(), length,

--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -1328,7 +1328,8 @@ class TestPrimitiveBuilder : public TestBuilder {
 
 /// \brief uint8_t isn't a valid template parameter to uniform_int_distribution, so
 /// we use SampleType to determine which kind of integer to use to sample.
-template <typename T, typename = enable_if_t<std::is_integral<T>::value, T>>
+template <typename T>
+  requires std::is_integral_v<T>
 struct UniformIntSampleType {
   using type = T;
 };

--- a/cpp/src/arrow/array/builder_adaptive.cc
+++ b/cpp/src/arrow/array/builder_adaptive.cc
@@ -64,14 +64,14 @@ Status AdaptiveIntBuilderBase::Resize(int64_t capacity) {
 }
 
 template <typename new_type, typename old_type>
-typename std::enable_if<sizeof(old_type) >= sizeof(new_type), Status>::type
-AdaptiveIntBuilderBase::ExpandIntSizeInternal() {
+  requires(sizeof(old_type) >= sizeof(new_type))
+Status AdaptiveIntBuilderBase::ExpandIntSizeInternal() {
   return Status::OK();
 }
 
 template <typename new_type, typename old_type>
-typename std::enable_if<(sizeof(old_type) < sizeof(new_type)), Status>::type
-AdaptiveIntBuilderBase::ExpandIntSizeInternal() {
+  requires(sizeof(old_type) < sizeof(new_type))
+Status AdaptiveIntBuilderBase::ExpandIntSizeInternal() {
   int_size_ = sizeof(new_type);
   RETURN_NOT_OK(Resize(data_->size() / sizeof(old_type)));
 

--- a/cpp/src/arrow/array/builder_adaptive.h
+++ b/cpp/src/arrow/array/builder_adaptive.h
@@ -113,11 +113,11 @@ class ARROW_EXPORT AdaptiveIntBuilderBase : public ArrayBuilder {
   virtual Status CommitPendingData() = 0;
 
   template <typename new_type, typename old_type>
-  typename std::enable_if<sizeof(old_type) >= sizeof(new_type), Status>::type
-  ExpandIntSizeInternal();
+    requires(sizeof(old_type) >= sizeof(new_type))
+  Status ExpandIntSizeInternal();
   template <typename new_type, typename old_type>
-  typename std::enable_if<(sizeof(old_type) < sizeof(new_type)), Status>::type
-  ExpandIntSizeInternal();
+    requires(sizeof(old_type) < sizeof(new_type))
+  Status ExpandIntSizeInternal();
 
   std::shared_ptr<ResizableBuffer> data_;
   uint8_t* raw_data_ = NULLPTR;

--- a/cpp/src/arrow/array/builder_base.cc
+++ b/cpp/src/arrow/array/builder_base.cc
@@ -114,7 +114,8 @@ struct AppendScalarImpl {
   }
 
   template <typename T>
-  enable_if_t<has_c_type<T>::value, Status> Visit(const T& t) {
+    requires arrow_has_c_type<T>
+  Status Visit(const T& t) {
     return HandleFixedWidth(t);
   }
 
@@ -125,7 +126,8 @@ struct AppendScalarImpl {
   Status Visit(const Decimal256Type& t) { return HandleFixedWidth(t); }
 
   template <typename T>
-  enable_if_has_string_view<T, Status> Visit(const T&) {
+    requires arrow_has_string_view<T>
+  Status Visit(const T&) {
     int64_t data_size = 0;
     for (auto it = scalars_begin_; it != scalars_end_; ++it) {
       const auto& scalar = checked_cast<const typename TypeTraits<T>::ScalarType&>(*it);
@@ -152,8 +154,8 @@ struct AppendScalarImpl {
   }
 
   template <typename T>
-  enable_if_t<is_list_view_type<T>::value || is_list_like_type<T>::value, Status> Visit(
-      const T&) {
+    requires(arrow_list_view<T> || arrow_list_like<T>)
+  Status Visit(const T&) {
     auto builder = checked_cast<typename TypeTraits<T>::BuilderType*>(builder_);
     int64_t num_children = 0;
     for (auto it = scalars_begin_; it != scalars_end_; ++it) {

--- a/cpp/src/arrow/array/builder_dict.cc
+++ b/cpp/src/arrow/array/builder_dict.cc
@@ -44,13 +44,15 @@ class DictionaryMemoTable::DictionaryMemoTableImpl {
     std::unique_ptr<MemoTable>* memo_table_;
 
     template <typename T>
-    enable_if_no_memoize<T, Status> Visit(const T&) {
+      requires dictionary_has_no_memo_table<T>
+    Status Visit(const T&) {
       return Status::NotImplemented("Initialization of ", value_type_->ToString(),
                                     " memo table is not implemented");
     }
 
     template <typename T>
-    enable_if_memoize<T, Status> Visit(const T&) {
+      requires dictionary_has_memo_table<T>
+    Status Visit(const T&) {
       using MemoTable = typename DictionaryTraits<T>::MemoTableType;
       memo_table_->reset(new MemoTable(pool_, 0));
       return Status::OK();
@@ -70,13 +72,15 @@ class DictionaryMemoTable::DictionaryMemoTableImpl {
 
    private:
     template <typename T, typename ArrayType>
-    enable_if_no_memoize<T, Status> InsertValues(const T& type, const ArrayType&) {
+      requires dictionary_has_no_memo_table<T>
+    Status InsertValues(const T& type, const ArrayType&) {
       return Status::NotImplemented("Inserting array values of ", type,
                                     " is not implemented");
     }
 
     template <typename T, typename ArrayType>
-    enable_if_memoize<T, Status> InsertValues(const T&, const ArrayType& array) {
+      requires dictionary_has_memo_table<T>
+    Status InsertValues(const T&, const ArrayType& array) {
       if (array.null_count() > 0) {
         return Status::Invalid("Cannot insert dictionary values containing nulls");
       }
@@ -97,13 +101,15 @@ class DictionaryMemoTable::DictionaryMemoTableImpl {
     std::shared_ptr<ArrayData>* out_;
 
     template <typename T>
-    enable_if_no_memoize<T, Status> Visit(const T&) {
+      requires dictionary_has_no_memo_table<T>
+    Status Visit(const T&) {
       return Status::NotImplemented("Getting array data of ", value_type_,
                                     " is not implemented");
     }
 
     template <typename T>
-    enable_if_memoize<T, Status> Visit(const T&) {
+      requires dictionary_has_memo_table<T>
+    Status Visit(const T&) {
       using ConcreteMemoTable = typename DictionaryTraits<T>::MemoTableType;
       auto memo_table = checked_cast<ConcreteMemoTable*>(memo_table_);
       ARROW_ASSIGN_OR_RAISE(*out_, DictionaryTraits<T>::GetDictionaryArrayData(

--- a/cpp/src/arrow/array/builder_dict.h
+++ b/cpp/src/arrow/array/builder_dict.h
@@ -46,28 +46,28 @@ namespace arrow {
 
 namespace internal {
 
-template <typename T, typename Enable = void>
+template <typename T>
 struct DictionaryValue {
   using type = typename T::c_type;
   using PhysicalType = T;
 };
 
-template <typename T>
-struct DictionaryValue<T, enable_if_base_binary<T>> {
+template <arrow_base_binary T>
+struct DictionaryValue<T> {
   using type = std::string_view;
   using PhysicalType =
       typename std::conditional<std::is_same<typename T::offset_type, int32_t>::value,
                                 BinaryType, LargeBinaryType>::type;
 };
 
-template <typename T>
-struct DictionaryValue<T, enable_if_binary_view_like<T>> {
+template <arrow_binary_view_like T>
+struct DictionaryValue<T> {
   using type = std::string_view;
   using PhysicalType = BinaryViewType;
 };
 
-template <typename T>
-struct DictionaryValue<T, enable_if_fixed_size_binary<T>> {
+template <arrow_fixed_size_binary T>
+struct DictionaryValue<T> {
   using type = std::string_view;
   using PhysicalType = BinaryType;
 };
@@ -148,11 +148,9 @@ class DictionaryBuilderBase : public ArrayBuilder {
   // WARNING: the type given below is the value type, not the DictionaryType.
   // The DictionaryType is instantiated on the Finish() call.
   template <typename B = BuilderType, typename T1 = T>
+    requires(std::is_base_of_v<AdaptiveIntBuilderBase, B> && !arrow_fixed_size_binary<T1>)
   DictionaryBuilderBase(uint8_t start_int_size,
-                        enable_if_t<std::is_base_of<AdaptiveIntBuilderBase, B>::value &&
-                                        !is_fixed_size_binary_type<T1>::value,
-                                    const std::shared_ptr<DataType>&>
-                            value_type,
+                        const std::shared_ptr<DataType>& value_type,
                         MemoryPool* pool = default_memory_pool(),
                         int64_t alignment = kDefaultBufferAlignment)
       : ArrayBuilder(pool, alignment),
@@ -163,11 +161,10 @@ class DictionaryBuilderBase : public ArrayBuilder {
         value_type_(value_type) {}
 
   template <typename T1 = T>
-  explicit DictionaryBuilderBase(
-      enable_if_t<!is_fixed_size_binary_type<T1>::value, const std::shared_ptr<DataType>&>
-          value_type,
-      MemoryPool* pool = default_memory_pool(),
-      int64_t alignment = kDefaultBufferAlignment)
+    requires(!arrow_fixed_size_binary<T1>)
+  explicit DictionaryBuilderBase(const std::shared_ptr<DataType>& value_type,
+                                 MemoryPool* pool = default_memory_pool(),
+                                 int64_t alignment = kDefaultBufferAlignment)
       : ArrayBuilder(pool, alignment),
         memo_table_(new internal::DictionaryMemoTable(pool, value_type)),
         delta_offset_(0),
@@ -176,12 +173,11 @@ class DictionaryBuilderBase : public ArrayBuilder {
         value_type_(value_type) {}
 
   template <typename T1 = T>
-  explicit DictionaryBuilderBase(
-      const std::shared_ptr<DataType>& index_type,
-      enable_if_t<!is_fixed_size_binary_type<T1>::value, const std::shared_ptr<DataType>&>
-          value_type,
-      MemoryPool* pool = default_memory_pool(),
-      int64_t alignment = kDefaultBufferAlignment)
+    requires(!arrow_fixed_size_binary<T1>)
+  explicit DictionaryBuilderBase(const std::shared_ptr<DataType>& index_type,
+                                 const std::shared_ptr<DataType>& value_type,
+                                 MemoryPool* pool = default_memory_pool(),
+                                 int64_t alignment = kDefaultBufferAlignment)
       : ArrayBuilder(pool, alignment),
         memo_table_(new internal::DictionaryMemoTable(pool, value_type)),
         delta_offset_(0),
@@ -190,11 +186,9 @@ class DictionaryBuilderBase : public ArrayBuilder {
         value_type_(value_type) {}
 
   template <typename B = BuilderType, typename T1 = T>
+    requires(std::is_base_of_v<AdaptiveIntBuilderBase, B> && arrow_fixed_size_binary<T1>)
   DictionaryBuilderBase(uint8_t start_int_size,
-                        enable_if_t<std::is_base_of<AdaptiveIntBuilderBase, B>::value &&
-                                        is_fixed_size_binary_type<T1>::value,
-                                    const std::shared_ptr<DataType>&>
-                            value_type,
+                        const std::shared_ptr<DataType>& value_type,
                         MemoryPool* pool = default_memory_pool(),
                         int64_t alignment = kDefaultBufferAlignment)
       : ArrayBuilder(pool, alignment),
@@ -205,10 +199,10 @@ class DictionaryBuilderBase : public ArrayBuilder {
         value_type_(value_type) {}
 
   template <typename T1 = T>
-  explicit DictionaryBuilderBase(
-      enable_if_fixed_size_binary<T1, const std::shared_ptr<DataType>&> value_type,
-      MemoryPool* pool = default_memory_pool(),
-      int64_t alignment = kDefaultBufferAlignment)
+    requires arrow_fixed_size_binary<T1>
+  explicit DictionaryBuilderBase(const std::shared_ptr<DataType>& value_type,
+                                 MemoryPool* pool = default_memory_pool(),
+                                 int64_t alignment = kDefaultBufferAlignment)
       : ArrayBuilder(pool, alignment),
         memo_table_(new internal::DictionaryMemoTable(pool, value_type)),
         delta_offset_(0),
@@ -217,11 +211,11 @@ class DictionaryBuilderBase : public ArrayBuilder {
         value_type_(value_type) {}
 
   template <typename T1 = T>
-  explicit DictionaryBuilderBase(
-      const std::shared_ptr<DataType>& index_type,
-      enable_if_fixed_size_binary<T1, const std::shared_ptr<DataType>&> value_type,
-      MemoryPool* pool = default_memory_pool(),
-      int64_t alignment = kDefaultBufferAlignment)
+    requires arrow_fixed_size_binary<T1>
+  explicit DictionaryBuilderBase(const std::shared_ptr<DataType>& index_type,
+                                 const std::shared_ptr<DataType>& value_type,
+                                 MemoryPool* pool = default_memory_pool(),
+                                 int64_t alignment = kDefaultBufferAlignment)
       : ArrayBuilder(pool, alignment),
         memo_table_(new internal::DictionaryMemoTable(pool, value_type)),
         delta_offset_(0),
@@ -230,8 +224,8 @@ class DictionaryBuilderBase : public ArrayBuilder {
         value_type_(value_type) {}
 
   template <typename T1 = T>
-  explicit DictionaryBuilderBase(
-      enable_if_parameter_free<T1, MemoryPool*> pool = default_memory_pool())
+    requires arrow_parameter_free<T1>
+  explicit DictionaryBuilderBase(MemoryPool* pool = default_memory_pool())
       : DictionaryBuilderBase<BuilderType, T1>(TypeTraits<T1>::type_singleton(), pool) {}
 
   // This constructor doesn't check for errors. Use InsertMemoValues instead.
@@ -252,7 +246,8 @@ class DictionaryBuilderBase : public ArrayBuilder {
 
   /// \brief The value byte width (for FixedSizeBinaryType)
   template <typename T1 = T>
-  enable_if_fixed_size_binary<T1, int32_t> byte_width() const {
+    requires arrow_fixed_size_binary<T1>
+  int32_t byte_width() const {
     return byte_width_;
   }
 
@@ -270,37 +265,43 @@ class DictionaryBuilderBase : public ArrayBuilder {
 
   /// \brief Append a fixed-width string (only for FixedSizeBinaryType)
   template <typename T1 = T>
-  enable_if_fixed_size_binary<T1, Status> Append(const uint8_t* value) {
+    requires arrow_fixed_size_binary<T1>
+  Status Append(const uint8_t* value) {
     return Append(std::string_view(reinterpret_cast<const char*>(value), byte_width_));
   }
 
   /// \brief Append a fixed-width string (only for FixedSizeBinaryType)
   template <typename T1 = T>
-  enable_if_fixed_size_binary<T1, Status> Append(const char* value) {
+    requires arrow_fixed_size_binary<T1>
+  Status Append(const char* value) {
     return Append(std::string_view(value, byte_width_));
   }
 
   /// \brief Append a string (only for binary types)
   template <typename T1 = T>
-  enable_if_binary_like<T1, Status> Append(const uint8_t* value, int32_t length) {
+    requires arrow_binary_like<T1>
+  Status Append(const uint8_t* value, int32_t length) {
     return Append(reinterpret_cast<const char*>(value), length);
   }
 
   /// \brief Append a string (only for binary types)
   template <typename T1 = T>
-  enable_if_binary_like<T1, Status> Append(const char* value, int32_t length) {
+    requires arrow_binary_like<T1>
+  Status Append(const char* value, int32_t length) {
     return Append(std::string_view(value, length));
   }
 
   /// \brief Append a string (only for string types)
   template <typename T1 = T>
-  enable_if_string_like<T1, Status> Append(const char* value, int32_t length) {
+    requires arrow_string_like<T1>
+  Status Append(const char* value, int32_t length) {
     return Append(std::string_view(value, length));
   }
 
   /// \brief Append a decimal (only for Decimal32/64/128/256 Type)
   template <typename T1 = T, typename CType = typename TypeTraits<T1>::CType>
-  enable_if_decimal<T1, Status> Append(const CType& value) {
+    requires arrow_decimal<T1>
+  Status Append(const CType& value) {
     auto bytes = value.ToBytes();
     return Append(bytes.data(), static_cast<int32_t>(bytes.size()));
   }
@@ -411,8 +412,8 @@ class DictionaryBuilderBase : public ArrayBuilder {
 
   /// \brief Append a whole dense array to the builder
   template <typename T1 = T>
-  enable_if_t<!is_fixed_size_binary_type<T1>::value, Status> AppendArray(
-      const Array& array) {
+    requires(!arrow_fixed_size_binary<T1>)
+  Status AppendArray(const Array& array) {
     using ArrayType = typename TypeTraits<T>::ArrayType;
 
 #ifndef NDEBUG
@@ -432,7 +433,8 @@ class DictionaryBuilderBase : public ArrayBuilder {
   }
 
   template <typename T1 = T>
-  enable_if_fixed_size_binary<T1, Status> AppendArray(const Array& array) {
+    requires arrow_fixed_size_binary<T1>
+  Status AppendArray(const Array& array) {
 #ifndef NDEBUG
     ARROW_RETURN_NOT_OK(ArrayBuilder::CheckArrayType(
         value_type_, array, "Wrong value type of array to be appended"));
@@ -567,11 +569,10 @@ template <typename BuilderType>
 class DictionaryBuilderBase<BuilderType, NullType> : public ArrayBuilder {
  public:
   template <typename B = BuilderType>
-  DictionaryBuilderBase(
-      enable_if_t<std::is_base_of<AdaptiveIntBuilderBase, B>::value, uint8_t>
-          start_int_size,
-      const std::shared_ptr<DataType>& value_type,
-      MemoryPool* pool = default_memory_pool())
+    requires std::is_base_of_v<AdaptiveIntBuilderBase, B>
+  DictionaryBuilderBase(uint8_t start_int_size,
+                        const std::shared_ptr<DataType>& value_type,
+                        MemoryPool* pool = default_memory_pool())
       : ArrayBuilder(pool), indices_builder_(start_int_size, pool) {}
 
   explicit DictionaryBuilderBase(const std::shared_ptr<DataType>& value_type,
@@ -584,10 +585,9 @@ class DictionaryBuilderBase<BuilderType, NullType> : public ArrayBuilder {
       : ArrayBuilder(pool), indices_builder_(index_type, pool) {}
 
   template <typename B = BuilderType>
-  explicit DictionaryBuilderBase(
-      enable_if_t<std::is_base_of<AdaptiveIntBuilderBase, B>::value, uint8_t>
-          start_int_size,
-      MemoryPool* pool = default_memory_pool())
+    requires std::is_base_of_v<AdaptiveIntBuilderBase, B>
+  explicit DictionaryBuilderBase(uint8_t start_int_size,
+                                 MemoryPool* pool = default_memory_pool())
       : ArrayBuilder(pool), indices_builder_(start_int_size, pool) {}
 
   explicit DictionaryBuilderBase(MemoryPool* pool = default_memory_pool())

--- a/cpp/src/arrow/array/builder_primitive.h
+++ b/cpp/src/arrow/array/builder_primitive.h
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <type_traits>
 #include <vector>
 
 #include "arrow/array/builder_base.h"
@@ -88,9 +89,9 @@ class NumericBuilder
   using ArrayType = typename TypeTraits<T>::ArrayType;
 
   template <typename T1 = T>
-  explicit NumericBuilder(
-      enable_if_parameter_free<T1, MemoryPool*> pool = default_memory_pool(),
-      int64_t alignment = kDefaultBufferAlignment)
+    requires arrow_parameter_free<T1>
+  explicit NumericBuilder(MemoryPool* pool = default_memory_pool(),
+                          int64_t alignment = kDefaultBufferAlignment)
       : ArrayBuilder(pool, alignment),
         type_(TypeTraits<T>::type_singleton()),
         data_builder_(pool, alignment) {}
@@ -268,8 +269,9 @@ class NumericBuilder
   ///  or null(0) values.
   /// \return Status
   template <typename ValuesIter, typename ValidIter>
-  enable_if_t<!std::is_pointer<ValidIter>::value, Status> AppendValues(
-      ValuesIter values_begin, ValuesIter values_end, ValidIter valid_begin) {
+    requires(!std::is_pointer_v<ValidIter>)
+  Status AppendValues(ValuesIter values_begin, ValuesIter values_end,
+                      ValidIter valid_begin) {
     static_assert(!internal::is_null_pointer<ValidIter>::value,
                   "Don't pass a NULLPTR directly as valid_begin, use the 2-argument "
                   "version instead");
@@ -285,8 +287,9 @@ class NumericBuilder
 
   // Same as above, with a pointer type ValidIter
   template <typename ValuesIter, typename ValidIter>
-  enable_if_t<std::is_pointer<ValidIter>::value, Status> AppendValues(
-      ValuesIter values_begin, ValuesIter values_end, ValidIter valid_begin) {
+    requires std::is_pointer_v<ValidIter>
+  Status AppendValues(ValuesIter values_begin, ValuesIter values_end,
+                      ValidIter valid_begin) {
     int64_t length = static_cast<int64_t>(std::distance(values_begin, values_end));
     ARROW_RETURN_NOT_OK(Reserve(length));
     data_builder_.UnsafeAppend(values_begin, values_end);
@@ -624,8 +627,9 @@ class ARROW_EXPORT BooleanBuilder
   ///  or null(0) values
   /// \return Status
   template <typename ValuesIter, typename ValidIter>
-  enable_if_t<!std::is_pointer<ValidIter>::value, Status> AppendValues(
-      ValuesIter values_begin, ValuesIter values_end, ValidIter valid_begin) {
+    requires(!std::is_pointer_v<ValidIter>)
+  Status AppendValues(ValuesIter values_begin, ValuesIter values_end,
+                      ValidIter valid_begin) {
     static_assert(!internal::is_null_pointer<ValidIter>::value,
                   "Don't pass a NULLPTR directly as valid_begin, use the 2-argument "
                   "version instead");
@@ -643,8 +647,9 @@ class ARROW_EXPORT BooleanBuilder
 
   // Same as above, for a pointer type ValidIter
   template <typename ValuesIter, typename ValidIter>
-  enable_if_t<std::is_pointer<ValidIter>::value, Status> AppendValues(
-      ValuesIter values_begin, ValuesIter values_end, ValidIter valid_begin) {
+    requires std::is_pointer_v<ValidIter>
+  Status AppendValues(ValuesIter values_begin, ValuesIter values_end,
+                      ValidIter valid_begin) {
     int64_t length = static_cast<int64_t>(std::distance(values_begin, values_end));
     ARROW_RETURN_NOT_OK(Reserve(length));
     data_builder_.UnsafeAppend<false>(

--- a/cpp/src/arrow/array/concatenate.cc
+++ b/cpp/src/arrow/array/concatenate.cc
@@ -500,7 +500,8 @@ class ConcatenateImpl {
   }
 
   template <typename T>
-  enable_if_list_view<T, Status> Visit(const T& type) {
+    requires arrow_list_view<T>
+  Status Visit(const T& type) {
     using offset_type = typename T::offset_type;
     out_->buffers.resize(3);
     out_->child_data.resize(1);

--- a/cpp/src/arrow/array/dict_internal.h
+++ b/cpp/src/arrow/array/dict_internal.h
@@ -19,6 +19,7 @@
 
 #include "arrow/array/builder_dict.h"
 
+#include <concepts>
 #include <cstdint>
 #include <limits>
 #include <memory>
@@ -40,22 +41,27 @@
 namespace arrow {
 namespace internal {
 
-template <typename T, typename Enable = void>
+template <typename T>
 struct DictionaryTraits {
   using MemoTableType = void;
 };
 
 }  // namespace internal
 
+template <typename T>
+concept dictionary_has_memo_table =
+    !std::same_as<typename internal::DictionaryTraits<T>::MemoTableType, void>;
+
+template <typename T>
+concept dictionary_has_no_memo_table =
+    std::same_as<typename internal::DictionaryTraits<T>::MemoTableType, void>;
+
+// Keep compatibility aliases while downstream files are migrated.
 template <typename T, typename Out = void>
-using enable_if_memoize = enable_if_t<
-    !std::is_same<typename internal::DictionaryTraits<T>::MemoTableType, void>::value,
-    Out>;
+using enable_if_memoize = enable_if_t<dictionary_has_memo_table<T>, Out>;
 
 template <typename T, typename Out = void>
-using enable_if_no_memoize = enable_if_t<
-    std::is_same<typename internal::DictionaryTraits<T>::MemoTableType, void>::value,
-    Out>;
+using enable_if_no_memoize = enable_if_t<dictionary_has_no_memo_table<T>, Out>;
 
 namespace internal {
 
@@ -87,8 +93,8 @@ struct DictionaryTraits<BooleanType> {
   }
 };  // namespace internal
 
-template <typename T>
-struct DictionaryTraits<T, enable_if_has_c_type<T>> {
+template <arrow_has_c_type T>
+struct DictionaryTraits<T> {
   using c_type = typename T::c_type;
   using MemoTableType = typename HashTraits<T>::MemoTableType;
 
@@ -115,8 +121,8 @@ struct DictionaryTraits<T, enable_if_has_c_type<T>> {
   }
 };
 
-template <typename T>
-struct DictionaryTraits<T, enable_if_base_binary<T>> {
+template <arrow_base_binary T>
+struct DictionaryTraits<T> {
   using MemoTableType = typename HashTraits<T>::MemoTableType;
 
   static Result<std::shared_ptr<ArrayData>> GetDictionaryArrayData(
@@ -150,8 +156,8 @@ struct DictionaryTraits<T, enable_if_base_binary<T>> {
   }
 };
 
-template <typename T>
-struct DictionaryTraits<T, enable_if_binary_view_like<T>> {
+template <arrow_binary_view_like T>
+struct DictionaryTraits<T> {
   using MemoTableType = typename HashTraits<T>::MemoTableType;
 
   static_assert(std::is_same_v<MemoTableType, BinaryMemoTable<BinaryBuilder>>);
@@ -176,8 +182,8 @@ struct DictionaryTraits<T, enable_if_binary_view_like<T>> {
   }
 };
 
-template <typename T>
-struct DictionaryTraits<T, enable_if_fixed_size_binary<T>> {
+template <arrow_fixed_size_binary T>
+struct DictionaryTraits<T> {
   using MemoTableType = typename HashTraits<T>::MemoTableType;
 
   static Result<std::shared_ptr<ArrayData>> GetDictionaryArrayData(

--- a/cpp/src/arrow/array/diff.cc
+++ b/cpp/src/arrow/array/diff.cc
@@ -76,8 +76,8 @@ struct Slice {
   bool operator!=(const Slice& other) const { return !(*this == other); }
 };
 
-template <typename ArrayType, typename T = typename ArrayType::TypeClass,
-          typename = enable_if_list_like<T>>
+template <typename ArrayType, typename T = typename ArrayType::TypeClass>
+  requires arrow_list_like<T>
 static Slice GetView(const ArrayType& array, int64_t index) {
   return Slice{array.values().get(), array.value_offset(index),
                array.value_length(index)};
@@ -614,7 +614,8 @@ class MakeFormatterImpl {
 
   // format Numerics with std::ostream defaults
   template <typename T>
-  enable_if_number<T, Status> Visit(const T&) {
+    requires arrow_number<T>
+  Status Visit(const T&) {
     impl_ = [](const Array& array, int64_t index, std::ostream* os) {
       const auto& numeric = checked_cast<const NumericArray<T>&>(array);
       if (sizeof(decltype(numeric.Value(index))) == sizeof(char)) {
@@ -629,7 +630,8 @@ class MakeFormatterImpl {
   }
 
   template <typename T>
-  enable_if_date<T, Status> Visit(const T&) {
+    requires arrow_date<T>
+  Status Visit(const T&) {
     using unit = typename std::conditional<std::is_same<T, Date32Type>::value,
                                            arrow_vendored::date::days,
                                            std::chrono::milliseconds>::type;
@@ -644,7 +646,8 @@ class MakeFormatterImpl {
   }
 
   template <typename T>
-  enable_if_time<T, Status> Visit(const T&) {
+    requires arrow_time<T>
+  Status Visit(const T&) {
     impl_ = MakeTimeFormatter<T, false>("%T");
     return Status::OK();
   }
@@ -673,7 +676,8 @@ class MakeFormatterImpl {
   }
 
   template <typename T>
-  enable_if_has_string_view<T, Status> Visit(const T&) {
+    requires arrow_has_string_view<T>
+  Status Visit(const T&) {
     using ArrayType = typename TypeTraits<T>::ArrayType;
     impl_ = [](const Array& array, int64_t index, std::ostream* os) {
       std::string_view view = checked_cast<const ArrayType&>(array).GetView(index);
@@ -690,7 +694,8 @@ class MakeFormatterImpl {
 
   // format Decimals with Decimal___Array::FormatValue
   template <typename T>
-  enable_if_decimal<T, Status> Visit(const T&) {
+    requires arrow_decimal<T>
+  Status Visit(const T&) {
     impl_ = [](const Array& array, int64_t index, std::ostream* os) {
       const auto& decimal_array =
           checked_cast<const typename TypeTraits<T>::ArrayType&>(array);
@@ -700,7 +705,8 @@ class MakeFormatterImpl {
   }
 
   template <typename T>
-  enable_if_list_like<T, Status> Visit(const T& t) {
+    requires arrow_list_like<T>
+  Status Visit(const T& t) {
     struct ListImpl {
       explicit ListImpl(Formatter f) : values_formatter_(std::move(f)) {}
 

--- a/cpp/src/arrow/array/util.cc
+++ b/cpp/src/arrow/array/util.cc
@@ -141,11 +141,8 @@ class ArrayDataEndianSwapper {
   }
 
   template <typename T>
-  enable_if_t<std::is_base_of<FixedWidthType, T>::value &&
-                  !std::is_base_of<FixedSizeBinaryType, T>::value &&
-                  !std::is_base_of<DictionaryType, T>::value,
-              Status>
-  Visit(const T& type) {
+    requires(arrow_fixed_width<T> && !arrow_fixed_size_binary<T> && !arrow_dictionary<T>)
+  Status Visit(const T& type) {
     using value_type = typename T::c_type;
     ARROW_ASSIGN_OR_RAISE(out_->buffers[1],
                           ByteSwapBuffer<value_type>(data_->buffers[1]));
@@ -153,7 +150,8 @@ class ArrayDataEndianSwapper {
   }
 
   template <typename T>
-  enable_if_decimal<T, Status> Visit(const T& type) {
+    requires arrow_decimal<T>
+  Status Visit(const T& type) {
     using value_type = typename TypeTraits<T>::CType;
     auto data = data_->buffers[1]->span_as<value_type>();
     ARROW_ASSIGN_OR_RAISE(auto new_buffer,
@@ -219,19 +217,16 @@ class ArrayDataEndianSwapper {
   }
 
   template <typename T>
-  enable_if_t<std::is_same<BinaryType, T>::value || std::is_same<StringType, T>::value,
-              Status>
-  Visit(const T& type) {
+    requires(std::is_same_v<BinaryType, T> || std::is_same_v<StringType, T>)
+  Status Visit(const T& type) {
     RETURN_NOT_OK(SwapOffsets<int32_t>(1));
     out_->buffers[2] = data_->buffers[2];
     return Status::OK();
   }
 
   template <typename T>
-  enable_if_t<std::is_same<LargeBinaryType, T>::value ||
-                  std::is_same<LargeStringType, T>::value,
-              Status>
-  Visit(const T& type) {
+    requires(std::is_same_v<LargeBinaryType, T> || std::is_same_v<LargeStringType, T>)
+  Status Visit(const T& type) {
     RETURN_NOT_OK(SwapOffsets<int64_t>(1));
     out_->buffers[2] = data_->buffers[2];
     return Status::OK();
@@ -350,7 +345,8 @@ class NullArrayFactory {
     }
 
     template <typename T>
-    enable_if_var_size_list<T, Status> Visit(const T& type) {
+      requires arrow_var_length_list<T>
+    Status Visit(const T& type) {
       // values array may be empty, but there must be at least one offset of 0
       RETURN_NOT_OK(MaxOf(sizeof(typename T::offset_type) * (length_ + 1)));
       RETURN_NOT_OK(MaxOf(GetBufferLength(type.value_type(), /*length=*/0)));
@@ -358,14 +354,16 @@ class NullArrayFactory {
     }
 
     template <typename T>
-    enable_if_list_view<T, Status> Visit(const T& type) {
+      requires arrow_list_view<T>
+    Status Visit(const T& type) {
       RETURN_NOT_OK(MaxOf(sizeof(typename T::offset_type) * length_));
       RETURN_NOT_OK(MaxOf(GetBufferLength(type.value_type(), /*length=*/0)));
       return Status::OK();
     }
 
     template <typename T>
-    enable_if_base_binary<T, Status> Visit(const T&) {
+      requires arrow_base_binary<T>
+    Status Visit(const T&) {
       // values buffer may be empty, but there must be at least one offset of 0
       return MaxOf(sizeof(typename T::offset_type) * (length_ + 1));
     }
@@ -488,7 +486,8 @@ class NullArrayFactory {
   }
 
   template <typename T>
-  enable_if_base_binary<T, Status> Visit(const T&) {
+    requires arrow_base_binary<T>
+  Status Visit(const T&) {
     out_->buffers.resize(3, buffer_);
     return Status::OK();
   }
@@ -499,7 +498,8 @@ class NullArrayFactory {
   }
 
   template <typename T>
-  enable_if_var_length_list_like<T, Status> Visit(const T& type) {
+    requires arrow_var_length_list_like<T>
+  Status Visit(const T& type) {
     out_->buffers.resize(is_list_view(T::type_id) ? 3 : 2, buffer_);
     ARROW_ASSIGN_OR_RAISE(out_->child_data[0], CreateChild(type, 0, /*length=*/0));
     return Status::OK();
@@ -624,8 +624,8 @@ class RepeatedArrayFactory {
   }
 
   template <typename T>
-  enable_if_t<is_number_type<T>::value || is_temporal_type<T>::value, Status> Visit(
-      const T&) {
+    requires(arrow_number<T> || arrow_temporal<T>)
+  Status Visit(const T&) {
     auto value = scalar<T>().value;
     return FinishFixedWidth(&value, sizeof(value));
   }
@@ -636,7 +636,8 @@ class RepeatedArrayFactory {
   }
 
   template <typename T>
-  enable_if_decimal<T, Status> Visit(const T&) {
+    requires arrow_decimal<T>
+  Status Visit(const T&) {
     auto value = scalar<T>().value.ToBytes();
     return FinishFixedWidth(value.data(), value.size());
   }
@@ -647,7 +648,8 @@ class RepeatedArrayFactory {
   }
 
   template <typename T>
-  enable_if_base_binary<T, Status> Visit(const T&) {
+    requires arrow_base_binary<T>
+  Status Visit(const T&) {
     const std::shared_ptr<Buffer>& value = scalar<T>().value;
     std::shared_ptr<Buffer> values_buffer, offsets_buffer;
     RETURN_NOT_OK(CreateBufferOf(value->data(), value->size(), &values_buffer));
@@ -659,7 +661,8 @@ class RepeatedArrayFactory {
   }
 
   template <typename T>
-  enable_if_binary_view_like<T, Status> Visit(const T& type) {
+    requires arrow_binary_view_like<T>
+  Status Visit(const T& type) {
     std::string_view value{*scalar<T>().value};
     auto s = util::ToBinaryView(value, 0, 0);
     RETURN_NOT_OK(FinishFixedWidth(&s, sizeof(s)));
@@ -670,7 +673,8 @@ class RepeatedArrayFactory {
   }
 
   template <typename T>
-  enable_if_var_size_list<T, Status> Visit(const T& type) {
+    requires arrow_var_length_list<T>
+  Status Visit(const T& type) {
     using ArrayType = typename TypeTraits<T>::ArrayType;
 
     ArrayVector values(length_, scalar<T>().value);
@@ -685,7 +689,8 @@ class RepeatedArrayFactory {
   }
 
   template <typename T>
-  enable_if_list_view<T, Status> Visit(const T& type) {
+    requires arrow_list_view<T>
+  Status Visit(const T& type) {
     using ScalarType = typename TypeTraits<T>::ScalarType;
     using ArrayType = typename TypeTraits<T>::ArrayType;
 

--- a/cpp/src/arrow/array/validate.cc
+++ b/cpp/src/arrow/array/validate.cc
@@ -81,7 +81,8 @@ struct BoundsChecker {
   }
 
   template <typename IntegerType>
-  enable_if_integer<IntegerType, Status> Visit(const IntegerType&) {
+    requires arrow_integer<IntegerType>
+  Status Visit(const IntegerType&) {
     using c_type = typename IntegerType::c_type;
 
     int64_t i = 0;

--- a/cpp/src/arrow/buffer_builder.h
+++ b/cpp/src/arrow/buffer_builder.h
@@ -223,14 +223,13 @@ class ARROW_EXPORT BufferBuilder {
   int64_t alignment_;
 };
 
-template <typename T, typename Enable = void>
+template <typename T>
 class TypedBufferBuilder;
 
 /// \brief A BufferBuilder for building a buffer of arithmetic elements
 template <typename T>
-class TypedBufferBuilder<
-    T, typename std::enable_if<std::is_arithmetic<T>::value ||
-                               std::is_standard_layout<T>::value>::type> {
+  requires(std::is_arithmetic_v<T> || std::is_standard_layout_v<T>)
+class TypedBufferBuilder<T> {
  public:
   explicit TypedBufferBuilder(MemoryPool* pool = default_memory_pool(),
                               int64_t alignment = kDefaultBufferAlignment)

--- a/cpp/src/arrow/builder.cc
+++ b/cpp/src/arrow/builder.cc
@@ -195,7 +195,8 @@ struct DictionaryBuilderCase {
 
 struct MakeBuilderImpl {
   template <typename T>
-  enable_if_not_nested<T, Status> Visit(const T& t) {
+    requires(!arrow_nested<T>)
+  Status Visit(const T& t) {
     out.reset(new typename TypeTraits<T>::BuilderType(type, pool));
     return Status::OK();
   }

--- a/cpp/src/arrow/compare.cc
+++ b/cpp/src/arrow/compare.cc
@@ -240,12 +240,14 @@ class RangeDataEqualsImpl {
   Status Visit(const NullType&) { return Status::OK(); }
 
   template <typename TypeClass>
-  enable_if_primitive_ctype<TypeClass, Status> Visit(const TypeClass& type) {
+    requires arrow_primitive_ctype<TypeClass>
+  Status Visit(const TypeClass& type) {
     return ComparePrimitive(type);
   }
 
   template <typename TypeClass>
-  enable_if_t<is_temporal_type<TypeClass>::value, Status> Visit(const TypeClass& type) {
+    requires arrow_temporal<TypeClass>
+  Status Visit(const TypeClass& type) {
     return ComparePrimitive(type);
   }
 
@@ -739,10 +741,8 @@ class TypeEqualsVisitor {
   }
 
   template <typename T>
-  enable_if_t<is_null_type<T>::value || is_primitive_ctype<T>::value ||
-                  is_base_binary_type<T>::value,
-              Status>
-  Visit(const T&) {
+    requires(arrow_null<T> || arrow_primitive_ctype<T> || arrow_base_binary<T>)
+  Status Visit(const T&) {
     result_ = true;
     return Status::OK();
   }
@@ -753,17 +753,16 @@ class TypeEqualsVisitor {
   }
 
   template <typename T>
-  enable_if_interval<T, Status> Visit(const T& left) {
+    requires arrow_interval<T>
+  Status Visit(const T& left) {
     const auto& right = checked_cast<const IntervalType&>(right_);
     result_ = right.interval_type() == left.interval_type();
     return Status::OK();
   }
 
   template <typename T>
-  enable_if_t<is_time_type<T>::value || is_date_type<T>::value ||
-                  is_duration_type<T>::value,
-              Status>
-  Visit(const T& left) {
+    requires(arrow_time<T> || arrow_date<T> || arrow_duration<T>)
+  Status Visit(const T& left) {
     const auto& right = checked_cast<const T&>(right_);
     result_ = left.unit() == right.unit();
     return Status::OK();
@@ -789,8 +788,8 @@ class TypeEqualsVisitor {
   }
 
   template <typename T>
-  enable_if_t<is_list_type<T>::value || is_list_view_type<T>::value, Status> Visit(
-      const T& left) {
+    requires(arrow_list<T> || arrow_list_view<T>)
+  Status Visit(const T& left) {
     std::shared_ptr<Field> left_field = left.field(0);
     std::shared_ptr<Field> right_field = checked_cast<const T&>(right_).field(0);
     bool equal_names = !check_metadata_ || (left_field->name() == right_field->name());
@@ -804,7 +803,8 @@ class TypeEqualsVisitor {
   }
 
   template <typename T>
-  enable_if_t<is_struct_type<T>::value, Status> Visit(const T& left) {
+    requires arrow_struct<T>
+  Status Visit(const T& left) {
     return VisitChildren(left);
   }
 
@@ -904,10 +904,9 @@ class ScalarEqualsVisitor {
   }
 
   template <typename T>
-  typename std::enable_if<(is_primitive_ctype<typename T::TypeClass>::value ||
-                           is_temporal_type<typename T::TypeClass>::value),
-                          Status>::type
-  Visit(const T& left_) {
+    requires(arrow_primitive_ctype<typename T::TypeClass> ||
+             arrow_temporal<typename T::TypeClass>)
+  Status Visit(const T& left_) {
     const auto& right = checked_cast<const T&>(right_);
     result_ = right.value == left_.value;
     return Status::OK();
@@ -920,7 +919,8 @@ class ScalarEqualsVisitor {
   Status Visit(const HalfFloatScalar& left) { return CompareFloating(left); }
 
   template <typename T>
-  enable_if_t<std::is_base_of<BaseBinaryScalar, T>::value, Status> Visit(const T& left) {
+    requires std::is_base_of_v<BaseBinaryScalar, T>
+  Status Visit(const T& left) {
     const auto& right = checked_cast<const BaseBinaryScalar&>(right_);
     result_ = internal::SharedPtrEquals(left.value, right.value);
     return Status::OK();

--- a/cpp/src/arrow/compute/expression.h
+++ b/cpp/src/arrow/compute/expression.h
@@ -161,8 +161,8 @@ ARROW_EXPORT
 Expression call(std::string function, std::vector<Expression> arguments,
                 std::shared_ptr<FunctionOptions> options = NULLPTR);
 
-template <typename Options, typename = typename std::enable_if<
-                                std::is_base_of<FunctionOptions, Options>::value>::type>
+template <typename Options>
+  requires std::is_base_of_v<FunctionOptions, Options>
 Expression call(std::string function, std::vector<Expression> arguments,
                 Options options) {
   return call(std::move(function), std::move(arguments),

--- a/cpp/src/arrow/compute/function_internal.h
+++ b/cpp/src/arrow/compute/function_internal.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <concepts>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -30,6 +31,7 @@
 #include "arrow/result.h"
 #include "arrow/scalar.h"
 #include "arrow/status.h"
+#include "arrow/type_traits.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/key_value_metadata.h"
 #include "arrow/util/reflection_internal.h"
@@ -97,16 +99,16 @@ ARROW_EXPORT
 Result<std::unique_ptr<FunctionOptions>> DeserializeFunctionOptions(const Buffer& buffer);
 
 template <typename T>
-static inline enable_if_t<!has_enum_traits<T>::value, std::string> GenericToString(
-    const T& value) {
+  requires(!has_enum_traits<T>::value)
+static inline std::string GenericToString(const T& value) {
   std::stringstream ss;
   ss << value;
   return ss.str();
 }
 
 template <typename T>
-static inline enable_if_t<!has_enum_traits<T>::value, std::string> GenericToString(
-    const std::optional<T>& value) {
+  requires(!has_enum_traits<T>::value)
+static inline std::string GenericToString(const std::optional<T>& value) {
   return value.has_value() ? GenericToString(value.value()) : "nullopt";
 }
 
@@ -119,8 +121,8 @@ static inline std::string GenericToString(const std::string& value) {
 }
 
 template <typename T>
-static inline enable_if_t<has_enum_traits<T>::value, std::string> GenericToString(
-    const T value) {
+  requires has_enum_traits<T>::value
+static inline std::string GenericToString(const T value) {
   return EnumTraits<T>::value_name(value);
 }
 
@@ -256,21 +258,20 @@ GenericTypeSingleton() {
 }
 
 template <typename T>
-static inline enable_if_same<T, std::shared_ptr<const KeyValueMetadata>,
-                             std::shared_ptr<DataType>>
-GenericTypeSingleton() {
+  requires std::same_as<T, std::shared_ptr<const KeyValueMetadata>>
+static inline std::shared_ptr<DataType> GenericTypeSingleton() {
   return map(binary(), binary());
 }
 
 template <typename T>
-static inline enable_if_t<has_enum_traits<T>::value, std::shared_ptr<DataType>>
-GenericTypeSingleton() {
+  requires has_enum_traits<T>::value
+static inline std::shared_ptr<DataType> GenericTypeSingleton() {
   return TypeTraits<typename EnumTraits<T>::Type>::type_singleton();
 }
 
 template <typename T>
-static inline enable_if_same<T, SortKey, std::shared_ptr<DataType>>
-GenericTypeSingleton() {
+  requires std::same_as<T, SortKey>
+static inline std::shared_ptr<DataType> GenericTypeSingleton() {
   std::vector<std::shared_ptr<Field>> fields;
   fields.emplace_back(new Field("target", GenericTypeSingleton<std::string>()));
   fields.emplace_back(new Field("order", GenericTypeSingleton<SortOrder>()));
@@ -294,7 +295,8 @@ static inline Result<std::shared_ptr<Scalar>> GenericToScalar(const FieldRef& re
   return MakeScalar(ref.ToDotPath());
 }
 
-template <typename T, typename Enable = enable_if_t<has_enum_traits<T>::value>>
+template <typename T>
+  requires has_enum_traits<T>::value
 static inline Result<std::shared_ptr<Scalar>> GenericToScalar(const T value) {
   using CType = typename EnumTraits<T>::CType;
   return GenericToScalar(static_cast<CType>(value));
@@ -389,8 +391,8 @@ static inline Result<std::shared_ptr<Scalar>> GenericToScalar(
 }
 
 template <typename T>
-static inline enable_if_primitive_ctype<typename CTypeTraits<T>::ArrowType, Result<T>>
-GenericFromScalar(const std::shared_ptr<Scalar>& value) {
+  requires arrow_primitive_ctype<typename CTypeTraits<T>::ArrowType>
+static inline Result<T> GenericFromScalar(const std::shared_ptr<Scalar>& value) {
   using ArrowType = typename CTypeTraits<T>::ArrowType;
   using ScalarType = typename TypeTraits<ArrowType>::ScalarType;
   if (value->type->id() != ArrowType::type_id) {
@@ -403,19 +405,16 @@ GenericFromScalar(const std::shared_ptr<Scalar>& value) {
 }
 
 template <typename T>
-static inline enable_if_primitive_ctype<typename EnumTraits<T>::Type, Result<T>>
-GenericFromScalar(const std::shared_ptr<Scalar>& value) {
+  requires arrow_primitive_ctype<typename EnumTraits<T>::Type>
+static inline Result<T> GenericFromScalar(const std::shared_ptr<Scalar>& value) {
   ARROW_ASSIGN_OR_RAISE(auto raw_val,
                         GenericFromScalar<typename EnumTraits<T>::CType>(value));
   return ValidateEnumValue<T>(raw_val);
 }
 
-template <typename T, typename U>
-using enable_if_same_result = enable_if_same<T, U, Result<T>>;
-
 template <typename T>
-static inline enable_if_same_result<T, std::string> GenericFromScalar(
-    const std::shared_ptr<Scalar>& value) {
+  requires std::same_as<T, std::string>
+static inline Result<T> GenericFromScalar(const std::shared_ptr<Scalar>& value) {
   if (!is_base_binary_like(value->type->id())) {
     return Status::Invalid("Expected binary-like type but got ", value->type->ToString());
   }
@@ -425,15 +424,15 @@ static inline enable_if_same_result<T, std::string> GenericFromScalar(
 }
 
 template <typename T>
-static inline enable_if_same_result<T, FieldRef> GenericFromScalar(
-    const std::shared_ptr<Scalar>& value) {
+  requires std::same_as<T, FieldRef>
+static inline Result<T> GenericFromScalar(const std::shared_ptr<Scalar>& value) {
   ARROW_ASSIGN_OR_RAISE(auto path, GenericFromScalar<std::string>(value));
   return FieldRef::FromDotPath(path);
 }
 
 template <typename T>
-static inline enable_if_same_result<T, SortKey> GenericFromScalar(
-    const std::shared_ptr<Scalar>& value) {
+  requires std::same_as<T, SortKey>
+static inline Result<T> GenericFromScalar(const std::shared_ptr<Scalar>& value) {
   if (value->type->id() != Type::STRUCT) {
     return Status::Invalid("Expected type STRUCT but got ", value->type->id());
   }
@@ -447,26 +446,26 @@ static inline enable_if_same_result<T, SortKey> GenericFromScalar(
 }
 
 template <typename T>
-static inline enable_if_same_result<T, std::shared_ptr<DataType>> GenericFromScalar(
-    const std::shared_ptr<Scalar>& value) {
+  requires std::same_as<T, std::shared_ptr<DataType>>
+static inline Result<T> GenericFromScalar(const std::shared_ptr<Scalar>& value) {
   return value->type;
 }
 
 template <typename T>
-static inline enable_if_same_result<T, TypeHolder> GenericFromScalar(
-    const std::shared_ptr<Scalar>& value) {
+  requires std::same_as<T, TypeHolder>
+static inline Result<T> GenericFromScalar(const std::shared_ptr<Scalar>& value) {
   return value->type;
 }
 
 template <typename T>
-static inline enable_if_same_result<T, std::shared_ptr<Scalar>> GenericFromScalar(
-    const std::shared_ptr<Scalar>& value) {
+  requires std::same_as<T, std::shared_ptr<Scalar>>
+static inline Result<T> GenericFromScalar(const std::shared_ptr<Scalar>& value) {
   return value;
 }
 
 template <typename T>
-static inline enable_if_same_result<T, std::shared_ptr<const KeyValueMetadata>>
-GenericFromScalar(const std::shared_ptr<Scalar>& value) {
+  requires std::same_as<T, std::shared_ptr<const KeyValueMetadata>>
+static inline Result<T> GenericFromScalar(const std::shared_ptr<Scalar>& value) {
   auto ty = GenericTypeSingleton<std::shared_ptr<const KeyValueMetadata>>();
   if (!value->type->Equals(ty)) {
     return Status::Invalid("Expected ", ty->ToString(), " but got ",
@@ -486,8 +485,8 @@ GenericFromScalar(const std::shared_ptr<Scalar>& value) {
 }
 
 template <typename T>
-static inline enable_if_same_result<T, Datum> GenericFromScalar(
-    const std::shared_ptr<Scalar>& value) {
+  requires std::same_as<T, Datum>
+static inline Result<T> GenericFromScalar(const std::shared_ptr<Scalar>& value) {
   if (value->type->id() == Type::LIST) {
     const auto& holder = checked_cast<const BaseListScalar&>(*value);
     return holder.value;
@@ -504,8 +503,8 @@ template <>
 constexpr inline bool is_optional_v<std::nullopt_t> = true;
 
 template <typename T>
-static inline std::enable_if_t<is_optional_v<T>, Result<T>> GenericFromScalar(
-    const std::shared_ptr<Scalar>& value) {
+  requires is_optional_v<T>
+static inline Result<T> GenericFromScalar(const std::shared_ptr<Scalar>& value) {
   using value_type = typename T::value_type;
   if (value->type->id() == Type::NA) {
     return std::nullopt;
@@ -514,8 +513,8 @@ static inline std::enable_if_t<is_optional_v<T>, Result<T>> GenericFromScalar(
 }
 
 template <typename T>
-static enable_if_same<typename CTypeTraits<T>::ArrowType, ListType, Result<T>>
-GenericFromScalar(const std::shared_ptr<Scalar>& value) {
+  requires std::same_as<typename CTypeTraits<T>::ArrowType, ListType>
+static Result<T> GenericFromScalar(const std::shared_ptr<Scalar>& value) {
   using ValueType = typename T::value_type;
   if (value->type->id() != Type::LIST) {
     return Status::Invalid("Expected type LIST but got ", value->type->ToString());

--- a/cpp/src/arrow/compute/kernels/aggregate_basic.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_basic.cc
@@ -416,15 +416,15 @@ struct ProductInit {
     return Status::OK();
   }
 
-  template <typename Type>
-  enable_if_number<Type, Status> Visit(const Type&) {
+  template <arrow_number Type>
+  Status Visit(const Type&) {
     auto ty = TypeTraits<typename ProductImpl<Type>::AccType>::type_singleton();
     state.reset(new ProductImpl<Type>(ty, options));
     return Status::OK();
   }
 
-  template <typename Type>
-  enable_if_decimal<Type, Status> Visit(const Type&) {
+  template <arrow_decimal Type>
+  Status Visit(const Type&) {
     state.reset(new ProductImpl<Type>(type, options));
     return Status::OK();
   }
@@ -777,14 +777,14 @@ struct IndexInit {
     return Status::OK();
   }
 
-  template <typename Type>
-  enable_if_number<Type, Status> Visit(const Type&) {
+  template <arrow_number Type>
+  Status Visit(const Type&) {
     state.reset(new IndexImpl<Type>(options, ctx->state()));
     return Status::OK();
   }
 
-  template <typename Type>
-  enable_if_base_binary<Type, Status> Visit(const Type&) {
+  template <arrow_base_binary Type>
+  Status Visit(const Type&) {
     state.reset(new IndexImpl<Type>(options, ctx->state()));
     return Status::OK();
   }
@@ -794,26 +794,26 @@ struct IndexInit {
     return Status::OK();
   }
 
-  template <typename Type>
-  enable_if_decimal<Type, Status> Visit(const Type&) {
+  template <arrow_decimal Type>
+  Status Visit(const Type&) {
     state.reset(new IndexImpl<Type>(options, ctx->state()));
     return Status::OK();
   }
 
-  template <typename Type>
-  enable_if_date<Type, Status> Visit(const Type&) {
+  template <arrow_date Type>
+  Status Visit(const Type&) {
     state.reset(new IndexImpl<Type>(options, ctx->state()));
     return Status::OK();
   }
 
-  template <typename Type>
-  enable_if_time<Type, Status> Visit(const Type&) {
+  template <arrow_time Type>
+  Status Visit(const Type&) {
     state.reset(new IndexImpl<Type>(options, ctx->state()));
     return Status::OK();
   }
 
-  template <typename Type>
-  enable_if_timestamp<Type, Status> Visit(const Type&) {
+  template <arrow_timestamp Type>
+  Status Visit(const Type&) {
     state.reset(new IndexImpl<Type>(options, ctx->state()));
     return Status::OK();
   }

--- a/cpp/src/arrow/compute/kernels/aggregate_basic.inc.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_basic.inc.cc
@@ -188,8 +188,8 @@ struct SumLikeInit {
     return Status::OK();
   }
 
-  template <typename Type>
-  enable_if_number<Type, Status> Visit(const Type&) {
+  template <arrow_number Type>
+  Status Visit(const Type&) {
     auto ty = TypeTraits<typename KernelClass<Type>::SumType>::type_singleton();
     state.reset(new KernelClass<Type>(ty, options));
     return Status::OK();
@@ -197,8 +197,8 @@ struct SumLikeInit {
 
   // By default, we widen the decimal to max precision for SumLikes
   // However, this may not be the desired behaviour (see, e.g., MeanKernelInit)
-  template <typename Type>
-  enable_if_decimal<Type, Status> Visit(const Type&) {
+  template <arrow_decimal Type>
+  Status Visit(const Type&) {
     if (PromoteDecimal()) {
       ARROW_ASSIGN_OR_RAISE(auto ty, WidenDecimalToMaxPrecision(type));
       state.reset(new KernelClass<Type>(ty, options));
@@ -223,12 +223,12 @@ struct SumLikeInit {
 // ----------------------------------------------------------------------
 // Mean implementation
 
-template <typename ArrowType, SimdLevel::type SimdLevel, typename Enable = void>
+template <typename ArrowType, SimdLevel::type SimdLevel>
 struct MeanImpl;
 
 template <typename ArrowType, SimdLevel::type SimdLevel>
-struct MeanImpl<ArrowType, SimdLevel, enable_if_decimal<ArrowType>>
-    : public SumImpl<ArrowType, SimdLevel> {
+  requires arrow_decimal<ArrowType>
+struct MeanImpl<ArrowType, SimdLevel> : public SumImpl<ArrowType, SimdLevel> {
   using SumImpl<ArrowType, SimdLevel>::SumImpl;
   using SumImpl<ArrowType, SimdLevel>::options;
   using SumCType = typename SumImpl<ArrowType, SimdLevel>::SumCType;
@@ -260,8 +260,8 @@ struct MeanImpl<ArrowType, SimdLevel, enable_if_decimal<ArrowType>>
 };
 
 template <typename ArrowType, SimdLevel::type SimdLevel>
-struct MeanImpl<ArrowType, SimdLevel,
-                std::enable_if_t<!is_decimal_type<ArrowType>::value>>
+  requires(!arrow_decimal<ArrowType>)
+struct MeanImpl<ArrowType, SimdLevel>
     // Override the ResultType of SumImpl because we need to use double for intermediate
     // sum to prevent integer overflows
     : public SumImpl<ArrowType, SimdLevel, DoubleType> {
@@ -302,11 +302,11 @@ struct MeanKernelInit : public SumLikeInit<KernelClass> {
 // ----------------------------------------------------------------------
 // FirstLast implementation
 
-template <typename ArrowType, typename Enable = void>
+template <typename ArrowType>
 struct FirstLastState {};
 
-template <typename ArrowType>
-struct FirstLastState<ArrowType, enable_if_boolean<ArrowType>> {
+template <arrow_boolean ArrowType>
+struct FirstLastState<ArrowType> {
   using ThisType = FirstLastState<ArrowType>;
   using T = typename ArrowType::c_type;
   using ScalarType = typename TypeTraits<ArrowType>::ScalarType;
@@ -337,8 +337,8 @@ struct FirstLastState<ArrowType, enable_if_boolean<ArrowType>> {
   bool has_any_values = false;
 };
 
-template <typename ArrowType>
-struct FirstLastState<ArrowType, enable_if_physical_integer<ArrowType>> {
+template <arrow_physical_integer ArrowType>
+struct FirstLastState<ArrowType> {
   using ThisType = FirstLastState<ArrowType>;
   using T = typename ArrowType::c_type;
   using ScalarType = typename TypeTraits<ArrowType>::ScalarType;
@@ -377,8 +377,8 @@ struct FirstLastState<ArrowType, enable_if_physical_integer<ArrowType>> {
   bool has_any_values = false;
 };
 
-template <typename ArrowType>
-struct FirstLastState<ArrowType, enable_if_floating_point<ArrowType>> {
+template <arrow_floating_point ArrowType>
+struct FirstLastState<ArrowType> {
   using ThisType = FirstLastState<ArrowType>;
   using T = typename ArrowType::c_type;
   using ScalarType = typename TypeTraits<ArrowType>::ScalarType;
@@ -410,9 +410,8 @@ struct FirstLastState<ArrowType, enable_if_floating_point<ArrowType>> {
 };
 
 template <typename ArrowType>
-struct FirstLastState<ArrowType,
-                      enable_if_t<is_base_binary_type<ArrowType>::value ||
-                                  std::is_same<ArrowType, FixedSizeBinaryType>::value>> {
+  requires(arrow_base_binary<ArrowType> || std::same_as<ArrowType, FixedSizeBinaryType>)
+struct FirstLastState<ArrowType> {
   using ThisType = FirstLastState<ArrowType>;
   using ScalarType = typename TypeTraits<ArrowType>::ScalarType;
 
@@ -593,28 +592,29 @@ struct FirstLastInitState {
     return Status::OK();
   }
 
-  template <typename Type>
-  enable_if_physical_integer<Type, Status> Visit(const Type&) {
+  template <arrow_physical_integer Type>
+  Status Visit(const Type&) {
     using PhysicalType = typename Type::PhysicalType;
     state.reset(new FirstLastImpl<PhysicalType>(out_type, options));
     return Status::OK();
   }
 
-  template <typename Type>
-  enable_if_physical_floating_point<Type, Status> Visit(const Type&) {
+  template <arrow_physical_floating_point Type>
+  Status Visit(const Type&) {
     using PhysicalType = typename Type::PhysicalType;
     state.reset(new FirstLastImpl<PhysicalType>(out_type, options));
     return Status::OK();
   }
 
-  template <typename Type>
-  enable_if_base_binary<Type, Status> Visit(const Type&) {
+  template <arrow_base_binary Type>
+  Status Visit(const Type&) {
     state.reset(new FirstLastImpl<Type>(out_type, options));
     return Status::OK();
   }
 
   template <typename Type>
-  enable_if_t<std::is_same<Type, FixedSizeBinaryType>::value, Status> Visit(const Type&) {
+    requires std::same_as<Type, FixedSizeBinaryType>
+  Status Visit(const Type&) {
     state.reset(new FirstLastImpl<Type>(out_type, options));
     return Status::OK();
   }
@@ -628,11 +628,11 @@ struct FirstLastInitState {
 // ----------------------------------------------------------------------
 // MinMax implementation
 
-template <typename ArrowType, SimdLevel::type SimdLevel, typename Enable = void>
+template <typename ArrowType, SimdLevel::type SimdLevel>
 struct MinMaxState {};
 
-template <typename ArrowType, SimdLevel::type SimdLevel>
-struct MinMaxState<ArrowType, SimdLevel, enable_if_boolean<ArrowType>> {
+template <arrow_boolean ArrowType, SimdLevel::type SimdLevel>
+struct MinMaxState<ArrowType, SimdLevel> {
   using ThisType = MinMaxState<ArrowType, SimdLevel>;
   using T = typename ArrowType::c_type;
 
@@ -653,8 +653,8 @@ struct MinMaxState<ArrowType, SimdLevel, enable_if_boolean<ArrowType>> {
   bool has_nulls = false;
 };
 
-template <typename ArrowType, SimdLevel::type SimdLevel>
-struct MinMaxState<ArrowType, SimdLevel, enable_if_integer<ArrowType>> {
+template <arrow_integer ArrowType, SimdLevel::type SimdLevel>
+struct MinMaxState<ArrowType, SimdLevel> {
   using ThisType = MinMaxState<ArrowType, SimdLevel>;
   using T = typename ArrowType::c_type;
   using ScalarType = typename TypeTraits<ArrowType>::ScalarType;
@@ -676,8 +676,8 @@ struct MinMaxState<ArrowType, SimdLevel, enable_if_integer<ArrowType>> {
   bool has_nulls = false;
 };
 
-template <typename ArrowType, SimdLevel::type SimdLevel>
-struct MinMaxState<ArrowType, SimdLevel, enable_if_floating_point<ArrowType>> {
+template <arrow_floating_point ArrowType, SimdLevel::type SimdLevel>
+struct MinMaxState<ArrowType, SimdLevel> {
   using ThisType = MinMaxState<ArrowType, SimdLevel>;
   using T = typename ArrowType::c_type;
   using ScalarType = typename TypeTraits<ArrowType>::ScalarType;
@@ -699,8 +699,8 @@ struct MinMaxState<ArrowType, SimdLevel, enable_if_floating_point<ArrowType>> {
   bool has_nulls = false;
 };
 
-template <typename ArrowType, SimdLevel::type SimdLevel>
-struct MinMaxState<ArrowType, SimdLevel, enable_if_decimal<ArrowType>> {
+template <arrow_decimal ArrowType, SimdLevel::type SimdLevel>
+struct MinMaxState<ArrowType, SimdLevel> {
   using ThisType = MinMaxState<ArrowType, SimdLevel>;
   using T = typename TypeTraits<ArrowType>::CType;
   using ScalarType = typename TypeTraits<ArrowType>::ScalarType;
@@ -729,9 +729,8 @@ struct MinMaxState<ArrowType, SimdLevel, enable_if_decimal<ArrowType>> {
 };
 
 template <typename ArrowType, SimdLevel::type SimdLevel>
-struct MinMaxState<ArrowType, SimdLevel,
-                   enable_if_t<is_base_binary_type<ArrowType>::value ||
-                               std::is_same<ArrowType, FixedSizeBinaryType>::value>> {
+  requires(arrow_base_binary<ArrowType> || std::same_as<ArrowType, FixedSizeBinaryType>)
+struct MinMaxState<ArrowType, SimdLevel> {
   using ThisType = MinMaxState<ArrowType, SimdLevel>;
   using ScalarType = typename TypeTraits<ArrowType>::ScalarType;
 
@@ -1009,27 +1008,27 @@ struct MinMaxInitState {
     return Status::OK();
   }
 
-  template <typename Type>
-  enable_if_physical_integer<Type, Status> Visit(const Type&) {
+  template <arrow_physical_integer Type>
+  Status Visit(const Type&) {
     using PhysicalType = typename Type::PhysicalType;
     state.reset(new MinMaxImpl<PhysicalType, SimdLevel>(out_type, options));
     return Status::OK();
   }
 
-  template <typename Type>
-  enable_if_floating_point<Type, Status> Visit(const Type&) {
+  template <arrow_floating_point Type>
+  Status Visit(const Type&) {
     state.reset(new MinMaxImpl<Type, SimdLevel>(out_type, options));
     return Status::OK();
   }
 
-  template <typename Type>
-  enable_if_base_binary<Type, Status> Visit(const Type&) {
+  template <arrow_base_binary Type>
+  Status Visit(const Type&) {
     state.reset(new MinMaxImpl<Type, SimdLevel>(out_type, options));
     return Status::OK();
   }
 
-  template <typename Type>
-  enable_if_fixed_size_binary<Type, Status> Visit(const Type&) {
+  template <arrow_fixed_size_binary Type>
+  Status Visit(const Type&) {
     state.reset(new MinMaxImpl<Type, SimdLevel>(out_type, options));
     return Status::OK();
   }

--- a/cpp/src/arrow/compute/kernels/aggregate_internal.h
+++ b/cpp/src/arrow/compute/kernels/aggregate_internal.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <cmath>
+#include <concepts>
 #include <initializer_list>
 
 #include "arrow/compute/kernels/util_internal.h"
@@ -30,52 +31,52 @@
 namespace arrow::compute::internal {
 
 // Find the largest compatible primitive type for a primitive type.
-template <typename I, typename Enable = void>
+template <typename I>
 struct FindAccumulatorType {};
 
-template <typename I>
-struct FindAccumulatorType<I, enable_if_boolean<I>> {
+template <arrow_boolean I>
+struct FindAccumulatorType<I> {
   using Type = UInt64Type;
 };
 
-template <typename I>
-struct FindAccumulatorType<I, enable_if_signed_integer<I>> {
+template <arrow_signed_integer I>
+struct FindAccumulatorType<I> {
   using Type = Int64Type;
 };
 
-template <typename I>
-struct FindAccumulatorType<I, enable_if_unsigned_integer<I>> {
+template <arrow_unsigned_integer I>
+struct FindAccumulatorType<I> {
   using Type = UInt64Type;
 };
 
-template <typename I>
-struct FindAccumulatorType<I, enable_if_floating_point<I>> {
+template <arrow_floating_point I>
+struct FindAccumulatorType<I> {
   using Type = DoubleType;
 };
 
-template <typename I>
-struct FindAccumulatorType<I, enable_if_decimal32<I>> {
+template <arrow_decimal32 I>
+struct FindAccumulatorType<I> {
   using Type = Decimal32Type;
 };
 
-template <typename I>
-struct FindAccumulatorType<I, enable_if_decimal64<I>> {
+template <arrow_decimal64 I>
+struct FindAccumulatorType<I> {
   using Type = Decimal64Type;
 };
 
-template <typename I>
-struct FindAccumulatorType<I, enable_if_decimal128<I>> {
+template <arrow_decimal128 I>
+struct FindAccumulatorType<I> {
   using Type = Decimal128Type;
 };
 
-template <typename I>
-struct FindAccumulatorType<I, enable_if_decimal256<I>> {
+template <arrow_decimal256 I>
+struct FindAccumulatorType<I> {
   using Type = Decimal256Type;
 };
 
 // Helpers for implementing aggregations on decimals
 
-template <typename Type, typename Enable = void>
+template <typename Type>
 struct MultiplyTraits {
   using CType = typename TypeTraits<Type>::CType;
 
@@ -86,8 +87,8 @@ struct MultiplyTraits {
   }
 };
 
-template <typename Type>
-struct MultiplyTraits<Type, enable_if_decimal<Type>> {
+template <arrow_decimal Type>
+struct MultiplyTraits<Type> {
   using CType = typename TypeTraits<Type>::CType;
 
   constexpr static CType one(const DataType& ty) {
@@ -129,21 +130,21 @@ void AddAggKernel(std::shared_ptr<KernelSignature> sig, KernelInit init,
 
 using arrow::internal::VisitSetBitRunsVoid;
 
-template <typename T, typename Enable = void>
+template <typename T>
 struct GetSumType;
 
-template <typename T>
-struct GetSumType<T, enable_if_floating_point<T>> {
+template <arrow_floating_point T>
+struct GetSumType<T> {
   using SumType = double;
 };
 
-template <typename T>
-struct GetSumType<T, enable_if_integer<T>> {
+template <arrow_integer T>
+struct GetSumType<T> {
   using SumType = arrow::internal::int128_t;
 };
 
-template <typename T>
-struct GetSumType<T, enable_if_decimal<T>> {
+template <arrow_decimal T>
+struct GetSumType<T> {
   using SumType = typename TypeTraits<T>::CType;
 };
 
@@ -156,8 +157,8 @@ struct GetSumType<T, enable_if_decimal<T>> {
 // https://en.wikipedia.org/wiki/Pairwise_summation
 template <typename ValueType, typename SumType, SimdLevel::type SimdLevel,
           typename ValueFunc>
-enable_if_t<std::is_floating_point<SumType>::value, SumType> SumArray(
-    const ArraySpan& data, ValueFunc&& func) {
+  requires std::floating_point<SumType>
+SumType SumArray(const ArraySpan& data, ValueFunc&& func) {
   using arrow::internal::VisitSetBitRunsVoid;
 
   const int64_t data_size = data.length - data.GetNullCount();
@@ -234,8 +235,8 @@ enable_if_t<std::is_floating_point<SumType>::value, SumType> SumArray(
 // naive summation for integers and decimals
 template <typename ValueType, typename SumType, SimdLevel::type SimdLevel,
           typename ValueFunc>
-enable_if_t<!std::is_floating_point<SumType>::value, SumType> SumArray(
-    const ArraySpan& data, ValueFunc&& func) {
+  requires(!std::floating_point<SumType>)
+SumType SumArray(const ArraySpan& data, ValueFunc&& func) {
   using arrow::internal::VisitSetBitRunsVoid;
 
   SumType sum = 0;

--- a/cpp/src/arrow/compute/kernels/aggregate_mode.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_mode.cc
@@ -260,13 +260,14 @@ struct SortModer {
   using CType = typename TypeTraits<T>::CType;
   using Allocator = arrow::stl::allocator<CType>;
 
-  template <typename Type = T>
-  static enable_if_floating_point<Type, CType> GetNan() {
+  template <arrow_floating_point Type = T>
+  static CType GetNan() {
     return static_cast<CType>(NAN);
   }
 
   template <typename Type = T>
-  static enable_if_t<!is_floating_type<Type>::value, CType> GetNan() {
+    requires(!arrow_floating_point<Type>)
+  static CType GetNan() {
     DCHECK(false);
     return static_cast<CType>(0);
   }
@@ -381,7 +382,7 @@ struct CountOrSortModer {
   }
 };
 
-template <typename InType, typename Enable = void>
+template <typename InType>
 struct Moder;
 
 template <>
@@ -402,18 +403,18 @@ struct Moder<BooleanType> {
 };
 
 template <typename InType>
-struct Moder<InType, enable_if_t<(is_integer_type<InType>::value &&
-                                  (sizeof(typename InType::c_type) > 1))>> {
+  requires(arrow_integer<InType> && (sizeof(typename InType::c_type) > 1))
+struct Moder<InType> {
   CountOrSortModer<InType> impl;
 };
 
-template <typename InType>
-struct Moder<InType, enable_if_floating_point<InType>> {
+template <arrow_floating_point InType>
+struct Moder<InType> {
   SortModer<InType> impl;
 };
 
-template <typename InType>
-struct Moder<InType, enable_if_decimal<InType>> {
+template <arrow_decimal InType>
+struct Moder<InType> {
   SortModer<InType> impl;
 };
 

--- a/cpp/src/arrow/compute/kernels/aggregate_quantile.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_quantile.cc
@@ -168,7 +168,7 @@ struct SortQuantiler {
       CopyNonNullValues(container, in_buffer->data());
 
       // drop nan
-      if (is_floating_type<InType>::value) {
+      if constexpr (arrow_floating_point<InType>) {
         const auto& it = std::remove_if(in_buffer->begin(), in_buffer->end(),
                                         [](CType v) { return v != v; });
         in_buffer->resize(it - in_buffer->begin());
@@ -448,7 +448,7 @@ struct CountOrSortQuantiler {
   }
 };
 
-template <typename InType, typename Enable = void>
+template <typename InType>
 struct ExactQuantiler;
 
 template <>
@@ -464,18 +464,20 @@ struct ExactQuantiler<Int8Type> {
 };
 
 template <typename InType>
-struct ExactQuantiler<InType, enable_if_t<(is_integer_type<InType>::value &&
-                                           (sizeof(typename InType::c_type) > 1))>> {
+  requires(arrow_integer<InType> && (sizeof(typename InType::c_type) > 1))
+struct ExactQuantiler<InType> {
   CountOrSortQuantiler<InType> impl;
 };
 
 template <typename InType>
-struct ExactQuantiler<InType, enable_if_t<is_floating_type<InType>::value>> {
+  requires arrow_floating_point<InType>
+struct ExactQuantiler<InType> {
   SortQuantiler<InType> impl;
 };
 
 template <typename InType>
-struct ExactQuantiler<InType, enable_if_t<is_decimal_type<InType>::value>> {
+  requires arrow_decimal<InType>
+struct ExactQuantiler<InType> {
   SortQuantiler<InType> impl;
 };
 

--- a/cpp/src/arrow/compute/kernels/aggregate_tdigest.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_tdigest.cc
@@ -147,14 +147,14 @@ struct TDigestInitState {
     return Status::NotImplemented("No tdigest implemented");
   }
 
-  template <typename Type>
-  enable_if_number<Type, Status> Visit(const Type&) {
+  template <arrow_number Type>
+  Status Visit(const Type&) {
     state.reset(new TDigestImpl<Type>(options, in_type));
     return Status::OK();
   }
 
-  template <typename Type>
-  enable_if_decimal<Type, Status> Visit(const Type&) {
+  template <arrow_decimal Type>
+  Status Visit(const Type&) {
     state.reset(new TDigestImpl<Type>(options, in_type));
     return Status::OK();
   }

--- a/cpp/src/arrow/compute/kernels/aggregate_test.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_test.cc
@@ -2260,9 +2260,8 @@ struct MinMaxResult {
   bool is_valid = false;
 };
 
-template <typename ArrowType>
-static enable_if_integer<ArrowType, MinMaxResult<ArrowType>> NaiveMinMax(
-    const Array& array) {
+template <arrow_integer ArrowType>
+static MinMaxResult<ArrowType> NaiveMinMax(const Array& array) {
   using T = typename ArrowType::c_type;
   using ArrayType = typename TypeTraits<ArrowType>::ArrayType;
 
@@ -2299,9 +2298,8 @@ static enable_if_integer<ArrowType, MinMaxResult<ArrowType>> NaiveMinMax(
   return result;
 }
 
-template <typename ArrowType>
-static enable_if_floating_point<ArrowType, MinMaxResult<ArrowType>> NaiveMinMax(
-    const Array& array) {
+template <arrow_floating_point ArrowType>
+static MinMaxResult<ArrowType> NaiveMinMax(const Array& array) {
   using T = typename ArrowType::c_type;
   using ArrayType = typename TypeTraits<ArrowType>::ArrayType;
 

--- a/cpp/src/arrow/compute/kernels/base_arithmetic_internal.h
+++ b/cpp/src/arrow/compute/kernels/base_arithmetic_internal.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <bit>
+#include <concepts>
 #include <limits>
 #include "arrow/compute/api_scalar.h"
 #include "arrow/compute/kernels/common_internal.h"
@@ -42,35 +43,44 @@ using util::Float16;
 namespace compute {
 namespace internal {
 
+template <typename T>
+concept arithmetic_decimal_value =
+    std::same_as<T, Decimal32> || std::same_as<T, Decimal64> ||
+    std::same_as<T, Decimal128> || std::same_as<T, Decimal256>;
+
+template <typename T>
+concept arithmetic_half_float_value = std::same_as<T, Float16>;
+
 struct Add {
   template <typename T, typename Arg0, typename Arg1>
-  static constexpr enable_if_floating_value<T> Call(KernelContext*, Arg0 left, Arg1 right,
-                                                    Status*) {
+    requires std::floating_point<T>
+  static constexpr T Call(KernelContext*, Arg0 left, Arg1 right, Status*) {
     return left + right;
   }
 
   template <typename T, typename Arg0, typename Arg1>
-  static constexpr enable_if_unsigned_integer_value<T> Call(KernelContext*, Arg0 left,
-                                                            Arg1 right, Status*) {
+    requires std::unsigned_integral<T>
+  static constexpr T Call(KernelContext*, Arg0 left, Arg1 right, Status*) {
     return left + right;
   }
 
   template <typename T, typename Arg0, typename Arg1>
-  static constexpr enable_if_signed_integer_value<T> Call(KernelContext*, Arg0 left,
-                                                          Arg1 right, Status*) {
+    requires std::signed_integral<T>
+  static constexpr T Call(KernelContext*, Arg0 left, Arg1 right, Status*) {
     return arrow::internal::SafeSignedAdd(left, right);
   }
 
   template <typename T, typename Arg0, typename Arg1>
-  static enable_if_decimal_value<T> Call(KernelContext*, Arg0 left, Arg1 right, Status*) {
+    requires arithmetic_decimal_value<T>
+  static T Call(KernelContext*, Arg0 left, Arg1 right, Status*) {
     return left + right;
   }
 };
 
 struct AddChecked {
   template <typename T, typename Arg0, typename Arg1>
-  static enable_if_integer_value<T> Call(KernelContext*, Arg0 left, Arg1 right,
-                                         Status* st) {
+    requires std::integral<T>
+  static T Call(KernelContext*, Arg0 left, Arg1 right, Status* st) {
     static_assert(std::is_same<T, Arg0>::value && std::is_same<T, Arg1>::value, "");
     T result = 0;
     if (ARROW_PREDICT_FALSE(AddWithOverflow(left, right, &result))) {
@@ -80,14 +90,15 @@ struct AddChecked {
   }
 
   template <typename T, typename Arg0, typename Arg1>
-  static enable_if_floating_value<T> Call(KernelContext*, Arg0 left, Arg1 right,
-                                          Status*) {
+    requires std::floating_point<T>
+  static T Call(KernelContext*, Arg0 left, Arg1 right, Status*) {
     static_assert(std::is_same<T, Arg0>::value && std::is_same<T, Arg1>::value, "");
     return left + right;
   }
 
   template <typename T, typename Arg0, typename Arg1>
-  static enable_if_decimal_value<T> Call(KernelContext*, Arg0 left, Arg1 right, Status*) {
+    requires arithmetic_decimal_value<T>
+  static T Call(KernelContext*, Arg0 left, Arg1 right, Status*) {
     return left + right;
   }
 };
@@ -125,34 +136,34 @@ struct AddTimeDurationChecked {
 
 struct AbsoluteValue {
   template <typename T, typename Arg>
-  static constexpr enable_if_floating_value<Arg, T> Call(KernelContext*, Arg arg,
-                                                         Status*) {
+    requires std::floating_point<Arg>
+  static constexpr T Call(KernelContext*, Arg arg, Status*) {
     return std::fabs(arg);
   }
 
   template <typename T, typename Arg>
-  static constexpr enable_if_unsigned_integer_value<Arg, T> Call(KernelContext*, Arg arg,
-                                                                 Status*) {
+    requires std::unsigned_integral<Arg>
+  static constexpr T Call(KernelContext*, Arg arg, Status*) {
     return arg;
   }
 
   template <typename T, typename Arg>
-  static constexpr enable_if_signed_integer_value<Arg, T> Call(KernelContext*, Arg arg,
-                                                               Status* st) {
+    requires std::signed_integral<Arg>
+  static constexpr T Call(KernelContext*, Arg arg, Status* st) {
     return (arg < 0) ? arrow::internal::SafeSignedNegate(arg) : arg;
   }
 
   template <typename T, typename Arg>
-  static constexpr enable_if_decimal_value<Arg, T> Call(KernelContext*, Arg arg,
-                                                        Status*) {
+    requires arithmetic_decimal_value<Arg>
+  static constexpr T Call(KernelContext*, Arg arg, Status*) {
     return arg.Abs();
   }
 };
 
 struct AbsoluteValueChecked {
   template <typename T, typename Arg>
-  static enable_if_signed_integer_value<Arg, T> Call(KernelContext*, Arg arg,
-                                                     Status* st) {
+    requires std::signed_integral<Arg>
+  static T Call(KernelContext*, Arg arg, Status* st) {
     static_assert(std::is_same<T, Arg>::value, "");
     if (arg == std::numeric_limits<Arg>::min()) {
       *st = Status::Invalid("overflow");
@@ -162,57 +173,58 @@ struct AbsoluteValueChecked {
   }
 
   template <typename T, typename Arg>
-  static enable_if_unsigned_integer_value<Arg, T> Call(KernelContext* ctx, Arg arg,
-                                                       Status* st) {
+    requires std::unsigned_integral<Arg>
+  static T Call(KernelContext* ctx, Arg arg, Status* st) {
     static_assert(std::is_same<T, Arg>::value, "");
     return arg;
   }
 
   template <typename T, typename Arg>
-  static constexpr enable_if_floating_value<Arg, T> Call(KernelContext*, Arg arg,
-                                                         Status* st) {
+    requires std::floating_point<Arg>
+  static constexpr T Call(KernelContext*, Arg arg, Status* st) {
     static_assert(std::is_same<T, Arg>::value, "");
     return std::fabs(arg);
   }
 
   template <typename T, typename Arg>
-  static constexpr enable_if_decimal_value<Arg, T> Call(KernelContext*, Arg arg,
-                                                        Status*) {
+    requires arithmetic_decimal_value<Arg>
+  static constexpr T Call(KernelContext*, Arg arg, Status*) {
     return arg.Abs();
   }
 };
 
 struct Subtract {
   template <typename T, typename Arg0, typename Arg1>
-  static constexpr enable_if_floating_value<T> Call(KernelContext*, Arg0 left, Arg1 right,
-                                                    Status*) {
+    requires std::floating_point<T>
+  static constexpr T Call(KernelContext*, Arg0 left, Arg1 right, Status*) {
     static_assert(std::is_same<T, Arg0>::value && std::is_same<T, Arg1>::value, "");
     return left - right;
   }
 
   template <typename T, typename Arg0, typename Arg1>
-  static constexpr enable_if_unsigned_integer_value<T> Call(KernelContext*, Arg0 left,
-                                                            Arg1 right, Status*) {
+    requires std::unsigned_integral<T>
+  static constexpr T Call(KernelContext*, Arg0 left, Arg1 right, Status*) {
     static_assert(std::is_same<T, Arg0>::value && std::is_same<T, Arg1>::value, "");
     return left - right;
   }
 
   template <typename T, typename Arg0, typename Arg1>
-  static constexpr enable_if_signed_integer_value<T> Call(KernelContext*, Arg0 left,
-                                                          Arg1 right, Status*) {
+    requires std::signed_integral<T>
+  static constexpr T Call(KernelContext*, Arg0 left, Arg1 right, Status*) {
     return arrow::internal::SafeSignedSubtract(left, right);
   }
 
   template <typename T, typename Arg0, typename Arg1>
-  static enable_if_decimal_value<T> Call(KernelContext*, Arg0 left, Arg1 right, Status*) {
+    requires arithmetic_decimal_value<T>
+  static T Call(KernelContext*, Arg0 left, Arg1 right, Status*) {
     return left + (-right);
   }
 };
 
 struct SubtractChecked {
   template <typename T, typename Arg0, typename Arg1>
-  static enable_if_integer_value<T> Call(KernelContext*, Arg0 left, Arg1 right,
-                                         Status* st) {
+    requires std::integral<T>
+  static T Call(KernelContext*, Arg0 left, Arg1 right, Status* st) {
     T result = 0;
     if (ARROW_PREDICT_FALSE(SubtractWithOverflow(left, right, &result))) {
       *st = Status::Invalid("overflow");
@@ -221,14 +233,15 @@ struct SubtractChecked {
   }
 
   template <typename T, typename Arg0, typename Arg1>
-  static enable_if_floating_value<T> Call(KernelContext*, Arg0 left, Arg1 right,
-                                          Status*) {
+    requires std::floating_point<T>
+  static T Call(KernelContext*, Arg0 left, Arg1 right, Status*) {
     static_assert(std::is_same<T, Arg0>::value && std::is_same<T, Arg1>::value, "");
     return left - right;
   }
 
   template <typename T, typename Arg0, typename Arg1>
-  static enable_if_decimal_value<T> Call(KernelContext*, Arg0 left, Arg1 right, Status*) {
+    requires arithmetic_decimal_value<T>
+  static T Call(KernelContext*, Arg0 left, Arg1 right, Status*) {
     return left + (-right);
   }
 };
@@ -298,22 +311,20 @@ struct Multiply {
   static_assert(std::is_same<decltype(uint64_t() * uint64_t()), uint64_t>::value, "");
 
   template <typename T, typename Arg0, typename Arg1>
-  static constexpr enable_if_floating_value<T> Call(KernelContext*, T left, T right,
-                                                    Status*) {
+    requires std::floating_point<T>
+  static constexpr T Call(KernelContext*, T left, T right, Status*) {
     return left * right;
   }
 
   template <typename T, typename Arg0, typename Arg1>
-  static constexpr enable_if_t<
-      is_unsigned_integer_value<T>::value && !std::is_same<T, uint16_t>::value, T>
-  Call(KernelContext*, T left, T right, Status*) {
+    requires(std::unsigned_integral<T> && !std::same_as<T, uint16_t>)
+  static constexpr T Call(KernelContext*, T left, T right, Status*) {
     return left * right;
   }
 
   template <typename T, typename Arg0, typename Arg1>
-  static constexpr enable_if_t<
-      is_signed_integer_value<T>::value && !std::is_same<T, int16_t>::value, T>
-  Call(KernelContext*, T left, T right, Status*) {
+    requires(std::signed_integral<T> && !std::same_as<T, int16_t>)
+  static constexpr T Call(KernelContext*, T left, T right, Status*) {
     return to_unsigned(left) * to_unsigned(right);
   }
 
@@ -322,26 +333,27 @@ struct Multiply {
   // behaviour). Therefore we first cast to 32 bit unsigned integers where overflow is
   // well defined.
   template <typename T, typename Arg0, typename Arg1>
-  static constexpr enable_if_same<T, int16_t, T> Call(KernelContext*, int16_t left,
-                                                      int16_t right, Status*) {
+    requires std::same_as<T, int16_t>
+  static constexpr T Call(KernelContext*, int16_t left, int16_t right, Status*) {
     return static_cast<uint32_t>(left) * static_cast<uint32_t>(right);
   }
   template <typename T, typename Arg0, typename Arg1>
-  static constexpr enable_if_same<T, uint16_t, T> Call(KernelContext*, uint16_t left,
-                                                       uint16_t right, Status*) {
+    requires std::same_as<T, uint16_t>
+  static constexpr T Call(KernelContext*, uint16_t left, uint16_t right, Status*) {
     return static_cast<uint32_t>(left) * static_cast<uint32_t>(right);
   }
 
   template <typename T, typename Arg0, typename Arg1>
-  static enable_if_decimal_value<T> Call(KernelContext*, Arg0 left, Arg1 right, Status*) {
+    requires arithmetic_decimal_value<T>
+  static T Call(KernelContext*, Arg0 left, Arg1 right, Status*) {
     return left * right;
   }
 };
 
 struct MultiplyChecked {
   template <typename T, typename Arg0, typename Arg1>
-  static enable_if_integer_value<T> Call(KernelContext*, Arg0 left, Arg1 right,
-                                         Status* st) {
+    requires std::integral<T>
+  static T Call(KernelContext*, Arg0 left, Arg1 right, Status* st) {
     static_assert(std::is_same<T, Arg0>::value && std::is_same<T, Arg1>::value, "");
     T result = 0;
     if (ARROW_PREDICT_FALSE(MultiplyWithOverflow(left, right, &result))) {
@@ -351,28 +363,29 @@ struct MultiplyChecked {
   }
 
   template <typename T, typename Arg0, typename Arg1>
-  static enable_if_floating_value<T> Call(KernelContext*, Arg0 left, Arg1 right,
-                                          Status*) {
+    requires std::floating_point<T>
+  static T Call(KernelContext*, Arg0 left, Arg1 right, Status*) {
     static_assert(std::is_same<T, Arg0>::value && std::is_same<T, Arg1>::value, "");
     return left * right;
   }
 
   template <typename T, typename Arg0, typename Arg1>
-  static enable_if_decimal_value<T> Call(KernelContext*, Arg0 left, Arg1 right, Status*) {
+    requires arithmetic_decimal_value<T>
+  static T Call(KernelContext*, Arg0 left, Arg1 right, Status*) {
     return left * right;
   }
 };
 
 struct Divide {
   template <typename T, typename Arg0, typename Arg1>
-  static enable_if_floating_value<T> Call(KernelContext*, Arg0 left, Arg1 right,
-                                          Status*) {
+    requires std::floating_point<T>
+  static T Call(KernelContext*, Arg0 left, Arg1 right, Status*) {
     return left / right;
   }
 
   template <typename T, typename Arg0, typename Arg1>
-  static enable_if_integer_value<T> Call(KernelContext*, Arg0 left, Arg1 right,
-                                         Status* st) {
+    requires std::integral<T>
+  static T Call(KernelContext*, Arg0 left, Arg1 right, Status* st) {
     T result;
     if (ARROW_PREDICT_FALSE(DivideWithOverflow(left, right, &result))) {
       if (right == 0) {
@@ -385,8 +398,8 @@ struct Divide {
   }
 
   template <typename T, typename Arg0, typename Arg1>
-  static enable_if_decimal_value<T> Call(KernelContext*, Arg0 left, Arg1 right,
-                                         Status* st) {
+    requires arithmetic_decimal_value<T>
+  static T Call(KernelContext*, Arg0 left, Arg1 right, Status* st) {
     if (right == Arg1()) {
       *st = Status::Invalid("Divide by zero");
       return T();
@@ -398,8 +411,8 @@ struct Divide {
 
 struct DivideChecked {
   template <typename T, typename Arg0, typename Arg1>
-  static enable_if_integer_value<T> Call(KernelContext*, Arg0 left, Arg1 right,
-                                         Status* st) {
+    requires std::integral<T>
+  static T Call(KernelContext*, Arg0 left, Arg1 right, Status* st) {
     static_assert(std::is_same<T, Arg0>::value && std::is_same<T, Arg1>::value, "");
     T result;
     if (ARROW_PREDICT_FALSE(DivideWithOverflow(left, right, &result))) {
@@ -413,8 +426,8 @@ struct DivideChecked {
   }
 
   template <typename T, typename Arg0, typename Arg1>
-  static enable_if_floating_value<T> Call(KernelContext*, Arg0 left, Arg1 right,
-                                          Status* st) {
+    requires std::floating_point<T>
+  static T Call(KernelContext*, Arg0 left, Arg1 right, Status* st) {
     static_assert(std::is_same<T, Arg0>::value && std::is_same<T, Arg1>::value, "");
     if (ARROW_PREDICT_FALSE(right == 0)) {
       *st = Status::Invalid("divide by zero");
@@ -424,22 +437,22 @@ struct DivideChecked {
   }
 
   template <typename T, typename Arg0, typename Arg1>
-  static enable_if_decimal_value<T> Call(KernelContext* ctx, Arg0 left, Arg1 right,
-                                         Status* st) {
+    requires arithmetic_decimal_value<T>
+  static T Call(KernelContext* ctx, Arg0 left, Arg1 right, Status* st) {
     return Divide::Call<T>(ctx, left, right, st);
   }
 };
 
 struct FloatingDivide {
   template <typename T, typename Arg0, typename Arg1>
-  static enable_if_floating_value<Arg0> Call(KernelContext*, Arg0 left, Arg1 right,
-                                             Status*) {
+    requires std::floating_point<Arg0>
+  static Arg0 Call(KernelContext*, Arg0 left, Arg1 right, Status*) {
     return left / right;
   }
 
   template <typename T, typename Arg0, typename Arg1>
-  static enable_if_integer_value<Arg0, double> Call(KernelContext* ctx, Arg0 left,
-                                                    Arg1 right, Status* st) {
+    requires std::integral<Arg0>
+  static double Call(KernelContext* ctx, Arg0 left, Arg1 right, Status* st) {
     static_assert(std::is_same<Arg0, Arg1>::value);
     return Call<double>(ctx, static_cast<double>(left), static_cast<double>(right), st);
   }
@@ -449,8 +462,8 @@ struct FloatingDivide {
 
 struct FloatingDivideChecked {
   template <typename T, typename Arg0, typename Arg1>
-  static enable_if_floating_value<Arg0> Call(KernelContext*, Arg0 left, Arg1 right,
-                                             Status* st) {
+    requires std::floating_point<Arg0>
+  static Arg0 Call(KernelContext*, Arg0 left, Arg1 right, Status* st) {
     static_assert(std::is_same<T, Arg0>::value && std::is_same<T, Arg1>::value);
     if (ARROW_PREDICT_FALSE(right == 0)) {
       *st = Status::Invalid("divide by zero");
@@ -460,8 +473,8 @@ struct FloatingDivideChecked {
   }
 
   template <typename T, typename Arg0, typename Arg1>
-  static enable_if_integer_value<Arg0, double> Call(KernelContext* ctx, Arg0 left,
-                                                    Arg1 right, Status* st) {
+    requires std::integral<Arg0>
+  static double Call(KernelContext* ctx, Arg0 left, Arg1 right, Status* st) {
     static_assert(std::is_same<Arg0, Arg1>::value);
     return Call<double>(ctx, static_cast<double>(left), static_cast<double>(right), st);
   }
@@ -470,38 +483,40 @@ struct FloatingDivideChecked {
 
 struct Negate {
   template <typename T, typename Arg>
-  static constexpr enable_if_floating_value<T> Call(KernelContext*, Arg arg, Status*) {
+    requires std::floating_point<T>
+  static constexpr T Call(KernelContext*, Arg arg, Status*) {
     return -arg;
   }
 
   template <typename T, typename Arg>
-  static constexpr enable_if_half_float_value<T> Call(KernelContext*, Arg arg, Status*) {
+    requires arithmetic_half_float_value<T>
+  static constexpr T Call(KernelContext*, Arg arg, Status*) {
     return -arg;
   }
 
   template <typename T, typename Arg>
-  static constexpr enable_if_unsigned_integer_value<T> Call(KernelContext*, Arg arg,
-                                                            Status*) {
+    requires std::unsigned_integral<T>
+  static constexpr T Call(KernelContext*, Arg arg, Status*) {
     return ~arg + 1;
   }
 
   template <typename T, typename Arg>
-  static constexpr enable_if_signed_integer_value<T> Call(KernelContext*, Arg arg,
-                                                          Status*) {
+    requires std::signed_integral<T>
+  static constexpr T Call(KernelContext*, Arg arg, Status*) {
     return arrow::internal::SafeSignedNegate(arg);
   }
 
   template <typename T, typename Arg>
-  static constexpr enable_if_decimal_value<Arg, T> Call(KernelContext*, Arg arg,
-                                                        Status*) {
+    requires arithmetic_decimal_value<Arg>
+  static constexpr T Call(KernelContext*, Arg arg, Status*) {
     return arg.Negate();
   }
 };
 
 struct NegateChecked {
   template <typename T, typename Arg>
-  static enable_if_signed_integer_value<Arg, T> Call(KernelContext*, Arg arg,
-                                                     Status* st) {
+    requires std::signed_integral<Arg>
+  static T Call(KernelContext*, Arg arg, Status* st) {
     static_assert(std::is_same<T, Arg>::value, "");
     T result = 0;
     if (ARROW_PREDICT_FALSE(NegateWithOverflow(arg, &result))) {
@@ -511,8 +526,8 @@ struct NegateChecked {
   }
 
   template <typename T, typename Arg>
-  static enable_if_unsigned_integer_value<Arg, T> Call(KernelContext* ctx, Arg arg,
-                                                       Status* st) {
+    requires std::unsigned_integral<Arg>
+  static T Call(KernelContext* ctx, Arg arg, Status* st) {
     static_assert(std::is_same<T, Arg>::value, "");
     ARROW_DCHECK(false) << "This is included only for the purposes of instantiability "
                            "from the arithmetic kernel generator";
@@ -520,21 +535,22 @@ struct NegateChecked {
   }
 
   template <typename T, typename Arg>
-  static constexpr enable_if_floating_value<Arg, T> Call(KernelContext*, Arg arg,
-                                                         Status* st) {
+    requires std::floating_point<Arg>
+  static constexpr T Call(KernelContext*, Arg arg, Status* st) {
     static_assert(std::is_same<T, Arg>::value, "");
     return -arg;
   }
 
   template <typename T, typename Arg>
-  static constexpr enable_if_half_float_value<T> Call(KernelContext*, Arg arg, Status*) {
+    requires arithmetic_half_float_value<T>
+  static constexpr T Call(KernelContext*, Arg arg, Status*) {
     static_assert(std::is_same<T, Arg>::value, "");
     return -arg;
   }
 
   template <typename T, typename Arg>
-  static constexpr enable_if_decimal_value<Arg, T> Call(KernelContext*, Arg arg,
-                                                        Status*) {
+    requires arithmetic_decimal_value<Arg>
+  static constexpr T Call(KernelContext*, Arg arg, Status*) {
     return arg.Negate();
   }
 };
@@ -569,7 +585,8 @@ struct Power {
   }
 
   template <typename T, typename Arg0, typename Arg1>
-  static enable_if_integer_value<T> Call(KernelContext*, T base, T exp, Status* st) {
+    requires std::integral<T>
+  static T Call(KernelContext*, T base, T exp, Status* st) {
     if (exp < 0) {
       *st = Status::Invalid("integers to negative integer powers are not allowed");
       return 0;
@@ -578,15 +595,16 @@ struct Power {
   }
 
   template <typename T, typename Arg0, typename Arg1>
-  static enable_if_floating_value<T> Call(KernelContext*, T base, T exp, Status*) {
+    requires std::floating_point<T>
+  static T Call(KernelContext*, T base, T exp, Status*) {
     return std::pow(base, exp);
   }
 };
 
 struct PowerChecked {
   template <typename T, typename Arg0, typename Arg1>
-  static enable_if_integer_value<T> Call(KernelContext*, Arg0 base, Arg1 exp,
-                                         Status* st) {
+    requires std::integral<T>
+  static T Call(KernelContext*, Arg0 base, Arg1 exp, Status* st) {
     if (exp < 0) {
       *st = Status::Invalid("integers to negative integer powers are not allowed");
       return 0;
@@ -611,7 +629,8 @@ struct PowerChecked {
   }
 
   template <typename T, typename Arg0, typename Arg1>
-  static enable_if_floating_value<T> Call(KernelContext*, Arg0 base, Arg1 exp, Status*) {
+    requires std::floating_point<T>
+  static T Call(KernelContext*, Arg0 base, Arg1 exp, Status*) {
     static_assert(std::is_same<T, Arg0>::value && std::is_same<T, Arg1>::value, "");
     return std::pow(base, exp);
   }
@@ -619,7 +638,8 @@ struct PowerChecked {
 
 struct SquareRoot {
   template <typename T, typename Arg>
-  static enable_if_floating_value<Arg, T> Call(KernelContext*, Arg arg, Status*) {
+    requires std::floating_point<Arg>
+  static T Call(KernelContext*, Arg arg, Status*) {
     static_assert(std::is_same<T, Arg>::value, "");
     if (arg < 0.0) {
       return std::numeric_limits<T>::quiet_NaN();
@@ -630,7 +650,8 @@ struct SquareRoot {
 
 struct SquareRootChecked {
   template <typename T, typename Arg>
-  static enable_if_floating_value<Arg, T> Call(KernelContext*, Arg arg, Status* st) {
+    requires std::floating_point<Arg>
+  static T Call(KernelContext*, Arg arg, Status* st) {
     static_assert(std::is_same<T, Arg>::value, "");
     if (arg < 0.0) {
       *st = Status::Invalid("square root of negative number");
@@ -642,14 +663,14 @@ struct SquareRootChecked {
 
 struct Sign {
   template <typename T, typename Arg>
-  static constexpr enable_if_floating_value<Arg, T> Call(KernelContext*, Arg arg,
-                                                         Status*) {
+    requires std::floating_point<Arg>
+  static constexpr T Call(KernelContext*, Arg arg, Status*) {
     return std::isnan(arg) ? arg : ((arg == 0) ? 0 : (std::signbit(arg) ? -1 : 1));
   }
 
   template <typename T, typename Arg>
-  static constexpr enable_if_half_float_value<Arg, T> Call(KernelContext*, Arg arg,
-                                                           Status*) {
+    requires arithmetic_half_float_value<Arg>
+  static constexpr T Call(KernelContext*, Arg arg, Status*) {
     return arg.is_nan()
                ? arg
                : (arg.is_zero() ? Float16::zero()
@@ -657,35 +678,35 @@ struct Sign {
   }
 
   template <typename T, typename Arg>
-  static constexpr enable_if_unsigned_integer_value<Arg, T> Call(KernelContext*, Arg arg,
-                                                                 Status*) {
+    requires std::unsigned_integral<Arg>
+  static constexpr T Call(KernelContext*, Arg arg, Status*) {
     return (arg > 0) ? 1 : 0;
   }
 
   template <typename T, typename Arg>
-  static constexpr enable_if_signed_integer_value<Arg, T> Call(KernelContext*, Arg arg,
-                                                               Status*) {
+    requires std::signed_integral<Arg>
+  static constexpr T Call(KernelContext*, Arg arg, Status*) {
     return (arg > 0) ? 1 : ((arg == 0) ? 0 : -1);
   }
 
   template <typename T, typename Arg>
-  static constexpr enable_if_decimal_value<Arg, T> Call(KernelContext*, Arg arg,
-                                                        Status*) {
+    requires arithmetic_decimal_value<Arg>
+  static constexpr T Call(KernelContext*, Arg arg, Status*) {
     return (arg == 0) ? 0 : arg.Sign();
   }
 };
 
 struct Max {
   template <typename T, typename Arg0, typename Arg1>
-  static constexpr enable_if_not_floating_value<T> Call(KernelContext*, Arg0 arg0,
-                                                        Arg1 arg1, Status*) {
+    requires(!std::floating_point<T>)
+  static constexpr T Call(KernelContext*, Arg0 arg0, Arg1 arg1, Status*) {
     static_assert(std::is_same<T, Arg0>::value && std::is_same<Arg0, Arg1>::value);
     return std::max(arg0, arg1);
   }
 
   template <typename T, typename Arg0, typename Arg1>
-  static constexpr enable_if_floating_value<T> Call(KernelContext*, Arg0 left, Arg1 right,
-                                                    Status*) {
+    requires std::floating_point<T>
+  static constexpr T Call(KernelContext*, Arg0 left, Arg1 right, Status*) {
     static_assert(std::is_same<T, Arg0>::value && std::is_same<Arg0, Arg1>::value);
     if (std::isnan(left)) {
       return right;
@@ -699,15 +720,15 @@ struct Max {
 
 struct Min {
   template <typename T, typename Arg0, typename Arg1>
-  static constexpr enable_if_not_floating_value<T> Call(KernelContext*, Arg0 arg0,
-                                                        Arg1 arg1, Status*) {
+    requires(!std::floating_point<T>)
+  static constexpr T Call(KernelContext*, Arg0 arg0, Arg1 arg1, Status*) {
     static_assert(std::is_same<T, Arg0>::value && std::is_same<Arg0, Arg1>::value);
     return std::min(arg0, arg1);
   }
 
   template <typename T, typename Arg0, typename Arg1>
-  static constexpr enable_if_floating_value<T> Call(KernelContext*, Arg0 left, Arg1 right,
-                                                    Status*) {
+    requires std::floating_point<T>
+  static constexpr T Call(KernelContext*, Arg0 left, Arg1 right, Status*) {
     static_assert(std::is_same<T, Arg0>::value && std::is_same<Arg0, Arg1>::value);
     if (std::isnan(left)) {
       return right;

--- a/cpp/src/arrow/compute/kernels/codegen_internal.h
+++ b/cpp/src/arrow/compute/kernels/codegen_internal.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <concepts>
 #include <cstdint>
 #include <cstring>
 #include <memory>
@@ -123,11 +124,11 @@ struct KernelStateFromFunctionOptions : public KernelState {
 // ----------------------------------------------------------------------
 // Input and output value type definitions
 
-template <typename Type, typename Enable = void>
+template <typename Type>
 struct GetViewType;
 
-template <typename Type>
-struct GetViewType<Type, enable_if_has_c_type<Type>> {
+template <arrow_has_c_type Type>
+struct GetViewType<Type> {
   using T = typename Type::c_type;
   using PhysicalType = T;
 
@@ -143,9 +144,9 @@ struct GetViewType<HalfFloatType> {
 };
 
 template <typename Type>
-struct GetViewType<Type, enable_if_t<is_base_binary_type<Type>::value ||
-                                     is_fixed_size_binary_type<Type>::value ||
-                                     is_binary_view_like_type<Type>::value>> {
+  requires(arrow_base_binary<Type> || arrow_fixed_size_binary<Type> ||
+           arrow_binary_view_like<Type>)
+struct GetViewType<Type> {
   using T = std::string_view;
   using PhysicalType = T;
 
@@ -200,11 +201,11 @@ struct GetViewType<Decimal256Type> {
   static T LogicalValue(T value) { return value; }
 };
 
-template <typename Type, typename Enable = void>
+template <typename Type>
 struct GetOutputType;
 
-template <typename Type>
-struct GetOutputType<Type, enable_if_has_c_type<Type>> {
+template <arrow_has_c_type Type>
+struct GetOutputType<Type> {
   using T = typename Type::c_type;
 };
 
@@ -213,8 +214,8 @@ struct GetOutputType<HalfFloatType> {
   using T = Float16;
 };
 
-template <typename Type>
-struct GetOutputType<Type, enable_if_t<is_string_like_type<Type>::value>> {
+template <arrow_string_like Type>
+struct GetOutputType<Type> {
   using T = std::string;
 };
 
@@ -239,7 +240,7 @@ struct GetOutputType<Decimal256Type> {
 };
 
 // ----------------------------------------------------------------------
-// enable_if helpers for C types
+// Local concepts for value-category and callback dispatch
 
 template <typename T>
 using is_unsigned_integer_value =
@@ -255,6 +256,8 @@ using is_integer_value =
     std::integral_constant<bool, is_signed_integer_value<T>::value ||
                                      is_unsigned_integer_value<T>::value>;
 
+// Keep these local aliases for compatibility with neighboring kernel .cc files
+// that still depend on codegen_internal.h for value-category SFINAE helpers.
 template <typename T, typename R = T>
 using enable_if_signed_integer_value = enable_if_t<is_signed_integer_value<T>::value, R>;
 
@@ -290,13 +293,26 @@ template <typename T, typename R = void>
 using enable_if_c_number_or_decimal = enable_if_t<
     (has_c_type<T>::value && !is_boolean_type<T>::value) || is_decimal_type<T>::value, R>;
 
+template <typename T>
+concept codegen_c_number_or_decimal =
+    (arrow_has_c_type<T> && !arrow_boolean<T>) || arrow_decimal<T>;
+
+template <typename VisitFunc, typename Arg>
+concept codegen_visit_returns_void =
+    std::same_as<void, std::invoke_result_t<VisitFunc&, Arg>>;
+
+template <typename VisitFunc, typename Arg>
+concept codegen_visit_returns_status =
+    std::same_as<Status, std::invoke_result_t<VisitFunc&, Arg>>;
+
 // Iterator over various input array types, yielding a GetViewType<Type>
 
-template <typename Type, typename Enable = void>
+template <typename Type>
 struct ArrayIterator;
 
 template <typename Type>
-struct ArrayIterator<Type, enable_if_c_number_or_decimal<Type>> {
+  requires codegen_c_number_or_decimal<Type>
+struct ArrayIterator<Type> {
   using T = typename TypeTraits<Type>::ScalarType::ValueType;
   const T* values;
 
@@ -313,8 +329,8 @@ struct ArrayIterator<HalfFloatType> {
   T operator()() { return *values++; }
 };
 
-template <typename Type>
-struct ArrayIterator<Type, enable_if_boolean<Type>> {
+template <arrow_boolean Type>
+struct ArrayIterator<Type> {
   BitmapReader reader;
 
   explicit ArrayIterator(const ArraySpan& arr)
@@ -326,8 +342,8 @@ struct ArrayIterator<Type, enable_if_boolean<Type>> {
   }
 };
 
-template <typename Type>
-struct ArrayIterator<Type, enable_if_base_binary<Type>> {
+template <arrow_base_binary Type>
+struct ArrayIterator<Type> {
   using offset_type = typename Type::offset_type;
   const ArraySpan& arr;
   const offset_type* offsets;
@@ -372,11 +388,12 @@ struct ArrayIterator<FixedSizeBinaryType> {
 
 // Iterator over various output array types, taking a GetOutputType<Type>
 
-template <typename Type, typename Enable = void>
+template <typename Type>
 struct OutputArrayWriter;
 
 template <typename Type>
-struct OutputArrayWriter<Type, enable_if_c_number_or_decimal<Type>> {
+  requires codegen_c_number_or_decimal<Type>
+struct OutputArrayWriter<Type> {
   using T = typename TypeTraits<Type>::ScalarType::ValueType;
   T* values;
 
@@ -395,11 +412,11 @@ struct OutputArrayWriter<Type, enable_if_c_number_or_decimal<Type>> {
 
 // (Un)box Scalar to / from C++ value
 
-template <typename Type, typename Enable = void>
+template <typename Type>
 struct UnboxScalar;
 
-template <typename Type>
-struct UnboxScalar<Type, enable_if_has_c_type<Type>> {
+template <arrow_has_c_type Type>
+struct UnboxScalar<Type> {
   using T = typename Type::c_type;
   static T Unbox(const Scalar& val) {
     std::string_view view =
@@ -417,8 +434,8 @@ struct UnboxScalar<HalfFloatType> {
   }
 };
 
-template <typename Type>
-struct UnboxScalar<Type, enable_if_has_string_view<Type>> {
+template <arrow_has_string_view Type>
+struct UnboxScalar<Type> {
   using T = std::string_view;
   static T Unbox(const Scalar& val) {
     if (!val.is_valid) return std::string_view();
@@ -462,9 +479,9 @@ struct UnboxScalar<Decimal256Type> {
 // values, such as Decimal128 rather than std::string_view.
 
 template <typename T, typename VisitFunc, typename NullFunc>
-static typename ::arrow::internal::call_traits::enable_if_return<VisitFunc, void>::type
-VisitArrayValuesInline(const ArraySpan& arr, VisitFunc&& valid_func,
-                       NullFunc&& null_func) {
+  requires codegen_visit_returns_void<VisitFunc, typename GetViewType<T>::T>
+static void VisitArrayValuesInline(const ArraySpan& arr, VisitFunc&& valid_func,
+                                   NullFunc&& null_func) {
   VisitArraySpanInline<T>(
       arr,
       [&](typename GetViewType<T>::PhysicalType v) {
@@ -474,9 +491,9 @@ VisitArrayValuesInline(const ArraySpan& arr, VisitFunc&& valid_func,
 }
 
 template <typename T, typename VisitFunc, typename NullFunc>
-static typename ::arrow::internal::call_traits::enable_if_return<VisitFunc, Status>::type
-VisitArrayValuesInline(const ArraySpan& arr, VisitFunc&& valid_func,
-                       NullFunc&& null_func) {
+  requires codegen_visit_returns_status<VisitFunc, typename GetViewType<T>::T>
+static Status VisitArrayValuesInline(const ArraySpan& arr, VisitFunc&& valid_func,
+                                     NullFunc&& null_func) {
   return VisitArraySpanInline<T>(
       arr,
       [&](typename GetViewType<T>::PhysicalType v) {
@@ -582,11 +599,11 @@ static Status SimpleBinary(KernelContext* ctx, const ExecSpan& batch, ExecResult
 // of output values to write into output memory. Boolean and primitive outputs
 // are currently implemented, and the validity bitmap is presumed to be handled
 // at a higher level, so this writes into every output slot, null or not.
-template <typename Type, typename Enable = void>
+template <typename Type>
 struct OutputAdapter;
 
-template <typename Type>
-struct OutputAdapter<Type, enable_if_boolean<Type>> {
+template <arrow_boolean Type>
+struct OutputAdapter<Type> {
   template <typename Generator>
   static Status Write(KernelContext*, ArraySpan* out, Generator&& generator) {
     GenerateBitsUnrolled(out->buffers[1].data, out->offset, out->length,
@@ -596,7 +613,8 @@ struct OutputAdapter<Type, enable_if_boolean<Type>> {
 };
 
 template <typename Type>
-struct OutputAdapter<Type, enable_if_c_number_or_decimal<Type>> {
+  requires codegen_c_number_or_decimal<Type>
+struct OutputAdapter<Type> {
   using T = std::conditional_t<std::is_same_v<Type, HalfFloatType>, Float16,
                                typename TypeTraits<Type>::ScalarType::ValueType>;
 
@@ -611,8 +629,8 @@ struct OutputAdapter<Type, enable_if_c_number_or_decimal<Type>> {
   }
 };
 
-template <typename Type>
-struct OutputAdapter<Type, enable_if_base_binary<Type>> {
+template <arrow_base_binary Type>
+struct OutputAdapter<Type> {
   template <typename Generator>
   static Status Write(KernelContext* ctx, ArraySpan* out, Generator&& generator) {
     return Status::NotImplemented("NYI");
@@ -668,7 +686,7 @@ struct ScalarUnaryNotNullStateful {
 
   // NOTE: In ArrayExec<Type>, Type is really OutputType
 
-  template <typename Type, typename Enable = void>
+  template <typename Type>
   struct ArrayExec {
     static Status Exec(const ThisType& functor, KernelContext* ctx, const ExecSpan& batch,
                        ExecResult* out) {
@@ -679,7 +697,11 @@ struct ScalarUnaryNotNullStateful {
   };
 
   template <typename Type>
-  struct ArrayExec<Type, enable_if_c_number_or_decimal<Type>> {
+    requires codegen_c_number_or_decimal<Type>
+  struct ArrayExec<Type> {
+    using OutValue = typename GetOutputType<OutType>::T;
+    using Arg0Value = typename GetViewType<Arg0Type>::T;
+
     static Status Exec(const ThisType& functor, KernelContext* ctx, const ArraySpan& arg0,
                        ExecResult* out) {
       Status st = Status::OK();
@@ -698,7 +720,11 @@ struct ScalarUnaryNotNullStateful {
   };
 
   template <typename Type>
-  struct ArrayExec<Type, enable_if_base_binary<Type>> {
+    requires arrow_base_binary<Type>
+  struct ArrayExec<Type> {
+    using OutValue = typename GetOutputType<OutType>::T;
+    using Arg0Value = typename GetViewType<Arg0Type>::T;
+
     static Status Exec(const ThisType& functor, KernelContext* ctx, const ArraySpan& arg0,
                        ExecResult* out) {
       // NOTE: This code is not currently used by any kernels and has
@@ -720,7 +746,11 @@ struct ScalarUnaryNotNullStateful {
   };
 
   template <typename Type>
-  struct ArrayExec<Type, enable_if_t<is_boolean_type<Type>::value>> {
+    requires arrow_boolean<Type>
+  struct ArrayExec<Type> {
+    using OutValue = typename GetOutputType<OutType>::T;
+    using Arg0Value = typename GetViewType<Arg0Type>::T;
+
     static Status Exec(const ThisType& functor, KernelContext* ctx, const ArraySpan& arg0,
                        ExecResult* out) {
       Status st = Status::OK();

--- a/cpp/src/arrow/compute/kernels/copy_data_internal.h
+++ b/cpp/src/arrow/compute/kernels/copy_data_internal.h
@@ -23,7 +23,7 @@ namespace arrow {
 namespace compute {
 namespace internal {
 
-template <typename Type, typename Enable = void>
+template <typename Type>
 struct CopyDataUtils {};
 
 template <>
@@ -83,8 +83,8 @@ struct CopyDataUtils<FixedSizeBinaryType> {
 };
 
 template <typename Type>
-struct CopyDataUtils<
-    Type, enable_if_t<is_number_type<Type>::value || is_interval_type<Type>::value>> {
+  requires(arrow_number<Type> || arrow_interval<Type>)
+struct CopyDataUtils<Type> {
   using CType = typename TypeTraits<Type>::CType;
 
   static void CopyData(const DataType&, const Scalar& in, const int64_t in_offset,

--- a/cpp/src/arrow/compute/kernels/hash_aggregate.cc
+++ b/cpp/src/arrow/compute/kernels/hash_aggregate.cc
@@ -328,7 +328,7 @@ struct MinMaxOp<CType> {
   static constexpr CType max(CType a, CType b) { return std::fmax(a, b); }
 };
 
-template <typename Type, typename Enable = void>
+template <typename Type>
 struct GroupedMinMaxImpl final : public GroupedAggregator {
   using CType = typename TypeTraits<Type>::CType;
   using GetSet = GroupedValueTraits<Type>;
@@ -434,10 +434,8 @@ struct GroupedMinMaxImpl final : public GroupedAggregator {
 // For binary-like types
 // In principle, FixedSizeBinary could use base implementation
 template <typename Type>
-struct GroupedMinMaxImpl<Type,
-                         enable_if_t<is_base_binary_type<Type>::value ||
-                                     std::is_same<Type, FixedSizeBinaryType>::value>>
-    final : public GroupedAggregator {
+  requires(arrow_base_binary<Type> || std::same_as<Type, FixedSizeBinaryType>)
+struct GroupedMinMaxImpl<Type> final : public GroupedAggregator {
   using Allocator = arrow::stl::allocator<char>;
   using StringType = std::basic_string<char, std::char_traits<char>, Allocator>;
 
@@ -526,8 +524,9 @@ struct GroupedMinMaxImpl<Type,
   }
 
   template <typename T = Type>
-  enable_if_base_binary<T, Status> MakeOffsetsValues(
-      ArrayData* array, const std::vector<std::optional<StringType>>& values) {
+    requires arrow_base_binary<T>
+  Status MakeOffsetsValues(ArrayData* array,
+                           const std::vector<std::optional<StringType>>& values) {
     using offset_type = typename T::offset_type;
     ARROW_ASSIGN_OR_RAISE(
         auto raw_offsets,
@@ -567,8 +566,9 @@ struct GroupedMinMaxImpl<Type,
   }
 
   template <typename T = Type>
-  enable_if_same<T, FixedSizeBinaryType, Status> MakeOffsetsValues(
-      ArrayData* array, const std::vector<std::optional<StringType>>& values) {
+    requires std::same_as<T, FixedSizeBinaryType>
+  Status MakeOffsetsValues(ArrayData* array,
+                           const std::vector<std::optional<StringType>>& values) {
     const uint8_t* null_bitmap = array->buffers[0]->data();
     const int32_t slot_width =
         checked_cast<const FixedSizeBinaryType&>(*array->type).byte_width();
@@ -667,8 +667,8 @@ HashAggregateKernel MakeMinOrMaxKernel(HashAggregateFunction* min_max_func) {
 }
 
 struct GroupedMinMaxFactory {
-  template <typename T>
-  enable_if_physical_integer<T, Status> Visit(const T&) {
+  template <arrow_physical_integer T>
+  Status Visit(const T&) {
     using PhysicalType = typename T::PhysicalType;
     kernel = MakeKernel(std::move(argument_type), MinMaxInit<PhysicalType>);
     return Status::OK();
@@ -686,14 +686,14 @@ struct GroupedMinMaxFactory {
     return Status::OK();
   }
 
-  template <typename T>
-  enable_if_decimal<T, Status> Visit(const T&) {
+  template <arrow_decimal T>
+  Status Visit(const T&) {
     kernel = MakeKernel(std::move(argument_type), MinMaxInit<T>);
     return Status::OK();
   }
 
-  template <typename T>
-  enable_if_base_binary<T, Status> Visit(const T&) {
+  template <arrow_base_binary T>
+  Status Visit(const T&) {
     kernel = MakeKernel(std::move(argument_type), MinMaxInit<T>);
     return Status::OK();
   }
@@ -736,7 +736,7 @@ struct GroupedMinMaxFactory {
 // ----------------------------------------------------------------------
 // FirstLast implementation
 
-template <typename Type, typename Enable = void>
+template <typename Type>
 struct GroupedFirstLastImpl final : public GroupedAggregator {
   using CType = typename TypeTraits<Type>::CType;
   using GetSet = GroupedValueTraits<Type>;
@@ -926,10 +926,8 @@ struct GroupedFirstLastImpl final : public GroupedAggregator {
 };
 
 template <typename Type>
-struct GroupedFirstLastImpl<Type,
-                            enable_if_t<is_base_binary_type<Type>::value ||
-                                        std::is_same<Type, FixedSizeBinaryType>::value>>
-    final : public GroupedAggregator {
+  requires(arrow_base_binary<Type> || std::same_as<Type, FixedSizeBinaryType>)
+struct GroupedFirstLastImpl<Type> final : public GroupedAggregator {
   using Allocator = arrow::stl::allocator<char>;
   using StringType = std::basic_string<char, std::char_traits<char>, Allocator>;
 
@@ -1059,8 +1057,9 @@ struct GroupedFirstLastImpl<Type,
   }
 
   template <typename T = Type>
-  enable_if_base_binary<T, Status> MakeOffsetsValues(
-      ArrayData* array, const std::vector<std::optional<StringType>>& values) {
+    requires arrow_base_binary<T>
+  Status MakeOffsetsValues(ArrayData* array,
+                           const std::vector<std::optional<StringType>>& values) {
     using offset_type = typename T::offset_type;
     ARROW_ASSIGN_OR_RAISE(
         auto raw_offsets,
@@ -1100,8 +1099,9 @@ struct GroupedFirstLastImpl<Type,
   }
 
   template <typename T = Type>
-  enable_if_same<T, FixedSizeBinaryType, Status> MakeOffsetsValues(
-      ArrayData* array, const std::vector<std::optional<StringType>>& values) {
+    requires std::same_as<T, FixedSizeBinaryType>
+  Status MakeOffsetsValues(ArrayData* array,
+                           const std::vector<std::optional<StringType>>& values) {
     const uint8_t* null_bitmap = array->buffers[0]->data();
     const int32_t slot_width =
         checked_cast<const FixedSizeBinaryType&>(*array->type).byte_width();
@@ -1172,8 +1172,8 @@ HashAggregateKernel MakeFirstOrLastKernel(HashAggregateFunction* first_last_func
 }
 
 struct GroupedFirstLastFactory {
-  template <typename T>
-  enable_if_physical_integer<T, Status> Visit(const T&) {
+  template <arrow_physical_integer T>
+  Status Visit(const T&) {
     using PhysicalType = typename T::PhysicalType;
     kernel = MakeKernel(std::move(argument_type), FirstLastInit<PhysicalType>,
                         /*ordered*/ true);
@@ -1192,8 +1192,8 @@ struct GroupedFirstLastFactory {
     return Status::OK();
   }
 
-  template <typename T>
-  enable_if_base_binary<T, Status> Visit(const T&) {
+  template <arrow_base_binary T>
+  Status Visit(const T&) {
     kernel = MakeKernel(std::move(argument_type), FirstLastInit<T>);
     return Status::OK();
   }
@@ -1556,7 +1556,7 @@ Result<std::unique_ptr<KernelState>> GroupedDistinctInit(KernelContext* ctx,
 // ----------------------------------------------------------------------
 // One implementation
 
-template <typename Type, typename Enable = void>
+template <typename Type>
 struct GroupedOneImpl final : public GroupedAggregator {
   using CType = typename TypeTraits<Type>::CType;
   using GetSet = GroupedValueTraits<Type>;
@@ -1652,9 +1652,8 @@ struct GroupedNullOneImpl : public GroupedAggregator {
 };
 
 template <typename Type>
-struct GroupedOneImpl<Type, enable_if_t<is_base_binary_type<Type>::value ||
-                                        std::is_same<Type, FixedSizeBinaryType>::value>>
-    final : public GroupedAggregator {
+  requires(arrow_base_binary<Type> || std::same_as<Type, FixedSizeBinaryType>)
+struct GroupedOneImpl<Type> final : public GroupedAggregator {
   using Allocator = arrow::stl::allocator<char>;
   using StringType = std::basic_string<char, std::char_traits<char>, Allocator>;
 
@@ -1713,8 +1712,9 @@ struct GroupedOneImpl<Type, enable_if_t<is_base_binary_type<Type>::value ||
   }
 
   template <typename T = Type>
-  enable_if_base_binary<T, Status> MakeOffsetsValues(
-      ArrayData* array, const std::vector<std::optional<StringType>>& values) {
+    requires arrow_base_binary<T>
+  Status MakeOffsetsValues(ArrayData* array,
+                           const std::vector<std::optional<StringType>>& values) {
     using offset_type = typename T::offset_type;
     ARROW_ASSIGN_OR_RAISE(
         auto raw_offsets,
@@ -1754,8 +1754,9 @@ struct GroupedOneImpl<Type, enable_if_t<is_base_binary_type<Type>::value ||
   }
 
   template <typename T = Type>
-  enable_if_same<T, FixedSizeBinaryType, Status> MakeOffsetsValues(
-      ArrayData* array, const std::vector<std::optional<StringType>>& values) {
+    requires std::same_as<T, FixedSizeBinaryType>
+  Status MakeOffsetsValues(ArrayData* array,
+                           const std::vector<std::optional<StringType>>& values) {
     const uint8_t* null_bitmap = array->buffers[0]->data();
     const int32_t slot_width =
         checked_cast<const FixedSizeBinaryType&>(*array->type).byte_width();
@@ -1796,27 +1797,27 @@ Result<std::unique_ptr<KernelState>> GroupedOneInit(KernelContext* ctx,
 }
 
 struct GroupedOneFactory {
-  template <typename T>
-  enable_if_physical_integer<T, Status> Visit(const T&) {
+  template <arrow_physical_integer T>
+  Status Visit(const T&) {
     using PhysicalType = typename T::PhysicalType;
     kernel = MakeKernel(std::move(argument_type), GroupedOneInit<PhysicalType>);
     return Status::OK();
   }
 
-  template <typename T>
-  enable_if_floating_point<T, Status> Visit(const T&) {
+  template <arrow_floating_point T>
+  Status Visit(const T&) {
     kernel = MakeKernel(std::move(argument_type), GroupedOneInit<T>);
     return Status::OK();
   }
 
-  template <typename T>
-  enable_if_decimal<T, Status> Visit(const T&) {
+  template <arrow_decimal T>
+  Status Visit(const T&) {
     kernel = MakeKernel(std::move(argument_type), GroupedOneInit<T>);
     return Status::OK();
   }
 
-  template <typename T>
-  enable_if_base_binary<T, Status> Visit(const T&) {
+  template <arrow_base_binary T>
+  Status Visit(const T&) {
     kernel = MakeKernel(std::move(argument_type), GroupedOneInit<T>);
     return Status::OK();
   }
@@ -1858,7 +1859,7 @@ struct GroupedOneFactory {
 // ----------------------------------------------------------------------
 // List implementation
 
-template <typename Type, typename Enable = void>
+template <typename Type>
 struct GroupedListImpl final : public GroupedAggregator {
   using CType = typename TypeTraits<Type>::CType;
   using GetSet = GroupedValueTraits<Type>;
@@ -1964,9 +1965,8 @@ struct GroupedListImpl final : public GroupedAggregator {
 };
 
 template <typename Type>
-struct GroupedListImpl<Type, enable_if_t<is_base_binary_type<Type>::value ||
-                                         std::is_same<Type, FixedSizeBinaryType>::value>>
-    final : public GroupedAggregator {
+  requires(arrow_base_binary<Type> || std::same_as<Type, FixedSizeBinaryType>)
+struct GroupedListImpl<Type> final : public GroupedAggregator {
   using Allocator = arrow::stl::allocator<char>;
   using StringType = std::basic_string<char, std::char_traits<char>, Allocator>;
   using GetSet = GroupedValueTraits<Type>;
@@ -2052,8 +2052,9 @@ struct GroupedListImpl<Type, enable_if_t<is_base_binary_type<Type>::value ||
   }
 
   template <typename T = Type>
-  enable_if_base_binary<T, Status> MakeOffsetsValues(
-      ArrayData* array, const std::vector<std::optional<StringType>>& values) {
+    requires arrow_base_binary<T>
+  Status MakeOffsetsValues(ArrayData* array,
+                           const std::vector<std::optional<StringType>>& values) {
     using offset_type = typename T::offset_type;
     ARROW_ASSIGN_OR_RAISE(
         auto raw_offsets,
@@ -2093,8 +2094,9 @@ struct GroupedListImpl<Type, enable_if_t<is_base_binary_type<Type>::value ||
   }
 
   template <typename T = Type>
-  enable_if_same<T, FixedSizeBinaryType, Status> MakeOffsetsValues(
-      ArrayData* array, const std::vector<std::optional<StringType>>& values) {
+    requires std::same_as<T, FixedSizeBinaryType>
+  Status MakeOffsetsValues(ArrayData* array,
+                           const std::vector<std::optional<StringType>>& values) {
     const uint8_t* null_bitmap = array->buffers[0]->data();
     const int32_t slot_width =
         checked_cast<const FixedSizeBinaryType&>(*array->type).byte_width();
@@ -2194,27 +2196,27 @@ Result<std::unique_ptr<KernelState>> GroupedListInit(KernelContext* ctx,
 }
 
 struct GroupedListFactory {
-  template <typename T>
-  enable_if_physical_integer<T, Status> Visit(const T&) {
+  template <arrow_physical_integer T>
+  Status Visit(const T&) {
     using PhysicalType = typename T::PhysicalType;
     kernel = MakeKernel(std::move(argument_type), GroupedListInit<PhysicalType>);
     return Status::OK();
   }
 
-  template <typename T>
-  enable_if_floating_point<T, Status> Visit(const T&) {
+  template <arrow_floating_point T>
+  Status Visit(const T&) {
     kernel = MakeKernel(std::move(argument_type), GroupedListInit<T>);
     return Status::OK();
   }
 
-  template <typename T>
-  enable_if_decimal<T, Status> Visit(const T&) {
+  template <arrow_decimal T>
+  Status Visit(const T&) {
     kernel = MakeKernel(std::move(argument_type), GroupedListInit<T>);
     return Status::OK();
   }
 
-  template <typename T>
-  enable_if_base_binary<T, Status> Visit(const T&) {
+  template <arrow_base_binary T>
+  Status Visit(const T&) {
     kernel = MakeKernel(std::move(argument_type), GroupedListInit<T>);
     return Status::OK();
   }

--- a/cpp/src/arrow/compute/kernels/hash_aggregate_internal.h
+++ b/cpp/src/arrow/compute/kernels/hash_aggregate_internal.h
@@ -17,7 +17,9 @@
 
 #pragma once
 
+#include <concepts>
 #include <memory>
+#include <type_traits>
 
 #include "arrow/array/data.h"
 #include "arrow/buffer_builder.h"
@@ -150,9 +152,10 @@ struct GroupedValueTraits<BooleanType> {
 };
 
 template <typename Type, typename ConsumeValue, typename ConsumeNull>
-typename arrow::internal::call_traits::enable_if_return<ConsumeValue, void>::type
-VisitGroupedValues(const ExecSpan& batch, ConsumeValue&& valid_func,
-                   ConsumeNull&& null_func) {
+  requires std::is_void_v<
+      std::invoke_result_t<ConsumeValue, uint32_t, typename TypeTraits<Type>::CType>>
+void VisitGroupedValues(const ExecSpan& batch, ConsumeValue&& valid_func,
+                        ConsumeNull&& null_func) {
   auto g = batch[1].array.GetValues<uint32_t>(1);
   if (batch[0].is_array()) {
     VisitArrayValuesInline<Type>(
@@ -175,9 +178,10 @@ VisitGroupedValues(const ExecSpan& batch, ConsumeValue&& valid_func,
 }
 
 template <typename Type, typename ConsumeValue, typename ConsumeNull>
-typename arrow::internal::call_traits::enable_if_return<ConsumeValue, Status>::type
-VisitGroupedValues(const ExecSpan& batch, ConsumeValue&& valid_func,
-                   ConsumeNull&& null_func) {
+  requires std::same_as<
+      Status, std::invoke_result_t<ConsumeValue, uint32_t, typename GetViewType<Type>::T>>
+Status VisitGroupedValues(const ExecSpan& batch, ConsumeValue&& valid_func,
+                          ConsumeNull&& null_func) {
   auto g = batch[1].array.GetValues<uint32_t>(1);
   if (batch[0].is_array()) {
     return VisitArrayValuesInline<Type>(

--- a/cpp/src/arrow/compute/kernels/hash_aggregate_numeric.cc
+++ b/cpp/src/arrow/compute/kernels/hash_aggregate_numeric.cc
@@ -155,14 +155,13 @@ struct GroupedReducingAggregator : public GroupedAggregator {
   std::shared_ptr<DataType> out_type() const override { return out_type_; }
 
   template <typename T = Type>
-  enable_if_t<!is_decimal_type<T>::value, Result<std::shared_ptr<DataType>>> GetOutType(
-      const std::shared_ptr<DataType>& in_type) {
+    requires(!arrow_decimal<T>)
+  Result<std::shared_ptr<DataType>> GetOutType(const std::shared_ptr<DataType>& in_type) {
     return TypeTraits<AccType>::type_singleton();
   }
 
-  template <typename T = Type>
-  enable_if_decimal<T, Result<std::shared_ptr<DataType>>> GetOutType(
-      const std::shared_ptr<DataType>& in_type) {
+  template <arrow_decimal T = Type>
+  Result<std::shared_ptr<DataType>> GetOutType(const std::shared_ptr<DataType>& in_type) {
     if (PromoteDecimal()) {
       return WidenDecimalToMaxPrecision(in_type);
     } else {
@@ -280,9 +279,8 @@ struct GroupedSumImpl : public GroupedReducingAggregator<Type, GroupedSumImpl<Ty
   // Default value for a group
   static CType NullValue(const DataType&) { return CType(0); }
 
-  template <typename T = Type>
-  static enable_if_number<T, CType> Reduce(const DataType&, const CType u,
-                                           const InputCType v) {
+  template <arrow_number T = Type>
+  static CType Reduce(const DataType&, const CType u, const InputCType v) {
     return static_cast<CType>(to_unsigned(u) + to_unsigned(static_cast<CType>(v)));
   }
 
@@ -320,9 +318,8 @@ struct GroupedProductImpl final
     return MultiplyTraits<AccType>::one(out_type);
   }
 
-  template <typename T = Type>
-  static enable_if_number<T, CType> Reduce(const DataType& out_type, const CType u,
-                                           const InputCType v) {
+  template <arrow_number T = Type>
+  static CType Reduce(const DataType& out_type, const CType u, const InputCType v) {
     return MultiplyTraits<AccType>::Multiply(out_type, u, static_cast<CType>(v));
   }
 
@@ -369,9 +366,8 @@ struct GroupedMeanImpl
 
   static CType NullValue(const DataType&) { return CType(0); }
 
-  template <typename T = Type>
-  static enable_if_number<T, CType> Reduce(const DataType&, const CType u,
-                                           const InputCType v) {
+  template <arrow_number T = Type>
+  static CType Reduce(const DataType&, const CType u, const InputCType v) {
     return static_cast<CType>(u) + static_cast<CType>(v);
   }
 
@@ -379,8 +375,8 @@ struct GroupedMeanImpl
     return static_cast<CType>(to_unsigned(u) + to_unsigned(v));
   }
 
-  template <typename T = Type>
-  static enable_if_decimal<T, Result<MeanType>> DoMean(CType reduced, int64_t count) {
+  template <arrow_decimal T = Type>
+  static Result<MeanType> DoMean(CType reduced, int64_t count) {
     static_assert(std::is_same<MeanType, CType>::value, "");
     CType quotient, remainder;
     ARROW_ASSIGN_OR_RAISE(std::tie(quotient, remainder), reduced.Divide(count));
@@ -397,8 +393,8 @@ struct GroupedMeanImpl
   }
 
   template <typename T = Type>
-  static enable_if_t<!is_decimal_type<T>::value, Result<MeanType>> DoMean(CType reduced,
-                                                                          int64_t count) {
+    requires(!arrow_decimal<T>)
+  static Result<MeanType> DoMean(CType reduced, int64_t count) {
     return static_cast<MeanType>(reduced) / count;
   }
 
@@ -868,14 +864,14 @@ using GroupedKurtosisImpl =
 template <template <typename Type> typename GroupedImpl>
 struct GroupedStatisticKernelFactory {
   // Supporting all number types except float16
-  template <typename T>
-  enable_if_number<T, Status> Visit(const T& type) {
+  template <arrow_number T>
+  Status Visit(const T& type) {
     out = MakeKernel(InputType(T::type_id), HashAggregateInit<GroupedImpl<T>>);
     return Status::OK();
   }
 
-  template <typename T>
-  enable_if_decimal<T, Status> Visit(const T& type) {
+  template <arrow_decimal T>
+  Status Visit(const T& type) {
     out = MakeKernel(InputType(T::type_id), HashAggregateInit<GroupedImpl<T>>);
     return Status::OK();
   }
@@ -1045,15 +1041,15 @@ struct GroupedTDigestImpl : public GroupedAggregator {
 };
 
 struct GroupedTDigestFactory {
-  template <typename T>
-  enable_if_number<T, Status> Visit(const T&) {
+  template <arrow_number T>
+  Status Visit(const T&) {
     kernel =
         MakeKernel(std::move(argument_type), HashAggregateInit<GroupedTDigestImpl<T>>);
     return Status::OK();
   }
 
-  template <typename T>
-  enable_if_decimal<T, Status> Visit(const T&) {
+  template <arrow_decimal T>
+  Status Visit(const T&) {
     kernel =
         MakeKernel(std::move(argument_type), HashAggregateInit<GroupedTDigestImpl<T>>);
     return Status::OK();

--- a/cpp/src/arrow/compute/kernels/ree_util_internal.h
+++ b/cpp/src/arrow/compute/kernels/ree_util_internal.h
@@ -40,13 +40,13 @@ namespace internal {
 namespace ree_util {
 
 template <typename ArrowType, bool in_has_validity_buffer,
-          bool out_has_validity_buffer = in_has_validity_buffer, typename Enable = void>
+          bool out_has_validity_buffer = in_has_validity_buffer>
 struct ReadWriteValue {};
 
 // Numeric and primitive C-compatible types
 template <typename ArrowType, bool in_has_validity_buffer, bool out_has_validity_buffer>
-class ReadWriteValue<ArrowType, in_has_validity_buffer, out_has_validity_buffer,
-                     enable_if_has_c_type<ArrowType>> {
+  requires arrow_has_c_type<ArrowType>
+class ReadWriteValue<ArrowType, in_has_validity_buffer, out_has_validity_buffer> {
  public:
   using ValueRepr = typename ArrowType::c_type;
 
@@ -141,8 +141,8 @@ class ReadWriteValue<ArrowType, in_has_validity_buffer, out_has_validity_buffer,
 
 // FixedSizeBinary, Decimal128
 template <typename ArrowType, bool in_has_validity_buffer, bool out_has_validity_buffer>
-class ReadWriteValue<ArrowType, in_has_validity_buffer, out_has_validity_buffer,
-                     enable_if_fixed_size_binary<ArrowType>> {
+  requires arrow_fixed_size_binary<ArrowType>
+class ReadWriteValue<ArrowType, in_has_validity_buffer, out_has_validity_buffer> {
  public:
   // Every value is represented as a pointer to byte_width_ bytes
   using ValueRepr = const uint8_t*;
@@ -224,8 +224,8 @@ class ReadWriteValue<ArrowType, in_has_validity_buffer, out_has_validity_buffer,
 
 // Binary, String...
 template <typename ArrowType, bool in_has_validity_buffer, bool out_has_validity_buffer>
-class ReadWriteValue<ArrowType, in_has_validity_buffer, out_has_validity_buffer,
-                     enable_if_base_binary<ArrowType>> {
+  requires arrow_base_binary<ArrowType>
+class ReadWriteValue<ArrowType, in_has_validity_buffer, out_has_validity_buffer> {
  public:
   using ValueRepr = std::string_view;
   using offset_type = typename ArrowType::offset_type;

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic.cc
@@ -105,8 +105,8 @@ struct ShiftLeft {
 // See SEI CERT C Coding Standard rule INT34-C
 struct ShiftLeftChecked {
   template <typename T, typename Arg0, typename Arg1>
-  static enable_if_unsigned_integer_value<T> Call(KernelContext*, Arg0 lhs, Arg1 rhs,
-                                                  Status* st) {
+    requires is_unsigned_integer_value<T>::value
+  static T Call(KernelContext*, Arg0 lhs, Arg1 rhs, Status* st) {
     static_assert(std::is_same<T, Arg0>::value, "");
     if (ARROW_PREDICT_FALSE(rhs < 0 || rhs >= std::numeric_limits<Arg0>::digits)) {
       *st = Status::Invalid("shift amount must be >= 0 and less than precision of type");
@@ -116,8 +116,8 @@ struct ShiftLeftChecked {
   }
 
   template <typename T, typename Arg0, typename Arg1>
-  static enable_if_signed_integer_value<T> Call(KernelContext*, Arg0 lhs, Arg1 rhs,
-                                                Status* st) {
+    requires is_signed_integer_value<T>::value
+  static T Call(KernelContext*, Arg0 lhs, Arg1 rhs, Status* st) {
     using Unsigned = typename std::make_unsigned<Arg0>::type;
     static_assert(std::is_same<T, Arg0>::value, "");
     if (ARROW_PREDICT_FALSE(rhs < 0 || rhs >= std::numeric_limits<Arg0>::digits)) {
@@ -162,7 +162,8 @@ struct ShiftRightChecked {
 
 struct Sin {
   template <typename T, typename Arg0>
-  static enable_if_floating_value<Arg0, T> Call(KernelContext*, Arg0 val, Status*) {
+    requires std::is_floating_point_v<Arg0>
+  static T Call(KernelContext*, Arg0 val, Status*) {
     static_assert(std::is_same<T, Arg0>::value, "");
     return std::sin(val);
   }
@@ -170,7 +171,8 @@ struct Sin {
 
 struct SinChecked {
   template <typename T, typename Arg0>
-  static enable_if_floating_value<Arg0, T> Call(KernelContext*, Arg0 val, Status* st) {
+    requires std::is_floating_point_v<Arg0>
+  static T Call(KernelContext*, Arg0 val, Status* st) {
     static_assert(std::is_same<T, Arg0>::value, "");
     if (ARROW_PREDICT_FALSE(std::isinf(val))) {
       *st = Status::Invalid("domain error");
@@ -182,7 +184,8 @@ struct SinChecked {
 
 struct Sinh {
   template <typename T, typename Arg0>
-  static enable_if_floating_value<Arg0, T> Call(KernelContext*, Arg0 val, Status*) {
+    requires std::is_floating_point_v<Arg0>
+  static T Call(KernelContext*, Arg0 val, Status*) {
     static_assert(std::is_same<T, Arg0>::value, "");
     return std::sinh(val);
   }
@@ -190,7 +193,8 @@ struct Sinh {
 
 struct Cos {
   template <typename T, typename Arg0>
-  static enable_if_floating_value<Arg0, T> Call(KernelContext*, Arg0 val, Status*) {
+    requires std::is_floating_point_v<Arg0>
+  static T Call(KernelContext*, Arg0 val, Status*) {
     static_assert(std::is_same<T, Arg0>::value, "");
     return std::cos(val);
   }
@@ -198,7 +202,8 @@ struct Cos {
 
 struct CosChecked {
   template <typename T, typename Arg0>
-  static enable_if_floating_value<Arg0, T> Call(KernelContext*, Arg0 val, Status* st) {
+    requires std::is_floating_point_v<Arg0>
+  static T Call(KernelContext*, Arg0 val, Status* st) {
     static_assert(std::is_same<T, Arg0>::value, "");
     if (ARROW_PREDICT_FALSE(std::isinf(val))) {
       *st = Status::Invalid("domain error");
@@ -210,7 +215,8 @@ struct CosChecked {
 
 struct Cosh {
   template <typename T, typename Arg0>
-  static enable_if_floating_value<Arg0, T> Call(KernelContext*, Arg0 val, Status*) {
+    requires std::is_floating_point_v<Arg0>
+  static T Call(KernelContext*, Arg0 val, Status*) {
     static_assert(std::is_same<T, Arg0>::value, "");
     return std::cosh(val);
   }
@@ -218,7 +224,8 @@ struct Cosh {
 
 struct Tan {
   template <typename T, typename Arg0>
-  static enable_if_floating_value<Arg0, T> Call(KernelContext*, Arg0 val, Status*) {
+    requires std::is_floating_point_v<Arg0>
+  static T Call(KernelContext*, Arg0 val, Status*) {
     static_assert(std::is_same<T, Arg0>::value, "");
     return std::tan(val);
   }
@@ -226,7 +233,8 @@ struct Tan {
 
 struct TanChecked {
   template <typename T, typename Arg0>
-  static enable_if_floating_value<Arg0, T> Call(KernelContext*, Arg0 val, Status* st) {
+    requires std::is_floating_point_v<Arg0>
+  static T Call(KernelContext*, Arg0 val, Status* st) {
     static_assert(std::is_same<T, Arg0>::value, "");
     if (ARROW_PREDICT_FALSE(std::isinf(val))) {
       *st = Status::Invalid("domain error");
@@ -239,7 +247,8 @@ struct TanChecked {
 
 struct Tanh {
   template <typename T, typename Arg0>
-  static enable_if_floating_value<Arg0, T> Call(KernelContext*, Arg0 val, Status*) {
+    requires std::is_floating_point_v<Arg0>
+  static T Call(KernelContext*, Arg0 val, Status*) {
     static_assert(std::is_same<T, Arg0>::value, "");
     return std::tanh(val);
   }
@@ -247,7 +256,8 @@ struct Tanh {
 
 struct Asin {
   template <typename T, typename Arg0>
-  static enable_if_floating_value<Arg0, T> Call(KernelContext*, Arg0 val, Status*) {
+    requires std::is_floating_point_v<Arg0>
+  static T Call(KernelContext*, Arg0 val, Status*) {
     static_assert(std::is_same<T, Arg0>::value, "");
     if (ARROW_PREDICT_FALSE(val < -1.0 || val > 1.0)) {
       return std::numeric_limits<T>::quiet_NaN();
@@ -258,7 +268,8 @@ struct Asin {
 
 struct AsinChecked {
   template <typename T, typename Arg0>
-  static enable_if_floating_value<Arg0, T> Call(KernelContext*, Arg0 val, Status* st) {
+    requires std::is_floating_point_v<Arg0>
+  static T Call(KernelContext*, Arg0 val, Status* st) {
     static_assert(std::is_same<T, Arg0>::value, "");
     if (ARROW_PREDICT_FALSE(val < -1.0 || val > 1.0)) {
       *st = Status::Invalid("domain error");
@@ -270,7 +281,8 @@ struct AsinChecked {
 
 struct Asinh {
   template <typename T, typename Arg0>
-  static enable_if_floating_value<Arg0, T> Call(KernelContext*, Arg0 val, Status*) {
+    requires std::is_floating_point_v<Arg0>
+  static T Call(KernelContext*, Arg0 val, Status*) {
     static_assert(std::is_same<T, Arg0>::value, "");
     return std::asinh(val);
   }
@@ -278,7 +290,8 @@ struct Asinh {
 
 struct Acos {
   template <typename T, typename Arg0>
-  static enable_if_floating_value<Arg0, T> Call(KernelContext*, Arg0 val, Status*) {
+    requires std::is_floating_point_v<Arg0>
+  static T Call(KernelContext*, Arg0 val, Status*) {
     static_assert(std::is_same<T, Arg0>::value, "");
     if (ARROW_PREDICT_FALSE((val < -1.0 || val > 1.0))) {
       return std::numeric_limits<T>::quiet_NaN();
@@ -289,7 +302,8 @@ struct Acos {
 
 struct AcosChecked {
   template <typename T, typename Arg0>
-  static enable_if_floating_value<Arg0, T> Call(KernelContext*, Arg0 val, Status* st) {
+    requires std::is_floating_point_v<Arg0>
+  static T Call(KernelContext*, Arg0 val, Status* st) {
     static_assert(std::is_same<T, Arg0>::value, "");
     if (ARROW_PREDICT_FALSE((val < -1.0 || val > 1.0))) {
       *st = Status::Invalid("domain error");
@@ -301,7 +315,8 @@ struct AcosChecked {
 
 struct Acosh {
   template <typename T, typename Arg0>
-  static enable_if_floating_value<Arg0, T> Call(KernelContext*, Arg0 val, Status*) {
+    requires std::is_floating_point_v<Arg0>
+  static T Call(KernelContext*, Arg0 val, Status*) {
     static_assert(std::is_same<T, Arg0>::value, "");
     if (ARROW_PREDICT_FALSE(val < 1.0)) {
       return std::numeric_limits<T>::quiet_NaN();
@@ -312,7 +327,8 @@ struct Acosh {
 
 struct AcoshChecked {
   template <typename T, typename Arg0>
-  static enable_if_floating_value<Arg0, T> Call(KernelContext*, Arg0 val, Status* st) {
+    requires std::is_floating_point_v<Arg0>
+  static T Call(KernelContext*, Arg0 val, Status* st) {
     static_assert(std::is_same<T, Arg0>::value, "");
     if (ARROW_PREDICT_FALSE(val < 1.0)) {
       *st = Status::Invalid("domain error");
@@ -324,7 +340,8 @@ struct AcoshChecked {
 
 struct Atan {
   template <typename T, typename Arg0>
-  static enable_if_floating_value<Arg0, T> Call(KernelContext*, Arg0 val, Status*) {
+    requires std::is_floating_point_v<Arg0>
+  static T Call(KernelContext*, Arg0 val, Status*) {
     static_assert(std::is_same<T, Arg0>::value, "");
     return std::atan(val);
   }
@@ -332,7 +349,8 @@ struct Atan {
 
 struct Atanh {
   template <typename T, typename Arg0>
-  static enable_if_floating_value<Arg0, T> Call(KernelContext*, Arg0 val, Status*) {
+    requires std::is_floating_point_v<Arg0>
+  static T Call(KernelContext*, Arg0 val, Status*) {
     static_assert(std::is_same<T, Arg0>::value, "");
     if (ARROW_PREDICT_FALSE((val < -1.0 || val > 1.0))) {
       // N.B. This predicate does *not* match the predicate in AtanhChecked. In
@@ -346,7 +364,8 @@ struct Atanh {
 
 struct AtanhChecked {
   template <typename T, typename Arg0>
-  static enable_if_floating_value<Arg0, T> Call(KernelContext*, Arg0 val, Status* st) {
+    requires std::is_floating_point_v<Arg0>
+  static T Call(KernelContext*, Arg0 val, Status* st) {
     static_assert(std::is_same<T, Arg0>::value, "");
     if (ARROW_PREDICT_FALSE((val <= -1.0 || val >= 1.0))) {
       // N.B. This predicate does *not* match the predicate in Atanh. In GH-44630 it was
@@ -361,7 +380,8 @@ struct AtanhChecked {
 
 struct Atan2 {
   template <typename T, typename Arg0, typename Arg1>
-  static enable_if_floating_value<Arg0, T> Call(KernelContext*, Arg0 y, Arg1 x, Status*) {
+    requires std::is_floating_point_v<Arg0>
+  static T Call(KernelContext*, Arg0 y, Arg1 x, Status*) {
     static_assert(std::is_same<T, Arg0>::value, "");
     static_assert(std::is_same<Arg0, Arg1>::value, "");
     return std::atan2(y, x);
@@ -370,7 +390,8 @@ struct Atan2 {
 
 struct LogNatural {
   template <typename T, typename Arg>
-  static enable_if_floating_value<Arg, T> Call(KernelContext*, Arg arg, Status*) {
+    requires std::is_floating_point_v<Arg>
+  static T Call(KernelContext*, Arg arg, Status*) {
     static_assert(std::is_same<T, Arg>::value, "");
     if (arg == 0.0) {
       return -std::numeric_limits<T>::infinity();
@@ -383,7 +404,8 @@ struct LogNatural {
 
 struct LogNaturalChecked {
   template <typename T, typename Arg>
-  static enable_if_floating_value<Arg, T> Call(KernelContext*, Arg arg, Status* st) {
+    requires std::is_floating_point_v<Arg>
+  static T Call(KernelContext*, Arg arg, Status* st) {
     static_assert(std::is_same<T, Arg>::value, "");
     if (arg == 0.0) {
       *st = Status::Invalid("logarithm of zero");
@@ -398,7 +420,8 @@ struct LogNaturalChecked {
 
 struct Log10 {
   template <typename T, typename Arg>
-  static enable_if_floating_value<Arg, T> Call(KernelContext*, Arg arg, Status*) {
+    requires std::is_floating_point_v<Arg>
+  static T Call(KernelContext*, Arg arg, Status*) {
     static_assert(std::is_same<T, Arg>::value, "");
     if (arg == 0.0) {
       return -std::numeric_limits<T>::infinity();
@@ -411,7 +434,8 @@ struct Log10 {
 
 struct Log10Checked {
   template <typename T, typename Arg>
-  static enable_if_floating_value<Arg, T> Call(KernelContext*, Arg arg, Status* st) {
+    requires std::is_floating_point_v<Arg>
+  static T Call(KernelContext*, Arg arg, Status* st) {
     static_assert(std::is_same<T, Arg>::value, "");
     if (arg == 0) {
       *st = Status::Invalid("logarithm of zero");
@@ -426,7 +450,8 @@ struct Log10Checked {
 
 struct Log2 {
   template <typename T, typename Arg>
-  static enable_if_floating_value<Arg, T> Call(KernelContext*, Arg arg, Status*) {
+    requires std::is_floating_point_v<Arg>
+  static T Call(KernelContext*, Arg arg, Status*) {
     static_assert(std::is_same<T, Arg>::value, "");
     if (arg == 0.0) {
       return -std::numeric_limits<T>::infinity();
@@ -439,7 +464,8 @@ struct Log2 {
 
 struct Log2Checked {
   template <typename T, typename Arg>
-  static enable_if_floating_value<Arg, T> Call(KernelContext*, Arg arg, Status* st) {
+    requires std::is_floating_point_v<Arg>
+  static T Call(KernelContext*, Arg arg, Status* st) {
     static_assert(std::is_same<T, Arg>::value, "");
     if (arg == 0.0) {
       *st = Status::Invalid("logarithm of zero");
@@ -454,7 +480,8 @@ struct Log2Checked {
 
 struct Log1p {
   template <typename T, typename Arg>
-  static enable_if_floating_value<Arg, T> Call(KernelContext*, Arg arg, Status*) {
+    requires std::is_floating_point_v<Arg>
+  static T Call(KernelContext*, Arg arg, Status*) {
     static_assert(std::is_same<T, Arg>::value, "");
     if (arg == -1) {
       return -std::numeric_limits<T>::infinity();
@@ -467,7 +494,8 @@ struct Log1p {
 
 struct Log1pChecked {
   template <typename T, typename Arg>
-  static enable_if_floating_value<Arg, T> Call(KernelContext*, Arg arg, Status* st) {
+    requires std::is_floating_point_v<Arg>
+  static T Call(KernelContext*, Arg arg, Status* st) {
     static_assert(std::is_same<T, Arg>::value, "");
     if (arg == -1) {
       *st = Status::Invalid("logarithm of zero");
@@ -482,7 +510,8 @@ struct Log1pChecked {
 
 struct Logb {
   template <typename T, typename Arg0, typename Arg1>
-  static enable_if_floating_value<T> Call(KernelContext*, Arg0 x, Arg1 base, Status*) {
+    requires std::is_floating_point_v<T>
+  static T Call(KernelContext*, Arg0 x, Arg1 base, Status*) {
     static_assert(std::is_same<T, Arg0>::value, "");
     static_assert(std::is_same<Arg0, Arg1>::value, "");
     if (x == 0.0) {
@@ -500,7 +529,8 @@ struct Logb {
 
 struct LogbChecked {
   template <typename T, typename Arg0, typename Arg1>
-  static enable_if_floating_value<T> Call(KernelContext*, Arg0 x, Arg1 base, Status* st) {
+    requires std::is_floating_point_v<T>
+  static T Call(KernelContext*, Arg0 x, Arg1 base, Status* st) {
     static_assert(std::is_same<T, Arg0>::value, "");
     static_assert(std::is_same<Arg0, Arg1>::value, "");
     if (x == 0.0 || base == 0.0) {

--- a/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_arithmetic_test.cc
@@ -120,9 +120,8 @@ class TestBaseArithmetic : public ::testing::Test {
     GTEST_SKIP() << "Unsupported on half-float"; \
   }
 
-template <typename T, typename R = void>
-using enable_if_numeric_value =
-    std::enable_if_t<std::is_arithmetic_v<T> || std::is_same_v<T, Float16>, R>;
+template <typename T>
+concept numeric_value = std::is_arithmetic_v<T> || std::same_as<T, Float16>;
 
 template <typename T, typename OptionsType>
 class TestBaseUnaryArithmetic : public TestBaseArithmetic<T> {
@@ -134,8 +133,8 @@ class TestBaseUnaryArithmetic : public TestBaseArithmetic<T> {
       std::function<Result<Datum>(const Datum&, OptionsType, ExecContext*)>;
 
   // (CScalar, CScalar)
-  template <typename V>
-  enable_if_numeric_value<V> AssertUnaryOp(UnaryFunction func, V argument, V expected) {
+  template <numeric_value V>
+  void AssertUnaryOp(UnaryFunction func, V argument, V expected) {
     auto arg = this->MakeScalar(argument);
     auto exp = this->MakeScalar(expected);
     ASSERT_OK_AND_ASSIGN(auto actual, func(arg, options_, nullptr));
@@ -188,9 +187,9 @@ class TestBaseUnaryArithmetic : public TestBaseArithmetic<T> {
   }
 
   // (CScalar, CScalar)
-  template <typename V>
-  enable_if_numeric_value<V> AssertUnaryOpRaises(UnaryFunction func, V argument,
-                                                 const std::string& expected_msg) {
+  template <numeric_value V>
+  void AssertUnaryOpRaises(UnaryFunction func, V argument,
+                           const std::string& expected_msg) {
     auto arg = this->MakeScalar(argument);
     EXPECT_RAISES_WITH_MESSAGE_THAT(Invalid, ::testing::HasSubstr(expected_msg),
                                     func(arg, options_, nullptr));
@@ -304,8 +303,8 @@ class TestBinaryArithmetic : public TestBaseArithmetic<T> {
   void SetUp() override { options_.check_overflow = false; }
 
   // (Scalar, Scalar)
-  template <typename V>
-  enable_if_numeric_value<V> AssertBinop(BinaryFunction func, V lhs, V rhs, V expected) {
+  template <numeric_value V>
+  void AssertBinop(BinaryFunction func, V lhs, V rhs, V expected) {
     auto left = this->MakeScalar(lhs);
     auto right = this->MakeScalar(rhs);
     auto exp = this->MakeScalar(expected);
@@ -315,10 +314,9 @@ class TestBinaryArithmetic : public TestBaseArithmetic<T> {
   }
 
   // (Scalar, Array)
-  template <typename V>
-  enable_if_numeric_value<V> AssertBinop(BinaryFunction func, V lhs,
-                                         const std::string& rhs,
-                                         const std::string& expected) {
+  template <numeric_value V>
+  void AssertBinop(BinaryFunction func, V lhs, const std::string& rhs,
+                   const std::string& expected) {
     auto left = this->MakeScalar(lhs);
     AssertBinop(func, left, rhs, expected);
   }
@@ -334,9 +332,9 @@ class TestBinaryArithmetic : public TestBaseArithmetic<T> {
   }
 
   // (Array, Scalar)
-  template <typename V>
-  enable_if_numeric_value<V> AssertBinop(BinaryFunction func, const std::string& lhs,
-                                         V rhs, const std::string& expected) {
+  template <numeric_value V>
+  void AssertBinop(BinaryFunction func, const std::string& lhs, V rhs,
+                   const std::string& expected) {
     auto right = this->MakeScalar(rhs);
     AssertBinop(func, lhs, right, expected);
   }

--- a/cpp/src/arrow/compute/kernels/scalar_cast_internal.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_internal.cc
@@ -37,7 +37,7 @@ namespace internal {
 
 namespace {
 
-template <typename OutType, typename InType, typename Enable = void>
+template <typename OutType, typename InType>
 struct CastPrimitive {
   ARROW_DISABLE_UBSAN("float-cast-overflow")
   static void Exec(const ArraySpan& arr, ArraySpan* out) {
@@ -53,7 +53,8 @@ struct CastPrimitive {
 
 // Converting floating types to half float.
 template <typename InType>
-struct CastPrimitive<HalfFloatType, InType, enable_if_physical_floating_point<InType>> {
+  requires arrow_physical_floating_point<InType>
+struct CastPrimitive<HalfFloatType, InType> {
   static void Exec(const ArraySpan& arr, ArraySpan* out) {
     using InT = typename InType::c_type;
     const InT* in_values = arr.GetValues<InT>(1);
@@ -66,7 +67,7 @@ struct CastPrimitive<HalfFloatType, InType, enable_if_physical_floating_point<In
 
 // Converting from half float to other floating types.
 template <>
-struct CastPrimitive<FloatType, HalfFloatType, enable_if_t<true>> {
+struct CastPrimitive<FloatType, HalfFloatType> {
   static void Exec(const ArraySpan& arr, ArraySpan* out) {
     const uint16_t* in_values = arr.GetValues<uint16_t>(1);
     float* out_values = out->GetValues<float>(1);
@@ -77,7 +78,7 @@ struct CastPrimitive<FloatType, HalfFloatType, enable_if_t<true>> {
 };
 
 template <>
-struct CastPrimitive<DoubleType, HalfFloatType, enable_if_t<true>> {
+struct CastPrimitive<DoubleType, HalfFloatType> {
   static void Exec(const ArraySpan& arr, ArraySpan* out) {
     const uint16_t* in_values = arr.GetValues<uint16_t>(1);
     double* out_values = out->GetValues<double>(1);
@@ -87,18 +88,19 @@ struct CastPrimitive<DoubleType, HalfFloatType, enable_if_t<true>> {
   }
 };
 
-template <typename OutType, typename InType>
-struct CastPrimitive<OutType, InType, enable_if_t<std::is_same<OutType, InType>::value>> {
+template <typename Type>
+struct CastPrimitive<Type, Type> {
   // memcpy output
   static void Exec(const ArraySpan& arr, ArraySpan* out) {
-    using T = typename InType::c_type;
+    using T = typename Type::c_type;
     std::memcpy(out->GetValues<T>(1), arr.GetValues<T>(1), arr.length * sizeof(T));
   }
 };
 
 // Cast int to half float
 template <typename InType>
-struct CastPrimitive<HalfFloatType, InType, enable_if_integer<InType>> {
+  requires arrow_integer<InType>
+struct CastPrimitive<HalfFloatType, InType> {
   static void Exec(const ArraySpan& arr, ArraySpan* out) {
     using InT = typename InType::c_type;
     const InT* in_values = arr.GetValues<InT>(1);
@@ -112,7 +114,8 @@ struct CastPrimitive<HalfFloatType, InType, enable_if_integer<InType>> {
 
 // Cast half float to int
 template <typename OutType>
-struct CastPrimitive<OutType, HalfFloatType, enable_if_integer<OutType>> {
+  requires arrow_integer<OutType>
+struct CastPrimitive<OutType, HalfFloatType> {
   static void Exec(const ArraySpan& arr, ArraySpan* out) {
     using OutT = typename OutType::c_type;
     const uint16_t* in_values = arr.GetValues<uint16_t>(1);

--- a/cpp/src/arrow/compute/kernels/scalar_cast_internal.h
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_internal.h
@@ -30,13 +30,13 @@ using internal::checked_cast;
 namespace compute {
 namespace internal {
 
-template <typename OutType, typename InType, typename Enable = void>
+template <typename OutType, typename InType>
 struct CastFunctor {};
 
 // No-op functor for identity casts
 template <typename O, typename I>
-struct CastFunctor<
-    O, I, enable_if_t<std::is_same<O, I>::value && is_parameter_free_type<I>::value>> {
+  requires(std::is_same_v<O, I> && arrow_parameter_free<I>)
+struct CastFunctor<O, I> {
   static Status Exec(KernelContext*, const ExecSpan&, ExecResult*) {
     return Status::OK();
   }

--- a/cpp/src/arrow/compute/kernels/scalar_cast_numeric.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_numeric.cc
@@ -293,7 +293,8 @@ struct BooleanToNumber {
 };
 
 template <typename O>
-struct CastFunctor<O, BooleanType, enable_if_number<O>> {
+  requires arrow_number<O>
+struct CastFunctor<O, BooleanType> {
   static Status Exec(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
     return applicator::ScalarUnary<O, BooleanType, BooleanToNumber>::Exec(ctx, batch,
                                                                           out);
@@ -317,17 +318,15 @@ struct ParseString {
 };
 
 template <typename O, typename I>
-struct CastFunctor<
-    O, I,
-    enable_if_t<(is_number_type<O>::value && (is_base_binary_type<I>::value ||
-                                              is_binary_view_like_type<I>::value))>> {
+  requires(arrow_number<O> && (arrow_base_binary<I> || arrow_binary_view_like<I>))
+struct CastFunctor<O, I> {
   static Status Exec(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
     return applicator::ScalarUnaryNotNull<O, I, ParseString<O>>::Exec(ctx, batch, out);
   }
 };
 
 template <>
-struct CastFunctor<HalfFloatType, StringType, enable_if_t<true>> {
+struct CastFunctor<HalfFloatType, StringType> {
   static Status Exec(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
     return applicator::ScalarUnaryNotNull<HalfFloatType, StringType,
                                           ParseString<HalfFloatType>>::Exec(ctx, batch,
@@ -393,8 +392,8 @@ struct SafeRescaleDecimalToInteger : public DecimalToIntegerMixin {
 };
 
 template <typename O, typename I>
-struct CastFunctor<O, I,
-                   enable_if_t<is_integer_type<O>::value && is_decimal_type<I>::value>> {
+  requires(arrow_integer<O> && arrow_decimal<I>)
+struct CastFunctor<O, I> {
   using out_type = typename O::c_type;
 
   static Status Exec(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
@@ -442,8 +441,8 @@ struct IntegerToDecimal {
 };
 
 template <typename O, typename I>
-struct CastFunctor<O, I,
-                   enable_if_t<is_decimal_type<O>::value && is_integer_type<I>::value>> {
+  requires(arrow_decimal<O> && arrow_integer<I>)
+struct CastFunctor<O, I> {
   static Status Exec(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
     const auto& out_type = checked_cast<const O&>(*out->type());
     const auto out_scale = out_type.scale();
@@ -593,8 +592,8 @@ struct SafeRescaleDecimal {
 };
 
 template <typename O, typename I>
-struct CastFunctor<O, I,
-                   enable_if_t<is_decimal_type<O>::value && is_decimal_type<I>::value>> {
+  requires(arrow_decimal<O> && arrow_decimal<I>)
+struct CastFunctor<O, I> {
   static Status Exec(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
     const auto& options = checked_cast<const CastState*>(ctx->state())->options;
 
@@ -647,8 +646,8 @@ struct RealToDecimal {
 };
 
 template <typename O, typename I>
-struct CastFunctor<O, I,
-                   enable_if_t<is_decimal_type<O>::value && is_floating_type<I>::value>> {
+  requires(arrow_decimal<O> && arrow_floating_point<I>)
+struct CastFunctor<O, I> {
   static Status Exec(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
     const auto& options = checked_cast<const CastState*>(ctx->state())->options;
     const auto& out_type = checked_cast<const O&>(*out->type());
@@ -716,28 +715,20 @@ struct DecimalCastFunctor {
 };
 
 template <typename I>
-struct CastFunctor<
-    Decimal32Type, I,
-    enable_if_t<is_base_binary_type<I>::value || is_binary_view_like_type<I>::value>>
-    : public DecimalCastFunctor<Decimal32Type, I> {};
+  requires(arrow_base_binary<I> || arrow_binary_view_like<I>)
+struct CastFunctor<Decimal32Type, I> : public DecimalCastFunctor<Decimal32Type, I> {};
 
 template <typename I>
-struct CastFunctor<
-    Decimal64Type, I,
-    enable_if_t<is_base_binary_type<I>::value || is_binary_view_like_type<I>::value>>
-    : public DecimalCastFunctor<Decimal64Type, I> {};
+  requires(arrow_base_binary<I> || arrow_binary_view_like<I>)
+struct CastFunctor<Decimal64Type, I> : public DecimalCastFunctor<Decimal64Type, I> {};
 
 template <typename I>
-struct CastFunctor<
-    Decimal128Type, I,
-    enable_if_t<is_base_binary_type<I>::value || is_binary_view_like_type<I>::value>>
-    : public DecimalCastFunctor<Decimal128Type, I> {};
+  requires(arrow_base_binary<I> || arrow_binary_view_like<I>)
+struct CastFunctor<Decimal128Type, I> : public DecimalCastFunctor<Decimal128Type, I> {};
 
 template <typename I>
-struct CastFunctor<
-    Decimal256Type, I,
-    enable_if_t<is_base_binary_type<I>::value || is_binary_view_like_type<I>::value>>
-    : public DecimalCastFunctor<Decimal256Type, I> {};
+  requires(arrow_base_binary<I> || arrow_binary_view_like<I>)
+struct CastFunctor<Decimal256Type, I> : public DecimalCastFunctor<Decimal256Type, I> {};
 
 // ----------------------------------------------------------------------
 // Decimal to real
@@ -752,8 +743,8 @@ struct DecimalToReal {
 };
 
 template <typename O, typename I>
-struct CastFunctor<O, I,
-                   enable_if_t<is_floating_type<O>::value && is_decimal_type<I>::value>> {
+  requires(arrow_floating_point<O> && arrow_decimal<I>)
+struct CastFunctor<O, I> {
   static Status Exec(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
     const auto& in_type = checked_cast<const I&>(*batch[0].type());
     const auto in_scale = in_type.scale();

--- a/cpp/src/arrow/compute/kernels/scalar_cast_string.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_string.cc
@@ -292,8 +292,9 @@ Status CastBinaryToBinaryOffsets<int64_t, int32_t>(KernelContext* ctx,
 
 // Offset String -> Offset String
 template <typename O, typename I>
-enable_if_t<is_base_binary_type<I>::value && is_base_binary_type<O>::value, Status>
-BinaryToBinaryCastExec(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
+  requires(arrow_base_binary<I> && arrow_base_binary<O>)
+Status BinaryToBinaryCastExec(KernelContext* ctx, const ExecSpan& batch,
+                              ExecResult* out) {
   const CastOptions& options = checked_cast<const CastState&>(*ctx->state()).options;
   const ArraySpan& input = batch[0].array;
 
@@ -338,8 +339,9 @@ BinaryToBinaryCastExec(KernelContext* ctx, const ExecSpan& batch, ExecResult* ou
 
 // String View -> Offset String
 template <typename O, typename I>
-enable_if_t<is_binary_view_like_type<I>::value && is_base_binary_type<O>::value, Status>
-BinaryToBinaryCastExec(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
+  requires(arrow_binary_view_like<I> && arrow_base_binary<O>)
+Status BinaryToBinaryCastExec(KernelContext* ctx, const ExecSpan& batch,
+                              ExecResult* out) {
   using offset_type = typename O::offset_type;
   using DataBuilder = TypedBufferBuilder<uint8_t>;
   using OffsetBuilder = TypedBufferBuilder<offset_type>;
@@ -390,8 +392,9 @@ BinaryToBinaryCastExec(KernelContext* ctx, const ExecSpan& batch, ExecResult* ou
 
 // Offset String -> String View
 template <typename O, typename I>
-enable_if_t<is_base_binary_type<I>::value && is_binary_view_like_type<O>::value, Status>
-BinaryToBinaryCastExec(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
+  requires(arrow_base_binary<I> && arrow_binary_view_like<O>)
+Status BinaryToBinaryCastExec(KernelContext* ctx, const ExecSpan& batch,
+                              ExecResult* out) {
   using offset_type = typename I::offset_type;
   const CastOptions& options = checked_cast<const CastState&>(*ctx->state()).options;
   const ArraySpan& input = batch[0].array;
@@ -470,9 +473,9 @@ BinaryToBinaryCastExec(KernelContext* ctx, const ExecSpan& batch, ExecResult* ou
 
 // String View -> String View
 template <typename O, typename I>
-enable_if_t<is_binary_view_like_type<I>::value && is_binary_view_like_type<O>::value,
-            Status>
-BinaryToBinaryCastExec(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
+  requires(arrow_binary_view_like<I> && arrow_binary_view_like<O>)
+Status BinaryToBinaryCastExec(KernelContext* ctx, const ExecSpan& batch,
+                              ExecResult* out) {
   const CastOptions& options = checked_cast<const CastState&>(*ctx->state()).options;
   const ArraySpan& input = batch[0].array;
 
@@ -490,10 +493,9 @@ BinaryToBinaryCastExec(KernelContext* ctx, const ExecSpan& batch, ExecResult* ou
 
 // Fixed -> String View
 template <typename O, typename I>
-enable_if_t<std::is_same<I, FixedSizeBinaryType>::value &&
-                is_binary_view_like_type<O>::value,
-            Status>
-BinaryToBinaryCastExec(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
+  requires(arrow_fixed_size_binary<I> && arrow_binary_view_like<O>)
+Status BinaryToBinaryCastExec(KernelContext* ctx, const ExecSpan& batch,
+                              ExecResult* out) {
   const CastOptions& options = checked_cast<const CastState&>(*ctx->state()).options;
   const ArraySpan& input = batch[0].array;
 
@@ -567,9 +569,9 @@ BinaryToBinaryCastExec(KernelContext* ctx, const ExecSpan& batch, ExecResult* ou
 
 // Fixed -> Offset String
 template <typename O, typename I>
-enable_if_t<std::is_same<I, FixedSizeBinaryType>::value && is_base_binary_type<O>::value,
-            Status>
-BinaryToBinaryCastExec(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
+  requires(arrow_fixed_size_binary<I> && arrow_base_binary<O>)
+Status BinaryToBinaryCastExec(KernelContext* ctx, const ExecSpan& batch,
+                              ExecResult* out) {
   const CastOptions& options = checked_cast<const CastState&>(*ctx->state()).options;
   const ArraySpan& input = batch[0].array;
 
@@ -642,10 +644,9 @@ BinaryToBinaryCastExec(KernelContext* ctx, const ExecSpan& batch, ExecResult* ou
 
 // Fixed -> Fixed
 template <typename O, typename I>
-enable_if_t<std::is_same<I, FixedSizeBinaryType>::value &&
-                std::is_same<O, FixedSizeBinaryType>::value,
-            Status>
-BinaryToBinaryCastExec(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
+  requires(arrow_fixed_size_binary<I> && arrow_fixed_size_binary<O>)
+Status BinaryToBinaryCastExec(KernelContext* ctx, const ExecSpan& batch,
+                              ExecResult* out) {
   const CastOptions& options = checked_cast<const CastState&>(*ctx->state()).options;
   const int32_t in_width = batch[0].type()->byte_width();
   const int32_t out_width =
@@ -659,10 +660,10 @@ BinaryToBinaryCastExec(KernelContext* ctx, const ExecSpan& batch, ExecResult* ou
 
 // Offset String | String View -> Fixed
 template <typename O, typename I>
-enable_if_t<(is_base_binary_type<I>::value || is_binary_view_like_type<I>::value) &&
-                std::is_same<O, FixedSizeBinaryType>::value,
-            Status>
-BinaryToBinaryCastExec(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
+  requires((arrow_base_binary<I> || arrow_binary_view_like<I>) &&
+           arrow_fixed_size_binary<O>)
+Status BinaryToBinaryCastExec(KernelContext* ctx, const ExecSpan& batch,
+                              ExecResult* out) {
   const CastOptions& options = checked_cast<const CastState&>(*ctx->state()).options;
   FixedSizeBinaryBuilder builder(options.to_type.GetSharedPtr(), ctx->memory_pool());
   const ArraySpan& input = batch[0].array;

--- a/cpp/src/arrow/compute/kernels/scalar_cast_temporal.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_temporal.cc
@@ -148,10 +148,9 @@ Status ExtractTemporal(KernelContext* ctx, const ExecSpan& batch, ExecResult* ou
 
 // <TimestampType, TimestampType> and <DurationType, DurationType>
 template <typename O, typename I>
-struct CastFunctor<
-    O, I,
-    enable_if_t<(is_timestamp_type<O>::value && is_timestamp_type<I>::value) ||
-                (is_duration_type<O>::value && is_duration_type<I>::value)>> {
+  requires((arrow_timestamp<O> && arrow_timestamp<I>) ||
+           (arrow_duration<O> && arrow_duration<I>))
+struct CastFunctor<O, I> {
   static Status Exec(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
     const auto& in_type = checked_cast<const I&>(*batch[0].type());
     const auto& out_type = checked_cast<const O&>(*out->type());
@@ -346,7 +345,8 @@ struct CastFunctor<Time64Type, TimestampType> {
 // From one time32 or time64 to another
 
 template <typename O, typename I>
-struct CastFunctor<O, I, enable_if_t<is_time_type<I>::value && is_time_type<O>::value>> {
+  requires(arrow_time<I> && arrow_time<O>)
+struct CastFunctor<O, I> {
   using in_t = typename I::c_type;
   using out_t = typename O::c_type;
 
@@ -448,7 +448,8 @@ struct ParseTimestamp {
 };
 
 template <typename I>
-struct CastFunctor<TimestampType, I, enable_if_t<is_base_binary_type<I>::value>> {
+  requires arrow_base_binary<I>
+struct CastFunctor<TimestampType, I> {
   static Status Exec(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
     const auto& out_type = checked_cast<const TimestampType&>(*out->type());
     applicator::ScalarUnaryNotNullStateful<TimestampType, I, ParseTimestamp> kernel(
@@ -488,8 +489,8 @@ struct ParseDate {
 };
 
 template <typename O, typename I>
-struct CastFunctor<O, I,
-                   enable_if_t<(is_date_type<O>::value && is_string_type<I>::value)>> {
+  requires(arrow_date<O> && arrow_string<I>)
+struct CastFunctor<O, I> {
   static Status Exec(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
     return applicator::ScalarUnaryNotNull<O, I, ParseDate<O>>::Exec(ctx, batch, out);
   }

--- a/cpp/src/arrow/compute/kernels/scalar_compare.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_compare.cc
@@ -39,6 +39,11 @@ namespace internal {
 
 namespace {
 
+template <typename T>
+concept decimal_compare_value =
+    std::same_as<T, Decimal32> || std::same_as<T, Decimal64> ||
+    std::same_as<T, Decimal128> || std::same_as<T, Decimal256>;
+
 struct Equal {
   template <typename T, typename Arg0, typename Arg1>
   static constexpr T Call(KernelContext*, const Arg0& left, const Arg1& right, Status*) {
@@ -73,19 +78,22 @@ struct GreaterEqual {
 
 struct Minimum {
   template <typename T, typename Arg0, typename Arg1>
-  static enable_if_floating_value<T> Call(Arg0 left, Arg1 right) {
+    requires std::is_floating_point_v<T>
+  static T Call(Arg0 left, Arg1 right) {
     static_assert(std::is_same<T, Arg0>::value && std::is_same<Arg0, Arg1>::value, "");
     return std::fmin(left, right);
   }
 
   template <typename T, typename Arg0, typename Arg1>
-  static enable_if_integer_value<T> Call(Arg0 left, Arg1 right) {
+    requires is_integer_value<T>::value
+  static T Call(Arg0 left, Arg1 right) {
     static_assert(std::is_same<T, Arg0>::value && std::is_same<Arg0, Arg1>::value, "");
     return std::min(left, right);
   }
 
   template <typename T, typename Arg0, typename Arg1>
-  static enable_if_decimal_value<T> Call(Arg0 left, Arg1 right) {
+    requires decimal_compare_value<T>
+  static T Call(Arg0 left, Arg1 right) {
     static_assert(std::is_same<T, Arg0>::value && std::is_same<Arg0, Arg1>::value, "");
     return std::min(left, right);
   }
@@ -95,41 +103,48 @@ struct Minimum {
   }
 
   template <typename T>
-  static constexpr enable_if_t<std::is_same<float, T>::value, T> antiextreme() {
+    requires std::is_same_v<float, T>
+  static constexpr T antiextreme() {
     return std::nanf("");
   }
 
   template <typename T>
-  static constexpr enable_if_t<std::is_same<double, T>::value, T> antiextreme() {
+    requires std::is_same_v<double, T>
+  static constexpr T antiextreme() {
     return std::nan("");
   }
 
   template <typename T>
-  static constexpr enable_if_integer_value<T> antiextreme() {
+    requires is_integer_value<T>::value
+  static constexpr T antiextreme() {
     return std::numeric_limits<T>::max();
   }
 
   template <typename T>
-  static constexpr enable_if_decimal_value<T> antiextreme() {
+    requires decimal_compare_value<T>
+  static constexpr T antiextreme() {
     return T::GetMaxSentinel();
   }
 };
 
 struct Maximum {
   template <typename T, typename Arg0, typename Arg1>
-  static enable_if_floating_value<T> Call(Arg0 left, Arg1 right) {
+    requires std::is_floating_point_v<T>
+  static T Call(Arg0 left, Arg1 right) {
     static_assert(std::is_same<T, Arg0>::value && std::is_same<Arg0, Arg1>::value, "");
     return std::fmax(left, right);
   }
 
   template <typename T, typename Arg0, typename Arg1>
-  static enable_if_integer_value<T> Call(Arg0 left, Arg1 right) {
+    requires is_integer_value<T>::value
+  static T Call(Arg0 left, Arg1 right) {
     static_assert(std::is_same<T, Arg0>::value && std::is_same<Arg0, Arg1>::value, "");
     return std::max(left, right);
   }
 
   template <typename T, typename Arg0, typename Arg1>
-  static enable_if_decimal_value<T> Call(Arg0 left, Arg1 right) {
+    requires decimal_compare_value<T>
+  static T Call(Arg0 left, Arg1 right) {
     static_assert(std::is_same<T, Arg0>::value && std::is_same<Arg0, Arg1>::value, "");
     return std::max(left, right);
   }
@@ -139,22 +154,26 @@ struct Maximum {
   }
 
   template <typename T>
-  static constexpr enable_if_t<std::is_same<float, T>::value, T> antiextreme() {
+    requires std::is_same_v<float, T>
+  static constexpr T antiextreme() {
     return std::nanf("");
   }
 
   template <typename T>
-  static constexpr enable_if_t<std::is_same<double, T>::value, T> antiextreme() {
+    requires std::is_same_v<double, T>
+  static constexpr T antiextreme() {
     return std::nan("");
   }
 
   template <typename T>
-  static constexpr enable_if_integer_value<T> antiextreme() {
+    requires is_integer_value<T>::value
+  static constexpr T antiextreme() {
     return std::numeric_limits<T>::min();
   }
 
   template <typename T>
-  static constexpr enable_if_decimal_value<T> antiextreme() {
+    requires decimal_compare_value<T>
+  static constexpr T antiextreme() {
     return T::GetMinSentinel();
   }
 };

--- a/cpp/src/arrow/compute/kernels/scalar_if_else.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else.cc
@@ -419,16 +419,15 @@ Status RunIfElseScalar(const BooleanScalar& cond, const ExecValue& left,
   }
 }
 
-template <typename Type, typename Enable = void>
+template <typename Type>
 struct IfElseFunctor {};
 
 // only number types needs to be handled for Fixed sized primitive data types because,
 // internal::GenerateTypeAgnosticPrimitive forwards types to the corresponding unsigned
 // int type
 template <typename Type>
-struct IfElseFunctor<Type,
-                     enable_if_t<is_number_type<Type>::value ||
-                                 std::is_same<Type, MonthDayNanoIntervalType>::value>> {
+  requires(is_number_type<Type>::value || std::is_same_v<Type, MonthDayNanoIntervalType>)
+struct IfElseFunctor<Type> {
   using T = typename TypeTraits<Type>::CType;
   // A - Array, S - Scalar, X = Array/Scalar
 
@@ -535,7 +534,8 @@ struct IfElseFunctor<Type,
 };
 
 template <typename Type>
-struct IfElseFunctor<Type, enable_if_boolean<Type>> {
+  requires arrow_boolean<Type>
+struct IfElseFunctor<Type> {
   // A - Array, S - Scalar, X = Array/Scalar
 
   // SXX
@@ -684,7 +684,8 @@ static Status IfElseGenericSXXCall(KernelContext* ctx, const BooleanScalar& cond
 }
 
 template <typename Type>
-struct IfElseFunctor<Type, enable_if_base_binary<Type>> {
+  requires arrow_base_binary<Type>
+struct IfElseFunctor<Type> {
   using OffsetType = typename TypeTraits<Type>::OffsetType::c_type;
   using ArrayType = typename TypeTraits<Type>::ArrayType;
   using BuilderType = typename TypeTraits<Type>::BuilderType;
@@ -905,7 +906,8 @@ struct IfElseFunctor<Type, enable_if_base_binary<Type>> {
 };
 
 template <typename Type>
-struct IfElseFunctor<Type, enable_if_fixed_size_binary<Type>> {
+  requires arrow_fixed_size_binary<Type>
+struct IfElseFunctor<Type> {
   // A - Array, S - Scalar, X = Array/Scalar
 
   // SXX
@@ -1040,8 +1042,9 @@ struct IfElseFunctor<Type, enable_if_fixed_size_binary<Type>> {
   }
 
   template <typename T = Type>
-  static enable_if_t<!is_decimal_type<T>::value, Result<int32_t>> GetByteWidth(
-      const DataType& left_type, const DataType& right_type) {
+    requires(!is_decimal_type<T>::value)
+  static Result<int32_t> GetByteWidth(const DataType& left_type,
+                                      const DataType& right_type) {
     const int32_t width =
         checked_cast<const FixedSizeBinaryType&>(left_type).byte_width();
     DCHECK_EQ(width, checked_cast<const FixedSizeBinaryType&>(right_type).byte_width());
@@ -1049,8 +1052,9 @@ struct IfElseFunctor<Type, enable_if_fixed_size_binary<Type>> {
   }
 
   template <typename T = Type>
-  static enable_if_decimal<T, Result<int32_t>> GetByteWidth(const DataType& left_type,
-                                                            const DataType& right_type) {
+    requires is_decimal_type<T>::value
+  static Result<int32_t> GetByteWidth(const DataType& left_type,
+                                      const DataType& right_type) {
     const auto& left = checked_cast<const T&>(left_type);
     const auto& right = checked_cast<const T&>(right_type);
     DCHECK_EQ(left.precision(), right.precision());
@@ -1687,7 +1691,7 @@ Status ExecArrayCaseWhen(KernelContext* ctx, const ExecSpan& batch, ExecResult* 
   return Status::OK();
 }
 
-template <typename Type, typename Enable = void>
+template <typename Type>
 struct CaseWhenFunctor {
   static Status Exec(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
     if (batch.values[0].is_array()) {
@@ -1806,7 +1810,8 @@ static Status ExecVarWidthArrayCaseWhen(
 }
 
 template <typename Type>
-struct CaseWhenFunctor<Type, enable_if_base_binary<Type>> {
+  requires arrow_base_binary<Type>
+struct CaseWhenFunctor<Type> {
   using offset_type = typename Type::offset_type;
   using BuilderType = typename TypeTraits<Type>::BuilderType;
   static Status Exec(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
@@ -1853,7 +1858,8 @@ struct CaseWhenFunctor<Type, enable_if_base_binary<Type>> {
 };
 
 template <typename Type>
-struct CaseWhenFunctor<Type, enable_if_var_size_list<Type>> {
+  requires arrow_var_length_list<Type>
+struct CaseWhenFunctor<Type> {
   using offset_type = typename Type::offset_type;
   using BuilderType = typename TypeTraits<Type>::BuilderType;
   static Status Exec(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
@@ -1894,7 +1900,8 @@ struct CaseWhenFunctor<Type, enable_if_var_size_list<Type>> {
 
 // TODO(GH-41453): a more efficient implementation for list-views is possible
 template <typename Type>
-struct CaseWhenFunctor<Type, enable_if_list_view<Type>> {
+  requires arrow_list_view<Type>
+struct CaseWhenFunctor<Type> {
   using offset_type = typename Type::offset_type;
   using BuilderType = typename TypeTraits<Type>::BuilderType;
   static Status Exec(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
@@ -1998,7 +2005,8 @@ struct CaseWhenFunctor<FixedSizeListType> {
 };
 
 template <typename Type>
-struct CaseWhenFunctor<Type, enable_if_union<Type>> {
+  requires arrow_union<Type>
+struct CaseWhenFunctor<Type> {
   static Status Exec(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
     if (batch[0].null_count() > 0) {
       return Status::Invalid("cond struct must not have outer nulls");
@@ -2378,7 +2386,7 @@ static Status ExecVarWidthCoalesce(KernelContext* ctx, const ExecSpan& batch,
                                   });
 }
 
-template <typename Type, typename Enable = void>
+template <typename Type>
 struct CoalesceFunctor {
   static Status Exec(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
     if (!TypeTraits<Type>::is_parameter_free) {
@@ -2400,7 +2408,8 @@ struct CoalesceFunctor<NullType> {
 };
 
 template <typename Type>
-struct CoalesceFunctor<Type, enable_if_base_binary<Type>> {
+  requires arrow_base_binary<Type>
+struct CoalesceFunctor<Type> {
   using offset_type = typename Type::offset_type;
   using ArrayType = typename TypeTraits<Type>::ArrayType;
   using BuilderType = typename TypeTraits<Type>::BuilderType;
@@ -2471,9 +2480,9 @@ struct CoalesceFunctor<Type, enable_if_base_binary<Type>> {
 };
 
 template <typename Type>
-struct CoalesceFunctor<
-    Type, enable_if_t<(is_nested_type<Type>::value || is_dictionary_type<Type>::value) &&
-                      !is_union_type<Type>::value>> {
+  requires((is_nested_type<Type>::value || is_dictionary_type<Type>::value) &&
+           !is_union_type<Type>::value)
+struct CoalesceFunctor<Type> {
   static Status Exec(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
     RETURN_NOT_OK(CheckIdenticalTypes(&batch.values[0], batch.num_values()));
     return ExecArray(ctx, batch, out);
@@ -2494,7 +2503,8 @@ const Scalar& GetUnionScalar(const SparseUnionType&, const Scalar& value) {
 }
 
 template <typename Type>
-struct CoalesceFunctor<Type, enable_if_union<Type>> {
+  requires arrow_union<Type>
+struct CoalesceFunctor<Type> {
   static Status Exec(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
     // Unions don't have top-level nulls, so a specialized implementation is needed
     RETURN_NOT_OK(CheckIdenticalTypes(&batch.values[0], batch.num_values()));
@@ -2619,7 +2629,7 @@ Status ExecArrayChoose(KernelContext* ctx, const ExecSpan& batch, ExecResult* ou
       });
 }
 
-template <typename Type, typename Enable = void>
+template <typename Type>
 struct ChooseFunctor {
   static Status Exec(KernelContext* ctx, const ExecSpan& batch, ExecResult* out) {
     if (batch.values[0].is_scalar()) {
@@ -2637,7 +2647,8 @@ struct ChooseFunctor<NullType> {
 };
 
 template <typename Type>
-struct ChooseFunctor<Type, enable_if_base_binary<Type>> {
+  requires arrow_base_binary<Type>
+struct ChooseFunctor<Type> {
   using offset_type = typename Type::offset_type;
   using BuilderType = typename TypeTraits<Type>::BuilderType;
 

--- a/cpp/src/arrow/compute/kernels/scalar_if_else_benchmark.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_if_else_benchmark.cc
@@ -52,14 +52,16 @@ struct GetBytesProcessedVisitor {
   }
 
   template <typename Type>
-  std::enable_if_t<is_number_type<Type>::value, Status> Visit(const Type& type) {
+    requires arrow_number<Type>
+  Status Visit(const Type& type) {
     using CType = typename Type::c_type;
     total_bytes += arr->length() * sizeof(CType);
     return Status::OK();
   }
 
   template <typename Type>
-  std::enable_if_t<is_base_binary_type<Type>::value, Status> Visit(const Type& type) {
+    requires arrow_base_binary<Type>
+  Status Visit(const Type& type) {
     using ArrayType = typename TypeTraits<Type>::ArrayType;
     using OffsetType = typename TypeTraits<Type>::OffsetType::c_type;
     total_bytes += arr->length() * sizeof(OffsetType) +
@@ -68,7 +70,8 @@ struct GetBytesProcessedVisitor {
   }
 
   template <typename ArrowType>
-  enable_if_var_length_list_like<ArrowType, Status> Visit(const ArrowType& type) {
+    requires arrow_var_length_list_like<ArrowType>
+  Status Visit(const ArrowType& type) {
     using ArrayType = typename TypeTraits<ArrowType>::ArrayType;
     using OffsetType = typename TypeTraits<ArrowType>::OffsetType::c_type;
 

--- a/cpp/src/arrow/compute/kernels/scalar_nested.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_nested.cc
@@ -893,23 +893,23 @@ struct ResolveMapLookup {
     return MapLookupFunctor<KeyType>::Exec(ctx, batch, out);
   }
 
-  template <typename KeyType>
-  enable_if_physical_integer<KeyType, Status> Visit(const KeyType& type) {
+  template <arrow_physical_integer KeyType>
+  Status Visit(const KeyType& type) {
     return Execute<KeyType>();
   }
 
-  template <typename KeyType>
-  enable_if_decimal<KeyType, Status> Visit(const KeyType& type) {
+  template <arrow_decimal KeyType>
+  Status Visit(const KeyType& type) {
     return Execute<KeyType>();
   }
 
-  template <typename KeyType>
-  enable_if_base_binary<KeyType, Status> Visit(const KeyType& type) {
+  template <arrow_base_binary KeyType>
+  Status Visit(const KeyType& type) {
     return Execute<KeyType>();
   }
 
-  template <typename KeyType>
-  enable_if_boolean<KeyType, Status> Visit(const KeyType& type) {
+  template <arrow_boolean KeyType>
+  Status Visit(const KeyType& type) {
     return Execute<KeyType>();
   }
 

--- a/cpp/src/arrow/compute/kernels/scalar_round.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_round.cc
@@ -86,10 +86,16 @@ bool IsPositive(const Scalar& scalar) {
   return visitor.result;
 }
 
+template <typename T>
+concept decimal_value_type =
+    std::is_same_v<T, Decimal32> || std::is_same_v<T, Decimal64> ||
+    std::is_same_v<T, Decimal128> || std::is_same_v<T, Decimal256>;
+
 struct RoundUtil {
   // Calculate powers of ten with arbitrary integer exponent
   template <typename T>
-  static enable_if_floating_value<T> Pow10(int64_t power) {
+    requires std::is_floating_point_v<T>
+  static T Pow10(int64_t power) {
     static constexpr T lut[] = {1e0F, 1e1F, 1e2F,  1e3F,  1e4F,  1e5F,  1e6F,  1e7F,
                                 1e8F, 1e9F, 1e10F, 1e11F, 1e12F, 1e13F, 1e14F, 1e15F};
     int64_t lut_size = (sizeof(lut) / sizeof(*lut));
@@ -103,7 +109,8 @@ struct RoundUtil {
 
   // Calculate powers of ten with arbitrary integer exponent
   template <typename T>
-  static enable_if_integer_value<T> Pow10(int64_t power) {
+    requires is_integer_value<T>::value
+  static T Pow10(int64_t power) {
     DCHECK_GE(power, 0);
     DCHECK_LE(power, std::numeric_limits<T>::digits10);
     static constexpr uint64_t lut[] = {
@@ -145,13 +152,14 @@ struct RoundImpl;
 template <typename Type>
 struct RoundImpl<Type, RoundMode::DOWN> {
   template <typename T = Type>
-  static constexpr enable_if_floating_value<T> Round(const T val) {
+    requires std::is_floating_point_v<T>
+  static constexpr T Round(const T val) {
     return std::floor(val);
   }
 
   template <typename T = Type>
-  static enable_if_decimal_value<T, void> Round(T* val, const T& remainder,
-                                                const T& pow10, const int32_t scale) {
+    requires decimal_value_type<T>
+  static void Round(T* val, const T& remainder, const T& pow10, const int32_t scale) {
     (*val) -= remainder;
     if (remainder.Sign() < 0) {
       (*val) -= pow10;
@@ -159,8 +167,8 @@ struct RoundImpl<Type, RoundMode::DOWN> {
   }
 
   template <typename T = Type>
-  static enable_if_integer_value<T> Round(const T val, const T floor, const T multiple,
-                                          Status* st) {
+    requires is_integer_value<T>::value
+  static T Round(const T val, const T floor, const T multiple, Status* st) {
     if constexpr (is_signed_integer_value<T>::value) {
       if (ARROW_PREDICT_FALSE(val < 0 &&
                               std::numeric_limits<T>::min() + multiple > floor)) {
@@ -177,13 +185,14 @@ struct RoundImpl<Type, RoundMode::DOWN> {
 template <typename Type>
 struct RoundImpl<Type, RoundMode::UP> {
   template <typename T = Type>
-  static constexpr enable_if_floating_value<T> Round(const T val) {
+    requires std::is_floating_point_v<T>
+  static constexpr T Round(const T val) {
     return std::ceil(val);
   }
 
   template <typename T = Type>
-  static enable_if_decimal_value<T, void> Round(T* val, const T& remainder,
-                                                const T& pow10, const int32_t scale) {
+    requires decimal_value_type<T>
+  static void Round(T* val, const T& remainder, const T& pow10, const int32_t scale) {
     (*val) -= remainder;
     if (remainder.Sign() > 0 && remainder != 0) {
       (*val) += pow10;
@@ -191,8 +200,8 @@ struct RoundImpl<Type, RoundMode::UP> {
   }
 
   template <typename T = Type>
-  static enable_if_integer_value<T> Round(const T val, const T floor, const T multiple,
-                                          Status* st) {
+    requires is_integer_value<T>::value
+  static T Round(const T val, const T floor, const T multiple, Status* st) {
     if (ARROW_PREDICT_FALSE(val > 0 &&
                             std::numeric_limits<T>::max() - multiple < floor)) {
       *st = Status::Invalid("Rounding ", val, " up to multiple of ", multiple,
@@ -206,19 +215,20 @@ struct RoundImpl<Type, RoundMode::UP> {
 template <typename Type>
 struct RoundImpl<Type, RoundMode::TOWARDS_ZERO> {
   template <typename T = Type>
-  static constexpr enable_if_floating_value<T> Round(const T val) {
+    requires std::is_floating_point_v<T>
+  static constexpr T Round(const T val) {
     return std::trunc(val);
   }
 
   template <typename T = Type>
-  static enable_if_decimal_value<T, void> Round(T* val, const T& remainder,
-                                                const T& pow10, const int32_t scale) {
+    requires decimal_value_type<T>
+  static void Round(T* val, const T& remainder, const T& pow10, const int32_t scale) {
     (*val) -= remainder;
   }
 
   template <typename T = Type>
-  static enable_if_integer_value<T> Round(const T val, const T floor, const T pow10,
-                                          Status* st) {
+    requires is_integer_value<T>::value
+  static T Round(const T val, const T floor, const T pow10, Status* st) {
     return floor;
   }
 };
@@ -226,13 +236,14 @@ struct RoundImpl<Type, RoundMode::TOWARDS_ZERO> {
 template <typename Type>
 struct RoundImpl<Type, RoundMode::TOWARDS_INFINITY> {
   template <typename T = Type>
-  static constexpr enable_if_floating_value<T> Round(const T val) {
+    requires std::is_floating_point_v<T>
+  static constexpr T Round(const T val) {
     return std::signbit(val) ? std::floor(val) : std::ceil(val);
   }
 
   template <typename T = Type>
-  static enable_if_decimal_value<T, void> Round(T* val, const T& remainder,
-                                                const T& pow10, const int32_t scale) {
+    requires decimal_value_type<T>
+  static void Round(T* val, const T& remainder, const T& pow10, const int32_t scale) {
     (*val) -= remainder;
     if (remainder.Sign() < 0) {
       (*val) -= pow10;
@@ -242,8 +253,8 @@ struct RoundImpl<Type, RoundMode::TOWARDS_INFINITY> {
   }
 
   template <typename T = Type>
-  static enable_if_integer_value<T> Round(const T val, const T floor, const T multiple,
-                                          Status* st) {
+    requires is_integer_value<T>::value
+  static T Round(const T val, const T floor, const T multiple, Status* st) {
     if constexpr (is_signed_integer_value<T>::value) {
       if (ARROW_PREDICT_FALSE(val < 0 &&
                               std::numeric_limits<T>::min() + multiple > floor)) {
@@ -275,19 +286,20 @@ struct RoundImpl<Type, RoundMode::TOWARDS_INFINITY> {
 template <typename Type>
 struct RoundImpl<Type, RoundMode::HALF_DOWN> {
   template <typename T = Type>
-  static constexpr enable_if_floating_value<T> Round(const T val) {
+    requires std::is_floating_point_v<T>
+  static constexpr T Round(const T val) {
     return RoundImpl<T, RoundMode::DOWN>::Round(val);
   }
 
   template <typename T = Type>
-  static enable_if_decimal_value<T, void> Round(T* val, const T& remainder,
-                                                const T& pow10, const int32_t scale) {
+    requires decimal_value_type<T>
+  static void Round(T* val, const T& remainder, const T& pow10, const int32_t scale) {
     RoundImpl<T, RoundMode::DOWN>::Round(val, remainder, pow10, scale);
   }
 
   template <typename T = Type>
-  static constexpr enable_if_integer_value<T> Round(const T val, const T floor,
-                                                    const T multiple, Status* st) {
+    requires is_integer_value<T>::value
+  static constexpr T Round(const T val, const T floor, const T multiple, Status* st) {
     return RoundImpl<T, RoundMode::DOWN>::Round(val, floor, multiple, st);
   }
 };
@@ -295,19 +307,20 @@ struct RoundImpl<Type, RoundMode::HALF_DOWN> {
 template <typename Type>
 struct RoundImpl<Type, RoundMode::HALF_UP> {
   template <typename T = Type>
-  static constexpr enable_if_floating_value<T> Round(const T val) {
+    requires std::is_floating_point_v<T>
+  static constexpr T Round(const T val) {
     return RoundImpl<T, RoundMode::UP>::Round(val);
   }
 
   template <typename T = Type>
-  static enable_if_decimal_value<T, void> Round(T* val, const T& remainder,
-                                                const T& pow10, const int32_t scale) {
+    requires decimal_value_type<T>
+  static void Round(T* val, const T& remainder, const T& pow10, const int32_t scale) {
     RoundImpl<T, RoundMode::UP>::Round(val, remainder, pow10, scale);
   }
 
   template <typename T = Type>
-  static constexpr enable_if_integer_value<T> Round(const T val, const T floor,
-                                                    const T multiple, Status* st) {
+    requires is_integer_value<T>::value
+  static constexpr T Round(const T val, const T floor, const T multiple, Status* st) {
     return RoundImpl<T, RoundMode::UP>::Round(val, floor, multiple, st);
   }
 };
@@ -315,19 +328,20 @@ struct RoundImpl<Type, RoundMode::HALF_UP> {
 template <typename Type>
 struct RoundImpl<Type, RoundMode::HALF_TOWARDS_ZERO> {
   template <typename T = Type>
-  static constexpr enable_if_floating_value<T> Round(const T val) {
+    requires std::is_floating_point_v<T>
+  static constexpr T Round(const T val) {
     return RoundImpl<T, RoundMode::TOWARDS_ZERO>::Round(val);
   }
 
   template <typename T = Type>
-  static enable_if_decimal_value<T, void> Round(T* val, const T& remainder,
-                                                const T& pow10, const int32_t scale) {
+    requires decimal_value_type<T>
+  static void Round(T* val, const T& remainder, const T& pow10, const int32_t scale) {
     RoundImpl<T, RoundMode::TOWARDS_ZERO>::Round(val, remainder, pow10, scale);
   }
 
   template <typename T = Type>
-  static constexpr enable_if_integer_value<T> Round(const T val, const T floor,
-                                                    const T multiple, Status* st) {
+    requires is_integer_value<T>::value
+  static constexpr T Round(const T val, const T floor, const T multiple, Status* st) {
     return RoundImpl<T, RoundMode::TOWARDS_ZERO>::Round(val, floor, multiple, st);
   }
 };
@@ -335,19 +349,20 @@ struct RoundImpl<Type, RoundMode::HALF_TOWARDS_ZERO> {
 template <typename Type>
 struct RoundImpl<Type, RoundMode::HALF_TOWARDS_INFINITY> {
   template <typename T = Type>
-  static constexpr enable_if_floating_value<T> Round(const T val) {
+    requires std::is_floating_point_v<T>
+  static constexpr T Round(const T val) {
     return RoundImpl<T, RoundMode::TOWARDS_INFINITY>::Round(val);
   }
 
   template <typename T = Type>
-  static enable_if_decimal_value<T, void> Round(T* val, const T& remainder,
-                                                const T& multiple, const int32_t scale) {
+    requires decimal_value_type<T>
+  static void Round(T* val, const T& remainder, const T& multiple, const int32_t scale) {
     RoundImpl<T, RoundMode::TOWARDS_INFINITY>::Round(val, remainder, multiple, scale);
   }
 
   template <typename T = Type>
-  static constexpr enable_if_integer_value<T> Round(const T val, const T floor,
-                                                    const T multiple, Status* st) {
+    requires is_integer_value<T>::value
+  static constexpr T Round(const T val, const T floor, const T multiple, Status* st) {
     return RoundImpl<T, RoundMode::TOWARDS_INFINITY>::Round(val, floor, multiple, st);
   }
 };
@@ -355,13 +370,14 @@ struct RoundImpl<Type, RoundMode::HALF_TOWARDS_INFINITY> {
 template <typename Type>
 struct RoundImpl<Type, RoundMode::HALF_TO_EVEN> {
   template <typename T = Type>
-  static constexpr enable_if_floating_value<T> Round(const T val) {
+    requires std::is_floating_point_v<T>
+  static constexpr T Round(const T val) {
     return std::round(val * T(0.5)) * 2;
   }
 
   template <typename T = Type>
-  static enable_if_decimal_value<T, void> Round(T* val, const T& remainder,
-                                                const T& pow10, const int32_t scale) {
+    requires decimal_value_type<T>
+  static void Round(T* val, const T& remainder, const T& pow10, const int32_t scale) {
     auto scaled = val->ReduceScaleBy(scale, /*round=*/false);
     if (scaled.low_bits() % 2 != 0) {
       scaled += remainder.Sign() >= 0 ? 1 : -1;
@@ -370,8 +386,8 @@ struct RoundImpl<Type, RoundMode::HALF_TO_EVEN> {
   }
 
   template <typename T = Type>
-  static constexpr enable_if_integer_value<T> Round(const T val, const T floor,
-                                                    const T multiple, Status* st) {
+    requires is_integer_value<T>::value
+  static constexpr T Round(const T val, const T floor, const T multiple, Status* st) {
     if ((floor / multiple) % 2 == 0) {
       return floor;
     }
@@ -382,13 +398,14 @@ struct RoundImpl<Type, RoundMode::HALF_TO_EVEN> {
 template <typename Type>
 struct RoundImpl<Type, RoundMode::HALF_TO_ODD> {
   template <typename T = Type>
-  static constexpr enable_if_floating_value<T> Round(const T val) {
+    requires std::is_floating_point_v<T>
+  static constexpr T Round(const T val) {
     return std::floor(val * T(0.5)) + std::ceil(val * T(0.5));
   }
 
   template <typename T = Type>
-  static enable_if_decimal_value<T, void> Round(T* val, const T& remainder,
-                                                const T& pow10, const int32_t scale) {
+    requires decimal_value_type<T>
+  static void Round(T* val, const T& remainder, const T& pow10, const int32_t scale) {
     auto scaled = val->ReduceScaleBy(scale, /*round=*/false);
     if (scaled.low_bits() % 2 == 0) {
       scaled += remainder.Sign() ? 1 : -1;
@@ -397,8 +414,8 @@ struct RoundImpl<Type, RoundMode::HALF_TO_ODD> {
   }
 
   template <typename T = Type>
-  static constexpr enable_if_integer_value<T> Round(const T val, const T floor,
-                                                    const T multiple, Status* st) {
+    requires is_integer_value<T>::value
+  static constexpr T Round(const T val, const T floor, const T multiple, Status* st) {
     if ((floor / multiple) % 2 != 0) {
       return floor;
     }
@@ -502,21 +519,24 @@ struct RoundOptionsWrapper<RoundToMultipleOptions, CType>
   }
 };
 
-template <typename ArrowType, typename Enable = void>
+template <typename ArrowType>
 struct RoundOptionsTrait;
 
 template <typename ArrowType>
-struct RoundOptionsTrait<ArrowType, enable_if_floating_point<ArrowType>> {
+  requires arrow_floating_point<ArrowType>
+struct RoundOptionsTrait<ArrowType> {
   using CType = double;
 };
 
 template <typename ArrowType>
-struct RoundOptionsTrait<ArrowType, enable_if_decimal<ArrowType>> {
+  requires arrow_decimal<ArrowType>
+struct RoundOptionsTrait<ArrowType> {
   using CType = double;
 };
 
 template <typename ArrowType>
-struct RoundOptionsTrait<ArrowType, enable_if_integer<ArrowType>> {
+  requires arrow_integer<ArrowType>
+struct RoundOptionsTrait<ArrowType> {
   using CType = typename ArrowType::c_type;
 };
 
@@ -524,7 +544,7 @@ struct RoundOptionsTrait<ArrowType, enable_if_integer<ArrowType>> {
 // ----------------------------------------------------------------------
 // Begin round op implementations
 
-template <typename ArrowType, RoundMode kRoundMode, typename Enable = void>
+template <typename ArrowType, RoundMode kRoundMode>
 struct RoundToMultiple {
   using CType = typename TypeTraits<ArrowType>::CType;
   using State = RoundOptionsWrapper<RoundToMultipleOptions,
@@ -541,7 +561,8 @@ struct RoundToMultiple {
   }
 
   template <typename T = ArrowType, typename CType = typename TypeTraits<T>::CType>
-  enable_if_floating_value<CType> Call(KernelContext* ctx, CType arg, Status* st) const {
+    requires std::is_floating_point_v<CType>
+  CType Call(KernelContext* ctx, CType arg, Status* st) const {
     // Do not process Inf or NaN because they will trigger the overflow error at end of
     // function.
     if (!std::isfinite(arg)) {
@@ -570,7 +591,8 @@ struct RoundToMultiple {
 };
 
 template <typename ArrowType, RoundMode kRoundMode>
-struct RoundToMultiple<ArrowType, kRoundMode, enable_if_decimal<ArrowType>> {
+  requires arrow_decimal<ArrowType>
+struct RoundToMultiple<ArrowType, kRoundMode> {
   using CType = typename TypeTraits<ArrowType>::CType;
   using State = RoundOptionsWrapper<RoundToMultipleOptions, double>;
   const ArrowType& ty;
@@ -590,7 +612,8 @@ struct RoundToMultiple<ArrowType, kRoundMode, enable_if_decimal<ArrowType>> {
   }
 
   template <typename T = ArrowType, typename CType = typename TypeTraits<T>::CType>
-  enable_if_decimal_value<CType> Call(KernelContext* ctx, CType arg, Status* st) const {
+    requires decimal_value_type<CType>
+  CType Call(KernelContext* ctx, CType arg, Status* st) const {
     std::pair<CType, CType> pair;
     *st = arg.Divide(multiple).Value(&pair);
     if (!st->ok()) return arg;
@@ -670,7 +693,8 @@ struct RoundToMultiple<ArrowType, kRoundMode, enable_if_decimal<ArrowType>> {
 };
 
 template <typename ArrowType, RoundMode kRoundMode>
-struct RoundToMultiple<ArrowType, kRoundMode, enable_if_integer<ArrowType>> {
+  requires arrow_integer<ArrowType>
+struct RoundToMultiple<ArrowType, kRoundMode> {
   using CType = typename TypeTraits<ArrowType>::CType;
   using State = RoundOptionsWrapper<RoundToMultipleOptions, CType>;
   CType multiple;
@@ -687,7 +711,8 @@ struct RoundToMultiple<ArrowType, kRoundMode, enable_if_integer<ArrowType>> {
       : multiple(multiple) {}
 
   template <typename T = ArrowType, typename CType = typename TypeTraits<T>::CType>
-  enable_if_integer_value<CType> Call(KernelContext* ctx, CType arg, Status* st) const {
+    requires is_integer_value<CType>::value
+  CType Call(KernelContext* ctx, CType arg, Status* st) const {
     CType floor = arg / multiple * multiple;
     CType remainder = arg > floor ? arg - floor : floor - arg;
 
@@ -722,7 +747,7 @@ struct RoundToMultiple<ArrowType, kRoundMode, enable_if_integer<ArrowType>> {
   }
 };
 
-template <typename ArrowType, RoundMode RndMode, typename Enable = void>
+template <typename ArrowType, RoundMode RndMode>
 struct Round {
   using CType = typename TypeTraits<ArrowType>::CType;
   using State =
@@ -734,7 +759,8 @@ struct Round {
       : pow10(static_cast<CType>(state.pow10)), ndigits(state.options.ndigits) {}
 
   template <typename T = ArrowType, typename CType = typename TypeTraits<T>::CType>
-  enable_if_floating_value<CType> Call(KernelContext* ctx, CType arg, Status* st) const {
+    requires std::is_floating_point_v<CType>
+  CType Call(KernelContext* ctx, CType arg, Status* st) const {
     // Do not process Inf or NaN because they will trigger the overflow error at end of
     // function.
     if (!std::isfinite(arg)) {
@@ -765,7 +791,8 @@ struct Round {
 };
 
 template <typename ArrowType, RoundMode kRoundMode>
-struct Round<ArrowType, kRoundMode, enable_if_decimal<ArrowType>> {
+  requires arrow_decimal<ArrowType>
+struct Round<ArrowType, kRoundMode> {
   using CType = typename TypeTraits<ArrowType>::CType;
   using State = RoundOptionsWrapper<RoundOptions, double>;
   const ArrowType& ty;
@@ -791,7 +818,8 @@ struct Round<ArrowType, kRoundMode, enable_if_decimal<ArrowType>> {
   }
 
   template <typename T = ArrowType, typename CType = typename TypeTraits<T>::CType>
-  enable_if_decimal_value<CType> Call(KernelContext* ctx, CType arg, Status* st) const {
+    requires decimal_value_type<CType>
+  CType Call(KernelContext* ctx, CType arg, Status* st) const {
     if (pow >= ty.precision()) {
       *st = Status::Invalid("Rounding to ", ndigits,
                             " digits will not fit in precision of ", ty);
@@ -837,7 +865,8 @@ struct Round<ArrowType, kRoundMode, enable_if_decimal<ArrowType>> {
 };
 
 template <typename ArrowType, RoundMode kRoundMode>
-struct Round<ArrowType, kRoundMode, enable_if_integer<ArrowType>> {
+  requires arrow_integer<ArrowType>
+struct Round<ArrowType, kRoundMode> {
   using CType = typename TypeTraits<ArrowType>::CType;
   using State = RoundOptionsWrapper<RoundOptions, CType>;
   CType pow10;
@@ -850,7 +879,8 @@ struct Round<ArrowType, kRoundMode, enable_if_integer<ArrowType>> {
         out_ty(out_ty) {}
 
   template <typename T = ArrowType, typename CType = typename TypeTraits<T>::CType>
-  enable_if_integer_value<CType> Call(KernelContext* ctx, CType arg, Status* st) const {
+    requires is_integer_value<CType>::value
+  CType Call(KernelContext* ctx, CType arg, Status* st) const {
     // no-op if ndigits is non-negative
     if (ndigits >= 0) {
       return arg;
@@ -862,7 +892,7 @@ struct Round<ArrowType, kRoundMode, enable_if_integer<ArrowType>> {
   }
 };
 
-template <typename ArrowType, RoundMode RndMode, typename Enable = void>
+template <typename ArrowType, RoundMode RndMode>
 struct RoundBinary {
   using CType = typename TypeTraits<ArrowType>::CType;
   using State = RoundOptionsWrapper<RoundBinaryOptions,
@@ -872,8 +902,8 @@ struct RoundBinary {
 
   template <typename T = ArrowType, typename CType0 = typename TypeTraits<T>::CType0,
             typename CType1 = typename TypeTraits<T>::CType1>
-  enable_if_floating_value<CType> Call(KernelContext* ctx, CType0 arg0, CType1 arg1,
-                                       Status* st) const {
+    requires std::is_floating_point_v<CType>
+  CType Call(KernelContext* ctx, CType0 arg0, CType1 arg1, Status* st) const {
     // Do not process Inf or NaN because they will trigger the overflow error at end of
     // function.
     if (!std::isfinite(arg0)) {
@@ -911,7 +941,8 @@ struct RoundBinary {
 };
 
 template <typename ArrowType, RoundMode kRoundMode>
-struct RoundBinary<ArrowType, kRoundMode, enable_if_decimal<ArrowType>> {
+  requires arrow_decimal<ArrowType>
+struct RoundBinary<ArrowType, kRoundMode> {
   using CType = typename TypeTraits<ArrowType>::CType;
   using State = RoundOptionsWrapper<RoundBinaryOptions, double>;
   const ArrowType& ty;
@@ -935,8 +966,8 @@ struct RoundBinary<ArrowType, kRoundMode, enable_if_decimal<ArrowType>> {
 
   template <typename T = ArrowType, typename CType0 = typename TypeTraits<T>::CType0,
             typename CType1 = typename TypeTraits<T>::CType1>
-  enable_if_decimal_value<CType> Call(KernelContext* ctx, CType0 arg0, CType1 arg1,
-                                      Status* st) const {
+    requires decimal_value_type<CType>
+  CType Call(KernelContext* ctx, CType0 arg0, CType1 arg1, Status* st) const {
     if (pow - arg1 >= ty.precision()) {
       *st = Status::Invalid("Rounding to ", arg1, " digits will not fit in precision of ",
                             ty);
@@ -984,7 +1015,8 @@ struct RoundBinary<ArrowType, kRoundMode, enable_if_decimal<ArrowType>> {
 };
 
 template <typename ArrowType, RoundMode kRoundMode>
-struct RoundBinary<ArrowType, kRoundMode, enable_if_integer<ArrowType>> {
+  requires arrow_integer<ArrowType>
+struct RoundBinary<ArrowType, kRoundMode> {
   using CType = typename TypeTraits<ArrowType>::CType;
   using State = RoundOptionsWrapper<RoundBinaryOptions, CType>;
 
@@ -993,8 +1025,8 @@ struct RoundBinary<ArrowType, kRoundMode, enable_if_integer<ArrowType>> {
 
   template <typename T = ArrowType, typename CType0 = typename TypeTraits<T>::CType0,
             typename CType1 = typename TypeTraits<T>::CType1>
-  enable_if_integer_value<CType> Call(KernelContext* ctx, CType0 arg0, CType1 arg1,
-                                      Status* st) const {
+    requires is_integer_value<CType>::value
+  CType Call(KernelContext* ctx, CType0 arg0, CType1 arg1, Status* st) const {
     // ndigits >= 0 is a no-op
     if (arg1 >= 0) {
       return arg0;
@@ -1016,8 +1048,8 @@ struct RoundBinary<ArrowType, kRoundMode, enable_if_integer<ArrowType>> {
 
 struct Floor {
   template <typename T, typename Arg>
-  static constexpr enable_if_floating_value<Arg, T> Call(KernelContext*, Arg arg,
-                                                         Status*) {
+    requires std::is_floating_point_v<Arg>
+  static constexpr T Call(KernelContext*, Arg arg, Status*) {
     static_assert(std::is_same<T, Arg>::value);
     return RoundImpl<T, RoundMode::DOWN>::Round(arg);
   }
@@ -1025,8 +1057,8 @@ struct Floor {
 
 struct Ceil {
   template <typename T, typename Arg>
-  static constexpr enable_if_floating_value<Arg, T> Call(KernelContext*, Arg arg,
-                                                         Status*) {
+    requires std::is_floating_point_v<Arg>
+  static constexpr T Call(KernelContext*, Arg arg, Status*) {
     static_assert(std::is_same<T, Arg>::value);
     return RoundImpl<T, RoundMode::UP>::Round(arg);
   }
@@ -1034,8 +1066,8 @@ struct Ceil {
 
 struct Trunc {
   template <typename T, typename Arg>
-  static constexpr enable_if_floating_value<Arg, T> Call(KernelContext*, Arg arg,
-                                                         Status*) {
+    requires std::is_floating_point_v<Arg>
+  static constexpr T Call(KernelContext*, Arg arg, Status*) {
     static_assert(std::is_same<T, Arg>::value);
     return RoundImpl<T, RoundMode::TOWARDS_ZERO>::Round(arg);
   }

--- a/cpp/src/arrow/compute/kernels/scalar_set_lookup.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_set_lookup.cc
@@ -185,21 +185,20 @@ struct InitStateVisitor {
 
   Status Visit(const DataType&) { return Init<NullType>(); }
 
-  template <typename Type>
-  enable_if_boolean<Type, Status> Visit(const Type&) {
+  template <arrow_boolean Type>
+  Status Visit(const Type&) {
     return Init<BooleanType>();
   }
 
   template <typename Type>
-  enable_if_t<has_c_type<Type>::value && !is_boolean_type<Type>::value &&
-                  !std::is_same<Type, MonthDayNanoIntervalType>::value,
-              Status>
-  Visit(const Type&) {
+    requires(arrow_has_c_type<Type> && !arrow_boolean<Type> &&
+             !std::is_same_v<Type, MonthDayNanoIntervalType>)
+  Status Visit(const Type&) {
     return Init<typename UnsignedIntType<sizeof(typename Type::c_type)>::Type>();
   }
 
-  template <typename Type>
-  enable_if_base_binary<Type, Status> Visit(const Type&) {
+  template <arrow_base_binary Type>
+  Status Visit(const Type&) {
     return Init<typename Type::PhysicalType>();
   }
 
@@ -356,22 +355,21 @@ struct IndexInVisitor {
     return ProcessIndexIn(state, data);
   }
 
-  template <typename Type>
-  enable_if_boolean<Type, Status> Visit(const Type&) {
+  template <arrow_boolean Type>
+  Status Visit(const Type&) {
     return ProcessIndexIn<BooleanType>();
   }
 
   template <typename Type>
-  enable_if_t<has_c_type<Type>::value && !is_boolean_type<Type>::value &&
-                  !std::is_same<Type, MonthDayNanoIntervalType>::value,
-              Status>
-  Visit(const Type&) {
+    requires(arrow_has_c_type<Type> && !arrow_boolean<Type> &&
+             !std::is_same_v<Type, MonthDayNanoIntervalType>)
+  Status Visit(const Type&) {
     return ProcessIndexIn<
         typename UnsignedIntType<sizeof(typename Type::c_type)>::Type>();
   }
 
-  template <typename Type>
-  enable_if_base_binary<Type, Status> Visit(const Type&) {
+  template <arrow_base_binary Type>
+  Status Visit(const Type&) {
     return ProcessIndexIn<typename Type::PhysicalType>();
   }
 
@@ -498,21 +496,20 @@ struct IsInVisitor {
     return ProcessIsIn(state, data);
   }
 
-  template <typename Type>
-  enable_if_boolean<Type, Status> Visit(const Type&) {
+  template <arrow_boolean Type>
+  Status Visit(const Type&) {
     return ProcessIsIn<BooleanType>();
   }
 
   template <typename Type>
-  enable_if_t<has_c_type<Type>::value && !is_boolean_type<Type>::value &&
-                  !std::is_same<Type, MonthDayNanoIntervalType>::value,
-              Status>
-  Visit(const Type&) {
+    requires(arrow_has_c_type<Type> && !arrow_boolean<Type> &&
+             !std::is_same_v<Type, MonthDayNanoIntervalType>)
+  Status Visit(const Type&) {
     return ProcessIsIn<typename UnsignedIntType<sizeof(typename Type::c_type)>::Type>();
   }
 
-  template <typename Type>
-  enable_if_base_binary<Type, Status> Visit(const Type&) {
+  template <arrow_base_binary Type>
+  Status Visit(const Type&) {
     return ProcessIsIn<typename Type::PhysicalType>();
   }
 

--- a/cpp/src/arrow/compute/kernels/scalar_temporal_binary.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_temporal_binary.cc
@@ -80,11 +80,9 @@ Status CheckTimezones(const ExecSpan& batch) {
 template <template <typename...> class Op, typename Duration, typename InType,
           typename OutType>
 struct TemporalBinary {
-  template <typename OptionsType, typename T = InType>
-  static enable_if_timestamp<T, Status> ExecWithOptions(KernelContext* ctx,
-                                                        const OptionsType* options,
-                                                        const ExecSpan& batch,
-                                                        ExecResult* out) {
+  template <typename OptionsType, arrow_timestamp T = InType>
+  static Status ExecWithOptions(KernelContext* ctx, const OptionsType* options,
+                                const ExecSpan& batch, ExecResult* out) {
     RETURN_NOT_OK(CheckTimezones(batch));
 
     const auto& timezone = GetInputTimezone(*batch[0].type());
@@ -105,9 +103,9 @@ struct TemporalBinary {
   }
 
   template <typename OptionsType, typename T = InType>
-  static enable_if_t<!is_timestamp_type<T>::value, Status> ExecWithOptions(
-      KernelContext* ctx, const OptionsType* options, const ExecSpan& batch,
-      ExecResult* out) {
+    requires(!arrow_timestamp<T>)
+  static Status ExecWithOptions(KernelContext* ctx, const OptionsType* options,
+                                const ExecSpan& batch, ExecResult* out) {
     using ExecTemplate = Op<Duration, NonZonedLocalizer>;
     auto op = ExecTemplate(options, NonZonedLocalizer());
     applicator::ScalarBinaryNotNullStatefulEqualTypes<OutType, T, ExecTemplate> kernel{

--- a/cpp/src/arrow/compute/kernels/test_util_internal.h
+++ b/cpp/src/arrow/compute/kernels/test_util_internal.h
@@ -176,28 +176,28 @@ void CheckDispatchExactFails(std::string func_name, std::vector<TypeHolder> type
 void CheckDispatchFails(std::string func_name, std::vector<TypeHolder> types);
 
 // Helper to get a default instance of a type, including parameterized types
-template <typename T>
-enable_if_parameter_free<T, std::shared_ptr<DataType>> default_type_instance() {
+template <arrow_parameter_free T>
+std::shared_ptr<DataType> default_type_instance() {
   return TypeTraits<T>::type_singleton();
 }
-template <typename T>
-enable_if_time<T, std::shared_ptr<DataType>> default_type_instance() {
+template <arrow_time T>
+std::shared_ptr<DataType> default_type_instance() {
   // Time32 requires second/milli, Time64 requires nano/micro
   if (bit_width(T::type_id) == 32) {
     return std::make_shared<T>(TimeUnit::type::SECOND);
   }
   return std::make_shared<T>(TimeUnit::type::NANO);
 }
-template <typename T>
-enable_if_timestamp<T, std::shared_ptr<DataType>> default_type_instance() {
+template <arrow_timestamp T>
+std::shared_ptr<DataType> default_type_instance() {
   return std::make_shared<T>(TimeUnit::type::SECOND);
 }
-template <typename T>
-enable_if_decimal<T, std::shared_ptr<DataType>> default_type_instance() {
+template <arrow_decimal T>
+std::shared_ptr<DataType> default_type_instance() {
   return std::make_shared<T>(5, 2);
 }
-template <typename T>
-enable_if_duration<T, std::shared_ptr<DataType>> default_type_instance() {
+template <arrow_duration T>
+std::shared_ptr<DataType> default_type_instance() {
   return std::make_shared<T>(TimeUnit::type::SECOND);
 }
 // Random Generator Helpers

--- a/cpp/src/arrow/compute/kernels/vector_array_sort.cc
+++ b/cpp/src/arrow/compute/kernels/vector_array_sort.cc
@@ -473,7 +473,7 @@ class ArrayNullSorter {
 // Generic Array sort dispatcher for physical types
 //
 
-template <typename Type, typename Enable = void>
+template <typename Type>
 struct ArraySorter {};
 
 template <>
@@ -499,17 +499,16 @@ struct ArraySorter<Int8Type> {
 };
 
 template <typename Type>
-struct ArraySorter<Type, enable_if_t<is_integer_type<Type>::value &&
-                                     (sizeof(typename Type::c_type) > 1)>> {
+  requires(arrow_integer<Type> && (sizeof(typename Type::c_type) > 1))
+struct ArraySorter<Type> {
   static constexpr bool is_supported = true;
   ArrayCountOrCompareSorter<Type> impl;
 };
 
 template <typename Type>
-struct ArraySorter<
-    Type, enable_if_t<is_floating_type<Type>::value || is_base_binary_type<Type>::value ||
-                      is_fixed_size_binary_type<Type>::value ||
-                      is_dictionary_type<Type>::value || is_struct_type<Type>::value>> {
+  requires(arrow_floating_point<Type> || arrow_base_binary<Type> ||
+           arrow_fixed_size_binary<Type> || arrow_dictionary<Type> || arrow_struct<Type>)
+struct ArraySorter<Type> {
   ArrayCompareSorter<Type> impl;
 };
 

--- a/cpp/src/arrow/compute/kernels/vector_cumulative_ops.cc
+++ b/cpp/src/arrow/compute/kernels/vector_cumulative_ops.cc
@@ -276,8 +276,8 @@ struct CumulativeStatefulKernelFactory {
     kernel.init = CumulativeOptionsWrapper<OptionsType>::Init;
   }
 
-  template <typename Type>
-  enable_if_number<Type, Status> Visit(const Type& type) {
+  template <arrow_number Type>
+  Status Visit(const Type& type) {
     kernel.signature = KernelSignature::Make(
         {type.GetSharedPtr()},
         OutputType(TypeTraits<typename State<Type>::OutType>::type_singleton()));

--- a/cpp/src/arrow/compute/kernels/vector_hash.cc
+++ b/cpp/src/arrow/compute/kernels/vector_hash.cc
@@ -300,7 +300,8 @@ class RegularHashKernel : public HashKernel {
   std::shared_ptr<DataType> value_type() const override { return type_; }
 
   template <bool HasError = with_error_status>
-  enable_if_t<!HasError, Status> DoAppend(const ArraySpan& arr) {
+    requires(!HasError)
+  Status DoAppend(const ArraySpan& arr) {
     return VisitArraySpanInline<Type>(
         arr,
         [this](Scalar v) {
@@ -332,7 +333,8 @@ class RegularHashKernel : public HashKernel {
   }
 
   template <bool HasError = with_error_status>
-  enable_if_t<HasError, Status> DoAppend(const ArraySpan& arr) {
+    requires HasError
+  Status DoAppend(const ArraySpan& arr) {
     return VisitArraySpanInline<Type>(
         arr,
         [this](Scalar v) {
@@ -389,7 +391,8 @@ class NullHashKernel : public HashKernel {
   Status Append(const ArraySpan& arr) override { return DoAppend(arr); }
 
   template <bool HasError = with_error_status>
-  enable_if_t<!HasError, Status> DoAppend(const ArraySpan& arr) {
+    requires(!HasError)
+  Status DoAppend(const ArraySpan& arr) {
     RETURN_NOT_OK(action_.Reserve(arr.length));
     for (int64_t i = 0; i < arr.length; ++i) {
       if (i == 0) {
@@ -403,7 +406,8 @@ class NullHashKernel : public HashKernel {
   }
 
   template <bool HasError = with_error_status>
-  enable_if_t<HasError, Status> DoAppend(const ArraySpan& arr) {
+    requires HasError
+  Status DoAppend(const ArraySpan& arr) {
     Status s = Status::OK();
     RETURN_NOT_OK(action_.Reserve(arr.length));
     for (int64_t i = 0; i < arr.length; ++i) {

--- a/cpp/src/arrow/compute/kernels/vector_replace.cc
+++ b/cpp/src/arrow/compute/kernels/vector_replace.cc
@@ -114,12 +114,12 @@ int64_t ReplaceMaskArrayImpl(const ArraySpan& array, const ArraySpan& mask,
   return replacements_offset;
 }
 
-template <typename Type, typename Enable = void>
+template <typename Type>
 struct ReplaceMaskImpl {};
 
 template <typename Type>
-struct ReplaceMaskImpl<
-    Type, enable_if_t<!(is_base_binary_type<Type>::value || is_null_type<Type>::value)>> {
+  requires(!arrow_base_binary<Type> && !arrow_null<Type>)
+struct ReplaceMaskImpl<Type> {
   static Result<int64_t> ExecScalarMask(KernelContext* ctx, const ArraySpan& array,
                                         const BooleanScalar& mask, ExecValue replacements,
                                         int64_t replacements_offset, ExecResult* out) {
@@ -212,8 +212,8 @@ struct ReplaceMaskImpl<
   }
 };
 
-template <typename Type>
-struct ReplaceMaskImpl<Type, enable_if_null<Type>> {
+template <arrow_null Type>
+struct ReplaceMaskImpl<Type> {
   static Result<int64_t> ExecScalarMask(KernelContext* ctx, const ArraySpan& array,
                                         const BooleanScalar& mask, ExecValue replacements,
                                         int64_t replacements_offset, ExecResult* out) {
@@ -229,8 +229,8 @@ struct ReplaceMaskImpl<Type, enable_if_null<Type>> {
   }
 };
 
-template <typename Type>
-struct ReplaceMaskImpl<Type, enable_if_base_binary<Type>> {
+template <arrow_base_binary Type>
+struct ReplaceMaskImpl<Type> {
   using offset_type = typename Type::offset_type;
   using BuilderType = typename TypeTraits<Type>::BuilderType;
 
@@ -518,15 +518,13 @@ void FillNullInDirectionImpl(const ArraySpan& current_chunk, const uint8_t* null
   out_arr->null_count = kUnknownNullCount;
 }
 
-template <typename Type, typename Enable = void>
+template <typename Type>
 struct FillNullImpl {};
 
 template <typename Type>
-struct FillNullImpl<
-    Type,
-    enable_if_t<is_number_type<Type>::value || is_boolean_type<Type>::value ||
-                is_boolean_type<Type>::value || is_fixed_size_binary_type<Type>::value ||
-                std::is_same<Type, MonthDayNanoIntervalType>::value>> {
+  requires(arrow_number<Type> || arrow_boolean<Type> || arrow_fixed_size_binary<Type> ||
+           std::is_same_v<Type, MonthDayNanoIntervalType>)
+struct FillNullImpl<Type> {
   static Status Exec(KernelContext* ctx, const ArraySpan& array,
                      const uint8_t* reversed_bitmap, ExecResult* out, int8_t direction,
                      const ArraySpan& last_valid_value_chunk,
@@ -537,8 +535,8 @@ struct FillNullImpl<
   }
 };
 
-template <typename Type>
-struct FillNullImpl<Type, enable_if_base_binary<Type>> {
+template <arrow_base_binary Type>
+struct FillNullImpl<Type> {
   using offset_type = typename Type::offset_type;
   using BuilderType = typename TypeTraits<Type>::BuilderType;
 
@@ -628,8 +626,8 @@ struct FillNullImpl<Type, enable_if_base_binary<Type>> {
   }
 };
 
-template <typename Type>
-struct FillNullImpl<Type, enable_if_null<Type>> {
+template <arrow_null Type>
+struct FillNullImpl<Type> {
   static Status Exec(KernelContext* ctx, const ArraySpan& array,
                      const uint8_t* reversed_bitmap, ExecResult* out, int8_t direction,
                      const ArraySpan& last_valid_value_chunk,

--- a/cpp/src/arrow/compute/kernels/vector_selection.cc
+++ b/cpp/src/arrow/compute/kernels/vector_selection.cc
@@ -235,10 +235,8 @@ struct NonZeroVisitor {
   Status Visit(const DataType& type) { return Status::NotImplemented(type.ToString()); }
 
   template <typename Type>
-  enable_if_t<is_decimal_type<Type>::value || is_primitive_ctype<Type>::value ||
-                  is_boolean_type<Type>::value,
-              Status>
-  Visit(const Type&) {
+    requires(arrow_decimal<Type> || arrow_primitive_ctype<Type> || arrow_boolean<Type>)
+  Status Visit(const Type&) {
     using T = typename GetOutputType<Type>::T;
     const T zero{};
     uint64_t index = 0;

--- a/cpp/src/arrow/compute/kernels/vector_sort.cc
+++ b/cpp/src/arrow/compute/kernels/vector_sort.cc
@@ -533,7 +533,8 @@ class MultipleKeyRecordBatchSorter : public TypeVisitor {
   }
 
   template <typename Type>
-  enable_if_t<!is_null_type<Type>::value, Status> SortInternal() {
+    requires(!arrow_null<Type>)
+  Status SortInternal() {
     using ArrayType = typename TypeTraits<Type>::ArrayType;
     using GetView = GetViewType<Type>;
 
@@ -566,8 +567,8 @@ class MultipleKeyRecordBatchSorter : public TypeVisitor {
     return comparator_.status();
   }
 
-  template <typename Type>
-  enable_if_null<Type, Status> SortInternal() {
+  template <arrow_null Type>
+  Status SortInternal() {
     std::stable_sort(indices_begin_, indices_end_, [&](uint64_t left, uint64_t right) {
       return comparator_.Compare(left, right, 1);
     });
@@ -832,9 +833,11 @@ class TableSorter {
   // Merge rows with a non-null in the first sort key
   //
   template <typename ArrowType>
-  enable_if_t<!is_null_type<ArrowType>::value> MergeNonNulls(
-      CompressedChunkLocation* range_begin, CompressedChunkLocation* range_middle,
-      CompressedChunkLocation* range_end, CompressedChunkLocation* temp_indices) {
+    requires(!arrow_null<ArrowType>)
+  void MergeNonNulls(CompressedChunkLocation* range_begin,
+                     CompressedChunkLocation* range_middle,
+                     CompressedChunkLocation* range_end,
+                     CompressedChunkLocation* temp_indices) {
     auto& comparator = comparator_;
     const auto& first_sort_key = sort_keys_[0];
 
@@ -868,11 +871,11 @@ class TableSorter {
     std::copy(temp_indices, temp_indices + (range_end - range_begin), range_begin);
   }
 
-  template <typename ArrowType>
-  enable_if_null<ArrowType> MergeNonNulls(CompressedChunkLocation* range_begin,
-                                          CompressedChunkLocation* range_middle,
-                                          CompressedChunkLocation* range_end,
-                                          CompressedChunkLocation* temp_indices) {
+  template <arrow_null ArrowType>
+  void MergeNonNulls(CompressedChunkLocation* range_begin,
+                     CompressedChunkLocation* range_middle,
+                     CompressedChunkLocation* range_end,
+                     CompressedChunkLocation* temp_indices) {
     const int64_t null_count = range_end - range_begin;
     MergeNullsOnly(range_begin, range_middle, range_end, temp_indices, null_count);
   }

--- a/cpp/src/arrow/compute/kernels/vector_swizzle.cc
+++ b/cpp/src/arrow/compute/kernels/vector_swizzle.cc
@@ -86,7 +86,8 @@ struct InversePermutationImpl {
   }
 
   template <typename Type>
-  enable_if_t<is_integer_type<Type>::value, Status> Visit(const Type& output_type) {
+    requires arrow_integer<Type>
+  Status Visit(const Type& output_type) {
     using OutputCType = typename Type::c_type;
 
     RETURN_NOT_OK(CheckInput(output_type));

--- a/cpp/src/arrow/compute/key_hash_test.cc
+++ b/cpp/src/arrow/compute/key_hash_test.cc
@@ -27,6 +27,7 @@
 #include "arrow/testing/gtest_util.h"
 #include "arrow/testing/random.h"
 #include "arrow/testing/util.h"
+#include "arrow/type_traits.h"
 #include "arrow/util/cpu_info.h"
 #include "arrow/util/pcg_random.h"
 
@@ -47,10 +48,10 @@ std::vector<int64_t> HardwareFlagsForTesting() {
 
 class TestVectorHash {
  private:
-  template <typename Type, typename ArrayType = typename TypeTraits<Type>::ArrayType>
-  static enable_if_base_binary<Type, Result<std::shared_ptr<ArrayType>>>
-  GenerateUniqueRandomBinary(random::pcg32_fast* random, int num, int min_length,
-                             int max_length) {
+  template <arrow_base_binary Type,
+            typename ArrayType = typename TypeTraits<Type>::ArrayType>
+  static Result<std::shared_ptr<ArrayType>> GenerateUniqueRandomBinary(
+      random::pcg32_fast* random, int num, int min_length, int max_length) {
     using BuilderType = typename TypeTraits<Type>::BuilderType;
     BuilderType builder;
     std::unordered_set<std::string> unique_key_strings;

--- a/cpp/src/arrow/dataset/file_json_test.cc
+++ b/cpp/src/arrow/dataset/file_json_test.cc
@@ -24,6 +24,7 @@
 #include "arrow/json/rapidjson_defs.h"
 #include "arrow/testing/gtest_util.h"
 #include "arrow/testing/util.h"
+#include "arrow/type_traits.h"
 #include "arrow/util/logging_internal.h"
 
 #include "rapidjson/ostreamwrapper.h"
@@ -65,20 +66,20 @@ struct WriteVisitor {
               : Status::Invalid("Unexpected false return from JSON writer");
   }
 
-  template <typename T>
-  enable_if_physical_signed_integer<T, Status> Visit(const T*) {
+  template <arrow_physical_signed_integer T>
+  Status Visit(const T*) {
     const auto& scalar = checked_cast<const NumericScalar<T>&>(scalar_);
     return OK(writer_.Int64(scalar.value));
   }
 
-  template <typename T>
-  enable_if_physical_unsigned_integer<T, Status> Visit(const T*) {
+  template <arrow_physical_unsigned_integer T>
+  Status Visit(const T*) {
     const auto& scalar = checked_cast<const NumericScalar<T>&>(scalar_);
     return OK(writer_.Uint64(scalar.value));
   }
 
-  template <typename T>
-  enable_if_physical_floating_point<T, Status> Visit(const T*) {
+  template <arrow_physical_floating_point T>
+  Status Visit(const T*) {
     const auto& scalar = checked_cast<const NumericScalar<T>&>(scalar_);
     return OK(writer_.Double(scalar.value));
   }

--- a/cpp/src/arrow/dataset/file_parquet_encryption_test.cc
+++ b/cpp/src/arrow/dataset/file_parquet_encryption_test.cc
@@ -84,8 +84,8 @@ const auto kAllParamValues = ::testing::Values(
     EncryptionTestParam{false, true, true}, EncryptionTestParam{true, true, true});
 
 // Base class to test writing and reading encrypted dataset.
-template <typename T,
-          typename = typename std::enable_if_t<std::is_base_of_v<EncryptionTestParam, T>>>
+template <typename T>
+  requires std::is_base_of_v<EncryptionTestParam, T>
 class DatasetEncryptionTestBase : public testing::TestWithParam<T> {
  public:
 #ifdef ARROW_VALGRIND

--- a/cpp/src/arrow/dataset/scanner_test.cc
+++ b/cpp/src/arrow/dataset/scanner_test.cc
@@ -413,8 +413,8 @@ struct MockDatasetBuilder {
   MockFragmentScanner* active_fragment = nullptr;
 };
 
-template <typename TYPE,
-          typename = typename std::enable_if<arrow::is_integer_type<TYPE>::value>::type>
+template <typename TYPE>
+  requires arrow::arrow_integer<TYPE>
 std::shared_ptr<Array> ArrayFromRange(int start, int end, bool add_nulls) {
   using ArrowBuilderType = typename arrow::TypeTraits<TYPE>::BuilderType;
   ArrowBuilderType builder;

--- a/cpp/src/arrow/datum.h
+++ b/cpp/src/arrow/datum.h
@@ -114,8 +114,8 @@ struct ARROW_EXPORT Datum {
 
   /// \brief Cast from concrete subtypes of Array or Scalar to Datum
   template <typename T, bool IsArray = std::is_base_of_v<Array, T>,
-            bool IsScalar = std::is_base_of_v<Scalar, T>,
-            typename = enable_if_t<IsArray || IsScalar>>
+            bool IsScalar = std::is_base_of_v<Scalar, T>>
+    requires(IsArray || IsScalar)
   Datum(std::shared_ptr<T> value)  // NOLINT implicit conversion
       : Datum(std::shared_ptr<typename std::conditional<IsArray, Array, Scalar>::type>(
             std::move(value))) {}
@@ -123,15 +123,16 @@ struct ARROW_EXPORT Datum {
   /// \brief Cast from concrete subtypes of Array or Scalar to Datum
   template <typename T, typename TV = typename std::remove_reference_t<T>,
             bool IsArray = std::is_base_of_v<Array, T>,
-            bool IsScalar = std::is_base_of_v<Scalar, T>,
-            typename = enable_if_t<IsArray || IsScalar>>
+            bool IsScalar = std::is_base_of_v<Scalar, T>>
+    requires(IsArray || IsScalar)
   Datum(T&& value)  // NOLINT implicit conversion
       : Datum(std::make_shared<TV>(std::forward<T>(value))) {}
 
   /// \brief Copy from concrete subtypes of Scalar.
   ///
   /// The concrete scalar type must be copyable (not all of them are).
-  template <typename T, typename = enable_if_t<std::is_base_of_v<Scalar, T>>>
+  template <typename T>
+    requires std::is_base_of_v<Scalar, T>
   Datum(const T& value)  // NOLINT implicit conversion
       : Datum(std::make_shared<T>(value)) {}
 

--- a/cpp/src/arrow/engine/substrait/expression_internal.cc
+++ b/cpp/src/arrow/engine/substrait/expression_internal.cc
@@ -55,6 +55,7 @@
 #include "arrow/scalar.h"
 #include "arrow/status.h"
 #include "arrow/type.h"
+#include "arrow/type_traits.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/decimal.h"
 #include "arrow/util/endian.h"
@@ -945,7 +946,8 @@ struct ScalarToProtoImpl {
   Status Visit(const DayTimeIntervalScalar& s) { return NotImplemented(s); }
 
   template <typename T, typename TypeClass = typename T::TypeClass>
-  enable_if_decimal<TypeClass, Status> Visit(const T& s) {
+    requires arrow_decimal<TypeClass>
+  Status Visit(const T& s) {
     using ValueType = typename T::ValueType;
 
     auto decimal = std::make_unique<Lit::Decimal>();

--- a/cpp/src/arrow/integration/json_internal.cc
+++ b/cpp/src/arrow/integration/json_internal.cc
@@ -233,11 +233,10 @@ class SchemaWriter {
   Status VisitType(const DataType& type);
 
   template <typename T>
-  enable_if_t<is_null_type<T>::value || is_primitive_ctype<T>::value ||
-              is_base_binary_type<T>::value || is_binary_view_like_type<T>::value ||
-              is_var_length_list_type<T>::value || is_struct_type<T>::value ||
-              is_run_end_encoded_type<T>::value || is_list_view_type<T>::value>
-  WriteTypeMetadata(const T& type) {}
+    requires(arrow_null<T> || arrow_primitive_ctype<T> || arrow_base_binary<T> ||
+             arrow_binary_view_like<T> || arrow_var_length_list<T> || arrow_struct<T> ||
+             arrow_run_end_encoded<T> || arrow_list_view<T>)
+  void WriteTypeMetadata(const T& type) {}
 
   void WriteTypeMetadata(const MapType& type) {
     writer_->Key("keysSorted");
@@ -497,9 +496,8 @@ class ArrayWriter {
 
   template <typename ArrayType, typename TypeClass = typename ArrayType::TypeClass,
             typename CType = typename TypeClass::c_type>
-  enable_if_t<is_physical_integer_type<TypeClass>::value &&
-              sizeof(CType) != sizeof(int64_t)>
-  WriteDataValues(const ArrayType& arr) {
+    requires(arrow_physical_integer<TypeClass> && sizeof(CType) != sizeof(int64_t))
+  void WriteDataValues(const ArrayType& arr) {
     static const std::string null_string = "0";
     for (int64_t i = 0; i < arr.length(); ++i) {
       if (arr.IsValid(i)) {
@@ -512,9 +510,8 @@ class ArrayWriter {
 
   template <typename ArrayType, typename TypeClass = typename ArrayType::TypeClass,
             typename CType = typename TypeClass::c_type>
-  enable_if_t<is_physical_integer_type<TypeClass>::value &&
-              sizeof(CType) == sizeof(int64_t)>
-  WriteDataValues(const ArrayType& arr) {
+    requires(arrow_physical_integer<TypeClass> && sizeof(CType) == sizeof(int64_t))
+  void WriteDataValues(const ArrayType& arr) {
     ::arrow::internal::StringFormatter<typename CTypeTraits<CType>::ArrowType> fmt;
 
     static const std::string null_string = "0";
@@ -531,8 +528,8 @@ class ArrayWriter {
   }
 
   template <typename ArrayType>
-  enable_if_physical_floating_point<typename ArrayType::TypeClass> WriteDataValues(
-      const ArrayType& arr) {
+    requires arrow_physical_floating_point<typename ArrayType::TypeClass>
+  void WriteDataValues(const ArrayType& arr) {
     static const std::string null_string = "0";
     const auto data = arr.raw_values();
     for (int64_t i = 0; i < arr.length(); ++i) {
@@ -545,9 +542,8 @@ class ArrayWriter {
   }
 
   template <typename ArrayType, typename Type = typename ArrayType::TypeClass>
-  std::enable_if_t<is_base_binary_type<Type>::value ||
-                   is_fixed_size_binary_type<Type>::value>
-  WriteDataValues(const ArrayType& arr) {
+    requires(arrow_base_binary<Type> || arrow_fixed_size_binary<Type>)
+  void WriteDataValues(const ArrayType& arr) {
     for (int64_t i = 0; i < arr.length(); ++i) {
       if constexpr (Type::is_utf8) {
         // UTF8 string, write as is
@@ -763,10 +759,9 @@ class ArrayWriter {
   }
 
   template <typename ArrayType>
-  enable_if_t<std::is_base_of<PrimitiveArray, ArrayType>::value &&
-                  !is_binary_view_like_type<typename ArrayType::TypeClass>::value,
-              Status>
-  Visit(const ArrayType& array) {
+    requires(std::is_base_of_v<PrimitiveArray, ArrayType> &&
+             !arrow_binary_view_like<typename ArrayType::TypeClass>)
+  Status Visit(const ArrayType& array) {
     WriteValidityField(array);
     WriteDataField(array);
     SetNoChildren();
@@ -774,8 +769,8 @@ class ArrayWriter {
   }
 
   template <typename ArrayType>
-  enable_if_base_binary<typename ArrayType::TypeClass, Status> Visit(
-      const ArrayType& array) {
+    requires arrow_base_binary<typename ArrayType::TypeClass>
+  Status Visit(const ArrayType& array) {
     WriteValidityField(array);
     WriteIntegerField("OFFSET", array.raw_value_offsets(), array.length() + 1);
     WriteDataField(array);
@@ -784,8 +779,8 @@ class ArrayWriter {
   }
 
   template <typename ArrayType>
-  enable_if_binary_view_like<typename ArrayType::TypeClass, Status> Visit(
-      const ArrayType& array) {
+    requires arrow_binary_view_like<typename ArrayType::TypeClass>
+  Status Visit(const ArrayType& array) {
     WriteValidityField(array);
     WriteBinaryViewField(array);
     WriteVariadicBuffersField(array);
@@ -799,16 +794,16 @@ class ArrayWriter {
   }
 
   template <typename ArrayType>
-  enable_if_var_size_list<typename ArrayType::TypeClass, Status> Visit(
-      const ArrayType& array) {
+    requires arrow_var_length_list<typename ArrayType::TypeClass>
+  Status Visit(const ArrayType& array) {
     WriteValidityField(array);
     WriteIntegerField("OFFSET", array.raw_value_offsets(), array.length() + 1);
     return WriteChildren(array.type()->fields(), {array.values()});
   }
 
   template <typename ArrayType>
-  enable_if_list_view<typename ArrayType::TypeClass, Status> Visit(
-      const ArrayType& array) {
+    requires arrow_list_view<typename ArrayType::TypeClass>
+  Status Visit(const ArrayType& array) {
     WriteValidityField(array);
     WriteIntegerField("OFFSET", array.raw_value_offsets(), array.length());
     WriteIntegerField("SIZE", array.raw_value_sizes(), array.length());
@@ -1323,22 +1318,22 @@ Result<std::shared_ptr<Field>> GetField(const rj::Value& obj, FieldPosition fiel
   return field;
 }
 
-template <typename T>
-enable_if_boolean<T, bool> UnboxValue(const rj::Value& val) {
+template <arrow_boolean T>
+bool UnboxValue(const rj::Value& val) {
   DCHECK(val.IsBool());
   return val.GetBool();
 }
 
 template <typename T, typename CType = typename T::c_type>
-enable_if_t<is_physical_integer_type<T>::value && sizeof(CType) != sizeof(int64_t), CType>
-UnboxValue(const rj::Value& val) {
+  requires(arrow_physical_integer<T> && sizeof(CType) != sizeof(int64_t))
+CType UnboxValue(const rj::Value& val) {
   DCHECK(val.IsInt64());
   return static_cast<CType>(val.GetInt64());
 }
 
 template <typename T, typename CType = typename T::c_type>
-enable_if_t<is_physical_integer_type<T>::value && sizeof(CType) == sizeof(int64_t), CType>
-UnboxValue(const rj::Value& val) {
+  requires(arrow_physical_integer<T> && sizeof(CType) == sizeof(int64_t))
+CType UnboxValue(const rj::Value& val) {
   DCHECK(val.IsString());
 
   CType out;
@@ -1350,8 +1345,8 @@ UnboxValue(const rj::Value& val) {
 }
 
 template <typename T>
-enable_if_physical_floating_point<T, typename T::c_type> UnboxValue(
-    const rj::Value& val) {
+  requires arrow_physical_floating_point<T>
+typename T::c_type UnboxValue(const rj::Value& val) {
   DCHECK(val.IsFloat());
   return static_cast<typename T::c_type>(val.GetDouble());
 }
@@ -1380,7 +1375,8 @@ class ArrayReader {
   }
 
   template <typename T>
-  enable_if_has_c_type<T, Status> Visit(const T& type) {
+    requires arrow_has_c_type<T>
+  Status Visit(const T& type) {
     typename TypeTraits<T>::BuilderType builder(type_, pool_);
 
     ARROW_ASSIGN_OR_RAISE(const auto json_data_arr, GetDataArray(obj_));
@@ -1401,7 +1397,8 @@ class ArrayReader {
   }
 
   template <typename T>
-  enable_if_base_binary<T, Status> Visit(const T& type) {
+    requires arrow_base_binary<T>
+  Status Visit(const T& type) {
     typename TypeTraits<T>::BuilderType builder(pool_);
     using offset_type = typename T::offset_type;
 
@@ -1455,7 +1452,8 @@ class ArrayReader {
   }
 
   template <typename ViewType>
-  enable_if_binary_view_like<ViewType, Status> Visit(const ViewType& type) {
+    requires arrow_binary_view_like<ViewType>
+  Status Visit(const ViewType& type) {
     ARROW_ASSIGN_OR_RAISE(const auto json_views, GetDataArray(obj_, "VIEWS"));
     ARROW_ASSIGN_OR_RAISE(const auto json_variadic_bufs,
                           GetMemberArray(obj_, "VARIADIC_DATA_BUFFERS"));
@@ -1585,8 +1583,8 @@ class ArrayReader {
   }
 
   template <typename T>
-  enable_if_t<is_fixed_size_binary_type<T>::value && !is_decimal_type<T>::value, Status>
-  Visit(const T& type) {
+    requires(arrow_fixed_size_binary<T> && !arrow_decimal<T>)
+  Status Visit(const T& type) {
     typename TypeTraits<T>::BuilderType builder(type_, pool_);
 
     ARROW_ASSIGN_OR_RAISE(const auto json_data_arr, GetDataArray(obj_));
@@ -1620,7 +1618,8 @@ class ArrayReader {
   }
 
   template <typename T>
-  enable_if_decimal<T, Status> Visit(const T& type) {
+    requires arrow_decimal<T>
+  Status Visit(const T& type) {
     typename TypeTraits<T>::BuilderType builder(type_, pool_);
 
     ARROW_ASSIGN_OR_RAISE(const auto json_data_arr, GetDataArray(obj_));
@@ -1701,7 +1700,8 @@ class ArrayReader {
   }
 
   template <typename T>
-  enable_if_var_size_list<T, Status> Visit(const T& type) {
+    requires arrow_var_length_list<T>
+  Status Visit(const T& type) {
     return CreateList<T>(type_);
   }
 
@@ -1721,7 +1721,8 @@ class ArrayReader {
   }
 
   template <typename T>
-  enable_if_list_view<T, Status> Visit(const T& type) {
+    requires arrow_list_view<T>
+  Status Visit(const T& type) {
     return CreateListView<T>(type_);
   }
 

--- a/cpp/src/arrow/ipc/feather.cc
+++ b/cpp/src/arrow/ipc/feather.cc
@@ -537,24 +537,19 @@ struct ArrayWriterV1 {
   }
 
   template <typename T>
-  typename std::enable_if<
-      is_nested_type<T>::value || is_null_type<T>::value || is_decimal_type<T>::value ||
-          std::is_same<DictionaryType, T>::value || is_duration_type<T>::value ||
-          is_interval_type<T>::value || is_fixed_size_binary_type<T>::value ||
-          is_binary_view_like_type<T>::value || std::is_same<Date64Type, T>::value ||
-          std::is_same<Time64Type, T>::value || std::is_same<ExtensionType, T>::value,
-      Status>::type
-  Visit(const T& type) {
+    requires(arrow_nested<T> || arrow_null<T> || arrow_decimal<T> ||
+             std::is_same_v<DictionaryType, T> || arrow_duration<T> ||
+             arrow_interval<T> || arrow_fixed_size_binary<T> ||
+             arrow_binary_view_like<T> || std::is_same_v<Date64Type, T> ||
+             std::is_same_v<Time64Type, T> || std::is_same_v<ExtensionType, T>)
+  Status Visit(const T& type) {
     return Status::NotImplemented(type.ToString());
   }
 
   template <typename T>
-  typename std::enable_if<is_number_type<T>::value ||
-                              std::is_same<Date32Type, T>::value ||
-                              std::is_same<Time32Type, T>::value ||
-                              is_timestamp_type<T>::value || is_boolean_type<T>::value,
-                          Status>::type
-  Visit(const T&) {
+    requires(arrow_number<T> || std::is_same_v<Date32Type, T> ||
+             std::is_same_v<Time32Type, T> || arrow_timestamp<T> || arrow_boolean<T>)
+  Status Visit(const T&) {
     const auto& prim_values = checked_cast<const PrimitiveArray&>(values);
     const auto& fw_type = checked_cast<const FixedWidthType&>(*values.type());
 
@@ -572,7 +567,8 @@ struct ArrayWriterV1 {
   }
 
   template <typename T>
-  enable_if_base_binary<T, Status> Visit(const T&) {
+    requires arrow_base_binary<T>
+  Status Visit(const T&) {
     using ArrayType = typename TypeTraits<T>::ArrayType;
     const auto& ty_values = checked_cast<const ArrayType&>(values);
 

--- a/cpp/src/arrow/ipc/metadata_internal.cc
+++ b/cpp/src/arrow/ipc/metadata_internal.cc
@@ -533,8 +533,8 @@ class FieldToFlatbufferVisitor {
     return Status::OK();
   }
 
-  template <typename T>
-  enable_if_integer<T, Status> Visit(const T& type) {
+  template <arrow_integer T>
+  Status Visit(const T& type) {
     constexpr bool is_signed = is_signed_integer_type<T>::value;
     return Visit<sizeof(typename T::c_type) * 8, is_signed>(type);
   }

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -413,16 +413,16 @@ class ArrayLoader {
   }
 
   template <typename T>
-  enable_if_t<std::is_base_of<FixedWidthType, T>::value &&
-                  !std::is_base_of<FixedSizeBinaryType, T>::value &&
-                  !std::is_base_of<DictionaryType, T>::value,
-              Status>
-  Visit(const T& type) {
+    requires(std::is_base_of_v<FixedWidthType, T> &&
+             !std::is_base_of_v<FixedSizeBinaryType, T> &&
+             !std::is_base_of_v<DictionaryType, T>)
+  Status Visit(const T& type) {
     return LoadPrimitive<T>(type.id());
   }
 
   template <typename T>
-  enable_if_base_binary<T, Status> Visit(const T& type) {
+    requires arrow_base_binary<T>
+  Status Visit(const T& type) {
     return LoadBinary(type.id());
   }
 
@@ -443,12 +443,14 @@ class ArrayLoader {
   }
 
   template <typename T>
-  enable_if_var_size_list<T, Status> Visit(const T& type) {
+    requires arrow_var_length_list<T>
+  Status Visit(const T& type) {
     return LoadList(type);
   }
 
   template <typename T>
-  enable_if_list_view<T, Status> Visit(const T& type) {
+    requires arrow_list_view<T>
+  Status Visit(const T& type) {
     return LoadListView(type);
   }
 

--- a/cpp/src/arrow/ipc/test_common.cc
+++ b/cpp/src/arrow/ipc/test_common.cc
@@ -1174,24 +1174,22 @@ void FillRandomData(CValueType* data, size_t n, CValueType min, CValueType max,
 }
 
 template <typename CValueType, typename SeedType>
-enable_if_t<std::is_integral<CValueType>::value && std::is_signed<CValueType>::value,
-            void>
-FillRandomData(CValueType* data, size_t n, SeedType seed) {
+  requires(std::integral<CValueType> && std::signed_integral<CValueType>)
+void FillRandomData(CValueType* data, size_t n, SeedType seed) {
   FillRandomData<CValueType, SeedType, std::uniform_int_distribution<CValueType>>(
       data, n, -1000, 1000, seed);
 }
 
 template <typename CValueType, typename SeedType>
-enable_if_t<std::is_integral<CValueType>::value && std::is_unsigned<CValueType>::value,
-            void>
-FillRandomData(CValueType* data, size_t n, SeedType seed) {
+  requires(std::integral<CValueType> && std::unsigned_integral<CValueType>)
+void FillRandomData(CValueType* data, size_t n, SeedType seed) {
   FillRandomData<CValueType, SeedType, std::uniform_int_distribution<CValueType>>(
       data, n, 0, 1000, seed);
 }
 
 template <typename CValueType, typename SeedType>
-enable_if_t<std::is_floating_point<CValueType>::value, void> FillRandomData(
-    CValueType* data, size_t n, SeedType seed) {
+  requires std::floating_point<CValueType>
+void FillRandomData(CValueType* data, size_t n, SeedType seed) {
   FillRandomData<CValueType, SeedType, std::uniform_real_distribution<CValueType>>(
       data, n, -1000, 1000, seed);
 }

--- a/cpp/src/arrow/ipc/writer.cc
+++ b/cpp/src/arrow/ipc/writer.cc
@@ -440,11 +440,10 @@ class RecordBatchSerializer {
   Status Visit(const NullArray& array) { return Status::OK(); }
 
   template <typename T>
-  typename std::enable_if<is_number_type<typename T::TypeClass>::value ||
-                              is_temporal_type<typename T::TypeClass>::value ||
-                              is_fixed_size_binary_type<typename T::TypeClass>::value,
-                          Status>::type
-  Visit(const T& array) {
+    requires(arrow_number<typename T::TypeClass> ||
+             arrow_temporal<typename T::TypeClass> ||
+             arrow_fixed_size_binary<typename T::TypeClass>)
+  Status Visit(const T& array) {
     std::shared_ptr<Buffer> data = array.values();
 
     const int64_t type_width = array.type()->byte_width();
@@ -465,7 +464,8 @@ class RecordBatchSerializer {
   }
 
   template <typename T>
-  enable_if_base_binary<typename T::TypeClass, Status> Visit(const T& array) {
+    requires arrow_base_binary<typename T::TypeClass>
+  Status Visit(const T& array) {
     using offset_type = typename T::offset_type;
 
     std::shared_ptr<Buffer> value_offsets;
@@ -508,7 +508,8 @@ class RecordBatchSerializer {
   }
 
   template <typename T>
-  enable_if_var_size_list<typename T::TypeClass, Status> Visit(const T& array) {
+    requires arrow_var_length_list<typename T::TypeClass>
+  Status Visit(const T& array) {
     using offset_type = typename T::offset_type;
 
     std::shared_ptr<Buffer> value_offsets;
@@ -542,7 +543,8 @@ class RecordBatchSerializer {
   }
 
   template <typename T>
-  enable_if_list_view<typename T::TypeClass, Status> Visit(const T& array) {
+    requires arrow_list_view<typename T::TypeClass>
+  Status Visit(const T& array) {
     using offset_type = typename T::offset_type;
 
     offset_type min_offset = 0;

--- a/cpp/src/arrow/json/from_string.cc
+++ b/cpp/src/arrow/json/from_string.cc
@@ -213,10 +213,9 @@ class BooleanConverter final : public ConcreteConverter<BooleanConverter> {
 // Helpers for numeric converters
 
 // Convert single signed integer value (also {Date,Time}{32,64} and Timestamp)
-template <typename T>
-enable_if_physical_signed_integer<T, Status> ConvertNumber(const rj::Value& json_obj,
-                                                           const DataType& type,
-                                                           typename T::c_type* out) {
+template <arrow_physical_signed_integer T>
+Status ConvertNumber(const rj::Value& json_obj, const DataType& type,
+                     typename T::c_type* out) {
   if (json_obj.IsInt64()) {
     int64_t v64 = json_obj.GetInt64();
     *out = static_cast<typename T::c_type>(v64);
@@ -232,10 +231,9 @@ enable_if_physical_signed_integer<T, Status> ConvertNumber(const rj::Value& json
 }
 
 // Convert single unsigned integer value
-template <typename T>
-enable_if_unsigned_integer<T, Status> ConvertNumber(const rj::Value& json_obj,
-                                                    const DataType& type,
-                                                    typename T::c_type* out) {
+template <arrow_unsigned_integer T>
+Status ConvertNumber(const rj::Value& json_obj, const DataType& type,
+                     typename T::c_type* out) {
   if (json_obj.IsUint64()) {
     uint64_t v64 = json_obj.GetUint64();
     *out = static_cast<typename T::c_type>(v64);
@@ -251,9 +249,8 @@ enable_if_unsigned_integer<T, Status> ConvertNumber(const rj::Value& json_obj,
 }
 
 // Convert float16/HalfFloatType
-template <typename T>
-enable_if_half_float<T, Status> ConvertNumber(const rj::Value& json_obj,
-                                              const DataType& type, uint16_t* out) {
+template <arrow_half_float T>
+Status ConvertNumber(const rj::Value& json_obj, const DataType& type, uint16_t* out) {
   if (json_obj.IsDouble()) {
     double f64 = json_obj.GetDouble();
     *out = Float16(f64).bits();
@@ -275,10 +272,9 @@ enable_if_half_float<T, Status> ConvertNumber(const rj::Value& json_obj,
 }
 
 // Convert single floating point value
-template <typename T>
-enable_if_physical_floating_point<T, Status> ConvertNumber(const rj::Value& json_obj,
-                                                           const DataType& type,
-                                                           typename T::c_type* out) {
+template <arrow_physical_floating_point T>
+Status ConvertNumber(const rj::Value& json_obj, const DataType& type,
+                     typename T::c_type* out) {
   if (json_obj.IsNumber()) {
     *out = static_cast<typename T::c_type>(json_obj.GetDouble());
     return Status::OK();

--- a/cpp/src/arrow/json/parser.cc
+++ b/cpp/src/arrow/json/parser.cc
@@ -462,7 +462,8 @@ class RawBuilderSet {
 
   /// Retrieve a pointer to a builder from a BuilderPtr
   template <Kind::type kind>
-  enable_if_t<kind != Kind::kNull, RawArrayBuilder<kind>*> Cast(BuilderPtr builder) {
+    requires(kind != Kind::kNull)
+  RawArrayBuilder<kind>* Cast(BuilderPtr builder) {
     DCHECK_EQ(builder.kind, kind);
     return arena<kind>().data() + builder.index;
   }
@@ -658,7 +659,8 @@ class HandlerBase : public BlockParser,
 
   /// Retrieve a pointer to a builder from a BuilderPtr
   template <Kind::type kind>
-  enable_if_t<kind != Kind::kNull, RawArrayBuilder<kind>*> Cast(BuilderPtr builder) {
+    requires(kind != Kind::kNull)
+  RawArrayBuilder<kind>* Cast(BuilderPtr builder) {
     return builder_set_.Cast<kind>(builder);
   }
 

--- a/cpp/src/arrow/json/test_common.h
+++ b/cpp/src/arrow/json/test_common.h
@@ -35,6 +35,7 @@
 #include "arrow/testing/gtest_util.h"
 #include "arrow/testing/random.h"
 #include "arrow/type.h"
+#include "arrow/type_traits.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/visit_type_inline.h"
 
@@ -93,20 +94,20 @@ struct GenerateImpl {
     return OK(writer.Bool(std::uniform_int_distribution<uint16_t>{}(e) & 1));
   }
 
-  template <typename T>
-  enable_if_physical_unsigned_integer<T, Status> Visit(const T&) {
+  template <arrow_physical_unsigned_integer T>
+  Status Visit(const T&) {
     auto val = std::uniform_int_distribution<>{}(e);
     return OK(writer.Uint64(static_cast<typename T::c_type>(val)));
   }
 
-  template <typename T>
-  enable_if_physical_signed_integer<T, Status> Visit(const T&) {
+  template <arrow_physical_signed_integer T>
+  Status Visit(const T&) {
     auto val = std::uniform_int_distribution<>{}(e);
     return OK(writer.Int64(static_cast<typename T::c_type>(val)));
   }
 
-  template <typename T>
-  enable_if_physical_floating_point<T, Status> Visit(const T&) {
+  template <arrow_physical_floating_point T>
+  Status Visit(const T&) {
     auto val = std::normal_distribution<typename T::c_type>{0, 1 << 10}(e);
     return OK(writer.Double(val));
   }
@@ -118,15 +119,15 @@ struct GenerateImpl {
     return OK(writer.String(s));
   }
 
-  template <typename T>
-  enable_if_base_binary<T, Status> Visit(const T& t) {
+  template <arrow_base_binary T>
+  Status Visit(const T& t) {
     return GenerateUtf8(t);
   }
 
   Status Visit(const BinaryViewType& t) { return GenerateUtf8(t); }
 
-  template <typename T>
-  enable_if_list_like<T, Status> Visit(const T& t) {
+  template <arrow_list_like T>
+  Status Visit(const T& t) {
     auto size = std::poisson_distribution<>{4}(e);
     writer.StartArray();
     for (int i = 0; i < size; ++i) {

--- a/cpp/src/arrow/pretty_print.cc
+++ b/cpp/src/arrow/pretty_print.cc
@@ -235,12 +235,14 @@ class ArrayPrinter : public PrettyPrinter {
   //
 
   template <typename ArrayType, typename T = typename ArrayType::TypeClass>
-  enable_if_has_c_type<T, Status> WriteDataValues(const ArrayType& array) {
+    requires arrow_has_c_type<T>
+  Status WriteDataValues(const ArrayType& array) {
     return WritePrimitiveValues(array);
   }
 
   template <typename ArrayType, typename T = typename ArrayType::TypeClass>
-  enable_if_has_string_view<T, Status> WriteDataValues(const ArrayType& array) {
+    requires arrow_has_string_view<T>
+  Status WriteDataValues(const ArrayType& array) {
     return WriteValues(array, [&](int64_t i) {
       if constexpr (T::is_utf8) {
         (*sink_) << "\"";
@@ -254,7 +256,8 @@ class ArrayPrinter : public PrettyPrinter {
   }
 
   template <typename ArrayType, typename T = typename ArrayType::TypeClass>
-  enable_if_decimal<T, Status> WriteDataValues(const ArrayType& array) {
+    requires arrow_decimal<T>
+  Status WriteDataValues(const ArrayType& array) {
     return WriteValues(array, [&](int64_t i) {
       this->Write(array.FormatValue(i));
       return Status::OK();
@@ -262,8 +265,8 @@ class ArrayPrinter : public PrettyPrinter {
   }
 
   template <typename ArrayType, typename T = typename ArrayType::TypeClass>
-  enable_if_t<is_list_like_type<T>::value || is_list_view_type<T>::value, Status>
-  WriteDataValues(const ArrayType& array) {
+    requires(arrow_list_like<T> || arrow_list_view<T>)
+  Status WriteDataValues(const ArrayType& array) {
     const auto values = array.values();
     const auto child_options = ChildOptions();
     ArrayPrinter values_printer(child_options, sink_);
@@ -307,19 +310,16 @@ class ArrayPrinter : public PrettyPrinter {
 
  public:
   template <typename T>
-  enable_if_t<std::is_base_of<PrimitiveArray, T>::value ||
-                  std::is_base_of<FixedSizeBinaryArray, T>::value ||
-                  std::is_base_of<BinaryArray, T>::value ||
-                  std::is_base_of<LargeBinaryArray, T>::value ||
-                  std::is_base_of<BinaryViewArray, T>::value ||
-                  std::is_base_of<ListArray, T>::value ||
-                  std::is_base_of<LargeListArray, T>::value ||
-                  std::is_base_of<ListViewArray, T>::value ||
-                  std::is_base_of<LargeListViewArray, T>::value ||
-                  std::is_base_of<MapArray, T>::value ||
-                  std::is_base_of<FixedSizeListArray, T>::value,
-              Status>
-  Visit(const T& array) {
+    requires(std::is_base_of_v<PrimitiveArray, T> ||
+             std::is_base_of_v<FixedSizeBinaryArray, T> ||
+             std::is_base_of_v<BinaryArray, T> ||
+             std::is_base_of_v<LargeBinaryArray, T> ||
+             std::is_base_of_v<BinaryViewArray, T> || std::is_base_of_v<ListArray, T> ||
+             std::is_base_of_v<LargeListArray, T> ||
+             std::is_base_of_v<ListViewArray, T> ||
+             std::is_base_of_v<LargeListViewArray, T> || std::is_base_of_v<MapArray, T> ||
+             std::is_base_of_v<FixedSizeListArray, T>)
+  Status Visit(const T& array) {
     Status st = array.Validate();
     if (!st.ok()) {
       (*sink_) << "<Invalid array: " << st.message() << ">";

--- a/cpp/src/arrow/record_batch.cc
+++ b/cpp/src/arrow/record_batch.cc
@@ -626,9 +626,8 @@ Status EnumerateStatistics(const RecordBatch& record_batch, OnStatistics on_stat
 }
 struct StringBuilderVisitor {
   template <typename DataType>
-  enable_if_has_string_view<DataType, Status> Visit(const DataType&,
-                                                    ArrayBuilder* raw_builder,
-                                                    const std::string& value) {
+    requires arrow_has_string_view<DataType>
+  Status Visit(const DataType&, ArrayBuilder* raw_builder, const std::string& value) {
     using Builder = typename TypeTraits<DataType>::BuilderType;
     auto builder = static_cast<Builder*>(raw_builder);
     return builder->Append(value);

--- a/cpp/src/arrow/record_batch_test.cc
+++ b/cpp/src/arrow/record_batch_test.cc
@@ -1218,9 +1218,8 @@ TEST_F(TestRecordBatch, ToTensorUnsupportedMixedFloat16) {
 }
 
 namespace {
-template <typename ArrowType,
-          typename = std::enable_if_t<is_boolean_type<ArrowType>::value ||
-                                      is_number_type<ArrowType>::value>>
+template <typename ArrowType>
+  requires(arrow_boolean<ArrowType> || arrow_number<ArrowType>)
 Result<std::shared_ptr<Array>> BuildArray(
     const std::vector<typename TypeTraits<ArrowType>::CType>& values) {
   using BuilderType = typename TypeTraits<ArrowType>::BuilderType;
@@ -1232,9 +1231,9 @@ Result<std::shared_ptr<Array>> BuildArray(
 }
 struct StringBuilderVisitor {
   template <typename DataType>
-  enable_if_t<has_string_view<DataType>::value, Status> Visit(
-      const DataType&, ArrayBuilder* raw_builder,
-      const std::vector<std::string>& values) {
+    requires arrow_has_string_view<DataType>
+  Status Visit(const DataType&, ArrayBuilder* raw_builder,
+               const std::vector<std::string>& values) {
     using Builder = typename TypeTraits<DataType>::BuilderType;
     auto builder = static_cast<Builder*>(raw_builder);
     for (const auto& value : values) {
@@ -1268,8 +1267,8 @@ std::vector<RawType> StatisticsValuesToRawValues(
   return raw_values;
 }
 
-template <typename ValueType, typename = std::enable_if_t<std::is_same<
-                                  ArrayStatistics::ValueType, ValueType>::value>>
+template <typename ValueType>
+  requires std::same_as<ArrayStatistics::ValueType, ValueType>
 Result<std::shared_ptr<Array>> BuildArray(const std::vector<ValueType>& values,
                                           const std::shared_ptr<DataType>& array_type) {
   struct Builder {

--- a/cpp/src/arrow/result.h
+++ b/cpp/src/arrow/result.h
@@ -202,9 +202,8 @@ class [[nodiscard]] Result : public util::EqualityComparable<Result<T>> {
   /// `T` must be implicitly constructible from `const U &`.
   ///
   /// \param other The value to copy from.
-  template <typename U, typename E = typename std::enable_if<
-                            std::is_constructible<T, const U&>::value &&
-                            std::is_convertible<U, T>::value>::type>
+  template <typename U>
+    requires(std::is_constructible_v<T, const U&> && std::is_convertible_v<U, T>)
   Result(const Result<U>& other) noexcept : status_(other.status_) {
     if (ARROW_PREDICT_TRUE(status_.ok())) {
       ConstructValue(other.ValueUnsafe());
@@ -235,9 +234,8 @@ class [[nodiscard]] Result : public util::EqualityComparable<Result<T>> {
   /// error code.
   ///
   /// \param other The Result object to move from and set to a non-OK status.
-  template <typename U,
-            typename E = typename std::enable_if<std::is_constructible<T, U&&>::value &&
-                                                 std::is_convertible<U, T>::value>::type>
+  template <typename U>
+    requires(std::is_constructible_v<T, U &&> && std::is_convertible_v<U, T>)
   Result(Result<U>&& other) noexcept {
     if (ARROW_PREDICT_TRUE(other.status_.ok())) {
       status_ = std::move(other.status_);
@@ -359,8 +357,8 @@ class [[nodiscard]] Result : public util::EqualityComparable<Result<T>> {
   /// equivalent Result returning functions. For example:
   ///
   /// Status GetInt(int *out) { return GetInt().Value(out); }
-  template <typename U, typename E = typename std::enable_if<
-                            std::is_constructible<U, T>::value>::type>
+  template <typename U>
+    requires std::is_constructible_v<U, T>
   Status Value(U* out) && {
     if (!ok()) {
       return std::move(*this).status();
@@ -419,8 +417,8 @@ class [[nodiscard]] Result : public util::EqualityComparable<Result<T>> {
 
   /// Cast the internally stored value to produce a new result or propagate the stored
   /// error.
-  template <typename U, typename E = typename std::enable_if<
-                            std::is_constructible<U, T>::value>::type>
+  template <typename U>
+    requires std::is_constructible_v<U, T>
   Result<U> As() && {
     if (!ok()) {
       return std::move(*this).status();
@@ -430,8 +428,8 @@ class [[nodiscard]] Result : public util::EqualityComparable<Result<T>> {
 
   /// Cast the internally stored value to produce a new result or propagate the stored
   /// error.
-  template <typename U, typename E = typename std::enable_if<
-                            std::is_constructible<U, const T&>::value>::type>
+  template <typename U>
+    requires std::is_constructible_v<U, const T&>
   Result<U> As() const& {
     if (!ok()) {
       return status();

--- a/cpp/src/arrow/scalar.cc
+++ b/cpp/src/arrow/scalar.cc
@@ -229,7 +229,8 @@ struct ScalarBoundsCheckImpl {
   }
 
   template <typename ScalarType, typename Type = typename ScalarType::TypeClass>
-  enable_if_integer<Type, Status> Visit(const ScalarType& scalar) {
+    requires arrow_integer<Type>
+  Status Visit(const ScalarType& scalar) {
     actual_value = static_cast<int64_t>(scalar.value);
     ok = (actual_value >= min_value && actual_value <= max_value);
     return Status::OK();
@@ -883,23 +884,20 @@ template <typename T>
 using scalar_constructor_has_arrow_type =
     std::is_constructible<typename TypeTraits<T>::ScalarType, std::shared_ptr<DataType>>;
 
-template <typename T, typename R = void>
-using enable_if_scalar_constructor_has_arrow_type =
-    typename std::enable_if<scalar_constructor_has_arrow_type<T>::value, R>::type;
-
-template <typename T, typename R = void>
-using enable_if_scalar_constructor_has_no_arrow_type =
-    typename std::enable_if<!scalar_constructor_has_arrow_type<T>::value, R>::type;
+template <typename T>
+concept scalar_constructor_has_arrow_type_v = scalar_constructor_has_arrow_type<T>::value;
 
 struct MakeNullImpl {
   template <typename T, typename ScalarType = typename TypeTraits<T>::ScalarType>
-  enable_if_scalar_constructor_has_arrow_type<T, Status> Visit(const T&) {
+    requires scalar_constructor_has_arrow_type_v<T>
+  Status Visit(const T&) {
     out_ = std::make_shared<ScalarType>(type_);
     return Status::OK();
   }
 
   template <typename T, typename ScalarType = typename TypeTraits<T>::ScalarType>
-  enable_if_scalar_constructor_has_no_arrow_type<T, Status> Visit(const T&) {
+    requires(!scalar_constructor_has_arrow_type_v<T>)
+  Status Visit(const T&) {
     out_ = std::make_shared<ScalarType>();
     return Status::OK();
   }
@@ -1018,7 +1016,8 @@ std::string Scalar::ToString() const {
 }
 
 struct ScalarParseImpl {
-  template <typename T, typename = internal::enable_if_parseable<T>>
+  template <typename T>
+    requires internal::is_parseable<T>::value
   Status Visit(const T& t) {
     typename internal::StringConverter<T>::value_type value;
     if (!internal::ParseValue(t, s_.data(), s_.size(), &value)) {
@@ -1100,8 +1099,9 @@ Result<std::shared_ptr<Scalar>> CastImpl(const Scalar& from,
 
 // numeric to numeric
 template <typename To, typename From>
-enable_if_number<To, Result<std::shared_ptr<Scalar>>> CastImpl(
-    const NumericScalar<From>& from, std::shared_ptr<DataType> to_type) {
+  requires arrow_number<To>
+Result<std::shared_ptr<Scalar>> CastImpl(const NumericScalar<From>& from,
+                                         std::shared_ptr<DataType> to_type) {
   using ToScalar = typename TypeTraits<To>::ScalarType;
   return std::make_shared<ToScalar>(static_cast<typename To::c_type>(from.value),
                                     std::move(to_type));
@@ -1109,16 +1109,18 @@ enable_if_number<To, Result<std::shared_ptr<Scalar>>> CastImpl(
 
 // numeric to boolean
 template <typename To, typename From>
-enable_if_boolean<To, Result<std::shared_ptr<Scalar>>> CastImpl(
-    const NumericScalar<From>& from, std::shared_ptr<DataType> to_type) {
+  requires arrow_boolean<To>
+Result<std::shared_ptr<Scalar>> CastImpl(const NumericScalar<From>& from,
+                                         std::shared_ptr<DataType> to_type) {
   constexpr auto zero = static_cast<typename From::c_type>(0);
   return std::make_shared<BooleanScalar>(from.value != zero, std::move(to_type));
 }
 
 // boolean to numeric
 template <typename To>
-enable_if_number<To, Result<std::shared_ptr<Scalar>>> CastImpl(
-    const BooleanScalar& from, std::shared_ptr<DataType> to_type) {
+  requires arrow_number<To>
+Result<std::shared_ptr<Scalar>> CastImpl(const BooleanScalar& from,
+                                         std::shared_ptr<DataType> to_type) {
   using ToScalar = typename TypeTraits<To>::ScalarType;
   return std::make_shared<ToScalar>(static_cast<typename To::c_type>(from.value),
                                     std::move(to_type));
@@ -1126,11 +1128,11 @@ enable_if_number<To, Result<std::shared_ptr<Scalar>>> CastImpl(
 
 // numeric to temporal
 template <typename To, typename From>
-typename std::enable_if<std::is_base_of<TemporalType, To>::value &&
-                            !std::is_same<DayTimeIntervalType, To>::value &&
-                            !std::is_same<MonthDayNanoIntervalType, To>::value,
-                        Result<std::shared_ptr<Scalar>>>::type
-CastImpl(const NumericScalar<From>& from, std::shared_ptr<DataType> to_type) {
+  requires(std::is_base_of_v<TemporalType, To> &&
+           !std::is_same_v<DayTimeIntervalType, To> &&
+           !std::is_same_v<MonthDayNanoIntervalType, To>)
+Result<std::shared_ptr<Scalar>> CastImpl(const NumericScalar<From>& from,
+                                         std::shared_ptr<DataType> to_type) {
   using ToScalar = typename TypeTraits<To>::ScalarType;
   return std::make_shared<ToScalar>(static_cast<typename To::c_type>(from.value),
                                     std::move(to_type));
@@ -1138,12 +1140,11 @@ CastImpl(const NumericScalar<From>& from, std::shared_ptr<DataType> to_type) {
 
 // temporal to numeric
 template <typename To, typename From>
-typename std::enable_if<is_number_type<To>::value &&
-                            std::is_base_of<TemporalType, From>::value &&
-                            !std::is_same<DayTimeIntervalType, From>::value &&
-                            !std::is_same<MonthDayNanoIntervalType, From>::value,
-                        Result<std::shared_ptr<Scalar>>>::type
-CastImpl(const TemporalScalar<From>& from, std::shared_ptr<DataType> to_type) {
+  requires(arrow_number<To> && std::is_base_of_v<TemporalType, From> &&
+           !std::is_same_v<DayTimeIntervalType, From> &&
+           !std::is_same_v<MonthDayNanoIntervalType, From>)
+Result<std::shared_ptr<Scalar>> CastImpl(const TemporalScalar<From>& from,
+                                         std::shared_ptr<DataType> to_type) {
   using ToScalar = typename TypeTraits<To>::ScalarType;
   return std::make_shared<ToScalar>(static_cast<typename To::c_type>(from.value),
                                     std::move(to_type));
@@ -1151,8 +1152,9 @@ CastImpl(const TemporalScalar<From>& from, std::shared_ptr<DataType> to_type) {
 
 // timestamp to timestamp
 template <typename To>
-enable_if_timestamp<To, Result<std::shared_ptr<Scalar>>> CastImpl(
-    const TimestampScalar& from, std::shared_ptr<DataType> to_type) {
+  requires arrow_timestamp<To>
+Result<std::shared_ptr<Scalar>> CastImpl(const TimestampScalar& from,
+                                         std::shared_ptr<DataType> to_type) {
   using ToScalar = typename TypeTraits<To>::ScalarType;
   ARROW_ASSIGN_OR_RAISE(auto value,
                         util::ConvertTimestampValue(from.type, to_type, from.value));
@@ -1166,8 +1168,9 @@ std::shared_ptr<DataType> AsTimestampType(const std::shared_ptr<DataType>& type)
 
 // duration to duration
 template <typename To>
-enable_if_duration<To, Result<std::shared_ptr<Scalar>>> CastImpl(
-    const DurationScalar& from, std::shared_ptr<DataType> to_type) {
+  requires arrow_duration<To>
+Result<std::shared_ptr<Scalar>> CastImpl(const DurationScalar& from,
+                                         std::shared_ptr<DataType> to_type) {
   using ToScalar = typename TypeTraits<To>::ScalarType;
   ARROW_ASSIGN_OR_RAISE(
       auto value,
@@ -1179,8 +1182,9 @@ enable_if_duration<To, Result<std::shared_ptr<Scalar>>> CastImpl(
 // time to time
 template <typename To, typename From,
           typename T = typename TypeTraits<To>::ScalarType::TypeClass>
-enable_if_time<To, Result<std::shared_ptr<Scalar>>> CastImpl(
-    const TimeScalar<From>& from, std::shared_ptr<DataType> to_type) {
+  requires arrow_time<To>
+Result<std::shared_ptr<Scalar>> CastImpl(const TimeScalar<From>& from,
+                                         std::shared_ptr<DataType> to_type) {
   using ToScalar = typename TypeTraits<To>::ScalarType;
   ARROW_ASSIGN_OR_RAISE(
       auto value, util::ConvertTimestampValue(AsTimestampType<From>(from.type),
@@ -1193,22 +1197,25 @@ constexpr int64_t kMillisecondsInDay = 86400000;
 
 // date to date
 template <typename To>
-enable_if_t<std::is_same<To, Date64Scalar>::value, Result<std::shared_ptr<Scalar>>>
-CastImpl(const Date32Scalar& from, std::shared_ptr<DataType> to_type) {
+  requires std::same_as<To, Date64Scalar>
+Result<std::shared_ptr<Scalar>> CastImpl(const Date32Scalar& from,
+                                         std::shared_ptr<DataType> to_type) {
   return std::make_shared<Date64Scalar>(from.value * kMillisecondsInDay,
                                         std::move(to_type));
 }
 template <typename To>
-enable_if_t<std::is_same<To, Date32Scalar>::value, Result<std::shared_ptr<Scalar>>>
-CastImpl(const Date64Scalar& from, std::shared_ptr<DataType> to_type) {
+  requires std::same_as<To, Date32Scalar>
+Result<std::shared_ptr<Scalar>> CastImpl(const Date64Scalar& from,
+                                         std::shared_ptr<DataType> to_type) {
   return std::make_shared<Date32Scalar>(
       static_cast<int32_t>(from.value / kMillisecondsInDay), std::move(to_type));
 }
 
 // timestamp to date
 template <typename To>
-enable_if_t<std::is_same<To, Date64Scalar>::value, Result<std::shared_ptr<Scalar>>>
-CastImpl(const TimestampScalar& from, std::shared_ptr<DataType> to_type) {
+  requires std::same_as<To, Date64Scalar>
+Result<std::shared_ptr<Scalar>> CastImpl(const TimestampScalar& from,
+                                         std::shared_ptr<DataType> to_type) {
   ARROW_ASSIGN_OR_RAISE(
       auto millis,
       util::ConvertTimestampValue(from.type, timestamp(TimeUnit::MILLI), from.value));
@@ -1216,8 +1223,9 @@ CastImpl(const TimestampScalar& from, std::shared_ptr<DataType> to_type) {
                                         std::move(to_type));
 }
 template <typename To>
-enable_if_t<std::is_same<To, Date32Scalar>::value, Result<std::shared_ptr<Scalar>>>
-CastImpl(const TimestampScalar& from, std::shared_ptr<DataType> to_type) {
+  requires std::same_as<To, Date32Scalar>
+Result<std::shared_ptr<Scalar>> CastImpl(const TimestampScalar& from,
+                                         std::shared_ptr<DataType> to_type) {
   ARROW_ASSIGN_OR_RAISE(
       auto millis,
       util::ConvertTimestampValue(from.type, timestamp(TimeUnit::MILLI), from.value));
@@ -1227,8 +1235,9 @@ CastImpl(const TimestampScalar& from, std::shared_ptr<DataType> to_type) {
 
 // date to timestamp
 template <typename To, typename From>
-enable_if_timestamp<Result<std::shared_ptr<To>>> CastImpl(
-    const DateScalar<From>& from, std::shared_ptr<DataType> to_type) {
+  requires arrow_timestamp<To>
+Result<std::shared_ptr<Scalar>> CastImpl(const DateScalar<From>& from,
+                                         std::shared_ptr<DataType> to_type) {
   using ToScalar = typename TypeTraits<To>::ScalarType;
   int64_t millis = from.value;
   if (std::is_same<From, Date32Type>::value) {
@@ -1252,11 +1261,10 @@ Result<std::shared_ptr<Scalar>> CastImpl(const StringScalar& from,
 
 // binary/large binary/large string to string
 template <typename To, typename From>
-enable_if_t<std::is_same<To, StringType>::value &&
-                std::is_base_of_v<BaseBinaryScalar, From> &&
-                !std::is_same<From, StringScalar>::value,
-            Result<std::shared_ptr<Scalar>>>
-CastImpl(const From& from, std::shared_ptr<DataType> to_type) {
+  requires(std::same_as<To, StringType> && std::is_base_of_v<BaseBinaryScalar, From> &&
+           !std::same_as<From, StringScalar>)
+Result<std::shared_ptr<Scalar>> CastImpl(const From& from,
+                                         std::shared_ptr<DataType> to_type) {
   return std::make_shared<StringScalar>(from.value, std::move(to_type));
 }
 
@@ -1266,18 +1274,18 @@ template <typename To, typename From, typename T = typename From::TypeClass,
           // note: Value unused but necessary to trigger SFINAE if Formatter is
           // undefined
           typename Value = typename Formatter::value_type>
-typename std::enable_if_t<std::is_same<To, StringType>::value,
-                          Result<std::shared_ptr<Scalar>>>
-CastImpl(const From& from, std::shared_ptr<DataType> to_type) {
+  requires std::same_as<To, StringType>
+Result<std::shared_ptr<Scalar>> CastImpl(const From& from,
+                                         std::shared_ptr<DataType> to_type) {
   return std::make_shared<StringScalar>(FormatToBuffer(Formatter{from.type.get()}, from),
                                         std::move(to_type));
 }
 
 // struct to string
 template <typename To>
-typename std::enable_if_t<std::is_same<To, StringType>::value,
-                          Result<std::shared_ptr<Scalar>>>
-CastImpl(const StructScalar& from, std::shared_ptr<DataType> to_type) {
+  requires std::same_as<To, StringType>
+Result<std::shared_ptr<Scalar>> CastImpl(const StructScalar& from,
+                                         std::shared_ptr<DataType> to_type) {
   std::stringstream ss;
   ss << '{';
   for (int i = 0; static_cast<size_t>(i) < from.value.size(); i++) {
@@ -1292,9 +1300,9 @@ CastImpl(const StructScalar& from, std::shared_ptr<DataType> to_type) {
 // casts between variable-length and fixed-length list types
 template <typename To, typename FromScalar,
           typename From = typename FromScalar::TypeClass>
-std::enable_if_t<is_list_type<To>::value && is_list_type<From>::value,
-                 Result<std::shared_ptr<Scalar>>>
-CastImpl(const FromScalar& from, std::shared_ptr<DataType> to_type) {
+  requires(arrow_list<To> && arrow_list<From>)
+Result<std::shared_ptr<Scalar>> CastImpl(const FromScalar& from,
+                                         std::shared_ptr<DataType> to_type) {
   if constexpr (sizeof(typename To::offset_type) < sizeof(int64_t)) {
     if (from.value->length() > std::numeric_limits<typename To::offset_type>::max()) {
       return Status::Invalid(from.type->ToString(), " too large to cast to ",
@@ -1317,9 +1325,9 @@ CastImpl(const FromScalar& from, std::shared_ptr<DataType> to_type) {
 
 // list based types (list, large list and map (fixed sized list too)) to string
 template <typename To>
-typename std::enable_if_t<std::is_same<To, StringType>::value,
-                          Result<std::shared_ptr<Scalar>>>
-CastImpl(const BaseListScalar& from, std::shared_ptr<DataType> to_type) {
+  requires std::same_as<To, StringType>
+Result<std::shared_ptr<Scalar>> CastImpl(const BaseListScalar& from,
+                                         std::shared_ptr<DataType> to_type) {
   std::stringstream ss;
   ss << from.type->ToString() << "[";
   for (int64_t i = 0; i < from.value->length(); i++) {
@@ -1333,9 +1341,9 @@ CastImpl(const BaseListScalar& from, std::shared_ptr<DataType> to_type) {
 
 // union types to string
 template <typename To>
-typename std::enable_if_t<std::is_same<To, StringType>::value,
-                          Result<std::shared_ptr<Scalar>>>
-CastImpl(const UnionScalar& from, std::shared_ptr<DataType> to_type) {
+  requires std::same_as<To, StringType>
+Result<std::shared_ptr<Scalar>> CastImpl(const UnionScalar& from,
+                                         std::shared_ptr<DataType> to_type) {
   const auto& union_ty = checked_cast<const UnionType&>(*from.type);
   std::stringstream ss;
   const Scalar* selected_value;
@@ -1378,8 +1386,8 @@ struct FromTypeVisitor : CastImplVisitor {
 
   // identity cast only for parameter free types
   template <typename T1 = ToType>
-  typename std::enable_if_t<TypeTraits<T1>::is_parameter_free, Status> Visit(
-      const ToType&) {
+    requires TypeTraits<T1>::is_parameter_free
+  Status Visit(const ToType&) {
     ARROW_ASSIGN_OR_RAISE(
         out_, MakeScalar(to_type_, checked_cast<const ToScalar&>(from_).value));
     return Status::OK();

--- a/cpp/src/arrow/scalar.h
+++ b/cpp/src/arrow/scalar.h
@@ -900,8 +900,8 @@ struct ARROW_EXPORT ExtensionScalar : public Scalar {
                   bool is_valid = true)
       : Scalar(std::move(type), is_valid), value(std::move(storage)) {}
 
-  template <typename Storage,
-            typename = enable_if_t<std::is_base_of<Scalar, Storage>::value>>
+  template <typename Storage>
+    requires std::is_base_of_v<Scalar, Storage>
   ExtensionScalar(Storage&& storage, std::shared_ptr<DataType> type, bool is_valid = true)
       : ExtensionScalar(std::make_shared<Storage>(std::move(storage)), std::move(type),
                         is_valid) {}
@@ -963,11 +963,9 @@ inline std::shared_ptr<Scalar> MakeScalar(const std::shared_ptr<Scalar>& scalar)
 template <typename ValueRef>
 struct MakeScalarImpl {
   template <typename T, typename ScalarType = typename TypeTraits<T>::ScalarType,
-            typename ValueType = typename ScalarType::ValueType,
-            typename Enable = typename std::enable_if<
-                std::is_constructible<ScalarType, ValueType,
-                                      std::shared_ptr<DataType>>::value &&
-                std::is_convertible<ValueRef, ValueType>::value>::type>
+            typename ValueType = typename ScalarType::ValueType>
+    requires(std::is_constructible_v<ScalarType, ValueType, std::shared_ptr<DataType>> &&
+             std::is_convertible_v<ValueRef, ValueType>)
   Status Visit(const T& t) {
     ARROW_RETURN_NOT_OK(internal::CheckBufferLength(&t, &value_));
     // `static_cast<ValueRef>` makes a rvalue if ValueRef is `ValueType&&`
@@ -979,10 +977,8 @@ struct MakeScalarImpl {
   // This isn't captured by the generic case above because `util::Float16` isn't implicity
   // convertible to `uint16_t` (HalfFloat's ValueType)
   template <typename T>
-  std::enable_if_t<std::is_same_v<std::decay_t<ValueRef>, util::Float16> &&
-                       is_half_float_type<T>::value,
-                   Status>
-  Visit(const T& t) {
+    requires(std::is_same_v<std::decay_t<ValueRef>, util::Float16> && arrow_half_float<T>)
+  Status Visit(const T& t) {
     out_ = std::make_shared<HalfFloatScalar>(static_cast<ValueRef>(value_),
                                              std::move(type_));
     return Status::OK();
@@ -997,11 +993,9 @@ struct MakeScalarImpl {
 
   // Enable constructing string/binary scalars (but not decimal, etc) from std::string
   template <typename T>
-  enable_if_t<
-      std::is_same<typename std::remove_reference<ValueRef>::type, std::string>::value &&
-          (is_base_binary_type<T>::value || std::is_same<T, FixedSizeBinaryType>::value),
-      Status>
-  Visit(const T& t) {
+    requires(std::is_same_v<std::remove_reference_t<ValueRef>, std::string> &&
+             (arrow_base_binary<T> || std::same_as<T, FixedSizeBinaryType>))
+  Status Visit(const T& t) {
     using ScalarType = typename TypeTraits<T>::ScalarType;
     out_ = std::make_shared<ScalarType>(Buffer::FromString(std::move(value_)),
                                         std::move(type_));

--- a/cpp/src/arrow/stl.h
+++ b/cpp/src/arrow/stl.h
@@ -48,22 +48,12 @@ namespace stl {
 
 namespace internal {
 
-template <typename T, typename = void>
-struct is_optional_like : public std::false_type {};
-
-template <typename T, typename = void>
-struct is_dereferencable : public std::false_type {};
+template <typename T>
+concept dereferencable = (requires(T t) { *t; });
 
 template <typename T>
-struct is_dereferencable<T, arrow::internal::void_t<decltype(*std::declval<T>())>>
-    : public std::true_type {};
-
-template <typename T>
-struct is_optional_like<
-    T, typename std::enable_if<
-           std::is_constructible<bool, T>::value && is_dereferencable<T>::value &&
-           !std::is_array<typename std::remove_reference<T>::type>::value>::type>
-    : public std::true_type {};
+concept optional_like = std::is_constructible_v<bool, T> && dereferencable<T> &&
+                        !std::is_array_v<std::remove_reference_t<T>>;
 
 template <size_t N, typename Tuple>
 using BareTupleElement =
@@ -71,12 +61,8 @@ using BareTupleElement =
 
 }  // namespace internal
 
-template <typename T, typename R = void>
-using enable_if_optional_like =
-    typename std::enable_if<internal::is_optional_like<T>::value, R>::type;
-
 /// Traits meta class to map standard C/C++ types to equivalent Arrow types.
-template <typename T, typename Enable = void>
+template <typename T>
 struct ConversionTraits {};
 
 /// Returns builder type for given standard C/C++ type.
@@ -217,7 +203,8 @@ struct ConversionTraits<std::array<ValueCType, N>>
 };
 
 template <typename Optional>
-struct ConversionTraits<Optional, enable_if_optional_like<Optional>>
+  requires internal::optional_like<Optional>
+struct ConversionTraits<Optional>
     : public CTypeTraits<typename std::decay<decltype(*std::declval<Optional>())>::type> {
   using OptionalInnerType =
       typename std::decay<decltype(*std::declval<Optional>())>::type;
@@ -252,7 +239,7 @@ struct SchemaFromTuple {
     std::vector<std::shared_ptr<Field>> ret =
         SchemaFromTuple<Tuple, N - 1>::MakeSchemaRecursion(names);
     auto type = ConversionTraits<Element>::type_singleton();
-    ret.push_back(field(names[N - 1], type, internal::is_optional_like<Element>::value));
+    ret.push_back(field(names[N - 1], type, internal::optional_like<Element>));
     return ret;
   }
 
@@ -283,8 +270,7 @@ struct SchemaFromTuple {
     std::vector<std::shared_ptr<Field>> ret =
         SchemaFromTuple<Tuple, N - 1>::MakeSchemaRecursionT(names);
     std::shared_ptr<DataType> type = ConversionTraits<Element>::type_singleton();
-    ret.push_back(
-        field(get<N - 1>(names), type, internal::is_optional_like<Element>::value));
+    ret.push_back(field(get<N - 1>(names), type, internal::optional_like<Element>));
     return ret;
   }
 

--- a/cpp/src/arrow/tensor.cc
+++ b/cpp/src/arrow/tensor.cc
@@ -523,7 +523,8 @@ struct NonZeroCounter {
   explicit NonZeroCounter(const Tensor& tensor) : tensor_(tensor) {}
 
   template <typename TYPE>
-  enable_if_number<TYPE, Status> Visit(const TYPE& type) {
+    requires arrow_number<TYPE>
+  Status Visit(const TYPE& type) {
     result = TensorCountNonZero<TYPE>(tensor_);
     return Status::OK();
   }

--- a/cpp/src/arrow/testing/random.cc
+++ b/cpp/src/arrow/testing/random.cc
@@ -109,14 +109,14 @@ struct GenerateOptions {
   }
 
   template <typename V>
-  typename std::enable_if<!std::is_floating_point_v<V> && !kIsHalfFloat>::type
-  GenerateTypedData(V* data, size_t n) {
+    requires(!std::is_floating_point_v<V> && !kIsHalfFloat)
+  void GenerateTypedData(V* data, size_t n) {
     GenerateTypedDataNoNan(data, n);
   }
 
   template <typename V>
-  typename std::enable_if<std::is_floating_point_v<V> || kIsHalfFloat>::type
-  GenerateTypedData(V* data, size_t n) {
+    requires(std::is_floating_point_v<V> || kIsHalfFloat)
+  void GenerateTypedData(V* data, size_t n) {
     if (nan_probability_ == 0.0) {
       GenerateTypedDataNoNan(data, n);
       return;
@@ -719,9 +719,8 @@ std::shared_ptr<Array> OffsetsFromLengthsArray(OffsetArrayType* lengths,
 // Helper for RandomArrayGenerator::ArrayOf: extract some C value from
 // a given metadata key.
 template <typename T, typename ArrowType = typename CTypeTraits<T>::ArrowType>
-enable_if_parameter_free<ArrowType, T> GetMetadata(const KeyValueMetadata* metadata,
-                                                   const std::string& key,
-                                                   T default_value) {
+  requires arrow_parameter_free<ArrowType>
+T GetMetadata(const KeyValueMetadata* metadata, const std::string& key, T default_value) {
   if (!metadata) return default_value;
   const auto index = metadata->FindKey(key);
   if (index < 0) return default_value;

--- a/cpp/src/arrow/type.cc
+++ b/cpp/src/arrow/type.cc
@@ -1678,7 +1678,8 @@ class NestedSelector {
   }
 
   template <typename OStream, typename U = T>
-  std::enable_if_t<std::is_same_v<U, Field>> Summarize(OStream* os) const {
+    requires std::same_as<U, Field>
+  void Summarize(OStream* os) const {
     const FieldVector* fields = get_children();
     if (!fields && get_parent()) {
       fields = &get_parent()->type()->fields();
@@ -1693,7 +1694,8 @@ class NestedSelector {
   }
 
   template <typename OStream, typename U = T>
-  std::enable_if_t<!std::is_same_v<U, Field>> Summarize(OStream* os) const {
+    requires(!std::same_as<U, Field>)
+  void Summarize(OStream* os) const {
     *os << "column types: { ";
     if (auto children = get_children()) {
       for (const auto& child : *children) {

--- a/cpp/src/arrow/type_traits.h
+++ b/cpp/src/arrow/type_traits.h
@@ -998,6 +998,173 @@ template <typename T, typename R = void>
 using enable_if_physical_floating_point =
     enable_if_t<is_physical_floating_type<T>::value, R>;
 
+//
+// C++20 concepts for Arrow type predicates
+//
+
+/// \addtogroup type-concepts
+/// @{
+
+// -- Primitive type concepts --
+template <typename T>
+concept arrow_null = is_null_type<T>::value;
+
+template <typename T>
+concept arrow_boolean = is_boolean_type<T>::value;
+
+template <typename T>
+concept arrow_number = is_number_type<T>::value;
+
+template <typename T>
+concept arrow_integer = is_integer_type<T>::value;
+
+template <typename T>
+concept arrow_signed_integer = is_signed_integer_type<T>::value;
+
+template <typename T>
+concept arrow_unsigned_integer = is_unsigned_integer_type<T>::value;
+
+template <typename T>
+concept arrow_floating_point = is_floating_type<T>::value;
+
+template <typename T>
+concept arrow_half_float = is_half_float_type<T>::value;
+
+template <typename T>
+concept arrow_8bit_int = is_8bit_int<T>::value;
+
+// -- Binary / String type concepts --
+template <typename T>
+concept arrow_base_binary = is_base_binary_type<T>::value;
+
+template <typename T>
+concept arrow_binary = is_binary_type<T>::value;
+
+template <typename T>
+concept arrow_string = is_string_type<T>::value;
+
+template <typename T>
+concept arrow_binary_view_like = is_binary_view_like_type<T>::value;
+
+template <typename T>
+concept arrow_binary_view = is_binary_view_type<T>::value;
+
+template <typename T>
+concept arrow_string_view = is_string_view_type<T>::value;
+
+template <typename T>
+concept arrow_string_like = is_string_like_type<T>::value;
+
+template <typename T>
+concept arrow_binary_like = is_binary_like_type<T>::value;
+
+template <typename T>
+concept arrow_fixed_size_binary = is_fixed_size_binary_type<T>::value;
+
+template <typename T>
+concept arrow_fixed_width = is_fixed_width_type<T>::value;
+
+// -- Decimal type concepts --
+template <typename T>
+concept arrow_decimal = is_decimal_type<T>::value;
+
+template <typename T>
+concept arrow_decimal32 = is_decimal32_type<T>::value;
+
+template <typename T>
+concept arrow_decimal64 = is_decimal64_type<T>::value;
+
+template <typename T>
+concept arrow_decimal128 = is_decimal128_type<T>::value;
+
+template <typename T>
+concept arrow_decimal256 = is_decimal256_type<T>::value;
+
+// -- Nested type concepts --
+template <typename T>
+concept arrow_nested = is_nested_type<T>::value;
+
+template <typename T>
+concept arrow_var_length_list = is_var_length_list_type<T>::value;
+
+template <typename T>
+concept arrow_fixed_size_list = is_fixed_size_list_type<T>::value;
+
+template <typename T>
+concept arrow_list = is_list_type<T>::value;
+
+template <typename T>
+concept arrow_list_view = is_list_view_type<T>::value;
+
+template <typename T>
+concept arrow_list_like = is_list_like_type<T>::value;
+
+template <typename T>
+concept arrow_var_length_list_like = is_var_length_list_like_type<T>::value;
+
+template <typename T>
+concept arrow_struct = is_struct_type<T>::value;
+
+template <typename T>
+concept arrow_union = is_union_type<T>::value;
+
+// -- Temporal type concepts --
+template <typename T>
+concept arrow_temporal = is_temporal_type<T>::value;
+
+template <typename T>
+concept arrow_date = is_date_type<T>::value;
+
+template <typename T>
+concept arrow_time = is_time_type<T>::value;
+
+template <typename T>
+concept arrow_timestamp = is_timestamp_type<T>::value;
+
+template <typename T>
+concept arrow_duration = is_duration_type<T>::value;
+
+template <typename T>
+concept arrow_interval = is_interval_type<T>::value;
+
+// -- Special type concepts --
+template <typename T>
+concept arrow_run_end_encoded = is_run_end_encoded_type<T>::value;
+
+template <typename T>
+concept arrow_dictionary = is_dictionary_type<T>::value;
+
+template <typename T>
+concept arrow_extension = is_extension_type<T>::value;
+
+// -- Attribute-based concepts --
+template <typename T>
+concept arrow_primitive_ctype = is_primitive_ctype<T>::value;
+
+template <typename T>
+concept arrow_has_c_type = has_c_type<T>::value;
+
+template <typename T>
+concept arrow_has_string_view = has_string_view<T>::value;
+
+template <typename T>
+concept arrow_parameter_free = is_parameter_free_type<T>::value;
+
+// -- Physical representation concepts --
+template <typename T>
+concept arrow_physical_signed_integer = is_physical_signed_integer_type<T>::value;
+
+template <typename T>
+concept arrow_physical_unsigned_integer = is_physical_unsigned_integer_type<T>::value;
+
+template <typename T>
+concept arrow_physical_integer = is_physical_integer_type<T>::value;
+
+template <typename T>
+concept arrow_physical_floating_point = is_physical_floating_type<T>::value;
+
+/// @}
+
 /// @}
 
 /// \addtogroup runtime-type-predicates

--- a/cpp/src/arrow/util/basic_decimal.h
+++ b/cpp/src/arrow/util/basic_decimal.h
@@ -78,9 +78,8 @@ class GenericBasicDecimal {
       : GenericBasicDecimal(bit_util::little_endian::ToNative(array)) {}
 
   /// \brief Create a decimal from any integer not wider than 64 bits.
-  template <typename T,
-            typename = typename std::enable_if<
-                std::is_integral<T>::value && (sizeof(T) <= sizeof(uint64_t)), T>::type>
+  template <typename T>
+    requires(std::is_integral_v<T> && (sizeof(T) <= sizeof(uint64_t)))
   constexpr GenericBasicDecimal(T value) noexcept  // NOLINT(runtime/explicit)
       : array_(WordsFromLowBits(value)) {}
 
@@ -185,9 +184,8 @@ class ARROW_EXPORT SmallBasicDecimal {
   constexpr SmallBasicDecimal() noexcept : value_(0) {}
 
   /// \brief Create a decimal from any integer not wider than 64 bits.
-  template <typename T,
-            typename = typename std::enable_if<
-                std::is_integral<T>::value && (sizeof(T) <= sizeof(int64_t)), T>::type>
+  template <typename T>
+    requires(std::is_integral_v<T> && (sizeof(T) <= sizeof(int64_t)))
   constexpr SmallBasicDecimal(T value) noexcept  // NOLINT(runtime/explicit)
       : value_(static_cast<DigitType>(value)) {}
 

--- a/cpp/src/arrow/util/decimal.h
+++ b/cpp/src/arrow/util/decimal.h
@@ -130,13 +130,15 @@ class ARROW_EXPORT Decimal32 : public BasicDecimal32 {
   }
 
   /// \brief Convert to a signed integer
-  template <typename T, typename = internal::EnableIfIsOneOf<T, int32_t, int64_t>>
+  template <typename T>
+    requires(internal::IsOneOf<T, int32_t, int64_t>::value)
   Result<T> ToInteger() const {
     return static_cast<T>(value_);
   }
 
   /// \brief Convert to a signed integer
-  template <typename T, typename = internal::EnableIfIsOneOf<T, int32_t, int64_t>>
+  template <typename T>
+    requires(internal::IsOneOf<T, int32_t, int64_t>::value)
   Status ToInteger(T* out) const {
     return ToInteger<T>().Value(out);
   }
@@ -147,7 +149,8 @@ class ARROW_EXPORT Decimal32 : public BasicDecimal32 {
   double ToDouble(int32_t scale) const;
 
   /// \brief Convert to a floating-point number (scaled)
-  template <typename T, typename = std::enable_if_t<std::is_floating_point_v<T>>>
+  template <typename T>
+    requires std::is_floating_point_v<T>
   T ToReal(int32_t scale) const {
     static_assert(std::is_same_v<T, float> || std::is_same_v<T, double>,
                   "Unexpected floating-point type");
@@ -236,13 +239,15 @@ class ARROW_EXPORT Decimal64 : public BasicDecimal64 {
   }
 
   /// \brief Convert to a signed integer
-  template <typename T, typename = internal::EnableIfIsOneOf<T, int32_t, int64_t>>
+  template <typename T>
+    requires(internal::IsOneOf<T, int32_t, int64_t>::value)
   Result<T> ToInteger() const {
     return static_cast<T>(value_);
   }
 
   /// \brief Convert to a signed integer
-  template <typename T, typename = internal::EnableIfIsOneOf<T, int32_t, int64_t>>
+  template <typename T>
+    requires(internal::IsOneOf<T, int32_t, int64_t>::value)
   Status ToInteger(T* out) const {
     return ToInteger<T>().Value(out);
   }
@@ -253,7 +258,8 @@ class ARROW_EXPORT Decimal64 : public BasicDecimal64 {
   double ToDouble(int32_t scale) const;
 
   /// \brief Convert to a floating-point number (scaled)
-  template <typename T, typename = std::enable_if_t<std::is_floating_point_v<T>>>
+  template <typename T>
+    requires std::is_floating_point_v<T>
   T ToReal(int32_t scale) const {
     static_assert(std::is_same_v<T, float> || std::is_same_v<T, double>,
                   "Unexpected floating-point type");
@@ -357,7 +363,8 @@ class ARROW_EXPORT Decimal128 : public BasicDecimal128 {
   }
 
   /// \brief Convert to a signed integer
-  template <typename T, typename = internal::EnableIfIsOneOf<T, int32_t, int64_t>>
+  template <typename T>
+    requires(internal::IsOneOf<T, int32_t, int64_t>::value)
   Result<T> ToInteger() const {
     constexpr auto min_value = std::numeric_limits<T>::min();
     constexpr auto max_value = std::numeric_limits<T>::max();
@@ -370,7 +377,8 @@ class ARROW_EXPORT Decimal128 : public BasicDecimal128 {
   }
 
   /// \brief Convert to a signed integer
-  template <typename T, typename = internal::EnableIfIsOneOf<T, int32_t, int64_t>>
+  template <typename T>
+    requires(internal::IsOneOf<T, int32_t, int64_t>::value)
   Status ToInteger(T* out) const {
     return ToInteger<T>().Value(out);
   }
@@ -381,7 +389,8 @@ class ARROW_EXPORT Decimal128 : public BasicDecimal128 {
   double ToDouble(int32_t scale) const;
 
   /// \brief Convert to a floating-point number (scaled)
-  template <typename T, typename = std::enable_if_t<std::is_floating_point_v<T>>>
+  template <typename T>
+    requires std::is_floating_point_v<T>
   T ToReal(int32_t scale) const {
     static_assert(std::is_same_v<T, float> || std::is_same_v<T, double>,
                   "Unexpected floating-point type");
@@ -482,7 +491,8 @@ class ARROW_EXPORT Decimal256 : public BasicDecimal256 {
   double ToDouble(int32_t scale) const;
 
   /// \brief Convert to a floating-point number (scaled)
-  template <typename T, typename = std::enable_if_t<std::is_floating_point_v<T>>>
+  template <typename T>
+    requires std::is_floating_point_v<T>
   T ToReal(int32_t scale) const {
     static_assert(std::is_same_v<T, float> || std::is_same_v<T, double>,
                   "Unexpected floating-point type");

--- a/cpp/src/arrow/util/float16.h
+++ b/cpp/src/arrow/util/float16.h
@@ -44,8 +44,8 @@ class ARROW_EXPORT Float16 {
   Float16() = default;
   explicit Float16(float f) : Float16(FromFloat(f)) {}
   explicit Float16(double d) : Float16(FromDouble(d)) {}
-  template <typename T,
-            typename std::enable_if_t<std::is_convertible_v<T, double>>* = NULLPTR>
+  template <typename T>
+    requires std::is_convertible_v<T, double>
   explicit Float16(T v) : Float16(static_cast<double>(v)) {}
 
   /// \brief Create a `Float16` from its exact binary representation

--- a/cpp/src/arrow/util/formatting.h
+++ b/cpp/src/arrow/util/formatting.h
@@ -42,7 +42,7 @@ namespace arrow {
 namespace internal {
 
 /// \brief The entry point for conversion to strings.
-template <typename ARROW_TYPE, typename Enable = void>
+template <typename ARROW_TYPE>
 class StringFormatter;
 
 template <typename T>
@@ -546,8 +546,8 @@ class StringFormatter<TimestampType> {
   std::string timezone_;
 };
 
-template <typename T>
-class StringFormatter<T, enable_if_time<T>> {
+template <arrow_time T>
+class StringFormatter<T> {
  public:
   using value_type = typename T::c_type;
 

--- a/cpp/src/arrow/util/functional.h
+++ b/cpp/src/arrow/util/functional.h
@@ -127,9 +127,9 @@ class FnOnce<R(A...)> {
  public:
   FnOnce() = default;
 
-  template <typename Fn,
-            typename = typename std::enable_if<std::is_convertible<
-                decltype(std::declval<Fn&&>()(std::declval<A>()...)), R>::value>::type>
+  template <typename Fn>
+    requires std::is_convertible_v<decltype(std::declval<Fn&&>()(std::declval<A>()...)),
+                                   R>
   FnOnce(Fn fn) : impl_(new FnImpl<Fn>(std::move(fn))) {  // NOLINT runtime/explicit
   }
 

--- a/cpp/src/arrow/util/future.h
+++ b/cpp/src/arrow/util/future.h
@@ -50,12 +50,12 @@ struct is_future : std::false_type {};
 template <typename T>
 struct is_future<Future<T>> : std::true_type {};
 
-template <typename Signature, typename Enable = void>
+template <typename Signature>
 struct result_of;
 
 template <typename Fn, typename... A>
-struct result_of<Fn(A...),
-                 internal::void_t<decltype(std::declval<Fn>()(std::declval<A>()...))>> {
+  requires requires { std::declval<Fn>()(std::declval<A>()...); }
+struct result_of<Fn(A...)> {
   using type = decltype(std::declval<Fn>()(std::declval<A>()...));
 };
 
@@ -128,8 +128,8 @@ struct ContinueFuture {
   template <typename ContinueFunc, typename... Args,
             typename ContinueResult = result_of_t<ContinueFunc && (Args && ...)>,
             typename NextFuture = ForReturn<ContinueResult>>
-  typename std::enable_if<std::is_void<ContinueResult>::value>::type operator()(
-      NextFuture next, ContinueFunc&& f, Args&&... a) const {
+    requires std::is_void_v<ContinueResult>
+  void operator()(NextFuture next, ContinueFunc&& f, Args&&... a) const {
     std::forward<ContinueFunc>(f)(std::forward<Args>(a)...);
     next.MarkFinished();
   }
@@ -143,10 +143,9 @@ struct ContinueFuture {
   template <typename ContinueFunc, typename... Args,
             typename ContinueResult = result_of_t<ContinueFunc && (Args && ...)>,
             typename NextFuture = ForReturn<ContinueResult>>
-  typename std::enable_if<
-      !std::is_void<ContinueResult>::value && !is_future<ContinueResult>::value &&
-      (!NextFuture::is_empty || std::is_same<ContinueResult, Status>::value)>::type
-  operator()(NextFuture next, ContinueFunc&& f, Args&&... a) const {
+    requires(!std::is_void_v<ContinueResult> && !is_future<ContinueResult>::value &&
+             (!NextFuture::is_empty || std::is_same_v<ContinueResult, Status>))
+  void operator()(NextFuture next, ContinueFunc&& f, Args&&... a) const {
     next.MarkFinished(std::forward<ContinueFunc>(f)(std::forward<Args>(a)...));
   }
 
@@ -160,10 +159,9 @@ struct ContinueFuture {
   template <typename ContinueFunc, typename... Args,
             typename ContinueResult = result_of_t<ContinueFunc && (Args && ...)>,
             typename NextFuture = ForReturn<ContinueResult>>
-  typename std::enable_if<!std::is_void<ContinueResult>::value &&
-                          !is_future<ContinueResult>::value && NextFuture::is_empty &&
-                          !std::is_same<ContinueResult, Status>::value>::type
-  operator()(NextFuture next, ContinueFunc&& f, Args&&... a) const {
+    requires(!std::is_void_v<ContinueResult> && !is_future<ContinueResult>::value &&
+             NextFuture::is_empty && !std::is_same_v<ContinueResult, Status>)
+  void operator()(NextFuture next, ContinueFunc&& f, Args&&... a) const {
     next.MarkFinished(std::forward<ContinueFunc>(f)(std::forward<Args>(a)...).status());
   }
 
@@ -173,8 +171,8 @@ struct ContinueFuture {
   template <typename ContinueFunc, typename... Args,
             typename ContinueResult = result_of_t<ContinueFunc && (Args && ...)>,
             typename NextFuture = ForReturn<ContinueResult>>
-  typename std::enable_if<is_future<ContinueResult>::value>::type operator()(
-      NextFuture next, ContinueFunc&& f, Args&&... a) const {
+    requires is_future<ContinueResult>::value
+  void operator()(NextFuture next, ContinueFunc&& f, Args&&... a) const {
     ContinueResult signal_to_complete_next =
         std::forward<ContinueFunc>(f)(std::forward<Args>(a)...);
     MarkNextFinished<ContinueResult, NextFuture> callback{std::move(next)};
@@ -403,8 +401,8 @@ class [[nodiscard]] Future {
   void MarkFinished(Result<ValueType> res) { DoMarkFinished(std::move(res)); }
 
   /// \brief Mark a Future<> completed with the provided Status.
-  template <typename E = ValueType, typename = typename std::enable_if<
-                                        std::is_same<E, internal::Empty>::value>::type>
+  template <typename E = ValueType>
+    requires std::is_same_v<E, internal::Empty>
   void MarkFinished(Status s = Status::OK()) {
     return DoMarkFinished(E::ToResult(std::move(s)));
   }
@@ -429,8 +427,8 @@ class [[nodiscard]] Future {
   }
 
   /// \brief Make a finished Future<> with the provided Status.
-  template <typename E = ValueType, typename = typename std::enable_if<
-                                        std::is_same<E, internal::Empty>::value>::type>
+  template <typename E = ValueType>
+    requires std::is_same_v<E, internal::Empty>
   static Future<> MakeFinished(Status s = Status::OK()) {
     return MakeFinished(E::ToResult(std::move(s)));
   }

--- a/cpp/src/arrow/util/hashing.h
+++ b/cpp/src/arrow/util/hashing.h
@@ -95,12 +95,12 @@ struct ScalarHelperBase {
   }
 };
 
-template <typename Scalar, uint64_t AlgNum = 0, typename Enable = void>
+template <typename Scalar, uint64_t AlgNum = 0>
 struct ScalarHelper : public ScalarHelperBase<Scalar, AlgNum> {};
 
 template <typename Scalar, uint64_t AlgNum>
-struct ScalarHelper<Scalar, AlgNum, enable_if_t<std::is_integral<Scalar>::value>>
-    : public ScalarHelperBase<Scalar, AlgNum> {
+  requires std::is_integral_v<Scalar>
+struct ScalarHelper<Scalar, AlgNum> : public ScalarHelperBase<Scalar, AlgNum> {
   // ScalarHelper specialization for integers
 
   static hash_t ComputeHash(const Scalar& value) {
@@ -120,9 +120,8 @@ struct ScalarHelper<Scalar, AlgNum, enable_if_t<std::is_integral<Scalar>::value>
 };
 
 template <typename Scalar, uint64_t AlgNum>
-struct ScalarHelper<Scalar, AlgNum,
-                    enable_if_t<std::is_same<std::string_view, Scalar>::value>>
-    : public ScalarHelperBase<Scalar, AlgNum> {
+  requires std::is_same_v<std::string_view, Scalar>
+struct ScalarHelper<Scalar, AlgNum> : public ScalarHelperBase<Scalar, AlgNum> {
   // ScalarHelper specialization for std::string_view
 
   static hash_t ComputeHash(std::string_view value) {
@@ -131,8 +130,8 @@ struct ScalarHelper<Scalar, AlgNum,
 };
 
 template <typename Scalar, uint64_t AlgNum>
-struct ScalarHelper<Scalar, AlgNum, enable_if_t<std::is_floating_point<Scalar>::value>>
-    : public ScalarHelperBase<Scalar, AlgNum> {
+  requires std::is_floating_point_v<Scalar>
+struct ScalarHelper<Scalar, AlgNum> : public ScalarHelperBase<Scalar, AlgNum> {
   // ScalarHelper specialization for reals
 
   static bool CompareScalars(Scalar u, Scalar v) {
@@ -145,9 +144,8 @@ struct ScalarHelper<Scalar, AlgNum, enable_if_t<std::is_floating_point<Scalar>::
 };
 
 template <typename Scalar, uint64_t AlgNum>
-struct ScalarHelper<Scalar, AlgNum,
-                    enable_if_t<std::is_same_v<Scalar, ::arrow::util::Float16>>>
-    : public ScalarHelperBase<Scalar, AlgNum> {
+  requires std::is_same_v<Scalar, ::arrow::util::Float16>
+struct ScalarHelper<Scalar, AlgNum> : public ScalarHelperBase<Scalar, AlgNum> {
   // ScalarHelper specialization for Float16
 
   static bool CompareScalars(Scalar u, Scalar v) {
@@ -547,7 +545,7 @@ class ScalarMemoTable : public MemoTable {
 // ----------------------------------------------------------------------
 // A memoization table for small scalar values, using direct indexing
 
-template <typename Scalar, typename Enable = void>
+template <typename Scalar>
 struct SmallScalarTraits {};
 
 template <>
@@ -558,7 +556,8 @@ struct SmallScalarTraits<bool> {
 };
 
 template <typename Scalar>
-struct SmallScalarTraits<Scalar, enable_if_t<std::is_integral<Scalar>::value>> {
+  requires std::is_integral_v<Scalar>
+struct SmallScalarTraits<Scalar> {
   using Unsigned = typename std::make_unsigned<Scalar>::type;
 
   static constexpr int32_t cardinality = 1U + std::numeric_limits<Unsigned>::max();
@@ -907,7 +906,7 @@ class BinaryMemoTable : public MemoTable {
   }
 };
 
-template <typename T, typename Enable = void>
+template <typename T>
 struct HashTraits {};
 
 template <>
@@ -916,13 +915,15 @@ struct HashTraits<BooleanType> {
 };
 
 template <typename T>
-struct HashTraits<T, enable_if_8bit_int<T>> {
+  requires is_8bit_int<T>::value
+struct HashTraits<T> {
   using c_type = typename T::c_type;
   using MemoTableType = SmallScalarMemoTable<typename T::c_type>;
 };
 
 template <typename T>
-struct HashTraits<T, enable_if_t<has_c_type<T>::value && !is_8bit_int<T>::value>> {
+  requires(has_c_type<T>::value && !is_8bit_int<T>::value)
+struct HashTraits<T> {
   using c_type = typename T::c_type;
   using MemoTableType = ScalarMemoTable<c_type, HashTable>;
 };
@@ -933,18 +934,20 @@ struct HashTraits<HalfFloatType> {
 };
 
 template <typename T>
-struct HashTraits<T, enable_if_t<has_string_view<T>::value &&
-                                 !std::is_base_of<LargeBinaryType, T>::value>> {
+  requires(has_string_view<T>::value && !std::is_base_of_v<LargeBinaryType, T>)
+struct HashTraits<T> {
   using MemoTableType = BinaryMemoTable<BinaryBuilder>;
 };
 
 template <typename T>
-struct HashTraits<T, enable_if_decimal<T>> {
+  requires is_decimal_type<T>::value
+struct HashTraits<T> {
   using MemoTableType = BinaryMemoTable<BinaryBuilder>;
 };
 
 template <typename T>
-struct HashTraits<T, enable_if_t<std::is_base_of<LargeBinaryType, T>::value>> {
+  requires std::is_base_of_v<LargeBinaryType, T>
+struct HashTraits<T> {
   using MemoTableType = BinaryMemoTable<LargeBinaryBuilder>;
 };
 

--- a/cpp/src/arrow/util/hashing.h
+++ b/cpp/src/arrow/util/hashing.h
@@ -940,7 +940,7 @@ struct HashTraits<T> {
 };
 
 template <typename T>
-  requires is_decimal_type<T>::value
+  requires arrow_decimal<T>
 struct HashTraits<T> {
   using MemoTableType = BinaryMemoTable<BinaryBuilder>;
 };

--- a/cpp/src/arrow/util/int_util.cc
+++ b/cpp/src/arrow/util/int_util.cc
@@ -477,8 +477,8 @@ struct TransposeIntsDest {
   int64_t length;
   const int32_t* transpose_map;
 
-  template <typename T>
-  enable_if_integer<T, Status> Visit(const T&) {
+  template <arrow_integer T>
+  Status Visit(const T&) {
     using DestType = typename T::c_type;
     TransposeInts(src, reinterpret_cast<DestType*>(dest) + dest_offset, length,
                   transpose_map);
@@ -501,8 +501,8 @@ struct TransposeIntsSrc {
   const int32_t* transpose_map;
   const DataType& dest_type;
 
-  template <typename T>
-  enable_if_integer<T, Status> Visit(const T&) {
+  template <arrow_integer T>
+  Status Visit(const T&) {
     using SrcType = typename T::c_type;
     return TransposeIntsDest<SrcType>{reinterpret_cast<const SrcType*>(src) + src_offset,
                                       dest, dest_offset, length,
@@ -711,14 +711,14 @@ Status CheckIntegersInRange(const ArraySpan& values, const Scalar& bound_lower,
 
 namespace {
 
-template <typename O, typename I, typename Enable = void>
+template <typename O, typename I>
 struct is_number_downcast {
   static constexpr bool value = false;
 };
 
 template <typename O, typename I>
-struct is_number_downcast<
-    O, I, enable_if_t<is_number_type<O>::value && is_number_type<I>::value>> {
+  requires(arrow_number<O> && arrow_number<I>)
+struct is_number_downcast<O, I> {
   using O_T = typename O::c_type;
   using I_T = typename I::c_type;
 
@@ -732,14 +732,14 @@ struct is_number_downcast<
        (sizeof(O_T) < sizeof(I_T)));
 };
 
-template <typename O, typename I, typename Enable = void>
+template <typename O, typename I>
 struct is_number_upcast {
   static constexpr bool value = false;
 };
 
 template <typename O, typename I>
-struct is_number_upcast<
-    O, I, enable_if_t<is_number_type<O>::value && is_number_type<I>::value>> {
+  requires(arrow_number<O> && arrow_number<I>)
+struct is_number_upcast<O, I> {
   using O_T = typename O::c_type;
   using I_T = typename I::c_type;
 
@@ -753,14 +753,14 @@ struct is_number_upcast<
        (sizeof(O_T) > sizeof(I_T)));
 };
 
-template <typename O, typename I, typename Enable = void>
+template <typename O, typename I>
 struct is_integral_signed_to_unsigned {
   static constexpr bool value = false;
 };
 
 template <typename O, typename I>
-struct is_integral_signed_to_unsigned<
-    O, I, enable_if_t<is_integer_type<O>::value && is_integer_type<I>::value>> {
+  requires(arrow_integer<O> && arrow_integer<I>)
+struct is_integral_signed_to_unsigned<O, I> {
   using O_T = typename O::c_type;
   using I_T = typename I::c_type;
 
@@ -769,14 +769,14 @@ struct is_integral_signed_to_unsigned<
        ((std::is_unsigned<O_T>::value && std::is_signed<I_T>::value)));
 };
 
-template <typename O, typename I, typename Enable = void>
+template <typename O, typename I>
 struct is_integral_unsigned_to_signed {
   static constexpr bool value = false;
 };
 
 template <typename O, typename I>
-struct is_integral_unsigned_to_signed<
-    O, I, enable_if_t<is_integer_type<O>::value && is_integer_type<I>::value>> {
+  requires(arrow_integer<O> && arrow_integer<I>)
+struct is_integral_unsigned_to_signed<O, I> {
   using O_T = typename O::c_type;
   using I_T = typename I::c_type;
 
@@ -785,63 +785,61 @@ struct is_integral_unsigned_to_signed<
        ((std::is_signed<O_T>::value && std::is_unsigned<I_T>::value)));
 };
 
-// This set of functions SafeMinimum/SafeMaximum would be simplified with
-// C++17 and `if constexpr`.
-
-// clang-format doesn't handle this construct properly. Thus the macro, but it
-// also improves readability.
-//
-// The effective return type of the function is always `I::c_type`, this is
-// just how enable_if works with functions.
-#define RET_TYPE(TRAIT) enable_if_t<TRAIT<O, I>::value, typename I::c_type>
-
 template <typename O, typename I>
-constexpr RET_TYPE(std::is_same) SafeMinimum() {
+  requires std::is_same_v<O, I>
+constexpr typename I::c_type SafeMinimum() {
   using out_type = typename O::c_type;
 
   return std::numeric_limits<out_type>::lowest();
 }
 
 template <typename O, typename I>
-constexpr RET_TYPE(std::is_same) SafeMaximum() {
+  requires std::is_same_v<O, I>
+constexpr typename I::c_type SafeMaximum() {
   using out_type = typename O::c_type;
 
   return std::numeric_limits<out_type>::max();
 }
 
 template <typename O, typename I>
-constexpr RET_TYPE(is_number_downcast) SafeMinimum() {
+  requires is_number_downcast<O, I>::value
+constexpr typename I::c_type SafeMinimum() {
   using out_type = typename O::c_type;
 
   return std::numeric_limits<out_type>::lowest();
 }
 
 template <typename O, typename I>
-constexpr RET_TYPE(is_number_downcast) SafeMaximum() {
+  requires is_number_downcast<O, I>::value
+constexpr typename I::c_type SafeMaximum() {
   using out_type = typename O::c_type;
 
   return std::numeric_limits<out_type>::max();
 }
 
 template <typename O, typename I>
-constexpr RET_TYPE(is_number_upcast) SafeMinimum() {
+  requires is_number_upcast<O, I>::value
+constexpr typename I::c_type SafeMinimum() {
   using in_type = typename I::c_type;
   return std::numeric_limits<in_type>::lowest();
 }
 
 template <typename O, typename I>
-constexpr RET_TYPE(is_number_upcast) SafeMaximum() {
+  requires is_number_upcast<O, I>::value
+constexpr typename I::c_type SafeMaximum() {
   using in_type = typename I::c_type;
   return std::numeric_limits<in_type>::max();
 }
 
 template <typename O, typename I>
-constexpr RET_TYPE(is_integral_unsigned_to_signed) SafeMinimum() {
+  requires is_integral_unsigned_to_signed<O, I>::value
+constexpr typename I::c_type SafeMinimum() {
   return 0;
 }
 
 template <typename O, typename I>
-constexpr RET_TYPE(is_integral_unsigned_to_signed) SafeMaximum() {
+  requires is_integral_unsigned_to_signed<O, I>::value
+constexpr typename I::c_type SafeMaximum() {
   using in_type = typename I::c_type;
   using out_type = typename O::c_type;
 
@@ -853,12 +851,14 @@ constexpr RET_TYPE(is_integral_unsigned_to_signed) SafeMaximum() {
 }
 
 template <typename O, typename I>
-constexpr RET_TYPE(is_integral_signed_to_unsigned) SafeMinimum() {
+  requires is_integral_signed_to_unsigned<O, I>::value
+constexpr typename I::c_type SafeMinimum() {
   return 0;
 }
 
 template <typename O, typename I>
-constexpr RET_TYPE(is_integral_signed_to_unsigned) SafeMaximum() {
+  requires is_integral_signed_to_unsigned<O, I>::value
+constexpr typename I::c_type SafeMaximum() {
   using in_type = typename I::c_type;
   using out_type = typename O::c_type;
 
@@ -866,8 +866,6 @@ constexpr RET_TYPE(is_integral_signed_to_unsigned) SafeMaximum() {
                                   ? std::numeric_limits<in_type>::max()
                                   : std::numeric_limits<out_type>::max());
 }
-
-#undef RET_TYPE
 
 #define GET_MIN_MAX_CASE(TYPE, OUT_TYPE)    \
   case Type::TYPE:                          \

--- a/cpp/src/arrow/util/int_util.h
+++ b/cpp/src/arrow/util/int_util.h
@@ -74,14 +74,14 @@ ARROW_EXPORT
 void UpcastInts(const int32_t* source, int64_t* dest, int64_t length);
 
 template <typename InputInt, typename OutputInt>
-inline typename std::enable_if<(sizeof(InputInt) >= sizeof(OutputInt))>::type CastInts(
-    const InputInt* source, OutputInt* dest, int64_t length) {
+  requires(sizeof(InputInt) >= sizeof(OutputInt))
+inline void CastInts(const InputInt* source, OutputInt* dest, int64_t length) {
   DowncastInts(source, dest, length);
 }
 
 template <typename InputInt, typename OutputInt>
-inline typename std::enable_if<(sizeof(InputInt) < sizeof(OutputInt))>::type CastInts(
-    const InputInt* source, OutputInt* dest, int64_t length) {
+  requires(sizeof(InputInt) < sizeof(OutputInt))
+inline void CastInts(const InputInt* source, OutputInt* dest, int64_t length) {
   UpcastInts(source, dest, length);
 }
 
@@ -120,16 +120,14 @@ Status IntegersCanFit(const Scalar& value, const DataType& target_type);
 /// Upcast an integer to the largest possible width (currently 64 bits)
 
 template <typename Integer>
-typename std::enable_if<
-    std::is_integral<Integer>::value && std::is_signed<Integer>::value, int64_t>::type
-UpcastInt(Integer v) {
+  requires(std::is_integral_v<Integer> && std::is_signed_v<Integer>)
+int64_t UpcastInt(Integer v) {
   return v;
 }
 
 template <typename Integer>
-typename std::enable_if<
-    std::is_integral<Integer>::value && std::is_unsigned<Integer>::value, uint64_t>::type
-UpcastInt(Integer v) {
+  requires(std::is_integral_v<Integer> && std::is_unsigned_v<Integer>)
+uint64_t UpcastInt(Integer v) {
   return v;
 }
 

--- a/cpp/src/arrow/util/iterator.h
+++ b/cpp/src/arrow/util/iterator.h
@@ -520,12 +520,12 @@ struct FilterIterator {
 };
 
 /// \brief Like MapIterator, but where the function can fail or reject elements.
-template <
-    typename Fn, typename From = typename internal::call_traits::argument_type<0, Fn>,
-    typename Ret = typename internal::call_traits::return_type<Fn>::ValueType,
-    typename To = typename std::tuple_element<0, Ret>::type,
-    typename Enable = typename std::enable_if<std::is_same<
-        typename std::tuple_element<1, Ret>::type, FilterIterator::Action>::value>::type>
+template <typename Fn,
+          typename From = typename internal::call_traits::argument_type<0, Fn>,
+          typename Ret = typename internal::call_traits::return_type<Fn>::ValueType,
+          typename To = typename std::tuple_element<0, Ret>::type>
+  requires std::is_same_v<typename std::tuple_element<1, Ret>::type,
+                          FilterIterator::Action>
 Iterator<To> MakeFilterIterator(Fn filter, Iterator<From> it) {
   return Iterator<To>(
       FilterIterator::Impl<Fn, From, To>(std::move(filter), std::move(it)));

--- a/cpp/src/arrow/util/small_vector_test.cc
+++ b/cpp/src/arrow/util/small_vector_test.cc
@@ -123,15 +123,6 @@ using VectorIntLikeParams =
 
 template <typename Param>
 class TestSmallStaticVector : public ::testing::Test {
-  template <bool B, typename T = void>
-  using enable_if_t = typename std::enable_if<B, T>::type;
-
-  template <typename P>
-  using enable_if_move_only = enable_if_t<P::IsMoveOnly(), int>;
-
-  template <typename P>
-  using enable_if_not_move_only = enable_if_t<!P::IsMoveOnly(), int>;
-
  public:
   using Traits = typename Param::Traits;
   using IntLike = typename Param::IntLike;
@@ -247,7 +238,8 @@ class TestSmallStaticVector : public ::testing::Test {
   }
 
   template <bool IsMoveOnly = Param::IsMoveOnly()>
-  void TestConstructFromCount(enable_if_t<!IsMoveOnly>* = 0) {
+    requires(!IsMoveOnly)
+  void TestConstructFromCount() {
     constexpr size_t N = Traits::TestSizeFor(4);
     {
       const IntVectorType<N> ints(3);
@@ -261,7 +253,8 @@ class TestSmallStaticVector : public ::testing::Test {
   }
 
   template <bool IsMoveOnly = Param::IsMoveOnly()>
-  void TestConstructFromCount(enable_if_t<IsMoveOnly>* = 0) {
+    requires IsMoveOnly
+  void TestConstructFromCount() {
     GTEST_SKIP() << "Cannot construct vector of move-only type with value count";
   }
 
@@ -285,13 +278,15 @@ class TestSmallStaticVector : public ::testing::Test {
   }
 
   template <bool IsMoveOnly = Param::IsMoveOnly()>
-  void TestConstructFromValues(enable_if_t<!IsMoveOnly>* = 0) {
+    requires(!IsMoveOnly)
+  void TestConstructFromValues() {
     CheckConstructFromValues<Traits::TestSizeFor(4)>();
     CheckConstructFromValues<5>();
   }
 
   template <bool IsMoveOnly = Param::IsMoveOnly()>
-  void TestConstructFromValues(enable_if_t<IsMoveOnly>* = 0) {
+    requires IsMoveOnly
+  void TestConstructFromValues() {
     GTEST_SKIP() << "Cannot construct vector of move-only type with explicit values";
   }
 
@@ -316,7 +311,8 @@ class TestSmallStaticVector : public ::testing::Test {
   }
 
   template <bool IsMoveOnly = Param::IsMoveOnly()>
-  void CheckConstructFromCopiedStdVector(enable_if_t<!IsMoveOnly>* = 0) {
+    requires(!IsMoveOnly)
+  void CheckConstructFromCopiedStdVector() {
     constexpr size_t N = Traits::TestSizeFor(6);
     {
       const std::vector<IntLike> src;
@@ -338,7 +334,8 @@ class TestSmallStaticVector : public ::testing::Test {
   }
 
   template <bool IsMoveOnly = Param::IsMoveOnly()>
-  void CheckConstructFromCopiedStdVector(enable_if_t<IsMoveOnly>* = 0) {}
+    requires IsMoveOnly
+  void CheckConstructFromCopiedStdVector() {}
 
   void TestConstructFromStdVector() {
     CheckConstructFromMovedStdVector();
@@ -368,7 +365,8 @@ class TestSmallStaticVector : public ::testing::Test {
   }
 
   template <bool IsMoveOnly = Param::IsMoveOnly()>
-  void CheckAssignFromCopiedStdVector(enable_if_t<!IsMoveOnly>* = 0) {
+    requires(!IsMoveOnly)
+  void CheckAssignFromCopiedStdVector() {
     constexpr size_t N = Traits::TestSizeFor(6);
     {
       const std::vector<IntLike> src;
@@ -392,7 +390,8 @@ class TestSmallStaticVector : public ::testing::Test {
   }
 
   template <bool IsMoveOnly = Param::IsMoveOnly()>
-  void CheckAssignFromCopiedStdVector(enable_if_t<IsMoveOnly>* = 0) {}
+    requires IsMoveOnly
+  void CheckAssignFromCopiedStdVector() {}
 
   void TestAssignFromStdVector() {
     CheckAssignFromMovedStdVector();
@@ -454,18 +453,21 @@ class TestSmallStaticVector : public ::testing::Test {
   }
 
   template <bool IsMoveOnly = Param::IsMoveOnly()>
-  void TestCopy(enable_if_t<!IsMoveOnly>* = 0) {
+    requires(!IsMoveOnly)
+  void TestCopy() {
     CheckCopy<Traits::TestSizeFor(5)>(/*expect_overflow=*/Traits::CanOverflow());
     CheckCopy<5>(/*expect_overflow=*/false);
   }
 
   template <bool IsMoveOnly = Param::IsMoveOnly()>
-  void TestCopy(enable_if_t<IsMoveOnly>* = 0) {
+    requires IsMoveOnly
+  void TestCopy() {
     GTEST_SKIP() << "Cannot copy vector of move-only type";
   }
 
   template <bool IsMoveOnly = Param::IsMoveOnly()>
-  void TestResize(enable_if_t<!IsMoveOnly>* = 0) {
+    requires(!IsMoveOnly)
+  void TestResize() {
     constexpr size_t N = Traits::TestSizeFor(8);
     {
       IntVectorType<N> ints;
@@ -520,7 +522,8 @@ class TestSmallStaticVector : public ::testing::Test {
   }
 
   template <bool IsMoveOnly = Param::IsMoveOnly()>
-  void TestResize(enable_if_t<IsMoveOnly>* = 0) {
+    requires IsMoveOnly
+  void TestResize() {
     GTEST_SKIP() << "Cannot resize vector of move-only type";
   }
 

--- a/cpp/src/arrow/util/span.h
+++ b/cpp/src/arrow/util/span.h
@@ -50,7 +50,8 @@ writing code which would break when it is replaced by std::span.)");
   span(const span&) = default;
   span& operator=(const span&) = default;
 
-  template <typename M, typename = std::enable_if_t<std::is_same_v<T, const M>>>
+  template <typename M>
+    requires std::is_same_v<T, const M>
   // NOLINTNEXTLINE runtime/explicit
   constexpr span(span<M> mut) : span{mut.data(), mut.size()} {}
 
@@ -60,9 +61,8 @@ writing code which would break when it is replaced by std::span.)");
       : data_{begin}, size_{static_cast<size_t>(end - begin)} {}
 
   template <typename R, typename RD = decltype(std::data(std::declval<R>())),
-            typename RS = decltype(std::size(std::declval<R>())),
-            typename E = std::enable_if_t<std::is_constructible_v<T*, RD> &&
-                                          std::is_constructible_v<size_t, RS>>>
+            typename RS = decltype(std::size(std::declval<R>()))>
+    requires(std::is_constructible_v<T*, RD> && std::is_constructible_v<size_t, RS>)
   // NOLINTNEXTLINE runtime/explicit, non-const reference
   constexpr span(R&& range) : data_{std::data(range)}, size_{std::size(range)} {}
 

--- a/cpp/src/arrow/util/tdigest_internal.h
+++ b/cpp/src/arrow/util/tdigest_internal.h
@@ -65,12 +65,14 @@ class ARROW_EXPORT TDigest {
 
   // skip NAN on adding
   template <typename T>
-  typename std::enable_if<std::is_floating_point<T>::value>::type NanAdd(T value) {
+    requires std::is_floating_point_v<T>
+  void NanAdd(T value) {
     if (!std::isnan(value)) Add(value);
   }
 
   template <typename T>
-  typename std::enable_if<std::is_integral<T>::value>::type NanAdd(T value) {
+    requires std::is_integral_v<T>
+  void NanAdd(T value) {
     Add(static_cast<double>(value));
   }
 

--- a/cpp/src/arrow/util/ubsan.h
+++ b/cpp/src/arrow/util/ubsan.h
@@ -54,8 +54,8 @@ inline T* MakeNonNull(T* maybe_null = NULLPTR) {
 }
 
 template <typename T>
-inline std::enable_if_t<std::is_trivially_copyable_v<T>, T> SafeLoadAs(
-    const uint8_t* unaligned) {
+  requires std::is_trivially_copyable_v<T>
+inline T SafeLoadAs(const uint8_t* unaligned) {
   using Type = std::remove_const_t<T>;
   arrow::internal::AlignedStorage<Type> raw_data;
   std::memcpy(raw_data.get(), unaligned, sizeof(T));
@@ -65,7 +65,8 @@ inline std::enable_if_t<std::is_trivially_copyable_v<T>, T> SafeLoadAs(
 }
 
 template <typename T>
-inline std::enable_if_t<std::is_trivially_copyable_v<T>, T> SafeLoad(const T* unaligned) {
+  requires std::is_trivially_copyable_v<T>
+inline T SafeLoad(const T* unaligned) {
   using Type = std::remove_const_t<T>;
   arrow::internal::AlignedStorage<Type> raw_data;
   std::memcpy(raw_data.get(), static_cast<const void*>(unaligned), sizeof(T));
@@ -75,10 +76,9 @@ inline std::enable_if_t<std::is_trivially_copyable_v<T>, T> SafeLoad(const T* un
 }
 
 template <typename U, typename T>
-inline std::enable_if_t<std::is_trivially_copyable_v<T> &&
-                            std::is_trivially_copyable_v<U> && sizeof(T) == sizeof(U),
-                        U>
-SafeCopy(T value) {
+  requires(std::is_trivially_copyable_v<T> && std::is_trivially_copyable_v<U> &&
+           sizeof(T) == sizeof(U))
+inline U SafeCopy(T value) {
   using TypeU = std::remove_const_t<U>;
   arrow::internal::AlignedStorage<TypeU> raw_data;
   std::memcpy(raw_data.get(), static_cast<const void*>(&value), sizeof(T));
@@ -88,8 +88,8 @@ SafeCopy(T value) {
 }
 
 template <typename T>
-inline std::enable_if_t<std::is_trivially_copyable_v<T>, void> SafeStore(void* unaligned,
-                                                                         T value) {
+  requires std::is_trivially_copyable_v<T>
+inline void SafeStore(void* unaligned, T value) {
   std::memcpy(unaligned, &value, sizeof(T));
 }
 

--- a/cpp/src/arrow/util/value_parsing.h
+++ b/cpp/src/arrow/util/value_parsing.h
@@ -75,7 +75,7 @@ namespace internal {
 ///   `Convert` returns truthy for successful parses and assigns the parsed values to
 ///   `*out`. Parameters required for parsing (for example a timestamp's TimeUnit)
 ///   are acquired from the type parameter `t`.
-template <typename ARROW_TYPE, typename Enable = void>
+template <typename ARROW_TYPE>
 struct StringConverter;
 
 template <typename T>
@@ -856,7 +856,8 @@ struct StringConverter<DurationType>
 };
 
 template <typename DATE_TYPE>
-struct StringConverter<DATE_TYPE, enable_if_date<DATE_TYPE>> {
+  requires arrow_date<DATE_TYPE>
+struct StringConverter<DATE_TYPE> {
   using value_type = typename DATE_TYPE::c_type;
 
   using duration_type =
@@ -880,7 +881,8 @@ struct StringConverter<DATE_TYPE, enable_if_date<DATE_TYPE>> {
 };
 
 template <typename TIME_TYPE>
-struct StringConverter<TIME_TYPE, enable_if_time<TIME_TYPE>> {
+  requires arrow_time<TIME_TYPE>
+struct StringConverter<TIME_TYPE> {
   using value_type = typename TIME_TYPE::c_type;
 
   // We allow the following formats for all units:
@@ -955,8 +957,9 @@ bool ParseValue(const T& type, const char* s, size_t length,
 }
 
 template <typename T>
-enable_if_parameter_free<T, bool> ParseValue(
-    const char* s, size_t length, typename StringConverter<T>::value_type* out) {
+  requires arrow_parameter_free<T>
+bool ParseValue(const char* s, size_t length,
+                typename StringConverter<T>::value_type* out) {
   static T type;
   return StringConverter<T>{}.Convert(type, s, length, out);
 }

--- a/cpp/src/arrow/util/value_parsing_benchmark.cc
+++ b/cpp/src/arrow/util/value_parsing_benchmark.cc
@@ -99,8 +99,8 @@ static std::vector<std::string> MakeTimestampStrings(int32_t num_items) {
 }
 
 template <typename c_int, typename c_int_limits = std::numeric_limits<c_int>>
-static typename std::enable_if<c_int_limits::is_signed, std::vector<c_int>>::type
-MakeInts(int32_t num_items) {
+  requires c_int_limits::is_signed
+static std::vector<c_int> MakeInts(int32_t num_items) {
   std::vector<c_int> out;
   // C++ doesn't guarantee that all integer types support std::uniform_int_distribution,
   // so use a known type (int64_t)
@@ -109,8 +109,8 @@ MakeInts(int32_t num_items) {
 }
 
 template <typename c_int, typename c_int_limits = std::numeric_limits<c_int>>
-static typename std::enable_if<!c_int_limits::is_signed, std::vector<c_int>>::type
-MakeInts(int32_t num_items) {
+  requires !c_int_limits::is_signed
+           static std::vector<c_int> MakeInts(int32_t num_items) {
   std::vector<c_int> out;
   // See above.
   randint<uint64_t, c_int>(num_items, c_int_limits::min(), c_int_limits::max(), &out);

--- a/cpp/src/arrow/util/value_parsing_test.cc
+++ b/cpp/src/arrow/util/value_parsing_test.cc
@@ -25,6 +25,7 @@
 
 #include "arrow/testing/gtest_util.h"
 #include "arrow/type.h"
+#include "arrow/type_traits.h"
 #include "arrow/util/float16.h"
 #include "arrow/util/value_parsing.h"
 
@@ -37,8 +38,8 @@ namespace internal {
 template <typename T, typename E = void>
 struct ConversionValueTrait;
 
-template <typename T>
-struct ConversionValueTrait<T, enable_if_has_c_type<T>> {
+template <arrow_has_c_type T>
+struct ConversionValueTrait<T, void> {
   using Type = typename T::c_type;
 };
 

--- a/cpp/src/arrow/visit_data_inline.h
+++ b/cpp/src/arrow/visit_data_inline.h
@@ -17,7 +17,9 @@
 
 #pragma once
 
+#include <concepts>
 #include <string_view>
+#include <type_traits>
 
 #include "arrow/array.h"
 #include "arrow/status.h"
@@ -32,12 +34,12 @@
 namespace arrow {
 namespace internal {
 
-template <typename T, typename Enable = void>
+template <typename T>
 struct ArraySpanInlineVisitor {};
 
 // Numeric and primitive C-compatible types
-template <typename T>
-struct ArraySpanInlineVisitor<T, enable_if_has_c_type<T>> {
+template <arrow_has_c_type T>
+struct ArraySpanInlineVisitor<T> {
   using c_type = typename T::c_type;
 
   template <typename ValidFunc, typename NullFunc>
@@ -78,8 +80,8 @@ struct ArraySpanInlineVisitor<T, enable_if_has_c_type<T>> {
 };
 
 // Binary, String...
-template <typename T>
-struct ArraySpanInlineVisitor<T, enable_if_base_binary<T>> {
+template <arrow_base_binary T>
+struct ArraySpanInlineVisitor<T> {
   using c_type = std::string_view;
 
   template <typename ValidFunc, typename NullFunc>
@@ -146,8 +148,8 @@ struct ArraySpanInlineVisitor<T, enable_if_base_binary<T>> {
 };
 
 // BinaryView, StringView...
-template <typename T>
-struct ArraySpanInlineVisitor<T, enable_if_binary_view_like<T>> {
+template <arrow_binary_view_like T>
+struct ArraySpanInlineVisitor<T> {
   using c_type = std::string_view;
 
   template <typename ValidFunc, typename NullFunc>
@@ -182,8 +184,8 @@ struct ArraySpanInlineVisitor<T, enable_if_binary_view_like<T>> {
 };
 
 // FixedSizeBinary, Decimal128
-template <typename T>
-struct ArraySpanInlineVisitor<T, enable_if_fixed_size_binary<T>> {
+template <arrow_fixed_size_binary T>
+struct ArraySpanInlineVisitor<T> {
   using c_type = std::string_view;
 
   template <typename ValidFunc, typename NullFunc>
@@ -227,15 +229,21 @@ struct ArraySpanInlineVisitor<T, enable_if_fixed_size_binary<T>> {
 }  // namespace internal
 
 template <typename T, typename ValidFunc, typename NullFunc>
-typename internal::call_traits::enable_if_return<ValidFunc, Status>::type
-VisitArraySpanInline(const ArraySpan& arr, ValidFunc&& valid_func, NullFunc&& null_func) {
+  requires std::same_as<
+      Status, std::invoke_result_t<ValidFunc&,
+                                   typename internal::ArraySpanInlineVisitor<T>::c_type>>
+Status VisitArraySpanInline(const ArraySpan& arr, ValidFunc&& valid_func,
+                            NullFunc&& null_func) {
   return internal::ArraySpanInlineVisitor<T>::VisitStatus(
       arr, std::forward<ValidFunc>(valid_func), std::forward<NullFunc>(null_func));
 }
 
 template <typename T, typename ValidFunc, typename NullFunc>
-typename internal::call_traits::enable_if_return<ValidFunc, void>::type
-VisitArraySpanInline(const ArraySpan& arr, ValidFunc&& valid_func, NullFunc&& null_func) {
+  requires std::same_as<
+      void, std::invoke_result_t<ValidFunc&,
+                                 typename internal::ArraySpanInlineVisitor<T>::c_type>>
+void VisitArraySpanInline(const ArraySpan& arr, ValidFunc&& valid_func,
+                          NullFunc&& null_func) {
   return internal::ArraySpanInlineVisitor<T>::VisitVoid(
       arr, std::forward<ValidFunc>(valid_func), std::forward<NullFunc>(null_func));
 }
@@ -274,10 +282,10 @@ struct ArraySpanVisitor {
 // The `NullFunc` should have the same return type as `ValidFunc`.
 
 template <typename ValidFunc, typename NullFunc>
-typename internal::call_traits::enable_if_return<ValidFunc, Status>::type
-VisitNullBitmapInline(const uint8_t* valid_bits, int64_t valid_bits_offset,
-                      int64_t num_values, int64_t null_count, ValidFunc&& valid_func,
-                      NullFunc&& null_func) {
+  requires std::same_as<Status, std::invoke_result_t<ValidFunc&>>
+Status VisitNullBitmapInline(const uint8_t* valid_bits, int64_t valid_bits_offset,
+                             int64_t num_values, int64_t null_count,
+                             ValidFunc&& valid_func, NullFunc&& null_func) {
   internal::OptionalBitBlockCounter bit_counter(null_count == 0 ? NULLPTR : valid_bits,
                                                 valid_bits_offset, num_values);
   int64_t position = 0;
@@ -306,10 +314,10 @@ VisitNullBitmapInline(const uint8_t* valid_bits, int64_t valid_bits_offset,
 }
 
 template <typename ValidFunc, typename NullFunc>
-typename internal::call_traits::enable_if_return<ValidFunc, void>::type
-VisitNullBitmapInline(const uint8_t* valid_bits, int64_t valid_bits_offset,
-                      int64_t num_values, int64_t null_count, ValidFunc&& valid_func,
-                      NullFunc&& null_func) {
+  requires std::same_as<void, std::invoke_result_t<ValidFunc&>>
+void VisitNullBitmapInline(const uint8_t* valid_bits, int64_t valid_bits_offset,
+                           int64_t num_values, int64_t null_count, ValidFunc&& valid_func,
+                           NullFunc&& null_func) {
   internal::OptionalBitBlockCounter bit_counter(null_count == 0 ? NULLPTR : valid_bits,
                                                 valid_bits_offset, num_values);
   int64_t position = 0;


### PR DESCRIPTION
### Rationale for this change

We can replace the SFINAE-based enable_if_* patterns with C++20 concepts. This gives us better compiler diagnostics, cleaner code, and faster compile times.

### What changes are included in this PR?

Note: I have broken down the migration into several commits so that each commit can be independently reviewed.

- Defined equivalent arrow concepts in type_traits.h that wrap existing is_*_type traits.
- Migrated raw std::enable_if / enable_if_t<std::is_*> patterns to use standard <concepts> and requires.

### Are these changes tested?

Yes. No new tests needed since this is a pure refactor; the concept constraints are semantically equivalent to the old enable_if guards.

### Are there any user-facing changes?

No functional changes. Template error messages from the compiler will be more readable on type mismatches. The old enable_if_* aliases remain available, and can be cleaned up in a follow-up PR.
* GitHub Issue: #48590