### PR TITLE
GH-47657: [C++][Parquet] Check for integer overflow when coercing timestamps

### DIFF
--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -2178,6 +2178,53 @@ TEST(TestArrowReadWrite, ImplicitSecondToMillisecondTimestampCoercion) {
   ASSERT_NO_FATAL_FAILURE(::arrow::AssertTablesEqual(*tx, *to));
 }
 
+TEST(TestArrowReadWrite, TimestampCoercionOverflow) {
+  using ::arrow::ArrayFromVector;
+  using ::arrow::field;
+  using ::arrow::schema;
+
+  auto t_s = ::arrow::timestamp(TimeUnit::SECOND);
+
+  std::vector<int64_t> overflow_values = {9223372036854776LL};
+  std::vector<bool> is_valid = {true};
+
+  std::shared_ptr<Array> a_s;
+  ArrayFromVector<::arrow::TimestampType, int64_t>(t_s, is_valid, overflow_values, &a_s);
+
+  auto s = schema({field("timestamp", t_s)});
+  auto table = Table::Make(s, {a_s});
+
+  ASSERT_RAISES(Invalid, WriteTable(*table, ::arrow::default_memory_pool(),
+                                    CreateOutputStream(), table->num_rows()));
+
+  auto coerce_millis =
+      ArrowWriterProperties::Builder().coerce_timestamps(TimeUnit::MILLI)->build();
+  ASSERT_RAISES(Invalid,
+                WriteTable(*table, ::arrow::default_memory_pool(), CreateOutputStream(),
+                           table->num_rows(), default_writer_properties(), coerce_millis));
+
+  auto coerce_micros =
+      ArrowWriterProperties::Builder().coerce_timestamps(TimeUnit::MICRO)->build();
+  ASSERT_RAISES(Invalid,
+                WriteTable(*table, ::arrow::default_memory_pool(), CreateOutputStream(),
+                           table->num_rows(), default_writer_properties(), coerce_micros));
+
+  auto coerce_nanos =
+      ArrowWriterProperties::Builder().coerce_timestamps(TimeUnit::NANO)->build();
+  ASSERT_RAISES(Invalid,
+                WriteTable(*table, ::arrow::default_memory_pool(), CreateOutputStream(),
+                           table->num_rows(), default_writer_properties(), coerce_nanos));
+
+  std::vector<int64_t> null_overflow_values = {9223372036854776LL};
+  std::vector<bool> null_valid = {false};
+  std::shared_ptr<Array> a_null;
+  ArrayFromVector<::arrow::TimestampType, int64_t>(t_s, null_valid, null_overflow_values,
+                                                   &a_null);
+  auto null_table = Table::Make(s, {a_null});
+  ASSERT_OK_NO_THROW(WriteTable(*null_table, ::arrow::default_memory_pool(),
+                                CreateOutputStream(), null_table->num_rows()));
+}
+
 TEST(TestArrowReadWrite, ParquetVersionTimestampDifferences) {
   using ::arrow::ArrayFromVector;
   using ::arrow::field;

--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -2194,26 +2194,16 @@ TEST(TestArrowReadWrite, TimestampCoercionOverflow) {
   auto s = schema({field("timestamp", t_s)});
   auto table = Table::Make(s, {a_s});
 
-  ASSERT_RAISES(Invalid, WriteTable(*table, ::arrow::default_memory_pool(),
+  ASSERT_RAISES(Invalid, WriteTable(*table, default_memory_pool(),
                                     CreateOutputStream(), table->num_rows()));
 
-  auto coerce_millis =
-      ArrowWriterProperties::Builder().coerce_timestamps(TimeUnit::MILLI)->build();
-  ASSERT_RAISES(Invalid,
-                WriteTable(*table, ::arrow::default_memory_pool(), CreateOutputStream(),
-                           table->num_rows(), default_writer_properties(), coerce_millis));
-
-  auto coerce_micros =
-      ArrowWriterProperties::Builder().coerce_timestamps(TimeUnit::MICRO)->build();
-  ASSERT_RAISES(Invalid,
-                WriteTable(*table, ::arrow::default_memory_pool(), CreateOutputStream(),
-                           table->num_rows(), default_writer_properties(), coerce_micros));
-
-  auto coerce_nanos =
-      ArrowWriterProperties::Builder().coerce_timestamps(TimeUnit::NANO)->build();
-  ASSERT_RAISES(Invalid,
-                WriteTable(*table, ::arrow::default_memory_pool(), CreateOutputStream(),
-                           table->num_rows(), default_writer_properties(), coerce_nanos));
+  for (auto unit : {TimeUnit::MILLI, TimeUnit::MICRO, TimeUnit::NANO}) {
+    auto coerce_props =
+        ArrowWriterProperties::Builder().coerce_timestamps(unit)->build();
+    ASSERT_RAISES(Invalid,
+                  WriteTable(*table, default_memory_pool(), CreateOutputStream(),
+                             table->num_rows(), default_writer_properties(), coerce_props));
+  }
 
   std::vector<int64_t> null_overflow_values = {9223372036854776LL};
   std::vector<bool> null_valid = {false};
@@ -2221,7 +2211,7 @@ TEST(TestArrowReadWrite, TimestampCoercionOverflow) {
   ArrayFromVector<::arrow::TimestampType, int64_t>(t_s, null_valid, null_overflow_values,
                                                    &a_null);
   auto null_table = Table::Make(s, {a_null});
-  ASSERT_OK_NO_THROW(WriteTable(*null_table, ::arrow::default_memory_pool(),
+  ASSERT_OK_NO_THROW(WriteTable(*null_table, default_memory_pool(),
                                 CreateOutputStream(), null_table->num_rows()));
 }
 

--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -2182,39 +2182,35 @@ TEST(TestArrowReadWrite, TimestampCoercionOverflow) {
   using ::arrow::ArrayFromVector;
   using ::arrow::field;
   using ::arrow::schema;
-
   auto t_s = ::arrow::timestamp(TimeUnit::SECOND);
-
   std::vector<int64_t> overflow_values = {9223372036854776LL};
   std::vector<bool> is_valid = {true};
-
   std::shared_ptr<Array> a_s;
   ArrayFromVector<::arrow::TimestampType, int64_t>(t_s, is_valid, overflow_values, &a_s);
 
   auto s = schema({field("timestamp", t_s)});
   auto table = Table::Make(s, {a_s});
 
-  ASSERT_RAISES(Invalid, WriteTable(*table, default_memory_pool(),
-                                    CreateOutputStream(), table->num_rows()));
-
-  for (auto unit : {TimeUnit::MILLI, TimeUnit::MICRO, TimeUnit::NANO}) {
-    auto coerce_props =
-        ArrowWriterProperties::Builder().coerce_timestamps(unit)->build();
-    ASSERT_RAISES(
-        Invalid,
-        WriteTable(*table, default_memory_pool(), CreateOutputStream(),
-                   table->num_rows(), default_writer_properties(),
-                   coerce_props));
+  for (auto unit : {TimeUnit::SECOND, TimeUnit::MILLI, TimeUnit::MICRO, TimeUnit::NANO}) {
+    if (unit == TimeUnit::SECOND) {
+      ASSERT_RAISES(Invalid, WriteTable(*table, default_memory_pool(),
+                                        CreateOutputStream(), table->num_rows()));
+    } else {
+      auto coerce_props =
+          ArrowWriterProperties::Builder().coerce_timestamps(unit)->build();
+      ASSERT_RAISES(Invalid, WriteTable(*table, default_memory_pool(),
+                                        CreateOutputStream(), table->num_rows(),
+                                        default_writer_properties(), coerce_props));
+    }
   }
 
-  std::vector<int64_t> null_overflow_values = {9223372036854776LL};
   std::vector<bool> null_valid = {false};
   std::shared_ptr<Array> a_null;
-  ArrayFromVector<::arrow::TimestampType, int64_t>(t_s, null_valid, null_overflow_values,
+  ArrayFromVector<::arrow::TimestampType, int64_t>(t_s, null_valid, overflow_values,
                                                    &a_null);
   auto null_table = Table::Make(s, {a_null});
-  ASSERT_OK_NO_THROW(WriteTable(*null_table, default_memory_pool(),
-                                CreateOutputStream(), null_table->num_rows()));
+  ASSERT_OK_NO_THROW(WriteTable(*null_table, default_memory_pool(), CreateOutputStream(),
+                                null_table->num_rows()));
 }
 
 TEST(TestArrowReadWrite, ParquetVersionTimestampDifferences) {

--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -2200,9 +2200,11 @@ TEST(TestArrowReadWrite, TimestampCoercionOverflow) {
   for (auto unit : {TimeUnit::MILLI, TimeUnit::MICRO, TimeUnit::NANO}) {
     auto coerce_props =
         ArrowWriterProperties::Builder().coerce_timestamps(unit)->build();
-    ASSERT_RAISES(Invalid,
-                  WriteTable(*table, default_memory_pool(), CreateOutputStream(),
-                             table->num_rows(), default_writer_properties(), coerce_props));
+    ASSERT_RAISES(
+        Invalid,
+        WriteTable(*table, default_memory_pool(), CreateOutputStream(),
+                   table->num_rows(), default_writer_properties(),
+                   coerce_props));
   }
 
   std::vector<int64_t> null_overflow_values = {9223372036854776LL};

--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -2353,9 +2353,9 @@ struct SerializeFunctor<Int64Type, ::arrow::TimestampType> {
 
     auto MultiplyBy = [&](const int64_t factor) {
       for (int64_t i = 0; i < array.length(); i++) {
-        if (ARROW_PREDICT_FALSE(::arrow::internal::MultiplyWithOverflowGeneric(
-                values[i], factor, &out[i])) &&
-            array.IsValid(i)) {
+        if (array.IsValid(i) &&
+            ARROW_PREDICT_FALSE(::arrow::internal::MultiplyWithOverflowGeneric(
+                values[i], factor, &out[i]))) {
           return Status::Invalid("Integer overflow when casting timestamp value ",
                                  values[i], " from ", source_type.ToString(), " to ",
                                  target_type->ToString());

--- a/cpp/src/parquet/column_writer.cc
+++ b/cpp/src/parquet/column_writer.cc
@@ -41,6 +41,7 @@
 #include "arrow/util/crc32.h"
 #include "arrow/util/endian.h"
 #include "arrow/util/float16.h"
+#include "arrow/util/int_util_overflow.h"
 #include "arrow/util/key_value_metadata.h"
 #include "arrow/util/logging_internal.h"
 #include "arrow/util/rle_encoding_internal.h"
@@ -2352,7 +2353,13 @@ struct SerializeFunctor<Int64Type, ::arrow::TimestampType> {
 
     auto MultiplyBy = [&](const int64_t factor) {
       for (int64_t i = 0; i < array.length(); i++) {
-        out[i] = values[i] * factor;
+        if (ARROW_PREDICT_FALSE(::arrow::internal::MultiplyWithOverflowGeneric(
+                values[i], factor, &out[i])) &&
+            array.IsValid(i)) {
+          return Status::Invalid("Integer overflow when casting timestamp value ",
+                                 values[i], " from ", source_type.ToString(), " to ",
+                                 target_type->ToString());
+        }
       }
       return Status::OK();
     };


### PR DESCRIPTION
### Rationale for this change
 - When writing Arrow timestamps to Parquet, timestamp values are multiplied to convert units
 - This multiplication was performed without overflow checking which can silently write corrupt data.

### What changes are included in this PR?
 - Use MultiplyWithOverflowGeneric to handle/detect overflow

### Are these changes tested?
 - Yes
### Are there any user-facing changes?
 - Yes

* GitHub Issue: #47657