### PR TITLE
GH-49617: [C++][CI] Validate all batches in IPC file fuzzer

### DIFF
--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -2807,6 +2807,7 @@ Status FuzzIpcFile(const uint8_t* data, int64_t size) {
         // EOS
         break;
       }
+      RETURN_NOT_OK(ValidateFuzzBatch(batch));
       batches.push_back(batch);
     }
     return IpcReadResult{batch_reader->schema(), batches};


### PR DESCRIPTION
### Rationale for this change

When using the IPC stream reader for differential fuzzing against the IPC file reader, ensure we validate batches because otherwise we might be doing invalid memory accesses down the road.

### Are these changes tested?

By additional fuzz regression file.

### Are there any user-facing changes?

No.

* GitHub Issue: #49617