### PR TITLE
GH-49623: [CI][Python] Install built wheel on Windows verification and test in isolation

### DIFF
--- a/dev/release/verify-release-candidate.bat
+++ b/dev/release/verify-release-candidate.bat
@@ -147,6 +147,6 @@ python -m build --sdist --wheel . --no-isolation || exit /B 1
 for %%f in (dist\*.whl) do pip install %%f || exit /B 1
 popd
 
-pytest pyarrow -v -s --enable-parquet || exit /B 1
+pytest --pyargs pyarrow -v -s --enable-parquet || exit /B 1
 
 call deactivate

--- a/dev/release/verify-release-candidate.bat
+++ b/dev/release/verify-release-candidate.bat
@@ -143,8 +143,10 @@ set PYARROW_WITH_DATASET=1
 set PYARROW_TEST_CYTHON=OFF
 set PYARROW_BUNDLE_ARROW_CPP=ON
 python -m build --sdist --wheel . --no-isolation || exit /B 1
-pytest pyarrow -v -s --enable-parquet || exit /B 1
-
+@rem Install the built wheel to verify it works
+for %%f in (dist\*.whl) do pip install %%f || exit /B 1
 popd
+
+pytest pyarrow -v -s --enable-parquet || exit /B 1
 
 call deactivate

--- a/dev/release/verify-release-candidate.bat
+++ b/dev/release/verify-release-candidate.bat
@@ -147,6 +147,7 @@ python -m build --sdist --wheel . --no-isolation || exit /B 1
 for %%f in (dist\*.whl) do pip install %%f || exit /B 1
 popd
 
-pytest --pyargs pyarrow -v -s --enable-parquet || exit /B 1
+set PYARROW_TEST_PARQUET=ON
+pytest --pyargs pyarrow -v -s || exit /B 1
 
 call deactivate


### PR DESCRIPTION
### Rationale for this change

Verification job is currently failing on Windows.

### What changes are included in this PR?

With the changes on sckit-build-core we changed how we build the wheel on Windows verification. Previously we were doing editable installations. For verification we should install the built wheel and test on isolation, not in-source.

### Are these changes tested?

Yes via CI

### Are there any user-facing changes?
No
* GitHub Issue: #49623