### PR TITLE
GH-49622:[R][CI] Some R CI jobs seem unable to access some S3 files on arrow-datasets bucket

### DIFF
--- a/r/tests/testthat/test-s3.R
+++ b/r/tests/testthat/test-s3.R
@@ -26,7 +26,7 @@ run_these <- tryCatch(
         !identical(Sys.getenv("AWS_SECRET_ACCESS_KEY"), "")
     ) {
       # See if we have access to the test bucket
-      bucket <- s3_bucket("arrow-datasets")
+      bucket <- s3_bucket("arrow-r-ci-test")
       bucket$GetFileInfo("")
       TRUE
     } else {
@@ -36,7 +36,7 @@ run_these <- tryCatch(
   error = function(e) FALSE
 )
 
-bucket_uri <- function(..., bucket = "s3://arrow-datasets/%s?region=us-east-1") {
+bucket_uri <- function(..., bucket = "s3://arrow-r-ci-test/%s?region=us-east-1") {
   segments <- paste(..., sep = "/")
   sprintf(bucket, segments)
 }


### PR DESCRIPTION
### Rationale for this change

Can't write to buckets, need new bucket so set one up with write access

### What changes are included in this PR?

Point to new bucket

### Are these changes tested?

By CI, yeah

### Are there any user-facing changes?

Nope
* GitHub Issue: #49622