### PR TITLE
GH-49628: [Python][Interchange protocol] Suppress warnings for pandas 4.0.0 and update docs

### DIFF
--- a/docs/source/python/interchange_protocol.rst
+++ b/docs/source/python/interchange_protocol.rst
@@ -36,6 +36,12 @@ libraries in the Python ecosystem. See more about the
 standard in the
 `protocol documentation <https://data-apis.org/dataframe-protocol/latest/index.html>`_.
 
+.. note::
+
+   The recommended way to convert between dataframe libraries is through
+   the :ref:`arrow-pycapsule-interface`, for example by calling ``pa.table(df)``
+   on a dataframe object that implements it.
+
 From PyArrow to other libraries: ``__dataframe__()`` method
 -----------------------------------------------------------
 

--- a/docs/source/python/interchange_protocol.rst
+++ b/docs/source/python/interchange_protocol.rst
@@ -61,33 +61,8 @@ from any dataframe object that implements the
 ``__dataframe__()`` method via the dataframe interchange
 protocol.
 
-We can for example take a pandas dataframe and construct a
+We can for example take a polars dataframe and construct a
 PyArrow table with the use of the interchange protocol:
-
-.. code-block:: python
-
-    >>> import pyarrow
-    >>> from pyarrow.interchange import from_dataframe
-
-    >>> import pandas as pd
-    >>> df = pd.DataFrame({
-    ...         "n_attendees": [100, 10, 1],
-    ...         "country": ["Italy", "Spain", "Slovenia"],
-    ...     })
-    >>> df
-       n_attendees   country
-    0          100     Italy
-    1           10     Spain
-    2            1  Slovenia
-    >>> from_dataframe(df)
-    pyarrow.Table
-    n_attendees: int64
-    country: large_string
-    ----
-    n_attendees: [[100,10,1]]
-    country: [["Italy","Spain","Slovenia"]]
-
-We can do the same with a polars dataframe:
 
 .. code-block:: python
 

--- a/python/pyarrow/interchange/from_dataframe.py
+++ b/python/pyarrow/interchange/from_dataframe.py
@@ -76,31 +76,6 @@ def from_dataframe(df: DataFrameObject, allow_copy=True) -> pa.Table:
     Returns
     -------
     pa.Table
-
-    Examples
-    --------
-    >>> import pyarrow
-    >>> from pyarrow.interchange import from_dataframe
-
-    Convert a pandas dataframe to a pyarrow table:
-
-    >>> import pandas as pd
-    >>> df = pd.DataFrame({
-    ...         "n_attendees": [100, 10, 1],
-    ...         "country": ["Italy", "Spain", "Slovenia"],
-    ...     })
-    >>> df
-       n_attendees   country
-    0          100     Italy
-    1           10     Spain
-    2            1  Slovenia
-    >>> from_dataframe(df)
-    pyarrow.Table
-    n_attendees: int64
-    country: large_string
-    ----
-    n_attendees: [[100,10,1]]
-    country: [["Italy","Spain","Slovenia"]]
     """
     if isinstance(df, pa.Table):
         return df

--- a/python/pyarrow/tests/interchange/test_conversion.py
+++ b/python/pyarrow/tests/interchange/test_conversion.py
@@ -103,6 +103,10 @@ def test_offset_of_sliced_array():
     #                        check_index=False, check_names=False)
 
 
+@pytest.mark.filterwarnings(
+    "ignore:The Dataframe Interchange Protocol "
+    "is deprecated:pandas.errors.Pandas4Warning"
+)
 @pytest.mark.pandas
 @pytest.mark.parametrize(
     "uint", [pa.uint8(), pa.uint16(), pa.uint32()]
@@ -146,6 +150,10 @@ def test_pandas_roundtrip(uint, int, float, np_float_str):
     assert table_protocol.column_names() == result_protocol.column_names()
 
 
+@pytest.mark.filterwarnings(
+    "ignore:The Dataframe Interchange Protocol "
+    "is deprecated:pandas.errors.Pandas4Warning"
+)
 @pytest.mark.pandas
 def test_pandas_roundtrip_string():
     # See https://github.com/pandas-dev/pandas/issues/50554
@@ -175,6 +183,10 @@ def test_pandas_roundtrip_string():
     assert table_protocol.column_names() == result_protocol.column_names()
 
 
+@pytest.mark.filterwarnings(
+    "ignore:The Dataframe Interchange Protocol "
+    "is deprecated:pandas.errors.Pandas4Warning"
+)
 @pytest.mark.pandas
 def test_pandas_roundtrip_large_string():
     # See https://github.com/pandas-dev/pandas/issues/50554
@@ -212,6 +224,10 @@ def test_pandas_roundtrip_large_string():
             pandas_from_dataframe(table)
 
 
+@pytest.mark.filterwarnings(
+    "ignore:The Dataframe Interchange Protocol "
+    "is deprecated:pandas.errors.Pandas4Warning"
+)
 @pytest.mark.pandas
 def test_pandas_roundtrip_string_with_missing():
     # See https://github.com/pandas-dev/pandas/issues/50554
@@ -244,6 +260,10 @@ def test_pandas_roundtrip_string_with_missing():
             pandas_from_dataframe(table)
 
 
+@pytest.mark.filterwarnings(
+    "ignore:The Dataframe Interchange Protocol "
+    "is deprecated:pandas.errors.Pandas4Warning"
+)
 @pytest.mark.pandas
 def test_pandas_roundtrip_categorical():
     if Version(pd.__version__) < Version("2.0.2"):
@@ -292,6 +312,10 @@ def test_pandas_roundtrip_categorical():
     assert isinstance(desc_cat_result["categories"]._col, pa.Array)
 
 
+@pytest.mark.filterwarnings(
+    "ignore:The Dataframe Interchange Protocol "
+    "is deprecated:pandas.errors.Pandas4Warning"
+)
 @pytest.mark.pandas
 @pytest.mark.parametrize("unit", ['s', 'ms', 'us', 'ns'])
 def test_pandas_roundtrip_datetime(unit):
@@ -328,6 +352,10 @@ def test_pandas_roundtrip_datetime(unit):
     assert expected_protocol.column_names() == result_protocol.column_names()
 
 
+@pytest.mark.filterwarnings(
+    "ignore:The Dataframe Interchange Protocol "
+    "is deprecated:pandas.errors.Pandas4Warning"
+)
 @pytest.mark.pandas
 @pytest.mark.parametrize(
     "np_float_str", ["float32", "float64"]
@@ -353,6 +381,10 @@ def test_pandas_to_pyarrow_with_missing(np_float_str):
     assert result.equals(expected)
 
 
+@pytest.mark.filterwarnings(
+    "ignore:The Dataframe Interchange Protocol "
+    "is deprecated:pandas.errors.Pandas4Warning"
+)
 @pytest.mark.pandas
 def test_pandas_to_pyarrow_float16_with_missing():
     if Version(pd.__version__) < Version("1.5.0"):
@@ -476,6 +508,10 @@ def test_nan_as_null():
         table.__dataframe__(nan_as_null=True)
 
 
+@pytest.mark.filterwarnings(
+    "ignore:The Dataframe Interchange Protocol "
+    "is deprecated:pandas.errors.Pandas4Warning"
+)
 @pytest.mark.pandas
 def test_allow_copy_false():
     if Version(pd.__version__) < Version("1.5.0"):
@@ -495,6 +531,10 @@ def test_allow_copy_false():
         pi.from_dataframe(df, allow_copy=False)
 
 
+@pytest.mark.filterwarnings(
+    "ignore:The Dataframe Interchange Protocol "
+    "is deprecated:pandas.errors.Pandas4Warning"
+)
 @pytest.mark.pandas
 def test_allow_copy_false_bool_categorical():
     if Version(pd.__version__) < Version("1.5.0"):

--- a/python/pyarrow/tests/interchange/test_conversion.py
+++ b/python/pyarrow/tests/interchange/test_conversion.py
@@ -104,8 +104,7 @@ def test_offset_of_sliced_array():
 
 
 @pytest.mark.filterwarnings(
-    "ignore:The Dataframe Interchange Protocol "
-    "is deprecated:pandas.errors.Pandas4Warning"
+    "ignore:The Dataframe Interchange Protocol is deprecated."
 )
 @pytest.mark.pandas
 @pytest.mark.parametrize(
@@ -151,8 +150,7 @@ def test_pandas_roundtrip(uint, int, float, np_float_str):
 
 
 @pytest.mark.filterwarnings(
-    "ignore:The Dataframe Interchange Protocol "
-    "is deprecated:pandas.errors.Pandas4Warning"
+    "ignore:The Dataframe Interchange Protocol is deprecated."
 )
 @pytest.mark.pandas
 def test_pandas_roundtrip_string():
@@ -184,8 +182,7 @@ def test_pandas_roundtrip_string():
 
 
 @pytest.mark.filterwarnings(
-    "ignore:The Dataframe Interchange Protocol "
-    "is deprecated:pandas.errors.Pandas4Warning"
+    "ignore:The Dataframe Interchange Protocol is deprecated."
 )
 @pytest.mark.pandas
 def test_pandas_roundtrip_large_string():
@@ -225,8 +222,7 @@ def test_pandas_roundtrip_large_string():
 
 
 @pytest.mark.filterwarnings(
-    "ignore:The Dataframe Interchange Protocol "
-    "is deprecated:pandas.errors.Pandas4Warning"
+    "ignore:The Dataframe Interchange Protocol is deprecated."
 )
 @pytest.mark.pandas
 def test_pandas_roundtrip_string_with_missing():
@@ -261,8 +257,7 @@ def test_pandas_roundtrip_string_with_missing():
 
 
 @pytest.mark.filterwarnings(
-    "ignore:The Dataframe Interchange Protocol "
-    "is deprecated:pandas.errors.Pandas4Warning"
+    "ignore:The Dataframe Interchange Protocol is deprecated."
 )
 @pytest.mark.pandas
 def test_pandas_roundtrip_categorical():
@@ -313,8 +308,7 @@ def test_pandas_roundtrip_categorical():
 
 
 @pytest.mark.filterwarnings(
-    "ignore:The Dataframe Interchange Protocol "
-    "is deprecated:pandas.errors.Pandas4Warning"
+    "ignore:The Dataframe Interchange Protocol is deprecated."
 )
 @pytest.mark.pandas
 @pytest.mark.parametrize("unit", ['s', 'ms', 'us', 'ns'])
@@ -353,8 +347,7 @@ def test_pandas_roundtrip_datetime(unit):
 
 
 @pytest.mark.filterwarnings(
-    "ignore:The Dataframe Interchange Protocol "
-    "is deprecated:pandas.errors.Pandas4Warning"
+    "ignore:The Dataframe Interchange Protocol is deprecated."
 )
 @pytest.mark.pandas
 @pytest.mark.parametrize(
@@ -382,8 +375,7 @@ def test_pandas_to_pyarrow_with_missing(np_float_str):
 
 
 @pytest.mark.filterwarnings(
-    "ignore:The Dataframe Interchange Protocol "
-    "is deprecated:pandas.errors.Pandas4Warning"
+    "ignore:The Dataframe Interchange Protocol is deprecated."
 )
 @pytest.mark.pandas
 def test_pandas_to_pyarrow_float16_with_missing():
@@ -509,8 +501,7 @@ def test_nan_as_null():
 
 
 @pytest.mark.filterwarnings(
-    "ignore:The Dataframe Interchange Protocol "
-    "is deprecated:pandas.errors.Pandas4Warning"
+    "ignore:The Dataframe Interchange Protocol is deprecated."
 )
 @pytest.mark.pandas
 def test_allow_copy_false():
@@ -532,8 +523,7 @@ def test_allow_copy_false():
 
 
 @pytest.mark.filterwarnings(
-    "ignore:The Dataframe Interchange Protocol "
-    "is deprecated:pandas.errors.Pandas4Warning"
+    "ignore:The Dataframe Interchange Protocol is deprecated."
 )
 @pytest.mark.pandas
 def test_allow_copy_false_bool_categorical():

--- a/python/pyarrow/tests/interchange/test_conversion.py
+++ b/python/pyarrow/tests/interchange/test_conversion.py
@@ -40,6 +40,10 @@ except ImportError:
     pass
 
 
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:The Dataframe Interchange Protocol is deprecated.")
+
+
 @pytest.mark.parametrize("unit", ['s', 'ms', 'us', 'ns'])
 @pytest.mark.parametrize("tz", ['', 'America/New_York', '+07:30', '-04:30'])
 def test_datetime(unit, tz):
@@ -103,9 +107,6 @@ def test_offset_of_sliced_array():
     #                        check_index=False, check_names=False)
 
 
-@pytest.mark.filterwarnings(
-    "ignore:The Dataframe Interchange Protocol is deprecated."
-)
 @pytest.mark.pandas
 @pytest.mark.parametrize(
     "uint", [pa.uint8(), pa.uint16(), pa.uint32()]
@@ -149,9 +150,6 @@ def test_pandas_roundtrip(uint, int, float, np_float_str):
     assert table_protocol.column_names() == result_protocol.column_names()
 
 
-@pytest.mark.filterwarnings(
-    "ignore:The Dataframe Interchange Protocol is deprecated."
-)
 @pytest.mark.pandas
 def test_pandas_roundtrip_string():
     # See https://github.com/pandas-dev/pandas/issues/50554
@@ -181,9 +179,6 @@ def test_pandas_roundtrip_string():
     assert table_protocol.column_names() == result_protocol.column_names()
 
 
-@pytest.mark.filterwarnings(
-    "ignore:The Dataframe Interchange Protocol is deprecated."
-)
 @pytest.mark.pandas
 def test_pandas_roundtrip_large_string():
     # See https://github.com/pandas-dev/pandas/issues/50554
@@ -221,9 +216,6 @@ def test_pandas_roundtrip_large_string():
             pandas_from_dataframe(table)
 
 
-@pytest.mark.filterwarnings(
-    "ignore:The Dataframe Interchange Protocol is deprecated."
-)
 @pytest.mark.pandas
 def test_pandas_roundtrip_string_with_missing():
     # See https://github.com/pandas-dev/pandas/issues/50554
@@ -256,9 +248,6 @@ def test_pandas_roundtrip_string_with_missing():
             pandas_from_dataframe(table)
 
 
-@pytest.mark.filterwarnings(
-    "ignore:The Dataframe Interchange Protocol is deprecated."
-)
 @pytest.mark.pandas
 def test_pandas_roundtrip_categorical():
     if Version(pd.__version__) < Version("2.0.2"):
@@ -307,9 +296,6 @@ def test_pandas_roundtrip_categorical():
     assert isinstance(desc_cat_result["categories"]._col, pa.Array)
 
 
-@pytest.mark.filterwarnings(
-    "ignore:The Dataframe Interchange Protocol is deprecated."
-)
 @pytest.mark.pandas
 @pytest.mark.parametrize("unit", ['s', 'ms', 'us', 'ns'])
 def test_pandas_roundtrip_datetime(unit):
@@ -346,9 +332,6 @@ def test_pandas_roundtrip_datetime(unit):
     assert expected_protocol.column_names() == result_protocol.column_names()
 
 
-@pytest.mark.filterwarnings(
-    "ignore:The Dataframe Interchange Protocol is deprecated."
-)
 @pytest.mark.pandas
 @pytest.mark.parametrize(
     "np_float_str", ["float32", "float64"]
@@ -374,9 +357,6 @@ def test_pandas_to_pyarrow_with_missing(np_float_str):
     assert result.equals(expected)
 
 
-@pytest.mark.filterwarnings(
-    "ignore:The Dataframe Interchange Protocol is deprecated."
-)
 @pytest.mark.pandas
 def test_pandas_to_pyarrow_float16_with_missing():
     if Version(pd.__version__) < Version("1.5.0"):
@@ -500,9 +480,6 @@ def test_nan_as_null():
         table.__dataframe__(nan_as_null=True)
 
 
-@pytest.mark.filterwarnings(
-    "ignore:The Dataframe Interchange Protocol is deprecated."
-)
 @pytest.mark.pandas
 def test_allow_copy_false():
     if Version(pd.__version__) < Version("1.5.0"):
@@ -522,9 +499,6 @@ def test_allow_copy_false():
         pi.from_dataframe(df, allow_copy=False)
 
 
-@pytest.mark.filterwarnings(
-    "ignore:The Dataframe Interchange Protocol is deprecated."
-)
 @pytest.mark.pandas
 def test_allow_copy_false_bool_categorical():
     if Version(pd.__version__) < Version("1.5.0"):


### PR DESCRIPTION
### Rationale for this change
Pandas is moving the dataframe interchange protocol out of the repo in the next major release (4.0.0).

### What changes are included in this PR?
Filterwarnings are added and the pandas example is removed from the interchange documentation.

### Are these changes tested?
Yes, via CI.

### Are there any user-facing changes?
No.

* GitHub Issue: #49628