### PR TITLE
GH-49634: [Ruby][Integration] Follow dictionary array API change

### DIFF
--- a/ruby/red-arrow-format/lib/arrow-format/integration/json-reader.rb
+++ b/ruby/red-arrow-format/lib/arrow-format/integration/json-reader.rb
@@ -384,7 +384,8 @@ module ArrowFormat
         when DictionaryType
           validity_buffer = read_bitmap(column["VALIDITY"])
           indices_buffer = read_values(column["DATA"], type.index_type)
-          dictionary = read_dictionary(type.id, type.value_type)
+          dictionary_array = read_dictionary(type.id, type.value_type)
+          dictionary = Dictionary.new(type.id, dictionary_array)
           type.build_array(length,
                            validity_buffer,
                            indices_buffer,


### PR DESCRIPTION
### Rationale for this change

GH-49621 changed dictionary array related API but we didn't follow the API change in integration test code.

### What changes are included in this PR?

Follow dictionary array related API change in integration test code.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #49634