### PR TITLE
GH-49227: [Python] Deprecate `pyarrow.gandiva`

### DIFF
--- a/docs/source/developers/python/building.rst
+++ b/docs/source/developers/python/building.rst
@@ -621,7 +621,7 @@ certain components to be built):
    * - ``ARROW_ORC``
      - ``PYARROW_WITH_ORC``
    * - ``ARROW_GANDIVA``
-     - ``PYARROW_WITH_GANDIVA``
+     - ``PYARROW_WITH_GANDIVA`` (deprecated since version 24.0.0)
 
 Installing Nightly Packages
 ===========================

--- a/docs/source/developers/python/development.rst
+++ b/docs/source/developers/python/development.rst
@@ -90,7 +90,7 @@ The test groups currently include:
 
 * ``dataset``: Apache Arrow Dataset tests
 * ``flight``: Flight RPC tests
-* ``gandiva``: tests for Gandiva expression compiler (uses LLVM)
+* ``gandiva``: tests for Gandiva expression compiler (uses LLVM, deprecated since version 24.0.0)
 * ``hdfs``: tests that use libhdfs to access the Hadoop filesystem
 * ``hypothesis``: tests that use the ``hypothesis`` module for generating
   random test cases. Note that ``--hypothesis`` doesn't work due to a quirk

--- a/python/pyarrow/gandiva.pyx
+++ b/python/pyarrow/gandiva.pyx
@@ -75,6 +75,14 @@ from pyarrow.includes.libgandiva cimport (
     GetRegisteredFunctionSignatures)
 
 
+import warnings
+warnings.warn(
+    "pyarrow.gandiva is deprecated as of 24.0.0 and will be removed in a future version.",
+    FutureWarning,
+    stacklevel=2,
+    )
+
+
 cdef class Node(_Weakrefable):
     cdef:
         shared_ptr[CNode] node

--- a/python/pyarrow/gandiva.pyx
+++ b/python/pyarrow/gandiva.pyx
@@ -80,7 +80,7 @@ warnings.warn(
     "pyarrow.gandiva is deprecated as of 24.0.0 and will be removed in a future version.",
     FutureWarning,
     stacklevel=2,
-    )
+)
 
 
 cdef class Node(_Weakrefable):

--- a/python/pyarrow/tests/test_gandiva.py
+++ b/python/pyarrow/tests/test_gandiva.py
@@ -20,8 +20,12 @@ import pytest
 
 import pyarrow as pa
 
+pytestmark = [
+    pytest.mark.gandiva,
+    pytest.mark.filterwarnings("ignore:pyarrow.gandiva is deprecated"),
+    ]
 
-@pytest.mark.gandiva
+
 def test_tree_exp_builder():
     import pyarrow.gandiva as gandiva
 
@@ -63,7 +67,6 @@ def test_tree_exp_builder():
     assert r.equals(e)
 
 
-@pytest.mark.gandiva
 def test_table():
     import pyarrow.gandiva as gandiva
 
@@ -90,7 +93,6 @@ def test_table():
     assert r.equals(e)
 
 
-@pytest.mark.gandiva
 def test_filter():
     import pyarrow.gandiva as gandiva
 
@@ -114,7 +116,6 @@ def test_filter():
     assert result.to_array().equals(pa.array(range(1000), type=pa.uint32()))
 
 
-@pytest.mark.gandiva
 def test_in_expr():
     import pyarrow.gandiva as gandiva
 
@@ -225,7 +226,6 @@ def test_in_expr_todo():
     assert list(result.to_array()) == [1]
 
 
-@pytest.mark.gandiva
 def test_boolean():
     import pyarrow.gandiva as gandiva
 
@@ -252,7 +252,6 @@ def test_boolean():
     assert result.to_array().equals(pa.array([0, 2, 5], type=pa.uint32()))
 
 
-@pytest.mark.gandiva
 def test_literals():
     import pyarrow.gandiva as gandiva
 
@@ -292,7 +291,6 @@ def test_literals():
         builder.make_literal(True, None)
 
 
-@pytest.mark.gandiva
 def test_regex():
     import pyarrow.gandiva as gandiva
 
@@ -316,7 +314,6 @@ def test_regex():
     assert r.equals(b)
 
 
-@pytest.mark.gandiva
 def test_get_registered_function_signatures():
     import pyarrow.gandiva as gandiva
     signatures = gandiva.get_registered_function_signatures()
@@ -326,7 +323,6 @@ def test_get_registered_function_signatures():
     assert hasattr(signatures[0], "name")
 
 
-@pytest.mark.gandiva
 def test_filter_project():
     import pyarrow.gandiva as gandiva
     mpool = pa.default_memory_pool()
@@ -373,7 +369,6 @@ def test_filter_project():
     assert r.equals(exp)
 
 
-@pytest.mark.gandiva
 def test_to_string():
     import pyarrow.gandiva as gandiva
     builder = gandiva.TreeExprBuilder()
@@ -393,7 +388,6 @@ def test_to_string():
     assert str(and_node) == 'bool not((bool) z) && (bool) y'
 
 
-@pytest.mark.gandiva
 def test_rejects_none():
     import pyarrow.gandiva as gandiva
 

--- a/python/pyarrow/tests/test_gandiva.py
+++ b/python/pyarrow/tests/test_gandiva.py
@@ -20,12 +20,8 @@ import pytest
 
 import pyarrow as pa
 
-pytestmark = [
-    pytest.mark.gandiva,
-    pytest.mark.filterwarnings("ignore:pyarrow.gandiva is deprecated"),
-    ]
 
-
+@pytest.mark.gandiva
 def test_tree_exp_builder():
     import pyarrow.gandiva as gandiva
 
@@ -67,6 +63,7 @@ def test_tree_exp_builder():
     assert r.equals(e)
 
 
+@pytest.mark.gandiva
 def test_table():
     import pyarrow.gandiva as gandiva
 
@@ -93,6 +90,7 @@ def test_table():
     assert r.equals(e)
 
 
+@pytest.mark.gandiva
 def test_filter():
     import pyarrow.gandiva as gandiva
 
@@ -116,6 +114,7 @@ def test_filter():
     assert result.to_array().equals(pa.array(range(1000), type=pa.uint32()))
 
 
+@pytest.mark.gandiva
 def test_in_expr():
     import pyarrow.gandiva as gandiva
 
@@ -226,6 +225,7 @@ def test_in_expr_todo():
     assert list(result.to_array()) == [1]
 
 
+@pytest.mark.gandiva
 def test_boolean():
     import pyarrow.gandiva as gandiva
 
@@ -252,6 +252,7 @@ def test_boolean():
     assert result.to_array().equals(pa.array([0, 2, 5], type=pa.uint32()))
 
 
+@pytest.mark.gandiva
 def test_literals():
     import pyarrow.gandiva as gandiva
 
@@ -291,6 +292,7 @@ def test_literals():
         builder.make_literal(True, None)
 
 
+@pytest.mark.gandiva
 def test_regex():
     import pyarrow.gandiva as gandiva
 
@@ -314,6 +316,7 @@ def test_regex():
     assert r.equals(b)
 
 
+@pytest.mark.gandiva
 def test_get_registered_function_signatures():
     import pyarrow.gandiva as gandiva
     signatures = gandiva.get_registered_function_signatures()
@@ -323,6 +326,7 @@ def test_get_registered_function_signatures():
     assert hasattr(signatures[0], "name")
 
 
+@pytest.mark.gandiva
 def test_filter_project():
     import pyarrow.gandiva as gandiva
     mpool = pa.default_memory_pool()
@@ -369,6 +373,7 @@ def test_filter_project():
     assert r.equals(exp)
 
 
+@pytest.mark.gandiva
 def test_to_string():
     import pyarrow.gandiva as gandiva
     builder = gandiva.TreeExprBuilder()
@@ -388,6 +393,7 @@ def test_to_string():
     assert str(and_node) == 'bool not((bool) z) && (bool) y'
 
 
+@pytest.mark.gandiva
 def test_rejects_none():
     import pyarrow.gandiva as gandiva
 

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -22,6 +22,8 @@ build-dir  = doc/_build
 [tool:pytest]
 addopts = --ignore=scripts
 filterwarnings =
+    # https://github.com/apache/arrow/issues/49227
+    ignore:pyarrow.gandiva is deprecated:FutureWarning
     error:The SparseDataFrame:FutureWarning
     # https://github.com/apache/arrow/issues/38239
     ignore:Setting custom ClientSession:DeprecationWarning


### PR DESCRIPTION
### Rationale for this change
See: https://github.com/apache/arrow/issues/49227#issue-3926177634

### What changes are included in this PR?
Deprecation warnings for `pyarrow.gandiva` added for version 24.0.0

### Are these changes tested?
Yes, tested locally that warnings are raised on import. CI tests verify the warnings are filtered in out test suite.

### Are there any user-facing changes?
Yes, `pyarrow.gandiva` is deprecated and will be removed in a feature PyArrow version.

* GitHub Issue: #49227