### PR TITLE
GH-49638: [CI][Packaging][Python] Pin setuptools < 80 to build oldest pandas to test on musllinux

### DIFF
--- a/ci/docker/python-wheel-musllinux-test.dockerfile
+++ b/ci/docker/python-wheel-musllinux-test.dockerfile
@@ -32,6 +32,12 @@ RUN cp /usr/share/zoneinfo/Etc/UTC /etc/localtime
 # pandas doesn't provide wheel for aarch64 yet, so cache the compiled
 # test dependencies in a docker image
 COPY python/requirements-wheel-test.txt /arrow/python/
+# Pandas 2.0.3 is the last version to support numpy 1.21.x which is
+# the lowest version we support for Python 3.10.
+# Pandas 2.0.3 doesn't have wheels for Python 3.10 so we need to build from source,
+# which requires setuptools < 80.
+RUN if [ "${python_image_tag}" = "3.10" ]; then pip install 'setuptools<80'; \
+    fi
 RUN pip install -r /arrow/python/requirements-wheel-test.txt
 
 # Install the GCS testbench with the system Python

--- a/ci/docker/python-wheel-musllinux-test.dockerfile
+++ b/ci/docker/python-wheel-musllinux-test.dockerfile
@@ -40,6 +40,7 @@ COPY python/requirements-wheel-test.txt /arrow/python/
 # the lowest version we support for Python 3.10.
 # Pandas 2.0.3 doesn't have wheels for Python 3.10 so we need to build from source,
 # which requires setuptools < 80.
+# Drop when bumping numpy from 1.21.x (GH-48473) or when dropping Python 3.10.
 RUN if [ "${python_image_tag}" = "3.10" ]; then \
         echo 'setuptools<80' > /tmp/setuptools-constraint.txt; \
         PIP_CONSTRAINT=/tmp/setuptools-constraint.txt \

--- a/ci/docker/python-wheel-musllinux-test.dockerfile
+++ b/ci/docker/python-wheel-musllinux-test.dockerfile
@@ -19,6 +19,10 @@ ARG alpine_linux
 ARG python_image_tag
 FROM python:${python_image_tag}-alpine${alpine_linux}
 
+# Re-define python_image_tag argument to be used in the next stage.
+# This is needed because the argument is not preserved after the FROM statement.
+ARG python_image_tag
+
 RUN apk add --no-cache \
     bash \
     g++ \

--- a/ci/docker/python-wheel-musllinux-test.dockerfile
+++ b/ci/docker/python-wheel-musllinux-test.dockerfile
@@ -43,7 +43,7 @@ COPY python/requirements-wheel-test.txt /arrow/python/
 RUN if [ "${python_image_tag}" = "3.10" ]; then \
         echo 'setuptools<80' > /tmp/setuptools-constraint.txt; \
         PIP_CONSTRAINT=/tmp/setuptools-constraint.txt \
-        pip install -r /arrow/python/requirements-wheel-test.txt; \
+            pip install -r /arrow/python/requirements-wheel-test.txt; \
     else \
         pip install -r /arrow/python/requirements-wheel-test.txt; \
     fi

--- a/ci/docker/python-wheel-musllinux-test.dockerfile
+++ b/ci/docker/python-wheel-musllinux-test.dockerfile
@@ -40,9 +40,13 @@ COPY python/requirements-wheel-test.txt /arrow/python/
 # the lowest version we support for Python 3.10.
 # Pandas 2.0.3 doesn't have wheels for Python 3.10 so we need to build from source,
 # which requires setuptools < 80.
-RUN if [ "${python_image_tag}" = "3.10" ]; then pip install 'setuptools<80'; \
+RUN if [ "${python_image_tag}" = "3.10" ]; then \
+        echo 'setuptools<80' > /tmp/setuptools-constraint.txt; \
+        PIP_CONSTRAINT=/tmp/setuptools-constraint.txt \
+        pip install -r /arrow/python/requirements-wheel-test.txt; \
+    else \
+        pip install -r /arrow/python/requirements-wheel-test.txt; \
     fi
-RUN pip install -r /arrow/python/requirements-wheel-test.txt
 
 # Install the GCS testbench with the system Python
 COPY ci/scripts/install_gcs_testbench.sh /arrow/ci/scripts/


### PR DESCRIPTION
### Rationale for this change

Musl Linux wheels for Python 3.10 fail to install due to newer setuptools not being able to build old pandas from source.
The version of Pandas does not have Musl Linux wheels and is the last one to support the oldest numpy we support for Python 3.10.

### What changes are included in this PR?

Pin old setuptools in case of Python 3.10 in order to be able to install old pandas from source. This will be deleted in a couple of releases once we drop support for Python 3.10.

### Are these changes tested?

Yes via archery

### Are there any user-facing changes?
No

* GitHub Issue: #49638