### PR TITLE
GH-49295: [Python] Remove "mimalloc" from `mandatory_backends`

### DIFF
--- a/python/pyarrow/tests/test_memory.py
+++ b/python/pyarrow/tests/test_memory.py
@@ -30,9 +30,7 @@ import pytest
 pytestmark = pytest.mark.processes
 
 possible_backends = ["system", "jemalloc", "mimalloc"]
-# Backends which are expected to be present in all builds of PyArrow,
-# except if the user manually recompiled Arrow C++.
-mandatory_backends = ["system", "mimalloc"]
+mandatory_backends = ["system"]
 
 
 def backend_factory(backend_name):


### PR DESCRIPTION
### Rationale for this change

mimalloc is enabled by default but users can disable it. For example, Debian package disables it.

If it's disabled, PyArrow tests are failed.

### What changes are included in this PR?

Remove `"mimalloc"` from `mandatory_backends` in our test.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #49295