### PR TITLE
GH-49611: [MATLAB] MATLAB workflow failing due to action permission error

### DIFF
--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install ninja-build
         run: sudo apt-get install ninja-build
       - name: Install MATLAB
-        uses: matlab-actions/setup-matlab@v2
+        uses: matlab-actions/setup-matlab@aa8bbc7b76daa63c5d456d1430cbd6cb5b626ab4
         with:
           release: R2025b
       - name: Install ccache
@@ -82,7 +82,7 @@ jobs:
           # Add the installation directory to the MATLAB Search Path by
           # setting the MATLABPATH environment variable.
           MATLABPATH: matlab/install/arrow_matlab
-        uses: matlab-actions/run-tests@v2
+        uses: matlab-actions/run-tests@4a3d2e8bdc811f72defb8122e46a009312acc198
         with:
           select-by-folder: matlab/test
           strict: true
@@ -105,7 +105,7 @@ jobs:
       - name: Install ninja-build
         run: brew install ninja
       - name: Install MATLAB
-        uses: matlab-actions/setup-matlab@v2
+        uses: matlab-actions/setup-matlab@aa8bbc7b76daa63c5d456d1430cbd6cb5b626ab4
         with:
           release: R2025b
       - name: Install ccache
@@ -130,7 +130,7 @@ jobs:
           # Add the installation directory to the MATLAB Search Path by
           # setting the MATLABPATH environment variable.
           MATLABPATH: matlab/install/arrow_matlab
-        uses: matlab-actions/run-tests@v2
+        uses: matlab-actions/run-tests@4a3d2e8bdc811f72defb8122e46a009312acc198
         with:
           select-by-folder: matlab/test
           strict: true
@@ -144,7 +144,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install MATLAB
-        uses: matlab-actions/setup-matlab@v2
+        uses: matlab-actions/setup-matlab@aa8bbc7b76daa63c5d456d1430cbd6cb5b626ab4
         with:
           release: R2025b
       - name: Install ccache
@@ -174,7 +174,7 @@ jobs:
           # Add the installation directory to the MATLAB Search Path by
           # setting the MATLABPATH environment variable.
           MATLABPATH: matlab/install/arrow_matlab
-        uses: matlab-actions/run-tests@v2
+        uses: matlab-actions/run-tests@4a3d2e8bdc811f72defb8122e46a009312acc198
         with:
           select-by-folder: matlab/test
           strict: true

--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install ninja-build
         run: sudo apt-get install ninja-build
       - name: Install MATLAB
-        uses: matlab-actions/setup-matlab@aa8bbc7b76daa63c5d456d1430cbd6cb5b626ab4
+        uses: matlab-actions/setup-matlab@aa8bbc7b76daa63c5d456d1430cbd6cb5b626ab4 # v2.7.0
         with:
           release: R2025b
       - name: Install ccache

--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -82,7 +82,7 @@ jobs:
           # Add the installation directory to the MATLAB Search Path by
           # setting the MATLABPATH environment variable.
           MATLABPATH: matlab/install/arrow_matlab
-        uses: matlab-actions/run-tests@4a3d2e8bdc811f72defb8122e46a009312acc198
+        uses: matlab-actions/run-tests@4a3d2e8bdc811f72defb8122e46a009312acc198 # v2.3.1
         with:
           select-by-folder: matlab/test
           strict: true

--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -105,7 +105,7 @@ jobs:
       - name: Install ninja-build
         run: brew install ninja
       - name: Install MATLAB
-        uses: matlab-actions/setup-matlab@aa8bbc7b76daa63c5d456d1430cbd6cb5b626ab4
+        uses: matlab-actions/setup-matlab@aa8bbc7b76daa63c5d456d1430cbd6cb5b626ab4 # v2.7.0
         with:
           release: R2025b
       - name: Install ccache
@@ -130,7 +130,7 @@ jobs:
           # Add the installation directory to the MATLAB Search Path by
           # setting the MATLABPATH environment variable.
           MATLABPATH: matlab/install/arrow_matlab
-        uses: matlab-actions/run-tests@4a3d2e8bdc811f72defb8122e46a009312acc198
+        uses: matlab-actions/run-tests@4a3d2e8bdc811f72defb8122e46a009312acc198 # v2.3.1
         with:
           select-by-folder: matlab/test
           strict: true
@@ -144,7 +144,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install MATLAB
-        uses: matlab-actions/setup-matlab@aa8bbc7b76daa63c5d456d1430cbd6cb5b626ab4
+        uses: matlab-actions/setup-matlab@aa8bbc7b76daa63c5d456d1430cbd6cb5b626ab4 # v2.7.0
         with:
           release: R2025b
       - name: Install ccache
@@ -174,7 +174,7 @@ jobs:
           # Add the installation directory to the MATLAB Search Path by
           # setting the MATLABPATH environment variable.
           MATLABPATH: matlab/install/arrow_matlab
-        uses: matlab-actions/run-tests@4a3d2e8bdc811f72defb8122e46a009312acc198
+        uses: matlab-actions/run-tests@4a3d2e8bdc811f72defb8122e46a009312acc198 # v2.3.1
         with:
           select-by-folder: matlab/test
           strict: true


### PR DESCRIPTION
### Rationale for this change

The MATLAB workflow began (silently) failing on March 20th with this startup error:

> The actions matlab-actions/setup-matlab@v2 and matlab-actions/run-tests@v2 are not allowed in apache/arrow because all actions must be from a repository owned by your enterprise, created by GitHub, or match one of the patterns: ...

The MATLAB workflows began failing in CI because it depends on two actions, `matlab-actions/setup-matlab` and `matlab-actions/run-tests`, that, prior to yesterday, were not included in [apache/infrastructure-actions](https://github.com/apache/infrastructure-actions) "action" allow list.

Both `matlab-actions/setup-matlab` and `matlab-actions/run-tests` are now included in the action allow list. See [PR#6423](https://github.com/apache/infrastructure-actions/pull/643) and [PR#644](https://github.com/apache/infrastructure-actions/pull/644) for details.

### Component(s)

MATLAB, Continuous Integration

### What changes are included in this PR?

1. Pinned `matlab-actions/setup-matlab` to version `v2.7.0`, specified by git hash `aa8bbc7b76daa63c5d456d1430cbd6cb5b626ab4`.

2. Pinned `matlab-actions/run-tests` to version `v2.3.1`, specified by git hash `4a3d2e8bdc811f72defb8122e46a009312acc198`.

### Are these changes tested?

N/A

### Are there any user-facing changes?

No.

* GitHub Issue: #49611