### PR TITLE
GH-49654: [R][CI] Add check for non-API calls onto existing r-devel job

### DIFF
--- a/dev/tasks/r/github.linux.cran.yml
+++ b/dev/tasks/r/github.linux.cran.yml
@@ -48,18 +48,18 @@ jobs:
         env:
         {{ macros.github_set_sccache_envvars()|indent(8)}}
         # setting ARROW_SOURCE_HOME='' here ensures that we use the cpp source copied into tools/
-        run: archery docker run -e ARROW_SOURCE_HOME='' -e SKIP_VIGNETTES={{ '${{ matrix.config.skip_vignettes }}' }} r
+        run: archery docker run -e ARROW_SOURCE_HOME='' -e SKIP_VIGNETTES={{ '${{ matrix.config.skip_vignettes }}' }} -e _R_CHECK_CRAN_INCOMING_=false r
       - name: Dump install logs
         run: cat arrow/r/check/arrow.Rcheck/00install.out
         if: always()
       - name: Dump test logs
         run: cat arrow/r/check/arrow.Rcheck/tests/testthat.Rout*
         if: always()
-      - name: Check for non-API calls
+      - name: Check for R CMD check NOTES
         run: |
-          if grep -q "non-API" arrow/r/check/arrow.Rcheck/00check.log; then
-            echo "Found non-API calls in R CMD check output:"
-            grep -A2 "non-API" arrow/r/check/arrow.Rcheck/00check.log
+          if grep -q "^.* checking .* \\.\\.\\. NOTE$" arrow/r/check/arrow.Rcheck/00check.log; then
+            echo "Found R CMD check NOTE(s) in output:"
+            grep -n "^.* checking .* \\.\\.\\. NOTE$" arrow/r/check/arrow.Rcheck/00check.log
             exit 1
           fi
       - name: Save the test output

--- a/dev/tasks/r/github.linux.cran.yml
+++ b/dev/tasks/r/github.linux.cran.yml
@@ -48,7 +48,13 @@ jobs:
         env:
         {{ macros.github_set_sccache_envvars()|indent(8)}}
         # setting ARROW_SOURCE_HOME='' here ensures that we use the cpp source copied into tools/
-        run: archery docker run -e ARROW_SOURCE_HOME='' -e SKIP_VIGNETTES={{ '${{ matrix.config.skip_vignettes }}' }} -e _R_CHECK_CRAN_INCOMING_=false r
+        run: >
+          archery docker run
+          -e ARROW_SOURCE_HOME=''
+          -e SKIP_VIGNETTES={{ '${{ matrix.config.skip_vignettes }}' }}
+          -e _R_CHECK_CRAN_INCOMING_=false
+          -e _R_CHECK_COMPILATION_FLAGS_KNOWN_="-Werror=implicit-function-declaration -Wno-error=enum-constexpr-conversion -Wp,-D_FORTIFY_SOURCE=3 -Wno-missing-template-arg-list-after-template-kw"
+          r
       - name: Dump install logs
         run: cat arrow/r/check/arrow.Rcheck/00install.out
         if: always()

--- a/dev/tasks/r/github.linux.cran.yml
+++ b/dev/tasks/r/github.linux.cran.yml
@@ -55,6 +55,13 @@ jobs:
       - name: Dump test logs
         run: cat arrow/r/check/arrow.Rcheck/tests/testthat.Rout*
         if: always()
+      - name: Check for non-API calls
+        run: |
+          if grep -q "non-API" arrow/r/check/arrow.Rcheck/00check.log; then
+            echo "Found non-API calls in R CMD check output:"
+            grep -A2 "non-API" arrow/r/check/arrow.Rcheck/00check.log
+            exit 1
+          fi
       - name: Save the test output
         if: always()
         uses: actions/upload-artifact@v4

--- a/dev/tasks/r/github.linux.cran.yml
+++ b/dev/tasks/r/github.linux.cran.yml
@@ -53,7 +53,6 @@ jobs:
           -e ARROW_SOURCE_HOME=''
           -e SKIP_VIGNETTES={{ '${{ matrix.config.skip_vignettes }}' }}
           -e _R_CHECK_CRAN_INCOMING_=false
-          -e _R_CHECK_COMPILATION_FLAGS_KNOWN_="-Werror=implicit-function-declaration -Wno-error=enum-constexpr-conversion -Wp,-D_FORTIFY_SOURCE=3 -Wno-missing-template-arg-list-after-template-kw"
           r
       - name: Dump install logs
         run: cat arrow/r/check/arrow.Rcheck/00install.out

--- a/dev/tasks/r/github.linux.cran.yml
+++ b/dev/tasks/r/github.linux.cran.yml
@@ -59,7 +59,7 @@ jobs:
         run: |
           if grep -q "^.* checking .* \\.\\.\\. NOTE$" arrow/r/check/arrow.Rcheck/00check.log; then
             echo "Found R CMD check NOTE(s) in output:"
-            grep -n "^.* checking .* \\.\\.\\. NOTE$" arrow/r/check/arrow.Rcheck/00check.log
+            grep -n -A8 "^.* checking .* \\.\\.\\. NOTE$" arrow/r/check/arrow.Rcheck/00check.log
             exit 1
           fi
       - name: Save the test output


### PR DESCRIPTION
### Rationale for this change

I wanna know when we get NOTEs about this so we don't need to wait til CRAN pings us

### What changes are included in this PR?

Add check to r-devel jobs

### Are these changes tested?

Those CI jobs should fail now

### Are there any user-facing changes?

Nah
* GitHub Issue: #49654