### PR TITLE
GH-49661: [CI][C++] Suppress deprecated warnings with gRPC 1.80.0

### DIFF
--- a/cpp/src/arrow/flight/transport/grpc/grpc_client.cc
+++ b/cpp/src/arrow/flight/transport/grpc/grpc_client.cc
@@ -732,19 +732,31 @@ class GrpcClientImpl : public internal::ClientTransport {
 #  endif  // defined(GRPC_USE_CERTIFICATE_VERIFIER)
 
 #  if defined(GRPC_USE_TLS_CHANNEL_CREDENTIALS_OPTIONS)
+#    if GRPC_CPP_VERSION_CHECK(1, 80, 0)
+          auto certificate_provider =
+              std::make_shared<::grpc::experimental::InMemoryCertificateProvider>();
+          RETURN_NOT_OK(FromAbslStatus(certificate_provider->UpdateRoot(kDummyRootCert)));
+#    else
           auto certificate_provider =
               std::make_shared<::grpc::experimental::StaticDataCertificateProvider>(
                   kDummyRootCert);
+#    endif
 #    if defined(GRPC_USE_TLS_CHANNEL_CREDENTIALS_OPTIONS_ROOT_CERTS)
           ::grpc::experimental::TlsChannelCredentialsOptions tls_options(
               certificate_provider);
-#    else   // defined(GRPC_USE_TLS_CHANNEL_CREDENTIALS_OPTIONS_ROOT_CERTS)
-            // While gRPC >= 1.36 does not require a root cert (it has a default)
-            // in practice the path it hardcodes is broken. See grpc/grpc#21655.
+#    else  // defined(GRPC_USE_TLS_CHANNEL_CREDENTIALS_OPTIONS_ROOT_CERTS)
+           // While gRPC >= 1.36 does not require a root cert (it has a default)
+           // in practice the path it hardcodes is broken. See grpc/grpc#21655.
           ::grpc::experimental::TlsChannelCredentialsOptions tls_options;
+#      if GRPC_CPP_VERSION_CHECK(1, 80, 0)
+          tls_options.set_root_certificate_provider(certificate_provider);
+#      else
           tls_options.set_certificate_provider(certificate_provider);
+#      endif
 #    endif  // defined(GRPC_USE_TLS_CHANNEL_CREDENTIALS_OPTIONS_ROOT_CERTS)
+#    if !GRPC_CPP_VERSION_CHECK(1, 80, 0)
           tls_options.watch_root_certs();
+#    endif
           tls_options.set_root_cert_name("dummy");
 #    if defined(GRPC_USE_CERTIFICATE_VERIFIER)
           tls_options.set_certificate_verifier(std::move(cert_verifier));

--- a/cpp/src/arrow/flight/transport/grpc/util_internal.cc
+++ b/cpp/src/arrow/flight/transport/grpc/util_internal.cc
@@ -331,6 +331,49 @@ static ::grpc::Status ToRawGrpcStatus(const Status& arrow_status) {
   return status;
 }
 
+#if GRPC_CPP_VERSION_CHECK(1, 80, 0)
+Status FromAbslStatus(const ::absl::Status& absl_status) {
+  switch (absl_status.code()) {
+    case ::absl::StatusCode::kOk:
+      return Status::OK();
+    case ::absl::StatusCode::kCancelled:
+      return Status::Cancelled(absl_status.ToString());
+    case ::absl::StatusCode::kUnknown:
+      return Status::UnknownError(absl_status.ToString());
+    case ::absl::StatusCode::kInvalidArgument:
+      return Status::Invalid(absl_status.ToString());
+    case ::absl::StatusCode::kDeadlineExceeded:
+      return Status::IOError(absl_status.ToString());
+    case ::absl::StatusCode::kNotFound:
+      return Status::KeyError(absl_status.ToString());
+    case ::absl::StatusCode::kAlreadyExists:
+      return Status::AlreadyExists(absl_status.ToString());
+    case ::absl::StatusCode::kPermissionDenied:
+      return Status::IOError(absl_status.ToString());
+    case ::absl::StatusCode::kResourceExhausted:
+      return Status::IOError(absl_status.ToString());
+    case ::absl::StatusCode::kFailedPrecondition:
+      return Status::IOError(absl_status.ToString());
+    case ::absl::StatusCode::kAborted:
+      return Status::IOError(absl_status.ToString());
+    case ::absl::StatusCode::kOutOfRange:
+      return Status::Invalid(absl_status.ToString());
+    case ::absl::StatusCode::kUnimplemented:
+      return Status::NotImplemented(absl_status.ToString());
+    case ::absl::StatusCode::kInternal:
+      return Status::IOError(absl_status.ToString());
+    case ::absl::StatusCode::kUnavailable:
+      return Status::IOError(absl_status.ToString());
+    case ::absl::StatusCode::kDataLoss:
+      return Status::IOError(absl_status.ToString());
+    case ::absl::StatusCode::kUnauthenticated:
+      return Status::IOError(absl_status.ToString());
+    default:
+      return Status::UnknownError(absl_status.ToString());
+  }
+}
+#endif
+
 }  // namespace grpc
 }  // namespace transport
 }  // namespace flight

--- a/cpp/src/arrow/flight/transport/grpc/util_internal.h
+++ b/cpp/src/arrow/flight/transport/grpc/util_internal.h
@@ -34,6 +34,12 @@ class Status;
 
 namespace flight {
 
+#define GRPC_CPP_VERSION_CHECK(major, minor, patch)                             \
+  ((GRPC_CPP_VERSION_MAJOR > (major) ||                                         \
+    (GRPC_CPP_VERSION_MAJOR == (major) && GRPC_CPP_VERSION_MINOR > (minor)) ||  \
+    ((GRPC_CPP_VERSION_MAJOR == (major) && GRPC_CPP_VERSION_MINOR == (minor) && \
+      GRPC_CPP_VERSION_PATCH >= (patch)))))
+
 #define GRPC_RETURN_NOT_OK(expr)                                 \
   do {                                                           \
     ::arrow::Status _s = (expr);                                 \
@@ -90,6 +96,12 @@ ARROW_FLIGHT_EXPORT
 ::grpc::Status ToGrpcStatus(const Status& arrow_status,
                             ::grpc::ServerContext* ctx = nullptr);
 
+// gRPC 1.80.0 or later use absl::Status.
+#if GRPC_CPP_VERSION_CHECK(1, 80, 0)
+/// Convert an Abseil status to an Arrow status.
+ARROW_FLIGHT_EXPORT
+Status FromAbslStatus(const ::absl::Status& absl_status);
+#endif
 }  // namespace grpc
 }  // namespace transport
 }  // namespace flight


### PR DESCRIPTION
### Rationale for this change

gRPC 1.80.0 introduced some deprecation warnings. See GH-49661 for real warning messages.

### What changes are included in this PR?

* Use `grpc::experimental::InMemoryCertificateProvider` instead of `grpc::experimental::StaticDataCertificateProvider`
* Use `set_root_certificate_provider()` instead of `set_certificate_provider()` of `grpc::experimental::TlsChannelCredentialsOptions`
* Don't call `::grpc::experimental::TlsChannelCredentialsOptions::watch_root_certs()` because we called `set_root_certificate_provider()` with gRPC 1.80.0 or later

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.
* GitHub Issue: #49661