### PR TITLE
GH-49552: [C++][FlightRPC][ODBC] Enable ODBC test build on Linux

### DIFF
--- a/ci/scripts/cpp_test.sh
+++ b/ci/scripts/cpp_test.sh
@@ -55,6 +55,7 @@ if ! type minio >/dev/null 2>&1; then
 fi
 case "$(uname)" in
   Linux)
+    exclude_tests+=("arrow-flight-sql-odbc-test")
     n_jobs=$(nproc)
     ;;
   Darwin)

--- a/cpp/src/arrow/flight/sql/odbc/CMakeLists.txt
+++ b/cpp/src/arrow/flight/sql/odbc/CMakeLists.txt
@@ -29,10 +29,7 @@ endif()
 
 add_subdirectory(odbc_impl)
 if(ARROW_BUILD_TESTS)
-  if(WIN32 OR APPLE)
-    # GH-49552 TODO: Enable Linux test build
-    add_subdirectory(tests)
-  endif()
+  add_subdirectory(tests)
 endif()
 
 arrow_install_all_headers("arrow/flight/sql/odbc")

--- a/cpp/src/arrow/flight/sql/odbc/tests/columns_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/columns_test.cc
@@ -364,7 +364,6 @@ void GetSQLColAttributeNumeric(SQLHSTMT stmt, const std::wstring& wsql, SQLUSMAL
 
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  SQLLEN num_val = 0;
   ASSERT_EQ(SQL_SUCCESS,
             SQLColAttribute(stmt, idx, field_identifier, 0, 0, nullptr, value));
 }
@@ -379,7 +378,6 @@ void GetSQLColAttributesNumeric(SQLHSTMT stmt, const std::wstring& wsql, SQLUSMA
 
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
 
-  SQLLEN num_val = 0;
   ASSERT_EQ(SQL_SUCCESS,
             SQLColAttributes(stmt, idx, field_identifier, 0, 0, nullptr, value));
 }
@@ -387,10 +385,10 @@ void GetSQLColAttributesNumeric(SQLHSTMT stmt, const std::wstring& wsql, SQLUSMA
 }  // namespace
 
 TYPED_TEST(ColumnsTest, SQLColumnsTestInputData) {
-  SQLWCHAR catalog_name[] = L"";
-  SQLWCHAR schema_name[] = L"";
-  SQLWCHAR table_name[] = L"";
-  SQLWCHAR column_name[] = L"";
+  SQLWCHAR catalog_name[] = {0};
+  SQLWCHAR schema_name[] = {0};
+  SQLWCHAR table_name[] = {0};
+  SQLWCHAR column_name[] = {0};
 
   // All values populated
   EXPECT_EQ(SQL_SUCCESS,
@@ -422,8 +420,8 @@ TEST_F(ColumnsMockTest, TestSQLColumnsAllColumns) {
   // Check table pattern and column pattern returns all columns
 
   // Attempt to get all columns
-  SQLWCHAR table_pattern[] = L"%";
-  SQLWCHAR column_pattern[] = L"%";
+  ASSIGN_SQLWCHAR_ARR(table_pattern, L"%");
+  ASSIGN_SQLWCHAR_ARR(column_pattern, L"%");
 
   ASSERT_EQ(SQL_SUCCESS, SQLColumns(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
                                     table_pattern, SQL_NTS, column_pattern, SQL_NTS));
@@ -447,7 +445,7 @@ TEST_F(ColumnsMockTest, TestSQLColumnsAllColumns) {
                       10,  // expected_num_prec_radix
                       SQL_NULLABLE,           // expected_nullable
                       SQL_BIGINT,             // expected_sql_data_type
-                      NULL,                   // expected_date_time_sub
+                      0,                      // expected_date_time_sub
                       8,                      // expected_octet_char_length
                       1,                      // expected_ordinal_position
                       std::wstring(L"YES"));  // expected_is_nullable
@@ -468,7 +466,7 @@ TEST_F(ColumnsMockTest, TestSQLColumnsAllColumns) {
                       0,   // expected_num_prec_radix
                       SQL_NULLABLE,           // expected_nullable
                       SQL_WVARCHAR,           // expected_sql_data_type
-                      NULL,                   // expected_date_time_sub
+                      0,                      // expected_date_time_sub
                       0,                      // expected_octet_char_length
                       2,                      // expected_ordinal_position
                       std::wstring(L"YES"));  // expected_is_nullable
@@ -488,7 +486,7 @@ TEST_F(ColumnsMockTest, TestSQLColumnsAllColumns) {
                       10,  // expected_num_prec_radix
                       SQL_NULLABLE,           // expected_nullable
                       SQL_BIGINT,             // expected_sql_data_type
-                      NULL,                   // expected_date_time_sub
+                      0,                      // expected_date_time_sub
                       8,                      // expected_octet_char_length
                       3,                      // expected_ordinal_position
                       std::wstring(L"YES"));  // expected_is_nullable
@@ -508,7 +506,7 @@ TEST_F(ColumnsMockTest, TestSQLColumnsAllColumns) {
                       10,  // expected_num_prec_radix
                       SQL_NULLABLE,           // expected_nullable
                       SQL_BIGINT,             // expected_sql_data_type
-                      NULL,                   // expected_date_time_sub
+                      0,                      // expected_date_time_sub
                       8,                      // expected_octet_char_length
                       1,                      // expected_ordinal_position
                       std::wstring(L"YES"));  // expected_is_nullable
@@ -529,7 +527,7 @@ TEST_F(ColumnsMockTest, TestSQLColumnsAllColumns) {
                       0,   // expected_num_prec_radix
                       SQL_NULLABLE,           // expected_nullable
                       SQL_WVARCHAR,           // expected_sql_data_type
-                      NULL,                   // expected_date_time_sub
+                      0,                      // expected_date_time_sub
                       0,                      // expected_octet_char_length
                       2,                      // expected_ordinal_position
                       std::wstring(L"YES"));  // expected_is_nullable
@@ -549,7 +547,7 @@ TEST_F(ColumnsMockTest, TestSQLColumnsAllColumns) {
                       10,  // expected_num_prec_radix
                       SQL_NULLABLE,           // expected_nullable
                       SQL_BIGINT,             // expected_sql_data_type
-                      NULL,                   // expected_date_time_sub
+                      0,                      // expected_date_time_sub
                       8,                      // expected_octet_char_length
                       3,                      // expected_ordinal_position
                       std::wstring(L"YES"));  // expected_is_nullable
@@ -569,7 +567,7 @@ TEST_F(ColumnsMockTest, TestSQLColumnsAllColumns) {
                       10,  // expected_num_prec_radix
                       SQL_NULLABLE,           // expected_nullable
                       SQL_BIGINT,             // expected_sql_data_type
-                      NULL,                   // expected_date_time_sub
+                      0,                      // expected_date_time_sub
                       8,                      // expected_octet_char_length
                       4,                      // expected_ordinal_position
                       std::wstring(L"YES"));  // expected_is_nullable
@@ -584,8 +582,8 @@ TEST_F(ColumnsMockTest, TestSQLColumnsAllTypes) {
   CreateAllDataTypeTable();
 
   // Attempt to get all columns from AllTypesTable
-  SQLWCHAR table_pattern[] = L"AllTypesTable";
-  SQLWCHAR column_pattern[] = L"%";
+  ASSIGN_SQLWCHAR_ARR(table_pattern, L"AllTypesTable");
+  ASSIGN_SQLWCHAR_ARR(column_pattern, L"%");
 
   ASSERT_EQ(SQL_SUCCESS, SQLColumns(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
                                     table_pattern, SQL_NTS, column_pattern, SQL_NTS));
@@ -607,7 +605,7 @@ TEST_F(ColumnsMockTest, TestSQLColumnsAllTypes) {
                       10,  // expected_num_prec_radix
                       SQL_NULLABLE,           // expected_nullable
                       SQL_BIGINT,             // expected_sql_data_type
-                      NULL,                   // expected_date_time_sub
+                      0,                      // expected_date_time_sub
                       8,                      // expected_octet_char_length
                       1,                      // expected_ordinal_position
                       std::wstring(L"YES"));  // expected_is_nullable
@@ -628,7 +626,7 @@ TEST_F(ColumnsMockTest, TestSQLColumnsAllTypes) {
                       0,   // expected_num_prec_radix
                       SQL_NULLABLE,           // expected_nullable
                       SQL_WVARCHAR,           // expected_sql_data_type
-                      NULL,                   // expected_date_time_sub
+                      0,                      // expected_date_time_sub
                       0,                      // expected_octet_char_length
                       2,                      // expected_ordinal_position
                       std::wstring(L"YES"));  // expected_is_nullable
@@ -649,7 +647,7 @@ TEST_F(ColumnsMockTest, TestSQLColumnsAllTypes) {
                       0,   // expected_num_prec_radix
                       SQL_NULLABLE,           // expected_nullable
                       SQL_BINARY,             // expected_sql_data_type
-                      NULL,                   // expected_date_time_sub
+                      0,                      // expected_date_time_sub
                       0,                      // expected_octet_char_length
                       3,                      // expected_ordinal_position
                       std::wstring(L"YES"));  // expected_is_nullable
@@ -669,7 +667,7 @@ TEST_F(ColumnsMockTest, TestSQLColumnsAllTypes) {
                       2,                               // expected_num_prec_radix
                       SQL_NULLABLE,                    // expected_nullable
                       SQL_DOUBLE,                      // expected_sql_data_type
-                      NULL,                            // expected_date_time_sub
+                      0,                               // expected_date_time_sub
                       8,                               // expected_octet_char_length
                       4,                               // expected_ordinal_position
                       std::wstring(L"YES"));           // expected_is_nullable
@@ -687,8 +685,8 @@ TEST_F(ColumnsMockTest, TestSQLColumnsUnicode) {
   CreateUnicodeTable();
 
   // Attempt to get all columns
-  SQLWCHAR table_pattern[] = L"数据";
-  SQLWCHAR column_pattern[] = L"%";
+  ASSIGN_SQLWCHAR_ARR(table_pattern, L"数据");
+  ASSIGN_SQLWCHAR_ARR(column_pattern, L"%");
 
   ASSERT_EQ(SQL_SUCCESS, SQLColumns(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
                                     table_pattern, SQL_NTS, column_pattern, SQL_NTS));
@@ -709,7 +707,7 @@ TEST_F(ColumnsMockTest, TestSQLColumnsUnicode) {
                       0,   // expected_num_prec_radix
                       SQL_NULLABLE,           // expected_nullable
                       SQL_WVARCHAR,           // expected_sql_data_type
-                      NULL,                   // expected_date_time_sub
+                      0,                      // expected_date_time_sub
                       0,                      // expected_octet_char_length
                       1,                      // expected_ordinal_position
                       std::wstring(L"YES"));  // expected_is_nullable
@@ -724,8 +722,8 @@ TEST_F(ColumnsRemoteTest, TestSQLColumnsAllTypes) {
   // GH-47159 TODO: Return NUM_PREC_RADIX based on whether COLUMN_SIZE contains number of
   // digits or bits
 
-  SQLWCHAR table_pattern[] = L"ODBCTest";
-  SQLWCHAR column_pattern[] = L"%";
+  ASSIGN_SQLWCHAR_ARR(table_pattern, L"ODBCTest");
+  ASSIGN_SQLWCHAR_ARR(column_pattern, L"%");
 
   ASSERT_EQ(SQL_SUCCESS, SQLColumns(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
                                     table_pattern, SQL_NTS, column_pattern, SQL_NTS));
@@ -746,7 +744,7 @@ TEST_F(ColumnsRemoteTest, TestSQLColumnsAllTypes) {
       10,            // expected_num_prec_radix
       SQL_NULLABLE,  // expected_nullable
       SQL_INTEGER,   // expected_sql_data_type
-      NULL,          // expected_date_time_sub
+      0,             // expected_date_time_sub
       4,             // expected_octet_char_length
       1,             // expected_ordinal_position
       std::wstring(L"YES"));  // expected_is_nullable
@@ -767,7 +765,7 @@ TEST_F(ColumnsRemoteTest, TestSQLColumnsAllTypes) {
       10,            // expected_num_prec_radix
       SQL_NULLABLE,  // expected_nullable
       SQL_BIGINT,    // expected_sql_data_type
-      NULL,          // expected_date_time_sub
+      0,             // expected_date_time_sub
       8,             // expected_octet_char_length
       2,             // expected_ordinal_position
       std::wstring(L"YES"));  // expected_is_nullable
@@ -787,7 +785,7 @@ TEST_F(ColumnsRemoteTest, TestSQLColumnsAllTypes) {
                         10,                                 // expected_num_prec_radix
                         SQL_NULLABLE,                       // expected_nullable
                         SQL_DECIMAL,                        // expected_sql_data_type
-                        NULL,                               // expected_date_time_sub
+                        0,                                  // expected_date_time_sub
                         2,                                  // expected_octet_char_length
                         3,                                  // expected_ordinal_position
                         std::wstring(L"YES"));              // expected_is_nullable
@@ -807,7 +805,7 @@ TEST_F(ColumnsRemoteTest, TestSQLColumnsAllTypes) {
                         2,   // expected_num_prec_radix
                         SQL_NULLABLE,           // expected_nullable
                         SQL_FLOAT,              // expected_sql_data_type
-                        NULL,                   // expected_date_time_sub
+                        0,                      // expected_date_time_sub
                         8,                      // expected_octet_char_length
                         4,                      // expected_ordinal_position
                         std::wstring(L"YES"));  // expected_is_nullable
@@ -827,7 +825,7 @@ TEST_F(ColumnsRemoteTest, TestSQLColumnsAllTypes) {
                         2,   // expected_num_prec_radix
                         SQL_NULLABLE,           // expected_nullable
                         SQL_DOUBLE,             // expected_sql_data_type
-                        NULL,                   // expected_date_time_sub
+                        0,                      // expected_date_time_sub
                         8,                      // expected_octet_char_length
                         5,                      // expected_ordinal_position
                         std::wstring(L"YES"));  // expected_is_nullable
@@ -848,7 +846,7 @@ TEST_F(ColumnsRemoteTest, TestSQLColumnsAllTypes) {
                         0,  // expected_num_prec_radix
                         SQL_NULLABLE,           // expected_nullable
                         SQL_BIT,                // expected_sql_data_type
-                        NULL,                   // expected_date_time_sub
+                        0,                      // expected_date_time_sub
                         1,                      // expected_octet_char_length
                         6,                      // expected_ordinal_position
                         std::wstring(L"YES"));  // expected_is_nullable
@@ -927,8 +925,8 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColumnsAllTypesODBCVer2) {
   // GH-47159 TODO: Return NUM_PREC_RADIX based on whether COLUMN_SIZE contains number of
   // digits or bits
 
-  SQLWCHAR table_pattern[] = L"ODBCTest";
-  SQLWCHAR column_pattern[] = L"%";
+  ASSIGN_SQLWCHAR_ARR(table_pattern, L"ODBCTest");
+  ASSIGN_SQLWCHAR_ARR(column_pattern, L"%");
 
   ASSERT_EQ(SQL_SUCCESS, SQLColumns(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
                                     table_pattern, SQL_NTS, column_pattern, SQL_NTS));
@@ -949,7 +947,7 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColumnsAllTypesODBCVer2) {
       10,            // expected_num_prec_radix
       SQL_NULLABLE,  // expected_nullable
       SQL_INTEGER,   // expected_sql_data_type
-      NULL,          // expected_date_time_sub
+      0,             // expected_date_time_sub
       4,             // expected_octet_char_length
       1,             // expected_ordinal_position
       std::wstring(L"YES"));  // expected_is_nullable
@@ -970,7 +968,7 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColumnsAllTypesODBCVer2) {
       10,            // expected_num_prec_radix
       SQL_NULLABLE,  // expected_nullable
       SQL_BIGINT,    // expected_sql_data_type
-      NULL,          // expected_date_time_sub
+      0,             // expected_date_time_sub
       8,             // expected_octet_char_length
       2,             // expected_ordinal_position
       std::wstring(L"YES"));  // expected_is_nullable
@@ -990,7 +988,7 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColumnsAllTypesODBCVer2) {
                         10,                                 // expected_num_prec_radix
                         SQL_NULLABLE,                       // expected_nullable
                         SQL_DECIMAL,                        // expected_sql_data_type
-                        NULL,                               // expected_date_time_sub
+                        0,                                  // expected_date_time_sub
                         2,                                  // expected_octet_char_length
                         3,                                  // expected_ordinal_position
                         std::wstring(L"YES"));              // expected_is_nullable
@@ -1010,7 +1008,7 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColumnsAllTypesODBCVer2) {
                         2,   // expected_num_prec_radix
                         SQL_NULLABLE,           // expected_nullable
                         SQL_FLOAT,              // expected_sql_data_type
-                        NULL,                   // expected_date_time_sub
+                        0,                      // expected_date_time_sub
                         8,                      // expected_octet_char_length
                         4,                      // expected_ordinal_position
                         std::wstring(L"YES"));  // expected_is_nullable
@@ -1030,7 +1028,7 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColumnsAllTypesODBCVer2) {
                         2,   // expected_num_prec_radix
                         SQL_NULLABLE,           // expected_nullable
                         SQL_DOUBLE,             // expected_sql_data_type
-                        NULL,                   // expected_date_time_sub
+                        0,                      // expected_date_time_sub
                         8,                      // expected_octet_char_length
                         5,                      // expected_ordinal_position
                         std::wstring(L"YES"));  // expected_is_nullable
@@ -1051,7 +1049,7 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColumnsAllTypesODBCVer2) {
                         0,  // expected_num_prec_radix
                         SQL_NULLABLE,           // expected_nullable
                         SQL_BIT,                // expected_sql_data_type
-                        NULL,                   // expected_date_time_sub
+                        0,                      // expected_date_time_sub
                         1,                      // expected_octet_char_length
                         6,                      // expected_ordinal_position
                         std::wstring(L"YES"));  // expected_is_nullable
@@ -1129,8 +1127,8 @@ TEST_F(ColumnsMockTest, TestSQLColumnsColumnPattern) {
   // Checks filtering table with column name pattern.
   // Only check table and column name
 
-  SQLWCHAR table_pattern[] = L"%";
-  SQLWCHAR column_pattern[] = L"id";
+  ASSIGN_SQLWCHAR_ARR(table_pattern, L"%");
+  ASSIGN_SQLWCHAR_ARR(column_pattern, L"id");
 
   EXPECT_EQ(SQL_SUCCESS, SQLColumns(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
                                     table_pattern, SQL_NTS, column_pattern, SQL_NTS));
@@ -1150,7 +1148,7 @@ TEST_F(ColumnsMockTest, TestSQLColumnsColumnPattern) {
                       10,  // expected_num_prec_radix
                       SQL_NULLABLE,           // expected_nullable
                       SQL_BIGINT,             // expected_sql_data_type
-                      NULL,                   // expected_date_time_sub
+                      0,                      // expected_date_time_sub
                       8,                      // expected_octet_char_length
                       1,                      // expected_ordinal_position
                       std::wstring(L"YES"));  // expected_is_nullable
@@ -1170,7 +1168,7 @@ TEST_F(ColumnsMockTest, TestSQLColumnsColumnPattern) {
                       10,  // expected_num_prec_radix
                       SQL_NULLABLE,           // expected_nullable
                       SQL_BIGINT,             // expected_sql_data_type
-                      NULL,                   // expected_date_time_sub
+                      0,                      // expected_date_time_sub
                       8,                      // expected_octet_char_length
                       1,                      // expected_ordinal_position
                       std::wstring(L"YES"));  // expected_is_nullable
@@ -1183,8 +1181,8 @@ TEST_F(ColumnsMockTest, TestSQLColumnsTableColumnPattern) {
   // Checks filtering table with table and column name pattern.
   // Only check table and column name
 
-  SQLWCHAR table_pattern[] = L"foreignTable";
-  SQLWCHAR column_pattern[] = L"id";
+  ASSIGN_SQLWCHAR_ARR(table_pattern, L"foreignTable");
+  ASSIGN_SQLWCHAR_ARR(column_pattern, L"id");
 
   ASSERT_EQ(SQL_SUCCESS, SQLColumns(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
                                     table_pattern, SQL_NTS, column_pattern, SQL_NTS));
@@ -1204,7 +1202,7 @@ TEST_F(ColumnsMockTest, TestSQLColumnsTableColumnPattern) {
                       10,  // expected_num_prec_radix
                       SQL_NULLABLE,           // expected_nullable
                       SQL_BIGINT,             // expected_sql_data_type
-                      NULL,                   // expected_date_time_sub
+                      0,                      // expected_date_time_sub
                       8,                      // expected_octet_char_length
                       1,                      // expected_ordinal_position
                       std::wstring(L"YES"));  // expected_is_nullable
@@ -1214,8 +1212,8 @@ TEST_F(ColumnsMockTest, TestSQLColumnsTableColumnPattern) {
 }
 
 TEST_F(ColumnsMockTest, TestSQLColumnsInvalidTablePattern) {
-  SQLWCHAR table_pattern[] = L"non-existent-table";
-  SQLWCHAR column_pattern[] = L"%";
+  ASSIGN_SQLWCHAR_ARR(table_pattern, L"non-existent-table");
+  ASSIGN_SQLWCHAR_ARR(column_pattern, L"%");
 
   ASSERT_EQ(SQL_SUCCESS, SQLColumns(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
                                     table_pattern, SQL_NTS, column_pattern, SQL_NTS));
@@ -1225,8 +1223,7 @@ TEST_F(ColumnsMockTest, TestSQLColumnsInvalidTablePattern) {
 }
 
 TYPED_TEST(ColumnsTest, SQLColAttributeTestInputData) {
-  SQLWCHAR wsql[] = L"SELECT 1 as col1;";
-  SQLSMALLINT wsql_len = std::wcslen(wsql);
+  ASSIGN_SQLWCHAR_ARR_AND_LEN(wsql, L"SELECT 1 as col1;");
 
   ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
@@ -1238,9 +1235,8 @@ TYPED_TEST(ColumnsTest, SQLColAttributeTestInputData) {
   SQLLEN numeric_attr = 0;
 
   // All character values populated
-  EXPECT_EQ(SQL_SUCCESS,
-            SQLColAttribute(this->stmt, idx, SQL_DESC_NAME, character_attr,
-                            std::wcslen(character_attr), &character_attr_len, nullptr));
+  EXPECT_EQ(SQL_SUCCESS, SQLColAttribute(this->stmt, idx, SQL_DESC_NAME, character_attr,
+                                         kOdbcBufferSize, &character_attr_len, nullptr));
 
   // All numeric values populated
   EXPECT_EQ(SQL_SUCCESS, SQLColAttribute(this->stmt, idx, SQL_DESC_COUNT, 0, 0, nullptr,
@@ -1255,8 +1251,7 @@ TYPED_TEST(ColumnsTest, SQLColAttributeTestInputData) {
 }
 
 TYPED_TEST(ColumnsTest, SQLColAttributeGetCharacterLen) {
-  SQLWCHAR wsql[] = L"SELECT 1 as col1;";
-  SQLSMALLINT wsql_len = std::wcslen(wsql);
+  ASSIGN_SQLWCHAR_ARR_AND_LEN(wsql, L"SELECT 1 as col1;");
 
   ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
@@ -1271,8 +1266,7 @@ TYPED_TEST(ColumnsTest, SQLColAttributeGetCharacterLen) {
 }
 
 TYPED_TEST(ColumnsTest, SQLColAttributeInvalidFieldId) {
-  SQLWCHAR wsql[] = L"SELECT 1 as col1;";
-  SQLSMALLINT wsql_len = std::wcslen(wsql);
+  ASSIGN_SQLWCHAR_ARR_AND_LEN(wsql, L"SELECT 1 as col1;");
 
   ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
@@ -1282,18 +1276,15 @@ TYPED_TEST(ColumnsTest, SQLColAttributeInvalidFieldId) {
   SQLUSMALLINT idx = 1;
   SQLWCHAR character_attr[kOdbcBufferSize];
   SQLSMALLINT character_attr_len = 0;
-  SQLLEN numeric_attr = 0;
 
-  ASSERT_EQ(SQL_ERROR,
-            SQLColAttribute(this->stmt, idx, invalid_field_id, character_attr,
-                            std::wcslen(character_attr), &character_attr_len, nullptr));
+  ASSERT_EQ(SQL_ERROR, SQLColAttribute(this->stmt, idx, invalid_field_id, character_attr,
+                                       kOdbcBufferSize, &character_attr_len, nullptr));
   // Verify invalid descriptor field identifier error state is returned
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorStateHY091);
 }
 
 TYPED_TEST(ColumnsTest, SQLColAttributeInvalidColId) {
-  SQLWCHAR wsql[] = L"SELECT 1 as col1;";
-  SQLSMALLINT wsql_len = std::wcslen(wsql);
+  ASSIGN_SQLWCHAR_ARR_AND_LEN(wsql, L"SELECT 1 as col1;");
 
   ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
@@ -1303,10 +1294,9 @@ TYPED_TEST(ColumnsTest, SQLColAttributeInvalidColId) {
   SQLWCHAR character_attr[kOdbcBufferSize];
   SQLSMALLINT character_attr_len = 0;
 
-  ASSERT_EQ(SQL_ERROR,
-            SQLColAttribute(this->stmt, invalid_col_id, SQL_DESC_BASE_COLUMN_NAME,
-                            character_attr, std::wcslen(character_attr),
-                            &character_attr_len, nullptr));
+  ASSERT_EQ(SQL_ERROR, SQLColAttribute(this->stmt, invalid_col_id,
+                                       SQL_DESC_BASE_COLUMN_NAME, character_attr,
+                                       kOdbcBufferSize, &character_attr_len, nullptr));
   // Verify invalid descriptor index error state is returned
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorState07009);
 }
@@ -1314,8 +1304,7 @@ TYPED_TEST(ColumnsTest, SQLColAttributeInvalidColId) {
 TEST_F(ColumnsMockTest, TestSQLColAttributeAllTypes) {
   CreateAllDataTypeTable();
 
-  SQLWCHAR wsql[] = L"SELECT * from AllTypesTable;";
-  SQLINTEGER wsql_len = std::wcslen(wsql);
+  ASSIGN_SQLWCHAR_ARR_AND_LEN(wsql, L"SELECT * from AllTypesTable;");
 
   ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
@@ -1398,8 +1387,7 @@ TEST_F(ColumnsOdbcV2MockTest, TestSQLColAttributesAllTypes) {
   // Tests ODBC 2.0 API SQLColAttributes
   CreateAllDataTypeTable();
 
-  SQLWCHAR wsql[] = L"SELECT * from AllTypesTable;";
-  SQLSMALLINT wsql_len = std::wcslen(wsql);
+  ASSIGN_SQLWCHAR_ARR_AND_LEN(wsql, L"SELECT * from AllTypesTable;");
 
   ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
@@ -1459,8 +1447,7 @@ TEST_F(ColumnsOdbcV2MockTest, TestSQLColAttributesAllTypes) {
 TEST_F(ColumnsRemoteTest, TestSQLColAttributeAllTypes) {
   // Test assumes there is a table $scratch.ODBCTest in remote server
 
-  SQLWCHAR wsql[] = L"SELECT * from $scratch.ODBCTest;";
-  SQLINTEGER wsql_len = std::wcslen(wsql);
+  ASSIGN_SQLWCHAR_ARR_AND_LEN(wsql, L"SELECT * from $scratch.ODBCTest;");
 
   ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
@@ -1624,8 +1611,7 @@ TEST_F(ColumnsRemoteTest, TestSQLColAttributeAllTypes) {
 #ifndef __APPLE__
 TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColAttributeAllTypes) {
   // Test assumes there is a table $scratch.ODBCTest in remote server
-  SQLWCHAR wsql[] = L"SELECT * from $scratch.ODBCTest;";
-  SQLSMALLINT wsql_len = std::wcslen(wsql);
+  ASSIGN_SQLWCHAR_ARR_AND_LEN(wsql, L"SELECT * from $scratch.ODBCTest;");
 
   ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
@@ -1789,8 +1775,7 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColAttributeAllTypes) {
 TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColAttributesAllTypes) {
   // Tests ODBC 2.0 API SQLColAttributes
   // Test assumes there is a table $scratch.ODBCTest in remote server
-  SQLWCHAR wsql[] = L"SELECT * from $scratch.ODBCTest;";
-  SQLINTEGER wsql_len = std::wcslen(wsql);
+  ASSIGN_SQLWCHAR_ARR_AND_LEN(wsql, L"SELECT * from $scratch.ODBCTest;");
 
   ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
@@ -2240,22 +2225,20 @@ TYPED_TEST(ColumnsOdbcV2Test, TestSQLColAttributesUpdatable) {
 TEST_F(ColumnsMockTest, SQLDescribeColValidateInput) {
   CreateTestTable();
 
-  SQLWCHAR sql_query[] = L"SELECT * FROM TestTable LIMIT 1;";
-  SQLINTEGER query_length = static_cast<SQLINTEGER>(wcslen(sql_query));
+  ASSIGN_SQLWCHAR_ARR_AND_LEN(sql_query, L"SELECT * FROM TestTable LIMIT 1;");
 
   SQLUSMALLINT bookmark_column = 0;
   SQLUSMALLINT out_of_range_column = 4;
   SQLUSMALLINT negative_column = -1;
   SQLWCHAR column_name[1024] = {0};
-  SQLSMALLINT buf_char_len =
-      static_cast<SQLSMALLINT>(sizeof(column_name) / GetSqlWCharSize());
+  SQLSMALLINT buf_char_len = sizeof(column_name) / GetSqlWCharSize();
   SQLSMALLINT name_length = 0;
   SQLSMALLINT data_type = 0;
   SQLULEN column_size = 0;
   SQLSMALLINT decimal_digits = 0;
   SQLSMALLINT nullable = 0;
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, sql_query, query_length));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, sql_query, sql_query_len));
 
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
@@ -2290,8 +2273,7 @@ TEST_F(ColumnsMockTest, SQLDescribeColQueryAllDataTypesMetadata) {
   // from SELECT AS queries
 
   SQLWCHAR column_name[1024];
-  SQLSMALLINT buf_char_len =
-      static_cast<SQLSMALLINT>(sizeof(column_name) / GetSqlWCharSize());
+  SQLSMALLINT buf_char_len = sizeof(column_name) / GetSqlWCharSize();
   SQLSMALLINT name_length = 0;
   SQLSMALLINT column_data_type = 0;
   SQLULEN column_size = 0;
@@ -2302,38 +2284,15 @@ TEST_F(ColumnsMockTest, SQLDescribeColQueryAllDataTypesMetadata) {
   std::wstring wsql = this->GetQueryAllDataTypes();
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
-  const SQLWCHAR* column_names[] = {static_cast<const SQLWCHAR*>(L"stiny_int_min"),
-                                    static_cast<const SQLWCHAR*>(L"stiny_int_max"),
-                                    static_cast<const SQLWCHAR*>(L"utiny_int_min"),
-                                    static_cast<const SQLWCHAR*>(L"utiny_int_max"),
-                                    static_cast<const SQLWCHAR*>(L"ssmall_int_min"),
-                                    static_cast<const SQLWCHAR*>(L"ssmall_int_max"),
-                                    static_cast<const SQLWCHAR*>(L"usmall_int_min"),
-                                    static_cast<const SQLWCHAR*>(L"usmall_int_max"),
-                                    static_cast<const SQLWCHAR*>(L"sinteger_min"),
-                                    static_cast<const SQLWCHAR*>(L"sinteger_max"),
-                                    static_cast<const SQLWCHAR*>(L"uinteger_min"),
-                                    static_cast<const SQLWCHAR*>(L"uinteger_max"),
-                                    static_cast<const SQLWCHAR*>(L"sbigint_min"),
-                                    static_cast<const SQLWCHAR*>(L"sbigint_max"),
-                                    static_cast<const SQLWCHAR*>(L"ubigint_min"),
-                                    static_cast<const SQLWCHAR*>(L"ubigint_max"),
-                                    static_cast<const SQLWCHAR*>(L"decimal_negative"),
-                                    static_cast<const SQLWCHAR*>(L"decimal_positive"),
-                                    static_cast<const SQLWCHAR*>(L"float_min"),
-                                    static_cast<const SQLWCHAR*>(L"float_max"),
-                                    static_cast<const SQLWCHAR*>(L"double_min"),
-                                    static_cast<const SQLWCHAR*>(L"double_max"),
-                                    static_cast<const SQLWCHAR*>(L"bit_false"),
-                                    static_cast<const SQLWCHAR*>(L"bit_true"),
-                                    static_cast<const SQLWCHAR*>(L"c_char"),
-                                    static_cast<const SQLWCHAR*>(L"c_wchar"),
-                                    static_cast<const SQLWCHAR*>(L"c_wvarchar"),
-                                    static_cast<const SQLWCHAR*>(L"c_varchar"),
-                                    static_cast<const SQLWCHAR*>(L"date_min"),
-                                    static_cast<const SQLWCHAR*>(L"date_max"),
-                                    static_cast<const SQLWCHAR*>(L"timestamp_min"),
-                                    static_cast<const SQLWCHAR*>(L"timestamp_max")};
+  const std::wstring column_names[] = {
+      L"stiny_int_min",    L"stiny_int_max",    L"utiny_int_min",  L"utiny_int_max",
+      L"ssmall_int_min",   L"ssmall_int_max",   L"usmall_int_min", L"usmall_int_max",
+      L"sinteger_min",     L"sinteger_max",     L"uinteger_min",   L"uinteger_max",
+      L"sbigint_min",      L"sbigint_max",      L"ubigint_min",    L"ubigint_max",
+      L"decimal_negative", L"decimal_positive", L"float_min",      L"float_max",
+      L"double_min",       L"double_max",       L"bit_false",      L"bit_true",
+      L"c_char",           L"c_wchar",          L"c_wvarchar",     L"c_varchar",
+      L"date_min",         L"date_max",         L"timestamp_min",  L"timestamp_max"};
   SQLSMALLINT column_data_types[] = {
       SQL_WVARCHAR, SQL_WVARCHAR, SQL_WVARCHAR, SQL_WVARCHAR, SQL_WVARCHAR, SQL_WVARCHAR,
       SQL_WVARCHAR, SQL_WVARCHAR, SQL_WVARCHAR, SQL_WVARCHAR, SQL_WVARCHAR, SQL_WVARCHAR,
@@ -2353,7 +2312,7 @@ TEST_F(ColumnsMockTest, SQLDescribeColQueryAllDataTypesMetadata) {
                                           buf_char_len, &name_length, &column_data_type,
                                           &column_size, &decimal_digits, &nullable));
 
-    EXPECT_EQ(wcslen(column_names[i]), name_length);
+    EXPECT_EQ(column_names[i].length(), name_length);
 
     std::wstring returned(column_name, column_name + name_length);
     EXPECT_EQ(column_names[i], returned);
@@ -2372,8 +2331,7 @@ TEST_F(ColumnsMockTest, SQLDescribeColQueryAllDataTypesMetadata) {
 
 TEST_F(ColumnsRemoteTest, SQLDescribeColQueryAllDataTypesMetadata) {
   SQLWCHAR column_name[1024];
-  SQLSMALLINT buf_char_len =
-      static_cast<SQLSMALLINT>(sizeof(column_name) / GetSqlWCharSize());
+  SQLSMALLINT buf_char_len = sizeof(column_name) / GetSqlWCharSize();
   SQLSMALLINT name_length = 0;
   SQLSMALLINT column_data_type = 0;
   SQLULEN column_size = 0;
@@ -2384,38 +2342,15 @@ TEST_F(ColumnsRemoteTest, SQLDescribeColQueryAllDataTypesMetadata) {
   std::wstring wsql = this->GetQueryAllDataTypes();
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
-  const SQLWCHAR* column_names[] = {static_cast<const SQLWCHAR*>(L"stiny_int_min"),
-                                    static_cast<const SQLWCHAR*>(L"stiny_int_max"),
-                                    static_cast<const SQLWCHAR*>(L"utiny_int_min"),
-                                    static_cast<const SQLWCHAR*>(L"utiny_int_max"),
-                                    static_cast<const SQLWCHAR*>(L"ssmall_int_min"),
-                                    static_cast<const SQLWCHAR*>(L"ssmall_int_max"),
-                                    static_cast<const SQLWCHAR*>(L"usmall_int_min"),
-                                    static_cast<const SQLWCHAR*>(L"usmall_int_max"),
-                                    static_cast<const SQLWCHAR*>(L"sinteger_min"),
-                                    static_cast<const SQLWCHAR*>(L"sinteger_max"),
-                                    static_cast<const SQLWCHAR*>(L"uinteger_min"),
-                                    static_cast<const SQLWCHAR*>(L"uinteger_max"),
-                                    static_cast<const SQLWCHAR*>(L"sbigint_min"),
-                                    static_cast<const SQLWCHAR*>(L"sbigint_max"),
-                                    static_cast<const SQLWCHAR*>(L"ubigint_min"),
-                                    static_cast<const SQLWCHAR*>(L"ubigint_max"),
-                                    static_cast<const SQLWCHAR*>(L"decimal_negative"),
-                                    static_cast<const SQLWCHAR*>(L"decimal_positive"),
-                                    static_cast<const SQLWCHAR*>(L"float_min"),
-                                    static_cast<const SQLWCHAR*>(L"float_max"),
-                                    static_cast<const SQLWCHAR*>(L"double_min"),
-                                    static_cast<const SQLWCHAR*>(L"double_max"),
-                                    static_cast<const SQLWCHAR*>(L"bit_false"),
-                                    static_cast<const SQLWCHAR*>(L"bit_true"),
-                                    static_cast<const SQLWCHAR*>(L"c_char"),
-                                    static_cast<const SQLWCHAR*>(L"c_wchar"),
-                                    static_cast<const SQLWCHAR*>(L"c_wvarchar"),
-                                    static_cast<const SQLWCHAR*>(L"c_varchar"),
-                                    static_cast<const SQLWCHAR*>(L"date_min"),
-                                    static_cast<const SQLWCHAR*>(L"date_max"),
-                                    static_cast<const SQLWCHAR*>(L"timestamp_min"),
-                                    static_cast<const SQLWCHAR*>(L"timestamp_max")};
+  const std::wstring column_names[] = {
+      L"stiny_int_min",    L"stiny_int_max",    L"utiny_int_min",  L"utiny_int_max",
+      L"ssmall_int_min",   L"ssmall_int_max",   L"usmall_int_min", L"usmall_int_max",
+      L"sinteger_min",     L"sinteger_max",     L"uinteger_min",   L"uinteger_max",
+      L"sbigint_min",      L"sbigint_max",      L"ubigint_min",    L"ubigint_max",
+      L"decimal_negative", L"decimal_positive", L"float_min",      L"float_max",
+      L"double_min",       L"double_max",       L"bit_false",      L"bit_true",
+      L"c_char",           L"c_wchar",          L"c_wvarchar",     L"c_varchar",
+      L"date_min",         L"date_max",         L"timestamp_min",  L"timestamp_max"};
   SQLSMALLINT column_data_types[] = {
       SQL_INTEGER,        SQL_INTEGER,       SQL_INTEGER,  SQL_INTEGER,   SQL_INTEGER,
       SQL_INTEGER,        SQL_INTEGER,       SQL_INTEGER,  SQL_INTEGER,   SQL_INTEGER,
@@ -2442,7 +2377,7 @@ TEST_F(ColumnsRemoteTest, SQLDescribeColQueryAllDataTypesMetadata) {
                                           buf_char_len, &name_length, &column_data_type,
                                           &column_size, &decimal_digits, &nullable));
 
-    EXPECT_EQ(wcslen(column_names[i]), name_length);
+    EXPECT_EQ(column_names[i].length(), name_length);
 
     std::wstring returned(column_name, column_name + name_length);
     EXPECT_EQ(column_names[i], returned);
@@ -2463,8 +2398,7 @@ TEST_F(ColumnsRemoteTest, SQLDescribeColODBCTestTableMetadata) {
   // Test assumes there is a table $scratch.ODBCTest in remote server
 
   SQLWCHAR column_name[1024];
-  SQLSMALLINT buf_char_len =
-      static_cast<SQLSMALLINT>(sizeof(column_name) / GetSqlWCharSize());
+  SQLSMALLINT buf_char_len = sizeof(column_name) / GetSqlWCharSize();
   SQLSMALLINT name_length = 0;
   SQLSMALLINT column_data_type = 0;
   SQLULEN column_size = 0;
@@ -2472,25 +2406,19 @@ TEST_F(ColumnsRemoteTest, SQLDescribeColODBCTestTableMetadata) {
   SQLSMALLINT nullable = 0;
   size_t column_index = 0;
 
-  SQLWCHAR sql_query[] = L"SELECT * from $scratch.ODBCTest LIMIT 1;";
-  SQLINTEGER query_length = static_cast<SQLINTEGER>(wcslen(sql_query));
+  ASSIGN_SQLWCHAR_ARR_AND_LEN(sql_query, L"SELECT * from $scratch.ODBCTest LIMIT 1;");
 
-  const SQLWCHAR* column_names[] = {static_cast<const SQLWCHAR*>(L"sinteger_max"),
-                                    static_cast<const SQLWCHAR*>(L"sbigint_max"),
-                                    static_cast<const SQLWCHAR*>(L"decimal_positive"),
-                                    static_cast<const SQLWCHAR*>(L"float_max"),
-                                    static_cast<const SQLWCHAR*>(L"double_max"),
-                                    static_cast<const SQLWCHAR*>(L"bit_true"),
-                                    static_cast<const SQLWCHAR*>(L"date_max"),
-                                    static_cast<const SQLWCHAR*>(L"time_max"),
-                                    static_cast<const SQLWCHAR*>(L"timestamp_max")};
+  const std::wstring column_names[] = {
+      L"sinteger_max", L"sbigint_max", L"decimal_positive",
+      L"float_max",    L"double_max",  L"bit_true",
+      L"date_max",     L"time_max",    L"timestamp_max"};
   SQLSMALLINT column_data_types[] = {SQL_INTEGER,   SQL_BIGINT,    SQL_DECIMAL,
                                      SQL_FLOAT,     SQL_DOUBLE,    SQL_BIT,
                                      SQL_TYPE_DATE, SQL_TYPE_TIME, SQL_TYPE_TIMESTAMP};
   SQLULEN column_sizes[] = {4, 8, 19, 8, 8, 1, 10, 12, 23};
   SQLULEN columndecimal_digits[] = {0, 0, 0, 0, 0, 0, 10, 12, 23};
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, sql_query, query_length));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, sql_query, sql_query_len));
 
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
@@ -2501,7 +2429,7 @@ TEST_F(ColumnsRemoteTest, SQLDescribeColODBCTestTableMetadata) {
                                           buf_char_len, &name_length, &column_data_type,
                                           &column_size, &decimal_digits, &nullable));
 
-    EXPECT_EQ(wcslen(column_names[i]), name_length);
+    EXPECT_EQ(column_names[i].length(), name_length);
 
     std::wstring returned(column_name, column_name + name_length);
     EXPECT_EQ(column_names[i], returned);
@@ -2521,8 +2449,7 @@ TEST_F(ColumnsRemoteTest, SQLDescribeColODBCTestTableMetadata) {
 TEST_F(ColumnsOdbcV2RemoteTest, SQLDescribeColODBCTestTableMetadataODBCVer2) {
   // Test assumes there is a table $scratch.ODBCTest in remote server
   SQLWCHAR column_name[1024];
-  SQLSMALLINT buf_char_len =
-      static_cast<SQLSMALLINT>(sizeof(column_name) / GetSqlWCharSize());
+  SQLSMALLINT buf_char_len = sizeof(column_name) / GetSqlWCharSize();
   SQLSMALLINT name_length = 0;
   SQLSMALLINT column_data_type = 0;
   SQLULEN column_size = 0;
@@ -2530,25 +2457,19 @@ TEST_F(ColumnsOdbcV2RemoteTest, SQLDescribeColODBCTestTableMetadataODBCVer2) {
   SQLSMALLINT nullable = 0;
   size_t column_index = 0;
 
-  SQLWCHAR sql_query[] = L"SELECT * from $scratch.ODBCTest LIMIT 1;";
-  SQLINTEGER query_length = static_cast<SQLINTEGER>(wcslen(sql_query));
+  ASSIGN_SQLWCHAR_ARR_AND_LEN(sql_query, L"SELECT * from $scratch.ODBCTest LIMIT 1;");
 
-  const SQLWCHAR* column_names[] = {static_cast<const SQLWCHAR*>(L"sinteger_max"),
-                                    static_cast<const SQLWCHAR*>(L"sbigint_max"),
-                                    static_cast<const SQLWCHAR*>(L"decimal_positive"),
-                                    static_cast<const SQLWCHAR*>(L"float_max"),
-                                    static_cast<const SQLWCHAR*>(L"double_max"),
-                                    static_cast<const SQLWCHAR*>(L"bit_true"),
-                                    static_cast<const SQLWCHAR*>(L"date_max"),
-                                    static_cast<const SQLWCHAR*>(L"time_max"),
-                                    static_cast<const SQLWCHAR*>(L"timestamp_max")};
+  const std::wstring column_names[] = {
+      L"sinteger_max", L"sbigint_max", L"decimal_positive",
+      L"float_max",    L"double_max",  L"bit_true",
+      L"date_max",     L"time_max",    L"timestamp_max"};
   SQLSMALLINT column_data_types[] = {SQL_INTEGER, SQL_BIGINT, SQL_DECIMAL,
                                      SQL_FLOAT,   SQL_DOUBLE, SQL_BIT,
                                      SQL_DATE,    SQL_TIME,   SQL_TIMESTAMP};
   SQLULEN column_sizes[] = {4, 8, 19, 8, 8, 1, 10, 12, 23};
   SQLULEN columndecimal_digits[] = {0, 0, 0, 0, 0, 0, 10, 12, 23};
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, sql_query, query_length));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, sql_query, sql_query_len));
 
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
@@ -2559,7 +2480,7 @@ TEST_F(ColumnsOdbcV2RemoteTest, SQLDescribeColODBCTestTableMetadataODBCVer2) {
                                           buf_char_len, &name_length, &column_data_type,
                                           &column_size, &decimal_digits, &nullable));
 
-    EXPECT_EQ(wcslen(column_names[i]), name_length);
+    EXPECT_EQ(column_names[i].length(), name_length);
 
     std::wstring returned(column_name, column_name + name_length);
     EXPECT_EQ(column_names[i], returned);
@@ -2580,8 +2501,7 @@ TEST_F(ColumnsMockTest, SQLDescribeColAllTypesTableMetadata) {
   CreateAllDataTypeTable();
 
   SQLWCHAR column_name[1024];
-  SQLSMALLINT buf_char_len =
-      static_cast<SQLSMALLINT>(sizeof(column_name) / GetSqlWCharSize());
+  SQLSMALLINT buf_char_len = sizeof(column_name) / GetSqlWCharSize();
   SQLSMALLINT name_length = 0;
   SQLSMALLINT column_data_type = 0;
   SQLULEN column_size = 0;
@@ -2589,17 +2509,14 @@ TEST_F(ColumnsMockTest, SQLDescribeColAllTypesTableMetadata) {
   SQLSMALLINT nullable = 0;
   size_t column_index = 0;
 
-  SQLWCHAR sql_query[] = L"SELECT * from AllTypesTable LIMIT 1;";
-  SQLINTEGER query_length = static_cast<SQLINTEGER>(wcslen(sql_query));
+  ASSIGN_SQLWCHAR_ARR_AND_LEN(sql_query, L"SELECT * from AllTypesTable LIMIT 1;");
 
-  const SQLWCHAR* column_names[] = {static_cast<const SQLWCHAR*>(L"bigint_col"),
-                                    static_cast<const SQLWCHAR*>(L"char_col"),
-                                    static_cast<const SQLWCHAR*>(L"varbinary_col"),
-                                    static_cast<const SQLWCHAR*>(L"double_col")};
+  const std::wstring column_names[] = {L"bigint_col", L"char_col", L"varbinary_col",
+                                       L"double_col"};
   SQLSMALLINT column_data_types[] = {SQL_BIGINT, SQL_WVARCHAR, SQL_BINARY, SQL_DOUBLE};
   SQLULEN column_sizes[] = {8, 0, 0, 8};
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, sql_query, query_length));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, sql_query, sql_query_len));
 
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
@@ -2610,7 +2527,7 @@ TEST_F(ColumnsMockTest, SQLDescribeColAllTypesTableMetadata) {
                                           buf_char_len, &name_length, &column_data_type,
                                           &column_size, &decimal_digits, &nullable));
 
-    EXPECT_EQ(wcslen(column_names[i]), name_length);
+    EXPECT_EQ(column_names[i].length(), name_length);
 
     std::wstring returned(column_name, column_name + name_length);
     EXPECT_EQ(column_names[i], returned);
@@ -2633,8 +2550,7 @@ TEST_F(ColumnsMockTest, SQLDescribeColUnicodeTableMetadata) {
   CreateUnicodeTable();
 
   SQLWCHAR column_name[1024];
-  SQLSMALLINT buf_char_len =
-      static_cast<SQLSMALLINT>(sizeof(column_name) / GetSqlWCharSize());
+  SQLSMALLINT buf_char_len = sizeof(column_name) / GetSqlWCharSize();
   SQLSMALLINT name_length = 0;
   SQLSMALLINT column_data_type = 0;
   SQLULEN column_size = 0;
@@ -2642,14 +2558,13 @@ TEST_F(ColumnsMockTest, SQLDescribeColUnicodeTableMetadata) {
   SQLSMALLINT nullable = 0;
   size_t column_index = 1;
 
-  SQLWCHAR sql_query[] = L"SELECT * from 数据 LIMIT 1;";
-  SQLINTEGER query_length = static_cast<SQLINTEGER>(wcslen(sql_query));
+  ASSIGN_SQLWCHAR_ARR_AND_LEN(sql_query, L"SELECT * from 数据 LIMIT 1;");
 
-  SQLWCHAR expected_column_name[] = L"资料";
+  ASSIGN_SQLWCHAR_ARR_AND_LEN(expected_column_name, L"资料");
   SQLSMALLINT expected_column_data_type = SQL_WVARCHAR;
   SQLULEN expected_column_size = 0;
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, sql_query, query_length));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, sql_query, sql_query_len));
 
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
@@ -2657,12 +2572,13 @@ TEST_F(ColumnsMockTest, SQLDescribeColUnicodeTableMetadata) {
                                         buf_char_len, &name_length, &column_data_type,
                                         &column_size, &decimal_digits, &nullable));
 
-  EXPECT_EQ(name_length, wcslen(expected_column_name));
+  EXPECT_EQ(name_length, expected_column_name_len);
 
   std::wstring returned(column_name, column_name + name_length);
-  EXPECT_EQ(returned, expected_column_name);
-  EXPECT_EQ(column_data_type, expected_column_data_type);
-  EXPECT_EQ(column_size, expected_column_size);
+  std::wstring expected_col_name_str = ConvertToWString(expected_column_name);
+  EXPECT_EQ(expected_col_name_str, returned);
+  EXPECT_EQ(expected_column_data_type, column_data_type);
+  EXPECT_EQ(expected_column_size, column_size);
   EXPECT_EQ(0, decimal_digits);
   EXPECT_EQ(SQL_NULLABLE, nullable);
 
@@ -2671,8 +2587,7 @@ TEST_F(ColumnsMockTest, SQLDescribeColUnicodeTableMetadata) {
 
 TYPED_TEST(ColumnsTest, SQLColumnsGetMetadataBySQLDescribeCol) {
   SQLWCHAR column_name[1024];
-  SQLSMALLINT buf_char_len =
-      static_cast<SQLSMALLINT>(sizeof(column_name) / GetSqlWCharSize());
+  SQLSMALLINT buf_char_len = sizeof(column_name) / GetSqlWCharSize();
   SQLSMALLINT name_length = 0;
   SQLSMALLINT column_data_type = 0;
   SQLULEN column_size = 0;
@@ -2680,24 +2595,12 @@ TYPED_TEST(ColumnsTest, SQLColumnsGetMetadataBySQLDescribeCol) {
   SQLSMALLINT nullable = 0;
   size_t column_index = 0;
 
-  const SQLWCHAR* column_names[] = {static_cast<const SQLWCHAR*>(L"TABLE_CAT"),
-                                    static_cast<const SQLWCHAR*>(L"TABLE_SCHEM"),
-                                    static_cast<const SQLWCHAR*>(L"TABLE_NAME"),
-                                    static_cast<const SQLWCHAR*>(L"COLUMN_NAME"),
-                                    static_cast<const SQLWCHAR*>(L"DATA_TYPE"),
-                                    static_cast<const SQLWCHAR*>(L"TYPE_NAME"),
-                                    static_cast<const SQLWCHAR*>(L"COLUMN_SIZE"),
-                                    static_cast<const SQLWCHAR*>(L"BUFFER_LENGTH"),
-                                    static_cast<const SQLWCHAR*>(L"DECIMAL_DIGITS"),
-                                    static_cast<const SQLWCHAR*>(L"NUM_PREC_RADIX"),
-                                    static_cast<const SQLWCHAR*>(L"NULLABLE"),
-                                    static_cast<const SQLWCHAR*>(L"REMARKS"),
-                                    static_cast<const SQLWCHAR*>(L"COLUMN_DEF"),
-                                    static_cast<const SQLWCHAR*>(L"SQL_DATA_TYPE"),
-                                    static_cast<const SQLWCHAR*>(L"SQL_DATETIME_SUB"),
-                                    static_cast<const SQLWCHAR*>(L"CHAR_OCTET_LENGTH"),
-                                    static_cast<const SQLWCHAR*>(L"ORDINAL_POSITION"),
-                                    static_cast<const SQLWCHAR*>(L"IS_NULLABLE")};
+  const std::wstring column_names[] = {
+      L"TABLE_CAT",        L"TABLE_SCHEM",    L"TABLE_NAME",       L"COLUMN_NAME",
+      L"DATA_TYPE",        L"TYPE_NAME",      L"COLUMN_SIZE",      L"BUFFER_LENGTH",
+      L"DECIMAL_DIGITS",   L"NUM_PREC_RADIX", L"NULLABLE",         L"REMARKS",
+      L"COLUMN_DEF",       L"SQL_DATA_TYPE",  L"SQL_DATETIME_SUB", L"CHAR_OCTET_LENGTH",
+      L"ORDINAL_POSITION", L"IS_NULLABLE"};
   SQLSMALLINT column_data_types[] = {
       SQL_WVARCHAR, SQL_WVARCHAR, SQL_WVARCHAR, SQL_WVARCHAR, SQL_SMALLINT, SQL_WVARCHAR,
       SQL_INTEGER,  SQL_INTEGER,  SQL_SMALLINT, SQL_SMALLINT, SQL_SMALLINT, SQL_WVARCHAR,
@@ -2715,7 +2618,7 @@ TYPED_TEST(ColumnsTest, SQLColumnsGetMetadataBySQLDescribeCol) {
                                           buf_char_len, &name_length, &column_data_type,
                                           &column_size, &decimal_digits, &nullable));
 
-    EXPECT_EQ(wcslen(column_names[i]), name_length);
+    EXPECT_EQ(column_names[i].length(), name_length);
 
     std::wstring returned(column_name, column_name + name_length);
     EXPECT_EQ(column_names[i], returned);
@@ -2734,8 +2637,7 @@ TYPED_TEST(ColumnsTest, SQLColumnsGetMetadataBySQLDescribeCol) {
 
 TYPED_TEST(ColumnsOdbcV2Test, SQLColumnsGetMetadataBySQLDescribeColODBCVer2) {
   SQLWCHAR column_name[1024];
-  SQLSMALLINT buf_char_len =
-      static_cast<SQLSMALLINT>(sizeof(column_name) / GetSqlWCharSize());
+  SQLSMALLINT buf_char_len = sizeof(column_name) / GetSqlWCharSize();
   SQLSMALLINT name_length = 0;
   SQLSMALLINT column_data_type = 0;
   SQLULEN column_size = 0;
@@ -2743,24 +2645,24 @@ TYPED_TEST(ColumnsOdbcV2Test, SQLColumnsGetMetadataBySQLDescribeColODBCVer2) {
   SQLSMALLINT nullable = 0;
   size_t column_index = 0;
 
-  const SQLWCHAR* column_names[] = {static_cast<const SQLWCHAR*>(L"TABLE_QUALIFIER"),
-                                    static_cast<const SQLWCHAR*>(L"TABLE_OWNER"),
-                                    static_cast<const SQLWCHAR*>(L"TABLE_NAME"),
-                                    static_cast<const SQLWCHAR*>(L"COLUMN_NAME"),
-                                    static_cast<const SQLWCHAR*>(L"DATA_TYPE"),
-                                    static_cast<const SQLWCHAR*>(L"TYPE_NAME"),
-                                    static_cast<const SQLWCHAR*>(L"PRECISION"),
-                                    static_cast<const SQLWCHAR*>(L"LENGTH"),
-                                    static_cast<const SQLWCHAR*>(L"SCALE"),
-                                    static_cast<const SQLWCHAR*>(L"RADIX"),
-                                    static_cast<const SQLWCHAR*>(L"NULLABLE"),
-                                    static_cast<const SQLWCHAR*>(L"REMARKS"),
-                                    static_cast<const SQLWCHAR*>(L"COLUMN_DEF"),
-                                    static_cast<const SQLWCHAR*>(L"SQL_DATA_TYPE"),
-                                    static_cast<const SQLWCHAR*>(L"SQL_DATETIME_SUB"),
-                                    static_cast<const SQLWCHAR*>(L"CHAR_OCTET_LENGTH"),
-                                    static_cast<const SQLWCHAR*>(L"ORDINAL_POSITION"),
-                                    static_cast<const SQLWCHAR*>(L"IS_NULLABLE")};
+  const std::wstring column_names[] = {L"TABLE_QUALIFIER",
+                                       L"TABLE_OWNER",
+                                       L"TABLE_NAME",
+                                       L"COLUMN_NAME",
+                                       L"DATA_TYPE",
+                                       L"TYPE_NAME",
+                                       L"PRECISION",
+                                       L"LENGTH",
+                                       L"SCALE",
+                                       L"RADIX",
+                                       L"NULLABLE",
+                                       L"REMARKS",
+                                       L"COLUMN_DEF",
+                                       L"SQL_DATA_TYPE",
+                                       L"SQL_DATETIME_SUB",
+                                       L"CHAR_OCTET_LENGTH",
+                                       L"ORDINAL_POSITION",
+                                       L"IS_NULLABLE"};
   SQLSMALLINT column_data_types[] = {
       SQL_WVARCHAR, SQL_WVARCHAR, SQL_WVARCHAR, SQL_WVARCHAR, SQL_SMALLINT, SQL_WVARCHAR,
       SQL_INTEGER,  SQL_INTEGER,  SQL_SMALLINT, SQL_SMALLINT, SQL_SMALLINT, SQL_WVARCHAR,
@@ -2778,7 +2680,7 @@ TYPED_TEST(ColumnsOdbcV2Test, SQLColumnsGetMetadataBySQLDescribeColODBCVer2) {
                                           buf_char_len, &name_length, &column_data_type,
                                           &column_size, &decimal_digits, &nullable));
 
-    EXPECT_EQ(wcslen(column_names[i]), name_length);
+    EXPECT_EQ(column_names[i].length(), name_length);
 
     std::wstring returned(column_name, column_name + name_length);
     EXPECT_EQ(column_names[i], returned);

--- a/cpp/src/arrow/flight/sql/odbc/tests/connection_info_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/connection_info_test.cc
@@ -372,7 +372,8 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoServerName) {
   SQLWCHAR value[kOdbcBufferSize] = {};
   GetInfoSQLWCHAR(this->conn, SQL_SERVER_NAME, value);
 
-  EXPECT_GT(wcslen(reinterpret_cast<wchar_t*>(value)), 0);
+  std::wstring result = ConvertToWString(value);
+  EXPECT_GT(result.length(), 0);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoStaticCursorAttributes1) {
@@ -403,14 +404,16 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDbmsName) {
   SQLWCHAR value[kOdbcBufferSize] = {};
   GetInfoSQLWCHAR(this->conn, SQL_DBMS_NAME, value);
 
-  EXPECT_GT(wcslen(reinterpret_cast<wchar_t*>(value)), 0);
+  std::wstring result = ConvertToWString(value);
+  EXPECT_GT(result.length(), 0);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDbmsVer) {
   SQLWCHAR value[kOdbcBufferSize] = {};
   GetInfoSQLWCHAR(this->conn, SQL_DBMS_VER, value);
 
-  EXPECT_GT(wcslen(reinterpret_cast<wchar_t*>(value)), 0);
+  std::wstring result = ConvertToWString(value);
+  EXPECT_GT(result.length(), 0);
 }
 
 // Data Source Information
@@ -850,7 +853,8 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoKeywords) {
   SQLWCHAR value[info_len] = {};
   GetInfoSQLWCHAR(this->conn, SQL_KEYWORDS, value, info_len);
 
-  EXPECT_GT(wcslen(reinterpret_cast<wchar_t*>(value)), 0);
+  std::wstring result = ConvertToWString(value, -1, info_len);
+  EXPECT_GT(result.length(), 0);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoLikeEscapeClause) {

--- a/cpp/src/arrow/flight/sql/odbc/tests/connection_info_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/connection_info_test.cc
@@ -64,8 +64,8 @@ void GetInfo(SQLHDBC connection, SQLUSMALLINT info_type, SQLULEN* value) {
 }
 
 // Get SQLWCHAR return value
-void GetInfo(SQLHDBC connection, SQLUSMALLINT info_type, SQLWCHAR* value,
-             SQLSMALLINT buf_len = kOdbcBufferSize) {
+void GetInfoSQLWCHAR(SQLHDBC connection, SQLUSMALLINT info_type, SQLWCHAR* value,
+                     SQLSMALLINT buf_len = kOdbcBufferSize) {
   SQLSMALLINT message_length;
 
   ASSERT_EQ(SQL_SUCCESS,
@@ -75,7 +75,7 @@ void GetInfo(SQLHDBC connection, SQLUSMALLINT info_type, SQLWCHAR* value,
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoTruncation) {
   static constexpr int info_len = 1;
-  SQLWCHAR value[info_len] = L"";
+  SQLWCHAR value[info_len] = {};
   SQLSMALLINT message_length;
 
   ASSERT_EQ(SQL_SUCCESS_WITH_INFO,
@@ -135,10 +135,11 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoBatchSupport) {
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDataSourceName) {
-  SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_DATA_SOURCE_NAME, value);
+  SQLWCHAR value[kOdbcBufferSize] = {};
+  GetInfoSQLWCHAR(this->conn, SQL_DATA_SOURCE_NAME, value);
 
-  EXPECT_STREQ(static_cast<const SQLWCHAR*>(L""), value);
+  std::wstring result = ConvertToWString(value);
+  EXPECT_EQ(std::wstring(L""), result);
 }
 
 #ifdef SQL_DRIVER_AWARE_POOLING_SUPPORTED
@@ -207,24 +208,27 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDriverHstmt) {
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDriverName) {
-  SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_DRIVER_NAME, value);
+  SQLWCHAR value[kOdbcBufferSize] = {};
+  GetInfoSQLWCHAR(this->conn, SQL_DRIVER_NAME, value);
 
-  EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"Arrow Flight ODBC Driver"), value);
+  std::wstring result = ConvertToWString(value);
+  EXPECT_EQ(std::wstring(L"Arrow Flight ODBC Driver"), result);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDriverOdbcVer) {
-  SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_DRIVER_ODBC_VER, value);
+  SQLWCHAR value[kOdbcBufferSize] = {};
+  GetInfoSQLWCHAR(this->conn, SQL_DRIVER_ODBC_VER, value);
 
-  EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"03.80"), value);
+  std::wstring result = ConvertToWString(value);
+  EXPECT_EQ(std::wstring(L"03.80"), result);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDriverVer) {
-  SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_DRIVER_VER, value);
+  SQLWCHAR value[kOdbcBufferSize] = {};
+  GetInfoSQLWCHAR(this->conn, SQL_DRIVER_VER, value);
 
-  EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"00.09.0000.0"), value);
+  std::wstring result = ConvertToWString(value);
+  EXPECT_EQ(std::wstring(L"00.09.0000.0"), result);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDynamicCursorAttributes1) {
@@ -322,13 +326,15 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoOdbcInterfaceConformance) {
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoOdbcVer) {
   // This is implemented only in the Driver Manager.
 
-  SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_ODBC_VER, value);
+  SQLWCHAR value[kOdbcBufferSize] = {};
+  GetInfoSQLWCHAR(this->conn, SQL_ODBC_VER, value);
+
+  std::wstring result = ConvertToWString(value);
 
 #ifdef __APPLE__
-  EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"03.52.0000"), value);
+  EXPECT_EQ(std::wstring(L"03.52.0000"), result);
 #else
-  EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"03.80.0000"), value);
+  EXPECT_EQ(std::wstring(L"03.80.0000"), result);
 #endif  // __APPLE__
 }
 
@@ -347,24 +353,26 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoParamArraySelects) {
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoRowUpdates) {
-  SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_ROW_UPDATES, value);
+  SQLWCHAR value[kOdbcBufferSize] = {};
+  GetInfoSQLWCHAR(this->conn, SQL_ROW_UPDATES, value);
 
-  EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"N"), value);
+  std::wstring result = ConvertToWString(value);
+  EXPECT_EQ(std::wstring(L"N"), result);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoSearchPatternEscape) {
-  SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_SEARCH_PATTERN_ESCAPE, value);
+  SQLWCHAR value[kOdbcBufferSize] = {};
+  GetInfoSQLWCHAR(this->conn, SQL_SEARCH_PATTERN_ESCAPE, value);
 
-  EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"\\"), value);
+  std::wstring result = ConvertToWString(value);
+  EXPECT_EQ(std::wstring(L"\\"), result);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoServerName) {
-  SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_SERVER_NAME, value);
+  SQLWCHAR value[kOdbcBufferSize] = {};
+  GetInfoSQLWCHAR(this->conn, SQL_SERVER_NAME, value);
 
-  EXPECT_GT(wcslen(value), 0);
+  EXPECT_GT(wcslen(reinterpret_cast<wchar_t*>(value)), 0);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoStaticCursorAttributes1) {
@@ -384,40 +392,43 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoStaticCursorAttributes2) {
 // DBMS Product Information
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDatabaseName) {
-  SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_DATABASE_NAME, value);
+  SQLWCHAR value[kOdbcBufferSize] = {};
+  GetInfoSQLWCHAR(this->conn, SQL_DATABASE_NAME, value);
 
-  EXPECT_STREQ(static_cast<const SQLWCHAR*>(L""), value);
+  std::wstring result = ConvertToWString(value);
+  EXPECT_EQ(std::wstring(L""), result);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDbmsName) {
-  SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_DBMS_NAME, value);
+  SQLWCHAR value[kOdbcBufferSize] = {};
+  GetInfoSQLWCHAR(this->conn, SQL_DBMS_NAME, value);
 
-  EXPECT_GT(wcslen(value), 0);
+  EXPECT_GT(wcslen(reinterpret_cast<wchar_t*>(value)), 0);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDbmsVer) {
-  SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_DBMS_VER, value);
+  SQLWCHAR value[kOdbcBufferSize] = {};
+  GetInfoSQLWCHAR(this->conn, SQL_DBMS_VER, value);
 
-  EXPECT_GT(wcslen(value), 0);
+  EXPECT_GT(wcslen(reinterpret_cast<wchar_t*>(value)), 0);
 }
 
 // Data Source Information
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoAccessibleProcedures) {
-  SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_ACCESSIBLE_PROCEDURES, value);
+  SQLWCHAR value[kOdbcBufferSize] = {};
+  GetInfoSQLWCHAR(this->conn, SQL_ACCESSIBLE_PROCEDURES, value);
 
-  EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"N"), value);
+  std::wstring result = ConvertToWString(value);
+  EXPECT_EQ(std::wstring(L"N"), result);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoAccessibleTables) {
-  SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_ACCESSIBLE_TABLES, value);
+  SQLWCHAR value[kOdbcBufferSize] = {};
+  GetInfoSQLWCHAR(this->conn, SQL_ACCESSIBLE_TABLES, value);
 
-  EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"Y"), value);
+  std::wstring result = ConvertToWString(value);
+  EXPECT_EQ(std::wstring(L"Y"), result);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoBookmarkPersistence) {
@@ -428,17 +439,19 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoBookmarkPersistence) {
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoCatalogTerm) {
-  SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_CATALOG_TERM, value);
+  SQLWCHAR value[kOdbcBufferSize] = {};
+  GetInfoSQLWCHAR(this->conn, SQL_CATALOG_TERM, value);
 
-  EXPECT_STREQ(static_cast<const SQLWCHAR*>(L""), value);
+  std::wstring result = ConvertToWString(value);
+  EXPECT_EQ(std::wstring(L""), result);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoCollationSeq) {
-  SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_COLLATION_SEQ, value);
+  SQLWCHAR value[kOdbcBufferSize] = {};
+  GetInfoSQLWCHAR(this->conn, SQL_COLLATION_SEQ, value);
 
-  EXPECT_STREQ(static_cast<const SQLWCHAR*>(L""), value);
+  std::wstring result = ConvertToWString(value);
+  EXPECT_EQ(std::wstring(L""), result);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoConcatNullBehavior) {
@@ -470,10 +483,11 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoCursorSensitivity) {
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDataSourceReadOnly) {
-  SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_DATA_SOURCE_READ_ONLY, value);
+  SQLWCHAR value[kOdbcBufferSize] = {};
+  GetInfoSQLWCHAR(this->conn, SQL_DATA_SOURCE_READ_ONLY, value);
 
-  EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"N"), value);
+  std::wstring result = ConvertToWString(value);
+  EXPECT_EQ(std::wstring(L"N"), result);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDefaultTxnIsolation) {
@@ -484,31 +498,35 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDefaultTxnIsolation) {
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDescribeParameter) {
-  SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_DESCRIBE_PARAMETER, value);
+  SQLWCHAR value[kOdbcBufferSize] = {};
+  GetInfoSQLWCHAR(this->conn, SQL_DESCRIBE_PARAMETER, value);
 
-  EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"N"), value);
+  std::wstring result = ConvertToWString(value);
+  EXPECT_EQ(std::wstring(L"N"), result);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoMultResultSets) {
-  SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_MULT_RESULT_SETS, value);
+  SQLWCHAR value[kOdbcBufferSize] = {};
+  GetInfoSQLWCHAR(this->conn, SQL_MULT_RESULT_SETS, value);
 
-  EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"N"), value);
+  std::wstring result = ConvertToWString(value);
+  EXPECT_EQ(std::wstring(L"N"), result);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoMultipleActiveTxn) {
-  SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_MULTIPLE_ACTIVE_TXN, value);
+  SQLWCHAR value[kOdbcBufferSize] = {};
+  GetInfoSQLWCHAR(this->conn, SQL_MULTIPLE_ACTIVE_TXN, value);
 
-  EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"N"), value);
+  std::wstring result = ConvertToWString(value);
+  EXPECT_EQ(std::wstring(L"N"), result);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoNeedLongDataLen) {
-  SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_NEED_LONG_DATA_LEN, value);
+  SQLWCHAR value[kOdbcBufferSize] = {};
+  GetInfoSQLWCHAR(this->conn, SQL_NEED_LONG_DATA_LEN, value);
 
-  EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"N"), value);
+  std::wstring result = ConvertToWString(value);
+  EXPECT_EQ(std::wstring(L"N"), result);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoNullCollation) {
@@ -518,17 +536,19 @@ TEST_F(ConnectionInfoMockTest, TestSQLGetInfoNullCollation) {
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoProcedureTerm) {
-  SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_PROCEDURE_TERM, value);
+  SQLWCHAR value[kOdbcBufferSize] = {};
+  GetInfoSQLWCHAR(this->conn, SQL_PROCEDURE_TERM, value);
 
-  EXPECT_STREQ(static_cast<const SQLWCHAR*>(L""), value);
+  std::wstring result = ConvertToWString(value);
+  EXPECT_EQ(std::wstring(L""), result);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoSchemaTerm) {
-  SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_SCHEMA_TERM, value);
+  SQLWCHAR value[kOdbcBufferSize] = {};
+  GetInfoSQLWCHAR(this->conn, SQL_SCHEMA_TERM, value);
 
-  EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"schema"), value);
+  std::wstring result = ConvertToWString(value);
+  EXPECT_EQ(std::wstring(L"schema"), result);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoScrollOptions) {
@@ -539,10 +559,11 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoScrollOptions) {
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoTableTerm) {
-  SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_TABLE_TERM, value);
+  SQLWCHAR value[kOdbcBufferSize] = {};
+  GetInfoSQLWCHAR(this->conn, SQL_TABLE_TERM, value);
 
-  EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"table"), value);
+  std::wstring result = ConvertToWString(value);
+  EXPECT_EQ(std::wstring(L"table"), result);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoTxnCapable) {
@@ -560,10 +581,11 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoTxnIsolationOption) {
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoUserName) {
-  SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_USER_NAME, value);
+  SQLWCHAR value[kOdbcBufferSize] = {};
+  GetInfoSQLWCHAR(this->conn, SQL_USER_NAME, value);
 
-  EXPECT_STREQ(static_cast<const SQLWCHAR*>(L""), value);
+  std::wstring result = ConvertToWString(value);
+  EXPECT_EQ(std::wstring(L""), result);
 }
 
 // Supported SQL
@@ -606,17 +628,19 @@ TYPED_TEST(ConnectionInfoHandleTest, TestSQLGetInfoCatalogLocation) {
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoCatalogName) {
-  SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_CATALOG_NAME, value);
+  SQLWCHAR value[kOdbcBufferSize] = {};
+  GetInfoSQLWCHAR(this->conn, SQL_CATALOG_NAME, value);
 
-  EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"N"), value);
+  std::wstring result = ConvertToWString(value);
+  EXPECT_EQ(std::wstring(L"N"), result);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoCatalogNameSeparator) {
-  SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_CATALOG_NAME_SEPARATOR, value);
+  SQLWCHAR value[kOdbcBufferSize] = {};
+  GetInfoSQLWCHAR(this->conn, SQL_CATALOG_NAME_SEPARATOR, value);
 
-  EXPECT_STREQ(static_cast<const SQLWCHAR*>(L""), value);
+  std::wstring result = ConvertToWString(value);
+  EXPECT_EQ(std::wstring(L""), result);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoCatalogUsage) {
@@ -627,10 +651,11 @@ TEST_F(ConnectionInfoMockTest, TestSQLGetInfoCatalogUsage) {
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoColumnAlias) {
-  SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_COLUMN_ALIAS, value);
+  SQLWCHAR value[kOdbcBufferSize] = {};
+  GetInfoSQLWCHAR(this->conn, SQL_COLUMN_ALIAS, value);
 
-  EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"Y"), value);
+  std::wstring result = ConvertToWString(value);
+  EXPECT_EQ(std::wstring(L"Y"), result);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoCorrelationName) {
@@ -767,10 +792,11 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDropView) {
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoExpressionsInOrderby) {
-  SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_EXPRESSIONS_IN_ORDERBY, value);
+  SQLWCHAR value[kOdbcBufferSize] = {};
+  GetInfoSQLWCHAR(this->conn, SQL_EXPRESSIONS_IN_ORDERBY, value);
 
-  EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"N"), value);
+  std::wstring result = ConvertToWString(value);
+  EXPECT_EQ(std::wstring(L"N"), result);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoGroupBy) {
@@ -788,10 +814,11 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoIdentifierCase) {
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoIdentifierQuoteChar) {
-  SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_IDENTIFIER_QUOTE_CHAR, value);
+  SQLWCHAR value[kOdbcBufferSize] = {};
+  GetInfoSQLWCHAR(this->conn, SQL_IDENTIFIER_QUOTE_CHAR, value);
 
-  EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"\""), value);
+  std::wstring result = ConvertToWString(value);
+  EXPECT_EQ(std::wstring(L"\""), result);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoIndexKeywords) {
@@ -810,26 +837,28 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoInsertStatement) {
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoIntegrity) {
-  SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_INTEGRITY, value);
+  SQLWCHAR value[kOdbcBufferSize] = {};
+  GetInfoSQLWCHAR(this->conn, SQL_INTEGRITY, value);
 
-  EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"N"), value);
+  std::wstring result = ConvertToWString(value);
+  EXPECT_EQ(std::wstring(L"N"), result);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoKeywords) {
   // Keyword strings can require 10000 buffer length
   static constexpr int info_len = kOdbcBufferSize * 10;
-  SQLWCHAR value[info_len] = L"";
-  GetInfo(this->conn, SQL_KEYWORDS, value, info_len);
+  SQLWCHAR value[info_len] = {};
+  GetInfoSQLWCHAR(this->conn, SQL_KEYWORDS, value, info_len);
 
-  EXPECT_GT(wcslen(value), 0);
+  EXPECT_GT(wcslen(reinterpret_cast<wchar_t*>(value)), 0);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoLikeEscapeClause) {
-  SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_LIKE_ESCAPE_CLAUSE, value);
+  SQLWCHAR value[kOdbcBufferSize] = {};
+  GetInfoSQLWCHAR(this->conn, SQL_LIKE_ESCAPE_CLAUSE, value);
 
-  EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"Y"), value);
+  std::wstring result = ConvertToWString(value);
+  EXPECT_EQ(std::wstring(L"Y"), result);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoNonNullableColumns) {
@@ -847,24 +876,27 @@ TEST_F(ConnectionInfoMockTest, TestSQLGetInfoOjCapabilities) {
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoOrderByColumnsInSelect) {
-  SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_ORDER_BY_COLUMNS_IN_SELECT, value);
+  SQLWCHAR value[kOdbcBufferSize] = {};
+  GetInfoSQLWCHAR(this->conn, SQL_ORDER_BY_COLUMNS_IN_SELECT, value);
 
-  EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"Y"), value);
+  std::wstring result = ConvertToWString(value);
+  EXPECT_EQ(std::wstring(L"Y"), result);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoOuterJoins) {
-  SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_OUTER_JOINS, value);
+  SQLWCHAR value[kOdbcBufferSize] = {};
+  GetInfoSQLWCHAR(this->conn, SQL_OUTER_JOINS, value);
 
-  EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"N"), value);
+  std::wstring result = ConvertToWString(value);
+  EXPECT_EQ(std::wstring(L"N"), result);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoProcedures) {
-  SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_PROCEDURES, value);
+  SQLWCHAR value[kOdbcBufferSize] = {};
+  GetInfoSQLWCHAR(this->conn, SQL_PROCEDURES, value);
 
-  EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"N"), value);
+  std::wstring result = ConvertToWString(value);
+  EXPECT_EQ(std::wstring(L"N"), result);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoQuotedIdentifierCase) {
@@ -882,10 +914,11 @@ TEST_F(ConnectionInfoMockTest, TestSQLGetInfoSchemaUsage) {
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoSpecialCharacters) {
-  SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_SPECIAL_CHARACTERS, value);
+  SQLWCHAR value[kOdbcBufferSize] = {};
+  GetInfoSQLWCHAR(this->conn, SQL_SPECIAL_CHARACTERS, value);
 
-  EXPECT_STREQ(static_cast<const SQLWCHAR*>(L""), value);
+  std::wstring result = ConvertToWString(value);
+  EXPECT_EQ(std::wstring(L""), result);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoSqlConformance) {
@@ -1005,17 +1038,19 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoMaxProcedureNameLen) {
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoMaxRowSize) {
-  SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_MAX_ROW_SIZE, value);
+  SQLWCHAR value[kOdbcBufferSize] = {};
+  GetInfoSQLWCHAR(this->conn, SQL_MAX_ROW_SIZE, value);
 
-  EXPECT_STREQ(static_cast<const SQLWCHAR*>(L""), value);
+  std::wstring result = ConvertToWString(value);
+  EXPECT_EQ(std::wstring(L""), result);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoMaxRowSizeIncludesLong) {
-  SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(this->conn, SQL_MAX_ROW_SIZE_INCLUDES_LONG, value);
+  SQLWCHAR value[kOdbcBufferSize] = {};
+  GetInfoSQLWCHAR(this->conn, SQL_MAX_ROW_SIZE_INCLUDES_LONG, value);
 
-  EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"N"), value);
+  std::wstring result = ConvertToWString(value);
+  EXPECT_EQ(std::wstring(L"N"), result);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoMaxSchemaNameLen) {

--- a/cpp/src/arrow/flight/sql/odbc/tests/connection_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/connection_test.cc
@@ -224,7 +224,7 @@ TYPED_TEST(ConnectionHandleTest, TestSQLDriverConnect) {
                        arrow::util::UTF8ToWideString(connect_str));
   std::vector<SQLWCHAR> connect_str0(wconnect_str.begin(), wconnect_str.end());
 
-  SQLWCHAR out_str[kOdbcBufferSize] = L"";
+  SQLWCHAR out_str[kOdbcBufferSize] = {};
   SQLSMALLINT out_str_len;
 
   // Connecting to ODBC server.
@@ -266,7 +266,7 @@ TYPED_TEST(ConnectionHandleTest, TestSQLDriverConnectDsn) {
                        arrow::util::UTF8ToWideString(connect_str));
   std::vector<SQLWCHAR> connect_str0(wconnect_str.begin(), wconnect_str.end());
 
-  SQLWCHAR out_str[kOdbcBufferSize] = L"";
+  SQLWCHAR out_str[kOdbcBufferSize] = {};
   SQLSMALLINT out_str_len;
 
   // Connecting to ODBC server.
@@ -484,7 +484,7 @@ TYPED_TEST(ConnectionHandleTest, TestCloseConnectionWithOpenStatement) {
                        arrow::util::UTF8ToWideString(connect_str));
   std::vector<SQLWCHAR> connect_str0(wconnect_str.begin(), wconnect_str.end());
 
-  SQLWCHAR out_str[kOdbcBufferSize] = L"";
+  SQLWCHAR out_str[kOdbcBufferSize] = {};
   SQLSMALLINT out_str_len;
 
   // Connecting to ODBC server.

--- a/cpp/src/arrow/flight/sql/odbc/tests/errors_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/errors_test.cc
@@ -253,7 +253,8 @@ TYPED_TEST(ErrorsTest, TestSQLGetDiagRecForDescriptorFailureFromDriverManager) {
   // API not implemented error from driver manager
   EXPECT_EQ(kErrorStateIM001, SqlWcharToString(sql_state));
 
-  EXPECT_FALSE(std::wstring(message).empty());
+  std::string msg = SqlWcharToString(message);
+  EXPECT_FALSE(msg.empty());
 
   // Free descriptor handle
   EXPECT_EQ(SQL_SUCCESS, SQLFreeHandle(SQL_HANDLE_DESC, descriptor));
@@ -291,7 +292,8 @@ TYPED_TEST(ErrorsHandleTest, TestSQLGetDiagRecForConnectFailure) {
 
   EXPECT_EQ(kErrorState28000, SqlWcharToString(sql_state));
 
-  EXPECT_FALSE(std::wstring(message).empty());
+  std::string msg = SqlWcharToString(message);
+  EXPECT_FALSE(msg.empty());
 }
 
 TYPED_TEST(ErrorsTest, TestSQLGetDiagRecInputData) {
@@ -370,7 +372,8 @@ TYPED_TEST(ErrorsTest, TestSQLErrorEnvErrorFromDriverManager) {
   // Function sequence error state from driver manager
   EXPECT_EQ(kErrorStateHY010, SqlWcharToString(sql_state));
 
-  EXPECT_FALSE(std::wstring(message).empty());
+  std::string msg = SqlWcharToString(message);
+  EXPECT_FALSE(msg.empty());
 }
 
 TYPED_TEST(ErrorsTest, TestSQLErrorConnError) {
@@ -397,7 +400,8 @@ TYPED_TEST(ErrorsTest, TestSQLErrorConnError) {
   // optional feature not supported error state
   EXPECT_EQ(kErrorStateHYC00, SqlWcharToString(sql_state));
 
-  EXPECT_FALSE(std::wstring(message).empty());
+  std::string msg = SqlWcharToString(message);
+  EXPECT_FALSE(msg.empty());
 }
 
 TYPED_TEST(ErrorsTest, TestSQLErrorStmtError) {
@@ -406,8 +410,7 @@ TYPED_TEST(ErrorsTest, TestSQLErrorStmtError) {
   // When application passes buffer length greater than SQL_MAX_MESSAGE_LENGTH (512),
   // DM passes 512 as buffer length to SQLError.
 
-  SQLWCHAR wsql[] = L"1";
-  SQLINTEGER wsql_len = std::wcslen(wsql);
+  ASSIGN_SQLWCHAR_ARR_AND_LEN(wsql, L"1");
 
   ASSERT_EQ(SQL_ERROR, SQLExecDirect(this->stmt, wsql, wsql_len));
 
@@ -426,14 +429,14 @@ TYPED_TEST(ErrorsTest, TestSQLErrorStmtError) {
 
   EXPECT_EQ(kErrorStateHY000, SqlWcharToString(sql_state));
 
-  EXPECT_FALSE(std::wstring(message).empty());
+  std::string msg = SqlWcharToString(message);
+  EXPECT_FALSE(msg.empty());
 }
 
 TYPED_TEST(ErrorsTest, TestSQLErrorStmtWarning) {
   // Test ODBC 2.0 API SQLError.
 
-  SQLWCHAR wsql[] = L"SELECT 'VERY LONG STRING here' AS string_col;";
-  SQLINTEGER wsql_len = std::wcslen(wsql);
+  ASSIGN_SQLWCHAR_ARR_AND_LEN(wsql, L"SELECT 'VERY LONG STRING here' AS string_col;");
 
   ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
@@ -462,7 +465,8 @@ TYPED_TEST(ErrorsTest, TestSQLErrorStmtWarning) {
   // Verify string truncation warning is reported
   EXPECT_EQ(kErrorState01004, SqlWcharToString(sql_state));
 
-  EXPECT_FALSE(std::wstring(message).empty());
+  std::string msg = SqlWcharToString(message);
+  EXPECT_FALSE(msg.empty());
 }
 
 TYPED_TEST(ErrorsOdbcV2Test, TestSQLErrorEnvErrorFromDriverManager) {
@@ -495,7 +499,8 @@ TYPED_TEST(ErrorsOdbcV2Test, TestSQLErrorEnvErrorFromDriverManager) {
   EXPECT_EQ(kErrorStateHY010, SqlWcharToString(sql_state));
 #endif  // _WIN32
 
-  EXPECT_FALSE(std::wstring(message).empty());
+  std::string msg = SqlWcharToString(message);
+  EXPECT_FALSE(msg.empty());
 }
 
 #ifndef __APPLE__
@@ -528,7 +533,8 @@ TYPED_TEST(ErrorsOdbcV2Test, TestSQLErrorConnError) {
   // optional feature not supported error state. Driver Manager maps state to S1C00
   EXPECT_EQ(kErrorStateS1C00, SqlWcharToString(sql_state));
 
-  EXPECT_FALSE(std::wstring(message).empty());
+  std::string msg = SqlWcharToString(message);
+  EXPECT_FALSE(msg.empty());
 }
 #endif  // __APPLE__
 
@@ -538,8 +544,7 @@ TYPED_TEST(ErrorsOdbcV2Test, TestSQLErrorStmtError) {
   // When application passes buffer length greater than SQL_MAX_MESSAGE_LENGTH (512),
   // DM passes 512 as buffer length to SQLError.
 
-  SQLWCHAR wsql[] = L"SELECT * from non_existent_table;";
-  SQLINTEGER wsql_len = std::wcslen(wsql);
+  ASSIGN_SQLWCHAR_ARR_AND_LEN(wsql, L"SELECT * from non_existent_table;");
 
   ASSERT_EQ(SQL_ERROR, SQLExecDirect(this->stmt, wsql, wsql_len));
 
@@ -557,14 +562,14 @@ TYPED_TEST(ErrorsOdbcV2Test, TestSQLErrorStmtError) {
   // Driver Manager maps error state to S1000
   EXPECT_EQ(kErrorStateS1000, SqlWcharToString(sql_state));
 
-  EXPECT_FALSE(std::wstring(message).empty());
+  std::string msg = SqlWcharToString(message);
+  EXPECT_FALSE(msg.empty());
 }
 
 TYPED_TEST(ErrorsOdbcV2Test, TestSQLErrorStmtWarning) {
   // Test ODBC 2.0 API SQLError.
 
-  SQLWCHAR wsql[] = L"SELECT 'VERY LONG STRING here' AS string_col;";
-  SQLINTEGER wsql_len = std::wcslen(wsql);
+  ASSIGN_SQLWCHAR_ARR_AND_LEN(wsql, L"SELECT 'VERY LONG STRING here' AS string_col;");
 
   ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
@@ -593,7 +598,8 @@ TYPED_TEST(ErrorsOdbcV2Test, TestSQLErrorStmtWarning) {
   // Verify string truncation warning is reported
   EXPECT_EQ(kErrorState01004, SqlWcharToString(sql_state));
 
-  EXPECT_FALSE(std::wstring(message).empty());
+  std::string msg = SqlWcharToString(message);
+  EXPECT_FALSE(msg.empty());
 }
 
 }  // namespace arrow::flight::sql::odbc

--- a/cpp/src/arrow/flight/sql/odbc/tests/odbc_test_suite.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/odbc_test_suite.cc
@@ -539,7 +539,7 @@ bool WriteDSN(Connection::ConnPropertyMap properties) {
   }
 
   std::string driver = config.Get(FlightSqlConnection::DRIVER);
-  std::wstring w_driver = arrow::util::UTF8ToWideString(driver).ValueOr(L"");
+  CONVERT_SQLWCHAR_STR(w_driver, driver);
   return RegisterDsn(config, reinterpret_cast<LPCWSTR>(w_driver.c_str()));
 }
 
@@ -570,7 +570,8 @@ size_t SqlWCharArrLen(const SQLWCHAR* str_val) {
   return static_cast<size_t>(p - str_val);
 }
 
-std::wstring ConvertToWString(const SQLWCHAR* str_val, SQLSMALLINT str_len) {
+std::wstring ConvertToWString(const SQLWCHAR* str_val, SQLSMALLINT str_len,
+                              SQLSMALLINT buffer_size) {
   if (str_len == -1) {
 #ifdef __linux__
     str_len = SqlWCharArrLen(str_val);
@@ -583,19 +584,20 @@ std::wstring ConvertToWString(const SQLWCHAR* str_val, SQLSMALLINT str_len) {
     attr_str = L"";
   } else {
     assert(str_val != nullptr);
-    assert(str_len > 0 && str_len <= static_cast<SQLSMALLINT>(kOdbcBufferSize));
+    assert(str_len > 0 && str_len <= buffer_size);
     attr_str.assign(str_val, str_val + str_len);
   }
   return attr_str;
 }
 
-std::wstring ConvertToWString(const std::vector<SQLWCHAR>& str_val, SQLSMALLINT str_len) {
+std::wstring ConvertToWString(const std::vector<SQLWCHAR>& str_val, SQLSMALLINT str_len,
+                              SQLSMALLINT buffer_size) {
   std::wstring attr_str;
   if (str_len == 0) {
     attr_str = L"";
   } else {
     EXPECT_GT(str_len, 0);
-    EXPECT_LE(str_len, static_cast<SQLSMALLINT>(kOdbcBufferSize));
+    EXPECT_LE(str_len, buffer_size);
     attr_str =
         std::wstring(str_val.begin(), str_val.begin() + str_len / GetSqlWCharSize());
   }

--- a/cpp/src/arrow/flight/sql/odbc/tests/odbc_test_suite.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/odbc_test_suite.cc
@@ -540,7 +540,7 @@ bool WriteDSN(Connection::ConnPropertyMap properties) {
 
   std::string driver = config.Get(FlightSqlConnection::DRIVER);
   std::wstring w_driver = arrow::util::UTF8ToWideString(driver).ValueOr(L"");
-  return RegisterDsn(config, w_driver.c_str());
+  return RegisterDsn(config, reinterpret_cast<LPCWSTR>(w_driver.c_str()));
 }
 
 std::wstring GetStringColumnW(SQLHSTMT stmt, int col_id) {
@@ -559,10 +559,40 @@ std::wstring GetStringColumnW(SQLHSTMT stmt, int col_id) {
   return std::wstring(buf, buf + char_count);
 }
 
+size_t SqlWCharArrLen(const SQLWCHAR* str_val) {
+  if (!str_val) {
+    return 0;
+  }
+  const SQLWCHAR* p = str_val;
+  while (*p != 0) {
+    ++p;
+  }
+  return static_cast<size_t>(p - str_val);
+}
+
+std::wstring ConvertToWString(const SQLWCHAR* str_val, SQLSMALLINT str_len) {
+  if (str_len == -1) {
+#ifdef __linux__
+    str_len = SqlWCharArrLen(str_val);
+#else  // Windows & Mac
+    str_len = std::wcslen(str_val);
+#endif
+  }
+  std::wstring attr_str;
+  if (str_len == 0) {
+    attr_str = L"";
+  } else {
+    assert(str_val != nullptr);
+    assert(str_len > 0 && str_len <= static_cast<SQLSMALLINT>(kOdbcBufferSize));
+    attr_str.assign(str_val, str_val + str_len);
+  }
+  return attr_str;
+}
+
 std::wstring ConvertToWString(const std::vector<SQLWCHAR>& str_val, SQLSMALLINT str_len) {
   std::wstring attr_str;
   if (str_len == 0) {
-    attr_str = std::wstring(&str_val[0]);
+    attr_str = L"";
   } else {
     EXPECT_GT(str_len, 0);
     EXPECT_LE(str_len, static_cast<SQLSMALLINT>(kOdbcBufferSize));

--- a/cpp/src/arrow/flight/sql/odbc/tests/odbc_test_suite.h
+++ b/cpp/src/arrow/flight/sql/odbc/tests/odbc_test_suite.h
@@ -38,6 +38,20 @@
 // For DSN registration
 #include "arrow/flight/sql/odbc/odbc_impl/system_dsn.h"
 
+#ifdef __linux__
+#  define ASSIGN_SQLWCHAR_ARR(name, wstring_literal)                         \
+    auto name##_vec = ODBC::ToSqlWCharVector(std::wstring(wstring_literal)); \
+    SQLWCHAR* name = name##_vec.data();
+#  define ASSIGN_SQLWCHAR_ARR_AND_LEN(name, wstring_literal) \
+    ASSIGN_SQLWCHAR_ARR(name, wstring_literal)               \
+    size_t name##_len = std::wstring(wstring_literal).length();
+#else  // Windows & Mac
+#  define ASSIGN_SQLWCHAR_ARR(name, wstring_literal) SQLWCHAR name[] = wstring_literal;
+#  define ASSIGN_SQLWCHAR_ARR_AND_LEN(name, wstring_literal) \
+    ASSIGN_SQLWCHAR_ARR(name, wstring_literal)               \
+    size_t name##_len = std::wcslen(name);
+#endif
+
 static constexpr std::string_view kTestConnectStr = "ARROW_FLIGHT_SQL_ODBC_CONN";
 static constexpr std::string_view kTestDsn = "Apache Arrow Flight SQL Test DSN";
 
@@ -277,6 +291,17 @@ bool WriteDSN(Connection::ConnPropertyMap properties);
 /// \param[in] col_id Column ID to check.
 /// \return wstring
 std::wstring GetStringColumnW(SQLHSTMT stmt, int col_id);
+
+/// \brief Get length of wide char array.
+/// \param[in] str_val Array of SQLWCHAR.
+/// \return number of wide characters in array
+size_t SqlWCharArrLen(const SQLWCHAR* str_val);
+
+/// \brief Check wide char array and convert into wstring
+/// \param[in] str_val Array of SQLWCHAR.
+/// \param[in] str_len length of string, in number of characters.
+/// \return wstring
+std::wstring ConvertToWString(const SQLWCHAR* str_val, SQLSMALLINT str_len = -1);
 
 /// \brief Check wide char vector and convert into wstring
 /// \param[in] str_val Vector of SQLWCHAR.

--- a/cpp/src/arrow/flight/sql/odbc/tests/odbc_test_suite.h
+++ b/cpp/src/arrow/flight/sql/odbc/tests/odbc_test_suite.h
@@ -39,17 +39,20 @@
 #include "arrow/flight/sql/odbc/odbc_impl/system_dsn.h"
 
 #ifdef __linux__
-#  define ASSIGN_SQLWCHAR_ARR(name, wstring_literal)                         \
-    auto name##_vec = ODBC::ToSqlWCharVector(std::wstring(wstring_literal)); \
+#  define ASSIGN_SQLWCHAR_ARR(name, wstring_literal)                           \
+    auto name##_vec = ODBC::ToSqlWCharVector(std::wstring(wstring_literal));   \
+    if (name##_vec.empty() || name##_vec.back() != static_cast<SQLWCHAR>(0)) { \
+      name##_vec.push_back(static_cast<SQLWCHAR>(0));                          \
+    }                                                                          \
     SQLWCHAR* name = name##_vec.data();
 #  define ASSIGN_SQLWCHAR_ARR_AND_LEN(name, wstring_literal) \
     ASSIGN_SQLWCHAR_ARR(name, wstring_literal)               \
-    size_t name##_len = std::wstring(wstring_literal).length();
+    SQLSMALLINT name##_len = static_cast<SQLSMALLINT>(name##_vec.size() - 1);
 #else  // Windows & Mac
 #  define ASSIGN_SQLWCHAR_ARR(name, wstring_literal) SQLWCHAR name[] = wstring_literal;
 #  define ASSIGN_SQLWCHAR_ARR_AND_LEN(name, wstring_literal) \
     ASSIGN_SQLWCHAR_ARR(name, wstring_literal)               \
-    size_t name##_len = std::wcslen(name);
+    SQLSMALLINT name##_len = static_cast<SQLSMALLINT>(std::wcslen(name));
 #endif
 
 static constexpr std::string_view kTestConnectStr = "ARROW_FLIGHT_SQL_ODBC_CONN";
@@ -300,14 +303,18 @@ size_t SqlWCharArrLen(const SQLWCHAR* str_val);
 /// \brief Check wide char array and convert into wstring
 /// \param[in] str_val Array of SQLWCHAR.
 /// \param[in] str_len length of string, in number of characters.
+/// \param[in] buffer_size size of underlying buffer, in number of characters.
 /// \return wstring
-std::wstring ConvertToWString(const SQLWCHAR* str_val, SQLSMALLINT str_len = -1);
+std::wstring ConvertToWString(const SQLWCHAR* str_val, SQLSMALLINT str_len = -1,
+                              SQLSMALLINT buffer_size = kOdbcBufferSize);
 
 /// \brief Check wide char vector and convert into wstring
 /// \param[in] str_val Vector of SQLWCHAR.
 /// \param[in] str_len length of string, in bytes.
+/// \param[in] buffer_size size of underlying buffer, in number of characters.
 /// \return wstring
-std::wstring ConvertToWString(const std::vector<SQLWCHAR>& str_val, SQLSMALLINT str_len);
+std::wstring ConvertToWString(const std::vector<SQLWCHAR>& str_val, SQLSMALLINT str_len,
+                              SQLSMALLINT buffer_size = kOdbcBufferSize);
 
 /// \brief Check wide string column.
 /// \param[in] stmt Statement.

--- a/cpp/src/arrow/flight/sql/odbc/tests/statement_attr_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/statement_attr_test.cc
@@ -334,8 +334,7 @@ TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrRowBindType) {
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrRowNumber) {
-  SQLWCHAR wsql[] = L"SELECT 1;";
-  SQLINTEGER wsql_len = std::wcslen(wsql);
+  ASSIGN_SQLWCHAR_ARR_AND_LEN(wsql, L"SELECT 1;");
 
   ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 

--- a/cpp/src/arrow/flight/sql/odbc/tests/statement_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/statement_test.cc
@@ -38,8 +38,7 @@ using TestTypes = ::testing::Types<StatementMockTest, StatementRemoteTest>;
 TYPED_TEST_SUITE(StatementTest, TestTypes);
 
 TYPED_TEST(StatementTest, TestSQLExecDirectSimpleQuery) {
-  SQLWCHAR wsql[] = L"SELECT 1;";
-  SQLINTEGER wsql_len = std::wcslen(wsql);
+  ASSIGN_SQLWCHAR_ARR_AND_LEN(wsql, L"SELECT 1;");
 
   ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
@@ -65,8 +64,7 @@ TYPED_TEST(StatementTest, TestSQLExecDirectSimpleQuery) {
 }
 
 TYPED_TEST(StatementTest, TestSQLExecDirectInvalidQuery) {
-  SQLWCHAR wsql[] = L"SELECT;";
-  SQLINTEGER wsql_len = std::wcslen(wsql);
+  ASSIGN_SQLWCHAR_ARR_AND_LEN(wsql, L"SELECT;");
 
   ASSERT_EQ(SQL_ERROR, SQLExecDirect(this->stmt, wsql, wsql_len));
   // ODBC provides generic error code HY000 to all statement errors
@@ -74,8 +72,7 @@ TYPED_TEST(StatementTest, TestSQLExecDirectInvalidQuery) {
 }
 
 TYPED_TEST(StatementTest, TestSQLExecuteSimpleQuery) {
-  SQLWCHAR wsql[] = L"SELECT 1;";
-  SQLINTEGER wsql_len = std::wcslen(wsql);
+  ASSIGN_SQLWCHAR_ARR_AND_LEN(wsql, L"SELECT 1;");
 
   ASSERT_EQ(SQL_SUCCESS, SQLPrepare(this->stmt, wsql, wsql_len));
 
@@ -104,8 +101,7 @@ TYPED_TEST(StatementTest, TestSQLExecuteSimpleQuery) {
 }
 
 TYPED_TEST(StatementTest, TestSQLPrepareInvalidQuery) {
-  SQLWCHAR wsql[] = L"SELECT;";
-  SQLINTEGER wsql_len = std::wcslen(wsql);
+  ASSIGN_SQLWCHAR_ARR_AND_LEN(wsql, L"SELECT;");
 
   ASSERT_EQ(SQL_ERROR, SQLPrepare(this->stmt, wsql, wsql_len));
   // ODBC provides generic error code HY000 to all statement errors
@@ -360,12 +356,11 @@ TEST_F(StatementRemoteTest, TestSQLExecDirectTimeQuery) {
   // Mock server test is skipped due to limitation on the mock server.
   // Time type from mock server does not include the fraction
 
-  SQLWCHAR wsql[] =
-      LR"(
+  ASSIGN_SQLWCHAR_ARR_AND_LEN(wsql,
+                              LR"(
     SELECT CAST(TIME '00:00:00' AS TIME) AS time_min,
            CAST(TIME '23:59:59' AS TIME) AS time_max;
-    )";
-  SQLSMALLINT wsql_len = std::wcslen(wsql);
+    )");
 
   ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
@@ -394,8 +389,7 @@ TEST_F(StatementMockTest, TestSQLExecDirectVarbinaryQuery) {
   // Have binary test on mock test base as remote test servers tend to have different
   // formats for binary data
 
-  SQLWCHAR wsql[] = L"SELECT X'ABCDEF' AS c_varbinary;";
-  SQLSMALLINT wsql_len = std::wcslen(wsql);
+  ASSIGN_SQLWCHAR_ARR_AND_LEN(wsql, L"SELECT X'ABCDEF' AS c_varbinary;");
 
   ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
@@ -601,12 +595,11 @@ TEST_F(StatementRemoteTest, TestSQLExecDirectTimeQueryDefaultType) {
   // Mock server test is skipped due to limitation on the mock server.
   // Time type from mock server does not include the fraction
 
-  SQLWCHAR wsql[] =
-      LR"(
+  ASSIGN_SQLWCHAR_ARR_AND_LEN(wsql,
+                              LR"(
    SELECT CAST(TIME '00:00:00' AS TIME) AS time_min,
           CAST(TIME '23:59:59' AS TIME) AS time_max;
-   )";
-  SQLINTEGER wsql_len = std::wcslen(wsql);
+   )");
 
   ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
@@ -636,8 +629,7 @@ TEST_F(StatementRemoteTest, TestSQLExecDirectVarbinaryQueryDefaultType) {
   // Mock server has type `DENSE_UNION` for varbinary.
   // Note that not all remote servers support "from_hex" function
 
-  SQLWCHAR wsql[] = L"SELECT from_hex('ABCDEF') AS c_varbinary;";
-  SQLINTEGER wsql_len = std::wcslen(wsql);
+  ASSIGN_SQLWCHAR_ARR_AND_LEN(wsql, L"SELECT from_hex('ABCDEF') AS c_varbinary;");
 
   ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
@@ -657,8 +649,7 @@ TEST_F(StatementRemoteTest, TestSQLExecDirectVarbinaryQueryDefaultType) {
 // TODO(GH-48730): Enable this test when ARD/IRD descriptor support is fully implemented
 TYPED_TEST(StatementTest, DISABLED_TestGetDataPrecisionScaleUsesIRDAsDefault) {
   // Verify that SQLGetData uses IRD precision/scale as defaults when ARD values are unset
-  SQLWCHAR wsql[] = L"SELECT CAST('123.45' AS NUMERIC) as decimal_col;";
-  SQLINTEGER wsql_len = std::wcslen(wsql);
+  ASSIGN_SQLWCHAR_ARR_AND_LEN(wsql, L"SELECT CAST('123.45' AS NUMERIC) as decimal_col;");
 
   ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
@@ -704,8 +695,7 @@ TYPED_TEST(StatementTest, DISABLED_TestGetDataPrecisionScaleUsesIRDAsDefault) {
 TYPED_TEST(StatementTest, DISABLED_TestGetDataPrecisionScaleUsesARDWhenSet) {
   // Verify that SQLGetData uses ARD precision/scale when set, for both SQL_ARD_TYPE and
   // SQL_C_DEFAULT
-  SQLWCHAR wsql[] = L"SELECT CAST('123.45' AS NUMERIC) as decimal_col;";
-  SQLINTEGER wsql_len = std::wcslen(wsql);
+  ASSIGN_SQLWCHAR_ARR_AND_LEN(wsql, L"SELECT CAST('123.45' AS NUMERIC) as decimal_col;");
 
   ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
@@ -750,8 +740,8 @@ TYPED_TEST(StatementTest, DISABLED_TestGetDataPrecisionScaleUsesARDWhenSet) {
 
 TYPED_TEST(StatementTest, TestSQLExecDirectGuidQueryUnsupported) {
   // Query GUID as string as SQLite does not support GUID
-  SQLWCHAR wsql[] = L"SELECT 'C77313CF-4E08-47CE-B6DF-94DD2FCF3541' AS guid;";
-  SQLINTEGER wsql_len = std::wcslen(wsql);
+  ASSIGN_SQLWCHAR_ARR_AND_LEN(wsql,
+                              L"SELECT 'C77313CF-4E08-47CE-B6DF-94DD2FCF3541' AS guid;");
 
   ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
@@ -766,15 +756,14 @@ TYPED_TEST(StatementTest, TestSQLExecDirectGuidQueryUnsupported) {
 }
 
 TYPED_TEST(StatementTest, TestSQLExecDirectRowFetching) {
-  SQLWCHAR wsql[] =
-      LR"(
+  ASSIGN_SQLWCHAR_ARR_AND_LEN(wsql,
+                              LR"(
    SELECT 1 AS small_table
    UNION ALL
    SELECT 2
    UNION ALL
    SELECT 3;
- )";
-  SQLINTEGER wsql_len = std::wcslen(wsql);
+ )");
 
   ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
@@ -824,15 +813,14 @@ TYPED_TEST(StatementTest, TestSQLFetchScrollRowFetching) {
   SQLLEN rows_fetched;
   SQLSetStmtAttr(this->stmt, SQL_ATTR_ROWS_FETCHED_PTR, &rows_fetched, 0);
 
-  SQLWCHAR wsql[] =
-      LR"(
+  ASSIGN_SQLWCHAR_ARR_AND_LEN(wsql,
+                              LR"(
    SELECT 1 AS small_table
    UNION ALL
    SELECT 2
    UNION ALL
    SELECT 3;
- )";
-  SQLINTEGER wsql_len = std::wcslen(wsql);
+ )");
 
   ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
@@ -886,8 +874,7 @@ TYPED_TEST(StatementTest, TestSQLFetchScrollRowFetching) {
 TYPED_TEST(StatementTest, TestSQLFetchScrollUnsupportedOrientation) {
   // SQL_FETCH_NEXT is the only supported fetch orientation.
 
-  SQLWCHAR wsql[] = L"SELECT 1;";
-  SQLINTEGER wsql_len = std::wcslen(wsql);
+  ASSIGN_SQLWCHAR_ARR_AND_LEN(wsql, L"SELECT 1;");
 
   ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
@@ -923,8 +910,7 @@ TYPED_TEST(StatementTest, TestSQLFetchScrollUnsupportedOrientation) {
 }
 
 TYPED_TEST(StatementTest, TestSQLExecDirectVarcharTruncation) {
-  SQLWCHAR wsql[] = L"SELECT 'VERY LONG STRING here' AS string_col;";
-  SQLINTEGER wsql_len = std::wcslen(wsql);
+  ASSIGN_SQLWCHAR_ARR_AND_LEN(wsql, L"SELECT 'VERY LONG STRING here' AS string_col;");
 
   ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
@@ -973,8 +959,8 @@ TYPED_TEST(StatementTest, TestSQLExecDirectVarcharTruncation) {
 }
 
 TYPED_TEST(StatementTest, TestSQLExecDirectWVarcharTruncation) {
-  SQLWCHAR wsql[] = L"SELECT 'VERY LONG Unicode STRING 句子 here' AS wstring_col;";
-  SQLINTEGER wsql_len = std::wcslen(wsql);
+  ASSIGN_SQLWCHAR_ARR_AND_LEN(
+      wsql, L"SELECT 'VERY LONG Unicode STRING 句子 here' AS wstring_col;");
 
   ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
@@ -990,7 +976,8 @@ TYPED_TEST(StatementTest, TestSQLExecDirectWVarcharTruncation) {
   // Verify string truncation is reported
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorState01004);
 
-  EXPECT_EQ(std::wstring(L"VERY LONG Unicode STRING 句子"), std::wstring(wchar_val));
+  std::wstring wchar_result = ConvertToWString(wchar_val);
+  EXPECT_EQ(std::wstring(L"VERY LONG Unicode STRING 句子"), wchar_result);
   EXPECT_EQ(32 * wchar_size, ind);
 
   // Fetch same column 2nd time
@@ -1002,7 +989,8 @@ TYPED_TEST(StatementTest, TestSQLExecDirectWVarcharTruncation) {
   // Verify string truncation is reported
   VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorState01004);
 
-  EXPECT_EQ(std::wstring(L" "), std::wstring(wchar_val2));
+  wchar_result = ConvertToWString(wchar_val2);
+  EXPECT_EQ(std::wstring(L" "), wchar_result);
   EXPECT_EQ(5 * wchar_size, ind);
 
   // Fetch same column 3rd time
@@ -1014,7 +1002,8 @@ TYPED_TEST(StatementTest, TestSQLExecDirectWVarcharTruncation) {
   ASSERT_EQ(SQL_SUCCESS,
             SQLGetData(this->stmt, 1, SQL_C_WCHAR, &wchar_val3, buf_len, &ind));
 
-  EXPECT_EQ(std::wstring(L"here"), std::wstring(wchar_val3));
+  wchar_result = ConvertToWString(wchar_val3);
+  EXPECT_EQ(std::wstring(L"here"), wchar_result);
   EXPECT_EQ(4 * wchar_size, ind);
 
   // Attempt to fetch data 4th time
@@ -1027,8 +1016,7 @@ TEST_F(StatementMockTest, TestSQLExecDirectVarbinaryTruncation) {
   // Have binary test on mock test base as remote test servers tend to have different
   // formats for binary data
 
-  SQLWCHAR wsql[] = L"SELECT X'ABCDEFAB' AS c_varbinary;";
-  SQLINTEGER wsql_len = std::wcslen(wsql);
+  ASSIGN_SQLWCHAR_ARR_AND_LEN(wsql, L"SELECT X'ABCDEFAB' AS c_varbinary;");
 
   ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
@@ -1096,8 +1084,7 @@ TEST_F(StatementRemoteTest, TestSQLExecDirectNullQuery) {
   // Limitation on mock test server prevents null from working properly, so use remote
   // server instead. Mock server has type `DENSE_UNION` for null column data.
 
-  SQLWCHAR wsql[] = L"SELECT null as null_col;";
-  SQLINTEGER wsql_len = std::wcslen(wsql);
+  ASSIGN_SQLWCHAR_ARR_AND_LEN(wsql, L"SELECT null as null_col;");
 
   ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
@@ -1117,14 +1104,13 @@ TEST_F(StatementMockTest, TestSQLExecDirectTruncationQueryNullIndicator) {
   // Have binary test on mock test base as remote test servers tend to have different
   // formats for binary data
 
-  SQLWCHAR wsql[] =
-      LR"(
+  ASSIGN_SQLWCHAR_ARR_AND_LEN(wsql,
+                              LR"(
        SELECT 1,
        'VERY LONG STRING here' AS string_col,
        'VERY LONG Unicode STRING 句子 here' AS wstring_col,
        X'ABCDEFAB' AS c_varbinary;
- )";
-  SQLINTEGER wsql_len = std::wcslen(wsql);
+ )");
 
   ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
@@ -1167,8 +1153,7 @@ TEST_F(StatementRemoteTest, TestSQLExecDirectNullQueryNullIndicator) {
   // Limitation on mock test server prevents null from working properly, so use remote
   // server instead. Mock server has type `DENSE_UNION` for null column data.
 
-  SQLWCHAR wsql[] = L"SELECT null as null_col;";
-  SQLINTEGER wsql_len = std::wcslen(wsql);
+  ASSIGN_SQLWCHAR_ARR_AND_LEN(wsql, L"SELECT null as null_col;");
 
   ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
@@ -1674,12 +1659,11 @@ TEST_F(StatementRemoteTest, TestSQLBindColTimeQuery) {
   ASSERT_EQ(SQL_SUCCESS,
             SQLBindCol(this->stmt, 2, SQL_C_TYPE_TIME, &time_var_max, buf_len, &ind));
 
-  SQLWCHAR wsql[] =
-      LR"(
+  ASSIGN_SQLWCHAR_ARR_AND_LEN(wsql,
+                              LR"(
    SELECT CAST(TIME '00:00:00' AS TIME) AS time_min,
           CAST(TIME '23:59:59' AS TIME) AS time_max;
-   )";
-  SQLINTEGER wsql_len = std::wcslen(wsql);
+   )");
 
   ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
@@ -1707,8 +1691,7 @@ TEST_F(StatementMockTest, TestSQLBindColVarbinaryQuery) {
   ASSERT_EQ(SQL_SUCCESS,
             SQLBindCol(this->stmt, 1, SQL_C_BINARY, &varbinary_val[0], buf_len, &ind));
 
-  SQLWCHAR wsql[] = L"SELECT X'ABCDEF' AS c_varbinary;";
-  SQLINTEGER wsql_len = std::wcslen(wsql);
+  ASSIGN_SQLWCHAR_ARR_AND_LEN(wsql, L"SELECT X'ABCDEF' AS c_varbinary;");
 
   ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
@@ -1729,8 +1712,7 @@ TEST_F(StatementRemoteTest, TestSQLBindColNullQuery) {
 
   ASSERT_EQ(SQL_SUCCESS, SQLBindCol(this->stmt, 1, SQL_C_LONG, &val, 0, &ind));
 
-  SQLWCHAR wsql[] = L"SELECT null as null_col;";
-  SQLINTEGER wsql_len = std::wcslen(wsql);
+  ASSIGN_SQLWCHAR_ARR_AND_LEN(wsql, L"SELECT null as null_col;");
 
   ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
@@ -1748,8 +1730,7 @@ TEST_F(StatementRemoteTest, TestSQLBindColNullQueryNullIndicator) {
 
   ASSERT_EQ(SQL_SUCCESS, SQLBindCol(this->stmt, 1, SQL_C_LONG, &val, 0, 0));
 
-  SQLWCHAR wsql[] = L"SELECT null as null_col;";
-  SQLINTEGER wsql_len = std::wcslen(wsql);
+  ASSIGN_SQLWCHAR_ARR_AND_LEN(wsql, L"SELECT null as null_col;");
 
   ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
@@ -1767,15 +1748,14 @@ TYPED_TEST(StatementTest, TestSQLBindColRowFetching) {
   // should be updated after every SQLFetch call.
   ASSERT_EQ(SQL_SUCCESS, SQLBindCol(this->stmt, 1, SQL_C_LONG, &val, buf_len, &ind));
 
-  SQLWCHAR wsql[] =
-      LR"(
+  ASSIGN_SQLWCHAR_ARR_AND_LEN(wsql,
+                              LR"(
    SELECT 1 AS small_table
    UNION ALL
    SELECT 2
    UNION ALL
    SELECT 3;
- )";
-  SQLINTEGER wsql_len = std::wcslen(wsql);
+ )");
 
   ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
@@ -1817,15 +1797,14 @@ TYPED_TEST(StatementTest, TestSQLBindColRowArraySize) {
   ASSERT_EQ(SQL_SUCCESS,
             SQLSetStmtAttr(this->stmt, SQL_ATTR_ROWS_FETCHED_PTR, &rows_fetched, 0));
 
-  SQLWCHAR wsql[] =
-      LR"(
+  ASSIGN_SQLWCHAR_ARR_AND_LEN(wsql,
+                              LR"(
    SELECT 1 AS small_table
    UNION ALL
    SELECT 2
    UNION ALL
    SELECT 3;
- )";
-  SQLINTEGER wsql_len = std::wcslen(wsql);
+ )");
 
   ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
@@ -1936,15 +1915,14 @@ TYPED_TEST(StatementTest, TestSQLExtendedFetchRowFetching) {
   ASSERT_EQ(SQL_SUCCESS, SQLSetStmtAttr(this->stmt, SQL_ROWSET_SIZE,
                                         reinterpret_cast<SQLPOINTER>(rows), 0));
 
-  SQLWCHAR wsql[] =
-      LR"(
+  ASSIGN_SQLWCHAR_ARR_AND_LEN(wsql,
+                              LR"(
    SELECT 1 AS small_table
    UNION ALL
    SELECT 2
    UNION ALL
    SELECT 3;
- )";
-  SQLINTEGER wsql_len = std::wcslen(wsql);
+ )");
 
   ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
@@ -1956,7 +1934,7 @@ TYPED_TEST(StatementTest, TestSQLExtendedFetchRowFetching) {
             SQLExtendedFetch(this->stmt, SQL_FETCH_NEXT, 0, &row_count, row_status));
   EXPECT_EQ(3, row_count);
 
-  for (int i = 0; i < rows; i++) {
+  for (SQLULEN i = 0; i < rows; i++) {
     EXPECT_EQ(SQL_SUCCESS, row_status[i]);
   }
 
@@ -1982,8 +1960,7 @@ TEST_F(StatementRemoteTest, DISABLED_TestSQLExtendedFetchQueryNullIndicator) {
 
   ASSERT_EQ(SQL_SUCCESS, SQLBindCol(this->stmt, 1, SQL_C_LONG, &val, 0, nullptr));
 
-  SQLWCHAR wsql[] = L"SELECT null as null_col;";
-  SQLINTEGER wsql_len = std::wcslen(wsql);
+  ASSIGN_SQLWCHAR_ARR_AND_LEN(wsql, L"SELECT null as null_col;");
 
   ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
@@ -1999,8 +1976,7 @@ TEST_F(StatementRemoteTest, DISABLED_TestSQLExtendedFetchQueryNullIndicator) {
 TYPED_TEST(StatementTest, TestSQLMoreResultsNoData) {
   // Verify SQLMoreResults returns SQL_NO_DATA by default.
 
-  SQLWCHAR wsql[] = L"SELECT 1;";
-  SQLINTEGER wsql_len = std::wcslen(wsql);
+  ASSIGN_SQLWCHAR_ARR_AND_LEN(wsql, L"SELECT 1;");
 
   ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
@@ -2017,80 +1993,76 @@ TYPED_TEST(StatementTest, TestSQLMoreResultsInvalidFunctionSequence) {
 TYPED_TEST(StatementTest, TestSQLNativeSqlReturnsInputString) {
   SQLWCHAR buf[1024];
   SQLINTEGER buf_char_len = sizeof(buf) / GetSqlWCharSize();
-  SQLWCHAR input_str[] = L"SELECT * FROM mytable WHERE id == 1";
-  SQLINTEGER input_char_len = static_cast<SQLINTEGER>(wcslen(input_str));
+  ASSIGN_SQLWCHAR_ARR_AND_LEN(input_str, L"SELECT * FROM mytable WHERE id == 1");
   SQLINTEGER output_char_len = 0;
-  std::wstring expected_string = std::wstring(input_str);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLNativeSql(this->conn, input_str, input_char_len, buf,
+  ASSERT_EQ(SQL_SUCCESS, SQLNativeSql(this->conn, input_str, input_str_len, buf,
                                       buf_char_len, &output_char_len));
 
-  EXPECT_EQ(input_char_len, output_char_len);
+  EXPECT_EQ(input_str_len, output_char_len);
 
   // returned length is in characters
   std::wstring returned_string(buf, buf + output_char_len);
 
-  EXPECT_EQ(expected_string, returned_string);
+  std::wstring input = ConvertToWString(input_str, input_str_len);
+  EXPECT_EQ(input, returned_string);
 }
 
 TYPED_TEST(StatementTest, TestSQLNativeSqlReturnsNTSInputString) {
   SQLWCHAR buf[1024];
   SQLINTEGER buf_char_len = sizeof(buf) / GetSqlWCharSize();
-  SQLWCHAR input_str[] = L"SELECT * FROM mytable WHERE id == 1";
-  SQLINTEGER input_char_len = static_cast<SQLINTEGER>(wcslen(input_str));
+  ASSIGN_SQLWCHAR_ARR_AND_LEN(input_str, L"SELECT * FROM mytable WHERE id == 1");
   SQLINTEGER output_char_len = 0;
-  std::wstring expected_string = std::wstring(input_str);
 
   ASSERT_EQ(SQL_SUCCESS, SQLNativeSql(this->conn, input_str, SQL_NTS, buf, buf_char_len,
                                       &output_char_len));
 
-  EXPECT_EQ(input_char_len, output_char_len);
+  EXPECT_EQ(input_str_len, output_char_len);
 
   // returned length is in characters
   std::wstring returned_string(buf, buf + output_char_len);
 
+  std::wstring expected_string = ConvertToWString(input_str, input_str_len);
   EXPECT_EQ(expected_string, returned_string);
 }
 
 TYPED_TEST(StatementTest, TestSQLNativeSqlReturnsInputStringLength) {
-  SQLWCHAR input_str[] = L"SELECT * FROM mytable WHERE id == 1";
-  SQLINTEGER input_char_len = static_cast<SQLINTEGER>(wcslen(input_str));
+  ASSIGN_SQLWCHAR_ARR_AND_LEN(input_str, L"SELECT * FROM mytable WHERE id == 1");
   SQLINTEGER output_char_len = 0;
-  std::wstring expected_string = std::wstring(input_str);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLNativeSql(this->conn, input_str, input_char_len, nullptr, 0,
+  ASSERT_EQ(SQL_SUCCESS, SQLNativeSql(this->conn, input_str, input_str_len, nullptr, 0,
                                       &output_char_len));
 
-  EXPECT_EQ(input_char_len, output_char_len);
+  EXPECT_EQ(input_str_len, output_char_len);
 
   ASSERT_EQ(SQL_SUCCESS,
             SQLNativeSql(this->conn, input_str, SQL_NTS, nullptr, 0, &output_char_len));
 
-  EXPECT_EQ(input_char_len, output_char_len);
+  EXPECT_EQ(input_str_len, output_char_len);
 }
 
 TYPED_TEST(StatementTest, TestSQLNativeSqlReturnsTruncatedString) {
   const SQLINTEGER small_buf_size_in_char = 11;
   SQLWCHAR small_buf[small_buf_size_in_char];
   SQLINTEGER small_buf_char_len = sizeof(small_buf) / GetSqlWCharSize();
-  SQLWCHAR input_str[] = L"SELECT * FROM mytable WHERE id == 1";
-  SQLINTEGER input_char_len = static_cast<SQLINTEGER>(wcslen(input_str));
+  ASSIGN_SQLWCHAR_ARR_AND_LEN(input_str, L"SELECT * FROM mytable WHERE id == 1");
   SQLINTEGER output_char_len = 0;
 
   // Create expected return string based on buf size
   SQLWCHAR expected_string_buf[small_buf_size_in_char];
-  wcsncpy(expected_string_buf, input_str, 10);
+  wcsncpy(reinterpret_cast<wchar_t*>(expected_string_buf),
+          reinterpret_cast<const wchar_t*>(input_str), 10);
   expected_string_buf[10] = L'\0';
   std::wstring expected_string(expected_string_buf,
                                expected_string_buf + small_buf_size_in_char);
 
   ASSERT_EQ(SQL_SUCCESS_WITH_INFO,
-            SQLNativeSql(this->conn, input_str, input_char_len, small_buf,
+            SQLNativeSql(this->conn, input_str, input_str_len, small_buf,
                          small_buf_char_len, &output_char_len));
   VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorState01004);
 
   // Returned text length represents full string char length regardless of truncation
-  EXPECT_EQ(input_char_len, output_char_len);
+  EXPECT_EQ(input_str_len, output_char_len);
 
   std::wstring returned_string(small_buf, small_buf + small_buf_char_len);
 
@@ -2100,15 +2072,10 @@ TYPED_TEST(StatementTest, TestSQLNativeSqlReturnsTruncatedString) {
 TYPED_TEST(StatementTest, TestSQLNativeSqlReturnsErrorOnBadInputs) {
   SQLWCHAR buf[1024];
   SQLINTEGER buf_char_len = sizeof(buf) / GetSqlWCharSize();
-  SQLWCHAR input_str[] = L"SELECT * FROM mytable WHERE id == 1";
-  SQLINTEGER input_char_len = static_cast<SQLINTEGER>(wcslen(input_str));
+  ASSIGN_SQLWCHAR_ARR_AND_LEN(input_str, L"SELECT * FROM mytable WHERE id == 1");
   SQLINTEGER output_char_len = 0;
 
-  ASSERT_EQ(SQL_ERROR, SQLNativeSql(this->conn, nullptr, input_char_len, buf,
-                                    buf_char_len, &output_char_len));
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorStateHY009);
-
-  ASSERT_EQ(SQL_ERROR, SQLNativeSql(this->conn, nullptr, SQL_NTS, buf, buf_char_len,
+  ASSERT_EQ(SQL_ERROR, SQLNativeSql(this->conn, nullptr, input_str_len, buf, buf_char_len,
                                     &output_char_len));
   VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorStateHY009);
 
@@ -2124,10 +2091,9 @@ TYPED_TEST(StatementTest, TestSQLNativeSqlReturnsErrorOnBadInputs) {
 TYPED_TEST(StatementTest, SQLNumResultColsReturnsColumnsOnSelect) {
   SQLSMALLINT column_count = 0;
   SQLSMALLINT expected_value = 3;
-  SQLWCHAR sql_query[] = L"SELECT 1 AS col1, 'One' AS col2, 3 AS col3";
-  SQLINTEGER query_length = static_cast<SQLINTEGER>(wcslen(sql_query));
+  ASSIGN_SQLWCHAR_ARR_AND_LEN(sql_query, L"SELECT 1 AS col1, 'One' AS col2, 3 AS col3");
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, sql_query, query_length));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, sql_query, sql_query_len));
 
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
@@ -2141,10 +2107,9 @@ TYPED_TEST(StatementTest, SQLNumResultColsReturnsColumnsOnSelect) {
 }
 
 TYPED_TEST(StatementTest, SQLNumResultColsReturnsSuccessOnNullptr) {
-  SQLWCHAR sql_query[] = L"SELECT 1 AS col1, 'One' AS col2, 3 AS col3";
-  SQLINTEGER query_length = static_cast<SQLINTEGER>(wcslen(sql_query));
+  ASSIGN_SQLWCHAR_ARR_AND_LEN(sql_query, L"SELECT 1 AS col1, 'One' AS col2, 3 AS col3");
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, sql_query, query_length));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, sql_query, sql_query_len));
 
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
@@ -2179,10 +2144,9 @@ TYPED_TEST(StatementTest, SQLNumResultColsFunctionSequenceErrorOnNoQuery) {
 TYPED_TEST(StatementTest, SQLRowCountReturnsNegativeOneOnSelect) {
   SQLLEN row_count = 0;
   SQLLEN expected_value = -1;
-  SQLWCHAR sql_query[] = L"SELECT 1 AS col1, 'One' AS col2, 3 AS col3";
-  SQLINTEGER query_length = static_cast<SQLINTEGER>(wcslen(sql_query));
+  ASSIGN_SQLWCHAR_ARR_AND_LEN(sql_query, L"SELECT 1 AS col1, 'One' AS col2, 3 AS col3");
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, sql_query, query_length));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, sql_query, sql_query_len));
 
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
@@ -2196,10 +2160,9 @@ TYPED_TEST(StatementTest, SQLRowCountReturnsNegativeOneOnSelect) {
 }
 
 TYPED_TEST(StatementTest, SQLRowCountReturnsSuccessOnNullptr) {
-  SQLWCHAR sql_query[] = L"SELECT 1 AS col1, 'One' AS col2, 3 AS col3";
-  SQLINTEGER query_length = static_cast<SQLINTEGER>(wcslen(sql_query));
+  ASSIGN_SQLWCHAR_ARR_AND_LEN(sql_query, L"SELECT 1 AS col1, 'One' AS col2, 3 AS col3");
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, sql_query, query_length));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, sql_query, sql_query_len));
 
   ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
@@ -2225,8 +2188,7 @@ TYPED_TEST(StatementTest, SQLRowCountFunctionSequenceErrorOnNoQuery) {
 }
 
 TYPED_TEST(StatementTest, TestSQLFreeStmtSQLClose) {
-  SQLWCHAR wsql[] = L"SELECT 1;";
-  SQLINTEGER wsql_len = std::wcslen(wsql);
+  ASSIGN_SQLWCHAR_ARR_AND_LEN(wsql, L"SELECT 1;");
 
   ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
@@ -2234,8 +2196,7 @@ TYPED_TEST(StatementTest, TestSQLFreeStmtSQLClose) {
 }
 
 TYPED_TEST(StatementTest, TestSQLCloseCursor) {
-  SQLWCHAR wsql[] = L"SELECT 1;";
-  SQLINTEGER wsql_len = std::wcslen(wsql);
+  ASSIGN_SQLWCHAR_ARR_AND_LEN(wsql, L"SELECT 1;");
 
   ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 

--- a/cpp/src/arrow/flight/sql/odbc/tests/statement_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/statement_test.cc
@@ -2050,8 +2050,7 @@ TYPED_TEST(StatementTest, TestSQLNativeSqlReturnsTruncatedString) {
 
   // Create expected return string based on buf size
   SQLWCHAR expected_string_buf[small_buf_size_in_char];
-  wcsncpy(reinterpret_cast<wchar_t*>(expected_string_buf),
-          reinterpret_cast<const wchar_t*>(input_str), 10);
+  std::copy(input_str, input_str + 10, expected_string_buf);
   expected_string_buf[10] = L'\0';
   std::wstring expected_string(expected_string_buf,
                                expected_string_buf + small_buf_size_in_char);

--- a/cpp/src/arrow/flight/sql/odbc/tests/tables_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/tables_test.cc
@@ -44,10 +44,10 @@ TYPED_TEST_SUITE(TablesOdbcV2Test, TestTypesOdbcV2);
 // Test Cases
 
 TYPED_TEST(TablesTest, SQLTablesTestInputData) {
-  SQLWCHAR catalog_name[] = L"";
-  SQLWCHAR schema_name[] = L"";
-  SQLWCHAR table_name[] = L"";
-  SQLWCHAR table_type[] = L"";
+  SQLWCHAR catalog_name[] = {0};
+  SQLWCHAR schema_name[] = {0};
+  SQLWCHAR table_name[] = {0};
+  SQLWCHAR table_type[] = {0};
 
   // All values populated
   EXPECT_EQ(SQL_SUCCESS, SQLTables(this->stmt, catalog_name, sizeof(catalog_name),
@@ -79,8 +79,8 @@ TYPED_TEST(TablesTest, SQLTablesTestInputData) {
 }
 
 TEST_F(TablesMockTest, SQLTablesTestGetMetadataForAllCatalogs) {
-  SQLWCHAR empty[] = L"";
-  SQLWCHAR SQL_ALL_CATALOGS_W[] = L"%";
+  SQLWCHAR empty[] = {0};
+  ASSIGN_SQLWCHAR_ARR(SQL_ALL_CATALOGS_W, L"%");
   std::wstring expected_catalog_name = std::wstring(L"main");
 
   // Get Catalog metadata
@@ -101,12 +101,10 @@ TEST_F(TablesMockTest, SQLTablesTestGetMetadataForAllCatalogs) {
 TEST_F(TablesMockTest, SQLTablesTestGetMetadataForNamedCatalog) {
   CreateTestTable();
 
-  SQLWCHAR catalog_name[] = L"main";
-  const SQLWCHAR* table_names[] = {static_cast<const SQLWCHAR*>(L"TestTable"),
-                                   static_cast<const SQLWCHAR*>(L"foreignTable"),
-                                   static_cast<const SQLWCHAR*>(L"intTable"),
-                                   static_cast<const SQLWCHAR*>(L"sqlite_sequence")};
-  std::wstring expected_catalog_name = std::wstring(catalog_name);
+  ASSIGN_SQLWCHAR_ARR(catalog_name, L"main");
+  const std::wstring table_names[] = {L"TestTable", L"foreignTable", L"intTable",
+                                      L"sqlite_sequence"};
+  std::wstring expected_catalog_name = std::wstring(L"main");
   std::wstring expected_table_type = std::wstring(L"table");
 
   // Get named Catalog metadata - Mock server returns the system table sqlite_sequence as
@@ -131,7 +129,7 @@ TEST_F(TablesMockTest, SQLTablesTestGetMetadataForNamedCatalog) {
 }
 
 TEST_F(TablesMockTest, SQLTablesTestGetSchemaHasNoData) {
-  SQLWCHAR SQL_ALL_SCHEMAS_W[] = L"%";
+  ASSIGN_SQLWCHAR_ARR(SQL_ALL_SCHEMAS_W, L"%");
 
   // Validate that no schema data is available for Mock server
   ASSERT_EQ(SQL_SUCCESS, SQLTables(this->stmt, nullptr, SQL_NTS, SQL_ALL_SCHEMAS_W,
@@ -141,8 +139,8 @@ TEST_F(TablesMockTest, SQLTablesTestGetSchemaHasNoData) {
 }
 
 TEST_F(TablesRemoteTest, SQLTablesTestGetMetadataForAllSchemas) {
-  SQLWCHAR empty[] = L"";
-  SQLWCHAR SQL_ALL_SCHEMAS_W[] = L"%";
+  SQLWCHAR empty[] = {0};
+  ASSIGN_SQLWCHAR_ARR(SQL_ALL_SCHEMAS_W, L"%");
   std::set<std::wstring> actual_schemas;
   std::set<std::wstring> expected_schemas = {L"$scratch", L"INFORMATION_SCHEMA", L"sys",
                                              L"sys.cache"};
@@ -174,39 +172,39 @@ TEST_F(TablesRemoteTest, SQLTablesTestGetMetadataForAllSchemas) {
 
 TEST_F(TablesRemoteTest, SQLTablesTestFilterByAllSchema) {
   // Requires creation of user table named ODBCTest using schema $scratch in remote server
-  SQLWCHAR SQL_ALL_SCHEMAS_W[] = L"%";
-  const SQLWCHAR* schema_names[] = {static_cast<const SQLWCHAR*>(L"INFORMATION_SCHEMA"),
-                                    static_cast<const SQLWCHAR*>(L"INFORMATION_SCHEMA"),
-                                    static_cast<const SQLWCHAR*>(L"INFORMATION_SCHEMA"),
-                                    static_cast<const SQLWCHAR*>(L"INFORMATION_SCHEMA"),
-                                    static_cast<const SQLWCHAR*>(L"INFORMATION_SCHEMA"),
-                                    static_cast<const SQLWCHAR*>(L"sys"),
-                                    static_cast<const SQLWCHAR*>(L"sys"),
-                                    static_cast<const SQLWCHAR*>(L"sys"),
-                                    static_cast<const SQLWCHAR*>(L"sys"),
-                                    static_cast<const SQLWCHAR*>(L"sys"),
-                                    static_cast<const SQLWCHAR*>(L"sys"),
-                                    static_cast<const SQLWCHAR*>(L"sys"),
-                                    static_cast<const SQLWCHAR*>(L"sys"),
-                                    static_cast<const SQLWCHAR*>(L"sys"),
-                                    static_cast<const SQLWCHAR*>(L"sys"),
-                                    static_cast<const SQLWCHAR*>(L"sys"),
-                                    static_cast<const SQLWCHAR*>(L"sys"),
-                                    static_cast<const SQLWCHAR*>(L"sys"),
-                                    static_cast<const SQLWCHAR*>(L"sys"),
-                                    static_cast<const SQLWCHAR*>(L"sys"),
-                                    static_cast<const SQLWCHAR*>(L"sys"),
-                                    static_cast<const SQLWCHAR*>(L"sys"),
-                                    static_cast<const SQLWCHAR*>(L"sys"),
-                                    static_cast<const SQLWCHAR*>(L"sys"),
-                                    static_cast<const SQLWCHAR*>(L"sys"),
-                                    static_cast<const SQLWCHAR*>(L"sys"),
-                                    static_cast<const SQLWCHAR*>(L"sys"),
-                                    static_cast<const SQLWCHAR*>(L"sys.cache"),
-                                    static_cast<const SQLWCHAR*>(L"sys.cache"),
-                                    static_cast<const SQLWCHAR*>(L"sys.cache"),
-                                    static_cast<const SQLWCHAR*>(L"sys.cache"),
-                                    static_cast<const SQLWCHAR*>(L"$scratch")};
+  ASSIGN_SQLWCHAR_ARR(SQL_ALL_SCHEMAS_W, L"%");
+  const std::wstring schema_names[] = {L"INFORMATION_SCHEMA",
+                                       L"INFORMATION_SCHEMA",
+                                       L"INFORMATION_SCHEMA",
+                                       L"INFORMATION_SCHEMA",
+                                       L"INFORMATION_SCHEMA",
+                                       L"sys",
+                                       L"sys",
+                                       L"sys",
+                                       L"sys",
+                                       L"sys",
+                                       L"sys",
+                                       L"sys",
+                                       L"sys",
+                                       L"sys",
+                                       L"sys",
+                                       L"sys",
+                                       L"sys",
+                                       L"sys",
+                                       L"sys",
+                                       L"sys",
+                                       L"sys",
+                                       L"sys",
+                                       L"sys",
+                                       L"sys",
+                                       L"sys",
+                                       L"sys",
+                                       L"sys",
+                                       L"sys.cache",
+                                       L"sys.cache",
+                                       L"sys.cache",
+                                       L"sys.cache",
+                                       L"$scratch"};
   std::wstring expected_system_table_type = std::wstring(L"SYSTEM_TABLE");
   std::wstring expected_user_table_type = std::wstring(L"TABLE");
 
@@ -234,8 +232,8 @@ TEST_F(TablesRemoteTest, SQLTablesTestFilterByAllSchema) {
 
 TEST_F(TablesRemoteTest, SQLTablesGetMetadataForNamedSchema) {
   // Requires creation of user table named ODBCTest using schema $scratch in remote server
-  SQLWCHAR schema_name[] = L"$scratch";
-  std::wstring expected_schema_name = std::wstring(schema_name);
+  ASSIGN_SQLWCHAR_ARR(schema_name, L"$scratch");
+  std::wstring expected_schema_name = std::wstring(L"$scratch");
   std::wstring expected_table_name = std::wstring(L"ODBCTest");
   std::wstring expected_table_type = std::wstring(L"TABLE");
 
@@ -256,11 +254,9 @@ TEST_F(TablesRemoteTest, SQLTablesGetMetadataForNamedSchema) {
 TEST_F(TablesMockTest, SQLTablesTestGetMetadataForAllTables) {
   CreateTestTable();
 
-  SQLWCHAR SQL_ALL_TABLES_W[] = L"%";
-  const SQLWCHAR* table_names[] = {static_cast<const SQLWCHAR*>(L"TestTable"),
-                                   static_cast<const SQLWCHAR*>(L"foreignTable"),
-                                   static_cast<const SQLWCHAR*>(L"intTable"),
-                                   static_cast<const SQLWCHAR*>(L"sqlite_sequence")};
+  ASSIGN_SQLWCHAR_ARR(SQL_ALL_TABLES_W, L"%");
+  const std::wstring table_names[] = {L"TestTable", L"foreignTable", L"intTable",
+                                      L"sqlite_sequence"};
   std::wstring expected_catalog_name = std::wstring(L"main");
   std::wstring expected_table_type = std::wstring(L"table");
 
@@ -288,11 +284,10 @@ TEST_F(TablesMockTest, SQLTablesTestGetMetadataForAllTables) {
 TEST_F(TablesMockTest, SQLTablesTestGetMetadataForTableName) {
   CreateTestTable();
 
-  // Use mutable arrays to pass SQLWCHAR parameters to SQLTables
-  SQLWCHAR test_table[] = L"TestTable";
-  SQLWCHAR foreign_table[] = L"foreignTable";
-  SQLWCHAR int_table[] = L"intTable";
-  SQLWCHAR sqlite_sequence[] = L"sqlite_sequence";
+  ASSIGN_SQLWCHAR_ARR(test_table, L"TestTable");
+  ASSIGN_SQLWCHAR_ARR(foreign_table, L"foreignTable");
+  ASSIGN_SQLWCHAR_ARR(int_table, L"intTable");
+  ASSIGN_SQLWCHAR_ARR(sqlite_sequence, L"sqlite_sequence");
 
   SQLWCHAR* table_names[] = {test_table, foreign_table, int_table, sqlite_sequence};
 
@@ -309,7 +304,10 @@ TEST_F(TablesMockTest, SQLTablesTestGetMetadataForTableName) {
     CheckStringColumnW(this->stmt, 1, expected_catalog_name);
     // Mock server does not support table schema
     CheckNullColumnW(this->stmt, 2);
-    CheckStringColumnW(this->stmt, 3, table_names[i]);
+
+    std::wstring table_name = ConvertToWString(table_names[i]);
+    CheckStringColumnW(this->stmt, 3, table_name);
+
     CheckStringColumnW(this->stmt, 4, expected_table_type);
     CheckNullColumnW(this->stmt, 5);
 
@@ -322,9 +320,9 @@ TEST_F(TablesMockTest, SQLTablesTestGetMetadataForTableName) {
 TEST_F(TablesMockTest, SQLTablesTestGetMetadataForUnicodeTableByTableName) {
   CreateUnicodeTable();
 
-  SQLWCHAR unicodetable_name[] = L"数据";
+  ASSIGN_SQLWCHAR_ARR(unicodetable_name, L"数据");
   std::wstring expected_catalog_name = std::wstring(L"main");
-  std::wstring expected_table_name = std::wstring(unicodetable_name);
+  std::wstring expected_table_name = std::wstring(L"数据");
   std::wstring expected_table_type = std::wstring(L"table");
 
   //  Get specific Table metadata
@@ -348,7 +346,7 @@ TEST_F(TablesMockTest, SQLTablesTestGetMetadataForUnicodeTableByTableName) {
 TEST_F(TablesMockTest, SQLTablesTestGetMetadataForInvalidTableNameNoData) {
   CreateTestTable();
 
-  SQLWCHAR invalid_table_name[] = L"NonExistenttable_name";
+  ASSIGN_SQLWCHAR_ARR(invalid_table_name, L"NonExistenttable_name");
 
   //  Try to get metadata for a non-existent table name
   ASSERT_EQ(SQL_SUCCESS, SQLTables(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
@@ -363,17 +361,15 @@ TEST_F(TablesMockTest, SQLTablesGetMetadataForTableType) {
   // Mock server only supports table type "table" in lowercase
   CreateTestTable();
 
-  SQLWCHAR table_type_table_lowercase[] = L"table";
-  SQLWCHAR table_type_table_uppercase[] = L"TABLE";
-  SQLWCHAR table_type_view[] = L"VIEW";
-  SQLWCHAR table_type_table_view[] = L"TABLE,VIEW";
-  const SQLWCHAR* table_names[] = {static_cast<const SQLWCHAR*>(L"TestTable"),
-                                   static_cast<const SQLWCHAR*>(L"foreignTable"),
-                                   static_cast<const SQLWCHAR*>(L"intTable"),
-                                   static_cast<const SQLWCHAR*>(L"sqlite_sequence")};
+  ASSIGN_SQLWCHAR_ARR(table_type_table_lowercase, L"table");
+  ASSIGN_SQLWCHAR_ARR(table_type_table_uppercase, L"TABLE");
+  ASSIGN_SQLWCHAR_ARR(table_type_view, L"VIEW");
+  ASSIGN_SQLWCHAR_ARR(table_type_table_view, L"TABLE,VIEW");
+  const std::wstring table_names[] = {L"TestTable", L"foreignTable", L"intTable",
+                                      L"sqlite_sequence"};
   std::wstring expected_catalog_name = std::wstring(L"main");
   std::wstring expected_table_name = std::wstring(L"TestTable");
-  std::wstring expected_table_type = std::wstring(table_type_table_lowercase);
+  std::wstring expected_table_type = std::wstring(L"table");
 
   EXPECT_EQ(SQL_SUCCESS,
             SQLTables(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS, nullptr, SQL_NTS,
@@ -416,8 +412,8 @@ TEST_F(TablesRemoteTest, SQLTablesGetMetadataForTableTypeTable) {
   // Requires creation of user table named ODBCTest using schema $scratch in remote server
 
   // Use mutable arrays to pass SQLWCHAR parameters to SQLTables
-  SQLWCHAR table[] = L"TABLE";
-  SQLWCHAR table_view[] = L"TABLE,VIEW";
+  ASSIGN_SQLWCHAR_ARR(table, L"TABLE");
+  ASSIGN_SQLWCHAR_ARR(table_view, L"TABLE,VIEW");
 
   SQLWCHAR* type_list[] = {table, table_view};
 
@@ -442,8 +438,8 @@ TEST_F(TablesRemoteTest, SQLTablesGetMetadataForTableTypeTable) {
 }
 
 TEST_F(TablesRemoteTest, SQLTablesGetMetadataForTableTypeViewHasNoData) {
-  SQLWCHAR empty[] = L"";
-  SQLWCHAR type_view[] = L"VIEW";
+  SQLWCHAR empty[] = {0};
+  ASSIGN_SQLWCHAR_ARR(type_view, L"VIEW");
 
   EXPECT_EQ(SQL_SUCCESS, SQLTables(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS, empty,
                                    SQL_NTS, type_view, SQL_NTS));
@@ -457,8 +453,8 @@ TEST_F(TablesRemoteTest, SQLTablesGetMetadataForTableTypeViewHasNoData) {
 }
 
 TEST_F(TablesMockTest, SQLTablesGetSupportedTableTypes) {
-  SQLWCHAR empty[] = L"";
-  SQLWCHAR SQL_ALL_TABLE_TYPES_W[] = L"%";
+  SQLWCHAR empty[] = {0};
+  ASSIGN_SQLWCHAR_ARR(SQL_ALL_TABLE_TYPES_W, L"%");
   std::wstring expected_table_type = std::wstring(L"table");
 
   // Mock server returns lower case for supported type of "table"
@@ -477,11 +473,9 @@ TEST_F(TablesMockTest, SQLTablesGetSupportedTableTypes) {
 }
 
 TEST_F(TablesRemoteTest, SQLTablesGetSupportedTableTypes) {
-  SQLWCHAR empty[] = L"";
-  SQLWCHAR SQL_ALL_TABLE_TYPES_W[] = L"%";
-  const SQLWCHAR* type_lists[] = {static_cast<const SQLWCHAR*>(L"TABLE"),
-                                  static_cast<const SQLWCHAR*>(L"SYSTEM_TABLE"),
-                                  static_cast<const SQLWCHAR*>(L"VIEW")};
+  SQLWCHAR empty[] = {0};
+  ASSIGN_SQLWCHAR_ARR(SQL_ALL_TABLE_TYPES_W, L"%");
+  const std::wstring type_lists[] = {L"TABLE", L"SYSTEM_TABLE", L"VIEW"};
 
   ASSERT_EQ(SQL_SUCCESS, SQLTables(this->stmt, empty, SQL_NTS, empty, SQL_NTS, empty,
                                    SQL_NTS, SQL_ALL_TABLE_TYPES_W, SQL_NTS));
@@ -510,11 +504,8 @@ TYPED_TEST(TablesTest, SQLTablesGetMetadataBySQLDescribeCol) {
   SQLSMALLINT nullable = 0;
   size_t column_index = 0;
 
-  const SQLWCHAR* column_names[] = {static_cast<const SQLWCHAR*>(L"TABLE_CAT"),
-                                    static_cast<const SQLWCHAR*>(L"TABLE_SCHEM"),
-                                    static_cast<const SQLWCHAR*>(L"TABLE_NAME"),
-                                    static_cast<const SQLWCHAR*>(L"TABLE_TYPE"),
-                                    static_cast<const SQLWCHAR*>(L"REMARKS")};
+  const std::wstring column_names[] = {L"TABLE_CAT", L"TABLE_SCHEM", L"TABLE_NAME",
+                                       L"TABLE_TYPE", L"REMARKS"};
   SQLSMALLINT column_data_types[] = {SQL_WVARCHAR, SQL_WVARCHAR, SQL_WVARCHAR,
                                      SQL_WVARCHAR, SQL_WVARCHAR};
   SQLULEN column_sizes[] = {1024, 1024, 1024, 1024, 1024};
@@ -529,7 +520,7 @@ TYPED_TEST(TablesTest, SQLTablesGetMetadataBySQLDescribeCol) {
                                           buf_char_len, &name_length, &column_data_type,
                                           &column_size, &decimal_digits, &nullable));
 
-    EXPECT_EQ(wcslen(column_names[i]), name_length);
+    EXPECT_EQ(column_names[i].length(), name_length);
 
     std::wstring returned(column_name, column_name + name_length);
     EXPECT_EQ(column_names[i], returned);
@@ -557,11 +548,8 @@ TYPED_TEST(TablesOdbcV2Test, SQLTablesGetMetadataBySQLDescribeColODBCVer2) {
   SQLSMALLINT nullable = 0;
   size_t column_index = 0;
 
-  const SQLWCHAR* column_names[] = {static_cast<const SQLWCHAR*>(L"TABLE_QUALIFIER"),
-                                    static_cast<const SQLWCHAR*>(L"TABLE_OWNER"),
-                                    static_cast<const SQLWCHAR*>(L"TABLE_NAME"),
-                                    static_cast<const SQLWCHAR*>(L"TABLE_TYPE"),
-                                    static_cast<const SQLWCHAR*>(L"REMARKS")};
+  const std::wstring column_names[] = {L"TABLE_QUALIFIER", L"TABLE_OWNER", L"TABLE_NAME",
+                                       L"TABLE_TYPE", L"REMARKS"};
   SQLSMALLINT column_data_types[] = {SQL_WVARCHAR, SQL_WVARCHAR, SQL_WVARCHAR,
                                      SQL_WVARCHAR, SQL_WVARCHAR};
   SQLULEN column_sizes[] = {1024, 1024, 1024, 1024, 1024};
@@ -576,7 +564,7 @@ TYPED_TEST(TablesOdbcV2Test, SQLTablesGetMetadataBySQLDescribeColODBCVer2) {
                                           buf_char_len, &name_length, &column_data_type,
                                           &column_size, &decimal_digits, &nullable));
 
-    EXPECT_EQ(wcslen(column_names[i]), name_length);
+    EXPECT_EQ(column_names[i].length(), name_length);
 
     std::wstring returned(column_name, column_name + name_length);
     EXPECT_EQ(column_names[i], returned);

--- a/cpp/src/arrow/flight/sql/odbc/tests/type_info_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/type_info_test.cc
@@ -70,25 +70,25 @@ void CheckSQLDescribeCol(SQLHSTMT stmt, const SQLUSMALLINT column_index,
 }
 
 void CheckSQLDescribeColODBCVer2(SQLHSTMT stmt) {
-  const SQLWCHAR* column_names[] = {static_cast<const SQLWCHAR*>(L"TYPE_NAME"),
-                                    static_cast<const SQLWCHAR*>(L"DATA_TYPE"),
-                                    static_cast<const SQLWCHAR*>(L"PRECISION"),
-                                    static_cast<const SQLWCHAR*>(L"LITERAL_PREFIX"),
-                                    static_cast<const SQLWCHAR*>(L"LITERAL_SUFFIX"),
-                                    static_cast<const SQLWCHAR*>(L"CREATE_PARAMS"),
-                                    static_cast<const SQLWCHAR*>(L"NULLABLE"),
-                                    static_cast<const SQLWCHAR*>(L"CASE_SENSITIVE"),
-                                    static_cast<const SQLWCHAR*>(L"SEARCHABLE"),
-                                    static_cast<const SQLWCHAR*>(L"UNSIGNED_ATTRIBUTE"),
-                                    static_cast<const SQLWCHAR*>(L"MONEY"),
-                                    static_cast<const SQLWCHAR*>(L"AUTO_INCREMENT"),
-                                    static_cast<const SQLWCHAR*>(L"LOCAL_TYPE_NAME"),
-                                    static_cast<const SQLWCHAR*>(L"MINIMUM_SCALE"),
-                                    static_cast<const SQLWCHAR*>(L"MAXIMUM_SCALE"),
-                                    static_cast<const SQLWCHAR*>(L"SQL_DATA_TYPE"),
-                                    static_cast<const SQLWCHAR*>(L"SQL_DATETIME_SUB"),
-                                    static_cast<const SQLWCHAR*>(L"NUM_PREC_RADIX"),
-                                    static_cast<const SQLWCHAR*>(L"INTERVAL_PRECISION")};
+  const std::wstring column_names[] = {L"TYPE_NAME",
+                                       L"DATA_TYPE",
+                                       L"PRECISION",
+                                       L"LITERAL_PREFIX",
+                                       L"LITERAL_SUFFIX",
+                                       L"CREATE_PARAMS",
+                                       L"NULLABLE",
+                                       L"CASE_SENSITIVE",
+                                       L"SEARCHABLE",
+                                       L"UNSIGNED_ATTRIBUTE",
+                                       L"MONEY",
+                                       L"AUTO_INCREMENT",
+                                       L"LOCAL_TYPE_NAME",
+                                       L"MINIMUM_SCALE",
+                                       L"MAXIMUM_SCALE",
+                                       L"SQL_DATA_TYPE",
+                                       L"SQL_DATETIME_SUB",
+                                       L"NUM_PREC_RADIX",
+                                       L"INTERVAL_PRECISION"};
   SQLSMALLINT column_data_types[] = {
       SQL_WVARCHAR, SQL_SMALLINT, SQL_INTEGER,  SQL_WVARCHAR, SQL_WVARCHAR,
       SQL_WVARCHAR, SQL_SMALLINT, SQL_SMALLINT, SQL_SMALLINT, SQL_SMALLINT,
@@ -112,25 +112,14 @@ void CheckSQLDescribeColODBCVer2(SQLHSTMT stmt) {
 }
 
 void CheckSQLDescribeColODBCVer3(SQLHSTMT stmt) {
-  const SQLWCHAR* column_names[] = {static_cast<const SQLWCHAR*>(L"TYPE_NAME"),
-                                    static_cast<const SQLWCHAR*>(L"DATA_TYPE"),
-                                    static_cast<const SQLWCHAR*>(L"COLUMN_SIZE"),
-                                    static_cast<const SQLWCHAR*>(L"LITERAL_PREFIX"),
-                                    static_cast<const SQLWCHAR*>(L"LITERAL_SUFFIX"),
-                                    static_cast<const SQLWCHAR*>(L"CREATE_PARAMS"),
-                                    static_cast<const SQLWCHAR*>(L"NULLABLE"),
-                                    static_cast<const SQLWCHAR*>(L"CASE_SENSITIVE"),
-                                    static_cast<const SQLWCHAR*>(L"SEARCHABLE"),
-                                    static_cast<const SQLWCHAR*>(L"UNSIGNED_ATTRIBUTE"),
-                                    static_cast<const SQLWCHAR*>(L"FIXED_PREC_SCALE"),
-                                    static_cast<const SQLWCHAR*>(L"AUTO_UNIQUE_VALUE"),
-                                    static_cast<const SQLWCHAR*>(L"LOCAL_TYPE_NAME"),
-                                    static_cast<const SQLWCHAR*>(L"MINIMUM_SCALE"),
-                                    static_cast<const SQLWCHAR*>(L"MAXIMUM_SCALE"),
-                                    static_cast<const SQLWCHAR*>(L"SQL_DATA_TYPE"),
-                                    static_cast<const SQLWCHAR*>(L"SQL_DATETIME_SUB"),
-                                    static_cast<const SQLWCHAR*>(L"NUM_PREC_RADIX"),
-                                    static_cast<const SQLWCHAR*>(L"INTERVAL_PRECISION")};
+  const std::wstring column_names[] = {
+      L"TYPE_NAME",          L"DATA_TYPE",        L"COLUMN_SIZE",
+      L"LITERAL_PREFIX",     L"LITERAL_SUFFIX",   L"CREATE_PARAMS",
+      L"NULLABLE",           L"CASE_SENSITIVE",   L"SEARCHABLE",
+      L"UNSIGNED_ATTRIBUTE", L"FIXED_PREC_SCALE", L"AUTO_UNIQUE_VALUE",
+      L"LOCAL_TYPE_NAME",    L"MINIMUM_SCALE",    L"MAXIMUM_SCALE",
+      L"SQL_DATA_TYPE",      L"SQL_DATETIME_SUB", L"NUM_PREC_RADIX",
+      L"INTERVAL_PRECISION"};
   SQLSMALLINT column_data_types[] = {
       SQL_WVARCHAR, SQL_SMALLINT, SQL_INTEGER,  SQL_WVARCHAR, SQL_WVARCHAR,
       SQL_WVARCHAR, SQL_SMALLINT, SQL_SMALLINT, SQL_SMALLINT, SQL_SMALLINT,
@@ -221,16 +210,16 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       SQL_NULLABLE,          // expected_nullable
                       SQL_FALSE,             // expected_case_sensitive
                       SQL_SEARCHABLE,        // expected_searchable
-                      NULL,                  // expected_unsigned_attr
+                      0,                     // expected_unsigned_attr
                       SQL_FALSE,             // expected_fixed_prec_scale
-                      NULL,                  // expected_auto_unique_value
+                      0,                     // expected_auto_unique_value
                       std::wstring(L"bit"),  // expected_local_type_name
-                      NULL,                  // expected_min_scale
-                      NULL,                  // expected_max_scale
+                      0,                     // expected_min_scale
+                      0,                     // expected_max_scale
                       SQL_BIT,               // expected_sql_data_type
-                      NULL,                  // expected_sql_datetime_sub
-                      NULL,                  // expected_num_prec_radix
-                      NULL);                 // expected_interval_prec
+                      0,                     // expected_sql_datetime_sub
+                      0,                     // expected_num_prec_radix
+                      0);                    // expected_interval_prec
 
   CheckSQLDescribeColODBCVer3(stmt);
 
@@ -249,14 +238,14 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       SQL_SEARCHABLE,            // expected_searchable
                       SQL_FALSE,                 // expected_unsigned_attr
                       SQL_FALSE,                 // expected_fixed_prec_scale
-                      NULL,                      // expected_auto_unique_value
+                      0,                         // expected_auto_unique_value
                       std::wstring(L"tinyint"),  // expected_local_type_name
-                      NULL,                      // expected_min_scale
-                      NULL,                      // expected_max_scale
+                      0,                         // expected_min_scale
+                      0,                         // expected_max_scale
                       SQL_TINYINT,               // expected_sql_data_type
-                      NULL,                      // expected_sql_datetime_sub
-                      NULL,                      // expected_num_prec_radix
-                      NULL);                     // expected_interval_prec
+                      0,                         // expected_sql_datetime_sub
+                      0,                         // expected_num_prec_radix
+                      0);                        // expected_interval_prec
 
   CheckSQLDescribeColODBCVer3(stmt);
 
@@ -275,14 +264,14 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       SQL_SEARCHABLE,           // expected_searchable
                       SQL_FALSE,                // expected_unsigned_attr
                       SQL_FALSE,                // expected_fixed_prec_scale
-                      NULL,                     // expected_auto_unique_value
+                      0,                        // expected_auto_unique_value
                       std::wstring(L"bigint"),  // expected_local_type_name
-                      NULL,                     // expected_min_scale
-                      NULL,                     // expected_max_scale
+                      0,                        // expected_min_scale
+                      0,                        // expected_max_scale
                       SQL_BIGINT,               // expected_sql_data_type
-                      NULL,                     // expected_sql_datetime_sub
-                      NULL,                     // expected_num_prec_radix
-                      NULL);                    // expected_interval_prec
+                      0,                        // expected_sql_datetime_sub
+                      0,                        // expected_num_prec_radix
+                      0);                       // expected_interval_prec
 
   CheckSQLDescribeColODBCVer3(stmt);
 
@@ -299,16 +288,16 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       SQL_NULLABLE,                    // expected_nullable
                       SQL_FALSE,                       // expected_case_sensitive
                       SQL_SEARCHABLE,                  // expected_searchable
-                      NULL,                            // expected_unsigned_attr
+                      0,                               // expected_unsigned_attr
                       SQL_FALSE,                       // expected_fixed_prec_scale
-                      NULL,                            // expected_auto_unique_value
+                      0,                               // expected_auto_unique_value
                       std::wstring(L"longvarbinary"),  // expected_local_type_name
-                      NULL,                            // expected_min_scale
-                      NULL,                            // expected_max_scale
+                      0,                               // expected_min_scale
+                      0,                               // expected_max_scale
                       SQL_LONGVARBINARY,               // expected_sql_data_type
-                      NULL,                            // expected_sql_datetime_sub
-                      NULL,                            // expected_num_prec_radix
-                      NULL);                           // expected_interval_prec
+                      0,                               // expected_sql_datetime_sub
+                      0,                               // expected_num_prec_radix
+                      0);                              // expected_interval_prec
 
   CheckSQLDescribeColODBCVer3(stmt);
 
@@ -325,16 +314,16 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       SQL_NULLABLE,                // expected_nullable
                       SQL_FALSE,                   // expected_case_sensitive
                       SQL_SEARCHABLE,              // expected_searchable
-                      NULL,                        // expected_unsigned_attr
+                      0,                           // expected_unsigned_attr
                       SQL_FALSE,                   // expected_fixed_prec_scale
-                      NULL,                        // expected_auto_unique_value
+                      0,                           // expected_auto_unique_value
                       std::wstring(L"varbinary"),  // expected_local_type_name
-                      NULL,                        // expected_min_scale
-                      NULL,                        // expected_max_scale
+                      0,                           // expected_min_scale
+                      0,                           // expected_max_scale
                       SQL_VARBINARY,               // expected_sql_data_type
-                      NULL,                        // expected_sql_datetime_sub
-                      NULL,                        // expected_num_prec_radix
-                      NULL);                       // expected_interval_prec
+                      0,                           // expected_sql_datetime_sub
+                      0,                           // expected_num_prec_radix
+                      0);                          // expected_interval_prec
 
   CheckSQLDescribeColODBCVer3(stmt);
 
@@ -352,16 +341,16 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       SQL_NULLABLE,             // expected_nullable
                       SQL_FALSE,                // expected_case_sensitive
                       SQL_SEARCHABLE,           // expected_searchable
-                      NULL,                     // expected_unsigned_attr
+                      0,                        // expected_unsigned_attr
                       SQL_FALSE,                // expected_fixed_prec_scale
-                      NULL,                     // expected_auto_unique_value
+                      0,                        // expected_auto_unique_value
                       std::wstring(L"text"),    // expected_local_type_name
-                      NULL,                     // expected_min_scale
-                      NULL,                     // expected_max_scale
+                      0,                        // expected_min_scale
+                      0,                        // expected_max_scale
                       SQL_WLONGVARCHAR,         // expected_sql_data_type
-                      NULL,                     // expected_sql_datetime_sub
-                      NULL,                     // expected_num_prec_radix
-                      NULL);                    // expected_interval_prec
+                      0,                        // expected_sql_datetime_sub
+                      0,                        // expected_num_prec_radix
+                      0);                       // expected_interval_prec
 
   CheckSQLDescribeColODBCVer3(stmt);
 
@@ -378,16 +367,16 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       SQL_NULLABLE,                  // expected_nullable
                       SQL_FALSE,                     // expected_case_sensitive
                       SQL_SEARCHABLE,                // expected_searchable
-                      NULL,                          // expected_unsigned_attr
+                      0,                             // expected_unsigned_attr
                       SQL_FALSE,                     // expected_fixed_prec_scale
-                      NULL,                          // expected_auto_unique_value
+                      0,                             // expected_auto_unique_value
                       std::wstring(L"longvarchar"),  // expected_local_type_name
-                      NULL,                          // expected_min_scale
-                      NULL,                          // expected_max_scale
+                      0,                             // expected_min_scale
+                      0,                             // expected_max_scale
                       SQL_WLONGVARCHAR,              // expected_sql_data_type
-                      NULL,                          // expected_sql_datetime_sub
-                      NULL,                          // expected_num_prec_radix
-                      NULL);                         // expected_interval_prec
+                      0,                             // expected_sql_datetime_sub
+                      0,                             // expected_num_prec_radix
+                      0);                            // expected_interval_prec
 
   CheckSQLDescribeColODBCVer3(stmt);
 
@@ -405,16 +394,16 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       SQL_NULLABLE,             // expected_nullable
                       SQL_FALSE,                // expected_case_sensitive
                       SQL_SEARCHABLE,           // expected_searchable
-                      NULL,                     // expected_unsigned_attr
+                      0,                        // expected_unsigned_attr
                       SQL_FALSE,                // expected_fixed_prec_scale
-                      NULL,                     // expected_auto_unique_value
+                      0,                        // expected_auto_unique_value
                       std::wstring(L"char"),    // expected_local_type_name
-                      NULL,                     // expected_min_scale
-                      NULL,                     // expected_max_scale
+                      0,                        // expected_min_scale
+                      0,                        // expected_max_scale
                       SQL_WCHAR,                // expected_sql_data_type
-                      NULL,                     // expected_sql_datetime_sub
-                      NULL,                     // expected_num_prec_radix
-                      NULL);                    // expected_interval_prec
+                      0,                        // expected_sql_datetime_sub
+                      0,                        // expected_num_prec_radix
+                      0);                       // expected_interval_prec
 
   CheckSQLDescribeColODBCVer3(stmt);
 
@@ -433,14 +422,14 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       SQL_SEARCHABLE,            // expected_searchable
                       SQL_FALSE,                 // expected_unsigned_attr
                       SQL_FALSE,                 // expected_fixed_prec_scale
-                      NULL,                      // expected_auto_unique_value
+                      0,                         // expected_auto_unique_value
                       std::wstring(L"integer"),  // expected_local_type_name
-                      NULL,                      // expected_min_scale
-                      NULL,                      // expected_max_scale
+                      0,                         // expected_min_scale
+                      0,                         // expected_max_scale
                       SQL_INTEGER,               // expected_sql_data_type
-                      NULL,                      // expected_sql_datetime_sub
-                      NULL,                      // expected_num_prec_radix
-                      NULL);                     // expected_interval_prec
+                      0,                         // expected_sql_datetime_sub
+                      0,                         // expected_num_prec_radix
+                      0);                        // expected_interval_prec
 
   CheckSQLDescribeColODBCVer3(stmt);
 
@@ -459,14 +448,14 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       SQL_SEARCHABLE,             // expected_searchable
                       SQL_FALSE,                  // expected_unsigned_attr
                       SQL_FALSE,                  // expected_fixed_prec_scale
-                      NULL,                       // expected_auto_unique_value
+                      0,                          // expected_auto_unique_value
                       std::wstring(L"smallint"),  // expected_local_type_name
-                      NULL,                       // expected_min_scale
-                      NULL,                       // expected_max_scale
+                      0,                          // expected_min_scale
+                      0,                          // expected_max_scale
                       SQL_SMALLINT,               // expected_sql_data_type
-                      NULL,                       // expected_sql_datetime_sub
-                      NULL,                       // expected_num_prec_radix
-                      NULL);                      // expected_interval_prec
+                      0,                          // expected_sql_datetime_sub
+                      0,                          // expected_num_prec_radix
+                      0);                         // expected_interval_prec
 
   CheckSQLDescribeColODBCVer3(stmt);
 
@@ -485,14 +474,14 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       SQL_SEARCHABLE,          // expected_searchable
                       SQL_FALSE,               // expected_unsigned_attr
                       SQL_FALSE,               // expected_fixed_prec_scale
-                      NULL,                    // expected_auto_unique_value
+                      0,                       // expected_auto_unique_value
                       std::wstring(L"float"),  // expected_local_type_name
-                      NULL,                    // expected_min_scale
-                      NULL,                    // expected_max_scale
+                      0,                       // expected_min_scale
+                      0,                       // expected_max_scale
                       SQL_FLOAT,               // expected_sql_data_type
-                      NULL,                    // expected_sql_datetime_sub
-                      NULL,                    // expected_num_prec_radix
-                      NULL);                   // expected_interval_prec
+                      0,                       // expected_sql_datetime_sub
+                      0,                       // expected_num_prec_radix
+                      0);                      // expected_interval_prec
 
   CheckSQLDescribeColODBCVer3(stmt);
 
@@ -511,14 +500,14 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       SQL_SEARCHABLE,           // expected_searchable
                       SQL_FALSE,                // expected_unsigned_attr
                       SQL_FALSE,                // expected_fixed_prec_scale
-                      NULL,                     // expected_auto_unique_value
+                      0,                        // expected_auto_unique_value
                       std::wstring(L"double"),  // expected_local_type_name
-                      NULL,                     // expected_min_scale
-                      NULL,                     // expected_max_scale
+                      0,                        // expected_min_scale
+                      0,                        // expected_max_scale
                       SQL_DOUBLE,               // expected_sql_data_type
-                      NULL,                     // expected_sql_datetime_sub
-                      NULL,                     // expected_num_prec_radix
-                      NULL);                    // expected_interval_prec
+                      0,                        // expected_sql_datetime_sub
+                      0,                        // expected_num_prec_radix
+                      0);                       // expected_interval_prec
 
   CheckSQLDescribeColODBCVer3(stmt);
 
@@ -538,14 +527,14 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       SQL_SEARCHABLE,            // expected_searchable
                       SQL_FALSE,                 // expected_unsigned_attr
                       SQL_FALSE,                 // expected_fixed_prec_scale
-                      NULL,                      // expected_auto_unique_value
+                      0,                         // expected_auto_unique_value
                       std::wstring(L"numeric"),  // expected_local_type_name
-                      NULL,                      // expected_min_scale
-                      NULL,                      // expected_max_scale
+                      0,                         // expected_min_scale
+                      0,                         // expected_max_scale
                       SQL_DOUBLE,                // expected_sql_data_type
-                      NULL,                      // expected_sql_datetime_sub
-                      NULL,                      // expected_num_prec_radix
-                      NULL);                     // expected_interval_prec
+                      0,                         // expected_sql_datetime_sub
+                      0,                         // expected_num_prec_radix
+                      0);                        // expected_interval_prec
 
   CheckSQLDescribeColODBCVer3(stmt);
 
@@ -565,14 +554,14 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       SQL_SEARCHABLE,            // expected_searchable
                       SQL_FALSE,                 // expected_unsigned_attr
                       SQL_FALSE,                 // expected_fixed_prec_scale
-                      NULL,                      // expected_auto_unique_value
+                      0,                         // expected_auto_unique_value
                       std::wstring(L"varchar"),  // expected_local_type_name
-                      NULL,                      // expected_min_scale
-                      NULL,                      // expected_max_scale
+                      0,                         // expected_min_scale
+                      0,                         // expected_max_scale
                       SQL_WVARCHAR,              // expected_sql_data_type
-                      NULL,                      // expected_sql_datetime_sub
-                      NULL,                      // expected_num_prec_radix
-                      NULL);                     // expected_interval_prec
+                      0,                         // expected_sql_datetime_sub
+                      0,                         // expected_num_prec_radix
+                      0);                        // expected_interval_prec
 
   CheckSQLDescribeColODBCVer3(stmt);
 
@@ -591,14 +580,14 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       SQL_SEARCHABLE,         // expected_searchable
                       SQL_FALSE,              // expected_unsigned_attr
                       SQL_FALSE,              // expected_fixed_prec_scale
-                      NULL,                   // expected_auto_unique_value
+                      0,                      // expected_auto_unique_value
                       std::wstring(L"date"),  // expected_local_type_name
-                      NULL,                   // expected_min_scale
-                      NULL,                   // expected_max_scale
+                      0,                      // expected_min_scale
+                      0,                      // expected_max_scale
                       SQL_DATETIME,           // expected_sql_data_type
                       SQL_CODE_DATE,          // expected_sql_datetime_sub
-                      NULL,                   // expected_num_prec_radix
-                      NULL);                  // expected_interval_prec
+                      0,                      // expected_num_prec_radix
+                      0);                     // expected_interval_prec
 
   CheckSQLDescribeColODBCVer3(stmt);
 
@@ -617,14 +606,14 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       SQL_SEARCHABLE,         // expected_searchable
                       SQL_FALSE,              // expected_unsigned_attr
                       SQL_FALSE,              // expected_fixed_prec_scale
-                      NULL,                   // expected_auto_unique_value
+                      0,                      // expected_auto_unique_value
                       std::wstring(L"time"),  // expected_local_type_name
-                      NULL,                   // expected_min_scale
-                      NULL,                   // expected_max_scale
+                      0,                      // expected_min_scale
+                      0,                      // expected_max_scale
                       SQL_DATETIME,           // expected_sql_data_type
                       SQL_CODE_TIME,          // expected_sql_datetime_sub
-                      NULL,                   // expected_num_prec_radix
-                      NULL);                  // expected_interval_prec
+                      0,                      // expected_num_prec_radix
+                      0);                     // expected_interval_prec
 
   CheckSQLDescribeColODBCVer3(stmt);
 
@@ -643,14 +632,14 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoAllTypes) {
                       SQL_SEARCHABLE,              // expected_searchable
                       SQL_FALSE,                   // expected_unsigned_attr
                       SQL_FALSE,                   // expected_fixed_prec_scale
-                      NULL,                        // expected_auto_unique_value
+                      0,                           // expected_auto_unique_value
                       std::wstring(L"timestamp"),  // expected_local_type_name
-                      NULL,                        // expected_min_scale
-                      NULL,                        // expected_max_scale
+                      0,                           // expected_min_scale
+                      0,                           // expected_max_scale
                       SQL_DATETIME,                // expected_sql_data_type
                       SQL_CODE_TIMESTAMP,          // expected_sql_datetime_sub
-                      NULL,                        // expected_num_prec_radix
-                      NULL);                       // expected_interval_prec
+                      0,                           // expected_num_prec_radix
+                      0);                          // expected_interval_prec
 
   CheckSQLDescribeColODBCVer3(stmt);
 }
@@ -671,16 +660,16 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       SQL_NULLABLE,          // expected_nullable
                       SQL_FALSE,             // expected_case_sensitive
                       SQL_SEARCHABLE,        // expected_searchable
-                      NULL,                  // expected_unsigned_attr
+                      0,                     // expected_unsigned_attr
                       SQL_FALSE,             // expected_fixed_prec_scale
-                      NULL,                  // expected_auto_unique_value
+                      0,                     // expected_auto_unique_value
                       std::wstring(L"bit"),  // expected_local_type_name
-                      NULL,                  // expected_min_scale
-                      NULL,                  // expected_max_scale
+                      0,                     // expected_min_scale
+                      0,                     // expected_max_scale
                       SQL_BIT,               // expected_sql_data_type
-                      NULL,                  // expected_sql_datetime_sub
-                      NULL,                  // expected_num_prec_radix
-                      NULL);                 // expected_interval_prec
+                      0,                     // expected_sql_datetime_sub
+                      0,                     // expected_num_prec_radix
+                      0);                    // expected_interval_prec
 
   CheckSQLDescribeColODBCVer2(stmt);
 
@@ -699,14 +688,14 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       SQL_SEARCHABLE,            // expected_searchable
                       SQL_FALSE,                 // expected_unsigned_attr
                       SQL_FALSE,                 // expected_fixed_prec_scale
-                      NULL,                      // expected_auto_unique_value
+                      0,                         // expected_auto_unique_value
                       std::wstring(L"tinyint"),  // expected_local_type_name
-                      NULL,                      // expected_min_scale
-                      NULL,                      // expected_max_scale
+                      0,                         // expected_min_scale
+                      0,                         // expected_max_scale
                       SQL_TINYINT,               // expected_sql_data_type
-                      NULL,                      // expected_sql_datetime_sub
-                      NULL,                      // expected_num_prec_radix
-                      NULL);                     // expected_interval_prec
+                      0,                         // expected_sql_datetime_sub
+                      0,                         // expected_num_prec_radix
+                      0);                        // expected_interval_prec
 
   CheckSQLDescribeColODBCVer2(stmt);
 
@@ -725,14 +714,14 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       SQL_SEARCHABLE,           // expected_searchable
                       SQL_FALSE,                // expected_unsigned_attr
                       SQL_FALSE,                // expected_fixed_prec_scale
-                      NULL,                     // expected_auto_unique_value
+                      0,                        // expected_auto_unique_value
                       std::wstring(L"bigint"),  // expected_local_type_name
-                      NULL,                     // expected_min_scale
-                      NULL,                     // expected_max_scale
+                      0,                        // expected_min_scale
+                      0,                        // expected_max_scale
                       SQL_BIGINT,               // expected_sql_data_type
-                      NULL,                     // expected_sql_datetime_sub
-                      NULL,                     // expected_num_prec_radix
-                      NULL);                    // expected_interval_prec
+                      0,                        // expected_sql_datetime_sub
+                      0,                        // expected_num_prec_radix
+                      0);                       // expected_interval_prec
 
   CheckSQLDescribeColODBCVer2(stmt);
 
@@ -749,16 +738,16 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       SQL_NULLABLE,                    // expected_nullable
                       SQL_FALSE,                       // expected_case_sensitive
                       SQL_SEARCHABLE,                  // expected_searchable
-                      NULL,                            // expected_unsigned_attr
+                      0,                               // expected_unsigned_attr
                       SQL_FALSE,                       // expected_fixed_prec_scale
-                      NULL,                            // expected_auto_unique_value
+                      0,                               // expected_auto_unique_value
                       std::wstring(L"longvarbinary"),  // expected_local_type_name
-                      NULL,                            // expected_min_scale
-                      NULL,                            // expected_max_scale
+                      0,                               // expected_min_scale
+                      0,                               // expected_max_scale
                       SQL_LONGVARBINARY,               // expected_sql_data_type
-                      NULL,                            // expected_sql_datetime_sub
-                      NULL,                            // expected_num_prec_radix
-                      NULL);                           // expected_interval_prec
+                      0,                               // expected_sql_datetime_sub
+                      0,                               // expected_num_prec_radix
+                      0);                              // expected_interval_prec
 
   CheckSQLDescribeColODBCVer2(stmt);
 
@@ -775,16 +764,16 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       SQL_NULLABLE,                // expected_nullable
                       SQL_FALSE,                   // expected_case_sensitive
                       SQL_SEARCHABLE,              // expected_searchable
-                      NULL,                        // expected_unsigned_attr
+                      0,                           // expected_unsigned_attr
                       SQL_FALSE,                   // expected_fixed_prec_scale
-                      NULL,                        // expected_auto_unique_value
+                      0,                           // expected_auto_unique_value
                       std::wstring(L"varbinary"),  // expected_local_type_name
-                      NULL,                        // expected_min_scale
-                      NULL,                        // expected_max_scale
+                      0,                           // expected_min_scale
+                      0,                           // expected_max_scale
                       SQL_VARBINARY,               // expected_sql_data_type
-                      NULL,                        // expected_sql_datetime_sub
-                      NULL,                        // expected_num_prec_radix
-                      NULL);                       // expected_interval_prec
+                      0,                           // expected_sql_datetime_sub
+                      0,                           // expected_num_prec_radix
+                      0);                          // expected_interval_prec
 
   CheckSQLDescribeColODBCVer2(stmt);
 
@@ -802,16 +791,16 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       SQL_NULLABLE,             // expected_nullable
                       SQL_FALSE,                // expected_case_sensitive
                       SQL_SEARCHABLE,           // expected_searchable
-                      NULL,                     // expected_unsigned_attr
+                      0,                        // expected_unsigned_attr
                       SQL_FALSE,                // expected_fixed_prec_scale
-                      NULL,                     // expected_auto_unique_value
+                      0,                        // expected_auto_unique_value
                       std::wstring(L"text"),    // expected_local_type_name
-                      NULL,                     // expected_min_scale
-                      NULL,                     // expected_max_scale
+                      0,                        // expected_min_scale
+                      0,                        // expected_max_scale
                       SQL_WLONGVARCHAR,         // expected_sql_data_type
-                      NULL,                     // expected_sql_datetime_sub
-                      NULL,                     // expected_num_prec_radix
-                      NULL);                    // expected_interval_prec
+                      0,                        // expected_sql_datetime_sub
+                      0,                        // expected_num_prec_radix
+                      0);                       // expected_interval_prec
 
   CheckSQLDescribeColODBCVer2(stmt);
 
@@ -828,16 +817,16 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       SQL_NULLABLE,                  // expected_nullable
                       SQL_FALSE,                     // expected_case_sensitive
                       SQL_SEARCHABLE,                // expected_searchable
-                      NULL,                          // expected_unsigned_attr
+                      0,                             // expected_unsigned_attr
                       SQL_FALSE,                     // expected_fixed_prec_scale
-                      NULL,                          // expected_auto_unique_value
+                      0,                             // expected_auto_unique_value
                       std::wstring(L"longvarchar"),  // expected_local_type_name
-                      NULL,                          // expected_min_scale
-                      NULL,                          // expected_max_scale
+                      0,                             // expected_min_scale
+                      0,                             // expected_max_scale
                       SQL_WLONGVARCHAR,              // expected_sql_data_type
-                      NULL,                          // expected_sql_datetime_sub
-                      NULL,                          // expected_num_prec_radix
-                      NULL);                         // expected_interval_prec
+                      0,                             // expected_sql_datetime_sub
+                      0,                             // expected_num_prec_radix
+                      0);                            // expected_interval_prec
 
   CheckSQLDescribeColODBCVer2(stmt);
 
@@ -855,16 +844,16 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       SQL_NULLABLE,             // expected_nullable
                       SQL_FALSE,                // expected_case_sensitive
                       SQL_SEARCHABLE,           // expected_searchable
-                      NULL,                     // expected_unsigned_attr
+                      0,                        // expected_unsigned_attr
                       SQL_FALSE,                // expected_fixed_prec_scale
-                      NULL,                     // expected_auto_unique_value
+                      0,                        // expected_auto_unique_value
                       std::wstring(L"char"),    // expected_local_type_name
-                      NULL,                     // expected_min_scale
-                      NULL,                     // expected_max_scale
+                      0,                        // expected_min_scale
+                      0,                        // expected_max_scale
                       SQL_WCHAR,                // expected_sql_data_type
-                      NULL,                     // expected_sql_datetime_sub
-                      NULL,                     // expected_num_prec_radix
-                      NULL);                    // expected_interval_prec
+                      0,                        // expected_sql_datetime_sub
+                      0,                        // expected_num_prec_radix
+                      0);                       // expected_interval_prec
 
   CheckSQLDescribeColODBCVer2(stmt);
 
@@ -883,14 +872,14 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       SQL_SEARCHABLE,            // expected_searchable
                       SQL_FALSE,                 // expected_unsigned_attr
                       SQL_FALSE,                 // expected_fixed_prec_scale
-                      NULL,                      // expected_auto_unique_value
+                      0,                         // expected_auto_unique_value
                       std::wstring(L"integer"),  // expected_local_type_name
-                      NULL,                      // expected_min_scale
-                      NULL,                      // expected_max_scale
+                      0,                         // expected_min_scale
+                      0,                         // expected_max_scale
                       SQL_INTEGER,               // expected_sql_data_type
-                      NULL,                      // expected_sql_datetime_sub
-                      NULL,                      // expected_num_prec_radix
-                      NULL);                     // expected_interval_prec
+                      0,                         // expected_sql_datetime_sub
+                      0,                         // expected_num_prec_radix
+                      0);                        // expected_interval_prec
 
   CheckSQLDescribeColODBCVer2(stmt);
 
@@ -909,14 +898,14 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       SQL_SEARCHABLE,             // expected_searchable
                       SQL_FALSE,                  // expected_unsigned_attr
                       SQL_FALSE,                  // expected_fixed_prec_scale
-                      NULL,                       // expected_auto_unique_value
+                      0,                          // expected_auto_unique_value
                       std::wstring(L"smallint"),  // expected_local_type_name
-                      NULL,                       // expected_min_scale
-                      NULL,                       // expected_max_scale
+                      0,                          // expected_min_scale
+                      0,                          // expected_max_scale
                       SQL_SMALLINT,               // expected_sql_data_type
-                      NULL,                       // expected_sql_datetime_sub
-                      NULL,                       // expected_num_prec_radix
-                      NULL);                      // expected_interval_prec
+                      0,                          // expected_sql_datetime_sub
+                      0,                          // expected_num_prec_radix
+                      0);                         // expected_interval_prec
 
   CheckSQLDescribeColODBCVer2(stmt);
 
@@ -935,14 +924,14 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       SQL_SEARCHABLE,          // expected_searchable
                       SQL_FALSE,               // expected_unsigned_attr
                       SQL_FALSE,               // expected_fixed_prec_scale
-                      NULL,                    // expected_auto_unique_value
+                      0,                       // expected_auto_unique_value
                       std::wstring(L"float"),  // expected_local_type_name
-                      NULL,                    // expected_min_scale
-                      NULL,                    // expected_max_scale
+                      0,                       // expected_min_scale
+                      0,                       // expected_max_scale
                       SQL_FLOAT,               // expected_sql_data_type
-                      NULL,                    // expected_sql_datetime_sub
-                      NULL,                    // expected_num_prec_radix
-                      NULL);                   // expected_interval_prec
+                      0,                       // expected_sql_datetime_sub
+                      0,                       // expected_num_prec_radix
+                      0);                      // expected_interval_prec
 
   CheckSQLDescribeColODBCVer2(stmt);
 
@@ -961,14 +950,14 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       SQL_SEARCHABLE,           // expected_searchable
                       SQL_FALSE,                // expected_unsigned_attr
                       SQL_FALSE,                // expected_fixed_prec_scale
-                      NULL,                     // expected_auto_unique_value
+                      0,                        // expected_auto_unique_value
                       std::wstring(L"double"),  // expected_local_type_name
-                      NULL,                     // expected_min_scale
-                      NULL,                     // expected_max_scale
+                      0,                        // expected_min_scale
+                      0,                        // expected_max_scale
                       SQL_DOUBLE,               // expected_sql_data_type
-                      NULL,                     // expected_sql_datetime_sub
-                      NULL,                     // expected_num_prec_radix
-                      NULL);                    // expected_interval_prec
+                      0,                        // expected_sql_datetime_sub
+                      0,                        // expected_num_prec_radix
+                      0);                       // expected_interval_prec
 
   CheckSQLDescribeColODBCVer2(stmt);
 
@@ -988,14 +977,14 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       SQL_SEARCHABLE,            // expected_searchable
                       SQL_FALSE,                 // expected_unsigned_attr
                       SQL_FALSE,                 // expected_fixed_prec_scale
-                      NULL,                      // expected_auto_unique_value
+                      0,                         // expected_auto_unique_value
                       std::wstring(L"numeric"),  // expected_local_type_name
-                      NULL,                      // expected_min_scale
-                      NULL,                      // expected_max_scale
+                      0,                         // expected_min_scale
+                      0,                         // expected_max_scale
                       SQL_DOUBLE,                // expected_sql_data_type
-                      NULL,                      // expected_sql_datetime_sub
-                      NULL,                      // expected_num_prec_radix
-                      NULL);                     // expected_interval_prec
+                      0,                         // expected_sql_datetime_sub
+                      0,                         // expected_num_prec_radix
+                      0);                        // expected_interval_prec
 
   CheckSQLDescribeColODBCVer2(stmt);
 
@@ -1015,14 +1004,14 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       SQL_SEARCHABLE,            // expected_searchable
                       SQL_FALSE,                 // expected_unsigned_attr
                       SQL_FALSE,                 // expected_fixed_prec_scale
-                      NULL,                      // expected_auto_unique_value
+                      0,                         // expected_auto_unique_value
                       std::wstring(L"varchar"),  // expected_local_type_name
-                      NULL,                      // expected_min_scale
-                      NULL,                      // expected_max_scale
+                      0,                         // expected_min_scale
+                      0,                         // expected_max_scale
                       SQL_WVARCHAR,              // expected_sql_data_type
-                      NULL,                      // expected_sql_datetime_sub
-                      NULL,                      // expected_num_prec_radix
-                      NULL);                     // expected_interval_prec
+                      0,                         // expected_sql_datetime_sub
+                      0,                         // expected_num_prec_radix
+                      0);                        // expected_interval_prec
 
   CheckSQLDescribeColODBCVer2(stmt);
 
@@ -1041,14 +1030,15 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       SQL_SEARCHABLE,         // expected_searchable
                       SQL_FALSE,              // expected_unsigned_attr
                       SQL_FALSE,              // expected_fixed_prec_scale
-                      NULL,                   // expected_auto_unique_value
+                      0,                      // expected_auto_unique_value
                       std::wstring(L"date"),  // expected_local_type_name
-                      NULL,                   // expected_min_scale
-                      NULL,                   // expected_max_scale
+                      0,                      // expected_min_scale
+                      0,                      // expected_max_scale
                       SQL_DATETIME,           // expected_sql_data_type
-                      NULL,   // expected_sql_datetime_sub, driver returns NULL for Ver2
-                      NULL,   // expected_num_prec_radix
-                      NULL);  // expected_interval_prec
+                      0,                      // 0, driver
+                                              // returns NULL for Ver2
+                      0,                      // expected_num_prec_radix
+                      0);                     // expected_interval_prec
 
   CheckSQLDescribeColODBCVer2(stmt);
 
@@ -1067,14 +1057,15 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       SQL_SEARCHABLE,         // expected_searchable
                       SQL_FALSE,              // expected_unsigned_attr
                       SQL_FALSE,              // expected_fixed_prec_scale
-                      NULL,                   // expected_auto_unique_value
+                      0,                      // expected_auto_unique_value
                       std::wstring(L"time"),  // expected_local_type_name
-                      NULL,                   // expected_min_scale
-                      NULL,                   // expected_max_scale
+                      0,                      // expected_min_scale
+                      0,                      // expected_max_scale
                       SQL_DATETIME,           // expected_sql_data_type
-                      NULL,   // expected_sql_datetime_sub, driver returns NULL for Ver2
-                      NULL,   // expected_num_prec_radix
-                      NULL);  // expected_interval_prec
+                      0,                      // 0, driver
+                                              // returns NULL for Ver2
+                      0,                      // expected_num_prec_radix
+                      0);                     // expected_interval_prec
 
   CheckSQLDescribeColODBCVer2(stmt);
 
@@ -1093,14 +1084,15 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoAllTypesODBCVer2) {
                       SQL_SEARCHABLE,              // expected_searchable
                       SQL_FALSE,                   // expected_unsigned_attr
                       SQL_FALSE,                   // expected_fixed_prec_scale
-                      NULL,                        // expected_auto_unique_value
+                      0,                           // expected_auto_unique_value
                       std::wstring(L"timestamp"),  // expected_local_type_name
-                      NULL,                        // expected_min_scale
-                      NULL,                        // expected_max_scale
+                      0,                           // expected_min_scale
+                      0,                           // expected_max_scale
                       SQL_DATETIME,                // expected_sql_data_type
-                      NULL,   // expected_sql_datetime_sub, driver returns NULL for Ver2
-                      NULL,   // expected_num_prec_radix
-                      NULL);  // expected_interval_prec
+                      0,                           // 0, driver
+                                                   // returns NULL for Ver2
+                      0,                           // expected_num_prec_radix
+                      0);                          // expected_interval_prec
 
   CheckSQLDescribeColODBCVer2(stmt);
 }
@@ -1121,16 +1113,16 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoBit) {
                       SQL_NULLABLE,          // expected_nullable
                       SQL_FALSE,             // expected_case_sensitive
                       SQL_SEARCHABLE,        // expected_searchable
-                      NULL,                  // expected_unsigned_attr
+                      0,                     // expected_unsigned_attr
                       SQL_FALSE,             // expected_fixed_prec_scale
-                      NULL,                  // expected_auto_unique_value
+                      0,                     // expected_auto_unique_value
                       std::wstring(L"bit"),  // expected_local_type_name
-                      NULL,                  // expected_min_scale
-                      NULL,                  // expected_max_scale
+                      0,                     // expected_min_scale
+                      0,                     // expected_max_scale
                       SQL_BIT,               // expected_sql_data_type
-                      NULL,                  // expected_sql_datetime_sub
-                      NULL,                  // expected_num_prec_radix
-                      NULL);                 // expected_interval_prec
+                      0,                     // expected_sql_datetime_sub
+                      0,                     // expected_num_prec_radix
+                      0);                    // expected_interval_prec
 
   CheckSQLDescribeColODBCVer3(stmt);
 
@@ -1156,14 +1148,14 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoTinyInt) {
                       SQL_SEARCHABLE,            // expected_searchable
                       SQL_FALSE,                 // expected_unsigned_attr
                       SQL_FALSE,                 // expected_fixed_prec_scale
-                      NULL,                      // expected_auto_unique_value
+                      0,                         // expected_auto_unique_value
                       std::wstring(L"tinyint"),  // expected_local_type_name
-                      NULL,                      // expected_min_scale
-                      NULL,                      // expected_max_scale
+                      0,                         // expected_min_scale
+                      0,                         // expected_max_scale
                       SQL_TINYINT,               // expected_sql_data_type
-                      NULL,                      // expected_sql_datetime_sub
-                      NULL,                      // expected_num_prec_radix
-                      NULL);                     // expected_interval_prec
+                      0,                         // expected_sql_datetime_sub
+                      0,                         // expected_num_prec_radix
+                      0);                        // expected_interval_prec
 
   CheckSQLDescribeColODBCVer3(stmt);
 
@@ -1189,14 +1181,14 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoBigInt) {
                       SQL_SEARCHABLE,           // expected_searchable
                       SQL_FALSE,                // expected_unsigned_attr
                       SQL_FALSE,                // expected_fixed_prec_scale
-                      NULL,                     // expected_auto_unique_value
+                      0,                        // expected_auto_unique_value
                       std::wstring(L"bigint"),  // expected_local_type_name
-                      NULL,                     // expected_min_scale
-                      NULL,                     // expected_max_scale
+                      0,                        // expected_min_scale
+                      0,                        // expected_max_scale
                       SQL_BIGINT,               // expected_sql_data_type
-                      NULL,                     // expected_sql_datetime_sub
-                      NULL,                     // expected_num_prec_radix
-                      NULL);                    // expected_interval_prec
+                      0,                        // expected_sql_datetime_sub
+                      0,                        // expected_num_prec_radix
+                      0);                       // expected_interval_prec
 
   CheckSQLDescribeColODBCVer3(stmt);
 
@@ -1220,16 +1212,16 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoLongVarbinary) {
                       SQL_NULLABLE,                    // expected_nullable
                       SQL_FALSE,                       // expected_case_sensitive
                       SQL_SEARCHABLE,                  // expected_searchable
-                      NULL,                            // expected_unsigned_attr
+                      0,                               // expected_unsigned_attr
                       SQL_FALSE,                       // expected_fixed_prec_scale
-                      NULL,                            // expected_auto_unique_value
+                      0,                               // expected_auto_unique_value
                       std::wstring(L"longvarbinary"),  // expected_local_type_name
-                      NULL,                            // expected_min_scale
-                      NULL,                            // expected_max_scale
+                      0,                               // expected_min_scale
+                      0,                               // expected_max_scale
                       SQL_LONGVARBINARY,               // expected_sql_data_type
-                      NULL,                            // expected_sql_datetime_sub
-                      NULL,                            // expected_num_prec_radix
-                      NULL);                           // expected_interval_prec
+                      0,                               // expected_sql_datetime_sub
+                      0,                               // expected_num_prec_radix
+                      0);                              // expected_interval_prec
 
   CheckSQLDescribeColODBCVer3(stmt);
 
@@ -1253,16 +1245,16 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoVarbinary) {
                       SQL_NULLABLE,                // expected_nullable
                       SQL_FALSE,                   // expected_case_sensitive
                       SQL_SEARCHABLE,              // expected_searchable
-                      NULL,                        // expected_unsigned_attr
+                      0,                           // expected_unsigned_attr
                       SQL_FALSE,                   // expected_fixed_prec_scale
-                      NULL,                        // expected_auto_unique_value
+                      0,                           // expected_auto_unique_value
                       std::wstring(L"varbinary"),  // expected_local_type_name
-                      NULL,                        // expected_min_scale
-                      NULL,                        // expected_max_scale
+                      0,                           // expected_min_scale
+                      0,                           // expected_max_scale
                       SQL_VARBINARY,               // expected_sql_data_type
-                      NULL,                        // expected_sql_datetime_sub
-                      NULL,                        // expected_num_prec_radix
-                      NULL);                       // expected_interval_prec
+                      0,                           // expected_sql_datetime_sub
+                      0,                           // expected_num_prec_radix
+                      0);                          // expected_interval_prec
 
   // No more data
   ASSERT_EQ(SQL_NO_DATA, SQLFetch(stmt));
@@ -1285,16 +1277,16 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoLongVarchar) {
                       SQL_NULLABLE,             // expected_nullable
                       SQL_FALSE,                // expected_case_sensitive
                       SQL_SEARCHABLE,           // expected_searchable
-                      NULL,                     // expected_unsigned_attr
+                      0,                        // expected_unsigned_attr
                       SQL_FALSE,                // expected_fixed_prec_scale
-                      NULL,                     // expected_auto_unique_value
+                      0,                        // expected_auto_unique_value
                       std::wstring(L"text"),    // expected_local_type_name
-                      NULL,                     // expected_min_scale
-                      NULL,                     // expected_max_scale
+                      0,                        // expected_min_scale
+                      0,                        // expected_max_scale
                       SQL_WLONGVARCHAR,         // expected_sql_data_type
-                      NULL,                     // expected_sql_datetime_sub
-                      NULL,                     // expected_num_prec_radix
-                      NULL);                    // expected_interval_prec
+                      0,                        // expected_sql_datetime_sub
+                      0,                        // expected_num_prec_radix
+                      0);                       // expected_interval_prec
 
   CheckSQLDescribeColODBCVer3(stmt);
 
@@ -1311,16 +1303,16 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoLongVarchar) {
                       SQL_NULLABLE,                  // expected_nullable
                       SQL_FALSE,                     // expected_case_sensitive
                       SQL_SEARCHABLE,                // expected_searchable
-                      NULL,                          // expected_unsigned_attr
+                      0,                             // expected_unsigned_attr
                       SQL_FALSE,                     // expected_fixed_prec_scale
-                      NULL,                          // expected_auto_unique_value
+                      0,                             // expected_auto_unique_value
                       std::wstring(L"longvarchar"),  // expected_local_type_name
-                      NULL,                          // expected_min_scale
-                      NULL,                          // expected_max_scale
+                      0,                             // expected_min_scale
+                      0,                             // expected_max_scale
                       SQL_WLONGVARCHAR,              // expected_sql_data_type
-                      NULL,                          // expected_sql_datetime_sub
-                      NULL,                          // expected_num_prec_radix
-                      NULL);                         // expected_interval_prec
+                      0,                             // expected_sql_datetime_sub
+                      0,                             // expected_num_prec_radix
+                      0);                            // expected_interval_prec
 
   CheckSQLDescribeColODBCVer3(stmt);
 
@@ -1345,16 +1337,16 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoChar) {
                       SQL_NULLABLE,             // expected_nullable
                       SQL_FALSE,                // expected_case_sensitive
                       SQL_SEARCHABLE,           // expected_searchable
-                      NULL,                     // expected_unsigned_attr
+                      0,                        // expected_unsigned_attr
                       SQL_FALSE,                // expected_fixed_prec_scale
-                      NULL,                     // expected_auto_unique_value
+                      0,                        // expected_auto_unique_value
                       std::wstring(L"char"),    // expected_local_type_name
-                      NULL,                     // expected_min_scale
-                      NULL,                     // expected_max_scale
+                      0,                        // expected_min_scale
+                      0,                        // expected_max_scale
                       SQL_WCHAR,                // expected_sql_data_type
-                      NULL,                     // expected_sql_datetime_sub
-                      NULL,                     // expected_num_prec_radix
-                      NULL);                    // expected_interval_prec
+                      0,                        // expected_sql_datetime_sub
+                      0,                        // expected_num_prec_radix
+                      0);                       // expected_interval_prec
 
   CheckSQLDescribeColODBCVer3(stmt);
 
@@ -1380,14 +1372,14 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoInteger) {
                       SQL_SEARCHABLE,            // expected_searchable
                       SQL_FALSE,                 // expected_unsigned_attr
                       SQL_FALSE,                 // expected_fixed_prec_scale
-                      NULL,                      // expected_auto_unique_value
+                      0,                         // expected_auto_unique_value
                       std::wstring(L"integer"),  // expected_local_type_name
-                      NULL,                      // expected_min_scale
-                      NULL,                      // expected_max_scale
+                      0,                         // expected_min_scale
+                      0,                         // expected_max_scale
                       SQL_INTEGER,               // expected_sql_data_type
-                      NULL,                      // expected_sql_datetime_sub
-                      NULL,                      // expected_num_prec_radix
-                      NULL);                     // expected_interval_prec
+                      0,                         // expected_sql_datetime_sub
+                      0,                         // expected_num_prec_radix
+                      0);                        // expected_interval_prec
 
   CheckSQLDescribeColODBCVer3(stmt);
 
@@ -1413,14 +1405,14 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoSmallInt) {
                       SQL_SEARCHABLE,             // expected_searchable
                       SQL_FALSE,                  // expected_unsigned_attr
                       SQL_FALSE,                  // expected_fixed_prec_scale
-                      NULL,                       // expected_auto_unique_value
+                      0,                          // expected_auto_unique_value
                       std::wstring(L"smallint"),  // expected_local_type_name
-                      NULL,                       // expected_min_scale
-                      NULL,                       // expected_max_scale
+                      0,                          // expected_min_scale
+                      0,                          // expected_max_scale
                       SQL_SMALLINT,               // expected_sql_data_type
-                      NULL,                       // expected_sql_datetime_sub
-                      NULL,                       // expected_num_prec_radix
-                      NULL);                      // expected_interval_prec
+                      0,                          // expected_sql_datetime_sub
+                      0,                          // expected_num_prec_radix
+                      0);                         // expected_interval_prec
 
   CheckSQLDescribeColODBCVer3(stmt);
 
@@ -1446,14 +1438,14 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoFloat) {
                       SQL_SEARCHABLE,          // expected_searchable
                       SQL_FALSE,               // expected_unsigned_attr
                       SQL_FALSE,               // expected_fixed_prec_scale
-                      NULL,                    // expected_auto_unique_value
+                      0,                       // expected_auto_unique_value
                       std::wstring(L"float"),  // expected_local_type_name
-                      NULL,                    // expected_min_scale
-                      NULL,                    // expected_max_scale
+                      0,                       // expected_min_scale
+                      0,                       // expected_max_scale
                       SQL_FLOAT,               // expected_sql_data_type
-                      NULL,                    // expected_sql_datetime_sub
-                      NULL,                    // expected_num_prec_radix
-                      NULL);                   // expected_interval_prec
+                      0,                       // expected_sql_datetime_sub
+                      0,                       // expected_num_prec_radix
+                      0);                      // expected_interval_prec
 
   CheckSQLDescribeColODBCVer3(stmt);
 
@@ -1479,14 +1471,14 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoDouble) {
                       SQL_SEARCHABLE,           // expected_searchable
                       SQL_FALSE,                // expected_unsigned_attr
                       SQL_FALSE,                // expected_fixed_prec_scale
-                      NULL,                     // expected_auto_unique_value
+                      0,                        // expected_auto_unique_value
                       std::wstring(L"double"),  // expected_local_type_name
-                      NULL,                     // expected_min_scale
-                      NULL,                     // expected_max_scale
+                      0,                        // expected_min_scale
+                      0,                        // expected_max_scale
                       SQL_DOUBLE,               // expected_sql_data_type
-                      NULL,                     // expected_sql_datetime_sub
-                      NULL,                     // expected_num_prec_radix
-                      NULL);                    // expected_interval_prec
+                      0,                        // expected_sql_datetime_sub
+                      0,                        // expected_num_prec_radix
+                      0);                       // expected_interval_prec
 
   CheckSQLDescribeColODBCVer3(stmt);
 
@@ -1506,14 +1498,14 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoDouble) {
                       SQL_SEARCHABLE,            // expected_searchable
                       SQL_FALSE,                 // expected_unsigned_attr
                       SQL_FALSE,                 // expected_fixed_prec_scale
-                      NULL,                      // expected_auto_unique_value
+                      0,                         // expected_auto_unique_value
                       std::wstring(L"numeric"),  // expected_local_type_name
-                      NULL,                      // expected_min_scale
-                      NULL,                      // expected_max_scale
+                      0,                         // expected_min_scale
+                      0,                         // expected_max_scale
                       SQL_DOUBLE,                // expected_sql_data_type
-                      NULL,                      // expected_sql_datetime_sub
-                      NULL,                      // expected_num_prec_radix
-                      NULL);                     // expected_interval_prec
+                      0,                         // expected_sql_datetime_sub
+                      0,                         // expected_num_prec_radix
+                      0);                        // expected_interval_prec
 
   CheckSQLDescribeColODBCVer3(stmt);
 
@@ -1540,14 +1532,14 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoVarchar) {
                       SQL_SEARCHABLE,            // expected_searchable
                       SQL_FALSE,                 // expected_unsigned_attr
                       SQL_FALSE,                 // expected_fixed_prec_scale
-                      NULL,                      // expected_auto_unique_value
+                      0,                         // expected_auto_unique_value
                       std::wstring(L"varchar"),  // expected_local_type_name
-                      NULL,                      // expected_min_scale
-                      NULL,                      // expected_max_scale
+                      0,                         // expected_min_scale
+                      0,                         // expected_max_scale
                       SQL_WVARCHAR,              // expected_sql_data_type
-                      NULL,                      // expected_sql_datetime_sub
-                      NULL,                      // expected_num_prec_radix
-                      NULL);                     // expected_interval_prec
+                      0,                         // expected_sql_datetime_sub
+                      0,                         // expected_num_prec_radix
+                      0);                        // expected_interval_prec
 
   CheckSQLDescribeColODBCVer3(stmt);
 
@@ -1573,14 +1565,14 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoSQLTypeDate) {
                       SQL_SEARCHABLE,         // expected_searchable
                       SQL_FALSE,              // expected_unsigned_attr
                       SQL_FALSE,              // expected_fixed_prec_scale
-                      NULL,                   // expected_auto_unique_value
+                      0,                      // expected_auto_unique_value
                       std::wstring(L"date"),  // expected_local_type_name
-                      NULL,                   // expected_min_scale
-                      NULL,                   // expected_max_scale
+                      0,                      // expected_min_scale
+                      0,                      // expected_max_scale
                       SQL_DATETIME,           // expected_sql_data_type
                       SQL_CODE_DATE,          // expected_sql_datetime_sub
-                      NULL,                   // expected_num_prec_radix
-                      NULL);                  // expected_interval_prec
+                      0,                      // expected_num_prec_radix
+                      0);                     // expected_interval_prec
 
   CheckSQLDescribeColODBCVer3(stmt);
 
@@ -1607,14 +1599,14 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoSQLDate) {
                       SQL_SEARCHABLE,         // expected_searchable
                       SQL_FALSE,              // expected_unsigned_attr
                       SQL_FALSE,              // expected_fixed_prec_scale
-                      NULL,                   // expected_auto_unique_value
+                      0,                      // expected_auto_unique_value
                       std::wstring(L"date"),  // expected_local_type_name
-                      NULL,                   // expected_min_scale
-                      NULL,                   // expected_max_scale
+                      0,                      // expected_min_scale
+                      0,                      // expected_max_scale
                       SQL_DATETIME,           // expected_sql_data_type
                       SQL_CODE_DATE,          // expected_sql_datetime_sub
-                      NULL,                   // expected_num_prec_radix
-                      NULL);                  // expected_interval_prec
+                      0,                      // expected_num_prec_radix
+                      0);                     // expected_interval_prec
 
   CheckSQLDescribeColODBCVer3(stmt);
 
@@ -1640,14 +1632,15 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoDateODBCVer2) {
                       SQL_SEARCHABLE,         // expected_searchable
                       SQL_FALSE,              // expected_unsigned_attr
                       SQL_FALSE,              // expected_fixed_prec_scale
-                      NULL,                   // expected_auto_unique_value
+                      0,                      // expected_auto_unique_value
                       std::wstring(L"date"),  // expected_local_type_name
-                      NULL,                   // expected_min_scale
-                      NULL,                   // expected_max_scale
+                      0,                      // expected_min_scale
+                      0,                      // expected_max_scale
                       SQL_DATETIME,           // expected_sql_data_type
-                      NULL,   // expected_sql_datetime_sub, driver returns NULL for Ver2
-                      NULL,   // expected_num_prec_radix
-                      NULL);  // expected_interval_prec
+                      0,                      // 0, driver
+                                              // returns NULL for Ver2
+                      0,                      // expected_num_prec_radix
+                      0);                     // expected_interval_prec
 
   CheckSQLDescribeColODBCVer2(stmt);
 
@@ -1685,14 +1678,14 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoSQLTypeTime) {
                       SQL_SEARCHABLE,         // expected_searchable
                       SQL_FALSE,              // expected_unsigned_attr
                       SQL_FALSE,              // expected_fixed_prec_scale
-                      NULL,                   // expected_auto_unique_value
+                      0,                      // expected_auto_unique_value
                       std::wstring(L"time"),  // expected_local_type_name
-                      NULL,                   // expected_min_scale
-                      NULL,                   // expected_max_scale
+                      0,                      // expected_min_scale
+                      0,                      // expected_max_scale
                       SQL_DATETIME,           // expected_sql_data_type
                       SQL_CODE_TIME,          // expected_sql_datetime_sub
-                      NULL,                   // expected_num_prec_radix
-                      NULL);                  // expected_interval_prec
+                      0,                      // expected_num_prec_radix
+                      0);                     // expected_interval_prec
 
   CheckSQLDescribeColODBCVer3(stmt);
 
@@ -1719,14 +1712,14 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoSQLTime) {
                       SQL_SEARCHABLE,         // expected_searchable
                       SQL_FALSE,              // expected_unsigned_attr
                       SQL_FALSE,              // expected_fixed_prec_scale
-                      NULL,                   // expected_auto_unique_value
+                      0,                      // expected_auto_unique_value
                       std::wstring(L"time"),  // expected_local_type_name
-                      NULL,                   // expected_min_scale
-                      NULL,                   // expected_max_scale
+                      0,                      // expected_min_scale
+                      0,                      // expected_max_scale
                       SQL_DATETIME,           // expected_sql_data_type
                       SQL_CODE_TIME,          // expected_sql_datetime_sub
-                      NULL,                   // expected_num_prec_radix
-                      NULL);                  // expected_interval_prec
+                      0,                      // expected_num_prec_radix
+                      0);                     // expected_interval_prec
 
   CheckSQLDescribeColODBCVer3(stmt);
 
@@ -1752,14 +1745,15 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoTimeODBCVer2) {
                       SQL_SEARCHABLE,         // expected_searchable
                       SQL_FALSE,              // expected_unsigned_attr
                       SQL_FALSE,              // expected_fixed_prec_scale
-                      NULL,                   // expected_auto_unique_value
+                      0,                      // expected_auto_unique_value
                       std::wstring(L"time"),  // expected_local_type_name
-                      NULL,                   // expected_min_scale
-                      NULL,                   // expected_max_scale
+                      0,                      // expected_min_scale
+                      0,                      // expected_max_scale
                       SQL_DATETIME,           // expected_sql_data_type
-                      NULL,   // expected_sql_datetime_sub, driver returns NULL for Ver2
-                      NULL,   // expected_num_prec_radix
-                      NULL);  // expected_interval_prec
+                      0,                      // 0, driver
+                                              // returns NULL for Ver2
+                      0,                      // expected_num_prec_radix
+                      0);                     // expected_interval_prec
 
   CheckSQLDescribeColODBCVer2(stmt);
 
@@ -1797,14 +1791,14 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoSQLTypeTimestamp) {
                       SQL_SEARCHABLE,              // expected_searchable
                       SQL_FALSE,                   // expected_unsigned_attr
                       SQL_FALSE,                   // expected_fixed_prec_scale
-                      NULL,                        // expected_auto_unique_value
+                      0,                           // expected_auto_unique_value
                       std::wstring(L"timestamp"),  // expected_local_type_name
-                      NULL,                        // expected_min_scale
-                      NULL,                        // expected_max_scale
+                      0,                           // expected_min_scale
+                      0,                           // expected_max_scale
                       SQL_DATETIME,                // expected_sql_data_type
                       SQL_CODE_TIMESTAMP,          // expected_sql_datetime_sub
-                      NULL,                        // expected_num_prec_radix
-                      NULL);                       // expected_interval_prec
+                      0,                           // expected_num_prec_radix
+                      0);                          // expected_interval_prec
 
   CheckSQLDescribeColODBCVer3(stmt);
 
@@ -1831,14 +1825,14 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoSQLTimestamp) {
                       SQL_SEARCHABLE,              // expected_searchable
                       SQL_FALSE,                   // expected_unsigned_attr
                       SQL_FALSE,                   // expected_fixed_prec_scale
-                      NULL,                        // expected_auto_unique_value
+                      0,                           // expected_auto_unique_value
                       std::wstring(L"timestamp"),  // expected_local_type_name
-                      NULL,                        // expected_min_scale
-                      NULL,                        // expected_max_scale
+                      0,                           // expected_min_scale
+                      0,                           // expected_max_scale
                       SQL_DATETIME,                // expected_sql_data_type
                       SQL_CODE_TIMESTAMP,          // expected_sql_datetime_sub
-                      NULL,                        // expected_num_prec_radix
-                      NULL);                       // expected_interval_prec
+                      0,                           // expected_num_prec_radix
+                      0);                          // expected_interval_prec
 
   CheckSQLDescribeColODBCVer3(stmt);
 
@@ -1864,14 +1858,14 @@ TEST_F(TypeInfoOdbcV2MockTest, TestSQLGetTypeInfoSQLTimestampODBCVer2) {
                       SQL_SEARCHABLE,              // expected_searchable
                       SQL_FALSE,                   // expected_unsigned_attr
                       SQL_FALSE,                   // expected_fixed_prec_scale
-                      NULL,                        // expected_auto_unique_value
+                      0,                           // expected_auto_unique_value
                       std::wstring(L"timestamp"),  // expected_local_type_name
-                      NULL,                        // expected_min_scale
-                      NULL,                        // expected_max_scale
+                      0,                           // expected_min_scale
+                      0,                           // expected_max_scale
                       SQL_DATETIME,                // expected_sql_data_type
-                      NULL,   // expected_sql_datetime_sub, driver returns NULL for Ver2
-                      NULL,   // expected_num_prec_radix
-                      NULL);  // expected_interval_prec
+                      0,   // expected_sql_datetime_sub, driver returns NULL for Ver2
+                      0,   // expected_num_prec_radix
+                      0);  // expected_interval_prec
 
   CheckSQLDescribeColODBCVer2(stmt);
 


### PR DESCRIPTION
### Rationale for this change
The test suite needs to be updated so it will build on Linux in addition to Windows & Mac.
Resolves https://github.com/apache/arrow/issues/49552

### What changes are included in this PR?
Miscellaneous changes to get the tests building on Linux.

### Are these changes tested?
Yes.

### Are there any user-facing changes?
No.
* GitHub Issue: #49552