### PR TITLE
GH-49671: [CI][Docs] Don't run jobs for push by Dependabot

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,12 +18,17 @@
 name: Docs
 
 on:
+  push:
+    branches:
+      - '**'
+      - '!dependabot/**'
+    tags:
+      - '**'
   pull_request:
     paths:
       - '.github/workflows/docs.yml'
       - 'cpp/apidoc/**'
       - 'docs/**'
-  push:
 
 permissions:
   contents: read


### PR DESCRIPTION
### Rationale for this change

We don't need to run the docs jobs for push by Dependabot because we can run them for PR by Dependabot. 

### What changes are included in this PR?

Add `on.push.branches` and `on.push.tags` to disable jobs for push by Dependabot.

### Are these changes tested?

No. But this will work because other workflows use this.

### Are there any user-facing changes?

No.
* GitHub Issue: #49671