### PR TITLE
GH-49252: [GLib] Deprecate Feather features

### DIFF
--- a/c_glib/arrow-glib/input-stream.h
+++ b/c_glib/arrow-glib/input-stream.h
@@ -180,7 +180,7 @@ garrow_gio_input_stream_new(GInputStream *gio_input_stream);
 
 #ifndef GARROW_DISABLE_DEPRECATED
 GARROW_AVAILABLE_IN_ALL
-G_GNUC_DEPRECATED
+GARROW_DEPRECATED
 GInputStream *
 garrow_gio_input_stream_get_raw(GArrowGIOInputStream *input_stream);
 #endif

--- a/c_glib/arrow-glib/output-stream.h
+++ b/c_glib/arrow-glib/output-stream.h
@@ -104,7 +104,7 @@ garrow_gio_output_stream_new(GOutputStream *gio_output_stream);
 
 #ifndef GARROW_DISABLE_DEPRECATED
 GARROW_AVAILABLE_IN_ALL
-G_GNUC_DEPRECATED
+GARROW_DEPRECATED
 GOutputStream *
 garrow_gio_output_stream_get_raw(GArrowGIOOutputStream *output_stream);
 #endif

--- a/c_glib/arrow-glib/reader.h
+++ b/c_glib/arrow-glib/reader.h
@@ -60,14 +60,14 @@ garrow_record_batch_reader_get_schema(GArrowRecordBatchReader *reader);
 
 #ifndef GARROW_DISABLE_DEPRECATED
 GARROW_AVAILABLE_IN_ALL
-G_GNUC_DEPRECATED_FOR(garrow_record_batch_reader_read_next)
+GARROW_DEPRECATED_FOR(garrow_record_batch_reader_read_next)
 GArrowRecordBatch *
 garrow_record_batch_reader_get_next_record_batch(GArrowRecordBatchReader *reader,
                                                  GError **error);
 #endif
 #ifndef GARROW_DISABLE_DEPRECATED
 GARROW_AVAILABLE_IN_ALL
-G_GNUC_DEPRECATED_FOR(garrow_record_batch_reader_read_next)
+GARROW_DEPRECATED_FOR(garrow_record_batch_reader_read_next)
 GArrowRecordBatch *
 garrow_record_batch_reader_read_next_record_batch(GArrowRecordBatchReader *reader,
                                                   GError **error);
@@ -153,7 +153,7 @@ garrow_record_batch_file_reader_get_version(GArrowRecordBatchFileReader *reader)
 
 #ifndef GARROW_DISABLE_DEPRECATED
 GARROW_AVAILABLE_IN_ALL
-G_GNUC_DEPRECATED_FOR(garrow_record_batch_file_reader_read_record_batch)
+GARROW_DEPRECATED_FOR(garrow_record_batch_file_reader_read_record_batch)
 GArrowRecordBatch *
 garrow_record_batch_file_reader_get_record_batch(GArrowRecordBatchFileReader *reader,
                                                  guint i,
@@ -183,18 +183,22 @@ struct _GArrowFeatherFileReaderClass
 };
 
 GARROW_AVAILABLE_IN_ALL
+GARROW_DEPRECATED_IN_24_0_FOR(garrow_record_batch_file_reader_new)
 GArrowFeatherFileReader *
 garrow_feather_file_reader_new(GArrowSeekableInputStream *file, GError **error);
 
 GARROW_AVAILABLE_IN_ALL
+GARROW_DEPRECATED_IN_24_0
 gint
 garrow_feather_file_reader_get_version(GArrowFeatherFileReader *reader);
 
 GARROW_AVAILABLE_IN_ALL
+GARROW_DEPRECATED_IN_24_0_FOR(garrow_record_batch_reader_read_all)
 GArrowTable *
 garrow_feather_file_reader_read(GArrowFeatherFileReader *reader, GError **error);
 
 GARROW_AVAILABLE_IN_ALL
+GARROW_DEPRECATED_IN_24_0
 GArrowTable *
 garrow_feather_file_reader_read_indices(GArrowFeatherFileReader *reader,
                                         const gint *indices,
@@ -202,6 +206,7 @@ garrow_feather_file_reader_read_indices(GArrowFeatherFileReader *reader,
                                         GError **error);
 
 GARROW_AVAILABLE_IN_ALL
+GARROW_DEPRECATED_IN_24_0
 GArrowTable *
 garrow_feather_file_reader_read_names(GArrowFeatherFileReader *reader,
                                       const gchar **names,

--- a/c_glib/arrow-glib/table.h
+++ b/c_glib/arrow-glib/table.h
@@ -163,10 +163,12 @@ struct _GArrowFeatherWritePropertiesClass
 };
 
 GARROW_AVAILABLE_IN_0_17
+GARROW_DEPRECATED_IN_24_0_FOR(garrow_write_options_new)
 GArrowFeatherWriteProperties *
 garrow_feather_write_properties_new(void);
 
 GARROW_AVAILABLE_IN_0_17
+GARROW_DEPRECATED_IN_24_0_FOR(garrow_record_batch_file_writer_new)
 gboolean
 garrow_table_write_as_feather(GArrowTable *table,
                               GArrowOutputStream *sink,


### PR DESCRIPTION
### Rationale for this change

We'll deprecate Feather V1 reader/writer. See also the discussion at https://lists.apache.org/thread/1npvnhjb1xwz09zh8vnd079zt2q4o08l .

We can use IPC file reader/writer for Feather V2.

### What changes are included in this PR?

* Add deprecation warnings to Feather features.
* Use `GARROW_DEPRECATED()`/`GARROW_DEPRECATED_FOR()` instead of `G_GNUC_DEPRECATED()`/`G_GNUC_DEPRECATED_FOR()`.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

Yes.
* GitHub Issue: #49252