### PR TITLE
GH-49586: [C++][CI] StructToStructSubset test failure with libc++ 22.1.1

### DIFF
--- a/cpp/src/arrow/compute/kernels/scalar_cast_nested.cc
+++ b/cpp/src/arrow/compute/kernels/scalar_cast_nested.cc
@@ -346,11 +346,13 @@ struct CastStruct {
     for (int out_field_index = 0; out_field_index < out_field_count; ++out_field_index) {
       const auto& out_field = out_type.field(out_field_index);
 
-      // Take the first field with matching name, if any. Extract it from the map so it
-      // can't be reused.
-      auto maybe_in_field_index = in_fields.extract(out_field->name());
-      if (!maybe_in_field_index.empty()) {
-        fields_to_select[out_field_index] = maybe_in_field_index.mapped();
+      // Take the first field with matching name, if any. Erase it from the map so it
+      // can't be reused. Use lower_bound (which guarantees first-match) instead of
+      // find/extract (which do not guarantee first for duplicate keys).
+      auto it = in_fields.lower_bound(out_field->name());
+      if (it != in_fields.end() && it->first == out_field->name()) {
+        fields_to_select[out_field_index] = it->second;
+        in_fields.erase(it);
       } else if (out_field->nullable()) {
         fields_to_select[out_field_index] = kFillNullSentinel;
       } else {


### PR DESCRIPTION
### Rationale for this change
Fixes #49586

`std::multimap::extract(key)` does not guarantee returning the first element when there are duplicate keys.

### What changes are included in this PR?
Replace extract(key) with lower_bound(key) plus erase(iterator). `lower_bound` guarantees first matching element, then read `it->second` and then `erase` the node (`extract` is not needed as the node isn't reused here).

### Are these changes tested?
Yes, CI jobs are passing.

### Are there any user-facing changes?
No.
* GitHub Issue: #49586