### PR TITLE
GH-49651: [C++][FlightRPC] Fix ODBC Linux test segmentation fault

### DIFF
--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -414,7 +414,7 @@ jobs:
       needs.check-labels.outputs.force == 'true' ||
       contains(fromJSON(needs.check-labels.outputs.ci-extra-labels || '[]'), 'CI: Extra') ||
       contains(fromJSON(needs.check-labels.outputs.ci-extra-labels || '[]'), 'CI: Extra: C++')
-    timeout-minutes: 75
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:

--- a/compose.yaml
+++ b/compose.yaml
@@ -516,6 +516,8 @@ services:
       ARROW_PARQUET: "OFF"
       ARROW_S3: "OFF"
       ARROW_SUBSTRAIT: "OFF"
+      # GH-49651 Link ODBC tests statically on Linux to fix segfault
+      ARROW_TEST_LINKAGE: "static"
     # Register ODBC before running tests
     command: >
       /bin/bash -c "

--- a/compose.yaml
+++ b/compose.yaml
@@ -516,8 +516,6 @@ services:
       ARROW_PARQUET: "OFF"
       ARROW_S3: "OFF"
       ARROW_SUBSTRAIT: "OFF"
-      # GH-49651 Link ODBC tests statically on Linux to fix segfault
-      ARROW_TEST_LINKAGE: "static"
     # Register ODBC before running tests
     command: >
       /bin/bash -c "

--- a/cpp/src/arrow/flight/sql/odbc/tests/CMakeLists.txt
+++ b/cpp/src/arrow/flight/sql/odbc/tests/CMakeLists.txt
@@ -42,6 +42,7 @@ set(ARROW_FLIGHT_SQL_ODBC_TEST_SRCS
     # GH-46889: move protobuf_test_util to a more common location
     ../../../../engine/substrait/protobuf_test_util.cc)
 
+# GH-49652: TODO support static test linkage on macOS
 if(ARROW_TEST_LINKAGE STREQUAL "static")
   set(ARROW_FLIGHT_SQL_ODBC_TEST_LINK_LIBS arrow_flight_sql_odbc_static
                                            ${ARROW_TEST_STATIC_LINK_LIBS})
@@ -65,6 +66,13 @@ else()
   # Unix
   list(APPEND ARROW_FLIGHT_SQL_ODBC_TEST_STATIC_LINK_LIBS
        ${ARROW_FLIGHT_SQL_ODBC_TEST_LIBS} ${ARROW_FLIGHT_SQL_ODBC_TEST_LINK_LIBS})
+
+  if(NOT APPLE)
+    # Links static dependencies on Linux to support ARROW_TEST_LINKAGE=static
+    list(APPEND ARROW_FLIGHT_SQL_ODBC_TEST_STATIC_LINK_LIBS arrow_odbc_spi_impl
+         ${ARROW_PROTOBUF_LIBPROTOBUF})
+  endif()
+
 endif()
 
 add_arrow_test(flight_sql_odbc_test

--- a/cpp/src/arrow/flight/sql/odbc/tests/CMakeLists.txt
+++ b/cpp/src/arrow/flight/sql/odbc/tests/CMakeLists.txt
@@ -42,13 +42,14 @@ set(ARROW_FLIGHT_SQL_ODBC_TEST_SRCS
     # GH-46889: move protobuf_test_util to a more common location
     ../../../../engine/substrait/protobuf_test_util.cc)
 
-# GH-49652: TODO support static test linkage on macOS
-if(ARROW_TEST_LINKAGE STREQUAL "static")
-  set(ARROW_FLIGHT_SQL_ODBC_TEST_LINK_LIBS arrow_flight_sql_odbc_static
-                                           ${ARROW_TEST_STATIC_LINK_LIBS})
-else()
+# GH-49651 Link ODBC tests statically on Linux and dynamically on macOS/Windows
+if(WIN32 OR APPLE)
   set(ARROW_FLIGHT_SQL_ODBC_TEST_LINK_LIBS arrow_flight_sql_odbc_shared
                                            ${ARROW_TEST_SHARED_LINK_LIBS})
+else()
+  # GH-49651 Link ODBC tests statically on Linux to fix segfault
+  set(ARROW_FLIGHT_SQL_ODBC_TEST_LINK_LIBS arrow_flight_sql_odbc_static
+                                           ${ARROW_TEST_STATIC_LINK_LIBS})
 endif()
 
 # On macOS, link `ODBCINST` first to ensure iodbc take precedence over unixodbc


### PR DESCRIPTION
### Rationale for this change
GH-49651

### What changes are included in this PR?
- On Linux, change to use static test linking for ODBC only

Note: enabling Linux test build will be in a separate PR

### Are these changes tested?
Tested on local machine and in our local repository 

### Are there any user-facing changes?
N/A
* GitHub Issue: #49651