### PR TITLE
GH-48068: [C++][FlightRPC] Linux ODBC: Configure Dremio instance to allow remote testing

### DIFF
--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -394,17 +394,21 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
           submodules: recursive
-      - name: Restore Docker Volumes
-        uses: apache/infrastructure-actions/stash/restore@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
-        with:
-          path: .docker
-          key: ubuntu-cpp-odbc
       - name: Setup Python on hosted runner
         uses: actions/setup-python@v6
         with:
           python-version: 3
       - name: Setup Archery
         run: python3 -m pip install -e dev/archery[docker]
+      - name: Set Up Dremio Instance
+        run: |
+          docker compose up -d dremio
+          cpp/src/arrow/flight/sql/odbc/tests/dremio/set_up_dremio_instance.sh
+      - name: Restore Docker Volumes
+        uses: apache/infrastructure-actions/stash/restore@0ba14156c9f4c3cfbe4b0c9f36339ab0f8d81e53
+        with:
+          path: .docker
+          key: ubuntu-cpp-odbc
       - name: Execute Docker Build
         env:
           ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -350,6 +350,7 @@ repos:
           ?^cpp/src/arrow/flight/sql/odbc/install/mac/postinstall$|
           ?^cpp/src/arrow/flight/sql/odbc/install/unix/install_odbc\.sh$|
           ?^cpp/src/arrow/flight/sql/odbc/install/unix/install_odbc_ini\.sh$|
+          ?^cpp/src/arrow/flight/sql/odbc/tests/dremio/set_up_dremio_instance\.sh$|
           ?^dev/release/05-binary-upload\.sh$|
           ?^dev/release/07-flightsqlodbc-upload\.sh$|
           ?^dev/release/09-binary-verify\.sh$|

--- a/compose.yaml
+++ b/compose.yaml
@@ -135,6 +135,7 @@ x-hierarchy:
       - debian-ruby
     - debian-python:
       - debian-docs
+  - dremio
   - fedora-cpp:
     - fedora-python
   - fedora-r-clang
@@ -372,6 +373,21 @@ services:
         /arrow/ci/scripts/cpp_build.sh /arrow /build &&
         /arrow/ci/scripts/cpp_test.sh /arrow /build"
 
+  dremio:
+    platform: linux/x86_64
+    image: dremio/dremio-oss:26.0.0
+    ports:
+      - 9047:9047  # REST API
+      - 31010:31010  # JDBC/ODBC
+      - 32010:32010
+    environment:
+      - "DREMIO_JAVA_SERVER_EXTRA_OPTS=-Dsaffron.default.charset=UTF-8 -Dsaffron.default.nationalcharset=UTF-8 -Dsaffron.default.collation.name=UTF-8$$en_US"
+    healthcheck:
+      test: curl --fail http://localhost:9047 || exit 1
+      interval: 10s
+      timeout: 5s
+      retries: 30
+
   ubuntu-cpp: &ubuntu-cpp-base
     # Usage:
     #   docker compose build ubuntu-cpp
@@ -510,6 +526,7 @@ services:
       ARROW_DEPENDENCY_SOURCE: BUNDLED
       ARROW_DEPENDENCY_USE_SHARED: "OFF"
       ARROW_FLIGHT_SQL_ODBC: "ON"
+      ARROW_FLIGHT_SQL_ODBC_CONN: "driver={Apache Arrow Flight SQL ODBC Driver};HOST=dremio;port=32010;pwd=admin2025;uid=admin;useEncryption=false;UseWideChar=true;"
       ARROW_GANDIVA: "OFF"
       ARROW_GCS: "OFF"
       ARROW_HDFS: "OFF"
@@ -518,6 +535,9 @@ services:
       ARROW_S3: "OFF"
       ARROW_SUBSTRAIT: "OFF"
     # Register ODBC before running tests
+    depends_on:
+      dremio:
+         condition: service_healthy
     command: >
       /bin/bash -c "
         /arrow/ci/scripts/cpp_build.sh /arrow /build &&

--- a/compose.yaml
+++ b/compose.yaml
@@ -383,7 +383,7 @@ services:
     environment:
       - "DREMIO_JAVA_SERVER_EXTRA_OPTS=-Dsaffron.default.charset=UTF-8 -Dsaffron.default.nationalcharset=UTF-8 -Dsaffron.default.collation.name=UTF-8$$en_US"
     healthcheck:
-      test: curl --fail http://localhost:9047 || exit 1
+      test: curl --fail http://localhost:9047
       interval: 10s
       timeout: 5s
       retries: 30

--- a/cpp/src/arrow/flight/sql/odbc/tests/dremio/set_up_dremio_instance.sh
+++ b/cpp/src/arrow/flight/sql/odbc/tests/dremio/set_up_dremio_instance.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -euo pipefail
+
+HOST_URL="http://localhost:9047"
+NEW_USER_URL="$HOST_URL/apiv2/bootstrap/firstuser"
+LOGIN_URL="$HOST_URL/apiv2/login"
+SQL_URL="$HOST_URL/api/v3/sql"
+
+ADMIN_USER="admin"
+ADMIN_PASSWORD="admin2025"
+
+MAX_WAIT_ATTEMPTS=60
+WAIT_INTERVAL_SECONDS=5
+
+# Wait for Dremio to be available.
+attempt=1
+until status_code="$(
+    curl --silent \
+         --output /dev/null \
+         --write-out '%{http_code}' \
+         "$NEW_USER_URL"
+)"; [[ "$status_code" == "200" || "$status_code" == "404" || "$status_code" == "405" ]]; do
+
+    if [[ "$attempt" -ge "$MAX_WAIT_ATTEMPTS" ]]; then
+        echo "Timed out waiting for Dremio to start." >&2
+        exit 1
+    fi
+
+    echo "Waiting for Dremio to start... HTTP $status_code"
+    attempt=$((attempt + 1))
+    sleep "$WAIT_INTERVAL_SECONDS"
+done
+
+echo ""
+echo "Creating admin user..."
+
+# Create new admin account.
+curl --fail --silent --show-error \
+     -X PUT "$NEW_USER_URL" \
+     -H "Content-Type: application/json" \
+     -d "$(python3 - <<EOF
+import json
+print(json.dumps({
+    "userName": "$ADMIN_USER",
+    "password": "$ADMIN_PASSWORD"
+}))
+EOF
+)"
+
+echo ""
+echo "Created admin user."
+
+echo "Logging in as admin user..."
+
+# Login and capture response body.
+LOGIN_RESPONSE="$(curl --fail --silent --show-error \
+     -X POST "$LOGIN_URL" \
+     -H "Content-Type: application/json" \
+     -d "$(python3 - <<EOF
+import json
+print(json.dumps({
+    "userName": "$ADMIN_USER",
+    "password": "$ADMIN_PASSWORD"
+}))
+EOF
+)")"
+
+# Extract token safely using Python JSON parsing.
+TOKEN="$(python3 - <<EOF
+import json
+import sys
+
+try:
+    response = json.loads("""$LOGIN_RESPONSE""")
+except json.JSONDecodeError as exc:
+    print(f"Failed to parse login response JSON: {exc}", file=sys.stderr)
+    sys.exit(1)
+
+token = response.get("token")
+
+if not token:
+    print("Login response did not contain a token.", file=sys.stderr)
+    sys.exit(1)
+
+print(token)
+EOF
+)"
+
+SQL_QUERY="
+Create Table \$scratch.ODBCTest As
+  SELECT CAST(2147483647 AS INTEGER) AS sinteger_max,
+         CAST(9223372036854775807 AS BIGINT) AS sbigint_max,
+         CAST(999999999 AS DECIMAL(38,0)) AS decimal_positive,
+         CAST(3.40282347E38 AS FLOAT) AS float_max,
+         CAST(1.7976931348623157E308 AS DOUBLE) AS double_max,
+         CAST(true AS BOOLEAN) AS bit_true,
+         CAST(DATE '9999-12-31' AS DATE) AS date_max,
+         CAST(TIME '23:59:59' AS TIME) AS time_max,
+         CAST(TIMESTAMP '9999-12-31 23:59:59' AS TIMESTAMP) AS timestamp_max;
+"
+
+echo "Creating \$scratch.ODBCTest table."
+
+# Create a new table by sending a SQL query.
+curl --fail --silent --show-error \
+     -X POST "$SQL_URL" \
+     -H "Authorization: _dremio$TOKEN" \
+     -H "Content-Type: application/json" \
+     -d "$(python3 - <<EOF
+import json
+print(json.dumps({"sql": """$SQL_QUERY"""}))
+EOF
+)"
+
+echo ""
+echo "Finished setting up dremio docker instance."


### PR DESCRIPTION
### Rationale for this change

The goal is to run remote tests against the Dremio instance on Ubuntu-latest runner, as Dremio docker instances are only available on Linux and they are not supported on macOS/Windows GitHub Actions.

### What changes are included in this PR?

- Added `dremio` to `compose.yaml`.
- Added logic for setting up dremio account and creating a table in `cpp/src/arrow/flight/sql/odbc/tests/dremio/set_up_dremio_instance.sh`.
- Add ODBC remote test connection variable `ARROW_FLIGHT_SQL_ODBC_CONN`.
- set up Dremio remote instance in CI

Note: This PR prepares the Dremio instance for remote testing, which is activated using `ARROW_FLIGHT_SQL_ODBC_CONN={..., HOST=dremio`.

### Are these changes tested?

Tested in CI at local repository. 

### Are there any user-facing changes?
N/A

* GitHub Issue: #48068