### PR TITLE
GH-49700: [R][CI][Dev] Use air precommit hook

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -64,8 +64,6 @@ jobs:
             ~/.cache/pre-commit
             ~/.local/share/renv/cache
           key: pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
-      - name: Install Air
-        uses: posit-dev/setup-air@63e80dedb6d275c94a3841e15e5ff8691e1ab237 # v1.0.0
       - name: Run pre-commit
         run: |
           pre-commit run --all-files --color=always --show-diff-on-failure

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -209,8 +209,6 @@ repos:
       - id: air-format
         alias: r
         name: R Format (Air)
-        files: >-
-            ^r/.*\.R$
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v18.1.8
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -203,13 +203,12 @@ repos:
         pass_filenames: false
         files: >-
           ^r/.*\.(R|Rmd)$
-  - repo: local
+  - repo: https://github.com/posit-dev/air-pre-commit
+    rev: 0.8.2
     hooks:
       - id: air-format
         alias: r
         name: R Format (Air)
-        language: system
-        entry: air format r --check
         files: >-
             ^r/.*\.R$
   - repo: https://github.com/pre-commit/mirrors-clang-format


### PR DESCRIPTION
### Rationale for this change

Simplifies setup of the R formatter air for local devs and in CI by moving from explicitly managed air to using a new official pre-commit hook.

### What changes are included in this PR?

Replace local hook with https://github.com/posit-dev/air-pre-commit.

### Are these changes tested?

Yes, locally.

### Are there any user-facing changes?

No.
* GitHub Issue: #49700