### PR TITLE
GH-49706 [C++][Parquet] Make writing of `path_in_schema` optional

### DIFF
--- a/cpp/src/generated/parquet_types.cpp
+++ b/cpp/src/generated/parquet_types.cpp
@@ -3946,6 +3946,7 @@ void ColumnMetaData::__set_encodings(const std::vector<Encoding::type> & val) {
 
 void ColumnMetaData::__set_path_in_schema(const std::vector<std::string> & val) {
   this->path_in_schema = val;
+__isset.path_in_schema = true;
 }
 
 void ColumnMetaData::__set_codec(const CompressionCodec::type val) {
@@ -4047,7 +4048,9 @@ bool ColumnMetaData::operator==(const ColumnMetaData & rhs) const
     return false;
   if (!(encodings == rhs.encodings))
     return false;
-  if (!(path_in_schema == rhs.path_in_schema))
+  if (__isset.path_in_schema != rhs.__isset.path_in_schema)
+    return false;
+  else if (__isset.path_in_schema && !(path_in_schema == rhs.path_in_schema))
     return false;
   if (!(codec == rhs.codec))
     return false;
@@ -4185,7 +4188,7 @@ void ColumnMetaData::printTo(std::ostream& out) const {
   out << "ColumnMetaData(";
   out << "type=" << to_string(type);
   out << ", " << "encodings=" << to_string(encodings);
-  out << ", " << "path_in_schema=" << to_string(path_in_schema);
+  out << ", " << "path_in_schema="; (__isset.path_in_schema ? (out << to_string(path_in_schema)) : (out << "<null>"));
   out << ", " << "codec=" << to_string(codec);
   out << ", " << "num_values=" << to_string(num_values);
   out << ", " << "total_uncompressed_size=" << to_string(total_uncompressed_size);

--- a/cpp/src/generated/parquet_types.h
+++ b/cpp/src/generated/parquet_types.h
@@ -2688,7 +2688,8 @@ void swap(PageEncodingStats &a, PageEncodingStats &b);
 std::ostream& operator<<(std::ostream& out, const PageEncodingStats& obj);
 
 typedef struct _ColumnMetaData__isset {
-  _ColumnMetaData__isset() : key_value_metadata(false), index_page_offset(false), dictionary_page_offset(false), statistics(false), encoding_stats(false), bloom_filter_offset(false), bloom_filter_length(false), size_statistics(false), geospatial_statistics(false) {}
+  _ColumnMetaData__isset() : path_in_schema(false), key_value_metadata(false), index_page_offset(false), dictionary_page_offset(false), statistics(false), encoding_stats(false), bloom_filter_offset(false), bloom_filter_length(false), size_statistics(false), geospatial_statistics(false) {}
+  bool path_in_schema :1;
   bool key_value_metadata :1;
   bool index_page_offset :1;
   bool dictionary_page_offset :1;

--- a/cpp/src/generated/parquet_types.tcc
+++ b/cpp/src/generated/parquet_types.tcc
@@ -3319,7 +3319,6 @@ uint32_t ColumnMetaData::read(Protocol_* iprot) {
 
   bool isset_type = false;
   bool isset_encodings = false;
-  bool isset_path_in_schema = false;
   bool isset_codec = false;
   bool isset_num_values = false;
   bool isset_total_uncompressed_size = false;
@@ -3381,7 +3380,7 @@ uint32_t ColumnMetaData::read(Protocol_* iprot) {
             }
             xfer += iprot->readListEnd();
           }
-          isset_path_in_schema = true;
+          this->__isset.path_in_schema = true;
         } else {
           xfer += iprot->skip(ftype);
         }
@@ -3537,8 +3536,6 @@ uint32_t ColumnMetaData::read(Protocol_* iprot) {
     throw TProtocolException(TProtocolException::INVALID_DATA);
   if (!isset_encodings)
     throw TProtocolException(TProtocolException::INVALID_DATA);
-  if (!isset_path_in_schema)
-    throw TProtocolException(TProtocolException::INVALID_DATA);
   if (!isset_codec)
     throw TProtocolException(TProtocolException::INVALID_DATA);
   if (!isset_num_values)
@@ -3574,18 +3571,19 @@ uint32_t ColumnMetaData::write(Protocol_* oprot) const {
   }
   xfer += oprot->writeFieldEnd();
 
-  xfer += oprot->writeFieldBegin("path_in_schema", ::apache::thrift::protocol::T_LIST, 3);
-  {
-    xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->path_in_schema.size()));
-    std::vector<std::string> ::const_iterator _iter222;
-    for (_iter222 = this->path_in_schema.begin(); _iter222 != this->path_in_schema.end(); ++_iter222)
+  if (this->__isset.path_in_schema) {
+    xfer += oprot->writeFieldBegin("path_in_schema", ::apache::thrift::protocol::T_LIST, 3);
     {
-      xfer += oprot->writeString((*_iter222));
+      xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->path_in_schema.size()));
+      std::vector<std::string> ::const_iterator _iter222;
+      for (_iter222 = this->path_in_schema.begin(); _iter222 != this->path_in_schema.end(); ++_iter222)
+      {
+        xfer += oprot->writeString((*_iter222));
+      }
+      xfer += oprot->writeListEnd();
     }
-    xfer += oprot->writeListEnd();
+    xfer += oprot->writeFieldEnd();
   }
-  xfer += oprot->writeFieldEnd();
-
   xfer += oprot->writeFieldBegin("codec", ::apache::thrift::protocol::T_I32, 4);
   xfer += oprot->writeI32(static_cast<int32_t>(this->codec));
   xfer += oprot->writeFieldEnd();

--- a/cpp/src/parquet/metadata.cc
+++ b/cpp/src/parquet/metadata.cc
@@ -1824,7 +1824,9 @@ class ColumnChunkMetaDataBuilder::ColumnChunkMetaDataBuilderImpl {
     column_chunk_ = column_chunk;
 
     column_chunk_->meta_data.__set_type(ToThrift(column_->physical_type()));
-    column_chunk_->meta_data.__set_path_in_schema(column_->path()->ToDotVector());
+    if (properties_->write_path_in_schema()) {
+      column_chunk_->meta_data.__set_path_in_schema(column_->path()->ToDotVector());
+    }
     column_chunk_->meta_data.__set_codec(
         ToThrift(properties_->compression(column_->path())));
   }

--- a/cpp/src/parquet/metadata.cc
+++ b/cpp/src/parquet/metadata.cc
@@ -518,6 +518,10 @@ Type::type ColumnChunkMetaData::type() const { return impl_->type(); }
 
 int64_t ColumnChunkMetaData::num_values() const { return impl_->num_values(); }
 
+bool ColumnChunkMetaData::is_path_in_schema_set() const {
+  return impl_->is_path_in_schema_set();
+}
+
 std::shared_ptr<schema::ColumnPath> ColumnChunkMetaData::path_in_schema() const {
   return impl_->path_in_schema();
 }

--- a/cpp/src/parquet/metadata.cc
+++ b/cpp/src/parquet/metadata.cc
@@ -321,8 +321,18 @@ class ColumnChunkMetaData::ColumnChunkMetaDataImpl {
 
   inline int64_t num_values() const { return column_metadata_->num_values; }
 
+  inline bool is_path_in_schema_set() const {
+    const std::lock_guard<std::mutex> guard(stats_mutex_);
+    if (possible_path_in_schema_ == nullptr && column_metadata_->__isset.path_in_schema) {
+      possible_path_in_schema_ =
+          std::make_shared<schema::ColumnPath>(column_metadata_->path_in_schema);
+    }
+
+    return possible_path_in_schema_ != nullptr;
+  }
+
   std::shared_ptr<schema::ColumnPath> path_in_schema() {
-    return std::make_shared<schema::ColumnPath>(column_metadata_->path_in_schema);
+    return is_path_in_schema_set() ? possible_path_in_schema_ : nullptr;
   }
 
   // Check if statistics are set and are valid
@@ -464,6 +474,7 @@ class ColumnChunkMetaData::ColumnChunkMetaDataImpl {
   mutable std::shared_ptr<EncodedStatistics> possible_encoded_stats_;
   mutable std::shared_ptr<Statistics> possible_stats_;
   mutable std::shared_ptr<geospatial::GeoStatistics> possible_geo_stats_;
+  mutable std::shared_ptr<schema::ColumnPath> possible_path_in_schema_;
   std::vector<Encoding::type> encodings_;
   std::vector<PageEncodingStats> encoding_stats_;
   const format::ColumnChunk* column_;

--- a/cpp/src/parquet/metadata.h
+++ b/cpp/src/parquet/metadata.h
@@ -131,6 +131,7 @@ class PARQUET_EXPORT ColumnChunkMetaData {
   // column metadata
   Type::type type() const;
   int64_t num_values() const;
+  bool is_path_in_schema_set() const;
   std::shared_ptr<schema::ColumnPath> path_in_schema() const;
   bool is_stats_set() const;
   bool is_geo_stats_set() const;

--- a/cpp/src/parquet/metadata_test.cc
+++ b/cpp/src/parquet/metadata_test.cc
@@ -152,6 +152,8 @@ TEST(Metadata, TestBuildAccess) {
 
     auto rg1_column1 = rg1_accessor->ColumnChunk(0);
     auto rg1_column2 = rg1_accessor->ColumnChunk(1);
+    ASSERT_EQ(true, rg1_column1->is_path_in_schema_set());
+    ASSERT_EQ(true, rg1_column2->is_path_in_schema_set());
     ASSERT_EQ(true, rg1_column1->is_stats_set());
     ASSERT_EQ(true, rg1_column2->is_stats_set());
     ASSERT_EQ(stats_float.min(), rg1_column2->statistics()->EncodeMin());
@@ -203,6 +205,8 @@ TEST(Metadata, TestBuildAccess) {
 
     auto rg2_column1 = rg2_accessor->ColumnChunk(0);
     auto rg2_column2 = rg2_accessor->ColumnChunk(1);
+    ASSERT_EQ(true, rg2_column1->is_path_in_schema_set());
+    ASSERT_EQ(true, rg2_column2->is_path_in_schema_set());
     ASSERT_EQ(true, rg2_column1->is_stats_set());
     ASSERT_EQ(true, rg2_column2->is_stats_set());
     ASSERT_EQ(stats_float.min(), rg2_column2->statistics()->EncodeMin());
@@ -468,6 +472,70 @@ TEST(Metadata, TestSortingColumns) {
   auto* row_group_read_metadata = row_group_reader->metadata();
   ASSERT_NE(nullptr, row_group_read_metadata);
   EXPECT_EQ(sorting_columns, row_group_read_metadata->sorting_columns());
+}
+
+TEST(Metadata, TestWritePathInSchema) {
+  parquet::schema::NodeVector fields;
+  parquet::schema::NodePtr root;
+  parquet::SchemaDescriptor schema;
+
+  WriterProperties::Builder prop_builder;
+
+  std::shared_ptr<WriterProperties> props =
+      prop_builder.version(ParquetVersion::PARQUET_2_6)
+          ->disable_write_path_in_schema()
+          ->build();
+
+  fields.push_back(parquet::schema::Int32("int_col", Repetition::REQUIRED));
+  fields.push_back(parquet::schema::Float("float_col", Repetition::REQUIRED));
+  root = parquet::schema::GroupNode::Make("schema", Repetition::REPEATED, fields);
+  schema.Init(root);
+
+  int64_t nrows = 1000;
+  int32_t int_min = 100, int_max = 200;
+  EncodedStatistics stats_int;
+  stats_int.set_null_count(0)
+      .set_distinct_count(nrows)
+      .set_min(std::string(reinterpret_cast<const char*>(&int_min), 4))
+      .set_max(std::string(reinterpret_cast<const char*>(&int_max), 4));
+  EncodedStatistics stats_float;
+  float float_min = 100.100f, float_max = 200.200f;
+  stats_float.set_null_count(0)
+      .set_distinct_count(nrows)
+      .set_min(std::string(reinterpret_cast<const char*>(&float_min), 4))
+      .set_max(std::string(reinterpret_cast<const char*>(&float_max), 4));
+
+  // Generate the metadata
+  auto f_accessor = GenerateTableMetaData(schema, props, nrows, stats_int, stats_float);
+
+  std::string f_accessor_serialized_metadata = f_accessor->SerializeToString();
+  uint32_t expected_len = static_cast<uint32_t>(f_accessor_serialized_metadata.length());
+
+  // decoded_len is an in-out parameter
+  uint32_t decoded_len = expected_len;
+  auto f_accessor_copy =
+      FileMetaData::Make(f_accessor_serialized_metadata.data(), &decoded_len);
+
+  // Check that all of the serialized data is consumed
+  ASSERT_EQ(expected_len, decoded_len);
+
+  // Run this block twice, one for f_accessor, one for f_accessor_copy.
+  // To make sure SerializedMetadata was deserialized correctly.
+  std::vector<FileMetaData*> f_accessors = {f_accessor.get(), f_accessor_copy.get()};
+  for (int loop_index = 0; loop_index < 2; loop_index++) {
+    // path_in_schema should not be present
+    auto rg1_accessor = f_accessors[loop_index]->RowGroup(0);
+    auto rg1_column1 = rg1_accessor->ColumnChunk(0);
+    auto rg1_column2 = rg1_accessor->ColumnChunk(1);
+    ASSERT_EQ(false, rg1_column1->is_path_in_schema_set());
+    ASSERT_EQ(false, rg1_column2->is_path_in_schema_set());
+
+    auto rg2_accessor = f_accessors[loop_index]->RowGroup(1);
+    auto rg2_column1 = rg2_accessor->ColumnChunk(0);
+    auto rg2_column2 = rg2_accessor->ColumnChunk(1);
+    ASSERT_EQ(false, rg2_column1->is_path_in_schema_set());
+    ASSERT_EQ(false, rg2_column2->is_path_in_schema_set());
+  }
 }
 
 TEST(ApplicationVersion, Basics) {

--- a/cpp/src/parquet/parquet.thrift
+++ b/cpp/src/parquet/parquet.thrift
@@ -882,7 +882,7 @@ struct ColumnMetaData {
   2: required list<Encoding> encodings
 
   /** Path in schema **/
-  3: required list<string> path_in_schema
+  3: optional list<string> path_in_schema
 
   /** Compression codec **/
   4: required CompressionCodec codec

--- a/cpp/src/parquet/properties.h
+++ b/cpp/src/parquet/properties.h
@@ -516,13 +516,21 @@ class PARQUET_EXPORT WriterProperties {
 
     /// \brief Enable writing the path_in_schema field to ColumnMetaData in the footer.
     ///
-    /// Writing ....
+    /// Writing path_in_schema is enabled by default, and should be left enabled for
+    /// maximum file compatibility, especially with older readers that expect this field
+    /// to be present.
     Builder* enable_write_path_in_schema() {
       write_path_in_schema_ = true;
       return this;
     }
 
     /// \brief Disable writing the path_in_schema field to ColumnMetaData in the footer.
+    ///
+    /// The path_in_schema field in the Thrift metadata is redundant and wastes a great
+    /// deal of space. Parquet file footers can be made much smaller by omitting this
+    /// field. Because the field was originally a mandatory field, writing of
+    /// path_in_schema is by default enabled. If one knows that all readers one plans to
+    /// use are tolerant of the absence of this field, writing may be safely disabled.
     Builder* disable_write_path_in_schema() {
       write_path_in_schema_ = false;
       return this;

--- a/cpp/src/parquet/properties.h
+++ b/cpp/src/parquet/properties.h
@@ -166,6 +166,7 @@ static constexpr Encoding::type DEFAULT_ENCODING = Encoding::UNKNOWN;
 static const char DEFAULT_CREATED_BY[] = CREATED_BY_VERSION;
 static constexpr Compression::type DEFAULT_COMPRESSION_TYPE = Compression::UNCOMPRESSED;
 static constexpr bool DEFAULT_IS_PAGE_INDEX_ENABLED = true;
+static constexpr bool DEFAULT_WRITE_PATH_IN_SCHEMA = true;
 static constexpr SizeStatisticsLevel DEFAULT_SIZE_STATISTICS_LEVEL =
     SizeStatisticsLevel::PageAndColumnChunk;
 
@@ -350,6 +351,7 @@ class PARQUET_EXPORT WriterProperties {
           created_by_(DEFAULT_CREATED_BY),
           store_decimal_as_integer_(false),
           page_checksum_enabled_(false),
+          write_path_in_schema_(DEFAULT_WRITE_PATH_IN_SCHEMA),
           size_statistics_level_(DEFAULT_SIZE_STATISTICS_LEVEL),
           content_defined_chunking_enabled_(false),
           content_defined_chunking_options_({}) {}
@@ -366,6 +368,7 @@ class PARQUET_EXPORT WriterProperties {
           created_by_(properties.created_by()),
           store_decimal_as_integer_(properties.store_decimal_as_integer()),
           page_checksum_enabled_(properties.page_checksum_enabled()),
+          write_path_in_schema_(properties.write_path_in_schema()),
           size_statistics_level_(properties.size_statistics_level()),
           sorting_columns_(properties.sorting_columns()),
           default_column_properties_(properties.default_column_properties()),
@@ -508,6 +511,20 @@ class PARQUET_EXPORT WriterProperties {
 
     Builder* disable_page_checksum() {
       page_checksum_enabled_ = false;
+      return this;
+    }
+
+    /// \brief Enable writing the path_in_schema field to ColumnMetaData in the footer.
+    ///
+    /// Writing ....
+    Builder* enable_write_path_in_schema() {
+      write_path_in_schema_ = true;
+      return this;
+    }
+
+    /// \brief Disable writing the path_in_schema field to ColumnMetaData in the footer.
+    Builder* disable_write_path_in_schema() {
+      write_path_in_schema_ = true;
       return this;
     }
 
@@ -868,10 +885,11 @@ class PARQUET_EXPORT WriterProperties {
       return std::shared_ptr<WriterProperties>(new WriterProperties(
           pool_, dictionary_pagesize_limit_, write_batch_size_, max_row_group_length_,
           pagesize_, max_rows_per_page_, version_, created_by_, page_checksum_enabled_,
-          size_statistics_level_, std::move(file_encryption_properties_),
-          default_column_properties_, column_properties, data_page_version_,
-          store_decimal_as_integer_, std::move(sorting_columns_),
-          content_defined_chunking_enabled_, content_defined_chunking_options_));
+          write_path_in_schema_, size_statistics_level_,
+          std::move(file_encryption_properties_), default_column_properties_,
+          column_properties, data_page_version_, store_decimal_as_integer_,
+          std::move(sorting_columns_), content_defined_chunking_enabled_,
+          content_defined_chunking_options_));
     }
 
    private:
@@ -888,6 +906,7 @@ class PARQUET_EXPORT WriterProperties {
     std::string created_by_;
     bool store_decimal_as_integer_;
     bool page_checksum_enabled_;
+    bool write_path_in_schema_;
     SizeStatisticsLevel size_statistics_level_;
 
     std::shared_ptr<FileEncryptionProperties> file_encryption_properties_;
@@ -932,6 +951,8 @@ class PARQUET_EXPORT WriterProperties {
   inline bool store_decimal_as_integer() const { return store_decimal_as_integer_; }
 
   inline bool page_checksum_enabled() const { return page_checksum_enabled_; }
+
+  inline bool write_path_in_schema() const { return write_path_in_schema_; }
 
   inline bool content_defined_chunking_enabled() const {
     return content_defined_chunking_enabled_;
@@ -1048,7 +1069,8 @@ class PARQUET_EXPORT WriterProperties {
       MemoryPool* pool, int64_t dictionary_pagesize_limit, int64_t write_batch_size,
       int64_t max_row_group_length, int64_t pagesize, int64_t max_rows_per_page,
       ParquetVersion::type version, const std::string& created_by,
-      bool page_write_checksum_enabled, SizeStatisticsLevel size_statistics_level,
+      bool page_write_checksum_enabled, bool write_path_in_schema,
+      SizeStatisticsLevel size_statistics_level,
       std::shared_ptr<FileEncryptionProperties> file_encryption_properties,
       const ColumnProperties& default_column_properties,
       const std::unordered_map<std::string, ColumnProperties>& column_properties,
@@ -1066,6 +1088,7 @@ class PARQUET_EXPORT WriterProperties {
         parquet_created_by_(created_by),
         store_decimal_as_integer_(store_short_decimal_as_integer),
         page_checksum_enabled_(page_write_checksum_enabled),
+        write_path_in_schema_(write_path_in_schema),
         size_statistics_level_(size_statistics_level),
         file_encryption_properties_(file_encryption_properties),
         sorting_columns_(std::move(sorting_columns)),
@@ -1085,6 +1108,7 @@ class PARQUET_EXPORT WriterProperties {
   std::string parquet_created_by_;
   bool store_decimal_as_integer_;
   bool page_checksum_enabled_;
+  bool write_path_in_schema_;
   SizeStatisticsLevel size_statistics_level_;
 
   std::shared_ptr<FileEncryptionProperties> file_encryption_properties_;

--- a/cpp/src/parquet/properties.h
+++ b/cpp/src/parquet/properties.h
@@ -524,7 +524,7 @@ class PARQUET_EXPORT WriterProperties {
 
     /// \brief Disable writing the path_in_schema field to ColumnMetaData in the footer.
     Builder* disable_write_path_in_schema() {
-      write_path_in_schema_ = true;
+      write_path_in_schema_ = false;
       return this;
     }
 


### PR DESCRIPTION

### Rationale for this change

`path_in_schema` in the `ColumnMetaData` is redundant. https://github.com/apache/parquet-format/issues/563 proposes fixing this by marking the field `optional` in the Thrift definition.

### What changes are included in this PR?
Modify the thrift generated code after makeing `path_in_schema` optional. Add options to `WriterProperties` to control the behavior, with the default being to continue writing the field. Makes changes to the metadata to account for the field now being optional.

### Are these changes tested?
Yes, adds a unit test to confirm the field is not present when that is requested.

### Are there any user-facing changes?

Adds a new configuration option, but no behavioral changes by default.

- Closes #49706 
* GitHub Issue: #49706