### PR TITLE
GH-40640: [R] to_arrow() loses group_by()

### DIFF
--- a/r/R/duckdb.R
+++ b/r/R/duckdb.R
@@ -183,9 +183,17 @@ to_arrow <- function(.data) {
     )
   }
 
+  groups <- dplyr::groups(.data)
+
   # Run the query
   res <- DBI::dbSendQuery(dbplyr::remote_con(.data), dbplyr::remote_query(.data), arrow = TRUE)
 
   reader <- duckdb::duckdb_fetch_record_batch(res)
-  MakeSafeRecordBatchReader(reader)
+  out <- MakeSafeRecordBatchReader(reader)
+
+  if (length(groups)) {
+    out <- dplyr::group_by(out, !!!groups)
+  }
+
+  out
 }

--- a/r/tests/testthat/test-duckdb.R
+++ b/r/tests/testthat/test-duckdb.R
@@ -190,6 +190,18 @@ test_that("to_arrow roundtrip, with dataset (without wrapping)", {
   expect_r6_class(out, "RecordBatchReader")
 })
 
+test_that("to_arrow preserves grouping from duckdb tables", {
+  ds <- InMemoryDataset$create(example_data)
+
+  out <- ds |>
+    to_duckdb() |>
+    group_by(lgl) |>
+    to_arrow()
+
+  expect_s3_class(out, "arrow_dplyr_query")
+  expect_equal(dplyr::group_vars(out), "lgl")
+})
+
 # The next set of tests use an already-extant connection to test features of
 # persistence and querying against the table without using the `tbl` itself, so
 # we need to create a connection separate from the ephemeral one that is made


### PR DESCRIPTION
### Rationale for this change

Roundtrip to duckdb loses grouping

### What changes are included in this PR?

Reapply grouping

### Are these changes tested?

Yup

### Are there any user-facing changes?

Nah

### AI usage

Done with Codex, but I went through it myself and am happy with it.
* GitHub Issue: #40640