### PR TITLE
GH-49725: [CI] Use environment variables instead of template expressions in workflow run blocks

### DIFF
--- a/.github/workflows/check_labels.yml
+++ b/.github/workflows/check_labels.yml
@@ -52,6 +52,7 @@ jobs:
         id: check
         env:
           GH_TOKEN: ${{ github.token }}
+          PARENT_WORKFLOW: ${{ inputs.parent-workflow }}
         run: |
           set -ex
           case "${GITHUB_EVENT_NAME}" in
@@ -71,7 +72,7 @@ jobs:
               git diff --stat origin/${GITHUB_BASE_REF}..
               if git diff --stat origin/${GITHUB_BASE_REF}.. | \
                    grep \
-                     --fixed-strings ".github/workflows/${{ inputs.parent-workflow }}.yml" \
+                     --fixed-strings ".github/workflows/${PARENT_WORKFLOW}.yml" \
                      --quiet; then
                 echo "force=true" >> "${GITHUB_OUTPUT}"
               fi

--- a/.github/workflows/comment_bot.yml
+++ b/.github/workflows/comment_bot.yml
@@ -53,8 +53,8 @@ jobs:
           CROSSBOW_GITHUB_TOKEN: ${{ secrets.CROSSBOW_GITHUB_TOKEN }}
         run: |
           archery --debug trigger-bot \
-            --event-name ${{ github.event_name }} \
-            --event-payload ${{ github.event_path }}
+            --event-name "${GITHUB_EVENT_NAME}" \
+            --event-payload "${GITHUB_EVENT_PATH}"
 
   issue_assign:
     name: "Assign issue"

--- a/.github/workflows/cpp_windows.yml
+++ b/.github/workflows/cpp_windows.yml
@@ -114,13 +114,18 @@ jobs:
           restore-keys: cpp-ccache-windows-${{ inputs.arch }}-
       - name: Build
         shell: cmd
+        env:
+          VCVARS_ARCH: ${{ inputs.arch }}
         run: |
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{ inputs.arch }}
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" %VCVARS_ARCH%
           bash -c "ci/scripts/cpp_build.sh $(pwd) $(pwd)/build"
       - name: Test
         shell: cmd
+        env:
+          VCVARS_ARCH: ${{ inputs.arch }}
+          MSYS2_LOCATION: ${{ steps.setup-msys2.outputs.msys2-location }}
         run: |
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{ inputs.arch }}
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" %VCVARS_ARCH%
           # For ORC
-          set TZDIR=${{ steps.setup-msys2.outputs.msys2-location }}\usr\share\zoneinfo
+          set TZDIR=%MSYS2_LOCATION%\usr\share\zoneinfo
           bash -c "ci/scripts/cpp_test.sh $(pwd) $(pwd)/build"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -119,10 +119,11 @@ jobs:
         env:
           ARCHERY_DOCKER_USER: ${{ secrets.DOCKERHUB_USER }}
           ARCHERY_DOCKER_PASSWORD: ${{ secrets.DOCKERHUB_TOKEN }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           source ci/scripts/util_enable_core_dumps.sh
           archery docker run \
-            -e ARCHERY_DEFAULT_BRANCH=${{ github.event.repository.default_branch }} \
+            -e ARCHERY_DEFAULT_BRANCH="${DEFAULT_BRANCH}" \
             -e ARCHERY_INTEGRATION_WITH_DOTNET=1 \
             -e ARCHERY_INTEGRATION_WITH_GO=1 \
             -e ARCHERY_INTEGRATION_WITH_JAVA=1 \

--- a/.github/workflows/pr_bot.yml
+++ b/.github/workflows/pr_bot.yml
@@ -90,16 +90,18 @@ jobs:
       - name: Handle PR workflow event
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_REVIEW_PATH: ${{ steps.extract.outputs.pr_review_path }}
+          COMMITTERS_PATH: ${{ steps.committers.outputs.committers_path }}
         run: |
           if [ "${GITHUB_EVENT_NAME}" = "workflow_run" ]; then
             # workflow_run is executed on PR review. Update to original event.
             archery trigger-bot \
               --event-name "pull_request_review" \
-              --event-payload "${{ steps.extract.outputs.pr_review_path }}" \
-              --committers-file "${{ steps.committers.outputs.committers_path }}"
+              --event-payload "${PR_REVIEW_PATH}" \
+              --committers-file "${COMMITTERS_PATH}"
           else
             archery trigger-bot \
-              --event-name "${{ github.event_name }}" \
-              --event-payload "${{ github.event_path }}" \
-              --committers-file "${{ steps.committers.outputs.committers_path }}"
+              --event-name "${GITHUB_EVENT_NAME}" \
+              --event-payload "${GITHUB_EVENT_PATH}" \
+              --committers-file "${COMMITTERS_PATH}"
           fi

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -297,8 +297,10 @@ jobs:
           CACHE_VERSION: "2025-09-16.1"
       - name: Build Arrow C++ and PyArrow
         shell: cmd
+        env:
+          USR_WINDOWS_DIR: ${{ steps.path-info.outputs.usr-windows-dir }}
         run: |
-          call "ci\scripts\python_build.bat" %cd% "${{ steps.path-info.outputs.usr-windows-dir }}"
+          call "ci\scripts\python_build.bat" %cd% "%USR_WINDOWS_DIR%"
       - name: Test PyArrow
         shell: cmd
         run: |

--- a/.github/workflows/verify_rc.yml
+++ b/.github/workflows/verify_rc.yml
@@ -52,10 +52,11 @@ jobs:
         id: detect
         env:
           GH_TOKEN: ${{ github.token }}
+          RC_TAG: ${{ inputs.rc_tag }}
         run: |
           case "${GITHUB_EVENT_NAME}" in
             workflow_dispatch)
-              tag="${{ inputs.rc_tag }}"
+              tag="${RC_TAG}"
               ;;
             pull_request)
               tag="$(gh release list \


### PR DESCRIPTION
### Rationale for this change

Update CI jobs to be more robust

### What changes are included in this PR?

Update CI jobs to use env vars instead of template expressions

### Are these changes tested?

CI should run

### Are there any user-facing changes?

No
* GitHub Issue: #49725