### PR TITLE
GH-49728: [CI] Set persist-credentials: false in checkout actions

### DIFF
--- a/.github/workflows/archery.yml
+++ b/.github/workflows/archery.yml
@@ -60,6 +60,7 @@ jobs:
       - name: Checkout Arrow
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 0
       - name: Git Fixup
         shell: bash

--- a/.github/workflows/check_labels.yml
+++ b/.github/workflows/check_labels.yml
@@ -48,6 +48,8 @@ jobs:
       - name: Checkout Arrow
         if: github.event_name == 'pull_request'
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Check
         id: check
         env:

--- a/.github/workflows/comment_bot.yml
+++ b/.github/workflows/comment_bot.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Checkout Arrow
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           path: arrow
           # fetch the tags for version number generation
           fetch-depth: 0

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -112,6 +112,7 @@ jobs:
       - name: Checkout Arrow
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 0
           submodules: recursive
       - name: Cache Docker Volumes
@@ -165,6 +166,7 @@ jobs:
       - name: Checkout Arrow
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 0
           submodules: recursive
       - name: Check CMake presets
@@ -220,6 +222,7 @@ jobs:
       - name: Checkout Arrow
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 0
           submodules: recursive
       - name: Install Dependencies
@@ -349,6 +352,7 @@ jobs:
       - name: Checkout Arrow
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 0
           submodules: recursive
       - uses: msys2/setup-msys2@v2

--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -139,6 +139,7 @@ jobs:
       - name: Checkout Arrow
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 0
           submodules: recursive
       - name: Cache Docker Volumes
@@ -221,6 +222,7 @@ jobs:
       - name: Checkout Arrow
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 0
           submodules: recursive
       - name: Free up disk space
@@ -273,6 +275,7 @@ jobs:
       - name: Checkout Arrow
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 0
           submodules: recursive
       - name: Install dependencies
@@ -367,6 +370,7 @@ jobs:
       - name: Checkout Arrow
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 0
           submodules: recursive
       - name: Cache Docker Volumes
@@ -431,6 +435,7 @@ jobs:
       - name: Checkout Arrow
         uses: actions/checkout@v6.0.1
         with:
+          persist-credentials: false
           fetch-depth: 0
           submodules: recursive
       - name: Install Dependencies
@@ -552,6 +557,7 @@ jobs:
       - name: Checkout Arrow
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 0
           submodules: recursive
       - name: Download Timezone Database
@@ -579,6 +585,7 @@ jobs:
       - name: Checkout vcpkg
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 0
           path: vcpkg
           repository: microsoft/vcpkg
@@ -706,6 +713,7 @@ jobs:
       - name: Checkout Arrow
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 1
           path: arrow
           repository: apache/arrow
@@ -736,6 +744,7 @@ jobs:
       - name: Checkout Arrow
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 0
           submodules: recursive
       - name: Download the artifacts

--- a/.github/workflows/cpp_windows.yml
+++ b/.github/workflows/cpp_windows.yml
@@ -84,6 +84,7 @@ jobs:
       - name: Checkout Arrow
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 0
           submodules: recursive
       - name: Install msys2 (for tzdata for ORC tests)

--- a/.github/workflows/cuda_extra.yml
+++ b/.github/workflows/cuda_extra.yml
@@ -85,6 +85,7 @@ jobs:
       - name: Checkout Arrow
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 0
           submodules: recursive
       - name: Cache Docker Volumes

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -49,6 +49,7 @@ jobs:
       - name: Checkout Arrow
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 0
       - name: Install pre-commit
         run: |
@@ -88,6 +89,7 @@ jobs:
       - name: Checkout Arrow
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 0
       - name: Install Python
         uses: actions/setup-python@v6

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -51,6 +51,7 @@ jobs:
       - name: Checkout Arrow
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 0
       - name: Free up disk space
         run: |

--- a/.github/workflows/docs_light.yml
+++ b/.github/workflows/docs_light.yml
@@ -52,6 +52,7 @@ jobs:
       - name: Checkout Arrow
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 0
       - name: Cache Docker Volumes
         uses: actions/cache@v5

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -68,36 +68,43 @@ jobs:
       - name: Checkout Arrow
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 0
           submodules: recursive
       - name: Checkout Arrow Rust
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           repository: apache/arrow-rs
           path: rust
       - name: Checkout Arrow nanoarrow
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           repository: apache/arrow-nanoarrow
           path: nanoarrow
       - name: Checkout Arrow Go
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           repository: apache/arrow-go
           path: go
       - name: Checkout Arrow Java
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           repository: apache/arrow-java
           path: java
       - name: Checkout Arrow JS
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           repository: apache/arrow-js
           path: js
       - name: Checkout Arrow .NET
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           repository: apache/arrow-dotnet
           path: dotnet
       - name: Free up disk space

--- a/.github/workflows/matlab.yml
+++ b/.github/workflows/matlab.yml
@@ -53,6 +53,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 0
       - name: Install ninja-build
         run: sudo apt-get install ninja-build
@@ -101,6 +102,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 0
       - name: Install ninja-build
         run: brew install ninja
@@ -142,6 +144,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 0
       - name: Install MATLAB
         uses: matlab-actions/setup-matlab@a0180c939fb1a28de13f44f7b778b912384ced1f # v3.0.1

--- a/.github/workflows/package_linux.yml
+++ b/.github/workflows/package_linux.yml
@@ -117,6 +117,7 @@ jobs:
       - name: Checkout Arrow
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 0
           submodules: recursive
       - name: Free up disk space

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -106,6 +106,7 @@ jobs:
       - name: Checkout Arrow
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 0
           submodules: recursive
       - name: Cache Docker Volumes
@@ -185,6 +186,7 @@ jobs:
       - name: Checkout Arrow
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 0
           submodules: recursive
       - name: Setup Python
@@ -266,6 +268,7 @@ jobs:
       - name: Checkout Arrow
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 0
           submodules: recursive
       - name: Setup Python

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -80,6 +80,7 @@ jobs:
       - name: Checkout Arrow
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 0
           submodules: recursive
       - name: Free up disk space
@@ -152,6 +153,7 @@ jobs:
       - name: Checkout Arrow
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 0
           submodules: recursive
       - name: Setup Python
@@ -209,6 +211,7 @@ jobs:
       - name: Checkout Arrow
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 0
       - name: Setup ccache
         shell: bash
@@ -266,6 +269,7 @@ jobs:
       - name: Checkout Arrow
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 0
       # This must be done before r-lib/actions/setup-r because curl in
       # Rtools doesn't work on non Rtools' MSYS2 environment. If we

--- a/.github/workflows/r_extra.yml
+++ b/.github/workflows/r_extra.yml
@@ -160,6 +160,7 @@ jobs:
       - name: Checkout Arrow
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 0
           submodules: recursive
       - name: Cache Docker Volumes

--- a/.github/workflows/r_nightly.yml
+++ b/.github/workflows/r_nightly.yml
@@ -47,6 +47,7 @@ jobs:
       - name: Checkout Arrow
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 1
           path: arrow
           repository: apache/arrow
@@ -55,6 +56,7 @@ jobs:
       - name: Checkout Crossbow
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 0
           path: crossbow
           repository: ursacomputing/crossbow

--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -46,6 +46,7 @@ jobs:
       - name: Checkout Arrow
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 0
       - name: Install dependencies
         run: |

--- a/.github/workflows/report_ci.yml
+++ b/.github/workflows/report_ci.yml
@@ -36,6 +36,7 @@ jobs:
       - name: Checkout Arrow
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 0
       - name: Setup Python
         uses: actions/setup-python@v6

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -83,6 +83,7 @@ jobs:
       - name: Checkout Arrow
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 0
           submodules: recursive
       - name: Cache Docker Volumes
@@ -152,6 +153,7 @@ jobs:
       - name: Checkout Arrow
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 0
           submodules: recursive
       - name: Install Homebrew Dependencies
@@ -250,6 +252,7 @@ jobs:
       - name: Checkout Arrow
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 0
           submodules: recursive
       - name: Setup Ruby
@@ -368,6 +371,7 @@ jobs:
       - name: Checkout Arrow
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 0
           submodules: recursive
       - name: Install meson
@@ -398,6 +402,7 @@ jobs:
       - name: Checkout vcpkg
         uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 0
           path: vcpkg
           repository: microsoft/vcpkg

--- a/.github/workflows/verify_rc.yml
+++ b/.github/workflows/verify_rc.yml
@@ -92,6 +92,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 0
       - name: Run
         run: |
@@ -134,6 +135,8 @@ jobs:
       VERSION: ${{ needs.target.outputs.version }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Run
         run: |
           dev/release/verify-release-candidate.sh ${VERSION} ${RC}
@@ -157,6 +160,8 @@ jobs:
       VERSION: ${{ needs.target.outputs.version }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v6
         with:
           python-version: 3
@@ -203,6 +208,8 @@ jobs:
       VERSION: ${{ needs.target.outputs.version }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Run
         env:
           GH_TOKEN: ${{ github.token }}
@@ -222,6 +229,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          persist-credentials: false
           submodules: recursive
       - uses: conda-incubator/setup-miniconda@835234971496cad1653abb28a638a281cf32541f # v3.2.0
       - name: Install System Dependencies
@@ -256,6 +264,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
+          persist-credentials: false
           fetch-depth: 0
       - name: Run
         run: |

--- a/dev/tasks/docs/github.linux.yml
+++ b/dev/tasks/docs/github.linux.yml
@@ -44,6 +44,7 @@ jobs:
       - name: Checkout Crossbow
         uses: actions/checkout@v4
         with:
+          persist-credentials: false
           ref: {{ default_branch|default("main") }}
           path: crossbow
           fetch-depth: 1

--- a/dev/tasks/macros.jinja
+++ b/dev/tasks/macros.jinja
@@ -34,6 +34,7 @@ env:
     with:
       fetch-depth: {{ fetch_depth }}
       path: arrow
+      persist-credentials: false
       repository: {{ arrow.github_repo }}
       ref: {{ arrow.head }}
       submodules: {{ submodules }}
@@ -84,6 +85,7 @@ env:
     uses: actions/checkout@v4
     with:
       path: crossbow
+      persist-credentials: false
       ref: {{ job.branch }}
   - name: Setup Crossbow
     shell: bash


### PR DESCRIPTION
### Rationale for this change

Some CI jobs didn't have persist-credential set to false, which presents potential risks

### What changes are included in this PR?

Set persist-credentials to false

### Are these changes tested?

Run CI jobs

### Are there any user-facing changes?

No

* GitHub Issue: #49728