### PR TITLE
MINOR: [CI][C++] Show machine info in Linux GHA jobs

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -109,6 +109,10 @@ jobs:
       LLVM: ${{ matrix.llvm }}
       UBUNTU: ${{ matrix.ubuntu }}
     steps:
+      - name: Show machine info
+        run: |
+          free -h
+          lscpu
       - name: Checkout Arrow
         uses: actions/checkout@v6
         with:


### PR DESCRIPTION
### Rationale for this change

Detailed info about available memory and CPU model can help in certain cases, for example to know whether a certain instruction set is available (example in https://github.com/apache/arrow/issues/47769).

### Are these changes tested?

N/A.

### Are there any user-facing changes?

No.
