### PR TITLE
GH-49737: [R][CI] Disable Rhub GCC 12 and GCC 13 with LTO jobs - images no longer match CRAN

### DIFF
--- a/.github/workflows/r_extra.yml
+++ b/.github/workflows/r_extra.yml
@@ -130,21 +130,27 @@ jobs:
             image: r
             runs-on: ubuntu-latest
             title: Rhub
-          - envs:
-              - R_CUSTOM_CCACHE=true
-              - R_IMAGE=ubuntu-gcc12
-              - R_ORG=rhub
-            image: r
-            runs-on: ubuntu-latest
-            title: Rhub GCC 12
-          - envs:
-              - R_IMAGE=gcc13
-              - R_ORG=rhub
-            image: r
-            runs-on: ubuntu-latest
-            run-options: >-
-              -e INSTALL_ARGS=--use-LTO
-            title: Rhub GCC 13 with LTO
+          # Disabled: rhub/ubuntu-gcc12 image uses GCC 12 but CRAN now uses GCC 15.
+          # See https://github.com/apache/arrow/issues/49737
+          # Re-enable once r-hub/containers provides a GCC 15 image (#49738).
+          # - envs:
+          #     - R_CUSTOM_CCACHE=true
+          #     - R_IMAGE=ubuntu-gcc12
+          #     - R_ORG=rhub
+          #   image: r
+          #   runs-on: ubuntu-latest
+          #   title: Rhub GCC 12
+          # Disabled: rhub/gcc13 image uses GCC 13 but CRAN now uses GCC 15.
+          # See https://github.com/apache/arrow/issues/49737
+          # Re-enable once r-hub/containers provides a GCC 15 image (#49738).
+          # - envs:
+          #     - R_IMAGE=gcc13
+          #     - R_ORG=rhub
+          #   image: r
+          #   runs-on: ubuntu-latest
+          #   run-options: >-
+          #     -e INSTALL_ARGS=--use-LTO
+          #   title: Rhub GCC 13 with LTO
           - envs:
               - R_IMAGE=r-base
               - R_ORG=rstudio


### PR DESCRIPTION
### Rationale for this change

Disable failing + out of date CI jobs until we have a container with GCC 15 to replace them

### What changes are included in this PR?

Disable them - leave commented out as we'll replace later

### Are these changes tested?

No

### Are there any user-facing changes?

No
* GitHub Issue: #49737