### PR TITLE
GH-49745: [Docs][Python] Fix doctests failure in substrait.rst

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -30,6 +30,7 @@ on:
       - 'ci/**'
       - 'cpp/**'
       - 'compose.yaml'
+      - 'docs/source/python/**'
       - 'python/**'
   pull_request:
     paths:
@@ -38,6 +39,7 @@ on:
       - 'ci/**'
       - 'cpp/**'
       - 'compose.yaml'
+      - 'docs/source/python/**'
       - 'python/**'
 
 concurrency:

--- a/docs/source/python/integration/substrait.rst
+++ b/docs/source/python/integration/substrait.rst
@@ -59,7 +59,7 @@ all the extensions types:
 .. code-block:: python
 
     >>> print(bytes(substrait_schema.expression))
-    b'"\x14\n\x01x\n\x01y\x12\x0c\n\x04*\x02\x10\x01\n\x04b\x02\x10\x01:\x19\x10,*\x15Acero ...'
+    b'"\x14\n\x01x\n\x01y\x12\x0c\n\x04*\x02\x10\x01\n\x04b\x02\x10\x01:...'
 
 If ``Substrait Python`` is installed, the schema can also be converted to
 a ``substrait-python`` object:
@@ -114,7 +114,7 @@ protobuf ``ExtendedExpression`` message data itself:
 .. code-block:: python
 
     >>> print(bytes(substrait_expr))
-    b'\nZ\x12Xhttps://github.com/substrait-io/substrait/blob/main/extensions/functions_arithmetic.yaml\x12\x07\x1a\x05\x1a\x03add\x1a>\n5\x1a3\x1a\x04*\x02\x10\x01"\n\x1a\x08\x12\x06\n\x02\x12\x00"\x00"\x0c\x1a\n\x12\x08\n\x04\x12\x02\x08\x01"\x00*\x11\n\x08overflow\x12\x05ERROR\x1a\x05total"\x14\n\x01x\n\x01y\x12\x0c\n\x04*\x02\x10\x01\n\x04*\x02\x10\x01:\x19\x10,*\x15Acero ...'
+    b'\nZ\x12Xhttps://github.com/substrait-io/substrait/blob/main/extensions/functions_arithmetic.yaml\x12\x07\x1a\x05\x1a\x03add\x1a>\n5\x1a3\x1a\x04*\x02\x10\x01"\n\x1a\x08\x12\x06\n\x02\x12\x00"\x00"\x0c\x1a\n\x12\x08\n\x04\x12\x02\x08\x01"\x00*\x11\n\x08overflow\x12\x05ERROR\x1a\x05total"\x14\n\x01x\n\x01y\x12\x0c\n\x04*\x02\x10\x01\n\x04*\x02\x10\x01:...'
 
 So in case a ``Substrait Python`` object is required, the expression
 has to be decoded from ``substrait-python`` itself:


### PR DESCRIPTION
### Rationale for this change

The [Python / AMD64 Conda Python 3.11 Sphinx & Numpydoc](https://github.com/apache/arrow/actions/runs/24404394331/job/71295731710?pr=49742) job is failing due to the version number change.

### What changes are included in this PR?

- Use ellipsis so that all version-dependent bytes are covered.
- Add `docs/source/python/**` to the python workflow path triggers to run Sphinx & Numpydoc CI on documentation changes.

### Are these changes tested?

Yes, with Conda Python 3.11 Sphinx & Numpydoc job.

### Are there any user-facing changes?

No.

* GitHub Issue: #49745