### PR TITLE
GH-49760: Document differences between bugs and security vulnerabilities

### DIFF
--- a/docs/source/cpp/security.rst
+++ b/docs/source/cpp/security.rst
@@ -63,8 +63,8 @@ is always assumed to be :ref:`valid <format-invalid-data>`. If your program may
 encounter invalid data, it must explicitly check its validity by calling one of
 the following validation APIs.
 
-Note that even if a library crashes or hangs when encountering invalid data, it is
-generally considered a bug rather than a security vulnerability, unless the behavior
+Note that library crashes or hangs triggered by invalid data are generally
+considered bugs rather than security vulnerabilities, unless the behavior
 is exploitable (see :ref:`Bugs vs. Security Vulnerabilities <bugs_vs_security>`).
 
 Structural validity

--- a/docs/source/cpp/security.rst
+++ b/docs/source/cpp/security.rst
@@ -65,7 +65,7 @@ the following validation APIs.
 
 Note that even if a library crashes or hangs when encountering invalid data, it is
 generally considered a bug rather than a security vulnerability, unless the behavior
-is exploitable (see :ref:`Bugs vs. Security Vulnerabilities <format_security>`).
+is exploitable (see :ref:`Bugs vs. Security Vulnerabilities <bugs_vs_security>`).
 
 Structural validity
 '''''''''''''''''''

--- a/docs/source/cpp/security.rst
+++ b/docs/source/cpp/security.rst
@@ -63,6 +63,10 @@ is always assumed to be :ref:`valid <format-invalid-data>`. If your program may
 encounter invalid data, it must explicitly check its validity by calling one of
 the following validation APIs.
 
+Note that even if a library crashes or hangs when encountering invalid data, it is
+generally considered a bug rather than a security vulnerability, unless the behavior
+is exploitable (see :ref:`Bugs vs. Security Vulnerabilities <format_security>`).
+
 Structural validity
 '''''''''''''''''''
 

--- a/docs/source/format/Security.rst
+++ b/docs/source/format/Security.rst
@@ -51,6 +51,44 @@ You should read this document if you belong to either of these two categories:
    documented on https://arrow.apache.org.
 
 
+Bugs vs. Security Vulnerabilities
+=================================
+
+The Arrow project aims for robustness when processing data from untrusted
+sources. However, it is important to distinguish between functional bugs
+and security vulnerabilities.
+
+Invalid input files (such as malformed IPC streams or Parquet files) that
+cause an Arrow implementation to misbehave, (for example, by triggering
+a segmentation fault or an infinite loop) are generally considered **bugs**,
+not security vulnerabilities, unless the behavior is **exploitable**.
+
+Such uncontrolled behavior is considered **exploitable** if it
+can be leveraged by an attacker to:
+
+* Perform arbitrary code execution (e.g. Remote Code Execution);
+* Access or exfiltrate sensitive information from the process memory
+  (Information Disclosure);
+* Cause a sustained Denial of Service (DoS) affecting the broader system
+  (beyond the individual process processing the data).
+
+Examples of behaviors that are bugs but generally **not** security vulnerabilities:
+
+* A segmentation fault (SIGSEGV) or null pointer dereference occurring within
+  the process parsing an invalid file, provided it cannot be leveraged for
+  code execution or information disclosure;
+* An assertion failure or abortion (`std::abort`) triggered by an internal
+  sanity check when encountering malformed data;
+* An infinite loop or excessive CPU/memory usage that only affects the local
+  process and does not impact the availability of the overall system.
+
+We encourage users to report such uncontrolled behavior on invalid data as
+regular bugs in our `public issue tracker <https://github.com/apache/arrow/issues>`_ so they can be fixed. If you suspect
+an issue is exploitable, please follow the
+`ASF security reporting process <https://apache.org/security/#reporting-a-vulnerability>`_
+and report it privately.
+
+
 Columnar Format
 ===============
 

--- a/docs/source/format/Security.rst
+++ b/docs/source/format/Security.rst
@@ -51,6 +51,8 @@ You should read this document if you belong to either of these two categories:
    documented on https://arrow.apache.org.
 
 
+.. _bugs_vs_security:
+
 Bugs vs. Security Vulnerabilities
 =================================
 
@@ -59,7 +61,7 @@ sources. However, it is important to distinguish between functional bugs
 and security vulnerabilities.
 
 Invalid input files (such as malformed IPC streams or Parquet files) that
-cause an Arrow implementation to misbehave, (for example, by triggering
+cause an Arrow implementation to misbehave (for example, by triggering
 a segmentation fault or an infinite loop) are generally considered **bugs**,
 not security vulnerabilities, unless the behavior is **exploitable**.
 

--- a/docs/source/format/Security.rst
+++ b/docs/source/format/Security.rst
@@ -56,39 +56,27 @@ You should read this document if you belong to either of these two categories:
 Bugs vs. Security Vulnerabilities
 =================================
 
-The Arrow project aims for robustness when processing data from untrusted
-sources. However, it is important to distinguish between functional bugs
-and security vulnerabilities.
+Arrow aims for robustness when processing untrusted data, but it is important to
+distinguish functional bugs from security vulnerabilities.
 
-Invalid input files (such as malformed IPC streams or Parquet files) that
-cause an Arrow implementation to misbehave (for example, by triggering
-a segmentation fault or an infinite loop) are generally considered **bugs**,
-not security vulnerabilities, unless the behavior is **exploitable**.
+Unexpected behavior (e.g., crashes or infinite loops) triggered by malformed
+input is generally considered a **bug**, not a security vulnerability, unless it
+is **exploitable**. An issue is exploitable if an attacker can:
 
-Such uncontrolled behavior is considered **exploitable** if it
-can be leveraged by an attacker to:
+* Execute arbitrary code (RCE);
+* Exfiltrate sensitive information from process memory (Information Disclosure);
+* Cause a sustained Denial of Service (DoS) affecting the broader system.
 
-* Perform arbitrary code execution (e.g. Remote Code Execution);
-* Access or exfiltrate sensitive information from the process memory
-  (Information Disclosure);
-* Cause a sustained Denial of Service (DoS) affecting the broader system
-  (beyond the individual process processing the data).
+Examples of bugs that are typically **not** security vulnerabilities:
 
-Examples of behaviors that are bugs but generally **not** security vulnerabilities:
+* Process-local crashes (SIGSEGV, null pointer dereference, or `std::abort`)
+  that cannot be leveraged for code execution or information disclosure;
+* Resource exhaustion (infinite loops, high CPU/memory usage) that only
+  affects the local process.
 
-* A segmentation fault (SIGSEGV) or null pointer dereference occurring within
-  the process parsing an invalid file, provided it cannot be leveraged for
-  code execution or information disclosure;
-* An assertion failure or abortion (`std::abort`) triggered by an internal
-  sanity check when encountering malformed data;
-* An infinite loop or excessive CPU/memory usage that only affects the local
-  process and does not impact the availability of the overall system.
-
-We encourage users to report such uncontrolled behavior on invalid data as
-regular bugs in our `public issue tracker <https://github.com/apache/arrow/issues>`_ so they can be fixed. If you suspect
-an issue is exploitable, please follow the
-`ASF security reporting process <https://apache.org/security/#reporting-a-vulnerability>`_
-and report it privately.
+Report such issues on our `public issue tracker <https://github.com/apache/arrow/issues>`_.
+If you suspect an issue is exploitable, report it privately via the
+`ASF security process <https://apache.org/security/#reporting-a-vulnerability>`_.
 
 
 Columnar Format


### PR DESCRIPTION
### Rationale for this change

The current security model documented https://arrow.apache.org/docs/dev/format/Security.html

Does not explicitly address what constitutes a bug vs a security vulnerability. We should make this clear

This is a follow on to the security documentation added by @pitrou  in 
- https://github.com/apache/arrow/pull/48870

### What changes are included in this PR?

Add a section to the format security document that defines bugs vs security vulnerabilitty

### Are these changes tested?

Not sure

### Are there any user-facing changes?

Yes as it defines our security posture more generally
* GitHub Issue: #49760