### PR TITLE
GH-49757: [Release][CI] export SSL_CERT_FILE to bypass incompatibility with OpenSSL on RHEL-8

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -2056,10 +2056,9 @@ services:
       CMAKE_GENERATOR: Ninja
       TEST_APT: 0  # would require docker-in-docker
       TEST_YUM: 0
+      SSL_CERT_FILE: /etc/ssl/certs/ca-bundle.crt  # required due to issue in RHEL-8 based images. See GH-49757
     command: >
       /bin/bash -c "
-        # SSL_CERT_FILE required due to issue in RHEL-8 based images. See GH-49757
-        export SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt &&
         /arrow/dev/release/verify-release-candidate.sh $${VERIFY_VERSION} $${VERIFY_RC}"
 
   ubuntu-verify-rc:

--- a/compose.yaml
+++ b/compose.yaml
@@ -2058,6 +2058,8 @@ services:
       TEST_YUM: 0
     command: >
       /bin/bash -c "
+        # SSL_CERT_FILE required due to issue in RHEL-8 based images. See GH-49757
+        export SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt &&
         /arrow/dev/release/verify-release-candidate.sh $${VERIFY_VERSION} $${VERIFY_RC}"
 
   ubuntu-verify-rc:

--- a/compose.yaml
+++ b/compose.yaml
@@ -2054,9 +2054,9 @@ services:
     environment:
       <<: [*common, *ccache]
       CMAKE_GENERATOR: Ninja
+      SSL_CERT_FILE: /etc/ssl/certs/ca-bundle.crt  # required due to issue in RHEL-8 based images. See GH-49757
       TEST_APT: 0  # would require docker-in-docker
       TEST_YUM: 0
-      SSL_CERT_FILE: /etc/ssl/certs/ca-bundle.crt  # required due to issue in RHEL-8 based images. See GH-49757
     command: >
       /bin/bash -c "
         /arrow/dev/release/verify-release-candidate.sh $${VERIFY_VERSION} $${VERIFY_RC}"


### PR DESCRIPTION
### Rationale for this change

The binary wheel verification is taking around 50 minutes locally, It is timing out on CI. After some investigation, see the issue, this is related to: https://bugzilla.redhat.com/show_bug.cgi?id=1053882

### What changes are included in this PR?

Export SSL_CERT_FILE before running the verification on almalinux-verify-rc job.

### Are these changes tested?

Yes, I tested this locally due to the binary verification not easily being tested on CI.

Locally executed the following which is exactly the same that the biniary verification CI job exercises:

> `$ time ALMALINUX=8 archery docker run -e TEST_DEFAULT=0 -e TEST_WHEELS=1 -e VERBOSE=1 -e VERIFY_RC=0 -e VERIFY_VERSION=24.0.0 -e GH_TOKEN=$GH_TOKEN almalinux-verify-rc`

It took previously ~50 minutes to complete (got clearly stuck on `test_fs.py`), it currently takes 7 minutes:
```
+ TEST_SUCCESS=yes
+ echo 'Release candidate 24.0.0-RC0 looks good!'
Release candidate 24.0.0-RC0 looks good!
+ exit 0
+ cleanup
+ '[' yes = yes ']'
+ rm -fr /tmp/arrow-24.0.0.CTLOf

real	7m4.906s
user	0m3.660s
sys	0m1.626s
```


### Are there any user-facing changes?
No

* GitHub Issue: #49757