### PR TITLE
GH-33823: [C++][IPC] Improve error messages when opening files that are the wrong format

### DIFF
--- a/cpp/src/arrow/ipc/message.cc
+++ b/cpp/src/arrow/ipc/message.cc
@@ -573,8 +573,8 @@ Status DecodeMessage(MessageDecoder* decoder, io::InputStream* file) {
                          remaining_magic.size()) == remaining_magic) {
       return Status::Invalid("Expected to read ", metadata_length,
                              " metadata bytes, but only read ", metadata->size(),
-                             ". This appears to be an Arrow IPC File format file. "
-                             "Try open_file() instead of open_stream().");
+                             ". This appears to be an Arrow IPC file. "
+                             "Try the IPC file reader instead of the IPC stream reader.");
     }
     return Status::Invalid("Expected to read ", metadata_length, " metadata bytes, but ",
                            "only read ", metadata->size());

--- a/cpp/src/arrow/ipc/message.cc
+++ b/cpp/src/arrow/ipc/message.cc
@@ -565,6 +565,18 @@ Status DecodeMessage(MessageDecoder* decoder, io::InputStream* file) {
   auto metadata_length = decoder->next_required_size();
   ARROW_ASSIGN_OR_RAISE(auto metadata, file->Read(metadata_length));
   if (metadata->size() != metadata_length) {
+    // The first sizeof(int32_t) bytes of the Arrow file magic ("ARRO") may have been
+    // misread as metadata_length. Check if the remaining bytes complete the magic.
+    const auto remaining_magic = internal::kArrowMagicBytes.substr(sizeof(int32_t));
+    if (metadata->size() >= static_cast<int64_t>(remaining_magic.size()) &&
+        std::string_view(reinterpret_cast<const char*>(metadata->data()),
+                         remaining_magic.size()) == remaining_magic) {
+      return Status::Invalid(
+          "Expected to read ", metadata_length, " metadata bytes, but only read ",
+          metadata->size(),
+          ". This appears to be an Arrow IPC File format file. "
+          "Try open_file() instead of open_stream().");
+    }
     return Status::Invalid("Expected to read ", metadata_length, " metadata bytes, but ",
                            "only read ", metadata->size());
   }

--- a/cpp/src/arrow/ipc/message.cc
+++ b/cpp/src/arrow/ipc/message.cc
@@ -571,11 +571,10 @@ Status DecodeMessage(MessageDecoder* decoder, io::InputStream* file) {
     if (metadata->size() >= static_cast<int64_t>(remaining_magic.size()) &&
         std::string_view(reinterpret_cast<const char*>(metadata->data()),
                          remaining_magic.size()) == remaining_magic) {
-      return Status::Invalid(
-          "Expected to read ", metadata_length, " metadata bytes, but only read ",
-          metadata->size(),
-          ". This appears to be an Arrow IPC File format file. "
-          "Try open_file() instead of open_stream().");
+      return Status::Invalid("Expected to read ", metadata_length,
+                             " metadata bytes, but only read ", metadata->size(),
+                             ". This appears to be an Arrow IPC File format file. "
+                             "Try open_file() instead of open_stream().");
     }
     return Status::Invalid("Expected to read ", metadata_length, " metadata bytes, but ",
                            "only read ", metadata->size());

--- a/cpp/src/arrow/ipc/message.cc
+++ b/cpp/src/arrow/ipc/message.cc
@@ -563,19 +563,26 @@ Status DecodeMessage(MessageDecoder* decoder, io::InputStream* file) {
   }
 
   auto metadata_length = decoder->next_required_size();
-  ARROW_ASSIGN_OR_RAISE(auto metadata, file->Read(metadata_length));
-  if (metadata->size() != metadata_length) {
-    // The first sizeof(int32_t) bytes of the Arrow file magic ("ARRO") may have been
-    // misread as metadata_length. Check if the remaining bytes complete the magic.
-    const auto remaining_magic = internal::kArrowMagicBytes.substr(sizeof(int32_t));
-    if (metadata->size() >= static_cast<int64_t>(remaining_magic.size()) &&
-        std::string_view(reinterpret_cast<const char*>(metadata->data()),
-                         remaining_magic.size()) == remaining_magic) {
-      return Status::Invalid("Expected to read ", metadata_length,
-                             " metadata bytes, but only read ", metadata->size(),
-                             ". This appears to be an Arrow IPC file. "
-                             "Try the IPC file reader instead of the IPC stream reader.");
+
+  // "ARRO" (first 4 bytes of kArrowMagicBytes) as little-endian int32.
+  constexpr int32_t kArrowMagicPrefix = 0x4F525241;
+
+  // Did we misinterpret the metadata as a length?
+  if (metadata_length == kArrowMagicPrefix) {
+    constexpr std::string_view kRemainingMagic =
+        internal::kArrowMagicBytes.substr(sizeof(int32_t));
+    ARROW_ASSIGN_OR_RAISE(auto peek, file->Read(kRemainingMagic.size()));
+    if (peek->size() >= static_cast<int64_t>(kRemainingMagic.size()) &&
+        std::string_view(reinterpret_cast<const char*>(peek->data()),
+                         kRemainingMagic.size()) == kRemainingMagic) {
+      return Status::Invalid(
+          "This appears to be an Arrow IPC file. "
+          "Try the IPC file reader instead of the IPC stream reader.");
     }
+  }
+  ARROW_ASSIGN_OR_RAISE(auto metadata, file->Read(metadata_length));
+
+  if (metadata->size() != metadata_length) {
     return Status::Invalid("Expected to read ", metadata_length, " metadata bytes, but ",
                            "only read ", metadata->size());
   }

--- a/cpp/src/arrow/ipc/read_write_test.cc
+++ b/cpp/src/arrow/ipc/read_write_test.cc
@@ -2265,6 +2265,52 @@ TEST(TestRecordBatchStreamReader, MalformedInput) {
   ASSERT_RAISES(Invalid, RecordBatchStreamReader::Open(&garbage_reader));
 }
 
+TEST(TestRecordBatchStreamReader, OpenFileFormatSuggestsFileReader) {
+  std::shared_ptr<RecordBatch> batch;
+  ASSERT_OK(MakeIntRecordBatch(&batch));
+
+  FileWriterHelper helper;
+  ASSERT_OK(helper.Init(batch->schema(), IpcWriteOptions::Defaults()));
+  ASSERT_OK(helper.WriteBatch(batch));
+  ASSERT_OK(helper.Finish());
+
+  io::BufferReader reader(helper.buffer_);
+  // Check we mention using the file_reader when we detect file format
+  EXPECT_RAISES_WITH_MESSAGE_THAT(Invalid, ::testing::HasSubstr("file reader"),
+                                  RecordBatchStreamReader::Open(&reader));
+}
+
+TEST(TestRecordBatchStreamReader, CorruptDataDoesNotSuggestFileReader) {
+  // Continuation marker + metadata_length = 100, then 8 bytes of non-magic data.
+  const std::string corrupt(
+      "\xff\xff\xff\xff"
+      "\x64\x00\x00\x00"
+      "ABABABAB",
+      16);
+  auto buffer = std::make_shared<Buffer>(corrupt);
+  io::BufferReader reader(buffer);
+  // Validate that we don't suggest file reader when file is just corrupt
+  EXPECT_RAISES_WITH_MESSAGE_THAT(
+      Invalid, ::testing::Not(::testing::HasSubstr("file reader")),
+      RecordBatchStreamReader::Open(&reader));
+}
+
+TEST(TestRecordBatchFileReader, OpenStreamFormatSuggestsStreamReader) {
+  std::shared_ptr<RecordBatch> batch;
+  ASSERT_OK(MakeIntRecordBatch(&batch));
+
+  StreamWriterHelper helper;
+  ASSERT_OK(helper.Init(batch->schema(), IpcWriteOptions::Defaults()));
+  ASSERT_OK(helper.WriteBatch(batch));
+  ASSERT_OK(helper.Finish());
+
+  auto buf_reader = std::make_shared<io::BufferReader>(helper.buffer_);
+  // Check we mention using the stream_reader when we detect stream format
+  EXPECT_RAISES_WITH_MESSAGE_THAT(
+      Invalid, ::testing::HasSubstr("stream reader"),
+      RecordBatchFileReader::Open(buf_reader.get(), helper.buffer_->size()));
+}
+
 class EndlessCollectListener : public CollectListener {
  public:
   EndlessCollectListener() : CollectListener(), decoder_(nullptr) {}

--- a/cpp/src/arrow/ipc/read_write_test.cc
+++ b/cpp/src/arrow/ipc/read_write_test.cc
@@ -2276,7 +2276,8 @@ TEST(TestRecordBatchStreamReader, OpenFileFormatSuggestsFileReader) {
 
   io::BufferReader reader(helper.buffer_);
   // Check we mention using the file_reader when we detect file format
-  EXPECT_RAISES_WITH_MESSAGE_THAT(Invalid, ::testing::HasSubstr("file reader"),
+  EXPECT_RAISES_WITH_MESSAGE_THAT(Invalid,
+                                  ::testing::HasSubstr("Try the IPC file reader"),
                                   RecordBatchStreamReader::Open(&reader));
 }
 
@@ -2291,7 +2292,7 @@ TEST(TestRecordBatchStreamReader, CorruptDataDoesNotSuggestFileReader) {
   io::BufferReader reader(buffer);
   // Validate that we don't suggest file reader when file is just corrupt
   EXPECT_RAISES_WITH_MESSAGE_THAT(
-      Invalid, ::testing::Not(::testing::HasSubstr("file reader")),
+      Invalid, ::testing::Not(::testing::HasSubstr("Try the IPC file reader")),
       RecordBatchStreamReader::Open(&reader));
 }
 
@@ -2307,7 +2308,7 @@ TEST(TestRecordBatchFileReader, OpenStreamFormatSuggestsStreamReader) {
   auto buf_reader = std::make_shared<io::BufferReader>(helper.buffer_);
   // Check we mention using the stream_reader when we detect stream format
   EXPECT_RAISES_WITH_MESSAGE_THAT(
-      Invalid, ::testing::HasSubstr("stream reader"),
+      Invalid, ::testing::HasSubstr("use the IPC stream reader"),
       RecordBatchFileReader::Open(buf_reader.get(), helper.buffer_->size()));
 }
 

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -1890,7 +1890,7 @@ class RecordBatchFileReaderImpl : public RecordBatchFileReader {
           const auto magic_start = buffer->data() + sizeof(int32_t);
           if (std::string_view(reinterpret_cast<const char*>(magic_start), kMagicSize) !=
               kArrowMagicBytes) {
-            return Status::Invalid("Not an Arrow file");
+            return Status::Invalid("Not an Arrow file. If this is an Arrow IPC Streaming format file, try open_stream() instead.");
           }
 
           int32_t footer_length = bit_util::FromLittleEndian(

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -1890,7 +1890,9 @@ class RecordBatchFileReaderImpl : public RecordBatchFileReader {
           const auto magic_start = buffer->data() + sizeof(int32_t);
           if (std::string_view(reinterpret_cast<const char*>(magic_start), kMagicSize) !=
               kArrowMagicBytes) {
-            return Status::Invalid("Not an Arrow file. If this is an Arrow IPC Streaming format file, try open_stream() instead.");
+            return Status::Invalid(
+                "Not an Arrow file. If this is an Arrow IPC Streaming format file, try "
+                "open_stream() instead.");
           }
 
           int32_t footer_length = bit_util::FromLittleEndian(

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -1891,8 +1891,8 @@ class RecordBatchFileReaderImpl : public RecordBatchFileReader {
           if (std::string_view(reinterpret_cast<const char*>(magic_start), kMagicSize) !=
               kArrowMagicBytes) {
             return Status::Invalid(
-                "Not an Arrow file. If this is an Arrow IPC Streaming format file, try "
-                "open_stream() instead.");
+                "Not an Arrow file. If this is an Arrow IPC streaming format file, use "
+                "the IPC stream reader instead.");
           }
 
           int32_t footer_length = bit_util::FromLittleEndian(

--- a/cpp/src/arrow/ipc/reader.cc
+++ b/cpp/src/arrow/ipc/reader.cc
@@ -1891,7 +1891,7 @@ class RecordBatchFileReaderImpl : public RecordBatchFileReader {
           if (std::string_view(reinterpret_cast<const char*>(magic_start), kMagicSize) !=
               kArrowMagicBytes) {
             return Status::Invalid(
-                "Not an Arrow file. If this is an Arrow IPC streaming format file, use "
+                "Not an Arrow file. If this is an Arrow IPC stream, use "
                 "the IPC stream reader instead.");
           }
 


### PR DESCRIPTION
### Rationale for this change
The original error messages did not provide instruction to users on how to best correct their usage when opening an Arrow IPC file with the wrong reader.

### What changes are included in this PR?
Improved error messages when an IPC file is opened with the stream reader and vice versa, guiding users to the correct reader.

**PR review suggestions applied:**
- The file-magic detection in `DecodeMessage` now compares the decoded metadata length against a constant derived from `FromLittleEndian`, hopefully avoiding any little/big endianness issues
- The magic check now runs before the large `file->Read(metadata_length)` call, avoiding the 1.3 GB read when an IPC file is fed to the stream reader.
- Rewording error message again
- Test substring matches use more specific strings

### Are these changes tested?
Yes. New tests were added to OpenFileSuggestsFileReader
1. CorruptDataDoesNotSuggestFileReader
2. OpenStreamFormatSuggestsStreamReader

Existing Tests executed and passing.

### Are there any user-facing changes?
Yes, error messages when using the wrong IPC reader have been updated.


* GitHub Issue: #33823