### PR TITLE
GH-49729: [CI] Scope workflow permissions and secret inheritance

### DIFF
--- a/.github/workflows/cpp_extra.yml
+++ b/.github/workflows/cpp_extra.yml
@@ -87,7 +87,6 @@ jobs:
   check-labels:
     if: github.event_name != 'schedule' || github.repository == 'apache/arrow'
     uses: ./.github/workflows/check_labels.yml
-    secrets: inherit
     with:
       parent-workflow: cpp_extra
 
@@ -778,4 +777,6 @@ jobs:
       - odbc-msvc
       - odbc-nightly
     uses: ./.github/workflows/report_ci.yml
-    secrets: inherit
+    secrets:
+      ARROW_SMTP_PASSWORD: ${{ secrets.ARROW_SMTP_PASSWORD }}
+      ARROW_ZULIP_WEBHOOK: ${{ secrets.ARROW_ZULIP_WEBHOOK }}

--- a/.github/workflows/cuda_extra.yml
+++ b/.github/workflows/cuda_extra.yml
@@ -44,7 +44,6 @@ jobs:
   check-labels:
     if: github.event_name != 'schedule' || github.repository == 'apache/arrow'
     uses: ./.github/workflows/check_labels.yml
-    secrets: inherit
     with:
       parent-workflow: cuda_extra
 
@@ -134,4 +133,6 @@ jobs:
     needs:
       - docker
     uses: ./.github/workflows/report_ci.yml
-    secrets: inherit
+    secrets:
+      ARROW_SMTP_PASSWORD: ${{ secrets.ARROW_SMTP_PASSWORD }}
+      ARROW_ZULIP_WEBHOOK: ${{ secrets.ARROW_ZULIP_WEBHOOK }}

--- a/.github/workflows/package_linux.yml
+++ b/.github/workflows/package_linux.yml
@@ -64,19 +64,19 @@ concurrency:
 
 permissions:
   actions: read
-  # Upload to GitHub Release
-  contents: write
   pull-requests: read
 
 jobs:
   check-labels:
     if: github.event_name != 'schedule' || github.repository == 'apache/arrow'
     uses: ./.github/workflows/check_labels.yml
-    secrets: inherit
     with:
       parent-workflow: package_linux
 
   package:
+    permissions:
+      # Upload to GitHub Release
+      contents: write
     name: ${{ matrix.id }}
     runs-on: ${{ contains(matrix.id, 'amd64') && 'ubuntu-latest' || 'ubuntu-24.04-arm' }}
     needs: check-labels
@@ -333,4 +333,6 @@ jobs:
     needs:
       - package
     uses: ./.github/workflows/report_ci.yml
-    secrets: inherit
+    secrets:
+      ARROW_SMTP_PASSWORD: ${{ secrets.ARROW_SMTP_PASSWORD }}
+      ARROW_ZULIP_WEBHOOK: ${{ secrets.ARROW_ZULIP_WEBHOOK }}

--- a/.github/workflows/r_extra.yml
+++ b/.github/workflows/r_extra.yml
@@ -77,7 +77,6 @@ jobs:
   check-labels:
     if: github.event_name != 'schedule' || github.repository == 'apache/arrow'
     uses: ./.github/workflows/check_labels.yml
-    secrets: inherit
     with:
       parent-workflow: r_extra
 
@@ -227,4 +226,6 @@ jobs:
     needs:
       - docker
     uses: ./.github/workflows/report_ci.yml
-    secrets: inherit
+    secrets:
+      ARROW_SMTP_PASSWORD: ${{ secrets.ARROW_SMTP_PASSWORD }}
+      ARROW_ZULIP_WEBHOOK: ${{ secrets.ARROW_ZULIP_WEBHOOK }}

--- a/.github/workflows/report_ci.yml
+++ b/.github/workflows/report_ci.yml
@@ -19,6 +19,11 @@ name: Report CI results
 
 on:
   workflow_call:
+    secrets:
+      ARROW_SMTP_PASSWORD:
+        required: true
+      ARROW_ZULIP_WEBHOOK:
+        required: true
 
 permissions:
   actions: read


### PR DESCRIPTION
### Rationale for this change

CI jobs allow secrets to be inherited which could present a security risk

### What changes are included in this PR?

Scope permissions better

### Are these changes tested?

Will be once we merge

### Are there any user-facing changes?

No

* GitHub Issue: #49729