### PR TITLE
GH-49719: [C++] Rename vendored date header guards

### DIFF
--- a/cpp/src/arrow/vendored/datetime/date.h
+++ b/cpp/src/arrow/vendored/datetime/date.h
@@ -1,5 +1,5 @@
-#ifndef DATE_H
-#define DATE_H
+#ifndef ARROW_VENDORED_DATE_H
+#define ARROW_VENDORED_DATE_H
 
 // The MIT License (MIT)
 //
@@ -8242,4 +8242,4 @@ operator<<(std::basic_ostream<CharT, Traits>& os,
 # pragma GCC diagnostic pop
 #endif
 
-#endif  // DATE_H
+#endif  // ARROW_VENDORED_DATE_H

--- a/cpp/src/arrow/vendored/datetime/ios.h
+++ b/cpp/src/arrow/vendored/datetime/ios.h
@@ -24,8 +24,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-#ifndef ios_hpp
-#define ios_hpp
+#ifndef ARROW_VENDORED_ios_hpp
+#define ARROW_VENDORED_ios_hpp
 
 #if __APPLE__
 # include <TargetConditionals.h>
@@ -47,4 +47,4 @@
 #else   // !__APPLE__
 # define TARGET_OS_IPHONE 0
 #endif  // !__APPLE__
-#endif // ios_hpp
+#endif // ARROW_VENDORED_ios_hpp

--- a/cpp/src/arrow/vendored/datetime/tz.h
+++ b/cpp/src/arrow/vendored/datetime/tz.h
@@ -1,5 +1,5 @@
-#ifndef TZ_H
-#define TZ_H
+#ifndef ARROW_VENDORED_TZ_H
+#define ARROW_VENDORED_TZ_H
 
 // The MIT License (MIT)
 //
@@ -2805,4 +2805,4 @@ to_gps_time(const tai_time<Duration>& t)
 
 }  // namespace arrow_vendored::date
 
-#endif  // TZ_H
+#endif  // ARROW_VENDORED_TZ_H

--- a/cpp/src/arrow/vendored/datetime/tz_private.h
+++ b/cpp/src/arrow/vendored/datetime/tz_private.h
@@ -1,5 +1,5 @@
-#ifndef TZ_PRIVATE_H
-#define TZ_PRIVATE_H
+#ifndef ARROW_VENDORED_TZ_PRIVATE_H
+#define ARROW_VENDORED_TZ_PRIVATE_H
 
 // The MIT License (MIT)
 //
@@ -312,4 +312,4 @@ struct transition
 #include "tz.h"
 #endif
 
-#endif  // TZ_PRIVATE_H
+#endif  // ARROW_VENDORED_TZ_PRIVATE_H

--- a/cpp/src/arrow/vendored/datetime/update.sh
+++ b/cpp/src/arrow/vendored/datetime/update.sh
@@ -47,6 +47,12 @@ sed -i.bak -E \
     -e 's,include "date/,include ",g' \
     *.{cpp,h,mm}
 sed -i.bak -E \
+    -e 's/(#ifndef |#define |#endif.*\/\/ )(DATE_H)/\1ARROW_VENDORED_\2/g' \
+    -e 's/(#ifndef |#define |#endif.*\/\/ )(ios_hpp)/\1ARROW_VENDORED_\2/g' \
+    -e 's/(#ifndef |#define |#endif.*\/\/ )(TZ_H)/\1ARROW_VENDORED_\2/g' \
+    -e 's/(#ifndef |#define |#endif.*\/\/ )(TZ_PRIVATE_H)/\1ARROW_VENDORED_\2/g' \
+    *.h
+sed -i.bak -E \
     -e "s/changeset [0-9a-f]+/changeset ${commit_id}/g" \
     README.md
 rm *.bak

--- a/cpp/src/arrow/vendored/datetime/update.sh
+++ b/cpp/src/arrow/vendored/datetime/update.sh
@@ -47,10 +47,7 @@ sed -i.bak -E \
     -e 's,include "date/,include ",g' \
     *.{cpp,h,mm}
 sed -i.bak -E \
-    -e 's/(#ifndef |#define |#endif.*\/\/ )(DATE_H)/\1ARROW_VENDORED_\2/g' \
-    -e 's/(#ifndef |#define |#endif.*\/\/ )(ios_hpp)/\1ARROW_VENDORED_\2/g' \
-    -e 's/(#ifndef |#define |#endif.*\/\/ )(TZ_H)/\1ARROW_VENDORED_\2/g' \
-    -e 's/(#ifndef |#define |#endif.*\/\/ )(TZ_PRIVATE_H)/\1ARROW_VENDORED_\2/g' \
+    -e 's/(#ifndef |#define |#endif *\/\/ )(DATE_H|ios_hpp|TZ_H|TZ_PRIVATE_H)/\1ARROW_VENDORED_\2/g' \
     *.h
 sed -i.bak -E \
     -e "s/changeset [0-9a-f]+/changeset ${commit_id}/g" \


### PR DESCRIPTION
### Rationale for this change
Arrow ships with a vendored date library that places all definitions in the `arrow_vendored` namespace but keeps the original header guards, leading to problems when used in a project that also consumes the real date library.

### What changes are included in this PR?
Prefix all header guards with `ARROW_VENDORED_`. Update `update.sh` to apply the same rewrite automatically on future re-vendoring.

| File | Change |
|------|--------|
| `date.h` | `DATE_H` → `ARROW_VENDORED_DATE_H` |
| `tz.h` | `TZ_H` → `ARROW_VENDORED_TZ_H` |
| `tz_private.h` | `TZ_PRIVATE_H` → `ARROW_VENDORED_TZ_PRIVATE_H` |
| `ios.h` | `ios_hpp` → `ARROW_VENDORED_ios_hpp` |
| `update.sh` | Added sed block for automatic guard renaming |

### Are these changes tested?
Built Arrow C++ locally. No build breakage.

### Are there any user-facing changes?
No API changes. Fixes a header collision for projects that also use the real date library.

* GitHub Issue: #49719