### PR TITLE
GH-49783: [C++][FlightRPC][ODBC] Reuse connections across test suite

### DIFF
--- a/cpp/src/arrow/flight/sql/odbc/tests/CMakeLists.txt
+++ b/cpp/src/arrow/flight/sql/odbc/tests/CMakeLists.txt
@@ -42,11 +42,6 @@ set(ARROW_FLIGHT_SQL_ODBC_TEST_SRCS
     # GH-46889: move protobuf_test_util to a more common location
     ../../../../engine/substrait/protobuf_test_util.cc)
 
-# Resolve segmentation fault error on Windows platform due to Arrow Compute Library Initialization
-if(WIN32)
-  list(APPEND ARROW_FLIGHT_SQL_ODBC_TEST_SRCS ../../../../compute/test_env.cc)
-endif()
-
 # GH-49651 Link ODBC tests statically on Linux and dynamically on macOS/Windows
 if(WIN32 OR APPLE)
   set(ARROW_FLIGHT_SQL_ODBC_TEST_LINK_LIBS arrow_flight_sql_odbc_shared

--- a/cpp/src/arrow/flight/sql/odbc/tests/CMakeLists.txt
+++ b/cpp/src/arrow/flight/sql/odbc/tests/CMakeLists.txt
@@ -42,6 +42,11 @@ set(ARROW_FLIGHT_SQL_ODBC_TEST_SRCS
     # GH-46889: move protobuf_test_util to a more common location
     ../../../../engine/substrait/protobuf_test_util.cc)
 
+# Resolve segmentation fault error on Windows platform due to Arrow Compute Library Initialization
+if(WIN32)
+  list(APPEND ARROW_FLIGHT_SQL_ODBC_TEST_SRCS ../../../../compute/test_env.cc)
+endif()
+
 # GH-49651 Link ODBC tests statically on Linux and dynamically on macOS/Windows
 if(WIN32 OR APPLE)
   set(ARROW_FLIGHT_SQL_ODBC_TEST_LINK_LIBS arrow_flight_sql_odbc_shared

--- a/cpp/src/arrow/flight/sql/odbc/tests/columns_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/columns_test.cc
@@ -393,28 +393,29 @@ TYPED_TEST(ColumnsTest, SQLColumnsTestInputData) {
   SQLWCHAR column_name[] = L"";
 
   // All values populated
-  EXPECT_EQ(SQL_SUCCESS, SQLColumns(stmt, catalog_name, sizeof(catalog_name), schema_name,
-                                    sizeof(schema_name), table_name, sizeof(table_name),
-                                    column_name, sizeof(column_name)));
-  ValidateFetch(stmt, SQL_NO_DATA);
+  EXPECT_EQ(SQL_SUCCESS,
+            SQLColumns(this->stmt, catalog_name, sizeof(catalog_name), schema_name,
+                       sizeof(schema_name), table_name, sizeof(table_name), column_name,
+                       sizeof(column_name)));
+  ValidateFetch(this->stmt, SQL_NO_DATA);
 
   // Sizes are zeros
-  EXPECT_EQ(SQL_SUCCESS, SQLColumns(stmt, catalog_name, 0, schema_name, 0, table_name, 0,
-                                    column_name, 0));
-  ValidateFetch(stmt, SQL_NO_DATA);
+  EXPECT_EQ(SQL_SUCCESS, SQLColumns(this->stmt, catalog_name, 0, schema_name, 0,
+                                    table_name, 0, column_name, 0));
+  ValidateFetch(this->stmt, SQL_NO_DATA);
 
   // Names are nulls
-  EXPECT_EQ(SQL_SUCCESS,
-            SQLColumns(stmt, nullptr, sizeof(catalog_name), nullptr, sizeof(schema_name),
-                       nullptr, sizeof(table_name), nullptr, sizeof(column_name)));
-  ValidateFetch(stmt, SQL_SUCCESS);
+  EXPECT_EQ(SQL_SUCCESS, SQLColumns(this->stmt, nullptr, sizeof(catalog_name), nullptr,
+                                    sizeof(schema_name), nullptr, sizeof(table_name),
+                                    nullptr, sizeof(column_name)));
+  ValidateFetch(this->stmt, SQL_SUCCESS);
   // Close statement cursor to avoid leaving in an invalid state
-  SQLFreeStmt(stmt, SQL_CLOSE);
+  SQLFreeStmt(this->stmt, SQL_CLOSE);
 
   // Names are nulls and sizes are zeros
   EXPECT_EQ(SQL_SUCCESS,
-            SQLColumns(stmt, nullptr, 0, nullptr, 0, nullptr, 0, nullptr, 0));
-  ValidateFetch(stmt, SQL_SUCCESS);
+            SQLColumns(this->stmt, nullptr, 0, nullptr, 0, nullptr, 0, nullptr, 0));
+  ValidateFetch(this->stmt, SQL_SUCCESS);
 }
 
 TEST_F(ColumnsMockTest, TestSQLColumnsAllColumns) {
@@ -424,17 +425,17 @@ TEST_F(ColumnsMockTest, TestSQLColumnsAllColumns) {
   SQLWCHAR table_pattern[] = L"%";
   SQLWCHAR column_pattern[] = L"%";
 
-  ASSERT_EQ(SQL_SUCCESS, SQLColumns(stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
+  ASSERT_EQ(SQL_SUCCESS, SQLColumns(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
                                     table_pattern, SQL_NTS, column_pattern, SQL_NTS));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
   // mock limitation: SQLite mock server returns 10 for bigint size when spec indicates
   // should be 19
   // DECIMAL_DIGITS should be 0 for bigint type since it is exact
   // mock limitation: SQLite mock server returns 10 for bigint decimal digits when spec
   // indicates should be 0
-  CheckMockSQLColumns(stmt,
+  CheckMockSQLColumns(this->stmt,
                       std::wstring(L"main"),          // expected_catalog
                       std::wstring(L"foreignTable"),  // expected_table
                       std::wstring(L"id"),            // expected_column
@@ -452,9 +453,9 @@ TEST_F(ColumnsMockTest, TestSQLColumnsAllColumns) {
                       std::wstring(L"YES"));  // expected_is_nullable
 
   // Check 2nd Column
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
-  CheckMockSQLColumns(stmt,
+  CheckMockSQLColumns(this->stmt,
                       std::wstring(L"main"),          // expected_catalog
                       std::wstring(L"foreignTable"),  // expected_table
                       std::wstring(L"foreignName"),   // expected_column
@@ -473,9 +474,9 @@ TEST_F(ColumnsMockTest, TestSQLColumnsAllColumns) {
                       std::wstring(L"YES"));  // expected_is_nullable
 
   // Check 3rd Column
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
-  CheckMockSQLColumns(stmt,
+  CheckMockSQLColumns(this->stmt,
                       std::wstring(L"main"),          // expected_catalog
                       std::wstring(L"foreignTable"),  // expected_table
                       std::wstring(L"value"),         // expected_column
@@ -493,9 +494,9 @@ TEST_F(ColumnsMockTest, TestSQLColumnsAllColumns) {
                       std::wstring(L"YES"));  // expected_is_nullable
 
   // Check 4th Column
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
-  CheckMockSQLColumns(stmt,
+  CheckMockSQLColumns(this->stmt,
                       std::wstring(L"main"),      // expected_catalog
                       std::wstring(L"intTable"),  // expected_table
                       std::wstring(L"id"),        // expected_column
@@ -513,9 +514,9 @@ TEST_F(ColumnsMockTest, TestSQLColumnsAllColumns) {
                       std::wstring(L"YES"));  // expected_is_nullable
 
   // Check 5th Column
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
-  CheckMockSQLColumns(stmt,
+  CheckMockSQLColumns(this->stmt,
                       std::wstring(L"main"),      // expected_catalog
                       std::wstring(L"intTable"),  // expected_table
                       std::wstring(L"keyName"),   // expected_column
@@ -534,9 +535,9 @@ TEST_F(ColumnsMockTest, TestSQLColumnsAllColumns) {
                       std::wstring(L"YES"));  // expected_is_nullable
 
   // Check 6th Column
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
-  CheckMockSQLColumns(stmt,
+  CheckMockSQLColumns(this->stmt,
                       std::wstring(L"main"),      // expected_catalog
                       std::wstring(L"intTable"),  // expected_table
                       std::wstring(L"value"),     // expected_column
@@ -554,9 +555,9 @@ TEST_F(ColumnsMockTest, TestSQLColumnsAllColumns) {
                       std::wstring(L"YES"));  // expected_is_nullable
 
   // Check 7th Column
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
-  CheckMockSQLColumns(stmt,
+  CheckMockSQLColumns(this->stmt,
                       std::wstring(L"main"),       // expected_catalog
                       std::wstring(L"intTable"),   // expected_table
                       std::wstring(L"foreignId"),  // expected_column
@@ -586,13 +587,13 @@ TEST_F(ColumnsMockTest, TestSQLColumnsAllTypes) {
   SQLWCHAR table_pattern[] = L"AllTypesTable";
   SQLWCHAR column_pattern[] = L"%";
 
-  ASSERT_EQ(SQL_SUCCESS, SQLColumns(stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
+  ASSERT_EQ(SQL_SUCCESS, SQLColumns(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
                                     table_pattern, SQL_NTS, column_pattern, SQL_NTS));
 
   // Fetch SQLColumn data for 1st column in AllTypesTable
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
-  CheckMockSQLColumns(stmt,
+  CheckMockSQLColumns(this->stmt,
                       std::wstring(L"main"),           // expected_catalog
                       std::wstring(L"AllTypesTable"),  // expected_table
                       std::wstring(L"bigint_col"),     // expected_column
@@ -612,9 +613,9 @@ TEST_F(ColumnsMockTest, TestSQLColumnsAllTypes) {
                       std::wstring(L"YES"));  // expected_is_nullable
 
   // Check SQLColumn data for 2nd column in AllTypesTable
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
-  CheckMockSQLColumns(stmt,
+  CheckMockSQLColumns(this->stmt,
                       std::wstring(L"main"),           // expected_catalog
                       std::wstring(L"AllTypesTable"),  // expected_table
                       std::wstring(L"char_col"),       // expected_column
@@ -633,9 +634,9 @@ TEST_F(ColumnsMockTest, TestSQLColumnsAllTypes) {
                       std::wstring(L"YES"));  // expected_is_nullable
 
   // Check SQLColumn data for 3rd column in AllTypesTable
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
-  CheckMockSQLColumns(stmt,
+  CheckMockSQLColumns(this->stmt,
                       std::wstring(L"main"),           // expected_catalog
                       std::wstring(L"AllTypesTable"),  // expected_table
                       std::wstring(L"varbinary_col"),  // expected_column
@@ -654,9 +655,9 @@ TEST_F(ColumnsMockTest, TestSQLColumnsAllTypes) {
                       std::wstring(L"YES"));  // expected_is_nullable
 
   // Check SQLColumn data for 4th column in AllTypesTable
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
-  CheckMockSQLColumns(stmt,
+  CheckMockSQLColumns(this->stmt,
                       std::wstring(L"main"),           // expected_catalog
                       std::wstring(L"AllTypesTable"),  // expected_table
                       std::wstring(L"double_col"),     // expected_column
@@ -674,7 +675,7 @@ TEST_F(ColumnsMockTest, TestSQLColumnsAllTypes) {
                       std::wstring(L"YES"));           // expected_is_nullable
 
   // There should be no more column data
-  ASSERT_EQ(SQL_NO_DATA, SQLFetch(stmt));
+  ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
 
   DropAllDataTypeTable();
 }
@@ -689,13 +690,13 @@ TEST_F(ColumnsMockTest, TestSQLColumnsUnicode) {
   SQLWCHAR table_pattern[] = L"数据";
   SQLWCHAR column_pattern[] = L"%";
 
-  ASSERT_EQ(SQL_SUCCESS, SQLColumns(stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
+  ASSERT_EQ(SQL_SUCCESS, SQLColumns(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
                                     table_pattern, SQL_NTS, column_pattern, SQL_NTS));
 
   // Check SQLColumn data for 1st column
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
-  CheckMockSQLColumns(stmt,
+  CheckMockSQLColumns(this->stmt,
                       std::wstring(L"main"),      // expected_catalog
                       std::wstring(L"数据"),      // expected_table
                       std::wstring(L"资料"),      // expected_column
@@ -714,7 +715,7 @@ TEST_F(ColumnsMockTest, TestSQLColumnsUnicode) {
                       std::wstring(L"YES"));  // expected_is_nullable
 
   // There should be no more column data
-  EXPECT_EQ(SQL_NO_DATA, SQLFetch(stmt));
+  EXPECT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
 
   DropUnicodeTable();
 }
@@ -726,14 +727,14 @@ TEST_F(ColumnsRemoteTest, TestSQLColumnsAllTypes) {
   SQLWCHAR table_pattern[] = L"ODBCTest";
   SQLWCHAR column_pattern[] = L"%";
 
-  ASSERT_EQ(SQL_SUCCESS, SQLColumns(stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
+  ASSERT_EQ(SQL_SUCCESS, SQLColumns(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
                                     table_pattern, SQL_NTS, column_pattern, SQL_NTS));
 
   // Check 1st Column
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
   CheckRemoteSQLColumns(
-      stmt,
+      this->stmt,
       std::wstring(L"$scratch"),      // expected_schema
       std::wstring(L"ODBCTest"),      // expected_table
       std::wstring(L"sinteger_max"),  // expected_column
@@ -751,10 +752,10 @@ TEST_F(ColumnsRemoteTest, TestSQLColumnsAllTypes) {
       std::wstring(L"YES"));  // expected_is_nullable
 
   // Check 2nd Column
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
   CheckRemoteSQLColumns(
-      stmt,
+      this->stmt,
       std::wstring(L"$scratch"),     // expected_schema
       std::wstring(L"ODBCTest"),     // expected_table
       std::wstring(L"sbigint_max"),  // expected_column
@@ -772,9 +773,9 @@ TEST_F(ColumnsRemoteTest, TestSQLColumnsAllTypes) {
       std::wstring(L"YES"));  // expected_is_nullable
 
   // Check 3rd Column
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
-  CheckRemoteSQLColumns(stmt,
+  CheckRemoteSQLColumns(this->stmt,
                         std::wstring(L"$scratch"),          // expected_schema
                         std::wstring(L"ODBCTest"),          // expected_table
                         std::wstring(L"decimal_positive"),  // expected_column
@@ -792,9 +793,9 @@ TEST_F(ColumnsRemoteTest, TestSQLColumnsAllTypes) {
                         std::wstring(L"YES"));              // expected_is_nullable
 
   // Check 4th Column
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
-  CheckRemoteSQLColumns(stmt,
+  CheckRemoteSQLColumns(this->stmt,
                         std::wstring(L"$scratch"),   // expected_schema
                         std::wstring(L"ODBCTest"),   // expected_table
                         std::wstring(L"float_max"),  // expected_column
@@ -812,9 +813,9 @@ TEST_F(ColumnsRemoteTest, TestSQLColumnsAllTypes) {
                         std::wstring(L"YES"));  // expected_is_nullable
 
   // Check 5th Column
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
-  CheckRemoteSQLColumns(stmt,
+  CheckRemoteSQLColumns(this->stmt,
                         std::wstring(L"$scratch"),    // expected_schema
                         std::wstring(L"ODBCTest"),    // expected_table
                         std::wstring(L"double_max"),  // expected_column
@@ -832,9 +833,9 @@ TEST_F(ColumnsRemoteTest, TestSQLColumnsAllTypes) {
                         std::wstring(L"YES"));  // expected_is_nullable
 
   // Check 6th Column
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
-  CheckRemoteSQLColumns(stmt,
+  CheckRemoteSQLColumns(this->stmt,
                         std::wstring(L"$scratch"),  // expected_schema
                         std::wstring(L"ODBCTest"),  // expected_table
                         std::wstring(L"bit_true"),  // expected_column
@@ -856,10 +857,10 @@ TEST_F(ColumnsRemoteTest, TestSQLColumnsAllTypes) {
   // DATA_TYPE field
 
   // Check 7th Column
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
   CheckRemoteSQLColumns(
-      stmt,
+      this->stmt,
       std::wstring(L"$scratch"),  // expected_schema
       std::wstring(L"ODBCTest"),  // expected_table
       std::wstring(L"date_max"),  // expected_column
@@ -877,10 +878,10 @@ TEST_F(ColumnsRemoteTest, TestSQLColumnsAllTypes) {
       std::wstring(L"YES"));  // expected_is_nullable
 
   // Check 8th Column
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
   CheckRemoteSQLColumns(
-      stmt,
+      this->stmt,
       std::wstring(L"$scratch"),  // expected_schema
       std::wstring(L"ODBCTest"),  // expected_table
       std::wstring(L"time_max"),  // expected_column
@@ -898,10 +899,10 @@ TEST_F(ColumnsRemoteTest, TestSQLColumnsAllTypes) {
       std::wstring(L"YES"));  // expected_is_nullable
 
   // Check 9th Column
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
   CheckRemoteSQLColumns(
-      stmt,
+      this->stmt,
       std::wstring(L"$scratch"),       // expected_schema
       std::wstring(L"ODBCTest"),       // expected_table
       std::wstring(L"timestamp_max"),  // expected_column
@@ -919,7 +920,7 @@ TEST_F(ColumnsRemoteTest, TestSQLColumnsAllTypes) {
       std::wstring(L"YES"));  // expected_is_nullable
 
   // There is no more column
-  EXPECT_EQ(SQL_NO_DATA, SQLFetch(stmt));
+  EXPECT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
 }
 
 TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColumnsAllTypesODBCVer2) {
@@ -929,14 +930,14 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColumnsAllTypesODBCVer2) {
   SQLWCHAR table_pattern[] = L"ODBCTest";
   SQLWCHAR column_pattern[] = L"%";
 
-  ASSERT_EQ(SQL_SUCCESS, SQLColumns(stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
+  ASSERT_EQ(SQL_SUCCESS, SQLColumns(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
                                     table_pattern, SQL_NTS, column_pattern, SQL_NTS));
 
   // Check 1st Column
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
   CheckRemoteSQLColumns(
-      stmt,
+      this->stmt,
       std::wstring(L"$scratch"),      // expected_schema
       std::wstring(L"ODBCTest"),      // expected_table
       std::wstring(L"sinteger_max"),  // expected_column
@@ -954,10 +955,10 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColumnsAllTypesODBCVer2) {
       std::wstring(L"YES"));  // expected_is_nullable
 
   // Check 2nd Column
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
   CheckRemoteSQLColumns(
-      stmt,
+      this->stmt,
       std::wstring(L"$scratch"),     // expected_schema
       std::wstring(L"ODBCTest"),     // expected_table
       std::wstring(L"sbigint_max"),  // expected_column
@@ -975,9 +976,9 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColumnsAllTypesODBCVer2) {
       std::wstring(L"YES"));  // expected_is_nullable
 
   // Check 3rd Column
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
-  CheckRemoteSQLColumns(stmt,
+  CheckRemoteSQLColumns(this->stmt,
                         std::wstring(L"$scratch"),          // expected_schema
                         std::wstring(L"ODBCTest"),          // expected_table
                         std::wstring(L"decimal_positive"),  // expected_column
@@ -995,9 +996,9 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColumnsAllTypesODBCVer2) {
                         std::wstring(L"YES"));              // expected_is_nullable
 
   // Check 4th Column
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
-  CheckRemoteSQLColumns(stmt,
+  CheckRemoteSQLColumns(this->stmt,
                         std::wstring(L"$scratch"),   // expected_schema
                         std::wstring(L"ODBCTest"),   // expected_table
                         std::wstring(L"float_max"),  // expected_column
@@ -1015,9 +1016,9 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColumnsAllTypesODBCVer2) {
                         std::wstring(L"YES"));  // expected_is_nullable
 
   // Check 5th Column
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
-  CheckRemoteSQLColumns(stmt,
+  CheckRemoteSQLColumns(this->stmt,
                         std::wstring(L"$scratch"),    // expected_schema
                         std::wstring(L"ODBCTest"),    // expected_table
                         std::wstring(L"double_max"),  // expected_column
@@ -1035,9 +1036,9 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColumnsAllTypesODBCVer2) {
                         std::wstring(L"YES"));  // expected_is_nullable
 
   // Check 6th Column
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
-  CheckRemoteSQLColumns(stmt,
+  CheckRemoteSQLColumns(this->stmt,
                         std::wstring(L"$scratch"),  // expected_schema
                         std::wstring(L"ODBCTest"),  // expected_table
                         std::wstring(L"bit_true"),  // expected_column
@@ -1058,10 +1059,10 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColumnsAllTypesODBCVer2) {
   // ODBC ver 2 returns SQL_DATE, SQL_TIME, and SQL_TIMESTAMP in the DATA_TYPE field
 
   // Check 7th Column
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
   CheckRemoteSQLColumns(
-      stmt,
+      this->stmt,
       std::wstring(L"$scratch"),  // expected_schema
       std::wstring(L"ODBCTest"),  // expected_table
       std::wstring(L"date_max"),  // expected_column
@@ -1079,10 +1080,10 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColumnsAllTypesODBCVer2) {
       std::wstring(L"YES"));  // expected_is_nullable
 
   // Check 8th Column
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
   CheckRemoteSQLColumns(
-      stmt,
+      this->stmt,
       std::wstring(L"$scratch"),  // expected_schema
       std::wstring(L"ODBCTest"),  // expected_table
       std::wstring(L"time_max"),  // expected_column
@@ -1100,10 +1101,10 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColumnsAllTypesODBCVer2) {
       std::wstring(L"YES"));  // expected_is_nullable
 
   // Check 9th Column
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
   CheckRemoteSQLColumns(
-      stmt,
+      this->stmt,
       std::wstring(L"$scratch"),       // expected_schema
       std::wstring(L"ODBCTest"),       // expected_table
       std::wstring(L"timestamp_max"),  // expected_column
@@ -1121,7 +1122,7 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColumnsAllTypesODBCVer2) {
       std::wstring(L"YES"));  // expected_is_nullable
 
   // There is no more column
-  EXPECT_EQ(SQL_NO_DATA, SQLFetch(stmt));
+  EXPECT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
 }
 
 TEST_F(ColumnsMockTest, TestSQLColumnsColumnPattern) {
@@ -1131,13 +1132,13 @@ TEST_F(ColumnsMockTest, TestSQLColumnsColumnPattern) {
   SQLWCHAR table_pattern[] = L"%";
   SQLWCHAR column_pattern[] = L"id";
 
-  EXPECT_EQ(SQL_SUCCESS, SQLColumns(stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
+  EXPECT_EQ(SQL_SUCCESS, SQLColumns(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
                                     table_pattern, SQL_NTS, column_pattern, SQL_NTS));
 
   // Check 1st Column
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
-  CheckMockSQLColumns(stmt,
+  CheckMockSQLColumns(this->stmt,
                       std::wstring(L"main"),          // expected_catalog
                       std::wstring(L"foreignTable"),  // expected_table
                       std::wstring(L"id"),            // expected_column
@@ -1155,9 +1156,9 @@ TEST_F(ColumnsMockTest, TestSQLColumnsColumnPattern) {
                       std::wstring(L"YES"));  // expected_is_nullable
 
   // Check 2nd Column
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
-  CheckMockSQLColumns(stmt,
+  CheckMockSQLColumns(this->stmt,
                       std::wstring(L"main"),      // expected_catalog
                       std::wstring(L"intTable"),  // expected_table
                       std::wstring(L"id"),        // expected_column
@@ -1175,7 +1176,7 @@ TEST_F(ColumnsMockTest, TestSQLColumnsColumnPattern) {
                       std::wstring(L"YES"));  // expected_is_nullable
 
   // There is no more column
-  EXPECT_EQ(SQL_NO_DATA, SQLFetch(stmt));
+  EXPECT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
 }
 
 TEST_F(ColumnsMockTest, TestSQLColumnsTableColumnPattern) {
@@ -1185,13 +1186,13 @@ TEST_F(ColumnsMockTest, TestSQLColumnsTableColumnPattern) {
   SQLWCHAR table_pattern[] = L"foreignTable";
   SQLWCHAR column_pattern[] = L"id";
 
-  ASSERT_EQ(SQL_SUCCESS, SQLColumns(stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
+  ASSERT_EQ(SQL_SUCCESS, SQLColumns(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
                                     table_pattern, SQL_NTS, column_pattern, SQL_NTS));
 
   // Check 1st Column
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
-  CheckMockSQLColumns(stmt,
+  CheckMockSQLColumns(this->stmt,
                       std::wstring(L"main"),          // expected_catalog
                       std::wstring(L"foreignTable"),  // expected_table
                       std::wstring(L"id"),            // expected_column
@@ -1209,28 +1210,27 @@ TEST_F(ColumnsMockTest, TestSQLColumnsTableColumnPattern) {
                       std::wstring(L"YES"));  // expected_is_nullable
 
   // There is no more column
-  EXPECT_EQ(SQL_NO_DATA, SQLFetch(stmt));
+  EXPECT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
 }
 
 TEST_F(ColumnsMockTest, TestSQLColumnsInvalidTablePattern) {
   SQLWCHAR table_pattern[] = L"non-existent-table";
   SQLWCHAR column_pattern[] = L"%";
 
-  ASSERT_EQ(SQL_SUCCESS, SQLColumns(stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
+  ASSERT_EQ(SQL_SUCCESS, SQLColumns(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
                                     table_pattern, SQL_NTS, column_pattern, SQL_NTS));
 
   // There is no column from filter
-  EXPECT_EQ(SQL_NO_DATA, SQLFetch(stmt));
+  EXPECT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
 }
 
 TYPED_TEST(ColumnsTest, SQLColAttributeTestInputData) {
   SQLWCHAR wsql[] = L"SELECT 1 as col1;";
   SQLSMALLINT wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len))
-      << GetOdbcErrorMessage(SQL_HANDLE_DBC, conn);
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
   SQLUSMALLINT idx = 1;
   SQLWCHAR character_attr[kOdbcBufferSize];
@@ -1239,33 +1239,33 @@ TYPED_TEST(ColumnsTest, SQLColAttributeTestInputData) {
 
   // All character values populated
   EXPECT_EQ(SQL_SUCCESS,
-            SQLColAttribute(stmt, idx, SQL_DESC_NAME, character_attr,
+            SQLColAttribute(this->stmt, idx, SQL_DESC_NAME, character_attr,
                             std::wcslen(character_attr), &character_attr_len, nullptr));
 
   // All numeric values populated
-  EXPECT_EQ(SQL_SUCCESS,
-            SQLColAttribute(stmt, idx, SQL_DESC_COUNT, 0, 0, nullptr, &numeric_attr));
+  EXPECT_EQ(SQL_SUCCESS, SQLColAttribute(this->stmt, idx, SQL_DESC_COUNT, 0, 0, nullptr,
+                                         &numeric_attr));
 
   // Pass null values, driver should not throw error
-  EXPECT_EQ(SQL_SUCCESS,
-            SQLColAttribute(stmt, idx, SQL_COLUMN_TABLE_NAME, 0, 0, nullptr, nullptr));
+  EXPECT_EQ(SQL_SUCCESS, SQLColAttribute(this->stmt, idx, SQL_COLUMN_TABLE_NAME, 0, 0,
+                                         nullptr, nullptr));
 
   EXPECT_EQ(SQL_SUCCESS,
-            SQLColAttribute(stmt, idx, SQL_DESC_COUNT, 0, 0, nullptr, nullptr));
+            SQLColAttribute(this->stmt, idx, SQL_DESC_COUNT, 0, 0, nullptr, nullptr));
 }
 
 TYPED_TEST(ColumnsTest, SQLColAttributeGetCharacterLen) {
   SQLWCHAR wsql[] = L"SELECT 1 as col1;";
   SQLSMALLINT wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
   SQLSMALLINT character_attr_len = 0;
 
   // Check length of character attribute
-  ASSERT_EQ(SQL_SUCCESS, SQLColAttribute(stmt, 1, SQL_DESC_BASE_COLUMN_NAME, 0, 0,
+  ASSERT_EQ(SQL_SUCCESS, SQLColAttribute(this->stmt, 1, SQL_DESC_BASE_COLUMN_NAME, 0, 0,
                                          &character_attr_len, nullptr));
   EXPECT_EQ(4 * GetSqlWCharSize(), character_attr_len);
 }
@@ -1274,9 +1274,9 @@ TYPED_TEST(ColumnsTest, SQLColAttributeInvalidFieldId) {
   SQLWCHAR wsql[] = L"SELECT 1 as col1;";
   SQLSMALLINT wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
   SQLUSMALLINT invalid_field_id = -100;
   SQLUSMALLINT idx = 1;
@@ -1285,29 +1285,30 @@ TYPED_TEST(ColumnsTest, SQLColAttributeInvalidFieldId) {
   SQLLEN numeric_attr = 0;
 
   ASSERT_EQ(SQL_ERROR,
-            SQLColAttribute(stmt, idx, invalid_field_id, character_attr,
+            SQLColAttribute(this->stmt, idx, invalid_field_id, character_attr,
                             std::wcslen(character_attr), &character_attr_len, nullptr));
   // Verify invalid descriptor field identifier error state is returned
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorStateHY091);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorStateHY091);
 }
 
 TYPED_TEST(ColumnsTest, SQLColAttributeInvalidColId) {
   SQLWCHAR wsql[] = L"SELECT 1 as col1;";
   SQLSMALLINT wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
   SQLUSMALLINT invalid_col_id = 2;
   SQLWCHAR character_attr[kOdbcBufferSize];
   SQLSMALLINT character_attr_len = 0;
 
-  ASSERT_EQ(SQL_ERROR, SQLColAttribute(stmt, invalid_col_id, SQL_DESC_BASE_COLUMN_NAME,
-                                       character_attr, std::wcslen(character_attr),
-                                       &character_attr_len, nullptr));
+  ASSERT_EQ(SQL_ERROR,
+            SQLColAttribute(this->stmt, invalid_col_id, SQL_DESC_BASE_COLUMN_NAME,
+                            character_attr, std::wcslen(character_attr),
+                            &character_attr_len, nullptr));
   // Verify invalid descriptor index error state is returned
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorState07009);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorState07009);
 }
 
 TEST_F(ColumnsMockTest, TestSQLColAttributeAllTypes) {
@@ -1316,11 +1317,11 @@ TEST_F(ColumnsMockTest, TestSQLColAttributeAllTypes) {
   SQLWCHAR wsql[] = L"SELECT * from AllTypesTable;";
   SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
-  CheckSQLColAttribute(stmt, 1,
+  CheckSQLColAttribute(this->stmt, 1,
                        "bigint_col",   // expected_column_name
                        SQL_BIGINT,     // expected_data_type
                        SQL_BIGINT,     // expected_concise_type
@@ -1337,7 +1338,7 @@ TEST_F(ColumnsMockTest, TestSQLColAttributeAllTypes) {
                        SQL_PRED_NONE,  // expected_searchable
                        SQL_FALSE);     // expected_unsigned_column
 
-  CheckSQLColAttribute(stmt, 2,
+  CheckSQLColAttribute(this->stmt, 2,
                        "char_col",     // expected_column_name
                        SQL_WVARCHAR,   // expected_data_type
                        SQL_WVARCHAR,   // expected_concise_type
@@ -1354,7 +1355,7 @@ TEST_F(ColumnsMockTest, TestSQLColAttributeAllTypes) {
                        SQL_PRED_NONE,  // expected_searchable
                        SQL_TRUE);      // expected_unsigned_column
 
-  CheckSQLColAttribute(stmt, 3,
+  CheckSQLColAttribute(this->stmt, 3,
                        "varbinary_col",  // expected_column_name
                        SQL_BINARY,       // expected_data_type
                        SQL_BINARY,       // expected_concise_type
@@ -1371,7 +1372,7 @@ TEST_F(ColumnsMockTest, TestSQLColAttributeAllTypes) {
                        SQL_PRED_NONE,    // expected_searchable
                        SQL_TRUE);        // expected_unsigned_column
 
-  CheckSQLColAttribute(stmt, 4,
+  CheckSQLColAttribute(this->stmt, 4,
                        "double_col",   // expected_column_name
                        SQL_DOUBLE,     // expected_data_type
                        SQL_DOUBLE,     // expected_concise_type
@@ -1400,10 +1401,10 @@ TEST_F(ColumnsOdbcV2MockTest, TestSQLColAttributesAllTypes) {
   SQLWCHAR wsql[] = L"SELECT * from AllTypesTable;";
   SQLSMALLINT wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
-  CheckSQLColAttributes(stmt, 1,
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
+  CheckSQLColAttributes(this->stmt, 1,
                         "bigint_col",   // expected_column_name
                         SQL_BIGINT,     // expected_data_type
                         20,             // expected_display_size
@@ -1415,7 +1416,7 @@ TEST_F(ColumnsOdbcV2MockTest, TestSQLColAttributesAllTypes) {
                         SQL_PRED_NONE,  // expected_searchable
                         SQL_FALSE);     // expected_unsigned_column
 
-  CheckSQLColAttributes(stmt, 2,
+  CheckSQLColAttributes(this->stmt, 2,
                         "char_col",     // expected_column_name
                         SQL_WVARCHAR,   // expected_data_type
                         0,              // expected_display_size
@@ -1427,7 +1428,7 @@ TEST_F(ColumnsOdbcV2MockTest, TestSQLColAttributesAllTypes) {
                         SQL_PRED_NONE,  // expected_searchable
                         SQL_TRUE);      // expected_unsigned_column
 
-  CheckSQLColAttributes(stmt, 3,
+  CheckSQLColAttributes(this->stmt, 3,
                         "varbinary_col",  // expected_column_name
                         SQL_BINARY,       // expected_data_type
                         0,                // expected_display_size
@@ -1439,7 +1440,7 @@ TEST_F(ColumnsOdbcV2MockTest, TestSQLColAttributesAllTypes) {
                         SQL_PRED_NONE,    // expected_searchable
                         SQL_TRUE);        // expected_unsigned_column
 
-  CheckSQLColAttributes(stmt, 4,
+  CheckSQLColAttributes(this->stmt, 4,
                         "double_col",   // expected_column_name
                         SQL_DOUBLE,     // expected_data_type
                         24,             // expected_display_size
@@ -1461,11 +1462,11 @@ TEST_F(ColumnsRemoteTest, TestSQLColAttributeAllTypes) {
   SQLWCHAR wsql[] = L"SELECT * from $scratch.ODBCTest;";
   SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
-  CheckSQLColAttribute(stmt, 1,
+  CheckSQLColAttribute(this->stmt, 1,
                        "sinteger_max",  // expected_column_name
                        SQL_INTEGER,     // expected_data_type
                        SQL_INTEGER,     // expected_concise_type
@@ -1482,7 +1483,7 @@ TEST_F(ColumnsRemoteTest, TestSQLColAttributeAllTypes) {
                        SQL_SEARCHABLE,  // expected_searchable
                        SQL_FALSE);      // expected_unsigned_column
 
-  CheckSQLColAttribute(stmt, 2,
+  CheckSQLColAttribute(this->stmt, 2,
                        "sbigint_max",   // expected_column_name
                        SQL_BIGINT,      // expected_data_type
                        SQL_BIGINT,      // expected_concise_type
@@ -1499,7 +1500,7 @@ TEST_F(ColumnsRemoteTest, TestSQLColAttributeAllTypes) {
                        SQL_SEARCHABLE,  // expected_searchable
                        SQL_FALSE);      // expected_unsigned_column
 
-  CheckSQLColAttribute(stmt, 3,
+  CheckSQLColAttribute(this->stmt, 3,
                        "decimal_positive",  // expected_column_name
                        SQL_DECIMAL,         // expected_data_type
                        SQL_DECIMAL,         // expected_concise_type
@@ -1516,7 +1517,7 @@ TEST_F(ColumnsRemoteTest, TestSQLColAttributeAllTypes) {
                        SQL_SEARCHABLE,      // expected_searchable
                        SQL_FALSE);          // expected_unsigned_column
 
-  CheckSQLColAttribute(stmt, 4,
+  CheckSQLColAttribute(this->stmt, 4,
                        "float_max",     // expected_column_name
                        SQL_FLOAT,       // expected_data_type
                        SQL_FLOAT,       // expected_concise_type
@@ -1533,7 +1534,7 @@ TEST_F(ColumnsRemoteTest, TestSQLColAttributeAllTypes) {
                        SQL_SEARCHABLE,  // expected_searchable
                        SQL_FALSE);      // expected_unsigned_column
 
-  CheckSQLColAttribute(stmt, 5,
+  CheckSQLColAttribute(this->stmt, 5,
                        "double_max",    // expected_column_name
                        SQL_DOUBLE,      // expected_data_type
                        SQL_DOUBLE,      // expected_concise_type
@@ -1550,7 +1551,7 @@ TEST_F(ColumnsRemoteTest, TestSQLColAttributeAllTypes) {
                        SQL_SEARCHABLE,  // expected_searchable
                        SQL_FALSE);      // expected_unsigned_column
 
-  CheckSQLColAttribute(stmt, 6,
+  CheckSQLColAttribute(this->stmt, 6,
                        "bit_true",      // expected_column_name
                        SQL_BIT,         // expected_data_type
                        SQL_BIT,         // expected_concise_type
@@ -1567,7 +1568,7 @@ TEST_F(ColumnsRemoteTest, TestSQLColAttributeAllTypes) {
                        SQL_SEARCHABLE,  // expected_searchable
                        SQL_TRUE);       // expected_unsigned_column
 
-  CheckSQLColAttribute(stmt, 7,
+  CheckSQLColAttribute(this->stmt, 7,
                        "date_max",      // expected_column_name
                        SQL_DATETIME,    // expected_data_type
                        SQL_TYPE_DATE,   // expected_concise_type
@@ -1584,7 +1585,7 @@ TEST_F(ColumnsRemoteTest, TestSQLColAttributeAllTypes) {
                        SQL_SEARCHABLE,  // expected_searchable
                        SQL_TRUE);       // expected_unsigned_column
 
-  CheckSQLColAttribute(stmt, 8,
+  CheckSQLColAttribute(this->stmt, 8,
                        "time_max",      // expected_column_name
                        SQL_DATETIME,    // expected_data_type
                        SQL_TYPE_TIME,   // expected_concise_type
@@ -1601,7 +1602,7 @@ TEST_F(ColumnsRemoteTest, TestSQLColAttributeAllTypes) {
                        SQL_SEARCHABLE,  // expected_searchable
                        SQL_TRUE);       // expected_unsigned_column
 
-  CheckSQLColAttribute(stmt, 9,
+  CheckSQLColAttribute(this->stmt, 9,
                        "timestamp_max",     // expected_column_name
                        SQL_DATETIME,        // expected_data_type
                        SQL_TYPE_TIMESTAMP,  // expected_concise_type
@@ -1626,11 +1627,11 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColAttributeAllTypes) {
   SQLWCHAR wsql[] = L"SELECT * from $scratch.ODBCTest;";
   SQLSMALLINT wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
-  CheckSQLColAttribute(stmt, 1,
+  CheckSQLColAttribute(this->stmt, 1,
                        "sinteger_max",  // expected_column_name
                        SQL_INTEGER,     // expected_data_type
                        SQL_INTEGER,     // expected_concise_type
@@ -1647,7 +1648,7 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColAttributeAllTypes) {
                        SQL_SEARCHABLE,  // expected_searchable
                        SQL_FALSE);      // expected_unsigned_column
 
-  CheckSQLColAttribute(stmt, 2,
+  CheckSQLColAttribute(this->stmt, 2,
                        "sbigint_max",   // expected_column_name
                        SQL_BIGINT,      // expected_data_type
                        SQL_BIGINT,      // expected_concise_type
@@ -1664,7 +1665,7 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColAttributeAllTypes) {
                        SQL_SEARCHABLE,  // expected_searchable
                        SQL_FALSE);      // expected_unsigned_column
 
-  CheckSQLColAttribute(stmt, 3,
+  CheckSQLColAttribute(this->stmt, 3,
                        "decimal_positive",  // expected_column_name
                        SQL_DECIMAL,         // expected_data_type
                        SQL_DECIMAL,         // expected_concise_type
@@ -1681,7 +1682,7 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColAttributeAllTypes) {
                        SQL_SEARCHABLE,      // expected_searchable
                        SQL_FALSE);          // expected_unsigned_column
 
-  CheckSQLColAttribute(stmt, 4,
+  CheckSQLColAttribute(this->stmt, 4,
                        "float_max",     // expected_column_name
                        SQL_FLOAT,       // expected_data_type
                        SQL_FLOAT,       // expected_concise_type
@@ -1698,7 +1699,7 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColAttributeAllTypes) {
                        SQL_SEARCHABLE,  // expected_searchable
                        SQL_FALSE);      // expected_unsigned_column
 
-  CheckSQLColAttribute(stmt, 5,
+  CheckSQLColAttribute(this->stmt, 5,
                        "double_max",    // expected_column_name
                        SQL_DOUBLE,      // expected_data_type
                        SQL_DOUBLE,      // expected_concise_type
@@ -1715,7 +1716,7 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColAttributeAllTypes) {
                        SQL_SEARCHABLE,  // expected_searchable
                        SQL_FALSE);      // expected_unsigned_column
 
-  CheckSQLColAttribute(stmt, 6,
+  CheckSQLColAttribute(this->stmt, 6,
                        "bit_true",      // expected_column_name
                        SQL_BIT,         // expected_data_type
                        SQL_BIT,         // expected_concise_type
@@ -1732,7 +1733,7 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColAttributeAllTypes) {
                        SQL_SEARCHABLE,  // expected_searchable
                        SQL_TRUE);       // expected_unsigned_column
 
-  CheckSQLColAttribute(stmt, 7,
+  CheckSQLColAttribute(this->stmt, 7,
                        "date_max",      // expected_column_name
                        SQL_DATETIME,    // expected_data_type
                        SQL_DATE,        // expected_concise_type
@@ -1749,7 +1750,7 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColAttributeAllTypes) {
                        SQL_SEARCHABLE,  // expected_searchable
                        SQL_TRUE);       // expected_unsigned_column
 
-  CheckSQLColAttribute(stmt, 8,
+  CheckSQLColAttribute(this->stmt, 8,
                        "time_max",      // expected_column_name
                        SQL_DATETIME,    // expected_data_type
                        SQL_TIME,        // expected_concise_type
@@ -1766,7 +1767,7 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColAttributeAllTypes) {
                        SQL_SEARCHABLE,  // expected_searchable
                        SQL_TRUE);       // expected_unsigned_column
 
-  CheckSQLColAttribute(stmt, 9,
+  CheckSQLColAttribute(this->stmt, 9,
                        "timestamp_max",  // expected_column_name
                        SQL_DATETIME,     // expected_data_type
                        SQL_TIMESTAMP,    // expected_concise_type
@@ -1791,11 +1792,11 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColAttributesAllTypes) {
   SQLWCHAR wsql[] = L"SELECT * from $scratch.ODBCTest;";
   SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
-  CheckSQLColAttributes(stmt, 1,
+  CheckSQLColAttributes(this->stmt, 1,
                         "sinteger_max",  // expected_column_name
                         SQL_INTEGER,     // expected_data_type
                         11,              // expected_display_size
@@ -1807,7 +1808,7 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColAttributesAllTypes) {
                         SQL_SEARCHABLE,  // expected_searchable
                         SQL_FALSE);      // expected_unsigned_column
 
-  CheckSQLColAttributes(stmt, 2,
+  CheckSQLColAttributes(this->stmt, 2,
                         "sbigint_max",   // expected_column_name
                         SQL_BIGINT,      // expected_data_type
                         20,              // expected_display_size
@@ -1819,7 +1820,7 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColAttributesAllTypes) {
                         SQL_SEARCHABLE,  // expected_searchable
                         SQL_FALSE);      // expected_unsigned_column
 
-  CheckSQLColAttributes(stmt, 3,
+  CheckSQLColAttributes(this->stmt, 3,
                         "decimal_positive",  // expected_column_name
                         SQL_DECIMAL,         // expected_data_type
                         40,                  // expected_display_size
@@ -1831,7 +1832,7 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColAttributesAllTypes) {
                         SQL_SEARCHABLE,      // expected_searchable
                         SQL_FALSE);          // expected_unsigned_column
 
-  CheckSQLColAttributes(stmt, 4,
+  CheckSQLColAttributes(this->stmt, 4,
                         "float_max",     // expected_column_name
                         SQL_FLOAT,       // expected_data_type
                         24,              // expected_display_size
@@ -1843,7 +1844,7 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColAttributesAllTypes) {
                         SQL_SEARCHABLE,  // expected_searchable
                         SQL_FALSE);      // expected_unsigned_column
 
-  CheckSQLColAttributes(stmt, 5,
+  CheckSQLColAttributes(this->stmt, 5,
                         "double_max",    // expected_column_name
                         SQL_DOUBLE,      // expected_data_type
                         24,              // expected_display_size
@@ -1855,7 +1856,7 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColAttributesAllTypes) {
                         SQL_SEARCHABLE,  // expected_searchable
                         SQL_FALSE);      // expected_unsigned_column
 
-  CheckSQLColAttributes(stmt, 6,
+  CheckSQLColAttributes(this->stmt, 6,
                         "bit_true",      // expected_column_name
                         SQL_BIT,         // expected_data_type
                         1,               // expected_display_size
@@ -1867,7 +1868,7 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColAttributesAllTypes) {
                         SQL_SEARCHABLE,  // expected_searchable
                         SQL_TRUE);       // expected_unsigned_column
 
-  CheckSQLColAttributes(stmt, 7,
+  CheckSQLColAttributes(this->stmt, 7,
                         "date_max",      // expected_column_name
                         SQL_DATE,        // expected_data_type
                         10,              // expected_display_size
@@ -1879,7 +1880,7 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColAttributesAllTypes) {
                         SQL_SEARCHABLE,  // expected_searchable
                         SQL_TRUE);       // expected_unsigned_column
 
-  CheckSQLColAttributes(stmt, 8,
+  CheckSQLColAttributes(this->stmt, 8,
                         "time_max",      // expected_column_name
                         SQL_TIME,        // expected_data_type
                         12,              // expected_display_size
@@ -1891,7 +1892,7 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColAttributesAllTypes) {
                         SQL_SEARCHABLE,  // expected_searchable
                         SQL_TRUE);       // expected_unsigned_column
 
-  CheckSQLColAttributes(stmt, 9,
+  CheckSQLColAttributes(this->stmt, 9,
                         "timestamp_max",  // expected_column_name
                         SQL_TIMESTAMP,    // expected_data_type
                         23,               // expected_display_size
@@ -1911,11 +1912,11 @@ TYPED_TEST(ColumnsTest, TestSQLColAttributeCaseSensitive) {
   std::wstring wsql = this->GetQueryAllDataTypes();
   // Int column
   SQLLEN value;
-  GetSQLColAttributeNumeric(stmt, wsql, 1, SQL_DESC_CASE_SENSITIVE, &value);
+  GetSQLColAttributeNumeric(this->stmt, wsql, 1, SQL_DESC_CASE_SENSITIVE, &value);
   ASSERT_EQ(SQL_FALSE, value);
-  SQLFreeStmt(stmt, SQL_CLOSE);
+  SQLFreeStmt(this->stmt, SQL_CLOSE);
   // Varchar column
-  GetSQLColAttributeNumeric(stmt, wsql, 28, SQL_DESC_CASE_SENSITIVE, &value);
+  GetSQLColAttributeNumeric(this->stmt, wsql, 28, SQL_DESC_CASE_SENSITIVE, &value);
   ASSERT_EQ(SQL_FALSE, value);
 }
 
@@ -1928,11 +1929,11 @@ TYPED_TEST(ColumnsOdbcV2Test, TestSQLColAttributesCaseSensitive) {
   std::wstring wsql = this->GetQueryAllDataTypes();
   // Int column
   SQLLEN value;
-  GetSQLColAttributesNumeric(stmt, wsql, 1, SQL_COLUMN_CASE_SENSITIVE, &value);
+  GetSQLColAttributesNumeric(this->stmt, wsql, 1, SQL_COLUMN_CASE_SENSITIVE, &value);
   ASSERT_EQ(SQL_FALSE, value);
-  SQLFreeStmt(stmt, SQL_CLOSE);
+  SQLFreeStmt(this->stmt, SQL_CLOSE);
   // Varchar column
-  GetSQLColAttributesNumeric(stmt, wsql, 28, SQL_COLUMN_CASE_SENSITIVE, &value);
+  GetSQLColAttributesNumeric(this->stmt, wsql, 28, SQL_COLUMN_CASE_SENSITIVE, &value);
   ASSERT_EQ(SQL_FALSE, value);
 }
 #endif  // __APPLE__
@@ -1943,7 +1944,7 @@ TEST_F(ColumnsMockTest, TestSQLColAttributeUniqueValue) {
 
   std::wstring wsql = L"SELECT * from AllTypesTable;";
   SQLLEN value;
-  GetSQLColAttributeNumeric(stmt, wsql, 1, SQL_DESC_AUTO_UNIQUE_VALUE, &value);
+  GetSQLColAttributeNumeric(this->stmt, wsql, 1, SQL_DESC_AUTO_UNIQUE_VALUE, &value);
   ASSERT_EQ(SQL_FALSE, value);
 
   DropAllDataTypeTable();
@@ -1958,7 +1959,7 @@ TEST_F(ColumnsOdbcV2MockTest, TestSQLColAttributesAutoIncrement) {
 
   std::wstring wsql = L"SELECT * from AllTypesTable;";
   SQLLEN value;
-  GetSQLColAttributeNumeric(stmt, wsql, 1, SQL_COLUMN_AUTO_INCREMENT, &value);
+  GetSQLColAttributeNumeric(this->stmt, wsql, 1, SQL_COLUMN_AUTO_INCREMENT, &value);
   ASSERT_EQ(SQL_FALSE, value);
 
   DropAllDataTypeTable();
@@ -1970,7 +1971,7 @@ TEST_F(ColumnsMockTest, TestSQLColAttributeBaseTableName) {
 
   std::wstring wsql = L"SELECT * from AllTypesTable;";
   std::wstring value;
-  GetSQLColAttributeString(stmt, wsql, 1, SQL_DESC_BASE_TABLE_NAME, value);
+  GetSQLColAttributeString(this->stmt, wsql, 1, SQL_DESC_BASE_TABLE_NAME, value);
   ASSERT_EQ(std::wstring(L"AllTypesTable"), value);
 
   DropAllDataTypeTable();
@@ -1984,7 +1985,7 @@ TEST_F(ColumnsOdbcV2MockTest, TestSQLColAttributesTableName) {
 
   std::wstring wsql = L"SELECT * from AllTypesTable;";
   std::wstring value;
-  GetSQLColAttributesString(stmt, wsql, 1, SQL_COLUMN_TABLE_NAME, value);
+  GetSQLColAttributesString(this->stmt, wsql, 1, SQL_COLUMN_TABLE_NAME, value);
   ASSERT_EQ(std::wstring(L"AllTypesTable"), value);
 
   DropAllDataTypeTable();
@@ -1998,7 +1999,7 @@ TEST_F(ColumnsMockTest, TestSQLColAttributeCatalogName) {
 
   std::wstring wsql = L"SELECT * from AllTypesTable;";
   std::wstring value;
-  GetSQLColAttributeString(stmt, wsql, 1, SQL_DESC_CATALOG_NAME, value);
+  GetSQLColAttributeString(this->stmt, wsql, 1, SQL_DESC_CATALOG_NAME, value);
   ASSERT_EQ(std::wstring(L""), value);
 
   DropAllDataTypeTable();
@@ -2009,7 +2010,7 @@ TEST_F(ColumnsRemoteTest, TestSQLColAttributeCatalogName) {
 
   std::wstring wsql = L"SELECT * from $scratch.ODBCTest;";
   std::wstring value;
-  GetSQLColAttributeString(stmt, wsql, 1, SQL_DESC_CATALOG_NAME, value);
+  GetSQLColAttributeString(this->stmt, wsql, 1, SQL_DESC_CATALOG_NAME, value);
   ASSERT_EQ(std::wstring(L""), value);
 }
 
@@ -2023,7 +2024,7 @@ TEST_F(ColumnsOdbcV2MockTest, TestSQLColAttributesQualifierName) {
 
   std::wstring wsql = L"SELECT * from AllTypesTable;";
   std::wstring value;
-  GetSQLColAttributeString(stmt, wsql, 1, SQL_COLUMN_QUALIFIER_NAME, value);
+  GetSQLColAttributeString(this->stmt, wsql, 1, SQL_COLUMN_QUALIFIER_NAME, value);
   ASSERT_EQ(std::wstring(L""), value);
 
   DropAllDataTypeTable();
@@ -2034,7 +2035,7 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColAttributesQualifierName) {
   // Tests ODBC 2.0 API SQLColAttributes
   std::wstring wsql = L"SELECT * from $scratch.ODBCTest;";
   std::wstring value;
-  GetSQLColAttributeString(stmt, wsql, 1, SQL_COLUMN_QUALIFIER_NAME, value);
+  GetSQLColAttributeString(this->stmt, wsql, 1, SQL_COLUMN_QUALIFIER_NAME, value);
   ASSERT_EQ(std::wstring(L""), value);
 }
 #endif  // __APPLE__
@@ -2043,7 +2044,7 @@ TYPED_TEST(ColumnsTest, TestSQLColAttributeCount) {
   std::wstring wsql = this->GetQueryAllDataTypes();
   // Pass 0 as column number, driver should ignore it
   SQLLEN value;
-  GetSQLColAttributeNumeric(stmt, wsql, 0, SQL_DESC_COUNT, &value);
+  GetSQLColAttributeNumeric(this->stmt, wsql, 0, SQL_DESC_COUNT, &value);
   ASSERT_EQ(32, value);
 }
 
@@ -2051,14 +2052,14 @@ TEST_F(ColumnsMockTest, TestSQLColAttributeLocalTypeName) {
   std::wstring wsql = this->GetQueryAllDataTypes();
   // Mock server doesn't have local type name
   std::wstring value;
-  GetSQLColAttributeString(stmt, wsql, 1, SQL_DESC_LOCAL_TYPE_NAME, value);
+  GetSQLColAttributeString(this->stmt, wsql, 1, SQL_DESC_LOCAL_TYPE_NAME, value);
   ASSERT_EQ(std::wstring(L""), value);
 }
 
 TEST_F(ColumnsRemoteTest, TestSQLColAttributeLocalTypeName) {
   std::wstring wsql = this->GetQueryAllDataTypes();
   std::wstring value;
-  GetSQLColAttributesString(stmt, wsql, 1, SQL_DESC_LOCAL_TYPE_NAME, value);
+  GetSQLColAttributesString(this->stmt, wsql, 1, SQL_DESC_LOCAL_TYPE_NAME, value);
   ASSERT_EQ(std::wstring(L"INTEGER"), value);
 }
 
@@ -2068,7 +2069,7 @@ TEST_F(ColumnsMockTest, TestSQLColAttributeSchemaName) {
   std::wstring wsql = L"SELECT * from AllTypesTable;";
   // Mock server doesn't have schemas
   std::wstring value;
-  GetSQLColAttributeString(stmt, wsql, 1, SQL_DESC_SCHEMA_NAME, value);
+  GetSQLColAttributeString(this->stmt, wsql, 1, SQL_DESC_SCHEMA_NAME, value);
   ASSERT_EQ(std::wstring(L""), value);
 
   DropAllDataTypeTable();
@@ -2081,7 +2082,7 @@ TEST_F(ColumnsRemoteTest, TestSQLColAttributeSchemaName) {
   // Remote server limitation: doesn't return schema name, expected schema name is
   // $scratch
   std::wstring value;
-  GetSQLColAttributeString(stmt, wsql, 1, SQL_DESC_SCHEMA_NAME, value);
+  GetSQLColAttributeString(this->stmt, wsql, 1, SQL_DESC_SCHEMA_NAME, value);
   ASSERT_EQ(std::wstring(L""), value);
 }
 
@@ -2094,7 +2095,7 @@ TEST_F(ColumnsOdbcV2MockTest, TestSQLColAttributesOwnerName) {
   std::wstring wsql = L"SELECT * from AllTypesTable;";
   // Mock server doesn't have schemas
   std::wstring value;
-  GetSQLColAttributesString(stmt, wsql, 1, SQL_COLUMN_OWNER_NAME, value);
+  GetSQLColAttributesString(this->stmt, wsql, 1, SQL_COLUMN_OWNER_NAME, value);
   ASSERT_EQ(std::wstring(L""), value);
 
   DropAllDataTypeTable();
@@ -2107,7 +2108,7 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColAttributesOwnerName) {
   // Remote server limitation: doesn't return schema name, expected schema name is
   // $scratch
   std::wstring value;
-  GetSQLColAttributesString(stmt, wsql, 1, SQL_COLUMN_OWNER_NAME, value);
+  GetSQLColAttributesString(this->stmt, wsql, 1, SQL_COLUMN_OWNER_NAME, value);
   ASSERT_EQ(std::wstring(L""), value);
 }
 #endif  // __APPLE__
@@ -2117,7 +2118,7 @@ TEST_F(ColumnsMockTest, TestSQLColAttributeTableName) {
 
   std::wstring wsql = L"SELECT * from AllTypesTable;";
   std::wstring value;
-  GetSQLColAttributeString(stmt, wsql, 1, SQL_DESC_TABLE_NAME, value);
+  GetSQLColAttributeString(this->stmt, wsql, 1, SQL_DESC_TABLE_NAME, value);
   ASSERT_EQ(std::wstring(L"AllTypesTable"), value);
 
   DropAllDataTypeTable();
@@ -2128,13 +2129,13 @@ TEST_F(ColumnsMockTest, TestSQLColAttributeTypeName) {
 
   std::wstring wsql = L"SELECT * from AllTypesTable;";
   std::wstring value;
-  GetSQLColAttributeString(stmt, wsql, 1, SQL_DESC_TYPE_NAME, value);
+  GetSQLColAttributeString(this->stmt, wsql, 1, SQL_DESC_TYPE_NAME, value);
   ASSERT_EQ(std::wstring(L"BIGINT"), value);
-  GetSQLColAttributeString(stmt, L"", 2, SQL_DESC_TYPE_NAME, value);
+  GetSQLColAttributeString(this->stmt, L"", 2, SQL_DESC_TYPE_NAME, value);
   ASSERT_EQ(std::wstring(L"WVARCHAR"), value);
-  GetSQLColAttributeString(stmt, L"", 3, SQL_DESC_TYPE_NAME, value);
+  GetSQLColAttributeString(this->stmt, L"", 3, SQL_DESC_TYPE_NAME, value);
   ASSERT_EQ(std::wstring(L"BINARY"), value);
-  GetSQLColAttributeString(stmt, L"", 4, SQL_DESC_TYPE_NAME, value);
+  GetSQLColAttributeString(this->stmt, L"", 4, SQL_DESC_TYPE_NAME, value);
   ASSERT_EQ(std::wstring(L"DOUBLE"), value);
 
   DropAllDataTypeTable();
@@ -2143,23 +2144,23 @@ TEST_F(ColumnsMockTest, TestSQLColAttributeTypeName) {
 TEST_F(ColumnsRemoteTest, TestSQLColAttributeTypeName) {
   std::wstring wsql = L"SELECT * from $scratch.ODBCTest;";
   std::wstring value;
-  GetSQLColAttributeString(stmt, wsql, 1, SQL_DESC_TYPE_NAME, value);
+  GetSQLColAttributeString(this->stmt, wsql, 1, SQL_DESC_TYPE_NAME, value);
   ASSERT_EQ(std::wstring(L"INTEGER"), value);
-  GetSQLColAttributeString(stmt, L"", 2, SQL_DESC_TYPE_NAME, value);
+  GetSQLColAttributeString(this->stmt, L"", 2, SQL_DESC_TYPE_NAME, value);
   ASSERT_EQ(std::wstring(L"BIGINT"), value);
-  GetSQLColAttributeString(stmt, L"", 3, SQL_DESC_TYPE_NAME, value);
+  GetSQLColAttributeString(this->stmt, L"", 3, SQL_DESC_TYPE_NAME, value);
   ASSERT_EQ(std::wstring(L"DECIMAL"), value);
-  GetSQLColAttributeString(stmt, L"", 4, SQL_DESC_TYPE_NAME, value);
+  GetSQLColAttributeString(this->stmt, L"", 4, SQL_DESC_TYPE_NAME, value);
   ASSERT_EQ(std::wstring(L"FLOAT"), value);
-  GetSQLColAttributeString(stmt, L"", 5, SQL_DESC_TYPE_NAME, value);
+  GetSQLColAttributeString(this->stmt, L"", 5, SQL_DESC_TYPE_NAME, value);
   ASSERT_EQ(std::wstring(L"DOUBLE"), value);
-  GetSQLColAttributeString(stmt, L"", 6, SQL_DESC_TYPE_NAME, value);
+  GetSQLColAttributeString(this->stmt, L"", 6, SQL_DESC_TYPE_NAME, value);
   ASSERT_EQ(std::wstring(L"BOOLEAN"), value);
-  GetSQLColAttributeString(stmt, L"", 7, SQL_DESC_TYPE_NAME, value);
+  GetSQLColAttributeString(this->stmt, L"", 7, SQL_DESC_TYPE_NAME, value);
   ASSERT_EQ(std::wstring(L"DATE"), value);
-  GetSQLColAttributeString(stmt, L"", 8, SQL_DESC_TYPE_NAME, value);
+  GetSQLColAttributeString(this->stmt, L"", 8, SQL_DESC_TYPE_NAME, value);
   ASSERT_EQ(std::wstring(L"TIME"), value);
-  GetSQLColAttributeString(stmt, L"", 9, SQL_DESC_TYPE_NAME, value);
+  GetSQLColAttributeString(this->stmt, L"", 9, SQL_DESC_TYPE_NAME, value);
   ASSERT_EQ(std::wstring(L"TIMESTAMP"), value);
 }
 
@@ -2172,13 +2173,13 @@ TEST_F(ColumnsOdbcV2MockTest, TestSQLColAttributesTypeName) {
   std::wstring wsql = L"SELECT * from AllTypesTable;";
   // Mock server doesn't return data source-dependent data type name
   std::wstring value;
-  GetSQLColAttributesString(stmt, wsql, 1, SQL_COLUMN_TYPE_NAME, value);
+  GetSQLColAttributesString(this->stmt, wsql, 1, SQL_COLUMN_TYPE_NAME, value);
   ASSERT_EQ(std::wstring(L"BIGINT"), value);
-  GetSQLColAttributesString(stmt, L"", 2, SQL_COLUMN_TYPE_NAME, value);
+  GetSQLColAttributesString(this->stmt, L"", 2, SQL_COLUMN_TYPE_NAME, value);
   ASSERT_EQ(std::wstring(L"WVARCHAR"), value);
-  GetSQLColAttributesString(stmt, L"", 3, SQL_COLUMN_TYPE_NAME, value);
+  GetSQLColAttributesString(this->stmt, L"", 3, SQL_COLUMN_TYPE_NAME, value);
   ASSERT_EQ(std::wstring(L"BINARY"), value);
-  GetSQLColAttributesString(stmt, L"", 4, SQL_COLUMN_TYPE_NAME, value);
+  GetSQLColAttributesString(this->stmt, L"", 4, SQL_COLUMN_TYPE_NAME, value);
   ASSERT_EQ(std::wstring(L"DOUBLE"), value);
 
   DropAllDataTypeTable();
@@ -2188,23 +2189,23 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColAttributesTypeName) {
   // Tests ODBC 2.0 API SQLColAttributes
   std::wstring wsql = L"SELECT * from $scratch.ODBCTest;";
   std::wstring value;
-  GetSQLColAttributesString(stmt, wsql, 1, SQL_COLUMN_TYPE_NAME, value);
+  GetSQLColAttributesString(this->stmt, wsql, 1, SQL_COLUMN_TYPE_NAME, value);
   ASSERT_EQ(std::wstring(L"INTEGER"), value);
-  GetSQLColAttributesString(stmt, L"", 2, SQL_COLUMN_TYPE_NAME, value);
+  GetSQLColAttributesString(this->stmt, L"", 2, SQL_COLUMN_TYPE_NAME, value);
   ASSERT_EQ(std::wstring(L"BIGINT"), value);
-  GetSQLColAttributesString(stmt, L"", 3, SQL_COLUMN_TYPE_NAME, value);
+  GetSQLColAttributesString(this->stmt, L"", 3, SQL_COLUMN_TYPE_NAME, value);
   ASSERT_EQ(std::wstring(L"DECIMAL"), value);
-  GetSQLColAttributesString(stmt, L"", 4, SQL_COLUMN_TYPE_NAME, value);
+  GetSQLColAttributesString(this->stmt, L"", 4, SQL_COLUMN_TYPE_NAME, value);
   ASSERT_EQ(std::wstring(L"FLOAT"), value);
-  GetSQLColAttributesString(stmt, L"", 5, SQL_COLUMN_TYPE_NAME, value);
+  GetSQLColAttributesString(this->stmt, L"", 5, SQL_COLUMN_TYPE_NAME, value);
   ASSERT_EQ(std::wstring(L"DOUBLE"), value);
-  GetSQLColAttributesString(stmt, L"", 6, SQL_COLUMN_TYPE_NAME, value);
+  GetSQLColAttributesString(this->stmt, L"", 6, SQL_COLUMN_TYPE_NAME, value);
   ASSERT_EQ(std::wstring(L"BOOLEAN"), value);
-  GetSQLColAttributesString(stmt, L"", 7, SQL_COLUMN_TYPE_NAME, value);
+  GetSQLColAttributesString(this->stmt, L"", 7, SQL_COLUMN_TYPE_NAME, value);
   ASSERT_EQ(std::wstring(L"DATE"), value);
-  GetSQLColAttributesString(stmt, L"", 8, SQL_COLUMN_TYPE_NAME, value);
+  GetSQLColAttributesString(this->stmt, L"", 8, SQL_COLUMN_TYPE_NAME, value);
   ASSERT_EQ(std::wstring(L"TIME"), value);
-  GetSQLColAttributesString(stmt, L"", 9, SQL_COLUMN_TYPE_NAME, value);
+  GetSQLColAttributesString(this->stmt, L"", 9, SQL_COLUMN_TYPE_NAME, value);
   ASSERT_EQ(std::wstring(L"TIMESTAMP"), value);
 }
 #endif  // __APPLE__
@@ -2212,7 +2213,7 @@ TEST_F(ColumnsOdbcV2RemoteTest, TestSQLColAttributesTypeName) {
 TYPED_TEST(ColumnsTest, TestSQLColAttributeUnnamed) {
   std::wstring wsql = this->GetQueryAllDataTypes();
   SQLLEN value;
-  GetSQLColAttributeNumeric(stmt, wsql, 1, SQL_DESC_UNNAMED, &value);
+  GetSQLColAttributeNumeric(this->stmt, wsql, 1, SQL_DESC_UNNAMED, &value);
   ASSERT_EQ(SQL_NAMED, value);
 }
 
@@ -2220,7 +2221,7 @@ TYPED_TEST(ColumnsTest, TestSQLColAttributeUpdatable) {
   std::wstring wsql = this->GetQueryAllDataTypes();
   // Mock server and remote server do not return updatable information
   SQLLEN value;
-  GetSQLColAttributeNumeric(stmt, wsql, 1, SQL_DESC_UPDATABLE, &value);
+  GetSQLColAttributeNumeric(this->stmt, wsql, 1, SQL_DESC_UPDATABLE, &value);
   ASSERT_EQ(SQL_ATTR_READWRITE_UNKNOWN, value);
 }
 
@@ -2231,7 +2232,7 @@ TYPED_TEST(ColumnsOdbcV2Test, TestSQLColAttributesUpdatable) {
   std::wstring wsql = this->GetQueryAllDataTypes();
   // Mock server and remote server do not return updatable information
   SQLLEN value;
-  GetSQLColAttributesNumeric(stmt, wsql, 1, SQL_COLUMN_UPDATABLE, &value);
+  GetSQLColAttributesNumeric(this->stmt, wsql, 1, SQL_COLUMN_UPDATABLE, &value);
   ASSERT_EQ(SQL_ATTR_READWRITE_UNKNOWN, value);
 }
 #endif  // __APPLE__
@@ -2254,32 +2255,32 @@ TEST_F(ColumnsMockTest, SQLDescribeColValidateInput) {
   SQLSMALLINT decimal_digits = 0;
   SQLSMALLINT nullable = 0;
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, sql_query, query_length));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, sql_query, query_length));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
   // Invalid descriptor index - Bookmarks are not supported
-  EXPECT_EQ(SQL_ERROR,
-            SQLDescribeCol(stmt, bookmark_column, column_name, buf_char_len, &name_length,
-                           &data_type, &column_size, &decimal_digits, &nullable));
+  EXPECT_EQ(SQL_ERROR, SQLDescribeCol(this->stmt, bookmark_column, column_name,
+                                      buf_char_len, &name_length, &data_type,
+                                      &column_size, &decimal_digits, &nullable));
 #ifdef __APPLE__
   // non-standard odbc error code for invalid column index
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorStateS1002);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorStateS1002);
 #else
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorState07009);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorState07009);
 #endif  // __APPLE__
 
   // Invalid descriptor index - index out of range
-  EXPECT_EQ(SQL_ERROR, SQLDescribeCol(stmt, out_of_range_column, column_name,
+  EXPECT_EQ(SQL_ERROR, SQLDescribeCol(this->stmt, out_of_range_column, column_name,
                                       buf_char_len, &name_length, &data_type,
                                       &column_size, &decimal_digits, &nullable));
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorState07009);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorState07009);
 
   // Invalid descriptor index - index out of range
-  EXPECT_EQ(SQL_ERROR,
-            SQLDescribeCol(stmt, negative_column, column_name, buf_char_len, &name_length,
-                           &data_type, &column_size, &decimal_digits, &nullable));
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorState07009);
+  EXPECT_EQ(SQL_ERROR, SQLDescribeCol(this->stmt, negative_column, column_name,
+                                      buf_char_len, &name_length, &data_type,
+                                      &column_size, &decimal_digits, &nullable));
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorState07009);
 
   DropTestTable();
 }
@@ -2342,15 +2343,15 @@ TEST_F(ColumnsMockTest, SQLDescribeColQueryAllDataTypesMetadata) {
       SQL_WVARCHAR, SQL_WVARCHAR};
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
   for (size_t i = 0; i < sizeof(column_names) / sizeof(*column_names); ++i) {
     column_index = i + 1;
 
-    ASSERT_EQ(SQL_SUCCESS, SQLDescribeCol(stmt, column_index, column_name, buf_char_len,
-                                          &name_length, &column_data_type, &column_size,
-                                          &decimal_digits, &nullable));
+    ASSERT_EQ(SQL_SUCCESS, SQLDescribeCol(this->stmt, column_index, column_name,
+                                          buf_char_len, &name_length, &column_data_type,
+                                          &column_size, &decimal_digits, &nullable));
 
     EXPECT_EQ(wcslen(column_names[i]), name_length);
 
@@ -2430,16 +2431,16 @@ TEST_F(ColumnsRemoteTest, SQLDescribeColQueryAllDataTypesMetadata) {
                                      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10, 23, 23};
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
   for (size_t i = 0; i < sizeof(column_names) / sizeof(*column_names); ++i) {
     column_index = i + 1;
 
-    ASSERT_EQ(SQL_SUCCESS, SQLDescribeCol(stmt, column_index, column_name, buf_char_len,
-                                          &name_length, &column_data_type, &column_size,
-                                          &decimal_digits, &nullable));
+    ASSERT_EQ(SQL_SUCCESS, SQLDescribeCol(this->stmt, column_index, column_name,
+                                          buf_char_len, &name_length, &column_data_type,
+                                          &column_size, &decimal_digits, &nullable));
 
     EXPECT_EQ(wcslen(column_names[i]), name_length);
 
@@ -2489,16 +2490,16 @@ TEST_F(ColumnsRemoteTest, SQLDescribeColODBCTestTableMetadata) {
   SQLULEN column_sizes[] = {4, 8, 19, 8, 8, 1, 10, 12, 23};
   SQLULEN columndecimal_digits[] = {0, 0, 0, 0, 0, 0, 10, 12, 23};
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, sql_query, query_length));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, sql_query, query_length));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
   for (size_t i = 0; i < sizeof(column_names) / sizeof(*column_names); ++i) {
     column_index = i + 1;
 
-    ASSERT_EQ(SQL_SUCCESS, SQLDescribeCol(stmt, column_index, column_name, buf_char_len,
-                                          &name_length, &column_data_type, &column_size,
-                                          &decimal_digits, &nullable));
+    ASSERT_EQ(SQL_SUCCESS, SQLDescribeCol(this->stmt, column_index, column_name,
+                                          buf_char_len, &name_length, &column_data_type,
+                                          &column_size, &decimal_digits, &nullable));
 
     EXPECT_EQ(wcslen(column_names[i]), name_length);
 
@@ -2547,16 +2548,16 @@ TEST_F(ColumnsOdbcV2RemoteTest, SQLDescribeColODBCTestTableMetadataODBCVer2) {
   SQLULEN column_sizes[] = {4, 8, 19, 8, 8, 1, 10, 12, 23};
   SQLULEN columndecimal_digits[] = {0, 0, 0, 0, 0, 0, 10, 12, 23};
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, sql_query, query_length));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, sql_query, query_length));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
   for (size_t i = 0; i < sizeof(column_names) / sizeof(*column_names); ++i) {
     column_index = i + 1;
 
-    ASSERT_EQ(SQL_SUCCESS, SQLDescribeCol(stmt, column_index, column_name, buf_char_len,
-                                          &name_length, &column_data_type, &column_size,
-                                          &decimal_digits, &nullable));
+    ASSERT_EQ(SQL_SUCCESS, SQLDescribeCol(this->stmt, column_index, column_name,
+                                          buf_char_len, &name_length, &column_data_type,
+                                          &column_size, &decimal_digits, &nullable));
 
     EXPECT_EQ(wcslen(column_names[i]), name_length);
 
@@ -2598,16 +2599,16 @@ TEST_F(ColumnsMockTest, SQLDescribeColAllTypesTableMetadata) {
   SQLSMALLINT column_data_types[] = {SQL_BIGINT, SQL_WVARCHAR, SQL_BINARY, SQL_DOUBLE};
   SQLULEN column_sizes[] = {8, 0, 0, 8};
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, sql_query, query_length));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, sql_query, query_length));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
   for (size_t i = 0; i < sizeof(column_names) / sizeof(*column_names); ++i) {
     column_index = i + 1;
 
-    ASSERT_EQ(SQL_SUCCESS, SQLDescribeCol(stmt, column_index, column_name, buf_char_len,
-                                          &name_length, &column_data_type, &column_size,
-                                          &decimal_digits, &nullable));
+    ASSERT_EQ(SQL_SUCCESS, SQLDescribeCol(this->stmt, column_index, column_name,
+                                          buf_char_len, &name_length, &column_data_type,
+                                          &column_size, &decimal_digits, &nullable));
 
     EXPECT_EQ(wcslen(column_names[i]), name_length);
 
@@ -2648,13 +2649,13 @@ TEST_F(ColumnsMockTest, SQLDescribeColUnicodeTableMetadata) {
   SQLSMALLINT expected_column_data_type = SQL_WVARCHAR;
   SQLULEN expected_column_size = 0;
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, sql_query, query_length));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, sql_query, query_length));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLDescribeCol(stmt, column_index, column_name, buf_char_len, &name_length,
-                           &column_data_type, &column_size, &decimal_digits, &nullable));
+  ASSERT_EQ(SQL_SUCCESS, SQLDescribeCol(this->stmt, column_index, column_name,
+                                        buf_char_len, &name_length, &column_data_type,
+                                        &column_size, &decimal_digits, &nullable));
 
   EXPECT_EQ(name_length, wcslen(expected_column_name));
 
@@ -2705,14 +2706,14 @@ TYPED_TEST(ColumnsTest, SQLColumnsGetMetadataBySQLDescribeCol) {
                             2,    2,    1024, 1024, 2, 2,    4, 4, 1024};
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLColumns(stmt, nullptr, 0, nullptr, 0, nullptr, 0, nullptr, 0));
+            SQLColumns(this->stmt, nullptr, 0, nullptr, 0, nullptr, 0, nullptr, 0));
 
   for (size_t i = 0; i < sizeof(column_names) / sizeof(*column_names); ++i) {
     column_index = i + 1;
 
-    ASSERT_EQ(SQL_SUCCESS, SQLDescribeCol(stmt, column_index, column_name, buf_char_len,
-                                          &name_length, &column_data_type, &column_size,
-                                          &decimal_digits, &nullable));
+    ASSERT_EQ(SQL_SUCCESS, SQLDescribeCol(this->stmt, column_index, column_name,
+                                          buf_char_len, &name_length, &column_data_type,
+                                          &column_size, &decimal_digits, &nullable));
 
     EXPECT_EQ(wcslen(column_names[i]), name_length);
 
@@ -2768,14 +2769,14 @@ TYPED_TEST(ColumnsOdbcV2Test, SQLColumnsGetMetadataBySQLDescribeColODBCVer2) {
                             2,    2,    1024, 1024, 2, 2,    4, 4, 1024};
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLColumns(stmt, nullptr, 0, nullptr, 0, nullptr, 0, nullptr, 0));
+            SQLColumns(this->stmt, nullptr, 0, nullptr, 0, nullptr, 0, nullptr, 0));
 
   for (size_t i = 0; i < sizeof(column_names) / sizeof(*column_names); ++i) {
     column_index = i + 1;
 
-    ASSERT_EQ(SQL_SUCCESS, SQLDescribeCol(stmt, column_index, column_name, buf_char_len,
-                                          &name_length, &column_data_type, &column_size,
-                                          &decimal_digits, &nullable));
+    ASSERT_EQ(SQL_SUCCESS, SQLDescribeCol(this->stmt, column_index, column_name,
+                                          buf_char_len, &name_length, &column_data_type,
+                                          &column_size, &decimal_digits, &nullable));
 
     EXPECT_EQ(wcslen(column_names[i]), name_length);
 

--- a/cpp/src/arrow/flight/sql/odbc/tests/connection_attr_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/connection_attr_test.cc
@@ -87,15 +87,18 @@ TYPED_TEST(ConnectionAttributeTest, TestSQLSetConnectAttrEnlistInDtcUnsupported)
 }
 
 TYPED_TEST(ConnectionAttributeTest, TestSQLSetConnectAttrOdbcCursorsDMOnly) {
-  this->AllocEnvConnHandles();
+  SQLHENV test_env = SQL_NULL_HENV;
+  SQLHDBC test_conn = SQL_NULL_HDBC;
+  this->AllocEnvConnHandles(test_env, test_conn);
 
   // Verify DM-only attribute is settable via Driver Manager
   ASSERT_EQ(SQL_SUCCESS,
-            SQLSetConnectAttr(conn, SQL_ATTR_ODBC_CURSORS,
+            SQLSetConnectAttr(test_conn, SQL_ATTR_ODBC_CURSORS,
                               reinterpret_cast<SQLPOINTER>(SQL_CUR_USE_DRIVER), 0));
 
   std::string connect_str = this->GetConnectionString();
-  this->ConnectWithString(connect_str);
+  this->ConnectWithString(connect_str, test_conn);
+  this->Disconnect(test_env, test_conn);
 }
 
 TYPED_TEST(ConnectionAttributeTest, TestSQLSetConnectAttrQuietModeReadOnly) {

--- a/cpp/src/arrow/flight/sql/odbc/tests/connection_attr_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/connection_attr_test.cc
@@ -35,55 +35,55 @@ TYPED_TEST_SUITE(ConnectionAttributeTest, TestTypes);
 
 #ifdef SQL_ATTR_ASYNC_DBC_EVENT
 TYPED_TEST(ConnectionAttributeTest, TestSQLSetConnectAttrAsyncDbcEventUnsupported) {
-  ASSERT_EQ(SQL_ERROR, SQLSetConnectAttr(conn, SQL_ATTR_ASYNC_DBC_EVENT, 0, 0));
+  ASSERT_EQ(SQL_ERROR, SQLSetConnectAttr(this->conn, SQL_ATTR_ASYNC_DBC_EVENT, 0, 0));
   // Driver Manager on Windows returns error code HY118
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorStateHY118);
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorStateHY118);
 }
 #endif
 
 #ifdef SQL_ATTR_ASYNC_ENABLE
 TYPED_TEST(ConnectionAttributeTest, TestSQLSetConnectAttrAyncEnableUnsupported) {
-  ASSERT_EQ(SQL_ERROR, SQLSetConnectAttr(conn, SQL_ATTR_ASYNC_ENABLE, 0, 0));
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorStateHYC00);
+  ASSERT_EQ(SQL_ERROR, SQLSetConnectAttr(this->conn, SQL_ATTR_ASYNC_ENABLE, 0, 0));
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorStateHYC00);
 }
 #endif
 
 #ifdef SQL_ATTR_ASYNC_DBC_PCALLBACK
 TYPED_TEST(ConnectionAttributeTest, TestSQLSetConnectAttrAyncDbcPcCallbackUnsupported) {
-  ASSERT_EQ(SQL_ERROR, SQLSetConnectAttr(conn, SQL_ATTR_ASYNC_DBC_PCALLBACK, 0, 0));
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorStateHYC00);
+  ASSERT_EQ(SQL_ERROR, SQLSetConnectAttr(this->conn, SQL_ATTR_ASYNC_DBC_PCALLBACK, 0, 0));
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorStateHYC00);
 }
 #endif
 
 #ifdef SQL_ATTR_ASYNC_DBC_PCONTEXT
 TYPED_TEST(ConnectionAttributeTest, TestSQLSetConnectAttrAyncDbcPcContextUnsupported) {
-  ASSERT_EQ(SQL_ERROR, SQLSetConnectAttr(conn, SQL_ATTR_ASYNC_DBC_PCONTEXT, 0, 0));
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorStateHYC00);
+  ASSERT_EQ(SQL_ERROR, SQLSetConnectAttr(this->conn, SQL_ATTR_ASYNC_DBC_PCONTEXT, 0, 0));
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorStateHYC00);
 }
 #endif
 
 TYPED_TEST(ConnectionAttributeTest, TestSQLSetConnectAttrAutoIpdReadOnly) {
   // Verify read-only attribute cannot be set
-  ASSERT_EQ(SQL_ERROR, SQLSetConnectAttr(conn, SQL_ATTR_AUTO_IPD, 0, 0));
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorStateHY092);
+  ASSERT_EQ(SQL_ERROR, SQLSetConnectAttr(this->conn, SQL_ATTR_AUTO_IPD, 0, 0));
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorStateHY092);
 }
 
 TYPED_TEST(ConnectionAttributeTest, TestSQLSetConnectAttrConnectionDeadReadOnly) {
   // Verify read-only attribute cannot be set
-  ASSERT_EQ(SQL_ERROR, SQLSetConnectAttr(conn, SQL_ATTR_CONNECTION_DEAD, 0, 0));
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorStateHY092);
+  ASSERT_EQ(SQL_ERROR, SQLSetConnectAttr(this->conn, SQL_ATTR_CONNECTION_DEAD, 0, 0));
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorStateHY092);
 }
 
 #ifdef SQL_ATTR_DBC_INFO_TOKEN
 TYPED_TEST(ConnectionAttributeTest, TestSQLSetConnectAttrDbcInfoTokenUnsupported) {
-  ASSERT_EQ(SQL_ERROR, SQLSetConnectAttr(conn, SQL_ATTR_DBC_INFO_TOKEN, 0, 0));
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorStateHYC00);
+  ASSERT_EQ(SQL_ERROR, SQLSetConnectAttr(this->conn, SQL_ATTR_DBC_INFO_TOKEN, 0, 0));
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorStateHYC00);
 }
 #endif
 
 TYPED_TEST(ConnectionAttributeTest, TestSQLSetConnectAttrEnlistInDtcUnsupported) {
-  ASSERT_EQ(SQL_ERROR, SQLSetConnectAttr(conn, SQL_ATTR_ENLIST_IN_DTC, 0, 0));
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorStateHYC00);
+  ASSERT_EQ(SQL_ERROR, SQLSetConnectAttr(this->conn, SQL_ATTR_ENLIST_IN_DTC, 0, 0));
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorStateHYC00);
 }
 
 TYPED_TEST(ConnectionAttributeTest, TestSQLSetConnectAttrOdbcCursorsDMOnly) {
@@ -103,8 +103,8 @@ TYPED_TEST(ConnectionAttributeTest, TestSQLSetConnectAttrOdbcCursorsDMOnly) {
 
 TYPED_TEST(ConnectionAttributeTest, TestSQLSetConnectAttrQuietModeReadOnly) {
   // Verify read-only attribute cannot be set
-  ASSERT_EQ(SQL_ERROR, SQLSetConnectAttr(conn, SQL_ATTR_QUIET_MODE, 0, 0));
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorStateHY092);
+  ASSERT_EQ(SQL_ERROR, SQLSetConnectAttr(this->conn, SQL_ATTR_QUIET_MODE, 0, 0));
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorStateHY092);
 }
 
 // iODBC needs to be compiled with tracing enabled to handle SQL_ATTR_TRACE
@@ -112,7 +112,7 @@ TYPED_TEST(ConnectionAttributeTest, TestSQLSetConnectAttrQuietModeReadOnly) {
 TYPED_TEST(ConnectionAttributeTest, TestSQLSetConnectAttrTraceDMOnly) {
   // Verify DM-only attribute is settable via Driver Manager
   ASSERT_EQ(SQL_SUCCESS,
-            SQLSetConnectAttr(conn, SQL_ATTR_TRACE,
+            SQLSetConnectAttr(this->conn, SQL_ATTR_TRACE,
                               reinterpret_cast<SQLPOINTER>(SQL_OPT_TRACE_OFF), 0));
 }
 #endif  // __APPLE__
@@ -124,44 +124,45 @@ TYPED_TEST(ConnectionAttributeTest, TestSQLSetConnectAttrTracefileDMOnly) {
   // the driver manager will produce a trace file.
   std::wstring trace_file = L"invalid/file/path";
   std::vector<SQLWCHAR> trace_file0(trace_file.begin(), trace_file.end());
-  ASSERT_EQ(SQL_ERROR, SQLSetConnectAttr(conn, SQL_ATTR_TRACEFILE, &trace_file0[0],
+  ASSERT_EQ(SQL_ERROR, SQLSetConnectAttr(this->conn, SQL_ATTR_TRACEFILE, &trace_file0[0],
                                          static_cast<SQLINTEGER>(trace_file0.size())));
 #ifdef __APPLE__
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorStateHYC00);
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorStateHYC00);
 #else
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorStateHY000);
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorStateHY000);
 #endif  // __APPLE__
 }
 
 TYPED_TEST(ConnectionAttributeTest, TestSQLSetConnectAttrTranslateLabDMOnly) {
   // Verify DM-only attribute is handled by Driver Manager
-  ASSERT_EQ(SQL_ERROR, SQLSetConnectAttr(conn, SQL_ATTR_TRANSLATE_LIB, 0, 0));
+  ASSERT_EQ(SQL_ERROR, SQLSetConnectAttr(this->conn, SQL_ATTR_TRANSLATE_LIB, 0, 0));
   // Checks for invalid argument return error
 #ifdef __APPLE__
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorStateHYC00);
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorStateHYC00);
 #else
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorStateHY024);
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorStateHY024);
 #endif  // __APPLE__
 }
 
 TYPED_TEST(ConnectionAttributeTest, TestSQLSetConnectAttrTranslateOptionUnsupported) {
-  ASSERT_EQ(SQL_ERROR, SQLSetConnectAttr(conn, SQL_ATTR_TRANSLATE_OPTION, 0, 0));
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorStateHYC00);
+  ASSERT_EQ(SQL_ERROR, SQLSetConnectAttr(this->conn, SQL_ATTR_TRANSLATE_OPTION, 0, 0));
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorStateHYC00);
 }
 
 TYPED_TEST(ConnectionAttributeTest, TestSQLSetConnectAttrTxnIsolationUnsupported) {
   ASSERT_EQ(SQL_ERROR,
-            SQLSetConnectAttr(conn, SQL_ATTR_TXN_ISOLATION,
+            SQLSetConnectAttr(this->conn, SQL_ATTR_TXN_ISOLATION,
                               reinterpret_cast<SQLPOINTER>(SQL_TXN_READ_UNCOMMITTED), 0));
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorStateHYC00);
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorStateHYC00);
 }
 
 #ifdef SQL_ATTR_DBC_INFO_TOKEN
 TYPED_TEST(ConnectionAttributeTest, TestSQLGetConnectAttrDbcInfoTokenSetOnly) {
   // Verify that set-only attribute cannot be read
   SQLPOINTER ptr = NULL;
-  ASSERT_EQ(SQL_ERROR, SQLGetConnectAttr(conn, SQL_ATTR_DBC_INFO_TOKEN, ptr, 0, nullptr));
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorStateHY092);
+  ASSERT_EQ(SQL_ERROR,
+            SQLGetConnectAttr(this->conn, SQL_ATTR_DBC_INFO_TOKEN, ptr, 0, nullptr));
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorStateHY092);
 }
 #endif
 
@@ -170,8 +171,8 @@ TYPED_TEST(ConnectionAttributeTest, TestSQLGetConnectAttrDbcInfoTokenSetOnly) {
 TYPED_TEST(ConnectionAttributeTest, TestSQLGetConnectAttrOdbcCursorsDMOnly) {
   // Verify that DM-only attribute is handled by driver manager
   SQLULEN cursor_attr;
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetConnectAttr(conn, SQL_ATTR_ODBC_CURSORS, &cursor_attr, 0, nullptr));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetConnectAttr(this->conn, SQL_ATTR_ODBC_CURSORS,
+                                           &cursor_attr, 0, nullptr));
   EXPECT_EQ(SQL_CUR_USE_DRIVER, cursor_attr);
 }
 
@@ -179,7 +180,8 @@ TYPED_TEST(ConnectionAttributeTest, TestSQLGetConnectAttrOdbcCursorsDMOnly) {
 TYPED_TEST(ConnectionAttributeTest, TestSQLGetConnectAttrTraceDMOnly) {
   // Verify that DM-only attribute is handled by driver manager
   SQLUINTEGER trace;
-  ASSERT_EQ(SQL_SUCCESS, SQLGetConnectAttr(conn, SQL_ATTR_TRACE, &trace, 0, nullptr));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetConnectAttr(this->conn, SQL_ATTR_TRACE, &trace, 0, nullptr));
   EXPECT_EQ(SQL_OPT_TRACE_OFF, trace);
 }
 
@@ -188,7 +190,7 @@ TYPED_TEST(ConnectionAttributeTest, TestSQLGetConnectAttrTraceFileDMOnly) {
   // Verify that DM-only attribute is handled by driver manager
   SQLWCHAR out_str[kOdbcBufferSize];
   SQLINTEGER out_str_len;
-  ASSERT_EQ(SQL_SUCCESS, SQLGetConnectAttr(conn, SQL_ATTR_TRACEFILE, out_str,
+  ASSERT_EQ(SQL_SUCCESS, SQLGetConnectAttr(this->conn, SQL_ATTR_TRACEFILE, out_str,
                                            kOdbcBufferSize, &out_str_len));
   // Length is returned in bytes for SQLGetConnectAttr,
   // we want the number of characters
@@ -202,23 +204,23 @@ TYPED_TEST(ConnectionAttributeTest, TestSQLGetConnectAttrTraceFileDMOnly) {
 TYPED_TEST(ConnectionAttributeTest, TestSQLGetConnectAttrTranslateLibUnsupported) {
   SQLWCHAR out_str[kOdbcBufferSize];
   SQLINTEGER out_str_len;
-  ASSERT_EQ(SQL_ERROR, SQLGetConnectAttr(conn, SQL_ATTR_TRANSLATE_LIB, out_str,
+  ASSERT_EQ(SQL_ERROR, SQLGetConnectAttr(this->conn, SQL_ATTR_TRANSLATE_LIB, out_str,
                                          kOdbcBufferSize, &out_str_len));
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorStateHYC00);
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorStateHYC00);
 }
 
 TYPED_TEST(ConnectionAttributeTest, TestSQLGetConnectAttrTranslateOptionUnsupported) {
   SQLINTEGER option;
-  ASSERT_EQ(SQL_ERROR,
-            SQLGetConnectAttr(conn, SQL_ATTR_TRANSLATE_OPTION, &option, 0, nullptr));
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorStateHYC00);
+  ASSERT_EQ(SQL_ERROR, SQLGetConnectAttr(this->conn, SQL_ATTR_TRANSLATE_OPTION, &option,
+                                         0, nullptr));
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorStateHYC00);
 }
 
 TYPED_TEST(ConnectionAttributeTest, TestSQLGetConnectAttrTxnIsolationUnsupported) {
   SQLINTEGER isolation;
-  ASSERT_EQ(SQL_ERROR,
-            SQLGetConnectAttr(conn, SQL_ATTR_TXN_ISOLATION, &isolation, 0, nullptr));
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorStateHYC00);
+  ASSERT_EQ(SQL_ERROR, SQLGetConnectAttr(this->conn, SQL_ATTR_TXN_ISOLATION, &isolation,
+                                         0, nullptr));
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorStateHYC00);
 }
 
 #ifdef SQL_ATTR_ASYNC_DBC_FUNCTIONS_ENABLE
@@ -226,9 +228,9 @@ TYPED_TEST(ConnectionAttributeTest,
            TestSQLGetConnectAttrAsyncDbcFunctionsEnableUnsupported) {
   // Verifies that the Windows driver manager returns HY114 for unsupported functionality
   SQLUINTEGER enable;
-  ASSERT_EQ(SQL_ERROR,
-            SQLGetConnectAttr(conn, SQL_ATTR_ASYNC_DBC_FUNCTIONS_ENABLE, &enable, 0, 0));
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorStateHY114);
+  ASSERT_EQ(SQL_ERROR, SQLGetConnectAttr(this->conn, SQL_ATTR_ASYNC_DBC_FUNCTIONS_ENABLE,
+                                         &enable, 0, 0));
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorStateHY114);
 }
 #endif
 
@@ -238,7 +240,7 @@ TYPED_TEST(ConnectionAttributeTest,
 TYPED_TEST(ConnectionAttributeTest, TestSQLGetConnectAttrAsyncDbcEventDefault) {
   SQLPOINTER ptr = NULL;
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetConnectAttr(conn, SQL_ATTR_ASYNC_DBC_EVENT, ptr, 0, nullptr));
+            SQLGetConnectAttr(this->conn, SQL_ATTR_ASYNC_DBC_EVENT, ptr, 0, nullptr));
   EXPECT_EQ(reinterpret_cast<SQLPOINTER>(NULL), ptr);
 }
 #endif
@@ -247,7 +249,7 @@ TYPED_TEST(ConnectionAttributeTest, TestSQLGetConnectAttrAsyncDbcEventDefault) {
 TYPED_TEST(ConnectionAttributeTest, TestSQLGetConnectAttrAsyncDbcPcallbackDefault) {
   SQLPOINTER ptr = NULL;
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetConnectAttr(conn, SQL_ATTR_ASYNC_DBC_PCALLBACK, ptr, 0, nullptr));
+            SQLGetConnectAttr(this->conn, SQL_ATTR_ASYNC_DBC_PCALLBACK, ptr, 0, nullptr));
   EXPECT_EQ(reinterpret_cast<SQLPOINTER>(NULL), ptr);
 }
 #endif
@@ -256,7 +258,7 @@ TYPED_TEST(ConnectionAttributeTest, TestSQLGetConnectAttrAsyncDbcPcallbackDefaul
 TYPED_TEST(ConnectionAttributeTest, TestSQLGetConnectAttrAsyncDbcPcontextDefault) {
   SQLPOINTER ptr = NULL;
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetConnectAttr(conn, SQL_ATTR_ASYNC_DBC_PCONTEXT, ptr, 0, nullptr));
+            SQLGetConnectAttr(this->conn, SQL_ATTR_ASYNC_DBC_PCONTEXT, ptr, 0, nullptr));
   EXPECT_EQ(reinterpret_cast<SQLPOINTER>(NULL), ptr);
 }
 #endif
@@ -264,33 +266,35 @@ TYPED_TEST(ConnectionAttributeTest, TestSQLGetConnectAttrAsyncDbcPcontextDefault
 TYPED_TEST(ConnectionAttributeTest, TestSQLGetConnectAttrAsyncEnableDefault) {
   SQLULEN enable;
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetConnectAttr(conn, SQL_ATTR_ASYNC_ENABLE, &enable, 0, nullptr));
+            SQLGetConnectAttr(this->conn, SQL_ATTR_ASYNC_ENABLE, &enable, 0, nullptr));
   EXPECT_EQ(SQL_ASYNC_ENABLE_OFF, enable);
 }
 
 TYPED_TEST(ConnectionAttributeTest, TestSQLGetConnectAttrAutoIpdDefault) {
   SQLUINTEGER ipd;
-  ASSERT_EQ(SQL_SUCCESS, SQLGetConnectAttr(conn, SQL_ATTR_AUTO_IPD, &ipd, 0, nullptr));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetConnectAttr(this->conn, SQL_ATTR_AUTO_IPD, &ipd, 0, nullptr));
   EXPECT_EQ(static_cast<SQLUINTEGER>(SQL_FALSE), ipd);
 }
 
 TYPED_TEST(ConnectionAttributeTest, TestSQLGetConnectAttrAutocommitDefault) {
   SQLUINTEGER auto_commit;
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetConnectAttr(conn, SQL_ATTR_AUTOCOMMIT, &auto_commit, 0, nullptr));
+            SQLGetConnectAttr(this->conn, SQL_ATTR_AUTOCOMMIT, &auto_commit, 0, nullptr));
   EXPECT_EQ(SQL_AUTOCOMMIT_ON, auto_commit);
 }
 
 TYPED_TEST(ConnectionAttributeTest, TestSQLGetConnectAttrEnlistInDtcDefault) {
   SQLPOINTER ptr = NULL;
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetConnectAttr(conn, SQL_ATTR_ENLIST_IN_DTC, ptr, 0, nullptr));
+            SQLGetConnectAttr(this->conn, SQL_ATTR_ENLIST_IN_DTC, ptr, 0, nullptr));
   EXPECT_EQ(reinterpret_cast<SQLPOINTER>(NULL), ptr);
 }
 
 TYPED_TEST(ConnectionAttributeTest, TestSQLGetConnectAttrQuietModeDefault) {
   HWND ptr = NULL;
-  ASSERT_EQ(SQL_SUCCESS, SQLGetConnectAttr(conn, SQL_ATTR_QUIET_MODE, ptr, 0, nullptr));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetConnectAttr(this->conn, SQL_ATTR_QUIET_MODE, ptr, 0, nullptr));
   EXPECT_EQ(reinterpret_cast<SQLPOINTER>(NULL), ptr);
 }
 
@@ -300,40 +304,40 @@ TYPED_TEST(ConnectionAttributeTest, TestSQLSetConnectAttrAccessModeValid) {
   // Check default value first
   SQLUINTEGER mode = -1;
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetConnectAttr(conn, SQL_ATTR_ACCESS_MODE, &mode, 0, nullptr));
+            SQLGetConnectAttr(this->conn, SQL_ATTR_ACCESS_MODE, &mode, 0, nullptr));
   EXPECT_EQ(SQL_MODE_READ_WRITE, mode);
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLSetConnectAttr(conn, SQL_ATTR_ACCESS_MODE,
+            SQLSetConnectAttr(this->conn, SQL_ATTR_ACCESS_MODE,
                               reinterpret_cast<SQLPOINTER>(SQL_MODE_READ_WRITE), 0));
 
   mode = -1;
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetConnectAttr(conn, SQL_ATTR_ACCESS_MODE, &mode, 0, nullptr));
+            SQLGetConnectAttr(this->conn, SQL_ATTR_ACCESS_MODE, &mode, 0, nullptr));
   EXPECT_EQ(SQL_MODE_READ_WRITE, mode);
 
   // Attempt to set to SQL_MODE_READ_ONLY, driver should return warning and not error
   EXPECT_EQ(SQL_SUCCESS_WITH_INFO,
-            SQLSetConnectAttr(conn, SQL_ATTR_ACCESS_MODE,
+            SQLSetConnectAttr(this->conn, SQL_ATTR_ACCESS_MODE,
                               reinterpret_cast<SQLPOINTER>(SQL_MODE_READ_ONLY), 0));
 
   // Verify warning status
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorState01S02);
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorState01S02);
 }
 
 TYPED_TEST(ConnectionAttributeTest, TestSQLSetConnectAttrConnectionTimeoutValid) {
   // Check default value first
   SQLUINTEGER timeout = -1;
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetConnectAttr(conn, SQL_ATTR_CONNECTION_TIMEOUT, &timeout, 0, nullptr));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetConnectAttr(this->conn, SQL_ATTR_CONNECTION_TIMEOUT,
+                                           &timeout, 0, nullptr));
   EXPECT_EQ(0, timeout);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLSetConnectAttr(conn, SQL_ATTR_CONNECTION_TIMEOUT,
+  ASSERT_EQ(SQL_SUCCESS, SQLSetConnectAttr(this->conn, SQL_ATTR_CONNECTION_TIMEOUT,
                                            reinterpret_cast<SQLPOINTER>(42), 0));
 
   timeout = -1;
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetConnectAttr(conn, SQL_ATTR_CONNECTION_TIMEOUT, &timeout, 0, nullptr));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetConnectAttr(this->conn, SQL_ATTR_CONNECTION_TIMEOUT,
+                                           &timeout, 0, nullptr));
   EXPECT_EQ(42, timeout);
 }
 
@@ -341,15 +345,15 @@ TYPED_TEST(ConnectionAttributeTest, TestSQLSetConnectAttrLoginTimeoutValid) {
   // Check default value first
   SQLUINTEGER timeout = -1;
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetConnectAttr(conn, SQL_ATTR_LOGIN_TIMEOUT, &timeout, 0, nullptr));
+            SQLGetConnectAttr(this->conn, SQL_ATTR_LOGIN_TIMEOUT, &timeout, 0, nullptr));
   EXPECT_EQ(0, timeout);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLSetConnectAttr(conn, SQL_ATTR_LOGIN_TIMEOUT,
+  ASSERT_EQ(SQL_SUCCESS, SQLSetConnectAttr(this->conn, SQL_ATTR_LOGIN_TIMEOUT,
                                            reinterpret_cast<SQLPOINTER>(42), 0));
 
   timeout = -1;
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetConnectAttr(conn, SQL_ATTR_LOGIN_TIMEOUT, &timeout, 0, nullptr));
+            SQLGetConnectAttr(this->conn, SQL_ATTR_LOGIN_TIMEOUT, &timeout, 0, nullptr));
   EXPECT_EQ(42, timeout);
 }
 
@@ -359,23 +363,23 @@ TYPED_TEST(ConnectionAttributeTest, TestSQLSetConnectAttrPacketSizeValid) {
   // Check default value first
   SQLUINTEGER size = -1;
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetConnectAttr(conn, SQL_ATTR_PACKET_SIZE, &size, 0, nullptr));
+            SQLGetConnectAttr(this->conn, SQL_ATTR_PACKET_SIZE, &size, 0, nullptr));
   EXPECT_EQ(0, size);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLSetConnectAttr(conn, SQL_ATTR_PACKET_SIZE,
+  ASSERT_EQ(SQL_SUCCESS, SQLSetConnectAttr(this->conn, SQL_ATTR_PACKET_SIZE,
                                            reinterpret_cast<SQLPOINTER>(0), 0));
 
   size = -1;
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetConnectAttr(conn, SQL_ATTR_PACKET_SIZE, &size, 0, nullptr));
+            SQLGetConnectAttr(this->conn, SQL_ATTR_PACKET_SIZE, &size, 0, nullptr));
   EXPECT_EQ(0, size);
 
   // Attempt to set to non-zero value, driver should return warning and not error
-  EXPECT_EQ(SQL_SUCCESS_WITH_INFO, SQLSetConnectAttr(conn, SQL_ATTR_PACKET_SIZE,
+  EXPECT_EQ(SQL_SUCCESS_WITH_INFO, SQLSetConnectAttr(this->conn, SQL_ATTR_PACKET_SIZE,
                                                      reinterpret_cast<SQLPOINTER>(2), 0));
 
   // Verify warning status
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorState01S02);
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorState01S02);
 }
 
 }  // namespace arrow::flight::sql::odbc

--- a/cpp/src/arrow/flight/sql/odbc/tests/connection_info_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/connection_info_test.cc
@@ -592,7 +592,7 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoAlterTable) {
 TYPED_TEST(ConnectionInfoHandleTest, TestSQLGetInfoCatalogLocation) {
   // GH-49482 TODO: resolve inconsitent return value for SQL_CATALOG_LOCATION and change
   // test type to `ConnectionInfoTest`
-  this->ConnectWithString(this->GetConnectionString());
+  this->ConnectWithString(this->GetConnectionString(), conn);
 
   SQLUSMALLINT value;
   GetInfo(conn, SQL_CATALOG_LOCATION, &value);
@@ -725,7 +725,7 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDropDomain) {
 TYPED_TEST(ConnectionInfoHandleTest, TestSQLGetInfoDropSchema) {
   // GH-49482 TODO: resolve inconsitent return value for SQL_DROP_SCHEMA and change test
   // type to `ConnectionInfoTest`
-  this->ConnectWithString(this->GetConnectionString());
+  this->ConnectWithString(this->GetConnectionString(), conn);
 
   SQLUINTEGER value;
   GetInfo(conn, SQL_DROP_SCHEMA, &value);
@@ -739,7 +739,7 @@ TYPED_TEST(ConnectionInfoHandleTest, TestSQLGetInfoDropSchema) {
 TYPED_TEST(ConnectionInfoHandleTest, TestSQLGetInfoDropTable) {
   // GH-49482 TODO: resolve inconsitent return value for SQL_DROP_TABLE and change test
   // type to `ConnectionInfoTest`
-  this->ConnectWithString(this->GetConnectionString());
+  this->ConnectWithString(this->GetConnectionString(), conn);
 
   SQLUINTEGER value;
   GetInfo(conn, SQL_DROP_TABLE, &value);

--- a/cpp/src/arrow/flight/sql/odbc/tests/connection_info_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/connection_info_test.cc
@@ -79,10 +79,10 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoTruncation) {
   SQLSMALLINT message_length;
 
   ASSERT_EQ(SQL_SUCCESS_WITH_INFO,
-            SQLGetInfo(conn, SQL_INTEGRITY, value, info_len, &message_length));
+            SQLGetInfo(this->conn, SQL_INTEGRITY, value, info_len, &message_length));
 
   // Verify string truncation is reported
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorState01004);
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorState01004);
   EXPECT_GT(message_length, 0);
 }
 
@@ -90,7 +90,7 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoTruncation) {
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoActiveEnvironments) {
   SQLUSMALLINT value;
-  GetInfo(conn, SQL_ACTIVE_ENVIRONMENTS, &value);
+  GetInfo(this->conn, SQL_ACTIVE_ENVIRONMENTS, &value);
 
   EXPECT_EQ(static_cast<SQLUSMALLINT>(0), value);
 }
@@ -98,7 +98,7 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoActiveEnvironments) {
 #ifdef SQL_ASYNC_DBC_FUNCTIONS
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoAsyncDbcFunctions) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_ASYNC_DBC_FUNCTIONS, &value);
+  GetInfo(this->conn, SQL_ASYNC_DBC_FUNCTIONS, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(SQL_ASYNC_DBC_NOT_CAPABLE), value);
 }
@@ -106,7 +106,7 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoAsyncDbcFunctions) {
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoAsyncMode) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_ASYNC_MODE, &value);
+  GetInfo(this->conn, SQL_ASYNC_MODE, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(SQL_AM_NONE), value);
 }
@@ -114,7 +114,7 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoAsyncMode) {
 #ifdef SQL_ASYNC_NOTIFICATION
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoAsyncNotification) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_ASYNC_NOTIFICATION, &value);
+  GetInfo(this->conn, SQL_ASYNC_NOTIFICATION, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(SQL_ASYNC_NOTIFICATION_NOT_CAPABLE), value);
 }
@@ -122,21 +122,21 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoAsyncNotification) {
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoBatchRowCount) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_BATCH_ROW_COUNT, &value);
+  GetInfo(this->conn, SQL_BATCH_ROW_COUNT, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoBatchSupport) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_BATCH_SUPPORT, &value);
+  GetInfo(this->conn, SQL_BATCH_SUPPORT, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDataSourceName) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(conn, SQL_DATA_SOURCE_NAME, value);
+  GetInfo(this->conn, SQL_DATA_SOURCE_NAME, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L""), value);
 }
@@ -148,7 +148,7 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDriverAwarePoolingSupported) {
   // driver's return value for it.
 
   SQLUINTEGER value;
-  GetInfo(conn, SQL_DRIVER_AWARE_POOLING_SUPPORTED, &value);
+  GetInfo(this->conn, SQL_DRIVER_AWARE_POOLING_SUPPORTED, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(SQL_DRIVER_AWARE_POOLING_NOT_CAPABLE), value);
 }
@@ -158,7 +158,7 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDriverAwarePoolingSupported) {
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDriverHdbc) {
   // Value returned from driver manager is the connection address
   SQLULEN value;
-  GetInfo(conn, SQL_DRIVER_HDBC, &value);
+  GetInfo(this->conn, SQL_DRIVER_HDBC, &value);
 
   EXPECT_GT(value, static_cast<SQLULEN>(0));
 }
@@ -168,11 +168,12 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDriverHdesc) {
   SQLHDESC descriptor;
 
   // Allocate a descriptor using alloc handle
-  ASSERT_EQ(SQL_SUCCESS, SQLAllocHandle(SQL_HANDLE_DESC, conn, &descriptor));
+  ASSERT_EQ(SQL_SUCCESS, SQLAllocHandle(SQL_HANDLE_DESC, this->conn, &descriptor));
 
   // Value returned from driver manager is the desc address
   SQLHDESC local_desc = descriptor;
-  ASSERT_EQ(SQL_SUCCESS, SQLGetInfo(conn, SQL_HANDLE_DESC, &local_desc, 0, nullptr));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetInfo(this->conn, SQL_HANDLE_DESC, &local_desc, 0, nullptr));
   EXPECT_GT(local_desc, static_cast<SQLHSTMT>(0));
 
   // Free descriptor handle
@@ -183,7 +184,7 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDriverHdesc) {
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDriverHenv) {
   // Value returned from driver manager is the env address
   SQLULEN value;
-  GetInfo(conn, SQL_DRIVER_HENV, &value);
+  GetInfo(this->conn, SQL_DRIVER_HENV, &value);
 
   EXPECT_GT(value, static_cast<SQLULEN>(0));
 }
@@ -191,7 +192,7 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDriverHenv) {
 // These information types are implemented by the Driver Manager alone.
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDriverHlib) {
   SQLULEN value;
-  GetInfo(conn, SQL_DRIVER_HLIB, &value);
+  GetInfo(this->conn, SQL_DRIVER_HLIB, &value);
 
   EXPECT_GT(value, static_cast<SQLULEN>(0));
 }
@@ -199,77 +200,78 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDriverHlib) {
 // These information types are implemented by the Driver Manager alone.
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDriverHstmt) {
   // Value returned from driver manager is the stmt address
-  SQLHSTMT local_stmt = stmt;
-  ASSERT_EQ(SQL_SUCCESS, SQLGetInfo(conn, SQL_DRIVER_HSTMT, &local_stmt, 0, nullptr));
+  SQLHSTMT local_stmt = this->stmt;
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetInfo(this->conn, SQL_DRIVER_HSTMT, &local_stmt, 0, nullptr));
   EXPECT_GT(local_stmt, static_cast<SQLHSTMT>(0));
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDriverName) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(conn, SQL_DRIVER_NAME, value);
+  GetInfo(this->conn, SQL_DRIVER_NAME, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"Arrow Flight ODBC Driver"), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDriverOdbcVer) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(conn, SQL_DRIVER_ODBC_VER, value);
+  GetInfo(this->conn, SQL_DRIVER_ODBC_VER, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"03.80"), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDriverVer) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(conn, SQL_DRIVER_VER, value);
+  GetInfo(this->conn, SQL_DRIVER_VER, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"00.09.0000.0"), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDynamicCursorAttributes1) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_DYNAMIC_CURSOR_ATTRIBUTES1, &value);
+  GetInfo(this->conn, SQL_DYNAMIC_CURSOR_ATTRIBUTES1, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDynamicCursorAttributes2) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_DYNAMIC_CURSOR_ATTRIBUTES2, &value);
+  GetInfo(this->conn, SQL_DYNAMIC_CURSOR_ATTRIBUTES2, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoForwardOnlyCursorAttributes1) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_FORWARD_ONLY_CURSOR_ATTRIBUTES1, &value);
+  GetInfo(this->conn, SQL_FORWARD_ONLY_CURSOR_ATTRIBUTES1, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(SQL_CA1_NEXT), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoForwardOnlyCursorAttributes2) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_FORWARD_ONLY_CURSOR_ATTRIBUTES2, &value);
+  GetInfo(this->conn, SQL_FORWARD_ONLY_CURSOR_ATTRIBUTES2, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(SQL_CA2_READ_ONLY_CONCURRENCY), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoFileUsage) {
   SQLUSMALLINT value;
-  GetInfo(conn, SQL_FILE_USAGE, &value);
+  GetInfo(this->conn, SQL_FILE_USAGE, &value);
 
   EXPECT_EQ(static_cast<SQLUSMALLINT>(SQL_FILE_NOT_SUPPORTED), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoGetDataExtensions) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_GETDATA_EXTENSIONS, &value);
+  GetInfo(this->conn, SQL_GETDATA_EXTENSIONS, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(SQL_GD_ANY_COLUMN | SQL_GD_ANY_ORDER), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoSchemaViews) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_INFO_SCHEMA_VIEWS, &value);
+  GetInfo(this->conn, SQL_INFO_SCHEMA_VIEWS, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(SQL_ISV_TABLES | SQL_ISV_COLUMNS | SQL_ISV_VIEWS),
             value);
@@ -277,42 +279,42 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoSchemaViews) {
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoKeysetCursorAttributes1) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_KEYSET_CURSOR_ATTRIBUTES1, &value);
+  GetInfo(this->conn, SQL_KEYSET_CURSOR_ATTRIBUTES1, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoKeysetCursorAttributes2) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_KEYSET_CURSOR_ATTRIBUTES2, &value);
+  GetInfo(this->conn, SQL_KEYSET_CURSOR_ATTRIBUTES2, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoMaxAsyncConcurrentStatements) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_MAX_ASYNC_CONCURRENT_STATEMENTS, &value);
+  GetInfo(this->conn, SQL_MAX_ASYNC_CONCURRENT_STATEMENTS, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoMaxConcurrentActivities) {
   SQLUSMALLINT value;
-  GetInfo(conn, SQL_MAX_CONCURRENT_ACTIVITIES, &value);
+  GetInfo(this->conn, SQL_MAX_CONCURRENT_ACTIVITIES, &value);
 
   EXPECT_EQ(static_cast<SQLUSMALLINT>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoMaxDriverConnections) {
   SQLUSMALLINT value;
-  GetInfo(conn, SQL_MAX_DRIVER_CONNECTIONS, &value);
+  GetInfo(this->conn, SQL_MAX_DRIVER_CONNECTIONS, &value);
 
   EXPECT_EQ(static_cast<SQLUSMALLINT>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoOdbcInterfaceConformance) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_ODBC_INTERFACE_CONFORMANCE, &value);
+  GetInfo(this->conn, SQL_ODBC_INTERFACE_CONFORMANCE, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(SQL_OIC_CORE), value);
 }
@@ -321,7 +323,7 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoOdbcVer) {
   // This is implemented only in the Driver Manager.
 
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(conn, SQL_ODBC_VER, value);
+  GetInfo(this->conn, SQL_ODBC_VER, value);
 
 #ifdef __APPLE__
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"03.52.0000"), value);
@@ -332,49 +334,49 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoOdbcVer) {
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoParamArrayRowCounts) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_PARAM_ARRAY_ROW_COUNTS, &value);
+  GetInfo(this->conn, SQL_PARAM_ARRAY_ROW_COUNTS, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(SQL_PARC_NO_BATCH), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoParamArraySelects) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_PARAM_ARRAY_SELECTS, &value);
+  GetInfo(this->conn, SQL_PARAM_ARRAY_SELECTS, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(SQL_PAS_NO_SELECT), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoRowUpdates) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(conn, SQL_ROW_UPDATES, value);
+  GetInfo(this->conn, SQL_ROW_UPDATES, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"N"), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoSearchPatternEscape) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(conn, SQL_SEARCH_PATTERN_ESCAPE, value);
+  GetInfo(this->conn, SQL_SEARCH_PATTERN_ESCAPE, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"\\"), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoServerName) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(conn, SQL_SERVER_NAME, value);
+  GetInfo(this->conn, SQL_SERVER_NAME, value);
 
   EXPECT_GT(wcslen(value), 0);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoStaticCursorAttributes1) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_STATIC_CURSOR_ATTRIBUTES1, &value);
+  GetInfo(this->conn, SQL_STATIC_CURSOR_ATTRIBUTES1, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoStaticCursorAttributes2) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_STATIC_CURSOR_ATTRIBUTES2, &value);
+  GetInfo(this->conn, SQL_STATIC_CURSOR_ATTRIBUTES2, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
@@ -383,21 +385,21 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoStaticCursorAttributes2) {
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDatabaseName) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(conn, SQL_DATABASE_NAME, value);
+  GetInfo(this->conn, SQL_DATABASE_NAME, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L""), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDbmsName) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(conn, SQL_DBMS_NAME, value);
+  GetInfo(this->conn, SQL_DBMS_NAME, value);
 
   EXPECT_GT(wcslen(value), 0);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDbmsVer) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(conn, SQL_DBMS_VER, value);
+  GetInfo(this->conn, SQL_DBMS_VER, value);
 
   EXPECT_GT(wcslen(value), 0);
 }
@@ -406,160 +408,160 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDbmsVer) {
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoAccessibleProcedures) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(conn, SQL_ACCESSIBLE_PROCEDURES, value);
+  GetInfo(this->conn, SQL_ACCESSIBLE_PROCEDURES, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"N"), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoAccessibleTables) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(conn, SQL_ACCESSIBLE_TABLES, value);
+  GetInfo(this->conn, SQL_ACCESSIBLE_TABLES, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"Y"), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoBookmarkPersistence) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_BOOKMARK_PERSISTENCE, &value);
+  GetInfo(this->conn, SQL_BOOKMARK_PERSISTENCE, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoCatalogTerm) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(conn, SQL_CATALOG_TERM, value);
+  GetInfo(this->conn, SQL_CATALOG_TERM, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L""), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoCollationSeq) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(conn, SQL_COLLATION_SEQ, value);
+  GetInfo(this->conn, SQL_COLLATION_SEQ, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L""), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoConcatNullBehavior) {
   SQLUSMALLINT value;
-  GetInfo(conn, SQL_CONCAT_NULL_BEHAVIOR, &value);
+  GetInfo(this->conn, SQL_CONCAT_NULL_BEHAVIOR, &value);
 
   EXPECT_EQ(static_cast<SQLUSMALLINT>(SQL_CB_NULL), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoCursorCommitBehavior) {
   SQLUSMALLINT value;
-  GetInfo(conn, SQL_CURSOR_COMMIT_BEHAVIOR, &value);
+  GetInfo(this->conn, SQL_CURSOR_COMMIT_BEHAVIOR, &value);
 
   EXPECT_EQ(static_cast<SQLUSMALLINT>(SQL_CB_CLOSE), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoCursorRollbackBehavior) {
   SQLUSMALLINT value;
-  GetInfo(conn, SQL_CURSOR_ROLLBACK_BEHAVIOR, &value);
+  GetInfo(this->conn, SQL_CURSOR_ROLLBACK_BEHAVIOR, &value);
 
   EXPECT_EQ(static_cast<SQLUSMALLINT>(SQL_CB_CLOSE), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoCursorSensitivity) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_CURSOR_SENSITIVITY, &value);
+  GetInfo(this->conn, SQL_CURSOR_SENSITIVITY, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(SQL_UNSPECIFIED), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDataSourceReadOnly) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(conn, SQL_DATA_SOURCE_READ_ONLY, value);
+  GetInfo(this->conn, SQL_DATA_SOURCE_READ_ONLY, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"N"), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDefaultTxnIsolation) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_DEFAULT_TXN_ISOLATION, &value);
+  GetInfo(this->conn, SQL_DEFAULT_TXN_ISOLATION, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDescribeParameter) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(conn, SQL_DESCRIBE_PARAMETER, value);
+  GetInfo(this->conn, SQL_DESCRIBE_PARAMETER, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"N"), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoMultResultSets) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(conn, SQL_MULT_RESULT_SETS, value);
+  GetInfo(this->conn, SQL_MULT_RESULT_SETS, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"N"), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoMultipleActiveTxn) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(conn, SQL_MULTIPLE_ACTIVE_TXN, value);
+  GetInfo(this->conn, SQL_MULTIPLE_ACTIVE_TXN, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"N"), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoNeedLongDataLen) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(conn, SQL_NEED_LONG_DATA_LEN, value);
+  GetInfo(this->conn, SQL_NEED_LONG_DATA_LEN, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"N"), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoNullCollation) {
   SQLUSMALLINT value;
-  GetInfo(conn, SQL_NULL_COLLATION, &value);
+  GetInfo(this->conn, SQL_NULL_COLLATION, &value);
   EXPECT_EQ(static_cast<SQLUSMALLINT>(SQL_NC_START), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoProcedureTerm) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(conn, SQL_PROCEDURE_TERM, value);
+  GetInfo(this->conn, SQL_PROCEDURE_TERM, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L""), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoSchemaTerm) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(conn, SQL_SCHEMA_TERM, value);
+  GetInfo(this->conn, SQL_SCHEMA_TERM, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"schema"), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoScrollOptions) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_SCROLL_OPTIONS, &value);
+  GetInfo(this->conn, SQL_SCROLL_OPTIONS, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(SQL_SO_FORWARD_ONLY), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoTableTerm) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(conn, SQL_TABLE_TERM, value);
+  GetInfo(this->conn, SQL_TABLE_TERM, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"table"), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoTxnCapable) {
   SQLUSMALLINT value;
-  GetInfo(conn, SQL_TXN_CAPABLE, &value);
+  GetInfo(this->conn, SQL_TXN_CAPABLE, &value);
 
   EXPECT_EQ(static_cast<SQLUSMALLINT>(SQL_TC_NONE), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoTxnIsolationOption) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_TXN_ISOLATION_OPTION, &value);
+  GetInfo(this->conn, SQL_TXN_ISOLATION_OPTION, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoUserName) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(conn, SQL_USER_NAME, value);
+  GetInfo(this->conn, SQL_USER_NAME, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L""), value);
 }
@@ -568,7 +570,7 @@ TEST_F(ConnectionInfoMockTest, TestSQLGetInfoUserName) {
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoAggregateFunctions) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_AGGREGATE_FUNCTIONS, &value);
+  GetInfo(this->conn, SQL_AGGREGATE_FUNCTIONS, &value);
 
   EXPECT_EQ(value, static_cast<SQLUINTEGER>(SQL_AF_ALL | SQL_AF_AVG | SQL_AF_COUNT |
                                             SQL_AF_DISTINCT | SQL_AF_MAX | SQL_AF_MIN |
@@ -577,14 +579,14 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoAggregateFunctions) {
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoAlterDomain) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_ALTER_DOMAIN, &value);
+  GetInfo(this->conn, SQL_ALTER_DOMAIN, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoAlterTable) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_ALTER_TABLE, &value);
+  GetInfo(this->conn, SQL_ALTER_TABLE, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
@@ -592,132 +594,132 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoAlterTable) {
 TYPED_TEST(ConnectionInfoHandleTest, TestSQLGetInfoCatalogLocation) {
   // GH-49482 TODO: resolve inconsitent return value for SQL_CATALOG_LOCATION and change
   // test type to `ConnectionInfoTest`
-  this->ConnectWithString(this->GetConnectionString(), conn);
+  this->ConnectWithString(this->GetConnectionString(), this->conn);
 
   SQLUSMALLINT value;
-  GetInfo(conn, SQL_CATALOG_LOCATION, &value);
+  GetInfo(this->conn, SQL_CATALOG_LOCATION, &value);
 
   EXPECT_EQ(static_cast<SQLUSMALLINT>(0), value);
 
-  EXPECT_EQ(SQL_SUCCESS, SQLDisconnect(conn))
-      << GetOdbcErrorMessage(SQL_HANDLE_DBC, conn);
+  EXPECT_EQ(SQL_SUCCESS, SQLDisconnect(this->conn))
+      << GetOdbcErrorMessage(SQL_HANDLE_DBC, this->conn);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoCatalogName) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(conn, SQL_CATALOG_NAME, value);
+  GetInfo(this->conn, SQL_CATALOG_NAME, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"N"), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoCatalogNameSeparator) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(conn, SQL_CATALOG_NAME_SEPARATOR, value);
+  GetInfo(this->conn, SQL_CATALOG_NAME_SEPARATOR, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L""), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoCatalogUsage) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_CATALOG_USAGE, &value);
+  GetInfo(this->conn, SQL_CATALOG_USAGE, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoColumnAlias) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(conn, SQL_COLUMN_ALIAS, value);
+  GetInfo(this->conn, SQL_COLUMN_ALIAS, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"Y"), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoCorrelationName) {
   SQLUSMALLINT value;
-  GetInfo(conn, SQL_CORRELATION_NAME, &value);
+  GetInfo(this->conn, SQL_CORRELATION_NAME, &value);
 
   EXPECT_EQ(static_cast<SQLUSMALLINT>(SQL_CN_NONE), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoCreateAssertion) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_CREATE_ASSERTION, &value);
+  GetInfo(this->conn, SQL_CREATE_ASSERTION, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoCreateCharacterSet) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_CREATE_CHARACTER_SET, &value);
+  GetInfo(this->conn, SQL_CREATE_CHARACTER_SET, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoCreateCollation) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_CREATE_COLLATION, &value);
+  GetInfo(this->conn, SQL_CREATE_COLLATION, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoCreateDomain) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_CREATE_DOMAIN, &value);
+  GetInfo(this->conn, SQL_CREATE_DOMAIN, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoCreateSchema) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_CREATE_SCHEMA, &value);
+  GetInfo(this->conn, SQL_CREATE_SCHEMA, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(1), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoCreateTable) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_CREATE_TABLE, &value);
+  GetInfo(this->conn, SQL_CREATE_TABLE, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(1), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoCreateTranslation) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_CREATE_TRANSLATION, &value);
+  GetInfo(this->conn, SQL_CREATE_TRANSLATION, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDdlIndex) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_DDL_INDEX, &value);
+  GetInfo(this->conn, SQL_DDL_INDEX, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDropAssertion) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_DROP_ASSERTION, &value);
+  GetInfo(this->conn, SQL_DROP_ASSERTION, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDropCharacterSet) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_DROP_CHARACTER_SET, &value);
+  GetInfo(this->conn, SQL_DROP_CHARACTER_SET, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDropCollation) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_DROP_COLLATION, &value);
+  GetInfo(this->conn, SQL_DROP_COLLATION, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDropDomain) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_DROP_DOMAIN, &value);
+  GetInfo(this->conn, SQL_DROP_DOMAIN, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
@@ -725,83 +727,83 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDropDomain) {
 TYPED_TEST(ConnectionInfoHandleTest, TestSQLGetInfoDropSchema) {
   // GH-49482 TODO: resolve inconsitent return value for SQL_DROP_SCHEMA and change test
   // type to `ConnectionInfoTest`
-  this->ConnectWithString(this->GetConnectionString(), conn);
+  this->ConnectWithString(this->GetConnectionString(), this->conn);
 
   SQLUINTEGER value;
-  GetInfo(conn, SQL_DROP_SCHEMA, &value);
+  GetInfo(this->conn, SQL_DROP_SCHEMA, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 
-  EXPECT_EQ(SQL_SUCCESS, SQLDisconnect(conn))
-      << GetOdbcErrorMessage(SQL_HANDLE_DBC, conn);
+  EXPECT_EQ(SQL_SUCCESS, SQLDisconnect(this->conn))
+      << GetOdbcErrorMessage(SQL_HANDLE_DBC, this->conn);
 }
 
 TYPED_TEST(ConnectionInfoHandleTest, TestSQLGetInfoDropTable) {
   // GH-49482 TODO: resolve inconsitent return value for SQL_DROP_TABLE and change test
   // type to `ConnectionInfoTest`
-  this->ConnectWithString(this->GetConnectionString(), conn);
+  this->ConnectWithString(this->GetConnectionString(), this->conn);
 
   SQLUINTEGER value;
-  GetInfo(conn, SQL_DROP_TABLE, &value);
+  GetInfo(this->conn, SQL_DROP_TABLE, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 
-  EXPECT_EQ(SQL_SUCCESS, SQLDisconnect(conn))
-      << GetOdbcErrorMessage(SQL_HANDLE_DBC, conn);
+  EXPECT_EQ(SQL_SUCCESS, SQLDisconnect(this->conn))
+      << GetOdbcErrorMessage(SQL_HANDLE_DBC, this->conn);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDropTranslation) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_DROP_TRANSLATION, &value);
+  GetInfo(this->conn, SQL_DROP_TRANSLATION, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoDropView) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_DROP_VIEW, &value);
+  GetInfo(this->conn, SQL_DROP_VIEW, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoExpressionsInOrderby) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(conn, SQL_EXPRESSIONS_IN_ORDERBY, value);
+  GetInfo(this->conn, SQL_EXPRESSIONS_IN_ORDERBY, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"N"), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoGroupBy) {
   SQLUSMALLINT value;
-  GetInfo(conn, SQL_GROUP_BY, &value);
+  GetInfo(this->conn, SQL_GROUP_BY, &value);
 
   EXPECT_EQ(static_cast<SQLUSMALLINT>(SQL_GB_GROUP_BY_CONTAINS_SELECT), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoIdentifierCase) {
   SQLUSMALLINT value;
-  GetInfo(conn, SQL_IDENTIFIER_CASE, &value);
+  GetInfo(this->conn, SQL_IDENTIFIER_CASE, &value);
 
   EXPECT_EQ(static_cast<SQLUSMALLINT>(SQL_IC_MIXED), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoIdentifierQuoteChar) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(conn, SQL_IDENTIFIER_QUOTE_CHAR, value);
+  GetInfo(this->conn, SQL_IDENTIFIER_QUOTE_CHAR, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"\""), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoIndexKeywords) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_INDEX_KEYWORDS, &value);
+  GetInfo(this->conn, SQL_INDEX_KEYWORDS, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(SQL_IK_NONE), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoInsertStatement) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_INSERT_STATEMENT, &value);
+  GetInfo(this->conn, SQL_INSERT_STATEMENT, &value);
 
   EXPECT_EQ(value, static_cast<SQLUINTEGER>(SQL_IS_INSERT_LITERALS |
                                             SQL_IS_INSERT_SEARCHED | SQL_IS_SELECT_INTO));
@@ -809,7 +811,7 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoInsertStatement) {
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoIntegrity) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(conn, SQL_INTEGRITY, value);
+  GetInfo(this->conn, SQL_INTEGRITY, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"N"), value);
 }
@@ -818,84 +820,84 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoKeywords) {
   // Keyword strings can require 10000 buffer length
   static constexpr int info_len = kOdbcBufferSize * 10;
   SQLWCHAR value[info_len] = L"";
-  GetInfo(conn, SQL_KEYWORDS, value, info_len);
+  GetInfo(this->conn, SQL_KEYWORDS, value, info_len);
 
   EXPECT_GT(wcslen(value), 0);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoLikeEscapeClause) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(conn, SQL_LIKE_ESCAPE_CLAUSE, value);
+  GetInfo(this->conn, SQL_LIKE_ESCAPE_CLAUSE, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"Y"), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoNonNullableColumns) {
   SQLUSMALLINT value;
-  GetInfo(conn, SQL_NON_NULLABLE_COLUMNS, &value);
+  GetInfo(this->conn, SQL_NON_NULLABLE_COLUMNS, &value);
 
   EXPECT_EQ(static_cast<SQLUSMALLINT>(SQL_NNC_NULL), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoOjCapabilities) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_OJ_CAPABILITIES, &value);
+  GetInfo(this->conn, SQL_OJ_CAPABILITIES, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(SQL_OJ_LEFT | SQL_OJ_RIGHT | SQL_OJ_FULL), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoOrderByColumnsInSelect) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(conn, SQL_ORDER_BY_COLUMNS_IN_SELECT, value);
+  GetInfo(this->conn, SQL_ORDER_BY_COLUMNS_IN_SELECT, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"Y"), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoOuterJoins) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(conn, SQL_OUTER_JOINS, value);
+  GetInfo(this->conn, SQL_OUTER_JOINS, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"N"), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoProcedures) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(conn, SQL_PROCEDURES, value);
+  GetInfo(this->conn, SQL_PROCEDURES, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"N"), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoQuotedIdentifierCase) {
   SQLUSMALLINT value;
-  GetInfo(conn, SQL_QUOTED_IDENTIFIER_CASE, &value);
+  GetInfo(this->conn, SQL_QUOTED_IDENTIFIER_CASE, &value);
 
   EXPECT_EQ(static_cast<SQLUSMALLINT>(SQL_IC_MIXED), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoSchemaUsage) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_SCHEMA_USAGE, &value);
+  GetInfo(this->conn, SQL_SCHEMA_USAGE, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(SQL_SU_DML_STATEMENTS), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoSpecialCharacters) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(conn, SQL_SPECIAL_CHARACTERS, value);
+  GetInfo(this->conn, SQL_SPECIAL_CHARACTERS, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L""), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoSqlConformance) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_SQL_CONFORMANCE, &value);
+  GetInfo(this->conn, SQL_SQL_CONFORMANCE, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(SQL_SC_SQL92_ENTRY), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoSubqueries) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_SUBQUERIES, &value);
+  GetInfo(this->conn, SQL_SUBQUERIES, &value);
 
   EXPECT_EQ(value,
             static_cast<SQLUINTEGER>(SQL_SQ_CORRELATED_SUBQUERIES | SQL_SQ_COMPARISON |
@@ -904,7 +906,7 @@ TEST_F(ConnectionInfoMockTest, TestSQLGetInfoSubqueries) {
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoUnion) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_UNION, &value);
+  GetInfo(this->conn, SQL_UNION, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(SQL_U_UNION | SQL_U_UNION_ALL), value);
 }
@@ -913,140 +915,140 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoUnion) {
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoMaxBinaryLiteralLen) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_MAX_BINARY_LITERAL_LEN, &value);
+  GetInfo(this->conn, SQL_MAX_BINARY_LITERAL_LEN, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoMaxCatalogNameLen) {
   SQLUSMALLINT value;
-  GetInfo(conn, SQL_MAX_CATALOG_NAME_LEN, &value);
+  GetInfo(this->conn, SQL_MAX_CATALOG_NAME_LEN, &value);
 
   EXPECT_EQ(static_cast<SQLUSMALLINT>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoMaxCharLiteralLen) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_MAX_CHAR_LITERAL_LEN, &value);
+  GetInfo(this->conn, SQL_MAX_CHAR_LITERAL_LEN, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoMaxColumnNameLen) {
   SQLUSMALLINT value;
-  GetInfo(conn, SQL_MAX_COLUMN_NAME_LEN, &value);
+  GetInfo(this->conn, SQL_MAX_COLUMN_NAME_LEN, &value);
 
   EXPECT_EQ(static_cast<SQLUSMALLINT>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoMaxColumnsInGroupBy) {
   SQLUSMALLINT value;
-  GetInfo(conn, SQL_MAX_COLUMNS_IN_GROUP_BY, &value);
+  GetInfo(this->conn, SQL_MAX_COLUMNS_IN_GROUP_BY, &value);
 
   EXPECT_EQ(static_cast<SQLUSMALLINT>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoMaxColumnsInIndex) {
   SQLUSMALLINT value;
-  GetInfo(conn, SQL_MAX_COLUMNS_IN_INDEX, &value);
+  GetInfo(this->conn, SQL_MAX_COLUMNS_IN_INDEX, &value);
 
   EXPECT_EQ(static_cast<SQLUSMALLINT>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoMaxColumnsInOrderBy) {
   SQLUSMALLINT value;
-  GetInfo(conn, SQL_MAX_COLUMNS_IN_ORDER_BY, &value);
+  GetInfo(this->conn, SQL_MAX_COLUMNS_IN_ORDER_BY, &value);
 
   EXPECT_EQ(static_cast<SQLUSMALLINT>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoMaxColumnsInSelect) {
   SQLUSMALLINT value;
-  GetInfo(conn, SQL_MAX_COLUMNS_IN_SELECT, &value);
+  GetInfo(this->conn, SQL_MAX_COLUMNS_IN_SELECT, &value);
 
   EXPECT_EQ(static_cast<SQLUSMALLINT>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoMaxColumnsInTable) {
   SQLUSMALLINT value;
-  GetInfo(conn, SQL_MAX_COLUMNS_IN_TABLE, &value);
+  GetInfo(this->conn, SQL_MAX_COLUMNS_IN_TABLE, &value);
 
   EXPECT_EQ(static_cast<SQLUSMALLINT>(0), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoMaxCursorNameLen) {
   SQLUSMALLINT value;
-  GetInfo(conn, SQL_MAX_CURSOR_NAME_LEN, &value);
+  GetInfo(this->conn, SQL_MAX_CURSOR_NAME_LEN, &value);
 
   EXPECT_EQ(static_cast<SQLUSMALLINT>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoMaxIdentifierLen) {
   SQLUSMALLINT value;
-  GetInfo(conn, SQL_MAX_IDENTIFIER_LEN, &value);
+  GetInfo(this->conn, SQL_MAX_IDENTIFIER_LEN, &value);
 
   EXPECT_EQ(static_cast<SQLUSMALLINT>(65535), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoMaxIndexSize) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_MAX_INDEX_SIZE, &value);
+  GetInfo(this->conn, SQL_MAX_INDEX_SIZE, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoMaxProcedureNameLen) {
   SQLUSMALLINT value;
-  GetInfo(conn, SQL_MAX_PROCEDURE_NAME_LEN, &value);
+  GetInfo(this->conn, SQL_MAX_PROCEDURE_NAME_LEN, &value);
 
   EXPECT_EQ(static_cast<SQLUSMALLINT>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoMaxRowSize) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(conn, SQL_MAX_ROW_SIZE, value);
+  GetInfo(this->conn, SQL_MAX_ROW_SIZE, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L""), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoMaxRowSizeIncludesLong) {
   SQLWCHAR value[kOdbcBufferSize] = L"";
-  GetInfo(conn, SQL_MAX_ROW_SIZE_INCLUDES_LONG, value);
+  GetInfo(this->conn, SQL_MAX_ROW_SIZE_INCLUDES_LONG, value);
 
   EXPECT_STREQ(static_cast<const SQLWCHAR*>(L"N"), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoMaxSchemaNameLen) {
   SQLUSMALLINT value;
-  GetInfo(conn, SQL_MAX_SCHEMA_NAME_LEN, &value);
+  GetInfo(this->conn, SQL_MAX_SCHEMA_NAME_LEN, &value);
 
   EXPECT_EQ(static_cast<SQLUSMALLINT>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoMaxStatementLen) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_MAX_STATEMENT_LEN, &value);
+  GetInfo(this->conn, SQL_MAX_STATEMENT_LEN, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoMaxTableNameLen) {
   SQLUSMALLINT value;
-  GetInfo(conn, SQL_MAX_TABLE_NAME_LEN, &value);
+  GetInfo(this->conn, SQL_MAX_TABLE_NAME_LEN, &value);
 
   EXPECT_EQ(static_cast<SQLUSMALLINT>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoMaxTablesInSelect) {
   SQLUSMALLINT value;
-  GetInfo(conn, SQL_MAX_TABLES_IN_SELECT, &value);
+  GetInfo(this->conn, SQL_MAX_TABLES_IN_SELECT, &value);
 
   EXPECT_EQ(static_cast<SQLUSMALLINT>(0), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoMaxUserNameLen) {
   SQLUSMALLINT value;
-  GetInfo(conn, SQL_MAX_USER_NAME_LEN, &value);
+  GetInfo(this->conn, SQL_MAX_USER_NAME_LEN, &value);
 
   EXPECT_EQ(static_cast<SQLUSMALLINT>(0), value);
 }
@@ -1055,21 +1057,21 @@ TEST_F(ConnectionInfoMockTest, TestSQLGetInfoMaxUserNameLen) {
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoConvertFunctions) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_CONVERT_FUNCTIONS, &value);
+  GetInfo(this->conn, SQL_CONVERT_FUNCTIONS, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoNumericFunctions) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_NUMERIC_FUNCTIONS, &value);
+  GetInfo(this->conn, SQL_NUMERIC_FUNCTIONS, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(4058942), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoStringFunctions) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_STRING_FUNCTIONS, &value);
+  GetInfo(this->conn, SQL_STRING_FUNCTIONS, &value);
 
   EXPECT_EQ(value, static_cast<SQLUINTEGER>(SQL_FN_STR_LTRIM | SQL_FN_STR_LENGTH |
                                             SQL_FN_STR_REPLACE | SQL_FN_STR_RTRIM));
@@ -1077,14 +1079,14 @@ TEST_F(ConnectionInfoMockTest, TestSQLGetInfoStringFunctions) {
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoSystemFunctions) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_SYSTEM_FUNCTIONS, &value);
+  GetInfo(this->conn, SQL_SYSTEM_FUNCTIONS, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(SQL_FN_SYS_IFNULL | SQL_FN_SYS_USERNAME), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoTimedateAddIntervals) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_TIMEDATE_ADD_INTERVALS, &value);
+  GetInfo(this->conn, SQL_TIMEDATE_ADD_INTERVALS, &value);
 
   EXPECT_EQ(value, static_cast<SQLUINTEGER>(
                        SQL_FN_TSI_FRAC_SECOND | SQL_FN_TSI_SECOND | SQL_FN_TSI_MINUTE |
@@ -1094,7 +1096,7 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoTimedateAddIntervals) {
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoTimedateDiffIntervals) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_TIMEDATE_DIFF_INTERVALS, &value);
+  GetInfo(this->conn, SQL_TIMEDATE_DIFF_INTERVALS, &value);
 
   EXPECT_EQ(value, static_cast<SQLUINTEGER>(
                        SQL_FN_TSI_FRAC_SECOND | SQL_FN_TSI_SECOND | SQL_FN_TSI_MINUTE |
@@ -1104,7 +1106,7 @@ TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoTimedateDiffIntervals) {
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoTimedateFunctions) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_TIMEDATE_FUNCTIONS, &value);
+  GetInfo(this->conn, SQL_TIMEDATE_FUNCTIONS, &value);
 
   EXPECT_EQ(value,
             static_cast<SQLUINTEGER>(
@@ -1121,147 +1123,147 @@ TEST_F(ConnectionInfoMockTest, TestSQLGetInfoTimedateFunctions) {
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoConvertBigint) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_CONVERT_BIGINT, &value);
+  GetInfo(this->conn, SQL_CONVERT_BIGINT, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(8), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoConvertBinary) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_CONVERT_BINARY, &value);
+  GetInfo(this->conn, SQL_CONVERT_BINARY, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoConvertBit) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_CONVERT_BIT, &value);
+  GetInfo(this->conn, SQL_CONVERT_BIT, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoConvertChar) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_CONVERT_CHAR, &value);
+  GetInfo(this->conn, SQL_CONVERT_CHAR, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoConvertDate) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_CONVERT_DATE, &value);
+  GetInfo(this->conn, SQL_CONVERT_DATE, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoConvertDecimal) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_CONVERT_DECIMAL, &value);
+  GetInfo(this->conn, SQL_CONVERT_DECIMAL, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoConvertDouble) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_CONVERT_DOUBLE, &value);
+  GetInfo(this->conn, SQL_CONVERT_DOUBLE, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoConvertFloat) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_CONVERT_FLOAT, &value);
+  GetInfo(this->conn, SQL_CONVERT_FLOAT, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoConvertInteger) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_CONVERT_INTEGER, &value);
+  GetInfo(this->conn, SQL_CONVERT_INTEGER, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoConvertIntervalDayTime) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_CONVERT_INTERVAL_DAY_TIME, &value);
+  GetInfo(this->conn, SQL_CONVERT_INTERVAL_DAY_TIME, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoConvertIntervalYearMonth) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_CONVERT_INTERVAL_YEAR_MONTH, &value);
+  GetInfo(this->conn, SQL_CONVERT_INTERVAL_YEAR_MONTH, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoConvertLongvarbinary) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_CONVERT_LONGVARBINARY, &value);
+  GetInfo(this->conn, SQL_CONVERT_LONGVARBINARY, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoConvertLongvarchar) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_CONVERT_LONGVARCHAR, &value);
+  GetInfo(this->conn, SQL_CONVERT_LONGVARCHAR, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TEST_F(ConnectionInfoMockTest, TestSQLGetInfoConvertNumeric) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_CONVERT_NUMERIC, &value);
+  GetInfo(this->conn, SQL_CONVERT_NUMERIC, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoConvertReal) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_CONVERT_REAL, &value);
+  GetInfo(this->conn, SQL_CONVERT_REAL, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoConvertSmallint) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_CONVERT_SMALLINT, &value);
+  GetInfo(this->conn, SQL_CONVERT_SMALLINT, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoConvertTime) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_CONVERT_TIME, &value);
+  GetInfo(this->conn, SQL_CONVERT_TIME, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoConvertTimestamp) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_CONVERT_TIMESTAMP, &value);
+  GetInfo(this->conn, SQL_CONVERT_TIMESTAMP, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoConvertTinyint) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_CONVERT_TINYINT, &value);
+  GetInfo(this->conn, SQL_CONVERT_TINYINT, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoConvertVarbinary) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_CONVERT_VARBINARY, &value);
+  GetInfo(this->conn, SQL_CONVERT_VARBINARY, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }
 
 TYPED_TEST(ConnectionInfoTest, TestSQLGetInfoConvertVarchar) {
   SQLUINTEGER value;
-  GetInfo(conn, SQL_CONVERT_VARCHAR, &value);
+  GetInfo(this->conn, SQL_CONVERT_VARCHAR, &value);
 
   EXPECT_EQ(static_cast<SQLUINTEGER>(0), value);
 }

--- a/cpp/src/arrow/flight/sql/odbc/tests/connection_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/connection_test.cc
@@ -155,7 +155,7 @@ TYPED_TEST(ConnectionTest, TestSQLGetEnvAttrOutputNTS) {
   SQLINTEGER output_nts;
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetEnvAttr(env, SQL_ATTR_OUTPUT_NTS, &output_nts, 0, nullptr));
+            SQLGetEnvAttr(this->env, SQL_ATTR_OUTPUT_NTS, &output_nts, 0, nullptr));
 
   ASSERT_EQ(SQL_TRUE, output_nts);
 }
@@ -165,7 +165,8 @@ TYPED_TEST(ConnectionTest, DISABLED_TestSQLGetEnvAttrGetLength) {
   // Windows. Windows driver manager ignores the length pointer.
   // This test case can be potentially used on macOS/Linux
   SQLINTEGER length;
-  ASSERT_EQ(SQL_SUCCESS, SQLGetEnvAttr(env, SQL_ATTR_ODBC_VERSION, nullptr, 0, &length));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetEnvAttr(this->env, SQL_ATTR_ODBC_VERSION, nullptr, 0, &length));
 
   EXPECT_EQ(sizeof(SQLINTEGER), length);
 }
@@ -174,7 +175,8 @@ TYPED_TEST(ConnectionTest, DISABLED_TestSQLGetEnvAttrNullValuePointer) {
   // Test is disabled because call to SQLGetEnvAttr is handled by the driver manager on
   // Windows. The Windows driver manager doesn't error out when null pointer is passed.
   // This test case can be potentially used on macOS/Linux
-  ASSERT_EQ(SQL_ERROR, SQLGetEnvAttr(env, SQL_ATTR_ODBC_VERSION, nullptr, 0, nullptr));
+  ASSERT_EQ(SQL_ERROR,
+            SQLGetEnvAttr(this->env, SQL_ATTR_ODBC_VERSION, nullptr, 0, nullptr));
 }
 
 TEST(SQLSetEnvAttr, TestSQLSetEnvAttrOutputNTSValid) {
@@ -227,10 +229,10 @@ TYPED_TEST(ConnectionHandleTest, TestSQLDriverConnect) {
 
   // Connecting to ODBC server.
   ASSERT_EQ(SQL_SUCCESS,
-            SQLDriverConnect(conn, NULL, &connect_str0[0],
+            SQLDriverConnect(this->conn, NULL, &connect_str0[0],
                              static_cast<SQLSMALLINT>(connect_str0.size()), out_str,
                              kOdbcBufferSize, &out_str_len, SQL_DRIVER_NOPROMPT))
-      << GetOdbcErrorMessage(SQL_HANDLE_DBC, conn);
+      << GetOdbcErrorMessage(SQL_HANDLE_DBC, this->conn);
 
   // Check that out_str has same content as connect_str
   std::string out_connection_string = ODBC::SqlWcharToString(out_str, out_str_len);
@@ -242,8 +244,8 @@ TYPED_TEST(ConnectionHandleTest, TestSQLDriverConnect) {
   ASSERT_TRUE(CompareConnPropertyMap(out_properties, in_properties));
 
   // Disconnect from ODBC
-  ASSERT_EQ(SQL_SUCCESS, SQLDisconnect(conn))
-      << GetOdbcErrorMessage(SQL_HANDLE_DBC, conn);
+  ASSERT_EQ(SQL_SUCCESS, SQLDisconnect(this->conn))
+      << GetOdbcErrorMessage(SQL_HANDLE_DBC, this->conn);
 }
 
 TYPED_TEST(ConnectionHandleTest, TestSQLDriverConnectDsn) {
@@ -269,17 +271,17 @@ TYPED_TEST(ConnectionHandleTest, TestSQLDriverConnectDsn) {
 
   // Connecting to ODBC server.
   ASSERT_EQ(SQL_SUCCESS,
-            SQLDriverConnect(conn, NULL, &connect_str0[0],
+            SQLDriverConnect(this->conn, NULL, &connect_str0[0],
                              static_cast<SQLSMALLINT>(connect_str0.size()), out_str,
                              kOdbcBufferSize, &out_str_len, SQL_DRIVER_NOPROMPT))
-      << GetOdbcErrorMessage(SQL_HANDLE_DBC, conn);
+      << GetOdbcErrorMessage(SQL_HANDLE_DBC, this->conn);
 
   // Remove DSN
   ASSERT_TRUE(UnregisterDsn(wdsn));
 
   // Disconnect from ODBC
-  ASSERT_EQ(SQL_SUCCESS, SQLDisconnect(conn))
-      << GetOdbcErrorMessage(SQL_HANDLE_DBC, conn);
+  ASSERT_EQ(SQL_SUCCESS, SQLDisconnect(this->conn))
+      << GetOdbcErrorMessage(SQL_HANDLE_DBC, this->conn);
 }
 
 TYPED_TEST(ConnectionHandleTest, TestSQLConnect) {
@@ -301,17 +303,17 @@ TYPED_TEST(ConnectionHandleTest, TestSQLConnect) {
 
   // Connecting to ODBC server. Empty uid and pwd should be ignored.
   ASSERT_EQ(SQL_SUCCESS,
-            SQLConnect(conn, dsn0.data(), static_cast<SQLSMALLINT>(dsn0.size()),
+            SQLConnect(this->conn, dsn0.data(), static_cast<SQLSMALLINT>(dsn0.size()),
                        uid0.data(), static_cast<SQLSMALLINT>(uid0.size()), pwd0.data(),
                        static_cast<SQLSMALLINT>(pwd0.size())))
-      << GetOdbcErrorMessage(SQL_HANDLE_DBC, conn);
+      << GetOdbcErrorMessage(SQL_HANDLE_DBC, this->conn);
 
   // Remove DSN
   ASSERT_TRUE(UnregisterDsn(wdsn));
 
   // Disconnect from ODBC
-  ASSERT_EQ(SQL_SUCCESS, SQLDisconnect(conn))
-      << GetOdbcErrorMessage(SQL_HANDLE_DBC, conn);
+  ASSERT_EQ(SQL_SUCCESS, SQLDisconnect(this->conn))
+      << GetOdbcErrorMessage(SQL_HANDLE_DBC, this->conn);
 }
 
 TEST_F(ConnectionRemoteTest, TestSQLConnectInputUidPwd) {
@@ -342,17 +344,17 @@ TEST_F(ConnectionRemoteTest, TestSQLConnectInputUidPwd) {
 
   // Connecting to ODBC server.
   ASSERT_EQ(SQL_SUCCESS,
-            SQLConnect(conn, dsn0.data(), static_cast<SQLSMALLINT>(dsn0.size()),
+            SQLConnect(this->conn, dsn0.data(), static_cast<SQLSMALLINT>(dsn0.size()),
                        uid0.data(), static_cast<SQLSMALLINT>(uid0.size()), pwd0.data(),
                        static_cast<SQLSMALLINT>(pwd0.size())))
-      << GetOdbcErrorMessage(SQL_HANDLE_DBC, conn);
+      << GetOdbcErrorMessage(SQL_HANDLE_DBC, this->conn);
 
   // Remove DSN
   ASSERT_TRUE(UnregisterDsn(wdsn));
 
   // Disconnect from ODBC
-  ASSERT_EQ(SQL_SUCCESS, SQLDisconnect(conn))
-      << GetOdbcErrorMessage(SQL_HANDLE_DBC, conn);
+  ASSERT_EQ(SQL_SUCCESS, SQLDisconnect(this->conn))
+      << GetOdbcErrorMessage(SQL_HANDLE_DBC, this->conn);
 }
 
 TEST_F(ConnectionRemoteTest, TestSQLConnectInvalidUid) {
@@ -384,11 +386,11 @@ TEST_F(ConnectionRemoteTest, TestSQLConnectInvalidUid) {
   // UID specified in DSN will take precedence,
   // so connection still fails despite passing valid uid in SQLConnect call
   ASSERT_EQ(SQL_ERROR,
-            SQLConnect(conn, dsn0.data(), static_cast<SQLSMALLINT>(dsn0.size()),
+            SQLConnect(this->conn, dsn0.data(), static_cast<SQLSMALLINT>(dsn0.size()),
                        uid0.data(), static_cast<SQLSMALLINT>(uid0.size()), pwd0.data(),
                        static_cast<SQLSMALLINT>(pwd0.size())));
 
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorState28000);
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorState28000);
 
   // Remove DSN
   ASSERT_TRUE(UnregisterDsn(wdsn));
@@ -416,17 +418,17 @@ TEST_F(ConnectionRemoteTest, TestSQLConnectDSNPrecedence) {
 
   // Connecting to ODBC server.
   ASSERT_EQ(SQL_SUCCESS,
-            SQLConnect(conn, dsn0.data(), static_cast<SQLSMALLINT>(dsn0.size()),
+            SQLConnect(this->conn, dsn0.data(), static_cast<SQLSMALLINT>(dsn0.size()),
                        uid0.data(), static_cast<SQLSMALLINT>(uid0.size()), pwd0.data(),
                        static_cast<SQLSMALLINT>(pwd0.size())))
-      << GetOdbcErrorMessage(SQL_HANDLE_DBC, conn);
+      << GetOdbcErrorMessage(SQL_HANDLE_DBC, this->conn);
 
   // Remove DSN
   ASSERT_TRUE(UnregisterDsn(wdsn));
 
   // Disconnect from ODBC
-  ASSERT_EQ(SQL_SUCCESS, SQLDisconnect(conn))
-      << GetOdbcErrorMessage(SQL_HANDLE_DBC, conn);
+  ASSERT_EQ(SQL_SUCCESS, SQLDisconnect(this->conn))
+      << GetOdbcErrorMessage(SQL_HANDLE_DBC, this->conn);
 }
 
 TEST_F(ConnectionRemoteTest, TestSQLDriverConnectInvalidUid) {
@@ -442,11 +444,11 @@ TEST_F(ConnectionRemoteTest, TestSQLDriverConnectInvalidUid) {
 
   // Connecting to ODBC server.
   ASSERT_EQ(SQL_ERROR,
-            SQLDriverConnect(conn, NULL, &connect_str0[0],
+            SQLDriverConnect(this->conn, NULL, &connect_str0[0],
                              static_cast<SQLSMALLINT>(connect_str0.size()), out_str,
                              kOdbcBufferSize, &out_str_len, SQL_DRIVER_NOPROMPT));
 
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorState28000);
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorState28000);
 
   std::string out_connection_string = ODBC::SqlWcharToString(out_str, out_str_len);
   ASSERT_TRUE(out_connection_string.empty());
@@ -454,17 +456,17 @@ TEST_F(ConnectionRemoteTest, TestSQLDriverConnectInvalidUid) {
 
 TYPED_TEST(ConnectionHandleTest, TestSQLDisconnectWithoutConnection) {
   // Attempt to disconnect without a connection, expect to fail
-  ASSERT_EQ(SQL_ERROR, SQLDisconnect(conn));
+  ASSERT_EQ(SQL_ERROR, SQLDisconnect(this->conn));
 
   // Expect ODBC driver manager to return error state
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorState08003);
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorState08003);
 }
 
 TYPED_TEST(ConnectionTest, TestSQLAllocFreeStmt) {
   SQLHSTMT statement;
 
   // Allocate a statement using alloc statement
-  ASSERT_EQ(SQL_SUCCESS, SQLAllocStmt(conn, &statement));
+  ASSERT_EQ(SQL_SUCCESS, SQLAllocStmt(this->conn, &statement));
 
   // Close statement handle
   ASSERT_EQ(SQL_SUCCESS, SQLFreeStmt(statement, SQL_CLOSE));
@@ -487,23 +489,23 @@ TYPED_TEST(ConnectionHandleTest, TestCloseConnectionWithOpenStatement) {
 
   // Connecting to ODBC server.
   ASSERT_EQ(SQL_SUCCESS,
-            SQLDriverConnect(conn, NULL, &connect_str0[0],
+            SQLDriverConnect(this->conn, NULL, &connect_str0[0],
                              static_cast<SQLSMALLINT>(connect_str0.size()), out_str,
                              kOdbcBufferSize, &out_str_len, SQL_DRIVER_NOPROMPT))
-      << GetOdbcErrorMessage(SQL_HANDLE_DBC, conn);
+      << GetOdbcErrorMessage(SQL_HANDLE_DBC, this->conn);
 
   // Allocate a statement using alloc statement
-  ASSERT_EQ(SQL_SUCCESS, SQLAllocStmt(conn, &statement));
+  ASSERT_EQ(SQL_SUCCESS, SQLAllocStmt(this->conn, &statement));
 
   // Disconnect from ODBC without closing the statement first
-  ASSERT_EQ(SQL_SUCCESS, SQLDisconnect(conn));
+  ASSERT_EQ(SQL_SUCCESS, SQLDisconnect(this->conn));
 }
 
 TYPED_TEST(ConnectionTest, TestSQLAllocFreeDesc) {
   SQLHDESC descriptor;
 
   // Allocate a descriptor using alloc handle
-  ASSERT_EQ(SQL_SUCCESS, SQLAllocHandle(SQL_HANDLE_DESC, conn, &descriptor));
+  ASSERT_EQ(SQL_SUCCESS, SQLAllocHandle(SQL_HANDLE_DESC, this->conn, &descriptor));
 
   // Free descriptor handle
   ASSERT_EQ(SQL_SUCCESS, SQLFreeHandle(SQL_HANDLE_DESC, descriptor));
@@ -513,37 +515,37 @@ TYPED_TEST(ConnectionTest, TestSQLSetStmtAttrDescriptor) {
   SQLHDESC apd_descriptor, ard_descriptor;
 
   // Allocate an APD descriptor using alloc handle
-  ASSERT_EQ(SQL_SUCCESS, SQLAllocHandle(SQL_HANDLE_DESC, conn, &apd_descriptor));
+  ASSERT_EQ(SQL_SUCCESS, SQLAllocHandle(SQL_HANDLE_DESC, this->conn, &apd_descriptor));
 
   // Allocate an ARD descriptor using alloc handle
-  ASSERT_EQ(SQL_SUCCESS, SQLAllocHandle(SQL_HANDLE_DESC, conn, &ard_descriptor));
+  ASSERT_EQ(SQL_SUCCESS, SQLAllocHandle(SQL_HANDLE_DESC, this->conn, &ard_descriptor));
 
   // Save implicitly allocated internal APD and ARD descriptor pointers
   SQLPOINTER internal_apd, internal_ard = nullptr;
 
-  EXPECT_EQ(SQL_SUCCESS, SQLGetStmtAttr(stmt, SQL_ATTR_APP_PARAM_DESC, &internal_apd,
-                                        sizeof(internal_apd), 0));
+  EXPECT_EQ(SQL_SUCCESS, SQLGetStmtAttr(this->stmt, SQL_ATTR_APP_PARAM_DESC,
+                                        &internal_apd, sizeof(internal_apd), 0));
 
-  EXPECT_EQ(SQL_SUCCESS, SQLGetStmtAttr(stmt, SQL_ATTR_APP_ROW_DESC, &internal_ard,
+  EXPECT_EQ(SQL_SUCCESS, SQLGetStmtAttr(this->stmt, SQL_ATTR_APP_ROW_DESC, &internal_ard,
                                         sizeof(internal_ard), 0));
 
   // Set APD descriptor to explicitly allocated handle
-  EXPECT_EQ(SQL_SUCCESS, SQLSetStmtAttr(stmt, SQL_ATTR_APP_PARAM_DESC,
+  EXPECT_EQ(SQL_SUCCESS, SQLSetStmtAttr(this->stmt, SQL_ATTR_APP_PARAM_DESC,
                                         reinterpret_cast<SQLPOINTER>(apd_descriptor), 0));
 
   // Set ARD descriptor to explicitly allocated handle
-  EXPECT_EQ(SQL_SUCCESS, SQLSetStmtAttr(stmt, SQL_ATTR_APP_ROW_DESC,
+  EXPECT_EQ(SQL_SUCCESS, SQLSetStmtAttr(this->stmt, SQL_ATTR_APP_ROW_DESC,
                                         reinterpret_cast<SQLPOINTER>(ard_descriptor), 0));
 
   // Verify APD and ARD descriptors are set to explicitly allocated pointers
   SQLPOINTER value = nullptr;
-  EXPECT_EQ(SQL_SUCCESS,
-            SQLGetStmtAttr(stmt, SQL_ATTR_APP_PARAM_DESC, &value, sizeof(value), 0));
+  EXPECT_EQ(SQL_SUCCESS, SQLGetStmtAttr(this->stmt, SQL_ATTR_APP_PARAM_DESC, &value,
+                                        sizeof(value), 0));
 
   EXPECT_EQ(apd_descriptor, value);
 
   EXPECT_EQ(SQL_SUCCESS,
-            SQLGetStmtAttr(stmt, SQL_ATTR_APP_ROW_DESC, &value, sizeof(value), 0));
+            SQLGetStmtAttr(this->stmt, SQL_ATTR_APP_ROW_DESC, &value, sizeof(value), 0));
 
   EXPECT_EQ(ard_descriptor, value);
 
@@ -555,13 +557,13 @@ TYPED_TEST(ConnectionTest, TestSQLSetStmtAttrDescriptor) {
   // Verify APD and ARD descriptors has been reverted to implicit descriptors
   value = nullptr;
 
-  EXPECT_EQ(SQL_SUCCESS,
-            SQLGetStmtAttr(stmt, SQL_ATTR_APP_PARAM_DESC, &value, sizeof(value), 0));
+  EXPECT_EQ(SQL_SUCCESS, SQLGetStmtAttr(this->stmt, SQL_ATTR_APP_PARAM_DESC, &value,
+                                        sizeof(value), 0));
 
   EXPECT_EQ(internal_apd, value);
 
   EXPECT_EQ(SQL_SUCCESS,
-            SQLGetStmtAttr(stmt, SQL_ATTR_APP_ROW_DESC, &value, sizeof(value), 0));
+            SQLGetStmtAttr(this->stmt, SQL_ATTR_APP_ROW_DESC, &value, sizeof(value), 0));
 
   EXPECT_EQ(internal_ard, value);
 }

--- a/cpp/src/arrow/flight/sql/odbc/tests/errors_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/errors_test.cc
@@ -62,7 +62,7 @@ TYPED_TEST(ErrorsHandleTest, TestSQLGetDiagFieldWForConnectFailure) {
 
   // Connecting to ODBC server.
   ASSERT_EQ(SQL_ERROR,
-            SQLDriverConnect(conn, NULL, &connect_str0[0],
+            SQLDriverConnect(this->conn, NULL, &connect_str0[0],
                              static_cast<SQLSMALLINT>(connect_str0.size()), out_str,
                              kOdbcBufferSize, &out_str_len, SQL_DRIVER_NOPROMPT));
 
@@ -75,7 +75,7 @@ TYPED_TEST(ErrorsHandleTest, TestSQLGetDiagFieldWForConnectFailure) {
   SQLSMALLINT diag_number_length;
 
   EXPECT_EQ(SQL_SUCCESS,
-            SQLGetDiagField(SQL_HANDLE_DBC, conn, HEADER_LEVEL, SQL_DIAG_NUMBER,
+            SQLGetDiagField(SQL_HANDLE_DBC, this->conn, HEADER_LEVEL, SQL_DIAG_NUMBER,
                             &diag_number, sizeof(SQLINTEGER), &diag_number_length));
 
   EXPECT_EQ(1, diag_number);
@@ -85,15 +85,16 @@ TYPED_TEST(ErrorsHandleTest, TestSQLGetDiagFieldWForConnectFailure) {
   SQLSMALLINT server_name_length;
 
   EXPECT_EQ(SQL_SUCCESS,
-            SQLGetDiagField(SQL_HANDLE_DBC, conn, RECORD_1, SQL_DIAG_SERVER_NAME,
+            SQLGetDiagField(SQL_HANDLE_DBC, this->conn, RECORD_1, SQL_DIAG_SERVER_NAME,
                             server_name, kOdbcBufferSize, &server_name_length));
 
   // SQL_DIAG_MESSAGE_TEXT
   SQLWCHAR message_text[kOdbcBufferSize];
   SQLSMALLINT message_text_length;
 
-  SQLRETURN ret = SQLGetDiagField(SQL_HANDLE_DBC, conn, RECORD_1, SQL_DIAG_MESSAGE_TEXT,
-                                  message_text, kOdbcBufferSize, &message_text_length);
+  SQLRETURN ret =
+      SQLGetDiagField(SQL_HANDLE_DBC, this->conn, RECORD_1, SQL_DIAG_MESSAGE_TEXT,
+                      message_text, kOdbcBufferSize, &message_text_length);
 
   // dependent on the size of the message it could output SQL_SUCCESS_WITH_INFO
   EXPECT_TRUE(ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO);
@@ -105,8 +106,8 @@ TYPED_TEST(ErrorsHandleTest, TestSQLGetDiagFieldWForConnectFailure) {
   SQLSMALLINT diag_native_length;
 
   EXPECT_EQ(SQL_SUCCESS,
-            SQLGetDiagField(SQL_HANDLE_DBC, conn, RECORD_1, SQL_DIAG_NATIVE, &diag_native,
-                            sizeof(diag_native), &diag_native_length));
+            SQLGetDiagField(SQL_HANDLE_DBC, this->conn, RECORD_1, SQL_DIAG_NATIVE,
+                            &diag_native, sizeof(diag_native), &diag_native_length));
 
   EXPECT_EQ(200, diag_native);
 
@@ -115,9 +116,10 @@ TYPED_TEST(ErrorsHandleTest, TestSQLGetDiagFieldWForConnectFailure) {
   SQLWCHAR sql_state[sql_state_size];
   SQLSMALLINT sql_state_length;
 
-  EXPECT_EQ(SQL_SUCCESS,
-            SQLGetDiagField(SQL_HANDLE_DBC, conn, RECORD_1, SQL_DIAG_SQLSTATE, sql_state,
-                            sql_state_size * GetSqlWCharSize(), &sql_state_length));
+  EXPECT_EQ(
+      SQL_SUCCESS,
+      SQLGetDiagField(SQL_HANDLE_DBC, this->conn, RECORD_1, SQL_DIAG_SQLSTATE, sql_state,
+                      sql_state_size * GetSqlWCharSize(), &sql_state_length));
 
   EXPECT_EQ(kErrorState28000, SqlWcharToString(sql_state));
 }
@@ -138,7 +140,7 @@ TYPED_TEST(ErrorsHandleTest, DISABLED_TestSQLGetDiagFieldWForConnectFailureNTS) 
 
   // Connecting to ODBC server.
   ASSERT_EQ(SQL_ERROR,
-            SQLDriverConnect(conn, NULL, &connect_str0[0],
+            SQLDriverConnect(this->conn, NULL, &connect_str0[0],
                              static_cast<SQLSMALLINT>(connect_str0.size()), out_str,
                              kOdbcBufferSize, &out_str_len, SQL_DRIVER_NOPROMPT));
 
@@ -152,7 +154,7 @@ TYPED_TEST(ErrorsHandleTest, DISABLED_TestSQLGetDiagFieldWForConnectFailureNTS) 
   message_text[kOdbcBufferSize - 1] = '\0';
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetDiagField(SQL_HANDLE_DBC, conn, RECORD_1, SQL_DIAG_MESSAGE_TEXT,
+            SQLGetDiagField(SQL_HANDLE_DBC, this->conn, RECORD_1, SQL_DIAG_MESSAGE_TEXT,
                             message_text, SQL_NTS, &message_text_length));
 
   EXPECT_GT(message_text_length, 100);
@@ -164,7 +166,7 @@ TYPED_TEST(ErrorsTest, TestSQLGetDiagFieldWForDescriptorFailureFromDriverManager
   SQLHDESC descriptor;
 
   // Allocate a descriptor using alloc handle
-  ASSERT_EQ(SQL_SUCCESS, SQLAllocHandle(SQL_HANDLE_DESC, conn, &descriptor));
+  ASSERT_EQ(SQL_SUCCESS, SQLAllocHandle(SQL_HANDLE_DESC, this->conn, &descriptor));
 
   EXPECT_EQ(SQL_ERROR, SQLGetDescField(descriptor, 1, SQL_DESC_DATETIME_INTERVAL_CODE, 0,
                                        0, nullptr));
@@ -230,7 +232,7 @@ TYPED_TEST(ErrorsTest, TestSQLGetDiagRecForDescriptorFailureFromDriverManager) {
   SQLHDESC descriptor;
 
   // Allocate a descriptor using alloc handle
-  ASSERT_EQ(SQL_SUCCESS, SQLAllocHandle(SQL_HANDLE_DESC, conn, &descriptor));
+  ASSERT_EQ(SQL_SUCCESS, SQLAllocHandle(SQL_HANDLE_DESC, this->conn, &descriptor));
 
   EXPECT_EQ(SQL_ERROR, SQLGetDescField(descriptor, 1, SQL_DESC_DATETIME_INTERVAL_CODE, 0,
                                        0, nullptr));
@@ -271,7 +273,7 @@ TYPED_TEST(ErrorsHandleTest, TestSQLGetDiagRecForConnectFailure) {
 
   // Connecting to ODBC server.
   ASSERT_EQ(SQL_ERROR,
-            SQLDriverConnect(conn, NULL, &connect_str0[0],
+            SQLDriverConnect(this->conn, NULL, &connect_str0[0],
                              static_cast<SQLSMALLINT>(connect_str0.size()), out_str,
                              kOdbcBufferSize, &out_str_len, SQL_DRIVER_NOPROMPT));
 
@@ -279,8 +281,9 @@ TYPED_TEST(ErrorsHandleTest, TestSQLGetDiagRecForConnectFailure) {
   SQLINTEGER native_error;
   SQLWCHAR message[kOdbcBufferSize];
   SQLSMALLINT message_length;
-  ASSERT_EQ(SQL_SUCCESS, SQLGetDiagRec(SQL_HANDLE_DBC, conn, 1, sql_state, &native_error,
-                                       message, kOdbcBufferSize, &message_length));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetDiagRec(SQL_HANDLE_DBC, this->conn, 1, sql_state, &native_error,
+                          message, kOdbcBufferSize, &message_length));
 
   EXPECT_GT(message_length, 120);
 
@@ -300,18 +303,19 @@ TYPED_TEST(ErrorsTest, TestSQLGetDiagRecInputData) {
   SQLSMALLINT message_length;
 
   // Pass invalid record number
-  EXPECT_EQ(SQL_ERROR, SQLGetDiagRec(SQL_HANDLE_DBC, conn, 0, sql_state, &native_error,
-                                     message, kOdbcBufferSize, &message_length));
+  EXPECT_EQ(SQL_ERROR,
+            SQLGetDiagRec(SQL_HANDLE_DBC, this->conn, 0, sql_state, &native_error,
+                          message, kOdbcBufferSize, &message_length));
 
   // Pass valid record number with null inputs
-  EXPECT_EQ(SQL_NO_DATA, SQLGetDiagRec(SQL_HANDLE_DBC, conn, 1, nullptr, nullptr, nullptr,
-                                       0, nullptr));
+  EXPECT_EQ(SQL_NO_DATA, SQLGetDiagRec(SQL_HANDLE_DBC, this->conn, 1, nullptr, nullptr,
+                                       nullptr, 0, nullptr));
 
   // Invalid handle
 #ifdef __APPLE__
   // MacOS ODBC driver manager requires connection handle
   EXPECT_EQ(SQL_INVALID_HANDLE,
-            SQLGetDiagRec(0, conn, 1, nullptr, nullptr, nullptr, 0, nullptr));
+            SQLGetDiagRec(0, this->conn, 1, nullptr, nullptr, nullptr, 0, nullptr));
 #else
   EXPECT_EQ(SQL_INVALID_HANDLE,
             SQLGetDiagRec(0, nullptr, 0, nullptr, nullptr, nullptr, 0, nullptr));
@@ -324,17 +328,17 @@ TYPED_TEST(ErrorsOdbcV2Test, TestSQLErrorInputData) {
 
   // Pass valid handles with null inputs
   EXPECT_EQ(SQL_NO_DATA,
-            SQLError(env, nullptr, nullptr, nullptr, nullptr, nullptr, 0, nullptr));
+            SQLError(this->env, nullptr, nullptr, nullptr, nullptr, nullptr, 0, nullptr));
 
-  EXPECT_EQ(SQL_NO_DATA,
-            SQLError(nullptr, conn, nullptr, nullptr, nullptr, nullptr, 0, nullptr));
+  EXPECT_EQ(SQL_NO_DATA, SQLError(nullptr, this->conn, nullptr, nullptr, nullptr, nullptr,
+                                  0, nullptr));
 
 #ifdef __APPLE__
-  EXPECT_EQ(SQL_NO_DATA,
-            SQLError(SQL_NULL_HENV, conn, stmt, nullptr, nullptr, nullptr, 0, nullptr));
+  EXPECT_EQ(SQL_NO_DATA, SQLError(SQL_NULL_HENV, this->conn, this->stmt, nullptr, nullptr,
+                                  nullptr, 0, nullptr));
 #else
-  EXPECT_EQ(SQL_NO_DATA,
-            SQLError(nullptr, nullptr, stmt, nullptr, nullptr, nullptr, 0, nullptr));
+  EXPECT_EQ(SQL_NO_DATA, SQLError(nullptr, nullptr, this->stmt, nullptr, nullptr, nullptr,
+                                  0, nullptr));
 #endif  // __APPLE__
 
   // Invalid handle
@@ -349,14 +353,14 @@ TYPED_TEST(ErrorsTest, TestSQLErrorEnvErrorFromDriverManager) {
   // DM passes 512 as buffer length to SQLError.
 
   // Attempt to set environment attribute after connection handle allocation
-  ASSERT_EQ(SQL_ERROR, SQLSetEnvAttr(env, SQL_ATTR_ODBC_VERSION,
+  ASSERT_EQ(SQL_ERROR, SQLSetEnvAttr(this->env, SQL_ATTR_ODBC_VERSION,
                                      reinterpret_cast<void*>(SQL_OV_ODBC2), 0));
 
   SQLWCHAR sql_state[6] = {0};
   SQLINTEGER native_error = 0;
   SQLWCHAR message[SQL_MAX_MESSAGE_LENGTH] = {0};
   SQLSMALLINT message_length = 0;
-  ASSERT_EQ(SQL_SUCCESS, SQLError(env, nullptr, nullptr, sql_state, &native_error,
+  ASSERT_EQ(SQL_SUCCESS, SQLError(this->env, nullptr, nullptr, sql_state, &native_error,
                                   message, SQL_MAX_MESSAGE_LENGTH, &message_length));
 
   EXPECT_GT(message_length, 40);
@@ -376,13 +380,14 @@ TYPED_TEST(ErrorsTest, TestSQLErrorConnError) {
   // DM passes 512 as buffer length to SQLError.
 
   // Attempt to set unsupported attribute
-  ASSERT_EQ(SQL_ERROR, SQLGetConnectAttr(conn, SQL_ATTR_TXN_ISOLATION, 0, 0, nullptr));
+  ASSERT_EQ(SQL_ERROR,
+            SQLGetConnectAttr(this->conn, SQL_ATTR_TXN_ISOLATION, 0, 0, nullptr));
 
   SQLWCHAR sql_state[6] = {0};
   SQLINTEGER native_error = 0;
   SQLWCHAR message[SQL_MAX_MESSAGE_LENGTH] = {0};
   SQLSMALLINT message_length = 0;
-  ASSERT_EQ(SQL_SUCCESS, SQLError(nullptr, conn, nullptr, sql_state, &native_error,
+  ASSERT_EQ(SQL_SUCCESS, SQLError(nullptr, this->conn, nullptr, sql_state, &native_error,
                                   message, SQL_MAX_MESSAGE_LENGTH, &message_length));
 
   EXPECT_GT(message_length, 60);
@@ -404,14 +409,14 @@ TYPED_TEST(ErrorsTest, TestSQLErrorStmtError) {
   SQLWCHAR wsql[] = L"1";
   SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_ERROR, SQLExecDirect(stmt, wsql, wsql_len));
+  ASSERT_EQ(SQL_ERROR, SQLExecDirect(this->stmt, wsql, wsql_len));
 
   SQLWCHAR sql_state[6] = {0};
   SQLINTEGER native_error = 0;
   SQLWCHAR message[SQL_MAX_MESSAGE_LENGTH] = {0};
   SQLSMALLINT message_length = 0;
-  SQLRETURN ret = SQLError(nullptr, conn, stmt, sql_state, &native_error, message,
-                           SQL_MAX_MESSAGE_LENGTH, &message_length);
+  SQLRETURN ret = SQLError(nullptr, this->conn, this->stmt, sql_state, &native_error,
+                           message, SQL_MAX_MESSAGE_LENGTH, &message_length);
 
   EXPECT_TRUE(ret == SQL_SUCCESS || ret == SQL_SUCCESS_WITH_INFO);
 
@@ -430,9 +435,9 @@ TYPED_TEST(ErrorsTest, TestSQLErrorStmtWarning) {
   SQLWCHAR wsql[] = L"SELECT 'VERY LONG STRING here' AS string_col;";
   SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
   const int len = 17;
   SQLCHAR char_val[len];
@@ -440,14 +445,15 @@ TYPED_TEST(ErrorsTest, TestSQLErrorStmtWarning) {
   SQLLEN ind;
 
   EXPECT_EQ(SQL_SUCCESS_WITH_INFO,
-            SQLGetData(stmt, 1, SQL_C_CHAR, &char_val, buf_len, &ind));
+            SQLGetData(this->stmt, 1, SQL_C_CHAR, &char_val, buf_len, &ind));
 
   SQLWCHAR sql_state[6] = {0};
   SQLINTEGER native_error = 0;
   SQLWCHAR message[SQL_MAX_MESSAGE_LENGTH] = {0};
   SQLSMALLINT message_length = 0;
-  ASSERT_EQ(SQL_SUCCESS, SQLError(SQL_NULL_HENV, conn, stmt, sql_state, &native_error,
-                                  message, SQL_MAX_MESSAGE_LENGTH, &message_length));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLError(SQL_NULL_HENV, this->conn, this->stmt, sql_state, &native_error,
+                     message, SQL_MAX_MESSAGE_LENGTH, &message_length));
 
   EXPECT_GT(message_length, 50);
 
@@ -466,14 +472,14 @@ TYPED_TEST(ErrorsOdbcV2Test, TestSQLErrorEnvErrorFromDriverManager) {
   // DM passes 512 as buffer length to SQLError.
 
   // Attempt to set environment attribute after connection handle allocation
-  ASSERT_EQ(SQL_ERROR, SQLSetEnvAttr(env, SQL_ATTR_ODBC_VERSION,
+  ASSERT_EQ(SQL_ERROR, SQLSetEnvAttr(this->env, SQL_ATTR_ODBC_VERSION,
                                      reinterpret_cast<void*>(SQL_OV_ODBC2), 0));
 
   SQLWCHAR sql_state[6] = {0};
   SQLINTEGER native_error = 0;
   SQLWCHAR message[SQL_MAX_MESSAGE_LENGTH] = {0};
   SQLSMALLINT message_length = 0;
-  ASSERT_EQ(SQL_SUCCESS, SQLError(env, nullptr, nullptr, sql_state, &native_error,
+  ASSERT_EQ(SQL_SUCCESS, SQLError(this->env, nullptr, nullptr, sql_state, &native_error,
                                   message, SQL_MAX_MESSAGE_LENGTH, &message_length));
 
   EXPECT_GT(message_length, 40);
@@ -505,13 +511,14 @@ TYPED_TEST(ErrorsOdbcV2Test, TestSQLErrorConnError) {
   // macOS Excel.
 
   // Attempt to set unsupported attribute
-  ASSERT_EQ(SQL_ERROR, SQLGetConnectAttr(conn, SQL_ATTR_TXN_ISOLATION, 0, 0, nullptr));
+  ASSERT_EQ(SQL_ERROR,
+            SQLGetConnectAttr(this->conn, SQL_ATTR_TXN_ISOLATION, 0, 0, nullptr));
 
   SQLWCHAR sql_state[6] = {0};
   SQLINTEGER native_error = 0;
   SQLWCHAR message[SQL_MAX_MESSAGE_LENGTH] = {0};
   SQLSMALLINT message_length = 0;
-  ASSERT_EQ(SQL_SUCCESS, SQLError(nullptr, conn, nullptr, sql_state, &native_error,
+  ASSERT_EQ(SQL_SUCCESS, SQLError(nullptr, this->conn, nullptr, sql_state, &native_error,
                                   message, SQL_MAX_MESSAGE_LENGTH, &message_length));
 
   EXPECT_GT(message_length, 60);
@@ -534,14 +541,15 @@ TYPED_TEST(ErrorsOdbcV2Test, TestSQLErrorStmtError) {
   SQLWCHAR wsql[] = L"SELECT * from non_existent_table;";
   SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_ERROR, SQLExecDirect(stmt, wsql, wsql_len));
+  ASSERT_EQ(SQL_ERROR, SQLExecDirect(this->stmt, wsql, wsql_len));
 
   SQLWCHAR sql_state[6] = {0};
   SQLINTEGER native_error = 0;
   SQLSMALLINT message_length = 0;
   SQLWCHAR message[SQL_MAX_MESSAGE_LENGTH] = {0};
-  ASSERT_EQ(SQL_SUCCESS, SQLError(SQL_NULL_HENV, conn, stmt, sql_state, &native_error,
-                                  message, SQL_MAX_MESSAGE_LENGTH, &message_length));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLError(SQL_NULL_HENV, this->conn, this->stmt, sql_state, &native_error,
+                     message, SQL_MAX_MESSAGE_LENGTH, &message_length));
   EXPECT_GT(message_length, 70);
 
   EXPECT_EQ(100, native_error);
@@ -558,9 +566,9 @@ TYPED_TEST(ErrorsOdbcV2Test, TestSQLErrorStmtWarning) {
   SQLWCHAR wsql[] = L"SELECT 'VERY LONG STRING here' AS string_col;";
   SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
   const int len = 17;
   SQLCHAR char_val[len];
@@ -568,14 +576,15 @@ TYPED_TEST(ErrorsOdbcV2Test, TestSQLErrorStmtWarning) {
   SQLLEN ind;
 
   EXPECT_EQ(SQL_SUCCESS_WITH_INFO,
-            SQLGetData(stmt, 1, SQL_C_CHAR, &char_val, buf_len, &ind));
+            SQLGetData(this->stmt, 1, SQL_C_CHAR, &char_val, buf_len, &ind));
 
   SQLWCHAR sql_state[6] = {0};
   SQLINTEGER native_error = 0;
   SQLWCHAR message[SQL_MAX_MESSAGE_LENGTH] = {0};
   SQLSMALLINT message_length = 0;
-  ASSERT_EQ(SQL_SUCCESS, SQLError(SQL_NULL_HENV, conn, stmt, sql_state, &native_error,
-                                  message, SQL_MAX_MESSAGE_LENGTH, &message_length));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLError(SQL_NULL_HENV, this->conn, this->stmt, sql_state, &native_error,
+                     message, SQL_MAX_MESSAGE_LENGTH, &message_length));
 
   EXPECT_GT(message_length, 50);
 

--- a/cpp/src/arrow/flight/sql/odbc/tests/get_functions_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/get_functions_test.cc
@@ -77,7 +77,8 @@ TYPED_TEST(GetFunctionsTest, TestSQLGetFunctionsAllFunctions) {
       SQL_API_SQLDESCRIBEPARAM,  SQL_API_SQLPROCEDURES,       SQL_API_SQLSETPOS,
       SQL_API_SQLTABLEPRIVILEGES};
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetFunctions(conn, SQL_API_ODBC3_ALL_FUNCTIONS, api_exists));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetFunctions(this->conn, SQL_API_ODBC3_ALL_FUNCTIONS, api_exists));
 
   for (int api : supported_functions) {
     EXPECT_EQ(SQL_TRUE, SQL_FUNC_EXISTS(api_exists, api));
@@ -113,7 +114,7 @@ TYPED_TEST(GetFunctionsOdbcV2Test, TestSQLGetFunctionsAllFunctions) {
       SQL_API_SQLBULKOPERATIONS, SQL_API_SQLCOLUMNPRIVILEGES, SQL_API_SQLPROCEDURECOLUMNS,
       SQL_API_SQLDESCRIBEPARAM,  SQL_API_SQLPROCEDURES,       SQL_API_SQLSETPOS,
       SQL_API_SQLTABLEPRIVILEGES};
-  ASSERT_EQ(SQL_SUCCESS, SQLGetFunctions(conn, SQL_API_ALL_FUNCTIONS, api_exists));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetFunctions(this->conn, SQL_API_ALL_FUNCTIONS, api_exists));
 
   for (int api : supported_functions) {
     EXPECT_EQ(SQL_TRUE, api_exists[api]);
@@ -148,7 +149,7 @@ TYPED_TEST(GetFunctionsTest, TestSQLGetFunctionsSupportedSingleAPI) {
       SQL_API_SQLGETFUNCTIONS, SQL_API_SQLDRIVERS, SQL_API_SQLDATASOURCES};
   SQLUSMALLINT api_exists;
   for (SQLUSMALLINT api : supported_functions) {
-    ASSERT_EQ(SQL_SUCCESS, SQLGetFunctions(conn, api, &api_exists));
+    ASSERT_EQ(SQL_SUCCESS, SQLGetFunctions(this->conn, api, &api_exists));
 
     EXPECT_EQ(SQL_TRUE, api_exists);
 
@@ -168,7 +169,7 @@ TYPED_TEST(GetFunctionsTest, TestSQLGetFunctionsUnsupportedSingleAPI) {
       SQL_API_SQLTABLEPRIVILEGES};
   SQLUSMALLINT api_exists;
   for (SQLUSMALLINT api : unsupported_functions) {
-    ASSERT_EQ(SQL_SUCCESS, SQLGetFunctions(conn, api, &api_exists));
+    ASSERT_EQ(SQL_SUCCESS, SQLGetFunctions(this->conn, api, &api_exists));
 
     EXPECT_EQ(SQL_FALSE, api_exists);
 
@@ -192,7 +193,7 @@ TYPED_TEST(GetFunctionsOdbcV2Test, TestSQLGetFunctionsSupportedSingleAPI) {
       SQL_API_SQLGETFUNCTIONS, SQL_API_SQLDRIVERS, SQL_API_SQLDATASOURCES};
   SQLUSMALLINT api_exists;
   for (SQLUSMALLINT api : supported_functions) {
-    ASSERT_EQ(SQL_SUCCESS, SQLGetFunctions(conn, api, &api_exists));
+    ASSERT_EQ(SQL_SUCCESS, SQLGetFunctions(this->conn, api, &api_exists));
 
     EXPECT_EQ(SQL_TRUE, api_exists);
 
@@ -210,7 +211,7 @@ TYPED_TEST(GetFunctionsOdbcV2Test, TestSQLGetFunctionsUnsupportedSingleAPI) {
       SQL_API_SQLTABLEPRIVILEGES};
   SQLUSMALLINT api_exists;
   for (SQLUSMALLINT api : unsupported_functions) {
-    ASSERT_EQ(SQL_SUCCESS, SQLGetFunctions(conn, api, &api_exists));
+    ASSERT_EQ(SQL_SUCCESS, SQLGetFunctions(this->conn, api, &api_exists));
 
     EXPECT_EQ(SQL_FALSE, api_exists);
 

--- a/cpp/src/arrow/flight/sql/odbc/tests/odbc_test_suite.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/odbc_test_suite.cc
@@ -19,6 +19,7 @@
 // with windows.h
 #include "arrow/flight/sql/odbc/odbc_impl/flight_sql_connection.h"
 
+#include "arrow/compute/api.h"
 #include "arrow/flight/sql/odbc/tests/odbc_test_suite.h"
 
 // For DSN registration
@@ -81,6 +82,17 @@ class OdbcTestEnvironment : public ::testing::Environment {
     ODBCTestBase::Disconnect(mock_odbcv2_handles.env, mock_odbcv2_handles.conn);
   }
 };
+
+#ifdef _WIN32
+// A global test "environment", to ensure Arrow compute kernel functions are registered
+class ComputeKernelEnvironment : public ::testing::Environment {
+ public:
+  void SetUp() override { ASSERT_OK(arrow::compute::Initialize()); }
+};
+
+::testing::Environment* compute_kernel_env =
+    ::testing::AddGlobalTestEnvironment(new ComputeKernelEnvironment);
+#endif  // _WIN32
 
 ::testing::Environment* mock_server_env =
     ::testing::AddGlobalTestEnvironment(new MockServerEnvironment);

--- a/cpp/src/arrow/flight/sql/odbc/tests/odbc_test_suite.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/odbc_test_suite.cc
@@ -100,6 +100,10 @@ class ComputeKernelEnvironment : public ::testing::Environment {
 ::testing::Environment* odbc_test_env =
     ::testing::AddGlobalTestEnvironment(new OdbcTestEnvironment);
 
+SQLHENV ODBCTestBase::env = SQL_NULL_HENV;
+SQLHDBC ODBCTestBase::conn = SQL_NULL_HDBC;
+SQLHSTMT ODBCTestBase::stmt = SQL_NULL_HSTMT;
+
 void ODBCTestBase::AllocEnvConnHandles(SQLHENV& env_handle, SQLHDBC& conn_handle,
                                        SQLINTEGER odbc_ver) {
   // Allocate an environment handle
@@ -262,11 +266,7 @@ void FlightSQLOdbcEnvConnHandleRemoteTestBase::SetUpTestSuite() {
     return;
   }
 
-  AllocEnvConnHandles(remote_non_connection_handles.env,
-                      remote_non_connection_handles.conn);
-  env = remote_non_connection_handles.env;
-  conn = remote_non_connection_handles.conn;
-  stmt = remote_non_connection_handles.stmt;
+  AllocEnvConnHandles(env, conn);
 }
 
 void FlightSQLOdbcEnvConnHandleRemoteTestBase::TearDownTestSuite() {
@@ -274,8 +274,7 @@ void FlightSQLOdbcEnvConnHandleRemoteTestBase::TearDownTestSuite() {
     return;
   }
 
-  FreeEnvConnHandles(remote_non_connection_handles.env,
-                     remote_non_connection_handles.conn);
+  FreeEnvConnHandles(env, conn);
 }
 
 std::string FindTokenInCallHeaders(const CallHeaders& incoming_headers) {
@@ -458,14 +457,11 @@ void FlightSQLOdbcV2MockTestBase::SetUpTestSuite() {
 }
 
 void FlightSQLOdbcEnvConnHandleMockTestBase::SetUpTestSuite() {
-  AllocEnvConnHandles(mock_non_connection_handles.env, mock_non_connection_handles.conn);
-  env = mock_non_connection_handles.env;
-  conn = mock_non_connection_handles.conn;
-  stmt = mock_non_connection_handles.stmt;
+  AllocEnvConnHandles(env, conn);
 }
 
 void FlightSQLOdbcEnvConnHandleMockTestBase::TearDownTestSuite() {
-  FreeEnvConnHandles(mock_non_connection_handles.env, mock_non_connection_handles.conn);
+  FreeEnvConnHandles(env, conn);
 }
 
 bool CompareConnPropertyMap(Connection::ConnPropertyMap map1,

--- a/cpp/src/arrow/flight/sql/odbc/tests/odbc_test_suite.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/odbc_test_suite.cc
@@ -51,28 +51,64 @@ class MockServerEnvironment : public ::testing::Environment {
   }
 };
 
-::testing::Environment* mock_env =
+bool RunningRemoteTests() { return !remote_test_connect_str.empty(); }
+
+class OdbcTestEnvironment : public ::testing::Environment {
+ public:
+  void SetUp() override {
+    remote_test_connect_str = ODBCTestBase::GetConnectionString();
+    if (RunningRemoteTests()) {
+      ODBCTestBase::Connect(remote_test_connect_str, remote_odbcv3_handles.env,
+                            remote_odbcv3_handles.conn, SQL_OV_ODBC3);
+      ODBCTestBase::Connect(remote_test_connect_str, remote_odbcv2_handles.env,
+                            remote_odbcv2_handles.conn, SQL_OV_ODBC2);
+    }
+
+    std::string mock_test_connect_str = ODBCMockTestBase::GetConnectionString();
+    ODBCMockTestBase::Connect(mock_test_connect_str, mock_odbcv3_handles.env,
+                              mock_odbcv3_handles.conn, SQL_OV_ODBC3);
+    ODBCMockTestBase::Connect(mock_test_connect_str, mock_odbcv2_handles.env,
+                              mock_odbcv2_handles.conn, SQL_OV_ODBC2);
+  }
+
+  void TearDown() override {
+    if (RunningRemoteTests()) {
+      ODBCTestBase::Disconnect(remote_odbcv3_handles.env, remote_odbcv3_handles.conn);
+      ODBCTestBase::Disconnect(remote_odbcv2_handles.env, remote_odbcv2_handles.conn);
+    }
+
+    ODBCTestBase::Disconnect(mock_odbcv3_handles.env, mock_odbcv3_handles.conn);
+    ODBCTestBase::Disconnect(mock_odbcv2_handles.env, mock_odbcv2_handles.conn);
+  }
+};
+
+::testing::Environment* mock_server_env =
     ::testing::AddGlobalTestEnvironment(new MockServerEnvironment);
 
-void ODBCTestBase::AllocEnvConnHandles(SQLINTEGER odbc_ver) {
+::testing::Environment* odbc_test_env =
+    ::testing::AddGlobalTestEnvironment(new OdbcTestEnvironment);
+
+void ODBCTestBase::AllocEnvConnHandles(SQLHENV& env_handle, SQLHDBC& conn_handle,
+                                       SQLINTEGER odbc_ver) {
   // Allocate an environment handle
-  ASSERT_EQ(SQL_SUCCESS, SQLAllocEnv(&env));
+  ASSERT_EQ(SQL_SUCCESS, SQLAllocEnv(&env_handle));
 
   ASSERT_EQ(
       SQL_SUCCESS,
-      SQLSetEnvAttr(env, SQL_ATTR_ODBC_VERSION,
+      SQLSetEnvAttr(env_handle, SQL_ATTR_ODBC_VERSION,
                     reinterpret_cast<SQLPOINTER>(static_cast<intptr_t>(odbc_ver)), 0));
 
   // Allocate a connection using alloc handle
-  ASSERT_EQ(SQL_SUCCESS, SQLAllocHandle(SQL_HANDLE_DBC, env, &conn));
+  ASSERT_EQ(SQL_SUCCESS, SQLAllocHandle(SQL_HANDLE_DBC, env_handle, &conn_handle));
 }
 
-void ODBCTestBase::Connect(std::string connect_str, SQLINTEGER odbc_ver) {
-  ASSERT_NO_FATAL_FAILURE(AllocEnvConnHandles(odbc_ver));
-  ASSERT_NO_FATAL_FAILURE(ConnectWithString(connect_str));
+void ODBCTestBase::Connect(std::string connect_str, SQLHENV& env_handle,
+                           SQLHDBC& conn_handle, SQLINTEGER odbc_ver) {
+  ASSERT_NO_FATAL_FAILURE(AllocEnvConnHandles(env_handle, conn_handle, odbc_ver));
+  ASSERT_NO_FATAL_FAILURE(ConnectWithString(connect_str, conn_handle));
 }
 
-void ODBCTestBase::ConnectWithString(std::string connect_str) {
+void ODBCTestBase::ConnectWithString(std::string connect_str, SQLHDBC& conn_handle) {
   // Connect string
   std::vector<SQLWCHAR> connect_str0(connect_str.begin(), connect_str.end());
 
@@ -81,31 +117,39 @@ void ODBCTestBase::ConnectWithString(std::string connect_str) {
 
   // Connecting to ODBC server.
   ASSERT_EQ(SQL_SUCCESS,
-            SQLDriverConnect(conn, NULL, &connect_str0[0],
+            SQLDriverConnect(conn_handle, NULL, &connect_str0[0],
                              static_cast<SQLSMALLINT>(connect_str0.size()), out_str,
                              kOdbcBufferSize, &out_str_len, SQL_DRIVER_NOPROMPT))
-      << GetOdbcErrorMessage(SQL_HANDLE_DBC, conn);
+      << GetOdbcErrorMessage(SQL_HANDLE_DBC, conn_handle);
 }
 
-void ODBCTestBase::Disconnect() {
+void ODBCTestBase::Disconnect(SQLHENV& env_handle, SQLHDBC& conn_handle) {
   // Disconnect from ODBC
-  EXPECT_EQ(SQL_SUCCESS, SQLDisconnect(conn))
-      << GetOdbcErrorMessage(SQL_HANDLE_DBC, conn);
+  if (conn_handle != SQL_NULL_HDBC) {
+    EXPECT_EQ(SQL_SUCCESS, SQLDisconnect(conn_handle))
+        << GetOdbcErrorMessage(SQL_HANDLE_DBC, conn_handle);
+  }
 
-  FreeEnvConnHandles();
+  FreeEnvConnHandles(env_handle, conn_handle);
 }
 
-void ODBCTestBase::FreeEnvConnHandles() {
+void ODBCTestBase::FreeEnvConnHandles(SQLHENV& env_handle, SQLHDBC& conn_handle) {
   // Free connection handle
-  EXPECT_EQ(SQL_SUCCESS, SQLFreeHandle(SQL_HANDLE_DBC, conn));
+  if (conn_handle != SQL_NULL_HDBC) {
+    EXPECT_EQ(SQL_SUCCESS, SQLFreeHandle(SQL_HANDLE_DBC, conn_handle));
+    conn_handle = SQL_NULL_HDBC;
+  }
 
   // Free environment handle
-  EXPECT_EQ(SQL_SUCCESS, SQLFreeHandle(SQL_HANDLE_ENV, env));
+  if (env_handle != SQL_NULL_HENV) {
+    EXPECT_EQ(SQL_SUCCESS, SQLFreeHandle(SQL_HANDLE_ENV, env_handle));
+    env_handle = SQL_NULL_HENV;
+  }
 }
 
 std::string ODBCTestBase::GetConnectionString() {
   std::string connect_str =
-      arrow::internal::GetEnvVar(kTestConnectStr.data()).ValueOrDie();
+      arrow::internal::GetEnvVar(kTestConnectStr.data()).ValueOr("");
   return connect_str;
 }
 
@@ -168,68 +212,58 @@ std::wstring ODBCTestBase::GetQueryAllDataTypes() {
 }
 
 void ODBCTestBase::SetUp() {
-  if (connected) {
-    ASSERT_EQ(SQL_SUCCESS, SQLAllocHandle(SQL_HANDLE_STMT, conn, &stmt));
-  }
+  ASSERT_EQ(SQL_SUCCESS, SQLAllocHandle(SQL_HANDLE_STMT, conn, &stmt));
 }
 
 void ODBCTestBase::TearDown() {
-  if (connected) {
-    ASSERT_EQ(SQL_SUCCESS, SQLFreeHandle(SQL_HANDLE_STMT, stmt));
-  }
-}
-
-void ODBCTestBase::TearDownTestSuite() {
-  if (connected) {
-    Disconnect();
-    connected = false;
-  }
-}
-
-void FlightSQLODBCRemoteTestBase::CheckForRemoteTest() {
-  if (arrow::internal::GetEnvVar(kTestConnectStr.data()).ValueOr("").empty()) {
-    skipping_test = true;
-    GTEST_SKIP() << "Skipping test: kTestConnectStr not set";
-  }
+  ASSERT_EQ(SQL_SUCCESS, SQLFreeHandle(SQL_HANDLE_STMT, stmt));
 }
 
 void FlightSQLODBCRemoteTestBase::SetUpTestSuite() {
-  CheckForRemoteTest();
-  if (skipping_test) {
+  if (!RunningRemoteTests()) {
+    GTEST_SKIP() << "Skipping Test Suite: Environment Variable " << kTestConnectStr.data()
+                 << " is not set";
     return;
   }
 
-  std::string connect_str = GetConnectionString();
-  Connect(connect_str, SQL_OV_ODBC3);
-  connected = true;
+  env = remote_odbcv3_handles.env;
+  conn = remote_odbcv3_handles.conn;
+  stmt = remote_odbcv3_handles.stmt;
 }
 
 void FlightSQLOdbcV2RemoteTestBase::SetUpTestSuite() {
-  CheckForRemoteTest();
-  if (skipping_test) {
+  if (!RunningRemoteTests()) {
+    GTEST_SKIP() << "Skipping Test Suite: Environment Variable " << kTestConnectStr.data()
+                 << " is not set";
     return;
   }
 
-  std::string connect_str = GetConnectionString();
-  Connect(connect_str, SQL_OV_ODBC2);
-  connected = true;
+  env = remote_odbcv2_handles.env;
+  conn = remote_odbcv2_handles.conn;
+  stmt = remote_odbcv2_handles.stmt;
 }
 
 void FlightSQLOdbcEnvConnHandleRemoteTestBase::SetUpTestSuite() {
-  CheckForRemoteTest();
-  if (skipping_test) {
+  if (!RunningRemoteTests()) {
+    GTEST_SKIP() << "Skipping Test Suite: Environment Variable " << kTestConnectStr.data()
+                 << " is not set";
     return;
   }
 
-  AllocEnvConnHandles();
+  AllocEnvConnHandles(remote_non_connection_handles.env,
+                      remote_non_connection_handles.conn);
+  env = remote_non_connection_handles.env;
+  conn = remote_non_connection_handles.conn;
+  stmt = remote_non_connection_handles.stmt;
 }
 
 void FlightSQLOdbcEnvConnHandleRemoteTestBase::TearDownTestSuite() {
-  if (skipping_test) {
+  if (!RunningRemoteTests()) {
     return;
   }
 
-  FreeEnvConnHandles();
+  FreeEnvConnHandles(remote_non_connection_handles.env,
+                     remote_non_connection_handles.conn);
 }
 
 std::string FindTokenInCallHeaders(const CallHeaders& incoming_headers) {
@@ -400,20 +434,27 @@ void ODBCMockTestBase::DropUnicodeTable() {
 }
 
 void FlightSQLODBCMockTestBase::SetUpTestSuite() {
-  std::string connect_str = GetConnectionString();
-  Connect(connect_str, SQL_OV_ODBC3);
-  connected = true;
+  env = mock_odbcv3_handles.env;
+  conn = mock_odbcv3_handles.conn;
+  stmt = mock_odbcv3_handles.stmt;
 }
 
 void FlightSQLOdbcV2MockTestBase::SetUpTestSuite() {
-  std::string connect_str = GetConnectionString();
-  Connect(connect_str, SQL_OV_ODBC2);
-  connected = true;
+  env = mock_odbcv2_handles.env;
+  conn = mock_odbcv2_handles.conn;
+  stmt = mock_odbcv2_handles.stmt;
 }
 
-void FlightSQLOdbcEnvConnHandleMockTestBase::SetUpTestSuite() { AllocEnvConnHandles(); }
+void FlightSQLOdbcEnvConnHandleMockTestBase::SetUpTestSuite() {
+  AllocEnvConnHandles(mock_non_connection_handles.env, mock_non_connection_handles.conn);
+  env = mock_non_connection_handles.env;
+  conn = mock_non_connection_handles.conn;
+  stmt = mock_non_connection_handles.stmt;
+}
 
-void FlightSQLOdbcEnvConnHandleMockTestBase::TearDownTestSuite() { FreeEnvConnHandles(); }
+void FlightSQLOdbcEnvConnHandleMockTestBase::TearDownTestSuite() {
+  FreeEnvConnHandles(mock_non_connection_handles.env, mock_non_connection_handles.conn);
+}
 
 bool CompareConnPropertyMap(Connection::ConnPropertyMap map1,
                             Connection::ConnPropertyMap map2) {

--- a/cpp/src/arrow/flight/sql/odbc/tests/odbc_test_suite.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/odbc_test_suite.cc
@@ -244,7 +244,7 @@ void FlightSQLODBCRemoteTestBase::SetUpTestSuite() {
 
   env = remote_odbcv3_handles.env;
   conn = remote_odbcv3_handles.conn;
-  stmt = remote_odbcv3_handles.stmt;
+  stmt = SQL_NULL_HSTMT;
 }
 
 void FlightSQLOdbcV2RemoteTestBase::SetUpTestSuite() {
@@ -256,7 +256,7 @@ void FlightSQLOdbcV2RemoteTestBase::SetUpTestSuite() {
 
   env = remote_odbcv2_handles.env;
   conn = remote_odbcv2_handles.conn;
-  stmt = remote_odbcv2_handles.stmt;
+  stmt = SQL_NULL_HSTMT;
 }
 
 void FlightSQLOdbcEnvConnHandleRemoteTestBase::SetUpTestSuite() {
@@ -447,13 +447,13 @@ void ODBCMockTestBase::DropUnicodeTable() {
 void FlightSQLODBCMockTestBase::SetUpTestSuite() {
   env = mock_odbcv3_handles.env;
   conn = mock_odbcv3_handles.conn;
-  stmt = mock_odbcv3_handles.stmt;
+  stmt = SQL_NULL_HSTMT;
 }
 
 void FlightSQLOdbcV2MockTestBase::SetUpTestSuite() {
   env = mock_odbcv2_handles.env;
   conn = mock_odbcv2_handles.conn;
-  stmt = mock_odbcv2_handles.stmt;
+  stmt = SQL_NULL_HSTMT;
 }
 
 void FlightSQLOdbcEnvConnHandleMockTestBase::SetUpTestSuite() {

--- a/cpp/src/arrow/flight/sql/odbc/tests/odbc_test_suite.h
+++ b/cpp/src/arrow/flight/sql/odbc/tests/odbc_test_suite.h
@@ -56,7 +56,7 @@ inline OdbcHandles mock_odbcv3_handles;
 inline OdbcHandles mock_odbcv2_handles;
 inline OdbcHandles mock_non_connection_handles;
 
-// These handles are meant to point to to the relevant handle above
+// These handles are meant to point to the relevant handle above
 // depending on the test fixture.
 inline SQLHENV env = SQL_NULL_HENV;
 inline SQLHDBC conn = SQL_NULL_HDBC;

--- a/cpp/src/arrow/flight/sql/odbc/tests/odbc_test_suite.h
+++ b/cpp/src/arrow/flight/sql/odbc/tests/odbc_test_suite.h
@@ -51,16 +51,8 @@ struct OdbcHandles {
 
 inline OdbcHandles remote_odbcv3_handles;
 inline OdbcHandles remote_odbcv2_handles;
-inline OdbcHandles remote_non_connection_handles;
 inline OdbcHandles mock_odbcv3_handles;
 inline OdbcHandles mock_odbcv2_handles;
-inline OdbcHandles mock_non_connection_handles;
-
-// These handles are meant to point to the relevant handle above
-// depending on the test fixture.
-inline SQLHENV env = SQL_NULL_HENV;
-inline SQLHDBC conn = SQL_NULL_HDBC;
-inline SQLHSTMT stmt = SQL_NULL_HSTMT;
 
 inline std::shared_ptr<arrow::flight::sql::example::SQLiteFlightSqlServer> mock_server;
 inline int mock_server_port = 0;
@@ -99,6 +91,10 @@ class ODBCTestBase : public ::testing::Test {
  protected:
   void SetUp() override;
   void TearDown() override;
+
+  static SQLHENV env;
+  static SQLHDBC conn;
+  static SQLHSTMT stmt;
 };
 
 /// \brief Base test fixture for running tests against a remote server.

--- a/cpp/src/arrow/flight/sql/odbc/tests/odbc_test_suite.h
+++ b/cpp/src/arrow/flight/sql/odbc/tests/odbc_test_suite.h
@@ -41,12 +41,26 @@
 static constexpr std::string_view kTestConnectStr = "ARROW_FLIGHT_SQL_ODBC_CONN";
 static constexpr std::string_view kTestDsn = "Apache Arrow Flight SQL Test DSN";
 
-inline SQLHENV env = 0;
-inline SQLHDBC conn = 0;
-inline SQLHSTMT stmt = 0;
+inline std::string remote_test_connect_str = "";
 
-inline bool skipping_test = false;
-inline bool connected = false;
+struct OdbcHandles {
+  SQLHENV env = SQL_NULL_HENV;
+  SQLHDBC conn = SQL_NULL_HDBC;
+  SQLHSTMT stmt = SQL_NULL_HSTMT;
+};
+
+inline OdbcHandles remote_odbcv3_handles;
+inline OdbcHandles remote_odbcv2_handles;
+inline OdbcHandles remote_non_connection_handles;
+inline OdbcHandles mock_odbcv3_handles;
+inline OdbcHandles mock_odbcv2_handles;
+inline OdbcHandles mock_non_connection_handles;
+
+// These handles are meant to point to to the relevant handle above
+// depending on the test fixture.
+inline SQLHENV env = SQL_NULL_HENV;
+inline SQLHDBC conn = SQL_NULL_HDBC;
+inline SQLHSTMT stmt = SQL_NULL_HSTMT;
 
 inline std::shared_ptr<arrow::flight::sql::example::SQLiteFlightSqlServer> mock_server;
 inline int mock_server_port = 0;
@@ -61,17 +75,19 @@ namespace arrow::flight::sql::odbc {
 class ODBCTestBase : public ::testing::Test {
  public:
   /// \brief Allocate environment and connection handles
-  static void AllocEnvConnHandles(SQLINTEGER odbc_ver = SQL_OV_ODBC3);
+  static void AllocEnvConnHandles(SQLHENV& env_handle, SQLHDBC& conn_handle,
+                                  SQLINTEGER odbc_ver = SQL_OV_ODBC3);
   /// \brief Free environment and connection handles
-  static void FreeEnvConnHandles();
+  static void FreeEnvConnHandles(SQLHENV& env_handle, SQLHDBC& conn_handle);
   /// \brief Connect to Arrow Flight SQL server using connection string defined in
   /// environment variable "ARROW_FLIGHT_SQL_ODBC_CONN", allocate statement handle.
   /// Connects using ODBC Ver 3 by default
-  static void Connect(std::string connect_str, SQLINTEGER odbc_ver = SQL_OV_ODBC3);
+  static void Connect(std::string connect_str, SQLHENV& env_handle, SQLHDBC& conn_handle,
+                      SQLINTEGER odbc_ver = SQL_OV_ODBC3);
   /// \brief Connect to Arrow Flight SQL server using connection string
-  static void ConnectWithString(std::string connection_str);
+  static void ConnectWithString(std::string connect_str, SQLHDBC& conn_handle);
   /// \brief Disconnect from server
-  static void Disconnect();
+  static void Disconnect(SQLHENV& env_handle, SQLHDBC& conn_handle);
   /// \brief Get connection string from environment variable "ARROW_FLIGHT_SQL_ODBC_CONN"
   static std::string GetConnectionString();
   /// \brief Get invalid connection string based on connection string defined in
@@ -83,7 +99,6 @@ class ODBCTestBase : public ::testing::Test {
  protected:
   void SetUp() override;
   void TearDown() override;
-  static void TearDownTestSuite();
 };
 
 /// \brief Base test fixture for running tests against a remote server.
@@ -92,9 +107,6 @@ class ODBCTestBase : public ::testing::Test {
 /// The connection string for connecting to this server is defined
 /// in the ARROW_FLIGHT_SQL_ODBC_CONN environment variable.
 class FlightSQLODBCRemoteTestBase : public ODBCTestBase {
- public:
-  static void CheckForRemoteTest();
-
  protected:
   static void SetUpTestSuite();
 };
@@ -111,6 +123,8 @@ class FlightSQLOdbcEnvConnHandleRemoteTestBase : public FlightSQLODBCRemoteTestB
  protected:
   static void SetUpTestSuite();
   static void TearDownTestSuite();
+  void SetUp() override {}
+  void TearDown() override {}
 };
 
 static constexpr std::string_view kAuthorizationHeader = "authorization";
@@ -200,6 +214,8 @@ class FlightSQLOdbcEnvConnHandleMockTestBase : public FlightSQLODBCMockTestBase 
  protected:
   static void SetUpTestSuite();
   static void TearDownTestSuite();
+  void SetUp() override {}
+  void TearDown() override {}
 };
 
 /** ODBC read buffer size. */

--- a/cpp/src/arrow/flight/sql/odbc/tests/odbc_test_suite.h
+++ b/cpp/src/arrow/flight/sql/odbc/tests/odbc_test_suite.h
@@ -46,7 +46,6 @@ inline std::string remote_test_connect_str = "";
 struct OdbcHandles {
   SQLHENV env = SQL_NULL_HENV;
   SQLHDBC conn = SQL_NULL_HDBC;
-  SQLHSTMT stmt = SQL_NULL_HSTMT;
 };
 
 inline OdbcHandles remote_odbcv3_handles;
@@ -72,7 +71,7 @@ class ODBCTestBase : public ::testing::Test {
   /// \brief Free environment and connection handles
   static void FreeEnvConnHandles(SQLHENV& env_handle, SQLHDBC& conn_handle);
   /// \brief Connect to Arrow Flight SQL server using connection string defined in
-  /// environment variable "ARROW_FLIGHT_SQL_ODBC_CONN", allocate statement handle.
+  /// environment variable "ARROW_FLIGHT_SQL_ODBC_CONN".
   /// Connects using ODBC Ver 3 by default
   static void Connect(std::string connect_str, SQLHENV& env_handle, SQLHDBC& conn_handle,
                       SQLINTEGER odbc_ver = SQL_OV_ODBC3);

--- a/cpp/src/arrow/flight/sql/odbc/tests/statement_attr_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/statement_attr_test.cc
@@ -123,21 +123,21 @@ void ValidateSetStmtAttrErrorCode(SQLHSTMT statement, SQLINTEGER attribute,
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrAppParamDesc) {
   SQLULEN value;
-  GetStmtAttr(stmt, SQL_ATTR_APP_PARAM_DESC, &value);
+  GetStmtAttr(this->stmt, SQL_ATTR_APP_PARAM_DESC, &value);
 
   EXPECT_GT(value, static_cast<SQLULEN>(0));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrAppRowDesc) {
   SQLULEN value;
-  GetStmtAttr(stmt, SQL_ATTR_APP_ROW_DESC, &value);
+  GetStmtAttr(this->stmt, SQL_ATTR_APP_ROW_DESC, &value);
 
   EXPECT_GT(value, static_cast<SQLULEN>(0));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrAsyncEnable) {
   SQLULEN value;
-  GetStmtAttr(stmt, SQL_ATTR_ASYNC_ENABLE, &value);
+  GetStmtAttr(this->stmt, SQL_ATTR_ASYNC_ENABLE, &value);
 
   EXPECT_EQ(static_cast<SQLULEN>(SQL_ASYNC_ENABLE_OFF), value);
 }
@@ -145,188 +145,190 @@ TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrAsyncEnable) {
 #ifdef SQL_ATTR_ASYNC_STMT_EVENT
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrAsyncStmtEventUnsupported) {
   // Optional feature not implemented
-  ValidateGetStmtAttrErrorCode(stmt, SQL_ATTR_ASYNC_STMT_EVENT, kErrorStateHYC00);
+  ValidateGetStmtAttrErrorCode(this->stmt, SQL_ATTR_ASYNC_STMT_EVENT, kErrorStateHYC00);
 }
 #endif
 
 #ifdef SQL_ATTR_ASYNC_STMT_PCALLBACK
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrAsyncStmtPCCallbackUnsupported) {
   // Optional feature not implemented
-  ValidateGetStmtAttrErrorCode(stmt, SQL_ATTR_ASYNC_STMT_PCALLBACK, kErrorStateHYC00);
+  ValidateGetStmtAttrErrorCode(this->stmt, SQL_ATTR_ASYNC_STMT_PCALLBACK,
+                               kErrorStateHYC00);
 }
 #endif
 
 #ifdef SQL_ATTR_ASYNC_STMT_PCONTEXT
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrAsyncStmtPCContextUnsupported) {
   // Optional feature not implemented
-  ValidateGetStmtAttrErrorCode(stmt, SQL_ATTR_ASYNC_STMT_PCONTEXT, kErrorStateHYC00);
+  ValidateGetStmtAttrErrorCode(this->stmt, SQL_ATTR_ASYNC_STMT_PCONTEXT,
+                               kErrorStateHYC00);
 }
 #endif
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrConcurrency) {
   SQLULEN value;
-  GetStmtAttr(stmt, SQL_ATTR_CONCURRENCY, &value);
+  GetStmtAttr(this->stmt, SQL_ATTR_CONCURRENCY, &value);
 
   EXPECT_EQ(static_cast<SQLULEN>(SQL_CONCUR_READ_ONLY), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrCursorScrollable) {
   SQLULEN value;
-  GetStmtAttr(stmt, SQL_ATTR_CURSOR_SCROLLABLE, &value);
+  GetStmtAttr(this->stmt, SQL_ATTR_CURSOR_SCROLLABLE, &value);
 
   EXPECT_EQ(static_cast<SQLULEN>(SQL_NONSCROLLABLE), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrCursorSensitivity) {
   SQLULEN value;
-  GetStmtAttr(stmt, SQL_ATTR_CURSOR_SENSITIVITY, &value);
+  GetStmtAttr(this->stmt, SQL_ATTR_CURSOR_SENSITIVITY, &value);
 
   EXPECT_EQ(static_cast<SQLULEN>(SQL_UNSPECIFIED), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrCursorType) {
   SQLULEN value;
-  GetStmtAttr(stmt, SQL_ATTR_CURSOR_TYPE, &value);
+  GetStmtAttr(this->stmt, SQL_ATTR_CURSOR_TYPE, &value);
 
   EXPECT_EQ(static_cast<SQLULEN>(SQL_CURSOR_FORWARD_ONLY), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrEnableAutoIPD) {
   SQLULEN value;
-  GetStmtAttr(stmt, SQL_ATTR_ENABLE_AUTO_IPD, &value);
+  GetStmtAttr(this->stmt, SQL_ATTR_ENABLE_AUTO_IPD, &value);
 
   EXPECT_EQ(static_cast<SQLULEN>(SQL_FALSE), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrFetchBookmarkPointer) {
   SQLLEN value;
-  GetStmtAttr(stmt, SQL_ATTR_FETCH_BOOKMARK_PTR, &value);
+  GetStmtAttr(this->stmt, SQL_ATTR_FETCH_BOOKMARK_PTR, &value);
 
   EXPECT_EQ(static_cast<SQLLEN>(NULL), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrIMPParamDesc) {
   SQLULEN value;
-  GetStmtAttr(stmt, SQL_ATTR_IMP_PARAM_DESC, &value);
+  GetStmtAttr(this->stmt, SQL_ATTR_IMP_PARAM_DESC, &value);
 
   EXPECT_GT(value, static_cast<SQLULEN>(0));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrIMPRowDesc) {
   SQLULEN value;
-  GetStmtAttr(stmt, SQL_ATTR_IMP_ROW_DESC, &value);
+  GetStmtAttr(this->stmt, SQL_ATTR_IMP_ROW_DESC, &value);
 
   EXPECT_GT(value, static_cast<SQLULEN>(0));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrKeysetSize) {
   SQLULEN value;
-  GetStmtAttr(stmt, SQL_ATTR_KEYSET_SIZE, &value);
+  GetStmtAttr(this->stmt, SQL_ATTR_KEYSET_SIZE, &value);
 
   EXPECT_EQ(static_cast<SQLULEN>(0), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrMaxLength) {
   SQLULEN value;
-  GetStmtAttr(stmt, SQL_ATTR_MAX_LENGTH, &value);
+  GetStmtAttr(this->stmt, SQL_ATTR_MAX_LENGTH, &value);
 
   EXPECT_EQ(static_cast<SQLULEN>(0), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrMaxRows) {
   SQLULEN value;
-  GetStmtAttr(stmt, SQL_ATTR_MAX_ROWS, &value);
+  GetStmtAttr(this->stmt, SQL_ATTR_MAX_ROWS, &value);
 
   EXPECT_EQ(static_cast<SQLULEN>(0), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrMetadataID) {
   SQLULEN value;
-  GetStmtAttr(stmt, SQL_ATTR_METADATA_ID, &value);
+  GetStmtAttr(this->stmt, SQL_ATTR_METADATA_ID, &value);
 
   EXPECT_EQ(static_cast<SQLULEN>(SQL_FALSE), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrNoscan) {
   SQLULEN value;
-  GetStmtAttr(stmt, SQL_ATTR_NOSCAN, &value);
+  GetStmtAttr(this->stmt, SQL_ATTR_NOSCAN, &value);
 
   EXPECT_EQ(static_cast<SQLULEN>(SQL_NOSCAN_OFF), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrParamBindOffsetPtr) {
   SQLPOINTER value = nullptr;
-  GetStmtAttr(stmt, SQL_ATTR_PARAM_BIND_OFFSET_PTR, &value);
+  GetStmtAttr(this->stmt, SQL_ATTR_PARAM_BIND_OFFSET_PTR, &value);
 
   EXPECT_EQ(static_cast<SQLPOINTER>(nullptr), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrParamBindType) {
   SQLULEN value;
-  GetStmtAttr(stmt, SQL_ATTR_PARAM_BIND_TYPE, &value);
+  GetStmtAttr(this->stmt, SQL_ATTR_PARAM_BIND_TYPE, &value);
 
   EXPECT_EQ(static_cast<SQLULEN>(SQL_PARAM_BIND_BY_COLUMN), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrParamOperationPtr) {
   SQLPOINTER value = nullptr;
-  GetStmtAttr(stmt, SQL_ATTR_PARAM_OPERATION_PTR, &value);
+  GetStmtAttr(this->stmt, SQL_ATTR_PARAM_OPERATION_PTR, &value);
 
   EXPECT_EQ(static_cast<SQLPOINTER>(nullptr), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrParamStatusPtr) {
   SQLPOINTER value = nullptr;
-  GetStmtAttr(stmt, SQL_ATTR_PARAM_STATUS_PTR, &value);
+  GetStmtAttr(this->stmt, SQL_ATTR_PARAM_STATUS_PTR, &value);
 
   EXPECT_EQ(static_cast<SQLPOINTER>(nullptr), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrParamsProcessedPtr) {
   SQLPOINTER value = nullptr;
-  GetStmtAttr(stmt, SQL_ATTR_PARAMS_PROCESSED_PTR, &value);
+  GetStmtAttr(this->stmt, SQL_ATTR_PARAMS_PROCESSED_PTR, &value);
 
   EXPECT_EQ(static_cast<SQLPOINTER>(nullptr), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrParamsetSize) {
   SQLULEN value;
-  GetStmtAttr(stmt, SQL_ATTR_PARAMSET_SIZE, &value);
+  GetStmtAttr(this->stmt, SQL_ATTR_PARAMSET_SIZE, &value);
 
   EXPECT_EQ(static_cast<SQLULEN>(1), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrQueryTimeout) {
   SQLULEN value;
-  GetStmtAttr(stmt, SQL_ATTR_QUERY_TIMEOUT, &value);
+  GetStmtAttr(this->stmt, SQL_ATTR_QUERY_TIMEOUT, &value);
 
   EXPECT_EQ(static_cast<SQLULEN>(0), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrRetrieveData) {
   SQLULEN value;
-  GetStmtAttr(stmt, SQL_ATTR_RETRIEVE_DATA, &value);
+  GetStmtAttr(this->stmt, SQL_ATTR_RETRIEVE_DATA, &value);
 
   EXPECT_EQ(static_cast<SQLULEN>(SQL_RD_ON), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrRowArraySize) {
   SQLULEN value;
-  GetStmtAttr(stmt, SQL_ATTR_ROW_ARRAY_SIZE, &value);
+  GetStmtAttr(this->stmt, SQL_ATTR_ROW_ARRAY_SIZE, &value);
 
   EXPECT_EQ(static_cast<SQLULEN>(1), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrRowBindOffsetPtr) {
   SQLPOINTER value = nullptr;
-  GetStmtAttr(stmt, SQL_ATTR_ROW_BIND_OFFSET_PTR, &value);
+  GetStmtAttr(this->stmt, SQL_ATTR_ROW_BIND_OFFSET_PTR, &value);
 
   EXPECT_EQ(static_cast<SQLPOINTER>(nullptr), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrRowBindType) {
   SQLULEN value;
-  GetStmtAttr(stmt, SQL_ATTR_ROW_BIND_TYPE, &value);
+  GetStmtAttr(this->stmt, SQL_ATTR_ROW_BIND_TYPE, &value);
 
   EXPECT_EQ(static_cast<SQLULEN>(0), value);
 }
@@ -335,47 +337,47 @@ TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrRowNumber) {
   SQLWCHAR wsql[] = L"SELECT 1;";
   SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
   SQLULEN value;
-  GetStmtAttr(stmt, SQL_ATTR_ROW_NUMBER, &value);
+  GetStmtAttr(this->stmt, SQL_ATTR_ROW_NUMBER, &value);
 
   EXPECT_EQ(static_cast<SQLULEN>(1), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrRowOperationPtr) {
   SQLPOINTER value = nullptr;
-  GetStmtAttr(stmt, SQL_ATTR_ROW_OPERATION_PTR, &value);
+  GetStmtAttr(this->stmt, SQL_ATTR_ROW_OPERATION_PTR, &value);
 
   EXPECT_EQ(static_cast<SQLPOINTER>(nullptr), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrRowStatusPtr) {
   SQLPOINTER value = nullptr;
-  GetStmtAttr(stmt, SQL_ATTR_ROW_STATUS_PTR, &value);
+  GetStmtAttr(this->stmt, SQL_ATTR_ROW_STATUS_PTR, &value);
 
   EXPECT_EQ(static_cast<SQLPOINTER>(nullptr), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrRowsFetchedPtr) {
   SQLPOINTER value = nullptr;
-  GetStmtAttr(stmt, SQL_ATTR_ROWS_FETCHED_PTR, &value);
+  GetStmtAttr(this->stmt, SQL_ATTR_ROWS_FETCHED_PTR, &value);
 
   EXPECT_EQ(static_cast<SQLPOINTER>(nullptr), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrSimulateCursor) {
   SQLULEN value;
-  GetStmtAttr(stmt, SQL_ATTR_SIMULATE_CURSOR, &value);
+  GetStmtAttr(this->stmt, SQL_ATTR_SIMULATE_CURSOR, &value);
 
   EXPECT_EQ(static_cast<SQLULEN>(SQL_SC_UNIQUE), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrUseBookmarks) {
   SQLULEN value;
-  GetStmtAttr(stmt, SQL_ATTR_USE_BOOKMARKS, &value);
+  GetStmtAttr(this->stmt, SQL_ATTR_USE_BOOKMARKS, &value);
 
   EXPECT_EQ(static_cast<SQLULEN>(SQL_UB_OFF), value);
 }
@@ -383,7 +385,7 @@ TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrUseBookmarks) {
 // This is a pre ODBC 3 attribute
 TYPED_TEST(StatementAttributeTest, TestSQLGetStmtAttrRowsetSize) {
   SQLULEN value;
-  GetStmtAttr(stmt, SQL_ROWSET_SIZE, &value);
+  GetStmtAttr(this->stmt, SQL_ROWSET_SIZE, &value);
 
   EXPECT_EQ(static_cast<SQLULEN>(1), value);
 }
@@ -392,12 +394,12 @@ TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrAppParamDesc) {
   SQLULEN app_param_desc = 0;
   SQLINTEGER string_length_ptr;
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetStmtAttr(stmt, SQL_ATTR_APP_PARAM_DESC, &app_param_desc, 0,
-                                        &string_length_ptr));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetStmtAttr(this->stmt, SQL_ATTR_APP_PARAM_DESC,
+                                        &app_param_desc, 0, &string_length_ptr));
 
-  ValidateSetStmtAttr(stmt, SQL_ATTR_APP_PARAM_DESC, static_cast<SQLULEN>(0));
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_APP_PARAM_DESC, static_cast<SQLULEN>(0));
 
-  ValidateSetStmtAttr(stmt, SQL_ATTR_APP_PARAM_DESC,
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_APP_PARAM_DESC,
                       static_cast<SQLULEN>(app_param_desc));
 }
 
@@ -405,18 +407,19 @@ TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrAppRowDesc) {
   SQLULEN app_row_desc = 0;
   SQLINTEGER string_length_ptr;
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetStmtAttr(stmt, SQL_ATTR_APP_ROW_DESC, &app_row_desc, 0,
-                                        &string_length_ptr));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetStmtAttr(this->stmt, SQL_ATTR_APP_ROW_DESC, &app_row_desc,
+                                        0, &string_length_ptr));
 
-  ValidateSetStmtAttr(stmt, SQL_ATTR_APP_ROW_DESC, static_cast<SQLULEN>(0));
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_APP_ROW_DESC, static_cast<SQLULEN>(0));
 
-  ValidateSetStmtAttr(stmt, SQL_ATTR_APP_ROW_DESC, static_cast<SQLULEN>(app_row_desc));
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_APP_ROW_DESC,
+                      static_cast<SQLULEN>(app_row_desc));
 }
 
 #ifdef SQL_ATTR_ASYNC_ENABLE
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrAsyncEnableUnsupported) {
   // Optional feature not implemented
-  ValidateSetStmtAttrErrorCode(stmt, SQL_ATTR_ASYNC_ENABLE, SQL_ASYNC_ENABLE_OFF,
+  ValidateSetStmtAttrErrorCode(this->stmt, SQL_ATTR_ASYNC_ENABLE, SQL_ASYNC_ENABLE_OFF,
                                SQL_ERROR, kErrorStateHYC00);
 }
 #endif
@@ -424,14 +427,14 @@ TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrAsyncEnableUnsupported) {
 #ifdef SQL_ATTR_ASYNC_STMT_EVENT
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrAsyncStmtEventUnsupported) {
   // Driver does not support asynchronous notification
-  ValidateSetStmtAttrErrorCode(stmt, SQL_ATTR_ASYNC_STMT_EVENT, 0, SQL_ERROR,
+  ValidateSetStmtAttrErrorCode(this->stmt, SQL_ATTR_ASYNC_STMT_EVENT, 0, SQL_ERROR,
                                kErrorStateHY118);
 }
 #endif
 
 #ifdef SQL_ATTR_ASYNC_STMT_PCALLBACK
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrAsyncStmtPCCallbackUnsupported) {
-  ValidateSetStmtAttrErrorCode(stmt, SQL_ATTR_ASYNC_STMT_PCALLBACK, 0, SQL_ERROR,
+  ValidateSetStmtAttrErrorCode(this->stmt, SQL_ATTR_ASYNC_STMT_PCALLBACK, 0, SQL_ERROR,
                                kErrorStateHYC00);
 }
 #endif
@@ -439,43 +442,44 @@ TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrAsyncStmtPCCallbackUnsuppor
 #ifdef SQL_ATTR_ASYNC_STMT_PCONTEXT
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrAsyncStmtPCContextUnsupported) {
   // Optional feature not implemented
-  ValidateSetStmtAttrErrorCode(stmt, SQL_ATTR_ASYNC_STMT_PCONTEXT, 0, SQL_ERROR,
+  ValidateSetStmtAttrErrorCode(this->stmt, SQL_ATTR_ASYNC_STMT_PCONTEXT, 0, SQL_ERROR,
                                kErrorStateHYC00);
 }
 #endif
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrConcurrency) {
-  ValidateSetStmtAttr(stmt, SQL_ATTR_CONCURRENCY,
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_CONCURRENCY,
                       static_cast<SQLULEN>(SQL_CONCUR_READ_ONLY));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrCursorScrollable) {
-  ValidateSetStmtAttr(stmt, SQL_ATTR_CURSOR_SCROLLABLE,
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_CURSOR_SCROLLABLE,
                       static_cast<SQLULEN>(SQL_NONSCROLLABLE));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrCursorSensitivity) {
-  ValidateSetStmtAttr(stmt, SQL_ATTR_CURSOR_SENSITIVITY,
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_CURSOR_SENSITIVITY,
                       static_cast<SQLULEN>(SQL_UNSPECIFIED));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrCursorType) {
-  ValidateSetStmtAttr(stmt, SQL_ATTR_CURSOR_TYPE,
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_CURSOR_TYPE,
                       static_cast<SQLULEN>(SQL_CURSOR_FORWARD_ONLY));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrEnableAutoIPD) {
-  ValidateSetStmtAttr(stmt, SQL_ATTR_ENABLE_AUTO_IPD, static_cast<SQLULEN>(SQL_FALSE));
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_ENABLE_AUTO_IPD,
+                      static_cast<SQLULEN>(SQL_FALSE));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrFetchBookmarkPointer) {
-  ValidateSetStmtAttr(stmt, SQL_ATTR_FETCH_BOOKMARK_PTR, static_cast<SQLLEN>(NULL));
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_FETCH_BOOKMARK_PTR, static_cast<SQLLEN>(NULL));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrIMPParamDesc) {
   // Invalid use of an automatically allocated descriptor handle
-  ValidateSetStmtAttrErrorCode(stmt, SQL_ATTR_IMP_PARAM_DESC, static_cast<SQLULEN>(0),
-                               SQL_ERROR,
+  ValidateSetStmtAttrErrorCode(this->stmt, SQL_ATTR_IMP_PARAM_DESC,
+                               static_cast<SQLULEN>(0), SQL_ERROR,
 #ifdef __APPLE__
                                // static iODBC on MacOS returns IM001 for this case
                                kErrorStateIM001);
@@ -486,7 +490,7 @@ TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrIMPParamDesc) {
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrIMPRowDesc) {
   // Invalid use of an automatically allocated descriptor handle
-  ValidateSetStmtAttrErrorCode(stmt, SQL_ATTR_IMP_ROW_DESC, static_cast<SQLULEN>(0),
+  ValidateSetStmtAttrErrorCode(this->stmt, SQL_ATTR_IMP_ROW_DESC, static_cast<SQLULEN>(0),
                                SQL_ERROR,
 #ifdef __APPLE__
                                // static iODBC on MacOS returns IM001 for this case
@@ -497,41 +501,41 @@ TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrIMPRowDesc) {
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrKeysetSizeUnsupported) {
-  ValidateSetStmtAttr(stmt, SQL_ATTR_KEYSET_SIZE, static_cast<SQLULEN>(0));
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_KEYSET_SIZE, static_cast<SQLULEN>(0));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrMaxLength) {
-  ValidateSetStmtAttr(stmt, SQL_ATTR_MAX_LENGTH, static_cast<SQLULEN>(0));
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_MAX_LENGTH, static_cast<SQLULEN>(0));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrMaxRows) {
   // Cannot set read-only attribute
-  ValidateSetStmtAttrErrorCode(stmt, SQL_ATTR_MAX_ROWS, static_cast<SQLULEN>(0),
+  ValidateSetStmtAttrErrorCode(this->stmt, SQL_ATTR_MAX_ROWS, static_cast<SQLULEN>(0),
                                SQL_ERROR, kErrorStateHY092);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrMetadataID) {
-  ValidateSetStmtAttr(stmt, SQL_ATTR_METADATA_ID, static_cast<SQLULEN>(SQL_FALSE));
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_METADATA_ID, static_cast<SQLULEN>(SQL_FALSE));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrNoscan) {
-  ValidateSetStmtAttr(stmt, SQL_ATTR_NOSCAN, static_cast<SQLULEN>(SQL_NOSCAN_OFF));
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_NOSCAN, static_cast<SQLULEN>(SQL_NOSCAN_OFF));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrParamBindOffsetPtr) {
   SQLULEN offset = 1000;
 
-  ValidateSetStmtAttr(stmt, SQL_ATTR_PARAM_BIND_OFFSET_PTR,
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_PARAM_BIND_OFFSET_PTR,
                       static_cast<SQLPOINTER>(&offset));
 
   SQLPOINTER value = nullptr;
-  GetStmtAttr(stmt, SQL_ATTR_PARAM_BIND_OFFSET_PTR, &value);
+  GetStmtAttr(this->stmt, SQL_ATTR_PARAM_BIND_OFFSET_PTR, &value);
 
   EXPECT_EQ(static_cast<SQLPOINTER>(&offset), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrParamBindType) {
-  ValidateSetStmtAttr(stmt, SQL_ATTR_PARAM_BIND_TYPE,
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_PARAM_BIND_TYPE,
                       static_cast<SQLULEN>(SQL_PARAM_BIND_BY_COLUMN));
 }
 
@@ -540,11 +544,11 @@ TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrParamOperationPtr) {
   SQLUSMALLINT param_operations[param_set_size] = {SQL_PARAM_PROCEED, SQL_PARAM_IGNORE,
                                                    SQL_PARAM_PROCEED, SQL_PARAM_IGNORE};
 
-  ValidateSetStmtAttr(stmt, SQL_ATTR_PARAM_OPERATION_PTR,
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_PARAM_OPERATION_PTR,
                       static_cast<SQLPOINTER>(param_operations));
 
   SQLPOINTER value = nullptr;
-  GetStmtAttr(stmt, SQL_ATTR_PARAM_OPERATION_PTR, &value);
+  GetStmtAttr(this->stmt, SQL_ATTR_PARAM_OPERATION_PTR, &value);
 
   EXPECT_EQ(static_cast<SQLPOINTER>(param_operations), value);
 }
@@ -555,11 +559,11 @@ TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrParamStatusPtr) {
   SQLUSMALLINT param_status[param_status_size] = {SQL_PARAM_PROCEED, SQL_PARAM_IGNORE,
                                                   SQL_PARAM_PROCEED, SQL_PARAM_IGNORE};
 
-  ValidateSetStmtAttr(stmt, SQL_ATTR_PARAM_STATUS_PTR,
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_PARAM_STATUS_PTR,
                       static_cast<SQLPOINTER>(param_status));
 
   SQLPOINTER value = nullptr;
-  GetStmtAttr(stmt, SQL_ATTR_PARAM_STATUS_PTR, &value);
+  GetStmtAttr(this->stmt, SQL_ATTR_PARAM_STATUS_PTR, &value);
 
   EXPECT_EQ(static_cast<SQLPOINTER>(param_status), value);
 }
@@ -567,50 +571,51 @@ TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrParamStatusPtr) {
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrParamsProcessedPtr) {
   SQLULEN processed_count = 0;
 
-  ValidateSetStmtAttr(stmt, SQL_ATTR_PARAMS_PROCESSED_PTR,
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_PARAMS_PROCESSED_PTR,
                       static_cast<SQLPOINTER>(&processed_count));
 
   SQLPOINTER value = nullptr;
-  GetStmtAttr(stmt, SQL_ATTR_PARAMS_PROCESSED_PTR, &value);
+  GetStmtAttr(this->stmt, SQL_ATTR_PARAMS_PROCESSED_PTR, &value);
 
   EXPECT_EQ(static_cast<SQLPOINTER>(&processed_count), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrParamsetSize) {
-  ValidateSetStmtAttr(stmt, SQL_ATTR_PARAMSET_SIZE, static_cast<SQLULEN>(1));
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_PARAMSET_SIZE, static_cast<SQLULEN>(1));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrQueryTimeout) {
-  ValidateSetStmtAttr(stmt, SQL_ATTR_QUERY_TIMEOUT, static_cast<SQLULEN>(1));
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_QUERY_TIMEOUT, static_cast<SQLULEN>(1));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrRetrieveData) {
-  ValidateSetStmtAttr(stmt, SQL_ATTR_RETRIEVE_DATA, static_cast<SQLULEN>(SQL_RD_ON));
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_RETRIEVE_DATA,
+                      static_cast<SQLULEN>(SQL_RD_ON));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrRowArraySize) {
-  ValidateSetStmtAttr(stmt, SQL_ATTR_ROW_ARRAY_SIZE, static_cast<SQLULEN>(1));
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_ROW_ARRAY_SIZE, static_cast<SQLULEN>(1));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrRowBindOffsetPtr) {
   SQLULEN offset = 1000;
 
-  ValidateSetStmtAttr(stmt, SQL_ATTR_ROW_BIND_OFFSET_PTR,
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_ROW_BIND_OFFSET_PTR,
                       static_cast<SQLPOINTER>(&offset));
 
   SQLPOINTER value = nullptr;
-  GetStmtAttr(stmt, SQL_ATTR_ROW_BIND_OFFSET_PTR, &value);
+  GetStmtAttr(this->stmt, SQL_ATTR_ROW_BIND_OFFSET_PTR, &value);
 
   EXPECT_EQ(static_cast<SQLPOINTER>(&offset), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrRowBindType) {
-  ValidateSetStmtAttr(stmt, SQL_ATTR_ROW_BIND_TYPE, static_cast<SQLULEN>(0));
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_ROW_BIND_TYPE, static_cast<SQLULEN>(0));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrRowNumber) {
   // Cannot set read-only attribute
-  ValidateSetStmtAttrErrorCode(stmt, SQL_ATTR_ROW_NUMBER, static_cast<SQLULEN>(0),
+  ValidateSetStmtAttrErrorCode(this->stmt, SQL_ATTR_ROW_NUMBER, static_cast<SQLULEN>(0),
                                SQL_ERROR, kErrorStateHY092);
 }
 
@@ -619,11 +624,11 @@ TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrRowOperationPtr) {
   SQLUSMALLINT row_operations[param_set_size] = {SQL_ROW_PROCEED, SQL_ROW_IGNORE,
                                                  SQL_ROW_PROCEED, SQL_ROW_IGNORE};
 
-  ValidateSetStmtAttr(stmt, SQL_ATTR_ROW_OPERATION_PTR,
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_ROW_OPERATION_PTR,
                       static_cast<SQLPOINTER>(row_operations));
 
   SQLPOINTER value = nullptr;
-  GetStmtAttr(stmt, SQL_ATTR_ROW_OPERATION_PTR, &value);
+  GetStmtAttr(this->stmt, SQL_ATTR_ROW_OPERATION_PTR, &value);
 
   EXPECT_EQ(static_cast<SQLPOINTER>(row_operations), value);
 }
@@ -632,10 +637,11 @@ TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrRowStatusPtr) {
   constexpr SQLULEN row_status_size = 4;
   SQLUSMALLINT values[row_status_size] = {0, 0, 0, 0};
 
-  ValidateSetStmtAttr(stmt, SQL_ATTR_ROW_STATUS_PTR, static_cast<SQLPOINTER>(values));
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_ROW_STATUS_PTR,
+                      static_cast<SQLPOINTER>(values));
 
   SQLPOINTER value = nullptr;
-  GetStmtAttr(stmt, SQL_ATTR_ROW_STATUS_PTR, &value);
+  GetStmtAttr(this->stmt, SQL_ATTR_ROW_STATUS_PTR, &value);
 
   EXPECT_EQ(static_cast<SQLPOINTER>(values), value);
 }
@@ -643,27 +649,28 @@ TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrRowStatusPtr) {
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrRowsFetchedPtr) {
   SQLULEN rows_fetched = 1;
 
-  ValidateSetStmtAttr(stmt, SQL_ATTR_ROWS_FETCHED_PTR,
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_ROWS_FETCHED_PTR,
                       static_cast<SQLPOINTER>(&rows_fetched));
 
   SQLPOINTER value = nullptr;
-  GetStmtAttr(stmt, SQL_ATTR_ROWS_FETCHED_PTR, &value);
+  GetStmtAttr(this->stmt, SQL_ATTR_ROWS_FETCHED_PTR, &value);
 
   EXPECT_EQ(static_cast<SQLPOINTER>(&rows_fetched), value);
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrSimulateCursor) {
-  ValidateSetStmtAttr(stmt, SQL_ATTR_SIMULATE_CURSOR,
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_SIMULATE_CURSOR,
                       static_cast<SQLULEN>(SQL_SC_UNIQUE));
 }
 
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrUseBookmarks) {
-  ValidateSetStmtAttr(stmt, SQL_ATTR_USE_BOOKMARKS, static_cast<SQLULEN>(SQL_UB_OFF));
+  ValidateSetStmtAttr(this->stmt, SQL_ATTR_USE_BOOKMARKS,
+                      static_cast<SQLULEN>(SQL_UB_OFF));
 }
 
 // This is a pre ODBC 3 attribute
 TYPED_TEST(StatementAttributeTest, TestSQLSetStmtAttrRowsetSize) {
-  ValidateSetStmtAttr(stmt, SQL_ROWSET_SIZE, static_cast<SQLULEN>(1));
+  ValidateSetStmtAttr(this->stmt, SQL_ROWSET_SIZE, static_cast<SQLULEN>(1));
 }
 
 }  // namespace arrow::flight::sql::odbc

--- a/cpp/src/arrow/flight/sql/odbc/tests/statement_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/statement_test.cc
@@ -41,26 +41,26 @@ TYPED_TEST(StatementTest, TestSQLExecDirectSimpleQuery) {
   SQLWCHAR wsql[] = L"SELECT 1;";
   SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
   SQLINTEGER val;
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 1, SQL_C_LONG, &val, 0, nullptr));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 1, SQL_C_LONG, &val, 0, nullptr));
   // Verify 1 is returned
   EXPECT_EQ(1, val);
 
-  ASSERT_EQ(SQL_NO_DATA, SQLFetch(stmt));
+  ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
 
 #ifdef __APPLE__
   // With iODBC we expect SQL_SUCCESS and the buffer unchanged in this situation.
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 1, SQL_C_LONG, &val, 0, nullptr));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 1, SQL_C_LONG, &val, 0, nullptr));
   EXPECT_EQ(1, val);
 #else
-  ASSERT_EQ(SQL_ERROR, SQLGetData(stmt, 1, SQL_C_LONG, &val, 0, nullptr));
+  ASSERT_EQ(SQL_ERROR, SQLGetData(this->stmt, 1, SQL_C_LONG, &val, 0, nullptr));
   // Invalid cursor state
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorState24000);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorState24000);
 #endif
 }
 
@@ -68,38 +68,38 @@ TYPED_TEST(StatementTest, TestSQLExecDirectInvalidQuery) {
   SQLWCHAR wsql[] = L"SELECT;";
   SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_ERROR, SQLExecDirect(stmt, wsql, wsql_len));
+  ASSERT_EQ(SQL_ERROR, SQLExecDirect(this->stmt, wsql, wsql_len));
   // ODBC provides generic error code HY000 to all statement errors
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorStateHY000);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorStateHY000);
 }
 
 TYPED_TEST(StatementTest, TestSQLExecuteSimpleQuery) {
   SQLWCHAR wsql[] = L"SELECT 1;";
   SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLPrepare(stmt, wsql, wsql_len));
+  ASSERT_EQ(SQL_SUCCESS, SQLPrepare(this->stmt, wsql, wsql_len));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecute(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecute(this->stmt));
 
   // Fetch data
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
   SQLINTEGER val;
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 1, SQL_C_LONG, &val, 0, nullptr));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 1, SQL_C_LONG, &val, 0, nullptr));
 
   // Verify 1 is returned
   EXPECT_EQ(1, val);
 
-  ASSERT_EQ(SQL_NO_DATA, SQLFetch(stmt));
+  ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
 
 #ifdef __APPLE__
   // With iODBC we expect SQL_SUCCESS and the buffer unchanged in this situation.
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 1, SQL_C_LONG, &val, 0, nullptr));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 1, SQL_C_LONG, &val, 0, nullptr));
   EXPECT_EQ(1, val);
 #else
-  ASSERT_EQ(SQL_ERROR, SQLGetData(stmt, 1, SQL_C_LONG, &val, 0, nullptr));
+  ASSERT_EQ(SQL_ERROR, SQLGetData(this->stmt, 1, SQL_C_LONG, &val, 0, nullptr));
   // Invalid cursor state
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorState24000);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorState24000);
 #endif
 }
 
@@ -107,16 +107,16 @@ TYPED_TEST(StatementTest, TestSQLPrepareInvalidQuery) {
   SQLWCHAR wsql[] = L"SELECT;";
   SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_ERROR, SQLPrepare(stmt, wsql, wsql_len));
+  ASSERT_EQ(SQL_ERROR, SQLPrepare(this->stmt, wsql, wsql_len));
   // ODBC provides generic error code HY000 to all statement errors
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorStateHY000);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorStateHY000);
 
-  ASSERT_EQ(SQL_ERROR, SQLExecute(stmt));
+  ASSERT_EQ(SQL_ERROR, SQLExecute(this->stmt));
   // Verify function sequence error state is returned
 #ifdef __APPLE__
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorStateS1010);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorStateS1010);
 #else
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorStateHY010);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorStateHY010);
 #endif  // __APPLE__
 }
 
@@ -125,9 +125,9 @@ TYPED_TEST(StatementTest, TestSQLExecDirectDataQuery) {
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
   // Numeric Types
 
@@ -137,84 +137,88 @@ TYPED_TEST(StatementTest, TestSQLExecDirectDataQuery) {
   SQLLEN ind;
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(stmt, 1, SQL_C_STINYINT, &stiny_int_val, buf_len, &ind));
+            SQLGetData(this->stmt, 1, SQL_C_STINYINT, &stiny_int_val, buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<int8_t>::min(), stiny_int_val);
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(stmt, 2, SQL_C_STINYINT, &stiny_int_val, buf_len, &ind));
+            SQLGetData(this->stmt, 2, SQL_C_STINYINT, &stiny_int_val, buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<int8_t>::max(), stiny_int_val);
 
   // Unsigned Tiny Int
   uint8_t utiny_int_val;
   buf_len = sizeof(utiny_int_val);
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(stmt, 3, SQL_C_UTINYINT, &utiny_int_val, buf_len, &ind));
+            SQLGetData(this->stmt, 3, SQL_C_UTINYINT, &utiny_int_val, buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<uint8_t>::min(), utiny_int_val);
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(stmt, 4, SQL_C_UTINYINT, &utiny_int_val, buf_len, &ind));
+            SQLGetData(this->stmt, 4, SQL_C_UTINYINT, &utiny_int_val, buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<uint8_t>::max(), utiny_int_val);
 
   // Signed Small Int
   int16_t ssmall_int_val;
   buf_len = sizeof(ssmall_int_val);
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(stmt, 5, SQL_C_SSHORT, &ssmall_int_val, buf_len, &ind));
+            SQLGetData(this->stmt, 5, SQL_C_SSHORT, &ssmall_int_val, buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<int16_t>::min(), ssmall_int_val);
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(stmt, 6, SQL_C_SSHORT, &ssmall_int_val, buf_len, &ind));
+            SQLGetData(this->stmt, 6, SQL_C_SSHORT, &ssmall_int_val, buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<int16_t>::max(), ssmall_int_val);
 
   // Unsigned Small Int
   uint16_t usmall_int_val;
   buf_len = sizeof(usmall_int_val);
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(stmt, 7, SQL_C_USHORT, &usmall_int_val, buf_len, &ind));
+            SQLGetData(this->stmt, 7, SQL_C_USHORT, &usmall_int_val, buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<uint16_t>::min(), usmall_int_val);
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(stmt, 8, SQL_C_USHORT, &usmall_int_val, buf_len, &ind));
+            SQLGetData(this->stmt, 8, SQL_C_USHORT, &usmall_int_val, buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<uint16_t>::max(), usmall_int_val);
 
   // Signed Integer
   SQLINTEGER slong_val;
   buf_len = sizeof(slong_val);
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 9, SQL_C_SLONG, &slong_val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetData(this->stmt, 9, SQL_C_SLONG, &slong_val, buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<SQLINTEGER>::min(), slong_val);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 10, SQL_C_SLONG, &slong_val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetData(this->stmt, 10, SQL_C_SLONG, &slong_val, buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<SQLINTEGER>::max(), slong_val);
 
   // Unsigned Integer
   SQLUINTEGER ulong_val;
   buf_len = sizeof(ulong_val);
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 11, SQL_C_ULONG, &ulong_val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetData(this->stmt, 11, SQL_C_ULONG, &ulong_val, buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<SQLUINTEGER>::min(), ulong_val);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 12, SQL_C_ULONG, &ulong_val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetData(this->stmt, 12, SQL_C_ULONG, &ulong_val, buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<SQLUINTEGER>::max(), ulong_val);
 
   // Signed Big Int
   SQLBIGINT sbig_int_val;
   buf_len = sizeof(sbig_int_val);
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(stmt, 13, SQL_C_SBIGINT, &sbig_int_val, buf_len, &ind));
+            SQLGetData(this->stmt, 13, SQL_C_SBIGINT, &sbig_int_val, buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<SQLBIGINT>::min(), sbig_int_val);
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(stmt, 14, SQL_C_SBIGINT, &sbig_int_val, buf_len, &ind));
+            SQLGetData(this->stmt, 14, SQL_C_SBIGINT, &sbig_int_val, buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<SQLBIGINT>::max(), sbig_int_val);
 
   // Unsigned Big Int
   SQLUBIGINT ubig_int_val;
   buf_len = sizeof(ubig_int_val);
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(stmt, 15, SQL_C_UBIGINT, &ubig_int_val, buf_len, &ind));
+            SQLGetData(this->stmt, 15, SQL_C_UBIGINT, &ubig_int_val, buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<SQLUBIGINT>::min(), ubig_int_val);
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(stmt, 16, SQL_C_UBIGINT, &ubig_int_val, buf_len, &ind));
+            SQLGetData(this->stmt, 16, SQL_C_UBIGINT, &ubig_int_val, buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<SQLUBIGINT>::max(), ubig_int_val);
 
   // Decimal
@@ -222,7 +226,7 @@ TYPED_TEST(StatementTest, TestSQLExecDirectDataQuery) {
   memset(&decimal_val, 0, sizeof(decimal_val));
   buf_len = sizeof(SQL_NUMERIC_STRUCT);
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(stmt, 17, SQL_C_NUMERIC, &decimal_val, buf_len, &ind));
+            SQLGetData(this->stmt, 17, SQL_C_NUMERIC, &decimal_val, buf_len, &ind));
   // Check for negative decimal_val value
   EXPECT_EQ(0, decimal_val.sign);
   EXPECT_EQ(0, decimal_val.scale);
@@ -232,7 +236,7 @@ TYPED_TEST(StatementTest, TestSQLExecDirectDataQuery) {
 
   memset(&decimal_val, 0, sizeof(decimal_val));
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(stmt, 18, SQL_C_NUMERIC, &decimal_val, buf_len, &ind));
+            SQLGetData(this->stmt, 18, SQL_C_NUMERIC, &decimal_val, buf_len, &ind));
   // Check for positive decimal_val value
   EXPECT_EQ(1, decimal_val.sign);
   EXPECT_EQ(0, decimal_val.scale);
@@ -243,30 +247,34 @@ TYPED_TEST(StatementTest, TestSQLExecDirectDataQuery) {
   // Float
   float float_val;
   buf_len = sizeof(float_val);
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 19, SQL_C_FLOAT, &float_val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetData(this->stmt, 19, SQL_C_FLOAT, &float_val, buf_len, &ind));
   // Get minimum negative float value
   EXPECT_EQ(-std::numeric_limits<float>::max(), float_val);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 20, SQL_C_FLOAT, &float_val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetData(this->stmt, 20, SQL_C_FLOAT, &float_val, buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<float>::max(), float_val);
 
   // Double
   SQLDOUBLE double_val;
   buf_len = sizeof(double_val);
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 21, SQL_C_DOUBLE, &double_val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetData(this->stmt, 21, SQL_C_DOUBLE, &double_val, buf_len, &ind));
   // Get minimum negative double value
   EXPECT_EQ(-std::numeric_limits<SQLDOUBLE>::max(), double_val);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 22, SQL_C_DOUBLE, &double_val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetData(this->stmt, 22, SQL_C_DOUBLE, &double_val, buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<SQLDOUBLE>::max(), double_val);
 
   // Bit
   bool bit_val;
   buf_len = sizeof(bit_val);
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 23, SQL_C_BIT, &bit_val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 23, SQL_C_BIT, &bit_val, buf_len, &ind));
   EXPECT_EQ(false, bit_val);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 24, SQL_C_BIT, &bit_val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 24, SQL_C_BIT, &bit_val, buf_len, &ind));
   EXPECT_EQ(true, bit_val);
 
   // Characters
@@ -274,27 +282,31 @@ TYPED_TEST(StatementTest, TestSQLExecDirectDataQuery) {
   // Char
   SQLCHAR char_val[2];
   buf_len = sizeof(SQLCHAR) * 2;
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 25, SQL_C_CHAR, &char_val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetData(this->stmt, 25, SQL_C_CHAR, &char_val, buf_len, &ind));
   EXPECT_EQ('Z', char_val[0]);
 
   // WChar
   SQLWCHAR wchar_val[2];
   size_t wchar_size = GetSqlWCharSize();
   buf_len = wchar_size * 2;
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 26, SQL_C_WCHAR, &wchar_val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetData(this->stmt, 26, SQL_C_WCHAR, &wchar_val, buf_len, &ind));
   EXPECT_EQ(L'你', wchar_val[0]);
 
   // WVarchar
   SQLWCHAR wvarchar_val[3];
   buf_len = wchar_size * 3;
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 27, SQL_C_WCHAR, &wvarchar_val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetData(this->stmt, 27, SQL_C_WCHAR, &wvarchar_val, buf_len, &ind));
   EXPECT_EQ(L'你', wvarchar_val[0]);
   EXPECT_EQ(L'好', wvarchar_val[1]);
 
   // varchar
   SQLCHAR varchar_val[4];
   buf_len = sizeof(SQLCHAR) * 4;
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 28, SQL_C_CHAR, &varchar_val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetData(this->stmt, 28, SQL_C_CHAR, &varchar_val, buf_len, &ind));
   EXPECT_EQ('X', varchar_val[0]);
   EXPECT_EQ('Y', varchar_val[1]);
   EXPECT_EQ('Z', varchar_val[2]);
@@ -304,13 +316,15 @@ TYPED_TEST(StatementTest, TestSQLExecDirectDataQuery) {
   // Date
   SQL_DATE_STRUCT date_var{};
   buf_len = sizeof(date_var);
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 29, SQL_C_TYPE_DATE, &date_var, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetData(this->stmt, 29, SQL_C_TYPE_DATE, &date_var, buf_len, &ind));
   // Check min values for date. Min valid year is 1400.
   EXPECT_EQ(1, date_var.day);
   EXPECT_EQ(1, date_var.month);
   EXPECT_EQ(1400, date_var.year);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 30, SQL_C_TYPE_DATE, &date_var, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetData(this->stmt, 30, SQL_C_TYPE_DATE, &date_var, buf_len, &ind));
   // Check max values for date. Max valid year is 9999.
   EXPECT_EQ(31, date_var.day);
   EXPECT_EQ(12, date_var.month);
@@ -319,8 +333,8 @@ TYPED_TEST(StatementTest, TestSQLExecDirectDataQuery) {
   // Timestamp
   SQL_TIMESTAMP_STRUCT timestamp_var{};
   buf_len = sizeof(timestamp_var);
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(stmt, 31, SQL_C_TYPE_TIMESTAMP, &timestamp_var, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 31, SQL_C_TYPE_TIMESTAMP, &timestamp_var,
+                                    buf_len, &ind));
   // Check min values for date. Min valid year is 1400.
   EXPECT_EQ(1, timestamp_var.day);
   EXPECT_EQ(1, timestamp_var.month);
@@ -330,8 +344,8 @@ TYPED_TEST(StatementTest, TestSQLExecDirectDataQuery) {
   EXPECT_EQ(0, timestamp_var.second);
   EXPECT_EQ(0, timestamp_var.fraction);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(stmt, 32, SQL_C_TYPE_TIMESTAMP, &timestamp_var, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 32, SQL_C_TYPE_TIMESTAMP, &timestamp_var,
+                                    buf_len, &ind));
   // Check max values for date. Max valid year is 9999.
   EXPECT_EQ(31, timestamp_var.day);
   EXPECT_EQ(12, timestamp_var.month);
@@ -353,21 +367,23 @@ TEST_F(StatementRemoteTest, TestSQLExecDirectTimeQuery) {
     )";
   SQLSMALLINT wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
   SQL_TIME_STRUCT time_var{};
   SQLLEN buf_len = sizeof(time_var);
   SQLLEN ind;
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 1, SQL_C_TYPE_TIME, &time_var, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetData(this->stmt, 1, SQL_C_TYPE_TIME, &time_var, buf_len, &ind));
   // Check min values for time.
   EXPECT_EQ(0, time_var.hour);
   EXPECT_EQ(0, time_var.minute);
   EXPECT_EQ(0, time_var.second);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 2, SQL_C_TYPE_TIME, &time_var, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetData(this->stmt, 2, SQL_C_TYPE_TIME, &time_var, buf_len, &ind));
   // Check max values for time.
   EXPECT_EQ(23, time_var.hour);
   EXPECT_EQ(59, time_var.minute);
@@ -381,16 +397,16 @@ TEST_F(StatementMockTest, TestSQLExecDirectVarbinaryQuery) {
   SQLWCHAR wsql[] = L"SELECT X'ABCDEF' AS c_varbinary;";
   SQLSMALLINT wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
   // varbinary
   std::vector<int8_t> varbinary_val(3);
   SQLLEN buf_len = varbinary_val.size();
   SQLLEN ind;
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(stmt, 1, SQL_C_BINARY, &varbinary_val[0], buf_len, &ind));
+            SQLGetData(this->stmt, 1, SQL_C_BINARY, &varbinary_val[0], buf_len, &ind));
   EXPECT_EQ('\xAB', varbinary_val[0]);
   EXPECT_EQ('\xCD', varbinary_val[1]);
   EXPECT_EQ('\xEF', varbinary_val[2]);
@@ -405,9 +421,9 @@ TEST_F(StatementRemoteTest, TestSQLExecDirectDataQueryDefaultType) {
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
   // Numeric Types
   // Signed Integer
@@ -415,10 +431,12 @@ TEST_F(StatementRemoteTest, TestSQLExecDirectDataQueryDefaultType) {
   SQLLEN buf_len = sizeof(slong_val);
   SQLLEN ind;
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 9, SQL_C_DEFAULT, &slong_val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetData(this->stmt, 9, SQL_C_DEFAULT, &slong_val, buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<SQLINTEGER>::min(), slong_val);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 10, SQL_C_DEFAULT, &slong_val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetData(this->stmt, 10, SQL_C_DEFAULT, &slong_val, buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<SQLINTEGER>::max(), slong_val);
 
   // Signed Big Int
@@ -426,11 +444,11 @@ TEST_F(StatementRemoteTest, TestSQLExecDirectDataQueryDefaultType) {
   buf_len = sizeof(sbig_int_val);
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(stmt, 13, SQL_C_DEFAULT, &sbig_int_val, buf_len, &ind));
+            SQLGetData(this->stmt, 13, SQL_C_DEFAULT, &sbig_int_val, buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<SQLBIGINT>::min(), sbig_int_val);
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(stmt, 14, SQL_C_DEFAULT, &sbig_int_val, buf_len, &ind));
+            SQLGetData(this->stmt, 14, SQL_C_DEFAULT, &sbig_int_val, buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<SQLBIGINT>::max(), sbig_int_val);
 
   // Decimal
@@ -439,7 +457,7 @@ TEST_F(StatementRemoteTest, TestSQLExecDirectDataQueryDefaultType) {
   buf_len = sizeof(SQL_NUMERIC_STRUCT);
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(stmt, 17, SQL_C_DEFAULT, &decimal_val, buf_len, &ind));
+            SQLGetData(this->stmt, 17, SQL_C_DEFAULT, &decimal_val, buf_len, &ind));
   // Check for negative decimal_val value
   EXPECT_EQ(0, decimal_val.sign);
   EXPECT_EQ(0, decimal_val.scale);
@@ -449,7 +467,7 @@ TEST_F(StatementRemoteTest, TestSQLExecDirectDataQueryDefaultType) {
 
   memset(&decimal_val, 0, sizeof(decimal_val));
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(stmt, 18, SQL_C_DEFAULT, &decimal_val, buf_len, &ind));
+            SQLGetData(this->stmt, 18, SQL_C_DEFAULT, &decimal_val, buf_len, &ind));
   // Check for positive decimal_val value
   EXPECT_EQ(1, decimal_val.sign);
   EXPECT_EQ(0, decimal_val.scale);
@@ -461,32 +479,38 @@ TEST_F(StatementRemoteTest, TestSQLExecDirectDataQueryDefaultType) {
   float float_val;
   buf_len = sizeof(float_val);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 19, SQL_C_DEFAULT, &float_val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetData(this->stmt, 19, SQL_C_DEFAULT, &float_val, buf_len, &ind));
   // Get minimum negative float value
   EXPECT_EQ(-std::numeric_limits<float>::max(), float_val);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 20, SQL_C_DEFAULT, &float_val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetData(this->stmt, 20, SQL_C_DEFAULT, &float_val, buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<float>::max(), float_val);
 
   // Double
   SQLDOUBLE double_val;
   buf_len = sizeof(double_val);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 21, SQL_C_DEFAULT, &double_val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetData(this->stmt, 21, SQL_C_DEFAULT, &double_val, buf_len, &ind));
   // Get minimum negative double value
   EXPECT_EQ(-std::numeric_limits<SQLDOUBLE>::max(), double_val);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 22, SQL_C_DEFAULT, &double_val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetData(this->stmt, 22, SQL_C_DEFAULT, &double_val, buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<SQLDOUBLE>::max(), double_val);
 
   // Bit
   bool bit_val;
   buf_len = sizeof(bit_val);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 23, SQL_C_DEFAULT, &bit_val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetData(this->stmt, 23, SQL_C_DEFAULT, &bit_val, buf_len, &ind));
   EXPECT_EQ(false, bit_val);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 24, SQL_C_DEFAULT, &bit_val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetData(this->stmt, 24, SQL_C_DEFAULT, &bit_val, buf_len, &ind));
   EXPECT_EQ(true, bit_val);
 
   // Characters
@@ -496,13 +520,15 @@ TEST_F(StatementRemoteTest, TestSQLExecDirectDataQueryDefaultType) {
   size_t wchar_size = GetSqlWCharSize();
   buf_len = wchar_size * 2;
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 25, SQL_C_DEFAULT, &wchar_val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetData(this->stmt, 25, SQL_C_DEFAULT, &wchar_val, buf_len, &ind));
   EXPECT_EQ(L'Z', wchar_val[0]);
 
   // WChar
   SQLWCHAR wchar_val2[2];
   buf_len = wchar_size * 2;
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 26, SQL_C_DEFAULT, &wchar_val2, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetData(this->stmt, 26, SQL_C_DEFAULT, &wchar_val2, buf_len, &ind));
   EXPECT_EQ(L'你', wchar_val2[0]);
 
   // WVarchar
@@ -510,7 +536,7 @@ TEST_F(StatementRemoteTest, TestSQLExecDirectDataQueryDefaultType) {
   buf_len = wchar_size * 3;
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(stmt, 27, SQL_C_DEFAULT, &wvarchar_val, buf_len, &ind));
+            SQLGetData(this->stmt, 27, SQL_C_DEFAULT, &wvarchar_val, buf_len, &ind));
   EXPECT_EQ(L'你', wvarchar_val[0]);
   EXPECT_EQ(L'好', wvarchar_val[1]);
 
@@ -519,7 +545,7 @@ TEST_F(StatementRemoteTest, TestSQLExecDirectDataQueryDefaultType) {
   buf_len = wchar_size * 4;
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(stmt, 28, SQL_C_DEFAULT, &wvarchar_val2, buf_len, &ind));
+            SQLGetData(this->stmt, 28, SQL_C_DEFAULT, &wvarchar_val2, buf_len, &ind));
   EXPECT_EQ(L'X', wvarchar_val2[0]);
   EXPECT_EQ(L'Y', wvarchar_val2[1]);
   EXPECT_EQ(L'Z', wvarchar_val2[2]);
@@ -530,13 +556,15 @@ TEST_F(StatementRemoteTest, TestSQLExecDirectDataQueryDefaultType) {
   SQL_DATE_STRUCT date_var{};
   buf_len = sizeof(date_var);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 29, SQL_C_DEFAULT, &date_var, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetData(this->stmt, 29, SQL_C_DEFAULT, &date_var, buf_len, &ind));
   // Check min values for date. Min valid year is 1400.
   EXPECT_EQ(1, date_var.day);
   EXPECT_EQ(1, date_var.month);
   EXPECT_EQ(1400, date_var.year);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 30, SQL_C_DEFAULT, &date_var, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetData(this->stmt, 30, SQL_C_DEFAULT, &date_var, buf_len, &ind));
   // Check max values for date. Max valid year is 9999.
   EXPECT_EQ(31, date_var.day);
   EXPECT_EQ(12, date_var.month);
@@ -547,7 +575,7 @@ TEST_F(StatementRemoteTest, TestSQLExecDirectDataQueryDefaultType) {
   buf_len = sizeof(timestamp_var);
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(stmt, 31, SQL_C_DEFAULT, &timestamp_var, buf_len, &ind));
+            SQLGetData(this->stmt, 31, SQL_C_DEFAULT, &timestamp_var, buf_len, &ind));
   // Check min values for date. Min valid year is 1400.
   EXPECT_EQ(1, timestamp_var.day);
   EXPECT_EQ(1, timestamp_var.month);
@@ -558,7 +586,7 @@ TEST_F(StatementRemoteTest, TestSQLExecDirectDataQueryDefaultType) {
   EXPECT_EQ(0, timestamp_var.fraction);
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(stmt, 32, SQL_C_DEFAULT, &timestamp_var, buf_len, &ind));
+            SQLGetData(this->stmt, 32, SQL_C_DEFAULT, &timestamp_var, buf_len, &ind));
   // Check max values for date. Max valid year is 9999.
   EXPECT_EQ(31, timestamp_var.day);
   EXPECT_EQ(12, timestamp_var.month);
@@ -580,21 +608,23 @@ TEST_F(StatementRemoteTest, TestSQLExecDirectTimeQueryDefaultType) {
    )";
   SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
   SQL_TIME_STRUCT time_var{};
   SQLLEN buf_len = sizeof(time_var);
   SQLLEN ind;
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 1, SQL_C_DEFAULT, &time_var, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetData(this->stmt, 1, SQL_C_DEFAULT, &time_var, buf_len, &ind));
   // Check min values for time.
   EXPECT_EQ(0, time_var.hour);
   EXPECT_EQ(0, time_var.minute);
   EXPECT_EQ(0, time_var.second);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 2, SQL_C_DEFAULT, &time_var, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetData(this->stmt, 2, SQL_C_DEFAULT, &time_var, buf_len, &ind));
   // Check max values for time.
   EXPECT_EQ(23, time_var.hour);
   EXPECT_EQ(59, time_var.minute);
@@ -609,16 +639,16 @@ TEST_F(StatementRemoteTest, TestSQLExecDirectVarbinaryQueryDefaultType) {
   SQLWCHAR wsql[] = L"SELECT from_hex('ABCDEF') AS c_varbinary;";
   SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
   // varbinary
   std::vector<int8_t> varbinary_val(3);
   SQLLEN buf_len = varbinary_val.size();
   SQLLEN ind;
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(stmt, 1, SQL_C_DEFAULT, &varbinary_val[0], buf_len, &ind));
+            SQLGetData(this->stmt, 1, SQL_C_DEFAULT, &varbinary_val[0], buf_len, &ind));
   EXPECT_EQ('\xAB', varbinary_val[0]);
   EXPECT_EQ('\xCD', varbinary_val[1]);
   EXPECT_EQ('\xEF', varbinary_val[2]);
@@ -630,15 +660,16 @@ TYPED_TEST(StatementTest, DISABLED_TestGetDataPrecisionScaleUsesIRDAsDefault) {
   SQLWCHAR wsql[] = L"SELECT CAST('123.45' AS NUMERIC) as decimal_col;";
   SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
   // Get precision and scale from IRD
   SQLLEN ird_precision = 0;
   SQLLEN ird_scale = 0;
   SQLHDESC ird = nullptr;
-  ASSERT_EQ(SQL_SUCCESS, SQLGetStmtAttr(stmt, SQL_ATTR_IMP_ROW_DESC, &ird, 0, nullptr));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetStmtAttr(this->stmt, SQL_ATTR_IMP_ROW_DESC, &ird, 0, nullptr));
   ASSERT_EQ(SQL_SUCCESS,
             SQLGetDescField(ird, 1, SQL_DESC_PRECISION, &ird_precision, 0, nullptr));
   ASSERT_EQ(SQL_SUCCESS, SQLGetDescField(ird, 1, SQL_DESC_SCALE, &ird_scale, 0, nullptr));
@@ -647,7 +678,7 @@ TYPED_TEST(StatementTest, DISABLED_TestGetDataPrecisionScaleUsesIRDAsDefault) {
   SQL_NUMERIC_STRUCT numeric_val;
   memset(&numeric_val, 0, sizeof(numeric_val));
   SQLLEN indicator;
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 1, SQL_C_NUMERIC, &numeric_val,
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 1, SQL_C_NUMERIC, &numeric_val,
                                     sizeof(SQL_NUMERIC_STRUCT), &indicator));
   EXPECT_EQ(static_cast<SQLSMALLINT>(ird_precision), numeric_val.precision);
   EXPECT_EQ(static_cast<SQLSMALLINT>(ird_scale), numeric_val.scale);
@@ -655,14 +686,15 @@ TYPED_TEST(StatementTest, DISABLED_TestGetDataPrecisionScaleUsesIRDAsDefault) {
   // Test with SQL_C_DEFAULT when ARD is unset (0) - should fall back to IRD
   // precision/scale
   SQLHDESC ard = nullptr;
-  ASSERT_EQ(SQL_SUCCESS, SQLGetStmtAttr(stmt, SQL_ATTR_APP_ROW_DESC, &ard, 0, nullptr));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetStmtAttr(this->stmt, SQL_ATTR_APP_ROW_DESC, &ard, 0, nullptr));
   ASSERT_EQ(SQL_SUCCESS, SQLSetDescField(ard, 1, SQL_DESC_PRECISION,
                                          reinterpret_cast<SQLPOINTER>(0), 0));
   ASSERT_EQ(SQL_SUCCESS,
             SQLSetDescField(ard, 1, SQL_DESC_SCALE, reinterpret_cast<SQLPOINTER>(0), 0));
 
   memset(&numeric_val, 0, sizeof(numeric_val));
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 1, SQL_C_DEFAULT, &numeric_val,
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 1, SQL_C_DEFAULT, &numeric_val,
                                     sizeof(SQL_NUMERIC_STRUCT), &indicator));
   EXPECT_EQ(static_cast<SQLSMALLINT>(ird_precision), numeric_val.precision);
   EXPECT_EQ(static_cast<SQLSMALLINT>(ird_scale), numeric_val.scale);
@@ -675,12 +707,13 @@ TYPED_TEST(StatementTest, DISABLED_TestGetDataPrecisionScaleUsesARDWhenSet) {
   SQLWCHAR wsql[] = L"SELECT CAST('123.45' AS NUMERIC) as decimal_col;";
   SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
   SQLHDESC ard = nullptr;
-  ASSERT_EQ(SQL_SUCCESS, SQLGetStmtAttr(stmt, SQL_ATTR_APP_ROW_DESC, &ard, 0, nullptr));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetStmtAttr(this->stmt, SQL_ATTR_APP_ROW_DESC, &ard, 0, nullptr));
 
   // Test with SQL_ARD_TYPE
   SQLSMALLINT ard_precision = 15;
@@ -695,7 +728,7 @@ TYPED_TEST(StatementTest, DISABLED_TestGetDataPrecisionScaleUsesARDWhenSet) {
   SQL_NUMERIC_STRUCT numeric_val;
   memset(&numeric_val, 0, sizeof(numeric_val));
   SQLLEN indicator;
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 1, SQL_ARD_TYPE, &numeric_val,
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 1, SQL_ARD_TYPE, &numeric_val,
                                     sizeof(SQL_NUMERIC_STRUCT), &indicator));
   EXPECT_EQ(ard_precision, numeric_val.precision);
   EXPECT_EQ(ard_scale, numeric_val.scale);
@@ -709,7 +742,7 @@ TYPED_TEST(StatementTest, DISABLED_TestGetDataPrecisionScaleUsesARDWhenSet) {
                                          reinterpret_cast<SQLPOINTER>(ard_scale), 0));
 
   memset(&numeric_val, 0, sizeof(numeric_val));
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 1, SQL_C_DEFAULT, &numeric_val,
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 1, SQL_C_DEFAULT, &numeric_val,
                                     sizeof(SQL_NUMERIC_STRUCT), &indicator));
   EXPECT_EQ(ard_precision, numeric_val.precision);
   EXPECT_EQ(ard_scale, numeric_val.scale);
@@ -720,16 +753,16 @@ TYPED_TEST(StatementTest, TestSQLExecDirectGuidQueryUnsupported) {
   SQLWCHAR wsql[] = L"SELECT 'C77313CF-4E08-47CE-B6DF-94DD2FCF3541' AS guid;";
   SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
   SQLGUID guid_var;
   SQLLEN buf_len = sizeof(guid_var);
   SQLLEN ind;
-  ASSERT_EQ(SQL_ERROR, SQLGetData(stmt, 1, SQL_C_GUID, &guid_var, buf_len, &ind));
+  ASSERT_EQ(SQL_ERROR, SQLGetData(this->stmt, 1, SQL_C_GUID, &guid_var, buf_len, &ind));
   // GUID is not supported by ODBC
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorStateHY000);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorStateHY000);
 }
 
 TYPED_TEST(StatementTest, TestSQLExecDirectRowFetching) {
@@ -743,53 +776,53 @@ TYPED_TEST(StatementTest, TestSQLExecDirectRowFetching) {
  )";
   SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
   // Fetch row 1
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
   SQLINTEGER val;
   SQLLEN buf_len = sizeof(val);
   SQLLEN ind;
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 1, SQL_C_LONG, &val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 1, SQL_C_LONG, &val, buf_len, &ind));
 
   // Verify 1 is returned
   EXPECT_EQ(1, val);
 
   // Fetch row 2
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 1, SQL_C_LONG, &val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 1, SQL_C_LONG, &val, buf_len, &ind));
 
   // Verify 2 is returned
   EXPECT_EQ(2, val);
 
   // Fetch row 3
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 1, SQL_C_LONG, &val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 1, SQL_C_LONG, &val, buf_len, &ind));
 
   // Verify 3 is returned
   EXPECT_EQ(3, val);
 
   // Verify result set has no more data beyond row 3
-  ASSERT_EQ(SQL_NO_DATA, SQLFetch(stmt));
+  ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
 
 #ifdef __APPLE__
   // With iODBC we expect SQL_SUCCESS and the buffer unchanged in this situation.
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 1, SQL_C_LONG, &val, 0, nullptr));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 1, SQL_C_LONG, &val, 0, nullptr));
   EXPECT_EQ(3, val);
 #else
-  ASSERT_EQ(SQL_ERROR, SQLGetData(stmt, 1, SQL_C_LONG, &val, 0, &ind));
+  ASSERT_EQ(SQL_ERROR, SQLGetData(this->stmt, 1, SQL_C_LONG, &val, 0, &ind));
   // Invalid cursor state
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorState24000);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorState24000);
 #endif
 }
 
 TYPED_TEST(StatementTest, TestSQLFetchScrollRowFetching) {
   SQLLEN rows_fetched;
-  SQLSetStmtAttr(stmt, SQL_ATTR_ROWS_FETCHED_PTR, &rows_fetched, 0);
+  SQLSetStmtAttr(this->stmt, SQL_ATTR_ROWS_FETCHED_PTR, &rows_fetched, 0);
 
   SQLWCHAR wsql[] =
       LR"(
@@ -801,25 +834,25 @@ TYPED_TEST(StatementTest, TestSQLFetchScrollRowFetching) {
  )";
   SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
   // Fetch row 1
-  ASSERT_EQ(SQL_SUCCESS, SQLFetchScroll(stmt, SQL_FETCH_NEXT, 0));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetchScroll(this->stmt, SQL_FETCH_NEXT, 0));
 
   SQLINTEGER val;
   SQLLEN buf_len = sizeof(val);
   SQLLEN ind;
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 1, SQL_C_LONG, &val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 1, SQL_C_LONG, &val, buf_len, &ind));
   // Verify 1 is returned
   EXPECT_EQ(1, val);
   // Verify 1 row is fetched
   EXPECT_EQ(1, rows_fetched);
 
   // Fetch row 2
-  ASSERT_EQ(SQL_SUCCESS, SQLFetchScroll(stmt, SQL_FETCH_NEXT, 0));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetchScroll(this->stmt, SQL_FETCH_NEXT, 0));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 1, SQL_C_LONG, &val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 1, SQL_C_LONG, &val, buf_len, &ind));
 
   // Verify 2 is returned
   EXPECT_EQ(2, val);
@@ -827,9 +860,9 @@ TYPED_TEST(StatementTest, TestSQLFetchScrollRowFetching) {
   EXPECT_EQ(1, rows_fetched);
 
   // Fetch row 3
-  ASSERT_EQ(SQL_SUCCESS, SQLFetchScroll(stmt, SQL_FETCH_NEXT, 0));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetchScroll(this->stmt, SQL_FETCH_NEXT, 0));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 1, SQL_C_LONG, &val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 1, SQL_C_LONG, &val, buf_len, &ind));
 
   // Verify 3 is returned
   EXPECT_EQ(3, val);
@@ -837,16 +870,16 @@ TYPED_TEST(StatementTest, TestSQLFetchScrollRowFetching) {
   EXPECT_EQ(1, rows_fetched);
 
   // Verify result set has no more data beyond row 3
-  ASSERT_EQ(SQL_NO_DATA, SQLFetchScroll(stmt, SQL_FETCH_NEXT, 0));
+  ASSERT_EQ(SQL_NO_DATA, SQLFetchScroll(this->stmt, SQL_FETCH_NEXT, 0));
 
 #ifdef __APPLE__
   // With iODBC we expect SQL_SUCCESS and the buffer unchanged in this situation.
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 1, SQL_C_LONG, &val, 0, nullptr));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 1, SQL_C_LONG, &val, 0, nullptr));
   EXPECT_EQ(3, val);
 #else
-  ASSERT_EQ(SQL_ERROR, SQLGetData(stmt, 1, SQL_C_LONG, &val, 0, &ind));
+  ASSERT_EQ(SQL_ERROR, SQLGetData(this->stmt, 1, SQL_C_LONG, &val, 0, &ind));
   // Invalid cursor state
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorState24000);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorState24000);
 #endif
 }
 
@@ -856,36 +889,36 @@ TYPED_TEST(StatementTest, TestSQLFetchScrollUnsupportedOrientation) {
   SQLWCHAR wsql[] = L"SELECT 1;";
   SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
-  ASSERT_EQ(SQL_ERROR, SQLFetchScroll(stmt, SQL_FETCH_PRIOR, 0));
+  ASSERT_EQ(SQL_ERROR, SQLFetchScroll(this->stmt, SQL_FETCH_PRIOR, 0));
 
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorStateHYC00);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorStateHYC00);
 
   SQLLEN fetch_offset = 1;
-  ASSERT_EQ(SQL_ERROR, SQLFetchScroll(stmt, SQL_FETCH_RELATIVE, fetch_offset));
+  ASSERT_EQ(SQL_ERROR, SQLFetchScroll(this->stmt, SQL_FETCH_RELATIVE, fetch_offset));
 
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorStateHYC00);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorStateHYC00);
 
-  ASSERT_EQ(SQL_ERROR, SQLFetchScroll(stmt, SQL_FETCH_ABSOLUTE, fetch_offset));
+  ASSERT_EQ(SQL_ERROR, SQLFetchScroll(this->stmt, SQL_FETCH_ABSOLUTE, fetch_offset));
 
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorStateHYC00);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorStateHYC00);
 
-  ASSERT_EQ(SQL_ERROR, SQLFetchScroll(stmt, SQL_FETCH_FIRST, 0));
+  ASSERT_EQ(SQL_ERROR, SQLFetchScroll(this->stmt, SQL_FETCH_FIRST, 0));
 
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorStateHYC00);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorStateHYC00);
 
-  ASSERT_EQ(SQL_ERROR, SQLFetchScroll(stmt, SQL_FETCH_LAST, 0));
+  ASSERT_EQ(SQL_ERROR, SQLFetchScroll(this->stmt, SQL_FETCH_LAST, 0));
 
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorStateHYC00);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorStateHYC00);
 
-  ASSERT_EQ(SQL_ERROR, SQLFetchScroll(stmt, SQL_FETCH_BOOKMARK, fetch_offset));
+  ASSERT_EQ(SQL_ERROR, SQLFetchScroll(this->stmt, SQL_FETCH_BOOKMARK, fetch_offset));
 
 #ifdef __APPLE__
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorStateHYC00);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorStateHYC00);
 #else
   // Windows DM returns state HY106 for SQL_FETCH_BOOKMARK
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorStateHY106);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorStateHY106);
 #endif  // __APPLE__
 }
 
@@ -893,18 +926,18 @@ TYPED_TEST(StatementTest, TestSQLExecDirectVarcharTruncation) {
   SQLWCHAR wsql[] = L"SELECT 'VERY LONG STRING here' AS string_col;";
   SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
   const int len = 17;
   SQLCHAR char_val[len];
   SQLLEN buf_len = sizeof(SQLCHAR) * len;
   SQLLEN ind;
   ASSERT_EQ(SQL_SUCCESS_WITH_INFO,
-            SQLGetData(stmt, 1, SQL_C_CHAR, &char_val, buf_len, &ind));
+            SQLGetData(this->stmt, 1, SQL_C_CHAR, &char_val, buf_len, &ind));
   // Verify string truncation is reported
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorState01004);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorState01004);
 
   EXPECT_EQ(std::string("VERY LONG STRING"), ODBC::SqlStringToString(char_val));
   EXPECT_EQ(21, ind);
@@ -914,9 +947,9 @@ TYPED_TEST(StatementTest, TestSQLExecDirectVarcharTruncation) {
   SQLCHAR char_val2[len2];
   buf_len = sizeof(SQLCHAR) * len2;
   ASSERT_EQ(SQL_SUCCESS_WITH_INFO,
-            SQLGetData(stmt, 1, SQL_C_CHAR, &char_val2, buf_len, &ind));
+            SQLGetData(this->stmt, 1, SQL_C_CHAR, &char_val2, buf_len, &ind));
   // Verify string truncation is reported
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorState01004);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorState01004);
 
   EXPECT_EQ(std::string(" "), ODBC::SqlStringToString(char_val2));
   EXPECT_EQ(5, ind);
@@ -927,7 +960,8 @@ TYPED_TEST(StatementTest, TestSQLExecDirectVarcharTruncation) {
   buf_len = sizeof(SQLCHAR) * len3;
 
   // Verify that there is no more truncation reports. The full string has been fetched.
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 1, SQL_C_CHAR, &char_val3, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetData(this->stmt, 1, SQL_C_CHAR, &char_val3, buf_len, &ind));
 
   EXPECT_EQ(std::string("here"), ODBC::SqlStringToString(char_val3));
   EXPECT_EQ(4, ind);
@@ -935,16 +969,16 @@ TYPED_TEST(StatementTest, TestSQLExecDirectVarcharTruncation) {
   // Attempt to fetch data 4th time
   SQLCHAR char_val4[len];
   // Verify SQL_NO_DATA is returned
-  ASSERT_EQ(SQL_NO_DATA, SQLGetData(stmt, 1, SQL_C_CHAR, &char_val4, 0, &ind));
+  ASSERT_EQ(SQL_NO_DATA, SQLGetData(this->stmt, 1, SQL_C_CHAR, &char_val4, 0, &ind));
 }
 
 TYPED_TEST(StatementTest, TestSQLExecDirectWVarcharTruncation) {
   SQLWCHAR wsql[] = L"SELECT 'VERY LONG Unicode STRING 句子 here' AS wstring_col;";
   SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
   const int len = 28;
   SQLWCHAR wchar_val[len];
@@ -952,9 +986,9 @@ TYPED_TEST(StatementTest, TestSQLExecDirectWVarcharTruncation) {
   SQLLEN buf_len = wchar_size * len;
   SQLLEN ind;
   ASSERT_EQ(SQL_SUCCESS_WITH_INFO,
-            SQLGetData(stmt, 1, SQL_C_WCHAR, &wchar_val, buf_len, &ind));
+            SQLGetData(this->stmt, 1, SQL_C_WCHAR, &wchar_val, buf_len, &ind));
   // Verify string truncation is reported
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorState01004);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorState01004);
 
   EXPECT_EQ(std::wstring(L"VERY LONG Unicode STRING 句子"), std::wstring(wchar_val));
   EXPECT_EQ(32 * wchar_size, ind);
@@ -964,9 +998,9 @@ TYPED_TEST(StatementTest, TestSQLExecDirectWVarcharTruncation) {
   SQLWCHAR wchar_val2[len2];
   buf_len = wchar_size * len2;
   ASSERT_EQ(SQL_SUCCESS_WITH_INFO,
-            SQLGetData(stmt, 1, SQL_C_WCHAR, &wchar_val2, buf_len, &ind));
+            SQLGetData(this->stmt, 1, SQL_C_WCHAR, &wchar_val2, buf_len, &ind));
   // Verify string truncation is reported
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorState01004);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorState01004);
 
   EXPECT_EQ(std::wstring(L" "), std::wstring(wchar_val2));
   EXPECT_EQ(5 * wchar_size, ind);
@@ -977,7 +1011,8 @@ TYPED_TEST(StatementTest, TestSQLExecDirectWVarcharTruncation) {
   buf_len = wchar_size * len3;
 
   // Verify that there is no more truncation reports. The full string has been fetched.
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 1, SQL_C_WCHAR, &wchar_val3, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLGetData(this->stmt, 1, SQL_C_WCHAR, &wchar_val3, buf_len, &ind));
 
   EXPECT_EQ(std::wstring(L"here"), std::wstring(wchar_val3));
   EXPECT_EQ(4 * wchar_size, ind);
@@ -985,7 +1020,7 @@ TYPED_TEST(StatementTest, TestSQLExecDirectWVarcharTruncation) {
   // Attempt to fetch data 4th time
   SQLWCHAR wchar_val4[len];
   // Verify SQL_NO_DATA is returned
-  ASSERT_EQ(SQL_NO_DATA, SQLGetData(stmt, 1, SQL_C_WCHAR, &wchar_val4, 0, &ind));
+  ASSERT_EQ(SQL_NO_DATA, SQLGetData(this->stmt, 1, SQL_C_WCHAR, &wchar_val4, 0, &ind));
 }
 
 TEST_F(StatementMockTest, TestSQLExecDirectVarbinaryTruncation) {
@@ -995,18 +1030,18 @@ TEST_F(StatementMockTest, TestSQLExecDirectVarbinaryTruncation) {
   SQLWCHAR wsql[] = L"SELECT X'ABCDEFAB' AS c_varbinary;";
   SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
   // varbinary
   std::vector<int8_t> varbinary_val(3);
   SQLLEN buf_len = varbinary_val.size();
   SQLLEN ind;
   ASSERT_EQ(SQL_SUCCESS_WITH_INFO,
-            SQLGetData(stmt, 1, SQL_C_BINARY, &varbinary_val[0], buf_len, &ind));
+            SQLGetData(this->stmt, 1, SQL_C_BINARY, &varbinary_val[0], buf_len, &ind));
   // Verify binary truncation is reported
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorState01004);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorState01004);
   EXPECT_EQ('\xAB', varbinary_val[0]);
   EXPECT_EQ('\xCD', varbinary_val[1]);
   EXPECT_EQ('\xEF', varbinary_val[2]);
@@ -1018,7 +1053,7 @@ TEST_F(StatementMockTest, TestSQLExecDirectVarbinaryTruncation) {
 
   // Verify that there is no more truncation reports. The full binary has been fetched.
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(stmt, 1, SQL_C_BINARY, &varbinary_val2[0], buf_len, &ind));
+            SQLGetData(this->stmt, 1, SQL_C_BINARY, &varbinary_val2[0], buf_len, &ind));
 
   EXPECT_EQ('\xAB', varbinary_val[0]);
   EXPECT_EQ(1, ind);
@@ -1028,7 +1063,7 @@ TEST_F(StatementMockTest, TestSQLExecDirectVarbinaryTruncation) {
   buf_len = varbinary_val3.size();
   // Verify SQL_NO_DATA is returned
   ASSERT_EQ(SQL_NO_DATA,
-            SQLGetData(stmt, 1, SQL_C_BINARY, &varbinary_val3[0], buf_len, &ind));
+            SQLGetData(this->stmt, 1, SQL_C_BINARY, &varbinary_val3[0], buf_len, &ind));
 }
 
 TYPED_TEST(StatementTest, DISABLED_TestSQLExecDirectFloatTruncation) {
@@ -1043,16 +1078,16 @@ TYPED_TEST(StatementTest, DISABLED_TestSQLExecDirectFloatTruncation) {
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
   int16_t ssmall_int_val;
 
   ASSERT_EQ(SQL_SUCCESS_WITH_INFO,
-            SQLGetData(stmt, 1, SQL_C_SSHORT, &ssmall_int_val, 0, nullptr));
+            SQLGetData(this->stmt, 1, SQL_C_SSHORT, &ssmall_int_val, 0, nullptr));
   // Verify float truncation is reported
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorState01S07);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorState01S07);
 
   EXPECT_EQ(1, ssmall_int_val);
 }
@@ -1064,14 +1099,14 @@ TEST_F(StatementRemoteTest, TestSQLExecDirectNullQuery) {
   SQLWCHAR wsql[] = L"SELECT null as null_col;";
   SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
   SQLINTEGER val;
   SQLLEN ind;
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 1, SQL_C_LONG, &val, 0, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 1, SQL_C_LONG, &val, 0, &ind));
 
   // Verify SQL_NULL_DATA is returned for indicator
   EXPECT_EQ(SQL_NULL_DATA, ind);
@@ -1091,12 +1126,12 @@ TEST_F(StatementMockTest, TestSQLExecDirectTruncationQueryNullIndicator) {
  )";
   SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
   SQLINTEGER val;
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 1, SQL_C_LONG, &val, 0, nullptr));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 1, SQL_C_LONG, &val, 0, nullptr));
   // Verify 1 is returned for non-truncation case.
   EXPECT_EQ(1, val);
 
@@ -1105,9 +1140,9 @@ TEST_F(StatementMockTest, TestSQLExecDirectTruncationQueryNullIndicator) {
   SQLCHAR char_val[len];
   SQLLEN buf_len = sizeof(SQLCHAR) * len;
   ASSERT_EQ(SQL_SUCCESS_WITH_INFO,
-            SQLGetData(stmt, 2, SQL_C_CHAR, &char_val, buf_len, nullptr));
+            SQLGetData(this->stmt, 2, SQL_C_CHAR, &char_val, buf_len, nullptr));
   // Verify string truncation is reported
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorState01004);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorState01004);
 
   // WChar
   const int len2 = 28;
@@ -1115,17 +1150,17 @@ TEST_F(StatementMockTest, TestSQLExecDirectTruncationQueryNullIndicator) {
   size_t wchar_size = GetSqlWCharSize();
   buf_len = wchar_size * len2;
   ASSERT_EQ(SQL_SUCCESS_WITH_INFO,
-            SQLGetData(stmt, 3, SQL_C_WCHAR, &wchar_val, buf_len, nullptr));
+            SQLGetData(this->stmt, 3, SQL_C_WCHAR, &wchar_val, buf_len, nullptr));
   // Verify string truncation is reported
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorState01004);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorState01004);
 
   // varbinary
   std::vector<int8_t> varbinary_val(3);
   buf_len = varbinary_val.size();
   ASSERT_EQ(SQL_SUCCESS_WITH_INFO,
-            SQLGetData(stmt, 4, SQL_C_BINARY, &varbinary_val[0], buf_len, nullptr));
+            SQLGetData(this->stmt, 4, SQL_C_BINARY, &varbinary_val[0], buf_len, nullptr));
   // Verify binary truncation is reported
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorState01004);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorState01004);
 }
 
 TEST_F(StatementRemoteTest, TestSQLExecDirectNullQueryNullIndicator) {
@@ -1135,15 +1170,15 @@ TEST_F(StatementRemoteTest, TestSQLExecDirectNullQueryNullIndicator) {
   SQLWCHAR wsql[] = L"SELECT null as null_col;";
   SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
   SQLINTEGER val;
 
-  ASSERT_EQ(SQL_ERROR, SQLGetData(stmt, 1, SQL_C_LONG, &val, 0, nullptr));
+  ASSERT_EQ(SQL_ERROR, SQLGetData(this->stmt, 1, SQL_C_LONG, &val, 0, nullptr));
   // Verify invalid null indicator is reported, as it is required
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorState22002);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorState22002);
 }
 
 // MacOS Driver Manager iODBC returns SQL_ERROR when invalid buffer length is provided to
@@ -1156,9 +1191,9 @@ TYPED_TEST(StatementTest, TestSQLExecDirectIgnoreInvalidBufLen) {
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
   // Numeric Types
 
@@ -1167,91 +1202,91 @@ TYPED_TEST(StatementTest, TestSQLExecDirectIgnoreInvalidBufLen) {
   SQLLEN invalid_buf_len = -1;
   SQLLEN ind;
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(stmt, 1, SQL_C_STINYINT, &stiny_int_val, invalid_buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 1, SQL_C_STINYINT, &stiny_int_val,
+                                    invalid_buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<int8_t>::min(), stiny_int_val);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(stmt, 2, SQL_C_STINYINT, &stiny_int_val, invalid_buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 2, SQL_C_STINYINT, &stiny_int_val,
+                                    invalid_buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<int8_t>::max(), stiny_int_val);
 
   // Unsigned Tiny Int
   uint8_t utiny_int_val;
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(stmt, 3, SQL_C_UTINYINT, &utiny_int_val, invalid_buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 3, SQL_C_UTINYINT, &utiny_int_val,
+                                    invalid_buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<uint8_t>::min(), utiny_int_val);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(stmt, 4, SQL_C_UTINYINT, &utiny_int_val, invalid_buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 4, SQL_C_UTINYINT, &utiny_int_val,
+                                    invalid_buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<uint8_t>::max(), utiny_int_val);
 
   // Signed Small Int
   int16_t ssmall_int_val;
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(stmt, 5, SQL_C_SSHORT, &ssmall_int_val, invalid_buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 5, SQL_C_SSHORT, &ssmall_int_val,
+                                    invalid_buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<int16_t>::min(), ssmall_int_val);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(stmt, 6, SQL_C_SSHORT, &ssmall_int_val, invalid_buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 6, SQL_C_SSHORT, &ssmall_int_val,
+                                    invalid_buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<int16_t>::max(), ssmall_int_val);
 
   // Unsigned Small Int
   uint16_t usmall_int_val;
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(stmt, 7, SQL_C_USHORT, &usmall_int_val, invalid_buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 7, SQL_C_USHORT, &usmall_int_val,
+                                    invalid_buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<uint16_t>::min(), usmall_int_val);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(stmt, 8, SQL_C_USHORT, &usmall_int_val, invalid_buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 8, SQL_C_USHORT, &usmall_int_val,
+                                    invalid_buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<uint16_t>::max(), usmall_int_val);
 
   // Signed Integer
   SQLINTEGER slong_val;
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(stmt, 9, SQL_C_SLONG, &slong_val, invalid_buf_len, &ind));
+            SQLGetData(this->stmt, 9, SQL_C_SLONG, &slong_val, invalid_buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<SQLINTEGER>::min(), slong_val);
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(stmt, 10, SQL_C_SLONG, &slong_val, invalid_buf_len, &ind));
+            SQLGetData(this->stmt, 10, SQL_C_SLONG, &slong_val, invalid_buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<SQLINTEGER>::max(), slong_val);
 
   // Unsigned Integer
   SQLUINTEGER ulong_val;
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(stmt, 11, SQL_C_ULONG, &ulong_val, invalid_buf_len, &ind));
+            SQLGetData(this->stmt, 11, SQL_C_ULONG, &ulong_val, invalid_buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<SQLUINTEGER>::min(), ulong_val);
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(stmt, 12, SQL_C_ULONG, &ulong_val, invalid_buf_len, &ind));
+            SQLGetData(this->stmt, 12, SQL_C_ULONG, &ulong_val, invalid_buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<SQLUINTEGER>::max(), ulong_val);
 
   // Signed Big Int
   SQLBIGINT sbig_int_val;
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(stmt, 13, SQL_C_SBIGINT, &sbig_int_val, invalid_buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 13, SQL_C_SBIGINT, &sbig_int_val,
+                                    invalid_buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<SQLBIGINT>::min(), sbig_int_val);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(stmt, 14, SQL_C_SBIGINT, &sbig_int_val, invalid_buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 14, SQL_C_SBIGINT, &sbig_int_val,
+                                    invalid_buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<SQLBIGINT>::max(), sbig_int_val);
 
   // Unsigned Big Int
   SQLUBIGINT ubig_int_val;
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(stmt, 15, SQL_C_UBIGINT, &ubig_int_val, invalid_buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 15, SQL_C_UBIGINT, &ubig_int_val,
+                                    invalid_buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<SQLUBIGINT>::min(), ubig_int_val);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(stmt, 16, SQL_C_UBIGINT, &ubig_int_val, invalid_buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 16, SQL_C_UBIGINT, &ubig_int_val,
+                                    invalid_buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<SQLUBIGINT>::max(), ubig_int_val);
 
   // Decimal
   SQL_NUMERIC_STRUCT decimal_val;
   memset(&decimal_val, 0, sizeof(decimal_val));
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(stmt, 17, SQL_C_NUMERIC, &decimal_val, invalid_buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 17, SQL_C_NUMERIC, &decimal_val,
+                                    invalid_buf_len, &ind));
   // Check for negative decimal_val value
   EXPECT_EQ(0, decimal_val.sign);
   EXPECT_EQ(0, decimal_val.scale);
@@ -1261,8 +1296,8 @@ TYPED_TEST(StatementTest, TestSQLExecDirectIgnoreInvalidBufLen) {
 
   memset(&decimal_val, 0, sizeof(decimal_val));
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(stmt, 18, SQL_C_NUMERIC, &decimal_val, invalid_buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 18, SQL_C_NUMERIC, &decimal_val,
+                                    invalid_buf_len, &ind));
   // Check for positive decimal_val value
   EXPECT_EQ(1, decimal_val.sign);
   EXPECT_EQ(0, decimal_val.scale);
@@ -1274,48 +1309,48 @@ TYPED_TEST(StatementTest, TestSQLExecDirectIgnoreInvalidBufLen) {
   float float_val;
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(stmt, 19, SQL_C_FLOAT, &float_val, invalid_buf_len, &ind));
+            SQLGetData(this->stmt, 19, SQL_C_FLOAT, &float_val, invalid_buf_len, &ind));
   // Get minimum negative float value
   EXPECT_EQ(-std::numeric_limits<float>::max(), float_val);
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(stmt, 20, SQL_C_FLOAT, &float_val, invalid_buf_len, &ind));
+            SQLGetData(this->stmt, 20, SQL_C_FLOAT, &float_val, invalid_buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<float>::max(), float_val);
 
   // Double
   SQLDOUBLE double_val;
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(stmt, 21, SQL_C_DOUBLE, &double_val, invalid_buf_len, &ind));
+            SQLGetData(this->stmt, 21, SQL_C_DOUBLE, &double_val, invalid_buf_len, &ind));
   // Get minimum negative double value
   EXPECT_EQ(-std::numeric_limits<SQLDOUBLE>::max(), double_val);
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(stmt, 22, SQL_C_DOUBLE, &double_val, invalid_buf_len, &ind));
+            SQLGetData(this->stmt, 22, SQL_C_DOUBLE, &double_val, invalid_buf_len, &ind));
   EXPECT_EQ(std::numeric_limits<SQLDOUBLE>::max(), double_val);
 
   // Bit
   bool bit_val;
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(stmt, 23, SQL_C_BIT, &bit_val, invalid_buf_len, &ind));
+            SQLGetData(this->stmt, 23, SQL_C_BIT, &bit_val, invalid_buf_len, &ind));
   EXPECT_EQ(false, bit_val);
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(stmt, 24, SQL_C_BIT, &bit_val, invalid_buf_len, &ind));
+            SQLGetData(this->stmt, 24, SQL_C_BIT, &bit_val, invalid_buf_len, &ind));
   EXPECT_EQ(true, bit_val);
 
   // Date and Timestamp
 
   // Date
   SQL_DATE_STRUCT date_var{};
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(stmt, 29, SQL_C_TYPE_DATE, &date_var, invalid_buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 29, SQL_C_TYPE_DATE, &date_var,
+                                    invalid_buf_len, &ind));
   // Check min values for date. Min valid year is 1400.
   EXPECT_EQ(1, date_var.day);
   EXPECT_EQ(1, date_var.month);
   EXPECT_EQ(1400, date_var.year);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLGetData(stmt, 30, SQL_C_TYPE_DATE, &date_var, invalid_buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 30, SQL_C_TYPE_DATE, &date_var,
+                                    invalid_buf_len, &ind));
   // Check max values for date. Max valid year is 9999.
   EXPECT_EQ(31, date_var.day);
   EXPECT_EQ(12, date_var.month);
@@ -1324,7 +1359,7 @@ TYPED_TEST(StatementTest, TestSQLExecDirectIgnoreInvalidBufLen) {
   // Timestamp
   SQL_TIMESTAMP_STRUCT timestamp_var{};
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 31, SQL_C_TYPE_TIMESTAMP, &timestamp_var,
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 31, SQL_C_TYPE_TIMESTAMP, &timestamp_var,
                                     invalid_buf_len, &ind));
   // Check min values for date. Min valid year is 1400.
   EXPECT_EQ(1, timestamp_var.day);
@@ -1335,7 +1370,7 @@ TYPED_TEST(StatementTest, TestSQLExecDirectIgnoreInvalidBufLen) {
   EXPECT_EQ(0, timestamp_var.second);
   EXPECT_EQ(0, timestamp_var.fraction);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetData(stmt, 32, SQL_C_TYPE_TIMESTAMP, &timestamp_var,
+  ASSERT_EQ(SQL_SUCCESS, SQLGetData(this->stmt, 32, SQL_C_TYPE_TIMESTAMP, &timestamp_var,
                                     invalid_buf_len, &ind));
   // Check max values for date. Max valid year is 9999.
   EXPECT_EQ(31, timestamp_var.day);
@@ -1358,79 +1393,80 @@ TYPED_TEST(StatementTest, TestSQLBindColDataQuery) {
   SQLLEN ind;
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(stmt, 1, SQL_C_STINYINT, &stiny_int_val_min, buf_len, &ind));
+            SQLBindCol(this->stmt, 1, SQL_C_STINYINT, &stiny_int_val_min, buf_len, &ind));
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(stmt, 2, SQL_C_STINYINT, &stiny_int_val_max, buf_len, &ind));
+            SQLBindCol(this->stmt, 2, SQL_C_STINYINT, &stiny_int_val_max, buf_len, &ind));
 
   // Unsigned Tiny Int
   uint8_t utiny_int_val_min;
   uint8_t utiny_int_val_max;
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(stmt, 3, SQL_C_UTINYINT, &utiny_int_val_min, buf_len, &ind));
+            SQLBindCol(this->stmt, 3, SQL_C_UTINYINT, &utiny_int_val_min, buf_len, &ind));
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(stmt, 4, SQL_C_UTINYINT, &utiny_int_val_max, buf_len, &ind));
+            SQLBindCol(this->stmt, 4, SQL_C_UTINYINT, &utiny_int_val_max, buf_len, &ind));
 
   // Signed Small Int
   int16_t ssmall_int_val_min;
   int16_t ssmall_int_val_max;
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(stmt, 5, SQL_C_SSHORT, &ssmall_int_val_min, buf_len, &ind));
+            SQLBindCol(this->stmt, 5, SQL_C_SSHORT, &ssmall_int_val_min, buf_len, &ind));
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(stmt, 6, SQL_C_SSHORT, &ssmall_int_val_max, buf_len, &ind));
+            SQLBindCol(this->stmt, 6, SQL_C_SSHORT, &ssmall_int_val_max, buf_len, &ind));
 
   // Unsigned Small Int
   uint16_t usmall_int_val_min;
   uint16_t usmall_int_val_max;
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(stmt, 7, SQL_C_USHORT, &usmall_int_val_min, buf_len, &ind));
+            SQLBindCol(this->stmt, 7, SQL_C_USHORT, &usmall_int_val_min, buf_len, &ind));
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(stmt, 8, SQL_C_USHORT, &usmall_int_val_max, buf_len, &ind));
+            SQLBindCol(this->stmt, 8, SQL_C_USHORT, &usmall_int_val_max, buf_len, &ind));
 
   // Signed Integer
   SQLINTEGER slong_val_min;
   SQLINTEGER slong_val_max;
 
-  ASSERT_EQ(SQL_SUCCESS, SQLBindCol(stmt, 9, SQL_C_SLONG, &slong_val_min, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLBindCol(this->stmt, 9, SQL_C_SLONG, &slong_val_min, buf_len, &ind));
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(stmt, 10, SQL_C_SLONG, &slong_val_max, buf_len, &ind));
+            SQLBindCol(this->stmt, 10, SQL_C_SLONG, &slong_val_max, buf_len, &ind));
 
   // Unsigned Integer
   SQLUINTEGER ulong_val_min;
   SQLUINTEGER ulong_val_max;
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(stmt, 11, SQL_C_ULONG, &ulong_val_min, buf_len, &ind));
+            SQLBindCol(this->stmt, 11, SQL_C_ULONG, &ulong_val_min, buf_len, &ind));
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(stmt, 12, SQL_C_ULONG, &ulong_val_max, buf_len, &ind));
+            SQLBindCol(this->stmt, 12, SQL_C_ULONG, &ulong_val_max, buf_len, &ind));
 
   // Signed Big Int
   SQLBIGINT sbig_int_val_min;
   SQLBIGINT sbig_int_val_max;
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(stmt, 13, SQL_C_SBIGINT, &sbig_int_val_min, buf_len, &ind));
+            SQLBindCol(this->stmt, 13, SQL_C_SBIGINT, &sbig_int_val_min, buf_len, &ind));
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(stmt, 14, SQL_C_SBIGINT, &sbig_int_val_max, buf_len, &ind));
+            SQLBindCol(this->stmt, 14, SQL_C_SBIGINT, &sbig_int_val_max, buf_len, &ind));
 
   // Unsigned Big Int
   SQLUBIGINT ubig_int_val_min;
   SQLUBIGINT ubig_int_val_max;
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(stmt, 15, SQL_C_UBIGINT, &ubig_int_val_min, buf_len, &ind));
+            SQLBindCol(this->stmt, 15, SQL_C_UBIGINT, &ubig_int_val_min, buf_len, &ind));
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(stmt, 16, SQL_C_UBIGINT, &ubig_int_val_max, buf_len, &ind));
+            SQLBindCol(this->stmt, 16, SQL_C_UBIGINT, &ubig_int_val_max, buf_len, &ind));
 
   // Decimal
   SQL_NUMERIC_STRUCT decimal_val_neg;
@@ -1439,87 +1475,93 @@ TYPED_TEST(StatementTest, TestSQLBindColDataQuery) {
   memset(&decimal_val_pos, 0, sizeof(decimal_val_pos));
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(stmt, 17, SQL_C_NUMERIC, &decimal_val_neg, buf_len, &ind));
+            SQLBindCol(this->stmt, 17, SQL_C_NUMERIC, &decimal_val_neg, buf_len, &ind));
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(stmt, 18, SQL_C_NUMERIC, &decimal_val_pos, buf_len, &ind));
+            SQLBindCol(this->stmt, 18, SQL_C_NUMERIC, &decimal_val_pos, buf_len, &ind));
 
   // Float
   float float_val_min;
   float float_val_max;
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(stmt, 19, SQL_C_FLOAT, &float_val_min, buf_len, &ind));
+            SQLBindCol(this->stmt, 19, SQL_C_FLOAT, &float_val_min, buf_len, &ind));
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(stmt, 20, SQL_C_FLOAT, &float_val_max, buf_len, &ind));
+            SQLBindCol(this->stmt, 20, SQL_C_FLOAT, &float_val_max, buf_len, &ind));
 
   // Double
   SQLDOUBLE double_val_min;
   SQLDOUBLE double_val_max;
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(stmt, 21, SQL_C_DOUBLE, &double_val_min, buf_len, &ind));
+            SQLBindCol(this->stmt, 21, SQL_C_DOUBLE, &double_val_min, buf_len, &ind));
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(stmt, 22, SQL_C_DOUBLE, &double_val_max, buf_len, &ind));
+            SQLBindCol(this->stmt, 22, SQL_C_DOUBLE, &double_val_max, buf_len, &ind));
 
   // Bit
   bool bit_val_false;
   bool bit_val_true;
 
-  ASSERT_EQ(SQL_SUCCESS, SQLBindCol(stmt, 23, SQL_C_BIT, &bit_val_false, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLBindCol(this->stmt, 23, SQL_C_BIT, &bit_val_false, buf_len, &ind));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLBindCol(stmt, 24, SQL_C_BIT, &bit_val_true, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLBindCol(this->stmt, 24, SQL_C_BIT, &bit_val_true, buf_len, &ind));
 
   // Characters
   SQLCHAR char_val[2];
   buf_len = sizeof(SQLCHAR) * 2;
 
-  ASSERT_EQ(SQL_SUCCESS, SQLBindCol(stmt, 25, SQL_C_CHAR, &char_val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLBindCol(this->stmt, 25, SQL_C_CHAR, &char_val, buf_len, &ind));
 
   SQLWCHAR wchar_val[2];
   size_t wchar_size = GetSqlWCharSize();
   buf_len = wchar_size * 2;
 
-  ASSERT_EQ(SQL_SUCCESS, SQLBindCol(stmt, 26, SQL_C_WCHAR, &wchar_val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLBindCol(this->stmt, 26, SQL_C_WCHAR, &wchar_val, buf_len, &ind));
 
   SQLWCHAR wvarchar_val[3];
   buf_len = wchar_size * 3;
 
-  ASSERT_EQ(SQL_SUCCESS, SQLBindCol(stmt, 27, SQL_C_WCHAR, &wvarchar_val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLBindCol(this->stmt, 27, SQL_C_WCHAR, &wvarchar_val, buf_len, &ind));
 
   SQLCHAR varchar_val[4];
   buf_len = sizeof(SQLCHAR) * 4;
 
-  ASSERT_EQ(SQL_SUCCESS, SQLBindCol(stmt, 28, SQL_C_CHAR, &varchar_val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLBindCol(this->stmt, 28, SQL_C_CHAR, &varchar_val, buf_len, &ind));
 
   // Date and Timestamp
   SQL_DATE_STRUCT date_val_min{}, date_val_max{};
   buf_len = 0;
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(stmt, 29, SQL_C_TYPE_DATE, &date_val_min, buf_len, &ind));
+            SQLBindCol(this->stmt, 29, SQL_C_TYPE_DATE, &date_val_min, buf_len, &ind));
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(stmt, 30, SQL_C_TYPE_DATE, &date_val_max, buf_len, &ind));
+            SQLBindCol(this->stmt, 30, SQL_C_TYPE_DATE, &date_val_max, buf_len, &ind));
 
   SQL_TIMESTAMP_STRUCT timestamp_val_min{}, timestamp_val_max{};
 
-  ASSERT_EQ(SQL_SUCCESS, SQLBindCol(stmt, 31, SQL_C_TYPE_TIMESTAMP, &timestamp_val_min,
-                                    buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLBindCol(this->stmt, 31, SQL_C_TYPE_TIMESTAMP,
+                                    &timestamp_val_min, buf_len, &ind));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLBindCol(stmt, 32, SQL_C_TYPE_TIMESTAMP, &timestamp_val_max,
-                                    buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLBindCol(this->stmt, 32, SQL_C_TYPE_TIMESTAMP,
+                                    &timestamp_val_max, buf_len, &ind));
 
   // Execute query and fetch data once since there is only 1 row.
   std::wstring wsql = this->GetQueryAllDataTypes();
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
   // Data verification
 
@@ -1627,10 +1669,10 @@ TEST_F(StatementRemoteTest, TestSQLBindColTimeQuery) {
   SQLLEN ind;
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(stmt, 1, SQL_C_TYPE_TIME, &time_var_min, buf_len, &ind));
+            SQLBindCol(this->stmt, 1, SQL_C_TYPE_TIME, &time_var_min, buf_len, &ind));
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(stmt, 2, SQL_C_TYPE_TIME, &time_var_max, buf_len, &ind));
+            SQLBindCol(this->stmt, 2, SQL_C_TYPE_TIME, &time_var_max, buf_len, &ind));
 
   SQLWCHAR wsql[] =
       LR"(
@@ -1639,9 +1681,9 @@ TEST_F(StatementRemoteTest, TestSQLBindColTimeQuery) {
    )";
   SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
   // Check min values for time.
   EXPECT_EQ(0, time_var_min.hour);
@@ -1663,14 +1705,14 @@ TEST_F(StatementMockTest, TestSQLBindColVarbinaryQuery) {
   SQLLEN buf_len = varbinary_val.size();
   SQLLEN ind;
   ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(stmt, 1, SQL_C_BINARY, &varbinary_val[0], buf_len, &ind));
+            SQLBindCol(this->stmt, 1, SQL_C_BINARY, &varbinary_val[0], buf_len, &ind));
 
   SQLWCHAR wsql[] = L"SELECT X'ABCDEF' AS c_varbinary;";
   SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
   // Check varbinary values
   EXPECT_EQ('\xAB', varbinary_val[0]);
@@ -1685,14 +1727,14 @@ TEST_F(StatementRemoteTest, TestSQLBindColNullQuery) {
   SQLINTEGER val;
   SQLLEN ind;
 
-  ASSERT_EQ(SQL_SUCCESS, SQLBindCol(stmt, 1, SQL_C_LONG, &val, 0, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLBindCol(this->stmt, 1, SQL_C_LONG, &val, 0, &ind));
 
   SQLWCHAR wsql[] = L"SELECT null as null_col;";
   SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
   // Verify SQL_NULL_DATA is returned for indicator
   EXPECT_EQ(SQL_NULL_DATA, ind);
@@ -1704,16 +1746,16 @@ TEST_F(StatementRemoteTest, TestSQLBindColNullQueryNullIndicator) {
 
   SQLINTEGER val;
 
-  ASSERT_EQ(SQL_SUCCESS, SQLBindCol(stmt, 1, SQL_C_LONG, &val, 0, 0));
+  ASSERT_EQ(SQL_SUCCESS, SQLBindCol(this->stmt, 1, SQL_C_LONG, &val, 0, 0));
 
   SQLWCHAR wsql[] = L"SELECT null as null_col;";
   SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
-  ASSERT_EQ(SQL_ERROR, SQLFetch(stmt));
+  ASSERT_EQ(SQL_ERROR, SQLFetch(this->stmt));
   // Verify invalid null indicator is reported, as it is required
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorState22002);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorState22002);
 }
 
 TYPED_TEST(StatementTest, TestSQLBindColRowFetching) {
@@ -1723,7 +1765,7 @@ TYPED_TEST(StatementTest, TestSQLBindColRowFetching) {
 
   // Same variable will be used for column 1, the value of `val`
   // should be updated after every SQLFetch call.
-  ASSERT_EQ(SQL_SUCCESS, SQLBindCol(stmt, 1, SQL_C_LONG, &val, buf_len, &ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLBindCol(this->stmt, 1, SQL_C_LONG, &val, buf_len, &ind));
 
   SQLWCHAR wsql[] =
       LR"(
@@ -1735,28 +1777,28 @@ TYPED_TEST(StatementTest, TestSQLBindColRowFetching) {
  )";
   SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
   // Fetch row 1
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
   // Verify 1 is returned
   EXPECT_EQ(1, val);
 
   // Fetch row 2
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
   // Verify 2 is returned
   EXPECT_EQ(2, val);
 
   // Fetch row 3
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
   // Verify 3 is returned
   EXPECT_EQ(3, val);
 
   // Verify result set has no more data beyond row 3
-  ASSERT_EQ(SQL_NO_DATA, SQLFetch(stmt));
+  ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
 }
 
 TYPED_TEST(StatementTest, TestSQLBindColRowArraySize) {
@@ -1769,11 +1811,11 @@ TYPED_TEST(StatementTest, TestSQLBindColRowArraySize) {
 
   // Same variable will be used for column 1, the value of `val`
   // should be updated after every SQLFetch call.
-  ASSERT_EQ(SQL_SUCCESS, SQLBindCol(stmt, 1, SQL_C_LONG, val, buf_len, ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLBindCol(this->stmt, 1, SQL_C_LONG, val, buf_len, ind));
 
   SQLLEN rows_fetched;
   ASSERT_EQ(SQL_SUCCESS,
-            SQLSetStmtAttr(stmt, SQL_ATTR_ROWS_FETCHED_PTR, &rows_fetched, 0));
+            SQLSetStmtAttr(this->stmt, SQL_ATTR_ROWS_FETCHED_PTR, &rows_fetched, 0));
 
   SQLWCHAR wsql[] =
       LR"(
@@ -1785,13 +1827,13 @@ TYPED_TEST(StatementTest, TestSQLBindColRowArraySize) {
  )";
   SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLSetStmtAttr(stmt, SQL_ATTR_ROW_ARRAY_SIZE,
+  ASSERT_EQ(SQL_SUCCESS, SQLSetStmtAttr(this->stmt, SQL_ATTR_ROW_ARRAY_SIZE,
                                         reinterpret_cast<SQLPOINTER>(rows), 0));
 
   // Fetch 3 rows at once
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
   // Verify 3 rows are fetched
   EXPECT_EQ(3, rows_fetched);
@@ -1804,7 +1846,7 @@ TYPED_TEST(StatementTest, TestSQLBindColRowArraySize) {
   EXPECT_EQ(3, val[2]);
 
   // Verify result set has no more data beyond row 3
-  ASSERT_EQ(SQL_NO_DATA, SQLFetch(stmt));
+  ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
 }
 
 TYPED_TEST(StatementTest, DISABLED_TestSQLBindColIndicatorOnly) {
@@ -1816,21 +1858,22 @@ TYPED_TEST(StatementTest, DISABLED_TestSQLBindColIndicatorOnly) {
 
   // Signed Tiny Int
   SQLLEN stiny_int_ind;
-  EXPECT_EQ(SQL_SUCCESS, SQLBindCol(stmt, 1, SQL_C_STINYINT, 0, 0, &stiny_int_ind));
+  EXPECT_EQ(SQL_SUCCESS, SQLBindCol(this->stmt, 1, SQL_C_STINYINT, 0, 0, &stiny_int_ind));
 
   // Characters
   SQLLEN buf_len = sizeof(SQLCHAR) * 2;
   SQLLEN char_val_ind;
-  ASSERT_EQ(SQL_SUCCESS, SQLBindCol(stmt, 25, SQL_C_CHAR, 0, buf_len, &char_val_ind));
+  ASSERT_EQ(SQL_SUCCESS,
+            SQLBindCol(this->stmt, 25, SQL_C_CHAR, 0, buf_len, &char_val_ind));
 
   // Execute query and fetch data once since there is only 1 row.
   std::wstring wsql = this->GetQueryAllDataTypes();
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
   // Verify values for indicator pointer
   // Signed Tiny Int
@@ -1849,26 +1892,26 @@ TYPED_TEST(StatementTest, TestSQLBindColIndicatorOnlySQLUnbind) {
   int8_t stiny_int_val;
   SQLLEN stiny_int_ind;
   ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(stmt, 1, SQL_C_STINYINT, &stiny_int_val, 0, &stiny_int_ind));
+            SQLBindCol(this->stmt, 1, SQL_C_STINYINT, &stiny_int_val, 0, &stiny_int_ind));
 
   // Characters
   SQLCHAR char_val[2];
   SQLLEN buf_len = sizeof(SQLCHAR) * 2;
   SQLLEN char_val_ind;
   ASSERT_EQ(SQL_SUCCESS,
-            SQLBindCol(stmt, 25, SQL_C_CHAR, &char_val, buf_len, &char_val_ind));
+            SQLBindCol(this->stmt, 25, SQL_C_CHAR, &char_val, buf_len, &char_val_ind));
 
   // Driver should still be able to execute queries after unbinding columns
-  EXPECT_EQ(SQL_SUCCESS, SQLFreeStmt(stmt, SQL_UNBIND));
+  EXPECT_EQ(SQL_SUCCESS, SQLFreeStmt(this->stmt, SQL_UNBIND));
 
   // Execute query and fetch data once since there is only 1 row.
   std::wstring wsql = this->GetQueryAllDataTypes();
   std::vector<SQLWCHAR> sql0(wsql.begin(), wsql.end());
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLExecDirect(stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
+            SQLExecDirect(this->stmt, &sql0[0], static_cast<SQLINTEGER>(sql0.size())));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
   // GH-47021 TODO: implement driver to return indicator value when data pointer is null
   // and uncomment the checks Verify values for indicator pointer Signed Tiny Int
@@ -1888,10 +1931,10 @@ TYPED_TEST(StatementTest, TestSQLExtendedFetchRowFetching) {
 
   // Same variable will be used for column 1, the value of `val`
   // should be updated after every SQLFetch call.
-  ASSERT_EQ(SQL_SUCCESS, SQLBindCol(stmt, 1, SQL_C_LONG, val, buf_len, ind));
+  ASSERT_EQ(SQL_SUCCESS, SQLBindCol(this->stmt, 1, SQL_C_LONG, val, buf_len, ind));
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLSetStmtAttr(stmt, SQL_ROWSET_SIZE, reinterpret_cast<SQLPOINTER>(rows), 0));
+  ASSERT_EQ(SQL_SUCCESS, SQLSetStmtAttr(this->stmt, SQL_ROWSET_SIZE,
+                                        reinterpret_cast<SQLPOINTER>(rows), 0));
 
   SQLWCHAR wsql[] =
       LR"(
@@ -1903,14 +1946,14 @@ TYPED_TEST(StatementTest, TestSQLExtendedFetchRowFetching) {
  )";
   SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
   // Fetch row 1-3.
   SQLULEN row_count;
   SQLUSMALLINT row_status[rows];
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLExtendedFetch(stmt, SQL_FETCH_NEXT, 0, &row_count, row_status));
+            SQLExtendedFetch(this->stmt, SQL_FETCH_NEXT, 0, &row_count, row_status));
   EXPECT_EQ(3, row_count);
 
   for (int i = 0; i < rows; i++) {
@@ -1928,7 +1971,7 @@ TYPED_TEST(StatementTest, TestSQLExtendedFetchRowFetching) {
   SQLULEN row_count2;
   SQLUSMALLINT row_status2[rows];
   EXPECT_EQ(SQL_NO_DATA,
-            SQLExtendedFetch(stmt, SQL_FETCH_NEXT, 0, &row_count2, row_status2));
+            SQLExtendedFetch(this->stmt, SQL_FETCH_NEXT, 0, &row_count2, row_status2));
 }
 
 TEST_F(StatementRemoteTest, DISABLED_TestSQLExtendedFetchQueryNullIndicator) {
@@ -1937,20 +1980,20 @@ TEST_F(StatementRemoteTest, DISABLED_TestSQLExtendedFetchQueryNullIndicator) {
   // server instead. Mock server has type `DENSE_UNION` for null column data.
   SQLINTEGER val;
 
-  ASSERT_EQ(SQL_SUCCESS, SQLBindCol(stmt, 1, SQL_C_LONG, &val, 0, nullptr));
+  ASSERT_EQ(SQL_SUCCESS, SQLBindCol(this->stmt, 1, SQL_C_LONG, &val, 0, nullptr));
 
   SQLWCHAR wsql[] = L"SELECT null as null_col;";
   SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
   SQLULEN row_count1;
   SQLUSMALLINT row_status1[1];
 
   // SQLExtendedFetch should return SQL_SUCCESS_WITH_INFO for 22002 state
   ASSERT_EQ(SQL_SUCCESS_WITH_INFO,
-            SQLExtendedFetch(stmt, SQL_FETCH_NEXT, 0, &row_count1, row_status1));
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorState22002);
+            SQLExtendedFetch(this->stmt, SQL_FETCH_NEXT, 0, &row_count1, row_status1));
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorState22002);
 }
 
 TYPED_TEST(StatementTest, TestSQLMoreResultsNoData) {
@@ -1959,16 +2002,16 @@ TYPED_TEST(StatementTest, TestSQLMoreResultsNoData) {
   SQLWCHAR wsql[] = L"SELECT 1;";
   SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
-  ASSERT_EQ(SQL_NO_DATA, SQLMoreResults(stmt));
+  ASSERT_EQ(SQL_NO_DATA, SQLMoreResults(this->stmt));
 }
 
 TYPED_TEST(StatementTest, TestSQLMoreResultsInvalidFunctionSequence) {
   // Verify function sequence error state is reported when SQLMoreResults is called
   // without executing any queries
-  ASSERT_EQ(SQL_ERROR, SQLMoreResults(stmt));
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorStateHY010);
+  ASSERT_EQ(SQL_ERROR, SQLMoreResults(this->stmt));
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorStateHY010);
 }
 
 TYPED_TEST(StatementTest, TestSQLNativeSqlReturnsInputString) {
@@ -1979,8 +2022,8 @@ TYPED_TEST(StatementTest, TestSQLNativeSqlReturnsInputString) {
   SQLINTEGER output_char_len = 0;
   std::wstring expected_string = std::wstring(input_str);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLNativeSql(conn, input_str, input_char_len, buf, buf_char_len,
-                                      &output_char_len));
+  ASSERT_EQ(SQL_SUCCESS, SQLNativeSql(this->conn, input_str, input_char_len, buf,
+                                      buf_char_len, &output_char_len));
 
   EXPECT_EQ(input_char_len, output_char_len);
 
@@ -1998,8 +2041,8 @@ TYPED_TEST(StatementTest, TestSQLNativeSqlReturnsNTSInputString) {
   SQLINTEGER output_char_len = 0;
   std::wstring expected_string = std::wstring(input_str);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLNativeSql(conn, input_str, SQL_NTS, buf, buf_char_len, &output_char_len));
+  ASSERT_EQ(SQL_SUCCESS, SQLNativeSql(this->conn, input_str, SQL_NTS, buf, buf_char_len,
+                                      &output_char_len));
 
   EXPECT_EQ(input_char_len, output_char_len);
 
@@ -2015,13 +2058,13 @@ TYPED_TEST(StatementTest, TestSQLNativeSqlReturnsInputStringLength) {
   SQLINTEGER output_char_len = 0;
   std::wstring expected_string = std::wstring(input_str);
 
-  ASSERT_EQ(SQL_SUCCESS,
-            SQLNativeSql(conn, input_str, input_char_len, nullptr, 0, &output_char_len));
+  ASSERT_EQ(SQL_SUCCESS, SQLNativeSql(this->conn, input_str, input_char_len, nullptr, 0,
+                                      &output_char_len));
 
   EXPECT_EQ(input_char_len, output_char_len);
 
   ASSERT_EQ(SQL_SUCCESS,
-            SQLNativeSql(conn, input_str, SQL_NTS, nullptr, 0, &output_char_len));
+            SQLNativeSql(this->conn, input_str, SQL_NTS, nullptr, 0, &output_char_len));
 
   EXPECT_EQ(input_char_len, output_char_len);
 }
@@ -2042,9 +2085,9 @@ TYPED_TEST(StatementTest, TestSQLNativeSqlReturnsTruncatedString) {
                                expected_string_buf + small_buf_size_in_char);
 
   ASSERT_EQ(SQL_SUCCESS_WITH_INFO,
-            SQLNativeSql(conn, input_str, input_char_len, small_buf, small_buf_char_len,
-                         &output_char_len));
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorState01004);
+            SQLNativeSql(this->conn, input_str, input_char_len, small_buf,
+                         small_buf_char_len, &output_char_len));
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorState01004);
 
   // Returned text length represents full string char length regardless of truncation
   EXPECT_EQ(input_char_len, output_char_len);
@@ -2061,20 +2104,20 @@ TYPED_TEST(StatementTest, TestSQLNativeSqlReturnsErrorOnBadInputs) {
   SQLINTEGER input_char_len = static_cast<SQLINTEGER>(wcslen(input_str));
   SQLINTEGER output_char_len = 0;
 
-  ASSERT_EQ(SQL_ERROR, SQLNativeSql(conn, nullptr, input_char_len, buf, buf_char_len,
+  ASSERT_EQ(SQL_ERROR, SQLNativeSql(this->conn, nullptr, input_char_len, buf,
+                                    buf_char_len, &output_char_len));
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorStateHY009);
+
+  ASSERT_EQ(SQL_ERROR, SQLNativeSql(this->conn, nullptr, SQL_NTS, buf, buf_char_len,
                                     &output_char_len));
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorStateHY009);
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorStateHY009);
 
-  ASSERT_EQ(SQL_ERROR,
-            SQLNativeSql(conn, nullptr, SQL_NTS, buf, buf_char_len, &output_char_len));
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorStateHY009);
-
-  ASSERT_EQ(SQL_ERROR,
-            SQLNativeSql(conn, input_str, -100, buf, buf_char_len, &output_char_len));
+  ASSERT_EQ(SQL_ERROR, SQLNativeSql(this->conn, input_str, -100, buf, buf_char_len,
+                                    &output_char_len));
 #ifdef __APPLE__
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorStateS1090);
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorStateS1090);
 #else
-  VerifyOdbcErrorState(SQL_HANDLE_DBC, conn, kErrorStateHY090);
+  VerifyOdbcErrorState(SQL_HANDLE_DBC, this->conn, kErrorStateHY090);
 #endif  // __APPLE__
 }
 
@@ -2084,15 +2127,15 @@ TYPED_TEST(StatementTest, SQLNumResultColsReturnsColumnsOnSelect) {
   SQLWCHAR sql_query[] = L"SELECT 1 AS col1, 'One' AS col2, 3 AS col3";
   SQLINTEGER query_length = static_cast<SQLINTEGER>(wcslen(sql_query));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, sql_query, query_length));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, sql_query, query_length));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
-  CheckIntColumn(stmt, 1, 1);
-  CheckStringColumnW(stmt, 2, L"One");
-  CheckIntColumn(stmt, 3, 3);
+  CheckIntColumn(this->stmt, 1, 1);
+  CheckStringColumnW(this->stmt, 2, L"One");
+  CheckIntColumn(this->stmt, 3, 3);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLNumResultCols(stmt, &column_count));
+  ASSERT_EQ(SQL_SUCCESS, SQLNumResultCols(this->stmt, &column_count));
 
   EXPECT_EQ(expected_value, column_count);
 }
@@ -2101,33 +2144,33 @@ TYPED_TEST(StatementTest, SQLNumResultColsReturnsSuccessOnNullptr) {
   SQLWCHAR sql_query[] = L"SELECT 1 AS col1, 'One' AS col2, 3 AS col3";
   SQLINTEGER query_length = static_cast<SQLINTEGER>(wcslen(sql_query));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, sql_query, query_length));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, sql_query, query_length));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
-  CheckIntColumn(stmt, 1, 1);
-  CheckStringColumnW(stmt, 2, L"One");
-  CheckIntColumn(stmt, 3, 3);
+  CheckIntColumn(this->stmt, 1, 1);
+  CheckStringColumnW(this->stmt, 2, L"One");
+  CheckIntColumn(this->stmt, 3, 3);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLNumResultCols(stmt, nullptr));
+  ASSERT_EQ(SQL_SUCCESS, SQLNumResultCols(this->stmt, nullptr));
 }
 
 TYPED_TEST(StatementTest, SQLNumResultColsFunctionSequenceErrorOnNoQuery) {
   SQLSMALLINT column_count = 0;
   SQLSMALLINT expected_value = 0;
 
-  ASSERT_EQ(SQL_ERROR, SQLNumResultCols(stmt, &column_count));
+  ASSERT_EQ(SQL_ERROR, SQLNumResultCols(this->stmt, &column_count));
 #ifdef __APPLE__
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorStateS1010);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorStateS1010);
 #else
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorStateHY010);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorStateHY010);
 #endif  // __APPLE__
 
-  ASSERT_EQ(SQL_ERROR, SQLNumResultCols(stmt, &column_count));
+  ASSERT_EQ(SQL_ERROR, SQLNumResultCols(this->stmt, &column_count));
 #ifdef __APPLE__
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorStateS1010);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorStateS1010);
 #else
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorStateHY010);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorStateHY010);
 #endif  // __APPLE__
 
   ASSERT_EQ(expected_value, column_count);
@@ -2139,15 +2182,15 @@ TYPED_TEST(StatementTest, SQLRowCountReturnsNegativeOneOnSelect) {
   SQLWCHAR sql_query[] = L"SELECT 1 AS col1, 'One' AS col2, 3 AS col3";
   SQLINTEGER query_length = static_cast<SQLINTEGER>(wcslen(sql_query));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, sql_query, query_length));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, sql_query, query_length));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
-  CheckIntColumn(stmt, 1, 1);
-  CheckStringColumnW(stmt, 2, L"One");
-  CheckIntColumn(stmt, 3, 3);
+  CheckIntColumn(this->stmt, 1, 1);
+  CheckStringColumnW(this->stmt, 2, L"One");
+  CheckIntColumn(this->stmt, 3, 3);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLRowCount(stmt, &row_count));
+  ASSERT_EQ(SQL_SUCCESS, SQLRowCount(this->stmt, &row_count));
 
   EXPECT_EQ(expected_value, row_count);
 }
@@ -2156,26 +2199,26 @@ TYPED_TEST(StatementTest, SQLRowCountReturnsSuccessOnNullptr) {
   SQLWCHAR sql_query[] = L"SELECT 1 AS col1, 'One' AS col2, 3 AS col3";
   SQLINTEGER query_length = static_cast<SQLINTEGER>(wcslen(sql_query));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, sql_query, query_length));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, sql_query, query_length));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFetch(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLFetch(this->stmt));
 
-  CheckIntColumn(stmt, 1, 1);
-  CheckStringColumnW(stmt, 2, L"One");
-  CheckIntColumn(stmt, 3, 3);
+  CheckIntColumn(this->stmt, 1, 1);
+  CheckStringColumnW(this->stmt, 2, L"One");
+  CheckIntColumn(this->stmt, 3, 3);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLRowCount(stmt, nullptr));
+  ASSERT_EQ(SQL_SUCCESS, SQLRowCount(this->stmt, nullptr));
 }
 
 TYPED_TEST(StatementTest, SQLRowCountFunctionSequenceErrorOnNoQuery) {
   SQLLEN row_count = 0;
   SQLLEN expected_value = 0;
 
-  ASSERT_EQ(SQL_ERROR, SQLRowCount(stmt, &row_count));
+  ASSERT_EQ(SQL_ERROR, SQLRowCount(this->stmt, &row_count));
 #ifdef __APPLE__
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorStateS1010);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorStateS1010);
 #else
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorStateHY010);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorStateHY010);
 #endif  // __APPLE__
 
   EXPECT_EQ(expected_value, row_count);
@@ -2185,31 +2228,31 @@ TYPED_TEST(StatementTest, TestSQLFreeStmtSQLClose) {
   SQLWCHAR wsql[] = L"SELECT 1;";
   SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFreeStmt(stmt, SQL_CLOSE));
+  ASSERT_EQ(SQL_SUCCESS, SQLFreeStmt(this->stmt, SQL_CLOSE));
 }
 
 TYPED_TEST(StatementTest, TestSQLCloseCursor) {
   SQLWCHAR wsql[] = L"SELECT 1;";
   SQLINTEGER wsql_len = std::wcslen(wsql);
 
-  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(stmt, wsql, wsql_len));
+  ASSERT_EQ(SQL_SUCCESS, SQLExecDirect(this->stmt, wsql, wsql_len));
 
-  ASSERT_EQ(SQL_SUCCESS, SQLCloseCursor(stmt));
+  ASSERT_EQ(SQL_SUCCESS, SQLCloseCursor(this->stmt));
 }
 
 TYPED_TEST(StatementTest, TestSQLFreeStmtSQLCloseWithoutCursor) {
   // Verify SQLFreeStmt(SQL_CLOSE) does not throw error with invalid cursor
 
-  ASSERT_EQ(SQL_SUCCESS, SQLFreeStmt(stmt, SQL_CLOSE));
+  ASSERT_EQ(SQL_SUCCESS, SQLFreeStmt(this->stmt, SQL_CLOSE));
 }
 
 TYPED_TEST(StatementTest, TestSQLCloseCursorWithoutCursor) {
-  ASSERT_EQ(SQL_ERROR, SQLCloseCursor(stmt));
+  ASSERT_EQ(SQL_ERROR, SQLCloseCursor(this->stmt));
 
   // Verify invalid cursor error state is returned
-  VerifyOdbcErrorState(SQL_HANDLE_STMT, stmt, kErrorState24000);
+  VerifyOdbcErrorState(SQL_HANDLE_STMT, this->stmt, kErrorState24000);
 }
 
 }  // namespace arrow::flight::sql::odbc

--- a/cpp/src/arrow/flight/sql/odbc/tests/tables_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/tables_test.cc
@@ -50,31 +50,32 @@ TYPED_TEST(TablesTest, SQLTablesTestInputData) {
   SQLWCHAR table_type[] = L"";
 
   // All values populated
-  EXPECT_EQ(SQL_SUCCESS, SQLTables(stmt, catalog_name, sizeof(catalog_name), schema_name,
-                                   sizeof(schema_name), table_name, sizeof(table_name),
-                                   table_type, sizeof(table_type)));
+  EXPECT_EQ(SQL_SUCCESS, SQLTables(this->stmt, catalog_name, sizeof(catalog_name),
+                                   schema_name, sizeof(schema_name), table_name,
+                                   sizeof(table_name), table_type, sizeof(table_type)));
 
-  ValidateFetch(stmt, SQL_NO_DATA);
+  ValidateFetch(this->stmt, SQL_NO_DATA);
 
   // Sizes are zeros
-  EXPECT_EQ(SQL_SUCCESS, SQLTables(stmt, catalog_name, 0, schema_name, 0, table_name, 0,
-                                   table_type, 0));
+  EXPECT_EQ(SQL_SUCCESS, SQLTables(this->stmt, catalog_name, 0, schema_name, 0,
+                                   table_name, 0, table_type, 0));
 
-  ValidateFetch(stmt, SQL_NO_DATA);
+  ValidateFetch(this->stmt, SQL_NO_DATA);
 
   // Names are nulls
-  EXPECT_EQ(SQL_SUCCESS,
-            SQLTables(stmt, nullptr, sizeof(catalog_name), nullptr, sizeof(schema_name),
-                      nullptr, sizeof(table_name), nullptr, sizeof(table_type)));
+  EXPECT_EQ(SQL_SUCCESS, SQLTables(this->stmt, nullptr, sizeof(catalog_name), nullptr,
+                                   sizeof(schema_name), nullptr, sizeof(table_name),
+                                   nullptr, sizeof(table_type)));
 
-  ValidateFetch(stmt, SQL_SUCCESS);
+  ValidateFetch(this->stmt, SQL_SUCCESS);
   // Close statement cursor to avoid leaving in an invalid state
-  SQLFreeStmt(stmt, SQL_CLOSE);
+  SQLFreeStmt(this->stmt, SQL_CLOSE);
 
   // Names are nulls and sizes are zeros
-  EXPECT_EQ(SQL_SUCCESS, SQLTables(stmt, nullptr, 0, nullptr, 0, nullptr, 0, nullptr, 0));
+  EXPECT_EQ(SQL_SUCCESS,
+            SQLTables(this->stmt, nullptr, 0, nullptr, 0, nullptr, 0, nullptr, 0));
 
-  ValidateFetch(stmt, SQL_SUCCESS);
+  ValidateFetch(this->stmt, SQL_SUCCESS);
 }
 
 TEST_F(TablesMockTest, SQLTablesTestGetMetadataForAllCatalogs) {
@@ -83,18 +84,18 @@ TEST_F(TablesMockTest, SQLTablesTestGetMetadataForAllCatalogs) {
   std::wstring expected_catalog_name = std::wstring(L"main");
 
   // Get Catalog metadata
-  ASSERT_EQ(SQL_SUCCESS, SQLTables(stmt, SQL_ALL_CATALOGS_W, SQL_NTS, empty, SQL_NTS,
-                                   empty, SQL_NTS, empty, SQL_NTS));
+  ASSERT_EQ(SQL_SUCCESS, SQLTables(this->stmt, SQL_ALL_CATALOGS_W, SQL_NTS, empty,
+                                   SQL_NTS, empty, SQL_NTS, empty, SQL_NTS));
 
-  ValidateFetch(stmt, SQL_SUCCESS);
+  ValidateFetch(this->stmt, SQL_SUCCESS);
 
-  CheckStringColumnW(stmt, 1, expected_catalog_name);
-  CheckNullColumnW(stmt, 2);
-  CheckNullColumnW(stmt, 3);
-  CheckNullColumnW(stmt, 4);
-  CheckNullColumnW(stmt, 5);
+  CheckStringColumnW(this->stmt, 1, expected_catalog_name);
+  CheckNullColumnW(this->stmt, 2);
+  CheckNullColumnW(this->stmt, 3);
+  CheckNullColumnW(this->stmt, 4);
+  CheckNullColumnW(this->stmt, 5);
 
-  ValidateFetch(stmt, SQL_NO_DATA);
+  ValidateFetch(this->stmt, SQL_NO_DATA);
 }
 
 TEST_F(TablesMockTest, SQLTablesTestGetMetadataForNamedCatalog) {
@@ -110,21 +111,21 @@ TEST_F(TablesMockTest, SQLTablesTestGetMetadataForNamedCatalog) {
 
   // Get named Catalog metadata - Mock server returns the system table sqlite_sequence as
   // type "table"
-  ASSERT_EQ(SQL_SUCCESS, SQLTables(stmt, catalog_name, SQL_NTS, nullptr, SQL_NTS, nullptr,
-                                   SQL_NTS, nullptr, SQL_NTS));
+  ASSERT_EQ(SQL_SUCCESS, SQLTables(this->stmt, catalog_name, SQL_NTS, nullptr, SQL_NTS,
+                                   nullptr, SQL_NTS, nullptr, SQL_NTS));
 
   for (size_t i = 0; i < sizeof(table_names) / sizeof(*table_names); ++i) {
-    ValidateFetch(stmt, SQL_SUCCESS);
+    ValidateFetch(this->stmt, SQL_SUCCESS);
 
-    CheckStringColumnW(stmt, 1, expected_catalog_name);
+    CheckStringColumnW(this->stmt, 1, expected_catalog_name);
     // Mock server does not support table schema
-    CheckNullColumnW(stmt, 2);
-    CheckStringColumnW(stmt, 3, table_names[i]);
-    CheckStringColumnW(stmt, 4, expected_table_type);
-    CheckNullColumnW(stmt, 5);
+    CheckNullColumnW(this->stmt, 2);
+    CheckStringColumnW(this->stmt, 3, table_names[i]);
+    CheckStringColumnW(this->stmt, 4, expected_table_type);
+    CheckNullColumnW(this->stmt, 5);
   }
 
-  ValidateFetch(stmt, SQL_NO_DATA);
+  ValidateFetch(this->stmt, SQL_NO_DATA);
 
   DropTestTable();
 }
@@ -133,10 +134,10 @@ TEST_F(TablesMockTest, SQLTablesTestGetSchemaHasNoData) {
   SQLWCHAR SQL_ALL_SCHEMAS_W[] = L"%";
 
   // Validate that no schema data is available for Mock server
-  ASSERT_EQ(SQL_SUCCESS, SQLTables(stmt, nullptr, SQL_NTS, SQL_ALL_SCHEMAS_W, SQL_NTS,
-                                   nullptr, SQL_NTS, nullptr, SQL_NTS));
+  ASSERT_EQ(SQL_SUCCESS, SQLTables(this->stmt, nullptr, SQL_NTS, SQL_ALL_SCHEMAS_W,
+                                   SQL_NTS, nullptr, SQL_NTS, nullptr, SQL_NTS));
 
-  ValidateFetch(stmt, SQL_NO_DATA);
+  ValidateFetch(this->stmt, SQL_NO_DATA);
 }
 
 TEST_F(TablesRemoteTest, SQLTablesTestGetMetadataForAllSchemas) {
@@ -148,19 +149,19 @@ TEST_F(TablesRemoteTest, SQLTablesTestGetMetadataForAllSchemas) {
 
   // Return is unordered and contains user specific schemas, so collect schema names for
   // comparison with a known list
-  ASSERT_EQ(SQL_SUCCESS, SQLTables(stmt, empty, SQL_NTS, SQL_ALL_SCHEMAS_W, SQL_NTS,
+  ASSERT_EQ(SQL_SUCCESS, SQLTables(this->stmt, empty, SQL_NTS, SQL_ALL_SCHEMAS_W, SQL_NTS,
                                    empty, SQL_NTS, empty, SQL_NTS));
 
   while (true) {
-    SQLRETURN ret = SQLFetch(stmt);
+    SQLRETURN ret = SQLFetch(this->stmt);
     if (ret == SQL_NO_DATA) break;
     ASSERT_EQ(SQL_SUCCESS, ret);
 
-    CheckNullColumnW(stmt, 1);
-    std::wstring schema = GetStringColumnW(stmt, 2);
-    CheckNullColumnW(stmt, 3);
-    CheckNullColumnW(stmt, 4);
-    CheckNullColumnW(stmt, 5);
+    CheckNullColumnW(this->stmt, 1);
+    std::wstring schema = GetStringColumnW(this->stmt, 2);
+    CheckNullColumnW(this->stmt, 3);
+    CheckNullColumnW(this->stmt, 4);
+    CheckNullColumnW(this->stmt, 5);
 
     // Skip user-specific schemas like "@UserName"
     if (!schema.empty() && schema[0] != L'@') {
@@ -209,11 +210,11 @@ TEST_F(TablesRemoteTest, SQLTablesTestFilterByAllSchema) {
   std::wstring expected_system_table_type = std::wstring(L"SYSTEM_TABLE");
   std::wstring expected_user_table_type = std::wstring(L"TABLE");
 
-  ASSERT_EQ(SQL_SUCCESS, SQLTables(stmt, nullptr, SQL_NTS, SQL_ALL_SCHEMAS_W, SQL_NTS,
-                                   nullptr, SQL_NTS, nullptr, SQL_NTS));
+  ASSERT_EQ(SQL_SUCCESS, SQLTables(this->stmt, nullptr, SQL_NTS, SQL_ALL_SCHEMAS_W,
+                                   SQL_NTS, nullptr, SQL_NTS, nullptr, SQL_NTS));
 
   for (size_t i = 0; i < sizeof(schema_names) / sizeof(*schema_names); ++i) {
-    ValidateFetch(stmt, SQL_SUCCESS);
+    ValidateFetch(this->stmt, SQL_SUCCESS);
 
     const std::wstring& expected_table_type =
         (std::wstring(schema_names[i]).rfind(L"sys", 0) == 0 ||
@@ -221,14 +222,14 @@ TEST_F(TablesRemoteTest, SQLTablesTestFilterByAllSchema) {
             ? expected_system_table_type
             : expected_user_table_type;
 
-    CheckNullColumnW(stmt, 1);
-    CheckStringColumnW(stmt, 2, schema_names[i]);
+    CheckNullColumnW(this->stmt, 1);
+    CheckStringColumnW(this->stmt, 2, schema_names[i]);
     // Ignore table name
-    CheckStringColumnW(stmt, 4, expected_table_type);
-    CheckNullColumnW(stmt, 5);
+    CheckStringColumnW(this->stmt, 4, expected_table_type);
+    CheckNullColumnW(this->stmt, 5);
   }
 
-  ValidateFetch(stmt, SQL_NO_DATA);
+  ValidateFetch(this->stmt, SQL_NO_DATA);
 }
 
 TEST_F(TablesRemoteTest, SQLTablesGetMetadataForNamedSchema) {
@@ -238,18 +239,18 @@ TEST_F(TablesRemoteTest, SQLTablesGetMetadataForNamedSchema) {
   std::wstring expected_table_name = std::wstring(L"ODBCTest");
   std::wstring expected_table_type = std::wstring(L"TABLE");
 
-  ASSERT_EQ(SQL_SUCCESS, SQLTables(stmt, nullptr, SQL_NTS, schema_name, SQL_NTS, nullptr,
-                                   SQL_NTS, nullptr, SQL_NTS));
+  ASSERT_EQ(SQL_SUCCESS, SQLTables(this->stmt, nullptr, SQL_NTS, schema_name, SQL_NTS,
+                                   nullptr, SQL_NTS, nullptr, SQL_NTS));
 
-  ValidateFetch(stmt, SQL_SUCCESS);
+  ValidateFetch(this->stmt, SQL_SUCCESS);
 
-  CheckNullColumnW(stmt, 1);
-  CheckStringColumnW(stmt, 2, expected_schema_name);
+  CheckNullColumnW(this->stmt, 1);
+  CheckStringColumnW(this->stmt, 2, expected_schema_name);
   // Ignore table name
-  CheckStringColumnW(stmt, 4, expected_table_type);
-  CheckNullColumnW(stmt, 5);
+  CheckStringColumnW(this->stmt, 4, expected_table_type);
+  CheckNullColumnW(this->stmt, 5);
 
-  ValidateFetch(stmt, SQL_NO_DATA);
+  ValidateFetch(this->stmt, SQL_NO_DATA);
 }
 
 TEST_F(TablesMockTest, SQLTablesTestGetMetadataForAllTables) {
@@ -265,21 +266,21 @@ TEST_F(TablesMockTest, SQLTablesTestGetMetadataForAllTables) {
 
   // Get all Table metadata - Mock server returns the system table sqlite_sequence as type
   // "table"
-  ASSERT_EQ(SQL_SUCCESS, SQLTables(stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
+  ASSERT_EQ(SQL_SUCCESS, SQLTables(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
                                    SQL_ALL_TABLES_W, SQL_NTS, nullptr, SQL_NTS));
 
   for (size_t i = 0; i < sizeof(table_names) / sizeof(*table_names); ++i) {
-    ValidateFetch(stmt, SQL_SUCCESS);
+    ValidateFetch(this->stmt, SQL_SUCCESS);
 
-    CheckStringColumnW(stmt, 1, expected_catalog_name);
+    CheckStringColumnW(this->stmt, 1, expected_catalog_name);
     // Mock server does not support table schema
-    CheckNullColumnW(stmt, 2);
-    CheckStringColumnW(stmt, 3, table_names[i]);
-    CheckStringColumnW(stmt, 4, expected_table_type);
-    CheckNullColumnW(stmt, 5);
+    CheckNullColumnW(this->stmt, 2);
+    CheckStringColumnW(this->stmt, 3, table_names[i]);
+    CheckStringColumnW(this->stmt, 4, expected_table_type);
+    CheckNullColumnW(this->stmt, 5);
   }
 
-  ValidateFetch(stmt, SQL_NO_DATA);
+  ValidateFetch(this->stmt, SQL_NO_DATA);
 
   DropTestTable();
 }
@@ -300,19 +301,19 @@ TEST_F(TablesMockTest, SQLTablesTestGetMetadataForTableName) {
 
   for (size_t i = 0; i < sizeof(table_names) / sizeof(*table_names); ++i) {
     //  Get specific Table metadata
-    ASSERT_EQ(SQL_SUCCESS, SQLTables(stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
+    ASSERT_EQ(SQL_SUCCESS, SQLTables(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
                                      table_names[i], SQL_NTS, nullptr, SQL_NTS));
 
-    ValidateFetch(stmt, SQL_SUCCESS);
+    ValidateFetch(this->stmt, SQL_SUCCESS);
 
-    CheckStringColumnW(stmt, 1, expected_catalog_name);
+    CheckStringColumnW(this->stmt, 1, expected_catalog_name);
     // Mock server does not support table schema
-    CheckNullColumnW(stmt, 2);
-    CheckStringColumnW(stmt, 3, table_names[i]);
-    CheckStringColumnW(stmt, 4, expected_table_type);
-    CheckNullColumnW(stmt, 5);
+    CheckNullColumnW(this->stmt, 2);
+    CheckStringColumnW(this->stmt, 3, table_names[i]);
+    CheckStringColumnW(this->stmt, 4, expected_table_type);
+    CheckNullColumnW(this->stmt, 5);
 
-    ValidateFetch(stmt, SQL_NO_DATA);
+    ValidateFetch(this->stmt, SQL_NO_DATA);
   }
 
   DropTestTable();
@@ -327,19 +328,19 @@ TEST_F(TablesMockTest, SQLTablesTestGetMetadataForUnicodeTableByTableName) {
   std::wstring expected_table_type = std::wstring(L"table");
 
   //  Get specific Table metadata
-  ASSERT_EQ(SQL_SUCCESS, SQLTables(stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
+  ASSERT_EQ(SQL_SUCCESS, SQLTables(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
                                    unicodetable_name, SQL_NTS, nullptr, SQL_NTS));
 
-  ValidateFetch(stmt, SQL_SUCCESS);
+  ValidateFetch(this->stmt, SQL_SUCCESS);
 
-  CheckStringColumnW(stmt, 1, expected_catalog_name);
+  CheckStringColumnW(this->stmt, 1, expected_catalog_name);
   // Mock server does not support table schema
-  CheckNullColumnW(stmt, 2);
-  CheckStringColumnW(stmt, 3, expected_table_name);
-  CheckStringColumnW(stmt, 4, expected_table_type);
-  CheckNullColumnW(stmt, 5);
+  CheckNullColumnW(this->stmt, 2);
+  CheckStringColumnW(this->stmt, 3, expected_table_name);
+  CheckStringColumnW(this->stmt, 4, expected_table_type);
+  CheckNullColumnW(this->stmt, 5);
 
-  ValidateFetch(stmt, SQL_NO_DATA);
+  ValidateFetch(this->stmt, SQL_NO_DATA);
 
   DropUnicodeTable();
 }
@@ -350,10 +351,10 @@ TEST_F(TablesMockTest, SQLTablesTestGetMetadataForInvalidTableNameNoData) {
   SQLWCHAR invalid_table_name[] = L"NonExistenttable_name";
 
   //  Try to get metadata for a non-existent table name
-  ASSERT_EQ(SQL_SUCCESS, SQLTables(stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
+  ASSERT_EQ(SQL_SUCCESS, SQLTables(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
                                    invalid_table_name, SQL_NTS, nullptr, SQL_NTS));
 
-  ValidateFetch(stmt, SQL_NO_DATA);
+  ValidateFetch(this->stmt, SQL_NO_DATA);
 
   DropTestTable();
 }
@@ -374,37 +375,39 @@ TEST_F(TablesMockTest, SQLTablesGetMetadataForTableType) {
   std::wstring expected_table_name = std::wstring(L"TestTable");
   std::wstring expected_table_type = std::wstring(table_type_table_lowercase);
 
-  EXPECT_EQ(SQL_SUCCESS, SQLTables(stmt, nullptr, SQL_NTS, nullptr, SQL_NTS, nullptr,
-                                   SQL_NTS, table_type_table_uppercase, SQL_NTS));
+  EXPECT_EQ(SQL_SUCCESS,
+            SQLTables(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS, nullptr, SQL_NTS,
+                      table_type_table_uppercase, SQL_NTS));
 
-  ValidateFetch(stmt, SQL_NO_DATA);
+  ValidateFetch(this->stmt, SQL_NO_DATA);
 
-  EXPECT_EQ(SQL_SUCCESS, SQLTables(stmt, nullptr, SQL_NTS, nullptr, SQL_NTS, nullptr,
-                                   SQL_NTS, table_type_view, SQL_NTS));
+  EXPECT_EQ(SQL_SUCCESS, SQLTables(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
+                                   nullptr, SQL_NTS, table_type_view, SQL_NTS));
 
-  ValidateFetch(stmt, SQL_NO_DATA);
+  ValidateFetch(this->stmt, SQL_NO_DATA);
 
-  EXPECT_EQ(SQL_SUCCESS, SQLTables(stmt, nullptr, SQL_NTS, nullptr, SQL_NTS, nullptr,
-                                   SQL_NTS, table_type_table_view, SQL_NTS));
+  EXPECT_EQ(SQL_SUCCESS, SQLTables(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
+                                   nullptr, SQL_NTS, table_type_table_view, SQL_NTS));
 
-  ValidateFetch(stmt, SQL_NO_DATA);
+  ValidateFetch(this->stmt, SQL_NO_DATA);
 
   // Returns user table as well as system tables, even though only type table requested
-  EXPECT_EQ(SQL_SUCCESS, SQLTables(stmt, nullptr, SQL_NTS, nullptr, SQL_NTS, nullptr,
-                                   SQL_NTS, table_type_table_lowercase, SQL_NTS));
+  EXPECT_EQ(SQL_SUCCESS,
+            SQLTables(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS, nullptr, SQL_NTS,
+                      table_type_table_lowercase, SQL_NTS));
 
   for (size_t i = 0; i < sizeof(table_names) / sizeof(*table_names); ++i) {
-    ValidateFetch(stmt, SQL_SUCCESS);
+    ValidateFetch(this->stmt, SQL_SUCCESS);
 
-    CheckStringColumnW(stmt, 1, expected_catalog_name);
+    CheckStringColumnW(this->stmt, 1, expected_catalog_name);
     // Mock server does not support table schema
-    CheckNullColumnW(stmt, 2);
-    CheckStringColumnW(stmt, 3, table_names[i]);
-    CheckStringColumnW(stmt, 4, expected_table_type);
-    CheckNullColumnW(stmt, 5);
+    CheckNullColumnW(this->stmt, 2);
+    CheckStringColumnW(this->stmt, 3, table_names[i]);
+    CheckStringColumnW(this->stmt, 4, expected_table_type);
+    CheckNullColumnW(this->stmt, 5);
   }
 
-  ValidateFetch(stmt, SQL_NO_DATA);
+  ValidateFetch(this->stmt, SQL_NO_DATA);
 
   DropTestTable();
 }
@@ -423,18 +426,18 @@ TEST_F(TablesRemoteTest, SQLTablesGetMetadataForTableTypeTable) {
   std::wstring expected_table_type = std::wstring(L"TABLE");
 
   for (size_t i = 0; i < sizeof(type_list) / sizeof(*type_list); ++i) {
-    ASSERT_EQ(SQL_SUCCESS, SQLTables(stmt, nullptr, SQL_NTS, nullptr, SQL_NTS, nullptr,
-                                     SQL_NTS, type_list[i], SQL_NTS));
+    ASSERT_EQ(SQL_SUCCESS, SQLTables(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
+                                     nullptr, SQL_NTS, type_list[i], SQL_NTS));
 
-    ValidateFetch(stmt, SQL_SUCCESS);
+    ValidateFetch(this->stmt, SQL_SUCCESS);
 
-    CheckNullColumnW(stmt, 1);
-    CheckStringColumnW(stmt, 2, expected_schema_name);
-    CheckStringColumnW(stmt, 3, expected_table_name);
-    CheckStringColumnW(stmt, 4, expected_table_type);
-    CheckNullColumnW(stmt, 5);
+    CheckNullColumnW(this->stmt, 1);
+    CheckStringColumnW(this->stmt, 2, expected_schema_name);
+    CheckStringColumnW(this->stmt, 3, expected_table_name);
+    CheckStringColumnW(this->stmt, 4, expected_table_type);
+    CheckNullColumnW(this->stmt, 5);
 
-    ValidateFetch(stmt, SQL_NO_DATA);
+    ValidateFetch(this->stmt, SQL_NO_DATA);
   }
 }
 
@@ -442,15 +445,15 @@ TEST_F(TablesRemoteTest, SQLTablesGetMetadataForTableTypeViewHasNoData) {
   SQLWCHAR empty[] = L"";
   SQLWCHAR type_view[] = L"VIEW";
 
-  EXPECT_EQ(SQL_SUCCESS, SQLTables(stmt, nullptr, SQL_NTS, nullptr, SQL_NTS, empty,
+  EXPECT_EQ(SQL_SUCCESS, SQLTables(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS, empty,
                                    SQL_NTS, type_view, SQL_NTS));
 
-  ValidateFetch(stmt, SQL_NO_DATA);
+  ValidateFetch(this->stmt, SQL_NO_DATA);
 
-  EXPECT_EQ(SQL_SUCCESS, SQLTables(stmt, nullptr, SQL_NTS, nullptr, SQL_NTS, nullptr,
-                                   SQL_NTS, type_view, SQL_NTS));
+  EXPECT_EQ(SQL_SUCCESS, SQLTables(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
+                                   nullptr, SQL_NTS, type_view, SQL_NTS));
 
-  ValidateFetch(stmt, SQL_NO_DATA);
+  ValidateFetch(this->stmt, SQL_NO_DATA);
 }
 
 TEST_F(TablesMockTest, SQLTablesGetSupportedTableTypes) {
@@ -459,18 +462,18 @@ TEST_F(TablesMockTest, SQLTablesGetSupportedTableTypes) {
   std::wstring expected_table_type = std::wstring(L"table");
 
   // Mock server returns lower case for supported type of "table"
-  ASSERT_EQ(SQL_SUCCESS, SQLTables(stmt, empty, SQL_NTS, empty, SQL_NTS, empty, SQL_NTS,
-                                   SQL_ALL_TABLE_TYPES_W, SQL_NTS));
+  ASSERT_EQ(SQL_SUCCESS, SQLTables(this->stmt, empty, SQL_NTS, empty, SQL_NTS, empty,
+                                   SQL_NTS, SQL_ALL_TABLE_TYPES_W, SQL_NTS));
 
-  ValidateFetch(stmt, SQL_SUCCESS);
+  ValidateFetch(this->stmt, SQL_SUCCESS);
 
-  CheckNullColumnW(stmt, 1);
-  CheckNullColumnW(stmt, 2);
-  CheckNullColumnW(stmt, 3);
-  CheckStringColumnW(stmt, 4, expected_table_type);
-  CheckNullColumnW(stmt, 5);
+  CheckNullColumnW(this->stmt, 1);
+  CheckNullColumnW(this->stmt, 2);
+  CheckNullColumnW(this->stmt, 3);
+  CheckStringColumnW(this->stmt, 4, expected_table_type);
+  CheckNullColumnW(this->stmt, 5);
 
-  ValidateFetch(stmt, SQL_NO_DATA);
+  ValidateFetch(this->stmt, SQL_NO_DATA);
 }
 
 TEST_F(TablesRemoteTest, SQLTablesGetSupportedTableTypes) {
@@ -480,20 +483,20 @@ TEST_F(TablesRemoteTest, SQLTablesGetSupportedTableTypes) {
                                   static_cast<const SQLWCHAR*>(L"SYSTEM_TABLE"),
                                   static_cast<const SQLWCHAR*>(L"VIEW")};
 
-  ASSERT_EQ(SQL_SUCCESS, SQLTables(stmt, empty, SQL_NTS, empty, SQL_NTS, empty, SQL_NTS,
-                                   SQL_ALL_TABLE_TYPES_W, SQL_NTS));
+  ASSERT_EQ(SQL_SUCCESS, SQLTables(this->stmt, empty, SQL_NTS, empty, SQL_NTS, empty,
+                                   SQL_NTS, SQL_ALL_TABLE_TYPES_W, SQL_NTS));
 
   for (size_t i = 0; i < sizeof(type_lists) / sizeof(*type_lists); ++i) {
-    ValidateFetch(stmt, SQL_SUCCESS);
+    ValidateFetch(this->stmt, SQL_SUCCESS);
 
-    CheckNullColumnW(stmt, 1);
-    CheckNullColumnW(stmt, 2);
-    CheckNullColumnW(stmt, 3);
-    CheckStringColumnW(stmt, 4, type_lists[i]);
-    CheckNullColumnW(stmt, 5);
+    CheckNullColumnW(this->stmt, 1);
+    CheckNullColumnW(this->stmt, 2);
+    CheckNullColumnW(this->stmt, 3);
+    CheckStringColumnW(this->stmt, 4, type_lists[i]);
+    CheckNullColumnW(this->stmt, 5);
   }
 
-  ValidateFetch(stmt, SQL_NO_DATA);
+  ValidateFetch(this->stmt, SQL_NO_DATA);
 }
 
 TYPED_TEST(TablesTest, SQLTablesGetMetadataBySQLDescribeCol) {
@@ -516,15 +519,15 @@ TYPED_TEST(TablesTest, SQLTablesGetMetadataBySQLDescribeCol) {
                                      SQL_WVARCHAR, SQL_WVARCHAR};
   SQLULEN column_sizes[] = {1024, 1024, 1024, 1024, 1024};
 
-  ASSERT_EQ(SQL_SUCCESS, SQLTables(stmt, nullptr, SQL_NTS, nullptr, SQL_NTS, nullptr,
-                                   SQL_NTS, nullptr, SQL_NTS));
+  ASSERT_EQ(SQL_SUCCESS, SQLTables(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
+                                   nullptr, SQL_NTS, nullptr, SQL_NTS));
 
   for (size_t i = 0; i < sizeof(column_names) / sizeof(*column_names); ++i) {
     column_index = i + 1;
 
-    ASSERT_EQ(SQL_SUCCESS, SQLDescribeCol(stmt, column_index, column_name, buf_char_len,
-                                          &name_length, &column_data_type, &column_size,
-                                          &decimal_digits, &nullable));
+    ASSERT_EQ(SQL_SUCCESS, SQLDescribeCol(this->stmt, column_index, column_name,
+                                          buf_char_len, &name_length, &column_data_type,
+                                          &column_size, &decimal_digits, &nullable));
 
     EXPECT_EQ(wcslen(column_names[i]), name_length);
 
@@ -563,15 +566,15 @@ TYPED_TEST(TablesOdbcV2Test, SQLTablesGetMetadataBySQLDescribeColODBCVer2) {
                                      SQL_WVARCHAR, SQL_WVARCHAR};
   SQLULEN column_sizes[] = {1024, 1024, 1024, 1024, 1024};
 
-  ASSERT_EQ(SQL_SUCCESS, SQLTables(stmt, nullptr, SQL_NTS, nullptr, SQL_NTS, nullptr,
-                                   SQL_NTS, nullptr, SQL_NTS));
+  ASSERT_EQ(SQL_SUCCESS, SQLTables(this->stmt, nullptr, SQL_NTS, nullptr, SQL_NTS,
+                                   nullptr, SQL_NTS, nullptr, SQL_NTS));
 
   for (size_t i = 0; i < sizeof(column_names) / sizeof(*column_names); ++i) {
     column_index = i + 1;
 
-    ASSERT_EQ(SQL_SUCCESS, SQLDescribeCol(stmt, column_index, column_name, buf_char_len,
-                                          &name_length, &column_data_type, &column_size,
-                                          &decimal_digits, &nullable));
+    ASSERT_EQ(SQL_SUCCESS, SQLDescribeCol(this->stmt, column_index, column_name,
+                                          buf_char_len, &name_length, &column_data_type,
+                                          &column_size, &decimal_digits, &nullable));
 
     EXPECT_EQ(wcslen(column_names[i]), name_length);
 

--- a/cpp/src/arrow/flight/sql/odbc/tests/type_info_test.cc
+++ b/cpp/src/arrow/flight/sql/odbc/tests/type_info_test.cc
@@ -1900,10 +1900,10 @@ TEST_F(TypeInfoMockTest, TestSQLGetTypeInfoInvalidDataType) {
 TYPED_TEST(TypeInfoTest, TestSQLGetTypeInfoUnsupportedDataType) {
   // Assumes mock and remote server don't support GUID data type
 
-  ASSERT_EQ(SQL_SUCCESS, SQLGetTypeInfo(stmt, SQL_GUID));
+  ASSERT_EQ(SQL_SUCCESS, SQLGetTypeInfo(this->stmt, SQL_GUID));
 
   // Result set is empty with valid data type that is unsupported by the server
-  ASSERT_EQ(SQL_NO_DATA, SQLFetch(stmt));
+  ASSERT_EQ(SQL_NO_DATA, SQLFetch(this->stmt));
 }
 
 }  // namespace arrow::flight::sql::odbc


### PR DESCRIPTION
### Rationale for this change
We avoid crashing tests on Linux if we minimize the number of connect/disconnect attempts. So now we are reusing the same connection as much as possible throughout the tests.

### What changes are included in this PR?
All our necessary connections happen during global `SetUp()` and then they get disconnected during global `TearDown()`.
Test Fixture SetUp logic is now about updating pointers to the correct environment, connection, and statement handles for those tests.

### Are these changes tested?
Yes.

### Are there any user-facing changes?
No.
* GitHub Issue: #49783