### PR TITLE
MINOR: [Dev][CI] Install libuv1-dev in dev.yml lint step for R fs package

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -57,7 +57,8 @@ jobs:
           sudo apt install -y -V \
             pre-commit \
             r-base \
-            ruby-dev
+            ruby-dev \
+            libuv1-dev
       - name: Cache pre-commit
         uses: actions/cache@v5
         with:


### PR DESCRIPTION
### Rationale for this change

Pre-commit in CI just started to fail trying to install the R `fs` package. See https://github.com/apache/arrow/actions/runs/24610839359. 

I think we didn't see this until now because we were using cached pre-commit and a recent PR of mine just invalidated the cache incidentally. See also https://github.com/apache/arrow/pull/49594. The `fs` package recently made a change that requires we install libuv development headers to install it.

### What changes are included in this PR?

- Updates dev.yml to Install libuv1-dev

### Are these changes tested?

Yes. See my other PR: https://github.com/apache/arrow/pull/49788#issuecomment-4274307436.

### Are there any user-facing changes?

No.