### PR TITLE
GH-49738: [R][CI] Re-enable GCC+LTO job once rhub has a GCC 15 image

### DIFF
--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -70,7 +70,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        r: ["4.5"]
+        r: ["4.6"]
         ubuntu: [24.04]
         force-tests: ["true"]
     env:

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -70,7 +70,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        r: ["4.4"]
+        r: ["4.5"]
         ubuntu: [24.04]
         force-tests: ["true"]
     env:

--- a/.github/workflows/r_extra.yml
+++ b/.github/workflows/r_extra.yml
@@ -140,10 +140,10 @@ jobs:
           - envs:
               - R_IMAGE=r-base
               - R_ORG=rstudio
-              - R_TAG=4.4-jammy
+              - R_TAG=4.5-jammy
             image: r
             runs-on: ubuntu-latest
-            title: RStudio R-Base 4.4
+            title: RStudio R-Base 4.5
     env:
       ARCHERY_DEBUG: 1
       ARROW_ENABLE_TIMING_TESTS: OFF

--- a/.github/workflows/r_extra.yml
+++ b/.github/workflows/r_extra.yml
@@ -129,34 +129,21 @@ jobs:
             image: r
             runs-on: ubuntu-latest
             title: Rhub
-          # Disabled: rhub/ubuntu-gcc12 image uses GCC 12 but CRAN now uses GCC 15.
-          # See https://github.com/apache/arrow/issues/49737
-          # Re-enable once r-hub/containers provides a GCC 15 image (#49738).
-          # - envs:
-          #     - R_CUSTOM_CCACHE=true
-          #     - R_IMAGE=ubuntu-gcc12
-          #     - R_ORG=rhub
-          #   image: r
-          #   runs-on: ubuntu-latest
-          #   title: Rhub GCC 12
-          # Disabled: rhub/gcc13 image uses GCC 13 but CRAN now uses GCC 15.
-          # See https://github.com/apache/arrow/issues/49737
-          # Re-enable once r-hub/containers provides a GCC 15 image (#49738).
-          # - envs:
-          #     - R_IMAGE=gcc13
-          #     - R_ORG=rhub
-          #   image: r
-          #   runs-on: ubuntu-latest
-          #   run-options: >-
-          #     -e INSTALL_ARGS=--use-LTO
-          #   title: Rhub GCC 13 with LTO
+          - envs:
+              - R_IMAGE=ubuntu-gcc15
+              - R_ORG=rhub
+            image: r
+            runs-on: ubuntu-latest
+            run-options: >-
+              -e INSTALL_ARGS=--use-LTO
+            title: Rhub GCC 15 with LTO
           - envs:
               - R_IMAGE=r-base
               - R_ORG=rstudio
-              - R_TAG=4.2-jammy
+              - R_TAG=4.4-jammy
             image: r
             runs-on: ubuntu-latest
-            title: RStudio R-Base 4.2
+            title: RStudio R-Base 4.4
     env:
       ARCHERY_DEBUG: 1
       ARROW_ENABLE_TIMING_TESTS: OFF

--- a/dev/tasks/r/github.linux.versions.yml
+++ b/dev/tasks/r/github.linux.versions.yml
@@ -33,6 +33,7 @@ jobs:
           - "4.1"
           - "4.2"
           - "4.3"
+          - "4.4"
     env:
       R_ORG: "rstudio"
       R_IMAGE: "r-base"

--- a/dev/tasks/r/github.linux.versions.yml
+++ b/dev/tasks/r/github.linux.versions.yml
@@ -34,6 +34,7 @@ jobs:
           - "4.2"
           - "4.3"
           - "4.4"
+          - "4.5"
     env:
       R_ORG: "rstudio"
       R_IMAGE: "r-base"

--- a/r/tests/testthat/helper-arrow.R
+++ b/r/tests/testthat/helper-arrow.R
@@ -36,19 +36,25 @@ options(arrow.pull_as_vector = FALSE)
 with_language <- function(lang, expr) {
   skip_on_cran()
   skip_if_not(capabilities("NLS"))
-  old <- Sys.getenv("LANGUAGE")
-  # Check what this message is before changing languages; this will
-  # trigger caching the translations if the OS does that (some do).
-  # If the OS does cache, then we can't test changing languages safely.
-  before <- i18ize_error_messages()
-  Sys.setenv(LANGUAGE = lang)
-  on.exit({
-    Sys.setenv(LANGUAGE = old)
+  # We know we're LANGUAGE=en because we just set it above.
+  # We only need to check whether we can change languages if we're not "en".
+  if (!identical(lang, "en")) {
     .cache$i18ized_error_pattern <<- NULL
-  })
-  if (!identical(before, i18ize_error_messages())) {
-    skip(paste("This OS either does not support changing languages to", lang, "or it caches translations"))
+    old <- Sys.getenv("LANGUAGE")
+    # Check what this message is before changing languages; this will
+    # trigger caching the translations if the OS does that (some do).
+    # If the OS does cache, then we can't test changing languages safely.
+    before <- i18ize_error_messages()
+    Sys.setenv(LANGUAGE = lang)
+    on.exit({
+      Sys.setenv(LANGUAGE = old)
+      .cache$i18ized_error_pattern <<- NULL
+    })
+    if (identical(before, i18ize_error_messages())) {
+      skip(paste("This OS either does not support changing languages to", lang, "or it caches translations"))
+    }
   }
+
   force(expr)
 }
 

--- a/r/tests/testthat/helper-arrow.R
+++ b/r/tests/testthat/helper-arrow.R
@@ -35,19 +35,25 @@ options(arrow.pull_as_vector = FALSE)
 
 with_language <- function(lang, expr) {
   skip_on_cran()
-  old <- Sys.getenv("LANGUAGE")
-  # Check what this message is before changing languages; this will
-  # trigger caching the translations if the OS does that (some do).
-  # If the OS does cache, then we can't test changing languages safely.
-  before <- i18ize_error_messages()
-  Sys.setenv(LANGUAGE = lang)
-  on.exit({
-    Sys.setenv(LANGUAGE = old)
+  # We know we're LANGUAGE=en because we just set it above.
+  # We only need to check whether we can change languages if we're not "en".
+  if (!identical(lang, "en")) {
     .cache$i18ized_error_pattern <<- NULL
-  })
-  if (!identical(before, i18ize_error_messages())) {
-    skip(paste("This OS either does not support changing languages to", lang, "or it caches translations"))
+    old <- Sys.getenv("LANGUAGE")
+    # Check what this message is before changing languages; this will
+    # trigger caching the translations if the OS does that (some do).
+    # If the OS does cache, then we can't test changing languages safely.
+    before <- i18ize_error_messages()
+    Sys.setenv(LANGUAGE = lang)
+    on.exit({
+      Sys.setenv(LANGUAGE = old)
+      .cache$i18ized_error_pattern <<- NULL
+    })
+    if (identical(before, i18ize_error_messages())) {
+      skip(paste("This OS either does not support changing languages to", lang, "or it caches translations"))
+    }
   }
+
   force(expr)
 }
 

--- a/r/tests/testthat/test-dplyr-filter.R
+++ b/r/tests/testthat/test-dplyr-filter.R
@@ -287,24 +287,25 @@ test_that("filter environment scope", {
 })
 
 test_that("Filtering on a column that doesn't exist errors correctly", {
+  # expect_warning(., NA) because the usual behavior when it hits a filter
+  # that it can't evaluate is to raise a warning, collect() to R, and retry
+  # the filter. But we want this to error the first time because it's
+  # a user error, not solvable by retrying in R
+  expect_warning(
+    expect_error(
+      tbl |> record_batch() |> filter(not_a_col == 42) |> collect(),
+      class = "validation_error"
+    ),
+    NA
+  )
+})
+
+test_that("Filtering on a non-existent column errors in the correct language", {
   with_language("fr", {
-    # expect_warning(., NA) because the usual behavior when it hits a filter
-    # that it can't evaluate is to raise a warning, collect() to R, and retry
-    # the filter. But we want this to error the first time because it's
-    # a user error, not solvable by retrying in R
     expect_warning(
       expect_error(
         tbl |> record_batch() |> filter(not_a_col == 42) |> collect(),
         "objet 'not_a_col' introuvable"
-      ),
-      NA
-    )
-  })
-  with_language("en", {
-    expect_warning(
-      expect_error(
-        tbl |> record_batch() |> filter(not_a_col == 42) |> collect(),
-        "object 'not_a_col' not found"
       ),
       NA
     )

--- a/r/tests/testthat/test-dplyr-filter.R
+++ b/r/tests/testthat/test-dplyr-filter.R
@@ -294,7 +294,7 @@ test_that("Filtering on a column that doesn't exist errors correctly", {
   expect_warning(
     expect_error(
       tbl |> record_batch() |> filter(not_a_col == 42) |> collect(),
-      class = "validation_error"
+      "object 'not_a_col' not found"
     ),
     NA
   )


### PR DESCRIPTION
### Rationale for this change

We removed a job as it was too old and didn't reflect CRAN and now we added it in as we have one which does reflect CRAN's environments

### What changes are included in this PR?

Add GCC 15 job

### Are these changes tested?

On CI, sure

### Are there any user-facing changes?

Nah
* GitHub Issue: #49738