### PR TITLE
GH-41017: [C++] Preserve ordered flag in DictionaryBuilder

### DIFF
--- a/cpp/src/arrow/array/array_dict_test.cc
+++ b/cpp/src/arrow/array/array_dict_test.cc
@@ -1761,4 +1761,93 @@ TEST(TestDictionaryUnifier, TableZeroColumns) {
   AssertTablesEqual(*table, *unified);
 }
 
+// GH-41017: DictionaryBuilder should preserve the ordered flag
+TEST(TestDictionaryBuilder, MakeBuilderPreservesOrdered) {
+  auto ordered_type = dictionary(int8(), utf8(), /*ordered=*/true);
+  std::unique_ptr<ArrayBuilder> boxed_builder;
+  ASSERT_OK(MakeBuilder(default_memory_pool(), ordered_type, &boxed_builder));
+
+  auto& builder = checked_cast<DictionaryBuilder<StringType>&>(*boxed_builder);
+  ASSERT_OK(builder.Append("a"));
+  ASSERT_OK(builder.Append("b"));
+  ASSERT_OK(builder.Append("a"));
+
+  std::shared_ptr<Array> result;
+  ASSERT_OK(builder.Finish(&result));
+
+  const auto& result_type = checked_cast<const DictionaryType&>(*result->type());
+  ASSERT_TRUE(result_type.ordered())
+      << "DictionaryBuilder should preserve ordered=true from the input type";
+}
+
+TEST(TestDictionaryBuilder, MakeBuilderUnorderedByDefault) {
+  auto unordered_type = dictionary(int8(), utf8(), /*ordered=*/false);
+  std::unique_ptr<ArrayBuilder> boxed_builder;
+  ASSERT_OK(MakeBuilder(default_memory_pool(), unordered_type, &boxed_builder));
+
+  auto& builder = checked_cast<DictionaryBuilder<StringType>&>(*boxed_builder);
+  ASSERT_OK(builder.Append("x"));
+
+  std::shared_ptr<Array> result;
+  ASSERT_OK(builder.Finish(&result));
+
+  const auto& result_type = checked_cast<const DictionaryType&>(*result->type());
+  ASSERT_FALSE(result_type.ordered());
+}
+
+TEST(TestDictionaryBuilder, MakeDictionaryBuilderPreservesOrdered) {
+  auto ordered_type = dictionary(int8(), int32(), /*ordered=*/true);
+  std::unique_ptr<ArrayBuilder> builder;
+  ASSERT_OK(
+      MakeDictionaryBuilder(default_memory_pool(), ordered_type, nullptr, &builder));
+
+  auto& dict_builder = checked_cast<DictionaryBuilder<Int32Type>&>(*builder);
+  ASSERT_OK(dict_builder.Append(10));
+  ASSERT_OK(dict_builder.Append(20));
+
+  std::shared_ptr<Array> result;
+  ASSERT_OK(dict_builder.Finish(&result));
+
+  const auto& result_type = checked_cast<const DictionaryType&>(*result->type());
+  ASSERT_TRUE(result_type.ordered());
+}
+
+// GH-41017: NullType dictionary builder should also preserve the ordered flag
+TEST(TestDictionaryBuilder, MakeBuilderNullTypePreservesOrdered) {
+  auto ordered_type = dictionary(int8(), null(), /*ordered=*/true);
+  std::unique_ptr<ArrayBuilder> boxed_builder;
+  ASSERT_OK(MakeBuilder(default_memory_pool(), ordered_type, &boxed_builder));
+
+  std::shared_ptr<Array> result;
+  ASSERT_OK(boxed_builder->Resize(0));
+  ASSERT_OK(boxed_builder->Finish(&result));
+
+  const auto& result_type = checked_cast<const DictionaryType&>(*result->type());
+  ASSERT_TRUE(result_type.ordered())
+      << "NullType DictionaryBuilder should preserve ordered=true";
+}
+
+// GH-41017: ordered_ should survive Reset() + second Finish()
+TEST(TestDictionaryBuilder, OrderedFlagSurvivesReset) {
+  auto ordered_type = dictionary(int8(), utf8(), /*ordered=*/true);
+  std::unique_ptr<ArrayBuilder> boxed_builder;
+  ASSERT_OK(MakeBuilder(default_memory_pool(), ordered_type, &boxed_builder));
+
+  auto& builder = checked_cast<DictionaryBuilder<StringType>&>(*boxed_builder);
+
+  // First finish
+  ASSERT_OK(builder.Append("a"));
+  std::shared_ptr<Array> result1;
+  ASSERT_OK(builder.Finish(&result1));
+  ASSERT_TRUE(checked_cast<const DictionaryType&>(*result1->type()).ordered());
+
+  // After Reset(), ordered_ must still be true
+  ASSERT_OK(builder.Resize(1));
+  ASSERT_OK(builder.Append("b"));
+  std::shared_ptr<Array> result2;
+  ASSERT_OK(builder.Finish(&result2));
+  ASSERT_TRUE(checked_cast<const DictionaryType&>(*result2->type()).ordered())
+      << "ordered_ should survive Reset()";
+}
+
 }  // namespace arrow

--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -854,6 +854,18 @@ TEST_F(TestArray, TestMakeEmptyArray) {
   }
 }
 
+// GH-41017: MakeEmptyArray calls MakeBuilder internally. Verify that the ordered
+// flag of a DictionaryType is preserved (was silently dropped before this fix).
+TEST_F(TestArray, TestMakeEmptyArrayPreservesDictionaryOrdered) {
+  auto ordered_type = dictionary(int8(), utf8(), /*ordered=*/true);
+  ASSERT_OK_AND_ASSIGN(auto array, MakeEmptyArray(ordered_type));
+  ASSERT_OK(array->ValidateFull());
+  ASSERT_EQ(array->length(), 0);
+  const auto& result_type = checked_cast<const DictionaryType&>(*array->type());
+  ASSERT_TRUE(result_type.ordered())
+      << "MakeEmptyArray must preserve ordered=true from the input DictionaryType";
+}
+
 TEST_F(TestArray, TestFillFromScalar) {
   for (auto type : TestArrayUtilitiesAgainstTheseTypes()) {
     ARROW_SCOPED_TRACE("type = ", type->ToString());

--- a/cpp/src/arrow/array/builder_dict.h
+++ b/cpp/src/arrow/array/builder_dict.h
@@ -490,8 +490,11 @@ class DictionaryBuilderBase : public ArrayBuilder {
   Status Finish(std::shared_ptr<DictionaryArray>* out) { return FinishTyped(out); }
 
   std::shared_ptr<DataType> type() const override {
-    return ::arrow::dictionary(indices_builder_.type(), value_type_);
+    return ::arrow::dictionary(indices_builder_.type(), value_type_, ordered_);
   }
+
+  /// \brief Set whether the dictionary is ordered
+  void set_ordered(bool ordered) { ordered_ = ordered; }
 
  protected:
   template <typename c_type>
@@ -558,6 +561,9 @@ class DictionaryBuilderBase : public ArrayBuilder {
 
   // Only used for FixedSizeBinaryType
   int32_t byte_width_;
+
+  // Whether the dictionary is ordered
+  bool ordered_ = false;
 
   BuilderType indices_builder_;
   std::shared_ptr<DataType> value_type_;
@@ -647,7 +653,7 @@ class DictionaryBuilderBase<BuilderType, NullType> : public ArrayBuilder {
 
   Status FinishInternal(std::shared_ptr<ArrayData>* out) override {
     ARROW_RETURN_NOT_OK(indices_builder_.FinishInternal(out));
-    (*out)->type = dictionary((*out)->type, null());
+    (*out)->type = dictionary((*out)->type, null(), ordered_);
     (*out)->dictionary = NullArray(0).data();
     return Status::OK();
   }
@@ -659,11 +665,15 @@ class DictionaryBuilderBase<BuilderType, NullType> : public ArrayBuilder {
   Status Finish(std::shared_ptr<DictionaryArray>* out) { return FinishTyped(out); }
 
   std::shared_ptr<DataType> type() const override {
-    return ::arrow::dictionary(indices_builder_.type(), null());
+    return ::arrow::dictionary(indices_builder_.type(), null(), ordered_);
   }
+
+  /// \brief Set whether the dictionary is ordered
+  void set_ordered(bool ordered) { ordered_ = ordered; }
 
  protected:
   BuilderType indices_builder_;
+  bool ordered_ = false;
 };
 
 }  // namespace internal

--- a/cpp/src/arrow/builder.cc
+++ b/cpp/src/arrow/builder.cc
@@ -169,16 +169,23 @@ struct DictionaryBuilderCase {
   Status CreateFor() {
     using AdaptiveBuilderType = DictionaryBuilder<ValueType>;
     if (dictionary != nullptr) {
-      out->reset(new AdaptiveBuilderType(dictionary, pool));
+      auto* builder = new AdaptiveBuilderType(dictionary, pool);
+      builder->set_ordered(ordered);
+      out->reset(builder);
     } else if (exact_index_type) {
       if (!is_integer(index_type->id())) {
         return Status::TypeError("MakeBuilder: invalid index type ", *index_type);
       }
-      out->reset(new internal::DictionaryBuilderBase<TypeErasedIntBuilder, ValueType>(
-          index_type, value_type, pool));
+      auto* builder =
+          new internal::DictionaryBuilderBase<TypeErasedIntBuilder, ValueType>(
+              index_type, value_type, pool);
+      builder->set_ordered(ordered);
+      out->reset(builder);
     } else {
       auto start_int_size = index_type->byte_width();
-      out->reset(new AdaptiveBuilderType(start_int_size, value_type, pool));
+      auto* builder = new AdaptiveBuilderType(start_int_size, value_type, pool);
+      builder->set_ordered(ordered);
+      out->reset(builder);
     }
     return Status::OK();
   }
@@ -191,6 +198,7 @@ struct DictionaryBuilderCase {
   const std::shared_ptr<Array>& dictionary;
   bool exact_index_type;
   std::unique_ptr<ArrayBuilder>* out;
+  bool ordered;
 };
 
 struct MakeBuilderImpl {
@@ -206,7 +214,8 @@ struct MakeBuilderImpl {
                                      dict_type.value_type(),
                                      /*dictionary=*/nullptr,
                                      exact_index_type,
-                                     &out};
+                                     &out,
+                                     dict_type.ordered()};
     return visitor.Make();
   }
 
@@ -332,9 +341,13 @@ Status MakeDictionaryBuilder(MemoryPool* pool, const std::shared_ptr<DataType>& 
                              const std::shared_ptr<Array>& dictionary,
                              std::unique_ptr<ArrayBuilder>* out) {
   const auto& dict_type = static_cast<const DictionaryType&>(*type);
-  DictionaryBuilderCase visitor = {
-      pool,       dict_type.index_type(),     dict_type.value_type(),
-      dictionary, /*exact_index_type=*/false, out};
+  DictionaryBuilderCase visitor = {pool,
+                                   dict_type.index_type(),
+                                   dict_type.value_type(),
+                                   dictionary,
+                                   /*exact_index_type=*/false,
+                                   out,
+                                   dict_type.ordered()};
   return visitor.Make();
 }
 

--- a/cpp/src/arrow/record_batch_test.cc
+++ b/cpp/src/arrow/record_batch_test.cc
@@ -680,6 +680,21 @@ TEST_F(TestRecordBatch, MakeEmpty) {
   ASSERT_EQ(empty->num_rows(), 0);
 }
 
+// GH-41017 / GH-49674: RecordBatch::MakeEmpty calls MakeEmptyArray which calls
+// MakeBuilder. Verify that the ordered flag of a DictionaryType is preserved.
+TEST_F(TestRecordBatch, MakeEmptyPreservesDictionaryOrdered) {
+  auto dict_type = dictionary(int32(), utf8(), /*ordered=*/true);
+  auto schema = ::arrow::schema({field("col", dict_type)});
+
+  ASSERT_OK_AND_ASSIGN(auto batch, RecordBatch::MakeEmpty(schema));
+  ASSERT_EQ(batch->num_rows(), 0);
+  ASSERT_EQ(batch->num_columns(), 1);
+
+  const auto& array_type = static_cast<const DictionaryType&>(*batch->column(0)->type());
+  ASSERT_TRUE(array_type.ordered())
+      << "RecordBatch::MakeEmpty lost ordered flag in dictionary-encoded column";
+}
+
 // See: https://github.com/apache/arrow/issues/35450
 TEST_F(TestRecordBatch, ToStructArrayMismatchedColumnLengths) {
   constexpr int kNumRows = 5;


### PR DESCRIPTION
### Rationale for this change

`DictionaryBuilderBase::type()` does not pass the `ordered` parameter to `::arrow::dictionary()`, causing it to always default to `false`. This means that any `DictionaryArray` built through `MakeBuilder()` or `MakeDictionaryBuilder()` with an ordered `DictionaryType` will produce an array where `type().ordered() == false`.

The `ordered` flag is a semantic annotation from the Arrow spec, not a guarantee that values are physically sorted. A typical use case is `pandas.CategoricalDtype(ordered=True)`: the user builds a dictionary array incrementally but needs the result to carry `ordered=true` for correct round-trips. `DictionaryBuilder` builds values as they appear; `ordered` just ensures the type metadata is preserved.

This affects PyArrow users: `pa.array(data, type=pa.dictionary(pa.int8(), pa.string(), ordered=True))` returns an array with `ordered=False`.

Reported in: https://github.com/apache/arrow/issues/41017
Also caused: https://github.com/pandas-dev/pandas/issues/58152
Also resolves: https://github.com/apache/arrow/issues/49674

### What changes are included in this PR?

Add `ordered_` member to `DictionaryBuilderBase` and propagate it through `type()`, `FinishInternal()`, `MakeBuilderImpl`, and `MakeDictionaryBuilder()`.

### Are these changes tested?

Yes. Added 7 C++ tests:
- `array_dict_test.cc`: `MakeBuilderPreservesOrdered`, `MakeBuilderUnorderedByDefault`, `MakeDictionaryBuilderPreservesOrdered`, `MakeBuilderNullTypePreservesOrdered`, `OrderedFlagSurvivesReset`
- `array_test.cc`: `TestMakeEmptyArrayPreservesDictionaryOrdered`
- `record_batch_test.cc`: `MakeEmptyPreservesDictionaryOrdered` (covers the full `RecordBatch::MakeEmpty → MakeEmptyArray → MakeBuilder` path)

### Are there any user-facing changes?

No API changes. `DictionaryBuilder` now correctly preserves the `ordered` flag from the input `DictionaryType`.

* GitHub Issue: #41017

### AI usage

Used GitHub Copilot to assist with the implementation. I identified the root cause, went through the generated code in detail, and verified the fix with C++ tests.