### PR TITLE
GH-49674: [C++][Array] Preserve ordered flag for DictionaryType in MakeEmptyArray

### DIFF
--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -4433,4 +4433,25 @@ TEST_F(TestDayTimeIntervalBuilder, TestConstructors) {
   ASSERT_TRUE(builder3.type()->Equals(type));
 }
 
+TEST(ArrayTest, MakeEmptyPreservesDictionaryOrderedFlagInArray) {
+  auto dict_type = arrow::dictionary(arrow::int32(), arrow::utf8(), /*ordered=*/true);
+  auto schema = arrow::schema({arrow::field("col", dict_type)});
+
+  ASSERT_OK_AND_ASSIGN(auto batch, arrow::RecordBatch::MakeEmpty(schema));
+
+  ASSERT_EQ(batch->num_rows(), 0);
+  ASSERT_EQ(batch->num_columns(), 1);
+
+  // Schema should be correct
+  auto schema_type =
+      std::static_pointer_cast<arrow::DictionaryType>(batch->schema()->field(0)->type());
+  // Ensure array type preserves the ordered flag
+  auto array_type =
+      std::static_pointer_cast<arrow::DictionaryType>(batch->column(0)->type());
+
+  ASSERT_TRUE(schema_type->ordered());
+  ASSERT_TRUE(array_type->ordered()) << "MakeEmpty() lost ordered flag in array type";
+  ASSERT_TRUE(array_type->Equals(*schema_type));
+}
+
 }  // namespace arrow

--- a/cpp/src/arrow/array/util.cc
+++ b/cpp/src/arrow/array/util.cc
@@ -924,7 +924,12 @@ Result<std::shared_ptr<Array>> MakeEmptyArray(std::shared_ptr<DataType> type,
   std::unique_ptr<ArrayBuilder> builder;
   RETURN_NOT_OK(MakeBuilder(memory_pool, type, &builder));
   RETURN_NOT_OK(builder->Resize(0));
-  return builder->Finish();
+  ARROW_ASSIGN_OR_RAISE(auto result, builder->Finish());
+  // Preserve original DictionaryType (including ordered flag)
+  if (type->id() == Type::DICTIONARY) {
+    result->data()->type = type;
+  }
+  return result;
 }
 
 namespace internal {


### PR DESCRIPTION
### Rationale for this change

`RecordBatch::MakeEmpty() `creates arrays using `MakeEmptyArray()`, which relies on `ArrayBuilder::Finish()`. For dictionary-encoded types, `DictionaryBuilder` reconstructs the `DictionaryType` without preserving the ordered flag (defaulting it to false). As a result, the resulting array type does not match the input schema.

This change ensures that the original `DictionaryType` (including the ordered flag) is preserved.

### What changes are included in this PR?

Update `MakeEmptyArray()` to restore the original `DataType` for **dictionary types only** after `builder->Finish()`, ensuring the ordered flag is preserved.

Add a unit test to verify:

- The ordered flag is preserved.
- The resulting array type matches the schema.
- The created batch is empty and structurally correct.

### Are these changes tested?

Yes. A unit test has been added that:

- Constructs a dictionary-encoded schema with `ordered = true`.
- Calls `RecordBatch::MakeEmpty()`.
- Verifies that:
  - The batch is empty (`num_rows == 0`, `num_columns == 1`).
  - Both schema and array types preserve the ordered flag.
  - The array type matches the schema type.

### Are there any user-facing changes?

No.

Closes #49674 

* GitHub Issue: #49674