### PR TITLE
docs: add safety warning to Array.from_buffers docstring

### DIFF
--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -1323,6 +1323,12 @@ cdef class Array(_PandasConvertible):
 
         The concrete type returned depends on the datatype.
 
+        .. warning::
+
+           The caller is responsible for ensuring that the buffers contain
+           valid Arrow data matching the given type. Passing invalid data
+           may lead to crashes or undefined behavior when using the result.
+
         Parameters
         ----------
         type : DataType


### PR DESCRIPTION
## Summary

Adds a `.. warning::` directive to the `Array.from_buffers` docstring to explicitly inform callers that they are responsible for passing valid Arrow data matching the given type, and that passing invalid data may lead to crashes or undefined behavior.

This addresses the concern raised in the issue that users may not be aware of the safety implications of using this low-level API.

Closes #49717