### PR TITLE
GH-49816: [C++][FlightRPC] Only Run ODBC tests on ODBC CI

### DIFF
--- a/ci/scripts/cpp_test.sh
+++ b/ci/scripts/cpp_test.sh
@@ -87,7 +87,10 @@ case "$(uname)" in
     n_jobs=${NPROC:-1}
     ;;
 esac
-if [ "${#exclude_tests[@]}" -gt 0 ]; then
+if [ "$ARROW_FLIGHT_SQL_ODBC" = "ON" ]; then
+  # GH-49816: Only run ODBC tests on ODBC CI pipelines
+  ctest_options+=(--tests-regex "arrow-flight-sql-odbc-test|arrow-odbc-spi-impl-test")
+elif [ "${#exclude_tests[@]}" -gt 0 ]; then
   IFS="|"
   ctest_options+=(--exclude-regex "${exclude_tests[*]}")
   unset IFS


### PR DESCRIPTION
### Rationale for this change
GH-49816

Only run ODBC tests on ODBC CI for easier maintenance.

### What changes are included in this PR?
* CIs that have ODBC enabled (`ARROW_FLIGHT_SQL_ODBC: ON`) will only run ODBC tests `arrow-flight-sql-odbc-test` and `arrow-odbc-spi-impl-test`. 
* Only ODBC CIs are affected by this change

### Are these changes tested?
* Yes, in CI

### Are there any user-facing changes?
N/A
* GitHub Issue: #49816