### PR TITLE
GH-49823: [CI] Add missing contents: read permission to Package Linux workflow

### DIFF
--- a/.github/workflows/package_linux.yml
+++ b/.github/workflows/package_linux.yml
@@ -64,6 +64,7 @@ concurrency:
 
 permissions:
   actions: read
+  contents: read
   pull-requests: read
 
 jobs:


### PR DESCRIPTION
### Rationale for this change

The workflow is currently failing to trigger due to changes on permissions.

### What changes are included in this PR?

Added the missing `contents: read` permission to the failing workflow.

### Are these changes tested?

Yes, via CI and I've also validated the rest of extra workflows that use `./.github/workflows/check_labels.yml` contain the required permissions.

### Are there any user-facing changes?

No
* GitHub Issue: #49823