### PR TITLE
GH-49807: [CI] Remove obsolete test-ubuntu-22.04-cpp-20 job

### DIFF
--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -458,17 +458,6 @@ tasks:
         FEDORA: 42
       image: fedora-cpp
 
-{% for cpp_standard in [20] %}
-  test-ubuntu-22.04-cpp-{{ cpp_standard }}:
-    ci: github
-    template: docker-tests/github.linux.yml
-    params:
-      env:
-        UBUNTU: 22.04
-      flags: "-e CMAKE_CXX_STANDARD={{ cpp_standard }}"
-      image: ubuntu-cpp
-{% endfor %}
-
   test-ubuntu-22.04-cpp-no-threading:
     ci: github
     template: docker-tests/github.linux.yml


### PR DESCRIPTION
### Rationale for this change

C++20 is the standard we are currently using. No specific need to have a job for it. We already have a different job for C++23 so this job is just unnecessary.

### What changes are included in this PR?

Remove the unnecessary job

### Are these changes tested?

No but removed from archery

### Are there any user-facing changes?

No

* GitHub Issue: #49807