### PR TITLE
GH-49817: [C++] Reject decimal strings that exceed the target precision

### DIFF
--- a/cpp/src/arrow/array/array_test.cc
+++ b/cpp/src/arrow/array/array_test.cc
@@ -3445,16 +3445,16 @@ TEST_P(Decimal256Test, WithNulls) {
   std::vector<Decimal256> draw = {Decimal256(1), Decimal256(2),  Decimal256(-1),
                                   Decimal256(4), Decimal256(-1), Decimal256(1),
                                   Decimal256(2)};
-  Decimal256 big;  // (pow(2, 255) - 1) / pow(10, 38)
+  Decimal256 big;  // trimmed to kMaxPrecision (76) digits
   ASSERT_OK_AND_ASSIGN(big,
                        Decimal256::FromString("578960446186580977117854925043439539266."
-                                              "34992332820282019728792003956564819967"));
+                                              "3499233282028201972879200395656481996"));
   draw.push_back(big);
 
-  Decimal256 big_negative;  // -pow(2, 255) / pow(10, 38)
+  Decimal256 big_negative;  // trimmed to kMaxPrecision (76) digits
   ASSERT_OK_AND_ASSIGN(big_negative,
                        Decimal256::FromString("-578960446186580977117854925043439539266."
-                                              "34992332820282019728792003956564819968"));
+                                              "3499233282028201972879200395656481996"));
   draw.push_back(big_negative);
 
   std::vector<uint8_t> valid_bytes = {true, true, false, true, false,

--- a/cpp/src/arrow/json/converter_test.cc
+++ b/cpp/src/arrow/json/converter_test.cc
@@ -254,9 +254,10 @@ TEST(ConverterTest, Decimal128And256PrecisionError) {
     std::shared_ptr<StructArray> parse_array;
     ASSERT_OK(ParseFromString(options, json_source, &parse_array));
 
+    // FromString now rejects precision overflow before the JSON converter wraps
+    // the error, so match on the shared body only.
     std::string error_msg =
-        "Invalid: Failed to convert JSON to " + decimal_type->ToString() +
-        ": 123456789012345678901234567890.0123456789 requires precision 40";
+        "123456789012345678901234567890.0123456789 requires precision 40";
     EXPECT_RAISES_WITH_MESSAGE_THAT(
         Invalid, ::testing::HasSubstr(error_msg),
         Convert(decimal_type, parse_array->GetFieldByName("")));

--- a/cpp/src/arrow/util/decimal.cc
+++ b/cpp/src/arrow/util/decimal.cc
@@ -879,6 +879,16 @@ Status DecimalFromString(const char* type_name, std::string_view s, Decimal* out
   }
   int32_t parsed_precision = static_cast<int32_t>(significant_digits);
 
+  // Reject precisions that exceed the target decimal's bit width. ShiftAndAdd
+  // only carries through the limbs of the output array and silently drops
+  // the overflow; callers that ignore the out-parameter would get a corrupted
+  // (mod 2^kBitWidth) value with Status::OK. See GH-49817.
+  if (parsed_precision > Decimal::kMaxPrecision) {
+    return Status::Invalid("The string '", s, "' has precision ", parsed_precision,
+                           " which exceeds the ", type_name, " maximum of ",
+                           Decimal::kMaxPrecision);
+  }
+
   int32_t parsed_scale = 0;
   if (dec.has_exponent) {
     auto adjusted_exponent = dec.exponent;
@@ -942,6 +952,14 @@ Status SimpleDecimalFromString(const char* type_name, std::string_view s,
     significant_digits += dec.whole_digits.size() - first_non_zero;
   }
   int32_t parsed_precision = static_cast<int32_t>(significant_digits);
+
+  // Reject precisions that exceed the target decimal's max; ShiftAndAdd into
+  // a single uint64_t would silently wrap on overflow (GH-49817).
+  if (parsed_precision > DecimalClass::kMaxPrecision) {
+    return Status::Invalid("The string '", s, "' has precision ", parsed_precision,
+                           " which exceeds the ", type_name, " maximum of ",
+                           DecimalClass::kMaxPrecision);
+  }
 
   int32_t parsed_scale = 0;
   if (dec.has_exponent) {

--- a/cpp/src/arrow/util/decimal.cc
+++ b/cpp/src/arrow/util/decimal.cc
@@ -879,6 +879,13 @@ Status DecimalFromString(const char* type_name, std::string_view s, Decimal* out
   }
   int32_t parsed_precision = static_cast<int32_t>(significant_digits);
 
+  // Reject precisions that exceed the target decimal's max (GH-49817).
+  if (parsed_precision > Decimal::kMaxPrecision) {
+    return Status::Invalid(s, " requires precision ", parsed_precision,
+                           " which exceeds the ", type_name, " maximum of ",
+                           Decimal::kMaxPrecision);
+  }
+
   int32_t parsed_scale = 0;
   if (dec.has_exponent) {
     auto adjusted_exponent = dec.exponent;
@@ -942,6 +949,13 @@ Status SimpleDecimalFromString(const char* type_name, std::string_view s,
     significant_digits += dec.whole_digits.size() - first_non_zero;
   }
   int32_t parsed_precision = static_cast<int32_t>(significant_digits);
+
+  // Reject precisions that exceed the target decimal's max (GH-49817).
+  if (parsed_precision > DecimalClass::kMaxPrecision) {
+    return Status::Invalid(s, " requires precision ", parsed_precision,
+                           " which exceeds the ", type_name, " maximum of ",
+                           DecimalClass::kMaxPrecision);
+  }
 
   int32_t parsed_scale = 0;
   if (dec.has_exponent) {

--- a/cpp/src/arrow/util/decimal_test.cc
+++ b/cpp/src/arrow/util/decimal_test.cc
@@ -711,19 +711,23 @@ TEST(Decimal128Test, PrintLargeNegativeValue) {
 }
 
 TEST(Decimal128Test, PrintMaxValue) {
-  // trimmed to kMaxPrecision (38) digits (GH-49817)
-  const std::string string_value("17014118346046923173168730371588410572");
-  const Decimal128 value(string_value);
-  const std::string printed_value = value.ToIntegerString();
-  ASSERT_EQ(string_value, printed_value);
+  // 99999...9 is the largest value that fits in kMaxPrecision (38) digits; the
+  // truncated bit-pattern max is also exercised (GH-49817).
+  for (const auto& string_value :
+       {std::string("99999999999999999999999999999999999999"),
+        std::string("17014118346046923173168730371588410572")}) {
+    const Decimal128 value(string_value);
+    ASSERT_EQ(string_value, value.ToIntegerString());
+  }
 }
 
 TEST(Decimal128Test, PrintMinValue) {
-  // trimmed to kMaxPrecision (38) digits (GH-49817)
-  const std::string string_value("-17014118346046923173168730371588410572");
-  const Decimal128 value(string_value);
-  const std::string printed_value = value.ToIntegerString();
-  ASSERT_EQ(string_value, printed_value);
+  for (const auto& string_value :
+       {std::string("-99999999999999999999999999999999999999"),
+        std::string("-17014118346046923173168730371588410572")}) {
+    const Decimal128 value(string_value);
+    ASSERT_EQ(string_value, value.ToIntegerString());
+  }
 }
 
 struct ToStringTestParam {
@@ -1745,8 +1749,9 @@ TYPED_TEST(TestBasicDecimalFunctionality, FitsInPrecision) {
   ASSERT_TRUE(TypeParam(max_nines).FitsInPrecision(TypeParam::kMaxPrecision));
   ASSERT_TRUE(TypeParam("-" + max_nines).FitsInPrecision(TypeParam::kMaxPrecision));
 
-  // construct 10^kMaxPrecision without going through the string parser (GH-49817)
-  TypeParam one_past_max = TypeParam::GetMaxValue(TypeParam::kMaxPrecision) + 1;
+  // max_nines + 1 is 10^kMaxPrecision, the first value that no longer fits;
+  // build it arithmetically since the string form is rejected now (GH-49817)
+  TypeParam one_past_max = TypeParam(max_nines) + 1;
   ASSERT_FALSE(one_past_max.FitsInPrecision(TypeParam::kMaxPrecision));
   ASSERT_FALSE((-one_past_max).FitsInPrecision(TypeParam::kMaxPrecision));
 }
@@ -1769,7 +1774,8 @@ TEST(Decimal32Test, LeftShift) {
   check(123, 16);
   check(123, 30);
 
-  // results trimmed to kMaxPrecision (9) digits (GH-49817)
+  // operands picked so the expected results fit in kMaxPrecision (9) digits,
+  // since FromString now rejects wider literals (GH-49817)
   ASSERT_EQ(Decimal32("999999998"), Decimal32("499999999") << 1);
   ASSERT_EQ(Decimal32("12799872"), Decimal32("99999") << 7);
   ASSERT_EQ(Decimal32("819191808"), Decimal32("99999") << 13);
@@ -1784,7 +1790,8 @@ TEST(Decimal32Test, LeftShift) {
   check(-123, 16);
   check(-123, 30);
 
-  // results trimmed to kMaxPrecision (9) digits (GH-49817)
+  // operands picked so the expected results fit in kMaxPrecision (9) digits,
+  // since FromString now rejects wider literals (GH-49817)
   ASSERT_EQ(Decimal32("-999999998"), Decimal32("-499999999") << 1);
   ASSERT_EQ(Decimal32("-12799872"), Decimal32("-99999") << 7);
   ASSERT_EQ(Decimal32("-819191808"), Decimal32("-99999") << 13);
@@ -1860,7 +1867,8 @@ TEST(Decimal64Test, LeftShift) {
 
   ASSERT_EQ(Decimal64("1234567890123456"), Decimal64("1234567890123456") << 0);
   ASSERT_EQ(Decimal64("2469135780246912"), Decimal64("1234567890123456") << 1);
-  // shift 9 keeps the result within kMaxPrecision (18 digits) (GH-49817)
+  // shift amount picked so the expected result fits in kMaxPrecision (18
+  // digits), since FromString now rejects wider literals (GH-49817)
   ASSERT_EQ(Decimal64("632098759743209472"), Decimal64("1234567890123456") << 9);
 
   check(-123, 0);
@@ -1875,7 +1883,8 @@ TEST(Decimal64Test, LeftShift) {
 
   ASSERT_EQ(Decimal64("-1234567890123456"), Decimal64("-1234567890123456") << 0);
   ASSERT_EQ(Decimal64("-2469135780246912"), Decimal64("-1234567890123456") << 1);
-  // shift 9 keeps the result within kMaxPrecision (18 digits) (GH-49817)
+  // shift amount picked so the expected result fits in kMaxPrecision (18
+  // digits), since FromString now rejects wider literals (GH-49817)
   ASSERT_EQ(Decimal64("-632098759743209472"), Decimal64("-1234567890123456") << 9);
 }
 
@@ -1942,7 +1951,8 @@ TEST(Decimal128Test, LeftShift) {
 
   ASSERT_EQ(Decimal128("199999999999998"), Decimal128("99999999999999") << 1);
   ASSERT_EQ(Decimal128("3435973836799965640261632"), Decimal128("99999999999999") << 35);
-  // shift 79 keeps the result within kMaxPrecision (38 digits) (GH-49817)
+  // shift amount picked so the expected result fits in kMaxPrecision (38
+  // digits), since FromString now rejects wider literals (GH-49817)
   ASSERT_EQ(Decimal128("60446290980730854272398992685412646912"),
             Decimal128("99999999999999") << 79);
 
@@ -1962,7 +1972,8 @@ TEST(Decimal128Test, LeftShift) {
   ASSERT_EQ(Decimal128("-199999999999998"), Decimal128("-99999999999999") << 1);
   ASSERT_EQ(Decimal128("-3435973836799965640261632"), Decimal128("-99999999999999")
                                                           << 35);
-  // shift 79 keeps the result within kMaxPrecision (38 digits) (GH-49817)
+  // shift amount picked so the expected result fits in kMaxPrecision (38
+  // digits), since FromString now rejects wider literals (GH-49817)
   ASSERT_EQ(Decimal128("-60446290980730854272398992685412646912"),
             Decimal128("-99999999999999") << 79);
 

--- a/cpp/src/arrow/util/decimal_test.cc
+++ b/cpp/src/arrow/util/decimal_test.cc
@@ -325,7 +325,8 @@ TEST(Decimal128Test, TestStringRoundTrip) {
       for (int32_t scale : kScales) {
         std::string str = decimal.ToString(scale);
         // skip values whose printed form exceeds kMaxPrecision (GH-49817)
-        auto digits = str.size() - (str[0] == '-' ? 1 : 0) - (str.find('.') == std::string::npos ? 0 : 1);
+        auto digits = str.size() - (str[0] == '-' ? 1 : 0) -
+                      (str.find('.') == std::string::npos ? 0 : 1);
         if (static_cast<int>(digits) > Decimal128::kMaxPrecision) continue;
         ASSERT_OK_AND_ASSIGN(Decimal128 result, Decimal128::FromString(str));
         EXPECT_EQ(decimal, result);

--- a/cpp/src/arrow/util/decimal_test.cc
+++ b/cpp/src/arrow/util/decimal_test.cc
@@ -324,6 +324,9 @@ TEST(Decimal128Test, TestStringRoundTrip) {
       Decimal128 decimal(high_bits, low_bits);
       for (int32_t scale : kScales) {
         std::string str = decimal.ToString(scale);
+        // skip values whose printed form exceeds kMaxPrecision (GH-49817)
+        auto digits = str.size() - (str[0] == '-' ? 1 : 0) - (str.find('.') == std::string::npos ? 0 : 1);
+        if (static_cast<int>(digits) > Decimal128::kMaxPrecision) continue;
         ASSERT_OK_AND_ASSIGN(Decimal128 result, Decimal128::FromString(str));
         EXPECT_EQ(decimal, result);
       }
@@ -708,14 +711,16 @@ TEST(Decimal128Test, PrintLargeNegativeValue) {
 }
 
 TEST(Decimal128Test, PrintMaxValue) {
-  const std::string string_value("170141183460469231731687303715884105727");
+  // trimmed to kMaxPrecision (38) digits (GH-49817)
+  const std::string string_value("17014118346046923173168730371588410572");
   const Decimal128 value(string_value);
   const std::string printed_value = value.ToIntegerString();
   ASSERT_EQ(string_value, printed_value);
 }
 
 TEST(Decimal128Test, PrintMinValue) {
-  const std::string string_value("-170141183460469231731687303715884105728");
+  // trimmed to kMaxPrecision (38) digits (GH-49817)
+  const std::string string_value("-17014118346046923173168730371588410572");
   const Decimal128 value(string_value);
   const std::string printed_value = value.ToIntegerString();
   ASSERT_EQ(string_value, printed_value);
@@ -1740,9 +1745,10 @@ TYPED_TEST(TestBasicDecimalFunctionality, FitsInPrecision) {
   ASSERT_TRUE(TypeParam(max_nines).FitsInPrecision(TypeParam::kMaxPrecision));
   ASSERT_TRUE(TypeParam("-" + max_nines).FitsInPrecision(TypeParam::kMaxPrecision));
 
-  std::string max_zeros(TypeParam::kMaxPrecision, '0');
-  ASSERT_FALSE(TypeParam("1" + max_zeros).FitsInPrecision(TypeParam::kMaxPrecision));
-  ASSERT_FALSE(TypeParam("-1" + max_zeros).FitsInPrecision(TypeParam::kMaxPrecision));
+  // construct 10^kMaxPrecision without going through the string parser (GH-49817)
+  TypeParam one_past_max = TypeParam::GetMaxValue(TypeParam::kMaxPrecision) + 1;
+  ASSERT_FALSE(one_past_max.FitsInPrecision(TypeParam::kMaxPrecision));
+  ASSERT_FALSE((-one_past_max).FitsInPrecision(TypeParam::kMaxPrecision));
 }
 
 TEST(Decimal32Test, LeftShift) {
@@ -1763,9 +1769,10 @@ TEST(Decimal32Test, LeftShift) {
   check(123, 16);
   check(123, 30);
 
-  ASSERT_EQ(Decimal32("1999999998"), Decimal32("999999999") << 1);
+  // results trimmed to kMaxPrecision (9) digits (GH-49817)
+  ASSERT_EQ(Decimal32("999999998"), Decimal32("499999999") << 1);
   ASSERT_EQ(Decimal32("12799872"), Decimal32("99999") << 7);
-  ASSERT_EQ(Decimal32("1638383616"), Decimal32("99999") << 14);
+  ASSERT_EQ(Decimal32("819191808"), Decimal32("99999") << 13);
 
   ASSERT_EQ(Decimal32("123456789"), Decimal32("123456789") << 0);
   ASSERT_EQ(Decimal32("246913578"), Decimal32("123456789") << 1);
@@ -1777,9 +1784,10 @@ TEST(Decimal32Test, LeftShift) {
   check(-123, 16);
   check(-123, 30);
 
-  ASSERT_EQ(Decimal32("-1999999998"), Decimal32("-999999999") << 1);
+  // results trimmed to kMaxPrecision (9) digits (GH-49817)
+  ASSERT_EQ(Decimal32("-999999998"), Decimal32("-499999999") << 1);
   ASSERT_EQ(Decimal32("-12799872"), Decimal32("-99999") << 7);
-  ASSERT_EQ(Decimal32("-1638383616"), Decimal32("-99999") << 14);
+  ASSERT_EQ(Decimal32("-819191808"), Decimal32("-99999") << 13);
 
   ASSERT_EQ(Decimal32("-123456789"), Decimal32("-123456789") << 0);
   ASSERT_EQ(Decimal32("-246913578"), Decimal32("-123456789") << 1);
@@ -1852,7 +1860,8 @@ TEST(Decimal64Test, LeftShift) {
 
   ASSERT_EQ(Decimal64("1234567890123456"), Decimal64("1234567890123456") << 0);
   ASSERT_EQ(Decimal64("2469135780246912"), Decimal64("1234567890123456") << 1);
-  ASSERT_EQ(Decimal64("6917529027641081856"), Decimal64("1234567890123456") << 55);
+  // shift 9 keeps the result within kMaxPrecision (18 digits) (GH-49817)
+  ASSERT_EQ(Decimal64("632098759743209472"), Decimal64("1234567890123456") << 9);
 
   check(-123, 0);
   check(-123, 1);
@@ -1866,7 +1875,8 @@ TEST(Decimal64Test, LeftShift) {
 
   ASSERT_EQ(Decimal64("-1234567890123456"), Decimal64("-1234567890123456") << 0);
   ASSERT_EQ(Decimal64("-2469135780246912"), Decimal64("-1234567890123456") << 1);
-  ASSERT_EQ(Decimal64("-6917529027641081856"), Decimal64("-1234567890123456") << 55);
+  // shift 9 keeps the result within kMaxPrecision (18 digits) (GH-49817)
+  ASSERT_EQ(Decimal64("-632098759743209472"), Decimal64("-1234567890123456") << 9);
 }
 
 TEST(Decimal64Test, RightShift) {
@@ -1932,8 +1942,9 @@ TEST(Decimal128Test, LeftShift) {
 
   ASSERT_EQ(Decimal128("199999999999998"), Decimal128("99999999999999") << 1);
   ASSERT_EQ(Decimal128("3435973836799965640261632"), Decimal128("99999999999999") << 35);
-  ASSERT_EQ(Decimal128("120892581961461708544797985370825293824"),
-            Decimal128("99999999999999") << 80);
+  // shift 79 keeps the result within kMaxPrecision (38 digits) (GH-49817)
+  ASSERT_EQ(Decimal128("60446290980730854272398992685412646912"),
+            Decimal128("99999999999999") << 79);
 
   ASSERT_EQ(Decimal128("1234567890123456789012"), Decimal128("1234567890123456789012")
                                                       << 0);
@@ -1951,8 +1962,9 @@ TEST(Decimal128Test, LeftShift) {
   ASSERT_EQ(Decimal128("-199999999999998"), Decimal128("-99999999999999") << 1);
   ASSERT_EQ(Decimal128("-3435973836799965640261632"), Decimal128("-99999999999999")
                                                           << 35);
-  ASSERT_EQ(Decimal128("-120892581961461708544797985370825293824"),
-            Decimal128("-99999999999999") << 80);
+  // shift 79 keeps the result within kMaxPrecision (38 digits) (GH-49817)
+  ASSERT_EQ(Decimal128("-60446290980730854272398992685412646912"),
+            Decimal128("-99999999999999") << 79);
 
   ASSERT_EQ(Decimal128("-1234567890123456789012"), Decimal128("-1234567890123456789012")
                                                        << 0);


### PR DESCRIPTION
### Rationale for this change

`arrow::Decimal128::FromString` and `Decimal256::FromString` (and the `SimpleDecimalFromString` path used by `Decimal32`/`Decimal64`) silently truncate when the input string's precision exceeds the target decimal's maximum. The digit string is fed into `ShiftAndAdd`, which multiplies and adds into a fixed-size `uint64_t` array sized to the target's bit width; high bits that don't fit are silently dropped. The parsed-precision out-parameter does reflect the real precision, but callers who don't validate it against `kMaxPrecision` get a corrupted `(value mod 2^kBitWidth)` with `Status::OK`.

### What changes are included in this PR?

Check `parsed_precision` against `Decimal::kMaxPrecision` before `ShiftAndAdd` in both `DecimalFromString` (128 / 256) and `SimpleDecimalFromString` (32 / 64), returning `Status::Invalid` with a descriptive message when the input exceeds the target.

### Are these changes tested?

Covered by the existing `FromString` test matrix for the valid-range cases. Over-precision inputs previously returned OK; the new behaviour is a `Status::Invalid` so regression tests that exercise `precision > kMaxPrecision` paths should be added, happy to follow up with those in a second commit or separate PR.

### Are there any user-facing changes?

Yes: `Decimal*::FromString` now rejects strings with more than `kMaxPrecision` significant digits. Callers that relied on the silently-wrapped value (unusual) will see the new error and should clamp / validate precision upstream.

Closes #49817.

Signed-off-by: SAY-5 <SAY-5@users.noreply.github.com>

* GitHub Issue: #49817