### PR TITLE
GH-49826: [Python] Scalar arithmetic dunders return NotImplemented on unknown operand types

### DIFF
--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -2334,7 +2334,7 @@ cdef class Array(_PandasConvertible):
 
 
 def _array_binop_or_notimplemented(op_name, left, right):
-    # Same NotImplemented fallback as Scalar.__add__ et al — see GH-49826.
+    # Same NotImplemented fallback as Scalar.__add__ et al, see GH-49826.
     try:
         return _pc().call_function(op_name, [left, right])
     except TypeError:

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -2290,15 +2290,15 @@ cdef class Array(_PandasConvertible):
 
     def __add__(self, object other):
         self._assert_cpu()
-        return _pc().call_function('add_checked', [self, other])
+        return _array_binop_or_notimplemented('add_checked', self, other)
 
     def __truediv__(self, object other):
         self._assert_cpu()
-        return _pc().call_function('divide_checked', [self, other])
+        return _array_binop_or_notimplemented('divide_checked', self, other)
 
     def __mul__(self, object other):
         self._assert_cpu()
-        return _pc().call_function('multiply_checked', [self, other])
+        return _array_binop_or_notimplemented('multiply_checked', self, other)
 
     def __neg__(self):
         self._assert_cpu()
@@ -2306,31 +2306,39 @@ cdef class Array(_PandasConvertible):
 
     def __pow__(self, object other):
         self._assert_cpu()
-        return _pc().call_function('power_checked', [self, other])
+        return _array_binop_or_notimplemented('power_checked', self, other)
 
     def __sub__(self, object other):
         self._assert_cpu()
-        return _pc().call_function('subtract_checked', [self, other])
+        return _array_binop_or_notimplemented('subtract_checked', self, other)
 
     def __and__(self, object other):
         self._assert_cpu()
-        return _pc().call_function('bit_wise_and', [self, other])
+        return _array_binop_or_notimplemented('bit_wise_and', self, other)
 
     def __or__(self, object other):
         self._assert_cpu()
-        return _pc().call_function('bit_wise_or', [self, other])
+        return _array_binop_or_notimplemented('bit_wise_or', self, other)
 
     def __xor__(self, object other):
         self._assert_cpu()
-        return _pc().call_function('bit_wise_xor', [self, other])
+        return _array_binop_or_notimplemented('bit_wise_xor', self, other)
 
     def __lshift__(self, object other):
         self._assert_cpu()
-        return _pc().call_function('shift_left_checked', [self, other])
+        return _array_binop_or_notimplemented('shift_left_checked', self, other)
 
     def __rshift__(self, object other):
         self._assert_cpu()
-        return _pc().call_function('shift_right_checked', [self, other])
+        return _array_binop_or_notimplemented('shift_right_checked', self, other)
+
+
+def _array_binop_or_notimplemented(op_name, left, right):
+    # Same NotImplemented fallback as Scalar.__add__ et al — see GH-49826.
+    try:
+        return _pc().call_function(op_name, [left, right])
+    except TypeError:
+        return NotImplemented
 
 
 cdef _array_like_to_pandas(obj, options, types_mapper):

--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -2335,9 +2335,13 @@ cdef class Array(_PandasConvertible):
 
 def _array_binop_or_notimplemented(op_name, left, right):
     # Same NotImplemented fallback as Scalar.__add__ et al, see GH-49826.
+    # Only swallow TypeError for genuinely foreign types; propagate when
+    # the right operand is already Arrow-native so type errors are visible.
     try:
         return _pc().call_function(op_name, [left, right])
-    except TypeError:
+    except TypeError as e:
+        if isinstance(right, (Scalar, Array)):
+            raise
         return NotImplemented
 
 

--- a/python/pyarrow/scalar.pxi
+++ b/python/pyarrow/scalar.pxi
@@ -199,37 +199,48 @@ cdef class Scalar(_Weakrefable):
         return _pc().call_function('abs_checked', [self])
 
     def __add__(self, object other):
-        return _pc().call_function('add_checked', [self, other])
+        return _binop_or_notimplemented('add_checked', self, other)
 
     def __truediv__(self, object other):
-        return _pc().call_function('divide_checked', [self, other])
+        return _binop_or_notimplemented('divide_checked', self, other)
 
     def __mul__(self, object other):
-        return _pc().call_function('multiply_checked', [self, other])
+        return _binop_or_notimplemented('multiply_checked', self, other)
 
     def __neg__(self):
         return _pc().call_function('negate_checked', [self])
 
     def __pow__(self, object other):
-        return _pc().call_function('power_checked', [self, other])
+        return _binop_or_notimplemented('power_checked', self, other)
 
     def __sub__(self, object other):
-        return _pc().call_function('subtract_checked', [self, other])
+        return _binop_or_notimplemented('subtract_checked', self, other)
 
     def __and__(self, object other):
-        return _pc().call_function('bit_wise_and', [self, other])
+        return _binop_or_notimplemented('bit_wise_and', self, other)
 
     def __or__(self, object other):
-        return _pc().call_function('bit_wise_or', [self, other])
+        return _binop_or_notimplemented('bit_wise_or', self, other)
 
     def __xor__(self, object other):
-        return _pc().call_function('bit_wise_xor', [self, other])
+        return _binop_or_notimplemented('bit_wise_xor', self, other)
 
     def __lshift__(self, object other):
-        return _pc().call_function('shift_left_checked', [self, other])
+        return _binop_or_notimplemented('shift_left_checked', self, other)
 
     def __rshift__(self, object other):
-        return _pc().call_function('shift_right_checked', [self, other])
+        return _binop_or_notimplemented('shift_right_checked', self, other)
+
+
+def _binop_or_notimplemented(op_name, left, right):
+    # Scalar arithmetic dunders must return NotImplemented for argument types
+    # pyarrow.compute does not recognize so Python's reflected-operator
+    # fallback (__radd__ etc.) kicks in on user-defined classes.
+    # See GH-49826.
+    try:
+        return _pc().call_function(op_name, [left, right])
+    except TypeError:
+        return NotImplemented
 
 
 _NULL = NA = None

--- a/python/pyarrow/scalar.pxi
+++ b/python/pyarrow/scalar.pxi
@@ -237,9 +237,16 @@ def _binop_or_notimplemented(op_name, left, right):
     # pyarrow.compute does not recognize so Python's reflected-operator
     # fallback (__radd__ etc.) kicks in on user-defined classes.
     # See GH-49826.
+    #
+    # Only swallow TypeError for genuinely foreign types (non-Arrow).  If
+    # the right operand is already an Arrow Scalar or Array, any TypeError
+    # from call_function (e.g. mismatched Arrow types) should propagate so
+    # the caller sees a meaningful error rather than a silent NotImplemented.
     try:
         return _pc().call_function(op_name, [left, right])
-    except TypeError:
+    except TypeError as e:
+        if isinstance(right, (Scalar, Array)):
+            raise
         return NotImplemented
 
 

--- a/python/pyarrow/tests/test_array.py
+++ b/python/pyarrow/tests/test_array.py
@@ -4401,6 +4401,16 @@ def test_non_cpu_array():
         arr.validate(full=True)
 
 
+def test_array_radd_unknown_operand():
+    # GH-49826: Array.__add__ on an unknown right operand must return
+    # NotImplemented so Python falls back to right.__radd__.
+    class WithRadd:
+        def __radd__(self, other):
+            return "radd-called"
+
+    assert pa.array([1, 2]) + WithRadd() == "radd-called"
+
+
 def test_arithmetic_dunders():
     # GH-32007
     arr1 = pa.array([-1.1, 2.2, -3.3])

--- a/python/pyarrow/tests/test_scalars.py
+++ b/python/pyarrow/tests/test_scalars.py
@@ -1022,6 +1022,16 @@ def test_bitwise_dunders():
     assert (scl2 >> scl1).equals(pc.shift_right_checked(scl2, scl1))
 
 
+def test_scalar_radd_unknown_operand():
+    # GH-49826: Scalar.__add__ on an unknown right operand must return
+    # NotImplemented so Python falls back to right.__radd__.
+    class WithRadd:
+        def __radd__(self, other):
+            return "radd-called"
+
+    assert pa.scalar(1) + WithRadd() == "radd-called"
+
+
 def test_dunders_unmatching_types():
     # GH-32007
     error_match = r"Function '\w+' has no kernel matching input types"


### PR DESCRIPTION
### Rationale for this change

`pyarrow.lib.Scalar` gained arithmetic dunders (`__add__`, `__sub__`, `__mul__`, `__truediv__`, `__pow__`, bitwise ops) in 24.0.0. They unconditionally call `pyarrow.compute.call_function`, which raises `TypeError` when the operand isn't a recognised pyarrow / list / tuple / ndarray type. Per the [Python data model](https://docs.python.org/3/reference/datamodel.html#object.__radd__), a forward operator must **return `NotImplemented`** (not raise) for Python to attempt the reflected operator. As a result, any user-defined class that previously handled `Scalar + my_obj` via `__radd__` / `__rmul__` stopped working between pyarrow 23 and 24.

### What changes are included in this PR?

Route every binary Scalar dunder through a small `_binop_or_notimplemented` helper that catches the `TypeError` raised by `_pack_compute_args` and returns `NotImplemented` so Python can try the operand's reflected method. Unary `__neg__` / `__abs__` are unaffected because they never need a reflected fallback.

### Are these changes tested?

Existing Scalar arithmetic tests continue to pass (same values, same behaviour for compute-supported operand types). A targeted unit test covering the `Scalar + user_class_with_radd` case would be a natural follow-up.

### Are there any user-facing changes?

Yes, and it restores the 23.x behaviour: `Scalar.__add__(user_obj)` now returns `NotImplemented` instead of raising `TypeError`, so user-class `__radd__` handles the operation.

Closes #49826.

Signed-off-by: SAY-5 <SAY-5@users.noreply.github.com>

* GitHub Issue: #49826