### PR TITLE
GH-49835: [C++] A constexpr dynamic dispatch with static dispatch when possible

### DIFF
--- a/cpp/src/arrow/util/bpacking.cc
+++ b/cpp/src/arrow/util/bpacking.cc
@@ -29,34 +29,16 @@ namespace {
 template <typename Uint>
 struct UnpackDynamicFunction {
   using FunctionType = decltype(&bpacking::unpack_scalar<Uint>);
-  using Implementation = std::pair<DispatchLevel, FunctionType>;
 
   static constexpr auto implementations() {
     return std::array{
-    // x86 implementations
-#if defined(ARROW_HAVE_SSE4_2)
-        Implementation{DispatchLevel::NONE, &bpacking::unpack_sse4_2<Uint>},
-#  if defined(ARROW_HAVE_RUNTIME_AVX2)
-        Implementation{DispatchLevel::AVX2, &bpacking::unpack_avx2<Uint>},
-#  endif
-#  if defined(ARROW_HAVE_RUNTIME_AVX512)
-        Implementation{DispatchLevel::AVX512, &bpacking::unpack_avx512<Uint>},
-#  endif
-
-    // ARM implementations
-#elif defined(ARROW_HAVE_NEON)
-        Implementation{DispatchLevel::NONE, &bpacking::unpack_neon<Uint>},
-#  if defined(ARROW_HAVE_RUNTIME_SVE128)
-        Implementation{DispatchLevel::SVE128, &bpacking::unpack_sve128<Uint>},
-#  endif
-#  if defined(ARROW_HAVE_RUNTIME_SVE256)
-        Implementation{DispatchLevel::SVE256, &bpacking::unpack_sve256<Uint>},
-#  endif
-
-    // Other implementations
-#else
-        Implementation{DispatchLevel::NONE, &bpacking::unpack_scalar<Uint>},
-#endif
+        ARROW_DISPATCH_TARGET_NONE(&bpacking::unpack_scalar<Uint>)    //
+        ARROW_DISPATCH_TARGET_NEON(&bpacking::unpack_neon<Uint>)      //
+        ARROW_DISPATCH_TARGET_SVE128(&bpacking::unpack_sve128<Uint>)  //
+        ARROW_DISPATCH_TARGET_SVE256(&bpacking::unpack_sve256<Uint>)  //
+        ARROW_DISPATCH_TARGET_SSE4_2(&bpacking::unpack_sse4_2<Uint>)  //
+        ARROW_DISPATCH_TARGET_AVX2(&bpacking::unpack_avx2<Uint>)      //
+        ARROW_DISPATCH_TARGET_AVX512(&bpacking::unpack_avx512<Uint>)  //
     };
   }
 };
@@ -65,7 +47,7 @@ struct UnpackDynamicFunction {
 
 template <typename Uint>
 void unpack(const uint8_t* in, Uint* out, const UnpackOptions& opts) {
-  static DynamicDispatch<UnpackDynamicFunction<Uint> > dispatch;
+  static const DynamicDispatch<UnpackDynamicFunction<Uint>> dispatch;
   return dispatch(in, out, opts);
 }
 

--- a/cpp/src/arrow/util/bpacking.cc
+++ b/cpp/src/arrow/util/bpacking.cc
@@ -30,7 +30,7 @@ template <typename Uint>
 struct UnpackDynamicFunction {
   using FunctionType = decltype(&bpacking::unpack_scalar<Uint>);
 
-  static constexpr auto implementations() {
+  static constexpr auto targets() {
     return std::array{
         ARROW_DISPATCH_TARGET_NONE(&bpacking::unpack_scalar<Uint>)    //
         ARROW_DISPATCH_TARGET_NEON(&bpacking::unpack_neon<Uint>)      //

--- a/cpp/src/arrow/util/bpacking.cc
+++ b/cpp/src/arrow/util/bpacking.cc
@@ -65,14 +65,8 @@ struct UnpackDynamicFunction {
 
 template <typename Uint>
 void unpack(const uint8_t* in, Uint* out, const UnpackOptions& opts) {
-  auto constexpr kImplementations = UnpackDynamicFunction<Uint>::implementations();
-  if constexpr (kImplementations.size() == 1) {
-    constexpr auto func = kImplementations.front().second;
-    func(in, out, opts);
-  } else {
-    static DynamicDispatch<UnpackDynamicFunction<Uint> > dispatch;
-    return dispatch.func(in, out, opts);
-  }
+  static DynamicDispatch<UnpackDynamicFunction<Uint> > dispatch;
+  return dispatch(in, out, opts);
 }
 
 template void unpack<bool>(const uint8_t*, bool*, const UnpackOptions&);

--- a/cpp/src/arrow/util/byte_stream_split_internal.cc
+++ b/cpp/src/arrow/util/byte_stream_split_internal.cc
@@ -24,6 +24,7 @@ namespace arrow::util::internal {
 
 using ::arrow::internal::DispatchLevel;
 using ::arrow::internal::DynamicDispatch;
+using ::arrow::internal::DynamicDispatchTarget;
 
 /************************
  *  Decode dispatching  *
@@ -32,28 +33,16 @@ using ::arrow::internal::DynamicDispatch;
 template <int kNumStreams>
 struct ByteStreamSplitDecodeDynamic {
   using FunctionType = decltype(&ByteStreamSplitDecodeScalar<kNumStreams>);
-  using Implementation = std::pair<DispatchLevel, FunctionType>;
 
   constexpr static auto implementations() {
     return std::array{
-        Implementation{
-            DispatchLevel::NONE,
-#if defined(ARROW_HAVE_NEON)
-            // We always expect Neon to be available on Arm64
-            &ByteStreamSplitDecodeSimd<xsimd::neon64, kNumStreams>,
-#elif defined(ARROW_HAVE_SSE4_2)
-            // We always expect SSE4.2 to be available on x86_64
-            &ByteStreamSplitDecodeSimd<xsimd::sse4_2, kNumStreams>,
-#else
-            &ByteStreamSplitDecodeScalar<kNumStreams>,
-#endif
-        },
-#if defined(ARROW_HAVE_RUNTIME_AVX2)
-        Implementation{
-            DispatchLevel::AVX2,
-            &ByteStreamSplitDecodeSimd<xsimd::avx2, kNumStreams>,
-        },
-#endif
+        ARROW_DISPATCH_TARGET_NONE(&ByteStreamSplitDecodeScalar<kNumStreams>)  //
+        ARROW_DISPATCH_TARGET_NEON(
+            (&ByteStreamSplitDecodeSimd<xsimd::neon64, kNumStreams>))  //
+        ARROW_DISPATCH_TARGET_SSE4_2(
+            (&ByteStreamSplitDecodeSimd<xsimd::sse4_2, kNumStreams>))  //
+        ARROW_DISPATCH_TARGET_AVX2(
+            (&ByteStreamSplitDecodeSimd<xsimd::avx2, kNumStreams>))  //
     };
   }
 };
@@ -62,7 +51,7 @@ template <int kNumStreams>
 void ByteStreamSplitDecodeSimdDispatch(const uint8_t* data, int width, int64_t num_values,
                                        int64_t stride, uint8_t* out) {
   static const DynamicDispatch<ByteStreamSplitDecodeDynamic<kNumStreams>> dispatch;
-  return dispatch.func(data, width, num_values, stride, out);
+  return dispatch(data, width, num_values, stride, out);
 }
 
 template void ByteStreamSplitDecodeSimdDispatch<2>(const uint8_t*, int, int64_t, int64_t,
@@ -79,25 +68,15 @@ template void ByteStreamSplitDecodeSimdDispatch<8>(const uint8_t*, int, int64_t,
 template <int kNumStreams>
 struct ByteStreamSplitEncodeDynamic {
   using FunctionType = decltype(&ByteStreamSplitEncodeScalar<kNumStreams>);
-  using Implementation = std::pair<DispatchLevel, FunctionType>;
 
   constexpr static auto implementations() {
     return std::array{
-        Implementation{
-            DispatchLevel::NONE,
-#if defined(ARROW_HAVE_NEON)
-            // We always expect Neon to be available on Arm64
-            &ByteStreamSplitEncodeSimd<xsimd::neon64, kNumStreams>,
-#elif defined(ARROW_HAVE_SSE4_2)
-            // We always expect SSE4.2 to be available on x86_64
-            &ByteStreamSplitEncodeSimd<xsimd::sse4_2, kNumStreams>,
-#else
-            &ByteStreamSplitEncodeScalar<kNumStreams>,
-#endif
-        },
-#if defined(ARROW_HAVE_RUNTIME_AVX2)
-        Implementation{DispatchLevel::AVX2, &ByteStreamSplitEncodeAvx2<kNumStreams>},
-#endif
+        ARROW_DISPATCH_TARGET_NONE(&ByteStreamSplitEncodeScalar<kNumStreams>)  //
+        ARROW_DISPATCH_TARGET_NEON(                                            //
+            (&ByteStreamSplitEncodeSimd<xsimd::neon64, kNumStreams>))          //
+        ARROW_DISPATCH_TARGET_SSE4_2(                                          //
+            (&ByteStreamSplitEncodeSimd<xsimd::sse4_2, kNumStreams>))          //
+        ARROW_DISPATCH_TARGET_AVX2((&ByteStreamSplitEncodeAvx2<kNumStreams>))  //
     };
   }
 };
@@ -107,7 +86,7 @@ void ByteStreamSplitEncodeSimdDispatch(const uint8_t* raw_values, int width,
                                        const int64_t num_values,
                                        uint8_t* output_buffer_raw) {
   static const DynamicDispatch<ByteStreamSplitEncodeDynamic<kNumStreams>> dispatch;
-  return dispatch.func(raw_values, width, num_values, output_buffer_raw);
+  return dispatch(raw_values, width, num_values, output_buffer_raw);
 }
 
 template void ByteStreamSplitEncodeSimdDispatch<2>(const uint8_t*, int, const int64_t,

--- a/cpp/src/arrow/util/byte_stream_split_internal.cc
+++ b/cpp/src/arrow/util/byte_stream_split_internal.cc
@@ -34,7 +34,7 @@ template <int kNumStreams>
 struct ByteStreamSplitDecodeDynamic {
   using FunctionType = decltype(&ByteStreamSplitDecodeScalar<kNumStreams>);
 
-  constexpr static auto implementations() {
+  constexpr static auto targets() {
     return std::array{
         ARROW_DISPATCH_TARGET_NONE(&ByteStreamSplitDecodeScalar<kNumStreams>)  //
         ARROW_DISPATCH_TARGET_NEON(
@@ -69,7 +69,7 @@ template <int kNumStreams>
 struct ByteStreamSplitEncodeDynamic {
   using FunctionType = decltype(&ByteStreamSplitEncodeScalar<kNumStreams>);
 
-  constexpr static auto implementations() {
+  constexpr static auto targets() {
     return std::array{
         ARROW_DISPATCH_TARGET_NONE(&ByteStreamSplitEncodeScalar<kNumStreams>)  //
         ARROW_DISPATCH_TARGET_NEON(                                            //

--- a/cpp/src/arrow/util/dispatch_internal.h
+++ b/cpp/src/arrow/util/dispatch_internal.h
@@ -18,7 +18,6 @@
 #pragma once
 
 #include <utility>
-#include <vector>
 
 #include "arrow/status.h"
 #include "arrow/util/cpu_info.h"

--- a/cpp/src/arrow/util/dispatch_internal.h
+++ b/cpp/src/arrow/util/dispatch_internal.h
@@ -175,6 +175,36 @@ constexpr DynamicDispatchTarget<Func> BestDispatchTarget(
 #  define ARROW_DISPATCH_TARGET_NEON(func)
 #endif
 
+#if defined(ARROW_HAVE_SVE128) || defined(ARROW_HAVE_RUNTIME_SVE128)
+#  define ARROW_DISPATCH_TARGET_SVE128(func)      \
+    ::arrow::internal::DynamicDispatchTarget{     \
+        ::arrow::internal::DispatchLevel::SVE128, \
+        (func),                                   \
+    },
+#else
+#  define ARROW_DISPATCH_TARGET_SVE128(func)
+#endif
+
+#if defined(ARROW_HAVE_SVE256) || defined(ARROW_HAVE_RUNTIME_SVE256)
+#  define ARROW_DISPATCH_TARGET_SVE256(func)      \
+    ::arrow::internal::DynamicDispatchTarget{     \
+        ::arrow::internal::DispatchLevel::SVE256, \
+        (func),                                   \
+    },
+#else
+#  define ARROW_DISPATCH_TARGET_SVE256(func)
+#endif
+
+#if defined(ARROW_HAVE_SVE512) || defined(ARROW_HAVE_RUNTIME_SVE512)
+#  define ARROW_DISPATCH_TARGET_SVE512(func)      \
+    ::arrow::internal::DynamicDispatchTarget{     \
+        ::arrow::internal::DispatchLevel::SVE512, \
+        (func),                                   \
+    },
+#else
+#  define ARROW_DISPATCH_TARGET_SVE512(func)
+#endif
+
 /// A concept to specify how dynamic dispatch should be handled.
 ///
 /// A requirement is that the list of available targets must be compile time

--- a/cpp/src/arrow/util/dispatch_internal.h
+++ b/cpp/src/arrow/util/dispatch_internal.h
@@ -41,9 +41,15 @@ enum class DispatchLevel : int {
   MAX
 };
 
-/// A pair of function dispatch level and
+/// A dispatch target pairing a dispatch level with a function pointer.
 template <typename Func>
-using DynamicDispatchTarget = std::pair<DispatchLevel, Func>;
+struct DynamicDispatchTarget {
+  DispatchLevel level = DispatchLevel::NONE;
+  Func func = {};
+};
+
+template <typename Func>
+DynamicDispatchTarget(DispatchLevel, Func) -> DynamicDispatchTarget<Func>;
 
 namespace detail {
 
@@ -90,7 +96,7 @@ constexpr bool DispatchIsStatic(DispatchLevel level) {
 template <typename Func>
 constexpr bool DispatchFullyStatic(const DynamicDispatchTargets<Func> auto& targets) {
   return std::ranges::all_of(targets, [](const DynamicDispatchTarget<Func>& trgt) {
-    return DispatchIsStatic(trgt.first);
+    return DispatchIsStatic(trgt.level);
   });
 }
 
@@ -99,7 +105,7 @@ constexpr bool DispatchFullyStatic(const DynamicDispatchTargets<Func> auto& targ
 template <typename Func>
 constexpr bool DispatchHasStatic(const DynamicDispatchTargets<Func> auto& targets) {
   return std::ranges::any_of(targets, [](const DynamicDispatchTarget<Func>& trgt) {
-    return DispatchIsStatic(trgt.first);
+    return DispatchIsStatic(trgt.level);
   });
 }
 
@@ -109,7 +115,7 @@ constexpr DynamicDispatchTarget<Func> BestDispatchTarget(
     const DynamicDispatchTargets<Func> auto& targets, Filter filter) {
   DynamicDispatchTarget<Func> best = {};
   for (const auto& trgt : targets) {
-    if (trgt.first >= best.first && filter(trgt)) {
+    if (trgt.level >= best.level && filter(trgt)) {
       best = trgt;
     }
   }
@@ -202,7 +208,7 @@ concept DynamicDispatchFullyStaticSpec =
     struct MyDynamicFunction {
       using FunctionType = decltype(&my_function_default);
 
-      static std::array<std::pair<DispatchLevel, FunctionType>, N> implementations() {
+      static std::array<DynamicDispatchTarget<FunctionType>, N> implementations() {
         return {
           { DispatchLevel::NONE, my_function_default }
     #if defined(ARROW_HAVE_RUNTIME_AVX2)
@@ -269,8 +275,8 @@ class DynamicDispatch {
 
   DynamicDispatch() {
     const auto best = BestDispatchTarget<FunctionType>(
-        kTargets, [this](const Target& trgt) { return IsSupported(trgt.first); });
-    func = best.second;
+        kTargets, [this](const Target& trgt) { return IsSupported(trgt.level); });
+    func = best.func;
   }
 
   template <typename... Args>
@@ -315,7 +321,7 @@ class DynamicDispatch<DynamicFunction> {
   using FunctionType = typename DynamicFunction::FunctionType;
   using Target = DynamicDispatchTarget<FunctionType>;
   static constexpr auto kTargets = DynamicFunction::implementations();
-  static constexpr FunctionType kBest = BestDispatchTarget<FunctionType>(kTargets).second;
+  static constexpr FunctionType kBest = BestDispatchTarget<FunctionType>(kTargets).func;
 
   template <typename... Args>
   auto operator()(Args&&... args) const -> decltype(auto) {

--- a/cpp/src/arrow/util/dispatch_internal.h
+++ b/cpp/src/arrow/util/dispatch_internal.h
@@ -213,9 +213,9 @@ template <typename T>
 concept DynamicDispatchSpec = requires {
   typename T::FunctionType;
 
-  { T::implementations() } -> DynamicDispatchTargets<typename T::FunctionType>;
-  requires T::implementations().size() > 0;
-  requires DispatchHasStatic<typename T::FunctionType>(T::implementations());
+  { T::targets() } -> DynamicDispatchTargets<typename T::FunctionType>;
+  requires T::targets().size() > 0;
+  requires DispatchHasStatic<typename T::FunctionType>(T::targets());
 };
 
 /// Refinement of DynamicDispatchSpec where all targets are statically available.
@@ -224,8 +224,7 @@ concept DynamicDispatchSpec = requires {
 /// implementation.
 template <typename T>
 concept DynamicDispatchFullyStaticSpec =
-    DynamicDispatchSpec<T> &&
-    DispatchFullyStatic<typename T::FunctionType>(T::implementations());
+    DynamicDispatchSpec<T> && DispatchFullyStatic<typename T::FunctionType>(T::targets());
 
 /*
   A facility for dynamic dispatch according to available DispatchLevel.
@@ -238,7 +237,7 @@ concept DynamicDispatchFullyStaticSpec =
     struct MyDynamicFunction {
       using FunctionType = decltype(&my_function_default);
 
-      static std::array<DynamicDispatchTarget<FunctionType>, N> implementations() {
+      static std::array<DynamicDispatchTarget<FunctionType>, N> targets() {
         return {
           { DispatchLevel::NONE, my_function_default }
     #if defined(ARROW_HAVE_RUNTIME_AVX2)
@@ -273,7 +272,7 @@ concept DynamicDispatchFullyStaticSpec =
 /// struct MyFunctionDyn {
 ///   using FunctionType = decltype(&MyFuncScalar);
 ///
-///   static constexpr auto implementations() {
+///   static constexpr auto targets() {
 ///     return std::array{
 ///         ARROW_DISPATCH_TARGET_NONE(&MyFuncScalar)    //
 ///         ARROW_DISPATCH_TARGET_NEON(&MyFuncNeon)      //
@@ -301,7 +300,7 @@ class DynamicDispatch {
  public:
   using FunctionType = typename DynamicFunction::FunctionType;
   using Target = DynamicDispatchTarget<FunctionType>;
-  static constexpr auto kTargets = DynamicFunction::implementations();
+  static constexpr auto kTargets = DynamicFunction::targets();
 
   DynamicDispatch() {
     const auto best = BestDispatchTarget<FunctionType>(
@@ -350,7 +349,7 @@ class DynamicDispatch<DynamicFunction> {
  public:
   using FunctionType = typename DynamicFunction::FunctionType;
   using Target = DynamicDispatchTarget<FunctionType>;
-  static constexpr auto kTargets = DynamicFunction::implementations();
+  static constexpr auto kTargets = DynamicFunction::targets();
   static constexpr FunctionType kBest = BestDispatchTarget<FunctionType>(kTargets).func;
 
   template <typename... Args>

--- a/cpp/src/arrow/util/dispatch_internal.h
+++ b/cpp/src/arrow/util/dispatch_internal.h
@@ -17,6 +17,9 @@
 
 #pragma once
 
+#include <algorithm>
+#include <array>
+#include <type_traits>
 #include <utility>
 
 #include "arrow/status.h"
@@ -38,6 +41,156 @@ enum class DispatchLevel : int {
   MAX
 };
 
+/// A pair of function dispatch level and
+template <typename Func>
+using DynamicDispatchTarget = std::pair<DispatchLevel, Func>;
+
+namespace detail {
+
+/// A trait for checking if a type is a static ``std::array``.
+template <typename>
+inline constexpr bool is_std_array_v = false;
+
+template <typename T, std::size_t N>
+inline constexpr bool is_std_array_v<std::array<T, N>> = true;
+
+}  // namespace detail
+
+/// A concept for an array of functions pointers and their dynamic dispatch level.
+template <typename Arr, typename FunctionType>
+concept DynamicDispatchTargets =
+    detail::is_std_array_v<Arr> &&
+    std::is_same_v<typename Arr::value_type, DynamicDispatchTarget<FunctionType>>;
+
+/// Return whether a given dispatch level is static.
+///
+/// This depends on macros defined in the build options.
+constexpr bool DispatchIsStatic(DispatchLevel level) {
+  switch (level) {
+#ifdef ARROW_HAVE_SSE4_2
+    case DispatchLevel::SSE4_2:
+#endif
+#ifdef ARROW_HAVE_AVX2
+    case DispatchLevel::AVX2:
+#endif
+#ifdef ARROW_HAVE_AVX512
+    case DispatchLevel::AVX512:
+#endif
+#ifdef ARROW_HAVE_NEON
+    case DispatchLevel::NEON:
+#endif
+    case DispatchLevel::NONE:
+      return true;
+    default:
+      return false;
+  }
+}
+
+/// Return whether all function in the array can be statically dispatched.
+template <typename Func>
+constexpr bool DispatchFullyStatic(const DynamicDispatchTargets<Func> auto& targets) {
+  return std::ranges::all_of(targets, [](const DynamicDispatchTarget<Func>& trgt) {
+    return DispatchIsStatic(trgt.first);
+  });
+}
+
+/// Return whether any function in the array can be statically dispatched.
+/// Return false on empty sets.
+template <typename Func>
+constexpr bool DispatchHasStatic(const DynamicDispatchTargets<Func> auto& targets) {
+  return std::ranges::any_of(targets, [](const DynamicDispatchTarget<Func>& trgt) {
+    return DispatchIsStatic(trgt.first);
+  });
+}
+
+/// Find the best dispatch target given a filter.
+template <typename Func, typename Filter>
+constexpr DynamicDispatchTarget<Func> BestDispatchTarget(
+    const DynamicDispatchTargets<Func> auto& targets, Filter filter) {
+  DynamicDispatchTarget<Func> best = {};
+  for (const auto& trgt : targets) {
+    if (trgt.first >= best.first && filter(trgt)) {
+      best = trgt;
+    }
+  }
+  return best;
+}
+
+/// Find the best dispatch target (no filter).
+template <typename Func>
+constexpr DynamicDispatchTarget<Func> BestDispatchTarget(
+    const DynamicDispatchTargets<Func> auto& targets) {
+  return BestDispatchTarget<Func>(targets, [](const auto&) { return true; });
+}
+
+#define ARROW_DISPATCH_TARGET_NONE(func)      \
+  ::arrow::internal::DynamicDispatchTarget{   \
+      ::arrow::internal::DispatchLevel::NONE, \
+      (func),                                 \
+  },
+
+#if defined(ARROW_HAVE_SSE4_2) || defined(ARROW_HAVE_RUNTIME_SSE4_2)
+#  define ARROW_DISPATCH_TARGET_SSE4_2(func)      \
+    ::arrow::internal::DynamicDispatchTarget{     \
+        ::arrow::internal::DispatchLevel::SSE4_2, \
+        (func),                                   \
+    },
+#else
+#  define ARROW_DISPATCH_TARGET_SSE4_2(func)
+#endif
+
+#if defined(ARROW_HAVE_AVX2) || defined(ARROW_HAVE_RUNTIME_AVX2)
+#  define ARROW_DISPATCH_TARGET_AVX2(func)      \
+    ::arrow::internal::DynamicDispatchTarget{   \
+        ::arrow::internal::DispatchLevel::AVX2, \
+        (func),                                 \
+    },
+#else
+#  define ARROW_DISPATCH_TARGET_AVX2(func)
+#endif
+
+#if defined(ARROW_HAVE_AVX512) || defined(ARROW_HAVE_RUNTIME_AVX512)
+#  define ARROW_DISPATCH_TARGET_AVX512(func)      \
+    ::arrow::internal::DynamicDispatchTarget{     \
+        ::arrow::internal::DispatchLevel::AVX512, \
+        (func),                                   \
+    },
+#else
+#  define ARROW_DISPATCH_TARGET_AVX512(func)
+#endif
+
+#if defined(ARROW_HAVE_NEON)
+#  define ARROW_DISPATCH_TARGET_NEON(func)      \
+    ::arrow::internal::DynamicDispatchTarget{   \
+        ::arrow::internal::DispatchLevel::NEON, \
+        (func),                                 \
+    },
+#else
+#  define ARROW_DISPATCH_TARGET_NEON(func)
+#endif
+
+/// A concept to specify how dynamic dispatch should be handled.
+///
+/// A requirement is that the list of available targets must be compile time
+/// array with at least one target available for static dispatch.
+template <typename T>
+concept DynamicDispatchSpec = requires {
+  typename T::FunctionType;
+
+  { T::implementations() } -> DynamicDispatchTargets<typename T::FunctionType>;
+  requires T::implementations().size() > 0;
+  requires DispatchHasStatic<typename T::FunctionType>(T::implementations());
+};
+
+/// Refinement of DynamicDispatchSpec where all targets are statically available.
+///
+/// Subsumes DynamicDispatchSpec, enabling a more specialized DynamicDispatch
+/// implementation.
+template <typename T>
+concept DynamicDispatchFullyStaticSpec =
+    DynamicDispatchSpec<T> &&
+    DispatchFullyStatic<typename T::FunctionType>(T::implementations());
+
 /*
   A facility for dynamic dispatch according to available DispatchLevel.
 
@@ -49,7 +202,7 @@ enum class DispatchLevel : int {
     struct MyDynamicFunction {
       using FunctionType = decltype(&my_function_default);
 
-      static std::vector<std::pair<DispatchLevel, FunctionType>> implementations() {
+      static std::array<std::pair<DispatchLevel, FunctionType>, N> implementations() {
         return {
           { DispatchLevel::NONE, my_function_default }
     #if defined(ARROW_HAVE_RUNTIME_AVX2)
@@ -64,37 +217,70 @@ enum class DispatchLevel : int {
       return dispatch.func(...);
     }
 */
-template <typename DynamicFunction>
+
+/// Dynamic dispatcher between function with different micro architectures.
+///
+/// The dispatcher is configured with a ``DynamicDispatchSpec`` to list available
+/// targets (function and dispatch level pair).
+/// The dispatch mechanism uses a combination of compile time computation and
+/// preprocessor macros to fallback to the best static dispatch when, due to build
+/// configurations, no tartget is dynamically available.
+/// This is for example the case on MacOS where Neon is always available while SVE
+/// never is. This is also the case when an Arrow is compiled with and advance baseline.
+/// For instance if the baseline is AVX2 and that there is no AVX512 target provided,
+/// then the dispatch will be fully static.
+///
+/// Typical usage involves ``ARROW_DISPATCH_TARGET_<ARCH>`` macros to avoid referencing
+/// functions that may not be available on certain build configurations.
+///
+/// ```cpp
+/// struct MyFunctionDyn {
+///   using FunctionType = decltype(&MyFuncScalar);
+///
+///   static constexpr auto implementations() {
+///     return std::array{
+///         ARROW_DISPATCH_TARGET_NONE(&MyFuncScalar)    //
+///         ARROW_DISPATCH_TARGET_NEON(&MyFuncNeon)      //
+///         ARROW_DISPATCH_TARGET_SSE4_2(&MyFuncSse42)   //
+///         ARROW_DISPATCH_TARGET_AVX2(&MyFuncAvx2)      //
+///         ARROW_DISPATCH_TARGET_AVX512(&MyFuncAvx512)  //
+///     };
+///   }
+/// };
+/// ```
+///
+/// And then used with the ``DynamicDispatch`` as such:
+///
+/// ```cpp
+/// int MyFunc(const uint8_t* input, int param) {
+///     static const DynamicDispatch<MyFuncDyn> dispatch;
+///     return dispatch(input, param);
+/// }
+/// ```
+template <DynamicDispatchSpec DynamicFunction>
+class DynamicDispatch;
+
+template <DynamicDispatchSpec DynamicFunction>
 class DynamicDispatch {
- protected:
-  using FunctionType = typename DynamicFunction::FunctionType;
-  using Implementation = std::pair<DispatchLevel, FunctionType>;
-
  public:
-  DynamicDispatch() { Resolve(DynamicFunction::implementations()); }
+  using FunctionType = typename DynamicFunction::FunctionType;
+  using Target = DynamicDispatchTarget<FunctionType>;
+  static constexpr auto kTargets = DynamicFunction::implementations();
 
-  FunctionType func = {};
+  DynamicDispatch() {
+    const auto best = BestDispatchTarget<FunctionType>(
+        kTargets, [this](const Target& trgt) { return IsSupported(trgt.first); });
+    func = best.second;
+  }
 
- protected:
-  // Use the Implementation with the highest DispatchLevel
-  template <typename Range>
-  void Resolve(const Range& implementations) {
-    Implementation cur{DispatchLevel::NONE, {}};
-
-    for (const auto& impl : implementations) {
-      if (impl.first >= cur.first && IsSupported(impl.first)) {
-        // Higher (or same) level than current
-        cur = impl;
-      }
-    }
-
-    if (!cur.second) {
-      Status::Invalid("No appropriate implementation found").Abort();
-    }
-    func = cur.second;
+  template <typename... Args>
+  auto operator()(Args&&... args) const -> decltype(auto) {
+    return func(std::forward<Args>(args)...);
   }
 
  private:
+  FunctionType func = {};
+
   bool IsSupported(DispatchLevel level) const {
     static const auto cpu_info = arrow::internal::CpuInfo::GetInstance();
 
@@ -118,6 +304,22 @@ class DynamicDispatch {
       default:
         return false;
     }
+  }
+};
+
+/// Specialization for the fully-static case: best target is resolved at compile time,
+/// no runtime CPU detection needed.
+template <DynamicDispatchFullyStaticSpec DynamicFunction>
+class DynamicDispatch<DynamicFunction> {
+ public:
+  using FunctionType = typename DynamicFunction::FunctionType;
+  using Target = DynamicDispatchTarget<FunctionType>;
+  static constexpr auto kTargets = DynamicFunction::implementations();
+  static constexpr FunctionType kBest = BestDispatchTarget<FunctionType>(kTargets).second;
+
+  template <typename... Args>
+  auto operator()(Args&&... args) const -> decltype(auto) {
+    return kBest(std::forward<Args>(args)...);
   }
 };
 

--- a/cpp/src/parquet/level_comparison.cc
+++ b/cpp/src/parquet/level_comparison.cc
@@ -35,33 +35,28 @@ namespace {
 
 using ::arrow::internal::DispatchLevel;
 using ::arrow::internal::DynamicDispatch;
+using ::arrow::internal::DynamicDispatchTarget;
 
 // defined in level_comparison_avx2.cc
 
 struct GreaterThanDynamicFunction {
   using FunctionType = decltype(&GreaterThanBitmap);
-  using Implementation = std::pair<DispatchLevel, FunctionType>;
 
   static constexpr auto implementations() {
     return std::array{
-        Implementation{DispatchLevel::NONE, standard::GreaterThanBitmapImpl},
-#if defined(ARROW_HAVE_RUNTIME_AVX2)
-        Implementation{DispatchLevel::AVX2, GreaterThanBitmapAvx2},
-#endif
+        ARROW_DISPATCH_TARGET_NONE(&standard::GreaterThanBitmapImpl)  //
+        ARROW_DISPATCH_TARGET_AVX2(&GreaterThanBitmapAvx2)            //
     };
   }
 };
 
 struct MinMaxDynamicFunction {
   using FunctionType = decltype(&FindMinMax);
-  using Implementation = std::pair<DispatchLevel, FunctionType>;
 
   static constexpr auto implementations() {
     return std::array{
-        Implementation{DispatchLevel::NONE, standard::FindMinMaxImpl},
-#if defined(ARROW_HAVE_RUNTIME_AVX2)
-        Implementation{DispatchLevel::AVX2, FindMinMaxAvx2},
-#endif
+        ARROW_DISPATCH_TARGET_NONE(&standard::FindMinMaxImpl)  //
+        ARROW_DISPATCH_TARGET_AVX2(&FindMinMaxAvx2)            //
     };
   }
 };
@@ -70,12 +65,12 @@ struct MinMaxDynamicFunction {
 
 uint64_t GreaterThanBitmap(const int16_t* levels, int64_t num_levels, int16_t rhs) {
   static DynamicDispatch<GreaterThanDynamicFunction> dispatch;
-  return dispatch.func(levels, num_levels, rhs);
+  return dispatch(levels, num_levels, rhs);
 }
 
 MinMax FindMinMax(const int16_t* levels, int64_t num_levels) {
   static DynamicDispatch<MinMaxDynamicFunction> dispatch;
-  return dispatch.func(levels, num_levels);
+  return dispatch(levels, num_levels);
 }
 
 }  // namespace parquet::internal

--- a/cpp/src/parquet/level_comparison.cc
+++ b/cpp/src/parquet/level_comparison.cc
@@ -15,6 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <array>
+
 #include "parquet/level_comparison.h"
 
 #if defined(ARROW_HAVE_RUNTIME_AVX2)
@@ -24,8 +26,6 @@
 #define PARQUET_IMPL_NAMESPACE standard
 #include "parquet/level_comparison_inc.h"
 #undef PARQUET_IMPL_NAMESPACE
-
-#include <vector>
 
 #include "arrow/util/dispatch_internal.h"
 
@@ -40,12 +40,13 @@ using ::arrow::internal::DynamicDispatch;
 
 struct GreaterThanDynamicFunction {
   using FunctionType = decltype(&GreaterThanBitmap);
+  using Implementation = std::pair<DispatchLevel, FunctionType>;
 
-  static std::vector<std::pair<DispatchLevel, FunctionType>> implementations() {
-    return {{DispatchLevel::NONE, standard::GreaterThanBitmapImpl}
+  static constexpr auto implementations() {
+    return std::array{
+        Implementation{DispatchLevel::NONE, standard::GreaterThanBitmapImpl},
 #if defined(ARROW_HAVE_RUNTIME_AVX2)
-            ,
-            {DispatchLevel::AVX2, GreaterThanBitmapAvx2}
+        Implementation{DispatchLevel::AVX2, GreaterThanBitmapAvx2},
 #endif
     };
   }
@@ -53,12 +54,13 @@ struct GreaterThanDynamicFunction {
 
 struct MinMaxDynamicFunction {
   using FunctionType = decltype(&FindMinMax);
+  using Implementation = std::pair<DispatchLevel, FunctionType>;
 
-  static std::vector<std::pair<DispatchLevel, FunctionType>> implementations() {
-    return {{DispatchLevel::NONE, standard::FindMinMaxImpl}
+  static constexpr auto implementations() {
+    return std::array{
+        Implementation{DispatchLevel::NONE, standard::FindMinMaxImpl},
 #if defined(ARROW_HAVE_RUNTIME_AVX2)
-            ,
-            {DispatchLevel::AVX2, FindMinMaxAvx2}
+        Implementation{DispatchLevel::AVX2, FindMinMaxAvx2},
 #endif
     };
   }

--- a/cpp/src/parquet/level_comparison.cc
+++ b/cpp/src/parquet/level_comparison.cc
@@ -42,7 +42,7 @@ using ::arrow::internal::DynamicDispatchTarget;
 struct GreaterThanDynamicFunction {
   using FunctionType = decltype(&GreaterThanBitmap);
 
-  static constexpr auto implementations() {
+  static constexpr auto targets() {
     return std::array{
         ARROW_DISPATCH_TARGET_NONE(&standard::GreaterThanBitmapImpl)  //
         ARROW_DISPATCH_TARGET_AVX2(&GreaterThanBitmapAvx2)            //
@@ -53,7 +53,7 @@ struct GreaterThanDynamicFunction {
 struct MinMaxDynamicFunction {
   using FunctionType = decltype(&FindMinMax);
 
-  static constexpr auto implementations() {
+  static constexpr auto targets() {
     return std::array{
         ARROW_DISPATCH_TARGET_NONE(&standard::FindMinMaxImpl)  //
         ARROW_DISPATCH_TARGET_AVX2(&FindMinMaxAvx2)            //


### PR DESCRIPTION
### Rationale for this change
- Reduce verbosity when using `DynamicDispatch`
- Optimizations: when all targets can be statically dispatched, simply pick the best one at compile time, avoiding jump and `CpuInfo` creation.

### What changes are included in this PR?
- Large refactor of `dispatch_internal.h`
- Cleanup of call sites

### Are these changes tested?
Via existing tests

### Are there any user-facing changes?
No
* GitHub Issue: #49835