### PR TITLE
GH-49846: [CI][Python] fix test-conda-python-3.11-hypothesis

### DIFF
--- a/python/pyarrow/conftest.py
+++ b/python/pyarrow/conftest.py
@@ -123,7 +123,10 @@ except ImportError:
     pass
 
 try:
-    import pyarrow.gandiva  # noqa
+    import warnings
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", FutureWarning)
+        import pyarrow.gandiva  # noqa
     defaults['gandiva'] = True
 except ImportError:
     pass


### PR DESCRIPTION
### Rationale for this change

[test-conda-python-3.11-hypothesis](https://github.com/ursacomputing/crossbow/actions/runs/24810904545/job/72615383517#step:6:3858) build is failing with `FutureWarning: pyarrow.gandiva is deprecated as of 24.0.0 and will be removed in a future version` due to  the `-W error` flag in the [dev/tasks/tasks.yml](https://github.com/apache/arrow/blob/487f1480914d0066a96db9c8f1395e4e9bdd6b56/dev/tasks/tasks.yml#L548).

### What changes are included in this PR?

Instead of adding `-W ignore::FutureWarning:pyarrow.gandiva` to the pytest args in the `tasks.yml` I asked Claude to do the fix in `conftest.py`. I have reviewed the change.

### Are these changes tested?

Yes, with the extended build.

### Are there any user-facing changes?
No.
* GitHub Issue: #49846