### PR TITLE
GH-46994: [C++][Parquet] Reuse BinaryView headers for repeated values in dictionary and DELTA_BYTE_ARRAY decoding

### DIFF
--- a/cpp/src/arrow/array/builder_binary.cc
+++ b/cpp/src/arrow/array/builder_binary.cc
@@ -96,6 +96,19 @@ Status BinaryViewBuilder::ReserveData(int64_t length) {
   return data_heap_builder_.Reserve(length);
 }
 
+Result<int32_t> internal::StringHeapBuilder::AppendHeapBuffer(
+    std::shared_ptr<ResizableBuffer> buffer) {
+  if (!blocks_.empty() && current_remaining_bytes_ > 0) {
+    ARROW_RETURN_NOT_OK(FinishLastBlock());
+  }
+  current_remaining_bytes_ = 0;
+  current_out_buffer_ = nullptr;
+  current_offset_ = 0;
+  int32_t index = static_cast<int32_t>(blocks_.size());
+  blocks_.emplace_back(std::move(buffer));
+  return index;
+}
+
 void BinaryViewBuilder::Reset() {
   ArrayBuilder::Reset();
   data_builder_.Reset();

--- a/cpp/src/arrow/array/builder_binary.h
+++ b/cpp/src/arrow/array/builder_binary.h
@@ -543,6 +543,13 @@ class ARROW_EXPORT StringHeapBuilder {
     blocks_.clear();
   }
 
+  /// \brief Register a pre-populated buffer as a new heap block.
+  ///
+  /// Returns the buffer_index that out-of-line BinaryView headers should use
+  /// to reference data in this buffer. The caller is responsible for ensuring
+  /// that offsets used in BinaryView headers are valid within this buffer.
+  Result<int32_t> AppendHeapBuffer(std::shared_ptr<ResizableBuffer> buffer);
+
   int64_t current_remaining_bytes() const { return current_remaining_bytes_; }
 
   Result<std::vector<std::shared_ptr<ResizableBuffer>>> Finish() {
@@ -643,6 +650,27 @@ class ARROW_EXPORT BinaryViewBuilder : public ArrayBuilder {
 
   void UnsafeAppend(std::string_view value) {
     UnsafeAppend(value.data(), static_cast<int64_t>(value.size()));
+  }
+
+  /// \brief Append a pre-constructed BinaryView header without copying data.
+  void UnsafeAppendView(BinaryViewType::c_type view) {
+    UnsafeAppendToBitmap(true);
+    data_builder_.UnsafeAppend(view);
+  }
+
+  /// \brief Append a value and return the BinaryView header that was created.
+  Result<BinaryViewType::c_type> AppendAndGetView(const uint8_t* value, int64_t length) {
+    ARROW_RETURN_NOT_OK(Reserve(1));
+    UnsafeAppendToBitmap(true);
+    ARROW_ASSIGN_OR_RAISE(auto v,
+                          data_heap_builder_.Append</*Safe=*/true>(value, length));
+    data_builder_.UnsafeAppend(v);
+    return v;
+  }
+
+  /// \brief Register an external buffer as a data buffer for out-of-line views.
+  Result<int32_t> AppendBuffer(std::shared_ptr<ResizableBuffer> buffer) {
+    return data_heap_builder_.AppendHeapBuffer(std::move(buffer));
   }
 
   /// \brief Ensures there is enough allocated available capacity in the

--- a/cpp/src/parquet/decoder.cc
+++ b/cpp/src/parquet/decoder.cc
@@ -34,6 +34,7 @@
 #include "arrow/array/builder_dict.h"
 #include "arrow/array/builder_primitive.h"
 #include "arrow/type_traits.h"
+#include "arrow/util/binary_view_util.h"
 #include "arrow/util/bit_block_counter.h"
 #include "arrow/util/bit_run_reader.h"
 #include "arrow/util/bit_stream_utils_internal.h"
@@ -870,6 +871,7 @@ class DictDecoderImpl : public TypedDecoderImpl<Type>, public DictDecoder<Type> 
   explicit DictDecoderImpl(const ColumnDescriptor* descr,
                            MemoryPool* pool = ::arrow::default_memory_pool())
       : TypedDecoderImpl<Type>(descr, Encoding::RLE_DICTIONARY),
+        pool_(pool),
         dictionary_(AllocateBuffer(pool, 0)),
         dictionary_length_(0),
         byte_array_data_(AllocateBuffer(pool, 0)),
@@ -1006,6 +1008,8 @@ class DictDecoderImpl : public TypedDecoderImpl<Type>, public DictDecoder<Type> 
                             /*shrink_to_fit=*/false));
     dictionary->Decode(dictionary_->mutable_data_as<T>(), dictionary_length_);
   }
+
+  MemoryPool* pool_;
 
   // Only one is set.
   std::shared_ptr<ResizableBuffer> dictionary_;
@@ -1261,6 +1265,13 @@ class DictByteArrayDecoderImpl : public DictDecoderImpl<ByteArrayType> {
   using BASE = DictDecoderImpl<ByteArrayType>;
   using BASE::DictDecoderImpl;
 
+  void SetDict(TypedDecoder<ByteArrayType>* dictionary) override {
+    BASE::SetDict(dictionary);
+    binary_view_dict_buffer_.reset();
+    binary_view_cache_.clear();
+    cached_builder_ = nullptr;
+  }
+
   int DecodeArrow(int num_values, int null_count, const uint8_t* valid_bits,
                   int64_t valid_bits_offset,
                   ::arrow::BinaryDictionary32Builder* builder) override {
@@ -1294,6 +1305,12 @@ class DictByteArrayDecoderImpl : public DictDecoderImpl<ByteArrayType> {
                           int64_t valid_bits_offset,
                           typename EncodingTraits<ByteArrayType>::Accumulator* out,
                           int* out_num_values) {
+    auto type_id = out->builder->type()->id();
+    if (type_id == ::arrow::Type::BINARY_VIEW || type_id == ::arrow::Type::STRING_VIEW) {
+      return DecodeArrowDenseBinaryView(num_values, null_count, valid_bits,
+                                        valid_bits_offset, out, out_num_values);
+    }
+
     constexpr int32_t kBufferSize = 1024;
     int32_t indices[kBufferSize];
 
@@ -1428,6 +1445,109 @@ class DictByteArrayDecoderImpl : public DictDecoderImpl<ByteArrayType> {
     *out_num_values = values_decoded;
     return Status::OK();
   }
+
+  Status EnsureBinaryViewCache(::arrow::BinaryViewBuilder* builder) {
+    // Rebuild cache if dictionary or builder changed.
+    if (cached_builder_ == builder && !binary_view_cache_.empty() &&
+        builder->length() > 0) {
+      return Status::OK();
+    }
+
+    const auto* dict_values = dictionary_->data_as<ByteArray>();
+    const auto* offsets = byte_array_offsets_->data_as<int32_t>();
+    binary_view_cache_.resize(dictionary_length_);
+
+    bool has_out_of_line = false;
+    for (int32_t i = 0; i < dictionary_length_; ++i) {
+      if (dict_values[i].len > ::arrow::BinaryViewType::kInlineSize) {
+        has_out_of_line = true;
+        break;
+      }
+    }
+
+    int32_t buffer_index = -1;
+    if (has_out_of_line) {
+      // Copy dictionary data if there are out-of-line values.
+      if (!binary_view_dict_buffer_) {
+        binary_view_dict_buffer_ = AllocateBuffer(pool_, byte_array_data_->size());
+        if (byte_array_data_->size() > 0) {
+          memcpy(binary_view_dict_buffer_->mutable_data(), byte_array_data_->data(),
+                 byte_array_data_->size());
+        }
+      }
+      ARROW_ASSIGN_OR_RAISE(buffer_index,
+                            builder->AppendBuffer(binary_view_dict_buffer_));
+    }
+
+    for (int32_t i = 0; i < dictionary_length_; ++i) {
+      if (dict_values[i].len <= ::arrow::BinaryViewType::kInlineSize) {
+        binary_view_cache_[i] = ::arrow::util::ToInlineBinaryView(
+            dict_values[i].ptr, static_cast<int32_t>(dict_values[i].len));
+      } else {
+        binary_view_cache_[i] = ::arrow::util::ToNonInlineBinaryView(
+            dict_values[i].ptr, static_cast<int32_t>(dict_values[i].len), buffer_index,
+            offsets[i]);
+      }
+    }
+
+    cached_builder_ = builder;
+    return Status::OK();
+  }
+
+  Status DecodeArrowDenseBinaryView(
+      int num_values, int null_count, const uint8_t* valid_bits,
+      int64_t valid_bits_offset, typename EncodingTraits<ByteArrayType>::Accumulator* out,
+      int* out_num_values) {
+    constexpr int32_t kBufferSize = 1024;
+    int32_t indices[kBufferSize];
+
+    auto* builder =
+        ::arrow::internal::checked_cast<::arrow::BinaryViewBuilder*>(out->builder.get());
+    RETURN_NOT_OK(EnsureBinaryViewCache(builder));
+    RETURN_NOT_OK(builder->Reserve(num_values));
+
+    const int values_to_decode = num_values - null_count;
+    int values_decoded = 0;
+    int num_indices = 0;
+    int pos_indices = 0;
+
+    auto visit_bit_run = [&](int64_t position, int64_t length, bool valid) {
+      if (valid) {
+        while (length > 0) {
+          if (num_indices == pos_indices) {
+            const auto max_batch_size =
+                std::min<int32_t>(kBufferSize, values_to_decode - values_decoded);
+            num_indices = idx_decoder_.GetBatch(indices, max_batch_size);
+            if (ARROW_PREDICT_FALSE(num_indices < 1)) {
+              return Status::Invalid("Invalid number of indices: ", num_indices);
+            }
+            pos_indices = 0;
+          }
+          const auto batch_size = std::min<int64_t>(num_indices - pos_indices, length);
+          for (int64_t j = 0; j < batch_size; ++j) {
+            const auto index = indices[pos_indices++];
+            RETURN_NOT_OK(IndexInBounds(index));
+            builder->UnsafeAppendView(binary_view_cache_[index]);
+          }
+          values_decoded += static_cast<int32_t>(batch_size);
+          length -= static_cast<int32_t>(batch_size);
+        }
+      } else {
+        for (int64_t i = 0; i < length; ++i) {
+          builder->UnsafeAppendNull();
+        }
+      }
+      return Status::OK();
+    };
+
+    RETURN_NOT_OK(VisitBitRuns(valid_bits, valid_bits_offset, num_values, visit_bit_run));
+    *out_num_values = values_decoded;
+    return Status::OK();
+  }
+
+  std::shared_ptr<ResizableBuffer> binary_view_dict_buffer_;
+  std::vector<::arrow::BinaryViewType::c_type> binary_view_cache_;
+  ::arrow::ArrayBuilder* cached_builder_ = nullptr;
 };
 
 // ----------------------------------------------------------------------
@@ -2122,6 +2242,15 @@ class DeltaByteArrayDecoderImpl : public TypedDecoderImpl<DType> {
                           int64_t valid_bits_offset,
                           typename EncodingTraits<DType>::Accumulator* out,
                           int* out_num_values) {
+    if constexpr (std::is_same_v<DType, ByteArrayType>) {
+      auto type_id = out->builder->type()->id();
+      if (type_id == ::arrow::Type::BINARY_VIEW ||
+          type_id == ::arrow::Type::STRING_VIEW) {
+        return DecodeArrowDenseBinaryView(num_values, null_count, valid_bits,
+                                          valid_bits_offset, out, out_num_values);
+      }
+    }
+
     std::vector<ByteArray> values(num_values - null_count);
     const int num_valid_values = GetInternal(values.data(), num_values - null_count);
     if (ARROW_PREDICT_FALSE(num_values - null_count != num_valid_values)) {
@@ -2154,6 +2283,56 @@ class DeltaByteArrayDecoderImpl : public TypedDecoderImpl<DType> {
     };
     return DispatchArrowBinaryHelper<DType>(out, num_values, /*estimated_data_length=*/{},
                                             visit_binary_helper);
+  }
+
+  Status DecodeArrowDenseBinaryView(int num_values, int null_count,
+                                    const uint8_t* valid_bits, int64_t valid_bits_offset,
+                                    typename EncodingTraits<DType>::Accumulator* out,
+                                    int* out_num_values) {
+    static_assert(std::is_same_v<DType, ByteArrayType>);
+
+    std::vector<ByteArray> values(num_values - null_count);
+    const int num_valid_values = GetInternal(values.data(), num_values - null_count);
+    if (ARROW_PREDICT_FALSE(num_values - null_count != num_valid_values)) {
+      throw ParquetException("Expected to decode ", num_values - null_count,
+                             " values, but decoded ", num_valid_values, " values.");
+    }
+
+    auto* builder =
+        ::arrow::internal::checked_cast<::arrow::BinaryViewBuilder*>(out->builder.get());
+    RETURN_NOT_OK(builder->Reserve(num_values));
+
+    const ByteArray* values_ptr = values.data();
+    int value_idx = 0;
+    ::arrow::BinaryViewType::c_type last_view{};
+    const uint8_t* last_ptr = nullptr;
+    uint32_t last_len = 0;
+
+    RETURN_NOT_OK(VisitBitRuns(valid_bits, valid_bits_offset, num_values,
+                               [&](int64_t position, int64_t run_length, bool is_valid) {
+                                 if (is_valid) {
+                                   for (int64_t i = 0; i < run_length; ++i) {
+                                     const auto& val = values_ptr[value_idx];
+                                     if (val.ptr == last_ptr && val.len == last_len) {
+                                       builder->UnsafeAppendView(last_view);
+                                     } else {
+                                       ARROW_ASSIGN_OR_RAISE(
+                                           last_view,
+                                           builder->AppendAndGetView(
+                                               val.ptr, static_cast<int64_t>(val.len)));
+                                       last_ptr = val.ptr;
+                                       last_len = val.len;
+                                     }
+                                     ++value_idx;
+                                   }
+                                   return Status::OK();
+                                 } else {
+                                   return builder->AppendNulls(run_length);
+                                 }
+                               }));
+
+    *out_num_values = num_valid_values;
+    return Status::OK();
   }
 
   MemoryPool* pool_;

--- a/cpp/src/parquet/encoding_test.cc
+++ b/cpp/src/parquet/encoding_test.cc
@@ -2660,4 +2660,295 @@ TEST(DeltaByteArrayEncodingAdHoc, ArrowDirectPut) {
   }
 }
 
+// ----------------------------------------------------------------------
+// BinaryView value reuse tests
+
+TEST(DictEncodingBinaryViewReuse, ReusesHeapForRepeatedValues) {
+  auto node = schema::ByteArray("name");
+  auto descr = std::make_unique<ColumnDescriptor>(node, 0, 0);
+  auto encoder = MakeTypedEncoder<ByteArrayType>(Encoding::PLAIN, /*use_dictionary=*/true,
+                                                 descr.get());
+
+  auto values =
+      ::arrow::ArrayFromJSON(::arrow::utf8(),
+                             R"(["a_very_long_string_one", "a_very_long_string_two",
+          "a_very_long_string_one", "a_very_long_string_two",
+          "a_very_long_string_one", "a_very_long_string_two",
+          "a_very_long_string_one", "a_very_long_string_two"])");
+  ASSERT_NO_THROW(encoder->Put(*values));
+  auto buf = encoder->FlushValues();
+
+  auto dict_encoder = dynamic_cast<DictEncoder<ByteArrayType>*>(encoder.get());
+  ASSERT_NE(dict_encoder, nullptr);
+  auto dict_buffer =
+      AllocateBuffer(default_memory_pool(), dict_encoder->dict_encoded_size());
+  dict_encoder->WriteDict(dict_buffer->mutable_data());
+
+  auto plain_decoder = MakeTypedDecoder<ByteArrayType>(Encoding::PLAIN, descr.get());
+  plain_decoder->SetData(dict_encoder->num_entries(), dict_buffer->data(),
+                         static_cast<int>(dict_buffer->size()));
+
+  auto dict_decoder = MakeDictDecoder<ByteArrayType>(descr.get());
+  dict_decoder->SetDict(plain_decoder.get());
+  int num_values = static_cast<int>(values->length());
+  dict_decoder->SetData(num_values, buf->data(), static_cast<int>(buf->size()));
+  auto* decoder = dynamic_cast<ByteArrayDecoder*>(dict_decoder.get());
+
+  typename EncodingTraits<ByteArrayType>::Accumulator acc;
+  ASSERT_OK_AND_ASSIGN(acc.builder, ::arrow::MakeBuilder(::arrow::binary_view()));
+  auto actual_num_values = decoder->DecodeArrow(num_values, 0, nullptr, 0, &acc);
+  ASSERT_EQ(actual_num_values, num_values);
+
+  std::shared_ptr<::arrow::Array> result;
+  ASSERT_OK(acc.builder->Finish(&result));
+  ASSERT_OK(result->ValidateFull());
+
+  ASSERT_OK_AND_ASSIGN(auto expected,
+                       ::arrow::compute::Cast(*values, ::arrow::binary_view()));
+  ASSERT_ARRAYS_EQUAL(*result, *expected);
+
+  auto* array_data = result->data().get();
+  int num_heap_buffers = static_cast<int>(array_data->buffers.size()) - 2;
+  ASSERT_EQ(num_heap_buffers, 1);
+  ASSERT_LE(array_data->buffers[2]->size(), 60);
+}
+
+TEST(DictEncodingBinaryViewReuse, InlineStringsNoHeapBuffer) {
+  auto node = schema::ByteArray("name");
+  auto descr = std::make_unique<ColumnDescriptor>(node, 0, 0);
+  auto encoder = MakeTypedEncoder<ByteArrayType>(Encoding::PLAIN, /*use_dictionary=*/true,
+                                                 descr.get());
+
+  auto values =
+      ::arrow::ArrayFromJSON(::arrow::utf8(), R"(["short", "tiny", "short", "tiny"])");
+  ASSERT_NO_THROW(encoder->Put(*values));
+  auto buf = encoder->FlushValues();
+
+  auto dict_encoder = dynamic_cast<DictEncoder<ByteArrayType>*>(encoder.get());
+  auto dict_buffer =
+      AllocateBuffer(default_memory_pool(), dict_encoder->dict_encoded_size());
+  dict_encoder->WriteDict(dict_buffer->mutable_data());
+
+  auto plain_decoder = MakeTypedDecoder<ByteArrayType>(Encoding::PLAIN, descr.get());
+  plain_decoder->SetData(dict_encoder->num_entries(), dict_buffer->data(),
+                         static_cast<int>(dict_buffer->size()));
+
+  auto dict_decoder = MakeDictDecoder<ByteArrayType>(descr.get());
+  dict_decoder->SetDict(plain_decoder.get());
+  int num_values = static_cast<int>(values->length());
+  dict_decoder->SetData(num_values, buf->data(), static_cast<int>(buf->size()));
+  auto* decoder = dynamic_cast<ByteArrayDecoder*>(dict_decoder.get());
+
+  typename EncodingTraits<ByteArrayType>::Accumulator acc;
+  ASSERT_OK_AND_ASSIGN(acc.builder, ::arrow::MakeBuilder(::arrow::binary_view()));
+  auto actual_num_values = decoder->DecodeArrow(num_values, 0, nullptr, 0, &acc);
+  ASSERT_EQ(actual_num_values, num_values);
+
+  std::shared_ptr<::arrow::Array> result;
+  ASSERT_OK(acc.builder->Finish(&result));
+  ASSERT_OK(result->ValidateFull());
+
+  ASSERT_OK_AND_ASSIGN(auto expected,
+                       ::arrow::compute::Cast(*values, ::arrow::binary_view()));
+  ASSERT_ARRAYS_EQUAL(*result, *expected);
+
+  auto* array_data = result->data().get();
+  ASSERT_EQ(static_cast<int>(array_data->buffers.size()) - 2, 0);
+}
+
+TEST(DictEncodingBinaryViewReuse, WithNulls) {
+  auto node = schema::ByteArray("name");
+  auto descr = std::make_unique<ColumnDescriptor>(node, 0, 0);
+  auto encoder = MakeTypedEncoder<ByteArrayType>(Encoding::PLAIN, /*use_dictionary=*/true,
+                                                 descr.get());
+
+  auto values = ::arrow::ArrayFromJSON(
+      ::arrow::utf8(),
+      R"(["a_very_long_string_one", null, "a_very_long_string_one", null,
+          "a_very_long_string_two", null])");
+  ASSERT_NO_THROW(encoder->Put(*values));
+  auto buf = encoder->FlushValues();
+
+  auto dict_encoder = dynamic_cast<DictEncoder<ByteArrayType>*>(encoder.get());
+  auto dict_buffer =
+      AllocateBuffer(default_memory_pool(), dict_encoder->dict_encoded_size());
+  dict_encoder->WriteDict(dict_buffer->mutable_data());
+
+  auto plain_decoder = MakeTypedDecoder<ByteArrayType>(Encoding::PLAIN, descr.get());
+  plain_decoder->SetData(dict_encoder->num_entries(), dict_buffer->data(),
+                         static_cast<int>(dict_buffer->size()));
+
+  auto dict_decoder = MakeDictDecoder<ByteArrayType>(descr.get());
+  dict_decoder->SetDict(plain_decoder.get());
+  int num_values = static_cast<int>(values->length());
+  int null_count = static_cast<int>(values->null_count());
+  dict_decoder->SetData(num_values - null_count, buf->data(),
+                        static_cast<int>(buf->size()));
+  auto* decoder = dynamic_cast<ByteArrayDecoder*>(dict_decoder.get());
+
+  typename EncodingTraits<ByteArrayType>::Accumulator acc;
+  ASSERT_OK_AND_ASSIGN(acc.builder, ::arrow::MakeBuilder(::arrow::binary_view()));
+  auto actual_num_values =
+      decoder->DecodeArrow(num_values, null_count, values->null_bitmap_data(), 0, &acc);
+  ASSERT_EQ(actual_num_values, num_values - null_count);
+
+  std::shared_ptr<::arrow::Array> result;
+  ASSERT_OK(acc.builder->Finish(&result));
+  ASSERT_OK(result->ValidateFull());
+
+  ASSERT_OK_AND_ASSIGN(auto expected,
+                       ::arrow::compute::Cast(*values, ::arrow::binary_view()));
+  ASSERT_ARRAYS_EQUAL(*result, *expected);
+}
+
+TEST(DeltaByteArrayBinaryViewReuse, ReusesViewForRepeatedValues) {
+  auto values = ::arrow::ArrayFromJSON(::arrow::utf8(),
+                                       R"(["a_very_long_repeated_str",
+          "a_very_long_repeated_str",
+          "a_very_long_repeated_str",
+          "different_long_str_here_",
+          "different_long_str_here_"])");
+
+  auto encoder = MakeTypedEncoder<ByteArrayType>(Encoding::DELTA_BYTE_ARRAY);
+  ASSERT_NO_THROW(encoder->Put(*values));
+  auto buf = encoder->FlushValues();
+
+  int num_values = static_cast<int>(values->length());
+  auto decoder = MakeTypedDecoder<ByteArrayType>(Encoding::DELTA_BYTE_ARRAY);
+  decoder->SetData(num_values, buf->data(), static_cast<int>(buf->size()));
+
+  typename EncodingTraits<ByteArrayType>::Accumulator acc;
+  ASSERT_OK_AND_ASSIGN(acc.builder, ::arrow::MakeBuilder(::arrow::binary_view()));
+  ASSERT_EQ(num_values, decoder->DecodeArrow(num_values, 0, nullptr, 0, &acc));
+
+  std::shared_ptr<::arrow::Array> result;
+  ASSERT_OK(acc.builder->Finish(&result));
+  ASSERT_OK(result->ValidateFull());
+
+  ASSERT_OK_AND_ASSIGN(auto expected,
+                       ::arrow::compute::Cast(*values, ::arrow::binary_view()));
+  ASSERT_ARRAYS_EQUAL(*result, *expected);
+
+  auto* array_data = result->data().get();
+  int64_t total_heap = 0;
+  for (size_t i = 2; i < array_data->buffers.size(); ++i) {
+    if (array_data->buffers[i]) {
+      total_heap += array_data->buffers[i]->size();
+    }
+  }
+  ASSERT_LE(total_heap, 60);
+}
+
+TEST(DictEncodingBinaryViewReuse, MultiBatchDecodingAfterBuilderReset) {
+  auto node = schema::ByteArray("name");
+  auto descr = std::make_unique<ColumnDescriptor>(node, 0, 0);
+  auto encoder = MakeTypedEncoder<ByteArrayType>(Encoding::PLAIN, /*use_dictionary=*/true,
+                                                 descr.get());
+
+  auto values =
+      ::arrow::ArrayFromJSON(::arrow::utf8(),
+                             R"(["a_very_long_string_one", "a_very_long_string_two",
+          "a_very_long_string_one", "a_very_long_string_two"])");
+  ASSERT_NO_THROW(encoder->Put(*values));
+  auto buf = encoder->FlushValues();
+
+  auto dict_encoder = dynamic_cast<DictEncoder<ByteArrayType>*>(encoder.get());
+  ASSERT_NE(dict_encoder, nullptr);
+  auto dict_buffer =
+      AllocateBuffer(default_memory_pool(), dict_encoder->dict_encoded_size());
+  dict_encoder->WriteDict(dict_buffer->mutable_data());
+
+  auto plain_decoder = MakeTypedDecoder<ByteArrayType>(Encoding::PLAIN, descr.get());
+  plain_decoder->SetData(dict_encoder->num_entries(), dict_buffer->data(),
+                         static_cast<int>(dict_buffer->size()));
+
+  auto dict_decoder = MakeDictDecoder<ByteArrayType>(descr.get());
+  dict_decoder->SetDict(plain_decoder.get());
+  int num_values = static_cast<int>(values->length());
+  dict_decoder->SetData(num_values, buf->data(), static_cast<int>(buf->size()));
+  auto* decoder = dynamic_cast<ByteArrayDecoder*>(dict_decoder.get());
+
+  typename EncodingTraits<ByteArrayType>::Accumulator acc;
+  ASSERT_OK_AND_ASSIGN(acc.builder, ::arrow::MakeBuilder(::arrow::binary_view()));
+
+  auto actual = decoder->DecodeArrow(2, 0, nullptr, 0, &acc);
+  ASSERT_EQ(actual, 2);
+  std::shared_ptr<::arrow::Array> result1;
+  ASSERT_OK(acc.builder->Finish(&result1));
+  ASSERT_OK(result1->ValidateFull());
+
+  actual = decoder->DecodeArrow(2, 0, nullptr, 0, &acc);
+  ASSERT_EQ(actual, 2);
+  std::shared_ptr<::arrow::Array> result2;
+  ASSERT_OK(acc.builder->Finish(&result2));
+  ASSERT_OK(result2->ValidateFull());
+
+  ASSERT_OK_AND_ASSIGN(auto expected,
+                       ::arrow::compute::Cast(*values, ::arrow::binary_view()));
+  ASSERT_OK_AND_ASSIGN(auto expected1, expected->Slice(0, 2)->View(expected->type()));
+  ASSERT_OK_AND_ASSIGN(auto expected2, expected->Slice(2, 2)->View(expected->type()));
+  ASSERT_ARRAYS_EQUAL(*result1, *expected1);
+  ASSERT_ARRAYS_EQUAL(*result2, *expected2);
+}
+
+TEST(DictEncodingBinaryViewReuse, NewDictionaryDoesNotCorruptPreviousArray) {
+  auto node = schema::ByteArray("name");
+  auto descr = std::make_unique<ColumnDescriptor>(node, 0, 0);
+
+  auto encoder1 = MakeTypedEncoder<ByteArrayType>(Encoding::PLAIN,
+                                                  /*use_dictionary=*/true, descr.get());
+  auto values1 = ::arrow::ArrayFromJSON(
+      ::arrow::utf8(), R"(["first_dict_long_val_a", "first_dict_long_val_b"])");
+  ASSERT_NO_THROW(encoder1->Put(*values1));
+  auto buf1 = encoder1->FlushValues();
+  auto dict_enc1 = dynamic_cast<DictEncoder<ByteArrayType>*>(encoder1.get());
+  auto dict_buf1 = AllocateBuffer(default_memory_pool(), dict_enc1->dict_encoded_size());
+  dict_enc1->WriteDict(dict_buf1->mutable_data());
+
+  auto encoder2 = MakeTypedEncoder<ByteArrayType>(Encoding::PLAIN,
+                                                  /*use_dictionary=*/true, descr.get());
+  auto values2 = ::arrow::ArrayFromJSON(
+      ::arrow::utf8(), R"(["second_dict_long_vl_x", "second_dict_long_vl_y"])");
+  ASSERT_NO_THROW(encoder2->Put(*values2));
+  auto buf2 = encoder2->FlushValues();
+  auto dict_enc2 = dynamic_cast<DictEncoder<ByteArrayType>*>(encoder2.get());
+  auto dict_buf2 = AllocateBuffer(default_memory_pool(), dict_enc2->dict_encoded_size());
+  dict_enc2->WriteDict(dict_buf2->mutable_data());
+
+  auto dict_decoder = MakeDictDecoder<ByteArrayType>(descr.get());
+  auto plain_decoder = MakeTypedDecoder<ByteArrayType>(Encoding::PLAIN, descr.get());
+
+  plain_decoder->SetData(dict_enc1->num_entries(), dict_buf1->data(),
+                         static_cast<int>(dict_buf1->size()));
+  dict_decoder->SetDict(plain_decoder.get());
+  dict_decoder->SetData(static_cast<int>(values1->length()), buf1->data(),
+                        static_cast<int>(buf1->size()));
+  auto* decoder = dynamic_cast<ByteArrayDecoder*>(dict_decoder.get());
+
+  typename EncodingTraits<ByteArrayType>::Accumulator acc;
+  ASSERT_OK_AND_ASSIGN(acc.builder, ::arrow::MakeBuilder(::arrow::binary_view()));
+  ASSERT_EQ(2, decoder->DecodeArrow(2, 0, nullptr, 0, &acc));
+  std::shared_ptr<::arrow::Array> result1;
+  ASSERT_OK(acc.builder->Finish(&result1));
+  ASSERT_OK(result1->ValidateFull());
+
+  plain_decoder->SetData(dict_enc2->num_entries(), dict_buf2->data(),
+                         static_cast<int>(dict_buf2->size()));
+  dict_decoder->SetDict(plain_decoder.get());
+  dict_decoder->SetData(static_cast<int>(values2->length()), buf2->data(),
+                        static_cast<int>(buf2->size()));
+
+  ASSERT_EQ(2, decoder->DecodeArrow(2, 0, nullptr, 0, &acc));
+  std::shared_ptr<::arrow::Array> result2;
+  ASSERT_OK(acc.builder->Finish(&result2));
+  ASSERT_OK(result2->ValidateFull());
+
+  ASSERT_OK_AND_ASSIGN(auto expected1,
+                       ::arrow::compute::Cast(*values1, ::arrow::binary_view()));
+  ASSERT_OK_AND_ASSIGN(auto expected2,
+                       ::arrow::compute::Cast(*values2, ::arrow::binary_view()));
+  ASSERT_ARRAYS_EQUAL(*result1, *expected1);
+  ASSERT_ARRAYS_EQUAL(*result2, *expected2);
+}
+
 }  // namespace parquet::test


### PR DESCRIPTION
### Rationale for this change
When decoding Parquet ByteArray columns into Arrow BinaryView arrays, repeated dictionary values previously caused redundant data copies.

### What changes are included in this PR?
Dictionary decoding: Pre-build a cache of `BinaryViewType::c_type` headers from the dictionary entries. Out-of-line dictionary data is registered once as a shared heap buffer via a new `BinaryViewBuilder::AppendBuffer` API. Decoding then emits the cached header directly.

DELTA_BYTE_ARRAY decoding: When a decoded value has the same pointer and length as the previous value (the delta encoder's representation of an exact repeat), reuse the last BinaryView header instead of appending a duplicate.

### Are these changes tested?
Yes. Added new tests.

### Are there any user-facing changes?
No
* GitHub Issue: #46994