### PR TITLE
MINOR: [R] `cast()` documented but not exported in NAMESPACE

### DIFF
--- a/r/R/dplyr-funcs-type.R
+++ b/r/R/dplyr-funcs-type.R
@@ -42,7 +42,7 @@ register_bindings_type <- function() {
 #'   arrow_table() |>
 #'   mutate(cyl = cast(cyl, string()))
 #' }
-#' @keywords internal
+#' @export
 #' @seealso [`data-type`] for a list of [DataType] to be used with `to`.
 #' @seealso [Arrow C++ CastOptions documentation](https://arrow.apache.org/docs/cpp/api/compute.html?highlight=castoptions#arrow%3A%3Acompute%3A%3ACastOptions) # nolint
 #' for the list of supported CastOptions.


### PR DESCRIPTION
FIX #49852

### Rationale for this change

cast() is a publicly documented function available at https://arrow.apache.org/docs/r/reference/cast.html and is intended for use in dplyr pipelines. However, it was marked with @keywords internal which prevented it from being exported in the NAMESPACE file.

### What changes are included in this PR?
Removed @keywords internal tag which was incorrectly marking cast() as an internal function
Added @export tag so that devtools::document() adds cast to the NAMESPACE file, making it publicly accessible to users

### Are these changes tested?
Existing tests in the test suite already cover cast(). No new tests needed as only the export tag was changed, not the implementation.

### Are there any user-facing changes?

Yes. cast() can now be called directly by users as documented:
