### PR TITLE
GH-39808: [C++][Parquet] Evict pre-buffered row-group bytes after decode

### DIFF
--- a/cpp/src/arrow/dataset/file_parquet.cc
+++ b/cpp/src/arrow/dataset/file_parquet.cc
@@ -130,6 +130,8 @@ parquet::ArrowReaderProperties MakeArrowReaderProperties(
   // Must be set here since the sync ScanTask handles pre-buffering itself
   arrow_properties.set_pre_buffer(
       parquet_scan_options.arrow_reader_properties->pre_buffer());
+  // Dataset scans consume each row group once, so cached ranges can be released.
+  arrow_properties.set_auto_evict_read_cache(true);
   arrow_properties.set_cache_options(
       parquet_scan_options.arrow_reader_properties->cache_options());
   arrow_properties.set_io_context(

--- a/cpp/src/arrow/io/caching.cc
+++ b/cpp/src/arrow/io/caching.cc
@@ -151,10 +151,18 @@ struct ReadRangeCache::Impl {
   IOContext ctx;
   CacheOptions options;
 
-  // Ordered by offset (so as to find a matching region by binary search)
+  // Ordered by offset (so as to find a matching region by binary search).
+  // Mutation of `entries` and of individual entries' futures must be
+  // serialized via `entry_mutex`. Every public method that touches either
+  // acquires the mutex before delegating to the protected *Locked helpers
+  // below, so both the eager and lazy variants are safe to call concurrently
+  // from multiple threads.
   std::vector<RangeCacheEntry> entries;
+  std::mutex entry_mutex;
 
   virtual ~Impl() = default;
+
+  // -- Polymorphic hooks. Always called with entry_mutex held. --
 
   // Get the future corresponding to a range
   virtual Future<std::shared_ptr<Buffer>> MaybeRead(RangeCacheEntry* entry) {
@@ -173,23 +181,31 @@ struct ReadRangeCache::Impl {
     return new_entries;
   }
 
-  // Add the given ranges to the cache, coalescing them where possible
-  virtual Status Cache(std::vector<ReadRange> ranges) {
+  // -- Public entry points (acquire entry_mutex, then delegate). --
+
+  // Add the given ranges to the cache, coalescing them where possible.
+  Status Cache(std::vector<ReadRange> ranges) {
     ARROW_ASSIGN_OR_RAISE(
         ranges, internal::CoalesceReadRanges(std::move(ranges), options.hole_size_limit,
                                              options.range_size_limit));
-    std::vector<RangeCacheEntry> new_entries = MakeCacheEntries(ranges);
-    // Add new entries, themselves ordered by offset
-    if (entries.size() > 0) {
-      std::vector<RangeCacheEntry> merged(entries.size() + new_entries.size());
-      std::merge(entries.begin(), entries.end(), new_entries.begin(), new_entries.end(),
-                 merged.begin());
-      entries = std::move(merged);
-    } else {
-      entries = std::move(new_entries);
+    Status st;
+    {
+      std::unique_lock<std::mutex> guard(entry_mutex);
+      std::vector<RangeCacheEntry> new_entries = MakeCacheEntries(ranges);
+      // Add new entries, themselves ordered by offset
+      if (entries.size() > 0) {
+        std::vector<RangeCacheEntry> merged(entries.size() + new_entries.size());
+        std::merge(entries.begin(), entries.end(), new_entries.begin(),
+                   new_entries.end(), merged.begin());
+        entries = std::move(merged);
+      } else {
+        entries = std::move(new_entries);
+      }
     }
-    // Prefetch immediately, regardless of executor availability, if possible
-    auto st = file->WillNeed(ranges);
+    // Prefetch immediately, regardless of executor availability, if possible.
+    // Do this outside the lock: WillNeed() may block on an mmap advise / I/O
+    // hint and we don't want to serialize concurrent Reads on it.
+    st = file->WillNeed(ranges);
     // As this is optimisation only, I/O failures should not be treated as fatal
     if (st.IsIOError()) {
       return Status::OK();
@@ -197,22 +213,28 @@ struct ReadRangeCache::Impl {
     return st;
   }
 
-  // Read the given range from the cache, blocking if needed. Cannot read a range
-  // that spans cache entries.
-  virtual Result<std::shared_ptr<Buffer>> Read(ReadRange range) {
+  // Read the given range from the cache, blocking if needed. Cannot read a
+  // range that spans cache entries.
+  Result<std::shared_ptr<Buffer>> Read(ReadRange range) {
     if (range.length == 0) {
       static const uint8_t byte = 0;
       return std::make_shared<Buffer>(&byte, 0);
     }
 
-    const auto it = std::lower_bound(
-        entries.begin(), entries.end(), range,
-        [](const RangeCacheEntry& entry, const ReadRange& range) {
-          return entry.range.offset + entry.range.length < range.offset + range.length;
-        });
-    if (it != entries.end() && it->range.Contains(range)) {
-      auto fut = MaybeRead(&*it);
-      ARROW_ASSIGN_OR_RAISE(auto buf, fut.result());
+    Future<std::shared_ptr<Buffer>> fut;
+    int64_t slice_offset = 0;
+    {
+      std::unique_lock<std::mutex> guard(entry_mutex);
+      const auto it = std::lower_bound(
+          entries.begin(), entries.end(), range,
+          [](const RangeCacheEntry& entry, const ReadRange& range) {
+            return entry.range.offset + entry.range.length < range.offset + range.length;
+          });
+      if (it == entries.end() || !it->range.Contains(range)) {
+        return Status::Invalid("ReadRangeCache did not find matching cache entry");
+      }
+      fut = MaybeRead(&*it);
+      slice_offset = range.offset - it->range.offset;
       if (options.lazy && options.prefetch_limit > 0) {
         int64_t num_prefetched = 0;
         for (auto next_it = it + 1;
@@ -226,53 +248,94 @@ struct ReadRangeCache::Impl {
           ++num_prefetched;
         }
       }
-      return SliceBuffer(std::move(buf), range.offset - it->range.offset, range.length);
     }
-    return Status::Invalid("ReadRangeCache did not find matching cache entry");
+    // Drop the lock before blocking on the I/O future so other threads can
+    // still do lookups while a previously queued read is in flight.
+    ARROW_ASSIGN_OR_RAISE(auto buf, fut.result());
+    return SliceBuffer(std::move(buf), slice_offset, range.length);
   }
 
-  virtual Future<> Wait() {
+  Future<> Wait() {
     std::vector<Future<>> futures;
-    for (auto& entry : entries) {
-      futures.emplace_back(MaybeRead(&entry));
+    {
+      std::unique_lock<std::mutex> guard(entry_mutex);
+      futures.reserve(entries.size());
+      for (auto& entry : entries) {
+        futures.emplace_back(MaybeRead(&entry));
+      }
     }
     return AllComplete(futures);
   }
 
+  // Evict cache entries whose byte range is fully contained within
+  // [start_offset, start_offset + length).
+  Result<int64_t> EvictEntriesInRange(int64_t start_offset, int64_t length) {
+    if (length <= 0) {
+      return 0;
+    }
+    const int64_t end_offset = start_offset + length;
+    int64_t n_evicted = 0;
+    std::unique_lock<std::mutex> guard(entry_mutex);
+    // entries is sorted by range.offset, so we can fast-forward to the first
+    // entry whose offset is >= start_offset and stop once we pass end_offset.
+    auto it = std::lower_bound(
+        entries.begin(), entries.end(), start_offset,
+        [](const RangeCacheEntry& entry, int64_t offset) {
+          return entry.range.offset < offset;
+        });
+    while (it != entries.end() && it->range.offset < end_offset) {
+      if (it->range.offset + it->range.length <= end_offset) {
+        it = entries.erase(it);
+        ++n_evicted;
+      } else {
+        // Entry extends beyond the requested window (e.g. coalesced with a
+        // neighboring range). Leave it alone and keep scanning in case
+        // smaller siblings follow.
+        ++it;
+      }
+    }
+    return n_evicted;
+  }
+
   // Return a Future that completes when the given ranges have been read.
-  virtual Future<> WaitFor(std::vector<ReadRange> ranges) {
+  Future<> WaitFor(std::vector<ReadRange> ranges) {
     auto end = std::remove_if(ranges.begin(), ranges.end(),
                               [](const ReadRange& range) { return range.length == 0; });
     ranges.resize(end - ranges.begin());
     std::vector<Future<>> futures;
     futures.reserve(ranges.size());
-    for (auto& range : ranges) {
-      const auto it = std::lower_bound(
-          entries.begin(), entries.end(), range,
-          [](const RangeCacheEntry& entry, const ReadRange& range) {
-            return entry.range.offset + entry.range.length < range.offset + range.length;
-          });
-      if (it != entries.end() && it->range.Contains(range)) {
-        futures.push_back(Future<>(MaybeRead(&*it)));
-      } else {
-        return Status::Invalid("Range was not requested for caching: offset=",
-                               range.offset, " length=", range.length);
+    {
+      std::unique_lock<std::mutex> guard(entry_mutex);
+      for (auto& range : ranges) {
+        const auto it = std::lower_bound(
+            entries.begin(), entries.end(), range,
+            [](const RangeCacheEntry& entry, const ReadRange& range) {
+              return entry.range.offset + entry.range.length <
+                     range.offset + range.length;
+            });
+        if (it != entries.end() && it->range.Contains(range)) {
+          futures.push_back(Future<>(MaybeRead(&*it)));
+        } else {
+          return Status::Invalid("Range was not requested for caching: offset=",
+                                 range.offset, " length=", range.length);
+        }
       }
     }
     return AllComplete(futures);
   }
 };
 
-// Don't read ranges when they're first added. Instead, wait until they're requested
-// (either through Read or WaitFor).
+// Don't read ranges when they're first added. Instead, wait until they're
+// requested (either through Read or WaitFor). Thread safety is inherited from
+// the base Impl: both MakeCacheEntries and MaybeRead are only ever invoked
+// from the public entry points, and those hold the base class's entry_mutex
+// before delegating.
 struct ReadRangeCache::LazyImpl : public ReadRangeCache::Impl {
-  // Protect against concurrent modification of entries[i]->future
-  std::mutex entry_mutex;
-
   virtual ~LazyImpl() = default;
 
   Future<std::shared_ptr<Buffer>> MaybeRead(RangeCacheEntry* entry) override {
-    // Called by superclass Read()/WaitFor() so we have the lock
+    // Called by the superclass under entry_mutex, so it is safe to mutate
+    // entry->future here.
     if (!entry->future.is_valid()) {
       entry->future = file->ReadAsync(ctx, entry->range.offset, entry->range.length,
                                       /*allow_short_read=*/false);
@@ -290,26 +353,6 @@ struct ReadRangeCache::LazyImpl : public ReadRangeCache::Impl {
       new_entries.emplace_back(range, Future<std::shared_ptr<Buffer>>());
     }
     return new_entries;
-  }
-
-  Status Cache(std::vector<ReadRange> ranges) override {
-    std::unique_lock<std::mutex> guard(entry_mutex);
-    return ReadRangeCache::Impl::Cache(std::move(ranges));
-  }
-
-  Result<std::shared_ptr<Buffer>> Read(ReadRange range) override {
-    std::unique_lock<std::mutex> guard(entry_mutex);
-    return ReadRangeCache::Impl::Read(range);
-  }
-
-  Future<> Wait() override {
-    std::unique_lock<std::mutex> guard(entry_mutex);
-    return ReadRangeCache::Impl::Wait();
-  }
-
-  Future<> WaitFor(std::vector<ReadRange> ranges) override {
-    std::unique_lock<std::mutex> guard(entry_mutex);
-    return ReadRangeCache::Impl::WaitFor(std::move(ranges));
   }
 };
 
@@ -337,6 +380,10 @@ Future<> ReadRangeCache::Wait() { return impl_->Wait(); }
 
 Future<> ReadRangeCache::WaitFor(std::vector<ReadRange> ranges) {
   return impl_->WaitFor(std::move(ranges));
+}
+
+Result<int64_t> ReadRangeCache::EvictEntriesInRange(int64_t start_offset, int64_t length) {
+  return impl_->EvictEntriesInRange(start_offset, length);
 }
 
 }  // namespace internal

--- a/cpp/src/arrow/io/caching.cc
+++ b/cpp/src/arrow/io/caching.cc
@@ -195,8 +195,8 @@ struct ReadRangeCache::Impl {
       // Add new entries, themselves ordered by offset
       if (entries.size() > 0) {
         std::vector<RangeCacheEntry> merged(entries.size() + new_entries.size());
-        std::merge(entries.begin(), entries.end(), new_entries.begin(),
-                   new_entries.end(), merged.begin());
+        std::merge(entries.begin(), entries.end(), new_entries.begin(), new_entries.end(),
+                   merged.begin());
         entries = std::move(merged);
       } else {
         entries = std::move(new_entries);
@@ -278,11 +278,10 @@ struct ReadRangeCache::Impl {
     std::unique_lock<std::mutex> guard(entry_mutex);
     // entries is sorted by range.offset, so we can fast-forward to the first
     // entry whose offset is >= start_offset and stop once we pass end_offset.
-    auto it = std::lower_bound(
-        entries.begin(), entries.end(), start_offset,
-        [](const RangeCacheEntry& entry, int64_t offset) {
-          return entry.range.offset < offset;
-        });
+    auto it = std::lower_bound(entries.begin(), entries.end(), start_offset,
+                               [](const RangeCacheEntry& entry, int64_t offset) {
+                                 return entry.range.offset < offset;
+                               });
     while (it != entries.end() && it->range.offset < end_offset) {
       if (it->range.offset + it->range.length <= end_offset) {
         it = entries.erase(it);
@@ -307,12 +306,12 @@ struct ReadRangeCache::Impl {
     {
       std::unique_lock<std::mutex> guard(entry_mutex);
       for (auto& range : ranges) {
-        const auto it = std::lower_bound(
-            entries.begin(), entries.end(), range,
-            [](const RangeCacheEntry& entry, const ReadRange& range) {
-              return entry.range.offset + entry.range.length <
-                     range.offset + range.length;
-            });
+        const auto it =
+            std::lower_bound(entries.begin(), entries.end(), range,
+                             [](const RangeCacheEntry& entry, const ReadRange& range) {
+                               return entry.range.offset + entry.range.length <
+                                      range.offset + range.length;
+                             });
         if (it != entries.end() && it->range.Contains(range)) {
           futures.push_back(Future<>(MaybeRead(&*it)));
         } else {
@@ -382,7 +381,8 @@ Future<> ReadRangeCache::WaitFor(std::vector<ReadRange> ranges) {
   return impl_->WaitFor(std::move(ranges));
 }
 
-Result<int64_t> ReadRangeCache::EvictEntriesInRange(int64_t start_offset, int64_t length) {
+Result<int64_t> ReadRangeCache::EvictEntriesInRange(int64_t start_offset,
+                                                    int64_t length) {
   return impl_->EvictEntriesInRange(start_offset, length);
 }
 

--- a/cpp/src/arrow/io/caching.cc
+++ b/cpp/src/arrow/io/caching.cc
@@ -267,10 +267,9 @@ struct ReadRangeCache::Impl {
     return AllComplete(futures);
   }
 
-  // Evict cache entries that end at or before `end_offset`. `entries` is sorted
-  // by offset, so we stop once an entry starts at/after `end_offset`. An entry
-  // that starts before but extends past `end_offset` (coalesced with a range a
-  // later consumer still needs) is left in place.
+  // `entries` is sorted by offset, so we stop once an entry starts at/after
+  // `end_offset`. An entry that starts before but extends past `end_offset`
+  // (coalesced with a range a later consumer still needs) is left in place.
   int64_t EvictEntriesBefore(int64_t end_offset) {
     int64_t n_evicted = 0;
     std::unique_lock<std::mutex> guard(entry_mutex);

--- a/cpp/src/arrow/io/caching.cc
+++ b/cpp/src/arrow/io/caching.cc
@@ -18,6 +18,7 @@
 #include <algorithm>
 #include <atomic>
 #include <cmath>
+#include <deque>
 #include <mutex>
 #include <utility>
 #include <vector>
@@ -157,7 +158,7 @@ struct ReadRangeCache::Impl {
   // acquires the mutex before delegating to the protected *Locked helpers
   // below, so both the eager and lazy variants are safe to call concurrently
   // from multiple threads.
-  std::vector<RangeCacheEntry> entries;
+  std::deque<RangeCacheEntry> entries;
   std::mutex entry_mutex;
 
   virtual ~Impl() = default;
@@ -194,12 +195,14 @@ struct ReadRangeCache::Impl {
       std::vector<RangeCacheEntry> new_entries = MakeCacheEntries(ranges);
       // Add new entries, themselves ordered by offset
       if (entries.size() > 0) {
-        std::vector<RangeCacheEntry> merged(entries.size() + new_entries.size());
+        std::deque<RangeCacheEntry> merged(entries.size() + new_entries.size());
         std::merge(entries.begin(), entries.end(), new_entries.begin(), new_entries.end(),
                    merged.begin());
         entries = std::move(merged);
       } else {
-        entries = std::move(new_entries);
+        for (auto& entry : new_entries) {
+          entries.push_back(std::move(entry));
+        }
       }
     }
     // Prefetch immediately, regardless of executor availability, if possible.
@@ -267,17 +270,19 @@ struct ReadRangeCache::Impl {
     return AllComplete(futures);
   }
 
-  // `entries` is sorted by offset; an entry that extends past `end_offset`
-  // (coalesced with a range a later consumer still needs) is kept.
+  // Cached ranges are sorted and non-overlapping, so entries ending at or
+  // before `end_offset` form a prefix. Keep a straddling entry.
   int64_t EvictEntriesBefore(int64_t end_offset) {
     std::unique_lock<std::mutex> guard(entry_mutex);
-    const auto first_kept =
-        std::remove_if(entries.begin(), entries.end(),
-                       [end_offset](const RangeCacheEntry& entry) {
-                         return entry.range.offset + entry.range.length <= end_offset;
-                       });
-    const auto n_evicted = static_cast<int64_t>(entries.end() - first_kept);
-    entries.erase(first_kept, entries.end());
+    int64_t n_evicted = 0;
+    while (!entries.empty()) {
+      const auto& range = entries.front().range;
+      if (range.offset + range.length > end_offset) {
+        break;
+      }
+      entries.pop_front();
+      ++n_evicted;
+    }
     return n_evicted;
   }
 

--- a/cpp/src/arrow/io/caching.cc
+++ b/cpp/src/arrow/io/caching.cc
@@ -267,9 +267,8 @@ struct ReadRangeCache::Impl {
     return AllComplete(futures);
   }
 
-  // `entries` is sorted by offset, so we stop once an entry starts at/after
-  // `end_offset`. An entry that starts before but extends past `end_offset`
-  // (coalesced with a range a later consumer still needs) is left in place.
+  // `entries` is sorted by offset; an entry that extends past `end_offset`
+  // (coalesced with a range a later consumer still needs) is kept.
   int64_t EvictEntriesBefore(int64_t end_offset) {
     int64_t n_evicted = 0;
     std::unique_lock<std::mutex> guard(entry_mutex);

--- a/cpp/src/arrow/io/caching.cc
+++ b/cpp/src/arrow/io/caching.cc
@@ -267,29 +267,19 @@ struct ReadRangeCache::Impl {
     return AllComplete(futures);
   }
 
-  // Evict cache entries whose byte range is fully contained within
-  // [start_offset, start_offset + length).
-  Result<int64_t> EvictEntriesInRange(int64_t start_offset, int64_t length) {
-    if (length <= 0) {
-      return 0;
-    }
-    const int64_t end_offset = start_offset + length;
+  // Evict cache entries that end at or before `end_offset`. `entries` is sorted
+  // by offset, so we stop once an entry starts at/after `end_offset`. An entry
+  // that starts before but extends past `end_offset` (coalesced with a range a
+  // later consumer still needs) is left in place.
+  int64_t EvictEntriesBefore(int64_t end_offset) {
     int64_t n_evicted = 0;
     std::unique_lock<std::mutex> guard(entry_mutex);
-    // entries is sorted by range.offset, so we can fast-forward to the first
-    // entry whose offset is >= start_offset and stop once we pass end_offset.
-    auto it = std::lower_bound(entries.begin(), entries.end(), start_offset,
-                               [](const RangeCacheEntry& entry, int64_t offset) {
-                                 return entry.range.offset < offset;
-                               });
+    auto it = entries.begin();
     while (it != entries.end() && it->range.offset < end_offset) {
       if (it->range.offset + it->range.length <= end_offset) {
         it = entries.erase(it);
         ++n_evicted;
       } else {
-        // Entry extends beyond the requested window (e.g. coalesced with a
-        // neighboring range). Leave it alone and keep scanning in case
-        // smaller siblings follow.
         ++it;
       }
     }
@@ -381,9 +371,8 @@ Future<> ReadRangeCache::WaitFor(std::vector<ReadRange> ranges) {
   return impl_->WaitFor(std::move(ranges));
 }
 
-Result<int64_t> ReadRangeCache::EvictEntriesInRange(int64_t start_offset,
-                                                    int64_t length) {
-  return impl_->EvictEntriesInRange(start_offset, length);
+int64_t ReadRangeCache::EvictEntriesBefore(int64_t end_offset) {
+  return impl_->EvictEntriesBefore(end_offset);
 }
 
 }  // namespace internal

--- a/cpp/src/arrow/io/caching.cc
+++ b/cpp/src/arrow/io/caching.cc
@@ -270,17 +270,14 @@ struct ReadRangeCache::Impl {
   // `entries` is sorted by offset; an entry that extends past `end_offset`
   // (coalesced with a range a later consumer still needs) is kept.
   int64_t EvictEntriesBefore(int64_t end_offset) {
-    int64_t n_evicted = 0;
     std::unique_lock<std::mutex> guard(entry_mutex);
-    auto it = entries.begin();
-    while (it != entries.end() && it->range.offset < end_offset) {
-      if (it->range.offset + it->range.length <= end_offset) {
-        it = entries.erase(it);
-        ++n_evicted;
-      } else {
-        ++it;
-      }
-    }
+    const auto first_kept =
+        std::remove_if(entries.begin(), entries.end(),
+                       [end_offset](const RangeCacheEntry& entry) {
+                         return entry.range.offset + entry.range.length <= end_offset;
+                       });
+    const auto n_evicted = static_cast<int64_t>(entries.end() - first_kept);
+    entries.erase(first_kept, entries.end());
     return n_evicted;
   }
 

--- a/cpp/src/arrow/io/caching.cc
+++ b/cpp/src/arrow/io/caching.cc
@@ -19,7 +19,9 @@
 #include <atomic>
 #include <cmath>
 #include <deque>
+#include <iterator>
 #include <mutex>
+#include <optional>
 #include <utility>
 #include <vector>
 
@@ -152,20 +154,12 @@ struct ReadRangeCache::Impl {
   IOContext ctx;
   CacheOptions options;
 
-  // Ordered by offset (so as to find a matching region by binary search).
-  // Mutation of `entries` and of individual entries' futures must be
-  // serialized via `entry_mutex`. Every public method that touches either
-  // acquires the mutex before delegating to the protected *Locked helpers
-  // below, so both the eager and lazy variants are safe to call concurrently
-  // from multiple threads.
-  std::deque<RangeCacheEntry> entries;
+  std::deque<RangeCacheEntry> entries;  // GUARDED_BY(entry_mutex)
   std::mutex entry_mutex;
 
   virtual ~Impl() = default;
 
-  // -- Polymorphic hooks. Always called with entry_mutex held. --
-
-  // Get the future corresponding to a range
+  // Get the future corresponding to a range. Called with entry_mutex held.
   virtual Future<std::shared_ptr<Buffer>> MaybeRead(RangeCacheEntry* entry) {
     return entry->future;
   }
@@ -182,28 +176,21 @@ struct ReadRangeCache::Impl {
     return new_entries;
   }
 
-  // -- Public entry points (acquire entry_mutex, then delegate). --
-
   // Add the given ranges to the cache, coalescing them where possible.
   Status Cache(std::vector<ReadRange> ranges) {
     ARROW_ASSIGN_OR_RAISE(
         ranges, internal::CoalesceReadRanges(std::move(ranges), options.hole_size_limit,
                                              options.range_size_limit));
+    std::vector<RangeCacheEntry> new_entries = MakeCacheEntries(ranges);
     Status st;
     {
       std::unique_lock<std::mutex> guard(entry_mutex);
-      std::vector<RangeCacheEntry> new_entries = MakeCacheEntries(ranges);
-      // Add new entries, themselves ordered by offset
-      if (entries.size() > 0) {
-        std::deque<RangeCacheEntry> merged(entries.size() + new_entries.size());
-        std::merge(entries.begin(), entries.end(), new_entries.begin(), new_entries.end(),
-                   merged.begin());
-        entries = std::move(merged);
-      } else {
-        for (auto& entry : new_entries) {
-          entries.push_back(std::move(entry));
-        }
-      }
+      std::deque<RangeCacheEntry> merged;
+      std::merge(std::make_move_iterator(entries.begin()),
+                 std::make_move_iterator(entries.end()),
+                 std::make_move_iterator(new_entries.begin()),
+                 std::make_move_iterator(new_entries.end()), std::back_inserter(merged));
+      entries.swap(merged);
     }
     // Prefetch immediately, regardless of executor availability, if possible.
     // Do this outside the lock: WillNeed() may block on an mmap advise / I/O
@@ -218,10 +205,10 @@ struct ReadRangeCache::Impl {
 
   // Read the given range from the cache, blocking if needed. Cannot read a
   // range that spans cache entries.
-  Result<std::shared_ptr<Buffer>> Read(ReadRange range) {
+  Result<std::optional<std::shared_ptr<Buffer>>> ReadIfCached(ReadRange range) {
     if (range.length == 0) {
       static const uint8_t byte = 0;
-      return std::make_shared<Buffer>(&byte, 0);
+      return std::make_optional(std::make_shared<Buffer>(&byte, 0));
     }
 
     Future<std::shared_ptr<Buffer>> fut;
@@ -234,7 +221,7 @@ struct ReadRangeCache::Impl {
             return entry.range.offset + entry.range.length < range.offset + range.length;
           });
       if (it == entries.end() || !it->range.Contains(range)) {
-        return Status::Invalid("ReadRangeCache did not find matching cache entry");
+        return std::nullopt;
       }
       fut = MaybeRead(&*it);
       slice_offset = range.offset - it->range.offset;
@@ -255,7 +242,15 @@ struct ReadRangeCache::Impl {
     // Drop the lock before blocking on the I/O future so other threads can
     // still do lookups while a previously queued read is in flight.
     ARROW_ASSIGN_OR_RAISE(auto buf, fut.result());
-    return SliceBuffer(std::move(buf), slice_offset, range.length);
+    return std::make_optional(SliceBuffer(std::move(buf), slice_offset, range.length));
+  }
+
+  Result<std::shared_ptr<Buffer>> Read(ReadRange range) {
+    ARROW_ASSIGN_OR_RAISE(auto buffer, ReadIfCached(range));
+    if (!buffer) {
+      return Status::Invalid("ReadRangeCache did not find matching cache entry");
+    }
+    return std::move(*buffer);
   }
 
   Future<> Wait() {
@@ -272,18 +267,13 @@ struct ReadRangeCache::Impl {
 
   // Cached ranges are sorted and non-overlapping, so entries ending at or
   // before `end_offset` form a prefix. Keep a straddling entry.
-  int64_t EvictEntriesBefore(int64_t end_offset) {
+  void EvictEntriesBefore(int64_t end_offset) {
     std::unique_lock<std::mutex> guard(entry_mutex);
-    int64_t n_evicted = 0;
-    while (!entries.empty()) {
-      const auto& range = entries.front().range;
-      if (range.offset + range.length > end_offset) {
-        break;
-      }
-      entries.pop_front();
-      ++n_evicted;
-    }
-    return n_evicted;
+    const auto first_kept = std::find_if(
+        entries.cbegin(), entries.cend(), [end_offset](const RangeCacheEntry& entry) {
+          return entry.range.offset + entry.range.length > end_offset;
+        });
+    entries.erase(entries.cbegin(), first_kept);
   }
 
   // Return a Future that completes when the given ranges have been read.
@@ -315,16 +305,11 @@ struct ReadRangeCache::Impl {
 };
 
 // Don't read ranges when they're first added. Instead, wait until they're
-// requested (either through Read or WaitFor). Thread safety is inherited from
-// the base Impl: both MakeCacheEntries and MaybeRead are only ever invoked
-// from the public entry points, and those hold the base class's entry_mutex
-// before delegating.
+// requested (either through Read or WaitFor).
 struct ReadRangeCache::LazyImpl : public ReadRangeCache::Impl {
   virtual ~LazyImpl() = default;
 
   Future<std::shared_ptr<Buffer>> MaybeRead(RangeCacheEntry* entry) override {
-    // Called by the superclass under entry_mutex, so it is safe to mutate
-    // entry->future here.
     if (!entry->future.is_valid()) {
       entry->future = file->ReadAsync(ctx, entry->range.offset, entry->range.length,
                                       /*allow_short_read=*/false);
@@ -365,14 +350,19 @@ Result<std::shared_ptr<Buffer>> ReadRangeCache::Read(ReadRange range) {
   return impl_->Read(range);
 }
 
+Result<std::optional<std::shared_ptr<Buffer>>> ReadRangeCache::ReadIfCached(
+    ReadRange range) {
+  return impl_->ReadIfCached(range);
+}
+
 Future<> ReadRangeCache::Wait() { return impl_->Wait(); }
 
 Future<> ReadRangeCache::WaitFor(std::vector<ReadRange> ranges) {
   return impl_->WaitFor(std::move(ranges));
 }
 
-int64_t ReadRangeCache::EvictEntriesBefore(int64_t end_offset) {
-  return impl_->EvictEntriesBefore(end_offset);
+void ReadRangeCache::EvictEntriesBefore(int64_t end_offset) {
+  impl_->EvictEntriesBefore(end_offset);
 }
 
 }  // namespace internal

--- a/cpp/src/arrow/io/caching.h
+++ b/cpp/src/arrow/io/caching.h
@@ -142,6 +142,21 @@ class ARROW_EXPORT ReadRangeCache {
   /// \brief Wait until all given ranges have been cached.
   Future<> WaitFor(std::vector<ReadRange> ranges);
 
+  /// \brief Evict cache entries whose byte range is fully contained within
+  ///        [start_offset, start_offset + length).
+  ///
+  /// This releases the memory held by those entries, allowing buffers to be
+  /// freed as soon as no other owner retains a reference. Entries that are not
+  /// fully contained in the given window (for example, because I/O range
+  /// coalescing merged them with an adjacent region the caller still needs)
+  /// are not evicted, so this method is safe to call even if some cached
+  /// ranges have been merged across unrelated consumers.
+  ///
+  /// \param[in] start_offset Start of the window (inclusive).
+  /// \param[in] length Length of the window.
+  /// \return Number of cache entries that were evicted.
+  Result<int64_t> EvictEntriesInRange(int64_t start_offset, int64_t length);
+
  protected:
   struct Impl;
   struct LazyImpl;

--- a/cpp/src/arrow/io/caching.h
+++ b/cpp/src/arrow/io/caching.h
@@ -142,16 +142,10 @@ class ARROW_EXPORT ReadRangeCache {
   /// \brief Wait until all given ranges have been cached.
   Future<> WaitFor(std::vector<ReadRange> ranges);
 
-  /// \brief Evict cache entries that end at or before `end_offset`.
-  ///
-  /// Releases the memory of entries whose byte range lies entirely before
-  /// `end_offset`. An entry straddling `end_offset` is retained, so this is safe
-  /// even when I/O coalescing merged several requested ranges into one entry.
-  /// Buffers already returned by Read() stay valid through shared ownership.
-  ///
-  /// \param[in] end_offset Exclusive byte bound; entries ending at or before it
-  ///     are evicted.
-  /// \return Number of cache entries evicted.
+  /// \brief Evict cache entries ending at or before `end_offset`, returning the
+  /// count. An entry straddling `end_offset` is retained (safe when coalescing
+  /// merged ranges). Buffers already returned by Read() stay valid through
+  /// shared ownership.
   int64_t EvictEntriesBefore(int64_t end_offset);
 
  protected:

--- a/cpp/src/arrow/io/caching.h
+++ b/cpp/src/arrow/io/caching.h
@@ -142,20 +142,17 @@ class ARROW_EXPORT ReadRangeCache {
   /// \brief Wait until all given ranges have been cached.
   Future<> WaitFor(std::vector<ReadRange> ranges);
 
-  /// \brief Evict cache entries whose byte range is fully contained within
-  ///        [start_offset, start_offset + length).
+  /// \brief Evict cache entries that end at or before `end_offset`.
   ///
-  /// This releases the memory held by those entries, allowing buffers to be
-  /// freed as soon as no other owner retains a reference. Entries that are not
-  /// fully contained in the given window (for example, because I/O range
-  /// coalescing merged them with an adjacent region the caller still needs)
-  /// are not evicted, so this method is safe to call even if some cached
-  /// ranges have been merged across unrelated consumers.
+  /// Releases the memory of entries whose byte range lies entirely before
+  /// `end_offset`. An entry straddling `end_offset` is retained, so this is safe
+  /// even when I/O coalescing merged several requested ranges into one entry.
+  /// Buffers already returned by Read() stay valid through shared ownership.
   ///
-  /// \param[in] start_offset Start of the window (inclusive).
-  /// \param[in] length Length of the window.
-  /// \return Number of cache entries that were evicted.
-  Result<int64_t> EvictEntriesInRange(int64_t start_offset, int64_t length);
+  /// \param[in] end_offset Exclusive byte bound; entries ending at or before it
+  ///     are evicted.
+  /// \return Number of cache entries evicted.
+  int64_t EvictEntriesBefore(int64_t end_offset);
 
  protected:
   struct Impl;

--- a/cpp/src/arrow/io/caching.h
+++ b/cpp/src/arrow/io/caching.h
@@ -19,6 +19,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -136,17 +137,22 @@ class ARROW_EXPORT ReadRangeCache {
   /// \brief Read a range previously given to Cache().
   Result<std::shared_ptr<Buffer>> Read(ReadRange range);
 
+  /// \brief Read a range if it is still cached.
+  ///
+  /// A cache miss returns an empty optional. I/O errors are propagated.
+  Result<std::optional<std::shared_ptr<Buffer>>> ReadIfCached(ReadRange range);
+
   /// \brief Wait until all ranges added so far have been cached.
   Future<> Wait();
 
   /// \brief Wait until all given ranges have been cached.
   Future<> WaitFor(std::vector<ReadRange> ranges);
 
-  /// \brief Evict cache entries ending at or before `end_offset`, returning the
-  /// count. An entry straddling `end_offset` is retained (safe when coalescing
-  /// merged ranges). Buffers already returned by Read() stay valid through
-  /// shared ownership.
-  int64_t EvictEntriesBefore(int64_t end_offset);
+  /// \brief Evict cache entries ending at or before `end_offset`.
+  ///
+  /// An entry straddling `end_offset` is retained. Buffers already returned by
+  /// Read() stay valid through shared ownership.
+  void EvictEntriesBefore(int64_t end_offset);
 
  protected:
   struct Impl;

--- a/cpp/src/arrow/io/memory_test.cc
+++ b/cpp/src/arrow/io/memory_test.cc
@@ -746,6 +746,16 @@ class CountingBufferReader : public BufferReader {
   int64_t read_count_ = 0;
 };
 
+class InvalidReadBufferReader : public BufferReader {
+ public:
+  using BufferReader::BufferReader;
+
+  Future<std::shared_ptr<Buffer>> ReadAsync(const IOContext&, int64_t, int64_t,
+                                            bool) override {
+    return Future<std::shared_ptr<Buffer>>::MakeFinished(Status::Invalid("read failed"));
+  }
+};
+
 TEST(RangeReadCache, Basics) {
   std::string data = "abcdefghijklmnopqrstuvwxyz";
 
@@ -786,6 +796,8 @@ TEST(RangeReadCache, Basics) {
     ASSERT_RAISES(Invalid, cache.Read({19, 3}));
     ASSERT_RAISES(Invalid, cache.Read({0, 3}));
     ASSERT_RAISES(Invalid, cache.Read({25, 2}));
+    ASSERT_OK_AND_ASSIGN(auto missing, cache.ReadIfCached({25, 2}));
+    ASSERT_FALSE(missing);
     ASSERT_FINISHES_AND_RAISES(Invalid, cache.WaitFor({{25, 2}}));
     ASSERT_FINISHES_AND_RAISES(Invalid, cache.WaitFor({{1, 2}, {25, 2}}));
 
@@ -793,6 +805,14 @@ TEST(RangeReadCache, Basics) {
     // 8 ranges should lead to less than 8 reads
     ASSERT_LT(file->read_count(), 8);
   }
+}
+
+TEST(RangeReadCache, ReadIfCachedPropagatesErrors) {
+  auto file = std::make_shared<InvalidReadBufferReader>(Buffer::FromString("data"));
+  internal::ReadRangeCache cache(file, {}, CacheOptions::Defaults());
+
+  ASSERT_OK(cache.Cache({{0, 4}}));
+  ASSERT_RAISES(Invalid, cache.ReadIfCached({0, 4}));
 }
 
 TEST(RangeReadCache, Concurrency) {
@@ -941,25 +961,27 @@ TEST(RangeReadCache, EvictEntriesBefore) {
     AssertBufferEqual(*buf, "klmn");
 
     // An offset that splits no entry frees nothing.
-    ASSERT_EQ(0, cache.EvictEntriesBefore(0));
-    ASSERT_EQ(0, cache.EvictEntriesBefore(2));  // [1,3) extends past 2 -> retained
+    cache.EvictEntriesBefore(0);
+    cache.EvictEntriesBefore(2);  // [1,3) extends past 2 -> retained
+    ASSERT_OK(cache.Read({1, 2}));
 
     // end_offset == an entry's end frees exactly that entry ([1,3) ends at 3).
-    ASSERT_EQ(1, cache.EvictEntriesBefore(3));
+    cache.EvictEntriesBefore(3);
     ASSERT_RAISES(Invalid, cache.Read({1, 2}));
     ASSERT_OK_AND_ASSIGN(buf, cache.Read({10, 4}));  // others intact
     AssertBufferEqual(*buf, "klmn");
 
     // An offset inside an entry leaves it in place.
-    ASSERT_EQ(0, cache.EvictEntriesBefore(12));  // [10,14) straddles 12
+    cache.EvictEntriesBefore(12);  // [10,14) straddles 12
+    ASSERT_OK(cache.Read({10, 4}));
 
     // A wide offset frees every remaining entry in one call.
-    ASSERT_EQ(2, cache.EvictEntriesBefore(100));
+    cache.EvictEntriesBefore(100);
     ASSERT_RAISES(Invalid, cache.Read({10, 4}));
     ASSERT_RAISES(Invalid, cache.Read({20, 2}));
 
     // Empty cache is a safe no-op.
-    ASSERT_EQ(0, cache.EvictEntriesBefore(100));
+    cache.EvictEntriesBefore(100);
   }
 }
 
@@ -1056,13 +1078,13 @@ TEST(RangeReadCache, EvictEntriesBeforeSpanningEntry) {
   ASSERT_OK(cache.Cache({{1, 3}, {10, 4}}));
 
   // An offset inside the entry (e.g. just past the first logical range) keeps it.
-  ASSERT_EQ(0, cache.EvictEntriesBefore(4));
-  ASSERT_EQ(0, cache.EvictEntriesBefore(13));
+  cache.EvictEntriesBefore(4);
+  cache.EvictEntriesBefore(13);
   ASSERT_OK_AND_ASSIGN(auto buf, cache.Read({10, 4}));
   ASSERT_EQ(4, buf->size());
 
   // end_offset at/after the entry's end (14) frees it.
-  ASSERT_EQ(1, cache.EvictEntriesBefore(14));
+  cache.EvictEntriesBefore(14);
   ASSERT_RAISES(Invalid, cache.Read({1, 3}));
   ASSERT_RAISES(Invalid, cache.Read({10, 4}));
 }

--- a/cpp/src/arrow/io/memory_test.cc
+++ b/cpp/src/arrow/io/memory_test.cc
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+#include <atomic>
 #include <chrono>
 #include <cmath>
 #include <cstdint>
@@ -25,6 +26,7 @@
 #include <ostream>
 #include <random>
 #include <string>
+#include <thread>
 #include <vector>
 
 #include <gtest/gtest.h>
@@ -916,6 +918,186 @@ TEST(RangeReadCache, LazyWithPrefetching) {
   ASSERT_RAISES(Invalid, cache.Read({19, 3}));
   ASSERT_RAISES(Invalid, cache.Read({0, 3}));
   ASSERT_RAISES(Invalid, cache.Read({25, 2}));
+}
+
+TEST(RangeReadCache, EvictEntriesInRange) {
+  // GH-39808: entries cached by PreBuffer()-style code need to be evictable so
+  // that memory usage remains bounded while iterating over a large Parquet
+  // file.
+  std::string data = "abcdefghijklmnopqrstuvwxyz";
+
+  for (auto lazy : std::vector<bool>{false, true}) {
+    SCOPED_TRACE(lazy);
+    CacheOptions options = CacheOptions::Defaults();
+    // Disable coalescing so each requested range becomes its own entry.
+    options.hole_size_limit = 0;
+    options.range_size_limit = 10;
+    options.lazy = lazy;
+
+    auto file = std::make_shared<BufferReader>(std::make_shared<Buffer>(data));
+    internal::ReadRangeCache cache(file, {}, options);
+
+    // Cache three disjoint ranges, each forming its own entry.
+    ASSERT_OK(cache.Cache({{1, 2}, {10, 4}, {20, 2}}));
+
+    // Sanity: all three ranges are readable.
+    ASSERT_OK_AND_ASSIGN(auto buf, cache.Read({1, 2}));
+    AssertBufferEqual(*buf, "bc");
+    ASSERT_OK_AND_ASSIGN(buf, cache.Read({10, 4}));
+    AssertBufferEqual(*buf, "klmn");
+    ASSERT_OK_AND_ASSIGN(buf, cache.Read({20, 2}));
+    AssertBufferEqual(*buf, "uv");
+
+    // A window that doesn't fully contain any entry evicts nothing.
+    ASSERT_OK_AND_ASSIGN(int64_t evicted, cache.EvictEntriesInRange(0, 1));
+    ASSERT_EQ(0, evicted);
+    ASSERT_OK_AND_ASSIGN(evicted, cache.EvictEntriesInRange(11, 2));
+    ASSERT_EQ(0, evicted);
+
+    // A zero- or negative-length window is a no-op.
+    ASSERT_OK_AND_ASSIGN(evicted, cache.EvictEntriesInRange(0, 0));
+    ASSERT_EQ(0, evicted);
+    ASSERT_OK_AND_ASSIGN(evicted, cache.EvictEntriesInRange(10, -5));
+    ASSERT_EQ(0, evicted);
+
+    // Windows that partially overlap with an entry but don't fully contain
+    // it must also leave the entry in place.
+    ASSERT_OK_AND_ASSIGN(evicted, cache.EvictEntriesInRange(0, 2));
+    ASSERT_EQ(0, evicted);
+    ASSERT_OK_AND_ASSIGN(evicted, cache.EvictEntriesInRange(10, 3));
+    ASSERT_EQ(0, evicted);
+
+    // Evicting the exact range of the middle entry removes only that entry.
+    ASSERT_OK_AND_ASSIGN(evicted, cache.EvictEntriesInRange(10, 4));
+    ASSERT_EQ(1, evicted);
+    // Other entries are still readable.
+    ASSERT_OK_AND_ASSIGN(buf, cache.Read({1, 2}));
+    AssertBufferEqual(*buf, "bc");
+    ASSERT_OK_AND_ASSIGN(buf, cache.Read({20, 2}));
+    AssertBufferEqual(*buf, "uv");
+    // Evicted entry is gone.
+    ASSERT_RAISES(Invalid, cache.Read({10, 4}));
+
+    // A wider window evicts every remaining fully-contained entry in one call.
+    ASSERT_OK_AND_ASSIGN(evicted, cache.EvictEntriesInRange(0, 100));
+    ASSERT_EQ(2, evicted);
+    ASSERT_RAISES(Invalid, cache.Read({1, 2}));
+    ASSERT_RAISES(Invalid, cache.Read({20, 2}));
+
+    // Evicting an already-empty cache is a safe no-op.
+    ASSERT_OK_AND_ASSIGN(evicted, cache.EvictEntriesInRange(0, 100));
+    ASSERT_EQ(0, evicted);
+  }
+}
+
+TEST(RangeReadCache, ConcurrentReadAndEvict) {
+  // GH-39808: the Parquet dataset scanner calls EvictEntriesInRange from the
+  // thread-pool continuation that runs after a row group is decoded, while
+  // other threads may still be calling Read() for column chunks of other
+  // in-flight row groups. Exercise that pattern explicitly by slamming the
+  // cache with parallel Read()s interleaved with Evict()s and make sure we
+  // don't hit UB (iterator invalidation, torn reads, etc.).
+  constexpr int kNumRanges = 64;
+  constexpr int kRangeSize = 64;
+  constexpr int kIterations = 50;
+  std::string data(kNumRanges * kRangeSize, 'x');
+
+  for (auto lazy : std::vector<bool>{false, true}) {
+    SCOPED_TRACE(lazy);
+    CacheOptions options = CacheOptions::Defaults();
+    // No coalescing: each range is its own entry so we can evict them
+    // individually without fighting the coalescing heuristic.
+    options.hole_size_limit = 0;
+    options.range_size_limit = kRangeSize;
+    options.lazy = lazy;
+
+    auto file = std::make_shared<BufferReader>(std::make_shared<Buffer>(data));
+    internal::ReadRangeCache cache(file, {}, options);
+
+    std::vector<ReadRange> ranges;
+    ranges.reserve(kNumRanges);
+    for (int i = 0; i < kNumRanges; ++i) {
+      ranges.push_back({static_cast<int64_t>(i * kRangeSize), kRangeSize});
+    }
+    ASSERT_OK(cache.Cache(ranges));
+
+    // Half of the threads repeatedly read the upper half of the ranges.
+    // The other half repeatedly evict and re-cache the lower half. Under
+    // the old code this would race on the shared `entries` vector.
+    std::atomic<bool> stop{false};
+    std::atomic<int> failures{0};
+
+    auto reader_fn = [&]() {
+      while (!stop.load(std::memory_order_relaxed)) {
+        for (int i = kNumRanges / 2; i < kNumRanges; ++i) {
+          auto result = cache.Read(ranges[i]);
+          if (!result.ok() || (*result)->size() != kRangeSize) {
+            failures.fetch_add(1, std::memory_order_relaxed);
+          }
+        }
+      }
+    };
+    auto evictor_fn = [&]() {
+      for (int iter = 0; iter < kIterations; ++iter) {
+        // Evict every lower-half entry.
+        for (int i = 0; i < kNumRanges / 2; ++i) {
+          auto result = cache.EvictEntriesInRange(ranges[i].offset, ranges[i].length);
+          if (!result.ok()) {
+            failures.fetch_add(1, std::memory_order_relaxed);
+          }
+        }
+        // Re-cache them so the next iteration has something to evict.
+        std::vector<ReadRange> lower(ranges.begin(), ranges.begin() + kNumRanges / 2);
+        if (!cache.Cache(lower).ok()) {
+          failures.fetch_add(1, std::memory_order_relaxed);
+        }
+      }
+      stop.store(true, std::memory_order_relaxed);
+    };
+
+    std::vector<std::thread> threads;
+    for (int i = 0; i < 4; ++i) threads.emplace_back(reader_fn);
+    threads.emplace_back(evictor_fn);
+    for (auto& t : threads) t.join();
+    ASSERT_EQ(0, failures.load());
+
+    // Every upper-half range is still readable after the torture loop.
+    for (int i = kNumRanges / 2; i < kNumRanges; ++i) {
+      ASSERT_OK_AND_ASSIGN(auto buf, cache.Read(ranges[i]));
+      ASSERT_EQ(kRangeSize, buf->size());
+    }
+  }
+}
+
+TEST(RangeReadCache, EvictEntriesInRangeSpanningEntry) {
+  // Coalesced entries (entries that were merged with a neighboring range at
+  // Cache() time) must not be evicted unless the eviction window fully
+  // contains them, otherwise we would drop bytes the caller still needs.
+  std::string data(40, 'x');
+
+  CacheOptions options = CacheOptions::Defaults();
+  // Large hole_size_limit forces coalescing of adjacent ranges into one entry.
+  options.hole_size_limit = 100;
+  options.range_size_limit = 200;
+
+  auto file = std::make_shared<BufferReader>(std::make_shared<Buffer>(data));
+  internal::ReadRangeCache cache(file, {}, options);
+
+  // These two ranges get coalesced into a single entry [1, 14).
+  ASSERT_OK(cache.Cache({{1, 3}, {10, 4}}));
+
+  // Trying to evict only one of the two "logical" ranges must not drop the
+  // coalesced entry - it still holds data the other logical range needs.
+  ASSERT_OK_AND_ASSIGN(int64_t evicted, cache.EvictEntriesInRange(1, 3));
+  ASSERT_EQ(0, evicted);
+  ASSERT_OK_AND_ASSIGN(auto buf, cache.Read({10, 4}));
+  ASSERT_EQ(4, buf->size());
+
+  // A wide window that contains the whole coalesced entry evicts it.
+  ASSERT_OK_AND_ASSIGN(evicted, cache.EvictEntriesInRange(0, 20));
+  ASSERT_EQ(1, evicted);
+  ASSERT_RAISES(Invalid, cache.Read({1, 3}));
+  ASSERT_RAISES(Invalid, cache.Read({10, 4}));
 }
 
 TEST(CacheOptions, Basics) {

--- a/cpp/src/arrow/io/memory_test.cc
+++ b/cpp/src/arrow/io/memory_test.cc
@@ -920,78 +920,51 @@ TEST(RangeReadCache, LazyWithPrefetching) {
   ASSERT_RAISES(Invalid, cache.Read({25, 2}));
 }
 
-TEST(RangeReadCache, EvictEntriesInRange) {
+TEST(RangeReadCache, EvictEntriesBefore) {
   // GH-39808: entries cached by PreBuffer()-style code need to be evictable so
-  // that memory usage remains bounded while iterating over a large Parquet
-  // file.
+  // memory stays bounded while iterating a large Parquet file.
   std::string data = "abcdefghijklmnopqrstuvwxyz";
 
   for (auto lazy : std::vector<bool>{false, true}) {
     SCOPED_TRACE(lazy);
     CacheOptions options = CacheOptions::Defaults();
-    // Disable coalescing so each requested range becomes its own entry.
-    options.hole_size_limit = 0;
+    options.hole_size_limit = 0;  // disable coalescing: one entry per range
     options.range_size_limit = 10;
     options.lazy = lazy;
 
     auto file = std::make_shared<BufferReader>(std::make_shared<Buffer>(data));
     internal::ReadRangeCache cache(file, {}, options);
 
-    // Cache three disjoint ranges, each forming its own entry.
+    // Entries: [1,3), [10,14), [20,22).
     ASSERT_OK(cache.Cache({{1, 2}, {10, 4}, {20, 2}}));
-
-    // Sanity: all three ranges are readable.
-    ASSERT_OK_AND_ASSIGN(auto buf, cache.Read({1, 2}));
-    AssertBufferEqual(*buf, "bc");
-    ASSERT_OK_AND_ASSIGN(buf, cache.Read({10, 4}));
+    ASSERT_OK_AND_ASSIGN(auto buf, cache.Read({10, 4}));
     AssertBufferEqual(*buf, "klmn");
-    ASSERT_OK_AND_ASSIGN(buf, cache.Read({20, 2}));
-    AssertBufferEqual(*buf, "uv");
 
-    // A window that doesn't fully contain any entry evicts nothing.
-    ASSERT_OK_AND_ASSIGN(int64_t evicted, cache.EvictEntriesInRange(0, 1));
-    ASSERT_EQ(0, evicted);
-    ASSERT_OK_AND_ASSIGN(evicted, cache.EvictEntriesInRange(11, 2));
-    ASSERT_EQ(0, evicted);
+    // An offset that splits no entry frees nothing.
+    ASSERT_EQ(0, cache.EvictEntriesBefore(0));
+    ASSERT_EQ(0, cache.EvictEntriesBefore(2));  // [1,3) extends past 2 -> retained
 
-    // A zero- or negative-length window is a no-op.
-    ASSERT_OK_AND_ASSIGN(evicted, cache.EvictEntriesInRange(0, 0));
-    ASSERT_EQ(0, evicted);
-    ASSERT_OK_AND_ASSIGN(evicted, cache.EvictEntriesInRange(10, -5));
-    ASSERT_EQ(0, evicted);
-
-    // Windows that partially overlap with an entry but don't fully contain
-    // it must also leave the entry in place.
-    ASSERT_OK_AND_ASSIGN(evicted, cache.EvictEntriesInRange(0, 2));
-    ASSERT_EQ(0, evicted);
-    ASSERT_OK_AND_ASSIGN(evicted, cache.EvictEntriesInRange(10, 3));
-    ASSERT_EQ(0, evicted);
-
-    // Evicting the exact range of the middle entry removes only that entry.
-    ASSERT_OK_AND_ASSIGN(evicted, cache.EvictEntriesInRange(10, 4));
-    ASSERT_EQ(1, evicted);
-    // Other entries are still readable.
-    ASSERT_OK_AND_ASSIGN(buf, cache.Read({1, 2}));
-    AssertBufferEqual(*buf, "bc");
-    ASSERT_OK_AND_ASSIGN(buf, cache.Read({20, 2}));
-    AssertBufferEqual(*buf, "uv");
-    // Evicted entry is gone.
-    ASSERT_RAISES(Invalid, cache.Read({10, 4}));
-
-    // A wider window evicts every remaining fully-contained entry in one call.
-    ASSERT_OK_AND_ASSIGN(evicted, cache.EvictEntriesInRange(0, 100));
-    ASSERT_EQ(2, evicted);
+    // end_offset == an entry's end frees exactly that entry ([1,3) ends at 3).
+    ASSERT_EQ(1, cache.EvictEntriesBefore(3));
     ASSERT_RAISES(Invalid, cache.Read({1, 2}));
+    ASSERT_OK_AND_ASSIGN(buf, cache.Read({10, 4}));  // others intact
+    AssertBufferEqual(*buf, "klmn");
+
+    // An offset inside an entry leaves it in place.
+    ASSERT_EQ(0, cache.EvictEntriesBefore(12));  // [10,14) straddles 12
+
+    // A wide offset frees every remaining entry in one call.
+    ASSERT_EQ(2, cache.EvictEntriesBefore(100));
+    ASSERT_RAISES(Invalid, cache.Read({10, 4}));
     ASSERT_RAISES(Invalid, cache.Read({20, 2}));
 
-    // Evicting an already-empty cache is a safe no-op.
-    ASSERT_OK_AND_ASSIGN(evicted, cache.EvictEntriesInRange(0, 100));
-    ASSERT_EQ(0, evicted);
+    // Empty cache is a safe no-op.
+    ASSERT_EQ(0, cache.EvictEntriesBefore(100));
   }
 }
 
 TEST(RangeReadCache, ConcurrentReadAndEvict) {
-  // GH-39808: the Parquet dataset scanner calls EvictEntriesInRange from the
+  // GH-39808: the Parquet dataset scanner calls EvictEntriesBefore from the
   // thread-pool continuation that runs after a row group is decoded, while
   // other threads may still be calling Read() for column chunks of other
   // in-flight row groups. Exercise that pattern explicitly by slamming the
@@ -1039,13 +1012,11 @@ TEST(RangeReadCache, ConcurrentReadAndEvict) {
     };
     auto evictor_fn = [&]() {
       for (int iter = 0; iter < kIterations; ++iter) {
-        // Evict every lower-half entry.
-        for (int i = 0; i < kNumRanges / 2; ++i) {
-          auto result = cache.EvictEntriesInRange(ranges[i].offset, ranges[i].length);
-          if (!result.ok()) {
-            failures.fetch_add(1, std::memory_order_relaxed);
-          }
-        }
+        // Evict the entire lower half in one call (entries ending before the
+        // midpoint offset).
+        const int64_t mid_offset =
+            ranges[kNumRanges / 2 - 1].offset + ranges[kNumRanges / 2 - 1].length;
+        cache.EvictEntriesBefore(mid_offset);
         // Re-cache them so the next iteration has something to evict.
         std::vector<ReadRange> lower(ranges.begin(), ranges.begin() + kNumRanges / 2);
         if (!cache.Cache(lower).ok()) {
@@ -1069,33 +1040,29 @@ TEST(RangeReadCache, ConcurrentReadAndEvict) {
   }
 }
 
-TEST(RangeReadCache, EvictEntriesInRangeSpanningEntry) {
-  // Coalesced entries (entries that were merged with a neighboring range at
-  // Cache() time) must not be evicted unless the eviction window fully
-  // contains them, otherwise we would drop bytes the caller still needs.
+TEST(RangeReadCache, EvictEntriesBeforeSpanningEntry) {
+  // A coalesced entry must not be dropped until end_offset passes its end,
+  // otherwise we drop bytes a later consumer still needs.
   std::string data(40, 'x');
 
   CacheOptions options = CacheOptions::Defaults();
-  // Large hole_size_limit forces coalescing of adjacent ranges into one entry.
-  options.hole_size_limit = 100;
+  options.hole_size_limit = 100;  // force coalescing into one entry
   options.range_size_limit = 200;
 
   auto file = std::make_shared<BufferReader>(std::make_shared<Buffer>(data));
   internal::ReadRangeCache cache(file, {}, options);
 
-  // These two ranges get coalesced into a single entry [1, 14).
+  // {1,3} and {10,4} coalesce into a single entry [1, 14).
   ASSERT_OK(cache.Cache({{1, 3}, {10, 4}}));
 
-  // Trying to evict only one of the two "logical" ranges must not drop the
-  // coalesced entry - it still holds data the other logical range needs.
-  ASSERT_OK_AND_ASSIGN(int64_t evicted, cache.EvictEntriesInRange(1, 3));
-  ASSERT_EQ(0, evicted);
+  // An offset inside the entry (e.g. just past the first logical range) keeps it.
+  ASSERT_EQ(0, cache.EvictEntriesBefore(4));
+  ASSERT_EQ(0, cache.EvictEntriesBefore(13));
   ASSERT_OK_AND_ASSIGN(auto buf, cache.Read({10, 4}));
   ASSERT_EQ(4, buf->size());
 
-  // A wide window that contains the whole coalesced entry evicts it.
-  ASSERT_OK_AND_ASSIGN(evicted, cache.EvictEntriesInRange(0, 20));
-  ASSERT_EQ(1, evicted);
+  // end_offset at/after the entry's end (14) frees it.
+  ASSERT_EQ(1, cache.EvictEntriesBefore(14));
   ASSERT_RAISES(Invalid, cache.Read({1, 3}));
   ASSERT_RAISES(Invalid, cache.Read({10, 4}));
 }

--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -24,8 +24,10 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+#include <algorithm>
 #include <cstdint>
 #include <functional>
+#include <limits>
 #include <set>
 #include <sstream>
 #include <type_traits>
@@ -2730,7 +2732,7 @@ TEST(TestArrowReadWrite, GetRecordBatchReaderNoColumns) {
 // should be released when the caller explicitly evicts them, otherwise
 // Dataset.to_batches accumulates memory across the lifetime of an open
 // FileReader.
-TEST(TestArrowReadWrite, EvictPreBufferedData) {
+TEST(TestArrowReadWrite, EvictPreBufferedDataBefore) {
   ArrowReaderProperties properties = default_arrow_reader_properties();
   properties.set_pre_buffer(true);
   const int num_rows = 1024;
@@ -2752,33 +2754,80 @@ TEST(TestArrowReadWrite, EvictPreBufferedData) {
   ASSERT_OK(builder.properties(properties)->Build(&reader));
   ASSERT_EQ(reader->num_row_groups(), static_cast<int>(row_groups.size()));
 
-  // Pre-buffer every row group/column so the cache is fully populated.
   reader->parquet_reader()->PreBuffer(row_groups, column_indices,
                                       ::arrow::io::IOContext(),
                                       ::arrow::io::CacheOptions::LazyDefaults());
   ASSERT_OK(reader->parquet_reader()->WhenBuffered(row_groups, column_indices).status());
 
-  // Decode the first row group; reads go through the cache.
   std::shared_ptr<Table> rg_table;
   ASSERT_OK(reader->ReadRowGroup(/*i=*/0, column_indices, &rg_table));
   ASSERT_EQ(rg_table->num_rows(), row_group_size);
 
-  // Evict only row group 0. The ranges for the other row groups are untouched,
-  // so they must still be readable.
-  reader->parquet_reader()->EvictPreBufferedData({0}, column_indices);
+  // The lowest byte offset row group 1 needs: evicting before it frees row
+  // group 0's (separately coalesced) entries while leaving row group 1 intact.
+  ASSERT_OK_AND_ASSIGN(auto rg1_ranges,
+                       reader->parquet_reader()->GetReadRanges({1}, column_indices));
+  int64_t rg1_min = std::numeric_limits<int64_t>::max();
+  for (const auto& r : rg1_ranges) rg1_min = std::min(rg1_min, r.offset);
+
+  EXPECT_GT(reader->parquet_reader()->EvictPreBufferedDataBefore(rg1_min), 0);
   ASSERT_OK(reader->ReadRowGroup(/*i=*/1, column_indices, &rg_table));
   ASSERT_EQ(rg_table->num_rows(), row_group_size);
 
-  // Evicting twice is a no-op (and must not crash).
-  reader->parquet_reader()->EvictPreBufferedData({0}, column_indices);
+  // Re-evicting the same window frees nothing more.
+  ASSERT_EQ(0, reader->parquet_reader()->EvictPreBufferedDataBefore(rg1_min));
 
-  // Calling EvictPreBufferedData on a reader that never called PreBuffer is
-  // also a no-op.
+  // A reader that never called PreBuffer is a no-op.
   std::unique_ptr<FileReader> no_prebuffer_reader;
   FileReaderBuilder no_prebuffer_builder;
   ASSERT_OK(no_prebuffer_builder.Open(std::make_shared<BufferReader>(buffer)));
   ASSERT_OK(no_prebuffer_builder.Build(&no_prebuffer_reader));
-  no_prebuffer_reader->parquet_reader()->EvictPreBufferedData(row_groups, column_indices);
+  ASSERT_EQ(0,
+            no_prebuffer_reader->parquet_reader()->EvictPreBufferedDataBefore(rg1_min));
+}
+
+// GH-39808: with coalescing a single cache entry can span adjacent row groups.
+// Offset-based eviction frees such an entry once end_offset passes its end.
+TEST(TestArrowReadWrite, EvictPreBufferedDataBeforeReleasesCrossRowGroupEntry) {
+  ArrowReaderProperties properties = default_arrow_reader_properties();
+  properties.set_pre_buffer(true);
+  const int num_rows = 1024;
+  const int row_group_size = 256;  // 4 row groups
+  const int num_columns = 2;
+  const std::vector<int> row_groups = {0, 1, 2, 3};
+  const std::vector<int> column_indices = {0, 1};
+
+  std::shared_ptr<Table> table;
+  ASSERT_NO_FATAL_FAILURE(MakeDoubleTable(num_columns, num_rows, 1, &table));
+
+  std::shared_ptr<Buffer> buffer;
+  ASSERT_NO_FATAL_FAILURE(WriteTableToBuffer(table, row_group_size,
+                                             default_arrow_writer_properties(), &buffer));
+
+  std::unique_ptr<FileReader> reader;
+  FileReaderBuilder builder;
+  ASSERT_OK(builder.Open(std::make_shared<BufferReader>(buffer)));
+  ASSERT_OK(builder.properties(properties)->Build(&reader));
+
+  // Huge limits coalesce every column chunk of every row group into ONE entry
+  // spanning all row-group boundaries.
+  ::arrow::io::CacheOptions options = ::arrow::io::CacheOptions::LazyDefaults();
+  options.hole_size_limit = static_cast<int64_t>(buffer->size());
+  options.range_size_limit = static_cast<int64_t>(buffer->size());
+  reader->parquet_reader()->PreBuffer(row_groups, column_indices,
+                                      ::arrow::io::IOContext(), options);
+  ASSERT_OK(reader->parquet_reader()->WhenBuffered(row_groups, column_indices).status());
+
+  // Any offset short of the spanning entry's end frees nothing.
+  ASSERT_OK_AND_ASSIGN(auto rg3_ranges,
+                       reader->parquet_reader()->GetReadRanges({3}, column_indices));
+  int64_t rg3_min = std::numeric_limits<int64_t>::max();
+  for (const auto& r : rg3_ranges) rg3_min = std::min(rg3_min, r.offset);
+  ASSERT_EQ(0, reader->parquet_reader()->EvictPreBufferedDataBefore(rg3_min));
+
+  // An offset past the whole file frees the spanning entry.
+  ASSERT_EQ(1, reader->parquet_reader()->EvictPreBufferedDataBefore(
+                   static_cast<int64_t>(buffer->size())));
 }
 
 // GH-39808: when Dataset.to_batches-style iteration drives the async
@@ -2832,142 +2881,6 @@ TEST(TestArrowReadWrite, GetRecordBatchGeneratorReleasesPreBufferedRowGroups) {
   ASSERT_OK_AND_ASSIGN(auto actual,
                        ::arrow::Table::FromRecordBatches(batches[0]->schema(), batches));
   AssertTablesEqual(*table, *actual, /*same_chunk_layout=*/false);
-}
-
-// GH-39808: with default coalescing a single cache entry can span adjacent row
-// groups. Per-row-group eviction must still release such an entry, but only
-// once every row group it covers has been evicted.
-TEST(TestArrowReadWrite, EvictPreBufferedDataReleasesCrossRowGroupEntry) {
-  ArrowReaderProperties properties = default_arrow_reader_properties();
-  properties.set_pre_buffer(true);
-  const int num_rows = 1024;
-  const int row_group_size = 256;  // 4 row groups
-  const int num_columns = 2;
-  const std::vector<int> row_groups = {0, 1, 2, 3};
-  const std::vector<int> column_indices = {0, 1};
-
-  std::shared_ptr<Table> table;
-  ASSERT_NO_FATAL_FAILURE(MakeDoubleTable(num_columns, num_rows, 1, &table));
-
-  std::shared_ptr<Buffer> buffer;
-  ASSERT_NO_FATAL_FAILURE(WriteTableToBuffer(table, row_group_size,
-                                             default_arrow_writer_properties(), &buffer));
-
-  std::unique_ptr<FileReader> reader;
-  FileReaderBuilder builder;
-  ASSERT_OK(builder.Open(std::make_shared<BufferReader>(buffer)));
-  ASSERT_OK(builder.properties(properties)->Build(&reader));
-  ASSERT_EQ(reader->num_row_groups(), static_cast<int>(row_groups.size()));
-
-  // Force every column chunk of every row group to coalesce into a single
-  // cache entry that spans all row-group boundaries.
-  ::arrow::io::CacheOptions options = ::arrow::io::CacheOptions::LazyDefaults();
-  options.hole_size_limit = static_cast<int64_t>(buffer->size());
-  options.range_size_limit = static_cast<int64_t>(buffer->size());
-  reader->parquet_reader()->PreBuffer(row_groups, column_indices,
-                                      ::arrow::io::IOContext(), options);
-  ASSERT_OK(reader->parquet_reader()->WhenBuffered(row_groups, column_indices).status());
-
-  // Evicting any strict subset of the row groups leaves the spanning entry in
-  // place: it is not fully contained in any run that omits a row group it
-  // still covers, so each of these calls evicts nothing.
-  ASSERT_EQ(0, reader->parquet_reader()->EvictPreBufferedData({0}, column_indices));
-  ASSERT_EQ(0, reader->parquet_reader()->EvictPreBufferedData({1}, column_indices));
-  ASSERT_EQ(0, reader->parquet_reader()->EvictPreBufferedData({2}, column_indices));
-
-  // Once the final row group completes the contiguous run [0, 3], the spanning
-  // entry is fully contained and is freed.
-  ASSERT_EQ(1, reader->parquet_reader()->EvictPreBufferedData({3}, column_indices));
-
-  // Idempotent: re-evicting frees nothing more.
-  ASSERT_EQ(0, reader->parquet_reader()->EvictPreBufferedData({3}, column_indices));
-}
-
-// GH-39808: eviction order is non-deterministic under readahead (row groups
-// decode concurrently). The spanning entry must be freed exactly once the gap
-// between evicted runs is filled, regardless of order.
-TEST(TestArrowReadWrite, EvictPreBufferedDataReleasesCrossRowGroupEntryOutOfOrder) {
-  ArrowReaderProperties properties = default_arrow_reader_properties();
-  properties.set_pre_buffer(true);
-  const int num_rows = 1024;
-  const int row_group_size = 256;  // 4 row groups
-  const int num_columns = 2;
-  const std::vector<int> row_groups = {0, 1, 2, 3};
-  const std::vector<int> column_indices = {0, 1};
-
-  std::shared_ptr<Table> table;
-  ASSERT_NO_FATAL_FAILURE(MakeDoubleTable(num_columns, num_rows, 1, &table));
-
-  std::shared_ptr<Buffer> buffer;
-  ASSERT_NO_FATAL_FAILURE(WriteTableToBuffer(table, row_group_size,
-                                             default_arrow_writer_properties(), &buffer));
-
-  std::unique_ptr<FileReader> reader;
-  FileReaderBuilder builder;
-  ASSERT_OK(builder.Open(std::make_shared<BufferReader>(buffer)));
-  ASSERT_OK(builder.properties(properties)->Build(&reader));
-
-  ::arrow::io::CacheOptions options = ::arrow::io::CacheOptions::LazyDefaults();
-  options.hole_size_limit = static_cast<int64_t>(buffer->size());
-  options.range_size_limit = static_cast<int64_t>(buffer->size());
-  reader->parquet_reader()->PreBuffer(row_groups, column_indices,
-                                      ::arrow::io::IOContext(), options);
-  ASSERT_OK(reader->parquet_reader()->WhenBuffered(row_groups, column_indices).status());
-
-  // Evict 2, then 0, then 3: runs {2,3} and {0} exist but neither covers the
-  // whole entry, so nothing is freed.
-  ASSERT_EQ(0, reader->parquet_reader()->EvictPreBufferedData({2}, column_indices));
-  ASSERT_EQ(0, reader->parquet_reader()->EvictPreBufferedData({0}, column_indices));
-  ASSERT_EQ(0, reader->parquet_reader()->EvictPreBufferedData({3}, column_indices));
-
-  // Evicting 1 fills the gap, merging {0} and {2,3} into {0,1,2,3}; the entry
-  // is now fully contained and freed.
-  ASSERT_EQ(1, reader->parquet_reader()->EvictPreBufferedData({1}, column_indices));
-}
-
-// GH-39808: a filtered scan pre-buffers a non-contiguous subset of row groups.
-// I/O coalescing can still merge column chunks of two buffered row groups into
-// one entry that bridges the un-buffered (filtered-out) gap between them. Such
-// an entry must be freed once both buffered row groups are evicted, even though
-// they are not index-adjacent.
-TEST(TestArrowReadWrite, EvictPreBufferedDataReleasesEntrySpanningFilteredRowGroups) {
-  ArrowReaderProperties properties = default_arrow_reader_properties();
-  properties.set_pre_buffer(true);
-  const int num_rows = 1024;
-  const int row_group_size = 256;  // 4 row groups
-  const int num_columns = 2;
-  const std::vector<int> buffered_row_groups = {0, 2};  // 1 and 3 filtered out
-  const std::vector<int> column_indices = {0, 1};
-
-  std::shared_ptr<Table> table;
-  ASSERT_NO_FATAL_FAILURE(MakeDoubleTable(num_columns, num_rows, 1, &table));
-
-  std::shared_ptr<Buffer> buffer;
-  ASSERT_NO_FATAL_FAILURE(WriteTableToBuffer(table, row_group_size,
-                                             default_arrow_writer_properties(), &buffer));
-
-  std::unique_ptr<FileReader> reader;
-  FileReaderBuilder builder;
-  ASSERT_OK(builder.Open(std::make_shared<BufferReader>(buffer)));
-  ASSERT_OK(builder.properties(properties)->Build(&reader));
-
-  // Huge limits coalesce RG0's and RG2's column chunks into ONE entry that
-  // bridges the un-buffered RG1 gap.
-  ::arrow::io::CacheOptions options = ::arrow::io::CacheOptions::LazyDefaults();
-  options.hole_size_limit = static_cast<int64_t>(buffer->size());
-  options.range_size_limit = static_cast<int64_t>(buffer->size());
-  reader->parquet_reader()->PreBuffer(buffered_row_groups, column_indices,
-                                      ::arrow::io::IOContext(), options);
-  ASSERT_OK(reader->parquet_reader()
-                ->WhenBuffered(buffered_row_groups, column_indices)
-                .status());
-
-  // Evicting only RG0 leaves the entry in place (RG2 still needs it).
-  ASSERT_EQ(0, reader->parquet_reader()->EvictPreBufferedData({0}, column_indices));
-
-  // Evicting RG2 completes the buffered run {0, 2} and frees the spanning
-  // entry, even though the un-buffered RG1 lies between them by index.
-  ASSERT_EQ(1, reader->parquet_reader()->EvictPreBufferedData({2}, column_indices));
 }
 
 TEST(TestArrowReadWrite, GetRecordBatchGenerator) {

--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -2925,6 +2925,51 @@ TEST(TestArrowReadWrite, EvictPreBufferedDataReleasesCrossRowGroupEntryOutOfOrde
   ASSERT_EQ(1, reader->parquet_reader()->EvictPreBufferedData({1}, column_indices));
 }
 
+// GH-39808: a filtered scan pre-buffers a non-contiguous subset of row groups.
+// I/O coalescing can still merge column chunks of two buffered row groups into
+// one entry that bridges the un-buffered (filtered-out) gap between them. Such
+// an entry must be freed once both buffered row groups are evicted, even though
+// they are not index-adjacent.
+TEST(TestArrowReadWrite, EvictPreBufferedDataReleasesEntrySpanningFilteredRowGroups) {
+  ArrowReaderProperties properties = default_arrow_reader_properties();
+  properties.set_pre_buffer(true);
+  const int num_rows = 1024;
+  const int row_group_size = 256;  // 4 row groups
+  const int num_columns = 2;
+  const std::vector<int> buffered_row_groups = {0, 2};  // 1 and 3 filtered out
+  const std::vector<int> column_indices = {0, 1};
+
+  std::shared_ptr<Table> table;
+  ASSERT_NO_FATAL_FAILURE(MakeDoubleTable(num_columns, num_rows, 1, &table));
+
+  std::shared_ptr<Buffer> buffer;
+  ASSERT_NO_FATAL_FAILURE(WriteTableToBuffer(table, row_group_size,
+                                             default_arrow_writer_properties(), &buffer));
+
+  std::unique_ptr<FileReader> reader;
+  FileReaderBuilder builder;
+  ASSERT_OK(builder.Open(std::make_shared<BufferReader>(buffer)));
+  ASSERT_OK(builder.properties(properties)->Build(&reader));
+
+  // Huge limits coalesce RG0's and RG2's column chunks into ONE entry that
+  // bridges the un-buffered RG1 gap.
+  ::arrow::io::CacheOptions options = ::arrow::io::CacheOptions::LazyDefaults();
+  options.hole_size_limit = static_cast<int64_t>(buffer->size());
+  options.range_size_limit = static_cast<int64_t>(buffer->size());
+  reader->parquet_reader()->PreBuffer(buffered_row_groups, column_indices,
+                                      ::arrow::io::IOContext(), options);
+  ASSERT_OK(reader->parquet_reader()
+                ->WhenBuffered(buffered_row_groups, column_indices)
+                .status());
+
+  // Evicting only RG0 leaves the entry in place (RG2 still needs it).
+  ASSERT_EQ(0, reader->parquet_reader()->EvictPreBufferedData({0}, column_indices));
+
+  // Evicting RG2 completes the buffered run {0, 2} and frees the spanning
+  // entry, even though the un-buffered RG1 lies between them by index.
+  ASSERT_EQ(1, reader->parquet_reader()->EvictPreBufferedData({2}, column_indices));
+}
+
 TEST(TestArrowReadWrite, GetRecordBatchGenerator) {
   ArrowReaderProperties properties = default_arrow_reader_properties();
   const int num_rows = 1024;

--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -28,7 +28,6 @@
 #include <cstdint>
 #include <functional>
 #include <limits>
-#include <optional>
 #include <set>
 #include <sstream>
 #include <type_traits>
@@ -2769,27 +2768,29 @@ TEST(TestArrowReadWrite, EvictPreBufferedDataBefore) {
   int64_t rg1_min = std::numeric_limits<int64_t>::max();
   for (const auto& r : rg1_ranges) rg1_min = std::min(rg1_min, r.offset);
 
-  EXPECT_GT(reader->parquet_reader()->EvictPreBufferedDataBefore(rg1_min), 0);
+  reader->parquet_reader()->EvictPreBufferedDataBefore(rg1_min);
+  ASSERT_RAISES(Invalid,
+                reader->parquet_reader()->WhenBuffered({0}, column_indices).status());
   ASSERT_OK(reader->ReadRowGroup(/*i=*/1, column_indices, &rg_table));
   ASSERT_EQ(rg_table->num_rows(), row_group_size);
 
-  EXPECT_GT(reader->parquet_reader()->EvictPreBufferedDataBefore(
-                std::numeric_limits<int64_t>::max()),
-            0);
+  reader->parquet_reader()->EvictPreBufferedDataBefore(
+      std::numeric_limits<int64_t>::max());
+  ASSERT_RAISES(Invalid,
+                reader->parquet_reader()->WhenBuffered({1}, column_indices).status());
   std::shared_ptr<ChunkedArray> reread_column;
   ASSERT_OK(reader->RowGroup(1)->Column(0)->Read(&reread_column));
   ASSERT_EQ(reread_column->length(), row_group_size);
 
   // Re-evicting the same window frees nothing more.
-  ASSERT_EQ(0, reader->parquet_reader()->EvictPreBufferedDataBefore(rg1_min));
+  reader->parquet_reader()->EvictPreBufferedDataBefore(rg1_min);
 
   // A reader that never called PreBuffer is a no-op.
   std::unique_ptr<FileReader> no_prebuffer_reader;
   FileReaderBuilder no_prebuffer_builder;
   ASSERT_OK(no_prebuffer_builder.Open(std::make_shared<BufferReader>(buffer)));
   ASSERT_OK(no_prebuffer_builder.Build(&no_prebuffer_reader));
-  ASSERT_EQ(0,
-            no_prebuffer_reader->parquet_reader()->EvictPreBufferedDataBefore(rg1_min));
+  no_prebuffer_reader->parquet_reader()->EvictPreBufferedDataBefore(rg1_min);
 }
 
 // GH-39808: with coalescing a single cache entry can span adjacent row groups.
@@ -2829,11 +2830,15 @@ TEST(TestArrowReadWrite, EvictPreBufferedDataBeforeReleasesCrossRowGroupEntry) {
                        reader->parquet_reader()->GetReadRanges({3}, column_indices));
   int64_t rg3_min = std::numeric_limits<int64_t>::max();
   for (const auto& r : rg3_ranges) rg3_min = std::min(rg3_min, r.offset);
-  ASSERT_EQ(0, reader->parquet_reader()->EvictPreBufferedDataBefore(rg3_min));
+  reader->parquet_reader()->EvictPreBufferedDataBefore(rg3_min);
+  ASSERT_OK(reader->parquet_reader()->WhenBuffered(row_groups, column_indices).status());
 
   // An offset past the whole file frees the spanning entry.
-  ASSERT_EQ(1, reader->parquet_reader()->EvictPreBufferedDataBefore(
-                   static_cast<int64_t>(buffer->size())));
+  reader->parquet_reader()->EvictPreBufferedDataBefore(
+      static_cast<int64_t>(buffer->size()));
+  ASSERT_RAISES(
+      Invalid,
+      reader->parquet_reader()->WhenBuffered(row_groups, column_indices).status());
 }
 
 // GH-39808: when Dataset.to_batches-style iteration drives the async
@@ -2859,6 +2864,30 @@ TEST(TestArrowReadWrite, GetRecordBatchGeneratorReleasesPreBufferedRowGroups) {
   ASSERT_NO_FATAL_FAILURE(WriteTableToBuffer(table, row_group_size,
                                              default_arrow_writer_properties(), &buffer));
 
+  // General FileReaders retain their cache because callers may create another
+  // generator for the same row group.
+  ASSERT_FALSE(properties.auto_evict_read_cache());
+  std::shared_ptr<FileReader> retaining_reader;
+  {
+    std::unique_ptr<FileReader> unique_reader;
+    FileReaderBuilder builder;
+    ASSERT_OK(builder.Open(std::make_shared<BufferReader>(buffer)));
+    ASSERT_OK(builder.properties(properties)->Build(&unique_reader));
+    retaining_reader = std::move(unique_reader);
+  }
+  ASSERT_OK_AND_ASSIGN(
+      auto retaining_generator,
+      retaining_reader->GetRecordBatchGenerator(retaining_reader, {0}, {0}));
+  auto retained_fut = retaining_generator();
+  ASSERT_OK_AND_ASSIGN(auto retained_batch, retained_fut.result());
+  ASSERT_NE(retained_batch, nullptr);
+  auto retained_end_fut = retaining_generator();
+  ASSERT_OK_AND_ASSIGN(auto retained_end, retained_end_fut.result());
+  ASSERT_EQ(retained_end, nullptr);
+  ASSERT_OK(retaining_reader->parquet_reader()->WhenBuffered({0}, {0}).status());
+
+  properties.set_auto_evict_read_cache(true);
+
   std::shared_ptr<FileReader> reader;
   {
     std::unique_ptr<FileReader> unique_reader;
@@ -2870,8 +2899,11 @@ TEST(TestArrowReadWrite, GetRecordBatchGeneratorReleasesPreBufferedRowGroups) {
   ASSERT_EQ(reader->num_row_groups(), num_rows / row_group_size);
 
   // Drive the generator exactly as ScanBatchesAsync does.
-  ASSERT_OK_AND_ASSIGN(auto batch_generator,
-                       reader->GetRecordBatchGenerator(reader, {0, 1, 2, 3}, {0, 1}));
+  ASSERT_OK_AND_ASSIGN(
+      auto batch_generator,
+      reader->GetRecordBatchGenerator(reader, {0, 1, 2, 3}, {0, 1},
+                                      /*cpu_executor=*/nullptr,
+                                      /*rows_to_readahead=*/2 * row_group_size));
   std::vector<std::shared_ptr<::arrow::RecordBatch>> batches;
   for (int i = 0; i < reader->num_row_groups(); ++i) {
     auto fut = batch_generator();
@@ -2887,23 +2919,8 @@ TEST(TestArrowReadWrite, GetRecordBatchGeneratorReleasesPreBufferedRowGroups) {
   ASSERT_OK_AND_ASSIGN(auto actual,
                        ::arrow::Table::FromRecordBatches(batches[0]->schema(), batches));
   AssertTablesEqual(*table, *actual, /*same_chunk_layout=*/false);
-}
-
-// Readahead completes row groups out of order, so the watermark advance must
-// only evict once the contiguous prefix of completed row groups grows. This
-// drives that logic directly, without a reader, for determinism.
-TEST(TestArrowReadWrite, ReadCacheEvictionStateOutOfOrder) {
-  constexpr int64_t kNoMoreRanges = std::numeric_limits<int64_t>::max();
-  ReadCacheEvictionState state({100, 200, 300, kNoMoreRanges});
-
-  // Index 1 completes first: prefix stays at 0 (index 0 not done), no eviction.
-  EXPECT_EQ(state.MarkDecodedAndGetEvictOffset(1), std::nullopt);
-  // Index 0 completes: prefix jumps 0 -> 2, evict before row group 2's offset.
-  EXPECT_EQ(state.MarkDecodedAndGetEvictOffset(0), std::optional<int64_t>(300));
-  // Index 2 completes: prefix jumps 2 -> 3, everything is evictable.
-  EXPECT_EQ(state.MarkDecodedAndGetEvictOffset(2), std::optional<int64_t>(kNoMoreRanges));
-  // Re-decoding an already-completed index is idempotent: no eviction.
-  EXPECT_EQ(state.MarkDecodedAndGetEvictOffset(0), std::nullopt);
+  ASSERT_RAISES(Invalid,
+                reader->parquet_reader()->WhenBuffered({0, 1, 2, 3}, {0, 1}).status());
 }
 
 TEST(TestArrowReadWrite, GetRecordBatchGenerator) {

--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -2756,8 +2756,7 @@ TEST(TestArrowReadWrite, EvictPreBufferedData) {
   reader->parquet_reader()->PreBuffer(row_groups, column_indices,
                                       ::arrow::io::IOContext(),
                                       ::arrow::io::CacheOptions::LazyDefaults());
-  ASSERT_OK(
-      reader->parquet_reader()->WhenBuffered(row_groups, column_indices).status());
+  ASSERT_OK(reader->parquet_reader()->WhenBuffered(row_groups, column_indices).status());
 
   // Decode the first row group; reads go through the cache.
   std::shared_ptr<Table> rg_table;
@@ -2779,8 +2778,7 @@ TEST(TestArrowReadWrite, EvictPreBufferedData) {
   FileReaderBuilder no_prebuffer_builder;
   ASSERT_OK(no_prebuffer_builder.Open(std::make_shared<BufferReader>(buffer)));
   ASSERT_OK(no_prebuffer_builder.Build(&no_prebuffer_reader));
-  no_prebuffer_reader->parquet_reader()->EvictPreBufferedData(row_groups,
-                                                              column_indices);
+  no_prebuffer_reader->parquet_reader()->EvictPreBufferedData(row_groups, column_indices);
 }
 
 // GH-39808: when Dataset.to_batches-style iteration drives the async
@@ -2831,8 +2829,8 @@ TEST(TestArrowReadWrite, GetRecordBatchGeneratorReleasesPreBufferedRowGroups) {
   ASSERT_OK_AND_ASSIGN(auto end_batch, fut_end.result());
   ASSERT_EQ(end_batch, nullptr);
 
-  ASSERT_OK_AND_ASSIGN(
-      auto actual, ::arrow::Table::FromRecordBatches(batches[0]->schema(), batches));
+  ASSERT_OK_AND_ASSIGN(auto actual,
+                       ::arrow::Table::FromRecordBatches(batches[0]->schema(), batches));
   AssertTablesEqual(*table, *actual, /*same_chunk_layout=*/false);
 }
 

--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -2773,6 +2773,13 @@ TEST(TestArrowReadWrite, EvictPreBufferedDataBefore) {
   ASSERT_OK(reader->ReadRowGroup(/*i=*/1, column_indices, &rg_table));
   ASSERT_EQ(rg_table->num_rows(), row_group_size);
 
+  EXPECT_GT(reader->parquet_reader()->EvictPreBufferedDataBefore(
+                std::numeric_limits<int64_t>::max()),
+            0);
+  std::shared_ptr<ChunkedArray> reread_column;
+  ASSERT_OK(reader->RowGroup(1)->Column(0)->Read(&reread_column));
+  ASSERT_EQ(reread_column->length(), row_group_size);
+
   // Re-evicting the same window frees nothing more.
   ASSERT_EQ(0, reader->parquet_reader()->EvictPreBufferedDataBefore(rg1_min));
 

--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -2729,10 +2729,8 @@ TEST(TestArrowReadWrite, GetRecordBatchReaderNoColumns) {
   ASSERT_EQ(actual_batch->num_rows(), num_rows);
 }
 
-// GH-39808: bytes cached by PreBuffer() for an already-decoded row group
-// should be released when the caller explicitly evicts them, otherwise
-// Dataset.to_batches accumulates memory across the lifetime of an open
-// FileReader.
+// GH-39808: bytes cached by PreBuffer() for a decoded row group must be
+// releasable, else Dataset.to_batches accumulates memory over the reader's life.
 TEST(TestArrowReadWrite, EvictPreBufferedDataBefore) {
   ArrowReaderProperties properties = default_arrow_reader_properties();
   properties.set_pre_buffer(true);
@@ -2814,7 +2812,7 @@ TEST(TestArrowReadWrite, EvictPreBufferedDataBeforeReleasesCrossRowGroupEntry) {
   // spanning all row-group boundaries.
   ::arrow::io::CacheOptions options = ::arrow::io::CacheOptions::LazyDefaults();
   options.hole_size_limit = static_cast<int64_t>(buffer->size());
-  options.range_size_limit = static_cast<int64_t>(buffer->size());
+  options.range_size_limit = static_cast<int64_t>(buffer->size()) + 1;
   reader->parquet_reader()->PreBuffer(row_groups, column_indices,
                                       ::arrow::io::IOContext(), options);
   ASSERT_OK(reader->parquet_reader()->WhenBuffered(row_groups, column_indices).status());

--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -2834,6 +2834,97 @@ TEST(TestArrowReadWrite, GetRecordBatchGeneratorReleasesPreBufferedRowGroups) {
   AssertTablesEqual(*table, *actual, /*same_chunk_layout=*/false);
 }
 
+// GH-39808: with default coalescing a single cache entry can span adjacent row
+// groups. Per-row-group eviction must still release such an entry, but only
+// once every row group it covers has been evicted.
+TEST(TestArrowReadWrite, EvictPreBufferedDataReleasesCrossRowGroupEntry) {
+  ArrowReaderProperties properties = default_arrow_reader_properties();
+  properties.set_pre_buffer(true);
+  const int num_rows = 1024;
+  const int row_group_size = 256;  // 4 row groups
+  const int num_columns = 2;
+  const std::vector<int> row_groups = {0, 1, 2, 3};
+  const std::vector<int> column_indices = {0, 1};
+
+  std::shared_ptr<Table> table;
+  ASSERT_NO_FATAL_FAILURE(MakeDoubleTable(num_columns, num_rows, 1, &table));
+
+  std::shared_ptr<Buffer> buffer;
+  ASSERT_NO_FATAL_FAILURE(WriteTableToBuffer(table, row_group_size,
+                                             default_arrow_writer_properties(), &buffer));
+
+  std::unique_ptr<FileReader> reader;
+  FileReaderBuilder builder;
+  ASSERT_OK(builder.Open(std::make_shared<BufferReader>(buffer)));
+  ASSERT_OK(builder.properties(properties)->Build(&reader));
+  ASSERT_EQ(reader->num_row_groups(), static_cast<int>(row_groups.size()));
+
+  // Force every column chunk of every row group to coalesce into a single
+  // cache entry that spans all row-group boundaries.
+  ::arrow::io::CacheOptions options = ::arrow::io::CacheOptions::LazyDefaults();
+  options.hole_size_limit = static_cast<int64_t>(buffer->size());
+  options.range_size_limit = static_cast<int64_t>(buffer->size());
+  reader->parquet_reader()->PreBuffer(row_groups, column_indices,
+                                      ::arrow::io::IOContext(), options);
+  ASSERT_OK(reader->parquet_reader()->WhenBuffered(row_groups, column_indices).status());
+
+  // Evicting any strict subset of the row groups leaves the spanning entry in
+  // place: it is not fully contained in any run that omits a row group it
+  // still covers, so each of these calls evicts nothing.
+  ASSERT_EQ(0, reader->parquet_reader()->EvictPreBufferedData({0}, column_indices));
+  ASSERT_EQ(0, reader->parquet_reader()->EvictPreBufferedData({1}, column_indices));
+  ASSERT_EQ(0, reader->parquet_reader()->EvictPreBufferedData({2}, column_indices));
+
+  // Once the final row group completes the contiguous run [0, 3], the spanning
+  // entry is fully contained and is freed.
+  ASSERT_EQ(1, reader->parquet_reader()->EvictPreBufferedData({3}, column_indices));
+
+  // Idempotent: re-evicting frees nothing more.
+  ASSERT_EQ(0, reader->parquet_reader()->EvictPreBufferedData({3}, column_indices));
+}
+
+// GH-39808: eviction order is non-deterministic under readahead (row groups
+// decode concurrently). The spanning entry must be freed exactly once the gap
+// between evicted runs is filled, regardless of order.
+TEST(TestArrowReadWrite, EvictPreBufferedDataReleasesCrossRowGroupEntryOutOfOrder) {
+  ArrowReaderProperties properties = default_arrow_reader_properties();
+  properties.set_pre_buffer(true);
+  const int num_rows = 1024;
+  const int row_group_size = 256;  // 4 row groups
+  const int num_columns = 2;
+  const std::vector<int> row_groups = {0, 1, 2, 3};
+  const std::vector<int> column_indices = {0, 1};
+
+  std::shared_ptr<Table> table;
+  ASSERT_NO_FATAL_FAILURE(MakeDoubleTable(num_columns, num_rows, 1, &table));
+
+  std::shared_ptr<Buffer> buffer;
+  ASSERT_NO_FATAL_FAILURE(WriteTableToBuffer(table, row_group_size,
+                                             default_arrow_writer_properties(), &buffer));
+
+  std::unique_ptr<FileReader> reader;
+  FileReaderBuilder builder;
+  ASSERT_OK(builder.Open(std::make_shared<BufferReader>(buffer)));
+  ASSERT_OK(builder.properties(properties)->Build(&reader));
+
+  ::arrow::io::CacheOptions options = ::arrow::io::CacheOptions::LazyDefaults();
+  options.hole_size_limit = static_cast<int64_t>(buffer->size());
+  options.range_size_limit = static_cast<int64_t>(buffer->size());
+  reader->parquet_reader()->PreBuffer(row_groups, column_indices,
+                                      ::arrow::io::IOContext(), options);
+  ASSERT_OK(reader->parquet_reader()->WhenBuffered(row_groups, column_indices).status());
+
+  // Evict 2, then 0, then 3: runs {2,3} and {0} exist but neither covers the
+  // whole entry, so nothing is freed.
+  ASSERT_EQ(0, reader->parquet_reader()->EvictPreBufferedData({2}, column_indices));
+  ASSERT_EQ(0, reader->parquet_reader()->EvictPreBufferedData({0}, column_indices));
+  ASSERT_EQ(0, reader->parquet_reader()->EvictPreBufferedData({3}, column_indices));
+
+  // Evicting 1 fills the gap, merging {0} and {2,3} into {0,1,2,3}; the entry
+  // is now fully contained and freed.
+  ASSERT_EQ(1, reader->parquet_reader()->EvictPreBufferedData({1}, column_indices));
+}
+
 TEST(TestArrowReadWrite, GetRecordBatchGenerator) {
   ArrowReaderProperties properties = default_arrow_reader_properties();
   const int num_rows = 1024;

--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -2726,6 +2726,116 @@ TEST(TestArrowReadWrite, GetRecordBatchReaderNoColumns) {
   ASSERT_EQ(actual_batch->num_rows(), num_rows);
 }
 
+// GH-39808: bytes cached by PreBuffer() for an already-decoded row group
+// should be released when the caller explicitly evicts them, otherwise
+// Dataset.to_batches accumulates memory across the lifetime of an open
+// FileReader.
+TEST(TestArrowReadWrite, EvictPreBufferedData) {
+  ArrowReaderProperties properties = default_arrow_reader_properties();
+  properties.set_pre_buffer(true);
+  const int num_rows = 1024;
+  const int row_group_size = 256;
+  const int num_columns = 3;
+  const std::vector<int> row_groups = {0, 1, 2, 3};
+  const std::vector<int> column_indices = {0, 1, 2};
+
+  std::shared_ptr<Table> table;
+  ASSERT_NO_FATAL_FAILURE(MakeDoubleTable(num_columns, num_rows, 1, &table));
+
+  std::shared_ptr<Buffer> buffer;
+  ASSERT_NO_FATAL_FAILURE(WriteTableToBuffer(table, row_group_size,
+                                             default_arrow_writer_properties(), &buffer));
+
+  std::unique_ptr<FileReader> reader;
+  FileReaderBuilder builder;
+  ASSERT_OK(builder.Open(std::make_shared<BufferReader>(buffer)));
+  ASSERT_OK(builder.properties(properties)->Build(&reader));
+  ASSERT_EQ(reader->num_row_groups(), static_cast<int>(row_groups.size()));
+
+  // Pre-buffer every row group/column so the cache is fully populated.
+  reader->parquet_reader()->PreBuffer(row_groups, column_indices,
+                                      ::arrow::io::IOContext(),
+                                      ::arrow::io::CacheOptions::LazyDefaults());
+  ASSERT_OK(
+      reader->parquet_reader()->WhenBuffered(row_groups, column_indices).status());
+
+  // Decode the first row group; reads go through the cache.
+  std::shared_ptr<Table> rg_table;
+  ASSERT_OK(reader->ReadRowGroup(/*i=*/0, column_indices, &rg_table));
+  ASSERT_EQ(rg_table->num_rows(), row_group_size);
+
+  // Evict only row group 0. The ranges for the other row groups are untouched,
+  // so they must still be readable.
+  reader->parquet_reader()->EvictPreBufferedData({0}, column_indices);
+  ASSERT_OK(reader->ReadRowGroup(/*i=*/1, column_indices, &rg_table));
+  ASSERT_EQ(rg_table->num_rows(), row_group_size);
+
+  // Evicting twice is a no-op (and must not crash).
+  reader->parquet_reader()->EvictPreBufferedData({0}, column_indices);
+
+  // Calling EvictPreBufferedData on a reader that never called PreBuffer is
+  // also a no-op.
+  std::unique_ptr<FileReader> no_prebuffer_reader;
+  FileReaderBuilder no_prebuffer_builder;
+  ASSERT_OK(no_prebuffer_builder.Open(std::make_shared<BufferReader>(buffer)));
+  ASSERT_OK(no_prebuffer_builder.Build(&no_prebuffer_reader));
+  no_prebuffer_reader->parquet_reader()->EvictPreBufferedData(row_groups,
+                                                              column_indices);
+}
+
+// GH-39808: when Dataset.to_batches-style iteration drives the async
+// RecordBatchGenerator, each row group's pre-buffered bytes should be
+// released as soon as the row group has been converted into record batches,
+// so the overall memory footprint is independent of how many row groups the
+// file contains.
+TEST(TestArrowReadWrite, GetRecordBatchGeneratorReleasesPreBufferedRowGroups) {
+  ArrowReaderProperties properties = default_arrow_reader_properties();
+  properties.set_pre_buffer(true);
+  // Read one row group at a time so the test deterministically exercises the
+  // per-row-group eviction path.
+  properties.set_batch_size(256);
+
+  const int num_rows = 1024;
+  const int row_group_size = 256;
+  const int num_columns = 2;
+
+  std::shared_ptr<Table> table;
+  ASSERT_NO_FATAL_FAILURE(MakeDoubleTable(num_columns, num_rows, 1, &table));
+
+  std::shared_ptr<Buffer> buffer;
+  ASSERT_NO_FATAL_FAILURE(WriteTableToBuffer(table, row_group_size,
+                                             default_arrow_writer_properties(), &buffer));
+
+  std::shared_ptr<FileReader> reader;
+  {
+    std::unique_ptr<FileReader> unique_reader;
+    FileReaderBuilder builder;
+    ASSERT_OK(builder.Open(std::make_shared<BufferReader>(buffer)));
+    ASSERT_OK(builder.properties(properties)->Build(&unique_reader));
+    reader = std::move(unique_reader);
+  }
+  ASSERT_EQ(reader->num_row_groups(), num_rows / row_group_size);
+
+  // Drive the generator exactly as ScanBatchesAsync does.
+  ASSERT_OK_AND_ASSIGN(auto batch_generator,
+                       reader->GetRecordBatchGenerator(reader, {0, 1, 2, 3}, {0, 1}));
+  std::vector<std::shared_ptr<::arrow::RecordBatch>> batches;
+  for (int i = 0; i < reader->num_row_groups(); ++i) {
+    auto fut = batch_generator();
+    ASSERT_OK_AND_ASSIGN(auto batch, fut.result());
+    ASSERT_NE(batch, nullptr);
+    batches.push_back(std::move(batch));
+  }
+  // Generator is drained.
+  auto fut_end = batch_generator();
+  ASSERT_OK_AND_ASSIGN(auto end_batch, fut_end.result());
+  ASSERT_EQ(end_batch, nullptr);
+
+  ASSERT_OK_AND_ASSIGN(
+      auto actual, ::arrow::Table::FromRecordBatches(batches[0]->schema(), batches));
+  AssertTablesEqual(*table, *actual, /*same_chunk_layout=*/false);
+}
+
 TEST(TestArrowReadWrite, GetRecordBatchGenerator) {
   ArrowReaderProperties properties = default_arrow_reader_properties();
   const int num_rows = 1024;

--- a/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
+++ b/cpp/src/parquet/arrow/arrow_reader_writer_test.cc
@@ -28,6 +28,7 @@
 #include <cstdint>
 #include <functional>
 #include <limits>
+#include <optional>
 #include <set>
 #include <sstream>
 #include <type_traits>
@@ -2881,6 +2882,23 @@ TEST(TestArrowReadWrite, GetRecordBatchGeneratorReleasesPreBufferedRowGroups) {
   ASSERT_OK_AND_ASSIGN(auto actual,
                        ::arrow::Table::FromRecordBatches(batches[0]->schema(), batches));
   AssertTablesEqual(*table, *actual, /*same_chunk_layout=*/false);
+}
+
+// Readahead completes row groups out of order, so the watermark advance must
+// only evict once the contiguous prefix of completed row groups grows. This
+// drives that logic directly, without a reader, for determinism.
+TEST(TestArrowReadWrite, ReadCacheEvictionStateOutOfOrder) {
+  constexpr int64_t kNoMoreRanges = std::numeric_limits<int64_t>::max();
+  ReadCacheEvictionState state({100, 200, 300, kNoMoreRanges});
+
+  // Index 1 completes first: prefix stays at 0 (index 0 not done), no eviction.
+  EXPECT_EQ(state.MarkDecodedAndGetEvictOffset(1), std::nullopt);
+  // Index 0 completes: prefix jumps 0 -> 2, evict before row group 2's offset.
+  EXPECT_EQ(state.MarkDecodedAndGetEvictOffset(0), std::optional<int64_t>(300));
+  // Index 2 completes: prefix jumps 2 -> 3, everything is evictable.
+  EXPECT_EQ(state.MarkDecodedAndGetEvictOffset(2), std::optional<int64_t>(kNoMoreRanges));
+  // Re-decoding an already-completed index is idempotent: no eviction.
+  EXPECT_EQ(state.MarkDecodedAndGetEvictOffset(0), std::nullopt);
 }
 
 TEST(TestArrowReadWrite, GetRecordBatchGenerator) {

--- a/cpp/src/parquet/arrow/reader.cc
+++ b/cpp/src/parquet/arrow/reader.cc
@@ -20,7 +20,9 @@
 #include <algorithm>
 #include <cstring>
 #include <iterator>
+#include <limits>
 #include <memory>
+#include <mutex>
 #include <span>
 #include <unordered_set>
 #include <utility>
@@ -1192,6 +1194,48 @@ Result<std::unique_ptr<RecordBatchReader>> FileReaderImpl::GetRecordBatchReader(
       ::arrow::MakeFlattenIterator(std::move(batches)), std::move(batch_schema));
 }
 
+// GH-39808: releases pre-buffered cache entries as row groups are decoded.
+// RowGroupDecoded() is called (possibly out of order, from readahead
+// continuations) once a row group's batches are produced. It advances a
+// watermark over the contiguous prefix of completed row groups and evicts every
+// cache entry ending before the lowest byte any not-yet-completed row group
+// still needs. A coalesced entry spanning a row-group boundary is freed once
+// the watermark passes its end.
+class ReadCacheEvictionState {
+ public:
+  // evict_before_offsets[i] = lowest byte offset row groups i..n-1 (in
+  // generator order) still need; evict_before_offsets[n] == INT64_MAX.
+  explicit ReadCacheEvictionState(std::vector<int64_t> evict_before_offsets)
+      : evict_before_offsets_(std::move(evict_before_offsets)),
+        completed_(evict_before_offsets_.size() - 1, false) {}
+
+  void RowGroupDecoded(ParquetFileReader* reader, size_t row_group_index) {
+    int64_t evict_before = -1;
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      if (row_group_index >= completed_.size() || completed_[row_group_index]) {
+        return;
+      }
+      completed_[row_group_index] = true;
+      const size_t old_prefix = completed_prefix_;
+      while (completed_prefix_ < completed_.size() && completed_[completed_prefix_]) {
+        ++completed_prefix_;
+      }
+      if (completed_prefix_ == old_prefix) {
+        return;
+      }
+      evict_before = evict_before_offsets_[completed_prefix_];
+    }
+    reader->EvictPreBufferedDataBefore(evict_before);
+  }
+
+ private:
+  std::mutex mutex_;
+  std::vector<int64_t> evict_before_offsets_;
+  std::vector<bool> completed_;
+  size_t completed_prefix_ = 0;
+};
+
 /// Given a file reader and a list of row groups, this is a generator of record
 /// batch generators (where each sub-generator is the contents of a single row group).
 class RowGroupGenerator {
@@ -1207,12 +1251,14 @@ class RowGroupGenerator {
   explicit RowGroupGenerator(std::shared_ptr<FileReaderImpl> arrow_reader,
                              ::arrow::internal::Executor* cpu_executor,
                              std::vector<int> row_groups, std::vector<int> column_indices,
-                             int64_t min_rows_in_flight)
+                             int64_t min_rows_in_flight,
+                             std::shared_ptr<ReadCacheEvictionState> eviction_state)
       : arrow_reader_(std::move(arrow_reader)),
         cpu_executor_(cpu_executor),
         row_groups_(std::move(row_groups)),
         column_indices_(std::move(column_indices)),
         min_rows_in_flight_(min_rows_in_flight),
+        eviction_state_(std::move(eviction_state)),
         rows_in_flight_(0),
         index_(0),
         readahead_index_(0) {}
@@ -1258,10 +1304,19 @@ class RowGroupGenerator {
       auto ready = reader->parquet_reader()->WhenBuffered({row_group}, column_indices);
       if (cpu_executor_) ready = cpu_executor_->TransferAlways(ready);
       row_group_read =
-          ready.Then([cpu_executor = cpu_executor_, reader, row_group,
+          ready.Then([cpu_executor = cpu_executor_, reader, row_group, row_group_index,
+                      eviction_state = eviction_state_,
                       column_indices = std::move(
                           column_indices)]() -> ::arrow::Future<RecordBatchGenerator> {
-            return ReadOneRowGroup(cpu_executor, reader, row_group, column_indices);
+            return ReadOneRowGroup(cpu_executor, reader, row_group, column_indices)
+                .Then([reader, row_group_index, eviction_state](
+                          RecordBatchGenerator generator) -> RecordBatchGenerator {
+                  if (eviction_state) {
+                    eviction_state->RowGroupDecoded(reader->parquet_reader(),
+                                                    row_group_index);
+                  }
+                  return generator;
+                });
           });
     }
     in_flight_reads_.push({std::move(row_group_read), num_rows});
@@ -1288,19 +1343,12 @@ class RowGroupGenerator {
       const int row_group, const std::vector<int>& column_indices) {
     // Skips bound checks/pre-buffering, since we've done that already
     const int64_t batch_size = self->properties().batch_size();
-    const bool pre_buffered = self->properties().pre_buffer();
     return self->DecodeRowGroups(self, {row_group}, column_indices, cpu_executor)
-        .Then([batch_size, self, row_group, column_indices = column_indices,
-               pre_buffered](const std::shared_ptr<Table>& table)
+        .Then([batch_size](const std::shared_ptr<Table>& table)
                   -> ::arrow::Result<RecordBatchGenerator> {
           ::arrow::TableBatchReader table_reader(*table);
           table_reader.set_chunksize(batch_size);
           ARROW_ASSIGN_OR_RAISE(auto batches, table_reader.ToRecordBatches());
-          // GH-39808: release this row group's pre-buffered bytes now that it
-          // is decoded, keeping memory bounded while iterating.
-          if (pre_buffered) {
-            self->parquet_reader()->EvictPreBufferedData({row_group}, column_indices);
-          }
           return ::arrow::MakeVectorGenerator(std::move(batches));
         });
   }
@@ -1310,6 +1358,7 @@ class RowGroupGenerator {
   std::vector<int> row_groups_;
   std::vector<int> column_indices_;
   int64_t min_rows_in_flight_;
+  std::shared_ptr<ReadCacheEvictionState> eviction_state_;
   std::queue<ReadRequest> in_flight_reads_;
   int64_t rows_in_flight_;
   size_t index_;
@@ -1332,10 +1381,32 @@ FileReaderImpl::GetRecordBatchGenerator(std::shared_ptr<FileReader> reader,
                        reader_properties_.cache_options());
     END_PARQUET_CATCH_EXCEPTIONS
   }
+  // GH-39808: when pre-buffering, release each row group's cached bytes once the
+  // contiguous prefix of decoded row groups no longer needs them, keeping the
+  // memory footprint bounded while iterating. Confined to this read-once path,
+  // so PreBuffer()'s contract for other callers is unchanged.
+  std::shared_ptr<ReadCacheEvictionState> eviction_state;
+  if (reader_properties_.pre_buffer() && !column_indices.empty() &&
+      !row_group_indices.empty()) {
+    const int64_t kNoMoreRanges = std::numeric_limits<int64_t>::max();
+    std::vector<int64_t> evict_before(row_group_indices.size() + 1, kNoMoreRanges);
+    for (int64_t i = static_cast<int64_t>(row_group_indices.size()) - 1; i >= 0; --i) {
+      ARROW_ASSIGN_OR_RAISE(
+          auto ranges, reader_->GetReadRanges({row_group_indices[static_cast<size_t>(i)]},
+                                              column_indices));
+      int64_t rg_min = kNoMoreRanges;
+      for (const auto& range : ranges) {
+        rg_min = std::min(rg_min, range.offset);
+      }
+      evict_before[static_cast<size_t>(i)] =
+          std::min(evict_before[static_cast<size_t>(i + 1)], rg_min);
+    }
+    eviction_state = std::make_shared<ReadCacheEvictionState>(std::move(evict_before));
+  }
   ::arrow::AsyncGenerator<RowGroupGenerator::RecordBatchGenerator> row_group_generator =
       RowGroupGenerator(::arrow::internal::checked_pointer_cast<FileReaderImpl>(reader),
                         cpu_executor, row_group_indices, column_indices,
-                        rows_to_readahead);
+                        rows_to_readahead, std::move(eviction_state));
   ::arrow::AsyncGenerator<std::shared_ptr<::arrow::RecordBatch>> concatenated =
       ::arrow::MakeConcatenatedGenerator(std::move(row_group_generator));
   WRAP_ASYNC_GENERATOR(std::move(concatenated));

--- a/cpp/src/parquet/arrow/reader.cc
+++ b/cpp/src/parquet/arrow/reader.cc
@@ -1339,10 +1339,9 @@ FileReaderImpl::GetRecordBatchGenerator(std::shared_ptr<FileReader> reader,
                        reader_properties_.cache_options());
     END_PARQUET_CATCH_EXCEPTIONS
   }
-  // GH-39808: when pre-buffering, release each row group's cached bytes once the
-  // contiguous prefix of decoded row groups no longer needs them, keeping the
-  // memory footprint bounded while iterating. Confined to this read-once path,
-  // so PreBuffer()'s contract for other callers is unchanged.
+  // GH-39808: evict each row group's bytes as the decoded prefix advances, so
+  // memory stays bounded. Only this read-once path evicts, so PreBuffer()'s
+  // contract is unchanged for other callers.
   std::shared_ptr<ReadCacheEvictionState> eviction_state;
   if (reader_properties_.pre_buffer() && !column_indices.empty() &&
       !row_group_indices.empty()) {

--- a/cpp/src/parquet/arrow/reader.cc
+++ b/cpp/src/parquet/arrow/reader.cc
@@ -22,7 +22,6 @@
 #include <iterator>
 #include <limits>
 #include <memory>
-#include <mutex>
 #include <span>
 #include <unordered_set>
 #include <utility>
@@ -1210,13 +1209,13 @@ class RowGroupGenerator {
                              ::arrow::internal::Executor* cpu_executor,
                              std::vector<int> row_groups, std::vector<int> column_indices,
                              int64_t min_rows_in_flight,
-                             std::shared_ptr<ReadCacheEvictionState> eviction_state)
+                             std::vector<int64_t> evict_before_offsets)
       : arrow_reader_(std::move(arrow_reader)),
         cpu_executor_(cpu_executor),
         row_groups_(std::move(row_groups)),
         column_indices_(std::move(column_indices)),
         min_rows_in_flight_(min_rows_in_flight),
-        eviction_state_(std::move(eviction_state)),
+        evict_before_offsets_(std::move(evict_before_offsets)),
         rows_in_flight_(0),
         index_(0),
         readahead_index_(0) {}
@@ -1225,13 +1224,21 @@ class RowGroupGenerator {
     if (index_ >= row_groups_.size()) {
       return ::arrow::AsyncGeneratorEnd<RecordBatchGenerator>();
     }
-    index_++;
+    const size_t request_index = index_++;
     FillReadahead();
-    ReadRequest next = std::move(in_flight_reads_.front());
     DCHECK(!in_flight_reads_.empty());
+    ReadRequest next = std::move(in_flight_reads_.front());
     in_flight_reads_.pop();
     rows_in_flight_ -= next.num_rows;
-    return next.read;
+    if (evict_before_offsets_.empty()) {
+      return next.read;
+    }
+    auto reader = arrow_reader_;
+    return next.read.Then([reader, offset = evict_before_offsets_[request_index + 1]](
+                              RecordBatchGenerator generator) {
+      reader->parquet_reader()->EvictPreBufferedDataBefore(offset);
+      return generator;
+    });
   }
 
  private:
@@ -1248,8 +1255,7 @@ class RowGroupGenerator {
   }
 
   void FetchNext() {
-    size_t row_group_index = readahead_index_++;
-    int row_group = row_groups_[row_group_index];
+    int row_group = row_groups_[readahead_index_++];
     std::vector<int> column_indices = column_indices_;
     auto reader = arrow_reader_;
     int64_t num_rows =
@@ -1262,19 +1268,10 @@ class RowGroupGenerator {
       auto ready = reader->parquet_reader()->WhenBuffered({row_group}, column_indices);
       if (cpu_executor_) ready = cpu_executor_->TransferAlways(ready);
       row_group_read =
-          ready.Then([cpu_executor = cpu_executor_, reader, row_group, row_group_index,
-                      eviction_state = eviction_state_,
+          ready.Then([cpu_executor = cpu_executor_, reader, row_group,
                       column_indices = std::move(
                           column_indices)]() -> ::arrow::Future<RecordBatchGenerator> {
-            return ReadOneRowGroup(cpu_executor, reader, row_group, column_indices)
-                .Then([reader, row_group_index, eviction_state](
-                          RecordBatchGenerator generator) -> RecordBatchGenerator {
-                  if (eviction_state) {
-                    eviction_state->RowGroupDecoded(reader->parquet_reader(),
-                                                    row_group_index);
-                  }
-                  return generator;
-                });
+            return ReadOneRowGroup(cpu_executor, reader, row_group, column_indices);
           });
     }
     in_flight_reads_.push({std::move(row_group_read), num_rows});
@@ -1316,7 +1313,7 @@ class RowGroupGenerator {
   std::vector<int> row_groups_;
   std::vector<int> column_indices_;
   int64_t min_rows_in_flight_;
-  std::shared_ptr<ReadCacheEvictionState> eviction_state_;
+  std::vector<int64_t> evict_before_offsets_;
   std::queue<ReadRequest> in_flight_reads_;
   int64_t rows_in_flight_;
   size_t index_;
@@ -1339,14 +1336,11 @@ FileReaderImpl::GetRecordBatchGenerator(std::shared_ptr<FileReader> reader,
                        reader_properties_.cache_options());
     END_PARQUET_CATCH_EXCEPTIONS
   }
-  // GH-39808: evict each row group's bytes as the decoded prefix advances, so
-  // memory stays bounded. Only this read-once path evicts, so PreBuffer()'s
-  // contract is unchanged for other callers.
-  std::shared_ptr<ReadCacheEvictionState> eviction_state;
-  if (reader_properties_.pre_buffer() && !column_indices.empty() &&
-      !row_group_indices.empty()) {
+  std::vector<int64_t> evict_before_offsets;
+  if (reader_properties_.pre_buffer() && reader_properties_.auto_evict_read_cache() &&
+      !column_indices.empty() && !row_group_indices.empty()) {
     const int64_t kNoMoreRanges = std::numeric_limits<int64_t>::max();
-    std::vector<int64_t> evict_before(row_group_indices.size() + 1, kNoMoreRanges);
+    evict_before_offsets.resize(row_group_indices.size() + 1, kNoMoreRanges);
     for (int64_t i = static_cast<int64_t>(row_group_indices.size()) - 1; i >= 0; --i) {
       ARROW_ASSIGN_OR_RAISE(
           auto ranges, reader_->GetReadRanges({row_group_indices[static_cast<size_t>(i)]},
@@ -1355,15 +1349,14 @@ FileReaderImpl::GetRecordBatchGenerator(std::shared_ptr<FileReader> reader,
       for (const auto& range : ranges) {
         rg_min = std::min(rg_min, range.offset);
       }
-      evict_before[static_cast<size_t>(i)] =
-          std::min(evict_before[static_cast<size_t>(i + 1)], rg_min);
+      evict_before_offsets[static_cast<size_t>(i)] =
+          std::min(evict_before_offsets[static_cast<size_t>(i + 1)], rg_min);
     }
-    eviction_state = std::make_shared<ReadCacheEvictionState>(std::move(evict_before));
   }
   ::arrow::AsyncGenerator<RowGroupGenerator::RecordBatchGenerator> row_group_generator =
       RowGroupGenerator(::arrow::internal::checked_pointer_cast<FileReaderImpl>(reader),
                         cpu_executor, row_group_indices, column_indices,
-                        rows_to_readahead, std::move(eviction_state));
+                        rows_to_readahead, std::move(evict_before_offsets));
   ::arrow::AsyncGenerator<std::shared_ptr<::arrow::RecordBatch>> concatenated =
       ::arrow::MakeConcatenatedGenerator(std::move(row_group_generator));
   WRAP_ASYNC_GENERATOR(std::move(concatenated));

--- a/cpp/src/parquet/arrow/reader.cc
+++ b/cpp/src/parquet/arrow/reader.cc
@@ -1296,11 +1296,8 @@ class RowGroupGenerator {
           ::arrow::TableBatchReader table_reader(*table);
           table_reader.set_chunksize(batch_size);
           ARROW_ASSIGN_OR_RAISE(auto batches, table_reader.ToRecordBatches());
-          // GH-39808: once a row group has been fully decoded into Arrow
-          // arrays, the bytes cached by PreBuffer() for that row group are no
-          // longer needed. Release them so memory usage stays bounded while
-          // iterating a large dataset instead of growing until the whole file
-          // has been read.
+          // GH-39808: release this row group's pre-buffered bytes now that it
+          // is decoded, keeping memory bounded while iterating.
           if (pre_buffered) {
             self->parquet_reader()->EvictPreBufferedData({row_group}, column_indices);
           }

--- a/cpp/src/parquet/arrow/reader.cc
+++ b/cpp/src/parquet/arrow/reader.cc
@@ -1288,12 +1288,22 @@ class RowGroupGenerator {
       const int row_group, const std::vector<int>& column_indices) {
     // Skips bound checks/pre-buffering, since we've done that already
     const int64_t batch_size = self->properties().batch_size();
+    const bool pre_buffered = self->properties().pre_buffer();
     return self->DecodeRowGroups(self, {row_group}, column_indices, cpu_executor)
-        .Then([batch_size](const std::shared_ptr<Table>& table)
+        .Then([batch_size, self, row_group, column_indices = column_indices,
+               pre_buffered](const std::shared_ptr<Table>& table)
                   -> ::arrow::Result<RecordBatchGenerator> {
           ::arrow::TableBatchReader table_reader(*table);
           table_reader.set_chunksize(batch_size);
           ARROW_ASSIGN_OR_RAISE(auto batches, table_reader.ToRecordBatches());
+          // GH-39808: once a row group has been fully decoded into Arrow
+          // arrays, the bytes cached by PreBuffer() for that row group are no
+          // longer needed. Release them so memory usage stays bounded while
+          // iterating a large dataset instead of growing until the whole file
+          // has been read.
+          if (pre_buffered) {
+            self->parquet_reader()->EvictPreBufferedData({row_group}, column_indices);
+          }
           return ::arrow::MakeVectorGenerator(std::move(batches));
         });
   }

--- a/cpp/src/parquet/arrow/reader.cc
+++ b/cpp/src/parquet/arrow/reader.cc
@@ -1194,48 +1194,6 @@ Result<std::unique_ptr<RecordBatchReader>> FileReaderImpl::GetRecordBatchReader(
       ::arrow::MakeFlattenIterator(std::move(batches)), std::move(batch_schema));
 }
 
-// GH-39808: releases pre-buffered cache entries as row groups are decoded.
-// RowGroupDecoded() is called (possibly out of order, from readahead
-// continuations) once a row group's batches are produced. It advances a
-// watermark over the contiguous prefix of completed row groups and evicts every
-// cache entry ending before the lowest byte any not-yet-completed row group
-// still needs. A coalesced entry spanning a row-group boundary is freed once
-// the watermark passes its end.
-class ReadCacheEvictionState {
- public:
-  // evict_before_offsets[i] = lowest byte offset row groups i..n-1 (in
-  // generator order) still need; evict_before_offsets[n] == INT64_MAX.
-  explicit ReadCacheEvictionState(std::vector<int64_t> evict_before_offsets)
-      : evict_before_offsets_(std::move(evict_before_offsets)),
-        completed_(evict_before_offsets_.size() - 1, false) {}
-
-  void RowGroupDecoded(ParquetFileReader* reader, size_t row_group_index) {
-    int64_t evict_before = -1;
-    {
-      std::lock_guard<std::mutex> lock(mutex_);
-      if (row_group_index >= completed_.size() || completed_[row_group_index]) {
-        return;
-      }
-      completed_[row_group_index] = true;
-      const size_t old_prefix = completed_prefix_;
-      while (completed_prefix_ < completed_.size() && completed_[completed_prefix_]) {
-        ++completed_prefix_;
-      }
-      if (completed_prefix_ == old_prefix) {
-        return;
-      }
-      evict_before = evict_before_offsets_[completed_prefix_];
-    }
-    reader->EvictPreBufferedDataBefore(evict_before);
-  }
-
- private:
-  std::mutex mutex_;
-  std::vector<int64_t> evict_before_offsets_;
-  std::vector<bool> completed_;
-  size_t completed_prefix_ = 0;
-};
-
 /// Given a file reader and a list of row groups, this is a generator of record
 /// batch generators (where each sub-generator is the contents of a single row group).
 class RowGroupGenerator {

--- a/cpp/src/parquet/arrow/reader.h
+++ b/cpp/src/parquet/arrow/reader.h
@@ -224,6 +224,10 @@ class PARQUET_EXPORT FileReader {
   /// The FileReader must outlive the generator, so this requires that you pass in a
   /// shared_ptr.
   ///
+  /// If automatic read-cache eviction is enabled, this is intended for one-pass
+  /// consumption. Row groups may be supplied in any order, but file order allows
+  /// pre-buffered memory to be released progressively.
+  ///
   /// \returns error Result if either row_group_indices or column_indices contains an
   ///     invalid index
   virtual ::arrow::Result<

--- a/cpp/src/parquet/arrow/reader_internal.h
+++ b/cpp/src/parquet/arrow/reader_internal.h
@@ -138,13 +138,9 @@ Status TransferColumnData(::parquet::internal::RecordReader* reader,
 // ----------------------------------------------------------------------
 // Pre-buffer eviction
 
-// GH-39808: releases pre-buffered cache entries as row groups are decoded.
-// RowGroupDecoded() is called (possibly out of order, from readahead
-// continuations) once a row group's batches are produced. It advances a
-// watermark over the contiguous prefix of completed row groups and evicts every
-// cache entry ending before the lowest byte any not-yet-completed row group
-// still needs. A coalesced entry spanning a row-group boundary is freed once
-// the watermark passes its end.
+// GH-39808: as row groups finish decoding (possibly out of order under
+// readahead), advance a watermark over the leading run of completed ones and
+// evict cache entries ending before the lowest byte any remaining one needs.
 class ReadCacheEvictionState {
  public:
   // evict_before_offsets[i] = lowest byte offset row groups i..n-1 (in
@@ -159,11 +155,8 @@ class ReadCacheEvictionState {
     }
   }
 
-  // Marks row_group_index decoded and advances the contiguous completed prefix.
-  // Returns the offset to evict before when the prefix advanced, or std::nullopt
-  // when nothing newly became evictable (index out of range, already completed,
-  // or the prefix did not grow). Separated from RowGroupDecoded so the
-  // out-of-order watermark logic is unit-testable without a reader.
+  // Reader-free half of RowGroupDecoded (so the out-of-order advance is testable):
+  // the evict-before offset when the prefix grows, else nullopt.
   std::optional<int64_t> MarkDecodedAndGetEvictOffset(size_t row_group_index) {
     std::lock_guard<std::mutex> lock(mutex_);
     if (row_group_index >= completed_.size() || completed_[row_group_index]) {

--- a/cpp/src/parquet/arrow/reader_internal.h
+++ b/cpp/src/parquet/arrow/reader_internal.h
@@ -22,6 +22,8 @@
 #include <deque>
 #include <functional>
 #include <memory>
+#include <mutex>
+#include <optional>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -132,6 +134,60 @@ Status TransferColumnData(::parquet::internal::RecordReader* reader,
                           const std::shared_ptr<::arrow::Field>& value_field,
                           const ColumnDescriptor* descr, const ReaderContext* ctx,
                           std::shared_ptr<::arrow::ChunkedArray>* out);
+
+// ----------------------------------------------------------------------
+// Pre-buffer eviction
+
+// GH-39808: releases pre-buffered cache entries as row groups are decoded.
+// RowGroupDecoded() is called (possibly out of order, from readahead
+// continuations) once a row group's batches are produced. It advances a
+// watermark over the contiguous prefix of completed row groups and evicts every
+// cache entry ending before the lowest byte any not-yet-completed row group
+// still needs. A coalesced entry spanning a row-group boundary is freed once
+// the watermark passes its end.
+class ReadCacheEvictionState {
+ public:
+  // evict_before_offsets[i] = lowest byte offset row groups i..n-1 (in
+  // generator order) still need; evict_before_offsets[n] == INT64_MAX.
+  // Must be non-empty: it always holds the n row-group offsets plus the
+  // INT64_MAX sentinel.
+  explicit ReadCacheEvictionState(std::vector<int64_t> evict_before_offsets)
+      : evict_before_offsets_(std::move(evict_before_offsets)),
+        completed_(evict_before_offsets_.size() - 1, false) {}
+
+  void RowGroupDecoded(ParquetFileReader* reader, size_t row_group_index) {
+    if (auto evict_before = MarkDecodedAndGetEvictOffset(row_group_index)) {
+      reader->EvictPreBufferedDataBefore(*evict_before);
+    }
+  }
+
+  // Marks row_group_index decoded and advances the contiguous completed prefix.
+  // Returns the offset to evict before when the prefix advanced, or std::nullopt
+  // when nothing newly became evictable (index out of range, already completed,
+  // or the prefix did not grow). Separated from RowGroupDecoded so the
+  // out-of-order watermark logic is unit-testable without a reader.
+  std::optional<int64_t> MarkDecodedAndGetEvictOffset(size_t row_group_index) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (row_group_index >= completed_.size() || completed_[row_group_index]) {
+      return std::nullopt;
+    }
+    completed_[row_group_index] = true;
+    const size_t old_prefix = completed_prefix_;
+    while (completed_prefix_ < completed_.size() && completed_[completed_prefix_]) {
+      ++completed_prefix_;
+    }
+    if (completed_prefix_ == old_prefix) {
+      return std::nullopt;
+    }
+    return evict_before_offsets_[completed_prefix_];
+  }
+
+ private:
+  std::mutex mutex_;
+  std::vector<int64_t> evict_before_offsets_;
+  std::vector<bool> completed_;
+  size_t completed_prefix_ = 0;
+};
 
 }  // namespace arrow
 }  // namespace parquet

--- a/cpp/src/parquet/arrow/reader_internal.h
+++ b/cpp/src/parquet/arrow/reader_internal.h
@@ -149,8 +149,6 @@ class ReadCacheEvictionState {
  public:
   // evict_before_offsets[i] = lowest byte offset row groups i..n-1 (in
   // generator order) still need; evict_before_offsets[n] == INT64_MAX.
-  // Must be non-empty: it always holds the n row-group offsets plus the
-  // INT64_MAX sentinel.
   explicit ReadCacheEvictionState(std::vector<int64_t> evict_before_offsets)
       : evict_before_offsets_(std::move(evict_before_offsets)),
         completed_(evict_before_offsets_.size() - 1, false) {}

--- a/cpp/src/parquet/arrow/reader_internal.h
+++ b/cpp/src/parquet/arrow/reader_internal.h
@@ -22,8 +22,6 @@
 #include <deque>
 #include <functional>
 #include <memory>
-#include <mutex>
-#include <optional>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -134,51 +132,6 @@ Status TransferColumnData(::parquet::internal::RecordReader* reader,
                           const std::shared_ptr<::arrow::Field>& value_field,
                           const ColumnDescriptor* descr, const ReaderContext* ctx,
                           std::shared_ptr<::arrow::ChunkedArray>* out);
-
-// ----------------------------------------------------------------------
-// Pre-buffer eviction
-
-// GH-39808: as row groups finish decoding (possibly out of order under
-// readahead), advance a watermark over the leading run of completed ones and
-// evict cache entries ending before the lowest byte any remaining one needs.
-class ReadCacheEvictionState {
- public:
-  // evict_before_offsets[i] = lowest byte offset row groups i..n-1 (in
-  // generator order) still need; evict_before_offsets[n] == INT64_MAX.
-  explicit ReadCacheEvictionState(std::vector<int64_t> evict_before_offsets)
-      : evict_before_offsets_(std::move(evict_before_offsets)),
-        completed_(evict_before_offsets_.size() - 1, false) {}
-
-  void RowGroupDecoded(ParquetFileReader* reader, size_t row_group_index) {
-    if (auto evict_before = MarkDecodedAndGetEvictOffset(row_group_index)) {
-      reader->EvictPreBufferedDataBefore(*evict_before);
-    }
-  }
-
-  // Reader-free half of RowGroupDecoded (so the out-of-order advance is testable):
-  // the evict-before offset when the prefix grows, else nullopt.
-  std::optional<int64_t> MarkDecodedAndGetEvictOffset(size_t row_group_index) {
-    std::lock_guard<std::mutex> lock(mutex_);
-    if (row_group_index >= completed_.size() || completed_[row_group_index]) {
-      return std::nullopt;
-    }
-    completed_[row_group_index] = true;
-    const size_t old_prefix = completed_prefix_;
-    while (completed_prefix_ < completed_.size() && completed_[completed_prefix_]) {
-      ++completed_prefix_;
-    }
-    if (completed_prefix_ == old_prefix) {
-      return std::nullopt;
-    }
-    return evict_before_offsets_[completed_prefix_];
-  }
-
- private:
-  std::mutex mutex_;
-  std::vector<int64_t> evict_before_offsets_;
-  std::vector<bool> completed_;
-  size_t completed_prefix_ = 0;
-};
 
 }  // namespace arrow
 }  // namespace parquet

--- a/cpp/src/parquet/file_reader.cc
+++ b/cpp/src/parquet/file_reader.cc
@@ -20,12 +20,8 @@
 #include <algorithm>
 #include <cstdint>
 #include <cstring>
-#include <limits>
-#include <map>
 #include <memory>
-#include <mutex>
 #include <ostream>
-#include <set>
 #include <string>
 #include <unordered_map>
 #include <utility>

--- a/cpp/src/parquet/file_reader.cc
+++ b/cpp/src/parquet/file_reader.cc
@@ -385,14 +385,6 @@ class SerializedFile : public ParquetFileReader::Contents {
                  const ::arrow::io::CacheOptions& options) {
     cached_source_ =
         std::make_shared<::arrow::io::internal::ReadRangeCache>(source_, ctx, options);
-    {
-      // GH-39808: a fresh cache invalidates any eviction runs we were tracking
-      // (they referenced the previous cache's byte ranges). Record the buffered
-      // row groups so eviction can merge runs across filtered-out gaps.
-      std::lock_guard<std::mutex> lock(eviction_mutex_);
-      evicted_runs_.clear();
-      buffered_row_groups_ = std::set<int>(row_groups.begin(), row_groups.end());
-    }
     std::vector<::arrow::io::ReadRange> ranges;
     prebuffered_column_chunks_.clear();
     int num_cols = file_metadata_->num_columns();
@@ -445,95 +437,14 @@ class SerializedFile : public ParquetFileReader::Contents {
     return cached_source_->WaitFor(ranges);
   }
 
-  // Evict cached bytes populated by PreBuffer() for the given row groups. I/O
-  // coalescing can merge column chunks of nearby row groups into one cache
-  // entry, so an entry is freed only once every row group it covers has been
-  // evicted: we track runs of evicted row groups that are contiguous in the
-  // buffered set and evict each run's combined byte window. A filtered-out
-  // (un-buffered) row group between two buffered ones does not block a merge;
-  // a buffered but not-yet-evicted neighbor does. Returns the number of cache
-  // entries evicted.
-  //
-  // Callers must have fully decoded the row groups (no reader still holds the
-  // cached buffers). Safe to call concurrently for different row groups.
-  int64_t EvictPreBufferedData(const std::vector<int>& row_groups,
-                               const std::vector<int>& column_indices) {
-    if (!cached_source_ || column_indices.empty()) {
+  // Evict cached bytes (from PreBuffer()) that end at or before `end_offset`.
+  // Buffers already handed to a decoder stay alive through shared ownership.
+  // A no-op if PreBuffer() was not called.
+  int64_t EvictPreBufferedDataBefore(int64_t end_offset) {
+    if (!cached_source_) {
       return 0;
     }
-    int64_t total_evicted = 0;
-    std::lock_guard<std::mutex> lock(eviction_mutex_);
-    for (int row : row_groups) {
-      // Bounding box of this row group's selected column chunks.
-      int64_t start = std::numeric_limits<int64_t>::max();
-      int64_t end = std::numeric_limits<int64_t>::min();
-      for (int col : column_indices) {
-        auto range =
-            ComputeColumnChunkRange(file_metadata_.get(), source_size_, row, col);
-        start = std::min(start, range.offset);
-        end = std::max(end, range.offset + range.length);
-      }
-      if (end <= start) {
-        continue;
-      }
-
-      // Skip row groups already covered by a run (idempotent).
-      auto after = evicted_runs_.upper_bound(row);
-      if (after != evicted_runs_.begin() &&
-          row <= std::prev(after)->second.last_row_group) {
-        continue;
-      }
-
-      // Buffered row groups immediately before/after `row`. Runs are contiguous
-      // in the buffered set, so an un-buffered (filtered-out) gap is bridged
-      // while a buffered, not-yet-evicted neighbor blocks the merge.
-      bool have_pred = false;
-      bool have_succ = false;
-      int pred = 0;
-      int succ = 0;
-      auto row_it = buffered_row_groups_.find(row);
-      if (row_it != buffered_row_groups_.end()) {
-        if (row_it != buffered_row_groups_.begin()) {
-          pred = *std::prev(row_it);
-          have_pred = true;
-        }
-        auto succ_it = std::next(row_it);
-        if (succ_it != buffered_row_groups_.end()) {
-          succ = *succ_it;
-          have_succ = true;
-        }
-      }
-
-      // Merge with the run starting at the buffered successor and/or the run
-      // ending at the buffered predecessor, unioning the byte windows.
-      int first = row;
-      int last = row;
-      if (have_succ) {
-        auto right = evicted_runs_.find(succ);
-        if (right != evicted_runs_.end()) {
-          last = right->second.last_row_group;
-          end = std::max(end, right->second.end_offset);
-          evicted_runs_.erase(right);
-        }
-      }
-      if (have_pred) {
-        auto upper = evicted_runs_.lower_bound(row);
-        if (upper != evicted_runs_.begin()) {
-          auto left = std::prev(upper);
-          if (left->second.last_row_group == pred) {
-            first = left->first;
-            start = std::min(start, left->second.start_offset);
-            evicted_runs_.erase(left);
-          }
-        }
-      }
-      evicted_runs_[first] = EvictedRowGroupRun{last, start, end};
-
-      PARQUET_ASSIGN_OR_THROW(int64_t evicted,
-                              cached_source_->EvictEntriesInRange(start, end - start));
-      total_evicted += evicted;
-    }
-    return total_evicted;
+    return cached_source_->EvictEntriesBefore(end_offset);
   }
 
   // Metadata/footer parsing. Divided up to separate sync/async paths, and to use
@@ -721,22 +632,6 @@ class SerializedFile : public ParquetFileReader::Contents {
   std::shared_ptr<PageIndexReader> page_index_reader_;
   std::unique_ptr<BloomFilterReader> bloom_filter_reader_;
 
-  // GH-39808: runs of evicted row groups that are contiguous in the buffered
-  // set (so a run may span filtered-out row groups), keyed by each run's first
-  // row-group index. A coalesced cache entry is freed only once every row group
-  // in its run has been evicted. Guarded by eviction_mutex_ because row groups
-  // are decoded (and evicted) concurrently under readahead.
-  struct EvictedRowGroupRun {
-    int last_row_group;
-    int64_t start_offset;
-    int64_t end_offset;
-  };
-  std::mutex eviction_mutex_;
-  std::map<int, EvictedRowGroupRun> evicted_runs_;
-  // Row groups passed to the most recent PreBuffer(); lets eviction merge runs
-  // across filtered-out (un-buffered) row groups while still blocking on a
-  // buffered-but-undecoded neighbor. Guarded by eviction_mutex_.
-  std::set<int> buffered_row_groups_;
   // Maps row group ordinal and prebuffer status of its column chunks in the form of a
   // bitmap buffer.
   std::unordered_map<int, std::shared_ptr<Buffer>> prebuffered_column_chunks_;
@@ -1029,12 +924,11 @@ void ParquetFileReader::PreBuffer(const std::vector<int>& row_groups,
   file->PreBuffer(row_groups, column_indices, ctx, options);
 }
 
-int64_t ParquetFileReader::EvictPreBufferedData(const std::vector<int>& row_groups,
-                                                const std::vector<int>& column_indices) {
+int64_t ParquetFileReader::EvictPreBufferedDataBefore(int64_t end_offset) {
   // Access private methods here
   SerializedFile* file =
       ::arrow::internal::checked_cast<SerializedFile*>(contents_.get());
-  return file->EvictPreBufferedData(row_groups, column_indices);
+  return file->EvictPreBufferedDataBefore(end_offset);
 }
 
 Result<std::vector<::arrow::io::ReadRange>> ParquetFileReader::GetReadRanges(

--- a/cpp/src/parquet/file_reader.cc
+++ b/cpp/src/parquet/file_reader.cc
@@ -437,12 +437,14 @@ class SerializedFile : public ParquetFileReader::Contents {
   // Evict cached bytes that were populated by PreBuffer() for the given row
   // groups and column indices. Callers should only invoke this once the
   // corresponding row group data has been fully decoded and no readers are
-  // holding a reference to the cached buffers.
-  void EvictPreBufferedData(const std::vector<int>& row_groups,
-                            const std::vector<int>& column_indices) {
+  // holding a reference to the cached buffers. Returns the number of cache
+  // entries that were evicted.
+  int64_t EvictPreBufferedData(const std::vector<int>& row_groups,
+                               const std::vector<int>& column_indices) {
     if (!cached_source_) {
-      return;
+      return 0;
     }
+    int64_t total_evicted = 0;
     for (int row : row_groups) {
       if (column_indices.empty()) {
         continue;
@@ -462,10 +464,13 @@ class SerializedFile : public ParquetFileReader::Contents {
         max_end = std::max(max_end, range.offset + range.length);
       }
       if (max_end > min_start) {
-        PARQUET_THROW_NOT_OK(
-            cached_source_->EvictEntriesInRange(min_start, max_end - min_start).status());
+        PARQUET_ASSIGN_OR_THROW(
+            int64_t evicted,
+            cached_source_->EvictEntriesInRange(min_start, max_end - min_start));
+        total_evicted += evicted;
       }
     }
+    return total_evicted;
   }
 
   // Metadata/footer parsing. Divided up to separate sync/async paths, and to use
@@ -944,12 +949,12 @@ void ParquetFileReader::PreBuffer(const std::vector<int>& row_groups,
   file->PreBuffer(row_groups, column_indices, ctx, options);
 }
 
-void ParquetFileReader::EvictPreBufferedData(const std::vector<int>& row_groups,
-                                             const std::vector<int>& column_indices) {
+int64_t ParquetFileReader::EvictPreBufferedData(const std::vector<int>& row_groups,
+                                                const std::vector<int>& column_indices) {
   // Access private methods here
   SerializedFile* file =
       ::arrow::internal::checked_cast<SerializedFile*>(contents_.get());
-  file->EvictPreBufferedData(row_groups, column_indices);
+  return file->EvictPreBufferedData(row_groups, column_indices);
 }
 
 Result<std::vector<::arrow::io::ReadRange>> ParquetFileReader::GetReadRanges(

--- a/cpp/src/parquet/file_reader.cc
+++ b/cpp/src/parquet/file_reader.cc
@@ -248,11 +248,8 @@ class SerializedRowGroup : public RowGroupReader::Contents {
         ::arrow::bit_util::GetBit(prebuffered_column_chunks_bitmap_->data(), i)) {
       // PARQUET-1698: if read coalescing is enabled, read from pre-buffered
       // segments.
-      auto buffer = cached_source_->Read(col_range);
-      if (!buffer.ok() && !buffer.status().IsInvalid()) {
-        PARQUET_THROW_NOT_OK(buffer.status());
-      }
-      if (buffer.ok()) {
+      PARQUET_ASSIGN_OR_THROW(auto buffer, cached_source_->ReadIfCached(col_range));
+      if (buffer) {
         stream = std::make_shared<::arrow::io::BufferReader>(*std::move(buffer));
       }
     }
@@ -439,11 +436,10 @@ class SerializedFile : public ParquetFileReader::Contents {
     return cached_source_->WaitFor(ranges);
   }
 
-  int64_t EvictPreBufferedDataBefore(int64_t end_offset) {
-    if (!cached_source_) {
-      return 0;
+  void EvictPreBufferedDataBefore(int64_t end_offset) {
+    if (cached_source_) {
+      cached_source_->EvictEntriesBefore(end_offset);
     }
-    return cached_source_->EvictEntriesBefore(end_offset);
   }
 
   // Metadata/footer parsing. Divided up to separate sync/async paths, and to use
@@ -631,8 +627,6 @@ class SerializedFile : public ParquetFileReader::Contents {
   std::shared_ptr<PageIndexReader> page_index_reader_;
   std::unique_ptr<BloomFilterReader> bloom_filter_reader_;
 
-  // Maps row group ordinal and prebuffer status of its column chunks in the form of a
-  // bitmap buffer.
   std::unordered_map<int, std::shared_ptr<Buffer>> prebuffered_column_chunks_;
 
   // \return The true length of the metadata in bytes
@@ -923,11 +917,11 @@ void ParquetFileReader::PreBuffer(const std::vector<int>& row_groups,
   file->PreBuffer(row_groups, column_indices, ctx, options);
 }
 
-int64_t ParquetFileReader::EvictPreBufferedDataBefore(int64_t end_offset) {
+void ParquetFileReader::EvictPreBufferedDataBefore(int64_t end_offset) {
   // Access private methods here
   SerializedFile* file =
       ::arrow::internal::checked_cast<SerializedFile*>(contents_.get());
-  return file->EvictPreBufferedDataBefore(end_offset);
+  file->EvictPreBufferedDataBefore(end_offset);
 }
 
 Result<std::vector<::arrow::io::ReadRange>> ParquetFileReader::GetReadRanges(

--- a/cpp/src/parquet/file_reader.cc
+++ b/cpp/src/parquet/file_reader.cc
@@ -433,9 +433,6 @@ class SerializedFile : public ParquetFileReader::Contents {
     return cached_source_->WaitFor(ranges);
   }
 
-  // Evict cached bytes (from PreBuffer()) that end at or before `end_offset`.
-  // Buffers already handed to a decoder stay alive through shared ownership.
-  // A no-op if PreBuffer() was not called.
   int64_t EvictPreBufferedDataBefore(int64_t end_offset) {
     if (!cached_source_) {
       return 0;

--- a/cpp/src/parquet/file_reader.cc
+++ b/cpp/src/parquet/file_reader.cc
@@ -25,6 +25,7 @@
 #include <memory>
 #include <mutex>
 #include <ostream>
+#include <set>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -385,10 +386,12 @@ class SerializedFile : public ParquetFileReader::Contents {
     cached_source_ =
         std::make_shared<::arrow::io::internal::ReadRangeCache>(source_, ctx, options);
     {
-      // GH-39808: a fresh cache invalidates any eviction runs we were
-      // tracking; they referenced the previous cache's byte ranges.
+      // GH-39808: a fresh cache invalidates any eviction runs we were tracking
+      // (they referenced the previous cache's byte ranges). Record the buffered
+      // row groups so eviction can merge runs across filtered-out gaps.
       std::lock_guard<std::mutex> lock(eviction_mutex_);
       evicted_runs_.clear();
+      buffered_row_groups_ = std::set<int>(row_groups.begin(), row_groups.end());
     }
     std::vector<::arrow::io::ReadRange> ranges;
     prebuffered_column_chunks_.clear();
@@ -443,11 +446,13 @@ class SerializedFile : public ParquetFileReader::Contents {
   }
 
   // Evict cached bytes populated by PreBuffer() for the given row groups. I/O
-  // coalescing can merge column chunks of adjacent row groups into one cache
+  // coalescing can merge column chunks of nearby row groups into one cache
   // entry, so an entry is freed only once every row group it covers has been
-  // evicted: we track contiguous runs of evicted row groups (row-group index
-  // order matches byte order) and evict each run's combined byte window.
-  // Returns the number of cache entries evicted.
+  // evicted: we track runs of evicted row groups that are contiguous in the
+  // buffered set and evict each run's combined byte window. A filtered-out
+  // (un-buffered) row group between two buffered ones does not block a merge;
+  // a buffered but not-yet-evicted neighbor does. Returns the number of cache
+  // entries evicted.
   //
   // Callers must have fully decoded the row groups (no reader still holds the
   // cached buffers). Safe to call concurrently for different row groups.
@@ -479,23 +484,47 @@ class SerializedFile : public ParquetFileReader::Contents {
         continue;
       }
 
-      // Merge with the adjacent runs (one ending at row - 1, one starting at
-      // row + 1) into a single contiguous run, unioning the byte windows.
+      // Buffered row groups immediately before/after `row`. Runs are contiguous
+      // in the buffered set, so an un-buffered (filtered-out) gap is bridged
+      // while a buffered, not-yet-evicted neighbor blocks the merge.
+      bool have_pred = false;
+      bool have_succ = false;
+      int pred = 0;
+      int succ = 0;
+      auto row_it = buffered_row_groups_.find(row);
+      if (row_it != buffered_row_groups_.end()) {
+        if (row_it != buffered_row_groups_.begin()) {
+          pred = *std::prev(row_it);
+          have_pred = true;
+        }
+        auto succ_it = std::next(row_it);
+        if (succ_it != buffered_row_groups_.end()) {
+          succ = *succ_it;
+          have_succ = true;
+        }
+      }
+
+      // Merge with the run starting at the buffered successor and/or the run
+      // ending at the buffered predecessor, unioning the byte windows.
       int first = row;
       int last = row;
-      auto right = evicted_runs_.find(row + 1);
-      if (right != evicted_runs_.end()) {
-        last = right->second.last_row_group;
-        end = std::max(end, right->second.end_offset);
-        evicted_runs_.erase(right);
+      if (have_succ) {
+        auto right = evicted_runs_.find(succ);
+        if (right != evicted_runs_.end()) {
+          last = right->second.last_row_group;
+          end = std::max(end, right->second.end_offset);
+          evicted_runs_.erase(right);
+        }
       }
-      auto upper = evicted_runs_.lower_bound(row);
-      if (upper != evicted_runs_.begin()) {
-        auto left = std::prev(upper);
-        if (left->second.last_row_group == row - 1) {
-          first = left->first;
-          start = std::min(start, left->second.start_offset);
-          evicted_runs_.erase(left);
+      if (have_pred) {
+        auto upper = evicted_runs_.lower_bound(row);
+        if (upper != evicted_runs_.begin()) {
+          auto left = std::prev(upper);
+          if (left->second.last_row_group == pred) {
+            first = left->first;
+            start = std::min(start, left->second.start_offset);
+            evicted_runs_.erase(left);
+          }
         }
       }
       evicted_runs_[first] = EvictedRowGroupRun{last, start, end};
@@ -692,11 +721,11 @@ class SerializedFile : public ParquetFileReader::Contents {
   std::shared_ptr<PageIndexReader> page_index_reader_;
   std::unique_ptr<BloomFilterReader> bloom_filter_reader_;
 
-  // GH-39808: contiguous runs of row groups whose pre-buffered bytes have been
-  // evicted, keyed by each run's first row-group index. A coalesced cache entry
-  // can span adjacent row groups, so it is freed only once every row group in
-  // its run has been evicted. Guarded by eviction_mutex_ because row groups are
-  // decoded (and evicted) concurrently under readahead.
+  // GH-39808: runs of evicted row groups that are contiguous in the buffered
+  // set (so a run may span filtered-out row groups), keyed by each run's first
+  // row-group index. A coalesced cache entry is freed only once every row group
+  // in its run has been evicted. Guarded by eviction_mutex_ because row groups
+  // are decoded (and evicted) concurrently under readahead.
   struct EvictedRowGroupRun {
     int last_row_group;
     int64_t start_offset;
@@ -704,6 +733,10 @@ class SerializedFile : public ParquetFileReader::Contents {
   };
   std::mutex eviction_mutex_;
   std::map<int, EvictedRowGroupRun> evicted_runs_;
+  // Row groups passed to the most recent PreBuffer(); lets eviction merge runs
+  // across filtered-out (un-buffered) row groups while still blocking on a
+  // buffered-but-undecoded neighbor. Guarded by eviction_mutex_.
+  std::set<int> buffered_row_groups_;
   // Maps row group ordinal and prebuffer status of its column chunks in the form of a
   // bitmap buffer.
   std::unordered_map<int, std::shared_ptr<Buffer>> prebuffered_column_chunks_;

--- a/cpp/src/parquet/file_reader.cc
+++ b/cpp/src/parquet/file_reader.cc
@@ -21,7 +21,9 @@
 #include <cstdint>
 #include <cstring>
 #include <limits>
+#include <map>
 #include <memory>
+#include <mutex>
 #include <ostream>
 #include <string>
 #include <unordered_map>
@@ -382,6 +384,12 @@ class SerializedFile : public ParquetFileReader::Contents {
                  const ::arrow::io::CacheOptions& options) {
     cached_source_ =
         std::make_shared<::arrow::io::internal::ReadRangeCache>(source_, ctx, options);
+    {
+      // GH-39808: a fresh cache invalidates any eviction runs we were
+      // tracking; they referenced the previous cache's byte ranges.
+      std::lock_guard<std::mutex> lock(eviction_mutex_);
+      evicted_runs_.clear();
+    }
     std::vector<::arrow::io::ReadRange> ranges;
     prebuffered_column_chunks_.clear();
     int num_cols = file_metadata_->num_columns();
@@ -434,41 +442,69 @@ class SerializedFile : public ParquetFileReader::Contents {
     return cached_source_->WaitFor(ranges);
   }
 
-  // Evict cached bytes that were populated by PreBuffer() for the given row
-  // groups and column indices. Callers should only invoke this once the
-  // corresponding row group data has been fully decoded and no readers are
-  // holding a reference to the cached buffers. Returns the number of cache
-  // entries that were evicted.
+  // Evict cached bytes populated by PreBuffer() for the given row groups. I/O
+  // coalescing can merge column chunks of adjacent row groups into one cache
+  // entry, so an entry is freed only once every row group it covers has been
+  // evicted: we track contiguous runs of evicted row groups (row-group index
+  // order matches byte order) and evict each run's combined byte window.
+  // Returns the number of cache entries evicted.
+  //
+  // Callers must have fully decoded the row groups (no reader still holds the
+  // cached buffers). Safe to call concurrently for different row groups.
   int64_t EvictPreBufferedData(const std::vector<int>& row_groups,
                                const std::vector<int>& column_indices) {
-    if (!cached_source_) {
+    if (!cached_source_ || column_indices.empty()) {
       return 0;
     }
     int64_t total_evicted = 0;
+    std::lock_guard<std::mutex> lock(eviction_mutex_);
     for (int row : row_groups) {
-      if (column_indices.empty()) {
-        continue;
-      }
-      // Bounding box of the row group's column chunk ranges. Using the bounding
-      // box (instead of per-column ranges) allows the cache to evict coalesced
-      // entries that cover multiple columns of the same row group, while
-      // leaving alone any entry that may have merged across row groups (in
-      // which case the merged entry extends beyond this bounding box and is
-      // not fully contained).
-      int64_t min_start = std::numeric_limits<int64_t>::max();
-      int64_t max_end = std::numeric_limits<int64_t>::min();
+      // Bounding box of this row group's selected column chunks.
+      int64_t start = std::numeric_limits<int64_t>::max();
+      int64_t end = std::numeric_limits<int64_t>::min();
       for (int col : column_indices) {
         auto range =
             ComputeColumnChunkRange(file_metadata_.get(), source_size_, row, col);
-        min_start = std::min(min_start, range.offset);
-        max_end = std::max(max_end, range.offset + range.length);
+        start = std::min(start, range.offset);
+        end = std::max(end, range.offset + range.length);
       }
-      if (max_end > min_start) {
-        PARQUET_ASSIGN_OR_THROW(
-            int64_t evicted,
-            cached_source_->EvictEntriesInRange(min_start, max_end - min_start));
-        total_evicted += evicted;
+      if (end <= start) {
+        continue;
       }
+
+      // Skip row groups already covered by a run (idempotent).
+      auto after = evicted_runs_.upper_bound(row);
+      if (after != evicted_runs_.begin() &&
+          row <= std::prev(after)->second.last_row_group) {
+        continue;
+      }
+
+      // Merge with the adjacent runs (one ending at row - 1, one starting at
+      // row + 1) into a single contiguous run, unioning the byte windows.
+      int first = row;
+      int last = row;
+      auto right = evicted_runs_.find(row + 1);
+      if (right != evicted_runs_.end()) {
+        last = right->second.last_row_group;
+        end = std::max(end, right->second.end_offset);
+        evicted_runs_.erase(right);
+      }
+      auto upper = evicted_runs_.lower_bound(row);
+      if (upper != evicted_runs_.begin()) {
+        auto left = std::prev(upper);
+        if (left->second.last_row_group == row - 1) {
+          first = left->first;
+          start = std::min(start, left->second.start_offset);
+          evicted_runs_.erase(left);
+        }
+      }
+      evicted_runs_[first] = EvictedRowGroupRun{last, start, end};
+
+      // A cross-row-group coalesced entry is fully contained in the run's
+      // window only once every row group it spans has been evicted.
+      PARQUET_ASSIGN_OR_THROW(int64_t evicted,
+                              cached_source_->EvictEntriesInRange(start, end - start));
+      total_evicted += evicted;
     }
     return total_evicted;
   }
@@ -657,6 +693,19 @@ class SerializedFile : public ParquetFileReader::Contents {
   ReaderProperties properties_;
   std::shared_ptr<PageIndexReader> page_index_reader_;
   std::unique_ptr<BloomFilterReader> bloom_filter_reader_;
+
+  // GH-39808: contiguous runs of row groups whose pre-buffered bytes have been
+  // evicted, keyed by each run's first row-group index. A coalesced cache entry
+  // can span adjacent row groups, so it is freed only once every row group in
+  // its run has been evicted. Guarded by eviction_mutex_ because row groups are
+  // decoded (and evicted) concurrently under readahead.
+  struct EvictedRowGroupRun {
+    int last_row_group;
+    int64_t start_offset;
+    int64_t end_offset;
+  };
+  std::mutex eviction_mutex_;
+  std::map<int, EvictedRowGroupRun> evicted_runs_;
   // Maps row group ordinal and prebuffer status of its column chunks in the form of a
   // bitmap buffer.
   std::unordered_map<int, std::shared_ptr<Buffer>> prebuffered_column_chunks_;

--- a/cpp/src/parquet/file_reader.cc
+++ b/cpp/src/parquet/file_reader.cc
@@ -248,9 +248,15 @@ class SerializedRowGroup : public RowGroupReader::Contents {
         ::arrow::bit_util::GetBit(prebuffered_column_chunks_bitmap_->data(), i)) {
       // PARQUET-1698: if read coalescing is enabled, read from pre-buffered
       // segments.
-      PARQUET_ASSIGN_OR_THROW(auto buffer, cached_source_->Read(col_range));
-      stream = std::make_shared<::arrow::io::BufferReader>(buffer);
-    } else {
+      auto buffer = cached_source_->Read(col_range);
+      if (!buffer.ok() && !buffer.status().IsInvalid()) {
+        PARQUET_THROW_NOT_OK(buffer.status());
+      }
+      if (buffer.ok()) {
+        stream = std::make_shared<::arrow::io::BufferReader>(*std::move(buffer));
+      }
+    }
+    if (stream == nullptr) {
       stream = properties_.GetStream(source_, col_range.offset, col_range.length);
     }
 

--- a/cpp/src/parquet/file_reader.cc
+++ b/cpp/src/parquet/file_reader.cc
@@ -463,8 +463,7 @@ class SerializedFile : public ParquetFileReader::Contents {
       }
       if (max_end > min_start) {
         PARQUET_THROW_NOT_OK(
-            cached_source_->EvictEntriesInRange(min_start, max_end - min_start)
-                .status());
+            cached_source_->EvictEntriesInRange(min_start, max_end - min_start).status());
       }
     }
   }
@@ -945,8 +944,8 @@ void ParquetFileReader::PreBuffer(const std::vector<int>& row_groups,
   file->PreBuffer(row_groups, column_indices, ctx, options);
 }
 
-void ParquetFileReader::EvictPreBufferedData(
-    const std::vector<int>& row_groups, const std::vector<int>& column_indices) {
+void ParquetFileReader::EvictPreBufferedData(const std::vector<int>& row_groups,
+                                             const std::vector<int>& column_indices) {
   // Access private methods here
   SerializedFile* file =
       ::arrow::internal::checked_cast<SerializedFile*>(contents_.get());

--- a/cpp/src/parquet/file_reader.cc
+++ b/cpp/src/parquet/file_reader.cc
@@ -500,8 +500,6 @@ class SerializedFile : public ParquetFileReader::Contents {
       }
       evicted_runs_[first] = EvictedRowGroupRun{last, start, end};
 
-      // A cross-row-group coalesced entry is fully contained in the run's
-      // window only once every row group it spans has been evicted.
       PARQUET_ASSIGN_OR_THROW(int64_t evicted,
                               cached_source_->EvictEntriesInRange(start, end - start));
       total_evicted += evicted;

--- a/cpp/src/parquet/file_reader.cc
+++ b/cpp/src/parquet/file_reader.cc
@@ -20,6 +20,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <cstring>
+#include <limits>
 #include <memory>
 #include <ostream>
 #include <string>
@@ -431,6 +432,41 @@ class SerializedFile : public ParquetFileReader::Contents {
       }
     }
     return cached_source_->WaitFor(ranges);
+  }
+
+  // Evict cached bytes that were populated by PreBuffer() for the given row
+  // groups and column indices. Callers should only invoke this once the
+  // corresponding row group data has been fully decoded and no readers are
+  // holding a reference to the cached buffers.
+  void EvictPreBufferedData(const std::vector<int>& row_groups,
+                            const std::vector<int>& column_indices) {
+    if (!cached_source_) {
+      return;
+    }
+    for (int row : row_groups) {
+      if (column_indices.empty()) {
+        continue;
+      }
+      // Bounding box of the row group's column chunk ranges. Using the bounding
+      // box (instead of per-column ranges) allows the cache to evict coalesced
+      // entries that cover multiple columns of the same row group, while
+      // leaving alone any entry that may have merged across row groups (in
+      // which case the merged entry extends beyond this bounding box and is
+      // not fully contained).
+      int64_t min_start = std::numeric_limits<int64_t>::max();
+      int64_t max_end = std::numeric_limits<int64_t>::min();
+      for (int col : column_indices) {
+        auto range =
+            ComputeColumnChunkRange(file_metadata_.get(), source_size_, row, col);
+        min_start = std::min(min_start, range.offset);
+        max_end = std::max(max_end, range.offset + range.length);
+      }
+      if (max_end > min_start) {
+        PARQUET_THROW_NOT_OK(
+            cached_source_->EvictEntriesInRange(min_start, max_end - min_start)
+                .status());
+      }
+    }
   }
 
   // Metadata/footer parsing. Divided up to separate sync/async paths, and to use
@@ -907,6 +943,14 @@ void ParquetFileReader::PreBuffer(const std::vector<int>& row_groups,
   SerializedFile* file =
       ::arrow::internal::checked_cast<SerializedFile*>(contents_.get());
   file->PreBuffer(row_groups, column_indices, ctx, options);
+}
+
+void ParquetFileReader::EvictPreBufferedData(
+    const std::vector<int>& row_groups, const std::vector<int>& column_indices) {
+  // Access private methods here
+  SerializedFile* file =
+      ::arrow::internal::checked_cast<SerializedFile*>(contents_.get());
+  file->EvictPreBufferedData(row_groups, column_indices);
 }
 
 Result<std::vector<::arrow::io::ReadRange>> ParquetFileReader::GetReadRanges(

--- a/cpp/src/parquet/file_reader.h
+++ b/cpp/src/parquet/file_reader.h
@@ -201,6 +201,23 @@ class PARQUET_EXPORT ParquetFileReader {
                  const ::arrow::io::IOContext& ctx,
                  const ::arrow::io::CacheOptions& options);
 
+  /// Release bytes buffered by a previous call to PreBuffer() for the
+  /// specified row groups and column indices.
+  ///
+  /// This releases the memory held by those cached ranges, allowing the
+  /// underlying buffers to be freed as soon as no other owner retains a
+  /// reference. Callers must ensure that the targeted row groups have been
+  /// fully decoded before invoking this method; otherwise subsequent reads
+  /// of the same row groups may fail because the cached bytes are gone.
+  ///
+  /// It is safe to call this concurrently with reads of other row groups:
+  /// cache entries that were coalesced across the targeted row groups and
+  /// unrelated data are left intact.
+  ///
+  /// Calling this method when PreBuffer() has not been called is a no-op.
+  void EvictPreBufferedData(const std::vector<int>& row_groups,
+                            const std::vector<int>& column_indices);
+
   /// Retrieve the list of byte ranges that would need to be read to retrieve
   /// the data for the specified row groups and column indices.
   ///

--- a/cpp/src/parquet/file_reader.h
+++ b/cpp/src/parquet/file_reader.h
@@ -203,7 +203,8 @@ class PARQUET_EXPORT ParquetFileReader {
 
   /// \brief Release cached bytes (from PreBuffer()) ending at or before
   /// `end_offset`. Call once those row groups are decoded; later reads of evicted
-  /// ranges may fail. No-op (returns 0) if PreBuffer() was not called.
+  /// ranges fall back to the source file. No-op (returns 0) if PreBuffer() was not
+  /// called.
   int64_t EvictPreBufferedDataBefore(int64_t end_offset);
 
   /// Retrieve the list of byte ranges that would need to be read to retrieve

--- a/cpp/src/parquet/file_reader.h
+++ b/cpp/src/parquet/file_reader.h
@@ -201,13 +201,9 @@ class PARQUET_EXPORT ParquetFileReader {
                  const ::arrow::io::IOContext& ctx,
                  const ::arrow::io::CacheOptions& options);
 
-  /// \brief Release cached bytes that end at or before `end_offset`.
-  ///
-  /// Only affects data cached by PreBuffer(). Call once the row groups needing
-  /// those bytes are fully decoded; later reads of evicted ranges may fail.
-  /// Buffers already handed to readers stay valid through shared ownership. A
-  /// no-op (returns 0) if PreBuffer() was not called. Returns the number of
-  /// cache entries evicted.
+  /// \brief Release cached bytes (from PreBuffer()) ending at or before
+  /// `end_offset`. Call once those row groups are decoded; later reads of evicted
+  /// ranges may fail. No-op (returns 0) if PreBuffer() was not called.
   int64_t EvictPreBufferedDataBefore(int64_t end_offset);
 
   /// Retrieve the list of byte ranges that would need to be read to retrieve

--- a/cpp/src/parquet/file_reader.h
+++ b/cpp/src/parquet/file_reader.h
@@ -201,15 +201,14 @@ class PARQUET_EXPORT ParquetFileReader {
                  const ::arrow::io::IOContext& ctx,
                  const ::arrow::io::CacheOptions& options);
 
-  /// \brief Release cached bytes pre-buffered for the given row groups/columns.
+  /// \brief Release cached bytes that end at or before `end_offset`.
   ///
-  /// Call only after the row groups are fully decoded; reads of those row
-  /// groups afterward may fail. An entry coalesced across row groups is freed
-  /// once all the row groups it spans have been evicted. Safe to call
-  /// concurrently for different row groups; a no-op if PreBuffer() was not
-  /// called. Returns the number of cache entries evicted.
-  int64_t EvictPreBufferedData(const std::vector<int>& row_groups,
-                               const std::vector<int>& column_indices);
+  /// Only affects data cached by PreBuffer(). Call once the row groups needing
+  /// those bytes are fully decoded; later reads of evicted ranges may fail.
+  /// Buffers already handed to readers stay valid through shared ownership. A
+  /// no-op (returns 0) if PreBuffer() was not called. Returns the number of
+  /// cache entries evicted.
+  int64_t EvictPreBufferedDataBefore(int64_t end_offset);
 
   /// Retrieve the list of byte ranges that would need to be read to retrieve
   /// the data for the specified row groups and column indices.

--- a/cpp/src/parquet/file_reader.h
+++ b/cpp/src/parquet/file_reader.h
@@ -215,8 +215,8 @@ class PARQUET_EXPORT ParquetFileReader {
   /// unrelated data are left intact.
   ///
   /// Calling this method when PreBuffer() has not been called is a no-op.
-  void EvictPreBufferedData(const std::vector<int>& row_groups,
-                            const std::vector<int>& column_indices);
+  int64_t EvictPreBufferedData(const std::vector<int>& row_groups,
+                               const std::vector<int>& column_indices);
 
   /// Retrieve the list of byte ranges that would need to be read to retrieve
   /// the data for the specified row groups and column indices.

--- a/cpp/src/parquet/file_reader.h
+++ b/cpp/src/parquet/file_reader.h
@@ -201,20 +201,13 @@ class PARQUET_EXPORT ParquetFileReader {
                  const ::arrow::io::IOContext& ctx,
                  const ::arrow::io::CacheOptions& options);
 
-  /// Release bytes buffered by a previous call to PreBuffer() for the
-  /// specified row groups and column indices.
+  /// \brief Release cached bytes pre-buffered for the given row groups/columns.
   ///
-  /// This releases the memory held by those cached ranges, allowing the
-  /// underlying buffers to be freed as soon as no other owner retains a
-  /// reference. Callers must ensure that the targeted row groups have been
-  /// fully decoded before invoking this method; otherwise subsequent reads
-  /// of the same row groups may fail because the cached bytes are gone.
-  ///
-  /// It is safe to call this concurrently with reads of other row groups:
-  /// cache entries that were coalesced across the targeted row groups and
-  /// unrelated data are left intact.
-  ///
-  /// Calling this method when PreBuffer() has not been called is a no-op.
+  /// Call only after the row groups are fully decoded; reads of those row
+  /// groups afterward may fail. An entry coalesced across row groups is freed
+  /// once all the row groups it spans have been evicted. Safe to call
+  /// concurrently for different row groups; a no-op if PreBuffer() was not
+  /// called. Returns the number of cache entries evicted.
   int64_t EvictPreBufferedData(const std::vector<int>& row_groups,
                                const std::vector<int>& column_indices);
 

--- a/cpp/src/parquet/file_reader.h
+++ b/cpp/src/parquet/file_reader.h
@@ -203,9 +203,8 @@ class PARQUET_EXPORT ParquetFileReader {
 
   /// \brief Release cached bytes (from PreBuffer()) ending at or before
   /// `end_offset`. Call once those row groups are decoded; later reads of evicted
-  /// ranges fall back to the source file. No-op (returns 0) if PreBuffer() was not
-  /// called.
-  int64_t EvictPreBufferedDataBefore(int64_t end_offset);
+  /// ranges fall back to the source file. No-op if PreBuffer() was not called.
+  void EvictPreBufferedDataBefore(int64_t end_offset);
 
   /// Retrieve the list of byte ranges that would need to be read to retrieve
   /// the data for the specified row groups and column indices.

--- a/cpp/src/parquet/properties.h
+++ b/cpp/src/parquet/properties.h
@@ -1151,6 +1151,7 @@ class PARQUET_EXPORT ArrowReaderProperties {
         read_dict_indices_(),
         batch_size_(kArrowDefaultBatchSize),
         pre_buffer_(true),
+        auto_evict_read_cache_(false),
         cache_options_(::arrow::io::CacheOptions::LazyDefaults()),
         coerce_int96_timestamp_unit_(::arrow::TimeUnit::NANO),
         binary_type_(kArrowDefaultBinaryType),
@@ -1235,6 +1236,14 @@ class PARQUET_EXPORT ArrowReaderProperties {
   /// Return whether read coalescing is enabled.
   bool pre_buffer() const { return pre_buffer_; }
 
+  /// Enable eviction of pre-buffered ranges as record batch generators consume them.
+  ///
+  /// This is intended for one-pass consumers. It is safe with any row group order, but
+  /// file order allows the cache to release memory progressively. Default is false.
+  void set_auto_evict_read_cache(bool auto_evict) { auto_evict_read_cache_ = auto_evict; }
+  /// Return whether consumed pre-buffered ranges are evicted.
+  bool auto_evict_read_cache() const { return auto_evict_read_cache_; }
+
   /// Set options for read coalescing. This can be used to tune the
   /// implementation for characteristics of different filesystems.
   void set_cache_options(::arrow::io::CacheOptions options) { cache_options_ = options; }
@@ -1300,6 +1309,7 @@ class PARQUET_EXPORT ArrowReaderProperties {
   std::unordered_set<int> read_dict_indices_;
   int64_t batch_size_;
   bool pre_buffer_;
+  bool auto_evict_read_cache_;
   ::arrow::io::IOContext io_context_;
   ::arrow::io::CacheOptions cache_options_;
   ::arrow::TimeUnit::type coerce_int96_timestamp_unit_;


### PR DESCRIPTION
### Rationale for this change

`Dataset.to_batches()` accumulates memory because `ReadRangeCache`
has no eviction API. `PreBuffer()` is called with every row group up
front and entries stay resident until the `FileReader` is destroyed,
so users see ~10x more peak memory than `ParquetFile.iter_batches()`.
Issue #39808 has been open for over a year; downstream projects have
worked around it by disabling `pre_buffer` (Ray) or dropping the
dataset API (Marin), both of which give up features or throughput.

### What changes are included in this PR?

* Add `ReadRangeCache::EvictEntriesBefore(end_offset)` to release cached entries that end at or before a safe offset. Entries that cross the offset stay cached so coalesced reads remain safe.
* Add `ReadRangeCache::ReadIfCached(...)` so a cache miss is separate from a real read error. Parquet falls back to the source only on a cache miss.
* Add `ParquetFileReader::EvictPreBufferedDataBefore(...)` and `ArrowReaderProperties::auto_evict_read_cache`. Automatic eviction is off by default for reusable file readers and enabled by the Dataset Parquet reader.
* Track the earliest byte still needed by the remaining row groups and evict as each queued row-group result is delivered. Any row-group order is safe; file order releases memory sooner.
* Synchronize shared cache entries and lazy read futures across reads, prefetches, and eviction.

### Performance

Measured on a 458 MB / 10 row group / 10M row parquet file
(6 columns: 3 float64, 2 int64, 1 large_string; Snappy; macOS arm64;
Release build). Fix toggled via a one-line A/B test:

| Mode                                     | Peak `total_allocated_bytes` |
|------------------------------------------|------------------------------|
| `Dataset.to_batches`, fix disabled       | 598 MB                       |
| `Dataset.to_batches`, fix enabled        | **331 MB** (-267 MB, -44.6%) |
| `Dataset.to_batches`, `pre_buffer=False` | 151 MB                       |
| `ParquetFile.iter_batches`               | 59 MB                        |

```mermaid
xychart-beta
    title "Peak allocated memory (458 MB / 10 row groups, lower is better)"
    x-axis ["without fix", "with fix", "no prebuffer", "iter_batches"]
    y-axis "MB" 0 --> 650
    bar [598, 331, 151, 59]
```

Per-row-group progression during iteration
(`max(total_allocated_bytes)` in MB, sampled every 10k of 100k batches):

```
batches (k)        10   20   30   40   50   60   70   80   90  100
----------------  ---  ---  ---  ---  ---  ---  ---  ---  ---  ---
without fix       159  232  294  323  386  415  477  507  569  598
with fix          129  202  205  234  237  266  270  299  302  331
saved              30   30   89   89  149  149  207  208  267  267
```

```mermaid
xychart-beta
    title "max_allocated over iteration (top line: without fix; bottom: with fix)"
    x-axis "batches consumed (thousands)" 10 --> 100
    y-axis "MB" 0 --> 650
    line [159, 232, 294, 323, 386, 415, 477, 507, 569, 598]
    line [129, 202, 205, 234, 237, 266, 270, 299, 302, 331]
```

Savings scale linearly with row-group count, so on the multi-GB files
from the issue thread this single fix recovers several GB of peak.

### Related work/commits

Downstream projects have shipped workarounds while this issue has
been open, all of them in their own code rather than upstream:

* `ray-project/ray#62745` (merged 2026-04-20): injects
  `ParquetFragmentScanOptions(pre_buffer=False, use_buffered_stream=True)`
  in Ray Data's parquet reader. Gets peak alloc down to ~75 MB but
  gives up the `pre_buffer=True` coalesced-read optimization that
  makes S3 fast.
* `marin-community/marin#4344` (merged): replaces dataset-API usage
  with `ParquetFile.iter_batches`, giving up hive-partition discovery,
  filter pushdown, and dataset-level schema unification.

No open PR against `apache/arrow` addresses the cache-side
accumulation. This PR is the upstream fix that lets both workarounds
be reverted without losing features or throughput.

### Scope of this fix

This PR fixes the `ReadRangeCache` accumulation that dominates peak
memory on the default `pre_buffer=true` path.

A second source of growth, visible as the 151 MB vs 59 MB gap in the
`pre_buffer=false` row of the table above, lives in the dataset async
generator pipeline and is unrelated to the cache. It should be
tracked as a follow-up issue.

Partially closes #39808.

### Test plan

Rebuilt and ran the full affected C++ test binaries on a Release build after rebasing onto current `main`:

* `arrow-io-memory-test`: **58/58 passed**.
* `parquet-arrow-reader-writer-test`: **833 passed, 2 skipped, 0 failed** (1 disabled test was not run).
* `arrow-dataset-file-parquet-test`: **59/59 passed**.

Coverage includes cache-miss versus I/O-error behavior, prefix and straddling eviction, coalesced entries spanning row groups, direct rereads after eviction, default cache retention for general `FileReader` users, and Dataset generator eviction with readahead.

### Are there any user-facing changes?

`ParquetFileReader::EvictPreBufferedDataBefore` and `ArrowReaderProperties::auto_evict_read_cache` are new C++ APIs. General `FileReader` behavior is unchanged by default; Dataset Parquet scans enable automatic eviction internally.

**This PR contains a "Critical Fix"**: No (memory usage improvement,
not correctness).

* GitHub Issue: #39808
