### PR TITLE
MINOR: [R][CI] Fix backwards compatibility job issue for R<6

### DIFF
--- a/dev/tasks/r/github.linux.arrow.version.back.compat.yml
+++ b/dev/tasks/r/github.linux.arrow.version.back.compat.yml
@@ -107,6 +107,10 @@ jobs:
             # for 6.0.0 or later.
             rspm="https://packagemanager.rstudio.com/cran/__linux__/jammy/latest"
             echo "RSPM=${rspm}" >> $GITHUB_ENV
+          else
+            # testthat requires fs which now requires libuv1-dev. Install it
+            # when RSPM isn't available
+            sudo apt update && sudo apt install -y -V libuv1-dev
           fi
       - uses: r-lib/actions/setup-r@v2
         with:


### PR DESCRIPTION
### Rationale for this change

The R backwards compat job was failing for R versions 5 and 6 because the job couldn't install testthat.  This is due to the recent breaking change in the `fs` package related to libuv dev headers.

### What changes are included in this PR?

- Cherry-picked 5903161 (maint-24.0.0-r) to add a fallback for R<6.

### Are these changes tested?

Yes, separately in https://github.com/apache/arrow/pull/49859.

### Are there any user-facing changes?

No.