### PR TITLE
MINOR: [R][CI][Release] Update r-binary-packages artifacts pattern

### DIFF
--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -245,11 +245,12 @@ tasks:
       - r-libarrow-darwin-arm64-{no_rc_r_version}\.zip
       - r-libarrow-darwin-x86_64-{no_rc_r_version}\.zip
       - r-pkg__bin__windows__contrib__4.5__arrow_{no_rc_r_version}\.zip
-      - r-pkg__bin__windows__contrib__4.4__arrow_{no_rc_r_version}\.zip
+      - r-pkg__bin__windows__contrib__4.6__arrow_{no_rc_r_version}\.zip
       - r-pkg__bin__macosx__big-sur-x86_64__contrib__4.5__arrow_{no_rc_r_version}\.tgz
-      - r-pkg__bin__macosx__big-sur-x86_64__contrib__4.4__arrow_{no_rc_r_version}\.tgz
+      - r-pkg__bin__macosx__big-sur-x86_64__contrib__4.6__arrow_{no_rc_r_version}\.tgz
       - r-pkg__bin__macosx__big-sur-arm64__contrib__4.5__arrow_{no_rc_r_version}\.tgz
-      - r-pkg__bin__macosx__big-sur-arm64__contrib__4.4__arrow_{no_rc_r_version}\.tgz
+      # TODO: Uncomment once setup-r resolves release to 4.6
+      #  -r-pkg__bin__macosx__sonoma-arm64__contrib__4.6__arrow_{no_rc_r_version}\.tgz
       - r-pkg__src__contrib__arrow_{no_rc_r_version}\.tar\.gz
 
 {% for which in ["strong", "most"] %}


### PR DESCRIPTION
### Rationale for this change

The r-binary-packages job is failing

https://github.com/ursacomputing/crossbow/actions/runs/24952559049/job/73067211103

due to the R 4.6 release and these artifact paths now being out of date. R 4.6 isn't fully released (not out on arm64 mac yet) so we'll need a follow-up PR once it is.

### What changes are included in this PR?

- Updates the artifact paths so they match and the job runs successfully.

### Are these changes tested?

Yes, separately in https://github.com/apache/arrow/pull/49859.

### Are there any user-facing changes?

No.