### PR TITLE
MINOR: [R][Doc] Re-sync Roxygen docs and fix link to parse_value_mapping

### DIFF
--- a/r/R/dplyr-funcs-conditional.R
+++ b/r/R/dplyr-funcs-conditional.R
@@ -18,7 +18,7 @@
 #' Parse logical condition formulas
 #'
 #' Converts condition ~ value formulas into Arrow expressions. Unlike
-#' [parse_value_mapping()], the LHS must be a logical expression (not a value
+#' `parse_value_mapping()`, the LHS must be a logical expression (not a value
 #' to match against).
 #'
 #' @param formulas A list of two-sided formulas where LHS is a logical condition

--- a/r/man/Field-class.Rd
+++ b/r/man/Field-class.Rd
@@ -13,7 +13,21 @@
 
 \itemize{
 \item \code{f$ToString()}: convert to a string
-\item \code{f$Equals(other)}: test for equality. More naturally called as \code{f == other}
+\item \code{f$Equals(other, check_metadata = FALSE)}: test for equality.
+More naturally called as \code{f == other}
+\item \code{f$WithMetadata(metadata)}: returns a new \code{Field} with the key-value
+\code{metadata} set. Note that all list elements in \code{metadata} will be coerced
+to \code{character}.
+\item \code{f$RemoveMetadata()}: returns a new \code{Field} without metadata.
+}
+}
+
+\section{Active bindings}{
+
+\itemize{
+\item \verb{$HasMetadata}: logical: does this \code{Field} have extra metadata?
+\item \verb{$metadata}: returns the key-value metadata as a named list, or \code{NULL}
+if no metadata is set.
 }
 }
 

--- a/r/man/Field.Rd
+++ b/r/man/Field.Rd
@@ -4,14 +4,15 @@
 \alias{field}
 \title{Create a Field}
 \usage{
-field(name, type, metadata, nullable = TRUE)
+field(name, type, metadata = NULL, nullable = TRUE)
 }
 \arguments{
 \item{name}{field name}
 
 \item{type}{logical type, instance of \link{DataType}}
 
-\item{metadata}{currently ignored}
+\item{metadata}{a named character vector or list to attach as field metadata.
+All values will be coerced to \code{character}.}
 
 \item{nullable}{TRUE if field is nullable}
 }
@@ -20,6 +21,7 @@ Create a Field
 }
 \examples{
 field("x", int32())
+field("x", int32(), metadata = list(key = "value"))
 }
 \seealso{
 \link{Field}

--- a/r/man/acero.Rd
+++ b/r/man/acero.Rd
@@ -72,7 +72,7 @@ can assume that the function works in Acero just as it does in R.
 Functions can be called either as \code{pkg::fun()} or just \code{fun()}, i.e. both
 \code{str_sub()} and \code{stringr::str_sub()} work.
 
-In addition to these functions, you can call any of Arrow's 253 compute
+In addition to these functions, you can call any of Arrow's 281 compute
 functions directly. Arrow has many functions that don't map to an existing R
 function. In other cases where there is an R function mapping, you can still
 call the Arrow function directly if you don't want the adaptations that the R


### PR DESCRIPTION
### Rationale for this change

The checked in docs are out of sync with the result of `make doc` and, additionally, roxygen was complaining about the `parse_value_mapping` link since it's `noRd`. I saw these during the submission to CRAN and needed to fix this on main.

### What changes are included in this PR?

- De-linked parse_value_mapping
- Re-ran `make doc`

### Are these changes tested?

No.

### Are there any user-facing changes?

No.