### PR TITLE
MINOR: [R][Dev] Fix silent CMake failure in nixlibs.R with CMake>4

### DIFF
--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -925,7 +925,11 @@ cmake_find_package <- function(pkg, version = NULL, env_var_list) {
   cleanup(td)
   find_package <- paste0(
     "cmake_minimum_required(VERSION 3.10)\n",
-    "find_package(", pkg, " ", version, " REQUIRED)"
+    "find_package(",
+    pkg,
+    " ",
+    version,
+    " REQUIRED)"
   )
   writeLines(find_package, file.path(td, "CMakeLists.txt"))
   env_vars <- env_vars_as_string(env_var_list)

--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -923,7 +923,10 @@ cmake_find_package <- function(pkg, version = NULL, env_var_list) {
   td <- tempfile()
   dir.create(td)
   cleanup(td)
-  find_package <- paste0("find_package(", pkg, " ", version, " REQUIRED)")
+  find_package <- paste0(
+    "cmake_minimum_required(VERSION 3.10)\n",
+    "find_package(", pkg, " ", version, " REQUIRED)"
+  )
   writeLines(find_package, file.path(td, "CMakeLists.txt"))
   env_vars <- env_vars_as_string(env_var_list)
   cmake_cmd <- paste0(

--- a/r/tools/nixlibs.R
+++ b/r/tools/nixlibs.R
@@ -939,7 +939,7 @@ cmake_find_package <- function(pkg, version = NULL, env_var_list) {
     " -DCMAKE_FIND_PACKAGE_NO_PACKAGE_REGISTRY=ON",
     " ."
   )
-  system(cmake_cmd, ignore.stdout = TRUE, ignore.stderr = TRUE) == 0
+  system(cmake_cmd, ignore.stdout = quietly, ignore.stderr = quietly) == 0
 }
 
 ############### Main logic #############


### PR DESCRIPTION
### Rationale for this change

On my Mac, when I try to install the R package from main, I get a confusing warning that S3 support is disabled:

```
**** cmake 4.3.0: /opt/homebrew/bin/cmake
****  S3  support  requires libcurl-devel (rpm) or libcurl4-openssl-dev (deb) ; building with  ARROW_S3=OFF
```

I figured out we were getting a failure from the cmake invocation,

```
CMake Error in CMakeLists.txt:
  No cmake_minimum_required command is present.  A line of code such as

    cmake_minimum_required(VERSION 4.3)

  should be added at the top of the file.  The version specified may be lower
  if you wish to support older CMake versions for this project.  For more
  information run "cmake --help-policy CMP0000".
```

but silently ignoring it because the subprocess call hardcoded ignoring stdout/stderr.

### What changes are included in this PR?

- Fixes the issue with cmake by specifying `cmake_minimum_required`
- Makes the cmake command respect `quietly` (ARROW_R_DEV) so we don't swallow errors

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.