### PR TITLE
GH-49866: [R][Release] Restore using tzdb on Windows for tzdata

### DIFF
--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -286,9 +286,7 @@ jobs:
         run: |
           # RTools 40 uses GCC 8.x which does not support C++20 chrono timezones,
           # so Arrow uses the vendored date library which requires tzdata
-
-          # TESTING: Use this workflow to fake an env without tzdata
-          # ci/scripts/download_tz_database.sh
+          ci/scripts/download_tz_database.sh
       - run: mkdir r/windows
       - name: Download artifacts
         uses: actions/download-artifact@v8

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -286,7 +286,9 @@ jobs:
         run: |
           # RTools 40 uses GCC 8.x which does not support C++20 chrono timezones,
           # so Arrow uses the vendored date library which requires tzdata
-          ci/scripts/download_tz_database.sh
+
+          # TESTING: Use this workflow to fake an env without tzdata
+          # ci/scripts/download_tz_database.sh
       - run: mkdir r/windows
       - name: Download artifacts
         uses: actions/download-artifact@v8

--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -70,7 +70,6 @@ Suggests:
     sys,
     testthat (>= 3.3.0),
     tibble,
-    tzdb,
     withr
 LinkingTo: cpp11 (>= 0.4.2)
 Collate:

--- a/r/DESCRIPTION
+++ b/r/DESCRIPTION
@@ -70,6 +70,7 @@ Suggests:
     sys,
     testthat (>= 3.3.0),
     tibble,
+    tzdb,
     withr
 LinkingTo: cpp11 (>= 0.4.2)
 Collate:

--- a/r/R/arrow-package.R
+++ b/r/R/arrow-package.R
@@ -153,14 +153,6 @@ s3_finalizer <- new.env(parent = emptyenv())
     # Disable multithreading on Windows
     # See https://issues.apache.org/jira/browse/ARROW-8379
     options(arrow.use_threads = FALSE)
-
-    # MinGW/GCC builds (e.g. CRAN's winbuilder) use the vendored Howard Hinnant
-    # date library and need an IANA tzdata path. MSVC builds use std::chrono
-    # with the Windows system timezone database and don't need this.
-    # See https://github.com/apache/arrow/issues/48593
-    if (!identical(build_info()[[2]], "MSVC")) {
-      configure_tzdb()
-    }
   }
 
   # Set interrupt handlers
@@ -175,18 +167,6 @@ s3_finalizer <- new.env(parent = emptyenv())
   reg.finalizer(s3_finalizer, finalize_s3, onexit = TRUE)
 
   invisible()
-}
-
-configure_tzdb <- function() {
-  if (requireNamespace("tzdb", quietly = TRUE)) {
-    tzdb::tzdb_initialize()
-    set_timezone_database(tzdb::tzdb_path("text"))
-  } else {
-    packageStartupMessage(
-      "The tzdb package is not installed. ",
-      "Timezones will not be available to Arrow compute functions."
-    )
-  }
 }
 
 .onAttach <- function(libname, pkgname) {

--- a/r/R/arrow-package.R
+++ b/r/R/arrow-package.R
@@ -153,6 +153,14 @@ s3_finalizer <- new.env(parent = emptyenv())
     # Disable multithreading on Windows
     # See https://issues.apache.org/jira/browse/ARROW-8379
     options(arrow.use_threads = FALSE)
+
+    # MinGW/GCC builds (e.g. CRAN's winbuilder) use the vendored Howard Hinnant
+    # date library and need an IANA tzdata path. MSVC builds use std::chrono
+    # with the Windows system timezone database and don't need this.
+    # See https://github.com/apache/arrow/issues/48593
+    if (!identical(build_info()[[2]], "MSVC")) {
+      configure_tzdb()
+    }
   }
 
   # Set interrupt handlers
@@ -167,6 +175,18 @@ s3_finalizer <- new.env(parent = emptyenv())
   reg.finalizer(s3_finalizer, finalize_s3, onexit = TRUE)
 
   invisible()
+}
+
+configure_tzdb <- function() {
+  if (requireNamespace("tzdb", quietly = TRUE)) {
+    tzdb::tzdb_initialize()
+    set_timezone_database(tzdb::tzdb_path("text"))
+  } else {
+    packageStartupMessage(
+      "The tzdb package is not installed. ",
+      "Timezones will not be available to Arrow compute functions."
+    )
+  }
 }
 
 .onAttach <- function(libname, pkgname) {

--- a/r/R/arrow-package.R
+++ b/r/R/arrow-package.R
@@ -184,7 +184,9 @@ configure_tzdb <- function() {
   } else {
     packageStartupMessage(
       "The tzdb package is not installed. ",
-      "Timezones will not be available to Arrow compute functions."
+      "Timezones will not be available to Arrow compute functions. ",
+      "If you get errors when using Arrow on datetimes, try running ",
+      "`install.packages('tzdb')` and trying again."
     )
   }
 }

--- a/r/R/arrow-package.R
+++ b/r/R/arrow-package.R
@@ -179,8 +179,19 @@ s3_finalizer <- new.env(parent = emptyenv())
 
 configure_tzdb <- function() {
   if (requireNamespace("tzdb", quietly = TRUE)) {
-    tzdb::tzdb_initialize()
-    set_timezone_database(tzdb::tzdb_path("text"))
+    tryCatch(
+      {
+        tzdb::tzdb_initialize()
+        set_timezone_database(tzdb::tzdb_path("text"))
+      },
+      error = function(e) {
+        packageStartupMessage(
+          "The tzdb package was available but failed to initialize: ",
+          e,
+          "Timezones will not be available to Arrow compute functions."
+        )
+      }
+    )
   } else {
     packageStartupMessage(
       "The tzdb package is not installed. ",

--- a/r/R/arrow-package.R
+++ b/r/R/arrow-package.R
@@ -154,10 +154,10 @@ s3_finalizer <- new.env(parent = emptyenv())
     # See https://issues.apache.org/jira/browse/ARROW-8379
     options(arrow.use_threads = FALSE)
 
-    # MinGW/GCC builds (e.g. CRAN's winbuilder) use the vendored Howard Hinnant
-    # date library and need an IANA tzdata path. MSVC builds use std::chrono
-    # with the Windows system timezone database and don't need this.
-    # See https://github.com/apache/arrow/issues/48593
+    # Use the tzdata package to configure the tzdata database on non-MSVC (i.e.
+    # MinGW) systems. This fix was put in specifically for Winbuilder (See
+    # GH-49866) but is needed for all non-MSVC systems. This code assumes the
+    # tzdata package is in Suggests.
     if (!identical(build_info()[[2]], "MSVC")) {
       configure_tzdb()
     }

--- a/r/R/arrowExports.R
+++ b/r/R/arrowExports.R
@@ -552,6 +552,10 @@ runtime_info <- function() {
   .Call(`_arrow_runtime_info`)
 }
 
+set_timezone_database <- function(path) {
+  invisible(.Call(`_arrow_set_timezone_database`, path))
+}
+
 csv___WriteOptions__initialize <- function(options) {
   .Call(`_arrow_csv___WriteOptions__initialize`, options)
 }

--- a/r/R/arrowExports.R
+++ b/r/R/arrowExports.R
@@ -552,10 +552,6 @@ runtime_info <- function() {
   .Call(`_arrow_runtime_info`)
 }
 
-set_timezone_database <- function(path) {
-  invisible(.Call(`_arrow_set_timezone_database`, path))
-}
-
 csv___WriteOptions__initialize <- function(options) {
   .Call(`_arrow_csv___WriteOptions__initialize`, options)
 }

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -1383,6 +1383,15 @@ BEGIN_CPP11
 	return cpp11::as_sexp(runtime_info());
 END_CPP11
 }
+// config.cpp
+void set_timezone_database(cpp11::strings path);
+extern "C" SEXP _arrow_set_timezone_database(SEXP path_sexp){
+BEGIN_CPP11
+	arrow::r::Input<cpp11::strings>::type path(path_sexp);
+	set_timezone_database(path);
+	return R_NilValue;
+END_CPP11
+}
 // csv.cpp
 std::shared_ptr<arrow::csv::WriteOptions> csv___WriteOptions__initialize(cpp11::list options);
 extern "C" SEXP _arrow_csv___WriteOptions__initialize(SEXP options_sexp){
@@ -5869,9 +5878,10 @@ static const R_CallMethodDef CallEntries[] = {
 		{ "_arrow_compute__GetFunctionNames", (DL_FUNC) &_arrow_compute__GetFunctionNames, 0}, 
 		{ "_arrow_compute__Initialize", (DL_FUNC) &_arrow_compute__Initialize, 0}, 
 		{ "_arrow_RegisterScalarUDF", (DL_FUNC) &_arrow_RegisterScalarUDF, 2}, 
-		{ "_arrow_build_info", (DL_FUNC) &_arrow_build_info, 0}, 
-		{ "_arrow_runtime_info", (DL_FUNC) &_arrow_runtime_info, 0}, 
-		{ "_arrow_csv___WriteOptions__initialize", (DL_FUNC) &_arrow_csv___WriteOptions__initialize, 1}, 
+		{ "_arrow_build_info", (DL_FUNC) &_arrow_build_info, 0},
+		{ "_arrow_runtime_info", (DL_FUNC) &_arrow_runtime_info, 0},
+		{ "_arrow_set_timezone_database", (DL_FUNC) &_arrow_set_timezone_database, 1},
+		{ "_arrow_csv___WriteOptions__initialize", (DL_FUNC) &_arrow_csv___WriteOptions__initialize, 1},
 		{ "_arrow_csv___ReadOptions__initialize", (DL_FUNC) &_arrow_csv___ReadOptions__initialize, 1}, 
 		{ "_arrow_csv___ParseOptions__initialize", (DL_FUNC) &_arrow_csv___ParseOptions__initialize, 1}, 
 		{ "_arrow_csv___ReadOptions__column_names", (DL_FUNC) &_arrow_csv___ReadOptions__column_names, 1}, 

--- a/r/src/arrowExports.cpp
+++ b/r/src/arrowExports.cpp
@@ -1383,15 +1383,6 @@ BEGIN_CPP11
 	return cpp11::as_sexp(runtime_info());
 END_CPP11
 }
-// config.cpp
-void set_timezone_database(cpp11::strings path);
-extern "C" SEXP _arrow_set_timezone_database(SEXP path_sexp){
-BEGIN_CPP11
-	arrow::r::Input<cpp11::strings>::type path(path_sexp);
-	set_timezone_database(path);
-	return R_NilValue;
-END_CPP11
-}
 // csv.cpp
 std::shared_ptr<arrow::csv::WriteOptions> csv___WriteOptions__initialize(cpp11::list options);
 extern "C" SEXP _arrow_csv___WriteOptions__initialize(SEXP options_sexp){
@@ -5878,10 +5869,9 @@ static const R_CallMethodDef CallEntries[] = {
 		{ "_arrow_compute__GetFunctionNames", (DL_FUNC) &_arrow_compute__GetFunctionNames, 0}, 
 		{ "_arrow_compute__Initialize", (DL_FUNC) &_arrow_compute__Initialize, 0}, 
 		{ "_arrow_RegisterScalarUDF", (DL_FUNC) &_arrow_RegisterScalarUDF, 2}, 
-		{ "_arrow_build_info", (DL_FUNC) &_arrow_build_info, 0},
-		{ "_arrow_runtime_info", (DL_FUNC) &_arrow_runtime_info, 0},
-		{ "_arrow_set_timezone_database", (DL_FUNC) &_arrow_set_timezone_database, 1},
-		{ "_arrow_csv___WriteOptions__initialize", (DL_FUNC) &_arrow_csv___WriteOptions__initialize, 1},
+		{ "_arrow_build_info", (DL_FUNC) &_arrow_build_info, 0}, 
+		{ "_arrow_runtime_info", (DL_FUNC) &_arrow_runtime_info, 0}, 
+		{ "_arrow_csv___WriteOptions__initialize", (DL_FUNC) &_arrow_csv___WriteOptions__initialize, 1}, 
 		{ "_arrow_csv___ReadOptions__initialize", (DL_FUNC) &_arrow_csv___ReadOptions__initialize, 1}, 
 		{ "_arrow_csv___ParseOptions__initialize", (DL_FUNC) &_arrow_csv___ParseOptions__initialize, 1}, 
 		{ "_arrow_csv___ReadOptions__column_names", (DL_FUNC) &_arrow_csv___ReadOptions__column_names, 1}, 

--- a/r/src/config.cpp
+++ b/r/src/config.cpp
@@ -17,6 +17,8 @@
 
 #include "./arrow_types.h"
 
+#include <optional>
+
 #include <arrow/config.h>
 
 // [[arrow::export]]
@@ -30,4 +32,18 @@ std::vector<std::string> build_info() {
 std::vector<std::string> runtime_info() {
   auto info = arrow::GetRuntimeInfo();
   return {info.simd_level, info.detected_simd_level};
+}
+
+// [[arrow::export]]
+void set_timezone_database(cpp11::strings path) {
+  auto paths = cpp11::as_cpp<std::vector<std::string>>(path);
+  if (path.size() != 1) {
+    cpp11::stop("Must provide a single path to the timezone database.");
+  }
+
+  ARROW_SUPPRESS_DEPRECATION_WARNING
+  arrow::GlobalOptions options;
+  options.timezone_db_path = std::make_optional(paths[0]);
+  ARROW_UNSUPPRESS_DEPRECATION_WARNING
+  arrow::StopIfNotOk(arrow::Initialize(options));
 }

--- a/r/src/config.cpp
+++ b/r/src/config.cpp
@@ -17,8 +17,6 @@
 
 #include "./arrow_types.h"
 
-#include <optional>
-
 #include <arrow/config.h>
 
 // [[arrow::export]]
@@ -32,18 +30,4 @@ std::vector<std::string> build_info() {
 std::vector<std::string> runtime_info() {
   auto info = arrow::GetRuntimeInfo();
   return {info.simd_level, info.detected_simd_level};
-}
-
-// [[arrow::export]]
-void set_timezone_database(cpp11::strings path) {
-  auto paths = cpp11::as_cpp<std::vector<std::string>>(path);
-  if (path.size() != 1) {
-    cpp11::stop("Must provide a single path to the timezone database.");
-  }
-
-  ARROW_SUPPRESS_DEPRECATION_WARNING
-  arrow::GlobalOptions options;
-  options.timezone_db_path = std::make_optional(paths[0]);
-  ARROW_UNSUPPRESS_DEPRECATION_WARNING
-  arrow::StopIfNotOk(arrow::Initialize(options));
 }


### PR DESCRIPTION
### Rationale for this change

Winbuilder is currently failing for the tip of the `maint-24.0.0-r` branch. https://github.com/apache/arrow/pull/48601 introduced a new mechanism for tzdata resolution for Arrow C++ that requires non-MSVC Windows users to set up the tzdata database on their own.

We need to restore the mechanism we had before to which uses the tzdb package to provide a tzdata database because all CRAN builds are MinGW (GNU) builds.

This change was cherry-picked onto the R 24.0.0 maint branch to avoid any disruption.

### What changes are included in this PR?

- Puts tzdata back in Suggests so it's available
- Restored a modified detection mechanism to use the tzdata package on non-MSVC Windows systems. This is effectively all R users since CRAN builds with MinGW.

### Are these changes tested?

Yes. Here in CI.

### Are there any user-facing changes?

No.

* GitHub Issue: #49866