### PR TITLE
MINOR: [R] Update r/inst/NOTICE.txt from main NOTICE.txt file

### DIFF
--- a/r/inst/NOTICE.txt
+++ b/r/inst/NOTICE.txt
@@ -1,5 +1,5 @@
 Apache Arrow
-Copyright 2016-2024 The Apache Software Foundation
+Copyright 2016-2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
@@ -16,9 +16,6 @@ https://github.com/libdynd
 
 This product includes software from the LLVM project
  * distributed under the University of Illinois Open Source
-
-This product includes software from the google-lint project
- * Copyright (c) 2009 Google Inc. All rights reserved.
 
 This product includes software from the mman-win32 project
  * Copyright https://code.google.com/p/mman-win32/


### PR DESCRIPTION
### Rationale for this change

The NOTICE.txt we ship in the R package comes from the root of the repo. In https://github.com/apache/arrow/pull/46686 we made a code change which involved an update to the root NOTICE.txt but we could have also updated the R one.

`make build` in the `r` subdir automatically does this so I discovered the R NOTICE.txt was out of date when I ran `make build` as part of the release process.

### What changes are included in this PR?

- Updated NOTICE.txt. Done entirely by running `make build` in the `r` subdir.

### Are these changes tested?

No.

### Are there any user-facing changes?

No.