### PR TITLE
GH-49872: [C++] Remove deprecated std::is_trivial

### DIFF
--- a/cpp/src/arrow/util/aligned_storage.h
+++ b/cpp/src/arrow/util/aligned_storage.h
@@ -30,7 +30,7 @@ namespace internal {
 template <typename T>
 class AlignedStorage {
  public:
-  static constexpr bool can_memcpy = std::is_trivial<T>::value;
+  static constexpr bool can_memcpy = std::is_trivially_copyable<T>::value && std::is_trivially_default_constructible<T>::value;
 
   constexpr T* get() noexcept {
     return arrow::internal::launder(reinterpret_cast<T*>(&data_));

--- a/cpp/src/arrow/util/aligned_storage.h
+++ b/cpp/src/arrow/util/aligned_storage.h
@@ -30,7 +30,8 @@ namespace internal {
 template <typename T>
 class AlignedStorage {
  public:
-  static constexpr bool can_memcpy = std::is_trivially_copyable<T>::value && std::is_trivially_default_constructible<T>::value;
+  static constexpr bool can_memcpy = std::is_trivially_copyable<T>::value &&
+                                     std::is_trivially_default_constructible<T>::value;
 
   constexpr T* get() noexcept {
     return arrow::internal::launder(reinterpret_cast<T*>(&data_));


### PR DESCRIPTION
Resolves https://github.com/apache/arrow/issues/49872

### Rationale for this change

`std::is_trivial` is deprecated since C++26, so it leads to warning when building app with Apache Arrow and new C++ standard

### What changes are included in this PR?

This PR applies suggestion from libc++ code: `'is_trivial<std::shared_ptr<arrow::io::ReadableFile>>' is deprecated: Consider using is_trivially_copyable<T>::value && is_trivially_default_constructible<T>::value instead`

### Are these changes tested?

Tested with CI

### Are there any user-facing changes?

Changes allow user to build with warning as error flags
* GitHub Issue: #49872