### PR TITLE
MINOR: [R] Skip translation tests if NLS is not enabled

### DIFF
--- a/r/tests/testthat/helper-arrow.R
+++ b/r/tests/testthat/helper-arrow.R
@@ -35,6 +35,7 @@ options(arrow.pull_as_vector = FALSE)
 
 with_language <- function(lang, expr) {
   skip_on_cran()
+  skip_if_not(capabilities("NLS"))
   old <- Sys.getenv("LANGUAGE")
   # Check what this message is before changing languages; this will
   # trigger caching the translations if the OS does that (some do).


### PR DESCRIPTION
### Rationale for this change

R builds with `--disable-nls` and no `-DENABLE_NLS=1` will not translate any messages, so associated tests don't really make sense.

### What changes are included in this PR?

Skip such tests by reading from `capabilities()`.

### Are these changes tested?

GHA/CI

### Are there any user-facing changes?

No

### Could this be solved another way?

Yes, I think we could just use `withr::with_language()` instead which has its own `capabilities()` check:

https://github.com/r-lib/withr/blob/22e392c9cc13efaa9ba042bb193991f78316edb1/R/language.R#L81