### PR TITLE
GH-49875: [Python] Fix timezone dropped when converting tz-aware Categorical to Arrow array

### DIFF
--- a/python/pyarrow/array.pxi
+++ b/python/pyarrow/array.pxi
@@ -356,8 +356,8 @@ def array(object obj, type=None, mask=None, size=None, from_pandas=None,
                 values.codes, mask, index_type, memory_pool)
             try:
                 dictionary = array(
-                    values.categories.values, type=value_type,
-                    memory_pool=memory_pool)
+                    values.categories, type=value_type,
+                    from_pandas=True, memory_pool=memory_pool)
             except TypeError:
                 # TODO when removing the deprecation warning, this whole
                 # try/except can be removed (to bubble the TypeError of
@@ -371,7 +371,8 @@ def array(object obj, type=None, mask=None, size=None, from_pandas=None,
                         "TypeError",
                         FutureWarning, stacklevel=2)
                     dictionary = array(
-                        values.categories.values, memory_pool=memory_pool)
+                        values.categories, from_pandas=True,
+                        memory_pool=memory_pool)
                 else:
                     raise
 

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -492,22 +492,6 @@ class TestConvertMetadata:
 
         _check_pandas_roundtrip(df, preserve_index=True)
 
-    def test_categorical_with_timezone(self):
-        # pandas Categorical with timezone-aware datetime categories
-        # GH-49875: timezone was dropped when converting tz-aware categorical
-        cats = pd.DatetimeIndex(["2024-01-01", "2024-01-02"]).tz_localize("US/Eastern")
-        cat = pd.Categorical(values=[cats[0], cats[1], cats[0]], categories=cats)
-
-        # Verify pandas keeps the timezone on categories
-        assert "US/Eastern" in str(cat.dtype.categories.dtype)
-
-        # Convert to PyArrow
-        arr = pa.array(cat, from_pandas=True)
-
-        # Verify timezone is preserved in the dictionary value type
-        assert arr.type.value_type.tz is not None
-        assert str(arr.type.value_type.tz) == "US/Eastern"
-
     def test_duplicate_column_names_does_not_crash(self):
         df = pd.DataFrame([(1, 'a'), (2, 'b')], columns=list('aa'))
         with pytest.raises(ValueError):
@@ -3062,6 +3046,15 @@ class TestConvertMisc:
         df = pd.DataFrame({'a': [None, None, None]})
         df['a'] = df['a'].astype('category')
         _check_pandas_roundtrip(df)
+
+    def test_categorical_with_timezone(self):
+        # GH-49875: timezone was dropped when converting tz-aware categorical
+        cats = pd.DatetimeIndex(["2024-01-01", "2024-01-02"]).tz_localize("US/Eastern")
+        cat = pd.Categorical(values=[cats[0], cats[1], cats[0]], categories=cats)
+
+        arr = pa.array(cat, from_pandas=True)
+
+        assert arr.type.value_type.tz == "US/Eastern"
 
     def test_empty_arrays(self):
         for dtype_str, pa_type in self.type_pairs:

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -497,13 +497,13 @@ class TestConvertMetadata:
         # GH-49875: timezone was dropped when converting tz-aware categorical
         cats = pd.DatetimeIndex(["2024-01-01", "2024-01-02"]).tz_localize("US/Eastern")
         cat = pd.Categorical(values=[cats[0], cats[1], cats[0]], categories=cats)
-        
+
         # Verify pandas keeps the timezone on categories
-        assert str(cat.dtype.categories.dtype) == "datetime64[us, US/Eastern]"
-        
+        assert "US/Eastern" in str(cat.dtype.categories.dtype)
+
         # Convert to PyArrow
         arr = pa.array(cat, from_pandas=True)
-        
+
         # Verify timezone is preserved in the dictionary value type
         assert arr.type.value_type.tz is not None
         assert str(arr.type.value_type.tz) == "US/Eastern"

--- a/python/pyarrow/tests/test_pandas.py
+++ b/python/pyarrow/tests/test_pandas.py
@@ -492,6 +492,22 @@ class TestConvertMetadata:
 
         _check_pandas_roundtrip(df, preserve_index=True)
 
+    def test_categorical_with_timezone(self):
+        # pandas Categorical with timezone-aware datetime categories
+        # GH-49875: timezone was dropped when converting tz-aware categorical
+        cats = pd.DatetimeIndex(["2024-01-01", "2024-01-02"]).tz_localize("US/Eastern")
+        cat = pd.Categorical(values=[cats[0], cats[1], cats[0]], categories=cats)
+        
+        # Verify pandas keeps the timezone on categories
+        assert str(cat.dtype.categories.dtype) == "datetime64[us, US/Eastern]"
+        
+        # Convert to PyArrow
+        arr = pa.array(cat, from_pandas=True)
+        
+        # Verify timezone is preserved in the dictionary value type
+        assert arr.type.value_type.tz is not None
+        assert str(arr.type.value_type.tz) == "US/Eastern"
+
     def test_duplicate_column_names_does_not_crash(self):
         df = pd.DataFrame([(1, 'a'), (2, 'b')], columns=list('aa'))
         with pytest.raises(ValueError):


### PR DESCRIPTION



### Rationale for this change

When converting a pandas.Categorical with tz-aware datetime categories to a PyArrow array, the timezone information was silently dropped from the dictionary array's value type. This is a silent data loss bug — no warning or error is raised, but the timezone metadata is lost.

### What changes are included in this PR?

In `python/pyarrow/array.pxi`, the Categorical conversion was using `values.categories.values(raw numpy array) `which strips timezone metadata since numpy does not support tz-aware datetimes. Changed to values.categories (pandas Index) and added from_pandas=True so PyArrow uses the pandas conversion path, which correctly preserves timezone metadata.

### Are these changes tested?

Yes. Verified manually 
### Are there any user-facing changes?

Yes — this is a bug fix. Users did #49875 

This PR contains a **"Critical Fix"** — timezone information was lost silently during conversion without any warning or error.
* GitHub Issue: #49875