### PR TITLE
GH-19667: [C++][Gandiva] Use arrow::Result<std::string> for RegexUtil::SqlLikePatternToPcre

### DIFF
--- a/cpp/src/gandiva/regex_functions_holder.cc
+++ b/cpp/src/gandiva/regex_functions_holder.cc
@@ -128,8 +128,7 @@ Result<std::shared_ptr<LikeHolder>> LikeHolder::Make(const FunctionNode& node) {
 }
 
 Result<std::shared_ptr<LikeHolder>> LikeHolder::Make(const std::string& sql_pattern) {
-  std::string pcre_pattern;
-  ARROW_RETURN_NOT_OK(RegexUtil::SqlLikePatternToPcre(sql_pattern, pcre_pattern));
+  ARROW_ASSIGN_OR_RAISE(auto pcre_pattern, RegexUtil::SqlLikePatternToPcre(sql_pattern));
 
   RE2::Options regex_op;
   regex_op.set_dot_nl(true);  // set dotall mode for the regex.
@@ -148,11 +147,12 @@ Result<std::shared_ptr<LikeHolder>> LikeHolder::Make(const std::string& sql_patt
                   Status::Invalid("The length of escape char ", escape_char,
                                   " in 'like' function is greater than 1"));
   std::string pcre_pattern;
+
   if (escape_char.length() == 1) {
-    ARROW_RETURN_NOT_OK(
-        RegexUtil::SqlLikePatternToPcre(sql_pattern, escape_char.at(0), pcre_pattern));
+    ARROW_ASSIGN_OR_RAISE(
+        pcre_pattern, RegexUtil::SqlLikePatternToPcre(sql_pattern, escape_char.at(0)));
   } else {
-    ARROW_RETURN_NOT_OK(RegexUtil::SqlLikePatternToPcre(sql_pattern, pcre_pattern));
+    ARROW_ASSIGN_OR_RAISE(pcre_pattern, RegexUtil::SqlLikePatternToPcre(sql_pattern));
   }
 
   auto lholder = std::shared_ptr<LikeHolder>(new LikeHolder(pcre_pattern, regex_op));
@@ -165,8 +165,7 @@ Result<std::shared_ptr<LikeHolder>> LikeHolder::Make(const std::string& sql_patt
 
 Result<std::shared_ptr<LikeHolder>> LikeHolder::Make(const std::string& sql_pattern,
                                                      RE2::Options regex_op) {
-  std::string pcre_pattern;
-  ARROW_RETURN_NOT_OK(RegexUtil::SqlLikePatternToPcre(sql_pattern, pcre_pattern));
+  ARROW_ASSIGN_OR_RAISE(auto pcre_pattern, RegexUtil::SqlLikePatternToPcre(sql_pattern));
 
   auto lholder = std::shared_ptr<LikeHolder>(new LikeHolder(pcre_pattern, regex_op));
 

--- a/cpp/src/gandiva/regex_functions_holder_test.cc
+++ b/cpp/src/gandiva/regex_functions_holder_test.cc
@@ -88,9 +88,8 @@ TEST_F(TestLikeHolder, TestPcreSpecialWithNewLine) {
 }
 
 TEST_F(TestLikeHolder, TestRegexEscape) {
-  std::string res;
-  ARROW_EXPECT_OK(RegexUtil::SqlLikePatternToPcre("#%hello#_abc_def##", '#', res));
-
+  ASSERT_OK_AND_ASSIGN(auto res,
+                       RegexUtil::SqlLikePatternToPcre("#%hello#_abc_def##", '#'));
   EXPECT_EQ(res, "%hello_abc.def#");
 }
 

--- a/cpp/src/gandiva/regex_util.cc
+++ b/cpp/src/gandiva/regex_util.cc
@@ -22,11 +22,11 @@ namespace gandiva {
 const std::set<char> RegexUtil::pcre_regex_specials_ = {
     '[', ']', '(', ')', '|', '^', '-', '+', '*', '?', '{', '}', '$', '\\', '.'};
 
-Status RegexUtil::SqlLikePatternToPcre(const std::string& sql_pattern, char escape_char,
-                                       std::string& pcre_pattern) {
-  /// Characters that are considered special by pcre regex. These needs to be
+arrow::Result<std::string> RegexUtil::SqlLikePatternToPcre(const std::string& sql_pattern,
+                                                           char escape_char) {
+  /// Characters that are considered special by pcre regex. These need to be
   /// escaped with '\\'.
-  pcre_pattern.clear();
+  std::string pcre_pattern;
   for (size_t idx = 0; idx < sql_pattern.size(); ++idx) {
     auto cur = sql_pattern.at(idx);
 
@@ -57,7 +57,7 @@ Status RegexUtil::SqlLikePatternToPcre(const std::string& sql_pattern, char esca
       pcre_pattern += cur;
     }
   }
-  return Status::OK();
+  return pcre_pattern;
 }
 
 }  // namespace gandiva

--- a/cpp/src/gandiva/regex_util.h
+++ b/cpp/src/gandiva/regex_util.h
@@ -27,15 +27,15 @@
 namespace gandiva {
 
 /// \brief Utility class for converting sql patterns to pcre patterns.
-class GANDIVA_EXPORT RegexUtil {
+class RegexUtil {
  public:
   // Convert an sql pattern to a pcre pattern
-  static Status SqlLikePatternToPcre(const std::string& like_pattern, char escape_char,
-                                     std::string& pcre_pattern);
+  static GANDIVA_EXPORT arrow::Result<std::string> SqlLikePatternToPcre(
+      const std::string& like_pattern, char escape_char);
 
-  static Status SqlLikePatternToPcre(const std::string& like_pattern,
-                                     std::string& pcre_pattern) {
-    return SqlLikePatternToPcre(like_pattern, 0 /*escape_char*/, pcre_pattern);
+  static arrow::Result<std::string> SqlLikePatternToPcre(
+      const std::string& like_pattern) {
+    return SqlLikePatternToPcre(like_pattern, '\0' /*escape_char*/);
   }
 
  private:


### PR DESCRIPTION
### Rationale for this change

Replace the `Status` + out-parameter pattern in `RegexUtil::SqlLikePatternToPcre` with `arrow::Result<std::string>`, aligning with modern Arrow API practices.

### What changes are included in this PR?

* Updated `RegexUtil::SqlLikePatternToPcre` to return `arrow::Result<std::string>` instead of using an out-parameter
* Updated call sites in `regex_functions_holder.cc` to use `ARROW_ASSIGN_OR_RAISE`
* Updated tests in `regex_functions_holder_test.cc` to use `ASSERT_OK_AND_ASSIGN`
* Removed `GANDIVA_EXPORT` from the inline wrapper to avoid Windows `dllimport` issues
* Simplified control flow in `regex_functions_holder.cc`

### Are these changes tested?

* Rebuilt with `ninja gandiva`
* Ran Gandiva tests successfully

### Are there any user-facing changes?

Yes.

* GitHub Issue: #19667
