### PR TITLE
GH-49884: [C++] Fix integer overflow in BufferBuilder reachable from JSON parsing

### DIFF
--- a/cpp/src/arrow/buffer_builder.h
+++ b/cpp/src/arrow/buffer_builder.h
@@ -27,9 +27,9 @@
 #include "arrow/buffer.h"
 #include "arrow/status.h"
 #include "arrow/util/bit_util.h"
-#include "arrow/util/int_util_overflow.h"
 #include "arrow/util/bitmap_generate.h"
 #include "arrow/util/bitmap_ops.h"
+#include "arrow/util/int_util_overflow.h"
 #include "arrow/util/macros.h"
 #include "arrow/util/ubsan.h"
 #include "arrow/util/visibility.h"
@@ -114,8 +114,8 @@ class ARROW_EXPORT BufferBuilder {
     // jemalloc, but significantly better performance when using the system
     // allocator. See ARROW-6450 for further discussion
     int64_t doubled;
-    if (ARROW_PREDICT_FALSE(internal::AddWithOverflow(current_capacity, current_capacity,
-                                                      &doubled))) {
+    if (ARROW_PREDICT_FALSE(
+            internal::AddWithOverflow(current_capacity, current_capacity, &doubled))) {
       return new_capacity;
     }
     return std::max(new_capacity, doubled);
@@ -274,21 +274,12 @@ class TypedBufferBuilder<
   }
 
   Status Append(const T* values, int64_t num_elements) {
-    if (ARROW_PREDICT_FALSE(num_elements < 0)) {
-      return Status::Invalid("Append: negative number of elements");
-    }
     int64_t num_bytes;
-    if (ARROW_PREDICT_FALSE(internal::MultiplyWithOverflow(
-            num_elements, static_cast<int64_t>(sizeof(T)), &num_bytes))) {
-      return Status::CapacityError("Append: size overflow");
-    }
+    ARROW_RETURN_NOT_OK(ElementsToBytes("Append", num_elements, &num_bytes));
     return bytes_builder_.Append(reinterpret_cast<const uint8_t*>(values), num_bytes);
   }
 
   Status Append(const int64_t num_copies, T value) {
-    if (ARROW_PREDICT_FALSE(num_copies < 0)) {
-      return Status::Invalid("Append: negative number of copies");
-    }
     ARROW_RETURN_NOT_OK(Reserve(num_copies));
     UnsafeAppend(num_copies, value);
     return Status::OK();
@@ -318,38 +309,20 @@ class TypedBufferBuilder<
   }
 
   Status Resize(const int64_t new_capacity, bool shrink_to_fit = true) {
-    if (ARROW_PREDICT_FALSE(new_capacity < 0)) {
-      return Status::Invalid("Resize: negative capacity");
-    }
     int64_t num_bytes;
-    if (ARROW_PREDICT_FALSE(internal::MultiplyWithOverflow(
-            new_capacity, static_cast<int64_t>(sizeof(T)), &num_bytes))) {
-      return Status::CapacityError("Resize: capacity overflow");
-    }
+    ARROW_RETURN_NOT_OK(ElementsToBytes("Resize", new_capacity, &num_bytes));
     return bytes_builder_.Resize(num_bytes, shrink_to_fit);
   }
 
   Status Reserve(const int64_t additional_elements) {
-    if (ARROW_PREDICT_FALSE(additional_elements < 0)) {
-      return Status::Invalid("Reserve: negative additional_elements");
-    }
     int64_t num_bytes;
-    if (ARROW_PREDICT_FALSE(internal::MultiplyWithOverflow(
-            additional_elements, static_cast<int64_t>(sizeof(T)), &num_bytes))) {
-      return Status::CapacityError("Reserve: size overflow");
-    }
+    ARROW_RETURN_NOT_OK(ElementsToBytes("Reserve", additional_elements, &num_bytes));
     return bytes_builder_.Reserve(num_bytes);
   }
 
   Status Advance(const int64_t length) {
-    if (ARROW_PREDICT_FALSE(length < 0)) {
-      return Status::Invalid("Advance: negative length");
-    }
     int64_t num_bytes;
-    if (ARROW_PREDICT_FALSE(internal::MultiplyWithOverflow(
-            length, static_cast<int64_t>(sizeof(T)), &num_bytes))) {
-      return Status::CapacityError("Advance: size overflow");
-    }
+    ARROW_RETURN_NOT_OK(ElementsToBytes("Advance", length, &num_bytes));
     return bytes_builder_.Advance(num_bytes);
   }
 
@@ -374,14 +347,8 @@ class TypedBufferBuilder<
   /// only for memory allocation).
   Result<std::shared_ptr<Buffer>> FinishWithLength(int64_t final_length,
                                                    bool shrink_to_fit = true) {
-    if (ARROW_PREDICT_FALSE(final_length < 0)) {
-      return Status::Invalid("FinishWithLength: negative final length");
-    }
     int64_t num_bytes;
-    if (ARROW_PREDICT_FALSE(internal::MultiplyWithOverflow(
-            final_length, static_cast<int64_t>(sizeof(T)), &num_bytes))) {
-      return Status::CapacityError("FinishWithLength: final length overflow");
-    }
+    ARROW_RETURN_NOT_OK(ElementsToBytes("FinishWithLength", final_length, &num_bytes));
     return bytes_builder_.FinishWithLength(num_bytes, shrink_to_fit);
   }
 
@@ -393,6 +360,20 @@ class TypedBufferBuilder<
   T* mutable_data() { return reinterpret_cast<T*>(bytes_builder_.mutable_data()); }
 
  private:
+  // Convert a number of elements to a number of bytes, erroring out on
+  // negative element counts and byte size overflow.
+  static Status ElementsToBytes(const char* operation, int64_t num_elements,
+                                int64_t* num_bytes) {
+    if (ARROW_PREDICT_FALSE(num_elements < 0)) {
+      return Status::Invalid(operation, ": negative number of elements");
+    }
+    if (ARROW_PREDICT_FALSE(internal::MultiplyWithOverflow(
+            num_elements, static_cast<int64_t>(sizeof(T)), num_bytes))) {
+      return Status::CapacityError(operation, ": byte size overflow");
+    }
+    return Status::OK();
+  }
+
   BufferBuilder bytes_builder_;
 };
 
@@ -503,7 +484,7 @@ class TypedBufferBuilder<bool> {
             internal::AddWithOverflow(bit_length_, additional_elements, &min_length))) {
       return Status::CapacityError("Reserve: capacity overflow");
     }
-    return Resize(min_length, false);
+    return Resize(BufferBuilder::GrowByFactor(bit_length_, min_length), false);
   }
 
   Status Advance(const int64_t length) {
@@ -534,6 +515,9 @@ class TypedBufferBuilder<bool> {
   /// only for memory allocation).
   Result<std::shared_ptr<Buffer>> FinishWithLength(int64_t final_length,
                                                    bool shrink_to_fit = true) {
+    if (ARROW_PREDICT_FALSE(final_length < 0)) {
+      return Status::Invalid("FinishWithLength: negative final length");
+    }
     const auto final_byte_length = bit_util::BytesForBits(final_length);
     bytes_builder_.UnsafeAdvance(final_byte_length - bytes_builder_.length());
     bit_length_ = false_count_ = 0;

--- a/cpp/src/arrow/buffer_builder.h
+++ b/cpp/src/arrow/buffer_builder.h
@@ -93,18 +93,18 @@ class ARROW_EXPORT BufferBuilder {
   /// \return Status
   Status Reserve(const int64_t additional_bytes) {
     if (ARROW_PREDICT_FALSE(additional_bytes < 0)) {
-      return Status::Invalid("Reserve: negative additional_bytes");
+      return Status::Invalid("Reserve: negative additional_bytes: ", additional_bytes);
     }
     int64_t min_capacity;
     if (ARROW_PREDICT_FALSE(
             internal::AddWithOverflow(size_, additional_bytes, &min_capacity))) {
-      return Status::CapacityError("Reserve: capacity overflow");
+      return Status::CapacityError("Reserve: capacity overflow: ", size_, " + ",
+                                   additional_bytes);
     }
     if (min_capacity <= capacity_) {
       return Status::OK();
     }
-    int64_t requested_capacity = GrowByFactor(capacity_, min_capacity);
-    return Resize(requested_capacity, false);
+    return Resize(GrowByFactor(capacity_, min_capacity), false);
   }
 
   /// \brief Return a capacity expanded by the desired growth factor
@@ -126,11 +126,11 @@ class ARROW_EXPORT BufferBuilder {
   /// The buffer is automatically expanded if necessary.
   Status Append(const void* data, const int64_t length) {
     if (ARROW_PREDICT_FALSE(length < 0)) {
-      return Status::Invalid("Append: negative length");
+      return Status::Invalid("Append: negative length: ", length);
     }
     int64_t new_size;
     if (ARROW_PREDICT_FALSE(internal::AddWithOverflow(size_, length, &new_size))) {
-      return Status::CapacityError("Append: size overflow");
+      return Status::CapacityError("Append: size overflow: ", size_, " + ", length);
     }
     if (ARROW_PREDICT_FALSE(new_size > capacity_)) {
       ARROW_RETURN_NOT_OK(Resize(GrowByFactor(capacity_, new_size), false));
@@ -208,7 +208,7 @@ class ARROW_EXPORT BufferBuilder {
   Result<std::shared_ptr<Buffer>> FinishWithLength(int64_t final_length,
                                                    bool shrink_to_fit = true) {
     if (ARROW_PREDICT_FALSE(final_length < 0)) {
-      return Status::Invalid("FinishWithLength: negative final length");
+      return Status::Invalid("FinishWithLength: negative final length: ", final_length);
     }
     size_ = final_length;
     return Finish(shrink_to_fit);
@@ -365,11 +365,12 @@ class TypedBufferBuilder<
   static Status ElementsToBytes(const char* operation, int64_t num_elements,
                                 int64_t* num_bytes) {
     if (ARROW_PREDICT_FALSE(num_elements < 0)) {
-      return Status::Invalid(operation, ": negative number of elements");
+      return Status::Invalid(operation, ": negative number of elements: ", num_elements);
     }
     if (ARROW_PREDICT_FALSE(internal::MultiplyWithOverflow(
             num_elements, static_cast<int64_t>(sizeof(T)), num_bytes))) {
-      return Status::CapacityError(operation, ": byte size overflow");
+      return Status::CapacityError(operation, ": byte size overflow: ", num_elements,
+                                   " * ", sizeof(T));
     }
     return Status::OK();
   }
@@ -460,6 +461,9 @@ class TypedBufferBuilder<bool> {
   }
 
   Status Resize(const int64_t new_capacity, bool shrink_to_fit = true) {
+    if (ARROW_PREDICT_FALSE(new_capacity < 0)) {
+      return Status::Invalid("Resize: negative capacity: ", new_capacity);
+    }
     const int64_t old_byte_capacity = bytes_builder_.capacity();
     ARROW_RETURN_NOT_OK(
         bytes_builder_.Resize(bit_util::BytesForBits(new_capacity), shrink_to_fit));
@@ -477,12 +481,14 @@ class TypedBufferBuilder<bool> {
 
   Status Reserve(const int64_t additional_elements) {
     if (ARROW_PREDICT_FALSE(additional_elements < 0)) {
-      return Status::Invalid("Reserve: negative additional_elements");
+      return Status::Invalid("Reserve: negative additional_elements: ",
+                             additional_elements);
     }
     int64_t min_length;
     if (ARROW_PREDICT_FALSE(
             internal::AddWithOverflow(bit_length_, additional_elements, &min_length))) {
-      return Status::CapacityError("Reserve: capacity overflow");
+      return Status::CapacityError("Reserve: capacity overflow: ", bit_length_, " + ",
+                                   additional_elements);
     }
     return Resize(BufferBuilder::GrowByFactor(bit_length_, min_length), false);
   }
@@ -516,7 +522,7 @@ class TypedBufferBuilder<bool> {
   Result<std::shared_ptr<Buffer>> FinishWithLength(int64_t final_length,
                                                    bool shrink_to_fit = true) {
     if (ARROW_PREDICT_FALSE(final_length < 0)) {
-      return Status::Invalid("FinishWithLength: negative final length");
+      return Status::Invalid("FinishWithLength: negative final length: ", final_length);
     }
     const auto final_byte_length = bit_util::BytesForBits(final_length);
     bytes_builder_.UnsafeAdvance(final_byte_length - bytes_builder_.length());

--- a/cpp/src/arrow/buffer_builder.h
+++ b/cpp/src/arrow/buffer_builder.h
@@ -36,10 +36,6 @@
 
 namespace arrow {
 
-static inline bool BufferBuilderCapacityTooLarge(int64_t capacity) {
-  return ARROW_PREDICT_FALSE(capacity > std::numeric_limits<int64_t>::max() - 63);
-}
-
 // ----------------------------------------------------------------------
 // Buffer builder classes
 
@@ -79,12 +75,6 @@ class ARROW_EXPORT BufferBuilder {
   /// shrinking the builder.
   /// \return Status
   Status Resize(const int64_t new_capacity, bool shrink_to_fit = true) {
-    if (ARROW_PREDICT_FALSE(new_capacity < 0)) {
-      return Status::Invalid("Resize: negative capacity");
-    }
-    if (ARROW_PREDICT_FALSE(BufferBuilderCapacityTooLarge(new_capacity))) {
-      return Status::CapacityError("Resize: capacity overflow");
-    }
     if (buffer_ == NULLPTR) {
       ARROW_ASSIGN_OR_RAISE(buffer_,
                             AllocateResizableBuffer(new_capacity, alignment_, pool_));
@@ -110,16 +100,10 @@ class ARROW_EXPORT BufferBuilder {
             internal::AddWithOverflow(size_, additional_bytes, &min_capacity))) {
       return Status::CapacityError("Reserve: capacity overflow");
     }
-    if (ARROW_PREDICT_FALSE(BufferBuilderCapacityTooLarge(min_capacity))) {
-      return Status::CapacityError("Reserve: capacity overflow");
-    }
     if (min_capacity <= capacity_) {
       return Status::OK();
     }
     int64_t requested_capacity = GrowByFactor(capacity_, min_capacity);
-    if (ARROW_PREDICT_FALSE(BufferBuilderCapacityTooLarge(requested_capacity))) {
-      return Status::CapacityError("Reserve: capacity overflow");
-    }
     return Resize(requested_capacity, false);
   }
 
@@ -342,9 +326,6 @@ class TypedBufferBuilder<
             new_capacity, static_cast<int64_t>(sizeof(T)), &num_bytes))) {
       return Status::CapacityError("Resize: capacity overflow");
     }
-    if (ARROW_PREDICT_FALSE(BufferBuilderCapacityTooLarge(num_bytes))) {
-      return Status::CapacityError("Resize: capacity overflow");
-    }
     return bytes_builder_.Resize(num_bytes, shrink_to_fit);
   }
 
@@ -355,9 +336,6 @@ class TypedBufferBuilder<
     int64_t num_bytes;
     if (ARROW_PREDICT_FALSE(internal::MultiplyWithOverflow(
             additional_elements, static_cast<int64_t>(sizeof(T)), &num_bytes))) {
-      return Status::CapacityError("Reserve: size overflow");
-    }
-    if (ARROW_PREDICT_FALSE(BufferBuilderCapacityTooLarge(num_bytes))) {
       return Status::CapacityError("Reserve: size overflow");
     }
     return bytes_builder_.Reserve(num_bytes);
@@ -523,9 +501,6 @@ class TypedBufferBuilder<bool> {
     int64_t min_length;
     if (ARROW_PREDICT_FALSE(
             internal::AddWithOverflow(bit_length_, additional_elements, &min_length))) {
-      return Status::CapacityError("Reserve: capacity overflow");
-    }
-    if (ARROW_PREDICT_FALSE(BufferBuilderCapacityTooLarge(min_length))) {
       return Status::CapacityError("Reserve: capacity overflow");
     }
     return Resize(min_length, false);

--- a/cpp/src/arrow/buffer_builder.h
+++ b/cpp/src/arrow/buffer_builder.h
@@ -27,6 +27,7 @@
 #include "arrow/buffer.h"
 #include "arrow/status.h"
 #include "arrow/util/bit_util.h"
+#include "arrow/util/int_util_overflow.h"
 #include "arrow/util/bitmap_generate.h"
 #include "arrow/util/bitmap_ops.h"
 #include "arrow/util/macros.h"
@@ -74,6 +75,9 @@ class ARROW_EXPORT BufferBuilder {
   /// shrinking the builder.
   /// \return Status
   Status Resize(const int64_t new_capacity, bool shrink_to_fit = true) {
+    if (ARROW_PREDICT_FALSE(new_capacity < 0)) {
+      return Status::Invalid("Resize: negative capacity");
+    }
     if (buffer_ == NULLPTR) {
       ARROW_ASSIGN_OR_RAISE(buffer_,
                             AllocateResizableBuffer(new_capacity, alignment_, pool_));
@@ -91,7 +95,14 @@ class ARROW_EXPORT BufferBuilder {
   /// \param[in] additional_bytes number of additional bytes to make space for
   /// \return Status
   Status Reserve(const int64_t additional_bytes) {
-    auto min_capacity = size_ + additional_bytes;
+    if (ARROW_PREDICT_FALSE(additional_bytes < 0)) {
+      return Status::Invalid("Reserve: negative additional_bytes");
+    }
+    int64_t min_capacity;
+    if (ARROW_PREDICT_FALSE(
+            internal::AddWithOverflow(size_, additional_bytes, &min_capacity))) {
+      return Status::CapacityError("Reserve: capacity overflow");
+    }
     if (min_capacity <= capacity_) {
       return Status::OK();
     }
@@ -104,15 +115,27 @@ class ARROW_EXPORT BufferBuilder {
     // (versus 1.5x) seems to have slightly better performance when using
     // jemalloc, but significantly better performance when using the system
     // allocator. See ARROW-6450 for further discussion
-    return std::max(new_capacity, current_capacity * 2);
+    int64_t doubled;
+    if (ARROW_PREDICT_FALSE(internal::AddWithOverflow(current_capacity, current_capacity,
+                                                      &doubled))) {
+      return new_capacity;
+    }
+    return std::max(new_capacity, doubled);
   }
 
   /// \brief Append the given data to the buffer
   ///
   /// The buffer is automatically expanded if necessary.
   Status Append(const void* data, const int64_t length) {
-    if (ARROW_PREDICT_FALSE(size_ + length > capacity_)) {
-      ARROW_RETURN_NOT_OK(Resize(GrowByFactor(capacity_, size_ + length), false));
+    if (ARROW_PREDICT_FALSE(length < 0)) {
+      return Status::Invalid("Append: negative length");
+    }
+    int64_t new_size;
+    if (ARROW_PREDICT_FALSE(internal::AddWithOverflow(size_, length, &new_size))) {
+      return Status::CapacityError("Append: size overflow");
+    }
+    if (ARROW_PREDICT_FALSE(new_size > capacity_)) {
+      ARROW_RETURN_NOT_OK(Resize(GrowByFactor(capacity_, new_size), false));
     }
     UnsafeAppend(data, length);
     return Status::OK();
@@ -186,6 +209,9 @@ class ARROW_EXPORT BufferBuilder {
   /// mostly for memory allocation).
   Result<std::shared_ptr<Buffer>> FinishWithLength(int64_t final_length,
                                                    bool shrink_to_fit = true) {
+    if (ARROW_PREDICT_FALSE(final_length < 0)) {
+      return Status::Invalid("FinishWithLength: negative final length");
+    }
     size_ = final_length;
     return Finish(shrink_to_fit);
   }
@@ -250,12 +276,22 @@ class TypedBufferBuilder<
   }
 
   Status Append(const T* values, int64_t num_elements) {
-    return bytes_builder_.Append(reinterpret_cast<const uint8_t*>(values),
-                                 num_elements * sizeof(T));
+    if (ARROW_PREDICT_FALSE(num_elements < 0)) {
+      return Status::Invalid("Append: negative number of elements");
+    }
+    int64_t num_bytes;
+    if (ARROW_PREDICT_FALSE(internal::MultiplyWithOverflow(
+            num_elements, static_cast<int64_t>(sizeof(T)), &num_bytes))) {
+      return Status::CapacityError("Append: size overflow");
+    }
+    return bytes_builder_.Append(reinterpret_cast<const uint8_t*>(values), num_bytes);
   }
 
   Status Append(const int64_t num_copies, T value) {
-    ARROW_RETURN_NOT_OK(Reserve(num_copies + length()));
+    if (ARROW_PREDICT_FALSE(num_copies < 0)) {
+      return Status::Invalid("Append: negative number of copies");
+    }
+    ARROW_RETURN_NOT_OK(Reserve(num_copies));
     UnsafeAppend(num_copies, value);
     return Status::OK();
   }
@@ -284,15 +320,39 @@ class TypedBufferBuilder<
   }
 
   Status Resize(const int64_t new_capacity, bool shrink_to_fit = true) {
-    return bytes_builder_.Resize(new_capacity * sizeof(T), shrink_to_fit);
+    if (ARROW_PREDICT_FALSE(new_capacity < 0)) {
+      return Status::Invalid("Resize: negative capacity");
+    }
+    int64_t num_bytes;
+    if (ARROW_PREDICT_FALSE(internal::MultiplyWithOverflow(
+            new_capacity, static_cast<int64_t>(sizeof(T)), &num_bytes))) {
+      return Status::CapacityError("Resize: capacity overflow");
+    }
+    return bytes_builder_.Resize(num_bytes, shrink_to_fit);
   }
 
   Status Reserve(const int64_t additional_elements) {
-    return bytes_builder_.Reserve(additional_elements * sizeof(T));
+    if (ARROW_PREDICT_FALSE(additional_elements < 0)) {
+      return Status::Invalid("Reserve: negative additional_elements");
+    }
+    int64_t num_bytes;
+    if (ARROW_PREDICT_FALSE(internal::MultiplyWithOverflow(
+            additional_elements, static_cast<int64_t>(sizeof(T)), &num_bytes))) {
+      return Status::CapacityError("Reserve: size overflow");
+    }
+    return bytes_builder_.Reserve(num_bytes);
   }
 
   Status Advance(const int64_t length) {
-    return bytes_builder_.Advance(length * sizeof(T));
+    if (ARROW_PREDICT_FALSE(length < 0)) {
+      return Status::Invalid("Advance: negative length");
+    }
+    int64_t num_bytes;
+    if (ARROW_PREDICT_FALSE(internal::MultiplyWithOverflow(
+            length, static_cast<int64_t>(sizeof(T)), &num_bytes))) {
+      return Status::CapacityError("Advance: size overflow");
+    }
+    return bytes_builder_.Advance(num_bytes);
   }
 
   void UnsafeAdvance(const int64_t length) {
@@ -316,7 +376,15 @@ class TypedBufferBuilder<
   /// only for memory allocation).
   Result<std::shared_ptr<Buffer>> FinishWithLength(int64_t final_length,
                                                    bool shrink_to_fit = true) {
-    return bytes_builder_.FinishWithLength(final_length * sizeof(T), shrink_to_fit);
+    if (ARROW_PREDICT_FALSE(final_length < 0)) {
+      return Status::Invalid("FinishWithLength: negative final length");
+    }
+    int64_t num_bytes;
+    if (ARROW_PREDICT_FALSE(internal::MultiplyWithOverflow(
+            final_length, static_cast<int64_t>(sizeof(T)), &num_bytes))) {
+      return Status::CapacityError("FinishWithLength: final length overflow");
+    }
+    return bytes_builder_.FinishWithLength(num_bytes, shrink_to_fit);
   }
 
   void Reset() { bytes_builder_.Reset(); }

--- a/cpp/src/arrow/buffer_builder.h
+++ b/cpp/src/arrow/buffer_builder.h
@@ -36,6 +36,10 @@
 
 namespace arrow {
 
+static inline bool BufferBuilderCapacityTooLarge(int64_t capacity) {
+  return ARROW_PREDICT_FALSE(capacity > std::numeric_limits<int64_t>::max() - 63);
+}
+
 // ----------------------------------------------------------------------
 // Buffer builder classes
 
@@ -78,6 +82,9 @@ class ARROW_EXPORT BufferBuilder {
     if (ARROW_PREDICT_FALSE(new_capacity < 0)) {
       return Status::Invalid("Resize: negative capacity");
     }
+    if (ARROW_PREDICT_FALSE(BufferBuilderCapacityTooLarge(new_capacity))) {
+      return Status::CapacityError("Resize: capacity overflow");
+    }
     if (buffer_ == NULLPTR) {
       ARROW_ASSIGN_OR_RAISE(buffer_,
                             AllocateResizableBuffer(new_capacity, alignment_, pool_));
@@ -103,10 +110,17 @@ class ARROW_EXPORT BufferBuilder {
             internal::AddWithOverflow(size_, additional_bytes, &min_capacity))) {
       return Status::CapacityError("Reserve: capacity overflow");
     }
+    if (ARROW_PREDICT_FALSE(BufferBuilderCapacityTooLarge(min_capacity))) {
+      return Status::CapacityError("Reserve: capacity overflow");
+    }
     if (min_capacity <= capacity_) {
       return Status::OK();
     }
-    return Resize(GrowByFactor(capacity_, min_capacity), false);
+    int64_t requested_capacity = GrowByFactor(capacity_, min_capacity);
+    if (ARROW_PREDICT_FALSE(BufferBuilderCapacityTooLarge(requested_capacity))) {
+      return Status::CapacityError("Reserve: capacity overflow");
+    }
+    return Resize(requested_capacity, false);
   }
 
   /// \brief Return a capacity expanded by the desired growth factor
@@ -328,6 +342,9 @@ class TypedBufferBuilder<
             new_capacity, static_cast<int64_t>(sizeof(T)), &num_bytes))) {
       return Status::CapacityError("Resize: capacity overflow");
     }
+    if (ARROW_PREDICT_FALSE(BufferBuilderCapacityTooLarge(num_bytes))) {
+      return Status::CapacityError("Resize: capacity overflow");
+    }
     return bytes_builder_.Resize(num_bytes, shrink_to_fit);
   }
 
@@ -338,6 +355,9 @@ class TypedBufferBuilder<
     int64_t num_bytes;
     if (ARROW_PREDICT_FALSE(internal::MultiplyWithOverflow(
             additional_elements, static_cast<int64_t>(sizeof(T)), &num_bytes))) {
+      return Status::CapacityError("Reserve: size overflow");
+    }
+    if (ARROW_PREDICT_FALSE(BufferBuilderCapacityTooLarge(num_bytes))) {
       return Status::CapacityError("Reserve: size overflow");
     }
     return bytes_builder_.Reserve(num_bytes);
@@ -497,9 +517,18 @@ class TypedBufferBuilder<bool> {
   }
 
   Status Reserve(const int64_t additional_elements) {
-    return Resize(
-        BufferBuilder::GrowByFactor(bit_length_, bit_length_ + additional_elements),
-        false);
+    if (ARROW_PREDICT_FALSE(additional_elements < 0)) {
+      return Status::Invalid("Reserve: negative additional_elements");
+    }
+    int64_t min_length;
+    if (ARROW_PREDICT_FALSE(
+            internal::AddWithOverflow(bit_length_, additional_elements, &min_length))) {
+      return Status::CapacityError("Reserve: capacity overflow");
+    }
+    if (ARROW_PREDICT_FALSE(BufferBuilderCapacityTooLarge(min_length))) {
+      return Status::CapacityError("Reserve: capacity overflow");
+    }
+    return Resize(min_length, false);
   }
 
   Status Advance(const int64_t length) {

--- a/cpp/src/arrow/buffer_builder.h
+++ b/cpp/src/arrow/buffer_builder.h
@@ -274,7 +274,7 @@ class TypedBufferBuilder<
   }
 
   Status Append(const T* values, int64_t num_elements) {
-    int64_t num_bytes;
+    int64_t num_bytes = 0;
     ARROW_RETURN_NOT_OK(ElementsToBytes("Append", num_elements, &num_bytes));
     return bytes_builder_.Append(reinterpret_cast<const uint8_t*>(values), num_bytes);
   }
@@ -309,19 +309,19 @@ class TypedBufferBuilder<
   }
 
   Status Resize(const int64_t new_capacity, bool shrink_to_fit = true) {
-    int64_t num_bytes;
+    int64_t num_bytes = 0;
     ARROW_RETURN_NOT_OK(ElementsToBytes("Resize", new_capacity, &num_bytes));
     return bytes_builder_.Resize(num_bytes, shrink_to_fit);
   }
 
   Status Reserve(const int64_t additional_elements) {
-    int64_t num_bytes;
+    int64_t num_bytes = 0;
     ARROW_RETURN_NOT_OK(ElementsToBytes("Reserve", additional_elements, &num_bytes));
     return bytes_builder_.Reserve(num_bytes);
   }
 
   Status Advance(const int64_t length) {
-    int64_t num_bytes;
+    int64_t num_bytes = 0;
     ARROW_RETURN_NOT_OK(ElementsToBytes("Advance", length, &num_bytes));
     return bytes_builder_.Advance(num_bytes);
   }
@@ -347,7 +347,7 @@ class TypedBufferBuilder<
   /// only for memory allocation).
   Result<std::shared_ptr<Buffer>> FinishWithLength(int64_t final_length,
                                                    bool shrink_to_fit = true) {
-    int64_t num_bytes;
+    int64_t num_bytes = 0;
     ARROW_RETURN_NOT_OK(ElementsToBytes("FinishWithLength", final_length, &num_bytes));
     return bytes_builder_.FinishWithLength(num_bytes, shrink_to_fit);
   }

--- a/cpp/src/arrow/buffer_test.cc
+++ b/cpp/src/arrow/buffer_test.cc
@@ -881,9 +881,18 @@ TYPED_TEST(TypedTestBufferBuilder, NegativeAndOverflowAppend) {
   ASSERT_RAISES(Invalid, builder.Append(-1, static_cast<TypeParam>(0)));
 
   const int64_t max_num_elements =
-      std::numeric_limits<int64_t>::max() / sizeof(TypeParam) + 1;
+      std::numeric_limits<int64_t>::max() / static_cast<int64_t>(sizeof(TypeParam)) + 1;
   ASSERT_RAISES(CapacityError,
                 builder.Append(max_num_elements, static_cast<TypeParam>(0)));
+}
+
+TEST(TestBoolBufferBuilder, NegativeInputs) {
+  TypedBufferBuilder<bool> builder;
+
+  ASSERT_RAISES(Invalid, builder.Resize(-1));
+  ASSERT_RAISES(Invalid, builder.Reserve(-1));
+  ASSERT_RAISES(Invalid, builder.Append(-1, true));
+  ASSERT_RAISES(Invalid, builder.FinishWithLength(-1));
 }
 
 TEST(TestBoolBufferBuilder, Basics) {

--- a/cpp/src/arrow/buffer_test.cc
+++ b/cpp/src/arrow/buffer_test.cc
@@ -726,6 +726,19 @@ TEST(TestBufferBuilder, ResizeReserve) {
   ASSERT_EQ(9, builder.length());
 }
 
+TEST(TestBufferBuilder, InvalidReserveAndAppendLengths) {
+  const std::string data = "x";
+  auto data_ptr = data.c_str();
+  BufferBuilder builder;
+
+  ASSERT_RAISES(Invalid, builder.Append(data_ptr, -1));
+  ASSERT_RAISES(Invalid, builder.Reserve(-1));
+  ASSERT_RAISES(Invalid, builder.Advance(-1));
+
+  const int64_t overflow_add = std::numeric_limits<int64_t>::max() - 8;
+  ASSERT_RAISES(CapacityError, builder.Reserve(overflow_add));
+}
+
 TEST(TestBufferBuilder, Alignment) {
   const std::string data = "some data";
   auto data_ptr = data.c_str();
@@ -860,6 +873,16 @@ TYPED_TEST(TypedTestBufferBuilder, AppendCopies) {
   for (int i = 0; i != 13 + 17; ++i, ++data) {
     ASSERT_EQ(*data, static_cast<TypeParam>(i < 13)) << "index = " << i;
   }
+}
+
+TYPED_TEST(TypedTestBufferBuilder, NegativeAndOverflowAppend) {
+  TypedBufferBuilder<TypeParam> builder;
+
+  ASSERT_RAISES(Invalid, builder.Append(-1, static_cast<TypeParam>(0)));
+
+  const int64_t max_num_elements = std::numeric_limits<int64_t>::max() / sizeof(TypeParam) + 1;
+  ASSERT_RAISES(CapacityError,
+                builder.Append(max_num_elements, static_cast<TypeParam>(0)));
 }
 
 TEST(TestBoolBufferBuilder, Basics) {

--- a/cpp/src/arrow/buffer_test.cc
+++ b/cpp/src/arrow/buffer_test.cc
@@ -736,7 +736,7 @@ TEST(TestBufferBuilder, InvalidReserveAndAppendLengths) {
   ASSERT_RAISES(Invalid, builder.Advance(-1));
 
   const int64_t overflow_add = std::numeric_limits<int64_t>::max() - 8;
-  ASSERT_RAISES(CapacityError, builder.Reserve(overflow_add));
+  ASSERT_RAISES(OutOfMemory, builder.Reserve(overflow_add));
 }
 
 TEST(TestBufferBuilder, Alignment) {
@@ -880,7 +880,8 @@ TYPED_TEST(TypedTestBufferBuilder, NegativeAndOverflowAppend) {
 
   ASSERT_RAISES(Invalid, builder.Append(-1, static_cast<TypeParam>(0)));
 
-  const int64_t max_num_elements = std::numeric_limits<int64_t>::max() / sizeof(TypeParam) + 1;
+  const int64_t max_num_elements =
+      std::numeric_limits<int64_t>::max() / sizeof(TypeParam) + 1;
   ASSERT_RAISES(CapacityError,
                 builder.Append(max_num_elements, static_cast<TypeParam>(0)));
 }

--- a/cpp/src/arrow/memory_pool.cc
+++ b/cpp/src/arrow/memory_pool.cc
@@ -73,10 +73,10 @@ constexpr int64_t kMaxBufferCapacity = std::numeric_limits<int64_t>::max() - 63;
 
 Status ValidateBufferCapacity(int64_t capacity, const char* operation) {
   if (ARROW_PREDICT_FALSE(capacity < 0)) {
-    return Status::Invalid(operation, ": negative capacity");
+    return Status::Invalid(operation, ": negative capacity: ", capacity);
   }
   if (ARROW_PREDICT_FALSE(capacity > kMaxBufferCapacity)) {
-    return Status::CapacityError(operation, ": capacity overflow");
+    return Status::OutOfMemory(operation, ": capacity too large: ", capacity);
   }
   return Status::OK();
 }
@@ -1031,7 +1031,6 @@ Result<std::unique_ptr<ResizableBuffer>> AllocateResizableBuffer(const int64_t s
 Result<std::unique_ptr<ResizableBuffer>> AllocateResizableBuffer(const int64_t size,
                                                                  const int64_t alignment,
                                                                  MemoryPool* pool) {
-  RETURN_NOT_OK(ValidateBufferCapacity(size, "AllocateResizableBuffer"));
   return ResizePoolBuffer<std::unique_ptr<ResizableBuffer>>(
       PoolBuffer::MakeUnique(pool, alignment), size);
 }

--- a/cpp/src/arrow/memory_pool.cc
+++ b/cpp/src/arrow/memory_pool.cc
@@ -69,6 +69,17 @@ namespace {
 
 constexpr char kDefaultBackendEnvVar[] = "ARROW_DEFAULT_MEMORY_POOL";
 constexpr char kDebugMemoryEnvVar[] = "ARROW_DEBUG_MEMORY_POOL";
+constexpr int64_t kMaxBufferCapacity = std::numeric_limits<int64_t>::max() - 63;
+
+Status ValidateBufferCapacity(int64_t capacity, const char* operation) {
+  if (ARROW_PREDICT_FALSE(capacity < 0)) {
+    return Status::Invalid(operation, ": negative capacity");
+  }
+  if (ARROW_PREDICT_FALSE(capacity > kMaxBufferCapacity)) {
+    return Status::CapacityError(operation, ": capacity overflow");
+  }
+  return Status::OK();
+}
 
 enum class MemoryPoolBackend : uint8_t { System, Jemalloc, Mimalloc };
 
@@ -920,9 +931,7 @@ class PoolBuffer final : public ResizableBuffer {
   }
 
   Status Reserve(const int64_t capacity) override {
-    if (capacity < 0) {
-      return Status::Invalid("Negative buffer capacity: ", capacity);
-    }
+    RETURN_NOT_OK(ValidateBufferCapacity(capacity, "Reserve"));
     uint8_t* ptr = mutable_data();
     if (!ptr || capacity > capacity_) {
       ARROW_ASSIGN_OR_RAISE(int64_t new_capacity, RoundCapacity(capacity));
@@ -938,9 +947,7 @@ class PoolBuffer final : public ResizableBuffer {
   }
 
   Status Resize(const int64_t new_size, bool shrink_to_fit = true) override {
-    if (ARROW_PREDICT_FALSE(new_size < 0)) {
-      return Status::Invalid("Negative buffer resize: ", new_size);
-    }
+    RETURN_NOT_OK(ValidateBufferCapacity(new_size, "Resize"));
     uint8_t* ptr = mutable_data();
     if (ptr && shrink_to_fit && new_size <= size_) {
       // Buffer is non-null and is not growing, so shrink to the requested size without
@@ -984,9 +991,7 @@ class PoolBuffer final : public ResizableBuffer {
 
  private:
   static Result<int64_t> RoundCapacity(int64_t capacity) {
-    if (capacity > std::numeric_limits<int64_t>::max() - 63) {
-      return Status::OutOfMemory("capacity too large");
-    }
+    DCHECK_LE(capacity, kMaxBufferCapacity);
     return bit_util::RoundUpToMultipleOf64(capacity);
   }
 
@@ -1026,6 +1031,7 @@ Result<std::unique_ptr<ResizableBuffer>> AllocateResizableBuffer(const int64_t s
 Result<std::unique_ptr<ResizableBuffer>> AllocateResizableBuffer(const int64_t size,
                                                                  const int64_t alignment,
                                                                  MemoryPool* pool) {
+  RETURN_NOT_OK(ValidateBufferCapacity(size, "AllocateResizableBuffer"));
   return ResizePoolBuffer<std::unique_ptr<ResizableBuffer>>(
       PoolBuffer::MakeUnique(pool, alignment), size);
 }


### PR DESCRIPTION
### Rationale for this change

`BufferBuilder` and `TypedBufferBuilder` perform size calculations that are reachable from JSON parsing of untrusted input. These calculations previously used unchecked integer arithmetic (e.g., `size_ + additional_bytes`, `num_elements * sizeof(T)`), which can overflow.

Since the JSON parser constructs arrays, strings, and offsets based on input data, an attacker can influence these values. Overflow in these calculations can result in incorrect buffer sizing and unsafe memory operations.


### What changes are included in this PR?

- Added overflow-safe arithmetic using `internal::AddWithOverflow` and `internal::MultiplyWithOverflow` for:
  - `size_ + additional_bytes`
  - `num_elements * sizeof(T)`
  - capacity growth logic

- Centralised the negative / too-large capacity check in a single `ValidateBufferCapacity` helper in `memory_pool.cc`, used by `PoolBuffer::Reserve`, `PoolBuffer::Resize` and `AllocateResizableBuffer`

- Hardened `GrowByFactor` to prevent overflow when doubling capacity

- Updated `TypedBufferBuilder` to safely compute byte sizes from element counts

- Added regression tests covering:
  - addition overflow
  - multiplication overflow


### Are these changes tested?

Yes.

New tests were added to:
- Detect overflow conditions in both `BufferBuilder` and `TypedBufferBuilder`
- Ensure proper error handling (`CapacityError`, `OutOfMemory`) instead of undefined behavior


### Are there any user-facing changes?

No functional changes for valid inputs.

Sizes that overflow `int64_t` during these calculations, which previously resulted in undefined behavior, are now explicitly rejected with clear error statuses. Negative arguments are still treated as a caller error and are not checked in the builders.


**This PR contains a "Critical Fix".**

Unchecked integer arithmetic in buffer size calculations could overflow when processing untrusted JSON input. This may result in under-allocation of buffers followed by writes of larger logical sizes, leading to potential out-of-bounds memory writes and undefined behavior.

This patch ensures all such arithmetic is validated, preventing incorrect buffer sizing and eliminating this class of memory safety issues.
* GitHub Issue: #49884
