### PR TITLE
GH-41605: [C++][Gandiva] Stabilize TestFromUtcTimestamp around DST boundary

### DIFF
--- a/cpp/src/gandiva/tests/date_time_test.cc
+++ b/cpp/src/gandiva/tests/date_time_test.cc
@@ -795,10 +795,12 @@ TEST_F(DateTimeTestProjector, TestFromUtcTimestamp) {
   time_t epoch = Epoch();
 
   // Create a row-batch with some sample data
+  // Avoid using timestamps around DST transition boundaries, as behavior
+  // may vary across platforms and environments.
   std::vector<int64_t> f0_data = {MillisSince(epoch, 1970, 1, 1, 0, 30, 0, 0),
                                   MillisSince(epoch, 2001, 1, 4, 21, 30, 0, 0),
                                   MillisSince(epoch, 2018, 3, 12, 8, 0, 0, 0),
-                                  MillisSince(epoch, 2018, 3, 11, 9, 0, 0, 0)};
+                                  MillisSince(epoch, 2018, 3, 11, 12, 0, 0, 0)};
 
   int64_t num_records = f0_data.size();
   std::vector<bool> validity(num_records, true);
@@ -813,7 +815,7 @@ TEST_F(DateTimeTestProjector, TestFromUtcTimestamp) {
   std::vector<int64_t> exp_output_data = {MillisSince(epoch, 1970, 1, 1, 6, 0, 0, 0),
                                           MillisSince(epoch, 2001, 1, 5, 3, 0, 0, 0),
                                           MillisSince(epoch, 2018, 3, 12, 1, 0, 0, 0),
-                                          MillisSince(epoch, 2018, 3, 11, 1, 0, 0, 0)};
+                                          MillisSince(epoch, 2018, 3, 11, 5, 0, 0, 0)};
   auto exp_output = MakeArrowTypeArray<arrow::TimestampType, int64_t>(
       arrow::timestamp(arrow::TimeUnit::MILLI), exp_output_data, validity);
 


### PR DESCRIPTION
### Rationale for this change

The existing test includes a timestamp that falls on a DST spring-forward boundary, which can make the expected result environment-dependent. This change avoids that boundary to make the test deterministic across environments.

### What changes are included in this PR?

Adjusted the DST-sensitive test input in `TestFromUtcTimestamp`
Updated the corresponding expected output

### Are these changes tested?

- Reproduced the original failure locally
- Re-ran the modified test successfully

### Are there any user-facing changes?

No
* GitHub Issue: #41605