### PR TITLE
GH-49890: [Dev] Group files under component comment headers in `.github/CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -38,7 +38,6 @@
 /cpp/src/parquet @wgtmac
 
 ## MATLAB
-/.github/workflows/matlab.yml @kevingurney @sgilmore10
 /matlab/ @kevingurney @kou @sgilmore10
 
 ## Python
@@ -66,6 +65,7 @@
 
 # PR CI and repository files
 /.github/ @assignUser @jonkeane @kou @raulcd
+/.github/workflows/matlab.yml @kevingurney @sgilmore10
 .asf.yaml @assignUser @kou @raulcd
 .pre-commit-config.yaml @raulcd
 # .git*

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,6 +25,26 @@
 # Arrow Format
 # /format/
 
+# Docs
+# /docs/
+# *.md
+# *.rmd
+# *.rst
+# *.txt
+
+# PR CI and repository files
+/.github/ @assignUser @jonkeane @kou @raulcd
+.asf.yaml @assignUser @kou @raulcd
+.pre-commit-config.yaml @raulcd
+# .git*
+
+# Release scripts, archery etc.
+/ci/ @assignUser @jonkeane @kou @raulcd
+/dev/ @assignUser @jonkeane @kou @raulcd
+.dockerignore @raulcd
+.env @assignUser @jonkeane @kou @raulcd
+compose.yaml @assignUser @jonkeane @kou @raulcd
+
 # Components
 
 ## C GLib
@@ -38,6 +58,7 @@
 /cpp/src/parquet @wgtmac
 
 ## MATLAB
+/.github/workflows/matlab.yml @kevingurney @sgilmore10
 /matlab/ @kevingurney @kou @sgilmore10
 
 ## Python
@@ -55,24 +76,3 @@
 
 ## Ruby
 /ruby/ @kou
-
-# Docs
-# /docs/
-# *.md
-# *.rmd
-# *.rst
-# *.txt
-
-# PR CI and repository files
-/.github/ @assignUser @jonkeane @kou @raulcd
-/.github/workflows/matlab.yml @kevingurney @sgilmore10
-.asf.yaml @assignUser @kou @raulcd
-.pre-commit-config.yaml @raulcd
-# .git*
-
-# release scripts, archery etc.
-/ci/ @assignUser @jonkeane @kou @raulcd
-/dev/ @assignUser @jonkeane @kou @raulcd
-.dockerignore @raulcd
-.env @assignUser @jonkeane @kou @raulcd
-compose.yaml @assignUser @jonkeane @kou @raulcd

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,19 +25,36 @@
 # Arrow Format
 # /format/
 
-## Components
+# Components
+
+## C Glib
 /c_glib/ @kou
-# /cpp/
+
+## C++
 /cpp/src/arrow/acero @westonpace
 /cpp/src/arrow/adapters/orc @wgtmac
 /cpp/src/arrow/engine @westonpace
 /cpp/src/arrow/flight/ @lidavidm
 /cpp/src/parquet @wgtmac
+
+## MATLAB
 /matlab/ @kevingurney @kou @sgilmore10
+/.github/workflows/matlab.yml @kevingurney @sgilmore10
+
+## Python
 /python/ @AlenkaF @raulcd @rok
 /python/pyarrow/_flight.pyx @lidavidm
 /python/pyarrow/**/*gandiva* @wjones127
+
+## R
 /r/ @jonkeane @thisisnic
+/r/configure* @assignUser
+/r/Makefile @assignUser
+/r/PACKAGING.md @assignUser
+/r/tools/ @assignUser
+/r/.Rbuildignore @assignUser
+
+## Ruby
 /ruby/ @kou
 
 # Docs
@@ -59,10 +76,3 @@
 .dockerignore @raulcd
 .env @assignUser @jonkeane @kou @raulcd
 compose.yaml @assignUser @jonkeane @kou @raulcd
-
-# R specific packaging tooling
-/r/configure* @assignUser
-/r/Makefile @assignUser
-/r/PACKAGING.md @assignUser
-/r/tools/ @assignUser
-/r/.Rbuildignore @assignUser

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,7 +27,7 @@
 
 # Components
 
-## C Glib
+## C GLib
 /c_glib/ @kou
 
 ## C++

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -38,8 +38,8 @@
 /cpp/src/parquet @wgtmac
 
 ## MATLAB
-/matlab/ @kevingurney @kou @sgilmore10
 /.github/workflows/matlab.yml @kevingurney @sgilmore10
+/matlab/ @kevingurney @kou @sgilmore10
 
 ## Python
 /python/ @AlenkaF @raulcd @rok


### PR DESCRIPTION
### Rationale for this change

Based on the feedback shared by @kou in https://github.com/apache/arrow/pull/49811#issuecomment-4284161273, we should consider grouping files under component comment headers in `.github/CODEOWNERS` to improve readability.

We should also add `@kevingurney` and `@sgilmore10` as `CODEOWNERS` for the MATLAB-related CI file `.github/workflows/matlab.yml`.

### Component(s)

Developer Tools

### What changes are included in this PR?

1. Group files under component comment headers in `.github/CODEOWNERS` file.
2. Add `@kevingurney` and `@sgilmore10` as `CODEOWNERS` for file `.github/workflows/matlab.yml`.

### Are these changes tested?

N/A.

### Are there any user-facing changes?

No.

### Notes

1.  Thank you @sgilmore10 for your help with this pull request!
* GitHub Issue: #49890