### PR TITLE
GH-14796: [Dev] Prepend missing "[COMPONENT]" to issue title automatically

### DIFF
--- a/.github/workflows/issue_bot.yml
+++ b/.github/workflows/issue_bot.yml
@@ -60,21 +60,8 @@ jobs:
               return prefix_overrides[component] || component;
             };
 
-            let strip_component_prefixes = (title, prefixes) => {
-              let stripped_title = title.trimStart();
-              let prefix_removed = true;
-              while (prefix_removed) {
-                prefix_removed = false;
-                for (let prefix of prefixes) {
-                  let title_prefix = `[${prefix}]`;
-                  if (stripped_title.startsWith(title_prefix)) {
-                    stripped_title = stripped_title.substring(title_prefix.length).trimStart();
-                    prefix_removed = true;
-                    break;
-                  }
-                }
-              }
-              return stripped_title;
+            let title_has_prefix = (title, prefix) => {
+              return title.includes(`[${prefix}]`);
             };
 
             let split_body = context.payload.issue.body.split('### Component(s)');
@@ -133,23 +120,19 @@ jobs:
             let component_prefixes = component_labels.map(
               label => component_to_prefix(label.substring("Component: ".length))
             );
-            let repo_component_prefixes = repo_labels.data
-              .map(label => label.name)
-              .filter(label => label.startsWith("Component: "))
-              .map(label => component_to_prefix(label.substring("Component: ".length)));
-            let stripped_title = strip_component_prefixes(
-              context.payload.issue.title,
-              repo_component_prefixes
+            let issue_title = context.payload.issue.title.trimStart();
+            let missing_prefixes = component_prefixes.filter(
+              prefix => !title_has_prefix(issue_title, prefix)
             );
-            let prefixed_title = component_prefixes
+            let missing_title_prefix = missing_prefixes
               .map(prefix => `[${prefix}]`)
-              .join("") + " " + stripped_title;
-            if (prefixed_title != context.payload.issue.title) {
+              .join("");
+            if (missing_title_prefix) {
               await github.rest.issues.update({
                 "owner": context.repo.owner,
                 "repo": context.repo.repo,
                 "issue_number": context.payload.issue.number,
-                "title": prefixed_title,
+                "title": missing_title_prefix + " " + issue_title,
               });
             }
 

--- a/.github/workflows/issue_bot.yml
+++ b/.github/workflows/issue_bot.yml
@@ -51,6 +51,32 @@ jobs:
               `Thanks for your report! The ${component} implementation has moved to https://github.com/apache/${repo}.\n\n` +
               `This issue has been closed automatically - please open a new issue there.`;
 
+            let component_to_prefix = (component) => {
+              const prefix_overrides = {
+                "Continuous Integration": "CI",
+                "Developer Tools": "Dev",
+                "Documentation": "Docs",
+              };
+              return prefix_overrides[component] || component;
+            };
+
+            let strip_component_prefixes = (title, prefixes) => {
+              let stripped_title = title.trimStart();
+              let prefix_removed = true;
+              while (prefix_removed) {
+                prefix_removed = false;
+                for (let prefix of prefixes) {
+                  let title_prefix = `[${prefix}]`;
+                  if (stripped_title.startsWith(title_prefix)) {
+                    stripped_title = stripped_title.substring(title_prefix.length).trimStart();
+                    prefix_removed = true;
+                    break;
+                  }
+                }
+              }
+              return stripped_title;
+            };
+
             let split_body = context.payload.issue.body.split('### Component(s)');
             if (split_body.length != 2) throw new Error('No components found!');
 
@@ -103,6 +129,29 @@ jobs:
             );
 
             if (component_labels.length == 0) throw new Error('No components found!');
+
+            let component_prefixes = component_labels.map(
+              label => component_to_prefix(label.substring("Component: ".length))
+            );
+            let repo_component_prefixes = repo_labels.data
+              .map(label => label.name)
+              .filter(label => label.startsWith("Component: "))
+              .map(label => component_to_prefix(label.substring("Component: ".length)));
+            let stripped_title = strip_component_prefixes(
+              context.payload.issue.title,
+              repo_component_prefixes
+            );
+            let prefixed_title = component_prefixes
+              .map(prefix => `[${prefix}]`)
+              .join("") + " " + stripped_title;
+            if (prefixed_title != context.payload.issue.title) {
+              await github.rest.issues.update({
+                "owner": context.repo.owner,
+                "repo": context.repo.repo,
+                "issue_number": context.payload.issue.number,
+                "title": prefixed_title,
+              });
+            }
 
             await github.rest.issues.setLabels({
               "owner": context.repo.owner,

--- a/.github/workflows/issue_bot.yml
+++ b/.github/workflows/issue_bot.yml
@@ -128,11 +128,12 @@ jobs:
               .map(prefix => `[${prefix}]`)
               .join("");
             if (missing_title_prefix) {
+              let title_separator = issue_title.startsWith("[") ? "" : " ";
               await github.rest.issues.update({
                 "owner": context.repo.owner,
                 "repo": context.repo.repo,
                 "issue_number": context.payload.issue.number,
-                "title": missing_title_prefix + " " + issue_title,
+                "title": missing_title_prefix + title_separator + issue_title,
               });
             }
 

--- a/.github/workflows/issue_bot.yml
+++ b/.github/workflows/issue_bot.yml
@@ -120,13 +120,17 @@ jobs:
             let component_prefixes = component_labels.map(
               label => component_to_prefix(label.substring("Component: ".length))
             );
+
             let issue_title = context.payload.issue.title.trimStart();
+
             let missing_prefixes = component_prefixes.filter(
               prefix => !title_has_prefix(issue_title, prefix)
             );
+
             let missing_title_prefix = missing_prefixes
               .map(prefix => `[${prefix}]`)
               .join("");
+
             if (missing_title_prefix) {
               let title_separator = issue_title.startsWith("[") ? "" : " ";
               await github.rest.issues.update({


### PR DESCRIPTION
### Rationale for this change

Easier to see which issues are related to which component when we add the component to the title automatically if it's missing

### What changes are included in this PR?

Add code to do so

### Are these changes tested?

Yep - look at issues open at www.github.com/thisisnic/arrow

### Are there any user-facing changes?

Nope
* GitHub Issue: #14796