### PR TITLE
GH-49861: [R] Missing R libarrow binary for linux-arm64

### DIFF
--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -242,6 +242,7 @@ tasks:
     artifacts:
       - r-libarrow-windows-x86_64-{no_rc_r_version}\.zip
       - r-libarrow-linux-x86_64-{no_rc_r_version}\.zip
+      - r-libarrow-linux-arm64-{no_rc_r_version}\.zip
       - r-libarrow-darwin-arm64-{no_rc_r_version}\.zip
       - r-libarrow-darwin-x86_64-{no_rc_r_version}\.zip
       - r-pkg__bin__windows__contrib__4.5__arrow_{no_rc_r_version}\.zip


### PR DESCRIPTION
### Rationale for this change

Binary for arm64 missing from the release as we didn't add it to the list which is used to compare against

### What changes are included in this PR?

Add binary to list

### Are these changes tested?

No

### Are there any user-facing changes?

No
* GitHub Issue: #49861