### PR TITLE
GH-49861: [R][Release] Include linux-arm64 libarrow binary in releases

### DIFF
--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -241,6 +241,7 @@ tasks:
       custom_version: Unset
     artifacts:
       - r-libarrow-windows-x86_64-{no_rc_r_version}\.zip
+      - r-libarrow-linux-arm64-{no_rc_r_version}\.zip
       - r-libarrow-linux-x86_64-{no_rc_r_version}\.zip
       - r-libarrow-darwin-arm64-{no_rc_r_version}\.zip
       - r-libarrow-darwin-x86_64-{no_rc_r_version}\.zip


### PR DESCRIPTION
### Rationale for this change

https://github.com/apache/arrow/pull/48574 added most of the pieces for publishing Linux arm64 libarrow binaries for R but it was missing the final step to upload to the release.

### What changes are included in this PR?

- Updates the `r-binary-packages` task definition with a pattern to catch the linux-arm64 binary

### Are these changes tested?

No, we'll test in CI.

### Are there any user-facing changes?

No.
* GitHub Issue: #49861