### PR TITLE
MINOR: [R][Release] Update r-binary-packages crossbow job for R 4.6 on arm64 macOS

### DIFF
--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -249,7 +249,7 @@ tasks:
       - r-pkg__bin__macosx__big-sur-x86_64__contrib__4.5__arrow_{no_rc_r_version}\.tgz
       - r-pkg__bin__macosx__big-sur-x86_64__contrib__4.6__arrow_{no_rc_r_version}\.tgz
       - r-pkg__bin__macosx__big-sur-arm64__contrib__4.5__arrow_{no_rc_r_version}\.tgz
-       -r-pkg__bin__macosx__sonoma-arm64__contrib__4.6__arrow_{no_rc_r_version}\.tgz
+      - r-pkg__bin__macosx__sonoma-arm64__contrib__4.6__arrow_{no_rc_r_version}\.tgz
       - r-pkg__src__contrib__arrow_{no_rc_r_version}\.tar\.gz
 
 {% for which in ["strong", "most"] %}

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -249,8 +249,7 @@ tasks:
       - r-pkg__bin__macosx__big-sur-x86_64__contrib__4.5__arrow_{no_rc_r_version}\.tgz
       - r-pkg__bin__macosx__big-sur-x86_64__contrib__4.6__arrow_{no_rc_r_version}\.tgz
       - r-pkg__bin__macosx__big-sur-arm64__contrib__4.5__arrow_{no_rc_r_version}\.tgz
-      # TODO: Uncomment once setup-r resolves release to 4.6
-      #  -r-pkg__bin__macosx__sonoma-arm64__contrib__4.6__arrow_{no_rc_r_version}\.tgz
+       -r-pkg__bin__macosx__sonoma-arm64__contrib__4.6__arrow_{no_rc_r_version}\.tgz
       - r-pkg__src__contrib__arrow_{no_rc_r_version}\.tar\.gz
 
 {% for which in ["strong", "most"] %}


### PR DESCRIPTION
### Rationale for this change

The last change to this list was made during the transition between R 4.5.3 and 4.6.0. At the time, R 4.6.0 wasn't yet available so I commented this out to make CI pass. We're now out of the transition period. Also of note is that R 4.6.0 bumped the minimum macOS version from Big Sur to Sonona but just for arm64. x86_64 stays with a minimum of Big Sur.

### What changes are included in this PR?

- Updates the artifact pattern in the r-binary-packages job

### Are these changes tested?

We'll test in CI.

### Are there any user-facing changes?

No.