### PR TITLE
GH-49898: [C++][CI] Use mold in more builds

### DIFF
--- a/ci/docker/debian-13-cpp.dockerfile
+++ b/ci/docker/debian-13-cpp.dockerfile
@@ -75,6 +75,7 @@ RUN apt-get update -y -q && \
         libzstd-dev \
         llvm-${llvm}-dev \
         make \
+        mold \
         ninja-build \
         nlohmann-json3-dev \
         npm \
@@ -124,6 +125,7 @@ ENV ARROW_ACERO=ON \
     ARROW_S3=ON \
     ARROW_SUBSTRAIT=ON \
     ARROW_USE_CCACHE=ON \
+    ARROW_USE_MOLD=ON \
     ARROW_WITH_BROTLI=ON \
     ARROW_WITH_BZ2=ON \
     ARROW_WITH_LZ4=ON \

--- a/ci/docker/fedora-42-cpp.dockerfile
+++ b/ci/docker/fedora-42-cpp.dockerfile
@@ -51,6 +51,7 @@ RUN dnf update -y && \
         llvm-devel \
         lz4-devel \
         make \
+        mold \
         ninja-build \
         openssl-devel \
         patch \
@@ -93,6 +94,7 @@ ENV ARROW_ACERO=ON \
     ARROW_S3=ON \
     ARROW_SUBSTRAIT=ON \
     ARROW_USE_CCACHE=ON \
+    ARROW_USE_MOLD=ON \
     ARROW_WITH_BROTLI=ON \
     ARROW_WITH_BZ2=ON \
     ARROW_WITH_LZ4=ON \

--- a/cpp/cmake_modules/DefineOptions.cmake
+++ b/cpp/cmake_modules/DefineOptions.cmake
@@ -110,17 +110,6 @@ macro(resolve_option_dependencies)
   if(MSVC_TOOLCHAIN)
     set(ARROW_USE_GLOG OFF)
   endif()
-  # Tests are crashed with mold + sanitizer checks.
-  if(ARROW_USE_ASAN
-     OR ARROW_USE_TSAN
-     OR ARROW_USE_UBSAN)
-    if(ARROW_USE_MOLD)
-      message(WARNING "ARROW_USE_MOLD is disabled when one of "
-                      "ARROW_USE_ASAN, ARROW_USE_TSAN or ARROW_USE_UBSAN is specified "
-                      "because it causes some problems.")
-      set(ARROW_USE_MOLD OFF)
-    endif()
-  endif()
 
   tsort_bool_option_dependencies()
   foreach(option_name ${ARROW_BOOL_OPTION_DEPENDENCIES_TSORTED})


### PR DESCRIPTION
### Rationale for this change

We're currently using the mold linker only on a couple of C++ builds. This PR uses it in more builds to get faster link times and thus faster CI builds.

### Are these changes tested?

Yes, by CI builds.

### Are there any user-facing changes?

No.

* GitHub Issue: #49898