### PR TITLE
MINOR: [R][Release] Update arrow R backwards compatibility job

### DIFF
--- a/dev/tasks/r/github.linux.arrow.version.back.compat.yml
+++ b/dev/tasks/r/github.linux.arrow.version.back.compat.yml
@@ -73,6 +73,7 @@ jobs:
         config:
         # We use the R version that was released at the time of the arrow release in order
         # to make sure we can download binaries from RSPM.
+        - { old_arrow_version: '23.0.1.2', r: '4.5' }
         - { old_arrow_version: '22.0.0.1', r: '4.5' }
         - { old_arrow_version: '21.0.0.1', r: '4.5' }
         - { old_arrow_version: '20.0.0.2', r: '4.5' }


### PR DESCRIPTION
### Rationale for this change

After R releases, we update this job. See the step in https://github.com/apache/arrow/issues/49685.

### What changes are included in this PR?

- Adds a line for arrow R 23.0.1.2

### Are these changes tested?

We can test in CI.

### Are there any user-facing changes?

No.