### PR TITLE
GH-48094: [C++] Restrict SecureString capacity tail check to Linux

### DIFF
--- a/cpp/src/arrow/util/secure_string_test.cc
+++ b/cpp/src/arrow/util/secure_string_test.cc
@@ -30,8 +30,14 @@ namespace arrow::util::test {
 #  define CAN_TEST_DEALLOCATED_AREAS 1
 #endif
 
+// Reading the unused tail past size() is undefined behavior, exclude MSVC
+// from the tail check.
 std::string_view StringArea(const std::string& string) {
+#if defined(_MSC_VER)
+  return {string.data(), string.size()};
+#else
   return {string.data(), string.capacity()};
+#endif
 }
 
 // same as GTest ASSERT_PRED_FORMAT2 macro, but without the outer GTEST_ASSERT_


### PR DESCRIPTION
### Rationale for this change
  - The test reads the unused tail of string past size(), which is undefined. libstdc++ keeps that range addressable, but MSVC does not.
  - Ensure the check is not run for MSVC. Existing assertions still run, the unused capacity is not asserted on non linux platforms.
  - Closes #48094.

### What changes are included in this PR?
 - Guard for platform specific behavior.

### Are these changes tested?
 - Yes
### Are there any user-facing changes?
 - Yes
* GitHub Issue: #48094