### PR TITLE
GH-49888: [C++][Compute] Fix count for run-end encoded arrays with nulls

### DIFF
--- a/cpp/src/arrow/compute/kernels/aggregate_basic.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_basic.cc
@@ -103,7 +103,7 @@ struct CountImpl : public ScalarAggregator {
       this->non_nulls += batch.length;
     } else if (batch[0].is_array()) {
       const ArraySpan& input = batch[0].array;
-      const int64_t nulls = input.GetNullCount();
+      const int64_t nulls = input.ComputeLogicalNullCount();
       this->nulls += nulls;
       this->non_nulls += input.length - nulls;
     } else {

--- a/cpp/src/arrow/compute/kernels/aggregate_test.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_test.cc
@@ -942,10 +942,13 @@ TYPED_TEST(TestCountKernel, SimpleCount) {
 }
 
 TEST(TestCountKernel, RunEndEncodedNulls) {
-  auto input = ArrayFromJSON(int32(), "[1, null]");
+  auto input = ArrayFromJSON(int32(), "[1, 1, null, null, null, 2, 2, 2, null, 3]");
   ASSERT_OK_AND_ASSIGN(auto encoded, RunEndEncode(input));
 
-  ValidateCount(*encoded.make_array(), {1, 1});
+  auto array = encoded.make_array();
+  ValidateCount(*array, {6, 4});
+  // Logical slice: [null, null, 2, 2, 2, null].
+  ValidateCount(*array->Slice(3, 6), {3, 3});
 }
 
 template <typename ArrowType>

--- a/cpp/src/arrow/compute/kernels/aggregate_test.cc
+++ b/cpp/src/arrow/compute/kernels/aggregate_test.cc
@@ -941,6 +941,13 @@ TYPED_TEST(TestCountKernel, SimpleCount) {
   EXPECT_THAT(Count(*MakeScalar(ty, 1), all), ResultWith(Datum(int64_t(1))));
 }
 
+TEST(TestCountKernel, RunEndEncodedNulls) {
+  auto input = ArrayFromJSON(int32(), "[1, null]");
+  ASSERT_OK_AND_ASSIGN(auto encoded, RunEndEncode(input));
+
+  ValidateCount(*encoded.make_array(), {1, 1});
+}
+
 template <typename ArrowType>
 class TestRandomNumericCountKernel : public ::testing::Test {};
 

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -2849,6 +2849,14 @@ def test_count():
         pc.count(arr, 'something else')
 
 
+def test_count_run_end_encoded_nulls():
+    arr = pc.run_end_encode(pa.array([1, None]))
+
+    assert pc.count(arr, mode="only_valid").as_py() == 1
+    assert pc.count(arr, mode="only_null").as_py() == 1
+    assert pc.count(arr, mode="all").as_py() == 2
+
+
 def test_index():
     arr = pa.array([0, 1, None, 3, 4], type=pa.int64())
     assert pc.index(arr, pa.scalar(0)).as_py() == 0

--- a/python/pyarrow/tests/test_compute.py
+++ b/python/pyarrow/tests/test_compute.py
@@ -2850,11 +2850,15 @@ def test_count():
 
 
 def test_count_run_end_encoded_nulls():
-    arr = pc.run_end_encode(pa.array([1, None]))
+    arr = pc.run_end_encode(
+        pa.array([1, 1, None, None, None, 2, 2, 2, None, 3]))
 
-    assert pc.count(arr, mode="only_valid").as_py() == 1
-    assert pc.count(arr, mode="only_null").as_py() == 1
-    assert pc.count(arr, mode="all").as_py() == 2
+    assert pc.count(arr, mode="only_valid").as_py() == 6
+    assert pc.count(arr, mode="only_null").as_py() == 4
+    assert pc.count(arr, mode="all").as_py() == 10
+    # Slice crosses run boundaries: logical [None, None, 2, 2, 2, None].
+    assert pc.count(arr.slice(3, 6), mode="only_valid").as_py() == 3
+    assert pc.count(arr.slice(3, 6), mode="only_null").as_py() == 3
 
 
 def test_index():


### PR DESCRIPTION
### Rationale for this change

The `count` kernel used `GetNullCount()`, which reports the physical null count. For run-end encoded arrays, this ignored nulls in the encoded values child.

### What changes are included in this PR?

Use `ComputeLogicalNullCount()` in the `count` kernel so run-end encoded arrays are counted correctly. Add C++ and Python tests for this case.

### Are these changes tested?

Yes.

### Are there any user-facing changes?

No.

* GitHub Issue: #49888