### PR TITLE
GH-49744: [Integration][Format] Remove unneeded skips for Rust and nanoarrow integration tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -76,7 +76,7 @@ jobs:
         with:
           persist-credentials: false
           repository: apache/arrow-rs
-          # Temporary: check with the arros-rs fix
+          # Temporary: check with the arrow-rs fix
           ref: refs/pull/9888/head
           path: rust
       - name: Checkout Arrow nanoarrow
@@ -84,6 +84,8 @@ jobs:
         with:
           persist-credentials: false
           repository: apache/arrow-nanoarrow
+          # Temporary: check with the nanoarrow fix
+          ref: refs/pull/880/head
           path: nanoarrow
       - name: Checkout Arrow Go
         uses: actions/checkout@v6
@@ -139,6 +141,7 @@ jobs:
             -e ARCHERY_INTEGRATION_WITH_JS=1 \
             -e ARCHERY_INTEGRATION_WITH_NANOARROW=1 \
             -e ARCHERY_INTEGRATION_WITH_RUST=1 \
+            -e RUST_BACKTRACE=1 \
             conda-integration
       - name: Docker Push
         if: >-

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -76,6 +76,8 @@ jobs:
         with:
           persist-credentials: false
           repository: apache/arrow-rs
+          # Temporary: check with the arros-rs fix
+          ref: refs/pull/9888/head
           path: rust
       - name: Checkout Arrow nanoarrow
         uses: actions/checkout@v6

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -76,16 +76,12 @@ jobs:
         with:
           persist-credentials: false
           repository: apache/arrow-rs
-          # Temporary: check with the arrow-rs fix
-          ref: refs/pull/9888/head
           path: rust
       - name: Checkout Arrow nanoarrow
         uses: actions/checkout@v6
         with:
           persist-credentials: false
           repository: apache/arrow-nanoarrow
-          # Temporary: check with the nanoarrow fix
-          ref: refs/pull/880/head
           path: nanoarrow
       - name: Checkout Arrow Go
         uses: actions/checkout@v6

--- a/dev/archery/archery/integration/datagen.py
+++ b/dev/archery/archery/integration/datagen.py
@@ -1975,15 +1975,20 @@ def get_generated_json_files(tempdir=None):
         .skip_tester('JS'),
 
         generate_dictionary_case()
+        # TODO(https://github.com/apache/arrow-nanoarrow/issues/622)
+        .skip_tester('nanoarrow')
         # TODO(https://github.com/apache/arrow/issues/38045)
         .skip_format(SKIP_FLIGHT, '.NET'),
 
         generate_dictionary_unsigned_case()
+        .skip_tester('nanoarrow')
         .skip_tester('Java')  # TODO(ARROW-9377)
         # TODO(https://github.com/apache/arrow/issues/38045)
         .skip_format(SKIP_FLIGHT, '.NET'),
 
         generate_nested_dictionary_case()
+        # TODO(https://github.com/apache/arrow-nanoarrow/issues/622)
+        .skip_tester('nanoarrow')
         .skip_tester('Java')  # TODO(ARROW-7779)
         # TODO(https://github.com/apache/arrow/issues/38045)
         .skip_format(SKIP_FLIGHT, '.NET')
@@ -2010,6 +2015,9 @@ def get_generated_json_files(tempdir=None):
         .skip_tester('Ruby'),
 
         generate_extension_case()
+        # Also contains a dictionary column
+        # TODO(https://github.com/apache/arrow-nanoarrow/issues/622)
+        .skip_tester('nanoarrow')
         # TODO(https://github.com/apache/arrow/issues/38045)
         .skip_format(SKIP_FLIGHT, '.NET')
         .skip_tester('Ruby'),

--- a/dev/archery/archery/integration/datagen.py
+++ b/dev/archery/archery/integration/datagen.py
@@ -1936,17 +1936,13 @@ def get_generated_json_files(tempdir=None):
         generate_decimal32_case()
         .skip_tester('Java')
         .skip_tester('JS')
-        .skip_tester('nanoarrow')
         .skip_tester('Ruby')
-        .skip_tester('Rust')
         .skip_tester('Go'),
 
         generate_decimal64_case()
         .skip_tester('Java')
         .skip_tester('JS')
-        .skip_tester('nanoarrow')
         .skip_tester('Ruby')
-        .skip_tester('Rust')
         .skip_tester('Go'),
 
         generate_datetime_case(),
@@ -1979,20 +1975,15 @@ def get_generated_json_files(tempdir=None):
         .skip_tester('JS'),
 
         generate_dictionary_case()
-        # TODO(https://github.com/apache/arrow-nanoarrow/issues/622)
-        .skip_tester('nanoarrow')
         # TODO(https://github.com/apache/arrow/issues/38045)
         .skip_format(SKIP_FLIGHT, '.NET'),
 
         generate_dictionary_unsigned_case()
-        .skip_tester('nanoarrow')
         .skip_tester('Java')  # TODO(ARROW-9377)
         # TODO(https://github.com/apache/arrow/issues/38045)
         .skip_format(SKIP_FLIGHT, '.NET'),
 
         generate_nested_dictionary_case()
-        # TODO(https://github.com/apache/arrow-nanoarrow/issues/622)
-        .skip_tester('nanoarrow')
         .skip_tester('Java')  # TODO(ARROW-7779)
         # TODO(https://github.com/apache/arrow/issues/38045)
         .skip_format(SKIP_FLIGHT, '.NET')
@@ -2003,26 +1994,22 @@ def get_generated_json_files(tempdir=None):
         .skip_tester('JS')
         # TODO(https://github.com/apache/arrow-nanoarrow/issues/618)
         .skip_tester('nanoarrow')
-        .skip_tester('Ruby')
-        .skip_tester('Rust'),
+        .skip_tester('Ruby'),
 
         generate_binary_view_case()
         .skip_tester('JS')
         # TODO(https://github.com/apache/arrow-nanoarrow/issues/618)
         .skip_tester('nanoarrow')
-        .skip_tester('Ruby')
-        .skip_tester('Rust'),
+        .skip_tester('Ruby'),
 
         generate_list_view_case()
         .skip_tester('.NET')     # Doesn't support large list views
         .skip_tester('JS')
         # TODO(https://github.com/apache/arrow-nanoarrow/issues/618)
         .skip_tester('nanoarrow')
-        .skip_tester('Ruby')
-        .skip_tester('Rust'),
+        .skip_tester('Ruby'),
 
         generate_extension_case()
-        .skip_tester('nanoarrow')
         # TODO(https://github.com/apache/arrow/issues/38045)
         .skip_format(SKIP_FLIGHT, '.NET')
         .skip_tester('Ruby'),


### PR DESCRIPTION
### Rationale for this change

The current skip list in the Archery datagen (where the skip list is kept) is out of date.

### What changes are included in this PR?

Skips were removed.

### Are these changes tested?

Yes, the integration test CI run should ensure these skips can in fact be removed.

### Are there any user-facing changes?

No
* GitHub Issue: #49744