### PR TITLE
MINOR: [C++][Parquet] Fix incorrect default in ArrowReaderProperties::set_pre_buffer doc

### DIFF
--- a/cpp/src/parquet/properties.h
+++ b/cpp/src/parquet/properties.h
@@ -1195,7 +1195,7 @@ class PARQUET_EXPORT ArrowReaderProperties {
   /// Note that some APIs such as ReadTable may ignore this setting.
   int64_t batch_size() const { return batch_size_; }
 
-  /// Enable read coalescing (default false).
+  /// Enable read coalescing (default true).
   ///
   /// When enabled, the Arrow reader will pre-buffer necessary regions
   /// of the file in-memory. This is intended to improve performance on


### PR DESCRIPTION
### Rationale for this change
 - The docs comment on ArrowReaderProperties::set_pre_buffer says `default false`, but the constructor initializes pre_buffer_(true). The API page at arrow.apache.org/docs/cpp/api/formats.html shows false.
 - Default was changed in a previous pr but comment/doc was not updated

### What changes are included in this PR?
  - Updated the default value 
### Are these changes tested?
  - N/A - Docs
### Are there any user-facing changes?
  - Yes
