### PR TITLE
GH-49917: [Python] Remove Py_XDECREF to avoid Use-After-Free on `PyList_SetItem` in `SparseCSFTensorToNdarray`

### DIFF
--- a/python/pyarrow/src/arrow/python/numpy_convert.cc
+++ b/python/pyarrow/src/arrow/python/numpy_convert.cc
@@ -395,7 +395,6 @@ Status SparseCSFTensorToNdarray(const std::shared_ptr<SparseCSFTensor>& sparse_t
     PyObject* item;
     RETURN_NOT_OK(TensorToNdarray(sparse_index.indptr()[i], base, &item));
     if (PyList_SetItem(indptr.obj(), i, item) < 0) {
-      Py_XDECREF(item);
       RETURN_IF_PYERROR();
     }
   }

--- a/python/pyarrow/src/arrow/python/numpy_convert.cc
+++ b/python/pyarrow/src/arrow/python/numpy_convert.cc
@@ -402,7 +402,6 @@ Status SparseCSFTensorToNdarray(const std::shared_ptr<SparseCSFTensor>& sparse_t
     PyObject* item;
     RETURN_NOT_OK(TensorToNdarray(sparse_index.indices()[i], base, &item));
     if (PyList_SetItem(indices.obj(), i, item) < 0) {
-      Py_XDECREF(item);
       RETURN_IF_PYERROR();
     }
   }


### PR DESCRIPTION
### Rationale for this change

Py_DECREF(item) in PyList_SetItem will cause Use-After-Free bug if `PyList_SetItem(indptr.obj(), i, item) < 0` is `true`, cause `PyList_SetItem` always steals a reference to the item, even when it fails.

### What changes are included in this PR?

1. Remove Py_DECREF(item) in PyList_SetItem error path.

### Are these changes tested?

By CI.

### Are there any user-facing changes?

No.
* GitHub Issue: #49917