### PR TITLE
GH-49930: [CI][C++] Pin MinGW MSYS2 packages to unblock CI

### DIFF
--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -367,12 +367,7 @@ jobs:
         shell: msys2 {0}
         run: ci/scripts/msys2_setup.sh cpp
       - name: Pin MSYS2 packages
-        # Temporary workaround for #49272: gcc 16 makes the intermittent
-        # __emutls race in ThreadPool crash on every run.
-        # Also pins C++ packages whose latest MSYS2 build is against
-        # gcc-libs 16.1, reverting each to a build against gcc-libs 15.2 for
-        # ABI compat. Remove once #49462 is solved.
-        if: matrix.msystem_upper == 'MINGW64'
+        if: false
         shell: msys2 {0}
         run: |
           set -ex

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -363,6 +363,35 @@ jobs:
         with:
           msystem: ${{ matrix.msystem_upper }}
           update: true
+      - name: Pin MSYS2 packages
+        # Pin upstream packages whose latest versions break this job:
+        # - mingw-w64-x86_64-gcc 16.1.0 ships a libstdc++ regression that
+        #   breaks std::shared_ptr/threading tests on MINGW64 (bad_weak_ptr,
+        #   heap corruption 0xc0000374, segfaults, hangs).
+        # - mingw-w64-{x86_64,clang-x86_64}-aws-sdk-cpp 1.11.801 stopped
+        #   sending the legacy Content-Md5 header on DeleteObjects, which the
+        #   bundled MinIO test server (2024-09-13) still requires.
+        shell: msys2 {0}
+        run: |
+          set -ex
+          case "${{ matrix.msystem_lower }}" in
+            mingw64)
+              urls=(
+                "https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-gcc-libs-15.2.0-14-any.pkg.tar.zst"
+                "https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-gcc-15.2.0-14-any.pkg.tar.zst"
+                "https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-aws-sdk-cpp-1.11.479-1-any.pkg.tar.zst"
+              )
+              ignore="mingw-w64-x86_64-gcc mingw-w64-x86_64-gcc-libs mingw-w64-x86_64-aws-sdk-cpp"
+              ;;
+            clang64)
+              urls=(
+                "https://repo.msys2.org/mingw/clang64/mingw-w64-clang-x86_64-aws-sdk-cpp-1.11.479-1-any.pkg.tar.zst"
+              )
+              ignore="mingw-w64-clang-x86_64-aws-sdk-cpp"
+              ;;
+          esac
+          pacman -U --noconfirm "${urls[@]}"
+          printf '\nIgnorePkg = %s\n' "$ignore" >> /etc/pacman.conf
       - name: Setup MSYS2
         shell: msys2 {0}
         run: ci/scripts/msys2_setup.sh cpp

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -367,12 +367,16 @@ jobs:
         shell: msys2 {0}
         run: ci/scripts/msys2_setup.sh cpp
       - name: Pin MSYS2 packages
-        # Workaround for upstream regressions:
-        # - gcc 16.1.0 has a libstdc++ regression that breaks threading
-        #   tests on MINGW64. We also pin C++ packages rebuilt against
-        #   the new libstdc++ since they reference symbols missing from 15.2.
-        # - aws-sdk-cpp 1.11.801 drops Content-Md5 on DeleteObjects which
-        #   our bundled MinIO (RELEASE.2024-09-13) still requires.
+        # Temporary workarounds for upstream issues, both with concrete exit
+        # criteria.
+        # - MINGW64: gcc 16 makes the intermittent __emutls race in ThreadPool's
+        #   `thread_local current_thread_pool_` (#49272) crash on every run. The
+        #   list also pins C++ packages rebuilt at pkgrel 2 since they reference
+        #   libstdc++ symbols missing from 15.2. Remove once #49462 lands. CLANG64
+        #   uses libc++ and is unaffected.
+        # - MINGW64 + CLANG64 jobs: aws-sdk-cpp 1.11.801 dropped Content-Md5 on
+        #   DeleteObjects, which the bundled MinIO (RELEASE.2024-09-13) still
+        #   requires. Remove once MinIO is bumped or the SDK keeps sending MD5.
         shell: msys2 {0}
         run: |
           set -ex
@@ -427,6 +431,8 @@ jobs:
           # https://github.com/apache/arrow/issues/48593
           ci/scripts/download_tz_database.sh
       - name: Download MinIO
+        # Pinned in tandem with aws-sdk-cpp 1.11.479 (see "Pin MSYS2
+        # packages" step). Bump this version and remove the SDK pin together.
         shell: msys2 {0}
         run: |
           mkdir -p /usr/local/bin

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -367,7 +367,14 @@ jobs:
         shell: msys2 {0}
         run: ci/scripts/msys2_setup.sh cpp
       - name: Pin MSYS2 packages
-        if: false
+        # Temporary workaround for #49930: gcc 16 surfaces a cluster of 5
+        # MINGW64 test failures. Pinning gcc-libs to 15.2 (and C++ packages
+        # rebuilt against gcc-libs 16.1, for ABI compatibility) avoids all
+        # of them. #49272/#49462 cover one (arrow-json-test); the other 4
+        # (async-utility-test, threading-utility-test, dataset-writer-test
+        # `bad_weak_ptr`, dataset-file-test) need separate fixes — see #49930.
+        # Remove once all 5 pass on current upstream MSYS2 without these pins
+        if: matrix.msystem_upper == 'MINGW64'
         shell: msys2 {0}
         run: |
           set -ex

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -363,38 +363,50 @@ jobs:
         with:
           msystem: ${{ matrix.msystem_upper }}
           update: true
-      - name: Pin MSYS2 packages
-        # Pin upstream packages whose latest versions break this job:
-        # - mingw-w64-x86_64-gcc 16.1.0 ships a libstdc++ regression that
-        #   breaks std::shared_ptr/threading tests on MINGW64 (bad_weak_ptr,
-        #   heap corruption 0xc0000374, segfaults, hangs).
-        # - mingw-w64-{x86_64,clang-x86_64}-aws-sdk-cpp 1.11.801 stopped
-        #   sending the legacy Content-Md5 header on DeleteObjects, which the
-        #   bundled MinIO test server (2024-09-13) still requires.
-        shell: msys2 {0}
-        run: |
-          set -ex
-          case "${{ matrix.msystem_lower }}" in
-            mingw64)
-              urls=(
-                "https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-gcc-libs-15.2.0-14-any.pkg.tar.zst"
-                "https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-gcc-15.2.0-14-any.pkg.tar.zst"
-                "https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-aws-sdk-cpp-1.11.479-1-any.pkg.tar.zst"
-              )
-              ignore="mingw-w64-x86_64-gcc mingw-w64-x86_64-gcc-libs mingw-w64-x86_64-aws-sdk-cpp"
-              ;;
-            clang64)
-              urls=(
-                "https://repo.msys2.org/mingw/clang64/mingw-w64-clang-x86_64-aws-sdk-cpp-1.11.479-1-any.pkg.tar.zst"
-              )
-              ignore="mingw-w64-clang-x86_64-aws-sdk-cpp"
-              ;;
-          esac
-          pacman -U --noconfirm "${urls[@]}"
-          printf '\nIgnorePkg = %s\n' "$ignore" >> /etc/pacman.conf
       - name: Setup MSYS2
         shell: msys2 {0}
         run: ci/scripts/msys2_setup.sh cpp
+      - name: Pin MSYS2 packages
+        # Workaround for upstream regressions:
+        # - gcc 16.1.0 has a libstdc++ regression that breaks threading
+        #   tests on MINGW64. We also pin C++ packages rebuilt against
+        #   the new libstdc++ since they reference symbols missing from 15.2.
+        # - aws-sdk-cpp 1.11.801 drops Content-Md5 on DeleteObjects which
+        #   our bundled MinIO (RELEASE.2024-09-13) still requires.
+        shell: msys2 {0}
+        run: |
+          set -ex
+          base="https://repo.msys2.org/mingw"
+          case "${{ matrix.msystem_lower }}" in
+            mingw64)
+              urls=(
+                "$base/mingw64/mingw-w64-x86_64-gcc-libs-15.2.0-14-any.pkg.tar.zst"
+                "$base/mingw64/mingw-w64-x86_64-gcc-15.2.0-14-any.pkg.tar.zst"
+                "$base/mingw64/mingw-w64-x86_64-aws-crt-cpp-0.38.4-1-any.pkg.tar.zst"
+                "$base/mingw64/mingw-w64-x86_64-boost-libs-1.91.0-1-any.pkg.tar.zst"
+                "$base/mingw64/mingw-w64-x86_64-boost-1.91.0-1-any.pkg.tar.zst"
+                "$base/mingw64/mingw-w64-x86_64-ccache-4.13.2-1-any.pkg.tar.zst"
+                "$base/mingw64/mingw-w64-x86_64-clang-libs-22.1.4-1-any.pkg.tar.zst"
+                "$base/mingw64/mingw-w64-x86_64-clang-22.1.4-1-any.pkg.tar.zst"
+                "$base/mingw64/mingw-w64-x86_64-cmake-4.3.2-2-any.pkg.tar.zst"
+                "$base/mingw64/mingw-w64-x86_64-icu-78.3-1-any.pkg.tar.zst"
+                "$base/mingw64/mingw-w64-x86_64-llvm-libs-22.1.4-1-any.pkg.tar.zst"
+                "$base/mingw64/mingw-w64-x86_64-llvm-tools-22.1.4-1-any.pkg.tar.zst"
+                "$base/mingw64/mingw-w64-x86_64-llvm-22.1.4-1-any.pkg.tar.zst"
+                "$base/mingw64/mingw-w64-x86_64-tbb-2022.3.0-1-any.pkg.tar.zst"
+                "$base/mingw64/mingw-w64-x86_64-thrift-0.22.0-1-any.pkg.tar.zst"
+                "$base/mingw64/mingw-w64-x86_64-zstd-1.5.7-1-any.pkg.tar.zst"
+                "$base/mingw64/mingw-w64-x86_64-gflags-2.2.2-7-any.pkg.tar.zst"
+                "$base/mingw64/mingw-w64-x86_64-aws-sdk-cpp-1.11.479-1-any.pkg.tar.zst"
+              )
+              ;;
+            clang64)
+              urls=(
+                "$base/clang64/mingw-w64-clang-x86_64-aws-sdk-cpp-1.11.479-1-any.pkg.tar.zst"
+              )
+              ;;
+          esac
+          pacman -U --noconfirm "${urls[@]}"
       - name: Cache ccache
         uses: actions/cache@v5
         with:

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -367,49 +367,36 @@ jobs:
         shell: msys2 {0}
         run: ci/scripts/msys2_setup.sh cpp
       - name: Pin MSYS2 packages
-        # Temporary workarounds for upstream issues, both with concrete exit
-        # criteria.
-        # - MINGW64: gcc 16 makes the intermittent __emutls race in ThreadPool's
-        #   `thread_local current_thread_pool_` (#49272) crash on every run. The
-        #   list also pins C++ packages rebuilt at pkgrel 2 since they reference
-        #   libstdc++ symbols missing from 15.2. Remove once #49462 lands. CLANG64
-        #   uses libc++ and is unaffected.
-        # - MINGW64 + CLANG64 jobs: aws-sdk-cpp 1.11.801 dropped Content-Md5 on
-        #   DeleteObjects, which the bundled MinIO (RELEASE.2024-09-13) still
-        #   requires. Remove once MinIO is bumped or the SDK keeps sending MD5.
+        # Temporary workaround for #49272: gcc 16 makes the intermittent
+        # __emutls race in ThreadPool crash on every run.
+        # Also pins C++ packages whose latest MSYS2 build is against
+        # gcc-libs 16.1, reverting each to a build against gcc-libs 15.2 for
+        # ABI compat. Remove once #49462 is solved.
+        if: matrix.msystem_upper == 'MINGW64'
         shell: msys2 {0}
         run: |
           set -ex
-          base="https://repo.msys2.org/mingw"
-          case "${{ matrix.msystem_lower }}" in
-            mingw64)
-              urls=(
-                "$base/mingw64/mingw-w64-x86_64-gcc-libs-15.2.0-14-any.pkg.tar.zst"
-                "$base/mingw64/mingw-w64-x86_64-gcc-15.2.0-14-any.pkg.tar.zst"
-                "$base/mingw64/mingw-w64-x86_64-aws-crt-cpp-0.38.4-1-any.pkg.tar.zst"
-                "$base/mingw64/mingw-w64-x86_64-boost-libs-1.91.0-1-any.pkg.tar.zst"
-                "$base/mingw64/mingw-w64-x86_64-boost-1.91.0-1-any.pkg.tar.zst"
-                "$base/mingw64/mingw-w64-x86_64-ccache-4.13.2-1-any.pkg.tar.zst"
-                "$base/mingw64/mingw-w64-x86_64-clang-libs-22.1.4-1-any.pkg.tar.zst"
-                "$base/mingw64/mingw-w64-x86_64-clang-22.1.4-1-any.pkg.tar.zst"
-                "$base/mingw64/mingw-w64-x86_64-cmake-4.3.2-2-any.pkg.tar.zst"
-                "$base/mingw64/mingw-w64-x86_64-icu-78.3-1-any.pkg.tar.zst"
-                "$base/mingw64/mingw-w64-x86_64-llvm-libs-22.1.4-1-any.pkg.tar.zst"
-                "$base/mingw64/mingw-w64-x86_64-llvm-tools-22.1.4-1-any.pkg.tar.zst"
-                "$base/mingw64/mingw-w64-x86_64-llvm-22.1.4-1-any.pkg.tar.zst"
-                "$base/mingw64/mingw-w64-x86_64-tbb-2022.3.0-1-any.pkg.tar.zst"
-                "$base/mingw64/mingw-w64-x86_64-thrift-0.22.0-1-any.pkg.tar.zst"
-                "$base/mingw64/mingw-w64-x86_64-zstd-1.5.7-1-any.pkg.tar.zst"
-                "$base/mingw64/mingw-w64-x86_64-gflags-2.2.2-7-any.pkg.tar.zst"
-                "$base/mingw64/mingw-w64-x86_64-aws-sdk-cpp-1.11.479-1-any.pkg.tar.zst"
-              )
-              ;;
-            clang64)
-              urls=(
-                "$base/clang64/mingw-w64-clang-x86_64-aws-sdk-cpp-1.11.479-1-any.pkg.tar.zst"
-              )
-              ;;
-          esac
+          base="https://repo.msys2.org/mingw/mingw64"
+          urls=(
+            "$base/mingw-w64-x86_64-gcc-libs-15.2.0-14-any.pkg.tar.zst"
+            "$base/mingw-w64-x86_64-gcc-15.2.0-14-any.pkg.tar.zst"
+            "$base/mingw-w64-x86_64-aws-crt-cpp-0.38.4-1-any.pkg.tar.zst"
+            "$base/mingw-w64-x86_64-boost-libs-1.91.0-1-any.pkg.tar.zst"
+            "$base/mingw-w64-x86_64-boost-1.91.0-1-any.pkg.tar.zst"
+            "$base/mingw-w64-x86_64-ccache-4.13.2-1-any.pkg.tar.zst"
+            "$base/mingw-w64-x86_64-clang-libs-22.1.4-1-any.pkg.tar.zst"
+            "$base/mingw-w64-x86_64-clang-22.1.4-1-any.pkg.tar.zst"
+            "$base/mingw-w64-x86_64-cmake-4.3.2-2-any.pkg.tar.zst"
+            "$base/mingw-w64-x86_64-icu-78.3-1-any.pkg.tar.zst"
+            "$base/mingw-w64-x86_64-llvm-libs-22.1.4-1-any.pkg.tar.zst"
+            "$base/mingw-w64-x86_64-llvm-tools-22.1.4-1-any.pkg.tar.zst"
+            "$base/mingw-w64-x86_64-llvm-22.1.4-1-any.pkg.tar.zst"
+            "$base/mingw-w64-x86_64-tbb-2022.3.0-1-any.pkg.tar.zst"
+            "$base/mingw-w64-x86_64-thrift-0.22.0-1-any.pkg.tar.zst"
+            "$base/mingw-w64-x86_64-zstd-1.5.7-1-any.pkg.tar.zst"
+            "$base/mingw-w64-x86_64-gflags-2.2.2-7-any.pkg.tar.zst"
+            "$base/mingw-w64-x86_64-aws-sdk-cpp-1.11.479-1-any.pkg.tar.zst"
+          )
           pacman -U --noconfirm "${urls[@]}"
       - name: Cache ccache
         uses: actions/cache@v5
@@ -431,14 +418,13 @@ jobs:
           # https://github.com/apache/arrow/issues/48593
           ci/scripts/download_tz_database.sh
       - name: Download MinIO
-        # Pinned in tandem with aws-sdk-cpp 1.11.479 (see "Pin MSYS2
-        # packages" step). Bump this version and remove the SDK pin together.
+        # Match the version pinned in ci/scripts/install_minio.sh.
         shell: msys2 {0}
         run: |
           mkdir -p /usr/local/bin
           wget \
             --output-document /usr/local/bin/minio.exe \
-            https://dl.min.io/server/minio/release/windows-amd64/archive/minio.RELEASE.2024-09-13T20-26-02Z
+            https://dl.min.io/server/minio/release/windows-amd64/archive/minio.RELEASE.2025-01-20T14-49-07Z
           chmod +x /usr/local/bin/minio.exe
       - name: Set up Python
         uses: actions/setup-python@v6


### PR DESCRIPTION
### Rationale for this change
Temporary workaround for #49930!
Both MinGW jobs fail every run since 2026 April 30 from two MSYS2 updates:
1. MINGW64: `gcc 15.2 -> 16.1` deterministically breaks 4 tests (`arrow-async-utility-test`, `arrow-threading-utility-test`, `arrow-dataset-dataset-writer-test`, `arrow-dataset-file-test`)
See #49930 for per-test status (and the connection to #49272/#49462).
2. MINGW64 and CLANG64: `arrow-s3fs-test` fails - `aws-sdk-cpp 1.11.479 -> 1.11.801` stopped sending `Content-Md5` on `DeleteObjects`, but bundled MinIO `RELEASE.2024-09-13` still requires it.

### What changes are included in this PR?
a) Workaround for 1.: new temporary `Pin MSYS2 packages` step on MINGW64 (CLANG64 is unaffected). Pins `gcc-libs` to 15.2 plus C++ packages for ABI compatibility.
**Removable** when all #49930-tracked failures pass on current upstream MSYS2.

b) Resolves 2.: bump bundled MinIO to `RELEASE.2025-01-20T14-49-07Z` to match `ci/scripts/install_minio.sh` (per review). See further discussion about migrating from MinIO in #47908

### Are these changes tested?
CI
[failing without pins](https://github.com/apache/arrow/actions/runs/25442601074/job/74637722454) ->
[passing](https://github.com/apache/arrow/actions/runs/25479824734/job/74761254697)

### Are there any user-facing changes?
No
* GitHub Issue: #49930