### PR TITLE
MINOR: [C++][Parquet][Doc] pointer dereference instead of dot in parquet.rst

### DIFF
--- a/docs/source/cpp/parquet.rst
+++ b/docs/source/cpp/parquet.rst
@@ -256,11 +256,11 @@ To configure how Parquet files are written, use the :class:`WriterProperties::Bu
 
    std::shared_ptr<WriterProperties> props = WriterProperties::Builder()
       .max_row_group_length(64 * 1024)
-      .created_by("My Application")
-      .version(ParquetVersion::PARQUET_2_6)
-      .data_page_version(ParquetDataPageVersion::V2)
-      .compression(Compression::SNAPPY)
-      .build();
+      ->created_by("My Application")
+      ->version(ParquetVersion::PARQUET_2_6)
+      ->data_page_version(ParquetDataPageVersion::V2)
+      ->compression(Compression::SNAPPY)
+      ->build();
 
 The ``max_row_group_length`` sets an upper bound on the number of rows per row
 group that takes precedent over the ``chunk_size`` passed in the write methods.


### PR DESCRIPTION
### Rationale for this change
Example code did not compile because it used dot (`.`) instead of arrow (`->`) in C++ code.

### What changes are included in this PR?
One C++ example code in a documentation to have dot (`.`) replaced by arrow (`->`).

### Are these changes tested?
Manually, when I've tried to copy-and-paste example, and it did not compile.

### Are there any user-facing changes?
One external example will change.
